### PR TITLE
wsd: revisit log messages DocumentBroker.cpp

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1772,7 +1772,7 @@ std::shared_ptr<ClientSession> DocumentBroker::createNewClientSession(
     }
     catch (const std::exception& exc)
     {
-        LOG_WRN("Exception while preparing session [" << id << "]: " << exc.what());
+        LOG_ERR("Exception while preparing session [" << id << "]: " << exc.what());
     }
 
     return nullptr;
@@ -2422,7 +2422,7 @@ void DocumentBroker::shutdownClients(const std::string& closeReason)
         }
         catch (const std::exception& exc)
         {
-            LOG_WRN("Error while shutting down client [" <<
+            LOG_ERR("Error while shutting down client [" <<
                     session->getName() << "]: " << exc.what());
         }
     }


### PR DESCRIPTION
LOG_FTL = abnormal, crash, denied service
LOG_ERR = load, save, session, connection, wrong parameters
other cases LOG_WRN, LOG_INF

Change-Id: I174a86f48e6b4107d0f846fd9af28a7ab1f62afc
Signed-off-by: Henry Castro <hcastro@collabora.com>
