### PR TITLE
document broker, tile combined handling: warn only once without tile cache

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1784,17 +1784,17 @@ void DocumentBroker::handleTileCombinedRequest(TileCombined& tileCombined,
     std::unique_lock<std::mutex> lock(_mutex);
 
     LOG_TRC("TileCombined request for " << tileCombined.serialize());
+    if (!hasTileCache())
+    {
+        LOG_WRN("Combined tile request without a loaded document?");
+        return;
+    }
 
     // Check which newly requested tiles need rendering.
     std::vector<TileDesc> tilesNeedsRendering;
     for (auto& tile : tileCombined.getTiles())
     {
         tile.setVersion(++_tileVersion);
-        if (!hasTileCache())
-        {
-            LOG_WRN("Combined tile request without a loaded document?");
-            continue;
-        }
 
         TileCache::Tile cachedTile = _tileCache->lookupTile(tile);
         if(!cachedTile)


### PR DESCRIPTION
Follow-up to commit 3a7a6948f1d5058bac6616dfe0bc780d505cd735 (document
broker: handle combined tile request without tile cache, 2020-10-05),
requested at <https://github.com/CollaboraOnline/online/pull/242>.

Change-Id: I57124c64dbf3034de8f43584164572eed8d67f86
