### PR TITLE
wsd: allow URIs without access_header or access_token

### DIFF
--- a/common/Authorization.cpp
+++ b/common/Authorization.cpp
@@ -82,8 +82,8 @@ void Authorization::authorizeRequest(Poco::Net::HTTPRequest& request) const
             break;
         }
         default:
-            // assert(false);
-            throw BadRequestException("Invalid HTTP request type");
+            LOG_TRC("No HTTP Authorization type detected. Assuming no authorization needed. "
+                    "Specify access_token to set the Authorization Bearer header.");
             break;
     }
 }

--- a/test/WhiteBoxTests.cpp
+++ b/test/WhiteBoxTests.cpp
@@ -753,7 +753,7 @@ void WhiteBoxTests::testAuthorization()
 
     Authorization auth6(Authorization::Type::None, "Authorization: basic huh==");
     Poco::Net::HTTPRequest req6;
-    CPPUNIT_ASSERT_THROW(auth6.authorizeRequest(req6), BadRequestException);
+    CPPUNIT_ASSERT_NO_THROW(auth6.authorizeRequest(req6));
 
     {
         const std::string WorkingDocumentURI
@@ -787,6 +787,19 @@ void WhiteBoxTests::testAuthorization()
         auth7.authorizeRequest(req7);
         LOK_ASSERT_EQUAL(AuthorizationParam, req7.get("Authorization"));
         LOK_ASSERT_EQUAL(std::string("XMLHttpRequest"), req7.get("X-Requested-With"));
+    }
+
+    {
+        const std::string URI
+            = "https://example.com:8443/rest/files/wopi/files/"
+              "8ac75551de4d89e60002?reuse_cookies=lang%3Den-us%3A_xx_%3DGS1.1.%3APublicToken%"
+              "3DeyJzdWIiOiJhZG1pbiIsImV4cCI6MTU4ODkxNzc3NCwiaWF0IjoxNTg4OTE2ODc0LCJqdGkiOiI4OGZhN2"
+              "E3ZC1lMzU5LTQ2OWEtYjg3Zi02NmFhNzI0ZGFkNTcifQ%3AZNPCQ003-32383700%3De9c71c3b%"
+              "3AJSESSIONID%3Dnode019djohorurnaf1eo6f57ejhg0520.node0&permission=edit";
+
+        Authorization auth7(Authorization::create(URI));
+        Poco::Net::HTTPRequest req;
+        auth7.authorizeRequest(req);
     }
 }
 


### PR DESCRIPTION
URIs may or may not have authorization data specified
via access_header or access_token query parameters.

In the event that the host doesn't have such needs
(for example authrorization could be performed by
some other means), we should accept the request
and still go ahead and make the WOPI request
all the same.

This patch effectively reverts the changes from
a019c93d90e08aceb8b645e6cf963e6256fb38c6 which threw
an exception when the authorization method was
undefined. Since there was an assertion to warn
programmers that something is amis, now we simply
log the fact in trace mode and move on.

A new unit-test is added and another one that
expected the now-removed exception has been modified.

Change-Id: I26cc2514d7465b344037a6e32b777c0fe0ba9a2c