### PR TITLE
Move temporary files in jail

### DIFF
--- a/common/JailUtil.cpp
+++ b/common/JailUtil.cpp
@@ -184,7 +184,7 @@ void setupJails(bool bindMount, const std::string& jailRoot, const std::string& 
 {
     // Start with a clean slate.
     cleanupJails(jailRoot);
-    Poco::File(jailRoot).createDirectories();
+    Poco::File(jailRoot + JAIL_TMP_INCOMING_PATH).createDirectories();
 
     disableBindMounting(); // Clear to avoid surprises.
 

--- a/common/JailUtil.hpp
+++ b/common/JailUtil.hpp
@@ -14,6 +14,10 @@
 
 namespace JailUtil
 {
+
+/// Files uploaded by users are stored in this sub-directory of child-root.
+constexpr const char JAIL_TMP_INCOMING_PATH[] = "/tmp/incoming";
+
 /// Bind mount a jail directory.
 bool bind(const std::string& source, const std::string& target);
 

--- a/test/UnitConvert.cpp
+++ b/test/UnitConvert.cpp
@@ -49,6 +49,7 @@ public:
 
         config.setBool("ssl.enable", true);
         config.setInt("per_document.limit_load_secs", 30);
+        config.setBool("storage.filesystem[@allow]", false);
     }
 
     void sendConvertTo(std::unique_ptr<Poco::Net::HTTPClientSession>& session, const std::string& filename)

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -597,7 +597,8 @@ bool DocumentBroker::load(const std::shared_ptr<ClientSession>& session, const s
 
         try
         {
-            _storage = StorageBase::create(uriPublic, jailRoot, jailPath.toString());
+            _storage = StorageBase::create(uriPublic, jailRoot, jailPath.toString(),
+                                           /*takeOwnership=*/isConvertTo());
         }
         catch (...)
         {

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -386,6 +386,12 @@ private:
     /// Sum the I/O stats from all connected sessions
     void getIOStats(uint64_t &sent, uint64_t &recv);
 
+    /// Returns true iff this is a Convert-To request.
+    /// This is needed primarily for security reasons,
+    /// because we can't trust the given file-path is
+    /// a convert-to request or doctored to look like one.
+    virtual bool isConvertTo() const { return false; }
+
 protected:
     /// Seconds to live for, or 0 forever
     int64_t _limitLifeSeconds;
@@ -501,6 +507,9 @@ public:
 
     /// Cleanup path and its parent
     static void removeFile(const std::string &uri);
+
+private:
+    bool isConvertTo() const override { return true; }
 };
 #endif
 

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -619,7 +619,8 @@ public:
 
         // FIXME: needs wrapping - until then - keep in sync with ~ConvertToBroker
         Path tempPath = Path::forDirectory(
-            Poco::TemporaryFile::tempName(_convertTo ? "/tmp/convert-to" : "") + '/');
+            Poco::TemporaryFile::tempName(_convertTo ? LOOLWSD::ChildRoot + "/tmp/convert-to" : "")
+            + '/');
         LOG_TRC("Creating temporary convert-to path: " << tempPath.toString());
         File(tempPath).createDirectories();
         chmod(tempPath.toString().c_str(), S_IXUSR | S_IWUSR | S_IRUSR);
@@ -628,7 +629,7 @@ public:
         // A "filename" should always be a filename, not a path
         const Path filenameParam(params.get("filename"));
         tempPath.setFileName(filenameParam.getFileName());
-        _filename = tempPath.toString();
+        _filename = tempPath.toString(); // For convert-to this is bogus.
 
         // Copy the stream to _filename.
         std::ofstream fileStream;

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -334,6 +334,11 @@ std::string LocalStorage::loadStorageFileToLocal(const Authorization& /*auth*/,
         {
             // Neither link nor copy, just move, it's a temporary file.
             Poco::File(publicFilePath).moveTo(getRootFilePath());
+
+            // Cleanup the directory after moving.
+            const std::string dir = Poco::Path(publicFilePath).parent().toString();
+            if (FileUtil::isEmptyDirectory(dir))
+                FileUtil::removeFile(dir);
         }
         catch (const Poco::Exception& exc)
         {

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -212,7 +212,8 @@ bool isLocalhost(const std::string& targetHost)
 
 #endif
 
-std::unique_ptr<StorageBase> StorageBase::create(const Poco::URI& uri, const std::string& jailRoot, const std::string& jailPath)
+std::unique_ptr<StorageBase> StorageBase::create(const Poco::URI& uri, const std::string& jailRoot,
+                                                 const std::string& jailPath, bool takeOwnership)
 {
     // FIXME: By the time this gets called we have already sent to the client three
     // 'statusindicator:' messages: 'find', 'connect' and 'ready'. We should ideally do the checks
@@ -240,24 +241,10 @@ std::unique_ptr<StorageBase> StorageBase::create(const Poco::URI& uri, const std
             throw UnauthorizedRequestException("No acceptable WOPI hosts found matching the target host in config.");
         }
 #endif
-        if (FilesystemEnabled)
+        if (FilesystemEnabled || takeOwnership)
         {
-            return std::unique_ptr<StorageBase>(new LocalStorage(uri, jailRoot, jailPath));
-        }
-        else
-        {
-            // guard against attempts to escape
-            Poco::URI normalizedUri(uri);
-            normalizedUri.normalize();
-
-            std::vector<std::string> pathSegments;
-            normalizedUri.getPathSegments(pathSegments);
-
-            if (pathSegments.size() == 4 && pathSegments[0] == "tmp" && pathSegments[1] == "convert-to")
-            {
-                LOG_INF("Public URI [" << LOOLWSD::anonymizeUrl(normalizedUri.toString()) << "] is actually a convert-to tempfile.");
-                return std::unique_ptr<StorageBase>(new LocalStorage(normalizedUri, jailRoot, jailPath));
-            }
+            return std::unique_ptr<StorageBase>(
+                new LocalStorage(uri, jailRoot, jailPath, takeOwnership));
         }
 
         LOG_ERR("Local Storage is disabled by default. Enable in the config file or on the command-line to enable.");
@@ -330,25 +317,50 @@ std::string LocalStorage::loadStorageFileToLocal(const Authorization& /*auth*/,
 
     // Despite the talk about URIs it seems that _uri is actually just a pathname here
     const std::string publicFilePath = getUri().getPath();
+    if (!Poco::File(publicFilePath).exists())
+    {
+        LOG_ERR("Local file URI [" << publicFilePath << "] invalid or doesn't exist.");
+        throw BadRequestException("Invalid URI: " + getUri().toString());
+    }
 
     if (!FileUtil::checkDiskSpace(getRootFilePath()))
     {
         throw StorageSpaceLowException("Low disk space for " + getRootFilePathAnonym());
     }
 
-    LOG_INF("Linking " << LOOLWSD::anonymizeUrl(publicFilePath) << " to " << getRootFilePathAnonym());
-    if (!Poco::File(getRootFilePath()).exists() && link(publicFilePath.c_str(), getRootFilePath().c_str()) == -1)
+    if (_isTemporaryFile)
     {
-        // Failed
-        LOG_WRN("link(\"" << LOOLWSD::anonymizeUrl(publicFilePath) << "\", \""
-                          << getRootFilePathAnonym() << "\") failed. Will copy. Linking error: "
-                          << Util::symbolicErrno(errno) << ' ' << strerror(errno));
+        try
+        {
+            // Neither link nor copy, just move, it's a temporary file.
+            Poco::File(publicFilePath).moveTo(getRootFilePath());
+        }
+        catch (const Poco::Exception& exc)
+        {
+            LOG_WRN("Failed to move [" << LOOLWSD::anonymizeUrl(publicFilePath) << "] to ["
+                                       << getRootFilePathAnonym() << "]: " << exc.displayText());
+        }
+    }
+
+    if (!FileUtil::Stat(getRootFilePath()).exists())
+    {
+        // Try to link.
+        LOG_INF("Linking " << LOOLWSD::anonymizeUrl(publicFilePath) << " to "
+                           << getRootFilePathAnonym());
+        if (!Poco::File(getRootFilePath()).exists()
+            && link(publicFilePath.c_str(), getRootFilePath().c_str()) == -1)
+        {
+            // Failed
+            LOG_INF("link(\"" << LOOLWSD::anonymizeUrl(publicFilePath) << "\", \""
+                              << getRootFilePathAnonym() << "\") failed. Will copy. Linking error: "
+                              << Util::symbolicErrno(errno) << ' ' << strerror(errno));
+        }
     }
 
     try
     {
         // Fallback to copying.
-        if (!Poco::File(getRootFilePath()).exists())
+        if (!FileUtil::Stat(getRootFilePath()).exists())
         {
             FileUtil::copyFileTo(publicFilePath, getRootFilePath());
             _isCopy = true;


### PR DESCRIPTION
- wsd: move convert-to docs into the jail
- wsd: cleanup temp incoming directories after use

This PR addresses a number of issues with the life-time management of temporary files by moving them into the jail directory and managing their lifetime through the jail lifetime management system already in place. This also reduces our file-system surface area.