### PR TITLE
comment wizard: fixed permissions for comment insertion

### DIFF
--- a/loleaflet/src/control/Control.JSDialogBuilder.js
+++ b/loleaflet/src/control/Control.JSDialogBuilder.js
@@ -2192,13 +2192,19 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			}, data.annotation);
 		}
 
-		if (data.annotation.options.noMenu !== true && this.map.isPermissionEditForComments()) {
+		if (data.annotation.options.noMenu !== true && this.map.isPermissionEditForComments() && !this.map.isPermissionReadOnly()) {
 			var tdMenu = L.DomUtil.create(tagTd, 'loleaflet-annotation-menubar', tr);
 			var divMenu = data.annotation._menu = L.DomUtil.create(tagDiv, data.data.trackchange ? 'loleaflet-annotation-menu-redline' : 'loleaflet-annotation-menu', tdMenu);
 			divMenu.title = _('Open menu');
 			divMenu.annotation = data.annotation;
 			if (this.map._docLayer._docType === 'text')
 				divMenu.isRoot = isRoot;
+
+			divMenu.onclick = function(e) {
+				L.DomEvent.stopPropagation(e);
+				L.DomEvent.preventDefault(e);
+				$(divMenu).contextMenu();
+			};
 		}
 		if (data.data.trackchange) {
 			data.annotation._captionNode = L.DomUtil.create(tagDiv, 'loleaflet-annotation-caption', wrapper);
@@ -2213,12 +2219,6 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		var d = new Date(data.data.dateTime.replace(/,.*/, 'Z'));
 		var dateOptions = { weekday: 'short', year: 'numeric', month: 'short', day: 'numeric' };
 		$(data.annotation._contentDate).text(isNaN(d.getTime()) ? data.data.dateTime: d.toLocaleDateString(String.locale, dateOptions));
-
-		divMenu.onclick = function(e) {
-			L.DomEvent.stopPropagation(e);
-			L.DomEvent.preventDefault(e);
-			$(divMenu).contextMenu();
-		};
 	},
 
 	_rootCommentControl: function(parentContainer, data, builder) {
@@ -2289,9 +2289,11 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		var textNode = L.DomUtil.create('figcaption', 'empty-comment-wizard', emptyCommentWizard);
 		textNode.innerText = data.text;
 		L.DomUtil.create('br', 'empty-comment-wizard', textNode);
-		var linkNode = L.DomUtil.create('div', 'empty-comment-wizard-link', textNode);
-		linkNode.innerText = _('Insert Comment');
-		linkNode.onclick = builder.map.insertComment.bind(builder.map);
+		if (this.map.isPermissionEditForComments() && !this.map.isPermissionReadOnly()) {
+			var linkNode = L.DomUtil.create('div', 'empty-comment-wizard-link', textNode);
+			linkNode.innerText = _('Insert Comment');
+			linkNode.onclick = builder.map.insertComment.bind(builder.map);
+		}
 	},
 
 	_createIconURL: function(name) {

--- a/loleaflet/src/control/Permission.js
+++ b/loleaflet/src/control/Permission.js
@@ -79,6 +79,7 @@ L.Map.include({
 		this._enterEditMode('edit');
 		if (window.mode.isMobile() || window.mode.isTablet()) {
 			this.fire('editorgotfocus');
+			this.fire('closemobilewizard');
 			// In the iOS/android app, just clicking the mobile-edit-button is
 			// not reason enough to pop up the on-screen keyboard.
 			if (!(window.ThisIsTheiOSApp || window.ThisIsTheAndroidApp))

--- a/loleaflet/src/layer/tile/TileLayer.js
+++ b/loleaflet/src/layer/tile/TileLayer.js
@@ -4000,11 +4000,13 @@ L.TileLayer = L.GridLayer.extend({
 				type : 'mainmenu',
 				enabled : true,
 				text : _('Comment'),
-				customTitle : customTitleBar,
 				executionType : 'menu',
 				data : [],
 				children : []
 			};
+
+			if (this._map.isPermissionEditForComments() && !this._map.isPermissionReadOnly())
+				menuStructure['customTitle'] = customTitleBar;
 		}
 
 		this._map._docLayer._createCommentStructure(menuStructure);


### PR DESCRIPTION


Signed-off-by: Pranam Lashkari <lpranam@collabora.com>
Change-Id: I72e6c7d5077433c2eec283e9bc05493fdb8abefe


* Target version: distro/collabora/co-6-4 

### Summary
comment wizard allowed comment insertion and modification,
in readonly mode too


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

