### PR TITLE
Remove Poco/TimeStamp.h left-over

### DIFF
--- a/common/Log.cpp
+++ b/common/Log.cpp
@@ -24,12 +24,10 @@
 
 #include <Poco/AutoPtr.h>
 #include <Poco/ConsoleChannel.h>
-#include <Poco/DateTimeFormatter.h>
 #include <Poco/FileChannel.h>
 #include <Poco/FormattingChannel.h>
 #include <Poco/PatternFormatter.h>
 #include <Poco/SplitterChannel.h>
-#include <Poco/Timestamp.h>
 
 #include "Log.hpp"
 #include "Util.hpp"

--- a/common/Util.cpp
+++ b/common/Util.cpp
@@ -53,7 +53,6 @@
 #include <Poco/JSON/Parser.h>
 #include <Poco/RandomStream.h>
 #include <Poco/TemporaryFile.h>
-#include <Poco/Timestamp.h>
 #include <Poco/Util/Application.h>
 
 #include "Common.hpp"


### PR DESCRIPTION
Change-Id: I78f76266a50f799306dcfd8ec996db54784acfd8


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

