### PR TITLE
Don't allow to switch ui mode on mobile

### DIFF
--- a/loleaflet/src/control/Control.UIManager.js
+++ b/loleaflet/src/control/Control.UIManager.js
@@ -224,6 +224,9 @@ L.Control.UIManager = L.Control.extend({
 	},
 
 	onChangeUIMode: function(uiMode) {
+		if (window.mode.isMobile())
+			return;
+
 		if (uiMode.mode === window.userInterfaceMode && !uiMode.force)
 			return;
 


### PR DESCRIPTION
Changing ui mode on mobile causes problems eg. after save as
or reloading the document.
We don't support notebookbar on mobile also

Change-Id: Iaa8d80dbdd139833c0505354be870f33b4f95413
Signed-off-by: Szymon Kłos <szymon.klos@collabora.com>
