### PR TITLE
HTTP improvements to allow for Server-Side handling

### DIFF
--- a/common/Clipboard.hpp
+++ b/common/Clipboard.hpp
@@ -17,7 +17,6 @@
 #include <stdlib.h>
 #include <Log.hpp>
 #include <Exceptions.hpp>
-#include <Poco/MemoryStream.h>
 
 struct ClipboardData
 {

--- a/common/Common.hpp
+++ b/common/Common.hpp
@@ -52,11 +52,14 @@ constexpr const char CAPABILITIES_END_POINT[] = "/hosting/capabilities";
 /// the code: they are logical execution unit names.
 #define SHARED_DOC_THREADNAME_SUFFIX "broker_"
 
-/// The HTTP response User-Agent.
+/// The HTTP request User-Agent. Used only in Requests.
 #define HTTP_AGENT_STRING "LOOLWSD HTTP Agent " LOOLWSD_VERSION
 
-/// The WOPI User-Agent.
-#define WOPI_AGENT_STRING "LOOLWSD WOPI Agent " LOOLWSD_VERSION
+/// The WOPI User-Agent. Depricated: use HTTP_AGENT_STRING.
+#define WOPI_AGENT_STRING HTTP_AGENT_STRING
+
+/// The HTTP response Server. Used only in Responses.
+#define HTTP_SERVER_STRING "LOOLWSD HTTP Server " LOOLWSD_VERSION
 
 // The client port number, both loolwsd and the kits have this.
 extern int ClientPortNumber;

--- a/common/UnitHTTP.hpp
+++ b/common/UnitHTTP.hpp
@@ -11,7 +11,6 @@
 #include <sstream>
 
 #include <Poco/Net/HTTPClientSession.h>
-#include <Poco/Net/HTTPRequest.h>
 #include <Poco/Net/HTTPServerParams.h>
 #include <Poco/Net/HTTPServerRequest.h>
 #include <Poco/Net/HTTPServerResponse.h>

--- a/common/Util.cpp
+++ b/common/Util.cpp
@@ -102,7 +102,9 @@ namespace Util
         {
             std::stringstream ss;
             Poco::HexBinaryEncoder hex(ss);
+            hex.rdbuf()->setLineLength(0); // Don't insert line breaks.
             hex.write(getBytes(length).data(), length);
+            hex.close(); // Flush.
             return ss.str().substr(0, length);
         }
 
@@ -123,7 +125,10 @@ namespace Util
                 LOG_ERR("failed to read " << length << " hard random bytes, got " << len << " for hash: " << errno);
             }
             close(fd);
+
+            hex.rdbuf()->setLineLength(0); // Don't insert line breaks.
             hex.write(random.data(), length);
+            hex.close(); // Flush.
             return ss.str().substr(0, length);
         }
 

--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -13,6 +13,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <algorithm>
 #include <atomic>
 #include <functional>
 #include <memory>
@@ -1184,6 +1185,13 @@ int main(int argc, char**argv)
     {
         const auto pair = u64FromString(input);
         return pair.second ? pair : std::make_pair(def, false);
+    }
+
+    /// Converts and returns the argument to lower-case.
+    inline std::string toLower(std::string s)
+    {
+        std::transform(s.begin(), s.end(), s.begin(), ::tolower);
+        return s;
     }
 
     /// Get system_clock now in miliseconds.

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -53,9 +53,6 @@
 #include <Poco/Exception.h>
 #include <Poco/JSON/Object.h>
 #include <Poco/JSON/Parser.h>
-#include <Poco/Net/HTTPRequest.h>
-#include <Poco/Net/HTTPResponse.h>
-#include <Poco/Net/NetException.h>
 #include <Poco/Net/Socket.h>
 #include <Poco/URI.h>
 

--- a/net/Buffer.hpp
+++ b/net/Buffer.hpp
@@ -77,6 +77,10 @@ public:
         _size = _buffer.size() - _offset;
     }
 
+    void append(const std::string& s) { append(s.c_str(), s.size()); }
+
+    void append(const char ch) { append(&ch, 1); }
+
     void dumpHex(std::ostream &os, const char *legend, const char *prefix) const
     {
         if (_size > 0 || _offset > 0)

--- a/net/HttpHelper.cpp
+++ b/net/HttpHelper.cpp
@@ -13,9 +13,8 @@
 #include <string>
 #include <zlib.h>
 
-#include <Poco/MemoryStream.h>
-#include <Poco/Net/HTTPRequest.h>
 #include <Poco/Net/HTTPResponse.h>
+
 #include <common/Common.hpp>
 #include <common/FileUtil.hpp>
 #include <common/Util.hpp>

--- a/net/HttpRequest.cpp
+++ b/net/HttpRequest.cpp
@@ -5,6 +5,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include <config.h>
+
 #include "HttpRequest.hpp"
 
 #include <Poco/MemoryStream.h>

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -140,6 +140,90 @@ enum class FieldParseState
     Valid //< The field is both complete and valid.
 };
 
+/// Returns the Reason Phrase for a given HTTP Status Code.
+/// If not defined, "Unknown" is returned.
+/// The Reason Phrase is informational only, but it helps
+/// to use the canonical one for consistency.
+/// See https://en.wikipedia.org/wiki/List_of_HTTP_status_codes
+static inline const char* getReasonPhraseForCode(int code)
+{
+#define CASE(C, R)                                                                                 \
+    case C:                                                                                        \
+        return R;
+    switch (code)
+    {
+        CASE(100, "Continue");
+        CASE(101, "Switching Protocols");
+        CASE(102, "Processing"); // RFC 2518 (WebDAV)
+        CASE(103, "Early Hints"); // RFC 8297
+
+        CASE(200, "OK");
+        CASE(201, "Created");
+        CASE(202, "Accepted");
+        CASE(203, "Non Authoritative Information");
+        CASE(204, "No Content");
+        CASE(205, "Reset Content");
+        CASE(206, "Partial Content");
+        CASE(207, "Multi Status"); // RFC 4918 (WebDAV)
+        CASE(208, "Already Reported"); // RFC 5842 (WebDAV)
+        CASE(226, "IM Used"); // RFC 3229
+
+        CASE(300, "Multiple Choices");
+        CASE(301, "Moved Permanently");
+        CASE(302, "Found");
+        CASE(303, "See Other");
+        CASE(304, "Not Modified");
+        CASE(305, "Use Proxy");
+        CASE(307, "Temporary Redirect");
+
+        CASE(400, "Bad Request");
+        CASE(401, "Unauthorized");
+        CASE(402, "Payment Required");
+        CASE(403, "Forbidden");
+        CASE(404, "Not Found");
+        CASE(405, "Method Not Allowed");
+        CASE(406, "Not Acceptable");
+        CASE(407, "Proxy Authentication Required");
+        CASE(408, "Request Timeout");
+        CASE(409, "Conflict");
+        CASE(410, "Gone");
+        CASE(411, "Length Required");
+        CASE(412, "Precondition Failed");
+        CASE(413, "Payload Too Large"); // Previously called "Request Entity Too Large"
+        CASE(414, "URI Too Long"); // Previously called "Request-URI Too Long"
+        CASE(415, "Unsupported Media Type");
+        CASE(416, "Range Not Satisfiable"); // Previously called "Requested Range Not Satisfiable"
+        CASE(417, "Expectation Failed");
+        CASE(418, "I'm A Teapot"); // RFC 2324, RFC 7168 (April's fool)
+        CASE(421, "Misdirected Request"); // RFC 7540
+        CASE(422, "Unprocessable Entity"); // RFC 4918 (WebDAV)
+        CASE(423, "Locked"); // RFC 4918 (WebDAV)
+        CASE(424, "Failed Dependency"); // RFC 4918 (WebDAV)
+        CASE(425, "Too Early"); // RFC 8470
+        CASE(426, "Upgrade Required");
+        CASE(428, "Precondition Required"); // RFC 6585
+        CASE(429, "Too Many Requests"); // RFC 6585
+        CASE(431, "Request Header Fields Too Large"); // RFC 6585
+        CASE(440, "Login Time-out"); // IIS
+        CASE(449, "Retry With"); // IIS
+        CASE(451, "Unavailable For Legal Reasons"); // RFC 7725 and IIS Redirect
+
+        CASE(500, "Internal Server Error");
+        CASE(501, "Not Implemented");
+        CASE(502, "Bad Gateway");
+        CASE(503, "Service Unavailable");
+        CASE(504, "Gateway Timeout");
+        CASE(505, "HTTP Version Not Supported");
+        CASE(507, "Insufficient Storage"); // RFC 4918 (WebDAV)
+        CASE(508, "Loop Detected"); // RFC 5842 (WebDAV)
+        CASE(510, "Not Extended"); // RFC 2774
+        CASE(511, "Network Authentication Required"); // RFC 6585
+    }
+#undef CASE
+
+    return "Unknown";
+}
+
 /// The callback signature for handling IO writes.
 /// Returns the number of bytes read from the buffer,
 /// -1 for error (terminates the transfer).

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -273,24 +273,24 @@ public:
     int64_t parse(const char* p, int64_t len);
 
     /// Add an HTTP header field.
-    void add(const std::string& key, const std::string& value)
+    void add(std::string key, std::string value)
     {
-        _headers.emplace_back(key, value);
+        _headers.emplace_back(std::move(key), std::move(value));
     }
 
     /// Set an HTTP header field, replacing an earlier value, if exists.
-    void set(const std::string& key, const std::string& value)
+    void set(const std::string& key, std::string value)
     {
         for (auto& pair : _headers)
         {
             if (pair.first == key)
             {
-                pair.second = value;
+                pair.second.swap(value);
                 return;
             }
         }
 
-        _headers.emplace_back(key, value);
+        _headers.emplace_back(key, std::move(value));
     }
 
     bool has(const std::string& key) const
@@ -319,7 +319,7 @@ public:
     }
 
     /// Set the Content-Type header.
-    void setContentType(const std::string& type) { set(CONTENT_TYPE, type); }
+    void setContentType(std::string type) { set(CONTENT_TYPE, std::move(type)); }
     /// Get the Content-Type header.
     std::string getContentType() const { return get(CONTENT_TYPE); }
     /// Returns true iff a Content-Type header exists.
@@ -456,10 +456,10 @@ public:
     const Header& header() const { return _header; }
 
     /// Add an HTTP header field.
-    void add(const std::string& key, const std::string& value) { _header.add(key, value); }
+    void add(std::string key, std::string value) { _header.add(std::move(key), std::move(value)); }
 
     /// Set an HTTP header field, replacing an earlier value, if exists.
-    void set(const std::string& key, const std::string& value) { _header.set(key, value); }
+    void set(const std::string& key, std::string value) { _header.set(key, std::move(value)); }
 
     /// Set the request body source to upload some data. Meaningful for POST.
     /// Size is needed to set the Content-Length.
@@ -691,10 +691,10 @@ public:
     const Header& header() const { return _header; }
 
     /// Add an HTTP header field.
-    void add(const std::string& key, const std::string& value) { _header.add(key, value); }
+    void add(std::string key, std::string value) { _header.add(std::move(key), std::move(value)); }
 
     /// Set an HTTP header field, replacing an earlier value, if exists.
-    void set(const std::string& key, const std::string& value) { _header.set(key, value); }
+    void set(const std::string& key, std::string value) { _header.set(key, std::move(value)); }
 
     /// Redirect the response body, if any, to a file.
     /// If the server responds with a non-success status code (i.e. not 2xx)

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -364,6 +364,20 @@ public:
         return cookies;
     }
 
+    bool writeData(Buffer& out)
+    {
+        // Note: we don't add the end-of-header '\r\n'.
+        for (const auto& pair : _headers)
+        {
+            out.append(pair.first);
+            out.append(": ", 2);
+            out.append(pair.second);
+            out.append("\r\n", 2);
+        }
+
+        return true;
+    }
+
     /// Serialize the header to an output stream.
     template <typename T> T& serialize(T& os) const
     {
@@ -635,6 +649,11 @@ public:
         saveBodyToMemory();
     }
 
+    Response(StatusLine statusLine)
+        : _statusLine(std::move(statusLine))
+    {
+    }
+
     /// The state of the response.
     enum class State
     {
@@ -657,6 +676,12 @@ public:
     const StatusLine& statusLine() const { return _statusLine; }
 
     const Header& header() const { return _header; }
+
+    /// Add an HTTP header field.
+    void add(const std::string& key, const std::string& value) { _header.add(key, value); }
+
+    /// Set an HTTP header field, replacing an earlier value, if exists.
+    void set(const std::string& key, const std::string& value) { _header.set(key, value); }
 
     /// Redirect the response body, if any, to a file.
     /// If the server responds with a non-success status code (i.e. not 2xx)
@@ -691,10 +716,23 @@ public:
     /// Returns the body, assuming it wasn't redirected to file or callback.
     const std::string& getBody() const { return _body; }
 
-    /// Handles incoming data.
+    /// Handles incoming data (from the Server) in the Client.
     /// Returns the number of bytes consumed, or -1 for error
     /// and/or to interrupt transmission.
     int64_t readData(const char* p, int64_t len);
+
+    /// Serializes the Server Response into the given buffer.
+    bool writeData(Buffer& out)
+    {
+        _header.set("Date", Util::getHttpTimeNow());
+        // constexpr auto server = HTTP_AGENT_STRING;
+        // _header.set("Server", server);
+
+        _statusLine.writeData(out);
+        _header.writeData(out);
+        out.append("\r\n", 2);
+        return true;
+    }
 
     /// Signifies that we got all the data we expected
     /// and cleans up and updates the states.

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -544,8 +544,22 @@ public:
     static constexpr const char* HTTP_1_1 = "HTTP/1.1";
     static constexpr const char* OK = "OK";
 
+    /// Construct an invalid StatusLine, used for parsing.
     StatusLine()
-        : _statusCode(0)
+        : _versionMajor(1)
+        , _versionMinor(1)
+        , _statusCode(0)
+    {
+    }
+
+    /// Construct a StatusLine with a given code and
+    /// the default protocol version.
+    StatusLine(unsigned statusCode)
+        : _httpVersion(HTTP_1_1)
+        , _versionMajor(1)
+        , _versionMinor(1)
+        , _statusCode(statusCode)
+        , _reasonPhrase(getReasonPhraseForCode(statusCode))
     {
     }
 
@@ -580,17 +594,28 @@ public:
     /// Returns the state and clobbers the len on succcess to the number of bytes read.
     FieldParseState parse(const char* p, int64_t& len);
 
+    bool writeData(Buffer& out)
+    {
+        out.append(_httpVersion);
+        out.append(' ');
+        out.append(std::to_string(_statusCode));
+        out.append(' ');
+        out.append(_reasonPhrase);
+        out.append("\r\n", 2);
+        return true;
+    }
+
     const std::string& httpVersion() const { return _httpVersion; }
-    int versionMajor() const { return _versionMajor; }
-    int versionMinor() const { return _versionMinor; }
-    int statusCode() const { return _statusCode; }
+    unsigned versionMajor() const { return _versionMajor; }
+    unsigned versionMinor() const { return _versionMinor; }
+    unsigned statusCode() const { return _statusCode; }
     const std::string& reasonPhrase() const { return _reasonPhrase; }
 
 private:
     std::string _httpVersion; //< Typically "HTTP/1.1"
-    int _versionMajor; //< The first version digit (typically 1).
-    int _versionMinor; //< The second version digit (typically 1).
-    int _statusCode;
+    unsigned _versionMajor; //< The first version digit (typically 1).
+    unsigned _versionMinor; //< The second version digit (typically 1).
+    unsigned _statusCode;
     std::string _reasonPhrase; //< A client SHOULD ignore the reason-phrase content.
 };
 

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -367,7 +367,7 @@ public:
         return cookies;
     }
 
-    bool writeData(Buffer& out)
+    bool writeData(Buffer& out) const
     {
         // Note: we don't add the end-of-header '\r\n'.
         for (const auto& pair : _headers)
@@ -615,7 +615,7 @@ public:
     /// Returns the state and clobbers the len on succcess to the number of bytes read.
     FieldParseState parse(const char* p, int64_t& len);
 
-    bool writeData(Buffer& out)
+    bool writeData(Buffer& out) const
     {
         out.append(_httpVersion);
         out.append(' ');

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -490,14 +490,18 @@ public:
     {
         if (_stage == Stage::Header)
         {
-            std::ostringstream oss;
-            oss << getVerb() << ' ' << getUrl() << ' ' << getVersion() << "\r\n";
-            _header.serialize(oss);
-            oss << "\r\n";
-            const std::string headerStr = oss.str();
+            LOG_TRC("performWrites (header).");
 
-            out.append(headerStr.data(), headerStr.size());
-            LOG_TRC("performWrites (header): " << headerStr.size() << ": " << headerStr);
+            out.append(getVerb());
+            out.append(' ');
+            out.append(getUrl());
+            out.append(' ');
+            out.append(getVersion());
+            out.append("\r\n", 2);
+
+            _header.writeData(out);
+            out.append("\r\n", 2);
+
             _stage = Stage::Body;
         }
 

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -451,7 +451,8 @@ public:
     static constexpr int64_t VersionLen = 8;
     static constexpr int64_t StatusCodeLen = 3;
     static constexpr int64_t MaxReasonPhraseLen = 512; // Arbitrary large number.
-    static constexpr int64_t MinStatusLineLen = sizeof("HTTP/0.0 000 X\r\n");
+    static constexpr int64_t MinStatusLineLen
+        = sizeof("HTTP/0.0 000\r\n") - 1; // Reason phrase is optional.
     static constexpr int64_t MaxStatusLineLen = VersionLen + StatusCodeLen + MaxReasonPhraseLen;
     static constexpr int64_t MinValidStatusCode = 100;
     static constexpr int64_t MaxValidStatusCode = 599;

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -306,6 +306,9 @@ public:
 
     std::string get(const std::string& key) const
     {
+        // There are typically half a dozen header
+        // entries, rarely much more. A map would
+        // probably not be faster but would add complexity.
         for (const auto& pair : _headers)
         {
             if (pair.first == key)
@@ -761,7 +764,8 @@ private:
             LOG_TRC("Finishing");
             _bodyFile.close();
             _state = newState;
-            _finishedCallback();
+            if (_finishedCallback)
+                _finishedCallback();
         }
     }
 

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -1005,8 +1005,8 @@ private:
         if (duration > getTimeout())
         {
             LOG_WRN("Socket #" << _socket->getFD() << " has timed out while requesting ["
-                               << _request.getVerb() << ' ' << _request.getUrl() << "] after "
-                               << duration);
+                               << _request.getVerb() << ' ' << _host << _request.getUrl()
+                               << "] after " << duration);
 
             // Flag that we timed out.
             _response->timeout();

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -729,8 +729,7 @@ public:
     bool writeData(Buffer& out)
     {
         _header.set("Date", Util::getHttpTimeNow());
-        // constexpr auto server = HTTP_AGENT_STRING;
-        // _header.set("Server", server);
+        _header.set("Server", HTTP_SERVER_STRING);
 
         _statusLine.writeData(out);
         _header.writeData(out);

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -587,7 +587,7 @@ void StreamSocket::dumpState(std::ostream& os)
 
 void StreamSocket::send(Poco::Net::HTTPResponse& response)
 {
-    response.set("User-Agent", HTTP_AGENT_STRING);
+    response.set("Server", HTTP_SERVER_STRING);
     response.set("Date", Util::getHttpTimeNow());
 
     std::ostringstream oss;

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -946,6 +946,13 @@ public:
     /// Adds Date and User-Agent.
     void send(Poco::Net::HTTPResponse& response);
 
+    /// Safely flush any outgoing data.
+    inline void flush()
+    {
+        if (!_outBuffer.empty())
+            writeOutgoingData();
+    }
+
     /// Sends data with file descriptor as control data.
     /// Can be used only with Unix sockets.
     void sendFD(const char* data, const uint64_t len, int fd)
@@ -955,8 +962,7 @@ public:
         // Flush existing non-ancillary data
         // so that our non-ancillary data will
         // match ancillary data.
-        if (getOutBuffer().size() > 0)
-            writeOutgoingData();
+        flush();
 
         msghdr msg;
         iovec iov[1];

--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -15,6 +15,7 @@
 #include "common/Log.hpp"
 #include "common/Unit.hpp"
 #include "Socket.hpp"
+#include <net/HttpRequest.hpp>
 
 #include <Poco/MemoryStream.h>
 #include <Poco/Net/HTTPRequest.h>
@@ -418,7 +419,17 @@ public:
         }
 #if !MOBILEAPP
         else if (_isClient && !socket->isWebSocket())
-            handleClientUpgrade(socket);
+        {
+            try
+            {
+                handleClientUpgrade(socket);
+            }
+            catch (const std::exception& ex)
+            {
+                LOG_DBG('#' << socket->getFD()
+                            << " handleClientUpgrade exception caught: " << ex.what());
+            }
+        }
 #endif
         else
         {
@@ -802,66 +813,50 @@ protected:
     {
         assert(socket && "socket must be valid");
 
-        LOG_TRC("Incoming client websocket upgrade response: "
-                << std::string(&socket->getInBuffer()[0], socket->getInBuffer().size()));
+        std::vector<char>& data = socket->getInBuffer();
 
-        bool bOk = false;
-        StreamSocket::MessageMap map;
+        LOG_TRC('#' << socket->getFD() << " Incoming client websocket upgrade response: "
+                    << std::string(data.data(), data.size()));
 
-        try
-        {
-            Poco::MemoryInputStream message(&socket->getInBuffer()[0], socket->getInBuffer().size());;
-            Poco::Net::HTTPResponse response;
-
-            response.read(message);
-
-            {
-                static const std::string marker("\r\n\r\n");
-                auto itBody = std::search(socket->getInBuffer().begin(),
-                                          socket->getInBuffer().end(),
-                                          marker.begin(), marker.end());
-
-                if (itBody != socket->getInBuffer().end())
-                    map._headerSize = itBody - socket->getInBuffer().begin() + marker.size();
-            }
-
-            if (response.getStatus() == Poco::Net::HTTPResponse::HTTP_SWITCHING_PROTOCOLS
-                && response.has("Upgrade")
-                && Poco::icompare(response.get("Upgrade"), "websocket") == 0)
+        // Consume the incoming data by parsing and processing the body.
+        http::Response response([&]() {
+            if (response.statusLine().statusCode()
+                    == Poco::Net::HTTPResponse::HTTP_SWITCHING_PROTOCOLS
+                && Poco::icompare(response.header().get("Upgrade"), "websocket") == 0)
             {
 #if 0 // SAL_DEBUG ...
-                const std::string wsKey = response.get("Sec-WebSocket-Accept", "");
-                const std::string wsProtocol = response.get("Sec-WebSocket-Protocol", "");
-                if (Poco::icompare(wsProtocol, "chat") != 0)
-                    LOG_ERR("Unknown websocket protocol " << wsProtocol);
-                else
+                    const std::string wsKey = response.get("Sec-WebSocket-Accept", "");
+                    const std::string wsProtocol = response.get("Sec-WebSocket-Protocol", "");
+                    if (Poco::icompare(wsProtocol, "chat") != 0)
+                        LOG_ERR("Unknown websocket protocol " << wsProtocol);
+                    else
 #endif
                 {
-                    LOG_TRC("Accepted incoming websocket response");
+                    LOG_TRC('#' << socket->getFD() << " Accepted incoming websocket response");
                     // FIXME: validate Sec-WebSocket-Accept vs. Sec-WebSocket-Key etc.
-                    bOk = true;
+                    setWebSocket();
                 }
             }
-        }
-        catch (const Poco::Exception& exc)
-        {
-            LOG_DBG("handleClientUpgrade exception caught: " << exc.displayText());
-        }
-        catch (const std::exception& exc)
-        {
-            LOG_DBG("handleClientUpgrade exception caught.");
-        }
+        });
 
-        if (!bOk || map._headerSize == 0)
+        const int64_t read = response.readData(data.data(), data.size());
+        if (read < 0)
         {
-            LOG_ERR("Bad websocker server response.");
-
+            // Error: Interrupt the transfer.
+            LOG_ERR('#' << socket->getFD()
+                        << " Error in client websocket upgrade response. Disconnecting");
             socket->shutdown();
             return;
         }
 
-        setWebSocket();
-        socket->eraseFirstInputBytes(map);
+        if (read > 0)
+        {
+            // Remove consumed data.
+            data.erase(data.begin(), data.begin() + read);
+            return;
+        }
+
+        assert(read == 0 && "Not enough data.");
     }
 #endif
 

--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -704,7 +704,7 @@ protected:
         return size;
     }
 
-    bool isControlFrame(WSOpCode code){ return code >= WSOpCode::Close; }
+    bool isControlFrame(WSOpCode code) const { return code >= WSOpCode::Close; }
 
     void readPayload(unsigned char *data, size_t dataLen, unsigned char* mask, std::vector<char>& payload)
     {

--- a/net/clientnb.cpp
+++ b/net/clientnb.cpp
@@ -24,7 +24,6 @@
 #include <Poco/Net/FilePartSource.h>
 #include <Poco/Net/SSLManager.h>
 #include <Poco/Net/WebSocket.h>
-#include <Poco/Net/KeyConsoleHandler.h>
 #include <Poco/Net/AcceptCertificateHandler.h>
 #include <Poco/StreamCopier.h>
 #include <Poco/URI.h>

--- a/test/HttpRequestTests.cpp
+++ b/test/HttpRequestTests.cpp
@@ -131,9 +131,7 @@ void HttpRequestTests::testSimpleGet()
         LOK_ASSERT(httpResponse->statusLine().statusCategory()
                    == http::StatusLine::StatusCodeClass::Successful);
 
-        const std::string body = httpResponse->getBody();
-        LOK_ASSERT(!body.empty());
-        LOK_ASSERT_EQUAL(pocoResponse.second, body);
+        LOK_ASSERT_EQUAL(pocoResponse.second, httpResponse->getBody());
     }
 
     pollThread.joinThread();
@@ -163,10 +161,10 @@ void HttpRequestTests::testSimpleGetSync()
     LOK_ASSERT_EQUAL(200, httpResponse->statusLine().statusCode());
     LOK_ASSERT(httpResponse->statusLine().statusCategory()
                == http::StatusLine::StatusCodeClass::Successful);
+    LOK_ASSERT_EQUAL(std::string("HTTP/1.1"), httpResponse->statusLine().httpVersion());
+    LOK_ASSERT_EQUAL(std::string("OK"), httpResponse->statusLine().reasonPhrase());
 
-    const std::string body = httpResponse->getBody();
-    LOK_ASSERT(!body.empty());
-    LOK_ASSERT_EQUAL(pocoResponse.second, body);
+    LOK_ASSERT_EQUAL(pocoResponse.second, httpResponse->getBody());
 }
 
 static void compare(const Poco::Net::HTTPResponse& pocoResponse, const std::string& pocoBody,

--- a/test/HttpRequestTests.cpp
+++ b/test/HttpRequestTests.cpp
@@ -232,11 +232,17 @@ void HttpRequestTests::test500GetStatuses()
 
         httpSession->asyncRequest(httpRequest, pollThread);
 
-        std::unique_lock<std::mutex> lock(mutex);
-        cv.wait_for(lock, std::chrono::seconds(1));
+        // Get via Poco in parallel.
+        std::pair<std::shared_ptr<Poco::Net::HTTPResponse>, std::string> pocoResponse;
+        if (statusCode > 100)
+            pocoResponse = helpers::pocoGet(secure, Host, port, url);
 
         const std::shared_ptr<const http::Response> httpResponse = httpSession->response();
-        LOK_ASSERT(httpResponse->state() == http::Response::State::Complete);
+
+        std::unique_lock<std::mutex> lock(mutex);
+        cv.wait_for(lock, std::chrono::seconds(1), [&]() { return httpResponse->done(); });
+
+        LOK_ASSERT_EQUAL(http::Response::State::Complete, httpResponse->state());
         LOK_ASSERT(!httpResponse->statusLine().httpVersion().empty());
         LOK_ASSERT(!httpResponse->statusLine().reasonPhrase().empty());
 
@@ -247,11 +253,9 @@ void HttpRequestTests::test500GetStatuses()
 
         LOK_ASSERT_EQUAL(statusCode, httpResponse->statusLine().statusCode());
 
-        if (httpResponse->statusLine().statusCategory()
-            != http::StatusLine::StatusCodeClass::Informational)
+        // Poco throws exception "No message received" for 1xx Status Codes.
+        if (statusCode > 100)
         {
-            // Get via Poco in parallel.
-            const auto pocoResponse = helpers::pocoGet(secure, Host, port, url);
             compare(*pocoResponse.first, pocoResponse.second, *httpResponse);
         }
     }

--- a/test/HttpRequestTests.cpp
+++ b/test/HttpRequestTests.cpp
@@ -10,7 +10,6 @@
 #include <config.h>
 
 #include <Poco/Net/HTTPClientSession.h>
-#include <Poco/Net/HTTPRequest.h>
 #include <Poco/Net/HTTPResponse.h>
 #include <Poco/StreamCopier.h>
 

--- a/test/HttpRequestTests.cpp
+++ b/test/HttpRequestTests.cpp
@@ -70,7 +70,7 @@ void HttpRequestTests::testInvalidURI()
     LOK_ASSERT(httpResponse->done() == false);
     LOK_ASSERT(httpResponse->state() != http::Response::State::Complete);
     LOK_ASSERT(httpResponse->statusLine().statusCode() != Poco::Net::HTTPResponse::HTTP_OK);
-    LOK_ASSERT_EQUAL(0, httpResponse->statusLine().statusCode());
+    LOK_ASSERT_EQUAL(0U, httpResponse->statusLine().statusCode());
     LOK_ASSERT(httpResponse->statusLine().statusCategory()
                == http::StatusLine::StatusCodeClass::Invalid);
     LOK_ASSERT(httpResponse->getBody().empty());
@@ -126,7 +126,7 @@ void HttpRequestTests::testSimpleGet()
         LOK_ASSERT(httpResponse->state() == http::Response::State::Complete);
         LOK_ASSERT(!httpResponse->statusLine().httpVersion().empty());
         LOK_ASSERT(!httpResponse->statusLine().reasonPhrase().empty());
-        LOK_ASSERT_EQUAL(200, httpResponse->statusLine().statusCode());
+        LOK_ASSERT_EQUAL(200U, httpResponse->statusLine().statusCode());
         LOK_ASSERT(httpResponse->statusLine().statusCategory()
                    == http::StatusLine::StatusCodeClass::Successful);
 
@@ -157,7 +157,7 @@ void HttpRequestTests::testSimpleGetSync()
     LOK_ASSERT(httpResponse->state() == http::Response::State::Complete);
     LOK_ASSERT(!httpResponse->statusLine().httpVersion().empty());
     LOK_ASSERT(!httpResponse->statusLine().reasonPhrase().empty());
-    LOK_ASSERT_EQUAL(200, httpResponse->statusLine().statusCode());
+    LOK_ASSERT_EQUAL(200U, httpResponse->statusLine().statusCode());
     LOK_ASSERT(httpResponse->statusLine().statusCategory()
                == http::StatusLine::StatusCodeClass::Successful);
     LOK_ASSERT_EQUAL(std::string("HTTP/1.1"), httpResponse->statusLine().httpVersion());
@@ -176,7 +176,7 @@ static void compare(const Poco::Net::HTTPResponse& pocoResponse, const std::stri
 
     LOK_ASSERT_EQUAL_MESSAGE("Body", pocoBody, httpResponse.getBody());
 
-    LOK_ASSERT_EQUAL_MESSAGE("Status Code", static_cast<int>(pocoResponse.getStatus()),
+    LOK_ASSERT_EQUAL_MESSAGE("Status Code", static_cast<unsigned>(pocoResponse.getStatus()),
                              httpResponse.statusLine().statusCode());
     LOK_ASSERT_EQUAL_MESSAGE("Reason Phrase", pocoResponse.getReason(),
                              httpResponse.statusLine().reasonPhrase());
@@ -221,7 +221,7 @@ void HttpRequestTests::test500GetStatuses()
             http::StatusLine::StatusCodeClass::Client_Error,
             http::StatusLine::StatusCodeClass::Server_Error };
     int curStatusCodeClass = -1;
-    for (int statusCode = 100; statusCode < 512; ++statusCode)
+    for (unsigned statusCode = 100; statusCode < 512; ++statusCode)
     {
         const std::string url = "/status/" + std::to_string(statusCode);
 
@@ -300,7 +300,7 @@ void HttpRequestTests::testSimplePost()
     LOK_ASSERT(httpResponse->state() == http::Response::State::Complete);
     LOK_ASSERT(!httpResponse->statusLine().httpVersion().empty());
     LOK_ASSERT(!httpResponse->statusLine().reasonPhrase().empty());
-    LOK_ASSERT_EQUAL(200, httpResponse->statusLine().statusCode());
+    LOK_ASSERT_EQUAL(200U, httpResponse->statusLine().statusCode());
     LOK_ASSERT(httpResponse->statusLine().statusCategory()
                == http::StatusLine::StatusCodeClass::Successful);
 

--- a/test/HttpWhiteBoxTests.cpp
+++ b/test/HttpWhiteBoxTests.cpp
@@ -7,6 +7,7 @@
 
 #include <config.h>
 
+#include <string>
 #include <test/lokassert.hpp>
 
 #include <net/HttpRequest.hpp>
@@ -93,7 +94,8 @@ void HttpWhiteBoxTests::testRequestParserValidComplete()
     const std::string expVerb = "GET";
     const std::string expUrl = "/path/to/data";
     const std::string expVersion = "HTTP/1.1";
-    const std::string data = expVerb + ' ' + expUrl + ' ' + expVersion + "\r\n";
+    const std::string data
+        = expVerb + ' ' + expUrl + ' ' + expVersion + "\r\n" + "Host: localhost.com\r\n\r\n";
 
     http::Request req;
 
@@ -108,7 +110,8 @@ void HttpWhiteBoxTests::testRequestParserValidIncomplete()
     const std::string expVerb = "GET";
     const std::string expUrl = "/path/to/data";
     const std::string expVersion = "HTTP/1.1";
-    const std::string data = expVerb + ' ' + expUrl + ' ' + expVersion + "\r\n";
+    const std::string data
+        = expVerb + ' ' + expUrl + ' ' + expVersion + "\r\n" + "Host: localhost.com\r\n\r\n";
 
     http::Request req;
 
@@ -116,7 +119,7 @@ void HttpWhiteBoxTests::testRequestParserValidIncomplete()
     for (std::size_t i = 0; i < data.size(); ++i)
     {
         // Should return 0 to signify data is incomplete.
-        LOK_ASSERT_EQUAL(0L, req.readData(data.c_str(), i));
+        LOK_ASSERT_EQUAL_MESSAGE("i = " + std::to_string(i), 0L, req.readData(data.c_str(), i));
     }
 
     // Now parse the whole thing.

--- a/test/HttpWhiteBoxTests.cpp
+++ b/test/HttpWhiteBoxTests.cpp
@@ -24,6 +24,7 @@ class HttpWhiteBoxTests : public CPPUNIT_NS::TestFixture
 
     CPPUNIT_TEST(testStatusLineParserValidComplete);
     CPPUNIT_TEST(testStatusLineParserValidIncomplete);
+    CPPUNIT_TEST(testStatusLineSerialize);
 
     CPPUNIT_TEST(testRequestParserValidComplete);
     CPPUNIT_TEST(testRequestParserValidIncomplete);
@@ -32,17 +33,18 @@ class HttpWhiteBoxTests : public CPPUNIT_NS::TestFixture
 
     void testStatusLineParserValidComplete();
     void testStatusLineParserValidIncomplete();
+    void testStatusLineSerialize();
     void testRequestParserValidComplete();
     void testRequestParserValidIncomplete();
 };
 
 void HttpWhiteBoxTests::testStatusLineParserValidComplete()
 {
-    const int expVersionMajor = 1;
-    const int expVersionMinor = 1;
+    const unsigned expVersionMajor = 1;
+    const unsigned expVersionMinor = 1;
     const std::string expVersion
         = "HTTP/" + std::to_string(expVersionMajor) + '.' + std::to_string(expVersionMinor);
-    const int expStatusCode = 101;
+    const unsigned expStatusCode = 101;
     const std::string expReasonPhrase = "Something Something";
     const std::string data
         = expVersion + ' ' + std::to_string(expStatusCode) + ' ' + expReasonPhrase + "\r\n";
@@ -60,11 +62,11 @@ void HttpWhiteBoxTests::testStatusLineParserValidComplete()
 
 void HttpWhiteBoxTests::testStatusLineParserValidIncomplete()
 {
-    const int expVersionMajor = 1;
-    const int expVersionMinor = 1;
+    const unsigned expVersionMajor = 1;
+    const unsigned expVersionMinor = 1;
     const std::string expVersion
         = "HTTP/" + std::to_string(expVersionMajor) + '.' + std::to_string(expVersionMinor);
-    const int expStatusCode = 101;
+    const unsigned expStatusCode = 101;
     const std::string expReasonPhrase = "Something Something";
     const std::string data
         = expVersion + ' ' + std::to_string(expStatusCode) + ' ' + expReasonPhrase + "\r\n";
@@ -87,6 +89,15 @@ void HttpWhiteBoxTests::testStatusLineParserValidIncomplete()
     LOK_ASSERT_EQUAL(expVersionMinor, statusLine.versionMinor());
     LOK_ASSERT_EQUAL(expStatusCode, statusLine.statusCode());
     LOK_ASSERT_EQUAL(expReasonPhrase, statusLine.reasonPhrase());
+}
+
+void HttpWhiteBoxTests::testStatusLineSerialize()
+{
+    http::StatusLine statusLine(200);
+    Buffer buf;
+    statusLine.writeData(buf);
+    const std::string out(buf.getBlock(), buf.getBlockSize());
+    LOK_ASSERT_EQUAL(std::string("HTTP/1.1 200 OK\r\n"), out);
 }
 
 void HttpWhiteBoxTests::testRequestParserValidComplete()

--- a/test/UnitWOPILoadEncoded.cpp
+++ b/test/UnitWOPILoadEncoded.cpp
@@ -12,7 +12,6 @@
 #include <Unit.hpp>
 #include <UnitHTTP.hpp>
 #include <helpers.hpp>
-#include <Poco/Net/HTTPRequest.h>
 #include <Poco/Util/LayeredConfiguration.h>
 
 class UnitWOPILoadEncoded : public WopiTestServer

--- a/test/httpcrashtest.cpp
+++ b/test/httpcrashtest.cpp
@@ -18,10 +18,7 @@
 #include <Poco/JSON/JSON.h>
 #include <Poco/JSON/Parser.h>
 #include <Poco/Net/AcceptCertificateHandler.h>
-#include <Poco/Net/HTTPClientSession.h>
-#include <Poco/Net/HTTPRequest.h>
 #include <Poco/Net/HTTPResponse.h>
-#include <Poco/Net/HTTPSClientSession.h>
 #include <Poco/Net/InvalidCertificateHandler.h>
 #include <Poco/Net/NetException.h>
 #include <Poco/Net/PrivateKeyPassphraseHandler.h>

--- a/tools/Stress.cpp
+++ b/tools/Stress.cpp
@@ -19,9 +19,6 @@
 #include <sysexits.h>
 #include <thread>
 
-#include <Poco/Net/HTTPRequest.h>
-#include <Poco/Net/HTTPResponse.h>
-#include <Poco/URI.h>
 #include <Poco/Util/Application.h>
 #include <Poco/Util/HelpFormatter.h>
 #include <Poco/Util/Option.h>

--- a/wsd/Auth.hpp
+++ b/wsd/Auth.hpp
@@ -17,8 +17,6 @@
 #include <Poco/Crypto/RSADigestEngine.h>
 #include <Poco/Crypto/RSAKey.h>
 #endif
-#include <Poco/Net/HTTPRequest.h>
-#include <Poco/URI.h>
 
 /// Base class of all Authentication/Authorization implementations.
 class AuthBase

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -426,7 +426,7 @@ void FileServerRequestHandler::handleRequest(const HTTPRequest& request,
                 }
             }
 
-            response.set("User-Agent", HTTP_AGENT_STRING);
+            response.set("Server", HTTP_SERVER_STRING);
             response.set("Date", Util::getHttpTimeNow());
 
             bool gzip = request.hasToken("Accept-Encoding", "gzip");
@@ -984,7 +984,7 @@ void FileServerRequestHandler::preprocessAdminFile(const HTTPRequest& request,
     // No referrer-policy
     response.add("Referrer-Policy", "no-referrer");
     response.add("X-Content-Type-Options", "nosniff");
-    response.set("User-Agent", HTTP_AGENT_STRING);
+    response.set("Server", HTTP_SERVER_STRING);
     response.set("Date", Util::getHttpTimeNow());
 
     response.setContentType("text/html");

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -2494,7 +2494,7 @@ private:
                 response->add("X-XSS-Protection", "1; mode=block");
                 // No referrer-policy
                 response->add("Referrer-Policy", "no-referrer");
-                response->add("User-Agent", HTTP_AGENT_STRING);
+                response->set("Server", HTTP_SERVER_STRING);
                 response->add("Content-Type", "text/plain");
                 response->add("X-Content-Type-Options", "nosniff");
 
@@ -3024,7 +3024,7 @@ private:
                 std::ostringstream oss;
                 oss << "HTTP/1.1 403\r\n"
                     "Date: " << Util::getHttpTimeNow() << "\r\n"
-                    "User-Agent: " HTTP_AGENT_STRING "\r\n"
+                    "Server: " HTTP_SERVER_STRING "\r\n"
                     "Content-Length: 0\r\n"
                     "\r\n";
                 socket->send(oss.str());
@@ -3204,7 +3204,7 @@ private:
                 std::ostringstream oss;
                 oss << "HTTP/1.1 404 Not Found\r\n"
                     << "Date: " << Util::getHttpTimeNow() << "\r\n"
-                    << "User-Agent: " << HTTP_AGENT_STRING << "\r\n"
+                    << "Server: " HTTP_SERVER_STRING "\r\n"
                     << "Content-Length: 0\r\n"
                     << "\r\n";
                 socket->send(oss.str());

--- a/wsd/ProofKey.cpp
+++ b/wsd/ProofKey.cpp
@@ -20,17 +20,7 @@
 #include <Poco/BinaryWriter.h>
 #include <Poco/Crypto/RSADigestEngine.h>
 #include <Poco/Crypto/RSAKey.h>
-#include <Poco/Dynamic/Var.h>
-#include <Poco/JSON/Object.h>
-#include <Poco/JSON/Parser.h>
 #include <Poco/LineEndingConverter.h>
-#include <Poco/Net/HTTPClientSession.h>
-#include <Poco/Net/HTTPRequest.h>
-#include <Poco/Net/HTTPResponse.h>
-#include <Poco/Net/NetException.h>
-#include <Poco/Timestamp.h>
-#include <Poco/URI.h>
-#include <Poco/Util/Application.h>
 
 #include "Exceptions.hpp"
 #include <Log.hpp>


### PR DESCRIPTION
- wsd: http: tolerate the absence of a reason phrase
- wsd: test: better http tests
- wsd: http: parse the http header only
- wsd: http: improved whitebox http tests
- wsd: Util::toLower helper
- wsd: prevent poco from inserting line breaks in hex bytes
- wsd: http: map Status Codes to Reason Phrases
- wsd: http: log the hostname in warning
- wsd: cleanup Poco headers
- wsd: http: improve StatusLine
- wsd: test: http: improve HttpRequestTests
- wsd: http: better serialization into the socket buffer directly
- wsd: add member to Socket to flush safely
- wsd: http: use writeData to serialize http::Request
- wsd: correct User-Agent usage in http headers
- wsd: const correctness
- wsd: tolerate missing FinishedCallback in http::Response
- wsd: http: set date and server/agent as early as possible
- wsd: http: use std::move where efficient
- wsd: http: make writeData const
- wsd: use http::Response to parse client websocket upgrade
