### PR TITLE
canvas: avoid flicker when zooming

### DIFF
--- a/loleaflet/src/layer/tile/CanvasSectionContainer.ts
+++ b/loleaflet/src/layer/tile/CanvasSectionContainer.ts
@@ -105,6 +105,8 @@
 */
 
 // This class will be used internally by CanvasSectionContainer.
+
+declare var L: any;
 class CanvasSectionObject {
 	context: CanvasRenderingContext2D = null;
 	myTopLeft: Array<number> = null;
@@ -1159,9 +1161,17 @@ class CanvasSectionContainer {
 	private drawSections () {
 		this.context.setTransform(1, 0, 0, 1, 0, 0);
 		this.context.fillStyle = this.clearColor;
-		this.context.clearRect(0, 0, this.canvas.width, this.canvas.height);
-		this.context.fillRect(0, 0, this.canvas.width, this.canvas.height);
 
+		// When we zoom in we try to avoid the entire canvas repaint
+		// instead we just clear the surrounding of the doc (remnant from previous zoom)
+		if (L.Map.THIS.getTileSectionMgr() && L.Map.THIS.getTileSectionMgr()._zoomChanged) {
+			this.context.clearRect(0, 0, -this.documentTopLeft[0], this.canvas.height);
+			this.context.fillRect(0, 0, -this.documentTopLeft[0], this.canvas.height);
+		}
+		else {
+			this.context.clearRect(0, 0, this.canvas.width, this.canvas.height);
+			this.context.fillRect(0, 0, this.canvas.width, this.canvas.height);
+		}
 		this.context.font = String(20 * this.dpiScale) + "px Verdana";
 		for (var i: number = 0; i < this.sections.length; i++) {
 			if (this.sections[i].isLocated) {

--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -78,12 +78,13 @@ L.TileSectionManager = L.Class.extend({
 		sourceElement.addEventListener('touchcancel', function (e) { that._sectionContainer.onTouchCancel(e); }, true);
 	},
 
-	startUpdates: function () {
+	startUpdates: function (e) {
 		if (this._updatesRunning === true) {
 			return false;
 		}
 
 		this._updatesRunning = true;
+		this._zoomChanged = e.zoomChanged;
 		this._updateWithRAF();
 		return true;
 	},
@@ -93,6 +94,7 @@ L.TileSectionManager = L.Class.extend({
 			L.Util.cancelAnimFrame(this._canvasRAF);
 			this.update();
 			this._updatesRunning = false;
+			this._zoomChanged = false;
 			return true;
 		}
 
@@ -330,7 +332,9 @@ L.TileSectionManager = L.Class.extend({
 		this._layer._canvasOverlay.paintRegion(tileBounds);
 	},
 
-	update: function () {
+	update: function (e) {
+		if (e)
+			this._zoomChanged = e.zoomChanged;
 		this._sectionContainer.requestReDraw();
 	},
 
@@ -495,8 +499,8 @@ L.CanvasTileLayer = L.TileLayer.extend({
 		// Using L.TileSectionManager's own requestAnimationFrame loop to do the updates in that case does not perform well.
 		if (window.mode.isMobile() || window.mode.isTablet()) {
 			this._map.on('move', this._painter.update, this._painter);
-			this._map.on('moveend', function () {
-				setTimeout(this.update.bind(this), 200);
+			this._map.on('moveend', function (e) {
+				setTimeout(this.update.bind(this, e), 200);
 			}, this._painter);
 		}
 		else {

--- a/loleaflet/src/layer/tile/TilesSection.ts
+++ b/loleaflet/src/layer/tile/TilesSection.ts
@@ -93,8 +93,17 @@ class TilesSection {
 	paintWithPanes (tile: any, ctx: any) {
 		var tileTopLeft = tile.coords.getPos();
 		var tileBounds = new L.Bounds(tileTopLeft, tileTopLeft.add(ctx.tileSize));
+		var tileWidth = tileBounds.max.x - tileBounds.min.x;
+		var tileHeight = tileBounds.max.y - tileBounds.min.y;
 
 		for (var i = 0; i < ctx.paneBoundsList.length; ++i) {
+
+			// When zooming we have avoided to clear the canvas
+			// so here we clear area for each tile as we recieve
+			if (L.Map.THIS.getTileSectionMgr() && L.Map.THIS.getTileSectionMgr()._zoomChanged) {
+				this.context.clearRect(tileTopLeft.x, tileTopLeft.y, tileWidth, tileHeight);
+				this.context.fillRect(tileTopLeft.x, tileTopLeft.y, tileWidth, tileHeight);
+			}
 			// co-ordinates of this pane in core document pixels
 			var paneBounds = ctx.paneBoundsList[i];
 			// co-ordinates of the main-(bottom right) pane in core document pixels
@@ -165,6 +174,12 @@ class TilesSection {
 			this.context.fillRect(offset.x, offset.y, ctx.tileSize.x, ctx.tileSize.y);
 		}
 
+		// When zooming we have avoided to clear the canvas
+		// so here we clear area for each tile as we recieve
+		if (L.Map.THIS.getTileSectionMgr() && L.Map.THIS.getTileSectionMgr()._zoomChanged) {
+			this.context.clearRect(offset.x, offset.y, ctx.tileSize.x, ctx.tileSize.y);
+			this.context.fillRect(offset.x, offset.y, ctx.tileSize.x, ctx.tileSize.y);
+		}
 		this.context.drawImage(tile.el, offset.x, offset.y, ctx.tileSize.x, ctx.tileSize.y);
 		this.oscCtxs[0].drawImage(tile.el, extendedOffset.x, extendedOffset.y, ctx.tileSize.x, ctx.tileSize.y);
 	}

--- a/loleaflet/src/map/Map.js
+++ b/loleaflet/src/map/Map.js
@@ -1151,7 +1151,7 @@ L.Map = L.Evented.extend({
 		var zoomChanged = (this._zoom !== zoom);
 
 		if (!afterZoomAnim) {
-			this.fire('movestart');
+			this.fire('movestart', {zoomChanged: zoomChanged});
 
 			if (zoomChanged) {
 				this.fire('zoomstart');
@@ -1169,20 +1169,20 @@ L.Map = L.Evented.extend({
 		var loading = !this._loaded;
 		this._loaded = true;
 
-		this.fire('viewreset', {hard: !preserveMapOffset});
+		this.fire('viewreset', {hard: !preserveMapOffset, zoomChanged: zoomChanged});
 
 		if (loading) {
-			this.fire('load');
+			this.fire('load', {zoomChanged: zoomChanged});
 		}
 
-		this.fire('move');
+		this.fire('move', {zoomChanged: zoomChanged});
 
 		if (zoomChanged || afterZoomAnim) {
-			this.fire('zoomend');
-			this.fire('zoomlevelschange');
+			this.fire('zoomend', {zoomChanged: zoomChanged});
+			this.fire('zoomlevelschange', {zoomChanged: zoomChanged});
 		}
 
-		this.fire('moveend', {hard: !preserveMapOffset});
+		this.fire('moveend', {hard: !preserveMapOffset, zoomChanged: zoomChanged});
 
 		if (this.getDocType() === 'presentation') {
 			if (this._docLayer._annotationManager.getSelectedPart() !== undefined) {


### PR DESCRIPTION


Signed-off-by: Pranam Lashkari <lpranam@collabora.com>
Change-Id: I9fb8e463b69288fb3e9e6033eb04fd4b85351ea1


* Target version: master 

### Summary
flicker was caused because when we zoom we cleared the entire canvas at once
this patch would make sure instead of clearing the entire canvas,
we clear the area for a tile as we receive a tile


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

