### PR TITLE
Android: Change target SDK version 28 -> 29

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -4,13 +4,13 @@ apply plugin: 'com.android.application'
 apply from: 'appSettings.gradle'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     buildDir = "${rootProject.getBuildDir()}/app"
 
     defaultConfig {
         // applicationId, versionCode and versionName are defined in appSettings.gradle
         minSdkVersion 21
-        targetSdkVersion 28
+        targetSdkVersion 29
     }
 
     lintOptions {

--- a/android/lib/build.gradle
+++ b/android/lib/build.gradle
@@ -4,12 +4,12 @@ apply plugin: 'com.android.library'
 apply from: 'libSettings.gradle'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     buildDir = "${rootProject.getBuildDir()}/lib"
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
         externalNativeBuild {


### PR DESCRIPTION
Signed-off-by: Yunusemre Şentürk <yunusemre@collabora.com>
Change-Id: Iad612e973ffb4a8851c6d0e657ff124a32b42828

* Target version: co-6-4 

### Summary
We just needed to bump target SDK version for android, Google play requires at least 29 currently

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

