### PR TITLE
fix: avoid view jump after pinch zoom animation

### DIFF
--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -349,7 +349,7 @@ L.TileSectionManager = L.Class.extend({
 		var splitPos = ctx.splitPos;
 		var canvasOverlay = this._layer._canvasOverlay;
 
-		var rafFunc = function () {
+		var rafFunc = function (timeStamp, final) {
 			painter._sectionContainer.setPenPosition(painter._tilesSection);
 			for (var i = 0; i < paneBoundsList.length; ++i) {
 				var paneBounds = paneBoundsList[i];
@@ -368,13 +368,25 @@ L.TileSectionManager = L.Class.extend({
 				if (inYBounds)
 					center.y = painter._newCenter.y;
 
-				// Top left position in the offscreen canvas.
-				var sourceTopLeft = new L.Point(
+				// Top left in document coordinates.
+				var docTopLeft = new L.Point(
 					Math.max(paneBounds.min.x ? splitPos.x: 0,
 						center.x - (center.x - paneBounds.min.x) / scale),
 					Math.max(paneBounds.min.y ? splitPos.y: 0,
-						center.y - (center.y - paneBounds.min.y) / scale))
-					._subtract(paneBounds.min)._add(paneBoundsOffset);
+						center.y - (center.y - paneBounds.min.y) / scale));
+
+				if (final &&
+					(paneBounds.min.x || (!paneBounds.min.x && !splitPos.x)) &&
+					(paneBounds.min.y || (!paneBounds.min.y && !splitPos.y))) {
+					// This is needed to set the map center once animation has finished.
+					// Done only for the freely movable pane.
+					painter._newMapCenter = new L.Point(
+						(docTopLeft.x - splitPos.x + (paneSize.x + splitPos.x) / (2 * scale)) * scale / painter._tilesSection.dpiScale,
+						(docTopLeft.y - splitPos.y + (paneSize.y + splitPos.y) / (2 * scale)) * scale / painter._tilesSection.dpiScale);
+				}
+
+				// Top left position in the offscreen canvas.
+				var sourceTopLeft = docTopLeft.subtract(paneBounds.min).add(paneBoundsOffset);
 
 				var destPos = new L.Point(0, 0);
 				if (paneBoundsList.length > 1) {
@@ -411,7 +423,8 @@ L.TileSectionManager = L.Class.extend({
 
 			canvasOverlay.onDraw();
 
-			painter._zoomRAF = requestAnimationFrame(rafFunc);
+			if (!final)
+				painter._zoomRAF = requestAnimationFrame(rafFunc);
 		};
 		this.rafFunc = rafFunc;
 		rafFunc();
@@ -443,11 +456,12 @@ L.TileSectionManager = L.Class.extend({
 		if (this._inZoomAnim) {
 			cancelAnimationFrame(this._zoomRAF);
 			this._calcZoomFrameScale(zoom, newCenter);
-			this.rafFunc();
-			cancelAnimationFrame(this._zoomRAF);
+			this.rafFunc(undefined, true /* final? */);
 			this._zoomFrameScale = undefined;
 			this._tilesSection.setInZoomAnim(false);
 			this._inZoomAnim = false;
+			var newMapCenterLatLng = this._newMapCenter ? this._map.unproject(this._newMapCenter, zoom) : undefined;
+			return newMapCenterLatLng;
 		}
 	},
 
@@ -667,7 +681,7 @@ L.CanvasTileLayer = L.TileLayer.extend({
 	},
 
 	zoomStepEnd: function (zoom, newCenter) {
-		this._painter.zoomStepEnd(zoom, newCenter);
+		return this._painter.zoomStepEnd(zoom, newCenter);
 	},
 
 	_viewReset: function (e) {

--- a/loleaflet/src/map/handler/Map.TouchGesture.js
+++ b/loleaflet/src/map/handler/Map.TouchGesture.js
@@ -617,12 +617,13 @@ L.Map.TouchGesture = L.Handler.extend({
 
 		this._pinchStartCenter = undefined;
 
+		var newMapCenter;
 		if (this._map._docLayer.zoomStepEnd) {
-			this._map._docLayer.zoomStepEnd(finalZoom, this._origCenter);
+			newMapCenter = this._map._docLayer.zoomStepEnd(finalZoom, this._origCenter);
 		}
 
 		this._map.setZoomViewPanning(true);
-		this._map.setView(this._center, finalZoom);
+		this._map.setView(newMapCenter || this._center, finalZoom);
 		this._map.setZoomViewPanning(false);
 	},
 


### PR DESCRIPTION
Fix description:

The view jump is because after the zoom animation has ended, the map
center is set to the pinch center and not the last frame's center. The
patch computes the last frame's center and uses that to set the map
view's center. This only fixes the view jump and not the flicker after
the animation which is an independent issue.

Caveats:

Since we show only one discontinuous frame at the "final allowable zoom"
at the end of the zoom animation, there will be perceived view jump at
the end of the animation itself. This is apparent if the user pays
attention to the contents of the document at the corners of the view
before and after the is pinch stopped. This jump is more pronounced if
the pinch zoom factor is much different from the "final-zoom".
Note: The final zoom is determined from the final pinch zoom as
var finalZoom = this._map._limitZoom(zoomDelta > 0 ? Math.ceil(this._zoom) : Math.floor(this._zoom));

A possible solution for this problem is to render a few frames at the
end of the animation that are closer to the "final zoom" from the where
the pinch left off.


Signed-off-by: Dennis Francis <dennis.francis@collabora.com>
Change-Id: I0a6989248970aeb60acc451d9b0bc7a08a0dbf06


* Target version: co-6-4

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

