### PR TITLE
loleaflet: fix activate messages

### DIFF
--- a/loleaflet/src/layer/tile/ImpressTileLayer.js
+++ b/loleaflet/src/layer/tile/ImpressTileLayer.js
@@ -28,6 +28,9 @@ L.ImpressTileLayer = L.CanvasTileLayer.extend({
 		map.on('updatepermission', this.onUpdatePermission, this);
 		map.on('resize', this.onResize, this);
 
+		if (!map._docPreviews)
+			map._docPreviews = {};
+
 		this._annotationManager = L.annotationManagerImpress(map);
 		map.uiManager.initializeSpecializedUI(this._docType);
 		if (window.mode.isMobile()) {

--- a/loleaflet/src/layer/tile/TileLayer.js
+++ b/loleaflet/src/layer/tile/TileLayer.js
@@ -496,6 +496,9 @@ L.TileLayer = L.GridLayer.extend({
 		map.fire('statusindicator', {statusType: 'loleafletloaded'});
 
 		this._map.sendInitUNOCommands();
+
+		this._resetClientVisArea();
+		this._requestNewTiles();
 	},
 
 	// Returns true iff the document type is Writer.

--- a/loleaflet/src/map/Map.js
+++ b/loleaflet/src/map/Map.js
@@ -1338,10 +1338,6 @@ L.Map = L.Evented.extend({
 				// console.debug('sending useractive');
 				this._socket.sendMessage('useractive');
 				this._active = true;
-				if (this._docLayer) {
-					this._docLayer._resetClientVisArea();
-					this._docLayer._requestNewTiles();
-				}
 				this._socket.sendMessage('commandvalues command=.uno:ViewAnnotations');
 
 				if (isAnyVexDialogActive()) {


### PR DESCRIPTION
The activate() function assumes that the document
is loaded when the socket is connected.
This is not true until a status message arrives,
then a document layer is created.
If the document has an interactive dialog (i.e. Macro Warning)
the document formally is not loaded and it should not send
messages that will receive "nodocloaded error".

Change-Id: I01ceb156376712234ab4c12226d080446aa9279d
Signed-off-by: Henry Castro <hcastro@collabora.com>
