### PR TITLE
Blinking cursor only when window is focused

### DIFF
--- a/loleaflet/src/layer/marker/Cursor.ts
+++ b/loleaflet/src/layer/marker/Cursor.ts
@@ -62,14 +62,15 @@ class Cursor {
 		this.map.getCursorOverlayContainer().appendChild(this.container);
 		this.visible = true;
 		this.domAttached = true;
+		this.onFocusBlur(new FocusEvent('focus'));
 		this.update();
 		if (this.map._docLayer.isCalc())
 			this.map.on('splitposchanged move', this.update, this);
 		else
 			this.map.on('move', this.update, this);
 
-		document.addEventListener('blur', this.onFocusBlur.bind(this));
-		document.addEventListener('focus', this.onFocusBlur.bind(this));
+		window.addEventListener('blur', this.onFocusBlur.bind(this));
+		window.addEventListener('focus', this.onFocusBlur.bind(this));
 	}
 
 	remove() {
@@ -86,8 +87,8 @@ class Cursor {
 		this.visible = false;
 		this.domAttached = false;
 
-		document.removeEventListener('blur', this.onFocusBlur.bind(this));
-		document.removeEventListener('focus', this.onFocusBlur.bind(this));
+		window.removeEventListener('blur', this.onFocusBlur.bind(this));
+		window.removeEventListener('focus', this.onFocusBlur.bind(this));
 	}
 
 	isDomAttached(): boolean {


### PR DESCRIPTION
use window instead of document.
now it works also in chrome.

Change-Id: Id58b8810fb6a8d5ba00369308cce1dd201b7340a
Signed-off-by: Szymon Kłos <szymon.klos@collabora.com>

