### PR TITLE
Use chrono data types for type-safety and readability where possible

### DIFF
--- a/common/Log.hpp
+++ b/common/Log.hpp
@@ -42,6 +42,27 @@ inline std::ostream& operator<< (std::ostream& os, const std::chrono::system_clo
     return os;
 }
 
+/// Format seconds with the units suffix until we migrate to C++20.
+inline std::ostream& operator<<(std::ostream& os, const std::chrono::seconds& s)
+{
+    os << s.count() << 's';
+    return os;
+}
+
+/// Format milliseconds with the units suffix until we migrate to C++20.
+inline std::ostream& operator<<(std::ostream& os, const std::chrono::milliseconds& ms)
+{
+    os << ms.count() << "ms";
+    return os;
+}
+
+/// Format microeconds with the units suffix until we migrate to C++20.
+inline std::ostream& operator<<(std::ostream& os, const std::chrono::microseconds& ms)
+{
+    os << ms.count() << "us";
+    return os;
+}
+
 namespace Log
 {
     /// Initialize the logging system.

--- a/common/Png.hpp
+++ b/common/Png.hpp
@@ -202,17 +202,17 @@ inline bool encodeSubBufferToPNG(unsigned char* pixmap, size_t startX, size_t st
     {
         const auto end = std::chrono::steady_clock::now();
 
-        std::chrono::milliseconds::rep duration
-            = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
+        std::chrono::milliseconds duration
+            = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
 
-        static std::chrono::milliseconds::rep totalDuration = 0;
+        static std::chrono::milliseconds totalDuration;
         static int nCalls = 0;
 
         totalDuration += duration;
         ++nCalls;
         LOG_TRC("PNG compression took "
-                << duration << " ms (" << output.size() << " bytes). Average after " << nCalls
-                << " calls: " << (totalDuration / static_cast<double>(nCalls)) << " ms.");
+                << duration << " (" << output.size() << " bytes). Average after " << nCalls
+                << " calls: " << (totalDuration.count() / static_cast<double>(nCalls)) << "ms.");
     }
 
     return res;

--- a/common/RenderTiles.hpp
+++ b/common/RenderTiles.hpp
@@ -526,11 +526,12 @@ namespace RenderTiles
                                 renderArea.getLeft(), renderArea.getTop(),
                                 renderArea.getWidth(), renderArea.getHeight());
         auto duration = std::chrono::steady_clock::now() - start;
-        auto elapsed = std::chrono::duration_cast<std::chrono::microseconds>(duration).count();
-        double totalTime = elapsed/1000.;
-        LOG_DBG("paintPartTile at (" << renderArea.getLeft() << ", " << renderArea.getTop() << "), (" <<
-                renderArea.getWidth() << ", " << renderArea.getHeight() << ") " <<
-                " rendered in " << totalTime << " ms (" << area / elapsed << " MP/s).");
+        const auto elapsedMs = std::chrono::duration_cast<std::chrono::milliseconds>(duration);
+        const double elapsedMics = elapsedMs.count() * 1000.; // Need MPixels/sec, use Pixels/mics.
+        LOG_DBG("paintPartTile at ("
+                << renderArea.getLeft() << ", " << renderArea.getTop() << "), ("
+                << renderArea.getWidth() << ", " << renderArea.getHeight() << ") "
+                << " rendered in " << elapsedMs << " (" << area / elapsedMics << " MP/s).");
 
 #ifdef IOS
 
@@ -734,11 +735,11 @@ namespace RenderTiles
         pngCache.balanceCache();
 
         duration = std::chrono::steady_clock::now() - start;
-        elapsed = std::chrono::duration_cast<std::chrono::microseconds>(duration).count();
-        totalTime = elapsed/1000.;
-        LOG_DBG("rendering tiles at (" << renderArea.getLeft() << ", " << renderArea.getTop() << "), (" <<
-                renderArea.getWidth() << ", " << renderArea.getHeight() << ") " <<
-                " took " << totalTime << " ms (including the paintPartTile).");
+        const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(duration);
+        LOG_DBG("rendering tiles at (" << renderArea.getLeft() << ", " << renderArea.getTop()
+                                       << "), (" << renderArea.getWidth() << ", "
+                                       << renderArea.getHeight() << ") "
+                                       << " took " << elapsed << " (including the paintPartTile).");
 
         if (tileIndex == 0)
             return false;

--- a/common/RenderTiles.hpp
+++ b/common/RenderTiles.hpp
@@ -518,14 +518,14 @@ namespace RenderTiles
 
         // Render the whole area
         const double area = pixmapWidth * pixmapHeight;
-        auto start = std::chrono::system_clock::now();
+        const auto start = std::chrono::steady_clock::now();
         LOG_TRC("Calling paintPartTile(" << (void*)pixmap.data() << ')');
         document->paintPartTile(pixmap.data(),
                                 tileCombined.getPart(),
                                 pixmapWidth, pixmapHeight,
                                 renderArea.getLeft(), renderArea.getTop(),
                                 renderArea.getWidth(), renderArea.getHeight());
-        auto duration = std::chrono::system_clock::now() - start;
+        auto duration = std::chrono::steady_clock::now() - start;
         auto elapsed = std::chrono::duration_cast<std::chrono::microseconds>(duration).count();
         double totalTime = elapsed/1000.;
         LOG_DBG("paintPartTile at (" << renderArea.getLeft() << ", " << renderArea.getTop() << "), (" <<
@@ -733,7 +733,7 @@ namespace RenderTiles
 
         pngCache.balanceCache();
 
-        duration = std::chrono::system_clock::now() - start;
+        duration = std::chrono::steady_clock::now() - start;
         elapsed = std::chrono::duration_cast<std::chrono::microseconds>(duration).count();
         totalTime = elapsed/1000.;
         LOG_DBG("rendering tiles at (" << renderArea.getLeft() << ", " << renderArea.getTop() << "), (" <<

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -125,7 +125,7 @@ bool ChildSession::_handleInput(const char *buffer, int length)
 
     if (tokens.size() > 0 && tokens.equals(0, "useractive") && getLOKitDocument() != nullptr)
     {
-        LOG_DBG("Handling message after inactivity of " << getInactivityMS() << "ms.");
+        LOG_DBG("Handling message after inactivity of " << getInactivityMS());
         setIsActive(true);
 
         // Client is getting active again.
@@ -734,8 +734,8 @@ bool ChildSession::sendFontRendering(const char* /*buffer*/, int /*length*/, con
     ptrFont = getLOKitDocument()->renderFont(decodedFont.c_str(), decodedChar.c_str(), &width, &height);
 
     const auto duration = std::chrono::steady_clock::now() - start;
-    const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
-    LOG_TRC("renderFont [" << font << "] rendered in " << elapsed << "ms");
+    const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(duration);
+    LOG_TRC("renderFont [" << font << "] rendered in " << elapsed);
 
     if (!ptrFont)
     {
@@ -1650,13 +1650,13 @@ bool ChildSession::renderWindow(const char* /*buffer*/, int /*length*/, const St
                                     _viewId);
     const double area = width * height;
 
-    const auto elapsedMics = std::chrono::duration_cast<std::chrono::microseconds>(
-                                 std::chrono::steady_clock::now() - start)
-                                 .count();
+    const auto elapsedMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - start);
+    const double elapsedMics = elapsedMs.count() * 1000.; // Need MPixels/second, use Pixels/mics.
     LOG_TRC("paintWindow for " << winId << " returned " << width << "X" << height << "@(" << startX
                                << ',' << startY << ',' << " with dpi scale: " << dpiScale
-                               << " and rendered in " << elapsedMics / 1000. << "ms ("
-                               << area / elapsedMics << " MP/s).");
+                               << " and rendered in " << elapsedMs << " (" << area / elapsedMics
+                               << " MP/s).");
 
     std::string response = "windowpaint: id=" + tokens[1] + " width=" + std::to_string(width)
                            + " height=" + std::to_string(height);

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -724,7 +724,7 @@ bool ChildSession::sendFontRendering(const char* /*buffer*/, int /*length*/, con
     output.resize(response.size());
     std::memcpy(output.data(), response.data(), response.size());
 
-    const auto start = std::chrono::system_clock::now();
+    const auto start = std::chrono::steady_clock::now();
     // renderFont use a default font size (25) when width and height are 0
     int width = 0, height = 0;
     unsigned char* ptrFont = nullptr;
@@ -733,8 +733,8 @@ bool ChildSession::sendFontRendering(const char* /*buffer*/, int /*length*/, con
 
     ptrFont = getLOKitDocument()->renderFont(decodedFont.c_str(), decodedChar.c_str(), &width, &height);
 
-    const auto duration = std::chrono::system_clock::now() - start;
-    const auto elapsed = std::chrono::duration_cast<std::chrono::microseconds>(duration).count();
+    const auto duration = std::chrono::steady_clock::now() - start;
+    const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
     LOG_TRC("renderFont [" << font << "] rendered in " << elapsed << "ms");
 
     if (!ptrFont)
@@ -1641,25 +1641,25 @@ bool ChildSession::renderWindow(const char* /*buffer*/, int /*length*/, const St
             dpiScale = 1.0;
     }
 
-    size_t pixmapDataSize = 4 * bufferWidth * bufferHeight;
+    const size_t pixmapDataSize = 4 * bufferWidth * bufferHeight;
     std::vector<unsigned char> pixmap(pixmapDataSize);
-    int width = bufferWidth, height = bufferHeight;
-    std::string response;
-    const auto start = std::chrono::system_clock::now();
-    getLOKitDocument()->paintWindow(winId, pixmap.data(), startX, startY, width, height, dpiScale, _viewId);
+    const int width = bufferWidth;
+    const int height = bufferHeight;
+    const auto start = std::chrono::steady_clock::now();
+    getLOKitDocument()->paintWindow(winId, pixmap.data(), startX, startY, width, height, dpiScale,
+                                    _viewId);
     const double area = width * height;
 
-    const auto duration = std::chrono::system_clock::now() - start;
-    const auto elapsed = std::chrono::duration_cast<std::chrono::microseconds>(duration).count();
-    const double totalTime = elapsed/1000.;
-    LOG_TRC("paintWindow for " << winId << " returned " << width << "X" << height
-            << "@(" << startX << ',' << startY << ','
-            << " with dpi scale: " << dpiScale
-            << " and rendered in " << totalTime
-            << "ms (" << area / elapsed << " MP/s).");
+    const auto elapsedMics = std::chrono::duration_cast<std::chrono::microseconds>(
+                                 std::chrono::steady_clock::now() - start)
+                                 .count();
+    LOG_TRC("paintWindow for " << winId << " returned " << width << "X" << height << "@(" << startX
+                               << ',' << startY << ',' << " with dpi scale: " << dpiScale
+                               << " and rendered in " << elapsedMics / 1000. << "ms ("
+                               << area / elapsedMics << " MP/s).");
 
-    response = "windowpaint: id=" + tokens[1] +
-        " width=" + std::to_string(width) + " height=" + std::to_string(height);
+    std::string response = "windowpaint: id=" + tokens[1] + " width=" + std::to_string(width)
+                           + " height=" + std::to_string(height);
 
     if (!paintRectangle.empty())
         response += " rectangle=" + paintRectangle;

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1198,8 +1198,9 @@ private:
             _loKitDocumentForAndroidOnly = _loKitDocument;
 #endif
             const auto duration = std::chrono::steady_clock::now() - start;
-            const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
-            LOG_DBG("Returned lokit::documentLoad(" << FileUtil::anonymizeUrl(pURL) << ") in " << elapsed << "ms.");
+            const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(duration);
+            LOG_DBG("Returned lokit::documentLoad(" << FileUtil::anonymizeUrl(pURL) << ") in "
+                                                    << elapsed);
 #ifdef IOS
             getDocumentDataForMobileAppDocId(_mobileAppDocId).loKitDocument = _loKitDocument.get();
 #endif
@@ -2258,9 +2259,8 @@ void lokit_main(
             ::setenv("HOME", HomePathInJail, 1);
 
             const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
-                                std::chrono::steady_clock::now() - jailSetupStartTime)
-                                .count();
-            LOG_DBG("Initialized jail files in " << ms << " ms.");
+                std::chrono::steady_clock::now() - jailSetupStartTime);
+            LOG_DBG("Initialized jail files in " << ms);
 
             ProcSMapsFile = open("/proc/self/smaps", O_RDONLY);
             if (ProcSMapsFile < 0)
@@ -2607,9 +2607,9 @@ bool globalPreinit(const std::string &loTemplate)
         return false;
     }
 
-    LOG_TRC("Finished lok_preinit(" << loTemplate << "/program\", \"file:///tmp/user\") in " <<
-            std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start).count() <<
-            " ms.");
+    LOG_TRC("Finished lok_preinit(" << loTemplate << "/program\", \"file:///tmp/user\") in "
+                                    << std::chrono::duration_cast<std::chrono::milliseconds>(
+                                           std::chrono::steady_clock::now() - start));
     return true;
 }
 

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1192,15 +1192,14 @@ private:
 
             const char *pURL = docTemplate.empty() ? uri.c_str() : docTemplate.c_str();
             LOG_DBG("Calling lokit::documentLoad(" << FileUtil::anonymizeUrl(pURL) << ", \"" << options << "\").");
-            const auto start = std::chrono::system_clock::now();
+            const auto start = std::chrono::steady_clock::now();
             _loKitDocument.reset(_loKit->documentLoad(pURL, options.c_str()));
 #ifdef __ANDROID__
             _loKitDocumentForAndroidOnly = _loKitDocument;
 #endif
-            const auto duration = std::chrono::system_clock::now() - start;
-            const auto elapsed = std::chrono::duration_cast<std::chrono::microseconds>(duration).count();
-            const double totalTime = elapsed/1000.;
-            LOG_DBG("Returned lokit::documentLoad(" << FileUtil::anonymizeUrl(pURL) << ") in " << totalTime << "ms.");
+            const auto duration = std::chrono::steady_clock::now() - start;
+            const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
+            LOG_DBG("Returned lokit::documentLoad(" << FileUtil::anonymizeUrl(pURL) << ") in " << elapsed << "ms.");
 #ifdef IOS
             getDocumentDataForMobileAppDocId(_mobileAppDocId).loKitDocument = _loKitDocument.get();
 #endif

--- a/net/DelaySocket.cpp
+++ b/net/DelaySocket.cpp
@@ -65,10 +65,9 @@ public:
         auto now = std::chrono::steady_clock::now();
         for (auto &chunk : _chunks)
         {
-            os << "\t\tin: " <<
-                std::chrono::duration_cast<std::chrono::milliseconds>(
-                    chunk->getSendTime() - now).count() << "ms - "
-               << chunk->getData().size() << "bytes\n";
+            os << "\t\tin: "
+               << std::chrono::duration_cast<std::chrono::milliseconds>(chunk->getSendTime() - now)
+               << " - " << chunk->getData().size() << "bytes\n";
         }
     }
 

--- a/test/UnitPrefork.cpp
+++ b/test/UnitPrefork.cpp
@@ -15,7 +15,7 @@ const int NumToPrefork = 20;
 // Inside the WSD process
 class UnitPrefork : public UnitWSD
 {
-    std::chrono::system_clock::time_point _startTime = std::chrono::system_clock::now();
+    std::chrono::steady_clock::time_point _startTime = std::chrono::steady_clock::now();
     std::atomic< int > _childSockets;
 
 public:
@@ -38,9 +38,8 @@ public:
 
         if (_childSockets >= NumToPrefork)
         {
-            const auto duration = std::chrono::system_clock::now() - _startTime;
-            const auto elapsed = std::chrono::duration_cast<std::chrono::microseconds>(duration).count();
-            const double totalTime = elapsed/1000.;
+            const auto duration = std::chrono::steady_clock::now() - _startTime;
+            const auto totalTime = std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
 
             LOG_INF("Launched " << _childSockets << " in " << totalTime);
             std::cerr << "Launch time total   " << totalTime << " ms" << std::endl;

--- a/test/UnitPrefork.cpp
+++ b/test/UnitPrefork.cpp
@@ -39,11 +39,12 @@ public:
         if (_childSockets >= NumToPrefork)
         {
             const auto duration = std::chrono::steady_clock::now() - _startTime;
-            const auto totalTime = std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
+            const auto totalTime = std::chrono::duration_cast<std::chrono::milliseconds>(duration);
 
             LOG_INF("Launched " << _childSockets << " in " << totalTime);
-            std::cerr << "Launch time total   " << totalTime << " ms" << std::endl;
-            std::cerr << "Launch time average " << (totalTime / _childSockets) << " ms" << std::endl;
+            std::cerr << "Launch time total   " << totalTime << std::endl;
+            std::cerr << "Launch time average " << (totalTime.count() / _childSockets) << "ms"
+                      << std::endl;
 
             exitTest(TestResult::Ok);
         }

--- a/test/countloolkits.hpp
+++ b/test/countloolkits.hpp
@@ -103,9 +103,9 @@ static void testNoExtraLoolKitsLeft()
     LOK_ASSERT_EQUAL(InitialLoolKitCount, countNow);
 
     const auto duration = (std::chrono::steady_clock::now() - TestStartTime);
-    const std::chrono::milliseconds::rep durationMs = std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
+    const auto durationMs = std::chrono::duration_cast<std::chrono::milliseconds>(duration);
 
-    TST_LOG(" (" << durationMs << " ms)");
+    TST_LOG(" (" << durationMs << ')');
 }
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/Admin.cpp
+++ b/wsd/Admin.cpp
@@ -146,7 +146,7 @@ void AdminSocketHandler::handleMessage(const std::vector<char> &payload)
         sendTextFrame("recv_bytes " + std::to_string(model.getRecvBytesTotal() / 1024));
 
     else if (tokens.equals(0, "uptime"))
-        sendTextFrame("uptime " + std::to_string(model.getServerUptime()));
+        sendTextFrame("uptime " + std::to_string(model.getServerUptimeSecs()));
 
     else if (tokens.equals(0, "log_lines"))
         sendTextFrame("log_lines " + _admin->getLogLines());

--- a/wsd/AdminModel.cpp
+++ b/wsd/AdminModel.cpp
@@ -148,7 +148,7 @@ void Document::updateMemoryDirty()
 
 void Document::setLastJiffies(size_t newJ)
 {
-    auto now = std::chrono::system_clock::now();
+    const auto now = std::chrono::steady_clock::now();
     if (_lastJiffy)
         _lastCpuPercentage = (100 * 1000 * (newJ - _lastJiffy) / ::sysconf(_SC_CLK_TCK))
                             / std::chrono::duration_cast<std::chrono::milliseconds>(now - _lastJiffyTime).count();
@@ -812,11 +812,12 @@ void AdminModel::updateLastActivityTime(const std::string& docKey)
     }
 }
 
-double AdminModel::getServerUptime()
+double AdminModel::getServerUptimeSecs()
 {
-    auto currentTime = std::chrono::system_clock::now();
-    std::chrono::duration<double> uptime = currentTime - LOOLWSD::StartTime;
-    return uptime.count();
+    const auto currentTime = std::chrono::steady_clock::now();
+    const std::chrono::milliseconds uptime
+        = std::chrono::duration_cast<std::chrono::milliseconds>(currentTime - LOOLWSD::StartTime);
+    return uptime.count() / 1000.0; // Convert to seconds and fractions.
 }
 
 void AdminModel::setViewLoadDuration(const std::string& docKey, const std::string& sessionId, std::chrono::milliseconds viewLoadDuration)

--- a/wsd/AdminModel.hpp
+++ b/wsd/AdminModel.hpp
@@ -233,7 +233,7 @@ private:
     size_t _memoryDirty;
     /// Last noted Jiffy count
     unsigned _lastJiffy;
-    std::chrono::time_point<std::chrono::system_clock> _lastJiffyTime;
+    std::chrono::steady_clock::time_point _lastJiffyTime;
     unsigned _lastCpuPercentage;
 
     std::time_t _start;
@@ -362,7 +362,7 @@ public:
     uint64_t getSentBytesTotal() { return _sentBytesTotal; }
     uint64_t getRecvBytesTotal() { return _recvBytesTotal; }
 
-    double getServerUptime();
+    static double getServerUptimeSecs();
 
     /// Document basic info list sorted by most idle time
     std::vector<DocBasicInfo> getDocumentsSortedByIdle() const;

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1638,12 +1638,13 @@ void ClientSession::removeOutdatedTilesOnFly()
     while(!_tilesOnFly.empty() && continueLoop)
     {
         auto tileIter = _tilesOnFly.begin();
-        double elapsedTimeMs = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - tileIter->second).count();
-        if(elapsedTimeMs > TILE_ROUNDTRIP_TIMEOUT_MS)
+        const auto elapsedTimeMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - tileIter->second);
+        if (elapsedTimeMs > std::chrono::milliseconds(TILE_ROUNDTRIP_TIMEOUT_MS))
         {
             LOG_WRN("Tracker tileID " << tileIter->first << " was dropped because of time out ("
                                       << elapsedTimeMs
-                                      << " ms). Tileprocessed message did not arrive in time.");
+                                      << "). Tileprocessed message did not arrive in time.");
             _tilesOnFly.erase(tileIter);
         }
         else

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -163,7 +163,7 @@ DocumentBroker::DocumentBroker(ChildType type,
                                const Poco::URI& uriPublic,
                                const std::string& docKey,
                                unsigned mobileAppDocId) :
-    _limitLifeSeconds(0),
+    _limitLifeSeconds(std::chrono::seconds::zero()),
     _uriOrig(uri),
     _type(type),
     _uriPublic(uriPublic),
@@ -335,19 +335,22 @@ void DocumentBroker::pollThread()
             continue;
         }
 
-        if (_limitLifeSeconds > 0 &&
-            std::chrono::duration_cast<std::chrono::seconds>(now - _threadStart).count() > _limitLifeSeconds)
+        // Check if we had a sunset time and expired.
+        if (_limitLifeSeconds > std::chrono::seconds::zero()
+            && std::chrono::duration_cast<std::chrono::seconds>(now - _threadStart)
+                   > _limitLifeSeconds)
         {
             LOG_WRN("Doc [" << _docKey << "] is taking too long to convert. Will kill process ["
-                            << _childProcess->getPid() << "]. per_document.limit_convert_secs set to "
-                            << _limitLifeSeconds << " secs.");
+                            << _childProcess->getPid()
+                            << "]. per_document.limit_convert_secs set to "
+                            << _limitLifeSeconds.count() << " secs.");
             broadcastMessage("error: cmd=load kind=docexpired");
 
             // Brutal but effective.
             if (_childProcess)
                 _childProcess->terminate();
 
-            stop("Load timed out");
+            stop("Convert-to timed out");
             continue;
         }
 
@@ -2449,9 +2452,10 @@ ConvertToBroker::ConvertToBroker(const std::string& uri,
                                               << "], docKey: [" << docKey << "], format: ["
                                               << format << "], options: [" << sOptions << "].");
 
-    static const int limit_convert_secs = LOOLWSD::getConfigValue<int>("per_document.limit_convert_secs", 100);
-    NumConverters++;
+    static const std::chrono::seconds limit_convert_secs(
+        LOOLWSD::getConfigValue<int>("per_document.limit_convert_secs", 100));
     _limitLifeSeconds = limit_convert_secs;
+    ++NumConverters;
 }
 
 bool ConvertToBroker::startConversion(SocketDisposition &disposition, const std::string &id)
@@ -2586,8 +2590,8 @@ void DocumentBroker::dumpState(std::ostream& os)
     os << "\n  last storage save was successful: " << isLastStorageSaveSuccessful();
     os << "\n  last modified: " << Util::getHttpTime(_documentLastModifiedTime);
     os << "\n  file last modified: " << Util::getHttpTime(_lastFileModifiedTime);
-    if (_limitLifeSeconds)
-        os << "\n  life limit in seconds: " << _limitLifeSeconds;
+    if (_limitLifeSeconds > std::chrono::seconds::zero())
+        os << "\n  life limit in seconds: " << _limitLifeSeconds.count();
     os << "\n  idle time: " << getIdleTimeSecs();
     os << "\n  cursor " << _cursorPosX << ", " << _cursorPosY
       << "( " << _cursorWidth << ',' << _cursorHeight << ")\n";

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1249,7 +1249,7 @@ void DocumentBroker::setLoaded()
         _isLoaded = true;
         _loadDuration = std::chrono::duration_cast<std::chrono::milliseconds>(
                                 std::chrono::steady_clock::now() - _threadStart);
-        LOG_TRC("Document loaded in " << _loadDuration.count() << "ms");
+        LOG_TRC("Document loaded in " << _loadDuration);
     }
 }
 
@@ -1343,9 +1343,9 @@ bool DocumentBroker::autoSave(const bool force, const bool dontSaveIfUnmodified)
             = std::chrono::duration_cast<std::chrono::milliseconds>(now - _lastActivityTime);
         const std::chrono::milliseconds timeSinceLastSaveMs
             = std::chrono::duration_cast<std::chrono::milliseconds>(now - _lastSaveTime);
-        LOG_TRC("Time since last save of docKey ["
-                << _docKey << "] is " << timeSinceLastSaveMs.count()
-                << " ms and most recent activity was " << inactivityTimeMs.count() << " ms ago.");
+        LOG_TRC("Time since last save of docKey [" << _docKey << "] is " << timeSinceLastSaveMs
+                                                   << " and most recent activity was "
+                                                   << inactivityTimeMs << " ago.");
 
         bool save = false;
         // Zero or negative config value disables save.
@@ -2567,7 +2567,7 @@ void DocumentBroker::dumpState(std::ostream& os)
     else
         os << " has live sessions";
     if (_isLoaded)
-        os << "\n  loaded in: " << _loadDuration.count() << "ms";
+        os << "\n  loaded in: " << _loadDuration;
     else
         os << "\n  still loading... " <<
             std::chrono::duration_cast<std::chrono::seconds>(

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -234,11 +234,12 @@ void DocumentBroker::pollThread()
 #if !MOBILEAPP
     do
     {
-        static const int timeoutMs = COMMAND_TIMEOUT_MS * 5;
+        static constexpr std::chrono::milliseconds timeoutMs(COMMAND_TIMEOUT_MS * 5);
         _childProcess = getNewChild_Blocks();
-        if (_childProcess ||
-            std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() -
-                                                                  _threadStart).count() > timeoutMs)
+        if (_childProcess
+            || std::chrono::duration_cast<std::chrono::milliseconds>(
+                   std::chrono::steady_clock::now() - _threadStart)
+                   > timeoutMs)
             break;
 
         // Nominal time between retries, lest we busy-loop. getNewChild could also wait, so don't double that here.
@@ -1327,25 +1328,38 @@ bool DocumentBroker::autoSave(const bool force, const bool dontSaveIfUnmodified)
     }
     else if (isModified())
     {
-        const std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
-        const std::chrono::milliseconds::rep inactivityTimeMs = std::chrono::duration_cast<std::chrono::milliseconds>(now - _lastActivityTime).count();
-        const std::chrono::milliseconds::rep timeSinceLastSaveMs = std::chrono::duration_cast<std::chrono::milliseconds>(now - _lastSaveTime).count();
-        LOG_TRC("Time since last save of docKey [" << _docKey << "] is " << timeSinceLastSaveMs <<
-                "ms and most recent activity was " << inactivityTimeMs << "ms ago.");
+        // The configured maximum idle duration before saving. Zero to disable.
+        static const std::chrono::milliseconds MaxIdleSaveDurationMs = std::chrono::seconds(
+            LOOLWSD::getConfigValue<int>("per_document.idlesave_duration_secs", 30));
 
-        static const int idleSaveDurationMs = LOOLWSD::getConfigValue<int>("per_document.idlesave_duration_secs", 30) * 1000;
-        static const int autoSaveDurationMs = LOOLWSD::getConfigValue<int>("per_document.autosave_duration_secs", 300) * 1000;
+        // The configured maximum duration before saving. Zero to disable.
+        static const std::chrono::milliseconds MaxAutoSaveDurationMs = std::chrono::seconds(
+            LOOLWSD::getConfigValue<int>("per_document.autosave_duration_secs", 300));
+
+        const std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
+        const std::chrono::milliseconds inactivityTimeMs
+            = std::chrono::duration_cast<std::chrono::milliseconds>(now - _lastActivityTime);
+        const std::chrono::milliseconds timeSinceLastSaveMs
+            = std::chrono::duration_cast<std::chrono::milliseconds>(now - _lastSaveTime);
+        LOG_TRC("Time since last save of docKey ["
+                << _docKey << "] is " << timeSinceLastSaveMs.count()
+                << " ms and most recent activity was " << inactivityTimeMs.count() << " ms ago.");
+
         bool save = false;
         // Zero or negative config value disables save.
         // Either we've been idle long enough, or it's auto-save time.
-        if (idleSaveDurationMs > 0 && inactivityTimeMs >= idleSaveDurationMs)
+        if (MaxIdleSaveDurationMs > std::chrono::milliseconds::zero()
+            && inactivityTimeMs >= MaxIdleSaveDurationMs)
         {
             save = true;
         }
-        if (autoSaveDurationMs > 0 && timeSinceLastSaveMs >= autoSaveDurationMs)
+
+        if (MaxAutoSaveDurationMs > std::chrono::milliseconds::zero()
+            && timeSinceLastSaveMs >= MaxAutoSaveDurationMs)
         {
             save = true;
         }
+
         if (save)
         {
             LOG_TRC("Sending timed save command for [" << _docKey << "].");

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -623,7 +623,7 @@ bool DocumentBroker::load(const std::shared_ptr<ClientSession>& session, const s
     std::string templateSource;
 
 #if !MOBILEAPP
-    std::chrono::duration<double> getInfoCallDuration(0);
+    std::chrono::milliseconds checkFileInfoCallDurationMs;
     WopiStorage* wopiStorage = dynamic_cast<WopiStorage*>(_storage.get());
     if (wopiStorage != nullptr)
     {
@@ -712,7 +712,7 @@ bool DocumentBroker::load(const std::shared_ptr<ClientSession>& session, const s
             session->setDocumentOwner(true);
         }
 
-        getInfoCallDuration = wopifileinfo->getCallDuration();
+        checkFileInfoCallDurationMs = wopifileinfo->getCallDurationMs();
 
         // Pass the ownership to client session
         session->setWopiFileInfo(wopifileinfo);
@@ -917,11 +917,10 @@ bool DocumentBroker::load(const std::shared_ptr<ClientSession>& session, const s
     if (wopiStorage != nullptr)
     {
         // Get the time taken to load the file from storage
-        auto callDuration = wopiStorage->getWopiLoadDuration();
         // Add the time taken to check file info
-        callDuration += getInfoCallDuration;
-        _wopiLoadDuration = std::chrono::duration_cast<std::chrono::milliseconds>(callDuration);
-        const std::string msg = "stats: wopiloadduration " + std::to_string(callDuration.count());
+        _wopiLoadDuration = wopiStorage->getWopiLoadDuration() + checkFileInfoCallDurationMs;
+        const std::string msg
+            = "stats: wopiloadduration " + std::to_string(_wopiLoadDuration.count() / 1000.); // In seconds.
         LOG_TRC("Sending to Client [" << msg << "].");
         session->sendTextFrame(msg);
     }

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -410,7 +410,7 @@ private:
 
 protected:
     /// Seconds to live for, or 0 forever
-    int64_t _limitLifeSeconds;
+    std::chrono::seconds _limitLifeSeconds;
     std::string _uriOrig;
     /// What type are we: affects priority.
     ChildType _type;

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -757,7 +757,7 @@ unsigned LOOLWSD::MaxConnections;
 unsigned LOOLWSD::MaxDocuments;
 std::string LOOLWSD::OverrideWatermark;
 std::set<const Poco::Util::AbstractConfiguration*> LOOLWSD::PluginConfigurations;
-std::chrono::time_point<std::chrono::system_clock> LOOLWSD::StartTime;
+std::chrono::steady_clock::time_point LOOLWSD::StartTime;
 
 // If you add global state please update dumpState below too
 
@@ -890,7 +890,7 @@ void LOOLWSD::initialize(Application& self)
         throw std::runtime_error("Failed to load wsd unit test library.");
     }
 
-    StartTime = std::chrono::system_clock::now();
+    StartTime = std::chrono::steady_clock::now();
 
     auto& conf = config();
 

--- a/wsd/LOOLWSD.hpp
+++ b/wsd/LOOLWSD.hpp
@@ -261,7 +261,7 @@ public:
     static unsigned MaxDocuments;
     static std::string OverrideWatermark;
     static std::set<const Poco::Util::AbstractConfiguration*> PluginConfigurations;
-    static std::chrono::time_point<std::chrono::system_clock> StartTime;
+    static std::chrono::steady_clock::time_point StartTime;
 #if MOBILEAPP
 #ifndef IOS
     /// This is used to be able to wait until the lokit main thread has finished (and it is safe to load a new document).

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -662,9 +662,9 @@ std::unique_ptr<WopiStorage::WOPIFileInfo> WopiStorage::getWOPIFileInfo(const Au
     if (JsonUtil::parseJSON(wopiResponse, object))
     {
         if (LOOLWSD::AnonymizeUserData)
-            LOG_DBG("WOPI::CheckFileInfo (" << callDurationMs.count() << " ms): anonymizing...");
+            LOG_DBG("WOPI::CheckFileInfo (" << callDurationMs << "): anonymizing...");
         else
-            LOG_DBG("WOPI::CheckFileInfo (" << callDurationMs.count() << " ms): " << wopiResponse);
+            LOG_DBG("WOPI::CheckFileInfo (" << callDurationMs << "): " << wopiResponse);
 
         std::size_t size = 0;
         std::string filename, ownerId, lastModifiedTime;
@@ -693,9 +693,8 @@ std::unique_ptr<WopiStorage::WOPIFileInfo> WopiStorage::getWOPIFileInfo(const Au
             wopiResponse = "obfuscated";
 
         LOG_ERR("WOPI::CheckFileInfo ("
-                << callDurationMs.count()
-                << " ms) failed or no valid JSON payload returned. Access denied. "
-                   "Original response: ["
+                << callDurationMs
+                << ") failed or no valid JSON payload returned. Access denied. Original response: ["
                 << wopiResponse << "].");
 
         throw UnauthorizedRequestException("Access denied. WOPI::CheckFileInfo failed on: " + uriAnonym);
@@ -772,7 +771,7 @@ WopiStorage::WOPIFileInfo::WOPIFileInfo(const FileInfo &fileInfo,
     else
         object->stringify(wopiResponse);
 
-    LOG_DBG("WOPI::CheckFileInfo (" << callDurationMs.count() << " ms): " << wopiResponse.str());
+    LOG_DBG("WOPI::CheckFileInfo (" << callDurationMs << "): " << wopiResponse.str());
 
     JsonUtil::findJSONValue(object, "UserExtraInfo", _userExtraInfo);
     JsonUtil::findJSONValue(object, "WatermarkText", _watermarkText);

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -374,8 +374,6 @@ public:
                 const std::string& localStorePath,
                 const std::string& jailPath) :
         StorageBase(uri, localStorePath, jailPath),
-        _wopiLoadDuration(0),
-        _wopiSaveDuration(0),
         _reuseCookies(false)
     {
         const auto& app = Poco::Util::Application::instance();
@@ -398,8 +396,8 @@ public:
         };
 
         /// warning - removes items from object.
-        WOPIFileInfo(const FileInfo &fileInfo, std::chrono::duration<double> callDuration,
-                     Poco::JSON::Object::Ptr &object);
+        WOPIFileInfo(const FileInfo& fileInfo, std::chrono::milliseconds callDurationMs,
+                     Poco::JSON::Object::Ptr& object);
 
         const std::string& getUserId() const { return _userId; }
         const std::string& getUsername() const { return _username; }
@@ -432,7 +430,7 @@ public:
         TriState getDisableChangeTrackingShow() const { return _disableChangeTrackingShow; }
         TriState getDisableChangeTrackingRecord() const { return _disableChangeTrackingRecord; }
         TriState getHideChangeTrackingControls() const { return _hideChangeTrackingControls; }
-        std::chrono::duration<double> getCallDuration() const { return _callDuration; }
+        std::chrono::milliseconds getCallDurationMs() const { return _callDurationMs; }
     private:
         /// User id of the user accessing the file
         std::string _userId;
@@ -496,7 +494,7 @@ public:
         bool _userCanRename;
 
         /// Time it took to call WOPI's CheckFileInfo
-        std::chrono::duration<double> _callDuration;
+        std::chrono::milliseconds _callDurationMs;
     };
 
     /// Returns the response of CheckFileInfo WOPI call for URI that was
@@ -522,8 +520,8 @@ public:
                                           const bool isRename) override;
 
     /// Total time taken for making WOPI calls during load
-    std::chrono::duration<double> getWopiLoadDuration() const { return _wopiLoadDuration; }
-    std::chrono::duration<double> getWopiSaveDuration() const { return _wopiSaveDuration; }
+    std::chrono::milliseconds getWopiLoadDuration() const { return _wopiLoadDuration; }
+    std::chrono::milliseconds getWopiSaveDuration() const { return _wopiSaveDuration; }
 
 protected:
     struct WopiUploadDetails
@@ -549,8 +547,8 @@ private:
 
 private:
     // Time spend in loading the file from storage
-    std::chrono::duration<double> _wopiLoadDuration;
-    std::chrono::duration<double> _wopiSaveDuration;
+    std::chrono::milliseconds _wopiLoadDuration;
+    std::chrono::milliseconds _wopiSaveDuration;
     /// Whether or not to re-use cookies from the browser for the WOPI requests.
     bool _reuseCookies;
 };

--- a/wsd/TileCache.hpp
+++ b/wsd/TileCache.hpp
@@ -123,7 +123,6 @@ public:
     static std::pair<int, Util::Rectangle> parseInvalidateMsg(const std::string& tiles);
 
     void forgetTileBeingRendered(const std::shared_ptr<TileCache::TileBeingRendered>& tileBeingRendered);
-    double getTileBeingRenderedElapsedTimeMs(const TileDesc &tileDesc) const;
 
     size_t countTilesBeingRenderedForSession(const std::shared_ptr<ClientSession>& session,
                                              const std::chrono::steady_clock::time_point& now);


### PR DESCRIPTION
### Summary

This is an attempt at avoiding mixing int/double with implicit units of time in favor of std::chrono, which does all that and more in a type safe and efficient fashion.

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

