### PR TITLE
Simulate socket errors more reliably

### DIFF
--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -74,11 +74,11 @@ bool StreamSocket::simulateSocketError(bool)
 {
     if ((socketErrorCount++ % 7) == 0)
     {
+        LOG_DBG("Simulating socket error.");
         errno = EAGAIN;
         return true;
     }
 
-    LOG_DBG("Simulating socket error.");
     return false;
 }
 
@@ -87,11 +87,12 @@ bool SslStreamSocket::simulateSocketError(bool read)
 {
     if ((socketErrorCount++ % 7) == 0)
     {
+        LOG_DBG("Simulating socket error.");
         _sslWantsTo = read ? SslWantsTo::Read : SslWantsTo::Write;
+        errno = EAGAIN;
         return true;
     }
 
-    LOG_DBG("Simulating socket error.");
     return false;
 }
 #endif

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -70,11 +70,11 @@ int Socket::createSocket(Socket::Type type)
 #if ENABLE_DEBUG
 static std::atomic<long> socketErrorCount;
 
-bool StreamSocket::simulateSocketError(bool)
+bool StreamSocket::simulateSocketError(bool read)
 {
     if ((socketErrorCount++ % 7) == 0)
     {
-        LOG_DBG("Simulating socket error.");
+        LOG_DBG("Simulating socket error during " << (read ? "read." : "write."));
         errno = EAGAIN;
         return true;
     }
@@ -87,8 +87,9 @@ bool SslStreamSocket::simulateSocketError(bool read)
 {
     if ((socketErrorCount++ % 7) == 0)
     {
-        LOG_DBG("Simulating socket error.");
-        _sslWantsTo = read ? SslWantsTo::Read : SslWantsTo::Write;
+        LOG_DBG("Simulating socket error during " << (read ? "read." : "write."));
+        // Note: maintain the _sslWantsTo state so we poll on
+        // the right event as that requested by the last ssl API.
         errno = EAGAIN;
         return true;
     }


### PR DESCRIPTION
We avoid changing the SSL wantsTo state and instead set EAGAIN in SSL just like we do for the non-SSL, because the error-handling is the same for both cases. We also have correct (and more informative) logging now.

- wsd: set errno when simulating socket errors for SSL
- wsd: socket error simulation to maintain the ssl state
