### PR TITLE
fix auto-hiding shelf can obscure the FAB on ChromeOS

### DIFF
--- a/android/app/src/main/java/org/libreoffice/androidapp/ui/LibreOfficeUIActivity.java
+++ b/android/app/src/main/java/org/libreoffice/androidapp/ui/LibreOfficeUIActivity.java
@@ -80,6 +80,7 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.app.AppCompatDelegate;
 import androidx.appcompat.widget.Toolbar;
+import androidx.constraintlayout.widget.ConstraintLayout;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 import androidx.core.view.ViewCompat;
@@ -398,6 +399,14 @@ public class LibreOfficeUIActivity extends AppCompatActivity implements Settings
     /** Initialize the FloatingActionButton. */
     private void setupFloatingActionButton() {
         editFAB = findViewById(R.id.editFAB);
+        if (LOActivity.isChromeOS(this)) {
+            int dp = (int)getResources().getDisplayMetrics().density;
+            ConstraintLayout.LayoutParams layoutParams = (ConstraintLayout.LayoutParams)editFAB.getLayoutParams();
+            layoutParams.leftToLeft = ConstraintLayout.LayoutParams.PARENT_ID;
+            layoutParams.bottomMargin = dp * 24;
+            editFAB.setCustomSize(dp * 70);
+        }
+
         editFAB.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {


### PR DESCRIPTION
1) FAB button size has been increased to 70dp (56dp default)
2) Given 24dp margin from bottom
3) Its now placed in the bottom-center of the screen

This way it is now visible clearly with auto-hiding shelf
and ChromeOS notifications

Change-Id: Ia53c6621f2758366d04a79fe19f5cb89aaa80de5
Signed-off-by: mert <mert.tumer@collabora.com>
