### PR TITLE
iOS: Fix fontname btn styles and inherit defaults from...

### DIFF
--- a/loleaflet/css/toolbar.css
+++ b/loleaflet/css/toolbar.css
@@ -394,6 +394,12 @@ button.leaflet-control-search-next
 	margin-right: 5px;
 	width: 150px !important;
 }
+#fontnamecombobox {
+	border-color: transparent;
+	background-color: transparent;
+	line-height: 24px;
+	padding-right: 8px;
+}
 .fontsizes-select {
 	width: 55px !important;
 }

--- a/loleaflet/src/control/Control.NotebookbarBuilder.js
+++ b/loleaflet/src/control/Control.NotebookbarBuilder.js
@@ -205,6 +205,9 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 
 		if (commandName === '.uno:CharFontName') {
 			if (window.ThisIsTheiOSApp) {
+				$('#table-fontnamecombobox').addClass('select2 select2-container select2-container--default');
+				$('#table-fontnamecombobox > .row.notebookbar').addClass('select2-selection select2-selection--single');
+				$('#fontnamecombobox').addClass('select2-selection__rendered');
 				$('#fontnamecombobox').html(state);
 				window.LastSetiOSFontNameButtonFont = state;
 			} else {


### PR DESCRIPTION
existent classes while overruling line-height and padding
for that particular btn (has np chevron since it's a btn and not a combobox)

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I393c972b44402c4030a6d7838750cfbd8156530e
