### PR TITLE
DocumentBroker::saveToStorage: guard against nullptr _storage

### DIFF
--- a/fuzzer/data/crash-f6c825f2349dcb9b0cb3ed7c7695a4cb293ec2cf
+++ b/fuzzer/data/crash-f6c825f2349dcb9b0cb3ed7c7695a4cb293ec2cf
@@ -1,0 +1,3 @@
+load url=f·
+ savetostorage
+r

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -955,7 +955,7 @@ bool DocumentBroker::saveToStorage(const std::string& sessionId, bool success,
         }
     }
 
-    if (force)
+    if (force && _storage)
     {
         _storage->forceSave();
     }


### PR DESCRIPTION
This can happen on a 'savetostorage' which is after a failed load.

Change-Id: Iad26bf6415c772c8646a119b0454c202873d6860
