### PR TITLE
Notebookbar height 72px instead of 84px #2088

### DIFF
--- a/loleaflet/css/notebookbar.css
+++ b/loleaflet/css/notebookbar.css
@@ -206,7 +206,7 @@
 	scrollbar-width: none; /* Firefox */
 	-ms-overflow-style: none;  /* Internet Explorer 10+ */
 	display: flex;
-	height: 84px;
+	height: 72px;
 	align-items: center;
 }
 

--- a/loleaflet/src/control/Control.UIManager.js
+++ b/loleaflet/src/control/Control.UIManager.js
@@ -433,9 +433,9 @@ L.Control.UIManager = L.Control.extend({
 				additionalOffset = 57;
 		}
 
-		this.moveObjectVertically($('#document-container'), 43 + additionalOffset);
-		this.moveObjectVertically($('#presentation-controls-wrapper'), 43);
-		this.moveObjectVertically($('#sidebar-dock-wrapper'), 43);
+		this.moveObjectVertically($('#document-container'), 31 + additionalOffset);
+		this.moveObjectVertically($('#presentation-controls-wrapper'), 31);
+		this.moveObjectVertically($('#sidebar-dock-wrapper'), 31);
 
 		$('#map').addClass('notebookbar-opened');
 	},
@@ -444,9 +444,9 @@ L.Control.UIManager = L.Control.extend({
 		if (this.isNotebookbarCollapsed())
 			return;
 
-		this.moveObjectVertically($('#document-container'), -85);
-		this.moveObjectVertically($('#presentation-controls-wrapper'), -85);
-		this.moveObjectVertically($('#sidebar-dock-wrapper'), -85);
+		this.moveObjectVertically($('#document-container'), -73);
+		this.moveObjectVertically($('#presentation-controls-wrapper'), -73);
+		this.moveObjectVertically($('#sidebar-dock-wrapper'), -73);
 		this.moveObjectVertically($('#formulabar'), -1);
 		$('#toolbar-up').css('display', 'none');
 
@@ -459,9 +459,9 @@ L.Control.UIManager = L.Control.extend({
 		if (!this.isNotebookbarCollapsed())
 			return;
 
-		this.moveObjectVertically($('#document-container'), 85);
-		this.moveObjectVertically($('#presentation-controls-wrapper'), 85);
-		this.moveObjectVertically($('#sidebar-dock-wrapper'), 85);
+		this.moveObjectVertically($('#document-container'), 73);
+		this.moveObjectVertically($('#presentation-controls-wrapper'), 73);
+		this.moveObjectVertically($('#sidebar-dock-wrapper'), 73);
 		this.moveObjectVertically($('#formulabar'), 1);
 		$('#toolbar-up').css('display', '');
 


### PR DESCRIPTION
with #2235 and the fix of the home tab height it's now possible to reduce the notebookbar height to 72px in height instead of 84px.
Sure there would be 68 px theoretical possible, but the additional 4px in height are good for the home tab.

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: Id28bcc63db142d235986cb5449d750808b684c4f
