### PR TITLE
Add  sanity checks to the PNG cache code in loleaflet

### DIFF
--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -1269,6 +1269,9 @@ L.Socket = L.Class.extend({
 			else if (tokens[i].startsWith('hash=')) {
 				command.hash = tokens[i].substring('hash='.length);
 			}
+			else if (tokens[i] === 'nopng') {
+				command.nopng = true;
+			}
 		}
 		if (command.tileWidth && command.tileHeight && this._map._docLayer) {
 			var defaultZoom = this._map.options.zoom;


### PR DESCRIPTION
If the client cache seems to be inconsistent with what the server
thinks, send an ERROR message to the server that will be logged.

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: Ic7f9d7fb15b2c34f7a6cd2decbacaa7745ac9389
Signed-off-by: Tor Lillqvist <tml@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

