### PR TITLE
wsd: do not decode already decoded fields

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1402,9 +1402,8 @@ private:
         // Append name of the user, if any, who opened the document to rendering options
         if (!userName.empty())
         {
-            std::string decodedUserName;
-            URI::decode(userName, decodedUserName);
-            renderOptsObj->set(".uno:Author", makePropertyValue("string", decodedUserName));
+            // userName must be decoded already.
+            renderOptsObj->set(".uno:Author", makePropertyValue("string", userName));
         }
 
         if (!spellOnline.empty())


### PR DESCRIPTION
The different attributes of a document/user
are decoded when the kit receives them.
Decoding them a second time is usually harmless,
unless, that is, they contain '%'.

After the first decoding the '%' character might
not be escaping anything valid (depending on what
follows it). So a second attempt at decoding
might very well fail and throw, since the escape
code is invalid.

Change-Id: I73d56ce995b0237140a54b6c06bd36bde8b387bd
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
