### PR TITLE
Writer: Improve table controls (markers)

### DIFF
--- a/loleaflet/css/loleaflet.css
+++ b/loleaflet/css/loleaflet.css
@@ -131,14 +131,38 @@
 	cursor: row-resize;
 }
 
-.table-row-or-column-select-marker {
+.table-select-marker {
 	margin: 0px;
 	width: 24px;
 	height: 24px;
-	background-image: url('images/table-row-or-column-select-marker.svg');
-	background-size: cover;
-	background-repeat: no-repeat;
+	background: url('images/table-row-or-column-select-marker.svg') no-repeat center center /12px;
 	cursor: pointer;
+}
+
+.table-select-marker::before {
+	content: '';
+	position: absolute;
+	z-index: 0;
+}
+
+.table-select-marker--column::before {
+	bottom: 50%;
+	border-bottom: 1px dashed lightgray;
+	width: 100%;
+}
+
+.table-select-marker--row::before {
+	left: 50%;
+	border-left: 1px dashed lightgray;
+	height: 100%;
+}
+
+.table-select-marker:hover {
+	background: url('images/table-row-or-column-select-marker-selected.svg') no-repeat center center /12px;
+}
+
+.table-select-marker:hover::before {
+	border-color: #1C99E0;
 }
 
 .table-move-marker {

--- a/loleaflet/images/table-row-or-column-select-marker-selected.svg
+++ b/loleaflet/images/table-row-or-column-select-marker-selected.svg
@@ -9,5 +9,5 @@
    </cc:Work>
   </rdf:RDF>
  </metadata>
- <rect width="1" height="1" rx=".1" ry=".1" fill="#ddd" style="paint-order:fill markers stroke"/>
+ <rect width="1" height="1" rx=".1" ry=".1" fill="#1c99e0" style="paint-order:fill markers stroke"/>
 </svg>

--- a/loleaflet/src/layer/tile/TileLayer.TableOverlay.js
+++ b/loleaflet/src/layer/tile/TileLayer.TableOverlay.js
@@ -237,13 +237,15 @@ L.CanvasTileLayer.include({
 
 		var delta1 = this._convertPixelToTwips(this._selectionHeaderDistanceFromTable);
 
-		// The 24 is the height and width of the .table-row-or-column-select-marker in loleaflet.css
+		// The 24 is the height and width of the .table-select-marker in loleaflet.css
 		var height = 24;
 		var width = height;
 		var selectionMarkerNominalSize = this._convertPixelToTwips(width);
+		var classNameMarker = 'table-select-marker';
 
 		for (var i = 0; i < positions.length - 1; i++) {
 			if (type === 'column') {
+				classNameMarker += ' table-select-marker--column';
 				startX = this._tablePositionColumnOffset + positions[i];
 				endX = this._tablePositionColumnOffset + positions[i + 1];
 				startY = start;
@@ -253,6 +255,7 @@ L.CanvasTileLayer.include({
 				width = this._convertTwipsToPixels(new L.Point(endX - startX, 0)).x - 2;
 			}
 			else {
+				classNameMarker += ' table-select-marker--row';
 				startX = start;
 				endX = end;
 				startY = this._tablePositionRowOffset + positions[i];
@@ -265,7 +268,7 @@ L.CanvasTileLayer.include({
 			var selectionRectangle = L.marker(point1,
 				{
 					icon: L.divIcon({
-						className: 'table-row-or-column-select-marker',
+						className: classNameMarker,
 						iconSize: [width, height],
 						iconAnchor: [0, 0],
 					}),


### PR DESCRIPTION
- Do not use big rectangles as markers
  - it hides surrounding content
	- too intrusive (since it appears every time we select a table)
- Use smaller discreeter elements WHILE maintaining the existing
  active zone size (so it's still easy to click it, no need to be precise)
- Add missing hover status
  - Create new SVG plus add rounded corners
- Treat column and row marker as different elements
  - Use one generic class + add another for each type (element modifier)
	- So we can target each one and have a nice center line
	no matter the disposition (vertical, horizontal)

note: motivated by the reported issue:
https://github.com/CollaboraOnline/online/issues/1297

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I4d997864e99582f74411a12c33381a926fd47a05
