### PR TITLE
Notebookbar: closebutton: Fix size

### DIFF
--- a/loleaflet/css/toolbar.css
+++ b/loleaflet/css/toolbar.css
@@ -285,10 +285,9 @@ td[id^='tb_editbar_item_sidebar']{
 }
 
 #closebutton {
-	width: 24px;
-	height: 24px;
-	padding: 4px 6px;
-	background: url('images/closedoc.svg') no-repeat center !important;
+	width: 100%;
+	height: 100%;
+	background: url('images/closedoc.svg') no-repeat 6px 4px/24px !important;
 }
 
 #closebutton:hover {


### PR DESCRIPTION
it seems close button is bigger than it's parent
- Avoid that
- Remove paddings
- Use background position instead

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I9ff86be375be78fc27dddaf5a8d38d4c41590be9
