### PR TITLE
Avoid ERANGE poisoning numerical conversions.

### DIFF
--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -1148,6 +1148,7 @@ int main(int argc, char**argv)
     {
         const char* str = input.data();
         char* endptr = nullptr;
+        errno = 0;
         const auto value = std::strtol(str, &endptr, 10);
         return std::make_pair(value, endptr > str && errno != ERANGE);
     }
@@ -1161,50 +1162,13 @@ int main(int argc, char**argv)
         return pair.second ? pair : std::make_pair(def, false);
     }
 
-    /// Convert a string to 32-bit unsigned int.
-    /// Returs the parsed value and a boolean indiciating success or failure.
-    inline std::pair<std::uint32_t, bool> u32FromString(const std::string& input)
-    {
-        const char* str = input.data();
-        char* endptr = nullptr;
-        const auto value = std::strtoul(str, &endptr, 10);
-        return std::make_pair(value, endptr > str && errno != ERANGE);
-    }
-
-    /// Convert a string to 32-bit usigned int. On failure, returns the default
-    /// value, and sets the bool to false (to signify that parsing had failed).
-    inline std::pair<std::uint32_t, bool> u32FromString(const std::string& input,
-                                                        const std::uint32_t def)
-    {
-        const auto pair = u32FromString(input);
-        return pair.second ? pair : std::make_pair(def, false);
-    }
-
-    /// Convert a string to 64-bit signed int.
-    /// Returs the parsed value and a boolean indiciating success or failure.
-    inline std::pair<std::int64_t, bool> i64FromString(const std::string& input)
-    {
-        const char* str = input.data();
-        char* endptr = nullptr;
-        const auto value = std::strtol(str, &endptr, 10);
-        return std::make_pair(value, endptr > str && errno != ERANGE);
-    }
-
-    /// Convert a string to 64-bit signed int. On failure, returns the default
-    /// value, and sets the bool to false (to signify that parsing had failed).
-    inline std::pair<std::int64_t, bool> i64FromString(const std::string& input,
-                                                       const std::int64_t def)
-    {
-        const auto pair = i64FromString(input);
-        return pair.second ? pair : std::make_pair(def, false);
-    }
-
     /// Convert a string to 64-bit unsigned int.
     /// Returs the parsed value and a boolean indiciating success or failure.
     inline std::pair<std::uint64_t, bool> u64FromString(const std::string& input)
     {
         const char* str = input.data();
         char* endptr = nullptr;
+        errno = 0;
         const auto value = std::strtoul(str, &endptr, 10);
         return std::make_pair(value, endptr > str && errno != ERANGE);
     }

--- a/test/WhiteBoxTests.cpp
+++ b/test/WhiteBoxTests.cpp
@@ -38,6 +38,7 @@ class WhiteBoxTests : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST(testRegexListMatcher);
     CPPUNIT_TEST(testRegexListMatcher_Init);
     CPPUNIT_TEST(testEmptyCellCursor);
+    CPPUNIT_TEST(testTileDesc);
     CPPUNIT_TEST(testRectanglesIntersect);
     CPPUNIT_TEST(testAuthorization);
     CPPUNIT_TEST(testJson);
@@ -63,6 +64,7 @@ class WhiteBoxTests : public CPPUNIT_NS::TestFixture
     void testRegexListMatcher();
     void testRegexListMatcher_Init();
     void testEmptyCellCursor();
+    void testTileDesc();
     void testRectanglesIntersect();
     void testAuthorization();
     void testJson();
@@ -683,6 +685,18 @@ void WhiteBoxTests::testEmptyCellCursor()
     CallbackDescriptor callbackDescriptor{&document, 0};
     // This failed as stoi raised an std::invalid_argument exception.
     documentViewCallback(LOK_CALLBACK_CELL_CURSOR, "EMPTY", &callbackDescriptor);
+}
+
+void WhiteBoxTests::testTileDesc()
+{
+    // simulate a previous overflow
+    errno = ERANGE;
+    TileDesc desc = TileDesc::parse(
+        "tile nviewid=0 part=5 width=256 height=256 tileposx=0 tileposy=12288 tilewidth=3072 tileheight=3072 oldwid=0 wid=0 ver=33");
+    (void)desc; // exception in parse if we have problems.
+    TileCombined combined = TileCombined::parse(
+        "tilecombine nviewid=0 part=5 width=256 height=256 tileposx=0,3072,6144,9216,12288,15360,18432,21504,0,3072,6144,9216,12288,15360,18432,21504,0,3072,6144,9216,12288,15360,18432,21504,0,3072,6144,9216,12288,15360,18432,21504,0,3072,6144,9216,12288,15360,18432,21504,0,3072,6144,9216,12288,15360,18432,21504,0,3072,6144,9216,12288,15360,18432,21504 tileposy=0,0,0,0,0,0,0,0,3072,3072,3072,3072,3072,3072,3072,3072,6144,6144,6144,6144,6144,6144,6144,6144,9216,9216,9216,9216,9216,9216,9216,9216,12288,12288,12288,12288,12288,12288,12288,12288,15360,15360,15360,15360,15360,15360,15360,15360,18432,18432,18432,18432,18432,18432,18432,18432 oldwid=2,3,4,5,6,7,8,8,9,10,11,12,13,14,15,16,17,18,19,20,21,0,0,0,24,25,26,27,28,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0 tilewidth=3072 tileheight=3072");
+    (void)combined; // exception in parse if we have problems.
 }
 
 void WhiteBoxTests::testRectanglesIntersect()


### PR DESCRIPTION
Behave more similarly to before 65c245eab0.

Change-Id: I0156310257caf7c578fb273393566a0970b3bb1f


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

