### PR TITLE
cypress: try to fix random syntay error.

### DIFF
--- a/cypress_test/package.json
+++ b/cypress_test/package.json
@@ -13,7 +13,7 @@
     "eslint": "7.12.0",
     "eslint-plugin-cypress-rules": "file:eslint_plugin",
     "get-port-cli": "2.0.0",
-    "wait-on": "5.2.0"
+    "wait-on": "3.3.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I see some random test failures:
"An uncaught error was detected outside of a test:
SyntaxError: The following error originated from your test code, not from Cypress.

> Invalid or unexpected token"

There is no backtrace or code pointer or anything to find out
what is the actual problem, but it might be related the missing
import of 3rd-party code.

Signed-off-by: Tamás Zolnai <tamas.zolnai@collabora.com>
Change-Id: Ia2243852e825eee18c226d89fd17e92960daa129
