### PR TITLE
cypress_test/impress: Add test for strikethrough font shape

### DIFF
--- a/cypress_test/integration_tests/desktop/impress/top_toolbar_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/top_toolbar_spec.js
@@ -53,6 +53,16 @@ describe('Top toolbar tests.', function() {
 			.should('have.attr', 'text-decoration', 'underline');
 	});
 
+	it('Apply strikethrough on text shape.', function() {
+		cy.get('#tb_editbar_item_strikeout')
+			.click();
+
+		impressHelper.triggerNewSVGForShapeInTheCenter();
+
+		cy.get('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph')
+			.should('have.attr', 'text-decoration', 'line-through');
+	});
+
 	it('Apply left/right alignment on text seleced text.', function() {
 		cy.get('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition')
 			.should('have.attr', 'x', '1400');


### PR DESCRIPTION
Add  Cypress test for strikethrough font shape on Impress.

Signed-off-by: Thais Vieira <thais.vieira@collabora.com>
Change-Id: I5c83c95aa968334a82a7ae7a3bb8fc1c7bba9b7c


