### PR TITLE
Replaces Poco::DateTimeFormatter to Util::getHttpTimeNow #207

### DIFF
--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -416,8 +416,7 @@ void FileServerRequestHandler::handleRequest(const HTTPRequest& request,
                     Poco::DateTime now;
                     Poco::DateTime later(now.utcTime(), int64_t(1000)*1000 * 60 * 60 * 24 * 128);
                     oss << "HTTP/1.1 304 Not Modified\r\n"
-                        "Date: " << Poco::DateTimeFormatter::format(
-                            now, Poco::DateTimeFormat::HTTP_FORMAT) << "\r\n"
+                        "Date: " << Util::getHttpTimeNow() << "\r\n"
                         "Expires: " << Poco::DateTimeFormatter::format(
                             later, Poco::DateTimeFormat::HTTP_FORMAT) << "\r\n"
                         "User-Agent: " WOPI_AGENT_STRING "\r\n"

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -2466,7 +2466,7 @@ private:
                     std::ostringstream oss;
                     oss << "HTTP/1.1 401 \r\n"
                         << "Content-Type: text/html charset=UTF-8\r\n"
-                        << "Date: " << Poco::DateTimeFormatter::format(Poco::Timestamp(), Poco::DateTimeFormat::HTTP_FORMAT) << "\r\n"
+                        << "Date: " << Util::getHttpTimeNow() << "\r\n"
                         << "User-Agent: " << WOPI_AGENT_STRING << "\r\n"
                         << "WWW-authenticate: Basic realm=\"online\"\r\n"
                         << "\r\n";


### PR DESCRIPTION
Change-Id: I49b8d4b2acb0d4bcc719325a28537d45700bebdc


* Resolves: #207 
* Target version: master 

### Summary
There are two changes in wsd/FileServer.cpp and  wsd/LOOLWSD.cpp. I only changed Poco::DateTimeFormatter to Util::getHttpTimeNow.

### TODO

- [ ] ...

### Checklist

- [ X] Code is properly formatted
- [x] All commits have Change-Id
- [ X] I have run tests with `make check`
- [ X] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

