### PR TITLE
Impress: A fix on Clear Direct Formatting command

### DIFF
--- a/loleaflet/src/control/Control.TopToolbar.js
+++ b/loleaflet/src/control/Control.TopToolbar.js
@@ -99,7 +99,8 @@ L.Control.TopToolbar = L.Control.extend({
 			{type: 'button',  id: 'undo',  img: 'undo', hint: _UNO('.uno:Undo'), uno: 'Undo', disabled: true, mobile: false},
 			{type: 'button',  id: 'redo',  img: 'redo', hint: _UNO('.uno:Redo'), uno: 'Redo', disabled: true, mobile: false},
 			{type: 'button',  id: 'formatpaintbrush',  img: 'copyformat', hint: _UNO('.uno:FormatPaintbrush'), uno: 'FormatPaintbrush', mobile: false},
-			{type: 'button',  id: 'reset',  img: 'deleteformat', hint: _UNO('.uno:ResetAttributes', 'text'), uno: 'ResetAttributes', mobile: false},
+			{type: 'button',  id: 'reset',  img: 'deleteformat', hint: _UNO('.uno:ResetAttributes', 'text'), hidden: true, uno: 'ResetAttributes', mobile: false},
+			{type: 'button',  id: 'resetimpress',  img: 'deleteformat', hint: _UNO('.uno:SetDefault', 'presentation', 'true'), hidden: true, uno:'SetDefault', mobile: false},
 			{type: 'break', mobile: false, tablet: false,},
 			{type: 'html', id: 'styles',
 				html: '<select class="styles-select"><option>' + _('Default Style') + '</option></select>',
@@ -274,10 +275,10 @@ L.Control.TopToolbar = L.Control.extend({
 		switch (docType) {
 		case 'spreadsheet':
 			if (toolbarUp) {
-				toolbarUp.show('textalign', 'wraptext', 'breakspacing', 'insertannotation', 'conditionalformaticonset',
-				'numberformatcurrency', 'numberformatpercent',
-				'numberformatincdecimals', 'numberformatdecdecimals', 'break-number', 'togglemergecells', 'breakmergecells',
-				'setborderstyle', 'sortascending', 'sortdescending', 'breaksorting', 'backgroundcolor', 'breaksidebar', 'sidebar');
+				toolbarUp.show('reset', 'textalign', 'wraptext', 'breakspacing', 'insertannotation', 'conditionalformaticonset',
+					'numberformatcurrency', 'numberformatpercent',
+					'numberformatincdecimals', 'numberformatdecdecimals', 'break-number', 'togglemergecells', 'breakmergecells',
+					'setborderstyle', 'sortascending', 'sortdescending', 'breaksorting', 'backgroundcolor', 'breaksidebar', 'sidebar');
 				toolbarUp.remove('styles');
 			}
 
@@ -291,9 +292,9 @@ L.Control.TopToolbar = L.Control.extend({
 			break;
 		case 'text':
 			if (toolbarUp)
-				toolbarUp.show('leftpara', 'centerpara', 'rightpara', 'justifypara', 'breakpara', 'linespacing',
-				'breakspacing', 'defaultbullet', 'defaultnumbering', 'breakbullet', 'incrementindent', 'decrementindent',
-				'breakindent', 'inserttable', 'insertannotation', 'backcolor', 'breaksidebar', 'sidebar');
+				toolbarUp.show('reset', 'leftpara', 'centerpara', 'rightpara', 'justifypara', 'breakpara', 'linespacing',
+					'breakspacing', 'defaultbullet', 'defaultnumbering', 'breakbullet', 'incrementindent', 'decrementindent',
+					'breakindent', 'inserttable', 'insertannotation', 'backcolor', 'breaksidebar', 'sidebar');
 
 			break;
 		case 'presentation':
@@ -315,7 +316,7 @@ L.Control.TopToolbar = L.Control.extend({
 			}
 
 			if (toolbarUp) {
-				toolbarUp.show('breaksidebar', 'modifypage');
+				toolbarUp.show('resetimpress', 'breaksidebar', 'modifypage');
 			}
 
 			// FALLTHROUGH intended


### PR DESCRIPTION
Impress: A fix on Clear Direct Formatting attribute

In Impress, the Clear Direct format button sends an uno:SetDefault command while in writer and Calc, the Clear Direct Format button sends an uno:ResetAttribute command.
The bug existed because the uno:SetDefault command was not captured in the Control.TopToolbar.js file.
I added the uno:SetDefault command and set the hidden attribute to true. I also set the hidden attribute of the uno:ResetAttribute to true.
This is to create these Clear Direct Formatting buttons as hidden and show them for their respective documents.

Signed-off-by: Ezinne Nnamani <nnamani.ezinne@collabora.com>
Change-Id: I37439a902684f015ffcc8d0a9acde40fec3603d5
Signed-off-by: Ezinne Nnamani <nnamani.ezinne@collabora.com>
