### PR TITLE
Revert "kit: enable send LOK_CALLBACK_STATUS_INDICATOR_FINISH"

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -792,8 +792,7 @@ public:
             self->setDocumentPassword(type);
             return;
         }
-        else if (type == LOK_CALLBACK_STATUS_INDICATOR_SET_VALUE ||
-                 type == LOK_CALLBACK_STATUS_INDICATOR_FINISH)
+        else if (type == LOK_CALLBACK_STATUS_INDICATOR_SET_VALUE)
         {
             for (auto& it : self->_sessions)
             {


### PR DESCRIPTION
The commit in question breaks two unit-tests: wopi-template
and copy-paste. Temporarily reverting until the regressions
it introduces are resolved.

This reverts commit be68f06f70ce0acdec688abf1d201b98a367d376.

Change-Id: I1fafd73fdea57077eea05a146b7df0b013e6e8ba
