### PR TITLE
cypress: added image operation tests for impress and writer

### DIFF
--- a/cypress_test/integration_tests/common/desktop_helper.js
+++ b/cypress_test/integration_tests/common/desktop_helper.js
@@ -229,6 +229,32 @@ function resetZoomLevel() {
 	shouldHaveZoomLevel('100');
 }
 
+function insertImage() {
+	cy.get('#menu-insert').click();
+
+	cy.contains('#menu-insertgraphic', 'Local Image...')
+		.should('be.visible');
+
+	cy.get('#insertgraphic[type=file]')
+		.attachFile('/desktop/writer/image_to_insert.png');
+
+	cy.get('.leaflet-pane.leaflet-overlay-pane svg g')
+		.should('exist');
+}
+
+function deleteImage() {
+	insertImage();
+
+	cy.get('.leaflet-pane.leaflet-overlay-pane svg g path.leaflet-interactive')
+		.rightclick();
+
+	cy.contains('.context-menu-item','Delete')
+		.click();
+
+	cy.get('.leaflet-pane.leaflet-overlay-pane svg g')
+		.should('not.exist');
+}
+
 module.exports.showSidebar = showSidebar;
 module.exports.hideSidebar = hideSidebar;
 module.exports.showStatusBarIfHidden = showStatusBarIfHidden;
@@ -242,3 +268,5 @@ module.exports.zoomOut = zoomOut;
 module.exports.shouldHaveZoomLevel = shouldHaveZoomLevel;
 module.exports.selectZoomLevel = selectZoomLevel;
 module.exports.resetZoomLevel = resetZoomLevel;
+module.exports.insertImage = insertImage;
+module.exports.deleteImage = deleteImage;

--- a/cypress_test/integration_tests/common/mobile_helper.js
+++ b/cypress_test/integration_tests/common/mobile_helper.js
@@ -309,6 +309,40 @@ function selectListBoxItem2(listboxSelector, item) {
 	cy.log('Selecting an item from listbox 2 - end.');
 }
 
+function insertImage() {
+	openInsertionWizard();
+
+	// We can't use the menu item directly, because it would open file picker.
+	cy.contains('.menu-entry-with-icon', 'Local Image...')
+		.should('be.visible');
+
+	cy.get('#insertgraphic[type=file]')
+		.attachFile('/mobile/writer/image_to_insert.png');
+
+	cy.get('.leaflet-pane.leaflet-overlay-pane svg g')
+		.should('exist');
+}
+
+function deleteImage() {
+	insertImage();
+	var eventOptions = {
+		force: true,
+		button: 0,
+		pointerType: 'mouse'
+	};
+
+	cy.get('.leaflet-control-buttons-disabled > .leaflet-interactive')
+		.trigger('pointerdown', eventOptions)
+		.wait(1000)
+		.trigger('pointerup', eventOptions);
+
+	cy.contains('.menu-entry-with-icon', 'Delete')
+		.should('be.visible').click();
+
+	cy.get('.leaflet-pane.leaflet-overlay-pane svg g')
+		.should('not.exist');
+}
+
 module.exports.enableEditingMobile = enableEditingMobile;
 module.exports.longPressOnDocument = longPressOnDocument;
 module.exports.openHamburgerMenu = openHamburgerMenu;
@@ -325,3 +359,5 @@ module.exports.openTextPropertiesPanel = openTextPropertiesPanel;
 module.exports.selectListBoxItem = selectListBoxItem;
 module.exports.selectListBoxItem2 = selectListBoxItem2;
 module.exports.openCommentWizard = openCommentWizard;
+module.exports.insertImage = insertImage;
+module.exports.deleteImage = deleteImage;

--- a/cypress_test/integration_tests/desktop/impress/image_operation_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/image_operation_spec.js
@@ -1,0 +1,30 @@
+
+/* global describe it cy require afterEach beforeEach */
+
+var helper = require('../../common/helper');
+var { insertImage, deleteImage } = require('../../common/desktop_helper');
+
+describe('Image Operation Tests', function() {
+	var testFileName = 'comment_switching.odp';
+
+	beforeEach(function() {
+		helper.beforeAll(testFileName, 'impress');
+	});
+
+	afterEach(function() {
+		helper.afterAll(testFileName, this.currentTest.state);
+	});
+
+	it('Insert Image',function() {
+		insertImage();
+	});
+
+	it('Delete Image', function() {
+		//close sidebar because it is covering other elements
+		cy.get('#toolbar-up > .w2ui-scroll-right').click();
+
+		cy.get('#tb_editbar_item_modifypage').click();
+
+		deleteImage();
+	});
+});

--- a/cypress_test/integration_tests/desktop/writer/image_operation_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/image_operation_spec.js
@@ -1,0 +1,24 @@
+/* global describe it require afterEach beforeEach */
+
+var helper = require('../../common/helper');
+var { insertImage, deleteImage } = require('../../common/desktop_helper');
+
+describe('Image Operation Tests', function() {
+	var testFileName = 'copy_paste.odt';
+
+	beforeEach(function() {
+		helper.beforeAll(testFileName, 'writer');
+	});
+
+	afterEach(function() {
+		helper.afterAll(testFileName, this.currentTest.state);
+	});
+
+	it('Insert Image',function() {
+		insertImage();
+	});
+
+	it('Delete Image', function() {
+		deleteImage();
+	});
+});

--- a/cypress_test/integration_tests/mobile/impress/image_operation_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/image_operation_spec.js
@@ -1,0 +1,27 @@
+/* global describe it beforeEach require afterEach */
+
+var helper = require('../../common/helper');
+var mobileHelper = require('../../common/mobile_helper');
+
+describe('Image Operation Tests', function() {
+	var testFileName = 'annotation.odp';
+
+	beforeEach(function() {
+		helper.beforeAll(testFileName, 'impress');
+
+		// Click on edit button
+		mobileHelper.enableEditingMobile();
+	});
+
+	afterEach(function() {
+		helper.afterAll(testFileName, this.currentTest.state);
+	});
+
+	it('Insert Image', function() {
+		mobileHelper.insertImage();
+	});
+
+	it('Delete Image', function() {
+		mobileHelper.deleteImage();
+	});
+});

--- a/cypress_test/integration_tests/mobile/writer/image_operation_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/image_operation_spec.js
@@ -1,0 +1,27 @@
+/* global describe it beforeEach require afterEach */
+
+var helper = require('../../common/helper');
+var mobileHelper = require('../../common/mobile_helper');
+
+describe('Image Operation Tests', function() {
+	var testFileName = 'annotation.odt';
+
+	beforeEach(function() {
+		helper.beforeAll(testFileName, 'writer');
+
+		// Click on edit button
+		mobileHelper.enableEditingMobile();
+	});
+
+	afterEach(function() {
+		helper.afterAll(testFileName, this.currentTest.state);
+	});
+
+	it('Insert Image', function() {
+		mobileHelper.insertImage();
+	});
+
+	it('Delete Image', function() {
+		mobileHelper.deleteImage();
+	});
+});

--- a/loleaflet/src/control/Control.ContextMenu.js
+++ b/loleaflet/src/control/Control.ContextMenu.js
@@ -170,8 +170,8 @@ L.Control.ContextMenu = L.Control.extend({
 	},
 
 	_amendContextMenuData: function(obj) {
-		// Add a 'delete' entry  for graphic selection on a mobile device (in browser or app).
-		if (this._map._docLayer.hasGraphicSelection() && (window.mode.isTablet() || window.mode.isMobile())) {
+		// Add a 'delete' entry  for graphic selection on desktop and mobile device (in browser or app).
+		if (this._map._docLayer.hasGraphicSelection()) {
 			var insertIndex = -1;
 			obj.menu.forEach(function(item, index) {
 				if (item.command === '.uno:Paste') {


### PR DESCRIPTION

Signed-off-by: Rash419 <rashesh.padia@collabora.com>
Change-Id: Ic552217d03d77f93f5c38107d622d8404c122cd7

* Target version: master 

### Summary
added delete option in context menu when rightclicking on graphic 

![image](https://user-images.githubusercontent.com/26241069/115239990-efe7fd00-a13c-11eb-8773-b3a0e36104a9.png)
