### PR TITLE
leaflet: isolate the html5 history manipulation to mobile only

### DIFF
--- a/loleaflet/src/control/Control.UIManager.js
+++ b/loleaflet/src/control/Control.UIManager.js
@@ -14,11 +14,13 @@ L.Control.UIManager = L.Control.extend({
 
 		map.on('updatepermission', this.onUpdatePermission, this);
 
-		window.addEventListener('popstate', this.onGoBack.bind(this));
+		if (window.mode.isMobile()) {
+			window.addEventListener('popstate', this.onGoBack.bind(this));
 
-		// provide entries in the history we can catch to close the app
-		history.pushState({context: 'app-started'}, 'app-started');
-		history.pushState({context: 'app-started'}, 'app-started');
+			// provide entries in the history we can catch to close the app
+			history.pushState({context: 'app-started'}, 'app-started');
+			history.pushState({context: 'app-started'}, 'app-started');
+		}
 	},
 
 	// UI initialization


### PR DESCRIPTION
This fixes the issue with reloading pages on desktop that
were changing from POST to GET, which broken the world.

Change-Id: Ie60942a91527c3d10b570e5eb70aa3d5d35972a2
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
