### PR TITLE
test: makefile: fix build  builddir!=srcdir

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -9,6 +9,7 @@ noinst_PROGRAMS = fakesockettest unittest
 
 AM_CXXFLAGS = $(CPPUNIT_CFLAGS) -DTDOC=\"$(abs_top_srcdir)/test/data\" \
 	-I${top_srcdir}/common -I${top_srcdir}/net -I${top_srcdir}/wsd -I${top_srcdir}/kit \
+	-I${top_srcdir} \
 	-pthread -DLOOLWSD_DATADIR='"@LOOLWSD_DATADIR@"' \
 	-DLOOLWSD_CONFIGDIR='"@LOOLWSD_CONFIGDIR@"' \
 	-DDEBUG_ABSSRCDIR='"@abs_srcdir@"' \


### PR DESCRIPTION
fatal error: test/lokassert.hpp: No such file or dire
ctory
   17 | #include <test/lokassert.hpp>

Change-Id: I935cc4e0afd6862469d27b3d2620dfa83e38ef69
Signed-off-by: Henry Castro <hcastro@collabora.com>
