### PR TITLE
CanvasSectionContainer: Improve anchor property.

### DIFF
--- a/loleaflet/src/control/Control.ColumnGroup.js
+++ b/loleaflet/src/control/Control.ColumnGroup.js
@@ -15,10 +15,10 @@
 
 L.Control.ColumnGroup = L.Control.GroupBase.extend({
 	name: L.CSections.ColumnGroup.name,
-	anchor: ['top', 'left'],
-	position: [350 * window.devicePixelRatio, 0], // Set its initial position to somewhere blank. Other sections shouldn't cover this point after initializing.
-	size: [0, 0], // No initial width is necessary. Height is computed inside update function.
-	expand: ['left', 'right'], // Expand vertically.
+	anchor: ['top', [L.CSections.CornerGroup.name, 'right', 'left']],
+	position: [0, 0], // This section's myTopLeft is placed according to corner group section if exists, if not, this is placed at (0, 0).
+	size: [0, 0], // No initial width is necessary. Width will be expanded. Height is computed inside update function.
+	expand: ['left', 'right'], // Expand horizontally.
 	processingOrder: L.CSections.ColumnGroup.processingOrder,
 	drawingOrder: L.CSections.ColumnGroup.drawingOrder,
 	zIndex: L.CSections.ColumnGroup.zIndex,
@@ -50,10 +50,6 @@ L.Control.ColumnGroup = L.Control.GroupBase.extend({
 
 		// Calculate width on the fly.
 		this.size[1] = this._computeSectionHeight();
-
-		// Because this section's width is calculated on the fly, ColumnHeader and CornerHeader sections should be shifted.
-		this.containerObject.getSectionWithName(L.CSections.ColumnHeader.name).position[1] = this.size[1] + Math.round(this.dpiScale);
-		this.containerObject.getSectionWithName(L.CSections.CornerHeader.name).position[1] = this.size[1] + Math.round(this.dpiScale);
 
 		this._cornerHeaderWidth = this.containerObject.getSectionWithName(L.CSections.CornerHeader.name).size[0];
 

--- a/loleaflet/src/control/Control.ColumnHeader.js
+++ b/loleaflet/src/control/Control.ColumnHeader.js
@@ -6,10 +6,10 @@
 /* global _UNO */
 L.Control.ColumnHeader = L.Control.Header.extend({
 	name: L.CSections.ColumnHeader.name,
-	anchor: ['top', 'left'],
-	position: [250 * window.devicePixelRatio, 0], // Set its initial position to somewhere blank. Other sections shouldn't cover this point after initializing.
-	size: [0, 19 * window.devicePixelRatio], // No initial height is necessary.
-	expand: ['left', 'right'], // Expand vertically.
+	anchor: [[L.CSections.ColumnGroup.name, 'bottom', 'top'], [L.CSections.CornerHeader.name, 'right', 'left']],
+	position: [0, 0], // This section's myTopLeft is placed according to corner header and column group sections.
+	size: [0, 19 * window.devicePixelRatio], // No initial width is necessary.
+	expand: ['left', 'right'], // Expand horizontally.
 	processingOrder: L.CSections.ColumnHeader.processingOrder,
 	drawingOrder: L.CSections.ColumnHeader.drawingOrder,
 	zIndex: L.CSections.ColumnHeader.zIndex,

--- a/loleaflet/src/control/Control.CornerGroup.js
+++ b/loleaflet/src/control/Control.CornerGroup.js
@@ -41,18 +41,18 @@ L.Control.CornerGroup = L.Class.extend({
 	},
 
 	update: function () {
-		// Below 2 sections exist, unless they are being removed.
+		// Below 2 sections exist (since this section is added), unless they are being removed.
 
 		var rowGroupSection = this.containerObject.getSectionWithName(L.CSections.RowGroup.name);
 		if (rowGroupSection) {
-			rowGroupSection.update();
-			this.size[0] = rowGroupSection._computeSectionWidth();
+			rowGroupSection.update(); // This will update its size.
+			this.size[0] = rowGroupSection.size[0];
 		}
 
 		var columnGroupSection = this.containerObject.getSectionWithName(L.CSections.ColumnGroup.name);
 		if (columnGroupSection) {
-			columnGroupSection.update();
-			this.size[1] = columnGroupSection._computeSectionHeight();
+			columnGroupSection.update(); // This will update its size.
+			this.size[1] = columnGroupSection.size[1];
 		}
 	},
 

--- a/loleaflet/src/control/Control.CornerHeader.js
+++ b/loleaflet/src/control/Control.CornerHeader.js
@@ -10,8 +10,8 @@
 /* global $ */
 L.Control.CornerHeader = L.Class.extend({
 	name: L.CSections.CornerHeader.name,
-	anchor: ['top', 'left'],
-	position: [0, 0],
+	anchor: [[L.CSections.ColumnGroup.name, 'bottom', 'top'], [L.CSections.RowGroup.name, 'right', 'left']],
+	position: [0, 0], // If column group or row group sections exist, myTopleft will be set according to their positions.
 	size: [48 * window.devicePixelRatio, 19 * window.devicePixelRatio], // These values are static.
 	expand: [''], // Don't expand.
 	processingOrder: L.CSections.CornerHeader.processingOrder,

--- a/loleaflet/src/control/Control.RowGroup.js
+++ b/loleaflet/src/control/Control.RowGroup.js
@@ -15,9 +15,9 @@
 
 L.Control.RowGroup = L.Control.GroupBase.extend({
 	name: L.CSections.RowGroup.name,
-	anchor: ['top', 'left'],
-	position: [0, 350 * window.devicePixelRatio], // Set its initial position to somewhere blank. Other sections shouldn't cover this point after initializing.
-	size: [0, 0], // No initial height is necessary. Width is computed inside update function.
+	anchor: [[L.CSections.CornerGroup.name, 'bottom', 'top'], 'left'],
+	position: [0, 0], // This section's myTopLeft is placed according to corner group section if exists, if not, this is placed at (0, 0).
+	size: [0, 0], // No initial height is necessary. Height will be expanded. Width is computed inside update function.
 	expand: ['top', 'bottom'], // Expand vertically.
 	processingOrder: L.CSections.RowGroup.processingOrder,
 	drawingOrder: L.CSections.RowGroup.drawingOrder,
@@ -50,10 +50,6 @@ L.Control.RowGroup = L.Control.GroupBase.extend({
 
 		// Calculate width on the fly.
 		this.size[0] = this._computeSectionWidth();
-
-		// Because this section's width is calculated on the fly, RowHeader and CornerHeader sections should be shifted.
-		this.containerObject.getSectionWithName(L.CSections.RowHeader.name).position[0] = this.size[0] + Math.round(this.dpiScale);
-		this.containerObject.getSectionWithName(L.CSections.CornerHeader.name).position[0] = this.size[0] + Math.round(this.dpiScale);
 
 		this._cornerHeaderHeight = this.containerObject.getSectionWithName(L.CSections.CornerHeader.name).size[1];
 

--- a/loleaflet/src/control/Control.RowHeader.js
+++ b/loleaflet/src/control/Control.RowHeader.js
@@ -6,8 +6,8 @@
 /* global _UNO */
 L.Control.RowHeader = L.Control.Header.extend({
 	name: L.CSections.RowHeader.name,
-	anchor: ['top', 'left'],
-	position: [0, 250 * window.devicePixelRatio], // Set its initial position to somewhere blank. Other sections shouldn't cover this point after initializing.
+	anchor: [[L.CSections.CornerHeader.name, 'bottom', 'top'], [L.CSections.RowGroup.name, 'right', 'left']],
+	position: [0, 0], // This section's myTopLeft is placed according to corner header and row group sections.
 	size: [48 * window.devicePixelRatio, 0], // No initial height is necessary.
 	expand: ['top', 'bottom'], // Expand vertically.
 	processingOrder: L.CSections.RowHeader.processingOrder,

--- a/loleaflet/src/layer/tile/CanvasSectionProps.js
+++ b/loleaflet/src/layer/tile/CanvasSectionProps.js
@@ -39,10 +39,10 @@ L.CSections.CornerHeader.processingOrder =			30; // Calc.
 L.CSections.RowHeader.processingOrder =				40; // Calc.
 L.CSections.ColumnHeader.processingOrder =			50; // Calc.
 L.CSections.Tiles.processingOrder = 				60; // Writer & Impress & Calc.
-L.CSections.Overlays.processingOrder =				60; // Writer & Impress & Calc. This is bound to tiles, processingOrder is not important.
-L.CSections.Debug.TilePixelGrid.processingOrder = 	60; // Writer & Impress & Calc. This is bound to tiles, processingOrder is not important.
-L.CSections.CalcGrid.processingOrder = 				60; // Calc. This is bound to tiles, processingOrder is not important.
-L.CSections.Debug.Splits.processingOrder = 			60; // Calc. This is bound to tiles, processingOrder is not important.
+L.CSections.Overlays.processingOrder =				61; // Writer & Impress & Calc. This is bound to tiles.
+L.CSections.Debug.TilePixelGrid.processingOrder = 	62; // Writer & Impress & Calc. This is bound to tiles.
+L.CSections.CalcGrid.processingOrder = 				63; // Calc. This is bound to tiles.
+L.CSections.Debug.Splits.processingOrder = 			64; // Calc. This is bound to tiles.
 
 
 L.CSections.CalcGrid.drawingOrder = 				4; // Calc.

--- a/loleaflet/src/layer/tile/TilesSection.ts
+++ b/loleaflet/src/layer/tile/TilesSection.ts
@@ -15,7 +15,7 @@ class TilesSection {
 	backgroundColor: string = null;
 	borderColor: string = null;
 	boundToSection: string = null;
-	anchor: Array<string> = new Array(0);
+	anchor: Array<any> = new Array(0);
 	position: Array<number> = new Array(0);
 	size: Array<number> = new Array(0);
 	expand: Array<string> = new Array(0);
@@ -32,8 +32,9 @@ class TilesSection {
 
 	constructor () {
 		this.name = L.CSections.Tiles.name;
-		this.anchor = ['top', 'left'];
-		this.position = [200, 200]; // This will be adjusted in "onInitialize" according to dpiScale.
+		// Below anchor list may be expanded. For example, Writer may have ruler section. Then ruler section should also be added here.
+		this.anchor = [[L.CSections.ColumnHeader.name, 'bottom', 'top'], [L.CSections.RowHeader.name, 'right', 'left']];
+		this.position = [0, 0]; // This section's myTopLeft will be anchored to other sections^. No initial position is needed.
 		this.size = [0, 0]; // Going to be expanded, no initial width or height is necessary.
 		this.expand = ['top', 'left', 'bottom', 'right'];
 		this.processingOrder = L.CSections.Tiles.processingOrder;
@@ -47,8 +48,6 @@ class TilesSection {
 	}
 
 	public onInitialize () {
-		this.position = [Math.round(200 * this.dpiScale), Math.round(200 * this.dpiScale)]; // Set its initial position to somewhere blank. Other sections shouldn't cover this point after initializing.
-
 		for (var i = 0; i < 4; i++) {
 			this.offscreenCanvases.push(document.createElement('canvas'));
 			this.oscCtxs.push(this.offscreenCanvases[i].getContext('2d', { alpha: false }));


### PR DESCRIPTION
Now, sections can be anchored to other sections's edges.
One does not need to set approximated initial positions for expandable sections any more.

Signed-off-by: Gökay Şatır <gokay.satir@collabora.com>
Change-Id: Ic012960dedbd937c19c7442cefefdfebdaffafd3


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

