### PR TITLE
loleaflet: Postmessage-api: Fix missing tr tag in documentation

### DIFF
--- a/loleaflet/postmessage-api.html
+++ b/loleaflet/postmessage-api.html
@@ -614,6 +614,7 @@ Editor to WOPI host
 		presenting an overlayed dialog.
 		</td>
 	</tr>
+	<tr>
 		<td><code><b>Hide_Ruler</b></code></td>
 		<td></td>
 		<td>


### PR DESCRIPTION
Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I2798b137df43cc322879012a774248fa8185cdec
