### PR TITLE
leaflet: avoid keyboard suggestions after undo/redo

### DIFF
--- a/loleaflet/src/control/Control.Toolbar.js
+++ b/loleaflet/src/control/Control.Toolbar.js
@@ -954,10 +954,22 @@ function onCommandResult(e) {
 
 		map.fire('postMessage', {msgId: 'Action_Save_Resp', args: postMessageObj});
 	}
-	else if ((commandName === '.uno:Undo' || commandName === '.uno:Redo') &&
-		e.success === true && e.result.value && !isNaN(e.result.value)) { /*UNDO_CONFLICT*/
-		$('#tb_editbar_item_repair').w2overlay({ html: '<div style="padding: 10px; line-height: 150%">' +
+	else if (commandName === '.uno:Undo' || commandName === '.uno:Redo') {
+		if (e.success === true && e.result.value && !isNaN(e.result.value)) { /*UNDO_CONFLICT*/
+			$('#tb_editbar_item_repair').w2overlay({ html: '<div style="padding: 10px; line-height: 150%">' +
 			_('Conflict Undo/Redo with multiple users. Please use document repair to resolve') + '</div>'});
+		}
+		else if (window.mode.isMobile()) {
+			//undoing something on mobile does not trigger any input method
+			//this causes problem in mobile working with suggestions
+			//i.e: type "than" and then select "thank" from suggestion
+			//now undo and then again select "thanks" from suggestions
+			//final output is "thans"
+			//this happens because undo doesn't change the textArea value
+			//and no other way to maintain the history
+			//So better to clean the textarea so no suggestions appear
+			map._textInput._textArea.value = map._textInput._preSpaceChar;
+		}
 	}
 }
 

--- a/loleaflet/src/control/Control.Toolbar.js
+++ b/loleaflet/src/control/Control.Toolbar.js
@@ -954,22 +954,10 @@ function onCommandResult(e) {
 
 		map.fire('postMessage', {msgId: 'Action_Save_Resp', args: postMessageObj});
 	}
-	else if (commandName === '.uno:Undo' || commandName === '.uno:Redo') {
-		if (e.success === true && e.result.value && !isNaN(e.result.value)) { /*UNDO_CONFLICT*/
-			$('#tb_editbar_item_repair').w2overlay({ html: '<div style="padding: 10px; line-height: 150%">' +
-			_('Conflict Undo/Redo with multiple users. Please use document repair to resolve') + '</div>'});
-		}
-		else if (window.mode.isMobile()) {
-			//undoing something on mobile does not trigger any input method
-			//this causes problem in mobile working with suggestions
-			//i.e: type "than" and then select "thank" from suggestion
-			//now undo and then again select "thanks" from suggestions
-			//final output is "thans"
-			//this happens because undo doesn't change the textArea value
-			//and no other way to maintain the history
-			//So better to clean the textarea so no suggestions appear
-			map._textInput._textArea.value = map._textInput._preSpaceChar;
-		}
+	else if ((commandName === '.uno:Undo' || commandName === '.uno:Redo') &&
+		e.success === true && e.result.value && !isNaN(e.result.value)) { /*UNDO_CONFLICT*/
+		$('#tb_editbar_item_repair').w2overlay({ html: '<div style="padding: 10px; line-height: 150%">' +
+		_('Conflict Undo/Redo with multiple users. Please use document repair to resolve') + '</div>'});
 	}
 }
 

--- a/loleaflet/src/layer/marker/TextInput.js
+++ b/loleaflet/src/layer/marker/TextInput.js
@@ -90,6 +90,7 @@ L.TextInput = L.Layer.extend({
 		this._emptyArea();
 
 		this._map.on('updatepermission', this._onPermission, this);
+		this._map.on('commandresult', this._onCommandResult, this);
 		L.DomEvent.on(this._textArea, 'focus blur', this._onFocusBlur, this);
 
 		// Do not wait for a 'focus' event to attach events if the
@@ -137,6 +138,20 @@ L.TextInput = L.Layer.extend({
 			this._textArea.removeAttribute('disabled');
 		} else {
 			this._textArea.setAttribute('disabled', true);
+		}
+	},
+
+	_onCommandResult: function(e) {
+		if ((e.commandName === '.uno:Undo' || e.commandName === '.uno:Redo') && window.mode.isMobile()) {
+			//undoing something on mobile does not trigger any input method
+			//this causes problem in mobile working with suggestions
+			//i.e: type "than" and then select "thank" from suggestion
+			//now undo and then again select "thanks" from suggestions
+			//final output is "thans"
+			//this happens because undo doesn't change the textArea value
+			//and no other way to maintain the history
+			//So better to clean the textarea so no suggestions appear
+			this._map._textInput._textArea.value = this._map._textInput._preSpaceChar;
 		}
 	},
 


### PR DESCRIPTION
* Target version: distro/collabora/co-6-4

### Summary
problem:
undoing something on mobile does not trigger any input method
this causes problem in mobile working with suggestions
i.e: type "than" and then select "thank" from suggestion
now undo and then again select "thanks" from suggestions
final output is "thans"
this happens because undo doesn't change the textArea value
and no other way to maintain the history
So better to clean the textarea so no suggestions appear


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

