### PR TITLE
Don't initialize Menubar button for tablets on Notebookbar

### DIFF
--- a/loleaflet/src/control/Control.NotebookbarBuilder.js
+++ b/loleaflet/src/control/Control.NotebookbarBuilder.js
@@ -639,6 +639,8 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 	},
 
 	_menubarControl: function(parentContainer, data, builder) {
+		if (window.ThisIsAMobileApp && window.mode.isTablet())
+			return;
 		var control = builder._unoToolButton(parentContainer, data, builder);
 
 		$(control.container).unbind('click');


### PR DESCRIPTION
Normally when waited enough before pressing the blue edit button
it will be removed but tapping on the button early before the
notebookbar initialization it stays visible.

Change-Id: If3536702319f029232ebd53315796f1618f56241
Signed-off-by: mert <mert.tumer@collabora.com>
(cherry picked from commit 1fc42dc390cada852bcafb74c9aab7cf7763f69e)
Signed-off-by: Tor Lillqvist <tml@collabora.com>
