### PR TITLE
Fix Rotation moves the center away on calc

### DIFF
--- a/loleaflet/src/layer/tile/TileLayer.js
+++ b/loleaflet/src/layer/tile/TileLayer.js
@@ -2998,6 +2998,9 @@ L.TileLayer = L.GridLayer.extend({
 		}
 		else if (e.type === 'rotateend') {
 			var center = this._graphicSelectionTwips.getCenter();
+			if (this.isCalc() && this.options.printTwipsMsgsEnabled) {
+				center = this.sheetGeometry.getPrintTwipsPointFromTile(center);
+			}
 			var param = {
 				TransformRotationDeltaAngle: {
 					type: 'long',


### PR DESCRIPTION
For calc, gridoffset must be taken into account
when calculating the center point of the shape
otherwise the coordinates will not match with
core

Signed-off-by: merttumer <mert.tumer@collabora.com>
Change-Id: Ie1003d52f233a79e5b1640c2cf7a095a7315a749


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

