### PR TITLE
Partly revert cb27d2c ..

### DIFF
--- a/loleaflet/css/menubar.css
+++ b/loleaflet/css/menubar.css
@@ -71,7 +71,7 @@
 }
 .main-nav.hasnotebookbar:not(.readonly) {
 	background: var(--gray-bg-color);
-	margin-top: 0px;
+	margin: 0px;
 }
 
 /* Customizations to sm-simple theme to make it look like LO menu, lo-menu class */

--- a/loleaflet/css/notebookbar.css
+++ b/loleaflet/css/notebookbar.css
@@ -183,7 +183,7 @@
 	overflow-y: hidden;
 	scrollbar-width: none; /* Firefox */
 	-ms-overflow-style: none;  /* Internet Explorer 10+ */
-	display: table;
+	display: block;
 	height: 84px;
 }
 


### PR DESCRIPTION
- Fix #1395
- This was also affecting iPad
- Overflow property doesn't apply to some table elements like table grouping and containers by default.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I2e12c3cb1e5e2ced16748e79063774502c670946
