### PR TITLE
Throttle preview requests on Impress

### DIFF
--- a/loleaflet/src/control/Control.PartsPreview.js
+++ b/loleaflet/src/control/Control.PartsPreview.js
@@ -472,6 +472,12 @@ L.Control.PartsPreview = L.Control.extend({
 
 	_updatePreview: function (e) {
 		if (this._map.getDocType() === 'presentation' || this._map.getDocType() === 'drawing') {
+			this._map._previewRequestsOnFly--;
+			if (this._map._previewRequestsOnFly < 0) {
+				this._map._previewRequestsOnFly = 0;
+				this._map._timeToEmptyQueue = new Date();
+			}
+			this._map._processPreviewQueue();
 			if (!this._previewInitialized)
 				return;
 			if (this._previewTiles[e.id])

--- a/loleaflet/src/control/Control.PartsPreview.js
+++ b/loleaflet/src/control/Control.PartsPreview.js
@@ -57,6 +57,7 @@ L.Control.PartsPreview = L.Control.extend({
 			axis: this._direction,
 			theme: 'dark-thick',
 			scrollInertia: 0,
+			mouseWheelPixels: 100,
 			alwaysShowScrollbar: 1,
 			callbacks:{
 				whileScrolling: function() {
@@ -217,7 +218,7 @@ L.Control.PartsPreview = L.Control.extend({
 		var imgClassName = 'preview-img ' + this.options.imageClass;
 		var img = L.DomUtil.create('img', imgClassName, frame);
 		img.hash = hashCode;
-		img.src = L.Icon.Default.imagePath + '/preview_placeholder.png';
+		img.src = 'images/preview_placeholder.png';
 		img.fetched = false;
 		if (!window.mode.isDesktop()) {
 			(new Hammer(img, {recognizers: [[Hammer.Press]]}))
@@ -443,10 +444,9 @@ L.Control.PartsPreview = L.Control.extend({
 
 				for (it = 0; it < e.partNames.length; it++) {
 					this._previewTiles[it].hash = e.partNames[it];
-					this._previewTiles[it].src = L.Icon.Default.imagePath + '/preview_placeholder.png';
+					this._previewTiles[it].src = 'images/preview_placeholder.png';
 					this._previewTiles[it].fetched = false;
 				}
-				this._onScrollEnd();
 			}
 		}
 		else {

--- a/loleaflet/src/control/Parts.js
+++ b/loleaflet/src/control/Parts.js
@@ -101,6 +101,42 @@ L.Map.include({
 		}
 	},
 
+	_processPreviewQueue: function() {
+		if (this._previewRequestsOnFly > 1) {
+			// we don't always get a response for each tile requests
+			// especially when we have more than one view
+			// the server can determine that we have the tile already
+			// and does not response to us
+			// in that case we cannot decrease previewRequestsOnFly counter
+			// we should not wait more than 2 seconds for each 3 requests
+			var now = new Date();
+			if (now - this._timeToEmptyQueue < 2000)
+				// wait until the queue is empty
+				return;
+			else {
+				this._previewRequestsOnFly = 0;
+				this._timeToEmptyQueue = now;
+			}
+		}
+		// take 3 requests from the queue:
+		while (this._previewRequestsOnFly < 3) {
+			var tile = this._previewQueue.pop();
+			if (!tile)
+				break;
+			this._previewRequestsOnFly++;
+			this._socket.sendMessage(tile[1]);
+		}
+	},
+
+	_addPreviewToQueue: function(part, tileMsg) {
+		for (var tile in this._previewQueue)
+			if (tile[0] === part)
+				// we already have this tile in the queue
+				// no need to ask for it twice
+				return;
+		this._previewQueue.push([part, tileMsg]);
+	},
+
 	getPreview: function (id, index, maxWidth, maxHeight, options) {
 		if (!this._docPreviews) {
 			this._docPreviews = {};
@@ -137,7 +173,7 @@ L.Map.include({
 		}
 
 		if (fetchThumbnail) {
-			this._socket.sendMessage('tile ' +
+			this._addPreviewToQueue(part, 'tile ' +
 							'nviewid=0' + ' ' +
 							'part=' + part + ' ' +
 							'width=' + maxWidth * dpiscale + ' ' +
@@ -148,6 +184,7 @@ L.Map.include({
 							'tileheight=' + tileHeight + ' ' +
 							'id=' + id + ' ' +
 						 'broadcast=no');
+			this._processPreviewQueue();
 		}
 
 		return {width: maxWidth, height: maxHeight};
@@ -163,7 +200,7 @@ L.Map.include({
 
 		var dpiscale = L.getDpiScaleFactor();
 
-		this._socket.sendMessage('tile ' +
+		this._addPreviewToQueue(part, 'tile ' +
 							'nviewid=0' + ' ' +
 							'part=' + part + ' ' +
 							'width=' + width * dpiscale + ' ' +
@@ -174,6 +211,7 @@ L.Map.include({
 							'tileheight=' + tileHeight + ' ' +
 							'id=' + id + ' ' +
 							'broadcast=no');
+		this._processPreviewQueue();
 	},
 
 	removePreviewUpdate: function (id) {

--- a/loleaflet/src/control/Parts.js
+++ b/loleaflet/src/control/Parts.js
@@ -120,9 +120,13 @@ L.Map.include({
 		}
 		// take 3 requests from the queue:
 		while (this._previewRequestsOnFly < 3) {
-			var tile = this._previewQueue.pop();
+			var tile = this._previewQueue.shift();
 			if (!tile)
 				break;
+			var isVisible = this.isPreviewVisible(tile[0], true);
+			if (isVisible != true)
+				// skip this! we can't see it
+				continue;
 			this._previewRequestsOnFly++;
 			this._socket.sendMessage(tile[1]);
 		}

--- a/loleaflet/src/map/Map.js
+++ b/loleaflet/src/map/Map.js
@@ -101,7 +101,7 @@ L.Map = L.Evented.extend({
 		// we are adding components like '/insertfile' at the end which would
 		// lead to URL's of the form <webserver>//insertfile/...
 		options.webserver = options.webserver.replace(/\/*$/, '');
-
+		/* private members */
 		this._handlers = [];
 		this._layers = {};
 		this._zoomBoundLayers = {};
@@ -116,7 +116,9 @@ L.Map = L.Evented.extend({
 		this._helpTarget = null; // help page that fits best the current context
 		this._disableDefaultAction = {}; // The events for which the default handler is disabled and only issues postMessage.
 		this.showSidebar = false;
-
+		this._previewQueue = [];
+		this._previewRequestsOnFly = 0;
+		this._timeToEmptyQueue = new Date();
 		// Focusing:
 		//
 		// Cursor is visible or hidden (e.g. for graphic selection).


### PR DESCRIPTION
We should limit the on-fly preview requests to stop trashing
the server with countless preview requests
depending on the slide size and ask for more when we have them
rendered.

This patch adds the preview tile requests to a queue to be sent to server
as 3 requests at a time until they are rendered and received by the client
Also adding them to the queue allows us to check whether we already have
the same tile in the queue waiting to be sent which we can avoid sending
twice.

Change-Id: I03684dc807a7aef6c996a91efba100a9dca9686d
Signed-off-by: mert <mert.tumer@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

