### PR TITLE
leaflet: fixed print shortcut not working in readonly mode

### DIFF
--- a/loleaflet/src/layer/marker/TextInput.js
+++ b/loleaflet/src/layer/marker/TextInput.js
@@ -198,6 +198,10 @@ L.TextInput = L.Layer.extend({
 		// to pop-up), unless the document is read only.
 		if (!this._map.isPermissionEdit()) {
 			this._setAcceptInput(false);
+			// on clicking focus is important
+			// specially in chrome once document loses focus it never gets it back
+			// which causes shortcuts to stop working (i.e: print, search etc...)
+			this._map.getContainer().focus();
 			return;
 		}
 


### PR DESCRIPTION
Signed-off-by: Pranam Lashkari <lpranam@collabora.com>
Change-Id: I084635c5d3e61215a4e88d84271587186605133d

* Target version: master 

### Summary
original problem was when in read only mode document container
is not in focus and that is why keyboard shortcut events were
never triggered

This solution focuses the document for composed keys to trigger
shortcuts

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

