### PR TITLE
leaflet: fixed pdf loading

### DIFF
--- a/loleaflet/src/control/Control.Menubar.js
+++ b/loleaflet/src/control/Control.Menubar.js
@@ -5,7 +5,7 @@
 
 /* global $ _ _UNO vex L */
 L.Control.Menubar = L.Control.extend({
-	// TODO: Some mechanism to stop the need to copy duplicate menus (eg. Help)
+	// TODO: Some mechanism to stop the need to copy duplicate menus (eg. Help, eg: mobiledrawing)
 	options: {
 		initial: [
 			{name: _UNO('.uno:PickList')},
@@ -767,6 +767,55 @@ L.Control.Menubar = L.Control.extend({
 		],
 
 		mobilepresentation: [
+			{name: _UNO('.uno:PickList', 'presentation'), id: 'file', type: 'menu', menu: [
+				{name: _UNO('.uno:Save', 'presentation'), id: 'save', type: 'action'},
+				{name: _UNO('.uno:SaveAs', 'presentation'), id: 'saveas', type: 'action'},
+				{name: _('Share...'), id:'shareas', type: 'action'},
+				{name: _UNO('.uno:Print', 'presentation'), id: 'print', type: 'action'},
+				{name: _('See revision history'), id: 'rev-history', type: 'action'},
+			]},
+			{name: !window.ThisIsAMobileApp ? _('Download as') : _('Export as'), id:'downloadas', type: 'menu', menu: [
+				{name: _('PDF Document (.pdf)'), id: 'downloadas-pdf', type: 'action'},
+				{name: _('ODF presentation (.odp)'), id: 'downloadas-odp', type: 'action', drawing: false},
+				{name: _('PowerPoint 2003 Presentation (.ppt)'), id: 'downloadas-ppt', type: 'action', drawing: false},
+				{name: _('PowerPoint Presentation (.pptx)'), id: 'downloadas-pptx', type: 'action', drawing: false},
+				{name: _('ODF Drawing (.odg)'), id: 'downloadas-odg', type: 'action'}
+			]},
+			{name: _UNO('.uno:EditMenu', 'presentation'), id: 'editmenu', type: 'menu', menu: [
+				{uno: '.uno:Undo'},
+				{uno: '.uno:Redo'},
+				{name: _('Repair'), id: 'repair',  type: 'action'},
+				{type: 'separator'},
+				{uno: '.uno:Cut'},
+				{uno: '.uno:Copy'},
+				{uno: '.uno:Paste'},
+				{uno: '.uno:SelectAll'}
+			]},
+			{name: _('Search'), id: 'searchdialog', type: 'action'},
+			{name: _UNO('.uno:TableMenu', 'text'/*HACK should be 'presentation', but not in xcu*/), id: 'tablemenu', type: 'menu', menu: [
+				{uno: '.uno:InsertRowsBefore'},
+				{uno: '.uno:InsertRowsAfter'},
+				{type: 'separator'},
+				{uno: '.uno:InsertColumnsBefore'},
+				{uno: '.uno:InsertColumnsAfter'},
+				{uno: '.uno:DeleteRows'},
+				{uno: '.uno:DeleteColumns'},
+				{uno: '.uno:MergeCells'}]
+			},
+			{name: _UNO('.uno:SlideMenu', 'presentation'), id: 'slidemenu', type: 'menu', menu: [
+				{name: _UNO('.uno:InsertSlide', 'presentation'), id: 'insertpage', type: 'action'},
+				{name: _UNO('.uno:DuplicateSlide', 'presentation'), id: 'duplicatepage', type: 'action'},
+				{name: _UNO('.uno:DeleteSlide', 'presentation'), id: 'deletepage', type: 'action'}]
+			},
+			{name: _UNO('.uno:FullScreen', 'presentation'), id: 'fullscreen', type: 'action', mobileapp: false},
+			{name: _UNO('.uno:RunMacro'), id: 'runmacro', uno: '.uno:RunMacro'},
+			{uno: '.uno:SpellOnline'},
+			{name: _('Fullscreen presentation'), id: 'fullscreen-presentation', type: 'action'},
+			{name: _('Latest Updates'), id: 'latest-updates', type: 'action', iosapp: false},
+			{name: _('About'), id: 'about', type: 'action'},
+		],
+
+		mobiledrawing: [
 			{name: _UNO('.uno:PickList', 'presentation'), id: 'file', type: 'menu', menu: [
 				{name: _UNO('.uno:Save', 'presentation'), id: 'save', type: 'action'},
 				{name: _UNO('.uno:SaveAs', 'presentation'), id: 'saveas', type: 'action'},

--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -1012,7 +1012,7 @@ L.Socket = L.Class.extend({
 					(new L.CalcGridLines()).addTo(this._map);
 				}
 			}
-			else if (command.type === 'presentation') {
+			else if (command.type === 'presentation' || command.type === 'drawing') {
 				docLayer = new L.ImpressTileLayer('', {
 					permission: this._map.options.permission,
 					tileWidthTwips: tileWidthTwips / window.devicePixelRatio,


### PR DESCRIPTION


Signed-off-by: Pranam Lashkari <lpranam@collabora.com>
Change-Id: Idcd70f49010b074ee9987755132b7010b72a86f9

* Target version: distro/collabora/co-6-4 

### Summary
pdf cloud not be loaded at all
regression caused by ddbc4e25ffb0c40b27aa8a0 (#1737)

also fixed the main menu in mobile for pdf/drawing


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

