### PR TITLE
Document State

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -174,7 +174,6 @@ DocumentBroker::DocumentBroker(ChildType type,
     _lastStorageUploadSuccessful(true),
     _lastSaveTime(std::chrono::steady_clock::now()),
     _lastSaveRequestTime(std::chrono::steady_clock::now() - std::chrono::milliseconds(COMMAND_TIMEOUT_MS)),
-    _markToDestroy(false),
     _isLoaded(false),
     _isModified(false),
     _cursorPosX(0),
@@ -451,7 +450,7 @@ void DocumentBroker::pollThread()
             }
         }
 #endif
-        else if (_sessions.empty() && (isLoaded() || _markToDestroy))
+        else if (_sessions.empty() && (isLoaded() || _docState.isMarkedToDestroy()))
         {
             // If all sessions have been removed, no reason to linger.
             LOG_INF("Terminating dead DocumentBroker for docKey [" << getDocKey() << "].");
@@ -574,7 +573,7 @@ bool DocumentBroker::download(const std::shared_ptr<ClientSession>& session, con
             return result;
     }
 
-    if (_markToDestroy)
+    if (_docState.isMarkedToDestroy())
     {
         // Tearing down.
         LOG_WRN("Will not load document marked to destroy. DocKey: [" << _docKey << "].");
@@ -980,11 +979,11 @@ void DocumentBroker::uploadToStorage(const std::string& sessionId, bool success,
 
     // If marked to destroy, or session is disconnected, remove.
     const auto it = _sessions.find(sessionId);
-    if (_markToDestroy || (it != _sessions.end() && it->second->isCloseFrame()))
+    if (_docState.isMarkedToDestroy() || (it != _sessions.end() && it->second->isCloseFrame()))
         disconnectSessionInternal(sessionId);
 
     // If marked to destroy, then this was the last session.
-    if (_markToDestroy || _sessions.empty())
+    if (_docState.isMarkedToDestroy() || _sessions.empty())
     {
         // Stop so we get cleaned up and removed.
         _stop = true;
@@ -1461,7 +1460,7 @@ std::size_t DocumentBroker::addSession(const std::shared_ptr<ClientSession>& ses
         if (_sessions.empty())
         {
             LOG_INF("Doc [" << _docKey << "] has no more sessions. Marking to destroy.");
-            _markToDestroy = true;
+            _docState.markToDestroy();
         }
 
         throw;
@@ -1540,7 +1539,11 @@ std::size_t DocumentBroker::removeSession(const std::string& id)
         std::shared_ptr<ClientSession> session = it->second;
 
         // Last view going away, can destroy.
-        _markToDestroy = (_sessions.size() <= 1);
+        if (_sessions.size() <= 1)
+            _docState.markToDestroy();
+
+        assert((_sessions.size() <= 1 && _docState.isMarkedToDestroy())
+               || !_docState.isMarkedToDestroy());
 
         const bool lastEditableSession = (!session->isReadOnly() || session->isAllowChangeComments()) && !haveAnotherEditableSession(id);
         static const bool dontSaveIfUnmodified = !LOOLWSD::getConfigValue<bool>("per_document.always_save_on_exit", false);
@@ -1549,7 +1552,7 @@ std::size_t DocumentBroker::removeSession(const std::string& id)
                 << id << "] on docKey [" << _docKey << "]. Have " << _sessions.size()
                 << " sessions. IsReadOnly: " << session->isReadOnly()
                 << ", IsViewLoaded: " << session->isViewLoaded() << ", IsWaitDisconnected: "
-                << session->inWaitDisconnected() << ", MarkToDestroy: " << _markToDestroy
+                << session->inWaitDisconnected() << ", MarkToDestroy: " << _docState.isMarkedToDestroy()
                 << ", LastEditableSession: " << lastEditableSession << ", DontSaveIfUnmodified: "
                 << dontSaveIfUnmodified << ", IsPossiblyModified: " << isPossiblyModified());
 
@@ -1602,10 +1605,10 @@ void DocumentBroker::disconnectSessionInternal(const std::string& id)
 #endif
 
             LOG_TRC("Disconnect session internal " << id <<
-                    " destroy? " << _markToDestroy <<
+                    " destroy? " << _docState.isMarkedToDestroy() <<
                     " locked? " << _lockCtx->_isLocked);
 
-            if (_markToDestroy && // last session to remove; FIXME: Editable?
+            if (_docState.isMarkedToDestroy() && // last session to remove; FIXME: Editable?
                 _lockCtx->_isLocked && _storage)
             {
                 if (!_storage->updateLockState(it->second->getAuthorization(), it->second->getCookies(), *_lockCtx, false))
@@ -2284,7 +2287,6 @@ bool DocumentBroker::forwardToChild(const std::string& viewId, const std::string
 
     // try the not yet created sessions
     LOG_WRN("Child session [" << viewId << "] not found to forward message: " << getAbbreviatedMessage(message));
-
     return false;
 }
 
@@ -2577,7 +2579,7 @@ void DocumentBroker::dumpState(std::ostream& os)
     auto now = std::chrono::steady_clock::now();
 
     os << " Broker: " << LOOLWSD::anonymizeUrl(_filename) << " pid: " << getPid();
-    if (_markToDestroy)
+    if (_docState.isMarkedToDestroy())
         os << " *** Marked to destroy ***";
     else
         os << " has live sessions";

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -174,7 +174,6 @@ DocumentBroker::DocumentBroker(ChildType type,
     _lastStorageUploadSuccessful(true),
     _lastSaveTime(std::chrono::steady_clock::now()),
     _lastSaveRequestTime(std::chrono::steady_clock::now() - std::chrono::milliseconds(COMMAND_TIMEOUT_MS)),
-    _isLoaded(false),
     _isModified(false),
     _cursorPosX(0),
     _cursorPosY(0),
@@ -1254,7 +1253,7 @@ void DocumentBroker::setLoaded()
 {
     if (!isLoaded())
     {
-        _isLoaded = true;
+        _docState.setLive();
         _loadDuration = std::chrono::duration_cast<std::chrono::milliseconds>(
                                 std::chrono::steady_clock::now() - _threadStart);
         LOG_TRC("Document loaded in " << _loadDuration);

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -175,7 +175,6 @@ DocumentBroker::DocumentBroker(ChildType type,
     _lastSaveTime(std::chrono::steady_clock::now()),
     _lastSaveRequestTime(std::chrono::steady_clock::now() - std::chrono::milliseconds(COMMAND_TIMEOUT_MS)),
     _markToDestroy(false),
-    _closeRequest(false),
     _isLoaded(false),
     _isModified(false),
     _cursorPosX(0),
@@ -394,7 +393,7 @@ void DocumentBroker::pollThread()
             continue;
         }
 
-        if (SigUtil::getShutdownRequestFlag() || _closeRequest)
+        if (SigUtil::getShutdownRequestFlag() || _docState.isCloseRequested())
         {
             const std::string reason = SigUtil::getShutdownRequestFlag() ? "recycling" : _closeReason;
             LOG_INF("Autosaving DocumentBroker for docKey [" << getDocKey() << "] for " << reason);
@@ -2410,7 +2409,7 @@ void DocumentBroker::closeDocument(const std::string& reason)
 
     LOG_DBG("Closing DocumentBroker for docKey [" << _docKey << "] with reason: " << reason);
     _closeReason = reason;
-    _closeRequest = true;
+    _docState.setCloseRequested();
 }
 
 void DocumentBroker::broadcastMessage(const std::string& message) const

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -596,6 +596,8 @@ bool DocumentBroker::download(const std::shared_ptr<ClientSession>& session, con
     bool firstInstance = false;
     if (_storage == nullptr)
     {
+        _docState.setStatus(DocumentState::Status::Downloading);
+
         // Pass the public URI to storage as it needs to load using the token
         // and other storage-specific data provided in the URI.
         const Poco::URI& uriPublic = session->getPublicUri();
@@ -804,6 +806,8 @@ bool DocumentBroker::download(const std::shared_ptr<ClientSession>& session, con
     {
         std::string localPath = _storage->downloadStorageFileToLocal(
             session->getAuthorization(), session->getCookies(), *_lockCtx, templateSource);
+
+        _docState.setStatus(DocumentState::Status::Loading); // Done downloading.
 
         // Only lock the document on storage for editing sessions
         // FIXME: why not lock before downloadStorageFileToLocal? Would also prevent race conditions

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -327,7 +327,7 @@ private:
 
     /// Loads a document from the public URI into the jail.
     bool download(const std::shared_ptr<ClientSession>& session, const std::string& jailId);
-    bool isLoaded() const { return _isLoaded; }
+    bool isLoaded() const { return _docState.hadLoaded(); }
 
     std::size_t getIdleTimeSecs() const
     {
@@ -480,6 +480,7 @@ private:
         DocumentState()
             : _status(Status::None)
             , _closeRequested(false)
+            , _loaded(false)
         {
         }
 
@@ -492,8 +493,21 @@ private:
             _status = newStatus;
         }
 
+        /// True iff the document had ever loaded completely, without implying it's still loaded.
+        bool hadLoaded() const { return _loaded; }
+
         /// True iff the document is fully loaded and available for viewing/editing.
         bool isLive() const { return _status == Status::Live; }
+
+        /// Transitions to Status::Live, implying the document has loaded.
+        void setLive()
+        {
+            LOG_TRC("Setting DocumentState to Status::Live from " << toString(_status));
+            // assert(_status == Status::Loading
+            //        && "Document wasn't in Loading state to transition to Status::Live");
+            _loaded = true;
+            setStatus(Status::Live);
+        }
 
         /// Flags the document for unloading and destruction.
         void markToDestroy() { _status = Status::Destroying; }
@@ -506,6 +520,7 @@ private:
     private:
         Status _status;
         std::atomic<bool> _closeRequested; //< Owner-Termination flag.
+        std::atomic<bool> _loaded; //< If the document ever loaded (check isLive to see if it still is).
     };
 
     /// The main state of the document.
@@ -542,7 +557,6 @@ private:
 
     std::unique_ptr<StorageBase> _storage;
     std::unique_ptr<TileCache> _tileCache;
-    std::atomic<bool> _isLoaded;
     std::atomic<bool> _isModified;
     int _cursorPosX;
     int _cursorPosY;

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -479,6 +479,7 @@ private:
 
         DocumentState()
             : _status(Status::None)
+            , _closeRequested(false)
         {
         }
 
@@ -491,8 +492,13 @@ private:
             _status = newStatus;
         }
 
+        /// Flag close-requested. Cannot be reset.
+        void setCloseRequested() { _closeRequested = true; }
+        bool isCloseRequested() const { return _closeRequested; }
+
     private:
         Status _status;
+        std::atomic<bool> _closeRequested; //< Owner-Termination flag.
     };
 
     /// The main state of the document.
@@ -530,7 +536,6 @@ private:
     std::unique_ptr<StorageBase> _storage;
     std::unique_ptr<TileCache> _tileCache;
     std::atomic<bool> _markToDestroy;
-    std::atomic<bool> _closeRequest;
     std::atomic<bool> _isLoaded;
     std::atomic<bool> _isModified;
     int _cursorPosX;

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -274,7 +274,7 @@ public:
     static bool lookupSendClipboardTag(const std::shared_ptr<StreamSocket> &socket,
                                        const std::string &tag, bool sendError = false);
 
-    bool isMarkedToDestroy() const { return _markToDestroy || _stop; }
+    bool isMarkedToDestroy() const { return _docState.isMarkedToDestroy() || _stop; }
 
     bool handleInput(const std::vector<char>& payload);
 
@@ -492,7 +492,14 @@ private:
             _status = newStatus;
         }
 
-        /// Flag close-requested. Cannot be reset.
+        /// True iff the document is fully loaded and available for viewing/editing.
+        bool isLive() const { return _status == Status::Live; }
+
+        /// Flags the document for unloading and destruction.
+        void markToDestroy() { _status = Status::Destroying; }
+        bool isMarkedToDestroy() const { return _status >= Status::Destroying; }
+
+        /// Flag document termination. Cannot be reset.
         void setCloseRequested() { _closeRequested = true; }
         bool isCloseRequested() const { return _closeRequested; }
 
@@ -535,7 +542,6 @@ private:
 
     std::unique_ptr<StorageBase> _storage;
     std::unique_ptr<TileCache> _tileCache;
-    std::atomic<bool> _markToDestroy;
     std::atomic<bool> _isLoaded;
     std::atomic<bool> _isModified;
     int _cursorPosX;


### PR DESCRIPTION
This PR introduces a new DocumentStatus class to encapsulate the document lifecycle states
and the related members to track it.

- wsd: introduce DocumentState class
- wsd: move the closeRequested flag into DocumentStatus
- wsd: move the markToDestroy flag into DocumentStatus
- wsd: move the loaded flag into DocumentStatus
