### PR TITLE
Add missing tooltip for clear direct formatting icon

### DIFF
--- a/loleaflet/src/control/Control.JSDialogBuilder.js
+++ b/loleaflet/src/control/Control.JSDialogBuilder.js
@@ -1890,6 +1890,9 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			titleClass = 'menu-entry-with-icon';
 		}
 
+		sectionTitle.title = data.text;
+		$(sectionTitle).tooltip();
+
 		var updateFunction = function() {
 			var items = builder.map['stateChangeHandler'];
 			var state = items.getItemValue(data.command);


### PR DESCRIPTION
Change-Id: I20a30e7a37f98cd35d5dfb5086fa7617e433314f


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

