### PR TITLE
leaflet: prevent entering non numeric value in spin field

### DIFF
--- a/loleaflet/src/control/Control.JSDialogBuilder.js
+++ b/loleaflet/src/control/Control.JSDialogBuilder.js
@@ -62,6 +62,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 
 			var spinfield = L.DomUtil.create('input', 'spinfield', div);
 			spinfield.type = 'number';
+			spinfield.onkeypress = L.Control.JSDialogBuilder._preventNonNumericalInput;
 			controls['spinfield'] = spinfield;
 
 			if (data.unit) {
@@ -114,6 +115,15 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			});
 
 			return controls;
+		},
+
+		_preventNonNumericalInput: function(e) {
+			e = e || window.event;
+			var charCode = (typeof e.which === undefined) ? e.keyCode : e.which;
+			var charStr = String.fromCharCode(charCode);
+
+			if (!charStr.match(/^[0-9.,]+$/) && charCode !== 13)
+				e.preventDefault();
 		},
 
 		listenNumericChanges: function (data, builder, controls, customCallback) {


### PR DESCRIPTION
Signed-off-by: Pranam Lashkari <lpranam@collabora.com>
Change-Id: I78403b489f8057b3131e1ccc1cbeef74377bedc4

* Target version: distro/collabora/co-4-2

### Summary
In safari, firefox and in ios app user could enter non-numeric characters in the spin field, this patch prevents it.


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

