### PR TITLE
master

### DIFF
--- a/loleaflet/Makefile.am
+++ b/loleaflet/Makefile.am
@@ -335,7 +335,7 @@ SPACE := $(EMPTY) $(EMPTY)
 LOLEAFLET_VERSION = $(shell cd $(srcdir) && git log -1 --pretty=format:"%h")
 INTERMEDIATE_DIR ?= $(if $(IS_DEBUG),$(abs_builddir)/debug,$(abs_builddir)/release)
 
-EXTRA_DIST = $(shell find . -type f -not -path './.git/*' | sed 's/.\///')
+EXTRA_DIST = $(shell find . -type f -not -path './.git/*' -not -path './node_modules/*' | sed 's/.\///')
 
 define bundle_loleaflet
 	$(if $(IS_DEBUG),\

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -298,7 +298,7 @@ group1.log: unit-crash.log unit-tiletest.log unit-insert-delete.log unit-each-vi
 endif
 
 TEST_EXTENSIONS = .la
-LA_LOG_DRIVER = ${top_srcdir}/test/run_unit.sh
+LA_LOG_DRIVER = ${top_builddir}/test/run_unit.sh
 
 EXTRA_DIST = data/delta-text.png data/delta-text2.png data/hello.odt data/hello.txt $(test_SOURCES) $(unittest_SOURCES) run_unit.sh
 

--- a/test/UnitConvert.cpp
+++ b/test/UnitConvert.cpp
@@ -49,7 +49,30 @@ public:
         UnitWSD::configure(config);
 
         config.setBool("ssl.enable", true);
-        config.setInt("per_document.limit_load_secs", 1);
+        config.setInt("per_document.limit_load_secs", 30);
+    }
+
+    void sendConvertTo(std::unique_ptr<Poco::Net::HTTPClientSession>& session, const std::string& filename)
+    {
+        Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_POST, "/lool/convert-to/pdf");
+        Poco::Net::HTMLForm form;
+        form.setEncoding(Poco::Net::HTMLForm::ENCODING_MULTIPART);
+        form.set("format", "txt");
+        form.addPart("data", new Poco::Net::StringPartSource("Hello World Content", "text/plain", filename));
+        form.prepareSubmit(request);
+        form.write(session->sendRequest(request));
+    }
+
+    bool checkConvertTo(std::unique_ptr<Poco::Net::HTTPClientSession>& session)
+    {
+        Poco::Net::HTTPResponse response;
+        try {
+            session->receiveResponse(response);
+        } catch (...) {
+            return false;
+        }
+
+        return response.getStatus() == Poco::Net::HTTPResponse::HTTPStatus::HTTP_OK;
     }
 
     void invokeTest() override
@@ -61,26 +84,23 @@ public:
         _worker = std::thread([this]{
                 std::cerr << "Now started thread ...\n";
                 std::unique_ptr<Poco::Net::HTTPClientSession> session(helpers::createSession(Poco::URI(helpers::getTestServerURI())));
-                session->setTimeout(Poco::Timespan(10, 0)); // 10 seconds.
+                session->setTimeout(Poco::Timespan(30, 0)); // 30 seconds.
 
-                Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_POST, "/lool/convert-to/pdf");
-                Poco::Net::HTMLForm form;
-                form.setEncoding(Poco::Net::HTMLForm::ENCODING_MULTIPART);
-                form.set("format", "txt");
-                form.addPart("data", new Poco::Net::StringPartSource("Hello World Content", "text/plain", "foo.txt"));
-                form.prepareSubmit(request);
-                form.write(session->sendRequest(request));
-
-                Poco::Net::HTTPResponse response;
-                try {
-                    session->receiveResponse(response);
-                } catch (Poco::Net::NoMessageException &) {
-                    std::cerr << "No response as expected.\n";
-                    exitTest(TestResult::Ok); // child should have timed out and been killed.
+                sendConvertTo(session, "foo.txt");
+                if(!checkConvertTo(session))
+                {
+                    exitTest(TestResult::Failed);
                     return;
-                } // else
-                std::cerr << "Failed to terminate the sleeping kit\n";
-                exitTest(TestResult::Failed);
+                }
+
+                sendConvertTo(session, "test___á.txt");
+                if(!checkConvertTo(session))
+                {
+                    exitTest(TestResult::Failed);
+                    return;
+                }
+
+                exitTest(TestResult::Ok);
             });
     }
 };
@@ -92,16 +112,6 @@ public:
     UnitKitConvert()
     {
         setTimeout(3600 * 1000); /* one hour */
-    }
-    bool filterKitMessage(WebSocketHandler *, std::string &message) override
-    {
-        std::cerr << "kit message " << message << '\n';
-        if (message.find("load") != std::string::npos)
-        {
-            std::cerr << "Load message received - starting to sleep\n";
-            sleep(60);
-        }
-        return false;
     }
 };
 

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1245,8 +1245,9 @@ bool ClientSession::handleKitToClientMessage(const char* buffer, const int lengt
         std::string wopiFilename;
         Poco::URI::decode(encodedWopiFilename, wopiFilename);
 
-        // URI constructor implicitly decodes when it gets std::string as param
-        Poco::URI resultURL(encodedURL);
+        std::string decodedURL;
+        Poco::URI::decode(encodedURL, decodedURL);
+        Poco::URI resultURL(decodedURL);
 
         // Prepend the jail path in the normal (non-nocaps) case
         if (resultURL.getScheme() == "file" && !LOOLWSD::NoCapsForKit)

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1260,11 +1260,18 @@ bool ClientSession::handleKitToClientMessage(const char* buffer, const int lengt
             const Path path(docBroker->getJailRoot(), relative);
             if (Poco::File(path).exists())
             {
-                // Encode path for special characters (i.e '%') since Poco::URI::setPath implicitly decodes the input param
-                std::string encodedPath;
-                Poco::URI::encode(path.toString(), "", encodedPath);
+                if (!isConvertTo)
+                {
+                    // Encode path for special characters (i.e '%') since Poco::URI::setPath implicitly decodes the input param
+                    std::string encodedPath;
+                    Poco::URI::encode(path.toString(), "", encodedPath);
 
-                resultURL.setPath(encodedPath);
+                    resultURL.setPath(encodedPath);
+                }
+                else
+                {
+                    resultURL.setPath(path.toString());
+                }
             }
             else
             {

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1302,16 +1302,14 @@ bool ClientSession::handleKitToClientMessage(const char* buffer, const int lengt
             if (!resultURL.getPath().empty())
             {
                 const std::string mimeType = "application/octet-stream";
-                std::string encodedFilePath;
-                Poco::URI::encode(resultURL.getPath(), "", encodedFilePath);
-                LOG_TRC("Sending file: " << encodedFilePath);
+                LOG_TRC("Sending file: " << resultURL.getPath());
 
                 const std::string fileName = Poco::Path(resultURL.getPath()).getFileName();
                 Poco::Net::HTTPResponse response;
                 if (!fileName.empty())
                     response.set("Content-Disposition", "attachment; filename=\"" + fileName + '"');
 
-                HttpHelper::sendFileAndShutdown(_saveAsSocket, encodedFilePath, mimeType, &response);
+                HttpHelper::sendFileAndShutdown(_saveAsSocket, resultURL.getPath(), mimeType, &response);
             }
 
             // Conversion is done, cleanup this fake session.


### PR DESCRIPTION
- loleaflet: Makefile: avoid the node_module path distribution
- wsd: explicit decode URI
- wsd: do not encode the URI if the API is "convert-to"
- wsd: do not encode to send file when the API is "covert-to"
- test: Makefile: fix builddir != srcdir
- test: check for non ASCII file name if convert-to
