### PR TITLE
Revert "Send HYPERLINK post message when link opened"

### DIFF
--- a/loleaflet/src/control/Control.AlertDialog.js
+++ b/loleaflet/src/control/Control.AlertDialog.js
@@ -64,14 +64,6 @@ L.Control.AlertDialog = L.Control.extend({
 					click: function openClick () {
 						window.open(url, '_blank');
 						vex.closeAll();
-
-						if (!window.ThisIsAMobileApp &&
-							window.webkit &&
-							window.webkit.messageHandlers &&
-							window.webkit.messageHandlers.lool &&
-							window.webkit.messageHandlers.lool.postMessage) {
-							window.webkit.messageHandlers.lool.postMessage('HYPERLINK ' + url);
-						}
 					}
 				});
 			}


### PR DESCRIPTION
Now when we have the UI_Hyperlink postMessage, this can be reverted,
because it does not really do what we need anyway.

This reverts commit bd85bf3a1d488ebc621fdfb9fdc512a1a32f0904.

Change-Id: I05c5301c5510f132c7066087bb7642907d911705


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

