### PR TITLE
Add handling of a "DEBUG" message that is just printed to stderr

### DIFF
--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -336,6 +336,12 @@ bool ClientSession::_handleInput(const char *buffer, int length)
         return false;
     }
 
+    if (tokens.equals(0, "DEBUG"))
+    {
+        std::cerr << std::string(buffer, length).substr(strlen("DEBUG") + 1) << std::endl;
+        return false;
+    }
+
     LOOLWSD::dumpIncomingTrace(docBroker->getJailId(), getId(), firstLine);
 
     if (LOOLProtocol::tokenIndicatesUserInteraction(tokens[0]))

--- a/wsd/protocol.txt
+++ b/wsd/protocol.txt
@@ -39,6 +39,11 @@ it as a final error (that requires reloading to retry).
 client -> server
 ================
 
+DEBUG <rest of message>
+
+    The rest of the message (without the DEBUG keyword), possibly
+    multiple lines, is printed to the server's stderr.
+
 canceltiles
 
     All outstanding tile messages from the client to the server are


### PR DESCRIPTION
Useful in situations where you can't get at console.log() output from
the JavaScript, like when you are using the Nextcloud iOS app
installed from the App Store and want to debug the loleaflet offered
by a Collabora Online server you are using. You can add code like

    this._map._socket.sendMessage('DEBUG Foo bar=' + bar);

temporarily to the JavaScript and will see those then in the terminal
where you run 'make run.'

Change-Id: I04c78d86faa283e135dbcb86dac0cabd7b6a0724


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

