### PR TITLE
removed a duplicate of if statement in TileLayer.js

### DIFF
--- a/loleaflet/src/layer/tile/TileLayer.js
+++ b/loleaflet/src/layer/tile/TileLayer.js
@@ -777,9 +777,6 @@ L.TileLayer = L.GridLayer.extend({
 			if (this._map._clip)
 				this._map._clip.onComplexSelection(textMsg.substr('complexselection:'.length));
 		}
-		else if (textMsg.startsWith('tile:')) {
-			this._onTileMsg(textMsg, img);
-		}
 		else if (textMsg.startsWith('windowpaint:')) {
 			this._onDialogPaintMsg(textMsg, img);
 		}


### PR DESCRIPTION
Signed-off-by: Bayram Çiçek <mail@bayramcicek.com.tr>
Change-Id: I6c49ff442b1ed11f10802a54c675eca1cbd8a1f7

* Resolves: # 
* Target version: master 

### Summary

Redundant if statement removed according to https://lgtm.com/projects/g/CollaboraOnline/online/snapshot/d45121a0459e03c06ea3afb45d5cb1e38cd9f487/files/loleaflet/src/layer/tile/TileLayer.js?sort=name&dir=ASC&mode=heatmap#L780

### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

