### PR TITLE
Avoid parsers believing that the body is a forward message.

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -796,8 +796,7 @@ public:
 
             LOG_TRC("Document::GlobalCallback " << lokCallbackTypeToString(type) << ": " << payload.length() << " bytes.");
 
-            self->sendTextFrame("trace:\n" + payload);
-
+            self->sendTextFrame("trace: \n" + payload);
             return;
         }
 


### PR DESCRIPTION
We need a space after the prefix here to get past the
getForwardToken detection in the core; \n doesn't cut it.

Change-Id: I3f125d47586964ff844f0a89b04b8de866d01f8b
Signed-off-by: Michael Meeks <michael.meeks@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

