### PR TITLE
Thesaurus work only in writer #2129

### DIFF
--- a/loleaflet/src/control/Control.NotebookbarCalc.js
+++ b/loleaflet/src/control/Control.NotebookbarCalc.js
@@ -1225,11 +1225,6 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				'command': '.uno:SpellDialog'
 			},
 			{
-				'type': 'bigtoolitem',
-				'text': _UNO('.uno:ThesaurusDialog'),
-				'command': '.uno:ThesaurusDialog'
-			},
-			{
 				'id': 'Review-Section-Language1',
 				'children': [
 					{

--- a/loleaflet/src/control/Control.NotebookbarImpress.js
+++ b/loleaflet/src/control/Control.NotebookbarImpress.js
@@ -941,11 +941,6 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'command': '.uno:SpellDialog'
 			},
 			{
-				'type': 'bigtoolitem',
-				'text': _UNO('.uno:ThesaurusDialog'),
-				'command': '.uno:ThesaurusDialog'
-			},
-			{
 				'id': 'Review-Section-Language1',
 				'type': 'container',
 				'children': [


### PR DESCRIPTION
Thesaurus was removed from calc and impress/draw see issue #2129

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: If440bdf2c61aaac22811706cc440b9ccbe7a30d1
