### PR TITLE
wsd: do not encode to send file when the API is "convert-to"

### DIFF
--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1294,16 +1294,14 @@ bool ClientSession::handleKitToClientMessage(const char* buffer, const int lengt
             if (!resultURL.getPath().empty())
             {
                 const std::string mimeType = "application/octet-stream";
-                std::string encodedFilePath;
-                Poco::URI::encode(resultURL.getPath(), "", encodedFilePath);
-                LOG_TRC("Sending file: " << encodedFilePath);
+                LOG_TRC("Sending file: " << resultURL.getPath());
 
                 const std::string fileName = Poco::Path(resultURL.getPath()).getFileName();
                 Poco::Net::HTTPResponse response;
                 if (!fileName.empty())
                     response.set("Content-Disposition", "attachment; filename=\"" + fileName + '"');
 
-                HttpHelper::sendFileAndShutdown(_saveAsSocket, encodedFilePath, mimeType, &response);
+                HttpHelper::sendFileAndShutdown(_saveAsSocket, resultURL.getPath(), mimeType, &response);
             }
 
             // Conversion is done, cleanup this fake session.


### PR DESCRIPTION
if a file is "test__á.pdf" and if it is encoded "test___%C3%A1.pdf"
then stat("test___%C3%A1.pdf") is false

Change-Id: I28a5ed90c599b7244f0c3a3d2259d83b25be762f
