### PR TITLE
Add logging when the WebContent process has died

### DIFF
--- a/ios/Mobile/DocumentViewController.mm
+++ b/ios/Mobile/DocumentViewController.mm
@@ -270,6 +270,10 @@ static IMP standardImpOfInputAccessoryView = nil;
     completionHandler(@"Something happened.");
 }
 
+- (void)webViewWebContentProcessDidTerminate:(WKWebView *)webView {
+    LOG_ERR("WebContent process terminated! What should we do?");
+}
+
 - (void)userContentController:(WKUserContentController *)userContentController didReceiveScriptMessage:(WKScriptMessage *)message {
     int rc;
     struct pollfd p;


### PR DESCRIPTION
See https://github.com/CollaboraOnline/online/issues/403

Change-Id: I59012565ac6376d03872fe6e4cd78a5d14be1319
Signed-off-by: Tor Lillqvist <tml@collabora.com>
(cherry picked from commit 3a4169a9ebebea56bcdc467691913cd767af878b)
Signed-off-by: Tor Lillqvist <tml@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

