### PR TITLE
leaflet: set mouse cursor on cursor show

### DIFF
--- a/loleaflet/src/layer/marker/TextInput.js
+++ b/loleaflet/src/layer/marker/TextInput.js
@@ -421,6 +421,7 @@ L.TextInput = L.Layer.extend({
 			// Display caret
 			this._map._docLayer._cursorMarker.add();
 		}
+		this._map._docLayer._cursorMarker.setMouseCursor();
 
 		// Move and display under-caret marker
 		if (L.Browser.touch) {


### PR DESCRIPTION

Signed-off-by: Pranam Lashkari <lpranam@collabora.com>
Change-Id: I6adda739dc26fb93857bf8dcf70348b07f8eab33



### Summary
This is absolutely necessary for impress,
if cursor visible state is not changed,
we do not add or remove the cursor,
which handles the mouse cursor

so we explicitly set mouse cursor

i.e: in impress try to edit in one text box,
now click on the text on another text box
the mouse cursor will be incorrectly set



### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

