### PR TITLE
leaflet: calc text selection is never removed

### DIFF
--- a/loleaflet/src/layer/tile/TileLayer.js
+++ b/loleaflet/src/layer/tile/TileLayer.js
@@ -1238,6 +1238,7 @@ L.TileLayer = L.GridLayer.extend({
 
 		// Remove input help if there is any:
 		this._removeInputHelpMarker();
+		this._removeSelection();
 	},
 
 	_removeInputHelpMarker: function() {
@@ -3278,14 +3279,19 @@ L.TileLayer = L.GridLayer.extend({
 			this._updateMarkers();
 		}
 		else {
-			this._textSelectionStart = null;
-			this._textSelectionEnd = null;
-			this._selectedTextContent = '';
-			for (var key in this._selectionHandles) {
-				this._map.removeLayer(this._selectionHandles[key]);
-				this._selectionHandles[key].isDragged = false;
-			}
+			this._removeSelection();
 		}
+	},
+
+	_removeSelection: function() {
+		this._textSelectionStart = null;
+		this._textSelectionEnd = null;
+		this._selectedTextContent = '';
+		for (var key in this._selectionHandles) {
+			this._map.removeLayer(this._selectionHandles[key]);
+			this._selectionHandles[key].isDragged = false;
+		}
+		this._selections.clearLayers();
 	},
 
 	_updateMarkers: function() {


### PR DESCRIPTION


Change-Id: I2c4bd4e46a42854bdcc5a09f6af170d33dc4e8c0
Signed-off-by: Pranam Lashkari <lpranam@collabora.com>


* Target version: distro/collabora/co-6-4  

### Summary
problem:
once text inside the cell is selected,
taping on other cell does not remove the selection


### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

