### PR TITLE
WebSocket and Tests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -10,7 +10,7 @@ endif
 
 else
 
-SUBDIRS = . test loleaflet cypress_test
+SUBDIRS = loleaflet . test cypress_test
 
 export ENABLE_DEBUG
 

--- a/common/FileUtil.cpp
+++ b/common/FileUtil.cpp
@@ -197,6 +197,8 @@ namespace FileUtil
         if (root.empty())
             root = getSysTempDirectoryPath();
 
+        Poco::File(root).createDirectories();
+
         // Don't const to allow for automatic move on return.
         std::string newTmp = root + "/lool-" + Util::rng::getFilename(16);
         if (::mkdir(newTmp.c_str(), S_IRWXU) < 0)

--- a/loleaflet/Makefile.am
+++ b/loleaflet/Makefile.am
@@ -679,8 +679,11 @@ l10n: pot
 clean-local:
 	@rm -rf $(DIST_FOLDER)
 	@rm -rf $(INTERMEDIATE_DIR)
+	@rm -rf node_modules
 	@rm -f $(abs_srcdir)/jsconfig.json
 	@rm -f $(abs_srcdir)/admin/jsconfig.json
+
+CLEANFILES = tscompile.done $(INTERMEDIATE_DIR)/loleaflet-src.js $(DIST_FOLDER)/bundle.css $(DIST_FOLDER)/bundle.js $(INTERMEDIATE_DIR)/loleaflet-src.js
 
 ctags:
 	@$(CTAGS) --language-force=JavaScript $(LOLEAFLET_JS_SRC) $(srcdir)/js/global.js

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -432,9 +432,12 @@ public:
         Finished //< Done.
     };
 
-    explicit Request(std::string url = "/", std::string verb = VERB_GET,
+    /// Create a Request given a @url, http @verb, @header, and http @version.
+    /// All are optional, since they can be overwritten later.
+    explicit Request(std::string url = "/", std::string verb = VERB_GET, Header header = Header(),
                      std::string version = VERS_1_1)
-        : _url(std::move(url))
+        : _header(std::move(header))
+        , _url(std::move(url))
         , _verb(std::move(verb))
         , _version(std::move(version))
         , _bodyReaderCb([](const char*, int64_t) { return 0; })

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -403,10 +403,11 @@ void SocketPoll::wakeupWorld()
 
 #if !MOBILEAPP
 
-void SocketPoll::insertNewWebSocketSync(
-    const Poco::URI &uri,
-    const std::shared_ptr<ProtocolHandlerInterface>& websocketHandler)
+void SocketPoll::insertNewWebSocketSync(const Poco::URI& uri,
+                                        const std::shared_ptr<WebSocketHandler>& websocketHandler)
 {
+    LOG_TRC("Connecting WS to " << uri.getHost());
+
     const bool isSSL = uri.getScheme() != "ws";
 #if !ENABLE_SSL
     if (isSSL)
@@ -416,13 +417,21 @@ void SocketPoll::insertNewWebSocketSync(
     }
 #endif
 
-    std::shared_ptr<StreamSocket> socket
-        = net::connect(uri.getHost(), std::to_string(uri.getPort()), isSSL, websocketHandler);
-    if (socket)
+    http::Request req(uri.getPathAndQuery());
+    req.set("User-Foo", "Adminbits");
+    //FIXME: Why do we need the following here?
+    req.set("Accept-Language", "en");
+    req.set("Cache-Control", "no-cache");
+    req.set("Pragma", "no-cache");
+
+    const std::string port = std::to_string(uri.getPort());
+    if (websocketHandler->wsRequest(req, uri.getHost(), port, isSSL, *this))
     {
-        LOG_DBG("Connected to client websocket " << uri.getHost() << " #" << socket->getFD());
-        clientRequestWebsocketUpgrade(socket, websocketHandler, uri.getPathAndQuery());
-        insertNewSocket(socket);
+        LOG_DBG("Connected WS to " << uri.getHost());
+    }
+    else
+    {
+        LOG_ERR("Failed to connected WS to " << uri.getHost());
     }
 }
 

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -13,6 +13,7 @@
 #include <cstring>
 #include <ctype.h>
 #include <iomanip>
+#include <memory>
 #include <sstream>
 #include <stdio.h>
 #include <string>
@@ -435,45 +436,14 @@ void SocketPoll::insertNewWebSocketSync(const Poco::URI& uri,
     }
 }
 
-// should this be a static method in the WebsocketHandler(?)
-void SocketPoll::clientRequestWebsocketUpgrade(const std::shared_ptr<StreamSocket>& socket,
-                                               const std::shared_ptr<ProtocolHandlerInterface>& websocketHandler,
-                                               const std::string &pathAndQuery, const int shareFD)
-{
-    // cf. WebSocketHandler::upgradeToWebSocket (?)
-    // send Sec-WebSocket-Key: <hmm> ... Sec-WebSocket-Protocol: chat, Sec-WebSocket-Version: 13
-
-    LOG_TRC("Requesting upgrade of websocket at path " << pathAndQuery << " #" << socket->getFD());
-
-    std::ostringstream oss;
-    oss << "GET " << pathAndQuery << " HTTP/1.1\r\n"
-        "Connection:Upgrade\r\n"
-        "User-Foo: Adminbits\r\n"
-        "Sec-WebSocket-Key:fxTaWTEMVhq1PkWsMoLxGw==\r\n"
-        "Upgrade:websocket\r\n"
-        "Accept-Language:en\r\n"
-        "Cache-Control:no-cache\r\n"
-        "Pragma:no-cache\r\n"
-        "Sec-WebSocket-Version:13\r\n"
-        "User-Agent: " WOPI_AGENT_STRING "\r\n"
-        "\r\n";
-    if (shareFD == -1)
-        socket->send(oss.str());
-    else
-    {
-        std::string request = oss.str();
-        socket->sendFD(request.c_str(), request.size(), shareFD);
-    }
-    websocketHandler->onConnect(socket);
-}
-
 void SocketPoll::insertNewUnixSocket(
     const std::string &location,
     const std::string &pathAndQuery,
-    const std::shared_ptr<ProtocolHandlerInterface>& websocketHandler,
+    const std::shared_ptr<WebSocketHandler>& websocketHandler,
     const int shareFD)
 {
-    int fd = socket(AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, 0);
+    LOG_DBG("Connecting to local UDS " << location);
+    const int fd = socket(AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, 0);
 
     struct sockaddr_un addrunix;
     std::memset(&addrunix, 0, sizeof(addrunix));
@@ -481,23 +451,47 @@ void SocketPoll::insertNewUnixSocket(
     addrunix.sun_path[0] = '\0'; // abstract name
     memcpy(&addrunix.sun_path[1], location.c_str(), location.length());
 
-    int res = connect(fd, (const struct sockaddr *)&addrunix, sizeof(addrunix));
+    const int res = connect(fd, (const struct sockaddr*)&addrunix, sizeof(addrunix));
     if (fd < 0 || (res < 0 && errno != EINPROGRESS))
     {
         LOG_ERR("Failed to connect to unix socket at " << location);
         ::close(fd);
+        return;
+    }
+
+    std::shared_ptr<StreamSocket> socket
+        = StreamSocket::create<StreamSocket>(fd, true, websocketHandler);
+    if (!socket)
+    {
+        LOG_ERR("Failed to create socket unix socket at " << location);
+        return;
+    }
+
+    LOG_DBG("Connected to local UDS " << location << " #" << socket->getFD());
+
+    http::Request req(pathAndQuery);
+    req.set("User-Foo", "Adminbits");
+    req.set("Sec-WebSocket-Key", websocketHandler->getWebSocketKey());
+    req.set("Sec-WebSocket-Version", "13");
+    //FIXME: Why do we need the following here?
+    req.set("Accept-Language", "en");
+    req.set("Cache-Control", "no-cache");
+    req.set("Pragma", "no-cache");
+
+    LOG_TRC("Requesting upgrade of websocket at path " << pathAndQuery << " #" << socket->getFD());
+    if (shareFD == -1)
+    {
+        socket->send(req);
     }
     else
     {
-        std::shared_ptr<StreamSocket> socket;
-        socket = StreamSocket::create<StreamSocket>(fd, true, websocketHandler);
-        if (socket)
-        {
-            LOG_DBG("Connected to local UDS " << location << " #" << socket->getFD());
-            clientRequestWebsocketUpgrade(socket, websocketHandler, pathAndQuery, shareFD);
-            insertNewSocket(socket);
-        }
+        Buffer buf;
+        req.writeData(buf);
+        socket->sendFD(buf.getBlock(), buf.getBlockSize(), shareFD);
     }
+
+    std::static_pointer_cast<ProtocolHandlerInterface>(websocketHandler)->onConnect(socket);
+    insertNewSocket(socket);
 }
 
 #else

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -555,7 +555,7 @@ class SocketPoll
 {
 public:
     /// Create a socket poll, called rather infrequently.
-    SocketPoll(const std::string& threadName);
+    explicit SocketPoll(const std::string& threadName);
     virtual ~SocketPoll();
 
     /// Default poll time - useful to increase for debugging.

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -454,6 +454,9 @@ public:
     virtual void dumpState(std::ostream& os) { os << '\n'; }
 };
 
+// Forward declare WebSocketHandler, which is inherited from ProtocolHandlerInterface.
+class WebSocketHandler;
+
 /// A ProtocolHandlerInterface with dummy sending API.
 class SimpleSocketHandler : public ProtocolHandlerInterface
 {
@@ -710,8 +713,8 @@ public:
 #if !MOBILEAPP
     /// Inserts a new remote websocket to be polled.
     /// NOTE: The DNS lookup is synchronous.
-    void insertNewWebSocketSync(const Poco::URI &uri,
-                                const std::shared_ptr<ProtocolHandlerInterface>& websocketHandler);
+    void insertNewWebSocketSync(const Poco::URI& uri,
+                                const std::shared_ptr<WebSocketHandler>& websocketHandler);
 
     void insertNewUnixSocket(
         const std::string &location,

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -661,6 +661,16 @@ public:
     /// -1 for error, and otherwise the number of events signalled.
     int poll(std::chrono::microseconds timeoutMax) { return poll(timeoutMax.count()); }
 
+    /// Poll the sockets for available data to read or buffer to write.
+    /// Returns the return-value of poll(2): 0 on timeout,
+    /// -1 for error, and otherwise the number of events signalled.
+    /// Takes the deadline, instead of a timeout.
+    int poll(std::chrono::steady_clock::time_point deadline)
+    {
+        const auto now = std::chrono::steady_clock::now();
+        return poll(std::chrono::duration_cast<std::chrono::microseconds>(deadline - now));
+    }
+
     /// Write to a wakeup descriptor
     static void wakeup (int fd)
     {

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -719,7 +719,7 @@ public:
     void insertNewUnixSocket(
         const std::string &location,
         const std::string &pathAndQuery,
-        const std::shared_ptr<ProtocolHandlerInterface>& websocketHandler,
+        const std::shared_ptr<WebSocketHandler>& websocketHandler,
         const int shareFD = -1);
 #else
     void insertNewFakeSocket(
@@ -779,12 +779,6 @@ protected:
 private:
     /// Actual poll implementation
     int poll(int64_t timeoutMaxMicroS);
-
-    /// Generate the request to connect & upgrade this socket to a given path
-    /// and sends a file descriptor along request if is != -1.
-    void clientRequestWebsocketUpgrade(const std::shared_ptr<StreamSocket>& socket,
-                                       const std::shared_ptr<ProtocolHandlerInterface>& websocketHandler,
-                                       const std::string &pathAndQuery, const int shareFD = -1);
 
     /// Initialize the poll fds array with the right events
     void setupPollFds(std::chrono::steady_clock::time_point now,

--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -778,7 +778,6 @@ protected:
     /// Implementation of the ProtocolHandlerInterface.
     void dumpState(std::ostream& os) override;
 
-private:
     /// To make the protected 'computeAccept' accessible.
     class PublicComputeAccept final : public Poco::Net::WebSocket
     {
@@ -791,7 +790,6 @@ private:
         static std::string generateKey() { return createKey(); }
     };
 
-protected:
     /// Upgrade the http(s) connection to a websocket.
     template <typename T>
     void upgradeToWebSocket(StreamSocket& socket, const T& req)

--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -793,16 +793,14 @@ protected:
             socket->setSocketBufferSize(0);
 #endif
 
-        std::ostringstream oss;
-        oss << "HTTP/1.1 101 Switching Protocols\r\n"
-            << "Upgrade: websocket\r\n"
-            << "Connection: Upgrade\r\n"
-            << "Sec-WebSocket-Accept: " << PublicComputeAccept::doComputeAccept(wsKey) << "\r\n"
-            << "\r\n";
-
-        const std::string res = oss.str();
-        LOG_TRC('#' << socket->getFD() << ": Sending WS Upgrade response: " << res);
-        socket->send(res);
+        http::Response httpResponse(http::StatusLine(101));
+        httpResponse.set("Upgrade", "websocket");
+        httpResponse.set("Connection", "Upgrade");
+        httpResponse.set("Sec-WebSocket-Accept", PublicComputeAccept::doComputeAccept(wsKey));
+        httpResponse.writeData(socket->getOutBuffer());
+        LOG_TRC('#' << socket->getFD()
+                    << ": Sending WS Upgrade response: " << httpResponse.header().toString());
+        socket->flush();
 #endif
         setWebSocket();
     }

--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -227,6 +227,9 @@ private:
         size_t payloadLen = p[1] & 0x7f;
         size_t headerLen = 2;
 
+        LOG_TRC('#' << socket->getFD() << " >>> : isClient: " << _isClient
+                    << ", isWebSocket: " << socket->isWebSocket());
+
         if (_isClient && !socket->isWebSocket())
         {
             // Handle the upgrade response from the server and validate.

--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -36,6 +36,9 @@ private:
 #endif
 
     std::vector<char> _wsPayload;
+
+    /// The security key. Meaningful only for clients.
+    const std::string _key;
     std::atomic<bool> _shuttingDown;
     bool _isClient;
 
@@ -66,6 +69,7 @@ public:
         _isMasking(isClient && isMasking),
         _inFragmentBlock(false),
 #endif
+        _key(isClient ? PublicComputeAccept::generateKey() : std::string()),
         _shuttingDown(false),
         _isClient(isClient)
     {
@@ -76,7 +80,8 @@ public:
     /// socket: the TCP socket which received the upgrade request
     /// request: the HTTP upgrade request to WebSocket
     template <typename T>
-    WebSocketHandler(const std::shared_ptr<StreamSocket>& socket, const T& request)
+    WebSocketHandler(const std::shared_ptr<StreamSocket>& socket, const T& request,
+                     bool isClient = false)
         : _socket(socket)
 #if !MOBILEAPP
         , _lastPingSentTime(std::chrono::steady_clock::now()
@@ -86,13 +91,16 @@ public:
         , _isMasking(false)
         , _inFragmentBlock(false)
 #endif
+        , _key(isClient ? PublicComputeAccept::generateKey() : std::string())
         , _shuttingDown(false)
-        , _isClient(false)
+        , _isClient(isClient)
     {
         if (!socket)
             throw std::runtime_error("Invalid socket while upgrading to WebSocket.");
 
-        upgradeToWebSocket(*socket, request);
+        // As a server, respond with 101 protocol-upgrade.
+        if (!_isClient)
+            upgradeToWebSocket(*socket, request);
     }
 
     /// Status codes sent to peer on shutdown.
@@ -218,6 +226,12 @@ private:
         const bool hasMask = p[1] & 0x80;
         size_t payloadLen = p[1] & 0x7f;
         size_t headerLen = 2;
+
+        if (_isClient && !socket->isWebSocket())
+        {
+            // Handle the upgrade response from the server and validate.
+            return finishHandshake(socket);
+        }
 
         // normally - 7 bit length.
         if (payloadLen == 126) // 2 byte length
@@ -773,6 +787,8 @@ private:
         {
             return computeAccept(key);
         }
+
+        static std::string generateKey() { return createKey(); }
     };
 
 protected:
@@ -806,6 +822,49 @@ protected:
         socket.send(httpResponse);
 #endif
         setWebSocket();
+    }
+
+    /// Finish Web-Socket upgrade handshake, on the client side.
+    bool finishHandshake(const std::shared_ptr<StreamSocket>& socket)
+    {
+        assert(_isClient && "Handshake is finished by the client.");
+
+        http::Response response;
+        const int64_t read
+            = response.readData(socket->getInBuffer().data(), socket->getInBuffer().size());
+        if (read < 0)
+        {
+            LOG_ERR('#' << socket->getFD()
+                        << " Error while handling Web-Socket upgrade response from the server. "
+                           "Shutting down socket.");
+            socket->shutdown();
+            return false;
+        }
+
+        if (read > 0)
+        {
+            // Remove what we consumed.
+            socket->eraseFirstInputBytes(read);
+
+            if (Util::iequal(response.get("Connection", ""), "Upgrade")
+                && Util::iequal(response.get("Upgrade", ""), "websocket")
+                && response.get("Sec-WebSocket-Accept", "")
+                       == PublicComputeAccept::doComputeAccept(_key))
+            {
+                LOG_TRC('#' << socket->getFD() << " Web-Socket upgrade completed.");
+                socket->setWebSocket();
+                return true;
+            }
+
+            LOG_ERR('#' << socket->getFD()
+                        << " Server returned invalid accept token during handshake. "
+                           "Shutting down socket.");
+            socket->shutdown();
+            return false;
+        }
+
+        assert(read == 0);
+        return false; // Not enough data.
     }
 
 #if !MOBILEAPP

--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -873,9 +873,8 @@ protected:
                     == Poco::Net::HTTPResponse::HTTP_SWITCHING_PROTOCOLS
                 && Util::iequal(response.get("Upgrade"), "websocket")
                 && Util::iequal(response.get("Connection", ""), "Upgrade")
-                // && response.get("Sec-WebSocket-Accept", "") // FIXME: enable validation
-                //        == PublicComputeAccept::doComputeAccept(_key)
-                )
+                && response.get("Sec-WebSocket-Accept", "")
+                       == PublicComputeAccept::doComputeAccept(_key))
             {
                 LOG_TRC('#' << socket->getFD() << " Accepted incoming websocket response");
                 setWebSocket();

--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -76,7 +76,7 @@ public:
     /// socket: the TCP socket which received the upgrade request
     /// request: the HTTP upgrade request to WebSocket
     template <typename T>
-    WebSocketHandler(const std::weak_ptr<StreamSocket>& socket, const T& request)
+    WebSocketHandler(const std::shared_ptr<StreamSocket>& socket, const T& request)
         : _socket(socket)
 #if !MOBILEAPP
         , _lastPingSentTime(std::chrono::steady_clock::now()
@@ -89,7 +89,10 @@ public:
         , _shuttingDown(false)
         , _isClient(false)
     {
-        upgradeToWebSocket(request);
+        if (!socket)
+            throw std::runtime_error("Invalid socket while upgrading to WebSocket.");
+
+        upgradeToWebSocket(*socket, request);
     }
 
     /// Implementation of the ProtocolHandlerInterface.
@@ -771,14 +774,10 @@ private:
 protected:
     /// Upgrade the http(s) connection to a websocket.
     template <typename T>
-    void upgradeToWebSocket(const T& req)
+    void upgradeToWebSocket(StreamSocket& socket, const T& req)
     {
-        std::shared_ptr<StreamSocket> socket = _socket.lock();
-        if (!socket)
-            throw std::runtime_error("Invalid socket while upgrading to WebSocket. Request: " + req.getURI());
-
-        LOG_TRC('#' << socket->getFD() << ": Upgrading to WebSocket.");
-        assert(!socket->isWebSocket());
+        LOG_TRC('#' << socket.getFD() << ": Upgrading to WebSocket.");
+        assert(!socket.isWebSocket());
 
 #if !MOBILEAPP
         // create our websocket goodness ...
@@ -786,21 +785,21 @@ protected:
         const std::string wsKey = req.get("Sec-WebSocket-Key", "");
         const std::string wsProtocol = req.get("Sec-WebSocket-Protocol", "chat");
         // FIXME: other sanity checks ...
-        LOG_INF('#' << socket->getFD() << ": WebSocket version: " << wsVersion <<
-                ", key: [" << wsKey << "], protocol: [" << wsProtocol << "].");
+        LOG_INF('#' << socket.getFD() << ": WebSocket version: " << wsVersion << ", key: [" << wsKey
+                    << "], protocol: [" << wsProtocol << "].");
 
 #if ENABLE_DEBUG
         if (std::getenv("LOOL_ZERO_BUFFER_SIZE"))
-            socket->setSocketBufferSize(0);
+            socket.setSocketBufferSize(0);
 #endif
 
         http::Response httpResponse(http::StatusLine(101));
         httpResponse.set("Upgrade", "websocket");
         httpResponse.set("Connection", "Upgrade");
         httpResponse.set("Sec-WebSocket-Accept", PublicComputeAccept::doComputeAccept(wsKey));
-        LOG_TRC('#' << socket->getFD()
+        LOG_TRC('#' << socket.getFD()
                     << ": Sending WS Upgrade response: " << httpResponse.header().toString());
-        socket->send(httpResponse);
+        socket.send(httpResponse);
 #endif
         setWebSocket();
     }

--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -120,6 +120,11 @@ public:
         RESERVED_TLS_FAILURE    = 1015
     };
 
+#if !MOBILEAPP
+
+    /// Returns the Web-Socket Security Key generated for this instance.
+    const std::string& getWebSocketKey() const { return _key; }
+
     bool wsRequest(http::Request& req, const std::string& host, const std::string& port,
                    bool isSecure, SocketPoll& poll)
     {
@@ -152,6 +157,7 @@ public:
         LOG_ERR("Failed to make WebSocket request.");
         return false;
     }
+#endif
 
 protected:
     /// Implementation of the ProtocolHandlerInterface.
@@ -850,9 +856,6 @@ protected:
     }
 
 #if !MOBILEAPP
-    /// Returns the Web-Socket Security Key generated for this instance.
-    const std::string& getWebSocketKey() const { return _key; }
-
     // Handle incoming upgrade to full socket as client WS.
     void handleClientUpgrade(const std::shared_ptr<StreamSocket>& socket)
     {

--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -33,12 +33,11 @@ private:
     int _pingTimeUs;
     bool _isMasking;
     bool _inFragmentBlock;
+    /// The security key. Meaningful only for clients.
+    const std::string _key;
 #endif
 
     std::vector<char> _wsPayload;
-
-    /// The security key. Meaningful only for clients.
-    const std::string _key;
     std::atomic<bool> _shuttingDown;
     bool _isClient;
 
@@ -68,8 +67,8 @@ public:
         _pingTimeUs(0),
         _isMasking(isClient && isMasking),
         _inFragmentBlock(false),
-#endif
         _key(isClient ? PublicComputeAccept::generateKey() : std::string()),
+#endif
         _shuttingDown(false),
         _isClient(isClient)
     {
@@ -90,8 +89,8 @@ public:
         , _pingTimeUs(0)
         , _isMasking(false)
         , _inFragmentBlock(false)
-#endif
         , _key(isClient ? PublicComputeAccept::generateKey() : std::string())
+#endif
         , _shuttingDown(false)
         , _isClient(isClient)
     {
@@ -226,15 +225,6 @@ private:
         const bool hasMask = p[1] & 0x80;
         size_t payloadLen = p[1] & 0x7f;
         size_t headerLen = 2;
-
-        LOG_TRC('#' << socket->getFD() << " >>> : isClient: " << _isClient
-                    << ", isWebSocket: " << socket->isWebSocket());
-
-        if (_isClient && !socket->isWebSocket())
-        {
-            // Handle the upgrade response from the server and validate.
-            return finishHandshake(socket);
-        }
 
         // normally - 7 bit length.
         if (payloadLen == 126) // 2 byte length
@@ -799,6 +789,7 @@ protected:
     {
         LOG_TRC('#' << socket.getFD() << ": Upgrading to WebSocket.");
         assert(!socket.isWebSocket());
+        assert(!_isClient && "Accepting upgrade requests are done by servers only.");
 
 #if !MOBILEAPP
         // create our websocket goodness ...
@@ -825,54 +816,15 @@ protected:
         setWebSocket();
     }
 
-    /// Finish Web-Socket upgrade handshake, on the client side.
-    bool finishHandshake(const std::shared_ptr<StreamSocket>& socket)
-    {
-        assert(_isClient && "Handshake is finished by the client.");
-
-        http::Response response;
-        const int64_t read
-            = response.readData(socket->getInBuffer().data(), socket->getInBuffer().size());
-        if (read < 0)
-        {
-            LOG_ERR('#' << socket->getFD()
-                        << " Error while handling Web-Socket upgrade response from the server. "
-                           "Shutting down socket.");
-            socket->shutdown();
-            return false;
-        }
-
-        if (read > 0)
-        {
-            // Remove what we consumed.
-            socket->eraseFirstInputBytes(read);
-
-            if (Util::iequal(response.get("Connection", ""), "Upgrade")
-                && Util::iequal(response.get("Upgrade", ""), "websocket")
-                && response.get("Sec-WebSocket-Accept", "")
-                       == PublicComputeAccept::doComputeAccept(_key))
-            {
-                LOG_TRC('#' << socket->getFD() << " Web-Socket upgrade completed.");
-                socket->setWebSocket();
-                return true;
-            }
-
-            LOG_ERR('#' << socket->getFD()
-                        << " Server returned invalid accept token during handshake. "
-                           "Shutting down socket.");
-            socket->shutdown();
-            return false;
-        }
-
-        assert(read == 0);
-        return false; // Not enough data.
-    }
-
 #if !MOBILEAPP
+    /// Returns the Web-Socket Security Key generated for this instance.
+    const std::string& getWebSocketKey() const { return _key; }
+
     // Handle incoming upgrade to full socket as client WS.
     void handleClientUpgrade(const std::shared_ptr<StreamSocket>& socket)
     {
         assert(socket && "socket must be valid");
+        assert(_isClient && "Upgrade handshakes are finished by clients.");
 
         std::vector<char>& data = socket->getInBuffer();
 
@@ -883,20 +835,21 @@ protected:
         http::Response response([&]() {
             if (response.statusLine().statusCode()
                     == Poco::Net::HTTPResponse::HTTP_SWITCHING_PROTOCOLS
-                && Util::iequal(response.header().get("Upgrade"), "websocket"))
+                && Util::iequal(response.get("Upgrade"), "websocket")
+                && Util::iequal(response.get("Connection", ""), "Upgrade")
+                // && response.get("Sec-WebSocket-Accept", "") // FIXME: enable validation
+                //        == PublicComputeAccept::doComputeAccept(_key)
+                )
             {
-#if 0 // SAL_DEBUG ...
-                    const std::string wsKey = response.get("Sec-WebSocket-Accept", "");
-                    const std::string wsProtocol = response.get("Sec-WebSocket-Protocol", "");
-                    if (!Util::iequal(wsProtocol, "chat"))
-                        LOG_ERR("Unknown websocket protocol " << wsProtocol);
-                    else
-#endif
-                {
-                    LOG_TRC('#' << socket->getFD() << " Accepted incoming websocket response");
-                    // FIXME: validate Sec-WebSocket-Accept vs. Sec-WebSocket-Key etc.
-                    setWebSocket();
-                }
+                LOG_TRC('#' << socket->getFD() << " Accepted incoming websocket response");
+                setWebSocket();
+            }
+            else
+            {
+                LOG_ERR('#' << socket->getFD()
+                            << " Server returned invalid accept token during handshake. "
+                               "Disconnecting.");
+                socket->shutdown();
             }
         });
 
@@ -913,7 +866,7 @@ protected:
         if (read > 0)
         {
             // Remove consumed data.
-            data.erase(data.begin(), data.begin() + read);
+            socket->eraseFirstInputBytes(read);
             return;
         }
 

--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -95,13 +95,6 @@ public:
         upgradeToWebSocket(*socket, request);
     }
 
-    /// Implementation of the ProtocolHandlerInterface.
-    void onConnect(const std::shared_ptr<StreamSocket>& socket) override
-    {
-        _socket = socket;
-        LOG_TRC('#' << socket->getFD() << " Connected to WS Handler " << this);
-    }
-
     /// Status codes sent to peer on shutdown.
     enum class StatusCodes : unsigned short
     {
@@ -119,6 +112,14 @@ public:
         UNEXPECTED_CONDITION    = 1011,
         RESERVED_TLS_FAILURE    = 1015
     };
+
+protected:
+    /// Implementation of the ProtocolHandlerInterface.
+    void onConnect(const std::shared_ptr<StreamSocket>& socket) override
+    {
+        _socket = socket;
+        LOG_TRC('#' << socket->getFD() << " Connected to WS Handler " << this);
+    }
 
     /// Sends WS Close frame to the peer.
     void sendCloseFrame(const StatusCodes statusCode = StatusCodes::NORMAL_CLOSE,
@@ -173,6 +174,7 @@ public:
         }
     }
 
+public:
     void shutdown(const StatusCodes statusCode = StatusCodes::NORMAL_CLOSE,
                   const std::string& statusMessage = std::string())
     {
@@ -192,6 +194,7 @@ public:
         _shuttingDown = false;
     }
 
+private:
     bool handleTCPStream(const std::shared_ptr<StreamSocket>& socket)
     {
         assert(socket && "Expected a valid socket instance.");
@@ -405,6 +408,7 @@ public:
         return true;
     }
 
+protected:
     /// Implementation of the ProtocolHandlerInterface.
     virtual void handleIncomingMessage(SocketDisposition&) override
     {

--- a/net/WebSocketSession.hpp
+++ b/net/WebSocketSession.hpp
@@ -143,14 +143,14 @@ public:
     const std::string& host() const { return _host; }
     const std::string& port() const { return _port; }
     Protocol protocol() const { return _protocol; }
-    bool isSecure() const { return _protocol == Protocol::HttpSsl; }
+    bool secure() const { return _protocol == Protocol::HttpSsl; }
 
     bool asyncRequest(http::Request& req, SocketPoll& poll)
     {
         LOG_TRC("asyncRequest: " << req.getVerb() << ' ' << host() << ':' << port() << ' '
                                  << req.getUrl());
 
-        return wsRequest(req, host(), port(), isSecure(), poll);
+        return wsRequest(req, host(), port(), secure(), poll);
     }
 
     /// Poll for messages and invoke the given callback.

--- a/net/WebSocketSession.hpp
+++ b/net/WebSocketSession.hpp
@@ -149,7 +149,7 @@ public:
     Protocol protocol() const { return _protocol; }
     bool isSecure() const { return _protocol == Protocol::HttpSsl; }
 
-    bool asyncRequest(http::Request req, SocketPoll& poll)
+    bool asyncRequest(http::Request& req, SocketPoll& poll)
     {
         LOG_TRC("asyncRequest: " << req.getVerb() << ' ' << host() << ':' << port() << ' '
                                  << req.getUrl());

--- a/net/WebSocketSession.hpp
+++ b/net/WebSocketSession.hpp
@@ -1,0 +1,202 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+#include <iostream>
+#include <fstream>
+#include <memory>
+#include <sstream>
+#include <string>
+
+#include "Common.hpp"
+#include "NetUtil.hpp"
+#include <net/Socket.hpp>
+#include <net/HttpRequest.hpp>
+#include <net/WebSocketHandler.hpp>
+#include <utility>
+#if ENABLE_SSL
+#include <net/SslSocket.hpp>
+#endif
+#include "Log.hpp"
+#include "Util.hpp"
+
+// This is a partial implementation of RFC 6455
+// The WebSocket Protocol.
+
+namespace http
+{
+/// A client socket to make asynchronous HTTP requests.
+/// Designed to be reused for multiple requests.
+class WebSocketSession final : public WebSocketHandler
+{
+public:
+    enum class Protocol
+    {
+        HttpUnencrypted,
+        HttpSsl,
+    };
+
+private:
+    WebSocketSession(const std::string& hostname, Protocol protocolType, int portNumber)
+        : _host(hostname)
+        , _port(std::to_string(portNumber))
+        , _protocol(protocolType)
+    {
+    }
+
+    /// Returns the given protocol's scheme.
+    static const char* getProtocolScheme(Protocol protocol)
+    {
+        switch (protocol)
+        {
+            case Protocol::HttpUnencrypted:
+                return "ws";
+            case Protocol::HttpSsl:
+                return "wss";
+        }
+
+        return "";
+    }
+
+public:
+    /// Create a new HTTP WebSocketSession to the given host.
+    /// The port defaults to the protocol's default port.
+    static std::shared_ptr<WebSocketSession> create(const std::string& host, Protocol protocol,
+                                                    int port = 0)
+    {
+        port = (port > 0 ? port : getDefaultPort(protocol));
+        return std::shared_ptr<WebSocketSession>(new WebSocketSession(host, protocol, port));
+    }
+
+    /// Create a new unencrypted HTTP WebSocketSession to the given host.
+    /// @port <= 0 will default to the http default port.
+    static std::shared_ptr<WebSocketSession> createHttp(const std::string& host, int port = 0)
+    {
+        return create(host, Protocol::HttpUnencrypted, port);
+    }
+
+    /// Create a new SSL HTTP WebSocketSession to the given host.
+    /// @port <= 0 will default to the https default port.
+    static std::shared_ptr<WebSocketSession> createHttpSsl(const std::string& host, int port = 0)
+    {
+        return create(host, Protocol::HttpSsl, port);
+    }
+
+    /// Create a new HTTP WebSocketSession to the given URI.
+    /// The @uri must include the scheme, e.g. https://domain.com:9980
+    static std::shared_ptr<WebSocketSession> create(const std::string& uri)
+    {
+        const std::string lowerUri = Util::toLower(uri);
+        if (!Util::startsWith(lowerUri, "http"))
+        {
+            LOG_ERR("Unsupported scheme in URI: " << uri);
+            return nullptr;
+        }
+
+        std::string hostPort;
+        bool secure = false;
+        if (Util::startsWith(uri, "http://"))
+        {
+            hostPort = uri.substr(7);
+        }
+        else if (Util::startsWith(uri, "https://"))
+        {
+            hostPort = uri.substr(8);
+            secure = true;
+        }
+        else
+        {
+            LOG_ERR("Invalid URI: " << uri);
+            return nullptr;
+        }
+
+        int port = 0;
+        const auto tokens = Util::tokenize(hostPort, ':');
+        if (tokens.size() > 1)
+        {
+            port = std::stoi(tokens[1]);
+        }
+
+        return create(tokens[0], secure ? Protocol::HttpSsl : Protocol::HttpUnencrypted, port);
+    }
+
+    /// Returns the given protocol's default port.
+    static int getDefaultPort(Protocol protocol)
+    {
+        switch (protocol)
+        {
+            case Protocol::HttpUnencrypted:
+                return 80;
+            case Protocol::HttpSsl:
+                return 443;
+        }
+
+        return 0;
+    }
+
+    /// Returns the current protocol scheme.
+    const char* getProtocolScheme() const { return getProtocolScheme(_protocol); }
+
+    const std::string& host() const { return _host; }
+    const std::string& port() const { return _port; }
+    Protocol protocol() const { return _protocol; }
+    bool isSecure() const { return _protocol == Protocol::HttpSsl; }
+
+    bool asyncRequest(Request req, SocketPoll& poll)
+    {
+        LOG_TRC("asyncRequest: " << req.getVerb() << ' ' << host() << ':' << port() << ' '
+                                 << req.getUrl());
+
+        // FIXME: Generate key.
+        std::string key = "fxTaWTEMVhq1PkWsMoLxGw==";
+
+        _request = std::move(req);
+        _request.set("Host", host()); // Make sure the host is set.
+        _request.set("Date", Util::getHttpTimeNow());
+        _request.set("User-Agent", HTTP_AGENT_STRING);
+
+        _request.set("Connection", "Upgrade");
+        _request.set("Upgrade", "websocket");
+        _request.set("Sec-WebSocket-Version", "13");
+        _request.set("Sec-WebSocket-Key", key);
+
+        auto socket = net::connect(_host, _port, isSecure(), shared_from_this());
+        if (!socket)
+        {
+            LOG_ERR("Failed to connect to " << _host << ':' << _port);
+            return false;
+        }
+
+        onConnect(socket);
+
+        if (socket->send(_request))
+        {
+            poll.insertNewSocket(socket);
+
+            return true;
+        }
+
+        LOG_ERR("Failed to make WebSocket request.");
+        return false;
+    }
+
+    /// Upgrade the socket to WebSocket and migrate to the given handler.
+    std::shared_ptr<WebSocketHandler> upgradeToWebSocket();
+
+private:
+    const std::string _host;
+    const std::string _port;
+    const Protocol _protocol;
+    Request _request;
+};
+
+} // namespace http
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/net/WebSocketSession.hpp
+++ b/net/WebSocketSession.hpp
@@ -69,13 +69,9 @@ private:
     }
 
 public:
-
     /// Destroy WebSocketSession.
     /// Note: must never be called with the owning poll thread still active.
-    ~WebSocketSession()
-    {
-        shutdown();
-    }
+    ~WebSocketSession() { shutdown(); }
 
     /// Create a new HTTP WebSocketSession to the given host.
     /// The port defaults to the protocol's default port.
@@ -158,10 +154,11 @@ public:
     }
 
     /// Wait until the given prefix is matched and return the payload.
-    std::vector<char> waitForMessage(const std::string& prefix, std::chrono::milliseconds timeout)
+    std::vector<char> waitForMessage(const std::string& prefix, std::chrono::milliseconds timeout,
+                                     const std::string& context = std::string())
     {
         const auto deadline = std::chrono::steady_clock::now() + timeout;
-        LOG_DBG("Waiting for [" << prefix << "] for " << timeout);
+        LOG_DBG(context << "Waiting for [" << prefix << "] for " << timeout);
 
         std::unique_lock<std::mutex> lock(_mutex);
         do
@@ -170,14 +167,14 @@ public:
             while (!_queue.isEmpty())
             {
                 std::vector<char> message = _queue.pop();
-                if (matchMessage(prefix, message))
+                if (matchMessage(prefix, message, context))
                     return message;
             }
 
             // Timed wait, if we must.
         } while (_cv.wait_until(lock, deadline, [this]() { return !_queue.isEmpty(); }));
 
-        LOG_DBG("Giving up waiting for [" << prefix << "] after " << timeout);
+        LOG_DBG(context << "Giving up waiting for [" << prefix << "] after " << timeout);
         return std::vector<char>();
     }
 
@@ -190,11 +187,14 @@ private:
         _cv.notify_one();
     }
 
-    bool matchMessage(const std::string& prefix, const std::vector<char>& message)
+    bool matchMessage(const std::string& prefix, const std::vector<char>& message,
+                      const std::string& context)
     {
         const auto header = LOOLProtocol::getFirstLine(message);
-        LOG_DBG("Evaluating message: " << header);
-        return LOOLProtocol::matchPrefix(prefix, header);
+        const bool match = LOOLProtocol::matchPrefix(prefix, header);
+        LOG_DBG(context << (match ? "Matched" : "Skipped") << " message [" << prefix
+                        << "]: " << header);
+        return match;
     }
 
     using WebSocketHandler::shutdown;

--- a/net/WebSocketSession.hpp
+++ b/net/WebSocketSession.hpp
@@ -165,7 +165,7 @@ public:
         _request.set("Connection", "Upgrade");
         _request.set("Upgrade", "websocket");
         _request.set("Sec-WebSocket-Version", "13");
-        _request.set("Sec-WebSocket-Key", PublicComputeAccept::generateKey());
+        _request.set("Sec-WebSocket-Key", getWebSocketKey());
 
         auto socket = net::connect(_host, _port, isSecure(), shared_from_this());
         if (!socket)

--- a/test/HttpRequestTests.cpp
+++ b/test/HttpRequestTests.cpp
@@ -294,6 +294,8 @@ static void compare(const Poco::Net::HTTPResponse& pocoResponse, const std::stri
 /// It exercises a few hundred requests/responses.
 void HttpRequestTests::test500GetStatuses()
 {
+    constexpr auto testname = "test500GetStatuses ";
+
     constexpr auto Host = "httpbin.org";
     constexpr bool secure = false;
     constexpr int port = 80;
@@ -328,6 +330,9 @@ void HttpRequestTests::test500GetStatuses()
         http::Request httpRequest;
         httpRequest.setUrl(url);
 
+        TST_LOG("Requesting Status Code [" << statusCode << "]: " << url);
+
+        std::unique_lock<std::mutex> lock(mutex);
         timedout = true; // Assume we timed out until we prove otherwise.
 
         httpSession->asyncRequest(httpRequest, pollThread);
@@ -344,7 +349,6 @@ void HttpRequestTests::test500GetStatuses()
 
         const std::shared_ptr<const http::Response> httpResponse = httpSession->response();
 
-        std::unique_lock<std::mutex> lock(mutex);
         cv.wait_for(lock, DefTimeoutSeconds, [&]() { return httpResponse->done(); });
 
         LOK_ASSERT_EQUAL(http::Response::State::Complete, httpResponse->state());

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -281,6 +281,7 @@ unit-load-torture.log : group0.log
 
 unit-wopi-saveas.log : group0.log
 unit-password-protected.log : group0.log
+unit-http.log : group0.log
 unit-tiff-load.log : group0.log
 unit-render-shape.log : group0.log
 unit-oauth.log : group0.log

--- a/test/UnitHTTP.cpp
+++ b/test/UnitHTTP.cpp
@@ -88,11 +88,14 @@ public:
 
     void writeString(const std::shared_ptr<Poco::Net::StreamSocket> &socket, const std::string& str)
     {
+        LOG_TST("Sending " << str.size() << " bytes:\n" << str);
         socket->sendBytes(str.c_str(), str.size());
     }
 
     bool expectString(const std::shared_ptr<Poco::Net::StreamSocket> &socket, const std::string& str)
     {
+        LOG_TST("Expecting " << str.size() << " bytes:\n" << str);
+
         std::vector<char> buffer(str.size() + 64);
         const int got = socket->receiveBytes(buffer.data(), str.size());
         LOK_ASSERT_EQUAL(str, std::string(buffer.data(), got));
@@ -170,6 +173,7 @@ public:
 
         writeString(socket, START_CHUNK_HEX("0"));
 
+        LOG_TST("Receiving...");
         char buffer[4096] = { 0, };
         int got = socket->receiveBytes(buffer, 4096);
         static const std::string start =
@@ -203,6 +207,7 @@ public:
         }
 
         // Oddly we need another read to get the content.
+        LOG_TST("Receiving...");
         got = socket->receiveBytes(buffer, 4096);
         LOK_ASSERT_MESSAGE("No content returned.", got >= 0);
         if (got >=0 )

--- a/test/UnitLoad.cpp
+++ b/test/UnitLoad.cpp
@@ -216,20 +216,7 @@ UnitBase::TestResult UnitLoad::testLoad()
     std::vector<char> message = wsSession->waitForMessage("status:", std::chrono::seconds(50));
     LOK_ASSERT_MESSAGE("Failed to load the document", !message.empty());
 
-    // TST_LOG(">>> Sleeping");
-    // std::this_thread::sleep_for(std::chrono::seconds(20));
-    // TST_LOG(">>> Woke up");
-
-    // Load a document and wait for the status.
-    // Don't replace with helpers, so we catch status.
-    // Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, documentURL);
-    // Poco::URI uri(helpers::getTestServerURI());
-    // Poco::Net::HTTPResponse response;
-    // std::shared_ptr<LOOLWebSocket> socket = helpers::connectLOKit(uri, request, response, testname);
-    // helpers::sendTextFrame(socket, "load url=" + documentURL, testname);
-
-    // helpers::assertResponseString(socket, "status:", testname);
-
+    pollThread.joinThread();
     return TestResult::Ok;
 }
 

--- a/test/UnitLoad.cpp
+++ b/test/UnitLoad.cpp
@@ -5,6 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include <chrono>
 #include <config.h>
 
 #include <memory>
@@ -212,9 +213,12 @@ UnitBase::TestResult UnitLoad::testLoad()
     TST_LOG(">>> Loading");
     wsSession->sendMessage("load url=" + documentURL);
 
-    TST_LOG(">>> Sleeping");
-    std::this_thread::sleep_for(std::chrono::seconds(20));
-    TST_LOG(">>> Woke up");
+    std::vector<char> message = wsSession->waitForMessage("status:", std::chrono::seconds(50));
+    LOK_ASSERT_MESSAGE("Failed to load the document", !message.empty());
+
+    // TST_LOG(">>> Sleeping");
+    // std::this_thread::sleep_for(std::chrono::seconds(20));
+    // TST_LOG(">>> Woke up");
 
     // Load a document and wait for the status.
     // Don't replace with helpers, so we catch status.

--- a/test/UnitLoadTorture.cpp
+++ b/test/UnitLoadTorture.cpp
@@ -7,6 +7,8 @@
 
 #include <config.h>
 
+#include "Protocol.hpp"
+
 #include <memory>
 #include <string>
 
@@ -16,6 +18,7 @@
 #include <Unit.hpp>
 #include <Util.hpp>
 #include <helpers.hpp>
+#include <net/WebSocketSession.hpp>
 
 class LOOLWebSocket;
 
@@ -41,10 +44,14 @@ int UnitLoadTorture::loadTorture(const std::string& testname, const std::string&
     std::string documentPath, documentURL;
     helpers::getDocumentPathAndURL(docName, documentPath, documentURL, testname);
 
+    TST_LOG("Starting test on " << documentURL << ' ' << documentPath);
+
     std::atomic<int> sum_view_ids;
     sum_view_ids = 0;
     std::atomic<int> num_of_views(0);
     std::atomic<int> num_to_load(thread_count);
+    SocketPoll poll("WebSocketPoll");
+    poll.startThread();
 
     std::vector<std::thread> threads;
     for (size_t i = 0; i < thread_count; ++i)
@@ -58,15 +65,17 @@ int UnitLoadTorture::loadTorture(const std::string& testname, const std::string&
             try
             {
                 // Load a document and wait for the status.
-                Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, documentURL);
-                Poco::Net::HTTPResponse response;
-                std::shared_ptr<LOOLWebSocket> socket = helpers::connectLOKit(
-                    Poco::URI(helpers::getTestServerURI()), request, response, testname);
-                helpers::sendTextFrame(socket, "load url=" + documentURL, testname);
+                auto wsSession = http::WebSocketSession::create(helpers::getTestServerURI());
+                http::Request req(documentURL);
+                wsSession->asyncRequest(req, poll);
+
+                wsSession->sendMessage("load url=" + documentURL);
 
                 // 20s is double of the default.
-                const auto status = helpers::assertResponseString(socket, "status:", testname,
-                                                                  std::chrono::seconds(20));
+                std::vector<char> message
+                    = wsSession->waitForMessage("status:", std::chrono::seconds(20), testname + id + ' ');
+                const std::string status = LOOLProtocol::getFirstLine(message);
+
                 int viewid = -1;
                 LOOLProtocol::getTokenIntegerFromMessage(status, "viewid", viewid);
                 sum_view_ids += viewid;

--- a/test/helpers.hpp
+++ b/test/helpers.hpp
@@ -30,6 +30,7 @@
 #include <LOOLWebSocket.hpp>
 #include <common/ConfigUtil.hpp>
 #include <common/Util.hpp>
+#include <net/WebSocketSession.hpp>
 
 #include <iterator>
 #include <fstream>
@@ -138,6 +139,18 @@ inline
 void sendTextFrame(const std::shared_ptr<LOOLWebSocket>& socket, const std::string& string, const std::string& name = "")
 {
     sendTextFrame(*socket, string, name);
+}
+
+inline void sendTextFrame(const std::shared_ptr<http::WebSocketSession>& ws,
+                          const std::string& string, const std::string& testname = std::string())
+{
+#ifndef FUZZER
+    TST_LOG("Sending " << string.size()
+                       << " bytes: " << LOOLProtocol::getAbbreviatedMessage(string));
+#else
+    (void)testname;
+#endif
+    ws->sendMessage(string);
 }
 
 inline std::unique_ptr<Poco::Net::HTTPClientSession> createSession(const Poco::URI& uri)
@@ -424,6 +437,16 @@ std::string getResponseString(T& ws, const std::string& prefix, const std::strin
     return std::string(response.data(), response.size());
 }
 
+inline std::string getResponseString(const std::shared_ptr<http::WebSocketSession>& ws,
+                                     const std::string& prefix, const std::string& testname,
+                                     const std::chrono::milliseconds timeoutMs
+                                     = std::chrono::seconds(10))
+{
+    const std::vector<char> response = ws->waitForMessage(prefix, timeoutMs, testname);
+
+    return std::string(response.data(), response.size());
+}
+
 template <typename T>
 std::string assertResponseString(T& ws, const std::string& prefix, const std::string& testname,
                                  const std::chrono::milliseconds timeoutMs
@@ -476,6 +499,19 @@ inline
 bool isDocumentLoaded(std::shared_ptr<LOOLWebSocket>& ws, const std::string& testname, bool isView = true)
 {
     return isDocumentLoaded(*ws, testname, isView);
+}
+
+inline bool isDocumentLoaded(const std::shared_ptr<http::WebSocketSession>& ws,
+                             const std::string& testname, bool isView = true)
+{
+    const std::string prefix = isView ? "status:" : "statusindicatorfinish:";
+    constexpr auto timeout = std::chrono::seconds(20); // Allow 20 secs to load
+    const std::string message = getResponseString(ws, prefix, testname, timeout);
+
+    const bool success = LOOLProtocol::matchPrefix(prefix, message);
+    if (!success)
+        TST_LOG("ERROR: Timed out loading document. Did not get [" << prefix << "] in time.");
+    return success;
 }
 
 // Connecting to a Kit process is managed by document broker, that it does several
@@ -574,6 +610,42 @@ std::shared_ptr<LOOLWebSocket> loadDocAndGetSocket(const std::string& docFilenam
     return nullptr;
 }
 
+inline std::shared_ptr<http::WebSocketSession>
+loadDocAndGetSession(SocketPoll& socketPoll, const Poco::URI& uri, const std::string& documentURL,
+                     const std::string& testname, bool isView = true, bool isAssert = true)
+{
+    try
+    {
+        // Load a document and get its status.
+        auto ws = http::WebSocketSession::create(uri.toString());
+        http::Request req(documentURL);
+        ws->asyncRequest(req, socketPoll);
+
+        sendTextFrame(ws, "load url=" + documentURL, testname);
+        const bool isLoaded = isDocumentLoaded(ws, testname, isView);
+        if (!isLoaded && !isAssert)
+        {
+            return nullptr;
+        }
+
+        LOK_ASSERT_MESSAGE("Failed to load the document " + documentURL, isLoaded);
+
+        TST_LOG("Loaded document [" << documentURL << "].");
+        return ws;
+    }
+    catch (const Poco::Exception& ex)
+    {
+        LOK_ASSERT_FAIL(ex.displayText());
+    }
+    catch (const std::exception& ex)
+    {
+        LOK_ASSERT_FAIL(ex.what());
+    }
+
+    // Really can't reach here, but the compiler doesn't know better.
+    return nullptr;
+}
+
 inline void SocketProcessor(const std::string& testname,
                             const std::shared_ptr<LOOLWebSocket>& socket,
                             const std::function<bool(const std::string& msg)>& handler,
@@ -604,6 +676,18 @@ inline void SocketProcessor(const std::string& testname,
         }
     }
     while (n > 0 && (flags & Poco::Net::WebSocket::FRAME_OP_BITMASK) != Poco::Net::WebSocket::FRAME_OP_CLOSE);
+}
+
+inline void
+SocketProcessor(const std::string& testname, const std::shared_ptr<http::WebSocketSession>& ws,
+                const std::function<bool(const std::string& msg)>& handler,
+                const std::chrono::milliseconds timeout = std::chrono::milliseconds(10000))
+{
+    ws->poll(
+        [&](const std::vector<char>& message) {
+            return !handler(std::string(message.data(), message.size()));
+        },
+        timeout, testname);
 }
 
 inline
@@ -818,6 +902,18 @@ inline void selectAll(const std::shared_ptr<LOOLWebSocket>& socket, const std::s
     }
 }
 
+/// Select all and wait for the text selection update.
+inline void selectAll(const std::shared_ptr<http::WebSocketSession>& ws,
+                      const std::string& testname, int repeat = COMMAND_RETRY_COUNT)
+{
+    for (int i = 0; i < repeat; ++i)
+    {
+        TST_LOG("Sending [uno .uno:SelectAll], attempt #" << repeat);
+        sendTextFrame(ws, "uno .uno:SelectAll", testname);
+        if (!getResponseString(ws, "textselection:", testname).empty())
+            break;
+    }
+}
 
 /// Delete all and wait for the text selection update.
 inline void deleteAll(const std::shared_ptr<LOOLWebSocket>& socket, const std::string& testname, int repeat = COMMAND_RETRY_COUNT)
@@ -828,6 +924,21 @@ inline void deleteAll(const std::shared_ptr<LOOLWebSocket>& socket, const std::s
     {
         sendTextFrame(socket, "uno .uno:Delete", testname);
         if (!getResponseString(socket, "textselection:", testname).empty())
+            break;
+    }
+}
+
+/// Delete all and wait for the text selection update.
+inline void deleteAll(const std::shared_ptr<http::WebSocketSession>& ws,
+                      const std::string& testname, int repeat = COMMAND_RETRY_COUNT)
+{
+    selectAll(ws, testname);
+
+    for (int i = 0; i < repeat; ++i)
+    {
+        TST_LOG("Sending [uno .uno:Delete], attempt #" << repeat);
+        sendTextFrame(ws, "uno .uno:Delete", testname);
+        if (!getResponseString(ws, "textselection:", testname).empty())
             break;
     }
 }

--- a/tools/WebSocketDump.cpp
+++ b/tools/WebSocketDump.cpp
@@ -36,8 +36,8 @@ class DumpSocketHandler : public WebSocketHandler
 {
 public:
     DumpSocketHandler(const std::weak_ptr<StreamSocket>& socket,
-                      const Poco::Net::HTTPRequest& request) :
-        WebSocketHandler(socket, request)
+                      const Poco::Net::HTTPRequest& request)
+        : WebSocketHandler(socket.lock(), request)
     {
     }
 

--- a/wsd/Admin.cpp
+++ b/wsd/Admin.cpp
@@ -296,9 +296,9 @@ void AdminSocketHandler::handleMessage(const std::vector<char> &payload)
 AdminSocketHandler::AdminSocketHandler(Admin* adminManager,
                                        const std::weak_ptr<StreamSocket>& socket,
                                        const Poco::Net::HTTPRequest& request)
-    : WebSocketHandler(socket, request),
-      _admin(adminManager),
-      _isAuthenticated(false)
+    : WebSocketHandler(socket.lock(), request)
+    , _admin(adminManager)
+    , _isAuthenticated(false)
 {
     // Different session id pool for admin sessions (?)
     _sessionId = Util::decodeId(LOOLWSD::GetConnectionId());

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -281,8 +281,7 @@ void FileServerRequestHandler::handleRequest(const HTTPRequest& request,
         LOG_TRC("Fileserver request: " << requestUri.toString());
         requestUri.normalize(); // avoid .'s and ..'s
 
-        std::string path(requestUri.getPath());
-        if (path.find("loleaflet/" LOOLWSD_VERSION_HASH "/") == std::string::npos)
+        if (requestUri.getPath().find("loleaflet/" LOOLWSD_VERSION_HASH "/") == std::string::npos)
         {
             LOG_WRN("client - server version mismatch, disabling browser cache. Expected: " LOOLWSD_VERSION_HASH);
             noCache = true;

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -2538,15 +2538,12 @@ private:
                 catch (const Poco::Net::NotAuthenticatedException& exc)
                 {
                     //LOG_ERR("FileServerRequestHandler::NotAuthenticated: " << exc.displayText());
-                    std::ostringstream oss;
-                    oss << "HTTP/1.1 401 \r\n"
-                        << "Content-Type: text/html charset=UTF-8\r\n"
-                        << "Date: " << Util::getHttpTimeNow() << "\r\n"
-                        << "User-Agent: " << WOPI_AGENT_STRING << "\r\n"
-                        << "WWW-authenticate: Basic realm=\"online\"\r\n"
-                        << "Connection: close\r\n" // Let the client know we will disconnect.
-                        << "\r\n";
-                    socket->send(oss.str());
+                    http::Response httpResponse(http::StatusLine(401));
+                    httpResponse.set("Content-Type", "text/html charset=UTF-8");
+                    httpResponse.set("WWW-authenticate", "Basic realm=\"online\"");
+                    httpResponse.set("Connection", "close");
+                    httpResponse.writeData(socket->getOutBuffer());
+                    socket->flush();
                     socket->shutdown();
                     return;
                 }
@@ -3272,14 +3269,11 @@ private:
                 else
                     LOG_ERR("Download with id [" << downloadId << "] not found.");
 
-                std::ostringstream oss;
-                oss << "HTTP/1.1 404 Not Found\r\n"
-                    << "Date: " << Util::getHttpTimeNow() << "\r\n"
-                    << "Server: " HTTP_SERVER_STRING "\r\n"
-                    << "Content-Length: 0\r\n"
-                    << "Connection: close\r\n" // Let the client know we will disconnect.
-                    << "\r\n";
-                socket->send(oss.str());
+                http::Response httpResponse(http::StatusLine(404));
+                httpResponse.set("Content-Length", "0");
+                httpResponse.set("Connection", "close");
+                httpResponse.writeData(socket->getOutBuffer());
+                socket->flush();
                 socket->shutdown();
             }
             return;

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -2544,8 +2544,7 @@ private:
                     httpResponse.set("Content-Type", "text/html charset=UTF-8");
                     httpResponse.set("WWW-authenticate", "Basic realm=\"online\"");
                     httpResponse.set("Connection", "close");
-                    httpResponse.writeData(socket->getOutBuffer());
-                    socket->flush();
+                    socket->send(httpResponse);
                     socket->shutdown();
                     return;
                 }
@@ -2620,8 +2619,7 @@ private:
             http::Response httpResponse(http::StatusLine(400));
             httpResponse.set("Content-Length", "0");
             httpResponse.set("Connection", "close");
-            httpResponse.writeData(socket->getOutBuffer());
-            socket->flush();
+            socket->send(httpResponse);
             socket->shutdown();
             return;
         }
@@ -2733,13 +2731,11 @@ private:
         Poco::replaceInPlace(xml, std::string("%SRV_URI%"), srvUrl);
 
         http::Response httpResponse(http::StatusLine(200));
-        httpResponse.set("Content-Length", std::to_string(xml.size()));
-        httpResponse.set("Content-Type", "text/xml");
+        httpResponse.setBody(xml, "text/xml");
         httpResponse.set("Last-Modified", Util::getHttpTimeNow());
         httpResponse.set("X-Content-Type-Options", "nosniff");
         httpResponse.set("Connection", "close");
-        httpResponse.writeData(socket->getOutBuffer());
-        socket->send(xml);
+        socket->send(httpResponse);
         socket->shutdown();
         LOG_INF("Sent discovery.xml successfully.");
     }
@@ -2755,12 +2751,10 @@ private:
 
         http::Response httpResponse(http::StatusLine(200));
         httpResponse.set("Last-Modified", Util::getHttpTimeNow());
-        httpResponse.set("Content-Length", std::to_string(capabilities.size()));
-        httpResponse.set("Content-Type", "application/json");
+        httpResponse.setBody(capabilities, "application/json");
         httpResponse.set("X-Content-Type-Options", "nosniff");
         httpResponse.set("Connection", "close");
-        httpResponse.writeData(socket->getOutBuffer());
-        socket->send(capabilities);
+        socket->send(httpResponse);
         socket->shutdown();
         LOG_INF("Sent capabilities.json successfully.");
     }
@@ -2804,8 +2798,7 @@ private:
             http::Response httpResponse(http::StatusLine(400));
             httpResponse.set("Content-Length", "0");
             httpResponse.set("Connection", "close");
-            httpResponse.writeData(socket->getOutBuffer());
-            socket->send(errMsg);
+            socket->send(httpResponse);
             socket->shutdown();
             return;
         }
@@ -3065,8 +3058,7 @@ private:
                 http::Response httpResponse(http::StatusLine(403));
                 httpResponse.set("Content-Length", "0");
                 httpResponse.set("Connection", "close");
-                httpResponse.writeData(socket->getOutBuffer());
-                socket->flush();
+                socket->send(httpResponse);
                 socket->shutdown();
                 return;
             }
@@ -3163,8 +3155,7 @@ private:
                     http::Response httpResponse(http::StatusLine(200));
                     httpResponse.set("Content-Length", "0");
                     httpResponse.set("Connection", "close");
-                    httpResponse.writeData(socket->getOutBuffer());
-                    socket->flush();
+                    socket->send(httpResponse);
                     socket->shutdown();
                     return;
                 }
@@ -3249,8 +3240,7 @@ private:
                 http::Response httpResponse(http::StatusLine(404));
                 httpResponse.set("Content-Length", "0");
                 httpResponse.set("Connection", "close");
-                httpResponse.writeData(socket->getOutBuffer());
-                socket->flush();
+                socket->send(httpResponse);
                 socket->shutdown();
             }
             return;

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -3344,7 +3344,7 @@ private:
         LOG_TRC("Client WS request: " << requestDetails.getURI() << ", url: " << url << ", socket #" << socket->getFD());
 
         // First Upgrade.
-        auto ws = std::make_shared<WebSocketHandler>(_socket, request);
+        auto ws = std::make_shared<WebSocketHandler>(socket, request);
 
         // Response to clients beyond this point is done via WebSocket.
         try

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -2531,7 +2531,8 @@ private:
                 if (!LOOLWSD::AdminEnabled)
                     throw Poco::FileAccessDeniedException("Admin console disabled");
 
-                try{
+                try
+                {
                     if (!FileServerRequestHandler::isAdminLoggedIn(request, *response))
                         throw Poco::Net::NotAuthenticatedException("Invalid admin login");
                 }
@@ -2615,14 +2616,11 @@ private:
 
             // Bad request.
             // NOTE: Check _wsState to choose between HTTP response or WebSocket (app-level) error.
-            std::ostringstream oss;
-            oss << "HTTP/1.1 400\r\n"
-                << "Date: " << Util::getHttpTimeNow() << "\r\n"
-                << "User-Agent: LOOLWSD WOPI Agent\r\n"
-                << "Content-Length: 0\r\n"
-                << "Connection: close\r\n" // Let the client know we will disconnect.
-                << "\r\n";
-            socket->send(oss.str());
+            http::Response httpResponse(http::StatusLine(400));
+            httpResponse.set("Content-Length", "0");
+            httpResponse.set("Connection", "close");
+            httpResponse.writeData(socket->getOutBuffer());
+            socket->flush();
             socket->shutdown();
             return;
         }

--- a/wsd/LOOLWSD.hpp
+++ b/wsd/LOOLWSD.hpp
@@ -184,16 +184,16 @@ private:
 
 #if !MOBILEAPP
 
-class ForKitProcWSHandler: public WebSocketHandler
+class ForKitProcWSHandler : public WebSocketHandler
 {
 public:
-
-    ForKitProcWSHandler(const std::weak_ptr<StreamSocket>& socket, const Poco::Net::HTTPRequest& request)
-    : WebSocketHandler(socket, request)
+    ForKitProcWSHandler(const std::weak_ptr<StreamSocket>& socket,
+                        const Poco::Net::HTTPRequest& request)
+        : WebSocketHandler(socket.lock(), request)
     {
     }
 
-    virtual void handleMessage(const std::vector<char> &data) override;
+    virtual void handleMessage(const std::vector<char>& data) override;
 };
 
 class ForKitProcess : public WSProcess


### PR DESCRIPTION
- leaflet: make: cleanup timestamp files
- wsd: create the temp directory root recursively
- wsd: test: unit-http is part of group0
- wsd: use http::Response for LOOLWSD 401 and 404 errors
- wsd: use http::Response for LOOLWSD 400 errors
- wsd: use http::Response in LOOLWSD file serving
- wsd: use http::Response in WebSocketHandler 101 responses
- wsd: use http::Response in LOOLWSD
- wsd: use setbody in LOOLWSD and avoid manual plumbing
- wsd: WebSocketHandler accepts http::Request in addition to Poco
- wsd: WebSocketHandler fully supports http::Request
- wsd: test: new WebSocket load Test using http::Request
- wsd: restrict WebSocketHandler members
- wsd: http: handle client-side WebSocket upgrade
- wsd: new WebSocketSession to createa a WebSocket connection
- wsd: test: new document-load test with WebSocketSession
- wsd: WebSocketSession handhsake and wait for message
- wsd: improved WebSocket support
- wsd: http: explicit Request constructor and Header arg
- wsd: http: move WebSocket creation into Request
- wsd: use WebSocketHandler instead of explicit WebSocket request
- wsd: use http::Request for internal WS and simplify
- wsd: http: reuse parseUri
- wsd: WebSocketSession create helper and shutdown member
- wsd: test: use WebSocketSession::create in unit test
- wsd: log the context in WebSocket Session logs
- wsd: test: use WebSocketSession in UnitLoadTorture
- wsd: http: WebSocketSession supports flexible message polling
- wsd: test: helpers for http::WebSocketSession in tests
- wsd: make single-argument ctor explicit
- wsd: test: improve 500 GET test
- wsd: WebSocketSession isSecure() -> secure()
- make: build test after JS and WSD
- wsd: reduce string copies
- wsd: test: log more in UnitHTTP
- leaflet: make: cleanup touched files