### PR TITLE
fix reference/autofill selection redraw on removal

### DIFF
--- a/loleaflet/src/layer/vector/CanvasOverlay.ts
+++ b/loleaflet/src/layer/vector/CanvasOverlay.ts
@@ -132,11 +132,10 @@ class CanvasOverlay {
 	}
 
 	removePath(path: CPath) {
-		// This does not get called via onDraw, so ask tileSection to "erase" by painting over.
-		this.tsManager._tilesSection.onDraw();
+		// This does not get called via onDraw, so ask section container to redraw everything.
 		path.setDeleted();
 		this.paths.delete(path.getId());
-		this.draw();
+		this.overlaySection.containerObject.requestReDraw();
 	}
 
 	updatePath(path: CPath, oldBounds: CBounds) {


### PR DESCRIPTION
Signed-off-by: Dennis Francis <dennis.francis@collabora.com>
Change-Id: I8b6c8dc14093125acbbfc362afb52e0c4c865e2c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
This fixes reference selection and autofill selections. On receiving update messages, it was not erasing the previous drawing before this patch.

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

