### PR TITLE
Socket - re-work disposition to ensure we transfer sockets.

### DIFF
--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -1,3 +1,4 @@
+
 /* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
 /*
  * This Source Code Form is subject to the terms of the Mozilla Public
@@ -132,6 +133,7 @@ bool SocketPoll::startThread()
         _stop = false;
         try
         {
+            LOG_TRC("starting thread for poll " << _name);
             _thread = std::thread(&SocketPoll::pollingThreadEntry, this);
             return true;
         }
@@ -314,7 +316,7 @@ int SocketPoll::poll(int64_t timeoutMaxMicroS)
             rc = -1;
         }
 
-        if (disposition.isMove() || disposition.isClosed())
+        if (!disposition.isContinue())
         {
             LOG_DBG("Removing socket #" << _pollFds[i].fd << " (of " <<
                     _pollSockets.size() << ") from " << _name);
@@ -519,9 +521,26 @@ void SocketDisposition::execute()
     {
         // Drop pretentions of ownership before _socketMove.
         _socket->setThreadOwner(std::thread::id());
-        _socketMove(_socket);
+
+        if (!_toPoll) {
+            assert (isMove());
+            _socketMove(_socket);
+        } else {
+            assert (isTransfer());
+            // Ensure the thread is running before adding callback.
+            _toPoll->startThread();
+            auto pollCopy = _toPoll;
+            auto socket = _socket;
+            auto socketMoveFn = std::move(_socketMove);
+            _toPoll->addCallback([pollCopy, socket, socketMoveFn]()
+                {
+                    pollCopy->insertNewSocket(socket);
+                    socketMoveFn(socket);
+                });
+        }
+        _socketMove = nullptr;
+        _toPoll = nullptr;
     }
-    _socketMove = nullptr;
 }
 
 const int WebSocketHandler::InitialPingDelayMicroS = 25 * 1000;

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -49,35 +49,42 @@ namespace Poco
 }
 
 class Socket;
+class SocketPoll;
 
 /// Helper to allow us to easily defer the movement of a socket
 /// between polls to clarify thread ownership.
 class SocketDisposition
 {
-    typedef std::function<void(const std::shared_ptr<Socket> &)> MoveFunction;
-    enum class Type { CONTINUE, CLOSED, MOVE };
-
-    Type _disposition;
-    MoveFunction _socketMove;
-    std::shared_ptr<Socket> _socket;
+    enum class Type { CONTINUE, CLOSED, MOVE, TRANSFER };
 
 public:
+    typedef std::function<void(const std::shared_ptr<Socket> &)> MoveFunction;
+
     SocketDisposition(const std::shared_ptr<Socket> &socket) :
         _disposition(Type::CONTINUE),
+        _toPoll(nullptr),
         _socket(socket)
     {}
     ~SocketDisposition()
     {
         assert (!_socketMove);
     }
-    void setMove()
-    {
-        _disposition = Type::MOVE;
-    }
+    // not the method you want.
     void setMove(MoveFunction moveFn)
     {
         _socketMove = std::move(moveFn);
         _disposition = Type::MOVE;
+    }
+    /** move, correctly change ownership of and insert into a new poll.
+     * @transferFn is called as a callback inside the new poll, which
+     * has its thread started if it is not already.
+     * @moveFn can be used for optional setup.
+     */
+    void setTransfer(SocketPoll &poll, MoveFunction transferFn)
+    {
+        _socketMove = std::move(transferFn);
+        _disposition = Type::TRANSFER;
+        _toPoll = &poll; // rely on the closure to ensure lifetime
     }
     void setClosed()
     {
@@ -87,11 +94,19 @@ public:
     {
         return _socket;
     }
-    bool isMove() { return _disposition == Type::MOVE; }
-    bool isClosed() { return _disposition == Type::CLOSED; }
+    bool isMove() const { return _disposition == Type::MOVE; }
+    bool isClosed() const { return _disposition == Type::CLOSED; }
+    bool isTransfer() const { return  _disposition == Type::TRANSFER; }
+    bool isContinue() const { return _disposition == Type::CONTINUE; }
 
     /// Perform the queued up work.
     void execute();
+
+private:
+    Type _disposition;
+    MoveFunction _socketMove;
+    SocketPoll *_toPoll;
+    std::shared_ptr<Socket> _socket;
 };
 
 /// A non-blocking, streaming socket.
@@ -1101,7 +1116,7 @@ protected:
         {
             oldSize = _inBuffer.size();
             _socketHandler->handleIncomingMessage(disposition);
-            if (disposition.isMove())
+            if (disposition.isMove() || disposition.isTransfer())
                 return;
         }
 

--- a/wsd/Admin.cpp
+++ b/wsd/Admin.cpp
@@ -875,11 +875,6 @@ void Admin::sendMetrics(const std::shared_ptr<StreamSocket>& socket, const std::
     socket->shutdown();
 }
 
-void Admin::sendMetricsAsync(const std::shared_ptr<StreamSocket>& socket, const std::shared_ptr<Poco::Net::HTTPResponse>& response)
-{
-    addCallback([this, socket, response]{ sendMetrics(socket, response); });
-}
-
 void Admin::start()
 {
     bool haveMonitors = false;

--- a/wsd/Admin.hpp
+++ b/wsd/Admin.hpp
@@ -132,7 +132,6 @@ public:
     void scheduleMonitorConnect(const std::string &uri, std::chrono::steady_clock::time_point when);
 
     void sendMetrics(const std::shared_ptr<StreamSocket>& socket, const std::shared_ptr<Poco::Net::HTTPResponse>& response);
-    void sendMetricsAsync(const std::shared_ptr<StreamSocket>& socket, const std::shared_ptr<Poco::Net::HTTPResponse>& response);
 
     void setViewLoadDuration(const std::string& docKey, const std::string& sessionId, std::chrono::milliseconds viewLoadDuration);
     void setDocWopiDownloadDuration(const std::string& docKey, std::chrono::milliseconds wopiDownloadDuration);

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -216,9 +216,10 @@ void DocumentBroker::setupPriorities()
 #endif
 }
 
-void DocumentBroker::startThread()
+void DocumentBroker::setupTransfer(SocketDisposition &disposition,
+                                   SocketDisposition::MoveFunction transferFn)
 {
-    _poll->startThread();
+    disposition.setTransfer(*_poll.get(), transferFn);
 }
 
 void DocumentBroker::assertCorrectThread() const
@@ -2412,36 +2413,22 @@ bool ConvertToBroker::startConversion(SocketDisposition &disposition, const std:
     if (!_clientSession)
         return false;
 
-    disposition.setMove([docBroker] (const std::shared_ptr<Socket> &moveSocket)
+    docBroker->setupTransfer(disposition, [docBroker] (const std::shared_ptr<Socket> &moveSocket)
         {
-            // Perform all of this after removing the socket
+            auto streamSocket = std::static_pointer_cast<StreamSocket>(moveSocket);
+            docBroker->_clientSession->setSaveAsSocket(streamSocket);
 
-            // Make sure the thread is running before adding callback.
-            docBroker->startThread();
+            // First add and load the session.
+            docBroker->addSession(docBroker->_clientSession);
 
-            // We no longer own this socket.
-            moveSocket->setThreadOwner(std::thread::id(0));
+            // Load the document manually and request saving in the target format.
+            std::string encodedFrom;
+            Poco::URI::encode(docBroker->getPublicUri().getPath(), "", encodedFrom);
+            const std::string _load = "load url=" + encodedFrom;
+            std::vector<char> loadRequest(_load.begin(), _load.end());
+            docBroker->_clientSession->handleMessage(loadRequest);
 
-            docBroker->addCallback([docBroker, moveSocket]()
-                 {
-                     auto streamSocket = std::static_pointer_cast<StreamSocket>(moveSocket);
-                     docBroker->_clientSession->setSaveAsSocket(streamSocket);
-
-                     // Move the socket into DocBroker.
-                     docBroker->addSocketToPoll(moveSocket);
-
-                     // First add and load the session.
-                     docBroker->addSession(docBroker->_clientSession);
-
-                     // Load the document manually and request saving in the target format.
-                     std::string encodedFrom;
-                     Poco::URI::encode(docBroker->getPublicUri().getPath(), "", encodedFrom);
-                     const std::string _load = "load url=" + encodedFrom;
-                     std::vector<char> loadRequest(_load.begin(), _load.end());
-                     docBroker->_clientSession->handleMessage(loadRequest);
-
-                     // Save is done in the setLoaded
-                 });
+            // Save is done in the setLoaded
         });
     return true;
 }

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -137,8 +137,9 @@ public:
     /// Called when removed from the DocBrokers list
     virtual void dispose() {}
 
-    /// Start processing events
-    void startThread();
+    /// setup the transfer of a socket into this DocumentBroker poll.
+    void setupTransfer(SocketDisposition &disposition,
+                       SocketDisposition::MoveFunction transferFn);
 
     /// Flag for termination. Note that this doesn't save any unsaved changes in the document
     void stop(const std::string& reason);

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -2443,7 +2443,6 @@ private:
                             Admin::instance().insertNewSocket(moveSocket);
                         });
                 }
-
             }
             else if (requestDetails.equals(RequestDetails::Field::Type, "lool") &&
                      requestDetails.equals(1, "getMetrics"))
@@ -2482,10 +2481,12 @@ private:
                 response->add("Content-Type", "text/plain");
                 response->add("X-Content-Type-Options", "nosniff");
 
-                disposition.setMove([response](const std::shared_ptr<Socket> &moveSocket){
-                            const std::shared_ptr<StreamSocket> streamSocket = std::static_pointer_cast<StreamSocket>(moveSocket);
-                            Admin::instance().sendMetricsAsync(streamSocket, response);
-                        });
+                disposition.setTransfer(Admin::instance(),
+                                        [response](const std::shared_ptr<Socket> &moveSocket){
+                                            const std::shared_ptr<StreamSocket> streamSocket =
+                                                std::static_pointer_cast<StreamSocket>(moveSocket);
+                                            Admin::instance().sendMetrics(streamSocket, response);
+                                        });
             }
             else if (requestDetails.isGetOrHead("/"))
                 handleRootRequest(requestDetails, socket);
@@ -2782,19 +2783,12 @@ private:
                     LOG_ERR("Invalid zero size set clipboard content");
             }
             // Do things in the right thread.
-            disposition.setMove([=] (const std::shared_ptr<Socket> &moveSocket)
+            LOG_TRC("Move clipboard request " << tag << " to docbroker thread with data: " <<
+                    (data ? data->length() : 0) << " bytes");
+            docBroker->setupTransfer(disposition, [=] (const std::shared_ptr<Socket> &moveSocket)
                 {
-                    LOG_TRC("Move clipboard request " << tag << " to docbroker thread with data: " <<
-                            (data ? data->length() : 0) << " bytes");
-                    // We no longer own this socket.
-                    moveSocket->setThreadOwner(std::thread::id(0));
-
-                    // Perform all of this after removing the socket
-                    docBroker->addCallback([=]()
-                        {
-                            auto streamSocket = std::static_pointer_cast<StreamSocket>(moveSocket);
-                            docBroker->handleClipboardRequest(type, streamSocket, viewId, tag, data);
-                        });
+                    auto streamSocket = std::static_pointer_cast<StreamSocket>(moveSocket);
+                    docBroker->handleClipboardRequest(type, streamSocket, viewId, tag, data);
                 });
             LOG_TRC("queued clipboard command " << type << " on docBroker fetch");
         }
@@ -3247,53 +3241,42 @@ private:
         {
             // need to move into the DocumentBroker context before doing session lookup / creation etc.
             std::string id = _id;
-            disposition.setMove([docBroker, id, uriPublic,
-                                 isReadOnly, requestDetails]
-                                (const std::shared_ptr<Socket> &moveSocket)
+            docBroker->setupTransfer(disposition, [docBroker, id, uriPublic,
+                                     isReadOnly, requestDetails]
+                                    (const std::shared_ptr<Socket> &moveSocket)
                 {
-                    LOG_TRC("Setting up docbroker thread for " << docBroker->getDocKey());
-                    // Make sure the thread is running before adding callback.
-                    docBroker->startThread();
+                    // Now inside the document broker thread ...
+                    LOG_TRC("In the docbroker thread for " << docBroker->getDocKey());
 
-                    // We no longer own this socket.
-                    moveSocket->setThreadOwner(std::thread::id());
-
-                    docBroker->addCallback([docBroker, id, uriPublic, isReadOnly,
-                                            requestDetails, moveSocket]()
-                        {
-                            // Now inside the document broker thread ...
-                            LOG_TRC("In the docbroker thread for " << docBroker->getDocKey());
-
-                            auto streamSocket = std::static_pointer_cast<StreamSocket>(moveSocket);
-                            try
-                            {
-                                docBroker->handleProxyRequest(
-                                    id, uriPublic, isReadOnly,
-                                    requestDetails, streamSocket);
-                                return;
-                            }
-                            catch (const UnauthorizedRequestException& exc)
-                            {
-                                LOG_ERR("Unauthorized Request while loading session for " << docBroker->getDocKey() << ": " << exc.what());
-                            }
-                            catch (const StorageConnectionException& exc)
-                            {
-                                LOG_ERR("Error while loading : " << exc.what());
-                            }
-                            catch (const std::exception& exc)
-                            {
-                                LOG_ERR("Error while loading : " << exc.what());
-                            }
-                            // badness occurred:
-                            std::ostringstream oss;
-                            oss << "HTTP/1.1 400\r\n"
-                                << "Date: " << Util::getHttpTimeNow() << "\r\n"
-                                << "User-Agent: LOOLWSD WOPI Agent\r\n"
-                                << "Content-Length: 0\r\n"
-                                << "\r\n";
-                            streamSocket->send(oss.str());
-                            streamSocket->shutdown();
-                        });
+                    auto streamSocket = std::static_pointer_cast<StreamSocket>(moveSocket);
+                    try
+                    {
+                        docBroker->handleProxyRequest(
+                            id, uriPublic, isReadOnly,
+                            requestDetails, streamSocket);
+                        return;
+                    }
+                    catch (const UnauthorizedRequestException& exc)
+                    {
+                        LOG_ERR("Unauthorized Request while loading session for " << docBroker->getDocKey() << ": " << exc.what());
+                    }
+                    catch (const StorageConnectionException& exc)
+                    {
+                        LOG_ERR("Error while loading : " << exc.what());
+                    }
+                    catch (const std::exception& exc)
+                    {
+                        LOG_ERR("Error while loading : " << exc.what());
+                    }
+                    // badness occurred:
+                    std::ostringstream oss;
+                    oss << "HTTP/1.1 400\r\n"
+                        << "Date: " << Util::getHttpTimeNow() << "\r\n"
+                        << "User-Agent: LOOLWSD WOPI Agent\r\n"
+                        << "Content-Length: 0\r\n"
+                        << "\r\n";
+                    streamSocket->send(oss.str());
+                    streamSocket->shutdown();
                 });
         }
         else
@@ -3383,62 +3366,51 @@ private:
                 if (clientSession)
                 {
                     // Transfer the client socket to the DocumentBroker when we get back to the poll:
-                    disposition.setMove([docBroker, clientSession, ws]
-                                        (const std::shared_ptr<Socket> &moveSocket)
+                    docBroker->setupTransfer(disposition, [docBroker, clientSession, ws]
+                                            (const std::shared_ptr<Socket> &moveSocket)
                     {
-                        // Make sure the thread is running before adding callback.
-                        docBroker->startThread();
-
-                        // We no longer own this socket.
-                        moveSocket->setThreadOwner(std::thread::id());
-
-                        docBroker->addCallback([docBroker, moveSocket, clientSession, ws]()
+                        try
                         {
-                            try
-                            {
-                                auto streamSocket = std::static_pointer_cast<StreamSocket>(moveSocket);
+                            auto streamSocket = std::static_pointer_cast<StreamSocket>(moveSocket);
 
-                                // Set WebSocketHandler's socket after its construction for shared_ptr goodness.
-                                streamSocket->setHandler(ws);
+                            // Set WebSocketHandler's socket after its construction for shared_ptr goodness.
+                            streamSocket->setHandler(ws);
 
-                                LOG_DBG("Socket #" << moveSocket->getFD() << " handler is " << clientSession->getName());
-                                // Move the socket into DocBroker.
-                                docBroker->addSocketToPoll(moveSocket);
+                            LOG_DBG("Socket #" << moveSocket->getFD() << " handler is " << clientSession->getName());
 
-                                // Add and load the session.
-                                docBroker->addSession(clientSession);
+                            // Add and load the session.
+                            docBroker->addSession(clientSession);
 
-                                LOOLWSD::checkDiskSpaceAndWarnClients(true);
-                                // Users of development versions get just an info
-                                // when reaching max documents or connections
-                                LOOLWSD::checkSessionLimitsAndWarnClients();
+                            LOOLWSD::checkDiskSpaceAndWarnClients(true);
+                            // Users of development versions get just an info
+                            // when reaching max documents or connections
+                            LOOLWSD::checkSessionLimitsAndWarnClients();
 
-                                sendLoadResult(clientSession, true, "");
-                            }
-                            catch (const UnauthorizedRequestException& exc)
-                            {
-                                LOG_ERR("Unauthorized Request while loading session for " << docBroker->getDocKey() << ": " << exc.what());
-                                sendLoadResult(clientSession, false, "Unauthorized Request");
-                                const std::string msg = "error: cmd=internal kind=unauthorized";
-                                clientSession->sendMessage(msg);
-                            }
-                            catch (const StorageConnectionException& exc)
-                            {
-                                sendLoadResult(clientSession, false, exc.what());
-                                // Alert user about failed load
-                                const std::string msg = "error: cmd=storage kind=loadfailed";
-                                clientSession->sendMessage(msg);
-                            }
-                            catch (const std::exception& exc)
-                            {
-                                LOG_ERR("Error while loading : " << exc.what());
+                            sendLoadResult(clientSession, true, "");
+                        }
+                        catch (const UnauthorizedRequestException& exc)
+                        {
+                            LOG_ERR("Unauthorized Request while loading session for " << docBroker->getDocKey() << ": " << exc.what());
+                            sendLoadResult(clientSession, false, "Unauthorized Request");
+                            const std::string msg = "error: cmd=internal kind=unauthorized";
+                            clientSession->sendMessage(msg);
+                        }
+                        catch (const StorageConnectionException& exc)
+                        {
+                            sendLoadResult(clientSession, false, exc.what());
+                            // Alert user about failed load
+                            const std::string msg = "error: cmd=storage kind=loadfailed";
+                            clientSession->sendMessage(msg);
+                        }
+                        catch (const std::exception& exc)
+                        {
+                            LOG_ERR("Error while loading : " << exc.what());
 
-                                // Alert user about failed load
-                                const std::string msg = "error: cmd=storage kind=loadfailed";
-                                clientSession->sendMessage(msg);
-                                sendLoadResult(clientSession, false, exc.what());
-                            }
-                        });
+                            // Alert user about failed load
+                            const std::string msg = "error: cmd=storage kind=loadfailed";
+                            clientSession->sendMessage(msg);
+                            sendLoadResult(clientSession, false, exc.what());
+                        }
                     });
                 }
                 else


### PR DESCRIPTION
A number of call-sites, eg. clipboard, or admin-ws were
writing to sockets assuming they could return all the data
in a single series of writes, without needing to poll. As
such they failed to addSocketToPoll on the new poll - eg.
the docBroker. Unfortunately this meant that on EAGAIN
writes, the socket would be closed and the last parts
of a message lost.

Browsers would give net::ERR_CONTENT_LENGTH_MISMATCH 200 (OK)

The situation is/was intermittent, so painful to debug.
On under-loaded developer machines, socket buffers are larger,
so this was seldom seen.

The re-factor forces a transfer to another SocketPoll via
the disposition, except for a couple of corner cases.

Change-Id: I2f1b2f99f179c4fda84464c9241fe434fa527725
Signed-off-by: Michael Meeks <michael.meeks@collabora.com>
