### PR TITLE
remove all the paths not using canvas rendered on calc

### DIFF
--- a/loleaflet/js/global.js
+++ b/loleaflet/js/global.js
@@ -189,10 +189,6 @@
 
 			return !L.Browser.mobile;
 		},
-		useCanvasLayer: function() {
-			// FIXME the CanvasTileLayer is so far desktop-only
-			return global.mode.isDesktop();
-		},
 		getDeviceFormFactor: function() {
 			if (window.mode.isMobile())
 				return 'mobile';

--- a/loleaflet/src/layer/tile/CalcTileLayer.js
+++ b/loleaflet/src/layer/tile/CalcTileLayer.js
@@ -476,7 +476,7 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 		this._sendClientZoom();
 		if (this.sheetGeometry) {
 			this.sheetGeometry.setTileGeometryData(this._tileWidthTwips, this._tileHeightTwips,
-				this._tileSize, window.mode.useCanvasLayer() ? this.canvasDPIScale() : this._tilePixelScale);
+				this._tileSize, this.canvasDPIScale());
 		}
 		this._restrictDocumentSize();
 		this._replayPrintTwipsMsgs();
@@ -742,7 +742,7 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 	_handleSheetGeometryDataMsg: function (jsonMsgObj) {
 		if (!this.sheetGeometry) {
 			this._sheetGeomFirstWait = false;
-			var dpiScale = window.mode.useCanvasLayer() ? this.canvasDPIScale() : this._tilePixelScale;
+			var dpiScale = this.canvasDPIScale();
 			this.sheetGeometry = new L.SheetGeometry(jsonMsgObj,
 				this._tileWidthTwips, this._tileHeightTwips,
 				this._tileSize, dpiScale, this._selectedPart);
@@ -1621,10 +1621,7 @@ L.SheetDimension = L.Class.extend({
 		this._coreZoomFactor = this._tileSizePixels * 15.0 / this._tileSizeTwips;
 		this._twipsPerCorePixel = this._tileSizeTwips / this._tileSizePixels;
 
-		if (window.mode.useCanvasLayer())
-			this._corePixelsPerCssPixel = this._dpiScale;
-		else
-			this._corePixelsPerCssPixel = 1;
+		this._corePixelsPerCssPixel = this._dpiScale;
 
 		if (updatePositions) {
 			// We need to compute positions data for every zoom change.


### PR DESCRIPTION
* Target version: master 

### Summary
following `6a0241f3cf9433d878f4eaaae52e3650532fbee0` caused calc headers to not load.
this problem was fixed by `002e1832c67cdc2ef17a447971aae1c907e41d3e` which caused regression in mobile 

now there can be 2 solutions:
1. revert both of the above-mentioned commits (current proposed solution in the PR)
2. or again introduce some of the changes of `1c2c4f1ed6440e7683043ab192e65daf6397f97c`.

@kendy what are your suggestions?

# Edit
according to @kendy's suggestions on the master branch canvas renderer should be used everywhere 

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

