### PR TITLE
Update Help icons #2026

### DIFF
--- a/loleaflet/images/lc_helpindex.svg
+++ b/loleaflet/images/lc_helpindex.svg
@@ -1,1 +1,51 @@
-<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" fill="#0063b1" r="10"/><path d="m12 3a9 9 0 0 0 -9 9 9 9 0 0 0 9 9 9 9 0 0 0 9-9 9 9 0 0 0 -9-9z" fill="#83beec"/><path d="m12 4.9999998c-2.2100002 0-4.0000002 1.79-4.0000002 4h2c0-1.1.9000002-2 2.0000002-2s2 .9 2 2c0 .55-.219844 1.0501562-.589844 1.4101562l-1.240234 1.259766c-.72.73-1.169922 1.730078-1.169922 2.830078v.5h2c0-1.5.449922-2.100078 1.169922-2.830078l.90039-.919922c.57-.57.929688-1.3700002.929688-2.2500002 0-2.21-1.79-4-4-4zm-1 12.0000002v2h2v-2z" fill="#fafafa"/></svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg8"
+   sodipodi:docname="lc_helpindex.svg"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)">
+  <metadata
+     id="metadata14">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs12" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1379"
+     id="namedview10"
+     showgrid="false"
+     inkscape:zoom="19.666667"
+     inkscape:cx="4.2252033"
+     inkscape:cy="14.270685"
+     inkscape:window-x="0"
+     inkscape:window-y="34"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg8" />
+  <path
+     d="M 12 5 C 9.7899998 5 8 6.79 8 9 L 10 9 C 10 7.9 10.9 7 12 7 C 13.1 7 14 7.9 14 9 C 14 9.55 13.780156 10.050156 13.410156 10.410156 L 12.169922 11.669922 C 11.449922 12.399922 11 13.4 11 14.5 L 11 15 L 13 15 C 13 13.5 13.449922 12.899922 14.169922 12.169922 L 15.070312 11.25 C 15.640313 10.68 16 9.88 16 9 C 16 6.79 14.21 5 12 5 z M 11 17 L 11 19 L 13 19 L 13 17 L 11 17 z "
+     id="path6" />
+</svg>

--- a/loleaflet/images/lc_keyboard-shortcuts.svg
+++ b/loleaflet/images/lc_keyboard-shortcuts.svg
@@ -1,1 +1,21 @@
-<svg height="24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="m3 6c-.554 0-1 .446-1 1v9c0 .554.446 1 1 1h17c.554 0 1-.446 1-1v-9c0-.554-.446-1-1-1zm0 1h17v9h-17zm1 1v1h1v-1zm2 0v1h1v-1zm2 0v1h1v-1zm2 0v1h1v-1zm2 0v1h1v-1zm2 0v1h1v-1zm2 0v1h1v-1zm2 0v1h1v-1zm-14 2v1h1v-1zm2 0v1h1v-1zm2 0v1h1v-1zm2 0v1h1v-1zm2 0v1h1v-1zm2 0v1h1v-1zm2 0v1h1v-1zm2 0v1h1v-1zm-14 2v1h2v-1zm3 0v1h1v-1zm2 0v1h1v-1zm2 0v1h1v-1zm2 0v1h1v-1zm2 0v1h1v-1zm2 0v1h2v-1zm-13 2v1h2v-1zm3 0v1h9v-1zm10 0v1h2v-1z" fill="#3a3a38"/></svg>
+<?xml-stylesheet type="text/css" href="icons.css" ?>
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <g id="background"
+     class="icn icn--area-color"
+     fill="#fafafa"
+     stroke="#3a3a38" 
+	 stroke-linecap="round" 
+	 stroke-linejoin="round"
+     >
+      <path d="m 2.5,6.5 h 19 v 11 h -19 z" />
+  </g>
+  <g id="background"
+     class="icn icn--secondary-line-color"
+     fill="none"
+     stroke="#797774"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     >
+      <path d="M 5.5 8.5 L 5.5 9.5 L 6.5 9.5 L 6.5 8.5 L 5.5 8.5 z M 8.5 8.5 L 8.5 9.5 L 9.5 9.5 L 9.5 8.5 L 8.5 8.5 z M 11.5 8.5 L 11.5 9.5 L 12.5 9.5 L 12.5 8.5 L 11.5 8.5 z M 14.5 8.5 L 14.5 9.5 L 15.5 9.5 L 15.5 8.5 L 14.5 8.5 z M 17.5 8.5 L 17.5 9.5 L 18.5 9.5 L 18.5 8.5 L 17.5 8.5 z M 5.5 11.5 L 5.5 12.5 L 6.5 12.5 L 6.5 11.5 L 5.5 11.5 z M 8.5 11.5 L 8.5 12.5 L 9.5 12.5 L 9.5 11.5 L 8.5 11.5 z M 11.5 11.5 L 11.5 12.5 L 12.5 12.5 L 12.5 11.5 L 11.5 11.5 z M 14.5 11.5 L 14.5 12.5 L 15.5 12.5 L 15.5 11.5 L 14.5 11.5 z M 17.5 11.5 L 17.5 12.5 L 18.5 12.5 L 18.5 11.5 L 17.5 11.5 z M 7.5 14.5 L 7.5 15.5 L 16.5 15.5 L 16.5 14.5 L 7.5 14.5 z " />
+  </g>
+</svg>

--- a/loleaflet/images/lc_report-an-issue.svg
+++ b/loleaflet/images/lc_report-an-issue.svg
@@ -18,4 +18,26 @@
      >
       <path d="m 6.5,5.5 v 3 h 3 v -3 z m 6,0 h 5 z m 0,3 h 5 z m -6,3 h 11 z m 0,3 h 11 z m 0,3 h 11 z" />
   </g>
+  <g id="symbol-background"
+	 class="icn icn--background"
+     stroke="#fff" 
+     stroke-width="3px"
+	 stroke-linecap="round" 
+	 stroke-linejoin="round"
+      >
+      <path d="m 10.5,22.5 5,-2 -3,-3 z" />
+      <path d="m 15.5,20.5 5,-5 -3,-3 -5,5 z" />
+      <path d="m 22.5,13.5 -2,2 -3,-3 2,-2 z" />
+  </g>
+  <g id="symbol"
+	 class="icn icn--highlight-color"  
+     fill="#83beec" 
+     stroke="#1e8bcd" 
+	 stroke-linecap="round" 
+	 stroke-linejoin="round"
+      >
+      <path d="m 10.5,22.5 5,-2 -3,-3 z" />
+      <path d="m 15.5,20.5 5,-5 -3,-3 -5,5 z" />
+      <path d="m 22.5,13.5 -2,2 -3,-3 2,-2 z" />
+  </g>
 </svg>


### PR DESCRIPTION
* Resolves: #2026

lc_report_an_issue use the report icon with an edit symbol cause by click on it, user can edit cool
lc_keyboard-shortcuts icon get less keys so the icon isn't that busy and use the correct colors
lc_online_help the earch stuff was removed, sorry but cool is online so no need for an online symbol

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I6c9f57f316997da3298f8ac4748bfe980733ad54