### PR TITLE
Let the server tell loleaflet whether trace events can be collected o…

### DIFF
--- a/loleaflet/js/global.js
+++ b/loleaflet/js/global.js
@@ -54,11 +54,6 @@ window.app.definitions = {};
 
 		/// Shows revision history file menu option
 		revHistoryEnabled: global.getParameterByName('revisionhistory'),
-
-		/// WHether Trace Event recording is enabled or not.
-		/// ("Enabled" here means whether it can be turned on
-		/// (and off again), not whether it is on.)
-		enableTraceEventLogging: (global.getParameterByName('enabletraceeventlogging') === 'yes'),
 	};
 
 	global.L.Browser = {

--- a/loleaflet/src/control/Toolbar.js
+++ b/loleaflet/src/control/Toolbar.js
@@ -721,7 +721,7 @@ L.Map.include({
 					// started with the --enable-trace-event-logging option.
 					// Triple-clicking again turns it off.
 
-					if (L.Params.enableTraceEventLogging) {
+					if (app.socket.enableTraceEventLogging) {
 						app.socket.sendMessage('traceeventrecording ' + (app.socket.traceEventRecordingToggle ? 'stop' : 'start'));
 
 						// Just as a test, uncomment this to toggle SAL_WARN and SAL_INFO

--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -11,6 +11,10 @@ app.definitions.Socket = L.Class.extend({
 	WasShownLimitDialog: false,
 	WSDServer: {},
 
+	/// Whether Trace Event recording is enabled or not. ("Enabled" here means whether it can be
+	/// turned on (and off again), not whether it is on.)
+	enableTraceEventLogging: false,
+
 	// Will be set from lokitversion message
 	TunnelledDialogImageCacheSize: 0,
 
@@ -378,6 +382,9 @@ app.definitions.Socket = L.Class.extend({
 			                         lokitVersionObj.ProductVersion + lokitVersionObj.ProductExtension.replace('.0.','-') +
 			                         ' (git hash: ' + h + ')');
 			this.TunnelledDialogImageCacheSize = lokitVersionObj.tunnelled_dialog_image_cache_size;
+		}
+		else if (textMsg.startsWith('enabletraceeventlogging ')) {
+			this.enableTraceEventLogging = true;
 		}
 		else if (textMsg.startsWith('osinfo ')) {
 			var osInfo = textMsg.replace('osinfo ', '');

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -439,6 +439,11 @@ bool ClientSession::_handleInput(const char *buffer, int length)
         // Send LOKit version information
         sendTextFrame("lokitversion " + LOOLWSD::LOKitVersion);
 
+        // If Trace Event generation and logging is enabled (whether it can be turned on), tell it
+        // to loleaflet
+        if (LOOLWSD::EnableTraceEventLogging)
+            sendTextFrame("enabletraceeventlogging yes");
+
         #if !MOBILEAPP
             // If it is not mobile, it must be Linux (for now).
             sendTextFrame(std::string("osinfo ") + Util::getLinuxVersion());


### PR DESCRIPTION
…r not

Instead of requiring that information in the query string of the loleaflet.html URL.

Change-Id: I8c41e87c7f561561adeb03ec34ce0c19fe9d7fa5
Signed-off-by: Tor Lillqvist <tml@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

