### PR TITLE
Calc: Minus & plus sign hairline drawings.

### DIFF
--- a/loleaflet/src/control/Control.ColumnGroup.js
+++ b/loleaflet/src/control/Control.ColumnGroup.js
@@ -104,19 +104,19 @@ L.Control.ColumnGroup = L.Control.GroupBase.extend({
 			startY -= this._groupHeadSize * 0.5;
 			if (startX > this._cornerHeaderWidth) {
 				// draw '-'
-				this.context.moveTo(startX + this._groupHeadSize * 0.25 + 0.5, startY + this._groupHeadSize * 0.5 + 0.5);
-				this.context.lineTo(startX + this._groupHeadSize * 0.75 + 0.5, startY + this._groupHeadSize * 0.5 + 0.5);
+				this.context.moveTo(startX + this._groupHeadSize * 0.25, startY + this._groupHeadSize * 0.5 + 0.5);
+				this.context.lineTo(startX + this._groupHeadSize * 0.75 + Math.round(this.dpiScale), startY + this._groupHeadSize * 0.5 + 0.5);
 				this.context.stroke();
 			}
 		}
 		else if (startX > this._cornerHeaderWidth) {
 			// draw '+'
 			this.context.beginPath();
-			this.context.moveTo(startX + this._groupHeadSize * 0.25 + 0.5, startY + this._groupHeadSize * 0.5 + 0.5);
-			this.context.lineTo(startX + this._groupHeadSize * 0.75 + 0.5, startY + this._groupHeadSize * 0.5 + 0.5);
+			this.context.moveTo(startX + this._groupHeadSize * 0.25, startY + this._groupHeadSize * 0.5 + 0.5);
+			this.context.lineTo(startX + this._groupHeadSize * 0.75 + Math.round(this.dpiScale), startY + this._groupHeadSize * 0.5 + 0.5);
 
-			this.context.moveTo(startX + this._groupHeadSize * 0.50 + 0.5, startY + this._groupHeadSize * 0.25 + 0.5);
-			this.context.lineTo(startX + this._groupHeadSize * 0.50 + 0.5, startY + this._groupHeadSize * 0.75 + 0.5);
+			this.context.moveTo(startX + this._groupHeadSize * 0.50 + 0.5, startY + this._groupHeadSize * 0.25);
+			this.context.lineTo(startX + this._groupHeadSize * 0.50 + 0.5, startY + this._groupHeadSize * 0.75 + Math.round(this.dpiScale));
 
 			this.context.stroke();
 		}

--- a/loleaflet/src/control/Control.RowGroup.js
+++ b/loleaflet/src/control/Control.RowGroup.js
@@ -104,8 +104,8 @@ L.Control.RowGroup = L.Control.GroupBase.extend({
 			startX -= this._groupHeadSize * 0.5;
 			if (startY > this._cornerHeaderHeight) {
 				// draw '-'
-				this.context.moveTo(startX + this._groupHeadSize * 0.25 + 0.5, startY + this._groupHeadSize / 2 + 0.5);
-				this.context.lineTo(startX + this._groupHeadSize * 0.75 + 0.5, startY + this._groupHeadSize / 2 + 0.5);
+				this.context.moveTo(startX + this._groupHeadSize * 0.25, startY + this._groupHeadSize / 2 + 0.5);
+				this.context.lineTo(startX + this._groupHeadSize * 0.75 + Math.round(this.dpiScale), startY + this._groupHeadSize / 2 + 0.5);
 				this.context.stroke();
 			}
 		}
@@ -113,11 +113,11 @@ L.Control.RowGroup = L.Control.GroupBase.extend({
 			// draw '+'
 			this.context.beginPath();
 
-			this.context.moveTo(startX + this._groupHeadSize * 0.25 + 0.5, startY + this._groupHeadSize / 2 + 0.5);
-			this.context.lineTo(startX + this._groupHeadSize * 0.75 + 0.5, startY + this._groupHeadSize / 2 + 0.5);
+			this.context.moveTo(startX + this._groupHeadSize * 0.25, startY + this._groupHeadSize / 2 + 0.5);
+			this.context.lineTo(startX + this._groupHeadSize * 0.75 + Math.round(this.dpiScale), startY + this._groupHeadSize / 2 + 0.5);
 
-			this.context.moveTo(startX + this._groupHeadSize * 0.50 + 0.5, startY + this._groupHeadSize * 0.25 + 0.5);
-			this.context.lineTo(startX + this._groupHeadSize * 0.50 + 0.5, startY + this._groupHeadSize * 0.75 + 0.5);
+			this.context.moveTo(startX + this._groupHeadSize * 0.50 + 0.5, startY + this._groupHeadSize * 0.25);
+			this.context.lineTo(startX + this._groupHeadSize * 0.50 + 0.5, startY + this._groupHeadSize * 0.75 + Math.round(this.dpiScale));
 
 			this.context.stroke();
 		}


### PR DESCRIPTION
Row and column group controls' plus & minus signs were not hairline. It is fixed.

Signed-off-by: Gökay Şatır <gokaysatir@collabora.com>
Change-Id: I964f0e3916df91b110ba17e819c24d589c6bd3cd


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

