### PR TITLE
jsdialog: add class "collapsed"

### DIFF
--- a/loleaflet/src/control/Control.JSDialogBuilder.js
+++ b/loleaflet/src/control/Control.JSDialogBuilder.js
@@ -1591,6 +1591,9 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			// block expand/collapse on checkbox
 			if (entry.state)
 				$(checkbox).click(toggleFunction);
+
+			if (entry.ondemand)
+				L.DomUtil.addClass(span, 'collapsed');
 		}
 
 		$(text).click(function() {


### PR DESCRIPTION
Occurs that when showing the Macro Selector Dialog
the nodes of the treelistbox are shown on demand,
so the item is collapsed waiting user click to expand.

Change-Id: I45ea3252c9ea7f3806b22aec3063a57bf59c6d21
Signed-off-by: Henry Castro <hcastro@collabora.com>
