### PR TITLE
fix error reporting: we do not abort every time when loolforkit is in…

### DIFF
--- a/common/security.h
+++ b/common/security.h
@@ -41,7 +41,7 @@ inline int hasCorrectUID(const char *appName)
     if (hasUID(LOOL_USER_ID))
         return 1;
     else {
-        fprintf(stderr, "Error: %s incorrect user-name, other than '" LOOL_USER_ID "' - aborting\n", appName);
+        fprintf(stderr, "Security: %s incorrect user-name, other than '" LOOL_USER_ID "'\n", appName);
         return 0;
     }
 #endif

--- a/kit/ForKit.cpp
+++ b/kit/ForKit.cpp
@@ -474,13 +474,17 @@ int main(int argc, char** argv)
     /*WARNING*/         if (!checkLoolUser)
     /*WARNING*/             std::cerr << "Security: --disable-lool-user-checking failed, loolforkit has some capabilities set." << std::endl;
 
+    /*WARNING*/         std::cerr << "Aborting." << std::endl;
     /*WARNING*/         return EX_SOFTWARE;
     /*WARNING*/     }
 
     /*WARNING*/     // even without the capabilities, don't run unless the user really knows
     /*WARNING*/     // what they are doing, and provided a --disable-lool-user-checking
     /*WARNING*/     if (checkLoolUser)
+    /*WARNING*/     {
+    /*WARNING*/         std::cerr << "Aborting." << std::endl;
     /*WARNING*/         return EX_SOFTWARE;
+    /*WARNING*/     }
 
     /*WARNING*/     std::cerr << "Security: Check for the 'lool' username overridden on the command line." << std::endl;
     /*WARNING*/ }

--- a/tools/mount.cpp
+++ b/tools/mount.cpp
@@ -121,7 +121,10 @@ void usage(const char* program)
 int main(int argc, char** argv)
 {
     if (!hasCorrectUID(/* appName = */"loolmount"))
+    {
+        fprintf(stderr, "Aborting.\n");
         return EX_SOFTWARE;
+    }
 
     const char* program = argv[0];
     if (argc < 3)


### PR DESCRIPTION
…voked with incorrect user name

Signed-off-by: Andras Timar <andras.timar@collabora.com>
Change-Id: I2994b6a825a00e2eedaf5df89edbf3ebeff1a845


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

