### PR TITLE
kit: enable send LOK_CALLBACK_STATUS_INDICATOR_FINISH

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -792,7 +792,8 @@ public:
             self->setDocumentPassword(type);
             return;
         }
-        else if (type == LOK_CALLBACK_STATUS_INDICATOR_SET_VALUE)
+        else if (type == LOK_CALLBACK_STATUS_INDICATOR_SET_VALUE ||
+                 type == LOK_CALLBACK_STATUS_INDICATOR_FINISH)
         {
             for (auto& it : self->_sessions)
             {


### PR DESCRIPTION
Otherwise the LOK_CALLBACK_STATUS_INDICATOR_FINISH
message is lost, and client side does not receive
it when Macro Security dialog popup.

Change-Id: Ife52c77078160b8cc1075eff9137de2d26b87b55
Signed-off-by: Henry Castro <hcastro@collabora.com>
