### PR TITLE
Calc: Fix header rendering.

### DIFF
--- a/loleaflet/src/control/Control.LokDialog.js
+++ b/loleaflet/src/control/Control.LokDialog.js
@@ -420,6 +420,10 @@ L.Control.LokDialog = L.Control.extend({
 				$('#' + strId).remove();
 				this._launchDialog(e.id, null, null, width, height, this._dialogs[parseInt(e.id)].title);
 			}
+			if (this._map._docLayer && this._map._docLayer._docType === 'spreadsheet') {
+				this._map._docLayer._painter._sectionContainer.getSectionWithName(L.CSections.RowHeader.name)._updateCanvas();
+				this._map._docLayer._painter._sectionContainer.getSectionWithName(L.CSections.ColumnHeader.name)._updateCanvas();
+			}
 		} else if (e.action === 'cursor_invalidate') {
 			if (this._isOpen(e.id) && !!e.rectangle) {
 				rectangle = e.rectangle.split(',');


### PR DESCRIPTION
When window is resized, sometimes header drawings aren't updated. This
patch solves that bug.

Signed-off-by: Gökay Şatır <gokay.satir@collabora.com>
Change-Id: I1920435a49662c283e9b691bc02d32865ca401e8


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

