### PR TITLE
Notebookbar Calc Sheet and Data Tab update #2007

### DIFF
--- a/loleaflet/css/notebookbar.css
+++ b/loleaflet/css/notebookbar.css
@@ -437,7 +437,6 @@ div[id*='Row'].notebookbar, div[id*='Column'].notebookbar, #SendToBack.notebookb
 }
 
 #Copy.notebookbar,
-#DataFilterAutoFilter.notebookbar,
 #clearFormatting.notebookbar {
 	margin-top: 10px;
 }

--- a/loleaflet/images/lc_goalseekdialog.svg
+++ b/loleaflet/images/lc_goalseekdialog.svg
@@ -1,0 +1,30 @@
+<?xml-stylesheet type="text/css" href="icons.css" ?>
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <g id="background"
+     class="icn icn--area-color"
+     fill="#fafafa"
+     stroke="#3a3a38"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     >
+      <path d="m 14.5,13.5 6,-8 v -2 L 19,2.5 H 5 L 3.5,4 v 1.5 l 6,8 V 18 l 5,3.5 z" />
+  </g>
+  <g id="symbol-background"
+	 class="icn icn--background"
+     stroke="#fff" 
+     stroke-width="3px"
+	 stroke-linecap="round" 
+	 stroke-linejoin="round"
+      >
+      <path d="M 17.4 13.5 L 17 15.6 L 15.24 14.4 L 14.4 15.24 L 15.6 17 L 13.5 17.4 L 13.5 18.6 L 15.6 19.0 L 14.4 20.76 L 15.24 21.6 L 17 20.4 L 17.4 22.5 L 18.6 22.5 L 19.0 20.4 L 20.76 21.6 L 21.6 20.76 L 20.4 19.0 L 22.5 18.6 L 22.5 17.4 L 20.4 17 L 21.6 15.24 L 20.76 14.4 L 19.0 15.6 L 18.6 13.5 L 17.4 13.5 z M 18 16.5 A 1.5 1.5 0 0 1 19.5 18 A 1.5 1.5 0 0 1 18 19.5 A 1.5 1.5 0 0 1 16.5 18 A 1.5 1.5 0 0 1 18 16.5 z " />
+  </g>
+  <g id="symbol"
+	 class="icn icn--highlight-color"  
+     fill="#83beec" 
+     stroke="#1e8bcd" 
+	 stroke-linecap="round" 
+	 stroke-linejoin="round"
+      >
+      <path d="M 17.4 13.5 L 17 15.6 L 15.24 14.4 L 14.4 15.24 L 15.6 17 L 13.5 17.4 L 13.5 18.6 L 15.6 19.0 L 14.4 20.76 L 15.24 21.6 L 17 20.4 L 17.4 22.5 L 18.6 22.5 L 19.0 20.4 L 20.76 21.6 L 21.6 20.76 L 20.4 19.0 L 22.5 18.6 L 22.5 17.4 L 20.4 17 L 21.6 15.24 L 20.76 14.4 L 19.0 15.6 L 18.6 13.5 L 17.4 13.5 z M 18 16.5 A 1.5 1.5 0 0 1 19.5 18 A 1.5 1.5 0 0 1 18 19.5 A 1.5 1.5 0 0 1 16.5 18 A 1.5 1.5 0 0 1 18 16.5 z " />
+  </g>
+</svg>

--- a/loleaflet/src/control/Control.NotebookbarCalc.js
+++ b/loleaflet/src/control/Control.NotebookbarCalc.js
@@ -762,62 +762,6 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 						]
 					},
 					{
-						'id': 'Data-Section-Group1',
-						'children': [
-							{
-								'id': 'LeftParaMargin14',
-								'type': 'toolbox',
-								'children': [
-									{
-										'type': 'toolitem',
-										'text': _UNO('.uno:Group'),
-										'command': '.uno:Group'
-									}
-								]
-							},
-							{
-								'id': 'belowspacing16',
-								'type': 'toolbox',
-								'children': [
-									{
-										'type': 'toolitem',
-										'text': _UNO('.uno:Ungroup'),
-										'command': '.uno:Ungroup'
-									}
-								]
-							}
-						],
-						'vertical': 'true'
-					},
-					{
-						'id': 'Data-Section-Group2',
-						'children': [
-							{
-								'id': 'LeftParaMargin15',
-								'type': 'toolbox',
-								'children': [
-									{
-										'type': 'toolitem',
-										'text': _UNO('.uno:HideDetail'),
-										'command': '.uno:HideDetail'
-									}
-								]
-							},
-							{
-								'id': 'belowspacing17',
-								'type': 'toolbox',
-								'children': [
-									{
-										'type': 'toolitem',
-										'text': _UNO('.uno:ShowDetail'),
-										'command': '.uno:ShowDetail'
-									}
-								]
-							}
-						],
-						'vertical': 'true'
-					},
-					{
 						'id': 'freeze-section1',
 						'type': 'container',
 						'children': [
@@ -946,6 +890,31 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				'command': '.uno:HyperlinkDialog'
 			},
 			{
+				'children': [
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:AddName', 'spreadsheet'),
+								'command': '.uno:AddName'
+							}
+						]
+					},
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:DefineName', 'spreadsheet'),
+								'command': '.uno:DefineName'
+							}
+						]
+					}
+				],
+				'vertical': 'true'
+			},
+			{
 				'type': 'bigtoolitem',
 				'text': _UNO('.uno:DrawText'),
 				'command': '.uno:DrawText'
@@ -1051,54 +1020,13 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 		var content = [
 			{
 				'type': 'bigtoolitem',
-				'text': _UNO('.uno:Calculate', 'spreadsheet'),
-				'command': '.uno:Calculate'
-			},
-			{
-				'type': 'bigtoolitem',
-				'text': _UNO('.uno:DataDataPilotRun', 'spreadsheet'),
-				'command': '.uno:DataDataPilotRun'
-			},
-			{
-				'id': 'GroupPivotTable1',
-				'type': 'container',
-				'children': [
-					{
-						'id': 'ToolBoxPivotTable1',
-						'type': 'toolbox',
-						'children': [
-							{
-								'type': 'toolitem',
-								'text': _UNO('.uno:RecalcPivotTable', 'spreadsheet'),
-								'command': '.uno:RecalcPivotTable'
-							}
-						]
-					},
-					{
-						'id': 'ToolBoxPivotTable2',
-						'type': 'toolbox',
-						'children': [
-							{
-								'type': 'toolitem',
-								'text': _UNO('.uno:DeletePivotTable', 'spreadsheet'),
-								'command': '.uno:DeletePivotTable'
-							}
-						]
-					}
-				],
-				'vertical': 'true'
-			},
-			{
-				'type': 'bigtoolitem',
 				'text': _UNO('.uno:DataSort', 'spreadsheet'),
 				'command': '.uno:DataSort'
 			},
 			{
-				'id': 'Data-Section-Sort1',
 				'type': 'container',
 				'children': [
 					{
-						'id': 'LeftParaMargin8',
 						'type': 'toolbox',
 						'children': [
 							{
@@ -1106,46 +1034,15 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 								'text': _UNO('.uno:SortAscending', 'spreadsheet'),
 								'command': '.uno:SortAscending'
 							},
-							{}
 						]
 					},
 					{
-						'id': 'belowspacing8',
 						'type': 'toolbox',
 						'children': [
 							{
 								'type': 'toolitem',
 								'text': _UNO('.uno:SortDescending', 'spreadsheet'),
 								'command': '.uno:SortDescending'
-							},
-							{}
-						]
-					}
-				],
-				'vertical': 'true'
-			},
-			{
-				'id': 'Data-Section-Filter',
-				'children': [
-					{
-						'id': 'SectionBottom8',
-						'type': 'toolbox',
-						'children': [
-							{
-								'type': 'toolitem',
-								'text': _UNO('.uno:DataFilterAutoFilter', 'spreadsheet'),
-								'command': '.uno:DataFilterAutoFilter'
-							}
-						]
-					},
-					{
-						'id': 'SectionBottom88',
-						'type': 'toolbox',
-						'children': [
-							{
-								'type': 'toolitem',
-								'text': _UNO('.uno:DataFilterHideAutoFilter', 'spreadsheet'),
-								'command': '.uno:DataFilterHideAutoFilter'
 							}
 						]
 					}
@@ -1153,21 +1050,24 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				'vertical': 'true'
 			},
 			{
-				'id': 'Data-Section-Filter1',
+				'type': 'bigtoolitem',
+				'text': _UNO('.uno:DataFilterAutoFilter', 'spreadsheet'),
+				'command': '.uno:DataFilterAutoFilter'
+			},
+			{
+				'type': 'container',
 				'children': [
 					{
-						'id': 'belowspacing9',
 						'type': 'toolbox',
 						'children': [
 							{
 								'type': 'toolitem',
 								'text': _UNO('.uno:DataFilterStandardFilter', 'spreadsheet'),
 								'command': '.uno:DataFilterStandardFilter'
-							}
+							},
 						]
 					},
 					{
-						'id': 'LeftParaMargin9',
 						'type': 'toolbox',
 						'children': [
 							{
@@ -1181,10 +1081,19 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				'vertical': 'true'
 			},
 			{
-				'id': 'Data-Section-Filter2',
+				'type': 'container',
 				'children': [
 					{
-						'id': 'belowspacing9',
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:DataFilterHideAutoFilter', 'spreadsheet'),
+								'command': '.uno:DataFilterHideAutoFilter'
+							},
+						]
+					},
+					{
 						'type': 'toolbox',
 						'children': [
 							{
@@ -1193,9 +1102,29 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 								'command': '.uno:DataFilterRemoveFilter'
 							}
 						]
+					}
+				],
+				'vertical': 'true'
+			},
+			{
+				'type': 'bigtoolitem',
+				'text': _UNO('.uno:Group'),
+				'command': '.uno:Group'
+			},
+			{
+				'type': 'container',
+				'children': [
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:Ungroup'),
+								'command': '.uno:Ungroup'
+							}
+						]
 					},
 					{
-						'id': 'LeftParaMargin9',
 						'type': 'toolbox',
 						'children': [
 							{
@@ -1209,27 +1138,25 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				'vertical': 'true'
 			},
 			{
-				'id': 'Data-Section-NamedRanges',
+				'type': 'container',
 				'children': [
 					{
-						'id': 'LeftParaMargin161',
 						'type': 'toolbox',
 						'children': [
 							{
 								'type': 'toolitem',
-								'text': _UNO('.uno:AddName', 'spreadsheet'),
-								'command': '.uno:AddName'
+								'text': _UNO('.uno:ShowDetail'),
+								'command': '.uno:ShowDetail'
 							}
 						]
 					},
 					{
-						'id': 'belowspacing181',
 						'type': 'toolbox',
 						'children': [
 							{
 								'type': 'toolitem',
-								'text': _UNO('.uno:DefineName', 'spreadsheet'),
-								'command': '.uno:DefineName'
+								'text': _UNO('.uno:HideDetail'),
+								'command': '.uno:HideDetail'
 							}
 						]
 					}
@@ -1238,15 +1165,41 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 			},
 			{
 				'type': 'bigtoolitem',
-				'text': _UNO('.uno:Validation', 'spreadsheet'),
-				'command': '.uno:Validation'
+				'text': _UNO('.uno:Calculate', 'spreadsheet'),
+				'command': '.uno:Calculate'
+			},
+			{
+				'type': 'container',
+				'children': [
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:GoalSeekDialog', 'spreadsheet'),
+								'command': '.uno:GoalSeekDialog'
+							},
+						]
+					},
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:Validation', 'spreadsheet'),
+								'command': '.uno:Validation'
+							}
+						]
+					}
+				],
+				'vertical': 'true'
 			},
 			{
 				'id': 'Data-StatisticsMenu:Menu Statistic',
 				'type': 'menubutton',
 				'text': _UNO('.uno:StatisticsMenu', 'spreadsheet'),
 				'enabled': 'true'
-			}
+			},
 		];
 
 		return this.getTabPage('Data', content);


### PR DESCRIPTION
Update the structure of the Insert Notebookbar Tab for all apps.

### general sections:
1. as there are not that much commands and it's very difficult to arrange them into 3 item groups, all commans are bigtoolitems

### Calc Insert Tab
Define and Manage commands moved from Data Sheet to Insert Sheet, section Hyperlink
- Now the group is similar to LibreOffice Insert Tab

*Before*
![Insert-Before](https://user-images.githubusercontent.com/8517736/115973871-90348c00-a558-11eb-85cc-dec31c03b6bb.png)

*After*
![Insert-After](https://user-images.githubusercontent.com/8517736/115973874-93c81300-a558-11eb-8d63-e7fb2cd5d80b.png)

### Calc Sheet Tab
Group/UnGroup Hide/Show Details moved to Data Tab
- Now the group is similar to LibreOffice Data Tab
- Commands are at the Menubar also in Data Section

*Before*
![Sheeet-Before](https://user-images.githubusercontent.com/8517736/115973878-99255d80-a558-11eb-9b18-15ee6e980c06.png)

*After*
![Sheet-After](https://user-images.githubusercontent.com/8517736/115973880-9c204e00-a558-11eb-81a9-c1ff769855d9.png)

### Calc Data Tab
- Pivot Table + Refresh/Delete Section was removed cause it's already in Insert Tab and Data Tab has a lot of content, so no need for duplicated content at the very left area
- Sort section has the same layout than all other sections
- Autofilter section layout is similar to all other sections
- Group section was moved from sheet tab and as Remove Outline is an command for Group, it was added
- Recalculate, Validity and Goal Seek get into one section. Recalculate and Validity area already into one section in the menubar.
Finaly the Data Tab has a similar command layout with bigtoolitem and toolitems.

*Before*
![Data-Before](https://user-images.githubusercontent.com/8517736/115973857-7bf08f00-a558-11eb-9e5f-13d8d285baa3.png)

*After*
![Data-After](https://user-images.githubusercontent.com/8517736/115973860-80b54300-a558-11eb-85e1-18ea5587c796.png)
