### PR TITLE
Toolbar: differentiate close btn as a top action from the sidebar toggles..

### DIFF
--- a/loleaflet/css/toolbar.css
+++ b/loleaflet/css/toolbar.css
@@ -258,26 +258,23 @@ td[id^='tb_editbar_item_sidebar']{
 	top: 0px;
 	width: 32px;
 	height: 32px;
-	background-color: white;
+	background-color: transparent;
 	display: none;
 }
 
 #closebutton {
-	width: 18px;
-	height: 18px;
-	border: 1px solid;
-	border-color: transparent;
-	border-radius: 5px;
-	margin: 8px;
+	width: 22px;
+	height: 22px;
+	margin: 6px;
+	border-radius: 20px;
+	border: none;
+	box-shadow: inset 0 0 1px black;
+	background: url('images/closedoc.svg') no-repeat center white !important;
 }
 
 #closebutton:hover {
 	border-color: #ccc;
 	background-color: #eee;
-}
-
-.closebuttonimage {
-	background: url('images/closedoc.svg') no-repeat center !important;
 }
 
 #tb_actionbar_item_left {

--- a/loleaflet/images/closedoc.svg
+++ b/loleaflet/images/closedoc.svg
@@ -7,11 +7,13 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   viewBox="0 0 24 24"
+   viewBox="0 0 22 22"
    id="svg2"
    version="1.1"
-   inkscape:version="0.91 r13725"
-   sodipodi:docname="lc_closedoc.svg">
+   inkscape:version="1.0 (4035a4f, 2020-05-01)"
+   sodipodi:docname="closedoc.svg"
+   width="22"
+   height="22">
   <metadata
      id="metadata14">
     <rdf:RDF>
@@ -20,6 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -34,32 +37,34 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1073"
-     inkscape:window-height="480"
+     inkscape:window-width="1920"
+     inkscape:window-height="1021"
      id="namedview10"
      showgrid="false"
-     inkscape:zoom="9.8333333"
-     inkscape:cx="12"
-     inkscape:cy="12"
-     inkscape:window-x="1920"
+     inkscape:zoom="13.906433"
+     inkscape:cx="1.7019796"
+     inkscape:cy="14.367661"
+     inkscape:window-x="0"
      inkscape:window-y="30"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="svg2" />
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2"
+     inkscape:document-rotation="0" />
   <g
      fill="none"
      stroke="#e68497"
      stroke-linecap="round"
      stroke-linejoin="round"
-     stroke-width="2"
+     stroke-width="1.2"
      id="g4"
-     style="fill:#333333;stroke:#333333">
+     style="fill:#4d4d4d;stroke:#4d4d4d;stroke-width:4;stroke-miterlimit:4;stroke-dasharray:none;fill-opacity:1;stroke-opacity:1"
+     transform="matrix(0.49999999,0,0,0.49999999,5.0000001,5.0000001)">
     <path
-       d="m4 20 16-16"
+       d="M 4,20 20,4"
        id="path6"
-       style="fill:#333333;stroke:#333333" />
+       style="fill:#4d4d4d;stroke:#4d4d4d;stroke-width:4;stroke-miterlimit:4;stroke-dasharray:none;fill-opacity:1;stroke-opacity:1" />
     <path
-       d="m20 20-16-15.9999998"
+       d="M 20,20 4,4.0000002"
        id="path8"
-       style="fill:#333333;stroke:#333333" />
+       style="fill:#4d4d4d;stroke:#4d4d4d;stroke-width:4;stroke-miterlimit:4;stroke-dasharray:none;fill-opacity:1;stroke-opacity:1" />
   </g>
 </svg>


### PR DESCRIPTION
- Fix redundant values and declarations
- while keeping the style the same across different platforms (desktop, tablet)
- while account for different parent's background (notebookbar)

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I501cb0137282682980864d980571429ded8cf6c1
