### PR TITLE
wsd: set state loaded when "statusindicatorfinish:" received

### DIFF
--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1465,7 +1465,7 @@ bool ClientSession::handleKitToClientMessage(const char* buffer, const int lengt
         {
             assert(false && "Tile traffic should go through the DocumentBroker-LoKit WS.");
         }
-        else if (tokens[0] == "status:")
+        else if (tokens[0] == "status:" || tokens[0] == "statusindicatorfinish:")
         {
             setState(ClientSession::SessionState::LIVE);
             docBroker->setLoaded();


### PR DESCRIPTION
Normally the client session waits for a message
"status:" when the document has loaded to forward
to client side. However, when the document has macros
embedded, and a Macro Warning Security dialog popup
it will never receive the "status:" message.
So it is added "statusindicatorfinish:" to formally set that
the document has loaded.

Change-Id: Id40b853c002403577d7664c4f8206cb5a01403b6
Signed-off-by: Henry Castro <hcastro@collabora.com>
