### PR TITLE
Zoom-animation and oversized canvas fixes

### DIFF
--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -465,7 +465,7 @@ L.CanvasTilePainter = L.Class.extend({
 		var paneBoundsList = ctx.paneBoundsList;
 		var splitPos = ctx.paneBoundsActive ? this._splitPos.multiplyBy(this._dpiScale) : new L.Point(0, 0);
 
-		var rafFunc = function () {
+		this._rafFunc = function () {
 
 			for (var i = 0; i < paneBoundsList.length; ++i) {
 				var paneBounds = paneBoundsList[i];
@@ -497,18 +497,23 @@ L.CanvasTilePainter = L.Class.extend({
 					paneSize.x, paneSize.y);
 			}
 
-			painter._zoomRAF = requestAnimationFrame(rafFunc);
+			painter._zoomRAF = requestAnimationFrame(painter._rafFunc);
 		};
-		rafFunc();
+		this._rafFunc();
 	},
 
-	zoomStep: function (zoom, newCenter) {
+	_calcZoomFrameScale: function (zoom, newCenter) {
 		zoom = this._map._limitZoom(zoom);
 		var origZoom = this._map.getZoom();
 		// Compute relative-multiplicative scale of this zoom-frame w.r.t the starting zoom(ie the current Map's zoom).
 		this._zoomFrameScale = this._map.zoomToFactor(zoom - origZoom + this._map.options.zoom);
 
 		this._newCenter = this._map.project(newCenter).multiplyBy(this._dpiScale); // in core pixels
+	},
+
+	zoomStep: function (zoom, newCenter) {
+		this._calcZoomFrameScale(zoom, newCenter);
+
 		if (!this._inZoomAnim) {
 			this._inZoomAnim = true;
 			this._layer._prefetchTilesSync();
@@ -517,10 +522,12 @@ L.CanvasTilePainter = L.Class.extend({
 		}
 	},
 
-	zoomStepEnd: function () {
-		this._zoomFrameScale = undefined;
+	zoomStepEnd: function (zoom, newCenter) {
 		if (this._inZoomAnim) {
 			cancelAnimationFrame(this._zoomRAF);
+			this._calcZoomFrameScale(zoom, newCenter);
+			this._rafFunc();
+			this._zoomFrameScale = undefined;
 			this._inZoomAnim = false;
 		}
 	}
@@ -693,8 +700,8 @@ L.CanvasTileLayer = L.TileLayer.extend({
 		this._painter.zoomStep(zoom, newCenter);
 	},
 
-	zoomStepEnd: function () {
-		this._painter.zoomStepEnd();
+	zoomStepEnd: function (zoom, newCenter) {
+		this._painter.zoomStepEnd(zoom, newCenter);
 	},
 
 	_viewReset: function (e) {

--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -106,9 +106,9 @@ L.CanvasTilePainter = L.Class.extend({
 		this._canvasCtx.setTransform(1,0,0,1,0,0);
 	},
 
-	_setCanvasSize: function (widthCSSPx, heightCSSPx) {
-		this._pixWidth = Math.floor(widthCSSPx * this._dpiScale);
-		this._pixHeight = Math.floor(heightCSSPx * this._dpiScale);
+	_setCanvasSize: function (widthCorePx, heightCorePx) {
+		this._pixWidth = Math.floor(widthCorePx);
+		this._pixHeight = Math.floor(heightCorePx);
 
 		// real pixels have to be integral
 		this._canvas.width = this._pixWidth;
@@ -133,7 +133,7 @@ L.CanvasTilePainter = L.Class.extend({
 		this.clear();
 		this._syncTileContainerSize();
 
-		this._lastSize = new L.Point(widthCSSPx, heightCSSPx);
+		this._lastSize = new L.Point(widthCorePx, heightCorePx);
 	},
 
 	_syncTileContainerSize: function () {

--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -192,13 +192,21 @@ L.CanvasTilePainter = L.Class.extend({
 	_extendedPaneBounds: function (paneBounds) {
 		var extendedBounds = paneBounds.clone();
 		var halfExtraSize = this._osCanvasExtraSize / 2; // This is always an integer.
-		if (paneBounds.min.x) { // pane can move in x direction.
-			extendedBounds.min.x = Math.max(0, extendedBounds.min.x - halfExtraSize);
-			extendedBounds.max.x += halfExtraSize;
-		}
+		if (this._layer.getSplitPanesContext()) {
+			if (paneBounds.min.x) { // pane can move in x direction.
+				extendedBounds.min.x = Math.max(0, extendedBounds.min.x - halfExtraSize);
+				extendedBounds.max.x += halfExtraSize;
+			}
 
-		if (paneBounds.min.y) { // pane can move in y direction.
-			extendedBounds.min.y = Math.max(0, extendedBounds.min.y - halfExtraSize);
+			if (paneBounds.min.y) { // pane can move in y direction.
+				extendedBounds.min.y = Math.max(0, extendedBounds.min.y - halfExtraSize);
+				extendedBounds.max.y += halfExtraSize;
+			}
+		}
+		else {
+			extendedBounds.min.x -= halfExtraSize;
+			extendedBounds.max.x += halfExtraSize;
+			extendedBounds.min.y -= halfExtraSize;
 			extendedBounds.max.y += halfExtraSize;
 		}
 
@@ -270,7 +278,10 @@ L.CanvasTilePainter = L.Class.extend({
 
 	_paintSimple: function (tile, ctx) {
 		var offset = new L.Point(tile.coords.getPos().x - ctx.viewBounds.min.x, tile.coords.getPos().y - ctx.viewBounds.min.y);
+		var halfExtraSize = this._osCanvasExtraSize / 2;
+		var extendedOffset = offset.add(new L.Point(halfExtraSize, halfExtraSize));
 		this._canvasCtx.drawImage(tile.el, offset.x, offset.y, ctx.tileSize.x, ctx.tileSize.y);
+		this._oscCtxs[0].drawImage(tile.el, extendedOffset.x, extendedOffset.y, ctx.tileSize.x, ctx.tileSize.y);
 	},
 
 	paint: function(tile, ctx) {

--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -233,9 +233,9 @@ L.CanvasTilePainter = L.Class.extend({
 
 			if (extendedBounds.intersects(tileBounds)) {
 				var offset = extendedBounds.getTopLeft();
-				viewBounds.x = Math.min(offset.x, viewBounds.min.x);
-				viewBounds.y = Math.min(offset.y, viewBounds.min.y);
-				this._drawTileInPane(tile, tileBounds, extendedBounds, extendedBounds.getTopLeft(), this._oscCtxs[i]);
+				offset.x = Math.min(offset.x, viewBounds.min.x);
+				offset.y = Math.min(offset.y, viewBounds.min.y);
+				this._drawTileInPane(tile, tileBounds, extendedBounds, offset, this._oscCtxs[i]);
 			}
 		}
 	},

--- a/loleaflet/src/map/Map.js
+++ b/loleaflet/src/map/Map.js
@@ -1862,6 +1862,20 @@ L.Map = L.Evented.extend({
 		}
 
 		return undefined;
+	},
+
+	_setPaneOpacity: function(paneClassString, opacity) {
+		var panes = document.getElementsByClassName(paneClassString);
+		if (panes.length)
+			panes[0].style.opacity = opacity;
+	},
+
+	setOverlaysOpacity: function(opacity) {
+		this._setPaneOpacity('leaflet-pane leaflet-overlay-pane', opacity);
+	},
+
+	setMarkersOpacity: function(opacity) {
+		this._setPaneOpacity('leaflet-pane leaflet-marker-pane', opacity);
 	}
 });
 

--- a/loleaflet/src/map/handler/Map.TouchGesture.js
+++ b/loleaflet/src/map/handler/Map.TouchGesture.js
@@ -569,11 +569,11 @@ L.Map.TouchGesture = L.Handler.extend({
 		this._center = this._map._limitCenter(this._map.mouseEventToLatLng({clientX: center.x, clientY: center.y}),
 						      this._zoom, this._map.options.maxBounds);
 
-		var origCenter = this._map._limitCenter(this._map.mouseEventToLatLng({clientX: center.x, clientY: center.y}),
+		this._origCenter = this._map._limitCenter(this._map.mouseEventToLatLng({clientX: center.x, clientY: center.y}),
 							  this._map.getZoom(), this._map.options.maxBounds);
 
 		if (this._map._docLayer.zoomStep) {
-			this._map._docLayer.zoomStep(this._zoom, origCenter);
+			this._map._docLayer.zoomStep(this._zoom, this._origCenter);
 		}
 	},
 
@@ -610,7 +610,7 @@ L.Map.TouchGesture = L.Handler.extend({
 		this._pinchStartCenter = undefined;
 
 		if (this._map._docLayer.zoomStepEnd) {
-			this._map._docLayer.zoomStepEnd();
+			this._map._docLayer.zoomStepEnd(finalZoom, this._origCenter);
 		}
 
 		this._map.setView(this._center, finalZoom);

--- a/loleaflet/src/map/handler/Map.TouchGesture.js
+++ b/loleaflet/src/map/handler/Map.TouchGesture.js
@@ -544,6 +544,10 @@ L.Map.TouchGesture = L.Handler.extend({
 		if (this._map._textInput._cursorHandler) {
 			this._map._textInput._cursorHandler.setOpacity(0);
 		}
+		if (this._map._docLayer._cellCursorMarker) {
+			this._map.setOverlaysOpacity(0);
+			this._map.setMarkersOpacity(0);
+		}
 		if (this._map._docLayer._selectionHandles['start']) {
 			this._map._docLayer._selectionHandles['start'].setOpacity(0);
 		}
@@ -591,6 +595,10 @@ L.Map.TouchGesture = L.Handler.extend({
 		}
 		if (this._map._textInput._cursorHandler) {
 			this._map._textInput._cursorHandler.setOpacity(1);
+		}
+		if (this._map._docLayer._cellCursorMarker) {
+			this._map.setOverlaysOpacity(1);
+			this._map.setMarkersOpacity(1);
 		}
 		if (this._map._docLayer._selectionHandles['start']) {
 			this._map._docLayer._selectionHandles['start'].setOpacity(1);


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

The patchset fixes lack of zoom-animation in writer/impress, reduces the view jump after zoom animation due to rounding of zoom and finally fixes oversized canvases due to double application of DPI-scale.

### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

