### PR TITLE
Fix Chromebook text input focus issues

### DIFF
--- a/loleaflet/src/layer/marker/TextInput.js
+++ b/loleaflet/src/layer/marker/TextInput.js
@@ -275,12 +275,12 @@ L.TextInput = L.Layer.extend({
 
 		// Trick to avoid showing the software keyboard: Set the textarea
 		// read-only before focus() and reset it again after the blur()
-		if (navigator.platform !== 'iPhone') {
+		if (navigator.platform !== 'iPhone' && !window.mode.isChromebook()) {
 			if ((window.ThisIsAMobileApp || window.mode.isMobile()) && acceptInput !== true)
 				this._textArea.setAttribute('readonly', true);
 		}
 
-		if (navigator.platform !== 'iPhone') {
+		if (navigator.platform !== 'iPhone' && !window.mode.isChromebook()) {
 			this._textArea.focus();
 		} else if (acceptInput === true) {
 			// On the iPhone, only call the textarea's focus() when we get an explicit
@@ -302,7 +302,7 @@ L.TextInput = L.Layer.extend({
 			this._textArea.focus();
 		}
 
-		if (navigator.platform !== 'iPhone') {
+		if (navigator.platform !== 'iPhone' && !window.mode.isChromebook()) {
 			if ((window.ThisIsAMobileApp || window.mode.isMobile()) && acceptInput !== true) {
 				this._setAcceptInput(false);
 				this._textArea.blur();
@@ -329,7 +329,7 @@ L.TextInput = L.Layer.extend({
 		}
 
 		this._setAcceptInput(false);
-		if (navigator.platform !== 'iPhone')
+		if (navigator.platform !== 'iPhone' && !window.mode.isChromebook())
 			this._textArea.blur();
 	},
 


### PR DESCRIPTION
This fixes various of focus problems related to
writing. We have a hack for mobile devices for
hiding onscreen keyboard and to do that, we blur the
TextInput. But it is not relevant for Chromebooks despite
being a mobile app.

Also fixes calc text input problem, now theres no need to
double tap on a cell to write.

Change-Id: I674a3d553e130c34211c04ad0ebcb6401b462412
Signed-off-by: mert <mert.tumer@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

