### PR TITLE
Client side grids and zoom animation improvements

### DIFF
--- a/loleaflet/src/layer/tile/CanvasSectionContainer.ts
+++ b/loleaflet/src/layer/tile/CanvasSectionContainer.ts
@@ -144,7 +144,7 @@ class CanvasSectionObject {
 	onMultiTouchEnd: Function; // Parameters: e (native event object)
 	onResize: Function; // Parameters: null (Section's size is up to date when this callback is called.)
 	onDraw: Function; // Parameters: null || (frameCount, elapsedTime)
-	onDrawArea: Function; // Optional Parameters: (area, canvasContext) - area is the area to be painted using canvasContext.
+	onDrawArea: Function; // Optional Parameters: (area, paneTopLeft, canvasContext) - area is the area to be painted using canvasContext.
 	onAnimationEnded: Function; // frameCount, elapsedTime. Sections that will use animation, have to have this function defined.
 	onNewDocumentTopLeft: Function; // Parameters: Size [x, y]
 	onRemove: Function; // This Function is called right before section is removed.

--- a/loleaflet/src/layer/tile/CanvasSectionContainer.ts
+++ b/loleaflet/src/layer/tile/CanvasSectionContainer.ts
@@ -144,7 +144,7 @@ class CanvasSectionObject {
 	onMultiTouchEnd: Function; // Parameters: e (native event object)
 	onResize: Function; // Parameters: null (Section's size is up to date when this callback is called.)
 	onDraw: Function; // Parameters: null || (frameCount, elapsedTime)
-	onDrawArea: Function; // Optional Parameter: area - The area inside the section to be painted.
+	onDrawArea: Function; // Optional Parameters: (area, canvasContext) - area is the area to be painted using canvasContext.
 	onAnimationEnded: Function; // frameCount, elapsedTime. Sections that will use animation, have to have this function defined.
 	onNewDocumentTopLeft: Function; // Parameters: Size [x, y]
 	onRemove: Function; // This Function is called right before section is removed.

--- a/loleaflet/src/layer/tile/CanvasSectionContainer.ts
+++ b/loleaflet/src/layer/tile/CanvasSectionContainer.ts
@@ -144,6 +144,7 @@ class CanvasSectionObject {
 	onMultiTouchEnd: Function; // Parameters: e (native event object)
 	onResize: Function; // Parameters: null (Section's size is up to date when this callback is called.)
 	onDraw: Function; // Parameters: null || (frameCount, elapsedTime)
+	onDrawArea: Function; // Optional Parameter: area - The area inside the section to be painted.
 	onAnimationEnded: Function; // frameCount, elapsedTime. Sections that will use animation, have to have this function defined.
 	onNewDocumentTopLeft: Function; // Parameters: Size [x, y]
 	onRemove: Function; // This Function is called right before section is removed.
@@ -184,6 +185,7 @@ class CanvasSectionObject {
 		this.onMultiTouchEnd = options.onMultiTouchEnd ? options.onMultiTouchEnd: function() {};
 		this.onResize = options.onResize ? options.onResize: function() {};
 		this.onDraw = options.onDraw ? options.onDraw: function() {};
+		this.onDrawArea = options.onDrawArea ? options.onDrawArea: function() {};
 		this.onNewDocumentTopLeft = options.onNewDocumentTopLeft ? options.onNewDocumentTopLeft: function() {};
 		this.onRemove = options.onRemove ? options.onRemove: function() {};
 		this.onAnimationEnded = options.onAnimationEnded ? options.onAnimationEnded: function() {};

--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -491,7 +491,7 @@ L.TileSectionManager = L.Class.extend({
 		}
 	},
 
-	zoomStepEnd: function (zoom, newCenter, mapUpdater) {
+	zoomStepEnd: function (zoom, newCenter, mapUpdater, showMarkers) {
 
 		if (!this._inZoomAnim || this._finishingZoom)
 			return;
@@ -560,6 +560,8 @@ L.TileSectionManager = L.Class.extend({
 					painter._sectionContainer.requestReDraw();
 					// Don't let a subsequent pinchZoom start before finishing all steps till this point.
 					painter._finishingZoom = false;
+					// Make the markers and svg overlays visible.
+					showMarkers();
 				}
 				else
 					waitTries -= 1;
@@ -791,8 +793,8 @@ L.CanvasTileLayer = L.TileLayer.extend({
 		this._painter.zoomStep(zoom, newCenter);
 	},
 
-	zoomStepEnd: function (zoom, newCenter, mapUpdater) {
-		this._painter.zoomStepEnd(zoom, newCenter, mapUpdater);
+	zoomStepEnd: function (zoom, newCenter, mapUpdater, showMarkers) {
+		this._painter.zoomStepEnd(zoom, newCenter, mapUpdater, showMarkers);
 	},
 
 	_viewReset: function (e) {

--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -519,6 +519,7 @@ L.TileSectionManager = L.Class.extend({
 
 		var stopAnimation = false;
 		var waitForTiles = false;
+		var waitTries = 30;
 		var intervalId = setInterval(function () {
 
 			if (stepId < steps) {
@@ -548,8 +549,8 @@ L.TileSectionManager = L.Class.extend({
 			}
 
 			if (waitForTiles) {
-				// Wait until we get all tiles.
-				if (painter._tilesSection.haveAllTilesInView()) {
+				// Wait until we get all tiles or wait time exceeded.
+				if (waitTries <= 0 || painter._tilesSection.haveAllTilesInView()) {
 					// All done.
 					waitForTiles = false;
 					clearInterval(intervalId);
@@ -560,6 +561,8 @@ L.TileSectionManager = L.Class.extend({
 					// Don't let a subsequent pinchZoom start before finishing all steps till this point.
 					painter._finishingZoom = false;
 				}
+				else
+					waitTries -= 1;
 			}
 
 		}, intervalGap);

--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -193,17 +193,16 @@ L.TileSectionManager = L.Class.extend({
 		this.onDrawArea();
 	},
 
-	_drawGridSectionArea: function (repaintArea) {
+	_drawGridSectionArea: function (repaintArea, canvasCtx) {
 		if (!this.sectionProperties.docLayer.sheetGeometry)
 			return;
 
-		this.context.strokeStyle = this.sectionProperties.strokeStyle;
-		this.context.lineWidth = 1.0;
+		var context = canvasCtx ? canvasCtx : this.context;
+		context.strokeStyle = this.sectionProperties.strokeStyle;
+		context.lineWidth = 1.0;
 
 		var ctx = this.sectionProperties.tsManager._paintContext();
-		var context = this.context;
-
-		this.context.beginPath();
+		context.beginPath();
 		for (var i = 0; i < ctx.paneBoundsList.length; ++i) {
 			// co-ordinates of this pane in core document pixels
 			var paneBounds = ctx.paneBoundsList[i];
@@ -241,7 +240,7 @@ L.TileSectionManager = L.Class.extend({
 					context.stroke();
 				});
 		}
-		this.context.closePath();
+		context.closePath();
 	},
 
 	// This section is added when debug is enabled. Splits are enabled for only Calc for now.

--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -189,11 +189,13 @@ L.TileSectionManager = L.Class.extend({
 	},
 
 	_onDrawGridSection: function () {
+		if (this._inZoomAnim)
+			return;
 		// grid-section's onDrawArea is TileSectionManager's _drawGridSectionArea().
 		this.onDrawArea();
 	},
 
-	_drawGridSectionArea: function (repaintArea, canvasCtx) {
+	_drawGridSectionArea: function (repaintArea, paneTopLeft, canvasCtx) {
 		if (!this.sectionProperties.docLayer.sheetGeometry)
 			return;
 
@@ -212,16 +214,17 @@ L.TileSectionManager = L.Class.extend({
 			paneBounds.round();
 			viewBounds.round();
 
-			if (!repaintArea) {
+			var paneOffset;
+			if (!repaintArea || !paneTopLeft) {
 				repaintArea = paneBounds;
+				paneOffset = paneBounds.getTopLeft(); // allocates
+				// Cute way to detect the in-canvas pixel offset of each pane
+				paneOffset.x = Math.min(paneOffset.x, viewBounds.min.x);
+				paneOffset.y = Math.min(paneOffset.y, viewBounds.min.y);
 			} else {
 				repaintArea = paneBounds.clamp(repaintArea);
+				paneOffset = paneTopLeft.clone();
 			}
-
-			var paneOffset = paneBounds.getTopLeft(); // allocates
-			// Cute way to detect the in-canvas pixel offset of each pane
-			paneOffset.x = Math.min(paneOffset.x, viewBounds.min.x);
-			paneOffset.y = Math.min(paneOffset.y, viewBounds.min.y);
 
 			// URGH -> zooming etc. (!?) ...
 			this.sectionProperties.docLayer.sheetGeometry._columns.forEachInCorePixelRange(

--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -158,7 +158,8 @@ L.TileSectionManager = L.Class.extend({
 				tsManager: that,
 				strokeStyle: '#c0c0c0'
 			},
-			onDraw: that._onDrawGridSection
+			onDraw: that._onDrawGridSection,
+			onDrawArea: that._drawGridSectionArea
 		}, 'tiles'); // Its size and position will be copied from 'tiles' section.
 	},
 
@@ -188,6 +189,11 @@ L.TileSectionManager = L.Class.extend({
 	},
 
 	_onDrawGridSection: function () {
+		// grid-section's onDrawArea is TileSectionManager's _drawGridSectionArea().
+		this.onDrawArea();
+	},
+
+	_drawGridSectionArea: function (repaintArea) {
 		if (!this.sectionProperties.docLayer.sheetGeometry)
 			return;
 
@@ -207,6 +213,12 @@ L.TileSectionManager = L.Class.extend({
 			paneBounds.round();
 			viewBounds.round();
 
+			if (!repaintArea) {
+				repaintArea = paneBounds;
+			} else {
+				repaintArea = paneBounds.clamp(repaintArea);
+			}
+
 			var paneOffset = paneBounds.getTopLeft(); // allocates
 			// Cute way to detect the in-canvas pixel offset of each pane
 			paneOffset.x = Math.min(paneOffset.x, viewBounds.min.x);
@@ -214,18 +226,18 @@ L.TileSectionManager = L.Class.extend({
 
 			// URGH -> zooming etc. (!?) ...
 			this.sectionProperties.docLayer.sheetGeometry._columns.forEachInCorePixelRange(
-				paneBounds.min.x, paneBounds.max.x,
+				repaintArea.min.x, repaintArea.max.x,
 				function(pos) {
-					context.moveTo(pos - paneOffset.x - 0.5, paneBounds.min.y - paneOffset.y - 0.5);
-					context.lineTo(pos - paneOffset.x - 0.5, paneBounds.max.y - paneOffset.y - 0.5);
+					context.moveTo(pos - paneOffset.x - 0.5, repaintArea.min.y - paneOffset.y - 0.5);
+					context.lineTo(pos - paneOffset.x - 0.5, repaintArea.max.y - paneOffset.y - 0.5);
 					context.stroke();
 				});
 
 			this.sectionProperties.docLayer.sheetGeometry._rows.forEachInCorePixelRange(
-				paneBounds.min.y, paneBounds.max.y,
+				repaintArea.min.y, repaintArea.max.y,
 				function(pos) {
-					context.moveTo(paneBounds.min.x - paneOffset.x - 0.5, pos - paneOffset.y - 0.5);
-					context.lineTo(paneBounds.max.x - paneOffset.x - 0.5, pos - paneOffset.y - 0.5);
+					context.moveTo(repaintArea.min.x - paneOffset.x - 0.5, pos - paneOffset.y - 0.5);
+					context.lineTo(repaintArea.max.x - paneOffset.x - 0.5, pos - paneOffset.y - 0.5);
 					context.stroke();
 				});
 		}

--- a/loleaflet/src/layer/tile/TilesSection.ts
+++ b/loleaflet/src/layer/tile/TilesSection.ts
@@ -141,6 +141,8 @@ class TilesSection {
 					crop.min.x - paneOffset.x,
 					crop.min.y - paneOffset.y,
 					cropWidth, cropHeight);
+				var gridSection = this.containerObject.getSectionWithName(L.CSections.CalcGrid.name);
+				gridSection.onDrawArea(crop);
 			}
 			canvasCtx.drawImage(tile.el,
 				crop.min.x - tileBounds.min.x,

--- a/loleaflet/src/layer/tile/TilesSection.ts
+++ b/loleaflet/src/layer/tile/TilesSection.ts
@@ -136,13 +136,13 @@ class TilesSection {
 		if (cropWidth && cropHeight) {
 			if (clearBackground || this.containerObject.isZoomChanged()) {
 				// Whole canvas is not cleared after zoom has changed, so clear it per tile as they arrive.
-				this.context.fillStyle = this.containerObject.getClearColor();
-				this.context.fillRect(
+				canvasCtx.fillStyle = this.containerObject.getClearColor();
+				canvasCtx.fillRect(
 					crop.min.x - paneOffset.x,
 					crop.min.y - paneOffset.y,
 					cropWidth, cropHeight);
 				var gridSection = this.containerObject.getSectionWithName(L.CSections.CalcGrid.name);
-				gridSection.onDrawArea(crop);
+				gridSection.onDrawArea(crop, canvasCtx);
 			}
 			canvasCtx.drawImage(tile.el,
 				crop.min.x - tileBounds.min.x,

--- a/loleaflet/src/layer/tile/TilesSection.ts
+++ b/loleaflet/src/layer/tile/TilesSection.ts
@@ -134,7 +134,7 @@ class TilesSection {
 		var cropHeight = crop.max.y - crop.min.y;
 
 		if (cropWidth && cropHeight) {
-			if (clearBackground || this.containerObject.isZoomChanged()) {
+			if (clearBackground || this.containerObject.isZoomChanged() || canvasCtx !== this.context) {
 				// Whole canvas is not cleared after zoom has changed, so clear it per tile as they arrive.
 				canvasCtx.fillStyle = this.containerObject.getClearColor();
 				canvasCtx.fillRect(
@@ -142,7 +142,7 @@ class TilesSection {
 					crop.min.y - paneOffset.y,
 					cropWidth, cropHeight);
 				var gridSection = this.containerObject.getSectionWithName(L.CSections.CalcGrid.name);
-				gridSection.onDrawArea(crop, canvasCtx);
+				gridSection.onDrawArea(crop, paneOffset, canvasCtx);
 			}
 			canvasCtx.drawImage(tile.el,
 				crop.min.x - tileBounds.min.x,

--- a/loleaflet/src/layer/tile/TilesSection.ts
+++ b/loleaflet/src/layer/tile/TilesSection.ts
@@ -89,7 +89,7 @@ class TilesSection {
 		return extendedBounds;
 	}
 
-	paintWithPanes (tile: any, ctx: any) {
+	paintWithPanes (tile: any, ctx: any, async: boolean) {
 		var tileTopLeft = tile.coords.getPos();
 		var tileBounds = new L.Bounds(tileTopLeft, tileTopLeft.add(ctx.tileSize));
 
@@ -112,17 +112,17 @@ class TilesSection {
 				paneOffset.x = Math.min(paneOffset.x, viewBounds.min.x);
 				paneOffset.y = Math.min(paneOffset.y, viewBounds.min.y);
 
-				this.drawTileInPane(tile, tileBounds, paneBounds, paneOffset, this.context);
+				this.drawTileInPane(tile, tileBounds, paneBounds, paneOffset, this.context, async);
 			}
 
 			if (extendedBounds.intersects(tileBounds)) {
 				var offset = extendedBounds.getTopLeft();
-				this.drawTileInPane(tile, tileBounds, extendedBounds, offset, this.oscCtxs[i]);
+				this.drawTileInPane(tile, tileBounds, extendedBounds, offset, this.oscCtxs[i], async);
 			}
 		}
 	}
 
-	drawTileInPane (tile: any, tileBounds: any, paneBounds: any, paneOffset: any, canvasCtx: any) {
+	drawTileInPane (tile: any, tileBounds: any, paneBounds: any, paneOffset: any, canvasCtx: any, clearBackground: boolean) {
 		// intersect - to avoid state thrash through clipping
 		var crop = new L.Bounds(tileBounds.min, tileBounds.max);
 		crop.min.x = Math.max(paneBounds.min.x, tileBounds.min.x);
@@ -134,7 +134,7 @@ class TilesSection {
 		var cropHeight = crop.max.y - crop.min.y;
 
 		if (cropWidth && cropHeight) {
-			if (this.containerObject.isZoomChanged()) {
+			if (clearBackground || this.containerObject.isZoomChanged()) {
 				// Whole canvas is not cleared after zoom has changed, so clear it per tile as they arrive.
 				this.context.fillStyle = this.containerObject.getClearColor();
 				this.context.fillRect(
@@ -187,7 +187,7 @@ class TilesSection {
 		this.containerObject.setPenPosition(this);
 
 		if (ctx.paneBoundsActive === true)
-			this.paintWithPanes(tile, ctx);
+			this.paintWithPanes(tile, ctx, async);
 		else
 			this.paintSimple(tile, ctx, async);
 	}

--- a/loleaflet/src/layer/vector/CanvasOverlay.ts
+++ b/loleaflet/src/layer/vector/CanvasOverlay.ts
@@ -372,8 +372,7 @@ class CanvasOverlay {
 		if (path.stroke && path.weight !== 0) {
 			this.ctx.globalAlpha = path.opacity;
 
-			this.ctx.lineWidth = this.tsManager._inZoomAnim ?
-				path.weight / this.tsManager._zoomFrameScale : path.weight;
+			this.ctx.lineWidth = path.weight;
 			this.ctx.strokeStyle = path.color;
 			this.ctx.lineCap = path.lineCap;
 			this.ctx.lineJoin = path.lineJoin;

--- a/loleaflet/src/layer/vector/CanvasOverlay.ts
+++ b/loleaflet/src/layer/vector/CanvasOverlay.ts
@@ -177,6 +177,11 @@ class CanvasOverlay {
 	}
 
 	private draw(paintArea?: CBounds) {
+		if (this.overlaySection && this.overlaySection.containerObject.isZoomChanged()) {
+			// don't paint anything till tiles arrive for new zoom.
+			return;
+		}
+
 		var orderedPaths = Array<CPath>();
 		this.paths.forEach((path: CPath) => {
 			orderedPaths.push(path);
@@ -196,6 +201,11 @@ class CanvasOverlay {
 	}
 
 	private redraw(path: CPath, oldBounds: CBounds) {
+		if (this.overlaySection && this.overlaySection.containerObject.isZoomChanged()) {
+			// don't paint anything till tiles arrive for new zoom.
+			return;
+		}
+
 		if (!this.isVisible(path) && (!oldBounds.isValid() || !this.intersectsVisible(oldBounds)))
 			return;
 		// This does not get called via onDraw(ie, tiles aren't painted), so ask tileSection to "erase" by painting over.

--- a/loleaflet/src/map/handler/Map.TouchGesture.js
+++ b/loleaflet/src/map/handler/Map.TouchGesture.js
@@ -536,7 +536,7 @@ L.Map.TouchGesture = L.Handler.extend({
 	},
 
 	_onPinchStart: function (e) {
-		if (isNaN(e.center.x) || isNaN(e.center.y))
+		if (isNaN(e.center.x) || isNaN(e.center.y) || this._inSwipeAction)
 			return;
 
 		this._pinchStartCenter = {x: e.center.x, y: e.center.y};
@@ -663,12 +663,15 @@ L.Map.TouchGesture = L.Handler.extend({
 		this._startSwipePoint = new L.Point(evt.clientX, evt.clientY);
 		this._map.dragging._draggable._onDown(evt);
 		this._timeStamp = Date.now();
+		this._inSwipeAction = true;
 		L.Util.requestAnimFrame(this._autoscroll, this, true);
 	},
 
 	_autoscroll: function() {
 		if (this._cancelAutoScroll === true) {
 			this._cancelAutoScroll = false;
+			this._inSwipeAction = false;
+			L.Util.cancelAnimFrame(this.autoscrollAnimReq);
 			return;
 		}
 
@@ -715,10 +718,13 @@ L.Map.TouchGesture = L.Handler.extend({
 
 			if (!horizontalEnd || !verticalEnd) {
 				this.autoscrollAnimReq = L.Util.requestAnimFrame(this._autoscroll, this, true);
+			} else {
+				this._inSwipeAction = false;
 			}
 		}
 		else {
 			this._map.dragging._draggable._onUp(e);
+			this._inSwipeAction = false;
 		}
 	}
 });

--- a/loleaflet/src/map/handler/Map.TouchGesture.js
+++ b/loleaflet/src/map/handler/Map.TouchGesture.js
@@ -600,8 +600,13 @@ L.Map.TouchGesture = L.Handler.extend({
 
 		if (this._map._docLayer.zoomStepEnd) {
 			var thisObj = this;
-			this._map._docLayer.zoomStepEnd(finalZoom, this._origCenter, function (newMapCenter) {
+			this._map._docLayer.zoomStepEnd(finalZoom, this._origCenter,
+			// mapUpdater
+			function (newMapCenter) {
 				thisObj._map.setView(newMapCenter || thisObj._center, finalZoom);
+			},
+			// showMarkers
+			function () {
 
 				if (thisObj._map._docLayer.isCursorVisible()) {
 					thisObj._map._docLayer._cursorMarker.setOpacity(1);

--- a/loleaflet/src/map/handler/Map.TouchGesture.js
+++ b/loleaflet/src/map/handler/Map.TouchGesture.js
@@ -536,7 +536,12 @@ L.Map.TouchGesture = L.Handler.extend({
 	},
 
 	_onPinchStart: function (e) {
-		if (isNaN(e.center.x) || isNaN(e.center.y) || this._inSwipeAction)
+		if (this._inSwipeAction) {
+			this._cancelAutoscrollRAF();
+			return;
+		}
+
+		if (isNaN(e.center.x) || isNaN(e.center.y))
 			return;
 
 		this._pinchStartCenter = {x: e.center.x, y: e.center.y};
@@ -664,14 +669,19 @@ L.Map.TouchGesture = L.Handler.extend({
 		this._map.dragging._draggable._onDown(evt);
 		this._timeStamp = Date.now();
 		this._inSwipeAction = true;
-		L.Util.requestAnimFrame(this._autoscroll, this, true);
+		this.autoscrollAnimReq = L.Util.requestAnimFrame(this._autoscroll, this, true);
+	},
+
+	_cancelAutoscrollRAF: function () {
+		this._cancelAutoScroll = false;
+		this._inSwipeAction = false;
+		L.Util.cancelAnimFrame(this.autoscrollAnimReq);
+		return;
 	},
 
 	_autoscroll: function() {
 		if (this._cancelAutoScroll === true) {
-			this._cancelAutoScroll = false;
-			this._inSwipeAction = false;
-			L.Util.cancelAnimFrame(this.autoscrollAnimReq);
+			this._cancelAutoscrollRAF();
 			return;
 		}
 


### PR DESCRIPTION
* Target version: co-6-4

### Summary
Client side grids and zoom animation improvements.
1. Prepare calc online grid/tile rendering for transparent tiles (without background and grids). Merged cell border clearing will be done by core. The feature of client side grid rendering is not yet enabled, it needs a core patch before that.
2. Zoom animation improvements: Avoid flicker, avoid swipe-pinch zoom overlap, fixes thicker overlay line width on zoom out.

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

