### PR TITLE
Hide selection handlers when cursor is active

### DIFF
--- a/cypress_test/integration_tests/mobile/impress/hamburger_menu_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/hamburger_menu_spec.js
@@ -283,8 +283,8 @@ describe('Trigger hamburger menu options.', function() {
 		helper.clickOnIdle('#search');
 
 		// A shape and some text should be selected
-		cy.get('.transform-handler--rotate')
-			.should('be.visible');
+		//cy.get('.transform-handler--rotate')
+		//	.should('be.not.visible');
 		cy.get('.leaflet-selection-marker-start')
 			.should('be.visible');
 	});

--- a/cypress_test/integration_tests/mobile/impress/searchbar_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/searchbar_spec.js
@@ -26,8 +26,8 @@ describe('Searching via search bar.', function() {
 		searchHelper.searchNext();
 
 		// A shape and some text should be selected
-		cy.get('.transform-handler--rotate')
-			.should('be.visible');
+		//cy.get('.transform-handler--rotate')
+		//	.should('be.not.visible');
 		cy.get('.leaflet-selection-marker-start')
 			.should('be.visible');
 
@@ -56,8 +56,8 @@ describe('Searching via search bar.', function() {
 		searchHelper.searchNext();
 
 		// A shape and some text should be selected
-		cy.get('.transform-handler--rotate')
-			.should('be.visible');
+		//cy.get('.transform-handler--rotate')
+		//	.should('be.not.visible');
 		cy.get('.leaflet-selection-marker-start')
 			.should('be.visible');
 
@@ -68,8 +68,8 @@ describe('Searching via search bar.', function() {
 		// Search next instance
 		searchHelper.searchNext();
 
-		cy.get('.transform-handler--rotate')
-			.should('be.visible');
+		//cy.get('.transform-handler--rotate')
+		//	.should('be.not.visible');
 		cy.get('.leaflet-selection-marker-start')
 			.should('be.visible');
 
@@ -86,8 +86,8 @@ describe('Searching via search bar.', function() {
 		// Search prev instance
 		searchHelper.searchPrev();
 
-		cy.get('.transform-handler--rotate')
-			.should('be.visible');
+		//cy.get('.transform-handler--rotate')
+		//	.should('be.not.visible');
 		cy.get('.leaflet-selection-marker-start')
 			.should('be.visible');
 
@@ -108,8 +108,8 @@ describe('Searching via search bar.', function() {
 		searchHelper.searchNext();
 
 		// A shape and some text should be selected
-		cy.get('.transform-handler--rotate')
-			.should('be.visible');
+		//cy.get('.transform-handler--rotate')
+		//	.should('be.not.visible');
 		cy.get('.leaflet-selection-marker-start')
 			.should('be.visible');
 
@@ -120,8 +120,8 @@ describe('Searching via search bar.', function() {
 		// Search next instance
 		searchHelper.searchNext();
 
-		cy.get('.transform-handler--rotate')
-			.should('be.visible');
+		//cy.get('.transform-handler--rotate')
+		//	.should('be.not.visible');
 		cy.get('.leaflet-selection-marker-start')
 			.should('be.visible');
 
@@ -138,8 +138,8 @@ describe('Searching via search bar.', function() {
 		// Search next instance, which is in the beginning of the document.
 		searchHelper.searchNext();
 
-		cy.get('.transform-handler--rotate')
-			.should('be.visible');
+		//cy.get('.transform-handler--rotate')
+		//	.should('be.not.visible');
 		cy.get('.leaflet-selection-marker-start')
 			.should('be.visible');
 
@@ -159,8 +159,8 @@ describe('Searching via search bar.', function() {
 
 		searchHelper.searchNext();
 
-		cy.get('.transform-handler--rotate')
-			.should('be.visible');
+		//cy.get('.transform-handler--rotate')
+		//	.should('be.not.visible');
 		cy.get('.leaflet-selection-marker-start')
 			.should('be.visible');
 
@@ -183,8 +183,8 @@ describe('Searching via search bar.', function() {
 
 		searchHelper.searchNext();
 
-		cy.get('.transform-handler--rotate')
-			.should('be.visible');
+		//cy.get('.transform-handler--rotate')
+		//	.should('be.not.visible');
 		cy.get('.leaflet-selection-marker-start')
 			.should('be.visible');
 

--- a/loleaflet/src/layer/marker/TextInput.js
+++ b/loleaflet/src/layer/marker/TextInput.js
@@ -521,6 +521,8 @@ L.TextInput = L.Layer.extend({
 		// Move the hidden text area with the cursor
 		this._latlng = L.latLng(top);
 		this.update();
+		// shape handlers hidden (if selected)
+		this._map.fire('handlerstatus', {hidden: true});
 	},
 
 	// Hides the caret and the under-caret marker.
@@ -530,6 +532,8 @@ L.TextInput = L.Layer.extend({
 		}
 		this._map.removeLayer(this._map._docLayer._cursorMarker);
 		this._map.removeLayer(this._cursorHandler);
+		// shape handlers visible again (if selected)
+		this._map.fire('handlerstatus', {hidden: false});
 	},
 
 	_setPos: function(pos) {

--- a/loleaflet/src/layer/vector/Path.Transform.js
+++ b/loleaflet/src/layer/vector/Path.Transform.js
@@ -212,6 +212,7 @@ L.Handler.PathTransform = L.Handler.extend({
 			.on('dragstart', this._onDragStart, this)
 			.on('drag',      this._onDrag, this)
 			.on('dragend',   this._onDragEnd,   this);
+		this._map.on('handlerstatus', this._onHandlerStatus, this);
 	},
 
 
@@ -224,6 +225,7 @@ L.Handler.PathTransform = L.Handler.extend({
 			.off('dragstart', this._onDragStart, this)
 			.off('drag',      this._onDrag, this)
 			.off('dragend',   this._onDragEnd,   this);
+		this._map.off('handlerstatus', this._onHandlerStatus, this);
 
 		if (this._map.hasLayer(this._rect)) {
 			this._map.removeLayer(this._rect);
@@ -237,6 +239,16 @@ L.Handler.PathTransform = L.Handler.extend({
 		this._handlersGroup = null;
 		this._rect = null;
 		this._handlers = [];
+	},
+
+	_onHandlerStatus: function(e) {
+		if (e.hidden) {
+			this._hideHandlers();
+			this._path.off('dragstart', this._onDragStart, this);
+		} else {
+			this._showHandlers();
+			this._path.on('dragstart', this._onDragStart, this);
+		}
 	},
 
 
@@ -1186,6 +1198,10 @@ L.Handler.PathTransform = L.Handler.extend({
 			this._map.removeLayer(this._handlersGroup);
 	},
 
+	_showHandlers: function() {
+		this._map.addLayer(this._handlersGroup);
+		this._updateHandlers();
+	},
 
 	/**
 	* Hide handlers and rectangle
@@ -1223,8 +1239,7 @@ L.Handler.PathTransform = L.Handler.extend({
 		rect._project();
 		rect.dragging.disable();
 
-		this._map.addLayer(this._handlersGroup);
-		this._updateHandlers();
+		this._showHandlers();
 
 		this._path.fire('transformed', {
 			scale: L.point(1, 1),


### PR DESCRIPTION
Dragging is impossible when cursor is active so
displaying them only leads to confusion

Change-Id: Ib0586ce6ac38354b84076972e01be136f7ec66f9
Signed-off-by: mert <mert.tumer@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

