### PR TITLE
overlays on main canvas

### DIFF
--- a/loleaflet/Makefile.am
+++ b/loleaflet/Makefile.am
@@ -33,7 +33,7 @@ SRC_TS_JS = $(patsubst $(srcdir)/src/layer/tile/%.ts,$(srcdir)/src/layer/tile/%.
 $(srcdir)/src/layer/tile/%.js: $(srcdir)/src/layer/tile/%.ts
 	$(builddir)/node_modules/typescript/bin/tsc $< --outfile $@ --module none --lib dom,es2016 --target ES5
 
-$(srcdir)/src/layer/vector/CanvasOverlay.js: $(srcdir)/src/layer/vector/CPoint.ts $(srcdir)/src/layer/vector/CBounds.ts $(srcdir)/src/layer/vector/CPath.ts $(srcdir)/src/layer/vector/CanvasOverlay.ts
+$(srcdir)/src/layer/vector/CanvasOverlay.js: $(srcdir)/src/layer/vector/*.ts 
 	$(builddir)/node_modules/typescript/bin/tsc $(srcdir)/src/layer/vector/CanvasOverlay.ts --outfile $(srcdir)/src/layer/vector/CanvasOverlay.js --module none --lib dom,es2016 --target ES5
 
 JQUERY_LIGHTNESS_IMAGE_PATH = $(srcdir)/images/jquery-ui-lightness

--- a/loleaflet/Makefile.am
+++ b/loleaflet/Makefile.am
@@ -27,10 +27,13 @@ $(L10N_IOS_ALL_JS) : $(wildcard $(srcdir)/po/ui-*.po) $(shell find $(srcdir)/l10
 	done
 endif
 
-SRC_TS = $(wildcard $(srcdir)/src/layer/tile/*.ts)
-SRC_TS_JS = $(patsubst $(srcdir)/src/layer/tile/%.ts,$(srcdir)/src/layer/tile/%.js,$(SRC_TS))
+SRC_TS = $(wildcard $(srcdir)/src/layer/tile/*.ts) $(wildcard $(srcdir)/src/layer/vector/*.ts)
+SRC_TS_JS = $(patsubst $(srcdir)/src/layer/tile/%.ts,$(srcdir)/src/layer/tile/%.js,$(SRC_TS)) $(patsubst $(srcdir)/src/layer/vector/%.ts,$(srcdir)/src/layer/vector/%.js,$(SRC_TS))
 
 $(srcdir)/src/layer/tile/%.js: $(srcdir)/src/layer/tile/%.ts
+	$(builddir)/node_modules/typescript/bin/tsc $< --outfile $@ --module none --lib dom,es2016 --target ES5
+
+$(srcdir)/src/layer/vector/%.js: $(srcdir)/src/layer/vector/%.ts
 	$(builddir)/node_modules/typescript/bin/tsc $< --outfile $@ --module none --lib dom,es2016 --target ES5
 
 JQUERY_LIGHTNESS_IMAGE_PATH = $(srcdir)/images/jquery-ui-lightness
@@ -207,6 +210,7 @@ LOLEAFLET_JS =\
 	src/layer/Layer.js \
 	src/layer/tile/CanvasSectionProps.js \
 	src/layer/tile/CanvasSectionContainer.js \
+	src/layer/vector/CanvasOverlay.js \
 	src/layer/tile/GridLayer.js \
 	src/layer/tile/TileLayer.js \
 	src/layer/tile/CanvasTileLayer.js \

--- a/loleaflet/Makefile.am
+++ b/loleaflet/Makefile.am
@@ -27,13 +27,13 @@ $(L10N_IOS_ALL_JS) : $(wildcard $(srcdir)/po/ui-*.po) $(shell find $(srcdir)/l10
 	done
 endif
 
-SRC_TS = $(wildcard $(srcdir)/src/layer/tile/*.ts) $(wildcard $(srcdir)/src/layer/vector/*.ts)
-SRC_TS_JS = $(patsubst $(srcdir)/src/layer/tile/%.ts,$(srcdir)/src/layer/tile/%.js,$(SRC_TS)) $(patsubst $(srcdir)/src/layer/vector/%.ts,$(srcdir)/src/layer/vector/%.js,$(SRC_TS))
+SRC_TS = $(wildcard $(srcdir)/src/layer/tile/*.ts) $(srcdir)/src/layer/vector/CanvasOverlay.ts
+SRC_TS_JS = $(patsubst $(srcdir)/src/layer/tile/%.ts,$(srcdir)/src/layer/tile/%.js,$(SRC_TS)) $(srcdir)/src/layer/vector/CanvasOverlay.js
 
 $(srcdir)/src/layer/tile/%.js: $(srcdir)/src/layer/tile/%.ts
 	$(builddir)/node_modules/typescript/bin/tsc $< --outfile $@ --module none --lib dom,es2016 --target ES5
 
-$(srcdir)/src/layer/vector/%.js: $(srcdir)/src/layer/vector/%.ts
+$(srcdir)/src/layer/vector/CanvasOverlay.js: $(srcdir)/src/layer/vector/CanvasOverlay.ts
 	$(builddir)/node_modules/typescript/bin/tsc $< --outfile $@ --module none --lib dom,es2016 --target ES5
 
 JQUERY_LIGHTNESS_IMAGE_PATH = $(srcdir)/images/jquery-ui-lightness

--- a/loleaflet/Makefile.am
+++ b/loleaflet/Makefile.am
@@ -33,8 +33,8 @@ SRC_TS_JS = $(patsubst $(srcdir)/src/layer/tile/%.ts,$(srcdir)/src/layer/tile/%.
 $(srcdir)/src/layer/tile/%.js: $(srcdir)/src/layer/tile/%.ts
 	$(builddir)/node_modules/typescript/bin/tsc $< --outfile $@ --module none --lib dom,es2016 --target ES5
 
-$(srcdir)/src/layer/vector/CanvasOverlay.js: $(srcdir)/src/layer/vector/CanvasOverlay.ts
-	$(builddir)/node_modules/typescript/bin/tsc $< --outfile $@ --module none --lib dom,es2016 --target ES5
+$(srcdir)/src/layer/vector/CanvasOverlay.js: $(srcdir)/src/layer/vector/CPoint.ts $(srcdir)/src/layer/vector/CBounds.ts $(srcdir)/src/layer/vector/CPath.ts $(srcdir)/src/layer/vector/CanvasOverlay.ts
+	$(builddir)/node_modules/typescript/bin/tsc $(srcdir)/src/layer/vector/CanvasOverlay.ts --outfile $(srcdir)/src/layer/vector/CanvasOverlay.js --module none --lib dom,es2016 --target ES5
 
 JQUERY_LIGHTNESS_IMAGE_PATH = $(srcdir)/images/jquery-ui-lightness
 JQUERY_LIGHTNESS_IMAGES = $(wildcard $(JQUERY_LIGHTNESS_IMAGE_PATH)/*.png)

--- a/loleaflet/Makefile.am
+++ b/loleaflet/Makefile.am
@@ -29,11 +29,12 @@ endif
 
 SRC_TS = $(wildcard $(srcdir)/src/layer/tile/*.ts) $(srcdir)/src/layer/vector/CanvasOverlay.ts
 SRC_TS_JS = $(patsubst $(srcdir)/src/layer/tile/%.ts,$(srcdir)/src/layer/tile/%.js,$(SRC_TS)) $(srcdir)/src/layer/vector/CanvasOverlay.js
+SRC_TS_JS_DST = $(patsubst $(srcdir)/src/layer/tile/%.js,$(DIST_FOLDER)/src/layer/tile/%.js,$(SRC_TS_JS)) $(DIST_FOLDER)/src/layer/vector/CanvasOverlay.js
 
 $(srcdir)/src/layer/tile/%.js: $(srcdir)/src/layer/tile/%.ts
 	$(builddir)/node_modules/typescript/bin/tsc $< --outfile $@ --module none --lib dom,es2016 --target ES5
 
-$(srcdir)/src/layer/vector/CanvasOverlay.js: $(srcdir)/src/layer/vector/*.ts 
+$(srcdir)/src/layer/vector/CanvasOverlay.js: $(srcdir)/src/layer/vector/*.ts
 	$(builddir)/node_modules/typescript/bin/tsc $(srcdir)/src/layer/vector/CanvasOverlay.ts --outfile $(srcdir)/src/layer/vector/CanvasOverlay.js --module none --lib dom,es2016 --target ES5
 
 JQUERY_LIGHTNESS_IMAGE_PATH = $(srcdir)/images/jquery-ui-lightness
@@ -426,7 +427,7 @@ $(TYPESCRIPT_JS_DIR)/%.js: $(srcdir)/%.ts
 build-loleaflet: \
 	$(LOLEAFLET_L10N_DST) \
 	$(L10N_JSON) \
-	$(SRC_TS_JS) \
+	$(SRC_TS_JS_DST) \
 	$(LOLEAFLET_IMAGES_DST) \
 	$(LOLEAFLET_IMAGES_CUSTOM_DST) \
 	$(JQUERY_LIGHTNESS_DIST_IMAGES) \

--- a/loleaflet/src/layer/tile/CanvasSectionContainer.ts
+++ b/loleaflet/src/layer/tile/CanvasSectionContainer.ts
@@ -197,6 +197,10 @@ class CanvasSectionContainer {
 		this.canvas.ontouchcancel = this.onTouchCancel.bind(this);
 	}
 
+	getContext () {
+		return this.context;
+	}
+
 	setClearColor (color: string) {
 		this.clearColor = color;
 	}

--- a/loleaflet/src/layer/tile/CanvasSectionProps.js
+++ b/loleaflet/src/layer/tile/CanvasSectionProps.js
@@ -12,6 +12,7 @@ L.CSections.Debug = {}; // For keeping things simple.
 
 // First definitions. Other properties will be written according to their orders.
 L.CSections.Tiles = 				{ name: 'tiles'				, zIndex: 5 };
+L.CSections.Overlays =				{ name: 'overlay'			, zIndex: 5 };
 L.CSections.CalcGrid = 				{ name: 'calc grid'			, zIndex: 5 };
 L.CSections.Debug.Splits = 			{ name: 'splits'			, zIndex: 5 };
 L.CSections.Debug.TilePixelGrid = 	{ name: 'tile pixel grid'	, zIndex: 5 };
@@ -38,23 +39,24 @@ L.CSections.CornerHeader.processingOrder =			30; // Calc.
 L.CSections.RowHeader.processingOrder =				40; // Calc.
 L.CSections.ColumnHeader.processingOrder =			50; // Calc.
 L.CSections.Tiles.processingOrder = 				60; // Writer & Impress & Calc.
+L.CSections.Overlays.processingOrder =				60; // Writer & Impress & Calc. This is bound to tiles, processingOrder is not important.
 L.CSections.Debug.TilePixelGrid.processingOrder = 	60; // Writer & Impress & Calc. This is bound to tiles, processingOrder is not important.
 L.CSections.CalcGrid.processingOrder = 				60; // Calc. This is bound to tiles, processingOrder is not important.
 L.CSections.Debug.Splits.processingOrder = 			60; // Calc. This is bound to tiles, processingOrder is not important.
 
 
-L.CSections.CalcGrid.drawingOrder = 				4; // Calc. This is 7 when debugging is enabled.
+L.CSections.CalcGrid.drawingOrder = 				4; // Calc. This is 8 when debugging is enabled.
 L.CSections.Tiles.drawingOrder = 					5; // Writer & Impress & Calc.
 L.CSections.Debug.TilePixelGrid.drawingOrder = 		6; // Writer & Impress & Calc.
-/* drawingOrder = 7 is reserved for debugging mode of CalcGrid */
-L.CSections.Debug.Splits.drawingOrder = 			8; // Calc.
-L.CSections.RowGroup.drawingOrder =					9; // Calc.
-L.CSections.ColumnGroup.drawingOrder =				10; // Calc.
-L.CSections.CornerGroup.drawingOrder =				11; // Calc.
-L.CSections.CornerHeader.drawingOrder =				12; // Calc.
-L.CSections.RowHeader.drawingOrder = 				13; // Calc.
-L.CSections.ColumnHeader.drawingOrder = 			14; // Calc.
-
+L.CSections.Overlays.drawingOrder =					7; // Writer & Impress & Calc.
+/* drawingOrder = 8 is reserved for debugging mode of CalcGrid */
+L.CSections.Debug.Splits.drawingOrder = 			9; // Calc.
+L.CSections.RowGroup.drawingOrder =					10; // Calc.
+L.CSections.ColumnGroup.drawingOrder =				11; // Calc.
+L.CSections.CornerGroup.drawingOrder =				12; // Calc.
+L.CSections.CornerHeader.drawingOrder =				13; // Calc.
+L.CSections.RowHeader.drawingOrder = 				14; // Calc.
+L.CSections.ColumnHeader.drawingOrder = 			15; // Calc.
 
 
 /* zIndex = 6 and goes on. */

--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -866,6 +866,13 @@ L.CanvasTileLayer = L.TileLayer.extend({
 			twips.y / this._tileHeightTwips * this._tileSize);
 	},
 
+	_twipsToCorePixelsBounds: function (twips) {
+		return new L.Bounds(
+			this._twipsToCorePixels(twips.min),
+			this._twipsToCorePixels(twips.max)
+		);
+	},
+
 	_corePixelsToTwips: function (corePixels) {
 		return new L.Point(
 			corePixels.x / this._tileSize * this._tileWidthTwips,

--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -463,6 +463,14 @@ L.TileSectionManager = L.Class.extend({
 		this.onResize();
 	},
 
+	paintOverlayArea: function(coords) {
+		var tileTopLeft = coords.getPos();
+		var tileSize = this._layer._getTileSize();
+		var tileBounds = new L.Bounds(tileTopLeft,
+			tileTopLeft.add(new L.Point(tileSize, tileSize)));
+		this._layer._canvasOverlay.paintRegion(tileBounds);
+	},
+
 	update: function () {
 		this._sectionContainer.requestReDraw();
 	},
@@ -1241,6 +1249,7 @@ L.CanvasTileLayer = L.TileLayer.extend({
 
 		// paint this tile on canvas.
 		this._painter.paint(tile);
+		this._painter.paintOverlayArea(coords);
 
 		if (this._noTilesToLoad()) {
 			this.fire('load');

--- a/loleaflet/src/layer/vector/CBounds.ts
+++ b/loleaflet/src/layer/vector/CBounds.ts
@@ -1,0 +1,214 @@
+/* eslint-disable */
+
+/*
+ * CBounds represents a rectangular area on the screen in pixel coordinates.
+ */
+
+class CBounds {
+	min: CPoint;
+	max: CPoint;
+
+	constructor(a: CPoint, b: CPoint) {
+		this.extend(a).extend(b);
+	}
+
+	static fromPointArray(points: Array<CPoint>): CBounds {
+
+		if (!points.length)
+			return undefined;
+
+		if (points.length == 1)
+			return new CBounds(points[0], points[0]);
+
+		var bounds = new CBounds(points[0], points[1]);
+		for (var i: number = 2; i < points.length; ++i)
+			bounds.extend(points[i]);
+
+		return bounds;
+	}
+
+	static parse(rectString: string): CBounds {
+
+		var rectParts = rectString.match(/\d+/g);
+		if (rectParts === null || rectParts.length < 4) {
+			console.error('incomplete rectangle');
+			return undefined;
+		}
+
+		var refPoint1 = new CPoint(parseInt(rectParts[0]), parseInt(rectParts[1]));
+		var offset = new CPoint(parseInt(rectParts[2]), parseInt(rectParts[3]));
+		var refPoint2 = refPoint1.add(offset);
+
+		return new CBounds(refPoint1, refPoint2);
+	};
+
+	static parseArray(rectListString: string): Array<CBounds> {
+
+		var parts = rectListString.match(/\d+/g);
+		if (parts === null || parts.length < 4) {
+			return new Array<CBounds>();
+		}
+
+		var rectangles = new Array<CBounds>();
+		for (var i = 0; (i + 3) < parts.length; i += 4) {
+			var refPoint1 = new CPoint(parseInt(parts[i]), parseInt(parts[i + 1]));
+			var offset = new CPoint(parseInt(parts[i + 2]), parseInt(parts[i + 3]));
+			var refPoint2 = refPoint1.add(offset);
+			rectangles.push(new CBounds(refPoint1, refPoint2));
+		}
+
+		return rectangles;
+	};
+
+	// extend the bounds to contain the given point
+	extend(point: CPoint): CBounds {
+
+		if (!this.min && !this.max) {
+			this.min = point.clone();
+			this.max = point.clone();
+		} else {
+			this.min.x = Math.min(point.x, this.min.x);
+			this.max.x = Math.max(point.x, this.max.x);
+			this.min.y = Math.min(point.y, this.min.y);
+			this.max.y = Math.max(point.y, this.max.y);
+		}
+		return this;
+	}
+
+	clone(): CBounds {
+		return new CBounds(this.min, this.max);
+	}
+
+	getCenter(round: boolean = false): CPoint {
+		return new CPoint(
+		        (this.min.x + this.max.x) / 2,
+		        (this.min.y + this.max.y) / 2, round);
+	}
+
+	round() {
+		this.min.x = Math.round(this.min.x);
+		this.min.y = Math.round(this.min.y);
+		this.max.x = Math.round(this.max.x);
+		this.max.y = Math.round(this.max.y);
+	}
+
+	getBottomLeft(): CPoint {
+		return new CPoint(this.min.x, this.max.y);
+	}
+
+	getTopRight(): CPoint {
+		return new CPoint(this.max.x, this.min.y);
+	}
+
+	getTopLeft(): CPoint {
+		return new CPoint(this.min.x, this.min.y);
+	}
+
+	getBottomRight(): CPoint {
+		return new CPoint(this.max.x, this.max.y);
+	}
+
+	getSize(): CPoint {
+		return this.max.subtract(this.min);
+	}
+
+	contains(obj: CBounds | CPoint): boolean {
+		var min: CPoint, max: CPoint;
+
+		if (obj instanceof CBounds) {
+			min = obj.min;
+			max = obj.max;
+		} else {
+			min = max = obj;
+		}
+
+		return (min.x >= this.min.x) &&
+		       (max.x <= this.max.x) &&
+		       (min.y >= this.min.y) &&
+		       (max.y <= this.max.y);
+	}
+
+	intersects(bounds: CBounds): boolean { // (Bounds) -> Boolean
+
+		var min = this.min,
+		    max = this.max,
+		    min2 = bounds.min,
+		    max2 = bounds.max,
+		    xIntersects = (max2.x >= min.x) && (min2.x <= max.x),
+		    yIntersects = (max2.y >= min.y) && (min2.y <= max.y);
+
+		return xIntersects && yIntersects;
+	}
+
+	// non-destructive, returns a new Bounds
+	add(point: CPoint): CBounds {
+		return this.clone()._add(point);
+	}
+
+	// destructive, used directly for performance in situations where it's safe to modify existing Bounds
+	_add(point: CPoint): CBounds {
+		this.min._add(point);
+		this.max._add(point);
+		return this;
+	}
+
+	getPointArray(): Array<CPoint> {
+		return Array<CPoint>(
+			this.getBottomLeft(), this.getBottomRight(),
+			this.getTopLeft(), this.getTopRight()
+		);
+	}
+
+	toString(): string {
+		return '[' +
+		        this.min.toString() + ', ' +
+		        this.max.toString() + ']';
+	}
+
+	isValid(): boolean {
+		return !!(this.min && this.max);
+	}
+
+	intersectsAny(boundsArray: Array<CBounds>): boolean {
+		for (var i = 0; i < boundsArray.length; ++i) {
+			if (boundsArray[i].intersects(this)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	clampX(x: number): number {
+		return Math.max(this.min.x, Math.min(this.max.x, x));
+	}
+
+	clampY(y: number): number {
+		return Math.max(this.min.y, Math.min(this.max.y, y));
+	}
+
+	clampPoint(obj: CPoint): CPoint {
+		return new CPoint(
+			this.clampX(obj.x),
+			this.clampY(obj.y)
+		);
+	}
+
+	clampBounds(obj: CBounds): CBounds {
+		return new CBounds(
+			new CPoint(
+				this.clampX(obj.min.x),
+				this.clampY(obj.min.y)
+			),
+
+			new CPoint(
+				this.clampX(obj.max.x),
+				this.clampY(obj.max.y)
+			)
+		);
+	}
+
+	equals(bounds: CBounds): boolean {
+		return this.min.equals(bounds.min) && this.max.equals(bounds.max);
+	}
+};

--- a/loleaflet/src/layer/vector/CBounds.ts
+++ b/loleaflet/src/layer/vector/CBounds.ts
@@ -8,8 +8,11 @@ class CBounds {
 	min: CPoint;
 	max: CPoint;
 
-	constructor(a: CPoint, b: CPoint) {
-		this.extend(a).extend(b);
+	constructor(a?: CPoint, b?: CPoint) {
+		if (a !== undefined)
+			this.extend(a);
+		if (b !== undefined)
+			this.extend(b);
 	}
 
 	static fromPointArray(points: Array<CPoint>): CBounds {

--- a/loleaflet/src/layer/vector/CLineUtil.ts
+++ b/loleaflet/src/layer/vector/CLineUtil.ts
@@ -1,0 +1,215 @@
+/* -*- js-indent-level: 8 -*- */
+/*
+ * CLineUtil contains different utility functions for line segments
+ * and polylines (clipping, simplification, distances, etc.)
+ */
+
+namespace CLineUtil {
+
+    var _lastCode: number = 0;
+
+	// Simplify polyline with vertex reduction and Douglas-Peucker simplification.
+	// Improves rendering performance dramatically by lessening the number of points to draw.
+
+	export function simplify(points: Array<CPoint>, tolerance: number): Array<CPoint> {
+		if (!tolerance || !points.length) {
+			return points.slice();
+		}
+
+		var sqTolerance = tolerance * tolerance;
+
+		// stage 1: vertex reduction
+		points = _reducePoints(points, sqTolerance);
+
+		// stage 2: Douglas-Peucker simplification
+		points = _simplifyDP(points, sqTolerance);
+
+		return points;
+	}
+
+	// distance from a point to a segment between two points
+	function pointToSegmentDistance(p: CPoint, p1: CPoint, p2: CPoint) {
+		return Math.sqrt(_sqDistToClosestPointOnSegment(p, p1, p2));
+	}
+
+	// Douglas-Peucker simplification, see http://en.wikipedia.org/wiki/Douglas-Peucker_algorithm
+	function _simplifyDP(points: Array<CPoint>, sqTolerance: number): Array<CPoint> {
+
+		var len = points.length;
+		var markers = typeof Uint8Array !== undefined + '' ? new Uint8Array(len) : Array<boolean>(len);
+
+		markers[0] = markers[len - 1] = true;
+
+		_simplifyDPStep(points, markers, sqTolerance, 0, len - 1);
+
+		var i: number;
+		var newPoints = Array<CPoint>();
+
+		for (i = 0; i < len; i++) {
+			if (markers[i]) {
+				newPoints.push(points[i]);
+			}
+		}
+
+		return newPoints;
+	}
+
+	function _simplifyDPStep(points: Array<CPoint>, markers: Uint8Array | Array<boolean>, sqTolerance: number, first: number, last: number) {
+
+		var maxSqDist = 0;
+        var index: number;
+        var i: number;
+        var sqDist: number;
+
+		for (i = first + 1; i <= last - 1; i++) {
+			sqDist = _sqDistToClosestPointOnSegment(points[i], points[first], points[last]);
+
+			if (sqDist > maxSqDist) {
+				index = i;
+				maxSqDist = sqDist;
+			}
+		}
+
+		if (maxSqDist > sqTolerance) {
+			markers[index] = true;
+
+			_simplifyDPStep(points, markers, sqTolerance, first, index);
+			_simplifyDPStep(points, markers, sqTolerance, index, last);
+		}
+	}
+
+	// reduce points that are too close to each other to a single point
+	function _reducePoints(points: Array<CPoint>, sqTolerance: number): Array<CPoint> {
+		var reducedPoints = [points[0]];
+
+		for (var i = 1, prev = 0, len = points.length; i < len; i++) {
+			if (_sqDist(points[i], points[prev]) > sqTolerance) {
+				reducedPoints.push(points[i]);
+				prev = i;
+			}
+		}
+		if (prev < len - 1) {
+			reducedPoints.push(points[len - 1]);
+		}
+		return reducedPoints;
+	}
+
+	// Cohen-Sutherland line clipping algorithm.
+	// Used to avoid rendering parts of a polyline that are not currently visible.
+
+	export function clipSegment(a: CPoint, b: CPoint, bounds: CBounds, useLastCode: boolean, round: boolean): Array<CPoint> {
+		var codeA = useLastCode ? _lastCode : _getBitCode(a, bounds);
+		var codeB = _getBitCode(b, bounds);
+        var codeOut: number;
+        var p: CPoint
+        var newCode: number;
+
+		// save 2nd code to avoid calculating it on the next segment
+		_lastCode = codeB;
+
+		while (true) {
+			// if a,b is inside the clip window (trivial accept)
+			if (!(codeA | codeB)) {
+				return [a, b];
+			// if a,b is outside the clip window (trivial reject)
+			} else if (codeA & codeB) {
+				return [];
+			// other cases
+			} else {
+				codeOut = codeA || codeB;
+				p = _getEdgeIntersection(a, b, codeOut, bounds, round);
+				newCode = _getBitCode(p, bounds);
+
+				if (codeOut === codeA) {
+					a = p;
+					codeA = newCode;
+				} else {
+					b = p;
+					codeB = newCode;
+				}
+			}
+		}
+	}
+
+	function _getEdgeIntersection(a: CPoint, b: CPoint, code: number, bounds: CBounds, round: boolean): CPoint {
+		var dx = b.x - a.x;
+        var dy = b.y - a.y;
+		var min = bounds.min;
+		var max = bounds.max;
+        var x: number;
+        var y: number;
+
+		if (code & 8) { // top
+			x = a.x + dx * (max.y - a.y) / dy;
+			y = max.y;
+
+		} else if (code & 4) { // bottom
+			x = a.x + dx * (min.y - a.y) / dy;
+			y = min.y;
+
+		} else if (code & 2) { // right
+			x = max.x;
+			y = a.y + dy * (max.x - a.x) / dx;
+
+		} else if (code & 1) { // left
+			x = min.x;
+			y = a.y + dy * (min.x - a.x) / dx;
+		}
+
+		return new CPoint(x, y, round);
+	}
+
+	function _getBitCode(p: CPoint, bounds: CBounds): number {
+		var code = 0;
+
+		if (p.x < bounds.min.x) { // left
+			code |= 1;
+		} else if (p.x > bounds.max.x) { // right
+			code |= 2;
+		}
+
+		if (p.y < bounds.min.y) { // bottom
+			code |= 4;
+		} else if (p.y > bounds.max.y) { // top
+			code |= 8;
+		}
+
+		return code;
+	}
+
+	// square distance (to avoid unnecessary Math.sqrt calls)
+	function _sqDist(p1: CPoint, p2: CPoint): number {
+		var dx = p2.x - p1.x,
+		    dy = p2.y - p1.y;
+		return dx * dx + dy * dy;
+	}
+
+	// return closest point on segment or distance to that point
+	function _sqClosestPointOnSegment(p: CPoint, p1: CPoint, p2: CPoint): CPoint {
+		var x = p1.x;
+		var y = p1.y;
+		var dx = p2.x - x;
+		var dy = p2.y - y;
+		var dot = dx * dx + dy * dy;
+		var t: number;
+
+		if (dot > 0) {
+			t = ((p.x - x) * dx + (p.y - y) * dy) / dot;
+
+			if (t > 1) {
+				x = p2.x;
+				y = p2.y;
+			} else if (t > 0) {
+				x += dx * t;
+				y += dy * t;
+			}
+		}
+
+		return new CPoint(x, y);
+    }
+
+    // returns distance to closest point on segment.
+	function _sqDistToClosestPointOnSegment(p: CPoint, p1: CPoint, p2: CPoint): number {
+        return _sqDist(_sqClosestPointOnSegment(p, p1, p2), p);
+	}
+}

--- a/loleaflet/src/layer/vector/CPath.ts
+++ b/loleaflet/src/layer/vector/CPath.ts
@@ -21,7 +21,7 @@ class CPath {
 
 	radius: number = 0;
 	radiusY: number = 0;
-	point: Array<number>;
+	point: CPoint;
 	zIndex: number = 0;
 
 	static countObjects: number = 0;
@@ -108,9 +108,9 @@ class CPath {
 		return false;
 	}
 
-	getParts(): Array<Array<Array<number>>> {
+	getParts(): Array<Array<CPoint>> {
 		// Overridden in implementations.
-		return Array<Array<Array<number>>>();
+		return Array<Array<CPoint>>();
 	}
 
 	clickTolerance(): number {

--- a/loleaflet/src/layer/vector/CPath.ts
+++ b/loleaflet/src/layer/vector/CPath.ts
@@ -82,7 +82,33 @@ abstract class CPath {
 		}
 	}
 
-	updatePath(paintArea?: CBounds) {
+	updatePathAllPanes(paintArea?: CBounds) {
+		var viewBounds = this.renderer.getBounds().clone();
+
+		var splitPanesContext = this.renderer.getSplitPanesContext();
+		var paneBoundsList: Array<CBounds> = splitPanesContext ?
+		    splitPanesContext.getPxBoundList() :
+			[viewBounds];
+		var paneProperties = splitPanesContext ? splitPanesContext.getPanesProperties() :
+			[{ xFixed : false, yFixed: false }];
+
+		for (var i = 0; i < paneBoundsList.length; ++i) {
+			var panePaintArea = paintArea ? paintArea.clone() : paneBoundsList[i].clone();
+			if (paintArea) {
+				var paneArea = paneBoundsList[i];
+
+				panePaintArea.min.x = Math.max(panePaintArea.min.x, paneArea.min.x);
+				panePaintArea.min.y = Math.max(panePaintArea.min.y, paneArea.min.y);
+
+				panePaintArea.max.x = Math.min(panePaintArea.max.x, paneArea.max.x);
+				panePaintArea.max.y = Math.min(panePaintArea.max.y, paneArea.max.y);
+			}
+
+			this.updatePath(panePaintArea, paneProperties[i].xFixed, paneProperties[i].yFixed);
+		}
+	}
+
+	updatePath(paintArea?: CBounds, paneXFixed?: boolean, paneYFixed?: boolean) {
 		// Overridden in implementations.
 	}
 

--- a/loleaflet/src/layer/vector/CPath.ts
+++ b/loleaflet/src/layer/vector/CPath.ts
@@ -97,6 +97,9 @@ abstract class CPath {
 			if (paintArea) {
 				var paneArea = paneBoundsList[i];
 
+				if (!paneArea.intersects(panePaintArea))
+					continue;
+
 				panePaintArea.min.x = Math.max(panePaintArea.min.x, paneArea.min.x);
 				panePaintArea.min.y = Math.max(panePaintArea.min.y, paneArea.min.y);
 

--- a/loleaflet/src/layer/vector/CPath.ts
+++ b/loleaflet/src/layer/vector/CPath.ts
@@ -4,7 +4,7 @@
  * CPath is the base class for all vector paths like polygons and circles.
  */
 
-class CPath {
+abstract class CPath {
 	stroke: boolean = true;
 	color: string = '#3388ff';
 	weight: number = 3;
@@ -28,7 +28,7 @@ class CPath {
 	static isTouchDevice: boolean = false; // Need to set this from current L.Browser.touch
 	private id: number;
 	private isDeleted: boolean = false;
-	private renderer: CanvasOverlay = null;
+	protected renderer: CanvasOverlay = null;
 
 	constructor(options: any) {
 		this.setStyleOptions(options);

--- a/loleaflet/src/layer/vector/CPath.ts
+++ b/loleaflet/src/layer/vector/CPath.ts
@@ -98,9 +98,9 @@ class CPath {
 		}
 	}
 
-	getBounds(): Array<number> {
+	getBounds(): CBounds {
 		// Overridden in implementations.
-		return Array<number>();
+		return undefined;
 	}
 
 	empty(): boolean {

--- a/loleaflet/src/layer/vector/CPath.ts
+++ b/loleaflet/src/layer/vector/CPath.ts
@@ -105,7 +105,7 @@ abstract class CPath {
 
 	empty(): boolean {
 		// Overridden in implementations.
-		return false;
+		return true;
 	}
 
 	getParts(): Array<Array<CPoint>> {

--- a/loleaflet/src/layer/vector/CPath.ts
+++ b/loleaflet/src/layer/vector/CPath.ts
@@ -82,7 +82,7 @@ abstract class CPath {
 		}
 	}
 
-	updatePath() {
+	updatePath(paintArea?: CBounds) {
 		// Overridden in implementations.
 	}
 

--- a/loleaflet/src/layer/vector/CPath.ts
+++ b/loleaflet/src/layer/vector/CPath.ts
@@ -1,0 +1,126 @@
+/* eslint-disable */
+
+/*
+ * CPath is the base class for all vector paths like polygons and circles.
+ */
+
+class CPath {
+	stroke: boolean = true;
+	color: string = '#3388ff';
+	weight: number = 3;
+	opacity: number = 1;
+	lineCap: CanvasLineCap = 'round';
+	lineJoin: CanvasLineJoin = 'round';
+	fill: boolean = false;
+	fillColor: string = this.color;
+	fillOpacity: number = 0.2;
+	fillRule: CanvasFillRule = 'evenodd';
+	interactive: boolean = true;
+	fixed: boolean = false;
+	cursorType: string;
+
+	radius: number = 0;
+	radiusY: number = 0;
+	point: Array<number>;
+	zIndex: number = 0;
+
+	static countObjects: number = 0;
+	static isTouchDevice: boolean = false; // Need to set this from current L.Browser.touch
+	private id: number;
+	private isDeleted: boolean = false;
+	private renderer: CanvasOverlay = null;
+
+	constructor(options: any) {
+		this.setStyleOptions(options);
+
+		this.radius = options.radius !== undefined ? options.radius : this.radius;
+		this.radiusY = options.radiusY !== undefined ? options.radiusY : this.radiusY;
+		this.point = options.point !== undefined ? options.point : this.point;
+
+		CPath.countObjects += 1;
+		this.id = CPath.countObjects;
+		this.zIndex = this.id;
+	}
+
+	setStyleOptions(options: any) {
+		this.stroke = options.stroke !== undefined ? options.stroke : this.stroke;
+		this.color = options.color !== undefined ? options.color : this.color;
+		this.weight = options.weight !== undefined ? options.weight : this.weight;
+		this.opacity = options.opacity !== undefined ? options.opacity : this.opacity;
+		this.lineCap = options.lineCap !== undefined ? options.lineCap : this.lineCap;
+		this.lineJoin = options.lineJoin !== undefined ? options.lineJoin : this.lineJoin;
+		this.fill = options.fill !== undefined ? options.fill : this.fill;
+		this.fillColor = options.fillColor !== undefined ? options.fillColor : this.fillColor;
+		this.fillOpacity = options.fillOpacity !== undefined ? options.fillOpacity : this.fillOpacity;
+		this.fillRule = options.fillRule !== undefined ? options.fillRule : this.fillRule;
+		this.cursorType = options.cursorType !== undefined ? options.cursorType : this.cursorType;
+		this.interactive = options.interactive !== undefined ? options.interactive : this.interactive;
+		this.fixed = options.fixed !== undefined ? options.fixed : this.fixed;
+	}
+
+	setRenderer(rendererObj: CanvasOverlay) {
+		this.renderer = rendererObj;
+	}
+
+	getId(): number {
+		return this.id;
+	}
+
+	setDeleted() {
+		this.isDeleted = true;
+	}
+
+	redraw() {
+		if (this.renderer)
+			this.renderer.updatePath(this);
+	}
+
+	setStyle(style: any) {
+		this.setStyleOptions(style);
+		if (this.renderer) {
+			this.renderer.updateStyle(this);
+		}
+	}
+
+	updatePath() {
+		// Overridden in implementations.
+	}
+
+	bringToFront() {
+		if (this.renderer) {
+			this.renderer.bringToFront(this);
+		}
+	}
+
+	bringToBack() {
+		if (this.renderer) {
+			this.renderer.bringToBack(this);
+		}
+	}
+
+	getBounds(): Array<number> {
+		// Overridden in implementations.
+		return Array<number>();
+	}
+
+	empty(): boolean {
+		// Overridden in implementations.
+		return false;
+	}
+
+	getParts(): Array<Array<Array<number>>> {
+		// Overridden in implementations.
+		return Array<Array<Array<number>>>();
+	}
+
+	clickTolerance(): number {
+		// used when doing hit detection for Canvas layers
+		return (this.stroke ? this.weight / 2 : 0) + (CPath.isTouchDevice ? 10 : 0);
+	}
+
+	setCursorType(cursorType: string) {
+		// TODO: Implement this using move-move + hover handler.
+		this.cursorType = cursorType;
+	}
+
+};

--- a/loleaflet/src/layer/vector/CPoint.ts
+++ b/loleaflet/src/layer/vector/CPoint.ts
@@ -1,0 +1,155 @@
+/* eslint-disable */
+
+/*
+ * CPoint represents a point with x and y coordinates.
+ */
+
+class CPoint {
+    x: number;
+    y: number;
+
+    constructor(x: number, y: number, round: boolean = false) {
+        this.x = (round ? Math.round(x) : x);
+	    this.y = (round ? Math.round(y) : y);
+    }
+
+    static arrayToPoint(arr: Array<number>) : CPoint {
+        return new CPoint(arr[0], arr[1]);
+    }
+
+    static parse(pointString: string): CPoint {
+
+        var pointParts = pointString.match(/\d+/g);
+        if (pointParts === null || pointParts.length < 2) {
+            console.error('incomplete point');
+            return undefined;
+        }
+
+        return new CPoint(parseInt(pointParts[0]), parseInt(pointParts[1]));
+    };
+
+    clone(): CPoint {
+        return new CPoint(this.x, this.y);
+    }
+
+    // non-destructive, returns a new point
+	add(point: CPoint): CPoint {
+		return this.clone()._add(point);
+	}
+
+	// destructive, used directly for performance in situations where it's safe to modify existing point
+	_add(point: CPoint): CPoint {
+		this.x += point.x;
+		this.y += point.y;
+		return this;
+	}
+
+	subtract(point: CPoint): CPoint {
+		return this.clone()._subtract(point);
+	}
+
+	_subtract(point: CPoint): CPoint {
+		this.x -= point.x;
+		this.y -= point.y;
+		return this;
+	}
+
+	divideBy(num: number): CPoint {
+		return this.clone()._divideBy(num);
+	}
+
+	_divideBy(num: number): CPoint {
+		this.x /= num;
+		this.y /= num;
+		return this;
+	}
+
+	multiplyBy(num: number): CPoint {
+		return this.clone()._multiplyBy(num);
+	}
+
+	_multiplyBy(num: number): CPoint {
+		this.x *= num;
+		this.y *= num;
+		return this;
+	}
+
+	round(): CPoint {
+		return this.clone()._round();
+	}
+
+	_round(): CPoint {
+		this.x = Math.round(this.x);
+		this.y = Math.round(this.y);
+		return this;
+    }
+
+	floor(): CPoint {
+		return this.clone()._floor();
+	}
+
+	_floor(): CPoint {
+		this.x = Math.floor(this.x);
+		this.y = Math.floor(this.y);
+		return this;
+	}
+
+	ceil(): CPoint {
+		return this.clone()._ceil();
+	}
+
+	_ceil(): CPoint {
+		this.x = Math.ceil(this.x);
+		this.y = Math.ceil(this.y);
+		return this;
+	}
+
+	distanceTo(point: CPoint): number {
+
+		var x = point.x - this.x,
+		    y = point.y - this.y;
+
+		return Math.sqrt(x * x + y * y);
+	}
+
+	equals(point: CPoint): boolean {
+
+		// Proper ieee 754 equality comparison.
+		return Math.abs(point.x - this.x) < Number.EPSILON &&
+			   Math.abs(point.y - this.y) < Number.EPSILON;
+    }
+
+	contains(point: CPoint): boolean {
+
+		return Math.abs(point.x) <= Math.abs(this.x) &&
+		       Math.abs(point.y) <= Math.abs(this.y);
+	}
+
+	assign(point: CPoint): boolean {
+		var xChanged = this.setX(point.x);
+		var yChanged = this.setY(point.y);
+		return xChanged || yChanged;
+    }
+
+	setX(x: number): boolean {
+		if (x === this.x) {
+			return false;
+		}
+
+		this.x = x;
+		return true;
+	}
+
+	setY(y: number): boolean {
+		if (y === this.y) {
+			return false;
+		}
+
+		this.y = y;
+		return true;
+	}
+
+	toString(): string {
+		return 'CPoint(' + this.x + ', ' + this.y + ')';
+	}
+};

--- a/loleaflet/src/layer/vector/CPolyUtil.ts
+++ b/loleaflet/src/layer/vector/CPolyUtil.ts
@@ -1,0 +1,138 @@
+/* eslint-disable */
+
+/*
+ * CPolyUtil contains utility functions for polygons.
+ */
+
+namespace CPolyUtil {
+
+	function rectanglesToPolygons(rectangles: Array<Array<CPoint>>, unitConverter: (point: CPoint) => CPoint): CPointSet {
+		/* An Implementation based on O'ROURKE, Joseph. "Uniqueness of orthogonal connect-the-dots."
+		   Machine Intelligence and Pattern Recognition. Vol. 6. North-Holland, 1988. 97-104.
+		   http://www.science.smith.edu/~jorourke/Papers/OrthoConnect.pdf
+		*/
+		var eps = 20;
+		// Glue rectangles if the space between them is less then eps
+		for (var i = 0; i < rectangles.length - 1; i++) {
+			for (var j = i + 1; j < rectangles.length; j++) {
+				for (var k = 0; k < rectangles[i].length; k++) {
+					for (var l = 0; l < rectangles[j].length; l++) {
+						if (Math.abs(rectangles[i][k].x - rectangles[j][l].x) < eps) {
+							rectangles[j][l].x = rectangles[i][k].x;
+						}
+						if (Math.abs(rectangles[i][k].y - rectangles[j][l].y) < eps) {
+							rectangles[j][l].y = rectangles[i][k].y;
+						}
+					}
+				}
+			}
+		}
+
+		var points = new Map<CPoint, CPoint>();
+		for (i = 0; i < rectangles.length; i++) {
+			for (j = 0; j < rectangles[i].length; j++) {
+				if (points.has(rectangles[i][j])) {
+					points.delete(rectangles[i][j]);
+				}
+				else {
+					points.set(rectangles[i][j], rectangles[i][j]);
+				}
+			}
+		}
+
+		function getKeys(points: Map<CPoint, CPoint>): Array<CPoint> {
+			var keys: Array<CPoint> = [];
+			points.forEach((_: CPoint, key: CPoint) => {
+				keys.push(key);
+			});
+			return keys;
+		}
+
+		function xThenY(ap: CPoint, bp: CPoint): number {
+			if (ap.x < bp.x || (ap.x === bp.x && ap.y < bp.y)) {
+				return -1;
+			}
+			else if (ap.x === bp.x && ap.y === bp.y) {
+				return 0;
+			}
+			else {
+				return 1;
+			}
+		}
+
+		function yThenX(ap: CPoint, bp: CPoint): number {
+
+			if (ap.y < bp.y || (ap.y === bp.y && ap.x < bp.x)) {
+				return -1;
+			}
+			else if (ap.x === bp.x && ap.y === bp.y) {
+				return 0;
+			}
+			else {
+				return 1;
+			}
+		}
+
+		var sortX = getKeys(points).sort(xThenY);
+		var sortY = getKeys(points).sort(yThenX);
+
+		var edgesH = new Map<CPoint, CPoint>();
+		var edgesV = new Map<CPoint, CPoint>();
+
+		var len = getKeys(points).length;
+		i = 0;
+		while (i < len) {
+			var currY = points.get(sortY[i]).y;
+			while (i < len && points.get(sortY[i]).y === currY) {
+				edgesH.set(sortY[i], sortY[i + 1]);
+				edgesH.set(sortY[i + 1], sortY[i]);
+				i += 2;
+			}
+		}
+
+		i = 0;
+		while (i < len) {
+			var currX = points.get(sortX[i]).x;
+			while (i < len && points.get(sortX[i]).x === currX) {
+				edgesV.set(sortX[i], sortX[i + 1]);
+				edgesV.set(sortX[i + 1], sortX[i]);
+				i += 2;
+			}
+		}
+
+		var polygons = new Array<CPointSet>();
+		var edgesHKeys = getKeys(edgesH);
+
+		while (edgesHKeys.length > 0) {
+			var p: Array<[CPoint, number]> = [[edgesHKeys[0], 0]];
+			while (true) {
+				var curr = p[p.length - 1][0];
+				var e = p[p.length - 1][1];
+				if (e === 0) {
+					var nextVertex = edgesV.get(curr);
+					edgesV.delete(curr);
+					p.push([nextVertex, 1]);
+				}
+				else {
+					var nextVertex = edgesH.get(curr);
+					edgesH.delete(curr);
+					p.push([nextVertex, 0]);
+				}
+				if (p[p.length - 1][0].equals(p[0][0]) && p[p.length - 1][1] === p[0][1]) {
+					p.pop();
+					break;
+				}
+			}
+			var polygon = new Array<CPoint>();
+			for (i = 0; i < p.length; i++) {
+				polygon.push(unitConverter(points.get(p[i][0])));
+				edgesH.delete(p[i][0]);
+				edgesV.delete(p[i][0]);
+			}
+			polygon.push(unitConverter(points.get(p[0][0])));
+			edgesHKeys = getKeys(edgesH);
+			polygons.push(CPointSet.fromPointArray(polygon));
+		}
+		return CPointSet.fromSetArray(polygons);
+	}
+}

--- a/loleaflet/src/layer/vector/CPolygon.ts
+++ b/loleaflet/src/layer/vector/CPolygon.ts
@@ -1,0 +1,62 @@
+/* eslint-disable */
+/// <reference path="CPolyUtil.ts" />
+
+/*
+ * CPolygon implements polygon vector layer (closed polyline with a fill inside).
+ */
+
+class CPolygon extends CPolyline {
+
+	constructor(pointSet: CPointSet, options: any) {
+		super(pointSet, options);
+		if (options.fill === undefined)
+			this.fill = true;
+	}
+
+	getCenter(): CPoint {
+		var i: number;
+		var j: number;
+		var len: number;
+		var p1: CPoint;
+		var p2: CPoint;
+		var f: number;
+		var area: number;
+		var x: number;
+		var y: number;
+		var points = this.rings[0];
+
+		// polygon centroid algorithm; only uses the first ring if there are multiple
+
+		area = x = y = 0;
+
+		for (i = 0, len = points.length, j = len - 1; i < len; j = i++) {
+			p1 = points[i];
+			p2 = points[j];
+
+			f = p1.y * p2.x - p2.y * p1.x;
+			x += (p1.x + p2.x) * f;
+			y += (p1.y + p2.y) * f;
+			area += f * 3;
+		}
+
+		return new CPoint(x / area, y / area);
+	}
+
+	updatePath(paintArea?: CBounds, paneXFixed?: boolean, paneYFixed?: boolean) {
+
+		this.parts = this.rings;
+
+		// remove last point in the rings/parts if it equals first one
+		for (var i = 0, len = this.rings.length; i < len; i++) {
+			var ring = this.rings[i];
+			var ringlen = ring.length;
+			if (ring.length >= 2 && ring[0].equals(ring[ringlen - 1])) {
+				ring.pop();
+			}
+		}
+
+		this.simplifyPoints();
+		this.renderer.updatePoly(this, true /* closed? */, paneXFixed, paneYFixed);
+	}
+
+};

--- a/loleaflet/src/layer/vector/CPolygon.ts
+++ b/loleaflet/src/layer/vector/CPolygon.ts
@@ -56,7 +56,6 @@ class CPolygon extends CPolyline {
 		}
 
 		this.simplifyPoints();
-		this.renderer.updatePoly(this, true /* closed? */, paneXFixed, paneYFixed);
+		this.renderer.updatePoly(this, true /* closed? */, paneXFixed, paneYFixed, paintArea);
 	}
-
 };

--- a/loleaflet/src/layer/vector/CPolyline.ts
+++ b/loleaflet/src/layer/vector/CPolyline.ts
@@ -164,7 +164,7 @@ class CPolyline extends CPath {
 		this.clipPoints(paintArea);
 		this.simplifyPoints();
 
-		this.renderer.updatePoly(this, false /* closed? */, paneXFixed, paneYFixed);
+		this.renderer.updatePoly(this, false /* closed? */, paneXFixed, paneYFixed, paintArea);
 	}
 
 	// clip polyline by renderer bounds so that we have less to render for performance

--- a/loleaflet/src/layer/vector/CPolyline.ts
+++ b/loleaflet/src/layer/vector/CPolyline.ts
@@ -1,0 +1,240 @@
+/* eslint-disable */
+/// <reference path="CLineUtil.ts" />
+
+/*
+ * CPolyline implements polyline vector layer (a set of points connected with lines)
+ */
+
+class CPointSet {
+	private points: Array<CPoint>;
+	private pointSets: Array<CPointSet>;
+
+	static fromPointArray(array: Array<CPoint>) {
+		var ps = new CPointSet();
+		ps.points = array;
+		return ps;
+	}
+
+	static fromSetArray(array: Array<CPointSet>) {
+		var ps = new CPointSet();
+		ps.pointSets = array;
+		return ps;
+	}
+
+	isFlat(): boolean {
+		return this.points !== undefined;
+	}
+
+	getPointArray(): Array<CPoint> {
+		return this.points;
+	}
+
+	getSetArray(): Array<CPointSet> {
+		return this.pointSets;
+	}
+
+	setPointArray(array: Array<CPoint>) {
+		this.points = array;
+		this.pointSets = undefined;
+	}
+
+	setSetArray(array: Array<CPointSet>) {
+		this.points = undefined;
+		this.pointSets = array;
+	}
+};
+
+class CPolyline extends CPath {
+
+	// how much to simplify the polyline on each zoom level
+	// more = better performance and smoother look, less = more accurate
+	private smoothFactor: number = 1.0;
+	private noClip: boolean = false;
+	private pointSet: CPointSet;
+	private bounds: CBounds;
+	private rings: Array<Array<CPoint>>;
+	private parts: Array<Array<CPoint>>;
+
+	constructor(pointSet: CPointSet, options: any) {
+		super(options);
+		this.smoothFactor = options.smoothFactor !== undefined ? options.smoothFactor : this.smoothFactor;
+		this.pointSet = pointSet;
+		this.updateBounds();
+	}
+
+	getPointSet(): CPointSet {
+		return this.pointSet;
+	}
+
+	setPointSet(pointSet: CPointSet) {
+		this.pointSet = pointSet;
+		this.updateBounds();
+		return this.redraw();
+	}
+
+	updateBounds() {
+		var bounds = this.bounds = new CBounds();
+		CPolyline.traverse(this.pointSet, (pt: CPoint) => {
+			bounds.extend(pt);
+		});
+	}
+
+	private static traverse(pset: CPointSet, pointCallback: (pt: CPoint) => void) {
+		if (pset.isFlat()) {
+			var points = pset.getPointArray();
+			points.forEach(pointCallback);
+			return;
+		}
+
+		var psetArray = pset.getSetArray();
+		if (psetArray) {
+			psetArray.forEach((psetNew: CPointSet) => {
+				CPolyline.traverse(psetNew, pointCallback);
+			});
+		}
+	}
+
+	private static getPoints(pset: CPointSet): Array<CPoint> {
+		if (pset.isFlat()) {
+			return pset.getPointArray();
+		}
+
+		var psetArray = pset.getSetArray();
+		if (psetArray && psetArray.length) {
+			return CPolyline.getPoints(psetArray[0]);
+		}
+
+		return [];
+	}
+
+	getCenter(): CPoint {
+		var i: number;
+		var halfDist: number;
+		var segDist: number;
+		var dist: number;
+		var p1: CPoint;
+		var p2: CPoint;
+		var ratio: number;
+		var points = CPolyline.getPoints(this.pointSet);
+		var len = points.length;
+
+		// polyline centroid algorithm; only uses the first ring if there are multiple
+
+		for (i = 0, halfDist = 0; i < len - 1; i++) {
+			halfDist += points[i].distanceTo(points[i + 1]) / 2;
+		}
+
+		for (i = 0, dist = 0; i < len - 1; i++) {
+			p1 = points[i];
+			p2 = points[i + 1];
+			segDist = p1.distanceTo(p2);
+			dist += segDist;
+
+			if (dist > halfDist) {
+				ratio = (dist - halfDist) / segDist;
+				return new CPoint(
+					p2.x - ratio * (p2.x - p1.x),
+					p2.y - ratio * (p2.y - p1.y)
+				);
+			}
+		}
+	}
+
+	getBounds(): CBounds {
+		return this.bounds;
+	}
+
+	getHitBounds(): CBounds {
+		// add clicktolerance for hit detection/etc.
+		var w = this.clickTolerance();
+		var p = new CPoint(w, w);
+		return new CBounds(this.bounds.getTopLeft().subtract(p), this.bounds.getBottomRight().add(p));
+	}
+
+	updatePath() {
+		this.rings = new Array<Array<CPoint>>();
+		CPolyline.calcRings(this.pointSet, this.rings);
+		this.clipPoints();
+		this.simplifyPoints();
+
+		this.renderer.updatePoly(this);
+	}
+
+	// Converts the point-set datastructure into an array of point-arrays each of which is called a 'ring'.
+	private static calcRings(pset: CPointSet, rings: Array<Array<CPoint>>) {
+		if (pset.isFlat()) {
+			var srcArray = pset.getPointArray();
+			var array = Array<CPoint>(srcArray.length);
+			srcArray.forEach((pt: CPoint, index: number) => {
+				array[index] = pt.clone();
+			})
+
+			rings.push(array);
+			return;
+		}
+
+		var psetArray = pset.getSetArray();
+		if (psetArray) {
+			psetArray.forEach((psetNext: CPointSet) => {
+				CPolyline.calcRings(psetNext, rings);
+			});
+		}
+	}
+
+	// clip polyline by renderer bounds so that we have less to render for performance
+	clipPoints() {
+		if (this.noClip) {
+			return;
+		}
+
+		this.parts = new Array<Array<CPoint>>();
+
+		var parts = this.parts;
+		var bounds = this.renderer.getBounds();
+		var i: number;
+		var j: number;
+		var k: number;
+		var len: number;
+		var len2: number;
+		var segment: Array<CPoint>;
+		var points: Array<CPoint>;
+
+		for (i = 0, k = 0, len = this.rings.length; i < len; i++) {
+			points = this.rings[i];
+
+			for (j = 0, len2 = points.length; j < len2 - 1; j++) {
+				segment = CLineUtil.clipSegment(points[j], points[j + 1], bounds, j != 0, true);
+
+				if (!segment.length) { continue; }
+
+				parts[k] = parts[k] || [];
+				parts[k].push(segment[0]);
+
+				// if segment goes out of screen, or it's the last one, it's the end of the line part
+				if ((segment[1] !== points[j + 1]) || (j === len2 - 2)) {
+					parts[k].push(segment[1]);
+					k++;
+				}
+			}
+		}
+	}
+
+	// simplify each clipped part of the polyline for performance
+	simplifyPoints() {
+		var parts = this.parts;
+		var tolerance = this.smoothFactor;
+
+		for (var i: number = 0, len = parts.length; i < len; i++) {
+			parts[i] = CLineUtil.simplify(parts[i], tolerance);
+		}
+	}
+
+	getParts(): Array<Array<CPoint>> {
+		return this.parts;
+	}
+
+	empty(): boolean {
+		// Overridden in implementations.
+		return this.parts.length > 0;
+	}
+};

--- a/loleaflet/src/layer/vector/CPolyline.ts
+++ b/loleaflet/src/layer/vector/CPolyline.ts
@@ -160,15 +160,15 @@ class CPolyline extends CPath {
 		return new CBounds(this.bounds.getTopLeft().subtract(p), this.bounds.getBottomRight().add(p));
 	}
 
-	updatePath() {
-		this.clipPoints();
+	updatePath(paintArea?: CBounds) {
+		this.clipPoints(paintArea);
 		this.simplifyPoints();
 
 		this.renderer.updatePoly(this);
 	}
 
 	// clip polyline by renderer bounds so that we have less to render for performance
-	clipPoints() {
+	clipPoints(paintArea?: CBounds) {
 		if (this.noClip) {
 			return;
 		}
@@ -176,7 +176,7 @@ class CPolyline extends CPath {
 		this.parts = new Array<Array<CPoint>>();
 
 		var parts = this.parts;
-		var bounds = this.renderer.getBounds();
+		var bounds = paintArea ? paintArea : this.renderer.getBounds();
 		var i: number;
 		var j: number;
 		var k: number;

--- a/loleaflet/src/layer/vector/CPolyline.ts
+++ b/loleaflet/src/layer/vector/CPolyline.ts
@@ -58,8 +58,7 @@ class CPolyline extends CPath {
 	constructor(pointSet: CPointSet, options: any) {
 		super(options);
 		this.smoothFactor = options.smoothFactor !== undefined ? options.smoothFactor : this.smoothFactor;
-		this.pointSet = pointSet;
-		this.updateBounds();
+		this.setPointSet(pointSet);
 	}
 
 	getPointSet(): CPointSet {

--- a/loleaflet/src/layer/vector/CPolyline.ts
+++ b/loleaflet/src/layer/vector/CPolyline.ts
@@ -49,11 +49,11 @@ class CPolyline extends CPath {
 	// how much to simplify the polyline on each zoom level
 	// more = better performance and smoother look, less = more accurate
 	private smoothFactor: number = 1.0;
-	private noClip: boolean = false;
+	protected noClip: boolean = false;
 	private pointSet: CPointSet;
 	private bounds: CBounds;
-	private rings: Array<Array<CPoint>>;
-	private parts: Array<Array<CPoint>>;
+	protected rings: Array<Array<CPoint>>;
+	protected parts: Array<Array<CPoint>>;
 
 	constructor(pointSet: CPointSet, options: any) {
 		super(options);
@@ -170,6 +170,7 @@ class CPolyline extends CPath {
 	// clip polyline by renderer bounds so that we have less to render for performance
 	clipPoints(paintArea?: CBounds) {
 		if (this.noClip) {
+			this.parts = this.rings;
 			return;
 		}
 

--- a/loleaflet/src/layer/vector/CPolyline.ts
+++ b/loleaflet/src/layer/vector/CPolyline.ts
@@ -160,11 +160,11 @@ class CPolyline extends CPath {
 		return new CBounds(this.bounds.getTopLeft().subtract(p), this.bounds.getBottomRight().add(p));
 	}
 
-	updatePath(paintArea?: CBounds) {
+	updatePath(paintArea?: CBounds, paneXFixed?: boolean, paneYFixed?: boolean) {
 		this.clipPoints(paintArea);
 		this.simplifyPoints();
 
-		this.renderer.updatePoly(this);
+		this.renderer.updatePoly(this, false /* closed? */, paneXFixed, paneYFixed);
 	}
 
 	// clip polyline by renderer bounds so that we have less to render for performance

--- a/loleaflet/src/layer/vector/CRectangle.ts
+++ b/loleaflet/src/layer/vector/CRectangle.ts
@@ -1,0 +1,20 @@
+/* eslint-disable */
+
+/*
+ * CRectangle extends CPolygon and creates a rectangle of given bounds.
+ */
+
+class CRectangle extends CPolygon {
+
+	constructor(bounds: CBounds, options: any) {
+		super(CRectangle.boundsToPointSet(bounds), options);
+	}
+
+	setBounds(bounds: CBounds) {
+		this.setPointSet(CRectangle.boundsToPointSet(bounds));
+	}
+
+	private static boundsToPointSet(bounds: CBounds): CPointSet {
+		return CPointSet.fromPointArray([bounds.getTopLeft(), bounds.getTopRight(), bounds.getBottomRight(), bounds.getBottomLeft(), bounds.getTopLeft()]);
+	}
+}

--- a/loleaflet/src/layer/vector/CanvasOverlay.ts
+++ b/loleaflet/src/layer/vector/CanvasOverlay.ts
@@ -1,0 +1,175 @@
+/* eslint-disable */
+
+// CanvasOverlay handles CPath rendering and mouse events handling via overlay-section of the main canvas.
+class CanvasOverlay {
+	private map: any;
+	private ctx: CanvasRenderingContext2D;
+	private paths: Map<number, any>;
+	private bounds: Array<number>;
+	private docTopLeft: Array<number> = [0, 0];
+	private tsManager: any;
+
+	constructor(mapObject: any, canvasContext: CanvasRenderingContext2D) {
+		this.map = mapObject;
+		this.ctx = canvasContext;
+		this.tsManager = this.map.getTileSectionMgr();
+		this.paths = new Map<number, any>();
+		this.updateCanvasBounds();
+	}
+
+	onInitialize() {
+	}
+
+	onResize() {
+		this.onDraw();
+	}
+
+	onDraw() {
+		// No need to "erase" previous drawings because tiles are draw first via its onDraw.
+		this.draw();
+	}
+
+	initPath(path: any) {
+		var pathId: number = path.getId();
+		this.paths.set(pathId, path);
+	}
+
+	removePath(path: any) {
+		// This does not get called via onDraw, so ask tileSection to "erase" by painting over.
+		this.tsManager._onTilesSectionDraw();
+		path.setDeleted();
+		this.paths.delete(path.getId());
+	}
+
+	updatePath(path: any) {
+		this.redraw(path);
+	}
+
+	updateStyle(path: any) {
+		this.redraw(path);
+	}
+
+	private static intersects(bound1: Array<number>, bound2: Array<number>): boolean {
+		// check if both X and Y segments intersect.
+		return (bound2[2] >= bound1[0] && bound2[0] <= bound1[2] &&
+			bound2[3] >= bound1[1] && bound2[1] <= bound1[3]);
+	}
+
+	private isVisible(path: any): boolean {
+		var pathBounds = path.getBounds();
+		this.updateCanvasBounds();
+		return CanvasOverlay.intersects(pathBounds, this.bounds);
+	}
+
+	private draw() {
+		this.paths.forEach((path: any) => {
+			path.updatePath();
+		});
+	}
+
+	private redraw(path: any) {
+		if (!this.isVisible(path))
+			return;
+		// This does not get called via onDraw(ie, tiles aren't painted), so ask tileSection to "erase" by painting over.
+		// Repainting the whole canvas is not necessary but finding the minimum area to paint over
+		// is potentially expensive to compute (think of overlapped path objects).
+		// TODO: We could repaint the area on the canvas occupied by all the visible path-objects
+		// and paint tiles just for that, but need a more general version of _onTilesSectionDraw() and callees.
+		this.tsManager._onTilesSectionDraw();
+		this.draw();
+	}
+
+	private updateCanvasBounds() {
+		var viewBounds: any = this.map.getPixelBoundsCore();
+		this.bounds = Array(viewBounds.min.x, viewBounds.min.y, viewBounds.max.x, viewBounds.max.y);
+	}
+
+	// Applies canvas translation so that polygons/circles can be drawn using core-pixel coordinates.
+	private ctStart() {
+		this.updateCanvasBounds();
+		this.docTopLeft = Array(this.bounds[0], this.bounds[1]);
+		this.ctx.translate(this.docTopLeft[0], this.docTopLeft[1]);
+	}
+
+	// Undo the canvas translation done by ctStart().
+	private ctEnd() {
+		this.ctx.translate(-this.docTopLeft[0], -this.docTopLeft[0]);
+	}
+
+	updatePoly(path: any, closed: boolean) {
+		var i: number;
+		var j: number;
+		var len2: number;
+		var part: any;
+		var parts: Array<any> = path.getParts();
+		var len: number = parts.length;
+
+		if (!len)
+			return;
+
+		this.ctStart();
+		this.ctx.beginPath();
+
+		for (i = 0; i < len; i++) {
+			for (j = 0, len2 = parts[i].length; j < len2; j++) {
+				part = parts[i][j];
+				this.ctx[j ? 'lineTo' : 'moveTo'](part.x, part.y);
+			}
+			if (closed) {
+				this.ctx.closePath();
+			}
+		}
+
+		this.fillStroke(path);
+
+		this.ctEnd();
+	}
+
+	updateCircle(path: any) {
+		if (path.empty())
+			return;
+
+		this.ctStart();
+
+		var point: Array<number> = path.point;
+		var r: number = path.radius;
+		var s: number = (path._radiusY || r) / r;
+
+		if (s !== 1) {
+			this.ctx.save();
+			this.ctx.scale(1, s);
+		}
+
+		this.ctx.beginPath();
+		this.ctx.arc(point[0], point[1] / s, r, 0, Math.PI * 2, false);
+
+		if (s !== 1) {
+			this.ctx.restore();
+		}
+
+		this.fillStroke(path);
+
+		this.ctEnd();
+	}
+
+	private fillStroke(path: any) {
+		var options: any = path.options;
+
+		if (options.fill) {
+			this.ctx.globalAlpha = options.fillOpacity;
+			this.ctx.fillStyle = options.fillColor || options.color;
+			this.ctx.fill(options.fillRule || 'evenodd');
+		}
+
+		if (options.stroke && options.weight !== 0) {
+			this.ctx.globalAlpha = options.opacity;
+
+			this.ctx.lineWidth = options.weight;
+			this.ctx.strokeStyle = options.color;
+			this.ctx.lineCap = options.lineCap;
+			this.ctx.lineJoin = options.lineJoin;
+			this.ctx.stroke();
+		}
+
+	}
+};

--- a/loleaflet/src/layer/vector/CanvasOverlay.ts
+++ b/loleaflet/src/layer/vector/CanvasOverlay.ts
@@ -3,6 +3,7 @@
 /// <reference path="CPath.ts" />
 /// <reference path="CPolyline.ts" />
 /// <reference path="CPolygon.ts" />
+/// <reference path="CRectangle.ts" />
 /* eslint-disable */
 
 // CanvasOverlay handles CPath rendering and mouse events handling via overlay-section of the main canvas.

--- a/loleaflet/src/layer/vector/CanvasOverlay.ts
+++ b/loleaflet/src/layer/vector/CanvasOverlay.ts
@@ -104,12 +104,12 @@ class CanvasOverlay {
 	private ctStart() {
 		this.updateCanvasBounds();
 		this.docTopLeft = this.bounds.getTopLeft();
-		this.ctx.translate(this.docTopLeft.x, this.docTopLeft.y);
+		this.ctx.translate(-this.docTopLeft.x, -this.docTopLeft.y);
 	}
 
 	// Undo the canvas translation done by ctStart().
 	private ctEnd() {
-		this.ctx.translate(-this.docTopLeft.x, -this.docTopLeft.y);
+		this.ctx.translate(this.docTopLeft.x, this.docTopLeft.y);
 	}
 
 	updatePoly(path: CPath, closed: boolean = false) {

--- a/loleaflet/src/layer/vector/CanvasOverlay.ts
+++ b/loleaflet/src/layer/vector/CanvasOverlay.ts
@@ -1,4 +1,5 @@
 /// <reference path="CPoint.ts" />
+/// <reference path="CBounds.ts" />
 /// <reference path="CPath.ts" />
 /* eslint-disable */
 
@@ -7,7 +8,7 @@ class CanvasOverlay {
 	private map: any;
 	private ctx: CanvasRenderingContext2D;
 	private paths: Map<number, any>;
-	private bounds: Array<number>;
+	private bounds: CBounds;
 	private docTopLeft: CPoint;
 	private tsManager: any;
 
@@ -53,16 +54,10 @@ class CanvasOverlay {
 		this.redraw(path);
 	}
 
-	private static intersects(bound1: Array<number>, bound2: Array<number>): boolean {
-		// check if both X and Y segments intersect.
-		return (bound2[2] >= bound1[0] && bound2[0] <= bound1[2] &&
-			bound2[3] >= bound1[1] && bound2[1] <= bound1[3]);
-	}
-
 	private isVisible(path: CPath): boolean {
 		var pathBounds = path.getBounds();
 		this.updateCanvasBounds();
-		return CanvasOverlay.intersects(pathBounds, this.bounds);
+		return this.bounds.intersects(pathBounds);
 	}
 
 	private draw() {
@@ -96,13 +91,13 @@ class CanvasOverlay {
 
 	private updateCanvasBounds() {
 		var viewBounds: any = this.map.getPixelBoundsCore();
-		this.bounds = Array(viewBounds.min.x, viewBounds.min.y, viewBounds.max.x, viewBounds.max.y);
+		this.bounds = new CBounds(new CPoint(viewBounds.min.x, viewBounds.min.y), new CPoint(viewBounds.max.x, viewBounds.max.y));
 	}
 
 	// Applies canvas translation so that polygons/circles can be drawn using core-pixel coordinates.
 	private ctStart() {
 		this.updateCanvasBounds();
-		this.docTopLeft = new CPoint(this.bounds[0], this.bounds[1]);
+		this.docTopLeft = this.bounds.getTopLeft();
 		this.ctx.translate(this.docTopLeft.x, this.docTopLeft.y);
 	}
 

--- a/loleaflet/src/layer/vector/CanvasOverlay.ts
+++ b/loleaflet/src/layer/vector/CanvasOverlay.ts
@@ -1,6 +1,7 @@
 /// <reference path="CPoint.ts" />
 /// <reference path="CBounds.ts" />
 /// <reference path="CPath.ts" />
+/// <reference path="CPolyline.ts" />
 /* eslint-disable */
 
 // CanvasOverlay handles CPath rendering and mouse events handling via overlay-section of the main canvas.

--- a/loleaflet/src/layer/vector/CanvasOverlay.ts
+++ b/loleaflet/src/layer/vector/CanvasOverlay.ts
@@ -45,6 +45,7 @@ class CanvasOverlay {
 		this.tsManager._onTilesSectionDraw();
 		path.setDeleted();
 		this.paths.delete(path.getId());
+		this.draw();
 	}
 
 	updatePath(path: CPath) {

--- a/loleaflet/src/layer/vector/CanvasOverlay.ts
+++ b/loleaflet/src/layer/vector/CanvasOverlay.ts
@@ -2,6 +2,7 @@
 /// <reference path="CBounds.ts" />
 /// <reference path="CPath.ts" />
 /// <reference path="CPolyline.ts" />
+/// <reference path="CPolygon.ts" />
 /* eslint-disable */
 
 // CanvasOverlay handles CPath rendering and mouse events handling via overlay-section of the main canvas.

--- a/loleaflet/src/layer/vector/CanvasOverlay.ts
+++ b/loleaflet/src/layer/vector/CanvasOverlay.ts
@@ -111,7 +111,7 @@ class CanvasOverlay {
 		this.ctx.translate(-this.docTopLeft.x, -this.docTopLeft.y);
 	}
 
-	updatePoly(path: CPath, closed: boolean) {
+	updatePoly(path: CPath, closed: boolean = false) {
 		var i: number;
 		var j: number;
 		var len2: number;

--- a/loleaflet/src/layer/vector/CanvasOverlay.ts
+++ b/loleaflet/src/layer/vector/CanvasOverlay.ts
@@ -55,13 +55,17 @@ class CanvasOverlay {
 		this.redraw(path);
 	}
 
+	paintRegion(paintArea: CBounds) {
+		this.draw(paintArea);
+	}
+
 	private isVisible(path: CPath): boolean {
 		var pathBounds = path.getBounds();
 		this.updateCanvasBounds();
 		return this.bounds.intersects(pathBounds);
 	}
 
-	private draw() {
+	private draw(paintArea?: CBounds) {
 		var orderedPaths = Array<CPath>();
 		this.paths.forEach((path: any) => {
 			orderedPaths.push(path);
@@ -73,8 +77,10 @@ class CanvasOverlay {
 			return a.zIndex - b.zIndex;
 		});
 
+		var renderer = this;
 		orderedPaths.forEach((path: any) => {
-			path.updatePath();
+			if (renderer.isVisible(path))
+				path.updatePath(paintArea);
 		});
 	}
 

--- a/loleaflet/src/layer/vector/CanvasOverlay.ts
+++ b/loleaflet/src/layer/vector/CanvasOverlay.ts
@@ -1,3 +1,4 @@
+/// <reference path="CPoint.ts" />
 /// <reference path="CPath.ts" />
 /* eslint-disable */
 
@@ -7,7 +8,7 @@ class CanvasOverlay {
 	private ctx: CanvasRenderingContext2D;
 	private paths: Map<number, any>;
 	private bounds: Array<number>;
-	private docTopLeft: Array<number> = [0, 0];
+	private docTopLeft: CPoint;
 	private tsManager: any;
 
 	constructor(mapObject: any, canvasContext: CanvasRenderingContext2D) {
@@ -101,20 +102,20 @@ class CanvasOverlay {
 	// Applies canvas translation so that polygons/circles can be drawn using core-pixel coordinates.
 	private ctStart() {
 		this.updateCanvasBounds();
-		this.docTopLeft = Array(this.bounds[0], this.bounds[1]);
-		this.ctx.translate(this.docTopLeft[0], this.docTopLeft[1]);
+		this.docTopLeft = new CPoint(this.bounds[0], this.bounds[1]);
+		this.ctx.translate(this.docTopLeft.x, this.docTopLeft.y);
 	}
 
 	// Undo the canvas translation done by ctStart().
 	private ctEnd() {
-		this.ctx.translate(-this.docTopLeft[0], -this.docTopLeft[0]);
+		this.ctx.translate(-this.docTopLeft.x, -this.docTopLeft.y);
 	}
 
 	updatePoly(path: CPath, closed: boolean) {
 		var i: number;
 		var j: number;
 		var len2: number;
-		var part: Array<number>;
+		var part: CPoint;
 		var parts = path.getParts();
 		var len: number = parts.length;
 
@@ -127,7 +128,7 @@ class CanvasOverlay {
 		for (i = 0; i < len; i++) {
 			for (j = 0, len2 = parts[i].length; j < len2; j++) {
 				part = parts[i][j];
-				this.ctx[j ? 'lineTo' : 'moveTo'](part[0], part[1]);
+				this.ctx[j ? 'lineTo' : 'moveTo'](part.x, part.y);
 			}
 			if (closed) {
 				this.ctx.closePath();
@@ -145,7 +146,7 @@ class CanvasOverlay {
 
 		this.ctStart();
 
-		var point: Array<number> = path.point;
+		var point = path.point;
 		var r: number = path.radius;
 		var s: number = (path.radiusY || r) / r;
 
@@ -155,7 +156,7 @@ class CanvasOverlay {
 		}
 
 		this.ctx.beginPath();
-		this.ctx.arc(point[0], point[1] / s, r, 0, Math.PI * 2, false);
+		this.ctx.arc(point.x, point.y / s, r, 0, Math.PI * 2, false);
 
 		if (s !== 1) {
 			this.ctx.restore();

--- a/loleaflet/src/layer/vector/CanvasOverlay.ts
+++ b/loleaflet/src/layer/vector/CanvasOverlay.ts
@@ -126,7 +126,6 @@ class CanvasOverlay {
 
 		this.ctx.translate(cOrigin.x, cOrigin.y);
 		if (clipArea) {
-			this.ctx.save();
 			this.ctx.beginPath();
 			var clipSize = clipArea.getSize();
 			this.ctx.rect(clipArea.min.x, clipArea.min.y, clipSize.x, clipSize.y);
@@ -167,10 +166,6 @@ class CanvasOverlay {
 		this.fillStroke(path);
 
 		this.ctEnd();
-
-		if (clipArea) {
-			this.ctx.restore();
-		}
 	}
 
 	updateCircle(path: CPath, paneXFixed?: boolean, paneYFixed?: boolean) {

--- a/loleaflet/src/layer/vector/CanvasOverlay.ts
+++ b/loleaflet/src/layer/vector/CanvasOverlay.ts
@@ -94,6 +94,11 @@ class CanvasOverlay {
 		this.bounds = new CBounds(new CPoint(viewBounds.min.x, viewBounds.min.y), new CPoint(viewBounds.max.x, viewBounds.max.y));
 	}
 
+	getBounds(): CBounds {
+		this.updateCanvasBounds();
+		return this.bounds;
+	}
+
 	// Applies canvas translation so that polygons/circles can be drawn using core-pixel coordinates.
 	private ctStart() {
 		this.updateCanvasBounds();

--- a/loleaflet/src/map/Map.js
+++ b/loleaflet/src/map/Map.js
@@ -1773,6 +1773,12 @@ L.Map = L.Evented.extend({
 
 	setMarkersOpacity: function(opacity) {
 		this._setPaneOpacity('leaflet-pane leaflet-marker-pane', opacity);
+	},
+
+	getTileSectionMgr: function() {
+		if (this._docLayer)
+			return this._docLayer._painter;
+		return undefined;
 	}
 });
 


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
This is a set of patches to help migrate SVG based overlays objects like cell-cursor, selections etc to directly draw on main canvas via canvas-sections. It migrates cell cursor to main canvas to start with. The other overlay layer objects will be migrated one by one in further pull requests.

Following typescript classes are written based on corresponding old L. js classes but without the latlng stuff:

CanvasOverlay.ts  <- L.Canvas.
CPath <- L.Path
CPolyline <- L.Polyline
CLineUtil <- L.LineUtil
CPoint <- L.Point 
CBounds <- L.Bounds
CPolygon <- L.Polygon
CPolyUtil <- L.PolyUtil
CRectangle <- L.Rectangle

### TODO

- [x] Migrate rest of L.Path based classes to typescript for making them work with CavasOverlay.
- [x] Use CanvasOverlay and its paths for cell cursor.
- [x] Remove debug/test commits. 
- [x] Squash fixup commits
 
### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

