### PR TITLE
Issues: Add links to forum and customer portal

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+blank_issues_enabled: false
+contact_links:
+    - name: Question
+      url: https://forum.collaboraonline.com/
+      about: Ask your questions, find the answer, on our forum …
+    - name: Customer or partner issue
+      url: https://www.collaboraoffice.com/partner-client-portal/
+      about: If you are a Collabora Online customer or partner, please submit your issue directly in the Customer and Partner portal so that our engineers can act on it more quickly.
+


### PR DESCRIPTION
Change-Id: I15fe1eab1d3cf9b517164167ba353a80a4471261


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
Seems like it would be nice to have some links with explanations on the issue creation page, to avoid confusion among the reporters, and point them to the right direction. (See #336)

This is how it would look like (the 2 items at the bottom will be added):

![forum-and-portal-links](https://user-images.githubusercontent.com/9937631/96386424-9dd11980-11a3-11eb-8387-fd0361e41de3.png)


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

