### PR TITLE
zoom-animation in the canvas

### DIFF
--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -450,7 +450,6 @@ L.CanvasTilePainter = L.Class.extend({
 
 	_zoomAnimation: function () {
 		var painter = this;
-		// TODO: do for all panes and for zoom-out case.
 		var ctx = this._paintContext();
 		var paneBoundsList = ctx.paneBoundsList;
 		var splitPos = ctx.paneBoundsActive ? this._splitPos.multiplyBy(this._dpiScale) : new L.Point(0, 0);

--- a/loleaflet/src/map/handler/Map.TouchGesture.js
+++ b/loleaflet/src/map/handler/Map.TouchGesture.js
@@ -568,11 +568,23 @@ L.Map.TouchGesture = L.Handler.extend({
 		this._zoom = this._map._limitZoom(this._map.getScaleZoom(e.scale));
 		this._center = this._map._limitCenter(this._map.mouseEventToLatLng({clientX: center.x, clientY: center.y}),
 						      this._zoom, this._map.options.maxBounds);
+
+		var origCenter = this._map._limitCenter(this._map.mouseEventToLatLng({clientX: center.x, clientY: center.y}),
+							  this._map.getZoom(), this._map.options.maxBounds);
+
+		if (this._map._docLayer.zoomStep) {
+			this._map._docLayer.zoomStep(this._zoom, origCenter);
+		}
 	},
 
 	_onPinchEnd: function () {
 		if (!this._pinchStartCenter)
 			return;
+
+		var oldZoom = this._map.getZoom();
+		var zoomDelta = this._zoom - oldZoom;
+		var finalZoom = this._map._limitZoom(zoomDelta > 0 ? Math.ceil(this._zoom) : Math.floor(this._zoom));
+
 
 		if (this._map._docLayer.isCursorVisible()) {
 			this._map._docLayer._cursorMarker.setOpacity(1);
@@ -596,6 +608,12 @@ L.Map.TouchGesture = L.Handler.extend({
 		}
 
 		this._pinchStartCenter = undefined;
+
+		if (this._map._docLayer.zoomStepEnd) {
+			this._map._docLayer.zoomStepEnd();
+		}
+
+		this._map.setView(this._center, finalZoom);
 	},
 
 	_constructFakeEvent: function (evt, type) {


### PR DESCRIPTION
...(CanvasTileLayer) for the pinch-zoom event. This uses extra canvas
elements for each freeze-pane which are not attached to the DOM
(OffScreenCanvas is not available in IE11). These canvases will always
be kept updated as the main canvas except that they also include a few
(three for now) border tiles, so that zoom-out works. The zoom animation
frames are drawn on the main canvas by drawImage() call from the
offscreen canvas at the right intermediate scaling. After the pinch zoom
event has ended (_onPinchEnd()) the map's zoom/center are updated and
offscreen canvases are cleaned up.

Caveat: The zoom animation frames will have out of sync row/col headers
and it is slow to render them frame by frame for every intermediate
zoom. It is much easier/faster to have them in sync if they are drawn in
main canvas which is currently a WIP item.

Signed-off-by: Dennis Francis <dennis.francis@collabora.com>
Change-Id: I74fefd0302d139d32c227f67eb6759bb6b298f83


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

