### PR TITLE
Make AutoSpellChecking option state remembered on first start

### DIFF
--- a/common/Session.cpp
+++ b/common/Session.cpp
@@ -187,6 +187,11 @@ void Session::parseDocOptions(const StringVector& tokens, int& part, std::string
             _deviceFormFactor = value;
             ++offset;
         }
+        else if (name == "spellOnline")
+        {
+            _spellOnline = value;
+            ++offset;
+        }
     }
 
     Util::mapAnonymized(_userId, _userIdAnonym);

--- a/common/Session.hpp
+++ b/common/Session.hpp
@@ -213,6 +213,8 @@ public:
 
     const std::string& getDeviceFormFactor() const { return _deviceFormFactor; }
 
+    const std::string& getSpellOnline() const { return _spellOnline; }
+
 protected:
     Session(const std::shared_ptr<ProtocolHandlerInterface> &handler,
             const std::string& name, const std::string& id, bool readonly);
@@ -310,6 +312,9 @@ private:
 
     /// The form factor of the device where the client is running: desktop, tablet, mobile.
     std::string _deviceFormFactor;
+
+    /// The start value of Auto Spell Checking wheter it is enabled or disabled on start.
+    std::string _spellOnline;
 };
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/loleaflet/js/global.js
+++ b/loleaflet/js/global.js
@@ -786,7 +786,10 @@
 				if (window.deviceFormFactor) {
 					msg += ' deviceFormFactor=' + window.deviceFormFactor;
 				}
-
+				if (window.isLocalStorageAllowed) {
+					var spellOnline = window.localStorage.getItem('SpellOnline');
+					msg += ' spellOnline=' +  spellOnline;
+				}
 				global.socket.send(msg);
 			}
 		};

--- a/loleaflet/src/control/Toolbar.js
+++ b/loleaflet/src/control/Toolbar.js
@@ -177,6 +177,18 @@ L.Map.include({
 				break;
 			}
 		}
+		if (command.startsWith('.uno:SpellOnline')) {
+			var map = this;
+			var val = map['stateChangeHandler'].getItemValue('.uno:SpellOnline');
+
+			// proceed if the toggle button is pressed
+			if (val && (json === undefined || json === null)) {
+				 // because it is toggle, state has to be the opposite
+				var state = !(val === 'true');
+				if (window.isLocalStorageAllowed)
+					window.localStorage.setItem('SpellOnline', state);
+			}
+		}
 
 		if (this.dialog.hasOpenedDialog())
 			this.dialog.blinkOpenDialog();

--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -201,6 +201,10 @@ L.Socket = L.Class.extend({
 			};
 			msg += ' options=' + JSON.stringify(options);
 		}
+		if (window.isLocalStorageAllowed) {
+			var spellOnline = window.localStorage.getItem('SpellOnline');
+			msg += ' spellOnline=' +  spellOnline;
+		}
 
 		this._doSend(msg);
 		for (var i = 0; i < this._msgQueue.length; i++) {

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -825,6 +825,11 @@ bool ClientSession::loadDocument(const char* /*buffer*/, int /*length*/,
             oss << " deviceFormFactor=" << getDeviceFormFactor();
         }
 
+        if (!getSpellOnline().empty())
+        {
+            oss << " spellOnline=" << getSpellOnline();
+        }
+
         if (!getWatermarkText().empty())
         {
             std::string encodedWatermarkText;


### PR DESCRIPTION
Change-Id: I25823025e35ba6f580b03834979fb0bea616bcc1
Signed-off-by: mert <mert.tumer@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

