### PR TITLE
Sidebar should use .png icons instead of .svg fix #786

### DIFF
--- a/loolkitconfig.xcu
+++ b/loolkitconfig.xcu
@@ -28,8 +28,8 @@
 <!-- Enable thumbnail generation by default (disabling saves CPU time) -->
 <item oor:path="/org.openoffice.Office.Common/Save/Document"><prop oor:name="GenerateThumbnail" oor:op="fuse"><value>true</value></prop></item>
 
-<!-- Use the colibre_svg theme for the sidebar -->
-<item oor:path="/org.openoffice.Office.Common/Misc"><prop oor:name="SymbolStyle" oor:op="fuse"><value>colibre_svg</value></prop></item>
+<!-- Use the colibre theme for the sidebar -->
+<item oor:path="/org.openoffice.Office.Common/Misc"><prop oor:name="SymbolStyle" oor:op="fuse"><value>colibre</value></prop></item>
 
 <!-- Disable GIO UCP we don't want -->
 <item oor:path="/org.openoffice.ucb.Configuration/ContentProviders/Local/SecondaryKeys/Office/ProviderData/Provider999"><prop oor:name="URLTemplate" oor:op="fuse"><value>NeverMatchAnyUrlSuffix</value></prop></item>

--- a/loolkitconfig.xcu
+++ b/loolkitconfig.xcu
@@ -30,6 +30,7 @@
 
 <!-- Use the colibre theme for the sidebar -->
 <item oor:path="/org.openoffice.Office.Common/Misc"><prop oor:name="SymbolStyle" oor:op="fuse"><value>colibre</value></prop></item>
+<item oor:path="/org.openoffice.Office.Common/Misc"><prop oor:name="SidebarIconSize" oor:op="fuse"><value>2</value></prop></item>
 
 <!-- Disable GIO UCP we don't want -->
 <item oor:path="/org.openoffice.ucb.Configuration/ContentProviders/Local/SecondaryKeys/Office/ProviderData/Provider999"><prop oor:name="URLTemplate" oor:op="fuse"><value>NeverMatchAnyUrlSuffix</value></prop></item>


### PR DESCRIPTION
Change-Id: Ieeb8c5f37efb6e3f262d50f4fb54bbef59c2ff06

The problem is, that the svg2png rendering in core result in bad quality. That's the reason LibreOffice use .png icons by default and the .svg icons are available ONLY for HIDPI screens.

As the sidebar was rendered by core the sidebar has to use the .png icons instead of the .svg one.

before
![2021-01-15 11_45_51-ws-578f8750-def4-4f7c-b8a0-0a19feac508e_0 - noVNC](https://user-images.githubusercontent.com/8517736/104716224-e9a24900-5727-11eb-8861-d01e36a85a70.png)

after
![2021-01-15 11_47_17-ws-578f8750-def4-4f7c-b8a0-0a19feac508e_0 - noVNC](https://user-images.githubusercontent.com/8517736/104716239-eeff9380-5727-11eb-95b7-30d7dd157b1e.png)
