### PR TITLE
private/pedro/cherry pick jsdialogbits drag fixed

### DIFF
--- a/loleaflet/css/btns.css
+++ b/loleaflet/css/btns.css
@@ -1,5 +1,6 @@
 .loleaflet-annotation-edit #annotation-cancel,
-.ui-button-box #cancel,
+.ui-button-box.jsdialog #cancel,
+.ui-button-box.autofilter #cancel,
 .cell.jsdialog > button:not(#ok),
 .ui-button-box.jsdialog button:not(#ok),
 .jsdialog-container #source-button,
@@ -23,7 +24,8 @@
 
 .loleaflet-annotation-edit #annotation-save,
 #annotation-reply,
-.ui-button-box #ok,
+.ui-button-box.jsdialog #ok,
+.ui-button-box.autofilter #ok,
 .cell.jsdialog > button,
 .ui-button-box.jsdialog button {
 	height: 32px;

--- a/loleaflet/css/jsdialogs.css
+++ b/loleaflet/css/jsdialogs.css
@@ -302,6 +302,7 @@ td.jsdialog > [id^='table-box'] {
 	top: 1px;
 	left: -18px;
 	cursor: pointer;
+	pointer-events: none;
 }
 
 .ui-listbox[disabled='disabled'] ~ .ui-listbox-arrow {

--- a/loleaflet/css/jsdialogs.css
+++ b/loleaflet/css/jsdialogs.css
@@ -14,7 +14,7 @@
 }
 
 .jsdialog.vertical p, .ui-frame-label {
-	margin-bottom: 0px;
+	margin: 0px;
 	color: #666;
 	font-size: 10px;
 	font-weight: bold;
@@ -283,7 +283,7 @@ td.jsdialog > [id^='table-box'] {
 	border-radius: 3px;
 	padding-right: 2em;
 	padding-left: 0.4em;
-	margin: 2px 0px 14px;
+	margin: 2px 0px;
 	background-color: #F1F1F1;
 }
 

--- a/loleaflet/css/jsdialogs.css
+++ b/loleaflet/css/jsdialogs.css
@@ -309,6 +309,16 @@ td.jsdialog > [id^='table-box'] {
 	cursor: auto;
 }
 
+/* button box */
+
+.jsdialog.ui-button-box.end .ui-button-box-right {
+	float: right;
+}
+
+.jsdialog.ui-button-box-left {
+	float: left;
+}
+
 /* Autofilter dropdown */
 
 .autofilter.row {

--- a/loleaflet/css/mobilewizard.css
+++ b/loleaflet/css/mobilewizard.css
@@ -904,7 +904,8 @@ input[type='checkbox'][disabled] {
 	width: -webkit-fill-available !important;
 }
 
-.ui-edit.mobile-wizard {
+.ui-edit.mobile-wizard,
+.ui-textarea.mobile-wizard {
 	/*
 	, textarea was also here assign but it was messing up with all textareas (annotations on desktop and vex on mobile):
 	- added 93038: jsdialog: style dialogs; a5016d547c6242f6f9b28748b5724b0bc10cdb67

--- a/loleaflet/src/control/Control.JSDialog.js
+++ b/loleaflet/src/control/Control.JSDialog.js
@@ -82,12 +82,14 @@ L.Control.JSDialog = L.Control.extend({
 		hammerTitlebar.on('panmove', this.onPan.bind(this));
 		hammerTitlebar.on('hammer.input', onInput);
 
-		var hammerContent = new Hammer(content);
-		hammerContent.add(new Hammer.Pan({ threshold: 20, pointers: 0 }));
+		if (window.mode.isTablet()) {
+			var hammerContent = new Hammer(content);
+			hammerContent.add(new Hammer.Pan({ threshold: 20, pointers: 0 }));
 
-		hammerContent.on('panstart', this.onPan.bind(this));
-		hammerContent.on('panmove', this.onPan.bind(this));
-		hammerContent.on('hammer.input', onInput);
+			hammerContent.on('panstart', this.onPan.bind(this));
+			hammerContent.on('panmove', this.onPan.bind(this));
+			hammerContent.on('hammer.input', onInput);
+		}
 
 		if (posX === 0 && posY === 0) {
 			posX = window.innerWidth/2 - container.offsetWidth/2;

--- a/loleaflet/src/control/Control.JSDialog.js
+++ b/loleaflet/src/control/Control.JSDialog.js
@@ -60,41 +60,34 @@ L.Control.JSDialog = L.Control.extend({
 			builder.callback('dialog', 'close', {id: '__DIALOG__'}, null, builder);
 		};
 
-		var hammerTitlebar = new Hammer(titlebar);
-		hammerTitlebar.add(new Hammer.Pan({ threshold: 20, pointers: 0 }));
-
-		hammerTitlebar.on('panstart', this.onPan.bind(this));
-		hammerTitlebar.on('panmove', this.onPan.bind(this));
-		hammerTitlebar.on('hammer.input', function(ev) {
+		var onInput = function(ev) {
 			if (ev.isFirst)
 				that.draggingObject = container;
 
-			if (ev.isFinal && that.draggingObject) {
+			if (ev.isFinal && that.draggingObject
+				&& that.draggingObject.translateX
+				&& that.draggingObject.translateY) {
 				that.draggingObject.startX = that.draggingObject.translateX;
 				that.draggingObject.startY = that.draggingObject.translateY;
 				that.draggingObject.translateX = 0;
 				that.draggingObject.translateY = 0;
 				that.draggingObject = null;
 			}
-		});
+		};
+
+		var hammerTitlebar = new Hammer(titlebar);
+		hammerTitlebar.add(new Hammer.Pan({ threshold: 20, pointers: 0 }));
+
+		hammerTitlebar.on('panstart', this.onPan.bind(this));
+		hammerTitlebar.on('panmove', this.onPan.bind(this));
+		hammerTitlebar.on('hammer.input', onInput);
 
 		var hammerContent = new Hammer(content);
 		hammerContent.add(new Hammer.Pan({ threshold: 20, pointers: 0 }));
 
 		hammerContent.on('panstart', this.onPan.bind(this));
 		hammerContent.on('panmove', this.onPan.bind(this));
-		hammerContent.on('hammer.input', function(ev) {
-			if (ev.isFirst)
-				that.draggingObject = container;
-
-			if (ev.isFinal && that.draggingObject) {
-				that.draggingObject.startX = that.draggingObject.translateX;
-				that.draggingObject.startY = that.draggingObject.translateY;
-				that.draggingObject.translateX = 0;
-				that.draggingObject.translateY = 0;
-				that.draggingObject = null;
-			}
-		});
+		hammerContent.on('hammer.input', onInput);
 
 		if (posX === 0 && posY === 0) {
 			posX = window.innerWidth/2 - container.offsetWidth/2;

--- a/loleaflet/src/control/Control.JSDialogBuilder.js
+++ b/loleaflet/src/control/Control.JSDialogBuilder.js
@@ -206,6 +206,9 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		if (data.max != undefined)
 			$(spinfield).attr('max', data.max);
 
+		if (data.step != undefined)
+			$(spinfield).attr('step', data.step);
+
 		if (data.enabled == 'false') {
 			$(spinfield).attr('disabled', 'disabled');
 		}

--- a/loleaflet/src/control/Control.JSDialogBuilder.js
+++ b/loleaflet/src/control/Control.JSDialogBuilder.js
@@ -1613,7 +1613,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 
 		var li = L.DomUtil.create('li', builder.options.cssClass, parentContainer);
 
-		if (!disabled) {
+		if (!disabled && entry.state == null) {
 			li.draggable = true;
 
 			li.ondragstart = function drag(ev) {
@@ -1686,7 +1686,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			}
 		}
 
-		if (!disabled) {
+		if (!disabled && entry.state == null) {
 			$(text).click(function() {
 				$('#' + treeViewData.id + ' .ui-treeview-entry').removeClass('selected');
 				$(span).addClass('selected');

--- a/loleaflet/src/control/Control.JSDialogBuilder.js
+++ b/loleaflet/src/control/Control.JSDialogBuilder.js
@@ -1416,7 +1416,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		if (data.cursor && (data.cursor === 'false' || data.cursor === false))
 			controlType = 'p';
 
-		var edit = L.DomUtil.create(controlType, '', parentContainer);
+		var edit = L.DomUtil.create(controlType, 'ui-textarea ' + builder.options.cssClass, parentContainer);
 
 		if (controlType === 'textarea')
 			edit.value = builder._cleanText(data.text);

--- a/loleaflet/src/control/Control.JSDialogBuilder.js
+++ b/loleaflet/src/control/Control.JSDialogBuilder.js
@@ -402,7 +402,6 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		}
 
 		var left = L.DomUtil.create('div', builder.options.cssClass + ' ui-button-box-left', container);
-		$(left).css('float', 'left');
 
 		for (i in leftAlignButtons) {
 			child = leftAlignButtons[i];
@@ -411,7 +410,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 
 		var right = L.DomUtil.create('div', builder.options.cssClass + ' ui-button-box-right', container);
 		if (data.layoutstyle && data.layoutstyle === 'end')
-			$(right).css('float', 'right');
+			L.DomUtil.addClass(container, 'end');
 
 		for (i in rightAlignButton) {
 			child = rightAlignButton[i];

--- a/loleaflet/src/control/Control.MobileWizardBuilder.js
+++ b/loleaflet/src/control/Control.MobileWizardBuilder.js
@@ -64,6 +64,9 @@ L.Control.MobileWizardBuilder = L.Control.JSDialogBuilder.extend({
 		if (data.max != undefined)
 			$(spinfield).attr('max', data.max);
 
+		if (data.step != undefined)
+			$(spinfield).attr('step', data.step);
+
 		if (data.enabled == 'false') {
 			$(spinfield).attr('disabled', 'disabled');
 			$(image).addClass('disabled');


### PR DESCRIPTION
- JSDialog: Checkbox's parent shouldn't get dragged or selected plus label improvements
- jsdialog: don't override mobilewizard buttons
- jsdialog: fix textarea position in mobile-wizard
- jsdialog: make draggable also on tablet
- jsdialog: support step in spinfields
- jsdialog: fix dialog jumping
- jsdialog: open dropdown also when clicked on arrow
- jsdialog: pan gesture on dialog content only on tablets
