### PR TITLE
Revert "tdf#133279: Use CollaboraOnlineWebViewKeyboardManager also fo…

### DIFF
--- a/ios/Mobile/DocumentViewController.mm
+++ b/ios/Mobile/DocumentViewController.mm
@@ -100,8 +100,10 @@ static IMP standardImpOfInputAccessoryView = nil;
     // contents is handled fully in JavaScript, the WebView has no knowledge of that.)
     self.webView.scrollView.delegate = self;
 
-    keyboardManager =
-        [[CollaboraOnlineWebViewKeyboardManager alloc] initForWebView:self.webView];
+    if (!isExternalKeyboardAttached()) {
+        keyboardManager =
+            [[CollaboraOnlineWebViewKeyboardManager alloc] initForWebView:self.webView];
+    }
 
     [self.view addSubview:self.webView];
 


### PR DESCRIPTION
…r hw keyboards"

The reverted change caused many problems when using a hardware
keyboard. See https://github.com/CollaboraOnline/online/issues/402 ,
https://github.com/CollaboraOnline/online/issues/389 , and
https://github.com/CollaboraOnline/online/issues/399 .

tdf#133279 (Not possible to type in "tunneled dialogs" on iOS using a
hardware keyboard) will now then re-appear, but it will have to be
fixed in another way.

This reverts commit 68d2d9cbd42f57418927bf3e619e372bb674b218.

Change-Id: Ic723f57a95700f352a2c1f501922aad4eb84479c
Signed-off-by: Tor Lillqvist <tml@collabora.com>
(cherry picked from commit 051e594d7a81d818c16ddce9203bf9b5d929df61)


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

