### PR TITLE
leaflet: fixed DOM leaking on annotation remove in mobile

### DIFF
--- a/cypress_test/integration_tests/mobile/writer/annotation_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/annotation_spec.js
@@ -96,10 +96,10 @@ describe('Annotation tests.', function() {
 		cy.get('.loleaflet-annotation')
 			.should('exist');
 
-		cy.get('.loleaflet-annotation:nth-of-type(2) .loleaflet-annotation-content')
+		cy.get('.loleaflet-annotation:nth-of-type(1) .loleaflet-annotation-content')
 			.should('have.text', 'some text');
 
-		cy.get('.loleaflet-annotation:nth-of-type(3) .loleaflet-annotation-content')
+		cy.get('.loleaflet-annotation:nth-of-type(2) .loleaflet-annotation-content')
 			.should('have.text', 'reply');
 	});
 
@@ -112,7 +112,8 @@ describe('Annotation tests.', function() {
 		mobileHelper.selectAnnotationMenuItem('Remove');
 
 		cy.get('.loleaflet-annotation-content')
-			.should('have.text', '');
+			.should('not.exist');
+
 	});
 
 	it('Try to insert empty comment.', function() {

--- a/cypress_test/integration_tests/mobile/writer/hamburger_menu_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/hamburger_menu_spec.js
@@ -726,21 +726,21 @@ describe('Trigger hamburger menu options.', function() {
 		cy.get('.vex-dialog-button-primary')
 			.click();
 
-		cy.get('.loleaflet-annotation:nth-of-type(2)')
+		cy.get('.loleaflet-annotation')
 			.should('have.attr', 'style')
 			.should('not.contain', 'visibility: hidden');
 
 		// Resolve comment
 		mobileHelper.selectAnnotationMenuItem('Resolve');
 
-		cy.get('.loleaflet-annotation:nth-of-type(2)')
+		cy.get('.loleaflet-annotation')
 			.should('have.attr', 'style')
 			.should('contain', 'visibility: hidden');
 
 		// Show resolved comments
 		mobileHelper.selectHamburgerMenuItem(['View', 'Resolved Comments']);
 
-		cy.get('.loleaflet-annotation:nth-of-type(2)')
+		cy.get('.loleaflet-annotation')
 			.should('have.attr', 'style')
 			.should('not.contain', 'visibility: hidden');
 

--- a/loleaflet/src/layer/tile/TileLayer.js
+++ b/loleaflet/src/layer/tile/TileLayer.js
@@ -438,6 +438,8 @@ L.TileLayer = L.GridLayer.extend({
 
 					// FIXME: Unify annotation code in all modules...
 					addCommentFn.call(that, {annotation: annotation}, comment);
+					if (!isMod)
+						that._map.removeLayer(annotation);
 				}
 			}
 		});


### PR DESCRIPTION
Change-Id: I53fc7d55154a601c52f89e35b9236f5ae66b46fd

* Target version: master 

### Summary
An extra annotation element was added but never removed
This was not a functional problem
But not a good practice and also made cypress hard to maintain

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

