### PR TITLE
autofill/reference selection fix, flicker with freezepane fix and others (to co-6-4)

### DIFF
--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -219,6 +219,7 @@ L.TileSectionManager = L.Class.extend({
 			viewBounds.round();
 
 			var paneOffset;
+			var doOnePane = false;
 			if (!repaintArea || !paneTopLeft) {
 				repaintArea = paneBounds;
 				paneOffset = paneBounds.getTopLeft(); // allocates
@@ -226,7 +227,8 @@ L.TileSectionManager = L.Class.extend({
 				paneOffset.x = Math.min(paneOffset.x, viewBounds.min.x);
 				paneOffset.y = Math.min(paneOffset.y, viewBounds.min.y);
 			} else {
-				repaintArea = paneBounds.clamp(repaintArea);
+				// do only for the predefined pane (paneOffset/repaintArea)
+				doOnePane = true;
 				paneOffset = paneTopLeft.clone();
 			}
 
@@ -246,6 +248,9 @@ L.TileSectionManager = L.Class.extend({
 					context.lineTo(repaintArea.max.x - paneOffset.x - 0.5, pos - paneOffset.y - 0.5);
 					context.stroke();
 				});
+
+			if (doOnePane)
+				break;
 		}
 		context.closePath();
 	},

--- a/loleaflet/src/layer/tile/TilesSection.ts
+++ b/loleaflet/src/layer/tile/TilesSection.ts
@@ -259,11 +259,16 @@ class TilesSection {
 
 		var docLayer = this.sectionProperties.docLayer;
 		var tileSection = this;
+		var doneTiles = new Set();
 		this.forEachTileInView(zoom, part, ctx, function (tile: any, coords: any): boolean {
+			if (doneTiles.has(coords.key()))
+				return true;
+
 			// Ensure tile is loaded and is within document bounds.
 			if (tile && tile.loaded && docLayer._isValidTile(coords)) {
 				tileSection.paint(tile, ctx, false /* async? */);
 			}
+			doneTiles.add(coords.key());
 			return true; // continue with remaining tiles.
 		});
 	}

--- a/loleaflet/src/layer/vector/CanvasOverlay.ts
+++ b/loleaflet/src/layer/vector/CanvasOverlay.ts
@@ -140,11 +140,10 @@ class CanvasOverlay {
 	}
 
 	removePath(path: CPath) {
-		// This does not get called via onDraw, so ask tileSection to "erase" by painting over.
-		this.tsManager._tilesSection.onDraw();
+		// This does not get called via onDraw, so ask section container to redraw everything.
 		path.setDeleted();
 		this.paths.delete(path.getId());
-		this.draw();
+		this.overlaySection.containerObject.requestReDraw();
 	}
 
 	updatePath(path: CPath, oldBounds: CBounds) {

--- a/loleaflet/src/layer/vector/CanvasOverlay.ts
+++ b/loleaflet/src/layer/vector/CanvasOverlay.ts
@@ -212,9 +212,7 @@ class CanvasOverlay {
 		// is potentially expensive to compute (think of overlapped path objects).
 		// TODO: We could repaint the area on the canvas occupied by all the visible path-objects
 		// and paint tiles just for that, but need a more general version of _tilesSection.onDraw() and callees.
-		this.tsManager.clearTilesSection();
-		this.tsManager._tilesSection.onDraw();
-		this.draw();
+		this.overlaySection.containerObject.requestReDraw();
 	}
 
 	private updateCanvasBounds() {


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
Autofill/reference selection fix, flicker with freezepane fix and other canvas related fixes.

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

