### PR TITLE
Allow the iOS app to open PDF files

### DIFF
--- a/ios/Mobile/Info.plist.in
+++ b/ios/Mobile/Info.plist.in
@@ -176,6 +176,21 @@
 				<string>com.collabora.office.uti.vsd</string>
 			</array>
 		</dict>
+		<!-- Other -->
+		<dict>
+			<key>CFBundleTypeIconFiles</key>
+			<array/>
+			<key>CFBundleTypeName</key>
+			<string>PDF Document</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSHandlerRank</key>
+			<string>Alternate</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.adobe.pdf</string>
+			</array>
+		</dict>
 	</array>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
@@ -626,6 +641,27 @@
 				<key>public.mime-type</key>
 				<array>
 					<string>application/vnd.openxmlformats-officedocument.presentationml.presentation</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.composite-content</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>PDF Document</string>
+			<key>UTTypeIdentifier</key>
+			<string>com.adobe.pdf</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>pdf</string>
+				</array>
+				<key>public.mime-type</key>
+				<array>
+					<string>application/pdf</string>
 				</array>
 			</dict>
 		</dict>


### PR DESCRIPTION
Part of implementing https://github.com/CollaboraOnline/online/issues/1824

Change-Id: Ib1fd2626880d0bafece2a79f6bfd26616d8a61ad
Signed-off-by: Tor Lillqvist <tml@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

