### PR TITLE
copy/paste dialogs: stop propagation to avoid confusing the document.

### DIFF
--- a/loleaflet/src/control/Control.DownloadProgress.js
+++ b/loleaflet/src/control/Control.DownloadProgress.js
@@ -17,9 +17,20 @@ L.Control.DownloadProgress = L.Control.extend({
 		return this._container;
 	},
 
+	// we really don't want mouse and other events propagating
+	// to the parent map - since they affect the context.
+	_ignoreEvents: function(elem) {
+		L.DomEvent.on(elem, 'mousedown mouseup mouseover mouseout mousemove',
+			      function(e) {
+				      L.DomEvent.stopPropagation(e);
+				      return false;
+			      }, this);
+	},
+
 	_initLayout: function () {
 		this._container = L.DomUtil.create('div', 'leaflet-control-layers');
 		this._container.style.visibility = 'hidden';
+		this._ignoreEvents(this._container);
 
 		var closeButton = L.DomUtil.create('a', 'leaflet-popup-close-button', this._container);
 		closeButton.href = '#close';
@@ -193,6 +204,7 @@ L.Control.UploadProgress = L.Control.extend({
 	_initLayout: function () {
 		this._container = L.DomUtil.create('div', 'leaflet-control-layers');
 		this._container.style.visibility = 'hidden';
+		this._ignoreEvents(this._container);
 
 		var closeButton = L.DomUtil.create('a', 'leaflet-popup-close-button', this._container);
 		closeButton.href = '#close';
@@ -296,6 +308,7 @@ L.Control.CrossProgress = L.Control.extend({
 	_initLayout: function () {
 		this._container = L.DomUtil.create('div', 'leaflet-control-layers');
 		this._container.style.visibility = 'hidden';
+		this._ignoreEvents(this._container);
 
 		// close button
 		var closeButton = L.DomUtil.create('a', 'leaflet-popup-close-button', this._container);


### PR DESCRIPTION
Previously a 'click' on 'start download' - also resulted in a pair
of mouse down/up events getting sent to the map, the TileLayer, and
thus the core - resetting the object selection during the download,
and causing nasty issues in the second 'Confirm copy to clipboard'
which had a different & random selection depending what was under
that popup.

Signed-off-by: Michael Meeks <michael.meeks@collabora.com>
Change-Id: I7f6510494500dd36beb232e4720a66f2d9e09f27


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

