### PR TITLE
Test improvements for stability and maintainability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,8 @@ gtk/mobile
 .eclipsesettingfile
 eclipsesettingfile.xml
 .clang_complete
+.clangd
+.cache
 .cxx_tags
 .yavide_proj
 .yavide_session

--- a/Makefile.am
+++ b/Makefile.am
@@ -288,6 +288,7 @@ noinst_HEADERS = $(wsd_headers) $(shared_headers) $(kit_headers) \
                  test/countloolkits.hpp \
                  test/lokassert.hpp \
                  test/test.hpp \
+                 test/testlog.hpp \
                  test/helpers.hpp
 
 dist-hook:

--- a/common/LOOLWebSocket.hpp
+++ b/common/LOOLWebSocket.hpp
@@ -162,19 +162,24 @@ public:
         std::ostringstream result;
         switch (flags & Poco::Net::WebSocket::FRAME_OP_BITMASK)
         {
-#define CASE(x) case Poco::Net::WebSocket::FRAME_OP_##x: result << #x; break
-        CASE(CONT);
-        CASE(TEXT);
-        CASE(BINARY);
-        CASE(CLOSE);
-        CASE(PING);
-        CASE(PONG);
+#define CASE(x)                                                                                    \
+    case Poco::Net::WebSocket::FRAME_OP_##x:                                                       \
+        result << #x << " (0x" << std::hex << flags << ')';                                        \
+        break
+            CASE(CONT);
+            CASE(TEXT);
+            CASE(BINARY);
+            CASE(CLOSE);
+            CASE(PING);
+            CASE(PONG);
 #undef CASE
-        default:
-            result << Poco::format("%#x", flags);
-            break;
+            default:
+                result << "UNKNOWN (0x" << std::hex << flags << ')';
+                break;
         }
-        result << ' ' << std::setw(3) << length << " bytes";
+
+        result << ' ' << std::setw(3) << length << " bytes"
+               << (flags & Poco::Net::WebSocket::FRAME_FLAG_FIN ? " (FIN)" : "");
 
         if (length > 0 &&
             ((flags & Poco::Net::WebSocket::FRAME_OP_BITMASK) == Poco::Net::WebSocket::FRAME_OP_TEXT ||

--- a/common/Unit.cpp
+++ b/common/Unit.cpp
@@ -202,7 +202,11 @@ void UnitBase::exitTest(TestResult result)
         return;
     }
 
-    LOG_INF("exitTest: " << testResultAsString(result) << ". Flagging to shutdown.");
+    if (result == TestResult::Ok)
+        LOG_INF("SUCCESS: exitTest: " << testResultAsString(result) << ". Flagging to shutdown.");
+    else
+        LOG_ERR("FAILURE: exitTest: " << testResultAsString(result) << ". Flagging to shutdown.");
+
     _setRetValue = true;
     _retValue = result == TestResult::Ok ? EX_OK : EX_SOFTWARE;
 #if !MOBILEAPP

--- a/common/Unit.cpp
+++ b/common/Unit.cpp
@@ -154,8 +154,9 @@ UnitBase::~UnitBase()
     _dlHandle = nullptr;
 }
 
-UnitWSD::UnitWSD()
-    : _hasKitHooks(false)
+UnitWSD::UnitWSD(std::string testname)
+    : UnitBase(std::move(testname))
+    , _hasKitHooks(false)
 {
 }
 

--- a/common/Unit.cpp
+++ b/common/Unit.cpp
@@ -90,14 +90,14 @@ bool UnitBase::init(UnitType type, const std::string &unitLibPath)
                     TimeoutThreadRunning = true;
                     Util::setThreadName("unit timeout");
 
-                    if (TimeoutThreadMutex.try_lock_for(std::chrono::milliseconds(Global->_timeoutMilliSeconds)))
+                    if (TimeoutThreadMutex.try_lock_for(Global->_timeoutMilliSeconds))
                     {
                         LOG_DBG("Unit test finished in time");
                         TimeoutThreadMutex.unlock();
                     }
                     else
                     {
-                        LOG_ERR("Unit test timeout");
+                        LOG_ERR("Unit test timeout after " << Global->_timeoutMilliSeconds);
                         Global->timeout();
                     }
                     TimeoutThreadRunning = false;
@@ -217,7 +217,8 @@ void UnitBase::exitTest(TestResult result)
 
 void UnitBase::timeout()
 {
-    if (isUnitTesting())
+    // Don't timeout if we had already finished.
+    if (isUnitTesting() && !_setRetValue)
     {
         LOG_ERR("Timed out waiting for unit test to complete");
         exitTest(TestResult::TimedOut);

--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -89,6 +89,12 @@ protected:
     void exitTest(TestResult result);
 
     UnitBase();
+    UnitBase(std::string name)
+        : UnitBase()
+    {
+        _testname = std::move(name);
+    }
+
     virtual ~UnitBase();
 
 public:
@@ -157,6 +163,9 @@ public:
 
     static std::string getUnitLibPath() { return std::string(UnitLibPath); }
 
+    const std::string& getTestname() const { return _testname; }
+    void setTestname(const std::string& testname) { _testname = testname; }
+
 private:
     void setHandle(void *dlHandle)
     {
@@ -171,6 +180,9 @@ private:
     std::chrono::milliseconds _timeoutMilliSeconds;
     static UnitBase *Global;
     UnitType _type;
+
+    /// The name of the current test.
+    std::string _testname;
 };
 
 /// Derive your WSD unit test / hooks from me.
@@ -179,7 +191,8 @@ class UnitWSD : public UnitBase
     bool _hasKitHooks;
 
 public:
-    UnitWSD();
+    UnitWSD(std::string testname = std::string());
+
     virtual ~UnitWSD();
 
     static UnitWSD& get()

--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <test/testlog.hpp>
+
 #include <atomic>
 #include <cassert>
 #include <chrono>
@@ -219,8 +221,28 @@ public:
 
     /// Manipulate and modify the configuration before any usage.
     virtual void configure(Poco::Util::LayeredConfiguration& /* config */);
-    /// Main-loop reached, time for testing
-    virtual void invokeTest() {}
+
+    /// Main-loop reached, time for testing.
+    /// Invoked from loolwsd's main thread.
+    void invokeTest()
+    {
+        try
+        {
+            // Invoke the test, expect no exceptions.
+            invokeWSDTest();
+        }
+        catch (const std::exception& ex)
+        {
+            LOG_TST("ERROR: unexpected exception while invoking WSD Test: " << ex.what());
+            exitTest(TestResult::Failed);
+        }
+        catch (...)
+        {
+            LOG_TST("ERROR: unexpected unknown exception while invoking WSD Test");
+            exitTest(TestResult::Failed);
+        }
+    }
+
     /// When a new child kit process reports
     virtual void newChild(WebSocketHandler &/* socket */) {}
     /// Intercept createStorage
@@ -280,6 +302,9 @@ public:
     virtual void onTileCacheSubscribe(int /*part*/, int /*width*/, int /*height*/,
                                       int /*tilePosX*/, int /*tilePosY*/,
                                       int /*tileWidth*/, int /*tileHeight*/) {}
+private:
+    /// The actual test implementation.
+    virtual void invokeWSDTest() {}
 };
 
 /// Derive your Kit unit test / hooks from me.

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -101,7 +101,8 @@ unittest_LDADD += -lssl -lcrypto
 unit_base_la_LIBADD += -lssl -lcrypto
 endif
 
-fakesockettest_SOURCES = fakesockettest.cpp ../net/FakeSocket.cpp
+fakesockettest_CPPFLAGS = -g
+fakesockettest_SOURCES = fakesockettest.cpp  ../net/FakeSocket.cpp ../common/Log.cpp ../common/Util.cpp
 fakesockettest_LDADD = $(CPPUNIT_LIBS)
 
 # old-style unit tests - bootstrapped via UnitClient

--- a/test/UnitAdmin.cpp
+++ b/test/UnitAdmin.cpp
@@ -426,7 +426,7 @@ public:
     }
 
     // Runs tests sequentially in _tests
-    virtual void invokeTest()
+    virtual void invokeWSDTest()
     {
         if (!_isTestRunning)
         {

--- a/test/UnitBadDocLoad.cpp
+++ b/test/UnitBadDocLoad.cpp
@@ -33,7 +33,7 @@ class UnitBadDocLoad : public UnitWSD
     TestResult testMaxViews();
 
 public:
-    void invokeTest() override;
+    void invokeWSDTest() override;
 };
 
 UnitBase::TestResult UnitBadDocLoad::testBadDocLoadFail()
@@ -247,7 +247,7 @@ UnitBase::TestResult UnitBadDocLoad::testMaxViews()
     return TestResult::Ok;
 }
 
-void UnitBadDocLoad::invokeTest()
+void UnitBadDocLoad::invokeWSDTest()
 {
     UnitBase::TestResult result = testBadDocLoadFail();
     if (result != TestResult::Ok)

--- a/test/UnitCalc.cpp
+++ b/test/UnitCalc.cpp
@@ -68,7 +68,7 @@ class UnitCalc : public UnitWSD
     TestResult testOptimalResize();
 
 public:
-    void invokeTest() override;
+    void invokeWSDTest() override;
 };
 
 UnitBase::TestResult UnitCalc::testCalcEditRendering()
@@ -454,7 +454,7 @@ UnitBase::TestResult UnitCalc::testOptimalResize()
     return TestResult::Ok;
 }
 
-void UnitCalc::invokeTest()
+void UnitCalc::invokeWSDTest()
 {
     UnitBase::TestResult result = testCalcEditRendering();
     if (result != TestResult::Ok)

--- a/test/UnitClient.cpp
+++ b/test/UnitClient.cpp
@@ -11,6 +11,7 @@
 
 #include <config.h>
 
+#define TST_LOG_REDIRECT
 #include <Unit.hpp>
 #include <wsd/LOOLWSD.hpp>
 
@@ -48,7 +49,7 @@ public:
         config.setBool("ssl.enable", true);
     }
 
-    void invokeTest() override
+    void invokeWSDTest() override
     {
         // this method gets called every few seconds.
         if (_workerStarted)

--- a/test/UnitClose.cpp
+++ b/test/UnitClose.cpp
@@ -49,7 +49,7 @@ class UnitClose : public UnitWSD
 
 public:
     UnitClose();
-    void invokeTest() override;
+    void invokeWSDTest() override;
 };
 
 UnitBase::TestResult UnitClose::testCloseAfterClose()
@@ -215,7 +215,7 @@ UnitClose::UnitClose()
     setTimeout(timeout_minutes);
 }
 
-void UnitClose::invokeTest()
+void UnitClose::invokeWSDTest()
 {
     UnitBase::TestResult result = testCloseAfterClose();
     if (result != TestResult::Ok)

--- a/test/UnitConvert.cpp
+++ b/test/UnitConvert.cpp
@@ -76,7 +76,7 @@ public:
         return response.getStatus() == Poco::Net::HTTPResponse::HTTPStatus::HTTP_OK;
     }
 
-    void invokeTest() override
+    void invokeWSDTest() override
     {
         if (_workerStarted)
             return;

--- a/test/UnitCopyPaste.cpp
+++ b/test/UnitCopyPaste.cpp
@@ -215,7 +215,7 @@ public:
         return clipData.str();
     }
 
-    void invokeTest() override
+    void invokeWSDTest() override
     {
         std::string testname = "copypaste";
 

--- a/test/UnitCursor.cpp
+++ b/test/UnitCursor.cpp
@@ -115,7 +115,7 @@ class UnitCursor : public UnitWSD
     TestResult testInsertAnnotationCalc();
 
 public:
-    void invokeTest() override;
+    void invokeWSDTest() override;
 };
 
 UnitBase::TestResult UnitCursor::testMaxColumn()
@@ -378,7 +378,7 @@ UnitBase::TestResult UnitCursor::testInsertAnnotationCalc()
     return TestResult::Ok;
 }
 
-void UnitCursor::invokeTest()
+void UnitCursor::invokeWSDTest()
 {
     UnitBase::TestResult result = testMaxColumn();
     if (result != TestResult::Ok)

--- a/test/UnitEachView.cpp
+++ b/test/UnitEachView.cpp
@@ -113,7 +113,7 @@ class UnitEachView : public UnitWSD
 
 public:
     UnitEachView();
-    void invokeTest() override;
+    void invokeWSDTest() override;
 };
 
 UnitBase::TestResult UnitEachView::testInvalidateViewCursor()
@@ -163,7 +163,7 @@ UnitEachView::UnitEachView()
     setTimeout(std::chrono::seconds(240));
 }
 
-void UnitEachView::invokeTest()
+void UnitEachView::invokeWSDTest()
 {
     UnitBase::TestResult result = testInvalidateViewCursor();
     if (result != TestResult::Ok)

--- a/test/UnitHTTP.cpp
+++ b/test/UnitHTTP.cpp
@@ -218,7 +218,7 @@ public:
         }
     }
 
-    void invokeTest() override
+    void invokeWSDTest() override
     {
         testChunks();
         testContinue();

--- a/test/UnitHosting.cpp
+++ b/test/UnitHosting.cpp
@@ -35,7 +35,7 @@ class UnitHosting : public UnitWSD
     TestResult testCapabilities();
 
 public:
-    void invokeTest() override;
+    void invokeWSDTest() override;
 };
 
 UnitBase::TestResult UnitHosting::testDiscovery()
@@ -130,7 +130,7 @@ UnitBase::TestResult UnitHosting::testCapabilities()
     return TestResult::Ok;
 }
 
-void UnitHosting::invokeTest()
+void UnitHosting::invokeWSDTest()
 {
     UnitBase::TestResult result = testDiscovery();
     if (result != TestResult::Ok)

--- a/test/UnitInsertDelete.cpp
+++ b/test/UnitInsertDelete.cpp
@@ -81,7 +81,7 @@ class UnitInsertDelete : public UnitWSD
     TestResult testCursorPosition();
 
 public:
-    void invokeTest() override;
+    void invokeWSDTest() override;
 };
 
 UnitBase::TestResult UnitInsertDelete::testInsertDelete()
@@ -305,7 +305,7 @@ UnitBase::TestResult UnitInsertDelete::testCursorPosition()
     return TestResult::Ok;
 }
 
-void UnitInsertDelete::invokeTest()
+void UnitInsertDelete::invokeWSDTest()
 {
     UnitBase::TestResult result = testInsertDelete();
     if (result != TestResult::Ok)

--- a/test/UnitLargePaste.cpp
+++ b/test/UnitLargePaste.cpp
@@ -23,12 +23,12 @@ class UnitLargePaste : public UnitWSD
 public:
     UnitLargePaste();
 
-    void invokeTest() override;
+    void invokeWSDTest() override;
 };
 
 UnitLargePaste::UnitLargePaste() {}
 
-void UnitLargePaste::invokeTest()
+void UnitLargePaste::invokeWSDTest()
 {
     const char testname[] = "UnitLargePaste";
 

--- a/test/UnitLoad.cpp
+++ b/test/UnitLoad.cpp
@@ -54,7 +54,7 @@ class UnitLoad : public UnitWSD
     TestResult testReload();
 
 public:
-    void invokeTest() override;
+    void invokeWSDTest() override;
 };
 
 UnitBase::TestResult UnitLoad::testConnectNoLoad()
@@ -181,7 +181,7 @@ UnitBase::TestResult UnitLoad::testReload()
     return TestResult::Ok;
 }
 
-void UnitLoad::invokeTest()
+void UnitLoad::invokeWSDTest()
 {
     // FIXME fails on Jenkins for some reason.
 #if 0

--- a/test/UnitLoadTorture.cpp
+++ b/test/UnitLoadTorture.cpp
@@ -29,7 +29,7 @@ class UnitLoadTorture : public UnitWSD
 
 public:
     UnitLoadTorture();
-    void invokeTest() override;
+    void invokeWSDTest() override;
 };
 
 int UnitLoadTorture::loadTorture(const std::string& testname, const std::string& docName,
@@ -201,7 +201,7 @@ UnitLoadTorture::UnitLoadTorture()
     setTimeout(timeout_minutes);
 }
 
-void UnitLoadTorture::invokeTest()
+void UnitLoadTorture::invokeWSDTest()
 {
     UnitBase::TestResult result = testLoadTortureODT();
     if (result != TestResult::Ok)

--- a/test/UnitOAuth.cpp
+++ b/test/UnitOAuth.cpp
@@ -86,7 +86,7 @@ public:
             exitTest(TestResult::Ok);
     }
 
-    void invokeTest() override
+    void invokeWSDTest() override
     {
         constexpr char testName[] = "UnitOAuth";
 

--- a/test/UnitOAuth.cpp
+++ b/test/UnitOAuth.cpp
@@ -31,10 +31,11 @@ class UnitOAuth : public WopiTestServer
     bool _finishedHeader;
 
 public:
-    UnitOAuth() :
-        _phase(Phase::LoadToken),
-        _finishedToken(false),
-        _finishedHeader(false)
+    UnitOAuth()
+        : WopiTestServer("UnitOAuth")
+        , _phase(Phase::LoadToken)
+        , _finishedToken(false)
+        , _finishedHeader(false)
     {
     }
 

--- a/test/UnitOOB.cpp
+++ b/test/UnitOOB.cpp
@@ -28,7 +28,7 @@ public:
     {
     }
 
-    virtual void invokeTest() override
+    virtual void invokeWSDTest() override
     {
         UnitHTTPServerResponse response;
         UnitHTTPServerRequest request(response, "nonsense URI");

--- a/test/UnitPasswordProtected.cpp
+++ b/test/UnitPasswordProtected.cpp
@@ -28,7 +28,7 @@ class UnitPasswordProtected : public UnitWSD
     TestResult testPasswordProtectedBinaryMSOfficeDocument();
 
 public:
-    void invokeTest() override;
+    void invokeWSDTest() override;
 };
 
 UnitBase::TestResult UnitPasswordProtected::testPasswordProtectedDocumentWithoutPassword()
@@ -192,7 +192,7 @@ UnitBase::TestResult UnitPasswordProtected::testPasswordProtectedBinaryMSOfficeD
     return TestResult::Ok;
 }
 
-void UnitPasswordProtected::invokeTest()
+void UnitPasswordProtected::invokeWSDTest()
 {
     UnitBase::TestResult result = testPasswordProtectedDocumentWithoutPassword();
     if (result != TestResult::Ok)

--- a/test/UnitPaste.cpp
+++ b/test/UnitPaste.cpp
@@ -21,10 +21,10 @@ class LOOLWebSocket;
 class UnitPaste : public UnitWSD
 {
 public:
-    void invokeTest() override;
+    void invokeWSDTest() override;
 };
 
-void UnitPaste::invokeTest()
+void UnitPaste::invokeWSDTest()
 {
     const char testname[] = "UnitPaste";
 

--- a/test/UnitRenderShape.cpp
+++ b/test/UnitRenderShape.cpp
@@ -72,7 +72,7 @@ class UnitRenderShape : public UnitWSD
     TestResult testRenderShapeSelectionWriterImage();
 
 public:
-    void invokeTest() override;
+    void invokeWSDTest() override;
 };
 
 UnitBase::TestResult UnitRenderShape::testRenderShapeSelectionImpress()
@@ -152,7 +152,7 @@ UnitBase::TestResult UnitRenderShape::testRenderShapeSelectionWriterImage()
     return TestResult::Ok;
 }
 
-void UnitRenderShape::invokeTest()
+void UnitRenderShape::invokeWSDTest()
 {
     UnitBase::TestResult result = testRenderShapeSelectionImpress();
     if (result != TestResult::Ok)

--- a/test/UnitRenderingOptions.cpp
+++ b/test/UnitRenderingOptions.cpp
@@ -21,10 +21,10 @@ class LOOLWebSocket;
 class UnitRenderingOptions : public UnitWSD
 {
 public:
-    void invokeTest() override;
+    void invokeWSDTest() override;
 };
 
-void UnitRenderingOptions::invokeTest()
+void UnitRenderingOptions::invokeWSDTest()
 {
     const char testname[] = "UnitRenderingOptions";
 

--- a/test/UnitSession.cpp
+++ b/test/UnitSession.cpp
@@ -56,7 +56,7 @@ class UnitSession : public UnitWSD
     TestResult testSlideShow();
 
 public:
-    void invokeTest() override;
+    void invokeWSDTest() override;
 };
 
 UnitBase::TestResult UnitSession::testBadRequest()
@@ -243,7 +243,7 @@ UnitBase::TestResult UnitSession::testSlideShow()
     return TestResult::Ok;
 }
 
-void UnitSession::invokeTest()
+void UnitSession::invokeWSDTest()
 {
     UnitBase::TestResult result = testBadRequest();
     if (result != TestResult::Ok)

--- a/test/UnitStorage.cpp
+++ b/test/UnitStorage.cpp
@@ -68,9 +68,9 @@ public:
         }
     }
 
-    void invokeTest() override
+    void invokeWSDTest() override
     {
-        LOG_TRC("invokeTest: " << (int)_phase);
+        LOG_TRC("invokeWSDTest: " << (int)_phase);
         switch (_phase)
         {
         case Phase::Load:

--- a/test/UnitTiffLoad.cpp
+++ b/test/UnitTiffLoad.cpp
@@ -23,12 +23,12 @@ class UnitTiffLoad : public UnitWSD
 public:
     UnitTiffLoad();
 
-    void invokeTest() override;
+    void invokeWSDTest() override;
 };
 
 UnitTiffLoad::UnitTiffLoad() {}
 
-void UnitTiffLoad::invokeTest()
+void UnitTiffLoad::invokeWSDTest()
 {
     const char testname[] = "UnitTiffLoad";
 

--- a/test/UnitTileCache.cpp
+++ b/test/UnitTileCache.cpp
@@ -45,7 +45,7 @@ public:
         exitTest(TestResult::Ok);
     }
 
-    virtual void invokeTest()
+    virtual void invokeWSDTest()
     {
         switch (_phase)
         {

--- a/test/UnitTyping.cpp
+++ b/test/UnitTyping.cpp
@@ -288,7 +288,7 @@ public:
         return res;
     }
 
-    void invokeTest() override
+    void invokeWSDTest() override
     {
         // this method gets called every few seconds.
         if (_workerStarted)

--- a/test/UnitUNOCommand.cpp
+++ b/test/UnitUNOCommand.cpp
@@ -63,7 +63,7 @@ class UnitUNOCommand : public UnitWSD
     TestResult testStateUnoCommandImpress();
 
 public:
-    void invokeTest() override;
+    void invokeWSDTest() override;
 };
 
 UnitBase::TestResult UnitUNOCommand::testStateUnoCommandWriter()
@@ -255,7 +255,7 @@ UnitBase::TestResult UnitUNOCommand::testStateUnoCommandImpress()
     return TestResult::Ok;
 }
 
-void UnitUNOCommand::invokeTest()
+void UnitUNOCommand::invokeWSDTest()
 {
     UnitBase::TestResult result = testStateUnoCommandWriter();
     if (result != TestResult::Ok)

--- a/test/UnitWOPI.cpp
+++ b/test/UnitWOPI.cpp
@@ -35,10 +35,11 @@ class UnitWOPI : public WopiTestServer
     bool _finishedSaveModified;
 
 public:
-    UnitWOPI() :
-        _phase(Phase::LoadAndSave),
-        _finishedSaveUnmodified(false),
-        _finishedSaveModified(false)
+    UnitWOPI()
+        : WopiTestServer("UnitWOPI")
+        , _phase(Phase::LoadAndSave)
+        , _finishedSaveUnmodified(false)
+        , _finishedSaveModified(false)
     {
     }
 

--- a/test/UnitWOPI.cpp
+++ b/test/UnitWOPI.cpp
@@ -80,7 +80,7 @@ public:
             exitTest(TestResult::Ok);
     }
 
-    void invokeTest() override
+    void invokeWSDTest() override
     {
         constexpr char testName[] = "UnitWOPI";
 

--- a/test/UnitWOPIDocumentConflict.cpp
+++ b/test/UnitWOPIDocumentConflict.cpp
@@ -146,7 +146,7 @@ public:
         return false;
     }
 
-    void invokeTest() override
+    void invokeWSDTest() override
     {
         switch (_phase)
         {

--- a/test/UnitWOPIDocumentConflict.cpp
+++ b/test/UnitWOPIDocumentConflict.cpp
@@ -5,6 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include "Util.hpp"
 #include "config.h"
 
 #include "WopiTestServer.hpp"
@@ -12,6 +13,7 @@
 #include "Unit.hpp"
 #include "UnitHTTP.hpp"
 #include "helpers.hpp"
+#include "lokassert.hpp"
 
 #include <Poco/Net/HTTPRequest.h>
 
@@ -20,13 +22,26 @@
  * discarded in case document is changed in storage behind our back. We don't
  * want to overwrite the document which is in storage when the user asks us to
  * do so.
+ *
+ * The way this works is as follows:
+ * 1. Load a document.
+ * 2. When we get 'status:' in filterSendMessage, we modify it.
+ * 3. Simulate content-change in storage and attempt to save it.
+ * 4. Saving should fail with 'error:' in filterSendMessage.
+ * 5. Load the document again and verify the storage-chagned contents.
+ * 6. Finish when the second load is processed in assertGetFileRequest.
  */
 class UnitWOPIDocumentConflict : public WopiTestServer
 {
     enum class Phase
     {
         Load,
-        ModifyAndChangeStorageDoc,
+        WaitLoadStatus,
+        ModifyDoc,
+        WaitModifiedStatus,
+        ChangeStorageDoc,
+        WaitSaveResponse,
+        WaitDocClose,
         LoadNewDocument,
         Polling
     } _phase;
@@ -37,6 +52,8 @@ class UnitWOPIDocumentConflict : public WopiTestServer
         Doc2
     } _docLoaded;
 
+    static constexpr auto ExpectedDocContent = "Modified content in storage";
+
 public:
     UnitWOPIDocumentConflict()
         : WopiTestServer("UnitWOPIDocumentConflict")
@@ -46,11 +63,14 @@ public:
 
     void assertGetFileRequest(const Poco::Net::HTTPRequest& /*request*/) override
     {
+        LOG_TST("assertGetFileRequest: Doc " << (_docLoaded == DocLoaded::Doc1 ? "1" : "2"));
         if (_docLoaded == DocLoaded::Doc2)
         {
             // On second doc load, we should have the document in storage which
             // was changed beneath us, not the one which we modified by pressing 'a'
-            if (getFileContent() != "Modified content in storage")
+            LOK_ASSERT_EQUAL_MESSAGE("File contents not modified in storage",
+                                     std::string(ExpectedDocContent), getFileContent());
+            if (getFileContent() != ExpectedDocContent)
                 exitTest(TestResult::Failed);
             else
                 exitTest(TestResult::Ok);
@@ -60,13 +80,67 @@ public:
     bool filterSendMessage(const char* data, const std::size_t len, const WSOpCode /* code */,
                            const bool /* flush */, int& /*unitReturn*/) override
     {
-        std::string message(data, len);
-        if (message == "error: cmd=storage kind=documentconflict")
+        const std::string message(data, len);
+        switch (_phase)
         {
-            // we don't want to save current changes because doing so would
-            // overwrite the document which was changed underneath us
-            helpers::sendTextFrame(*getWs()->getLOOLWebSocket(), "closedocument", getTestname());
-            _phase = Phase::LoadNewDocument;
+            case Phase::WaitLoadStatus:
+            {
+                LOG_TST("filterSendMessage: Doc " << (_docLoaded == DocLoaded::Doc1 ? "1" : "2")
+                                                  << "(WaitLoadStatus): [" << message << ']');
+                if (_docLoaded == DocLoaded::Doc1 && Util::startsWith(message, "status:"))
+                {
+                    _phase = Phase::ModifyDoc;
+                    LOG_TST("filterSendMessage: Switching to Phase::ModifyDoc");
+                    SocketPoll::wakeupWorld();
+                }
+            }
+            break;
+            case Phase::WaitModifiedStatus:
+            {
+                LOG_TST("filterSendMessage: Doc " << (_docLoaded == DocLoaded::Doc1 ? "1" : "2")
+                                                  << "(WaitModifiedStatus): [" << message << ']');
+                if (_docLoaded == DocLoaded::Doc1
+                    && message == "statechanged: .uno:ModifiedStatus=true")
+                {
+                    _phase = Phase::ChangeStorageDoc;
+                    LOG_TST("filterSendMessage: Switching to Phase::ChangeStorageDoc");
+                    SocketPoll::wakeupWorld();
+                }
+            }
+            break;
+            case Phase::WaitSaveResponse:
+            {
+                LOG_TST("filterSendMessage: Doc " << (_docLoaded == DocLoaded::Doc1 ? "1" : "2")
+                                                  << "(WaitSaveResponse): [" << message << ']');
+                if (message == "error: cmd=storage kind=documentconflict")
+                {
+                    _phase = Phase::WaitDocClose;
+                    LOG_TST("filterSendMessage: Switching to Phase::WaitDocClose");
+
+                    // we don't want to save current changes because doing so would
+                    // overwrite the document which was changed underneath us
+                    helpers::sendTextFrame(*getWs()->getLOOLWebSocket(), "closedocument",
+                                           getTestname());
+                }
+            }
+            break;
+            case Phase::WaitDocClose:
+            {
+                LOG_TST("filterSendMessage: Doc " << (_docLoaded == DocLoaded::Doc1 ? "1" : "2")
+                                                  << "(WaitDocClose): [" << message << ']');
+                if (message == "exit")
+                {
+                    _phase = Phase::LoadNewDocument;
+                    LOG_TST("filterSendMessage: Switching to Phase::LoadNewDocument");
+                    SocketPoll::wakeupWorld();
+                }
+            }
+            break;
+            default:
+            {
+                // Nothing to do.
+            }
+            break;
         }
 
         return false;
@@ -78,59 +152,90 @@ public:
         {
             case Phase::Load:
             {
-                initWebsocket("/wopi/files/0?access_token=anything");
+                LOG_TST("Phase::Load");
                 _docLoaded = DocLoaded::Doc1;
+                _phase = Phase::WaitLoadStatus;
+
+                initWebsocket("/wopi/files/0?access_token=anything");
 
                 helpers::sendTextFrame(*getWs()->getLOOLWebSocket(), "load url=" + getWopiSrc(),
                                        getTestname());
-
-                _phase = Phase::ModifyAndChangeStorageDoc;
-                break;
             }
-            case Phase::ModifyAndChangeStorageDoc:
+            break;
+            case Phase::WaitLoadStatus:
             {
+                // Nothing to do.
+            }
+            break;
+            case Phase::ModifyDoc:
+            {
+                LOG_TST("Phase::ModifyAndChangeStorageDoc");
+                _phase = Phase::WaitModifiedStatus;
+
                 // modify the currently opened document; type 'a'
                 helpers::sendTextFrame(*getWs()->getLOOLWebSocket(), "key type=input char=97 key=0",
                                        getTestname());
                 helpers::sendTextFrame(*getWs()->getLOOLWebSocket(), "key type=up char=0 key=512",
                                        getTestname());
                 SocketPoll::wakeupWorld();
+            }
+            break;
+            case Phase::WaitModifiedStatus:
+            {
+                // Nothing to do.
+            }
+            break;
+            case Phase::ChangeStorageDoc:
+            {
+                // Change the document underneath, in storage.
+                LOG_TST("Phase::ChangeStorageDoc: changing contents in storage");
+                _phase = Phase::WaitSaveResponse;
 
-                // ModifiedStatus=true is a bit slow; let's sleep and hope that
-                // it is received before we wake up
-                std::this_thread::sleep_for(std::chrono::microseconds(POLL_TIMEOUT_MICRO_S));
+                setFileContent(ExpectedDocContent);
 
-                // change the document underneath, in storage
-                setFileContent("Modified content in storage");
-
-                // save the document; wsd should detect now that document has
+                // Save the document; wsd should detect now that document has
                 // been changed underneath it and send us:
                 // "error: cmd=storage kind=documentconflict"
+                // When we get it (in filterSendMessage, above),
+                // we will switch to Phase::LoadNewDocument.
+                LOG_TST("Phase::ChangeStorageDoc: saving");
                 helpers::sendTextFrame(*getWs()->getLOOLWebSocket(), "save", getTestname());
-
-                _phase = Phase::Polling;
-
-                break;
             }
+            break;
+            case Phase::WaitSaveResponse:
+            case Phase::WaitDocClose:
+            {
+                // Nothing to do.
+            }
+            break;
             case Phase::LoadNewDocument:
             {
-                initWebsocket("/wopi/files/0?access_token=anything");
-                _docLoaded = DocLoaded::Doc2;
+                // Now load the document again and, when we hit
+                // assertGetFileRequest, verify that its contents
+                // are the changed-in-storage (and not our modified).
+                // Unfortunately we don't have a way to find out
+                // if the previous document's DocBroker is gone
+                // since sending 'exit' to the kit, so wait a bit.
+                // We could add a call back after cleaning the
+                // DocBroker, but a short wait will do for now.
+                LOG_TST("Phase::LoadNewDocument: Reloading.");
+                _docLoaded = DocLoaded::Doc2; // Update before loading!
                 _phase = Phase::Polling;
-                break;
+
+                std::this_thread::sleep_for(std::chrono::seconds(1));
+                initWebsocket("/wopi/files/0?access_token=anything");
             }
+            break;
             case Phase::Polling:
             {
+                LOG_TST("Phase::Polling");
                 // just wait for the results
-                break;
             }
+            break;
         }
     }
 };
 
-UnitBase *unit_create_wsd(void)
-{
-    return new UnitWOPIDocumentConflict();
-}
+UnitBase* unit_create_wsd(void) { return new UnitWOPIDocumentConflict(); }
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/test/UnitWOPIDocumentConflict.cpp
+++ b/test/UnitWOPIDocumentConflict.cpp
@@ -37,11 +37,10 @@ class UnitWOPIDocumentConflict : public WopiTestServer
         Doc2
     } _docLoaded;
 
-    const std::string _testName = "UnitWOPIDocumentConflict";
-
 public:
     UnitWOPIDocumentConflict()
-        : _phase(Phase::Load)
+        : WopiTestServer("UnitWOPIDocumentConflict")
+        , _phase(Phase::Load)
     {
     }
 
@@ -66,7 +65,7 @@ public:
         {
             // we don't want to save current changes because doing so would
             // overwrite the document which was changed underneath us
-            helpers::sendTextFrame(*getWs()->getLOOLWebSocket(), "closedocument", _testName);
+            helpers::sendTextFrame(*getWs()->getLOOLWebSocket(), "closedocument", getTestname());
             _phase = Phase::LoadNewDocument;
         }
 
@@ -83,7 +82,7 @@ public:
                 _docLoaded = DocLoaded::Doc1;
 
                 helpers::sendTextFrame(*getWs()->getLOOLWebSocket(), "load url=" + getWopiSrc(),
-                                       _testName);
+                                       getTestname());
 
                 _phase = Phase::ModifyAndChangeStorageDoc;
                 break;
@@ -92,9 +91,9 @@ public:
             {
                 // modify the currently opened document; type 'a'
                 helpers::sendTextFrame(*getWs()->getLOOLWebSocket(), "key type=input char=97 key=0",
-                                       _testName);
+                                       getTestname());
                 helpers::sendTextFrame(*getWs()->getLOOLWebSocket(), "key type=up char=0 key=512",
-                                       _testName);
+                                       getTestname());
                 SocketPoll::wakeupWorld();
 
                 // ModifiedStatus=true is a bit slow; let's sleep and hope that
@@ -107,7 +106,7 @@ public:
                 // save the document; wsd should detect now that document has
                 // been changed underneath it and send us:
                 // "error: cmd=storage kind=documentconflict"
-                helpers::sendTextFrame(*getWs()->getLOOLWebSocket(), "save", _testName);
+                helpers::sendTextFrame(*getWs()->getLOOLWebSocket(), "save", getTestname());
 
                 _phase = Phase::Polling;
 

--- a/test/UnitWOPIHttpHeaders.cpp
+++ b/test/UnitWOPIHttpHeaders.cpp
@@ -74,7 +74,7 @@ public:
     {
     }
 
-    void invokeTest() override
+    void invokeWSDTest() override
     {
         constexpr char testName[] = "UnitWopiHttpHeaders";
 

--- a/test/UnitWOPIHttpHeaders.cpp
+++ b/test/UnitWOPIHttpHeaders.cpp
@@ -69,7 +69,8 @@ protected:
 
 public:
     UnitWopiHttpHeaders()
-        : _phase(Phase::Load)
+        : WopiTestServer("UnitWOPIHttpHeaders")
+        , _phase(Phase::Load)
     {
     }
 

--- a/test/UnitWOPILoadEncoded.cpp
+++ b/test/UnitWOPILoadEncoded.cpp
@@ -25,8 +25,9 @@ class UnitWOPILoadEncoded : public WopiTestServer
     } _phase;
 
 public:
-    UnitWOPILoadEncoded() :
-        _phase(Phase::LoadEncoded)
+    UnitWOPILoadEncoded()
+        : WopiTestServer("UnitWOPILoadEncoded")
+        , _phase(Phase::LoadEncoded)
     {
     }
 

--- a/test/UnitWOPILoadEncoded.cpp
+++ b/test/UnitWOPILoadEncoded.cpp
@@ -31,7 +31,7 @@ public:
     {
     }
 
-    void invokeTest() override
+    void invokeWSDTest() override
     {
         constexpr char testName[] = "UnitWOPILoadEncoded";
 

--- a/test/UnitWOPIRenameFile.cpp
+++ b/test/UnitWOPIRenameFile.cpp
@@ -25,8 +25,9 @@ class UnitWOPIRenameFile : public WopiTestServer
     } _phase;
 
 public:
-    UnitWOPIRenameFile() :
-        _phase(Phase::Load)
+    UnitWOPIRenameFile()
+        : WopiTestServer("UnitWOPIRenameFile")
+        , _phase(Phase::Load)
     {
     }
 

--- a/test/UnitWOPIRenameFile.cpp
+++ b/test/UnitWOPIRenameFile.cpp
@@ -53,7 +53,7 @@ public:
         return false;
     }
 
-    void invokeTest() override
+    void invokeWSDTest() override
     {
         constexpr char testName[] = "UnitWOPIRenameFile";
 

--- a/test/UnitWOPISaveAs.cpp
+++ b/test/UnitWOPISaveAs.cpp
@@ -24,8 +24,9 @@ class UnitWOPISaveAs : public WopiTestServer
     } _phase;
 
 public:
-    UnitWOPISaveAs() :
-        _phase(Phase::LoadAndSaveAs)
+    UnitWOPISaveAs()
+        : WopiTestServer("UnitWOPISaveAs")
+        , _phase(Phase::LoadAndSaveAs)
     {
     }
 

--- a/test/UnitWOPISaveAs.cpp
+++ b/test/UnitWOPISaveAs.cpp
@@ -57,7 +57,7 @@ public:
         return false;
     }
 
-    void invokeTest() override
+    void invokeWSDTest() override
     {
         constexpr char testName[] = "UnitWOPISaveAs";
 

--- a/test/UnitWOPITemplate.cpp
+++ b/test/UnitWOPITemplate.cpp
@@ -27,8 +27,9 @@ class UnitWOPITemplate : public WopiTestServer
     } _phase;
 
 public:
-    UnitWOPITemplate() :
-        _phase(Phase::LoadTemplate)
+    UnitWOPITemplate()
+        : WopiTestServer("UnitWOPITemplate")
+        , _phase(Phase::LoadTemplate)
     {
     }
 

--- a/test/UnitWOPITemplate.cpp
+++ b/test/UnitWOPITemplate.cpp
@@ -126,7 +126,7 @@ public:
     }
 
 
-    void invokeTest() override
+    void invokeWSDTest() override
     {
         constexpr char testName[] = "UnitWOPITemplate";
 

--- a/test/UnitWOPIVersionRestore.cpp
+++ b/test/UnitWOPIVersionRestore.cpp
@@ -62,11 +62,11 @@ public:
         return false;
     }
 
-    void invokeTest() override
+    void invokeWSDTest() override
     {
         constexpr char testName[] = "UnitWOPIVersionRestore";
 
-        LOG_TRC("invokeTest " << (int)_phase);
+        LOG_TRC("invokeWSDTest " << (int)_phase);
         switch (_phase)
         {
             case Phase::Load:

--- a/test/UnitWOPIVersionRestore.cpp
+++ b/test/UnitWOPIVersionRestore.cpp
@@ -37,8 +37,9 @@ class UnitWOPIVersionRestore : public WopiTestServer
     bool _isDocumentSaved = false;
 
 public:
-    UnitWOPIVersionRestore() :
-        _phase(Phase::Load)
+    UnitWOPIVersionRestore()
+        : WopiTestServer("UnitWOPIVersionRestore")
+        , _phase(Phase::Load)
     {
     }
 

--- a/test/UnitWOPIWatermark.cpp
+++ b/test/UnitWOPIWatermark.cpp
@@ -25,8 +25,9 @@ class UnitWOPIWatermark : public WopiTestServer
     } _phase;
 
 public:
-    UnitWOPIWatermark() :
-        _phase(Phase::Load)
+    UnitWOPIWatermark()
+        : WopiTestServer("UnitWOPIWatermark")
+        , _phase(Phase::Load)
     {
     }
 

--- a/test/UnitWOPIWatermark.cpp
+++ b/test/UnitWOPIWatermark.cpp
@@ -106,7 +106,7 @@ public:
         return false;
     }
 
-    void invokeTest() override
+    void invokeWSDTest() override
     {
         constexpr char testName[] = "UnitWOPIWatermark";
 

--- a/test/UnitWopiOwnertermination.cpp
+++ b/test/UnitWopiOwnertermination.cpp
@@ -26,8 +26,9 @@ class UnitWopiOwnertermination : public WopiTestServer
     } _phase;
 
 public:
-    UnitWopiOwnertermination() :
-        _phase(Phase::Load)
+    UnitWopiOwnertermination()
+        : WopiTestServer("UnitWOPIOwnerTermination")
+        , _phase(Phase::Load)
     {
     }
 

--- a/test/UnitWopiOwnertermination.cpp
+++ b/test/UnitWopiOwnertermination.cpp
@@ -41,7 +41,7 @@ public:
         }
     }
 
-    void invokeTest() override
+    void invokeWSDTest() override
     {
         constexpr char testName[] = "UnitWopiOwnertermination";
 

--- a/test/WopiTestServer.hpp
+++ b/test/WopiTestServer.hpp
@@ -19,6 +19,7 @@
 #include <Poco/URI.h>
 #include <Poco/Timestamp.h>
 #include <Poco/Util/LayeredConfiguration.h>
+#include <sstream>
 
 class WopiTestServer : public UnitWSD
 {
@@ -70,7 +71,7 @@ public:
         _wopiSrc.clear();
         Poco::URI::encode(wopiURL.toString(), ":/?", _wopiSrc);
 
-        LOG_INF("Connecting to the fake WOPI server: /lool/" << _wopiSrc << "/ws");
+        LOG_TST("Connecting to the fake WOPI server: /lool/" << _wopiSrc << "/ws");
 
         _ws.reset(new UnitWebSocket("/lool/" + _wopiSrc + "/ws"));
         assert(_ws.get());
@@ -112,22 +113,21 @@ protected:
         Poco::RegularExpression regInfo("/wopi/files/[0-9]");
         Poco::RegularExpression regContent("/wopi/files/[0-9]/contents");
 
-        Log::StreamLogger logger = Log::info();
-        if (logger.enabled())
         {
-            logger << "Fake wopi host request URI [" << uriReq.toString() << "]:\n";
+            std::ostringstream oss;
+            oss << "Fake wopi host request URI [" << uriReq.toString() << "]:\n";
             for (const auto& pair : request)
             {
-                logger << '\t' << pair.first << ": " << pair.second << " / ";
+                oss << '\t' << pair.first << ": " << pair.second << " / ";
             }
 
-            LOG_END(logger, true);
+            LOG_TST(oss.str());
         }
 
         // CheckFileInfo
         if (request.getMethod() == "GET" && regInfo.match(uriReq.getPath()))
         {
-            LOG_INF("Fake wopi host request, handling CheckFileInfo: " << uriReq.getPath());
+            LOG_TST("Fake wopi host request, handling CheckFileInfo: " << uriReq.getPath());
 
             assertCheckFileInfoRequest(request);
 
@@ -167,7 +167,7 @@ protected:
         // GetFile
         else if (request.getMethod() == "GET" && regContent.match(uriReq.getPath()))
         {
-            LOG_INF("Fake wopi host request, handling GetFile: " << uriReq.getPath());
+            LOG_TST("Fake wopi host request, handling GetFile: " << uriReq.getPath());
 
             assertGetFileRequest(request);
 
@@ -189,7 +189,7 @@ protected:
         }
         else if (request.getMethod() == "POST" && regInfo.match(uriReq.getPath()))
         {
-            LOG_INF("Fake wopi host request, handling PutRelativeFile: " << uriReq.getPath());
+            LOG_TST("Fake wopi host request, handling PutRelativeFile: " << uriReq.getPath());
             std::string wopiURL = helpers::getTestServerURI() + "/something wopi/files/1?access_token=anything&reuse_cookies=cook=well";
             std::string content;
 
@@ -223,7 +223,7 @@ protected:
         }
         else if (request.getMethod() == "POST" && regContent.match(uriReq.getPath()))
         {
-            LOG_INF("Fake wopi host request, handling PutFile: " << uriReq.getPath());
+            LOG_TST("Fake wopi host request, handling PutFile: " << uriReq.getPath());
 
             std::string wopiTimestamp = request.get("X-LOOL-WOPI-Timestamp");
             if (!wopiTimestamp.empty())

--- a/test/WopiTestServer.hpp
+++ b/test/WopiTestServer.hpp
@@ -57,8 +57,9 @@ protected:
     const std::chrono::system_clock::time_point& getFileLastModifiedTime() const { return _fileLastModifiedTime; }
 
 public:
-    WopiTestServer(std::string fileContent = "Hello, world")
-        : _fileContent(std::move(fileContent))
+    WopiTestServer(std::string testname, std::string fileContent = "Hello, world")
+        : UnitWSD(std::move(testname))
+        , _fileContent(std::move(fileContent))
     {
     }
 
@@ -66,7 +67,7 @@ public:
     {
         Poco::URI wopiURL(helpers::getTestServerURI() + wopiName);
 
-        _wopiSrc = "";
+        _wopiSrc.clear();
         Poco::URI::encode(wopiURL.toString(), ":/?", _wopiSrc);
 
         LOG_INF("Connecting to the fake WOPI server: /lool/" << _wopiSrc << "/ws");

--- a/test/WopiTestServer.hpp
+++ b/test/WopiTestServer.hpp
@@ -4,6 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
+#include "Util.hpp"
 #include "config.h"
 
 #include "helpers.hpp"
@@ -51,17 +52,22 @@ protected:
     /// Sets the file content to a given value and update the last file modified time
     void setFileContent(const std::string& fileContent)
     {
+        LOG_TST("setFileContent: [" << fileContent << ']');
         _fileContent = fileContent;
         _fileLastModifiedTime = std::chrono::system_clock::now();
     }
 
-    const std::chrono::system_clock::time_point& getFileLastModifiedTime() const { return _fileLastModifiedTime; }
+    const std::chrono::system_clock::time_point& getFileLastModifiedTime() const
+    {
+        return _fileLastModifiedTime;
+    }
 
 public:
-    WopiTestServer(std::string testname, std::string fileContent = "Hello, world")
+    WopiTestServer(std::string testname, const std::string& fileContent = "Hello, world")
         : UnitWSD(std::move(testname))
-        , _fileContent(std::move(fileContent))
     {
+        LOG_TST("WopiTestServer created for [" << testname << ']');
+        setFileContent(fileContent);
     }
 
     void initWebsocket(const std::string& wopiName)
@@ -107,11 +113,11 @@ public:
 protected:
     /// Here we act as a WOPI server, so that we have a server that responds to
     /// the wopi requests without additional expensive setup.
-    virtual bool handleHttpRequest(const Poco::Net::HTTPRequest& request, Poco::MemoryInputStream& message, std::shared_ptr<StreamSocket>& socket) override
+    virtual bool handleHttpRequest(const Poco::Net::HTTPRequest& request,
+                                   Poco::MemoryInputStream& message,
+                                   std::shared_ptr<StreamSocket>& socket) override
     {
         Poco::URI uriReq(request.getURI());
-        Poco::RegularExpression regInfo("/wopi/files/[0-9]");
-        Poco::RegularExpression regContent("/wopi/files/[0-9]/contents");
 
         {
             std::ostringstream oss;
@@ -123,6 +129,9 @@ protected:
 
             LOG_TST(oss.str());
         }
+
+        static const Poco::RegularExpression regInfo("/wopi/files/[0-9]");
+        static const Poco::RegularExpression regContent("/wopi/files/[0-9]/contents");
 
         // CheckFileInfo
         if (request.getMethod() == "GET" && regInfo.match(uriReq.getPath()))
@@ -261,6 +270,11 @@ protected:
             socket->shutdown();
 
             return true;
+        }
+        else if (!Util::startsWith(uriReq.getPath(), "/lool/")) // Skip requests to the websrv.
+        {
+            // Complain if we are expected to handle something that we don't.
+            LOG_TST("ERROR: Fake wopi host request, cannot handle request: " << uriReq.getPath());
         }
 
         return false;

--- a/test/helpers.hpp
+++ b/test/helpers.hpp
@@ -7,7 +7,8 @@
 
 #pragma once
 
-#include <iterator>
+#include <test/testlog.hpp>
+#include <test/lokassert.hpp>
 
 #include <Poco/BinaryReader.h>
 #include <Poco/Dynamic/Var.h>
@@ -24,85 +25,17 @@
 #include <Poco/Path.h>
 #include <Poco/URI.h>
 
-#include <test/lokassert.hpp>
-
 #include <Common.hpp>
 #include "common/FileUtil.hpp"
 #include <LOOLWebSocket.hpp>
 #include <Util.hpp>
 
+#include <iterator>
+#include <fstream>
+
 #ifndef TDOC
 #error TDOC must be defined (see Makefile.am)
 #endif
-
-// Oh dear std::cerr and/or its re-direction is not
-// necessarily thread safe on Linux
-// This is the canonical test log function.
-inline void writeTestLog(const char* const p)
-{
-    fputs(p, stderr);
-    fflush(stderr);
-}
-
-inline void writeTestLog(const std::string& s) { writeTestLog(s.c_str()); }
-
-#ifdef TST_LOG_REDIRECT
-void tstLog(const std::ostringstream& stream);
-#else
-inline void tstLog(const std::ostringstream& stream) { writeTestLog(stream.str()); }
-#endif
-
-#define TST_LOG_NAME_BEGIN(OSS, NAME, X, FLUSH)                                                    \
-    do                                                                                             \
-    {                                                                                              \
-        char t[64];                                                                                \
-        Poco::DateTime time;                                                                       \
-        snprintf(t, sizeof(t), "%.2u:%.2u:%.2u.%.6u (@%zums) ", time.hour(), time.minute(),        \
-                 time.second(), time.millisecond() * 1000 + time.microsecond(),                    \
-                 helpers::timeSinceTestStartMs());                                                 \
-        OSS << NAME << t << X;                                                                     \
-        if (FLUSH)                                                                                 \
-            tstLog(OSS);                                                                           \
-    } while (false)
-
-#define TST_LOG_BEGIN(X)                                                                           \
-    do                                                                                             \
-    {                                                                                              \
-        std::ostringstream oss;                                                                    \
-        TST_LOG_NAME_BEGIN(oss, testname, X, true);                                                \
-    } while (false)
-
-#define TST_LOG_APPEND(X)                                                                          \
-    do                                                                                             \
-    {                                                                                              \
-        std::ostringstream str;                                                                    \
-        str << X;                                                                                  \
-        tstLog(str);                                                                               \
-    } while (false)
-
-#define TST_LOG_END_X(OSS)                                                                         \
-    do                                                                                             \
-    {                                                                                              \
-        OSS << "| " __FILE__ ":" << __LINE__ << '\n';                                              \
-        tstLog(OSS);                                                                               \
-    } while (false)
-
-#define TST_LOG_END                                                                                \
-    do                                                                                             \
-    {                                                                                              \
-        std::ostringstream oss_log_end;                                                            \
-        TST_LOG_END_X(oss_log_end);                                                                \
-    } while (false)
-
-#define TST_LOG_NAME(NAME, X)                                                                      \
-    do                                                                                             \
-    {                                                                                              \
-        std::ostringstream oss_log_name;                                                           \
-        TST_LOG_NAME_BEGIN(oss_log_name, NAME, X, false);                                          \
-        TST_LOG_END_X(oss_log_name);                                                               \
-    } while (false)
-
-#define TST_LOG(X) TST_LOG_NAME(testname, X)
 
 // Sometimes we need to retry some commands as they can (due to timing or load) soft-fail.
 constexpr int COMMAND_RETRY_COUNT = 5;

--- a/test/helpers.hpp
+++ b/test/helpers.hpp
@@ -45,20 +45,6 @@ constexpr int COMMAND_RETRY_COUNT = 5;
 /// These are supposed to be testing the latter.
 namespace helpers
 {
-inline std::chrono::steady_clock::time_point& getTestStartTime()
-{
-    static auto TestStartTime = std::chrono::steady_clock::now();
-
-    return TestStartTime;
-}
-
-inline void resetTestStartTime() { getTestStartTime() = std::chrono::steady_clock::now(); }
-
-inline std::chrono::milliseconds timeSinceTestStartMs()
-{
-    return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now()
-                                                                 - getTestStartTime());
-}
 
 inline
 std::vector<char> genRandomData(const size_t size)

--- a/test/helpers.hpp
+++ b/test/helpers.hpp
@@ -45,25 +45,19 @@ constexpr int COMMAND_RETRY_COUNT = 5;
 /// These are supposed to be testing the latter.
 namespace helpers
 {
-inline
-std::chrono::time_point<std::chrono::steady_clock>& getTestStartTime()
+inline std::chrono::steady_clock::time_point& getTestStartTime()
 {
     static auto TestStartTime = std::chrono::steady_clock::now();
 
     return TestStartTime;
 }
 
-inline
-void resetTestStartTime()
-{
-    getTestStartTime() = std::chrono::steady_clock::now();
-}
+inline void resetTestStartTime() { getTestStartTime() = std::chrono::steady_clock::now(); }
 
-inline
-size_t timeSinceTestStartMs()
+inline std::chrono::milliseconds timeSinceTestStartMs()
 {
-    return std::chrono::duration_cast<std::chrono::milliseconds>(
-                            std::chrono::steady_clock::now() - getTestStartTime()).count();
+    return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now()
+                                                                 - getTestStartTime());
 }
 
 inline

--- a/test/httpcrashtest.cpp
+++ b/test/httpcrashtest.cpp
@@ -135,20 +135,14 @@ void HTTPCrashTest::testCrashKit()
         std::shared_ptr<LOOLWebSocket> socket = loadDocAndGetSocket("empty.odt", _uri, testname);
 
         TST_LOG("Allowing time for kits to spawn and connect to wsd to get cleanly killed");
-        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+        std::this_thread::sleep_for(std::chrono::seconds(1));
 
         TST_LOG("Killing loolkit instances.");
 
         killLoKitProcesses();
         countLoolKitProcesses(0);
 
-        // We expect the client connection to close.
-        // In the future we might restore the kit, but currently we don't.
-        TST_LOG("Reading after kill.");
-
-        // Drain the socket.
-        getResponseMessage(socket, "", testname, 1000);
-
+        TST_LOG("Reading the error code from the socket.");
         std::string message;
         const int statusCode = getErrorCode(socket, message, testname);
         LOK_ASSERT_EQUAL(static_cast<int>(Poco::Net::WebSocket::WS_ENDPOINT_GOING_AWAY), statusCode);

--- a/test/lokassert.hpp
+++ b/test/lokassert.hpp
@@ -35,7 +35,7 @@ inline std::ostream& operator<<(std::ostream& os, const std::vector<char>& v)
     {                                                                                              \
         if (!(condition))                                                                          \
         {                                                                                          \
-            std::cerr << "Assertion failure: " << (#condition) << std::endl;                       \
+            TST_LOG_NAME("unittest", "Assertion failure: " << (#condition));                       \
             LOK_ASSERT_IMPL(condition);                                                            \
             CPPUNIT_ASSERT(condition);                                                             \
         }                                                                                          \
@@ -46,8 +46,8 @@ inline std::ostream& operator<<(std::ostream& os, const std::vector<char>& v)
     {                                                                                              \
         if (!((expected) == (actual)))                                                             \
         {                                                                                          \
-            std::cerr << "Assertion failure: Expected [" << (expected) << "] but got ["            \
-                      << (actual) << ']' << std::endl;                                             \
+            TST_LOG_NAME("unittest", "Assertion failure: Expected ["                               \
+                                         << (expected) << "] but got [" << (actual) << ']');       \
             LOK_ASSERT_IMPL((expected) == (actual));                                               \
             CPPUNIT_ASSERT_EQUAL((expected), (actual));                                            \
         }                                                                                          \
@@ -58,8 +58,9 @@ inline std::ostream& operator<<(std::ostream& os, const std::vector<char>& v)
     {                                                                                              \
         if (!((expected) == (actual)))                                                             \
         {                                                                                          \
-            std::cerr << "Assertion failure: " << (message) << ". Expected [" << (expected)        \
-                      << "] but got [" << (actual) << "]: " << std::endl;                          \
+            TST_LOG_NAME("unittest", "Assertion failure: " << (message) << ". Expected ["          \
+                                                           << (expected) << "] but got ["          \
+                                                           << (actual) << "]: ");                  \
             LOK_ASSERT_IMPL((expected) == (actual));                                               \
             CPPUNIT_ASSERT_EQUAL_MESSAGE((message), (expected), (actual));                         \
         }                                                                                          \
@@ -70,8 +71,8 @@ inline std::ostream& operator<<(std::ostream& os, const std::vector<char>& v)
     {                                                                                              \
         if (!(condition))                                                                          \
         {                                                                                          \
-            std::cerr << "Assertion failure: " << (message) << ". Condition: " << (#condition)     \
-                      << std::endl;                                                                \
+            TST_LOG_NAME("unittest",                                                               \
+                         "Assertion failure: " << (message) << ". Condition: " << (#condition));   \
             LOK_ASSERT_IMPL(condition);                                                            \
             CPPUNIT_ASSERT_MESSAGE((message), (condition));                                        \
         }                                                                                          \
@@ -80,7 +81,7 @@ inline std::ostream& operator<<(std::ostream& os, const std::vector<char>& v)
 #define LOK_ASSERT_FAIL(message)                                                                   \
     do                                                                                             \
     {                                                                                              \
-        std::cerr << "Forced failure: " << (message) << std::endl;                                 \
-        LOK_ASSERT_IMPL(!"Forced failure");                                                               \
+        TST_LOG_NAME("unittest", "Forced failure: " << (message));                                 \
+        LOK_ASSERT_IMPL(!"Forced failure");                                                        \
         CPPUNIT_FAIL((message));                                                                   \
     } while (false)

--- a/test/lokassert.hpp
+++ b/test/lokassert.hpp
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include "testlog.hpp"
+
 #include <assert.h>
 
 #include <cppunit/extensions/HelperMacros.h>

--- a/test/testlog.hpp
+++ b/test/testlog.hpp
@@ -9,6 +9,25 @@
 
 #include <Log.hpp>
 
+namespace helpers
+{
+inline std::chrono::steady_clock::time_point& getTestStartTime()
+{
+    static auto TestStartTime = std::chrono::steady_clock::now();
+
+    return TestStartTime;
+}
+
+inline void resetTestStartTime() { getTestStartTime() = std::chrono::steady_clock::now(); }
+
+inline std::chrono::milliseconds timeSinceTestStartMs()
+{
+    return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now()
+                                                                 - getTestStartTime());
+}
+
+} // namespace helpers
+
 //FIXME: use LOG_ macros and unify with the existing logging system.
 // Oh dear std::cerr and/or its re-direction is not
 // necessarily thread safe on Linux

--- a/test/testlog.hpp
+++ b/test/testlog.hpp
@@ -74,6 +74,10 @@ inline void tstLog(const std::ostringstream& stream) { writeTestLog(stream.str()
         TST_LOG_END_X(oss_log_name);                                                               \
     } while (false)
 
+/// Used by the "old-style" tests. FIXME: Unify.
 #define TST_LOG(X) TST_LOG_NAME(testname, X)
+
+/// Used by the "new-style" tests. FIXME: Unify.
+#define LOG_TST(X) TST_LOG_NAME(getTestname(), X)
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/test/testlog.hpp
+++ b/test/testlog.hpp
@@ -1,0 +1,79 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <Log.hpp>
+
+//FIXME: use LOG_ macros and unify with the existing logging system.
+// Oh dear std::cerr and/or its re-direction is not
+// necessarily thread safe on Linux
+// This is the canonical test log function.
+inline void writeTestLog(const char* const p)
+{
+    fputs(p, stderr);
+    fflush(stderr);
+}
+
+inline void writeTestLog(const std::string& s) { writeTestLog(s.c_str()); }
+
+#ifdef TST_LOG_REDIRECT
+void tstLog(const std::ostringstream& stream);
+#else
+inline void tstLog(const std::ostringstream& stream) { writeTestLog(stream.str()); }
+#endif
+
+#define TST_LOG_NAME_BEGIN(OSS, NAME, X, FLUSH)                                                    \
+    do                                                                                             \
+    {                                                                                              \
+        char b_[1024];                                                                             \
+        OSS << Log::prefix<sizeof(b_) - 1>(b_, "TST") << NAME << " (+"                             \
+            << helpers::timeSinceTestStartMs() << "): " << X;                                      \
+        if (FLUSH)                                                                                 \
+            tstLog(OSS);                                                                           \
+    } while (false)
+
+#define TST_LOG_BEGIN(X)                                                                           \
+    do                                                                                             \
+    {                                                                                              \
+        std::ostringstream oss;                                                                    \
+        TST_LOG_NAME_BEGIN(oss, testname, X, true);                                                \
+    } while (false)
+
+#define TST_LOG_APPEND(X)                                                                          \
+    do                                                                                             \
+    {                                                                                              \
+        std::ostringstream str;                                                                    \
+        str << X;                                                                                  \
+        tstLog(str);                                                                               \
+    } while (false)
+
+#define TST_LOG_END_X(OSS)                                                                         \
+    do                                                                                             \
+    {                                                                                              \
+        OSS << "| " __FILE__ ":" << __LINE__ << '\n';                                              \
+        tstLog(OSS);                                                                               \
+    } while (false)
+
+#define TST_LOG_END                                                                                \
+    do                                                                                             \
+    {                                                                                              \
+        std::ostringstream oss_log_end;                                                            \
+        TST_LOG_END_X(oss_log_end);                                                                \
+    } while (false)
+
+#define TST_LOG_NAME(NAME, X)                                                                      \
+    do                                                                                             \
+    {                                                                                              \
+        std::ostringstream oss_log_name;                                                           \
+        TST_LOG_NAME_BEGIN(oss_log_name, NAME, X, false);                                          \
+        TST_LOG_END_X(oss_log_name);                                                               \
+    } while (false)
+
+#define TST_LOG(X) TST_LOG_NAME(testname, X)
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -4014,7 +4014,12 @@ int LOOLWSD::innerMain()
 
         // Unit test timeout
         if (timeSinceStartMs > UnitWSD::get().getTimeoutMilliSeconds())
+        {
+            LOG_ERR("Test exceeded its time limit of " << UnitWSD::get().getTimeoutMilliSeconds()
+                                                       << ". It's been running for "
+                                                       << timeSinceStartMs);
             UnitWSD::get().timeout();
+        }
 
 #if ENABLE_DEBUG && !MOBILEAPP
         if (careerSpanMs > std::chrono::milliseconds::zero() && timeSinceStartMs > careerSpanMs)


### PR DESCRIPTION
These changes make debugging test failures easier while improving the stability of the two most unstable tests: UnitWOPIDocumentConflict and httpcrashtest.

- gitignore: .clangd and .cache
- wsd: test: leverage the log system in TST_LOG
- wsd: test: use chrono types
- wsd: test: store the current test name in UnitBase
- wsd: test: use LOG_TST in new-style tests
- wsd: test: log test assertions
- wsd: test: better logging in WopiTestServer
- wsd: test: improved UnitWOPIDocumentConflict
- wsd: test: catch and fail WSD tests when exceptions are thrown
- wsd: test: httpcrashtest drain using the getErrorCode helper
- wsd: test: check if a WS Close Frame message exists
