### PR TITLE
cypress: print out test failure output online during parallel build.

### DIFF
--- a/cypress_test/run_parallel.sh
+++ b/cypress_test/run_parallel.sh
@@ -98,10 +98,9 @@ mkdir -p `dirname ${TEST_LOG}`
 touch ${TEST_LOG}
 rm -rf ${TEST_ERROR}
 echo "`echo ${RUN_COMMAND} && ${RUN_COMMAND} || touch ${TEST_ERROR}`" > ${TEST_LOG} 2>&1
-if [ ! -f ${TEST_ERROR} ];
-    then cat ${TEST_LOG};
-    else echo -e "Cypress test failed: ${TEST_FILE}\n" && \
-        cat ${TEST_LOG} >> ${ERROR_LOG} && \
+cat ${TEST_LOG}
+if [ -f ${TEST_ERROR} ];
+    then cat ${TEST_LOG} >> ${ERROR_LOG} && \
         print_error;
 fi;
 


### PR DESCRIPTION
Before this commit failure logs were gathered inside an error log
file and they were displayed after all tests are finsihed.
After this commit we print this failures logs when the error occurs
and also at the end of the test run. Sometimes Jenkins does not finish
the whole build because of timeout abortion. In this case, it would
be helpful to see some failure logs.

Signed-off-by: Tamás Zolnai <tamas.zolnai@collabora.com>
Change-Id: Ibe7cb6aa2c9f99912d604c4b642cda363352ffcd
