### PR TITLE
Introduce ways to toggle and tweak core profile zone recording and lo…

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -305,7 +305,9 @@ bool ChildSession::_handleInput(const char *buffer, int length)
                tokens.equals(0, "removetextcontext") ||
                tokens.equals(0, "dialogevent") ||
                tokens.equals(0, "completefunction")||
-               tokens.equals(0, "formfieldevent"));
+               tokens.equals(0, "formfieldevent") ||
+               tokens.equals(0, "traceeventrecording") ||
+               tokens.equals(0, "sallogoverride"));
 
         if (tokens.equals(0, "clientzoom"))
         {
@@ -456,6 +458,37 @@ bool ChildSession::_handleInput(const char *buffer, int length)
         else if (tokens.equals(0, "formfieldevent"))
         {
             return formFieldEvent(buffer, length, tokens);
+        }
+        else if (tokens.equals(0, "traceeventrecording"))
+        {
+            if (tokens.size() > 0)
+            {
+                if (tokens.equals(1, "start"))
+                {
+                    getLOKit()->setOption("traceeventrecording", "start");
+                    LOG_INF("Profile zone tracing in this kit process turned on (might have been on all the time)");
+                }
+                else if (tokens.equals(1, "stop"))
+                {
+                    getLOKit()->setOption("traceeventrecording", "stop");
+                    LOG_INF("Profile zone tracing in this kit process turned off");
+                }
+            }
+        }
+        else if (tokens.equals(0, "sallogoverride"))
+        {
+            if (tokens.size() == 0 || tokens.equals(1, "default"))
+            {
+                getLOKit()->setOption("sallogoverride", nullptr);
+            }
+            else if (tokens.size() > 0 && tokens.equals(1, "off"))
+            {
+                getLOKit()->setOption("sallogoverride", "-WARN-INFO");
+            }
+            else if (tokens.size() > 0)
+            {
+                getLOKit()->setOption("sallogoverride", tokens[1].c_str());
+            }
         }
         else
         {

--- a/loleaflet/src/control/Toolbar.js
+++ b/loleaflet/src/control/Toolbar.js
@@ -26,6 +26,11 @@ L.Map.include({
 		}
 	},
 
+	// Triple-clicking turns profiling on in the kit process for
+	// this document (it is already if the server is running with log level
+	// "trace"). Triple-clicking again turns it off. Etc.
+	_profilingRequestedToggle: false,
+
 	onFontSelect: function(e) {
 		var font = e.target.value;
 		this.applyFont(font);
@@ -703,6 +708,19 @@ L.Map.include({
 				hammer.add(new Hammer.Tap({ taps: 3 }));
 				hammer.on('tap', function() {
 					map._docLayer.toggleTileDebugMode();
+
+					map._socket.sendMessage('traceeventrecording ' + (map._profilingRequestedToggle ? 'stop' : 'start'));
+
+					// Just as a test, uncomment this to toggle SAL_WARN and SAL_INFO
+					// selection between two states: 1) the default as directed by the
+					// SAL_LOG environment variable, and 2) all warnings on plus SAL_INFO for sc.
+					//
+					// (Note that loolwsd sets the SAL_LOG environment variable to
+					// "-WARN-INFO", i.e. the default is that nothing is logged)
+
+					// map._socket.sendMessage('sallogoverride ' + (map._profilingRequestedToggle ? 'default' : '+WARN+INFO.sc'));
+
+					map._profilingRequestedToggle = !map._profilingRequestedToggle;
 				});
 
 				this.contentEl.style.width = w + 'px';

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -704,7 +704,10 @@ bool ClientSession::_handleInput(const char *buffer, int length)
         docBroker->uploadAsToStorage(getId(), "", wopiFilename, true);
         return true;
     }
-    else if (tokens.equals(0, "dialogevent") || tokens.equals(0, "formfieldevent"))
+    else if (tokens.equals(0, "dialogevent") ||
+             tokens.equals(0, "formfieldevent") ||
+             tokens.equals(0, "traceeventrecording") ||
+             tokens.equals(0, "sallogoverride"))
     {
         return forwardToChild(firstLine, docBroker);
     }

--- a/wsd/protocol.txt
+++ b/wsd/protocol.txt
@@ -289,6 +289,15 @@ removesession <viewid>
     privilege views cannot remove higher ones, eg. a readonly view
     can't remove an editor.
 
+traceeventrecording <start/stop>
+
+    Starts or stops comphelper::TraceEvent recording.
+
+sallogoverride <string>
+
+    Overrides the SAL_LOG value, or stops overriding if no parameter
+    or parameter is "default".
+
 server -> client
 ================
 
@@ -621,6 +630,12 @@ clipboardcontent:
      length\n
      <binary selection content>
      ...
+
+trace:
+
+     Followed by a number of lines consisting of Chrome Trace Event
+     formatted data recorded by the comphelper::TraceEvent API in the
+     core parts of the kit process.
 
 parent -> child
 ===============


### PR DESCRIPTION
…gging

When toggling tile debugging in the Help>About, toggle profile zone
tracing, too. Add a comment with an example of how to turn on SAL_LOG
overriding at the sa,e place.

The following new messages from client to server are introduced:

profilezonerecording <start/stop>

    Starts or stops comphelper::ProfileZone recording.

sallogoverride <string>

    Overrides the SAL_LOG value, or stops overriding if no parameter
    or parameter is "default".

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: I8b56c28cd99d39115cd796c44e5051d934d21a1f
Signed-off-by: Tor Lillqvist <tml@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

