### PR TITLE
CanvasSectionProps: Add an overview of sections.

### DIFF
--- a/loleaflet/Makefile.am
+++ b/loleaflet/Makefile.am
@@ -205,6 +205,7 @@ LOLEAFLET_JS =\
 	src/map/Map.js \
 	src/map/Clipboard.js \
 	src/layer/Layer.js \
+	src/layer/tile/CanvasSectionProps.js \
 	src/layer/tile/CanvasSectionContainer.js \
 	src/layer/tile/GridLayer.js \
 	src/layer/tile/TileLayer.js \

--- a/loleaflet/src/layer/tile/CanvasSectionContainer.ts
+++ b/loleaflet/src/layer/tile/CanvasSectionContainer.ts
@@ -522,7 +522,6 @@ class CanvasSectionContainer {
 		this.bottom = this.canvas.height;
 		for (var i: number = 0; i < this.sections.length; i++) {
 			this.sections[i].dpiScale = this.dpiScale;
-			this.sections[i].isLocated = false;
 		}
 
 		this.reNewAllSections();

--- a/loleaflet/src/layer/tile/CanvasSectionProps.js
+++ b/loleaflet/src/layer/tile/CanvasSectionProps.js
@@ -1,0 +1,53 @@
+/*
+* CanvasSectionProps
+*
+* It's really difficult to set drawing and processing orders of sections, since they are mostly defined on different files.
+* So we have this file, to manage their orders easily. Define them here, globally. Then you can use from everywhere.
+* Refer to CanvasSectionContainer.ts for definitions of processingOrder, drawingOrder and zIndex.
+*/
+/* global L */
+
+L.CSections = {};
+L.CSections.Debug = {}; // For keeping things simple.
+
+// First definitions. Other properties will be written according to their orders.
+L.CSections.Tiles = 				{ name: 'tiles'				, zIndex: 5 };
+L.CSections.CalcGrid = 				{ name: 'calc grid'			, zIndex: 5 };
+L.CSections.Debug.Splits = 			{ name: 'splits'			, zIndex: 5 };
+L.CSections.Debug.TilePixelGrid = 	{ name: 'tile pixel grid'	, zIndex: 5 };
+
+L.CSections.ColumnHeader = 			{ name: 'column header'		, zIndex: 5 };
+L.CSections.RowHeader = 			{ name: 'row header'		, zIndex: 5 };
+L.CSections.CornerHeader = 			{ name: 'corner header'		, zIndex: 5 };
+
+L.CSections.ColumnGroup = 			{ name: 'column group'		, zIndex: 5 };
+L.CSections.RowGroup = 				{ name: 'row group'			, zIndex: 5 };
+L.CSections.CornerGroup = 			{ name: 'corner group'		, zIndex: 5 };
+
+
+/* Processing and drawing orders are meaningful between sections with the same zIndex. */
+/* Processing order	: Important for locations and sizes of sections. */
+/* Drawing order	: Highest with the same zIndex will be drawn on top. */
+
+/* zIndex = 5 */
+L.CSections.CornerHeader.processingOrder =			1; // Calc.
+L.CSections.RowHeader.processingOrder =				2; // Calc.
+L.CSections.ColumnHeader.processingOrder =			3; // Calc.
+L.CSections.Tiles.processingOrder = 				5; // Writer & Impress & Calc.
+L.CSections.Debug.TilePixelGrid.processingOrder = 	5; // Writer & Impress & Calc. This is bound to tiles, processingOrder is not important.
+L.CSections.CalcGrid.processingOrder = 				5; // Calc. This is bound to tiles, processingOrder is not important.
+L.CSections.Debug.Splits.processingOrder = 			5; // Calc. This is bound to tiles, processingOrder is not important.
+
+
+L.CSections.CalcGrid.drawingOrder = 				4; // Calc. This is 7 when debugging is enabled.
+L.CSections.Tiles.drawingOrder = 					5; // Writer & Impress & Calc.
+L.CSections.Debug.TilePixelGrid.drawingOrder = 		6; // Writer & Impress & Calc.
+/* drawingOrder = 7 is reserved for debugging mode of CalcGrid */
+L.CSections.Debug.Splits.drawingOrder = 			8; // Calc.
+L.CSections.RowHeader.drawingOrder = 				9; // Calc.
+L.CSections.ColumnHeader.drawingOrder = 			10; // Calc.
+L.CSections.CornerHeader.drawingOrder =				11; // Calc.
+
+
+
+/* zIndex = 6 and goes on. */

--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -213,14 +213,14 @@ L.TileSectionManager = L.Class.extend({
 	_addTilesSection: function () {
 		var that = this;
 		this._sectionContainer.createSection({
-			name: 'tiles',
+			name: L.CSections.Tiles.name,
 			anchor: 'top left',
 			position: [250 * that._dpiScale, 250 * that._dpiScale], // Set its initial position to somewhere blank. Other sections shouldn't cover this point after initializing.
 			size: [0, 0], // Going to be expanded, no initial width or height is necessary.
 			expand: 'top left bottom right', // Expand to all directions.
-			processingOrder: 5,
-			drawingOrder: 5,
-			zIndex: 5,
+			processingOrder: L.CSections.Tiles.processingOrder,
+			drawingOrder: L.CSections.Tiles.drawingOrder,
+			zIndex: L.CSections.Tiles.zIndex,
 			interactable: false,
 			sectionProperties: {
 				docLayer: that._layer,
@@ -236,14 +236,14 @@ L.TileSectionManager = L.Class.extend({
 	_addGridSection: function () {
 		var that = this;
 		this._sectionContainer.createSection({
-			name: 'calc grid',
+			name: L.CSections.CalcGrid.name,
 			anchor: 'top left',
 			position: [0, 0],
 			size: [0, 0],
 			expand: '',
-			processingOrder: 5, // Size and position will be copied, this value is not important.
-			drawingOrder: 4,
-			zIndex: 5,
+			processingOrder: L.CSections.CalcGrid.processingOrder, // Size and position will be copied, this value is not important.
+			drawingOrder: L.CSections.CalcGrid.drawingOrder,
+			zIndex: L.CSections.CalcGrid.zIndex,
 			// Even if this one is drawn on top, won't be able to catch events.
 			// Sections with "interactable: true" can catch events even if they are under a section with property "interactable: false".
 			interactable: false,
@@ -305,14 +305,14 @@ L.TileSectionManager = L.Class.extend({
 	_addSplitsSection: function () {
 		var that = this;
 		this._sectionContainer.createSection({
-			name: 'splits',
+			name: L.CSections.Debug.Splits.name,
 			anchor: 'top left',
 			position: [0, 0],
 			size: [0, 0],
 			expand: '',
-			processingOrder: 5, // Size and position will be copied, this value is not important.
-			drawingOrder: 8, // Above tiles section (same zIndex, higher drawing order).
-			zIndex: 5,
+			processingOrder: L.CSections.Debug.Splits.processingOrder,
+			drawingOrder: L.CSections.Debug.Splits.drawingOrder,
+			zIndex: L.CSections.Debug.Splits.zIndex,
 			// Even if this one is drawn on top, won't be able to catch events.
 			// Sections with "interactable: true" can catch events even if they are under a section with property "interactable: false".
 			interactable: false,
@@ -327,14 +327,14 @@ L.TileSectionManager = L.Class.extend({
 	_addTilePixelGridSection: function () {
 		var that = this;
 		this._sectionContainer.createSection({
-			name: 'tile pixel grid',
+			name: L.CSections.Debug.TilePixelGrid.name,
 			anchor: 'top left',
 			position: [0, 0],
 			size: [0, 0],
 			expand: '',
-			processingOrder: 5, // Size and position will be copied, this value is not important.
-			drawingOrder: 6,
-			zIndex: 5,
+			processingOrder: L.CSections.Debug.TilePixelGrid.processingOrder, // Size and position will be copied, this value is not important.
+			drawingOrder: L.CSections.Debug.TilePixelGrid.drawingOrder,
+			zIndex: L.CSections.Debug.TilePixelGrid.zIndex,
 			interactable: false,
 			sectionProperties: {},
 			onDraw: that._onDrawTilePixelGrid


### PR DESCRIPTION
We are drawing things from different files onto the same canvas.
CanvasSectionContainer is organising them. When they are too many, it is difficult to know about sections' important properties.
CanvasSectionProps keeps sections maintainable.

Signed-off-by: Gökay Şatır <gokaysatir@collabora.com>
Change-Id: I9e81104c30f30a47c02625ce9d6716a98958317c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

