### PR TITLE
Don't show blinking cursor when no focus on document

### DIFF
--- a/loleaflet/css/leaflet.css
+++ b/loleaflet/css/leaflet.css
@@ -637,6 +637,15 @@ div.leaflet-cursor-container:hover > .leaflet-cursor-header {
 	animation: 1s blink step-end 0s infinite;
 }
 
+.blinking-cursor-hidden {
+	-webkit-animation: none !important;
+	-moz-animation: none !important;
+	-ms-animation: none !important;
+	-o-animation: none !important;
+	animation: none !important;
+	display: none !important;
+}
+
 @keyframes blink {
 	from, to {
 		background: black;

--- a/loleaflet/src/layer/marker/Cursor.js
+++ b/loleaflet/src/layer/marker/Cursor.js
@@ -38,6 +38,16 @@ L.Cursor = L.Layer.extend({
 		this.update();
 		this.getPane().appendChild(this._container);
 		this._map.on('splitposchanged', this.update, this);
+
+		document.addEventListener('blur', this.onFocusBlur.bind(this));
+		document.addEventListener('focus', this.onFocusBlur.bind(this));
+	},
+
+	onFocusBlur: function(ev) {
+		if (ev.type === 'blur')
+			$('.leaflet-cursor').addClass('blinking-cursor-hidden');
+		else
+			$('.leaflet-cursor').removeClass('blinking-cursor-hidden');
 	},
 
 	onRemove: function () {
@@ -50,6 +60,9 @@ L.Cursor = L.Layer.extend({
 		if (this._container) {
 			this.getPane().removeChild(this._container);
 		}
+
+		document.removeEventListener('blur', this.onFocusBlur.bind(this));
+		document.removeEventListener('focus', this.onFocusBlur.bind(this));
 	},
 
 	getEvents: function () {


### PR DESCRIPTION
Use listener to detect focus change. Hide cursor by css class to not break JS code around cursor.

Change-Id: I6dd2ba0a88eff71870dc608ba6d961c9d0f7a67f
Signed-off-by: Szymon Kłos <szymon.klos@collabora.com>
