### PR TITLE
Fix build with --disable-ssl

### DIFF
--- a/test/HttpRequestTests.cpp
+++ b/test/HttpRequestTests.cpp
@@ -109,12 +109,17 @@ public:
             if (HttpRequestTests::SimulatedLatencyMs > 0)
                 fd = Delay::create(HttpRequestTests::SimulatedLatencyMs, physicalFd);
 #endif
+#if ENABLE_SSL
             if (helpers::haveSsl())
                 return StreamSocket::create<SslStreamSocket>(
                     fd, false, std::make_shared<ServerRequestHandler>());
             else
                 return StreamSocket::create<StreamSocket>(fd, false,
                                                           std::make_shared<ServerRequestHandler>());
+#else
+            return StreamSocket::create<StreamSocket>(fd, false,
+                                                      std::make_shared<ServerRequestHandler>());
+#endif
         }
     };
 


### PR DESCRIPTION
After 358b30a682227a5260e932fadbc585fddc9c0a8c.

Signed-off-by: Aron Budea <aron.budea@collabora.com>
Change-Id: I53ab88b240bde8fcd09dd916cf156dc251452b26
(cherry picked from commit 9bf17cd902402073c823446c90fc15ad6d33266a)

* Target version: co-6-4

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

