### PR TITLE
gh pr 17

### DIFF
--- a/loleaflet/Makefile.am
+++ b/loleaflet/Makefile.am
@@ -27,11 +27,12 @@ $(L10N_IOS_ALL_JS) : $(wildcard $(srcdir)/po/ui-*.po) $(shell find $(srcdir)/l10
 	done
 endif
 
-SRC_TS = $(wildcard src/layer/tile/*.ts)
-SRC_TS_JS = $(patsubst src/layer/tile/%.ts,src/layer/tile/%.js,$(SRC_TS))
+SRC_TS = $(wildcard $(srcdir)/src/layer/tile/*.ts)
+SRC_TS_JS = $(patsubst $(srcdir)/src/layer/tile/%.ts,$(srcdir)/src/layer/tile/%.js,$(SRC_TS))
 
-src/layer/tile/%.js: src/layer/tile/%.ts
-	$(srcdir)/node_modules/typescript/bin/tsc $< --outfile $@ --module none --lib dom,es2016 --target ES5
+#
+$(srcdir)/src/layer/tile/%.js: $(srcdir)/src/layer/tile/%.ts
+	$(builddir)/node_modules/typescript/bin/tsc $< --outfile $@ --module none --lib dom,es2016 --target ES5
 
 JQUERY_LIGHTNESS_IMAGE_PATH = $(srcdir)/images/jquery-ui-lightness
 JQUERY_LIGHTNESS_IMAGES = $(wildcard $(JQUERY_LIGHTNESS_IMAGE_PATH)/*.png)


### PR DESCRIPTION
- loleaflet: makefile: fix override recipe
- loleaflet: fix remove child
- notebookbar: improve readibility of JSON
- notebookbar: improve readibility in Writer
- notebookbar: improve readibility in Calc
- notebookbar: improve readibility in Impress
- notebookbar: select correct tab for cached ones
- add clone and clear to ContextMenu
- wsd: chrono type-safe usage
- wsd: UploadResult cleanup
- jsdialog: apply updates using new message
- jsdialog: support radio groups
- jsdialog: radiobutton updates
- Fix #895: build poco from source, link poco statically, add openSUSE target, and other fixes
- cypress: NC: disable failing spellchecking tests.
- wsd: disable setting "SAL_LOG" in "DEBUG" mode
- Add pixel-testing image for interpolation avoidance.
- JSDialog: force checkbox style
- wsd: default UserFriendlyName if missing
- mobilewizard: send XLineColor data properly
- mobilewizard: add disabled state for toolbox children
- mobilewizard: refresh sidebar after border change
- Created Cypress test for Merge cells in Desktop Calc
- Notebookbar: Promote Print to bigtoolitem
- NotebookBar: Promote Revision History to bigtoolitem
- notebookbar: share revhistory and print with menubar
- NotebookBar: Promote shareas to bigtoolitem
- NotebookBar: Promote saveas to bigtoolitem
- Writer NB: Layout tab fix icon size of align commands
- check if we run in a container
- cypress: remove duplicate selectFirstColumn() helper method.
- notebookbar: clear timeout on remove
- Initialize menubar only once
- autofilter: don't allow to place outside screen
- Mark current linespacing setting in menu
- jsdialog: draggable only using titlebar
- jsdialog: implemented IconView
- Add fontwork dialog to the ui
- jsdialog: TreeView doubleclick to activate row
- Notebookbar: disable commands without gray background
- Notebookbar: disable command: easier to scan its status
- wsd: disable ssl by default, enable ssl termination by default
- wsd: test: remove redundant wakeupWorld and log the exit status
- wsd: test: move inherited filterSendMessage to onFilterSendMessage
- wsd: test: make DocumentConflict test robus and simpler
- wsd: test: make UnitWOPI test robust and simpler
- wsd: test: make owner-termination test robust and simpler
- wsd: test: make Version Restore test robust and simpler
- wsd: test: simplify sending commands
- wsd: test: shorter poll interval during tests
- wsd: test: support SSL in classic tests
- cypress: simplify typeIntoDocument() method.
- Fontwork: layout improvements
- Resolve #805 : Remove Mutex lock
- Remove un-used _isLoading and ScopeGuard.
- wsd: avoid reading the config entry more than once
- wsd: log when simulating socket error to help troubleshoot
- wsd: misc and cosmetics
- wsd: test: don't report test timeout outside of tests
- wsd: new NetUtil file for network utilities
- Signed-off-by: Andreas-Kainz <andreas_k@abwesend.de> Change-Id: I3ce2be9cc6362c09725fe1692e6853f195274211
- popup: improve text layout
- Fix calc text-input focus problem on Android
- cypress: print out test failure output online during parallel build.
- Revert "wsd: disable ssl by default, enable ssl termination by default"
- Fix wrong view info when opening two views close in time.
- cypress: reenable paragraph_prop multi-user test.
- cypress: remove workaround for multi-user test cases.
- Fix crash in iOS app: Don't bother with UnitKit
- clipboard: give a more explicit clustering error earlier.
- cypress: improve selectFullTable() helper of table properties tests.
- Revert "cypress: remove workaround for multi-user test cases."
- Special case opacity to avoid arithmetic where possible.
- Start of using NodeJS to do load simulation.
- Use jsdom to load and execute our CSS, HTML and JS.
- fix the debug tile-border rectangles in red
- don't leave 1px empty space near headers
- fix pixel offset between grid and row headers
- On resize allow recomputation of section pos and size
- CanvasSectionContainer: Fixes.
- Sidebar should use .png icons instead of .svg fix #786
- change default sidebar icon size to use 24px icons (like in toolbars)
- CanvasSectionProps: Add an overview of sections.
- cypress: prefer chromium over chrome.
- Fix "Cannot read property 'color' of undefined" error
- Revert "docker: do not modify loolwsd.xml, use command line parameters instead"
- leaflet: display correct number of characters in statusbar
- Add coolstress to gitignore
- Switch to the correct view before calling getSelectionType() method.
- cypress: reenable writer/simultaneous_typing multi-user test.
- loleaflet: makefile: fix builddir != srcdir
