### PR TITLE
Canvas: not alpha, and de-synchronized.

### DIFF
--- a/loleaflet/src/layer/tile/CanvasSectionContainer.ts
+++ b/loleaflet/src/layer/tile/CanvasSectionContainer.ts
@@ -260,7 +260,7 @@ class CanvasSectionContainer {
 
 	constructor (canvasDOMElement: HTMLCanvasElement) {
 		this.canvas = canvasDOMElement;
-		this.context = canvasDOMElement.getContext('2d');
+		this.context = canvasDOMElement.getContext('2d', { alpha: false , desynchronized: true });
 		this.context.setTransform(1,0,0,1,0,0);
 		document.addEventListener('mousemove', this.onMouseMove.bind(this));
 		this.canvas.onmousedown = this.onMouseDown.bind(this);


### PR DESCRIPTION
scrolling a calc sheet down that contains some useful numerical data.

Seeming desynchronized can reduce copying and improve interactivity:

https://developers.google.com/web/updates/2019/05/desynchronized

alpha	desync	frame times	avg/ms
--------------------------------------
false	true	105, 94, 86	95
true	true	90, 108, 92	96
true	false	287, 284, 273	281
false	false	278, 298, 288	288

Change-Id: Id59ab3870ccd3d85d88fc0763bf9742cb21b5731
Signed-off-by: Michael Meeks <michael.meeks@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

