### PR TITLE
Blind fix for lastModButton.firstChild is null error

### DIFF
--- a/loleaflet/src/map/Map.js
+++ b/loleaflet/src/map/Map.js
@@ -389,7 +389,7 @@ L.Map = L.Evented.extend({
 	initializeModificationIndicator: function() {
 		var lastModButton = L.DomUtil.get('menu-last-mod');
 		if (lastModButton !== null && lastModButton !== undefined
-			&& lastModButton.firstChild.innerHTML !== null
+			&& lastModButton.firstChild && lastModButton.firstChild.innerHTML !== null
 			&& lastModButton.firstChild.childElementCount == 0) {
 			if (this._lastmodtime == null) {
 				// No modification time -> hide the indicator


### PR DESCRIPTION
Change-Id: I7c788def4fde992922a47606c25f9e2721c39edc
Signed-off-by: mert <mert.tumer@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

