### PR TITLE
kit: enable input process when early dialog show

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -766,6 +766,21 @@ public:
             }
             return;
         }
+        else if (type == LOK_CALLBACK_JSDIALOG)
+        {
+            if (self->_sessions.size() == 1)
+            {
+                auto it = self->_sessions.begin();
+                std::shared_ptr<ChildSession> session = it->second;
+                if (session && !session->isCloseFrame())
+                {
+                    session->loKitCallback(type, payload);
+                    // TODO.  It should filter some messages
+                    // before loading the document
+                    session->getProtocol()->enableProcessInput(true);
+                }
+            }
+        }
         else if (type == LOK_CALLBACK_PROFILE_FRAME)
             return; // already trace dumped above.
 


### PR DESCRIPTION
Before loading the document and if it has an embedded
macros, it will show the "Macro Security Warning"
message dialog.

If the input process is not enabled, the result will be
a virtual deadlock, so it should filter some messages at least.

Change-Id: I565569a0227ac0e7ce2feae2cf3ccdf21ce4b1d4
Signed-off-by: Henry Castro <hcastro@collabora.com>
