### PR TITLE
Notebookbar Find and Replace everywhere in Home Tab #2136

### DIFF
--- a/loleaflet/src/control/Control.NotebookbarWriter.js
+++ b/loleaflet/src/control/Control.NotebookbarWriter.js
@@ -603,6 +603,11 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 					}
 				],
 				'vertical': 'true'
+			},
+			{
+				'type': 'bigtoolitem',
+				'text': _UNO('.uno:SearchDialog'),
+				'command': '.uno:SearchDialog'
 			}
 		];
 


### PR DESCRIPTION
writer was missing now in all home tabs find and replace is visible.

![Screenshot_20210430_001027](https://user-images.githubusercontent.com/8517736/116624630-8dff7280-a948-11eb-8691-8019deedd29b.png)


Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: Ic30b0a5c4d9cf72eacca92922597f80fc424fc33