### PR TITLE
wsd: revisit log messages ClientSession.cpp

### DIFF
--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1387,7 +1387,7 @@ bool ClientSession::handleKitToClientMessage(const char* buffer, const int lengt
         {
             if (errorCommand == "load")
             {
-                LOG_WRN("Document load failed: " << errorKind);
+                LOG_ERR("Document load failed: " << errorKind);
                 if (errorKind == "passwordrequired:to-view" ||
                     errorKind == "passwordrequired:to-modify" ||
                     errorKind == "wrongpassword")
@@ -1415,7 +1415,7 @@ bool ClientSession::handleKitToClientMessage(const char* buffer, const int lengt
             }
             else
             {
-                LOG_WRN(errorCommand << " error failure: " << errorKind);
+                LOG_ERR(errorCommand << " error failure: " << errorKind);
             }
         }
     }
@@ -1971,7 +1971,7 @@ void ClientSession::onDisconnect()
     }
     catch (const std::exception& exc)
     {
-        LOG_WRN(getName() << ": Exception while closing socket for docKey [" << docKey << "]: " << exc.what());
+        LOG_ERR(getName() << ": Exception while closing socket for docKey [" << docKey << "]: " << exc.what());
     }
 }
 


### PR DESCRIPTION
LOG_FTL = abnormal, crash, denied service
LOG_ERR = load, save, session, connection, wrong parameters
other cases LOG_WRN, LOG_INF

Change-Id: I4ab8d04099a432e7fd3fb6810d7a9aa038cbb57d
Signed-off-by: Henry Castro <hcastro@collabora.com>
