### PR TITLE
Fix UTF-8 decoding and fix handling of non-BMP codepoints for IE11

### DIFF
--- a/loleaflet/js/global.js
+++ b/loleaflet/js/global.js
@@ -281,10 +281,10 @@
 					else if (b <= 0xdf) {
 						code = b & 0x1f;
 						seqLen = 2;
-					} else if (b <= 0xdf) {
+					} else if (b <= 0xef) {
 						code = b & 0x0f;
 						seqLen = 3;
-					} else if (b <= 0xf4) {
+					} else if (b <= 0xf7) {
 						code = b & 0x07;
 						seqLen = 4;
 					}
@@ -296,7 +296,11 @@
 						seqLen = left;
 						code = 0xfffd;
 					}
-					decoded += String.fromCharCode(code);
+					if (code <= 0xFFFF)
+						decoded += String.fromCharCode(code);
+					else
+						decoded += String.fromCharCode(((code - 0x10000) >> 10) + 0xD800,
+									       ((code - 0x10000) % 0x400) + 0xDC00);
 					i += seqLen;
 				}
 				return decoded;


### PR DESCRIPTION
The UTF-8 decoder here was buggy, and additionally it tried to feed
the Unicode codepoints it had constructed directly to
String.fromCharCode() even if that function takes UTF-16 units, not
Unicode codepoints.

The function in question is used only on IE11, apparently, so
presumably the problems had not been noticed.

Change-Id: I78f8ecea6ce6349e4121066774ae5c3fcfa87363
Signed-off-by: Tor Lillqvist <tml@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

