### PR TITLE
notebookbar.css use --gray-light-txt-color for dimgray

### DIFF
--- a/loleaflet/css/notebookbar.css
+++ b/loleaflet/css/notebookbar.css
@@ -18,6 +18,7 @@
 	font-family: var(--loleaflet-font);
 	line-height: normal;
 	color: dimgray;
+	color: var(--gray-light-txt--color);
 	height: 32px;
 	display: flex;
 	align-items: center;


### PR DESCRIPTION
dimgray is #696969
--gray-light-txt-color is #696969
now it use the value and can be themed

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: Ia4ce421aad99a2b9b45c7fce0a43b4d0b72d3a69
