### PR TITLE
./g review: add an optional 'name' parameter

### DIFF
--- a/g
+++ b/g
@@ -2,10 +2,12 @@
 #
 # './g pull -r' just forwards to 'git pull -r'.
 #
-# './g review' to submit a pull request, assuming:
+# './g review [name]' to submit a pull request, assuming:
 # 1) You have 'gh' installed.
 # 2) You are a committer, so you have the permission to push to a private/nick/name branch.
 # 3) You delete this branch after the PR is merged.
+# 4) "name" is the name of part of the private/user/name remote branch, defaults to the current
+#    branch. You have to specify this explicitly if you want to update an existing PR.
 #
 
 if [ "$1" == "review" ]; then
@@ -15,16 +17,30 @@ if [ "$1" == "review" ]; then
     fi
 
     BRANCH=$(git symbolic-ref HEAD|sed 's|refs/heads/||')
+    REMOTE_BRANCH=private/$USER/$BRANCH
+    CUSTOM_BRANCH=
+    if [ -n "$2" ]; then
+        REMOTE_BRANCH=private/$USER/$2
+        CUSTOM_BRANCH=y
+    fi
+    HAS_REMOTE_BRANCH=
     REMOTE=$(git config branch.$BRANCH.remote)
-    if git rev-parse --quiet --verify $REMOTE/private/$USER/$BRANCH >/dev/null; then
-        # PR is open, just update it.
-        git push -f $REMOTE HEAD:private/$USER/$BRANCH
+    if git rev-parse --quiet --verify $REMOTE/$REMOTE_BRANCH >/dev/null; then
+        HAS_REMOTE_BRANCH=y
+    fi
+    if [ -n "$HAS_REMOTE_BRANCH" ] && [ -z "$CUSTOM_BRANCH" ]; then
+        echo "Error: default remote branch would be '$REMOTE_BRANCH', but it already exists."
+        echo "To update the existing PR: type './g review $BRANCH' explicitly."
+        exit 1
+    elif [ -n "$HAS_REMOTE_BRANCH" ] && [ -n "$CUSTOM_BRANCH" ]; then
+        # PR is open, same branch is explicitly specified, just update it.
+        git push -f $REMOTE HEAD:$REMOTE_BRANCH
     else
         # Open a new PR.
-        git push $REMOTE HEAD:private/$USER/$BRANCH
-        git branch private/$USER/$BRANCH
-        gh pr create --base $BRANCH --head private/$USER/$BRANCH --fill
-        git branch -D private/$USER/$BRANCH
+        git push $REMOTE HEAD:$REMOTE_BRANCH
+        git branch $REMOTE_BRANCH
+        gh pr create --base $BRANCH --head $REMOTE_BRANCH --fill
+        git branch -D $REMOTE_BRANCH
     fi
     exit 0
 fi


### PR DESCRIPTION
Use-case: create a commit, submit to CI, then forget about it (git reset
--hard origin/master). Then create a next commit, and submit that to CI
as well -- instead of silently updating the previous PR.

Now the silent update doesn't happen anymore:

- If the update is intentional, have to specify the same branch name
explicitly. (E.g. you're on master, then specify 'master'.)

- If the update is not intentional, choose a different name.

Change-Id: Iee9d9ef13286a6a5083c6f9a28682ba65b8504ff
