### PR TITLE
Introduce UI_Hyperlink postMessage.

### DIFF
--- a/loleaflet/reference.html
+++ b/loleaflet/reference.html
@@ -3432,6 +3432,21 @@ Note that they usually don't change but there is no guarantee that they are stab
 		</td>
 	</tr>
 	<tr>
+		<td><code><b>UI_Hyperlink</b></code></td>
+		<td></td>
+		<td>
+		Notifies WOPI host that the user clicked a hyperlink and
+		confirmed they really want to leave the document to follow the
+		hyperlink.</br>
+		This is especially useful for integrations that
+		embed Collabora Online into an iframe in a mobile app, where
+		actually trying to open a new window should trigger starting a
+		new Activity on Android (or something similar on iOS).</br>
+		The integration using this most probably also wants to trigger
+		the <b>Disable_Default_UIAction</b> for UI_Hyperlink.
+		</td>
+	</tr>
+	<tr>
 		<td><code><b>Doc_ModifiedStatus</b></code></td>
 		<td></td>
 		<td>

--- a/loleaflet/src/map/handler/Map.WOPI.js
+++ b/loleaflet/src/map/handler/Map.WOPI.js
@@ -54,6 +54,28 @@ L.Map.WOPI = L.Handler.extend({
 		L.DomEvent.on(window, 'message', this._postMessageListener, this);
 
 		this._map.on('updateviewslist', function() { this._postViewsMessage('Views_List'); }, this);
+
+		if (!window.ThisIsAMobileApp) {
+			// override the window.open to issue a postMessage, so that
+			// it is possible to handle the hyperlink in the integration
+			var that = this;
+			window.open = function (open) {
+				return function (url, name, features) {
+					that._map.fire('postMessage', {
+						msgId: 'UI_Hyperlink',
+						args: {
+							Url: url,
+							Name: name,
+							Features: features
+						}
+					});
+					if (!that._map._disableDefaultAction['UI_Hyperlink'])
+						return open.call(window, url, name, features);
+					else
+						return null;
+				};
+			}(window.open);
+		}
 	},
 
 	removeHooks: function() {


### PR DESCRIPTION
This is to be able to send the URL that the user wants to be open
outside the iframe, to the integration, and the integration can then
decide how to actually open the URL.

This is most useful for mobile apps that integrate the Collabora Online
in an iframe, so that they can handle the hyperlink their own way.

Change-Id: I389bb6ff15fbd66ced128e0ee2e1b08fea76bc8c
