### PR TITLE
Fix different size thumbnail rendering problem

### DIFF
--- a/loleaflet/src/control/Parts.js
+++ b/loleaflet/src/control/Parts.js
@@ -106,7 +106,6 @@ L.Map.include({
 			this._docPreviews = {};
 		}
 		var autoUpdate = options ? !!options.autoUpdate : false;
-		var forAllClients = options ? !!options.broadcast : false;
 		var fetchThumbnail = options && options.fetchThumbnail ? options.fetchThumbnail : true;
 		this._docPreviews[id] = {id: id, index: index, maxWidth: maxWidth, maxHeight: maxHeight, autoUpdate: autoUpdate, invalid: false};
 
@@ -132,9 +131,6 @@ L.Map.include({
 		}
 
 		var dpiscale = L.getDpiScaleFactor();
-		if (forAllClients) {
-			dpiscale = 2; // some may be hidpi, and it is fine to send the hi-dpi slide preview to non-hpi clients
-		}
 
 		if (fetchThumbnail) {
 			this._socket.sendMessage('tile ' +

--- a/loleaflet/src/layer/tile/TileLayer.js
+++ b/loleaflet/src/layer/tile/TileLayer.js
@@ -3489,7 +3489,7 @@ L.TileLayer = L.GridLayer.extend({
 				preview = this._map._docPreviews[key];
 				if (preview.autoUpdate) {
 					if (preview.index >= 0) {
-						this._map.getPreview(preview.id, preview.index, preview.maxWidth, preview.maxHeight, {autoUpdate: true, broadcast: true});
+						this._map.getPreview(preview.id, preview.index, preview.maxWidth, preview.maxHeight, {autoUpdate: true});
 					}
 					else {
 						this._map.getCustomPreview(preview.id, preview.part, preview.width, preview.height, preview.tilePosX,


### PR DESCRIPTION
We dont send broadcasts anymore for thumbnails
therefore no need to use higher dpi in case
we have highdpi views. This causes glitching on the thumbnail
especially when a watermark is applied. It gets smaller and bigger
back and forth and also this mean x2 more rendering for single preview.

Change-Id: I80ba8c70bcd9d5d3c00c2ddffadae11a6b0b2e61
Signed-off-by: mert <mert.tumer@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

