### PR TITLE
Writer Notebookbar Home Tab update

### DIFF
--- a/loleaflet/css/notebookbar.css
+++ b/loleaflet/css/notebookbar.css
@@ -419,7 +419,7 @@ div[id*='Row'].notebookbar, div[id*='Column'].notebookbar, #SendToBack.notebookb
 	width: 60px !important;
 }
 
-#Paste.notebookbar img, #InsertAnnotation.notebookbar img, #SearchDialog.notebookbar img {
+#Paste.notebookbar img, #SearchDialog.notebookbar img {
 	height: 32px !important;
 	width: 32px !important;
 }
@@ -464,7 +464,7 @@ div[id*='Row'].notebookbar, div[id*='Column'].notebookbar, #SendToBack.notebookb
 
 #stylesview {
 	height: 60px;
-	width: 400px;
+	width: 530px;
 	overflow-x: hidden;
 	border: 1px dashed silver;
 	padding: 5px;

--- a/loleaflet/src/control/Control.NotebookbarCalc.js
+++ b/loleaflet/src/control/Control.NotebookbarCalc.js
@@ -115,7 +115,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 					{
 						'id': 'downloadas-ods',
 						'type': 'menubartoolitem',
-						'text': _('ODF spreadsheet (.ods)'),
+						'text': _('ODF Spreadsheet (.ods)'),
 						'command': ''
 					},
 					{

--- a/loleaflet/src/control/Control.NotebookbarImpress.js
+++ b/loleaflet/src/control/Control.NotebookbarImpress.js
@@ -196,7 +196,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 					{
 						'id': 'downloadas-odp',
 						'type': 'menubartoolitem',
-						'text': _('ODF presentation (.odp)'),
+						'text': _('ODF Presentation (.odp)'),
 						'command': ''
 					},
 					{
@@ -221,7 +221,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 					{
 						'id': 'downloadas-pptx',
 						'type': 'menubartoolitem',
-						'text': _('PowerPoint 2003 Presentation (.pptx)'),
+						'text': _('PowerPoint Presentation (.pptx)'),
 						'command': ''
 					},
 				],

--- a/loleaflet/src/control/Control.NotebookbarWriter.js
+++ b/loleaflet/src/control/Control.NotebookbarWriter.js
@@ -130,7 +130,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 					{
 						'id': 'downloadas-odt',
 						'type': 'menubartoolitem',
-						'text': _('ODF text document (.odt)'),
+						'text': _('ODF Text Document (.odt)'),
 						'command': ''
 					},
 					{
@@ -174,7 +174,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 					{
 						'id': 'downloadas-epub',
 						'type': 'menubartoolitem',
-						'text': _('EPUB (.epub)'),
+						'text': _('EPUB Document (.epub)'),
 						'command': ''
 					},
 				],
@@ -316,6 +316,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				'vertical': 'true'
 			},
 			{
+				'id': 'Home-Section-Style',
 				'type': 'container',
 				'children': [
 					{
@@ -344,6 +345,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				'vertical': 'true'
 			},
 			{
+				'id': 'Home-Section-Format',
 				'type': 'container',
 				'children': [
 					{
@@ -422,13 +424,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 										'type': 'toolitem',
 										'text': _UNO('.uno:Strikeout'),
 										'command': '.uno:Strikeout'
-									}
-								]
-							},
-							{
-								'id': 'ExtTop5',
-								'type': 'toolbox',
-								'children': [
+									},
 									{
 										'type': 'toolitem',
 										'text': _UNO('.uno:SubScript'),
@@ -438,13 +434,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 										'type': 'toolitem',
 										'text': _UNO('.uno:SuperScript'),
 										'command': '.uno:SuperScript'
-									}
-								]
-							},
-							{
-								'id': 'ExtTop2',
-								'type': 'toolbox',
-								'children': [
+									},
 									{
 										'type': 'toolitem',
 										'text': _UNO('.uno:BackColor'),
@@ -464,6 +454,8 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				'vertical': 'true'
 			},
 			{
+				'id': 'Home-Section-Paragraph',
+				'type': 'container',
 				'children': [
 					{
 						'type': 'container',
@@ -494,9 +486,19 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 									},
 									{
 										'type': 'toolitem',
-										'text': _UNO('.uno:LineSpacing'),
-										'command': '.uno:LineSpacing'
+										'text': _UNO('.uno:ControlCodes', 'text'),
+										'command': '.uno:ControlCodes'
 									},
+									{
+										'type': 'toolitem',
+										'text': _UNO('.uno:ParaLeftToRight'),
+										'command': '.uno:ParaLeftToRight'
+									},
+									{
+										'type': 'toolitem',
+										'text': _UNO('.uno:ParaRightToLeft'),
+										'command': '.uno:ParaRightToLeft'
+									}
 								]
 							},
 						],
@@ -528,54 +530,12 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 										'type': 'toolitem',
 										'text': _UNO('.uno:JustifyPara'),
 										'command': '.uno:JustifyPara'
-									}
-								]
-							},
-						],
-						'vertical': 'false'
-					}
-				],
-				'vertical': 'true'
-			},
-			{
-				'children': [
-					{
-						'type': 'container',
-						'children': [
-							{
-								'id': 'SectionBottom81',
-								'type': 'toolbox',
-								'children': [
-									
+									},
 									{
 										'type': 'toolitem',
-										'text': _UNO('.uno:ControlCodes', 'text'),
-										'command': '.uno:ControlCodes'
-									}
-								]
-							},
-							{
-								'id': 'SectionBottom93',
-								'type': 'toolbox',
-								'children': [
-									{
-										'type': 'toolitem',
-										'text': _UNO('.uno:ParaLeftToRight'),
-										'command': '.uno:ParaLeftToRight'
-									}
-								]
-							}
-						],
-						'vertical': 'false'
-					},
-					{
-						'type': 'container',
-						'children': [
-							{
-								'id': 'SectionBottom125',
-								'type': 'toolbox',
-								'children': [
-									
+										'text': _UNO('.uno:LineSpacing'),
+										'command': '.uno:LineSpacing'
+									},
 									{
 										'type': 'toolitem',
 										'text': _UNO('.uno:BackgroundColor'),
@@ -583,17 +543,6 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 									}
 								]
 							},
-							{
-								'id': 'SectionBottom130',
-								'type': 'toolbox',
-								'children': [
-									{
-										'type': 'toolitem',
-										'text': _UNO('.uno:ParaRightToLeft'),
-										'command': '.uno:ParaRightToLeft'
-									}
-								]
-							}
 						],
 						'vertical': 'false'
 					}
@@ -616,45 +565,6 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 					}
 				],
 				'vertical': 'false'
-			},
-			{
-				'id': 'Home-Section-Style4',
-				'type': 'container',
-				'children': [
-					{
-						'id': 'SectionBottom138',
-						'type': 'toolbox',
-						'children': [
-							{
-								'type': 'toolitem',
-								'text': _UNO('.uno:StyleUpdateByExample'),
-								'command': '.uno:StyleUpdateByExample'
-							},
-							{
-								'type': 'toolitem',
-								'text': _UNO('.uno:EditStyle'),
-								'command': '.uno:EditStyle'
-							}
-						]
-					},
-					{
-						'id': 'SectionBottom141',
-						'type': 'toolbox',
-						'children': [
-							{
-								'type': 'toolitem',
-								'text': _('Emphasis'),
-								'command': '.uno:StyleApply?Style:string=Emphasis&FamilyName:string=CharacterStyles'
-							},
-							{
-								'type': 'toolitem',
-								'text': _('Strong Emphasis'),
-								'command': '.uno:StyleApply?Style:string=Strong Emphasis&FamilyName:string=CharacterStyles'
-							}
-						]
-					}
-				],
-				'vertical': 'true'
 			},
 			{
 				'id': 'Home-Section-Insert',
@@ -689,16 +599,16 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 								'type': 'toolitem',
 								'text': _UNO('.uno:CharmapControl'),
 								'command': '.uno:CharmapControl'
+							},
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:InsertAnnotation'),
+								'command': '.uno:InsertAnnotation'
 							}
 						]
 					}
 				],
 				'vertical': 'true'
-			},
-			{
-				'type': 'bigtoolitem',
-				'text': _UNO('.uno:InsertAnnotation'),
-				'command': '.uno:InsertAnnotation'
 			}
 		];
 


### PR DESCRIPTION
Signed-off-by: Andreas_K <andreas_k@abwesend.de>
Change-Id: I2fe501fcf512f7712022177806b45eb48bc4e204


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
Update writer notebookbar home tab

### Before
![Writer-Home-1](https://user-images.githubusercontent.com/8517736/115795435-36a15580-a3d0-11eb-9009-554923638191.png)

### After
![Writer-Home-2](https://user-images.githubusercontent.com/8517736/115795621-86801c80-a3d0-11eb-8403-49bc834bba51.png)

1. Paragraph section is now one single group (more simple)
2. Preview of 4 styles. Online it's not so importend how width an widget is cause the widget wasn't hidden. Next group is something like an "shortcut" for insert. In addition show more previews, will be easier to select, recognize, and there are Default Style, Text Style, Title, Subtitle (4 items) than Heading 1, Heading 2, Heading 3, Quoations