### PR TITLE
Add version of std::atoi() that needs no extra allocation

### DIFF
--- a/common/Util.cpp
+++ b/common/Util.cpp
@@ -44,6 +44,7 @@
 #include <sstream>
 #include <string>
 #include <thread>
+#include <limits>
 
 #include <Poco/Base64Encoder.h>
 #include <Poco/HexBinaryEncoder.h>
@@ -1041,6 +1042,56 @@ namespace Util
         }
 
         return StringVector(s, std::move(tokens));
+    }
+
+    int safe_atoi(const char* p, int len)
+    {
+        long ret{};
+        if (!p || !len)
+        {
+            return ret;
+        }
+
+        int multiplier = 1;
+        int offset = 0;
+        while (isspace(p[offset]))
+        {
+            ++offset;
+            if (offset >= len)
+            {
+                return ret;
+            }
+        }
+
+        switch (p[offset])
+        {
+            case '-':
+                multiplier = -1;
+                ++offset;
+                break;
+            case '+':
+                ++offset;
+                break;
+        }
+        if (offset >= len)
+        {
+            return ret;
+        }
+
+        while (isdigit(p[offset]))
+        {
+            std::int64_t next = ret * 10 + (p[offset] - '0');
+            if (next >= std::numeric_limits<int>::max())
+                return multiplier * std::numeric_limits<int>::max();
+            ret = next;
+            ++offset;
+            if (offset >= len)
+            {
+                return multiplier * ret;
+            }
+        }
+
+        return multiplier * ret;
     }
 }
 

--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -1197,6 +1197,13 @@ int main(int argc, char**argv)
         return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
     }
 
+    /**
+     * Similar to std::atoi() but does not require p to be null-terminated.
+     *
+     * Returns std::numeric_limits<int>::min/max() if the result would overflow.
+     */
+    int safe_atoi(const char* p, int len);
+
 } // end namespace Util
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/net/HttpRequest.cpp
+++ b/net/HttpRequest.cpp
@@ -248,15 +248,7 @@ FieldParseState StatusLine::parse(const char* p, int64_t& len)
         LOG_ERR("StatusLine::parse: expected valid integer number");
         return FieldParseState::Invalid;
     }
-    // p may not be null-terminated, also make sure we limit the size of the allocated string.
-    int64_t lineBreak = findLineBreak(p, off, len);
-    if (lineBreak - off > MaxStatusLineLen)
-    {
-        LOG_ERR("StatusLine::parse: StatusCode is too long: " << (lineBreak - off));
-        return FieldParseState::Invalid;
-    }
-    std::string token(&p[off], lineBreak - off);
-    _statusCode = std::atoi(token.c_str());
+    _statusCode = Util::safe_atoi(&p[off], len - off);
     if (_statusCode < MinValidStatusCode || _statusCode > MaxValidStatusCode)
     {
         LOG_ERR("StatusLine::parse: Invalid StatusCode [" << _statusCode << "]");

--- a/test/WhiteBoxTests.cpp
+++ b/test/WhiteBoxTests.cpp
@@ -64,6 +64,7 @@ class WhiteBoxTests : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST(testParseUri);
     CPPUNIT_TEST(testParseUriUrl);
     CPPUNIT_TEST(testParseUrl);
+    CPPUNIT_TEST(testSafeAtoi);
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -95,6 +96,7 @@ class WhiteBoxTests : public CPPUNIT_NS::TestFixture
     void testParseUri();
     void testParseUriUrl();
     void testParseUrl();
+    void testSafeAtoi();
 };
 
 void WhiteBoxTests::testLOOLProtocolFunctions()
@@ -1953,6 +1955,53 @@ void WhiteBoxTests::testParseUrl()
 
     LOK_ASSERT_EQUAL(std::string("/some/path"),
                      net::parseUrl("https://sub.domain.com:80/some/path"));
+}
+
+void WhiteBoxTests::testSafeAtoi()
+{
+    {
+        std::string s("7");
+        LOK_ASSERT_EQUAL(7, Util::safe_atoi(s.data(), s.size()));
+    }
+    {
+        std::string s("+7");
+        LOK_ASSERT_EQUAL(7, Util::safe_atoi(s.data(), s.size()));
+    }
+    {
+        std::string s("-7");
+        LOK_ASSERT_EQUAL(-7, Util::safe_atoi(s.data(), s.size()));
+    }
+    {
+        std::string s("42");
+        LOK_ASSERT_EQUAL(42, Util::safe_atoi(s.data(), s.size()));
+    }
+    {
+        std::string s("42");
+        LOK_ASSERT_EQUAL(4, Util::safe_atoi(s.data(), 1));
+    }
+    {
+        std::string s("  42");
+        LOK_ASSERT_EQUAL(42, Util::safe_atoi(s.data(), s.size()));
+    }
+    {
+        std::string s("42xy");
+        LOK_ASSERT_EQUAL(42, Util::safe_atoi(s.data(), s.size()));
+    }
+    {
+        // Make sure signed integer overflow doesn't happen.
+        std::string s("9999999990");
+        // Good:       2147483647
+        // Bad:        1410065398
+        LOK_ASSERT_EQUAL(std::numeric_limits<int>::max(), Util::safe_atoi(s.data(), s.size()));
+    }
+    {
+        std::string s("123");
+        s[1] = '\0';
+        LOK_ASSERT_EQUAL(1, Util::safe_atoi(s.data(), s.size()));
+    }
+    {
+        LOK_ASSERT_EQUAL(0, Util::safe_atoi(nullptr, 0));
+    }
 }
 
 CPPUNIT_TEST_SUITE_REGISTRATION(WhiteBoxTests);


### PR DESCRIPTION
std::atoi() assumes a null-terminated string and our strings are not
always null-terminated. So add a version that takes a length parameter,
this way we don't have to copy strings around.

Also switch to this in http::StatusLine::parse().

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I449b356c1b9948c562434618596e8e3b38656088
