### PR TITLE
leaflet: allow document scrolling when mouse is over annotations

### DIFF
--- a/loleaflet/src/layer/marker/Annotation.js
+++ b/loleaflet/src/layer/marker/Annotation.js
@@ -29,10 +29,12 @@ L.Annotation = L.Layer.extend({
 			this._initLayout();
 		}
 
-		L.DomEvent.on(this._container, {
-			mousewheel: this._map.scrollHandler._onWheelScroll,
-			MozMousePixelScroll: L.DomEvent.preventDefault
-		}, this._map.scrollHandler);
+		if (window.mode.isDesktop()) {
+			L.DomEvent.on(this._container, {
+				mousewheel: this._map.scrollHandler._onWheelScroll,
+				MozMousePixelScroll: L.DomEvent.preventDefault
+			}, this._map.scrollHandler);
+		}
 
 		map._panes.popupPane.appendChild(this._container);
 		this.update();

--- a/loleaflet/src/layer/marker/Annotation.js
+++ b/loleaflet/src/layer/marker/Annotation.js
@@ -29,6 +29,11 @@ L.Annotation = L.Layer.extend({
 			this._initLayout();
 		}
 
+		L.DomEvent.on(this._container, {
+			mousewheel: this._map.scrollHandler._onWheelScroll,
+			MozMousePixelScroll: L.DomEvent.preventDefault
+		}, this._map.scrollHandler);
+
 		map._panes.popupPane.appendChild(this._container);
 		this.update();
 	},


### PR DESCRIPTION
Signed-off-by: Pranam Lashkari <lpranam@collabora.com>
Change-Id: I9bb092a053b61f9cdd13c020b1349ae753d2289a


* Target version: distro/collabora/co-6-4

### Summary
problem: the user could not scroll sometimes when there are too many annotations and the mouse is over an annotation. This will make things more convenient for the user.


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

