### PR TITLE
Better HTTP + Better Tests - Poco

### DIFF
--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -432,11 +432,11 @@ public:
         Finished //< Done.
     };
 
-    Request(const std::string& url = "/", const std::string& verb = VERB_GET,
-            const std::string& version = VERS_1_1)
-        : _url(url)
-        , _verb(verb)
-        , _version(version)
+    explicit Request(std::string url = "/", std::string verb = VERB_GET,
+                     std::string version = VERS_1_1)
+        : _url(std::move(url))
+        , _verb(std::move(verb))
+        , _version(std::move(version))
         , _bodyReaderCb([](const char*, int64_t) { return 0; })
         , _stage(Stage::Header)
     {

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -1074,6 +1074,12 @@ private:
                 LOG_TRC("onFinished calling client");
                 _onFinished(std::static_pointer_cast<Session>(shared_from_this()));
             }
+
+            if (_response->get("Connection", "") == "close")
+            {
+                LOG_TRC("Our peer has sent the 'Connection: close' token. Disconnecting.");
+                onDisconnect();
+            }
         };
 
         _response.reset(new Response(onFinished));
@@ -1147,12 +1153,22 @@ private:
     void onDisconnect() override
     {
         LOG_TRC("onDisconnect");
+
+        // Make sure the socket is disconnected and released.
+        if (_socket)
+        {
+            _socket->shutdown(); // Flag for shutdown for housekeeping in SocketPoll.
+            _socket->closeConnection(); // Immediately disconnect.
+            _socket.reset();
+        }
+
         _connected = false;
         _response->complete();
     }
 
     bool connect()
     {
+        _socket.reset(); // Reset to make sure we are disconnected.
         _socket = net::connect(_host, _port, isSecure(), shared_from_this());
         return _socket != nullptr;
     }
@@ -1176,8 +1192,6 @@ private:
             // Disconnect and trigger the right events and handlers.
             // Note that this is the right way to end a request in HTTP, it's also
             // no good maintaining a poor connection (if that's the issue).
-            _socket->shutdown(); // Flag for shutdown for housekeeping in SocketPoll.
-            _socket->closeConnection(); // Immediately disconnect.
             onDisconnect(); // Trigger manually (why wait for poll to do it?).
             assert(_connected == false);
         }

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -850,7 +850,7 @@ private:
         , _timeout(getDefaultTimeout())
         , _connected(false)
     {
-        assert(!_host.empty() && portNumber > 0
+        assert(!_host.empty() && portNumber > 0 && !_port.empty()
                && "Invalid hostname and portNumber for http::Sesssion");
 #ifdef ENABLE_DEBUG
         std::string scheme;
@@ -1079,7 +1079,7 @@ private:
         _response.reset(new Response(onFinished));
 
         _request = std::move(req);
-        _request.set("Host", host()); // Make sure the host is set.
+        _request.set("Host", host() + ':' + port()); // Make sure the host is set.
         _request.set("Date", Util::getHttpTimeNow());
         _request.set("User-Agent", HTTP_AGENT_STRING);
     }

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -841,6 +841,8 @@ public:
     };
 
 private:
+    /// Construct a Session instance from a hostname, protocol and port.
+    /// @hostname is *not* a URI, it's either an IP or a domain name.
     Session(std::string hostname, Protocol protocolType, int portNumber)
         : _host(std::move(hostname))
         , _port(std::to_string(portNumber))
@@ -848,6 +850,15 @@ private:
         , _timeout(std::chrono::seconds(30))
         , _connected(false)
     {
+        assert(!_host.empty() && portNumber > 0
+               && "Invalid hostname and portNumber for http::Sesssion");
+#ifdef ENABLE_DEBUG
+        std::string scheme;
+        std::string host;
+        std::string port;
+        assert(net::parseUri(_host, scheme, host, port) && scheme.empty() && port.empty()
+               && host == _host && "http::Session expects a hostname and not a URI");
+#endif
     }
 
     /// Returns the given protocol's scheme.
@@ -867,11 +878,7 @@ private:
 public:
     /// Create a new HTTP Session to the given host.
     /// The port defaults to the protocol's default port.
-    static std::shared_ptr<Session> create(std::string host, Protocol protocol, int port = 0)
-    {
-        port = (port > 0 ? port : getDefaultPort(protocol));
-        return std::shared_ptr<Session>(new Session(std::move(host), protocol, port));
-    }
+    static std::shared_ptr<Session> create(std::string host, Protocol protocol, int port = 0);
 
     /// Create a new unencrypted HTTP Session to the given host.
     /// @port <= 0 will default to the http default port.

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -896,40 +896,21 @@ public:
 
     /// Create a new HTTP Session to the given URI.
     /// The @uri must include the scheme, e.g. https://domain.com:9980
-    static std::shared_ptr<Session> create(std::string uri)
+    static std::shared_ptr<Session> create(const std::string& uri)
     {
-        const std::string lowerUri = Util::toLower(std::move(uri));
-        if (!Util::startsWith(lowerUri, "http"))
+        std::string scheme;
+        std::string hostname;
+        std::string portString;
+        if (!net::parseUri(uri, scheme, hostname, portString))
         {
-            LOG_ERR("Unsupported scheme in URI: " << uri);
+            LOG_ERR("Invalid URI [" << uri << "] to http::Session::create.");
             return nullptr;
         }
 
-        std::string hostPort;
-        bool secure = false;
-        if (Util::startsWith(uri, "http://"))
-        {
-            hostPort = uri.substr(7);
-        }
-        else if (Util::startsWith(uri, "https://"))
-        {
-            hostPort = uri.substr(8);
-            secure = true;
-        }
-        else
-        {
-            LOG_ERR("Invalid URI: " << uri);
-            return nullptr;
-        }
-
-        int port = 0;
-        const auto tokens = Util::tokenize(hostPort, ':');
-        if (tokens.size() > 1)
-        {
-            port = std::stoi(tokens[1]);
-        }
-
-        return create(tokens[0], secure ? Protocol::HttpSsl : Protocol::HttpUnencrypted, port);
+        scheme = Util::toLower(std::move(scheme));
+        const bool secure = (scheme == "https://" || scheme == "wss://");
+        return create(hostname, secure ? Protocol::HttpSsl : Protocol::HttpUnencrypted,
+                      std::stoi(portString));
     }
 
     /// Returns the given protocol's default port.

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -960,7 +960,8 @@ public:
     /// Note: when the server returns an error, the response body,
     /// if any, will be stored in memory and can be read via getBody().
     /// I.e. when statusLine().statusCategory() != StatusLine::StatusCodeClass::Successful.
-    bool syncDownload(const Request& req, const std::string& saveToFilePath)
+    const std::shared_ptr<const Response> syncDownload(const Request& req,
+                                                       const std::string& saveToFilePath)
     {
         LOG_TRC("syncDownload: " << req.getVerb() << ' ' << host() << ':' << port() << ' '
                                  << req.getUrl());
@@ -970,19 +971,20 @@ public:
         if (!saveToFilePath.empty())
             _response->saveBodyToFile(saveToFilePath);
 
-        return syncRequestImpl();
+        syncRequestImpl();
+        return _response;
     }
 
     /// Make a synchronous request.
     /// The payload body of the response, if any, can be read via getBody().
-    bool syncRequest(const Request& req)
+    const std::shared_ptr<const Response> syncRequest(const Request& req)
     {
         LOG_TRC("syncRequest: " << req.getVerb() << ' ' << host() << ':' << port() << ' '
                                 << req.getUrl());
 
         newRequest(req);
-
-        return syncRequestImpl();
+        syncRequestImpl();
+        return _response;
     }
 
     bool asyncRequest(const Request& req, SocketPoll& poll)
@@ -1048,7 +1050,7 @@ private:
         // has retired, so we can perform housekeeping.
         Response::FinishedCallback onFinished = [&]() {
             LOG_TRC("onFinished");
-            assert(_response->done());
+            assert(_response && _response->done() && "Must have response and must be done");
             if (_onFinished)
             {
                 LOG_TRC("onFinished calling client");

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -987,6 +987,24 @@ public:
         return _response;
     }
 
+    /// Make a synchronous request with the given timeout.
+    /// After returning the timeout set by setTimeout is restored.
+    const std::shared_ptr<const Response> syncRequest(const Request& req,
+                                                      std::chrono::milliseconds timeout)
+    {
+        LOG_TRC("syncRequest: " << req.getVerb() << ' ' << host() << ':' << port() << ' '
+                                << req.getUrl());
+
+        const auto origTimeout = getTimeout();
+        setTimeout(timeout);
+
+        auto response = syncRequest(req);
+
+        setTimeout(origTimeout);
+
+        return response;
+    }
+
     bool asyncRequest(const Request& req, SocketPoll& poll)
     {
         LOG_TRC("asyncRequest: " << req.getVerb() << ' ' << host() << ':' << port() << ' '
@@ -1180,6 +1198,23 @@ private:
     FinishedCallback _onFinished;
     bool _connected;
 };
+
+/// HTTP Get a URL synchronously.
+inline const std::shared_ptr<const http::Response>
+get(const std::string& url, std::chrono::milliseconds timeout = Session::getDefaultTimeout())
+{
+    auto httpSession = http::Session::create(url);
+    return httpSession->syncRequest(http::Request(net::parseUrl(url)), timeout);
+}
+
+/// HTTP Get synchronously given a url and a path.
+inline const std::shared_ptr<const http::Response> get(std::string url, const std::string& path,
+                                                       std::chrono::milliseconds timeout
+                                                       = Session::getDefaultTimeout())
+{
+    auto httpSession = http::Session::create(std::move(url));
+    return httpSession->syncRequest(http::Request(path), timeout);
+}
 
 } // namespace http
 

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -847,7 +847,7 @@ private:
         : _host(std::move(hostname))
         , _port(std::to_string(portNumber))
         , _protocol(protocolType)
-        , _timeout(std::chrono::seconds(30))
+        , _timeout(getDefaultTimeout())
         , _connected(false)
     {
         assert(!_host.empty() && portNumber > 0
@@ -925,6 +925,12 @@ public:
         }
 
         return 0;
+    }
+
+    /// Returns the default timeout.
+    static constexpr std::chrono::milliseconds getDefaultTimeout()
+    {
+        return std::chrono::seconds(30);
     }
 
     /// Returns the current protocol scheme.

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -841,8 +841,8 @@ public:
     };
 
 private:
-    Session(const std::string& hostname, Protocol protocolType, int portNumber)
-        : _host(hostname)
+    Session(std::string hostname, Protocol protocolType, int portNumber)
+        : _host(std::move(hostname))
         , _port(std::to_string(portNumber))
         , _protocol(protocolType)
         , _timeout(std::chrono::seconds(30))
@@ -867,31 +867,31 @@ private:
 public:
     /// Create a new HTTP Session to the given host.
     /// The port defaults to the protocol's default port.
-    static std::shared_ptr<Session> create(const std::string& host, Protocol protocol, int port = 0)
+    static std::shared_ptr<Session> create(std::string host, Protocol protocol, int port = 0)
     {
         port = (port > 0 ? port : getDefaultPort(protocol));
-        return std::shared_ptr<Session>(new Session(host, protocol, port));
+        return std::shared_ptr<Session>(new Session(std::move(host), protocol, port));
     }
 
     /// Create a new unencrypted HTTP Session to the given host.
     /// @port <= 0 will default to the http default port.
-    static std::shared_ptr<Session> createHttp(const std::string& host, int port = 0)
+    static std::shared_ptr<Session> createHttp(std::string host, int port = 0)
     {
-        return create(host, Protocol::HttpUnencrypted, port);
+        return create(std::move(host), Protocol::HttpUnencrypted, port);
     }
 
     /// Create a new SSL HTTP Session to the given host.
     /// @port <= 0 will default to the https default port.
-    static std::shared_ptr<Session> createHttpSsl(const std::string& host, int port = 0)
+    static std::shared_ptr<Session> createHttpSsl(std::string host, int port = 0)
     {
-        return create(host, Protocol::HttpSsl, port);
+        return create(std::move(host), Protocol::HttpSsl, port);
     }
 
     /// Create a new HTTP Session to the given URI.
     /// The @uri must include the scheme, e.g. https://domain.com:9980
-    static std::shared_ptr<Session> create(const std::string& uri)
+    static std::shared_ptr<Session> create(std::string uri)
     {
-        const std::string lowerUri = Util::toLower(uri);
+        const std::string lowerUri = Util::toLower(std::move(uri));
         if (!Util::startsWith(lowerUri, "http"))
         {
             LOG_ERR("Unsupported scheme in URI: " << uri);

--- a/net/NetUtil.cpp
+++ b/net/NetUtil.cpp
@@ -108,7 +108,8 @@ connect(std::string uri, const std::shared_ptr<ProtocolHandlerInterface>& protoc
     return connect(host, port, isSsl, protocolHandler);
 }
 
-bool parseUri(std::string uri, std::string& scheme, std::string& host, std::string& port)
+bool parseUri(std::string uri, std::string& scheme, std::string& host, std::string& port,
+              std::string& url)
 {
     const auto itScheme = uri.find("://");
     if (itScheme != uri.npos)
@@ -125,8 +126,12 @@ bool parseUri(std::string uri, std::string& scheme, std::string& host, std::stri
     const auto itUrl = uri.find('/');
     if (itUrl != uri.npos)
     {
-        // Remove the URL.
+        url = uri.substr(itUrl); // Including the first foreslash.
         uri = uri.substr(0, itUrl);
+    }
+    else
+    {
+        url.clear();
     }
 
     const auto itPort = uri.find(':');

--- a/net/NetUtil.hpp
+++ b/net/NetUtil.hpp
@@ -30,6 +30,37 @@ connect(std::string uri, const std::shared_ptr<ProtocolHandlerInterface>& protoc
 
 /// Decomposes a URI into its components.
 /// Returns true if parsing was successful.
-bool parseUri(std::string uri, std::string& scheme, std::string& host, std::string& port);
+bool parseUri(std::string uri, std::string& scheme, std::string& host, std::string& port,
+              std::string& url);
+
+/// Decomposes a URI into its components.
+/// Returns true if parsing was successful.
+inline bool parseUri(std::string uri, std::string& scheme, std::string& host, std::string& port)
+{
+    std::string url;
+    return parseUri(std::move(uri), scheme, host, port, url);
+}
+
+/// Return the locator given a URI.
+inline std::string parseUrl(const std::string& uri)
+{
+    auto itScheme = uri.find("://");
+    if (itScheme != uri.npos)
+    {
+        itScheme += 3; // Skip it.
+    }
+    else
+    {
+        itScheme = 0;
+    }
+
+    const auto itUrl = uri.find('/', itScheme);
+    if (itUrl != uri.npos)
+    {
+        return uri.substr(itUrl); // Including the first foreslash.
+    }
+
+    return std::string();
+}
 
 } // namespace net

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -1201,7 +1201,7 @@ protected:
 
 #ifdef LOG_SOCKET_DATA
         if (!_inBuffer.empty())
-            LOG_TRC('#' << getFD() << " inBuffer (" << _outBuffer.size() << " bytes):\n"
+            LOG_TRC('#' << getFD() << " inBuffer (" << _inBuffer.size() << " bytes):\n"
                         << Util::dumpHex(_inBuffer));
 #endif
 

--- a/test/HttpRequestTests.cpp
+++ b/test/HttpRequestTests.cpp
@@ -235,9 +235,8 @@ void HttpRequestTests::testSimpleGetSync()
     for (int i = 0; i < 5; ++i)
     {
         TST_LOG("Request #" << i);
-        LOK_ASSERT(httpSession->syncRequest(httpRequest));
-
-        const std::shared_ptr<const http::Response> httpResponse = httpSession->response();
+        const std::shared_ptr<const http::Response> httpResponse
+            = httpSession->syncRequest(httpRequest);
         LOK_ASSERT(httpResponse->done());
         LOK_ASSERT(httpResponse->state() == http::Response::State::Complete);
 
@@ -445,9 +444,8 @@ void HttpRequestTests::testTimeout()
 
     httpSession->setTimeout(std::chrono::milliseconds(1)); // Very short interval.
 
-    LOK_ASSERT(!httpSession->syncRequest(httpRequest)); // Must fail to complete.
-
-    const std::shared_ptr<const http::Response> httpResponse = httpSession->response();
+    const std::shared_ptr<const http::Response> httpResponse
+        = httpSession->syncRequest(httpRequest);
     LOK_ASSERT(httpResponse->done());
     LOK_ASSERT(httpResponse->state() == http::Response::State::Timeout);
 }
@@ -469,9 +467,8 @@ void HttpRequestTests::testOnFinished_Complete()
         return true;
     });
 
-    LOK_ASSERT(httpSession->syncRequest(httpRequest));
-
-    const std::shared_ptr<const http::Response> httpResponse = httpSession->response();
+    const std::shared_ptr<const http::Response> httpResponse
+        = httpSession->syncRequest(httpRequest);
     LOK_ASSERT(completed);
     LOK_ASSERT(httpResponse->done());
     LOK_ASSERT(httpResponse->state() == http::Response::State::Complete);
@@ -496,9 +493,8 @@ void HttpRequestTests::testOnFinished_Timeout()
         return true;
     });
 
-    LOK_ASSERT(!httpSession->syncRequest(httpRequest));
-
-    const std::shared_ptr<const http::Response> httpResponse = httpSession->response();
+    const std::shared_ptr<const http::Response> httpResponse
+        = httpSession->syncRequest(httpRequest);
     LOK_ASSERT(completed);
     LOK_ASSERT(httpResponse->done());
     LOK_ASSERT(httpResponse->state() == http::Response::State::Timeout);

--- a/test/HttpRequestTests.cpp
+++ b/test/HttpRequestTests.cpp
@@ -148,23 +148,8 @@ constexpr std::chrono::seconds HttpRequestTests::DefTimeoutSeconds;
 
 void HttpRequestTests::testInvalidURI()
 {
-    const char* Host = "";
-    const char* URL = "/";
-
-    http::Request httpRequest(URL);
-
-    auto httpSession = http::Session::createHttp(Host);
-    httpSession->setTimeout(DefTimeoutSeconds);
-    LOK_ASSERT(httpSession->syncRequest(httpRequest) == false);
-
-    const std::shared_ptr<const http::Response> httpResponse = httpSession->response();
-    LOK_ASSERT(httpResponse->done() == false);
-    LOK_ASSERT(httpResponse->state() != http::Response::State::Complete);
-    LOK_ASSERT(httpResponse->statusLine().statusCode() != Poco::Net::HTTPResponse::HTTP_OK);
-    LOK_ASSERT_EQUAL(0U, httpResponse->statusLine().statusCode());
-    LOK_ASSERT(httpResponse->statusLine().statusCategory()
-               == http::StatusLine::StatusCodeClass::Invalid);
-    LOK_ASSERT(httpResponse->getBody().empty());
+    // Cannot create from a blank URI.
+    LOK_ASSERT(http::Session::createHttp(std::string()) == nullptr);
 }
 
 void HttpRequestTests::testSimpleGet()

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -5,7 +5,7 @@ AUTOMAKE_OPTION = serial-tests
 # unittest: tests that run a captive loolwsd as part of themselves.
 check_PROGRAMS = fakesockettest
 
-noinst_PROGRAMS = fakesockettest unittest
+noinst_PROGRAMS = fakesockettest unittest unithttplib
 
 AM_CXXFLAGS = $(CPPUNIT_CFLAGS) -DTDOC=\"$(abs_top_srcdir)/test/data\" \
 	-I${top_srcdir}/common -I${top_srcdir}/net -I${top_srcdir}/wsd -I${top_srcdir}/kit \
@@ -61,10 +61,7 @@ endif
 AM_CPPFLAGS = -pthread -I$(top_srcdir) -DBUILDING_TESTS -DLOK_ABORT_ON_ASSERTION
 
 wsd_sources = \
-            ../common/FileUtil.cpp \
-            ../common/Protocol.cpp \
             ../common/SpookyV2.cpp \
-            ../common/Util.cpp \
             ../common/Authorization.cpp \
             ../kit/Kit.cpp \
             ../kit/TestStubs.cpp \
@@ -81,20 +78,30 @@ test_base_source = \
 	WopiProofTests.cpp \
 	$(wsd_sources)
 
+common_sources = \
+	../common/Protocol.cpp \
+	../common/ConfigUtil.cpp \
+	../common/Log.cpp \
+	../common/MessageQueue.cpp \
+	../common/Session.cpp \
+	../common/SigUtil.cpp \
+	../common/Unit.cpp \
+	../common/FileUtil.cpp \
+	../common/Util.cpp \
+	../common/StringVector.cpp \
+	../net/HttpRequest.cpp \
+	../net/Socket.cpp \
+	../net/NetUtil.cpp \
+	../wsd/Auth.cpp
+
+unithttplib_CPPFLAGS = -I$(top_srcdir) -DBUILDING_TESTS -DSTANDALONE_CPPUNIT -g
+unithttplib_SOURCES = $(common_sources) test.cpp HttpRequestTests.cpp
+unithttplib_LDADD = $(CPPUNIT_LIBS)
+
 unittest_CPPFLAGS = -I$(top_srcdir) -DBUILDING_TESTS -DSTANDALONE_CPPUNIT -g
 unittest_SOURCES = \
     $(test_base_source) \
-    ../common/ConfigUtil.cpp \
-    ../common/Log.cpp \
-    ../common/MessageQueue.cpp \
-    ../common/Session.cpp \
-    ../common/SigUtil.cpp \
-    ../common/Unit.cpp \
-    ../common/StringVector.cpp \
-    ../net/HttpRequest.cpp \
-    ../net/Socket.cpp \
-    ../net/NetUtil.cpp \
-    ../wsd/Auth.cpp \
+	$(common_sources) \
     ../wsd/TestStubs.cpp \
     test.cpp
 
@@ -102,8 +109,10 @@ unittest_LDADD = $(CPPUNIT_LIBS)
 unit_base_la_LIBADD = $(CPPUNIT_LIBS)
 if ENABLE_SSL
 unittest_SOURCES += ../net/Ssl.cpp
+unithttplib_SOURCES += ../net/Ssl.cpp
 else
 unittest_LDADD += -lssl -lcrypto
+unithttplib_LDADD += -lssl -lcrypto
 unit_base_la_LIBADD += -lssl -lcrypto
 endif
 
@@ -112,7 +121,7 @@ fakesockettest_SOURCES = fakesockettest.cpp  ../net/FakeSocket.cpp ../common/Log
 fakesockettest_LDADD = $(CPPUNIT_LIBS)
 
 # old-style unit tests - bootstrapped via UnitClient
-unit_base_la_SOURCES = UnitClient.cpp ${test_base_source} HttpRequestTests.cpp
+unit_base_la_SOURCES = UnitClient.cpp ${test_base_source}
 unit_tiletest_la_SOURCES = UnitClient.cpp TileCacheTests.cpp
 unit_tiletest_la_LIBADD = $(CPPUNIT_LIBS)
 unit_integration_la_SOURCES = UnitClient.cpp integration-http-server.cpp
@@ -241,7 +250,8 @@ TESTS = \
 	unit-wopi-loadencoded.la \
 	unit-wopi-temp.la \
 	unit-wopi-fileurl.la \
-	unit-wopi-httpheaders.la
+	unit-wopi-httpheaders.la \
+	${top_builddir}/test/unithttplib
 # TESTS += unit-admin.test
 # TESTS += unit-storage.test
 
@@ -271,7 +281,6 @@ unit-load-torture.log : group0.log
 
 unit-wopi-saveas.log : group0.log
 unit-password-protected.log : group0.log
-unit-http.log : group0.log
 unit-tiff-load.log : group0.log
 unit-render-shape.log : group0.log
 unit-oauth.log : group0.log

--- a/test/UnitCopyPaste.cpp
+++ b/test/UnitCopyPaste.cpp
@@ -32,6 +32,7 @@ class UnitCopyPaste : public UnitWSD
 {
 public:
     UnitCopyPaste()
+        : UnitWSD("UnitCopyPaste")
     {
     }
 
@@ -58,7 +59,7 @@ public:
     std::shared_ptr<ClipboardData> getClipboard(const std::string &clipURIstr,
                                                 HTTPResponse::HTTPStatus expected)
     {
-        LOG_TST("connect to " << clipURIstr);
+        LOG_TST("getClipboard: connect to " << clipURIstr);
         Poco::URI clipURI(clipURIstr);
 
         HTTPResponse response;
@@ -66,11 +67,11 @@ public:
         std::unique_ptr<HTTPClientSession> session(helpers::createSession(clipURI));
         session->setTimeout(Poco::Timespan(10, 0)); // 10 seconds.
         session->sendRequest(request);
-        LOG_TST("sent request.");
+        LOG_TST("getClipboard: sent request: " << clipURI.getPathAndQuery());
 
         try {
             std::istream& responseStream = session->receiveResponse(response);
-            LOG_TST("HTTP get request returned reason: " << response.getReason());
+            LOG_TST("getClipboard: HTTP get request returned reason: " << response.getReason());
 
             if (response.getStatus() != expected)
             {
@@ -80,7 +81,7 @@ public:
                 return std::shared_ptr<ClipboardData>();
             }
 
-            LOK_ASSERT_EQUAL_MESSAGE("clipboard content-type mismatches expected",
+            LOK_ASSERT_EQUAL_MESSAGE("getClipboard: clipboard content-type mismatches expected",
                                      std::string("application/octet-stream"),
                                      response.getContentType());
 
@@ -88,7 +89,7 @@ public:
             clipboard->read(responseStream);
             clipboard->dumpState(std::cerr);
 
-            LOG_TST("got response");
+            LOG_TST("getClipboard: got response");
             return clipboard;
         } catch (Poco::Exception &e) {
             LOG_TST("Poco exception: " << e.message());

--- a/test/UnitHTTP.cpp
+++ b/test/UnitHTTP.cpp
@@ -27,6 +27,7 @@ class UnitHTTP : public UnitWSD
 {
 public:
     UnitHTTP()
+        : UnitWSD("UnitHTTP")
     {
     }
 
@@ -40,7 +41,7 @@ public:
     void testContinue()
     {
         //FIXME: use logging
-        std::cerr << "testContinue\n";
+        LOG_TST("testContinue");
         for (int i = 0; i < 3; ++i)
         {
             std::unique_ptr<Poco::Net::HTTPClientSession> session(helpers::createSession(Poco::URI(helpers::getTestServerURI())));
@@ -77,7 +78,8 @@ public:
 
             if (sent != responseStr)
             {
-                std::cerr << "Test " << i << " failed - mismatching string '" << responseStr << " vs. '" << sent << "'\n";
+                LOG_TST("Test " << i << " failed - mismatching string '" << responseStr << " vs. '"
+                                << sent << "'");
                 exitTest(TestResult::Failed);
                 return;
             }
@@ -98,7 +100,8 @@ public:
         if (got != (int)str.size() ||
             strncmp(buffer.data(), str.c_str(), got))
         {
-            std::cerr << "testChunks got " << got << " mismatching strings '" << buffer.data() << " vs. expected '" << str << "'\n";
+            LOG_TST("testChunks got " << got << " mismatching strings '" << buffer.data()
+                                      << " vs. expected '" << str << "'");
             exitTest(TestResult::Failed);
             return false;
         }
@@ -108,7 +111,7 @@ public:
 
     void testChunks()
     {
-        std::cerr << "testChunks\n";
+        LOG_TST("testChunks");
 
         std::shared_ptr<Poco::Net::StreamSocket> socket = helpers::createRawSocket();
 
@@ -172,11 +175,12 @@ public:
         static const std::string start =
             "HTTP/1.0 200 OK\r\n"
             "Content-Disposition: attachment; filename=\"test.txt\"\r\n";
-        LOK_ASSERT(Util::startsWith(std::string(buffer), start));
 
         if (strncmp(buffer, start.c_str(), start.size()))
         {
-            std::cerr << "missing pre-amble " << got << " '" << buffer << " vs. expected '" << start << "'\n";
+            LOG_TST("missing pre-amble " << got << " [" << buffer << "] vs. expected [" << start
+                                         << ']');
+            LOK_ASSERT(Util::startsWith(std::string(buffer), start));
             exitTest(TestResult::Failed);
             return;
         }
@@ -187,7 +191,7 @@ public:
         LOK_ASSERT_MESSAGE("Missing separator, got " + std::string(buffer), ptr);
         if (!ptr)
         {
-            std::cerr << "missing separator " << got << " '" << buffer << '\n';
+            LOG_TST("missing separator " << got << " '" << buffer);
             exitTest(TestResult::Failed);
             return;
         }
@@ -205,14 +209,14 @@ public:
             buffer[got] = '\0';
         else
         {
-            std::cerr << "No content returned " << got << '\n';
+            LOG_TST("No content returned " << got);
             exitTest(TestResult::Failed);
             return;
         }
 
         if (strcmp(buffer, "\357\273\277This is some text.\nAnd some more.\n"))
         {
-            std::cerr << "unexpected file content " << got << " '" << buffer << '\n';
+            LOG_TST("unexpected file content " << got << " '" << buffer);
             exitTest(TestResult::Failed);
             return;
         }
@@ -222,7 +226,7 @@ public:
     {
         testChunks();
         testContinue();
-        std::cerr << "All tests passed.\n";
+        LOG_TST("All tests passed.");
         exitTest(TestResult::Ok);
     }
 };

--- a/test/UnitHosting.cpp
+++ b/test/UnitHosting.cpp
@@ -44,9 +44,8 @@ UnitBase::TestResult UnitHosting::testDiscovery()
     http::Request httpRequest("/hosting/discovery");
 
     auto httpSession = http::Session::create(helpers::getTestServerURI());
-    LOK_ASSERT(httpSession->syncRequest(httpRequest));
-
-    const std::shared_ptr<const http::Response> httpResponse = httpSession->response();
+    const std::shared_ptr<const http::Response> httpResponse
+        = httpSession->syncRequest(httpRequest);
 
     LOK_ASSERT(httpResponse->done());
     LOK_ASSERT(httpResponse->state() == http::Response::State::Complete);
@@ -64,9 +63,8 @@ UnitBase::TestResult UnitHosting::testDiscovery()
     http::Request httpRequest2("/hosting/discovery/");
 
     auto httpSession2 = http::Session::create(helpers::getTestServerURI());
-    LOK_ASSERT(httpSession2->syncRequest(httpRequest2));
-
-    const std::shared_ptr<const http::Response> httpResponse2 = httpSession2->response();
+    const std::shared_ptr<const http::Response> httpResponse2
+        = httpSession2->syncRequest(httpRequest2);
 
     LOK_ASSERT(httpResponse2->done());
     LOK_ASSERT(httpResponse2->state() == http::Response::State::Complete);

--- a/test/UnitHosting.cpp
+++ b/test/UnitHosting.cpp
@@ -41,11 +41,8 @@ public:
 
 UnitBase::TestResult UnitHosting::testDiscovery()
 {
-    http::Request httpRequest("/hosting/discovery");
-
-    auto httpSession = http::Session::create(helpers::getTestServerURI());
     const std::shared_ptr<const http::Response> httpResponse
-        = httpSession->syncRequest(httpRequest);
+        = http::get(helpers::getTestServerURI(), "/hosting/discovery");
 
     LOK_ASSERT(httpResponse->done());
     LOK_ASSERT(httpResponse->state() == http::Response::State::Complete);
@@ -60,11 +57,8 @@ UnitBase::TestResult UnitHosting::testDiscovery()
     LOK_ASSERT_EQUAL(std::string("text/xml"), httpResponse->header().getContentType());
 
     // Repeat, with a trailing foreslash in the URL.
-    http::Request httpRequest2("/hosting/discovery/");
-
-    auto httpSession2 = http::Session::create(helpers::getTestServerURI());
     const std::shared_ptr<const http::Response> httpResponse2
-        = httpSession2->syncRequest(httpRequest2);
+        = http::get(helpers::getTestServerURI(), "/hosting/discovery/");
 
     LOK_ASSERT(httpResponse2->done());
     LOK_ASSERT(httpResponse2->state() == http::Response::State::Complete);

--- a/test/WhiteBoxTests.cpp
+++ b/test/WhiteBoxTests.cpp
@@ -1805,10 +1805,25 @@ void WhiteBoxTests::testParseUri()
     LOK_ASSERT(host.empty());
     LOK_ASSERT(port.empty());
 
+    LOK_ASSERT(net::parseUri("localhost", scheme, host, port));
+    LOK_ASSERT(scheme.empty());
+    LOK_ASSERT_EQUAL(std::string("localhost"), host);
+    LOK_ASSERT(port.empty());
+
+    LOK_ASSERT(net::parseUri("127.0.0.1", scheme, host, port));
+    LOK_ASSERT(scheme.empty());
+    LOK_ASSERT_EQUAL(std::string("127.0.0.1"), host);
+    LOK_ASSERT(port.empty());
+
     LOK_ASSERT(net::parseUri("domain.com", scheme, host, port));
     LOK_ASSERT(scheme.empty());
     LOK_ASSERT_EQUAL(std::string("domain.com"), host);
     LOK_ASSERT(port.empty());
+
+    LOK_ASSERT(net::parseUri("127.0.0.1:9999", scheme, host, port));
+    LOK_ASSERT(scheme.empty());
+    LOK_ASSERT_EQUAL(std::string("127.0.0.1"), host);
+    LOK_ASSERT_EQUAL(std::string("9999"), port);
 
     LOK_ASSERT(net::parseUri("domain.com:88", scheme, host, port));
     LOK_ASSERT(scheme.empty());
@@ -1834,6 +1849,11 @@ void WhiteBoxTests::testParseUri()
     LOK_ASSERT_EQUAL(std::string("https://"), scheme);
     LOK_ASSERT_EQUAL(std::string("domain.com"), host);
     LOK_ASSERT_EQUAL(std::string("88"), port);
+
+    LOK_ASSERT(net::parseUri("wss://127.0.0.1:9999/", scheme, host, port));
+    LOK_ASSERT_EQUAL(std::string("wss://"), scheme);
+    LOK_ASSERT_EQUAL(std::string("127.0.0.1"), host);
+    LOK_ASSERT_EQUAL(std::string("9999"), port);
 }
 
 CPPUNIT_TEST_SUITE_REGISTRATION(WhiteBoxTests);

--- a/test/WhiteBoxTests.cpp
+++ b/test/WhiteBoxTests.cpp
@@ -61,6 +61,8 @@ class WhiteBoxTests : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST(testStat);
     CPPUNIT_TEST(testStringCompare);
     CPPUNIT_TEST(testParseUri);
+    CPPUNIT_TEST(testParseUriUrl);
+    CPPUNIT_TEST(testParseUrl);
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -89,6 +91,8 @@ class WhiteBoxTests : public CPPUNIT_NS::TestFixture
     void testStat();
     void testStringCompare();
     void testParseUri();
+    void testParseUriUrl();
+    void testParseUrl();
 };
 
 void WhiteBoxTests::testLOOLProtocolFunctions()
@@ -1793,13 +1797,10 @@ void WhiteBoxTests::testStringCompare()
 
 void WhiteBoxTests::testParseUri()
 {
-    std::string scheme;
-    std::string host;
-    std::string port;
+    std::string scheme = "***";
+    std::string host = "***";
+    std::string port = "***";
 
-    scheme = "***";
-    host = "***";
-    port = "***";
     LOK_ASSERT(!net::parseUri(std::string(), scheme, host, port));
     LOK_ASSERT(scheme.empty());
     LOK_ASSERT(host.empty());
@@ -1854,6 +1855,90 @@ void WhiteBoxTests::testParseUri()
     LOK_ASSERT_EQUAL(std::string("wss://"), scheme);
     LOK_ASSERT_EQUAL(std::string("127.0.0.1"), host);
     LOK_ASSERT_EQUAL(std::string("9999"), port);
+}
+
+void WhiteBoxTests::testParseUriUrl()
+{
+    std::string scheme = "***";
+    std::string host = "***";
+    std::string port = "***";
+    std::string url = "***";
+
+    LOK_ASSERT(!net::parseUri(std::string(), scheme, host, port, url));
+    LOK_ASSERT(scheme.empty());
+    LOK_ASSERT(host.empty());
+    LOK_ASSERT(port.empty());
+    LOK_ASSERT(url.empty());
+
+    LOK_ASSERT(net::parseUri("localhost", scheme, host, port, url));
+    LOK_ASSERT(scheme.empty());
+    LOK_ASSERT_EQUAL(std::string("localhost"), host);
+    LOK_ASSERT(port.empty());
+    LOK_ASSERT(url.empty());
+
+    LOK_ASSERT(net::parseUri("127.0.0.1", scheme, host, port, url));
+    LOK_ASSERT(scheme.empty());
+    LOK_ASSERT_EQUAL(std::string("127.0.0.1"), host);
+    LOK_ASSERT(port.empty());
+    LOK_ASSERT(url.empty());
+
+    LOK_ASSERT(net::parseUri("domain.com", scheme, host, port, url));
+    LOK_ASSERT(scheme.empty());
+    LOK_ASSERT_EQUAL(std::string("domain.com"), host);
+    LOK_ASSERT(port.empty());
+    LOK_ASSERT(url.empty());
+
+    LOK_ASSERT(net::parseUri("127.0.0.1:9999", scheme, host, port, url));
+    LOK_ASSERT(scheme.empty());
+    LOK_ASSERT_EQUAL(std::string("127.0.0.1"), host);
+    LOK_ASSERT_EQUAL(std::string("9999"), port);
+    LOK_ASSERT(url.empty());
+
+    LOK_ASSERT(net::parseUri("domain.com:88", scheme, host, port, url));
+    LOK_ASSERT(scheme.empty());
+    LOK_ASSERT_EQUAL(std::string("domain.com"), host);
+    LOK_ASSERT_EQUAL(std::string("88"), port);
+    LOK_ASSERT(url.empty());
+
+    LOK_ASSERT(net::parseUri("http://domain.com", scheme, host, port, url));
+    LOK_ASSERT_EQUAL(std::string("http://"), scheme);
+    LOK_ASSERT_EQUAL(std::string("domain.com"), host);
+    LOK_ASSERT(port.empty());
+    LOK_ASSERT(url.empty());
+
+    LOK_ASSERT(net::parseUri("https://domain.com:88", scheme, host, port, url));
+    LOK_ASSERT_EQUAL(std::string("https://"), scheme);
+    LOK_ASSERT_EQUAL(std::string("domain.com"), host);
+    LOK_ASSERT_EQUAL(std::string("88"), port);
+
+    LOK_ASSERT(net::parseUri("http://domain.com/path/to/file", scheme, host, port, url));
+    LOK_ASSERT_EQUAL(std::string("http://"), scheme);
+    LOK_ASSERT_EQUAL(std::string("domain.com"), host);
+    LOK_ASSERT(port.empty());
+    LOK_ASSERT_EQUAL(std::string("/path/to/file"), url);
+
+    LOK_ASSERT(net::parseUri("https://domain.com:88/path/to/file", scheme, host, port, url));
+    LOK_ASSERT_EQUAL(std::string("https://"), scheme);
+    LOK_ASSERT_EQUAL(std::string("domain.com"), host);
+    LOK_ASSERT_EQUAL(std::string("88"), port);
+    LOK_ASSERT_EQUAL(std::string("/path/to/file"), url);
+
+    LOK_ASSERT(net::parseUri("wss://127.0.0.1:9999/", scheme, host, port, url));
+    LOK_ASSERT_EQUAL(std::string("wss://"), scheme);
+    LOK_ASSERT_EQUAL(std::string("127.0.0.1"), host);
+    LOK_ASSERT_EQUAL(std::string("9999"), port);
+    LOK_ASSERT_EQUAL(std::string("/"), url);
+}
+
+void WhiteBoxTests::testParseUrl()
+{
+    LOK_ASSERT_EQUAL(std::string(), net::parseUrl(""));
+
+    LOK_ASSERT_EQUAL(std::string(), net::parseUrl("https://sub.domain.com:80"));
+    LOK_ASSERT_EQUAL(std::string("/"), net::parseUrl("https://sub.domain.com:80/"));
+
+    LOK_ASSERT_EQUAL(std::string("/some/path"),
+                     net::parseUrl("https://sub.domain.com:80/some/path"));
 }
 
 CPPUNIT_TEST_SUITE_REGISTRATION(WhiteBoxTests);

--- a/test/lokassert.hpp
+++ b/test/lokassert.hpp
@@ -58,13 +58,13 @@ inline std::ostream& operator<<(std::ostream& os, const std::vector<char>& v)
     {                                                                                              \
         if (!((expected) == (actual)))                                                             \
         {                                                                                          \
-            LOK_ASSERT_IMPL((expected) == (actual));                                               \
             std::ostringstream oss##__LINE__;                                                      \
             oss##__LINE__ << message;                                                              \
             const auto msg##__LINE__ = oss##__LINE__.str();                                        \
             TST_LOG_NAME("unittest", "ERROR: Assertion failure: "                                  \
                                          << msg##__LINE__ << ". Expected [" << (expected)          \
                                          << "] but got [" << (actual) << "]: ");                   \
+            LOK_ASSERT_IMPL((expected) == (actual));                                               \
             CPPUNIT_ASSERT_EQUAL_MESSAGE(msg##__LINE__, (expected), (actual));                     \
         }                                                                                          \
     } while (false)

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -2544,6 +2544,7 @@ private:
                         << "Date: " << Util::getHttpTimeNow() << "\r\n"
                         << "User-Agent: " << WOPI_AGENT_STRING << "\r\n"
                         << "WWW-authenticate: Basic realm=\"online\"\r\n"
+                        << "Connection: close\r\n" // Let the client know we will disconnect.
                         << "\r\n";
                     socket->send(oss.str());
                     socket->shutdown();
@@ -2622,6 +2623,7 @@ private:
                 << "Date: " << Util::getHttpTimeNow() << "\r\n"
                 << "User-Agent: LOOLWSD WOPI Agent\r\n"
                 << "Content-Length: 0\r\n"
+                << "Connection: close\r\n" // Let the client know we will disconnect.
                 << "\r\n";
             socket->send(oss.str());
             socket->shutdown();
@@ -2693,6 +2695,7 @@ private:
             "User-Agent: " WOPI_AGENT_STRING "\r\n"
             "Content-Length: " << responseString.size() << "\r\n"
             "Content-Type: " << mimeType << "\r\n"
+            "Connection: close\r\n" // Let the client know we will disconnect.
             "\r\n";
 
         if (requestDetails.isGet())
@@ -2745,9 +2748,11 @@ private:
             "Content-Length: " << xml.size() << "\r\n"
             "Content-Type: text/xml\r\n"
             "X-Content-Type-Options: nosniff\r\n"
+            "Connection: close\r\n" // Let the client know we will disconnect.
             "\r\n"
             << xml;
 
+        LOG_ERR("Sending back: " << oss.str());
         socket->send(oss.str());
         socket->shutdown();
         LOG_INF("Sent discovery.xml successfully.");
@@ -2769,6 +2774,7 @@ private:
             "Content-Length: " << capabilities.size() << "\r\n"
             "Content-Type: application/json\r\n"
             "X-Content-Type-Options: nosniff\r\n"
+            "Connection: close\r\n" // Let the client know we will disconnect.
             "\r\n"
             << capabilities;
 
@@ -2818,6 +2824,7 @@ private:
                 << "Date: " << Util::getHttpTimeNow() << "\r\n"
                 << "User-Agent: LOOLWSD WOPI Agent\r\n"
                 << "Content-Length: 0\r\n"
+                << "Connection: close\r\n" // Let the client know we will disconnect.
                 << "\r\n"
                 << errMsg;
             socket->send(oss.str());
@@ -2899,6 +2906,7 @@ private:
             "User-Agent: " WOPI_AGENT_STRING "\r\n"
             "Content-Length: " << responseString.size() << "\r\n"
             "Content-Type: " << mimeType << "\r\n"
+            "Connection: close\r\n" // Let the client know we will disconnect.
             "\r\n";
 
         if (request.getMethod() == Poco::Net::HTTPRequest::HTTP_GET)
@@ -3087,6 +3095,7 @@ private:
                     "Date: " << Util::getHttpTimeNow() << "\r\n"
                     "Server: " HTTP_SERVER_STRING "\r\n"
                     "Content-Length: 0\r\n"
+                    "Connection: close\r\n" // Let the client know we will disconnect.
                     "\r\n";
                 socket->send(oss.str());
                 socket->shutdown();
@@ -3182,6 +3191,7 @@ private:
 
                     handler.takeFile();
                     response.setContentLength(0);
+                    response.set("Connection", "close"); // Let the client know we will disconnect.
                     socket->send(response);
                     socket->shutdown();
                     return;
@@ -3267,6 +3277,7 @@ private:
                     << "Date: " << Util::getHttpTimeNow() << "\r\n"
                     << "Server: " HTTP_SERVER_STRING "\r\n"
                     << "Content-Length: 0\r\n"
+                    << "Connection: close\r\n" // Let the client know we will disconnect.
                     << "\r\n";
                 socket->send(oss.str());
                 socket->shutdown();

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -666,9 +666,8 @@ std::unique_ptr<WopiStorage::WOPIFileInfo> WopiStorage::getWOPIFileInfo(const Au
             LOG_END(logger, true);
         }
 
-        const bool success = httpSession->syncRequest(httpRequest);
-
-        std::shared_ptr<const http::Response> httpResponse = httpSession->response();
+        const std::shared_ptr<const http::Response> httpResponse
+            = httpSession->syncRequest(httpRequest);
 
         callDurationMs = std::chrono::duration_cast<std::chrono::milliseconds>(
             std::chrono::steady_clock::now() - startTime);
@@ -676,8 +675,7 @@ std::unique_ptr<WopiStorage::WOPIFileInfo> WopiStorage::getWOPIFileInfo(const Au
         // Note: we don't log the response if obfuscation is enabled, except for failures.
         wopiResponse = httpResponse->getBody();
         const bool failed
-            = !success
-              || (httpResponse->statusLine().statusCode() != Poco::Net::HTTPResponse::HTTP_OK);
+            = (httpResponse->statusLine().statusCode() != Poco::Net::HTTPResponse::HTTP_OK);
 
         Log::StreamLogger logRes = failed ? Log::error() : Log::trace();
         if (logRes.enabled())
@@ -1042,13 +1040,13 @@ std::string WopiStorage::downloadDocument(const Poco::URI& uriObject, const std:
 
     LOG_TRC("Downloading from [" << uriAnonym << "] to [" << getRootFilePath()
                                  << "]: " << httpRequest.header().toString());
-    bool success = httpSession->syncDownload(httpRequest, getRootFilePath());
-    std::shared_ptr<const http::Response> httpResponse = httpSession->response();
+    const std::shared_ptr<const http::Response> httpResponse
+        = httpSession->syncDownload(httpRequest, getRootFilePath());
 
     const std::chrono::milliseconds diff = std::chrono::duration_cast<std::chrono::milliseconds>(
         std::chrono::steady_clock::now() - startTime);
 
-    if (success)
+    if (httpResponse->statusLine().statusCode() == Poco::Net::HTTPResponse::HTTP_OK)
     {
         // Log the response header.
         Log::StreamLogger logger = Log::trace();
@@ -1062,11 +1060,8 @@ std::string WopiStorage::downloadDocument(const Poco::URI& uriObject, const std:
 
             LOG_END(logger, true);
         }
-
-        success = (httpResponse->statusLine().statusCode() == Poco::Net::HTTPResponse::HTTP_OK);
     }
-
-    if (!success)
+    else
     {
         const std::string responseString = httpResponse->getBody();
         LOG_ERR("WOPI::GetFile [" << uriAnonym << "] failed with Status Code: "
@@ -1201,9 +1196,8 @@ WopiStorage::uploadLocalFileToStorage(const Authorization& auth, const std::stri
         httpRequest.setBodyFile(filePath);
 
         // Make the request.
-        httpSession->syncRequest(httpRequest);
-
-        const std::shared_ptr<const http::Response> httpResponse = httpSession->response();
+        const std::shared_ptr<const http::Response> httpResponse
+            = httpSession->syncRequest(httpRequest);
 
         _wopiSaveDuration = std::chrono::duration_cast<std::chrono::milliseconds>(
             std::chrono::steady_clock::now() - startTime);


### PR DESCRIPTION
- wsd: test new unit-httplib test for http tests
- wsd: test: log before asserting
- wsd: test: better loggin in UnitCopyPaste
- wsd: http: use std::move where sensible
- wsd: http: parse the host and validate
- wsd: http: use parseUri
- wsd: test: http: more parseUri tests
- killpoco: use http::Request in UnitHosting
- wsd: http: use std::move
- wsd: http: default Session timeout is now public
- wsd: http: simplify syncRequest to return Response
- wsd: http: improved parseUri and new parseUrl with tests
- wsd: http: new syncRequest with timeout and new helper
- killpoco: use http::Request in HTTPServerTest
- wsd: http: set the port in the Host header entry
- wsd: http: support http Connection: close header
- wsd: log the inBuffer size not the outBuffer
- wsd: set http 'Connection: close' header before disconnecting
- killpoco: use http::Request in UnitHosting