### PR TITLE
Avoid static objects in LOOLWSD

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -335,7 +335,10 @@ EXTRA_DIST = discovery.xml \
 if ENABLE_LIBFUZZER
 CLEANUP_COMMAND=true
 else
-CLEANUP_COMMAND=if test -s ./loolwsd; then echo "Cleaning up..." && ./loolwsd --disable-lool-user-checking --cleanup --o:logging.level=trace; fi
+# Use loolwsd to cleanup jails, if any. If it fails, we may have a broken/old loolwsd binary, remove it to rebuild.
+# A CI box may switch branches without cleaning up the binaries, if loolwsd from a broken branch is used here
+# it will fail all subsequent builds, until it's rebuilt from the new branch. So removing loolwsd after failing is needed.
+CLEANUP_COMMAND=if test -s ./loolwsd; then echo "Cleaning up..." && ./loolwsd --disable-lool-user-checking --cleanup --o:logging.level=trace || rm ./loolwsd; fi
 endif
 
 if HAVE_LO_PATH

--- a/net/DelaySocket.cpp
+++ b/net/DelaySocket.cpp
@@ -9,12 +9,13 @@
 
 #include <net/DelaySocket.hpp>
 
+#include <memory>
+#include <mutex>
+
 #define DELAY_LOG(X) std::cerr << X << '\n';
 
-class Delayer;
-
-// FIXME: TerminatingPoll ?
-static SocketPoll DelayPoll("delay_poll");
+std::shared_ptr<TerminatingPoll> Delay::DelayPoll;
+std::once_flag Delay::DelayPollOnceFlag;
 
 /// Reads from fd, delays that and then writes to _dest.
 class DelaySocket : public Socket {
@@ -228,12 +229,31 @@ public:
 ///    internalFd - the internal side of the socket-pair
 ///    delayFd - what we hand on to our un-suspecting wrapped socket
 ///              which looks like an external socket - but delayed.
-namespace Delay {
-    int create(int delayMs, int physicalFd)
+Delay::Delay(std::size_t latencyMs)
+{
+    if (latencyMs)
+    {
+        // This will be called exactly once, and all
+        // competing threads (if more than one) will
+        // block until it returns.
+        std::call_once(DelayPollOnceFlag, []() {
+            DelayPoll = std::make_shared<TerminatingPoll>("delay_poll");
+            DelayPoll->startThread(); // Start the thread.
+        });
+    }
+}
+
+Delay::~Delay() { DelayPoll.reset(); }
+
+int Delay::create(int delayMs, int physicalFd)
+{
+    auto delayPoll = DelayPoll;
+    if (delayPoll && delayPoll->isAlive())
     {
         int pair[2];
         int rc = socketpair(AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0, pair);
-        assert (rc == 0); (void)rc;
+        assert(rc == 0);
+        (void)rc;
         int internalFd = pair[0];
         int delayFd = pair[1];
 
@@ -242,19 +262,32 @@ namespace Delay {
         physical->setDestination(internal);
         internal->setDestination(physical);
 
-        DelayPoll.startThread();
-        DelayPoll.insertNewSocket(physical);
-        DelayPoll.insertNewSocket(internal);
-
+        delayPoll->insertNewSocket(physical);
+        delayPoll->insertNewSocket(internal);
+        LOG_TRC("Created DelaySockets with physicalFd: " << physicalFd
+                                                         << " and internalFd: " << internalFd);
         return delayFd;
     }
-    void dumpState(std::ostream &os)
+    else
     {
-        if (DelayPoll.isAlive())
-        {
-            os << "Delay poll:\n";
-            DelayPoll.dumpState(os);
-        }
+        LOG_ERR("Failed to create DelaySockets for physicalFd: " << physicalFd
+                                                                 << ". No DelayPoll exists.");
+    }
+
+    return -1;
+}
+
+void Delay::dumpState(std::ostream& os)
+{
+    auto delayPoll = DelayPoll;
+    if (delayPoll && delayPoll->isAlive())
+    {
+        os << "Delay poll:\n";
+        delayPoll->dumpState(os);
+    }
+    else
+    {
+        os << "Delay poll: doesn't exist.\n";
     }
 }
 

--- a/net/DelaySocket.hpp
+++ b/net/DelaySocket.hpp
@@ -9,14 +9,27 @@
 
 #include <Socket.hpp>
 
+#include <mutex>
+
 /// Simulates network latency for local debugging.
 ///
 /// We are lifecycle managed internally based on the physical /
 /// delayFd lifecycle.
-namespace Delay
+///
+/// An instance of Delay must be created before using the
+/// static members and must outlive all sockets.
+class Delay final
 {
-    int create(int delayMs, int physicalFd);
-    void dumpState(std::ostream &os);
+public:
+    Delay(std::size_t latencyMs);
+    ~Delay();
+
+    static int create(int delayMs, int physicalFd);
+    static void dumpState(std::ostream &os);
+
+private:
+    static std::shared_ptr<TerminatingPoll> DelayPoll;
+    static std::once_flag DelayPollOnceFlag;
 };
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -817,6 +817,20 @@ private:
     std::thread::id _owner;
 };
 
+/// A SocketPoll that will stop polling and
+/// terminate when the TerminationFlag is set.
+class TerminatingPoll : public SocketPoll
+{
+public:
+    TerminatingPoll(const std::string &threadName) :
+        SocketPoll(threadName) {}
+
+    bool continuePolling() override
+    {
+        return SocketPoll::continuePolling() && !SigUtil::getTerminationFlag();
+    }
+};
+
 /// A plain, non-blocking, data streaming socket.
 class StreamSocket : public Socket,
                      public std::enable_shared_from_this<StreamSocket>

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -42,18 +42,6 @@ struct LockContext;
 class TileCache;
 class Message;
 
-class TerminatingPoll : public SocketPoll
-{
-public:
-    TerminatingPoll(const std::string &threadName) :
-        SocketPoll(threadName) {}
-
-    bool continuePolling() override
-    {
-        return SocketPoll::continuePolling() && !SigUtil::getTerminationFlag();
-    }
-};
-
 #include "LOOLWSD.hpp"
 
 /// A ChildProcess object represents a KIT process that hosts a document and manipulates the

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -223,7 +223,7 @@ int LOOLWSD::prisonerServerSocketFD;
 #else
 
 /// Funky latency simulation basic delay (ms)
-static int SimulatedLatencyMs = 0;
+static std::size_t SimulatedLatencyMs = 0;
 
 #endif
 
@@ -3926,6 +3926,9 @@ int LOOLWSD::innerMain()
         FileServerRoot = Util::getApplicationPath();
     FileServerRoot = Poco::Path(FileServerRoot).absolute().toString();
     LOG_DBG("FileServerRoot: " << FileServerRoot);
+
+    LOG_DBG("Initializing DelaySocket with " << SimulatedLatencyMs << "ms.");
+    Delay delay(SimulatedLatencyMs);
 #endif
 
     ClientRequestDispatcher::InitStaticFileContentCache();

--- a/wsd/LOOLWSD.hpp
+++ b/wsd/LOOLWSD.hpp
@@ -208,7 +208,9 @@ public:
 
 #endif
 
+// Forward declarations for classes defined in LOOLWSD.cpp.
 class PrisonPoll;
+class LOOLWSDServer;
 
 /// The Server class which is responsible for all
 /// external interactions.
@@ -266,6 +268,8 @@ public:
     /// This thread listens for and accepts prisoner kit processes.
     /// And also cleans up and balances the correct number of children.
     static std::unique_ptr<PrisonPoll> PrisonerPoll;
+
+    static std::unique_ptr<LOOLWSDServer> Server;
 
     static std::unordered_set<std::string> EditFileExtensions;
     static std::unordered_set<std::string> ViewWithCommentsFileExtensions;

--- a/wsd/LOOLWSD.hpp
+++ b/wsd/LOOLWSD.hpp
@@ -208,6 +208,8 @@ public:
 
 #endif
 
+class PrisonPoll;
+
 /// The Server class which is responsible for all
 /// external interactions.
 class LOOLWSD : public Poco::Util::ServerApplication
@@ -255,6 +257,16 @@ public:
 #if !MOBILEAPP
     static std::unique_ptr<ClipboardCache> SavedClipboards;
 #endif
+
+    /// This thread polls basic web serving, and handling of
+    /// websockets before upgrade: when upgraded they go to the
+    /// relevant DocumentBroker poll instead.
+    static std::unique_ptr<TerminatingPoll> WebServerPoll;
+
+    /// This thread listens for and accepts prisoner kit processes.
+    /// And also cleans up and balances the correct number of children.
+    static std::unique_ptr<PrisonPoll> PrisonerPoll;
+
     static std::unordered_set<std::string> EditFileExtensions;
     static std::unordered_set<std::string> ViewWithCommentsFileExtensions;
     static unsigned MaxConnections;

--- a/wsd/LOOLWSD.hpp
+++ b/wsd/LOOLWSD.hpp
@@ -431,10 +431,20 @@ public:
     /// get correct server URL with protocol + port number for this running server
     static std::string getServerURL();
 
-    int innerMain();
-
 protected:
-    void initialize(Poco::Util::Application& self) override;
+    void initialize(Poco::Util::Application& self) override
+    {
+        try
+        {
+            innerInitialize(self);
+        }
+        catch (const std::exception& ex)
+        {
+            LOG_FTL("Failed to initialize LOOLWSD: " << ex.what());
+            throw; // Nothing further to do.
+        }
+    }
+
     void defineOptions(Poco::Util::OptionSet& options) override;
     void handleOption(const std::string& name, const std::string& value) override;
     int main(const std::vector<std::string>& args) override;
@@ -450,6 +460,12 @@ private:
 
     void initializeSSL();
     void displayHelp();
+
+    /// The actual initialize implementation.
+    void innerInitialize(Application& self);
+
+    /// The actual main implementation.
+    int innerMain();
 
     class ConfigValueGetter
     {


### PR DESCRIPTION
Large and complex objects such as SocketPoll and its derivatives and users need controlled lifetime management to avoid destroying them out-of-order and especially after other statics are destroyed. One such external static is the Logging (and other) Poco instances that we can't control. A static object that logs anything at all can potentially crash if it runs after Poco is destroyed (partially or completely).

We hit such an issue on one of the CI boxes. The issue had been there, but a small change in the logging and other structures in the code resulted in consistent segfaults on said box everytime loolwsd exited. This failed the build, of course, which was enough to catch our notice.

Even though the issue was now in the limelight, it was still not reproducible elsewhere. It wasn't reproducible on my dev box either, and neither clang's ASAN, nor gcc's ASAN complained of any issues. In fact, it wasn't crashing anywhere else except for that one CI box. gdb on the broken CI box revealed the problem immediately. Stacktraces and other details in the commit logs.

This PR contains the patches that convert the global statics in loolwsd to unique_ptr instances and the lifetime management associated with it. We always make sure that the objects in question are created before use and that they are destroyed before we exit (at least for the normal workflow).

- wsd: capture and log exceptions during un/initialization
- wsd: move TerminatingPoll to Socket.hpp
- wsd: avoid static SocketPoll
- wsd: avoid static LOOLWSDServer instance
- wsd: convert static objects to unique_ptr
- wsd: move srv instance into LOOLWSD and rename
- make: delete loolwsd binary if it fails to cleanup