### PR TITLE
Calc: Filter with split panes improvement.

### DIFF
--- a/loleaflet/src/layer/tile/CalcTileLayer.js
+++ b/loleaflet/src/layer/tile/CalcTileLayer.js
@@ -756,7 +756,9 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 		this._updateHeadersGridLines(undefined, true /* updateCols */,
 			true /* updateRows */);
 
+		this.dontSendSplitPosToCore = true;
 		this.setSplitPosFromCell();
+		this.dontSendSplitPosToCore = false;
 
 		this._syncTileContainerSize();
 
@@ -1189,8 +1191,10 @@ L.CalcSplitPanesContext = L.SplitPanesContext.extend({
 		var newSplitCell = this._docLayer.sheetGeometry.getCellFromPos(this._splitPos, 'corepixels');
 
 		// Send new state via uno commands if there is any change.
-		this.setSplitCol(newSplitCell.x) && this._docLayer.sendSplitIndex(newSplitCell.x, true /*  isSplitCol */);
-		this.setSplitRow(newSplitCell.y) && this._docLayer.sendSplitIndex(newSplitCell.y, false /* isSplitCol */);
+		if (!this._docLayer.dontSendSplitPosToCore) {
+			this.setSplitCol(newSplitCell.x) && this._docLayer.sendSplitIndex(newSplitCell.x, true /*  isSplitCol */);
+			this.setSplitRow(newSplitCell.y) && this._docLayer.sendSplitIndex(newSplitCell.y, false /* isSplitCol */);
+		}
 	},
 });
 


### PR DESCRIPTION
Signed-off-by: Gökay Şatır <gokay.satir@collabora.com>
Change-Id: I866edb95f55d8b16a6ce3ba4e0cb4bbaa79e182d


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
* Apply filters to columns.
* Add some value under filters.
* From a filter, select "show empty".
* If there is no empty rows, all rows will be hidden.
* In this case, if user has created a split-pane between the hidden rows, when user selects "show non empty" option, panes are mis-positioned.

### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

