### PR TITLE
fix: undo + sheet switch breaks cursors

### DIFF
--- a/loleaflet/src/layer/tile/CalcTileLayer.js
+++ b/loleaflet/src/layer/tile/CalcTileLayer.js
@@ -520,6 +520,10 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 			this._docType = command.type;
 			this._parts = command.parts;
 			this._selectedPart = command.selectedPart;
+			if (this.sheetGeometry && this._selectedPart != this.sheetGeometry.getPart()) {
+				// Core initiated sheet switch, need to get full sheetGeometry data for the selected sheet.
+				this.requestSheetGeometryData();
+			}
 			this._viewId = parseInt(command.viewid);
 			var mapSize = this._map.getSize();
 			var sizePx = this._twipsToPixels(new L.Point(this._docWidthTwips, this._docHeightTwips));
@@ -1277,6 +1281,10 @@ L.SheetGeometry = L.Class.extend({
 		this._rows.setViewLimits(top, bottom);
 
 		return true;
+	},
+
+	getPart: function () {
+		return this._part;
 	},
 
 	getColumnsGeometry: function () {


### PR DESCRIPTION
Fix description:
Doing an undo causes core to do switch sheets if last change was in some
other sheet. But core sends status message with changed sheet number, so
ask for sheetGeometryData for this selected sheet if the sheetGeometry
we have is not for that sheet.

Signed-off-by: Dennis Francis <dennis.francis@collabora.com>
Change-Id: I6870bed86e0ffa234d659b8853a9ef9a33e02bc5


* Target version: co-6-4

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

