### PR TITLE
Show menu with download options in readonly on tablets

### DIFF
--- a/loleaflet/src/control/Control.UIManager.js
+++ b/loleaflet/src/control/Control.UIManager.js
@@ -511,15 +511,19 @@ L.Control.UIManager = L.Control.extend({
 		var enableNotebookbar = window.userInterfaceMode === 'notebookbar';
 		if (enableNotebookbar && !window.mode.isMobile()) {
 			if (e.perm === 'edit') {
+				if (this.map.menubar) {
+					this.map.removeControl(this.map.menubar);
+					this.map.menubar = null;
+				}
 				this.makeSpaceForNotebookbar(this.map._docLayer._docType);
-			} else if (e.perm === 'readonly' && $('#mobile-edit-button').is(':hidden')) {
+			} else if (e.perm === 'readonly') {
 				if (!this.map.menubar) {
 					var menubar = L.control.menubar();
 					this.map.menubar = menubar;
 					this.map.addControl(menubar);
 				}
 
-				if (this.notebookbar) {
+				if (this.notebookbar && $('#mobile-edit-button').is(':hidden')) {
 					this.map.removeControl(this.notebookbar);
 					this.notebookbar = null;
 				}


### PR DESCRIPTION
When notebookbar is activated but user is in readonly mode
show the simple menubar with download and view options
instead of empty bar on the top

Change-Id: I49ac7f8d7d8691761a15fd767f278e23ea228b50
Signed-off-by: Szymon Kłos <szymon.klos@collabora.com>


