### PR TITLE
leaflet: enable comments for PDF in mobile

### DIFF
--- a/loleaflet/css/mobilewizard.css
+++ b/loleaflet/css/mobilewizard.css
@@ -263,7 +263,7 @@ p.mobile-wizard.ui-combobox-text.selected {
 	width: 100%;
 	position: fixed;
 	bottom: 0px;
-	z-index: 1000;
+	z-index: 1001;
 	background-color: white;
 	box-shadow: 0px -2px 4px 1px #00000030;
 	overflow-y: hidden;

--- a/loleaflet/src/control/Control.JSDialogBuilder.js
+++ b/loleaflet/src/control/Control.JSDialogBuilder.js
@@ -2216,7 +2216,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			}, data.annotation);
 		}
 
-		if (data.annotation.options.noMenu !== true && this.map.isPermissionEditForComments() && !this.map.isPermissionReadOnly()) {
+		if (data.annotation.options.noMenu !== true && this.map.isPermissionEditForComments()) {
 			var tdMenu = L.DomUtil.create(tagTd, 'loleaflet-annotation-menubar', tr);
 			var divMenu = data.annotation._menu = L.DomUtil.create(tagDiv, data.data.trackchange ? 'loleaflet-annotation-menu-redline' : 'loleaflet-annotation-menu', tdMenu);
 			divMenu.title = _('Open menu');
@@ -2313,7 +2313,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		var textNode = L.DomUtil.create('figcaption', 'empty-comment-wizard', emptyCommentWizard);
 		textNode.innerText = data.text;
 		L.DomUtil.create('br', 'empty-comment-wizard', textNode);
-		if (this.map.isPermissionEditForComments() && !this.map.isPermissionReadOnly()) {
+		if (this.map.isPermissionEditForComments()) {
 			var linkNode = L.DomUtil.create('div', 'empty-comment-wizard-link', textNode);
 			linkNode.innerText = _('Insert Comment');
 			linkNode.onclick = builder.map.insertComment.bind(builder.map);

--- a/loleaflet/src/control/Control.MobileTopBar.js
+++ b/loleaflet/src/control/Control.MobileTopBar.js
@@ -61,6 +61,10 @@ L.Control.MobileTopBar = L.Control.extend({
 				{type: 'button',  id: 'comment_wizard', img: 'viewcomments'},
 				{type: 'drop', id: 'userlist', img: 'users', hidden: true, html: L.control.createUserListWidget()},
 			];
+		} else if (docType == 'drawing') {
+			return [
+				{type: 'button',  id: 'comment_wizard', img: 'viewcomments'}
+			];
 		}
 	},
 

--- a/loleaflet/src/control/Permission.js
+++ b/loleaflet/src/control/Permission.js
@@ -147,7 +147,10 @@ L.Map.include({
 	},
 
 	isPermissionEditForComments: function() {
-		return true;
+		// Currently we allow user to perform comment operations
+		// even in the view/readonly mode(initial mobile mode)
+		// allow comment operations if user has edit permission for doc
+		return window.docPermission === 'edit';
 	},
 
 	isPermissionReadOnly: function() {

--- a/loleaflet/src/layer/tile/ImpressTileLayer.js
+++ b/loleaflet/src/layer/tile/ImpressTileLayer.js
@@ -333,8 +333,10 @@ L.ImpressTileLayer = L.CanvasTileLayer.extend({
 		if (this.lastWizardCommentHighlight) {
 			this.lastWizardCommentHighlight.removeClass('impress-comment-highlight');
 		}
-		this.lastWizardCommentHighlight = $(this._map._layers[annotation._annotationMarker._leaflet_id]._icon);
-		this.lastWizardCommentHighlight.addClass('impress-comment-highlight');
+		if (annotation._annotationMarker) {
+			this.lastWizardCommentHighlight = $(this._map._layers[annotation._annotationMarker._leaflet_id]._icon);
+			this.lastWizardCommentHighlight.addClass('impress-comment-highlight');
+		}
 	},
 
 	_removeHighlightSelectedWizardComment: function() {

--- a/loleaflet/src/layer/tile/TileLayer.js
+++ b/loleaflet/src/layer/tile/TileLayer.js
@@ -4064,7 +4064,7 @@ L.TileLayer = L.GridLayer.extend({
 				children : []
 			};
 
-			if (this._map.isPermissionEditForComments() && !this._map.isPermissionReadOnly())
+			if (this._map.isPermissionEditForComments())
 				menuStructure['customTitle'] = customTitleBar;
 		}
 


### PR DESCRIPTION


Signed-off-by: Pranam Lashkari <lpranam@collabora.com>
Change-Id: Ie80f9a808d0234f6c58b768fa27673c9fe50b122

### Summary
in addition, allow users to work with comments in read only mode
wizard z index increased to avoid mobile-edit-button overlapping it



### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

