### PR TITLE
g review: fix advice on how to update the existing PR ...

### DIFF
--- a/g
+++ b/g
@@ -49,7 +49,9 @@ if [ "$1" == "review" ]; then
     fi
     if [ -n "$HAS_REMOTE_BRANCH" ] && [ -z "$CUSTOM_BRANCH" ]; then
         echo "Error: default remote branch would be '$REMOTE_BRANCH', but it already exists."
-        echo "To update the existing PR: type './g review $BRANCH' explicitly."
+        # Use $TRACKED_BRANCH, because we push to $REMOTE_BRANCH, which derives from
+        # $TRACKED_BRANCH, not $BRANCH.
+        echo "To update the existing PR: type './g review $TRACKED_BRANCH' explicitly."
         exit 1
     elif [ -n "$HAS_REMOTE_BRANCH" ] && [ -n "$CUSTOM_BRANCH" ]; then
         # PR is open, same branch is explicitly specified, just update it.


### PR DESCRIPTION
In case the local branch name and the remote branch name is different.

E.g. if you had co-6-4 tracking origin/distro/collabora/co-6-4, then the
correct advice is './g review distro/collabora/co-6-4', not './g review
co-6-4'.

(cherry picked from commit b47a4e7f53c54e8a1eb9c0e5a1aac2746e1ec530)

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I6b5556f992e30756542ed8e1f1cc15e61ce9bffa
