### PR TITLE
Do not try to convert std::thread::id to integer value.

### DIFF
--- a/common/Log.cpp
+++ b/common/Log.cpp
@@ -194,22 +194,11 @@ namespace Log
         *pos++ = '-';
 
         // Thread ID.
-        const long osTid = Util::getThreadId();
-        if (osTid > 99999)
-        {
-            if (osTid > 999999)
-                pos = to_ascii(pos, osTid);
-            else
-            {
-                to_ascii_fixed<6>(pos, osTid);
-                pos += 6;
-            }
-        }
-        else
-        {
-            to_ascii_fixed<5>(pos, osTid);
-            pos += 5;
-        }
+        auto osTid = Util::getThreadId();
+        std::stringstream ss;
+        ss << osTid;
+        pos = strcopy(ss.str().c_str(), pos);
+
         *pos++ = ' ';
 #endif
 

--- a/common/Log.cpp
+++ b/common/Log.cpp
@@ -194,10 +194,30 @@ namespace Log
         *pos++ = '-';
 
         // Thread ID.
-        auto osTid = Util::getThreadId();
+        const auto osTid = Util::getThreadId();
+#if defined(__linux__)
+        // On Linux osTid is pid_t.
+        if (osTid > 99999)
+        {
+            if (osTid > 999999)
+                pos = to_ascii(pos, osTid);
+            else
+            {
+                to_ascii_fixed<6>(pos, osTid);
+                pos += 6;
+            }
+        }
+        else
+        {
+            to_ascii_fixed<5>(pos, osTid);
+            pos += 5;
+        }
+#else
+        // On all other systems osTid is std::thread::id.
         std::stringstream ss;
         ss << osTid;
         pos = strcopy(ss.str().c_str(), pos);
+#endif
 
         *pos++ = ' ';
 #endif

--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -26,7 +26,7 @@
 
 #include <memory.h>
 
-#ifndef __linux
+#ifndef __linux__
 #include <thread>
 #endif
 
@@ -165,7 +165,7 @@ namespace Util
 
     const char *getThreadName();
 
-#ifdef __linux
+#ifdef __linux__
     pid_t getThreadId();
 #else
     std::thread::id getThreadId();


### PR DESCRIPTION
This is not allowed by the standard and libc++ is more stricter than libstdc++ on that matter.

Luckily, the conversion is used to turn it into a string, so just use stringstream to convert the thread::id directly.

Signed-off-by: Gleb Popov <6yearold@gmail.com>
Change-Id: Iea1a844a086b7fe7ed4703fd06e1d538d5d0bc43

* Target version: master 

### TODO

I didn't run-test this, as LOOL doesn't yet run on FreeBSD. This patch needs checking that I didn't broke anything.

### Checklist

- [X] Code is properly formatted
- [X] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

