### PR TITLE
Add an initial libfuzzer based fuzzer for http::Header::parse()

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -144,7 +144,8 @@ noinst_PROGRAMS = clientnb \
 if ENABLE_LIBFUZZER
 noinst_PROGRAMS += \
 		   admin_fuzzer \
-		   clientsession_fuzzer
+		   clientsession_fuzzer \
+		   httpheader_fuzzer
 else
 noinst_PROGRAMS += loolwsd_fuzzer
 endif
@@ -194,6 +195,16 @@ clientsession_fuzzer_SOURCES = \
 			       $(shared_sources) \
 			       fuzzer/ClientSession.cpp
 clientsession_fuzzer_LDFLAGS = -fsanitize=fuzzer $(AM_LDFLAGS)
+
+httpheader_fuzzer_CPPFLAGS = \
+				-DKIT_IN_PROCESS=1 \
+				$(AM_CPPFLAGS)
+httpheader_fuzzer_SOURCES = \
+			       $(loolwsd_sources) \
+			       $(loolforkit_sources) \
+			       $(shared_sources) \
+			       fuzzer/HttpHeader.cpp
+httpheader_fuzzer_LDFLAGS = -fsanitize=fuzzer $(AM_LDFLAGS)
 
 clientnb_SOURCES = net/clientnb.cpp \
                    common/Log.cpp \

--- a/fuzzer/HttpHeader.cpp
+++ b/fuzzer/HttpHeader.cpp
@@ -1,0 +1,14 @@
+#include <iostream>
+
+#include "config.h"
+
+#include <net/HttpRequest.hpp>
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
+{
+    http::Header header;
+    header.parse(reinterpret_cast<const char*>(data), size);
+    return 0;
+}
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/fuzzer/httpheader-data/load
+++ b/fuzzer/httpheader-data/load
@@ -1,0 +1,7 @@
+HTTP/1.1 101 Switching Protocols
+Date: Thu, 22 Apr 2021 07:37:15
+Server: LOOLWSD HTTP Server 2021.0.0
+Upgrade: websocket
+Connection: Upgrade
+Sec-WebSocket-Accept: WPZXjXJKKiTiMWIRRSJnOzhX5ZI=
+


### PR DESCRIPTION
Run the actual fuzzer like this:

./httpheader_fuzzer -max_len=16384 fuzzer/httpheader-data/

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I91afe44a632826cc15bd1c338bcc5234582e9674
