### PR TITLE
Properly process URLs with existing query

### DIFF
--- a/loleaflet/js/global.js
+++ b/loleaflet/js/global.js
@@ -752,7 +752,9 @@ window.app.definitions = {};
 		global.socket = new global.FakeWebSocket();
 		window.TheFakeWebSocket = global.socket;
 	} else {
-		var websocketURI = global.host + global.serviceRoot + '/lool/' + encodeURIComponent(global.docURL + (docParams ? '?' + docParams : '')) + '/ws' + wopiSrc;
+		// The URL may already contain a query (e.g., 'http://server.tld/foo/wopi/files/bar?desktop=baz') - then just append more params
+		var docParamsPart = docParams ? (global.docURL.includes('?') ? '&' : '?') + docParams : '';
+		var websocketURI = global.host + global.serviceRoot + '/lool/' + encodeURIComponent(global.docURL + docParamsPart) + '/ws' + wopiSrc;
 
 		try {
 			global.socket = global.createWebSocket(websocketURI);


### PR DESCRIPTION
URLs from host may already contain a query, like

  http://server.tld/foo/wopi/files/bar?desktop=baz

Previously, we simply appended '?' and then our parameters, resulting in

  http://server.tld/foo/wopi/files/bar?desktop=baz?access_token=...

which later was processed as if the question mark and following parameter
were part of previous parameter's value, so proper 'access_token' parameter
was missing.

This checks if the URL contains '?', and uses proper separator accordingly.

Signed-off-by: Mike Kaganski <mike.kaganski@collabora.com>
Change-Id: I1a237c0e47e1eea3704ef7d4a8a596283ea2a241
