### PR TITLE
WebSocketSession in Tests and Replace Poco (partially)

### DIFF
--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -474,10 +474,11 @@ class MessageHandlerInterface :
 {
 protected:
     std::shared_ptr<ProtocolHandlerInterface> _protocol;
-    MessageHandlerInterface(const std::shared_ptr<ProtocolHandlerInterface> &protocol) :
-        _protocol(protocol)
+    MessageHandlerInterface(std::shared_ptr<ProtocolHandlerInterface> protocol)
+        : _protocol(std::move(protocol))
     {
     }
+
     virtual ~MessageHandlerInterface() {}
 
 public:

--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -125,19 +125,13 @@ public:
     /// Returns the Web-Socket Security Key generated for this instance.
     const std::string& getWebSocketKey() const { return _key; }
 
+    /// Create a WebSocket connection to the given @host
+    /// and @port and add the socket to @poll.
     bool wsRequest(http::Request& req, const std::string& host, const std::string& port,
                    bool isSecure, SocketPoll& poll)
     {
-        LOG_TRC("Web-Socket request: " << host << ':' << port);
-
-        req.set("Host", host); // Make sure the host is set.
-        req.set("Date", Util::getHttpTimeNow());
-        req.set("User-Agent", HTTP_AGENT_STRING);
-
-        req.set("Connection", "Upgrade");
-        req.set("Upgrade", "websocket");
-        req.set("Sec-WebSocket-Version", "13");
-        req.set("Sec-WebSocket-Key", getWebSocketKey());
+        const std::string hostAndPort = host + ':' + port;
+        LOG_TRC("Web-Socket request: " << hostAndPort);
 
         auto socket = net::connect(host, port, isSecure, shared_from_this());
         if (!socket)
@@ -147,6 +141,15 @@ public:
         }
 
         onConnect(socket);
+
+        req.set("Host", hostAndPort); // Make sure the host is set.
+        req.set("Date", Util::getHttpTimeNow());
+        req.set("User-Agent", HTTP_AGENT_STRING);
+
+        req.set("Connection", "Upgrade");
+        req.set("Upgrade", "websocket");
+        req.set("Sec-WebSocket-Version", "13");
+        req.set("Sec-WebSocket-Key", getWebSocketKey());
 
         if (socket->send(req))
         {

--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -426,7 +426,7 @@ private:
         const size_t payloadLen = len;
 #endif
 
-        socket->getInBuffer().erase(socket->getInBuffer().begin(), socket->getInBuffer().begin() + headerLen + payloadLen);
+        socket->eraseFirstInputBytes(headerLen + payloadLen);
 
 #if !MOBILEAPP
 
@@ -449,7 +449,6 @@ private:
         }
 #else
         handleMessage(_wsPayload);
-
 #endif
 
         _wsPayload.clear();

--- a/net/WebSocketSession.hpp
+++ b/net/WebSocketSession.hpp
@@ -203,6 +203,16 @@ public:
         _outQueue.put(std::vector<char>(msg.data(), msg.data() + msg.size()));
     }
 
+    /// Send asynchronous shutdown frame and disconnect socket.
+    void asyncShutdown(SocketPoll& poll)
+    {
+        LOG_TRC("WebSocketSession: queueing shutdown");
+        poll.addCallback([&]() {
+            LOG_TRC("WebSocketSession: shutdown");
+            shutdown(true, "Shutting down");
+        });
+    }
+
 private:
     void handleMessage(const std::vector<char>& data) override
     {
@@ -257,12 +267,6 @@ private:
     using WebSocketHandler::sendMessage;
     using WebSocketHandler::sendTextMessage;
     using WebSocketHandler::shutdown;
-
-    void shutdown()
-    {
-        LOG_TRC("shutdown");
-        shutdown(true, "Shutting down");
-    }
 
 private:
     const std::string _host;

--- a/test/UnitLoad.cpp
+++ b/test/UnitLoad.cpp
@@ -211,8 +211,13 @@ UnitBase::TestResult UnitLoad::testLoad()
     TST_LOG("Loading " << documentURL);
     wsSession->sendMessage("load url=" + documentURL);
 
-    std::vector<char> message = wsSession->waitForMessage("status:", std::chrono::seconds(50));
+    std::vector<char> message = wsSession->waitForMessage("status:", std::chrono::seconds(5));
     LOK_ASSERT_MESSAGE("Failed to load the document", !message.empty());
+
+    wsSession->asyncShutdown(socketPoll);
+
+    LOK_ASSERT_MESSAGE("Expected success disconnection of the WebSocket",
+                       wsSession->waitForDisconnection(std::chrono::seconds(5)));
 
     socketPoll.joinThread();
     return TestResult::Ok;

--- a/test/helpers.hpp
+++ b/test/helpers.hpp
@@ -421,6 +421,24 @@ getResponseMessage(LOOLWebSocket& ws, const std::string& prefix, const std::stri
     return std::vector<char>();
 }
 
+inline std::vector<char> getResponseMessage(const std::shared_ptr<http::WebSocketSession>& ws,
+                                     const std::string& prefix, const std::string& testname,
+                                     const std::chrono::milliseconds timeoutMs
+                                     = std::chrono::seconds(10))
+{
+    return ws->waitForMessage(prefix, timeoutMs, testname);
+}
+
+inline std::string getResponseString(const std::shared_ptr<http::WebSocketSession>& ws,
+                                     const std::string& prefix, const std::string& testname,
+                                     const std::chrono::milliseconds timeoutMs
+                                     = std::chrono::seconds(10))
+{
+    const std::vector<char> response = ws->waitForMessage(prefix, timeoutMs, testname);
+
+    return std::string(response.data(), response.size());
+}
+
 inline std::vector<char> getResponseMessage(const std::shared_ptr<LOOLWebSocket>& ws,
                                             const std::string& prefix, const std::string& testname,
                                             const std::chrono::milliseconds timeoutMs
@@ -434,16 +452,6 @@ std::string getResponseString(T& ws, const std::string& prefix, const std::strin
                               const std::chrono::milliseconds timeoutMs = std::chrono::seconds(10))
 {
     const auto response = getResponseMessage(ws, prefix, testname, timeoutMs);
-    return std::string(response.data(), response.size());
-}
-
-inline std::string getResponseString(const std::shared_ptr<http::WebSocketSession>& ws,
-                                     const std::string& prefix, const std::string& testname,
-                                     const std::chrono::milliseconds timeoutMs
-                                     = std::chrono::seconds(10))
-{
-    const std::vector<char> response = ws->waitForMessage(prefix, timeoutMs, testname);
-
     return std::string(response.data(), response.size());
 }
 

--- a/test/helpers.hpp
+++ b/test/helpers.hpp
@@ -569,6 +569,55 @@ connectLOKit(const Poco::URI& uri,
     throw std::runtime_error("Cannot connect to [" + uri.toString() + "].");
 }
 
+// Connecting to a Kit process is managed by document broker, that it does several
+// jobs to establish the bridge connection between the Client and Kit process,
+// The result, it is mostly time outs to get messages in the unit test and it could fail.
+// connectLOKit ensures the websocket is connected to a kit process.
+inline std::shared_ptr<http::WebSocketSession> connectLOKit(SocketPoll& socketPoll,
+                                                            const Poco::URI& uri,
+                                                            const std::string& url,
+                                                            const std::string& testname)
+{
+    TST_LOG("Connecting to " << uri.toString());
+    constexpr int max_retries = 11;
+    int retries = max_retries - 1;
+    do
+    {
+        try
+        {
+            // Load a document and get its status.
+            auto ws = http::WebSocketSession::create(uri.toString());
+
+            TST_LOG("Connection to " << uri.toString() << " is "
+                                     << (ws->secure() ? "secure" : "plain"));
+
+            http::Request req(url);
+            ws->asyncRequest(req, socketPoll);
+
+            const char* expected_response = "statusindicator: ready";
+
+            TST_LOG("Connected to " << uri.toString() << ", waiting for response ["
+                                    << expected_response << "]");
+            if (getResponseString(ws, expected_response, testname) == expected_response)
+            {
+                return ws;
+            }
+
+            TST_LOG("ERROR: Reconnecting (retry #" << (max_retries - retries) << ") to "
+                                                   << uri.toString());
+        }
+        catch (const std::exception& ex)
+        {
+            TST_LOG("ERROR: Failed to connect to " << uri.toString() << ": " << ex.what());
+        }
+
+        std::this_thread::sleep_for(std::chrono::microseconds(POLL_TIMEOUT_MICRO_S));
+    } while (retries--);
+
+    TST_LOG("ERROR: Giving up connecting to " << uri.toString());
+    throw std::runtime_error("Cannot connect to [" + uri.toString() + "].");
+}
+
 inline
 std::shared_ptr<LOOLWebSocket> loadDocAndGetSocket(const Poco::URI& uri, const std::string& documentURL, const std::string& testname, bool isView = true, bool isAssert = true)
 {


### PR DESCRIPTION
- wsd: always include port in the Host header
- wsd: use Socket::eraseFirstInputBytes for a cleaner interface
- wsd: std::move better than copy-from-ref
- wsd: test: fixup helpers
- wsd: test: WebSocketSession helper
- wsd: improved WebSocketSession
- wsd: support asyncronous shutdown of WebSocketSession
- wsd: trap disconnection in WebSocketSession
- wsd: test: improved UnitLoad test
- wsd: test: killpoco in httpwstest
