### PR TITLE
Notebookbar Writer/Impress Table Contextual Tab update

### DIFF
--- a/loleaflet/src/control/Control.NotebookbarImpress.js
+++ b/loleaflet/src/control/Control.NotebookbarImpress.js
@@ -1107,11 +1107,14 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 	getTableTab: function() {
 		var content = [
 			{
-				'id': 'Table-Section-Layout1',
+				'type': 'bigtoolitem',
+				'text': _UNO('.uno:TableDialog', 'presentation'),
+				'command': '.uno:TableDialog'
+			},
+			{
 				'type': 'container',
 				'children': [
 					{
-						'id': 'SectionBottom55',
 						'type': 'toolbox',
 						'children': [
 							{
@@ -1132,7 +1135,6 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 						]
 					},
 					{
-						'id': 'SectionBottom57',
 						'type': 'toolbox',
 						'children': [
 							{
@@ -1157,16 +1159,6 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 			},
 			{
 				'type': 'bigtoolitem',
-				'text': _UNO('.uno:FormatArea'),
-				'command': '.uno:FormatArea'
-			},
-			{
-				'type': 'bigtoolitem',
-				'text': _UNO('.uno:FillColor'),
-				'command': '.uno:FillColor'
-			},
-			{
-				'type': 'bigtoolitem',
 				'text': _UNO('.uno:MergeCells', 'presentation'),
 				'command': '.uno:MergeCells'
 			},
@@ -1181,11 +1173,9 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'command': '.uno:SelectTable'
 			},
 			{
-				'id': 'Table-Section-Select1',
 				'type': 'container',
 				'children': [
 					{
-						'id': 'SectionBottom40',
 						'type': 'toolbox',
 						'children': [
 							{
@@ -1196,7 +1186,6 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 						]
 					},
 					{
-						'id': 'SectionBottom62',
 						'type': 'toolbox',
 						'children': [
 							{
@@ -1210,11 +1199,9 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'vertical': 'true'
 			},
 			{
-				'id': 'Table-Section-Optimize1',
 				'type': 'container',
 				'children': [
 					{
-						'id': 'SectionBottom84',
 						'type': 'toolbox',
 						'children': [
 							{
@@ -1231,16 +1218,10 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 								'type': 'toolitem',
 								'text': _UNO('.uno:CellVertBottom'),
 								'command': '.uno:CellVertBottom'
-							},
-							{
-								'type': 'toolitem',
-								'text': _UNO('.uno:ParaRightToLeft'),
-								'command': '.uno:ParaRightToLeft'
 							}
 						]
 					},
 					{
-						'id': 'SectionBottom85',
 						'type': 'toolbox',
 						'children': [
 							{
@@ -1267,11 +1248,6 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 					}
 				],
 				'vertical': 'true'
-			},
-			{
-				'type': 'bigtoolitem',
-				'text': _UNO('.uno:TableDialog', 'presentation'),
-				'command': '.uno:TableDialog'
 			}
 		];
 

--- a/loleaflet/src/control/Control.NotebookbarWriter.js
+++ b/loleaflet/src/control/Control.NotebookbarWriter.js
@@ -1547,15 +1547,13 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 		var content = [
 			{
 				'type': 'bigtoolitem',
-				'text': _UNO('.uno:InsertCaptionDialog', 'text'),
-				'command': '.uno:InsertCaptionDialog'
+				'text': _UNO('.uno:TableDialog', 'text'),
+				'command': '.uno:TableDialog'
 			},
 			{
-				'id': 'Table-Section-Layout1',
 				'type': 'container',
 				'children': [
 					{
-						'id': 'SectionBottom39',
 						'type': 'toolbox',
 						'children': [
 							{
@@ -1576,7 +1574,6 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 						]
 					},
 					{
-						'id': 'SectionBottom41',
 						'type': 'toolbox',
 						'children': [
 							{
@@ -1605,11 +1602,9 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				'command': '.uno:MergeCells'
 			},
 			{
-				'id': 'Table-Section-Merge1',
 				'type': 'container',
 				'children': [
 					{
-						'id': 'LineA25',
 						'type': 'toolbox',
 						'children': [
 							{
@@ -1620,7 +1615,6 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 						]
 					},
 					{
-						'id': 'LineB26',
 						'type': 'toolbox',
 						'children': [
 							{
@@ -1639,11 +1633,9 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				'command': '.uno:EntireCell'
 			},
 			{
-				'id': 'Table-Section-Select1',
 				'type': 'container',
 				'children': [
 					{
-						'id': 'SectionBottom84',
 						'type': 'toolbox',
 						'children': [
 							{
@@ -1659,7 +1651,6 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 						]
 					},
 					{
-						'id': 'SectionBottom85',
 						'type': 'toolbox',
 						'children': [
 							{
@@ -1678,11 +1669,9 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				'vertical': 'true'
 			},
 			{
-				'id': 'Table-Section-Optimize1',
 				'type': 'container',
 				'children': [
 					{
-						'id': 'SectionBottom44',
 						'type': 'toolbox',
 						'children': [
 							{
@@ -1699,16 +1688,10 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 								'type': 'toolitem',
 								'text': _UNO('.uno:CellVertBottom'),
 								'command': '.uno:CellVertBottom'
-							},
-							{
-								'type': 'toolitem',
-								'text': _UNO('.uno:ParaRightToLeft'),
-								'command': '.uno:ParaRightToLeft'
 							}
 						]
 					},
 					{
-						'id': 'SectionBottom101',
 						'type': 'toolbox',
 						'children': [
 							{
@@ -1747,11 +1730,9 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				'command': '.uno:TableNumberFormatDialog'
 			},
 			{
-				'id': 'Table-Section-FormatCalc1',
 				'type': 'container',
 				'children': [
 					{
-						'id': 'SectionBottom109',
 						'type': 'toolbox',
 						'children': [
 							{
@@ -1761,24 +1742,23 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 							},
 							{
 								'type': 'toolitem',
-								'text': _UNO('.uno:NumberFormatDecimal', 'text'),
-								'command': '.uno:NumberFormatDecimal'
+								'text': _UNO('.uno:NumberFormatDate', 'text'),
+								'command': '.uno:NumberFormatDate'
 							}
 						]
 					},
 					{
-						'id': 'SectionBottom110',
 						'type': 'toolbox',
 						'children': [
 							{
 								'type': 'toolitem',
-								'text': _UNO('.uno:NumberFormatPercent', 'text'),
-								'command': '.uno:NumberFormatPercent'
+								'text': _UNO('.uno:NumberFormatDecimal', 'text'),
+								'command': '.uno:NumberFormatDecimal'
 							},
 							{
 								'type': 'toolitem',
-								'text': _UNO('.uno:NumberFormatDate', 'text'),
-								'command': '.uno:NumberFormatDate'
+								'text': _UNO('.uno:NumberFormatPercent', 'text'),
+								'command': '.uno:NumberFormatPercent'
 							}
 						]
 					}
@@ -1787,8 +1767,8 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 			},
 			{
 				'type': 'bigtoolitem',
-				'text': _UNO('.uno:TableDialog', 'text'),
-				'command': '.uno:TableDialog'
+				'text': _UNO('.uno:InsertCaptionDialog', 'text'),
+				'command': '.uno:InsertCaptionDialog'
 			},
 		];
 


### PR DESCRIPTION
- Property get the first item
- ParaRightToLeft was removed, already in Home Tab
- Rearranged of NumberFormatDecimal items

Signed-off-by: Andreas_K <andreas_k@abwesend.de>
Change-Id: I78969e46ba94f300d26ab2f6413657a65b537832

### Writer Table Tab

*Before*
![Screenshot_20210425_004013](https://user-images.githubusercontent.com/8517736/115975231-384f5280-a563-11eb-8702-be7f546366a9.png)

*After*
![Screenshot_20210425_010241](https://user-images.githubusercontent.com/8517736/115975234-3d140680-a563-11eb-816f-ce6e3dcdf7a5.png)

### Impress Table Tab

*Before*
![Screenshot_20210425_004037](https://user-images.githubusercontent.com/8517736/115975243-443b1480-a563-11eb-9ebd-bc4e3c9e8b2e.png)

*After*
![Screenshot_20210425_011224](https://user-images.githubusercontent.com/8517736/115975249-51f09a00-a563-11eb-8daf-adb06435cc70.png)
