### PR TITLE
fix build.sh: wrong directory after poco install

### DIFF
--- a/docker/from-source/build.sh
+++ b/docker/from-source/build.sh
@@ -82,6 +82,7 @@ if test ! -f poco/lib/libPocoFoundation.a ; then
     ./configure --static --no-tests --no-samples --no-sharedlibs --cflags="-fPIC" --omit=Zip,Data,Data/SQLite,Data/ODBC,Data/MySQL,MongoDB,PDF,CppParser,PageCompiler,Redis,Encodings --prefix=$BUILDDIR/poco
     make -j 8
     make install
+    cd ..
 fi
 
 


### PR DESCRIPTION
After compiling and installing poco the script is left in the wrong path, resulting core to be deployed underneath poco directory which breaks configure --with-lo-path later on.