### PR TITLE
HttpRequest: add missing config.h include

### DIFF
--- a/fuzzer/Admin.cpp
+++ b/fuzzer/Admin.cpp
@@ -1,5 +1,7 @@
 #include <iostream>
 
+#include "config.h"
+
 #include "Admin.hpp"
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)

--- a/fuzzer/ClientSession.cpp
+++ b/fuzzer/ClientSession.cpp
@@ -1,5 +1,7 @@
 #include <iostream>
 
+#include "config.h"
+
 #include "ClientSession.hpp"
 
 bool DoInitialization()


### PR DESCRIPTION
fuzzers build was failing with:

	In file included from fuzzer/Admin.cpp:3:
	In file included from ./wsd/Admin.hpp:12:
	In file included from ./wsd/AdminModel.hpp:20:
	In file included from ./net/WebSocketHandler.hpp:18:
	./net/HttpRequest.hpp:667:31: error: expected ')'
		_header.add("Server", HTTP_SERVER_STRING);
				      ^
	./common/Common.hpp:62:51: note: expanded from macro 'HTTP_SERVER_STRING'
	#define HTTP_SERVER_STRING "LOOLWSD HTTP Server " LOOLWSD_VERSION
							  ^
	./net/HttpRequest.hpp:667:20: note: to match this '('
		_header.add("Server", HTTP_SERVER_STRING);
			   ^

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Ibc3905e3e62e0eb9788b750971916ff4a4937f12
