### PR TITLE
jsdialog: warn children data type check

### DIFF
--- a/loleaflet/src/layer/tile/TileLayer.js
+++ b/loleaflet/src/layer/tile/TileLayer.js
@@ -1043,14 +1043,14 @@ L.TileLayer = L.GridLayer.extend({
 	},
 
 	_onJSDialogMsg: function (textMsg) {
+		var msgData = JSON.parse(textMsg.substring('jsdialog:'.length + 1));
+
+		if (msgData.children && !L.Util.isArray(msgData.children)) {
+			console.warn('_onJSDialogMsg: The children\'s data should be created of array type');
+			return;
+		}
+
 		if (window.mode.isMobile()) {
-			var msgData = JSON.parse(textMsg.substring('jsdialog:'.length + 1));
-
-			if (msgData.children && !L.Util.isArray(msgData.children)) {
-				console.warn('_onJSDialogMsg: The children\'s data should be created of array type');
-				return;
-			}
-
 			if (msgData.type == 'borderwindow')
 				return;
 			if (msgData.enabled) {
@@ -1058,19 +1058,16 @@ L.TileLayer = L.GridLayer.extend({
 			} else {
 				this._closeMobileWizard();
 			}
-		} else {
-			msgData = JSON.parse(textMsg.substring('jsdialog:'.length + 1));
-			if (msgData.jsontype === 'autofilter') {
-				this._map.fire('autofilterdropdown', msgData);
-			} else if (msgData.jsontype === 'dialog') {
-				this._map.fire('jsdialog', {data: msgData});
-			} else if (msgData.jsontype === 'notebookbar' || msgData.type === 'borderwindow') {
-				window.notebookbarId = msgData.id;
-				for (var i = 0; i < msgData.children.length; i++) {
-					if (msgData.children[i].type === 'control') {
-						this._map.fire('notebookbar', msgData.children[i]);
-						return;
-					}
+		} else if (msgData.jsontype === 'autofilter') {
+			this._map.fire('autofilterdropdown', msgData);
+		} else if (msgData.jsontype === 'dialog') {
+			this._map.fire('jsdialog', {data: msgData});
+		} else if (msgData.jsontype === 'notebookbar' || msgData.type === 'borderwindow') {
+			window.notebookbarId = msgData.id;
+			for (var i = 0; i < msgData.children.length; i++) {
+				if (msgData.children[i].type === 'control') {
+					this._map.fire('notebookbar', msgData.children[i]);
+					return;
 				}
 			}
 		}


### PR DESCRIPTION
Occurs when using the latest LO master branch
the mobile wizard fails:

    Util.js:107 Uncaught RangeError: Maximum call stack size exceeded
        at String.split (<anonymous>)
        at Object.splitWords (Util.js:107)
        at NewClass.on (Events.js:20)
        at Function.listenNumericChanges (Control.JSDialogBuilder.js:124)
        at _formattedfieldControl (Control.JSDialogBuilder.js:1312)
        at NewClass.build (Control.MobileWizardBuilder.js:145)
        at NewClass.build (Control.MobileWizardBuilder.js:150)
        at NewClass.build (Control.MobileWizardBuilder.js:150)
        at NewClass.build (Control.MobileWizardBuilder.js:150)
        at NewClass.build (Control.MobileWizardBuilder.js:150)

Change-Id: I743ce22f62a1436d7814d6a414f6b703cd3df997
Signed-off-by: Henry Castro <hcastro@collabora.com>
