### PR TITLE
Use image if present in the clipboard

### DIFF
--- a/loleaflet/src/map/Clipboard.js
+++ b/loleaflet/src/map/Clipboard.js
@@ -385,7 +385,8 @@ L.Clipboard = L.Class.extend({
 		// FIXME: do we want this section ?
 
 		// Images get a look in only if we have no content and are async
-		if (content == null && htmlText === '' && dataTransfer != null)
+		var htmlImage = htmlText.substring(0, 4) === '<img';
+		if (((content == null && htmlText === '') || htmlImage) && dataTransfer != null)
 		{
 			var types = dataTransfer.types;
 


### PR DESCRIPTION
When image is copied in the browser we have two mimetypes
in the clipboard: text/html and file with image.
If html contains only img then use image file because
in Calc and Impress html pasting will result in pasting
as a text without images (Writer uses better HTML reader).

Change-Id: If2962476cdc6c8d75d23bacbf31bfaf519394aed