### PR TITLE
Cypress test:  clear direct formating

### DIFF
--- a/cypress_test/integration_tests/desktop/impress/top_toolbar_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/top_toolbar_spec.js
@@ -29,6 +29,16 @@ describe('Top toolbar tests.', function() {
 			.should('have.attr', 'font-weight', '700');
 	});
 
+	it('Apply italic on text shape.', function() {
+		cy.get('#tb_editbar_item_italic')
+			.click();
+
+		impressHelper.triggerNewSVGForShapeInTheCenter();
+
+		cy.get('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph')
+			.should('have.attr', 'font-style', 'italic');
+	});	
+
 	it('Apply left/right alignment on text seleced text.', function() {
 		cy.get('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition')
 			.should('have.attr', 'x', '1400');


### PR DESCRIPTION
add cypress tests for clear direct formating, italic, underline, strikethrough, font color, and highlight color on text shape.

Change-Id: I7cf9e31beba87cd12d562b0e899b83c895ba68d7


