### PR TITLE
Private/eszkadev/formulabar resize optimization

### DIFF
--- a/loleaflet/src/control/Control.LokDialog.js
+++ b/loleaflet/src/control/Control.LokDialog.js
@@ -1556,7 +1556,7 @@ L.Control.LokDialog = L.Control.extend({
 				that._map._docLayer._syncTileContainerSize();
 				// resize the input bar to the correct size
 				// the input bar is rendered only if when the size is the expected one
-				if (that._calcInputBar.width !== correctWidth) {
+				if (correctWidth !== 0 && that._calcInputBar.width !== correctWidth) {
 					console.log('_paintDialog: correct width: ' + correctWidth + ', _calcInputBar width: ' + that._calcInputBar.width);
 					that._dialogs[parentId].isPainting = false;
 					that._map._socket.sendMessage('resizewindow ' + parentId + ' size=' + correctWidth + ',' + that._calcInputBar.height);

--- a/loleaflet/src/map/Map.js
+++ b/loleaflet/src/map/Map.js
@@ -1307,9 +1307,16 @@ L.Map = L.Evented.extend({
 			if (calcInputbar) {
 				var calcInputbarContainer = calcInputbar.children[0];
 				if (calcInputbarContainer) {
+					var sizeChanged = true;
 					var width = calcInputbarContainer.clientWidth - deckOffset;
 					var height = calcInputbarContainer.clientHeight;
-					if (width > 0 && height > 0) {
+					if (calcInputbarContainer.children && calcInputbarContainer.children.length) {
+						var inputbarCanvas = calcInputbarContainer.children[0];
+						var currentWidth = inputbarCanvas.clientWidth;
+						var currentHeight = inputbarCanvas.clientHeight;
+						sizeChanged = (currentWidth !== width || currentHeight !== height);
+					}
+					if (width > 0 && height > 0 && sizeChanged) {
 						console.log('_onResize: container width: ' + width + ', container height: ' + height + ', _calcInputBar width: ' + this.dialog._calcInputBar.width);
 						this._socket.sendMessage('resizewindow ' + id + ' size=' + width + ',' + height);
 					}


### PR DESCRIPTION
Fix for #1988 which allows us to revert core hacks (https://gerrit.libreoffice.org/c/core/+/114474).
Solves two problems:
- formulabar not visible when just loaded spreadsheet
- spamming core with "resizewindow" messages on every sidebar refresh