### PR TITLE
Also save cellviewcursor: messages for handling when we are ready

### DIFF
--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -921,6 +921,7 @@ L.Socket = L.Class.extend({
 		var delayed = false;
 		if (textMsg.startsWith('window:') ||
 			textMsg.startsWith('celladdress:') ||
+			textMsg.startsWith('cellviewcursor:') ||
 			textMsg.startsWith('statechanged:') ||
 			textMsg.startsWith('invalidatecursor:') ||
 			textMsg.startsWith('viewinfo:')) {


### PR DESCRIPTION
Without this, when joining an editing session of a spreadsheet, you
don't see the cell cursors of another participant until they move the
cell cursor.

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: I87b8ad584d57bce52b39706fa9f0bbf56a59082a


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

