### PR TITLE
annotation: avoid comment wizard opening on text modify

### DIFF
--- a/loleaflet/src/layer/AnnotationManager.js
+++ b/loleaflet/src/layer/AnnotationManager.js
@@ -908,10 +908,17 @@ L.AnnotationManager = L.AnnotationManagerBase.extend({
 				this.update();
 			}
 		}
-		if (window.mode.isMobile() &&
-		(obj.comment.author === this._map.getViewName(this._map._docLayer._viewId) ||
-		obj.comment.author === undefined && window.commentWizard === true))
-			this._map._docLayer._openCommentWizard(annotation);
+		if (window.mode.isMobile()) {
+			var shouldOpenWizard = false;
+			var wePerformedAction = obj.comment.author === this._map.getViewName(this._map._docLayer._viewId);
+
+			if (window.commentWizard || (action === 'Add' && wePerformedAction))
+				shouldOpenWizard = true;
+
+			if (shouldOpenWizard) {
+				this._map._docLayer._openCommentWizard(annotation);
+			}
+		}
 	},
 
 	_onAnnotationCancel: function (e) {


### PR DESCRIPTION


Signed-off-by: Pranam Lashkari <lpranam@collabora.com>
Change-Id: Ie9422cb5c868eac52239a3a0998246e9b98972cb


* Target version: master 

### Summary
problem:
when the text where comment was inserted is modified
it would invoke comment wizard

i.e: try to insert image between comment text

### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

