### PR TITLE
loleaflet: sort the packages in package.json

### DIFF
--- a/loleaflet/package.json
+++ b/loleaflet/package.json
@@ -19,13 +19,13 @@
     "select2": "4.0.13",
     "shrinkpack": "1.0.0-alpha",
     "smartmenus": "1.0.0",
+    "stylelint": "13.7.0",
+    "stylelint-config-standard": "20.0.0",
+    "typescript": "3.9.5",
     "uglify-js": "3.9.4",
     "uglifycss": "0.0.29",
     "uglifyify": "5.0.2",
-    "vex-js": "4.1.0",
-    "typescript": "3.9.5",
-    "stylelint-config-standard": "20.0.0",
-    "stylelint": "13.7.0"
+    "vex-js": "4.1.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I am using the "npm" version 7.0.12, and after
bundling the "loleaflet", the "package.json" is modified.

Let's sort permanently so I cannot get contaminated with
something that I did not touch in my source directory files.

Change-Id: I6a1e6d6b3f1b2898288f06de85fc0307b62cbbeb
Signed-off-by: Henry Castro <hcastro@collabora.com>
