### PR TITLE
Add an --enable-trace-event-logging option to loolwsd

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -417,7 +417,8 @@ run: all @JAILS_PATH@
 			  --o:ssl.key_file_path="$(abs_top_srcdir)/etc/key.pem" \
 			  --o:ssl.ca_file_path="$(abs_top_srcdir)/etc/ca-chain.cert.pem" \
 			  --o:admin_console.username=admin --o:admin_console.password=admin \
-			  --o:logging.file[@enable]=true --o:logging.level=trace
+			  --o:logging.file[@enable]=true --o:logging.level=trace \
+			  --enable-trace-event-logging
 
 if ENABLE_DEBUG
 run-one: all @JAILS_PATH@

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -461,17 +461,20 @@ bool ChildSession::_handleInput(const char *buffer, int length)
         }
         else if (tokens.equals(0, "traceeventrecording"))
         {
-            if (tokens.size() > 0)
+            if (EnableTraceEventLogging)
             {
-                if (tokens.equals(1, "start"))
+                if (tokens.size() > 0)
                 {
-                    getLOKit()->setOption("traceeventrecording", "start");
-                    LOG_INF("Profile zone tracing in this kit process turned on (might have been on all the time)");
-                }
-                else if (tokens.equals(1, "stop"))
-                {
-                    getLOKit()->setOption("traceeventrecording", "stop");
-                    LOG_INF("Profile zone tracing in this kit process turned off");
+                    if (tokens.equals(1, "start"))
+                        {
+                            getLOKit()->setOption("traceeventrecording", "start");
+                            LOG_INF("Trace Event recording in this kit process turned on (might have been on all the time)");
+                        }
+                    else if (tokens.equals(1, "stop"))
+                    {
+                        getLOKit()->setOption("traceeventrecording", "stop");
+                        LOG_INF("Trace Event recording in this kit process turned off");
+                    }
                 }
             }
         }

--- a/kit/ForKit.cpp
+++ b/kit/ForKit.cpp
@@ -642,6 +642,12 @@ int main(int argc, char** argv)
             eq = std::strchr(cmd, '=');
             UserInterface = std::string(eq+1);
         }
+
+        else if (std::strstr(cmd, "--enable-trace-event-logging") == cmd)
+        {
+            EnableTraceEventLogging = true;
+        }
+
     }
 
     if (loSubPath.empty() || sysTemplate.empty() ||

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -2738,4 +2738,6 @@ void dump_kit_state()
     LOG_TRC(msg);
 }
 
+bool EnableTraceEventLogging = false;
+
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/kit/Kit.hpp
+++ b/kit/Kit.hpp
@@ -144,4 +144,6 @@ std::string anonymizeUsername(const std::string& username);
 std::shared_ptr<lok::Document> getLOKDocumentForAndroidOnly();
 #endif
 
+extern bool EnableTraceEventLogging;
+
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/loleaflet/js/global.js
+++ b/loleaflet/js/global.js
@@ -54,6 +54,11 @@ window.app.definitions = {};
 
 		/// Shows revision history file menu option
 		revHistoryEnabled: global.getParameterByName('revisionhistory'),
+
+		/// WHether Trace Event recording is enabled or not.
+		/// ("Enabled" here means whether it can be turned on
+		/// (and off again), not whether it is on.)
+		enableTraceEventLogging: (global.getParameterByName('enabletraceeventlogging') === 'yes'),
 	};
 
 	global.L.Browser = {

--- a/loleaflet/src/control/Toolbar.js
+++ b/loleaflet/src/control/Toolbar.js
@@ -26,11 +26,6 @@ L.Map.include({
 		}
 	},
 
-	// Triple-clicking turns profiling on in the kit process for
-	// this document (it is already if the server is running with log level
-	// "trace"). Triple-clicking again turns it off. Etc.
-	_profilingRequestedToggle: false,
-
 	onFontSelect: function(e) {
 		var font = e.target.value;
 		this.applyFont(font);
@@ -721,18 +716,25 @@ L.Map.include({
 				hammer.on('tap', function() {
 					map._docLayer.toggleTileDebugMode();
 
-					app.socket.sendMessage('traceeventrecording ' + (map._profilingRequestedToggle ? 'stop' : 'start'));
+					// Triple-clicking turns Trace Event recording on in the kit
+					// process for this document, as long as loolwsd has been
+					// started with the --enable-trace-event-logging option.
+					// Triple-clicking again turns it off.
 
-					// Just as a test, uncomment this to toggle SAL_WARN and SAL_INFO
-					// selection between two states: 1) the default as directed by the
-					// SAL_LOG environment variable, and 2) all warnings on plus SAL_INFO for sc.
-					//
-					// (Note that loolwsd sets the SAL_LOG environment variable to
-					// "-WARN-INFO", i.e. the default is that nothing is logged)
+					if (L.Params.enableTraceEventLogging) {
+						app.socket.sendMessage('traceeventrecording ' + (app.socket.traceEventRecordingToggle ? 'stop' : 'start'));
 
-					// app.socket.sendMessage('sallogoverride ' + (map._profilingRequestedToggle ? 'default' : '+WARN+INFO.sc'));
+						// Just as a test, uncomment this to toggle SAL_WARN and SAL_INFO
+						// selection between two states: 1) the default as directed by the
+						// SAL_LOG environment variable, and 2) all warnings on plus SAL_INFO for sc.
+						//
+						// (Note that loolwsd sets the SAL_LOG environment variable to
+						// "-WARN-INFO", i.e. the default is that nothing is logged)
 
-					map._profilingRequestedToggle = !map._profilingRequestedToggle;
+						// app.socket.sendMessage('sallogoverride ' + (app.socket.traceEventRecordingToggle ? 'default' : '+WARN+INFO.sc'));
+
+						app.socket.traceEventRecordingToggle = !app.socket.traceEventRecordingToggle;
+					}
 				});
 
 				this.contentEl.style.width = w + 'px';

--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -1347,8 +1347,11 @@ app.definitions.Socket = L.Class.extend({
 		return command;
 	},
 
+	traceEventRecordingToggle: false,
+
 	emitInstantTraceEvent: function (name) {
-		this.sendMessage('TRACEEVENT name=' + name + ' ph=i ts=' + performance.now());
+		if (this.traceEventRecordingToggle)
+			this.sendMessage('TRACEEVENT name=' + name + ' ph=i ts=' + performance.now());
 	},
 
 	asyncTraceEventCounter: 0,
@@ -1356,8 +1359,11 @@ app.definitions.Socket = L.Class.extend({
 	createAsyncTraceEvent: function (name) {
 		var result = {};
 		result.id = this.asyncTraceEventCounter++;
-		result.active = true;
-		this.sendMessage('TRACEEVENT name=' + name + ' ph=b ts=' + Math.round(performance.now() * 1000) + ' id=' + result.id);
+		result.active = this.traceEventRecordingToggle;
+
+		if (this.traceEventRecordingToggle)
+			this.sendMessage('TRACEEVENT name=' + name + ' ph=b ts=' + Math.round(performance.now() * 1000) + ' id=' + result.id);
+
 		var that = this;
 		result.finish = function () {
 			if (this.active) {
@@ -1373,7 +1379,7 @@ app.definitions.Socket = L.Class.extend({
 
 	createCompleteTraceEvent: function (name) {
 		var result = {};
-		result.active = true;
+		result.active = this.traceEventRecordingToggle;
 		result.begin = performance.now();
 		var that = this;
 		result.finish = function () {

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -342,43 +342,46 @@ bool ClientSession::_handleInput(const char *buffer, int length)
     }
     else if (tokens.equals(0, "TRACEEVENT"))
     {
-        if (tokens.size() >= 4)
+        if (LOOLWSD::EnableTraceEventLogging)
         {
-            // The timestamps and durations loleaflet sends are in milliseconds, the Trace Event
-            // format wants microseconds. The intent is that when doing event trace generation, the
-            // web browser client and the server run on the same machine, so there is no clock skew
-            // problem.
-            std::string name;
-            std::string ph;
-            uint64_t ts;
-            if (getTokenString(tokens[1], "name", name) &&
-                getTokenString(tokens[2], "ph", ph) &&
-                getTokenUInt64(tokens[3], "ts", ts))
+            if (tokens.size() >= 4)
             {
-                uint64_t id;
-                uint64_t dur;
-                if (ph == "i")
+                // The timestamps and durations loleaflet sends are in milliseconds, the Trace Event
+                // format wants microseconds. The intent is that when doing event trace generation, the
+                // web browser client and the server run on the same machine, so there is no clock skew
+                // problem.
+                std::string name;
+                std::string ph;
+                uint64_t ts;
+                if (getTokenString(tokens[1], "name", name) &&
+                    getTokenString(tokens[2], "ph", ph) &&
+                    getTokenUInt64(tokens[3], "ts", ts))
                 {
-                    fprintf(LOOLWSD::TraceEventFile, "{\"name\":\"%s\",\"ph\":\"i\",\"ts\":%lu,\"pid\":%d,\"tid\":1,}\n", name.c_str(), (ts + _performanceCounterEpoch), docBroker->getPid());
-                }
-                else if ((ph == "b" || ph == "e") &&
-                    getTokenUInt64(tokens[4], "id", id))
-                {
-                    fprintf(LOOLWSD::TraceEventFile, "{\"name\":\"%s\",\"ph\":\"%s\",\"ts\":%lu,\"pid\":%d,\"tid\":1,\"id\"=%lu}\n", name.c_str(), ph.c_str(), (ts + _performanceCounterEpoch), docBroker->getPid(), id);
-                }
-                else if (ph == "X" &&
-                         getTokenUInt64(tokens[4], "dur", dur))
-                {
-                    fprintf(LOOLWSD::TraceEventFile, "{\"name\":\"%s\",\"ph\":\"X\",\"ts\":%lu,\"pid\":%d,\"tid\":1,\"dur\"=%lu}\n", name.c_str(), (ts + _performanceCounterEpoch), docBroker->getPid(), dur);
-                }
-                else
-                {
-                    LOG_WRN("Unrecognized TRACEEVENT message");
+                    uint64_t id;
+                    uint64_t dur;
+                    if (ph == "i")
+                    {
+                        fprintf(LOOLWSD::TraceEventFile, "{\"name\":\"%s\",\"ph\":\"i\",\"ts\":%lu,\"pid\":%d,\"tid\":1,}\n", name.c_str(), (ts + _performanceCounterEpoch), docBroker->getPid());
+                    }
+                    else if ((ph == "b" || ph == "e") &&
+                        getTokenUInt64(tokens[4], "id", id))
+                    {
+                        fprintf(LOOLWSD::TraceEventFile, "{\"name\":\"%s\",\"ph\":\"%s\",\"ts\":%lu,\"pid\":%d,\"tid\":1,\"id\"=%lu}\n", name.c_str(), ph.c_str(), (ts + _performanceCounterEpoch), docBroker->getPid(), id);
+                    }
+                    else if (ph == "X" &&
+                             getTokenUInt64(tokens[4], "dur", dur))
+                    {
+                        fprintf(LOOLWSD::TraceEventFile, "{\"name\":\"%s\",\"ph\":\"X\",\"ts\":%lu,\"pid\":%d,\"tid\":1,\"dur\"=%lu}\n", name.c_str(), (ts + _performanceCounterEpoch), docBroker->getPid(), dur);
+                    }
+                    else
+                    {
+                        LOG_WRN("Unrecognized TRACEEVENT message");
+                    }
                 }
             }
+            else
+                LOG_WRN("Unrecognized TRACEEVENT message");
         }
-        else
-            LOG_WRN("Unrecognized TRACEEVENT message");
         return false;
     }
 

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -681,6 +681,8 @@ inline std::string getLaunchURI(const std::string &document)
     oss << "?file_path=file://";
     oss << DEBUG_ABSSRCDIR "/";
     oss << document;
+    if (LOOLWSD::EnableTraceEventLogging)
+        oss << "&enabletraceeventlogging=yes";
 
     return oss.str();
 }
@@ -749,6 +751,7 @@ std::string LOOLWSD::ServiceRoot;
 std::string LOOLWSD::LOKitVersion;
 std::string LOOLWSD::ConfigFile = LOOLWSD_CONFIGDIR "/loolwsd.xml";
 std::string LOOLWSD::ConfigDir = LOOLWSD_CONFIGDIR "/conf.d";
+bool LOOLWSD::EnableTraceEventLogging = false;
 FILE *LOOLWSD::TraceEventFile = NULL;
 std::string LOOLWSD::LogLevel = "trace";
 std::string LOOLWSD::UserInterface = "classic";
@@ -1637,6 +1640,13 @@ void LOOLWSD::defineOptions(OptionSet& optionSet)
                         .repeatable(false)
                         .argument("path"));
 
+    optionSet.addOption(Option("enable-trace-event-logging", "",
+                               "Enable turning Trace Event recording and logging on and off. "
+                               "Note that this option does not turn it on, that needs to be done at run-time "
+                               "for a specific client.")
+                        .required(false)
+                        .repeatable(false));
+
 #if ENABLE_DEBUG
     optionSet.addOption(Option("unitlib", "", "Unit testing library path.")
                         .required(false)
@@ -1706,6 +1716,8 @@ void LOOLWSD::handleOption(const std::string& optionName,
         ConfigDir = value;
     else if (optionName == "lo-template-path")
         LoTemplate = value;
+    else if (optionName == "enable-trace-event-logging")
+        EnableTraceEventLogging = true;
 #if ENABLE_DEBUG
     else if (optionName == "unitlib")
         UnitTestLibrary = value;
@@ -1985,6 +1997,9 @@ bool LOOLWSD::createForKit()
 
     if (!CheckLoolUser)
         args.push_back("--disable-lool-user-checking");
+
+    if (EnableTraceEventLogging)
+        args.push_back("--enable-trace-event-logging");
 
 #if ENABLE_DEBUG
     if (SingleKit)

--- a/wsd/LOOLWSD.hpp
+++ b/wsd/LOOLWSD.hpp
@@ -250,6 +250,7 @@ public:
     static std::string WelcomeFilesRoot; ///< From where we should serve the release notes (or otherwise useful content) that is shown on first install or version update.
     static std::string ServiceRoot; ///< There are installations that need prefixing every page with some path.
     static std::string LOKitVersion;
+    static bool EnableTraceEventLogging;
     static FILE *TraceEventFile;
     static std::string LogLevel;
     static bool AnonymizeUserData;


### PR DESCRIPTION
It enables turning Trace Event recording on (and off again). The
option is passed down to the client through loleaflet.html, and to the
KIT processes. If the option is not used, the new JS functions that
send trace events to the server turn into no-ops to avoid wasting
bandwidth.

It is always on in a "make run".

Change-Id: Iafe1919ccba7c376137d3e0568b857e20780bbc8
Signed-off-by: Tor Lillqvist <tml@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

