### PR TITLE
notebookbar-shortcuts-bar: overlays vex dialogs on small screens

### DIFF
--- a/loleaflet/css/notebookbar.css
+++ b/loleaflet/css/notebookbar.css
@@ -67,7 +67,7 @@
 .notebookbar-shortcuts-bar {
 	display: inline-block;
 	position: relative;
-	z-index: 10000;
+	z-index: 1000;
 }
 
 .notebookbar-shortcuts-bar > table {


### PR DESCRIPTION
- or ipad
- vex dialogs examples: shortcuts and help

Reset z-index to be the same as in `main-menu(desktop-only)`:loleaflet/README

Signed-off-by: Pedro Silva <pedro.silva@collabora.com>
Change-Id: Ib9bf635c03312e4302b14d99fc5c461bc0f7fb0d
