### PR TITLE
Introduce Util::make_unique()

### DIFF
--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -1221,6 +1221,17 @@ int main(int argc, char**argv)
         return std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::system_clock::now()).time_since_epoch().count();
     }
 
+    /**
+     * Constructs an object of type T and wraps it in a std::unique_ptr.
+     *
+     * Can be replaced by std::make_unique when we allow C++14.
+     */
+    template<typename T, typename... Args>
+    typename std::unique_ptr<T> make_unique(Args&& ... args)
+    {
+        return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+    }
+
 } // end namespace Util
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1596,7 +1596,7 @@ void ClientSession::enqueueSendMessage(const std::shared_ptr<Message>& data)
     if (command == "tile:")
     {
         // Avoid sending tile if it has the same wireID as the previously sent tile
-        tile.reset(new TileDesc(TileDesc::parse(data->firstLine())));
+        tile = Util::make_unique<TileDesc>(TileDesc::parse(data->firstLine()));
         auto iter = _oldWireIds.find(tile->generateID());
         if(iter != _oldWireIds.end() && tile->getWireId() != 0 && tile->getWireId() == iter->second)
         {


### PR DESCRIPTION
In the old code, if the evaluation first allocates the memory for the
raw pointer, then calls firstLine() and an exception is thrown before
the std::unique_ptr construction, then the memory is leaked. Using
make_unique() has the benefit of avoiding this problem.

Convert only a single usage, so the remaining places can be done as easy
hacks.

Change-Id: Iaf3d8051a8a0627a57fdf1196bde7d5f8612fcff
