### PR TITLE
leaflet: writer cursor does not appear after session idle

### DIFF
--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -499,6 +499,7 @@ L.Socket = L.Class.extend({
 					{
 						console.debug('idleness: reactivating');
 						map._documentIdle = false;
+						map._docLayer._setCursorVisible();
 						// force reinitialization of calcInputBar(formulabar)
 						if (map.dialog._calcInputBar)
 							map.dialog._calcInputBar.id = null;

--- a/loleaflet/src/layer/tile/TileLayer.js
+++ b/loleaflet/src/layer/tile/TileLayer.js
@@ -924,6 +924,10 @@ L.TileLayer = L.GridLayer.extend({
 		this._onUpdateCursor();
 	},
 
+	_setCursorVisible: function() {
+		this._map._isCursorVisible = true;
+	},
+
 	_onDownloadAsMsg: function (textMsg) {
 		var command = this._map._socket.parseServerCmd(textMsg);
 		var parser = document.createElement('a');

--- a/loleaflet/src/map/Map.js
+++ b/loleaflet/src/map/Map.js
@@ -310,6 +310,8 @@ L.Map = L.Evented.extend({
 
 	loadDocument: function(socket) {
 		this._socket.connect(socket);
+		if (this._clip)
+			this._clip.clearSelection();
 		this.removeObjectFocusDarkOverlay();
 	},
 


### PR DESCRIPTION
Change-Id: I2c7170e9ee73a3c4c6bc36688c7ebc8b95bccb57

* Target version: master 

### Summary
problem:
if shape was selected when document idle out,
on reconnecting cursor will not appear directly,
and after clicking somewhere cursor will not follow the view

the reason behind the problem:
if the shape was selected before idle out, on reconnecting
_clip._selectionType is not cleared and is still "complex"
this is what stops the view to follow cursor
cursor is not visible because _isCursorVisible never reset


### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

