### PR TITLE
ChromeOS: Fix loosing textarea focus when using arrow keys

### DIFF
--- a/loleaflet/src/map/handler/Map.Keyboard.js
+++ b/loleaflet/src/map/handler/Map.Keyboard.js
@@ -336,6 +336,7 @@ L.Map.Keyboard = L.Handler.extend({
 				// console.log(e);
 				if (this.handleOnKeyDownKeys[keyCode] && charCode === 0) {
 					keyEventFn('input', charCode, unoKeyCode);
+					ev.preventDefault();
 				}
 			}
 			else if ((ev.type === 'keypress') && (!this.handleOnKeyDownKeys[keyCode] || charCode !== 0)) {


### PR DESCRIPTION
Change-Id: Ieec5779cfbb6c864279ad4f725ed10a1860ce7a5
Signed-off-by: mert <mert.tumer@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

