### PR TITLE
cypress: try to handle support file better during parallel run.

### DIFF
--- a/cypress_test/plugins/index.js
+++ b/cypress_test/plugins/index.js
@@ -1,6 +1,8 @@
 /* global require */
 
 var process = require('process');
+var uuid = require('uuid');
+
 var tasks = require('./tasks');
 var blacklists = require('./blacklists');
 var selectTests = require('cypress-select-tests');
@@ -41,7 +43,16 @@ function plugin(on, config) {
 		config.defaultCommandTimeout = 10000;
 	}
 
-	on('file:preprocessor', selectTests(config, pickTests));
+	on('file:preprocessor', (file) => {
+		if (file.outputPath.endsWith('support/index.js')) {
+			var runUuid = uuid.v4();
+			var truncLength = file.outputPath.length - ('index.js').length;
+			file.outputPath = file.outputPath.substring(0, truncLength);
+			file.outputPath += runUuid + 'index.js';
+		}
+
+		return selectTests(config, pickTests)(file);
+	});
 
 	return config;
 }


### PR DESCRIPTION
When we run cypress tests in parallel (e.g. make check -j4), the
tests randomly fail with an uncaught error. The issue might be
because the same support file is shared between the different threads,
and they might access it at the same time. We try to create different
instances of the support file via preprocessing. Let's see whether it
makes the issue go away.

Issue's error message was:
"An uncaught error was detected outside of a test:
SyntaxError: The following error originated from your test code, not from Cypress.
Unexpected end of input"

Signed-off-by: Tamás Zolnai <tamas.zolnai@collabora.com>
Change-Id: I7b256cd686fb2b0e79ab602e95d197388a5aadca
