### PR TITLE
update unocommands script: don't replace characters

### DIFF
--- a/scripts/unocommands.py
+++ b/scripts/unocommands.py
@@ -37,12 +37,6 @@ Update the translations of unocommands.js before releasing:
     print(message.format(program = sys.argv[0]))
     exit(1)
 
-# Replace characters which are not allowed as keys in JS
-def cleanSpecialCharacters(command):
-    clean = re.sub('\.', '_', command)
-    clean = re.sub('-', '_', clean)
-    return clean
-
 # Extract uno commands name from lines like "  'Command1', 'Command2',"
 def commandsFromLine(line):
     commands = []
@@ -273,7 +267,7 @@ def writeUnocommandsJS(onlineDir, lofficeDir, menuCommands, contextCommands, too
 var unoCommandsArray = {\n''')
 
     for key in sorted(descriptions.keys()):
-        f.write('\t' + cleanSpecialCharacters(key) + ':{')
+        f.write('\t\'' + key + '\':{')
         for type in sorted(descriptions[key].keys()):
             f.write(type + ':{')
             for menuType in sorted(descriptions[key][type].keys()):
@@ -285,8 +279,6 @@ var unoCommandsArray = {\n''')
 
 window._UNO = function(string, component, isContext) {
 \tvar command = string.substr(5);
-\tcommand = command.replace(/\./g, '_');
-\tcommand = command.replace(/\-/g, '_');
 \tvar context = 'menu';
 \tif (isContext === true) {
 \t\tcontext = 'context';
@@ -332,7 +324,7 @@ def parseUnocommandsJS(onlineDir):
     f = open(onlineDir + '/loleaflet/src/unocommands.js', 'r', encoding='utf-8')
     readingCommands = False
     for line in f:
-        m = re.match(r"\t([^:]*):.*", line)
+        m = re.match(r"\t\'([^:]*)\':.*", line)
         if m:
             command = m.group(1)
 
@@ -421,9 +413,9 @@ if __name__ == "__main__":
         processedCommands = set(parsed.keys())
     else:
         written = writeUnocommandsJS(onlineDir, lofficeDir, menuCommands, contextCommands, toolbarCommands)
-        processedCommands = set([cleanSpecialCharacters(key) for key in written.keys()])
+        processedCommands = set(written.keys())
 
-    requiredCommands = set([cleanSpecialCharacters(key) for key in (menuCommands | contextCommands | toolbarCommands)])
+    requiredCommands = (menuCommands | contextCommands | toolbarCommands)
 
     # check that we have translations for everything
     dif = requiredCommands - processedCommands


### PR DESCRIPTION
use original names as it is required for pulling translations

Change-Id: I0b679d0802afcfacc7db8cb56a08254749811bc1
Signed-off-by: Szymon Kłos <szymon.klos@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

