### PR TITLE
test: tolerate missing minor core version

### DIFF
--- a/test/helpers.hpp
+++ b/test/helpers.hpp
@@ -975,8 +975,14 @@ inline void getServerVersion(LOOLWebSocket& socket,
     std::string loProductVersion = loVersionObject->get("ProductVersion").toString();
     std::istringstream stream(loProductVersion);
     stream >> major;
-    assert(stream.get() == '.');
-    stream >> minor;
+    if (stream.get() == '.')
+    {
+        stream >> minor;
+    }
+    else
+    {
+        minor = 0;
+    }
 
     TST_LOG("Client [" << major << '.' << minor << "].");
 }


### PR DESCRIPTION
ProductVersion used to be e.g. "6.4", but co-2021 sets it to just
"2021".

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I08c1204c42bba21c8036975138e3d999b7357bdf
