### PR TITLE
Notebookbar Insert Tab: update writer insert tab

### DIFF
--- a/loleaflet/css/notebookbar.css
+++ b/loleaflet/css/notebookbar.css
@@ -438,12 +438,10 @@ div[id*='Row'].notebookbar, div[id*='Column'].notebookbar, #SendToBack.notebookb
 }
 
 #table-Insert-Section-Pagebreak #InsertPagebreak.notebookbar img,
-#table-Insert-Section-Table #InsertTable.notebookbar img,
-#InsertObjectChart.notebookbar img,
 #table-Insert-Section-Image #InsertGraphic.notebookbar img,
 #HyperlinkDialog.notebookbar img,
 #InsertFieldCtrl.notebookbar img,
-#BasicShapes.notebookbar img,
+#DrawText.notebookbar img,
 #table-Insert-Section-Symbol #CharmapControl.notebookbar img
 {
 	height: 32px !important;
@@ -484,7 +482,6 @@ div[id*='Row'].notebookbar, div[id*='Column'].notebookbar, #SendToBack.notebookb
 #table-Reference-Section-Reference #InsertReferenceField.notebookbar img,
 #InsertAuthoritiesEntry.notebookbar img,
 #UpdateAll.notebookbar img,
-#InsertReferenceField.notebookbar img
 {
 	height: 32px !important;
 	width: 32px !important;

--- a/loleaflet/src/control/Control.NotebookbarWriter.js
+++ b/loleaflet/src/control/Control.NotebookbarWriter.js
@@ -2193,116 +2193,6 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 																			'vertical': 'false'
 																		},
 																		{
-																			'id': 'Insert-Section-Endnote',
-																			'type': 'container',
-																			'text': '',
-																			'enabled': 'true',
-																			'children': [
-																				{
-																					'id': 'GroupB292',
-																					'type': 'container',
-																					'text': '',
-																					'enabled': 'true',
-																					'children': [
-																						{
-																							'id': 'LineA152',
-																							'type': 'toolbox',
-																							'text': '',
-																							'enabled': 'true',
-																							'children': [
-																								{
-																									'type': 'toolitem',
-																									'text': _UNO('.uno:InsertFootnote', 'text'),
-																									'command': '.uno:InsertFootnote'
-																								}
-																							]
-																						},
-																						{
-																							'id': 'LineB162',
-																							'type': 'toolbox',
-																							'text': '',
-																							'enabled': 'true',
-																							'children': [
-																								{
-																									'type': 'toolitem',
-																									'text': _UNO('.uno:InsertEndnote', 'text'),
-																									'command': '.uno:InsertEndnote'
-																								}
-																							]
-																						}
-																					],
-																					'vertical': 'true'
-																				}
-																			],
-																			'vertical': 'false'
-																		},
-																		{
-																			'id': 'Insert-Section-HeaderFoorter',
-																			'type': 'container',
-																			'text': '',
-																			'enabled': 'true',
-																			'children': [
-																				{
-																					'id': 'GroupB291',
-																					'type': 'container',
-																					'text': '',
-																					'enabled': 'true',
-																					'children': [
-																						{
-																							'id': 'LineA151',
-																							'type': 'toolbox',
-																							'text': '',
-																							'enabled': 'true',
-																							'children': [
-																								{
-																									'type': 'toolitem',
-																									'text': _UNO('.uno:InsertPageHeader', 'text'),
-																									'command': '.uno:InsertPageHeader'
-																								}
-																							]
-																						},
-																						{
-																							'id': 'LineB161',
-																							'type': 'toolbox',
-																							'text': '',
-																							'enabled': 'true',
-																							'children': [
-																								{
-																									'type': 'toolitem',
-																									'text': _UNO('.uno:InsertPageFooter', 'text'),
-																									'command': '.uno:InsertPageFooter'
-																								}
-																							]
-																						}
-																					],
-																					'vertical': 'true'
-																				}
-																			],
-																			'vertical': 'false'
-																		},
-																		{
-																			'id': 'Insert-Section-Table',
-																			'type': 'container',
-																			'text': '',
-																			'enabled': 'true',
-																			'children': [
-																				{
-																					'id': 'SectionBottom12',
-																					'type': 'toolbox',
-																					'text': '',
-																					'enabled': 'true',
-																					'children': [
-																						{
-																							'type': 'toolitem',
-																							'text': _UNO('.uno:InsertTable', 'text'),
-																							'command': '.uno:InsertTable'
-																						}
-																					]
-																				}
-																			],
-																			'vertical': 'true'
-																		},
-																		{
 																			'id': 'Insert-Section-Image',
 																			'type': 'container',
 																			'text': '',
@@ -2325,29 +2215,51 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 																			'vertical': 'false'
 																		},
 																		{
-																			'id': 'Insert-Section-Table1',
+																			'id': 'Insert-Section-Table-Chart',
 																			'type': 'container',
 																			'text': '',
 																			'enabled': 'true',
 																			'children': [
 																				{
-																					'id': 'LineA11',
-																					'type': 'toolbox',
+																					'id': 'GroupB292',
+																					'type': 'container',
 																					'text': '',
 																					'enabled': 'true',
 																					'children': [
 																						{
-																							'type': 'bigtoolitem',
-																							'text': _UNO('.uno:InsertObjectChart'),
-																							'command': '.uno:InsertObjectChart'
+																							'id': 'LineA152',
+																							'type': 'toolbox',
+																							'text': '',
+																							'enabled': 'true',
+																							'children': [
+																								{
+																									'type': 'toolitem',
+																									'text': 'Table',
+																									'command': '.uno:InsertTable'
+																								}
+																							]
+																						},
+																						{
+																							'id': 'LineB162',
+																							'type': 'toolbox',
+																							'text': '',
+																							'enabled': 'true',
+																							'children': [
+																								{
+																									'type': 'toolitem',
+																									'text': _UNO('.uno:InsertObjectChart'),
+																									'command': '.uno:InsertObjectChart'
+																								}
+																							]
 																						}
-																					]
+																					],
+																					'vertical': 'true'
 																				}
 																			],
 																			'vertical': 'false'
 																		},
 																		{
-																			'id': 'Insert-Section-Bookmark',
+																			'id': 'Insert-Section-Hyperlink',
 																			'type': 'container',
 																			'text': '',
 																			'enabled': 'true',
@@ -2369,29 +2281,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 																			'vertical': 'false'
 																		},
 																		{
-																			'id': 'Insert-Section-InsertAnnotation',
-																			'type': 'container',
-																			'text': '',
-																			'enabled': 'true',
-																			'children': [
-																				{
-																					'id': 'SectionBottom15',
-																					'type': 'toolbox',
-																					'text': '',
-																					'enabled': 'true',
-																					'children': [
-																						{
-																							'type': 'bigtoolitem',
-																							'text': _UNO('.uno:InsertAnnotation', 'text'),
-																							'command': '.uno:InsertAnnotation'
-																						}
-																					]
-																				}
-																			],
-																			'vertical': 'false'
-																		},
-																		{
-																			'id': 'Insert-Section-Bookmark1',
+																			'id': 'Insert-Section-Bookmark',
 																			'type': 'container',
 																			'text': '',
 																			'enabled': 'true',
@@ -2448,7 +2338,73 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 																			]
 																		},
 																		{
+																			'id': 'Insert-Section-HeaderFoorter',
+																			'type': 'container',
+																			'text': '',
+																			'enabled': 'true',
+																			'children': [
+																				{
+																					'id': 'GroupB291',
+																					'type': 'container',
+																					'text': '',
+																					'enabled': 'true',
+																					'children': [
+																						{
+																							'id': 'LineA151',
+																							'type': 'toolbox',
+																							'text': '',
+																							'enabled': 'true',
+																							'children': [
+																								{
+																									'type': 'toolitem',
+																									'text': _UNO('.uno:InsertPageHeader', 'text'),
+																									'command': '.uno:InsertPageHeader'
+																								}
+																							]
+																						},
+																						{
+																							'id': 'LineB161',
+																							'type': 'toolbox',
+																							'text': '',
+																							'enabled': 'true',
+																							'children': [
+																								{
+																									'type': 'toolitem',
+																									'text': _UNO('.uno:InsertPageFooter', 'text'),
+																									'command': '.uno:InsertPageFooter'
+																								}
+																							]
+																						}
+																					],
+																					'vertical': 'true'
+																				}
+																			],
+																			'vertical': 'false'
+																		},
+																		{
 																			'id': 'Insert-Text',
+																			'type': 'container',
+																			'text': '',
+																			'enabled': 'true',
+																			'children': [
+																				{
+																					'id': 'shapes6',
+																					'type': 'toolbox',
+																					'text': '',
+																					'enabled': 'true',
+																					'children': [
+																						{
+																							'type': 'bigtoolitem',
+																							'text': _UNO('.uno:DrawText'),
+																							'command': '.uno:DrawText'
+																						}
+																					]
+																				}
+																			],
+																			'vertical': 'false'
+																		},
+																		{
+																			'id': 'Insert-BasicShapes-VerticalText',
 																			'type': 'container',
 																			'text': '',
 																			'enabled': 'true',
@@ -2467,8 +2423,8 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 																							'children': [
 																								{
 																									'type': 'toolitem',
-																									'text': _UNO('.uno:DrawText'),
-																									'command': '.uno:DrawText'
+																									'text': _UNO('.uno:BasicShapes'),
+																									'command': '.uno:BasicShapes'
 																								}
 																							]
 																						},
@@ -2490,28 +2446,6 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 																				}
 																			],
 																			'vertical': 'false'
-																		},
-																		{
-																			'id': 'Insert-Section-Draw2',
-																			'type': 'container',
-																			'text': '',
-																			'enabled': 'true',
-																			'children': [
-																				{
-																					'id': 'shapes6',
-																					'type': 'toolbox',
-																					'text': '',
-																					'enabled': 'true',
-																					'children': [
-																						{
-																							'type': 'toolitem',
-																							'text': _UNO('.uno:BasicShapes'),
-																							'command': '.uno:BasicShapes'
-																						}
-																					]
-																				}
-																			],
-																			'vertical': 'true'
 																		},
 																		{
 																			'id': 'Insert-Section-Symbol',


### PR DESCRIPTION
Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I255116b6bb16e84d2b465f8fb862145924552f68

Before
![Screenshot_20201219_111919](https://user-images.githubusercontent.com/8517736/102687021-30198c00-41ec-11eb-82c0-4a2bc870846b.png)

After pull request
![Screenshot_20201219_111750](https://user-images.githubusercontent.com/8517736/102687026-3a3b8a80-41ec-11eb-9046-53f539bf01b9.png)

LibreOffice (Desktop)
![Screenshot_20201219_111944](https://user-images.githubusercontent.com/8517736/102687031-47587980-41ec-11eb-8700-25a5e5d91863.png)

With the PR the Writer Insert tab follow how it look on desktop (exclusive the non existing commands) and the layout is similar to how NB's are designed. Each group start with one big button and than the commands are arranged in two columns.