### PR TITLE
Make WebSocketHandler::_isClient const and drop default values for bo…

### DIFF
--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -39,7 +39,7 @@ private:
 
     std::vector<char> _wsPayload;
     std::atomic<bool> _shuttingDown;
-    bool _isClient;
+    const bool _isClient;
 
 protected:
     struct WSFrameMask
@@ -61,7 +61,7 @@ public:
     ///                 defragmentation should be handled inside message handler (true) or the message handler
     ///                 should be called after all fragments of a message were received and the message
     ///                 was defragmented (false).
-    WebSocketHandler(bool isClient = false, bool isMasking = true) :
+    WebSocketHandler(bool isClient, bool isMasking) :
 #if !MOBILEAPP
         _lastPingSentTime(std::chrono::steady_clock::now()),
         _pingTimeUs(0),
@@ -79,8 +79,7 @@ public:
     /// socket: the TCP socket which received the upgrade request
     /// request: the HTTP upgrade request to WebSocket
     template <typename T>
-    WebSocketHandler(const std::shared_ptr<StreamSocket>& socket, const T& request,
-                     bool isClient = false)
+    WebSocketHandler(const std::shared_ptr<StreamSocket>& socket, const T& request)
         : _socket(socket)
 #if !MOBILEAPP
         , _lastPingSentTime(std::chrono::steady_clock::now()
@@ -89,10 +88,10 @@ public:
         , _pingTimeUs(0)
         , _isMasking(false)
         , _inFragmentBlock(false)
-        , _key(isClient ? PublicComputeAccept::generateKey() : std::string())
+        , _key(std::string())
 #endif
         , _shuttingDown(false)
-        , _isClient(isClient)
+        , _isClient(false)
     {
         if (!socket)
             throw std::runtime_error("Invalid socket while upgrading to WebSocket.");

--- a/net/WebSocketSession.hpp
+++ b/net/WebSocketSession.hpp
@@ -47,7 +47,7 @@ public:
 
 private:
     WebSocketSession(const std::string& hostname, Protocol protocolType, int portNumber)
-        : WebSocketHandler(true)
+        : WebSocketHandler(/* isClient = */ true, /* isMasking = */ true)
         , _host(hostname)
         , _port(std::to_string(portNumber))
         , _protocol(protocolType)

--- a/wsd/Admin.cpp
+++ b/wsd/Admin.cpp
@@ -305,7 +305,7 @@ AdminSocketHandler::AdminSocketHandler(Admin* adminManager,
 }
 
 AdminSocketHandler::AdminSocketHandler(Admin* adminManager)
-    : WebSocketHandler(true),
+    : WebSocketHandler(/* isClient = */ true, /* isMasking = */ true),
       _admin(adminManager),
       _isAuthenticated(true)
 {

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -2143,6 +2143,7 @@ class PrisonerRequestDispatcher : public WebSocketHandler
     std::weak_ptr<ChildProcess> _childProcess;
 public:
     PrisonerRequestDispatcher()
+        : WebSocketHandler(/* isClient = */ false, /* isMasking = */ true)
     {
     }
     ~PrisonerRequestDispatcher()


### PR DESCRIPTION
…ol parms

Avoiding default values for parameters makes the code easier to read.
Especially true for bool parameters. But sure, just a question of
taste.

Change-Id: I473f70bdfafe3a9ccfb325def8760d78fee7e9a6


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

