### PR TITLE
wsd: perform socket writes more efficiently

### DIFF
--- a/common/Session.hpp
+++ b/common/Session.hpp
@@ -100,7 +100,7 @@ public:
     }
 
     // By default rely on the socket buffer.
-    void writeQueuedMessages() override
+    void writeQueuedMessages(std::size_t) override
     {
         assert(false);
     }

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -529,7 +529,7 @@ public:
             // Get the data to write into the socket
             // from the client's callback. This is
             // used to upload files, or other data.
-            char buffer[16 * 1024];
+            char buffer[64 * 1024];
             std::size_t wrote = 0;
             do
             {

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -486,7 +486,7 @@ void SocketPoll::insertNewUnixSocket(
     else
     {
         Buffer buf;
-        req.writeData(buf);
+        req.writeData(buf, INT_MAX); // Write the whole request.
         socket->sendFD(buf.getBlock(), buf.getBlockSize(), shareFD);
     }
 
@@ -616,7 +616,7 @@ bool StreamSocket::send(const http::Response& response)
 
 bool StreamSocket::send(http::Request& request)
 {
-    if (request.writeData(_outBuffer))
+    if (request.writeData(_outBuffer, getSendBufferCapacity()))
     {
         flush();
         return true;

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -1226,7 +1226,7 @@ protected:
         do
         {
             // If we have space for writing and that was requested
-            if ((events & POLLOUT) && _outBuffer.empty())
+            if ((events & POLLOUT) && (static_cast<int>(_outBuffer.size()) < getSendBufferSize()))
                 _socketHandler->performWrites();
 
             // perform the shutdown if we have sent everything.

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -252,17 +252,6 @@ public:
 #endif
     }
 
-    /// The available number of bytes in the socket
-    /// buffer for an optimal transmition.
-    int getSendBufferCapacity() const
-    {
-#if !MOBILEAPP
-        return _sendBufferSize * 6;
-#else
-        return INT_MAX; // We want to always send a single record in one go
-#endif
-    }
-
 #if !MOBILEAPP
     /// Sets the receive buffer size in bytes.
     /// Note: TCP will allocate twice this size for admin purposes,
@@ -1194,6 +1183,18 @@ public:
 
     bool processInputEnabled() const { return _inputProcessingEnabled; }
     void enableProcessInput(bool enable = true){ _inputProcessingEnabled = enable; }
+
+    /// The available number of bytes in the socket
+    /// buffer for an optimal transmition.
+    int getSendBufferCapacity() const
+    {
+#if !MOBILEAPP
+        const int capacity = getSendBufferSize();
+        return std::max<int>(0, capacity - _outBuffer.size());
+#else
+        return INT_MAX; // We want to always send a single record in one go
+#endif
+    }
 
 protected:
 

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -213,8 +213,9 @@ public:
         _sendBufferSize = getSocketBufferSize();
         if (rc != 0 || _sendBufferSize < 0 )
         {
-            LOG_SYS('#' << _fd << ": Error getting socket buffer size");
             _sendBufferSize = DefaultSendBufferSize;
+            LOG_SYS('#' << _fd << ": Error getting socket buffer size. Using default size of "
+                        << _sendBufferSize << " bytes.");
             return false;
         }
         else
@@ -246,6 +247,17 @@ public:
     {
 #if !MOBILEAPP
         return _sendBufferSize;
+#else
+        return INT_MAX; // We want to always send a single record in one go
+#endif
+    }
+
+    /// The available number of bytes in the socket
+    /// buffer for an optimal transmition.
+    int getSendBufferCapacity() const
+    {
+#if !MOBILEAPP
+        return _sendBufferSize * 6;
 #else
         return INT_MAX; // We want to always send a single record in one go
 #endif
@@ -416,7 +428,7 @@ public:
     virtual void checkTimeout(std::chrono::steady_clock::time_point /* now */) {}
 
     /// Do some of the queued writing.
-    virtual void performWrites() = 0;
+    virtual void performWrites(std::size_t capacity) = 0;
 
     /// Called when the socket is disconnected and will be destroyed.
     /// Will be called exactly once.
@@ -507,7 +519,9 @@ public:
     /// Do we have something to send ?
     virtual bool hasQueuedMessages() const = 0;
     /// Please send them to me then.
-    virtual void writeQueuedMessages() = 0;
+    /// Write queued messages into the socket, at least capacity bytes,
+    /// and up to the next message boundary.
+    virtual void writeQueuedMessages(std::size_t capacity) = 0;
     /// We just got a message - here it is
     virtual void handleMessage(const std::vector<char> &data) = 0;
     /// Get notified that the underlying transports disconnected
@@ -1226,8 +1240,13 @@ protected:
         do
         {
             // If we have space for writing and that was requested
-            if ((events & POLLOUT) && (static_cast<int>(_outBuffer.size()) < getSendBufferSize()))
-                _socketHandler->performWrites();
+            if (events & POLLOUT)
+            {
+                // Try to get multiple blocks at a time.
+                const int capacity = getSendBufferCapacity();
+                if (capacity > 0)
+                    _socketHandler->performWrites(capacity);
+            }
 
             // perform the shutdown if we have sent everything.
             if (_shutdownSignalled && _outBuffer.empty())

--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -571,10 +571,10 @@ private:
     }
 
 public:
-    void performWrites() override
+    void performWrites(std::size_t capacity) override
     {
         if (_msgHandler)
-            _msgHandler->writeQueuedMessages();
+            _msgHandler->writeQueuedMessages(capacity);
     }
 
     void onDisconnect() override

--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -908,7 +908,8 @@ protected:
             return;
         }
 
-        assert(read == 0 && "Not enough data.");
+        // Nothing to do, not enough data to parse.
+        assert(read == 0 && "Need more more data to parse.");
     }
 #endif
 

--- a/net/WebSocketSession.hpp
+++ b/net/WebSocketSession.hpp
@@ -307,9 +307,9 @@ private:
         return POLLIN;
     }
 
-    void performWrites() override
+    void performWrites(std::size_t capacity) override
     {
-        LOG_TRC("WebSocketSession: performing writes.");
+        LOG_TRC("WebSocketSession: performing writes, up to " << capacity << " bytes.");
 
         std::unique_lock<std::mutex> lock(_outMutex);
 
@@ -317,7 +317,7 @@ private:
         try
         {
             // Drain the queue, for efficient communication.
-            if (!_outQueue.isEmpty())
+            while (capacity > wrote && !_outQueue.isEmpty())
             {
                 std::vector<char> item = _outQueue.get();
                 const auto size = item.size();

--- a/test/HttpTestServer.hpp
+++ b/test/HttpTestServer.hpp
@@ -135,7 +135,7 @@ private:
         return POLLIN;
     }
 
-    void performWrites() override
+    void performWrites(std::size_t) override
     {
         std::shared_ptr<StreamSocket> socket = _socket.lock();
         if (!socket)

--- a/tools/WebSocketDump.cpp
+++ b/tools/WebSocketDump.cpp
@@ -182,9 +182,7 @@ private:
         return POLLIN;
     }
 
-    void performWrites() override
-    {
-    }
+    void performWrites(std::size_t /*capacity*/) override {}
 
 private:
     // The socket that owns us (we can't own it).

--- a/wsd/Admin.cpp
+++ b/wsd/Admin.cpp
@@ -871,11 +871,11 @@ public:
             return AdminSocketHandler::getPollEvents(now, timeoutMaxMicroS);
     }
 
-    void performWrites() override
+    void performWrites(std::size_t capacity) override
     {
         LOG_TRC("Outbound monitor - connected");
         _connecting = false;
-        return AdminSocketHandler::performWrites();
+        return AdminSocketHandler::performWrites(capacity);
     }
 
     void onDisconnect() override

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1062,34 +1062,43 @@ bool ClientSession::hasQueuedMessages() const
     return _senderQueue.size() > 0;
 }
 
-    /// Please send them to me then.
-void ClientSession::writeQueuedMessages()
+void ClientSession::writeQueuedMessages(std::size_t capacity)
 {
-    LOG_TRC(getName() << " ClientSession: performing writes.");
+    LOG_TRC(getName() << " ClientSession: performing writes, up to " << capacity << " bytes.");
 
     std::shared_ptr<Message> item;
-    if (_senderQueue.dequeue(item))
+    std::size_t wrote = 0;
+    try
     {
-        try
+        // Drain the queue, for efficient communication.
+        // FIXME: use 'while' to write at least capacity bytes, if possible.
+        if (capacity > wrote && _senderQueue.dequeue(item) && item)
         {
             const std::vector<char>& data = item->data();
+            const auto size = data.size();
+            assert(size && "Zero-sized messages must never be queued for sending.");
+
             if (item->isBinary())
             {
-                Session::sendBinaryFrame(data.data(), data.size());
+                Session::sendBinaryFrame(data.data(), size);
             }
             else
             {
-                Session::sendTextFrame(data.data(), data.size());
+                Session::sendTextFrame(data.data(), size);
             }
-        }
-        catch (const std::exception& ex)
-        {
-            LOG_ERR("Failed to send message " << item->abbr() <<
-                    " to " << getName() << ": " << ex.what());
+
+            wrote += size;
+            LOG_TRC(getName() << " ClientSession: wrote " << size << ", total " << wrote
+                              << " bytes.");
         }
     }
+    catch (const std::exception& ex)
+    {
+        LOG_ERR(getName() << " Failed to send message " << (item ? item->abbr() : "<empty-item>")
+                          << " to client: " << ex.what());
+    }
 
-    LOG_TRC(getName() << " ClientSession: performed write.");
+    LOG_TRC(getName() << " ClientSession: performed write, wrote " << wrote << " bytes.");
 }
 
 // NB. also see loleaflet/src/map/Clipboard.js that does this in JS for stubs.

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1071,8 +1071,7 @@ void ClientSession::writeQueuedMessages(std::size_t capacity)
     try
     {
         // Drain the queue, for efficient communication.
-        // FIXME: use 'while' to write at least capacity bytes, if possible.
-        if (capacity > wrote && _senderQueue.dequeue(item) && item)
+        while (capacity > wrote && _senderQueue.dequeue(item) && item)
         {
             const std::vector<char>& data = item->data();
             const auto size = data.size();

--- a/wsd/ClientSession.hpp
+++ b/wsd/ClientSession.hpp
@@ -201,7 +201,7 @@ private:
     bool hasQueuedMessages() const override;
 
     /// SocketHandler: send those messages
-    void writeQueuedMessages() override;
+    void writeQueuedMessages(std::size_t capacity) override;
 
     virtual bool _handleInput(const char* buffer, int length) override;
 

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -2304,9 +2304,7 @@ private:
         return POLLIN;
     }
 
-    void performWrites() override
-    {
-    }
+    void performWrites(std::size_t /*capacity*/) override {}
 };
 
 #if !MOBILEAPP
@@ -2667,9 +2665,7 @@ private:
         return POLLIN;
     }
 
-    void performWrites() override
-    {
-    }
+    void performWrites(std::size_t /*capacity*/) override {}
 
 #if !MOBILEAPP
     void handleRootRequest(const RequestDetails& requestDetails,

--- a/wsd/ProxyProtocol.cpp
+++ b/wsd/ProxyProtocol.cpp
@@ -301,17 +301,17 @@ int ProxyProtocolHandler::getPollEvents(std::chrono::steady_clock::time_point /*
 }
 
 /// slurp from the core to us, @returns true if there are messages to send
-bool ProxyProtocolHandler::slurpHasMessages()
+bool ProxyProtocolHandler::slurpHasMessages(std::size_t capacity)
 {
-    if (_msgHandler && _msgHandler->hasQueuedMessages())
-        _msgHandler->writeQueuedMessages();
+    if (_msgHandler)
+        _msgHandler->writeQueuedMessages(capacity);
 
     return _writeQueue.size() > 0;
 }
 
-void ProxyProtocolHandler::performWrites()
+void ProxyProtocolHandler::performWrites(std::size_t capacity)
 {
-    if (!slurpHasMessages())
+    if (!slurpHasMessages(capacity))
         return;
 
     auto sock = popOutSocket();
@@ -325,7 +325,7 @@ void ProxyProtocolHandler::performWrites()
 
 bool ProxyProtocolHandler::flushQueueTo(const std::shared_ptr<StreamSocket> &socket)
 {
-    if (!slurpHasMessages())
+    if (!slurpHasMessages(socket->getSendBufferCapacity()))
         return false;
 
     size_t totalSize = 0;

--- a/wsd/ProxyProtocol.hpp
+++ b/wsd/ProxyProtocol.hpp
@@ -40,7 +40,7 @@ public:
     {
     }
 
-    void performWrites() override;
+    void performWrites(std::size_t capacity) override;
 
     void onDisconnect() override
     {
@@ -69,7 +69,7 @@ public:
 private:
     std::shared_ptr<StreamSocket> popOutSocket();
     /// can we find anything to send back if we try ?
-    bool slurpHasMessages();
+    bool slurpHasMessages(std::size_t capacity);
     int sendMessage(const char *msg, const size_t len, bool text, bool flush);
     bool flushQueueTo(const std::shared_ptr<StreamSocket> &socket);
 

--- a/wsd/TestStubs.cpp
+++ b/wsd/TestStubs.cpp
@@ -27,7 +27,7 @@ void ClientSession::onDisconnect() {}
 
 bool ClientSession::hasQueuedMessages() const { return false; }
 
-void ClientSession::writeQueuedMessages() {}
+void ClientSession::writeQueuedMessages(std::size_t) {}
 
 void ClientSession::dumpState(std::ostream& /*os*/) {}
 


### PR DESCRIPTION
Since it's most efficent to send full blocks at
once (especially so when SSL encryption is done),
we now perform write when the buffer has fewer
than the send-buffer-size bytes. Previously,
we were only getting more data to write to the
socket when the buffer was completely empty,
potentially wasting valuable opportunity to
write more data to the socket while we're at it.

Change-Id: I69a18a042dc2e551ebc5e1af40dae091da3f3d13
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
