### PR TITLE
Add caching of tunnelled dialog images

### DIFF
--- a/kit/ChildSession.hpp
+++ b/kit/ChildSession.hpp
@@ -359,6 +359,8 @@ private:
 
     /// If we are copying to clipboard.
     bool _copyToClipboard;
+
+    std::vector<uint64_t> _pixmapCache;
 };
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -2407,6 +2407,17 @@ void lokit_main(
             std::string versionString(versionInfo);
             if (displayVersion)
                 std::cout << "office version details: " << versionString << std::endl;
+
+            // Add some parameters we want to pass to the client. Could not figure out how to get
+            // the configuration parameters from LOOLWSD.cpp's initialize() or loolwsd.xml here, so
+            // oh well, just have the value hardcoded in KitHelper.hpp. It isn't really useful to
+            // "tune" it at end-user installations anyway, I think.
+            auto versionJSON = Poco::JSON::Parser().parse(versionString).extract<Poco::JSON::Object::Ptr>();
+            versionJSON->set("tunnelled_dialog_image_cache_size", std::to_string(LOKitHelper::tunnelled_dialog_image_cache_size));
+            std::stringstream ss;
+            versionJSON->stringify(ss);
+            versionString = ss.str();
+
             std::string encodedVersion;
             Poco::URI::encode(versionString, "?#/", encodedVersion);
             pathAndQuery.append("&version=");

--- a/kit/KitHelper.hpp
+++ b/kit/KitHelper.hpp
@@ -17,6 +17,8 @@
 
 namespace LOKitHelper
 {
+    constexpr auto tunnelled_dialog_image_cache_size = 100;
+
     inline std::string documentTypeToString(LibreOfficeKitDocumentType type)
     {
         switch (type)

--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -11,6 +11,9 @@ L.Socket = L.Class.extend({
 	WasShownLimitDialog: false,
 	WSDServer: {},
 
+	// Will be set from lokitversion message
+	TunnelledDialogImageCacheSize: 0,
+
 	getParameterValue: function (s) {
 		var i = s.indexOf('=');
 		if (i === -1)
@@ -319,6 +322,7 @@ L.Socket = L.Class.extend({
 			$('#lokit-version').html(lokitVersionObj.ProductName + ' ' +
 			                         lokitVersionObj.ProductVersion + lokitVersionObj.ProductExtension.replace('.10.','-') +
 			                         ' (git hash: ' + h + ')');
+			this.TunnelledDialogImageCacheSize = lokitVersionObj.tunnelled_dialog_image_cache_size;
 		}
 		else if (textMsg.startsWith('osinfo ')) {
 			var osInfo = textMsg.replace('osinfo ', '');
@@ -1261,6 +1265,9 @@ L.Socket = L.Class.extend({
 				selectedParts.forEach(function (item) {
 					command.selectedParts.push(parseInt(item));
 				});
+			}
+			else if (tokens[i].startsWith('hash=')) {
+				command.hash = tokens[i].substring('hash='.length);
 			}
 		}
 		if (command.tileWidth && command.tileHeight && this._map._docLayer) {

--- a/loleaflet/src/layer/tile/TileLayer.js
+++ b/loleaflet/src/layer/tile/TileLayer.js
@@ -63,6 +63,8 @@ L.TileLayer = L.GridLayer.extend({
 		marginY: 10
 	},
 
+	_pngCache: [],
+
 	initialize: function (url, options) {
 
 		this._url = url;
@@ -2000,12 +2002,34 @@ L.TileLayer = L.GridLayer.extend({
 	_onDialogPaintMsg: function(textMsg, img) {
 		var command = this._map._socket.parseServerCmd(textMsg);
 
+		// this._map._socket.sendMessage('DEBUG _onDialogPaintMsg: hash=' + command.hash + ' img=' + typeof(img) + (typeof(img) == 'string' ? (' (length:' + img.length + ':"' + img.substring(0, 30) + (img.length > 30 ? '...' : '') + '")') : '') + ', cache size ' + this._pngCache.length);
+		for (var i = 0; i < this._pngCache.length; i++) {
+			if (this._pngCache[i].hash == command.hash) {
+				// this._map._socket.sendMessage('DEBUG - Found in cache');
+				img = this._pngCache[i].img;
+				// Remove item and add it at the start of the array
+				this._pngCache.splice(i, 1);
+				break;
+			}
+		}
+		// If cache is max size, drop the last element
+		if (this._pngCache.length == this._map._socket.TunnelledDialogImageCacheSize) {
+			// this._map._socket.sendMessage('DEBUG - Dropping last cache element');
+			this._pngCache.pop();
+		}
+
+		// Add element to cache
+		this._pngCache.unshift({hash: command.hash, img:img});
+
+		// this._map._socket.sendMessage('DEBUG - Cache size now ' + this._pngCache.length);
+
 		this._map.fire('windowpaint', {
 			id: command.id,
 			img: img,
 			width: command.width,
 			height: command.height,
-			rectangle: command.rectangle
+			rectangle: command.rectangle,
+			hash: command.hash
 		});
 	},
 


### PR DESCRIPTION
The same cache size is used in server and client. The caches use the
invalidation algorithm. Pass the hash of the pixmap in the
windowpaint: message. The client stores dialog images in its cache.
The server stores hashes of the images. When the server knows that the
client already has an image cached, it sends just its hash and the
client will use the cached image.

Pass the size of the cache to the client so that we don't have to keep
the the cache size synchronised in two places in the code.

Change-Id: Ie6cbfca79a9ede48fcc115e3acc669b925bb624e
Signed-off-by: Tor Lillqvist <tml@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

