### PR TITLE
Make the help file work properly in the mobile apps

### DIFF
--- a/loleaflet/html/loleaflet.html.m4
+++ b/loleaflet/html/loleaflet.html.m4
@@ -40,6 +40,7 @@ m4_dnl# and window.ThisIsTheGtkApp
 
 m4_ifelse(MOBILEAPP,[true],
   [   window.ThisIsAMobileApp = true;
+   window.HelpFile = String.raw`m4_syscmd([cat html/loleaflet-help.html])`;
    window.open = function (url, windowName, windowFeatures) {
      window.postMobileMessage('HYPERLINK ' + url); /* don't call the 'normal' window.open on mobile at all */
    }

--- a/loleaflet/src/control/Toolbar.js
+++ b/loleaflet/src/control/Toolbar.js
@@ -337,7 +337,13 @@ L.Map.include({
 		this.fire('selectbackground', {file: file});
 	},
 
-	showHelp: function(id) {
+	_doVexOpenHelpFile: function(data, id, map) {
+		var productName;
+		if (window.ThisIsAMobileApp) {
+			productName = window.MobileAppName;
+		} else {
+			productName = (typeof brandProductName !== 'undefined') ? brandProductName : 'Collabora Online Development Edition';
+		}
 		var w;
 		var iw = window.innerWidth;
 		if (iw < 768) {
@@ -349,161 +355,158 @@ L.Map.include({
 		else {
 			w = iw / 5 + 590;
 		}
+		vex.open({
+			unsafeContent: data,
+			showCloseButton: true,
+			escapeButtonCloses: true,
+			overlayClosesOnClick: true,
+			closeAllOnPopState: false,
+			buttons: {},
+			afterOpen: function() {
+				var $vexContent = $(this.contentEl);
+				this.contentEl.style.width = w + 'px';
+				var i;
+				// Display keyboard shortcut or online help
+				if (id === 'keyboard-shortcuts') {
+					document.getElementById('online-help').style.display='none';
+					// Display help according to document opened
+					if (map.getDocType() === 'text') {
+						document.getElementById('text-shortcuts').style.display='block';
+					}
+					else if (map.getDocType() === 'spreadsheet') {
+						document.getElementById('spreadsheet-shortcuts').style.display='block';
+					}
+					else if (map.getDocType() === 'presentation') {
+						document.getElementById('presentation-shortcuts').style.display='block';
+					}
+					else if (map.getDocType() === 'drawing') {
+						document.getElementById('drawing-shortcuts').style.display='block';
+					}
+				} else /* id === 'online-help' */ {
+					document.getElementById('keyboard-shortcuts').style.display='none';
+					if (window.socketProxy) {
+						var helpdiv = document.getElementById('online-help');
+						var imgList = helpdiv.querySelectorAll('img');
+						for (var p = 0; p < imgList.length; p++) {
+							var imgSrc = imgList[p].src;
+							imgSrc = imgSrc.substring(imgSrc.indexOf('/images'));
+							imgList[p].src = window.host + window.serviceRoot + '/loleaflet/dist'+ imgSrc;
+						}
+					}
+					// Display help according to document opened
+					if (map.getDocType() === 'text') {
+						var x = document.getElementsByClassName('text');
+						for (i = 0; i < x.length; i++) {
+							x[i].style.display = 'block';
+						}
+					}
+					else if (map.getDocType() === 'spreadsheet') {
+						x = document.getElementsByClassName('spreadsheet');
+						for (i = 0; i < x.length; i++) {
+							x[i].style.display = 'block';
+						}
+					}
+					else if (map.getDocType() === 'presentation' || map.getDocType() === 'drawing') {
+						x = document.getElementsByClassName('presentation');
+						for (i = 0; i < x.length; i++) {
+							x[i].style.display = 'block';
+						}
+					}
+				}
+
+				// Let's translate
+				var max;
+				var translatableContent = $vexContent.find('h1');
+				for (i = 0, max = translatableContent.length; i < max; i++) {
+					translatableContent[i].innerHTML = translatableContent[i].innerHTML.toLocaleString();
+				}
+				translatableContent = $vexContent.find('h2');
+				for (i = 0, max = translatableContent.length; i < max; i++) {
+					translatableContent[i].innerHTML = translatableContent[i].innerHTML.toLocaleString();
+				}
+				translatableContent = $vexContent.find('h3');
+				for (i = 0, max = translatableContent.length; i < max; i++) {
+					translatableContent[i].innerHTML = translatableContent[i].innerHTML.toLocaleString();
+				}
+				translatableContent = $vexContent.find('h4');
+				for (i = 0, max = translatableContent.length; i < max; i++) {
+					translatableContent[i].innerHTML = translatableContent[i].innerHTML.toLocaleString();
+				}
+				translatableContent = $vexContent.find('td');
+				for (i = 0, max = translatableContent.length; i < max; i++) {
+					translatableContent[i].innerHTML = translatableContent[i].innerHTML.toLocaleString();
+				}
+				translatableContent = $vexContent.find('p');
+				for (i = 0, max = translatableContent.length; i < max; i++) {
+					translatableContent[i].innerHTML = translatableContent[i].innerHTML.toLocaleString();
+				}
+				translatableContent = $vexContent.find('button'); // TOC
+				for (i = 0, max = translatableContent.length; i < max; i++) {
+					translatableContent[i].innerHTML = translatableContent[i].innerHTML.toLocaleString();
+				}
+
+				//translatable screenshots
+				var supportedLanguage = ['fr', 'it', 'de', 'es', 'pt-BR'];
+				var currentLanguage = String.locale;
+				if (supportedLanguage.includes(currentLanguage)) {
+					translatableContent = $($vexContent.find('.screenshot')).find('img');
+					for (i = 0, max = translatableContent.length; i < max; i++) {
+						translatableContent[i].src = translatableContent[i].src.replace('/en/', '/'+currentLanguage+'/');
+					}
+				}
+
+				// Substitute %productName in Online Help
+				if (id === 'online-help') {
+					var productNameContent = $vexContent.find('span.productname');
+					for (i = 0, max = productNameContent.length; i < max; i++) {
+						productNameContent[i].innerHTML = productNameContent[i].innerHTML.replace(/%productName/g, productName);
+					}
+				}
+
+				// Special Mac key names
+				if (navigator.appVersion.indexOf('Mac') != -1 || navigator.userAgent.indexOf('Mac') != -1) {
+					var ctrl = /Ctrl/g;
+					var alt = /Alt/g;
+					if (String.locale.startsWith('de') || String.locale.startsWith('dsb') || String.locale.startsWith('hsb')) {
+						ctrl = /Strg/g;
+					}
+					if (String.locale.startsWith('lt')) {
+						ctrl = /Vald/g;
+					}
+					if (String.locale.startsWith('sl')) {
+						ctrl = /Krmilka/gi;
+						alt = /Izmenjalka/gi;
+					}
+					if (id === 'keyboard-shortcuts') {
+						document.getElementById('keyboard-shortcuts').innerHTML = document.getElementById('keyboard-shortcuts').innerHTML.replace(ctrl, '⌘').replace(alt, '⌥');
+					}
+					if (id === 'online-help') {
+						document.getElementById('online-help').innerHTML = document.getElementById('online-help').innerHTML.replace(ctrl, '⌘').replace(alt, '⌥');
+					}
+				}
+
+				$vexContent.attr('tabindex', -1);
+				$vexContent.focus();
+				// workaround for https://github.com/HubSpot/vex/issues/43
+				$('.vex-overlay').css({ 'pointer-events': 'none'});
+			},
+			beforeClose: function () {
+				map.focus();
+			}
+		});
+	},
+
+	showHelp: function(id) {
 		var map = this;
-		var helpLocation = 'loleaflet-help.html';
 		if (window.ThisIsAMobileApp) {
-			window.open(helpLocation);
+			map._doVexOpenHelpFile(window.HelpFile, id, map);
 			return;
 		}
+		var helpLocation = 'loleaflet-help.html';
 		if (window.socketProxy)
 			helpLocation = window.host + window.serviceRoot + '/loleaflet/dist/' + helpLocation;
-
 		$.get(helpLocation, function(data) {
-			var productName;
-			if (window.ThisIsAMobileApp) {
-				productName = window.MobileAppName;
-			} else {
-				productName = (typeof brandProductName !== 'undefined') ? brandProductName : 'Collabora Online Development Edition';
-			}
-			vex.open({
-				unsafeContent: data,
-				showCloseButton: true,
-				escapeButtonCloses: true,
-				overlayClosesOnClick: true,
-				closeAllOnPopState: false,
-				buttons: {},
-				afterOpen: function() {
-					var $vexContent = $(this.contentEl);
-					this.contentEl.style.width = w + 'px';
-					var i;
-					// Display keyboard shortcut or online help
-					if (id === 'keyboard-shortcuts') {
-						document.getElementById('online-help').style.display='none';
-						// Display help according to document opened
-						if (map.getDocType() === 'text') {
-							document.getElementById('text-shortcuts').style.display='block';
-						}
-						else if (map.getDocType() === 'spreadsheet') {
-							document.getElementById('spreadsheet-shortcuts').style.display='block';
-						}
-						else if (map.getDocType() === 'presentation') {
-							document.getElementById('presentation-shortcuts').style.display='block';
-						}
-						else if (map.getDocType() === 'drawing') {
-							document.getElementById('drawing-shortcuts').style.display='block';
-						}
-					} else /* id === 'online-help' */ {
-						document.getElementById('keyboard-shortcuts').style.display='none';
-						if (window.socketProxy) {
-							var helpdiv = document.getElementById('online-help');
-							var imgList = helpdiv.querySelectorAll('img');
-							for (var p = 0; p < imgList.length; p++) {
-								var imgSrc = imgList[p].src;
-								imgSrc = imgSrc.substring(imgSrc.indexOf('/images'));
-								imgList[p].src = window.host + window.serviceRoot + '/loleaflet/dist'+ imgSrc;
-							}
-						}
-						// Display help according to document opened
-						if (map.getDocType() === 'text') {
-							var x = document.getElementsByClassName('text');
-							for (i = 0; i < x.length; i++) {
-								x[i].style.display = 'block';
-							}
-						}
-						else if (map.getDocType() === 'spreadsheet') {
-							x = document.getElementsByClassName('spreadsheet');
-							for (i = 0; i < x.length; i++) {
-								x[i].style.display = 'block';
-							}
-						}
-						else if (map.getDocType() === 'presentation' || map.getDocType() === 'drawing') {
-							x = document.getElementsByClassName('presentation');
-							for (i = 0; i < x.length; i++) {
-								x[i].style.display = 'block';
-							}
-						}
-					}
-
-					// Let's translate
-					var max;
-					var translatableContent = $vexContent.find('h1');
-					for (i = 0, max = translatableContent.length; i < max; i++) {
-						translatableContent[i].innerHTML = translatableContent[i].innerHTML.toLocaleString();
-					}
-					translatableContent = $vexContent.find('h2');
-					for (i = 0, max = translatableContent.length; i < max; i++) {
-						translatableContent[i].innerHTML = translatableContent[i].innerHTML.toLocaleString();
-					}
-					translatableContent = $vexContent.find('h3');
-					for (i = 0, max = translatableContent.length; i < max; i++) {
-						translatableContent[i].innerHTML = translatableContent[i].innerHTML.toLocaleString();
-					}
-					translatableContent = $vexContent.find('h4');
-					for (i = 0, max = translatableContent.length; i < max; i++) {
-						translatableContent[i].innerHTML = translatableContent[i].innerHTML.toLocaleString();
-					}
-					translatableContent = $vexContent.find('td');
-					for (i = 0, max = translatableContent.length; i < max; i++) {
-						translatableContent[i].innerHTML = translatableContent[i].innerHTML.toLocaleString();
-					}
-					translatableContent = $vexContent.find('p');
-					for (i = 0, max = translatableContent.length; i < max; i++) {
-						translatableContent[i].innerHTML = translatableContent[i].innerHTML.toLocaleString();
-					}
-					translatableContent = $vexContent.find('button'); // TOC
-					for (i = 0, max = translatableContent.length; i < max; i++) {
-						translatableContent[i].innerHTML = translatableContent[i].innerHTML.toLocaleString();
-					}
-
-					//translatable screenshots
-					var supportedLanguage = ['fr', 'it', 'de', 'es', 'pt-BR'];
-					var currentLanguage = String.locale;
-					if (supportedLanguage.includes(currentLanguage)) {
-						translatableContent = $($vexContent.find('.screenshot')).find('img');
-						for (i = 0, max = translatableContent.length; i < max; i++) {
-							translatableContent[i].src = translatableContent[i].src.replace('/en/', '/'+currentLanguage+'/');
-						}
-					}
-
-					// Substitute %productName in Online Help
-					if (id === 'online-help') {
-						var productNameContent = $vexContent.find('span.productname');
-						for (i = 0, max = productNameContent.length; i < max; i++) {
-							productNameContent[i].innerHTML = productNameContent[i].innerHTML.replace(/%productName/g, productName);
-						}
-					}
-
-					// Special Mac key names
-					if (navigator.appVersion.indexOf('Mac') != -1 || navigator.userAgent.indexOf('Mac') != -1) {
-						var ctrl = /Ctrl/g;
-						var alt = /Alt/g;
-						if (String.locale.startsWith('de') || String.locale.startsWith('dsb') || String.locale.startsWith('hsb')) {
-							ctrl = /Strg/g;
-						}
-						if (String.locale.startsWith('lt')) {
-							ctrl = /Vald/g;
-						}
-						if (String.locale.startsWith('sl')) {
-							ctrl = /Krmilka/gi;
-							alt = /Izmenjalka/gi;
-						}
-						if (id === 'keyboard-shortcuts') {
-							document.getElementById('keyboard-shortcuts').innerHTML = document.getElementById('keyboard-shortcuts').innerHTML.replace(ctrl, '⌘').replace(alt, '⌥');
-						}
-						if (id === 'online-help') {
-							document.getElementById('online-help').innerHTML = document.getElementById('online-help').innerHTML.replace(ctrl, '⌘').replace(alt, '⌥');
-						}
-					}
-
-					$vexContent.attr('tabindex', -1);
-					$vexContent.focus();
-					// workaround for https://github.com/HubSpot/vex/issues/43
-					$('.vex-overlay').css({ 'pointer-events': 'none'});
-				},
-				beforeClose: function () {
-					map.focus();
-				}
-			});
+			map._doVexOpenHelpFile(data, id, map);
 		});
 	},
 


### PR DESCRIPTION
We cannot use jQuery.get (a.k.a. $.get) in the mobile apps as that
uses some XMLHttpRequest thing that obviously won't work when there is
no web server involved, but loleaflet.html has been loaded from a
file: URL. Simply store the help file into a global variable and use
that instead.

A small refactoring of the showHelp function was needed to factor out
the call of vex.open into a separate function. That is called directly
from showHelp in the mobile app case. Otherwise, it is called from a
short function passed to $.get, as before.

Note that in the mobile apps we cannot use window.open (which in the
mobile apps has been redefined to send a "HYPERLINK <url>" message to
the native app code) to open the help file, because the HYPERLINK
message is for opening a web page in a browser, completely separately
from the app. It is used to display the commit log for the Help>About
functionality.

And anyway, the old idea (that didn't work) to take a shortcut in the
mobile app case and just display the help file in showHelp will not
work anyway as we need the code that edits the contents before it is
displayed, and handles the close button in the help file.

This fixes https://github.com/CollaboraOnline/online/issues/400
This fixes https://github.com/CollaboraOnline/online/issues/401

Change-Id: I16dc960f26af7e6e89663c3ac0523ce5c3d41c34
Signed-off-by: Tor Lillqvist <tml@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

