### PR TITLE
fix #1285 remove elipsis ... from NB strings

### DIFF
--- a/loleaflet/src/control/Control.JSDialogBuilder.js
+++ b/loleaflet/src/control/Control.JSDialogBuilder.js
@@ -357,7 +357,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 	_cleanText: function(text) {
 		if (!text)
 			return '';
-		return text.replace('~', '');
+		return text.replace('~', '').replace('...', '');
 	},
 
 	_cleanValueFromUnits: function(text) {
@@ -2398,7 +2398,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 				$(div).addClass('inline');
 				label = L.DomUtil.create('span', 'ui-content unolabel', div);
 				label.for = buttonId;
-				label.innerHTML = data.text;
+				label.innerHTML = builder._cleanText(data.text);
 
 				controls['label'] = label;
 			}

--- a/loleaflet/src/control/Control.NotebookbarBuilder.js
+++ b/loleaflet/src/control/Control.NotebookbarBuilder.js
@@ -676,7 +676,6 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 	},
 
 	_saveAsControl: function(parentContainer, data, builder) {
-		data.text = data.text.replace('...', '');
 		var control = builder._unoToolButton(parentContainer, data, builder);
 
 		$(control.container).unbind('click');
@@ -695,7 +694,6 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 	},
 
 	_printControl: function(parentContainer, data, builder) {
-		data.text = data.text.replace('...', '');
 		var control = builder._unoToolButton(parentContainer, data, builder);
 
 		$(control.container).unbind('click');


### PR DESCRIPTION
Signed-off-by: Andreas_K <andreas_k@abwesend.de>
Change-Id: I9d9d70c292772b349687d14fc3b92cd3fd5d86b7


* Resolves: #1284 
* Target version: master 

### Summary
No ... any more at the Notebookbar labels
![Screenshot_20210421_003932](https://user-images.githubusercontent.com/8517736/115472397-1049b180-a23a-11eb-8e6e-f5f46dffd8ce.png)

As there is already an _cleanText function to remove the ~ I added the '...' for replacement and add _cleanText to the NB labels.

If NB use the wrong strings from core this PR isn't wrong anyway cause it's remove the elipsis elements in addition to ~ when the string from core don't has ... it's also well.
