### PR TITLE
Notebookbar Calc sync tab arrangement wit writer/impress

### DIFF
--- a/loleaflet/src/control/Control.NotebookbarCalc.js
+++ b/loleaflet/src/control/Control.NotebookbarCalc.js
@@ -35,14 +35,14 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				'name': 'Data'
 			},
 			{
-				'text': _('Format'),
-				'id': '-7',
-				'name': 'Format'
-			},
-			{
 				'text': _('~Review'),
 				'id': '-6',
 				'name': 'Review'
+			},
+			{
+				'text': _('Format'),
+				'id': '-7',
+				'name': 'Format'
 			},
 			{
 				'text': _('~Help'),
@@ -60,8 +60,8 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				this.getInsertTab(),
 				this.getSheetTab(),
 				this.getDataTab(),
-				this.getFormatTab(),
 				this.getReviewTab(),
+				this.getFormatTab(),
 				this.getHelpTab()
 			], selectedId);
 	},


### PR DESCRIPTION
Signed-off-by: andreas kainz <kainz.a@gmail.com>

In writer and impress there is File / Home / ... Review / Format / Help
In calc there is  File / Home / ... Format / Review / Help

As there is no reason why there should be a difference in calc compare to writer and impress, this patch change the arrangement of the Review and Format Tab.