### PR TITLE
lok: sc: wrong selection rectangle shown on hit enter

### DIFF
--- a/loleaflet/src/layer/tile/CalcTileLayer.js
+++ b/loleaflet/src/layer/tile/CalcTileLayer.js
@@ -520,6 +520,9 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 			this._docHeightTwips = command.height;
 			this._docType = command.type;
 			this._parts = command.parts;
+			if (this._selectedPart !== command.selectedPart) {
+				this._map._socket.sendMessage('resetselection');
+			}
 			this._selectedPart = command.selectedPart;
 			if (this.sheetGeometry && this._selectedPart != this.sheetGeometry.getPart()) {
 				// Core initiated sheet switch, need to get full sheetGeometry data for the selected sheet.


### PR DESCRIPTION
This patch fix the following Calc issue:
- type '='
- swicth to another Calc tab
- click on a cell in order to enter a cell ref
- press enter

expected result:
 1 - swicth back to the previos Calc tab
 2 - the cell ref has been entered correctly
 3 - cell cursor is placed just below the modified cell
 4 - no selection overlay

actual result:
1, 2, 3 are fine
4 - an odd rectangle overlay is visible inside the modified cell

Signed-off-by: Marco Cecchetti <marco.cecchetti@collabora.com>
Change-Id: I932b604db8c337eb46d50259b6b8ec1c21d179eb
