### PR TITLE
Desktop: disable outline on non form elements (vex dialogs)

### DIFF
--- a/loleaflet/css/vex.css
+++ b/loleaflet/css/vex.css
@@ -44,6 +44,7 @@
 	border: 1px solid #a4a4a4;
 	box-shadow: 0 -1px 2px 0 rgba(0, 0, 0, 0.15), 0 2px 2px 0 rgba(0, 0, 0, 0.1);
 	border-radius: 4px;
+	outline: none;
 }
 
 .vex-closing {


### PR DESCRIPTION
Example: Keyboard Shortcuts dialog was getting an getting
an outline every-time it was being opened

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I2be8ffa7678a71ecd51ea7477e70ba2ea4baac36

