### PR TITLE
cypress: fix random failures on co-4-2 branch.

### DIFF
--- a/cypress_test/integration_tests/common/mobile_helper.js
+++ b/cypress_test/integration_tests/common/mobile_helper.js
@@ -144,6 +144,9 @@ function openMobileWizard() {
 	cy.get('#tb_actionbar_item_mobile_wizard table')
 		.should('have.class', 'checked');
 
+	// Wait for mobile wizard to be idle.
+	cy.wait(2000);
+
 	cy.log('Opening mobile wizard - end.');
 }
 

--- a/cypress_test/integration_tests/mobile/writer/shape_properties_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/shape_properties_spec.js
@@ -61,6 +61,9 @@ describe('Change shape properties via mobile wizard.', function() {
 
 		cy.get('.ui-content.level-0.mobile-wizard')
 			.should('be.visible');
+
+		// Wait for mobile wizard to be idle.
+		cy.wait(2000);
 	}
 
 	function openLinePropertyPanel() {
@@ -71,6 +74,9 @@ describe('Change shape properties via mobile wizard.', function() {
 
 		cy.get('.ui-content.level-0.mobile-wizard')
 			.should('be.visible');
+
+		// Wait for mobile wizard to be idle.
+		cy.wait(2000);
 	}
 
 	it('Check default shape geometry.', function() {

--- a/cypress_test/integration_tests/mobile/writer/table_properties_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/table_properties_spec.js
@@ -28,6 +28,9 @@ describe('Change table properties / layout via mobile wizard.', function() {
 
 		cy.get('.ui-content.level-0.mobile-wizard')
 			.should('be.visible');
+
+		// Wait for mobile wizard to be idle.
+		cy.wait(2000);
 	}
 
 	function moveCursorToFirstCell() {


### PR DESCRIPTION
These tests fail with: "this element is detached from the DOM"
error. This error was handled on master branch with clickOnIdle()
method, which avoids failures comming from the mobile wizard
flickering.
On co-4-2, I add workaround for this issue at those places,
where it fails frequently.

