### PR TITLE
cypress: update 'Check disabled elements in master view.' test.

### DIFF
--- a/cypress_test/integration_tests/mobile/impress/slide_properties_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/slide_properties_spec.js
@@ -416,11 +416,11 @@ describe('Changing slide properties.', function() {
 		//	.should('have.text', 'Portrait');
 	});
 
-	it('Check disabled elements in master view.', function() {
+	it.skip('Check disabled elements in master view.', function() {
 		switchToMasterView();
 
 		cy.get('#masterslide')
-			.should('have.class', 'disabled');
+			.should('not.exist');
 
 		cy.get('#displaymasterbackground label')
 			.should('have.class', 'disabled');
@@ -436,7 +436,7 @@ describe('Changing slide properties.', function() {
 			.should('exist');
 
 		cy.get('#masterslide')
-			.should('have.class', 'disabled');
+			.should('not.exist');
 
 		cy.get('#displaymasterbackground label')
 			.should('have.class', 'disabled');
@@ -453,7 +453,7 @@ describe('Changing slide properties.', function() {
 		previewShouldBeFullWhite();
 
 		cy.get('#masterslide')
-			.should('not.have.class', 'disabled');
+			.should('exist');
 
 		cy.get('#displaymasterbackground label')
 			.should('not.have.class', 'disabled');


### PR DESCRIPTION
In master view, the 'Master Slide' list should be empty and so it's
not shown on mobile wizard. No, I disable this test, because
it needs the core code to be updated.

Signed-off-by: Tamás Zolnai <tamas.zolnai@collabora.com>
Change-Id: I12562c453673ac85e050303ebb5803fee6f1892a
(cherry picked from commit c2620ce5cf509a91ae23688779ba5df8d0cd4f03)

