### PR TITLE
Loleaflet: contextMenu: Fix single action entry style

### DIFF
--- a/loleaflet/css/loleaflet.css
+++ b/loleaflet/css/loleaflet.css
@@ -326,8 +326,8 @@ body {
 	content: '\2713';
 }
 
-.context-menu-hover
-{
+.context-menu-hover,
+.context-menu-hover > span > a {
 	background-color: #0b87e7 !important;
 	color: #fff !important;
 }


### PR DESCRIPTION
E.g.: right click; paste (single entry with action) was not changing color

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ib3889859f4210ac01a1c308ac15e383a511aa067
