### PR TITLE
Example how easy an tabbed NB will switch to tabbed compact NB

### DIFF
--- a/loleaflet/src/control/Control.NotebookbarWriter.js
+++ b/loleaflet/src/control/Control.NotebookbarWriter.js
@@ -140,10 +140,11 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 							'type': 'toolbox',
 							'text': '',
 							'enabled': 'true',
+							'vertical': 'false',
 							'children': [
 								{
 									'id': 'print',
-									'type': 'bigtoolitem',
+									'type': 'menubartoolitem',
 									'text': _UNO('.uno:Print', 'text'),
 									'command': '.uno:Print'
 								}
@@ -169,7 +170,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 						'type': 'container',
 						'text': '',
 						'enabled': 'true',
-						'vertical': 'true',
+						'vertical': 'false',
 						'children': [
 							{
 								'id': 'saveas-Section1',
@@ -222,7 +223,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 						'type': 'container',
 						'text': '',
 						'enabled': 'true',
-						'vertical': 'true',
+						'vertical': 'false',
 						'children': [
 							{
 								'id': 'saveas-Section1',
@@ -275,7 +276,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 						'type': 'container',
 						'text': '',
 						'enabled': 'true',
-						'vertical': 'true',
+						'vertical': 'false',
 						'children': [
 							{
 								'id': 'saveas-Section1',


### PR DESCRIPTION
Signed-off-by: Andreas-Kainz <andreas_k@abwesend.de>
Change-Id: Icd3b2f90b35921052267c4de5444ae3485cc1a54

How easy you convert an tabbed notebookbar into tabbed compact notebookbar you will see in this example PR (I wan't push it to master). And as the idea is to reuse the JSON notebookbar stuff, you can reuse even more like all the context toolbars will have the same commands than the context tab.

**Tabbed**
![Screenshot_20210120_163316](https://user-images.githubusercontent.com/8517736/105198827-5fe6e700-5b3e-11eb-9791-39bf41cdcfb1.png)

**Tabbed Compact**
![Screenshot_20210120_163953](https://user-images.githubusercontent.com/8517736/105198846-66755e80-5b3e-11eb-8528-8ed3d976efac.png)