### PR TITLE
Don't show jsdialog tooltips in the Android app, either

### DIFF
--- a/loleaflet/src/control/Control.JSDialogBuilder.js
+++ b/loleaflet/src/control/Control.JSDialogBuilder.js
@@ -1590,7 +1590,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			image.id = data.id;
 			image.alt = data.text;
 			image.title = data.text;
-			if (!window.ThisIsTheiOSApp)
+			if (!window.ThisIsAMobileApp)
 				$(image).tooltip();
 
 			if (data.loading && data.loading === 'true') {
@@ -1679,7 +1679,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 				$(div).addClass('has-label');
 			} else {
 				div.title = data.text;
-				if (!window.ThisIsTheiOSApp)
+				if (!window.ThisIsAMobileApp)
 					$(div).tooltip();
 				$(div).addClass('no-label');
 			}
@@ -1893,7 +1893,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		}
 
 		sectionTitle.title = data.text;
-		if (!window.ThisIsTheiOSApp)
+		if (!window.ThisIsAMobileApp)
 			$(sectionTitle).tooltip();
 
 		var updateFunction = function() {


### PR DESCRIPTION
Change-Id: I4cf0434a1a1f8c6f8ab8e963f2c0881d0df2f173


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

