### PR TITLE
wsd: perform post-loading actions only once

### DIFF
--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -294,6 +294,9 @@ public:
     /// Notify that the load has completed
     virtual void setLoaded();
 
+    /// Returns true iff the document had ever loaded (even if it's now unloaded).
+    bool isLoaded() const { return _docState.hadLoaded(); }
+
     /// If not yet locked, try to lock
     bool attemptLock(const ClientSession& session, std::string& failReason);
 
@@ -451,7 +454,6 @@ private:
 
     /// Loads a document from the public URI into the jail.
     bool download(const std::shared_ptr<ClientSession>& session, const std::string& jailId);
-    bool isLoaded() const { return _docState.hadLoaded(); }
 
     std::size_t getIdleTimeSecs() const
     {


### PR DESCRIPTION
Since now we consider "statusindicatorfinish:" as
indication of document loading (in addition to
"status:") we have to avoid performing the
post-loading actions twice.

Specifically, we need to save the document
immediately after loading if it had been
loaded from a template.

Change-Id: I269bab3b76feddaa9e65a51c8d23d7c1f8ad3e02
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
