### PR TITLE
leaflet: don't create container for frame in mobile wizard

### DIFF
--- a/loleaflet/src/control/Control.MobileWizardBuilder.js
+++ b/loleaflet/src/control/Control.MobileWizardBuilder.js
@@ -260,7 +260,7 @@ L.Control.MobileWizardBuilder = L.Control.JSDialogBuilder.extend({
 			var childType = childData.type;
 			var processChildren = true;
 			var needsToCreateContainer =
-				childType == 'panel' || childType == 'frame';
+				childType == 'panel';
 
 			if ((childData.id === undefined || childData.id === '' || childData.id === null)
 				&& (childType == 'checkbox' || childType == 'radiobutton')) {


### PR DESCRIPTION


Signed-off-by: Pranam Lashkari <lpranam@collabora.com>
Change-Id: I5f6342febcf444c71eef964da5585e5f73ae367e


* Target version: distro/collabora/co-6-4 

### Summary
problem:
creating an additional container for frames causes problem in wizard
while trying to go level up because changing level depends upon
finding the sibling of the current not and making them visible or invisible
having extra container breaks this relation

in addition not creating an additional container does not affect anything visually

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

