### PR TITLE
android: Hide progress dialog on initial mobilewizard pop up

### DIFF
--- a/android/lib/src/main/java/org/libreoffice/androidlib/LOActivity.java
+++ b/android/lib/src/main/java/org/libreoffice/androidlib/LOActivity.java
@@ -1048,6 +1048,11 @@ public class LOActivity extends AppCompatActivity {
                 }
                 return false;
             }
+            case "hideProgressbar": {
+                if (mProgressDialog != null)
+                    mProgressDialog.dismiss();
+                return false;
+            }
             case "loadwithpassword": {
                 mProgressDialog.determinate(R.string.loading);
                 return true;

--- a/loleaflet/src/control/Control.MobileWizard.js
+++ b/loleaflet/src/control/Control.MobileWizard.js
@@ -442,6 +442,8 @@ L.Control.MobileWizard = L.Control.extend({
 
 			this._builder = L.control.mobileWizardBuilder({windowId: data.id, mobileWizard: this, map: this.map, cssClass: 'mobile-wizard'});
 			this._builder.build(this.content.get(0), [data]);
+			if (window.ThisIsTheAndroidApp)
+				window.postMobileMessage('hideProgressbar');
 
 			this._mainTitle = data.text ? data.text : '';
 			this._customTitle = data.customTitle;


### PR DESCRIPTION
Text import dialog is displayed on initial document load
so we need to hide progressbar after that in order to
interact with the ui

Signed-off-by: merttumer <mert.tumer@collabora.com>
Change-Id: I840bfea9d078260751622cbb09d256153821ff0e


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

