### PR TITLE
Tile load slurping.

### DIFF
--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -282,7 +282,7 @@ app.definitions.Socket = L.Class.extend({
 		var that = this;
 		if (!this._slurpQueue || !this._slurpQueue.length) {
 			setTimeout(function() {
-				console.log2('Slurp events ' + that._slurpQueue.length);
+				// console.log2('Slurp events ' + that._slurpQueue.length);
 				for (var i = 0; i < that._slurpQueue.length; ++i) {
 					// it is - are you ?
 					that._onMessage(that._slurpQueue[i]);
@@ -291,8 +291,6 @@ app.definitions.Socket = L.Class.extend({
 			}, 1 /* ms */);
 			that._slurpQueue = [];
 		}
-		// I imagine e doesn't hang around at all nicely and this fails
-		// but lets see ...
 		that._slurpQueue.push(e);
 	},
 

--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -3187,10 +3187,28 @@ L.CanvasTileLayer = L.Layer.extend({
 	},
 
 	_tileOnLoad: function (done, tile) {
-		done(null, tile);
-		if (window.ThisIsTheiOSApp) {
-			window.webkit.messageHandlers.lool.postMessage('REMOVE ' + tile.src, '*');
+		// slurp multiple async tile loads into one render:
+		// FIXME: probably we should nicely combine
+		// async image decoding into Socket.js' _slurpMessage
+		// to save another 1ms timer.
+		var that = this;
+		if (!that._slurpQueue || !that._slurpQueue.length) {
+			setTimeout(function() {
+				console.log2('Slurp tiles ' + that._slurpQueue.length / 2);
+				for (var i = 0; i < that._slurpQueue.length; i += 2) {
+					var slurpTile = that._slurpQueue[i];
+					var slurpCallback = that._slurpQueue[i+1];
+					slurpCallback(null, slurpTile);
+					if (window.ThisIsTheiOSApp) {
+						window.webkit.messageHandlers.lool.postMessage('REMOVE ' + slurpTile.src, '*');
+					}
+				}
+				that._slurpQueue = [];
+			}, 1 /* ms */);
+			that._slurpQueue = [];
 		}
+		that._slurpQueue.push(tile);
+		that._slurpQueue.push(done);
 	},
 
 	_tileOnError: function (done, tile, e) {


### PR DESCRIPTION
The browsers - unfortunately appear to round-robin the asynchronous
unload of an individual tile - which causes a _tileReady callback
with updating the canvas.

This means that we re-render the canvas (at whatever speed) for each
tile we load - guarenteeing a nice animated effect of loading tiles
one by one, and refreshing the view: not so cool.

So - instead, as per WebSocket messages, slurp them - and then
refresh the view in one shot after 1ms; since it is fairly bogus
to convert a base64 encoded URL image to a real image asynchronously
anyway, this gives some nice results eg.

TileLayer.js:2464 Slurp tiles 34
TileLayer.js:2464 Slurp tiles 25
TileLayer.js:2464 Slurp tiles 53
TileLayer.js:2464 Slurp tiles 5
TileLayer.js:2464 Slurp tiles 3

It also significantly improves pageing down in calc, and presumably
a number of other operations.

Signed-off-by: Michael Meeks <michael.meeks@collabora.com>
Change-Id: Ib2a7daf8aa35835edd78dc5da187b0cb76b76ac3


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

