### PR TITLE
Backports from co-6-4 and test improvements

### DIFF
--- a/common/StringVector.cpp
+++ b/common/StringVector.cpp
@@ -43,7 +43,7 @@ bool StringVector::getUInt32(std::size_t index, const std::string& key, uint32_t
             _string[token._index + key.size()] == '=')
     {
         value = Util::safe_atoi(&_string[token._index + offset], token._length - offset);
-        return value < std::numeric_limits<int>::max();
+        return value < std::numeric_limits<uint32_t>::max();
     }
 
     return false;

--- a/common/Unit.cpp
+++ b/common/Unit.cpp
@@ -182,7 +182,8 @@ void UnitWSD::lookupTile(int part, int width, int height, int tilePosX, int tile
         onTileCacheMiss(part, width, height, tilePosX, tilePosY, tileWidth, tileHeight);
 }
 
-UnitKit::UnitKit()
+UnitKit::UnitKit(std::string testname)
+    : UnitBase(std::move(testname))
 {
 }
 

--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -105,7 +105,7 @@ protected:
     }
 
     /// Construct a UnitBase instance with a default name.
-    explicit UnitBase(std::string name = "UnitBase")
+    explicit UnitBase(std::string name)
         : _dlHandle(nullptr)
         , _setRetValue(false)
         , _retValue(0)
@@ -390,7 +390,7 @@ private:
 class UnitKit : public UnitBase
 {
 public:
-    UnitKit();
+    explicit UnitKit(std::string testname = std::string());
     virtual ~UnitKit();
     static UnitKit& get()
     {

--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -310,6 +310,13 @@ public:
             // Invoke the test, expect no exceptions.
             invokeWSDTest();
         }
+        catch (const Poco::Exception& ex)
+        {
+            LOG_ERR("ERROR: unexpected exception while invoking WSD Test: : "
+                    << ex.displayText()
+                    << (ex.nested() ? "( " + ex.nested()->displayText() + ')' : ""));
+            exitTest(TestResult::Failed);
+        }
         catch (const std::exception& ex)
         {
             LOG_TST("ERROR: unexpected exception while invoking WSD Test: " << ex.what());

--- a/net/Buffer.hpp
+++ b/net/Buffer.hpp
@@ -79,7 +79,12 @@ public:
 
     void append(const std::string& s) { append(s.c_str(), s.size()); }
 
-    void append(const char ch) { append(&ch, 1); }
+    /// Append a literal string, with compile-time size capturing.
+    template <std::size_t N> void append(const char (&s)[N])
+    {
+        static_assert(N > 1, "Cannot append empty strings.");
+        append(s, N - 1); // Minus null termination.
+    }
 
     void dumpHex(std::ostream &os, const char *legend, const char *prefix) const
     {

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -379,9 +379,9 @@ public:
         for (const auto& pair : _headers)
         {
             out.append(pair.first);
-            out.append(": ", 2);
+            out.append(": ");
             out.append(pair.second);
-            out.append("\r\n", 2);
+            out.append("\r\n");
         }
 
         return true;
@@ -512,14 +512,14 @@ public:
             LOG_TRC("performWrites (header).");
 
             out.append(getVerb());
-            out.append(' ');
+            out.append(" ");
             out.append(getUrl());
-            out.append(' ');
+            out.append(" ");
             out.append(getVersion());
-            out.append("\r\n", 2);
+            out.append("\r\n");
 
             _header.writeData(out);
-            out.append("\r\n", 2); // End the header.
+            out.append("\r\n"); // End the header.
 
             _stage = Stage::Body;
         }
@@ -639,11 +639,11 @@ public:
     bool writeData(Buffer& out) const
     {
         out.append(_httpVersion);
-        out.append(' ');
+        out.append(" ");
         out.append(std::to_string(_statusCode));
-        out.append(' ');
+        out.append(" ");
         out.append(_reasonPhrase);
-        out.append("\r\n", 2);
+        out.append("\r\n");
         return true;
     }
 
@@ -783,7 +783,7 @@ public:
     {
         _statusLine.writeData(out);
         _header.writeData(out);
-        out.append("\r\n", 2); // End of header.
+        out.append("\r\n"); // End of header.
         out.append(_body);
         return true;
     }

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -1236,11 +1236,11 @@ get(const std::string& url, std::chrono::milliseconds timeout = Session::getDefa
 }
 
 /// HTTP Get synchronously given a url and a path.
-inline const std::shared_ptr<const http::Response> get(std::string url, const std::string& path,
-                                                       std::chrono::milliseconds timeout
-                                                       = Session::getDefaultTimeout())
+inline const std::shared_ptr<const http::Response>
+get(const std::string& url, const std::string& path,
+    std::chrono::milliseconds timeout = Session::getDefaultTimeout())
 {
-    auto httpSession = http::Session::create(std::move(url));
+    auto httpSession = http::Session::create(url);
     return httpSession->syncRequest(http::Request(path), timeout);
 }
 

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -496,7 +496,8 @@ public:
         ifs->seekg(0, std::ios_base::beg);
 
         setBodySource(
-            [=](char* buf, int64_t len) -> int64_t {
+            [=](char* buf, int64_t len) -> int64_t
+            {
                 ifs->read(buf, len);
                 return ifs->gcount();
             },
@@ -577,8 +578,8 @@ public:
     static constexpr int64_t VersionLen = 8;
     static constexpr int64_t StatusCodeLen = 3;
     static constexpr int64_t MaxReasonPhraseLen = 512; // Arbitrary large number.
-    static constexpr int64_t MinStatusLineLen
-        = sizeof("HTTP/0.0 000\r\n") - 1; // Reason phrase is optional.
+    static constexpr int64_t MinStatusLineLen =
+        sizeof("HTTP/0.0 000\r\n") - 1; // Reason phrase is optional.
     static constexpr int64_t MaxStatusLineLen = VersionLen + StatusCodeLen + MaxReasonPhraseLen;
     static constexpr int64_t MinValidStatusCode = 100;
     static constexpr int64_t MaxValidStatusCode = 599;
@@ -737,7 +738,8 @@ public:
     void saveBodyToFile(const std::string& path)
     {
         _bodyFile.open(path, std::ios_base::out | std::ios_base::binary);
-        _onBodyWriteCb = [this](const char* p, int64_t len) {
+        _onBodyWriteCb = [this](const char* p, int64_t len)
+        {
             LOG_TRC("Writing " << len << " bytes.");
             if (_bodyFile.good())
                 _bodyFile.write(p, len);
@@ -753,7 +755,8 @@ public:
     /// Use getBody() to read it.
     void saveBodyToMemory()
     {
-        _onBodyWriteCb = [this](const char* p, int64_t len) {
+        _onBodyWriteCb = [this](const char* p, int64_t len)
+        {
             _body.insert(_body.end(), p, p + len);
             // LOG_TRC("Body: " << len << "\n" << _body);
             return len;
@@ -1074,7 +1077,8 @@ private:
         // doesn't have our (Session) reference. Also,
         // it's good that we are notified that the request
         // has retired, so we can perform housekeeping.
-        Response::FinishedCallback onFinished = [&]() {
+        Response::FinishedCallback onFinished = [&]()
+        {
             LOG_TRC("onFinished");
             assert(_response && _response->done() && "Must have response and must be done");
             if (_onFinished)

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -632,6 +632,18 @@ bool StreamSocket::send(http::Request& request)
     }
 }
 
+bool StreamSocket::sendAndShutdown(http::Response& response)
+{
+    response.set("Connection", "close");
+    if (send(response))
+    {
+        shutdown();
+        return true;
+    }
+
+    return false;
+}
+
 void SocketPoll::dumpState(std::ostream& os)
 {
     // FIXME: NOT thread-safe! _pollSockets is modified from the polling thread!

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -972,6 +972,12 @@ public:
     /// Will shutdown the socket upon error and return false.
     bool send(const http::Response& response);
 
+    /// Send an http::Response, flush, and shutdown.
+    /// Will set 'Connection: close' header.
+    /// Returns true if no errors are encountered.
+    /// Will always shutdown the socket.
+    bool sendAndShutdown(http::Response& response);
+
     /// Safely flush any outgoing data.
     inline void flush()
     {

--- a/test/HttpRequestTests.cpp
+++ b/test/HttpRequestTests.cpp
@@ -8,7 +8,7 @@
 #include <config.h>
 
 #include "ConfigUtil.hpp"
-#include "HttpTestServer.hpp"
+#include <HttpTestServer.hpp>
 
 #include <Poco/URI.h>
 #include <Poco/Net/AcceptCertificateHandler.h>

--- a/test/HttpWhiteBoxTests.cpp
+++ b/test/HttpWhiteBoxTests.cpp
@@ -26,6 +26,8 @@ class HttpWhiteBoxTests : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST(testStatusLineParserValidIncomplete);
     CPPUNIT_TEST(testStatusLineSerialize);
 
+    CPPUNIT_TEST(testHeader);
+
     CPPUNIT_TEST(testRequestParserValidComplete);
     CPPUNIT_TEST(testRequestParserValidIncomplete);
 
@@ -34,6 +36,7 @@ class HttpWhiteBoxTests : public CPPUNIT_NS::TestFixture
     void testStatusLineParserValidComplete();
     void testStatusLineParserValidIncomplete();
     void testStatusLineSerialize();
+    void testHeader();
     void testRequestParserValidComplete();
     void testRequestParserValidIncomplete();
 };
@@ -100,13 +103,21 @@ void HttpWhiteBoxTests::testStatusLineSerialize()
     LOK_ASSERT_EQUAL(std::string("HTTP/1.1 200 OK\r\n"), out);
 }
 
+void HttpWhiteBoxTests::testHeader()
+{
+    http::Header header;
+
+    const std::string data = "\r\na=\r\n\r\n";
+    LOK_ASSERT_EQUAL(8L, header.parse(data.c_str(), data.size()));
+}
+
 void HttpWhiteBoxTests::testRequestParserValidComplete()
 {
     const std::string expVerb = "GET";
     const std::string expUrl = "/path/to/data";
     const std::string expVersion = "HTTP/1.1";
-    const std::string data
-        = expVerb + ' ' + expUrl + ' ' + expVersion + "\r\n" + "Host: localhost.com\r\n\r\n";
+    const std::string data = expVerb + ' ' + expUrl + ' ' + expVersion + "\r\n" + "EmptyKey:\r\n"
+                             + "Host: localhost.com\r\n\r\n";
 
     http::Request req;
 
@@ -114,6 +125,8 @@ void HttpWhiteBoxTests::testRequestParserValidComplete()
     LOK_ASSERT_EQUAL(expVerb, req.getVerb());
     LOK_ASSERT_EQUAL(expUrl, req.getUrl());
     LOK_ASSERT_EQUAL(expVersion, req.getVersion());
+    LOK_ASSERT_EQUAL(std::string(), req.get("emptykey"));
+    LOK_ASSERT_EQUAL(std::string("localhost.com"), req.get("Host"));
 }
 
 void HttpWhiteBoxTests::testRequestParserValidIncomplete()

--- a/test/UnitHosting.cpp
+++ b/test/UnitHosting.cpp
@@ -36,11 +36,17 @@ class UnitHosting : public UnitWSD
     TestResult testCapabilities();
 
 public:
+    UnitHosting()
+        : UnitWSD("UnitHosting")
+    {
+    }
+
     void invokeWSDTest() override;
 };
 
 UnitBase::TestResult UnitHosting::testDiscovery()
 {
+    LOG_TST("Getting /hosting/discovery the first time.");
     const std::shared_ptr<const http::Response> httpResponse
         = http::get(helpers::getTestServerURI(), "/hosting/discovery");
 
@@ -57,6 +63,7 @@ UnitBase::TestResult UnitHosting::testDiscovery()
     LOK_ASSERT_EQUAL(std::string("text/xml"), httpResponse->header().getContentType());
 
     // Repeat, with a trailing foreslash in the URL.
+    LOG_TST("Getting /hosting/discovery the second time.");
     const std::shared_ptr<const http::Response> httpResponse2
         = http::get(helpers::getTestServerURI(), "/hosting/discovery/");
 
@@ -72,6 +79,7 @@ UnitBase::TestResult UnitHosting::testDiscovery()
     LOK_ASSERT_EQUAL(std::string("OK"), httpResponse2->statusLine().reasonPhrase());
     LOK_ASSERT_EQUAL(std::string("text/xml"), httpResponse2->header().getContentType());
 
+    LOG_TST("Comparing /hosting/discovery from both requests.");
     LOK_ASSERT_EQUAL(httpResponse2->getBody(), httpResponse->getBody());
 
     return TestResult::Ok;

--- a/test/UnitWOPI.cpp
+++ b/test/UnitWOPI.cpp
@@ -55,7 +55,8 @@ public:
         return res;
     }
 
-    void assertPutFileRequest(const Poco::Net::HTTPRequest& request) override
+    std::unique_ptr<http::Response>
+    assertPutFileRequest(const Poco::Net::HTTPRequest& request) override
     {
         if (_savingPhase == SavingPhase::Unmodified)
         {
@@ -88,6 +89,8 @@ public:
 
         if (_finishedSaveUnmodified && _finishedSaveModified)
             passTest("Headers for both modified and unmodified received as expected.");
+
+        return nullptr;
     }
 
     bool onDocumentLoaded(const std::string& message) override

--- a/test/UnitWOPIHttpHeaders.cpp
+++ b/test/UnitWOPIHttpHeaders.cpp
@@ -35,10 +35,12 @@ protected:
         exitTest(TestResult::Ok); //TODO: Remove when we add put/rename cases.
     }
 
-    void assertPutFileRequest(const Poco::Net::HTTPRequest& request) override
+    std::unique_ptr<http::Response>
+    assertPutFileRequest(const Poco::Net::HTTPRequest& request) override
     {
         assertHeaders(request);
         exitTest(TestResult::Ok);
+        return nullptr;
     }
 
     void assertPutRelativeFileRequest(const Poco::Net::HTTPRequest& request) override

--- a/test/UnitWOPIVersionRestore.cpp
+++ b/test/UnitWOPIVersionRestore.cpp
@@ -43,13 +43,16 @@ public:
     {
     }
 
-    void assertPutFileRequest(const Poco::Net::HTTPRequest& /*request*/) override
+    std::unique_ptr<http::Response>
+    assertPutFileRequest(const Poco::Net::HTTPRequest& /*request*/) override
     {
         if (_phase == Phase::WaitPutFile)
         {
             LOG_TST("assertPutFileRequest: document saved.");
             _isDocumentSaved = true;
         }
+
+        return nullptr;
     }
 
     bool onDocumentLoaded(const std::string& message) override

--- a/test/UnitWopiOwnertermination.cpp
+++ b/test/UnitWopiOwnertermination.cpp
@@ -49,7 +49,8 @@ public:
     {
     }
 
-    void assertPutFileRequest(const Poco::Net::HTTPRequest& /*request*/) override
+    std::unique_ptr<http::Response>
+    assertPutFileRequest(const Poco::Net::HTTPRequest& /*request*/) override
     {
         if (_phase == Phase::Polling)
         {
@@ -60,6 +61,8 @@ public:
         {
             failTest("Saving in an unexpected phase: " + toString(_phase));
         }
+
+        return nullptr;
     }
 
     bool onDocumentLoaded(const std::string& message) override

--- a/test/WopiTestServer.hpp
+++ b/test/WopiTestServer.hpp
@@ -242,14 +242,11 @@ protected:
                 const std::string fileModifiedTime = Util::getIso8601FracformatTime(_fileLastModifiedTime);
                 if (wopiTimestamp != fileModifiedTime)
                 {
-                    std::ostringstream oss;
-                    oss << "HTTP/1.1 409 Conflict\r\n"
-                        "User-Agent: " WOPI_AGENT_STRING "\r\n"
-                        "\r\n"
-                        "{\"LOOLStatusCode\":" << static_cast<int>(LOOLStatusCode::DocChanged) << '}';
-
-                    socket->send(oss.str());
-                    socket->shutdown();
+                    http::Response httpResponse(http::StatusLine(409));
+                    httpResponse.setBody(
+                        "{\"LOOLStatusCode\":" +
+                        std::to_string(static_cast<int>(LOOLStatusCode::DocChanged)) + '}');
+                    socket->sendAndShutdown(httpResponse);
                     return true;
                 }
             }
@@ -261,15 +258,10 @@ protected:
 
             assertPutFileRequest(request);
 
-            std::ostringstream oss;
-            oss << "HTTP/1.1 200 OK\r\n"
-                "User-Agent: " WOPI_AGENT_STRING "\r\n"
-                "\r\n"
-                "{\"LastModifiedTime\": \"" << Util::getIso8601FracformatTime(_fileLastModifiedTime) << "\" }";
-
-            socket->send(oss.str());
-            socket->shutdown();
-
+            http::Response httpResponse(http::StatusLine(200));
+            httpResponse.setBody("{\"LastModifiedTime\": \"" +
+                                 Util::getIso8601FracformatTime(_fileLastModifiedTime) + "\" }");
+            socket->sendAndShutdown(httpResponse);
             return true;
         }
         else if (!Util::startsWith(uriReq.getPath(), "/lool/")) // Skip requests to the websrv.

--- a/test/WopiTestServer.hpp
+++ b/test/WopiTestServer.hpp
@@ -262,15 +262,21 @@ protected:
             std::unique_ptr<http::Response> response = assertPutFileRequest(request);
             if (response)
             {
+                LOG_TST("Fake wopi host response to POST "
+                        << uriReq.getPath() << ": " << response->statusLine().statusCode()
+                        << response->statusLine().reasonPhrase());
                 socket->sendAndShutdown(*response);
             }
             else
             {
                 // By default we return success.
+                const std::string body = "{\"LastModifiedTime\": \"" +
+                                         Util::getIso8601FracformatTime(_fileLastModifiedTime) +
+                                         "\" }";
+                LOG_TST("Fake wopi host response to POST " << uriReq.getPath() << ": 200 OK "
+                                                           << body);
                 http::Response httpResponse(http::StatusLine(200));
-                httpResponse.setBody("{\"LastModifiedTime\": \"" +
-                                     Util::getIso8601FracformatTime(_fileLastModifiedTime) +
-                                     "\" }");
+                httpResponse.setBody(body);
                 socket->sendAndShutdown(httpResponse);
             }
 

--- a/test/WopiTestServer.hpp
+++ b/test/WopiTestServer.hpp
@@ -92,8 +92,11 @@ public:
     {
     }
 
-    virtual void assertPutFileRequest(const Poco::Net::HTTPRequest& /*request*/)
+    /// Assert the PutFile request is valid and optinally return a response.
+    virtual std::unique_ptr<http::Response>
+    assertPutFileRequest(const Poco::Net::HTTPRequest& /*request*/)
     {
+        return nullptr;
     }
 
     virtual void assertPutRelativeFileRequest(const Poco::Net::HTTPRequest& /*request*/)
@@ -256,12 +259,21 @@ protected:
             message.read(buffer, size);
             setFileContent(std::string(buffer, size));
 
-            assertPutFileRequest(request);
+            std::unique_ptr<http::Response> response = assertPutFileRequest(request);
+            if (response)
+            {
+                socket->sendAndShutdown(*response);
+            }
+            else
+            {
+                // By default we return success.
+                http::Response httpResponse(http::StatusLine(200));
+                httpResponse.setBody("{\"LastModifiedTime\": \"" +
+                                     Util::getIso8601FracformatTime(_fileLastModifiedTime) +
+                                     "\" }");
+                socket->sendAndShutdown(httpResponse);
+            }
 
-            http::Response httpResponse(http::StatusLine(200));
-            httpResponse.setBody("{\"LastModifiedTime\": \"" +
-                                 Util::getIso8601FracformatTime(_fileLastModifiedTime) + "\" }");
-            socket->sendAndShutdown(httpResponse);
             return true;
         }
         else if (!Util::startsWith(uriReq.getPath(), "/lool/")) // Skip requests to the websrv.

--- a/test/WopiTestServer.hpp
+++ b/test/WopiTestServer.hpp
@@ -238,7 +238,7 @@ protected:
         {
             LOG_TST("Fake wopi host request, handling PutFile: " << uriReq.getPath());
 
-            std::string wopiTimestamp = request.get("X-LOOL-WOPI-Timestamp");
+            std::string wopiTimestamp = request.get("X-LOOL-WOPI-Timestamp", std::string());
             if (!wopiTimestamp.empty())
             {
 

--- a/test/run_unit.sh.in
+++ b/test/run_unit.sh.in
@@ -113,6 +113,6 @@ else
 	echo ":test-result: FAIL $tst" >> $test_output
 fi
 
-echo "Finished $tst in $SECONDS";
+echo "Finished $tst in ${SECONDS}s";
 
 # vim:set shiftwidth=4 expandtab:

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -315,6 +315,7 @@ void DocumentBroker::pollThread()
 
         if (isInteractive())
         {
+            // Extend the deadline while we are interactiving with the user.
             loadDeadline = now + std::chrono::seconds(limit_load_secs);
             continue;
         }

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1582,9 +1582,8 @@ std::size_t DocumentBroker::removeSession(const std::string& id)
         // Last view going away, can destroy.
         if (_sessions.size() <= 1)
             _docState.markToDestroy();
-
-        assert((_sessions.size() <= 1 && _docState.isMarkedToDestroy())
-               || !_docState.isMarkedToDestroy());
+        else
+            assert(!_docState.isMarkedToDestroy());
 
         const bool lastEditableSession = (!session->isReadOnly() || session->isAllowChangeComments()) && !haveAnotherEditableSession(id);
         static const bool dontSaveIfUnmodified = !LOOLWSD::getConfigValue<bool>("per_document.always_save_on_exit", false);

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -210,7 +210,7 @@ void DocumentBroker::setupPriorities()
 void DocumentBroker::setupTransfer(SocketDisposition &disposition,
                                    SocketDisposition::MoveFunction transferFn)
 {
-    disposition.setTransfer(*_poll.get(), transferFn);
+    disposition.setTransfer(*_poll, transferFn);
 }
 
 void DocumentBroker::assertCorrectThread() const

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -2539,9 +2539,7 @@ private:
                     http::Response httpResponse(http::StatusLine(401));
                     httpResponse.set("Content-Type", "text/html charset=UTF-8");
                     httpResponse.set("WWW-authenticate", "Basic realm=\"online\"");
-                    httpResponse.set("Connection", "close");
-                    socket->send(httpResponse);
-                    socket->shutdown();
+                    socket->sendAndShutdown(httpResponse);
                     return;
                 }
 
@@ -2614,9 +2612,7 @@ private:
             // NOTE: Check _wsState to choose between HTTP response or WebSocket (app-level) error.
             http::Response httpResponse(http::StatusLine(400));
             httpResponse.set("Content-Length", "0");
-            httpResponse.set("Connection", "close");
-            socket->send(httpResponse);
-            socket->shutdown();
+            socket->sendAndShutdown(httpResponse);
             return;
         }
 
@@ -2728,9 +2724,7 @@ private:
         httpResponse.setBody(xml, "text/xml");
         httpResponse.set("Last-Modified", Util::getHttpTimeNow());
         httpResponse.set("X-Content-Type-Options", "nosniff");
-        httpResponse.set("Connection", "close");
-        socket->send(httpResponse);
-        socket->shutdown();
+        socket->sendAndShutdown(httpResponse);
         LOG_INF("Sent discovery.xml successfully.");
     }
 
@@ -2747,9 +2741,7 @@ private:
         httpResponse.set("Last-Modified", Util::getHttpTimeNow());
         httpResponse.setBody(capabilities, "application/json");
         httpResponse.set("X-Content-Type-Options", "nosniff");
-        httpResponse.set("Connection", "close");
-        socket->send(httpResponse);
-        socket->shutdown();
+        socket->sendAndShutdown(httpResponse);
         LOG_INF("Sent capabilities.json successfully.");
     }
 
@@ -2791,9 +2783,7 @@ private:
             // we got the wrong request.
             http::Response httpResponse(http::StatusLine(400));
             httpResponse.set("Content-Length", "0");
-            httpResponse.set("Connection", "close");
-            socket->send(httpResponse);
-            socket->shutdown();
+            socket->sendAndShutdown(httpResponse);
             return;
         }
 
@@ -3051,9 +3041,7 @@ private:
                 LOG_WRN("Conversion requests not allowed from this address: " << socket->clientAddress());
                 http::Response httpResponse(http::StatusLine(403));
                 httpResponse.set("Content-Length", "0");
-                httpResponse.set("Connection", "close");
-                socket->send(httpResponse);
-                socket->shutdown();
+                socket->sendAndShutdown(httpResponse);
                 return;
             }
 
@@ -3148,9 +3136,7 @@ private:
 
                     http::Response httpResponse(http::StatusLine(200));
                     httpResponse.set("Content-Length", "0");
-                    httpResponse.set("Connection", "close");
-                    socket->send(httpResponse);
-                    socket->shutdown();
+                    socket->sendAndShutdown(httpResponse);
                     return;
                 }
             }
@@ -3233,9 +3219,7 @@ private:
 
                 http::Response httpResponse(http::StatusLine(404));
                 httpResponse.set("Content-Length", "0");
-                httpResponse.set("Connection", "close");
-                socket->send(httpResponse);
-                socket->shutdown();
+                socket->sendAndShutdown(httpResponse);
             }
             return;
         }


### PR DESCRIPTION
- wsd: test: http::Header parsing tests
- wsd: simplify assertion
- wsd: test: UnitBase takes the test name from derived classes
- wsd: http: simplify appending to Buffer
- wsd: fix signed/unsigned mismatch
- wsd: shared_ptr can dereference directly
- wsd: explanation comment
- wsd: http: simplify sending response and shutting down the socket
- wsd: test: use http objects instead of manual strings
- wsd: test: assertPutFileRequest returns the http response
- wsd: test: log poco exceptions
- wsd: http: braces always on new line
- wsd: http: add isConnected getter to http::Session
- wsd: http: simplify http::get
- wsd: test: log UnitHosting activity
- wsd: test: safe header reader
- wsd: test: log the fake wopi response
- wsd: test: add the seconds suffix to the output
