### PR TITLE
jsdialog: avoid to insert the "<dummy>" entry

### DIFF
--- a/loleaflet/src/control/Control.JSDialogBuilder.js
+++ b/loleaflet/src/control/Control.JSDialogBuilder.js
@@ -1537,6 +1537,9 @@ L.Control.JSDialogBuilder = L.Control.extend({
 	},
 
 	_treelistboxEntry: function (parentContainer, treeViewData, entry, builder) {
+		if (entry.text == '<dummy>')
+			return;
+
 		var li = L.DomUtil.create('li', builder.options.cssClass, parentContainer);
 		li.draggable = true;
 


### PR DESCRIPTION
Apparently the treeview control in server side,
create a "<dummy>" entry when no children exist.

Change-Id: If2afdd8aed7f8090ed33a8b77a96447394cad7bf
Signed-off-by: Henry Castro <hcastro@collabora.com>
