### PR TITLE
ClientSession: fix -Wdangling-gsl

### DIFF
--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -409,7 +409,8 @@ bool ClientSession::_handleInput(const char *buffer, int length)
         _performanceCounterEpoch = 0;
         if (tokens.size() >= 4)
         {
-            const char* str = tokens[2].data();
+            std::string token = tokens[2];
+            const char* str = token.data();
             char* endptr = nullptr;
             uint64_t ts = strtoull(str, &endptr, 10);
             if (*endptr == '\0')


### PR DESCRIPTION
wsd/ClientSession.cpp:411:31: error: object backing the pointer will be destroyed at the end of the full-expression [-Werror,-Wdangling-gsl]
            const char* str = tokens[2].data();
                              ^~~~~~~~~

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I67e4aa5f61e049ad13663dc1e11ae2bd67399bea
