### PR TITLE
tdf#133279: More hacks to improve keyboard functionality in tunnelled…

### DIFF
--- a/ios/CollaboraOnlineWebViewKeyboardManager/CollaboraOnlineWebViewKeyboardManager.m
+++ b/ios/CollaboraOnlineWebViewKeyboardManager/CollaboraOnlineWebViewKeyboardManager.m
@@ -314,6 +314,8 @@
         lastCommandIsHide = NO;
         lastActionIsDisplay = YES;
 
+        NSLog(@"COKbdMgr: lastCommandIsHide:=NO lastActionIsDisplay:=YES");
+
         [self->webView addSubview:control];
         NSLog(@"COKbdMgr: Added _COWVKMKeyInputControl to webView");
         [control becomeFirstResponder];
@@ -330,17 +332,17 @@
     // folllowed by a display request within 100 ms.
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 100000000ll), dispatch_get_main_queue(), ^{
             if (!self->lastCommandIsHide) {
-                NSLog(@"COKbdMgr: Ignoring hide command that was quickly followed by a display command");
+                NSLog(@"COKbdMgr: lastCommandIsHide==NO Ignoring hide command that was quickly followed by a display command");
                 return;
             }
             if (self->lastActionIsDisplay) {
-                NSLog(@"COKbdMgr: Ignoring hide command that quickly followed a display command");
+                NSLog(@"COKbdMgr: lastActionIsDisplay==YES Ignoring hide command that quickly followed a display command");
                 return;
             }
             if (self->control != nil) {
                 self->lastActionIsDisplay = NO;
                 [self->control removeFromSuperview];
-                NSLog(@"COKbdMgr: Removed _COWVKMKeyInputControl from webView");
+                NSLog(@"COKbdMgr: lastActionIsDisplay:=NO Removed _COWVKMKeyInputControl from webView");
                 self->control = nil;
             }
         });
@@ -366,7 +368,7 @@
             [self displayKeyboardOfType:type withText:text at:(location != nil ? [location unsignedIntegerValue] : UINT_MAX)];
         } else if ([stringCommand isEqualToString:@"hide"]) {
             lastCommandIsHide = YES;
-            NSLog(@"COKbdMgr: command=hide");
+            NSLog(@"COKbdMgr: command=hide lastCommandIsHide:=YES");
             [self hideKeyboard];
         } else if (stringCommand == nil) {
             NSLog(@"COKbdMgr: No 'command' in %@", message.body);
@@ -384,6 +386,10 @@
         [control removeFromSuperview];
         NSLog(@"COKbdMgr: Removed _COWVKMKeyInputControl from webView");
         control = nil;
+        if (self->lastActionIsDisplay) {
+            NSLog(@"COKbdMgr: lastActionIsDisplay==YES But display it again as loleaflet hasn't asked for it to be hidden");
+            [self displayKeyboardOfType:nil withText:@"" at:UINT_MAX];
+        }
     }
 }
 


### PR DESCRIPTION
… dialogs

When keyboard input has been directed to one text field in a tunnelled
dialog, and the user taps in another field, we (for some unclear
reason) then get a UIKeyboardDidHideNotification, but we do want the
keyboard to stay usable, so make sure that happens.

Change-Id: I6d0ba9ab65027ad1f687b2bc98b2294e061376d5