### PR TITLE
Update cypress: 6.1.0 -> 6.2.1.

### DIFF
--- a/cypress_test/package.json
+++ b/cypress_test/package.json
@@ -4,7 +4,7 @@
   "description": "Cypress integration test suit",
   "license": "MPL-2.0",
   "dependencies": {
-    "cypress": "6.1.0",
+    "cypress": "6.2.1",
     "cypress-failed-log": "2.7.0",
     "cypress-file-upload": "4.1.1",
     "cypress-log-to-output": "1.1.2",


### PR DESCRIPTION
It fixes a hang related to retries. It might be useful
in our case too. I've seen hangs on Jenkins, which might be
related.

Signed-off-by: Tamás Zolnai <tamas.zolnai@collabora.com>
Change-Id: I8320f9b38c59074d2b5dd3d7b0cad0c5828b0849
