### PR TITLE
wsd: test: disable external http regression tests

### DIFF
--- a/test/HttpRequestTests.cpp
+++ b/test/HttpRequestTests.cpp
@@ -36,8 +36,8 @@ class HttpRequestTests final : public CPPUNIT_NS::TestFixture
 
     CPPUNIT_TEST(testSimpleGet);
     CPPUNIT_TEST(testSimpleGetSync);
-    CPPUNIT_TEST(test500GetStatuses); // Slow.
-    CPPUNIT_TEST(testSimplePost);
+    // CPPUNIT_TEST(test500GetStatuses); // Slow.
+    // CPPUNIT_TEST(testSimplePost);
     CPPUNIT_TEST(testTimeout);
     CPPUNIT_TEST(testOnFinished_Complete);
     CPPUNIT_TEST(testOnFinished_Timeout);
@@ -182,6 +182,10 @@ static void compare(const Poco::Net::HTTPResponse& pocoResponse, const std::stri
         LOK_ASSERT_EQUAL(pocoResponse.getContentLength(), httpResponse.header().getContentLength());
 }
 
+/// This test requests specific *reponse* codes from
+/// the server to test the handling of all possible
+/// response status codes.
+/// It exercises a few hundred requests/responses.
 void HttpRequestTests::test500GetStatuses()
 {
     // Start the polling thread.


### PR DESCRIPTION
These are not needed to be executed on an ongoing
basis, only when modifying the http code.

As the external service is only used to verify
the initial implementation, it will also get
replaced with an internal (loopback) one.

Disabling for now to avoid noise when randomly
failing, due to network or other reasons.

Change-Id: I54f5203c39e48ba442313698d519b035200b41e5
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
