### PR TITLE
sometimes it's useful, when path to loolkitconfig.xcu is configurable

### DIFF
--- a/cypress_test/integration_tests/desktop/impress/top_toolbar_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/top_toolbar_spec.js
@@ -41,7 +41,7 @@ describe('Top toolbar tests.', function() {
 
 		cy.get('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph')
 			.should('have.attr', 'font-style', 'italic');
-	});	
+	});
 
 	it('Apply underline on text shape.', function() {
 		cy.get('#tb_editbar_item_underline')
@@ -93,29 +93,29 @@ describe('Top toolbar tests.', function() {
 	it('Apply a selected font name on the text shape', function() {
 		cy.get('#tb_editbar_item_fonts')
 			.click();
-	   
-		desktopHelper.selectFromListbox('Liberation Mono');    
-	   
+
+		desktopHelper.selectFromListbox('Liberation Mono');
+
 		impressHelper.triggerNewSVGForShapeInTheCenter();
-  
+
 		cy.get('.leaflet-pane.leaflet-overlay-pane g.Page .TextShape .TextParagraph')
 			.should('have.attr', 'font-family', 'Liberation Mono');
 	});
-  
+
 	it('Apply a selected font size on the text shape', function() {
-  
+
 		cy.get('#tb_editbar_item_fontsizes')
 			.click();
-	   
+
 		desktopHelper.selectFromListbox('22');
-  
+
 		impressHelper.triggerNewSVGForShapeInTheCenter();
-	   
+
 		cy.get('.leaflet-pane.leaflet-overlay-pane g.Page .TextShape .TextParagraph')
 			.should('have.attr', 'font-size', '776px');
 	});
 
-	it('Apply left/right alignment on text seleced text.', function() {
+	it('Apply left/right alignment on selected text.', function() {
 		cy.get('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition')
 			.should('have.attr', 'x', '1400');
 

--- a/kit/SetupKitEnvironment.hpp
+++ b/kit/SetupKitEnvironment.hpp
@@ -15,20 +15,23 @@
 inline void setupKitEnvironment(const std::string& userInterface)
 {
     // Setup & check environment
-    const std::string layers(
+    std::string layers(
         "xcsxcu:${BRAND_BASE_DIR}/share/registry "
         "res:${BRAND_BASE_DIR}/share/registry "
         "bundledext:${${BRAND_BASE_DIR}/program/lounorc:BUNDLED_EXTENSIONS_USER}/registry/com.sun.star.comp.deployment.configuration.PackageRegistryBackend/configmgr.ini "
         "sharedext:${${BRAND_BASE_DIR}/program/lounorc:SHARED_EXTENSIONS_USER}/registry/com.sun.star.comp.deployment.configuration.PackageRegistryBackend/configmgr.ini "
         "userext:${${BRAND_BASE_DIR}/program/lounorc:UNO_USER_PACKAGES_CACHE}/registry/com.sun.star.comp.deployment.configuration.PackageRegistryBackend/configmgr.ini "
-#ifdef IOS
-        "user:*${BRAND_BASE_DIR}/loolkitconfig.xcu "
-#elif ENABLE_DEBUG && !defined(ANDROID) // '*' denotes non-writable.
-        "user:*file://" DEBUG_ABSSRCDIR "/loolkitconfig.xcu "
-#else
-        "user:*file://" LOOLWSD_CONFIGDIR "/loolkitconfig.xcu "
-#endif
         );
+#ifdef IOS
+    layers += "user:*${BRAND_BASE_DIR}/loolkitconfig.xcu ";
+#elif ENABLE_DEBUG && !defined(ANDROID) // '*' denotes non-writable.
+    layers += "user:*file://" DEBUG_ABSSRCDIR "/loolkitconfig.xcu ";
+#else
+    if(::getenv("LOOLKITCONFIG_XCU"))
+        layers += "user:*file://" + std::string(::getenv("LOOLKITCONFIG_XCU")) + " ";
+    else
+        layers += "user:*file://" LOOLWSD_CONFIGDIR "/loolkitconfig.xcu ";
+#endif
     ::setenv("CONFIGURATION_LAYERS", layers.c_str(),
              1 /* override */);
 


### PR DESCRIPTION
e.g. in case of CODE AppImage, that is built from packages,
/etc/loolwsd/loolkitconfig.xcu will not be good, the good
location is within the AppImage's file system.

Signed-off-by: Andras Timar <andras.timar@collabora.com>
Change-Id: Ie2bf56cd95781c193a0e7185bd96d40c4849d920


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

