### PR TITLE
fix typescript error due to build/ dir if any

### DIFF
--- a/loleaflet/tsconfig.json
+++ b/loleaflet/tsconfig.json
@@ -26,6 +26,7 @@
       "typescript_js",
       "dist",
       "release",
-      "debug"
+      "debug",
+      "build"
     ]
   }


### PR DESCRIPTION
Signed-off-by: Dennis Francis <dennis.francis@collabora.com>
Change-Id: Ibed6facc18a83ae2d7d3ef59be06ddedd5142cad


* Target version: master 

### Summary
Since typescript project compilation is done just for the source directory loleaflet/src/ and tsconfig.json sits in loleaflet/ we need to to add other dirs that contain js files to tsconfig.json's exclude list.

### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

