### PR TITLE
Preparatory work on the loleaflet side to open help file in mobile apps

### DIFF
--- a/loleaflet/src/control/Toolbar.js
+++ b/loleaflet/src/control/Toolbar.js
@@ -240,6 +240,10 @@ L.Map.include({
 		}
 		var map = this;
 		var helpLocation = 'loleaflet-help.html';
+		if (window.ThisIsAMobileApp) {
+			window.open(helpLocation);
+			return;
+		}
 		if (window.socketProxy)
 			helpLocation = window.host + window.serviceRoot + '/loleaflet/dist/' + helpLocation;
 


### PR DESCRIPTION
Does not fix https://github.com/CollaboraOnline/online/issues/400, but
is one step on the way there.

Additionally, for the iOS app, the handling of the HYPERLINK message
in -[DocumentViewController userContentController:didReceiveScriptMessage:]
in ios/Mobile/DocumentViewController.mm needs work for the case where
the "url" is just a file name. It needs to turn it into a file: URL,
and then open a pop-up WKWebView (or something) showing that document.
Just passing it on to -[UIApplication openURL:options:completionHandler:]
won't work, as Safari (which would be used to show such a URL)
obviously has no access to a HTML file in the Collabora Office app's
bundle.

Change-Id: Id436f7bd2849f765e24fd5ff9e647119afe0dd64
Signed-off-by: Tor Lillqvist <tml@collabora.com>
(cherry picked from commit 9a50f14bcb9829731c11bd018ce4f8c3f67ecfbd)


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

