### PR TITLE
clang-format: turn off BreakBeforeBinaryOperators

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -7,7 +7,7 @@ AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakTemplateDeclarations: false
 AlwaysBreakBeforeMultilineStrings: false
-BreakBeforeBinaryOperators: true
+BreakBeforeBinaryOperators: None
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializersBeforeComma: true
 BinPackParameters: true


### PR DESCRIPTION
Improve readability by not suggesting changes like:

-                    if (JsonUtil::findJSONValue(object, "Url", url) &&
-                        JsonUtil::findJSONValue(object, "Name", filename))
+                    if (JsonUtil::findJSONValue(object, "Url", url)
+                        && JsonUtil::findJSONValue(object, "Name", filename))

Note that clang-format is never enforced (we never re-format existing
code), but your editor may respect it for new code.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Id6679220f83b77a4c63ca9a9429052535c75939a
