### PR TITLE
Support for templates with nocaps

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -466,12 +466,6 @@ bool ChildSession::_handleInput(const char *buffer, int length)
 
 #if !MOBILEAPP
 
-// add to common / tools
-size_t getFileSize(const std::string& filename)
-{
-    return std::ifstream(filename, std::ifstream::ate | std::ifstream::binary).tellg();
-}
-
 std::string getMimeFromFileType(const std::string & fileType)
 {
     if (fileType == "pdf")
@@ -554,7 +548,9 @@ bool ChildSession::uploadSignedDocument(const char* buffer, int length, const St
 
         request.set("X-WOPI-Override", "PUT");
 
-        const size_t filesize = getFileSize(url);
+        // If we can't access the file, reading it will throw.
+        const FileUtil::Stat fileStat(url);
+        const std::size_t filesize = (fileStat.good() ? fileStat.size() : 0);
 
         request.setContentType(mimetype);
         request.setContentLength(filesize);
@@ -1915,7 +1911,9 @@ bool ChildSession::exportSignAndUploadDocument(const char* buffer, int length, c
 
         request.set("X-WOPI-Override", "PUT");
 
-        const size_t filesize = getFileSize(aTempDocumentURL);
+        // If we can't access the file, reading it will throw.
+        const FileUtil::Stat fileStat(aTempDocumentURL);
+        const std::size_t filesize = (fileStat.good() ? fileStat.size() : 0);
 
         request.setContentType(mimetype);
         request.setContentLength(filesize);

--- a/kit/ChildSession.hpp
+++ b/kit/ChildSession.hpp
@@ -200,6 +200,7 @@ public:
         const std::shared_ptr<ProtocolHandlerInterface> &protocol,
         const std::string& id,
         const std::string& jailId,
+        const std::string& jailRoot,
         DocumentManagerInterface& docManager);
     virtual ~ChildSession();
 
@@ -322,6 +323,7 @@ public:
 
 private:
     const std::string _jailId;
+    const std::string _jailRoot;
     DocumentManagerInterface* _docManager;
 
     std::queue<std::chrono::steady_clock::time_point> _cursorInvalidatedEvent;

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1468,8 +1468,14 @@ bool ClientSession::handleKitToClientMessage(const char* buffer, const int lengt
             // Wopi post load actions
             if (_wopiFileInfo && !_wopiFileInfo->getTemplateSource().empty())
             {
-                std::string result;
+                // When creating new documents from templates, a reproducible race-condition
+                // in at least one host results in 'file locked' error when saving the document
+                // within a short time from creating it. To avoid this, a small delay seems to
+                // be sufficient to allow enough time for the creation lock to be released.
+                // FIXM: remove when said race-condition is reliably fixed in the affected hosts.
+                sleep(2);
                 LOG_DBG("Saving template [" << _wopiFileInfo->getTemplateSource() << "] to storage");
+                std::string result;
                 docBroker->saveToStorage(getId(), true, result, /*force=*/false);
             }
 

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -1054,14 +1054,13 @@ void LOOLWSD::initialize(Application& self)
     // Setup the logfile envar for the kit processes.
     if (logToFile)
     {
-        setenv("LOOL_LOGFILE", "1", true);
         const auto it = logProperties.find("path");
         if (it != logProperties.end())
         {
+            setenv("LOOL_LOGFILE", "1", true);
             setenv("LOOL_LOGFILENAME", it->second.c_str(), true);
-#if ENABLE_DEBUG
-            std::cerr << "\nFull log is available in: " << it->second.c_str() << std::endl;
-#endif
+            std::cerr << "\nLogging at " << LogLevel << " level to file: " << it->second.c_str()
+                      << std::endl;
         }
     }
 
@@ -1069,7 +1068,8 @@ void LOOLWSD::initialize(Application& self)
     Log::initialize("wsd", "trace", withColor, logToFile, logProperties);
     if (LogLevel != "trace")
     {
-        LOG_INF("Setting log-level to [trace] and delaying setting to configured [" << LogLevel << "] until after WSD initialization.");
+        LOG_INF("Setting log-level to [trace] and delaying setting to configured ["
+                << LogLevel << "] until after WSD initialization.");
     }
 
     ServerName = config().getString("server_name");

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -1118,9 +1118,9 @@ WopiStorage::saveLocalFileToStorage(const Authorization& auth, const std::string
                 }
             }
 
-            LOG_INF(wopiLog << " response: " << responseString);
-            LOG_INF(wopiLog << " uploaded " << size << " bytes from [" << filePathAnonym <<
-                    "] -> [" << uriAnonym << "]: " << response.getStatus() << ' ' << response.getReason());
+            LOG_INF(wopiLog << " uploaded " << size << " bytes from [" << filePathAnonym << "] -> ["
+                            << uriAnonym << "]: " << response.getStatus() << ' '
+                            << response.getReason() << ": " << responseString);
         }
 
         if (response.getStatus() == Poco::Net::HTTPResponse::HTTP_OK)
@@ -1181,8 +1181,10 @@ WopiStorage::saveLocalFileToStorage(const Authorization& auth, const std::string
         else
         {
             // Internal server error, and other failures.
-            LOG_ERR("Unexpected response to " << wopiLog << " : " << response.getStatus() <<
-                    "Cannot save file to WOPI storage uri [" << uriAnonym << "]. Error: ");
+            LOG_ERR("Unexpected response to "
+                    << wopiLog << ". Cannot upload file to WOPI storage uri [" << uriAnonym
+                    << "]: " << response.getStatus() << ' ' << response.getReason() << ": "
+                    << responseString);
             saveResult.setResult(StorageBase::SaveResult::FAILED);
         }
     }

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -256,8 +256,6 @@ public:
                            const std::string& saveAsFilename, const bool isRename)
         = 0;
 
-    static size_t getFileSize(const std::string& filename);
-
     /// Must be called at startup to configure.
     static void initialize();
 


### PR DESCRIPTION
* Target version: master 

### Summary

When nocaps is enabled, templated documents are saved to disk from the Kit, and they must know the correct path of the jail.

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

