### PR TITLE
jsdialog: increase minimum width and height

### DIFF
--- a/loleaflet/css/jsdialogs.css
+++ b/loleaflet/css/jsdialogs.css
@@ -46,8 +46,8 @@
 
 .ui-treeview-body {
 	display: block;
-	min-height: 50px;
-	min-width: 50px;
+	min-height: 100px;
+	min-width: 100px;
 	max-height: 150px;
 	overflow-y: auto;
 	overflow-x: hidden;


### PR DESCRIPTION
When Macro Dialog Selector dialog is shown,
the empty list box is too small.

Change-Id: Ic07d2e027c250744f0e830d648a5d0865a3375ee
Signed-off-by: Henry Castro <hcastro@collabora.com>
