### PR TITLE
Notebookbar center align all tabs with display: flex #2121 and #2007

### DIFF
--- a/loleaflet/css/notebookbar.css
+++ b/loleaflet/css/notebookbar.css
@@ -205,8 +205,9 @@
 	overflow-y: hidden;
 	scrollbar-width: none; /* Firefox */
 	-ms-overflow-style: none;  /* Internet Explorer 10+ */
-	display: block;
+	display: flex;
 	height: 84px;
+	align-items: center;
 }
 
 .root-container.notebookbar {
@@ -253,11 +254,6 @@
 	background-color: var(--gray-light-bg-color);
 	outline: 2px solid var(--gray-light-bg-color);
 	color: var(--gray-light-txt--color);
-}
-
-div[id*='Row'].notebookbar, div[id*='Column'].notebookbar, #SendToBack.notebookbar, #ObjectBackOne.notebookbar, #ObjectForwardOne.notebookbar, #BringToFront.notebookbar, #SetObjectToBackground.notebookbar, #SetObjectToForeground.notebookbar, #FlipVertical.notebookbar, #FlipHorizontal.notebookbar, #Bold.notebookbar, #Italic.notebookbar, #Underline.notebookbar, #Strikeout.notebookbar, #StyleApply.notebookbar, #StyleUpdateByExample.notebookbar, #StyleNewByExample.notebookbar, #Shadowed.notebookbar, #Grow.notebookbar, #Shrink.notebookbar, #Spacing.notebookbar, #SuperScript.notebookbar, #SubScript.notebookbar,#AlignLeft.notebookbar, #AlignRight.notebookbar, #AlignHorizontalCenter.notebookbar, #AlignBlock.notebookbar, #ParaRightToLeft.notebookbar, #ParaLeftToRight.notebookbar, #AlignTop.notebookbar, #AlignVCenter.notebookbar, #AlignBottom.notebookbar, #IncrementIndent.notebookbar, #DecrementIndent.notebookbar, #LeftPara.notebookbar, #RightPara.notebookbar, #CenterPara.notebookbar, #JustifyPara.notebookbar, #DefaultBullet.notebookbar, #DefaultNumbering.notebookbar, #ParaspaceIncrease.notebookbar, #ParaspaceDecrease.notebookbar, #LineSpacing.notebookbar, #HangingIndent.notebookbar, #CellVertTop.notebookbar, #CellVertCenter.notebookbar, #CellVertBottom.notebookbar, #DeleteTable.notebookbar, #MergeCells.notebookbar{
-	padding: 2px !important;
-	margin: 0px 1px 0px 0px !important;
 }
 
 /* avoid bug with arrow in new line when window is small */
@@ -398,11 +394,6 @@ div[id*='Row'].notebookbar, div[id*='Column'].notebookbar, #SendToBack.notebookb
 
 /* File Tab */
 
-#table-File.notebookbar
-{
-	margin-top: 10px;
-}
-
 /* Home tab */
 #table-HomeTab {
 	margin-left: -16px;/*force alignment: clipboard elements*/
@@ -420,11 +411,6 @@ div[id*='Row'].notebookbar, div[id*='Column'].notebookbar, #SendToBack.notebookb
 
 #fontsize.notebookbar .select2.select2-container {
 	width: 60px !important;
-}
-
-#Paste.notebookbar img, #SearchDialog.notebookbar img {
-	height: 32px !important;
-	width: 32px !important;
 }
 
 #fontnamecombobox.notebookbar .select2 {
@@ -534,233 +520,41 @@ div[id*='Row'].notebookbar, div[id*='Column'].notebookbar, #SendToBack.notebookb
 
 /* Insert Tab */
 
-#table-Insert.notebookbar
-{
-	margin-top: 10px;
-}
-
-#table-Insert-Section-Pagebreak #InsertPagebreak.notebookbar img,
-#table-Insert-Section-Image #InsertGraphic.notebookbar img,
-#HyperlinkDialog.notebookbar img,
-#InsertFieldCtrl.notebookbar img,
-#DrawText.notebookbar img,
-#table-Insert-Section-Symbol #CharmapControl.notebookbar img
-{
-	height: 32px !important;
-	width: 32px !important;
-}
-
-#table-InsertTab.notebookbar #table-GroupB18 #table-SectionBottom32
-{
-	display: none;
-}
-
 /* Layout Tab */
-
-#table-Layout.notebookbar
-{
-	margin-top: 10px;
-}
-
-#FormatGroup.notebookbar img,
-#PageDialog.notebookbar img
-{
-	height: 32px !important;
-	width: 32px !important;
-}
-
-#table-Layout-Section-ParaMargin {
-	display: none;
-}
 
 /* References Tab */
 
-#table-References.notebookbar
-{
-	margin-top: 10px;
-}
-
-#InsertMultiIndex.notebookbar img,
-#table-Reference-Section-Reference #InsertFootnote.notebookbar img,
-#table-Reference-Section-Reference #InsertReferenceField.notebookbar img,
-#InsertAuthoritiesEntry.notebookbar img,
-#UpdateAll.notebookbar img,
-{
-	height: 32px !important;
-	width: 32px !important;
-}
-
-#InsertMultiIndex .unolabel {
-	max-width: 190px;
-	table-layout: fixed;
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
-}
-
-#table-Reference-Section-Field.notebookbar
-{
-	display: none;
-}
-
 /* Format Tab */
-
-#table-Format {
-	margin-top: 10px;
-}
-
-.presentation-color-indicator + table #table-Format,
-.drawing-color-indicator + table #table-Format {
-	margin-top: 15px;
-}
 
 /* Table Tab */
 
-#table-Table {
-	margin-top: 10px;
-}
-
-#table-Table-Section-Layout #InsertCaptionDialog.notebookbar img,
-#BorderDialog.notebookbar img,
-#MergeCells.notebookbar img,
-#EntireCell.notebookbar img,
-#OptimizeTable.notebookbar img,
-#AutoFormat.notebookbar img,
-#TableSort.notebookbar img,
-#TableNumberFormatDialog.notebookbar img,
-#TableDialog.notebookbar img
-{
-	height: 32px !important;
-	width: 32px !important;
-}
-
-#table-Table-Section-Merge #table-GroupB61 #SplitCell.notebookbar img,
-#table-Table-Section-Select #table-GroupB65 #SelectTable.notebookbar img
-{
-	height: 24px !important;
-	width: 24px !important;
-}
-
-#NumberFormatPercent.notebookbar {
-	margin-right: 10px;
-}
-
-#table-box17.notebookbar #BackgroundColor {
-	padding-left: 15px;
-}
-
 /* Review Tab */
-
-#table-Review {
-	margin-top: 15px;
-}
-
-.spreadsheet-color-indicator + table #table-Review {
-	margin-top: 10px;
-}
-
-#SpellingAndGrammarDialog.notebookbar img,
-#ThesaurusDialog.notebookbar img,
-#TrackChanges.notebookbar img,
-#ShowTrackedChanges.notebookbar img,
-#ProtectTraceChangeMode.notebookbar img,
-#EditDoc.notebookbar img,
-#AcceptTrackedChanges.notebookbar img
-{
-	height: 32px !important;
-	width: 32px !important;
-}
 
 /* Help tab */
 
-#table-Help-Section.notebookbar {
-	margin-top: 30px;
-}
-
 /* File tab */
 
-#table-File-Section.notebookbar {
-	margin-top: 10px;
-}
-
 /* Draw tab */
-#table-Draw #table-box16 #table-first16.notebookbar,
-#table-DrawTab #table-GroupB74 #table-SectionBottom48.notebookbar {
-	display: none;
-}
 
-#table-Draw
-{
-	margin-top: 5px;
-}
 
 /* Calc */
 
 /* Home tab */
 
-#table-HomeTab #table-PasteBox1 #table-SectionBottom10 #SortAscending.notebookbar,
-#table-HomeTab #table-PasteBox1 #table-SectionBottom10 #DataFilterAutoFilter.notebookbar,
-#table-InsertTab #table-GroupB26 #table-SectionBottom32.notebookbar,
-#table-Home-Section-Find #SearchDialog.notebookbar #numbertype
-{
-	display: none;
-}
-
 #numbertype .select2.select2-container {
 	width: 170px !important;
 }
 
-#Shrinkimg {
-	padding-left: 5px;
-}
-
 /* Review Tab */
-
-#SpellDialog.notebookbar img,
-#TraceChangeMode.notebookbar img,
-#AcceptChanges.notebookbar img,
-#Protect.notebookbar img,
-#ToolProtectionDocument.notebookbar img
-{
-	height: 32px !important;
-	width: 32px !important;
-}
-
-#table-ReviewTab #table-Review #AcceptChanges.notebookbar {
-	display: none;
-}
 
 /* Sheet Tab */
 
-#table-Sheet-Section.notebookbar {
-	margin-top: 5px;
-}
-
 /* Data Tab */
 
-#table-Data {
-	margin-top: 10px;
-}
-
-#table-DataTab #table-ViewMenu3.notebookbar {
-	display: none;
-}
 
 /* Impress */
 
 /* Home Tab */
-
-#table-shapes15 #BasicShapes.notebookbar,
-#table-HomeTab #table-SectionBottom10.notebookbar #Presentation
-{
-	display: none;
-}
-
-#table-SectionBottom5 #Text.notebookbar img
-{
-	height: 32px !important;
-	width: 32px !important;
-}
 
 /* Insert Tab */
 
@@ -768,45 +562,12 @@ div[id*='Row'].notebookbar, div[id*='Column'].notebookbar, #SendToBack.notebookb
 	min-width: 160px;
 }
 
-#table-Insert-Section-DrawText #Text.notebookbar img,
-#table-Insert-Section-Slide #InsertPage.notebookbar img
-{
-	height: 32px !important;
-	width: 32px !important;
-}
-
 /* Review Tab */
 
-#table-GroupB42 #DeleteAllAnnotation.notebookbar img
-{
-	height: 32px !important;
-	width: 32px !important;
-}
-
-#table-GroupB37 #InsertAnnotation.notebookbar
-{
-	display: none;
-}
 
 /* Table Tab */
 
-#table-box11 #FrameLineColor.notebookbar img,
-#table-Table-Section-Merge #SplitCell.notebookbar img,
-#table-Table-Section-Select #SelectTable.notebookbar img
-{
-	height: 32px !important;
-	width: 32px !important;
-}
-
 /* Draw Tab */
-
-#table-DrawTab #table-box6 #XLineColor.notebookbar {
-	margin-left: -10px;
-}
-
-#table-DrawTab #table-Draw #table-GroupB102.notebookbar {
-	margin-left: -70px;
-}
 
 /* other */
 


### PR DESCRIPTION
* Resolves: #2121 and #2007

### Summary
Instead of fixed margin-top values for each single notebookbar tab, I switched to `display: flex;` and `align-item: center;`

```
.notebookbar-scroll-wrapper {
	overflow-x: scroll;
	overflow-y: hidden;
	scrollbar-width: none; /* Firefox */
	-ms-overflow-style: none;  /* Internet Explorer 10+ */
	display: flex;
	height: 84px;
	align-items: center;
```

As all tabs use similar json structure see #2007, all tab content is now center align. Only open work is the home tab, cause the height of the home tab, is heigher than for the other tabs. However the content is center align.

Most of the writer, calc, impress and draw specific settings were removed, cause for example the icon height is defined more global so they don't have to be defined within every bigtoolitem. 
- div[id*='Row'].notebookbar, div[id*='Column'].notebookbar, ... was removed cause didn't need any more
- #table-*.notebookbar margin-top was removed cause of `align-item: center`
- All the height: 32px ... icon size was removed cause it was already defined
- table-DrawTab #table-box6 #XLineColor.notebookbar wasn't needed

## Updated notebookbar tabs

### Writer File Tab
![01_File_new](https://user-images.githubusercontent.com/8517736/116483363-3c42e380-a887-11eb-8265-22a60e291526.png)

### Writer Home Tab
![02_Home_new](https://user-images.githubusercontent.com/8517736/116483393-4bc22c80-a887-11eb-9d97-70dcc4778fe6.png)

### Writer Insert Tab
![03_Insert_new](https://user-images.githubusercontent.com/8517736/116483408-5250a400-a887-11eb-97ed-4acdc389bcfb.png)

### Writer Layout Tab
![04_Lyout_new](https://user-images.githubusercontent.com/8517736/116483423-5a104880-a887-11eb-8279-c8ac9f2991a9.png)

## Writer References Tab
![05_References_new](https://user-images.githubusercontent.com/8517736/116483443-62688380-a887-11eb-91f7-cb6f64ea8153.png)

### Writer Review Tab
![06_Review_new](https://user-images.githubusercontent.com/8517736/116483465-6ac0be80-a887-11eb-83ef-7b57b6ca42e5.png)

### Writer Format Tab
![07_Format_new](https://user-images.githubusercontent.com/8517736/116483478-714f3600-a887-11eb-8796-a11415037808.png)

### Writer Table Tab
![08_Table_new](https://user-images.githubusercontent.com/8517736/116483490-790eda80-a887-11eb-86b3-9053264dafda.png)

### Draw Tab
![09_Draw_new](https://user-images.githubusercontent.com/8517736/116483505-81671580-a887-11eb-8dba-cb661ae94dae.png)

**I added the past command, only to show that the position is in all tabs the same. It was only for the Alignment check**

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I32f8e2158f99b11082dd8d9e9755e8cf3e790716