### PR TITLE
loleaflet:prevent changing focus in sheet rename dialog when double c…

### DIFF
--- a/loleaflet/src/layer/tile/TileLayer.js
+++ b/loleaflet/src/layer/tile/TileLayer.js
@@ -2679,7 +2679,7 @@ L.TileLayer = L.GridLayer.extend({
 		} else {
 			this._map._textInput.hideCursor();
 			// Maintain input if a dialog or search-box has the focus.
-			if (this._map.editorHasFocus() && !this._map.isSearching())
+			if (this._map.editorHasFocus() && !isAnyVexDialogActive() && !this._map.isSearching())
 				this._map.focus(false);
 		}
 	},


### PR DESCRIPTION
…lick

Signed-off-by: Rash419 <rasheshpadia419@gmail.com>
Change-Id: I83b24045aa88eb0cc61ece1ca76fc0d677eb6a38


* Resolves: #1800 
* Target version: master 

### Summary
now focus doesnot change when rename sheet dialog (vex) is open on double click event
