### PR TITLE
Fontwork: layout improvements

### DIFF
--- a/loleaflet/css/jsdialogs.css
+++ b/loleaflet/css/jsdialogs.css
@@ -339,19 +339,25 @@ input[type='checkbox']:checked.autofilter, .jsdialog input[type='checkbox']:chec
 	overflow: scroll;
 	display: inline-flex;
 	flex-wrap: wrap;
+	justify-content: space-between;
+}
+
+.ui-iconview.mobile-wizard {
+	justify-content: space-around;
 }
 
 .ui-iconview-entry {
 	float: left;
 	position: relative;
-	flex-direction: column;
-	margin-left: 10px;
-	margin-top: 10px;
-	flex: 1;
+	display: flex;
+	flex-direction: row;
+	align-self: center;
+	border: 2px solid transparent;
+	border-radius: 3px;
 }
 
 .ui-iconview-entry.selected {
-	border: 5px solid silver;
+	border: 2px solid gray;
 }
 
 /* Autofilter dropdown */
@@ -519,4 +525,7 @@ input[type='checkbox']:checked.autofilter, .jsdialog input[type='checkbox']:chec
 #FontworkGalleryDialog #ctlFavoriteswin {
 	max-width: 400px;
 	max-height: 400px;
+}
+#FontworkGalleryDialog #label1 {
+	display: none;
 }


### PR DESCRIPTION
- iconview fix layout without using hard-coded margins
- fontwork: make sure the elements start at the same left position as the title and that they occupy the dialog evenly
- hide unnecessary label
- space-around when on mobile

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ia92acf1cbf09a3e7c6e996f9a846163835b115af
