### PR TITLE
Add the possibiliy to include arbitrary arguments in the generated Tr…

### DIFF
--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -346,10 +346,8 @@ bool ClientSession::_handleInput(const char *buffer, int length)
         {
             if (tokens.size() >= 4)
             {
-                // The timestamps and durations loleaflet sends are in milliseconds, the Trace Event
-                // format wants microseconds. The intent is that when doing event trace generation, the
-                // web browser client and the server run on the same machine, so there is no clock skew
-                // problem.
+                // The intent is that when doing event trace generation, the web browser client and
+                // the server run on the same machine, so there is no clock skew problem.
                 std::string name;
                 std::string ph;
                 uint64_t ts;
@@ -357,21 +355,35 @@ bool ClientSession::_handleInput(const char *buffer, int length)
                     getTokenString(tokens[2], "ph", ph) &&
                     getTokenUInt64(tokens[3], "ts", ts))
                 {
+                    std::string args;
+                    if (tokens.size() >= 5 && getTokenString(tokens, "args", args))
+                        args = ",\"args\":" + args;
+
                     uint64_t id;
                     uint64_t dur;
                     if (ph == "i")
                     {
-                        fprintf(LOOLWSD::TraceEventFile, "{\"name\":\"%s\",\"ph\":\"i\",\"ts\":%lu,\"pid\":%d,\"tid\":1}m\n", name.c_str(), (ts + _performanceCounterEpoch), docBroker->getPid());
+                        fprintf(LOOLWSD::TraceEventFile, "{\"name\":\"%s\",\"ph\":\"i\"%s,\"ts\":%lu,\"pid\":%d,\"tid\":1},\n",
+                                name.c_str(),
+                                args.c_str(),
+                                (ts + _performanceCounterEpoch), docBroker->getPid());
                     }
                     else if ((ph == "b" || ph == "e") &&
                         getTokenUInt64(tokens[4], "id", id))
                     {
-                        fprintf(LOOLWSD::TraceEventFile, "{\"name\":\"%s\",\"ph\":\"%s\",\"ts\":%lu,\"pid\":%d,\"tid\":1,\"id\":%lu},\n", name.c_str(), ph.c_str(), (ts + _performanceCounterEpoch), docBroker->getPid(), id);
+                        fprintf(LOOLWSD::TraceEventFile, "{\"name\":\"%s\",\"ph\":\"%s\"%s,\"ts\":%lu,\"pid\":%d,\"tid\":1,\"id\":%lu},\n",
+                                name.c_str(),
+                                ph.c_str(),
+                                args.c_str(),
+                                (ts + _performanceCounterEpoch), docBroker->getPid(), id);
                     }
                     else if (ph == "X" &&
                              getTokenUInt64(tokens[4], "dur", dur))
                     {
-                        fprintf(LOOLWSD::TraceEventFile, "{\"name\":\"%s\",\"ph\":\"X\",\"ts\":%lu,\"pid\":%d,\"tid\":1,\"dur\":%lu},\n", name.c_str(), (ts + _performanceCounterEpoch), docBroker->getPid(), dur);
+                        fprintf(LOOLWSD::TraceEventFile, "{\"name\":\"%s\",\"ph\":\"X\"%s,\"ts\":%lu,\"pid\":%d,\"tid\":1,\"dur\":%lu},\n",
+                                name.c_str(),
+                                args.c_str(),
+                                (ts + _performanceCounterEpoch), docBroker->getPid(), dur);
                     }
                     else
                     {

--- a/wsd/protocol.txt
+++ b/wsd/protocol.txt
@@ -53,7 +53,7 @@ ERROR <rest of message>
     The rest of the message (without the ERROR keyword), possibly
     multiple lines, is logged by the server as LOG_ERR.
 
-TRACEEVENT name=<name> ph=<letter> ts=<timestamp> <more parameters>...
+TRACEEVENT name=<name> ph=<letter> ts=<timestamp> <more parameters>... [ args=<JSON.stringify-string> ]
 
     Timestamps and durations are in microseconds, from
     performance.now(), multiplied by 1000, and rouded to an integer.
@@ -65,7 +65,10 @@ TRACEEVENT name=<name> ph=<letter> ts=<timestamp> <more parameters>...
     ph is one of the following, and the rest of the parameters depend
     on what it is.
 
-    'i': An "Instant" event. Nothing more.
+    args is an optional parameter, and its value is a JSON string
+    where the keys and values are strings with no spaces in them.
+
+    'i': An "Instant" event.
 
     'b', 'e': The begin and end of an "Async" event. In addition to
     the name, the messages have an "id" parameter, a unique number


### PR DESCRIPTION
…ace Events in JS, too

For now, an argument object should have all keys and values as strings
not containing any spaces because of the trivial way in which it is
parsed.

This is a bit sad, yes, but necessary until we move to some more
structured syntax for the messages.

Also fix an incorrect comment.

Change-Id: I8a1408a4a1787b66a3cf7b26b3d92c07df244c47
Signed-off-by: Tor Lillqvist <tml@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

