### PR TITLE
cypress: fix buildir != srcdir when run parallel

### DIFF
--- a/cypress_test/run_parallel.sh
+++ b/cypress_test/run_parallel.sh
@@ -1,11 +1,18 @@
 #!/usr/bin/env bash
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-CYPRESS_BINARY="${DIR}/node_modules/cypress/bin/cypress"
+
+if [ -z "${NODE_PATH}" ]; then
+    BUILDDIR=${DIR}
+else
+    BUILDDIR=$(dirname ${NODE_PATH})
+fi
+
+CYPRESS_BINARY="${BUILDDIR}/node_modules/cypress/bin/cypress"
 DESKTOP_TEST_FOLDER="${DIR}/integration_tests/desktop/"
 MOBILE_TEST_FOLDER="${DIR}/integration_tests/mobile/"
 MULTIUSER_TEST_FOLDER="${DIR}/integration_tests/multiuser/"
-ERROR_LOG="${DIR}/workdir/error.log"
+ERROR_LOG="${BUILDDIR}/workdir/error.log"
 
 print_help ()
 {


### PR DESCRIPTION
Change-Id: Id4763a7af8a0d705aefb403dbfb8fb694f97749f
