### PR TITLE
Revert "config: add "Macro Security" default value"

### DIFF
--- a/loolkitconfig.xcu
+++ b/loolkitconfig.xcu
@@ -19,9 +19,6 @@
 <!-- Save memory by avoiding collecting autocompletion words  -->
 <item oor:path="/org.openoffice.Office.Writer/AutoFunction/Completion"><prop oor:name="Enable" oor:op="fuse"><value>false</value></prop></item>
 
-<!-- Set MacroSecurityLevel 1 -->
-+<item oor:path="/org.openoffice.Office.Common/Security/Scripting"><prop oor:name="MacroSecurityLevel" oor:op="fuse"><value>1</value></prop></item>
-
 <!-- Set a work path which is valid in chroot -->
 <item oor:path="/org.openoffice.Office.Paths/Variables"><prop oor:name="Work" oor:op="fuse"><value>file:///tmp</value></prop></item>
 


### PR DESCRIPTION
This reverts commit 3ce3108a5fbddb4e3e5cdcbd519e8044882d52fc.
Reason: We added macro config settings to loolwsd.xcu

