### PR TITLE
Drop the pressesEnded method that did just logging

### DIFF
--- a/ios/CollaboraOnlineWebViewKeyboardManager/CollaboraOnlineWebViewKeyboardManager.m
+++ b/ios/CollaboraOnlineWebViewKeyboardManager/CollaboraOnlineWebViewKeyboardManager.m
@@ -216,11 +216,6 @@
     [super pressesBegan:presses withEvent:event];
 }
 
-- (void)pressesEnded:(NSSet<UIPress*>*)presses
-           withEvent:(UIPressesEvent*)event {
-    NSLog(@"COKbdMgr: pressesEnded: %@", [self describeUIPresses:presses]);
-}
-
 @synthesize hasText;
 
 @end


### PR DESCRIPTION
It didn't even call the method in the superclass, which surely was
wrong.

Change-Id: I081e3d6650a71c8527b31f1b3fc5f5df9b41379b