### PR TITLE
Pan and zoom animation fixes

### DIFF
--- a/loleaflet/mocha_tests/CBounds.test.ts
+++ b/loleaflet/mocha_tests/CBounds.test.ts
@@ -29,3 +29,26 @@ describe('CBounds parse() tests', function () {
 		});
 	});
 });
+
+describe('CBounds fromCompat() tests', function () {
+
+	describe('CBounds.fromCompat() with a CBounds like object', function () {
+		it('should return correct CBounds object', function () {
+			var compatBoundsObj = {
+				min: {
+					x: 34,
+					y: 56
+				},
+				max: {
+					x: 94,
+					y: 76
+				}
+			};
+			assert.ok(CBounds.fromCompat(compatBoundsObj).equals(
+				new CBounds(
+					new CPoint(compatBoundsObj.min.x, compatBoundsObj.min.y),
+					new CPoint(compatBoundsObj.max.x, compatBoundsObj.max.y))
+			));
+		});
+	});
+});

--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -317,6 +317,7 @@ L.TileSectionManager = L.Class.extend({
 		var ctx = this._paintContext();
 		var paneBoundsList = ctx.paneBoundsList;
 		var splitPos = ctx.paneBoundsActive ? this._splitPos.multiplyBy(this._tilesSection.dpiScale) : new L.Point(0, 0);
+		var canvasOverlay = this._layer._canvasOverlay;
 
 		var rafFunc = function () {
 			painter._sectionContainer.setPenPosition(painter._tilesSection);
@@ -349,6 +350,8 @@ L.TileSectionManager = L.Class.extend({
 					// destWidth, destHeight
 					paneSize.x, paneSize.y);
 			}
+
+			canvasOverlay.onDraw();
 
 			painter._zoomRAF = requestAnimationFrame(rafFunc);
 		};

--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -383,6 +383,7 @@ L.TileSectionManager = L.Class.extend({
 			cancelAnimationFrame(this._zoomRAF);
 			this._calcZoomFrameScale(zoom, newCenter);
 			this.rafFunc();
+			cancelAnimationFrame(this._zoomRAF);
 			this._zoomFrameScale = undefined;
 			this._tilesSection.setInZoomAnim(false);
 			this._inZoomAnim = false;

--- a/loleaflet/src/layer/tile/TileLayer.js
+++ b/loleaflet/src/layer/tile/TileLayer.js
@@ -3107,13 +3107,17 @@ L.TileLayer = L.GridLayer.extend({
 
 		if (this._cellResizeMarkerStart === e.target) {
 			this._postSelectTextEvent('start', aMousePosition.x, aMousePosition.y);
-			if (e.type === 'dragend')
+			if (e.type === 'dragend') {
 				this._onUpdateCellResizeMarkers();
+				window.IgnorePanning = undefined;
+			}
 		}
 		else if (this._cellResizeMarkerEnd === e.target) {
 			this._postSelectTextEvent('end', aMousePosition.x, aMousePosition.y);
-			if (e.type === 'dragend')
+			if (e.type === 'dragend') {
 				this._onUpdateCellResizeMarkers();
+				window.IgnorePanning = undefined;
+			}
 		}
 		else if (this._cellAutofillMarker === e.target) {
 			this._postMouseEvent(buttonType, aMousePosition.x, aMousePosition.y, 1, 1, 0);

--- a/loleaflet/src/layer/tile/TilesSection.ts
+++ b/loleaflet/src/layer/tile/TilesSection.ts
@@ -68,13 +68,15 @@ class TilesSection {
 	extendedPaneBounds (paneBounds: any) {
 		var extendedBounds = paneBounds.clone();
 		var halfExtraSize = this.sectionProperties.osCanvasExtraSize / 2; // This is always an integer.
-		if (this.sectionProperties.docLayer.getSplitPanesContext()) {
+		var spCxt = this.sectionProperties.docLayer.getSplitPanesContext();
+		if (spCxt) {
+			var splitPos = spCxt.getSplitPos().multiplyBy(this.dpiScale);
 			if (paneBounds.min.x) { // pane can move in x direction.
-				extendedBounds.min.x = Math.max(0, extendedBounds.min.x - halfExtraSize);
+				extendedBounds.min.x = Math.max(splitPos.x + 1, extendedBounds.min.x - halfExtraSize);
 				extendedBounds.max.x += halfExtraSize;
 			}
 			if (paneBounds.min.y) { // pane can move in y direction.
-				extendedBounds.min.y = Math.max(0, extendedBounds.min.y - halfExtraSize);
+				extendedBounds.min.y = Math.max(splitPos.y + 1, extendedBounds.min.y - halfExtraSize);
 				extendedBounds.max.y += halfExtraSize;
 			}
 		}
@@ -116,8 +118,6 @@ class TilesSection {
 
 			if (extendedBounds.intersects(tileBounds)) {
 				var offset = extendedBounds.getTopLeft();
-				offset.x = Math.min(offset.x, viewBounds.min.x);
-				offset.y = Math.min(offset.y, viewBounds.min.y);
 				this.drawTileInPane(tile, tileBounds, extendedBounds, offset, this.oscCtxs[i]);
 			}
 		}

--- a/loleaflet/src/layer/vector/CBounds.ts
+++ b/loleaflet/src/layer/vector/CBounds.ts
@@ -63,6 +63,13 @@ class CBounds {
 		return rectangles;
 	};
 
+	static fromCompat(bounds: any) : CBounds {
+		return new CBounds(
+			CPoint.fromCompat(bounds.min),
+			CPoint.fromCompat(bounds.max)
+		);
+	}
+
 	// extend the bounds to contain the given point
 	extend(point: CPoint): CBounds {
 

--- a/loleaflet/src/layer/vector/CPath.ts
+++ b/loleaflet/src/layer/vector/CPath.ts
@@ -131,8 +131,6 @@ abstract class CPath {
 		var paneBoundsList: Array<CBounds> = splitPanesContext ?
 			splitPanesContext.getPxBoundList() :
 			[viewBounds];
-		var paneProperties = splitPanesContext ? splitPanesContext.getPanesProperties() :
-			[{ xFixed: false, yFixed: false }];
 
 		for (var i = 0; i < paneBoundsList.length; ++i) {
 			var panePaintArea = paintArea ? paintArea.clone() : paneBoundsList[i].clone();
@@ -149,13 +147,13 @@ abstract class CPath {
 				panePaintArea.max.y = Math.min(panePaintArea.max.y, paneArea.max.y);
 			}
 
-			this.updatePath(panePaintArea, paneProperties[i].xFixed, paneProperties[i].yFixed);
+			this.updatePath(panePaintArea, paneBoundsList[i]);
 		}
 
 		this.updateTestData();
 	}
 
-	updatePath(paintArea?: CBounds, paneXFixed?: boolean, paneYFixed?: boolean) {
+	updatePath(paintArea?: CBounds, paneBounds?: CBounds) {
 		// Overridden in implementations.
 	}
 

--- a/loleaflet/src/layer/vector/CPoint.ts
+++ b/loleaflet/src/layer/vector/CPoint.ts
@@ -28,6 +28,10 @@ class CPoint {
 		return new CPoint(parseInt(pointParts[0]), parseInt(pointParts[1]));
 	};
 
+	static fromCompat(point: any): CPoint {
+		return new CPoint(<number>(point.x), <number>(point.y));
+	}
+
 	clone(): CPoint {
 		return new CPoint(this.x, this.y);
 	}

--- a/loleaflet/src/layer/vector/CPolygon.ts
+++ b/loleaflet/src/layer/vector/CPolygon.ts
@@ -43,7 +43,7 @@ class CPolygon extends CPolyline {
 		return new CPoint(x / area, y / area);
 	}
 
-	updatePath(paintArea?: CBounds, paneXFixed?: boolean, paneYFixed?: boolean) {
+	updatePath(paintArea?: CBounds, paneBounds?: CBounds) {
 
 		this.parts = this.rings;
 
@@ -57,7 +57,7 @@ class CPolygon extends CPolyline {
 		}
 
 		this.simplifyPoints();
-		this.renderer.updatePoly(this, true /* closed? */, paneXFixed, paneYFixed, paintArea);
+		this.renderer.updatePoly(this, true /* closed? */, paintArea, paneBounds);
 	}
 
 	anyRingBoundContains(corePxPoint: CPoint): boolean {

--- a/loleaflet/src/layer/vector/CPolyline.ts
+++ b/loleaflet/src/layer/vector/CPolyline.ts
@@ -142,11 +142,11 @@ class CPolyline extends CPath {
 		return new CBounds(this.bounds.getTopLeft().subtract(p), this.bounds.getBottomRight().add(p));
 	}
 
-	updatePath(paintArea?: CBounds, paneXFixed?: boolean, paneYFixed?: boolean) {
+	updatePath(paintArea?: CBounds, paneBounds?: CBounds) {
 		this.clipPoints(paintArea);
 		this.simplifyPoints();
 
-		this.renderer.updatePoly(this, false /* closed? */, paneXFixed, paneYFixed, paintArea);
+		this.renderer.updatePoly(this, false /* closed? */, paintArea, paneBounds);
 	}
 
 	// clip polyline by renderer bounds so that we have less to render for performance


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
The patchset addresses three zoom animation related issues :
1. A leak of requestAnimationFrame loop after zoom has ended.
2. Absence of overlays like cell cursor and selections etc during animation.
3. Incorrect rendering of freeze panes on pinch zooming.

This also fixes an issue of inability to pan after making an area selection.

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

