### PR TITLE
private/pedro/jsdialog pivottable fixes

### DIFF
--- a/loleaflet/css/jsdialogs.css
+++ b/loleaflet/css/jsdialogs.css
@@ -10,6 +10,10 @@
 	font-family: var(--jquery-ui-font);
 }
 
+.jsdialog.vertical p {
+	margin-bottom: 2px;
+}
+
 .jsdialog.row {
 	display: table-row;
 }
@@ -22,6 +26,12 @@
 
 .jsdialog.vertical {
 	width: max-content;
+}
+
+.jsdialog.vertical:not([id^='table-dialog-action_area']) > .jsdialog.row,
+td.jsdialog > [id^='table-box'] {
+	display: table;
+	width: 100%;
 }
 
 /* Expander */

--- a/loleaflet/css/jsdialogs.css
+++ b/loleaflet/css/jsdialogs.css
@@ -168,6 +168,12 @@ td.jsdialog > [id^='table-box'] {
 	border: 2px dashed darkslateblue;
 }
 
+/* input text */
+
+.jsdialog.ui-edit {
+	line-height: 18px;
+}
+
 /* checkbox */
 
 .jsdialog.checkbutton {
@@ -276,11 +282,10 @@ td.jsdialog > [id^='table-box'] {
 .jsdialog-container #refbutton,
 .jsdialog-container #assign {
 	background: url('images/refinp1.svg') no-repeat center;
-	height: 25px;
-	width: 25px;
+	height: 24px;
+	width: 24px;
 	border: 1px solid silver;
 	vertical-align: middle;
-	padding: 15px;
 }
 
 .jsdialog-container.collapsed #source-button,

--- a/loleaflet/css/jsdialogs.css
+++ b/loleaflet/css/jsdialogs.css
@@ -37,11 +37,22 @@ td.jsdialog > [id^='table-box'] {
 /* Expander */
 .ui-expander-label::before {
 	content: '>';
-	margin-right: 10px;
+	color: transparent;
+	margin-right: 5px;
+	background: transparent url('images/lc_menu_chevron.svg') no-repeat center right;
 }
 
 .ui-expander-label.expanded::before {
 	content: 'V';
+	margin: 0px;
+	position: absolute;
+	transform: rotate(90deg);
+	left: 4px;
+	background: transparent url('images/lc_menu_chevron.svg') no-repeat center;
+}
+
+.ui-expander-label.expanded {
+	padding-left: 14px; /*adding extra padding to account for image absolute position*/
 }
 
 .ui-expander:hover {

--- a/loleaflet/css/jsdialogs.css
+++ b/loleaflet/css/jsdialogs.css
@@ -1,4 +1,7 @@
 /* JSDialog */
+.jsdialog.root-container {
+	margin: .5em 1em; /*same as in .ui-dialog */
+}
 
 .jsdialog-container {
 	position: absolute;
@@ -11,7 +14,16 @@
 }
 
 .jsdialog.vertical p {
-	margin-bottom: 2px;
+	margin-bottom: 0px;
+	color: #666;
+	font-size: 10px;
+	font-weight: bold;
+	text-transform: uppercase;
+}
+
+td.jsdialog:hover *,
+#table-box3:hover p {
+	color: #333;
 }
 
 .jsdialog.row {
@@ -21,7 +33,11 @@
 .jsdialog.cell {
 	display: table-cell;
 	vertical-align: middle;
-	padding: 2px;
+}
+
+td.jsdialog .jsdialog.cell,
+[id^='table-dialog-action_area'] .jsdialog.cell{
+	padding: 4px;
 }
 
 .jsdialog.vertical {
@@ -35,6 +51,10 @@ td.jsdialog > [id^='table-box'] {
 }
 
 /* Expander */
+
+.jsdialog.ui-expander {
+	box-shadow: 0 1px 0px 0 #f1f1f1;
+}
 .ui-expander-label::before {
 	content: '>';
 	color: transparent;
@@ -47,7 +67,7 @@ td.jsdialog > [id^='table-box'] {
 	margin: 0px;
 	position: absolute;
 	transform: rotate(90deg);
-	left: 4px;
+	left: 16px;
 	background: transparent url('images/lc_menu_chevron.svg') no-repeat center;
 }
 
@@ -59,6 +79,9 @@ td.jsdialog > [id^='table-box'] {
 	cursor: pointer;
 }
 
+.ui-expander-content > .root-container.jsdialog {
+	margin: 4px;
+}
 /* TreeView */
 
 .ui-treeview {
@@ -154,6 +177,10 @@ td.jsdialog > [id^='table-box'] {
 .jsdialog.checkbutton input,
 .jsdialog.checkbutton label {
 	vertical-align: middle;
+}
+
+.jsdialog.checkbutton label {
+	padding: 0px 2px;
 }
 
 /* listbox */


### PR DESCRIPTION
- JSDialog: Fix pseudo table-rows dimension (actually they should be tables)
- JSDialog: Improve expanders
- JSDialog: Fix root-container margins, Make labels react on hover, checkbtn
- JSDialog: Fix input text line height and repective btn sizes and paddings
