### PR TITLE
Notebookbar Insert Tab: update impress insert tab

### DIFF
--- a/loleaflet/src/control/Control.NotebookbarImpress.js
+++ b/loleaflet/src/control/Control.NotebookbarImpress.js
@@ -2039,6 +2039,28 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 																			'enabled': 'true',
 																			'children': [
 																				{
+																					'id': 'SectionBottom13',
+																					'type': 'toolbox',
+																					'text': '',
+																					'enabled': 'true',
+																					'children': [
+																						{
+																							'type': 'bigtoolitem',
+																							'text': _UNO('.uno:InsertPage', 'presentation'),
+																							'command': '.uno:InsertPage'
+																						}
+																					]
+																				}
+																			],
+																			'vertical': 'false'
+																		},
+																		{
+																			'id': 'Insert-Section-Pages',
+																			'type': 'container',
+																			'text': '',
+																			'enabled': 'true',
+																			'children': [
+																				{
 																					'id': 'GroupB29',
 																					'type': 'container',
 																					'text': '',
@@ -2052,8 +2074,8 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 																							'children': [
 																								{
 																									'type': 'toolitem',
-																									'text': _UNO('.uno:InsertPage', 'presentation'),
-																									'command': '.uno:InsertPage'
+																									'text': _UNO('.uno:DuplicatePage', 'presentation'),
+																									'command': '.uno:DuplicatePage'
 																								}
 																							]
 																						},
@@ -2064,9 +2086,10 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 																							'enabled': 'true',
 																							'children': [
 																								{
-																									'type': 'toolitem',
-																									'text': _UNO('.uno:DuplicatePage', 'presentation'),
-																									'command': '.uno:DuplicatePage'
+																									'id': 'selectbackground',
+																									'type': 'menubartoolitem',
+																									'text': _UNO('.uno:SelectBackground', 'presentation'),
+																									'command': ''
 																								}
 																							]
 																						}
@@ -2075,28 +2098,6 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 																				}
 																			],
 																			'vertical': 'false'
-																		},
-																		{
-																			'id': 'Insert-Section-Table',
-																			'type': 'container',
-																			'text': '',
-																			'enabled': 'true',
-																			'children': [
-																				{
-																					'id': 'SectionBottom12',
-																					'type': 'toolbox',
-																					'text': '',
-																					'enabled': 'true',
-																					'children': [
-																						{
-																							'type': 'toolitem',
-																							'text': _UNO('.uno:InsertTable', 'presentation'),
-																							'command': '.uno:InsertTable'
-																						}
-																					]
-																				}
-																			],
-																			'vertical': 'true'
 																		},
 																		{
 																			'id': 'Insert-Section-Image',
@@ -2121,29 +2122,51 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 																			'vertical': 'false'
 																		},
 																		{
-																			'id': 'Insert-Section-Table1',
+																			'id': 'Insert-Section-Table',
 																			'type': 'container',
 																			'text': '',
 																			'enabled': 'true',
 																			'children': [
 																				{
-																					'id': 'LineA11',
-																					'type': 'toolbox',
+																					'id': 'GroupB29',
+																					'type': 'container',
 																					'text': '',
 																					'enabled': 'true',
 																					'children': [
 																						{
-																							'type': 'bigtoolitem',
-																							'text': _UNO('.uno:InsertObjectChart'),
-																							'command': '.uno:InsertObjectChart'
+																							'id': 'LineA15',
+																							'type': 'toolbox',
+																							'text': '',
+																							'enabled': 'true',
+																							'children': [
+																								{
+																									'type': 'toolitem',
+																									'text': _UNO('.uno:InsertTable', 'presentation'),
+																									'command': '.uno:InsertTable'
+																								}
+																							]
+																						},
+																						{
+																							'id': 'LineB16',
+																							'type': 'toolbox',
+																							'text': '',
+																							'enabled': 'true',
+																							'children': [
+																								{
+																									'type': 'toolitem',
+																									'text': _UNO('.uno:InsertObjectChart', 'presentation'),
+																									'command': '.uno:InsertObjectChart'
+																								}
+																							]
 																						}
-																					]
+																					],
+																					'vertical': 'true'
 																				}
 																			],
 																			'vertical': 'false'
 																		},
 																		{
-																			'id': 'Insert-Section-Bookmark',
+																			'id': 'Insert-Section-Hyperlink',
 																			'type': 'container',
 																			'text': '',
 																			'enabled': 'true',
@@ -2163,94 +2186,6 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 																				}
 																			],
 																			'vertical': 'false'
-																		},
-																		{
-																			'id': 'Insert-Section-Annotation',
-																			'type': 'container',
-																			'text': '',
-																			'enabled': 'true',
-																			'children': [
-																				{
-																					'id': 'SectionBottom15',
-																					'type': 'toolbox',
-																					'text': '',
-																					'enabled': 'true',
-																					'children': [
-																						{
-																							'type': 'bigtoolitem',
-																							'text': _UNO('.uno:InsertAnnotation', 'presentation'),
-																							'command': '.uno:InsertAnnotation'
-																						}
-																					]
-																				}
-																			],
-																			'vertical': 'false'
-																		},
-																		{
-																			'id': 'Insert-Text',
-																			'type': 'container',
-																			'text': '',
-																			'enabled': 'true',
-																			'children': [
-																				{
-																					'id': 'GroupB293',
-																					'type': 'container',
-																					'text': '',
-																					'enabled': 'true',
-																					'children': [
-																						{
-																							'id': 'LineA153',
-																							'type': 'toolbox',
-																							'text': '',
-																							'enabled': 'true',
-																							'children': [
-																								{
-																									'type': 'toolitem',
-																									'text': _UNO('.uno:Text', 'presentation'),
-																									'command': '.uno:Text'
-																								}
-																							]
-																						},
-																						{
-																							'id': 'LineB163',
-																							'type': 'toolbox',
-																							'text': '',
-																							'enabled': 'true',
-																							'children': [
-																								{
-																									'type': 'toolitem',
-																									'text': _UNO('.uno:VerticalText', 'presentation'),
-																									'command': '.uno:VerticalText'
-																								}
-																							]
-																						}
-																					],
-																					'vertical': 'true'
-																				}
-																			],
-																			'vertical': 'false'
-																		},
-																		{
-																			'id': 'Insert-Section-Draw2',
-																			'type': 'container',
-																			'text': '',
-																			'enabled': 'true',
-																			'children': [
-																				{
-																					'id': 'shapes6',
-																					'type': 'toolbox',
-																					'text': '',
-																					'enabled': 'true',
-																					'children': [
-																						{
-																							'type': 'toolitem',
-																							'text': _UNO('.uno:BasicShapes'),
-																							'command': '.uno:BasicShapes'
-																						}
-																					]
-																				}
-																			],
-																			'vertical': 'true'
 																		},
 																		{
 																			'id': 'Insert-Text',
@@ -2322,6 +2257,72 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 																			'vertical': 'false'
 																		},
 																		{
+																			'id': 'Insert-Section-Text',
+																			'type': 'container',
+																			'text': '',
+																			'enabled': 'true',
+																			'children': [
+																				{
+																					'id': 'shapes6',
+																					'type': 'toolbox',
+																					'text': '',
+																					'enabled': 'true',
+																					'children': [
+																						{
+																							'type': 'bigtoolitem',
+																							'text': _UNO('.uno:Text'),
+																							'command': '.uno:Text'
+																						}
+																					]
+																				}
+																			],
+																			'vertical': 'false'
+																		},
+																		{
+																			'id': 'Insert-Text',
+																			'type': 'container',
+																			'text': '',
+																			'enabled': 'true',
+																			'children': [
+																				{
+																					'id': 'GroupB293',
+																					'type': 'container',
+																					'text': '',
+																					'enabled': 'true',
+																					'children': [
+																						{
+																							'id': 'LineA153',
+																							'type': 'toolbox',
+																							'text': '',
+																							'enabled': 'true',
+																							'children': [
+																								{
+																									'type': 'toolitem',
+																									'text': _UNO('.uno:BasicShapes', 'presentation'),
+																									'command': '.uno:BasicShapes'
+																								}
+																							]
+																						},
+																						{
+																							'id': 'LineB163',
+																							'type': 'toolbox',
+																							'text': '',
+																							'enabled': 'true',
+																							'children': [
+																								{
+																									'type': 'toolitem',
+																									'text': _UNO('.uno:VerticalText', 'presentation'),
+																									'command': '.uno:VerticalText'
+																								}
+																							]
+																						}
+																					],
+																					'vertical': 'true'
+																				}
+																			],
+																			'vertical': 'false'
+																		},
+																		{
 																			'id': 'Insert-Section-Symbol',
 																			'type': 'container',
 																			'text': '',
@@ -2359,29 +2360,6 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 																							'type': 'bigtoolitem',
 																							'text': _UNO('.uno:HeaderAndFooter', 'presentation'),
 																							'command': '.uno:HeaderAndFooter'
-																						}
-																					]
-																				}
-																			],
-																			'vertical': 'false'
-																		},
-																		{
-																			'id': 'Insert-Section-Background',
-																			'type': 'container',
-																			'text': '',
-																			'enabled': 'true',
-																			'children': [
-																				{
-																					'id': 'Section2',
-																					'type': 'toolbox',
-																					'text': '',
-																					'enabled': 'true',
-																					'children': [
-																						{
-																							'id': 'selectbackground',
-																							'type': 'menubartoolitem',
-																							'text': _UNO('.uno:SelectBackground', 'presentation'),
-																							'command': ''
 																						}
 																					]
 																				}


### PR DESCRIPTION
Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: Iadae860ec5bb82d84e262eaf5bc602f2ce304758

Before
![Screenshot_20201219_233454](https://user-images.githubusercontent.com/8517736/102701042-3131d400-4253-11eb-93f2-ca68ef1a3cff.png)

After pull request
![Screenshot_20201219_233424](https://user-images.githubusercontent.com/8517736/102701044-342cc480-4253-11eb-9ff1-501642c768ed.png)

LibreOffice (Desktop)
![Screenshot_20201219_233516](https://user-images.githubusercontent.com/8517736/102701045-38f17880-4253-11eb-8391-9481dbb833a3.png)

With the PR the Impress Insert tab follow how it look on desktop (exclusive the non existing commands) and the layout is similar to how NB's are designed. Each group start with one big button and than the commands are arranged in two columns.