### PR TITLE
WOPITest improvements

### DIFF
--- a/common/Unit.cpp
+++ b/common/Unit.cpp
@@ -210,9 +210,10 @@ void UnitBase::exitTest(TestResult result)
     _setRetValue = true;
     _retValue = result == TestResult::Ok ? EX_OK : EX_SOFTWARE;
 #if !MOBILEAPP
-    SigUtil::requestShutdown();
-#endif
+    SigUtil::requestShutdown(); // And wakupWorld.
+#else
     SocketPoll::wakeupWorld();
+#endif
 }
 
 void UnitBase::timeout()

--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -137,11 +137,34 @@ public:
     }
 
     /// Message that is about to be sent via the websocket.
-    virtual bool filterSendMessage(const char* /* data */, const std::size_t /* len */,
-                                   const WSOpCode /* code */, const bool /* flush */,
-                                   int& /*unitReturn*/)
+    /// To override, handle onFilterSendMessage or any of the onDocument...() handlers.
+    bool filterSendMessage(const char* data, const std::size_t len, const WSOpCode code,
+                           const bool flush, int& unitReturn)
     {
-        return false;
+        const std::string message(data, len);
+
+        if (Util::startsWith(message, "status:"))
+        {
+            if (onDocumentLoaded(message))
+                return false;
+        }
+        else if (message == "statechanged: .uno:ModifiedStatus=true")
+        {
+            if (onDocumentModified(message))
+                return false;
+        }
+        else if (Util::startsWith(message, "statechanged:"))
+        {
+            if (onDocumentStateChanged(message))
+                return false;
+        }
+        else if (Util::startsWith(message, "error:"))
+        {
+            if (onDocumentError(message))
+                return false;
+        }
+
+        return onFilterSendMessage(data, len, code, flush, unitReturn);
     }
 
     /// Hook the disk space check
@@ -158,10 +181,34 @@ public:
     }
 
     /// Custom response to a http request.
-    virtual bool handleHttpRequest(const Poco::Net::HTTPRequest& /*request*/, Poco::MemoryInputStream& /*message*/,std::shared_ptr<StreamSocket>& /*socket*/)
+    virtual bool handleHttpRequest(const Poco::Net::HTTPRequest& /*request*/,
+                                   Poco::MemoryInputStream& /*message*/,
+                                   std::shared_ptr<StreamSocket>& /*socket*/)
     {
         return false;
     }
+
+    /// Called when the document has been loaded,
+    /// based on the "status:" message, in the context of filterSendMessage.
+    /// Return true to stop further handling of messages.
+    virtual bool onDocumentLoaded(const std::string&) { return false; }
+
+    /// Called when the document's 'modified' status
+    /// changes to true.
+    /// Return true to stop further handling of messages.
+    virtual bool onDocumentModified(const std::string&) { return false; }
+
+    /// Called when the document has been saved.
+    /// Return true to stop further handling of messages.
+    virtual bool onDocumentSaved(const std::string&) { return false; }
+
+    /// Called when the document issues a 'statechanged:' message.
+    /// Return true to stop further handling of messages.
+    virtual bool onDocumentStateChanged(const std::string&) { return false; }
+
+    /// Called when the document issues an 'error:' message.
+    /// Return true to stop further handling of messages.
+    virtual bool onDocumentError(const std::string&) { return false; }
 
     /// If the test times out this gets invoked, the default just exits.
     virtual void timeout();
@@ -188,6 +235,14 @@ private:
         _dlHandle = dlHandle;
     }
     static UnitBase *linkAndCreateUnit(UnitType type, const std::string& unitLibPath);
+
+    /// Handles messages sent via WebSocket.
+    virtual bool onFilterSendMessage(const char* /*data*/, const std::size_t /*len*/,
+                                     const WSOpCode /* code */, const bool /* flush */,
+                                     int& /*unitReturn*/)
+    {
+        return false;
+    }
 
     void *_dlHandle;
     static char *UnitLibPath;

--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -90,6 +90,20 @@ protected:
     /// Encourages the process to exit with this value (unless hooked)
     void exitTest(TestResult result);
 
+    /// Fail the test with the given reason.
+    void failTest(const std::string& reason)
+    {
+        LOG_TST("FAILURE: " << getTestname() << " finished: " << reason);
+        exitTest(TestResult::Failed);
+    }
+
+    /// Pass the test with the given optional reason.
+    void passTest(const std::string& reason = std::string())
+    {
+        LOG_TST("SUCCESS: " << getTestname() << " finished: " << reason);
+        exitTest(TestResult::Ok);
+    }
+
     UnitBase();
     UnitBase(std::string name)
         : UnitBase()

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -31,8 +31,8 @@
 
 #include <SigUtil.hpp>
 #include "ServerSocket.hpp"
-#if !MOBILEAPP
-#include "SslSocket.hpp"
+#if !MOBILEAPP && ENABLE_SSL
+#include <net/SslSocket.hpp>
 #endif
 #include "WebSocketHandler.hpp"
 

--- a/net/Ssl.hpp
+++ b/net/Ssl.hpp
@@ -36,6 +36,9 @@ public:
 
     static void uninitialize();
 
+    /// Returns true iff the SslContext has been initialized.
+    static bool isInitialized() { return !!Instance; }
+
     static SSL* newSsl()
     {
         return SSL_new(Instance->_ctx);

--- a/test/UnitWOPI.cpp
+++ b/test/UnitWOPI.cpp
@@ -99,8 +99,7 @@ public:
         _savingPhase = SavingPhase::Unmodified;
         _phase = Phase::Modify;
 
-        helpers::sendTextFrame(*getWs()->getLOOLWebSocket(),
-                               "save dontTerminateEdit=1 dontSaveIfUnmodified=0", getTestname());
+        WSD_CMD("save dontTerminateEdit=1 dontSaveIfUnmodified=0");
 
         SocketPoll::wakeupWorld();
         return true;
@@ -116,11 +115,8 @@ public:
             _phase = Phase::Polling;
             _savingPhase = SavingPhase::Modified;
 
-            helpers::sendTextFrame(
-                *getWs()->getLOOLWebSocket(),
-                "save dontTerminateEdit=0 dontSaveIfUnmodified=0 "
-                "extendedData=CustomFlag%3DCustom%20Value%3BAnotherFlag%3DAnotherValue",
-                getTestname());
+            WSD_CMD("save dontTerminateEdit=0 dontSaveIfUnmodified=0 "
+                    "extendedData=CustomFlag%3DCustom%20Value%3BAnotherFlag%3DAnotherValue");
 
             SocketPoll::wakeupWorld();
         }
@@ -139,8 +135,7 @@ public:
                 LOG_TST("Load: initWebsocket.");
                 initWebsocket("/wopi/files/0?access_token=anything");
 
-                helpers::sendTextFrame(*getWs()->getLOOLWebSocket(), "load url=" + getWopiSrc(),
-                                       getTestname());
+                WSD_CMD("load url=" + getWopiSrc());
                 break;
             }
             case Phase::Modify:
@@ -148,11 +143,8 @@ public:
                 LOG_TST("Modify => WaitModified");
                 _phase = Phase::WaitModifiedStatus;
 
-                helpers::sendTextFrame(*getWs()->getLOOLWebSocket(), "key type=input char=97 key=0",
-                                       getTestname());
-                helpers::sendTextFrame(*getWs()->getLOOLWebSocket(), "key type=up char=0 key=512",
-                                       getTestname());
-
+                WSD_CMD("key type=input char=97 key=0");
+                WSD_CMD("key type=up char=0 key=512");
                 break;
             }
             case Phase::WaitLoadStatus:

--- a/test/UnitWOPIDocumentConflict.cpp
+++ b/test/UnitWOPIDocumentConflict.cpp
@@ -152,7 +152,7 @@ public:
 
         // we don't want to save current changes because doing so would
         // overwrite the document which was changed underneath us
-        helpers::sendTextFrame(*getWs()->getLOOLWebSocket(), "closedocument", getTestname());
+        WSD_CMD("closedocument");
         return true;
     }
 
@@ -196,8 +196,7 @@ public:
 
                 initWebsocket("/wopi/files/0?access_token=anything");
 
-                helpers::sendTextFrame(*getWs()->getLOOLWebSocket(), "load url=" + getWopiSrc(),
-                                       getTestname());
+                WSD_CMD("load url=" + getWopiSrc());
             }
             break;
             case Phase::WaitLoadStatus:
@@ -211,10 +210,8 @@ public:
                 _phase = Phase::WaitModifiedStatus;
 
                 // modify the currently opened document; type 'a'
-                helpers::sendTextFrame(*getWs()->getLOOLWebSocket(), "key type=input char=97 key=0",
-                                       getTestname());
-                helpers::sendTextFrame(*getWs()->getLOOLWebSocket(), "key type=up char=0 key=512",
-                                       getTestname());
+                WSD_CMD("key type=input char=97 key=0");
+                WSD_CMD("key type=up char=0 key=512");
                 SocketPoll::wakeupWorld();
             }
             break;
@@ -237,7 +234,7 @@ public:
                 // When we get it (in onFilterSendMessage, above),
                 // we will switch to Phase::LoadNewDocument.
                 LOG_TST("Phase::ChangeStorageDoc: saving");
-                helpers::sendTextFrame(*getWs()->getLOOLWebSocket(), "save", getTestname());
+                WSD_CMD("save");
             }
             break;
             case Phase::WaitSaveResponse:

--- a/test/UnitWOPIDocumentConflict.cpp
+++ b/test/UnitWOPIDocumentConflict.cpp
@@ -16,6 +16,7 @@
 #include "lokassert.hpp"
 
 #include <Poco/Net/HTTPRequest.h>
+#include <string>
 
 /**
  * This test asserts that the unsaved changes in the opened document are
@@ -46,6 +47,30 @@ class UnitWOPIDocumentConflict : public WopiTestServer
         Polling
     } _phase;
 
+    /// Return the name of the given Phase.
+    static std::string toString(Phase phase)
+    {
+#define ENUM_CASE(X)                                                                               \
+    case X:                                                                                        \
+        return #X
+
+        switch (phase)
+        {
+            ENUM_CASE(Phase::Load);
+            ENUM_CASE(Phase::WaitLoadStatus);
+            ENUM_CASE(Phase::ModifyDoc);
+            ENUM_CASE(Phase::WaitModifiedStatus);
+            ENUM_CASE(Phase::ChangeStorageDoc);
+            ENUM_CASE(Phase::WaitSaveResponse);
+            ENUM_CASE(Phase::WaitDocClose);
+            ENUM_CASE(Phase::LoadNewDocument);
+            ENUM_CASE(Phase::Polling);
+            default:
+                return "Unknown";
+        }
+#undef ENUM_CASE
+    }
+
     enum class DocLoaded
     {
         Doc1,
@@ -64,6 +89,9 @@ public:
     void assertGetFileRequest(const Poco::Net::HTTPRequest& /*request*/) override
     {
         LOG_TST("assertGetFileRequest: Doc " << (_docLoaded == DocLoaded::Doc1 ? "1" : "2"));
+        LOK_ASSERT_MESSAGE("Expected to be in Phase::WaitLoadStatus but was " + toString(_phase),
+                           _phase == Phase::WaitLoadStatus);
+
         if (_docLoaded == DocLoaded::Doc2)
         {
             // On second doc load, we should have the document in storage which
@@ -71,10 +99,61 @@ public:
             LOK_ASSERT_EQUAL_MESSAGE("File contents not modified in storage",
                                      std::string(ExpectedDocContent), getFileContent());
             if (getFileContent() != ExpectedDocContent)
-                exitTest(TestResult::Failed);
+                failTest("The file is stale and not the one in storage.");
             else
-                exitTest(TestResult::Ok);
+                passTest("The file reloaded from the storage as expected.");
         }
+    }
+
+    bool onDocumentLoaded(const std::string& message) override
+    {
+        LOG_TST("onDocumentLoaded: Doc " << (_docLoaded == DocLoaded::Doc1 ? "1" : "2")
+                                         << "(WaitLoadStatus): [" << message << ']');
+        LOK_ASSERT_MESSAGE("Expected to be in Phase::WaitLoadStatus but was " + toString(_phase),
+                           _phase == Phase::WaitLoadStatus);
+
+        if (_docLoaded == DocLoaded::Doc1)
+        {
+            _phase = Phase::ModifyDoc;
+            LOG_TST("onDocumentLoaded: Switching to Phase::ModifyDoc");
+            SocketPoll::wakeupWorld();
+        }
+
+        return true;
+    }
+
+    bool onDocumentModified(const std::string& message) override
+    {
+        LOG_TST("onDocumentModified: Doc " << (_docLoaded == DocLoaded::Doc1 ? "1" : "2")
+                                           << "(WaitModifiedStatus): [" << message << ']');
+        LOK_ASSERT_MESSAGE("Expected to be in Phase::WaitModifiedStatus but was "
+                               + toString(_phase),
+                           _phase == Phase::WaitModifiedStatus);
+
+        if (_docLoaded == DocLoaded::Doc1)
+        {
+            _phase = Phase::ChangeStorageDoc;
+            LOG_TST("onDocumentModified: Switching to Phase::ChangeStorageDoc");
+            SocketPoll::wakeupWorld();
+        }
+
+        return true;
+    }
+
+    bool onDocumentError(const std::string& message) override
+    {
+        LOG_TST("onDocumentError: Doc " << (_docLoaded == DocLoaded::Doc1 ? "1" : "2")
+                                        << "(WaitSaveResponse): [" << message << ']');
+        LOK_ASSERT_MESSAGE("Expected to be in Phase::WaitSaveResponse but was " + toString(_phase),
+                           _phase == Phase::WaitSaveResponse);
+
+        _phase = Phase::WaitDocClose;
+        LOG_TST("onDocumentError: Switching to Phase::WaitDocClose");
+
+        // we don't want to save current changes because doing so would
+        // overwrite the document which was changed underneath us
+        helpers::sendTextFrame(*getWs()->getLOOLWebSocket(), "closedocument", getTestname());
+        return true;
     }
 
     bool onFilterSendMessage(const char* data, const std::size_t len, const WSOpCode /* code */,
@@ -83,47 +162,6 @@ public:
         const std::string message(data, len);
         switch (_phase)
         {
-            case Phase::WaitLoadStatus:
-            {
-                LOG_TST("onFilterSendMessage: Doc " << (_docLoaded == DocLoaded::Doc1 ? "1" : "2")
-                                                  << "(WaitLoadStatus): [" << message << ']');
-                if (_docLoaded == DocLoaded::Doc1 && Util::startsWith(message, "status:"))
-                {
-                    _phase = Phase::ModifyDoc;
-                    LOG_TST("onFilterSendMessage: Switching to Phase::ModifyDoc");
-                    SocketPoll::wakeupWorld();
-                }
-            }
-            break;
-            case Phase::WaitModifiedStatus:
-            {
-                LOG_TST("onFilterSendMessage: Doc " << (_docLoaded == DocLoaded::Doc1 ? "1" : "2")
-                                                  << "(WaitModifiedStatus): [" << message << ']');
-                if (_docLoaded == DocLoaded::Doc1
-                    && message == "statechanged: .uno:ModifiedStatus=true")
-                {
-                    _phase = Phase::ChangeStorageDoc;
-                    LOG_TST("onFilterSendMessage: Switching to Phase::ChangeStorageDoc");
-                    SocketPoll::wakeupWorld();
-                }
-            }
-            break;
-            case Phase::WaitSaveResponse:
-            {
-                LOG_TST("onFilterSendMessage: Doc " << (_docLoaded == DocLoaded::Doc1 ? "1" : "2")
-                                                  << "(WaitSaveResponse): [" << message << ']');
-                if (message == "error: cmd=storage kind=documentconflict")
-                {
-                    _phase = Phase::WaitDocClose;
-                    LOG_TST("onFilterSendMessage: Switching to Phase::WaitDocClose");
-
-                    // we don't want to save current changes because doing so would
-                    // overwrite the document which was changed underneath us
-                    helpers::sendTextFrame(*getWs()->getLOOLWebSocket(), "closedocument",
-                                           getTestname());
-                }
-            }
-            break;
             case Phase::WaitDocClose:
             {
                 LOG_TST("onFilterSendMessage: Doc " << (_docLoaded == DocLoaded::Doc1 ? "1" : "2")
@@ -220,7 +258,7 @@ public:
                 // DocBroker, but a short wait will do for now.
                 LOG_TST("Phase::LoadNewDocument: Reloading.");
                 _docLoaded = DocLoaded::Doc2; // Update before loading!
-                _phase = Phase::Polling;
+                _phase = Phase::WaitLoadStatus;
 
                 std::this_thread::sleep_for(std::chrono::seconds(1));
                 initWebsocket("/wopi/files/0?access_token=anything");

--- a/test/UnitWOPIRenameFile.cpp
+++ b/test/UnitWOPIRenameFile.cpp
@@ -37,8 +37,8 @@ public:
         LOK_ASSERT_EQUAL(std::string("hello"), request.get("X-WOPI-RequestedName"));
     }
 
-    bool filterSendMessage(const char* data, const std::size_t len, const WSOpCode /* code */,
-                           const bool /* flush */, int& /*unitReturn*/) override
+    bool onFilterSendMessage(const char* data, const std::size_t len, const WSOpCode /* code */,
+                             const bool /* flush */, int& /*unitReturn*/) override
     {
         const std::string message(data, len);
 

--- a/test/UnitWOPISaveAs.cpp
+++ b/test/UnitWOPISaveAs.cpp
@@ -40,8 +40,8 @@ public:
         LOK_ASSERT(std::stoul(request.get("X-WOPI-Size")) > getFileContent().size());
     }
 
-    bool filterSendMessage(const char* data, const std::size_t len, const WSOpCode /* code */,
-                           const bool /* flush */, int& /*unitReturn*/) override
+    bool onFilterSendMessage(const char* data, const std::size_t len, const WSOpCode /* code */,
+                             const bool /* flush */, int& /*unitReturn*/) override
     {
         const std::string message(data, len);
 

--- a/test/UnitWOPIVersionRestore.cpp
+++ b/test/UnitWOPIVersionRestore.cpp
@@ -62,14 +62,11 @@ public:
         _phase = Phase::WaitPutFile;
 
         // Modify the document.
-        helpers::sendTextFrame(*getWs()->getLOOLWebSocket(), "key type=input char=97 key=0",
-                               getTestname());
-        helpers::sendTextFrame(*getWs()->getLOOLWebSocket(), "key type=up char=0 key=512",
-                               getTestname());
+        WSD_CMD("key type=input char=97 key=0");
+        WSD_CMD("key type=up char=0 key=512");
 
         // tell wsd that we are about to restore
-        helpers::sendTextFrame(*getWs()->getLOOLWebSocket(), "versionrestore prerestore",
-                               getTestname());
+        WSD_CMD("versionrestore prerestore");
 
         SocketPoll::wakeupWorld();
         return true;
@@ -104,8 +101,7 @@ public:
                 LOG_TST("Load: initWebsocket.");
                 initWebsocket("/wopi/files/0?access_token=anything");
 
-                helpers::sendTextFrame(*getWs()->getLOOLWebSocket(), "load url=" + getWopiSrc(),
-                                       getTestname());
+                WSD_CMD("load url=" + getWopiSrc());
                 break;
             }
             case Phase::WaitLoadStatus:

--- a/test/UnitWOPIVersionRestore.cpp
+++ b/test/UnitWOPIVersionRestore.cpp
@@ -12,6 +12,7 @@
 #include "Unit.hpp"
 #include "UnitHTTP.hpp"
 #include "helpers.hpp"
+#include "lokassert.hpp"
 
 #include <Poco/Net/HTTPRequest.h>
 #include <Poco/Util/LayeredConfiguration.h>
@@ -28,10 +29,8 @@ class UnitWOPIVersionRestore : public WopiTestServer
     enum class Phase
     {
         Load,
-        Modify,
-        VersionRestoreRequest,
-        VersionRestoreAck,
-        Polling
+        WaitLoadStatus,
+        WaitPutFile
     } _phase;
 
     bool _isDocumentSaved = false;
@@ -40,15 +39,40 @@ public:
     UnitWOPIVersionRestore()
         : WopiTestServer("UnitWOPIVersionRestore")
         , _phase(Phase::Load)
+        , _isDocumentSaved(false)
     {
     }
 
     void assertPutFileRequest(const Poco::Net::HTTPRequest& /*request*/) override
     {
-        if (_phase == Phase::Polling)
+        if (_phase == Phase::WaitPutFile)
         {
+            LOG_TST("assertPutFileRequest: document saved.");
             _isDocumentSaved = true;
         }
+    }
+
+    bool onDocumentLoaded(const std::string& message) override
+    {
+        LOG_TST("onDocumentLoaded: [" << message << ']');
+        LOK_ASSERT_MESSAGE("Expected to be in Phase::WaitLoadStatus",
+                           _phase == Phase::WaitLoadStatus);
+
+        LOG_TST("onDocumentModified: Switching to Phase::WaitPutFile and modifying document");
+        _phase = Phase::WaitPutFile;
+
+        // Modify the document.
+        helpers::sendTextFrame(*getWs()->getLOOLWebSocket(), "key type=input char=97 key=0",
+                               getTestname());
+        helpers::sendTextFrame(*getWs()->getLOOLWebSocket(), "key type=up char=0 key=512",
+                               getTestname());
+
+        // tell wsd that we are about to restore
+        helpers::sendTextFrame(*getWs()->getLOOLWebSocket(), "versionrestore prerestore",
+                               getTestname());
+
+        SocketPoll::wakeupWorld();
+        return true;
     }
 
     bool onFilterSendMessage(const char* data, const size_t len, const WSOpCode /* code */,
@@ -57,7 +81,13 @@ public:
         std::string message(data, len);
         if (message == "close: versionrestore: prerestore_ack")
         {
-            _phase = Phase::VersionRestoreAck;
+            LOK_ASSERT_MESSAGE("Must be in Phase::WaitPutFile", _phase == Phase::WaitPutFile);
+            LOK_ASSERT_MESSAGE("Must have already saved the file", _isDocumentSaved);
+
+            if (_isDocumentSaved)
+                passTest("Document saved on version restore as expected.");
+            else
+                failTest("Document failed to save on version restore.");
         }
 
         return false;
@@ -65,47 +95,26 @@ public:
 
     void invokeWSDTest() override
     {
-        constexpr char testName[] = "UnitWOPIVersionRestore";
-
-        LOG_TRC("invokeWSDTest " << (int)_phase);
         switch (_phase)
         {
             case Phase::Load:
             {
+                _phase = Phase::WaitLoadStatus;
+
+                LOG_TST("Load: initWebsocket.");
                 initWebsocket("/wopi/files/0?access_token=anything");
 
-                helpers::sendTextFrame(*getWs()->getLOOLWebSocket(), "load url=" + getWopiSrc(), testName);
-
-                _phase = Phase::Modify;
+                helpers::sendTextFrame(*getWs()->getLOOLWebSocket(), "load url=" + getWopiSrc(),
+                                       getTestname());
                 break;
             }
-            case Phase::Modify:
+            case Phase::WaitLoadStatus:
             {
-                helpers::sendTextFrame(*getWs()->getLOOLWebSocket(), "key type=input char=97 key=0", testName);
-                helpers::sendTextFrame(*getWs()->getLOOLWebSocket(), "key type=up char=0 key=512", testName);
-
-                _phase = Phase::VersionRestoreRequest;
-                SocketPoll::wakeupWorld();
-                break;
+                break; // Nothing to do.
             }
-	        case Phase::VersionRestoreRequest:
+            case Phase::WaitPutFile:
             {
-                // tell wsd that we are about to restore
-                helpers::sendTextFrame(*getWs()->getLOOLWebSocket(), "versionrestore prerestore", testName);
-                _phase = Phase::Polling;
-                break;
-            }
-	        case Phase::VersionRestoreAck:
-            {
-                if (_isDocumentSaved)
-                    exitTest(TestResult::Ok);
-
-                break;
-            }
-            case Phase::Polling:
-            {
-                // just wait for the results
-                break;
+                break; // Nothing to do.
             }
         }
     }

--- a/test/UnitWOPIVersionRestore.cpp
+++ b/test/UnitWOPIVersionRestore.cpp
@@ -51,7 +51,8 @@ public:
         }
     }
 
-    bool filterSendMessage(const char* data, const size_t len, const WSOpCode /* code */, const bool /* flush */, int& /*unitReturn*/) override
+    bool onFilterSendMessage(const char* data, const size_t len, const WSOpCode /* code */,
+                             const bool /* flush */, int& /*unitReturn*/) override
     {
         std::string message(data, len);
         if (message == "close: versionrestore: prerestore_ack")

--- a/test/UnitWopiOwnertermination.cpp
+++ b/test/UnitWopiOwnertermination.cpp
@@ -70,14 +70,12 @@ public:
 
         // Modify the document.
         LOG_TST("onDocumentLoaded: Modifying");
-        helpers::sendTextFrame(*getWs()->getLOOLWebSocket(), "key type=input char=97 key=0",
-                               getTestname());
-        helpers::sendTextFrame(*getWs()->getLOOLWebSocket(), "key type=up char=0 key=512",
-                               getTestname());
+        WSD_CMD("key type=input char=97 key=0");
+        WSD_CMD("key type=up char=0 key=512");
 
         // And close. We expect the document to be marked as modified and saved.
         LOG_TST("onDocumentLoaded: Closing");
-        helpers::sendTextFrame(*getWs()->getLOOLWebSocket(), "closedocument", getTestname());
+        WSD_CMD("closedocument");
 
         _phase = Phase::Polling;
         SocketPoll::wakeupWorld();
@@ -94,7 +92,7 @@ public:
 
                 _phase = Phase::WaitLoadStatus;
 
-                helpers::sendTextFrame(*getWs()->getLOOLWebSocket(), "load url=" + getWopiSrc(), getTestname());
+                WSD_CMD("load url=" + getWopiSrc());
                 break;
             }
             case Phase::WaitLoadStatus:

--- a/test/WopiTestServer.hpp
+++ b/test/WopiTestServer.hpp
@@ -279,7 +279,14 @@ protected:
 
         return false;
     }
-
 };
+
+/// Send a command message to WSD from a WopiTestServer.
+#define WSD_CMD(MSG)                                                                               \
+    do                                                                                             \
+    {                                                                                              \
+        LOG_TST(": Sending: " << MSG);                                                             \
+        helpers::sendTextFrame(*getWs()->getLOOLWebSocket(), MSG, getTestname());                  \
+    } while (false)
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/Admin.cpp
+++ b/wsd/Admin.cpp
@@ -30,7 +30,9 @@
 #include <Util.hpp>
 
 #include <net/Socket.hpp>
-#include <net/SslSocket.hpp>
+#if ENABLE_SSL
+#include <SslSocket.hpp>
+#endif
 #include <net/WebSocketHandler.hpp>
 
 #include <common/SigUtil.hpp>

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -4184,7 +4184,7 @@ int LOOLWSD::main(const std::vector<std::string>& /*args*/)
 
     UnitWSD::get().returnValue(returnValue);
 
-    LOG_INF("Process [loolwsd] finished.");
+    LOG_INF("Process [loolwsd] finished with exit status: " << returnValue);
     return returnValue;
 }
 

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -4008,8 +4008,9 @@ int LOOLWSD::innerMain()
 
         // This timeout affects the recovery time of prespawned children.
         const std::chrono::microseconds waitMicroS
-            = UnitWSD::isUnitTesting() ? UnitWSD::get().getTimeoutMilliSeconds() / 4
-                                       : SocketPoll::DefaultPollTimeoutMicroS * 4;
+            = UnitWSD::isUnitTesting()
+                  ? std::min(UnitWSD::get().getTimeoutMilliSeconds(), std::chrono::milliseconds(1000)) / 4
+                  : SocketPoll::DefaultPollTimeoutMicroS * 4;
         mainWait.poll(waitMicroS);
 
         // Wake the prisoner poll to spawn some children, if necessary.


### PR DESCRIPTION
These commits fix 4 WOPI Tests so they wouldn't rely on the timing of the SocketPoll interval, instead they now properly wait for the different events from Core before they move to the next test phase.

Better logging, comments, and overall readability is also improved. 

More info in the individual commit messages (but the review is best done over all changes together).

- wsd: test: remove redundant wakeupWorld and log the exit status
- wsd: test: move inherited filterSendMessage to onFilterSendMessage
- wsd: test: make DocumentConflict test robus and simpler
- wsd: test: make UnitWOPI test robust and simpler
- wsd: test: make owner-termination test robust and simpler
- wsd: test: make Version Restore test robust and simpler
- wsd: test: simplify sending commands
- wsd: test: shorter poll interval during tests
- wsd: test: support SSL in classic tests
