### PR TITLE
Pre-fetching next or previous slide tiles

### DIFF
--- a/loleaflet/src/control/Parts.js
+++ b/loleaflet/src/control/Parts.js
@@ -13,14 +13,17 @@ L.Map.include({
 		if (part === 'prev') {
 			if (docLayer._selectedPart > 0) {
 				docLayer._selectedPart -= 1;
+				this._partsDirection = -1;
 			}
 		}
 		else if (part === 'next') {
 			if (docLayer._selectedPart < docLayer._parts - 1) {
 				docLayer._selectedPart += 1;
+				this._partsDirection = 1;
 			}
 		}
 		else if (typeof (part) === 'number' && part >= 0 && part < docLayer._parts) {
+			this._partsDirection = (part >= docLayer._selectedPart) ? 1 : -1;
 			docLayer._selectedPart = part;
 			docLayer._updateReferenceMarks();
 		}

--- a/loleaflet/src/layer/tile/GridLayer.js
+++ b/loleaflet/src/layer/tile/GridLayer.js
@@ -626,8 +626,8 @@ L.GridLayer = L.Layer.extend({
 
 			// create DOM fragment to append tiles in one batch
 			var fragment = document.createDocumentFragment();
-			var tilePositionsX = '';
-			var tilePositionsY = '';
+			var tilePositionsX = [];
+			var tilePositionsY = [];
 
 			for (i = 0; i < queue.length; i++) {
 				coords = queue[i];
@@ -666,32 +666,16 @@ L.GridLayer = L.Layer.extend({
 				}
 				if (!this._tileCache[key]) {
 					var twips = this._coordsToTwips(coords);
-					if (tilePositionsX !== '') {
-						tilePositionsX += ',';
-					}
-					tilePositionsX += twips.x;
-					if (tilePositionsY !== '') {
-						tilePositionsY += ',';
-					}
-					tilePositionsY += twips.y;
+					tilePositionsX.push(twips.x);
+					tilePositionsY.push(twips.y);
 				}
 				else {
 					tile.src = this._tileCache[key];
 				}
 			}
 
-			if (tilePositionsX !== '' && tilePositionsY !== '') {
-				var message = 'tilecombine ' +
-					'nviewid=0 ' +
-					'part=' + this._selectedPart + ' ' +
-					'width=' + this._tileWidthPx + ' ' +
-					'height=' + this._tileHeightPx + ' ' +
-					'tileposx=' + tilePositionsX + ' ' +
-					'tileposy=' + tilePositionsY + ' ' +
-					'tilewidth=' + this._tileWidthTwips + ' ' +
-					'tileheight=' + this._tileHeightTwips;
-
-				this._map._socket.sendMessage(message, '');
+			if (tilePositionsX.length > 0 && tilePositionsY.length > 0) {
+				this._sendTileCombineRequest(this._selectedPart, tilePositionsX, tilePositionsY);
 			}
 
 			this._level.el.appendChild(fragment);
@@ -710,6 +694,7 @@ L.GridLayer = L.Layer.extend({
 			// this._cellCursorXY = new L.Point(-1, -1);
 			// this._prevCellCursorXY = new L.Point(0, 0);
 		}
+		this._initPreFetchPartTiles();
 	},
 
 	_requestNewTiles: function () {
@@ -1010,38 +995,20 @@ L.GridLayer = L.Layer.extend({
 			rectangles.push(rectQueue);
 		}
 
-		var twips, msg;
+		var twips;
 		for (var r = 0; r < rectangles.length; ++r) {
 			rectQueue = rectangles[r];
-			var tilePositionsX = '';
-			var tilePositionsY = '';
+			var tilePositionsX = [];
+			var tilePositionsY = [];
 			for (i = 0; i < rectQueue.length; i++) {
 				coords = rectQueue[i];
 				twips = this._coordsToTwips(coords);
-
-				if (tilePositionsX !== '') {
-					tilePositionsX += ',';
-				}
-				tilePositionsX += twips.x;
-
-				if (tilePositionsY !== '') {
-					tilePositionsY += ',';
-				}
-				tilePositionsY += twips.y;
+				tilePositionsX.push(twips.x);
+				tilePositionsY.push(twips.y);
 			}
-
-			twips = this._coordsToTwips(coords);
-			msg = 'tilecombine ' +
-				'nviewid=0 ' +
-				'part=' + coords.part + ' ' +
-				'width=' + this._tileWidthPx + ' ' +
-				'height=' + this._tileHeightPx + ' ' +
-				'tileposx=' + tilePositionsX + ' '	+
-				'tileposy=' + tilePositionsY + ' ' +
-				'tilewidth=' + this._tileWidthTwips + ' ' +
-				'tileheight=' + this._tileHeightTwips;
-			this._map._socket.sendMessage(msg, '');
+			this._sendTileCombineRequest(coords.part, tilePositionsX, tilePositionsY);
 		}
+		this._initPreFetchPartTiles();
 	},
 
 	_tileReady: function (coords, err, tile) {
@@ -1167,6 +1134,63 @@ L.GridLayer = L.Layer.extend({
 			if (!this._tiles[key].loaded) { return false; }
 		}
 		return true;
+	},
+
+	_initPreFetchPartTiles: function() {
+		// check existing timeout and clear it before the new one
+		if (this._partTilePreFetcher)
+			clearTimeout(this._partTilePreFetcher);
+		this._partTilePreFetcher =
+			setTimeout(
+				L.bind(function() {
+					this._preFetchPartTiles(this._selectedPart + this._map._partsDirection);
+				},
+				this),
+				100 /*ms*/);
+	},
+
+	_preFetchPartTiles: function(part) {
+		var center = this._map.getCenter();
+		var zoom = this._map.getZoom();
+		var pixelBounds = this._map.getPixelBounds(center, zoom);
+		var tileRange = this._pxBoundsToTileRange(pixelBounds);
+		var tilePositionsX = [];
+		var tilePositionsY = [];
+		for (var j = tileRange.min.y; j <= tileRange.max.y; j++) {
+			for (var i = tileRange.min.x; i <= tileRange.max.x; i++) {
+				var coords = new L.Point(i, j);
+				coords.z = zoom;
+				coords.part = part;
+
+				if (!this._isValidTile(coords))
+					continue;
+
+				var key = this._tileCoordsToKey(coords);
+				if (this._tileCache[key])
+					continue;
+
+				var twips = this._coordsToTwips(coords);
+				tilePositionsX.push(twips.x);
+				tilePositionsY.push(twips.y);
+			}
+		}
+		if (tilePositionsX.length <= 0 || tilePositionsY.length <= 0) {
+			return;
+		}
+		this._sendTileCombineRequest(part, tilePositionsX, tilePositionsY);
+	},
+
+	_sendTileCombineRequest: function(part, tilePositionsX, tilePositionsY) {
+		var msg = 'tilecombine ' +
+			'nviewid=0 ' +
+			'part=' + part + ' ' +
+			'width=' + this._tileWidthPx + ' ' +
+			'height=' + this._tileHeightPx + ' ' +
+			'tileposx=' + tilePositionsX.join() + ' '	+
+			'tileposy=' + tilePositionsY.join() + ' ' +
+			'tilewidth=' + this._tileWidthTwips + ' ' +
+			'tileheight=' + this._tileHeightTwips;
+		this._map._socket.sendMessage(msg, '');
 	},
 
 	_preFetchTiles: function (forceBorderCalc) {

--- a/loleaflet/src/layer/tile/TileLayer.js
+++ b/loleaflet/src/layer/tile/TileLayer.js
@@ -2147,6 +2147,11 @@ L.TileLayer = L.GridLayer.extend({
 			}
 			tile.el.src = img;
 		}
+		// cache the following parts tiles
+		// this will help avoiding the tear effect when switching to the next part
+		if (this._selectedPart !== coords.part && !this._tileCache[key]) {
+			this._tileCache[key] = img;
+		}
 		L.Log.log(textMsg, 'INCOMING', key);
 
 		// Send acknowledgment, that the tile message arrived

--- a/loleaflet/src/map/Map.js
+++ b/loleaflet/src/map/Map.js
@@ -118,6 +118,7 @@ L.Map = L.Evented.extend({
 		this._previewQueue = [];
 		this._previewRequestsOnFly = 0;
 		this._timeToEmptyQueue = new Date();
+		this._partsDirection = 1; // For pre-fetching the slides in the direction of travel.
 		// Focusing:
 		//
 		// Cursor is visible or hidden (e.g. for graphic selection).


### PR DESCRIPTION
Fetch the tiles of the part that is in the direction
of travel. This way we will avoid the tear effect
while browsing the tiles sequentially.

Change-Id: Ie47d1174f986253e4b43aa0c3276f05e7ddd0c81
Signed-off-by: mert <mert.tumer@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

