### PR TITLE
Update start-collabora-online.sh

### DIFF
--- a/docker/from-packages/scripts/start-collabora-online.sh
+++ b/docker/from-packages/scripts/start-collabora-online.sh
@@ -51,4 +51,4 @@ perl -pi -e "s/<allowed_languages (.*)>.*<\/allowed_languages>/<allowed_language
 loolwsd-generate-proof-key
 
 # Start loolwsd
-exec /usr/bin/loolwsd --version --o:sys_template_path=/opt/lool/systemplate --o:child_root_path=/opt/lool/child-roots --o:file_server_root_path=/usr/share/loolwsd --o:logging.color=false --o:user_interface.mode=notebookbar ${extra_params}
+exec /usr/bin/loolwsd --version --o:sys_template_path=/opt/lool/systemplate --o:child_root_path=/opt/lool/child-roots --o:file_server_root_path=/usr/share/loolwsd --o:logging.color=false ${extra_params}


### PR DESCRIPTION
There is no reason why the UI mode should be set here where it overrides the setting in loolwsd.xml.


* Resolves: #897  <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

