### PR TITLE
test: avoid http status 512 and higher when interacting with poco

### DIFF
--- a/test/HttpRequestTests.cpp
+++ b/test/HttpRequestTests.cpp
@@ -211,7 +211,7 @@ void HttpRequestTests::test500GetStatuses()
             http::StatusLine::StatusCodeClass::Client_Error,
             http::StatusLine::StatusCodeClass::Server_Error };
     int curStatusCodeClass = -1;
-    for (int statusCode = 100; statusCode < 600; ++statusCode)
+    for (int statusCode = 100; statusCode < 512; ++statusCode)
     {
         const std::string url = "/status/" + std::to_string(statusCode);
         httpRequest.setUrl(url);


### PR DESCRIPTION
The last enumerator in Poco::Net::HTTPResponse::HTTPStatus is 511.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Id183916729c8d13f63fe0d6e0d7ca7e84c8afaeb
