### PR TITLE
Fix crash in iOS app: Don't bother with UnitKit

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -2404,9 +2404,10 @@ void ChildSession::loKitCallback(const int type, const std::string& payload)
     LOG_TRC("ChildSession::loKitCallback [" << getName() << "]: " <<
             typeName << " [" << payload << "].");
 
+#if !MOBILEAPP
     if (UnitKit::get().filterLoKitCallback(type, payload))
         return;
-
+#endif
     if (isCloseFrame())
     {
         LOG_TRC("Skipping callback [" << typeName << "] on closing session " << getName());


### PR DESCRIPTION
I don't recall if simply ifdeffing is the proper way to bypass UnitKit
stuff (that I don't understand) for the mobile apps, but at least it
helps.

Signed-off-by: Tor Lillqvist <tml@iki.fi>
Change-Id: I85d477e4ee7d11c597d95a9b0b42af7e5f7ad122


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

