### PR TITLE
Initialize SSL un-conditionally.

### DIFF
--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -1479,9 +1479,6 @@ void LOOLWSD::innerInitialize(Application& self)
 void LOOLWSD::initializeSSL()
 {
 #if ENABLE_SSL
-    if (!LOOLWSD::isSSLEnabled())
-        return;
-
     const std::string ssl_cert_file_path = getPathFromConfig("ssl.cert_file_path");
     LOG_INF("SSL Cert file: " << ssl_cert_file_path);
 


### PR DESCRIPTION
Even if we use http:// locally via a tunnel the new outgoing socket
code needs SSL initialized to connect securely to remote servers.

Change-Id: If64a3838267182757591a8026097bf08d9ba732f


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

