### PR TITLE
Add Cirrus CI configuration for FreeBSD testing.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,31 @@
+task:
+  name: "FreeBSD 13"
+  freebsd_instance:
+    matrix:
+      - image_family: freebsd-13-0-snap
+  deps_script:
+    - sed -i.bak -e 's/quarterly/latest/' /etc/pkg/FreeBSD.conf
+    - env ASSUME_ALWAYS_YES=yes pkg update -f
+    - env ASSUME_ALWAYS_YES=yes pkg remove -y python27 python2 python37
+    - env ASSUME_ALWAYS_YES=yes pkg install -y python3 python38 py38-polib py38-lxml
+    - env ASSUME_ALWAYS_YES=yes pkg install -y gmake pkgconf poco cppunit autotools coreutils libreoffice pango git bash npm
+    - mkdir libreoffice-src
+    - cd libreoffice-src
+    - fetch http://arrowd.name/libreoffice-include.tar.xz
+    - tar -xvf libreoffice-include.tar.xz
+  build_script:
+    - mkdir .git/hooks
+    - pw useradd -n lool -d /tmp/loolhome -m
+    - chmod -R o+rwx ./
+    - su -m lool -c './autogen.sh'
+    - 'su -m lool -c ''env HOME=/tmp/loolhome MAKE=gmake
+        CPPFLAGS="-isystem /usr/local/include" CFLAGS="-I/usr/local/include"
+        CXXFLAGS="-I/usr/local/include" LDFLAGS=-L/usr/local/lib ./configure
+        --with-lo-path=/usr/local/lib/libreoffice/
+        --with-lokit-path=./libreoffice-src/include
+        --disable-seccomp --disable-setcap --enable-debug'' '
+    - su -m lool -c 'env HOME=/tmp/loolhome gmake -j`sysctl -n hw.ncpu`'
+    - chown root ./loolmount
+    - chmod +s ./loolmount
+  test_script:
+#    - su -m lool -c 'env HOME=/tmp/loolhome gmake check'


### PR DESCRIPTION
* Target version: master 

This PR adds FreeBSD continuous integration using Cirrus CI. To make it work for https://github.com/CollaboraOnline/online repository, the Cirrus CI app should be enabled for it: https://cirrus-ci.org/guide/quick-start/

Running `make check` is currently disabled, as some tests fail for unknown reason. They pass on my local machine, though, so I hope to resolve it quickly.

### Checklist

- [X] Code is properly formatted
- [X] All commits have Change-Id
- [X] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

