### PR TITLE
make clone formating context menu string shorter

### DIFF
--- a/loleaflet/src/unocommands.js
+++ b/loleaflet/src/unocommands.js
@@ -150,7 +150,7 @@ var unoCommandsArray = {
 	FormatMeanValue:{global:{menu:_('Format Mean Value Line...'),},},
 	FormatMenu:{global:{menu:_('F~ormat'),},},
 	FormatMinorGrid:{global:{menu:_('Format Minor Grid...'),},},
-	FormatPaintbrush:{global:{context:_('Clone Formatting (double click for multi-selection)'),menu:_('Clone'),},text:{context:_('Clone Formatting (double click and Ctrl or Cmd to alter behavior)'),menu:_('Clone'),},},
+	FormatPaintbrush:{global:{context:_('Clone Formatting (double click for multi-selection)'),menu:_('Clone'),},text:{context:_('Clone Formatting'),menu:_('Clone'),},},
 	FormatSelection:{global:{menu:_('Format Selection...'),},},
 	FormatSpacingMenu:{global:{menu:_('~Spacing'),},},
 	FormatStockGain:{global:{menu:_('Format Stock Gain...'),},},


### PR DESCRIPTION
Signed-off-by: Andreas-Kainz <andreas_k@abwesend.de>
Change-Id: I8224c8351bd5528986302ae9df09090d8393c3f4

before
![2021-02-04 13_02_17-ws-6046668b-b82e-4909-bd71-c9f38d8e79be_0 - noVNC](https://user-images.githubusercontent.com/8517736/106890863-373c2100-66ea-11eb-9793-b70ec7f33425.png)

after
![2021-02-04 13_09_16-ws-6046668b-b82e-4909-bd71-c9f38d8e79be_0 - noVNC](https://user-images.githubusercontent.com/8517736/106890877-3c00d500-66ea-11eb-97b7-3ab20d85c202.png)

same string than in LibreOffice
![2021-02-04 13_09_45-Untitled 1 - LibreOfficeDev Writer](https://user-images.githubusercontent.com/8517736/106890913-49b65a80-66ea-11eb-8ec9-866c286357c6.png)
