### PR TITLE
Simplify another Util::getHttpTimeNow() in headers

### DIFF
--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -2475,7 +2475,7 @@ private:
                     return;
                 }
 
-                response->add("Last-Modified", Poco::DateTimeFormatter::format(Poco::Timestamp(), Poco::DateTimeFormat::HTTP_FORMAT));
+                response->add("Last-Modified", Util::getHttpTimeNow());
                 // Ask UAs to block if they detect any XSS attempt
                 response->add("X-XSS-Protection", "1; mode=block");
                 // No referrer-policy


### PR DESCRIPTION
Change-Id: Ib2718e1dbcff20cd3fa1e6463287ca512f39efc8


* Resolves: #207 (partially; reopen after!)
* Target version: master 

### Summary

I found another place where `Util::getHttpTimeNow()`  would be useful. I am also thinking whether something like `later` couldn't be simplified as well (for instance here: https://github.com/CollaboraOnline/online/blob/29251ef432b0cd531b408c8658aafa590510c47b/wsd/FileServer.cpp#L421)

(also, this is my first pull request to COOL -which is cool- so please advise if you think that this change does not make sense...)


### TODO

- [ ] reopen #207 after merging, because the actual issue has not yet been resolved. Will comment there...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

