### PR TITLE
Make the help file show up in the iOS app

### DIFF
--- a/ios/Mobile/DocumentViewController.h
+++ b/ios/Mobile/DocumentViewController.h
@@ -16,6 +16,7 @@
 @property (strong) WKWebView *slideshowWebView;
 @property std::string slideshowFile;
 @property (strong) NSURL *slideshowURL;
+@property (strong) UIStackView *helpView;
 
 - (void)bye;
 

--- a/ios/Mobile/DocumentViewController.mm
+++ b/ios/Mobile/DocumentViewController.mm
@@ -484,21 +484,24 @@ static IMP standardImpOfInputAccessoryView = nil;
                     UIButton *helpCloseButton = [UIButton buttonWithType:UIButtonTypeClose];
                     [helpCloseButton addTarget:self action:@selector(helpCloseButtonPressed:) forControlEvents:UIControlEventPrimaryActionTriggered];
 
-                    WKWebView *helpWebView = [[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration];
+                    UIStackView *helpCloseButtonContainer = [[UIStackView alloc] initWithArrangedSubviews:@[ helpCloseButton ]];
+                    helpCloseButtonContainer.axis = UILayoutConstraintAxisVertical;
+                    helpCloseButtonContainer.alignment = UIStackViewAlignmentLeading;
 
-                    // helpWebView.translatesAutoresizingMaskIntoConstraints = NO;
+                    WKWebView *helpWebView = [[WKWebView alloc] initWithFrame:CGRectInset(self.view.frame, 20, 40) configuration:configuration];
+
+                    [helpWebView becomeFirstResponder];
+
                     helpWebView.navigationDelegate = self;
 
                     self.webView.hidden = true;
 
-                    self.helpView = [[UIStackView alloc] initWithFrame:self.view.frame];
+                    self.helpView = [[UIStackView alloc] initWithFrame:CGRectInset(self.view.frame, 20, 20)];
 
-                    // FIXME: The helpCloseButton gets grotesquely stretched horizontally.
-                    [self.helpView addArrangedSubview:helpCloseButton];
+                    [self.helpView addArrangedSubview:helpCloseButtonContainer];
                     [self.helpView addArrangedSubview:helpWebView];
 
                     self.helpView.axis = UILayoutConstraintAxisVertical;
-                    self.helpView.alignment = UIStackViewAlignmentFill;
 
                     [self.view addSubview:self.helpView];
                     [self.view bringSubviewToFront:self.helpView];


### PR DESCRIPTION
The current loleaflet-help.html if quite inadequate for the iOS (and
Android) app, though. For instance, it talks about collaborative
editing.

This is initial work on fixing https://github.com/CollaboraOnline/online/issues/400 .

Change-Id: Ied6b5b8e10902f796ea0e99a0d8d0b8fa52824d4
Signed-off-by: Tor Lillqvist <tml@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

