### PR TITLE
In force saving case allow also when unmodified

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -998,8 +998,11 @@ bool DocumentBroker::saveToStorageInternal(const std::string& sessionId, bool su
         return false;
     }
 
+    // Last internal save could be successfull but storage save failed
+    bool needToFinishSaveToStorage = !_lastStorageSaveSuccessful && result == "unmodified";
+
     // Check that we are actually about to upload a successfully saved document.
-    if (!success && !force)
+    if (!success && !needToFinishSaveToStorage && !force)
     {
         LOG_ERR("Cannot store docKey [" << _docKey << "] as .uno:Save has failed in LOK.");
         it->second->sendTextFrameAndLogError("error: cmd=storage kind=savefailed");


### PR DESCRIPTION
Force save should only avoid saving to storage when
internal saving failed. When last save to storage failed
but internal save results in unmodified allow to continue
to finish the saving process. This will let us to
escape from infinite loop of autoSave trials when
internal save returns unmodified but DocumentBroker thinks
that there is something to save.

Change-Id: I1a244731ce05d3e162297fa369edd236d9678ab6