### PR TITLE
Admin: vex.css usage improvements.

### DIFF
--- a/loleaflet/admin/admintemplate.html
+++ b/loleaflet/admin/admintemplate.html
@@ -10,9 +10,8 @@
     <link rel="localizations" href="%SERVICE_ROOT%/loleaflet/%VERSION%/l10n/admin-localizations.json" type="application/vnd.oftn.l10n+json"/>
 
     <title>Collabora Online - Admin console</title>
-    <script src="%SERVICE_ROOT%/loleaflet/%VERSION%/admin-bundle.js"></script>
     <link rel=StyleSheet href="%SERVICE_ROOT%/loleaflet/%VERSION%/admin/css/bulma.min.css" type="text/css" />
-    <link rel=StyleSheet href="%SERVICE_ROOT%/loleaflet/%VERSION%/vex.css" type="text/css" />
+    <script src="%SERVICE_ROOT%/loleaflet/%VERSION%/admin-bundle.js"></script>
 
     <style>
         @font-face {

--- a/loleaflet/admin/src/AdminSocketBase.js
+++ b/loleaflet/admin/src/AdminSocketBase.js
@@ -31,6 +31,12 @@ var AdminSocketBase = Base.extend({
 			this.socket.onerror = this.onSocketError.bind(this);
 			this.socket.binaryType = 'arraybuffer';
 		}
+
+		this.pageWillBeRefreshed = false;
+		var onBeforeFunction = function() {
+			this.pageWillBeRefreshed = true;
+		};
+		window.onbeforeunload = onBeforeFunction.bind(this);
 	},
 
 	onSocketOpen: function () {
@@ -47,15 +53,17 @@ var AdminSocketBase = Base.extend({
 		this.socket.onerror = function () { };
 		this.socket.onclose = function () { };
 		this.socket.onmessage = function () { };
-
-		this.vexInstance = vex.open({
-			content: _('Server has been shut down; please reload the page.'),
-			contentClassName: 'loleaflet-user-idle',
-			showCloseButton: false,
-			overlayClosesOnClick: false,
-			escapeButtonCloses: false,
-		});
 		this.socket.close();
+
+		if (this.pageWillBeRefreshed === false) {
+			this.vexInstance = vex.open({
+				content: _('Server has been shut down; please reload the page.'),
+				contentClassName: 'loleaflet-user-idle',
+				showCloseButton: false,
+				overlayClosesOnClick: false,
+				escapeButtonCloses: false,
+			});
+		}
 	},
 
 	onSocketError: function () {


### PR DESCRIPTION
vex.css reference is removed from admintemplate.html file. main-admin.js already injects it into html.
There was a bug causing "socket closed" message to appear on every page refresh.

Signed-off-by: Gökay Şatır <gokaysatir@collabora.com>
Change-Id: I1ae625a184bc353feb6af056f5767b92b518be16


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

