### PR TITLE
cypress: Don't check cursor in formulabar

### DIFF
--- a/cypress_test/integration_tests/common/calc_helper.js
+++ b/cypress_test/integration_tests/common/calc_helper.js
@@ -94,8 +94,11 @@ function typeIntoFormulabar(text) {
 			}
 		});
 
-	cy.get('#calc-inputbar .lokdialog-cursor')
-		.should('be.visible');
+	// TODO: check if cursor is in formulabar
+	// with core cp-6.4 it was possible with:
+	// cy.get('#calc-inputbar .lokdialog-cursor')
+	//	 .should('be.visible');
+	// with core co-2021 cursor is rendered on the canvas
 
 	helper.doIfOnMobile(function() {
 		cy.get('#tb_actionbar_item_acceptformula')


### PR DESCRIPTION
because it is tunneled now as drawing on the canvas

Signed-off-by: Szymon Kłos <szymon.klos@collabora.com>
Change-Id: I76c7d218abf155b2bd835d9f74b46d02e2808bbc
