### PR TITLE
CheckFileInfo: Report mis-spelled CheckFileInfo properties as errors.

### DIFF
--- a/common/JsonUtil.hpp
+++ b/common/JsonUtil.hpp
@@ -115,7 +115,7 @@ bool findJSONValue(Poco::JSON::Object::Ptr &object, const std::string& key, T& v
                 continue; // Not even close, keep searching.
 
             // We found something with some differences--warn and return.
-            LOG_WRN("Incorrect JSON property [" << userInput << "]. Did you mean [" << key <<
+            LOG_ERR("Incorrect JSON property [" << userInput << "]. Did you mean [" << key <<
                     "] ? (Levenshtein distance: " << levDist << ')');
 
             // Fail without exact match.


### PR DESCRIPTION
To be able to locate them in the logs more easily; this is likely to
catch mistakes early in the development of new integrations.

Change-Id: I11c528d11e4a4e1d13f8d32085fa1bf1a163b779
