### PR TITLE
Fix background color in which document page is placed

### DIFF
--- a/loleaflet/src/layer/tile/CanvasSectionContainer.ts
+++ b/loleaflet/src/layer/tile/CanvasSectionContainer.ts
@@ -218,7 +218,7 @@ class CanvasSectionContainer {
 	private multiTouch: boolean = false;
 	private touchCenter: Array<number> = null;
 	private potentialLongPress: boolean = false;
-	private clearColor: string = 'white';
+	private clearColor: string = '#f8f9fa';
 	private touchEventInProgress: boolean = false; // This prevents multiple calling of mouse down and up events.
 	public testing: boolean = false; // If this set to true, container will create a div element for every section. So, cypress tests can find where to click etc.
 	public lowestPropagatedBoundSection: string = null; // Event propagating to bound sections. The first section which stops propagating and the sections those are on top of that section, get the event.


### PR DESCRIPTION
Avoid pure white and instead use another color for canvas background

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I4cc9dffd19932bc631f5b880e53f8d413357d662
