### PR TITLE
wsd: download templates by wsd

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -628,7 +628,7 @@ bool ChildSession::loadDocument(const char * /*buffer*/, int /*length*/, const S
     }
 #endif
 
-    const bool loaded = _docManager->onLoad(getId(), getJailedFilePathAnonym(), renderOpts, doctemplate);
+    const bool loaded = _docManager->onLoad(getId(), getJailedFilePathAnonym(), renderOpts);
     if (!loaded || _viewId < 0)
     {
         LOG_ERR("Failed to get LoKitDocument instance for [" << getJailedFilePathAnonym() << "].");

--- a/kit/ChildSession.hpp
+++ b/kit/ChildSession.hpp
@@ -36,8 +36,7 @@ public:
     /// Request loading a document, or a new view, if one exists.
     virtual bool onLoad(const std::string& sessionId,
                         const std::string& uriAnonym,
-                        const std::string& renderOpts,
-                        const std::string& docTemplate) = 0;
+                        const std::string& renderOpts) = 0;
 
     /// Unload a client session, which unloads the document
     /// if it is the last and only.

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -932,8 +932,7 @@ private:
     /// Load a document (or view) and register callbacks.
     bool onLoad(const std::string& sessionId,
                 const std::string& uriAnonym,
-                const std::string& renderOpts,
-                const std::string& docTemplate) override
+                const std::string& renderOpts) override
     {
         std::unique_lock<std::mutex> lock(_mutex);
 
@@ -967,7 +966,7 @@ private:
 
         try
         {
-            if (!load(session, renderOpts, docTemplate))
+            if (!load(session, renderOpts))
                 return false;
         }
         catch (const std::exception &exc)
@@ -1207,8 +1206,7 @@ private:
     }
 
     std::shared_ptr<lok::Document> load(const std::shared_ptr<ChildSession>& session,
-                                        const std::string& renderOpts,
-                                        const std::string& docTemplate)
+                                        const std::string& renderOpts)
     {
         const std::string sessionId = session->getId();
 
@@ -1250,7 +1248,7 @@ private:
             _jailedUrl = uri;
             _isDocPasswordProtected = false;
 
-            const char *pURL = docTemplate.empty() ? uri.c_str() : docTemplate.c_str();
+            const char *pURL = uri.c_str();
             LOG_DBG("Calling lokit::documentLoad(" << FileUtil::anonymizeUrl(pURL) << ", \"" << options << "\").");
             const auto start = std::chrono::system_clock::now();
             _loKitDocument.reset(_loKit->documentLoad(pURL, options.c_str()));

--- a/test/UnitWOPITemplate.cpp
+++ b/test/UnitWOPITemplate.cpp
@@ -43,7 +43,7 @@ public:
             Poco::LocalDateTime now;
             Poco::JSON::Object::Ptr fileInfo = new Poco::JSON::Object();
             fileInfo->set("BaseFileName", "test.odt");
-            fileInfo->set("TemplateSource", std::string("http://127.0.0.1:") + std::to_string(ClientPortNumber) + "/test.ott"); // must be http, otherwise Neon in the core complains
+            fileInfo->set("TemplateSource", helpers::getTestServerURI() + "/test.ott");
             fileInfo->set("Size", getFileContent().size());
             fileInfo->set("Version", "1.0");
             fileInfo->set("OwnerId", "test");

--- a/test/WhiteBoxTests.cpp
+++ b/test/WhiteBoxTests.cpp
@@ -605,8 +605,7 @@ public:
 
     bool onLoad(const std::string& /*sessionId*/,
                 const std::string& /*uriAnonym*/,
-                const std::string& /*renderOpts*/,
-                const std::string& /*docTemplate*/) override
+                const std::string& /*renderOpts*/) override
     {
         return false;
     }

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -888,13 +888,21 @@ std::string WopiStorage::loadStorageFileToLocal(const Authorization& auth,
 {
     if (!templateUri.empty())
     {
-        // template are created in kit process, so just obtain a reference
-        setRootFilePath(Poco::Path(getLocalRootPath(), getFileInfo().getFilename()).toString());
-        setRootFilePathAnonym(LOOLWSD::anonymizeUrl(getRootFilePath()));
-        LOG_INF("Template reference " << getRootFilePathAnonym());
+        // Download the template file and load it normally.
+        // The document will get saved once loading in Core is complete.
+        const std::string templateUriAnonym = LOOLWSD::anonymizeUrl(templateUri);
+        try
+        {
+            LOG_INF("WOPI::GetFile template source: " << templateUriAnonym);
+            return downloadDocument(Poco::URI(templateUri), templateUriAnonym, auth, cookies);
+        }
+        catch (const std::exception& ex)
+        {
+            LOG_ERR("Could not download template from [" + templateUriAnonym + "]. Error: "
+                    << ex.what());
+        }
 
-        setLoaded(true);
-        return Poco::Path(getJailPath(), getFileInfo().getFilename()).toString();
+        return std::string();
     }
 
     // First try the FileUrl, if provided.


### PR DESCRIPTION
Templates were downloaded by Core
upon loading. This works fine, as
long as there is no special network
setup in loolwsd. However, when
loolwsd has a complex network setup,
such as when using reverse proxies,
Core wouldn't know about the details
and would likely fail to download
the template.

Luckily, there is no reason to rely
on Core for downloading templates.
Instead, we download it in loolwsd,
just like any other document, and
load it in Core as normal. The
remaining post-load saving of
templates remain unchanged.

Change-Id: Ib22ada4ae469863d5e5c8baeee27f667f7cd40ff
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
