### PR TITLE
private/kendy/calc pixel here pixel there

### DIFF
--- a/loleaflet/css/device-mobile.css
+++ b/loleaflet/css/device-mobile.css
@@ -213,9 +213,6 @@ div#w2ui-overlay-actionbar.w2ui-overlay{
 	#spreadsheet-row-column-frame.readonly {
 		top: 36px !important;
 	}
-	#document-container.spreadsheet-document.readonly {
-		top: 56px !important;
-	}
 	#spreadsheet-row-column-frame {
 		top: 75px !important
 	}
@@ -630,9 +627,6 @@ td[id^='tb_spreadsheet-toolbar_item']:focus table.w2ui-button div.w2ui-icon, td[
 	bottom: 68px;
 }
 
-#document-container.spreadsheet-document.readonly {
-	top: 57px !important;
-}
 #spreadsheet-row-column-frame.readonly {
 	top: 41px !important;
 	bottom: 35px !important;

--- a/loleaflet/css/device-mobile.css
+++ b/loleaflet/css/device-mobile.css
@@ -602,7 +602,7 @@ td[id^='tb_spreadsheet-toolbar_item']:focus table.w2ui-button div.w2ui-icon, td[
 
 #document-container.readonly.spreadsheet-document {
 	top: 61px !important;
-	bottom: 42px;
+	bottom: 39px;
 }
 
 #document-container.parts-preview-document {

--- a/loleaflet/css/device-mobile.css
+++ b/loleaflet/css/device-mobile.css
@@ -601,7 +601,7 @@ td[id^='tb_spreadsheet-toolbar_item']:focus table.w2ui-button div.w2ui-icon, td[
 }
 
 #document-container.readonly.spreadsheet-document {
-	top: 61px !important;
+	top: 58px !important;
 	bottom: 39px;
 }
 
@@ -628,7 +628,7 @@ td[id^='tb_spreadsheet-toolbar_item']:focus table.w2ui-button div.w2ui-icon, td[
 }
 
 #spreadsheet-row-column-frame.readonly {
-	top: 41px !important;
+	top: 38px !important;
 	bottom: 35px !important;
 }
 

--- a/loleaflet/css/spreadsheet.css
+++ b/loleaflet/css/spreadsheet.css
@@ -1,7 +1,7 @@
 #document-container.spreadsheet-document {
 	border-top: 1px solid #B6B6B6;
 	top: 137px;
-	left: 50px;
+	left: 49px;
 	bottom: 75px;
 }
 


### PR DESCRIPTION
- mobile: The calc grid was not aligned with the row headers on mobile.
- mobile: spreadsheet-header-rows-container's with is 48...
- mobile: The last few pixels at the bottom of the sheet weren't moving.
- mobile: Fix the gap between the toolbar and the actual document.
