### PR TITLE
cypress: fail on missing LO installation.

### DIFF
--- a/cypress_test/Makefile.am
+++ b/cypress_test/Makefile.am
@@ -402,6 +402,11 @@ $(NPM_INSTALLED): package.json eslint_plugin/index.js eslint_plugin/package.json
 	@mkdir -p $(dir $(NPM_INSTALLED))
 	@touch $(NPM_INSTALLED)
 
+else
+
+check-local:
+	$(error CypressError: Can't find LibreOffice core installation!)
+
 endif
 
 clean-local:


### PR DESCRIPTION
Jenkins sometimes does not work properly and core
installation is not accessible for online build.
In this case the test build was passing without
actually run the tests. Fail on this instead to
avoid getting untested patches in the code repo.

Change-Id: I35c49562dfeaeda5f6c8aa4bd3a746b1f04de3ea