### PR TITLE
menu-last-mod without underline cause it's no link

### DIFF
--- a/loleaflet/css/menubar.css
+++ b/loleaflet/css/menubar.css
@@ -293,7 +293,6 @@
 
 #menu-last-mod a {
 	color: grey;
-	text-decoration: underline;
 	padding: 8px 15px 7px;
 	z-index: 400;
 	border: 1px solid transparent;


### PR DESCRIPTION
Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I7e8d0a63c15ed5976e1bb486b3e7ac48467a8cbe


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
In html underline was used for links and as Last modification Time is no link, I would remove the underline property in css.