### PR TITLE
Do the iOS font selection for the notebookbar in native iOS code

### DIFF
--- a/loleaflet/src/control/Control.NotebookbarBuilder.js
+++ b/loleaflet/src/control/Control.NotebookbarBuilder.js
@@ -6,6 +6,8 @@
 /* global $ _ _UNO */
 L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 
+	_iOSFontNameButton: null,
+
 	_customizeOptions: function() {
 		this.options.noLabelsForUnoButtons = true;
 		this.options.useInLineLabelsForUnoButtons = false;
@@ -204,7 +206,13 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 		var state = e.state;
 
 		if (commandName === '.uno:CharFontName') {
-			$('#fontnamecombobox').val(state).trigger('change');
+			if (window.ThisIsTheiOSApp) {
+				if (this._iOSFontNameButton !== null) {
+					this._iOSFontNameButton.innerHTML = state;
+				}
+			} else {
+				$('#fontnamecombobox').val(state).trigger('change');
+			}
 		} else if (commandName === '.uno:FontHeight') {
 			$('#fontsize').val(parseFloat(state)).trigger('change');
 			$('#fontsizecombobox').val(parseFloat(state)).trigger('change');
@@ -273,6 +281,26 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 	_comboboxControl: function(parentContainer, data, builder) {
 		if (!data.entries || data.entries.length === 0)
 			return false;
+
+		if (window.ThisIsTheiOSApp && data.id === 'fontnamecombobox') {
+			var button = L.DomUtil.createWithId('button', data.id, parentContainer);
+			this._iOSFontNameButton = button;
+			button.innerHTML = data.entries[data.selectedEntries[0]];
+			var map = builder.map;
+			window.MagicFontNameCallback = function(font) {
+				button.innerHTML = font;
+				map.applyFont(font);
+				map.focus();
+			};
+			button.onclick = function() {
+
+				// There doesn't seem to be a way to pre-select an entry in the
+				// UIFontPickerViewController so no need to pass the
+				// current font here.
+				window.postMobileMessage('FONTPICKER');
+			};
+			return false;
+		}
 
 		var select = L.DomUtil.createWithId('select', data.id, parentContainer);
 		$(select).addClass(builder.options.cssClass);


### PR DESCRIPTION
That way we can use UIFontPickerViewController which gives acess also
to fonst provided and registered by other third-party apps on iOS.
These fonts are not available otherwise. They don't show up when vcl
enumerates fonts in core.

This patch is work in progress for
https://github.com/CollaboraOnline/online/issues/472 . This patch
affects only the font name selection control in the notebookbar. On
iOS this is now no longer a "combo box" (implemented by the external
"select2" Javascript library, if I understand correctly), but a button
that brings up a native iOS control). For now it is just a plain HTML
button. It should ideally later be styled to fit better into the
visual style of the notebookbar.

Change-Id: Ic5e53cad09ffa8c99336dfed594337525909dc90
Signed-off-by: Tor Lillqvist <tml@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

