### PR TITLE
Revert "cypress: use moveCursor() helper method in table tests."

### DIFF
--- a/cypress_test/integration_tests/mobile/writer/table_properties_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/table_properties_spec.js
@@ -28,11 +28,11 @@ describe('Change table properties / layout via mobile wizard.', function() {
 			.should('be.visible');
 	}
 
-	function selectFullTable(cursorMovementCount) {
-		// Move cursor out of the table.
-		for (var i = 0; i < cursorMovementCount; i++) {
-			helper.moveCursor('down');
-		}
+	function selectFullTable() {
+		helper.typeIntoDocument('{downarrow}{downarrow}{downarrow}{downarrow}');
+
+		// TODO: solve this better.
+		cy.wait(1000);
 
 		writerHelper.selectAllTextOfDoc();
 	}
@@ -47,7 +47,7 @@ describe('Change table properties / layout via mobile wizard.', function() {
 		cy.get('.leaflet-marker-icon.table-row-resize-marker')
 			.should('have.length', 4);
 
-		selectFullTable(3);
+		selectFullTable();
 
 		// Check rows / columns
 		cy.get('#copy-paste-container tr')
@@ -70,7 +70,7 @@ describe('Change table properties / layout via mobile wizard.', function() {
 		cy.get('.leaflet-marker-icon.table-row-resize-marker')
 			.should('have.length', 4);
 
-		selectFullTable(4);
+		selectFullTable();
 
 		// Check rows / columns
 		cy.get('#copy-paste-container tr')
@@ -93,7 +93,7 @@ describe('Change table properties / layout via mobile wizard.', function() {
 		cy.get('.leaflet-marker-icon.table-column-resize-marker')
 			.should('have.length', 4);
 
-		selectFullTable(3);
+		selectFullTable();
 
 		// Check rows / columns
 		cy.get('#copy-paste-container tr')
@@ -116,7 +116,7 @@ describe('Change table properties / layout via mobile wizard.', function() {
 		cy.get('.leaflet-marker-icon.table-column-resize-marker')
 			.should('have.length', 4);
 
-		selectFullTable(3);
+		selectFullTable();
 
 		// Check rows / columns
 		cy.get('#copy-paste-container tr')
@@ -139,7 +139,7 @@ describe('Change table properties / layout via mobile wizard.', function() {
 		cy.get('.leaflet-marker-icon.table-row-resize-marker')
 			.should('have.length', 2);
 
-		selectFullTable(2);
+		selectFullTable();
 
 		// Check rows / columns
 		cy.get('#copy-paste-container tr')
@@ -204,7 +204,7 @@ describe('Change table properties / layout via mobile wizard.', function() {
 
 		helper.clickOnIdle('#MergeCells');
 
-		selectFullTable(2);
+		selectFullTable();
 
 		// Check rows / columns
 		cy.get('#copy-paste-container tr')
@@ -229,7 +229,7 @@ describe('Change table properties / layout via mobile wizard.', function() {
 		cy.get('#rowheight .spinfield')
 			.should('have.attr', 'value', '1.4');
 
-		selectFullTable(3);
+		selectFullTable();
 
 		// Check row height
 		cy.get('#copy-paste-container td')
@@ -249,7 +249,7 @@ describe('Change table properties / layout via mobile wizard.', function() {
 		cy.get('#columnwidth .spinfield')
 			.should('have.attr', 'value', '1.6');
 
-		selectFullTable(3);
+		selectFullTable();
 
 		// Check row height
 		cy.get('#copy-paste-container td')
@@ -265,7 +265,7 @@ describe('Change table properties / layout via mobile wizard.', function() {
 
 		helper.clickOnIdle('#SetMinimalRowHeight');
 
-		selectFullTable(1);
+		selectFullTable();
 
 		// Check new row height
 		cy.get('#copy-paste-container td')
@@ -281,7 +281,7 @@ describe('Change table properties / layout via mobile wizard.', function() {
 
 		helper.clickOnIdle('#SetOptimalRowHeight');
 
-		selectFullTable(1);
+		selectFullTable();
 
 		// Check new row height
 		cy.get('#copy-paste-container td')
@@ -307,7 +307,7 @@ describe('Change table properties / layout via mobile wizard.', function() {
 
 		helper.clickOnIdle('#DistributeRows');
 
-		selectFullTable(1);
+		selectFullTable();
 
 		// Check new row height
 		cy.get('#copy-paste-container td')
@@ -333,7 +333,7 @@ describe('Change table properties / layout via mobile wizard.', function() {
 
 		helper.clickOnIdle('#SetMinimalColumnWidth');
 
-		selectFullTable(1);
+		selectFullTable();
 
 		cy.get('#copy-paste-container td')
 			.should('have.attr', 'width', '24');
@@ -348,7 +348,7 @@ describe('Change table properties / layout via mobile wizard.', function() {
 
 		helper.clickOnIdle('#SetOptimalColumnWidth');
 
-		selectFullTable(1);
+		selectFullTable();
 
 		cy.get('#copy-paste-container td:nth-of-type(1n)')
 			.should('have.attr', 'width', '324');
@@ -365,7 +365,7 @@ describe('Change table properties / layout via mobile wizard.', function() {
 
 		helper.clickOnIdle('#DistributeColumns');
 
-		selectFullTable(1);
+		selectFullTable();
 
 		cy.get('#copy-paste-container td')
 			.should('have.attr', 'width', '323');


### PR DESCRIPTION
This reverts commit e1ed5d3c299f2664d108375a5ea3cb90814556a4.