### PR TITLE
Update canvas when sidebar is closed

### DIFF
--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -271,7 +271,8 @@ L.CanvasTilePainter = L.Class.extend({
 			!partChanged &&
 			!resizeCanvas &&
 			!splitPosChanged &&
-			!scaleChanged);
+			!scaleChanged &&
+			!mapSizeChanged);
 
 //		console.debug('Tile size: ' + this._layer._getTileSize());
 


### PR DESCRIPTION
When we close sidebar map size is changed. We need
to update the content to avoid blank space.

Change-Id: I59c840b750987001c9ef410bb6ba8e8725f44aca
