### PR TITLE
CanvasTileLayer improvements.

### DIFF
--- a/loleaflet/src/control/Control.ColumnHeader.js
+++ b/loleaflet/src/control/Control.ColumnHeader.js
@@ -224,8 +224,8 @@ L.Control.ColumnHeader = L.Control.Header.extend({
 			return;
 
 		ctx.save();
-		var scale = this.canvasDPIScale();
-		ctx.scale(scale, scale);
+		//var scale = this.canvasDPIScale();
+		//ctx.scale(scale, scale);
 		// background gradient
 		var selectionBackgroundGradient = null;
 		if (isHighlighted) {

--- a/loleaflet/src/control/Control.ColumnHeader.js
+++ b/loleaflet/src/control/Control.ColumnHeader.js
@@ -39,8 +39,7 @@ L.Control.ColumnHeader = L.Control.Header.extend({
 		this._setCanvasHeight();
 		this._canvasBaseHeight = this._canvasHeight;
 
-		var scale = this.canvasDPIScale();
-		this._canvasContext.scale(scale, scale);
+		this._canvasContext.scale(this._dpiScale, this._dpiScale);
 
 		this._headerHeight = this._canvasHeight;
 		L.Control.Header.colHeaderHeight = this._canvasHeight;
@@ -224,8 +223,6 @@ L.Control.ColumnHeader = L.Control.Header.extend({
 			return;
 
 		ctx.save();
-		//var scale = this.canvasDPIScale();
-		//ctx.scale(scale, scale);
 		// background gradient
 		var selectionBackgroundGradient = null;
 		if (isHighlighted) {
@@ -290,8 +287,7 @@ L.Control.ColumnHeader = L.Control.Header.extend({
 		var height = group.endPos - group.startPos;
 
 		ctx.save();
-		var scale = this.canvasDPIScale();
-		ctx.scale(scale, scale);
+		ctx.scale(this._dpiScale, this._dpiScale);
 
 		// clip mask
 		ctx.beginPath();
@@ -339,13 +335,12 @@ L.Control.ColumnHeader = L.Control.Header.extend({
 		var ctx = this._cornerCanvasContext;
 		var ctrlHeadSize = this._groupHeadSize;
 		var levelSpacing = this._levelSpacing;
-		var scale = this.canvasDPIScale();
 
 		var startOrt = levelSpacing + (ctrlHeadSize + levelSpacing) * level;
-		var startPar = this._cornerCanvas.width / scale - (ctrlHeadSize + (L.Control.Header.rowHeaderWidth - ctrlHeadSize) / 2);
+		var startPar = this._cornerCanvas.width / this._dpiScale - (ctrlHeadSize + (L.Control.Header.rowHeaderWidth - ctrlHeadSize) / 2);
 
 		ctx.save();
-		ctx.scale(scale, scale);
+		ctx.scale(this._dpiScale, this._dpiScale);
 		ctx.fillStyle = this._hoverColor;
 		ctx.fillRect(startPar, startOrt, ctrlHeadSize, ctrlHeadSize);
 		ctx.strokeStyle = 'black';
@@ -532,8 +527,7 @@ L.Control.ColumnHeader = L.Control.Header.extend({
 			return;
 		}
 
-		var scale = this.canvasDPIScale();
-		var rowOutlineWidth = this._cornerCanvas.width / scale - L.Control.Header.rowHeaderWidth - this._borderWidth;
+		var rowOutlineWidth = this._cornerCanvas.width / this._dpiScale - L.Control.Header.rowHeaderWidth - this._borderWidth;
 		if (pos.x <= rowOutlineWidth) {
 			// empty rectangle on the left select all
 			this._map.sendUnoCommand('.uno:SelectAll');

--- a/loleaflet/src/control/Control.ColumnHeader.js
+++ b/loleaflet/src/control/Control.ColumnHeader.js
@@ -39,8 +39,6 @@ L.Control.ColumnHeader = L.Control.Header.extend({
 		this._setCanvasHeight();
 		this._canvasBaseHeight = this._canvasHeight;
 
-		this._canvasContext.scale(this._dpiScale, this._dpiScale);
-
 		this._headerHeight = this._canvasHeight;
 		L.Control.Header.colHeaderHeight = this._canvasHeight;
 
@@ -222,7 +220,6 @@ L.Control.ColumnHeader = L.Control.Header.extend({
 		if (width <= 0)
 			return;
 
-		ctx.save();
 		// background gradient
 		var selectionBackgroundGradient = null;
 		if (isHighlighted) {
@@ -234,17 +231,18 @@ L.Control.ColumnHeader = L.Control.Header.extend({
 
 		// draw header/outline border separator
 		if (this._headerHeight !== this._canvasHeight) {
+			ctx.beginPath();
 			ctx.fillStyle = this._borderColor;
-			ctx.fillRect(startPar, startOrt - this._borderWidth, width, this._borderWidth);
+			ctx.rect(startPar, startOrt - this._borderWidth, width, this._borderWidth);
+			ctx.fill();
 		}
 
-		// clip mask
-		ctx.beginPath();
-		ctx.rect(startPar, startOrt, width, height);
-		ctx.clip();
 		// draw background
+		ctx.beginPath();
 		ctx.fillStyle = isHighlighted ? selectionBackgroundGradient : isOver ? this._hoverColor : this._backgroundColor;
-		ctx.fillRect(startPar, startOrt, width, height);
+		ctx.rect(startPar, startOrt, width, height);
+		ctx.fill();
+
 		// draw resize handle
 		var handleSize = this._resizeHandleSize;
 		if (isCurrent && width > 2 * handleSize) {
@@ -254,9 +252,14 @@ L.Control.ColumnHeader = L.Control.Header.extend({
 			var size = 2;
 			var offset = 1;
 			ctx.fillStyle = '#BBBBBB';
-			ctx.fillRect(center - size - offset, y + 2, size, h - 4);
-			ctx.fillRect(center + offset, y + 2, size, h - 4);
+			ctx.beginPath();
+			ctx.rect(center - size - offset, y + 2, size, h - 4);
+			ctx.fill();
+			ctx.beginPath();
+			ctx.rect(center + offset, y + 2, size, h - 4);
+			ctx.fill();
 		}
+
 		// draw text content
 		ctx.fillStyle = isHighlighted ? this._selectionTextColor : this._textColor;
 		ctx.font = this._font.getFont();
@@ -269,8 +272,9 @@ L.Control.ColumnHeader = L.Control.Header.extend({
 		ctx.fillText(content, endPar - (width / 2), startOrt + (height / 2) + 1);
 		// draw row separator
 		ctx.fillStyle = this._borderColor;
-		ctx.fillRect(endPar -1, startOrt, this._borderWidth, height);
-		ctx.restore();
+		ctx.beginPath();
+		ctx.rect(endPar -1, startOrt, this._borderWidth, height);
+		ctx.fill();
 	},
 
 	drawGroupControl: function (group) {
@@ -285,9 +289,6 @@ L.Control.ColumnHeader = L.Control.Header.extend({
 		var startOrt = spacing + (headSize + spacing) * level;
 		var startPar = this._headerInfo.docToHeaderPos(group.startPos);
 		var height = group.endPos - group.startPos;
-
-		ctx.save();
-		ctx.scale(this._dpiScale, this._dpiScale);
 
 		// clip mask
 		ctx.beginPath();
@@ -328,7 +329,6 @@ L.Control.ColumnHeader = L.Control.Header.extend({
 			ctx.lineTo(startPar + headSize / 2, startOrt + 3 * headSize / 4);
 			ctx.stroke();
 		}
-		ctx.restore();
 	},
 
 	drawLevelHeader: function(level) {
@@ -339,8 +339,6 @@ L.Control.ColumnHeader = L.Control.Header.extend({
 		var startOrt = levelSpacing + (ctrlHeadSize + levelSpacing) * level;
 		var startPar = this._cornerCanvas.width / this._dpiScale - (ctrlHeadSize + (L.Control.Header.rowHeaderWidth - ctrlHeadSize) / 2);
 
-		ctx.save();
-		ctx.scale(this._dpiScale, this._dpiScale);
 		ctx.fillStyle = this._hoverColor;
 		ctx.fillRect(startPar, startOrt, ctrlHeadSize, ctrlHeadSize);
 		ctx.strokeStyle = 'black';
@@ -352,7 +350,6 @@ L.Control.ColumnHeader = L.Control.Header.extend({
 		ctx.textAlign = 'center';
 		ctx.textBaseline = 'middle';
 		ctx.fillText(level + 1, startPar + (ctrlHeadSize / 2), startOrt + (ctrlHeadSize / 2));
-		ctx.restore();
 	},
 
 	getHeaderEntryBoundingClientRect: function (index) {

--- a/loleaflet/src/control/Control.Header.js
+++ b/loleaflet/src/control/Control.Header.js
@@ -352,16 +352,16 @@ L.Control.Header = L.Control.extend({
 	_mouseEventToCanvasPos: function(canvas, evt) {
 		var rect = canvas.getBoundingClientRect();
 		return {
-			x: (evt.clientX - rect.left) * window.devicePixelRatio,
-			y: (evt.clientY - rect.top) * window.devicePixelRatio
+			x: (evt.clientX - rect.left),
+			y: (evt.clientY - rect.top)
 		};
 	},
 
 	_hammerEventToCanvasPos: function(canvas, event) {
 		var rect = canvas.getBoundingClientRect();
 		return {
-			x: (event.center.x - rect.left) * window.devicePixelRatio,
-			y: (event.center.y - rect.top) * window.devicePixelRatio
+			x: (event.center.x - rect.left),
+			y: (event.center.y - rect.top)
 		};
 	},
 

--- a/loleaflet/src/control/Control.Header.js
+++ b/loleaflet/src/control/Control.Header.js
@@ -73,7 +73,7 @@ L.Control.Header = L.Control.extend({
 		var rate = fontHeight / fontSize;
 		this._font = {
 			_hdr: this,
-			_baseFontSize: fontSize,
+			_baseFontSize: fontSize * window.devicePixelRatio,
 			_fontSizeRate: rate,
 			_fontFamily: fontFamily,
 			getFont: function() {
@@ -92,7 +92,7 @@ L.Control.Header = L.Control.extend({
 		};
 		this._borderColor = L.DomUtil.getStyle(elem, 'border-top-color');
 		var borderWidth = L.DomUtil.getStyle(elem, 'border-top-width');
-		this._borderWidth = Math.round(parseFloat(borderWidth));
+		this._borderWidth = Math.round(parseFloat(borderWidth)) * window.devicePixelRatio;
 		this._cursor = L.DomUtil.getStyle(elem, 'cursor');
 		L.DomUtil.remove(elem);
 	},
@@ -352,16 +352,16 @@ L.Control.Header = L.Control.extend({
 	_mouseEventToCanvasPos: function(canvas, evt) {
 		var rect = canvas.getBoundingClientRect();
 		return {
-			x: evt.clientX - rect.left,
-			y: evt.clientY - rect.top
+			x: (evt.clientX - rect.left) * window.devicePixelRatio,
+			y: (evt.clientY - rect.top) * window.devicePixelRatio
 		};
 	},
 
 	_hammerEventToCanvasPos: function(canvas, event) {
 		var rect = canvas.getBoundingClientRect();
 		return {
-			x: event.center.x - rect.left,
-			y: event.center.y - rect.top
+			x: (event.center.x - rect.left) * window.devicePixelRatio,
+			y: (event.center.y - rect.top) * window.devicePixelRatio
 		};
 	},
 
@@ -579,9 +579,7 @@ L.Control.Header = L.Control.extend({
 	},
 
 	canvasDPIScale: function () {
-		var docLayer = this._map && this._map._docLayer;
-		var scale = docLayer && docLayer.canvasDPIScale ? docLayer.canvasDPIScale() : L.getDpiScaleFactor();
-		return scale;
+		return L.getDpiScaleFactor(true);
 	},
 
 	_setCanvasSizeImpl: function (container, canvas, property, value, isCorner) {
@@ -596,13 +594,13 @@ L.Control.Header = L.Control.extend({
 		if (property === 'width') {
 			canvas.width = Math.floor(value * scale);
 			if (!isCorner)
-				this._canvasWidth = value;
+				this._canvasWidth = value * scale;
 			// console.log('Header._setCanvasSizeImpl: _canvasWidth' + this._canvasWidth);
 		}
 		else if (property === 'height') {
 			canvas.height = Math.floor(value * scale);
 			if (!isCorner)
-				this._canvasHeight = value;
+				this._canvasHeight = value * scale;
 			// console.log('Header._setCanvasSizeImpl: _canvasHeight' + this._canvasHeight);
 		}
 	},
@@ -798,12 +796,12 @@ L.Control.Header.HeaderInfo = L.Class.extend({
 	},
 
 	update: function () {
-		var bounds = this._map.getPixelBounds();
+		var bounds = this._map.getPixelBoundsCore();
 		var startPx = this._isCol ? bounds.getTopLeft().x : bounds.getTopLeft().y;
 		this._docVisStart = startPx;
 		var endPx = this._isCol ? bounds.getBottomRight().x : bounds.getBottomRight().y;
-		var startIdx = this._dimGeom.getIndexFromPos(startPx, 'csspixels');
-		var endIdx = this._dimGeom.getIndexFromPos(endPx - 1, 'csspixels');
+		var startIdx = this._dimGeom.getIndexFromPos(startPx, 'corepixels');
+		var endIdx = this._dimGeom.getIndexFromPos(endPx - 1, 'corepixels');
 		this._elements = [];
 
 		var splitPosContext = this._map.getSplitPanesContext();
@@ -815,7 +813,7 @@ L.Control.Header.HeaderInfo = L.Class.extend({
 		if (splitPosContext) {
 
 			splitPos = this._isCol ? splitPosContext.getSplitPos().x : splitPosContext.getSplitPos().y;
-			var splitIndex = this._dimGeom.getIndexFromPos(splitPos + 1, 'csspixels');
+			var splitIndex = this._dimGeom.getIndexFromPos(splitPos + 1, 'corepixels');
 
 			if (splitIndex) {
 				// Make sure splitPos is aligned to the cell boundary.
@@ -836,7 +834,7 @@ L.Control.Header.HeaderInfo = L.Class.extend({
 				this._splitIndex = splitIndex;
 
 				var freeStartPos = startPx + splitPos + 1;
-				var freeStartIndex = this._dimGeom.getIndexFromPos(freeStartPos + 1, 'csspixels');
+				var freeStartIndex = this._dimGeom.getIndexFromPos(freeStartPos + 1, 'corepixels');
 
 				startIdx = freeStartIndex;
 			}

--- a/loleaflet/src/control/Control.Header.js
+++ b/loleaflet/src/control/Control.Header.js
@@ -29,6 +29,7 @@ L.Control.Header = L.Control.extend({
 		this._hitResizeArea = false;
 		this._overHeaderArea = false;
 		this._hammer = null;
+		this._dpiScale = L.Util.getDpiScaleFactor(true);
 
 		this._selectionBackgroundGradient = [ '#3465A4', '#729FCF', '#004586' ];
 
@@ -352,8 +353,8 @@ L.Control.Header = L.Control.extend({
 	_mouseEventToCanvasPos: function(canvas, evt) {
 		var rect = canvas.getBoundingClientRect();
 		return {
-			x: (evt.clientX - rect.left),
-			y: (evt.clientY - rect.top)
+			x: (evt.clientX - rect.left) * this._dpiScale,
+			y: (evt.clientY - rect.top) * this._dpiScale
 		};
 	},
 
@@ -578,10 +579,6 @@ L.Control.Header = L.Control.extend({
 		return Math.round(this._getParallelPos(this.converter(point)));
 	},
 
-	canvasDPIScale: function () {
-		return L.getDpiScaleFactor(true);
-	},
-
 	_setCanvasSizeImpl: function (container, canvas, property, value, isCorner) {
 		if (!value) {
 			value = parseInt(L.DomUtil.getStyle(container, property));
@@ -590,17 +587,16 @@ L.Control.Header = L.Control.extend({
 			L.DomUtil.setStyle(container, property, value + 'px');
 		}
 
-		var scale = this.canvasDPIScale();
 		if (property === 'width') {
-			canvas.width = Math.floor(value * scale);
+			canvas.width = Math.floor(value * this._dpiScale);
 			if (!isCorner)
-				this._canvasWidth = value * scale;
+				this._canvasWidth = value * this._dpiScale;
 			// console.log('Header._setCanvasSizeImpl: _canvasWidth' + this._canvasWidth);
 		}
 		else if (property === 'height') {
-			canvas.height = Math.floor(value * scale);
+			canvas.height = Math.floor(value * this._dpiScale);
 			if (!isCorner)
-				this._canvasHeight = value * scale;
+				this._canvasHeight = value * this._dpiScale;
 			// console.log('Header._setCanvasSizeImpl: _canvasHeight' + this._canvasHeight);
 		}
 	},
@@ -720,18 +716,16 @@ L.Control.Header = L.Control.extend({
 		if (!this._groups)
 			return;
 
-		ctx.save();
-		var scale = this.canvasDPIScale();
-		ctx.scale(scale, scale);
+		ctx.scale(this._dpiScale, this._dpiScale);
 
 		ctx.fillStyle = this._borderColor;
 		if (this._isColumn) {
-			var startY = this._cornerCanvas.height / scale - (L.Control.Header.colHeaderHeight + this._borderWidth);
+			var startY = this._cornerCanvas.height / this._dpiScale - (L.Control.Header.colHeaderHeight + this._borderWidth);
 			if (startY > 0)
 				ctx.fillRect(0, startY, this._cornerCanvas.width, this._borderWidth);
 		}
 		else {
-			var startX = this._cornerCanvas.width / scale - (L.Control.Header.rowHeaderWidth + this._borderWidth);
+			var startX = this._cornerCanvas.width / this._dpiScale - (L.Control.Header.rowHeaderWidth + this._borderWidth);
 			if (startX > 0)
 				ctx.fillRect(startX, 0, this._borderWidth, this._cornerCanvas.height);
 		}

--- a/loleaflet/src/control/Control.RowHeader.js
+++ b/loleaflet/src/control/Control.RowHeader.js
@@ -39,8 +39,7 @@ L.Control.RowHeader = L.Control.Header.extend({
 		this._setCanvasWidth();
 		this._setCanvasHeight();
 
-		var scale = this.canvasDPIScale();
-		this._canvasContext.scale(scale, scale);
+		this._canvasContext.scale(this._dpiScale, this._dpiScale);
 		this._headerWidth = this._canvasWidth;
 		L.Control.Header.rowHeaderWidth = this._canvasWidth;
 
@@ -277,8 +276,7 @@ L.Control.RowHeader = L.Control.Header.extend({
 		var height = group.endPos - group.startPos;
 
 		ctx.save();
-		var scale = this.canvasDPIScale();
-		ctx.scale(scale, scale);
+		ctx.scale(this._dpiScale, this._dpiScale);
 
 		// clip mask
 		ctx.beginPath();
@@ -326,13 +324,12 @@ L.Control.RowHeader = L.Control.Header.extend({
 		var ctx = this._cornerCanvasContext;
 		var ctrlHeadSize = this._groupHeadSize;
 		var levelSpacing = this._levelSpacing;
-		var scale = this.canvasDPIScale();
 
 		var startOrt = levelSpacing + (ctrlHeadSize + levelSpacing) * level;
-		var startPar = this._cornerCanvas.height / scale - (ctrlHeadSize + (L.Control.Header.colHeaderHeight - ctrlHeadSize) / 2);
+		var startPar = this._cornerCanvas.height / this._dpiScale - (ctrlHeadSize + (L.Control.Header.colHeaderHeight - ctrlHeadSize) / 2);
 
 		ctx.save();
-		ctx.scale(scale, scale);
+		ctx.scale(this._dpiScale, this._dpiScale);
 		ctx.fillStyle = this._hoverColor;
 		ctx.fillRect(startOrt, startPar, ctrlHeadSize, ctrlHeadSize);
 		ctx.strokeStyle = 'black';

--- a/loleaflet/src/control/Control.RowHeader.js
+++ b/loleaflet/src/control/Control.RowHeader.js
@@ -217,8 +217,6 @@ L.Control.RowHeader = L.Control.Header.extend({
 			return;
 
 		ctx.save();
-		var scale = this.canvasDPIScale();
-		ctx.scale(scale, scale);
 		// background gradient
 		var selectionBackgroundGradient = null;
 		if (isHighlighted) {

--- a/loleaflet/src/control/Control.Scroll.js
+++ b/loleaflet/src/control/Control.Scroll.js
@@ -123,7 +123,8 @@ L.Control.Scroll = L.Control.extend({
 
 	_onScroll: function (e) {
 		if (this._map._docLayer._docType === 'spreadsheet') {
-			this._onCalcScroll(e);
+			if (window.mode.isDesktop())
+				this._onCalcScroll(e);
 			return;
 		}
 

--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -247,9 +247,9 @@ L.Socket = L.Class.extend({
 	_logSocket: function(type, msg) {
 		var fullDebug = this._map._docLayer && this._map._docLayer._debug;
 
-		if (fullDebug) 
+		if (fullDebug)
 			this._map._docLayer._debugSetPostMessage(type,msg);
-		
+
 		if (!window.protocolDebug && !fullDebug)
 			return;
 
@@ -1001,16 +1001,16 @@ L.Socket = L.Class.extend({
 			if (command.type === 'text') {
 				docLayer = new L.WriterTileLayer('', {
 					permission: this._map.options.permission,
-					tileWidthTwips: tileWidthTwips,
-					tileHeightTwips: tileHeightTwips,
+					tileWidthTwips: tileWidthTwips / window.devicePixelRatio,
+					tileHeightTwips: tileHeightTwips / window.devicePixelRatio,
 					docType: command.type
 				});
 			}
 			else if (command.type === 'spreadsheet') {
 				docLayer = new L.CalcTileLayer('', {
 					permission: this._map.options.permission,
-					tileWidthTwips: tileWidthTwips,
-					tileHeightTwips: tileHeightTwips,
+					tileWidthTwips: tileWidthTwips / window.devicePixelRatio,
+					tileHeightTwips: tileHeightTwips / window.devicePixelRatio,
 					docType: command.type
 				});
 
@@ -1039,8 +1039,8 @@ L.Socket = L.Class.extend({
 				}
 				docLayer = new L.ImpressTileLayer('', {
 					permission: this._map.options.permission,
-					tileWidthTwips: tileWidthTwips,
-					tileHeightTwips: tileHeightTwips,
+					tileWidthTwips: tileWidthTwips / window.devicePixelRatio,
+					tileHeightTwips: tileHeightTwips / window.devicePixelRatio,
 					docType: command.type
 				});
 			}

--- a/loleaflet/src/layer/SplitPanesContext.js
+++ b/loleaflet/src/layer/SplitPanesContext.js
@@ -193,10 +193,10 @@ L.SplitPanesContext = L.Class.extend({
 		return paneStatusList;
 	},
 
-	// returns all the pane rectangles for the provided full-map area (all in CSS pixels).
+	// returns all the pane rectangles for the provided full-map area (all in core pixels).
 	getPxBoundList: function (pxBounds) {
 		if (!pxBounds) {
-			pxBounds = this._map.getPixelBounds();
+			pxBounds = this._map.getPixelBoundsCore();
 		}
 		var topLeft = pxBounds.getTopLeft();
 		var bottomRight = pxBounds.getBottomRight();
@@ -240,14 +240,14 @@ L.SplitPanesContext = L.Class.extend({
 		var docLayer = this._docLayer;
 		return bounds.map(function (bound) {
 			return new L.Bounds(
-				docLayer._pixelsToTwips(bound.min),
-				docLayer._pixelsToTwips(bound.max)
+				docLayer._corePixelsToTwips(bound.min),
+				docLayer._corePixelsToTwips(bound.max)
 			);
 		});
 	},
 
 	getClientVisibleArea: function () {
-		var pixelBounds = this._map.getPixelBounds();
+		var pixelBounds = this._map.getPixelBoundsCore();
 		var fullSize = pixelBounds.getSize();
 		var cursorPos = this._docLayer.getCursorPos();
 		cursorPos._floor();
@@ -277,7 +277,7 @@ L.SplitPanesContext = L.Class.extend({
 	},
 
 	intersectsVisible: function (areaPx) {
-		var pixBounds = this._map.getPixelBounds();
+		var pixBounds = this._map.getPixelBoundsCore();
 		var boundList = this.getPxBoundList(pixBounds);
 		for (var i = 0; i < boundList.length; ++i) {
 			if (areaPx.intersects(boundList[i])) {

--- a/loleaflet/src/layer/tile/CalcTileLayer.js
+++ b/loleaflet/src/layer/tile/CalcTileLayer.js
@@ -333,7 +333,7 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 					obj.comment.avatar = this._map._viewInfoByUserName[obj.comment.author].userextrainfo.avatar;
 				}
 				var cellPos = L.LOUtil.stringToBounds(obj.comment.cellPos);
-				obj.comment.cellPos = this._convertToTileTwipsSheetArea(cellPos);
+				obj.comment.cellPos = cellPos;
 				obj.comment.cellPos = L.latLngBounds(this._twipsToLatLng(obj.comment.cellPos.getBottomLeft()),
 					this._twipsToLatLng(obj.comment.cellPos.getTopRight()));
 				if (!this._annotations[obj.comment.tab]) {
@@ -352,7 +352,7 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 			} else if (obj.comment.action === 'Modify') {
 				var modified = this._annotations[obj.comment.tab][obj.comment.id];
 				cellPos = L.LOUtil.stringToBounds(obj.comment.cellPos);
-				obj.comment.cellPos = this._convertToTileTwipsSheetArea(cellPos);
+				obj.comment.cellPos = cellPos;
 				obj.comment.cellPos = L.latLngBounds(this._twipsToLatLng(obj.comment.cellPos.getBottomLeft()),
 					this._twipsToLatLng(obj.comment.cellPos.getTopRight()));
 				if (modified) {
@@ -977,7 +977,7 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 			// No refpoint information available, treat it as cell-range selection rectangle.
 			var rangeRectArray = L.Bounds.parseArray(textMsg);
 			rangeRectArray = rangeRectArray.map(function (rect) {
-				return this._convertToTileTwipsSheetArea(rect);
+				return rect;
 			}, this);
 			return rangeRectArray;
 		}
@@ -1406,26 +1406,6 @@ L.SheetGeometry = L.Class.extend({
 
 		return new L.Point(this._columns.getPrintTwipsPosFromTile(point.x),
 			this._rows.getPrintTwipsPosFromTile(point.y));
-	},
-
-	// accepts a rectangle in print twips coordinates and returns the equivalent rectangle
-	// in tile-twips aligned to the cells.
-	getTileTwipsSheetAreaFromPrint: function (rectangle) { // (L.Bounds) -> L.Bounds
-		if (!(rectangle instanceof L.Bounds)) {
-			console.error('Bad argument type, expected L.Bounds');
-			return rectangle;
-		}
-
-		var topLeft = rectangle.getTopLeft();
-		var bottomRight = rectangle.getBottomRight();
-
-		var horizBounds = this._columns.getTileTwipsRangeFromPrint(topLeft.x, bottomRight.x);
-		var vertBounds = this._rows.getTileTwipsRangeFromPrint(topLeft.y, bottomRight.y);
-
-		topLeft = new L.Point(horizBounds.startpos, vertBounds.startpos);
-		bottomRight = new L.Point(horizBounds.endpos, vertBounds.endpos);
-
-		return new L.Bounds(topLeft, bottomRight);
 	},
 
 	// Returns full sheet size as L.Point in the given unit.

--- a/loleaflet/src/layer/tile/CalcTileLayer.js
+++ b/loleaflet/src/layer/tile/CalcTileLayer.js
@@ -266,6 +266,9 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 	},
 
 	_saveMessageForReplay: function (textMsg, viewId) {
+		// I couldn't understand this. It feels like it would be possible only for the top left corner of the view if and only if our anchor was top left corner when zooming.
+		// And at least for mobile, zooming anchor should be the the center point of the pinch.
+
 		// If this.options.printTwipsMsgsEnabled is set, we will not get some messages (with coordinates)
 		// from core when zoom changes because print-twips coordinates are zoom-invariant. So we need to
 		// remember the last version of them and replay, when zoom is changed.
@@ -956,7 +959,6 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 
 		var relrect = L.Bounds.parse(msgObj.relrect);
 		var refpoint = L.Point.parse(msgObj.refpoint);
-		refpoint = this.sheetGeometry.getTileTwipsPointFromPrint(refpoint);
 		return relrect.add(refpoint);
 	},
 
@@ -983,7 +985,6 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 		}
 
 		var refpoint = L.Point.parse(textMsg.substring(delimIndex + refpointDelim.length));
-		refpoint = this.sheetGeometry.getTileTwipsPointFromPrint(refpoint);
 
 		var rectArray = L.Bounds.parseArray(textMsg.substring(0, delimIndex));
 		rectArray.forEach(function (rect) {
@@ -1382,30 +1383,6 @@ L.SheetGeometry = L.Class.extend({
 
 	getRowGroupsDataInView: function () {
 		return this._rows.getGroupsDataInView();
-	},
-
-	// accepts a point in print twips coordinates and returns the equivalent point
-	// in tile-twips.
-	getTileTwipsPointFromPrint: function (point) { // (L.Point) -> L.Point
-		if (!(point instanceof L.Point)) {
-			console.error('Bad argument type, expected L.Point');
-			return point;
-		}
-
-		return new L.Point(this._columns.getTileTwipsPosFromPrint(point.x),
-			this._rows.getTileTwipsPosFromPrint(point.y));
-	},
-
-	// accepts a point in tile-twips coordinates and returns the equivalent point
-	// in print-twips.
-	getPrintTwipsPointFromTile: function (point) { // (L.Point) -> L.Point
-		if (!(point instanceof L.Point)) {
-			console.error('Bad argument type, expected L.Point');
-			return point;
-		}
-
-		return new L.Point(this._columns.getPrintTwipsPosFromTile(point.x),
-			this._rows.getPrintTwipsPosFromTile(point.y));
 	},
 
 	// Returns full sheet size as L.Point in the given unit.

--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -588,14 +588,14 @@ L.CanvasTileLayer = L.TileLayer.extend({
 
 	_twipsToCssPixels: function (twips) {
 		return new L.Point(
-			twips.x / this._tileWidthTwips * this._tileSize,
-			twips.y / this._tileHeightTwips * this._tileSize);
+			(twips.x / this._tileWidthTwips) * (this._tileSize / this._painter._dpiScale),
+			(twips.y / this._tileHeightTwips) * (this._tileSize / this._painter._dpiScale));
 	},
 
 	_cssPixelsToTwips: function (pixels) {
 		return new L.Point(
-			pixels.x / this._tileSize * this._tileWidthTwips,
-			pixels.y / this._tileSize * this._tileHeightTwips);
+			((pixels.x * this._painter._dpiScale) / this._tileSize) * this._tileWidthTwips,
+			((pixels.y * this._painter._dpiScale) / this._tileSize) * this._tileHeightTwips);
 	},
 
 	_twipsToLatLng: function (twips, zoom) {

--- a/loleaflet/src/layer/tile/GridLayer.js
+++ b/loleaflet/src/layer/tile/GridLayer.js
@@ -489,6 +489,8 @@ L.GridLayer = L.Layer.extend({
 		];
 	},
 
+	/// Since we use tile size in Core's pixel size, when we want to use this size with CSS pixels, we have to divide this with window.devicePixelRatio (_dpiScale).
+	/// We can't do this here, but maybe we can add a variable like tileSizeCSS, that maybe an option if we will have to convert this in too many places.
 	_getTileSize: function () {
 		return this.options.tileSize;
 	},

--- a/loleaflet/src/layer/tile/TileLayer.js
+++ b/loleaflet/src/layer/tile/TileLayer.js
@@ -1202,8 +1202,7 @@ L.TileLayer = L.GridLayer.extend({
 			var topLeftTwips = new L.Point(parseInt(strTwips[0]), parseInt(strTwips[1]));
 			var offset = new L.Point(parseInt(strTwips[2]), parseInt(strTwips[3]));
 			var bottomRightTwips = topLeftTwips.add(offset);
-			this._cellCursorTwips = this._convertToTileTwipsSheetArea(
-				new L.Bounds(topLeftTwips, bottomRightTwips));
+			this._cellCursorTwips = new L.Bounds(topLeftTwips, bottomRightTwips);
 			this._cellCursor = new L.LatLngBounds(
 				this._twipsToLatLng(this._cellCursorTwips.getTopLeft(), this._map.getZoom()),
 				this._twipsToLatLng(this._cellCursorTwips.getBottomRight(), this._map.getZoom()));
@@ -1470,8 +1469,7 @@ L.TileLayer = L.GridLayer.extend({
 			var topLeftTwips = new L.Point(parseInt(strTwips[0]), parseInt(strTwips[1]));
 			var offset = new L.Point(parseInt(strTwips[2]), parseInt(strTwips[3]));
 			var bottomRightTwips = topLeftTwips.add(offset);
-			var boundsTwips = this._convertToTileTwipsSheetArea(
-				new L.Bounds(topLeftTwips, bottomRightTwips));
+			var boundsTwips = new L.Bounds(topLeftTwips, bottomRightTwips);
 			this._cellViewCursors[viewId].bounds = new L.LatLngBounds(
 				this._twipsToLatLng(boundsTwips.getTopLeft(), this._map.getZoom()),
 				this._twipsToLatLng(boundsTwips.getBottomRight(), this._map.getZoom()));
@@ -1863,8 +1861,7 @@ L.TileLayer = L.GridLayer.extend({
 				for (var i = 0; i < strTwips.length; i += 4) {
 					var topLeftTwips = new L.Point(parseInt(strTwips[i]), parseInt(strTwips[i + 1]));
 					var offset = new L.Point(parseInt(strTwips[i + 2]), parseInt(strTwips[i + 3]));
-					var boundsTwips = this._convertToTileTwipsSheetArea(
-						new L.Bounds(topLeftTwips, topLeftTwips.add(offset)));
+					var boundsTwips = new L.Bounds(topLeftTwips, topLeftTwips.add(offset));
 					rectangles.push([boundsTwips.getBottomLeft(), boundsTwips.getBottomRight(),
 						boundsTwips.getTopLeft(), boundsTwips.getTopRight()]);
 				}
@@ -1964,8 +1961,7 @@ L.TileLayer = L.GridLayer.extend({
 			var topLeftTwips = new L.Point(parseInt(strTwips[0]), parseInt(strTwips[1]));
 			var offset = new L.Point(parseInt(strTwips[2]), parseInt(strTwips[3]));
 			var bottomRightTwips = topLeftTwips.add(offset);
-			var boundsTwips = this._convertToTileTwipsSheetArea(
-				new L.Bounds(topLeftTwips, bottomRightTwips));
+			var boundsTwips = new L.Bounds(topLeftTwips, bottomRightTwips);
 			var oldSelection = this._cellSelectionArea;
 			this._cellSelectionArea = new L.LatLngBounds(
 				this._twipsToLatLng(boundsTwips.getTopLeft(), this._map.getZoom()),
@@ -3522,15 +3518,6 @@ L.TileLayer = L.GridLayer.extend({
 		} else if (this._formFieldButton) {
 			this._map.removeLayer(this._formFieldButton);
 		}
-	},
-
-	// converts rectangle in print-twips to tile-twips rectangle of the smallest cell-range that encloses it.
-	_convertToTileTwipsSheetArea: function (rectangle) {
-		if (!(rectangle instanceof L.Bounds) || !this.options.printTwipsMsgsEnabled || !this.sheetGeometry) {
-			return rectangle;
-		}
-
-		return this.sheetGeometry.getTileTwipsSheetAreaFromPrint(rectangle);
 	},
 
 	_getGraphicSelectionRectangle: function (rectangle) {

--- a/loleaflet/src/layer/tile/TileLayer.js
+++ b/loleaflet/src/layer/tile/TileLayer.js
@@ -2620,10 +2620,6 @@ L.TileLayer = L.GridLayer.extend({
 				if (newPos.y < 0)
 					newPos.y = 0;
 
-				if (this.isCalc() && this.options.printTwipsMsgsEnabled) {
-					newPos = this.sheetGeometry.getPrintTwipsPointFromTile(newPos);
-				}
-
 				param = {
 					TransformPosX: {
 						type: 'long',
@@ -2754,10 +2750,6 @@ L.TileLayer = L.GridLayer.extend({
 					newSize.x = Math.round(u / s);
 					newSize.y = Math.round(v / c);
 				}
-			}
-
-			if (this.isCalc() && this.options.printTwipsMsgsEnabled) {
-				newPos = this.sheetGeometry.getPrintTwipsPointFromTile(newPos);
 			}
 
 			// fill params for uno command
@@ -3526,7 +3518,7 @@ L.TileLayer = L.GridLayer.extend({
 		}
 
 		var rectSize = rectangle.getSize();
-		var newTopLeft = this.sheetGeometry.getTileTwipsPointFromPrint(rectangle.getTopLeft());
+		var newTopLeft = rectangle.getTopLeft();
 		return new L.Bounds(newTopLeft, newTopLeft.add(rectSize));
 	},
 

--- a/loleaflet/src/map/Map.js
+++ b/loleaflet/src/map/Map.js
@@ -848,6 +848,13 @@ L.Map = L.Evented.extend({
 		return new L.Bounds(topLeftPoint, topLeftPoint.add(this.getSize()));
 	},
 
+	getPixelBoundsCore: function (center, zoom) {
+		var bounds = this.getPixelBounds(center, zoom);
+		bounds.min = bounds.min.multiplyBy(L.Util.getDpiScaleFactor(true));
+		bounds.max = bounds.max.multiplyBy(L.Util.getDpiScaleFactor(true));
+		return bounds;
+	},
+
 	getPixelOrigin: function () {
 		this._checkIfLoaded();
 		return this._pixelOrigin;


### PR DESCRIPTION
CalcTileLayer: css pixel <-> core pixel conversion is removed. CorePixels are used everywhere for simplicity.
CanvasTileLayer: I tried to use core pixels as much as possible. Canvas will be working on its own in the future. Only css pixels <-> core pixels conversions
will be needed when user interacts with the canvas, like mouse move etc. So there will be less conversions.

Control.RowHeader, Control.Header, Control.ColumnHeader: Just some little adjustments to see Calc view a bit more beautiful in this patch.

Map.js: A helper is added for the CanvasTileLayer.

No cosmetic changes.

View on mobile devices was already broken before this patch. This patch introduces only crisp images on mobile views.

Signed-off-by: Gökay Şatır <gokaysatir@collabora.com>
Change-Id: I55bbb9a03588d00db5f0a266588d5306cb802cbf


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

