### PR TITLE
mobileWizard: Fix comment layout and avoid inline syles

### DIFF
--- a/loleaflet/src/control/Control.JSDialogBuilder.js
+++ b/loleaflet/src/control/Control.JSDialogBuilder.js
@@ -2159,7 +2159,6 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		}
 
 		var container = L.DomUtil.create('div',  'ui-header level-' + builder._currentDepth + ' ' + builder.options.cssClass + ' ui-widget', parentContainer);
-		container.setAttribute('style', 'padding: 5px 10px 10px !important; display: table !important;width: -webkit-fill-available !important');
 		container.annotation = data.annotation;
 		container.id = data.id;
 		builder._createComment(container, data, true);
@@ -2179,7 +2178,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 				$(replyCountNode).text(replyCountText);
 			}
 			var childContainer = L.DomUtil.create('div', 'ui-content level-' + builder._currentDepth + ' ' + builder.options.cssClass, parentContainer);
-			childContainer.setAttribute('style', 'padding: 5px 10px 10px !important; display: table !important;width: -webkit-fill-available !important');
+			childContainer.id = 'comment-thread' + data.id;
 			childContainer.title = _('Comment');
 
 			builder._currentDepth++;


### PR DESCRIPTION
- make top level look like cards with their padding etc
- add class for comment threads and make it look like we entered the thread (thus the list style)

ported from 62ab2194ffa8d171be0aebbc554ba6b9a679b0d8
- only JavaScript side
- css was already in

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I062841c645d416b7db4dc20302e2095d77416f8d
