### PR TITLE
Notebookbar: Writer: References tab: Fields: rm duplicated & fix layout

### DIFF
--- a/loleaflet/src/control/Control.NotebookbarWriter.js
+++ b/loleaflet/src/control/Control.NotebookbarWriter.js
@@ -2402,17 +2402,6 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 						'children': [
 							{
 								'type': 'toolitem',
-								'text': _UNO('.uno:InsertField', 'text'),
-								'command': '.uno:InsertField'
-							}
-						]
-					},
-					{
-						'id': 'LineA18',
-						'type': 'toolbox',
-						'children': [
-							{
-								'type': 'toolitem',
 								'text': _UNO('.uno:InsertPageNumberField'),
 								'command': '.uno:InsertPageNumberField'
 							},
@@ -2421,6 +2410,12 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 								'text': _UNO('.uno:InsertPageCountField', 'text'),
 								'command': '.uno:InsertPageCountField'
 							},
+						]
+					},
+					{
+						'id': 'LineA18',
+						'type': 'toolbox',
+						'children': [
 							{
 								'type': 'toolitem',
 								'text': _UNO('.uno:InsertDateField', 'text'),


### PR DESCRIPTION
- Remove duplicated of "Field" (Fields dialog)
  - Retain bigtoolitem
  - Remove menutoolitem with label
- Fix alignment of remaining field items
  - Group it in two groups
  - Vertically so to use notebookbar space more efeciently

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I40f74dbf7818d19ddead0d7e36f1f42f3ce59032
