### PR TITLE
restore client-side-grid: disable core grid and bg

### DIFF
--- a/kit/SetupKitEnvironment.hpp
+++ b/kit/SetupKitEnvironment.hpp
@@ -50,7 +50,7 @@ inline void setupKitEnvironment(const std::string& userInterface)
     if (userInterface == "notebookbar")
         options += ":notebookbar";
 
-//    options += ":sc_no_grid_bg"; // leave this disabled for now, merged-cells needs more work.
+    options += ":sc_no_grid_bg";
 
     options += ":sc_print_twips_msgs";
 


### PR DESCRIPTION
This reverts commit 9c217d6d9314bdb3a7a832c407e58ea5598932ab.


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
restore client-side-grid: disable core grid and bg, now that fixes for related bugs are in co64.

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

