### PR TITLE
leaflet: avoid wrong column resizing in mobile

### DIFF
--- a/loleaflet/src/control/Control.ColumnHeader.js
+++ b/loleaflet/src/control/Control.ColumnHeader.js
@@ -561,12 +561,14 @@ L.Control.ColumnHeader = L.Control.Header.extend({
 	},
 
 	onDragMove: function (item, start, offset, e) {
-		if (this._vertLine) {
+		if (this._vertLine && offset) {
 			this._vertLine.setLatLngs(this._getVertLatLng(start, offset, e));
 		}
 	},
 
 	onDragEnd: function (item, start, offset, e) {
+		if (!offset)
+			return;
 		var end = new L.Point(e.clientX + offset.x, e.clientY);
 		var distance = this._map._docLayer._pixelsToTwips(end.subtract(start));
 

--- a/loleaflet/src/control/Control.Header.js
+++ b/loleaflet/src/control/Control.Header.js
@@ -291,7 +291,7 @@ L.Control.Header = L.Control.extend({
 		this._tickMap.forEachGap(function(gap) {
 			if (position >= gap.start && position < gap.end) {
 				var resizeAreaStart = Math.max(gap.start, gap.end - 3);
-				if (that.isHeaderSelected(gap.index)) {
+				if (that.isHeaderSelected(gap.index) || window.mode.isMobile()) {
 					resizeAreaStart = gap.end - that._resizeHandleSize;
 				}
 				var isMouseOverResizeArea = (position > resizeAreaStart);
@@ -312,6 +312,9 @@ L.Control.Header = L.Control.extend({
 
 		var result = this._entryAtPoint(this._hammerEventToCanvasPos(this._canvas, event));
 		if (!result)
+			return false;
+
+		if (!result.hit)
 			return false;
 
 		this._mouseOverEntry = result.entry;


### PR DESCRIPTION
Signed-off-by: Pranam Lashkari <lpranam@collabora.com>
Change-Id: I12a071877548dda02a5c6199ade570c74f8dc7ee


* Resolves: # <!-- related github issue -->
* Target version: distro/collabora/co-4-2 

### Summary
problem: in mobile we could resize the column from anywhere in entier header

This caused problem because of the small size we may resize adjacent column

now allow user only to resize from resizing area even if resizing handler are invisible


### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

