### PR TITLE
jsdialog: request 'expanding' to server side

### DIFF
--- a/loleaflet/src/control/Control.JSDialogBuilder.js
+++ b/loleaflet/src/control/Control.JSDialogBuilder.js
@@ -1586,7 +1586,11 @@ L.Control.JSDialogBuilder = L.Control.extend({
 				$(span).toggleClass('collapsed');
 			};
 
-			$(expander).click(toggleFunction);
+			L.DomEvent.on(expander, 'click', function() {
+				if (entry.ondemand && L.DomUtil.hasClass(span, 'collapsed'))
+					builder.callback('treeview', 'expand', treeViewData, entry.row, builder);
+				toggleFunction();
+			});
 
 			// block expand/collapse on checkbox
 			if (entry.state)


### PR DESCRIPTION
Occurs when showing the Macro Selector dialog,
the node children populate on demand when the
user click the expand element.

So client side will send the request 'expanding'
and asynchronous it receives the data to update
the dialog, another result it is not acceptable.

Change-Id: Ib176b86ab7f1b3bb5b463c825565f5d25fedf1f9
Signed-off-by: Henry Castro <hcastro@collabora.com>
