### PR TITLE
Async WebSockets in Tests and Kill Poco

### DIFF
--- a/common/Clipboard.hpp
+++ b/common/Clipboard.hpp
@@ -58,7 +58,7 @@ struct ClipboardData
 
     void dumpState(std::ostream& os)
     {
-        os << "Clipboard with " << size() << " entries\n";
+        os << "Clipboard with " << size() << " entries:\n";
         for (size_t i = 0; i < size(); ++i)
             os << "\t[" << i << "] - size " << _content[i].size() <<
                 " type: '" << _mimeTypes[i] << "'\n";
@@ -74,7 +74,7 @@ struct ClipboardData
                 return true;
             }
         }
-        value = "";
+        value.clear();
         return false;
     }
 };

--- a/common/Unit.cpp
+++ b/common/Unit.cpp
@@ -140,15 +140,6 @@ void UnitBase::setTimeout(std::chrono::milliseconds timeoutMilliSeconds)
     LOG_TST(getTestname() << ": setTimeout: " << _timeoutMilliSeconds);
 }
 
-UnitBase::UnitBase()
-    : _dlHandle(nullptr),
-      _setRetValue(false),
-      _retValue(0),
-      _timeoutMilliSeconds(std::chrono::seconds(30)),
-      _type(UnitType::Wsd)
-{
-}
-
 UnitBase::~UnitBase()
 {
 // FIXME: we should really clean-up properly.

--- a/common/Unit.cpp
+++ b/common/Unit.cpp
@@ -156,12 +156,15 @@ UnitBase::~UnitBase()
 
 UnitWSD::UnitWSD(std::string testname)
     : UnitBase(std::move(testname))
+    , _socketPoll(getTestname())
     , _hasKitHooks(false)
 {
+    _socketPoll.startThread();
 }
 
 UnitWSD::~UnitWSD()
 {
+    _socketPoll.joinThread();
 }
 
 void UnitWSD::configure(Poco::Util::LayeredConfiguration &config)

--- a/common/Unit.cpp
+++ b/common/Unit.cpp
@@ -208,6 +208,7 @@ void UnitBase::exitTest(TestResult result)
     _setRetValue = true;
     _retValue = result == TestResult::Ok ? EX_OK : EX_SOFTWARE;
 #if !MOBILEAPP
+    LOG_INF("Setting ShutdownRequestFlag: " << getTestname() << " test has finished.");
     SigUtil::requestShutdown(); // And wakupWorld.
 #else
     SocketPoll::wakeupWorld();

--- a/common/Unit.cpp
+++ b/common/Unit.cpp
@@ -150,7 +150,6 @@ UnitBase::~UnitBase()
 
 UnitWSD::UnitWSD(std::string testname)
     : UnitBase(std::move(testname))
-    , _socketPoll(getTestname())
     , _hasKitHooks(false)
 {
     _socketPoll.startThread();

--- a/common/Unit.cpp
+++ b/common/Unit.cpp
@@ -146,18 +146,17 @@ UnitBase::~UnitBase()
 //    if (_dlHandle)
 //        dlclose(_dlHandle);
     _dlHandle = nullptr;
+    _socketPoll->joinThread();
 }
 
 UnitWSD::UnitWSD(std::string testname)
     : UnitBase(std::move(testname))
     , _hasKitHooks(false)
 {
-    _socketPoll.startThread();
 }
 
 UnitWSD::~UnitWSD()
 {
-    _socketPoll.joinThread();
 }
 
 void UnitWSD::configure(Poco::Util::LayeredConfiguration &config)

--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -259,6 +259,7 @@ private:
 /// Derive your WSD unit test / hooks from me.
 class UnitWSD : public UnitBase
 {
+    SocketPoll _socketPoll;
     bool _hasKitHooks;
 
 public:
@@ -271,6 +272,8 @@ public:
         assert(Global && Global->_type == UnitType::Wsd);
         return *static_cast<UnitWSD *>(Global);
     }
+
+    SocketPoll& socketPoll() { return _socketPoll; }
 
     enum class TestRequest
     {

--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -112,8 +112,9 @@ protected:
         , _timeoutMilliSeconds(std::chrono::seconds(30))
         , _type(UnitType::Wsd)
         , _testname(std::move(name))
-        , _socketPoll(_testname)
+        , _socketPoll(std::make_shared<SocketPoll>(_testname))
     {
+        _socketPoll->startThread();
     }
 
     virtual ~UnitBase();
@@ -234,7 +235,7 @@ public:
     const std::string& getTestname() const { return _testname; }
     void setTestname(const std::string& testname) { _testname = testname; }
 
-    SocketPoll& socketPoll() { return _socketPoll; }
+    std::shared_ptr<SocketPoll> socketPoll() { return _socketPoll; }
 
 private:
     void setHandle(void *dlHandle)
@@ -262,7 +263,7 @@ private:
     /// The name of the current test.
     std::string _testname;
 
-    SocketPoll _socketPoll; //< Poll thread for async http comm.
+    std::shared_ptr<SocketPoll> _socketPoll; //< Poll thread for async http comm.
 };
 
 /// Derive your WSD unit test / hooks from me.

--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -104,11 +104,15 @@ protected:
         exitTest(TestResult::Ok);
     }
 
-    UnitBase();
-    UnitBase(std::string name)
-        : UnitBase()
+    /// Construct a UnitBase instance with a default name.
+    explicit UnitBase(std::string name = "UnitBase")
+        : _dlHandle(nullptr)
+        , _setRetValue(false)
+        , _retValue(0)
+        , _timeoutMilliSeconds(std::chrono::seconds(30))
+        , _type(UnitType::Wsd)
+        , _testname(std::move(name))
     {
-        _testname = std::move(name);
     }
 
     virtual ~UnitBase();

--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -112,6 +112,7 @@ protected:
         , _timeoutMilliSeconds(std::chrono::seconds(30))
         , _type(UnitType::Wsd)
         , _testname(std::move(name))
+        , _socketPoll(_testname)
     {
     }
 
@@ -233,6 +234,8 @@ public:
     const std::string& getTestname() const { return _testname; }
     void setTestname(const std::string& testname) { _testname = testname; }
 
+    SocketPoll& socketPoll() { return _socketPoll; }
+
 private:
     void setHandle(void *dlHandle)
     {
@@ -258,12 +261,13 @@ private:
 
     /// The name of the current test.
     std::string _testname;
+
+    SocketPoll _socketPoll; //< Poll thread for async http comm.
 };
 
 /// Derive your WSD unit test / hooks from me.
 class UnitWSD : public UnitBase
 {
-    SocketPoll _socketPoll;
     bool _hasKitHooks;
 
 public:
@@ -276,8 +280,6 @@ public:
         assert(Global && Global->_type == UnitType::Wsd);
         return *static_cast<UnitWSD *>(Global);
     }
-
-    SocketPoll& socketPoll() { return _socketPoll; }
 
     enum class TestRequest
     {

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -1050,7 +1050,7 @@ public:
                             << Util::symbolicErrno(last_errno) << ": " << std::strerror(last_errno)
                             << ')');
 
-                if (len <= 0 && last_errno != EAGAIN && last_errno != EWOULDBLOCK)
+                if (len < 0 && last_errno != EAGAIN && last_errno != EWOULDBLOCK)
                     LOG_SYS_ERRNO(last_errno, '#' << getFD() << ": Socket read returned " << len);
             }
             while (len < 0 && last_errno == EINTR);

--- a/net/WebSocketSession.hpp
+++ b/net/WebSocketSession.hpp
@@ -279,9 +279,12 @@ public:
 private:
     void handleMessage(const std::vector<char>& data) override
     {
-        LOG_DBG("Got message: " << LOOLProtocol::getFirstLine(data));
-        std::unique_lock<std::mutex> lock(_inMutex);
-        _inQueue.put(data);
+        LOG_DBG("Got message: " << LOOLProtocol::getAbbreviatedMessage(data));
+        {
+            std::unique_lock<std::mutex> lock(_inMutex);
+            _inQueue.put(data);
+        }
+
         _inCv.notify_one();
     }
 
@@ -354,8 +357,11 @@ private:
 
     void onDisconnect() override
     {
-        std::unique_lock<std::mutex> lock(_outMutex);
-        _disconnected = true;
+        {
+            std::unique_lock<std::mutex> lock(_outMutex);
+            _disconnected = true;
+        }
+
         _disconnectCv.notify_all();
     }
 

--- a/test/HttpTestServer.hpp
+++ b/test/HttpTestServer.hpp
@@ -107,11 +107,17 @@ private:
 
                 socket->send(response);
             }
+            else if (request.getUrl() == "/timeout")
+            {
+                // Don't send anything back.
+            }
             else
             {
                 http::Response response(http::StatusLine(200));
                 if (Util::startsWith(request.getUrl(), "/echo/"))
                     response.setBody(request.getUrl().substr(sizeof("/echo")));
+                else
+                    response.setBody("You have reached HttpTestServer " + request.getUrl());
                 socket->send(response);
             }
         }

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -251,28 +251,9 @@ TESTS = \
 	unit-wopi-temp.la \
 	unit-wopi-fileurl.la \
 	unit-wopi-httpheaders.la \
-	${top_builddir}/test/unithttplib
+	unithttplib
 # TESTS += unit-admin.test
 # TESTS += unit-storage.test
-
-# Start forced grouping of tests using stamp files
-
-group0.log: unit-integration.log \
-			unit-tiletest.log unit-insert-delete.log unit-crash.log unit-each-view.log \
-			unit-httpws.log unit-close.log unit-wopi-documentconflict.log unit-prefork.log \
-			unit-wopi-versionrestore.log unit-wopi-temp.log unit-wopi-fileurl.log \
-			unit_wopi_renamefile.log unit_wopi_watermark.log unit-wopi.log \
-			unit-wopi-ownertermination.log unit-load-torture.log unit-wopi-saveas.log \
-			unit-password-protected.log unit-http.log unit-tiff-load.log unit-render-shape.log \
-			unit-oauth.log unit-large-paste.log unit-paste.log unit-rendering-options.log \
-			unit-session.log unit-uno-command.log unit-load.log unit-cursor.log unit-calc.log \
-			unit-bad-doc-load.log unit-hosting.log unit-wopi-loadencoded.log \
-			unit-convert.log unit-typing.log unit-tilecache.log unit-timeout.log unit-base.log \
-			unit-wopi-httpheaders.log unit-copy-paste.log
-	$(CLEANUP_COMMAND)
-	touch $@
-
-# end forced grouping
 
 endif
 

--- a/test/TileCacheTests.cpp
+++ b/test/TileCacheTests.cpp
@@ -54,7 +54,7 @@ class TileCacheTests : public CPPUNIT_NS::TestFixture
 {
     const Poco::URI _uri;
     Poco::Net::HTTPResponse _response;
-    SocketPoll _socketPoll;
+    std::shared_ptr<SocketPoll> _socketPoll;
 
     CPPUNIT_TEST_SUITE(TileCacheTests);
 
@@ -144,7 +144,7 @@ class TileCacheTests : public CPPUNIT_NS::TestFixture
 public:
     TileCacheTests()
         : _uri(helpers::getTestServerURI())
-        , _socketPoll("TileCachePoll")
+        , _socketPoll(std::make_shared<SocketPoll>("TileCachePoll"))
     {
 #if ENABLE_SSL
         Poco::Net::initializeSSL();
@@ -165,18 +165,18 @@ public:
 
     void setUp()
     {
-        _socketPoll.startThread();
         resetTestStartTime();
         testCountHowManyLoolkits();
         resetTestStartTime();
+        _socketPoll->startThread();
     }
 
     void tearDown()
     {
+        _socketPoll->joinThread();
         resetTestStartTime();
         testNoExtraLoolKitsLeft();
         resetTestStartTime();
-        _socketPoll.joinThread();
     }
 };
 
@@ -269,8 +269,8 @@ void TileCacheTests::testSimpleCombine()
     std::vector<char> tile2b = getResponseMessage(socket2, "tile:", testname + "2 ");
     LOK_ASSERT_MESSAGE("did not receive a tile: message as expected", !tile2b.empty());
 
-    socket1->asyncShutdown(_socketPoll);
-    socket2->asyncShutdown(_socketPoll);
+    socket1->asyncShutdown();
+    socket2->asyncShutdown();
 
     LOK_ASSERT_MESSAGE("Expected successful disconnection of the WebSocket 1",
                        socket1->waitForDisconnection(std::chrono::seconds(5)));
@@ -342,7 +342,7 @@ void TileCacheTests::testCancelTiles()
             TST_LOG("Unexpected: [" << res << ']');
         }
 
-        socket->asyncShutdown(_socketPoll);
+        socket->asyncShutdown();
         LOK_ASSERT_MESSAGE("Expected successful disconnection of the WebSocket 1",
                            socket->waitForDisconnection(std::chrono::seconds(5)));
         if (res.empty())
@@ -418,8 +418,8 @@ void TileCacheTests::testCancelTilesMultiView()
             continue;
         }
 
-        socket1->asyncShutdown(_socketPoll);
-        socket2->asyncShutdown(_socketPoll);
+        socket1->asyncShutdown();
+        socket2->asyncShutdown();
 
         LOK_ASSERT_MESSAGE("Expected successful disconnection of the WebSocket 1",
                            socket1->waitForDisconnection(std::chrono::seconds(5)));
@@ -464,7 +464,7 @@ void TileCacheTests::testDisconnectMultiView()
                       "tileposy=0,0,0,22520 tilewidth=3840 tileheight=3840",
                       "cancelTilesMultiView-2 ");
 
-        socket1->asyncShutdown(_socketPoll);
+        socket1->asyncShutdown();
 
         for (int i = 0; i < 4; ++i)
         {
@@ -475,7 +475,7 @@ void TileCacheTests::testDisconnectMultiView()
         getResponseString(socket2, "tile:", "disconnectMultiView-2 ",
                           std::chrono::milliseconds(500));
 
-        socket2->asyncShutdown(_socketPoll);
+        socket2->asyncShutdown();
 
         LOK_ASSERT_MESSAGE("Expected successful disconnection of the WebSocket 1",
                            socket1->waitForDisconnection(std::chrono::seconds(5)));
@@ -543,8 +543,8 @@ void TileCacheTests::testUnresponsiveClient()
         sendTextFrame(socket2, "canceltiles", testname + "2 ");
     }
 
-    socket1->asyncShutdown(_socketPoll);
-    socket2->asyncShutdown(_socketPoll);
+    socket1->asyncShutdown();
+    socket2->asyncShutdown();
 
     LOK_ASSERT_MESSAGE("Expected successful disconnection of the WebSocket 1",
                        socket1->waitForDisconnection(std::chrono::seconds(5)));
@@ -566,7 +566,7 @@ void TileCacheTests::testImpressTiles()
                       testName);
         getTileMessage(socket, testName);
 
-        socket->asyncShutdown(_socketPoll);
+        socket->asyncShutdown();
         LOK_ASSERT_MESSAGE("Expected successful disconnection of the WebSocket",
                            socket->waitForDisconnection(std::chrono::seconds(5)));
     }
@@ -586,7 +586,7 @@ void TileCacheTests::testClientPartImpress()
 
         checkTiles(socket, "presentation", testName);
 
-        socket->asyncShutdown(_socketPoll);
+        socket->asyncShutdown();
         LOK_ASSERT_MESSAGE("Expected successful disconnection of the WebSocket",
                            socket->waitForDisconnection(std::chrono::seconds(5)));
     }
@@ -606,7 +606,7 @@ void TileCacheTests::testClientPartCalc()
 
         checkTiles(socket, "spreadsheet", testName);
 
-        socket->asyncShutdown(_socketPoll);
+        socket->asyncShutdown();
         LOK_ASSERT_MESSAGE("Expected successful disconnection of the WebSocket",
                            socket->waitForDisconnection(std::chrono::seconds(5)));
     }
@@ -676,7 +676,7 @@ void TileCacheTests::testTilesRenderedJustOnce()
         LOK_ASSERT_EQUAL(renderCount2, renderCount3);
     }
 
-    socket->asyncShutdown(_socketPoll);
+    socket->asyncShutdown();
     LOK_ASSERT_MESSAGE("Expected successful disconnection of the WebSocket",
                        socket->waitForDisconnection(std::chrono::seconds(5)));
 }
@@ -1493,7 +1493,7 @@ void TileCacheTests::testTileRequestByInvalidation()
     // Then sends the new tile which was invalidated inside the visible area
     assertResponseString(socket, "tile:", testname);
 
-    socket->asyncShutdown(_socketPoll);
+    socket->asyncShutdown();
     socket->waitForDisconnection(std::chrono::seconds(5));
 }
 

--- a/test/TileCacheTests.cpp
+++ b/test/TileCacheTests.cpp
@@ -125,26 +125,19 @@ class TileCacheTests : public CPPUNIT_NS::TestFixture
     void testLimitTileVersionsOnFly();
 
     void checkTiles(std::shared_ptr<http::WebSocketSession>& socket, const std::string& docType,
-                    const std::string& name);
-    void checkTiles(std::shared_ptr<LOOLWebSocket>& socket,
-                    const std::string& type,
-                    const std::string& name = "checkTiles ");
+                    const std::string& testname);
+    void checkTiles(std::shared_ptr<LOOLWebSocket>& socket, const std::string& type,
+                    const std::string& testname);
 
     void requestTiles(std::shared_ptr<http::WebSocketSession>& socket, const std::string& docType,
                       const int part, const int docWidth, const int docHeight,
-                      const std::string& name = "requestTiles ");
-    void requestTiles(std::shared_ptr<LOOLWebSocket>& socket,
-                      const std::string& docType,
-                      const int part,
-                      const int docWidth,
-                      const int docHeight,
-                      const std::string& name = "requestTiles ");
+                      const std::string& testname);
+    void requestTiles(std::shared_ptr<LOOLWebSocket>& socket, const std::string& docType,
+                      const int part, const int docWidth, const int docHeight,
+                      const std::string& testname);
 
-    void checkBlackTiles(std::shared_ptr<LOOLWebSocket>& socket,
-                         const int part,
-                         const int docWidth,
-                         const int docHeight,
-                         const std::string& name = "checkBlackTiles ");
+    void checkBlackTiles(std::shared_ptr<LOOLWebSocket>& socket, const int part, const int docWidth,
+                         const int docHeight, const std::string& testname);
 
     void checkBlackTile(std::stringstream& tile);
 
@@ -882,7 +875,9 @@ void TileCacheTests::checkBlackTile(std::stringstream& tile)
     LOK_ASSERT_MESSAGE("The tile is 90% black", (black * 100) / (height * width) < 90);
 }
 
-void TileCacheTests::checkBlackTiles(std::shared_ptr<LOOLWebSocket>& socket, const int /*part*/, const int /*docWidth*/, const int /*docHeight*/, const std::string& name)
+void TileCacheTests::checkBlackTiles(std::shared_ptr<LOOLWebSocket>& socket, const int /*part*/,
+                                     const int /*docWidth*/, const int /*docHeight*/,
+                                     const std::string& testname)
 {
     // Check the last row of tiles to verify that the tiles
     // render correctly and there are no black tiles.
@@ -891,7 +886,7 @@ void TileCacheTests::checkBlackTiles(std::shared_ptr<LOOLWebSocket>& socket, con
     const char* req = "tile nviewid=0 part=0 width=256 height=256 tileposx=0 tileposy=253440 tilewidth=3840 tileheight=3840";
     sendTextFrame(socket, req);
 
-    const std::vector<char> tile = getResponseMessage(socket, "tile:", name);
+    const std::vector<char> tile = getResponseMessage(socket, "tile:", testname);
     if (!tile.size())
     {
         LOK_ASSERT_FAIL("No tile returned to checkBlackTiles - failed load ?");
@@ -1160,9 +1155,8 @@ void TileCacheTests::testTileInvalidatePartImpress()
 }
 
 void TileCacheTests::checkTiles(std::shared_ptr<http::WebSocketSession>& socket,
-                                const std::string& docType, const std::string& name)
+                                const std::string& docType, const std::string& testname)
 {
-    const char* testname = "checkTiles";
     const std::string current = "current=";
     const std::string height = "height=";
     const std::string parts = "parts=";
@@ -1175,8 +1169,8 @@ void TileCacheTests::checkTiles(std::shared_ptr<http::WebSocketSession>& socket,
     int docWidth = 0;
 
     // check total slides 10
-    sendTextFrame(socket, "status", name);
-    const auto response = assertResponseString(socket, "status:", name);
+    sendTextFrame(socket, "status", testname);
+    const auto response = assertResponseString(socket, "status:", testname);
     {
         std::string line;
         std::istringstream istr(response.substr(8));
@@ -1213,7 +1207,7 @@ void TileCacheTests::checkTiles(std::shared_ptr<http::WebSocketSession>& socket,
     {
         // request tiles
         TST_LOG("Requesting Impress tiles.");
-        requestTiles(socket, docType, currentPart, docWidth, docHeight, name);
+        requestTiles(socket, docType, currentPart, docWidth, docHeight, testname);
     }
 
     // random setclientpart
@@ -1227,17 +1221,18 @@ void TileCacheTests::checkTiles(std::shared_ptr<http::WebSocketSession>& socket,
         {
             // change part
             const std::string text = Poco::format("setclientpart part=%d", it);
-            sendTextFrame(socket, text, name);
+            sendTextFrame(socket, text, testname);
             // Wait for the change to take effect otherwise we get invalidatetile
             // which removes our next tile request subscription (expecting us to
             // issue a new tile request as a response, which a real client would do).
-            assertResponseString(socket, "setpart:", name);
+            assertResponseString(socket, "setpart:", testname);
 
-            requestTiles(socket, docType, it, docWidth, docHeight, name);
+            requestTiles(socket, docType, it, docWidth, docHeight, testname);
 
             if (++requests >= 3)
             {
                 // No need to test all parts.
+                TST_LOG("Breaking checkTiles for " << testname);
                 break;
             }
         }
@@ -1248,7 +1243,7 @@ void TileCacheTests::checkTiles(std::shared_ptr<http::WebSocketSession>& socket,
 
 void TileCacheTests::requestTiles(std::shared_ptr<http::WebSocketSession>& socket,
                                   const std::string&, const int part, const int docWidth,
-                                  const int docHeight, const std::string& name)
+                                  const int docHeight, const std::string& testname)
 {
     // twips
     const int tileSize = 3840;
@@ -1267,6 +1262,8 @@ void TileCacheTests::requestTiles(std::shared_ptr<http::WebSocketSession>& socke
 
     rows = docHeight / tileSize;
     cols = docWidth / tileSize;
+    TST_LOG("requestTiles for " << testname << " will request " << rows << " rows and " << cols
+                                << " cols.");
 
     // Note: this code tests tile requests in the wrong way.
 
@@ -1292,8 +1289,8 @@ void TileCacheTests::requestTiles(std::shared_ptr<http::WebSocketSession>& socke
                                "tilewidth=%d tileheight=%d",
                                part, pixTileSize, pixTileSize, tileX, tileY, tileWidth, tileHeight);
 
-            sendTextFrame(socket, text, name);
-            tile = assertResponseString(socket, "tile:", name);
+            sendTextFrame(socket, text, testname);
+            tile = assertResponseString(socket, "tile:", testname);
             // expected tile: part= width= height= tileposx= tileposy= tilewidth= tileheight=
             StringVector tokens(Util::tokenize(tile, ' '));
             LOK_ASSERT_EQUAL(std::string("tile:"), tokens[0]);
@@ -1311,11 +1308,13 @@ void TileCacheTests::requestTiles(std::shared_ptr<http::WebSocketSession>& socke
                              std::stoi(tokens[8].substr(std::string("tileHeight=").size())));
         }
     }
+
+    TST_LOG("requestTiles for " << testname << " finished.");
 }
 
-void TileCacheTests::checkTiles(std::shared_ptr<LOOLWebSocket>& socket, const std::string& docType, const std::string& name)
+void TileCacheTests::checkTiles(std::shared_ptr<LOOLWebSocket>& socket, const std::string& docType,
+                                const std::string& testname)
 {
-    const char* testname = "checkTiles";
     const std::string current = "current=";
     const std::string height = "height=";
     const std::string parts = "parts=";
@@ -1328,8 +1327,8 @@ void TileCacheTests::checkTiles(std::shared_ptr<LOOLWebSocket>& socket, const st
     int docWidth = 0;
 
     // check total slides 10
-    sendTextFrame(socket, "status", name);
-    const auto response = assertResponseString(socket, "status:", name);
+    sendTextFrame(socket, "status", testname);
+    const auto response = assertResponseString(socket, "status:", testname);
     {
         std::string line;
         std::istringstream istr(response.substr(8));
@@ -1365,7 +1364,7 @@ void TileCacheTests::checkTiles(std::shared_ptr<LOOLWebSocket>& socket, const st
     {
         // request tiles
         TST_LOG("Requesting Impress tiles.");
-        requestTiles(socket, docType, currentPart, docWidth, docHeight, name);
+        requestTiles(socket, docType, currentPart, docWidth, docHeight, testname);
     }
 
     // random setclientpart
@@ -1379,13 +1378,13 @@ void TileCacheTests::checkTiles(std::shared_ptr<LOOLWebSocket>& socket, const st
         {
             // change part
             const std::string text = Poco::format("setclientpart part=%d", it);
-            sendTextFrame(socket, text, name);
+            sendTextFrame(socket, text, testname);
             // Wait for the change to take effect otherwise we get invalidatetile
             // which removes our next tile request subscription (expecting us to
             // issue a new tile request as a response, which a real client would do).
-            assertResponseString(socket, "setpart:", name);
+            assertResponseString(socket, "setpart:", testname);
 
-            requestTiles(socket, docType, it, docWidth, docHeight, name);
+            requestTiles(socket, docType, it, docWidth, docHeight, testname);
 
             if (++requests >= 3)
             {
@@ -1400,7 +1399,7 @@ void TileCacheTests::checkTiles(std::shared_ptr<LOOLWebSocket>& socket, const st
 
 void TileCacheTests::requestTiles(std::shared_ptr<LOOLWebSocket>& socket,
                                   const std::string& , const int part, const int docWidth,
-                                  const int docHeight, const std::string& name)
+                                  const int docHeight, const std::string& testname)
 {
     // twips
     const int tileSize = 3840;
@@ -1442,8 +1441,8 @@ void TileCacheTests::requestTiles(std::shared_ptr<LOOLWebSocket>& socket,
             text = Poco::format("tile nviewid=0 part=%d width=%d height=%d tileposx=%d tileposy=%d tilewidth=%d tileheight=%d",
                                 part, pixTileSize, pixTileSize, tileX, tileY, tileWidth, tileHeight);
 
-            sendTextFrame(socket, text, name);
-            tile = assertResponseString(socket, "tile:", name);
+            sendTextFrame(socket, text, testname);
+            tile = assertResponseString(socket, "tile:", testname);
             // expected tile: part= width= height= tileposx= tileposy= tilewidth= tileheight=
             StringVector tokens(Util::tokenize(tile, ' '));
             LOK_ASSERT_EQUAL(std::string("tile:"), tokens[0]);

--- a/test/TileCacheTests.cpp
+++ b/test/TileCacheTests.cpp
@@ -136,6 +136,9 @@ class TileCacheTests : public CPPUNIT_NS::TestFixture
                       const int part, const int docWidth, const int docHeight,
                       const std::string& testname);
 
+    void checkBlackTiles(std::shared_ptr<http::WebSocketSession>& socket, const int /*part*/,
+                         const int /*docWidth*/, const int /*docHeight*/,
+                         const std::string& testname);
     void checkBlackTiles(std::shared_ptr<LOOLWebSocket>& socket, const int part, const int docWidth,
                          const int docHeight, const std::string& testname);
 
@@ -556,15 +559,15 @@ void TileCacheTests::testImpressTiles()
 {
     try
     {
-        const std::string testName = "impressTiles ";
+        const std::string testname = "impressTiles ";
         std::shared_ptr<http::WebSocketSession> socket
-            = loadDocAndGetSession(_socketPoll, "setclientpart.odp", _uri, testName);
+            = loadDocAndGetSession(_socketPoll, "setclientpart.odp", _uri, testname);
 
         sendTextFrame(socket,
                       "tile nviewid=0 part=0 width=180 height=135 tileposx=0 tileposy=0 "
                       "tilewidth=15875 tileheight=11906 id=0",
-                      testName);
-        getTileMessage(socket, testName);
+                      testname);
+        getTileMessage(socket, testname);
 
         socket->asyncShutdown();
         LOK_ASSERT_MESSAGE("Expected successful disconnection of the WebSocket",
@@ -580,11 +583,11 @@ void TileCacheTests::testClientPartImpress()
 {
     try
     {
-        const std::string testName = "clientPartImpress ";
+        const std::string testname = "clientPartImpress ";
         std::shared_ptr<http::WebSocketSession> socket
-            = loadDocAndGetSession(_socketPoll, "setclientpart.odp", _uri, testName);
+            = loadDocAndGetSession(_socketPoll, "setclientpart.odp", _uri, testname);
 
-        checkTiles(socket, "presentation", testName);
+        checkTiles(socket, "presentation", testname);
 
         socket->asyncShutdown();
         LOK_ASSERT_MESSAGE("Expected successful disconnection of the WebSocket",
@@ -600,11 +603,11 @@ void TileCacheTests::testClientPartCalc()
 {
     try
     {
-        const std::string testName = "clientPartCalc ";
+        const std::string testname = "clientPartCalc ";
         std::shared_ptr<http::WebSocketSession> socket
-            = loadDocAndGetSession(_socketPoll, "setclientpart.ods", _uri, testName);
+            = loadDocAndGetSession(_socketPoll, "setclientpart.ods", _uri, testname);
 
-        checkTiles(socket, "spreadsheet", testName);
+        checkTiles(socket, "spreadsheet", testname);
 
         socket->asyncShutdown();
         LOK_ASSERT_MESSAGE("Expected successful disconnection of the WebSocket",
@@ -693,38 +696,42 @@ void TileCacheTests::testTilesRenderedJustOnceMultiClient()
     getDocumentPathAndURL("with_comment.odt", documentPath, documentURL, testname);
 
     TST_LOG("Connecting first client.");
-    std::shared_ptr<LOOLWebSocket> socket = loadDocAndGetSocket(_uri, documentURL, testname1);
+    std::shared_ptr<http::WebSocketSession> socket1
+        = loadDocAndGetSession(_socketPoll, _uri, documentURL, testname1);
     TST_LOG("Connecting second client.");
-    std::shared_ptr<LOOLWebSocket> socket2 = loadDocAndGetSocket(_uri, documentURL, testname2);
+    std::shared_ptr<http::WebSocketSession> socket2
+        = loadDocAndGetSession(_socketPoll, _uri, documentURL, testname2);
     TST_LOG("Connecting third client.");
-    std::shared_ptr<LOOLWebSocket> socket3 = loadDocAndGetSocket(_uri, documentURL, testname3);
+    std::shared_ptr<http::WebSocketSession> socket3
+        = loadDocAndGetSession(_socketPoll, _uri, documentURL, testname3);
     TST_LOG("Connecting fourth client.");
-    std::shared_ptr<LOOLWebSocket> socket4 = loadDocAndGetSocket(_uri, documentURL, "tilesRenderdJustOnce-4 ");
+    std::shared_ptr<http::WebSocketSession> socket4
+        = loadDocAndGetSession(_socketPoll, _uri, documentURL, testname4);
 
     for (int i = 0; i < 10; ++i)
     {
         // No tiles at this point.
-        assertNotInResponse(socket, "tile:", testname1);
+        assertNotInResponse(socket1, "tile:", testname1);
         assertNotInResponse(socket2, "tile:", testname2);
         assertNotInResponse(socket3, "tile:", testname3);
         assertNotInResponse(socket4, "tile:", testname4);
 
         // Get initial rendercount.
-        sendTextFrame(socket, "ping", testname1);
-        const auto ping1 = assertResponseString(socket, "pong", testname1);
+        sendTextFrame(socket1, "ping", testname1);
+        const auto ping1 = assertResponseString(socket1, "pong", testname1);
         int renderCount1 = 0;
         LOK_ASSERT(LOOLProtocol::getTokenIntegerFromMessage(ping1, "rendercount", renderCount1));
         LOK_ASSERT_EQUAL(i * 3, renderCount1);
 
         // Modify.
-        sendText(socket, "a", testname1);
-        assertResponseString(socket, "invalidatetiles:", testname1);
+        sendText(socket1, "a", testname1);
+        assertResponseString(socket1, "invalidatetiles:", testname1);
 
         // Get 3 tiles.
-        sendTextFrame(socket, "tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0,3840,7680 tileposy=0,0,0 tilewidth=3840 tileheight=3840", testname1);
-        assertResponseString(socket, "tile:", testname1);
-        assertResponseString(socket, "tile:", testname1);
-        assertResponseString(socket, "tile:", testname1);
+        sendTextFrame(socket1, "tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0,3840,7680 tileposy=0,0,0 tilewidth=3840 tileheight=3840", testname1);
+        assertResponseString(socket1, "tile:", testname1);
+        assertResponseString(socket1, "tile:", testname1);
+        assertResponseString(socket1, "tile:", testname1);
 
         assertResponseString(socket2, "invalidatetiles:", testname2);
         sendTextFrame(socket2, "tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0,3840,7680 tileposy=0,0,0 tilewidth=3840 tileheight=3840", testname2);
@@ -745,48 +752,64 @@ void TileCacheTests::testTilesRenderedJustOnceMultiClient()
         assertResponseString(socket4, "tile:", testname4);
 
         // Get new rendercount.
-        sendTextFrame(socket, "ping", testname1);
-        const auto ping2 = assertResponseString(socket, "pong", testname1);
+        sendTextFrame(socket1, "ping", testname1);
+        const auto ping2 = assertResponseString(socket1, "pong", testname1);
         int renderCount2 = 0;
         LOK_ASSERT(LOOLProtocol::getTokenIntegerFromMessage(ping2, "rendercount", renderCount2));
         LOK_ASSERT_EQUAL((i+1) * 3, renderCount2);
 
         // Get same 3 tiles.
-        sendTextFrame(socket, "tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0,3840,7680 tileposy=0,0,0 tilewidth=3840 tileheight=3840", testname1);
-        const auto tile1 = assertResponseString(socket, "tile:", testname1);
+        sendTextFrame(socket1, "tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0,3840,7680 tileposy=0,0,0 tilewidth=3840 tileheight=3840", testname1);
+        const auto tile1 = assertResponseString(socket1, "tile:", testname1);
         std::string renderId1;
         LOOLProtocol::getTokenStringFromMessage(tile1, "renderid", renderId1);
         LOK_ASSERT_EQUAL(std::string("cached"), renderId1);
 
-        const auto tile2 = assertResponseString(socket, "tile:", testname1);
+        const auto tile2 = assertResponseString(socket1, "tile:", testname1);
         std::string renderId2;
         LOOLProtocol::getTokenStringFromMessage(tile2, "renderid", renderId2);
         LOK_ASSERT_EQUAL(std::string("cached"), renderId2);
 
-        const auto tile3 = assertResponseString(socket, "tile:", testname1);
+        const auto tile3 = assertResponseString(socket1, "tile:", testname1);
         std::string renderId3;
         LOOLProtocol::getTokenStringFromMessage(tile3, "renderid", renderId3);
         LOK_ASSERT_EQUAL(std::string("cached"), renderId3);
 
         // Get new rendercount.
-        sendTextFrame(socket, "ping", testname1);
-        const auto ping3 = assertResponseString(socket, "pong", testname1);
+        sendTextFrame(socket1, "ping", testname1);
+        const auto ping3 = assertResponseString(socket1, "pong", testname1);
         int renderCount3 = 0;
         LOK_ASSERT(LOOLProtocol::getTokenIntegerFromMessage(ping3, "rendercount", renderCount3));
         LOK_ASSERT_EQUAL(renderCount2, renderCount3);
     }
+
+    socket1->asyncShutdown();
+    socket2->asyncShutdown();
+    socket3->asyncShutdown();
+    socket4->asyncShutdown();
+
+    LOK_ASSERT_MESSAGE("Expected successful disconnection of the WebSocket 1",
+                       socket1->waitForDisconnection(std::chrono::seconds(5)));
+    LOK_ASSERT_MESSAGE("Expected successful disconnection of the WebSocket 2",
+                       socket2->waitForDisconnection(std::chrono::seconds(5)));
+    LOK_ASSERT_MESSAGE("Expected successful disconnection of the WebSocket 3",
+                       socket3->waitForDisconnection(std::chrono::seconds(5)));
+    LOK_ASSERT_MESSAGE("Expected successful disconnection of the WebSocket 4",
+                       socket4->waitForDisconnection(std::chrono::seconds(5)));
 }
 
 void TileCacheTests::testSimultaneousTilesRenderedJustOnce()
 {
-    const char* testname = "testSimultaneousTilesRenderedJustOnce";
+    const std::string testname = "testSimultaneousTilesRenderedJustOnce-";
     std::string documentPath, documentURL;
-    getDocumentPathAndURL("hello.odt", documentPath, documentURL, "simultaneousTilesrenderedJustOnce ");
+    getDocumentPathAndURL("hello.odt", documentPath, documentURL, testname);
 
     TST_LOG("Connecting first client.");
-    std::shared_ptr<LOOLWebSocket> socket1 = loadDocAndGetSocket(_uri, documentURL, "simultaneousTilesRenderdJustOnce-1 ");
+    std::shared_ptr<http::WebSocketSession> socket1
+        = loadDocAndGetSession(_socketPoll, _uri, documentURL, testname + "1 ");
     TST_LOG("Connecting second client.");
-    std::shared_ptr<LOOLWebSocket> socket2 = loadDocAndGetSocket(_uri, documentURL, "simultaneousTilesRenderdJustOnce-2 ");
+    std::shared_ptr<http::WebSocketSession> socket2
+        = loadDocAndGetSession(_socketPoll, _uri, documentURL, testname + "2 ");
 
     // Wait for the invalidatetile events to pass, otherwise they
     // remove our tile subscription.
@@ -810,6 +833,14 @@ void TileCacheTests::testSimultaneousTilesRenderedJustOnce()
                        (renderId1 == "cached" && renderId2 != "cached") ||
                        (renderId1 != "cached" && renderId2 == "cached"));
     }
+
+    socket1->asyncShutdown();
+    socket2->asyncShutdown();
+
+    LOK_ASSERT_MESSAGE("Expected successful disconnection of the WebSocket 1",
+                       socket1->waitForDisconnection(std::chrono::seconds(5)));
+    LOK_ASSERT_MESSAGE("Expected successful disconnection of the WebSocket 2",
+                       socket2->waitForDisconnection(std::chrono::seconds(5)));
 }
 
 void TileCacheTests::testLoad12ods()
@@ -817,7 +848,8 @@ void TileCacheTests::testLoad12ods()
     try
     {
         const char* testname = "load12ods ";
-        std::shared_ptr<LOOLWebSocket> socket = loadDocAndGetSocket("load12.ods", _uri, testname);
+        std::shared_ptr<http::WebSocketSession> socket
+            = loadDocAndGetSession(_socketPoll, "load12.ods", _uri, testname);
 
         int docSheet = -1;
         int docSheets = 0;
@@ -832,6 +864,10 @@ void TileCacheTests::testLoad12ods()
         parseDocSize(response.substr(7), "spreadsheet", docSheet, docSheets, docWidth, docHeight, docViewId);
 
         checkBlackTiles(socket, docSheet, docWidth, docWidth, testname);
+
+        socket->asyncShutdown();
+        LOK_ASSERT_MESSAGE("Expected successful disconnection of the WebSocket",
+                           socket->waitForDisconnection(std::chrono::seconds(5)));
     }
     catch (const Poco::Exception& exc)
     {
@@ -875,6 +911,39 @@ void TileCacheTests::checkBlackTile(std::stringstream& tile)
     LOK_ASSERT_MESSAGE("The tile is 90% black", (black * 100) / (height * width) < 90);
 }
 
+void TileCacheTests::checkBlackTiles(std::shared_ptr<http::WebSocketSession>& socket,
+                                     const int /*part*/, const int /*docWidth*/,
+                                     const int /*docHeight*/, const std::string& testname)
+{
+    // Check the last row of tiles to verify that the tiles
+    // render correctly and there are no black tiles.
+    // Current cap of table size ends at 257280 twips (for load12.ods),
+    // otherwise 2035200 should be rendered successfully.
+    const char* req = "tile nviewid=0 part=0 width=256 height=256 tileposx=0 tileposy=253440 "
+                      "tilewidth=3840 tileheight=3840";
+    sendTextFrame(socket, req);
+
+    const std::vector<char> tile = getResponseMessage(socket, "tile:", testname);
+    if (!tile.size())
+    {
+        LOK_ASSERT_FAIL("No tile returned to checkBlackTiles - failed load ?");
+        return;
+    }
+
+    const std::string firstLine = LOOLProtocol::getFirstLine(tile);
+
+#if 0
+    std::fstream outStream("/tmp/black.png", std::ios::out);
+    outStream.write(tile.data() + firstLine.size() + 1, tile.size() - firstLine.size() - 1);
+    outStream.close();
+#endif
+
+    std::stringstream streamTile;
+    std::copy(tile.begin() + firstLine.size() + 1, tile.end(),
+              std::ostream_iterator<char>(streamTile));
+    checkBlackTile(streamTile);
+}
+
 void TileCacheTests::checkBlackTiles(std::shared_ptr<LOOLWebSocket>& socket, const int /*part*/,
                                      const int /*docWidth*/, const int /*docHeight*/,
                                      const std::string& testname)
@@ -911,9 +980,9 @@ void TileCacheTests::testTileInvalidateWriter()
     const char* testname = "tileInvalidateWriter ";
     std::string documentPath, documentURL;
     getDocumentPathAndURL("empty.odt", documentPath, documentURL, testname);
-    Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, documentURL);
 
-    std::shared_ptr<LOOLWebSocket> socket = loadDocAndGetSocket(_uri, documentURL, testname);
+    std::shared_ptr<http::WebSocketSession> socket
+        = loadDocAndGetSession(_socketPoll, _uri, documentURL, testname);
 
     std::string text = "Test. Now go 3 \"Enters\":\n\n\nNow after the enters, goes this text";
     for (char ch : text)
@@ -940,6 +1009,10 @@ void TileCacheTests::testTileInvalidateWriter()
     //LOK_ASSERT_MESSAGE("received unexpected invalidatetiles: message", getResponseMessage(socket, "invalidatetiles:").empty());
 
     // TODO: implement a random-sequence "monkey test"
+
+    socket->asyncShutdown();
+    LOK_ASSERT_MESSAGE("Expected successful disconnection of the WebSocket",
+                       socket->waitForDisconnection(std::chrono::seconds(5)));
 }
 
 void TileCacheTests::testTileInvalidateWriterPage()
@@ -948,9 +1021,9 @@ void TileCacheTests::testTileInvalidateWriterPage()
 
     std::string documentPath, documentURL;
     getDocumentPathAndURL("empty.odt", documentPath, documentURL, testname);
-    Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, documentURL);
 
-    std::shared_ptr<LOOLWebSocket> socket = loadDocAndGetSocket(_uri, documentURL, testname);
+    std::shared_ptr<http::WebSocketSession> socket
+        = loadDocAndGetSession(_socketPoll, _uri, documentURL, testname);
 
     sendChar(socket, '\n', skCtrl, testname); // Send Ctrl+Enter (page break).
     assertResponseString(socket, "invalidatetiles:", testname);
@@ -962,6 +1035,10 @@ void TileCacheTests::testTileInvalidateWriterPage()
     LOK_ASSERT_MESSAGE("No part# in invalidatetiles message.",
                            LOOLProtocol::getTokenIntegerFromMessage(res, "part", part));
     LOK_ASSERT_EQUAL(0, part);
+
+    socket->asyncShutdown();
+    LOK_ASSERT_MESSAGE("Expected successful disconnection of the WebSocket",
+                       socket->waitForDisconnection(std::chrono::seconds(5)));
 }
 
 // This isn't yet used
@@ -970,9 +1047,9 @@ void TileCacheTests::testWriterAnyKey()
     const char* testname = "writerAnyKey ";
     std::string documentPath, documentURL;
     getDocumentPathAndURL("empty.odt", documentPath, documentURL, testname);
-    Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, documentURL);
 
-    std::shared_ptr<LOOLWebSocket> socket = loadDocAndGetSocket(_uri, documentURL, testname);
+    std::shared_ptr<http::WebSocketSession> socket
+        = loadDocAndGetSession(_socketPoll, _uri, documentURL, testname);
 
     // Now test "usual" keycodes (TODO: whole 32-bit range)
     for (int i=0; i<0x1000; ++i)
@@ -1047,12 +1124,17 @@ void TileCacheTests::testWriterAnyKey()
         getResponseMessage(socket, "status:", testname);
     }
     //    sendTextFrame(socket, "saveas url=file:///tmp/emptyempty.odt format= options=");
+
+    socket->asyncShutdown();
+    LOK_ASSERT_MESSAGE("Expected successful disconnection of the WebSocket",
+                       socket->waitForDisconnection(std::chrono::seconds(5)));
 }
 
 void TileCacheTests::testTileInvalidateCalc()
 {
     const std::string testname = "tileInvalidateCalc ";
-    std::shared_ptr<LOOLWebSocket> socket = loadDocAndGetSocket("empty.ods", _uri, testname);
+        std::shared_ptr<http::WebSocketSession> socket
+            = loadDocAndGetSession(_socketPoll, "empty.ods", _uri, testname);
 
     std::string text = "Test. Now go 3 \"Enters\": Now after the enters, goes this text";
     for (char ch : text)
@@ -1075,6 +1157,10 @@ void TileCacheTests::testTileInvalidateCalc()
         sendChar(socket, ch, skNone, testname);
         assertResponseString(socket, "invalidatetiles:", testname);
     }
+
+    socket->asyncShutdown();
+    LOK_ASSERT_MESSAGE("Expected successful disconnection of the WebSocket",
+                       socket->waitForDisconnection(std::chrono::seconds(5)));
 }
 
 void TileCacheTests::testTileInvalidatePartCalc()
@@ -1086,13 +1172,15 @@ void TileCacheTests::testTileInvalidatePartCalc()
 
     std::string documentPath, documentURL;
     getDocumentPathAndURL(filename, documentPath, documentURL, testname);
-    std::shared_ptr<LOOLWebSocket> socket1 = loadDocAndGetSocket(_uri, documentURL, testname1);
+    std::shared_ptr<http::WebSocketSession> socket1
+        = loadDocAndGetSession(_socketPoll, _uri, documentURL, testname1);
 
     sendTextFrame(socket1, "setclientpart part=2", testname1);
     assertResponseString(socket1, "setpart:", testname1);
     sendTextFrame(socket1, "mouse type=buttondown x=1500 y=1500 count=1 buttons=1 modifier=0", testname1);
 
-    std::shared_ptr<LOOLWebSocket> socket2 = loadDocAndGetSocket(_uri, documentURL, testname2);
+    std::shared_ptr<http::WebSocketSession> socket2
+        = loadDocAndGetSession(_socketPoll, _uri, documentURL, testname2);
     sendTextFrame(socket2, "setclientpart part=5", testname2);
     assertResponseString(socket2, "setpart:", testname2);
     sendTextFrame(socket2, "mouse type=buttondown x=1500 y=1500 count=1 buttons=1 modifier=0", testname2);
@@ -1113,6 +1201,14 @@ void TileCacheTests::testTileInvalidatePartCalc()
         LOOLProtocol::getTokenIntegerFromMessage(response2, "part", value2);
         LOK_ASSERT_EQUAL(5, value2);
     }
+
+    socket1->asyncShutdown();
+    socket2->asyncShutdown();
+
+    LOK_ASSERT_MESSAGE("Expected successful disconnection of the WebSocket 1",
+                       socket1->waitForDisconnection(std::chrono::seconds(5)));
+    LOK_ASSERT_MESSAGE("Expected successful disconnection of the WebSocket 2",
+                       socket2->waitForDisconnection(std::chrono::seconds(5)));
 }
 
 void TileCacheTests::testTileInvalidatePartImpress()
@@ -1124,13 +1220,15 @@ void TileCacheTests::testTileInvalidatePartImpress()
 
     std::string documentPath, documentURL;
     getDocumentPathAndURL(filename, documentPath, documentURL, testname);
-    std::shared_ptr<LOOLWebSocket> socket1 = loadDocAndGetSocket(_uri, documentURL, testname1);
+    std::shared_ptr<http::WebSocketSession> socket1
+        = loadDocAndGetSession(_socketPoll, _uri, documentURL, testname1);
 
     sendTextFrame(socket1, "setclientpart part=2", testname1);
     assertResponseString(socket1, "setpart:", testname1);
     sendTextFrame(socket1, "mouse type=buttondown x=1500 y=1500 count=1 buttons=1 modifier=0", testname1);
 
-    std::shared_ptr<LOOLWebSocket> socket2 = loadDocAndGetSocket(_uri, documentURL, testname2);
+    std::shared_ptr<http::WebSocketSession> socket2
+        = loadDocAndGetSession(_socketPoll, _uri, documentURL, testname2);
     sendTextFrame(socket2, "setclientpart part=5", testname2);
     assertResponseString(socket2, "setpart:", testname2);
     sendTextFrame(socket2, "mouse type=buttondown x=1500 y=1500 count=1 buttons=1 modifier=0", testname2);
@@ -1152,6 +1250,14 @@ void TileCacheTests::testTileInvalidatePartImpress()
         LOOLProtocol::getTokenIntegerFromMessage(response2, "part", value2);
         LOK_ASSERT_EQUAL(5, value2);
     }
+
+    socket1->asyncShutdown();
+    socket2->asyncShutdown();
+
+    LOK_ASSERT_MESSAGE("Expected successful disconnection of the WebSocket 1",
+                       socket1->waitForDisconnection(std::chrono::seconds(5)));
+    LOK_ASSERT_MESSAGE("Expected successful disconnection of the WebSocket 2",
+                       socket2->waitForDisconnection(std::chrono::seconds(5)));
 }
 
 void TileCacheTests::checkTiles(std::shared_ptr<http::WebSocketSession>& socket,
@@ -1506,7 +1612,8 @@ void TileCacheTests::testTileRequestByZoom()
 
     std::string documentPath, documentURL;
     getDocumentPathAndURL("empty.odt", documentPath, documentURL, testname);
-    std::shared_ptr<LOOLWebSocket> socket = loadDocAndGetSocket(_uri, documentURL, testname);
+    std::shared_ptr<http::WebSocketSession> socket
+        = loadDocAndGetSession(_socketPoll, _uri, documentURL, testname);
 
     // Set the client visible area
     sendTextFrame(socket, "clientvisiblearea x=-2662 y=0 width=16000 height=9875");
@@ -1521,6 +1628,10 @@ void TileCacheTests::testTileRequestByZoom()
         std::vector<char> tile = getResponseMessage(socket, "tile:", testname);
         LOK_ASSERT_MESSAGE("Did not get tile as expected!", !tile.empty());
     }
+
+    socket->asyncShutdown();
+    LOK_ASSERT_MESSAGE("Expected successful disconnection of the WebSocket",
+                       socket->waitForDisconnection(std::chrono::seconds(5)));
 }
 
 void TileCacheTests::testTileWireIDHandling()
@@ -1529,7 +1640,8 @@ void TileCacheTests::testTileWireIDHandling()
 
     std::string documentPath, documentURL;
     getDocumentPathAndURL("empty.odt", documentPath, documentURL, testname);
-    std::shared_ptr<LOOLWebSocket> socket = loadDocAndGetSocket(_uri, documentURL, testname);
+    std::shared_ptr<http::WebSocketSession> socket
+        = loadDocAndGetSession(_socketPoll, _uri, documentURL, testname);
 
     // Set the client visible area
     sendTextFrame(socket, "clientvisiblearea x=-4005 y=0 width=50490 height=72300");
@@ -1572,6 +1684,10 @@ void TileCacheTests::testTileWireIDHandling()
     LOK_ASSERT_MESSAGE("Expected exactly one tile.",
                        countMessages(socket, "tile:", testname, std::chrono::milliseconds(500))
                            == 1);
+
+    socket->asyncShutdown();
+    LOK_ASSERT_MESSAGE("Expected successful disconnection of the WebSocket",
+                       socket->waitForDisconnection(std::chrono::seconds(5)));
 }
 
 void TileCacheTests::testTileProcessed()
@@ -1581,7 +1697,8 @@ void TileCacheTests::testTileProcessed()
 
     std::string documentPath, documentURL;
     getDocumentPathAndURL("empty.odt", documentPath, documentURL, testname);
-    std::shared_ptr<LOOLWebSocket> socket = loadDocAndGetSocket(_uri, documentURL, testname);
+    std::shared_ptr<http::WebSocketSession> socket
+        = loadDocAndGetSession(_socketPoll, _uri, documentURL, testname);
 
     // Set the client visible area
     sendTextFrame(socket, "clientvisiblearea x=-2662 y=0 width=10000 height=9000");
@@ -1637,6 +1754,10 @@ void TileCacheTests::testTileProcessed()
     } while(gotTile);
 
     LOK_ASSERT_MESSAGE("We expect one tile at least!", arrivedTile2 > 1);
+
+    socket->asyncShutdown();
+    LOK_ASSERT_MESSAGE("Expected successful disconnection of the WebSocket",
+                       socket->waitForDisconnection(std::chrono::seconds(5)));
 }
 
 void TileCacheTests::testTileInvalidatedOutside()
@@ -1646,7 +1767,8 @@ void TileCacheTests::testTileInvalidatedOutside()
 
     std::string documentPath, documentURL;
     getDocumentPathAndURL("empty.odt", documentPath, documentURL, testname);
-    std::shared_ptr<LOOLWebSocket> socket = loadDocAndGetSocket(_uri, documentURL, testname);
+    std::shared_ptr<http::WebSocketSession> socket
+        = loadDocAndGetSession(_socketPoll, _uri, documentURL, testname);
 
     // Type one character to trigger invalidation and get the invalidation rectangle
     sendChar(socket, 'x', skNone, testname);
@@ -1675,6 +1797,10 @@ void TileCacheTests::testTileInvalidatedOutside()
     // are partly visible.
     std::vector<char> tile = getResponseMessage(socket, "tile:", testname);
     LOK_ASSERT_MESSAGE("Not expected tile message arrived!", tile.empty());
+
+    socket->asyncShutdown();
+    LOK_ASSERT_MESSAGE("Expected successful disconnection of the WebSocket",
+                       socket->waitForDisconnection(std::chrono::seconds(5)));
 }
 
 void TileCacheTests::testTileBeingRenderedHandling()
@@ -1685,7 +1811,8 @@ void TileCacheTests::testTileBeingRenderedHandling()
 
     std::string documentPath, documentURL;
     getDocumentPathAndURL("empty.odt", documentPath, documentURL, testname);
-    std::shared_ptr<LOOLWebSocket> socket = loadDocAndGetSocket(_uri, documentURL, testname);
+    std::shared_ptr<http::WebSocketSession> socket
+        = loadDocAndGetSession(_socketPoll, _uri, documentURL, testname);
 
     // Set the client visible area
     sendTextFrame(socket, "clientvisiblearea x=-2662 y=0 width=16000 height=9875");
@@ -1730,6 +1857,10 @@ void TileCacheTests::testTileBeingRenderedHandling()
                 countMessages(socket, "tile:", testname, std::chrono::milliseconds(500)) == 1);
         }
     }
+
+    socket->asyncShutdown();
+    LOK_ASSERT_MESSAGE("Expected successful disconnection of the WebSocket",
+                        socket->waitForDisconnection(std::chrono::seconds(5)));
 }
 
 void TileCacheTests::testWireIDFilteringOnWSDSide()
@@ -1738,12 +1869,14 @@ void TileCacheTests::testWireIDFilteringOnWSDSide()
 
     std::string documentPath, documentURL;
     getDocumentPathAndURL("empty.odt", documentPath, documentURL, testname);
-    std::shared_ptr<LOOLWebSocket> socket1 = loadDocAndGetSocket(_uri, documentURL, testname);
+    std::shared_ptr<http::WebSocketSession> socket1
+        = loadDocAndGetSession(_socketPoll, _uri, documentURL, testname);
     // Set the client visible area
     sendTextFrame(socket1, "clientvisiblearea x=-4005 y=0 width=50490 height=72300");
     sendTextFrame(socket1, "clientzoom tilepixelwidth=256 tilepixelheight=256 tiletwipwidth=3840 tiletwipheight=3840");
 
-    std::shared_ptr<LOOLWebSocket> socket2 = loadDocAndGetSocket(_uri, documentURL, testname, true);
+    std::shared_ptr<http::WebSocketSession> socket2
+        = loadDocAndGetSession(_socketPoll, _uri, documentURL, testname, true);
     // Set the client visible area
     sendTextFrame(socket1, "clientvisiblearea x=-4005 y=0 width=50490 height=72300");
     sendTextFrame(socket1, "clientzoom tilepixelwidth=256 tilepixelheight=256 tiletwipwidth=3840 tiletwipheight=3840");
@@ -1799,6 +1932,14 @@ void TileCacheTests::testWireIDFilteringOnWSDSide()
     const std::vector<char> tile
         = getResponseMessage(socket1, "tile:", testname, std::chrono::milliseconds(1000));
     LOK_ASSERT_MESSAGE("Not expected tile message arrived!", tile.empty());
+
+    socket1->asyncShutdown();
+    socket2->asyncShutdown();
+
+    LOK_ASSERT_MESSAGE("Expected successful disconnection of the WebSocket 1",
+                       socket1->waitForDisconnection(std::chrono::seconds(5)));
+    LOK_ASSERT_MESSAGE("Expected successful disconnection of the WebSocket 2",
+                       socket2->waitForDisconnection(std::chrono::seconds(5)));
 }
 
 void TileCacheTests::testLimitTileVersionsOnFly()
@@ -1809,7 +1950,8 @@ void TileCacheTests::testLimitTileVersionsOnFly()
 
     std::string documentPath, documentURL;
     getDocumentPathAndURL("empty.odt", documentPath, documentURL, testname);
-    std::shared_ptr<LOOLWebSocket> socket = loadDocAndGetSocket(_uri, documentURL, testname);
+    std::shared_ptr<http::WebSocketSession> socket
+        = loadDocAndGetSession(_socketPoll, _uri, documentURL, testname);
 
     // Set the client visible area
     sendTextFrame(socket, "clientvisiblearea x=-2662 y=0 width=16000 height=9875");
@@ -1862,6 +2004,10 @@ void TileCacheTests::testLimitTileVersionsOnFly()
     } while(gotTile);
 
     LOK_ASSERT_EQUAL(1, arrivedTiles);
+
+    socket->asyncShutdown();
+    LOK_ASSERT_MESSAGE("Expected successful disconnection of the WebSocket",
+                       socket->waitForDisconnection(std::chrono::seconds(5)));
 }
 
 CPPUNIT_TEST_SUITE_REGISTRATION(TileCacheTests);

--- a/test/TileCacheTests.cpp
+++ b/test/TileCacheTests.cpp
@@ -154,19 +154,18 @@ public:
         Poco::Net::Context::Ptr sslContext = new Poco::Net::Context(Poco::Net::Context::CLIENT_USE, sslParams);
         Poco::Net::SSLManager::instance().initializeClient(nullptr, invalidCertHandler, sslContext);
 #endif
-        _socketPoll.startThread();
     }
 
 #if ENABLE_SSL
     ~TileCacheTests()
     {
-        _socketPoll.joinThread();
         Poco::Net::uninitializeSSL();
     }
 #endif
 
     void setUp()
     {
+        _socketPoll.startThread();
         resetTestStartTime();
         testCountHowManyLoolkits();
         resetTestStartTime();
@@ -177,6 +176,7 @@ public:
         resetTestStartTime();
         testNoExtraLoolKitsLeft();
         resetTestStartTime();
+        _socketPoll.joinThread();
     }
 };
 

--- a/test/UnitClient.cpp
+++ b/test/UnitClient.cpp
@@ -24,8 +24,9 @@ class UnitClient : public UnitWSD
     std::thread _worker;
 
 public:
-    UnitClient() :
-        _workerStarted(false)
+    UnitClient()
+        : UnitWSD("UnitClient")
+        , _workerStarted(false)
     {
         constexpr std::chrono::minutes timeout_minutes(5);
         setTimeout(timeout_minutes);

--- a/test/UnitCopyPaste.cpp
+++ b/test/UnitCopyPaste.cpp
@@ -309,8 +309,8 @@ public:
             return;
 
         LOG_TST("Close sockets:");
-        socket2->asyncShutdown(socketPoll());
-        socket->asyncShutdown(socketPoll());
+        socket2->asyncShutdown();
+        socket->asyncShutdown();
 
         LOK_ASSERT_MESSAGE("Expected successful disconnection of the WebSocket 2",
                            socket2->waitForDisconnection(std::chrono::seconds(5)));

--- a/test/UnitCopyPaste.cpp
+++ b/test/UnitCopyPaste.cpp
@@ -18,6 +18,8 @@
 #include <wsd/LOOLWSD.hpp>
 #include <common/Clipboard.hpp>
 #include <wsd/ClientSession.hpp>
+#include <net/WebSocketSession.hpp>
+
 #include <Poco/Net/HTTPResponse.h>
 #include <Poco/Net/HTTPServerRequest.h>
 #include <Poco/Net/HTMLForm.h>
@@ -124,7 +126,7 @@ public:
                     << value.length() << " bytes vs. " << content.length() << " bytes. Clipboard:\n"
                     << Util::dumpHex(value) << "Expected:\n"
                     << Util::dumpHex(content));
-            LOK_ASSERT_EQUAL_MESSAGE("Clipboard content mismatch", value, content);
+            LOK_ASSERT_EQUAL_MESSAGE("Clipboard content mismatch", content, value);
             failed = true;
         }
         if (failed)
@@ -140,9 +142,10 @@ public:
                               const std::string &content,
                               HTTPResponse::HTTPStatus expected = HTTPResponse::HTTP_OK)
     {
-        std::shared_ptr<ClipboardData> clipboard;
-        try {
-            clipboard = getClipboard(clipURI, expected);
+        try
+        {
+            std::shared_ptr<ClipboardData> clipboard = getClipboard(clipURI, expected);
+            return assertClipboard(clipboard, mimeType, content);
         }
         catch (const ParseError& err)
         {
@@ -163,8 +166,6 @@ public:
             return false;
         }
 
-        if (!assertClipboard(clipboard, mimeType, content))
-            return false;
         return true;
     }
 
@@ -238,8 +239,9 @@ public:
         // Load a doc with the cursor saved at a top row.
         std::string documentPath, documentURL;
         helpers::getDocumentPathAndURL("empty.ods", documentPath, documentURL, testname);
-        std::shared_ptr<LOOLWebSocket> socket =
-            helpers::loadDocAndGetSocket(Poco::URI(helpers::getTestServerURI()), documentURL, testname);
+
+        std::shared_ptr<http::WebSocketSession> socket = helpers::loadDocAndGetSession(
+            socketPoll(), Poco::URI(helpers::getTestServerURI()), documentURL, testname);
 
         std::string clipURI = getSessionClipboardURI(0);
 
@@ -256,8 +258,8 @@ public:
             return;
 
         LOG_TST("Open second connection");
-        std::shared_ptr<LOOLWebSocket> socket2 =
-            helpers::loadDocAndGetSocket(Poco::URI(helpers::getTestServerURI()), documentURL, testname);
+        std::shared_ptr<http::WebSocketSession> socket2 = helpers::loadDocAndGetSession(
+            socketPoll(), Poco::URI(helpers::getTestServerURI()), documentURL, testname);
         std::string clipURI2 = getSessionClipboardURI(1);
 
         LOG_TST("Check no clipboard content");
@@ -307,8 +309,13 @@ public:
             return;
 
         LOG_TST("Close sockets:");
-        socket->shutdown(testname);
-        socket2->shutdown(testname);
+        socket2->asyncShutdown(socketPoll());
+        socket->asyncShutdown(socketPoll());
+
+        LOK_ASSERT_MESSAGE("Expected successful disconnection of the WebSocket 2",
+                           socket2->waitForDisconnection(std::chrono::seconds(5)));
+        LOK_ASSERT_MESSAGE("Expected successful disconnection of the WebSocket 0",
+                           socket->waitForDisconnection(std::chrono::seconds(5)));
 
         sleep(1); // paranoia.
 

--- a/test/UnitCopyPaste.cpp
+++ b/test/UnitCopyPaste.cpp
@@ -234,7 +234,7 @@ public:
 
     void invokeWSDTest() override
     {
-        std::string testname = "copypaste";
+        std::string testname = "copypaste ";
 
         // Load a doc with the cursor saved at a top row.
         std::string documentPath, documentURL;
@@ -245,12 +245,12 @@ public:
 
         std::string clipURI = getSessionClipboardURI(0);
 
-        LOG_TST("Fetch empty clipboard content");
+        LOG_TST("Fetch empty clipboard content after loading");
         if (!fetchClipboardAssert(clipURI, "", ""))
             return;
 
         // Check existing content
-        LOG_TST("Fetch pristine content");
+        LOG_TST("Fetch pristine content from the document");
         helpers::sendTextFrame(socket, "uno .uno:SelectAll", testname);
         helpers::sendTextFrame(socket, "uno .uno:Copy", testname);
         std::string oneColumn = "2\n3\n5\n";
@@ -262,11 +262,11 @@ public:
             socketPoll(), Poco::URI(helpers::getTestServerURI()), documentURL, testname);
         std::string clipURI2 = getSessionClipboardURI(1);
 
-        LOG_TST("Check no clipboard content");
+        LOG_TST("Check no clipboard content on second view");
         if (!fetchClipboardAssert(clipURI2, "", ""))
             return;
 
-        LOG_TST("Inject content");
+        LOG_TST("Inject content through first view");
         helpers::sendTextFrame(socket, "uno .uno:Deselect", testname);
         std::string text = "This is some content?&*/\\!!";
         helpers::sendTextFrame(socket, "paste mimetype=text/plain;charset=utf-8\n" + text, testname);

--- a/test/UnitCursor.cpp
+++ b/test/UnitCursor.cpp
@@ -198,7 +198,6 @@ UnitBase::TestResult UnitCursor::testInsertAnnotationWriter()
 
     std::string documentPath, documentURL;
     helpers::getDocumentPathAndURL("hello.odt", documentPath, documentURL, testname);
-    Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, documentURL);
 
     Poco::URI uri(helpers::getTestServerURI());
     std::shared_ptr<LOOLWebSocket> socket

--- a/test/UnitLoad.cpp
+++ b/test/UnitLoad.cpp
@@ -202,8 +202,8 @@ UnitBase::TestResult UnitLoad::testLoad()
     std::string documentPath, documentURL;
     helpers::getDocumentPathAndURL("hello.odt", documentPath, documentURL, testname);
 
-    SocketPoll socketPoll("UnitLoadPoll");
-    socketPoll.startThread();
+    std::shared_ptr<SocketPoll> socketPoll = std::make_shared<SocketPoll>("UnitLoadPoll");
+    socketPoll->startThread();
 
     auto wsSession
         = http::WebSocketSession::create(socketPoll, helpers::getTestServerURI(), documentURL);
@@ -214,12 +214,11 @@ UnitBase::TestResult UnitLoad::testLoad()
     std::vector<char> message = wsSession->waitForMessage("status:", std::chrono::seconds(5));
     LOK_ASSERT_MESSAGE("Failed to load the document", !message.empty());
 
-    wsSession->asyncShutdown(socketPoll);
+    wsSession->asyncShutdown();
 
     LOK_ASSERT_MESSAGE("Expected success disconnection of the WebSocket",
                        wsSession->waitForDisconnection(std::chrono::seconds(5)));
 
-    socketPoll.joinThread();
     return TestResult::Ok;
 }
 

--- a/test/UnitLoadTorture.cpp
+++ b/test/UnitLoadTorture.cpp
@@ -50,8 +50,8 @@ int UnitLoadTorture::loadTorture(const std::string& testname, const std::string&
     sum_view_ids = 0;
     std::atomic<int> num_of_views(0);
     std::atomic<int> num_to_load(thread_count);
-    SocketPoll poll("WebSocketPoll");
-    poll.startThread();
+    std::shared_ptr<SocketPoll> poll = std::make_shared<SocketPoll>("WebSocketPoll");
+    poll->startThread();
 
     std::vector<std::thread> threads;
     for (size_t i = 0; i < thread_count; ++i)

--- a/test/helpers.hpp
+++ b/test/helpers.hpp
@@ -26,6 +26,7 @@
 #include <Poco/URI.h>
 
 #include <Common.hpp>
+#include "Socket.hpp"
 #include "common/FileUtil.hpp"
 #include <LOOLWebSocket.hpp>
 #include <common/ConfigUtil.hpp>
@@ -457,6 +458,17 @@ inline std::string assertResponseString(const std::shared_ptr<http::WebSocketSes
     auto res = getResponseString(ws, prefix, testname, timeoutMs);
     LOK_ASSERT_EQUAL(prefix, res.substr(0, prefix.length()));
     return res;
+}
+
+inline int countMessages(const std::shared_ptr<http::WebSocketSession>& ws,
+                         const std::string& prefix, const std::string& testname,
+                         const std::chrono::milliseconds timeoutMs = std::chrono::seconds(10))
+{
+    int count = 0;
+    while (!getResponseMessage(ws, prefix, testname, timeoutMs).empty())
+        ++count;
+
+    return count;
 }
 
 inline std::vector<char> getResponseMessage(const std::shared_ptr<LOOLWebSocket>& ws,

--- a/test/helpers.hpp
+++ b/test/helpers.hpp
@@ -1070,6 +1070,32 @@ inline void sendAndWait(const std::shared_ptr<http::WebSocketSession>& ws,
     }
 }
 
+/// Sends a command and drain an event in response.
+/// We expect @response within the given @timeoutResponse and
+/// we drain all messages to get a steady-state.
+/// Draining happens for @timeoutDrain.
+inline bool sendAndDrain(const std::shared_ptr<http::WebSocketSession>& ws,
+                         const std::string& testname, const std::string& command,
+                         const std::string& response,
+                         std::chrono::milliseconds timeoutResponse = std::chrono::seconds(10),
+                         std::chrono::milliseconds timeoutDrain = std::chrono::milliseconds(300))
+{
+    TST_LOG("Sending [" << command << "], waiting for [" << response
+                        << "], and draining the events.");
+    sendTextFrame(ws, command, testname);
+    const std::string res = getResponseString(ws, response, testname, timeoutResponse);
+    if (res.empty())
+    {
+        TST_LOG("Timed-out waiting for [" << response << "] after sending [" << command << "].");
+        return false;
+    }
+
+    while (!getResponseString(ws, response, testname, timeoutDrain).empty())
+        ; // Skip.
+
+    return true;
+}
+
 /// Select all and wait for the text selection update.
 inline void selectAll(const std::shared_ptr<http::WebSocketSession>& ws,
                       const std::string& testname,

--- a/test/helpers.hpp
+++ b/test/helpers.hpp
@@ -301,11 +301,21 @@ inline int connectToLocalServer(int portNumber, int socketTimeOutMS, bool blocki
     }
 }
 
-inline
-std::string const & getTestServerURI()
+/// Returns true iff built with SSL and it is successfully initialized.
+inline bool haveSsl()
+{
+#if ENABLE_SSL
+    return SslContext::isInitialized();
+#else
+    return false;
+#endif
+}
+
+/// Return a fully-qualified URI, with schema, to the test loopback server.
+inline std::string const& getTestServerURI()
 {
     static std::string serverURI(
-        (config::isSslEnabled() ? "https://127.0.0.1:" : "http://127.0.0.1:")
+        (haveSsl() && config::isSslEnabled() ? "https://127.0.0.1:" : "http://127.0.0.1:")
         + std::to_string(ClientPortNumber));
 
     return serverURI;

--- a/test/httpwstest.cpp
+++ b/test/httpwstest.cpp
@@ -7,6 +7,8 @@
 
 #include <config.h>
 
+#include "WebSocketSession.hpp"
+
 #include <algorithm>
 #include <vector>
 

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -164,6 +164,8 @@ public:
     void startTest(CppUnit::Test* test)
     {
         writeTestLog("\n=============== START " + test->getName() + '\n');
+        if (UnitBase::isUnitTesting()) // Only if we are in UnitClient.
+            UnitBase::get().setTestname(test->getName());
         _startTime = std::chrono::steady_clock::now();
     }
 

--- a/wsd/Admin.cpp
+++ b/wsd/Admin.cpp
@@ -206,7 +206,7 @@ void AdminSocketHandler::handleMessage(const std::vector<char> &payload)
     }
     else if (tokens.equals(0, "shutdown"))
     {
-        LOG_INF("Shutdown requested by admin.");
+        LOG_INF("Setting ShutdownRequestFlag: Shutdown requested by admin.");
         SigUtil::requestShutdown();
         return;
     }

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -396,7 +396,8 @@ void DocumentBroker::pollThread()
             LOG_INF("Autosaving DocumentBroker for docKey [" << getDocKey() << "] for " << reason);
             if (!autoSave(isPossiblyModified()))
             {
-                LOG_INF("Terminating DocumentBroker for docKey [" << getDocKey() << "].");
+                LOG_INF("Terminating DocumentBroker for docKey [" << getDocKey()
+                                                                  << "]: " << reason);
                 stop(reason);
             }
         }

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -306,9 +306,9 @@ void DocumentBroker::pollThread()
     {
         _poll->poll(SocketPoll::DefaultPollTimeoutMicroS);
 
+#if !MOBILEAPP
         const auto now = std::chrono::steady_clock::now();
 
-#if !MOBILEAPP
         // a tile's data is ~8k, a 4k screen is ~128 256x256 tiles
         if (_tileCache)
             _tileCache->setMaxCacheSize(8 * 1024 * 128 * _sessions.size());

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -363,6 +363,7 @@ void cleanupDocBrokers()
 #if !MOBILEAPP && ENABLE_DEBUG
         if (LOOLWSD::SingleKit && DocBrokers.size() == 0)
         {
+            LOG_DBG("Setting ShutdownRequestFlag: No more docs left in single-kit mode.");
             SigUtil::requestShutdown();
         }
 #endif
@@ -1743,7 +1744,7 @@ bool LOOLWSD::checkAndRestoreForKit()
         if (!SigUtil::getShutdownRequestFlag() && !SigUtil::getTerminationFlag() && !createForKit())
         {
             // Should never fail.
-            LOG_FTL("Failed to spawn loolforkit.");
+            LOG_FTL("Setting ShutdownRequestFlag: Failed to spawn loolforkit.");
             SigUtil::requestShutdown();
         }
     }
@@ -1771,7 +1772,7 @@ bool LOOLWSD::checkAndRestoreForKit()
                 // Spawn a new forkit and try to dust it off and resume.
                 if (!SigUtil::getShutdownRequestFlag() && !SigUtil::getTerminationFlag() && !createForKit())
                 {
-                    LOG_FTL("Failed to spawn forkit instance. Shutting down.");
+                    LOG_FTL("Setting ShutdownRequestFlag: Failed to spawn forkit instance.");
                     SigUtil::requestShutdown();
                 }
             }
@@ -1805,7 +1806,7 @@ bool LOOLWSD::checkAndRestoreForKit()
             // Spawn a new forkit and try to dust it off and resume.
             if (!SigUtil::getShutdownRequestFlag() && !SigUtil::getTerminationFlag() && !createForKit())
             {
-                LOG_FTL("Failed to spawn forkit instance. Shutting down.");
+                LOG_FTL("Setting ShutdownRequestFlag: Failed to spawn forkit instance.");
                 SigUtil::requestShutdown();
             }
         }
@@ -4072,8 +4073,8 @@ int LOOLWSD::innerMain()
 #if ENABLE_DEBUG && !MOBILEAPP
         if (careerSpanMs > std::chrono::milliseconds::zero() && timeSinceStartMs > careerSpanMs)
         {
-            LOG_INF(timeSinceStartMs
-                    << " gone, finishing as requested. Setting ShutdownRequestFlag.");
+            LOG_INF("Setting ShutdownRequestFlag: " << timeSinceStartMs << " gone, career of "
+                                                    << careerSpanMs << " expired.");
             SigUtil::requestShutdown();
         }
 #endif
@@ -4093,7 +4094,8 @@ int LOOLWSD::innerMain()
     if (!SigUtil::getShutdownRequestFlag())
     {
         // This shouldn't happen, but it's fail safe to always cleanup properly.
-        LOG_WRN("Exiting WSD without ShutdownRequestFlag. Setting it now.");
+        LOG_WRN("Setting ShutdownRequestFlag: Exiting WSD without ShutdownRequestFlag. Setting it "
+                "now.");
         SigUtil::requestShutdown();
     }
 #endif

--- a/wsd/LOOLWSD.hpp
+++ b/wsd/LOOLWSD.hpp
@@ -455,6 +455,13 @@ protected:
         {
             innerInitialize(self);
         }
+        catch (const Poco::Exception& ex)
+        {
+            LOG_FTL("Failed to initialize LOOLWSD: "
+                    << ex.displayText()
+                    << (ex.nested() ? " (" + ex.nested()->displayText() + ')' : ""));
+            throw; // Nothing further to do.
+        }
         catch (const std::exception& ex)
         {
             LOG_FTL("Failed to initialize LOOLWSD: " << ex.what());


### PR DESCRIPTION
- wsd: test: killpoco web-sockets in httpwstest
- wsd: test: killpoco in UnitCopyPaste
- wsd: safer asyncShutdown in WebSocketSession
- wsd: read can return 0 from the socket
- wsd: log the reason for terminating DocumentBroker
- wsd: test: set the test name for old-style tests
- wsd: test: log the testname in the test setup and result
- wsd: test: remove superfluous object
- wsd: test: single UnitBase ctor with default name
- wsd: test: start the test poll thread only during the test
- wsd: test: move SocketPoll to UnitBase
- wsd: test: killpoco in TileCacheTests again
- wsd: test: killpoco in TileCacheTests
- wsd: test: fully enable loopback testing of http
- wsd: better and consistent logging of ShutdownRequestFlag setting
- wsd: test: log the actual test name instead of function names
- wsd: improved WebSocketSession interface
- wsd: test: killpoco in TileCacheTests
- make: simplify
- wsd: notify outside the lock
- wsd: test: better logging in copy/paste
- wsd: test: simplify and reuse some helpers
- wsd: test: improve the stability of UnitCopyPaste
- wsd: mobileapp: fix a warning
- wsd: more informative initialization failure log