### PR TITLE
kit: fix status indicator finish

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -797,7 +797,9 @@ public:
             self->setDocumentPassword(type);
             return;
         }
-        else if (type == LOK_CALLBACK_STATUS_INDICATOR_SET_VALUE)
+        else if (type == LOK_CALLBACK_STATUS_INDICATOR_START ||
+                 type == LOK_CALLBACK_STATUS_INDICATOR_SET_VALUE ||
+                 type == LOK_CALLBACK_STATUS_INDICATOR_FINISH)
         {
             for (auto& it : self->_sessions)
             {


### PR DESCRIPTION
Unfortunately the sequence message sent
from LO core is important, and the status
indicator finish should arrive to client side
before any dialog interactivity (i.e. Macros Warning Dialog).

However the LO core sends like 3 times status
finish for now we cannot duplicate them.

Change-Id: Ieee2ee93555b50b0e67507aae36096e10728a038
