### PR TITLE
leaflet: prevent comment textbox losing focus

### DIFF
--- a/loleaflet/src/layer/AnnotationManagerImpress.js
+++ b/loleaflet/src/layer/AnnotationManagerImpress.js
@@ -150,7 +150,6 @@ L.AnnotationManagerImpress = L.AnnotationManagerBase.extend({
 	},
 	onAnnotationClick: function (event) {
 		this._selectedForPopup = event.annotation;
-		this._map.focus();
 		this.layoutAnnotations();
 	},
 	onAnnotationSave: function (event) {


### PR DESCRIPTION

Change-Id: I351144c50818c48c7b6a4f88c9f5e6c68a1ab45c

* Target version: master 

### Summary
When clicked on the comment textbox it used to lose the focus making it impossible to type anything 



### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

