### PR TITLE
FIX #1018 add dropdown arrow to color picker

### DIFF
--- a/loleaflet/src/control/Control.NotebookbarBuilder.js
+++ b/loleaflet/src/control/Control.NotebookbarBuilder.js
@@ -415,9 +415,7 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 			button.id = buttonId;
 			button.setAttribute('alt', id);
 
-			if (data.id === 'FontColor' || data.id === 'BackColor' || data.id === 'BackgroundColor') {
-				L.DomUtil.create('i', 'unoarrow', div);
-			}
+			L.DomUtil.create('i', 'unoarrow', div);
 
 			var valueNode =  L.DomUtil.create('div', 'selected-color', div);
 


### PR DESCRIPTION
Signed-off-by: Andreas_K <andreas_k@abwesend.de>
Change-Id: I9029e1d9d6e951b77e195e8e0543e7e96d627efe


* Resolves: #1018
* Target version: master 

### Summary
All color pickers has a dropdown element at NB implementations