### PR TITLE
Private/gokay/writerkeyboard

### DIFF
--- a/loleaflet/src/layer/tile/CanvasSectionContainer.ts
+++ b/loleaflet/src/layer/tile/CanvasSectionContainer.ts
@@ -729,6 +729,10 @@ class CanvasSectionContainer {
 	}
 
 	private onTouchMove (e: TouchEvent) {
+		// Sometimes onTouchStart is fired for another element. In this case, we return.
+		if (this.positionOnMouseDown === null)
+			return;
+
 		this.potentialLongPress = false;
 		if (!this.multiTouch) {
 			this.mousePosition = this.convertPositionToCanvasLocale(e);

--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -574,6 +574,8 @@ L.CanvasTileLayer = L.TileLayer.extend({
 		var tileContainer = this._container;
 		if (tileContainer) {
 			var size = this._map.getPixelBounds().getSize();
+			var heightIncreased = parseInt(this._painter._sectionContainer.canvas.style.height.replace('px', '')) < size.y;
+
 			if (this._docType === 'spreadsheet') {
 				var offset = this._getUIWidth() + this._getGroupWidth();
 				offset += (this._getGroupWidth() > 0 ? 3: 1);
@@ -605,6 +607,9 @@ L.CanvasTileLayer = L.TileLayer.extend({
 				this._painter._sectionContainer.getSectionWithName(L.CSections.RowHeader.name)._updateCanvas();
 				this._painter._sectionContainer.getSectionWithName(L.CSections.ColumnHeader.name)._updateCanvas();
 			}
+
+			if (!heightIncreased)
+				this._onUpdateCursor(true);
 		}
 	},
 


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
When on mobile, if user clicks somewhere near to bottom of the screen,
virtual keyboard opens.

When virtual keyboard opens, "_onUpdateCursor" function is called.
Then onResize function is called.
Since onResize is called last, document thinks that user can still see the
cursor. In this case, we call _onUpdateCursor function one more time,
for scrolling the document if needed.

### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

