### PR TITLE
wsd: Save -> Upload in StorageManager

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1025,7 +1025,7 @@ void DocumentBroker::uploadToStorageInternal(const std::string& sessionId, bool 
     if (!success && result == "unmodified" && !isRename && !force)
     {
         LOG_DBG("Skipped uploading as document [" << _docKey << "] was not modified.");
-        _storageManager.markLastSaveTime(); // Mark that the storage is up-to-date.
+        _storageManager.markLastUploadTime(); // Mark that the storage is up-to-date.
         broadcastSaveResult(true, "unmodified");
         _poll->wakeup();
         return;
@@ -1120,7 +1120,7 @@ void DocumentBroker::handleUploadToStorageResponse(const StorageUploadDetails& d
         {
             // Saved and stored; update flags.
             _saveManager.setLastModifiedTime(details.newFileModifiedTime);
-            _storageManager.markLastSaveTime();
+            _storageManager.markLastUploadTime();
 
             // Save the storage timestamp.
             _storageManager.setLastModifiedTime(_storage->getFileInfo().getModifiedTime());
@@ -1367,7 +1367,7 @@ bool DocumentBroker::autoSave(const bool force, const bool dontSaveIfUnmodified)
         const std::chrono::milliseconds inactivityTimeMs
             = std::chrono::duration_cast<std::chrono::milliseconds>(now - _lastActivityTime);
         const auto timeSinceLastSaveMs = std::chrono::duration_cast<std::chrono::milliseconds>(
-            now - _storageManager.getLastSaveTime());
+            now - _storageManager.getLastUploadTime());
         LOG_TRC("Time since last save of docKey [" << _docKey << "] is " << timeSinceLastSaveMs
                                                    << " and most recent activity was "
                                                    << inactivityTimeMs << " ago.");
@@ -2617,7 +2617,7 @@ void DocumentBroker::dumpState(std::ostream& os)
     os << "\n  doc id: " << _docId;
     os << "\n  num sessions: " << _sessions.size();
     os << "\n  thread start: " << Util::getSteadyClockAsString(_threadStart);
-    os << "\n  last saved: " << Util::getSteadyClockAsString(_storageManager.getLastSaveTime());
+    os << "\n  last saved: " << Util::getSteadyClockAsString(_storageManager.getLastUploadTime());
     os << "\n  last save request: "
        << Util::getSteadyClockAsString(_saveManager.lastSaveRequestTime());
     os << "\n  last save response: "

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -722,22 +722,22 @@ private:
     {
     public:
         StorageManager()
-            : _lastSaveTime(RequestManager::now())
+            : _lastUploadTime(RequestManager::now())
             , _lastUploadedFileModifiedTime(std::chrono::system_clock::now())
         {
         }
 
-        /// Marks the last time we attempted to save and upload, regardless of outcome, to now.
-        void markLastSaveTime() { _lastSaveTime = RequestManager::now(); }
+        /// Marks the last time we attempted to upload, regardless of outcome, to now.
+        void markLastUploadTime() { _lastUploadTime = RequestManager::now(); }
+
+        // Gets the last time we attempted to upload.
+        std::chrono::steady_clock::time_point getLastUploadTime() const { return _lastUploadTime; }
 
         /// Returns whether the last upload was successful or not.
         bool lastUploadSuccessful() const { return _request.lastRequestSuccessful(); }
 
         /// Sets whether the last upload was successful or not.
         void setLastUploadResult(bool success) { _request.setLastRequestResult(success); }
-
-        // Gets the last time we attempted to save.
-        std::chrono::steady_clock::time_point getLastSaveTime() const { return _lastSaveTime; }
 
         /// Get the modified-timestamp of the local file on disk we last uploaded.
         std::chrono::system_clock::time_point getLastUploadedFileModifiedTime() const
@@ -767,14 +767,14 @@ private:
         /// Request tracking logic.
         RequestManager _request;
 
-        /// The last time we tried saving and uploading, regardless of
-        /// whether the document was modified and a newer version saved
+        /// The last time we tried uploading, regardless of whether the
+        /// document was modified and a newer version saved
         /// and uploaded or not. In effect, this tracks the time we
         /// synchronized with Storage (i.e. the last time we either uploaded
         /// or had nothing new to upload). It is redundant as it is
         /// equivalent to the larger of 'Last Save Response Time' and
         /// 'Last Storage Response Time', and should be removed.
-        std::chrono::steady_clock::time_point _lastSaveTime;
+        std::chrono::steady_clock::time_point _lastUploadTime;
 
         /// The modified-timestamp of the local file on disk we uploaded last.
         std::chrono::system_clock::time_point _lastUploadedFileModifiedTime;


### PR DESCRIPTION
We use download/upload in the storage
and load/save elsewhere, to avoid confusion.

This renames 'save' to 'upload' in the storage
for consistency.

Change-Id: I9ac991c2b52e2586b97c58db02110ff04bfd17d3
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
