### PR TITLE
test: check for non ASCII file name if convert-to

### DIFF
--- a/test/UnitConvert.cpp
+++ b/test/UnitConvert.cpp
@@ -49,7 +49,30 @@ public:
         UnitWSD::configure(config);
 
         config.setBool("ssl.enable", true);
-        config.setInt("per_document.limit_load_secs", 1);
+        config.setInt("per_document.limit_load_secs", 30);
+    }
+
+    void sendConvertTo(std::unique_ptr<Poco::Net::HTTPClientSession>& session, const std::string& filename)
+    {
+        Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_POST, "/lool/convert-to/pdf");
+        Poco::Net::HTMLForm form;
+        form.setEncoding(Poco::Net::HTMLForm::ENCODING_MULTIPART);
+        form.set("format", "txt");
+        form.addPart("data", new Poco::Net::StringPartSource("Hello World Content", "text/plain", filename));
+        form.prepareSubmit(request);
+        form.write(session->sendRequest(request));
+    }
+
+    bool checkConvertTo(std::unique_ptr<Poco::Net::HTTPClientSession>& session)
+    {
+        Poco::Net::HTTPResponse response;
+        try {
+            session->receiveResponse(response);
+        } catch (...) {
+            return false;
+        }
+
+        return response.getStatus() == Poco::Net::HTTPResponse::HTTPStatus::HTTP_OK;
     }
 
     void invokeTest() override
@@ -61,26 +84,23 @@ public:
         _worker = std::thread([this]{
                 std::cerr << "Now started thread ...\n";
                 std::unique_ptr<Poco::Net::HTTPClientSession> session(helpers::createSession(Poco::URI(helpers::getTestServerURI())));
-                session->setTimeout(Poco::Timespan(10, 0)); // 10 seconds.
+                session->setTimeout(Poco::Timespan(30, 0)); // 30 seconds.
 
-                Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_POST, "/lool/convert-to/pdf");
-                Poco::Net::HTMLForm form;
-                form.setEncoding(Poco::Net::HTMLForm::ENCODING_MULTIPART);
-                form.set("format", "txt");
-                form.addPart("data", new Poco::Net::StringPartSource("Hello World Content", "text/plain", "foo.txt"));
-                form.prepareSubmit(request);
-                form.write(session->sendRequest(request));
-
-                Poco::Net::HTTPResponse response;
-                try {
-                    session->receiveResponse(response);
-                } catch (Poco::Net::NoMessageException &) {
-                    std::cerr << "No response as expected.\n";
-                    exitTest(TestResult::Ok); // child should have timed out and been killed.
+                sendConvertTo(session, "foo.txt");
+                if(!checkConvertTo(session))
+                {
+                    exitTest(TestResult::Failed);
                     return;
-                } // else
-                std::cerr << "Failed to terminate the sleeping kit\n";
-                exitTest(TestResult::Failed);
+                }
+
+                sendConvertTo(session, "test___á.txt");
+                if(!checkConvertTo(session))
+                {
+                    exitTest(TestResult::Failed);
+                    return;
+                }
+
+                exitTest(TestResult::Ok);
             });
     }
 };
@@ -92,16 +112,6 @@ public:
     UnitKitConvert()
     {
         setTimeout(3600 * 1000); /* one hour */
-    }
-    bool filterKitMessage(WebSocketHandler *, std::string &message) override
-    {
-        std::cerr << "kit message " << message << '\n';
-        if (message.find("load") != std::string::npos)
-        {
-            std::cerr << "Load message received - starting to sleep\n";
-            sleep(60);
-        }
-        return false;
     }
 };
 


### PR DESCRIPTION
The unit test is extended to check the response status
when the API convert-to is used.

use case file name: "test___á.txt"

Change-Id: I7b18dde01f7d44251e7c584a5348dd1228d6e420
