### PR TITLE
Attempt to fix the "Copy Hyperlink Location" for desktop browsers

### DIFF
--- a/loleaflet/src/map/Clipboard.js
+++ b/loleaflet/src/map/Clipboard.js
@@ -665,7 +665,7 @@ L.Clipboard = L.Class.extend({
 			return true;
 		}
 
-		if (cmd === '.uno:Copy' || cmd === '.uno:CopyHyperlinkLocation') {
+		if (cmd === '.uno:Copy' || (L.Browser.mobile && L.Browser.safari && cmd === '.uno:CopyHyperlinkLocation')) {
 			this._execCopyCutPaste('copy', cmd);
 		} else if (cmd === '.uno:Cut') {
 			this._execCopyCutPaste('cut', cmd);


### PR DESCRIPTION
This undoes the plumbing change in
0752631deac1e427294ebec932be6624df220452 for desktop browsers.

Signed-off-by: Tor Lillqvist <tml@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

