### PR TITLE
Private/gokay/calcselectionhighlights

### DIFF
--- a/loleaflet/src/core/LOUtil.js
+++ b/loleaflet/src/core/LOUtil.js
@@ -216,6 +216,34 @@ L.LOUtil = {
 				return false;
 		};
 
+		result.containsXOrdinate = function (ox) {
+			if (ox >= result.x1 && ox <= result.x2)
+				return true;
+			else
+				return false;
+		};
+
+		result.containsYOrdinate = function (oy) {
+			if (oy >= result.y1 && oy <= result.y2)
+				return true;
+			else
+				return false;
+		};
+
+		result.containsPixelOrdinateX = function (ox) {
+			if (ox >= result.px.x1 && ox <= result.px.x2)
+				return true;
+			else
+				return false;
+		};
+
+		result.containsPixelOrdinateY = function (oy) {
+			if (oy >= result.px.y1 && oy <= result.px.y2)
+				return true;
+			else
+				return false;
+		};
+
 		result.calculatePx = function () {
 			result.px.x1 = Math.round(result.x1);
 			result.px.x2 = Math.round(result.x2);

--- a/loleaflet/src/layer/tile/CalcTileLayer.js
+++ b/loleaflet/src/layer/tile/CalcTileLayer.js
@@ -91,6 +91,10 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 		this._annotations = {};
 
 		app.sectionContainer.addSection(new app.definitions.AutoFillMarkerSection());
+
+		this.insertMode = false;
+		this._cellSelections = Array(0);
+		this._cellCursorXY = {x: -1, y: -1};
 	},
 
 	onAnnotationModify: function (annotation) {
@@ -470,10 +474,6 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 		this._map.fire('docsize', newSizePx.clone());
 	},
 
-	_onUpdateCurrentHeader: function() {
-		this._map.fire('updatecurrentheader', this._getCursorPosSize());
-	},
-
 	_getCursorPosSize: function () {
 		var x = -1, y = -1;
 		if (this._cellCursorXY) {
@@ -486,16 +486,6 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 		}
 
 		return { curX: x, curY: y, width: size.x, height: size.y };
-	},
-
-	_onUpdateSelectionHeader: function () {
-		var selectionHeaderData = this._getSelectionHeaderData();
-		if (selectionHeaderData.hasSelection) {
-			this._map.fire('updateselectionheader', selectionHeaderData);
-			return;
-		}
-
-		this._map.fire('clearselectionheader');
 	},
 
 	_getSelectionHeaderData: function() {
@@ -842,6 +832,13 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 			if (e.state.trim() === '' || e.state.startsWith('Selected'))
 				this._onRowColSelCount(e.state.replace('Selected:', '').replace('row', '').replace('column', '').replace('s', ''));
 		}
+		else if (e.commandName === '.uno:InsertMode') {
+			/* If we get textselection message from core:
+				When insertMode is active:  User is selecting some text.
+				When insertMode is passive: User is selecting cells.
+			*/
+			this.insertMode = e.state.trim() === '' ? false: true;
+		}
 	},
 
 	_onSplitStateChanged: function (e, isSplitCol) {
@@ -964,14 +961,37 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 		}
 	},
 
+	_refreshRowColumnHeaders: function () {
+		if (app.sectionContainer.doesSectionExist(L.CSections.RowHeader.name))
+			app.sectionContainer.getSectionWithName(L.CSections.RowHeader.name)._updateCanvas();
+		if (app.sectionContainer.doesSectionExist(L.CSections.ColumnHeader.name))
+			app.sectionContainer.getSectionWithName(L.CSections.ColumnHeader.name)._updateCanvas();
+	},
+
 	_onTextSelectionMsg: function (textMsg) {
 		L.CanvasTileLayer.prototype._onTextSelectionMsg.call(this, textMsg);
-		this._onUpdateSelectionHeader();
+		// If this is a cellSelection message, user shouldn't be editing a cell. Below check is for ensuring that.
+		if (this.insertMode === false && this._cellCursorXY && this._cellCursorXY.x !== -1) {
+			// When insertMode is false, this is a cell selection message.
+			textMsg = textMsg.replace('textselection:', '');
+			if (textMsg.trim() !== 'EMPTY') {
+				this._cellSelections = textMsg.split(';');
+				var ratio = this._tileSize / this._tileWidthTwips;
+				this._cellSelections = this._cellSelections.map(function(element) {
+					element = element.split(',');
+					return L.LOUtil.createRectangle(parseInt(element[0]) * ratio, parseInt(element[1]) * ratio, parseInt(element[2]) * ratio, parseInt(element[3]) * ratio);
+				});
+			}
+			else {
+				this._cellSelections = Array(0);
+			}
+			this._refreshRowColumnHeaders();
+		}
 	},
 
 	_onCellCursorMsg: function (textMsg) {
 		L.CanvasTileLayer.prototype._onCellCursorMsg.call(this, textMsg);
-		this._onUpdateCurrentHeader();
+		this._refreshRowColumnHeaders();
 	},
 
 	_getEditCursorRectangle: function (msgObj) {

--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -972,9 +972,6 @@ L.CanvasTileLayer = L.Layer.extend({
 		this._map.on('splitposchanged', this._painter.update, this._painter);
 		this._map.on('sheetgeometrychanged', this._painter.update, this._painter);
 		this._map.on('move', this._syncTilePanePos, this);
-		this._map.on('updateselectionheader', this._painter.update, this._painter);
-		this._map.on('clearselectionheader', this._painter.update, this._painter);
-		this._map.on('updatecurrentheader', this._painter.update, this._painter);
 
 		this._map.on('viewrowcolumnheaders', this._painter.update, this._painter);
 
@@ -3099,6 +3096,10 @@ L.CanvasTileLayer = L.Layer.extend({
 			this._cellSelectionArea = null;
 			if (autofillMarkerSection)
 				autofillMarkerSection.calculatePositionViaCellSelection(null);
+			this._cellSelections = Array(0);
+			this._map.wholeColumnSelected = false; // Message related to whole column/row selection should be on the way, we should update the variables now.
+			this._map.wholeRowSelected = false;
+			this._refreshRowColumnHeaders();
 		}
 	},
 


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
1:
Move to line 100 (line 1 shouldn't be visible)
Select it
Press CTRL+SHIFT+Home
Row headers aren't painted correctly.

2:
Select row 5
Select row 15
Rows between 5 and 15 shouldn't be painted, but they are.

3:
Select some cells.
Press F2.
Edit the cell content.
While you edit, row and column headers should be painted as selected,
they are not.
Press Enter.
Previous selection should exist.

This patch solves above issues.

### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

