### PR TITLE
Add an iOS setting for the user's name or nickname

### DIFF
--- a/ios/Mobile/AppDelegate.mm
+++ b/ios/Mobile/AppDelegate.mm
@@ -279,6 +279,17 @@ static void updateTemplates(NSData *data, NSURLResponse *response)
         }
     }
 
+    // Also look for managed configuration setting of the user name.
+
+    if (managedConfig != nil) {
+        NSString *userName = managedConfig[@"userName"];
+        if (userName != nil && [userName isKindOfClass:[NSString class]])
+            user_name = [userName UTF8String];
+    }
+
+    if (user_name == nullptr)
+        user_name = [[[NSUserDefaults standardUserDefaults] stringForKey:@"userName"] UTF8String];
+
     fakeSocketSetLoggingCallback([](const std::string& line)
                                  {
                                      LOG_INF_NOFILE(line);

--- a/ios/Mobile/Resources/Settings.bundle/Root.plist.in
+++ b/ios/Mobile/Resources/Settings.bundle/Root.plist.in
@@ -46,6 +46,14 @@
 			<key>Key</key>
 			<string>templateListURL</string>
 		</dict>
+		<dict>
+			<key>Type</key>
+			<string>PSTextFieldSpecifier</string>
+			<key>Title</key>
+			<string>Your name</string>
+			<key>Key</key>
+			<string>userName</string>
+		</dict>
 	</array>
 </dict>
 </plist>

--- a/ios/ios.h
+++ b/ios/ios.h
@@ -7,6 +7,8 @@
 
 #include <LibreOfficeKit/LibreOfficeKit.hxx>
 
+extern const char *user_name;
+
 extern int loolwsd_server_socket_fd;
 
 extern LibreOfficeKit *lo_kit;

--- a/ios/ios.mm
+++ b/ios/ios.mm
@@ -13,6 +13,8 @@ extern "C" {
 #import <native-code.h>
 }
 
+const char *user_name = nullptr;
+
 int loolwsd_server_socket_fd = -1;
 
 LibreOfficeKit *lo_kit;

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -50,6 +50,10 @@
 #include <common/FileUtil.hpp>
 #include <common/JsonUtil.hpp>
 
+#ifdef IOS
+#include <ios.h>
+#endif
+
 using std::size_t;
 
 bool StorageBase::FilesystemEnabled;
@@ -312,7 +316,16 @@ std::unique_ptr<LocalStorage::LocalFileInfo> LocalStorage::getLocalFileInfo()
     setFileInfo(FileInfo({filename, "localhost", lastModified, size}));
 
     // Set automatic userid and username
-    return std::unique_ptr<LocalStorage::LocalFileInfo>(new LocalFileInfo({"localhost" + std::to_string(LastLocalStorageId), "LocalHost#" + std::to_string(LastLocalStorageId++)}));
+    std::string userNameString;
+
+#ifdef IOS
+    if (user_name != nullptr)
+        userNameString = std::string(user_name);
+#endif
+    if (userNameString.size() == 0)
+        userNameString = "LocalHost#" + std::to_string(LastLocalStorageId++);
+
+    return std::unique_ptr<LocalStorage::LocalFileInfo>(new LocalFileInfo({"localhost" + std::to_string(LastLocalStorageId), userNameString}));
 }
 
 std::string LocalStorage::loadStorageFileToLocal(const Authorization& /*auth*/,


### PR DESCRIPTION
Used for comments added to documents by the user.

There is no trivial way on iOS for an app to programmatically find out
the name of the user, and that is good from a privacy point of view.

Fixes https://github.com/CollaboraOnline/online/issues/1843

Change-Id: Ie68fcbacf886ec8f1c74021a71879b38d4180c15
Signed-off-by: Tor Lillqvist <tml@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

