### PR TITLE
wsd: UploadResult cleanup

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1180,7 +1180,7 @@ void DocumentBroker::handleUploadToStorageResponse(
             sessionIt.second->sendTextFrameAndLogError("error: cmd=storage kind=savediskfull");
         }
 
-        broadcastSaveResult(false, "Disk full", storageSaveResult.getErrorMsg());
+        broadcastSaveResult(false, "Disk full", storageSaveResult.getReason());
     }
     else if (storageSaveResult.getResult() == StorageBase::UploadResult::Result::UNAUTHORIZED)
     {
@@ -1219,7 +1219,7 @@ void DocumentBroker::handleUploadToStorageResponse(
                                                 << "]. The client session is closed.");
         }
 
-        broadcastSaveResult(false, "Save failed", storageSaveResult.getErrorMsg());
+        broadcastSaveResult(false, "Save failed", storageSaveResult.getReason());
     }
     else if (storageSaveResult.getResult() == StorageBase::UploadResult::Result::DOC_CHANGED
              || storageSaveResult.getResult() == StorageBase::UploadResult::Result::CONFLICT)
@@ -1230,7 +1230,8 @@ void DocumentBroker::handleUploadToStorageResponse(
             = isModified() ? "error: cmd=storage kind=documentconflict" : "close: documentconflict";
 
         broadcastMessage(message);
-        broadcastSaveResult(false, "Conflict: Document changed in storage", storageSaveResult.getErrorMsg());
+        broadcastSaveResult(false, "Conflict: Document changed in storage",
+                            storageSaveResult.getReason());
     }
 }
 

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -424,10 +424,10 @@ StorageBase::UploadResult LocalStorage::uploadLocalFileToStorage(
     {
         LOG_ERR("copyTo(\"" << getRootFilePathAnonym() << "\", \"" << LOOLWSD::anonymizeUrl(path)
                             << "\") failed: " << exc.displayText());
-        return StorageBase::UploadResult::Result::FAILED;
+        return UploadResult(UploadResult::Result::FAILED, "Internal error.");
     }
 
-    return StorageBase::UploadResult::Result::OK;
+    return UploadResult(UploadResult::Result::OK);
 }
 
 #if !MOBILEAPP
@@ -1005,6 +1005,7 @@ WopiStorage::uploadLocalFileToStorage(const Authorization& auth, const std::stri
     if (!fileStat.good())
     {
         LOG_ERR("Cannot access file [" << filePathAnonym << "] to upload to wopi storage.");
+        return UploadResult(UploadResult::Result::FAILED, "File not found.");
     }
 
     const std::size_t size = (fileStat.good() ? fileStat.size() : 0);
@@ -1115,17 +1116,18 @@ WopiStorage::uploadLocalFileToStorage(const Authorization& auth, const std::stri
         Poco::StreamCopier::copyStream(rs, oss);
         return handleUploadToStorageResponse(details, oss.str());
     }
-    catch (const Poco::Exception& pexc)
+    catch (const Poco::Exception& ex)
     {
-        LOG_ERR("Cannot upload file to WOPI storage uri [" << uriAnonym << "]. Error: " <<
-                pexc.displayText() << (pexc.nested() ? " (" + pexc.nested()->displayText() + ')' : ""));
+        LOG_ERR("Cannot upload file to WOPI storage uri ["
+                << uriAnonym << "]. Error: " << ex.displayText()
+                << (ex.nested() ? " (" + ex.nested()->displayText() + ')' : ""));
     }
-    catch (const BadRequestException& exc)
+    catch (const std::exception& ex)
     {
-        LOG_ERR("Cannot upload file to WOPI storage uri [" + uriAnonym + "]. Error: " << exc.what());
+        LOG_ERR("Cannot upload file to WOPI storage uri [" + uriAnonym + "]. Error: " << ex.what());
     }
 
-    return StorageBase::UploadResult::Result::FAILED;
+    return UploadResult(UploadResult::Result::FAILED, "Internal error.");
 }
 
 StorageBase::UploadResult
@@ -1133,12 +1135,11 @@ WopiStorage::handleUploadToStorageResponse(const WopiUploadDetails& details,
                                            std::string responseString)
 {
     // Assume we failed, unless we have confirmation of success.
-    StorageBase::UploadResult result(StorageBase::UploadResult::Result::FAILED);
+    StorageBase::UploadResult result(UploadResult::Result::FAILED, responseString);
     try
     {
+        // Save a copy of the response because we might need to anonymize.
         const std::string origResponseString = responseString;
-
-        result.setErrorMsg(responseString);
 
         const std::string wopiLog(details.isSaveAs
                                       ? "WOPI::PutRelativeFile"

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -97,6 +97,9 @@ public:
         std::chrono::system_clock::time_point _modifiedTime;
     };
 
+    /// Represents the upload request result, with a Result code
+    /// and a reason message (typically for errors).
+    /// Note: the reason message may be displayed to the clients.
     class UploadResult final
     {
     public:
@@ -110,19 +113,20 @@ public:
             FAILED
         };
 
-        UploadResult(Result result) : _result(result)
+        explicit UploadResult(Result result)
+            : _result(result)
         {
         }
 
-        void setResult(Result result)
+        UploadResult(Result result, std::string reason)
+            : _result(result)
+            , _reason(std::move(reason))
         {
-            _result = result;
         }
 
-        Result getResult() const
-        {
-            return _result;
-        }
+        void setResult(Result result) { _result = result; }
+
+        Result getResult() const { return _result; }
 
         void setSaveAsResult(const std::string& name, const std::string& url)
         {
@@ -130,31 +134,19 @@ public:
             _saveAsUrl = url;
         }
 
-        const std::string& getSaveAsName() const
-        {
-            return _saveAsName;
-        }
+        const std::string& getSaveAsName() const { return _saveAsName; }
 
-        const std::string& getSaveAsUrl() const
-        {
-            return _saveAsUrl;
-        }
+        const std::string& getSaveAsUrl() const { return _saveAsUrl; }
 
-        void setErrorMsg(const std::string &msg)
-        {
-            _errorMsg = msg;
-        }
+        void setReason(const std::string& msg) { _reason = msg; }
 
-        const std::string &getErrorMsg() const
-        {
-            return _errorMsg;
-        }
+        const std::string& getReason() const { return _reason; }
 
     private:
         Result _result;
         std::string _saveAsName;
         std::string _saveAsUrl;
-        std::string _errorMsg;
+        std::string _reason;
     };
 
     enum class LOOLStatusCode


### PR DESCRIPTION
A minor cleanup of UploadResult to make tidy
it up a little bit and make it less specific.

Single-argument constructors should be explicit
to avoid unexpected conversion and other surprises.

Change-Id: I57599805743dffddac620f501dc6ca79c2217f89
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
