### PR TITLE
Back-port of dialog image caching work

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -1672,6 +1672,11 @@ bool ChildSession::renderWindow(const char* /*buffer*/, int /*length*/, const St
     assert(_pixmapCache.size() <= LOKitHelper::tunnelledDialogImageCacheSize);
 
     // If not found in cache, we need to encode to PNG and send to client
+
+    // To artificially induce intentional cache inconsistency between server and client, to be able
+    // to test error handling, you can do something like:
+    // const bool doPng = (found == _pixmapCache.end() || (time(NULL) % 10 == 0)) && ((time(NULL) % 10) < 8);
+
     const bool doPng = (found == _pixmapCache.end());
 
     LOG_DBG("Pixmap hash: " << pixmapHash << (doPng ? " NOT in cache, doing PNG" : " in cache, not encoding to PNG") << ", cache size now:" << _pixmapCache.size());

--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -1259,6 +1259,9 @@ L.Socket = L.Class.extend({
 			else if (tokens[i].startsWith('hash=')) {
 				command.hash = tokens[i].substring('hash='.length);
 			}
+			else if (tokens[i] === 'nopng') {
+				command.nopng = true;
+			}
 		}
 		if (command.tileWidth && command.tileHeight && this._map._docLayer) {
 			var defaultZoom = this._map.options.zoom;

--- a/loleaflet/src/layer/tile/TileLayer.js
+++ b/loleaflet/src/layer/tile/TileLayer.js
@@ -2028,7 +2028,7 @@ L.TileLayer = L.GridLayer.extend({
 			}
 		} else {
 			// Sanity check: If we get a PNG it should be for a hash that we don't have cached
-			for (var i = 0; i < this._pngCache.length; i++) {
+			for (i = 0; i < this._pngCache.length; i++) {
 				if (this._pngCache[i].hash == command.hash) {
 					this._map._socket.sendMessage('ERROR windowpaint: message included PNG for hash ' + command.hash
 								      + ' even if it was already cached here in the client');

--- a/loleaflet/src/layer/tile/TileLayer.js
+++ b/loleaflet/src/layer/tile/TileLayer.js
@@ -2009,15 +2009,36 @@ L.TileLayer = L.GridLayer.extend({
 		var command = this._map._socket.parseServerCmd(textMsg);
 
 		// this._map._socket.sendMessage('DEBUG _onDialogPaintMsg: hash=' + command.hash + ' img=' + typeof(img) + (typeof(img) == 'string' ? (' (length:' + img.length + ':"' + img.substring(0, 30) + (img.length > 30 ? '...' : '') + '")') : '') + ', cache size ' + this._pngCache.length);
-		for (var i = 0; i < this._pngCache.length; i++) {
-			if (this._pngCache[i].hash == command.hash) {
-				// this._map._socket.sendMessage('DEBUG - Found in cache');
-				img = this._pngCache[i].img;
-				// Remove item and add it at the start of the array
-				this._pngCache.splice(i, 1);
-				break;
+		if (command.nopng) {
+			var found = false;
+			for (var i = 0; i < this._pngCache.length; i++) {
+				if (this._pngCache[i].hash == command.hash) {
+					found = true;
+					// this._map._socket.sendMessage('DEBUG - Found in cache');
+					img = this._pngCache[i].img;
+					// Remove item (and add it below at the start of the array)
+					this._pngCache.splice(i, 1);
+					break;
+				}
+			}
+			if (!found) {
+				this._map._socket.sendMessage('ERROR windowpaint: message assumed PNG for hash ' + command.hash
+							      + ' is cached here in the client but not found');
+				// Not sure what to do. Ask the server to re-send the windowpaint: message but this time including the PNG?
+			}
+		} else {
+			// Sanity check: If we get a PNG it should be for a hash that we don't have cached
+			for (var i = 0; i < this._pngCache.length; i++) {
+				if (this._pngCache[i].hash == command.hash) {
+					this._map._socket.sendMessage('ERROR windowpaint: message included PNG for hash ' + command.hash
+								      + ' even if it was already cached here in the client');
+					// Remove the extra copy, code below will add it at the start of the array
+					this._pngCache.splice(i, 1);
+					break;
+				}
 			}
 		}
+
 		// If cache is max size, drop the last element
 		if (this._pngCache.length == this._map._socket.TunnelledDialogImageCacheSize) {
 			// this._map._socket.sendMessage('DEBUG - Dropping last cache element');

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -343,6 +343,11 @@ bool ClientSession::_handleInput(const char *buffer, int length)
         std::cerr << std::string(buffer, length).substr(strlen("DEBUG") + 1) << std::endl;
         return false;
     }
+    else if (tokens.equals(0, "ERROR"))
+    {
+        LOG_ERR("From client: " << std::string(buffer, length).substr(strlen("ERROR") + 1));
+        return false;
+    }
 
     LOOLWSD::dumpIncomingTrace(docBroker->getJailId(), getId(), firstLine);
 

--- a/wsd/protocol.txt
+++ b/wsd/protocol.txt
@@ -42,7 +42,7 @@ client -> server
 DEBUG <rest of message>
 
     The rest of the message (without the DEBUG keyword), possibly
-    multiple lines, is printed to the server's stderr.
+    multiple lines, is logged by the server as LOG_DBG.
 
 canceltiles
 

--- a/wsd/protocol.txt
+++ b/wsd/protocol.txt
@@ -44,6 +44,11 @@ DEBUG <rest of message>
     The rest of the message (without the DEBUG keyword), possibly
     multiple lines, is logged by the server as LOG_DBG.
 
+ERROR <rest of message>
+
+    The rest of the message (without the ERROR keyword), possibly
+    multiple lines, is logged by the server as LOG_ERR.
+
 canceltiles
 
     All outstanding tile messages from the client to the server are


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

