### PR TITLE
Android: Fix Cut/Copy/Paste keyboard shortcuts not working

### DIFF
--- a/android/lib/src/main/java/org/libreoffice/androidlib/LOActivity.java
+++ b/android/lib/src/main/java/org/libreoffice/androidlib/LOActivity.java
@@ -1262,7 +1262,7 @@ public class LOActivity extends AppCompatActivity {
 
                         if (clipboardData != null) {
                             LOActivity.this.setClipboardContent(clipboardData);
-                            LOActivity.this.postUnoCommand(".uno:Paste", null, false);
+                            return true;
                         } else {
                             // Couldn't get data from the clipboard file, but we can still paste html
                             byte[] htmlByteArray = html.getBytes(Charset.forName("UTF-8"));

--- a/loleaflet/src/map/handler/Map.Keyboard.js
+++ b/loleaflet/src/map/handler/Map.Keyboard.js
@@ -500,20 +500,21 @@ L.Map.Keyboard = L.Handler.extend({
 
 			return false;
 		}
-
-		if (window.ThisIsTheiOSApp) {
+		/* Without specifying the key type, the messages are sent twice (both keydown/up) */
+		if (e.type === 'keydown' &&
+			(window.ThisIsTheiOSApp || window.ThisIsTheAndroidApp)) {
 			if (e.key === 'c' || e.key === 'C') {
 				this._map._socket.sendMessage('uno .uno:Copy');
-				return true;
 			}
 			else if (e.key === 'v' || e.key === 'V') {
 				this._map._socket.sendMessage('uno .uno:Paste');
-				return true;
 			}
 			else if (e.key === 'x' || e.key === 'X') {
 				this._map._socket.sendMessage('uno .uno:Cut');
-				return true;
 			}
+			if (window.ThisIsTheAndroidApp)
+				e.preventDefault();
+			return true;
 		}
 
 		switch (e.keyCode) {


### PR DESCRIPTION
This patch will apply for Chromebook cases and also
other keyboard connected android devices as well.

Change-Id: I4d88a65ec49935640be6513498b87718b50977f5
Signed-off-by: mert <mert.tumer@collabora.com>
