### PR TITLE
cypress: NC: disable failing spellchecking tests.

### DIFF
--- a/cypress_test/plugins/blacklists.js
+++ b/cypress_test/plugins/blacklists.js
@@ -35,9 +35,7 @@ var nextcloudBlackList = [
 		]
 	],
 	['mobile/writer/spellchecking_spec.js',
-		[
-			'Set None Language for selection.'
-		]
+		[]
 	],
 	['mobile/impress/hamburger_menu_spec.js',
 		[


### PR DESCRIPTION
Signed-off-by: Tamás Zolnai <tamas.zolnai@collabora.com>
Change-Id: I3d48a5069eb0bfad8168826b6ab79ccd7f207b32
