### PR TITLE
notifyirc: no need to write about new PRs

### DIFF
--- a/.github/workflows/notifyirc.yml
+++ b/.github/workflows/notifyirc.yml
@@ -7,21 +7,13 @@ jobs:
     steps:
       - name: irc push
         uses: rectalogic/notify-irc@v1
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && github.event.ref == 'refs/heads/master'
         with:
           channel: "#cool-dev"
           nickname: cool-github-notifier
           message: |
             ${{ github.actor }} pushed ${{ github.event.ref }} ${{ github.event.compare }}
             ${{ join(github.event.commits.*.message) }}
-      - name: irc pull request
-        uses: rectalogic/notify-irc@v1
-        if: github.event_name == 'pull_request'
-        with:
-          channel: "#cool-dev"
-          nickname: cool-github-notifier
-          message: |
-            ${{ github.actor }} opened PR ${{ github.event.html_url }}
       - name: irc tag created
         uses: rectalogic/notify-irc@v1
         if: github.event_name == 'create' && github.event.ref_type == 'tag'


### PR DESCRIPTION
It's enough to notify when they hit master.

Also don't write about non-master commits, which are sources for PRs to
be opened, in many cases.

Change-Id: I4bb7628cce4bb767016cd30aace72e88074970d4
