### PR TITLE
Don't show blinking cursor when no focus on document

### DIFF
--- a/loleaflet/css/leaflet.css
+++ b/loleaflet/css/leaflet.css
@@ -637,6 +637,15 @@ div.leaflet-cursor-container:hover > .leaflet-cursor-header {
 	animation: 1s blink step-end 0s infinite;
 }
 
+.blinking-cursor-hidden {
+	-webkit-animation: none !important;
+	-moz-animation: none !important;
+	-ms-animation: none !important;
+	-o-animation: none !important;
+	animation: none !important;
+	display: none !important;
+}
+
 @keyframes blink {
 	from, to {
 		background: black;

--- a/loleaflet/src/layer/marker/Cursor.ts
+++ b/loleaflet/src/layer/marker/Cursor.ts
@@ -66,6 +66,9 @@ class Cursor {
 			this.map.on('zoomend move', this.update, this);
 
 		this.visible = true;
+
+		document.addEventListener('blur', this.onFocusBlur.bind(this));
+		document.addEventListener('focus', this.onFocusBlur.bind(this));
 	}
 
 	remove() {
@@ -80,10 +83,20 @@ class Cursor {
 		}
 
 		this.visible = false;
+
+		document.removeEventListener('blur', this.onFocusBlur.bind(this));
+		document.removeEventListener('focus', this.onFocusBlur.bind(this));
 	}
 
 	isVisible(): boolean {
 		return this.visible;
+	}
+
+	onFocusBlur(ev: FocusEvent) {
+		if (ev.type === 'blur')
+			$('.leaflet-cursor').addClass('blinking-cursor-hidden');
+		else
+			$('.leaflet-cursor').removeClass('blinking-cursor-hidden');
 	}
 
 	// position and size should be in core pixels.


### PR DESCRIPTION
Use listener to detect focus change. Hide cursor by css class to not break JS code around cursor.

Change-Id: I6dd2ba0a88eff71870dc608ba6d961c9d0f7a67f
Signed-off-by: Szymon Kłos <szymon.klos@collabora.com>
