### PR TITLE
Calc: use pixel coordinates for pane sizing

### DIFF
--- a/loleaflet/src/control/Control.ColumnHeader.js
+++ b/loleaflet/src/control/Control.ColumnHeader.js
@@ -209,11 +209,11 @@ L.Control.ColumnHeader = L.Control.Header.extend({
 
 		var ctx = this._canvasContext;
 		var content = this._colIndexToAlpha(entry.index + 1);
-		var startOrt = this._canvasHeight - this._headerHeight;
-		var startPar = entry.pos - entry.size;
-		var endPar = entry.pos;
-		var width = endPar - startPar;
-		var height = this._headerHeight;
+		var startY = this._canvasHeight - this._headerHeight;
+		var startX = (entry.pos - entry.size) * this._dpiScale;
+		var endPar = entry.pos * this._dpiScale;
+		var width = endPar - startX;
+		var height = this._headerHeight * this._dpiScale;
 
 		if (isHighlighted !== true && isHighlighted !== false) {
 			isHighlighted = this.isHighlighted(entry.index);
@@ -222,12 +222,10 @@ L.Control.ColumnHeader = L.Control.Header.extend({
 		if (width <= 0)
 			return;
 
-		ctx.save();
-		ctx.scale(this._dpiScale, this._dpiScale);
 		// background gradient
 		var selectionBackgroundGradient = null;
 		if (isHighlighted) {
-			selectionBackgroundGradient = ctx.createLinearGradient(startPar, startOrt, startPar, startOrt + height);
+			selectionBackgroundGradient = ctx.createLinearGradient(startX, startY, startX, startY + height);
 			selectionBackgroundGradient.addColorStop(0, this._selectionBackgroundGradient[0]);
 			selectionBackgroundGradient.addColorStop(0.5, this._selectionBackgroundGradient[1]);
 			selectionBackgroundGradient.addColorStop(1, this._selectionBackgroundGradient[2]);
@@ -236,28 +234,29 @@ L.Control.ColumnHeader = L.Control.Header.extend({
 		// draw header/outline border separator
 		if (this._headerHeight !== this._canvasHeight) {
 			ctx.fillStyle = this._borderColor;
-			ctx.fillRect(startPar, startOrt - this._borderWidth, width, this._borderWidth);
+			ctx.fillRect(startX, startY - this._borderWidth, width, this._borderWidth);
 		}
 
-		// clip mask
-		ctx.beginPath();
-		ctx.rect(startPar, startOrt, width, height);
-		ctx.clip();
 		// draw background
+		ctx.beginPath();
 		ctx.fillStyle = isHighlighted ? selectionBackgroundGradient : isOver ? this._hoverColor : this._backgroundColor;
-		ctx.fillRect(startPar, startOrt, width, height);
+		ctx.fillRect(startX, startY, width, height);
+
 		// draw resize handle
 		var handleSize = this._resizeHandleSize;
 		if (isCurrent && width > 2 * handleSize) {
-			var center = startPar + width - handleSize / 2;
-			var y = startOrt + 2;
-			var h = height - 4;
-			var size = 2;
-			var offset = 1;
+			var center = startX + width - handleSize / 2;
+			var y = startY + 2 * this._dpiScale;
+			var h = height - 4 * this._dpiScale;
+			var size = 2 * this._dpiScale;
+			var offset = 1 * this._dpiScale;
 			ctx.fillStyle = '#BBBBBB';
-			ctx.fillRect(center - size - offset, y + 2, size, h - 4);
-			ctx.fillRect(center + offset, y + 2, size, h - 4);
+			ctx.beginPath();
+			ctx.fillRect(center - size - offset, y + 2 * this._dpiScale, size, h - 4 * this._dpiScale);
+			ctx.beginPath();
+			ctx.fillRect(center + offset, y + 2 * this._dpiScale, size, h - 4 * this._dpiScale);
 		}
+
 		// draw text content
 		ctx.fillStyle = isHighlighted ? this._selectionTextColor : this._textColor;
 		ctx.font = this._font.getFont();
@@ -267,11 +266,11 @@ L.Control.ColumnHeader = L.Control.Header.extend({
 		// the exact bounding box in html5's canvas, and the textBaseline
 		// 'middle' measures everything including the descent etc.
 		// '+ 1' looks visually fine, and seems safe enough
-		ctx.fillText(content, endPar - (width / 2), startOrt + (height / 2) + 1);
+		ctx.fillText(content, endPar - (width / 2), startY + (height / 2) + 1);
 		// draw row separator
 		ctx.fillStyle = this._borderColor;
-		ctx.fillRect(endPar -1, startOrt, this._borderWidth, height);
-		ctx.restore();
+		ctx.beginPath();
+		ctx.fillRect(endPar -1, startY, this._borderWidth, height);
 	},
 
 	drawGroupControl: function (group) {

--- a/loleaflet/src/control/Control.ColumnHeader.js
+++ b/loleaflet/src/control/Control.ColumnHeader.js
@@ -39,8 +39,7 @@ L.Control.ColumnHeader = L.Control.Header.extend({
 		this._setCanvasHeight();
 		this._canvasBaseHeight = this._canvasHeight;
 
-		var scale = this.canvasDPIScale();
-		this._canvasContext.scale(scale, scale);
+		this._canvasContext.scale(this._dpiScale, this._dpiScale);
 
 		this._headerHeight = this._canvasHeight;
 		L.Control.Header.colHeaderHeight = this._canvasHeight;
@@ -224,8 +223,7 @@ L.Control.ColumnHeader = L.Control.Header.extend({
 			return;
 
 		ctx.save();
-		var scale = this.canvasDPIScale();
-		ctx.scale(scale, scale);
+		ctx.scale(this._dpiScale, this._dpiScale);
 		// background gradient
 		var selectionBackgroundGradient = null;
 		if (isHighlighted) {
@@ -290,8 +288,7 @@ L.Control.ColumnHeader = L.Control.Header.extend({
 		var height = group.endPos - group.startPos;
 
 		ctx.save();
-		var scale = this.canvasDPIScale();
-		ctx.scale(scale, scale);
+		ctx.scale(this._dpiScale, this._dpiScale);
 
 		// clip mask
 		ctx.beginPath();
@@ -339,13 +336,12 @@ L.Control.ColumnHeader = L.Control.Header.extend({
 		var ctx = this._cornerCanvasContext;
 		var ctrlHeadSize = this._groupHeadSize;
 		var levelSpacing = this._levelSpacing;
-		var scale = this.canvasDPIScale();
 
 		var startOrt = levelSpacing + (ctrlHeadSize + levelSpacing) * level;
-		var startPar = this._cornerCanvas.width / scale - (ctrlHeadSize + (L.Control.Header.rowHeaderWidth - ctrlHeadSize) / 2);
+		var startPar = this._cornerCanvas.width / this._dpiScale - (ctrlHeadSize + (L.Control.Header.rowHeaderWidth - ctrlHeadSize) / 2);
 
 		ctx.save();
-		ctx.scale(scale, scale);
+		ctx.scale(this._dpiScale, this._dpiScale);
 		ctx.fillStyle = this._hoverColor;
 		ctx.fillRect(startPar, startOrt, ctrlHeadSize, ctrlHeadSize);
 		ctx.strokeStyle = 'black';
@@ -532,8 +528,7 @@ L.Control.ColumnHeader = L.Control.Header.extend({
 			return;
 		}
 
-		var scale = this.canvasDPIScale();
-		var rowOutlineWidth = this._cornerCanvas.width / scale - L.Control.Header.rowHeaderWidth - this._borderWidth;
+		var rowOutlineWidth = this._cornerCanvas.width / this._dpiScale - L.Control.Header.rowHeaderWidth - this._borderWidth;
 		if (pos.x <= rowOutlineWidth) {
 			// empty rectangle on the left select all
 			this._map.sendUnoCommand('.uno:SelectAll');

--- a/loleaflet/src/control/Control.Header.js
+++ b/loleaflet/src/control/Control.Header.js
@@ -29,6 +29,7 @@ L.Control.Header = L.Control.extend({
 		this._hitResizeArea = false;
 		this._overHeaderArea = false;
 		this._hammer = null;
+		this._dpiScale = L.Util.getDpiScaleFactor(true);
 
 		this._selectionBackgroundGradient = [ '#3465A4', '#729FCF', '#004586' ];
 
@@ -585,12 +586,6 @@ L.Control.Header = L.Control.extend({
 		return Math.round(this._getParallelPos(this.converter(point)));
 	},
 
-	canvasDPIScale: function () {
-		var docLayer = this._map && this._map._docLayer;
-		var scale = docLayer && docLayer.canvasDPIScale ? docLayer.canvasDPIScale() : L.getDpiScaleFactor();
-		return scale;
-	},
-
 	_setCanvasSizeImpl: function (container, canvas, property, value, isCorner) {
 		if (!value) {
 			value = parseInt(L.DomUtil.getStyle(container, property));
@@ -599,15 +594,14 @@ L.Control.Header = L.Control.extend({
 			L.DomUtil.setStyle(container, property, value + 'px');
 		}
 
-		var scale = this.canvasDPIScale();
 		if (property === 'width') {
-			canvas.width = Math.floor(value * scale);
+			canvas.width = Math.floor(value * this._dpiScale);
 			if (!isCorner)
 				this._canvasWidth = value;
 			// console.log('Header._setCanvasSizeImpl: _canvasWidth' + this._canvasWidth);
 		}
 		else if (property === 'height') {
-			canvas.height = Math.floor(value * scale);
+			canvas.height = Math.floor(value * this._dpiScale);
 			if (!isCorner)
 				this._canvasHeight = value;
 			// console.log('Header._setCanvasSizeImpl: _canvasHeight' + this._canvasHeight);
@@ -730,17 +724,16 @@ L.Control.Header = L.Control.extend({
 			return;
 
 		ctx.save();
-		var scale = this.canvasDPIScale();
-		ctx.scale(scale, scale);
+		ctx.scale(this._dpiScale, this._dpiScale);
 
 		ctx.fillStyle = this._borderColor;
 		if (this._isColumn) {
-			var startY = this._cornerCanvas.height / scale - (L.Control.Header.colHeaderHeight + this._borderWidth);
+			var startY = this._cornerCanvas.height / this._dpiScale - (L.Control.Header.colHeaderHeight + this._borderWidth);
 			if (startY > 0)
 				ctx.fillRect(0, startY, this._cornerCanvas.width, this._borderWidth);
 		}
 		else {
-			var startX = this._cornerCanvas.width / scale - (L.Control.Header.rowHeaderWidth + this._borderWidth);
+			var startX = this._cornerCanvas.width / this._dpiScale - (L.Control.Header.rowHeaderWidth + this._borderWidth);
 			if (startX > 0)
 				ctx.fillRect(startX, 0, this._borderWidth, this._cornerCanvas.height);
 		}

--- a/loleaflet/src/control/Control.Header.js
+++ b/loleaflet/src/control/Control.Header.js
@@ -22,14 +22,14 @@ L.Control.Header = L.Control.extend({
 		this._canvasHeight = 0;
 		this._clicks = 0;
 		this._current = -1;
-		this._resizeHandleSize = 15;
+		this._dpiScale = L.Util.getDpiScaleFactor(true);
+		this._resizeHandleSize = 15 * this._dpiScale;
 		this._selection = {start: -1, end: -1};
 		this._mouseOverEntry = null;
 		this._lastMouseOverIndex = undefined;
 		this._hitResizeArea = false;
 		this._overHeaderArea = false;
 		this._hammer = null;
-		this._dpiScale = L.Util.getDpiScaleFactor(true);
 
 		this._selectionBackgroundGradient = [ '#3465A4', '#729FCF', '#004586' ];
 
@@ -74,7 +74,7 @@ L.Control.Header = L.Control.extend({
 		var rate = fontHeight / fontSize;
 		this._font = {
 			_hdr: this,
-			_baseFontSize: fontSize,
+			_baseFontSize: fontSize * this._dpiScale,
 			_fontSizeRate: rate,
 			_fontFamily: fontFamily,
 			getFont: function() {

--- a/loleaflet/src/control/Control.Header.js
+++ b/loleaflet/src/control/Control.Header.js
@@ -723,21 +723,17 @@ L.Control.Header = L.Control.extend({
 		if (!this._groups)
 			return;
 
-		ctx.save();
-		ctx.scale(this._dpiScale, this._dpiScale);
-
 		ctx.fillStyle = this._borderColor;
 		if (this._isColumn) {
-			var startY = this._cornerCanvas.height / this._dpiScale - (L.Control.Header.colHeaderHeight + this._borderWidth);
+			var startY = this._cornerCanvas.height - (L.Control.Header.colHeaderHeight + this._borderWidth);
 			if (startY > 0)
 				ctx.fillRect(0, startY, this._cornerCanvas.width, this._borderWidth);
 		}
 		else {
-			var startX = this._cornerCanvas.width / this._dpiScale - (L.Control.Header.rowHeaderWidth + this._borderWidth);
+			var startX = this._cornerCanvas.width - (L.Control.Header.rowHeaderWidth + this._borderWidth);
 			if (startX > 0)
 				ctx.fillRect(startX, 0, this._borderWidth, this._cornerCanvas.height);
 		}
-		ctx.restore();
 
 		var levels = this._groups.length + 1;
 		for (var i = 0; i < levels; ++i) {

--- a/loleaflet/src/control/Control.RowHeader.js
+++ b/loleaflet/src/control/Control.RowHeader.js
@@ -39,8 +39,7 @@ L.Control.RowHeader = L.Control.Header.extend({
 		this._setCanvasWidth();
 		this._setCanvasHeight();
 
-		var scale = this.canvasDPIScale();
-		this._canvasContext.scale(scale, scale);
+		this._canvasContext.scale(this._dpiScale, this._dpiScale);
 		this._headerWidth = this._canvasWidth;
 		L.Control.Header.rowHeaderWidth = this._canvasWidth;
 
@@ -217,8 +216,7 @@ L.Control.RowHeader = L.Control.Header.extend({
 			return;
 
 		ctx.save();
-		var scale = this.canvasDPIScale();
-		ctx.scale(scale, scale);
+		ctx.scale(this._dpiScale, this._dpiScale);
 		// background gradient
 		var selectionBackgroundGradient = null;
 		if (isHighlighted) {
@@ -279,8 +277,7 @@ L.Control.RowHeader = L.Control.Header.extend({
 		var height = group.endPos - group.startPos;
 
 		ctx.save();
-		var scale = this.canvasDPIScale();
-		ctx.scale(scale, scale);
+		ctx.scale(this._dpiScale, this._dpiScale);
 
 		// clip mask
 		ctx.beginPath();
@@ -328,13 +325,12 @@ L.Control.RowHeader = L.Control.Header.extend({
 		var ctx = this._cornerCanvasContext;
 		var ctrlHeadSize = this._groupHeadSize;
 		var levelSpacing = this._levelSpacing;
-		var scale = this.canvasDPIScale();
 
 		var startOrt = levelSpacing + (ctrlHeadSize + levelSpacing) * level;
-		var startPar = this._cornerCanvas.height / scale - (ctrlHeadSize + (L.Control.Header.colHeaderHeight - ctrlHeadSize) / 2);
+		var startPar = this._cornerCanvas.height / this._dpiScale - (ctrlHeadSize + (L.Control.Header.colHeaderHeight - ctrlHeadSize) / 2);
 
 		ctx.save();
-		ctx.scale(scale, scale);
+		ctx.scale(this._dpiScale, this._dpiScale);
 		ctx.fillStyle = this._hoverColor;
 		ctx.fillRect(startOrt, startPar, ctrlHeadSize, ctrlHeadSize);
 		ctx.strokeStyle = 'black';

--- a/loleaflet/src/control/Control.RowHeader.js
+++ b/loleaflet/src/control/Control.RowHeader.js
@@ -202,11 +202,11 @@ L.Control.RowHeader = L.Control.Header.extend({
 
 		var ctx = this._canvasContext;
 		var content = entry.index + 1;
-		var startOrt = this._canvasWidth - this._headerWidth;
-		var startPar = entry.pos - entry.size;
-		var endPar = entry.pos;
-		var height = endPar - startPar;
-		var width = this._headerWidth;
+		var startX = this._canvasWidth - this._headerWidth;
+		var startY = (entry.pos - entry.size) * this._dpiScale;
+		var endY = entry.pos * this._dpiScale;
+		var height = endY - startY;
+		var width = this._headerWidth * this._dpiScale;
 
 		if (isHighlighted !== true && isHighlighted !== false) {
 			isHighlighted = this.isHighlighted(entry.index);
@@ -215,52 +215,54 @@ L.Control.RowHeader = L.Control.Header.extend({
 		if (height <= 0)
 			return;
 
-		ctx.save();
-		ctx.scale(this._dpiScale, this._dpiScale);
 		// background gradient
 		var selectionBackgroundGradient = null;
 		if (isHighlighted) {
-			selectionBackgroundGradient = ctx.createLinearGradient(0, startPar, 0, startPar + height);
+			selectionBackgroundGradient = ctx.createLinearGradient(0, startY, 0, startY + height);
 			selectionBackgroundGradient.addColorStop(0, this._selectionBackgroundGradient[0]);
 			selectionBackgroundGradient.addColorStop(0.5, this._selectionBackgroundGradient[1]);
 			selectionBackgroundGradient.addColorStop(1, this._selectionBackgroundGradient[2]);
 		}
 
+		// draw background
+		ctx.beginPath();
+		ctx.fillStyle = isHighlighted ? selectionBackgroundGradient : isOver ? this._hoverColor : this._backgroundColor;
+		ctx.fillRect(startX, startY, width, height);
+
 		// draw header/outline border separator
 		if (this._headerWidth !== this._canvasWidth) {
+			ctx.beginPath();
 			ctx.fillStyle = this._borderColor;
-			ctx.fillRect(startOrt - this._borderWidth, startPar, this._borderWidth, height);
+			ctx.fillRect(startX - this._borderWidth, startY, this._borderWidth, height);
 		}
 
-		// clip mask
-		ctx.beginPath();
-		ctx.rect(startOrt, startPar, width, height);
-		ctx.clip();
-		// draw background
-		ctx.fillStyle = isHighlighted ? selectionBackgroundGradient : isOver ? this._hoverColor : this._backgroundColor;
-		ctx.fillRect(startOrt, startPar, width, height);
 		// draw resize handle
 		var handleSize = this._resizeHandleSize;
 		if (isCurrent && height > 2 * handleSize) {
-			var center = startPar + height - handleSize / 2;
-			var x = startOrt + 2;
-			var w = width - 4;
-			var size = 2;
-			var offset = 1;
+			var center = startY + height - handleSize / 2;
+			var x = startX + 2 * this._dpiScale;
+			var w = width - 4 * this._dpiScale;
+			var size = 2 * this._dpiScale;
+			var offset = 1 *this._dpiScale;
+
 			ctx.fillStyle = '#BBBBBB';
-			ctx.fillRect(x + 2, center - size - offset, w - 4, size);
-			ctx.fillRect(x + 2, center + offset, w - 4, size);
+			ctx.beginPath();
+			ctx.fillRect(x + 2 * this._dpiScale, center - size - offset, w - 4 * this._dpiScale, size);
+			ctx.beginPath();
+			ctx.fillRect(x + 2 * this._dpiScale, center + offset, w - 4 * this._dpiScale, size);
 		}
+
 		// draw text content
 		ctx.fillStyle = isHighlighted ? this._selectionTextColor : this._textColor;
 		ctx.font = this._font.getFont();
 		ctx.textAlign = 'center';
 		ctx.textBaseline = 'middle';
-		ctx.fillText(content, startOrt + (width / 2), endPar - (height / 2));
+		ctx.fillText(content, startX + (width / 2), endY - (height / 2));
+
 		// draw row separator
+		ctx.beginPath();
 		ctx.fillStyle = this._borderColor;
-		ctx.fillRect(startOrt, endPar - 1, width , this._borderWidth);
-		ctx.restore();
+		ctx.fillRect(startX, endY - 1, width , this._borderWidth);
 	},
 
 	drawGroupControl: function (group) {

--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -1010,8 +1010,8 @@ L.Socket = L.Class.extend({
 			else if (command.type === 'spreadsheet') {
 				docLayer = new L.CalcTileLayer('', {
 					permission: this._map.options.permission,
-					tileWidthTwips: tileWidthTwips,
-					tileHeightTwips: tileHeightTwips,
+					tileWidthTwips: tileWidthTwips / window.devicePixelRatio,
+					tileHeightTwips: tileHeightTwips / window.devicePixelRatio,
 					docType: command.type
 				});
 

--- a/loleaflet/src/layer/tile/CalcTileLayer.js
+++ b/loleaflet/src/layer/tile/CalcTileLayer.js
@@ -1658,8 +1658,6 @@ L.SheetDimension = L.Class.extend({
 		this._coreZoomFactor = this._tileSizePixels * 15.0 / this._tileSizeTwips;
 		this._twipsPerCorePixel = this._tileSizeTwips / this._tileSizePixels;
 
-		this._corePixelsPerCssPixel = this._dpiScale;
-
 		if (updatePositions) {
 			// We need to compute positions data for every zoom change.
 			this._updatePositions();
@@ -1686,7 +1684,7 @@ L.SheetDimension = L.Class.extend({
 			// Important: rounding needs to be done in core pixels to match core.
 			var sizeCorePxOne = Math.floor(size / dimensionObj._twipsPerCorePixel);
 			posCorePx += (sizeCorePxOne * spanLength);
-			var posCssPx = posCorePx / dimensionObj._corePixelsPerCssPixel;
+			var posCssPx = posCorePx / dimensionObj._dpiScale;
 			// position in core-pixel aligned twips.
 			var posTileTwips = Math.floor(posCorePx * dimensionObj._twipsPerCorePixel);
 			posPrintTwips += (size * spanLength);
@@ -1723,8 +1721,8 @@ L.SheetDimension = L.Class.extend({
 
 			if (!useCorePixels) {
 				// startpos and size are now in core pixels, so convert to css pixels.
-				startpos = Math.floor(startpos / this._corePixelsPerCssPixel);
-				size = Math.floor(size / this._corePixelsPerCssPixel);
+				startpos = Math.floor(startpos / this._dpiScale);
+				size = Math.floor(size / this._dpiScale);
 			}
 
 			return {
@@ -1773,7 +1771,7 @@ L.SheetDimension = L.Class.extend({
 		var inPixels = (unitName === 'csspixels' || unitName === 'corepixels');
 		if (inPixels) {
 			var useCorePixels = (unitName === 'corepixels');
-			var pixelScale = useCorePixels ? 1 : this._corePixelsPerCssPixel;
+			var pixelScale = useCorePixels ? 1 : this._dpiScale;
 			return {
 				startpos: (span.data.poscorepx - span.data.sizecore * numSizes) / pixelScale,
 				size: span.data.sizecore / pixelScale
@@ -2025,7 +2023,7 @@ L.SheetDimension = L.Class.extend({
 			unit = 'tiletwips';
 		}
 		else if (unit === 'csspixels') {
-			pos = pos * this._corePixelsPerCssPixel * this._twipsPerCorePixel;
+			pos = pos * this._dpiScale * this._twipsPerCorePixel;
 			unit = 'tiletwips';
 		}
 
@@ -2046,7 +2044,7 @@ L.SheetDimension = L.Class.extend({
 			unit = 'tiletwips';
 		}
 		else if (unit === 'csspixels') {
-			pos = pos * this._corePixelsPerCssPixel * this._twipsPerCorePixel;
+			pos = pos * this._dpiScale * this._twipsPerCorePixel;
 			unit = 'tiletwips';
 		}
 

--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -173,9 +173,9 @@ L.CanvasTilePainter = L.Class.extend({
 
 		for (var i = 0; i < ctx.paneBoundsList.length; ++i) {
 			// co-ordinates of this pane in core document pixels
-			var paneBounds = this._layer._cssBoundsToCore(ctx.paneBoundsList[i]);
+			var paneBounds = ctx.paneBoundsList[i];
 			// co-ordinates of the main-(bottom right) pane in core document pixels
-			var viewBounds = this._layer._cssBoundsToCore(ctx.viewBounds);
+			var viewBounds = ctx.viewBounds;
 
 			// into real pixel-land ...
 			paneBounds.round();

--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -118,10 +118,6 @@ L.CanvasTilePainter = L.Class.extend({
 		this._lastSize = new L.Point(widthCSSPx, heightCSSPx);
 	},
 
-	canvasDPIScale: function () {
-		return parseInt(this._canvas.width) / this._width;
-	},
-
 	_syncTileContainerSize: function () {
 		var tileContainer = this._layer._container;
 		if (tileContainer) {
@@ -623,10 +619,6 @@ L.CanvasTileLayer = L.TileLayer.extend({
 			this._wrapY ? L.Util.wrapNum(coords.y, this._wrapY) : coords.y,
 			coords.z,
 			coords.part);
-	},
-
-	canvasDPIScale: function () {
-		return this._painter.canvasDPIScale();
 	},
 
 	_pxBoundsToTileRanges: function (bounds) {

--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -215,29 +215,6 @@ L.CanvasTilePainter = L.Class.extend({
 				this._canvasCtx.strokeRect(tile.coords.x, tile.coords.y, 256, 256);
 			}
 		}
-
-		if (this._map._canvasDevicePixelGrid === true) {
-			var offset = 8;
-			var lineCount = Math.round(this._canvas.height / offset);
-			var columnCount = Math.round(this._canvas.width / offset);
-			this._canvasCtx.lineWidth = 1;
-			var currentX = 0;
-			var currentY = 0;
-			for (var i = 0; i < lineCount; i++) {
-				this._canvasCtx.beginPath();
-				this._canvasCtx.moveTo(0.5, currentY + 0.5);
-				this._canvasCtx.lineTo(this._canvas.width + 0.5, currentY + 0.5);
-				this._canvasCtx.stroke();
-				currentY += offset;
-			}
-			for (var i = 0; i < columnCount; i++) {
-				this._canvasCtx.beginPath();
-				this._canvasCtx.moveTo(currentX + 0.5, 0.5);
-				this._canvasCtx.lineTo(currentX + 0.5, this._canvas.height + 0.5);
-				this._canvasCtx.stroke();
-				currentX += offset;
-			}
-		}
 	},
 
 	_paintSimple: function (tile, ctx) {
@@ -253,6 +230,37 @@ L.CanvasTilePainter = L.Class.extend({
 			this._paintWithPanes(tile, ctx);
 		else
 			this._paintSimple(tile, ctx);
+
+		if (this._map._canvasDevicePixelGrid === true)
+			this._drawDebuggingGrid();
+	},
+
+	_drawDebuggingGrid: function() {
+		var offset = 8;
+		var count;
+		this._canvasCtx.lineWidth = 1;
+		var currentPos;
+		this._canvasCtx.strokeStyle = '#ff0000';
+
+		currentPos = 0;
+		count = Math.round(this._canvas.height / offset);
+		for (var i = 0; i < count; i++) {
+			this._canvasCtx.beginPath();
+			this._canvasCtx.moveTo(0.5, currentPos + 0.5);
+			this._canvasCtx.lineTo(this._canvas.width + 0.5, currentPos + 0.5);
+			this._canvasCtx.stroke();
+			currentPos += offset;
+		}
+
+		currentPos = 0;
+		count = Math.round(this._canvas.width / offset);
+		for (var i = 0; i < count; i++) {
+			this._canvasCtx.beginPath();
+			this._canvasCtx.moveTo(currentPos + 0.5, 0.5);
+			this._canvasCtx.lineTo(currentPos + 0.5, this._canvas.height + 0.5);
+			this._canvasCtx.stroke();
+			currentPos += offset;
+		}
 	},
 
 	_drawSplits: function () {

--- a/loleaflet/src/layer/tile/TileLayer.js
+++ b/loleaflet/src/layer/tile/TileLayer.js
@@ -3649,8 +3649,10 @@ L.TileLayer = L.GridLayer.extend({
 					for (var i = 0; i < this._debugDataNames.length; i++) {
 						this._debugData[this._debugDataNames[i]].addTo(this._map);
 					}
-				} else if (e.layer === this._canvasDevicePixelGrid)
+				} else if (e.layer === this._canvasDevicePixelGrid) {
 					this._map._canvasDevicePixelGrid = true;
+					this._map._docLayer._painter._paintWholeCanvas();
+				}
 			}, this);
 			this._map.on('layerremove', function(e) {
 				if (e.layer === this._debugAlwaysActive) {
@@ -3663,8 +3665,10 @@ L.TileLayer = L.GridLayer.extend({
 					for (var i in this._debugData) {
 						this._debugData[i].remove();
 					}
-				} else if (e.layer === this._canvasDevicePixelGrid)
+				} else if (e.layer === this._canvasDevicePixelGrid) {
 					this._map._canvasDevicePixelGrid = false;
+					this._map._docLayer._painter._paintWholeCanvas();
+				}
 			}, this);
 		}
 		this._debugTimePING = this._debugGetTimeArray();


### PR DESCRIPTION
Signed-off-by: Gökay Şatır <gokaysatir@collabora.com>
Change-Id: I7442f69d7653b2eb95ec60b281d4b61533dbf2ff


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
This commit resolves:
* Sizing of column and row headers of Calc.
* Uses core pixel sizes for tiles.


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

