### PR TITLE
Use winId here, too

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -1665,7 +1665,7 @@ bool ChildSession::renderWindow(const char* /*buffer*/, int /*length*/, const St
                                << " and rendered in " << elapsedMs << " (" << area / elapsedMics
                                << " MP/s).");
 
-    std::string response = "windowpaint: id=" + tokens[1] + " width=" + std::to_string(width)
+    std::string response = "windowpaint: id=" + std::to_string(winId) + " width=" + std::to_string(width)
                            + " height=" + std::to_string(height);
 
     if (!paintRectangle.empty())


### PR DESCRIPTION
The other code in this function carefully checks before indexing
tokes, and has already stored the integer from tokens[1] (if it
exists) into winId. Do it in one more place for consistency.

Change-Id: I2bc09b3e44e0549a94469d7569f724df17a113b3


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

