### PR TITLE
Revert "cypress: print out test failure output online during parallel…

### DIFF
--- a/cypress_test/run_parallel.sh
+++ b/cypress_test/run_parallel.sh
@@ -108,9 +108,10 @@ mkdir -p `dirname ${TEST_LOG}`
 touch ${TEST_LOG}
 rm -rf ${TEST_ERROR}
 echo "`echo ${RUN_COMMAND} && ${RUN_COMMAND} || touch ${TEST_ERROR}`" > ${TEST_LOG} 2>&1
-cat ${TEST_LOG}
-if [ -f ${TEST_ERROR} ];
-    then cat ${TEST_LOG} >> ${ERROR_LOG} && \
+if [ ! -f ${TEST_ERROR} ];
+    then cat ${TEST_LOG};
+    else echo -e "Cypress test failed: ${TEST_FILE}\n" && \
+        cat ${TEST_LOG} >> ${ERROR_LOG} && \
         print_error;
 fi;
 


### PR DESCRIPTION
… build."

It can be confusing to have the same error message twice.

This reverts commit 6786f563f84e5142dea47ddcfbbace1400d871aa.

Signed-off-by: Tamás Zolnai <tamas.zolnai@collabora.com>
Change-Id: I66f0495262fc5e5c0a228fdfc417e2e3301ad03e
