### PR TITLE
wsd: userName is optional

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1419,7 +1419,7 @@ private:
             Poco::Dynamic::Var var = parser.parse(renderOpts);
             renderOptsObj = var.extract<Object::Ptr>();
         }
-        else if (!userName.empty())
+        else
         {
             renderOptsObj = new Object();
         }
@@ -1431,11 +1431,9 @@ private:
             renderOptsObj->set(".uno:Author", makePropertyValue("string", userName));
         }
 
-        if (!spellOnline.empty())
-        {
-            bool bSet = (spellOnline != "false");
-            renderOptsObj->set(".uno:SpellOnline", makePropertyValue("boolean", bSet));
-        }
+        // By default we enable spell-checking, unless it's disabled explicitly.
+        const bool bSet = (spellOnline != "false");
+        renderOptsObj->set(".uno:SpellOnline", makePropertyValue("boolean", bSet));
 
         if (renderOptsObj)
         {

--- a/loleaflet/js/global.js
+++ b/loleaflet/js/global.js
@@ -784,7 +784,9 @@
 				}
 				if (window.isLocalStorageAllowed) {
 					var spellOnline = window.localStorage.getItem('SpellOnline');
-					msg += ' spellOnline=' +  spellOnline;
+					if (spellOnline) {
+						msg += ' spellOnline=' + spellOnline;
+					}
 				}
 				global.socket.send(msg);
 			}

--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -206,7 +206,9 @@ L.Socket = L.Class.extend({
 		}
 		if (window.isLocalStorageAllowed) {
 			var spellOnline = window.localStorage.getItem('SpellOnline');
-			msg += ' spellOnline=' +  spellOnline;
+			if (spellOnline) {
+				msg += ' spellOnline=' + spellOnline;
+			}
 		}
 
 		this._doSend(msg);


### PR DESCRIPTION
This resolves a dependency on userName
(a.k.a. UserFriendlyName) that was a source
of issues when missing.

It turns out that when it's missing but
spellOnline is set, an edge-case caused
an exception that failed loading.

The spellOnline value, in its turn, was
incorrectly set to "null" when in fact
it was missing. This resulted in online
spell-checking being active by default.
Perhaps this was intentional, but here
we don't change this behavior at all.
Instead, we avoid sending "null" when
it's missing, and by default we always
enable online spell-checking, unless
it is explicitly set to "false".

This way, the exception is not thrown
and spellOnline doesn't have invalid
values, while preserving the current
behavior.

Change-Id: I4a09ac44ff5d6147c715afa0fb34af9650da4afd
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
