### PR TITLE
Rename BasicShapes string #2111

### DIFF
--- a/loleaflet/src/unocommands.js
+++ b/loleaflet/src/unocommands.js
@@ -25,7 +25,7 @@ var unoCommandsArray = {
 	'BackColor':{text:{menu:_('Highlight Color'),},},
 	'BackgroundColor':{global:{menu:_('Background Color'),},},
 	'Backward':{global:{menu:_('Send Back~ward'),},presentation:{menu:_('Send Back~ward'),},},
-	'BasicShapes':{global:{context:_('Basic Shapes'),menu:_('Basic Shapes'),},},
+	'BasicShapes':{global:{context:_('Shapes'),menu:_('Shapes'),},},
 	'BibliographyComponent':{global:{menu:_('~Bibliography Database'),},},
 	'Bold':{global:{menu:_('Bold'),},},
 	'BringToFront':{global:{menu:_('~Bring to Front'),},},


### PR DESCRIPTION
- improve labeling: Basic Shapes command open all shapes not just basic shapes
- shorter strings are more space efficient

bug: #2111