### PR TITLE
private/pedro/MacroDialogs tweaks fixes

### DIFF
--- a/loleaflet/css/jsdialogs.css
+++ b/loleaflet/css/jsdialogs.css
@@ -524,12 +524,12 @@ input[type='checkbox']:checked.autofilter, .jsdialog input[type='checkbox']:chec
 #MacroWarnMedium p {
 	max-width: 512px;
 	color: #333;
-	text-transform: capitalize;
+	text-transform: none;
 }
 
 #MacroSelectorDialog #helpmacro {
 	margin-bottom: 8px;
-	text-transform: full-size-kana;
+	text-transform: none;
 	font-size: 12px;
 }
 

--- a/loleaflet/css/jsdialogs.css
+++ b/loleaflet/css/jsdialogs.css
@@ -555,7 +555,8 @@ input[type='checkbox']:checked.autofilter, .jsdialog input[type='checkbox']:chec
 	width: auto;
 }
 
-#MacroSelectorDialog #commands {
+#MacroSelectorDialog #commands,
+#MacroSelectorDialog #categories {
 	height: 150px;
 }
 


### PR DESCRIPTION
- Macros dialogs: do not capitalize text
- MacroSelectorDialog: Categories should expand from the top
