### PR TITLE
Backports from co-6-4 and a couple misc patches 

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -311,6 +311,7 @@ noinst_HEADERS = $(wsd_headers) $(shared_headers) $(kit_headers) \
                  test/lokassert.hpp \
                  test/test.hpp \
                  test/testlog.hpp \
+                 test/HttpTestServer.hpp \
                  test/helpers.hpp
 
 dist-hook:

--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -114,7 +114,6 @@ protected:
         , _testname(std::move(name))
         , _socketPoll(std::make_shared<SocketPoll>(_testname))
     {
-        _socketPoll->startThread();
     }
 
     virtual ~UnitBase();
@@ -240,7 +239,10 @@ public:
 private:
     void setHandle(void *dlHandle)
     {
+        assert(_dlHandle == nullptr && "setHandle must only be called once");
+        assert(dlHandle != nullptr && "Invalid handle to set");
         _dlHandle = dlHandle;
+        _socketPoll->startThread();
     }
     static UnitBase *linkAndCreateUnit(UnitType type, const std::string& unitLibPath);
 

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -1134,8 +1134,17 @@ private:
 
     virtual void handleIncomingMessage(SocketDisposition& disposition) override
     {
+        if (!isConnected())
+        {
+            LOG_ERR("handleIncomingMessage called when not connected.");
+            assert(!_socket && "Expected no socket when not connected.");
+            return;
+        }
+
+        assert(_socket && "No valid socket to handleIncomingMessage.");
         LOG_TRC('#' << _socket->getFD() << " handleIncomingMessage.");
 
+        bool close = false;
         std::vector<char>& data = _socket->getInBuffer();
 
         // Consume the incoming data by parsing and processing the body.
@@ -1144,12 +1153,18 @@ private:
         {
             // Remove consumed data.
             data.erase(data.begin(), data.begin() + read);
+            close = !isConnected();
         }
         else if (read < 0)
         {
-            // Interrupt the transfer.
+            // Protocol error: Interrupt the transfer.
+            close = true;
+        }
+
+        if (close)
+        {
             disposition.setClosed();
-            _socket->shutdown();
+            onDisconnect();
         }
     }
 
@@ -1192,8 +1207,8 @@ private:
         if (!_response || _response->done())
             return;
 
-        const auto duration
-            = std::chrono::duration_cast<std::chrono::milliseconds>(now - _startTime);
+        const auto duration =
+            std::chrono::duration_cast<std::chrono::milliseconds>(now - _startTime);
         if (duration > getTimeout())
         {
             LOG_WRN("Socket #" << _socket->getFD() << " has timed out while requesting ["

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -1174,10 +1174,10 @@ private:
             _socket->shutdown(); // Flag for shutdown for housekeeping in SocketPoll.
             _socket->closeConnection(); // Immediately disconnect.
             _socket.reset();
+            _response->complete();
         }
 
         _connected = false;
-        _response->complete();
     }
 
     bool connect()

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -10,6 +10,7 @@
 #include "ClientSession.hpp"
 
 #include <fstream>
+#include <ios>
 #include <sstream>
 #include <memory>
 #include <unordered_map>
@@ -1439,10 +1440,15 @@ bool ClientSession::handleKitToClientMessage(const char* buffer, const int lengt
             // When the document is saved internally, but saving to storage failed,
             // don't update the client's modified status
             // (otherwise client thinks document is unmodified b/c saving was successful)
+            const bool isModified = stateTokens.equals(1, "true");
             if (!docBroker->isLastStorageUploadSuccessful())
+            {
+                LOG_DBG("Skipping ModifiedStatus (" << std::boolalpha << isModified
+                                                    << ") because last storage upload failed.");
                 return false;
+            }
 
-            docBroker->setModified(stateTokens.equals(1, "true"));
+            docBroker->setModified(isModified);
         }
         else
         {


### PR DESCRIPTION
- wsd: http: complete the http response only once
- wsd: http: disconnect if the server closed the socket
- wsd: log if we skip updating the modified flag
- wsd: make: add new files
- wsd: create the unittest SocketPoll thread only when testing
