### PR TITLE
Chromebook: fix unable to re-gain textarea focus

### DIFF
--- a/loleaflet/src/layer/marker/TextInput.js
+++ b/loleaflet/src/layer/marker/TextInput.js
@@ -280,7 +280,7 @@ L.TextInput = L.Layer.extend({
 				this._textArea.setAttribute('readonly', true);
 		}
 
-		if (!window.ThisIsTheiOSApp && navigator.platform !== 'iPhone' && !window.mode.isChromebook()) {
+		if (!window.ThisIsTheiOSApp && navigator.platform !== 'iPhone') {
 			this._textArea.focus();
 		} else if (acceptInput === true) {
 			// On the iPhone, only call the textarea's focus() when we get an explicit


### PR DESCRIPTION
This is a regression started after:
b5bd8e1e0ef0d6f8b7c32b106e7eb611977a291d
!isChromebook() control added here accidentally

Change-Id: I0d774fdeadb30960413aa1b975145ed78ec7b20d
Signed-off-by: mert <mert.tumer@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

