### PR TITLE
loolwsd: after comment operation update status

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -2666,8 +2666,11 @@ void ChildSession::loKitCallback(const int type, const std::string& payload)
         sendTextFrame("redlinetablemodified: " + payload);
         break;
     case LOK_CALLBACK_COMMENT:
+    {
         sendTextFrame("comment: " + payload);
+        getStatus("", 0);
         break;
+    }
     case LOK_CALLBACK_INVALIDATE_HEADER:
         sendTextFrame("invalidateheader: " + payload);
         break;


### PR DESCRIPTION
Signed-off-by: Pranam Lashkari <lpranam@collabora.com>
Change-Id: I489648bb5ccd7223746fea42050088e078046a1a

* Target version: master 

### Summary
send status after performing any comment operation,
updating status send page dimensions,
which help in canvas layer to resize actual page size
without updating page size comments may go out of view
and will also not be scrollable into view

resolves: #1830


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

