### PR TITLE
Websocket - message slurping.

### DIFF
--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -69,7 +69,7 @@ L.Socket = L.Class.extend({
 		this.socket.onerror = L.bind(this._onSocketError, this);
 		this.socket.onclose = L.bind(this._onSocketClose, this);
 		this.socket.onopen = L.bind(this._onSocketOpen, this);
-		this.socket.onmessage = L.bind(this._onMessage, this);
+		this.socket.onmessage = L.bind(this._slurpMessage, this);
 		this.socket.binaryType = 'arraybuffer';
 		if (map.options.docParams.access_token && parseInt(map.options.docParams.access_token_ttl)) {
 			var tokenExpiryWarning = 900 * 1000; // Warn when 15 minutes remain
@@ -266,6 +266,30 @@ L.Socket = L.Class.extend({
 		var color = type === 'OUTGOING' ? 'color:red' : 'color:blue';
 		console.log2(+new Date() + ' %c' + type + status + '%c: ' + msg.concat(' ').replace(' ', '%c '),
 			     'background:#ddf;color:black', color, 'color:black');
+	},
+
+	// The problem: if we process one websocket message at a time, the
+	// browser -loves- to trigger a re-render as we hit the main-loop,
+	// this takes ~200ms on a large screen, and worse we get
+	// producer/consumer issues that can fill a multi-second long
+	// buffer of web-socket messages in the client that we can't
+	// process so - slurp and the emit at idle - its faster to delay!
+	_slurpMessage: function(e) {
+		var that = this;
+		if (!this._slurpQueue || !this._slurpQueue.length) {
+			setTimeout(function() {
+				console.log2('Slurp events ' + that._slurpQueue.length);
+				for (var i = 0; i < that._slurpQueue.length; ++i) {
+					// it is - are you ?
+					that._onMessage(that._slurpQueue[i]);
+				}
+				that._slurpQueue = [];
+			}, 1 /* ms */);
+			that._slurpQueue = [];
+		}
+		// I imagine e doesn't hang around at all nicely and this fails
+		// but lets see ...
+		that._slurpQueue.push(e);
 	},
 
 	_onMessage: function (e) {


### PR DESCRIPTION
The browsers - unfortunately appear to round-robin consuming a single
WebSocket message and processing it, against updating the UI. This
ensures that for large / slow to render documents - responsiveness is
impaired by eg. 200ms frame render time. That in turn can rapidly
build up a 2500ms buffer full of messages in the browser too be
processed - before we find out about it.

Avoid this by slurping the websocket messages quickly onto a queue,
and deferring emitting those for a 1ms timeout or so and triggering
re-rendering.

Profiling shows this shortens the queue significantly and gives
better responsiveness. To test - hold down the 'down' arrow key in
calc until your view hits row 100 - ie. we have got to processing
those events from the browser's backlog. Then let go. With patch
- stops at row 114 (for me - small backlog), without it at row 150
(large backlog).

Measurement of wsd/kit shows ~instant message passing there, sub 1ms
and back out to the browser.

Moving ahead, perhaps we should put a serial on each message we send
and reflect back the serial we most recently processed for each client
to give an idea how how many messages are in transit; and keep that
number down to avoid buffer-bloat.

Change-Id: I4fc4a8eca317d68527c2d5447e7d6efcb88ece02
Signed-off-by: Michael Meeks <michael.meeks@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

