### PR TITLE
Avoid showing the initial notebookbar iOS font button contents as "un…

### DIFF
--- a/loleaflet/src/control/Control.NotebookbarBuilder.js
+++ b/loleaflet/src/control/Control.NotebookbarBuilder.js
@@ -6,8 +6,6 @@
 /* global $ _ _UNO */
 L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 
-	_iOSFontNameButton: null,
-
 	_customizeOptions: function() {
 		this.options.noLabelsForUnoButtons = true;
 		this.options.useInLineLabelsForUnoButtons = false;
@@ -207,9 +205,8 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 
 		if (commandName === '.uno:CharFontName') {
 			if (window.ThisIsTheiOSApp) {
-				if (this._iOSFontNameButton !== null) {
-					this._iOSFontNameButton.innerHTML = state;
-				}
+				$('#fontnamecombobox').html(state);
+				window.LastSetiOSFontNameButtonFont = state;
 			} else {
 				$('#fontnamecombobox').val(state).trigger('change');
 			}
@@ -284,8 +281,10 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 
 		if (window.ThisIsTheiOSApp && data.id === 'fontnamecombobox') {
 			var button = L.DomUtil.createWithId('button', data.id, parentContainer);
-			this._iOSFontNameButton = button;
-			button.innerHTML = data.entries[data.selectedEntries[0]];
+			if (data.entries[data.selectedEntries[0]])
+				button.innerHTML = data.entries[data.selectedEntries[0]];
+			else if (window.LastSetiOSFontNameButtonFont)
+				button.innerHTML = window.LastSetiOSFontNameButtonFont;
 			var map = builder.map;
 			window.MagicFontNameCallback = function(font) {
 				button.innerHTML = font;


### PR DESCRIPTION
…defined"

I don't really understand how this works, but this seems to help.
Sadly I had to introduce a global variable, window.LastSetiOSFontNameButtonFont.

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: If61ca73fdf3efcbf2a62a1885ab0f5b0080371f5
Signed-off-by: Tor Lillqvist <tml@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

