### PR TITLE
Android: detect large screen devices for tablets

### DIFF
--- a/android/lib/src/main/java/org/libreoffice/androidlib/LOActivity.java
+++ b/android/lib/src/main/java/org/libreoffice/androidlib/LOActivity.java
@@ -811,6 +811,13 @@ public class LOActivity extends AppCompatActivity {
         System.loadLibrary("androidapp");
     }
 
+    /**
+     * Used for determining tablets
+     */
+    public boolean isLargeScreen() {
+        return getResources().getBoolean(R.bool.isLargeScreen);
+    }
+
     public SharedPreferences getPrefs() {
         return sPrefs;
     }

--- a/android/lib/src/main/res/values-large/large-screen.xml
+++ b/android/lib/src/main/res/values-large/large-screen.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="isLargeScreen">true</bool>
+</resources>

--- a/android/lib/src/main/res/values/values.xml
+++ b/android/lib/src/main/res/values/values.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="isLargeScreen">false</bool>
+</resources>


### PR DESCRIPTION
There's no built in detection for tablets and
the suggested way to to it by adding resource values
for large screen and checking it.

Change-Id: Ic4a949033e04d244dbb6d441df516203639d5c48
Signed-off-by: mert <mert.tumer@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

