### PR TITLE
Hide the progressbar after the initial JS Dialog

### DIFF
--- a/loleaflet/src/control/Control.JSDialog.js
+++ b/loleaflet/src/control/Control.JSDialog.js
@@ -69,6 +69,12 @@ L.Control.JSDialog = L.Control.extend({
 		var builder = new L.control.jsDialogBuilder({windowId: data.id, mobileWizard: this, map: this.map, cssClass: 'jsdialog'});
 		builder.build(content, [data]);
 
+		// We show some dialogs such as Macro Security Warning Dialog and Text Import Dialog (csv)
+		// They are displayed before the document is loaded
+		// Spinning should be happening until the 1st interaction with the user
+		// which is the dialog opening in this case
+		this.map._progressBar.end();
+
 		var that = this;
 		button.onclick = function() {
 			that.closeDialog(data.id);


### PR DESCRIPTION
When we display JS Dialog before the document is loaded
We should hide the progressbar. Spinning should be until the
1st user interaction.

Signed-off-by: merttumer <mert.tumer@collabora.com>
Change-Id: Iad8bf56d9bcc57e106e76a961ba72490a74b26c0


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

