### PR TITLE
leaflet: prevent search shortcut with shift or alt

### DIFF
--- a/loleaflet/src/map/handler/Map.Keyboard.js
+++ b/loleaflet/src/map/handler/Map.Keyboard.js
@@ -475,7 +475,7 @@ L.Map.Keyboard = L.Handler.extend({
 			return true;
 		}
 
-		if (e.ctrlKey && (e.key === 'f' || e.key === 'F')) {
+		if (e.ctrlKey && !e.shiftKey && !e.altKey && (e.key === 'f' || e.key === 'F')) {
 			this._map.fire('focussearch');
 			e.preventDefault();
 			return true;


### PR DESCRIPTION


Signed-off-by: Pranam Lashkari <lpranam@collabora.com>
Change-Id: I97ff4d95250aad326b7d48635ab425045959ca5d


* Target version: distro/collabora/co-6-4 

### Summary
in german shortcut for bold is ctrl+shift+f
bold shortcut is handled in the core
so we prevent online overwriting the search shortcut with shift


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

