### PR TITLE
Better http::Request error handling

### DIFF
--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -744,7 +744,7 @@ public:
         return syncRequestImpl();
     }
 
-    void asyncRequest(const Request& req, SocketPoll& poll)
+    bool asyncRequest(const Request& req, SocketPoll& poll)
     {
         LOG_TRC("asyncRequest");
 
@@ -755,8 +755,15 @@ public:
             LOG_TRC("Connected");
             poll.insertNewSocket(_socket);
         }
+        else if (!_socket)
+        {
+            LOG_ERR("Failed to connect to " << _host << ':' << _port);
+            return false;
+        }
         else
             poll.wakeupWorld();
+
+        return true;
     }
 
 private:

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -441,11 +441,10 @@ public:
     static constexpr const char* HTTP_1_1 = "HTTP/1.1";
     static constexpr const char* OK = "OK";
 
-    StatusLine(const std::string& version = HTTP_1_1, int code = 200,
-               const std::string& reason = OK)
-        : _httpVersion(version)
+    StatusLine(std::string version = HTTP_1_1, int code = 0, std::string reason = std::string())
+        : _httpVersion(std::move(version))
         , _statusCode(code)
-        , _reasonPhrase(reason)
+        , _reasonPhrase(std::move(reason))
     {
     }
 

--- a/net/NetUtil.cpp
+++ b/net/NetUtil.cpp
@@ -22,10 +22,15 @@ std::shared_ptr<StreamSocket>
 connect(const std::string& host, const std::string& port, const bool isSSL,
         const std::shared_ptr<ProtocolHandlerInterface>& protocolHandler)
 {
-    LOG_DBG("Connecting to " << host << ':' << port << " (" << (isSSL ? "SSL" : "Unencrypted")
-                             << ')');
-
     std::shared_ptr<StreamSocket> socket;
+
+    if (host.empty() || port.empty())
+    {
+        LOG_ERR("Invalid host/port " << host << ':' << port);
+        return socket;
+    }
+
+    LOG_DBG("Connecting to " << host << ':' << port << " (" << (isSSL ? "SSL)" : "Unencrypted)"));
 
 #if !ENABLE_SSL
     if (isSSL)

--- a/test/HttpRequestTests.cpp
+++ b/test/HttpRequestTests.cpp
@@ -34,6 +34,7 @@ class HttpRequestTests final : public CPPUNIT_NS::TestFixture
 {
     CPPUNIT_TEST_SUITE(HttpRequestTests);
 
+    CPPUNIT_TEST(testInvalidURI);
     CPPUNIT_TEST(testSimpleGet);
     CPPUNIT_TEST(testSimpleGetSync);
     // CPPUNIT_TEST(test500GetStatuses); // Slow.
@@ -44,6 +45,7 @@ class HttpRequestTests final : public CPPUNIT_NS::TestFixture
 
     CPPUNIT_TEST_SUITE_END();
 
+    void testInvalidURI();
     void testSimpleGet();
     void testSimpleGetSync();
     void test500GetStatuses();
@@ -74,6 +76,27 @@ pocoGet(const std::string& host, const std::string& url)
     }
 
     return std::make_pair(response, responseString);
+}
+
+void HttpRequestTests::testInvalidURI()
+{
+    const char* Host = "";
+    const char* URL = "/";
+
+    http::Request httpRequest(URL);
+
+    auto httpSession = http::Session::createHttp(Host);
+    httpSession->setTimeout(std::chrono::seconds(1));
+    LOK_ASSERT(httpSession->syncRequest(httpRequest) == false);
+
+    const std::shared_ptr<const http::Response> httpResponse = httpSession->response();
+    LOK_ASSERT(httpResponse->done() == false);
+    LOK_ASSERT(httpResponse->state() != http::Response::State::Complete);
+    LOK_ASSERT(httpResponse->statusLine().statusCode() != Poco::Net::HTTPResponse::HTTP_OK);
+    LOK_ASSERT(httpResponse->statusLine().statusCode() == 0);
+    LOK_ASSERT(httpResponse->statusLine().statusCategory()
+               == http::StatusLine::StatusCodeClass::Invalid);
+    LOK_ASSERT(httpResponse->getBody().empty());
 }
 
 void HttpRequestTests::testSimpleGet()

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -1079,8 +1079,7 @@ std::string WopiStorage::downloadDocument(const Poco::URI& uriObject, const std:
     const FileUtil::Stat fileStat(getRootFilePath());
     const std::size_t filesize = (fileStat.good() ? fileStat.size() : 0);
     LOG_INF("WOPI::GetFile downloaded " << filesize << " bytes from [" << uriAnonym << "] -> "
-                                        << getRootFilePathAnonym() << " in " << diff.count()
-                                        << 's');
+                                        << getRootFilePathAnonym() << " in " << diff);
     setDownloaded(true);
 
     // Now return the jailed path.


### PR DESCRIPTION
- wsd: http::StatusLine initialized as invalid
- wsd: fail when trying to connect to an invalid host
- wsd: test: http::Request with invalid host
- wsd: storage: better handling of failed http requests
- wsd: properly log time duration natively
