### PR TITLE
Notebookbar Insert Tab update #2007

### DIFF
--- a/loleaflet/src/control/Control.NotebookbarCalc.js
+++ b/loleaflet/src/control/Control.NotebookbarCalc.js
@@ -942,11 +942,6 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 			},
 			{
 				'type': 'bigtoolitem',
-				'text': _UNO('.uno:FontworkGalleryFloater'),
-				'command': '.uno:FontworkGalleryFloater'
-			},
-			{
-				'type': 'bigtoolitem',
 				'text': _UNO('.uno:HyperlinkDialog'),
 				'command': '.uno:HyperlinkDialog'
 			},
@@ -956,7 +951,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				'command': '.uno:DrawText'
 			},
 			{
-				'id': 'Insert-BasicShapes-VerticalText',
+				'id': 'Insert-BasicShapes-Shapes',
 				'type': 'container',
 				'children': [
 					{
@@ -976,7 +971,36 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 						'children': [
 							{
 								'type': 'toolitem',
-								'text': _UNO('.uno:VerticalText', 'text'),
+								'text': _UNO('.uno:Line', 'spreadsheet'),
+								'command': '.uno:Line'
+							}
+						]
+					}
+				],
+				'vertical': 'true'
+			},
+			{
+				'id': 'Insert-Text-Fontwork',
+				'type': 'container',
+				'children': [
+					{
+						'id': 'LineA153',
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:FontworkGalleryFloater'),
+								'command': '.uno:FontworkGalleryFloater'
+							}
+						]
+					},
+					{
+						'id': 'LineB163',
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:VerticalText', 'spreadsheet'),
 								'command': '.uno:VerticalText'
 							}
 						]
@@ -986,18 +1010,37 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 			},
 			{
 				'type': 'bigtoolitem',
-				'text': _UNO('.uno:CharmapControl'),
-				'command': '.uno:CharmapControl'
-			},
-			{
-				'type': 'bigtoolitem',
 				'text': _UNO('.uno:EditHeaderAndFooter', 'spreadsheet'),
 				'command': '.uno:EditHeaderAndFooter'
 			},
 			{
-				'type': 'bigtoolitem',
-				'text': _UNO('.uno:InsertAnnotation', 'spreadsheet'),
-				'command': '.uno:InsertAnnotation'
+				'id': 'Insert-Charmap-Annotation',
+				'type': 'container',
+				'children': [
+					{
+						'id': 'LineA153',
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:CharmapControl'),
+								'command': '.uno:CharmapControl'
+							}
+						]
+					},
+					{
+						'id': 'LineB163',
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:InsertAnnotation', 'text'),
+								'command': '.uno:InsertAnnotation'
+							}
+						]
+					}
+				],
+				'vertical': 'true'
 			}
 		];
 

--- a/loleaflet/src/control/Control.NotebookbarImpress.js
+++ b/loleaflet/src/control/Control.NotebookbarImpress.js
@@ -889,11 +889,6 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 			},
 			{
 				'type': 'bigtoolitem',
-				'text': _UNO('.uno:FontworkGalleryFloater'),
-				'command': '.uno:FontworkGalleryFloater'
-			},
-			{
-				'type': 'bigtoolitem',
 				'text': _UNO('.uno:HyperlinkDialog'),
 				'command': '.uno:HyperlinkDialog'
 			},
@@ -957,7 +952,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'command': '.uno:Text'
 			},
 			{
-				'id': 'Insert-Text',
+				'id': 'Insert-BasicShapes-Shapes',
 				'type': 'container',
 				'children': [
 					{
@@ -966,8 +961,37 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 						'children': [
 							{
 								'type': 'toolitem',
-								'text': _UNO('.uno:BasicShapes', 'presentation'),
+								'text': _UNO('.uno:BasicShapes'),
 								'command': '.uno:BasicShapes'
+							}
+						]
+					},
+					{
+						'id': 'LineB163',
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:Line', 'presentation'),
+								'command': '.uno:Line'
+							}
+						]
+					}
+				],
+				'vertical': 'true'
+			},
+			{
+				'id': 'Insert-Text-Fontwork',
+				'type': 'container',
+				'children': [
+					{
+						'id': 'LineA153',
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:FontworkGalleryFloater'),
+								'command': '.uno:FontworkGalleryFloater'
 							}
 						]
 					},
@@ -987,23 +1011,37 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 			},
 			{
 				'type': 'bigtoolitem',
-				'text': _UNO('.uno:CharmapControl'),
-				'command': '.uno:CharmapControl'
-			},
-			{
-				'type': 'bigtoolitem',
-				'text': _UNO('.uno:Line', 'text'),
-				'command': '.uno:Line'
-			},
-			{
-				'type': 'bigtoolitem',
 				'text': _UNO('.uno:HeaderAndFooter', 'presentation'),
 				'command': '.uno:HeaderAndFooter'
 			},
 			{
-				'type': 'bigtoolitem',
-				'text': _UNO('.uno:InsertAnnotation', 'presentation'),
-				'command': '.uno:InsertAnnotation'
+				'id': 'Insert-Charmap-Annotation',
+				'type': 'container',
+				'children': [
+					{
+						'id': 'LineA153',
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:CharmapControl'),
+								'command': '.uno:CharmapControl'
+							}
+						]
+					},
+					{
+						'id': 'LineB163',
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:InsertAnnotation', 'text'),
+								'command': '.uno:InsertAnnotation'
+							}
+						]
+					}
+				],
+				'vertical': 'true'
 			}
 		];
 

--- a/loleaflet/src/control/Control.NotebookbarWriter.js
+++ b/loleaflet/src/control/Control.NotebookbarWriter.js
@@ -750,11 +750,6 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				'command': '.uno:HyperlinkDialog'
 			},
 			{
-				'type': 'bigtoolitem',
-				'text': _UNO('.uno:FontworkGalleryFloater'),
-				'command': '.uno:FontworkGalleryFloater'
-			},
-			{
 				'id': 'Insert-Section-Bookmark',
 				'type': 'container',
 				'children': [
@@ -823,7 +818,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				'command': '.uno:DrawText'
 			},
 			{
-				'id': 'Insert-BasicShapes-VerticalText',
+				'id': 'Insert-BasicShapes-Shapes',
 				'type': 'container',
 				'children': [
 					{
@@ -843,6 +838,35 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 						'children': [
 							{
 								'type': 'toolitem',
+								'text': _UNO('.uno:Line', 'text'),
+								'command': '.uno:Line'
+							}
+						]
+					}
+				],
+				'vertical': 'true'
+			},
+			{
+				'id': 'Insert-Text-Fontwork',
+				'type': 'container',
+				'children': [
+					{
+						'id': 'LineA153',
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:FontworkGalleryFloater'),
+								'command': '.uno:FontworkGalleryFloater'
+							}
+						]
+					},
+					{
+						'id': 'LineB163',
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
 								'text': _UNO('.uno:VerticalText', 'text'),
 								'command': '.uno:VerticalText'
 							}
@@ -852,25 +876,39 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				'vertical': 'true'
 			},
 			{
-				'type': 'bigtoolitem',
-				'text': _UNO('.uno:CharmapControl'),
-				'command': '.uno:CharmapControl'
-			},
-			{
-				'type': 'bigtoolitem',
-				'text': _UNO('.uno:Line', 'text'),
-				'command': '.uno:Line'
-			},
-			{
-				'type': 'bigtoolitem',
-				'text': _UNO('.uno:InsertAnnotation', 'text'),
-				'command': '.uno:InsertAnnotation'
-			},
-			{
 				'id': 'FormattingMarkMenu:FormattingMarkMenu',
 				'type': 'menubutton',
 				'text': _UNO('.uno:FormattingMarkMenu', 'text'),
 				'command': '.uno:FormattingMarkMenu'
+			},
+			{
+				'id': 'Insert-Charmap-Annotation',
+				'type': 'container',
+				'children': [
+					{
+						'id': 'LineA153',
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:CharmapControl'),
+								'command': '.uno:CharmapControl'
+							}
+						]
+					},
+					{
+						'id': 'LineB163',
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:InsertAnnotation', 'text'),
+								'command': '.uno:InsertAnnotation'
+							}
+						]
+					}
+				],
+				'vertical': 'true'
 			}
 		];
 


### PR DESCRIPTION
Update the structure of the Insert Notebookbar Tab for all apps.

### general sections:
1. section: app specific
2. section: Image/Table/Chartbigtoolitem will be the most used item depending on the app
3+4. section: Hyperlink and Field values
5. section: Textbox Shapes + *new* inkl. Fontwork and Line
6. section: Headers Symbol and Comment

### writer:
- Fontwork move to Textbox/Shape section
- Line move to Textbox/Shape Section
- Formating Mark + Symbol + Comment are a new Section (Formating Mark is bigtoolitem hardcoded)

### calc:
- Fontwork move to Textbox/Shape section same with Line
- Header and Footer + Symbol and Comment are is a new section

### impress/draw:
- Fontwork move to Textbox/Shape section same with Line
- Header and Footer + Symbol and Comment are is a new section

* Related to: #2007 