### PR TITLE
Notebookbar: References tab: InsertMultiIndex is too long

### DIFF
--- a/loleaflet/css/notebookbar.css
+++ b/loleaflet/css/notebookbar.css
@@ -552,6 +552,14 @@ div[id*='Row'].notebookbar, div[id*='Column'].notebookbar, #SendToBack.notebookb
 	width: 32px !important;
 }
 
+#InsertMultiIndex .unolabel {
+	max-width: 190px;
+	table-layout: fixed;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
 #table-Reference-Section-Field.notebookbar
 {
 	display: none;


### PR DESCRIPTION
- Icon and label occupy a lot of horizontal space
  - Dramatic in smaller laptops
  - Limit width of that long label without increasing height

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I1e78257f0c6c166372b585b2a5a47e2811f54129
