### PR TITLE
Sidebar: avoid using two scrollbars by fixing bottom position

### DIFF
--- a/loleaflet/css/loleaflet.css
+++ b/loleaflet/css/loleaflet.css
@@ -192,13 +192,14 @@ body {
 	position: absolute;
 	top: 77px;
 	right: 0px;
-	bottom: 72px;
 	border-top: 1px solid #b6b6b6;
 	border-left: 1px solid #b6b6b6;
 	overflow: hidden;
 	z-index: 990;
 }
-
+nav.spreadsheet-color-indicator ~ #sidebar-dock-wrapper {
+	bottom: 72px;
+}
 #sidebar-panel {
 	padding: 0px;
 	margin: 0px;


### PR DESCRIPTION
- set a fixed bottom position only when on calc (due to tabs)

Signed-off-by: Pedro Silva <pedro.silva@collabora.com>
Change-Id: I9f98cdc65e83c06da814fe7b89b43ebbe6760f40
