### PR TITLE
Avoid tooltips for the colour control in the mobile apps

### DIFF
--- a/loleaflet/src/control/Control.NotebookbarBuilder.js
+++ b/loleaflet/src/control/Control.NotebookbarBuilder.js
@@ -399,7 +399,8 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 			div.id = id;
 
 			div.title = data.text;
-			$(div).tooltip();
+			if (!window.ThisIsAMobileApp)
+				$(div).tooltip();
 
 			var icon = builder._createIconURL(data.command);
 			var buttonId = id + 'img';


### PR DESCRIPTION
(Some of our tooltip() calls are conditional on
window.mode.isDesktop(), others on !window.ThisIsAMobileApp. Which is
more correct?)

Fixes https://github.com/CollaboraOnline/online/issues/1461

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: I98cd4c5f0cd05b78236c6722104cd1fe03f3e70f


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

