### PR TITLE
leaflet: avoid creating child comment when possible in wizard

### DIFF
--- a/loleaflet/src/control/Control.JSDialogBuilder.js
+++ b/loleaflet/src/control/Control.JSDialogBuilder.js
@@ -2020,7 +2020,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		container.annotation = data.annotation;
 		container.id = data.id;
 		builder._createComment(container, data, true);
-		if (data.children.length > 0)
+		if (data.children.length > 1)
 		{
 			var numberOfReplies = data.children.length - 1;
 			if (numberOfReplies > 0)


### PR DESCRIPTION
Signed-off-by: Pranam Lashkari <lpranam@collabora.com>
Change-Id: Ibd9b04c1f275adb8e2fd0429e1bef3adb1916e0b


* Target version: master 

### Summary
no need to add child comment into the DOM if the thread has only one comment

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

