### PR TITLE
loleaflet: fix remove child

### DIFF
--- a/loleaflet/src/layer/marker/Annotation.js
+++ b/loleaflet/src/layer/marker/Annotation.js
@@ -45,7 +45,8 @@ L.Annotation = L.Layer.extend({
 	},
 
 	onRemove: function (map) {
-		map._panes.popupPane.removeChild(this._container);
+		L.DomUtil.remove(this._container);
+
 		if (this._data.textSelected) {
 			this._data.textSelected.removeEventParent(map);
 			map.removeLayer(this._data.textSelected);


### PR DESCRIPTION
Uncaught DOMException: Failed to execute 'removeChild' on 'Node': The node to be removed is no longer a child of this node. Perhaps it was moved in a 'blur' event handler?
    at NewClass.onRemove (src/layer/marker/Annotation.js:48:24)
    at NewClass.removeLayer (src/layer/Layer.js:83:10)
    at NewClass.onAnnotationCancel (src/layer/AnnotationManagerImpress.js:107:14)
    at NewClass.fire (src/core/Events.js:152:22)
    at NewClass._onCancelClick (src/layer/marker/Annotation.js:314:14)
    at HTMLInputElement.handler (src/dom/DomEvent.js:51:14)

Change-Id: Ib4a9f60d6b0685b80cdf1271f506692dffe19715
Signed-off-by: Henry Castro <hcastro@collabora.com>
