### PR TITLE
CanvasTileLayer: Canvas is moved outside of "map" div.

### DIFF
--- a/loleaflet/css/loleaflet.css
+++ b/loleaflet/css/loleaflet.css
@@ -69,6 +69,7 @@
 	right: 0px;
 	z-index: 10;
 	cursor: auto;
+	background-color: transparent;
 }
 
 .leaflet-progress-layer

--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -533,7 +533,7 @@ L.CanvasTileLayer = L.TileLayer.extend({
 
 		L.TileLayer.prototype._initContainer.call(this);
 
-		var mapContainer = this._map.getContainer();
+		var mapContainer = document.getElementById('document-container');
 		var canvasContainerClass = 'leaflet-canvas-container';
 		this._canvasContainer = L.DomUtil.create('div', canvasContainerClass, mapContainer);
 		this._setup();


### PR DESCRIPTION
Canvas element's drawings will include part of UI outside of map area. Its size should be larger than tilelayer's and map's sizes.

Signed-off-by: Gökay Şatır <gokaysatir@collabora.com>
Change-Id: I89bf79ccfe0240abdb031b937626b0bb81f3ed6f


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [x] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

