### PR TITLE
cypress: avoid unintentional resizing.

### DIFF
--- a/loleaflet/src/control/Control.Header.js
+++ b/loleaflet/src/control/Control.Header.js
@@ -419,6 +419,10 @@ L.Control.Header = L.Control.extend({
 			this._lastMouseOverIndex = this._mouseOverEntry.index; // used by context menu
 		}
 
+		// cypress mobile emulation sometimes triggers resizing unintentionally.
+		if (L.Browser.cypressTest)
+			return false;
+
 		if (isMouseOverResizeArea !== this._hitResizeArea) {
 			if (isMouseOverResizeArea) {
 				L.DomEvent.off(this._canvas, 'click', this._onClick, this);


### PR DESCRIPTION
We use simple cy.click() on mobile, we might
get a better result to use a different way for
tap on document in the future.

Change-Id: I4b0c6989aaf105ae79be930ffc54898414efb92a
Signed-off-by: Tamás Zolnai <tamas.zolnai@collabora.com>
(cherry picked from commit db1584c664fd153bff66a6c41bc1e850bd766b31)