### PR TITLE
loleaflet: fix "offsetWidth" property value of the sidebar panel

### DIFF
--- a/loleaflet/src/control/Control.LokDialog.js
+++ b/loleaflet/src/control/Control.LokDialog.js
@@ -1642,9 +1642,22 @@ L.Control.LokDialog = L.Control.extend({
 		}
 
 		var wrapper = L.DomUtil.get('sidebar-dock-wrapper');
-		if (wrapper && wrapper.offsetWidth)
-			this._map.options.documentContainer.style.right = wrapper.offsetWidth + 'px';
-		else
+		if (wrapper) {
+			var offsetWidth;
+			var panel = L.DomUtil.get('sidebar-panel');
+
+			if (panel.style.display !== 'none')
+				offsetWidth = wrapper.offsetWidth;
+			else {
+				panel.style.visibility = 'hidden';
+				panel.style.display = '';
+				offsetWidth = wrapper.offsetWidth;
+				panel.style.display = 'none';
+				panel.style.visibility = '';
+			}
+
+			this._map.options.documentContainer.style.right = offsetWidth + 'px';
+		} else
 			this._map.options.documentContainer.style.right = (width - 15).toString() + 'px';
 
 		this._map._onResize();


### PR DESCRIPTION
Unfortunately when show/hide sidebar the "offsetWidth" property
works only if the element is visible otherwise it returns parent
empty size.

To fix add temporary a visibility property, then obtain the sidebar
"offsetWidth" property and update document container size.

Change-Id: I8e1c821518a4c155340edcfc8f2313098edff8b0
Signed-off-by: Henry Castro <hcastro@collabora.com>
