### PR TITLE
wsd: cap the socket read buffer size

### DIFF
--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -970,7 +970,6 @@ public:
         do
         {
             // Drain the read buffer.
-            // TODO: Cap the buffer size, lest we grow beyond control.
             do
             {
                 len = readData(buf, sizeof(buf));
@@ -983,6 +982,8 @@ public:
                 assert (len <= ssize_t(sizeof(buf)));
                 _bytesRecvd += len;
                 _inBuffer.insert(_inBuffer.end(), &buf[0], &buf[len]);
+                if (_inBuffer.size() >= 512 * 1024)
+                    break; // Cap the buffer size, lest we grow beyond control.
             }
             // else poll will handle errors.
         }


### PR DESCRIPTION
Previously we read as much data as we could
from the socket. This is good if we only have
a single socket and unlimited memory. However
in practice we may end up hogging resources
for one fast connection, filling megabytes
of buffer in memory instead of tending to
other sockets and keeping the buffers from
growing too much.

We break the read when we hit 512 KB of data.
This limit seems reasonable, mostly due to
diminishing returns after some point.

Change-Id: I7de8f202a0d43872501de42d2f77dab8e0f2aaf0
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
