### PR TITLE
Stopgap measure to avoid iterating over rows to 500001 and columns to…

### DIFF
--- a/loleaflet/src/control/Control.ColumnHeader.js
+++ b/loleaflet/src/control/Control.ColumnHeader.js
@@ -408,7 +408,7 @@ L.Control.ColumnHeader = L.Control.Header.extend({
 		}
 
 		// create data structure for column widths
-		this._tickMap = new L.Control.Header.GapTickMap(this._map, columns);
+		this._tickMap = new L.Control.Header.GapTickMap(this._map, columns, 1024);
 		this._startOffset = this._tickMap.getStartOffset();
 
 		// setup conversion routine

--- a/loleaflet/src/control/Control.RowHeader.js
+++ b/loleaflet/src/control/Control.RowHeader.js
@@ -389,7 +389,7 @@ L.Control.RowHeader = L.Control.Header.extend({
 		}
 
 		// create data structure for row heights
-		this._tickMap = new L.Control.Header.GapTickMap(this._map, rows);
+		this._tickMap = new L.Control.Header.GapTickMap(this._map, rows, 500001);
 		this._startOffset = this._tickMap.getStartOffset();
 
 		// setup conversion routine

--- a/loleaflet/src/layer/CalcGridLines.js
+++ b/loleaflet/src/layer/CalcGridLines.js
@@ -79,7 +79,7 @@ L.CalcGridLines = L.LayerGroup.extend({
 		var pixelToMapUnitRatio = this._map.options.crs.scale(this._map.getZoom());
 
 		if (ev.data.columns && ev.data.columns.length) {
-			ticks = new L.Control.Header.GapTickMap(this._map, ev.data.columns);
+			ticks = new L.Control.Header.GapTickMap(this._map, ev.data.columns, 1024);
 			this._colLines.clearLayers();
 
 			ticks.forEachTick(function(idx, pos) {
@@ -93,7 +93,7 @@ L.CalcGridLines = L.LayerGroup.extend({
 		}
 
 		if (ev.data.rows && ev.data.rows.length) {
-			ticks = new L.Control.Header.GapTickMap(this._map, ev.data.rows);
+			ticks = new L.Control.Header.GapTickMap(this._map, ev.data.rows, 500001);
 			this._rowLines.clearLayers();
 
 			ticks.forEachTick(function(idx, pos) {


### PR DESCRIPTION
… 1024

When the ticks parameter passed to the
L.Control.Header.GapTickMap.initialize() function has a last entry for
"all the rest", don't actually create elements in the knownTicks array
for all of those, but set a flag called _toTheLimit that indicates
that the last element in the array is to be interpreted to cover all
the rest up to the maximum for the data in question. (Row index 500001
or column index 1024.)

For now, that flag is not checked anywhere, but this patch seems to
help avoiding pointless and very time consuming iteration anyway
without any huge negative impact?

Change-Id: I81b6c1175aebb51069cb33d9b136166b06d03459


* Resolves: # <!-- related github issue -->
* Target version: co-4-2 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

