### PR TITLE
mutex and getMutex() removed

### DIFF
--- a/common/Session.cpp
+++ b/common/Session.cpp
@@ -20,7 +20,6 @@
 #include <iterator>
 #include <map>
 #include <memory>
-#include <mutex>
 #include <set>
 
 #include <Poco/Exception.h>

--- a/common/Session.hpp
+++ b/common/Session.hpp
@@ -10,7 +10,6 @@
 #include <atomic>
 #include <cassert>
 #include <memory>
-#include <mutex>
 #include <map>
 #include <ostream>
 #include <type_traits>
@@ -261,8 +260,6 @@ private:
 
     // Whether websocket received close frame.  Closing Handshake
     std::atomic<bool> _isCloseFrame;
-
-    std::mutex _mutex;
 
     /// Whether the session is opened as readonly
     bool _isReadOnly;

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -988,11 +988,6 @@ private:
         return _sessionUserInfo;
     }
 
-    std::mutex& getMutex() override
-    {
-        return _mutex;
-    }
-
     std::shared_ptr<TileQueue>& getTileQueue() override
     {
         return _tileQueue;
@@ -1659,7 +1654,6 @@ private:
     PasswordType _docPasswordType;
 
     std::atomic<bool> _stop;
-    mutable std::mutex _mutex;
 
     ThreadPool _pngPool;
 


### PR DESCRIPTION
Signed-off-by: gozeloglu <gozeloglu@gmail.com>
Change-Id: I45e86d17c8c73787753245f95ef972a90893a305


* Resolves:  https://github.com/CollaboraOnline/online/issues/805
* Target version: master 

### Summary
I did changes in https://github.com/CollaboraOnline/online/issues/805 issue. 

### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

