### PR TITLE
wsd: explicit decode URI

### DIFF
--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1249,7 +1249,12 @@ bool ClientSession::handleKitToClientMessage(const char* buffer, const int lengt
         // Prepend the jail path in the normal (non-nocaps) case
         if (resultURL.getScheme() == "file" && !LOOLWSD::NoCapsForKit)
         {
-            std::string relative(resultURL.getPath());
+            std::string relative;
+            if (isConvertTo)
+                Poco::URI::decode(resultURL.getPath(), relative);
+            else
+                relative = resultURL.getPath();
+
             if (relative.size() > 0 && relative[0] == '/')
                 relative = relative.substr(1);
 


### PR DESCRIPTION
is it a POCO bug?
The implicit decode URI is not working
if a file is "test___á.pdf" <=> "test___%C3%A1.pdf"
getPath() returns "test___%C3%A1.pdf"

Change-Id: I79e2ec13cd5500d188a1657e47af03d29b151824
