### PR TITLE
canvas: fix sizing on tablets

### DIFF
--- a/loleaflet/src/control/Control.UIManager.js
+++ b/loleaflet/src/control/Control.UIManager.js
@@ -415,9 +415,9 @@ L.Control.UIManager = L.Control.extend({
 		var additionalOffset = 0;
 		if (docType === 'spreadsheet') {
 			if (window.mode.isTablet())
-				additionalOffset = -7;
+				additionalOffset = -6;
 			else
-				additionalOffset = 53;
+				additionalOffset = 57;
 		}
 
 		this.moveObjectVertically($('#document-container'), 43 + additionalOffset);

--- a/loleaflet/src/control/Permission.js
+++ b/loleaflet/src/control/Permission.js
@@ -94,9 +94,6 @@ L.Map.include({
 	},
 
 	_enterEditMode: function (perm) {
-		if (this.isPermissionReadOnly() && (window.mode.isMobile() || window.mode.isTablet())) {
-			this.sendInitUNOCommands();
-		}
 		this._permission = perm;
 
 		this._socket.sendMessage('requestloksession');

--- a/loleaflet/src/layer/tile/CanvasSectionContainer.ts
+++ b/loleaflet/src/layer/tile/CanvasSectionContainer.ts
@@ -744,11 +744,14 @@ class CanvasSectionContainer {
 		if (!this.multiTouch) {
 			this.mousePosition = this.convertPositionToCanvasLocale(e);
 			this.draggingSomething = true;
-			this.dragDistance = [this.mousePosition[0] - this.positionOnMouseDown[0], this.mousePosition[1] - this.positionOnMouseDown[1]];
 
-			var section: CanvasSectionObject = this.getSectionWithName(this.sectionOnMouseDown);
-			if (section) {
-				this.propagateOnMouseMove(section, this.convertPositionToSectionLocale(section, this.mousePosition), this.dragDistance, <MouseEvent><any>e);
+			if (this.positionOnMouseDown !== null) {
+				this.dragDistance = [this.mousePosition[0] - this.positionOnMouseDown[0], this.mousePosition[1] - this.positionOnMouseDown[1]];
+
+				var section: CanvasSectionObject = this.getSectionWithName(this.sectionOnMouseDown);
+				if (section) {
+					this.propagateOnMouseMove(section, this.convertPositionToSectionLocale(section, this.mousePosition), this.dragDistance, <MouseEvent><any>e);
+				}
 			}
 		}
 		else if (e.touches.length === 2) {

--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -574,19 +574,28 @@ L.CanvasTileLayer = L.TileLayer.extend({
 		}
 	},
 
+	_getRealMapSize: function() {
+		this._map._sizeChanged = true; // force using real size
+		return this._map.getPixelBounds().getSize();
+	},
+
 	_syncTileContainerSize: function () {
 		var tileContainer = this._container;
 		if (tileContainer) {
-			var size = this._map.getPixelBounds().getSize();
+			var size = this._getRealMapSize();
 			var heightIncreased = parseInt(this._painter._sectionContainer.canvas.style.height.replace('px', '')) < size.y;
 
 			if (this._docType === 'spreadsheet') {
 				var offset = this._getUIWidth() + this._getGroupWidth();
 				offset += (this._getGroupWidth() > 0 ? 3: 1);
 
+				// modify map size
+				this._map.options.documentContainer.style.left = String(offset) + 'px';
+				// update according to the new size
+				size = this._getRealMapSize();
+
 				size.x += offset;
 				this._canvasContainer.style.left = -1 * (offset) + 'px';
-				this._map.options.documentContainer.style.left = String(offset) + 'px';
 
 				offset = this._getUIHeight() + this._getGroupHeight();
 				size.y += offset;
@@ -594,14 +603,7 @@ L.CanvasTileLayer = L.TileLayer.extend({
 
 				this._canvasContainer.style.top = -1 * offset + 'px';
 
-				if (window.mode.isDesktop() || window.mode.isTablet()) {
-					if (document.getElementById('map').classList.contains('notebookbar-opened'))
-						this._map.options.documentContainer.style.marginTop = (Math.floor(this._getGroupHeight() + this._getUIHeight())) + 'px';
-					else
-						this._map.options.documentContainer.style.marginTop = (Math.floor(this._getGroupHeight())) + 'px';
-				}
-				else // Mobile.
-					this._map.options.documentContainer.style.marginTop = String(this._getGroupHeight()) + 'px';
+				this._map.options.documentContainer.style.marginTop = this._getGroupHeight() + 'px';
 			}
 
 			this._painter._sectionContainer.onResize(size.x, size.y);

--- a/loleaflet/src/layer/tile/TileLayer.js
+++ b/loleaflet/src/layer/tile/TileLayer.js
@@ -354,8 +354,6 @@ L.TileLayer = L.GridLayer.extend({
 		this._levels = {};
 		this._tiles = {};
 		this._tileCache = {};
-		this._map._socket.sendMessage('commandvalues command=.uno:LanguageStatus');
-		this._map._socket.sendMessage('commandvalues command=.uno:ViewAnnotations');
 		var that = this;
 		L.installContextMenu({
 			selector: '.loleaflet-annotation-menu',
@@ -493,6 +491,8 @@ L.TileLayer = L.GridLayer.extend({
 		map.setPermission(this.options.permission);
 
 		map.fire('statusindicator', {statusType: 'loleafletloaded'});
+
+		this._map.sendInitUNOCommands();
 	},
 
 	// Returns true iff the document type is Writer.


### PR DESCRIPTION
Fixes issues with incorrect position and size of the canvas on tablets.
Fixes some errors (using null reference) and initializes properly the view
in readonly mode on tablets so it shows rows and columns headers
