### PR TITLE
wsd: save errno before invoking any other functions

### DIFF
--- a/common/FileUtil.cpp
+++ b/common/FileUtil.cpp
@@ -158,7 +158,7 @@ namespace FileUtil
             oss << "Error while copying from " << anonymizeUrl(fromPath) << " to "
                 << anonymizeUrl(toPath) << ": " << ex.what();
             const std::string err = oss.str();
-            LOG_SYS(err);
+            LOG_ERR(err);
             close(from);
             close(to);
             unlink(toPath.c_str());

--- a/common/Log.hpp
+++ b/common/Log.hpp
@@ -370,18 +370,18 @@ namespace Log
         }                                                                                          \
     } while (false)
 
-#define LOG_SYS(X)                                                                                 \
+/// Log an ERR entry with the given errno appended.
+#define LOG_SYS_ERRNO(ERRNO, X)                                                                    \
     do                                                                                             \
     {                                                                                              \
-        auto& log_ = Log::logger();                                                                \
-        if (!Log::isShutdownCalled() && log_.error())                                              \
-        {                                                                                          \
-            LOG_BODY_(log_, ERROR, "ERR",                                                          \
-                      X << " (" << Util::symbolicErrno(errno) << ": " << std::strerror(errno)      \
-                        << ')',                                                                    \
-                      true);                                                                       \
-        }                                                                                          \
+        const auto onrre = ERRNO; /* Save errno immediately while avoiding name clashes*/          \
+        LOG_ERR(X << " (" << Util::symbolicErrno(onrre) << ": " << std::strerror(onrre) << ')');   \
     } while (false)
+
+/// Log an ERR entry with errno appended.
+/// NOTE: Must be called immediately after an API that sets errno.
+/// Use LOG_SYS_ERRNO to pass errno explicitly.
+#define LOG_SYS(X) LOG_SYS_ERRNO(errno, X)
 
 #define LOG_FTL(X)                                                                                 \
     do                                                                                             \
@@ -394,17 +394,13 @@ namespace Log
         }                                                                                          \
     } while (false)
 
+/// Log an FTL (fatal) entry with errno appended.
+/// NOTE: Must be called immediately after an API that sets errno.
 #define LOG_SFL(X)                                                                                 \
     do                                                                                             \
     {                                                                                              \
-        auto& log_ = Log::logger();                                                                \
-        if (!Log::isShutdownCalled() && log_.error())                                              \
-        {                                                                                          \
-            LOG_BODY_(log_, FATAL, "FTL",                                                          \
-                      X << " (" << Util::symbolicErrno(errno) << ": " << std::strerror(errno)      \
-                        << ')',                                                                    \
-                      true);                                                                       \
-        }                                                                                          \
+        const auto onrre = errno; /* Save errno immediately while avoiding name clashes*/          \
+        LOG_FTL(X << " (" << Util::symbolicErrno(onrre) << ": " << std::strerror(onrre) << ')');   \
     } while (false)
 
 #define LOG_CHECK(X)                                                                               \

--- a/common/SigUtil.cpp
+++ b/common/SigUtil.cpp
@@ -272,7 +272,7 @@ namespace SigUtil
             backtrace_symbols_fd(backtraceBuffer, numSlots, STDERR_FILENO);
         }
 #else
-        LOG_SYS("Backtrace not available on Android.");
+        LOG_INF("Backtrace not available on Android.");
 #endif
 
         if (std::getenv("LOOL_DEBUG"))

--- a/common/Util.cpp
+++ b/common/Util.cpp
@@ -557,15 +557,14 @@ namespace Util
             LOG_SYS("Cannot set thread name of "
                     << getThreadId() << " (" << std::hex << std::this_thread::get_id() << std::dec
                     << ") of process " << getpid() << " currently " << knownAs << " to [" << s
-                    << "].");
+                    << ']');
         else
             LOG_INF("Thread " << getThreadId() << " (" << std::hex << std::this_thread::get_id()
                               << std::dec << ") of process " << getpid() << " formerly " << knownAs
-                              << " is now called [" << s << "].");
+                              << " is now called [" << s << ']');
 #elif defined IOS
         [[NSThread currentThread] setName:[NSString stringWithUTF8String:ThreadName]];
-        LOG_INF("Thread " << getThreadId() <<
-                ") is now called [" << s << "].");
+        LOG_INF("Thread " << getThreadId() << ") is now called [" << s << ']');
 #endif
     }
 

--- a/kit/ForKit.cpp
+++ b/kit/ForKit.cpp
@@ -194,7 +194,7 @@ static bool haveCapability(cap_value_t capability)
 
     if (caps == nullptr)
     {
-        LOG_SFL("cap_get_proc() failed.");
+        LOG_SFL("cap_get_proc() failed");
         return false;
     }
 
@@ -205,12 +205,12 @@ static bool haveCapability(cap_value_t capability)
     {
         if (cap_name)
         {
-            LOG_SFL("cap_get_flag failed for " << cap_name << '.');
+            LOG_SFL("cap_get_flag failed for " << cap_name);
             cap_free(cap_name);
         }
         else
         {
-            LOG_SFL("cap_get_flag failed for capability " << capability << '.');
+            LOG_SFL("cap_get_flag failed for capability " << capability);
         }
         return false;
     }
@@ -389,11 +389,11 @@ static int createLibreOfficeKit(const std::string& childRoot,
         // Parent
         if (pid < 0)
         {
-            LOG_SYS("Fork failed.");
+            LOG_SYS("Fork failed");
         }
         else
         {
-            LOG_INF("Forked kit [" << pid << "].");
+            LOG_INF("Forked kit [" << pid << ']');
             childJails[pid] = childRoot + jailId;
         }
 

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -404,7 +404,7 @@ namespace
         caps = cap_get_proc();
         if (caps == nullptr)
         {
-            LOG_SFL("cap_get_proc() failed.");
+            LOG_SFL("cap_get_proc() failed");
             Log::shutdown();
             std::_Exit(1);
         }
@@ -416,14 +416,14 @@ namespace
         if (cap_set_flag(caps, CAP_EFFECTIVE, sizeof(cap_list)/sizeof(cap_list[0]), cap_list, CAP_CLEAR) == -1 ||
             cap_set_flag(caps, CAP_PERMITTED, sizeof(cap_list)/sizeof(cap_list[0]), cap_list, CAP_CLEAR) == -1)
         {
-            LOG_SFL("cap_set_flag() failed.");
+            LOG_SFL("cap_set_flag() failed");
             Log::shutdown();
             std::_Exit(1);
         }
 
         if (cap_set_proc(caps) == -1)
         {
-            LOG_SFL("cap_set_proc() failed.");
+            LOG_SFL("cap_set_proc() failed");
             Log::shutdown();
             std::_Exit(1);
         }
@@ -2275,14 +2275,14 @@ void lokit_main(
             LOG_INF("chroot(\"" << jailPathStr << "\")");
             if (chroot(jailPathStr.c_str()) == -1)
             {
-                LOG_SFL("chroot(\"" << jailPathStr << "\") failed.");
+                LOG_SFL("chroot(\"" << jailPathStr << "\") failed");
                 Log::shutdown();
                 std::_Exit(EX_SOFTWARE);
             }
 
             if (chdir("/") == -1)
             {
-                LOG_SFL("chdir(\"/\") in jail failed.");
+                LOG_SFL("chdir(\"/\") in jail failed");
                 Log::shutdown();
                 std::_Exit(EX_SOFTWARE);
             }
@@ -2356,22 +2356,22 @@ void lokit_main(
         if (getrlimit(RLIMIT_AS, &rlim) == 0)
             LOG_INF("RLIMIT_AS is " << Util::getHumanizedBytes(rlim.rlim_max) << " (" << rlim.rlim_max << " bytes)");
         else
-            LOG_SYS("Failed to get RLIMIT_AS.");
+            LOG_SYS("Failed to get RLIMIT_AS");
 
         if (getrlimit(RLIMIT_STACK, &rlim) == 0)
             LOG_INF("RLIMIT_STACK is " << Util::getHumanizedBytes(rlim.rlim_max) << " (" << rlim.rlim_max << " bytes)");
         else
-            LOG_SYS("Failed to get RLIMIT_STACK.");
+            LOG_SYS("Failed to get RLIMIT_STACK");
 
         if (getrlimit(RLIMIT_FSIZE, &rlim) == 0)
             LOG_INF("RLIMIT_FSIZE is " << Util::getHumanizedBytes(rlim.rlim_max) << " (" << rlim.rlim_max << " bytes)");
         else
-            LOG_SYS("Failed to get RLIMIT_FSIZE.");
+            LOG_SYS("Failed to get RLIMIT_FSIZE");
 
         if (getrlimit(RLIMIT_NOFILE, &rlim) == 0)
             LOG_INF("RLIMIT_NOFILE is " << rlim.rlim_max << " files.");
         else
-            LOG_SYS("Failed to get RLIMIT_NOFILE.");
+            LOG_SYS("Failed to get RLIMIT_NOFILE");
 
         LOG_INF("Kit process for Jail [" << jailId << "] is ready.");
 

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -678,7 +678,8 @@ bool ServerSocket::bind(Type type, int port)
     }
 
     if (rc)
-        LOG_SYS("Failed to bind to: " << (_type == Socket::Type::IPv4 ? "IPv4" : "IPv6") << " port: " << port);
+        LOG_SYS("Failed to bind to: " << (_type == Socket::Type::IPv4 ? "IPv4" : "IPv6")
+                                      << " port: " << port);
 
     return rc == 0;
 #else
@@ -734,7 +735,7 @@ std::shared_ptr<Socket> ServerSocket::accept()
     }
     catch (const std::exception& ex)
     {
-        LOG_SYS("Failed to create client socket #" << rc << ". Error: " << ex.what());
+        LOG_ERR("Failed to create client socket #" << rc << ". Error: " << ex.what());
     }
 
     return nullptr;
@@ -835,7 +836,7 @@ std::shared_ptr<Socket> LocalServerSocket::accept()
     }
     catch (const std::exception& ex)
     {
-        LOG_SYS("Failed to create client socket #" << rc << ". Error: " << ex.what());
+        LOG_ERR("Failed to create client socket #" << rc << ". Error: " << ex.what());
         return std::shared_ptr<Socket>(nullptr);
     }
 }

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -1739,7 +1739,7 @@ bool LOOLWSD::checkAndRestoreForKit()
     }
     else if (pid < 0)
     {
-        LOG_SYS("Forkit waitpid failed.");
+        LOG_SYS("Forkit waitpid failed");
         if (errno == ECHILD)
         {
             // No child processes.


### PR DESCRIPTION
Most C and Posix API clobber errno. By failing to save
it immediately after invoking an API we risk simply
reporting the result of an arbitrary subsequent API call.

This changes LOG_SYS and LOG_SFL to take errno explicitly.
This is necessary because sometimes logging is not done
immediately after calling the function for which we
want to report errno. Similarly, both of these log
macros need to save errno before calling any functions.
This is necessary in case the argument is in fact errno
and not a copy.

Finally, both of these log macros append errno to the
log message, so there is little point in ending the
messages with a period.

Change-Id: Iecc656f67115fec78b65cad4e7c17a17623ecf43
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
