### PR TITLE
unit-crash: avoid socket deletion before _socketPoll completes the async shutdown

### DIFF
--- a/test/httpcrashtest.cpp
+++ b/test/httpcrashtest.cpp
@@ -243,6 +243,10 @@ void HTTPCrashTest::testCrashForkit()
         socket->asyncShutdown(_socketPoll);
         LOK_ASSERT_MESSAGE("Expected successful disconnection of the WebSocket",
                            socket->waitForDisconnection(std::chrono::seconds(5)));
+
+        // Wait till async shutdown fully completes, as _socketPoll has no owning reference to
+        // socket.
+        _socketPoll.wakeupWorld();
     }
     catch (const Poco::Exception& exc)
     {


### PR DESCRIPTION
Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Ibb9f7d7681d502d06de92c2f5d8305c3f27a76c0
