### PR TITLE
Notebookbar Format Tab update #2007

### DIFF
--- a/loleaflet/src/control/Control.NotebookbarCalc.js
+++ b/loleaflet/src/control/Control.NotebookbarCalc.js
@@ -1334,6 +1334,11 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 	getFormatTab: function() {
 		var content = [
 			{
+				'type': 'bigtoolitem',
+				'text': _UNO('.uno:FontDialog'),
+				'command': '.uno:FontDialog'
+			},
+			{
 				'id': 'FormatMenu:FormatMenu',
 				'type': 'menubutton',
 				'text': _UNO('.uno:FormatMenu', 'spreadsheet'),
@@ -1341,13 +1346,13 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 			},
 			{
 				'type': 'bigtoolitem',
-				'text': _UNO('.uno:FontDialog'),
-				'command': '.uno:FontDialog'
+				'text': _UNO('.uno:ParagraphDialog'),
+				'command': '.uno:ParagraphDialog'
 			},
 			{
 				'type': 'bigtoolitem',
-				'text': _UNO('.uno:ParagraphDialog'),
-				'command': '.uno:ParagraphDialog'
+				'text': _UNO('.uno:PageFormatDialog', 'spreadsheet', true),
+				'command': '.uno:PageFormatDialog'
 			},
 			{
 				'type': 'bigtoolitem',
@@ -1374,11 +1379,6 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				'type': 'bigtoolitem',
 				'text': _UNO('.uno:TransformDialog'),
 				'command': '.uno:TransformDialog'
-			},
-			{
-				'type': 'bigtoolitem',
-				'text': _UNO('.uno:PageFormatDialog', 'spreadsheet', true),
-				'command': '.uno:PageFormatDialog'
 			}
 		];
 

--- a/loleaflet/src/control/Control.NotebookbarImpress.js
+++ b/loleaflet/src/control/Control.NotebookbarImpress.js
@@ -788,13 +788,13 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 			},
 			{
 				'type': 'bigtoolitem',
-				'text': _UNO('.uno:PageSetup', 'presentation'),
-				'command': '.uno:PageSetup'
+				'text': _UNO('.uno:OutlineBullet'),
+				'command': '.uno:OutlineBullet'
 			},
 			{
 				'type': 'bigtoolitem',
-				'text': _UNO('.uno:OutlineBullet'),
-				'command': '.uno:OutlineBullet'
+				'text': _UNO('.uno:PageSetup', 'presentation'),
+				'command': '.uno:PageSetup'
 			},
 			{
 				'type': 'bigtoolitem',

--- a/loleaflet/src/control/Control.NotebookbarWriter.js
+++ b/loleaflet/src/control/Control.NotebookbarWriter.js
@@ -618,6 +618,11 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 	getFormatTab: function() {
 		var content = [
 			{
+				'type': 'bigtoolitem',
+				'text': _UNO('.uno:FontDialog', 'text'),
+				'command': '.uno:FontDialog'
+			},
+			{
 				'id': 'FormatMenu:FormatMenu',
 				'type': 'menubutton',
 				'text': _UNO('.uno:FormatMenu', 'text'),
@@ -625,18 +630,34 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 			},
 			{
 				'type': 'bigtoolitem',
-				'text': _UNO('.uno:FontDialog'),
-				'command': '.uno:FontDialog'
-			},
-			{
-				'type': 'bigtoolitem',
-				'text': _UNO('.uno:ParagraphDialog'),
+				'text': _UNO('.uno:ParagraphDialog', 'text'),
 				'command': '.uno:ParagraphDialog'
 			},
 			{
+				'id': 'FormatBulletsMenu:FormatBulletsMenu',
+				'type': 'menubutton',
+				'text': _UNO('.uno:FormatBulletsMenu', 'text'),
+				'command': '.uno:FormatBulletsMenu'
+			},
+			{
 				'type': 'bigtoolitem',
-				'text': _UNO('.uno:OutlineBullet'),
+				'text': _UNO('.uno:OutlineBullet', 'text'),
 				'command': '.uno:OutlineBullet'
+			},
+			{
+				'type': 'bigtoolitem',
+				'text': _UNO('.uno:PageDialog', 'text'),
+				'command': '.uno:PageDialog'
+			},
+			{
+				'type': 'bigtoolitem',
+				'text': _UNO('.uno:FormatColumns', 'text'),
+				'command': '.uno:FormatColumns'
+			},
+			{
+				'type': 'bigtoolitem',
+				'text': _UNO('.uno:EditRegion', 'text'),
+				'command': '.uno:EditRegion'
 			},
 			{
 				'type': 'bigtoolitem',
@@ -652,27 +673,8 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				'type': 'bigtoolitem',
 				'text': _UNO('.uno:TransformDialog'),
 				'command': '.uno:TransformDialog'
-			},
-			{
-				'type': 'bigtoolitem',
-				'text': _UNO('.uno:FormatColumns', 'text'),
-				'command': '.uno:FormatColumns'
-			},
-			{
-				'type': 'bigtoolitem',
-				'text': _UNO('.uno:EditRegion', 'text'),
-				'command': '.uno:EditRegion'
-			},
-			{
-				'id': 'FormatBulletsMenu:FormatBulletsMenu',
-				'type': 'menubutton',
-				'text': _UNO('.uno:FormatBulletsMenu', 'text'),
-				'command': '.uno:FormatBulletsMenu'
-			},
+			}
 		];
-
-		return this.getTabPage('Format', content);
-	},
 
 	getInsertTab: function() {
 		var content = [

--- a/loleaflet/src/control/Control.NotebookbarWriter.js
+++ b/loleaflet/src/control/Control.NotebookbarWriter.js
@@ -676,6 +676,9 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 			}
 		];
 
+		return this.getTabPage('Format', content);
+	},
+
 	getInsertTab: function() {
 		var content = [
 			{


### PR DESCRIPTION
Update the structure of the Insert Notebookbar Tab for all apps.

### general sections:
1. as there are not that much commands and it's very difficult to arrange them into 3 item groups, all commans are bigtoolitems

### writer:
- writer use the most format commands
- start with tiny and get bigger
- character, paragrapn, page, line / area / position
- as Lists and Bullets and Numbering are related to Paragraph they are next to Paragraph
- As Columns and Sections are related to pages or part of a page, the commands are related to Page Style

### calc
- Character, Format
- Paragraph
- Page
- Cell and Conditionals (calc related only)
- Line / Area / Position

### Impress
- Character
- Paragraph with Bullets
- Page
- Line / Area / Position

### Updated writer
![2021-04-24 01_44_05-ws-8b7e51ba-88e8-4328-a5f7-ad7d5a3597c1_0 - noVNC](https://user-images.githubusercontent.com/8517736/115939790-9286df80-a49f-11eb-94bf-4b691d013931.png)

### Updated calc
![2021-04-24 01_44_20-ws-8b7e51ba-88e8-4328-a5f7-ad7d5a3597c1_0 - noVNC](https://user-images.githubusercontent.com/8517736/115939799-974b9380-a49f-11eb-9a79-9dcec9602521.png)

### Updated impress
![2021-04-24 01_44_28-ws-8b7e51ba-88e8-4328-a5f7-ad7d5a3597c1_0 - noVNC](https://user-images.githubusercontent.com/8517736/115939805-9ca8de00-a49f-11eb-8d8c-a6fe7a91ac87.png)
