### PR TITLE
loleaflet: Bump eslint version to 5.0.0

### DIFF
--- a/loleaflet/package.json
+++ b/loleaflet/package.json
@@ -8,7 +8,7 @@
     "browserify": "16.5.1",
     "browserify-css": "0.15.0",
     "d3": "5.16.0",
-    "eslint": "4.18.2",
+    "eslint": "5.0.0",
     "hammerjs": "2.0.8",
     "jquery": "3.5.1",
     "jquery-contextmenu": "2.9.2",


### PR DESCRIPTION
* Resolves: #369 
* Target version: master 

### Summary
Bump eslint version to 5.0.0 in loleaflet.

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] Documentation (manuals or wiki) has been updated or is not required

