### PR TITLE
cypress: NC: disable failing 'Automatic spell checking.' test.

### DIFF
--- a/cypress_test/plugins/blacklists.js
+++ b/cypress_test/plugins/blacklists.js
@@ -30,7 +30,8 @@ var nextcloudBlackList = [
 	['mobile/writer/hamburger_menu_spec.js',
 		[
 			'Print',
-			'Save'
+			'Save',
+			'Automatic spell checking.'
 		]
 	],
 	['mobile/writer/spellchecking_spec.js',


### PR DESCRIPTION
Signed-off-by: Tamás Zolnai <tamas.zolnai@collabora.com>
Change-Id: I6762c08b9a921eb942ee537195cbe530f3260dc1
