### PR TITLE
wsd: avoid the using keyword and use C++ size_t

### DIFF
--- a/common/Authorization.cpp
+++ b/common/Authorization.cpp
@@ -57,21 +57,21 @@ void Authorization::authorizeRequest(Poco::Net::HTTPRequest& request) const
             {
                 std::string token = tokens.getParam(*it);
 
-                size_t separator = token.find_first_of(':');
+                std::size_t separator = token.find_first_of(':');
                 if (separator != std::string::npos)
                 {
-                    size_t headerStart = token.find_first_not_of(' ', 0);
-                    size_t headerEnd = token.find_last_not_of(' ', separator - 1);
+                    std::size_t headerStart = token.find_first_not_of(' ', 0);
+                    std::size_t headerEnd = token.find_last_not_of(' ', separator - 1);
 
-                    size_t valueStart = token.find_first_not_of(' ', separator + 1);
-                    size_t valueEnd = token.find_last_not_of(' ');
+                    std::size_t valueStart = token.find_first_not_of(' ', separator + 1);
+                    std::size_t valueEnd = token.find_last_not_of(' ');
 
                     // set the header
                     if (headerStart != std::string::npos && headerEnd != std::string::npos &&
                             valueStart != std::string::npos && valueEnd != std::string::npos)
                     {
-                        size_t headerLength = headerEnd - headerStart + 1;
-                        size_t valueLength = valueEnd - valueStart + 1;
+                        std::size_t headerLength = headerEnd - headerStart + 1;
+                        std::size_t valueLength = valueEnd - valueStart + 1;
 
                         request.set(token.substr(headerStart, headerLength), token.substr(valueStart, valueLength));
                     }

--- a/common/Clipboard.hpp
+++ b/common/Clipboard.hpp
@@ -51,7 +51,7 @@ struct ClipboardData
         }
     }
 
-    size_t size()
+    std::size_t size() const
     {
         assert(_mimeTypes.size() == _content.size());
         return _mimeTypes.size();
@@ -96,7 +96,7 @@ public:
     }
 
     void insertClipboard(const std::string key[2],
-                         const char *data, size_t size)
+                         const char *data, std::size_t size)
     {
         if (size == 0)
         {

--- a/common/Crypto.cpp
+++ b/common/Crypto.cpp
@@ -37,17 +37,18 @@ struct SupportKeyImpl
         : _invalid(true), _key(key)
     {
         LOG_INF("Support key '" << key << "' provided");
-        size_t firstColon = key.find(':');
+        std::size_t firstColon = key.find(':');
         if (firstColon != std::string::npos)
         {
             std::string expiry(key.substr(0, firstColon));
             LOG_INF("Support key with expiry '" << expiry << '\'');
 
-            try {
+            try
+            {
                 int timeZoneDifferential = 0;
                 Poco::DateTimeParser::parse(expiry, _expiry, timeZoneDifferential);
 
-                size_t lastColon = key.rfind(':');
+                std::size_t lastColon = key.rfind(':');
                 if (lastColon != std::string::npos)
                 {
                     _signature = key.substr(lastColon + 1,

--- a/common/JsonUtil.hpp
+++ b/common/JsonUtil.hpp
@@ -24,7 +24,7 @@ namespace JsonUtil
 // Returns true if parsing successful otherwise false
 inline bool parseJSON(const std::string& json, Poco::JSON::Object::Ptr& object)
 {
-    const size_t index = json.find_first_of('{');
+    const std::size_t index = json.find_first_of('{');
     if (index != std::string::npos)
     {
         const std::string stringJSON = json.substr(index);
@@ -43,9 +43,9 @@ int getLevenshteinDist(const std::string& string1, const std::string& string2)
     int matrix[string1.size() + 1][string2.size() + 1];
     std::memset(matrix, 0, sizeof(matrix[0][0]) * (string1.size() + 1) * (string2.size() + 1));
 
-    for (size_t i = 0; i < string1.size() + 1; i++)
+    for (std::size_t i = 0; i < string1.size() + 1; i++)
     {
-        for (size_t j = 0; j < string2.size() + 1; j++)
+        for (std::size_t j = 0; j < string2.size() + 1; j++)
         {
             if (i == 0)
             {

--- a/common/Log.cpp
+++ b/common/Log.cpp
@@ -109,7 +109,7 @@ namespace Log
     }
 
     /// Convert an unsigned number to ascii with 0 padding.
-    template <int Width> void to_ascii_fixed(char* buf, size_t num)
+    template <int Width> void to_ascii_fixed(char* buf, std::size_t num)
     {
         buf[Width - 1] = '0' + num % 10; // Units.
 
@@ -159,7 +159,7 @@ namespace Log
 
     /// Convert unsigned long num to base-10 ascii in place.
     /// Returns the *end* position.
-    char* to_ascii(char* buf, size_t num)
+    char* to_ascii(char* buf, std::size_t num)
     {
         int i = 0;
         do

--- a/common/Session.cpp
+++ b/common/Session.cpp
@@ -38,7 +38,6 @@
 using namespace LOOLProtocol;
 
 using Poco::Exception;
-using std::size_t;
 
 Session::Session(const std::shared_ptr<ProtocolHandlerInterface> &protocol,
                  const std::string& name, const std::string& id, bool readOnly) :
@@ -89,14 +88,14 @@ bool Session::sendBinaryFrame(const char *buffer, int length)
 void Session::parseDocOptions(const StringVector& tokens, int& part, std::string& timestamp, std::string& doctemplate)
 {
     // First token is the "load" command itself.
-    size_t offset = 1;
+    std::size_t offset = 1;
     if (tokens.size() > 2 && tokens[1].find("part=") == 0)
     {
         getTokenInteger(tokens[1], "part", part);
         ++offset;
     }
 
-    for (size_t i = offset; i < tokens.size(); ++i)
+    for (std::size_t i = offset; i < tokens.size(); ++i)
     {
         std::string name;
         std::string value;

--- a/common/Session.hpp
+++ b/common/Session.hpp
@@ -36,19 +36,23 @@ public:
     SessionMap() {
         static_assert(std::is_base_of<Session, T>::value, "sessions must have base of Session");
     }
+
     /// Generate a unique key for this set of view properties, only used by WSD
     int createCanonicalId(const std::string &viewProps)
     {
         if (viewProps.empty())
             return 0;
-        for (auto &it : _canonicalIds) {
+        for (const auto& it : _canonicalIds)
+        {
             if (it.first == viewProps)
                 return it.second;
         }
-        size_t id = _canonicalIds.size() + 1;
+
+        const std::size_t id = _canonicalIds.size() + 1;
         _canonicalIds[viewProps] = id;
         return id;
     }
+
     /// Lookup one session in the map that matches this canonical view id, only used by Kit
     std::shared_ptr<T> findByCanonicalId(int id)
     {

--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -114,7 +114,9 @@ public:
     }
 
     /// Message that is about to be sent via the websocket.
-    virtual bool filterSendMessage(const char* /* data */, const size_t /* len */, const WSOpCode /* code */, const bool /* flush */, int& /*unitReturn*/)
+    virtual bool filterSendMessage(const char* /* data */, const std::size_t /* len */,
+                                   const WSOpCode /* code */, const bool /* flush */,
+                                   int& /*unitReturn*/)
     {
         return false;
     }

--- a/common/Util.cpp
+++ b/common/Util.cpp
@@ -59,8 +59,6 @@
 #include "Log.hpp"
 #include "Protocol.hpp"
 
-using std::size_t;
-
 namespace Util
 {
     namespace rng
@@ -90,7 +88,7 @@ namespace Util
             return _rng();
         }
 
-        std::vector<char> getBytes(const size_t length)
+        std::vector<char> getBytes(const std::size_t length)
         {
             std::vector<char> v(length);
             _randBuf.readFromDevice(v.data(), v.size());
@@ -98,7 +96,7 @@ namespace Util
         }
 
         /// Generate a string of random characters.
-        std::string getHexString(const size_t length)
+        std::string getHexString(const std::size_t length)
         {
             std::stringstream ss;
             Poco::HexBinaryEncoder hex(ss);
@@ -107,7 +105,7 @@ namespace Util
         }
 
         /// Generate a string of harder random characters.
-        std::string getHardRandomHexString(const size_t length)
+        std::string getHardRandomHexString(const std::size_t length)
         {
             std::stringstream ss;
             Poco::HexBinaryEncoder hex(ss);
@@ -118,7 +116,7 @@ namespace Util
             int len = 0;
             if (fd < 0 ||
                 (len = read(fd, random.data(), length)) < 0 ||
-                size_t(len) < length)
+                std::size_t(len) < length)
             {
                 LOG_ERR("failed to read " << length << " hard random bytes, got " << len << " for hash: " << errno);
             }
@@ -129,7 +127,7 @@ namespace Util
 
         /// Generates a random string in Base64.
         /// Note: May contain '/' characters.
-        std::string getB64String(const size_t length)
+        std::string getB64String(const std::size_t length)
         {
             std::stringstream ss;
             Poco::Base64Encoder b64(ss);
@@ -137,7 +135,7 @@ namespace Util
             return ss.str().substr(0, length);
         }
 
-        std::string getFilename(const size_t length)
+        std::string getFilename(const std::size_t length)
         {
             std::string s = getB64String(length * 2);
             s.erase(std::remove_if(s.begin(), s.end(),
@@ -350,7 +348,7 @@ namespace Util
 
     static const char *startsWith(const char *line, const char *tag)
     {
-        size_t len = std::strlen(tag);
+        std::size_t len = std::strlen(tag);
         if (!strncmp(line, tag, len))
         {
             while (!isdigit(line[len]) && line[len] != '\0')
@@ -388,9 +386,9 @@ namespace Util
         return ss.str();
     }
 
-    size_t getTotalSystemMemoryKb()
+    std::size_t getTotalSystemMemoryKb()
     {
-        size_t totalMemKb = 0;
+        std::size_t totalMemKb = 0;
         FILE* file = fopen("/proc/meminfo", "r");
         if (file != nullptr)
         {
@@ -409,10 +407,10 @@ namespace Util
         return totalMemKb;
     }
 
-    std::pair<size_t, size_t> getPssAndDirtyFromSMaps(FILE* file)
+    std::pair<std::size_t, std::size_t> getPssAndDirtyFromSMaps(FILE* file)
     {
-        size_t numPSSKb = 0;
-        size_t numDirtyKb = 0;
+        std::size_t numPSSKb = 0;
+        std::size_t numDirtyKb = 0;
         if (file)
         {
             rewind(file);
@@ -437,7 +435,7 @@ namespace Util
 
     std::string getMemoryStats(FILE* file)
     {
-        const std::pair<size_t, size_t> pssAndDirtyKb = getPssAndDirtyFromSMaps(file);
+        const std::pair<std::size_t, std::size_t> pssAndDirtyKb = getPssAndDirtyFromSMaps(file);
         std::ostringstream oss;
         oss << "procmemstats: pid=" << getpid()
             << " pss=" << pssAndDirtyKb.first
@@ -446,7 +444,7 @@ namespace Util
         return oss.str();
     }
 
-    size_t getMemoryUsagePSS(const pid_t pid)
+    std::size_t getMemoryUsagePSS(const pid_t pid)
     {
         if (pid > 0)
         {
@@ -454,7 +452,7 @@ namespace Util
             FILE* fp = fopen(cmd.c_str(), "r");
             if (fp != nullptr)
             {
-                const size_t pss = getPssAndDirtyFromSMaps(fp).first;
+                const std::size_t pss = getPssAndDirtyFromSMaps(fp).first;
                 fclose(fp);
                 return pss;
             }
@@ -463,10 +461,10 @@ namespace Util
         return 0;
     }
 
-    size_t getMemoryUsageRSS(const pid_t pid)
+    std::size_t getMemoryUsageRSS(const pid_t pid)
     {
         static const int pageSizeBytes = getpagesize();
-        size_t rss = 0;
+        std::size_t rss = 0;
 
         if (pid > 0)
         {
@@ -478,11 +476,11 @@ namespace Util
         return 0;
     }
 
-    size_t getCpuUsage(const pid_t pid)
+    std::size_t getCpuUsage(const pid_t pid)
     {
         if (pid > 0)
         {
-            size_t totalJiffies = 0;
+            std::size_t totalJiffies = 0;
             totalJiffies += getStatFromPid(pid, 13);
             totalJiffies += getStatFromPid(pid, 14);
             return totalJiffies;
@@ -490,7 +488,7 @@ namespace Util
         return 0;
     }
 
-    size_t getStatFromPid(const pid_t pid, int ind)
+    std::size_t getStatFromPid(const pid_t pid, int ind)
     {
         if (pid > 0)
         {
@@ -503,7 +501,7 @@ namespace Util
                 {
                     const std::string s(line);
                     int index = 1;
-                    size_t pos = s.find(' ');
+                    std::size_t pos = s.find(' ');
                     while (pos != std::string::npos)
                     {
                         if (index == ind)
@@ -535,10 +533,10 @@ namespace Util
 
     std::string replace(std::string result, const std::string& a, const std::string& b)
     {
-        const size_t aSize = a.size();
+        const std::size_t aSize = a.size();
         if (aSize > 0)
         {
-            const size_t bSize = b.size();
+            const std::size_t bSize = b.size();
             std::string::size_type pos = 0;
             while ((pos = result.find(a, pos)) != std::string::npos)
             {
@@ -843,12 +841,12 @@ namespace Util
         return http_time;
     }
 
-    size_t findInVector(const std::vector<char>& tokens, const char *cstring)
+    std::size_t findInVector(const std::vector<char>& tokens, const char *cstring)
     {
         assert(cstring);
-        for (size_t i = 0; i < tokens.size(); ++i)
+        for (std::size_t i = 0; i < tokens.size(); ++i)
         {
-            size_t j;
+            std::size_t j;
             for (j = 0; i + j < tokens.size() && cstring[j] != '\0' && tokens[i + j] == cstring[j]; ++j)
                 ;
             if (cstring[j] == '\0')
@@ -921,7 +919,7 @@ namespace Util
         }
 
         char* end = nullptr;
-        const size_t us = strtoul(trailing + 1, &end, 10); // Skip the '.' and read as integer.
+        const std::size_t us = strtoul(trailing + 1, &end, 10); // Skip the '.' and read as integer.
 
         std::size_t denominator = 1;
         for (const char* i = trailing + 1; i != end; i++)
@@ -961,7 +959,7 @@ namespace Util
 
         for (std::vector<std::string>::iterator it = sVector.begin(); it != sVector.end(); it++)
         {
-            size_t delimiterPosition = 0;
+            std::size_t delimiterPosition = 0;
             delimiterPosition = (*it).find(delimiter, 0);
             if (delimiterPosition != std::string::npos)
             {

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -101,7 +101,6 @@ using Poco::Path;
 #endif
 
 using namespace LOOLProtocol;
-using std::size_t;
 
 extern "C" { void dump_kit_state(void); /* easy for gdb */ }
 
@@ -308,10 +307,10 @@ namespace
             break;
         case FTW_SL:
             {
-                const size_t size = sb->st_size;
+                const std::size_t size = sb->st_size;
                 char target[size + 1];
                 const ssize_t written = readlink(fpath, target, size);
-                if (written <= 0 || static_cast<size_t>(written) > size)
+                if (written <= 0 || static_cast<std::size_t>(written) > size)
                 {
                     LOG_SYS("nftw: readlink(\"" << fpath << "\") failed");
                     Log::shutdown();
@@ -557,10 +556,10 @@ public:
     /// Purges dead connections and returns
     /// the remaining number of clients.
     /// Returns -1 on failure.
-    size_t purgeSessions()
+    std::size_t purgeSessions()
     {
         std::vector<std::shared_ptr<ChildSession>> deadSessions;
-        size_t num_sessions = 0;
+        std::size_t num_sessions = 0;
         {
             std::unique_lock<std::mutex> lock(_mutex, std::defer_lock);
             if (!lock.try_lock())
@@ -676,14 +675,14 @@ public:
 #endif
 
         const auto blenderFunc = [&](unsigned char* data, int offsetX, int offsetY,
-                                     size_t pixmapWidth, size_t pixmapHeight, int pixelWidth,
-                                     int pixelHeight, LibreOfficeKitTileMode mode) {
+                                     std::size_t pixmapWidth, std::size_t pixmapHeight,
+                                     int pixelWidth, int pixelHeight, LibreOfficeKitTileMode mode) {
             if (session->watermark())
                 session->watermark()->blending(data, offsetX, offsetY, pixmapWidth, pixmapHeight,
                                                pixelWidth, pixelHeight, mode);
         };
 
-        const auto postMessageFunc = [&](const char* buffer, size_t length) {
+        const auto postMessageFunc = [&](const char* buffer, std::size_t length) {
             postMessage(buffer, length, WSOpCode::Binary);
         };
 
@@ -1292,7 +1291,7 @@ private:
         assert(payload.size() > prefix.size());
 
         // Remove the prefix and trim.
-        size_t index = prefix.size();
+        std::size_t index = prefix.size();
         for ( ; index < payload.size(); ++index)
         {
             if (payload[index] != ' ')
@@ -1302,7 +1301,7 @@ private:
         }
 
         const char* data = payload.data() + index;
-        size_t size = payload.size() - index;
+        std::size_t size = payload.size() - index;
 
         std::string name;
         std::string sessionId;
@@ -1328,7 +1327,7 @@ private:
                     session->sendTextFrame("disconnected:");
 
                     _sessions.erase(it);
-                    const size_t count = _sessions.size();
+                    const std::size_t count = _sessions.size();
                     LOG_DBG("Have " << count << " child" << (count == 1 ? "" : "ren") <<
                             " after removing ChildSession [" << sessionId << "].");
 
@@ -1470,7 +1469,8 @@ public:
                         const int type = std::stoi(tokens[2]);
 
                         // payload is the rest of the message
-                        const size_t offset = tokens[0].length() + tokens[1].length() + tokens[2].length() + 3; // + delims
+                        const std::size_t offset = tokens[0].length() + tokens[1].length()
+                                                   + tokens[2].length() + 3; // + delims
                         const std::string payload(input.data() + offset, input.size() - offset);
 
                         // Forward the callback to the same view, demultiplexing is done by the LibreOffice core.
@@ -2067,7 +2067,7 @@ void lokit_main(
                 int docBrokerSocket,
                 const std::string& userInterface,
 #endif
-                size_t numericIdentifier
+                std::size_t numericIdentifier
                 )
 {
 #if !MOBILEAPP

--- a/kit/Kit.hpp
+++ b/kit/Kit.hpp
@@ -38,7 +38,7 @@ void lokit_main(
                 int docBrokerSocket,
                 const std::string& userInterface,
 #endif
-                size_t numericIdentifier
+                std::size_t numericIdentifier
                 );
 
 #ifdef IOS

--- a/test/UnitEachView.cpp
+++ b/test/UnitEachView.cpp
@@ -61,7 +61,7 @@ void testEachView(const std::string& doc, const std::string& type, const std::st
                      std::string("buttonup"), docWidth / 2, docHeight / 6);
         helpers::sendTextFrame(socket, text, Poco::format(view, itView));
         // Double of the default.
-        size_t timeoutMs = 20000;
+        const std::size_t timeoutMs = 20000;
         response = helpers::getResponseString(socket, protocol, Poco::format(view, itView), timeoutMs);
         LOK_ASSERT_MESSAGE(Poco::format(error, itView, protocol), !response.empty());
 

--- a/test/UnitWOPIDocumentConflict.cpp
+++ b/test/UnitWOPIDocumentConflict.cpp
@@ -58,7 +58,7 @@ public:
         }
     }
 
-    bool filterSendMessage(const char* data, const size_t len, const WSOpCode /* code */,
+    bool filterSendMessage(const char* data, const std::size_t len, const WSOpCode /* code */,
                            const bool /* flush */, int& /*unitReturn*/) override
     {
         std::string message(data, len);

--- a/test/UnitWOPIRenameFile.cpp
+++ b/test/UnitWOPIRenameFile.cpp
@@ -36,7 +36,8 @@ public:
         LOK_ASSERT_EQUAL(std::string("hello"), request.get("X-WOPI-RequestedName"));
     }
 
-    bool filterSendMessage(const char* data, const size_t len, const WSOpCode /* code */, const bool /* flush */, int& /*unitReturn*/) override
+    bool filterSendMessage(const char* data, const std::size_t len, const WSOpCode /* code */,
+                           const bool /* flush */, int& /*unitReturn*/) override
     {
         const std::string message(data, len);
 

--- a/test/UnitWOPISaveAs.cpp
+++ b/test/UnitWOPISaveAs.cpp
@@ -39,7 +39,8 @@ public:
         LOK_ASSERT(std::stoul(request.get("X-WOPI-Size")) > getFileContent().size());
     }
 
-    bool filterSendMessage(const char* data, const size_t len, const WSOpCode /* code */, const bool /* flush */, int& /*unitReturn*/) override
+    bool filterSendMessage(const char* data, const std::size_t len, const WSOpCode /* code */,
+                           const bool /* flush */, int& /*unitReturn*/) override
     {
         const std::string message(data, len);
 

--- a/test/WhiteBoxTests.cpp
+++ b/test/WhiteBoxTests.cpp
@@ -120,53 +120,53 @@ void WhiteBoxTests::testLOOLProtocolFunctions()
     LOK_ASSERT(LOOLProtocol::getTokenKeywordFromMessage(message, "mumble", map, mumble));
     LOK_ASSERT_EQUAL(2, mumble);
 
-    LOK_ASSERT_EQUAL(static_cast<size_t>(1), Util::trimmed("A").size());
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(1), Util::trimmed("A").size());
     LOK_ASSERT_EQUAL(std::string("A"), Util::trimmed("A"));
 
-    LOK_ASSERT_EQUAL(static_cast<size_t>(1), Util::trimmed(" X").size());
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(1), Util::trimmed(" X").size());
     LOK_ASSERT_EQUAL(std::string("X"), Util::trimmed(" X"));
 
-    LOK_ASSERT_EQUAL(static_cast<size_t>(1), Util::trimmed("Y ").size());
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(1), Util::trimmed("Y ").size());
     LOK_ASSERT_EQUAL(std::string("Y"), Util::trimmed("Y "));
 
-    LOK_ASSERT_EQUAL(static_cast<size_t>(1), Util::trimmed(" Z ").size());
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(1), Util::trimmed(" Z ").size());
     LOK_ASSERT_EQUAL(std::string("Z"), Util::trimmed(" Z "));
 
-    LOK_ASSERT_EQUAL(static_cast<size_t>(0), Util::trimmed(" ").size());
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(0), Util::trimmed(" ").size());
     LOK_ASSERT_EQUAL(std::string(""), Util::trimmed(" "));
 
-    LOK_ASSERT_EQUAL(static_cast<size_t>(0), Util::trimmed("   ").size());
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(0), Util::trimmed("   ").size());
     LOK_ASSERT_EQUAL(std::string(""), Util::trimmed("   "));
 
     std::string s;
 
     s = "A";
-    LOK_ASSERT_EQUAL(static_cast<size_t>(1), Util::trim(s).size());
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(1), Util::trim(s).size());
     s = "A";
     LOK_ASSERT_EQUAL(std::string("A"), Util::trim(s));
 
     s = " X";
-    LOK_ASSERT_EQUAL(static_cast<size_t>(1), Util::trim(s).size());
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(1), Util::trim(s).size());
     s = " X";
     LOK_ASSERT_EQUAL(std::string("X"), Util::trim(s));
 
     s = "Y ";
-    LOK_ASSERT_EQUAL(static_cast<size_t>(1), Util::trim(s).size());
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(1), Util::trim(s).size());
     s = "Y ";
     LOK_ASSERT_EQUAL(std::string("Y"), Util::trim(s));
 
     s = " Z ";
-    LOK_ASSERT_EQUAL(static_cast<size_t>(1), Util::trim(s).size());
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(1), Util::trim(s).size());
     s = " Z ";
     LOK_ASSERT_EQUAL(std::string("Z"), Util::trim(s));
 
     s = " ";
-    LOK_ASSERT_EQUAL(static_cast<size_t>(0), Util::trim(s).size());
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(0), Util::trim(s).size());
     s = " ";
     LOK_ASSERT_EQUAL(std::string(""), Util::trim(s));
 
     s = "   ";
-    LOK_ASSERT_EQUAL(static_cast<size_t>(0), Util::trim(s).size());
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(0), Util::trim(s).size());
     s = "   ";
     LOK_ASSERT_EQUAL(std::string(""), Util::trim(s));
 }
@@ -240,7 +240,7 @@ void WhiteBoxTests::testSplitting()
     LOK_ASSERT_EQUAL(std::string("aa"), first);
     LOK_ASSERT_EQUAL(std::string(".bb"), second);
 
-    LOK_ASSERT_EQUAL(static_cast<size_t>(5), Util::getLastDelimiterPosition("aa.bb.cc", 8, '.'));
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(5), Util::getLastDelimiterPosition("aa.bb.cc", 8, '.'));
 
     // Split last, remove delim.
     std::tie(first, second) = Util::splitLast(std::string("aa.bb.cc"), '.', true);
@@ -333,51 +333,51 @@ void WhiteBoxTests::testTokenizer()
     StringVector tokens;
 
     tokens = Util::tokenize("");
-    LOK_ASSERT_EQUAL(static_cast<size_t>(0), tokens.size());
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(0), tokens.size());
 
     tokens = Util::tokenize("  ");
-    LOK_ASSERT_EQUAL(static_cast<size_t>(0), tokens.size());
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(0), tokens.size());
 
     tokens = Util::tokenize("A");
-    LOK_ASSERT_EQUAL(static_cast<size_t>(1), tokens.size());
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(1), tokens.size());
     LOK_ASSERT_EQUAL(std::string("A"), tokens[0]);
 
     tokens = Util::tokenize("  A");
-    LOK_ASSERT_EQUAL(static_cast<size_t>(1), tokens.size());
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(1), tokens.size());
     LOK_ASSERT_EQUAL(std::string("A"), tokens[0]);
 
     tokens = Util::tokenize("A  ");
-    LOK_ASSERT_EQUAL(static_cast<size_t>(1), tokens.size());
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(1), tokens.size());
     LOK_ASSERT_EQUAL(std::string("A"), tokens[0]);
 
     tokens = Util::tokenize(" A ");
-    LOK_ASSERT_EQUAL(static_cast<size_t>(1), tokens.size());
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(1), tokens.size());
     LOK_ASSERT_EQUAL(std::string("A"), tokens[0]);
 
     tokens = Util::tokenize(" A  Z ");
-    LOK_ASSERT_EQUAL(static_cast<size_t>(2), tokens.size());
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(2), tokens.size());
     LOK_ASSERT_EQUAL(std::string("A"), tokens[0]);
     LOK_ASSERT_EQUAL(std::string("Z"), tokens[1]);
 
     tokens = Util::tokenize("\n");
-    LOK_ASSERT_EQUAL(static_cast<size_t>(0), tokens.size());
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(0), tokens.size());
 
     tokens = Util::tokenize(" A  \nZ ");
-    LOK_ASSERT_EQUAL(static_cast<size_t>(1), tokens.size());
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(1), tokens.size());
     LOK_ASSERT_EQUAL(std::string("A"), tokens[0]);
 
     tokens = Util::tokenize(" A  Z\n ");
-    LOK_ASSERT_EQUAL(static_cast<size_t>(2), tokens.size());
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(2), tokens.size());
     LOK_ASSERT_EQUAL(std::string("A"), tokens[0]);
     LOK_ASSERT_EQUAL(std::string("Z"), tokens[1]);
 
     tokens = Util::tokenize(" A  Z  \n ");
-    LOK_ASSERT_EQUAL(static_cast<size_t>(2), tokens.size());
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(2), tokens.size());
     LOK_ASSERT_EQUAL(std::string("A"), tokens[0]);
     LOK_ASSERT_EQUAL(std::string("Z"), tokens[1]);
 
     tokens = Util::tokenize("tile nviewid=0 part=0 width=256 height=256 tileposx=0 tileposy=0 tilewidth=3840 tileheight=3840 ver=-1");
-    LOK_ASSERT_EQUAL(static_cast<size_t>(10), tokens.size());
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(10), tokens.size());
     LOK_ASSERT_EQUAL(std::string("tile"), tokens[0]);
     LOK_ASSERT_EQUAL(std::string("nviewid=0"), tokens[1]);
     LOK_ASSERT_EQUAL(std::string("part=0"), tokens[2]);
@@ -419,21 +419,21 @@ void WhiteBoxTests::testTokenizer()
     std::vector<int> ints;
 
     ints = LOOLProtocol::tokenizeInts(std::string("-1"));
-    LOK_ASSERT_EQUAL(static_cast<size_t>(1), ints.size());
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(1), ints.size());
     LOK_ASSERT_EQUAL(-1, ints[0]);
 
     ints = LOOLProtocol::tokenizeInts(std::string("1,2,3,4"));
-    LOK_ASSERT_EQUAL(static_cast<size_t>(4), ints.size());
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(4), ints.size());
     LOK_ASSERT_EQUAL(1, ints[0]);
     LOK_ASSERT_EQUAL(2, ints[1]);
     LOK_ASSERT_EQUAL(3, ints[2]);
     LOK_ASSERT_EQUAL(4, ints[3]);
 
     ints = LOOLProtocol::tokenizeInts("");
-    LOK_ASSERT_EQUAL(static_cast<size_t>(0), ints.size());
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(0), ints.size());
 
     ints = LOOLProtocol::tokenizeInts(std::string(",,,"));
-    LOK_ASSERT_EQUAL(static_cast<size_t>(0), ints.size());
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(0), ints.size());
 }
 
 void WhiteBoxTests::testTokenizerTokenizeAnyOf()
@@ -442,57 +442,57 @@ void WhiteBoxTests::testTokenizerTokenizeAnyOf()
     const char delimiters[] = "\n\r"; // any of these delimits; and we trim whitespace
 
     tokens = Util::tokenizeAnyOf("", delimiters);
-    LOK_ASSERT_EQUAL(static_cast<size_t>(0), tokens.size());
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(0), tokens.size());
 
     tokens = Util::tokenizeAnyOf("  ", delimiters);
-    LOK_ASSERT_EQUAL(static_cast<size_t>(0), tokens.size());
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(0), tokens.size());
 
     tokens = Util::tokenizeAnyOf("A", delimiters);
-    LOK_ASSERT_EQUAL(static_cast<size_t>(1), tokens.size());
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(1), tokens.size());
     LOK_ASSERT_EQUAL(std::string("A"), tokens[0]);
 
     tokens = Util::tokenizeAnyOf("  A", delimiters);
-    LOK_ASSERT_EQUAL(static_cast<size_t>(1), tokens.size());
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(1), tokens.size());
     LOK_ASSERT_EQUAL(std::string("A"), tokens[0]);
 
     tokens = Util::tokenizeAnyOf("A  ", delimiters);
-    LOK_ASSERT_EQUAL(static_cast<size_t>(1), tokens.size());
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(1), tokens.size());
     LOK_ASSERT_EQUAL(std::string("A"), tokens[0]);
 
     tokens = Util::tokenizeAnyOf(" A ", delimiters);
-    LOK_ASSERT_EQUAL(static_cast<size_t>(1), tokens.size());
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(1), tokens.size());
     LOK_ASSERT_EQUAL(std::string("A"), tokens[0]);
 
     tokens = Util::tokenizeAnyOf(" A  Z ", delimiters);
-    LOK_ASSERT_EQUAL(static_cast<size_t>(1), tokens.size());
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(1), tokens.size());
     LOK_ASSERT_EQUAL(std::string("A  Z"), tokens[0]);
 
     tokens = Util::tokenizeAnyOf("\n", delimiters);
-    LOK_ASSERT_EQUAL(static_cast<size_t>(0), tokens.size());
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(0), tokens.size());
 
     tokens = Util::tokenizeAnyOf("\n\r\r\n", delimiters);
-    LOK_ASSERT_EQUAL(static_cast<size_t>(0), tokens.size());
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(0), tokens.size());
 
     tokens = Util::tokenizeAnyOf(" A  \nZ ", delimiters);
-    LOK_ASSERT_EQUAL(static_cast<size_t>(2), tokens.size());
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(2), tokens.size());
     LOK_ASSERT_EQUAL(std::string("A"), tokens[0]);
     LOK_ASSERT_EQUAL(std::string("Z"), tokens[1]);
 
     tokens = Util::tokenizeAnyOf(" A  Z\n ", delimiters);
-    LOK_ASSERT_EQUAL(static_cast<size_t>(1), tokens.size());
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(1), tokens.size());
     LOK_ASSERT_EQUAL(std::string("A  Z"), tokens[0]);
 
     tokens = Util::tokenizeAnyOf(" A  Z  \n\r\r\n ", delimiters);
-    LOK_ASSERT_EQUAL(static_cast<size_t>(1), tokens.size());
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(1), tokens.size());
     LOK_ASSERT_EQUAL(std::string("A  Z"), tokens[0]);
 
     tokens = Util::tokenizeAnyOf(" A  \n\r\r\n  \r  \n  Z  \n ", delimiters);
-    LOK_ASSERT_EQUAL(static_cast<size_t>(2), tokens.size());
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(2), tokens.size());
     LOK_ASSERT_EQUAL(std::string("A"), tokens[0]);
     LOK_ASSERT_EQUAL(std::string("Z"), tokens[1]);
 
     tokens = Util::tokenizeAnyOf("  \r A  \n  \r  \n  Z  \n ", delimiters);
-    LOK_ASSERT_EQUAL(static_cast<size_t>(2), tokens.size());
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(2), tokens.size());
     LOK_ASSERT_EQUAL(std::string("A"), tokens[0]);
     LOK_ASSERT_EQUAL(std::string("Z"), tokens[1]);
 
@@ -816,9 +816,9 @@ void WhiteBoxTests::testJson()
     Poco::JSON::Object::Ptr object;
     LOK_ASSERT(JsonUtil::parseJSON(testString, object));
 
-    size_t iValue = false;
+    std::size_t iValue = 0;
     JsonUtil::findJSONValue(object, "Size", iValue);
-    LOK_ASSERT_EQUAL(size_t(193551U), iValue);
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(193551), iValue);
 
     bool bValue = false;
     JsonUtil::findJSONValue(object, "DisableCopy", bValue);
@@ -977,7 +977,7 @@ void WhiteBoxTests::testStringVector()
     StringVector vector;
     vector.push_back("a");
     vector.push_back("b");
-    CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(2), vector.size());
+    CPPUNIT_ASSERT_EQUAL(static_cast<std::size_t>(2), vector.size());
     auto it = vector.begin();
     CPPUNIT_ASSERT_EQUAL(std::string("a"), vector.getParam(*it));
     ++it;

--- a/test/countloolkits.hpp
+++ b/test/countloolkits.hpp
@@ -30,9 +30,9 @@ static int countLoolKitProcesses(const int expected)
     const int sleepMs = 50;
 
     // This has to cause waiting for at least COMMAND_TIMEOUT_MS. Tolerate more for safety.
-    const size_t repeat = ((COMMAND_TIMEOUT_MS * 8) / sleepMs);
+    const std::size_t repeat = ((COMMAND_TIMEOUT_MS * 8) / sleepMs);
     int count = getLoolKitProcessCount();
-    for (size_t i = 0; i < repeat; ++i)
+    for (std::size_t i = 0; i < repeat; ++i)
     {
         TST_LOG_APPEND(count << ' ');
         if (count == expected)

--- a/test/lokassert.hpp
+++ b/test/lokassert.hpp
@@ -13,7 +13,7 @@
 
 inline std::ostream& operator<<(std::ostream& os, const std::vector<char>& v)
 {
-    const size_t size = v.size();
+    const std::size_t size = v.size();
     if (size <= 32)
         os << std::string(v.data(), size);
     else

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -220,7 +220,7 @@ bool runClientTests(bool standalone, bool verbose)
         std::cerr << "  (cd test; CPPUNIT_TEST_NAME=\"" << (*failures.begin())->failedTestName() << "\" gdb --args " << cmd << ")\n\n";
 #else
         std::string aLib = UnitBase::get().getUnitLibPath();
-        size_t lastSlash = aLib.rfind('/');
+        std::size_t lastSlash = aLib.rfind('/');
         if (lastSlash != std::string::npos)
             aLib = aLib.substr(lastSlash + 1, aLib.length() - lastSlash - 4) + ".la";
         std::cerr << "(cd test; CPPUNIT_TEST_NAME=\"" << (*failures.begin())->failedTestName() <<

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -69,7 +69,7 @@ ClientSession::ClientSession(
     _serverURL(requestDetails),
     _isTextDocument(false)
 {
-    const size_t curConnections = ++LOOLWSD::NumConnections;
+    const std::size_t curConnections = ++LOOLWSD::NumConnections;
     LOG_INF("ClientSession ctor [" << getName() << "] for URI: [" << _uriPublic.toString()
                                    << "], current number of connections: " << curConnections);
 
@@ -102,7 +102,7 @@ void ClientSession::construct()
 
 ClientSession::~ClientSession()
 {
-    const size_t curConnections = --LOOLWSD::NumConnections;
+    const std::size_t curConnections = --LOOLWSD::NumConnections;
     LOG_INF("~ClientSession dtor [" << getName() << "], current number of connections: " << curConnections);
 
     std::unique_lock<std::mutex> lock(GlobalSessionMapMutex);
@@ -463,7 +463,7 @@ bool ClientSession::_handleInput(const char *buffer, int length)
     }
     else if (tokens.equals(0, "status") || tokens.equals(0, "statusupdate"))
     {
-        assert(firstLine.size() == static_cast<size_t>(length));
+        assert(firstLine.size() == static_cast<std::size_t>(length));
         return forwardToChild(firstLine, docBroker);
     }
     else if (tokens.equals(0, "tile"))
@@ -1068,7 +1068,7 @@ void ClientSession::postProcessCopyPayload(const std::shared_ptr<Message>& paylo
 {
     // Insert our meta origin if we can
     payload->rewriteDataBody([=](std::vector<char>& data) {
-            size_t pos = Util::findInVector(data, "<meta name=\"generator\" content=\"");
+            std::size_t pos = Util::findInVector(data, "<meta name=\"generator\" content=\"");
 
             if (pos == std::string::npos)
                 pos = Util::findInVector(data, "<meta http-equiv=\"content-type\" content=\"text/html;");
@@ -1115,7 +1115,7 @@ bool ClientSession::handleKitToClientMessage(const char* buffer, const int lengt
     {
         const std::string stringMsg(buffer, length);
         LOG_INF(getName() << ": Command: " << stringMsg);
-        const size_t index = stringMsg.find_first_of('{');
+        const std::size_t index = stringMsg.find_first_of('{');
         if (index != std::string::npos)
         {
             const std::string stringJSON = stringMsg.substr(index);
@@ -1393,7 +1393,7 @@ bool ClientSession::handleKitToClientMessage(const char* buffer, const int lengt
 
         postProcessCopyPayload(payload);
 
-        size_t header;
+        std::size_t header;
         for (header = 0; header < payload->size();)
             if (payload->data()[header++] == '\n')
                 break;
@@ -1422,8 +1422,8 @@ bool ClientSession::handleKitToClientMessage(const char* buffer, const int lengt
             if (!empty)
             {
                 oss.write(&payload->data()[header], payload->size() - header);
-                socket->setSocketBufferSize(std::min(payload->size() + 256,
-                                                     size_t(Socket::MaximumSendBufferSize)));
+                socket->setSocketBufferSize(
+                    std::min(payload->size() + 256, std::size_t(Socket::MaximumSendBufferSize)));
             }
 
             socket->send(oss.str());
@@ -1492,7 +1492,7 @@ bool ClientSession::handleKitToClientMessage(const char* buffer, const int lengt
         else if (tokens[0] == "commandvalues:")
         {
             const std::string stringMsg(buffer, length);
-            const size_t index = stringMsg.find_first_of('{');
+            const std::size_t index = stringMsg.find_first_of('{');
             if (index != std::string::npos)
             {
                 const std::string stringJSON = stringMsg.substr(index);
@@ -1522,7 +1522,7 @@ bool ClientSession::handleKitToClientMessage(const char* buffer, const int lengt
         {
             assert(firstLine.size() == static_cast<std::string::size_type>(length));
 
-            const size_t index = firstLine.find_first_of('{');
+            const std::size_t index = firstLine.find_first_of('{');
             const std::string stringJSON = firstLine.substr(index);
             Poco::JSON::Parser parser;
             const Poco::Dynamic::Var result = parser.parse(stringJSON);
@@ -1606,8 +1606,8 @@ void ClientSession::enqueueSendMessage(const std::shared_ptr<Message>& data)
     }
 
     LOG_TRC(getName() << " enqueueing client message " << data->id());
-    size_t sizeBefore = _senderQueue.size();
-    size_t newSize = _senderQueue.enqueue(data);
+    std::size_t sizeBefore = _senderQueue.size();
+    std::size_t newSize = _senderQueue.enqueue(data);
 
     // Track sent tile
     if (tile)
@@ -1646,9 +1646,9 @@ void ClientSession::removeOutdatedTilesOnFly()
     }
 }
 
-size_t ClientSession::countIdenticalTilesOnFly(const TileDesc& tile) const
+std::size_t ClientSession::countIdenticalTilesOnFly(const TileDesc& tile) const
 {
-    size_t count = 0;
+    std::size_t count = 0;
     const std::string tileID = tile.generateID();
     for (const auto& tileItem : _tilesOnFly)
     {

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -210,10 +210,10 @@ public:
     std::string getJailRoot() const;
 
     /// Add a new session. Returns the new number of sessions.
-    size_t addSession(const std::shared_ptr<ClientSession>& session);
+    std::size_t addSession(const std::shared_ptr<ClientSession>& session);
 
     /// Removes a session by ID. Returns the new number of sessions.
-    size_t removeSession(const std::string& id);
+    std::size_t removeSession(const std::string& id);
 
     /// Add a callback to be invoked in our polling thread.
     void addCallback(const SocketPoll::CallbackFn& fn);
@@ -298,7 +298,7 @@ public:
     std::vector<std::shared_ptr<ClientSession>> getSessionsTestOnlyUnsafe();
 
     /// Estimate memory usage / bytes
-    size_t getMemorySize() const;
+    std::size_t getMemorySize() const;
 
     /// Get URL for corresponding download id if registered, or empty string otherwise
     std::string getDownloadURL(const std::string& downloadId);
@@ -371,7 +371,7 @@ private:
     bool haveAnotherEditableSession(const std::string& id) const;
 
     /// Loads a new session and adds to the sessions container.
-    size_t addSessionInternal(const std::shared_ptr<ClientSession>& session);
+    std::size_t addSessionInternal(const std::shared_ptr<ClientSession>& session);
 
     /// Starts the Kit <-> DocumentBroker shutdown handshake
     void disconnectSessionInternal(const std::string& id);
@@ -452,7 +452,7 @@ private:
 
     /// Versioning is used to prevent races between
     /// painting and invalidation.
-    std::atomic<size_t> _tileVersion;
+    std::atomic<std::size_t> _tileVersion;
 
     int _debugRenderedTileCount;
 
@@ -497,7 +497,7 @@ public:
     void setLoaded() override;
 
     /// How many live conversions are running.
-    static size_t getInstanceCount();
+    static std::size_t getInstanceCount();
 
     /// Cleanup path and its parent
     static void removeFile(const std::string &uri);

--- a/wsd/ServerURL.hpp
+++ b/wsd/ServerURL.hpp
@@ -48,7 +48,7 @@ public:
         if (url.size() <= 0)
             return;
 
-        size_t pos = url.find("://");
+        std::size_t pos = url.find("://");
         if (pos != std::string::npos) {
             pos += 3;
             auto hostEndPos = url.find('/', pos);

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -50,8 +50,6 @@
 #include <common/FileUtil.hpp>
 #include <common/JsonUtil.hpp>
 
-using std::size_t;
-
 bool StorageBase::FilesystemEnabled;
 bool StorageBase::WopiEnabled;
 bool StorageBase::SSLAsScheme = true;
@@ -650,7 +648,7 @@ std::unique_ptr<WopiStorage::WOPIFileInfo> WopiStorage::getWOPIFileInfo(const Au
         else
             LOG_DBG("WOPI::CheckFileInfo (" << callDuration.count() * 1000. << " ms): " << wopiResponse);
 
-        size_t size = 0;
+        std::size_t size = 0;
         std::string filename, ownerId, lastModifiedTime;
 
         JsonUtil::findJSONValue(object, "Size", size);
@@ -1041,9 +1039,9 @@ WopiStorage::saveLocalFileToStorage(const Authorization& auth, const std::string
                 std::vector<char> buffer(8 * saveAsFilename.size());
 
                 char* in = &input[0];
-                size_t in_left = input.size();
+                std::size_t in_left = input.size();
                 char* out = &buffer[0];
-                size_t out_left = buffer.size();
+                std::size_t out_left = buffer.size();
 
                 if (iconv(cd, &in, &in_left, &out, &out_left) == (size_t) -1)
                     LOG_ERR("Failed to convert '" << saveAsFilename << "' to UTF-7, using '" << suggestedTarget << "'.");

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -70,7 +70,7 @@ public:
         FileInfo(const std::string& filename,
                  const std::string& ownerId,
                  const std::chrono::system_clock::time_point& modifiedTime,
-                 size_t /*size*/)
+                 std::size_t /*size*/)
             : _filename(filename),
               _ownerId(ownerId),
               _modifiedTime(modifiedTime)

--- a/wsd/TileDesc.hpp
+++ b/wsd/TileDesc.hpp
@@ -213,7 +213,7 @@ public:
 
         TileWireId oldWireId = 0;
         TileWireId wireId = 0;
-        for (size_t i = 0; i < tokens.size(); ++i)
+        for (std::size_t i = 0; i < tokens.size(); ++i)
         {
             if (LOOLProtocol::getTokenUInt32(tokens[i], "oldwid", oldWireId))
                 ;
@@ -311,7 +311,7 @@ private:
         StringVector oldWireIdTokens(Util::tokenize(oldWireIds, ','));
         StringVector wireIdTokens(Util::tokenize(wireIds, ','));
 
-        const size_t numberOfPositions = positionXtokens.size();
+        const std::size_t numberOfPositions = positionXtokens.size();
 
         // check that the comma-separated strings have the same number of elements
         if (numberOfPositions != positionYtokens.size() ||
@@ -323,7 +323,7 @@ private:
             throw BadArgumentException("Invalid tilecombine descriptor. Unequal number of tiles in parameters.");
         }
 
-        for (size_t i = 0; i < numberOfPositions; ++i)
+        for (std::size_t i = 0; i < numberOfPositions; ++i)
         {
             int x = 0;
             if (!LOOLProtocol::stringToInteger(positionXtokens[i], x))


### PR DESCRIPTION
size_t in C and in C++ are not necessarily the same
type. The C++ size_t is in the std namespace. Since
we do include many C headers, and indeed some C++
runtime headers do define size_t for backwards
compatibility, it's easy to mix and match the two
types.

Also, 'using std::size_t;' isn't a great practice,
so removed.

This is not exhaustive, just some low-hanging cases.

Change-Id: I85a36b6fd1acd204274b1869de9bcb94c8b3cf13
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
