### PR TITLE
wsd: add interactive state

### DIFF
--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1476,9 +1476,14 @@ bool ClientSession::handleKitToClientMessage(const char* buffer, const int lengt
         {
             assert(false && "Tile traffic should go through the DocumentBroker-LoKit WS.");
         }
+        else if (tokens[0] == "jsdialog:" && _state == ClientSession::SessionState::LOADING)
+        {
+            docBroker->setInteractive(true);
+        }
         else if (tokens[0] == "status:")
         {
             setState(ClientSession::SessionState::LIVE);
+            docBroker->setInteractive(false);
             docBroker->setLoaded();
 
 #if !MOBILEAPP

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -307,7 +307,7 @@ void DocumentBroker::pollThread()
 #endif
         LOOLWSD::getConfigValue<int>("per_document.limit_load_secs", 100);
 
-    const auto loadDeadline = std::chrono::steady_clock::now() + std::chrono::seconds(limit_load_secs);
+    auto loadDeadline = std::chrono::steady_clock::now() + std::chrono::seconds(limit_load_secs);
 #endif
     auto last30SecCheckTime = std::chrono::steady_clock::now();
 
@@ -322,6 +322,12 @@ void DocumentBroker::pollThread()
         // a tile's data is ~8k, a 4k screen is ~128 256x256 tiles
         if (_tileCache)
             _tileCache->setMaxCacheSize(8 * 1024 * 128 * _sessions.size());
+
+        if (isInteractive())
+        {
+            loadDeadline = now + std::chrono::seconds(limit_load_secs);
+            continue;
+        }
 
         if (!_isLoaded && (limit_load_secs > 0) && (now > loadDeadline))
         {
@@ -1203,6 +1209,15 @@ void DocumentBroker::setLoaded()
         _loadDuration = std::chrono::duration_cast<std::chrono::milliseconds>(
                                 std::chrono::steady_clock::now() - _threadStart);
         LOG_TRC("Document loaded in " << _loadDuration.count() << "ms");
+    }
+}
+
+void DocumentBroker::setInteractive(bool value)
+{
+    if (_interactive != value)
+    {
+        _interactive = value;
+        LOG_TRC("Document has interactive dialogs before load");
     }
 }
 

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -169,6 +169,9 @@ public:
     /// Notify that the load has completed
     virtual void setLoaded();
 
+    /// Notify that the document has dialogs before load
+    virtual void setInteractive(bool value);
+
     /// If not yet locked, try to lock
     bool attemptLock(const ClientSession& session, std::string& failReason);
 
@@ -321,6 +324,7 @@ private:
     /// Loads a document from the public URI into the jail.
     bool load(const std::shared_ptr<ClientSession>& session, const std::string& jailId);
     bool isLoaded() const { return _isLoaded; }
+    bool isInteractive() const { return _interactive; }
 
     std::size_t getIdleTimeSecs() const
     {
@@ -446,6 +450,7 @@ private:
     std::atomic<bool> _closeRequest;
     std::atomic<bool> _isLoaded;
     std::atomic<bool> _isModified;
+    bool _interactive; //< If the document has interactive dialogs before load
     int _cursorPosX;
     int _cursorPosY;
     int _cursorWidth;


### PR DESCRIPTION
Add a new state before load the document,
when Macro Security dialog popup, and avoid
to send the event load timeout.

Change-Id: I5973c5205e90e5447e5478cbab895709a68606f6
Signed-off-by: Henry Castro <hcastro@collabora.com>
