### PR TITLE
Introduce a TRACEEVENT message from client to server

### DIFF
--- a/loleaflet/src/control/Toolbar.js
+++ b/loleaflet/src/control/Toolbar.js
@@ -1,4 +1,4 @@
-/* -*- js-indent-level: 8 -*- */
+/* -*- js-indent-level: 8; fill-column: 100 -*- */
 /*
  * Toolbar handler
  */
@@ -304,6 +304,9 @@ L.Map.include({
 	},
 
 	sendUnoCommand: function (command, json) {
+		// To exercise the Trace Event functionality, uncomment this
+		// app.socket.emitInstantTraceEvent('loleaflet-unocommand:' + command);
+
 		var isAllowedInReadOnly = false;
 		var allowedCommands = ['.uno:Save', '.uno:WordCountDialog', '.uno:EditAnnotation', '.uno:InsertAnnotation', '.uno:DeleteAnnotation'];
 
@@ -654,6 +657,11 @@ L.Map.include({
 	},
 
 	showLOAboutDialog: function() {
+
+		// Just as a test to exercise the Async Trace Event functionality, uncomment this
+		// line and the asyncTraceEvent.finish() below.
+		// var asyncTraceEvent = app.socket.createAsyncTraceEvent('loleaflet-showLOAboutDialog');
+
 		// Move the div sitting in 'body' as vex-content and make it visible
 		var content = $('#about-dialog').clone().css({display: 'block'});
 		// fill product-name and product-string
@@ -713,7 +721,7 @@ L.Map.include({
 				hammer.on('tap', function() {
 					map._docLayer.toggleTileDebugMode();
 
-					map._socket.sendMessage('traceeventrecording ' + (map._profilingRequestedToggle ? 'stop' : 'start'));
+					app.socket.sendMessage('traceeventrecording ' + (map._profilingRequestedToggle ? 'stop' : 'start'));
 
 					// Just as a test, uncomment this to toggle SAL_WARN and SAL_INFO
 					// selection between two states: 1) the default as directed by the
@@ -722,7 +730,7 @@ L.Map.include({
 					// (Note that loolwsd sets the SAL_LOG environment variable to
 					// "-WARN-INFO", i.e. the default is that nothing is logged)
 
-					// map._socket.sendMessage('sallogoverride ' + (map._profilingRequestedToggle ? 'default' : '+WARN+INFO.sc'));
+					// app.socket.sendMessage('sallogoverride ' + (map._profilingRequestedToggle ? 'default' : '+WARN+INFO.sc'));
 
 					map._profilingRequestedToggle = !map._profilingRequestedToggle;
 				});
@@ -740,6 +748,7 @@ L.Map.include({
 					touchGesture._hammer.on('tripletap', L.bind(touchGesture._onTripleTap, touchGesture));
 				}
 				map.focus();
+				// asyncTraceEvent.finish();
 			}
 		});
 	},

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -339,6 +339,47 @@ bool ClientSession::_handleInput(const char *buffer, int length)
         LOG_ERR("From client: " << std::string(buffer, length).substr(strlen("ERROR") + 1));
         return false;
     }
+    else if (tokens.equals(0, "TRACEEVENT"))
+    {
+        if (tokens.size() >= 4)
+        {
+            // The timestamps and durations loleaflet sends are in milliseconds, the Trace Event
+            // format wants microseconds. The intent is that when doing event trace generation, the
+            // web browser client and the server run on the same machine, so there is no clock skew
+            // problem.
+            std::string name;
+            std::string ph;
+            uint64_t ts;
+            if (getTokenString(tokens[1], "name", name) &&
+                getTokenString(tokens[2], "ph", ph) &&
+                getTokenUInt64(tokens[3], "ts", ts))
+            {
+                uint64_t id;
+                uint64_t dur;
+                if (ph == "i")
+                {
+                    fprintf(LOOLWSD::TraceEventFile, "{\"name\":\"%s\",\"ph\":\"i\",\"ts\":%lu,\"pid\":%d,\"tid\":1,}\n", name.c_str(), (ts + _performanceCounterEpoch), docBroker->getPid());
+                }
+                else if ((ph == "b" || ph == "e") &&
+                    getTokenUInt64(tokens[4], "id", id))
+                {
+                    fprintf(LOOLWSD::TraceEventFile, "{\"name\":\"%s\",\"ph\":\"%s\",\"ts\":%lu,\"pid\":%d,\"tid\":1,\"id\"=%lu}\n", name.c_str(), ph.c_str(), (ts + _performanceCounterEpoch), docBroker->getPid(), id);
+                }
+                else if (ph == "X" &&
+                         getTokenUInt64(tokens[4], "dur", dur))
+                {
+                    fprintf(LOOLWSD::TraceEventFile, "{\"name\":\"%s\",\"ph\":\"X\",\"ts\":%lu,\"pid\":%d,\"tid\":1,\"dur\"=%lu}\n", name.c_str(), (ts + _performanceCounterEpoch), docBroker->getPid(), dur);
+                }
+                else
+                {
+                    LOG_WRN("Unrecognized TRACEEVENT message");
+                }
+            }
+        }
+        else
+            LOG_WRN("Unrecognized TRACEEVENT message");
+        return false;
+    }
 
     LOOLWSD::dumpIncomingTrace(docBroker->getJailId(), getId(), firstLine);
 
@@ -362,6 +403,29 @@ bool ClientSession::_handleInput(const char *buffer, int length)
         {
             sendTextFrameAndLogError("error: cmd=loolclient kind=badprotocolversion");
             return false;
+        }
+
+        _performanceCounterEpoch = 0;
+        if (tokens.size() >= 4)
+        {
+            const char* str = tokens[2].data();
+            char* endptr = nullptr;
+            uint64_t ts = strtoull(str, &endptr, 10);
+            if (*endptr == '\0')
+            {
+                str = tokens[3].data();
+                endptr = nullptr;
+                double counter = strtod(str, &endptr);
+                if (*endptr == '\0')
+                {
+                    // Now we know how to translate from the client's performance.now() values to
+                    // microseconds since the epoch.
+                    _performanceCounterEpoch = ts * 1000 - (uint64_t)(counter * 1000);
+                    LOG_INF("Client timestamps: Date.now():" << ts <<
+                            ", performance.now():" << counter
+                            << " => " << _performanceCounterEpoch);
+                }
+            }
         }
 
         // Send LOOL version information

--- a/wsd/ClientSession.hpp
+++ b/wsd/ClientSession.hpp
@@ -323,6 +323,9 @@ private:
 
     /// Store last sent payload of form field button, so we can filter out redundant messages.
     std::string _lastSentFormFielButtonMessage;
+
+    /// Epoch of the client's performance.now() function, as microseconds sinze Unix epoch
+    uint64_t _performanceCounterEpoch;
 };
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/protocol.txt
+++ b/wsd/protocol.txt
@@ -39,6 +39,10 @@ it as a final error (that requires reloading to retry).
 client -> server
 ================
 
+A convention: Messages that have the first token (keyword) in
+UPPERCASE are related to debugging and tracing of the client and
+server software and not related to the user's actions.
+
 DEBUG <rest of message>
 
     The rest of the message (without the DEBUG keyword), possibly
@@ -48,6 +52,28 @@ ERROR <rest of message>
 
     The rest of the message (without the ERROR keyword), possibly
     multiple lines, is logged by the server as LOG_ERR.
+
+TRACEEVENT name=<name> ph=<letter> ts=<timestamp> <more parameters>...
+
+    Timestamps and durations are in microseconds, from
+    performance.now(), multiplied by 1000, and rouded to an integer.
+
+    name is a string of non-space characters.
+
+    ts is the timestamp when the trace event was generated.
+
+    ph is one of the following, and the rest of the parameters depend
+    on what it is.
+
+    'i': An "Instant" event. Nothing more.
+
+    'b', 'e': The begin and end of an "Async" event. In addition to
+    the name, the messages have an "id" parameter, a unique number
+    that must be the same for the 'b' and 'e' messages.
+
+    'X': A "complete" event. The "dur" parameter is the duration
+    between the beginning of the thing being timed and the time when
+    the 'X' message was emitted, also in microseconds.
 
 canceltiles
 
@@ -122,15 +148,25 @@ load [part=<partNumber>] url=<url> [timestamp=<time>] [lang=<locale>] [deviceFor
 
     options are the whole rest of the line, not URL-encoded, and must be valid JSON.
 
-loolclient <major.minor[-patch]>
+loolclient <major.minor[-patch]> [ <timestamp> <perfcounter> ]
 
     Upon connection, a client must announce the version number it supports.
-    Major: an integer that must always match between client and server,
+    major: an integer that must always match between client and server,
            otherwise there are no guarantees of any sensible
            compatibility. This is bumped when API changes.
-    Minor: an integer is more flexible and is at the discretion of either party.
+    minor: an integer is more flexible and is at the discretion of either party.
            Security fixes that do not alter the API would bump the minor version number.
-    Patch: an optional string that is informational.
+    patch: an optional string that is informational.
+
+    timestamp: the value of the JavaScript Date.now(), i.e. integer number of milliseconds since
+           the Unix epoch.
+
+    perfcounter: the value of the JavaScript performance.now() function at the same time.
+            This is also in milliseconds but can be a floating point number and can be up to
+            microsecond precision.
+
+            The timestamp and perfcounter are used by the server to translate performance
+            counter values from the client for Trace Event logging into absolute timestamps.
 
 mouse type=<type> x=<x> y=<y> count=<count>
 


### PR DESCRIPTION
    Introduce a TRACEEVENT message from client to server
    
    Add a function emitInstantTraceEvent() to leaflet that sends an
    "Instant" Trace Event to the server for logging.
    
    Add a function createAsyncTraceEvent() that creates an object that
    records the timestamp of its creation and sends the 'b' event to the
    server for logging, and when you call finish() on the object, sends
    the corresponding 'e' event.
    
    Finally, add a function createCompleteTraceEvent() that creates an
    object for a "Complete" Trace Event that includes the end timestamp
    *and* the duration. The event is sent to the server when you call
    finish() on the object.
    
    Loleaflet sends timestamps in the above messages from
    performance.now(). To enable the server to turn those into absolute
    timestamps, the loolclient message is amended to include the current
    Date.now() and performance.now() values.
    
    Note that the intent is that when generating Trace Event logs, the
    server and the web browser run on the same machine, so there is no
    wall-clock synchronisation issues between server and client.

Change-Id: Ie9e68b093b769cc942e1e1d17083febeb07ccf5e
Signed-off-by: Tor Lillqvist <tml@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

