### PR TITLE
Revert "Action_Paste postMessage to work around the pasting mechanism."

### DIFF
--- a/loleaflet/src/map/handler/Map.WOPI.js
+++ b/loleaflet/src/map/handler/Map.WOPI.js
@@ -378,12 +378,6 @@ L.Map.WOPI = L.Handler.extend({
 				this._map.insertURL(msg.Values.url);
 			}
 		}
-		else if (msg.MessageId == 'Action_Paste') {
-			if (msg.Values && msg.Values.Mimetype && msg.Values.Data) {
-				var blob = new Blob(['paste mimetype=' + msg.Values.Mimetype + '\n', msg.Values.Data]);
-				this._map._socket.sendMessage(blob);
-			}
-		}
 		else if (msg.MessageId === 'Action_ShowBusy') {
 			if (msg.Values && msg.Values.Label) {
 				this._map.fire('showbusy', {label: msg.Values.Label});


### PR DESCRIPTION
This was not necessary in the end; and a bad idea in general probably,
so given that has never appeared in a release yet, let's revert it.

This reverts commit 5999a5b7cc7815f88484ff4f55e06406d1add068.

Signed-off-by: Jan Holesovsky <kendy@collabora.com>
Change-Id: I5ee98ea85324f584db7de702a8d98ff9a6780027
