### PR TITLE
Notebookbar ScrollButtons height shrink to 72px

### DIFF
--- a/loleaflet/src/control/Control.Notebookbar.js
+++ b/loleaflet/src/control/Control.Notebookbar.js
@@ -332,8 +332,8 @@ L.Control.Notebookbar = L.Control.extend({
 		var left = L.DomUtil.create('div', 'w2ui-scroll-left', parent);
 		var right = L.DomUtil.create('div', 'w2ui-scroll-right', parent);
 
-		$(left).css({'height': '80px'});
-		$(right).css({'height': '80px'});
+		$(left).css({'height': '72px'});
+		$(right).css({'height': '72px'});
 
 		$(left).click(function () {
 			var scroll = $('.notebookbar-scroll-wrapper').scrollLeft() - 300;


### PR DESCRIPTION
As the notebookbar height was shrinked, the ScrollButton has to be shrinked also.

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I6d195a10d98e57ec43d74f58d3bb13ed33b7b62f
