### PR TITLE
config: add "enable_macros_execution" item

### DIFF
--- a/common/Session.cpp
+++ b/common/Session.cpp
@@ -195,6 +195,11 @@ void Session::parseDocOptions(const StringVector& tokens, int& part, std::string
             _batch = value;
             ++offset;
         }
+        else if (name == "enableMacrosExecution")
+        {
+            _enableMacrosExecution = value;
+            ++offset;
+        }
     }
 
     Util::mapAnonymized(_userId, _userIdAnonym);

--- a/common/Session.cpp
+++ b/common/Session.cpp
@@ -200,6 +200,11 @@ void Session::parseDocOptions(const StringVector& tokens, int& part, std::string
             _enableMacrosExecution = value;
             ++offset;
         }
+        else if (name == "macroSecurityLevel")
+        {
+            _macroSecurityLevel = value;
+            ++offset;
+        }
     }
 
     Util::mapAnonymized(_userId, _userIdAnonym);

--- a/common/Session.hpp
+++ b/common/Session.hpp
@@ -231,6 +231,8 @@ public:
 
     const std::string& getEnableMacrosExecution() const { return _enableMacrosExecution; }
 
+    const std::string& getMacroSecurityLevel() const { return _macroSecurityLevel; }
+
 protected:
     Session(const std::shared_ptr<ProtocolHandlerInterface> &handler,
             const std::string& name, const std::string& id, bool readonly);
@@ -335,6 +337,9 @@ private:
 
     /// Specifies whether the macro execution is enabled in general.
     std::string _enableMacrosExecution;
+
+    /// Level of Macro security.
+    std::string _macroSecurityLevel;
 };
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/common/Session.hpp
+++ b/common/Session.hpp
@@ -229,6 +229,8 @@ public:
 
     const std::string& getBatchMode() const { return _batch; }
 
+    const std::string& getEnableMacrosExecution() const { return _enableMacrosExecution; }
+
 protected:
     Session(const std::shared_ptr<ProtocolHandlerInterface> &handler,
             const std::string& name, const std::string& id, bool readonly);
@@ -328,8 +330,11 @@ private:
     /// The start value of Auto Spell Checking wheter it is enabled or disabled on start.
     std::string _spellOnline;
 
-    /// Disable dialogs interactivity
+    /// Disable dialogs interactivity.
     std::string _batch;
+
+    /// Specifies whether the macro execution is enabled in general.
+    std::string _enableMacrosExecution;
 };
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1193,6 +1193,7 @@ private:
         const std::string& lang = session->getLang();
         const std::string& deviceFormFactor = session->getDeviceFormFactor();
         const std::string& batchMode = session->getBatchMode();
+        const std::string& enableMacrosExecution = session->getEnableMacrosExecution();
         std::string spellOnline;
 
         std::string options;
@@ -1204,6 +1205,9 @@ private:
 
         if (!batchMode.empty())
             options += ",Batch=" + batchMode;
+
+        if (!enableMacrosExecution.empty())
+            options += ",EnableMacrosExecution=" + enableMacrosExecution;
 
         if (!_loKitDocument)
         {

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1194,6 +1194,7 @@ private:
         const std::string& deviceFormFactor = session->getDeviceFormFactor();
         const std::string& batchMode = session->getBatchMode();
         const std::string& enableMacrosExecution = session->getEnableMacrosExecution();
+        const std::string& macroSecurityLevel = session->getMacroSecurityLevel();
         std::string spellOnline;
 
         std::string options;
@@ -1208,6 +1209,9 @@ private:
 
         if (!enableMacrosExecution.empty())
             options += ",EnableMacrosExecution=" + enableMacrosExecution;
+
+        if (!macroSecurityLevel.empty())
+            options += ",MacroSecurityLevel=" + macroSecurityLevel;
 
         if (!_loKitDocument)
         {

--- a/loolwsd.xml.in
+++ b/loolwsd.xml.in
@@ -15,6 +15,7 @@
     <memproportion desc="The maximum percentage of system memory consumed by all of the @APP_NAME@, after which we start cleaning up idle documents" type="double" default="80.0"></memproportion>
     <num_prespawn_children desc="Number of child processes to keep started in advance and waiting for new clients." type="uint" default="1">1</num_prespawn_children>
     <per_document desc="Document-specific settings, including LO Core settings.">
+
         <max_concurrency desc="The maximum number of threads to use while processing a document." type="uint" default="4">4</max_concurrency>
         <batch_priority desc="A (lower) priority for use by batch eg. convert-to processes to avoid starving interactive ones" type="uint" default="5">5</batch_priority>
         <document_signing_url desc="The endpoint URL of signing server, if empty the document signing is disabled" type="string" default="@VEREIGN_URL@">@VEREIGN_URL@</document_signing_url>
@@ -124,6 +125,7 @@
       <capabilities desc="Should we require capabilities to isolate processes into chroot jails" type="bool" default="true">true</capabilities>
       <jwt_expiry_secs desc="Time in seconds before the Admin Console's JWT token expires" type="int" default="1800">1800</jwt_expiry_secs>
       <enable_macros_execution desc="Specifies whether the macro execution is enabled in general. This will enable Basic, Beanshell, Javascript and Python scripts. If it is set to false, the macro_security_level is ignored. If it is set to true, the mentioned entry specified the level of macro security." type="bool" default="false">false</enable_macros_execution>
+      <macro_security_level desc="Level of Macro security. 1 (Medium) Confirmation required before executing macros from untrusted sources. 0 (Low, not recommended) All macros will be executed without confirmation." type="int" default="1">1</macro_security_level>
     </security>
 
     <watermark>

--- a/loolwsd.xml.in
+++ b/loolwsd.xml.in
@@ -123,6 +123,7 @@
       <seccomp desc="Should we use the seccomp system call filtering." type="bool" default="true">true</seccomp>
       <capabilities desc="Should we require capabilities to isolate processes into chroot jails" type="bool" default="true">true</capabilities>
       <jwt_expiry_secs desc="Time in seconds before the Admin Console's JWT token expires" type="int" default="1800">1800</jwt_expiry_secs>
+      <enable_macros_execution desc="Specifies whether the macro execution is enabled in general. This will enable Basic, Beanshell, Javascript and Python scripts. If it is set to false, the macro_security_level is ignored. If it is set to true, the mentioned entry specified the level of macro security." type="bool" default="false">false</enable_macros_execution>
     </security>
 
     <watermark>

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -849,6 +849,11 @@ bool ClientSession::loadDocument(const char* /*buffer*/, int /*length*/,
                 << LOOLWSD::getConfigValue<bool>("security.enable_macros_execution", false);
         }
 
+        if (LOOLWSD::hasProperty("security.macro_security_level"))
+        {
+            oss << " macroSecurityLevel=" << LOOLWSD::getConfigValue<int>("security.macro_security_level", 1);
+        }
+
         if (!getDocOptions().empty())
         {
             oss << " options=" << getDocOptions();

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -843,6 +843,12 @@ bool ClientSession::loadDocument(const char* /*buffer*/, int /*length*/,
             oss << " watermarkOpacity=" << LOOLWSD::getConfigValue<double>("watermark.opacity", 0.2);
         }
 
+        if (LOOLWSD::hasProperty("security.enable_macros_execution"))
+        {
+            oss << " enableMacrosExecution=" << std::boolalpha
+                << LOOLWSD::getConfigValue<bool>("security.enable_macros_execution", false);
+        }
+
         if (!getDocOptions().empty())
         {
             oss << " options=" << getDocOptions();

--- a/wsd/LOOLWSD.hpp
+++ b/wsd/LOOLWSD.hpp
@@ -368,6 +368,13 @@ public:
         return value;
     }
 
+    /// Returns true if and only if the property with the given key exists.
+    static
+    bool hasProperty(const std::string& key)
+    {
+        return Application::instance().config().hasProperty(key);
+    }
+
     /// Trace a new session and take a snapshot of the file.
     static void dumpNewSessionTrace(const std::string& id, const std::string& sessionId, const std::string& uri, const std::string& path);
 


### PR DESCRIPTION
"Specifies whether the macro execution is disabled in
general. This will disable Basic, Beanshell, Javascript
and Python scripts. If it is set to true, the
macro_security_level is ignored. If it isset to false,
the mentioned entry specified the level of macro security".

Change-Id: I4bc5b690268a93994d17e2b02b7b60b6398646b7
