### PR TITLE
fix: splitter line drawn over other overlays (co64)

### DIFF
--- a/loleaflet/src/layer/vector/CSplitterLine.ts
+++ b/loleaflet/src/layer/vector/CSplitterLine.ts
@@ -19,8 +19,8 @@ class CSplitterLine extends CRectangle {
 		this.fill = true;
 		this.opacity = 0;
 
-		// Splitters should always be on top.
-		this.zIndex = Infinity;
+		// Splitters should always be behind other overlays.
+		this.zIndex = -Infinity;
 
 		if (options.isHoriz !== undefined)
 			this.isHoriz = options.isHoriz;


### PR DESCRIPTION
Signed-off-by: Dennis Francis <dennis.francis@collabora.com>
Change-Id: I5b2c9f4937fbed9d03763cc25168142471d2f7a6


* Resolves: # <!-- related github issue -->
* Target version: master 


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

