### PR TITLE
leaflet: stop changing mouse cursor when new view opened

### DIFF
--- a/loleaflet/src/layer/marker/Cursor.js
+++ b/loleaflet/src/layer/marker/Cursor.js
@@ -23,10 +23,12 @@ L.Cursor = L.Layer.extend({
 		if (!this._container) {
 			this._initLayout();
 		}
-		if (this._map._docLayer._docType === 'presentation') {
-			$('.leaflet-interactive').css('cursor', 'text');
-		} else {
-			$('.leaflet-pane.leaflet-map-pane').css('cursor', 'text');
+		if (this._container.querySelector('.blinking-cursor') !== null) {
+			if (this._map._docLayer._docType === 'presentation') {
+				$('.leaflet-interactive').css('cursor', 'text');
+			} else {
+				$('.leaflet-pane.leaflet-map-pane').css('cursor', 'text');
+			}
 		}
 		this._zoomAnimated = this._zoomAnimated && this.options.zoomAnimation;
 		if (this._zoomAnimated) {


### PR DESCRIPTION
Change-Id: I33db0dbff4bd6229615d75892c7d1c23c9f39e7c

* Target version: master 

### Summary
Problem:
Open a spreadsheet in two views at the same time
In the view opened the first, mouse pointer changes to caret placement icon.


### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

