### PR TITLE
Notebookbar writer calc remove grow-shrink subgroup #2007

### DIFF
--- a/loleaflet/src/control/Control.NotebookbarCalc.js
+++ b/loleaflet/src/control/Control.NotebookbarCalc.js
@@ -264,20 +264,14 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 								'command': '.uno:FontHeight'
 							},
 							{
-								'id': 'ExtTop6',
-								'type': 'toolbox',
-								'children': [
-									{
-										'type': 'toolitem',
-										'text': _UNO('.uno:Grow'),
-										'command': '.uno:Grow'
-									},
-									{
-										'type': 'toolitem',
-										'text': _UNO('.uno:Shrink'),
-										'command': '.uno:Shrink'
-									}
-								]
+								'type': 'toolitem',
+								'text': _UNO('.uno:Grow'),
+								'command': '.uno:Grow'
+							},
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:Shrink'),
+								'command': '.uno:Shrink'
 							}
 						],
 						'vertical': 'false'

--- a/loleaflet/src/control/Control.NotebookbarWriter.js
+++ b/loleaflet/src/control/Control.NotebookbarWriter.js
@@ -379,20 +379,14 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 								'command': '.uno:FontHeight'
 							},
 							{
-								'id': 'ExtTop6',
-								'type': 'toolbox',
-								'children': [
-									{
-										'type': 'toolitem',
-										'text': _UNO('.uno:Grow'),
-										'command': '.uno:Grow'
-									},
-									{
-										'type': 'toolitem',
-										'text': _UNO('.uno:Shrink'),
-										'command': '.uno:Shrink'
-									}
-								]
+								'type': 'toolitem',
+								'text': _UNO('.uno:Grow'),
+								'command': '.uno:Grow'
+							},
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:Shrink'),
+								'command': '.uno:Shrink'
 							}
 						],
 						'vertical': 'false'


### PR DESCRIPTION
Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I0a4ac6ce73856d7f322e9cbf8fa52b7ad4aa81f4


* Resolves: # #2007 
* Target version: master 

### Summary
Remove an subgroup at the grow/shrink text setting in writer and calc. The structure of the json file will so follow #2007