### PR TITLE
Storage refactoring for Async IO

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -790,11 +790,11 @@ bool DocumentBroker::load(const std::shared_ptr<ClientSession>& session, const s
     // Let's load the document now, if not loaded.
     if (!_storage->isLoaded())
     {
-        std::string localPath = _storage->loadStorageFileToLocal(
+        std::string localPath = _storage->downloadStorageFileToLocal(
             session->getAuthorization(), session->getCookies(), *_lockCtx, templateSource);
 
         // Only lock the document on storage for editing sessions
-        // FIXME: why not lock before loadStorageFileToLocal? Would also prevent race conditions
+        // FIXME: why not lock before downloadStorageFileToLocal? Would also prevent race conditions
         if (!session->isReadOnly() &&
             !_storage->updateLockState(session->getAuthorization(), session->getCookies(), *_lockCtx, true))
         {
@@ -1068,7 +1068,7 @@ bool DocumentBroker::saveToStorageInternal(const std::string& sessionId, bool su
     LOG_DBG("Persisting [" << _docKey << "] after saving to URI [" << uriAnonym << "].");
 
     assert(_storage && _tileCache);
-    const StorageBase::SaveResult storageSaveResult = _storage->saveLocalFileToStorage(
+    const StorageBase::UploadResult storageSaveResult = _storage->uploadLocalFileToStorage(
         auth, it->second->getCookies(), *_lockCtx, saveAsPath, saveAsFilename, isRename);
 
     const StorageUploadDetails details { uriAnonym, newFileModifiedTime, it->second, isSaveAs, isRename };
@@ -1076,14 +1076,14 @@ bool DocumentBroker::saveToStorageInternal(const std::string& sessionId, bool su
 }
 
 bool DocumentBroker::handleUploadToStorageResponse(const StorageUploadDetails& details,
-                                                   const StorageBase::SaveResult& storageSaveResult)
+                                                   const StorageBase::UploadResult& storageSaveResult)
 {
     // Storage save is considered successful when either storage returns OK or the document on the storage
     // was changed and it was used to overwrite local changes
     _lastStorageSaveSuccessful
-        = storageSaveResult.getResult() == StorageBase::SaveResult::Result::OK ||
-        storageSaveResult.getResult() == StorageBase::SaveResult::Result::DOC_CHANGED;
-    if (storageSaveResult.getResult() == StorageBase::SaveResult::Result::OK)
+        = storageSaveResult.getResult() == StorageBase::UploadResult::Result::OK ||
+        storageSaveResult.getResult() == StorageBase::UploadResult::Result::DOC_CHANGED;
+    if (storageSaveResult.getResult() == StorageBase::UploadResult::Result::OK)
     {
 #if !MOBILEAPP
         WopiStorage* wopiStorage = dynamic_cast<WopiStorage*>(_storage.get());
@@ -1103,8 +1103,9 @@ bool DocumentBroker::handleUploadToStorageResponse(const StorageUploadDetails& d
             // After a successful save, we are sure that document in the storage is same as ours
             _documentChangedInStorage = false;
 
-            LOG_DBG("Saved docKey [" << _docKey << "] to URI [" << details.uriAnonym << "] and updated timestamps. " <<
-                    " Document modified timestamp: " << _documentLastModifiedTime);
+            LOG_DBG("Uploaded docKey [" << _docKey << "] to URI [" << details.uriAnonym
+                                        << "] and updated timestamps. Document modified timestamp: "
+                                        << _documentLastModifiedTime);
 
             // Resume polling.
             _poll->wakeup();
@@ -1137,9 +1138,9 @@ bool DocumentBroker::handleUploadToStorageResponse(const StorageUploadDetails& d
             const auto session = details.session.lock();
             if (session)
             {
-                LOG_DBG("Saved As docKey [" << _docKey << "] to URI [" << LOOLWSD::anonymizeUrl(url)
-                                            << "] with name [" << filenameAnonym
-                                            << "] successfully.");
+                LOG_DBG("Uploaded SaveAs docKey [" << _docKey << "] to URI ["
+                                                   << LOOLWSD::anonymizeUrl(url) << "] with name ["
+                                                   << filenameAnonym << "] successfully.");
 
                 std::ostringstream oss;
                 oss << "saveas: url=" << url << " filename=" << encodedName
@@ -1149,9 +1150,9 @@ bool DocumentBroker::handleUploadToStorageResponse(const StorageUploadDetails& d
             }
             else
             {
-                LOG_DBG("Saved As docKey [" << _docKey << "] to URI [" << LOOLWSD::anonymizeUrl(url)
-                                            << "] with name [" << filenameAnonym
-                                            << "] successfully, but the client session is closed.");
+                LOG_DBG("Uploaded SaveAs docKey ["
+                        << _docKey << "] to URI [" << LOOLWSD::anonymizeUrl(url) << "] with name ["
+                        << filenameAnonym << "] successfully, but the client session is closed.");
             }
         }
 
@@ -1159,10 +1160,11 @@ bool DocumentBroker::handleUploadToStorageResponse(const StorageUploadDetails& d
 
         return true;
     }
-    else if (storageSaveResult.getResult() == StorageBase::SaveResult::Result::DISKFULL)
+    else if (storageSaveResult.getResult() == StorageBase::UploadResult::Result::DISKFULL)
     {
-        LOG_WRN("Disk full while saving docKey [" << _docKey << "] to URI [" << details.uriAnonym <<
-                "]. Making all sessions on doc read-only and notifying clients.");
+        LOG_WRN("Disk full while uploading docKey ["
+                << _docKey << "] to URI [" << details.uriAnonym
+                << "]. Making all sessions on doc read-only and notifying clients.");
 
         // Make everyone readonly and tell everyone that storage is low on diskspace.
         for (const auto& sessionIt : _sessions)
@@ -1171,47 +1173,47 @@ bool DocumentBroker::handleUploadToStorageResponse(const StorageUploadDetails& d
         }
         broadcastSaveResult(false, "Disk full", storageSaveResult.getErrorMsg());
     }
-    else if (storageSaveResult.getResult() == StorageBase::SaveResult::Result::UNAUTHORIZED)
+    else if (storageSaveResult.getResult() == StorageBase::UploadResult::Result::UNAUTHORIZED)
     {
         const auto session = details.session.lock();
         if (session)
         {
-            LOG_ERR("Cannot save docKey ["
+            LOG_ERR("Cannot upload docKey ["
                     << _docKey << "] to storage URI [" << details.uriAnonym
                     << "]. Invalid or expired access token. Notifying client.");
             session->sendTextFrameAndLogError("error: cmd=storage kind=saveunauthorized");
         }
         else
         {
-            LOG_ERR("Cannot save docKey ["
+            LOG_ERR("Cannot upload docKey ["
                     << _docKey << "] to storage URI [" << details.uriAnonym
                     << "]. Invalid or expired access token. The client session is closed.");
         }
 
         broadcastSaveResult(false, "Invalid or expired access token");
     }
-    else if (storageSaveResult.getResult() == StorageBase::SaveResult::Result::FAILED)
+    else if (storageSaveResult.getResult() == StorageBase::UploadResult::Result::FAILED)
     {
         //TODO: Should we notify all clients?
         const auto session = details.session.lock();
         if (session)
         {
-            LOG_ERR("Failed to save docKey [" << _docKey << "] to URI [" << details.uriAnonym
-                                              << "]. Notifying client.");
+            LOG_ERR("Failed to upload docKey [" << _docKey << "] to URI [" << details.uriAnonym
+                                                << "]. Notifying client.");
             const std::string msg = std::string("error: cmd=storage kind=")
                                     + (details.isRename ? "renamefailed" : "savefailed");
             session->sendTextFrame(msg);
         }
         else
         {
-            LOG_ERR("Failed to save docKey [" << _docKey << "] to URI [" << details.uriAnonym
-                                              << "]. The client session is closed.");
+            LOG_ERR("Failed to upload docKey [" << _docKey << "] to URI [" << details.uriAnonym
+                                                << "]. The client session is closed.");
         }
 
         broadcastSaveResult(false, "Save failed", storageSaveResult.getErrorMsg());
     }
-    else if (storageSaveResult.getResult() == StorageBase::SaveResult::Result::DOC_CHANGED
-             || storageSaveResult.getResult() == StorageBase::SaveResult::Result::CONFLICT)
+    else if (storageSaveResult.getResult() == StorageBase::UploadResult::Result::DOC_CHANGED
+             || storageSaveResult.getResult() == StorageBase::UploadResult::Result::CONFLICT)
     {
         LOG_ERR("PutFile says that Document changed in storage");
         _documentChangedInStorage = true;

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1070,6 +1070,14 @@ bool DocumentBroker::saveToStorageInternal(const std::string& sessionId, bool su
     assert(_storage && _tileCache);
     const StorageBase::SaveResult storageSaveResult = _storage->saveLocalFileToStorage(
         auth, it->second->getCookies(), *_lockCtx, saveAsPath, saveAsFilename, isRename);
+
+    const StorageUploadDetails details { uriAnonym, newFileModifiedTime, it->second, isSaveAs, isRename };
+    return handleUploadToStorageResponse(details, storageSaveResult);
+}
+
+bool DocumentBroker::handleUploadToStorageResponse(const StorageUploadDetails& details,
+                                                   const StorageBase::SaveResult& storageSaveResult)
+{
     // Storage save is considered successful when either storage returns OK or the document on the storage
     // was changed and it was used to overwrite local changes
     _lastStorageSaveSuccessful
@@ -1083,10 +1091,10 @@ bool DocumentBroker::saveToStorageInternal(const std::string& sessionId, bool su
             Admin::instance().setDocWopiUploadDuration(_docKey, std::chrono::duration_cast<std::chrono::milliseconds>(wopiStorage->getWopiSaveDuration()));
 #endif
 
-        if (!isSaveAs && !isRename)
+        if (!details.isSaveAs && !details.isRename)
         {
             // Saved and stored; update flags.
-            _lastFileModifiedTime = newFileModifiedTime;
+            _lastFileModifiedTime = details.newFileModifiedTime;
             _lastSaveTime = std::chrono::steady_clock::now();
 
             // Save the storage timestamp.
@@ -1095,13 +1103,13 @@ bool DocumentBroker::saveToStorageInternal(const std::string& sessionId, bool su
             // After a successful save, we are sure that document in the storage is same as ours
             _documentChangedInStorage = false;
 
-            LOG_DBG("Saved docKey [" << _docKey << "] to URI [" << uriAnonym << "] and updated timestamps. " <<
+            LOG_DBG("Saved docKey [" << _docKey << "] to URI [" << details.uriAnonym << "] and updated timestamps. " <<
                     " Document modified timestamp: " << _documentLastModifiedTime);
 
             // Resume polling.
             _poll->wakeup();
         }
-        else if (isRename)
+        else if (details.isRename)
         {
             // encode the name
             const std::string& filename = storageSaveResult.getSaveAsName();
@@ -1129,7 +1137,7 @@ bool DocumentBroker::saveToStorageInternal(const std::string& sessionId, bool su
             std::ostringstream oss;
             oss << "saveas: url=" << url << " filename=" << encodedName
                 << " xfilename=" << filenameAnonym;
-            it->second->sendTextFrame(oss.str());
+            details.session->sendTextFrame(oss.str());
 
             LOG_DBG("Saved As docKey [" << _docKey << "] to URI [" << LOOLWSD::anonymizeUrl(url) <<
                     "] with name [" << filenameAnonym << "] successfully.");
@@ -1141,7 +1149,7 @@ bool DocumentBroker::saveToStorageInternal(const std::string& sessionId, bool su
     }
     else if (storageSaveResult.getResult() == StorageBase::SaveResult::Result::DISKFULL)
     {
-        LOG_WRN("Disk full while saving docKey [" << _docKey << "] to URI [" << uriAnonym <<
+        LOG_WRN("Disk full while saving docKey [" << _docKey << "] to URI [" << details.uriAnonym <<
                 "]. Making all sessions on doc read-only and notifying clients.");
 
         // Make everyone readonly and tell everyone that storage is low on diskspace.
@@ -1153,18 +1161,18 @@ bool DocumentBroker::saveToStorageInternal(const std::string& sessionId, bool su
     }
     else if (storageSaveResult.getResult() == StorageBase::SaveResult::Result::UNAUTHORIZED)
     {
-        LOG_ERR("Cannot save docKey [" << _docKey << "] to storage URI [" << uriAnonym <<
+        LOG_ERR("Cannot save docKey [" << _docKey << "] to storage URI [" << details.uriAnonym <<
                 "]. Invalid or expired access token. Notifying client.");
-        it->second->sendTextFrameAndLogError("error: cmd=storage kind=saveunauthorized");
+        details.session->sendTextFrameAndLogError("error: cmd=storage kind=saveunauthorized");
         broadcastSaveResult(false, "Invalid or expired access token");
     }
     else if (storageSaveResult.getResult() == StorageBase::SaveResult::Result::FAILED)
     {
         //TODO: Should we notify all clients?
-        LOG_ERR("Failed to save docKey [" << _docKey << "] to URI [" << uriAnonym << "]. Notifying client.");
+        LOG_ERR("Failed to save docKey [" << _docKey << "] to URI [" << details.uriAnonym << "]. Notifying client.");
         std::ostringstream oss;
-        oss << "error: cmd=storage kind=" << (isRename ? "renamefailed" : "savefailed");
-        it->second->sendTextFrame(oss.str());
+        oss << "error: cmd=storage kind=" << (details.isRename ? "renamefailed" : "savefailed");
+        details.session->sendTextFrame(oss.str());
         broadcastSaveResult(false, "Save failed", storageSaveResult.getErrorMsg());
     }
     else if (storageSaveResult.getResult() == StorageBase::SaveResult::Result::DOC_CHANGED

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1134,13 +1134,25 @@ bool DocumentBroker::handleUploadToStorageResponse(const StorageUploadDetails& d
             Poco::URI::encode(filename, "", encodedName);
             const std::string filenameAnonym = LOOLWSD::anonymizeUrl(filename);
 
-            std::ostringstream oss;
-            oss << "saveas: url=" << url << " filename=" << encodedName
-                << " xfilename=" << filenameAnonym;
-            details.session->sendTextFrame(oss.str());
+            const auto session = details.session.lock();
+            if (session)
+            {
+                LOG_DBG("Saved As docKey [" << _docKey << "] to URI [" << LOOLWSD::anonymizeUrl(url)
+                                            << "] with name [" << filenameAnonym
+                                            << "] successfully.");
 
-            LOG_DBG("Saved As docKey [" << _docKey << "] to URI [" << LOOLWSD::anonymizeUrl(url) <<
-                    "] with name [" << filenameAnonym << "] successfully.");
+                std::ostringstream oss;
+                oss << "saveas: url=" << url << " filename=" << encodedName
+                    << " xfilename=" << filenameAnonym;
+
+                session->sendTextFrame(oss.str());
+            }
+            else
+            {
+                LOG_DBG("Saved As docKey [" << _docKey << "] to URI [" << LOOLWSD::anonymizeUrl(url)
+                                            << "] with name [" << filenameAnonym
+                                            << "] successfully, but the client session is closed.");
+            }
         }
 
         broadcastLastModificationTime();
@@ -1161,18 +1173,41 @@ bool DocumentBroker::handleUploadToStorageResponse(const StorageUploadDetails& d
     }
     else if (storageSaveResult.getResult() == StorageBase::SaveResult::Result::UNAUTHORIZED)
     {
-        LOG_ERR("Cannot save docKey [" << _docKey << "] to storage URI [" << details.uriAnonym <<
-                "]. Invalid or expired access token. Notifying client.");
-        details.session->sendTextFrameAndLogError("error: cmd=storage kind=saveunauthorized");
+        const auto session = details.session.lock();
+        if (session)
+        {
+            LOG_ERR("Cannot save docKey ["
+                    << _docKey << "] to storage URI [" << details.uriAnonym
+                    << "]. Invalid or expired access token. Notifying client.");
+            session->sendTextFrameAndLogError("error: cmd=storage kind=saveunauthorized");
+        }
+        else
+        {
+            LOG_ERR("Cannot save docKey ["
+                    << _docKey << "] to storage URI [" << details.uriAnonym
+                    << "]. Invalid or expired access token. The client session is closed.");
+        }
+
         broadcastSaveResult(false, "Invalid or expired access token");
     }
     else if (storageSaveResult.getResult() == StorageBase::SaveResult::Result::FAILED)
     {
         //TODO: Should we notify all clients?
-        LOG_ERR("Failed to save docKey [" << _docKey << "] to URI [" << details.uriAnonym << "]. Notifying client.");
-        std::ostringstream oss;
-        oss << "error: cmd=storage kind=" << (details.isRename ? "renamefailed" : "savefailed");
-        details.session->sendTextFrame(oss.str());
+        const auto session = details.session.lock();
+        if (session)
+        {
+            LOG_ERR("Failed to save docKey [" << _docKey << "] to URI [" << details.uriAnonym
+                                              << "]. Notifying client.");
+            const std::string msg = std::string("error: cmd=storage kind=")
+                                    + (details.isRename ? "renamefailed" : "savefailed");
+            session->sendTextFrame(msg);
+        }
+        else
+        {
+            LOG_ERR("Failed to save docKey [" << _docKey << "] to URI [" << details.uriAnonym
+                                              << "]. The client session is closed.");
+        }
+
         broadcastSaveResult(false, "Save failed", storageSaveResult.getErrorMsg());
     }
     else if (storageSaveResult.getResult() == StorageBase::SaveResult::Result::DOC_CHANGED

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -64,28 +64,22 @@ void ChildProcess::setDocumentBroker(const std::shared_ptr<DocumentBroker>& docB
     docBroker->addSocketToPoll(getSocket());
 }
 
-namespace
+void DocumentBroker::broadcastLastModificationTime(
+    const std::shared_ptr<ClientSession>& session) const
 {
-
-void sendLastModificationTime(const std::shared_ptr<Session>& session,
-                              DocumentBroker* documentBroker,
-                              const std::chrono::system_clock::time_point& documentLastModifiedTime)
-{
-    if (!session)
-        return;
-
-    if (documentLastModifiedTime == std::chrono::system_clock::time_point())
+    if (_documentLastModifiedTime == std::chrono::system_clock::time_point())
         // No time from the storage (e.g., SharePoint 2013 and 2016) -> don't send
         return;
 
-    std::stringstream stream;
-    stream << "lastmodtime: " << documentLastModifiedTime;
+    std::ostringstream stream;
+    stream << "lastmodtime: " << _documentLastModifiedTime;
     const std::string message = stream.str();
-    session->sendTextFrame(message);
-    if (documentBroker)
-        documentBroker->broadcastMessage(message);
-}
 
+    // While loading, the current session is not yet added to
+    // the sessions container, so we need to send to it directly.
+    if (session)
+        session->sendTextFrame(message);
+    broadcastMessage(message);
 }
 
 Poco::URI DocumentBroker::sanitizeURI(const std::string& uri)
@@ -791,7 +785,7 @@ bool DocumentBroker::load(const std::shared_ptr<ClientSession>& session, const s
         }
     }
 
-    sendLastModificationTime(session, this, _documentLastModifiedTime);
+    broadcastLastModificationTime(session);
 
     // Let's load the document now, if not loaded.
     if (!_storage->isLoaded())
@@ -1141,7 +1135,7 @@ bool DocumentBroker::saveToStorageInternal(const std::string& sessionId, bool su
                     "] with name [" << filenameAnonym << "] successfully.");
         }
 
-        sendLastModificationTime(it->second, this, _documentLastModifiedTime);
+        broadcastLastModificationTime();
 
         return true;
     }
@@ -2341,7 +2335,7 @@ void DocumentBroker::closeDocument(const std::string& reason)
     _closeRequest = true;
 }
 
-void DocumentBroker::broadcastMessage(const std::string& message)
+void DocumentBroker::broadcastMessage(const std::string& message) const
 {
     assertCorrectThread();
 

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -358,7 +358,7 @@ private:
     };
 
     bool handleUploadToStorageResponse(const StorageUploadDetails& details,
-                                       const StorageBase::SaveResult& storageSaveResult);
+                                       const StorageBase::UploadResult& storageSaveResult);
 
     /**
      * Report back the save result to PostMessage users (Action_Save_Resp)

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -26,6 +26,7 @@
 #include "Util.hpp"
 #include "net/Socket.hpp"
 #include "net/WebSocketHandler.hpp"
+#include "Storage.hpp"
 
 #include "common/SigUtil.hpp"
 #include "common/Session.hpp"
@@ -38,7 +39,6 @@
 class PrisonerRequestDispatcher;
 class DocumentBroker;
 struct LockContext;
-class StorageBase;
 class TileCache;
 class Message;
 
@@ -347,6 +347,18 @@ private:
                                const std::string& saveAsPath = std::string(),
                                const std::string& saveAsFilename = std::string(),
                                const bool isRename = false, const bool force = false);
+
+    struct StorageUploadDetails
+    {
+        const std::string uriAnonym;
+        const std::chrono::system_clock::time_point newFileModifiedTime;
+        const std::shared_ptr<class ClientSession> session;
+        const bool isSaveAs;
+        const bool isRename;
+    };
+
+    bool handleUploadToStorageResponse(const StorageUploadDetails& details,
+                                       const StorageBase::SaveResult& storageSaveResult);
 
     /**
      * Report back the save result to PostMessage users (Action_Save_Resp)

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -352,7 +352,7 @@ private:
     {
         const std::string uriAnonym;
         const std::chrono::system_clock::time_point newFileModifiedTime;
-        const std::shared_ptr<class ClientSession> session;
+        const std::weak_ptr<class ClientSession> session;
         const bool isSaveAs;
         const bool isRename;
     };

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -286,7 +286,7 @@ public:
                      bool isExitSave = false, const std::string& extendedData = std::string());
 
     /// Sends a message to all sessions
-    void broadcastMessage(const std::string& message);
+    void broadcastMessage(const std::string& message) const;
 
     /// Returns true iff an initial setting by the given name is already initialized.
     bool isInitialSettingSet(const std::string& name) const;
@@ -355,6 +355,9 @@ private:
      * @param errorMsg: Long error msg (Error message from WOPI host if any)
      */
     void broadcastSaveResult(bool success, const std::string& result = "", const std::string& errorMsg = "");
+
+    /// Broadcasts to all sessions the last modification time of the document.
+    void broadcastLastModificationTime(const std::shared_ptr<ClientSession>& session = nullptr) const;
 
     /// True iff a save is in progress (requested but not completed).
     bool isSaving() const { return _lastSaveResponseTime < _lastSaveRequestTime; }

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -1011,7 +1011,6 @@ WopiStorage::saveLocalFileToStorage(const Authorization& auth, const std::string
     LOG_INF("Uploading " << size << " bytes from [" << filePathAnonym << "] to URI via WOPI ["
                          << uriAnonym << "].");
 
-    StorageBase::SaveResult saveResult(StorageBase::SaveResult::Result::FAILED);
     const auto startTime = std::chrono::steady_clock::now();
     try
     {
@@ -1100,12 +1099,41 @@ WopiStorage::saveLocalFileToStorage(const Authorization& auth, const std::string
 
         _wopiSaveDuration = std::chrono::steady_clock::now() - startTime;
 
+        WopiUploadDetails details
+            = { filePathAnonym, uriAnonym, response.getReason(), response.getStatus(), size,
+                isSaveAs,       isRename };
+
         std::ostringstream oss;
         Poco::StreamCopier::copyStream(rs, oss);
-        std::string responseString = oss.str();
+        return handleUploadToStorageResponse(details, oss.str());
+    }
+    catch (const Poco::Exception& pexc)
+    {
+        LOG_ERR("Cannot save file to WOPI storage uri [" << uriAnonym << "]. Error: " <<
+                pexc.displayText() << (pexc.nested() ? " (" + pexc.nested()->displayText() + ')' : ""));
+    }
+    catch (const BadRequestException& exc)
+    {
+        LOG_ERR("Cannot save file to WOPI storage uri [" + uriAnonym + "]. Error: " << exc.what());
+    }
+
+    return StorageBase::SaveResult::Result::FAILED;
+}
+
+StorageBase::SaveResult WopiStorage::handleUploadToStorageResponse(const WopiUploadDetails& details,
+                                                                   std::string responseString)
+{
+    // Assume we failed, unless we have confirmation of success.
+    StorageBase::SaveResult saveResult(StorageBase::SaveResult::Result::FAILED);
+    try
+    {
+        const std::string origResponseString = responseString;
+
         saveResult.setErrorMsg(responseString);
 
-        const std::string wopiLog(isSaveAs ? "WOPI::PutRelativeFile" : (isRename ? "WOPI::RenameFile":"WOPI::PutFile"));
+        const std::string wopiLog(details.isSaveAs
+                                      ? "WOPI::PutRelativeFile"
+                                      : (details.isRename ? "WOPI::RenameFile" : "WOPI::PutFile"));
 
         if (Log::infoEnabled())
         {
@@ -1117,14 +1145,15 @@ WopiStorage::saveLocalFileToStorage(const Authorization& auth, const std::string
                     // Anonymize the filename
                     std::string url;
                     std::string filename;
-                    if (JsonUtil::findJSONValue(object, "Url", url) &&
-                        JsonUtil::findJSONValue(object, "Name", filename))
+                    if (JsonUtil::findJSONValue(object, "Url", url)
+                        && JsonUtil::findJSONValue(object, "Name", filename))
                     {
                         // Get the FileId form the URL, which we use as the anonymized filename.
                         std::string decodedUrl;
                         Poco::URI::decode(url, decodedUrl);
                         const std::string obfuscatedFileId = Util::getFilenameFromURL(decodedUrl);
-                        Util::mapAnonymized(obfuscatedFileId, obfuscatedFileId); // Identity, to avoid re-anonymizing.
+                        Util::mapAnonymized(obfuscatedFileId,
+                                            obfuscatedFileId); // Identity, to avoid re-anonymizing.
 
                         const std::string filenameOnly = Util::getFilenameFromURL(filename);
                         Util::mapAnonymized(filenameOnly, obfuscatedFileId);
@@ -1138,22 +1167,25 @@ WopiStorage::saveLocalFileToStorage(const Authorization& auth, const std::string
                 }
             }
 
-            LOG_INF(wopiLog << " uploaded " << size << " bytes from [" << filePathAnonym << "] -> ["
-                            << uriAnonym << "]: " << response.getStatus() << ' '
-                            << response.getReason() << ": " << responseString);
+            LOG_INF(wopiLog << " uploaded " << details.size << " bytes from ["
+                            << details.filePathAnonym << "] -> [" << details.uriAnonym
+                            << "]: " << details.httpResponseCode << ' '
+                            << details.httpResponseReason << ": " << responseString);
         }
 
-        if (response.getStatus() == Poco::Net::HTTPResponse::HTTP_OK)
+        if (details.httpResponseCode == Poco::Net::HTTPResponse::HTTP_OK)
         {
             saveResult.setResult(StorageBase::SaveResult::Result::OK);
             Poco::JSON::Object::Ptr object;
-            if (JsonUtil::parseJSON(oss.str(), object))
+            if (JsonUtil::parseJSON(origResponseString, object))
             {
-                const std::string lastModifiedTime = JsonUtil::getJSONValue<std::string>(object, "LastModifiedTime");
+                const std::string lastModifiedTime
+                    = JsonUtil::getJSONValue<std::string>(object, "LastModifiedTime");
                 LOG_TRC(wopiLog << " returns LastModifiedTime [" << lastModifiedTime << "].");
-                getFileInfo().setModifiedTime(Util::iso8601ToTimestamp(lastModifiedTime, "LastModifiedTime"));
+                getFileInfo().setModifiedTime(
+                    Util::iso8601ToTimestamp(lastModifiedTime, "LastModifiedTime"));
 
-                if (isSaveAs || isRename)
+                if (details.isSaveAs || details.isRename)
                 {
                     const std::string name = JsonUtil::getJSONValue<std::string>(object, "Name");
                     LOG_TRC(wopiLog << " returns Name [" << LOOLWSD::anonymizeUrl(name) << "].");
@@ -1172,22 +1204,23 @@ WopiStorage::saveLocalFileToStorage(const Authorization& auth, const std::string
                 LOG_WRN("Invalid or missing JSON in " << wopiLog << " HTTP_OK response.");
             }
         }
-        else if (response.getStatus() == Poco::Net::HTTPResponse::HTTP_REQUESTENTITYTOOLARGE)
+        else if (details.httpResponseCode == Poco::Net::HTTPResponse::HTTP_REQUEST_ENTITY_TOO_LARGE)
         {
             saveResult.setResult(StorageBase::SaveResult::Result::DISKFULL);
         }
-        else if (response.getStatus() == Poco::Net::HTTPResponse::HTTP_UNAUTHORIZED ||
-                 response.getStatus() == Poco::Net::HTTPResponse::HTTP_FORBIDDEN)
+        else if (details.httpResponseCode == Poco::Net::HTTPResponse::HTTP_UNAUTHORIZED
+                 || details.httpResponseCode == Poco::Net::HTTPResponse::HTTP_FORBIDDEN)
         {
             saveResult.setResult(StorageBase::SaveResult::Result::UNAUTHORIZED);
         }
-        else if (response.getStatus() == Poco::Net::HTTPResponse::HTTP_CONFLICT)
+        else if (details.httpResponseCode == Poco::Net::HTTPResponse::HTTP_CONFLICT)
         {
             saveResult.setResult(StorageBase::SaveResult::Result::CONFLICT);
             Poco::JSON::Object::Ptr object;
-            if (JsonUtil::parseJSON(oss.str(), object))
+            if (JsonUtil::parseJSON(origResponseString, object))
             {
-                const unsigned loolStatusCode = JsonUtil::getJSONValue<unsigned>(object, "LOOLStatusCode");
+                const unsigned loolStatusCode
+                    = JsonUtil::getJSONValue<unsigned>(object, "LOOLStatusCode");
                 if (loolStatusCode == static_cast<unsigned>(LOOLStatusCode::DOC_CHANGED))
                 {
                     saveResult.setResult(StorageBase::SaveResult::Result::DOC_CHANGED);
@@ -1202,21 +1235,24 @@ WopiStorage::saveLocalFileToStorage(const Authorization& auth, const std::string
         {
             // Internal server error, and other failures.
             LOG_ERR("Unexpected response to "
-                    << wopiLog << ". Cannot upload file to WOPI storage uri [" << uriAnonym
-                    << "]: " << response.getStatus() << ' ' << response.getReason() << ": "
-                    << responseString);
+                    << wopiLog << ". Cannot upload file to WOPI storage uri [" << details.uriAnonym
+                    << "]: " << details.httpResponseCode << ' ' << details.httpResponseReason
+                    << ": " << responseString);
             saveResult.setResult(StorageBase::SaveResult::Result::FAILED);
         }
     }
     catch (const Poco::Exception& pexc)
     {
-        LOG_ERR("Cannot save file to WOPI storage uri [" << uriAnonym << "]. Error: " <<
-                pexc.displayText() << (pexc.nested() ? " (" + pexc.nested()->displayText() + ')' : ""));
+        LOG_ERR("Cannot save file to WOPI storage uri ["
+                << details.uriAnonym << "]. Error: " << pexc.displayText()
+                << (pexc.nested() ? " (" + pexc.nested()->displayText() + ')' : ""));
         saveResult.setResult(StorageBase::SaveResult::Result::FAILED);
     }
     catch (const BadRequestException& exc)
     {
-        LOG_ERR("Cannot save file to WOPI storage uri [" + uriAnonym + "]. Error: " << exc.what());
+        LOG_ERR("Cannot save file to WOPI storage uri [" + details.uriAnonym + "]. Error: "
+                << exc.what());
+        saveResult.setResult(StorageBase::SaveResult::Result::FAILED);
     }
 
     return saveResult;

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -97,7 +97,7 @@ public:
         std::chrono::system_clock::time_point _modifiedTime;
     };
 
-    class SaveResult final
+    class UploadResult final
     {
     public:
         enum class Result
@@ -110,7 +110,7 @@ public:
             FAILED
         };
 
-        SaveResult(Result result) : _result(result)
+        UploadResult(Result result) : _result(result)
         {
         }
 
@@ -242,18 +242,18 @@ public:
 
     /// Returns a local file path for the given URI.
     /// If necessary copies the file locally first.
-    virtual std::string loadStorageFileToLocal(const Authorization& auth,
-                                               const std::string& /*cookies*/, LockContext& lockCtx,
-                                               const std::string& templateUri)
+    virtual std::string downloadStorageFileToLocal(const Authorization& auth,
+                                                   const std::string& cookies, LockContext& lockCtx,
+                                                   const std::string& templateUri)
         = 0;
 
     /// Writes the contents of the file back to the source.
     /// @param cookies A string representing key=value pairs that are set as cookies.
     /// @param savedFile When the operation was saveAs, this is the path to the file that was saved.
-    virtual SaveResult
-    saveLocalFileToStorage(const Authorization& auth, const std::string& /*cookies*/,
-                           LockContext& lockCtx, const std::string& saveAsPath,
-                           const std::string& saveAsFilename, const bool isRename)
+    virtual UploadResult
+    uploadLocalFileToStorage(const Authorization& auth, const std::string& cookies,
+                             LockContext& lockCtx, const std::string& saveAsPath,
+                             const std::string& saveAsFilename, const bool isRename)
         = 0;
 
     /// Must be called at startup to configure.
@@ -348,14 +348,14 @@ public:
         return true;
     }
 
-    std::string loadStorageFileToLocal(const Authorization& auth, const std::string& /*cookies*/,
-                                       LockContext& lockCtx,
-                                       const std::string& templateUri) override;
+    std::string downloadStorageFileToLocal(const Authorization& auth,
+                                           const std::string& /*cookies*/, LockContext& lockCtx,
+                                           const std::string& templateUri) override;
 
-    SaveResult saveLocalFileToStorage(const Authorization& auth, const std::string& /*cookies*/,
-                                      LockContext& lockCtx, const std::string& saveAsPath,
-                                      const std::string& saveAsFilename,
-                                      const bool isRename) override;
+    UploadResult uploadLocalFileToStorage(const Authorization& auth, const std::string& /*cookies*/,
+                                          LockContext& lockCtx, const std::string& saveAsPath,
+                                          const std::string& saveAsFilename,
+                                          const bool isRename) override;
 
 private:
     /// True if we the source file a temporary that we own.
@@ -512,14 +512,14 @@ public:
                          LockContext& lockCtx, bool lock) override;
 
     /// uri format: http://server/<...>/wopi*/files/<id>/content
-    std::string loadStorageFileToLocal(const Authorization& auth, const std::string& /*cookies*/,
-                                       LockContext& lockCtx,
-                                       const std::string& templateUri) override;
+    std::string downloadStorageFileToLocal(const Authorization& auth,
+                                           const std::string& /*cookies*/, LockContext& lockCtx,
+                                           const std::string& templateUri) override;
 
-    SaveResult saveLocalFileToStorage(const Authorization& auth, const std::string& /*cookies*/,
-                                      LockContext& lockCtx, const std::string& saveAsPath,
-                                      const std::string& saveAsFilename,
-                                      const bool isRename) override;
+    UploadResult uploadLocalFileToStorage(const Authorization& auth, const std::string& /*cookies*/,
+                                          LockContext& lockCtx, const std::string& saveAsPath,
+                                          const std::string& saveAsFilename,
+                                          const bool isRename) override;
 
     /// Total time taken for making WOPI calls during load
     std::chrono::duration<double> getWopiLoadDuration() const { return _wopiLoadDuration; }
@@ -538,7 +538,7 @@ protected:
     };
 
     /// Handles the response from the server when uploading the document.
-    SaveResult handleUploadToStorageResponse(const WopiUploadDetails& details,
+    UploadResult handleUploadToStorageResponse(const WopiUploadDetails& details,
                                              std::string responseString);
 
 private:

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -525,6 +525,22 @@ public:
     std::chrono::duration<double> getWopiLoadDuration() const { return _wopiLoadDuration; }
     std::chrono::duration<double> getWopiSaveDuration() const { return _wopiSaveDuration; }
 
+protected:
+    struct WopiUploadDetails
+    {
+        const std::string filePathAnonym;
+        const std::string uriAnonym;
+        const std::string httpResponseReason;
+        const long httpResponseCode;
+        const std::size_t size;
+        const bool isSaveAs;
+        const bool isRename;
+    };
+
+    /// Handles the response from the server when uploading the document.
+    SaveResult handleUploadToStorageResponse(const WopiUploadDetails& details,
+                                             std::string responseString);
+
 private:
     /// Initialize an HTTPRequest instance with the common settings and headers.
     /// Older Poco versions don't support copying HTTPRequest objects, so we can't generate them.


### PR DESCRIPTION
Some preparation work for asynchronous IO:

- wsd: extract wopi upload response handling
- wsd: session is optional to broadcasting doc modification time
- wsd: extract storage saving reponse handling
- wsd: make session in the upload details weak_ptr
- wsd: label storage operations as upload and download
