### PR TITLE
jsdialog: don't scroll whole page

### DIFF
--- a/loleaflet/src/control/Control.JSDialogBuilder.js
+++ b/loleaflet/src/control/Control.JSDialogBuilder.js
@@ -1898,7 +1898,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 
 		var firstSelected = $(container).children('.selected').get(0);
 		if (firstSelected)
-			firstSelected.scrollIntoView({behavior: 'smooth', block: 'center'});
+			firstSelected.scrollIntoView({behavior: 'smooth', block: 'nearest', inline: 'nearest'});
 
 		return false;
 	},
@@ -2903,7 +2903,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			var entry = $(control).children().eq(pos);
 
 			entry.addClass('selected');
-			$(entry).get(0).scrollIntoView({behavior: 'smooth', block: 'center'});
+			$(entry).get(0).scrollIntoView({behavior: 'smooth', block: 'nearest', inline: 'nearest'});
 
 			break;
 		}


### PR DESCRIPTION
scrollIntoView scrolled whole page inside iframe
when selection in the fontwork dialog was changed

Change-Id: I40f59c1821d1327aaf6ce910e07587f0dcb5af31
Signed-off-by: Szymon Kłos <szymon.klos@collabora.com>
