### PR TITLE
Classic: select: do not change element's height

### DIFF
--- a/loleaflet/css/notebookbar.css
+++ b/loleaflet/css/notebookbar.css
@@ -429,12 +429,12 @@
 	width: 170px !important;
 }
 
-.select2-container--default .select2-selection--single .select2-selection__rendered {
+.notebookbar.ui-combobox > .select2 * {
 	line-height: 22px;
 }
 
-.select2-container--default .select2-selection--single .select2-selection__arrow {
-	height: 22px;    
+.notebookbar.ui-combobox > .select2 .select2-selection__arrow {
+	height: 22px;
 }
 
 #Copy.notebookbar,


### PR DESCRIPTION
93bc5f6083291f28460ccc7fd6c4e6b6ff55112f introduced a regression
in the Classic mode.

- Better target ui-combobox
	- Use notebookbar class
	- Simplify CSS declaration

Fixes: https://github.com/CollaboraOnline/online/issues/2088

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I0ab1dee8a29408c58621297ba8eefc18db3c4fa9
