### PR TITLE
Ensure consistent canonical view id accounting between wsd and kit.

### DIFF
--- a/common/Session.hpp
+++ b/common/Session.hpp
@@ -36,8 +36,8 @@ public:
     SessionMap() {
         static_assert(std::is_base_of<Session, T>::value, "sessions must have base of Session");
     }
-    /// Generate a unique key for this set of view properties
-    int getCanonicalId(const std::string &viewProps)
+    /// Generate a unique key for this set of view properties, only used by WSD
+    int createCanonicalId(const std::string &viewProps)
     {
         if (viewProps.empty())
             return 0;
@@ -49,6 +49,7 @@ public:
         _canonicalIds[viewProps] = id;
         return id;
     }
+    /// Lookup one session in the map that matches this canonical view id, only used by Kit
     std::shared_ptr<T> findByCanonicalId(int id)
     {
         for (const auto &it : *this) {
@@ -206,9 +207,12 @@ public:
     const std::string& getJailedFilePathAnonym() const { return _jailedFilePathAnonym; }
 
     int  getCanonicalViewId() { return _canonicalViewId; }
-    template<class T> void recalcCanonicalViewId(SessionMap<T> &map)
+    // Only called by kit.
+    void setCanonicalViewId(int viewId) { _canonicalViewId = viewId; }
+    // Only called by wsd.
+    template<class T> void createCanonicalViewId(SessionMap<T> &map)
     {
-        _canonicalViewId = map.getCanonicalId(_watermarkText);
+        _canonicalViewId = map.createCanonicalId(_watermarkText);
     }
 
     const std::string& getDeviceFormFactor() const { return _deviceFormFactor; }

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -745,14 +745,15 @@ bool DocumentBroker::load(const std::shared_ptr<ClientSession>& session, const s
         watermarkText = LOOLWSD::OverrideWatermark;
 #endif
 
-    LOG_DBG("Setting username [" << LOOLWSD::anonymizeUsername(username) << "] and userId [" <<
-            LOOLWSD::anonymizeUsername(userId) << "] for session [" << sessionId << ']');
-
     session->setUserId(userId);
     session->setUserName(username);
     session->setUserExtraInfo(userExtraInfo);
     session->setWatermarkText(watermarkText);
-    session->recalcCanonicalViewId(_sessions);
+    session->createCanonicalViewId(_sessions);
+
+    LOG_DBG("Setting username [" << LOOLWSD::anonymizeUsername(username) << "] and userId [" <<
+            LOOLWSD::anonymizeUsername(userId) << "] for session [" << sessionId <<
+            "] is canonical id " << session->getCanonicalViewId());
 
     // Basic file information was stored by the above getWOPIFileInfo() or getLocalFileInfo() calls
     const StorageBase::FileInfo fileInfo = _storage->getFileInfo();
@@ -1432,7 +1433,8 @@ size_t DocumentBroker::addSessionInternal(const std::shared_ptr<ClientSession>& 
     const std::string id = session->getId();
 
     // Request a new session from the child kit.
-    const std::string aMessage = "session " + id + ' ' + _docKey + ' ' + _docId;
+    const std::string aMessage = "session " + id + ' ' + _docKey + ' ' +
+        _docId + ' ' + std::to_string(session->getCanonicalViewId());
     _childProcess->sendTextFrame(aMessage);
 
 #if !MOBILEAPP


### PR DESCRIPTION
Confusion arose due to separate creation of session, and watermark
property fetch from CheckFileInfo which happens in DocumentBroker::load
which doesn't do a load. This happens in a subsequent 'load url='
message cf. global.js which can then race vs. the session creation.

This causes mis-ordering of another unhelpfully shared Session,
letting the view canonicalization list to get out of sync between
the two processes.

So instead - tell the view it's canonical id. An example of the
problems of trying to share some unclear subset of the Session
class between kit and wsd perhaps.

Change-Id: I63dc30f9a047e3f889fd339b6aaf392b9fef37b9
Signed-off-by: Michael Meeks <michael.meeks@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

