### PR TITLE
Fix insert line and shape icon #2152

### DIFF
--- a/loleaflet/images/lc_basicshapes.svg
+++ b/loleaflet/images/lc_basicshapes.svg
@@ -1,11 +1,11 @@
 <?xml-stylesheet type="text/css" href="icons.css" ?>
 <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
   <path
-	 class="icn icn--shape-color" 
-     d="m22 12a10 8 0 0 1 -10 8 10 8 0 0 1 -10-8 10 8 0 0 1 10-8 10 8 0 0 1 10 8z"
-     fill="#fafafa" 
-	 stroke="#3a3a38" 
-	 stroke-linecap="round" 
+	 class="icn icn--highlight-color"
+     d="m12 4.5a9.5 7.5 0 0 0 -9.5 7.5 9.5 7.5 0 0 0 9.5 7.5 9.5 7.5 0 0 0 9.5-7.5 9.5 7.5 0 0 0 -9.5-7.5"
+     fill="#83beec"
+	 stroke="#1e8bcd"
+	 stroke-linecap="round"
 	 stroke-linejoin="round"
      />
 </svg>

--- a/loleaflet/images/lc_line.svg
+++ b/loleaflet/images/lc_line.svg
@@ -2,7 +2,7 @@
 <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
   <path
 	 class="icn icn--highlight-color-line"
-     d="m 2.5,2.5 19,19"
+     d="m 2.5,11.5 h 19"
      fill="none"
      stroke="#1e8bcd" 
 	 stroke-linecap="round" 


### PR DESCRIPTION
Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I327dc32c22ee156a967fea3c6012d6bd0b677482

line icon is now a horizontal line, cause when click on line icon an horizontal line was drawn.
shape icon is now pixel align and use highlight color (blue), cause by default the shapes are blue.