### PR TITLE
fix auto-hiding shelf can obscure the FAB on ChromeOS

### DIFF
--- a/android/app/src/main/java/org/libreoffice/androidapp/ui/LibreOfficeUIActivity.java
+++ b/android/app/src/main/java/org/libreoffice/androidapp/ui/LibreOfficeUIActivity.java
@@ -80,6 +80,7 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.app.AppCompatDelegate;
 import androidx.appcompat.widget.Toolbar;
+import androidx.constraintlayout.widget.ConstraintLayout;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 import androidx.core.view.ViewCompat;
@@ -398,6 +399,14 @@ public class LibreOfficeUIActivity extends AppCompatActivity implements Settings
     /** Initialize the FloatingActionButton. */
     private void setupFloatingActionButton() {
         editFAB = findViewById(R.id.editFAB);
+        if (LOActivity.isChromeOS(this)) {
+            int dp = (int)getResources().getDisplayMetrics().density;
+            ConstraintLayout.LayoutParams layoutParams = (ConstraintLayout.LayoutParams)editFAB.getLayoutParams();
+            layoutParams.leftToLeft = ConstraintLayout.LayoutParams.PARENT_ID;
+            layoutParams.bottomMargin = dp * 24;
+            editFAB.setCustomSize(dp * 70);
+        }
+
         editFAB.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {

--- a/android/app/src/main/java/org/libreoffice/androidapp/ui/LibreOfficeUIActivity.java
+++ b/android/app/src/main/java/org/libreoffice/androidapp/ui/LibreOfficeUIActivity.java
@@ -416,34 +416,43 @@ public class LibreOfficeUIActivity extends AppCompatActivity implements Settings
                     expandFabMenu();
             }
         });
+        final OnClickListener clickListener = new OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                switch (view.getId()) {
+                    case R.id.newWriterFAB:
+                    case R.id.writerLayout:
+                        createNewFileInputDialog(getString(R.string.new_textdocument) + FileUtilities.DEFAULT_WRITER_EXTENSION, "application/vnd.oasis.opendocument.text", CREATE_DOCUMENT_REQUEST_CODE);
+                        break;
+                    case R.id.newCalcFAB:
+                    case R.id.calcLayout:
+                        createNewFileInputDialog(getString(R.string.new_spreadsheet) + FileUtilities.DEFAULT_SPREADSHEET_EXTENSION, "application/vnd.oasis.opendocument.spreadsheet", CREATE_SPREADSHEET_REQUEST_CODE);
+                        break;
+                    case R.id.newImpressFAB:
+                    case R.id.impressLayout:
+                        createNewFileInputDialog(getString(R.string.new_presentation) + FileUtilities.DEFAULT_IMPRESS_EXTENSION, "application/vnd.oasis.opendocument.presentation", CREATE_PRESENTATION_REQUEST_CODE);
+                        break;
+                }
+            }
+        };
 
         writerFAB = findViewById(R.id.newWriterFAB);
-        writerFAB.setOnClickListener(new OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                createNewFileInputDialog(getString(R.string.new_textdocument) + FileUtilities.DEFAULT_WRITER_EXTENSION, "application/vnd.oasis.opendocument.text", CREATE_DOCUMENT_REQUEST_CODE);
-            }
-        });
+        writerFAB.setOnClickListener(clickListener);
 
         calcFAB = findViewById(R.id.newCalcFAB);
-        calcFAB.setOnClickListener(new OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                createNewFileInputDialog(getString(R.string.new_spreadsheet) + FileUtilities.DEFAULT_SPREADSHEET_EXTENSION, "application/vnd.oasis.opendocument.spreadsheet", CREATE_SPREADSHEET_REQUEST_CODE);
-            }
-        });
+        calcFAB.setOnClickListener(clickListener);
 
         impressFAB = findViewById(R.id.newImpressFAB);
-        impressFAB.setOnClickListener(new OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                createNewFileInputDialog(getString(R.string.new_presentation) + FileUtilities.DEFAULT_IMPRESS_EXTENSION, "application/vnd.oasis.opendocument.presentation", CREATE_PRESENTATION_REQUEST_CODE);
-            }
-        });
+        impressFAB.setOnClickListener(clickListener);
 
         writerLayout = findViewById(R.id.writerLayout);
+        writerLayout.setOnClickListener(clickListener);
+
         impressLayout = findViewById(R.id.impressLayout);
+        impressLayout.setOnClickListener(clickListener);
+
         calcLayout = findViewById(R.id.calcLayout);
+        calcLayout.setOnClickListener(clickListener);
     }
 
     /** Expand the Floating action button. */


### PR DESCRIPTION
1) FAB button size has been increased to 70dp (56dp default)
2) Gave 24dp margin from bottom
3) Its now placed in the bottom-center of the screen

This way it is now visible clearly with auto-hiding shelf
and ChromeOS notifications

Change-Id: Ia53c6621f2758366d04a79fe19f5cb89aaa80de5
Signed-off-by: mert <mert.tumer@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

