### PR TITLE
improve cell cursors and selections

### DIFF
--- a/cypress_test/integration_tests/common/calc_helper.js
+++ b/cypress_test/integration_tests/common/calc_helper.js
@@ -56,7 +56,7 @@ function clickOnFirstCell(firstClick = true, dblClick = false) {
 		});
 
 	if (firstClick && !dblClick) {
-		cy.get('#test-div-overlay-cell-cursor')
+		cy.get('#test-div-overlay-cell-cursor-border-0')
 			.should(function (elem) {
 				expect(helper.Bounds.parseBoundsJson(elem.text()).left).to.be.equal(0);
 				expect(helper.Bounds.parseBoundsJson(elem.text()).top).to.be.equal(0);

--- a/cypress_test/integration_tests/mobile/calc/overlays_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/overlays_spec.js
@@ -23,13 +23,13 @@ describe('Overlay bounds.', function () {
 		calcHelper.clickOnFirstCell();
 
 		var cellA1Bounds = new helper.Bounds();
-		helper.getOverlayItemBounds('#test-div-overlay-cell-cursor', cellA1Bounds);
+		helper.getOverlayItemBounds('#test-div-overlay-cell-cursor-border-0', cellA1Bounds);
 
 		helper.typeIntoInputField('input#addressInput', 'C3');
 
 		var cellC3Bounds = new helper.Bounds();
-		helper.overlayItemHasDifferentBoundsThan('#test-div-overlay-cell-cursor', cellA1Bounds);
-		helper.getOverlayItemBounds('#test-div-overlay-cell-cursor', cellC3Bounds);
+		helper.overlayItemHasDifferentBoundsThan('#test-div-overlay-cell-cursor-border-0', cellA1Bounds);
+		helper.getOverlayItemBounds('#test-div-overlay-cell-cursor-border-0', cellC3Bounds);
 
 		helper.typeIntoInputField('input#addressInput', 'B2');
 
@@ -44,7 +44,7 @@ describe('Overlay bounds.', function () {
 			cellB2Bounds.width = cellC3Bounds.left - cellB2Bounds.left;
 			cellB2Bounds.height = cellC3Bounds.top - cellB2Bounds.top;
 
-			helper.overlayItemHasBounds('#test-div-overlay-cell-cursor', cellB2Bounds);
+			helper.overlayItemHasBounds('#test-div-overlay-cell-cursor-border-0', cellB2Bounds);
 		});
 	});
 
@@ -53,13 +53,13 @@ describe('Overlay bounds.', function () {
 		calcHelper.clickOnFirstCell();
 
 		var cellA1Bounds = new helper.Bounds();
-		helper.getOverlayItemBounds('#test-div-overlay-cell-cursor', cellA1Bounds);
+		helper.getOverlayItemBounds('#test-div-overlay-cell-cursor-border-0', cellA1Bounds);
 
 		helper.typeIntoInputField('input#addressInput', 'D4');
 
 		var cellD4Bounds = new helper.Bounds();
-		helper.overlayItemHasDifferentBoundsThan('#test-div-overlay-cell-cursor', cellA1Bounds);
-		helper.getOverlayItemBounds('#test-div-overlay-cell-cursor', cellD4Bounds);
+		helper.overlayItemHasDifferentBoundsThan('#test-div-overlay-cell-cursor-border-0', cellA1Bounds);
+		helper.getOverlayItemBounds('#test-div-overlay-cell-cursor-border-0', cellD4Bounds);
 
 		helper.typeIntoInputField('input#addressInput', 'A1:D4');
 
@@ -74,7 +74,7 @@ describe('Overlay bounds.', function () {
 			rangeA1D4Bounds.width = cellD4Bounds.left + cellD4Bounds.width - cellA1Bounds.left;
 			rangeA1D4Bounds.height = cellD4Bounds.top + cellD4Bounds.height - cellA1Bounds.top;
 
-			helper.overlayItemHasBounds('#test-div-overlay-selections', rangeA1D4Bounds);
+			helper.overlayItemHasBounds('#test-div-overlay-selections-border-0', rangeA1D4Bounds);
 		});
 	});
 });

--- a/loleaflet/src/layer/tile/TileLayer.js
+++ b/loleaflet/src/layer/tile/TileLayer.js
@@ -6,7 +6,7 @@
 // Implement String::startsWith which is non-portable (Firefox only, it seems)
 // See http://stackoverflow.com/questions/646628/how-to-check-if-a-string-startswith-another-string#4579228
 
-/* global vex $ L _ isAnyVexDialogActive CPointSet CRectangle CPolyUtil CPolygon Cursor CBounds */
+/* global vex $ L _ isAnyVexDialogActive CPointSet CPolyUtil CPolygon Cursor CBounds CCellCursor CCellSelection */
 /*eslint no-extend-native:0*/
 if (typeof String.prototype.startsWith !== 'function') {
 	String.prototype.startsWith = function (str) {
@@ -67,8 +67,8 @@ var CSelections = L.Class.extend({
 		this._name = 'selections' + (isView ? '-viewid-' + viewId : '');
 		this._isView = isView;
 		this._viewId = viewId;
-		this._polygon = undefined;
-		this._updatePolygon();
+		this._cellSelection = undefined;
+		this._updateCellSelection();
 	},
 
 	empty: function () {
@@ -81,22 +81,22 @@ var CSelections = L.Class.extend({
 
 	setPointSet: function(pointSet) {
 		this._pointSet = pointSet;
-		this._updatePolygon();
+		this._updateCellSelection();
 	},
 
 	contains: function(corePxPoint) {
-		if (!this._polygon)
+		if (!this._cellSelection)
 			return false;
 
-		return this._polygon.anyRingBoundContains(corePxPoint);
+		return this._cellSelection.anyRingBoundContains(corePxPoint);
 	},
 
 	getBounds: function() {
-		return this._polygon.getBounds();
+		return this._cellSelection.getBounds();
 	},
 
-	_updatePolygon: function() {
-		if (!this._polygon) {
+	_updateCellSelection: function() {
+		if (!this._cellSelection) {
 			var fillColor = this._isView ?
 				L.LOUtil.rgbToHex(this._map.getViewColor(this._viewId)) :
 				this._styleData.getPropValue('background-color');
@@ -110,17 +110,17 @@ var CSelections = L.Class.extend({
 				opacity: opacity,
 				weight: Math.round(weight * this._dpiScale)
 			};
-			this._polygon = new CPolygon(this._pointSet, attributes);
-			this._overlay.initPath(this._polygon);
+			this._cellSelection = new CCellSelection(this._pointSet, attributes);
+			this._overlay.initPathGroup(this._cellSelection);
 			return;
 		}
 
-		this._polygon.setPointSet(this._pointSet);
+		this._cellSelection.setPointSet(this._pointSet);
 	},
 
 	remove: function() {
-		if (this._polygon)
-			this._overlay.removePath(this._polygon);
+		if (this._cellSelection)
+			this._overlay.removePathGroup(this._cellSelection);
 	}
 });
 
@@ -1626,7 +1626,7 @@ L.TileLayer = L.GridLayer.extend({
 		if (!this._isEmptyRectangle(this._cellViewCursors[viewId].bounds) && this._selectedPart === viewPart && this._map.hasInfoForView(viewId)) {
 			if (!cellViewCursorMarker) {
 				var backgroundColor = L.LOUtil.rgbToHex(this._map.getViewColor(viewId));
-				cellViewCursorMarker = new CRectangle(this._cellViewCursors[viewId].corePixelBounds, {
+				cellViewCursorMarker = new CCellCursor(this._cellViewCursors[viewId].corePixelBounds, {
 					fill: false,
 					color: backgroundColor,
 					weight: 2 * (this._painter ? this._painter._dpiScale : 1),
@@ -1637,14 +1637,14 @@ L.TileLayer = L.GridLayer.extend({
 				});
 				this._cellViewCursors[viewId].marker = cellViewCursorMarker;
 				cellViewCursorMarker.bindPopup(this._map.getViewName(viewId), {autoClose: false, autoPan: false, backgroundColor: backgroundColor, color: 'white', closeButton: false});
-				this._canvasOverlay.initPath(cellViewCursorMarker);
+				this._canvasOverlay.initPathGroup(cellViewCursorMarker);
 			}
 			else {
 				cellViewCursorMarker.setBounds(this._cellViewCursors[viewId].corePixelBounds);
 			}
 		}
 		else if (cellViewCursorMarker) {
-			this._canvasOverlay.removePath(cellViewCursorMarker);
+			this._canvasOverlay.removePathGroup(cellViewCursorMarker);
 			this._cellViewCursors[viewId].marker = undefined;
 		}
 	},
@@ -3399,7 +3399,7 @@ L.TileLayer = L.GridLayer.extend({
 			else {
 				var cursorStyle = new CStyleData(this._cursorDataDiv);
 				var weight = cursorStyle.getFloatPropWithoutUnit('border-top-width');
-				this._cellCursorMarker = new CRectangle(
+				this._cellCursorMarker = new CCellCursor(
 					corePxBounds,
 					{
 						name: 'cell-cursor',
@@ -3413,7 +3413,7 @@ L.TileLayer = L.GridLayer.extend({
 					this._map.fire('error', {msg: 'Cell Cursor marker initialization', cmd: 'cellCursor', kind: 'failed', id: 1});
 					return;
 				}
-				this._canvasOverlay.initPath(this._cellCursorMarker);
+				this._canvasOverlay.initPathGroup(this._cellCursorMarker);
 			}
 
 			this._addDropDownMarker();
@@ -3432,7 +3432,7 @@ L.TileLayer = L.GridLayer.extend({
 				this._map.fire('editorgotfocus');
 		}
 		else if (this._cellCursorMarker) {
-			this._canvasOverlay.removePath(this._cellCursorMarker);
+			this._canvasOverlay.removePathGroup(this._cellCursorMarker);
 			this._cellCursorMarker = undefined;
 		}
 		this._removeDropDownMarker();

--- a/loleaflet/src/layer/vector/CPath.ts
+++ b/loleaflet/src/layer/vector/CPath.ts
@@ -106,10 +106,10 @@ abstract class CPath extends CEventsHandler {
 		var topLeft = bounds.getTopLeft();
 		var size = bounds.getSize();
 		this.testDiv.innerText = JSON.stringify({
-			top: topLeft.y,
-			left: topLeft.x,
-			width: size.x,
-			height: size.y
+			top: Math.round(topLeft.y),
+			left: Math.round(topLeft.x),
+			width: Math.round(size.x),
+			height: Math.round(size.y)
 		});
 	}
 
@@ -315,3 +315,19 @@ abstract class CPath extends CEventsHandler {
 	}
 
 };
+
+class CPathGroup {
+	private paths: CPath[];
+
+	constructor(paths: CPath[]) {
+		this.paths = paths;
+	}
+
+	forEach(callback: (path: CPath, index: number, pathArray: CPath[]) => void) {
+		this.paths.forEach(callback);
+	}
+
+	push(path: CPath) {
+		this.paths.push(path);
+	}
+}

--- a/loleaflet/src/layer/vector/CPointSet.ts
+++ b/loleaflet/src/layer/vector/CPointSet.ts
@@ -49,4 +49,72 @@ class CPointSet {
 		this.points = undefined;
 		this.pointSets = array;
 	}
+
+	// This is used in CCellSelection to draw multiple polygons based on a "inner" point-set
+	// where we need to apply an additive offset to each point in the pointSet w.r.t each polygon's centroid.
+	applyOffset(offset: CPoint, centroidSymmetry: boolean = false, preRound: boolean = true) {
+		CPointSet.applyOffsetImpl(this, offset, centroidSymmetry, preRound);
+	}
+
+	clone(): CPointSet {
+		return CPointSet.cloneImpl(this);
+	}
+
+	private static cloneImpl(source: CPointSet): CPointSet {
+		let newPointSet = new CPointSet();
+
+		if (source.points) {
+			newPointSet.points = [];
+			source.points.forEach(function(point) {
+				newPointSet.points.push(point.clone());
+			});
+		} else if (source.pointSets) {
+			newPointSet.pointSets = [];
+			source.pointSets.forEach(function (childPointSet) {
+				let clonedChild = CPointSet.cloneImpl(childPointSet);
+				newPointSet.pointSets.push(clonedChild);
+			});
+		}
+
+		return newPointSet;
+	}
+
+	private static applyOffsetImpl(pointSet: CPointSet, offset: CPoint, centroidSymmetry: boolean, preRound: boolean) {
+		if (pointSet.empty())
+			return;
+
+		if (pointSet.isFlat()) {
+			let refPoint = new CPoint(Infinity, Infinity);
+			if (centroidSymmetry) {
+				refPoint.x = 0;
+				refPoint.y = 0;
+				// Compute centroid for this set of points.
+				pointSet.points.forEach(function (point) {
+					refPoint._add(point);
+				});
+				refPoint._divideBy(pointSet.points.length);
+			}
+			pointSet.points.forEach(function (point, index) {
+				if (preRound)
+					pointSet.points[index]._round();
+
+				if (point.x < refPoint.x)
+					pointSet.points[index].x -= offset.x;
+				else
+					pointSet.points[index].x += offset.x;
+
+				if (point.y < refPoint.y)
+					pointSet.points[index].y -= offset.y;
+				else
+					pointSet.points[index].y += offset.y;
+			});
+
+			return;
+		}
+
+		// not flat so recurse.
+		pointSet.pointSets.forEach(function(childPointSet) {
+			CPointSet.applyOffsetImpl(childPointSet, offset, centroidSymmetry, preRound);
+		})
+	}
 };

--- a/loleaflet/src/layer/vector/CRectangle.ts
+++ b/loleaflet/src/layer/vector/CRectangle.ts
@@ -2,7 +2,6 @@
 
 /*
  * CRectangle extends CPolygon and creates a rectangle of given bounds.
- * This is used for drawing of the self and view cell-cursor on the canvas.
  */
 
 class CRectangle extends CPolygon {
@@ -15,10 +14,169 @@ class CRectangle extends CPolygon {
 		this.setPointSet(CRectangle.boundsToPointSet(bounds));
 	}
 
-	private static boundsToPointSet(bounds: CBounds): CPointSet {
+	public static boundsToPointSet(bounds: CBounds): CPointSet {
 		if (!bounds.isValid()) {
 			return new CPointSet();
 		}
 		return CPointSet.fromPointArray([bounds.getTopLeft(), bounds.getTopRight(), bounds.getBottomRight(), bounds.getBottomLeft(), bounds.getTopLeft()]);
+	}
+}
+
+function getOptionsClone(baseOpts: any): any {
+	// TODO: implement polyfill for Object.assign() instead.
+	let newOpt: any = {};
+	for (let prop in baseOpts) {
+		if (Object.prototype.hasOwnProperty.call(baseOpts, prop)) {
+			newOpt[prop] = baseOpts[prop];
+		}
+	}
+
+	return newOpt;
+}
+
+// CCellCursor is used for drawing of the self and view cell-cursor on the canvas.
+class CCellCursor extends CPathGroup {
+
+	private cursorWeight: number = 2;
+	private borderPaths: CRectangle[] = [];
+	private innerContrastBorder: CRectangle;
+	private options: any;
+
+	constructor(bounds: CBounds, options: any) {
+		super([]);
+		if (options.weight != 1) {
+			this.cursorWeight = Math.round(options.weight);
+			options.weight = 1;
+		}
+		this.options = options;
+		this.options.lineJoin = 'miter';
+		this.options.lineCap = 'butt';
+
+		this.setBounds(bounds);
+	}
+
+	setBounds(bounds: CBounds) {
+		let cellBounds = new CBounds(
+			bounds.min.subtract(new CPoint(0.5, 0.5)),
+			bounds.max.subtract(new CPoint(0.5, 0.5))
+		);
+
+		// Compute bounds for border path.
+		let boundsForBorder: CBounds[] = [];
+		for (let idx = 0; idx < this.cursorWeight; ++idx) {
+			let pixels = idx; // pixels from real cell-border.
+			boundsForBorder.push(new CBounds(
+				cellBounds.min.subtract(new CPoint(pixels, pixels)),
+				cellBounds.max.add(new CPoint(pixels, pixels))
+			));
+		}
+
+		let boundsForContrastBorder = new CBounds(
+			cellBounds.min.add(new CPoint(1, 1)),
+			cellBounds.max.subtract(new CPoint(1, 1)));
+
+		if (this.borderPaths && this.innerContrastBorder) {
+			console.assert(this.borderPaths.length === this.cursorWeight);
+			// Update the border path.
+			this.borderPaths.forEach(function (borderPath, index) {
+				borderPath.setBounds(boundsForBorder[index]);
+			})
+			// Update constrast path
+			this.innerContrastBorder.setBounds(boundsForContrastBorder);
+
+		} else {
+			for (let index = 0; index < this.cursorWeight; ++index) {
+				let borderOpt = getOptionsClone(this.options);
+				borderOpt.name += '-border-' + index;
+				let borderPath = new CRectangle(boundsForBorder[index], borderOpt);
+				this.borderPaths.push(borderPath);
+				this.push(borderPath);
+			}
+
+			let contrastBorderOpt = getOptionsClone(this.options);
+			contrastBorderOpt.name += '-contrast-border';
+			contrastBorderOpt.color = 'white';
+			this.innerContrastBorder = new CRectangle(boundsForContrastBorder, contrastBorderOpt);
+			this.push(this.innerContrastBorder);
+		}
+	}
+
+	// This method is needed to allow setting up of a popup which is needed for showing
+	// other user's name in it when the CCellCursor is used for displaying view cell cursors.
+	bindPopup(content: any, options: any): CPath {
+		// forward to the innermost black border rectangle.
+		console.assert(this.borderPaths && this.borderPaths.length, 'borders not setup yet!');
+
+		return this.borderPaths[0].bindPopup(content, options)
+	}
+}
+
+// CCellSelection is used for drawing of the self and view cell-range selections on the canvas.
+class CCellSelection extends CPathGroup {
+
+	private selectionWeight: number = 2;
+	private borderPaths: CPolygon[];
+	private options: any;
+
+	constructor(pointSet: CPointSet, options: any) {
+		super([]);
+		if (options.weight != 1) {
+			this.selectionWeight = Math.round(options.weight);
+			options.weight = 1;
+		}
+		this.options = options;
+		this.options.lineJoin = 'miter';
+		this.options.lineCap = 'butt';
+
+		this.setPointSet(pointSet);
+	}
+
+	// This method is used to create/update the internal CPaths with the correct positions and dimensions
+	// using CPointSet data-structure.
+	setPointSet(pointSet: CPointSet) {
+		let innerPointSet = pointSet;
+		innerPointSet.applyOffset(new CPoint(0.5, 0.5), false /* centroidSymmetry */, true /* preRound */);
+
+		let borderPointSets: CPointSet[] = [];
+
+		for (let idx = 0; idx < this.selectionWeight; ++idx) {
+			let pixels = idx; // pixels from real cell-border.
+			let borderPset = innerPointSet.clone();
+			borderPset.applyOffset(new CPoint(pixels, pixels), true /* centroidSymmetry */, false /* preRound */);
+			borderPointSets.push(borderPset);
+		}
+
+		if (this.borderPaths) {
+			console.assert(this.borderPaths.length === this.selectionWeight);
+			// Update the border path.
+			this.borderPaths.forEach(function (borderPath, index) {
+				borderPath.setPointSet(borderPointSets[index]);
+			})
+
+		} else {
+			this.borderPaths = [];
+			for (let index = 0; index < this.selectionWeight; ++index) {
+				let borderOpt = getOptionsClone(this.options);
+				borderOpt.name += '-border-' + index;
+				if (index)
+					borderOpt.fill = false;
+				let borderPath = new CPolygon(borderPointSets[index], borderOpt);
+				this.borderPaths.push(borderPath);
+				this.push(borderPath);
+			}
+		}
+	}
+
+	getBounds(): CBounds {
+		if (!this.borderPaths || !this.borderPaths.length)
+			return new CBounds();
+		return this.borderPaths[0].getBounds();
+	}
+
+	anyRingBoundContains(corePxPoint: CPoint): boolean {
+		if (!this.borderPaths || !this.borderPaths.length)
+			return false;
+
+		return this.borderPaths[0].anyRingBoundContains(corePxPoint);
 	}
 }

--- a/loleaflet/src/layer/vector/CanvasOverlay.ts
+++ b/loleaflet/src/layer/vector/CanvasOverlay.ts
@@ -139,11 +139,23 @@ class CanvasOverlay {
 		path.updatePathAllPanes();
 	}
 
+	initPathGroup(pathGroup: CPathGroup) {
+		pathGroup.forEach(function (path: CPath) {
+			this.initPath(path);
+		}.bind(this));
+	}
+
 	removePath(path: CPath) {
 		// This does not get called via onDraw, so ask section container to redraw everything.
 		path.setDeleted();
 		this.paths.delete(path.getId());
 		this.overlaySection.containerObject.requestReDraw();
+	}
+
+	removePathGroup(pathGroup: CPathGroup) {
+		pathGroup.forEach(function (path: CPath) {
+			this.removePath(path);
+		}.bind(this));
 	}
 
 	updatePath(path: CPath, oldBounds: CBounds) {


### PR DESCRIPTION
* No AA bleeding: render pixel aligned (ie. 0.5 offset) for all hair-lines
* Two pixel wide line, around the cell - black; with the inner pixels /
  line exactly on top of the cell border.
* inside this breaking the outline - an internal white border which is
  exactly 1 pixel inside that black border - for a high contrast look.

The change introduces CPathGroup which is just an array of CPaths that
allows separate styling. CCellCursor and CCellSelection classes
specialize CPathGroup and implements the above three guidelines.

The view cell-cursors and view-selection also use the same
implementation with different styling.

The cypress tests are updated accordingly for the name change in the
test-div.

Signed-off-by: Dennis Francis <dennis.francis@collabora.com>
Change-Id: I8881337df6cf8d543bd48e8de4560d9aab681dff


* Resolves: # <!-- related github issue -->
* Target version: master 

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

