### PR TITLE
Fix uncaught exception on localStorage

### DIFF
--- a/loleaflet/html/loleaflet.html.m4
+++ b/loleaflet/html/loleaflet.html.m4
@@ -102,6 +102,16 @@ var Base64ToArrayBuffer = function(base64Str) {
     window.fullyLoadedAndReady = true;
   }, false);
 
+window.isLocalStorageAllowed = (function() {
+  var str = 'localstorage_test';
+  try {
+    localStorage.setItem(str, str);
+    localStorage.removeItem(str);
+    return true;
+  } catch(e) {
+    return false;
+  }
+})();
 </script>
 
 m4_dnl In the debug case, just write all the .css files here

--- a/loleaflet/src/control/Control.UIManager.js
+++ b/loleaflet/src/control/Control.UIManager.js
@@ -375,13 +375,16 @@ L.Control.UIManager = L.Control.extend({
 	},
 
 	setSavedState: function(name, state) {
-		localStorage.setItem('UIDefaults_' + this.map.getDocType() + '_' + name, state);
+		if (window.isLocalStorageAllowed)
+			localStorage.setItem('UIDefaults_' + this.map.getDocType() + '_' + name, state);
 	},
 
 	getSavedStateOrDefault: function(name) {
 		var retval = true;
 		var docType = this.map.getDocType();
-		var state = localStorage.getItem('UIDefaults_' + docType + '_' + name);
+		var state = null;
+		if (window.isLocalStorageAllowed)
+			state = localStorage.getItem('UIDefaults_' + docType + '_' + name);
 		switch (state) {
 		case 'true':
 			return true;

--- a/loleaflet/src/control/Toolbar.js
+++ b/loleaflet/src/control/Toolbar.js
@@ -476,7 +476,7 @@ L.Map.include({
 	},
 
 	shouldWelcome: function() {
-		if (!window.enableWelcomeMessage || L.Browser.cypressTest)
+		if (!window.isLocalStorageAllowed || !window.enableWelcomeMessage || L.Browser.cypressTest)
 			return false;
 
 		var storedVersion = localStorage.getItem('WSDWelcomeVersion');


### PR DESCRIPTION
3rd party cookies or localstorage can be blocked
on the browser settings, especially is on chrome incognito
mode. This causes the document fail to load.

Change-Id: Ia2a182262a754c76aec58cbbce60a0298320df33
Signed-off-by: mert <mert.tumer@collabora.com>