### PR TITLE
wsd: disable setting "SAL_LOG" in "DEBUG" mode

### DIFF
--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -1027,8 +1027,12 @@ void LOOLWSD::initialize(Application& self)
     // Set the log-level after complete initialization to force maximum details at startup.
     LogLevel = getConfigValue<std::string>(conf, "logging.level", "trace");
     setenv("LOOL_LOGLEVEL", LogLevel.c_str(), true);
+
+#if !ENABLE_DEBUG
     std::string SalLog = getConfigValue<std::string>(conf, "logging.lokit_sal_log", "-INFO-WARN");
     setenv("SAL_LOG", SalLog.c_str(), 0);
+#endif
+
     const bool withColor = getConfigValue<bool>(conf, "logging.color", true) && isatty(fileno(stderr));
     if (withColor)
     {


### PR DESCRIPTION
The development environment is necessary analyse
the logs, so disable setting SAL_LOG instead to
add a parameter to already a long list of options

Change-Id: Id8e4a66e1dcb32c636806e47e1d69270af4c53f5
Signed-off-by: Henry Castro <hcastro@collabora.com>
