### PR TITLE
Notebookbar impress - draw home tab update #2007

### DIFF
--- a/loleaflet/src/control/Control.NotebookbarDraw.js
+++ b/loleaflet/src/control/Control.NotebookbarDraw.js
@@ -205,7 +205,11 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 	getHomeTab: function() {
 		var content = [
 			{
-				'id': 'Home-Section-Clipboard',
+				'type': 'bigtoolitem',
+				'text': _UNO('.uno:Paste'),
+				'command': '.uno:Paste'
+			},
+			{
 				'type': 'container',
 				'children': [
 					{
@@ -234,34 +238,25 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 				'vertical': 'true'
 			},
 			{
-				'id': 'Home-Section-DrawColor1',
 				'type': 'container',
 				'children': [
 					{
-						'id': 'third7',
 						'type': 'toolbox',
 						'children': [
 							{
 								'type': 'toolitem',
-								'text': _UNO('.uno:FormatLine'),
-								'command': '.uno:FormatLine'
-							},
-							{
-								'type': 'toolitem',
+								'text': _UNO('.uno:FormatPaintbrush'),
+								'command': '.uno:FormatPaintbrush'
 							}
 						]
 					},
 					{
-						'id': 'third8',
 						'type': 'toolbox',
 						'children': [
 							{
 								'type': 'toolitem',
-								'text': _UNO('.uno:BasicShapes'),
-								'command': '.uno:BasicShapes'
-							},
-							{
-								'type': 'toolitem',
+								'text': _UNO('.uno:SetDefault'),
+								'command': '.uno:SetDefault'
 							}
 						]
 					}
@@ -269,11 +264,280 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 				'vertical': 'true'
 			},
 			{
-				'id': 'Home-Section-DrawColor1',
 				'type': 'container',
 				'children': [
 					{
-						'id': 'third7',
+						'type': 'container',
+						'children': [
+							{
+								'id': 'fontnamecombobox',
+								'type': 'combobox',
+								'text': 'Carlito',
+								'entries': [
+									'Carlito'
+								],
+								'selectedCount': '1',
+								'selectedEntries': [
+									'0'
+								],
+								'command': '.uno:CharFontName'
+							},
+							{
+								'id': 'fontsize',
+								'type': 'combobox',
+								'text': '12 pt',
+								'entries': [
+									'12 pt'
+								],
+								'selectedCount': '1',
+								'selectedEntries': [
+									'0'
+								],
+								'command': '.uno:FontHeight'
+							},
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:Grow'),
+								'command': '.uno:Grow'
+							},
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:Shrink'),
+								'command': '.uno:Shrink'
+							}
+						],
+						'vertical': 'false'
+					},
+					{
+						'type': 'container',
+						'children': [
+							{
+								'id': 'ExtTop4',
+								'type': 'toolbox',
+								'children': [
+									{
+										'type': 'toolitem',
+										'text': _UNO('.uno:Bold'),
+										'command': '.uno:Bold'
+									},
+									{
+										'type': 'toolitem',
+										'text': _UNO('.uno:Italic'),
+										'command': '.uno:Italic'
+									},
+									{
+										'type': 'toolitem',
+										'text': _UNO('.uno:Underline'),
+										'command': '.uno:Underline'
+									},
+									{
+										'type': 'toolitem',
+										'text': _UNO('.uno:Strikeout'),
+										'command': '.uno:Strikeout'
+									},
+									{
+										'type': 'toolitem',
+										'text': _UNO('.uno:Shadowed'),
+										'command': '.uno:Shadowed'
+									},
+									{
+										'type': 'toolitem',
+										'text': _UNO('.uno:FontworkGalleryFloater'),
+										'command': '.uno:FontworkGalleryFloater'
+									},
+									{
+										'type': 'toolitem',
+										'text': _UNO('.uno:CharBackColor'),
+										'command': '.uno:CharBackColor'
+									},
+									{
+										'type': 'toolitem',
+										'text': _UNO('.uno:Color'),
+										'command': '.uno:Color'
+									}
+								]
+							}
+						],
+						'vertical': 'false'
+					}
+				],
+				'vertical': 'true'
+			},
+			{
+				'type': 'container',
+				'children': [
+					{
+						'type': 'container',
+						'children': [
+							{
+								'type': 'toolbox',
+								'children': [
+									{
+										'type': 'toolitem',
+										'text': _UNO('.uno:CellVertTop'),
+										'command': '.uno:CellVertTop'
+									},
+									{
+										'type': 'toolitem',
+										'text': _UNO('.uno:CellVertCenter'),
+										'command': '.uno:CellVertCenter'
+									},
+									{
+										'type': 'toolitem',
+										'text': _UNO('.uno:CellVertBottom'),
+										'command': '.uno:CellVertBottom'
+									}
+								]
+							},
+						],
+						'vertical': 'false'
+					},
+					{
+						'type': 'container',
+						'children': [
+							{
+								'id': 'SectionBottom13',
+								'type': 'toolbox',
+								'children': [
+									{
+										'type': 'toolitem',
+										'text': _UNO('.uno:LeftPara'),
+										'command': '.uno:LeftPara'
+									},
+									{
+										'type': 'toolitem',
+										'text': _UNO('.uno:CenterPara'),
+										'command': '.uno:CenterPara'
+									},
+									{
+										'type': 'toolitem',
+										'text': _UNO('.uno:RightPara'),
+										'command': '.uno:RightPara'
+									},
+									{
+										'type': 'toolitem',
+										'text': _UNO('.uno:JustifyPara'),
+										'command': '.uno:JustifyPara'
+									}
+								]
+							},
+						],
+						'vertical': 'false'
+					}
+				],
+				'vertical': 'true'
+			},
+			{
+				'type': 'container',
+				'children': [
+					{
+						'type': 'container',
+						'children': [
+							{
+								'type': 'toolbox',
+								'children': [
+									{
+										'type': 'toolitem',
+										'text': _UNO('.uno:DefaultBullet'),
+										'command': '.uno:DefaultBullet'
+									},
+									{
+										'type': 'toolitem',
+										'text': _UNO('.uno:DefaultNumbering'),
+										'command': '.uno:DefaultNumbering'
+									},
+									{
+										'type': 'toolitem',
+										'text': _UNO('.uno:IncrementIndent'),
+										'command': '.uno:IncrementIndent'
+									},
+									{
+										'type': 'toolitem',
+										'text': _UNO('.uno:DecrementIndent'),
+										'command': '.uno:DecrementIndent'
+									},
+									{
+										'type': 'toolitem',
+										'text': _UNO('.uno:ParaLeftToRight'),
+										'command': '.uno:ParaLeftToRight'
+									}
+								]
+							},
+						],
+						'vertical': 'false'
+					},
+					{
+						'type': 'container',
+						'children': [
+							{
+								'id': 'SectionBottom13',
+								'type': 'toolbox',
+								'children': [
+									{
+										'type': 'toolitem',
+										'text': _UNO('.uno:ParaspaceIncrease'),
+										'command': '.uno:ParaspaceIncrease'
+									},
+									{
+										'type': 'toolitem',
+										'text': _UNO('.uno:ParaspaceDecrease'),
+										'command': '.uno:ParaspaceDecrease'
+									},
+									{
+										'type': 'toolitem',
+										'text': _UNO('.uno:LineSpacing'),
+										'command': '.uno:LineSpacing'
+									},
+									{
+										'type': 'toolitem',
+										'text': _UNO('.uno:ParaRightToLeft'),
+										'command': '.uno:ParaRightToLeft'
+									}
+								]
+							},
+						],
+						'vertical': 'false'
+					}
+				],
+				'vertical': 'true'
+			},
+			{
+				'type': 'bigtoolitem',
+				'text': _UNO('.uno:Text'),
+				'command': '.uno:Text'
+			},
+			{
+				'type': 'container',
+				'children': [
+					{
+						'id': 'LineA6',
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:BasicShapes'),
+								'command': '.uno:BasicShapes'
+							}
+						]
+					},
+					{
+						'id': 'LineB7',
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': 'Connectors',
+								'command': '.uno:ConnectorToolbox'
+							}
+						]
+					}
+				],
+				'vertical': 'true'
+			},
+			{
+				'type': 'container',
+				'children': [
+					{
 						'type': 'toolbox',
 						'children': [
 							{
@@ -284,7 +548,6 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 						]
 					},
 					{
-						'id': 'third8',
 						'type': 'toolbox',
 						'children': [
 							{
@@ -298,243 +561,9 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 				'vertical': 'true'
 			},
 			{
-				'id': 'Home-Section-DrawColor1',
 				'type': 'container',
 				'children': [
 					{
-						'id': 'third7',
-						'type': 'toolbox',
-						'children': [
-							{
-								'type': 'toolitem',
-								'text': _UNO('.uno:Text'),
-								'command': '.uno:Text'
-							},
-							{
-								'type': 'toolitem',
-							}
-						]
-					},
-					{
-						'id': 'third8',
-						'type': 'toolbox',
-						'children': [
-							{
-								'type': 'toolitem',
-								'text': _UNO('.uno:VerticalText'),
-								'command': '.uno:VerticalText'
-							},
-							{
-								'type': 'toolitem',
-							}
-						]
-					}
-				],
-				'vertical': 'true'
-			},
-			{
-				'id': 'Home-Section-Draw',
-				'type': 'container',
-				'children': [
-					{
-						'id': 'shapes1',
-						'type': 'toolbox',
-						'children': [
-							{
-								'type': 'toolitem',
-								'text': _UNO('.uno:Line'),
-								'command': '.uno:Line'
-							},
-							{
-								'type': 'toolitem',
-							}
-						]
-					},
-					{
-						'id': 'shapes3',
-						'type': 'toolbox',
-						'children': [
-							{
-								'type': 'toolitem',
-								'text': _UNO('.uno:ConnectorToolbox'),
-								'command': '.uno:ConnectorToolbox'
-							},
-							{
-								'type': 'toolitem',
-							}
-						]
-					}
-				],
-				'vertical': 'true'
-			},
-			{
-				'id': 'Draw-Section-ObjectAlign1',
-				'type': 'container',
-				'children': [
-					{
-						'id': 'Align1',
-						'type': 'toolbox',
-						'children': [
-							{
-								'type': 'toolitem',
-								'text': _UNO('.uno:ObjectAlignLeft'),
-								'command': '.uno:ObjectAlignLeft'
-							},
-							{
-								'type': 'toolitem',
-								'text': _UNO('.uno:AlignCenter'),
-								'command': '.uno:AlignCenter'
-							},
-							{
-								'type': 'toolitem',
-								'text': _UNO('.uno:ObjectAlignRight'),
-								'command': '.uno:ObjectAlignRight'
-							}
-						]
-					},
-					{
-						'id': 'Align2',
-						'type': 'toolbox',
-						'children': [
-							{
-								'type': 'toolitem',
-								'text': _UNO('.uno:AlignUp'),
-								'command': '.uno:AlignUp'
-							},
-							{
-								'type': 'toolitem',
-								'text': _UNO('.uno:AlignMiddle'),
-								'command': '.uno:AlignMiddle'
-							},
-							{
-								'type': 'toolitem',
-								'text': _UNO('.uno:AlignDown'),
-								'command': '.uno:AlignDown'
-							}
-						]
-					}
-				],
-				'vertical': 'true'
-			},
-			{
-				'id': 'Draw-Section-Arrange',
-				'type': 'container',
-				'children': [
-					{
-						'id': 'grid2',
-						'type': 'grid',
-						'children': [
-							{
-								'id': 'first8',
-								'type': 'toolbox',
-								'children': [
-									{
-										'type': 'toolitem',
-										'text': _UNO('.uno:BringToFront'),
-										'command': '.uno:BringToFront'
-									}
-								],
-								'left': '0',
-								'top': '0'
-							},
-							{
-								'id': 'first9',
-								'type': 'toolbox',
-								'children': [
-									{
-										'type': 'toolitem',
-										'text': _UNO('.uno:Forward'),
-										'command': '.uno:Forward'
-									}
-								],
-								'left': '1',
-								'top': '0'
-							},
-							{
-								'id': 'second1',
-								'type': 'toolbox',
-								'children': [
-									{
-										'type': 'toolitem',
-										'text': _UNO('.uno:SendToBack'),
-										'command': '.uno:SendToBack'
-									}
-								],
-								'left': '0',
-								'top': '1'
-							},
-							{
-								'id': 'Second1',
-								'type': 'toolbox',
-								'children': [
-									{
-										'type': 'toolitem',
-										'text': _UNO('.uno:Backward'),
-										'command': '.uno:Backward'
-									}
-								],
-								'left': '1',
-								'top': '1'
-							}
-						]
-					}
-				]
-			},
-			{
-				'id': 'Draw-Section-MergeCombine',
-				'type': 'container',
-				'children': [
-					{
-						'id': 'SectionBottom147',
-						'type': 'toolbox',
-						'children': [
-							{
-								'type': 'toolitem',
-								'text': _UNO('.uno:Combine', 'presentation'),
-								'command': '.uno:Combine'
-							},
-							{
-								'type': 'toolitem',
-								'text': _UNO('.uno:Dismantle', 'presentation'),
-								'command': '.uno:Dismantle'
-							},
-							{
-								'type': 'toolitem',
-								'text': _UNO('.uno:DistributeSelection', 'presentation'),
-								'command': '.uno:DistributeSelection'
-							}
-						]
-					},
-					{
-						'id': 'SectionBottom148',
-						'type': 'toolbox',
-						'children': [
-							{
-								'type': 'toolitem',
-								'text': _UNO('.uno:Merge', 'presentation'),
-								'command': '.uno:Merge'
-							},
-							{
-								'type': 'toolitem',
-								'text': _UNO('.uno:Substract', 'presentation'),
-								'command': '.uno:Substract'
-							},
-							{
-								'type': 'toolitem',
-								'text': _UNO('.uno:Intersect', 'presentation'),
-								'command': '.uno:Intersect'
-							}
-						]
-					}
-				],
-				'vertical': 'true'
-			},
-			{
-				'id': 'Home-Section-Insert',
-				'type': 'container',
-				'children': [
-					{
-						'id': 'LineA24',
 						'type': 'toolbox',
 						'children': [
 							{
@@ -545,13 +574,17 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 						]
 					},
 					{
-						'id': 'LineB27',
 						'type': 'toolbox',
 						'children': [
 							{
 								'type': 'toolitem',
 								'text': _UNO('.uno:InsertPage'),
 								'command': '.uno:InsertPage'
+							},
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:DuplicatePage'),
+								'command': '.uno:DuplicatePage'
 							},
 							{
 								'type': 'toolitem',
@@ -567,6 +600,11 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 					}
 				],
 				'vertical': 'true'
+			},
+			{
+				'type': 'bigtoolitem',
+				'text': _UNO('.uno:SearchDialog'),
+				'command': '.uno:SearchDialog'
 			}
 		];
 

--- a/loleaflet/src/control/Control.NotebookbarImpress.js
+++ b/loleaflet/src/control/Control.NotebookbarImpress.js
@@ -253,7 +253,6 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'command': '.uno:Paste'
 			},
 			{
-				'id': 'GroupB9',
 				'type': 'container',
 				'children': [
 					{
@@ -282,45 +281,9 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'vertical': 'true'
 			},
 			{
-				'id': 'Home-Section-Slide',
 				'type': 'container',
 				'children': [
 					{
-						'id': 'LineA8',
-						'type': 'toolbox',
-						'children': [
-							{
-								'type': 'toolitem',
-								'text': _UNO('.uno:InsertPage', 'presentation'),
-								'command': '.uno:InsertPage'
-							}
-						]
-					},
-					{
-						'id': 'LineB9',
-						'type': 'toolbox',
-						'children': [
-							{
-								'type': 'toolitem',
-								'text': _UNO('.uno:DuplicatePage', 'presentation'),
-								'command': '.uno:DuplicatePage'
-							},
-							{
-								'type': 'toolitem',
-								'text': _UNO('.uno:DeletePage', 'presentation'),
-								'command': '.uno:DeletePage'
-							}
-						]
-					}
-				],
-				'vertical': 'true'
-			},
-			{
-				'id': 'Home-Section-Style',
-				'type': 'container',
-				'children': [
-					{
-						'id': 'LineA7',
 						'type': 'toolbox',
 						'children': [
 							{
@@ -331,7 +294,6 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 						]
 					},
 					{
-						'id': 'LineB8',
 						'type': 'toolbox',
 						'children': [
 							{
@@ -345,11 +307,9 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'vertical': 'true'
 			},
 			{
-				'id': 'Home-Section-Format',
 				'type': 'container',
 				'children': [
 					{
-						'id': 'box76',
 						'type': 'container',
 						'children': [
 							{
@@ -361,52 +321,37 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 								],
 								'selectedCount': '1',
 								'selectedEntries': [
-									'71'
+									'0'
 								],
 								'command': '.uno:CharFontName'
 							},
 							{
-								'id': 'fontheight',
-								'type': 'toolbox',
-								'text': '',
-								'enabled': 'true',
-								'children': [
-									{
-										'id': 'fontsize',
-										'type': 'combobox',
-										'text': '18 pt',
-										'entries': [
-											'18 pt'
-										],
-										'selectedCount': '1',
-										'selectedEntries': [
-											'12'
-										],
-										'command': '.uno:FontHeight'
-									}
-								]
+								'id': 'fontsize',
+								'type': 'combobox',
+								'text': '12 pt',
+								'entries': [
+									'12 pt'
+								],
+								'selectedCount': '1',
+								'selectedEntries': [
+									'0'
+								],
+								'command': '.uno:FontHeight'
 							},
 							{
-								'id': 'ExtTop6',
-								'type': 'toolbox',
-								'children': [
-									{
-										'type': 'toolitem',
-										'text': _UNO('.uno:Grow'),
-										'command': '.uno:Grow'
-									},
-									{
-										'type': 'toolitem',
-										'text': _UNO('.uno:Shrink'),
-										'command': '.uno:Shrink'
-									}
-								]
+								'type': 'toolitem',
+								'text': _UNO('.uno:Grow'),
+								'command': '.uno:Grow'
+							},
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:Shrink'),
+								'command': '.uno:Shrink'
 							}
 						],
 						'vertical': 'false'
 					},
 					{
-						'id': 'GroupB11',
 						'type': 'container',
 						'children': [
 							{
@@ -437,17 +382,11 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 										'type': 'toolitem',
 										'text': _UNO('.uno:Shadowed'),
 										'command': '.uno:Shadowed'
-									}
-								]
-							},
-							{
-								'id': 'ExtTop2',
-								'type': 'toolbox',
-								'children': [
+									},
 									{
 										'type': 'toolitem',
-										'text': _UNO('.uno:Spacing', 'presentation'),
-										'command': '.uno:Spacing'
+										'text': _UNO('.uno:FontworkGalleryFloater'),
+										'command': '.uno:FontworkGalleryFloater'
 									},
 									{
 										'type': 'toolitem',
@@ -468,15 +407,12 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'vertical': 'true'
 			},
 			{
-				'id': 'Home-Section-Paragraph',
 				'type': 'container',
 				'children': [
 					{
-						'id': 'GroupB16',
 						'type': 'container',
 						'children': [
 							{
-								'id': 'SectionBottom9',
 								'type': 'toolbox',
 								'children': [
 									{
@@ -495,12 +431,11 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 										'command': '.uno:CellVertBottom'
 									}
 								]
-							}
+							},
 						],
 						'vertical': 'false'
 					},
 					{
-						'id': 'GroupB15',
 						'type': 'container',
 						'children': [
 							{
@@ -521,9 +456,14 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 										'type': 'toolitem',
 										'text': _UNO('.uno:RightPara'),
 										'command': '.uno:RightPara'
+									},
+									{
+										'type': 'toolitem',
+										'text': _UNO('.uno:JustifyPara'),
+										'command': '.uno:JustifyPara'
 									}
 								]
-							}
+							},
 						],
 						'vertical': 'false'
 					}
@@ -531,17 +471,13 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'vertical': 'true'
 			},
 			{
-				'id': 'Home-Section-Paragraph2',
 				'type': 'container',
 				'children': [
 					{
-						'id': 'GroupB95',
 						'type': 'container',
 						'children': [
 							{
-								'id': 'SectionBottom98',
 								'type': 'toolbox',
-								'enabled': 'true',
 								'children': [
 									{
 										'type': 'toolitem',
@@ -552,207 +488,56 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 										'type': 'toolitem',
 										'text': _UNO('.uno:DefaultNumbering'),
 										'command': '.uno:DefaultNumbering'
+									},
+									{
+										'type': 'toolitem',
+										'text': _UNO('.uno:IncrementIndent'),
+										'command': '.uno:IncrementIndent'
+									},
+									{
+										'type': 'toolitem',
+										'text': _UNO('.uno:DecrementIndent'),
+										'command': '.uno:DecrementIndent'
+									},
+									{
+										'type': 'toolitem',
+										'text': _UNO('.uno:ParaLeftToRight'),
+										'command': '.uno:ParaLeftToRight'
 									}
 								]
-							}
+							},
 						],
 						'vertical': 'false'
 					},
 					{
-						'id': 'GroupB97',
 						'type': 'container',
 						'children': [
 							{
-								'id': 'SectionBottom143',
+								'id': 'SectionBottom13',
 								'type': 'toolbox',
 								'children': [
 									{
 										'type': 'toolitem',
-										'text': _UNO('.uno:JustifyPara'),
-										'command': '.uno:JustifyPara'
+										'text': _UNO('.uno:ParaspaceIncrease'),
+										'command': '.uno:ParaspaceIncrease'
+									},
+									{
+										'type': 'toolitem',
+										'text': _UNO('.uno:ParaspaceDecrease'),
+										'command': '.uno:ParaspaceDecrease'
 									},
 									{
 										'type': 'toolitem',
 										'text': _UNO('.uno:LineSpacing'),
 										'command': '.uno:LineSpacing'
-									}
-								]
-							}
-						],
-						'vertical': 'false'
-					}
-				],
-				'vertical': 'true'
-			},
-			{
-				'id': 'Home-Section-Paragraph3',
-				'type': 'container',
-				'children': [
-					{
-						'id': 'SectionBottom145',
-						'type': 'toolbox',
-						'children': [
-							{
-								'type': 'toolitem',
-								'text': _UNO('.uno:IncrementIndent'),
-								'command': '.uno:IncrementIndent'
-							},
-							{
-								'type': 'toolitem',
-								'text': _UNO('.uno:DecrementIndent'),
-								'command': '.uno:DecrementIndent'
-							},
-							{
-								'type': 'toolitem',
-								'text': _UNO('.uno:ParaLeftToRight'),
-								'command': '.uno:ParaLeftToRight'
-							}
-						]
-					},
-					{
-						'id': 'SectionBottom146',
-						'type': 'toolbox',
-						'children': [
-							{
-								'type': 'toolitem',
-								'text': _UNO('.uno:ParaspaceIncrease'),
-								'command': '.uno:ParaspaceIncrease'
-							},
-							{
-								'type': 'toolitem',
-								'text': _UNO('.uno:ParaspaceDecrease'),
-								'command': '.uno:ParaspaceDecrease'
-							},
-							{
-								'type': 'toolitem',
-								'text': _UNO('.uno:ParaRightToLeft'),
-								'command': '.uno:ParaRightToLeft'
-							}
-						]
-					}
-				],
-				'vertical': 'true'
-			},
-			{
-				'type': 'bigtoolitem',
-				'text': _UNO('.uno:BasicShapes'),
-				'command': '.uno:BasicShapes'
-			},
-			{
-				'id': 'Home-Section-DrawSection',
-				'type': 'container',
-				'children': [
-					{
-						'id': 'shapes121',
-						'type': 'toolbox',
-						'children': [
-							{
-								'type': 'toolitem',
-								'text': _UNO('.uno:Text'),
-								'command': '.uno:Text'
-							}
-						]
-					},
-					{
-						'id': 'LineA282',
-						'type': 'toolbox',
-						'children': [
-							{
-								'type': 'toolitem',
-								'text': _UNO('.uno:VerticalText'),
-								'command': '.uno:VerticalText'
-							}
-						]
-					}
-				],
-				'vertical': 'true'
-			},
-			{
-				'id': 'Home-Section-DrawSection1',
-				'type': 'container',
-				'children': [
-					{
-						'id': 'GroupB12',
-						'type': 'container',
-						'children': [
-							{
-								'id': 'shapes12',
-								'type': 'toolbox',
-								'children': [
-									{
-										'type': 'toolitem',
-										'text': _UNO('.uno:Line'),
-										'command': '.uno:Line'
 									},
-								]
-							}
-						],
-						'vertical': 'false'
-					},
-					{
-						'id': 'GroupB38',
-						'type': 'container',
-						'children': [
-							{
-								'id': 'shapes15',
-								'type': 'toolbox',
-								'children': [
-									{
-										'id': 'shapes1',
-										'type': 'toolbox',
-										'children': [
-											{
-												'type': 'toolitem',
-												'text': _UNO('.uno:ConnectorToolbox', 'presentation'),
-												'command': '.uno:ConnectorToolbox'
-											}
-										]
-									},
-								]
-							}
-						],
-						'vertical': 'false'
-					}
-				],
-				'vertical': 'true'
-			},
-			{
-				'id': 'Home-Section-DrawSection2',
-				'type': 'container',
-				'children': [
-					{
-						'id': 'GroupB93',
-						'type': 'container',
-						'children': [
-							{
-								'id': 'LineA28',
-								'type': 'toolbox',
-								'children': [
 									{
 										'type': 'toolitem',
-										'text': _UNO('.uno:XLineColor'),
-										'command': '.uno:XLineColor'
+										'text': _UNO('.uno:ParaRightToLeft'),
+										'command': '.uno:ParaRightToLeft'
 									}
 								]
-							}
-						],
-						'vertical': 'false'
-					},
-					{
-						'id': 'GroupB94',
-						'type': 'container',
-						'children': [
-							{
-								'id': 'LineB29',
-								'type': 'toolbox',
-								'children': [
-									{
-										'type': 'toolitem',
-										'text': _UNO('.uno:FillColor'),
-										'command': '.uno:FillColor'
-									}
-								]
-							}
+							},
 						],
 						'vertical': 'false'
 					}
@@ -761,14 +546,114 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 			},
 			{
 				'type': 'bigtoolitem',
-				'text': _UNO('.uno:Presentation', 'presentation'),
+				'text': _UNO('.uno:Text'),
+				'command': '.uno:Text'
+			},
+			{
+				'type': 'container',
+				'children': [
+					{
+						'id': 'LineA6',
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:BasicShapes'),
+								'command': '.uno:BasicShapes'
+							}
+						]
+					},
+					{
+						'id': 'LineB7',
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': 'Connectors',
+								'command': '.uno:ConnectorToolbox'
+							}
+						]
+					}
+				],
+				'vertical': 'true'
+			},
+			{
+				'type': 'container',
+				'children': [
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:XLineColor'),
+								'command': '.uno:XLineColor'
+							}
+						]
+					},
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:FillColor'),
+								'command': '.uno:FillColor'
+							}
+						]
+					}
+				],
+				'vertical': 'true'
+			},
+			{
+				'type': 'container',
+				'children': [
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:InsertGraphic'),
+								'command': '.uno:InsertGraphic'
+							}
+						]
+					},
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:InsertPage'),
+								'command': '.uno:InsertPage'
+							},
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:DuplicatePage'),
+								'command': '.uno:DuplicatePage'
+							},
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:InsertObjectChart'),
+								'command': '.uno:InsertObjectChart'
+							},
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:InsertTable'),
+								'command': '.uno:InsertTable'
+							}
+						]
+					}
+				],
+				'vertical': 'true'
+			},
+			{
+				'type': 'bigtoolitem',
+				'text': _UNO('.uno:Presentation'),
 				'command': '.uno:Presentation'
 			},
 			{
 				'type': 'bigtoolitem',
 				'text': _UNO('.uno:SearchDialog'),
 				'command': '.uno:SearchDialog'
-			},
+			}
 		];
 
 		return this.getTabPage('Home', content);


### PR DESCRIPTION
Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: Ifccb641a45d985d46c8938d5e0c495ce9a396d2b

Update the structure of the Home Notebookbar Tab for Impress and Draw.

### general
- draw didn't has options for edit text in the notebookbar (LibreOffice has a text context tab)
- impress has the text editing stuff in the home tab
Solution use the same layout in impress and draw with text editing stuff at the home tab.

### Impress home tab
- past / cut / copy like writer and calc
- text editing stuff
- add shadow and fontwork stuff instead of SubScript /SuperScript (which mean same number of commands in all text editing sections, easier alignment when set character spacing was added)
- align section
- bullet and paragraph stuff
- TextBox, Shapes, ... drawing section
- Most imported insert tab stuff 
- Start Presentation
- Find and Replace

*Before*
![Screenshot_20210426_001222](https://user-images.githubusercontent.com/8517736/116011284-81b3a680-a624-11eb-8deb-8321c0e09869.png)

*After*
![Screenshot_20210426_001640](https://user-images.githubusercontent.com/8517736/116011327-b6bff900-a624-11eb-9606-025599e32a36.png)

### Draw home tab
- same as impress home tab
- exclude Start presentation

*Before*
![Screenshot_20210426_001235](https://user-images.githubusercontent.com/8517736/116011278-7791a800-a624-11eb-8f7f-4917e3efbb87.png)

*After*
![Screenshot_20210426_001650](https://user-images.githubusercontent.com/8517736/116011329-baec1680-a624-11eb-93e8-99d604273763.png)
