### PR TITLE
Produce a Chrome Event Trace file

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -224,6 +224,10 @@ AC_ARG_WITH([logfile],
             AS_HELP_STRING([--with-logfile=<path>],
                            [Path to the location of the logfile.]))
 
+AC_ARG_WITH([event-trace-file],
+            AS_HELP_STRING([--with-event-trace-file=<path>],
+                           [Path to the location of the Event Trace file.]))
+
 AC_ARG_WITH([poco-includes],
             AS_HELP_STRING([--with-poco-includes=<path>],
                            [Path to the "include" directory with the Poco
@@ -309,6 +313,7 @@ ENABLE_DEBUG_PROTOCOL=false
 LOOLWSD_LOGLEVEL="warning"
 LOOLWSD_LOG_TO_FILE="false"
 LOOLWSD_LOGFILE="/var/log/loolwsd.log"
+LOOLWSD_EVENTTRACEFILE="/var/log/loolwsd.trace"
 LOOLWSD_ANONYMIZE_USER_DATA=false
 LOLEAFLET_LOGGING="false"
 debug_msg="secure mode: product build"
@@ -320,6 +325,7 @@ if test "$enable_debug" = "yes"; then
    LOOLWSD_LOGLEVEL="trace"
    LOOLWSD_LOG_TO_FILE="true"
    LOOLWSD_LOGFILE="/tmp/loolwsd.log"
+   LOOLWSD_EVENTTRACEFILE="/tmp/loolwsd.trace"
    LOOLWSD_ANONYMIZE_USER_DATA=false
    LOLEAFLET_LOGGING="true"
    debug_msg="low security debugging mode"
@@ -348,6 +354,12 @@ if test -n "$with_logfile" ; then
    LOOLWSD_LOGFILE="$with_logfile"
 fi
 AC_SUBST(LOOLWSD_LOGFILE)
+
+if test -n "$with_event_trace_file" ; then
+   LOOLWSD_EVENTTRACEFILE="$with_event_trace_file"
+fi
+AC_SUBST(LOOLWSD_EVENTTRACEFILE)
+AC_DEFINE_UNQUOTED([LOOLWSD_EVENTTRACEFILE], [["]$LOOLWSD_EVENTTRACEFILE["]], [Destination for Event Trace output])
 
 if test "$enable_anonymization" = "yes" ; then
    LOOLWSD_ANONYMIZE_USER_DATA=true

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -787,9 +787,22 @@ public:
         }
 
         const std::string payload = p ? p : "(nil)";
+        Document* self = static_cast<Document*>(data);
+
+        if (type == LOK_CALLBACK_PROFILE_FRAME)
+        {
+            // We must send the trace data to the wsd process for output
+
+            LOG_TRC("Document::GlobalCallback " << lokCallbackTypeToString(type) << ": " << payload.length() << " bytes.");
+
+            self->sendTextFrame("trace:\n" + payload);
+
+            return;
+        }
+
         LOG_TRC("Document::GlobalCallback " << lokCallbackTypeToString(type) <<
                 " [" << payload << "].");
-        Document* self = static_cast<Document*>(data);
+
         if (type == LOK_CALLBACK_DOCUMENT_PASSWORD_TO_MODIFY ||
             type == LOK_CALLBACK_DOCUMENT_PASSWORD)
         {
@@ -824,8 +837,6 @@ public:
                 }
             }
         }
-        else if (type == LOK_CALLBACK_PROFILE_FRAME)
-            return; // already trace dumped above.
 
         // Broadcast leftover status indicator callbacks to all clients
         self->broadcastCallbackToClients(type, payload);

--- a/loolwsd.xml.in
+++ b/loolwsd.xml.in
@@ -72,6 +72,10 @@
         </anonymize>
     </logging>
 
+    <event_trace>
+      <path type="string" desc="Event Trace file path." default="@LOOLWSD_EVENTTRACEFILE@">@LOOLWSD_EVENTTRACEFILE@</path>
+    </event_trace>
+
     <loleaflet_logging desc="Logging in the browser console" default="@LOLEAFLET_LOGGING@">@LOLEAFLET_LOGGING@</loleaflet_logging>
 
     <trace desc="Dump commands and notifications for replay. When 'snapshot' is true, the source file is copied to the path first." enable="false">

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1778,6 +1778,16 @@ bool DocumentBroker::handleInput(const std::vector<char>& payload)
 
             _registeredDownloadLinks[downloadid] = url;
         }
+        else if (command == "trace:")
+        {
+            LOG_CHECK_RET(message->tokens().size() == 1, false);
+            if (LOOLWSD::EventTraceFile != NULL)
+            {
+                const auto newLine = static_cast<const char*>(memchr(payload.data(), '\n', payload.size()));
+                if (newLine)
+                    fwrite(newLine + 1, payload.size() - (newLine + 1 - payload.data()), 1, LOOLWSD::EventTraceFile);
+            }
+        }
         else
         {
             LOG_ERR("Unexpected message: [" << msg << "].");

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -743,6 +743,7 @@ std::string LOOLWSD::ServiceRoot;
 std::string LOOLWSD::LOKitVersion;
 std::string LOOLWSD::ConfigFile = LOOLWSD_CONFIGDIR "/loolwsd.xml";
 std::string LOOLWSD::ConfigDir = LOOLWSD_CONFIGDIR "/conf.d";
+FILE *LOOLWSD::EventTraceFile = NULL;
 std::string LOOLWSD::LogLevel = "trace";
 std::string LOOLWSD::UserInterface = "classic";
 bool LOOLWSD::AnonymizeUserData = false;
@@ -1055,6 +1056,8 @@ void LOOLWSD::initialize(Application& self)
         }
     }
 
+    const auto eventTraceFile = getConfigValue<std::string>(conf, "event_trace.path", LOOLWSD_EVENTTRACEFILE);
+
     // Setup the logfile envar for the kit processes.
     if (logToFile)
     {
@@ -1074,6 +1077,22 @@ void LOOLWSD::initialize(Application& self)
     {
         LOG_INF("Setting log-level to [trace] and delaying setting to configured ["
                 << LogLevel << "] until after WSD initialization.");
+    }
+
+    if (LogLevel == "trace")
+    {
+        LOG_INF("Event Trace file is " << eventTraceFile << ".");
+        EventTraceFile = fopen(eventTraceFile.c_str(), "w");
+        if (EventTraceFile != NULL)
+        {
+            if (fcntl(fileno(EventTraceFile), F_SETFD, FD_CLOEXEC) == -1)
+            {
+                fclose(EventTraceFile);
+                EventTraceFile = NULL;
+            }
+            else
+                fprintf(EventTraceFile, "[\n");
+        }
     }
 
     ServerName = config().getString("server_name");
@@ -4156,6 +4175,16 @@ int LOOLWSD::innerMain()
         // Now should be safe to destroy what's left.
         cleanupDocBrokers();
         DocBrokers.clear();
+    }
+
+    if (EventTraceFile != NULL)
+    {
+        // Back over the last comma and newline.
+        fseek(EventTraceFile, -2, SEEK_CUR);
+        // And close the JSON array.
+        fprintf(EventTraceFile, "\n]\n");
+        fclose(EventTraceFile);
+        EventTraceFile = NULL;
     }
 
 #if !defined(KIT_IN_PROCESS) && !MOBILEAPP

--- a/wsd/LOOLWSD.hpp
+++ b/wsd/LOOLWSD.hpp
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <cstdio>
 #include <map>
 #include <set>
 #include <unordered_set>
@@ -240,6 +241,7 @@ public:
     static std::string WelcomeFilesRoot; ///< From where we should serve the release notes (or otherwise useful content) that is shown on first install or version update.
     static std::string ServiceRoot; ///< There are installations that need prefixing every page with some path.
     static std::string LOKitVersion;
+    static FILE *EventTraceFile;
     static std::string LogLevel;
     static bool AnonymizeUserData;
     static bool CheckLoolUser;


### PR DESCRIPTION
It is (for now) produced (by the ProfileZone things in core) whenever
logging level is "trace". The Event Trace file pathname can be given
in the loolesd.xml file or on the loolwsd command line.

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: I6d5829121e71460a4600ee94d2ebf51043c8893f


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

