### PR TITLE
fix: Other user's caret is shown when adding new sheet

### DIFF
--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -3526,7 +3526,7 @@ L.CanvasTileLayer = L.Layer.extend({
 			if (!viewCursorMarker.isDomAttached())
 				viewCursorMarker.add();
 		}
-		else if (viewCursorMarker.isDomAttached()) {
+		else if (viewCursorMarker && viewCursorMarker.isDomAttached()) {
 			viewCursorMarker.remove();
 		}
 


### PR DESCRIPTION
Don't crash if marker object is not defined for a view.

Conflicts:
	loleaflet/src/layer/tile/TileLayer.js

Signed-off-by: Dennis Francis <dennis.francis@collabora.com>
Change-Id: If8f13da684ebf4028bff888c9edf4bac3ab359bf
(cherry picked from commit 99985b91b2cb45a3d013be0a2d2d40f33829dca9)


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

