### PR TITLE
fix l10n of StateWordCount on status bar

### DIFF
--- a/loleaflet/src/control/Control.StatusBar.js
+++ b/loleaflet/src/control/Control.StatusBar.js
@@ -488,7 +488,8 @@ L.Control.StatusBar = L.Control.extend({
 			this.updateToolbarItem(statusbar, 'StatePageNumber', $('#StatePageNumber').html(state ? state : '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp').parent().html());
 		}
 		else if (commandName === '.uno:StateWordCount') {
-			state = this.toLocalePattern('%1 words, %2 characters', '([\\d,]+) words, ([\\d,]+) characters', state, '%1', '%2');
+			var wordCount = _('%1 words, %2 characters'); // we do not localize the rare cases of '1 word, 1 character' & '1 word, x characters'
+			state = this.toLocalePattern(wordCount, '([\\d,]+) words, ([\\d,]+) characters', state, '%1', '%2');
 			this.updateToolbarItem(statusbar, 'StateWordCount', $('#StateWordCount').html(state ? state : '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp').parent().html());
 		}
 		else if (commandName === '.uno:PageStatus') {

--- a/scripts/locorestrings.py
+++ b/scripts/locorestrings.py
@@ -71,7 +71,6 @@ if __name__ == "__main__":
             poFile,
             ["STR_POOL",
              "STR_PAGE_COUNT",
-             "STR_STATUSBAR_WORDCOUNT_NO_SELECTION",
              "STR_LANGSTATUS_NONE"], translations)
 
         # extract Impress/Draw style names,


### PR DESCRIPTION
STR_STATUSBAR_WORDCOUNT_NO_SELECTION was removed from core with
commit 41d588835c359171c8d1a410221d75b9410b0c2d
Author: Caolán McNamara <caolanm@redhat.com>
Date:   Fri Nov 16 11:35:28 2018 +0000

    Related: tdf#83128 translate word/char counts as separate n_gettext args

Signed-off-by: Andras Timar <andras.timar@collabora.com>
Change-Id: I36dfb2fa7798e79e8ca50fafdb73b0dcc9208ed5


