### PR TITLE
Page Reload: Add case for save-as.

### DIFF
--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -329,9 +329,8 @@ app.definitions.Socket = L.Class.extend({
 				oldVersion = this.WSDServer.Version;
 
 				// If another file is opened, we will not refresh the page.
-				var previousFileName = this._map.wopi.PreviousFileName;
-				if (previousFileName && this._map.wopi.BaseFileName) {
-					if (previousFileName !== this._map.wopi.BaseFileName)
+				if (this._map.options.previousWopiSrc && this._map.options.wopiSrc) {
+					if (this._map.options.previousWopiSrc !== this._map.options.wopiSrc)
 						sameFile = false;
 				}
 			}
@@ -845,6 +844,7 @@ app.definitions.Socket = L.Class.extend({
 				// setup for loading the new document, and trigger the load
 				var docUrl = url.split('?')[0];
 				this._map.options.doc = docUrl;
+				this._map.options.previousWopiSrc = this._map.options.wopiSrc; // After save-as op, we may connect to another server, then code will think that server has restarted. In this case, we don't want to reload the page (detect the file name is different).
 				this._map.options.wopiSrc = encodeURIComponent(docUrl);
 
 				// if this is save-as, we need to load the document with edit permission

--- a/loleaflet/src/map/handler/Map.WOPI.js
+++ b/loleaflet/src/map/handler/Map.WOPI.js
@@ -98,7 +98,6 @@ L.Map.WOPI = L.Handler.extend({
 			this.PostMessageOrigin = wopiInfo['PostMessageOrigin'];
 		}
 
-		this.PreviousFileName = this.BaseFileName; // After a save as operation, we will check the previous file name, for not refreshing the page.
 		this.BaseFileName = wopiInfo['BaseFileName'];
 		this.BreadcrumbDocName = wopiInfo['BreadcrumbDocName'];
 		if (this.BreadcrumbDocName === undefined)


### PR DESCRIPTION
When user saves the document with a different name, new document will be
loaded.

While this happens, if there are more than one servers, client may be
directed to another server for the new file.

In this case, socket code will think that current server has restarted
and will reload the page. Socket code can't see if the server is
different than the previos one.

So, after a save-as operation, if we check the file adress with the
previous one, we can detect that the file we are viewving has changed.
In that case, we will not reload the page.

Change-Id: Idbf50678a453feccb34eb67a5b9286904a96bffa
Signed-off-by: Gökay Şatır <gokay.satir@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

