### PR TITLE
Allow to paste in w2ui controls

### DIFF
--- a/loleaflet/src/map/Clipboard.js
+++ b/loleaflet/src/map/Clipboard.js
@@ -709,6 +709,9 @@ L.Clipboard = L.Class.extend({
 	paste: function(ev) {
 		console.log('Paste');
 
+		if ($('.w2ui-input').is(':focus'))
+			return;
+
 		if (isAnyVexDialogActive() && !(this.pasteSpecialVex && this.pasteSpecialVex.isOpen))
 			return;
 


### PR DESCRIPTION
For example in hex value field in color picker.
Before this patch text was always pasted into document.

Change-Id: Ieb9366a6f71cb247e1592f69700796a06d3f8be9


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

