### PR TITLE
Fix connectors scale uniformly on mobile

### DIFF
--- a/loleaflet/src/layer/vector/Path.Transform.js
+++ b/loleaflet/src/layer/vector/Path.Transform.js
@@ -1161,7 +1161,8 @@ L.Handler.PathTransform = L.Handler.extend({
 		this._handleDragged = true;
 
 		var isCornerMarker = (this._activeMarker.options.index % 2) == 0;
-		var scaleUniform = this.options.isRotated || (window.ThisIsAMobileApp && isCornerMarker);
+		var mobileScaling = window.ThisIsAMobileApp && !this._polyEdges.length;
+		var scaleUniform = this.options.isRotated || (mobileScaling && isCornerMarker);
 		// toggle with shift key when it does not matter whether it is scaled or not
 		if (!scaleUniform && isCornerMarker)
 			scaleUniform = this.options.uniformScaling ^ this._map._docLayer.shiftKeyPressed;


### PR DESCRIPTION
Dragging connector handles acts like regular shape handles
and scales uniformly

Signed-off-by: merttumer <mert.tumer@collabora.com>
Change-Id: Ic3a729b3fa1c720990f9c1c687693bdb3cef02d7


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

