### PR TITLE
Sync loolwsd.service between '/' and 'debian/'

### DIFF
--- a/debian/loolwsd.service
+++ b/debian/loolwsd.service
@@ -5,9 +5,20 @@ After=network.target
 [Service]
 EnvironmentFile=-/etc/sysconfig/loolwsd
 ExecStart=/usr/bin/loolwsd --version --o:sys_template_path=/opt/lool/systemplate --o:child_root_path=/opt/lool/child-roots --o:file_server_root_path=/usr/share/loolwsd
+KillSignal=SIGINT
+TimeoutStopSec=120
 User=lool
 KillMode=control-group
 Restart=always
+LimitNOFILE=infinity:infinity
+
+ProtectSystem=strict
+ReadWritePaths=/opt/lool
+
+ProtectHome=yes
+PrivateTmp=yes
+ProtectControlGroups=yes
+CapabilityBoundingSet=CAP_FOWNER CAP_MKNOD CAP_SYS_CHROOT
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
One is used in Debian-based installs, other is used in the rest.

Signed-off-by: Aron Budea <aron.budea@collabora.com>
Change-Id: If21c5d70cb8bb738931c3cd05bd4c5c732f394f7

* Target version: master 

### Checklist

- [X] Code is properly formatted
- [X] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

