### PR TITLE
fix #1611 remove gray background of uno:color command in NB

### DIFF
--- a/loleaflet/css/mobilewizard.css
+++ b/loleaflet/css/mobilewizard.css
@@ -665,7 +665,7 @@ a.leaflet-control-zoom-in {
 #buttonnone + label, #buttonbefore + label, #buttonafter + label, #buttonoptimal + label, #buttonparallel + label, #buttonthrough + label{
 	padding-left: 0;
 }
-#Color > img{
+#mobile-wizard #Color > img{
 	border-radius: 100px;
 	background-color: #696969;
 }


### PR DESCRIPTION
Signed-off-by: Andreas_K <andreas_k@abwesend.de>
Change-Id: I0e903990cb83bfe5e4194f760ae294c6c9083fc7

* Resolves: # 1611
* Target version: master 

### Summary
before
![Screenshot_20210420_233538](https://user-images.githubusercontent.com/8517736/115467774-53a02200-a232-11eb-85a5-c1b986c4d113.png)
after
![Screenshot_20210420_233612](https://user-images.githubusercontent.com/8517736/115467784-58fd6c80-a232-11eb-88f2-c0d774a8859c.png)

The change was done in mobilewizard.css file, I don't know what I break with remove the #Color stuff in mobile. So review is needed.