### PR TITLE
Backport: touch: do not show onscreen keyboard post zoom

### DIFF
--- a/loleaflet/src/layer/marker/TextInput.js
+++ b/loleaflet/src/layer/marker/TextInput.js
@@ -133,6 +133,14 @@ L.TextInput = L.Layer.extend({
 		this._map.removeLayer(this._cursorHandler);
 	},
 
+	disable: function () {
+		this._textArea.setAttribute('disabled', true);
+	},
+
+	enable: function () {
+		this._textArea.removeAttribute('disabled');
+	},
+
 	_onPermission: function(e) {
 		if (e.perm === 'edit') {
 			this._textArea.removeAttribute('disabled');

--- a/loleaflet/src/map/Map.js
+++ b/loleaflet/src/map/Map.js
@@ -540,6 +540,23 @@ L.Map = L.Evented.extend({
 		return this._inZoomViewPanning;
 	},
 
+	setZoomViewPanning: function (value) {
+		var docLayer = this._docLayer;
+		if (!docLayer)
+			return;
+		this._inZoomViewPanning = value;
+
+		if (!docLayer.isCursorVisible())
+			return;
+
+		if (this._inZoomViewPanning) {
+			this._textInput.disable();
+		} else {
+			this._textInput.enable();
+			docLayer._updateCursorPos();
+		}
+	},
+
 	setZoom: function (zoom, options) {
 
 		if (this._docLayer instanceof L.CanvasTileLayer) {

--- a/loleaflet/src/map/handler/Map.TouchGesture.js
+++ b/loleaflet/src/map/handler/Map.TouchGesture.js
@@ -621,7 +621,9 @@ L.Map.TouchGesture = L.Handler.extend({
 			this._map._docLayer.zoomStepEnd(finalZoom, this._origCenter);
 		}
 
+		this._map.setZoomViewPanning(true);
 		this._map.setView(this._center, finalZoom);
+		this._map.setZoomViewPanning(false);
 	},
 
 	_constructFakeEvent: function (evt, type) {


### PR DESCRIPTION
Fix description:
On setting the view area/zoom in map after the pinch has finished the
textarea for the text input is getting focus and the keyboard pops up.
This is prevented by temporarily disabling the textarea while setting
the view area/zoom in the map.

Signed-off-by: Dennis Francis <dennis.francis@collabora.com>
Change-Id: I193d36c7366c9c0a200c00b2966c5d31c4f2df2c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

