### PR TITLE
Remove incorrect assertion in iOS-only code

### DIFF
--- a/common/RenderTiles.hpp
+++ b/common/RenderTiles.hpp
@@ -433,8 +433,6 @@ namespace RenderTiles
 
     static void generateBmpHeader(char *buffer, int width, int height)
     {
-        assert(width%4 == 0);
-
         BITMAPFILEHEADER *bf = (BITMAPFILEHEADER*)buffer;
         bf->bfType = ('B' | ('M' << 8));
         bf->bfSize = bmpFileSize(width, height);


### PR DESCRIPTION
It caused a crash when opening some PDF files, for instance.

Change-Id: I85515e2e14ffac8928714d218cd2353df228ff4b
Signed-off-by: Tor Lillqvist <tml@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

