### PR TITLE
Revert "Don't block handling of touch events"

### DIFF
--- a/loleaflet/src/layer/marker/Marker.Drag.js
+++ b/loleaflet/src/layer/marker/Marker.Drag.js
@@ -16,6 +16,7 @@ L.Handler.MarkerDrag = L.Handler.extend({
 		}
 
 		this._draggable.on({
+			down: this._onDown,
 			dragstart: this._onDragStart,
 			drag: this._onDrag,
 			dragend: this._onDragEnd,
@@ -27,6 +28,7 @@ L.Handler.MarkerDrag = L.Handler.extend({
 
 	removeHooks: function () {
 		this._draggable.off({
+			down: this._onDown,
 			dragstart: this._onDragStart,
 			drag: this._onDrag,
 			dragend: this._onDragEnd,
@@ -50,6 +52,10 @@ L.Handler.MarkerDrag = L.Handler.extend({
 	freezeY: function (boolChoice) {
 		if (this._draggable)
 			this._draggable.freezeY(boolChoice);
+	},
+
+	_onDown: function (e) {
+		this._marker.fire('down', e);
 	},
 
 	_onDragStart: function (e) {

--- a/loleaflet/src/layer/marker/Marker.js
+++ b/loleaflet/src/layer/marker/Marker.js
@@ -23,6 +23,8 @@ L.Marker = L.Layer.extend({
 	initialize: function (latlng, options) {
 		L.setOptions(this, options);
 		this._latlng = L.latLng(latlng);
+		this.on('down', this.onDown);
+		this.on('up', this.onUp);
 	},
 
 	setDraggable: function(val) {
@@ -52,6 +54,18 @@ L.Marker = L.Layer.extend({
 
 		this._removeIcon();
 		this._removeShadow();
+	},
+
+	onDown: function () {
+		if (this._map && this._map.touchGesture) {
+			window.IgnorePanning = true;
+		}
+	},
+
+	onUp: function () {
+		if (this._map && this._map.touchGesture) {
+			window.IgnorePanning = undefined;
+		}
 	},
 
 	getEvents: function () {


### PR DESCRIPTION
This reverts commit 284e8ce308f2e8a3ea124f93fb7f8c27fbed0910.

We have to disable handler to avoid panning when resizing
the selection using handles. Instead introduce up handler
which will enable gestures again when it is a tap not panning.

Change-Id: I9994b3e9ba32bc3e43567d43e547eada311c050e
Signed-off-by: Szymon Kłos <szymon.klos@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

