### PR TITLE
leaflet: Removed impress download options from drawing doc

### DIFF
--- a/loleaflet/src/control/Control.Menubar.js
+++ b/loleaflet/src/control/Control.Menubar.js
@@ -774,9 +774,9 @@ L.Control.Menubar = L.Control.extend({
 			]},
 			{name: !window.ThisIsAMobileApp ? _('Download as') : _('Export as'), id:'downloadas', type: 'menu', menu: [
 				{name: _('PDF Document (.pdf)'), id: 'downloadas-pdf', type: 'action'},
-				{name: _('ODF presentation (.odp)'), id: 'downloadas-odp', type: 'action', drawing: false},
-				{name: _('PowerPoint 2003 Presentation (.ppt)'), id: 'downloadas-ppt', type: 'action', drawing: false},
-				{name: _('PowerPoint Presentation (.pptx)'), id: 'downloadas-pptx', type: 'action', drawing: false},
+				{name: _('ODF presentation (.odp)'), id: 'downloadas-odp', type: 'action'},
+				{name: _('PowerPoint 2003 Presentation (.ppt)'), id: 'downloadas-ppt', type: 'action'},
+				{name: _('PowerPoint Presentation (.pptx)'), id: 'downloadas-pptx', type: 'action'},
 				{name: _('ODF Drawing (.odg)'), id: 'downloadas-odg', type: 'action'}
 			]},
 			{name: _UNO('.uno:EditMenu', 'presentation'), id: 'editmenu', type: 'menu', menu: [
@@ -823,9 +823,6 @@ L.Control.Menubar = L.Control.extend({
 			]},
 			{name: !window.ThisIsAMobileApp ? _('Download as') : _('Export as'), id:'downloadas', type: 'menu', menu: [
 				{name: _('PDF Document (.pdf)'), id: 'downloadas-pdf', type: 'action'},
-				{name: _('ODF presentation (.odp)'), id: 'downloadas-odp', type: 'action', drawing: false},
-				{name: _('PowerPoint 2003 Presentation (.ppt)'), id: 'downloadas-ppt', type: 'action', drawing: false},
-				{name: _('PowerPoint Presentation (.pptx)'), id: 'downloadas-pptx', type: 'action', drawing: false},
 				{name: _('ODF Drawing (.odg)'), id: 'downloadas-odg', type: 'action'}
 			]},
 			{name: _UNO('.uno:EditMenu', 'presentation'), id: 'editmenu', type: 'menu', menu: [
@@ -1729,9 +1726,6 @@ L.Control.Menubar = L.Control.extend({
 		if (menuItem.id === 'changesmenu' && this._map['wopi'].HideChangeTrackingControls)
 			return false;
 
-		if (menuItem.drawing === false && this._map.getDocType() === 'drawing')
-			return false;
-
 		// polyfill endsWidth for IE11
 		if (!String.prototype.endsWith) {
 			String.prototype.endsWith = function(search, thisLen) {
@@ -1741,9 +1735,6 @@ L.Control.Menubar = L.Control.extend({
 				return this.substring(thisLen - search.length, thisLen) === search;
 			};
 		}
-
-		if (menuItem.id === 'downloadas-odg' && !this._map['wopi'].BaseFileName.endsWith('.odg'))
-			return false;
 
 		// Keep track of all 'downloadas-' options and register them as
 		// export formats with docLayer which can then be publicly accessed unlike


### PR DESCRIPTION
Signed-off-by: Pranam Lashkari <lpranam@collabora.com>
Change-Id: I282aeaa171081b60633720b4619e0b0f250b501a


* Target version: master 


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

