### PR TITLE
android: Fix intent.GetType() is null for the opened doc

### DIFF
--- a/android/lib/src/main/java/org/libreoffice/androidlib/LOActivity.java
+++ b/android/lib/src/main/java/org/libreoffice/androidlib/LOActivity.java
@@ -471,6 +471,9 @@ public class LOActivity extends AppCompatActivity {
                 // CSV files need a .csv suffix to be opened in Calc.
                 String suffix = null;
                 String intentType = mActivity.getIntent().getType();
+                if (mActivity.getIntent().getType() == null) {
+                    intentType = getMimeType();
+                }
                 // K-9 mail uses the first, GMail uses the second variant.
                 if ("text/comma-separated-values".equals(intentType) || "text/csv".equals(intentType))
                     suffix = ".csv";


### PR DESCRIPTION
When a document is opened inside the app's document list
intent.getType becomes null. In this case we can retrive the
correct mimeType from contentResolver. This is needed especially
for csv files, because ".csv" is needed to be added to the temp file name
for lok to recognize it correctly. Otherwise it will be treated as
text file.

Signed-off-by: merttumer <mert.tumer@collabora.com>
Change-Id: I61b853cf7ba9b648bf4ae8c54fd8b10d5754cf4c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

