### PR TITLE
fix: tiles not rendered on calls from setZoom()

### DIFF
--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -189,7 +189,7 @@ L.TileSectionManager = L.Class.extend({
 	},
 
 	_onDrawGridSection: function () {
-		if (this.containerObject.isInZoomAnimation() || this.containerObject.isZoomChanged())
+		if (this.containerObject.isInZoomAnimation() || this.sectionProperties.tsManager.waitForTiles())
 			return;
 		// grid-section's onDrawArea is TileSectionManager's _drawGridSectionArea().
 		this.onDrawArea();
@@ -476,6 +476,14 @@ L.TileSectionManager = L.Class.extend({
 		this._newCenter = this._layer._map.project(newCenter).multiplyBy(this._tilesSection.dpiScale); // in core pixels
 	},
 
+	setWaitForTiles: function (wait) {
+		this._waitForTiles = wait;
+	},
+
+	waitForTiles: function () {
+		return this._waitForTiles;
+	},
+
 	zoomStep: function (zoom, newCenter) {
 		if (this._finishingZoom) // finishing steps of animation still going on.
 			return;
@@ -542,6 +550,7 @@ L.TileSectionManager = L.Class.extend({
 				painter._inZoomAnim = false;
 
 				painter._sectionContainer.setZoomChanged(true);
+				painter.setWaitForTiles(true);
 				// Set view and paint the tiles if all available.
 				mapUpdater(newMapCenterLatLng);
 				waitForTiles = true;
@@ -554,6 +563,7 @@ L.TileSectionManager = L.Class.extend({
 					// All done.
 					waitForTiles = false;
 					clearInterval(intervalId);
+					painter.setWaitForTiles(false);
 					painter._sectionContainer.setZoomChanged(false);
 					map.enableTextInput();
 					// Paint everything.

--- a/loleaflet/src/layer/tile/TilesSection.ts
+++ b/loleaflet/src/layer/tile/TilesSection.ts
@@ -180,7 +180,7 @@ class TilesSection {
 	}
 
 	public paint (tile: any, ctx: any, async: boolean = false) {
-		if (this.containerObject.isInZoomAnimation() || this.containerObject.isZoomChanged())
+		if (this.containerObject.isInZoomAnimation() || this.sectionProperties.tsManager.waitForTiles())
 			return;
 
 		if (!ctx)
@@ -247,7 +247,7 @@ class TilesSection {
 		// Calculate all this here intead of doing it per tile.
 		var ctx = this.sectionProperties.tsManager._paintContext();
 
-		if (this.containerObject.isZoomChanged()) {
+		if (this.sectionProperties.tsManager.waitForTiles()) {
 			if (!this.haveAllTilesInView(zoom, part, ctx))
 				return;
 		}

--- a/loleaflet/src/layer/vector/CanvasOverlay.ts
+++ b/loleaflet/src/layer/vector/CanvasOverlay.ts
@@ -177,7 +177,7 @@ class CanvasOverlay {
 	}
 
 	private draw(paintArea?: CBounds) {
-		if (this.overlaySection && this.overlaySection.containerObject.isZoomChanged()) {
+		if (this.tsManager && this.tsManager.waitForTiles()) {
 			// don't paint anything till tiles arrive for new zoom.
 			return;
 		}
@@ -201,7 +201,7 @@ class CanvasOverlay {
 	}
 
 	private redraw(path: CPath, oldBounds: CBounds) {
-		if (this.overlaySection && this.overlaySection.containerObject.isZoomChanged()) {
+		if (this.tsManager && this.tsManager.waitForTiles()) {
 			// don't paint anything till tiles arrive for new zoom.
 			return;
 		}


### PR DESCRIPTION
where we set "zoomChanged". So we should have another state variable
waitForTiles to wait for tiles instead of re-using zoomChanged.

Signed-off-by: Dennis Francis <dennis.francis@collabora.com>
Change-Id: I3bd71fb97694a56be5f49a9e7b7ac7b9c49caa88


* Resolves: # <!-- related github issue -->
* Target version: co-6-4

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

