### PR TITLE
Online: Copy hyperlink location. / Online side.

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -1532,7 +1532,7 @@ bool ChildSession::unoCommand(const char* /*buffer*/, int /*length*/, const Stri
         }
         else
         {
-            if (tokens[1] == ".uno:Copy")
+            if (tokens[1] == ".uno:Copy" || tokens[1] == ".uno:CopyHyperlinkLocation")
                 _copyToClipboard = true;
 
             getLOKitDocument()->postUnoCommand(tokens[1].c_str(), nullptr, bNotify);
@@ -2603,14 +2603,15 @@ void ChildSession::loKitCallback(const int type, const std::string& payload)
         break;
     case LOK_CALLBACK_CLIPBOARD_CHANGED:
     {
-        std::string selection;
         if (_copyToClipboard)
         {
             _copyToClipboard = false;
-            selection = getTextSelectionInternal("");
+            if (payload.empty())
+                getTextSelectionInternal("");
+            else
+                sendTextFrame("clipboardchanged: " + payload);
         }
 
-        sendTextFrame("clipboardchanged: " + selection);
         break;
     }
     case LOK_CALLBACK_CONTEXT_CHANGED:

--- a/loleaflet/src/layer/tile/TileLayer.js
+++ b/loleaflet/src/layer/tile/TileLayer.js
@@ -651,6 +651,15 @@ L.TileLayer = L.GridLayer.extend({
 				// hack for ios and android to get selected text into hyperlink insertion dialog
 				this._selectedTextContent = textMsg.substr(22);
 		}
+		else if (textMsg.startsWith('clipboardchanged')) {
+			var jMessage = textMsg.substr(17);
+			jMessage = JSON.parse(jMessage);
+
+			if (jMessage.mimeType === 'text/plain') {
+				this._map._clip.setTextSelectionHTML(jMessage.content);
+				this._map._clip._execCopyCutPaste('copy');
+			}
+		}
 		else if (textMsg.startsWith('textselectionend:')) {
 			this._onTextSelectionEndMsg(textMsg);
 		}


### PR DESCRIPTION
Unused selection variable has been removed. "clipboardchanged" event is activated.
LOK_CALLBACK_CLIPBOARD_CHANGED is handled according to existence of payload.

Change-Id: I6e37cb2ca4d4c59e55555ba3397cb00dbb7eafa2
Reviewed-on: https://gerrit.libreoffice.org/c/online/+/103165
Tested-by: Jenkins CollaboraOffice <jenkinscollaboraoffice@gmail.com>
Reviewed-by: Jan Holesovsky <kendy@collabora.com>