### PR TITLE
NB File Tab Impress - Simplify json structure

### DIFF
--- a/loleaflet/src/control/Control.NotebookbarImpress.js
+++ b/loleaflet/src/control/Control.NotebookbarImpress.js
@@ -155,229 +155,120 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 
 		var content = [
 			{
-				'id': 'File-Section',
+				'id': 'File-Tab',
 				'type': 'container',
 				'text': '',
 				'enabled': 'true',
 				'children': [
 					hasSaveAs ?
 						{
-							'id': 'Section2',
-							'type': 'toolbox',
-							'text': '',
-							'enabled': 'true',
-							'children': [
-								{
-									'id': 'saveas',
-									'type': 'bigtoolitem',
-									'text': _UNO('.uno:SaveAs', 'presentation'),
-									'command': '.uno:SaveAs'
-								}
-							]
+							'id': 'saveas',
+							'type': 'bigtoolitem',
+							'text': _UNO('.uno:SaveAs', 'presentation'),
+							'command': '.uno:SaveAs'
 						} : {},
-					hasShare ?
-						{
-							'id': 'Section3',
-							'type': 'toolbox',
-							'text': '',
-							'enabled': 'true',
-							'children': [
-								{
-									'id': 'shareas',
-									'type': 'bigtoolitem',
-									'text': _('Share'),
-									'command': '.uno:shareas'
-								}
-							]
-						} : {},
+					{
+						'id': 'Share-Section-ShareHistory',
+						'type': 'container',
+						'children': [
+							{
+								'type': 'toolbox',
+								'children': [
+									hasShare ?
+										{
+											'id': 'shareas',
+											'type': 'menubartoolitem',
+											'text': _('Share'),
+											'command': '.uno:shareas'
+										} : {},
+								]
+							},
+							{
+								'type': 'toolbox',
+								'children': [
+									hasRevisionHistory ?
+										{
+											'id': 'rev-history',
+											'type': 'menubartoolitem',
+											'text': _('See history'),
+											'command': '.uno:rev-history'
+										} : {},
+								]
+							}
+						],
+						'vertical': 'true'
+					},
 					hasPrint ?
 						{
-							'id': 'Section4',
-							'type': 'toolbox',
-							'text': '',
-							'enabled': 'true',
-							'children': [
-								{
-									'id': 'print',
-									'type': 'bigtoolitem',
-									'text': _UNO('.uno:Print', 'presentation'),
-									'command': '.uno:Print'
-								}
-							]
-						} : {},
-					hasRevisionHistory ?
-						{
-							'id': 'Section5',
-							'type': 'toolbox',
-							'text': '',
-							'enabled': 'true',
-							'children': [
-								{
-									'id': 'rev-history',
-									'type': 'bigtoolitem',
-									'text': _('See history'),
-									'command': '.uno:rev-history'
-								}
-							]
+							'id': 'print',
+							'type': 'bigtoolitem',
+							'text': _UNO('.uno:Print', 'presentation'),
+							'command': '.uno:Print'
 						} : {},
 					{
-						'id': 'saveas-Section',
-						'type': 'container',
-						'text': '',
-						'enabled': 'true',
-						'vertical': 'true',
-						'children': [
-							{
-								'id': 'saveas-Section1',
-								'type': 'container',
-								'text': '',
-								'enabled': 'true',
-								'children': [
-									{
-										'id': 'Section7',
-										'type': 'toolbox',
-										'text': '',
-										'enabled': 'true',
-										'children': [
-											{
-												'id': 'downloadas-odp',
-												'type': 'menubartoolitem',
-												'text': _('ODF presentation (.odp)'),
-												'command': ''
-											}
-										]
-									}
-								]
-							},
-							{
-								'id': 'saveas-Section2',
-								'type': 'container',
-								'text': '',
-								'enabled': 'true',
-								'children': [
-									{
-										'id': 'Section10',
-										'type': 'toolbox',
-										'text': '',
-										'enabled': 'true',
-										'children': [
-											{
-												'id': 'downloadas-odg',
-												'type': 'menubartoolitem',
-												'text': _('ODF Drawing (.odg)'),
-												'command': ''
-											}
-										]
-									}
-								]
-							}
-						]
+						'id': 'downloadas-pdf',
+						'type': 'menubartoolitem',
+						'text': _('PDF Document (.pdf)'),
+						'command': ''
 					},
 					{
-						'id': 'saveas-Section',
+						'id': 'Save-Section-ODF',
 						'type': 'container',
-						'text': '',
-						'enabled': 'true',
-						'vertical': 'true',
 						'children': [
 							{
-								'id': 'saveas-Section1',
-								'type': 'container',
-								'text': '',
-								'enabled': 'true',
+								'type': 'toolbox',
 								'children': [
 									{
-										'id': 'Section8',
-										'type': 'toolbox',
-										'text': '',
-										'enabled': 'true',
-										'children': [
-											{
-												'id': 'downloadas-ppt',
-												'type': 'menubartoolitem',
-												'text': _('PowerPoint 2003 Presentation (.ppt)'),
-												'command': ''
-											}
-										]
+										'id': 'downloadas-odp',
+										'type': 'menubartoolitem',
+										'text': _('ODF presentation (.odp)'),
+										'command': ''
 									}
 								]
 							},
 							{
-								'id': 'saveas-Section2',
-								'type': 'container',
-								'text': '',
-								'enabled': 'true',
+								'type': 'toolbox',
 								'children': [
 									{
-										'id': 'Section9',
-										'type': 'toolbox',
-										'text': '',
-										'enabled': 'true',
-										'children': [
-											{
-												'id': 'downloadas-pptx',
-												'type': 'menubartoolitem',
-												'text': _('PowerPoint Presentation (.pptx)'),
-												'command': ''
-											}
-										]
+										'id': 'downloadas-odg',
+										'type': 'menubartoolitem',
+										'text': _('ODF Drawing (.odg)'),
+										'command': ''
 									}
 								]
 							}
-						]
+						],
+						'vertical': 'true'
 					},
 					{
-						'id': 'saveas-Section',
+						'id': 'Save-Section-Powerpoint',
 						'type': 'container',
-						'text': '',
-						'enabled': 'true',
-						'vertical': 'true',
 						'children': [
 							{
-								'id': 'saveas-Section1',
-								'type': 'container',
-								'text': '',
-								'enabled': 'true',
+								'type': 'toolbox',
 								'children': [
 									{
-										'id': 'Section6',
-										'type': 'toolbox',
-										'text': '',
-										'enabled': 'true',
-										'children': [
-											{
-												'id': 'downloadas-pdf',
-												'type': 'menubartoolitem',
-												'text': _('PDF Document (.pdf)'),
-												'command': ''
-											}
-										]
+										'id': 'downloadas-ppt',
+										'type': 'menubartoolitem',
+										'text': _('PowerPoint 2003 Presentation (.ppt)'),
+										'command': ''
 									}
 								]
 							},
 							{
-								'id': 'saveas-Section2',
-								'type': 'container',
-								'text': '',
-								'enabled': 'true',
+								'type': 'toolbox',
 								'children': [
 									{
-										'id': 'Section11',
-										'type': 'toolbox',
-										'text': '',
-										'enabled': 'true',
-										'children': [
-											{
-												'type': 'menubartoolitem',
-												'text': '',
-												'command': ''
-											}
-										]
+										'id': 'downloadas-pptx',
+										'type': 'menubartoolitem',
+										'text': _('PowerPoint Presentation (.pptx)'),
+										'command': ''
 									}
 								]
 							}
-						]
-					}
+						],
+						'vertical': 'true'
+					},
 				]
 			}
 		];

--- a/loleaflet/src/control/Control.NotebookbarImpress.js
+++ b/loleaflet/src/control/Control.NotebookbarImpress.js
@@ -206,12 +206,6 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 							'command': '.uno:Print'
 						} : {},
 					{
-						'id': 'downloadas-pdf',
-						'type': 'menubartoolitem',
-						'text': _('PDF Document (.pdf)'),
-						'command': ''
-					},
-					{
 						'id': 'Save-Section-ODF',
 						'type': 'container',
 						'children': [
@@ -268,6 +262,12 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 							}
 						],
 						'vertical': 'true'
+					},
+					{
+						'id': 'downloadas-pdf',
+						'type': 'menubartoolitem',
+						'text': _('PDF Document (.pdf)'),
+						'command': ''
 					},
 				]
 			}


### PR DESCRIPTION
Signed-off-by: Andreas_K <andreas_k@abwesend.de>
Change-Id: I40baa8e1855bf5b5744d47b702a4f388e71bb1fc


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
Simplify json structure of the file tab. Structure was used from the insert tab.

### TODO
How can I make the pdf button a bigtoolitem instead of menubartoolitem?

If @eszkadev will he happy with this PR and the pdf button will be a bigtoolitem, I will update all other NB File-Tabs