### PR TITLE
cypress: mention video recording option in failure log.

### DIFF
--- a/cypress_test/run_parallel.sh
+++ b/cypress_test/run_parallel.sh
@@ -79,6 +79,9 @@ print_error() {
     CypressError: a test failed, please do one of the following:\n\n\
     Run the failing test in headless mode:\n\
     \tcd cypress_test && make check-${COMMAND} spec=${SPEC}\n" >> ${ERROR_LOG}
+    echo -e "\
+    Run the failing test with video recording:\n\
+    \tcd cypress_test && ENABLE_VIDEO_REC="1" make check-${COMMAND} spec=${SPEC}\n" >> ${ERROR_LOG}
     if [ "${TEST_TYPE}" != "multi-user" ]; then
     echo -e "\
     Open the failing test in the interactive test runner:\n\


### PR DESCRIPTION
It's a useful option to create a video during headless run.
It's much closer to the headless build wrt. timing, than
interactive test runner.

Signed-off-by: Tamás Zolnai <tamas.zolnai@collabora.com>
Change-Id: Ic9889209ac07b9fe0a9b6e326e60513412950780
