### PR TITLE
Make AutoSpellChecking option state remembered on first start

### DIFF
--- a/common/Session.cpp
+++ b/common/Session.cpp
@@ -186,6 +186,11 @@ void Session::parseDocOptions(const StringVector& tokens, int& part, std::string
             _deviceFormFactor = value;
             ++offset;
         }
+        else if (name == "spellOnline")
+        {
+            _spellOnline = value;
+            ++offset;
+        }
     }
 
     Util::mapAnonymized(_userId, _userIdAnonym);

--- a/common/Session.hpp
+++ b/common/Session.hpp
@@ -221,6 +221,8 @@ public:
 
     const std::string& getDeviceFormFactor() const { return _deviceFormFactor; }
 
+    const std::string& getSpellOnline() const { return _spellOnline; }
+
 protected:
     Session(const std::shared_ptr<ProtocolHandlerInterface> &handler,
             const std::string& name, const std::string& id, bool readonly);
@@ -318,6 +320,9 @@ private:
 
     /// The form factor of the device where the client is running: desktop, tablet, mobile.
     std::string _deviceFormFactor;
+
+    /// The start value of Auto Spell Checking wheter it is enabled or disabled on start.
+    std::string _spellOnline;
 };
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1160,6 +1160,7 @@ private:
         const bool haveDocPassword = session->getHaveDocPassword();
         const std::string& lang = session->getLang();
         const std::string& deviceFormFactor = session->getDeviceFormFactor();
+        std::string spellOnline = "";
 
         std::string options;
         if (!lang.empty())
@@ -1236,6 +1237,7 @@ private:
             // Only save the options on opening the document.
             // No support for changing them after opening a document.
             _renderOpts = renderOpts;
+            spellOnline = session->getSpellOnline();
         }
         else
         {
@@ -1267,11 +1269,12 @@ private:
         }
 
         LOG_INF("Initializing for rendering session [" << sessionId << "] on document url [" <<
-                anonymizeUrl(_url) << "] with: [" << makeRenderParams(_renderOpts, userNameAnonym) << "].");
+                anonymizeUrl(_url) << "] with: [" << makeRenderParams(_renderOpts, userNameAnonym, spellOnline) << "].");
 
         // initializeForRendering() should be called before
         // registerCallback(), as the previous creates a new view in Impress.
-        const std::string renderParams = makeRenderParams(_renderOpts, userName);
+        const std::string renderParams = makeRenderParams(_renderOpts, userName, spellOnline);
+
         _loKitDocument->initializeForRendering(renderParams.c_str());
 
         const int viewId = _loKitDocument->getView();
@@ -1371,7 +1374,16 @@ private:
         return false;
     }
 
-    static std::string makeRenderParams(const std::string& renderOpts, const std::string& userName)
+    template <typename T>
+    static Object::Ptr makePropertyValue(const std::string& type, const T& val)
+    {
+        Object::Ptr obj = new Object();
+        obj->set("type", type);
+        obj->set("value", val);
+        return obj;
+    }
+
+    static std::string makeRenderParams(const std::string& renderOpts, const std::string& userName, const std::string& spellOnline)
     {
         Object::Ptr renderOptsObj;
 
@@ -1390,12 +1402,15 @@ private:
         // Append name of the user, if any, who opened the document to rendering options
         if (!userName.empty())
         {
-            Object::Ptr authorObj = new Object();
-            authorObj->set("type", "string");
             std::string decodedUserName;
             URI::decode(userName, decodedUserName);
-            authorObj->set("value", decodedUserName);
-            renderOptsObj->set(".uno:Author", authorObj);
+            renderOptsObj->set(".uno:Author", makePropertyValue("string", decodedUserName));
+        }
+
+        if (!spellOnline.empty())
+        {
+            bool bSet = (spellOnline != "false");
+            renderOptsObj->set(".uno:SpellOnline", makePropertyValue("boolean", bSet));
         }
 
         if (renderOptsObj)

--- a/loleaflet/js/global.js
+++ b/loleaflet/js/global.js
@@ -782,7 +782,10 @@
 				if (window.deviceFormFactor) {
 					msg += ' deviceFormFactor=' + window.deviceFormFactor;
 				}
-
+				if (window.isLocalStorageAllowed) {
+					var spellOnline = window.localStorage.getItem('SpellOnline');
+					msg += ' spellOnline=' +  spellOnline;
+				}
 				global.socket.send(msg);
 			}
 		};

--- a/loleaflet/src/control/Toolbar.js
+++ b/loleaflet/src/control/Toolbar.js
@@ -177,6 +177,18 @@ L.Map.include({
 				break;
 			}
 		}
+		if (command.startsWith('.uno:SpellOnline')) {
+			var map = this;
+			var val = map['stateChangeHandler'].getItemValue('.uno:SpellOnline');
+
+			// proceed if the toggle button is pressed
+			if (val && (json === undefined || json === null)) {
+				 // because it is toggle, state has to be the opposite
+				var state = !(val === 'true');
+				if (window.isLocalStorageAllowed)
+					window.localStorage.setItem('SpellOnline', state);
+			}
+		}
 
 		if (this.dialog.hasOpenedDialog())
 			this.dialog.blinkOpenDialog();

--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -201,6 +201,10 @@ L.Socket = L.Class.extend({
 			};
 			msg += ' options=' + JSON.stringify(options);
 		}
+		if (window.isLocalStorageAllowed) {
+			var spellOnline = window.localStorage.getItem('SpellOnline');
+			msg += ' spellOnline=' +  spellOnline;
+		}
 
 		this._doSend(msg);
 		for (var i = 0; i < this._msgQueue.length; i++) {

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -825,6 +825,11 @@ bool ClientSession::loadDocument(const char* /*buffer*/, int /*length*/,
             oss << " deviceFormFactor=" << getDeviceFormFactor();
         }
 
+        if (!getSpellOnline().empty())
+        {
+            oss << " spellOnline=" << getSpellOnline();
+        }
+
         if (!getWatermarkText().empty())
         {
             std::string encodedWatermarkText;


### PR DESCRIPTION
Change-Id: I25823025e35ba6f580b03834979fb0bea616bcc1
Signed-off-by: mert <mert.tumer@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

