### PR TITLE
wsd: create the unittest SocketPoll thread only when testing

### DIFF
--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -113,7 +113,6 @@ protected:
         , _testname(std::move(name))
         , _socketPoll(std::make_shared<SocketPoll>(_testname))
     {
-        _socketPoll->startThread();
     }
 
     virtual ~UnitBase();
@@ -237,7 +236,10 @@ public:
 private:
     void setHandle(void *dlHandle)
     {
+        assert(_dlHandle == nullptr && "setHandle must only be called once");
+        assert(dlHandle != nullptr && "Invalid handle to set");
         _dlHandle = dlHandle;
+        _socketPoll->startThread();
     }
     static UnitBase *linkAndCreateUnit(UnitType type, const std::string& unitLibPath);
 

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -1493,7 +1493,7 @@ void LOOLWSD::initialize(Application& self)
 void LOOLWSD::initializeSSL()
 {
 #if ENABLE_SSL
-    if (!LOOLWSD::isSSLEnabled())
+    if (!LOOLWSD::isSSLEnabled() && !LOOLWSD::isSSLTermination())
         return;
 
     const std::string ssl_cert_file_path = getPathFromConfig("ssl.cert_file_path");


### PR DESCRIPTION
This avoids having the test socket poll thread running when not testing (which was recently introduced with the async sockets in tests).

Also, initialize SSL when either termination is set or it's enabled outright.