### PR TITLE
GitPodify COOL - Initial support

### DIFF
--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -1,0 +1,15 @@
+FROM gitpod/workspace-full
+
+RUN sudo sh -c "echo deb-src http://archive.ubuntu.com/ubuntu/ focal main restricted >> /etc/apt/sources.list" \
+ && sudo sh -c "echo deb-src http://archive.ubuntu.com/ubuntu/ focal-updates main restricted >> /etc/apt/sources.list" \
+ && sudo sh -c "echo deb-src http://security.ubuntu.com/ubuntu/ focal-security main restricted >> /etc/apt/sources.list" \
+ && sudo sh -c "echo deb-src http://security.ubuntu.com/ubuntu/ focal-security universe >> /etc/apt/sources.list" \
+ && sudo sh -c "echo deb-src http://security.ubuntu.com/ubuntu/ focal-security multiverse >> /etc/apt/sources.list" \
+ && sudo apt-get update \
+ && sudo apt-get install -y \
+    build-essential git libpoco-dev libcap-dev python3-polib npm libpng-dev python3-lxml libpam-dev \
+ && sudo apt-get build-dep -y libreoffice \
+ && pip install lxml \
+ && pip install polib \
+ && sudo rm -rf /var/lib/apt/lists/*
+

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,30 @@
+image:
+  file: .gitpod.dockerfile
+
+vscode:
+  extensions:
+    - ms-vscode.cpptools@0.26.2:Pq/tmf2WN3SanVzB4xZc1g==
+
+github:
+  prebuilds:
+    # enable for the master/default branch (defaults to true)
+    master: true
+    # enable for all branches in this repo (defaults to false)
+    branches: false
+    # enable for pull requests coming from this repo (defaults to true)
+    pullRequests: false
+    # enable for pull requests coming from forks (defaults to false)
+    pullRequestsFromForks: false
+    # add a check to pull requests (defaults to true)
+    addCheck: false
+    # add a "Review in Gitpod" button as a comment to pull requests (defaults to false)
+    addComment: false
+    # add a "Review in Gitpod" button to the pull request's description (defaults to false)
+    addBadge: false
+    # add a label once the prebuild is ready to pull requests (defaults to false)
+    addLabel: false
+
+tasks:
+  - init: cd .. && wget https://github.com/CollaboraOnline/online/releases/download/for-code-assets/core-cp-6.4-assets.tar.gz
+    prebuild: tar xvf core-cp-6.4-assets.tar.gz && rm core-cp-6.4-assets.tar.gz && cd online && ./autogen.sh && ./configure --enable-silent-rules --with-lokit-path=/workspace/include --with-lo-path=/workspace/instdir --enable-debug --disable-setcap && make
+


### PR DESCRIPTION
Web based, containrized, ready-to-use dev environment & IDE.
https://gitpod.io

Open in GitPod: https://gitpod.io/#https://github.com/CollaboraOnline/online
* You will have the environment, but you might need to
  run the build commands yourselves

Force to prebuild: https://gitpod.io/#prebuild/https://github.com/CollaboraOnline/online
* This should come at the point make command stage is completed

We will also enable auto-prebuilds on each push,
and add a button to get a prebuilt/ready env

TODO:
* Open port(s) to be able to connect to COOL while running
* Add missing VSCode extensions if any
* Enable prebuilds for push events
* Add button on README

Change-Id: I726a7fb0693cd39109c88b86b3d6941e0210c249