### PR TITLE
Disambiguate between Save and Upload

### DIFF
--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1347,7 +1347,7 @@ bool ClientSession::handleKitToClientMessage(const char* buffer, const int lengt
             // When the document is saved internally, but saving to storage failed,
             // don't update the client's modified status
             // (otherwise client thinks document is unmodified b/c saving was successful)
-            if (!docBroker->isLastStorageSaveSuccessful())
+            if (!docBroker->isLastStorageUploadSuccessful())
                 return false;
 
             docBroker->setModified(stateTokens.equals(1, "true"));

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -687,7 +687,7 @@ bool ClientSession::_handleInput(const char *buffer, int length)
         }
         std::string wopiFilename;
         Poco::URI::decode(encodedWopiFilename, wopiFilename);
-        docBroker->saveAsToStorage(getId(), "", wopiFilename, true);
+        docBroker->uploadAsToStorage(getId(), "", wopiFilename, true);
         return true;
     }
     else if (tokens.equals(0, "dialogevent") || tokens.equals(0, "formfieldevent"))
@@ -1304,7 +1304,7 @@ bool ClientSession::handleKitToClientMessage(const char* buffer, const int lengt
             {
                 // this also sends the saveas: result
                 LOG_TRC("Save-as path: " << resultURL.getPath());
-                docBroker->saveAsToStorage(getId(), resultURL.getPath(), wopiFilename, false);
+                docBroker->uploadAsToStorage(getId(), resultURL.getPath(), wopiFilename, false);
             }
             else
                 sendTextFrameAndLogError("error: cmd=storage kind=savefailed");

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -521,7 +521,7 @@ bool ClientSession::_handleInput(const char *buffer, int length)
         // The savetostorage command is really only used to resolve save conflicts
         // and it seems to always have force=1. However, we should still honor the
         // contract and do as told, not as we expect the API to be used. Use force if provided.
-        docBroker->saveToStorage(getId(), true, "" /* This is irrelevant when success is true*/, force);
+        docBroker->uploadToStorage(getId(), true, "" /* This is irrelevant when success is true*/, force);
     }
     else if (tokens.equals(0, "clientvisiblearea"))
     {
@@ -1147,7 +1147,7 @@ bool ClientSession::handleKitToClientMessage(const char* buffer, const int lengt
                 }
 
                 // Save to Storage and log result.
-                docBroker->saveToStorage(getId(), success, result, /*force=*/false);
+                docBroker->uploadToStorage(getId(), success, result, /*force=*/false);
 
                 if (!isCloseFrame())
                     forwardToClient(payload);
@@ -1472,7 +1472,7 @@ bool ClientSession::handleKitToClientMessage(const char* buffer, const int lengt
             {
                 std::string result;
                 LOG_DBG("Saving template [" << _wopiFileInfo->getTemplateSource() << "] to storage");
-                docBroker->saveToStorage(getId(), true, result, /*force=*/false);
+                docBroker->uploadToStorage(getId(), true, result, /*force=*/false);
             }
 
             for(auto &token : tokens)

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -972,8 +972,8 @@ void DocumentBroker::uploadToStorage(const std::string& sessionId, bool success,
     }
 
     constexpr bool isRename = false;
-    saveToStorageInternal(sessionId, success, result, /*saveAsPath*/ std::string(),
-                          /*saveAsFilename*/ std::string(), isRename, force);
+    uploadToStorageInternal(sessionId, success, result, /*saveAsPath*/ std::string(),
+                            /*saveAsFilename*/ std::string(), isRename, force);
 
     // If marked to destroy, or session is disconnected, remove.
     const auto it = _sessions.find(sessionId);
@@ -994,10 +994,10 @@ void DocumentBroker::uploadAsToStorage(const std::string& sessionId,
 {
     assertCorrectThread();
 
-    saveToStorageInternal(sessionId, true, "", uploadAsPath, uploadAsFilename, isRename);
+    uploadToStorageInternal(sessionId, true, "", uploadAsPath, uploadAsFilename, isRename);
 }
 
-void DocumentBroker::saveToStorageInternal(const std::string& sessionId, bool success,
+void DocumentBroker::uploadToStorageInternal(const std::string& sessionId, bool success,
                                            const std::string& result, const std::string& saveAsPath,
                                            const std::string& saveAsFilename, const bool isRename,
                                            const bool force)

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -944,8 +944,8 @@ bool DocumentBroker::attemptLock(const ClientSession& session, std::string& fail
     return bResult;
 }
 
-void DocumentBroker::saveToStorage(const std::string& sessionId, bool success,
-                                   const std::string& result, bool force)
+void DocumentBroker::uploadToStorage(const std::string& sessionId, bool success,
+                                     const std::string& result, bool force)
 {
     assertCorrectThread();
 

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -171,7 +171,7 @@ DocumentBroker::DocumentBroker(ChildType type,
     _docKey(docKey),
     _docId(Util::encodeId(DocBrokerId++, 3)),
     _documentChangedInStorage(false),
-    _lastStorageSaveSuccessful(true),
+    _lastStorageUploadSuccessful(true),
     _lastSaveTime(std::chrono::steady_clock::now()),
     _lastSaveRequestTime(std::chrono::steady_clock::now() - std::chrono::milliseconds(COMMAND_TIMEOUT_MS)),
     _markToDestroy(false),
@@ -959,7 +959,7 @@ void DocumentBroker::saveToStorage(const std::string& sessionId, bool success,
             LOG_TRC("Enabling forced saving to storage per always_save_on_exit config.");
             force = true;
         }
-        else if (!_lastStorageSaveSuccessful)
+        else if (!_lastStorageUploadSuccessful)
         {
             LOG_TRC("Enabling forced saving to storage as last attempt had failed.");
             force = true;
@@ -1090,7 +1090,7 @@ void DocumentBroker::handleUploadToStorageResponse(
 {
     // Storage save is considered successful when either storage returns OK or the document on the storage
     // was changed and it was used to overwrite local changes
-    _lastStorageSaveSuccessful
+    _lastStorageUploadSuccessful
         = storageSaveResult.getResult() == StorageBase::UploadResult::Result::OK ||
         storageSaveResult.getResult() == StorageBase::UploadResult::Result::DOC_CHANGED;
     if (storageSaveResult.getResult() == StorageBase::UploadResult::Result::OK)
@@ -2597,7 +2597,7 @@ void DocumentBroker::dumpState(std::ostream& os)
     os << "\n  last saved: " << Util::getSteadyClockAsString(_lastSaveTime);
     os << "\n  last save request: " << Util::getSteadyClockAsString(_lastSaveRequestTime);
     os << "\n  last save response: " << Util::getSteadyClockAsString(_lastSaveResponseTime);
-    os << "\n  last storage save was successful: " << isLastStorageSaveSuccessful();
+    os << "\n  last storage save was successful: " << isLastStorageUploadSuccessful();
     os << "\n  last modified: " << Util::getHttpTime(_documentLastModifiedTime);
     os << "\n  file last modified: " << Util::getHttpTime(_lastFileModifiedTime);
     if (_limitLifeSeconds > std::chrono::seconds::zero())

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -988,12 +988,13 @@ void DocumentBroker::uploadToStorage(const std::string& sessionId, bool success,
     }
 }
 
-void DocumentBroker::saveAsToStorage(const std::string& sessionId, const std::string& saveAsPath,
-                                     const std::string& saveAsFilename, const bool isRename)
+void DocumentBroker::uploadAsToStorage(const std::string& sessionId,
+                                       const std::string& uploadAsPath,
+                                       const std::string& uploadAsFilename, const bool isRename)
 {
     assertCorrectThread();
 
-    saveToStorageInternal(sessionId, true, "", saveAsPath, saveAsFilename, isRename);
+    saveToStorageInternal(sessionId, true, "", uploadAsPath, uploadAsFilename, isRename);
 }
 
 void DocumentBroker::saveToStorageInternal(const std::string& sessionId, bool success,

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -186,10 +186,10 @@ public:
     void uploadToStorage(const std::string& sesionId, bool success, const std::string& result,
                          bool force);
 
-    /// Save As the document to Storage.
-    /// @param saveAsPath Absolute path to the jailed file.
-    void saveAsToStorage(const std::string& sesionId, const std::string& saveAsPath,
-                         const std::string& saveAsFilename, const bool isRename);
+    /// UploadAs the document to Storage, with a new name.
+    /// @param uploadAsPath Absolute path to the jailed file.
+    void uploadAsToStorage(const std::string& sesionId, const std::string& uploadAsPath,
+                           const std::string& uploadAsFilename, const bool isRename);
 
     bool isModified() const { return _isModified; }
     void setModified(const bool value);

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -181,10 +181,10 @@ public:
 
     bool isLastStorageUploadSuccessful() { return _lastStorageUploadSuccessful; }
 
-    /// Save the document to Storage if it needs persisting.
+    /// Upload the document to Storage if it needs persisting.
     /// Results are logged and broadcast to users.
-    void saveToStorage(const std::string& sesionId, bool success, const std::string& result,
-                       bool force);
+    void uploadToStorage(const std::string& sesionId, bool success, const std::string& result,
+                         bool force);
 
     /// Save As the document to Storage.
     /// @param saveAsPath Absolute path to the jailed file.
@@ -444,7 +444,7 @@ private:
     /// for user's command to act.
     bool _documentChangedInStorage;
 
-    /// Indicates whether the last saveToStorage operation was successful.
+    /// Indicates whether the last uploadToStorage operation was successful.
     bool _lastStorageUploadSuccessful;
 
     /// The last time we tried saving, regardless of whether the

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -179,7 +179,7 @@ public:
 
     bool isDocumentChangedInStorage() { return _documentChangedInStorage; }
 
-    bool isLastStorageSaveSuccessful() { return _lastStorageSaveSuccessful; }
+    bool isLastStorageUploadSuccessful() { return _lastStorageUploadSuccessful; }
 
     /// Save the document to Storage if it needs persisting.
     /// Results are logged and broadcast to users.
@@ -445,7 +445,7 @@ private:
     bool _documentChangedInStorage;
 
     /// Indicates whether the last saveToStorage operation was successful.
-    bool _lastStorageSaveSuccessful;
+    bool _lastStorageUploadSuccessful;
 
     /// The last time we tried saving, regardless of whether the
     /// document was modified and saved or not.

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -103,6 +103,13 @@ class ClientSession;
 
 /// There is one DocumentBroker object in the WSD process for each document that is open (in 1..n sessions).
 
+
+/// To disambiguate between Storage and Core, we
+/// use 'Download' for Reading from the Storage,
+/// and 'Load' for Loading a document in Core.
+/// Similarly, we 'Upload' to Storage after we
+/// 'Save' the document in Core.
+
 class DocumentBroker : public std::enable_shared_from_this<DocumentBroker>
 {
     class DocumentBrokerPoll;

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -354,12 +354,12 @@ private:
     /// with the child and cleans up ChildProcess etc.
     void terminateChild(const std::string& closeReason);
 
-    /// Saves the doc to the storage.
-    void saveToStorageInternal(const std::string& sesionId, bool success,
-                               const std::string& result = std::string(),
-                               const std::string& saveAsPath = std::string(),
-                               const std::string& saveAsFilename = std::string(),
-                               const bool isRename = false, const bool force = false);
+    /// Upload the doc to the storage.
+    void uploadToStorageInternal(const std::string& sesionId, bool success,
+                                 const std::string& result = std::string(),
+                                 const std::string& saveAsPath = std::string(),
+                                 const std::string& saveAsFilename = std::string(),
+                                 const bool isRename = false, const bool force = false);
 
     struct StorageUploadDetails
     {


### PR DESCRIPTION
This is to disambiguate between Saving the document in Core and Uploading to Storage.

- wsd: DocumentBroker documentation
- wsd: lastStorageSaveSuccessful -> lastStorageUploadSuccessful
- wsd: saveToStorage -> uploadToStorage
- wsd: saveAsToStroage -> uploadAsToStorage
- wsd: saveToStorageInternal -> uploadToStorageInternal
