### PR TITLE
Private/dennisf/header resize fix

### DIFF
--- a/loleaflet/src/control/Control.ColumnHeader.js
+++ b/loleaflet/src/control/Control.ColumnHeader.js
@@ -178,6 +178,8 @@ L.Control.ColumnHeader = L.Control.Header.extend({
 		this._headerInfo.forEachElement(function(elemData) {
 			this.drawHeaderEntry(elemData, false, isHighlighted);
 		}.bind(this));
+
+		this.drawResizeLineIfNeeded();
 	},
 
 	onClick: function (point, e) {

--- a/loleaflet/src/control/Control.ColumnHeader.js
+++ b/loleaflet/src/control/Control.ColumnHeader.js
@@ -242,6 +242,7 @@ L.Control.ColumnHeader = L.Control.Header.extend({
 			};
 
 			this._map.sendUnoCommand('.uno:ColumnWidth', command);
+			this._mouseOverEntry = null;
 		}
 	},
 

--- a/loleaflet/src/control/Control.ColumnHeader.js
+++ b/loleaflet/src/control/Control.ColumnHeader.js
@@ -118,7 +118,7 @@ L.Control.ColumnHeader = L.Control.Header.extend({
 
 		// draw resize handle
 		var handleSize = this._resizeHandleSize;
-		if (isCurrent && entry.size > 2 * handleSize) {
+		if (isCurrent && entry.size > 2 * handleSize && !this.inResize()) {
 			var center = startX + entry.size - handleSize / 2;
 			var y = 2 * this.dpiScale;
 			var h = this.size[1] - 4 * this.dpiScale;

--- a/loleaflet/src/control/Control.Header.js
+++ b/loleaflet/src/control/Control.Header.js
@@ -556,8 +556,29 @@ L.Control.Header = L.Class.extend({
 		$.contextMenu('destroy', '#document-canvas');
 	},
 
+	inResize: function () {
+		return this.containerObject.draggingSomething && this._dragEntry && this._dragDistance;
+	},
+
+	drawResizeLineIfNeeded: function () {
+		if (!this.inResize())
+			return;
+
+		this.containerObject.setPenPosition(this);
+		var x = this._isColumn ? (this._dragEntry.pos + this._dragDistance[0]): this.size[0];
+		var y = this._isColumn ? this.size[1]: (this._dragEntry.pos + this._dragDistance[1]);
+
+		this.context.lineWidth = this.dpiScale;
+		this.context.strokeStyle = 'darkblue';
+		this.context.beginPath();
+		this.context.moveTo(x, y);
+		this.context.lineTo(this._isColumn ? x: this.containerObject.right, this._isColumn ? this.containerObject.bottom: y);
+		this.context.stroke();
+	},
+
 	onMouseMove: function (point, dragDistance) {
 		if (!this.containerObject.draggingSomething) { // If we are not dragging anything.
+			this._dragDistance = null;
 			var result = this._entryAtPoint(point); // Data related to current entry that the mouse is over now.
 
 			// If mouse was over another entry previously, we draw that again (without mouse-over effect).
@@ -587,19 +608,8 @@ L.Control.Header = L.Class.extend({
 			}
 		}
 		else { // We are in dragging mode.
-			this.containerObject.requestReDraw(); // Remove previously drawn line.
-			this.containerObject.setPenPosition(this);
-			if (this._dragEntry) {
-				var x = this._isColumn ? (this._dragEntry.pos + dragDistance[0]): this.size[0];
-				var y = this._isColumn ? this.size[1]: (this._dragEntry.pos + dragDistance[1]);
-
-				this.context.lineWidth = this.dpiScale;
-				this.context.strokeStyle = 'darkblue';
-				this.context.beginPath();
-				this.context.moveTo(x, y);
-				this.context.lineTo(this._isColumn ? x: this.containerObject.right, this._isColumn ? this.containerObject.bottom: y);
-				this.context.stroke();
-			}
+			this._dragDistance = dragDistance;
+			this.containerObject.requestReDraw(); // Remove previously drawn line and paint a new one.
 		}
 	},
 

--- a/loleaflet/src/control/Control.RowHeader.js
+++ b/loleaflet/src/control/Control.RowHeader.js
@@ -117,7 +117,7 @@ L.Control.RowHeader = L.Control.Header.extend({
 
 		// draw resize handle
 		var handleSize = this._resizeHandleSize;
-		if (isCurrent && entry.size > 2 * handleSize) {
+		if (isCurrent && entry.size > 2 * handleSize && !this.inResize()) {
 			var center = startY + entry.size - handleSize / 2;
 			var x = 2 * this.dpiScale;
 			var w = this.size[0] - 4 * this.dpiScale;

--- a/loleaflet/src/control/Control.RowHeader.js
+++ b/loleaflet/src/control/Control.RowHeader.js
@@ -238,6 +238,7 @@ L.Control.RowHeader = L.Control.Header.extend({
 
 			this._map.sendUnoCommand('.uno:RowHeight', command);
 			//this.containerObject.requestReDraw();
+			this._mouseOverEntry = null;
 		}
 	},
 

--- a/loleaflet/src/control/Control.RowHeader.js
+++ b/loleaflet/src/control/Control.RowHeader.js
@@ -173,6 +173,8 @@ L.Control.RowHeader = L.Control.Header.extend({
 		this._headerInfo.forEachElement(function(elemData) {
 			this.drawHeaderEntry(elemData, false, isHighlighted);
 		}.bind(this));
+
+		this.drawResizeLineIfNeeded();
 	},
 
 	onClick: function (point, e) {


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
Fix :
1. header handle flicker on resize and cell cursor move.
2. update resize line on view move (arrow keys)
3. wrong sized header just after resize + mouse move (but goes away with another mousemove).

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

