### PR TITLE
leaflet: fixed DOM leaking on annotation remove in mobile

### DIFF
--- a/cypress_test/integration_tests/mobile/writer/hamburger_menu_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/hamburger_menu_spec.js
@@ -898,7 +898,7 @@ describe('Trigger hamburger menu options.', function() {
 		cy.get('.vex-dialog-button-primary')
 			.click();
 
-		cy.get('.loleaflet-annotation:nth-of-type(2)')
+		cy.get('.loleaflet-annotation')
 			.should('have.attr', 'style')
 			.should('not.contain', 'visibility: hidden');
 
@@ -909,7 +909,7 @@ describe('Trigger hamburger menu options.', function() {
 		cy.contains('.context-menu-link', 'Resolve')
 			.click();
 
-		cy.get('.loleaflet-annotation:nth-of-type(2)')
+		cy.get('.loleaflet-annotation')
 			.should('have.attr', 'style')
 			.should('contain', 'visibility: hidden');
 
@@ -922,7 +922,7 @@ describe('Trigger hamburger menu options.', function() {
 		cy.contains('.menu-entry-with-icon', 'Resolved Comments')
 			.click();
 
-		cy.get('.loleaflet-annotation:nth-of-type(2)')
+		cy.get('.loleaflet-annotation')
 			.should('have.attr', 'style')
 			.should('not.contain', 'visibility: hidden');
 

--- a/loleaflet/src/layer/tile/TileLayer.js
+++ b/loleaflet/src/layer/tile/TileLayer.js
@@ -438,6 +438,8 @@ L.TileLayer = L.GridLayer.extend({
 
 					// FIXME: Unify annotation code in all modules...
 					addCommentFn.call(that, {annotation: annotation}, comment);
+					if (!isMod)
+						that._map.removeLayer(annotation);
 				}
 			}
 		});


### PR DESCRIPTION
An extra annotation element was added but never removed
This was not a functional problem
But not a good practice and also made cypress hard to maintain

Change-Id: I53fc7d55154a601c52f89e35b9236f5ae66b46fd
Signed-off-by: Pranam Lashkari <lpranam@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

