### PR TITLE
wsd: test: move HttpRequestTests to 'make check'

### DIFF
--- a/test/HttpRequestTests.cpp
+++ b/test/HttpRequestTests.cpp
@@ -27,13 +27,16 @@
 #include <Util.hpp>
 
 /// http::Request unit-tests.
+/// FIXME: use loopback and avoid depending on external services.
+/// Currently we need to rely on external services to validate
+/// the implementation.
 class HttpRequestTests final : public CPPUNIT_NS::TestFixture
 {
     CPPUNIT_TEST_SUITE(HttpRequestTests);
 
     CPPUNIT_TEST(testSimpleGet);
     CPPUNIT_TEST(testSimpleGetSync);
-    // CPPUNIT_TEST(test500GetStatuses); // Slow.
+    CPPUNIT_TEST(test500GetStatuses); // Slow.
     CPPUNIT_TEST(testSimplePost);
     CPPUNIT_TEST(testTimeout);
     CPPUNIT_TEST(testOnFinished_Complete);

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -76,7 +76,6 @@ test_base_source = \
 	TileQueueTests.cpp \
 	WhiteBoxTests.cpp \
 	DeltaTests.cpp \
-	HttpRequestTests.cpp \
 	WopiProofTests.cpp \
 	$(wsd_sources)
 
@@ -110,7 +109,7 @@ fakesockettest_SOURCES = fakesockettest.cpp  ../net/FakeSocket.cpp ../common/Log
 fakesockettest_LDADD = $(CPPUNIT_LIBS)
 
 # old-style unit tests - bootstrapped via UnitClient
-unit_base_la_SOURCES = UnitClient.cpp ${test_base_source}
+unit_base_la_SOURCES = UnitClient.cpp ${test_base_source} HttpRequestTests.cpp
 unit_tiletest_la_SOURCES = UnitClient.cpp TileCacheTests.cpp
 unit_tiletest_la_LIBADD = $(CPPUNIT_LIBS)
 unit_integration_la_SOURCES = UnitClient.cpp integration-http-server.cpp


### PR DESCRIPTION
These tests require network setup and therefore
can be problematic for `make run`.

Change-Id: I8747a505e15edc91964b290a5476a24069b7d538
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
