### PR TITLE
jsdialog: only update the incoming control changes

### DIFF
--- a/loleaflet/src/control/Control.JSDialog.js
+++ b/loleaflet/src/control/Control.JSDialog.js
@@ -12,10 +12,12 @@ L.Control.JSDialog = L.Control.extend({
 		this.map = map;
 
 		this.map.on('jsdialog', this.onJSDialog, this);
+		this.map.on('commandresult', this.onJSUpdate, this);
 	},
 
 	onRemove: function() {
 		this.map.off('jsdialog', this.onJSDialog, this);
+		this.map.off('commandresult', this.onJSUpdate, this);
 	},
 
 	onJSDialog: function(e) {
@@ -83,6 +85,32 @@ L.Control.JSDialog = L.Control.extend({
 		container.startX = posX;
 		container.startY = posY;
 		this.updatePosition(container, posX, posY);
+	},
+
+	onJSUpdate: function (e) {
+		if (e.commandName === '.uno:jsdialog' && e.success) {
+			var data = e.result;
+			var dialog = this.dialogs[data.dialog_id];
+			if (!dialog)
+				return;
+
+			var control = dialog.querySelector('#' + data.control_id);
+			if (!control)
+				return;
+
+			var parent = control.parentNode;
+			if (!parent)
+				return;
+
+			control.style.visibility = 'hidden';
+			var builder = new L.control.jsDialogBuilder({windowId: data.dialog_id,
+								     mobileWizard: this,
+								     map: this.map,
+								     cssClass: 'jsdialog'});
+
+			builder.build(parent, [data.control], false);
+			L.DomUtil.remove(control);
+		}
 	},
 
 	onPan: function (ev) {


### PR DESCRIPTION
It will update the control that has changed the model,
in the current visible dialog instead to recreate the
dialog again.

Change-Id: Ibad681df32952f380d63ccd82b01d83c488d95b4
Signed-off-by: Henry Castro <hcastro@collabora.com>
