### PR TITLE
jsdialog: make MobileWizardBuilder a separate thing

### DIFF
--- a/loleaflet/Makefile.am
+++ b/loleaflet/Makefile.am
@@ -284,6 +284,7 @@ LOLEAFLET_JS =\
 	src/control/Control.Infobar.js src/control/ColorPicker.js \
 	src/control/Control.JSDialog.js \
 	src/control/Control.JSDialogBuilder.js \
+	src/control/Control.MobileWizardBuilder.js \
 	src/control/Control.MobileWizard.js \
 	src/control/Control.LanguageDialog.js \
 	src/control/Control.Attribution.js \
@@ -604,6 +605,7 @@ pot:
 		src/control/Control.DownloadProgress.js \
 		src/control/Control.FormulaBar.js \
 		src/control/Control.JSDialog.js \
+		src/control/Control.MobileWizardBuilder.js \
 		src/control/Control.JSDialogBuilder.js \
 		src/control/Control.LanguageDialog.js \
 		src/control/Control.Menubar.js \

--- a/loleaflet/css/jsdialogs.css
+++ b/loleaflet/css/jsdialogs.css
@@ -9,6 +9,20 @@
 	background-color: white !important;
 }
 
+.jsdialog.row {
+	display: table-row;
+}
+
+.jsdialog.cell {
+	display: table-cell;
+	vertical-align: middle;
+	padding: 2px;
+}
+
+.jsdialog.vertical {
+	width: max-content;
+}
+
 /* Expander */
 .ui-expander-label::before {
 	content: '>';

--- a/loleaflet/src/control/Control.JSDialog.js
+++ b/loleaflet/src/control/Control.JSDialog.js
@@ -43,7 +43,7 @@ L.Control.JSDialog = L.Control.extend({
 
 		var content = L.DomUtil.create('div', 'lokdialog ui-dialog-content ui-widget-content', container);
 
-		var builder = new L.control.notebookbarBuilder({windowId: data.id, mobileWizard: this, map: this.map, cssClass: 'jsdialog'});
+		var builder = new L.control.jsDialogBuilder({windowId: data.id, mobileWizard: this, map: this.map, cssClass: 'jsdialog'});
 		builder.build(content, [data]);
 
 		var that = this;

--- a/loleaflet/src/control/Control.JSDialogBuilder.js
+++ b/loleaflet/src/control/Control.JSDialogBuilder.js
@@ -2429,56 +2429,6 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		// so no need to recurse here over 'data'.
 		this._addMissingLabels(data);
 	},
-
-	build: function(parent, data) {
-		this._amendJSDialogData(data);
-		for (var childIndex in data) {
-			if (!data[childIndex])
-				continue;
-
-			var childData = data[childIndex];
-			if (!childData)
-				continue;
-			this._parentize(childData);
-			var childType = childData.type;
-			var processChildren = true;
-			var needsToCreateContainer =
-				childType == 'panel' || childType == 'frame';
-
-			if ((childData.id === undefined || childData.id === '' || childData.id === null)
-				&& (childType == 'checkbox' || childType == 'radiobutton')) {
-				continue;
-			}
-
-			var childObject = needsToCreateContainer ? L.DomUtil.createWithId('div', childData.id, parent) : parent;
-
-			var handler = this._controlHandlers[childType];
-			var twoPanelsAsChildren =
-					childData.children && childData.children.length == 2
-					&& childData.children[0] && childData.children[0].type == 'panel'
-					&& childData.children[1] && childData.children[1].type == 'panel';
-
-			if (childData.children && childData.children.length == 1
-				&& childData.children[0] && childData.children[0].type == 'panel') {
-				handler = this._controlHandlers['singlepanel'];
-				processChildren = handler(childObject, childData.children, this);
-			} else if (twoPanelsAsChildren) {
-				handler = this._controlHandlers['paneltabs'];
-				processChildren = handler(childObject, childData.children, this);
-			} else {
-				if (handler)
-					processChildren = handler(childObject, childData, this);
-				else
-					console.warn('JSDialogBuilder: Unsupported control type: "' + childType + '"');
-
-				if (processChildren && childData.children != undefined)
-					this.build(childObject, childData.children);
-				else if (childData.visible && (childData.visible === false || childData.visible === 'false')) {
-					$('#' + childData.id).addClass('hidden-from-event');
-				}
-			}
-		}
-	}
 });
 
 L.Control.JSDialogBuilder.getMenuStructureForMobileWizard = function(menu, mainMenu, itemCommand) {

--- a/loleaflet/src/control/Control.MobileWizard.js
+++ b/loleaflet/src/control/Control.MobileWizard.js
@@ -397,7 +397,7 @@ L.Control.MobileWizard = L.Control.extend({
 				history.pushState({context: 'mobile-wizard', level: 0}, 'mobile-wizard-level-0');
 			}
 
-			var builder = L.control.jsDialogBuilder({mobileWizard: this, map: this.map, cssClass: 'mobile-wizard'});
+			var builder = L.control.mobileWizardBuilder({mobileWizard: this, map: this.map, cssClass: 'mobile-wizard'});
 			builder.build(this.content.get(0), [data]);
 
 			this._mainTitle = data.text ? data.text : '';

--- a/loleaflet/src/control/Control.MobileWizardBuilder.js
+++ b/loleaflet/src/control/Control.MobileWizardBuilder.js
@@ -14,7 +14,29 @@ L.Control.MobileWizardBuilder = L.Control.JSDialogBuilder.extend({
 	},
 
 	_overrideHandlers: function() {
-		// eg. this._controlHandlers['combobox'] = this._comboboxControlHandler;
+		this._controlHandlers['grid'] = this._gridHandler;
+	},
+
+	_swapControls: function(controls, indexA, indexB) {
+		var tmp = controls[indexA];
+		controls[indexA] = controls[indexB];
+		controls[indexB] = tmp;
+	},
+
+	/// reorder widgets in case of vertical placement of labels and corresponding controls
+	/// current implementation fits for 2 column views
+	_gridHandler: function(parentContainer, data, builder) {
+		var children = data.children;
+		if (children) {
+			var count = children.length;
+			for (var i = 0; i < count - 2; i++) {
+				if (children[i].type == 'fixedtext' && children[i+1].type == 'fixedtext') {
+					builder._swapControls(children, i+1, i+2);
+				}
+			}
+		}
+
+		return true;
 	},
 
 	build: function(parent, data) {

--- a/loleaflet/src/control/Control.MobileWizardBuilder.js
+++ b/loleaflet/src/control/Control.MobileWizardBuilder.js
@@ -4,7 +4,7 @@
  * from the JSON description provided by the server.
  */
 
-/* global */
+/* global $ */
 
 L.Control.MobileWizardBuilder = L.Control.JSDialogBuilder.extend({
 	_customizeOptions: function() {
@@ -16,6 +16,56 @@ L.Control.MobileWizardBuilder = L.Control.JSDialogBuilder.extend({
 	_overrideHandlers: function() {
 		// eg. this._controlHandlers['combobox'] = this._comboboxControlHandler;
 	},
+
+	build: function(parent, data) {
+		this._amendJSDialogData(data);
+		for (var childIndex in data) {
+			if (!data[childIndex])
+				continue;
+
+			var childData = data[childIndex];
+			if (!childData)
+				continue;
+			this._parentize(childData);
+			var childType = childData.type;
+			var processChildren = true;
+			var needsToCreateContainer =
+				childType == 'panel' || childType == 'frame';
+
+			if ((childData.id === undefined || childData.id === '' || childData.id === null)
+				&& (childType == 'checkbox' || childType == 'radiobutton')) {
+				continue;
+			}
+
+			var childObject = needsToCreateContainer ? L.DomUtil.createWithId('div', childData.id, parent) : parent;
+
+			var handler = this._controlHandlers[childType];
+			var twoPanelsAsChildren =
+					childData.children && childData.children.length == 2
+					&& childData.children[0] && childData.children[0].type == 'panel'
+					&& childData.children[1] && childData.children[1].type == 'panel';
+
+			if (childData.children && childData.children.length == 1
+				&& childData.children[0] && childData.children[0].type == 'panel') {
+				handler = this._controlHandlers['singlepanel'];
+				processChildren = handler(childObject, childData.children, this);
+			} else if (twoPanelsAsChildren) {
+				handler = this._controlHandlers['paneltabs'];
+				processChildren = handler(childObject, childData.children, this);
+			} else {
+				if (handler)
+					processChildren = handler(childObject, childData, this);
+				else
+					console.warn('JSDialogBuilder: Unsupported control type: "' + childType + '"');
+
+				if (processChildren && childData.children != undefined)
+					this.build(childObject, childData.children);
+				else if (childData.visible && (childData.visible === false || childData.visible === 'false')) {
+					$('#' + childData.id).addClass('hidden-from-event');
+				}
+			}
+		}
+	}
 });
 
 L.control.mobileWizardBuilder = function (options) {

--- a/loleaflet/src/control/Control.MobileWizardBuilder.js
+++ b/loleaflet/src/control/Control.MobileWizardBuilder.js
@@ -1,0 +1,27 @@
+/* -*- js-indent-level: 8 -*- */
+/*
+ * L.Control.MobileWizardBuilder used for building the native HTML components
+ * from the JSON description provided by the server.
+ */
+
+/* global */
+
+L.Control.MobileWizardBuilder = L.Control.JSDialogBuilder.extend({
+	_customizeOptions: function() {
+		this.options.noLabelsForUnoButtons = false;
+		this.options.useInLineLabelsForUnoButtons = false;
+		this.options.cssClass = 'mobile-wizard';
+	},
+
+	_overrideHandlers: function() {
+		// eg. this._controlHandlers['combobox'] = this._comboboxControlHandler;
+	},
+});
+
+L.control.mobileWizardBuilder = function (options) {
+	var builder = new L.Control.MobileWizardBuilder(options);
+	builder._setup(options);
+	builder._overrideHandlers();
+	builder._customizeOptions();
+	return builder;
+};


### PR DESCRIPTION
We need JSDialogBuilder to be a common class for other builders.
MobileWizardBuilder will handle mobile specific cases only.

Change-Id: Icff024fe70d0e5386c92bdd106b6db2e74a584b5
Signed-off-by: Szymon Kłos <szymon.klos@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

