### PR TITLE
Fix save-as readonly file starts with readonly

### DIFF
--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -762,8 +762,15 @@ L.Socket = L.Class.extend({
 				var docUrl = url.split('?')[0];
 				this._map.options.doc = docUrl;
 				this._map.options.wopiSrc = encodeURIComponent(docUrl);
+
+				// if this is save-as, we need to load the document with edit permission
+				// otherwise the user has to close the doc then re-open it again
+				// in order to be able to edit.
+				if (textMsg.startsWith('saveas:'))
+					this._map.options.permission = 'edit';
 				this._map.loadDocument();
 				this._map.sendInitUNOCommands();
+
 
 				if (textMsg.startsWith('renamefile:')) {
 					this._map.fire('postMessage', {


### PR DESCRIPTION
When read-only shared file can be save-as to
users own storage, then it must be start with
edit permission after save-as. Otherwise,
user must close the doc and reopen again in order
to be able to edit.

Change-Id: I9eacc9373f3333d1ed3fff142d8023667e31342a
Signed-off-by: mert <mert.tumer@collabora.com>