### PR TITLE
wsd: avoid using invalid DocBroker for clipboard

### DIFF
--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -2767,7 +2767,14 @@ private:
             if (it != DocBrokers.end())
                 docBroker = it->second;
         }
-        if (docBroker)
+
+        // If we have a valid docBroker, use it.
+        // Note: there is a race here as DocBroker may
+        // have already exited its SocketPoll, but we
+        // haven't cleaned up the DocBrokers container.
+        // Since we don't care about creating a new one,
+        // we simply go to the fallback below.
+        if (docBroker && docBroker->isAlive())
         {
             std::shared_ptr<std::string> data;
             DocumentBroker::ClipboardRequest type;


### PR DESCRIPTION
The clipboard content is handled by the DocBroker,
if it it's available, otherwise, we fallback to the
cached clipboard entries.

When DocBroker has already terminated polling and
is no longer valid, we may end up using it for
the clipboard. In this case, we don't send anything
back, since there is no SocketPoll thread to
process the request or the socket data plumbing.

We avoid this by simply using the fallback (cache)
when we don't have a valid DocBroker.

Change-Id: Idf7f27b453605d173dd8e40d4a5d101f50355468
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
