### PR TITLE
wsd: terminate Kit when disconnected while loading

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1665,9 +1665,26 @@ void DocumentBroker::disconnectSessionInternal(const std::string& id)
             {
                 hardDisconnect = it->second->disconnectFromKit();
 
-                // Let the child know the client has disconnected.
-                const std::string msg("child-" + id + " disconnect");
-                _childProcess->sendTextFrame(msg);
+                if (isLoaded() || _sessions.size() > 1)
+                {
+                    // Let the child know the client has disconnected.
+                    const std::string msg("child-" + id + " disconnect");
+                    _childProcess->sendTextFrame(msg);
+                }
+                else
+                {
+                    // We aren't even loaded and no other views--kill.
+                    // If we send disconnect, we risk hanging because
+                    // we flag Core for quiting via unipoll, but Core
+                    // would still continue loading. If at the end of
+                    // loading it shows a dialog (such as the macro or
+                    // csv import dialogs), it will wait for their
+                    // dismissal indefinetely. Neither would our
+                    // load-timeout kick in, since we would be gone.
+                    LOG_INF("Session [" << id << "] disconnected but DocKey [" << _docKey
+                                        << "] isn't loaded yet. Terminating the child roughly.");
+                    _childProcess->terminate();
+                }
             }
 
             if (hardDisconnect)


### PR DESCRIPTION
When loading hasn't completed yet, DocBroker can't
simply send a message to Kit that the session is
disconnected, because there would be no UI or
handlers for events if that were the only session.

Of course letting the document load, only to close
it, is also less than helpful to resource consumption.

Here, we recognize this case and simply terminate the
loading by killing the Kit process altogether to
avoid any potential hangs or resource wastage.

Change-Id: Ia72de715cc6238831c244444bb47b417b9b1e1a4
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
