### PR TITLE
loleaflet: translate hyperlink toolbar button uno command to id

### DIFF
--- a/loleaflet/src/control/Control.Toolbar.js
+++ b/loleaflet/src/control/Control.Toolbar.js
@@ -705,6 +705,10 @@ function unoCmdToToolbarId(commandname)
 		// selectionType is 'text', so ignore object align state messages.
 		id = '';
 	}
+
+	if (id === 'hyperlinkdialog')
+		id = 'link';
+
 	return id;
 }
 


### PR DESCRIPTION
This fixes hyperlink button enabling issue when dynamically changing UI mode to classic.

Signed-off-by: Gabriel Masei <gabriel.masei@1and1.ro>
Change-Id: Ib4494e71c8cedf0818c946abea75e52e1b5ca7ad


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

