### PR TITLE
Guard against JS error when there is no "children" in the notebookbar…

### DIFF
--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -1105,11 +1105,13 @@ L.Socket = L.Class.extend({
 		} else if (msgData.jsontype === 'dialog') {
 			this._map.fire('jsdialog', {data: msgData});
 		} else if (msgData.jsontype === 'notebookbar') {
-			for (var i = 0; i < msgData.children.length; i++) {
-				if (msgData.children[i].type === 'control') {
-					msgData.children[i].id = msgData.id;
-					this._map.fire('notebookbar', msgData.children[i]);
-					return;
+			if (msgData.children) {
+				for (var i = 0; i < msgData.children.length; i++) {
+					if (msgData.children[i].type === 'control') {
+						msgData.children[i].id = msgData.id;
+						this._map.fire('notebookbar', msgData.children[i]);
+						return;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
… JSON

I saw that happening now and then when experimenting with the Insert >
Comment functionnality in the iOS app. The message in those cases
seemed to be 'jsdialog: { "id": "0", "jsontype": "notebookbar",
"action": "close" }'.

Change-Id: Ia8e07f849f88bb46cedd95f7c38534232c388efe
Signed-off-by: Tor Lillqvist <tml@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

