### PR TITLE
leaflet: removed context menu options with tunnelled dialogs

### DIFF
--- a/loleaflet/src/control/Control.ContextMenu.js
+++ b/loleaflet/src/control/Control.ContextMenu.js
@@ -71,9 +71,11 @@ L.Control.ContextMenu = L.Control.extend({
 			'TransformDialog', 'FormatLine', 'FormatArea',
 			'InsertTitles', 'InsertRemoveAxes',
 			'DiagramType', 'DataRanges',
-			'FormatWall', 'FormatDataSeries',
+			'FormatWall', 'FormatDataSeries', 'FormatXErrorBars', 'FormatYErrorBars',
 			'FormatDataPoint', 'FormatAxis', 'FormatMajorGrid', 'FormatMinorGrid',
-			'InsertTrendline', 'InsertXErrorBars' , 'InsertYErrorBars',
+			'InsertTrendline', 'InsertXErrorBars' , 'InsertYErrorBars', 'FormatChartArea',
+			'FormatMeanValue', 'DiagramData', 'FormatLegend', 'FormatTrendline', 
+			'FormatTrendlineEquation', 'FormatStockLoss', 'FormatStockGain',
 			// text
 			'SpellingAndGrammarDialog', 'FontDialog', 'FontDialogForParagraph',
 			// spreadsheet


### PR DESCRIPTION
Change-Id: I51b15dc8430193ee5ba145cf7d1f72a3cde6a5c5

* Target version: master 

### Summary
Tunnelled dialogs are depricated in mobile long ago, there were a few context menu options still visible in the mobile which opened tunnelled dialogs

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

