### PR TITLE
Notebookbar Draw Tab update #2007

### DIFF
--- a/loleaflet/src/control/Control.NotebookbarCalc.js
+++ b/loleaflet/src/control/Control.NotebookbarCalc.js
@@ -45,6 +45,12 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				'name': 'Format'
 			},
 			{
+				'text': _('~Draw'),
+				'id': '-9',
+				'name': 'Draw',
+				'context': 'Draw'
+			},
+			{
 				'text': _('~Help'),
 				'id': '-2',
 				'name': 'Help',
@@ -62,6 +68,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				this.getDataTab(),
 				this.getReviewTab(),
 				this.getFormatTab(),
+				this.getDrawTab(),
 				this.getHelpTab()
 			], selectedId);
 	},
@@ -1330,6 +1337,291 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 		];
 
 		return this.getTabPage('Format', content);
+	},
+
+	getDrawTab: function() {
+		var content = [
+			{
+				'type': 'bigtoolitem',
+				'text': _UNO('.uno:TransformDialog', 'text'),
+				'command': '.uno:TransformDialog'
+			},
+			{
+				'type': 'container',
+				'children': [
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:FlipVertical'),
+								'command': '.uno:FlipVertical'
+							}
+						]
+					},
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:FlipHorizontal'),
+								'command': '.uno:FlipHorizontal'
+							}
+						]
+					}
+				],
+				'vertical': 'true'
+			},
+			{
+				'type': 'container',
+				'children': [
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:XLineColor'),
+								'command': '.uno:XLineColor'
+							}
+						]
+					},
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:FillColor'),
+								'command': '.uno:FillColor'
+							}
+						]
+					}
+				],
+				'vertical': 'true'
+			},
+			{
+				'type': 'container',
+				'children': [
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:WrapOff', 'text'),
+								'command': '.uno:WrapOff'
+							},
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:WrapOn', 'text'),
+								'command': '.uno:WrapOn'
+							},
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:WrapIdeal', 'text'),
+								'command': '.uno:WrapIdeal'
+							}
+						]
+					},
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:WrapLeft', 'text'),
+								'command': '.uno:WrapLeft'
+							},
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:WrapThrough', 'text'),
+								'command': '.uno:WrapThrough'
+							},
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:WrapRight', 'text'),
+								'command': '.uno:WrapRight'
+							}
+						]
+					}
+				],
+				'vertical': 'true'
+			},
+			{
+				'type': 'container',
+				'children': [
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:ObjectAlignLeft'),
+								'command': '.uno:ObjectAlignLeft'
+							},
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:AlignCenter'),
+								'command': '.uno:AlignCenter'
+							},
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:ObjectAlignRight'),
+								'command': '.uno:ObjectAlignRight'
+							}
+						]
+					},
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:AlignUp'),
+								'command': '.uno:AlignUp'
+							},
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:AlignMiddle'),
+								'command': '.uno:AlignMiddle'
+							},
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:AlignDown'),
+								'command': '.uno:AlignDown'
+							}
+						]
+					}
+				],
+				'vertical': 'true'
+			},
+			{
+				'type': 'container',
+				'children': [
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:BringToFront'),
+								'command': '.uno:BringToFront'
+							},
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:SendToBack'),
+								'command': '.uno:SendToBack'
+							}
+						]
+					},
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:ObjectForwardOne'),
+								'command': '.uno:ObjectForwardOne'
+							},
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:ObjectBackOne'),
+								'command': '.uno:ObjectBackOne'
+							}
+						]
+					}
+				],
+				'vertical': 'true'
+			},
+			{
+				'type': 'bigtoolitem',
+				'text': _UNO('.uno:FormatGroup'),
+				'command': '.uno:FormatGroup'
+			},
+			{
+				'type': 'container',
+				'children': [
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:EnterGroup'),
+								'command': '.uno:EnterGroup'
+							}
+						]
+					},
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:LeaveGroup'),
+								'command': '.uno:LeaveGroup'
+							}
+						]
+					}
+				],
+				'vertical': 'true'
+			},
+			{
+				'type': 'bigtoolitem',
+				'text': _UNO('.uno:Text'),
+				'command': '.uno:Text'
+			},
+			{
+				'type': 'container',
+				'children': [
+					{
+						'id': 'LineA6',
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:BasicShapes'),
+								'command': '.uno:BasicShapes'
+							}
+						]
+					},
+					{
+						'id': 'LineB7',
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:Line', 'text'),
+								'command': '.uno:Line'
+							}
+						]
+					}
+				],
+				'vertical': 'true'
+			},
+			{
+				'id': 'Insert-Text-Fontwork',
+				'type': 'container',
+				'children': [
+					{
+						'id': 'LineA153',
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:FontworkGalleryFloater'),
+								'command': '.uno:FontworkGalleryFloater'
+							}
+						]
+					},
+					{
+						'id': 'LineB163',
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:VerticalText', 'text'),
+								'command': '.uno:VerticalText'
+							}
+						]
+					}
+				],
+				'vertical': 'true'
+			},
+		];
+
+		return this.getTabPage('Draw', content);
 	}
 });
 

--- a/loleaflet/src/control/Control.NotebookbarImpress.js
+++ b/loleaflet/src/control/Control.NotebookbarImpress.js
@@ -1143,37 +1143,29 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 		var content = [
 			{
 				'type': 'bigtoolitem',
-				'text': _UNO('.uno:FlipVertical'),
-				'command': '.uno:FlipVertical'
+				'text': _UNO('.uno:TransformDialog', 'text'),
+				'command': '.uno:TransformDialog'
 			},
 			{
-				'type': 'bigtoolitem',
-				'text': _UNO('.uno:FlipHorizontal'),
-				'command': '.uno:FlipHorizontal'
-			},
-			{
-				'id': 'Draw-Section-FormatLineArea1',
 				'type': 'container',
 				'children': [
 					{
-						'id': 'third10',
 						'type': 'toolbox',
 						'children': [
 							{
 								'type': 'toolitem',
-								'text': _UNO('.uno:FormatLine'),
-								'command': '.uno:FormatLine'
+								'text': _UNO('.uno:FlipVertical'),
+								'command': '.uno:FlipVertical'
 							}
 						]
 					},
 					{
-						'id': 'third13',
 						'type': 'toolbox',
 						'children': [
 							{
 								'type': 'toolitem',
-								'text': _UNO('.uno:FormatArea'),
-								'command': '.uno:FormatArea'
+								'text': _UNO('.uno:FlipHorizontal'),
+								'command': '.uno:FlipHorizontal'
 							}
 						]
 					}
@@ -1181,47 +1173,25 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'vertical': 'true'
 			},
 			{
-				'id': 'Draw-Section-FormatLineArea3',
 				'type': 'container',
 				'children': [
 					{
-						'id': 'box6',
-						'type': 'container',
-						'children': [
-							{
-								'id': 'SectionBottom38',
-								'type': 'toolbox',
-								'children': [
-									{
-										'type': 'toolitem',
-										'text': _UNO('.uno:XLineColor'),
-										'command': '.uno:XLineColor'
-									}
-								]
-							}
-						],
-						'vertical': 'false'
-					},
-					{
-						'id': 'SectionBottom50',
 						'type': 'toolbox',
 						'children': [
 							{
-								'id': '',
-								'type': 'window',
-								'children': [
-									{
-										'id': 'colortoolbox',
-										'type': 'toolbox',
-										'children': [
-											{
-												'type': 'toolitem',
-												'text': _UNO('.uno:FillColor'),
-												'command': '.uno:FillColor'
-											}
-										]
-									}
-								]
+								'type': 'toolitem',
+								'text': _UNO('.uno:XLineColor'),
+								'command': '.uno:XLineColor'
+							}
+						]
+					},
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:FillColor'),
+								'command': '.uno:FillColor'
 							}
 						]
 					}
@@ -1229,168 +1199,127 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'vertical': 'true'
 			},
 			{
-				'id': 'Draw-Section-ObjectAlign1',
 				'type': 'container',
 				'children': [
 					{
-						'id': 'AlignGroup1',
-						'type': 'container',
-						'children': [
-							{
-								'id': 'Align1',
-								'type': 'toolbox',
-								'children': [
-									{
-										'type': 'toolitem',
-										'text': _UNO('.uno:ObjectAlignLeft'),
-										'command': '.uno:ObjectAlignLeft'
-									},
-									{
-										'type': 'toolitem',
-										'text': _UNO('.uno:AlignCenter'),
-										'command': '.uno:AlignCenter'
-									},
-									{
-										'type': 'toolitem',
-										'text': _UNO('.uno:ObjectAlignRight'),
-										'command': '.uno:ObjectAlignRight'
-									}
-								]
-							},
-							{
-								'id': 'Align2',
-								'type': 'toolbox',
-								'children': [
-									{
-										'type': 'toolitem',
-										'text': _UNO('.uno:AlignUp'),
-										'command': '.uno:AlignUp'
-									},
-									{
-										'type': 'toolitem',
-										'text': _UNO('.uno:AlignMiddle'),
-										'command': '.uno:AlignMiddle'
-									},
-									{
-										'type': 'toolitem',
-										'text': _UNO('.uno:AlignDown'),
-										'command': '.uno:AlignDown'
-									}
-								]
-							}
-						],
-						'vertical': 'true'
-					}
-				],
-				'vertical': 'false'
-			},
-			{
-				'id': 'Draw-Section-Arrange',
-				'type': 'container',
-				'children': [
-					{
-						'id': 'grid2',
-						'type': 'grid',
-						'children': [
-							{
-								'id': 'first8',
-								'type': 'toolbox',
-								'children': [
-									{
-										'type': 'toolitem',
-										'text': _UNO('.uno:BringToFront'),
-										'command': '.uno:BringToFront'
-									}
-								],
-								'left': '0',
-								'top': '0'
-							},
-							{
-								'id': 'first9',
-								'type': 'toolbox',
-								'children': [
-									{
-										'type': 'toolitem',
-										'text': _UNO('.uno:Forward'),
-										'command': '.uno:Forward'
-									}
-								],
-								'left': '1',
-								'top': '0'
-							},
-							{
-								'id': 'second1',
-								'type': 'toolbox',
-								'children': [
-									{
-										'type': 'toolitem',
-										'text': _UNO('.uno:SendToBack'),
-										'command': '.uno:SendToBack'
-									}
-								],
-								'left': '0',
-								'top': '1'
-							},
-							{
-								'id': 'Second1',
-								'type': 'toolbox',
-								'children': [
-									{
-										'type': 'toolitem',
-										'text': _UNO('.uno:Backward'),
-										'command': '.uno:Backward'
-									}
-								],
-								'left': '1',
-								'top': '1'
-							}
-						]
-					}
-				]
-			},
-			{
-				'id': 'Draw-Section-MergeCombine',
-				'type': 'container',
-				'children': [
-					{
-						'id': 'SectionBottom147',
 						'type': 'toolbox',
 						'children': [
 							{
 								'type': 'toolitem',
-								'text': _UNO('.uno:Combine', 'presentation'),
-								'command': '.uno:Combine'
+								'text': _UNO('.uno:WrapOff', 'text'),
+								'command': '.uno:WrapOff'
 							},
 							{
 								'type': 'toolitem',
-								'text': _UNO('.uno:Dismantle', 'presentation'),
-								'command': '.uno:Dismantle'
+								'text': _UNO('.uno:WrapOn', 'text'),
+								'command': '.uno:WrapOn'
 							},
 							{
 								'type': 'toolitem',
-								'text': _UNO('.uno:DistributeSelection', 'presentation'),
-								'command': '.uno:DistributeSelection'
+								'text': _UNO('.uno:WrapIdeal', 'text'),
+								'command': '.uno:WrapIdeal'
 							}
 						]
 					},
 					{
-						'id': 'SectionBottom148',
 						'type': 'toolbox',
 						'children': [
 							{
 								'type': 'toolitem',
-								'text': _UNO('.uno:Merge', 'presentation'),
-								'command': '.uno:Merge'
+								'text': _UNO('.uno:WrapLeft', 'text'),
+								'command': '.uno:WrapLeft'
 							},
 							{
 								'type': 'toolitem',
-								'text': _UNO('.uno:Substract', 'presentation'),
-								'command': '.uno:Substract'
+								'text': _UNO('.uno:WrapThrough', 'text'),
+								'command': '.uno:WrapThrough'
 							},
 							{
 								'type': 'toolitem',
-								'text': _UNO('.uno:Intersect', 'presentation'),
-								'command': '.uno:Intersect'
+								'text': _UNO('.uno:WrapRight', 'text'),
+								'command': '.uno:WrapRight'
+							}
+						]
+					}
+				],
+				'vertical': 'true'
+			},
+			{
+				'type': 'container',
+				'children': [
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:ObjectAlignLeft'),
+								'command': '.uno:ObjectAlignLeft'
+							},
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:AlignCenter'),
+								'command': '.uno:AlignCenter'
+							},
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:ObjectAlignRight'),
+								'command': '.uno:ObjectAlignRight'
+							}
+						]
+					},
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:AlignUp'),
+								'command': '.uno:AlignUp'
+							},
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:AlignMiddle'),
+								'command': '.uno:AlignMiddle'
+							},
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:AlignDown'),
+								'command': '.uno:AlignDown'
+							}
+						]
+					}
+				],
+				'vertical': 'true'
+			},
+			{
+				'type': 'container',
+				'children': [
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:BringToFront'),
+								'command': '.uno:BringToFront'
+							},
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:SendToBack'),
+								'command': '.uno:SendToBack'
+							}
+						]
+					},
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:ObjectForwardOne'),
+								'command': '.uno:ObjectForwardOne'
+							},
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:ObjectBackOne'),
+								'command': '.uno:ObjectBackOne'
 							}
 						]
 					}
@@ -1403,11 +1332,9 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'command': '.uno:FormatGroup'
 			},
 			{
-				'id': 'Draw-Section-Group1',
 				'type': 'container',
 				'children': [
 					{
-						'id': 'SectionBottom52',
 						'type': 'toolbox',
 						'children': [
 							{
@@ -1418,7 +1345,6 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 						]
 					},
 					{
-						'id': 'SectionBottom53',
 						'type': 'toolbox',
 						'children': [
 							{
@@ -1433,9 +1359,66 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 			},
 			{
 				'type': 'bigtoolitem',
-				'text': _UNO('.uno:FontworkGalleryFloater'),
-				'command': '.uno:FontworkGalleryFloater'
-			}
+				'text': _UNO('.uno:Text'),
+				'command': '.uno:Text'
+			},
+			{
+				'type': 'container',
+				'children': [
+					{
+						'id': 'LineA6',
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:BasicShapes'),
+								'command': '.uno:BasicShapes'
+							}
+						]
+					},
+					{
+						'id': 'LineB7',
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': 'Connectors',
+								'command': '.uno:ConnectorToolbox'
+							}
+						]
+					}
+				],
+				'vertical': 'true'
+			},
+			{
+				'id': 'Insert-Text-Fontwork',
+				'type': 'container',
+				'children': [
+					{
+						'id': 'LineA153',
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:FontworkGalleryFloater'),
+								'command': '.uno:FontworkGalleryFloater'
+							}
+						]
+					},
+					{
+						'id': 'LineB163',
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:VerticalText', 'text'),
+								'command': '.uno:VerticalText'
+							}
+						]
+					}
+				],
+				'vertical': 'true'
+			},
 		];
 
 		return this.getTabPage('Draw', content);

--- a/loleaflet/src/control/Control.NotebookbarWriter.js
+++ b/loleaflet/src/control/Control.NotebookbarWriter.js
@@ -1773,42 +1773,29 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 		var content = [
 			{
 				'type': 'bigtoolitem',
-				'text': _UNO('.uno:InsertCaptionDialog', 'text'),
-				'command': '.uno:InsertCaptionDialog'
+				'text': _UNO('.uno:TransformDialog', 'text'),
+				'command': '.uno:TransformDialog'
 			},
 			{
-				'type': 'bigtoolitem',
-				'text': _UNO('.uno:FlipVertical'),
-				'command': '.uno:FlipVertical'
-			},
-			{
-				'type': 'bigtoolitem',
-				'text': _UNO('.uno:FlipHorizontal'),
-				'command': '.uno:FlipHorizontal'
-			},
-			{
-				'id': 'Draw-Section-FormatLineArea2',
 				'type': 'container',
 				'children': [
 					{
-						'id': 'third8',
 						'type': 'toolbox',
 						'children': [
 							{
 								'type': 'toolitem',
-								'text': _UNO('.uno:FormatLine'),
-								'command': '.uno:FormatLine'
+								'text': _UNO('.uno:FlipVertical'),
+								'command': '.uno:FlipVertical'
 							}
 						]
 					},
 					{
-						'id': 'third7',
 						'type': 'toolbox',
 						'children': [
 							{
 								'type': 'toolitem',
-								'text': _UNO('.uno:FormatArea'),
-								'command': '.uno:FormatArea'
+								'text': _UNO('.uno:FlipHorizontal'),
+								'command': '.uno:FlipHorizontal'
 							}
 						]
 					}
@@ -1816,16 +1803,35 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				'vertical': 'true'
 			},
 			{
-				'type': 'bigtoolitem',
-				'text': _UNO('.uno:XLineColor'),
-				'command': '.uno:XLineColor'
-			},
-			{
-				'id': 'Draw-Section-Wrap1',
 				'type': 'container',
 				'children': [
 					{
-						'id': 'Wrap13',
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:XLineColor'),
+								'command': '.uno:XLineColor'
+							}
+						]
+					},
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:FillColor'),
+								'command': '.uno:FillColor'
+							}
+						]
+					}
+				],
+				'vertical': 'true'
+			},
+			{
+				'type': 'container',
+				'children': [
+					{
 						'type': 'toolbox',
 						'children': [
 							{
@@ -1846,7 +1852,6 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 						]
 					},
 					{
-						'id': 'Wrap14',
 						'type': 'toolbox',
 						'children': [
 							{
@@ -1870,130 +1875,86 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				'vertical': 'true'
 			},
 			{
-				'type': 'bigtoolitem',
-				'text': _UNO('.uno:TextWrap'),
-				'command': '.uno:TextWrap'
-			},
-			{
-				'id': 'Draw-Section-ObjectAlign',
 				'type': 'container',
 				'children': [
 					{
-						'id': 'AlignGroup5',
-						'type': 'container',
+						'type': 'toolbox',
 						'children': [
 							{
-								'id': 'Align7',
-								'type': 'toolbox',
-								'children': [
-									{
-										'type': 'toolitem',
-										'text': _UNO('.uno:ObjectAlignLeft'),
-										'command': '.uno:ObjectAlignLeft'
-									},
-									{
-										'type': 'toolitem',
-										'text': _UNO('.uno:AlignCenter'),
-										'command': '.uno:AlignCenter'
-									},
-									{
-										'type': 'toolitem',
-										'text': _UNO('.uno:ObjectAlignRight'),
-										'command': '.uno:ObjectAlignRight'
-									}
-								]
+								'type': 'toolitem',
+								'text': _UNO('.uno:ObjectAlignLeft'),
+								'command': '.uno:ObjectAlignLeft'
 							},
 							{
-								'id': 'Align8',
-								'type': 'toolbox',
-								'children': [
-									{
-										'type': 'toolitem',
-										'text': _UNO('.uno:AlignUp'),
-										'command': '.uno:AlignUp'
-									},
-									{
-										'type': 'toolitem',
-										'text': _UNO('.uno:AlignMiddle'),
-										'command': '.uno:AlignMiddle'
-									},
-									{
-										'type': 'toolitem',
-										'text': _UNO('.uno:AlignDown'),
-										'command': '.uno:AlignDown'
-									}
-								]
+								'type': 'toolitem',
+								'text': _UNO('.uno:AlignCenter'),
+								'command': '.uno:AlignCenter'
+							},
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:ObjectAlignRight'),
+								'command': '.uno:ObjectAlignRight'
 							}
-						],
-						'vertical': 'true'
-					}
-				],
-				'vertical': 'false'
-			},
-			{
-				'id': 'Draw-Section-Arrange',
-				'type': 'container',
-				'children': [
+						]
+					},
 					{
-						'id': 'grid2',
-						'type': 'grid',
+						'type': 'toolbox',
 						'children': [
 							{
-								'id': 'first8',
-								'type': 'toolbox',
-								'children': [
-									{
-										'type': 'toolitem',
-										'text': _UNO('.uno:BringToFront'),
-										'command': '.uno:BringToFront'
-									}
-								],
-								'left': '0',
-								'top': '0'
+								'type': 'toolitem',
+								'text': _UNO('.uno:AlignUp'),
+								'command': '.uno:AlignUp'
 							},
 							{
-								'id': 'first9',
-								'type': 'toolbox',
-								'children': [
-									{
-										'type': 'toolitem',
-										'text': _UNO('.uno:ObjectForwardOne'),
-										'command': '.uno:ObjectForwardOne'
-									}
-								],
-								'left': '1',
-								'top': '0'
+								'type': 'toolitem',
+								'text': _UNO('.uno:AlignMiddle'),
+								'command': '.uno:AlignMiddle'
 							},
 							{
-								'id': 'second1',
-								'type': 'toolbox',
-								'children': [
-									{
-										'type': 'toolitem',
-										'text': _UNO('.uno:SendToBack'),
-										'command': '.uno:SendToBack'
-									}
-								],
-								'left': '0',
-								'top': '1'
-							},
-							{
-								'id': 'Second1',
-								'type': 'toolbox',
-								'children': [
-									{
-										'type': 'toolitem',
-										'text': _UNO('.uno:ObjectBackOne'),
-										'command': '.uno:ObjectBackOne'
-									}
-								],
-								'left': '1',
-								'top': '1'
+								'type': 'toolitem',
+								'text': _UNO('.uno:AlignDown'),
+								'command': '.uno:AlignDown'
 							}
 						]
 					}
 				],
-				'vertical': 'false'
+				'vertical': 'true'
+			},
+			{
+				'type': 'container',
+				'children': [
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:BringToFront'),
+								'command': '.uno:BringToFront'
+							},
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:SendToBack'),
+								'command': '.uno:SendToBack'
+							}
+						]
+					},
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:ObjectForwardOne'),
+								'command': '.uno:ObjectForwardOne'
+							},
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:ObjectBackOne'),
+								'command': '.uno:ObjectBackOne'
+							}
+						]
+					}
+				],
+				'vertical': 'true'
 			},
 			{
 				'type': 'bigtoolitem',
@@ -2001,11 +1962,9 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				'command': '.uno:FormatGroup'
 			},
 			{
-				'id': 'Draw-Section-Group1',
 				'type': 'container',
 				'children': [
 					{
-						'id': 'SectionBottom53',
 						'type': 'toolbox',
 						'children': [
 							{
@@ -2016,7 +1975,6 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 						]
 					},
 					{
-						'id': 'SectionBottom64',
 						'type': 'toolbox',
 						'children': [
 							{
@@ -2031,9 +1989,66 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 			},
 			{
 				'type': 'bigtoolitem',
-				'text': _UNO('.uno:FontworkGalleryFloater'),
-				'command': '.uno:FontworkGalleryFloater'
-			}
+				'text': _UNO('.uno:Text'),
+				'command': '.uno:Text'
+			},
+			{
+				'type': 'container',
+				'children': [
+					{
+						'id': 'LineA6',
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:BasicShapes'),
+								'command': '.uno:BasicShapes'
+							}
+						]
+					},
+					{
+						'id': 'LineB7',
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:Line', 'text'),
+								'command': '.uno:Line'
+							}
+						]
+					}
+				],
+				'vertical': 'true'
+			},
+			{
+				'id': 'Insert-Text-Fontwork',
+				'type': 'container',
+				'children': [
+					{
+						'id': 'LineA153',
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:FontworkGalleryFloater'),
+								'command': '.uno:FontworkGalleryFloater'
+							}
+						]
+					},
+					{
+						'id': 'LineB163',
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:VerticalText', 'text'),
+								'command': '.uno:VerticalText'
+							}
+						]
+					}
+				],
+				'vertical': 'true'
+			},
 		];
 
 		return this.getTabPage('Draw', content);


### PR DESCRIPTION
Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I5018bfcf5925ce5026a3d4069cb4bb096921742c

Update the structure of the Draw Notebookbar Tabs for Writer, Calc, Impress and Draw.

### Writer Draw Tab
- Position and Size is the first item
- Flip Horizontal/Vertical as Subsection
- (Line and) Area property dialog isn't available, but should be than there
- Line and Area Color Control
- Wrap
- Align
- Arrange
- Group
- Textbox, Shapes, ... as known from Insert (for faster drawing only, no switch between Insert and Draw tab)

**Before**
![Writer-Draw-Before](https://user-images.githubusercontent.com/8517736/116157232-e89c9280-a6ec-11eb-90bd-7b82f0b9e35f.png)

**After**
![Writer-Draw-After](https://user-images.githubusercontent.com/8517736/116157239-ec301980-a6ec-11eb-866c-f8b52fb46384.png)

### Calc Draw Tab
- See writer Draw Tab (could be synched between writer and calc
- Before there was no Draw Tab, now it's available

**After**
![Calc-Draw-After](https://user-images.githubusercontent.com/8517736/116157611-8e500180-a6ed-11eb-8227-7b9bf2f59c6f.png)


### Impress / Draw, Draw Tab
- Layout like in writer and calc
- Line was replaced with Connectors

**Before**
![Impress-Draw-Before](https://user-images.githubusercontent.com/8517736/116157671-ae7fc080-a6ed-11eb-9ebf-e40baf82976d.png)

**After**
![Impress-Draw-After](https://user-images.githubusercontent.com/8517736/116157689-b50e3800-a6ed-11eb-8c3b-4833cb9794ac.png)
