### PR TITLE
Notebookbar: File tab: Remove ellipsis from Print and _saveAs

### DIFF
--- a/loleaflet/src/control/Control.NotebookbarBuilder.js
+++ b/loleaflet/src/control/Control.NotebookbarBuilder.js
@@ -667,6 +667,7 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 	},
 
 	_saveAsControl: function(parentContainer, data, builder) {
+		data.text = data.text.slice(0, -3);
 		var control = builder._unoToolButton(parentContainer, data, builder);
 
 		$(control.container).unbind('click');
@@ -685,6 +686,7 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 	},
 
 	_printControl: function(parentContainer, data, builder) {
+		data.text = data.text.slice(0, -3);
 		var control = builder._unoToolButton(parentContainer, data, builder);
 
 		$(control.container).unbind('click');


### PR DESCRIPTION
In sequence of issue #1285:
* https://github.com/CollaboraOnline/online/issues/1285#issuecomment-764556056
  * @kendy we are actually using the right variant
  which is the one used also in core tabbed layout but it also has those
  ellipsis
* Removing the ellipsis in the most visible case (File tab) for Print...
  and Save As... shouldn't be problematic as it does not had any extra
  condition and instead just slices the string under their respective
  object's property

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I04b01d8fb8b3ecb242fa684019a293cb5aaf51b8
