### PR TITLE
leaflet: cursor: avoid first character not updating cursor position

### DIFF
--- a/loleaflet/src/layer/marker/TextInput.js
+++ b/loleaflet/src/layer/marker/TextInput.js
@@ -701,6 +701,15 @@ L.TextInput = L.Layer.extend({
 		// remove leading & tailing spaces.
 		content = content.slice(1, -1);
 
+		// In the android keyboard when you try to erase in an empty area
+		// and then enter some character,
+		// The first character will likely travel with the cursor,
+		// And that is caused because after entering the first character
+		// cursor position is never updated by keyboard (I know it is strange)
+		// so here we manually correct the position
+		if (content.length === 1 && this._lastContent.length === 0)
+			this._setCursorPosition(2);
+
 		var matchTo = 0;
 		var sharedLength = Math.min(content.length, this._lastContent.length);
 		while (matchTo < sharedLength && content[matchTo] === this._lastContent[matchTo])
@@ -812,11 +821,7 @@ L.TextInput = L.Layer.extend({
 
 		// avoid setting the focus keyboard
 		if (!noSelect) {
-			try {
-				this._textArea.setSelectionRange(1, 1);
-			} catch (err) {
-				// old firefox throws an exception on start.
-			}
+			this._setCursorPosition(1);
 
 			if (this._hasWorkingSelectionStart === undefined)
 				this._hasWorkingSelectionStart = (this._textArea.selectionStart === 1);
@@ -965,6 +970,14 @@ L.TextInput = L.Layer.extend({
 		var cursorPos = this._map._docLayer._latLngToTwips(ev.target.getLatLng());
 		this._map._docLayer._postMouseEvent('buttondown', cursorPos.x, cursorPos.y, 1, 1, 0);
 		this._map._docLayer._postMouseEvent('buttonup', cursorPos.x, cursorPos.y, 1, 1, 0);
+	},
+
+	_setCursorPosition: function(pos) {
+		try {
+			this._textArea.setSelectionRange(pos, pos);
+		} catch (err) {
+			// old firefox throws an exception on start.
+		}
 	},
 
 	_setAcceptInput: function(accept) {


### PR DESCRIPTION


Signed-off-by: Pranam Lashkari <lpranam@collabora.com>
Change-Id: I9cc00e5d50d21384155b16b60318090e4de70ac2


* Target version: master 

### Summary
problem:
In the android keyboard when you try to erase in an empty area
and then enter some character,
The first character will likely travel with the cursor,
And that is caused because after entering the first character
cursor position is never updated by keyboard (I know it is strange)
so here we manually correct the position

steps to reproduce:
1. type "=sum" in formula bar or an empty odt (or even just "=s" is okay)
2. now tap on backspace for total character +1 times (in this case 5 or 3 times)
3. now type "=s" it will become "s="
but this can be reproduced with any special characters (i.e: }, + etc...)


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

