### PR TITLE
Simulate EAGAIN in debug mode, every seventh operation.

### DIFF
--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -1,4 +1,3 @@
-
 /* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
 /*
  * This Source Code Form is subject to the terms of the Mozilla Public
@@ -61,6 +60,32 @@ int Socket::createSocket(Socket::Type type)
     return fakeSocketSocket();
 #endif
 }
+
+#if ENABLE_DEBUG
+static std::atomic<long> socketErrorCount;
+
+bool StreamSocket::simulateSocketError(bool)
+{
+    if ((socketErrorCount++ % 7) == 0)
+    {
+        errno = EAGAIN;
+        return true;
+    }
+    else
+        return false;
+}
+
+bool SslStreamSocket::simulateSocketError(bool read)
+{
+    if ((socketErrorCount++ % 7) == 0)
+    {
+        _sslWantsTo = read ? SslWantsTo::Read : SslWantsTo::Write;
+        return true;
+    }
+    else
+        return false;
+}
+#endif
 
 // help with initialization order
 namespace {
@@ -204,6 +229,11 @@ int SocketPoll::poll(int64_t timeoutMaxMicroS)
         checkAndReThread();
     else
         assertCorrectThread();
+
+#if ENABLE_DEBUG
+    // perturb - to rotate errors among several busy sockets.
+    socketErrorCount++;
+#endif
 
     std::chrono::steady_clock::time_point now =
         std::chrono::steady_clock::now();

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -1264,6 +1264,11 @@ protected:
         if (_readType == UseRecvmsgExpectFD)
             return readFD(buf, len, _incomingFD);
 
+#if ENABLE_DEBUG
+        if (simulateSocketError(true))
+            return -1;
+#endif
+
         return ::read(getFD(), buf, len);
 #else
         return fakeSocketRead(getFD(), buf, len);
@@ -1275,6 +1280,10 @@ protected:
     {
         assertCorrectThread();
 #if !MOBILEAPP
+#if ENABLE_DEBUG
+        if (simulateSocketError(false))
+            return -1;
+#endif
         return ::write(getFD(), buf, len);
 #else
         return fakeSocketWrite(getFD(), buf, len);
@@ -1295,6 +1304,12 @@ protected:
     {
         return _socketHandler;
     }
+
+protected:
+#if ENABLE_DEBUG
+    /// Return true and set errno to simulate an error
+    virtual bool simulateSocketError(bool read);
+#endif
 
   private:
     /// Client handling the actual data.

--- a/net/SslSocket.hpp
+++ b/net/SslSocket.hpp
@@ -113,6 +113,10 @@ public:
     {
         assertCorrectThread();
 
+#if ENABLE_DEBUG
+        if (simulateSocketError(true))
+            return -1;
+#endif
         return handleSslState(SSL_read(_ssl, buf, len));
     }
 
@@ -121,6 +125,11 @@ public:
         assertCorrectThread();
 
         assert (len > 0); // Never write 0 bytes.
+
+#if ENABLE_DEBUG
+        if (simulateSocketError(false))
+            return -1;
+#endif
         return handleSslState(SSL_write(_ssl, buf, len));
     }
 
@@ -148,6 +157,10 @@ public:
     }
 
 private:
+#if ENABLE_DEBUG
+    /// Return true and set errno to simulate an error
+    virtual bool simulateSocketError(bool read) override;
+#endif
 
     /// The possible next I/O operation that SSL want to do.
     enum class SslWantsTo

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -297,7 +297,7 @@ void DocumentBroker::pollThread()
     auto lastClipboardHashUpdateTime = std::chrono::steady_clock::now();
 
     const int limit_load_secs =
-#ifdef ENABLE_DEBUG
+#if ENABLE_DEBUG
         // paused waiting for a debugger to attach
         // ignore load time out
         std::getenv("PAUSEFORDEBUGGER") ? -1 :

--- a/wsd/TileCache.cpp
+++ b/wsd/TileCache.cpp
@@ -562,7 +562,7 @@ size_t TileCache::itemCacheSize(const Tile &tile)
 
 void TileCache::assertCacheSize()
 {
-#ifdef ENABLE_DEBUG
+#if ENABLE_DEBUG
     size_t recalcSize = 0;
     for (const auto& it : _cache)
     {


### PR DESCRIPTION
Hopefully reasonably simple; we perturb the count in the poll to
avoid starving a seventh socket in a poll.

Change-Id: I1a39cc36b9599ffe82186b896c6fd91d792c4127


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

