### PR TITLE
Similar improvements to the ProfileZone here as to that in core

### DIFF
--- a/common/ProfileZone.cpp
+++ b/common/ProfileZone.cpp
@@ -5,6 +5,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+// Turn this on to compile a test executable for just ProfileZone
+
+// #define TEST_PROFILEZONE_EXE
+
 #include <cassert>
 #include <mutex>
 
@@ -14,7 +18,7 @@
 
 std::atomic<bool> ProfileZone::s_bRecording(false);
 
-int ProfileZone::s_nNesting = 0; // level of overlapped zones
+thread_local int ProfileZone::s_nNesting = 0; // level of overlapped zones
 
 namespace
 {
@@ -79,7 +83,7 @@ std::vector<std::string> ProfileZone::getRecordingAndClear()
     return aRecording;
 }
 
-#if 0 // Test main() used during development of this
+#ifdef TEST_PROFILEZONE_EXE
 
 #include <iostream>
 #include <thread>
@@ -87,8 +91,6 @@ std::vector<std::string> ProfileZone::getRecordingAndClear()
 int main(int argc, char** argv)
 {
     ProfileZone::startRecording();
-
-    ProfileZone a("main");
 
     {
         ProfileZone b("first block");
@@ -150,6 +152,12 @@ int main(int argc, char** argv)
     for (auto e : v)
         std::cout << "  " << e << "\n";
     std::cout << "]\n";
+
+    // Intentional misuse: overlapping ProfileZones
+    auto p1 = new ProfileZone("p1");
+    auto p2 = new ProfileZone("p2");
+    delete p1;
+    delete p2;
 
     return 0;
 }


### PR DESCRIPTION
Perhaps we should use the exact same code in both core and online? But
that would be a bit tedious as core needs to be cross-platform (and
thus we use things like osl_getSystemTime and osl_getProcessInfo in
its version) while online is Linux-only.

Also imporve the test for it.

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: I0bc9dca71dc4489bd1671e0dae1e582990a8f8b4


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

