### PR TITLE
HTTP fixes, improvements, documentation, logging, and tests

### DIFF
--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -308,7 +308,8 @@ public:
         return false;
     }
 
-    std::string get(const std::string& key) const
+    /// Get a header entry value by key, if found, defaulting to @def, if missing.
+    std::string get(const std::string& key, const std::string& def = std::string()) const
     {
         // There are typically half a dozen header
         // entries, rarely much more. A map would
@@ -319,7 +320,7 @@ public:
                 return pair.second;
         }
 
-        return std::string();
+        return def;
     }
 
     /// Set the Content-Type header.
@@ -466,6 +467,12 @@ public:
 
     /// Set an HTTP header field, replacing an earlier value, if exists.
     void set(const std::string& key, std::string value) { _header.set(key, std::move(value)); }
+
+    /// Get a header entry value by key, if found, defaulting to @def, if missing.
+    std::string get(const std::string& key, const std::string& def = std::string()) const
+    {
+        return _header.get(key, def);
+    }
 
     /// Set the request body source to upload some data. Meaningful for POST.
     /// Size is needed to set the Content-Length.

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -671,6 +671,13 @@ public:
         saveBodyToMemory();
     }
 
+    /// A response received from a server.
+    /// Used for parsing an incoming response.
+    Response()
+        : Response(nullptr)
+    {
+    }
+
     /// A response sent from a server.
     /// Used for generating an outgoing response.
     Response(StatusLine statusLine)
@@ -708,6 +715,12 @@ public:
 
     /// Set an HTTP header field, replacing an earlier value, if exists.
     void set(const std::string& key, std::string value) { _header.set(key, std::move(value)); }
+
+    /// Get a header entry value by key, if found, defaulting to @def, if missing.
+    std::string get(const std::string& key, const std::string& def = std::string()) const
+    {
+        return _header.get(key, def);
+    }
 
     /// Redirect the response body, if any, to a file.
     /// If the server responds with a non-success status code (i.e. not 2xx)

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -1149,6 +1149,9 @@ private:
 
     void checkTimeout(std::chrono::steady_clock::time_point now) override
     {
+        if (!_response || _response->done())
+            return;
+
         const auto duration
             = std::chrono::duration_cast<std::chrono::milliseconds>(now - _startTime);
         if (duration > getTimeout())

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -373,7 +373,8 @@ public:
 
     bool writeData(Buffer& out) const
     {
-        // Note: we don't add the end-of-header '\r\n'.
+        // Note: we don't add the end-of-header '\r\n'
+        // to allow for manually extending the headers.
         for (const auto& pair : _headers)
         {
             out.append(pair.first);
@@ -397,6 +398,7 @@ public:
         return os;
     }
 
+    /// Serialize the header to string. For logging only.
     std::string toString() const
     {
         std::ostringstream oss;
@@ -507,7 +509,7 @@ public:
             out.append("\r\n", 2);
 
             _header.writeData(out);
-            out.append("\r\n", 2);
+            out.append("\r\n", 2); // End the header.
 
             _stage = Stage::Body;
         }
@@ -743,7 +745,7 @@ public:
     {
         _statusLine.writeData(out);
         _header.writeData(out);
-        out.append("\r\n", 2);
+        out.append("\r\n", 2); // End of header.
         return true;
     }
 

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -874,6 +874,44 @@ public:
         return create(host, Protocol::HttpSsl, port);
     }
 
+    /// Create a new HTTP Session to the given URI.
+    /// The @uri must include the scheme, e.g. https://domain.com:9980
+    static std::shared_ptr<Session> create(const std::string& uri)
+    {
+        const std::string lowerUri = Util::toLower(uri);
+        if (!Util::startsWith(lowerUri, "http"))
+        {
+            LOG_ERR("Unsupported scheme in URI: " << uri);
+            return nullptr;
+        }
+
+        std::string hostPort;
+        bool secure = false;
+        if (Util::startsWith(uri, "http://"))
+        {
+            hostPort = uri.substr(7);
+        }
+        else if (Util::startsWith(uri, "https://"))
+        {
+            hostPort = uri.substr(8);
+            secure = true;
+        }
+        else
+        {
+            LOG_ERR("Invalid URI: " << uri);
+            return nullptr;
+        }
+
+        int port = 0;
+        const auto tokens = Util::tokenize(hostPort, ':');
+        if (tokens.size() > 1)
+        {
+            port = std::stoi(tokens[1]);
+        }
+
+        return create(tokens[0], secure ? Protocol::HttpSsl : Protocol::HttpUnencrypted, port);
+    }
+
     /// Returns the given protocol's default port.
     static int getDefaultPort(Protocol protocol)
     {

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -742,17 +742,28 @@ public:
     /// Returns the body, assuming it wasn't redirected to file or callback.
     const std::string& getBody() const { return _body; }
 
+    /// Set the body to be sent to the client.
+    /// Also sets Content-Length and Content-Type.
+    void setBody(std::string body, std::string contentType = "text/html charset=UTF-8")
+    {
+        _body = std::move(body);
+        _header.setContentLength(_body.size()); // Always set it, even if 0.
+        if (!_body.empty()) // Type is only meaningful if there is a body.
+            _header.setContentType(std::move(contentType));
+    }
+
     /// Handles incoming data (from the Server) in the Client.
     /// Returns the number of bytes consumed, or -1 for error
     /// and/or to interrupt transmission.
     int64_t readData(const char* p, int64_t len);
 
     /// Serializes the Server Response into the given buffer.
-    bool writeData(Buffer& out)
+    bool writeData(Buffer& out) const
     {
         _statusLine.writeData(out);
         _header.writeData(out);
         out.append("\r\n", 2); // End of header.
+        out.append(_body);
         return true;
     }
 
@@ -785,7 +796,6 @@ private:
         }
     }
 
-private:
     /// The stage we're at in consuming the received data.
     enum class ParserStage
     {

--- a/net/NetUtil.cpp
+++ b/net/NetUtil.cpp
@@ -91,6 +91,23 @@ connect(const std::string& host, const std::string& port, const bool isSSL,
     return socket;
 }
 
+std::shared_ptr<StreamSocket>
+connect(std::string uri, const std::shared_ptr<ProtocolHandlerInterface>& protocolHandler)
+{
+    std::string scheme;
+    std::string host;
+    std::string port;
+    if (!parseUri(std::move(uri), scheme, host, port))
+    {
+        return nullptr;
+    }
+
+    scheme = Util::toLower(std::move(scheme));
+    const bool isSsl = scheme == "https://" || scheme == "wss://";
+
+    return connect(host, port, isSsl, protocolHandler);
+}
+
 bool parseUri(std::string uri, std::string& scheme, std::string& host, std::string& port)
 {
     const auto itScheme = uri.find("://");

--- a/net/NetUtil.hpp
+++ b/net/NetUtil.hpp
@@ -24,6 +24,10 @@ std::shared_ptr<StreamSocket>
 connect(const std::string& host, const std::string& port, const bool isSSL,
         const std::shared_ptr<ProtocolHandlerInterface>& protocolHandler);
 
+/// Connect to an end-point at the given @uri and return StreamSocket.
+std::shared_ptr<StreamSocket>
+connect(std::string uri, const std::shared_ptr<ProtocolHandlerInterface>& protocolHandler);
+
 /// Decomposes a URI into its components.
 /// Returns true if parsing was successful.
 bool parseUri(std::string uri, std::string& scheme, std::string& host, std::string& port);

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -38,6 +38,7 @@
 #include <net/SslSocket.hpp>
 #endif
 #include "WebSocketHandler.hpp"
+#include <net/HttpRequest.hpp>
 
 // Bug in pre C++17 where static constexpr must be defined. Fixed in C++17.
 constexpr std::chrono::microseconds SocketPoll::DefaultPollTimeoutMicroS;
@@ -594,6 +595,12 @@ void StreamSocket::send(Poco::Net::HTTPResponse& response)
     response.write(oss);
 
     send(oss.str());
+}
+
+void StreamSocket::send(const http::Response& response)
+{
+    response.writeData(_outBuffer);
+    flush();
 }
 
 void SocketPoll::dumpState(std::ostream& os)

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -1106,7 +1106,12 @@ public:
     /// Remove the first @count bytes from input buffer
     void eraseFirstInputBytes(const MessageMap &map)
     {
-        size_t count = map._headerSize;
+        eraseFirstInputBytes(map._headerSize);
+    }
+
+    /// Remove the first @count bytes from input buffer
+    void eraseFirstInputBytes(const std::size_t count)
+    {
         size_t toErase = std::min(count, _inBuffer.size());
         if (toErase < count)
             LOG_ERR('#' << getFD() << ": attempted to remove: " << count << " which is > size: " << _inBuffer.size() << " clamped to " << toErase);

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -39,6 +39,10 @@
 
 #define LOG_SOCKET_DATA
 
+namespace http
+{
+class Response;
+}
 namespace Poco
 {
     class MemoryInputStream;
@@ -945,6 +949,10 @@ public:
     /// Sends HTTP response.
     /// Adds Date and User-Agent.
     void send(Poco::Net::HTTPResponse& response);
+
+    /// Send an http::Response and flush.
+    /// Does not add any fields to the header.
+    void send(const http::Response& response);
 
     /// Safely flush any outgoing data.
     inline void flush()

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -37,7 +37,7 @@
 #include "Buffer.hpp"
 #include "SigUtil.hpp"
 
-#define LOG_SOCKET_DATA
+#define LOG_SOCKET_DATA ENABLE_DEBUG
 
 namespace http
 {

--- a/test/HttpRequestTests.cpp
+++ b/test/HttpRequestTests.cpp
@@ -53,7 +53,11 @@ class HttpRequestTests final : public CPPUNIT_NS::TestFixture
     void testTimeout();
     void testOnFinished_Complete();
     void testOnFinished_Timeout();
+
+    static constexpr std::chrono::seconds DefTimeoutSeconds {5};
 };
+
+constexpr std::chrono::seconds HttpRequestTests::DefTimeoutSeconds;
 
 void HttpRequestTests::testInvalidURI()
 {
@@ -63,7 +67,7 @@ void HttpRequestTests::testInvalidURI()
     http::Request httpRequest(URL);
 
     auto httpSession = http::Session::createHttp(Host);
-    httpSession->setTimeout(std::chrono::seconds(1));
+    httpSession->setTimeout(DefTimeoutSeconds);
     LOK_ASSERT(httpSession->syncRequest(httpRequest) == false);
 
     const std::shared_ptr<const http::Response> httpResponse = httpSession->response();
@@ -118,7 +122,7 @@ void HttpRequestTests::testSimpleGet()
         const auto pocoResponse = helpers::pocoGet(secure, Host, port, URL);
 
         std::unique_lock<std::mutex> lock(mutex);
-        cv.wait_for(lock, std::chrono::seconds(1));
+        cv.wait_for(lock, DefTimeoutSeconds);
 
         const std::shared_ptr<const http::Response> httpResponse = httpSession->response();
 
@@ -146,7 +150,7 @@ void HttpRequestTests::testSimpleGetSync()
     http::Request httpRequest(URL);
 
     auto httpSession = http::Session::create(Host);
-    httpSession->setTimeout(std::chrono::seconds(1));
+    httpSession->setTimeout(DefTimeoutSeconds);
     LOK_ASSERT(httpSession->syncRequest(httpRequest));
     LOK_ASSERT(httpSession->syncRequest(httpRequest)); // Second request.
 
@@ -201,7 +205,7 @@ void HttpRequestTests::test500GetStatuses()
     pollThread.startThread();
 
     auto httpSession = http::Session::createHttp(Host);
-    httpSession->setTimeout(std::chrono::seconds(1));
+    httpSession->setTimeout(DefTimeoutSeconds);
 
     std::condition_variable cv;
     std::mutex mutex;
@@ -238,7 +242,7 @@ void HttpRequestTests::test500GetStatuses()
         const std::shared_ptr<const http::Response> httpResponse = httpSession->response();
 
         std::unique_lock<std::mutex> lock(mutex);
-        cv.wait_for(lock, std::chrono::seconds(1), [&]() { return httpResponse->done(); });
+        cv.wait_for(lock, DefTimeoutSeconds, [&]() { return httpResponse->done(); });
 
         LOK_ASSERT_EQUAL(http::Response::State::Complete, httpResponse->state());
         LOK_ASSERT(!httpResponse->statusLine().httpVersion().empty());
@@ -282,7 +286,7 @@ void HttpRequestTests::testSimplePost()
     httpRequest.setBodyFile(path);
 
     auto httpSession = http::Session::createHttp(Host);
-    httpSession->setTimeout(std::chrono::seconds(1));
+    httpSession->setTimeout(DefTimeoutSeconds);
 
     std::condition_variable cv;
     std::mutex mutex;
@@ -296,7 +300,7 @@ void HttpRequestTests::testSimplePost()
     httpSession->asyncRequest(httpRequest, pollThread);
 
     std::unique_lock<std::mutex> lock(mutex);
-    cv.wait_for(lock, std::chrono::seconds(1));
+    cv.wait_for(lock, DefTimeoutSeconds);
 
     const std::shared_ptr<const http::Response> httpResponse = httpSession->response();
     LOK_ASSERT(httpResponse->state() == http::Response::State::Complete);

--- a/test/HttpRequestTests.cpp
+++ b/test/HttpRequestTests.cpp
@@ -138,16 +138,14 @@ void HttpRequestTests::testSimpleGet()
 
 void HttpRequestTests::testSimpleGetSync()
 {
-    const char* Host = "www.example.com";
+    const std::string Host = "http://www.example.com";
     const char* URL = "/";
-    const bool secure = false;
-    const int port = 80;
 
-    const auto pocoResponse = helpers::pocoGet(secure, Host, port, URL);
+    const auto pocoResponse = helpers::pocoGet(Poco::URI(Host + URL));
 
     http::Request httpRequest(URL);
 
-    auto httpSession = http::Session::createHttp(Host);
+    auto httpSession = http::Session::create(Host);
     httpSession->setTimeout(std::chrono::seconds(1));
     LOK_ASSERT(httpSession->syncRequest(httpRequest));
     LOK_ASSERT(httpSession->syncRequest(httpRequest)); // Second request.

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -1247,6 +1247,8 @@ void LOOLWSD::innerInitialize(Application& self)
             LOG_INF("Creating childroot: " + ChildRoot);
     }
 
+#if !MOBILEAPP
+
     // Copy and serialize the config into XML to pass to forkit.
     KitXmlConfig.reset(new Poco::Util::XMLConfiguration);
     for (const auto& pair : DefAppConfig)
@@ -1271,7 +1273,6 @@ void LOOLWSD::innerInitialize(Application& self)
     KitXmlConfig->save(oss);
     setenv("LOOL_CONFIG", oss.str().c_str(), true);
 
-#if !MOBILEAPP
     // Initialize the config subsystem too.
     config::initialize(&config());
 


### PR DESCRIPTION
A number of improvements to support server-side HTTP handling.

- wsd: http: comments and documentation
- wsd: http: get header entry with optional default
- wsd: http: Response writes out the body
- wsd: http: support sending http::Response directly to the socket
- wsd: http: support creating http::Session from URIs
- wsd: http: Response supports header getter and no Finished callback
- wsd: better support for erasing from the socket in-buffer
- wsd: log socket data only in debug builds
- wsd: trace socket data
- wsd: add utility to connect to socket given a uri
- wsd: test: http: name increase test timeout
- wsd: http: don't process timeout if the request is done
- wsd: exclude all of the kit config logic from mobileapp
