### PR TITLE
test helpers: fix -Werror,-Wreturn-type

### DIFF
--- a/test/helpers.hpp
+++ b/test/helpers.hpp
@@ -208,6 +208,10 @@ pocoGetRetry(const Poco::URI& uri, int retry = 3,
             std::this_thread::sleep_for(delayMs);
         }
     }
+
+    auto response = std::make_shared<Poco::Net::HTTPResponse>();
+    std::string responseString;
+    return std::make_pair(response, responseString);
 }
 
 /// Uses Poco to make an HTTP GET from the given URI components.


### PR DESCRIPTION
./test/helpers.hpp:211:1: error: non-void function does not return a value in all control paths [-Werror,-Wreturn-type]

Perhaps it could go further and even call LOK_ASSERT_FAIL().

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I4f68f6d290bcb0a832ea71153d5f699d5366def9
