### PR TITLE
Notebookbar: disable commands without gray background

### DIFF
--- a/loleaflet/css/notebookbar.css
+++ b/loleaflet/css/notebookbar.css
@@ -329,6 +329,10 @@ div[id*='Row'].notebookbar, div[id*='Column'].notebookbar, #SendToBack.notebookb
 	color: var(--blue1-txt-primary-color) !important;
 }
 
+.unotoolbutton.notebookbar.disabled:not(.unospan-shortcutstoolbox), .mobile-wizard-widebutton.disabled {
+	opacity: 0.65;
+}
+
 .unotoolbutton.notebookbar.disabled img, .mobile-wizard-widebutton.disabled img {
 	-webkit-filter: grayscale(100%) brightness(100%);
 	filter: grayscale(100%) brightness(100%);

--- a/loleaflet/css/notebookbar.css
+++ b/loleaflet/css/notebookbar.css
@@ -329,12 +329,6 @@ div[id*='Row'].notebookbar, div[id*='Column'].notebookbar, #SendToBack.notebookb
 	color: var(--blue1-txt-primary-color) !important;
 }
 
-.unotoolbutton.notebookbar.disabled:not(.unospan-shortcutstoolbox), .mobile-wizard-widebutton.disabled {
-	color: silver;
-	border-radius: 4px;
-	background: #c0c0c04a;
-}
-
 .unotoolbutton.notebookbar.disabled img, .mobile-wizard-widebutton.disabled img {
 	-webkit-filter: grayscale(100%) brightness(100%);
 	filter: grayscale(100%) brightness(100%);


### PR DESCRIPTION
Signed-off-by: Andreas-Kainz <andreas_k@abwesend.de>
Change-Id: I539d70ab1ba07d27cf34b61a8bf1a333e0bc4531

Before
![2021-01-12 19_40_24-ws-ea5b92be-06de-4305-a5ec-72e82ce16980_0 - noVNC](https://user-images.githubusercontent.com/8517736/104358105-4b876680-550e-11eb-9927-06e5c9500a0a.png)
After
![2021-01-12 19_39_28-ws-ea5b92be-06de-4305-a5ec-72e82ce16980_0 - noVNC](https://user-images.githubusercontent.com/8517736/104358124-4f1aed80-550e-11eb-83ea-5f49a51883d1.png)

not available commands shouldn't be "highlighted"  with a gray background. The icon and string are gray (like in the menu bar) so there is no reason for additional colors.