### PR TITLE
Optimize copy of jails to hard-linking with new capability.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -342,7 +342,7 @@ CAPABILITIES = $(if @ENABLE_SETCAP@,true,false)
 RUN_GDB = $(if $(GDB_FRONTEND),$(GDB_FRONTEND),gdb --tui --args)
 
 if ENABLE_SETCAP
-SET_CAPS_COMMAND=sudo @SETCAP@ cap_fowner,cap_mknod,cap_sys_chroot=ep loolforkit && sudo @SETCAP@ cap_sys_admin=ep loolmount
+SET_CAPS_COMMAND=sudo @SETCAP@ cap_fowner,cap_chown,cap_mknod,cap_sys_chroot=ep loolforkit && sudo @SETCAP@ cap_sys_admin=ep loolmount
 else
 SET_CAPS_COMMAND=echo "Skipping capability setting"
 endif

--- a/common/FileUtil.cpp
+++ b/common/FileUtil.cpp
@@ -380,18 +380,6 @@ namespace FileUtil
         return false;
     }
 
-    bool linkOrCopyFile(const char* source, const char* target)
-    {
-        if (link(source, target) == -1)
-        {
-            LOG_DBG("link(\"" << source << "\", \"" << target << "\") failed: " << strerror(errno)
-                              << ". Will copy.");
-            return copy(source, target, /*log=*/false, /*throw_on_error=*/false);
-        }
-
-        return true;
-    }
-
     bool compareFileContents(const std::string& rhsPath, const std::string& lhsPath)
     {
         std::ifstream rhs(rhsPath, std::ifstream::binary | std::ifstream::ate);

--- a/common/FileUtil.hpp
+++ b/common/FileUtil.hpp
@@ -117,9 +117,6 @@ namespace FileUtil
         return getTempFileCopyPath(srcDir, srcFilename, std::string());
     }
 
-    /// Link source to target, and copy if linking fails.
-    bool linkOrCopyFile(const char* source, const char* target);
-
     /// Returns the realpath(3) of the provided path.
     std::string realpath(const char* path);
     inline std::string realpath(const std::string& path)

--- a/common/JailUtil.cpp
+++ b/common/JailUtil.cpp
@@ -152,7 +152,7 @@ void cleanupJails(const std::string& root)
         return;
     }
 
-    //FIXME: technically, the loTemplate directory may have any name.
+    // FIXME: technically, the loTemplate directory may have any name.
     if (FileUtil::Stat(root + "/lo").exists())
     {
         // This is a jail.
@@ -168,7 +168,8 @@ void cleanupJails(const std::string& root)
         for (const auto& jail : jails)
         {
             const Poco::Path path(root, jail);
-            if (jail == "tmp") // Delete tmp with prejeduce.
+            // Delete tmp and link cache with prejudice.
+            if (jail == "tmp" || jail == "linkable")
                 FileUtil::removeFile(path.toString(), true);
             else
                 cleanupJails(path.toString());

--- a/debian/loolwsd.postinst.in
+++ b/debian/loolwsd.postinst.in
@@ -4,7 +4,7 @@ set -e
 
 case "$1" in
     configure)
-	setcap cap_fowner,cap_mknod,cap_sys_chroot=ep /usr/bin/loolforkit || true
+	setcap cap_fowner,cap_chown,cap_mknod,cap_sys_chroot=ep /usr/bin/loolforkit || true
 	setcap cap_sys_admin=ep /usr/bin/loolmount || true
 
 	adduser --quiet --system --group --home /opt/lool lool

--- a/docker/from-source/Debian
+++ b/docker/from-source/Debian
@@ -24,7 +24,7 @@ COPY /start-collabora-online.sh /
 
 # set up Collabora Online (normally done by postinstall script of package)
 # Fix permissions
-RUN setcap cap_fowner,cap_mknod,cap_sys_chroot=ep /usr/bin/loolforkit && \
+RUN setcap cap_fowner,cap_chown,cap_mknod,cap_sys_chroot=ep /usr/bin/loolforkit && \
     setcap cap_sys_admin=ep /usr/bin/loolmount && \
     adduser --quiet --system --group --home /opt/lool lool && \
     mkdir -p /var/cache/loolwsd && chown lool: /var/cache/loolwsd && \

--- a/docker/from-source/Ubuntu
+++ b/docker/from-source/Ubuntu
@@ -26,7 +26,7 @@ COPY /start-collabora-online.sh /
 
 # set up Collabora Online (normally done by postinstall script of package)
 # Fix permissions
-RUN setcap cap_fowner,cap_mknod,cap_sys_chroot=ep /usr/bin/loolforkit && \
+RUN setcap cap_fowner,cap_chown,cap_mknod,cap_sys_chroot=ep /usr/bin/loolforkit && \
     setcap cap_sys_admin=ep /usr/bin/loolmount && \
     adduser --quiet --system --group --home /opt/lool lool && \
     mkdir -p /var/cache/loolwsd && chown lool: /var/cache/loolwsd && \

--- a/kit/ForKit.cpp
+++ b/kit/ForKit.cpp
@@ -253,6 +253,8 @@ static bool haveCorrectCapabilities()
         result = false;
     if (!haveCapability(CAP_FOWNER))
         result = false;
+    if (!haveCapability(CAP_CHOWN))
+        result = false;
 
     return result;
 }

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -150,6 +150,7 @@ namespace
     LinkOrCopyType linkOrCopyType;
     std::string sourceForLinkOrCopy;
     Path destinationForLinkOrCopy;
+    std::string linkableForLinkOrCopy; // Place to stash copies that we can hard-link from
     std::chrono::time_point<std::chrono::steady_clock> linkOrCopyStartTime;
     bool linkOrCopyVerboseLogging = false;
     unsigned linkOrCopyFileCount = 0; // Track to help quantify the link-or-copy performance.
@@ -247,7 +248,56 @@ namespace
         if (linkOrCopyVerboseLogging)
             LOG_INF("Linking file \"" << fpath << "\" to \"" << newPath << '"');
 
-        if (!FileUtil::linkOrCopyFile(fpath, newPath.c_str()))
+        // first try a simple hard-link
+        if (link(fpath, newPath.c_str()) == 0)
+            return;
+
+        // incrementally build our 'linkable/' copy nearby
+        static bool canChown = true; // only if we can get permissions right
+        if (errno == EXDEV && canChown)
+        {
+            // then copy somewhere closer and hard link from there
+            LOG_TRC("link(\"" << fpath << "\", \"" << newPath << "\") failed: " << strerror(errno)
+                    << ". Will try to link template.");
+
+            std::string linkableCopy = linkableForLinkOrCopy + fpath;
+            if (::link(linkableCopy.c_str(), newPath.c_str()) == 0)
+                return;
+
+            if (errno == ENOENT)
+            {
+                File(Path(linkableCopy).parent()).createDirectories();
+                if (!FileUtil::copy(fpath, linkableCopy.c_str(), /*log=*/false, /*throw_on_error=*/false))
+                    LOG_TRC("Failed to create linkable copy [" << fpath << "] to [" << linkableCopy.c_str() << "]");
+                else {
+                    // Match system permissions, so a file we can write is not shared across jails.
+                    struct stat ownerInfo;
+                    if (::stat(fpath, &ownerInfo) != 0 ||
+                        ::chown(linkableCopy.c_str(), ownerInfo.st_uid, ownerInfo.st_gid) != 0)
+                    {
+                        LOG_WRN("Failed to stat or chown " << ownerInfo.st_uid << ":" << ownerInfo.st_gid <<
+                                " " << linkableCopy << ": " << strerror(errno) << " missing cap_chown?, disabling linkable");
+                        unlink(linkableCopy.c_str());
+                        canChown = false;
+                    }
+                    else if (::link(linkableCopy.c_str(), newPath.c_str()) == 0)
+                        return;
+                }
+            }
+            LOG_TRC("link(\"" << linkableCopy << "\", \"" << newPath << "\") failed: " << strerror(errno)
+                    << ". Cannot create linkable copy.");
+        }
+
+        static bool warned = false;
+        if (!warned)
+        {
+            LOG_ERR("link(\"" << fpath << "\", \"" << newPath.c_str() << "\") failed: " << strerror(errno)
+                    << ". Very slow copying path triggered.");
+            warned = true;
+        } else
+            LOG_TRC("link(\"" << fpath << "\", \"" << newPath.c_str() << "\") failed: " << strerror(errno)
+                    << ". Will copy.");
+        if (!FileUtil::copy(fpath, newPath.c_str(), /*log=*/false, /*throw_on_error=*/false))
         {
             LOG_FTL("Failed to copy or link [" << fpath << "] to [" << newPath << "]. Exiting.");
             Log::shutdown();
@@ -355,6 +405,7 @@ namespace
 
     void linkOrCopy(std::string source,
                     const Path& destination,
+                    std::string linkable,
                     LinkOrCopyType type)
     {
         std::string resolved = FileUtil::realpath(source);
@@ -373,6 +424,7 @@ namespace
         if (sourceForLinkOrCopy.back() == '/')
             sourceForLinkOrCopy.pop_back();
         destinationForLinkOrCopy = destination;
+        linkableForLinkOrCopy = linkable;
         linkOrCopyFileCount = 0;
         linkOrCopyStartTime = std::chrono::steady_clock::now();
 
@@ -2236,9 +2288,11 @@ void lokit_main(
                 LOG_INF("Mounting is disabled, will link/copy " << sysTemplate << " -> "
                                                                 << jailPathStr);
 
-                linkOrCopy(sysTemplate, jailPath, LinkOrCopyType::All);
+                const std::string linkablePath = childRoot + "/linkable";
 
-                linkOrCopy(loTemplate, loJailDestPath, LinkOrCopyType::LO);
+                linkOrCopy(sysTemplate, jailPath, linkablePath, LinkOrCopyType::All);
+
+                linkOrCopy(loTemplate, loJailDestPath, linkablePath, LinkOrCopyType::LO);
 
                 // Update the dynamic files inside the jail.
                 if (!JailUtil::SysTemplate::updateDynamicFiles(jailPathStr))

--- a/loolwsd.spec.in
+++ b/loolwsd.spec.in
@@ -140,7 +140,7 @@ getent group lool >/dev/null || groupadd -r lool
 getent passwd lool >/dev/null || useradd -g lool -r lool
 
 %post
-setcap cap_fowner,cap_mknod,cap_sys_chroot=ep /usr/bin/loolforkit
+setcap cap_fowner,cap_chown,cap_mknod,cap_sys_chroot=ep /usr/bin/loolforkit
 setcap cap_sys_admin=ep /usr/bin/loolmount
 
 mkdir -p /var/cache/loolwsd && chown lool:lool /var/cache/loolwsd

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -1867,7 +1867,7 @@ bool LOOLWSD::createForKit()
 
     StringVector args;
 #ifdef STRACE_LOOLFORKIT
-    // if you want to use this, you need to setcap cap_fowner,cap_mknod,cap_sys_chroot=ep /usr/bin/strace
+    // if you want to use this, you need to setcap cap_fowner,cap_chown,cap_mknod,cap_sys_chroot=ep /usr/bin/strace
     args.push_back("-o");
     args.push_back("strace.log");
     args.push_back("-f");


### PR DESCRIPTION
In some cases we cannot do a fast bind-mount of the files we want
in our jail since we don't have cap_sys_admin for loolmount inside
eg. docker.

Thus we need to fallback to hard-linking, however various security
systems namespace parts of our tree, such that link() fails with
EXDEV even across the (apparently) same file-system.

As such we need to assemble a copy of what we want to hard-link
close to our jails. However, this needs to be owned by root / the
system to avoid having writable files shared between jails. Hence
we need cap_chown in addition to cap_fowner, to get ownership right
and then hard-link.

Change-Id: Iba0ef46ddbc1c03f3dc7177bc1ec1755624135db
