### PR TITLE
MacroSelectorDialog: Style Description

### DIFF
--- a/loleaflet/css/jsdialogs.css
+++ b/loleaflet/css/jsdialogs.css
@@ -549,6 +549,15 @@ input[type='checkbox']:checked.autofilter, .jsdialog input[type='checkbox']:chec
 	width: 47%;
 }
 
+#MacroSelectorDialog #table-frame1 {
+	width: auto;
+	margin-left: 47%;
+}
+
+#MacroSelectorDialog #description {
+	text-transform: none;
+}
+
 #MacroSelectorDialog #table-frame3 {
 	width: 100%;
 }


### PR DESCRIPTION
- Align description group with the Macro name group
  as it's related to that
- Ensure paragraph is set with the right capitalization

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I25d4a1f811225f6efd46bfa0733635fa4544281f
