### PR TITLE
Draw: Display Presentationbar for Insert/Duplicate/Delete Pages

### DIFF
--- a/loleaflet/src/control/Control.PresentationBar.js
+++ b/loleaflet/src/control/Control.PresentationBar.js
@@ -115,7 +115,7 @@ L.Control.PresentationBar = L.Control.extend({
 
 	onDocLayerInit: function() {
 		var presentationToolbar = w2ui['presentation-toolbar'];
-		if (!this.map['wopi'].HideExportOption && presentationToolbar) {
+		if (!this.map['wopi'].HideExportOption && presentationToolbar && this._map.getDocType() !== 'drawing') {
 			presentationToolbar.show('presentation', 'presentationbreak');
 		}
 

--- a/loleaflet/src/control/Control.PresentationBar.js
+++ b/loleaflet/src/control/Control.PresentationBar.js
@@ -10,9 +10,6 @@ L.Control.PresentationBar = L.Control.extend({
 	},
 
 	onAdd: function (map) {
-		if (this._map.getDocType() === 'drawing') {
-			return;
-		}
 		this.map = map;
 		this.create();
 
@@ -30,11 +27,11 @@ L.Control.PresentationBar = L.Control.extend({
 			hidden: true,
 			items: [
 				{type: 'html',  id: 'left'},
-				{type: 'button',  id: 'presentation', img: 'presentation', hidden:true, hint: _('Fullscreen presentation')},
+				{type: 'button',  id: 'presentation', img: 'presentation', hidden:true, hint: this._getItemUnoName('presentation')},
 				{type: 'break', id: 'presentationbreak', hidden:true},
-				{type: 'button',  id: 'insertpage', img: 'insertpage', hint: _UNO('.uno:TaskPaneInsertPage', 'presentation')},
-				{type: 'button',  id: 'duplicatepage', img: 'duplicatepage', hint: _UNO('.uno:DuplicateSlide', 'presentation')},
-				{type: 'button',  id: 'deletepage', img: 'deletepage', hint: _UNO('.uno:DeleteSlide', 'presentation')},
+				{type: 'button',  id: 'insertpage', img: 'insertpage', hint: this._getItemUnoName('insertpage')},
+				{type: 'button',  id: 'duplicatepage', img: 'duplicatepage', hint: this._getItemUnoName('duplicatepage')},
+				{type: 'button',  id: 'deletepage', img: 'deletepage', hint: this._getItemUnoName('deletepage')},
 				{type: 'html',  id: 'right'}
 			],
 			onClick: function (e) {
@@ -45,9 +42,27 @@ L.Control.PresentationBar = L.Control.extend({
 		if (window.mode.isDesktop())
 			toolbar.tooltip();
 
+		if (this.map.getDocType() === 'drawing')
+			w2ui['presentation-toolbar'].disable('presentation');
+
 		toolbar.bind('touchstart', function() {
 			w2ui['presentation-toolbar'].touchStarted = true;
 		});
+	},
+
+	_getItemUnoName: function(id) {
+		var docType = this.map.getDocType();
+		switch (id) {
+		case 'presentation':
+			return docType === 'presentation' ? _('Fullscreen presentation') : '';
+		case 'insertpage':
+			return docType === 'presentation' ? _UNO('.uno:TaskPaneInsertPage', 'presentation') : _UNO('.uno:InsertPage', 'presentation');
+		case 'duplicatepage':
+			return docType === 'presentation' ? _UNO('.uno:DuplicateSlide', 'presentation') : _UNO('.uno:DuplicatePage', 'presentation');
+		case 'deletepage':
+			return docType === 'presentation' ? _UNO('.uno:DeleteSlide', 'presentation') : _UNO('.uno:DeletePage', 'presentation');
+		}
+		return '';
 	},
 
 	onDelete: function(e) {
@@ -99,19 +114,13 @@ L.Control.PresentationBar = L.Control.extend({
 	},
 
 	onDocLayerInit: function() {
-		var docType = this.map.getDocType();
-		switch (docType) {
-		case 'presentation':
-			var presentationToolbar = w2ui['presentation-toolbar'];
-			if (!this.map['wopi'].HideExportOption && presentationToolbar) {
-				presentationToolbar.show('presentation', 'presentationbreak');
-			}
+		var presentationToolbar = w2ui['presentation-toolbar'];
+		if (!this.map['wopi'].HideExportOption && presentationToolbar) {
+			presentationToolbar.show('presentation', 'presentationbreak');
+		}
 
-			// FALLTHROUGH intended
-		case 'drawing':
-			if (!window.mode.isMobile()) {
-				$('#presentation-toolbar').show();
-			}
+		if (!window.mode.isMobile()) {
+			$('#presentation-toolbar').show();
 		}
 	},
 

--- a/loleaflet/src/control/Control.UIManager.js
+++ b/loleaflet/src/control/Control.UIManager.js
@@ -119,7 +119,7 @@ L.Control.UIManager = L.Control.extend({
 			L.DomUtil.remove(L.DomUtil.get('presentation-controls-wrapper'));
 		}
 
-		if (docType === 'presentation') {
+		if (this.map.isPresentationOrDrawing()) {
 			// remove unused elements
 			L.DomUtil.remove(L.DomUtil.get('spreadsheet-toolbar'));
 		}
@@ -136,7 +136,7 @@ L.Control.UIManager = L.Control.extend({
 			}
 		}
 
-		if (docType === 'presentation' && (isDesktop || window.mode.isTablet())) {
+		if (this.map.isPresentationOrDrawing() && (isDesktop || window.mode.isTablet())) {
 			this.map.addControl(L.control.presentationBar());
 		}
 


### PR DESCRIPTION
We have these on the Top toolbar but in notebookbar case
We have only insert and duplicate options and they are
located in Insert tab. So deletion is not possible
with notebookbar. This patch re-enables presentationbar
with the correct hints of these items according to the doctype

Change-Id: I885b6353bce82232cfdfb5577f8cfbee16b219c7
Signed-off-by: mert <mert.tumer@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

