### PR TITLE
pure re-factor, creating Buffer class to wrap vector.

### DIFF
--- a/net/Buffer.hpp
+++ b/net/Buffer.hpp
@@ -35,7 +35,9 @@ public:
 
     const char *getBlock() const
     {
-        return &_buffer[_offset];
+        if (_size)
+            return &_buffer[_offset];
+        return nullptr;
     }
 
     std::size_t getBlockSize() const
@@ -45,6 +47,9 @@ public:
 
     void eraseFirst(std::size_t len)
     {
+        if (len <= 0)
+            return;
+
         assert(_offset + len <= _buffer.size());
         assert(_offset + _size == _buffer.size());
 

--- a/test/WhiteBoxTests.cpp
+++ b/test/WhiteBoxTests.cpp
@@ -994,8 +994,9 @@ void WhiteBoxTests::testBufferClass()
         buf.eraseFirst(1);
         CPPUNIT_ASSERT_EQUAL(i - 1, buf.size());
         CPPUNIT_ASSERT_EQUAL(i == 1, buf.empty()); // Not empty until the last element.
-        CPPUNIT_ASSERT(buf.getBlock() != nullptr);
-        CPPUNIT_ASSERT_EQUAL(0, memcmp(buf.getBlock(), data + (sizeof(data) - i) + 1, buf.size()));
+        CPPUNIT_ASSERT_EQUAL(buf.getBlock() != nullptr, !buf.empty());
+        if (!buf.empty())
+            CPPUNIT_ASSERT_EQUAL(0, memcmp(buf.getBlock(), data + (sizeof(data) - i) + 1, buf.size()));
     }
 
     // Large data.


### PR DESCRIPTION
For large transfers eg. image previews, particularly with SSL's
protocol limit of 16k byte blocks, we see lots of inefficiency
repeatedly copying a 20Mb image and shuffling it down a
std::vector as we write data out.

Change-Id: I620568cad2e6f41684c35289b0ee77cf7f59c077
