### PR TITLE
disable no-control-regex check of eslint

### DIFF
--- a/loleaflet/.eslintrc
+++ b/loleaflet/.eslintrc
@@ -17,6 +17,7 @@
     "key-spacing": 0,
     "no-shadow": 0,
     "no-console": 0,
+    "no-control-regex": 0,
     "semi": 2
   },
   "globals": {


### PR DESCRIPTION
We do want control characters in regex in loleaflet/src/map/Clipboard.js

Change-Id: I4e393cd57afc42cbb30e8c63f2a497519942411a

* Target version: distro/collabora/co-4-2 



### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

