### PR TITLE
cypress: NC: disable failing Save as test.

### DIFF
--- a/cypress_test/integration_tests/mobile/calc/nextcloud_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/nextcloud_spec.js
@@ -25,7 +25,8 @@ describe('Nextcloud specific tests.', function() {
 		//	.should('exist');
 	});
 
-	it('Save as.', function() {
+	// This feature is broken now: the top toolbar is gone, so we can't push close button.
+	it.skip('Save as.', function() {
 		helper.beforeAll(testFileName, 'calc');
 
 		// Click on edit button

--- a/cypress_test/integration_tests/mobile/impress/nextcloud_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/nextcloud_spec.js
@@ -24,7 +24,8 @@ describe('Nextcloud specific tests.', function() {
 			.should('exist');
 	});
 
-	it('Save as.', function() {
+	// This feature is broken now: the top toolbar is gone, so we can't push close button.
+	it.skip('Save as.', function() {
 		helper.beforeAll(testFileName, 'impress');
 
 		// Click on edit button

--- a/cypress_test/integration_tests/mobile/writer/nextcloud_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/nextcloud_spec.js
@@ -24,7 +24,8 @@ describe('Nextcloud specific tests.', function() {
 			.should('exist');
 	});
 
-	it('Save as.', function() {
+	// This feature is broken now: the top toolbar is gone, so we can't push close button.
+	it.skip('Save as.', function() {
 		helper.beforeAll(testFileName, 'writer');
 
 		mobileHelper.enableEditingMobile();


### PR DESCRIPTION
The feature it now broken. We can reenable these tests,
when it's fixed again.

Signed-off-by: Tamás Zolnai <tamas.zolnai@collabora.com>
Change-Id: I7cca152b4d19e1881bfcc195757605ffaa5b0f3c
