### PR TITLE
temporarily load RTL sheets as LTR

### DIFF
--- a/loleaflet/src/layer/tile/CalcTileLayer.js
+++ b/loleaflet/src/layer/tile/CalcTileLayer.js
@@ -815,6 +815,14 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 		else if (e.commandName === '.uno:FreezePanesRow') {
 			this._onSplitStateChanged(e, false /* isSplitCol */);
 		}
+		else if (e.commandName === '.uno:SheetRightToLeft') {
+			this._changeSheetDirection(e);
+		}
+	},
+
+	_changeSheetDirection: function(e) {
+		if (e.state == 'true')
+			this._map.sendUnoCommand('.uno:SheetRightToLeft?RightToLeft:bool=false');
 	},
 
 	_onSplitStateChanged: function (e, isSplitCol) {


### PR DESCRIPTION
Signed-off-by: Pranam Lashkari <lpranam@collabora.com>
Change-Id: I8e53d426055dcbfe9984153569d7815f63a8a872


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
currently, RTL sheets are not loaded correctly and can not be read or edit. This is a temporary solution to the problem by loading RTL sheet as LTR until RTL support is enabled in online calc.  

This will enable users to see and edit sheets correctly for now.

### Warning
This also causes to load the sheet as LTR in desktop too and will need to change that in settings explicitly.
### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

