### PR TITLE
Calc: Refresh headers after a resize.

### DIFF
--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -601,6 +601,10 @@ L.CanvasTileLayer = L.TileLayer.extend({
 			this._painter._sectionContainer.onResize(size.x, size.y);
 			tileContainer.style.width = this._painter._sectionContainer.canvas.style.width;
 			tileContainer.style.height = this._painter._sectionContainer.canvas.style.height;
+			if (this._painter._sectionContainer.doesSectionExist(L.CSections.RowHeader.name)) {
+				this._painter._sectionContainer.getSectionWithName(L.CSections.RowHeader.name)._updateCanvas();
+				this._painter._sectionContainer.getSectionWithName(L.CSections.ColumnHeader.name)._updateCanvas();
+			}
 		}
 	},
 


### PR DESCRIPTION
Headers weren't being refreshed when:
* Keyboard is hidden on mobile.
* Setting mode to read only.

Signed-off-by: Gökay Şatır <gokay.satir@collabora.com>
Change-Id: Iaa65c6145289f160977269a54c1b8409c411615d


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

