### PR TITLE
android: de_document -> the_document

### DIFF
--- a/android/lib/src/main/java/org/libreoffice/androidlib/LOActivity.java
+++ b/android/lib/src/main/java/org/libreoffice/androidlib/LOActivity.java
@@ -302,7 +302,7 @@ public class LOActivity extends AppCompatActivity {
                     Log.d(TAG, "SCHEME_CONTENT: getPath(): " + getIntent().getData().getPath());
                 } else {
                     Log.e(TAG, "couldn't create temporary file from " + getIntent().getData());
-                    Toast.makeText(this, R.string.cant_open_de_document, Toast.LENGTH_SHORT).show();
+                    Toast.makeText(this, R.string.cant_open_the_document, Toast.LENGTH_SHORT).show();
                     finish();
                 }
             } else if (getIntent().getData().getScheme().equals(ContentResolver.SCHEME_FILE)) {

--- a/android/lib/src/main/res/values/strings.xml
+++ b/android/lib/src/main/res/values/strings.xml
@@ -18,5 +18,5 @@
     <string name="view_only">View only</string>
     <string name="edit_copy">Edit a copy</string>
     <string name="ask_for_copy">This document is read-only. Do you want to make a copy for editing\?</string>
-    <string name="cant_open_de_document">Couldn\'t open the document</string>
+    <string name="cant_open_the_document">Couldn\'t open the document</string>
 </resources>


### PR DESCRIPTION
Backport, so translations can be in sync between co-6-4 and master.

(cherry picked from commit d35a5f963e9e6f487997f4e8223eab49556ac14f)

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Ic85297eb112def4a9197116177c857db910459cf
