### PR TITLE
Backport of zoom animation fixes

### DIFF
--- a/loleaflet/src/layer/vector/CanvasOverlay.ts
+++ b/loleaflet/src/layer/vector/CanvasOverlay.ts
@@ -221,13 +221,13 @@ class CanvasOverlay {
 			// Original pane size.
 			var paneSize = paneBounds.getSize();
 			var clipSize = paneSize.clone();
-			if (paneBounds.min.x) {
+			if (paneBounds.min.x || (!paneBounds.min.x && !splitPos.x)) {
 				clipTopLeft.x = newTopLeft.x + splitPos.x;
 				// Pane's "free" size will shrink(expand) as we zoom in(out)
 				// respectively because fixed pane size expand(shrink).
 				clipSize.x = (paneSize.x - splitPos.x * (scale - 1)) / scale;
 			}
-			if (paneBounds.min.y) {
+			if (paneBounds.min.y || (!paneBounds.min.y && !splitPos.y)) {
 				clipTopLeft.y = newTopLeft.y + splitPos.y;
 				// See comment regarding pane width above.
 				clipSize.y = (paneSize.y - splitPos.y * (scale - 1)) / scale;


### PR DESCRIPTION
* Target version: co-6-4

### Summary
* Fix overlay drawing on headers when animating zoom when view is tied to cell A1.
* Patch to avoid 2 branches of code to do coordinate translation/scaling for easier testing of overlays.

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

