### PR TITLE
Fixing pycodestyle checks

### DIFF
--- a/loleaflet/util/po2json.py
+++ b/loleaflet/util/po2json.py
@@ -1,60 +1,68 @@
 #!/usr/bin/env python3
-#
-# convert .po to .json
-#
+"""Convert .po to .json."""
 
 import json
 import optparse
 import os
-import polib
-import re
-import string
 import sys
 import errno
+import re
+import polib
 
 parser = optparse.OptionParser(usage="usage: %prog [options] pofile...")
-parser.add_option("--quiet", action="store_false", default=True, dest="verbose", help="don't print status messages to stdout")
-parser.add_option("-o", type="string", default="", dest="destfile", help="output file name (if there is exactly one input file)")
+parser.add_option("--quiet",
+                  action="store_false",
+                  default=True,
+                  dest="verbose",
+                  help="don't print status messages to stdout")
+parser.add_option("-o",
+                  type="string",
+                  default="",
+                  dest="destfile",
+                  help="output file name (if there is exactly one input file)")
 
 (options, args) = parser.parse_args()
 
-if args == None or len(args) == 0:
-	print("ERROR: you must specify at least one po file to translate");
-	sys.exit(1)
+if args is None or len(args) == 0:
+    print("ERROR: you must specify at least one po file to translate")
+    sys.exit(1)
 
 if options.destfile != '' and len(args) != 1:
-	print("ERROR: when -o is provided, there has to be exactly 1 input file")
-	sys.exit(1)
+    print("ERROR: when -o is provided, there has to be exactly 1 input file")
+    sys.exit(1)
 
 paramFix = re.compile("(\\(([0-9])\\))")
 
 for srcfile in args:
 
-	destfile = os.path.splitext(srcfile)[0] + ".json"
-	if options.destfile != '':
-		destfile = options.destfile
+    destfile = os.path.splitext(srcfile)[0] + ".json"
+    if options.destfile != '':
+        destfile = options.destfile
 
-	if options.verbose:
-		print("INFO: converting %s to %s" % (srcfile, destfile))
+    if options.verbose:
+        print("INFO: converting %s to %s" % (srcfile, destfile))
 
-	xlate_map = {}
+    xlate_map = {}
 
-	po = polib.pofile(srcfile, autodetect_encoding=False, encoding="utf-8", wrapwidth=-1)
-	for entry in po.translated_entries():
-		if entry.msgstr == '':
-			continue
+    po = polib.pofile(srcfile,
+                      autodetect_encoding=False,
+                      encoding="utf-8",
+                      wrapwidth=-1)
+    for entry in po.translated_entries():
+        if entry.msgstr == '':
+            continue
 
-		xlate_map[entry.msgid] = entry.msgstr;
+        xlate_map[entry.msgid] = entry.msgstr
 
-	if not os.path.exists(os.path.dirname(destfile)):
-		try:
-			os.makedirs(os.path.dirname(destfile))
-		except OSError as exc: # Guard against race condition
-			if exc.errno != errno.EEXIST:
-				raise
+    if not os.path.exists(os.path.dirname(destfile)):
+        try:
+            os.makedirs(os.path.dirname(destfile))
+        except OSError as exc:  # Guard against race condition
+            if exc.errno != errno.EEXIST:
+                raise
 
-	dest = open(destfile, "w")
+    dest = open(destfile, "w")
 
-	dest.write(json.dumps(xlate_map, sort_keys = True));
+    dest.write(json.dumps(xlate_map, sort_keys=True))
 
-	dest.close()
+    dest.close()


### PR DESCRIPTION
Hello @mrkara !
I fixed the pycodestyle errors.

However, please note that `pylint` still complains about using an outdated module. I would recommend using `argparse` instead of `optparse`:
```
po2json.py:5:0: W0402: Uses of a deprecated module 'optparse' (deprecated-module)

------------------------------------------------------------------
Your code has been rated at 9.74/10 (previous run: 8.46/10, +1.28)
```

I will check the other Python files shortly. Hope it helps!