### PR TITLE
Fixes offset between grid-lines and headers and other canvas related fixes

### DIFF
--- a/loleaflet/src/layer/SplitPanesContext.js
+++ b/loleaflet/src/layer/SplitPanesContext.js
@@ -198,11 +198,19 @@ L.SplitPanesContext = L.Class.extend({
 			));
 		}
 
-		// bottom-right/bottom-half/right-half pane or the full pane (when there are no split-panes active)
-		boundList.push(new L.Bounds(
-			topLeft.add(this._splitPos).add(new L.Point(1, 1)),
-			bottomRight
-		));
+		if (!boundList.length) {
+			// the full pane (when there are no split-panes active)
+			boundList.push(new L.Bounds(
+				topLeft,
+				bottomRight
+			));
+		} else {
+			// bottom-right/bottom-half/right-half pane
+			boundList.push(new L.Bounds(
+				topLeft.add(this._splitPos).add(new L.Point(1, 1)),
+				bottomRight
+			));
+		}
 
 		return boundList;
 	},

--- a/loleaflet/src/layer/tile/CanvasSectionContainer.ts
+++ b/loleaflet/src/layer/tile/CanvasSectionContainer.ts
@@ -496,6 +496,7 @@ class CanvasSectionContainer {
 		this.bottom = this.canvas.height;
 		for (var i: number = 0; i < this.sections.length; i++) {
 			this.sections[i].dpiScale = this.dpiScale;
+			this.sections[i].isLocated = false;
 		}
 
 		this.reNewAllSections();

--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -185,7 +185,7 @@ L.TileSectionManager = L.Class.extend({
 		if (this._layer._debug)
 		{
 			canvasCtx.strokeStyle = 'rgba(255, 0, 0, 0.5)';
-			canvasCtx.strokeRect(tile.coords.x, tile.coords.y, 256, 256);
+			canvasCtx.strokeRect(tile.coords.x - paneBounds.min.x, tile.coords.y - paneBounds.min.y, 256, 256);
 		}
 	},
 


### PR DESCRIPTION
* Target version: master 

### Summary
* Fixes offset between grid-lines and headers.
* Removes 1px empty spance near headers.
* Fixes debug mode tile-border red rectangle drawing.

### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

