### PR TITLE
Download time tracking

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -182,7 +182,7 @@ DocumentBroker::DocumentBroker(ChildType type,
     _lockCtx(new LockContext()),
     _tileVersion(0),
     _debugRenderedTileCount(0),
-    _wopiLoadDuration(0),
+    _wopiDownloadDuration(0),
     _mobileAppDocId(mobileAppDocId)
 {
     assert(!_docKey.empty());
@@ -924,9 +924,10 @@ bool DocumentBroker::download(const std::shared_ptr<ClientSession>& session, con
     if (wopiStorage != nullptr)
     {
         // Add the time taken to load the file from storage and to check file info.
-        _wopiLoadDuration += getFileCallDurationMs + checkFileInfoCallDurationMs;
-        const std::string msg = "stats: wopiloadduration "
-                                + std::to_string(_wopiLoadDuration.count() / 1000.); // In seconds.
+        _wopiDownloadDuration += getFileCallDurationMs + checkFileInfoCallDurationMs;
+        const auto downloadSecs = _wopiDownloadDuration.count() / 1000.;
+        const std::string msg
+            = "stats: wopiloadduration " + std::to_string(downloadSecs); // In seconds.
         LOG_TRC("Sending to Client [" << msg << "].");
         session->sendTextFrame(msg);
     }
@@ -1533,7 +1534,7 @@ std::size_t DocumentBroker::addSessionInternal(const std::shared_ptr<ClientSessi
     // Tell the admin console about this new doc
     Admin::instance().addDoc(_docKey, getPid(), getFilename(), id, session->getUserName(),
                              session->getUserId(), _childProcess->getSMapsFD());
-    Admin::instance().setDocWopiDownloadDuration(_docKey, _wopiLoadDuration);
+    Admin::instance().setDocWopiDownloadDuration(_docKey, _wopiDownloadDuration);
 #endif
 
     // Add and attach the session.

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -793,10 +793,15 @@ bool DocumentBroker::download(const std::shared_ptr<ClientSession>& session, con
     broadcastLastModificationTime(session);
 
     // Let's download the document now, if not downloaded.
+    std::chrono::milliseconds getFileCallDurationMs = std::chrono::milliseconds::zero();
     if (!_storage->isLoaded())
     {
+        std::chrono::steady_clock::time_point start = std::chrono::steady_clock::now();
         std::string localPath = _storage->downloadStorageFileToLocal(
             session->getAuthorization(), session->getCookies(), *_lockCtx, templateSource);
+
+        getFileCallDurationMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - start);
 
         _docState.setStatus(DocumentState::Status::Loading); // Done downloading.
 
@@ -918,11 +923,10 @@ bool DocumentBroker::download(const std::shared_ptr<ClientSession>& session, con
     // Since document has been loaded, send the stats if its WOPI
     if (wopiStorage != nullptr)
     {
-        // Get the time taken to load the file from storage
-        // Add the time taken to check file info
-        _wopiLoadDuration = wopiStorage->getWopiLoadDuration() + checkFileInfoCallDurationMs;
-        const std::string msg
-            = "stats: wopiloadduration " + std::to_string(_wopiLoadDuration.count() / 1000.); // In seconds.
+        // Add the time taken to load the file from storage and to check file info.
+        _wopiLoadDuration += getFileCallDurationMs + checkFileInfoCallDurationMs;
+        const std::string msg = "stats: wopiloadduration "
+                                + std::to_string(_wopiLoadDuration.count() / 1000.); // In seconds.
         LOG_TRC("Sending to Client [" << msg << "].");
         session->sendTextFrame(msg);
     }

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -924,7 +924,7 @@ private:
     std::chrono::steady_clock::time_point _lastActivityTime;
     std::chrono::steady_clock::time_point _threadStart;
     std::chrono::milliseconds _loadDuration;
-    std::chrono::milliseconds _wopiLoadDuration;
+    std::chrono::milliseconds _wopiDownloadDuration;
 
     /// Unique DocBroker ID for tracing and debugging.
     static std::atomic<unsigned> DocBrokerId;

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -993,7 +993,6 @@ std::string WopiStorage::downloadDocument(const Poco::URI& uriObject, const std:
     std::istream& rs = psession->receiveResponse(response);
     const std::chrono::milliseconds diff = std::chrono::duration_cast<std::chrono::milliseconds>(
         std::chrono::steady_clock::now() - startTime);
-    _wopiLoadDuration += diff;
 
     Log::StreamLogger logger = Log::trace();
     if (logger.enabled())

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -423,7 +423,6 @@ public:
         TriState getDisableChangeTrackingShow() const { return _disableChangeTrackingShow; }
         TriState getDisableChangeTrackingRecord() const { return _disableChangeTrackingRecord; }
         TriState getHideChangeTrackingControls() const { return _hideChangeTrackingControls; }
-        std::chrono::milliseconds getCallDurationMs() const { return _callDurationMs; }
     private:
         /// User id of the user accessing the file
         std::string _userId;
@@ -487,9 +486,6 @@ public:
         bool _supportsRename;
         /// If user is allowed to rename the document
         bool _userCanRename;
-
-        /// Time it took to call WOPI's CheckFileInfo
-        std::chrono::milliseconds _callDurationMs;
     };
 
     /// Returns the response of CheckFileInfo WOPI call for URI that was

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -364,7 +364,6 @@ public:
     WopiStorage(const Poco::URI& uri, const std::string& localStorePath,
                 const std::string& jailPath)
         : StorageBase(uri, localStorePath, jailPath)
-        , _wopiLoadDuration(std::chrono::milliseconds::zero())
         , _wopiSaveDuration(std::chrono::milliseconds::zero())
         , _reuseCookies(false)
     {
@@ -510,8 +509,7 @@ public:
                                           const std::string& saveAsFilename,
                                           const bool isRename) override;
 
-    /// Total time taken for making WOPI calls during load
-    std::chrono::milliseconds getWopiLoadDuration() const { return _wopiLoadDuration; }
+    /// Total time taken for making WOPI calls during saving.
     std::chrono::milliseconds getWopiSaveDuration() const { return _wopiSaveDuration; }
 
 protected:
@@ -545,8 +543,7 @@ private:
     /// A URl provided by the WOPI host to use for GetFile.
     std::string _fileUrl;
 
-    // Time spend in loading the file from storage
-    std::chrono::milliseconds _wopiLoadDuration;
+    // Time spend in saving the file from storage
     std::chrono::milliseconds _wopiSaveDuration;
     /// Whether or not to re-use cookies from the browser for the WOPI requests.
     bool _reuseCookies;


### PR DESCRIPTION
This fixes the time-tracking of the download stage and simplifies the code a little.

- wsd: actually compute the CheckFileInfo duration
- wsd: correct GetFile duration tracking
- wsd: wopiLoadDuration -> wopiDownloadDuration
