### PR TITLE
Switch to the correct view before calling getSelectionType() method.

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -1021,6 +1021,7 @@ bool ChildSession::getTextSelection(const char* /*buffer*/, int /*length*/, cons
     }
 
     std::string selection;
+    getLOKitDocument()->setView(_viewId);
     const int selectionType = getLOKitDocument()->getSelectionType();
     if (selectionType == LOK_SELTYPE_LARGE_TEXT || selectionType == LOK_SELTYPE_COMPLEX ||
         (selection = getTextSelectionInternal(mimeType)).size() >= 1024 * 1024) // Don't return huge data.


### PR DESCRIPTION
This method needs to be called with having the correct view activated.

It caused a crash in writer/simultaneous_typing multi-user cypress test.

Signed-off-by: Tamás Zolnai <tamas.zolnai@collabora.com>
Change-Id: I57dd58a635ce7ea127200a6a3f0cadc8c0861aaf
(cherry picked from commit 218e47e65a5e59871b9670e4bad020cf389d17fc)