### PR TITLE
Notebookbar.css remove settings for #table-optionstoolboxdown

### DIFF
--- a/loleaflet/css/notebookbar.css
+++ b/loleaflet/css/notebookbar.css
@@ -180,20 +180,6 @@
 	z-index: 1000;
 }
 
-#table-optionstoolboxdown .unospan-optionstoolboxdown {
-	margin: 0 !important;
-}
-
-#table-optionstoolboxdown .cell.notebookbar {
-	padding: 0 !important;
-}
-
-#table-optionstoolboxdown .unobutton {
-	width: 24px !important;
-	height: 24px !important;
-	padding: 4px;
-}
-
 /* root container */
 
 .notebookbar-scroll-wrapper {


### PR DESCRIPTION
## Summary
`#table-optionstoolboxdown` was used for the sidebar icons by remove the 3 sections within notebookbar.css the arangement was similar to any other icons.

### .unospan-optionstoolboxdown
`.unospan-optionstoolboxdown` define `margin: 0 !important;` in `.unotoolbutton.notebookbar` `margin-right: 5px !important;` was defined.
As the margin between two icons / commands is everywhere else 5px I don't see an reason to have here a special case. At least it's easier to select.

### .cell.notebookbar
`.cell.notebookbar` setting `padding: 0 !important;` is at any mother `.cell.notebookbar` 2px

### .unobutton
`.unobutton` was defined already with `width: 24px !important;` and `height: 24px !important;` by remove `.cell.notebookbar` `padding: 0` the `padding: 4px` isn't needed any more

Signed-off-by: Andreas-Kainz <kainz.a@gmail.com>
Change-Id: I92b13d40b3698e2c468f086501575c0378f00a9d
