### PR TITLE
Prevent flickering on annotation switch use

### DIFF
--- a/loleaflet/src/layer/AnnotationManagerImpress.js
+++ b/loleaflet/src/layer/AnnotationManagerImpress.js
@@ -238,8 +238,10 @@ L.AnnotationManagerImpress = L.AnnotationManagerBase.extend({
 
 		if (commentsOnThePage >= this._topAnnotation[part] + 1) {
 			this._topAnnotation[part] = this._topAnnotation[part] + 1;
-			var topRight = this._map.latLngToLayerPoint(this._map.options.docBounds.getNorthEast());
-			this._map.fire('scrollby', {x: topRight.x, y: 0});
+
+			var offset = this._map._getCenterOffset(this._map.options.docBounds.getNorthEast());
+			this._map.panBy({x: offset.x, y: 0});
+
 			this.onAnnotationCancel();
 		} else if (part + 1 < this._map._docLayer._parts) {
 			var newPart = this.findNextPartWithComment();


### PR DESCRIPTION
When scroll down button was used the view was jumping
on every use what caused flickering.

Change-Id: I16de0e9d01c9d025977edc6affc16de4bd098b49
Signed-off-by: Szymon Kłos <szymon.klos@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

