### PR TITLE
fix: avoid view jump after pinch zoom animation

### DIFF
--- a/loleaflet/src/map/handler/Map.TouchGesture.js
+++ b/loleaflet/src/map/handler/Map.TouchGesture.js
@@ -619,12 +619,13 @@ L.Map.TouchGesture = L.Handler.extend({
 
 		this._pinchStartCenter = undefined;
 
+		var newMapCenter;
 		if (this._map._docLayer.zoomStepEnd) {
-			this._map._docLayer.zoomStepEnd(finalZoom, this._origCenter);
+			newMapCenter = this._map._docLayer.zoomStepEnd(finalZoom, this._origCenter);
 		}
 
 		this._map.setZoomViewPanning(true);
-		this._map.setView(this._center, finalZoom);
+		this._map.setView(newMapCenter || this._center, finalZoom);
 		this._map.setZoomViewPanning(false);
 	},
 


### PR DESCRIPTION
Fix description:

The view jump is because after the zoom animation has ended, the map
center is set to the pinch center and not the last frame's center. The
patch computes the last frame's center and uses that to set the map
view's center. This only fixes the view jump and not the flicker after
the animation which is an independent issue.

Caveat:
Since we show only one discontinuous frame at the "final allowable zoom"
at the end of the zoom animation, there will be perceived view jump at
the end of the animation itself. This apparent if the user pays
attention to the contents of the document at the corners of the view
before and after the is pinch stopped. This jump is more pronounced if
the pinch zoom factor is much different from the "final-zoom".
Note: The final zoom is determined from the final pinch zoom as
var finalZoom = this._map._limitZoom(zoomDelta > 0 ? Math.ceil(this._zoom) : Math.floor(this._zoom));

A possible solution for this problem is to render a few frames at the
end of the animation that are closer to the "final zoom" from the where
the pinch left off.


Signed-off-by: Dennis Francis <dennis.francis@collabora.com>
Change-Id: I0a6989248970aeb60acc451d9b0bc7a08a0dbf06
(cherry picked from commit 5b2daac61edb78150ad9700ce11fab8bdfb7dd27)


* Target version: master 

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

