### PR TITLE
Notebookbar: Increase select status of unobuttons

### DIFF
--- a/loleaflet/css/notebookbar.css
+++ b/loleaflet/css/notebookbar.css
@@ -316,8 +316,6 @@ div[id*='Row'].notebookbar, div[id*='Column'].notebookbar, #SendToBack.notebookb
 	padding: 4px;
 }
 .unotoolbutton.notebookbar:not(.disabled):hover, #clearFormatting.notebookbar div img:hover {
-	box-shadow: 0 0 0px 4px #e6e6e6b0;
-	border-radius: 0.1px;
 	background-color: #e6e6e6b0;
 	cursor: pointer;
 }

--- a/loleaflet/css/notebookbar.css
+++ b/loleaflet/css/notebookbar.css
@@ -237,8 +237,8 @@
 }
 
 div[id*='Row'].notebookbar, div[id*='Column'].notebookbar, #SendToBack.notebookbar, #ObjectBackOne.notebookbar, #ObjectForwardOne.notebookbar, #BringToFront.notebookbar, #SetObjectToBackground.notebookbar, #SetObjectToForeground.notebookbar, #FlipVertical.notebookbar, #FlipHorizontal.notebookbar, #Bold.notebookbar, #Italic.notebookbar, #Underline.notebookbar, #Strikeout.notebookbar, #StyleApply.notebookbar, #StyleUpdateByExample.notebookbar, #StyleNewByExample.notebookbar, #Shadowed.notebookbar, #Grow.notebookbar, #Shrink.notebookbar, #Spacing.notebookbar, #SuperScript.notebookbar, #SubScript.notebookbar,#AlignLeft.notebookbar, #AlignRight.notebookbar, #AlignHorizontalCenter.notebookbar, #AlignBlock.notebookbar, #ParaRightToLeft.notebookbar, #ParaLeftToRight.notebookbar, #AlignTop.notebookbar, #AlignVCenter.notebookbar, #AlignBottom.notebookbar, #IncrementIndent.notebookbar, #DecrementIndent.notebookbar, #LeftPara.notebookbar, #RightPara.notebookbar, #CenterPara.notebookbar, #JustifyPara.notebookbar, #DefaultBullet.notebookbar, #DefaultNumbering.notebookbar, #ParaspaceIncrease.notebookbar, #ParaspaceDecrease.notebookbar, #LineSpacing.notebookbar, #HangingIndent.notebookbar, #CellVertTop.notebookbar, #CellVertCenter.notebookbar, #CellVertBottom.notebookbar, #DeleteTable.notebookbar, #MergeCells.notebookbar{
-	padding: 0px !important;
-	margin: 0px 5px 0px 0px !important;
+	padding: 2px !important;
+	margin: 0px 1px 0px 0px !important;
 }
 
 /* avoid bug with arrow in new line when window is small */
@@ -430,7 +430,7 @@ div[id*='Row'].notebookbar, div[id*='Column'].notebookbar, #SendToBack.notebookb
 
 #table-GroupB19 #table-GroupB93.notebookbar {
 	margin-left: -84px;
-	margin-bottom: -8px !important;
+	margin-bottom: -4px !important;
 }
 
 #table-GroupB95 {


### PR DESCRIPTION
in the sequence of the idea started in
https://github.com/CollaboraOnline/online/pull/1212
- by adding padding to unobuttons (independent of its status)
- do not really solely on margin

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Iad3389226297b7a8504def148b5d869db936fd19
