### PR TITLE
Fixes to properly close connections and not access released socket

### DIFF
--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -858,8 +858,8 @@ private:
         , _timeout(getDefaultTimeout())
         , _connected(false)
     {
-        assert(!_host.empty() && portNumber > 0 && !_port.empty()
-               && "Invalid hostname and portNumber for http::Sesssion");
+        assert(!_host.empty() && portNumber > 0 && !_port.empty() &&
+               "Invalid hostname and portNumber for http::Sesssion");
 #ifdef ENABLE_DEBUG
         std::string scheme;
         std::string hostString;
@@ -948,6 +948,7 @@ public:
     const std::string& port() const { return _port; }
     Protocol protocol() const { return _protocol; }
     bool isSecure() const { return _protocol == Protocol::HttpSsl; }
+    bool isConnected() const { return _connected; };
 
     /// Set the timeout, in microseconds.
     void setTimeout(const std::chrono::microseconds timeout) { _timeout = timeout; }
@@ -1020,7 +1021,7 @@ public:
 
         newRequest(req);
 
-        if (!_connected && connect())
+        if (!isConnected() && connect())
         {
             LOG_TRC("Connected");
             poll.insertNewSocket(_socket);
@@ -1045,7 +1046,7 @@ private:
 
         assert(!!_response && "Response must be set!");
 
-        if (!_connected && !connect())
+        if (!isConnected() && !connect())
             return false;
 
         SocketPoll poller("HttpSynReqPoll");
@@ -1087,6 +1088,7 @@ private:
             {
                 LOG_TRC("Our peer has sent the 'Connection: close' token. Disconnecting.");
                 onDisconnect();
+                assert(isConnected() == false);
             }
         };
 
@@ -1201,7 +1203,7 @@ private:
             // Note that this is the right way to end a request in HTTP, it's also
             // no good maintaining a poor connection (if that's the issue).
             onDisconnect(); // Trigger manually (why wait for poll to do it?).
-            assert(_connected == false);
+            assert(isConnected() == false);
         }
     }
 

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -1168,10 +1168,10 @@ private:
             _socket->shutdown(); // Flag for shutdown for housekeeping in SocketPoll.
             _socket->closeConnection(); // Immediately disconnect.
             _socket.reset();
+            _response->complete();
         }
 
         _connected = false;
-        _response->complete();
     }
 
     bool connect()


### PR DESCRIPTION
- wsd: http: complete the http response only once
- wsd: http: add isConnected getter to http::Session
- wsd: http: disconnect if the server closed the socket
