### PR TITLE
wsd: do not encode the URI if the API is "convert-to"

### DIFF
--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1259,11 +1259,18 @@ bool ClientSession::handleKitToClientMessage(const char* buffer, const int lengt
             const Path path(docBroker->getJailRoot(), relative);
             if (Poco::File(path).exists())
             {
-                // Encode path for special characters (i.e '%') since Poco::URI::setPath implicitly decodes the input param
-                std::string encodedPath;
-                Poco::URI::encode(path.toString(), "", encodedPath);
+                if (!isConvertTo)
+                {
+                    // Encode path for special characters (i.e '%') since Poco::URI::setPath implicitly decodes the input param
+                    std::string encodedPath;
+                    Poco::URI::encode(path.toString(), "", encodedPath);
 
-                resultURL.setPath(encodedPath);
+                    resultURL.setPath(encodedPath);
+                }
+                else
+                {
+                    resultURL.setPath(path.toString());
+                }
             }
             else
             {


### PR DESCRIPTION
If it is encoded again, the result file does
not exist.

If a file is "test___á.pdf" and encode again
"test___%C3%A1.pdf"

fileExists("test___%C3%A1.pdf") false

Change-Id: I9fa1b8b52ebf0993158eb6ebe383da53921f640a
