### PR TITLE
iOS: Fix sidebar toggle position.  fixes issue #616

### DIFF
--- a/loleaflet/css/toolbar.css
+++ b/loleaflet/css/toolbar.css
@@ -254,32 +254,35 @@ td[id^='tb_editbar_item_sidebar']{
 #closebuttonwrapper {
 	position: fixed;
 	z-index: 1050;
-	right: 4px;
-	top: 0px;
+	right: 0px;
+	top: -3px;
 	width: 32px;
 	height: 32px;
-	background-color: white;
+	background-color: #444444;
+	background-image: linear-gradient(black 0%, #444444 20%);
+	border-radius: 0px 0px 8px 8px;
 	display: none;
 }
 
 #closebutton {
 	width: 18px;
 	height: 18px;
-	border: 1px solid;
-	border-color: transparent;
-	border-radius: 5px;
+	border: none;
 	margin: 8px;
 }
 
 #closebutton:hover {
-	border-color: #ccc;
 	background-color: #eee;
+	filter: contrast(10) invert(1);
 }
 
 .closebuttonimage {
 	background: url('images/closedoc.svg') no-repeat center !important;
+	filter: contrast(1) invert(1);
 }
-
+.tablet #Sidebar {
+	margin-right: 42px !important;
+}
 #tb_actionbar_item_left {
 	width: 45%;
 }

--- a/loleaflet/src/control/Control.Notebookbar.js
+++ b/loleaflet/src/control/Control.Notebookbar.js
@@ -60,6 +60,8 @@ L.Control.Notebookbar = L.Control.extend({
 			this._showNotebookbar = true;
 			this.showTabs();
 			$('.main-nav').removeClass('readonly');
+			if (window.mode.isTablet())
+				$('.notebookbar-options-section').addClass('tablet');
 		}
 	},
 

--- a/loleaflet/src/control/Control.Notebookbar.js
+++ b/loleaflet/src/control/Control.Notebookbar.js
@@ -283,6 +283,8 @@ L.Control.Notebookbar = L.Control.extend({
 
 		if (L.Params.closeButtonEnabled && !window.mode.isTablet())
 			$(optionsSection).css('right', '30px');
+		if (window.ThisIsTheiOSApp)
+			$('.notebookbar-options-section').addClass('tablet');
 
 		var builderOptions = {
 			mobileWizard: this,


### PR DESCRIPTION
also restyle close btn to make a clear distinction between that (a top app action) and the nearby icons (sidebar toggles)

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I53ac42d6eff795919f02aab6cb9574d905e9fc21
