### PR TITLE
Don't enable profiling yet.

### DIFF
--- a/kit/SetupKitEnvironment.hpp
+++ b/kit/SetupKitEnvironment.hpp
@@ -42,11 +42,6 @@ inline void setupKitEnvironment(const std::string& userInterface)
 
     // Set various options we need.
     std::string options = "unipoll";
-#if !MOBILEAPP
-    if (Log::logger().trace())
-        options += ":profile_events";
-#endif
-
     if (userInterface == "notebookbar")
         options += ":notebookbar";
 


### PR DESCRIPTION
Kit initialization uses 'trace' for very early start, and then
switches to the configured trace level later on, so don't use
it this early.

Change-Id: I8e0333930b46e5ad25658d7eda12d7469bdfdd1e
Signed-off-by: Michael Meeks <michael.meeks@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

