### PR TITLE
fix: Other user's caret is shown when adding new sheet

### DIFF
--- a/loleaflet/src/layer/tile/TileLayer.js
+++ b/loleaflet/src/layer/tile/TileLayer.js
@@ -2774,7 +2774,7 @@ L.TileLayer = L.GridLayer.extend({
 			if (!viewCursorMarker.isDomAttached())
 				viewCursorMarker.add();
 		}
-		else if (viewCursorMarker.isDomAttached()) {
+		else if (viewCursorMarker && viewCursorMarker.isDomAttached()) {
 			viewCursorMarker.remove();
 		}
 


### PR DESCRIPTION
Don't crash if marker object is not defined for a view.

Signed-off-by: Dennis Francis <dennis.francis@collabora.com>
Change-Id: If8f13da684ebf4028bff888c9edf4bac3ab359bf


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

Problem summary:
Open eg. the sample hello world ODS in two views,
With view A, create and switch to a new sheet, and start editing a cell (don't finish it),
With view B, switch to the other sheet, and then add a new sheet.
-> View A's caret can be seen on the new sheet.

Fix: Add check for existence of marker for a view before accessing its methods.

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

