### PR TITLE
fixes: ghost pages/tiles in writer

### DIFF
--- a/loleaflet/src/layer/tile/TilesSection.ts
+++ b/loleaflet/src/layer/tile/TilesSection.ts
@@ -196,8 +196,8 @@ class TilesSection {
 			this.oscCtxs[i].fillRect(0, 0, this.offscreenCanvases[i].width, this.offscreenCanvases[i].height);
 		}
 
-		var tileRanges = ctx.paneBoundsList.map(this.sectionProperties.docLayer._pxBoundsToTileRange, this.sectionProperties.docLayer);
-
+		var docLayer = this.sectionProperties.docLayer;
+		var tileRanges = ctx.paneBoundsList.map(docLayer._pxBoundsToTileRange, docLayer);
 		for (var rangeIdx = 0; rangeIdx < tileRanges.length; ++rangeIdx) {
 			var tileRange = tileRanges[rangeIdx];
 			for (var j = tileRange.min.y; j <= tileRange.max.y; ++j) {
@@ -210,7 +210,8 @@ class TilesSection {
 
 					var key = coords.key();
 					var tile = this.sectionProperties.docLayer._tiles[key];
-					if (tile && tile.loaded) {
+					// Ensure tile is loaded and is within document bounds.
+					if (tile && tile.loaded && docLayer._isValidTile(coords)) {
 						this.paint(tile, ctx, false /* async? */);
 					}
 				}


### PR DESCRIPTION
The issue is: On creating a page break on a empty writer file and
hitting backspace, the deleted page or parts of it is still rendered.

We get a 'status' message containing the document size every time it
changes. So avoid the issue do not draw tiles that are not within the
document area.

Signed-off-by: Dennis Francis <dennis.francis@collabora.com>
Change-Id: I88d1715e861f068326d28d2930d01e3b5355be02


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

