### PR TITLE
HTTP improvements, tests, and fixes

### DIFF
--- a/net/HttpRequest.cpp
+++ b/net/HttpRequest.cpp
@@ -333,7 +333,6 @@ int64_t Response::readData(const char* p, int64_t len)
         switch (_statusLine.parse(p, read))
         {
             case FieldParseState::Unknown:
-            case FieldParseState::Complete:
             case FieldParseState::Incomplete:
                 return 0;
             case FieldParseState::Invalid:

--- a/net/HttpRequest.cpp
+++ b/net/HttpRequest.cpp
@@ -194,6 +194,10 @@ FieldParseState StatusLine::parse(const char* p, int64_t& len)
     const int64_t reasonOff = off;
 
     // Find the line break, which ends the status line.
+    off = findLineBreak(p, off, len);
+    if (off >= len)
+        return FieldParseState::Incomplete;
+
     for (; off < len; ++off)
     {
         if (p[off] == '\r' || p[off] == '\n')
@@ -206,10 +210,7 @@ FieldParseState StatusLine::parse(const char* p, int64_t& len)
         }
     }
 
-    if (off >= len)
-        return FieldParseState::Incomplete;
-
-    _reasonPhrase = std::string(&p[reasonOff], off - reasonOff);
+    _reasonPhrase = std::string(&p[reasonOff], off - reasonOff - 1); // Exclude '\r'.
 
     // Consume the line breaks.
     for (; off < len; ++off)

--- a/net/HttpRequest.cpp
+++ b/net/HttpRequest.cpp
@@ -26,15 +26,18 @@
 
 namespace http
 {
-/// Skips over space and tab characters starting at off.
-/// Returns the offset of the first match, otherwise, len.
+/// Returns true iff the character given is a whitespace.
 /// FIXME: Technically, we should skip: SP, HTAB, VT (%x0B),
 ///         FF (%x0C), or bare CR.
+static inline bool isWhitespace(const char ch) { return ch == ' ' || ch == '\t' || ch == '\r'; }
+
+/// Skips over space and tab characters starting at off.
+/// Returns the offset of the first match, otherwise, len.
 static inline int64_t skipSpaceAndTab(const char* p, int64_t off, int64_t len)
 {
     for (; off < len; ++off)
     {
-        if (p[off] != ' ' && p[off] != '\t')
+        if (!isWhitespace(p[off]))
             return off;
     }
 

--- a/net/HttpRequest.cpp
+++ b/net/HttpRequest.cpp
@@ -44,7 +44,7 @@ static inline int64_t skipSpaceAndTab(const char* p, int64_t off, int64_t len)
     return len;
 }
 
-static inline int64_t skipCRLF(const char* p, int64_t len, int64_t off = 0)
+static inline int64_t skipCRLF(const char* p, int64_t off, int64_t len)
 {
     for (; off < len; ++off)
     {
@@ -59,7 +59,7 @@ static inline int64_t skipCRLF(const char* p, int64_t len, int64_t off = 0)
 /// Returns the offset to the first LF character,
 /// if found, otherwise, len.
 /// Ex.: for [xxxCRLFCRLF] the offset to the second LF is returned.
-static inline int64_t findLineBreak(const char* p, int64_t len, int64_t off = 0)
+static inline int64_t findLineBreak(const char* p, int64_t off, int64_t len)
 {
     // Find the line break, which ends the status line.
     for (; off < len; ++off)
@@ -329,7 +329,7 @@ int64_t Response::readData(const char* p, int64_t len)
 
                 // Read ahead to see if we have enough data
                 // to consume the chunk length.
-                int64_t off = findLineBreak(p, available);
+                int64_t off = findLineBreak(p, 0, available);
                 if (off == available)
                 {
                     LOG_TRC("Not enough data for chunk size");
@@ -383,7 +383,7 @@ int64_t Response::readData(const char* p, int64_t len)
                     LOG_TRC("Wrote " << chunkLen << " bytes for a total of " << _recvBodySize);
 
                     // Skip blank lines.
-                    off = skipCRLF(p, available);
+                    off = skipCRLF(p, 0, available);
                     p += off;
                     available -= off;
                 }

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -350,14 +350,21 @@ public:
     const std::string& getVersion() const { return _version; }
 
     /// The header object to populate.
+    /// Deprecated: Use set and add directly.
     Header& header() { return _header; }
     const Header& header() const { return _header; }
+
+    /// Add an HTTP header field.
+    void add(const std::string& key, const std::string& value) { _header.add(key, value); }
+
+    /// Set an HTTP header field, replacing an earlier value, if exists.
+    void set(const std::string& key, const std::string& value) { _header.set(key, value); }
 
     /// Set the request body source to upload some data. Meaningful for POST.
     /// Size is needed to set the Content-Length.
     void setBodySource(IoReadFunc bodyReaderCb, int64_t size)
     {
-        header().setContentLength(size);
+        _header.setContentLength(size);
         _bodyReaderCb = std::move(bodyReaderCb);
     }
 
@@ -387,7 +394,7 @@ public:
         {
             std::ostringstream oss;
             oss << getVerb() << ' ' << getUrl() << ' ' << getVersion() << "\r\n";
-            header().serialize(oss);
+            _header.serialize(oss);
             oss << "\r\n";
             const std::string headerStr = oss.str();
 
@@ -825,7 +832,7 @@ private:
         _response.reset(new Response(onFinished));
 
         _request = std::move(req);
-        _request.header().set("Host", host()); // Make sure the host is set.
+        _request.set("Host", host()); // Make sure the host is set.
     }
 
     void onConnect(const std::shared_ptr<StreamSocket>& socket) override

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -389,7 +389,7 @@ public:
             const std::string headerStr = oss.str();
 
             out.append(headerStr.data(), headerStr.size());
-            LOG_TRC("performWrites (header): " << headerStr.size());
+            LOG_TRC("performWrites (header): " << headerStr.size() << ": " << headerStr);
             _stage = Stage::Body;
         }
 
@@ -401,7 +401,10 @@ public:
             char buffer[16 * 1024];
             const int64_t read = _bodyReaderCb(buffer, sizeof(buffer));
             if (read < 0)
+            {
+                LOG_ERR("Error reading the data to send as the HTTP request body: " << read);
                 return false;
+            }
 
             if (read == 0)
             {
@@ -847,7 +850,7 @@ private:
 
     virtual void handleIncomingMessage(SocketDisposition& disposition) override
     {
-        LOG_TRC("handleIncomingMessage");
+        LOG_TRC('#' << _socket->getFD() << " handleIncomingMessage.");
 
         std::vector<char>& data = _socket->getInBuffer();
 
@@ -868,9 +871,9 @@ private:
 
     void performWrites() override
     {
-        LOG_TRC("performWrites");
-
         Buffer& out = _socket->getOutBuffer();
+        LOG_TRC("performWrites: " << out.size() << " bytes.");
+
         if (!_request.writeData(out))
         {
             _socket->shutdown();

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -459,10 +459,8 @@ public:
     static constexpr const char* HTTP_1_1 = "HTTP/1.1";
     static constexpr const char* OK = "OK";
 
-    StatusLine(std::string version = HTTP_1_1, int code = 0, std::string reason = std::string())
-        : _httpVersion(std::move(version))
-        , _statusCode(code)
-        , _reasonPhrase(std::move(reason))
+    StatusLine()
+        : _statusCode(0)
     {
     }
 

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -786,7 +786,7 @@ private:
         if (!_connected && !connect())
             return false;
 
-        SocketPoll poller("HttpSessionPoll");
+        SocketPoll poller("HttpSynReqPoll");
 
         poller.insertNewSocket(_socket);
         poller.poll(timeout);

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -152,6 +152,7 @@ using IoWriteFunc = std::function<int64_t(const char*, int64_t)>;
 /// -1 for error (terminates the transfer).
 /// The second argument is the buffer size.
 using IoReadFunc = std::function<int64_t(char*, int64_t)>;
+
 /// An HTTP Header.
 class Header
 {
@@ -309,6 +310,8 @@ private:
 class Request final
 {
 public:
+    static constexpr int64_t VersionLen = 8;
+    static constexpr int64_t MinRequestHeaderLen = sizeof("GET / HTTP/0.0\r\n") - 1;
     static constexpr const char* VERB_GET = "GET";
     static constexpr const char* VERB_POST = "POST";
     static constexpr const char* VERS_1_1 = "HTTP/1.1";
@@ -419,6 +422,11 @@ public:
 
         return true;
     }
+
+    /// Handles incoming data.
+    /// Returns the number of bytes consumed, or -1 for error
+    /// and/or to interrupt transmission.
+    int64_t readData(const char* p, int64_t len);
 
 private:
     Header _header;

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -9,6 +9,7 @@
 
 #include <chrono>
 #include <cstdint>
+#include <iostream>
 #include <fstream>
 #include <memory>
 #include <sstream>
@@ -136,7 +137,6 @@ enum class FieldParseState
     Unknown, //< Not yet parsed.
     Incomplete, //< Not enough data to parse this field. Need more data.
     Invalid, //< The field is invalid/unexpected/long.
-    Complete, //< The field is complete. Doesn't imply it's valid.
     Valid //< The field is both complete and valid.
 };
 
@@ -945,5 +945,48 @@ private:
 };
 
 } // namespace http
+
+#define CASE(X)                                                                                    \
+    case X:                                                                                        \
+        os << #X;                                                                                  \
+        break;
+
+inline std::ostream& operator<<(std::ostream& os, const http::FieldParseState& fieldParseState)
+{
+    switch (fieldParseState)
+    {
+        CASE(http::FieldParseState::Unknown);
+        CASE(http::FieldParseState::Incomplete);
+        CASE(http::FieldParseState::Invalid);
+        CASE(http::FieldParseState::Valid);
+    }
+    return os;
+}
+
+inline std::ostream& operator<<(std::ostream& os, const http::Request::Stage& stage)
+{
+    switch (stage)
+    {
+        CASE(http::Request::Stage::Body);
+        CASE(http::Request::Stage::Finished);
+        CASE(http::Request::Stage::Header);
+    }
+    return os;
+}
+
+inline std::ostream& operator<<(std::ostream& os, const http::Response::State& state)
+{
+    switch (state)
+    {
+        CASE(http::Response::State::New);
+        CASE(http::Response::State::Incomplete);
+        CASE(http::Response::State::Error);
+        CASE(http::Response::State::Timeout);
+        CASE(http::Response::State::Complete);
+    }
+    return os;
+}
+
+#undef CASE
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -736,7 +736,8 @@ public:
     /// I.e. when statusLine().statusCategory() != StatusLine::StatusCodeClass::Successful.
     bool syncDownload(const Request& req, const std::string& saveToFilePath)
     {
-        LOG_TRC("syncDownload");
+        LOG_TRC("syncDownload: " << req.getVerb() << ' ' << host() << ':' << port() << ' '
+                                 << req.getUrl());
 
         newRequest(req);
 
@@ -750,7 +751,8 @@ public:
     /// The payload body of the response, if any, can be read via getBody().
     bool syncRequest(const Request& req)
     {
-        LOG_TRC("syncRequest");
+        LOG_TRC("syncRequest: " << req.getVerb() << ' ' << host() << ':' << port() << ' '
+                                << req.getUrl());
 
         newRequest(req);
 
@@ -759,7 +761,8 @@ public:
 
     bool asyncRequest(const Request& req, SocketPoll& poll)
     {
-        LOG_TRC("asyncRequest");
+        LOG_TRC("asyncRequest: " << req.getVerb() << ' ' << host() << ':' << port() << ' '
+                                 << req.getUrl());
 
         newRequest(req);
 

--- a/net/ServerSocket.hpp
+++ b/net/ServerSocket.hpp
@@ -104,12 +104,18 @@ public:
         }
     }
 
+protected:
+    /// Create a Socket instance from the accepted socket FD.
+    std::shared_ptr<Socket> createSocketFromAccept(int fd) const
+    {
+        return _sockFactory->create(fd);
+    }
+
 private:
 #if !MOBILEAPP
     Socket::Type _type;
 #endif
     SocketPoll& _clientPoller;
-protected:
     std::shared_ptr<SocketFactory> _sockFactory;
 };
 

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -685,7 +685,7 @@ std::shared_ptr<Socket> ServerSocket::accept()
         // Create a socket object using the factory.
         if (rc != -1)
         {
-            std::shared_ptr<Socket> _socket = _sockFactory->create(rc);
+            std::shared_ptr<Socket> _socket = createSocketFromAccept(rc);
 
 #if !MOBILEAPP
             char addrstr[INET6_ADDRSTRLEN];
@@ -768,7 +768,7 @@ std::shared_ptr<Socket> LocalServerSocket::accept()
         if (rc < 0)
             return std::shared_ptr<Socket>(nullptr);
 
-        std::shared_ptr<Socket> _socket = _sockFactory->create(rc);
+        std::shared_ptr<Socket> _socket = createSocketFromAccept(rc);
         // Sanity check this incoming socket
 #ifndef __FreeBSD__
 #define CREDS_UID(c) c.uid

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -1005,7 +1005,7 @@ public:
                 len = readData(buf, sizeof(buf));
                 last_errno = errno;
 
-                LOG_TRC('#' << getFD() << ": Read incoming data " << len << " bytes to have "
+                LOG_TRC('#' << getFD() << ": Read incoming data " << len << " bytes in addition to "
                             << _inBuffer.size() << " buffered bytes ("
                             << Util::symbolicErrno(last_errno) << ": " << std::strerror(last_errno)
                             << ')');

--- a/test/HttpRequestTests.cpp
+++ b/test/HttpRequestTests.cpp
@@ -71,7 +71,7 @@ void HttpRequestTests::testInvalidURI()
     LOK_ASSERT(httpResponse->done() == false);
     LOK_ASSERT(httpResponse->state() != http::Response::State::Complete);
     LOK_ASSERT(httpResponse->statusLine().statusCode() != Poco::Net::HTTPResponse::HTTP_OK);
-    LOK_ASSERT(httpResponse->statusLine().statusCode() == 0);
+    LOK_ASSERT_EQUAL(0, httpResponse->statusLine().statusCode());
     LOK_ASSERT(httpResponse->statusLine().statusCategory()
                == http::StatusLine::StatusCodeClass::Invalid);
     LOK_ASSERT(httpResponse->getBody().empty());
@@ -127,7 +127,7 @@ void HttpRequestTests::testSimpleGet()
         LOK_ASSERT(httpResponse->state() == http::Response::State::Complete);
         LOK_ASSERT(!httpResponse->statusLine().httpVersion().empty());
         LOK_ASSERT(!httpResponse->statusLine().reasonPhrase().empty());
-        LOK_ASSERT(httpResponse->statusLine().statusCode() == 200);
+        LOK_ASSERT_EQUAL(200, httpResponse->statusLine().statusCode());
         LOK_ASSERT(httpResponse->statusLine().statusCategory()
                    == http::StatusLine::StatusCodeClass::Successful);
 
@@ -160,7 +160,7 @@ void HttpRequestTests::testSimpleGetSync()
     LOK_ASSERT(httpResponse->state() == http::Response::State::Complete);
     LOK_ASSERT(!httpResponse->statusLine().httpVersion().empty());
     LOK_ASSERT(!httpResponse->statusLine().reasonPhrase().empty());
-    LOK_ASSERT(httpResponse->statusLine().statusCode() == 200);
+    LOK_ASSERT_EQUAL(200, httpResponse->statusLine().statusCode());
     LOK_ASSERT(httpResponse->statusLine().statusCategory()
                == http::StatusLine::StatusCodeClass::Successful);
 
@@ -244,7 +244,7 @@ void HttpRequestTests::test500GetStatuses()
         LOK_ASSERT(httpResponse->statusLine().statusCategory()
                    == statusCodeClasses[curStatusCodeClass]);
 
-        LOK_ASSERT(httpResponse->statusLine().statusCode() == statusCode);
+        LOK_ASSERT_EQUAL(statusCode, httpResponse->statusLine().statusCode());
 
         if (httpResponse->statusLine().statusCategory()
             != http::StatusLine::StatusCodeClass::Informational)
@@ -299,7 +299,7 @@ void HttpRequestTests::testSimplePost()
     LOK_ASSERT(httpResponse->state() == http::Response::State::Complete);
     LOK_ASSERT(!httpResponse->statusLine().httpVersion().empty());
     LOK_ASSERT(!httpResponse->statusLine().reasonPhrase().empty());
-    LOK_ASSERT(httpResponse->statusLine().statusCode() == 200);
+    LOK_ASSERT_EQUAL(200, httpResponse->statusLine().statusCode());
     LOK_ASSERT(httpResponse->statusLine().statusCategory()
                == http::StatusLine::StatusCodeClass::Successful);
 

--- a/test/HttpRequestTests.cpp
+++ b/test/HttpRequestTests.cpp
@@ -172,19 +172,23 @@ void HttpRequestTests::testSimpleGetSync()
 static void compare(const Poco::Net::HTTPResponse& pocoResponse, const std::string& pocoBody,
                     const http::Response& httpResponse)
 {
-    LOK_ASSERT(httpResponse.state() == http::Response::State::Complete);
+    LOK_ASSERT_EQUAL_MESSAGE("Response state", httpResponse.state(),
+                             http::Response::State::Complete);
     LOK_ASSERT(!httpResponse.statusLine().httpVersion().empty());
     LOK_ASSERT(!httpResponse.statusLine().reasonPhrase().empty());
 
-    LOK_ASSERT_EQUAL(pocoBody, httpResponse.getBody());
+    LOK_ASSERT_EQUAL_MESSAGE("Body", pocoBody, httpResponse.getBody());
 
-    LOK_ASSERT_EQUAL(static_cast<int>(pocoResponse.getStatus()),
-                     httpResponse.statusLine().statusCode());
-    LOK_ASSERT_EQUAL(pocoResponse.getReason(), httpResponse.statusLine().reasonPhrase());
+    LOK_ASSERT_EQUAL_MESSAGE("Status Code", static_cast<int>(pocoResponse.getStatus()),
+                             httpResponse.statusLine().statusCode());
+    LOK_ASSERT_EQUAL_MESSAGE("Reason Phrase", pocoResponse.getReason(),
+                             httpResponse.statusLine().reasonPhrase());
 
-    LOK_ASSERT_EQUAL(pocoResponse.hasContentLength(), httpResponse.header().hasContentLength());
+    LOK_ASSERT_EQUAL_MESSAGE("hasContentLength", pocoResponse.hasContentLength(),
+                             httpResponse.header().hasContentLength());
     if (pocoResponse.hasContentLength())
-        LOK_ASSERT_EQUAL(pocoResponse.getContentLength(), httpResponse.header().getContentLength());
+        LOK_ASSERT_EQUAL_MESSAGE("ContentLength", pocoResponse.getContentLength(),
+                                 httpResponse.header().getContentLength());
 }
 
 /// This test requests specific *reponse* codes from

--- a/test/HttpRequestTests.cpp
+++ b/test/HttpRequestTests.cpp
@@ -83,7 +83,7 @@ void HttpRequestTests::testSimpleGet()
     const char* URL = "/";
 
     // Start the polling thread.
-    SocketPoll pollThread("HttpSessionPoll");
+    SocketPoll pollThread("HttpAsyncReqPoll");
     pollThread.startThread();
 
     http::Request httpRequest(URL);
@@ -198,7 +198,7 @@ void HttpRequestTests::test500GetStatuses()
     constexpr int port = 80;
 
     // Start the polling thread.
-    SocketPoll pollThread("HttpSessionPoll");
+    SocketPoll pollThread("HttpAsyncReqPoll");
     pollThread.startThread();
 
     auto httpSession = http::Session::createHttp(Host);
@@ -264,7 +264,7 @@ void HttpRequestTests::testSimplePost()
     const char* URL = "/post";
 
     // Start the polling thread.
-    SocketPoll pollThread("HttpSessionPoll");
+    SocketPoll pollThread("HttpAsyncReqPoll");
     pollThread.startThread();
 
     http::Request httpRequest(URL, http::Request::VERB_POST);

--- a/test/HttpWhiteBoxTests.cpp
+++ b/test/HttpWhiteBoxTests.cpp
@@ -1,0 +1,73 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <config.h>
+
+#include <test/lokassert.hpp>
+
+#include <net/HttpRequest.hpp>
+
+#include <chrono>
+#include <fstream>
+
+#include <cppunit/extensions/HelperMacros.h>
+
+/// HTTP WhiteBox unit-tests.
+class HttpWhiteBoxTests : public CPPUNIT_NS::TestFixture
+{
+    CPPUNIT_TEST_SUITE(HttpWhiteBoxTests);
+
+    CPPUNIT_TEST(testRequestParserValidComplete);
+    CPPUNIT_TEST(testRequestParserValidIncomplete);
+
+    CPPUNIT_TEST_SUITE_END();
+
+    void testRequestParserValidComplete();
+    void testRequestParserValidIncomplete();
+};
+
+void HttpWhiteBoxTests::testRequestParserValidComplete()
+{
+    const std::string expVerb = "GET";
+    const std::string expUrl = "/path/to/data";
+    const std::string expVersion = "HTTP/1.1";
+    const std::string data = expVerb + ' ' + expUrl + ' ' + expVersion + "\r\n";
+
+    http::Request req;
+
+    LOK_ASSERT(req.readData(data.c_str(), data.size()) > 0);
+    LOK_ASSERT_EQUAL(expVerb, req.getVerb());
+    LOK_ASSERT_EQUAL(expUrl, req.getUrl());
+    LOK_ASSERT_EQUAL(expVersion, req.getVersion());
+}
+
+void HttpWhiteBoxTests::testRequestParserValidIncomplete()
+{
+    const std::string expVerb = "GET";
+    const std::string expUrl = "/path/to/data";
+    const std::string expVersion = "HTTP/1.1";
+    const std::string data = expVerb + ' ' + expUrl + ' ' + expVersion + "\r\n";
+
+    http::Request req;
+
+    // Pass incomplete data to the reader.
+    for (std::size_t i = 0; i < data.size(); ++i)
+    {
+        // Should return 0 to signify data is incomplete.
+        LOK_ASSERT_EQUAL(0L, req.readData(data.c_str(), i));
+    }
+
+    // Now parse the whole thing.
+    LOK_ASSERT(req.readData(data.c_str(), data.size()) > 0);
+    LOK_ASSERT_EQUAL(expVerb, req.getVerb());
+    LOK_ASSERT_EQUAL(expUrl, req.getUrl());
+    LOK_ASSERT_EQUAL(expVersion, req.getVersion());
+}
+
+CPPUNIT_TEST_SUITE_REGISTRATION(HttpWhiteBoxTests);
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/test/HttpWhiteBoxTests.cpp
+++ b/test/HttpWhiteBoxTests.cpp
@@ -21,14 +21,72 @@ class HttpWhiteBoxTests : public CPPUNIT_NS::TestFixture
 {
     CPPUNIT_TEST_SUITE(HttpWhiteBoxTests);
 
+    CPPUNIT_TEST(testStatusLineParserValidComplete);
+    CPPUNIT_TEST(testStatusLineParserValidIncomplete);
+
     CPPUNIT_TEST(testRequestParserValidComplete);
     CPPUNIT_TEST(testRequestParserValidIncomplete);
 
     CPPUNIT_TEST_SUITE_END();
 
+    void testStatusLineParserValidComplete();
+    void testStatusLineParserValidIncomplete();
     void testRequestParserValidComplete();
     void testRequestParserValidIncomplete();
 };
+
+void HttpWhiteBoxTests::testStatusLineParserValidComplete()
+{
+    const int expVersionMajor = 1;
+    const int expVersionMinor = 1;
+    const std::string expVersion
+        = "HTTP/" + std::to_string(expVersionMajor) + '.' + std::to_string(expVersionMinor);
+    const int expStatusCode = 101;
+    const std::string expReasonPhrase = "Something Something";
+    const std::string data
+        = expVersion + ' ' + std::to_string(expStatusCode) + ' ' + expReasonPhrase + "\r\n";
+
+    http::StatusLine statusLine;
+
+    int64_t len = data.size();
+    LOK_ASSERT_EQUAL(http::FieldParseState::Valid, statusLine.parse(data.c_str(), len));
+    LOK_ASSERT_EQUAL(expVersion, statusLine.httpVersion());
+    LOK_ASSERT_EQUAL(expVersionMajor, statusLine.versionMajor());
+    LOK_ASSERT_EQUAL(expVersionMinor, statusLine.versionMinor());
+    LOK_ASSERT_EQUAL(expStatusCode, statusLine.statusCode());
+    LOK_ASSERT_EQUAL(expReasonPhrase, statusLine.reasonPhrase());
+}
+
+void HttpWhiteBoxTests::testStatusLineParserValidIncomplete()
+{
+    const int expVersionMajor = 1;
+    const int expVersionMinor = 1;
+    const std::string expVersion
+        = "HTTP/" + std::to_string(expVersionMajor) + '.' + std::to_string(expVersionMinor);
+    const int expStatusCode = 101;
+    const std::string expReasonPhrase = "Something Something";
+    const std::string data
+        = expVersion + ' ' + std::to_string(expStatusCode) + ' ' + expReasonPhrase + "\r\n";
+
+    http::StatusLine statusLine;
+
+    // Pass incomplete data to the reader.
+    for (std::size_t i = 0; i < data.size(); ++i)
+    {
+        // Should return 0 to signify data is incomplete.
+        int64_t len = i;
+        LOK_ASSERT_EQUAL_MESSAGE("i = " + std::to_string(i), http::FieldParseState::Incomplete,
+                                 statusLine.parse(data.c_str(), len));
+    }
+
+    int64_t len = data.size();
+    LOK_ASSERT_EQUAL(http::FieldParseState::Valid, statusLine.parse(data.c_str(), len));
+    LOK_ASSERT_EQUAL(expVersion, statusLine.httpVersion());
+    LOK_ASSERT_EQUAL(expVersionMajor, statusLine.versionMajor());
+    LOK_ASSERT_EQUAL(expVersionMinor, statusLine.versionMinor());
+    LOK_ASSERT_EQUAL(expStatusCode, statusLine.statusCode());
+    LOK_ASSERT_EQUAL(expReasonPhrase, statusLine.reasonPhrase());
+}
 
 void HttpWhiteBoxTests::testRequestParserValidComplete()
 {

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -76,6 +76,7 @@ wsd_sources = \
 test_base_source = \
 	TileQueueTests.cpp \
 	WhiteBoxTests.cpp \
+	HttpWhiteBoxTests.cpp \
 	DeltaTests.cpp \
 	WopiProofTests.cpp \
 	$(wsd_sources)

--- a/test/WhiteBoxTests.cpp
+++ b/test/WhiteBoxTests.cpp
@@ -7,8 +7,6 @@
 
 #include <config.h>
 
-#include <chrono>
-#include <fstream>
 #include <test/lokassert.hpp>
 
 #include <Auth.hpp>
@@ -26,6 +24,11 @@
 #include <common/Authorization.hpp>
 #include <wsd/FileServer.hpp>
 #include <net/Buffer.hpp>
+
+#include <chrono>
+#include <fstream>
+
+#include <cppunit/extensions/HelperMacros.h>
 
 /// WhiteBox unit-tests.
 class WhiteBoxTests : public CPPUNIT_NS::TestFixture

--- a/test/helpers.hpp
+++ b/test/helpers.hpp
@@ -160,8 +160,17 @@ pocoGet(const Poco::URI& uri)
         session->sendRequest(request);
         auto response = std::make_shared<Poco::Net::HTTPResponse>();
         std::istream& rs = session->receiveResponse(*response);
-        LOG_DBG("pocoGet response for [" << uri.toString() << "]: " << response->getStatus() << ' '
-                                         << response->getReason());
+
+        LOG_DBG("pocoGet response for ["
+                << uri.toString() << "]: " << response->getStatus() << ' ' << response->getReason()
+                << ", hasContentLength: " << response->hasContentLength() << ", ContentLength: "
+                // << (response->hasContentLength() ? response->getContentLength64() : -1));
+                << response->getContentLength64());
+
+        for (const auto& pair : *response)
+        {
+            LOG_TRC(pair.first << '=' << pair.second);
+        }
 
         std::string responseString;
         if (response->hasContentLength() && response->getContentLength() > 0)

--- a/test/lokassert.hpp
+++ b/test/lokassert.hpp
@@ -58,11 +58,14 @@ inline std::ostream& operator<<(std::ostream& os, const std::vector<char>& v)
     {                                                                                              \
         if (!((expected) == (actual)))                                                             \
         {                                                                                          \
-            TST_LOG_NAME("unittest", "Assertion failure: " << (message) << ". Expected ["          \
+            LOK_ASSERT_IMPL((expected) == (actual));                                               \
+            std::ostringstream oss##__LINE__;                                                      \
+            oss##__LINE__ << message;                                                              \
+            const auto msg##__LINE__ = oss##__LINE__.str();                                        \
+            TST_LOG_NAME("unittest", "Assertion failure: " << msg##__LINE__ << ". Expected ["      \
                                                            << (expected) << "] but got ["          \
                                                            << (actual) << "]: ");                  \
-            LOK_ASSERT_IMPL((expected) == (actual));                                               \
-            CPPUNIT_ASSERT_EQUAL_MESSAGE((message), (expected), (actual));                         \
+            CPPUNIT_ASSERT_EQUAL_MESSAGE(msg##__LINE__, (expected), (actual));                     \
         }                                                                                          \
     } while (false)
 

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -97,7 +97,8 @@ int main(int argc, char** argv)
     }
 
     const char* loglevel = verbose ? "trace" : "warning";
-    Log::initialize("tst", loglevel, true, false, {});
+    const bool withColor = isatty(fileno(stderr));
+    Log::initialize("tst", loglevel, withColor, false, {});
 
 #if ENABLE_SSL
     try


### PR DESCRIPTION
Partial support for HTTP Server, new tests and fixes to the Client HTTP code and logging improvements.

- wsd: http: better logging and tracing
- wsd: encapsulate ServerSocket::_socketFactory
- wsd: http: factor out whitespace check
- wsd: http: normalize helper function API
- wsd: http::Request parser
- wsd: test: WhiteBoxTests include cleanup
- wsd: test: HttpRequestTests improved
- wsd: better http poll thread name
- wsd: minor logging improvement
- wsd: http: define streaming operators
- wsd: http: support setting header fields from Request
- wsd: http: StatusLine tests
- wsd: http: better logging
- wsd: http: better test assertions
- wsd: test: LOK_ASSERT messages support ostream
- test: don't use colored logging when output is redirected
