### PR TITLE
annotation: fixed annotation highlight on document load

### DIFF
--- a/loleaflet/src/layer/marker/Annotation.js
+++ b/loleaflet/src/layer/marker/Annotation.js
@@ -95,6 +95,10 @@ L.Annotation = L.Layer.extend({
 
 	show: function () {
 		this.showMarker();
+		if (this._data.textSelected && this._map.hasLayer && !this._map.hasLayer(this._data.textSelected)) {
+			this._map.addLayer(this._data.textSelected);
+		}
+
 		if (window.mode.isMobile())
 			return;
 
@@ -102,10 +106,6 @@ L.Annotation = L.Layer.extend({
 		this._contentNode.style.display = '';
 		this._nodeModify.style.display = 'none';
 		this._nodeReply.style.display = 'none';
-
-		if (this._data.textSelected && this._map.hasLayer && !this._map.hasLayer(this._data.textSelected)) {
-			this._map.addLayer(this._data.textSelected);
-		}
 	},
 
 	hide: function () {


### PR DESCRIPTION


Signed-off-by: Pranam Lashkari <lpranam@collabora.com>
Change-Id: I814c57069781a7fa39651c2beb4826775c0df177


* Target version: master 

### Summary
problem: when document was loaded comments were not highlighted

### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

