### PR TITLE
mobile calc: Fix the row / colum headers to match the grid.

### DIFF
--- a/loleaflet/src/layer/tile/CalcTileLayer.js
+++ b/loleaflet/src/layer/tile/CalcTileLayer.js
@@ -478,7 +478,7 @@ L.CalcTileLayer = BaseTileLayer.extend({
 		this._sendClientZoom();
 		if (this.sheetGeometry) {
 			this.sheetGeometry.setTileGeometryData(this._tileWidthTwips, this._tileHeightTwips,
-				this._tileSize, this.hasCanvasRenderer() ? this.canvasDPIScale() : this._tilePixelScale);
+				this._tileSize, window.mode.useCanvasLayer() ? this.canvasDPIScale() : this._tilePixelScale);
 		}
 		this._restrictDocumentSize();
 		this._replayPrintTwipsMsgs();
@@ -744,7 +744,7 @@ L.CalcTileLayer = BaseTileLayer.extend({
 	_handleSheetGeometryDataMsg: function (jsonMsgObj) {
 		if (!this.sheetGeometry) {
 			this._sheetGeomFirstWait = false;
-			var dpiScale = this.hasCanvasRenderer() ? this.canvasDPIScale() : this._tilePixelScale;
+			var dpiScale = window.mode.useCanvasLayer() ? this.canvasDPIScale() : this._tilePixelScale;
 			this.sheetGeometry = new L.SheetGeometry(jsonMsgObj,
 				this._tileWidthTwips, this._tileHeightTwips,
 				this._tileSize, dpiScale, this._selectedPart);
@@ -1623,7 +1623,10 @@ L.SheetDimension = L.Class.extend({
 		this._coreZoomFactor = this._tileSizePixels * 15.0 / this._tileSizeTwips;
 		this._twipsPerCorePixel = this._tileSizeTwips / this._tileSizePixels;
 
-		this._corePixelsPerCssPixel = this._dpiScale;
+		if (window.mode.useCanvasLayer())
+			this._corePixelsPerCssPixel = this._dpiScale;
+		else
+			this._corePixelsPerCssPixel = 1;
 
 		if (updatePositions) {
 			// We need to compute positions data for every zoom change.

--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -1439,10 +1439,6 @@ L.CanvasTileLayer = L.TileLayer.extend({
 		return !!(this._ySplitter);
 	},
 
-	hasCanvasRenderer: function () {
-		return true;
-	},
-
 });
 
 L.TilesPreFetcher = L.Class.extend({

--- a/loleaflet/src/layer/tile/GridLayer.js
+++ b/loleaflet/src/layer/tile/GridLayer.js
@@ -1352,10 +1352,6 @@ L.GridLayer = L.Layer.extend({
 		return docPosPixY;
 	},
 
-	hasCanvasRenderer: function () {
-		return false;
-	},
-
 	hasSplitPanesSupport: function () {
 		return false;
 	},


### PR DESCRIPTION
When we are not using the CanvasTileLayer, we still have to have a
different CSS pixel size (ie. default the _corePixelsPerCssPixel to 1).

The rest (update of the check whether we are using the canvas) is just
cosmetics.

Change-Id: Ie0e7002ac776ab6b0a7c550cf28473f41c5c5e77
