### PR TITLE
loleafet: simplify update max bounds

### DIFF
--- a/loleaflet/src/layer/AnnotationManager.js
+++ b/loleaflet/src/layer/AnnotationManager.js
@@ -299,7 +299,7 @@ L.AnnotationManager = L.AnnotationManagerBase.extend({
 
 	updateDocBounds: function () {
 		if (this._items.length === 0 || this._items.length === this._hiddenItems) {
-			this._map.fire('updatemaxbounds', {sizeChanged: true});
+			this._map._docLayer._updateMaxBounds(true);
 		}
 	},
 
@@ -323,10 +323,7 @@ L.AnnotationManager = L.AnnotationManagerBase.extend({
 			if (delta.y > 0) {
 				delta.y += margin.y;
 			}
-			this._map.fire('updatemaxbounds', {
-				sizeChanged: true,
-				extraSize: delta
-			});
+			this._map._docLayer._updateMaxBounds(true, {extraSize: delta});
 		}
 	},
 
@@ -986,7 +983,7 @@ L.AnnotationManager = L.AnnotationManagerBase.extend({
 	},
 
 	_onAnnotationZoom: function () {
-		this._map.fire('updatemaxbounds', {sizeChanged: true});
+		this._map._docLayer._updateMaxBounds(true);
 		this.layout(true);
 	},
 
@@ -1093,7 +1090,7 @@ L.AnnotationManager = L.AnnotationManagerBase.extend({
 			this.updateDocBounds();
 	},
 
-	
+
 });
 
 

--- a/loleaflet/src/layer/marker/Annotation.js
+++ b/loleaflet/src/layer/marker/Annotation.js
@@ -179,10 +179,7 @@ L.Annotation = L.Layer.extend({
 			if (delta.y > 0) {
 				delta.y += this.options.margin.y;
 			}
-			this._map.fire('updatemaxbounds', {
-				sizeChanged: true,
-				extraSize: delta
-			});
+			this._map._docLayer._updateMaxBounds(true, {extraSize: delta});
 		}
 	},
 

--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -813,7 +813,7 @@ L.CanvasTileLayer = L.TileLayer.extend({
 		return true;
 	},
 
-	_updateMaxBounds: function (sizeChanged, extraSize, options, zoom) {
+	_updateMaxBounds: function (sizeChanged, options, zoom) {
 		if (this._docWidthTwips === undefined || this._docHeightTwips === undefined) {
 			return;
 		}
@@ -822,6 +822,7 @@ L.CanvasTileLayer = L.TileLayer.extend({
 		}
 
 		var dpiScale = this._painter._dpiScale;
+		var extraSize = options ? options.extraSize : null;
 		var docPixelLimits = new L.Point(this._docWidthTwips / this.options.tileWidthTwips,
 			this._docHeightTwips / this.options.tileHeightTwips);
 		// docPixelLimits should be in csspx.

--- a/loleaflet/src/layer/tile/GridLayer.js
+++ b/loleaflet/src/layer/tile/GridLayer.js
@@ -363,13 +363,15 @@ L.GridLayer = L.Layer.extend({
 		this._tileHeightTwips = Math.round(this.options.tileHeightTwips * factor);
 	},
 
-	_updateMaxBounds: function (sizeChanged, extraSize, options, zoom) {
+	_updateMaxBounds: function (sizeChanged, options, zoom) {
 		if (this._docWidthTwips === undefined || this._docHeightTwips === undefined) {
 			return;
 		}
 		if (!zoom) {
 			zoom = this._map.getZoom();
 		}
+
+		var extraSize = options ? options.extraSize : null;
 		var docPixelLimits = new L.Point(this._docWidthTwips / this.options.tileWidthTwips,
 			this._docHeightTwips / this.options.tileHeightTwips);
 		docPixelLimits = docPixelLimits.multiplyBy(this._tileSize);

--- a/loleaflet/src/layer/tile/ImpressTileLayer.js
+++ b/loleaflet/src/layer/tile/ImpressTileLayer.js
@@ -85,13 +85,7 @@ L.ImpressTileLayer = L.CanvasTileLayer.extend({
 		}
 	},
 
-	onAdd: function (map) {
-		L.TileLayer.prototype.onAdd.call(this, map);
-		map.on('updatemaxbounds', this._onUpdateMaxBounds, this);
-	},
-
-	onRemove: function (map) {
-		map.off('updatemaxbounds', this._onUpdateMaxBounds, this);
+	onRemove: function () {
 		clearTimeout(this._previewInvalidator);
 	},
 
@@ -309,15 +303,12 @@ L.ImpressTileLayer = L.CanvasTileLayer.extend({
 		}
 	},
 
-	_updateMaxBounds: function (sizeChanged, extraSize) {
+	_updateMaxBounds: function (sizeChanged, options) {
+		var extraSize = options ? options.extraSize : null;
 		if (!extraSize) {
 			extraSize = this._annotationManager.allocateExtraSize();
 		}
-		L.GridLayer.prototype._updateMaxBounds.call(this, sizeChanged, extraSize, {panInside: false});
-	},
-
-	_onUpdateMaxBounds: function (e) {
-		this._updateMaxBounds(e.sizeChanged, e.extraSize);
+		L.GridLayer.prototype._updateMaxBounds.call(this, sizeChanged, {panInside: false, extraSize: extraSize});
 	},
 
 	_createCommentStructure: function (menuStructure) {

--- a/loleaflet/src/layer/tile/WriterTileLayer.js
+++ b/loleaflet/src/layer/tile/WriterTileLayer.js
@@ -34,19 +34,13 @@ L.WriterTileLayer = L.CanvasTileLayer.extend({
 		}
 	},
 
-	onRemove: function (map) {
-		map.off('updatemaxbounds', this._onUpdateMaxBounds, this);
-	},
-
 	beforeAdd: function (map) {
 		map.uiManager.initializeSpecializedUI('text');
 	},
 
 	onAdd: function (map) {
-
 		L.TileLayer.prototype.onAdd.call(this, map);
 		this._annotations = L.annotationManager(map);
-		map.on('updatemaxbounds', this._onUpdateMaxBounds, this);
 	},
 
 	onAnnotationModify: function (annotation) {
@@ -245,10 +239,6 @@ L.WriterTileLayer = L.CanvasTileLayer.extend({
 		});
 		this._resetPreFetching(true);
 		this._update();
-	},
-
-	_onUpdateMaxBounds: function (e) {
-		this._updateMaxBounds(e.sizeChanged, e.extraSize);
 	},
 
 	_createCommentStructure: function (menuStructure) {


### PR DESCRIPTION
it is not necessary fire 'updatemaxbounds',
because the association map <-> document layer
1:1

Change-Id: Ic41ab328f7d3d331624107a13acf9f1fdd4c46df
Signed-off-by: Henry Castro <hcastro@collabora.com>
