### PR TITLE
Notebookbar: Home tab: positioning direct formatting icons #2085

### DIFF
--- a/loleaflet/css/notebookbar.css
+++ b/loleaflet/css/notebookbar.css
@@ -400,7 +400,19 @@
 }
 
 #fontnamecombobox.notebookbar .select2 {
-	width: 150px !important;
+	width: 170px !important;
+}
+
+#fontnamecombobox.notebookbar {
+	padding-right: 0px;
+}
+
+#BackColor.notebookbar, #CharBackColor.notebookbar { /* remove when #2149 is fixed*/
+	margin-left: 44px !important;
+}
+
+#BackgroundColor.notebookbar {
+	margin-left: 0px !important;
 }
 
 #fontsizecombobox.notebookbar .select2 {


### PR DESCRIPTION
Calc has the most icons in the direct formatting group so the width of the fontnamecombobox was enlarged to optimize the group at calc
Writer, Impress/Draw use one icon less so I added an 44px space. By add Character Spacing command #2149 there are everywhere the same number of commands, so the 44px margin can be removed.

Signed-off-by: Andreas-Kainz <kainz.a@gmail.com>
Change-Id: I8782cc738d79174a7f78f9e9e3fbd604f64e2233
