### PR TITLE
android: Fix paste of plain text.

### DIFF
--- a/android/lib/src/main/java/org/libreoffice/androidlib/LOActivity.java
+++ b/android/lib/src/main/java/org/libreoffice/androidlib/LOActivity.java
@@ -1292,11 +1292,15 @@ public class LOActivity extends AppCompatActivity {
         }
 
         // try the plaintext as the last resort
-        if (clipDesc.hasMimeType(ClipDescription.MIMETYPE_TEXT_PLAIN)) {
-            final ClipData.Item clipItem = clipData.getItemAt(0);
-            String text = clipItem.getText().toString();
-            byte[] textByteArray = text.getBytes(Charset.forName("UTF-16"));
-            LOActivity.this.paste("text/plain;charset=utf-16", textByteArray);
+        for (int i = 0; i < clipDesc.getMimeTypeCount(); ++i) {
+            Log.d(TAG, "Plain text paste attempt " + i + ": " + clipDesc.getMimeType(i));
+
+            if (clipDesc.getMimeType(i).equals(ClipDescription.MIMETYPE_TEXT_PLAIN)) {
+                final ClipData.Item clipItem = clipData.getItemAt(i);
+                String text = clipItem.getText().toString();
+                byte[] textByteArray = text.getBytes(Charset.forName("UTF-8"));
+                LOActivity.this.paste("text/plain;charset=utf-8", textByteArray);
+            }
         }
 
         return false;


### PR DESCRIPTION
Without this, this scenario:

* in the browser's input line, tap, and use the "copy" icon
* open Collabora Office, long-tap, "paste"

lead to paste like ??#h#t#t#p#:#/#/#t#h#e#.#u#r#l

The actual fix is the usage of UTF-8; but at the time it is safer to
iterate over the mime types, so do that when I'm touching this code.

Change-Id: I62b7958f7fbc07acac4245465bc489fc86f202c3
