### PR TITLE
private/pedro/notebookbar shortcuts bar zindex

### DIFF
--- a/loleaflet/css/notebookbar.css
+++ b/loleaflet/css/notebookbar.css
@@ -67,7 +67,7 @@
 .notebookbar-shortcuts-bar {
 	display: inline-block;
 	position: relative;
-	z-index: 10000;
+	z-index: 1000;
 }
 
 .notebookbar-shortcuts-bar > table {


### PR DESCRIPTION
- notebookbar-shortcuts-bar: overlays vex dialogs on small screens
