### PR TITLE
Socket - re-work disposition to ensure we transfer sockets.

### DIFF
--- a/wsd/Admin.cpp
+++ b/wsd/Admin.cpp
@@ -875,11 +875,6 @@ void Admin::sendMetrics(const std::shared_ptr<StreamSocket>& socket, const std::
     socket->shutdown();
 }
 
-void Admin::sendMetricsAsync(const std::shared_ptr<StreamSocket>& socket, const std::shared_ptr<Poco::Net::HTTPResponse>& response)
-{
-    addCallback([this, socket, response]{ sendMetrics(socket, response); });
-}
-
 void Admin::start()
 {
     bool haveMonitors = false;

--- a/wsd/Admin.hpp
+++ b/wsd/Admin.hpp
@@ -132,7 +132,6 @@ public:
     void scheduleMonitorConnect(const std::string &uri, std::chrono::steady_clock::time_point when);
 
     void sendMetrics(const std::shared_ptr<StreamSocket>& socket, const std::shared_ptr<Poco::Net::HTTPResponse>& response);
-    void sendMetricsAsync(const std::shared_ptr<StreamSocket>& socket, const std::shared_ptr<Poco::Net::HTTPResponse>& response);
 
     void setViewLoadDuration(const std::string& docKey, const std::string& sessionId, std::chrono::milliseconds viewLoadDuration);
     void setDocWopiDownloadDuration(const std::string& docKey, std::chrono::milliseconds wopiDownloadDuration);

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -135,8 +135,9 @@ public:
     /// Called when removed from the DocBrokers list
     virtual void dispose() {}
 
-    /// Start processing events
-    void startThread();
+    /// setup the transfer of a socket into this DocumentBroker poll.
+    void setupTransfer(SocketDisposition &disposition,
+                       SocketDisposition::MoveFunction transferFn);
 
     /// Flag for termination. Note that this doesn't save any unsaved changes in the document
     void stop(const std::string& reason);


### PR DESCRIPTION
A number of call-sites, eg. clipboard, or admin-ws were
writing to sockets assuming they could return all the data
in a single series of writes, without needing to poll. As
such they failed to addSocketToPoll on the new poll - eg.
the docBroker. Unfortunately this meant that on EAGAIN
writes, the socket would be closed and the last parts
of a message lost.

Browsers would give net::ERR_CONTENT_LENGTH_MISMATCH 200 (OK)

The situation is/was intermittent, so painful to debug.
On under-loaded developer machines, socket buffers are larger,
so this was seldom seen.

The re-factor forces a transfer to another SocketPoll via
the disposition, except for a couple of corner cases.

Change-Id: I2f1b2f99f179c4fda84464c9241fe434fa527725
Signed-off-by: Michael Meeks <michael.meeks@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

