### PR TITLE
Notebookbar: Sync tile container size after collapsing / expanding tabs.

### DIFF
--- a/loleaflet/src/control/Control.UIManager.js
+++ b/loleaflet/src/control/Control.UIManager.js
@@ -440,6 +440,8 @@ L.Control.UIManager = L.Control.extend({
 		$('#toolbar-up').css('display', 'none');
 
 		$('#document-container').addClass('tabs-collapsed');
+
+		this.map._docLayer._syncTileContainerSize();
 	},
 
 	extendNotebookbar: function() {
@@ -453,6 +455,8 @@ L.Control.UIManager = L.Control.extend({
 		$('#toolbar-up').css('display', '');
 
 		$('#document-container').removeClass('tabs-collapsed');
+
+		this.map._docLayer._syncTileContainerSize();
 	},
 
 	isNotebookbarCollapsed: function() {


### PR DESCRIPTION
Canvas element wasn't sync with map element.

Signed-off-by: Gökay Şatır <gokay.satir@collabora.com>
Change-Id: I7771f662fb9a244b2acb1d450413343f4c450b1f


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

