### PR TITLE
Fix Debian 8 / gcc-4.9 warnings

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -303,6 +303,7 @@ kit_headers = kit/ChildSession.hpp \
               kit/Watermark.hpp
 
 noinst_HEADERS = $(wsd_headers) $(shared_headers) $(kit_headers) \
+                 test/HttpTestServer.hpp \
                  test/WopiTestServer.hpp \
                  test/countloolkits.hpp \
                  test/lokassert.hpp \

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -160,7 +160,11 @@ namespace
     bool detectSlowStackingFileSystem(const std::string &directory)
     {
 #ifdef __linux__
-        struct statfs fs = {};
+#ifndef OVERLAYFS_SUPER_MAGIC
+// From linux/magic.h.
+#define OVERLAYFS_SUPER_MAGIC   0x794c7630
+#endif
+        struct statfs fs;
         if (::statfs(directory.c_str(), &fs) != 0)
         {
             LOG_SYS("statfs failed on '" << directory << "'");

--- a/net/HttpRequest.cpp
+++ b/net/HttpRequest.cpp
@@ -123,8 +123,8 @@ int64_t Header::parse(const char* p, int64_t len)
     }
 
     // Make sure we have the full header before parsing.
-    const int64_t end = findBlankLine(p, 0, len);
-    if (end == len)
+    const int64_t endPos = findBlankLine(p, 0, len);
+    if (endPos == len)
     {
         return 0; // Incomplete.
     }
@@ -161,7 +161,7 @@ int64_t Header::parse(const char* p, int64_t len)
                         << ", chunked: " << getChunkedTransferEncoding());
 
         // We consumed the full header, including the blank line.
-        return end + 1;
+        return endPos + 1;
     }
     catch (const Poco::Exception& exc)
     {

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -434,9 +434,9 @@ public:
 
     /// Create a Request given a @url, http @verb, @header, and http @version.
     /// All are optional, since they can be overwritten later.
-    explicit Request(std::string url = "/", std::string verb = VERB_GET, Header header = Header(),
+    explicit Request(std::string url = "/", std::string verb = VERB_GET, Header headerObj = Header(),
                      std::string version = VERS_1_1)
-        : _header(std::move(header))
+        : _header(std::move(headerObj))
         , _url(std::move(url))
         , _verb(std::move(verb))
         , _version(std::move(version))
@@ -596,12 +596,12 @@ public:
 
     /// Construct a StatusLine with a given code and
     /// the default protocol version.
-    StatusLine(unsigned statusCode)
+    StatusLine(unsigned statusCodeNumber)
         : _httpVersion(HTTP_1_1)
         , _versionMajor(1)
         , _versionMinor(1)
-        , _statusCode(statusCode)
-        , _reasonPhrase(getReasonPhraseForCode(statusCode))
+        , _statusCode(statusCodeNumber)
+        , _reasonPhrase(getReasonPhraseForCode(statusCodeNumber))
     {
     }
 
@@ -688,8 +688,8 @@ public:
 
     /// A response sent from a server.
     /// Used for generating an outgoing response.
-    Response(StatusLine statusLine)
-        : _statusLine(std::move(statusLine))
+    Response(StatusLine statusLineObj)
+        : _statusLine(std::move(statusLineObj))
     {
         _header.add("Date", Util::getHttpTimeNow());
         _header.add("Server", HTTP_SERVER_STRING);
@@ -862,10 +862,10 @@ private:
                && "Invalid hostname and portNumber for http::Sesssion");
 #ifdef ENABLE_DEBUG
         std::string scheme;
-        std::string host;
-        std::string port;
-        assert(net::parseUri(_host, scheme, host, port) && scheme.empty() && port.empty()
-               && host == _host && "http::Session expects a hostname and not a URI");
+        std::string hostString;
+        std::string portString;
+        assert(net::parseUri(_host, scheme, hostString, portString) && scheme.empty() && portString.empty()
+               && hostString == _host && "http::Session expects a hostname and not a URI");
 #endif
     }
 
@@ -1006,11 +1006,11 @@ public:
         const auto origTimeout = getTimeout();
         setTimeout(timeout);
 
-        auto response = syncRequest(req);
+        auto responsePtr = syncRequest(req);
 
         setTimeout(origTimeout);
 
-        return response;
+        return responsePtr;
     }
 
     bool asyncRequest(const Request& req, SocketPoll& poll)

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -941,21 +941,21 @@ public:
     }
 
     /// Send data to the socket peer.
-    void send(const char* data, const int len, const bool flush = true)
+    void send(const char* data, const int len, const bool doFlush = true)
     {
         assertCorrectThread();
         if (data != nullptr && len > 0)
         {
             _outBuffer.append(data, len);
-            if (flush)
+            if (doFlush)
                 writeOutgoingData();
         }
     }
 
     /// Send a string to the socket peer.
-    void send(const std::string& str, const bool flush = true)
+    void send(const std::string& str, const bool doFlush = true)
     {
-        send(str.data(), str.size(), flush);
+        send(str.data(), str.size(), doFlush);
     }
 
     /// Sends HTTP response.

--- a/net/WebSocketSession.hpp
+++ b/net/WebSocketSession.hpp
@@ -213,9 +213,9 @@ public:
             _outQueue.put(std::vector<char>(msg.data(), msg.data() + msg.size()));
         }
 
-        const auto poll = _socketPoll.lock();
-        if (poll)
-            poll->wakeup();
+        const auto pollPtr = _socketPoll.lock();
+        if (pollPtr)
+            pollPtr->wakeup();
     }
 
     /// Shutdown the WebSocket, either asynchronously or synchronously,
@@ -224,14 +224,14 @@ public:
     {
         if (!_disconnected)
         {
-            const auto poll = _socketPoll.lock();
-            if (poll && poll->isAlive())
+            const auto pollPtr = _socketPoll.lock();
+            if (pollPtr && pollPtr->isAlive())
             {
                 // Delegate, never call shutdown when our poller is active.
                 LOG_TRC("WebSocketSession: queueing shutdown");
                 std::weak_ptr<WebSocketSession> weakptr
                     = std::static_pointer_cast<WebSocketSession>(shared_from_this());
-                poll->addCallback([weakptr]() {
+                pollPtr->addCallback([weakptr]() {
                     auto ws = weakptr.lock();
                     if (ws)
                     {

--- a/test/UnitLoad.cpp
+++ b/test/UnitLoad.cpp
@@ -202,11 +202,11 @@ UnitBase::TestResult UnitLoad::testLoad()
     std::string documentPath, documentURL;
     helpers::getDocumentPathAndURL("hello.odt", documentPath, documentURL, testname);
 
-    std::shared_ptr<SocketPoll> socketPoll = std::make_shared<SocketPoll>("UnitLoadPoll");
-    socketPoll->startThread();
+    std::shared_ptr<SocketPoll> socketPollPtr = std::make_shared<SocketPoll>("UnitLoadPoll");
+    socketPollPtr->startThread();
 
     auto wsSession
-        = http::WebSocketSession::create(socketPoll, helpers::getTestServerURI(), documentURL);
+        = http::WebSocketSession::create(socketPollPtr, helpers::getTestServerURI(), documentURL);
 
     TST_LOG("Loading " << documentURL);
     wsSession->sendMessage("load url=" + documentURL);


### PR DESCRIPTION
net/HttpRequest.cpp:126:19: error: declaration of 'end' shadows a member of 'this' [-Werror=shadow]

kit/Kit.cpp:163:29: error: missing initializer for member 'statfs::f_bsize' [-Werror=missing-field-initializers]

kit/Kit.cpp:171:14: error: 'OVERLAYFS_SUPER_MAGIC' was not declared in this scope

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Ibbd35ab5af3adad403ed22a0aeb70917b9e21970
