### PR TITLE
wsd: don't trust modified time when comparing files

### DIFF
--- a/common/FileUtil.hpp
+++ b/common/FileUtil.hpp
@@ -206,8 +206,7 @@ namespace FileUtil
             // and if they aren't, we still need to rely on the following.
             // Finally, compare the contents, to avoid costly copying if we fail to update.
             if (exists() && other.exists() && !isDirectory() && !other.isDirectory()
-                && size() == other.size() && modifiedTimeMs() == other.modifiedTimeMs()
-                && compareFileContents(_path, other._path))
+                && size() == other.size() && compareFileContents(_path, other._path))
             {
                 return true;
             }


### PR DESCRIPTION
We shouldn't assume two files are different just
because one was touched recently. This is an issue
when we think systemplate is out of date when it isn't.

Since we only do this file comparison on (very) small
/etc files, it's simply safer to compare the files
when their sizes are the same, instead of assuming
that timestamps are indicative of being outdated.

Ironically, by comparing the contents we spawn
jails faster when there is nothing to update
and we can safely use bind-mount.

Change-Id: Idb2088fcb52b493c91bef92890750f1dfcfbcc25
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
