### PR TITLE
leaflet: fixed incorrect info shown on the comment reply vex dialog

### DIFF
--- a/loleaflet/src/layer/AnnotationManager.js
+++ b/loleaflet/src/layer/AnnotationManager.js
@@ -638,7 +638,21 @@ L.AnnotationManager = L.AnnotationManagerBase.extend({
 
 	reply: function (annotation) {
 		if (window.mode.isMobile() || window.mode.isTablet()) {
-			this._doclayer.newAnnotationVex(annotation, annotation._onReplyClick,/* isMod */ true, '');
+			var avatar = undefined;
+			var author = this._map.getViewName(this._map._docLayer._viewId);
+			if (author in this._map._viewInfoByUserName) {
+				avatar = this._map._viewInfoByUserName[author].userextrainfo.avatar;
+			}
+			var replyAnnotation = {
+				text: '',
+				textrange: '',
+				author: author,
+				dateTime: new Date().toDateString(),
+				id: annotation._data.id,
+				avatar: avatar,
+				parent: annotation._data.parent
+			};
+			this._doclayer.newAnnotationVex(replyAnnotation, annotation._onReplyClick,/* isMod */ false, '');
 		}
 		else {
 			annotation.reply();

--- a/loleaflet/src/layer/AnnotationManagerImpress.js
+++ b/loleaflet/src/layer/AnnotationManagerImpress.js
@@ -131,7 +131,21 @@ L.AnnotationManagerImpress = L.AnnotationManagerBase.extend({
 		this.onAnnotationCancel();
 		this._selectedAnnotation = annotation._data.id;
 		if (window.mode.isMobile() || window.mode.isTablet()) {
-			this._doclayer.newAnnotationVex(annotation, annotation._onReplyClick,/* isMod */ true, '');
+			var avatar = undefined;
+			var author = this._map.getViewName(this._map._docLayer._viewId);
+			if (author in this._map._viewInfoByUserName) {
+				avatar = this._map._viewInfoByUserName[author].userextrainfo.avatar;
+			}
+			var replyAnnotation = {
+				text: '',
+				textrange: '',
+				author: author,
+				dateTime: new Date().toDateString(),
+				id: annotation._data.id,
+				avatar: avatar,
+				parent: annotation._data.parent
+			};
+			this._doclayer.newAnnotationVex(replyAnnotation, annotation._onReplyClick,/* isMod */ false, '');
 		} else {
 			annotation.reply();
 			this.scrollUntilAnnotationIsVisible(annotation);

--- a/loleaflet/src/layer/marker/Annotation.js
+++ b/loleaflet/src/layer/marker/Annotation.js
@@ -377,7 +377,7 @@ L.Annotation = L.Layer.extend({
 	_onReplyClick: function (e) {
 		L.DomEvent.stopPropagation(e);
 		if (window.mode.isMobile() || window.mode.isTablet()) {
-			e.annotation._data.reply = e.annotation.text;
+			e.annotation._data.reply = e.annotation._data.text;
 			e.annotation.show();
 			e.annotation._checkBounds();
 			this._map.fire('AnnotationReply', {annotation: e.annotation});


### PR DESCRIPTION
Signed-off-by: Pranam Lashkari <lpranam@collabora.com>
Change-Id: Iad3cc8dd8b3053c73ce1f575ff5d50ba3c666c70

* Target version: master 

### Summary
instead of the current author and date, it showed the date and author of the original comment we are replying to. It caused many problems in the development of comment wizard.

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

