### PR TITLE
net: http version string may not be null-terminated

### DIFF
--- a/net/HttpRequest.cpp
+++ b/net/HttpRequest.cpp
@@ -129,7 +129,8 @@ FieldParseState StatusLine::parse(const char* p, int64_t& len)
     constexpr int VersionMinPos = VersionDotPos + 1;
     const int versionMaj = version[VersionMajPos] - '0';
     const int versionMin = version[VersionMinPos] - '0';
-    if (!Util::startsWith(version, "HTTP/") || (versionMaj < 0 || versionMaj > 9)
+    // Version may not be null-terminated.
+    if (!Util::startsWith(std::string(version, VersionLen), "HTTP/") || (versionMaj < 0 || versionMaj > 9)
         || version[VersionDotPos] != '.' || (versionMin < 0 || versionMin > 9))
     {
         return FieldParseState::Invalid;


### PR DESCRIPTION
Limit its length, we know the version length anyway.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I0db2b9227baf3e10055082ad394c0f555b9898e1
