### PR TITLE
wsd: do not decode already decoded fields

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1917,9 +1917,7 @@ private:
         {
             Object::Ptr authorObj = new Object();
             authorObj->set("type", "string");
-            std::string decodedUserName;
-            URI::decode(userName, decodedUserName);
-            authorObj->set("value", decodedUserName);
+            authorObj->set("value", userName); // userName must be decoded already.
             renderOptsObj->set(".uno:Author", authorObj);
         }
 


### PR DESCRIPTION
The different attributes of a document/user
are decoded when the kit receives them.
Decoding them a second time is usually harmless,
unless, that is, they contain '%'.

After the first decoding the '%' character might
not be escaping anything valid (depending on what
follows it). So a second attempt at decoding
might very well fail and throw, since the escape
code is invalid.

Change-Id: I73d56ce995b0237140a54b6c06bd36bde8b387bd
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

