### PR TITLE
cypress: add a test case triggering assert related to sidebar cache.

### DIFF
--- a/cypress_test/integration_tests/desktop/calc/sidebar_dialog_image_caching_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/sidebar_dialog_image_caching_spec.js
@@ -36,4 +36,16 @@ describe('Calc sidebar dialog image caching', function() {
 			cy.wait(500);
 		}
 	});
+
+	it('Keep LOK dialog opened until closing document.', function() {
+		cy.get('#tb_editbar_item_setborderstyle')
+			.click();
+
+		cy.get('.w2ui-tb-image.w2ui-icon.frame13')
+		    .click();
+
+		cy.get('.lokdialog')
+			.should('exist');
+	});
+
 });


### PR DESCRIPTION
This assertion is triggered by interference testing:
make check-interfer-desktop spec=calc/sidebar_dialog_image_caching_spec.js

Signed-off-by: Tamás Zolnai <tamas.zolnai@collabora.com>
Change-Id: Ib16c97d7c45192a493720d028f38eb5efba4346f
