### PR TITLE
leaflet: User may continue writing a comment after it loses focus

### DIFF
--- a/loleaflet/src/layer/AnnotationManager.js
+++ b/loleaflet/src/layer/AnnotationManager.js
@@ -595,9 +595,20 @@ L.AnnotationManager = L.AnnotationManagerBase.extend({
 		} // else - avoid excessive re-layout
 	},
 
+	hasDraftComment: function() {
+		var found = false;
+		for (var i = 0; i < this._items.length; i++) {
+			if (this._items[i].options.draft === true) {
+				found = true;
+				break;
+			}
+		}
+		return found;
+	},
+
 	add: function (comment) {
 		var annotation = L.annotation(this._map._docLayer._twipsToLatLng(comment.anchorPos.getTopRight()), comment,
-			comment.id === 'new' ? {noMenu: true} : {}).addTo(this._map);
+			comment.id === 'new' ? {noMenu: true, draft: true} : {}).addTo(this._map);
 		if (comment.parent && comment.parent > '0') {
 			var parentIdx = this.getIndexOf(comment.parent);
 			this._items.splice(parentIdx + 1, 0, annotation);
@@ -869,6 +880,14 @@ L.AnnotationManager = L.AnnotationManagerBase.extend({
 				Author: {
 					type: 'string',
 					value: e.annotation._data.author
+				},
+				pointX: {
+					type: 'string',
+					value: e.annotation._data.anchorPos.min.x
+				},
+				pointY: {
+					type: 'string',
+					value: e.annotation._data.anchorPos.min.y
 				}
 			};
 			this._map.sendUnoCommand('.uno:InsertAnnotation', comment);

--- a/loleaflet/src/layer/marker/Annotation.js
+++ b/loleaflet/src/layer/marker/Annotation.js
@@ -11,7 +11,8 @@ L.Annotation = L.Layer.extend({
 		maxHeight: 50,
 		imgSize: L.point([32, 32]),
 		margin: L.point([40, 40]),
-		noMenu: false
+		noMenu: false,
+		draft: false
 	},
 
 	initialize: function (latlng, data, options) {
@@ -88,7 +89,9 @@ L.Annotation = L.Layer.extend({
 	show: function () {
 		this._container.style.visibility = '';
 		this._contentNode.style.display = '';
-		this._nodeModify.style.display = 'none';
+		if (this.options.draft === false) {
+			this._nodeModify.style.display = 'none';
+		}
 		this._nodeReply.style.display = 'none';
 		if (this._data.textSelected && this._map.hasLayer && !this._map.hasLayer(this._data.textSelected)) {
 			this._map.addLayer(this._data.textSelected);
@@ -99,7 +102,9 @@ L.Annotation = L.Layer.extend({
 	hide: function () {
 		this._container.style.visibility = 'hidden';
 		this._contentNode.style.display = 'none';
-		this._nodeModify.style.display = 'none';
+		if (this.options.draft === false) {
+			this._nodeModify.style.display = 'none';
+		}
 		this._nodeReply.style.display = 'none';
 		if (this._data.textSelected && this._map.hasLayer(this._data.textSelected)) {
 			this._map.removeLayer(this._data.textSelected);
@@ -315,13 +320,17 @@ L.Annotation = L.Layer.extend({
 	},
 
 	_onLostFocus: function (e) {
-		$(this._container).removeClass('annotation-active');
-		if (this._contentText.origText !== this._nodeModifyText.value) {
-			this._onSaveComment(e);
-		}
-		else if (this._nodeModifyText.value == '') {
-			// Implies that this._contentText.origText == ''
-			this._onCancelClick(e);
+		// On mobile view, a vex dialog opens and covers entire screen. So we can not allow user to make their comment open & waiting when it loses focus.
+		// On mobile or tablet view, when comment loses focus, comment has to be cancelled.
+		if (this.options.draft === false || window.mode.isMobile() || window.mode.isTablet()) {
+			L.DomUtil.removeClass(this._container, 'annotation-active');
+			if (this._contentText.origText !== this._nodeModifyText.value) {
+				this._onSaveComment(e);
+			}
+			else if (this._nodeModifyText.value === '') {
+				// Implies that this._contentText.origText == ''
+				this._onCancelClick(e);
+			}
 		}
 	},
 

--- a/loleaflet/src/layer/tile/WriterTileLayer.js
+++ b/loleaflet/src/layer/tile/WriterTileLayer.js
@@ -7,23 +7,25 @@
 L.WriterTileLayer = L.CanvasTileLayer.extend({
 
 	newAnnotation: function (comment) {
-		if (!comment.anchorPos && this._map._isCursorVisible) {
-			comment.anchorPos = L.bounds(this._latLngToTwips(this._visibleCursor.getSouthWest()),
-				this._latLngToTwips(this._visibleCursor.getNorthEast()));
-			comment.anchorPix = this._twipsToPixels(comment.anchorPos.min);
-		} else if (this._graphicSelection && !this._isEmptyRectangle(this._graphicSelection)) {
-			// An image is selected, then guess the anchor based on the graphic
-			// selection.
-			comment.anchorPos = L.bounds(this._latLngToTwips(this._graphicSelection.getSouthWest()),
-				this._latLngToTwips(this._graphicSelection.getNorthEast()));
-			comment.anchorPix = this._twipsToPixels(comment.anchorPos.min);
-		}
-		if (comment.anchorPos) {
-			this._annotations.modify(this._annotations.add(comment));
-		}
-		if (window.mode.isMobile() || window.mode.isTablet()) {
-			var that = this;
-			this.newAnnotationVex(comment, function(annotation) { that._annotations._onAnnotationSave(annotation); });
+		if (this._annotations.hasDraftComment() === false || comment.id !== 'new') {
+			if (!comment.anchorPos && this._map._isCursorVisible) {
+				comment.anchorPos = L.bounds(this._latLngToTwips(this._visibleCursor.getSouthWest()),
+					this._latLngToTwips(this._visibleCursor.getNorthEast()));
+				comment.anchorPix = this._twipsToPixels(comment.anchorPos.min);
+			} else if (this._graphicSelection && !this._isEmptyRectangle(this._graphicSelection)) {
+				// An image is selected, then guess the anchor based on the graphic
+				// selection.
+				comment.anchorPos = L.bounds(this._latLngToTwips(this._graphicSelection.getSouthWest()),
+					this._latLngToTwips(this._graphicSelection.getNorthEast()));
+				comment.anchorPix = this._twipsToPixels(comment.anchorPos.min);
+			}
+			if (comment.anchorPos) {
+				this._annotations.modify(this._annotations.add(comment));
+			}
+			if (window.mode.isMobile() || window.mode.isTablet()) {
+				var that = this;
+				this.newAnnotationVex(comment, function(annotation) { that._annotations._onAnnotationSave(annotation); });
+			}
 		}
 	},
 


### PR DESCRIPTION
This is Online part. This patch has also a Core part.

This path enables Online users to continue writing their comment after they click somewhere else in the document.
Online side will remember original position of comment and it will send the cursor position when needed.
When there is no cursor position, default behaviour will work.

Change-Id: Iff863f53ed623b2723c4b55816168e182f667da6