### PR TITLE
document broker: handle combined tile request without tile cache

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1790,6 +1790,12 @@ void DocumentBroker::handleTileCombinedRequest(TileCombined& tileCombined,
     for (auto& tile : tileCombined.getTiles())
     {
         tile.setVersion(++_tileVersion);
+        if (!hasTileCache())
+        {
+            LOG_WRN("Combined tile request without a loaded document?");
+            continue;
+        }
+
         TileCache::Tile cachedTile = _tileCache->lookupTile(tile);
         if(!cachedTile)
         {


### PR DESCRIPTION
Similar to commit 2b546f72dec43d8ac3bc24c1f767ceb7f617d9be (document
broker: handle tile request without tile cache, 2020-09-28), though
sadly I don't have a reproducer for this at hand anymore.

Change-Id: I5b3c2c69d5b5719998b3ce261aafb775d5441c2f