### PR TITLE
wsd: support line-breaks in watermark text

### DIFF
--- a/common/FileUtil.hpp
+++ b/common/FileUtil.hpp
@@ -70,7 +70,7 @@ namespace FileUtil
     bool isEmptyDirectory(const char* path);
     inline bool isEmptyDirectory(const std::string& path) { return isEmptyDirectory(path.c_str()); }
 
-    /// Returns truee iff the path given is writable by our *real* UID.
+    /// Returns true iff the path given is writable by our *real* UID.
     bool isWritable(const char* path);
     inline bool isWritable(const std::string& path) { return isWritable(path.c_str()); }
 

--- a/kit/ChildSession.hpp
+++ b/kit/ChildSession.hpp
@@ -17,8 +17,8 @@
 #include "Common.hpp"
 #include "Kit.hpp"
 #include "Session.hpp"
+#include "Watermark.hpp"
 
-class Watermark;
 class ChildSession;
 
 enum class LokEventTargetEnum
@@ -215,7 +215,20 @@ public:
 
     void loKitCallback(const int type, const std::string& payload);
 
-    std::shared_ptr<Watermark> _docWatermark;
+    /// Initializes the watermark support, if enabled and required.
+    /// Returns true if watermark is enabled and initialized.
+    bool initWatermark()
+    {
+        if (hasWatermark())
+        {
+            _docWatermark.reset(
+                new Watermark(getLOKitDocument(), getWatermarkText(), getWatermarkOpacity()));
+        }
+
+        return _docWatermark != nullptr;
+    }
+
+    const std::shared_ptr<Watermark>& watermark() const { return _docWatermark; };
 
     bool sendTextFrame(const char* buffer, int length) override
     {
@@ -297,12 +310,12 @@ private:
     virtual void disconnect() override;
     virtual bool _handleInput(const char* buffer, int length) override;
 
-    std::shared_ptr<lok::Document> getLOKitDocument()
+    std::shared_ptr<lok::Document> getLOKitDocument() const
     {
         return _docManager->getLOKitDocument();
     }
 
-    std::string getLOKitLastError()
+    std::string getLOKitLastError() const
     {
         char *lastErr = _docManager->getLOKit()->getError();
         std::string ret;
@@ -325,6 +338,8 @@ private:
     const std::string _jailId;
     const std::string _jailRoot;
     DocumentManagerInterface* _docManager;
+
+    std::shared_ptr<Watermark> _docWatermark;
 
     std::queue<std::chrono::steady_clock::time_point> _cursorInvalidatedEvent;
     const unsigned _eventStorageIntervalMs = 15*1000;

--- a/kit/Watermark.hpp
+++ b/kit/Watermark.hpp
@@ -15,24 +15,24 @@
 #include <Log.hpp>
 #include <cstdlib>
 #include <string>
-#include "ChildSession.hpp"
 
-class Watermark
+class Watermark final
 {
 public:
-    Watermark(const std::shared_ptr<lok::Document>& loKitDoc,
-              const std::shared_ptr<ChildSession> & session)
+    Watermark(const std::shared_ptr<lok::Document>& loKitDoc, const std::string& text,
+              double opacity)
         : _loKitDoc(loKitDoc)
-        , _text(session->getWatermarkText())
+        , _text(text)
         , _font("Carlito")
+        , _alphaLevel(opacity)
         , _width(0)
         , _height(0)
-        , _alphaLevel(session->getWatermarkOpacity())
     {
-    }
-
-    ~Watermark()
-    {
+        if (_loKitDoc == nullptr)
+        {
+            LOG_ERR("Watermark rendering requested without a valid document. Watermarking will be disabled.");
+            assert(_loKitDoc && "Valid loKitDoc is required for Watermark.");
+        }
     }
 
     void blending(unsigned char* tilePixmap,
@@ -42,8 +42,8 @@ public:
                    LibreOfficeKitTileMode /*mode*/)
     {
         // set requested watermark size a little bit smaller than tile size
-        int width = tileWidth * 0.9;
-        int height = tileHeight * 0.9;
+        const int width = tileWidth * 0.9;
+        const int height = tileHeight * 0.9;
 
         const std::vector<unsigned char>* pixmap = getPixmap(width, height);
 
@@ -106,9 +106,8 @@ private:
         _width = width;
         _height = height;
 
-        if (!_loKitDoc)
+        if (_loKitDoc == nullptr)
         {
-            LOG_ERR("Watermark rendering requested without a valid document.");
             return nullptr;
         }
 
@@ -177,12 +176,12 @@ private:
     }
 
 private:
-    std::shared_ptr<lok::Document> _loKitDoc;
-    std::string _text;
-    std::string _font;
+    const std::shared_ptr<lok::Document> _loKitDoc;
+    const std::string _text;
+    const std::string _font;
+    const double _alphaLevel;
     int _width;
     int _height;
-    double _alphaLevel;
     std::vector<unsigned char> _pixmap;
 };
 

--- a/kit/Watermark.hpp
+++ b/kit/Watermark.hpp
@@ -22,7 +22,7 @@ public:
     Watermark(const std::shared_ptr<lok::Document>& loKitDoc, const std::string& text,
               double opacity)
         : _loKitDoc(loKitDoc)
-        , _text(text)
+        , _text(Util::replace(text, "\\n", "\n"))
         , _font("Carlito")
         , _alphaLevel(opacity)
         , _width(0)


### PR DESCRIPTION
New-line breaks can now be inserted in the watermark
text using \\n.

The watermark handler member has been fully encapsulated
inside ChildSession, so there is no need to have public
members or circular dependencies (ChildSession owns Watermark
instance, and Watermark takes ChildSession instance to
construct and initialize).

Minor refactoring and const-correctness improvements.

Change-Id: I66188c2619dd7c95b872c87c5144810b06554442
