### PR TITLE
Replace all `__linux` in CPP conditions with `__linux__`.

### DIFF
--- a/common/FileUtil.cpp
+++ b/common/FileUtil.cpp
@@ -14,7 +14,7 @@
 #include <ftw.h>
 #include <stdexcept>
 #include <sys/time.h>
-#ifdef __linux
+#ifdef __linux__
 #include <sys/vfs.h>
 #elif defined IOS
 #import <Foundation/Foundation.h>
@@ -482,7 +482,7 @@ namespace FileUtil
 #endif
         constexpr int64_t ENOUGH_SPACE = gb*1024*1024*1024;
 
-#if defined(__linux ) || defined(__FreeBSD__)
+#if defined(__linux__) || defined(__FreeBSD__)
         struct statfs sfs;
         if (statfs(path.c_str(), &sfs) == -1)
             return true;

--- a/common/JailUtil.cpp
+++ b/common/JailUtil.cpp
@@ -13,7 +13,7 @@
 #include <sys/types.h>
 #include <fcntl.h>
 #include <unistd.h>
-#ifdef __linux
+#ifdef __linux__
 #include <sys/sysmacros.h>
 #endif
 

--- a/common/Log.cpp
+++ b/common/Log.cpp
@@ -7,7 +7,7 @@
 
 #include <config.h>
 
-#ifdef __linux
+#ifdef __linux__
 #include <sys/prctl.h>
 #include <sys/syscall.h>
 #endif

--- a/common/Seccomp.cpp
+++ b/common/Seccomp.cpp
@@ -15,7 +15,7 @@
 
 #include <dlfcn.h>
 #include <ftw.h>
-#ifdef __linux
+#ifdef __linux__
 #include <linux/audit.h>
 #include <linux/filter.h>
 #if DISABLE_SECCOMP == 0
@@ -26,7 +26,7 @@
 #include <sys/capability.h>
 #include <sys/prctl.h>
 #include <sys/syscall.h>
-#endif // __linux
+#endif // __linux__
 #include <sys/resource.h>
 #include <sys/time.h>
 #include <unistd.h>

--- a/common/Util.cpp
+++ b/common/Util.cpp
@@ -11,7 +11,7 @@
 
 #include <csignal>
 #include <sys/poll.h>
-#ifdef __linux
+#ifdef __linux__
 #  include <sys/prctl.h>
 #  include <sys/syscall.h>
 #  include <sys/vfs.h>
@@ -525,7 +525,7 @@ namespace Util
         int res = setpriority(PRIO_PROCESS, pid, prio);
         LOG_TRC("Lowered kit [" << (int)pid << "] priority: " << prio << " with result: " << res);
 
-#ifdef __linux
+#ifdef __linux__
         // rely on Linux thread-id priority setting to drop this thread' priority
         pid_t tid = getThreadId();
         res = setpriority(PRIO_PROCESS, tid, prio);
@@ -533,7 +533,7 @@ namespace Util
 #endif
     }
 
-#endif
+#endif // !MOBILEAPP
 
     std::string replace(std::string result, const std::string& a, const std::string& b)
     {
@@ -577,7 +577,7 @@ namespace Util
         // Set the new name.
         strncpy(ThreadName, s.c_str(), sizeof(ThreadName) - 1);
         ThreadName[sizeof(ThreadName) - 1] = '\0';
-#ifdef __linux
+#ifdef __linux__
         if (prctl(PR_SET_NAME, reinterpret_cast<unsigned long>(s.c_str()), 0, 0, 0) != 0)
             LOG_SYS("Cannot set thread name of "
                     << getThreadId() << " (" << std::hex << std::this_thread::get_id() << std::dec
@@ -599,7 +599,7 @@ namespace Util
         // Main process and/or not set yet.
         if (ThreadName[0] == '\0')
         {
-#ifdef __linux
+#ifdef __linux__
             // prctl(2): The buffer should allow space for up to 16 bytes; the returned string will be null-terminated.
             if (prctl(PR_GET_NAME, reinterpret_cast<unsigned long>(ThreadName), 0, 0, 0) != 0)
                 strncpy(ThreadName, "<noid>", sizeof(ThreadName) - 1);
@@ -614,7 +614,7 @@ namespace Util
         return ThreadName;
     }
 
-#ifdef __linux
+#ifdef __linux__
     static thread_local pid_t ThreadTid = 0;
 
     pid_t getThreadId()
@@ -623,7 +623,7 @@ namespace Util
 #endif
     {
         // Avoid so many redundant system calls
-#ifdef __linux
+#ifdef __linux__
         if (!ThreadTid)
             ThreadTid = ::syscall(SYS_gettid);
         return ThreadTid;

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -13,7 +13,7 @@
 #include <config.h>
 
 #include <dlfcn.h>
-#ifdef __linux
+#ifdef __linux__
 #include <ftw.h>
 #include <sys/capability.h>
 #include <sys/sysmacros.h>
@@ -2380,7 +2380,7 @@ void lokit_main(
         setupKitEnvironment(userInterface);
 #endif
 
-#if defined(__linux) && !defined(__ANDROID__)
+#if defined(__linux__) && !defined(__ANDROID__)
         Poco::URI userInstallationURI("file", LO_PATH);
         LibreOfficeKit *kit = lok_init_2(LO_PATH "/program", userInstallationURI.toString().c_str());
 #else

--- a/net/FakeSocket.hpp
+++ b/net/FakeSocket.hpp
@@ -13,7 +13,7 @@
 
 #include <poll.h>
 
-#ifndef __linux
+#ifndef __linux__
 #ifndef SOCK_NONBLOCK
 #define SOCK_NONBLOCK 0x100
 #endif

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -3881,7 +3881,7 @@ int LOOLWSD::innerMain()
 #endif
 
 #if !MOBILEAPP
-#  ifdef __linux
+#  ifdef __linux__
     // down-pay all the forkit linking cost once & early.
     setenv("LD_BIND_NOW", "1", 1);
 #  endif


### PR DESCRIPTION
Signed-off-by: Gleb Popov <6yearold@gmail.com>
Change-Id: If3e213b1cf1f3c4ab960276fc6edfb71f9416420

According to https://sourceforge.net/p/predef/wiki/OperatingSystems/ both `__linux` and `linux` are deprecated definitions, while `__linux__` is the POSIX-compliant one and should be preferred.

### Checklist

- [X] Code is properly formatted
- [X] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

