### PR TITLE
loleaflet: update cursor position if belong to the document

### DIFF
--- a/loleaflet/src/layer/tile/TileLayer.js
+++ b/loleaflet/src/layer/tile/TileLayer.js
@@ -1341,7 +1341,7 @@ L.TileLayer = L.GridLayer.extend({
 			return;
 		}
 		var modifierViewId = parseInt(obj.viewId);
-		if (modifierViewId != this._viewId)
+		if (modifierViewId !== this._viewId || (obj.window && obj.window === 'SwAnnotationWin'))
 			return;
 
 		this._cursorAtMispelledWord = obj.mispelledWord ? Boolean(parseInt(obj.mispelledWord)).valueOf() : false;


### PR DESCRIPTION
Unfortunately the Server Side sends cursor position for the
annotation window with different coordinates.
I am not sure why it is sending if are useless here,
I guess is used for gtktiledviewer.

Change-Id: Ibb0e2d70786b136c9aad2a3f9f6328503aed60c2
Signed-off-by: Henry Castro <hcastro@collabora.com>
