### PR TITLE
.ui-content.unobutton.selected selected color is larger

### DIFF
--- a/loleaflet/css/notebookbar.css
+++ b/loleaflet/css/notebookbar.css
@@ -227,6 +227,7 @@
 
 .hasnotebookbar .ui-content.unobutton.selected {
 	border-radius: 2px;
+	box-shadow: 0px 0px 0px 3px var(--gray-bg-color);
 	background-color: var(--gray-bg-color);
 }
 


### PR DESCRIPTION
Signed-off-by: Andreas-Kainz <andreas_k@abwesend.de>
Change-Id: Ic45b68778d8adef375ad0cb2495879c860e986cd

Before
![2021-01-12 21_03_21-text docx - Dateien - Nextcloud](https://user-images.githubusercontent.com/8517736/104369199-5d243a80-551d-11eb-9ed0-7ef4fb1b5f32.png)
After
![2021-01-12 21_27_53-text docx - Dateien - Nextcloud](https://user-images.githubusercontent.com/8517736/104369207-61e8ee80-551d-11eb-8d03-affaa8abdc77.png)

How it look in classic toolbar mode
![2021-01-12 21_02_50-text docx - Files - Nextcloud](https://user-images.githubusercontent.com/8517736/104369233-6c0aed00-551d-11eb-8065-0678a0bd69e8.png)

**with the patch the selected commands look similar to how they look in classic toolbar mode**
