### PR TITLE
Fix regression coming from 8887abe9de14d636a9951c454d9880c5d3bfd69f

### DIFF
--- a/loleaflet/src/control/Control.Menubar.js
+++ b/loleaflet/src/control/Control.Menubar.js
@@ -526,14 +526,7 @@ L.Control.Menubar = L.Control.extend({
 					{uno: '.uno:DeleteRowbreak'},
 					{uno: '.uno:DeleteColumnbreak'}]},
 				{type: 'separator'},
-				{uno: '.uno:Delete'},
-				{name: _UNO('.uno:NamesMenu', 'spreadsheet'), type: 'menu', menu: [
-					{uno: '.uno:AddName'},
-					{uno: '.uno:DefineName'},
-					{uno: '.uno:SheetInsertName'},
-					{type: 'separator'},
-					{uno: '.uno:CreateNames'},
-					{uno: '.uno:DefineLabelRange'}]}
+				{uno: '.uno:Delete'}
 			]},
 			{name: _UNO('.uno:DataMenu', 'spreadsheet'), type: 'menu', menu: [
 				{uno: '.uno:DataSort'},


### PR DESCRIPTION
- Named Ranges and Expressions were duplicated (appearing both on Sheet and Data)
- Plus avoid uno commands that wither were not tested, simply do not work or are unstable

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I257b9a2eb9e7db0d8881c96e7f3f31dba94f020a
