### PR TITLE
NB updates

### DIFF
--- a/loleaflet/src/control/Control.NotebookbarCalc.js
+++ b/loleaflet/src/control/Control.NotebookbarCalc.js
@@ -129,68 +129,125 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 																			'text': '',
 																			'enabled': 'true',
 																			'children': [
+																				{
+																					'id': 'File-Section-Save',
+																					'type': 'container',
+																					'text': '',
+																					'enabled': 'true',
+																					'children': [
+																						{
+																							'id': 'SectionBottom65',
+																							'type': 'toolbox',
+																							'text': '',
+																							'enabled': 'true',
+																							'children': [
+																								{
+																									'type': 'bigtoolitem',
+																									'text': _UNO('.uno:Save'),
+																									'command': '.uno:Save'
+																								}
+																							]
+																						}
+																					],
+																					'vertical': 'false'
+																				},
 																				hasSaveAs ?
 																					{
-																						'id': 'Section2',
-																						'type': 'toolbox',
+																						'id': 'File-Section-Saveas',
+																						'type': 'container',
 																						'text': '',
 																						'enabled': 'true',
 																						'children': [
 																							{
-																								'id': 'saveas',
-																								'type': 'menubartoolitem',
-																								'text': _UNO('.uno:SaveAs', 'spreadsheet'),
-																								'command': ''
+																								'id': 'SectionBottom61',
+																								'type': 'toolbox',
+																								'text': '',
+																								'enabled': 'true',
+																								'children': [
+																									{
+																										'id': 'saveas',
+																										'type': 'bigtoolitem',
+																										'text': _UNO('.uno:SaveAs', 'spreadsheet'),
+																										'command': ''
+																									}
+																								]
 																							}
-																						]
+																						],
+																						'vertical': 'false'
 																					} : {},
 																				hasShare ?
 																					{
-																						'id': 'Section3',
-																						'type': 'toolbox',
+																						'id': 'File-Section-Share',
+																						'type': 'container',
 																						'text': '',
 																						'enabled': 'true',
 																						'children': [
 																							{
-																								'id': 'shareas',
-																								'type': 'menubartoolitem',
-																								'text': _('Share...'),
-																								'command': ''
+																								'id': 'SectionBottom62',
+																								'type': 'toolbox',
+																								'text': '',
+																								'enabled': 'true',
+																								'children': [
+																									{
+																										'id': 'shareas',
+																										'type': 'bigtoolitem',
+																										'text': _('Share...'),
+																										'command': ''
+																									}
+																								]
 																							}
-																						]
+																						],
+																						'vertical': 'false'
 																					} : {},
 																				hasPrint ?
 																					{
-																						'id': 'Section4',
-																						'type': 'toolbox',
+																						'id': 'File-Section-Print',
+																						'type': 'container',
 																						'text': '',
 																						'enabled': 'true',
 																						'children': [
 																							{
-																								'id': 'print',
-																								'type': 'menubartoolitem',
-																								'text': _UNO('.uno:Print', 'spreadsheet'),
-																								'command': ''
+																								'id': 'SectionBottom66',
+																								'type': 'toolbox',
+																								'text': '',
+																								'enabled': 'true',
+																								'children': [
+																									{
+																										'type': 'bigtoolitem',
+																										'text': _UNO('.uno:Print', 'spreadsheet'),
+																										'command': '.uno:Print'
+																									}
+																								]
 																							}
-																						]
+																						],
+																						'vertical': 'false'
 																					} : {},
 																				hasRevisionHistory ?
 																					{
-																						'id': 'Section5',
-																						'type': 'toolbox',
+																						'id': 'File-Section-Revision',
+																						'type': 'container',
 																						'text': '',
 																						'enabled': 'true',
 																						'children': [
 																							{
-																								'id': 'rev-history',
-																								'type': 'menubartoolitem',
-																								'text': _('See revision history'),
-																								'command': ''
+																								'id': 'SectionBottom66',
+																								'type': 'toolbox',
+																								'text': '',
+																								'enabled': 'true',
+																								'children': [
+																									{
+																										'id': 'rev-history',
+																										'type': 'bigtoolitem',
+																										'text': _('See revision history'),
+																										'command': ''
+																									}
+																								]
 																							}
-																						]
+																						],
+																						'vertical': 'false'
 																					} : {},
 																				{
-																					'id': 'saveas-Section',
+																					'id': 'File-Section-Export',
 																					'type': 'container',
 																					'text': '',
 																					'enabled': 'true',
@@ -243,7 +300,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 																					]
 																				},
 																				{
-																					'id': 'saveas-Section',
+																					'id': 'File-Section-Export-2',
 																					'type': 'container',
 																					'text': '',
 																					'enabled': 'true',


### PR DESCRIPTION
Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I86e4eec764dcbe3771d0d381e078bbbb57665c3f

Calc file tab: bottom align labels

I use `'type': 'bigtoolitem',` like it is know from writer instead of `'type': 'menubartoolitem',` which arrangement is the one you prefer @eszkadev ? the layout from writer or from calc.