### PR TITLE
mobileWizard: Fix comment layout and avoid inline syles

### DIFF
--- a/loleaflet/css/mobilewizard.css
+++ b/loleaflet/css/mobilewizard.css
@@ -949,5 +949,13 @@ input[type='checkbox'][disabled] {
 .wizard-comment-box {
 	padding: 5px 10px 10px !important;
 	display: table !important;
-	width: -webkit-fill-available !important
+	width: 100% !important;
+	width: -webkit-fill-available !important;
+	width: -moz-available !important;
+}
+#mobile-wizard .ui-header[id^='comment'] {
+	padding: 5px 10px 10px !important;
+	display: table;
+	width: -moz-available !important;
+	box-sizing: border-box !important;
 }

--- a/loleaflet/src/control/Control.JSDialogBuilder.js
+++ b/loleaflet/src/control/Control.JSDialogBuilder.js
@@ -1858,14 +1858,13 @@ L.Control.JSDialogBuilder = L.Control.extend({
 
 	_rootCommentControl: function(parentContainer, data, builder) {
 		var container = L.DomUtil.create('div',  'ui-header level-' + builder._currentDepth + ' ' + builder.options.cssClass + ' ui-widget', parentContainer);
-		container.setAttribute('style', 'padding: 5px 10px 10px !important; display: table !important;width: -webkit-fill-available !important');
 		container.annotation = data.annotation;
 		container.id = data.id;
 		builder._createComment(container, data, true);
 		if (data.children.length > 0)
 		{
 			var childContainer = L.DomUtil.create('div', 'ui-content level-' + builder._currentDepth + ' ' + builder.options.cssClass, parentContainer);
-			childContainer.setAttribute('style', 'padding: 5px 10px 10px !important; display: table !important;width: -webkit-fill-available !important');
+			childContainer.id = 'comment-thread' + data.id;
 			childContainer.title = _('Comment');
 
 			builder._currentDepth++;


### PR DESCRIPTION
- make top level look like cards with their padding etc
- add class for comment threads and make it look like we entered the thread (thus the list style)

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I062841c645d416b7db4dc20302e2095d77416f8d
