### PR TITLE
Message: don't generate and allocate abbreviations just for trace log…

### DIFF
--- a/common/Message.hpp
+++ b/common/Message.hpp
@@ -32,10 +32,9 @@ public:
         _tokens(Util::tokenize(_data.data(), _data.size())),
         _id(makeId(dir)),
         _firstLine(LOOLProtocol::getFirstLine(_data.data(), _data.size())),
-        _abbr(_id + ' ' + LOOLProtocol::getAbbreviatedMessage(_data.data(), _data.size())),
         _type(detectType())
     {
-        LOG_TRC("Message " << _abbr);
+        LOG_TRC("Message " << abbr());
     }
 
     /// Construct a message from a string with type and
@@ -49,11 +48,10 @@ public:
         _tokens(Util::tokenize(message.data() + _forwardToken.size(), message.size() - _forwardToken.size())),
         _id(makeId(dir)),
         _firstLine(LOOLProtocol::getFirstLine(message)),
-        _abbr(_id + ' ' + LOOLProtocol::getAbbreviatedMessage(message)),
         _type(detectType())
     {
         _data.reserve(std::max(reserve, message.size()));
-        LOG_TRC("Message " << _abbr);
+        LOG_TRC("Message " << abbr());
     }
 
     /// Construct a message from a character array with type.
@@ -66,10 +64,9 @@ public:
         _tokens(Util::tokenize(_data.data(), _data.size())),
         _id(makeId(dir)),
         _firstLine(LOOLProtocol::getFirstLine(_data.data(), _data.size())),
-        _abbr(_id + ' ' + LOOLProtocol::getAbbreviatedMessage(_data.data(), _data.size())),
         _type(detectType())
     {
-        LOG_TRC("Message " << _abbr);
+        LOG_TRC("Message " << abbr());
     }
 
     size_t size() const { return _data.size(); }
@@ -88,7 +85,9 @@ public:
     }
 
     /// Return the abbreviated message for logging purposes.
-    const std::string& abbr() const { return _abbr; }
+    std::string abbr() const {
+        return _id + ' ' + LOOLProtocol::getAbbreviatedMessage(_data.data(), _data.size());
+    }
     const std::string& id() const { return _id; }
 
     /// Returns the json part of the message, if any.
@@ -121,7 +120,6 @@ public:
         {
             // Check - just the body.
             assert(_firstLine == LOOLProtocol::getFirstLine(_data.data(), _data.size()));
-            assert(_abbr == _id + ' ' + LOOLProtocol::getAbbreviatedMessage(_data.data(), _data.size()));
             assert(_type == detectType());
         }
     }
@@ -183,7 +181,6 @@ private:
     const StringVector _tokens;
     const std::string _id;
     const std::string _firstLine;
-    const std::string _abbr;
     const Type _type;
 };
 

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1832,11 +1832,11 @@ void DocumentBroker::unregisterDownloadId(const std::string& downloadId)
 bool DocumentBroker::handleInput(const std::vector<char>& payload)
 {
     auto message = std::make_shared<Message>(payload.data(), payload.size(), Message::Dir::Out);
-    const auto& msg = message->abbr();
-    LOG_TRC("DocumentBroker handling child message: [" << msg << "].");
+    LOG_TRC("DocumentBroker handling child message: [" << message->abbr() << "].");
 
 #if !MOBILEAPP
-    LOOLWSD::dumpOutgoingTrace(getJailId(), "0", msg);
+    if (LOOLWSD::TraceDumper)
+        LOOLWSD::dumpOutgoingTrace(getJailId(), "0", message->abbr());
 #endif
 
     if (LOOLProtocol::getFirstToken(message->forwardToken(), '-') == "client")
@@ -1886,7 +1886,7 @@ bool DocumentBroker::handleInput(const std::vector<char>& payload)
         }
         else
         {
-            LOG_ERR("Unexpected message: [" << msg << "].");
+            LOG_ERR("Unexpected message: [" << message->abbr() << "].");
             return false;
         }
     }
@@ -2361,9 +2361,8 @@ bool DocumentBroker::forwardToClient(const std::shared_ptr<Message>& payload)
 {
     assertCorrectThread();
 
-    const std::string& msg = payload->abbr();
     const std::string& prefix = payload->forwardToken();
-    LOG_TRC("Forwarding payload to [" << prefix << "]: " << msg);
+    LOG_TRC("Forwarding payload to [" << prefix << "]: " << payload->abbr());
 
     std::string name;
     std::string sid;
@@ -2395,7 +2394,7 @@ bool DocumentBroker::forwardToClient(const std::shared_ptr<Message>& payload)
             }
             else
             {
-                LOG_WRN("Client session [" << sid << "] not found to forward message: " << msg);
+                LOG_WRN("Client session [" << sid << "] not found to forward message: " << payload->abbr());
             }
         }
     }


### PR DESCRIPTION
…ging.

Also avoid generating abbreviations in various message handling loops
unless debugging is enabled.

Change-Id: I22f4929b0bfd4da36917db6882bb2f5f5be02780
Signed-off-by: Michael Meeks <michael.meeks@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

