### PR TITLE
Make table markers clickable on desktop

### DIFF
--- a/loleaflet/src/layer/tile/TileLayer.TableOverlay.js
+++ b/loleaflet/src/layer/tile/TileLayer.TableOverlay.js
@@ -280,7 +280,7 @@ L.TileLayer.include({
 			else
 				this._tableSelectionRowMarkers.push(selectionRectangle);
 
-			selectionRectangle.on('down', this._onSelectRowColumnClick, this);
+			selectionRectangle.on('click', this._onSelectRowColumnClick, this);
 			// We don't actually want this to be draggable of course, so use a dragstart
 			// handler that freezes it.
 			selectionRectangle.on('dragstart drag dragend', this._onSelectRowColumnDrag, this);


### PR DESCRIPTION
- Currently the markers are not touchable on ipad (both via web and app) so
- Revert back listener change introduce in ebaca16c4f28ae7a499c632b70b24eaaa1083439

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ia2ff20ed4ddf810c50b11c49600709489f07785f
