### PR TITLE
Restore missing rule to populate DIST_FOLDER with js.

### DIFF
--- a/loleaflet/Makefile.am
+++ b/loleaflet/Makefile.am
@@ -575,6 +575,15 @@ tscompile.done: $(LOLEAFLET_JS_SRC) $(LOLEAFLET_TS_SRC)
 $(LOLEAFLET_TS_JS_DST): tscompile.done
 	@echo -n ""
 
+$(DIST_FOLDER)/src/%.js: $(srcdir)/src/%.js
+	@mkdir -p $(dir $@)
+	@if test -z '$(ENABLE_BROWSERSYNC)'; then \
+		`cp $< $@`; \
+	else \
+		`echo $< $@`; \
+		`ln -sf $(abs_srcdir)/$< $@`; \
+	fi
+
 $(DIST_FOLDER)/%.js: $(srcdir)/js/%.js
 	@mkdir -p $(dir $@)
 	@if test -z '$(ENABLE_BROWSERSYNC)'; then \


### PR DESCRIPTION
Used by android to build the JS it desires. We lost that in c6f2e2211d

Change-Id: I4b790a300aee66628baa2e5a2997685c42f709fa


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

