### PR TITLE
Fix compilation with libc++

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -769,7 +769,7 @@ bool DocumentBroker::download(const std::shared_ptr<ClientSession>& session, con
     {
         // Check if document has been modified by some external action
         LOG_TRC("Document modified time: " << fileInfo.getModifiedTime());
-        constexpr std::chrono::system_clock::time_point Zero;
+        std::chrono::system_clock::time_point Zero;
         if (_storageManager.getLastModifiedTime() != Zero && fileInfo.getModifiedTime() != Zero
             && _storageManager.getLastModifiedTime() != fileInfo.getModifiedTime())
         {


### PR DESCRIPTION
```
wsd/DocumentBroker.cpp:772:57: error: constexpr variable cannot have non-literal type 'const std::chrono::system_clock::time_point' (aka 'const time_point<std::__1::chrono::system_clock>')
        constexpr std::chrono::system_clock::time_point Zero;
                                                        ^
/usr/include/c++/v1/chrono:1355:28: note: 'time_point<std::__1::chrono::system_clock, std::__1::chrono::duration<long long, std::__1::ratio<1, 1000000>>>' is not literal because it is not an aggregate and has no constexpr constructors other than copy or move con
class _LIBCPP_TEMPLATE_VIS time_point
                           ^
```

Signed-off-by: Gleb Popov <6yearold@gmail.com>
Change-Id: I88c5466b8ad104178cf7fa4101f5f5265ccf5e86

### Checklist

- [X] Code is properly formatted
- [X] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

