### PR TITLE
Fix view jump on autoinput

### DIFF
--- a/loleaflet/src/layer/tile/TileLayer.js
+++ b/loleaflet/src/layer/tile/TileLayer.js
@@ -2669,6 +2669,7 @@ L.TileLayer = L.GridLayer.extend({
 	_onUpdateCursor: function (scroll, zoom, keepCaretPositionRelativeToScreen) {
 
 		if (!this._visibleCursor ||
+			this._isEmptyRectangle(this._visibleCursor) ||
 			this._referenceMarkerStart.isDragged ||
 			this._referenceMarkerEnd.isDragged ||
 			this._map.ignoreCursorUpdate()) {

--- a/loleaflet/src/layer/tile/TileLayer.js
+++ b/loleaflet/src/layer/tile/TileLayer.js
@@ -1515,6 +1515,8 @@ L.TileLayer = L.GridLayer.extend({
 		}
 
 		this._onUpdateCursor(updateCursor && (modifierViewId === this._viewId), undefined /* zoom */, !(this._viewId === modifierViewId));
+		// Only for reference equality comparison.
+		this._lastVisibleCursorRef = this._visibleCursor;
 	},
 
 	_updateEditor: function(textMsg) {
@@ -2682,6 +2684,9 @@ L.TileLayer = L.GridLayer.extend({
 		if (!zoom
 		&& scroll !== false
 		&& this._map._isCursorVisible
+		// Do not center view in Calc if no new cursor coordinates have arrived yet.
+		// ie, 'invalidatecursor' has not arrived after 'cursorvisible' yet.
+		&& (!this.isCalc() || this._lastVisibleCursorRef !== this._visibleCursor)
 		&& this._allowViewJump()) {
 
 			var paneRectsInLatLng = this.getPaneLatLngRectangles();


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
This fixes two different kinds of view jumps on autoinput/autocomplete.


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

