### PR TITLE
Revert "cypress: make sure the cell selection is visible before run t…

### DIFF
--- a/cypress_test/integration_tests/common/mobile_helper.js
+++ b/cypress_test/integration_tests/common/mobile_helper.js
@@ -35,10 +35,6 @@ function enableEditingMobile() {
 	helper.doIfInCalc(function() {
 		cy.get('#formulabar')
 			.should('be.visible');
-
-		// we should have a cell selected here
-		cy.get('.spreadsheet-cell-resize-marker')
-			.should('be.visible');
 	});
 
 	// In writer, we should have the blinking cursor visible


### PR DESCRIPTION
…est steps."

This reverts commit 129ae61684ec8506eb7124342b335e965ea9be6c.

This is actually undefined, whether the cell cursor would be there
or not. We get cell cursor messages after loading the document,
so if we step into editing mode before these messages, then we
will have the cell cursor, but if we wait some seconds after
opening the document, then the cell cursor won't be displayed.