### PR TITLE
Cypress Test on Enable text wrapping on Calc

### DIFF
--- a/cypress_test/integration_tests/desktop/calc/top_toolbar_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/top_toolbar_spec.js
@@ -16,7 +16,45 @@ describe('Top toolbar tests.', function() {
 	afterEach(function() {
 		helper.afterAll(testFileName, this.currentTest.state);
 	});
+	function getTextEndPosForFirstCell() {
+		calcHelper.dblClickOnFirstCell();
 
+		helper.getCursorPos('left', 'currentTextEndPos');
+	}
+
+	it('Enable text wrapping.', function() {
+		calcHelper.clickOnFirstCell(true, false);
+		calcHelper.typeIntoFormulabar('_This_is_a_really_long_text');
+		helper.initAliasToNegative('originalTextEndPos');
+
+		getTextEndPosForFirstCell();
+		cy.get('@currentTextEndPos')
+			.as('originalTextEndPos');
+
+		cy.get('@currentTextEndPos')
+			.should('be.greaterThan', 0);
+
+		calcHelper.selectFirstColumn();
+
+		cy.get('.w2ui-tb-image.w2ui-icon.wraptext')
+			.click();
+
+		calcHelper.clickOnFirstCell(true, false);
+
+		// We use the text position as indicator
+		cy.waitUntil(function() {
+			getTextEndPosForFirstCell();
+
+			return cy.get('@currentTextEndPos')
+				.then(function(currentTextEndPos) {
+					return cy.get('@originalTextEndPos')
+						.then(function(originalTextEndPos) {
+							return originalTextEndPos > currentTextEndPos;
+						});
+				});
+		});
+	});
+	
 	it('Merge cells', function() {
 
 		// Select the full column


### PR DESCRIPTION
Created a cypress test for the Text wrap feature on the Calc top toolbar

Signed-off-by: Ezinne Nnamani <nnamani.ezinne@collabora.com>
Change-Id: I3d2e59b94e23e73b5980e049fe5c6e99178b8d3f


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

