### PR TITLE
Asynchronous Uploading

### DIFF
--- a/common/Common.hpp
+++ b/common/Common.hpp
@@ -38,6 +38,11 @@ constexpr const char FORKIT_URI[] = "/loolws/forkit";
 
 constexpr const char CAPABILITIES_END_POINT[] = "/hosting/capabilities";
 
+/// The file suffix used to mark the file slated for uploading.
+constexpr const char TO_UPLOAD_SUFFIX[] = ".upload";
+/// The file suffix used to mark the file being uploaded.
+constexpr const char UPLOADING_SUFFIX[] = "ing";
+
 /// A shared threadname suffix in both the WSD and Kit processes
 /// is highly helpful for filtering the logs for the same document
 /// by simply grepping for this shared suffix+ID. e.g. 'grep "broker_123" loolwsd.log'

--- a/gtk/mobile.cpp
+++ b/gtk/mobile.cpp
@@ -5,6 +5,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include <config.h>
+
 #include <cstdlib>
 #include <cstring>
 #include <iostream>

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -707,6 +707,21 @@ bool ChildSession::loadDocument(const char * /*buffer*/, int /*length*/, const S
             LOG_ERR("Failed to save template [" << url << "].");
             return false;
         }
+
+#if !MOBILEAPP
+            // Create the 'upload' file so DocBroker picks up and uploads.
+            const std::string oldName = Poco::URI(url).getPath();
+            const std::string newName = oldName + TO_UPLOAD_SUFFIX;
+            if (rename(oldName.c_str(), newName.c_str()) < 0)
+            {
+                // It's not an error if there was no file to rename, when the document isn't modified.
+                LOG_TRC("Failed to renamed [" << oldName << "] to [" << newName << ']');
+            }
+            else
+            {
+                LOG_TRC("Renamed [" << oldName << "] to [" << newName << ']');
+            }
+#endif //!MOBILEAPP
     }
 
     getLOKitDocument()->setView(_viewId);

--- a/loleaflet/src/control/Control.DocumentNameInput.js
+++ b/loleaflet/src/control/Control.DocumentNameInput.js
@@ -28,8 +28,7 @@ L.Control.DocumentNameInput = L.Control.extend({
 						// same extension, just rename the file
 						// file name must be without the extension for rename
 						value = value.substr(0, value.lastIndexOf('.'));
-						this.map._renameFilename = value;
-						this.map.sendUnoCommand('.uno:Save');
+						this.map.renameFile(value);
 					}
 				}
 			} else {

--- a/net/HttpRequest.cpp
+++ b/net/HttpRequest.cpp
@@ -216,12 +216,13 @@ FieldParseState StatusLine::parse(const char* p, int64_t& len)
     constexpr int VersionMajPos = sizeof("HTTP/") - 1;
     constexpr int VersionDotPos = VersionMajPos + 1;
     constexpr int VersionMinPos = VersionDotPos + 1;
+    constexpr int VersionBreakPos = VersionMinPos + 1; // Whitespace past the version.
     const int versionMaj = version[VersionMajPos] - '0';
     const int versionMin = version[VersionMinPos] - '0';
     // Version may not be null-terminated.
-    if (!Util::startsWith(std::string(version, VersionLen), "HTTP/")
-        || (versionMaj < 0 || versionMaj > 9) || version[VersionDotPos] != '.'
-        || (versionMin < 0 || versionMin > 9))
+    if (!Util::startsWith(std::string(version, VersionLen), "HTTP/") ||
+        (versionMaj < 0 || versionMaj > 9) || version[VersionDotPos] != '.' ||
+        (versionMin < 0 || versionMin > 9) || !isWhitespace(version[VersionBreakPos]))
     {
         LOG_ERR("StatusLine::parse: Invalid HTTP version [" << std::string(version, VersionLen)
                                                             << "]");
@@ -349,12 +350,13 @@ int64_t Request::readData(const char* p, const int64_t len)
         constexpr int VersionMajPos = sizeof("HTTP/") - 1;
         constexpr int VersionDotPos = VersionMajPos + 1;
         constexpr int VersionMinPos = VersionDotPos + 1;
+        constexpr int VersionBreakPos = VersionMinPos + 1; // Whitespace past the version.
         const int versionMaj = version[VersionMajPos] - '0';
         const int versionMin = version[VersionMinPos] - '0';
         // Version may not be null-terminated.
-        if (!Util::startsWith(std::string(version, VersionLen), "HTTP/")
-            || (versionMaj < 0 || versionMaj > 9) || version[VersionDotPos] != '.'
-            || (versionMin < 0 || versionMin > 9))
+        if (!Util::startsWith(std::string(version, VersionLen), "HTTP/") ||
+            (versionMaj < 0 || versionMaj > 9) || version[VersionDotPos] != '.' ||
+            (versionMin < 0 || versionMin > 9) || !isWhitespace(version[VersionBreakPos]))
         {
             LOG_ERR("Request::dataRead: Invalid HTTP version [" << std::string(version, VersionLen)
                                                                 << "]");

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -23,7 +23,7 @@ noinst_LTLIBRARIES = \
 	unit-admin.la unit-tilecache.la \
 	unit-fuzz.la unit-oob.la unit-http.la unit-oauth.la \
 	unit-wopi.la unit-wopi-saveas.la \
-	unit-wopi-async-upload-close.la \
+	unit-wopi-async-upload-close.la unit-wopi-async-upload-modify.la \
 	unit-wopi-ownertermination.la unit-wopi-versionrestore.la \
 	unit-wopi-documentconflict.la unit_wopi_renamefile.la unit_wopi_watermark.la \
 	unit-tiff-load.la \
@@ -155,6 +155,8 @@ unit_wopi_la_SOURCES = UnitWOPI.cpp
 unit_wopi_la_LIBADD = $(CPPUNIT_LIBS)
 unit_wopi_async_upload_close_la_SOURCES = UnitWOPIAsyncUpload_Close.cpp
 unit_wopi_async_upload_close_la_LIBADD = $(CPPUNIT_LIBS)
+unit_wopi_async_upload_modify_la_SOURCES = UnitWOPIAsyncUpload_Modify.cpp
+unit_wopi_async_upload_modify_la_LIBADD = $(CPPUNIT_LIBS)
 unit_wopi_saveas_la_SOURCES = UnitWOPISaveAs.cpp
 unit_wopi_saveas_la_LIBADD = $(CPPUNIT_LIBS)
 unit_wopi_ownertermination_la_SOURCES = UnitWopiOwnertermination.cpp
@@ -231,7 +233,7 @@ TESTS = \
 	unit-integration.la unit-httpws.la unit-crash.la \
 	unit-copy-paste.la unit-typing.la unit-convert.la unit-prefork.la unit-tilecache.la unit-timeout.la \
 	unit-oauth.la unit-wopi.la unit-wopi-saveas.la \
-	unit-wopi-async-upload-close.la \
+	unit-wopi-async-upload-close.la unit-wopi-async-upload-modify.la \
 	unit-wopi-ownertermination.la unit-wopi-versionrestore.la \
 	unit-wopi-documentconflict.la unit_wopi_renamefile.la unit_wopi_watermark.la \
 	unit-http.la \

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -23,6 +23,7 @@ noinst_LTLIBRARIES = \
 	unit-admin.la unit-tilecache.la \
 	unit-fuzz.la unit-oob.la unit-http.la unit-oauth.la \
 	unit-wopi.la unit-wopi-saveas.la \
+	unit-wopi-async-upload-close.la \
 	unit-wopi-ownertermination.la unit-wopi-versionrestore.la \
 	unit-wopi-documentconflict.la unit_wopi_renamefile.la unit_wopi_watermark.la \
 	unit-tiff-load.la \
@@ -152,6 +153,8 @@ unit_oauth_la_SOURCES = UnitOAuth.cpp
 unit_oauth_la_LIBADD = $(CPPUNIT_LIBS)
 unit_wopi_la_SOURCES = UnitWOPI.cpp
 unit_wopi_la_LIBADD = $(CPPUNIT_LIBS)
+unit_wopi_async_upload_close_la_SOURCES = UnitWOPIAsyncUpload_Close.cpp
+unit_wopi_async_upload_close_la_LIBADD = $(CPPUNIT_LIBS)
 unit_wopi_saveas_la_SOURCES = UnitWOPISaveAs.cpp
 unit_wopi_saveas_la_LIBADD = $(CPPUNIT_LIBS)
 unit_wopi_ownertermination_la_SOURCES = UnitWopiOwnertermination.cpp
@@ -228,6 +231,7 @@ TESTS = \
 	unit-integration.la unit-httpws.la unit-crash.la \
 	unit-copy-paste.la unit-typing.la unit-convert.la unit-prefork.la unit-tilecache.la unit-timeout.la \
 	unit-oauth.la unit-wopi.la unit-wopi-saveas.la \
+	unit-wopi-async-upload-close.la \
 	unit-wopi-ownertermination.la unit-wopi-versionrestore.la \
 	unit-wopi-documentconflict.la unit_wopi_renamefile.la unit_wopi_watermark.la \
 	unit-http.la \

--- a/test/UnitWOPIAsyncUpload_Close.cpp
+++ b/test/UnitWOPIAsyncUpload_Close.cpp
@@ -1,0 +1,169 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <config.h>
+
+#include "HttpRequest.hpp"
+#include "Util.hpp"
+#include "lokassert.hpp"
+
+#include <WopiTestServer.hpp>
+#include <Log.hpp>
+#include <Unit.hpp>
+#include <UnitHTTP.hpp>
+#include <helpers.hpp>
+#include <Poco/Net/HTTPRequest.h>
+#include <Poco/Util/LayeredConfiguration.h>
+
+/// Test Async uploading with simulated failing.
+/// We modify the document, save, and attempt to upload,
+/// which fails. We close the document and verify
+/// that the document is uploaded upon closing.
+// Modify, Save, Upload fails, close -> Upload.
+class UnitWOPIAsyncUpload_Close : public WopiTestServer
+{
+    enum class Phase
+    {
+        Load,
+        WaitLoadStatus,
+        Modify,
+        WaitModifiedStatus,
+        WaitFirstPutFile,
+        Close,
+        WaitSecondPutFile,
+        Polling
+    } _phase;
+
+public:
+    UnitWOPIAsyncUpload_Close()
+        : WopiTestServer("UnitWOPIAsyncUpload_Close")
+        , _phase(Phase::Load)
+    {
+    }
+
+    std::unique_ptr<http::Response>
+    assertPutFileRequest(const Poco::Net::HTTPRequest& request) override
+    {
+        // We save twice. First right after loading, unmodified.
+        if (_phase == Phase::WaitFirstPutFile)
+        {
+            LOG_TST("assertPutFileRequest: First PutFile, which will fail");
+
+            LOG_TST("WaitFirstPutFile => Close");
+            _phase = Phase::Close;
+
+            LOK_ASSERT_EQUAL(std::string("true"), request.get("X-LOOL-WOPI-IsModifiedByUser"));
+
+            // We requested the save.
+            LOK_ASSERT_EQUAL(std::string("false"), request.get("X-LOOL-WOPI-IsAutosave"));
+
+            // Fail with error.
+            return Util::make_unique<http::Response>(http::StatusLine(404));
+        }
+
+        // This during closing the document.
+        LOG_TST("assertPutFileRequest: Second PutFile, which will succeed");
+        LOK_ASSERT_MESSAGE("Expected to be in Phase::WaitSecondPutFile",
+                           _phase == Phase::WaitSecondPutFile);
+
+        // the document is modified
+        LOK_ASSERT_EQUAL(std::string("true"), request.get("X-LOOL-WOPI-IsModifiedByUser"));
+
+        // Triggered while closing.
+        LOK_ASSERT_EQUAL(std::string("false"), request.get("X-LOOL-WOPI-IsAutosave"));
+
+        passTest("Document uploaded on closing as expected.");
+
+        return nullptr;
+    }
+
+    /// The document is loaded.
+    bool onDocumentLoaded(const std::string& message) override
+    {
+        LOG_TST("onDocumentLoaded: [" << message << ']');
+        LOK_ASSERT_MESSAGE("Expected to be in Phase::WaitLoadStatus",
+                           _phase == Phase::WaitLoadStatus);
+
+        LOG_TST("onDocumentModified: Switching to Phase::WaitLoadStatus, SavingPhase::Modify");
+        _phase = Phase::Modify;
+
+        SocketPoll::wakeupWorld();
+        return true;
+    }
+
+    /// The document is modified. Save it.
+    bool onDocumentModified(const std::string& message) override
+    {
+        LOG_TST("onDocumentModified: Doc (WaitModifiedStatus): [" << message << ']');
+        LOK_ASSERT_MESSAGE("Expected to be in Phase::WaitModified",
+                           _phase == Phase::WaitModifiedStatus);
+        {
+            LOG_TST("onDocumentModified: Switching to Phase::WaitModifiedStatus, "
+                    "SavingPhase::WaitFirstPutFile");
+            _phase = Phase::WaitFirstPutFile;
+
+            WSD_CMD("save dontTerminateEdit=0 dontSaveIfUnmodified=0 "
+                    "extendedData=CustomFlag%3DCustom%20Value%3BAnotherFlag%3DAnotherValue");
+
+            SocketPoll::wakeupWorld();
+        }
+
+        return true;
+    }
+
+    void invokeWSDTest() override
+    {
+        switch (_phase)
+        {
+            case Phase::Load:
+            {
+                LOG_TST("Load => WaitLoadStatus");
+                _phase = Phase::WaitLoadStatus;
+
+                LOG_TST("Load: initWebsocket.");
+                initWebsocket("/wopi/files/0?access_token=anything");
+
+                WSD_CMD("load url=" + getWopiSrc());
+                break;
+            }
+            case Phase::WaitLoadStatus:
+                break;
+            case Phase::Modify:
+            {
+                LOG_TST("Modify => WaitModified");
+                _phase = Phase::WaitModifiedStatus;
+
+                WSD_CMD("key type=input char=97 key=0");
+                WSD_CMD("key type=up char=0 key=512");
+                break;
+            }
+            case Phase::WaitModifiedStatus:
+                break;
+            case Phase::WaitFirstPutFile:
+                break;
+            case Phase::Close:
+            {
+                LOG_TST("Close => WaitSecondPutFile");
+                _phase = Phase::WaitSecondPutFile;
+
+                WSD_CMD("closedocument");
+                break;
+            }
+            case Phase::WaitSecondPutFile:
+                break;
+            case Phase::Polling:
+            {
+                // just wait for the results
+                break;
+            }
+        }
+    }
+};
+
+UnitBase* unit_create_wsd(void) { return new UnitWOPIAsyncUpload_Close(); }
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/test/UnitWOPIAsyncUpload_Modify.cpp
+++ b/test/UnitWOPIAsyncUpload_Modify.cpp
@@ -1,0 +1,171 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <config.h>
+
+#include "HttpRequest.hpp"
+#include "Util.hpp"
+#include "lokassert.hpp"
+
+#include <WopiTestServer.hpp>
+#include <Log.hpp>
+#include <Unit.hpp>
+#include <UnitHTTP.hpp>
+#include <helpers.hpp>
+#include <Poco/Net/HTTPRequest.h>
+#include <Poco/Util/LayeredConfiguration.h>
+
+/// Test Async uploading with simulated failing.
+/// We modify the document, save, and attempt to upload,
+/// which fails. We then modify the document again
+/// and save. We expect another upload attemp,
+/// which will succeed.
+/// Modify, Save, Upload fails, Modify, Save -> Upload.
+class UnitWOPIAsyncUpload_Modify : public WopiTestServer
+{
+    enum class Phase
+    {
+        Load,
+        WaitLoadStatus,
+        Modify,
+        WaitModifiedStatus,
+        WaitFirstPutFile,
+        Close,
+        WaitSecondPutFile,
+        Polling
+    } _phase;
+
+public:
+    UnitWOPIAsyncUpload_Modify()
+        : WopiTestServer("UnitWOPIAsyncUpload_Modify")
+        , _phase(Phase::Load)
+    {
+    }
+
+    std::unique_ptr<http::Response>
+    assertPutFileRequest(const Poco::Net::HTTPRequest& request) override
+    {
+        // We save twice. First right after loading, unmodified.
+        if (_phase == Phase::WaitFirstPutFile)
+        {
+            LOG_TST("assertPutFileRequest: First PutFile, which will fail");
+
+            LOG_TST("WaitFirstPutFile => Close");
+            _phase = Phase::Close;
+
+            LOK_ASSERT_EQUAL(std::string("true"), request.get("X-LOOL-WOPI-IsModifiedByUser"));
+
+            // We requested the save.
+            LOK_ASSERT_EQUAL(std::string("false"), request.get("X-LOOL-WOPI-IsAutosave"));
+
+            // Fail with error.
+            LOG_TST("assertPutFileRequest: returning 404 to simulate PutFile failure");
+            return Util::make_unique<http::Response>(http::StatusLine(404));
+        }
+
+        // This during closing the document.
+        LOG_TST("assertPutFileRequest: Second PutFile, which will succeed");
+        LOK_ASSERT_MESSAGE("Expected to be in Phase::WaitSecondPutFile",
+                           _phase == Phase::WaitSecondPutFile);
+
+        // the document is modified
+        LOK_ASSERT_EQUAL(std::string("true"), request.get("X-LOOL-WOPI-IsModifiedByUser"));
+
+        // Triggered while closing.
+        LOK_ASSERT_EQUAL(std::string("false"), request.get("X-LOOL-WOPI-IsAutosave"));
+
+        passTest("Document uploaded on closing as expected.");
+
+        return nullptr;
+    }
+
+    /// The document is loaded.
+    bool onDocumentLoaded(const std::string& message) override
+    {
+        LOG_TST("onDocumentLoaded: [" << message << ']');
+        LOK_ASSERT_MESSAGE("Expected to be in Phase::WaitLoadStatus",
+                           _phase == Phase::WaitLoadStatus);
+
+        LOG_TST("onDocumentModified: Switching to Phase::WaitLoadStatus, SavingPhase::Modify");
+        _phase = Phase::Modify;
+
+        SocketPoll::wakeupWorld();
+        return true;
+    }
+
+    /// The document is modified. Save it.
+    bool onDocumentModified(const std::string& message) override
+    {
+        LOG_TST("onDocumentModified: Doc (WaitModifiedStatus): [" << message << ']');
+        LOK_ASSERT_MESSAGE("Expected to be in Phase::WaitModified",
+                           _phase == Phase::WaitModifiedStatus);
+        {
+            LOG_TST("onDocumentModified: Switching to Phase::WaitModifiedStatus, "
+                    "SavingPhase::WaitFirstPutFile");
+            _phase = Phase::WaitFirstPutFile;
+
+            WSD_CMD("save dontTerminateEdit=0 dontSaveIfUnmodified=0 "
+                    "extendedData=CustomFlag%3DCustom%20Value%3BAnotherFlag%3DAnotherValue");
+
+            SocketPoll::wakeupWorld();
+        }
+
+        return true;
+    }
+
+    void invokeWSDTest() override
+    {
+        switch (_phase)
+        {
+            case Phase::Load:
+            {
+                LOG_TST("Load => WaitLoadStatus");
+                _phase = Phase::WaitLoadStatus;
+
+                LOG_TST("Load: initWebsocket.");
+                initWebsocket("/wopi/files/0?access_token=anything");
+
+                WSD_CMD("load url=" + getWopiSrc());
+                break;
+            }
+            case Phase::WaitLoadStatus:
+                break;
+            case Phase::Modify:
+            {
+                LOG_TST("Modify => WaitModified");
+                _phase = Phase::WaitModifiedStatus;
+
+                WSD_CMD("key type=input char=97 key=0");
+                WSD_CMD("key type=up char=0 key=512");
+                break;
+            }
+            case Phase::WaitModifiedStatus:
+                break;
+            case Phase::WaitFirstPutFile:
+                break;
+            case Phase::Close:
+            {
+                LOG_TST("Close => WaitSecondPutFile");
+                _phase = Phase::WaitSecondPutFile;
+
+                WSD_CMD("closedocument");
+                break;
+            }
+            case Phase::WaitSecondPutFile:
+                break;
+            case Phase::Polling:
+            {
+                // just wait for the results
+                break;
+            }
+        }
+    }
+};
+
+UnitBase* unit_create_wsd(void) { return new UnitWOPIAsyncUpload_Modify(); }
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/test/WopiTestServer.hpp
+++ b/test/WopiTestServer.hpp
@@ -263,7 +263,7 @@ protected:
             if (response)
             {
                 LOG_TST("Fake wopi host response to POST "
-                        << uriReq.getPath() << ": " << response->statusLine().statusCode()
+                        << uriReq.getPath() << ": " << response->statusLine().statusCode() << ' '
                         << response->statusLine().reasonPhrase());
                 socket->sendAndShutdown(*response);
             }

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -21,7 +21,6 @@
 
 #include "DocumentBroker.hpp"
 #include "LOOLWSD.hpp"
-#include "Storage.hpp"
 #include <common/Common.hpp>
 #include <common/Log.hpp>
 #include <common/Protocol.hpp>
@@ -1716,9 +1715,9 @@ bool ClientSession::handleKitToClientMessage(const char* buffer, const int lengt
             // Wopi post load actions
             if (_wopiFileInfo && !_wopiFileInfo->getTemplateSource().empty())
             {
-                std::string result;
-                LOG_DBG("Saving template [" << _wopiFileInfo->getTemplateSource() << "] to storage");
-                docBroker->uploadToStorage(getId(), true, result, /*force=*/false);
+                LOG_DBG("Uploading template [" << _wopiFileInfo->getTemplateSource()
+                                               << "] to storage after loading.");
+                docBroker->uploadAfterLoadingTemplate(getId());
             }
 
             for(auto &token : tokens)

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -791,9 +791,17 @@ bool ClientSession::_handleInput(const char *buffer, int length)
             sendTextFrameAndLogError("error: cmd=renamefile kind=syntax");
             return false;
         }
+
         std::string wopiFilename;
         Poco::URI::decode(encodedWopiFilename, wopiFilename);
-        docBroker->uploadAsToStorage(getId(), "", wopiFilename, true);
+        const std::string error =
+            docBroker->handleRenameFileCommand(getId(), std::move(wopiFilename));
+        if (!error.empty())
+        {
+            sendTextFrameAndLogError(error);
+            return false;
+        }
+
         return true;
     }
     else if (tokens.equals(0, "dialogevent") ||

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1151,9 +1151,8 @@ void DocumentBroker::uploadToStorageInternal(const std::string& sessionId, bool 
 
             case StorageBase::AsyncUpload::State::Complete:
             {
-                LOG_DBG("Successfully uploaded [" << _docKey << "], processing results.");
-                const StorageBase::UploadResult& uploadResult = asyncUp.result();
-                return handleUploadToStorageResponse(uploadResult);
+                LOG_DBG("Finished uploading [" << _docKey << "], processing results.");
+                return handleUploadToStorageResponse(asyncUp.result());
             }
 
             case StorageBase::AsyncUpload::State::None: // Unexpected: fallback.
@@ -1175,6 +1174,7 @@ void DocumentBroker::handleUploadToStorageResponse(const StorageBase::UploadResu
     if (!_uploadRequest)
     {
         // We shouldn't get here if there is no active upload request.
+        LOG_ERR("No active upload request while handling upload result.");
         return;
     }
 

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1090,7 +1090,6 @@ void DocumentBroker::uploadToStorageInternal(const std::string& sessionId, bool 
     }
 
     const bool isSaveAs = !saveAsPath.empty();
-    const Authorization auth = session->getAuthorization();
     const std::string uri = isSaveAs ? saveAsPath : session->getPublicUri().toString();
 
     // Map the FileId from the docKey to the new filename to anonymize the new filename as the FileId.
@@ -1155,8 +1154,9 @@ void DocumentBroker::uploadToStorageInternal(const std::string& sessionId, bool 
         LOG_ERR("Failed to upload [" << _docKey << "] asynchronously.");
     };
 
-    _storage->uploadLocalFileToStorageAsync(auth, session->getCookies(), *_lockCtx, saveAsPath,
-                                            saveAsFilename, isRename, *_poll, asyncUploadCallback);
+    _storage->uploadLocalFileToStorageAsync(session->getAuthorization(), session->getCookies(),
+                                            *_lockCtx, saveAsPath, saveAsFilename, isRename, *_poll,
+                                            asyncUploadCallback);
 }
 
 void DocumentBroker::handleUploadToStorageResponse(const StorageBase::UploadResult& uploadResult)

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -957,7 +957,7 @@ bool DocumentBroker::attemptLock(const ClientSession& session, std::string& fail
     return bResult;
 }
 
-bool DocumentBroker::needToUploadToStorage() const
+DocumentBroker::NeedToUpload DocumentBroker::needToUploadToStorage() const
 {
     // When destroying, we might have to force uploading if always_save_on_exit=true.
     if (isMarkedToDestroy())
@@ -967,8 +967,17 @@ bool DocumentBroker::needToUploadToStorage() const
         if (always_save)
         {
             LOG_INF("Need to upload per always_save_on_exit config (MarkedToDestroy=true).");
-            return true;
+            return NeedToUpload::Force;
         }
+    }
+
+    if (!_storageManager.lastUploadSuccessful())
+    {
+        //FIXME: Forcing is used when overwriting a 'document conflict' and
+        // for uploading when otherwise we might not have an immediate
+        // reason. We shouldn't use a single flag for both these uses.
+        LOG_INF("Enabling forced uploading to storage as last attempt had failed.");
+        return NeedToUpload::Force;
     }
 
     // Get the modified-time of the file on disk.
@@ -976,7 +985,10 @@ bool DocumentBroker::needToUploadToStorage() const
         = FileUtil::Stat(_storage->getRootFilePath()).modifiedTimepoint();
 
     // Compare to the last uploaded file's modified-time.
-    return currentModifiedTime != _storageManager.getLastUploadedFileModifiedTime();
+    if (currentModifiedTime != _storageManager.getLastUploadedFileModifiedTime())
+        return NeedToUpload::Yes; // Timestamp changed, upload.
+
+    return NeedToUpload::No; // No reason to upload, seems up-to-date.
 }
 
 void DocumentBroker::handleSaveResponse(const std::string& sessionId, bool success,
@@ -993,9 +1005,11 @@ void DocumentBroker::handleSaveResponse(const std::string& sessionId, bool succe
     _saveManager.setLastSaveResult(success || result == "unmodified");
 
     // See if we have anything to upload.
-    if (needToUploadToStorage())
+    NeedToUpload needToUploadState = needToUploadToStorage();
+    if (needToUploadState != NeedToUpload::No)
     {
-        uploadToStorage(sessionId, success, result, /*force=*/false);
+        uploadToStorage(sessionId, success, result,
+                        /*force=*/needToUploadState == NeedToUpload::Force);
     }
 }
 
@@ -1003,27 +1017,6 @@ void DocumentBroker::uploadToStorage(const std::string& sessionId, bool success,
                                      const std::string& result, bool force)
 {
     assertCorrectThread();
-
-    // Force saving on exit, if enabled.
-    if (!force)
-    {
-        static const bool always_save
-            = LOOLWSD::getConfigValue<bool>("per_document.always_save_on_exit", false);
-        if (isMarkedToDestroy() && always_save)
-        {
-            LOG_INF("Enabling forced uploading to storage per always_save_on_exit config.");
-            force = true;
-        }
-        else if (!_storageManager.lastUploadSuccessful())
-        {
-            //FIXME: Forcing is used when overwriting a 'document conflict' and
-            // for uploading when otherwise we might not have an immediate
-            // reason. We shouldn't use a single flag for both these uses.
-            // Also, we should use the file timestamp to decide when we upload.
-            LOG_INF("Enabling forced uploading to storage as last attempt had failed.");
-            force = true;
-        }
-    }
 
     if (force && _storage)
     {

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1341,7 +1341,7 @@ void DocumentBroker::uploadToStorageInternal(const std::string& sessionId, bool 
         }
 
         //FIXME: flag the failure so we retry.
-        LOG_ERR("Failed to upload [" << _docKey << "] asynchronously.");
+        LOG_WRN("Failed to upload [" << _docKey << "] asynchronously.");
 
         switch (_docState.activity())
         {

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1189,6 +1189,30 @@ void DocumentBroker::uploadAsToStorage(const std::string& sessionId,
                             /*force=*/false);
 }
 
+void DocumentBroker::uploadAfterLoadingTemplate(const std::string& sessionId)
+{
+#if !MOBILEAPP
+    // Create the 'upload' file as it gets created only when
+    // handling .uno:Save, which isn't issued for templates
+    // (save is done in Kit right after loading a template).
+    const std::string oldName = _storage->getRootFilePathToUpload();
+    const std::string newName = _storage->getRootFilePathUploading();
+    if (rename(oldName.c_str(), newName.c_str()) < 0)
+    {
+        // It's not an error if there was no file to rename, when the document isn't modified.
+        LOG_SYS("Expected to renamed the document [" << oldName << "] after template-loading to ["
+                                                     << newName << ']');
+    }
+    else
+    {
+        LOG_TRC("Renamed [" << oldName << "] to [" << newName << ']');
+    }
+#endif //!MOBILEAPP
+
+    std::string result;
+    uploadToStorage(sessionId, true, result, /*force=*/false);
+}
+
 void DocumentBroker::uploadToStorageInternal(const std::string& sessionId, bool success,
                                              const std::string& result,
                                              const std::string& saveAsPath,

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1005,6 +1005,7 @@ std::string DocumentBroker::handleRenameFileCommand(std::string sessionId,
 
 void DocumentBroker::startRenameFileCommand()
 {
+    LOG_TRC("Starting renamefile command execution.");
     if (_docState.activity() != DocumentState::Activity::None)
     {
         assert(!"Saving before renaming must be invoked when no other activity exists.");
@@ -1023,7 +1024,7 @@ void DocumentBroker::startRenameFileCommand()
 
     _docState.setActivity(DocumentState::Activity::Rename);
 
-    constexpr bool dontTerminateEdit = false;
+    constexpr bool dontTerminateEdit = false; // We will save, rename, and reload: terminate.
     constexpr bool dontSaveIfUnmodified = true;
     constexpr bool isAutosave = false;
     constexpr bool isExitSave = false;
@@ -1063,8 +1064,8 @@ DocumentBroker::NeedToUpload DocumentBroker::needToUploadToStorage() const
     }
 
     // Get the modified-time of the file on disk.
-    const std::chrono::system_clock::time_point currentModifiedTime
-        = FileUtil::Stat(_storage->getRootFilePath()).modifiedTimepoint();
+    const auto st = FileUtil::Stat(_storage->getRootFilePathUploading());
+    const std::chrono::system_clock::time_point currentModifiedTime = st.modifiedTimepoint();
 
     // Compare to the last uploaded file's modified-time.
     if (currentModifiedTime != _storageManager.getLastUploadedFileModifiedTime())
@@ -1082,6 +1083,23 @@ void DocumentBroker::handleSaveResponse(const std::string& sessionId, bool succe
         LOG_DBG("Save result from Core: saved");
     else
         LOG_INF("Save result from Core (failure): " << result);
+
+#if !MOBILEAPP
+    // Create the 'upload' file regardless of success or failure,
+    // because we don't know if the last upload worked or not.
+    // DocBroker will have to decide to upload or skip.
+    const std::string oldName = _storage->getRootFilePathToUpload();
+    const std::string newName = _storage->getRootFilePathUploading();
+    if (rename(oldName.c_str(), newName.c_str()) < 0)
+    {
+        // It's not an error if there was no file to rename, when the document isn't modified.
+        LOG_TRC("Failed to renamed [" << oldName << "] to [" << newName << ']');
+    }
+    else
+    {
+        LOG_TRC("Renamed [" << oldName << "] to [" << newName << ']');
+    }
+#endif //!MOBILEAPP
 
     // Record that we got a response to avoid timing out on saving.
     _saveManager.setLastSaveResult(success || result == "unmodified");
@@ -1236,8 +1254,9 @@ void DocumentBroker::uploadToStorageInternal(const std::string& sessionId, bool 
     const std::string uriAnonym = LOOLWSD::anonymizeUrl(uri);
 
     // If the file timestamp hasn't changed, skip uploading.
+    const std::string filePath = _storage->getRootFilePathUploading();
     const std::chrono::system_clock::time_point newFileModifiedTime
-        = FileUtil::Stat(_storage->getRootFilePath()).modifiedTimepoint();
+        = FileUtil::Stat(filePath).modifiedTimepoint();
     if (!isSaveAs && newFileModifiedTime == _saveManager.getLastModifiedTime() && !isRename
         && !force)
     {

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -32,6 +32,7 @@
 #include "Storage.hpp"
 #include "TileCache.hpp"
 #include "ProxyProtocol.hpp"
+#include "Util.hpp"
 #include <common/Log.hpp>
 #include <common/Message.hpp>
 #include <common/Clipboard.hpp>
@@ -1107,18 +1108,47 @@ void DocumentBroker::uploadToStorageInternal(const std::string& sessionId, bool 
         return;
     }
 
-    LOG_DBG("Persisting [" << _docKey << "] after saving to URI [" << uriAnonym << "].");
+    LOG_DBG("Uploading [" << _docKey << "] after saving to URI [" << uriAnonym << "].");
 
-    const StorageBase::UploadResult uploadResult = _storage->uploadLocalFileToStorage(
+    _uploadRequest = Util::make_unique<UploadRequest>(uriAnonym, newFileModifiedTime, it->second,
+                                                      isSaveAs, isRename);
+    const StorageBase::AsyncUpload asyncUp = _storage->uploadLocalFileToStorageAsync(
         auth, it->second->getCookies(), *_lockCtx, saveAsPath, saveAsFilename, isRename);
 
-    const StorageUploadDetails details { uriAnonym, newFileModifiedTime, it->second, isSaveAs, isRename };
-    handleUploadToStorageResponse(details, uploadResult);
+    switch (asyncUp.state())
+    {
+        case StorageBase::AsyncUpload::State::Running:
+            LOG_DBG("Async upload of [" << _docKey << "] is in progress.");
+            return;
+
+        case StorageBase::AsyncUpload::State::Success:
+        {
+            LOG_DBG("Successfully uploaded [" << _docKey << "], processing results.");
+            const StorageBase::UploadResult& uploadResult = asyncUp.result();
+            return handleUploadToStorageResponse(uploadResult);
+        }
+
+        case StorageBase::AsyncUpload::State::None: // Unexpected: fallback.
+        case StorageBase::AsyncUpload::State::Error:
+        default:
+            break;
+    }
+
+    LOG_ERR("Failed to upload [" << _docKey
+                                 << "] asynchronously, will fallback to synchronous uploading.");
+    const StorageBase::UploadResult& uploadResult = _storage->uploadLocalFileToStorage(
+        auth, it->second->getCookies(), *_lockCtx, saveAsPath, saveAsFilename, isRename);
+    return handleUploadToStorageResponse(uploadResult);
 }
 
-void DocumentBroker::handleUploadToStorageResponse(const StorageUploadDetails& details,
-                                                   const StorageBase::UploadResult& uploadResult)
+void DocumentBroker::handleUploadToStorageResponse(const StorageBase::UploadResult& uploadResult)
 {
+    if (!_uploadRequest)
+    {
+        // We shouldn't get here if there is no active upload request.
+        return;
+    }
+
     // Storage save is considered successful when either storage returns OK or the document on the storage
     // was changed and it was used to overwrite local changes
     _storageManager.setLastUploadResult(
@@ -1133,29 +1163,29 @@ void DocumentBroker::handleUploadToStorageResponse(const StorageUploadDetails& d
             Admin::instance().setDocWopiUploadDuration(_docKey, std::chrono::duration_cast<std::chrono::milliseconds>(wopiStorage->getWopiSaveDuration()));
 #endif
 
-        if (!details.isSaveAs && !details.isRename)
+        if (!_uploadRequest->isSaveAs() && !_uploadRequest->isRename())
         {
             // Saved and stored; update flags.
-            _saveManager.setLastModifiedTime(details.newFileModifiedTime);
+            _saveManager.setLastModifiedTime(_uploadRequest->newFileModifiedTime());
             _storageManager.markLastUploadTime();
 
             // Save the storage timestamp.
             _storageManager.setLastModifiedTime(_storage->getFileInfo().getModifiedTime());
 
             // Set the timestamp of the file we uploaded, to detect changes.
-            _storageManager.setLastUploadedFileModifiedTime(details.newFileModifiedTime);
+            _storageManager.setLastUploadedFileModifiedTime(_uploadRequest->newFileModifiedTime());
 
             // After a successful save, we are sure that document in the storage is same as ours
             _documentChangedInStorage = false;
 
-            LOG_DBG("Uploaded docKey [" << _docKey << "] to URI [" << details.uriAnonym
+            LOG_DBG("Uploaded docKey [" << _docKey << "] to URI [" << _uploadRequest->uriAnonym()
                                         << "] and updated timestamps. Document modified timestamp: "
                                         << _storageManager.getLastModifiedTime());
 
             // Resume polling.
             _poll->wakeup();
         }
-        else if (details.isRename)
+        else if (_uploadRequest->isRename())
         {
             // encode the name
             const std::string& filename = uploadResult.getSaveAsName();
@@ -1180,7 +1210,7 @@ void DocumentBroker::handleUploadToStorageResponse(const StorageUploadDetails& d
             Poco::URI::encode(filename, "", encodedName);
             const std::string filenameAnonym = LOOLWSD::anonymizeUrl(filename);
 
-            const auto session = details.session.lock();
+            const auto session = _uploadRequest->session();
             if (session)
             {
                 LOG_DBG("Uploaded SaveAs docKey [" << _docKey << "] to URI ["
@@ -1207,7 +1237,7 @@ void DocumentBroker::handleUploadToStorageResponse(const StorageUploadDetails& d
     else if (uploadResult.getResult() == StorageBase::UploadResult::Result::DISKFULL)
     {
         LOG_WRN("Disk full while uploading docKey ["
-                << _docKey << "] to URI [" << details.uriAnonym
+                << _docKey << "] to URI [" << _uploadRequest->uriAnonym()
                 << "]. Making all sessions on doc read-only and notifying clients.");
 
         // Make everyone readonly and tell everyone that storage is low on diskspace.
@@ -1220,18 +1250,18 @@ void DocumentBroker::handleUploadToStorageResponse(const StorageUploadDetails& d
     }
     else if (uploadResult.getResult() == StorageBase::UploadResult::Result::UNAUTHORIZED)
     {
-        const auto session = details.session.lock();
+        const auto session = _uploadRequest->session();
         if (session)
         {
             LOG_ERR("Cannot upload docKey ["
-                    << _docKey << "] to storage URI [" << details.uriAnonym
+                    << _docKey << "] to storage URI [" << _uploadRequest->uriAnonym()
                     << "]. Invalid or expired access token. Notifying client.");
             session->sendTextFrameAndLogError("error: cmd=storage kind=saveunauthorized");
         }
         else
         {
             LOG_ERR("Cannot upload docKey ["
-                    << _docKey << "] to storage URI [" << details.uriAnonym
+                    << _docKey << "] to storage URI [" << _uploadRequest->uriAnonym()
                     << "]. Invalid or expired access token. The client session is closed.");
         }
 
@@ -1240,18 +1270,18 @@ void DocumentBroker::handleUploadToStorageResponse(const StorageUploadDetails& d
     else if (uploadResult.getResult() == StorageBase::UploadResult::Result::FAILED)
     {
         //TODO: Should we notify all clients?
-        const auto session = details.session.lock();
+        const auto session = _uploadRequest->session();
         if (session)
         {
-            LOG_ERR("Failed to upload docKey [" << _docKey << "] to URI [" << details.uriAnonym
+            LOG_ERR("Failed to upload docKey [" << _docKey << "] to URI [" << _uploadRequest->uriAnonym()
                                                 << "]. Notifying client.");
             const std::string msg = std::string("error: cmd=storage kind=")
-                                    + (details.isRename ? "renamefailed" : "savefailed");
+                                    + (_uploadRequest->isRename() ? "renamefailed" : "savefailed");
             session->sendTextFrame(msg);
         }
         else
         {
-            LOG_ERR("Failed to upload docKey [" << _docKey << "] to URI [" << details.uriAnonym
+            LOG_ERR("Failed to upload docKey [" << _docKey << "] to URI [" << _uploadRequest->uriAnonym()
                                                 << "]. The client session is closed.");
         }
 

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1075,10 +1075,11 @@ void DocumentBroker::uploadToStorageInternal(const std::string& sessionId, bool 
     }
 
     // Check that we are actually about to upload a successfully saved document.
+    auto session = it->second;
     if (!success && !force)
     {
         LOG_ERR("Cannot store docKey [" << _docKey << "] as .uno:Save has failed in LOK.");
-        it->second->sendTextFrameAndLogError("error: cmd=storage kind=savefailed");
+        session->sendTextFrameAndLogError("error: cmd=storage kind=savefailed");
         broadcastSaveResult(false, "Could not save document in LibreOfficeKit");
         return;
     }
@@ -1089,8 +1090,8 @@ void DocumentBroker::uploadToStorageInternal(const std::string& sessionId, bool 
     }
 
     const bool isSaveAs = !saveAsPath.empty();
-    const Authorization auth = it->second->getAuthorization();
-    const std::string uri = isSaveAs ? saveAsPath : it->second->getPublicUri().toString();
+    const Authorization auth = session->getAuthorization();
+    const std::string uri = isSaveAs ? saveAsPath : session->getPublicUri().toString();
 
     // Map the FileId from the docKey to the new filename to anonymize the new filename as the FileId.
     const std::string newFilename = Util::getFilenameFromURL(uri);
@@ -1125,7 +1126,7 @@ void DocumentBroker::uploadToStorageInternal(const std::string& sessionId, bool 
 
     LOG_DBG("Uploading [" << _docKey << "] after saving to URI [" << uriAnonym << "].");
 
-    _uploadRequest = Util::make_unique<UploadRequest>(uriAnonym, newFileModifiedTime, it->second,
+    _uploadRequest = Util::make_unique<UploadRequest>(uriAnonym, newFileModifiedTime, session,
                                                       isSaveAs, isRename);
 
     StorageBase::AsyncUploadCallback asyncUploadCallback =
@@ -1154,7 +1155,7 @@ void DocumentBroker::uploadToStorageInternal(const std::string& sessionId, bool 
         LOG_ERR("Failed to upload [" << _docKey << "] asynchronously.");
     };
 
-    _storage->uploadLocalFileToStorageAsync(auth, it->second->getCookies(), *_lockCtx, saveAsPath,
+    _storage->uploadLocalFileToStorageAsync(auth, session->getCookies(), *_lockCtx, saveAsPath,
                                             saveAsFilename, isRename, *_poll, asyncUploadCallback);
 }
 

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -954,6 +954,28 @@ bool DocumentBroker::attemptLock(const ClientSession& session, std::string& fail
     return bResult;
 }
 
+bool DocumentBroker::needToUploadToStorage() const
+{
+    // When destroying, we might have to force uploading if always_save_on_exit=true.
+    if (isMarkedToDestroy())
+    {
+        static const bool always_save
+            = LOOLWSD::getConfigValue<bool>("per_document.always_save_on_exit", false);
+        if (always_save)
+        {
+            LOG_INF("Need to upload per always_save_on_exit config (MarkedToDestroy=true).");
+            return true;
+        }
+    }
+
+    // Get the modified-time of the file on disk.
+    const std::chrono::system_clock::time_point currentModifiedTime
+        = FileUtil::Stat(_storage->getRootFilePath()).modifiedTimepoint();
+
+    // Compare to the last uploaded file's modified-time.
+    return currentModifiedTime != _storageManager.getLastUploadedFileModifiedTime();
+}
+
 void DocumentBroker::handleSaveResponse(const std::string& sessionId, bool success,
                                         const std::string& result)
 {
@@ -967,7 +989,11 @@ void DocumentBroker::handleSaveResponse(const std::string& sessionId, bool succe
     // Record that we got a response to avoid timing out on saving.
     _saveManager.setLastSaveResult(success || result == "unmodified");
 
-    uploadToStorage(sessionId, success, result, /*force=*/false);
+    // See if we have anything to upload.
+    if (needToUploadToStorage())
+    {
+        uploadToStorage(sessionId, success, result, /*force=*/false);
+    }
 }
 
 void DocumentBroker::uploadToStorage(const std::string& sessionId, bool success,

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1016,13 +1016,6 @@ std::string DocumentBroker::handleRenameFileCommand(std::string sessionId,
 void DocumentBroker::startRenameFileCommand()
 {
     LOG_TRC("Starting renamefile command execution.");
-    if (_docState.activity() != DocumentState::Activity::None)
-    {
-        assert(!"Saving before renaming must be invoked when no other activity exists.");
-        LOG_DBG("Error: Trying to saveBeforeRename while "
-                << DocumentState::toString(_docState.activity()));
-        return;
-    }
 
     if (_renameSessionId.empty() || _renameFilename.empty())
     {
@@ -1032,13 +1025,31 @@ void DocumentBroker::startRenameFileCommand()
         return;
     }
 
-    _docState.setActivity(DocumentState::Activity::Rename);
+    // Transition.
+    if (!startActivity(DocumentState::Activity::Rename))
+    {
+        return;
+    }
+
+    blockUI("rename"); // Prevent user interaction while we start renaming.
 
     constexpr bool dontTerminateEdit = false; // We will save, rename, and reload: terminate.
     constexpr bool dontSaveIfUnmodified = true;
     constexpr bool isAutosave = false;
     constexpr bool isExitSave = false;
     sendUnoSave(_renameSessionId, dontTerminateEdit, dontSaveIfUnmodified, isAutosave, isExitSave);
+}
+
+void DocumentBroker::endRenameFileCommand()
+{
+    LOG_TRC("Ending renamefile command execution.");
+
+    _renameSessionId.clear();
+    _renameFilename.clear();
+
+    unblockUI();
+
+    endActivity();
 }
 
 bool DocumentBroker::attemptLock(const ClientSession& session, std::string& failReason)
@@ -1133,9 +1144,7 @@ void DocumentBroker::handleSaveResponse(const std::string& sessionId, bool succe
                 constexpr bool isRename = true;
                 uploadAsToStorage(_renameSessionId, uploadAsPath, _renameFilename, isRename);
 
-                _docState.setActivity(DocumentState::Activity::None); // We are done.
-                _renameSessionId.clear();
-                _renameFilename.clear();
+                endRenameFileCommand();
                 return;
             }
         }
@@ -1342,12 +1351,12 @@ void DocumentBroker::uploadToStorageInternal(const std::string& sessionId, bool 
             case DocumentState::Activity::Rename:
             {
                 LOG_DBG("Failed to renameFile because uploading post-save failed.");
-                _docState.setActivity(DocumentState::Activity::None);
-                _renameFilename.clear();
-                auto pair = _sessions.find(_renameSessionId);
+                const std::string renameSessionId = _renameSessionId;
+                endRenameFileCommand();
+
+                auto pair = _sessions.find(renameSessionId);
                 if (pair != _sessions.end() && pair->second)
                     pair->second->sendTextFrameAndLogError("error: cmd=renamefile kind=failed");
-                _renameSessionId.clear();
             }
             break;
 
@@ -1420,9 +1429,7 @@ void DocumentBroker::handleUploadToStorageResponse(const StorageBase::UploadResu
                     constexpr bool isRename = true;
                     uploadAsToStorage(_renameSessionId, uploadAsPath, _renameFilename, isRename);
 
-                    _docState.setActivity(DocumentState::Activity::None); // We are done.
-                    _renameSessionId.clear();
-                    _renameFilename.clear();
+                    endRenameFileCommand();
                 }
                 break;
 

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1031,13 +1031,6 @@ void DocumentBroker::uploadToStorage(const std::string& sessionId, bool success,
     const auto it = _sessions.find(sessionId);
     if (_docState.isMarkedToDestroy() || (it != _sessions.end() && it->second->isCloseFrame()))
         disconnectSessionInternal(sessionId);
-
-    // If marked to destroy, then this was the last session.
-    if (_docState.isMarkedToDestroy() || _sessions.empty())
-    {
-        // Stop so we get cleaned up and removed.
-        _stop = true;
-    }
 }
 
 void DocumentBroker::uploadAsToStorage(const std::string& sessionId,
@@ -1259,6 +1252,17 @@ void DocumentBroker::handleUploadToStorageResponse(const StorageBase::UploadResu
         }
 
         broadcastLastModificationTime();
+
+        // If marked to destroy, then this was the last session.
+        if (_docState.isMarkedToDestroy() || _sessions.empty())
+        {
+            // Stop so we get cleaned up and removed.
+            LOG_DBG("Stopping after uploading because "
+                    << (_sessions.empty() ? "there are no active sessions left."
+                                          : "the document is marked to destroy."));
+            _stop = true;
+        }
+
         return;
     }
     else if (uploadResult.getResult() == StorageBase::UploadResult::Result::DISKFULL)

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -13,6 +13,7 @@
 #include <cassert>
 #include <chrono>
 #include <ctime>
+#include <ios>
 #include <fstream>
 #include <sstream>
 
@@ -384,6 +385,24 @@ void DocumentBroker::pollThread()
         if (_storage && _lockCtx->needsRefresh(now))
             refreshLock();
 #endif
+
+        switch (_docState.activity())
+        {
+            case DocumentState::Activity::None:
+            {
+                // Check if there are queued activities.
+                if (!_renameFilename.empty() && !_renameSessionId.empty())
+                {
+                    startRenameFileCommand();
+                    // Nothing more to do until the save is complete.
+                    continue;
+                }
+            }
+            break;
+
+            default:
+                break;
+        }
 
         //TODO: Review if we need this here.
         if (_saveManager.isSaving() && !_saveManager.hasSavingTimedOut())
@@ -948,6 +967,59 @@ bool DocumentBroker::download(const std::shared_ptr<ClientSession>& session, con
     return true;
 }
 
+std::string DocumentBroker::handleRenameFileCommand(std::string sessionId,
+                                                    std::string newFilename)
+{
+    if (newFilename.empty())
+        return "error: cmd=renamefile kind=invalid"; //TODO: better filename validation.
+
+    if (_docState.activity() == DocumentState::Activity::Rename)
+    {
+        if (_renameFilename == newFilename)
+            return std::string(); // Nothing to do, it's a duplicate.
+        else
+            return "error: cmd=renamefile kind=conflict"; // Renaming in progress.
+    }
+
+    _renameFilename = std::move(newFilename);
+    _renameSessionId = std::move(sessionId);
+
+    if (_docState.activity() == DocumentState::Activity::None)
+    {
+        // We can start by saving now.
+        startRenameFileCommand();
+    }
+
+    return std::string();
+}
+
+void DocumentBroker::startRenameFileCommand()
+{
+    if (_docState.activity() != DocumentState::Activity::None)
+    {
+        assert(!"Saving before renaming must be invoked when no other activity exists.");
+        LOG_DBG("Error: Trying to saveBeforeRename while "
+                << DocumentState::toString(_docState.activity()));
+        return;
+    }
+
+    if (_renameSessionId.empty() || _renameFilename.empty())
+    {
+        assert(!"Saving before renaming without valid filename or sessionId.");
+        LOG_DBG("Error: Trying to saveBeforeRename with invalid filename ["
+                << _renameFilename << "] and/or sessionId [" << _renameSessionId << "]");
+        return;
+    }
+
+    _docState.setActivity(DocumentState::Activity::Rename);
+
+    constexpr bool dontTerminateEdit = false;
+    constexpr bool dontSaveIfUnmodified = true;
+    constexpr bool isAutosave = false;
+    constexpr bool isExitSave = false;
+    sendUnoSave(_renameSessionId, dontTerminateEdit, dontSaveIfUnmodified, isAutosave, isExitSave);
+}
+
 bool DocumentBroker::attemptLock(const ClientSession& session, std::string& failReason)
 {
     const bool bResult = _storage->updateLockState(session.getAuthorization(), session.getCookies(),
@@ -1006,10 +1078,56 @@ void DocumentBroker::handleSaveResponse(const std::string& sessionId, bool succe
 
     // See if we have anything to upload.
     NeedToUpload needToUploadState = needToUploadToStorage();
+
+    // Handle activity-specific logic.
+    switch (_docState.activity())
+    {
+        case DocumentState::Activity::None:
+            break;
+
+        case DocumentState::Activity::Rename:
+        {
+            // If we have nothing to upload, do the rename now.
+            if (needToUploadState == NeedToUpload::No)
+            {
+                LOG_DBG("Renaming in storage as there is no new version to upload first.");
+                std::string uploadAsPath;
+                constexpr bool isRename = true;
+                uploadAsToStorage(_renameSessionId, uploadAsPath, _renameFilename, isRename);
+
+                _docState.setActivity(DocumentState::Activity::None); // We are done.
+                _renameSessionId.clear();
+                _renameFilename.clear();
+                return;
+            }
+        }
+        break;
+
+        default:
+        break;
+    }
+
     if (needToUploadState != NeedToUpload::No)
     {
         uploadToStorage(sessionId, success, result,
                         /*force=*/needToUploadState == NeedToUpload::Force);
+    }
+    else
+    {
+        // If the session is disconnected, remove.
+        const auto it = _sessions.find(sessionId);
+        if (it != _sessions.end() && it->second->isCloseFrame())
+            disconnectSessionInternal(sessionId);
+
+        // If marked to destroy, then this was the last session.
+        if (_docState.isMarkedToDestroy() || _sessions.empty())
+        {
+            // Stop so we get cleaned up and removed.
+            LOG_DBG("Stopping after saving because "
+                    << (_sessions.empty() ? "there are no active sessions left."
+                                          : "the document is marked to destroy."));
+            _stop = true;
+        }
     }
 }
 
@@ -1152,6 +1270,27 @@ void DocumentBroker::uploadToStorageInternal(const std::string& sessionId, bool 
 
         //FIXME: flag the failure so we retry.
         LOG_ERR("Failed to upload [" << _docKey << "] asynchronously.");
+
+        switch (_docState.activity())
+        {
+            case DocumentState::Activity::None:
+                break;
+
+            case DocumentState::Activity::Rename:
+            {
+                LOG_DBG("Failed to renameFile because uploading post-save failed.");
+                _docState.setActivity(DocumentState::Activity::None);
+                _renameFilename.clear();
+                auto pair = _sessions.find(_renameSessionId);
+                if (pair != _sessions.end() && pair->second)
+                    pair->second->sendTextFrameAndLogError("error: cmd=renamefile kind=failed");
+                _renameSessionId.clear();
+            }
+            break;
+
+            default:
+                break;
+        }
     };
 
     _storage->uploadLocalFileToStorageAsync(session->getAuthorization(), session->getCookies(),
@@ -1199,9 +1338,34 @@ void DocumentBroker::handleUploadToStorageResponse(const StorageBase::UploadResu
             // After a successful save, we are sure that document in the storage is same as ours
             _documentChangedInStorage = false;
 
-            LOG_DBG("Uploaded docKey [" << _docKey << "] to URI [" << _uploadRequest->uriAnonym()
-                                        << "] and updated timestamps. Document modified timestamp: "
-                                        << _storageManager.getLastModifiedTime());
+            LOG_DBG("Uploaded docKey ["
+                    << _docKey << "] to URI [" << _uploadRequest->uriAnonym()
+                    << "] and updated timestamps. Document modified timestamp: "
+                    << _storageManager.getLastModifiedTime()
+                    << ". Current Activity: " << DocumentState::toString(_docState.activity()));
+
+            // Handle activity-specific logic.
+            switch (_docState.activity())
+            {
+                case DocumentState::Activity::None:
+                    break;
+
+                case DocumentState::Activity::Rename:
+                {
+                    LOG_DBG("Renaming in storage after uploading the last saved version.");
+                    std::string uploadAsPath;
+                    constexpr bool isRename = true;
+                    uploadAsToStorage(_renameSessionId, uploadAsPath, _renameFilename, isRename);
+
+                    _docState.setActivity(DocumentState::Activity::None); // We are done.
+                    _renameSessionId.clear();
+                    _renameFilename.clear();
+                }
+                break;
+
+                default:
+                    break;
+            }
 
             // Resume polling.
             _poll->wakeup();
@@ -2731,6 +2895,10 @@ void DocumentBroker::dumpState(std::ostream& os)
     os << "\n  doc id: " << _docId;
     os << "\n  num sessions: " << _sessions.size();
     os << "\n  thread start: " << Util::getSteadyClockAsString(_threadStart);
+    os << "\n  doc state: " << DocumentState::toString(_docState.status());
+    os << "\n  doc activity: " << DocumentState::toString(_docState.activity());
+    if (_docState.activity() == DocumentState::Activity::Rename)
+        os << "\n  (new name: " << _renameFilename << ')';
     os << "\n  last saved: " << Util::getSteadyClockAsString(_storageManager.getLastUploadTime());
     os << "\n  last save request: "
        << Util::getSteadyClockAsString(_saveManager.lastSaveRequestTime());
@@ -2739,6 +2907,7 @@ void DocumentBroker::dumpState(std::ostream& os)
     os << "\n  last storage save was successful: " << isLastStorageUploadSuccessful();
     os << "\n  last modified: " << Util::getHttpTime(_storageManager.getLastModifiedTime());
     os << "\n  file last modified: " << Util::getHttpTime(_saveManager.getLastModifiedTime());
+    os << "\n  isSaving now: " << std::boolalpha << _saveManager.isSaving();
     if (_limitLifeSeconds > std::chrono::seconds::zero())
         os << "\n  life limit in seconds: " << _limitLifeSeconds.count();
     os << "\n  idle time: " << getIdleTimeSecs();

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -433,14 +433,16 @@ void DocumentBroker::pollThread()
 
 #if !MOBILEAPP
         if (std::chrono::duration_cast<std::chrono::minutes>(now - lastClipboardHashUpdateTime).count() >= 2)
-        for (auto &it : _sessions)
         {
-            if (it.second->staleWaitDisconnect(now))
+            for (auto &it : _sessions)
             {
-                std::string id = it.second->getId();
-                LOG_WRN("Unusual, Kit session " + id + " failed its disconnect handshake, killing");
-                finalRemoveSession(id);
-                break; // it invalid.
+                if (it.second->staleWaitDisconnect(now))
+                {
+                    std::string id = it.second->getId();
+                    LOG_WRN("Unusual, Kit session " + id + " failed its disconnect handshake, killing");
+                    finalRemoveSession(id);
+                    break; // it invalid.
+                }
             }
         }
 
@@ -469,8 +471,9 @@ void DocumentBroker::pollThread()
                 }
             }
         }
+        else
 #endif
-        else if (_sessions.empty() && (isLoaded() || _docState.isMarkedToDestroy()))
+        if (_sessions.empty() && (isLoaded() || _docState.isMarkedToDestroy()))
         {
             // If all sessions have been removed, no reason to linger.
             LOG_INF("Terminating dead DocumentBroker for docKey [" << getDocKey() << "].");

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -471,6 +471,10 @@ private:
     /// with the child and cleans up ChildProcess etc.
     void terminateChild(const std::string& closeReason);
 
+    /// Returns true iff the Document in Storage is
+    /// out-of-date and we must upload the last file on disk.
+    bool needToUploadToStorage() const;
+
     /// Upload the doc to the storage.
     void uploadToStorageInternal(const std::string& sesionId, bool success,
                                  const std::string& result, const std::string& saveAsPath,

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -311,6 +311,11 @@ public:
     void uploadAsToStorage(const std::string& sessionId, const std::string& uploadAsPath,
                            const std::string& uploadAsFilename, const bool isRename);
 
+    /// Uploads the document right after loading from a template.
+    /// Template-loading requires special handling because the
+    /// document changes once loaded into a non-template format.
+    void uploadAfterLoadingTemplate(const std::string& sessionId);
+
     bool isModified() const { return _isModified; }
     void setModified(const bool value);
 

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -489,6 +489,7 @@ private:
                                  const std::string& saveAsFilename, const bool isRename,
                                  const bool force);
 
+    /// Handles the completion of uploading to storage, both success and failure cases.
     void handleUploadToStorageResponse(const StorageBase::UploadResult& uploadResult);
 
     /**

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -471,9 +471,17 @@ private:
     /// with the child and cleans up ChildProcess etc.
     void terminateChild(const std::string& closeReason);
 
+    /// Encodes whether or not uploading is needed.
+    enum class NeedToUpload
+    {
+        No, //< No need to upload, data up-to-date.
+        Yes, //< Data is out of date.
+        Force //< Force uploading, typically because always_save_on_exit is set.
+    };
+
     /// Returns true iff the Document in Storage is
     /// out-of-date and we must upload the last file on disk.
-    bool needToUploadToStorage() const;
+    NeedToUpload needToUploadToStorage() const;
 
     /// Upload the doc to the storage.
     void uploadToStorageInternal(const std::string& sesionId, bool success,

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -293,6 +293,10 @@ public:
 
     bool isLastStorageUploadSuccessful() { return _storageManager.lastUploadSuccessful(); }
 
+    /// Invoked by the client to rename the document filename.
+    /// Returns an error message in case of failure, otherwise an empty string.
+    std::string handleRenameFileCommand(std::string sessionId, std::string newFilename);
+
     /// Handle the save response from Core and upload to storage as necessary.
     /// Also notifies clients of the result.
     void handleSaveResponse(const std::string& sessionId, bool success, const std::string& result);
@@ -463,6 +467,9 @@ private:
     void handleDialogPaintResponse(const std::vector<char>& payload, bool child);
     void handleTileCombinedResponse(const std::vector<char>& payload);
     void handleDialogRequest(const std::string& dialogCmd);
+
+    /// Invoked to issue a save before renaming the document filename.
+    void startRenameFileCommand();
 
     /// Shutdown all client connections with the given reason.
     void shutdownClients(const std::string& closeReason);
@@ -1017,6 +1024,8 @@ private:
     std::atomic<bool> _stop;
     std::string _closeReason;
     std::unique_ptr<LockContext> _lockCtx;
+    std::string _renameFilename; //< The new filename to rename to.
+    std::string _renameSessionId; //< The sessionId used for renaming.
 
     /// Versioning is used to prevent races between
     /// painting and invalidation.

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -655,7 +655,8 @@ private:
     {
     public:
         SaveManager()
-            : _lastAutosaveCheckTime(RequestManager::now())
+            : _autosaveInterval(std::chrono::seconds(30))
+            , _lastAutosaveCheckTime(RequestManager::now())
             , _isAutosaveEnabled(std::getenv("LOOL_NO_AUTOSAVE") == nullptr)
         {
         }
@@ -669,11 +670,29 @@ private:
             return isAutosaveEnabled()
                    && std::chrono::duration_cast<std::chrono::seconds>(RequestManager::now()
                                                                        - _lastAutosaveCheckTime)
-                          >= std::chrono::seconds(30);
+                          >= _autosaveInterval;
         }
 
         /// Marks autosave check done.
         void autosaveChecked() { _lastAutosaveCheckTime = RequestManager::now(); }
+
+        /// Called to postpone autosaving by at least the given duration.
+        void postponeAutosave(std::chrono::seconds seconds)
+        {
+            const auto now = RequestManager::now();
+
+            const auto nextAutosaveCheck = _lastAutosaveCheckTime + _autosaveInterval;
+            const auto postponeTime = now + seconds;
+            if (nextAutosaveCheck < postponeTime)
+            {
+                // Next autosave check will happen before the desired time.
+                // Let's postpone it by the difference.
+                const auto delay = postponeTime - nextAutosaveCheck;
+                _lastAutosaveCheckTime += delay;
+                LOG_TRC("Autosave check postponed by "
+                        << std::chrono::duration_cast<std::chrono::milliseconds>(delay));
+            }
+        }
 
         /// Marks the last save request as now.
         void markLastSaveRequestTime() { _request.markLastRequestTime(); }
@@ -732,6 +751,9 @@ private:
     private:
         /// Request tracking logic.
         RequestManager _request;
+
+        /// The number of seconds between autosave checks for modification.
+        const std::chrono::seconds _autosaveInterval;
 
         /// The last autosave check time.
         std::chrono::steady_clock::time_point _lastAutosaveCheckTime;

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -1149,7 +1149,7 @@ void WopiStorage::uploadLocalFileToStorageAsync(const Authorization& auth,
     //TODO: replace with state machine.
     if (_uploadHttpSession)
     {
-        LOG_ERR("Upload is already in progress.");
+        LOG_WRN("Upload is already in progress.");
         return;
     }
 

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -429,8 +429,8 @@ StorageBase::UploadResult LocalStorage::uploadLocalFileToStorage(
                                                                      << getRootFilePathAnonym());
 
         // Copy the file back.
-        if (_isCopy && Poco::File(getRootFilePath()).exists())
-            FileUtil::copyFileTo(getRootFilePath(), path);
+        if (_isCopy && Poco::File(getRootFilePathUploading()).exists())
+            FileUtil::copyFileTo(getRootFilePathUploading(), path);
 
         // update its fileinfo object. This is used later to check if someone else changed the
         // document while we are/were editing it
@@ -1154,7 +1154,7 @@ void WopiStorage::uploadLocalFileToStorageAsync(const Authorization& auth,
     }
 
     const bool isSaveAs = !saveAsPath.empty() && !saveAsFilename.empty();
-    const std::string filePath(isSaveAs ? saveAsPath : getRootFilePath());
+    const std::string filePath(isSaveAs ? saveAsPath : getRootFilePathUploading());
     const std::string filePathAnonym = LOOLWSD::anonymizeUrl(filePath);
 
     const FileUtil::Stat fileStat(filePath);

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -165,7 +165,7 @@ public:
             Complete //< The last async upload request completed (regardless of the server's response).
         };
 
-        AsyncUpload(State state, UploadResult result = UploadResult(UploadResult::Result::FAILED))
+        AsyncUpload(State state, UploadResult result)
             : _state(state)
             , _result(std::move(result))
         {
@@ -178,7 +178,7 @@ public:
         const UploadResult& result() const { return _result; }
 
     private:
-        const State _state;
+        State _state;
         UploadResult _result;
     };
 
@@ -280,25 +280,32 @@ public:
                              const std::string& saveAsFilename, const bool isRename)
         = 0;
 
+    /// The asynchronous upload completion callback function.
+    using AsyncUploadCallback = std::function<void(const AsyncUpload&)>;
+
     /// Writes the contents of the file back to the source asynchronously, if possible.
     /// @param cookies A string representing key=value pairs that are set as cookies.
     /// @param savedFile When the operation was saveAs, this is the path to the file that was saved.
-    virtual AsyncUpload
-    uploadLocalFileToStorageAsync(const Authorization& auth, const std::string& cookies,
-                                  LockContext& lockCtx, const std::string& saveAsPath,
-                                  const std::string& saveAsFilename, const bool isRename)
+    /// @param asyncUploadCallback Used to communicate the result back to the caller.
+    virtual void uploadLocalFileToStorageAsync(const Authorization& auth,
+                                               const std::string& cookies, LockContext& lockCtx,
+                                               const std::string& saveAsPath,
+                                               const std::string& saveAsFilename,
+                                               const bool isRename, SocketPoll&,
+                                               const AsyncUploadCallback& asyncUploadCallback)
     {
         // By default do a synchronous save.
-        const UploadResult res = uploadLocalFileToStorage(auth, cookies, lockCtx, saveAsPath,
-                                                          saveAsFilename, isRename);
-        return AsyncUpload(AsyncUpload::State::Complete, res);
+        const UploadResult res =
+            uploadLocalFileToStorage(auth, cookies, lockCtx, saveAsPath, saveAsFilename, isRename);
+        if (asyncUploadCallback)
+            asyncUploadCallback(AsyncUpload(AsyncUpload::State::Complete, res));
     }
 
     /// Get the progress state of an asynchronous LocalFileToStorage upload.
     virtual AsyncUpload queryLocalFileToStorageAsyncUploadState()
     {
         // Unsupported.
-        return AsyncUpload(AsyncUpload::State::None);
+        return AsyncUpload(AsyncUpload::State::None, UploadResult(UploadResult::Result::OK));
     }
 
     /// Cancels an active asynchronous LocalFileToStorage upload.
@@ -570,6 +577,12 @@ public:
                                           const std::string& saveAsFilename,
                                           const bool isRename) override;
 
+    void uploadLocalFileToStorageAsync(const Authorization& auth, const std::string& cookies,
+                                       LockContext& lockCtx, const std::string& saveAsPath,
+                                       const std::string& saveAsFilename, const bool isRename,
+                                       SocketPoll& socketPoll,
+                                       const AsyncUploadCallback& asyncUploadCallback) override;
+
     /// Total time taken for making WOPI calls during saving.
     std::chrono::milliseconds getWopiSaveDuration() const { return _wopiSaveDuration; }
 
@@ -610,6 +623,10 @@ private:
 
     // Time spend in saving the file from storage
     std::chrono::milliseconds _wopiSaveDuration;
+
+    /// The http::Session used for uploading asynchronously.
+    std::shared_ptr<http::Session> _uploadHttpSession;
+
     /// Whether or not to re-use cookies from the browser for the WOPI requests.
     bool _reuseCookies;
 };

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -214,6 +214,15 @@ public:
     /// Returns the root path to the jailed file.
     const std::string& getRootFilePath() const { return _jailedFilePath; };
 
+    /// Returns the root path to the jailed file to be uploaded.
+    std::string getRootFilePathToUpload() const { return _jailedFilePath + TO_UPLOAD_SUFFIX; };
+
+    /// Returns the root path to the jailed file being uploaded.
+    std::string getRootFilePathUploading() const
+    {
+        return _jailedFilePath + TO_UPLOAD_SUFFIX + UPLOADING_SUFFIX;
+    };
+
     /// Set the root path of the jailed file, only for use in cases where we actually have converted
     /// it to another format, in the same directory
     void setRootFilePath(const std::string& newPath)

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -18,6 +18,7 @@
 #include <Poco/JSON/Object.h>
 
 #include "Auth.hpp"
+#include "HttpRequest.hpp"
 #include "LOOLWSD.hpp"
 #include "Log.hpp"
 #include "Util.hpp"
@@ -152,6 +153,35 @@ public:
         std::string _reason;
     };
 
+    /// The state of an asynchronous upload request.
+    class AsyncUpload final
+    {
+    public:
+        enum class State
+        {
+            None, //< No async upload in progress or isn't supported.
+            Running, //< An async upload request is in progress.
+            Error, //< Failed to make an async upload request or timed out, no UploadResult.
+            Complete //< The last async upload request completed (regardless of the server's response).
+        };
+
+        AsyncUpload(State state, UploadResult result = UploadResult(UploadResult::Result::FAILED))
+            : _state(state)
+            , _result(std::move(result))
+        {
+        }
+
+        /// Returns the state of the async upload.
+        State state() const { return _state; }
+
+        /// Returns the result of the async upload.
+        const UploadResult& result() const { return _result; }
+
+    private:
+        const State _state;
+        UploadResult _result;
+    };
+
     enum class LOOLStatusCode
     {
         DOC_CHANGED = 1010 // Document changed externally in storage
@@ -249,6 +279,33 @@ public:
                              LockContext& lockCtx, const std::string& saveAsPath,
                              const std::string& saveAsFilename, const bool isRename)
         = 0;
+
+    /// Writes the contents of the file back to the source asynchronously, if possible.
+    /// @param cookies A string representing key=value pairs that are set as cookies.
+    /// @param savedFile When the operation was saveAs, this is the path to the file that was saved.
+    virtual AsyncUpload
+    uploadLocalFileToStorageAsync(const Authorization& auth, const std::string& cookies,
+                                  LockContext& lockCtx, const std::string& saveAsPath,
+                                  const std::string& saveAsFilename, const bool isRename)
+    {
+        // By default do a synchronous save.
+        const UploadResult res = uploadLocalFileToStorage(auth, cookies, lockCtx, saveAsPath,
+                                                          saveAsFilename, isRename);
+        return AsyncUpload(AsyncUpload::State::Complete, res);
+    }
+
+    /// Get the progress state of an asynchronous LocalFileToStorage upload.
+    virtual AsyncUpload queryLocalFileToStorageAsyncUploadState()
+    {
+        // Unsupported.
+        return AsyncUpload(AsyncUpload::State::None);
+    }
+
+    /// Cancels an active asynchronous LocalFileToStorage upload.
+    virtual void cancelLocalFileToStorageAsyncUpload()
+    {
+        // By default, nothing to do.
+    }
 
     /// Must be called at startup to configure.
     static void initialize();


### PR DESCRIPTION
These patches enable async uploading and add tests.

- wsd: add async API to Storage
- wsd: support asynchronous upload requests to storage
- wsd: handle async upload callback
- wsd: upload after saving only if necessary
- wsd: better logging of upload state
- wsd: better logging of autosave, upload, and modified states
- wsd: test: add async upload test on closing
- wsd: test: add async upload test to modify after fail
