### PR TITLE
Test improvements, cleanups, killpoco, etc.

### DIFF
--- a/common/MessageQueue.hpp
+++ b/common/MessageQueue.hpp
@@ -8,10 +8,8 @@
 #pragma once
 
 #include <algorithm>
-#include <condition_variable>
 #include <functional>
 #include <map>
-#include <mutex>
 #include <string>
 #include <vector>
 

--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -219,10 +219,10 @@ namespace Util
 
         for (unsigned int i = 0; i < width; i++)
         {
-            if ((offset + i) < buffer.size() && ::isprint(buffer[offset+i]))
-                sprintf (scratch, "%c", buffer[offset+i]);
+            if ((offset + i) < buffer.size())
+                sprintf(scratch, "%c", ::isprint(buffer[offset + i]) ? buffer[offset + i] : '.');
             else
-                sprintf (scratch, ".");
+                sprintf(scratch, " "); // Leave blank if we are out of data.
             os << scratch;
         }
 

--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -1194,6 +1194,28 @@ int main(int argc, char**argv)
         return s;
     }
 
+    /// Case insensitive comparison of two strings.
+    /// Returns true iff the two strings are equal, regardless of case.
+    inline bool iequal(const char* lhs, std::size_t lhs_len, const char* rhs, std::size_t rhs_len)
+    {
+        return ((lhs_len == rhs_len)
+                && std::equal(lhs, lhs + lhs_len, rhs, [](const char lch, const char rch) {
+                       return std::tolower(lch) == std::tolower(rch);
+                   }));
+    }
+
+    /// Case insensitive comparison of two strings.
+    template <std::size_t N> inline bool iequal(const std::string& lhs, const char (&rhs)[N])
+    {
+        return iequal(lhs.c_str(), lhs.size(), rhs, N - 1); // Minus null termination.
+    }
+
+    /// Case insensitive comparison of two strings.
+    inline bool iequal(const std::string& lhs, const std::string& rhs)
+    {
+        return iequal(lhs.c_str(), lhs.size(), rhs.c_str(), rhs.size());
+    }
+
     /// Get system_clock now in miliseconds.
     inline int64_t getNowInMS()
     {

--- a/net/NetUtil.cpp
+++ b/net/NetUtil.cpp
@@ -8,6 +8,7 @@
 #include <config.h>
 
 #include "NetUtil.hpp"
+#include <common/Util.hpp>
 
 #include "Socket.hpp"
 #if ENABLE_SSL && !MOBILEAPP
@@ -88,6 +89,43 @@ connect(const std::string& host, const std::string& port, const bool isSSL,
         LOG_ERR("Failed to lookup host [" << host << "]. Skipping.");
 
     return socket;
+}
+
+bool parseUri(std::string uri, std::string& scheme, std::string& host, std::string& port)
+{
+    const auto itScheme = uri.find("://");
+    if (itScheme != uri.npos)
+    {
+        scheme = uri.substr(0, itScheme + 3); // Include the last slash.
+        uri = uri.substr(scheme.size()); // Remove the scheme.
+    }
+    else
+    {
+        // No scheme.
+        scheme.clear();
+    }
+
+    const auto itUrl = uri.find('/');
+    if (itUrl != uri.npos)
+    {
+        // Remove the URL.
+        uri = uri.substr(0, itUrl);
+    }
+
+    const auto itPort = uri.find(':');
+    if (itPort != uri.npos)
+    {
+        host = uri.substr(0, itPort);
+        port = uri.substr(itPort + 1); // Skip the colon.
+    }
+    else
+    {
+        // No port, just hostname.
+        host = uri;
+        port.clear();
+    }
+
+    return !host.empty();
 }
 
 } // namespace net

--- a/net/NetUtil.hpp
+++ b/net/NetUtil.hpp
@@ -23,4 +23,9 @@ namespace net
 std::shared_ptr<StreamSocket>
 connect(const std::string& host, const std::string& port, const bool isSSL,
         const std::shared_ptr<ProtocolHandlerInterface>& protocolHandler);
+
+/// Decomposes a URI into its components.
+/// Returns true if parsing was successful.
+bool parseUri(std::string uri, std::string& scheme, std::string& host, std::string& port);
+
 } // namespace net

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -919,7 +919,7 @@ bool StreamSocket::parseHeader(const char *clientName,
             map->_messageSize += contentLength;
 
         const std::string expect = request.get("Expect", "");
-        bool getExpectContinue =  !expect.empty() && Poco::icompare(expect, "100-continue") == 0;
+        const bool getExpectContinue = Util::iequal(expect, "100-continue");
         if (getExpectContinue && !_sentHTTPContinue)
         {
             LOG_TRC('#' << getFD() << " got Expect: 100-continue, sending Continue");

--- a/net/Ssl.hpp
+++ b/net/Ssl.hpp
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <common/Util.hpp>
+
 #include <atomic>
 #include <cassert>
 #include <memory>
@@ -25,10 +27,9 @@
 class SslContext
 {
 public:
-    static void initialize(const std::string& certFilePath,
-                           const std::string& keyFilePath,
+    static void initialize(const std::string& certFilePath, const std::string& keyFilePath,
                            const std::string& caFilePath,
-                           const std::string& cipherList = "")
+                           const std::string& cipherList = std::string())
     {
         assert (!Instance);
         Instance.reset(new SslContext(certFilePath, keyFilePath, caFilePath, cipherList));
@@ -41,6 +42,7 @@ public:
 
     static SSL* newSsl()
     {
+        assert(SslContext::isInitialized() && "SslContext is not initialized");
         return SSL_new(Instance->_ctx);
     }
 

--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -822,12 +822,12 @@ protected:
         http::Response response([&]() {
             if (response.statusLine().statusCode()
                     == Poco::Net::HTTPResponse::HTTP_SWITCHING_PROTOCOLS
-                && Poco::icompare(response.header().get("Upgrade"), "websocket") == 0)
+                && Util::iequal(response.header().get("Upgrade"), "websocket"))
             {
 #if 0 // SAL_DEBUG ...
                     const std::string wsKey = response.get("Sec-WebSocket-Accept", "");
                     const std::string wsProtocol = response.get("Sec-WebSocket-Protocol", "");
-                    if (Poco::icompare(wsProtocol, "chat") != 0)
+                    if (!Util::iequal(wsProtocol, "chat"))
                         LOG_ERR("Unknown websocket protocol " << wsProtocol);
                     else
 #endif

--- a/test/TileCacheTests.cpp
+++ b/test/TileCacheTests.cpp
@@ -313,7 +313,8 @@ void TileCacheTests::testCancelTiles()
         sendTextFrame(socket, "tilecombine nviewid=0 part=0 width=2560 height=2560 tileposx=0 tileposy=0 tilewidth=38400 tileheight=38400");
         sendTextFrame(socket, "canceltiles");
 
-        const auto res = getResponseString(socket, "tile:", testname, 1000);
+        const auto res
+            = getResponseString(socket, "tile:", testname, std::chrono::milliseconds(1000));
         if (res.empty())
         {
             break;
@@ -354,7 +355,8 @@ void TileCacheTests::testCancelTilesMultiView()
         sendTextFrame(socket2, "tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0,3840,7680,0 tileposy=0,0,0,22520 tilewidth=3840 tileheight=3840", "cancelTilesMultiView-2 ");
 
         sendTextFrame(socket1, "canceltiles");
-        const auto res1 = getResponseString(socket1, "tile:", "cancelTilesMultiView-1 ", 500);
+        const auto res1 = getResponseString(socket1, "tile:", "cancelTilesMultiView-1 ",
+                                            std::chrono::milliseconds(500));
         if (!res1.empty())
         {
             if (j == repeat)
@@ -375,7 +377,8 @@ void TileCacheTests::testCancelTilesMultiView()
         // Though in practice we get the rendering result from socket1's request and ours.
         // This happens because we currently always send back tiles even if they are of old version
         // because we want to be responsive, since we've rendered them anyway.
-        const auto res2 = getResponseString(socket2, "tile:", "cancelTilesMultiView-2 ", 500);
+        const auto res2 = getResponseString(socket2, "tile:", "cancelTilesMultiView-2 ",
+                                            std::chrono::milliseconds(500));
         if (!res2.empty())
         {
             if (j == repeat)
@@ -423,7 +426,8 @@ void TileCacheTests::testDisconnectMultiView()
         }
 
         // Should never get more than 4 tiles on socket2.
-        getResponseString(socket2, "tile:", "disconnectMultiView-2 ", 500);
+        getResponseString(socket2, "tile:", "disconnectMultiView-2 ",
+                          std::chrono::milliseconds(500));
     }
 }
 
@@ -1292,7 +1296,9 @@ void TileCacheTests::testTileWireIDHandling()
     assertResponseString(socket, "invalidatetiles:", testname);
 
     // For the first input wsd will send all invalidated tiles
-    LOK_ASSERT_MESSAGE("Expected at least two tiles.", countMessages(socket, "tile:", testname, 500) > 1);
+    LOK_ASSERT_MESSAGE("Expected at least two tiles.",
+                       countMessages(socket, "tile:", testname, std::chrono::milliseconds(500))
+                           > 1);
 
     // Let WSD know we got these so it wouldn't stop sending us modified tiles automatically.
     sendTextFrame(socket, "tileprocessed tile=0:0:0:3840:3840:0", testname);
@@ -1304,7 +1310,8 @@ void TileCacheTests::testTileWireIDHandling()
     assertResponseString(socket, "invalidatetiles:", testname);
 
     // For the second input wsd will send one tile, since some of them are identical.
-    const int arrivedTiles = countMessages(socket, "tile:", testname, 500);
+    const int arrivedTiles
+        = countMessages(socket, "tile:", testname, std::chrono::milliseconds(500));
     if (arrivedTiles == 1)
         return;
 
@@ -1316,7 +1323,9 @@ void TileCacheTests::testTileWireIDHandling()
     sendChar(socket, 'z', skNone, testname);
     assertResponseString(socket, "invalidatetiles:", testname);
 
-    LOK_ASSERT_MESSAGE("Expected exactly one tile.", countMessages(socket, "tile:", testname, 500) == 1);
+    LOK_ASSERT_MESSAGE("Expected exactly one tile.",
+                       countMessages(socket, "tile:", testname, std::chrono::milliseconds(500))
+                           == 1);
 }
 
 void TileCacheTests::testTileProcessed()
@@ -1443,7 +1452,9 @@ void TileCacheTests::testTileBeingRenderedHandling()
     assertResponseString(socket, "invalidatetiles:", testname);
 
     // For the first input wsd will send all invalidated tiles
-    LOK_ASSERT_MESSAGE("Expected at least two tiles.", countMessages(socket, "tile:", testname, 500) > 1);
+    LOK_ASSERT_MESSAGE("Expected at least two tiles.",
+                       countMessages(socket, "tile:", testname, std::chrono::milliseconds(500))
+                           > 1);
 
     // For the later inputs wsd will send one tile, since other ones are identical
     for(int i = 0; i < 5; ++i)
@@ -1454,7 +1465,8 @@ void TileCacheTests::testTileBeingRenderedHandling()
         sendChar(socket, 'y', skNone, testname);
         assertResponseString(socket, "invalidatetiles:", testname);
 
-        const int arrivedTiles = countMessages(socket, "tile:", testname, 500);
+        const int arrivedTiles
+            = countMessages(socket, "tile:", testname, std::chrono::milliseconds(500));
         if (arrivedTiles != 1)
         {
             // Or, at most 2. The reason is that sometimes we get line antialiasing differences that
@@ -1467,7 +1479,9 @@ void TileCacheTests::testTileBeingRenderedHandling()
             sendChar(socket, 'z', skNone, testname);
             assertResponseString(socket, "invalidatetiles:", testname);
 
-            LOK_ASSERT_MESSAGE("Expected exactly one tile.", countMessages(socket, "tile:", testname, 500) == 1);
+            LOK_ASSERT_MESSAGE(
+                "Expected exactly one tile.",
+                countMessages(socket, "tile:", testname, std::chrono::milliseconds(500)) == 1);
         }
     }
 }
@@ -1497,7 +1511,9 @@ void TileCacheTests::testWireIDFilteringOnWSDSide()
     assertResponseString(socket1, "invalidatetiles:", testname);
 
     // For the first input wsd will send all invalidated tiles
-    LOK_ASSERT_MESSAGE("Expected at least two tiles.", countMessages(socket1, "tile:", testname, 500) > 1);
+    LOK_ASSERT_MESSAGE("Expected at least two tiles.",
+                       countMessages(socket1, "tile:", testname, std::chrono::milliseconds(500))
+                           > 1);
 
     // Let WSD know we got these so it wouldn't stop sending us modified tiles automatically.
     sendTextFrame(socket1, "tileprocessed tile=0:0:0:3840:3840:0", testname);
@@ -1509,7 +1525,8 @@ void TileCacheTests::testWireIDFilteringOnWSDSide()
     assertResponseString(socket1, "invalidatetiles:", testname);
 
     // For the second input wsd will send one tile, since some of them are identical.
-    const int arrivedTiles = countMessages(socket1, "tile:", testname, 500);
+    const int arrivedTiles
+        = countMessages(socket1, "tile:", testname, std::chrono::milliseconds(500));
     if (arrivedTiles == 1)
         return;
 
@@ -1521,17 +1538,20 @@ void TileCacheTests::testWireIDFilteringOnWSDSide()
     sendChar(socket1, 'z', skNone, testname);
     assertResponseString(socket1, "invalidatetiles:", testname);
 
-    LOK_ASSERT_MESSAGE("Expected exactly one tile.", countMessages(socket1, "tile:", testname, 500) == 1);
+    LOK_ASSERT_MESSAGE("Expected exactly one tile.",
+                       countMessages(socket1, "tile:", testname, std::chrono::milliseconds(500))
+                           == 1);
 
     //2. Now request the same tiles by the other client (e.g. scroll to the same view)
 
     sendTextFrame(socket2, "tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0,3840,7680 tileposy=0,0,0 tilewidth=3840 tileheight=3840");
 
     // We expect three tiles sent to the second client
-    LOK_ASSERT_EQUAL(3, countMessages(socket2, "tile:", testname, 500));
+    LOK_ASSERT_EQUAL(3, countMessages(socket2, "tile:", testname, std::chrono::milliseconds(500)));
 
     // wsd should not send tiles messages for the first client
-    std::vector<char> tile = getResponseMessage(socket1, "tile:", testname, 1000);
+    const std::vector<char> tile
+        = getResponseMessage(socket1, "tile:", testname, std::chrono::milliseconds(1000));
     LOK_ASSERT_MESSAGE("Not expected tile message arrived!", tile.empty());
 }
 
@@ -1556,7 +1576,8 @@ void TileCacheTests::testLimitTileVersionsOnFly()
     bool getTileResp = false;
     do
     {
-        std::string tile = getResponseString(socket, "tile:", testname, 1000);
+        const std::string tile
+            = getResponseString(socket, "tile:", testname, std::chrono::milliseconds(1000));
         getTileResp = !tile.empty();
     } while(getTileResp);
 
@@ -1566,7 +1587,8 @@ void TileCacheTests::testLimitTileVersionsOnFly()
     // Handle all tiles sent by wsd
     do
     {
-        std::string tile = getResponseString(socket, "tile:", testname, 1000);
+        const std::string tile
+            = getResponseString(socket, "tile:", testname, std::chrono::milliseconds(1000));
         getTileResp = !tile.empty();
     } while(getTileResp);
 
@@ -1574,7 +1596,8 @@ void TileCacheTests::testLimitTileVersionsOnFly()
     // two versions of the same tile were already sent.
     sendChar(socket, 'x', skNone, testname);
 
-    std::vector<char> tile1 = getResponseMessage(socket, "tile:", testname, 1000);
+    const std::vector<char> tile1
+        = getResponseMessage(socket, "tile:", testname, std::chrono::milliseconds(1000));
     LOK_ASSERT_MESSAGE("Not expected tile message arrived!", tile1.empty());
 
     // When the next tileprocessed message arrive with correct tileID
@@ -1585,7 +1608,8 @@ void TileCacheTests::testLimitTileVersionsOnFly()
     bool gotTile = false;
     do
     {
-        std::vector<char> tile = getResponseMessage(socket, "tile:", testname, 1000);
+        const std::vector<char> tile
+            = getResponseMessage(socket, "tile:", testname, std::chrono::milliseconds(1000));
         gotTile = !tile.empty();
         if(gotTile)
             ++arrivedTiles;

--- a/test/UnitEachView.cpp
+++ b/test/UnitEachView.cpp
@@ -63,7 +63,7 @@ void testEachView(const std::string& doc, const std::string& type, const std::st
                      std::string("buttonup"), docWidth / 2, docHeight / 6);
         helpers::sendTextFrame(socket, text, Poco::format(view, itView));
         // Double of the default.
-        const std::size_t timeoutMs = 20000;
+        constexpr std::chrono::milliseconds timeoutMs{ 20000 };
         response = helpers::getResponseString(socket, protocol, Poco::format(view, itView), timeoutMs);
         LOK_ASSERT_MESSAGE(Poco::format(error, itView, protocol), !response.empty());
 

--- a/test/UnitLoadTorture.cpp
+++ b/test/UnitLoadTorture.cpp
@@ -65,7 +65,8 @@ int UnitLoadTorture::loadTorture(const std::string& testname, const std::string&
                 helpers::sendTextFrame(socket, "load url=" + documentURL, testname);
 
                 // 20s is double of the default.
-                const auto status = helpers::assertResponseString(socket, "status:", testname, 20000);
+                const auto status = helpers::assertResponseString(socket, "status:", testname,
+                                                                  std::chrono::seconds(20));
                 int viewid = -1;
                 LOOLProtocol::getTokenIntegerFromMessage(status, "viewid", viewid);
                 sum_view_ids += viewid;

--- a/test/UnitTyping.cpp
+++ b/test/UnitTyping.cpp
@@ -100,8 +100,8 @@ public:
         LOG_TRC("Waiting for test selection:");
         const char response[] = "textselectioncontent:";
         const int responseLen = sizeof(response) - 1;
-        std::string result = getResponseString(
-            socket, response, testname, 5000 /* 5 secs */);
+        const std::string result
+            = getResponseString(socket, response, testname, std::chrono::seconds(5));
 
         LOG_TRC("length " << result.length() << " vs. " << (responseLen + 4));
         if (strncmp(result.c_str(), response, responseLen) ||
@@ -179,7 +179,7 @@ public:
             }
         }
 
-        int waitMS = 5;
+        constexpr std::chrono::milliseconds waitMS{ 5 };
         std::vector<std::thread> threads;
         std::atomic<bool> started(false);
         std::atomic<int> liveTyping(0);
@@ -200,7 +200,8 @@ public:
                             << " tilewidth=7680 tileheight=7680";
                         sendTextFrame(sock, oss.str(), testname);
 
-                        std::vector<char> tile = getResponseMessage(sock, "tile:", testname, 5 /* ms */);
+                        const std::vector<char> tile = getResponseMessage(
+                            sock, "tile:", testname, std::chrono::milliseconds(5));
 
                         std::this_thread::sleep_for(std::chrono::milliseconds(25));
                     }
@@ -223,7 +224,7 @@ public:
                             sendTextFrame(sock, "ping", testname);
 
                         // suck and dump replies down
-                        std::vector<char> tile = getResponseMessage(sock, "tile:", testname, waitMS /* ms */);
+                        std::vector<char> tile = getResponseMessage(sock, "tile:", testname, waitMS);
                         if (tile.size())
                         {
 // 1544818858022 INCOMING: tile: nviewid=0 part=0 width=256 height=256 tileposx=15360 tileposy=38400 tilewidth=3840 tileheight=3840 oldwid=0 wid=232 ver=913 imgsize=1002
@@ -259,7 +260,8 @@ public:
             sendTextFrame(sockets[i], "gettextselection mimetype=text/plain;charset=utf-8", testname);
 
             LOG_TRC("Waiting for test selection:");
-            std::string result = getResponseString(sockets[i],  "textselectioncontent:", testname, 20000 /* 20 secs */);
+            const std::string result = getResponseString(sockets[i], "textselectioncontent:", testname,
+                                                   std::chrono::seconds(20));
             results[i] = result;
 
             char target = 'a'+i;

--- a/test/WhiteBoxTests.cpp
+++ b/test/WhiteBoxTests.cpp
@@ -58,6 +58,7 @@ class WhiteBoxTests : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST(testUIDefaults);
     CPPUNIT_TEST(testCSSVars);
     CPPUNIT_TEST(testStat);
+    CPPUNIT_TEST(testStringCompare);
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -84,6 +85,7 @@ class WhiteBoxTests : public CPPUNIT_NS::TestFixture
     void testUIDefaults();
     void testCSSVars();
     void testStat();
+    void testStringCompare();
 };
 
 void WhiteBoxTests::testLOOLProtocolFunctions()
@@ -1771,6 +1773,19 @@ void WhiteBoxTests::testStat()
 
     ofs.close();
     FileUtil::removeFile(tmpFile);
+}
+
+void WhiteBoxTests::testStringCompare()
+{
+    LOK_ASSERT(Util::iequal("abcd", "abcd"));
+    LOK_ASSERT(Util::iequal("aBcd", "abCd"));
+    LOK_ASSERT(Util::iequal("", ""));
+
+    LOK_ASSERT(!Util::iequal("abcd", "abc"));
+    LOK_ASSERT(!Util::iequal("abc", "abcd"));
+    LOK_ASSERT(!Util::iequal("abc", "abcd"));
+
+    LOK_ASSERT(!Util::iequal("abc", 3, "abcd", 4));
 }
 
 CPPUNIT_TEST_SUITE_REGISTRATION(WhiteBoxTests);

--- a/test/WhiteBoxTests.cpp
+++ b/test/WhiteBoxTests.cpp
@@ -24,6 +24,7 @@
 #include <common/Authorization.hpp>
 #include <wsd/FileServer.hpp>
 #include <net/Buffer.hpp>
+#include <net/NetUtil.hpp>
 
 #include <chrono>
 #include <fstream>
@@ -59,6 +60,7 @@ class WhiteBoxTests : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST(testCSSVars);
     CPPUNIT_TEST(testStat);
     CPPUNIT_TEST(testStringCompare);
+    CPPUNIT_TEST(testParseUri);
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -86,6 +88,7 @@ class WhiteBoxTests : public CPPUNIT_NS::TestFixture
     void testCSSVars();
     void testStat();
     void testStringCompare();
+    void testParseUri();
 };
 
 void WhiteBoxTests::testLOOLProtocolFunctions()
@@ -1786,6 +1789,51 @@ void WhiteBoxTests::testStringCompare()
     LOK_ASSERT(!Util::iequal("abc", "abcd"));
 
     LOK_ASSERT(!Util::iequal("abc", 3, "abcd", 4));
+}
+
+void WhiteBoxTests::testParseUri()
+{
+    std::string scheme;
+    std::string host;
+    std::string port;
+
+    scheme = "***";
+    host = "***";
+    port = "***";
+    LOK_ASSERT(!net::parseUri(std::string(), scheme, host, port));
+    LOK_ASSERT(scheme.empty());
+    LOK_ASSERT(host.empty());
+    LOK_ASSERT(port.empty());
+
+    LOK_ASSERT(net::parseUri("domain.com", scheme, host, port));
+    LOK_ASSERT(scheme.empty());
+    LOK_ASSERT_EQUAL(std::string("domain.com"), host);
+    LOK_ASSERT(port.empty());
+
+    LOK_ASSERT(net::parseUri("domain.com:88", scheme, host, port));
+    LOK_ASSERT(scheme.empty());
+    LOK_ASSERT_EQUAL(std::string("domain.com"), host);
+    LOK_ASSERT_EQUAL(std::string("88"), port);
+
+    LOK_ASSERT(net::parseUri("http://domain.com", scheme, host, port));
+    LOK_ASSERT_EQUAL(std::string("http://"), scheme);
+    LOK_ASSERT_EQUAL(std::string("domain.com"), host);
+    LOK_ASSERT(port.empty());
+
+    LOK_ASSERT(net::parseUri("https://domain.com:88", scheme, host, port));
+    LOK_ASSERT_EQUAL(std::string("https://"), scheme);
+    LOK_ASSERT_EQUAL(std::string("domain.com"), host);
+    LOK_ASSERT_EQUAL(std::string("88"), port);
+
+    LOK_ASSERT(net::parseUri("http://domain.com/path/to/file", scheme, host, port));
+    LOK_ASSERT_EQUAL(std::string("http://"), scheme);
+    LOK_ASSERT_EQUAL(std::string("domain.com"), host);
+    LOK_ASSERT(port.empty());
+
+    LOK_ASSERT(net::parseUri("https://domain.com:88/path/to/file", scheme, host, port));
+    LOK_ASSERT_EQUAL(std::string("https://"), scheme);
+    LOK_ASSERT_EQUAL(std::string("domain.com"), host);
+    LOK_ASSERT_EQUAL(std::string("88"), port);
 }
 
 CPPUNIT_TEST_SUITE_REGISTRATION(WhiteBoxTests);

--- a/test/helpers.hpp
+++ b/test/helpers.hpp
@@ -467,6 +467,8 @@ connectLOKit(const Poco::URI& uri,
         try
         {
             std::unique_ptr<Poco::Net::HTTPClientSession> session(createSession(uri));
+            TST_LOG("Connection to " << uri.toString() << " is "
+                                     << (session->secure() ? "secure" : "plain"));
             auto ws = std::make_shared<LOOLWebSocket>(*session, request, response);
 
             const char* expected_response = "statusindicator: ready";

--- a/test/lokassert.hpp
+++ b/test/lokassert.hpp
@@ -35,7 +35,7 @@ inline std::ostream& operator<<(std::ostream& os, const std::vector<char>& v)
     {                                                                                              \
         if (!(condition))                                                                          \
         {                                                                                          \
-            TST_LOG_NAME("unittest", "Assertion failure: " << (#condition));                       \
+            TST_LOG_NAME("unittest", "ERROR: Assertion failure: " << (#condition));                \
             LOK_ASSERT_IMPL(condition);                                                            \
             CPPUNIT_ASSERT(condition);                                                             \
         }                                                                                          \
@@ -46,7 +46,7 @@ inline std::ostream& operator<<(std::ostream& os, const std::vector<char>& v)
     {                                                                                              \
         if (!((expected) == (actual)))                                                             \
         {                                                                                          \
-            TST_LOG_NAME("unittest", "Assertion failure: Expected ["                               \
+            TST_LOG_NAME("unittest", "ERROR: Assertion failure: Expected ["                        \
                                          << (expected) << "] but got [" << (actual) << ']');       \
             LOK_ASSERT_IMPL((expected) == (actual));                                               \
             CPPUNIT_ASSERT_EQUAL((expected), (actual));                                            \
@@ -62,9 +62,9 @@ inline std::ostream& operator<<(std::ostream& os, const std::vector<char>& v)
             std::ostringstream oss##__LINE__;                                                      \
             oss##__LINE__ << message;                                                              \
             const auto msg##__LINE__ = oss##__LINE__.str();                                        \
-            TST_LOG_NAME("unittest", "Assertion failure: " << msg##__LINE__ << ". Expected ["      \
-                                                           << (expected) << "] but got ["          \
-                                                           << (actual) << "]: ");                  \
+            TST_LOG_NAME("unittest", "ERROR: Assertion failure: "                                  \
+                                         << msg##__LINE__ << ". Expected [" << (expected)          \
+                                         << "] but got [" << (actual) << "]: ");                   \
             CPPUNIT_ASSERT_EQUAL_MESSAGE(msg##__LINE__, (expected), (actual));                     \
         }                                                                                          \
     } while (false)
@@ -74,8 +74,8 @@ inline std::ostream& operator<<(std::ostream& os, const std::vector<char>& v)
     {                                                                                              \
         if (!(condition))                                                                          \
         {                                                                                          \
-            TST_LOG_NAME("unittest",                                                               \
-                         "Assertion failure: " << (message) << ". Condition: " << (#condition));   \
+            TST_LOG_NAME("unittest", "ERROR: Assertion failure: " << (message) << ". Condition: "  \
+                                                                  << (#condition));                \
             LOK_ASSERT_IMPL(condition);                                                            \
             CPPUNIT_ASSERT_MESSAGE((message), (condition));                                        \
         }                                                                                          \
@@ -84,7 +84,7 @@ inline std::ostream& operator<<(std::ostream& os, const std::vector<char>& v)
 #define LOK_ASSERT_FAIL(message)                                                                   \
     do                                                                                             \
     {                                                                                              \
-        TST_LOG_NAME("unittest", "Forced failure: " << (message));                                 \
+        TST_LOG_NAME("unittest", "ERROR: Forced failure: " << (message));                          \
         LOK_ASSERT_IMPL(!"Forced failure");                                                        \
         CPPUNIT_FAIL((message));                                                                   \
     } while (false)

--- a/test/run_unit.sh.in
+++ b/test/run_unit.sh.in
@@ -92,19 +92,20 @@ if ${trace} \
 	echo "Test $tst passed."
 	echo ":test-result: PASS $tst" >> $test_output
 else
+	echo "Test $tst FAILED."
 	cat $tst_log
 	echo "============================================================="
 	echo "Test failed on unit: $tst re-run with:"
 	echo "   $ gdb --args ${abs_top_builddir}/loolwsd --o:sys_template_path=\"$systemplate_path\" \\"
-	echo "         --o:security.capabilities=\"${capabilities}\" \\"
 	echo "         --o:child_root_path=\"$jails_path\" \\"
+	echo "         --o:security.capabilities=\"${capabilities}\" \\"
 	echo "         --o:storage.filesystem[@allow]=true \\"
-	echo "         --o:storage.ssl.enable=false \\"
-	echo "         --o:logging.level=trace \\"
+	echo "         --o:logging.level=error\\" # logs and gdb don't go well together
 	echo "         --o:ssl.key_file_path=\"${abs_top_builddir}/etc/key.pem\" \\"
 	echo "         --o:ssl.cert_file_path=\"${abs_top_builddir}/etc/cert.pem\" \\"
 	echo "         --o:ssl.ca_file_path=\"${abs_top_builddir}/etc/ca-chain.cert.pem\" \\"
 	echo "         --o:admin_console.username=admin --o:admin_console.password=admin \\"
+	echo "         --o:storage.ssl.enable=false \\"
 	echo "         --unitlib=\"${abs_top_builddir}/test/.libs/$tst.so\""
 	echo ""
 	echo "   $ less $tst_log # for detailed failure log files"

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -121,6 +121,10 @@ int main(int argc, char** argv)
     if (!SslContext::isInitialized())
         LOG_ERR("Failed to initialize SSL. Set the path to the certificates via --cert-path. "
                 "HTTPS tests will be disabled in unit-tests.");
+    else
+        LOG_INF("Initialized SSL.");
+#else
+    LOG_INF("SSL is unsupported in this build.");
 #endif
 
     return runClientTests(true, verbose)? 0: 1;

--- a/tools/WebSocketDump.cpp
+++ b/tools/WebSocketDump.cpp
@@ -143,7 +143,8 @@ private:
 
             const std::string& requestURI = request.getURI();
             StringVector pathTokens(Util::tokenize(requestURI, '/'));
-            if (request.find("Upgrade") != request.end() && Poco::icompare(request["Upgrade"], "websocket") == 0)
+            if (request.find("Upgrade") != request.end()
+                && Util::iequal(request["Upgrade"], "websocket"))
             {
                 auto dumpHandler = std::make_shared<DumpSocketHandler>(_socket, request);
                 socket->setHandler(dumpHandler);

--- a/wsd/Admin.cpp
+++ b/wsd/Admin.cpp
@@ -359,7 +359,7 @@ bool AdminSocketHandler::handleInitialRequest(
     const std::string& requestURI = request.getURI();
     StringVector pathTokens(Util::tokenize(requestURI, '/'));
 
-    if (request.find("Upgrade") != request.end() && Poco::icompare(request["Upgrade"], "websocket") == 0)
+    if (request.find("Upgrade") != request.end() && Util::iequal(request["Upgrade"], "websocket"))
     {
         Admin &admin = Admin::instance();
         auto handler = std::make_shared<AdminSocketHandler>(&admin, socketWeak, request);

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -1499,6 +1499,13 @@ void LOOLWSD::initializeSSL()
                            ssl_key_file_path,
                            ssl_ca_file_path,
                            ssl_cipher_list);
+
+    if (!SslContext::isInitialized())
+        LOG_ERR("Failed to initialize SSL.");
+    else
+        LOG_INF("Initialized SSL.");
+#else
+    LOG_INF("SSL is unavailable in this build.");
 #endif
 }
 

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -1148,11 +1148,11 @@ void LOOLWSD::innerInitialize(Application& self)
 
     {
         std::string proto = getConfigValue<std::string>(conf, "net.proto", "");
-        if (!Poco::icompare(proto, "ipv4"))
+        if (Util::iequal(proto, "ipv4"))
             ClientPortProto = Socket::Type::IPv4;
-        else if (!Poco::icompare(proto, "ipv6"))
+        else if (Util::iequal(proto, "ipv6"))
             ClientPortProto = Socket::Type::IPv6;
-        else if (!Poco::icompare(proto, "all"))
+        else if (Util::iequal(proto, "all"))
             ClientPortProto = Socket::Type::All;
         else
             LOG_WRN("Invalid protocol: " << proto);
@@ -1160,9 +1160,9 @@ void LOOLWSD::innerInitialize(Application& self)
 
     {
         std::string listen = getConfigValue<std::string>(conf, "net.listen", "");
-        if (!Poco::icompare(listen, "any"))
+        if (Util::iequal(listen, "any"))
             ClientListenAddr = ServerSocket::Type::Public;
-        else if (!Poco::icompare(listen, "loopback"))
+        else if (Util::iequal(listen, "loopback"))
             ClientListenAddr = ServerSocket::Type::Local;
         else
             LOG_WRN("Invalid listen address: " << listen << ". Falling back to default: 'any'" );

--- a/wsd/RequestDetails.cpp
+++ b/wsd/RequestDetails.cpp
@@ -81,7 +81,7 @@ RequestDetails::RequestDetails(Poco::Net::HTTPRequest &request, const std::strin
     if (_isProxy)
         _proxyPrefix = it->second;
     it = request.find("Upgrade");
-    _isWebSocket = it != request.end() && (Poco::icompare(it->second, "websocket") == 0);
+    _isWebSocket = it != request.end() && Util::iequal(it->second, "websocket");
 #if MOBILEAPP
     // request.getHost fires an exception on mobile.
 #else

--- a/wsd/SenderQueue.hpp
+++ b/wsd/SenderQueue.hpp
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <condition_variable>
 #include <deque>
 #include <memory>
 #include <mutex>


### PR DESCRIPTION
- wsd: test: make test assertion failures more obvious
- wsd: test: log connection security
- wsd: dump blank in hex dump for out of data
- wsd: case-insensitive string equality utility added
- killpoco: replace Poco::icompare
- wsd: more informative SSL state reporting
- test: make run_unit.sh more helpful on failure
- wsd: include cleanup
- wsd: add utility to parse URIs into primary components
- wsd: test: use chrono for readable and safe time durations
