### PR TITLE
Impress: Fix #presentation-toolbar on chrome

### DIFF
--- a/loleaflet/css/loleaflet.css
+++ b/loleaflet/css/loleaflet.css
@@ -167,7 +167,7 @@ body {
 	top: 77px;
 	left: 0px;
 	bottom: 33px;
-	max-width: 218px;
+	max-width: 194px;
 	border-top: 1px solid var(--gray-color);
 	display: block;
 }

--- a/loleaflet/css/partsPreviewControl.css
+++ b/loleaflet/css/partsPreviewControl.css
@@ -7,7 +7,7 @@
 	min-width: 194px;
 	white-space: nowrap;
 	overflow-x: hidden;
-	overflow-y: scroll;
+	overflow-y: visible;
 	background: #dfdfdf;
 	scrollbar-color: #ccc #dfdfdf;
 	scrollbar-width: thin;

--- a/loleaflet/css/toolbar.css
+++ b/loleaflet/css/toolbar.css
@@ -99,6 +99,7 @@ w2ui-toolbar {
 	position: absolute;
 	z-index: 500;
 	width: 100%;
+	max-width: 194px;
 	padding-bottom: 0px;
 	margin-top: -1px;
 	border-bottom: none;


### PR DESCRIPTION
- Make sure width doesn't get above the available space
- Do not force scrollbar when there is no content to scroll
  - use visible (default): implicitly compute to auto

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ib7b6b15dcf093d6172a35346679a7985584f4ef9
