### PR TITLE
Tile load slurping.

### DIFF
--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -278,7 +278,7 @@ L.Socket = L.Class.extend({
 		var that = this;
 		if (!this._slurpQueue || !this._slurpQueue.length) {
 			setTimeout(function() {
-				console.log2('Slurp events ' + that._slurpQueue.length);
+				// console.log2('Slurp events ' + that._slurpQueue.length);
 				for (var i = 0; i < that._slurpQueue.length; ++i) {
 					// it is - are you ?
 					that._onMessage(that._slurpQueue[i]);
@@ -287,8 +287,6 @@ L.Socket = L.Class.extend({
 			}, 1 /* ms */);
 			that._slurpQueue = [];
 		}
-		// I imagine e doesn't hang around at all nicely and this fails
-		// but lets see ...
 		that._slurpQueue.push(e);
 	},
 


### PR DESCRIPTION
The browsers - unfortunately appear to round-robin the asynchronous
unload of an individual tile - which causes a _tileReady callback
with updating the canvas.

This means that we re-render the canvas (at whatever speed) for each
tile we load - guarenteeing a nice animated effect of loading tiles
one by one, and refreshing the view: not so cool.

So - instead, as per WebSocket messages, slurp them - and then
refresh the view in one shot after 1ms; since it is fairly bogus
to convert a base64 encoded URL image to a real image asynchronously
anyway, this gives some nice results eg.

TileLayer.js:2464 Slurp tiles 34
TileLayer.js:2464 Slurp tiles 25
TileLayer.js:2464 Slurp tiles 53
TileLayer.js:2464 Slurp tiles 5
TileLayer.js:2464 Slurp tiles 3

It also significantly improves pageing down in calc, and presumably
a number of other operations.

Signed-off-by: Michael Meeks <michael.meeks@collabora.com>
Change-Id: Ib2a7daf8aa35835edd78dc5da187b0cb76b76ac3


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

