### PR TITLE
wsd: support configurable PDF rendering resolution

### DIFF
--- a/loolwsd.xml.in
+++ b/loolwsd.xml.in
@@ -19,7 +19,7 @@
         <batch_priority desc="A (lower) priority for use by batch eg. convert-to processes to avoid starving interactive ones" type="uint" default="5">5</batch_priority>
         <document_signing_url desc="The endpoint URL of signing server, if empty the document signing is disabled" type="string" default="@VEREIGN_URL@">@VEREIGN_URL@</document_signing_url>
         <redlining_as_comments desc="If true show red-lines as comments" type="bool" default="false">false</redlining_as_comments>
-        <pdf_resolution_dpi desc="The resolution, in DPI, used to render PDF documents as image. Must be a positive value. Defaults to 96." type="uint" default="96">96</pdf_resolution_dpi>
+        <pdf_resolution_dpi desc="The resolution, in DPI, used to render PDF documents as image. Memory consumption grows proportionally. Must be a positive value less than 385. Defaults to 96." type="uint" default="96">96</pdf_resolution_dpi>
         <idle_timeout_secs desc="The maximum number of seconds before unloading an idle document. Defaults to 1 hour." type="uint" default="3600">3600</idle_timeout_secs>
         <!-- Idle save and auto save are checked every 30 seconds -->
         <!-- They are disabled when the value is zero or negative. -->

--- a/loolwsd.xml.in
+++ b/loolwsd.xml.in
@@ -15,11 +15,11 @@
     <memproportion desc="The maximum percentage of system memory consumed by all of the @APP_NAME@, after which we start cleaning up idle documents" type="double" default="80.0"></memproportion>
     <num_prespawn_children desc="Number of child processes to keep started in advance and waiting for new clients." type="uint" default="1">1</num_prespawn_children>
     <per_document desc="Document-specific settings, including LO Core settings.">
-
         <max_concurrency desc="The maximum number of threads to use while processing a document." type="uint" default="4">4</max_concurrency>
         <batch_priority desc="A (lower) priority for use by batch eg. convert-to processes to avoid starving interactive ones" type="uint" default="5">5</batch_priority>
         <document_signing_url desc="The endpoint URL of signing server, if empty the document signing is disabled" type="string" default="@VEREIGN_URL@">@VEREIGN_URL@</document_signing_url>
         <redlining_as_comments desc="If true show red-lines as comments" type="bool" default="false">false</redlining_as_comments>
+        <pdf_resolution_dpi desc="The resolution, in DPI, used to render PDF documents as image. Must be a positive value. Defaults to 96." type="uint" default="96">96</pdf_resolution_dpi>
         <idle_timeout_secs desc="The maximum number of seconds before unloading an idle document. Defaults to 1 hour." type="uint" default="3600">3600</idle_timeout_secs>
         <!-- Idle save and auto save are checked every 30 seconds -->
         <!-- They are disabled when the value is zero or negative. -->

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -1187,9 +1187,20 @@ void LOOLWSD::innerInitialize(Application& self)
 
 #endif
 
-    const int pdfResolution = getConfigValue<int>(conf, "per_document.pdf_resolution_dpi", 96);
+    int pdfResolution = getConfigValue<int>(conf, "per_document.pdf_resolution_dpi", 96);
     if (pdfResolution > 0)
     {
+        constexpr int MaxPdfResolutionDpi = 384;
+        if (pdfResolution > MaxPdfResolutionDpi)
+        {
+            // Avoid excessive memory consumption.
+            LOG_WRN("The PDF resolution specified in per_document.pdf_resolution_dpi ("
+                    << pdfResolution << ") is larger than the maximum (" << MaxPdfResolutionDpi
+                    << "). Using " << MaxPdfResolutionDpi << " instead.");
+
+            pdfResolution = MaxPdfResolutionDpi;
+        }
+
         const std::string pdfResolutionStr = std::to_string(pdfResolution);
         LOG_DBG("Setting envar PDFIMPORT_RESOLUTION_DPI="
                 << pdfResolutionStr << " per config per_document.pdf_resolution_dpi");

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -950,6 +950,7 @@ void LOOLWSD::innerInitialize(Application& self)
             { "per_document.limit_virt_mem_mb", "0" },
             { "per_document.max_concurrency", "4" },
             { "per_document.batch_priority", "5" },
+            { "per_document.pdf_resolution_dpi", "96"},
             { "per_document.redlining_as_comments", "false" },
             { "per_view.idle_timeout_secs", "900" },
             { "per_view.out_of_focus_timeout_secs", "120" },
@@ -1185,6 +1186,15 @@ void LOOLWSD::innerInitialize(Application& self)
     setenv("LOK_ALLOWLIST_LANGUAGES", allowedLanguages.c_str(), 1);
 
 #endif
+
+    const int pdfResolution = getConfigValue<int>(conf, "per_document.pdf_resolution_dpi", 96);
+    if (pdfResolution > 0)
+    {
+        const std::string pdfResolutionStr = std::to_string(pdfResolution);
+        LOG_DBG("Setting envar PDFIMPORT_RESOLUTION_DPI="
+                << pdfResolutionStr << " per config per_document.pdf_resolution_dpi");
+        ::setenv("PDFIMPORT_RESOLUTION_DPI", pdfResolutionStr.c_str(), 1);
+    }
 
     SysTemplate = getPathFromConfig("sys_template_path");
     if (SysTemplate.empty())


### PR DESCRIPTION
The defined envar is used by Core to override its
default resolution (of 96 dpi), when specified.

Change-Id: Ie7164e78f98990ac88b02dbfe2becbae8c134e9c
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
