### PR TITLE
mobilewizard: warn children data type check

### DIFF
--- a/loleaflet/src/layer/tile/TileLayer.js
+++ b/loleaflet/src/layer/tile/TileLayer.js
@@ -1045,6 +1045,12 @@ L.TileLayer = L.GridLayer.extend({
 	_onJSDialogMsg: function (textMsg) {
 		if (window.mode.isMobile()) {
 			var msgData = JSON.parse(textMsg.substring('jsdialog:'.length + 1));
+
+			if (msgData.children && !L.Util.isArray(msgData.children)) {
+				console.warn('_onJSDialogMsg: The children\'s data should be created of array type');
+				return;
+			}
+
 			if (msgData.type == 'borderwindow')
 				return;
 			if (msgData.enabled) {


### PR DESCRIPTION
Occurs when using the latest LO master branch
the mobile wizard fails:

Util.js:107 Uncaught RangeError: Maximum call stack size exceeded
    at String.split (<anonymous>)
    at Object.splitWords (Util.js:107)
    at NewClass.on (Events.js:20)
    at Function.listenNumericChanges (Control.JSDialogBuilder.js:124)
    at _formattedfieldControl (Control.JSDialogBuilder.js:1312)
    at NewClass.build (Control.MobileWizardBuilder.js:145)
    at NewClass.build (Control.MobileWizardBuilder.js:150)
    at NewClass.build (Control.MobileWizardBuilder.js:150)
    at NewClass.build (Control.MobileWizardBuilder.js:150)
    at NewClass.build (Control.MobileWizardBuilder.js:150)

The builder recursive looks like an infinity loop,
and the cause is that the server is not sending the array children
data type.

Change-Id: I298c239b6018a457d3825be886ea22cb984f13cc
