### PR TITLE
Remove unwanted Poco::Timestamp functions

### DIFF
--- a/common/Log.hpp
+++ b/common/Log.hpp
@@ -29,13 +29,6 @@
 
 #include "Util.hpp"
 
-inline std::ostream& operator<< (std::ostream& os, const Poco::Timestamp& ts)
-{
-    os << Poco::DateTimeFormatter::format(Poco::DateTime(ts),
-                                          Poco::DateTimeFormat::ISO8601_FRAC_FORMAT);
-    return os;
-}
-
 inline std::ostream& operator<< (std::ostream& os, const std::chrono::system_clock::time_point& ts)
 {
     os << Util::getIso8601FracformatTime(ts);
@@ -225,17 +218,6 @@ namespace Log
         if (lhs.enabled())
         {
             lhs.getStream() << rhs;
-        }
-
-        return lhs;
-    }
-
-    inline StreamLogger& operator<<(StreamLogger& lhs, const Poco::Timestamp& rhs)
-    {
-        if (lhs.enabled())
-        {
-            lhs.getStream() << Poco::DateTimeFormatter::format(Poco::DateTime(rhs),
-                                                           Poco::DateTimeFormat::ISO8601_FRAC_FORMAT);
         }
 
         return lhs;


### PR DESCRIPTION
Signed-off-by: 22shubh22 <22shubh22@gmail.com>
Change-Id: Ie042253d2b99237537bac450a4b3b673606a84a9


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

Remove unwanted Poco::Timestamp #115 
### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

