### PR TITLE
Notebookbar Insert Tab: update calc insert tab

### DIFF
--- a/loleaflet/src/control/Control.NotebookbarCalc.js
+++ b/loleaflet/src/control/Control.NotebookbarCalc.js
@@ -2231,23 +2231,45 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 																			'vertical': 'false'
 																		},
 																		{
-																			'id': 'Insert-Section-Image',
+																			'id': 'Insert-Section-PivotTable-Ext',
 																			'type': 'container',
 																			'text': '',
 																			'enabled': 'true',
 																			'children': [
 																				{
-																					'id': 'SectionBottom65',
-																					'type': 'toolbox',
+																					'id': 'GroupB292',
+																					'type': 'container',
 																					'text': '',
 																					'enabled': 'true',
 																					'children': [
 																						{
-																							'type': 'bigtoolitem',
-																							'text': _UNO('.uno:InsertGraphic'),
-																							'command': '.uno:InsertGraphic'
+																							'id': 'LineA152',
+																							'type': 'toolbox',
+																							'text': '',
+																							'enabled': 'true',
+																							'children': [
+																								{
+																									'type': 'toolitem',
+																									'text': _UNO('.uno:RecalcPivotTable', 'spreadsheet'),
+																									'command': '.uno:RecalcPivotTable'
+																								}
+																							]
+																						},
+																						{
+																							'id': 'LineB162',
+																							'type': 'toolbox',
+																							'text': '',
+																							'enabled': 'true',
+																							'children': [
+																								{
+																									'type': 'toolitem',
+																									'text': _UNO('.uno:DeletePivotTable', 'spreadsheet'),
+																									'command': '.uno:DeletePivotTable'
+																								}
+																							]
 																						}
-																					]
+																					],
+																					'vertical': 'true'
 																				}
 																			],
 																			'vertical': 'false'
@@ -2275,7 +2297,51 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 																			'vertical': 'false'
 																		},
 																		{
-																			'id': 'Insert-Section-Bookmark',
+																			'id': 'Insert-Section-PivotTable-Ext',
+																			'type': 'container',
+																			'text': '',
+																			'enabled': 'true',
+																			'children': [
+																				{
+																					'id': 'GroupB292',
+																					'type': 'container',
+																					'text': '',
+																					'enabled': 'true',
+																					'children': [
+																						{
+																							'id': 'LineA152',
+																							'type': 'toolbox',
+																							'text': '',
+																							'enabled': 'true',
+																							'children': [
+																								{
+																									'type': 'toolitem',
+																									'text': _UNO('.uno:InsertGraphic'),
+																									'command': '.uno:InsertGraphic'
+																								}
+																							]
+																						},
+																						{
+																							'id': 'LineB162',
+																							'type': 'toolbox',
+																							'text': '',
+																							'enabled': 'true',
+																							'children': [
+																								{
+																									'type': 'toolitem',
+																									'text': _UNO('.uno:FunctionDialog', 'spreadsheet'),
+																									'command': '.uno:FunctionDialog'
+																								}
+																							]
+																						}
+																					],
+																					'vertical': 'true'
+																				}
+																			],
+																			'vertical': 'false'
+																		},
+																		{
+																			'id': 'Insert-Section-Hyperlink',
 																			'type': 'container',
 																			'text': '',
 																			'enabled': 'true',
@@ -2297,7 +2363,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 																			'vertical': 'false'
 																		},
 																		{
-																			'id': 'Insert-Section-Draw2',
+																			'id': 'Insert-Text',
 																			'type': 'container',
 																			'text': '',
 																			'enabled': 'true',
@@ -2309,14 +2375,58 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 																					'enabled': 'true',
 																					'children': [
 																						{
-																							'type': 'toolitem',
-																							'text': _UNO('.uno:BasicShapes'),
-																							'command': '.uno:BasicShapes'
+																							'type': 'bigtoolitem',
+																							'text': _UNO('.uno:DrawText'),
+																							'command': '.uno:DrawText'
 																						}
 																					]
 																				}
 																			],
-																			'vertical': 'true'
+																			'vertical': 'false'
+																		},
+																		{
+																			'id': 'Insert-BasicShapes-VerticalText',
+																			'type': 'container',
+																			'text': '',
+																			'enabled': 'true',
+																			'children': [
+																				{
+																					'id': 'GroupB293',
+																					'type': 'container',
+																					'text': '',
+																					'enabled': 'true',
+																					'children': [
+																						{
+																							'id': 'LineA153',
+																							'type': 'toolbox',
+																							'text': '',
+																							'enabled': 'true',
+																							'children': [
+																								{
+																									'type': 'toolitem',
+																									'text': _UNO('.uno:BasicShapes'),
+																									'command': '.uno:BasicShapes'
+																								}
+																							]
+																						},
+																						{
+																							'id': 'LineB163',
+																							'type': 'toolbox',
+																							'text': '',
+																							'enabled': 'true',
+																							'children': [
+																								{
+																									'type': 'toolitem',
+																									'text': _UNO('.uno:VerticalText', 'text'),
+																									'command': '.uno:VerticalText'
+																								}
+																							]
+																						}
+																					],
+																					'vertical': 'true'
+																				}
+																			],
+																			'vertical': 'false'
 																		},
 																		{
 																			'id': 'Insert-Section-Symbol',
@@ -2325,7 +2435,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 																			'enabled': 'true',
 																			'children': [
 																				{
-																					'id': 'SectionBottom105',
+																					'id': 'shapes6',
 																					'type': 'toolbox',
 																					'text': '',
 																					'enabled': 'true',
@@ -2356,28 +2466,6 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 																							'type': 'bigtoolitem',
 																							'text': _UNO('.uno:EditHeaderAndFooter', 'spreadsheet'),
 																							'command': '.uno:EditHeaderAndFooter'
-																						}
-																					]
-																				}
-																			],
-																			'vertical': 'false'
-																		},
-																		{
-																			'id': 'Insert-Section-Annotation',
-																			'type': 'container',
-																			'text': '',
-																			'enabled': 'true',
-																			'children': [
-																				{
-																					'id': 'Annotation',
-																					'type': 'toolbox',
-																					'text': '',
-																					'enabled': 'true',
-																					'children': [
-																						{
-																							'type': 'bigtoolitem',
-																							'text': _UNO('.uno:InsertAnnotation', 'spreadsheet'),
-																							'command': '.uno:InsertAnnotation'
 																						}
 																					]
 																				}


### PR DESCRIPTION
Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I0d829aaa2e9869de87cddc997b8758fe8d20823c

Before
![Screenshot_20201219_214825](https://user-images.githubusercontent.com/8517736/102700405-64716480-424d-11eb-80ab-0fad45085809.png)

After pull request
![Screenshot_20201219_214805](https://user-images.githubusercontent.com/8517736/102700411-6f2bf980-424d-11eb-9eb6-970a966b59fb.png)

LibreOffice (Desktop)
![Screenshot_20201219_225706](https://user-images.githubusercontent.com/8517736/102700429-866ae700-424d-11eb-8801-1bafcb8dbb20.png)

With the PR the Calc Insert tab follow how it look on desktop (exclusive the non existing commands) and the layout is similar to how NB's are designed. Each group start with one big button and than the commands are arranged in two columns.