### PR TITLE
wsd: default UserFriendlyName if missing

### DIFF
--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -717,6 +717,20 @@ WopiStorage::WOPIFileInfo::WOPIFileInfo(const FileInfo &fileInfo,
     JsonUtil::findJSONValue(object, "TemplateSaveAs", _templateSaveAs);
     JsonUtil::findJSONValue(object, "TemplateSource", _templateSource);
 
+    // UserFriendlyName is used as the Author when loading the document.
+    // If it's missing, document loading fails. Since the UserFriendlyName
+    // field is optional in WOPI specs, it's often left out by integrators.
+    if (_username.empty())
+    {
+        _username = "UnknownUser"; // Default to something sensible yet friendly.
+        if (!_userId.empty())
+            _username += '_' + _userId;
+
+        LOG_WRN("WOPI::CheckFileInfo does not specify a valid UserFriendlyName for the current "
+                "user. Temporarily ["
+                << _username << "] will be used until a valid name is specified.");
+    }
+
     std::ostringstream wopiResponse;
 
     // Anonymize key values.

--- a/wsd/reference.md
+++ b/wsd/reference.md
@@ -78,6 +78,10 @@ A programmatic string identifier of the user.
 ### UserFriendlyName
 A string representing the name of the user for display in the UI.
 
+While nominally an optional field, it is used to identify the author of changes in documents.
+When missing, "UnknownUser" will be used instead, with a possible suffix with the UserId.
+
+Strongly recommended to set it to a valid value.
 
 CheckFileInfo extended response properties
 ------------------------------------------


### PR DESCRIPTION
While UserFriendlyName is an optional field
in the WOPI protocol, Core needs it for
the Author of the document. When it's blank
the Author is not set and the document fails
to load.

By default we are at least able to load the
document with a sensible placeholder for the
Author. Meanwhile, we log a warning to let
the integrators know of the issue.

Documentation updated.

Change-Id: I4dd2c9d164b4d889f85701a4a27ee8d395bff220
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
(cherry picked from commit 07cf0d52ef1a082de51d32205f396cb6dcb62e51)


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

