### PR TITLE
wsd: ssl: simplify SSL poll events

### DIFF
--- a/net/SslSocket.hpp
+++ b/net/SslSocket.hpp
@@ -137,20 +137,8 @@ public:
                       int64_t & timeoutMaxMicroS) override
     {
         assertCorrectThread();
-        int events = getSocketHandler()->getPollEvents(now, timeoutMaxMicroS);
-
-        if (_sslWantsTo == SslWantsTo::Read)
-        {
-            // Must read next before attempting to write.
-            return POLLIN;
-        }
-        else if (_sslWantsTo == SslWantsTo::Write)
-        {
-            // Must write next before attempting to read.
-            return POLLOUT;
-        }
-
-        if (!getOutBuffer().empty() || isShutdownSignalled())
+        int events = StreamSocket::getPollEvents(now, timeoutMaxMicroS); // Default to base.
+        if (_sslWantsTo == SslWantsTo::Write) // If OpenSSL wants to write (and we don't).
             events |= POLLOUT;
 
         return events;


### PR DESCRIPTION
This merges OpenSSL's poll events with ours.
Effectively, we now do a single poll when
there are reads and writes to be done,
regardless of the reason (i.e. SSL-specific
or application-specific).

Simpler code, and more efficient performance
by sharing code with http and reducing the
number of poll syscalls.

Change-Id: Ib329c7e76fccfdadc4a0783c1ad79c3eedcdd8f3
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
