### PR TITLE
jsdialog: fix the type dialog

### DIFF
--- a/loleaflet/src/control/Control.JSDialog.js
+++ b/loleaflet/src/control/Control.JSDialog.js
@@ -18,9 +18,10 @@ L.Control.JSDialog = L.Control.extend({
 		this.map.off('jsdialog', this.onJSDialog, this);
 	},
 
-	onJSDialog: function(data) {
+	onJSDialog: function(e) {
 		var posX = 0;
 		var posY = 0;
+		var data = e.data;
 
 		if (this.dialogs[data.id]) {
 			posX = this.dialogs[data.id].startX;

--- a/loleaflet/src/layer/tile/TileLayer.js
+++ b/loleaflet/src/layer/tile/TileLayer.js
@@ -1063,7 +1063,7 @@ L.TileLayer = L.GridLayer.extend({
 			if (msgData.jsontype === 'autofilter') {
 				this._map.fire('autofilterdropdown', msgData);
 			} else if (msgData.jsontype === 'dialog') {
-				this._map.fire('jsdialog', msgData);
+				this._map.fire('jsdialog', {data: msgData});
 			} else if (msgData.jsontype === 'notebookbar' || msgData.type === 'borderwindow') {
 				window.notebookbarId = msgData.id;
 				for (var i = 0; i < msgData.children.length; i++) {


### PR DESCRIPTION
Unfortunately when firifing the event "jsdialog"

this._map.fire('jsdialog', msgData);

the data type is replaced with the event type

Change-Id: Ib7ceb96c5fad82dc2d9db61d8399d7fa858c7044
Signed-off-by: Henry Castro <hcastro@collabora.com>
