### PR TITLE
loleaflet: update the document container when the size changes

### DIFF
--- a/loleaflet/src/control/Control.LokDialog.js
+++ b/loleaflet/src/control/Control.LokDialog.js
@@ -1654,6 +1654,8 @@ L.Control.LokDialog = L.Control.extend({
 		else
 			this._map.options.documentContainer.style.right = (width - 15).toString() + 'px';
 
+		this._map._onResize();
+
 		var spreadsheetRowColumnFrame = L.DomUtil.get('spreadsheet-row-column-frame');
 		if (spreadsheetRowColumnFrame)
 			spreadsheetRowColumnFrame.style.right = width.toString() + 'px';


### PR DESCRIPTION
Always call resize update when sidebar modifies the document
the size values, this will cause internal events to update the
document bounds, zoom, etc.

Change-Id: If8efce4b08b96e6156a87f69fe6188cf9d75f5d5
Signed-off-by: Henry Castro <hcastro@collabora.com>
