### PR TITLE
Replace Poco with http::Request for Synchronous Requests

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -955,7 +955,7 @@ void DocumentBroker::handleSaveResponse(const std::string& sessionId, bool succe
         LOG_INF("Save result from Core (failure): " << result);
 
     // Record that we got a response to avoid timing out on saving.
-    _saveManager.markLastSaveResponseTime();
+    _saveManager.setLastSaveResult(success || result == "unmodified");
 
     uploadToStorage(sessionId, success, result, /*force=*/false);
 }

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -794,7 +794,7 @@ bool DocumentBroker::download(const std::shared_ptr<ClientSession>& session, con
 
     // Let's download the document now, if not downloaded.
     std::chrono::milliseconds getFileCallDurationMs = std::chrono::milliseconds::zero();
-    if (!_storage->isLoaded())
+    if (!_storage->isDownloaded())
     {
         std::chrono::steady_clock::time_point start = std::chrono::steady_clock::now();
         std::string localPath = _storage->downloadStorageFileToLocal(

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -576,7 +576,12 @@ private:
         bool lastRequestSuccessful() const { return _lastRequestSuccessful; }
 
         /// Sets the last request's result, either to success or failure.
-        void setLastRequestResult(bool success) { _lastRequestSuccessful = success; }
+        /// And marks the last response time.
+        void setLastRequestResult(bool success)
+        {
+            markLastResponseTime();
+            _lastRequestSuccessful = success;
+        }
 
         /// Returns true iff there is an active request in progress.
         bool isActive() const { return _lastResponseTime < _lastRequestTime; }

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -379,7 +379,8 @@ std::string LocalStorage::downloadStorageFileToLocal(const Authorization& /*auth
         throw;
     }
 
-    setLoaded(true);
+    setDownloaded(true);
+
     // Now return the jailed path.
 #ifndef KIT_IN_PROCESS
     if (LOOLWSD::NoCapsForKit)
@@ -394,7 +395,6 @@ std::string LocalStorage::downloadStorageFileToLocal(const Authorization& /*auth
 
     // In the mobile app we use no jail
     setRootFilePath(getUri().getPath());
-    setLoaded(true);
 
     return getRootFilePath();
 #endif
@@ -1031,7 +1031,7 @@ std::string WopiStorage::downloadDocument(const Poco::URI& uriObject, const std:
     LOG_INF("WOPI::GetFile downloaded " << filesize << " bytes from [" << uriAnonym << "] -> "
                                         << getRootFilePathAnonym() << " in " << diff.count()
                                         << 's');
-    setLoaded(true);
+    setDownloaded(true);
 
     // Now return the jailed path.
     if (LOOLWSD::NoCapsForKit)

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -649,19 +649,16 @@ std::unique_ptr<WopiStorage::WOPIFileInfo> WopiStorage::getWOPIFileInfo(const Au
     std::chrono::milliseconds callDurationMs;
     try
     {
-        Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET,
-                                       uriObject.getPathAndQuery(),
-                                       Poco::Net::HTTPMessage::HTTP_1_1);
-        initHttpRequest(request, uriObject, auth, cookies);
+        std::shared_ptr<http::Session> httpSession = getHttpSession(uriObject);
+        http::Request httpRequest = initHttpRequest(uriObject, auth, cookies);
 
         const auto startTime = std::chrono::steady_clock::now();
 
-        std::unique_ptr<Poco::Net::HTTPClientSession> psession(getHTTPClientSession(uriObject));
         Log::StreamLogger logger = Log::trace();
         if (logger.enabled())
         {
             logger << "WOPI::CheckFileInfo request header for URI [" << uriAnonym << "]:\n";
-            for (const auto& pair : request)
+            for (const auto& pair : httpRequest.header())
             {
                 logger << '\t' << pair.first << ": " << pair.second << " / ";
             }
@@ -669,33 +666,39 @@ std::unique_ptr<WopiStorage::WOPIFileInfo> WopiStorage::getWOPIFileInfo(const Au
             LOG_END(logger, true);
         }
 
-        psession->sendRequest(request);
+        httpSession->syncRequest(httpRequest);
 
-        Poco::Net::HTTPResponse response;
-        std::istream& rs = psession->receiveResponse(response);
+        std::shared_ptr<const http::Response> httpResponse = httpSession->response();
+
         callDurationMs = std::chrono::duration_cast<std::chrono::milliseconds>(
             std::chrono::steady_clock::now() - startTime);
 
-        Log::StreamLogger logRes = Log::trace();
+        // Note: we don't log the response if obfuscation is enabled, except for failures.
+        wopiResponse = httpResponse->getBody();
+        const bool failed
+            = (httpResponse->statusLine().statusCode() != Poco::Net::HTTPResponse::HTTP_OK);
+
+        Log::StreamLogger logRes = failed ? Log::error() : Log::trace();
         if (logRes.enabled())
         {
-            logRes << "WOPI::CheckFileInfo response header for URI [" << uriAnonym
-                   << "]: " << response.getStatus() << '\n';
-            for (const auto& pair : response)
+            logRes << "WOPI::CheckFileInfo " << (failed ? "failed" : "returned") << " for URI ["
+                   << uriAnonym << "]: " << httpResponse->statusLine().statusCode() << ' '
+                   << httpResponse->statusLine().reasonPhrase() << ". Headers: ";
+            for (const auto& pair : httpResponse->header())
             {
                 logRes << '\t' << pair.first << ": " << pair.second << " / ";
             }
 
+            if (failed)
+                logRes << "\tBody: [" << wopiResponse << "]";
+
             LOG_END(logRes, true);
         }
 
-        if (response.getStatus() != Poco::Net::HTTPResponse::HTTP_OK)
+        if (failed)
         {
-            LOG_ERR("WOPI::CheckFileInfo failed with " << response.getStatus() << ' ' << response.getReason());
-            throw StorageConnectionException("WOPI::CheckFileInfo failed");
+            throw StorageConnectionException("WOPI::CheckFileInfo failed: " + wopiResponse);
         }
-
-        Poco::StreamCopier::copyToString(rs, wopiResponse);
     }
     catch (const Poco::Exception& pexc)
     {

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -22,6 +22,7 @@
 #include "Log.hpp"
 #include "Util.hpp"
 #include <common/Authorization.hpp>
+#include <net/HttpRequest.hpp>
 
 namespace Poco
 {
@@ -258,6 +259,7 @@ public:
 
     static bool allowedWopiHost(const std::string& host);
     static Poco::Net::HTTPClientSession* getHTTPClientSession(const Poco::URI& uri);
+    static std::shared_ptr<http::Session> getHttpSession(const Poco::URI& uri);
 
 protected:
 
@@ -533,6 +535,10 @@ private:
     /// Older Poco versions don't support copying HTTPRequest objects, so we can't generate them.
     void initHttpRequest(Poco::Net::HTTPRequest& request, const Poco::URI& uri,
                          const Authorization& auth, const std::string& cookies) const;
+
+    /// Create an http::Request with the common headers.
+    http::Request initHttpRequest(const Poco::URI& uri, const Authorization& auth,
+                                  const std::string& cookies) const;
 
     /// Download the document from the given URI.
     /// Does not add authorization tokens or any other logic.

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -163,7 +163,7 @@ public:
         _localStorePath(localStorePath),
         _jailPath(jailPath),
         _fileInfo("", "lool", std::chrono::system_clock::time_point(), 0),
-        _isLoaded(false),
+        _isDownloaded(false),
         _forceSave(false),
         _isUserModified(false),
         _isAutosave(false),
@@ -196,9 +196,9 @@ public:
         _jailedFilePathAnonym = newPath;
     }
 
-    void setLoaded(bool loaded) { _isLoaded = loaded; }
+    void setDownloaded(bool loaded) { _isDownloaded = loaded; }
 
-    bool isLoaded() const { return _isLoaded; }
+    bool isDownloaded() const { return _isDownloaded; }
 
     /// Asks the storage object to force overwrite to storage upon next save
     /// even if document turned out to be changed in storage
@@ -274,7 +274,7 @@ private:
     std::string _jailedFilePath;
     std::string _jailedFilePathAnonym;
     FileInfo _fileInfo;
-    bool _isLoaded;
+    bool _isDownloaded;
     bool _forceSave;
 
     /// The document has been modified by the user.


### PR DESCRIPTION
This PR replaces Poco with our new http::Request and family.

- wsd: Loaded -> Downloaded
- wsd: set the result of saving and mark the response time
- wsd: storage: download with http::Request and http::Session
- wsd: storage: GetFileInfo with http::Request
