### PR TITLE
wsd: LOK_WHITELIST_LANGUAGES was removed from new enough core

### DIFF
--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -1185,7 +1185,10 @@ void LOOLWSD::initialize(Application& self)
 #endif
 
     std::string allowedLanguages(config().getString("allowed_languages"));
+    // Core <= 7.0.
     setenv("LOK_WHITELIST_LANGUAGES", allowedLanguages.c_str(), 1);
+    // Core >= 7.1.
+    setenv("LOK_ALLOWLIST_LANGUAGES", allowedLanguages.c_str(), 1);
 
 #endif
 


### PR DESCRIPTION
See core.git commit abb6c01519a0318d7165dc9dc5b7d185353f93d6 (replace
usage of whitelist with allowlist, 2020-07-06).

Change-Id: I04646c63df4de14b9aa7dca02a4d5cec10e5eb67
