### PR TITLE
Non-functional improvements of the Jail helpers

### DIFF
--- a/common/Common.hpp
+++ b/common/Common.hpp
@@ -33,7 +33,6 @@ constexpr int MAX_MESSAGE_SIZE = 2 * 1024 * READ_BUFFER_SIZE;
 constexpr const char JAILED_DOCUMENT_ROOT[] = "/tmp/user/docs/";
 constexpr const char CHILD_URI[] = "/loolws/child?";
 constexpr const char NEW_CHILD_URI[] = "/loolws/newchild";
-constexpr const char LO_JAIL_SUBPATH[] = "lo";
 constexpr const char FORKIT_URI[] = "/loolws/forkit";
 
 constexpr const char CAPABILITIES_END_POINT[] = "/hosting/capabilities";

--- a/common/FileUtil.cpp
+++ b/common/FileUtil.cpp
@@ -382,6 +382,7 @@ namespace FileUtil
 
     bool linkOrCopyFile(const char* source, const char* target)
     {
+        unlink(target); // Remove, in case it's a link to the source.
         if (link(source, target) == -1)
         {
             LOG_DBG("link(\"" << source << "\", \"" << target << "\") failed: " << strerror(errno)

--- a/common/JailUtil.cpp
+++ b/common/JailUtil.cpp
@@ -182,11 +182,11 @@ void cleanupJails(const std::string& root)
         LOG_WRN("Jails root directory [" << root << "] is not empty. Will not remove it.");
 }
 
-void setupJails(bool bindMount, const std::string& jailRoot, const std::string& sysTemplate)
+void setupChildRoot(bool bindMount, const std::string& childRoot, const std::string& sysTemplate)
 {
     // Start with a clean slate.
-    cleanupJails(jailRoot);
-    Poco::File(jailRoot + JAIL_TMP_INCOMING_PATH).createDirectories();
+    cleanupJails(childRoot);
+    Poco::File(childRoot + CHILDROOT_TMP_INCOMING_PATH).createDirectories();
 
     disableBindMounting(); // Clear to avoid surprises.
 
@@ -195,7 +195,7 @@ void setupJails(bool bindMount, const std::string& jailRoot, const std::string& 
     {
         // Test mounting to verify it actually works,
         // as it might not function in some systems.
-        const std::string target = Poco::Path(jailRoot, "lool_test_mount").toString();
+        const std::string target = Poco::Path(childRoot, "lool_test_mount").toString();
         if (bind(sysTemplate, target))
         {
             enableBindMounting();

--- a/common/JailUtil.hpp
+++ b/common/JailUtil.hpp
@@ -21,6 +21,9 @@ constexpr const char CHILDROOT_TMP_PATH[] = "/tmp";
 /// Files uploaded by users are stored in this sub-directory of child-root.
 constexpr const char CHILDROOT_TMP_INCOMING_PATH[] = "/tmp/incoming";
 
+/// The LO installation directory with jail.
+constexpr const char LO_JAIL_SUBPATH[] = "lo";
+
 /// Bind mount a jail directory.
 bool bind(const std::string& source, const std::string& target);
 

--- a/common/JailUtil.hpp
+++ b/common/JailUtil.hpp
@@ -15,8 +15,11 @@
 namespace JailUtil
 {
 
+/// General temporary directory owned by us.
+constexpr const char CHILDROOT_TMP_PATH[] = "/tmp";
+
 /// Files uploaded by users are stored in this sub-directory of child-root.
-constexpr const char JAIL_TMP_INCOMING_PATH[] = "/tmp/incoming";
+constexpr const char CHILDROOT_TMP_INCOMING_PATH[] = "/tmp/incoming";
 
 /// Bind mount a jail directory.
 bool bind(const std::string& source, const std::string& target);
@@ -39,8 +42,8 @@ void removeJail(const std::string& root);
 /// Remove all jails.
 void cleanupJails(const std::string& jailRoot);
 
-/// Setup the jails.
-void setupJails(bool bindMount, const std::string& jailRoot, const std::string& sysTemplate);
+/// Setup the Child-Root directory.
+void setupChildRoot(bool bindMount, const std::string& jailRoot, const std::string& sysTemplate);
 
 /// Setup /dev/random and /dev/urandom in the given jail path.
 void setupJailDevNodes(const std::string& root);

--- a/kit/ForKit.cpp
+++ b/kit/ForKit.cpp
@@ -339,7 +339,6 @@ static void cleanupChildren()
 static int createLibreOfficeKit(const std::string& childRoot,
                                 const std::string& sysTemplate,
                                 const std::string& loTemplate,
-                                const std::string& loSubPath,
                                 bool queryVersion = false)
 {
     // Generate a jail ID to be used for in the jail path.
@@ -379,9 +378,9 @@ static int createLibreOfficeKit(const std::string& childRoot,
         }
 
 #ifndef KIT_IN_PROCESS
-        lokit_main(childRoot, jailId, sysTemplate, loTemplate, loSubPath, NoCapsForKit, NoSeccomp, queryVersion, DisplayVersion, spareKitId);
+        lokit_main(childRoot, jailId, sysTemplate, loTemplate, NoCapsForKit, NoSeccomp, queryVersion, DisplayVersion, spareKitId);
 #else
-        lokit_main(childRoot, jailId, sysTemplate, loTemplate, loSubPath, true, true, queryVersion, DisplayVersion, spareKitId);
+        lokit_main(childRoot, jailId, sysTemplate, loTemplate, true, true, queryVersion, DisplayVersion, spareKitId);
 #endif
     }
     else
@@ -408,7 +407,6 @@ static int createLibreOfficeKit(const std::string& childRoot,
 void forkLibreOfficeKit(const std::string& childRoot,
                         const std::string& sysTemplate,
                         const std::string& loTemplate,
-                        const std::string& loSubPath,
                         int limit)
 {
     // Cleanup first, to reduce disk load.
@@ -429,7 +427,7 @@ void forkLibreOfficeKit(const std::string& childRoot,
         const size_t retry = count * 2;
         for (size_t i = 0; ForkCounter > 0 && i < retry; ++i)
         {
-            if (ForkCounter-- <= 0 || createLibreOfficeKit(childRoot, sysTemplate, loTemplate, loSubPath) < 0)
+            if (ForkCounter-- <= 0 || createLibreOfficeKit(childRoot, sysTemplate, loTemplate) < 0)
             {
                 LOG_ERR("Failed to create a kit process.");
                 ++ForkCounter;
@@ -531,7 +529,6 @@ int main(int argc, char** argv)
     }
 
     std::string childRoot;
-    std::string loSubPath;
     std::string sysTemplate;
     std::string loTemplate;
 
@@ -539,12 +536,7 @@ int main(int argc, char** argv)
     {
         char *cmd = argv[i];
         char *eq;
-        if (std::strstr(cmd, "--losubpath=") == cmd)
-        {
-            eq = std::strchr(cmd, '=');
-            loSubPath = std::string(eq+1);
-        }
-        else if (std::strstr(cmd, "--systemplate=") == cmd)
+        if (std::strstr(cmd, "--systemplate=") == cmd)
         {
             eq = std::strchr(cmd, '=');
             sysTemplate = std::string(eq+1);
@@ -627,8 +619,7 @@ int main(int argc, char** argv)
         }
     }
 
-    if (loSubPath.empty() || sysTemplate.empty() ||
-        loTemplate.empty() || childRoot.empty())
+    if (sysTemplate.empty() || loTemplate.empty() || childRoot.empty())
     {
         printArgumentHelp();
         return EX_USAGE;
@@ -676,7 +667,7 @@ int main(int argc, char** argv)
     // We must have at least one child, more are created dynamically.
     // Ask this first child to send version information to master process and trace startup.
     ::setenv("LOOL_TRACE_STARTUP", "1", 1);
-    pid_t forKitPid = createLibreOfficeKit(childRoot, sysTemplate, loTemplate, loSubPath, true);
+    pid_t forKitPid = createLibreOfficeKit(childRoot, sysTemplate, loTemplate, true);
     if (forKitPid < 0)
     {
         LOG_FTL("Failed to create a kit process.");
@@ -716,7 +707,7 @@ int main(int argc, char** argv)
 #if ENABLE_DEBUG
         if (!SingleKit)
 #endif
-        forkLibreOfficeKit(childRoot, sysTemplate, loTemplate, loSubPath);
+        forkLibreOfficeKit(childRoot, sysTemplate, loTemplate);
     }
 
     int returnValue = EX_OK;

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -149,7 +149,7 @@ namespace
     };
     LinkOrCopyType linkOrCopyType;
     std::string sourceForLinkOrCopy;
-    Path destinationForLinkOrCopy;
+    Poco::Path destinationForLinkOrCopy;
     std::chrono::time_point<std::chrono::steady_clock> linkOrCopyStartTime;
     bool linkOrCopyVerboseLogging = false;
     unsigned linkOrCopyFileCount = 0; // Track to help quantify the link-or-copy performance.
@@ -281,13 +281,13 @@ namespace
 
         assert(fpath[strlen(sourceForLinkOrCopy.c_str())] == '/');
         const char *relativeOldPath = fpath + strlen(sourceForLinkOrCopy.c_str()) + 1;
-        const Path newPath(destinationForLinkOrCopy, Path(relativeOldPath));
+        const Poco::Path newPath(destinationForLinkOrCopy, Poco::Path(relativeOldPath));
 
         switch (typeflag)
         {
         case FTW_F:
         case FTW_SLN:
-            File(newPath.parent()).createDirectories();
+            Poco::File(newPath.parent()).createDirectories();
 
             if (shouldLinkFile(relativeOldPath))
                 linkOrCopyFile(fpath, newPath.toString());
@@ -305,7 +305,8 @@ namespace
                     LOG_TRC("nftw: Skipping redundant path: " << relativeOldPath);
                     return FTW_SKIP_SUBTREE;
                 }
-                File(newPath).createDirectories();
+
+                Poco::File(newPath).createDirectories();
                 struct utimbuf ut;
                 ut.actime = st.st_atime;
                 ut.modtime = st.st_mtime;
@@ -329,7 +330,7 @@ namespace
                 }
                 target[written] = '\0';
 
-                File(newPath.parent()).createDirectories();
+                Poco::File(newPath.parent()).createDirectories();
                 if (symlink(target, newPath.toString().c_str()) == -1)
                 {
                     LOG_SYS("nftw: symlink(\"" << target << "\", \"" << newPath.toString()
@@ -354,7 +355,7 @@ namespace
     }
 
     void linkOrCopy(std::string source,
-                    const Path& destination,
+                    const Poco::Path& destination,
                     LinkOrCopyType type)
     {
         std::string resolved = FileUtil::realpath(source);
@@ -394,7 +395,6 @@ namespace
                                           << " files / second.");
         }
     }
-
 #ifndef __FreeBSD__
     void dropCapability(cap_value_t capability)
     {
@@ -435,10 +435,10 @@ namespace
         cap_free(caps);
     }
 #endif // __FreeBSD__
-#endif
-}
+#endif // BUILDING_TESTS
+} // namespace
 
-#endif
+#endif // !MOBILEAPP
 
 /// A document container.
 /// Owns LOKitDocument instance and connections.

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -2088,7 +2088,6 @@ void lokit_main(
                 const std::string& jailId,
                 const std::string& sysTemplate,
                 const std::string& loTemplate,
-                const std::string& loSubPath,
                 bool noCapabilities,
                 bool noSeccomp,
                 bool queryVersion,
@@ -2142,7 +2141,6 @@ void lokit_main(
     assert(!childRoot.empty());
     assert(!sysTemplate.empty());
     assert(!loTemplate.empty());
-    assert(!loSubPath.empty());
 
     LOG_INF("Kit process for Jail [" << jailId << "] started.");
 
@@ -2172,9 +2170,9 @@ void lokit_main(
                 = std::chrono::steady_clock::now();
 
             userdir_url = "file:///tmp/user";
-            instdir_path = '/' + loSubPath + "/program";
+            instdir_path = '/' + std::string(JailUtil::LO_JAIL_SUBPATH) + "/program";
 
-            Poco::Path jailLOInstallation(jailPath, loSubPath);
+            Poco::Path jailLOInstallation(jailPath, JailUtil::LO_JAIL_SUBPATH);
             jailLOInstallation.makeDirectory();
             const std::string loJailDestPath = jailLOInstallation.toString();
 

--- a/kit/Kit.hpp
+++ b/kit/Kit.hpp
@@ -29,7 +29,6 @@ void lokit_main(
                 const std::string& jailId,
                 const std::string& sysTemplate,
                 const std::string& loTemplate,
-                const std::string& loSubPath,
                 bool noCapabilities,
                 bool noSeccomp,
                 bool queryVersionInfo,
@@ -129,7 +128,6 @@ private:
 void forkLibreOfficeKit(const std::string& childRoot,
                         const std::string& sysTemplate,
                         const std::string& loTemplate,
-                        const std::string& loSubPath,
                         int limit = 0);
 
 /// Anonymize the basename of filenames, preserving the path and extension.

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -380,7 +380,8 @@ static int forkChildren(const int number)
         LOOLWSD::checkDiskSpaceAndWarnClients(false);
 
 #ifdef KIT_IN_PROCESS
-        forkLibreOfficeKit(LOOLWSD::ChildRoot, LOOLWSD::SysTemplate, LOOLWSD::LoTemplate, LO_JAIL_SUBPATH, number);
+        forkLibreOfficeKit(LOOLWSD::ChildRoot, LOOLWSD::SysTemplate, LOOLWSD::LoTemplate,
+                           JailUtil::LO_JAIL_SUBPATH, number);
 #else
         const std::string aMessage = "spawn " + std::to_string(number) + '\n';
         LOG_DBG("MasterToForKit: " << aMessage.substr(0, aMessage.length() - 1));
@@ -1876,7 +1877,7 @@ bool LOOLWSD::createForKit()
     args.push_back("256");
     args.push_back(Path(Application::instance().commandPath()).parent().toString() + "loolforkit");
 #endif
-    args.push_back("--losubpath=" + std::string(LO_JAIL_SUBPATH));
+    args.push_back("--losubpath=" + std::string(JailUtil::LO_JAIL_SUBPATH));
     args.push_back("--systemplate=" + SysTemplate);
     args.push_back("--lotemplate=" + LoTemplate);
     args.push_back("--childroot=" + ChildRoot);

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -380,8 +380,7 @@ static int forkChildren(const int number)
         LOOLWSD::checkDiskSpaceAndWarnClients(false);
 
 #ifdef KIT_IN_PROCESS
-        forkLibreOfficeKit(LOOLWSD::ChildRoot, LOOLWSD::SysTemplate, LOOLWSD::LoTemplate,
-                           JailUtil::LO_JAIL_SUBPATH, number);
+        forkLibreOfficeKit(LOOLWSD::ChildRoot, LOOLWSD::SysTemplate, LOOLWSD::LoTemplate, number);
 #else
         const std::string aMessage = "spawn " + std::to_string(number) + '\n';
         LOG_DBG("MasterToForKit: " << aMessage.substr(0, aMessage.length() - 1));
@@ -1877,7 +1876,6 @@ bool LOOLWSD::createForKit()
     args.push_back("256");
     args.push_back(Path(Application::instance().commandPath()).parent().toString() + "loolforkit");
 #endif
-    args.push_back("--losubpath=" + std::string(JailUtil::LO_JAIL_SUBPATH));
     args.push_back("--systemplate=" + SysTemplate);
     args.push_back("--lotemplate=" + LoTemplate);
     args.push_back("--childroot=" + ChildRoot);

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -613,10 +613,10 @@ public:
         if (!params.has("filename"))
             return;
 
-        // The temporary directory is child-root/<JAIL_TMP_INCOMING_PATH>.
+        // The temporary directory is child-root/<CHILDROOT_TMP_INCOMING_PATH>.
         // Always create a random sub-directory to avoid file-name collision.
         Path tempPath = Path::forDirectory(
-            FileUtil::createRandomTmpDir(LOOLWSD::ChildRoot + JailUtil::JAIL_TMP_INCOMING_PATH)
+            FileUtil::createRandomTmpDir(LOOLWSD::ChildRoot + JailUtil::CHILDROOT_TMP_INCOMING_PATH)
             + '/');
         LOG_TRC("Created temporary convert-to/insert path: " << tempPath.toString());
 
@@ -1230,9 +1230,9 @@ void LOOLWSD::initialize(Application& self)
     }
 
 #if !MOBILEAPP
-    // Setup the jails.
-    JailUtil::setupJails(getConfigValue<bool>(conf, "mount_jail_tree", true), ChildRoot,
-                         SysTemplate);
+    // Setup the Child-Root directory.
+    JailUtil::setupChildRoot(getConfigValue<bool>(conf, "mount_jail_tree", true), ChildRoot,
+                             SysTemplate);
 
     LOG_DBG("FileServerRoot before config: " << FileServerRoot);
     FileServerRoot = getPathFromConfig("file_server_root_path");


### PR DESCRIPTION
Non-functional changes. Non-disruptive to allow cherry-picking to release branches with minimal effort (no large code movements, for example).

Each commit is self contained and has more explanation in the commit-message.

- wsd: jail: rename jails to childroot to distinguish them
- wsd: jail: move LO_JAIL_SUBPATH to JailUtil
- wsd: jail: no need to pass loSubPath between processes
- wsd: jail: add Poco namespace where missing in LinkOrCopy
- wsd: jail: encapsulate LinkOrCopy into a class
- wsd: jail: unlink before copying files
- wsd: jail: simplify linkOrCopy member names
