### PR TITLE
notebookbar: fix custom tabs

### DIFF
--- a/loleaflet/src/control/Control.NotebookbarBuilder.js
+++ b/loleaflet/src/control/Control.NotebookbarBuilder.js
@@ -802,7 +802,7 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 				td = containerToInsert;
 			}
 
-			var isVertical = childData.vertical === 'true' || childData.vertical === true ? true : false;
+			var isVertical = (childData.vertical === 'true' || childData.vertical === true) ? true : false;
 
 			this._parentize(childData);
 			var processChildren = true;

--- a/loleaflet/src/control/Control.NotebookbarCalc.js
+++ b/loleaflet/src/control/Control.NotebookbarCalc.js
@@ -88,7 +88,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 					'children': [
 						{
 							'id': 'NotebookBar',
-							'type': 'grid',
+							'type': 'container',
 							'text': '',
 							'enabled': 'true',
 							'children': [
@@ -330,7 +330,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 					'children': [
 						{
 							'id': 'NotebookBar',
-							'type': 'grid',
+							'type': 'container',
 							'text': '',
 							'enabled': 'true',
 							'children': [
@@ -1844,7 +1844,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 					'children': [
 						{
 							'id': 'NotebookBar',
-							'type': 'grid',
+							'type': 'container',
 							'text': '',
 							'enabled': 'true',
 							'children': [
@@ -2174,7 +2174,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 					'children': [
 						{
 							'id': 'NotebookBar',
-							'type': 'grid',
+							'type': 'container',
 							'text': '',
 							'enabled': 'true',
 							'children': [

--- a/loleaflet/src/control/Control.NotebookbarImpress.js
+++ b/loleaflet/src/control/Control.NotebookbarImpress.js
@@ -168,7 +168,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 					'children': [
 						{
 							'id': 'NotebookBar',
-							'type': 'grid',
+							'type': 'container',
 							'text': '',
 							'enabled': 'true',
 							'children': [
@@ -462,7 +462,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 					'children': [
 						{
 							'id': 'NotebookBar',
-							'type': 'grid',
+							'type': 'container',
 							'text': '',
 							'enabled': 'true',
 							'children': [
@@ -1844,7 +1844,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 					'children': [
 						{
 							'id': 'NotebookBar',
-							'type': 'grid',
+							'type': 'container',
 							'text': '',
 							'enabled': 'true',
 							'children': [
@@ -1998,7 +1998,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 					'children': [
 						{
 							'id': 'NotebookBar',
-							'type': 'grid',
+							'type': 'container',
 							'text': '',
 							'enabled': 'true',
 							'children': [

--- a/loleaflet/src/control/Control.NotebookbarWriter.js
+++ b/loleaflet/src/control/Control.NotebookbarWriter.js
@@ -106,7 +106,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 					'children': [
 						{
 							'id': 'NotebookBar',
-							'type': 'grid',
+							'type': 'container',
 							'text': '',
 							'enabled': 'true',
 							'children': [
@@ -418,7 +418,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 					'children': [
 						{
 							'id': 'NotebookBar',
-							'type': 'grid',
+							'type': 'container',
 							'text': '',
 							'enabled': 'true',
 							'children': [
@@ -565,7 +565,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 					'children': [
 						{
 							'id': 'NotebookBar',
-							'type': 'grid',
+							'type': 'container',
 							'text': '',
 							'enabled': 'true',
 							'children': [
@@ -1947,7 +1947,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 					'children': [
 						{
 							'id': 'NotebookBar',
-							'type': 'grid',
+							'type': 'container',
 							'text': '',
 							'enabled': 'true',
 							'children': [
@@ -2101,7 +2101,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 					'children': [
 						{
 							'id': 'NotebookBar',
-							'type': 'grid',
+							'type': 'container',
 							'text': '',
 							'enabled': 'true',
 							'children': [


### PR DESCRIPTION
grid -> container,
for grid handler there were 'top' and 'left' properties missing.
issue appeared when I implemented real grid handler based on positions.

Change-Id: I90d63188b77ec6590123648f8833a387d1463622
Signed-off-by: Szymon Kłos <szymon.klos@collabora.com>
