### PR TITLE
Revert "leaflet: User may continue writing a comment after it loses f…

### DIFF
--- a/loleaflet/src/layer/AnnotationManager.js
+++ b/loleaflet/src/layer/AnnotationManager.js
@@ -610,20 +610,9 @@ L.AnnotationManager = L.AnnotationManagerBase.extend({
 		} // else - avoid excessive re-layout
 	},
 
-	hasDraftComment: function() {
-		var found = false;
-		for (var i = 0; i < this._items.length; i++) {
-			if (this._items[i].options.draft === true) {
-				found = true;
-				break;
-			}
-		}
-		return found;
-	},
-
 	add: function (comment) {
 		var annotation = L.annotation(this._map._docLayer._twipsToLatLng(comment.anchorPos.getTopRight()), comment,
-			comment.id === 'new' ? {noMenu: true, draft: true} : {}).addTo(this._map);
+			comment.id === 'new' ? {noMenu: true} : {}).addTo(this._map);
 		if (comment.parent && comment.parent > '0') {
 			var parentIdx = this.getIndexOf(comment.parent);
 			this._items.splice(parentIdx + 1, 0, annotation);
@@ -961,14 +950,6 @@ L.AnnotationManager = L.AnnotationManagerBase.extend({
 				Author: {
 					type: 'string',
 					value: e.annotation._data.author
-				},
-				pointX: {
-					type: 'string',
-					value: e.annotation._data.anchorPos.min.x
-				},
-				pointY: {
-					type: 'string',
-					value: e.annotation._data.anchorPos.min.y
 				}
 			};
 			this._map.sendUnoCommand('.uno:InsertAnnotation', comment);

--- a/loleaflet/src/layer/marker/Annotation.js
+++ b/loleaflet/src/layer/marker/Annotation.js
@@ -11,8 +11,7 @@ L.Annotation = L.Layer.extend({
 		maxHeight: 50,
 		imgSize: L.point([32, 32]),
 		margin: L.point([40, 40]),
-		noMenu: false,
-		draft: false
+		noMenu: false
 	},
 
 	initialize: function (latlng, data, options) {
@@ -96,18 +95,14 @@ L.Annotation = L.Layer.extend({
 
 		this._container.style.visibility = '';
 		this._contentNode.style.display = '';
-		if (this.options.draft === false) {
-			this._nodeModify.style.display = 'none';
-		}
+		this._nodeModify.style.display = 'none';
 		this._nodeReply.style.display = 'none';
 	},
 
 	hide: function () {
 		this._container.style.visibility = 'hidden';
 		this._contentNode.style.display = 'none';
-		if (this.options.draft === false) {
-			this._nodeModify.style.display = 'none';
-		}
+		this._nodeModify.style.display = 'none';
 		this._nodeReply.style.display = 'none';
 		if (this._data.textSelected && this._map.hasLayer(this._data.textSelected)) {
 			this._map.removeLayer(this._data.textSelected);
@@ -329,17 +324,13 @@ L.Annotation = L.Layer.extend({
 	},
 
 	_onLostFocus: function (e) {
-		// On mobile view, a vex dialog opens and covers entire screen. So we can not allow user to make their comment open & waiting when it loses focus.
-		// On mobile or tablet view, when comment loses focus, comment has to be cancelled.
-		if (this.options.draft === false || window.mode.isMobile() || window.mode.isTablet()) {
-			L.DomUtil.removeClass(this._container, 'annotation-active');
-			if (this._contentText.origText !== this._nodeModifyText.value) {
-				this._onSaveComment(e);
-			}
-			else if (this._nodeModifyText.value === '') {
-				// Implies that this._contentText.origText == ''
-				this._onCancelClick(e);
-			}
+		$(this._container).removeClass('annotation-active');
+		if (this._contentText.origText !== this._nodeModifyText.value) {
+			this._onSaveComment(e);
+		}
+		else if (this._nodeModifyText.value == '') {
+			// Implies that this._contentText.origText == ''
+			this._onCancelClick(e);
 		}
 	},
 

--- a/loleaflet/src/layer/tile/TileLayer.js
+++ b/loleaflet/src/layer/tile/TileLayer.js
@@ -2408,7 +2408,14 @@ L.TileLayer = L.GridLayer.extend({
 			if (!window.mobileWizard && !window.pageMobileWizard && !window.insertionMobileWizard) {
 				// If the user is editing, show the keyboard, but don't change
 				// anything if nothing is changed.
-				this._map.focus(true);
+
+				// We will focus map if no comment is being edited (writer only for now).
+				if (this._docType === 'text') {
+					if (!this._annotations._selected || !this._annotations._selected.isEdit())
+						this._map.focus(true);
+				}
+				else
+					this._map.focus(true);
 			}
 		} else {
 			this._map._textInput.hideCursor();

--- a/loleaflet/src/layer/tile/WriterTileLayer.js
+++ b/loleaflet/src/layer/tile/WriterTileLayer.js
@@ -7,25 +7,23 @@
 L.WriterTileLayer = L.CanvasTileLayer.extend({
 
 	newAnnotation: function (comment) {
-		if (this._annotations.hasDraftComment() === false || comment.id !== 'new') {
-			if (!comment.anchorPos && this._map._isCursorVisible) {
-				comment.anchorPos = L.bounds(this._latLngToTwips(this._visibleCursor.getSouthWest()),
-					this._latLngToTwips(this._visibleCursor.getNorthEast()));
-				comment.anchorPix = this._twipsToPixels(comment.anchorPos.min);
-			} else if (this._graphicSelection && !this._isEmptyRectangle(this._graphicSelection)) {
-				// An image is selected, then guess the anchor based on the graphic
-				// selection.
-				comment.anchorPos = L.bounds(this._latLngToTwips(this._graphicSelection.getSouthWest()),
-					this._latLngToTwips(this._graphicSelection.getNorthEast()));
-				comment.anchorPix = this._twipsToPixels(comment.anchorPos.min);
-			}
-			if (comment.anchorPos) {
-				this._annotations.modify(this._annotations.add(comment));
-			}
-			if (window.mode.isMobile() || window.mode.isTablet()) {
-				var that = this;
-				this.newAnnotationVex(comment, function(annotation) { that._annotations._onAnnotationSave(annotation); });
-			}
+		if (!comment.anchorPos && this._map._isCursorVisible) {
+			comment.anchorPos = L.bounds(this._latLngToTwips(this._visibleCursor.getSouthWest()),
+				this._latLngToTwips(this._visibleCursor.getNorthEast()));
+			comment.anchorPix = this._twipsToPixels(comment.anchorPos.min);
+		} else if (this._graphicSelection && !this._isEmptyRectangle(this._graphicSelection)) {
+			// An image is selected, then guess the anchor based on the graphic
+			// selection.
+			comment.anchorPos = L.bounds(this._latLngToTwips(this._graphicSelection.getSouthWest()),
+				this._latLngToTwips(this._graphicSelection.getNorthEast()));
+			comment.anchorPix = this._twipsToPixels(comment.anchorPos.min);
+		}
+		if (comment.anchorPos) {
+			this._annotations.modify(this._annotations.add(comment));
+		}
+		if (window.mode.isMobile() || window.mode.isTablet()) {
+			var that = this;
+			this.newAnnotationVex(comment, function(annotation) { that._annotations._onAnnotationSave(annotation); });
 		}
 	},
 


### PR DESCRIPTION
…ocus/online part."

We will use another approach, comment box was lingering.

This reverts commit 1beb1fde3e76f7d86f7ccb9e55cd00fa204797c9.


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

