### PR TITLE
Don't show an empty font name field when the selection has multiple f…

### DIFF
--- a/loleaflet/src/control/Control.NotebookbarBuilder.js
+++ b/loleaflet/src/control/Control.NotebookbarBuilder.js
@@ -204,7 +204,10 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 				$('#table-fontnamecombobox').addClass('select2 select2-container select2-container--default');
 				$('#table-fontnamecombobox > .row.notebookbar').addClass('select2-selection select2-selection--single');
 				$('#fontnamecombobox').addClass('select2-selection__rendered');
-				$('#fontnamecombobox').html(state);
+				if (state === '')
+					$('#fontnamecombobox').html(_('Font Name'));
+				else
+					$('#fontnamecombobox').html(state);
 				window.LastSetiOSFontNameButtonFont = state;
 			} else {
 				$('#fontnamecombobox').val(state).trigger('change');


### PR DESCRIPTION
…onts

Instead use "Font Name". Fixes
https://github.com/CollaboraOnline/online/issues/1005 .

Change-Id: I427a2fc86c2c4a4415f80d27ffd2a1d4934f9cbe
Signed-off-by: Tor Lillqvist <tml@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

