### PR TITLE
loleaflet: Makefile: avoid the node_module path distribution

### DIFF
--- a/loleaflet/Makefile.am
+++ b/loleaflet/Makefile.am
@@ -335,7 +335,7 @@ SPACE := $(EMPTY) $(EMPTY)
 LOLEAFLET_VERSION = $(shell cd $(srcdir) && git log -1 --pretty=format:"%h")
 INTERMEDIATE_DIR ?= $(if $(IS_DEBUG),$(abs_builddir)/debug,$(abs_builddir)/release)
 
-EXTRA_DIST = $(shell find . -type f -not -path './.git/*' | sed 's/.\///')
+EXTRA_DIST = $(shell find . -type f -not -path './.git/*' -not -path './node_modules/*' | sed 's/.\///')
 
 define bundle_loleaflet
 	$(if $(IS_DEBUG),\


### PR DESCRIPTION
it gives an error:
"execvp: /bin/sh: Argument list too long"

Change-Id: Iffbf6d6f9ce46cba550dde9baf9ab8cbaddc3678
