### PR TITLE
StringVector: add a way to get a number out of this without copying the token

### DIFF
--- a/common/Protocol.hpp
+++ b/common/Protocol.hpp
@@ -74,13 +74,6 @@ namespace LOOLProtocol
         return false;
     }
 
-    inline
-    bool parseNameIntegerPair(const std::string& token, std::string& name, int& value)
-    {
-        std::string strValue;
-        return parseNameValuePair(token, name, strValue, '=') && stringToInteger(strValue, value);
-    }
-
     bool getTokenInteger(const std::string& token, const std::string& name, int& value);
     bool getTokenUInt32(const std::string& token, const std::string& name, uint32_t& value);
     bool getTokenUInt64(const std::string& token, const std::string& name, uint64_t& value);

--- a/common/StringVector.cpp
+++ b/common/StringVector.cpp
@@ -49,4 +49,34 @@ bool StringVector::getUInt32(std::size_t index, const std::string& key, uint32_t
     return false;
 }
 
+bool StringVector::getNameIntegerPair(std::size_t index, std::string& name, int& value) const
+{
+    if (index >= _tokens.size())
+    {
+        return false;
+    }
+
+    const StringToken& token = _tokens[index];
+    size_t mid = std::string::npos;
+    for (size_t i = token._index; i < token._index + token._length; ++i)
+    {
+        if (_string[i] != '=')
+        {
+            continue;
+        }
+
+        mid = i;
+        break;
+    }
+    if (mid == std::string::npos)
+    {
+        return false;
+    }
+
+    name = _string.substr(token._index, mid - token._index);
+    size_t offset = mid + 1;
+    value = Util::safe_atoi(&_string[offset], token._index + token._length - offset);
+    return value > std::numeric_limits<int>::min() && value < std::numeric_limits<int>::max();
+}
+
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/common/StringVector.cpp
+++ b/common/StringVector.cpp
@@ -7,6 +7,8 @@
 
 #include "StringVector.hpp"
 
+#include "Util.hpp"
+
 bool StringVector::equals(std::size_t index, const StringVector& other, std::size_t otherIndex)
 {
     if (index >= _tokens.size())
@@ -24,6 +26,27 @@ bool StringVector::equals(std::size_t index, const StringVector& other, std::siz
     int ret = _string.compare(token._index, token._length, other._string, otherToken._index,
                               otherToken._length);
     return ret == 0;
+}
+
+bool StringVector::getUInt32(std::size_t index, const std::string& key, uint32_t& value) const
+{
+    if (index >= _tokens.size())
+    {
+        return false;
+    }
+
+    const StringToken& token = _tokens[index];
+
+    size_t offset = key.size() + 1;
+    if (token._length > offset &&
+            _string.compare(token._index, key.size(), key, 0, key.size()) == 0 &&
+            _string[token._index + key.size()] == '=')
+    {
+        value = Util::safe_atoi(&_string[token._index + offset], token._length - offset);
+        return value < std::numeric_limits<int>::max();
+    }
+
+    return false;
 }
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/common/StringVector.hpp
+++ b/common/StringVector.hpp
@@ -138,6 +138,8 @@ public:
 
     /// Compares the nth token with the mth token from another StringVector.
     bool equals(std::size_t index, const StringVector& other, std::size_t otherIndex);
+
+    bool getUInt32(std::size_t index, const std::string& key, uint32_t& value) const;
 };
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/common/StringVector.hpp
+++ b/common/StringVector.hpp
@@ -140,6 +140,7 @@ public:
     bool equals(std::size_t index, const StringVector& other, std::size_t otherIndex);
 
     bool getUInt32(std::size_t index, const std::string& key, uint32_t& value) const;
+    bool getNameIntegerPair(std::size_t index, std::string& name, int& value) const;
 };
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/test/WhiteBoxTests.cpp
+++ b/test/WhiteBoxTests.cpp
@@ -1135,6 +1135,28 @@ void WhiteBoxTests::testStringVector()
 
     CPPUNIT_ASSERT(vector.equals(0, vector2, 0));
     CPPUNIT_ASSERT(!vector.equals(0, vector2, 1));
+
+    {
+        StringVector tokens;
+        tokens.push_back("a=1");
+        uint32_t value{};
+        CPPUNIT_ASSERT(tokens.getUInt32(0, "a", value));
+        CPPUNIT_ASSERT_EQUAL(static_cast<uint32_t>(1), value);
+
+        // Prefix does not match.
+        CPPUNIT_ASSERT(!tokens.getUInt32(0, "b", value));
+
+        // Index is out of bounds.
+        CPPUNIT_ASSERT(!tokens.getUInt32(1, "a", value));
+
+        // Expected key is prefix of actual key.
+        tokens.push_back("bb=1");
+        CPPUNIT_ASSERT(!tokens.getUInt32(1, "b", value));
+
+        // Actual key is prefix of expected key.
+        tokens.push_back("c=1");
+        CPPUNIT_ASSERT(!tokens.getUInt32(1, "cc", value));
+    }
 }
 
 void WhiteBoxTests::testRequestDetails_DownloadURI()

--- a/test/WhiteBoxTests.cpp
+++ b/test/WhiteBoxTests.cpp
@@ -1157,6 +1157,26 @@ void WhiteBoxTests::testStringVector()
         tokens.push_back("c=1");
         CPPUNIT_ASSERT(!tokens.getUInt32(1, "cc", value));
     }
+
+    {
+        StringVector tokens;
+        tokens.push_back("a=1");
+        std::string name;
+        int value{};
+        CPPUNIT_ASSERT(tokens.getNameIntegerPair(0, name, value));
+        CPPUNIT_ASSERT_EQUAL(std::string("a"), name);
+        CPPUNIT_ASSERT_EQUAL(1, value);
+
+        tokens.push_back("aa=1");
+        CPPUNIT_ASSERT(tokens.getNameIntegerPair(1, name, value));
+        CPPUNIT_ASSERT_EQUAL(std::string("aa"), name);
+        CPPUNIT_ASSERT_EQUAL(1, value);
+
+        tokens.push_back("a=11");
+        CPPUNIT_ASSERT(tokens.getNameIntegerPair(2, name, value));
+        CPPUNIT_ASSERT_EQUAL(std::string("a"), name);
+        CPPUNIT_ASSERT_EQUAL(11, value);
+    }
 }
 
 void WhiteBoxTests::testRequestDetails_DownloadURI()

--- a/wsd/TileDesc.hpp
+++ b/wsd/TileDesc.hpp
@@ -215,9 +215,9 @@ public:
         TileWireId wireId = 0;
         for (std::size_t i = 0; i < tokens.size(); ++i)
         {
-            if (LOOLProtocol::getTokenUInt32(tokens[i], "oldwid", oldWireId))
+            if (tokens.getUInt32(i, "oldwid", oldWireId))
                 ;
-            else if (LOOLProtocol::getTokenUInt32(tokens[i], "wid", wireId))
+            else if (tokens.getUInt32(i, "wid", wireId))
                 ;
             else
             {

--- a/wsd/TileDesc.hpp
+++ b/wsd/TileDesc.hpp
@@ -223,7 +223,7 @@ public:
             {
                 std::string name;
                 int value = -1;
-                if (LOOLProtocol::parseNameIntegerPair(tokens[i], name, value))
+                if (tokens.getNameIntegerPair(i, name, value))
                 {
                     pairs[name] = value;
                 }


### PR DESCRIPTION
And use it in TileDesc::parse(), which is known to be a hot path.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I20375d7a1c31f61662446979e4d6799fd45b49d3
