### PR TITLE
private/pedro/backporting various style

### DIFF
--- a/loleaflet/css/btns.css
+++ b/loleaflet/css/btns.css
@@ -1,3 +1,9 @@
+.jsdialog-container .ui-button-box button,
+.vex.vex-theme-plain .vex-dialog-button {
+	font-family: var(--jquery-ui-font);
+	text-transform: full-size-kana;
+}
+
 .loleaflet-annotation-edit #annotation-cancel,
 .ui-button-box.jsdialog #cancel,
 .ui-button-box.autofilter #cancel,

--- a/loleaflet/css/btns.css
+++ b/loleaflet/css/btns.css
@@ -10,7 +10,8 @@
 .jsdialog-container #input-range-button,
 .jsdialog-container #output-range-button,
 .jsdialog-container #variable1-range-button,
-.jsdialog-container #variable2-range-button {
+.jsdialog-container #variable2-range-button,
+.vex.vex-theme-plain .vex-dialog-button.vex-dialog-button-secondary {
 	height: 32px;
 	line-height: 0em;
 	color: #222;
@@ -38,6 +39,10 @@
 	border-radius: 3px;
 	margin: 5px;
 	vertical-align: middle;
+}
+
+.vex.vex-theme-plain .vex-dialog-form .vex-dialog-buttons {
+	margin-right: -5px; /* Account for child element (button)'s margin */
 }
 
 .jsdialog.ui-button-box.end {

--- a/loleaflet/css/btns.css
+++ b/loleaflet/css/btns.css
@@ -27,7 +27,8 @@
 .ui-button-box.jsdialog #ok,
 .ui-button-box.autofilter #ok,
 .cell.jsdialog > button,
-.ui-button-box.jsdialog button {
+.ui-button-box.jsdialog button,
+.vex.vex-theme-plain .vex-dialog-button.vex-dialog-button-primary {
 	height: 32px;
 	line-height: 0em;
 	color: #111;

--- a/loleaflet/css/menubar.css
+++ b/loleaflet/css/menubar.css
@@ -71,7 +71,7 @@
 }
 .main-nav.hasnotebookbar:not(.readonly) {
 	background: var(--gray-bg-color);
-	margin-top: 0px;
+	margin: 0px;
 }
 
 /* Customizations to sm-simple theme to make it look like LO menu, lo-menu class */

--- a/loleaflet/css/notebookbar.css
+++ b/loleaflet/css/notebookbar.css
@@ -182,7 +182,7 @@
 	overflow-y: hidden;
 	scrollbar-width: none; /* Firefox */
 	-ms-overflow-style: none;  /* Internet Explorer 10+ */
-
+	display: block;
 	height: 84px;
 }
 

--- a/loleaflet/css/vex.css
+++ b/loleaflet/css/vex.css
@@ -58,8 +58,10 @@
 	-webkit-animation: vex-fadeout .25s forwards;
 	animation: vex-fadeout .25s forwards;
 }
-.vex.vex-theme-plain .vex-dialog-form .vex-dialog-input select, .vex.vex-theme-plain .vex-dialog-form .vex-dialog-input textarea, .vex.vex-theme-plain .vex-dialog-form .vex-dialog-input input[type='date'], .vex.vex-theme-plain .vex-dialog-form .vex-dialog-input input[type='datetime'], .vex.vex-theme-plain .vex-dialog-form .vex-dialog-input input[type='datetime-local'], .vex.vex-theme-plain .vex-dialog-form .vex-dialog-input input[type='email'], .vex.vex-theme-plain .vex-dialog-form .vex-dialog-input input[type='month'], .vex.vex-theme-plain .vex-dialog-form .vex-dialog-input input[type='number'], .vex.vex-theme-plain .vex-dialog-form .vex-dialog-input input[type='password'], .vex.vex-theme-plain .vex-dialog-form .vex-dialog-input input[type='search'], .vex.vex-theme-plain .vex-dialog-form .vex-dialog-input input[type='tel'], .vex.vex-theme-plain .vex-dialog-form .vex-dialog-input input[type='text'], .vex.vex-theme-plain .vex-dialog-form .vex-dialog-input input[type='time'], .vex.vex-theme-plain .vex-dialog-form .vex-dialog-input input[type='url'], .vex.vex-theme-plain .vex-dialog-form .vex-dialog-input input[type='week']{
-	width: 95% !important;
+
+.vex.vex-theme-plain .vex-dialog-form .vex-dialog-input input{
+	border-radius: 3px;
+	box-shadow: inset 0 0 2px 0 lightgray;
 }
 
 .vex {


### PR DESCRIPTION
- Partly revert cb27d2c ..
- NB: Improve alignment by removing extra margin..
- Fix Vex btns: apply existent btn style
- Vex btns: secondary re-use btn style
- Vex: input fields: remove outdated width rule and add style
- Vex and jsdialog btns use the same btn font
