### PR TITLE
Remove Poco/TimeStamp.h left-over

### DIFF
--- a/test/UnitConvert.cpp
+++ b/test/UnitConvert.cpp
@@ -19,7 +19,6 @@
 #include <FileUtil.hpp>
 #include <helpers.hpp>
 
-#include <Poco/Timestamp.h>
 #include <Poco/Net/HTTPServerRequest.h>
 #include <Poco/Net/HTMLForm.h>
 #include <Poco/Net/StringPartSource.h>

--- a/test/UnitCopyPaste.cpp
+++ b/test/UnitCopyPaste.cpp
@@ -15,7 +15,6 @@
 #include <wsd/LOOLWSD.hpp>
 #include <common/Clipboard.hpp>
 #include <wsd/ClientSession.hpp>
-#include <Poco/Timestamp.h>
 #include <Poco/Net/HTTPResponse.h>
 #include <Poco/Net/HTTPServerRequest.h>
 #include <Poco/Net/HTMLForm.h>

--- a/test/UnitFuzz.cpp
+++ b/test/UnitFuzz.cpp
@@ -17,7 +17,6 @@
 #include <Unit.hpp>
 #include <Util.hpp>
 
-#include <Poco/Timestamp.h>
 #include <Poco/Net/HTTPServerRequest.h>
 
 // Inside the WSD process

--- a/test/UnitOOB.cpp
+++ b/test/UnitOOB.cpp
@@ -19,7 +19,6 @@
 #include <UnitHTTP.hpp>
 #include <Util.hpp>
 
-#include <Poco/Timestamp.h>
 #include <Poco/Net/HTTPServerRequest.h>
 
 class UnitOOB : public UnitWSD

--- a/test/UnitWOPIDocumentConflict.cpp
+++ b/test/UnitWOPIDocumentConflict.cpp
@@ -14,7 +14,6 @@
 #include "helpers.hpp"
 
 #include <Poco/Net/HTTPRequest.h>
-#include <Poco/Timestamp.h>
 
 /**
  * This test asserts that the unsaved changes in the opened document are

--- a/test/UnitWOPIVersionRestore.cpp
+++ b/test/UnitWOPIVersionRestore.cpp
@@ -14,7 +14,6 @@
 #include "helpers.hpp"
 
 #include <Poco/Net/HTTPRequest.h>
-#include <Poco/Timestamp.h>
 #include <Poco/Util/LayeredConfiguration.h>
 
 

--- a/wsd/Auth.cpp
+++ b/wsd/Auth.cpp
@@ -24,7 +24,6 @@
 #include <Poco/Net/HTTPRequest.h>
 #include <Poco/Net/HTTPResponse.h>
 #include <Poco/Net/NetException.h>
-#include <Poco/Timestamp.h>
 #include <Poco/URI.h>
 
 #include <Log.hpp>


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

