### PR TITLE
Notebookbar: Fix the order in which elements are added,

### DIFF
--- a/loleaflet/src/control/Control.Notebookbar.js
+++ b/loleaflet/src/control/Control.Notebookbar.js
@@ -10,6 +10,7 @@ L.Control.Notebookbar = L.Control.extend({
 	_showNotebookbar: false,
 
 	onAdd: function (map) {
+		// log and test window.ThisIsTheiOSApp = true;
 		this.map = map;
 		this._currentScrollPosition = 0;
 
@@ -102,7 +103,7 @@ L.Control.Notebookbar = L.Control.extend({
 	},
 
 	setTabs: function(tabs) {
-		$('nav').prepend(tabs);
+		$('#document-titlebar').before(tabs);
 		this.createShortcutsBar();
 	},
 
@@ -148,7 +149,7 @@ L.Control.Notebookbar = L.Control.extend({
 
 	createShortcutsBar: function() {
 		var shortcutsBar = L.DomUtil.create('div', 'notebookbar-shortcuts-bar');
-		$('nav').prepend(shortcutsBar);
+		$('#main-menu').after(shortcutsBar);
 		var builder = new L.control.notebookbarBuilder({mobileWizard: this, map: this.map, cssClass: 'notebookbar'});
 		builder.build(shortcutsBar, this.getShortcutsBarData());
 	},


### PR DESCRIPTION
fix logo (document-header) overlap on some devices, namely iPads.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ib2ca48d805f6decd941ae3f817f987791a074ed4
