### PR TITLE
Calc: Notebookbar: Download as CSV fix alignment

### DIFF
--- a/loleaflet/src/control/Control.NotebookbarCalc.js
+++ b/loleaflet/src/control/Control.NotebookbarCalc.js
@@ -260,9 +260,18 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 										]
 									}
 								]
-							},
+							}
+						]
+					},
+					{
+						'id': 'saveas-Section',
+						'type': 'container',
+						'text': '',
+						'enabled': 'true',
+						'vertical': 'true',
+						'children': [
 							{
-								'id': 'saveas-Section3',
+								'id': 'saveas-Section1',
 								'type': 'container',
 								'text': '',
 								'enabled': 'true',


### PR DESCRIPTION
New section has been wrongly back-ported as was being set inside of
existing group instead of a new one. This was resulting in a column with
3 elements and thus the whole notebookbar content was vertically
misaligned.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I21683caf5d2d47b825b4c11eabdea98e516364e4
