### PR TITLE
admin fuzzer: fix build

### DIFF
--- a/fuzzer/ClientSession.cpp
+++ b/fuzzer/ClientSession.cpp
@@ -39,7 +39,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
     }
 
     // Make sure SocketPoll::_newCallbacks does not grow forever, leading to OOM.
-    Admin::instance().poll(0);
+    Admin::instance().poll(std::chrono::microseconds(0));
 
     // Make sure the anon map does not grow forever, leading to OOM.
     Util::clearAnonymized();


### PR DESCRIPTION
This went wrong in commit 693a2e19e3732a08609d1a709010e12325de1e32 (wsd:
SocketPoll::poll accepts chrono duration, 2020-12-14).

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I04780d7a5ef8ba54530df7727f2fe4df59995fb9
