### PR TITLE
Fix #207: Provide a generic sendError method that sends error output (headers + optional body)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -102,6 +102,7 @@ shared_sources = common/FileUtil.cpp \
                  common/Util.cpp \
                  common/Authorization.cpp \
                  net/DelaySocket.cpp \
+                 net/HttpHelper.cpp \
                  net/Socket.cpp
 if ENABLE_SSL
 shared_sources += net/Ssl.cpp
@@ -263,6 +264,7 @@ shared_headers = common/Common.hpp \
                  common/SpookyV2.h \
                  net/DelaySocket.hpp \
                  net/FakeSocket.hpp \
+                 net/HttpHelper.hpp \
                  net/ServerSocket.hpp \
                  net/Socket.hpp \
                  net/WebSocketHandler.hpp \

--- a/net/HttpHelper.cpp
+++ b/net/HttpHelper.cpp
@@ -1,0 +1,41 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <config.h>
+
+#include "HttpHelper.hpp"
+
+#include <Poco/MemoryStream.h>
+#include <Poco/Net/HTTPRequest.h>
+#include <Poco/Net/HTTPResponse.h>
+#include <common/Common.hpp>
+#include <common/Util.hpp>
+#include <net/Socket.hpp>
+
+namespace HttpHelper
+{
+void sendError(int errorCode, const std::shared_ptr<StreamSocket>& socket, const std::string& body,
+               const std::string& extraHeader)
+{
+    std::ostringstream oss;
+    oss << "HTTP/1.1 " << errorCode << "\r\n"
+        << "Date: " << Util::getHttpTimeNow() << "\r\n"
+        << "User-Agent: " << WOPI_AGENT_STRING << "\r\n"
+        << "Content-Length: " << body.size() << "\r\n"
+        << extraHeader << "\r\n"
+        << body;
+    socket->send(oss.str());
+}
+
+void sendErrorAndShutdown(int errorCode, const std::shared_ptr<StreamSocket>& socket,
+                          const std::string& body, const std::string& extraHeader)
+{
+    sendError(errorCode, socket, body, extraHeader);
+    socket->shutdown();
+}
+} // namespace HttpHelper
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/net/HttpHelper.hpp
+++ b/net/HttpHelper.hpp
@@ -1,0 +1,26 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include "Socket.hpp"
+
+namespace HttpHelper
+{
+/// Write headers and body for an error response.
+void sendError(int errorCode, const std::shared_ptr<StreamSocket>& socket,
+               const std::string& body = std::string(),
+               const std::string& extraHeader = std::string());
+
+/// Write headers and body for an error response. Afterwards, shutdown the socket.
+void sendErrorAndShutdown(int errorCode, const std::shared_ptr<StreamSocket>& socket,
+                          const std::string& body = std::string(),
+                          const std::string& extraHeader = std::string());
+
+} // namespace HttpHelper
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/tools/WebSocketDump.cpp
+++ b/tools/WebSocketDump.cpp
@@ -22,6 +22,9 @@
 #include <Protocol.hpp>
 #include <ServerSocket.hpp>
 #include <WebSocketHandler.hpp>
+#if !MOBILEAPP
+#include <net/HttpHelper.hpp>
+#endif
 #if ENABLE_SSL
 #  include <SslSocket.hpp>
 #endif
@@ -160,14 +163,7 @@ private:
         catch (const std::exception& exc)
         {
             // Bad request.
-            std::ostringstream oss;
-            oss << "HTTP/1.1 400\r\n"
-                << "Date: " << Util::getHttpTimeNow() << "\r\n"
-                << "User-Agent: LOOLWSD WOPI Agent\r\n"
-                << "Content-Length: 0\r\n"
-                << "\r\n";
-            socket->send(oss.str());
-            socket->shutdown();
+            HttpHelper::sendErrorAndShutdown(400, socket);
 
             // NOTE: Check _wsState to choose between HTTP response or WebSocket (app-level) error.
             LOG_INF('#' << socket->getFD() << " Exception while processing incoming request: [" <<

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -28,7 +28,9 @@
 #include <common/Session.hpp>
 #include <common/Unit.hpp>
 #include <common/Util.hpp>
-
+#if !MOBILEAPP
+#include <net/HttpHelper.hpp>
+#endif
 using namespace LOOLProtocol;
 
 using Poco::Path;
@@ -259,14 +261,9 @@ void ClientSession::handleClipboardRequest(DocumentBroker::ClipboardRequest     
             return; // the getclipboard already completed.
         if (type == DocumentBroker::CLIP_REQUEST_SET)
         {
-            std::ostringstream oss;
-            oss << "HTTP/1.1 400 Bad Request\r\n"
-                << "Date: " << Util::getHttpTimeNow() << "\r\n"
-                << "User-Agent: " << WOPI_AGENT_STRING << "\r\n"
-                << "Content-Length: 0\r\n"
-                << "\r\n";
-            socket->send(oss.str());
-            socket->shutdown();
+            #if !MOBILEAPP
+            HttpHelper::sendErrorAndShutdown(400, socket);
+            #endif
         }
         else // will be handled during shutdown
         {
@@ -305,14 +302,9 @@ void ClientSession::handleClipboardRequest(DocumentBroker::ClipboardRequest     
         }
         else
         {
-            std::ostringstream oss;
-            oss << "HTTP/1.1 400 Bad Request\r\n"
-                << "Date: " << Util::getHttpTimeNow() << "\r\n"
-                << "User-Agent: " << WOPI_AGENT_STRING << "\r\n"
-                << "Content-Length: 0\r\n"
-                << "\r\n";
-            socket->send(oss.str());
-            socket->shutdown();
+            #if !MOBILEAPP
+            HttpHelper::sendErrorAndShutdown(400, socket);
+            #endif
         }
     }
 }

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -37,7 +37,9 @@
 #include <common/Protocol.hpp>
 #include <common/Unit.hpp>
 #include <common/FileUtil.hpp>
-
+#if !MOBILEAPP
+#include <net/HttpHelper.hpp>
+#endif
 #include <sys/types.h>
 #include <sys/wait.h>
 
@@ -1917,14 +1919,7 @@ bool DocumentBroker::lookupSendClipboardTag(const std::shared_ptr<StreamSocket> 
 
 #if !MOBILEAPP
     // Bad request.
-    std::ostringstream oss;
-    oss << "HTTP/1.1 400\r\n"
-        << "Date: " << Util::getHttpTimeNow() << "\r\n"
-        << "User-Agent: LOOLWSD WOPI Agent\r\n"
-        << "Content-Length: 0\r\n"
-        << "\r\n"
-        << "Failed to find this clipboard";
-    socket->send(oss.str());
+    HttpHelper::sendError(400, socket, "Failed to find this clipboard");
 #endif
     socket->shutdown();
 

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -45,8 +45,9 @@
 #include <Log.hpp>
 #include <Protocol.hpp>
 #include <Util.hpp>
+#if !MOBILEAPP
 #include <net/HttpHelper.hpp>
-
+#endif
 using Poco::Net::HTMLForm;
 using Poco::Net::HTTPBasicCredentials;
 using Poco::Net::HTTPRequest;
@@ -416,15 +417,11 @@ void FileServerRequestHandler::handleRequest(const HTTPRequest& request,
                     std::ostringstream oss;
                     Poco::DateTime now;
                     Poco::DateTime later(now.utcTime(), int64_t(1000)*1000 * 60 * 60 * 24 * 128);
-                    oss << "HTTP/1.1 304 Not Modified\r\n"
-                        "Date: " << Util::getHttpTimeNow() << "\r\n"
-                        "Expires: " << Poco::DateTimeFormatter::format(
-                            later, Poco::DateTimeFormat::HTTP_FORMAT) << "\r\n"
-                        "User-Agent: " WOPI_AGENT_STRING "\r\n"
-                        "Cache-Control: max-age=11059200\r\n"
-                        "\r\n";
-                    socket->send(oss.str());
-                    socket->shutdown();
+                    std::string extraHeaders =
+                        "Expires: " + Poco::DateTimeFormatter::format(
+                            later, Poco::DateTimeFormat::HTTP_FORMAT) + "\r\n" +
+                        "Cache-Control: max-age=11059200\r\n";
+                    HttpHelper::sendErrorAndShutdown(304, socket, std::string(), extraHeaders);
                     return;
                 }
             }


### PR DESCRIPTION
* Resolves: #207
* Target version: master 

### Summary

As a WIP prototype, declare a generic `sendError()` method sends error message headers into the active socket. Optionally, a body can be added and the socket can be closed.

This changeset illustrates my thoughts from https://github.com/CollaboraOnline/online/issues/207#issuecomment-715981040 , but for me this does not compile. `make` says `error: ‘Util’ has not been declared` :(

### TODO

- [x] Fix the `error: ‘Util’ has not been declared` error
- [x] Perhaps move the method into a more speaking namespace

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

