### PR TITLE
Optimize copy of jails to hard-linking with new capability.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -340,7 +340,7 @@ CAPABILITIES = $(if @ENABLE_SETCAP@,true,false)
 RUN_GDB = $(if $(GDB_FRONTEND),$(GDB_FRONTEND),gdb --tui --args)
 
 if ENABLE_SETCAP
-SET_CAPS_COMMAND=sudo @SETCAP@ cap_fowner,cap_mknod,cap_sys_chroot=ep loolforkit && sudo @SETCAP@ cap_sys_admin=ep loolmount
+SET_CAPS_COMMAND=sudo @SETCAP@ cap_fowner,cap_chown,cap_mknod,cap_sys_chroot=ep loolforkit && sudo @SETCAP@ cap_sys_admin=ep loolmount
 else
 SET_CAPS_COMMAND=echo "Skipping capability setting"
 endif

--- a/common/FileUtil.cpp
+++ b/common/FileUtil.cpp
@@ -338,18 +338,6 @@ namespace FileUtil
         return false;
     }
 
-    bool linkOrCopyFile(const char* source, const char* target)
-    {
-        if (link(source, target) == -1)
-        {
-            LOG_DBG("link(\"" << source << "\", \"" << target << "\") failed: " << strerror(errno)
-                              << ". Will copy.");
-            return copy(source, target, /*log=*/false, /*throw_on_error=*/false);
-        }
-
-        return true;
-    }
-
     bool compareFileContents(const std::string& rhsPath, const std::string& lhsPath)
     {
         std::ifstream rhs(rhsPath, std::ifstream::binary | std::ifstream::ate);

--- a/common/FileUtil.hpp
+++ b/common/FileUtil.hpp
@@ -107,9 +107,6 @@ namespace FileUtil
         return getTempFilePath(srcDir, srcFilename, std::string());
     }
 
-    /// Link source to target, and copy if linking fails.
-    bool linkOrCopyFile(const char* source, const char* target);
-
     /// Returns the realpath(3) of the provided path.
     std::string realpath(const char* path);
     inline std::string realpath(const std::string& path)

--- a/common/JailUtil.cpp
+++ b/common/JailUtil.cpp
@@ -150,7 +150,7 @@ void cleanupJails(const std::string& root)
         return;
     }
 
-    //FIXME: technically, the loTemplate directory may have any name.
+    // FIXME: technically, the loTemplate directory may have any name.
     if (FileUtil::Stat(root + "/lo").exists())
     {
         // This is a jail.
@@ -166,7 +166,8 @@ void cleanupJails(const std::string& root)
         for (const auto& jail : jails)
         {
             const Poco::Path path(root, jail);
-            if (jail == "tmp") // Delete tmp with prejeduce.
+            // Delete tmp and link cache with prejudice.
+            if (jail == "tmp" || jail == "linkable")
                 FileUtil::removeFile(path.toString(), true);
             else
                 cleanupJails(path.toString());

--- a/debian/loolwsd.postinst.in
+++ b/debian/loolwsd.postinst.in
@@ -4,7 +4,7 @@ set -e
 
 case "$1" in
     configure)
-	setcap cap_fowner,cap_mknod,cap_sys_chroot=ep /usr/bin/loolforkit || true
+	setcap cap_fowner,cap_chown,cap_mknod,cap_sys_chroot=ep /usr/bin/loolforkit || true
 	setcap cap_sys_admin=ep /usr/bin/loolmount || true
 
 	adduser --quiet --system --group --home /opt/lool lool

--- a/docker/from-source/Debian
+++ b/docker/from-source/Debian
@@ -1,0 +1,45 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+FROM debian:stable
+
+# get the latest fixes
+# install LibreOffice run-time dependencies
+# install adduser, findutils, openssl and cpio that we need later
+# install an editor
+# tdf#117557 - Add CJK Fonts to Collabora Online Docker Image
+RUN apt-get update && \
+    apt-get -y install libpng16-16 fontconfig adduser cpio \
+               findutils nano libpoco-dev libcap2-bin openssl inotify-tools \
+               procps libubsan0 libubsan1 openssh-client fonts-wqy-zenhei \
+               fonts-wqy-microhei fonts-droid-fallback fonts-noto-cjk
+
+
+# copy freshly built LOKit and Collabora Online
+COPY /instdir /
+
+# copy the shell script which can start Collabora Online (loolwsd)
+COPY /start-collabora-online.sh /
+
+# set up Collabora Online (normally done by postinstall script of package)
+# Fix permissions
+RUN setcap cap_fowner,cap_chown,cap_mknod,cap_sys_chroot=ep /usr/bin/loolforkit && \
+    setcap cap_sys_admin=ep /usr/bin/loolmount && \
+    adduser --quiet --system --group --home /opt/lool lool && \
+    mkdir -p /var/cache/loolwsd && chown lool: /var/cache/loolwsd && \
+    rm -rf /var/cache/loolwsd/* && \
+    rm -rf /opt/lool && \
+    mkdir -p /opt/lool/child-roots && \
+    loolwsd-systemplate-setup /opt/lool/systemplate /opt/libreoffice >/dev/null 2>&1 && \
+    touch /var/log/loolwsd.log && \
+    chown lool:lool /var/log/loolwsd.log && \
+    chown -R lool:lool /opt/ && \
+    chown -R lool:lool /etc/loolwsd
+
+EXPOSE 9980
+
+# switch to lool user (use numeric user id to be compatible with Kubernetes Pod Security Policies)
+USER 101
+
+CMD bash /start-collabora-online.sh

--- a/docker/from-source/Ubuntu
+++ b/docker/from-source/Ubuntu
@@ -1,0 +1,47 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+FROM ubuntu:18.04
+
+# refresh repos otherwise installations later may fail
+# install LibreOffice run-time dependencies
+# install adduser, findutils, openssl and cpio that we need later
+# install an editor
+# tdf#117557 - Add CJK Fonts to Collabora Online Docker Image
+RUN apt-get update && \
+    apt-get -y install libpng16-16 fontconfig adduser cpio \
+               findutils nano libpocoxml50 libpocoutil50 libpoconetssl50 \
+               libpoconet50 libpocojson50 libpocofoundation50 libpococrypto50 \
+               libcap2-bin openssl openssh-client inotify-tools procps \
+               libxcb-shm0 libxcb-render0 libxrender1 libxext6 \
+               fonts-wqy-zenhei fonts-wqy-microhei fonts-droid-fallback \
+               fonts-noto-cjk
+
+# copy freshly built LOKit and Collabora Online
+COPY /instdir /
+
+# copy the shell script which can start Collabora Online (loolwsd)
+COPY /start-collabora-online.sh /
+
+# set up Collabora Online (normally done by postinstall script of package)
+# Fix permissions
+RUN setcap cap_fowner,cap_chown,cap_mknod,cap_sys_chroot=ep /usr/bin/loolforkit && \
+    setcap cap_sys_admin=ep /usr/bin/loolmount && \
+    adduser --quiet --system --group --home /opt/lool lool && \
+    mkdir -p /var/cache/loolwsd && chown lool: /var/cache/loolwsd && \
+    rm -rf /var/cache/loolwsd/* && \
+    rm -rf /opt/lool && \
+    mkdir -p /opt/lool/child-roots && \
+    loolwsd-systemplate-setup /opt/lool/systemplate /opt/libreoffice >/dev/null 2>&1 && \
+    touch /var/log/loolwsd.log && \
+    chown lool:lool /var/log/loolwsd.log && \
+    chown -R lool:lool /opt/ && \
+    chown -R lool:lool /etc/loolwsd
+
+EXPOSE 9980
+
+# switch to lool user (use numeric user id to be compatible with Kubernetes Pod Security Policies)
+USER 101
+
+CMD bash /start-collabora-online.sh

--- a/kit/ForKit.cpp
+++ b/kit/ForKit.cpp
@@ -250,6 +250,8 @@ static bool haveCorrectCapabilities()
         result = false;
     if (!haveCapability(CAP_FOWNER))
         result = false;
+    if (!haveCapability(CAP_CHOWN))
+        result = false;
 
     return result;
 }

--- a/loolwsd.spec.in
+++ b/loolwsd.spec.in
@@ -187,7 +187,7 @@ if [ $LOOLWSD_IS_ACTIVE == "1" ]; then systemctl start loolwsd; fi
 echo "   Done."
 
 %post
-setcap cap_fowner,cap_mknod,cap_sys_chroot=ep /usr/bin/loolforkit
+setcap cap_fowner,cap_chown,cap_mknod,cap_sys_chroot=ep /usr/bin/loolforkit
 setcap cap_sys_admin=ep /usr/bin/loolmount
 
 mkdir -p /var/cache/loolwsd && chown lool:lool /var/cache/loolwsd

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -1862,7 +1862,7 @@ bool LOOLWSD::createForKit()
 
     StringVector args;
 #ifdef STRACE_LOOLFORKIT
-    // if you want to use this, you need to setcap cap_fowner,cap_mknod,cap_sys_chroot=ep /usr/bin/strace
+    // if you want to use this, you need to setcap cap_fowner,cap_chown,cap_mknod,cap_sys_chroot=ep /usr/bin/strace
     args.push_back("-o");
     args.push_back("strace.log");
     args.push_back("-f");


### PR DESCRIPTION
In some cases we cannot do a fast bind-mount of the files we want
in our jail since we don't have cap_sys_admin for loolmount inside
eg. docker.

Thus we need to fallback to hard-linking, however various security
systems namespace parts of our tree, such that link() fails with
EXDEV even across the (apparently) same file-system.

As such we need to assemble a copy of what we want to hard-link
close to our jails. However, this needs to be owned by root / the
system to avoid having writable files shared between jails. Hence
we need cap_chown in addition to cap_fowner, to get ownership right
and then hard-link.

Change-Id: Iba0ef46ddbc1c03f3dc7177bc1ec1755624135db
Signed-off-by: Michael Meeks <michael.meeks@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

