### PR TITLE
Notebookbar: Fix StatisticsMenu arrow on Chrome

### DIFF
--- a/loleaflet/css/notebookbar.css
+++ b/loleaflet/css/notebookbar.css
@@ -260,10 +260,21 @@ div[id*='Row'].notebookbar, div[id*='Column'].notebookbar, #SendToBack.notebookb
 }
 
 .unotoolbutton.notebookbar .unoarrow {
+	width: 0px;
+	height: 0px;
+	font-size: 0;
+	line-height: 0;
 	border: 4px solid transparent;
 	border-top: 5px solid #8D99A7;
 	display: inline-block;
 	margin-left: 3px;
+}
+
+/*Adjust arrow for statistics menu (has icon, label stacked up)*/
+.unospan-Data-StatisticsMenu .unoarrow {
+	display: block;
+	float: right;
+	margin-top: -28px;
 }
 
 .unotoolbutton.notebookbar:hover .unoarrow {
@@ -337,7 +348,7 @@ div[id*='Row'].notebookbar, div[id*='Column'].notebookbar, #SendToBack.notebookb
 .unotoolbutton.notebookbar.has-label:not(.inline) img {
 	width: 32px !important;
 	height: 32px !important;
-	padding-left: 25%;
+	margin: auto !important;
 }
 
 /* unobuttons with inline labels */


### PR DESCRIPTION
In some browsers the 3 components (icon, label and arrow)
were not being displayed properly.

- Adjust arrow element for StatisticsMenu
(fiddle with useInLineLabelsForUnoButtons and noLabelsForUnoButtons [Control.JSDialogBuilder.js] wouldn't solve it)

- Remove unnecessarily padding-left: 25% from .unotoolbutton images
- Also avoid other problems with regular arrow by setting its dimensions to 0

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I907bfe711bbf81ac2a1071b73c322813426fc4e9
