### PR TITLE
Don't apply invalid canvas split position

### DIFF
--- a/loleaflet/src/layer/tile/CalcTileLayer.js
+++ b/loleaflet/src/layer/tile/CalcTileLayer.js
@@ -828,6 +828,11 @@ L.CalcTileLayer = BaseTileLayer.extend({
 			this._splitCellState = new L.Point(-1, -1);
 		}
 
+		if (!e.state || e.state.length === 0) {
+			console.warn('Empty argument for ' + e.commandName);
+			return;
+		}
+
 		var newSplitIndex = Math.floor(parseInt(e.state));
 		console.assert(!isNaN(newSplitIndex) && newSplitIndex >= 0, 'invalid argument for ' + e.commandName);
 


### PR DESCRIPTION
When eg. Statistics -> Sampling dialog was opened
we received empty split position what caused to
setup NaN for split pos and no rendering at all

Change-Id: I4bd37778d23b15a01f1850459924c66f437f1570
Signed-off-by: Szymon Kłos <szymon.klos@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

