### PR TITLE
Fix build with libc++: std::min() parameters should be of the same type.

### DIFF
--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -426,7 +426,7 @@ public:
             const auto timeSincePingMicroS
                 = std::chrono::duration_cast<std::chrono::microseconds>(now - _lastPingSentTime);
             timeoutMaxMicroS
-                = std::min(timeoutMaxMicroS, (PingFrequencyMicroS - timeSincePingMicroS).count());
+                = std::min(timeoutMaxMicroS, (int64_t)(PingFrequencyMicroS - timeSincePingMicroS).count());
         }
 #endif
         int events = POLLIN;


### PR DESCRIPTION
Signed-off-by: Gleb Popov <6yearold@gmail.com>
Change-Id: Icdb67f0576992cd54c8e15c85fbaf2745aba218c


- [X] Code is properly formatted
- [X] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

