### PR TITLE
Include the view id in the tunnelled dialog image hash

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -1665,7 +1665,7 @@ bool ChildSession::renderWindow(const char* /*buffer*/, int /*length*/, const St
             << " and rendered in " << totalTime
             << "ms (" << area / elapsed << " MP/s).");
 
-    uint64_t pixmapHash = Png::hashSubBuffer(pixmap.data(), 0, 0, width, height, bufferWidth, bufferHeight);
+    uint64_t pixmapHash = Png::hashSubBuffer(pixmap.data(), 0, 0, width, height, bufferWidth, bufferHeight) + getViewId();
 
     auto found = std::find(_pixmapCache.begin(), _pixmapCache.end(), pixmapHash);
 


### PR DESCRIPTION
Otherwise this will break badly in the collaborative editing (multiple
views) case.

Change-Id: I63d391cb5a7d118c34564c4e1a4df7710b13e90e
Signed-off-by: Tor Lillqvist <tml@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

