### PR TITLE
fuzzer-clientsession: fix out of memory

### DIFF
--- a/common/Util.cpp
+++ b/common/Util.cpp
@@ -803,6 +803,11 @@ namespace Util
         return res;
     }
 
+    void clearAnonymized()
+    {
+        AnonymizedStrings.clear();
+    }
+
     std::string getFilenameFromURL(const std::string& url)
     {
         std::string base;

--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -922,6 +922,9 @@ int main(int argc, char**argv)
     /// After this, 'anonymize(plain)' will return 'anonymized'.
     void mapAnonymized(const std::string& plain, const std::string& anonymized);
 
+    /// Clears the shared state of mapAnonymized() / anonymize().
+    void clearAnonymized();
+
     /// Anonymize the basename of filenames only, preserving the path and extension.
     std::string anonymizeUrl(const std::string& url, const std::uint64_t nAnonymizationSalt);
 

--- a/fuzzer/ClientSession.cpp
+++ b/fuzzer/ClientSession.cpp
@@ -40,6 +40,9 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 
     // Make sure SocketPoll::_newCallbacks does not grow forever, leading to OOM.
     Admin::instance().poll(0);
+
+    // Make sure the anon map does not grow forever, leading to OOM.
+    Util::clearAnonymized();
     return 0;
 }
 


### PR DESCRIPTION
The fuzzer ran out of memory, 955443527 bytes (79%) of the used memory
was this map.

(cherry picked from commit 10c1885a83850139bb9b88ed9a6109428a7f42d5)

Change-Id: I2dd84a094d3dd3d98618667e3c78591e2193bce2
Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
