### PR TITLE
Pre-fetching next or previous slide tiles

### DIFF
--- a/loleaflet/src/control/Parts.js
+++ b/loleaflet/src/control/Parts.js
@@ -31,6 +31,8 @@ L.Map.include({
 			return;
 		}
 
+		this.fire('scrolltopart');
+
 		docLayer._selectedParts.push(docLayer._selectedPart);
 
 		if (docLayer.isCursorVisible()) {

--- a/loleaflet/src/control/Parts.js
+++ b/loleaflet/src/control/Parts.js
@@ -13,14 +13,17 @@ L.Map.include({
 		if (part === 'prev') {
 			if (docLayer._selectedPart > 0) {
 				docLayer._selectedPart -= 1;
+				this._partsDirection = -1;
 			}
 		}
 		else if (part === 'next') {
 			if (docLayer._selectedPart < docLayer._parts - 1) {
 				docLayer._selectedPart += 1;
+				this._partsDirection = 1;
 			}
 		}
 		else if (typeof (part) === 'number' && part >= 0 && part < docLayer._parts) {
+			this._partsDirection = (part >= docLayer._selectedPart) ? 1 : -1;
 			docLayer._selectedPart = part;
 			docLayer._updateReferenceMarks();
 		}

--- a/loleaflet/src/layer/tile/TileLayer.js
+++ b/loleaflet/src/layer/tile/TileLayer.js
@@ -2160,6 +2160,11 @@ L.TileLayer = L.GridLayer.extend({
 			}
 			tile.el.src = img;
 		}
+		// cache the following parts tiles
+		// this will help avoiding the tear effect when switching to the next part
+		if (this._selectedPart !== coords.part && !this._tileCache[key]) {
+			this._tileCache[key] = img;
+		}
 		L.Log.log(textMsg, 'INCOMING', key);
 
 		// Send acknowledgment, that the tile message arrived

--- a/loleaflet/src/map/Map.js
+++ b/loleaflet/src/map/Map.js
@@ -119,6 +119,7 @@ L.Map = L.Evented.extend({
 		this._previewQueue = [];
 		this._previewRequestsOnFly = 0;
 		this._timeToEmptyQueue = new Date();
+		this._partsDirection = 1; // For pre-fetching the slides in the direction of travel.
 		// Focusing:
 		//
 		// Cursor is visible or hidden (e.g. for graphic selection).


### PR DESCRIPTION
Fetch the tiles of the part that is in the direction
of travel. This way we will avoid the tear effect
while browsing the tiles sequentially.

Change-Id: Ie47d1174f986253e4b43aa0c3276f05e7ddd0c81
Signed-off-by: mert <mert.tumer@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

