### PR TITLE
canvas layer: Kill the _animateZoom() methods.

### DIFF
--- a/loleaflet/src/layer/ImageOverlay.js
+++ b/loleaflet/src/layer/ImageOverlay.js
@@ -91,10 +91,6 @@ L.ImageOverlay = L.Layer.extend({
 			viewreset: this._reset
 		};
 
-		if (this._zoomAnimated) {
-			events.zoomanim = this._animateZoom;
-		}
-
 		return events;
 	},
 
@@ -103,8 +99,7 @@ L.ImageOverlay = L.Layer.extend({
 	},
 
 	_initImage: function () {
-		var img = this._image = L.DomUtil.create('img',
-			'leaflet-image-layer ' + (this._zoomAnimated ? 'leaflet-zoom-animated' : ''));
+		var img = this._image = L.DomUtil.create('img', 'leaflet-image-layer');
 
 		img.onselectstart = L.Util.falseFn;
 		img.onmousemove = L.Util.falseFn;
@@ -112,16 +107,6 @@ L.ImageOverlay = L.Layer.extend({
 		img.onload = L.bind(this.fire, this, 'load');
 		img.src = this._url;
 		img.alt = this.options.alt;
-	},
-
-	_animateZoom: function (e) {
-		var bounds = new L.Bounds(
-			this._map._latLngToNewLayerPoint(this._bounds.getNorthWest(), e.zoom, e.center),
-		    this._map._latLngToNewLayerPoint(this._bounds.getSouthEast(), e.zoom, e.center));
-
-		var offset = bounds.min.add(bounds.getSize()._multiplyBy((1 - 1 / e.scale) / 2));
-
-		L.DomUtil.setTransform(this._image, offset, e.scale);
 	},
 
 	_reset: function () {

--- a/loleaflet/src/layer/Popup.js
+++ b/loleaflet/src/layer/Popup.js
@@ -26,7 +26,6 @@ L.Popup = L.Layer.extend({
 		autoClose: true,
 		// keepInView: false,
 		// className: '',
-		zoomAnimation: true
 	},
 
 	initialize: function (options, source) {
@@ -36,8 +35,6 @@ L.Popup = L.Layer.extend({
 	},
 
 	onAdd: function (map) {
-		this._zoomAnimated = this._zoomAnimated && this.options.zoomAnimation;
-
 		if (!this._container) {
 			this._initLayout();
 		}
@@ -122,9 +119,6 @@ L.Popup = L.Layer.extend({
 		var events = {viewreset: this._updatePosition},
 		    options = this.options;
 
-		if (this._zoomAnimated) {
-			events.zoomanim = this._animateZoom;
-		}
 		if ('closeOnClick' in options ? options.closeOnClick : this._map.options.closePopupOnClick) {
 			events.preclick = this._close;
 		}
@@ -148,7 +142,7 @@ L.Popup = L.Layer.extend({
 		var prefix = 'leaflet-popup',
 		    container = this._container = L.DomUtil.create('div',
 			prefix + ' ' + (this.options.className || '') +
-			' leaflet-zoom-' + (this._zoomAnimated ? 'animated' : 'hide'));
+			' leaflet-zoom-hide');
 
 		if (this.options.closeButton) {
 			var closeButton = this._closeButton = L.DomUtil.create('a', prefix + '-close-button', container);
@@ -231,11 +225,7 @@ L.Popup = L.Layer.extend({
 		var pos = this._map.latLngToLayerPoint(this._latlng),
 		    offset = L.point(this.options.offset);
 
-		if (this._zoomAnimated) {
-			L.DomUtil.setPosition(this._container, pos);
-		} else {
-			offset = offset.add(pos);
-		}
+		offset = offset.add(pos);
 
 		var bottom = this._containerBottom = -offset.y,
 		    left = this._containerLeft = -Math.round(this._containerWidth / 2) + offset.x;
@@ -245,11 +235,6 @@ L.Popup = L.Layer.extend({
 		this._container.style.left = left + 'px';
 	},
 
-	_animateZoom: function (e) {
-		var pos = this._map._latLngToNewLayerPoint(this._latlng, e.zoom, e.center);
-		L.DomUtil.setPosition(this._container, pos);
-	},
-
 	_adjustPan: function () {
 		if (!this.options.autoPan) { return; }
 
@@ -257,10 +242,6 @@ L.Popup = L.Layer.extend({
 		    containerHeight = this._container.offsetHeight,
 		    containerWidth = this._containerWidth,
 		    layerPos = new L.Point(this._containerLeft, -containerHeight - this._containerBottom);
-
-		if (this._zoomAnimated) {
-			layerPos._add(L.DomUtil.getPosition(this._container));
-		}
 
 		var containerPos = map.layerPointToContainerPoint(layerPos),
 		    padding = L.point(this.options.autoPanPadding),

--- a/loleaflet/src/layer/marker/Cursor.js
+++ b/loleaflet/src/layer/marker/Cursor.js
@@ -8,8 +8,7 @@ L.Cursor = L.Layer.extend({
 
 	options: {
 		opacity: 1,
-		zIndex: 1000,
-		zoomAnimation: true
+		zIndex: 1000
 	},
 
 	initialize: function (latlng, size, options) {
@@ -29,10 +28,6 @@ L.Cursor = L.Layer.extend({
 			} else {
 				$('.leaflet-pane.leaflet-map-pane').css('cursor', 'text');
 			}
-		}
-		this._zoomAnimated = this._zoomAnimated && this.options.zoomAnimation;
-		if (this._zoomAnimated) {
-			L.DomUtil.addClass(this._container, 'leaflet-zoom-animated');
 		}
 
 		this.update();
@@ -54,10 +49,6 @@ L.Cursor = L.Layer.extend({
 
 	getEvents: function () {
 		var events = {viewreset: this.update};
-
-		if (this._zoomAnimated) {
-			events.zoomanim = this._animateZoom;
-		}
 
 		return events;
 	},
@@ -142,11 +133,6 @@ L.Cursor = L.Layer.extend({
 	_setSize: function () {
 		this._cursor.style.height = this._size.y + 'px';
 		this._container.style.top = '-' + (this._container.clientHeight - this._size.y - 2) / 2 + 'px';
-	},
-
-	_animateZoom: function (opt) {
-		var pos = this._map._latLngToNewLayerPoint(this._latlng, opt.zoom, opt.center).round();
-		L.DomUtil.setPosition(this._container, pos);
 	}
 });
 

--- a/loleaflet/src/layer/marker/Marker.js
+++ b/loleaflet/src/layer/marker/Marker.js
@@ -38,9 +38,7 @@ L.Marker = L.Layer.extend({
 		}
 	},
 
-	onAdd: function (map) {
-		this._zoomAnimated = this._zoomAnimated && map.options.markerZoomAnimation;
-
+	onAdd: function () {
 		this._initIcon();
 		this.update();
 	},
@@ -62,10 +60,6 @@ L.Marker = L.Layer.extend({
 			events.moveend = this.update;
 			events.drag = this.update;
 			events.splitposchanged = this.update;
-		}
-
-		if (this._zoomAnimated && !splitPanesPossible) {
-			events.zoomanim = this._animateZoom;
 		}
 
 		return events;
@@ -183,7 +177,7 @@ L.Marker = L.Layer.extend({
 
 	_initIcon: function () {
 		var options = this.options,
-		    classToAdd = 'leaflet-zoom-' + (this._zoomAnimated ? 'animated' : 'hide');
+		    classToAdd = 'leaflet-zoom-hide';
 
 		var icon = options.icon.createIcon(this._icon),
 		    addIcon = false;
@@ -281,12 +275,6 @@ L.Marker = L.Layer.extend({
 
 	_updateZIndex: function (offset) {
 		this._icon.style.zIndex = this._zIndex + offset;
-	},
-
-	_animateZoom: function (opt) {
-		var pos = this._map._latLngToNewLayerPoint(this._latlng, opt.zoom, opt.center).round();
-
-		this._setPos(pos);
 	},
 
 	_initInteraction: function () {

--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -545,10 +545,6 @@ L.CanvasTileLayer = L.TileLayer.extend({
 			splitposchanged: this._move,
 		};
 
-		if (this._zoomAnimated) {
-			events.zoomanim = this._animateZoom;
-		}
-
 		return events;
 	},
 
@@ -598,9 +594,6 @@ L.CanvasTileLayer = L.TileLayer.extend({
 				this._removeTile(key);
 			}
 		}
-	},
-
-	_animateZoom: function () {
 	},
 
 	_setZoomTransforms: function () {

--- a/loleaflet/src/layer/tile/GridLayer.js
+++ b/loleaflet/src/layer/tile/GridLayer.js
@@ -121,10 +121,6 @@ L.GridLayer = L.Layer.extend({
 			events.move = L.Util.throttle(this._move, this.options.updateInterval, this);
 		}
 
-		if (this._zoomAnimated) {
-			events.zoomanim = this._animateZoom;
-		}
-
 		return events;
 	},
 
@@ -319,10 +315,6 @@ L.GridLayer = L.Layer.extend({
 		if (this._docType === 'spreadsheet' && this._annotations !== 'undefined') {
 			this._map._socket.sendMessage('commandvalues command=.uno:ViewAnnotationsPosition');
 		}
-	},
-
-	_animateZoom: function (e) {
-		this._reset(e.center, e.zoom, false, true, e.noUpdate);
 	},
 
 	_reset: function (center, zoom, hard, noPrune, noUpdate) {

--- a/loleaflet/src/layer/tile/TileLayer.js
+++ b/loleaflet/src/layer/tile/TileLayer.js
@@ -504,10 +504,6 @@ L.TileLayer = L.GridLayer.extend({
 			events.move = L.Util.throttle(this._move, this.options.updateInterval, this);
 		}
 
-		if (this._zoomAnimated) {
-			events.zoomanim = this._animateZoom;
-		}
-
 		return events;
 	},
 

--- a/loleaflet/src/layer/vector/Renderer.js
+++ b/loleaflet/src/layer/vector/Renderer.js
@@ -25,10 +25,6 @@ L.Renderer = L.Layer.extend({
 	onAdd: function () {
 		if (!this._container) {
 			this._initContainer(); // defined by renderer implementations
-
-			if (this._zoomAnimated && this.rendererId !== 'fixed') {
-				L.DomUtil.addClass(this._container, 'leaflet-zoom-animated');
-			}
 		}
 
 		if (this._parentRenderer) {
@@ -49,17 +45,7 @@ L.Renderer = L.Layer.extend({
 		var events = {
 			moveend: this._update
 		};
-		if (this._zoomAnimated && this.rendererId !== 'fixed') {
-			events.zoomanim = this._animateZoom;
-		}
 		return events;
-	},
-
-	_animateZoom: function (e) {
-		var origin = e.origin.subtract(this._map._getCenterLayerPoint()),
-		    offset = this._bounds.min.add(origin.multiplyBy(1 - e.scale)).add(e.offset).round();
-
-		L.DomUtil.setTransform(this._container, offset, e.scale);
 	},
 
 	_update: function () {

--- a/loleaflet/src/layer/vector/SplitPanesRenderer.js
+++ b/loleaflet/src/layer/vector/SplitPanesRenderer.js
@@ -41,9 +41,6 @@ L.SplitPanesRenderer = L.Layer.extend({
 		return {};
 	},
 
-	_animateZoom: function () {
-	},
-
 	_update: function () {
 	},
 

--- a/loleaflet/src/map/handler/Map.TouchGesture.js
+++ b/loleaflet/src/map/handler/Map.TouchGesture.js
@@ -568,20 +568,11 @@ L.Map.TouchGesture = L.Handler.extend({
 		this._zoom = this._map._limitZoom(this._map.getScaleZoom(e.scale));
 		this._center = this._map._limitCenter(this._map.mouseEventToLatLng({clientX: center.x, clientY: center.y}),
 						      this._zoom, this._map.options.maxBounds);
-
-		L.Util.cancelAnimFrame(this._animRequest);
-		this._animRequest = L.Util.requestAnimFrame(function () {
-			this._map._animateZoom(this._center, this._zoom, false, true);
-		}, this, true, this._map._container);
 	},
 
 	_onPinchEnd: function () {
 		if (!this._pinchStartCenter)
 			return;
-
-		var oldZoom = this._map.getZoom(),
-		    zoomDelta = this._zoom - oldZoom,
-		    finalZoom = this._map._limitZoom(zoomDelta > 0 ? Math.ceil(this._zoom) : Math.floor(this._zoom));
 
 		if (this._map._docLayer.isCursorVisible()) {
 			this._map._docLayer._cursorMarker.setOpacity(1);
@@ -594,11 +585,6 @@ L.Map.TouchGesture = L.Handler.extend({
 		}
 		if (this._map._docLayer._selectionHandles['end']) {
 			this._map._docLayer._selectionHandles['end'].setOpacity(1);
-		}
-
-		if (this._center) {
-			L.Util.cancelAnimFrame(this._animRequest);
-			this._map._animateZoom(this._center, finalZoom, true, true);
 		}
 
 		if (this._map._docLayer && this._map._docLayer._annotations) {


### PR DESCRIPTION
These are remnants of the css-based zoom animation, they will not be
used with the new, canvas-based zoom animation.

Signed-off-by: Jan Holesovsky <kendy@collabora.com>
Change-Id: I331968be144b0fbc3f5c8850cc08bac0b6e8f011
