### PR TITLE
wsd: correction in conversion  from timestamp to ISO8601

### DIFF
--- a/common/Util.cpp
+++ b/common/Util.cpp
@@ -880,7 +880,7 @@ namespace Util
         oss << std::setfill('0')
             << time_modified
             << std::setw(6)
-            << (time - lastModified_s).count() / 1000
+            << (time - lastModified_s).count() / (std::chrono::system_clock::period::den / std::chrono::system_clock::period::num / 1000000)
             << 'Z';
 
         return oss.str();
@@ -933,8 +933,15 @@ namespace Util
 
         char* end = nullptr;
         const size_t us = strtoul(trailing + 1, &end, 10); // Skip the '.' and read as integer.
+
+        std::size_t denominator = 1;
+        for (const char* i = trailing + 1; i != end; i++)
+        {
+            denominator *= 10;
+        }
+
         const std::size_t seconds_us = us * std::chrono::system_clock::period::den
-                                       / std::chrono::system_clock::period::num / 1000000;
+                                       / std::chrono::system_clock::period::num / denominator;
 
         timestamp += std::chrono::system_clock::duration(seconds_us);
 

--- a/test/WhiteBoxTests.cpp
+++ b/test/WhiteBoxTests.cpp
@@ -941,6 +941,14 @@ void WhiteBoxTests::testTime()
     t = std::chrono::system_clock::time_point(std::chrono::nanoseconds(1569592993495336798));
     LOK_ASSERT_EQUAL(std::string("Fri, 27 Sep 2019 14:03:13"), Util::getHttpTime(t));
 
+    t = Util::iso8601ToTimestamp("2020-09-22T21:45:12.583000Z", "LastModifiedTime");
+    LOK_ASSERT_EQUAL(std::string("2020-09-22T21:45:12.583000Z"),
+                         Util::time_point_to_iso8601(t));
+
+    t = Util::iso8601ToTimestamp("2020-09-22T21:45:12.583Z", "LastModifiedTime");
+    LOK_ASSERT_EQUAL(std::string("2020-09-22T21:45:12.583000Z"),
+                         Util::time_point_to_iso8601(t));
+
     for (int i = 0; i < 100; ++i)
     {
         t = std::chrono::system_clock::now();


### PR DESCRIPTION
closes #168

Change-Id: Ibdb1aa72a6961d4707c2336382cc593c984d3615