### PR TITLE
Don't show the cell cursor of another view too eagerly when it could …

### DIFF
--- a/loleaflet/src/control/Parts.js
+++ b/loleaflet/src/control/Parts.js
@@ -54,7 +54,12 @@ L.Map.include({
 		});
 
 		docLayer.eachView(docLayer._viewCursors, docLayer._onUpdateViewCursor, docLayer);
-		docLayer.eachView(docLayer._cellViewCursors, docLayer._onUpdateCellViewCursor, docLayer);
+
+		// We do not want to call _onUpdateCellViewCursor to update the cell view cursors of
+		// other views as we at this stage don't yet know the geometry of the sheet we are
+		// switching to, I think.
+		// docLayer.eachView(docLayer._cellViewCursors, docLayer._onUpdateCellViewCursor, docLayer);
+
 		docLayer.eachView(docLayer._graphicViewMarkers, docLayer._onUpdateGraphicViewSelection, docLayer);
 		docLayer.eachView(docLayer._viewSelections, docLayer._onUpdateTextViewSelection, docLayer);
 		docLayer._clearSelections(calledFromSetPartHandler);

--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -924,7 +924,6 @@ L.Socket = L.Class.extend({
 		var delayed = false;
 		if (textMsg.startsWith('window:') ||
 			textMsg.startsWith('celladdress:') ||
-			textMsg.startsWith('cellviewcursor:') ||
 			textMsg.startsWith('statechanged:') ||
 			textMsg.startsWith('invalidatecursor:') ||
 			textMsg.startsWith('viewinfo:')) {

--- a/loleaflet/src/layer/tile/CalcTileLayer.js
+++ b/loleaflet/src/layer/tile/CalcTileLayer.js
@@ -290,7 +290,6 @@ L.CalcTileLayer = BaseTileLayer.extend({
 			];
 
 			var otherViewTypes = [
-				'cellviewcursor',
 				'textviewselection',
 				'invalidateviewcursor',
 				'graphicviewselection',


### PR DESCRIPTION
…be wrong

The cell cursor displayed for another participant if they are on
another sheet is wrong anyway when we switch to that sheet. Fixing
that is too complicated for now.

A perfect fix for the related problems would require describing the
geometry of each sheet to all clients as necessary. The
.uno:SheetGeometryData data would need to be re-engineered to cover
all sheets, not just the "current" one. (Whenever some protocol uses
an implied "current" something, it seems to cause problems sooner or
later.)

Plus the handling of all that would then need re-work here in online
of course, while ideally keeping compatibility with a server that
doesn't yet have the corresponding change.

This reverts commit d11bea88f862eddb1e9ecf65dbaf0fd23fa89881.

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: Ic0f94a289a264065c381e051872e067bffa5ad9f


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

