### PR TITLE
Add caching of tunnelled dialog images

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -1665,13 +1665,60 @@ bool ChildSession::renderWindow(const char* /*buffer*/, int /*length*/, const St
             << " and rendered in " << totalTime
             << "ms (" << area / elapsed << " MP/s).");
 
+    uint64_t pixmapHash = Png::hashSubBuffer(pixmap.data(), 0, 0, width, height, bufferWidth, bufferHeight);
+
+    auto found = std::find(_pixmapCache.begin(), _pixmapCache.end(), pixmapHash);
+
+    assert(_pixmapCache.size() <= LOKitHelper::tunnelled_dialog_image_cache_size);
+
+    // If not found in cache, we need to encode to PNG and send to client
+    const bool doPng = (found == _pixmapCache.end());
+
+    LOG_DBG("Pixmap hash: " << pixmapHash << (doPng ? " NOT in cache, doing PNG" : " in cache, not encoding to PNG") << ", cache size now:" << _pixmapCache.size());
+
+    // If it is already the first in the cache, no need to do anything. Otherwise, if in cache, move
+    // to beginning. If not in cache, add it as first. Keep cache size limited.
+    if (_pixmapCache.size() > 0)
+    {
+        if (found != _pixmapCache.begin())
+        {
+            if (found != _pixmapCache.end())
+            {
+                LOG_DBG("Erasing found entry");
+                _pixmapCache.erase(found);
+            }
+            else if (_pixmapCache.size() == LOKitHelper::tunnelled_dialog_image_cache_size)
+            {
+                LOG_DBG("Popping last entry");
+                _pixmapCache.pop_back();
+            }
+            _pixmapCache.insert(_pixmapCache.begin(), pixmapHash);
+        }
+    }
+    else
+        _pixmapCache.insert(_pixmapCache.begin(), pixmapHash);
+
+    LOG_DBG("Pixmap cache size now:" << _pixmapCache.size());
+
+    assert(_pixmapCache.size() <= LOKitHelper::tunnelled_dialog_image_cache_size);
+
     response = "windowpaint: id=" + tokens[1] +
         " width=" + std::to_string(width) + " height=" + std::to_string(height);
 
     if (!paintRectangle.empty())
         response += " rectangle=" + paintRectangle;
 
-    response += '\n';
+    response += " hash=" + std::to_string(pixmapHash);
+
+    if (!doPng)
+    {
+        // Just so that we might see in the client console log that no PNG was included.
+        response += " nopng";
+        sendTextFrame(response.c_str());
+        return true;
+    }
+
+    response += "\n";
 
     std::vector<char> output;
     output.reserve(response.size() + pixmapDataSize);
@@ -1687,7 +1734,20 @@ bool ChildSession::renderWindow(const char* /*buffer*/, int /*length*/, const St
         return false;
     }
 
-    LOG_TRC("Sending response (" << output.size() << " bytes) for: " << response);
+#if 0
+    {
+        static const std::string tempDir = FileUtil::createRandomTmpDir();
+        static int pngDumpCounter = 0;
+        std::stringstream ss;
+        ss << tempDir << "/" << "renderwindow-" << pngDumpCounter++ << ".png";
+        LOG_INF("Dumping PNG to '"<< ss.str() << "'");
+        FILE *f = fopen(ss.str().c_str(), "w");
+        fwrite(output.data() + response.size(), output.size() - response.size(), 1, f);
+        fclose(f);
+    }
+#endif
+
+    LOG_TRC("Sending response (" << output.size() << " bytes) for: " << std::string(output.data(), response.size() - 1));
     sendBinaryFrame(output.data(), output.size());
     return true;
 }

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -1669,7 +1669,7 @@ bool ChildSession::renderWindow(const char* /*buffer*/, int /*length*/, const St
 
     auto found = std::find(_pixmapCache.begin(), _pixmapCache.end(), pixmapHash);
 
-    assert(_pixmapCache.size() <= LOKitHelper::tunnelled_dialog_image_cache_size);
+    assert(_pixmapCache.size() <= LOKitHelper::tunnelledDialogImageCacheSize);
 
     // If not found in cache, we need to encode to PNG and send to client
     const bool doPng = (found == _pixmapCache.end());
@@ -1687,7 +1687,7 @@ bool ChildSession::renderWindow(const char* /*buffer*/, int /*length*/, const St
                 LOG_DBG("Erasing found entry");
                 _pixmapCache.erase(found);
             }
-            else if (_pixmapCache.size() == LOKitHelper::tunnelled_dialog_image_cache_size)
+            else if (_pixmapCache.size() == LOKitHelper::tunnelledDialogImageCacheSize)
             {
                 LOG_DBG("Popping last entry");
                 _pixmapCache.pop_back();
@@ -1700,7 +1700,7 @@ bool ChildSession::renderWindow(const char* /*buffer*/, int /*length*/, const St
 
     LOG_DBG("Pixmap cache size now:" << _pixmapCache.size());
 
-    assert(_pixmapCache.size() <= LOKitHelper::tunnelled_dialog_image_cache_size);
+    assert(_pixmapCache.size() <= LOKitHelper::tunnelledDialogImageCacheSize);
 
     response = "windowpaint: id=" + tokens[1] +
         " width=" + std::to_string(width) + " height=" + std::to_string(height);

--- a/kit/ChildSession.hpp
+++ b/kit/ChildSession.hpp
@@ -361,6 +361,8 @@ private:
 
     /// If we are copying to clipboard.
     bool _copyToClipboard;
+
+    std::vector<uint64_t> _pixmapCache;
 };
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -2441,6 +2441,17 @@ void lokit_main(
             std::string versionString(versionInfo);
             if (displayVersion)
                 std::cout << "office version details: " << versionString << std::endl;
+
+            // Add some parameters we want to pass to the client. Could not figure out how to get
+            // the configuration parameters from LOOLWSD.cpp's initialize() or loolwsd.xml here, so
+            // oh well, just have the value hardcoded in KitHelper.hpp. It isn't really useful to
+            // "tune" it at end-user installations anyway, I think.
+            auto versionJSON = Poco::JSON::Parser().parse(versionString).extract<Poco::JSON::Object::Ptr>();
+            versionJSON->set("tunnelled_dialog_image_cache_size", std::to_string(LOKitHelper::tunnelled_dialog_image_cache_size));
+            std::stringstream ss;
+            versionJSON->stringify(ss);
+            versionString = ss.str();
+
             std::string encodedVersion;
             Poco::URI::encode(versionString, "?#/", encodedVersion);
             pathAndQuery.append("&version=");

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -2447,7 +2447,7 @@ void lokit_main(
             // oh well, just have the value hardcoded in KitHelper.hpp. It isn't really useful to
             // "tune" it at end-user installations anyway, I think.
             auto versionJSON = Poco::JSON::Parser().parse(versionString).extract<Poco::JSON::Object::Ptr>();
-            versionJSON->set("tunnelled_dialog_image_cache_size", std::to_string(LOKitHelper::tunnelled_dialog_image_cache_size));
+            versionJSON->set("tunnelled_dialog_image_cache_size", std::to_string(LOKitHelper::tunnelledDialogImageCacheSize));
             std::stringstream ss;
             versionJSON->stringify(ss);
             versionString = ss.str();

--- a/kit/KitHelper.hpp
+++ b/kit/KitHelper.hpp
@@ -17,7 +17,7 @@
 
 namespace LOKitHelper
 {
-    constexpr auto tunnelled_dialog_image_cache_size = 100;
+    constexpr auto tunnelledDialogImageCacheSize = 100;
 
     inline std::string documentTypeToString(LibreOfficeKitDocumentType type)
     {

--- a/kit/KitHelper.hpp
+++ b/kit/KitHelper.hpp
@@ -17,6 +17,8 @@
 
 namespace LOKitHelper
 {
+    constexpr auto tunnelled_dialog_image_cache_size = 100;
+
     inline std::string documentTypeToString(LibreOfficeKitDocumentType type)
     {
         switch (type)

--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -11,6 +11,9 @@ L.Socket = L.Class.extend({
 	WasShownLimitDialog: false,
 	WSDServer: {},
 
+	// Will be set from lokitversion message
+	TunnelledDialogImageCacheSize: 0,
+
 	getParameterValue: function (s) {
 		var i = s.indexOf('=');
 		if (i === -1)
@@ -315,6 +318,7 @@ L.Socket = L.Class.extend({
 			$('#lokit-version').html(lokitVersionObj.ProductName + ' ' +
 			                         lokitVersionObj.ProductVersion + lokitVersionObj.ProductExtension.replace('.10.','-') +
 			                         ' (git hash: ' + h + ')');
+			this.TunnelledDialogImageCacheSize = lokitVersionObj.tunnelled_dialog_image_cache_size;
 		}
 		else if (textMsg.startsWith('osinfo ')) {
 			var osInfo = textMsg.replace('osinfo ', '');
@@ -1251,6 +1255,9 @@ L.Socket = L.Class.extend({
 				selectedParts.forEach(function (item) {
 					command.selectedParts.push(parseInt(item));
 				});
+			}
+			else if (tokens[i].startsWith('hash=')) {
+				command.hash = tokens[i].substring('hash='.length);
 			}
 		}
 		if (command.tileWidth && command.tileHeight && this._map._docLayer) {

--- a/loleaflet/src/layer/tile/TileLayer.js
+++ b/loleaflet/src/layer/tile/TileLayer.js
@@ -63,6 +63,8 @@ L.TileLayer = L.GridLayer.extend({
 		marginY: 10
 	},
 
+	_pngCache: [],
+
 	initialize: function (url, options) {
 
 		this._url = url;
@@ -2006,12 +2008,34 @@ L.TileLayer = L.GridLayer.extend({
 	_onDialogPaintMsg: function(textMsg, img) {
 		var command = this._map._socket.parseServerCmd(textMsg);
 
+		// this._map._socket.sendMessage('DEBUG _onDialogPaintMsg: hash=' + command.hash + ' img=' + typeof(img) + (typeof(img) == 'string' ? (' (length:' + img.length + ':"' + img.substring(0, 30) + (img.length > 30 ? '...' : '') + '")') : '') + ', cache size ' + this._pngCache.length);
+		for (var i = 0; i < this._pngCache.length; i++) {
+			if (this._pngCache[i].hash == command.hash) {
+				// this._map._socket.sendMessage('DEBUG - Found in cache');
+				img = this._pngCache[i].img;
+				// Remove item and add it at the start of the array
+				this._pngCache.splice(i, 1);
+				break;
+			}
+		}
+		// If cache is max size, drop the last element
+		if (this._pngCache.length == this._map._socket.TunnelledDialogImageCacheSize) {
+			// this._map._socket.sendMessage('DEBUG - Dropping last cache element');
+			this._pngCache.pop();
+		}
+
+		// Add element to cache
+		this._pngCache.unshift({hash: command.hash, img:img});
+
+		// this._map._socket.sendMessage('DEBUG - Cache size now ' + this._pngCache.length);
+
 		this._map.fire('windowpaint', {
 			id: command.id,
 			img: img,
 			width: command.width,
 			height: command.height,
-			rectangle: command.rectangle
+			rectangle: command.rectangle,
+			hash: command.hash
 		});
 	},
 


### PR DESCRIPTION
The same cache size is used in server and client. The caches use the
invalidation algorithm. Pass the hash of the pixmap in the
windowpaint: message. The client stores dialog images in its cache.
The server stores hashes of the images. When the server knows that the
client already has an image cached, it sends just its hash and the
client will use the cached image.

Pass the size of the cache to the client so that we don't have to keep
the the cache size synchronised in two places in the code.

Change-Id: Ie6cbfca79a9ede48fcc115e3acc669b925bb624e
Signed-off-by: Tor Lillqvist <tml@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

