### PR TITLE
Fix view jump on autoinput (master)

### DIFF
--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -2389,6 +2389,8 @@ L.CanvasTileLayer = L.Layer.extend({
 
 		// If modifier view is different than the current view, then set last variable to "true". We'll keep the caret position at the same point relative to screen.
 		this._onUpdateCursor(updateCursor && (modifierViewId === this._viewId), undefined /* zoom */, !(this._viewId === modifierViewId));
+		// Only for reference equality comparison.
+		this._lastVisibleCursorRef = this._visibleCursor;
 	},
 
 	_updateEditor: function(textMsg) {
@@ -3411,6 +3413,9 @@ L.CanvasTileLayer = L.Layer.extend({
 		if (!zoom
 		&& scroll !== false
 		&& this._map._isCursorVisible
+		// Do not center view in Calc if no new cursor coordinates have arrived yet.
+		// ie, 'invalidatecursor' has not arrived after 'cursorvisible' yet.
+		&& (!this.isCalc() || this._lastVisibleCursorRef !== this._visibleCursor)
 		&& this._allowViewJump()) {
 
 			var paneRectsInLatLng = this.getPaneLatLngRectangles();

--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -3398,6 +3398,7 @@ L.CanvasTileLayer = L.Layer.extend({
 	_onUpdateCursor: function (scroll, zoom, keepCaretPositionRelativeToScreen) {
 
 		if (!this._visibleCursor ||
+			this._isEmptyRectangle(this._visibleCursor) ||
 			this._referenceMarkerStart.isDragged ||
 			this._referenceMarkerEnd.isDragged ||
 			this._map.ignoreCursorUpdate()) {


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
This fixes two different kinds of view jumps on autoinput/autocomplete.

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

