### PR TITLE
Improve state dump

### DIFF
--- a/common/MessageQueue.cpp
+++ b/common/MessageQueue.cpp
@@ -10,6 +10,7 @@
 #include "MessageQueue.hpp"
 #include <climits>
 #include <algorithm>
+#include <iostream>
 
 #include <Poco/JSON/JSON.h>
 #include <Poco/JSON/Object.h>
@@ -567,6 +568,31 @@ TileQueue::Payload TileQueue::get_impl()
     std::string tileCombined = TileCombined::create(tiles).serialize("tilecombine");
     LOG_TRC("MessageQueue res: " << LOOLProtocol::getAbbreviatedMessage(tileCombined));
     return Payload(tileCombined.data(), tileCombined.data() + tileCombined.size());
+}
+
+void TileQueue::dumpState(std::ostream& oss)
+{
+oss << "\ttileQueue:"
+    << "\n\t\tcursorPositions:";
+for (const auto &it : _cursorPositions)
+{
+    oss << "\n\t\t\tviewId: "
+    << it.first
+    << " part: " << it.second.getPart()
+    << " x: " << it.second.getX()
+    << " y: " << it.second.getY()
+    << " width: " << it.second.getWidth()
+    << " height: " << it.second.getHeight();
+}
+
+oss << "\n\t\tviewOrder: [";
+std::string separator;
+for (const auto& viewId : _viewOrder)
+{
+    oss << separator << viewId;
+    separator = ", ";
+}
+oss << "]\n";
 }
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/common/MessageQueue.hpp
+++ b/common/MessageQueue.hpp
@@ -179,6 +179,8 @@ public:
         _cursorPositions.erase(viewId);
     }
 
+    void dumpState(std::ostream& oss);
+
 protected:
     virtual void put_impl(const Payload& value) override;
 

--- a/common/RenderTiles.hpp
+++ b/common/RenderTiles.hpp
@@ -227,6 +227,23 @@ public:
         }
         return wid;
     }
+
+    void dumpState(std::ostream& oss)
+    {
+        oss << "\tpngCache:"
+            << "\n\t\tcacheSize: " << _cacheSize
+            << "\n\t\tcacheHits: " << _cacheHits
+            << "\n\t\tcacheTests: " << _cacheTests
+            << "\n\t\tnextId: " << _nextId
+            << "\n\t\tcache entry count: "<< _cache.size();
+        for (const auto &it : _cache)
+        {
+            oss << "\n\t\t\thash: " << it.first
+                << " hitCount: " << it.second.getHitCount()
+                << " wireId: " << it.second.getWireId();
+        }
+        oss << '\n';
+    }
 };
 
 class ThreadPool {
@@ -323,6 +340,16 @@ public:
             if (!_shutdown && !_work.empty())
                 runOne(lock);
         }
+    }
+
+    void dumpState(std::ostream& oss)
+    {
+        oss << "\tthreadPool:"
+            << "\n\t\tshutdown: " << _shutdown
+            << "\n\t\tworking: " << _working
+            << "\n\t\twork count: " << count()
+            << "\n\t\tthread count " << _threads.size()
+            << "\n";
     }
 };
 

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1742,7 +1742,6 @@ public:
                 << " readOnly: " << it.second.isReadOnly();
         }
         oss << "\n";
-        // TODO: std::chrono::steady_clock::time_point _lastMemStatsTime;
     }
 
 private:
@@ -1789,7 +1788,6 @@ private:
     std::map<int, int> _speedCount;
     /// For showing disconnected user info in the doc repair dialog.
     std::map<int, UserInfo> _sessionUserInfo;
-    std::chrono::steady_clock::time_point _lastMemStatsTime;
 #ifdef __ANDROID__
     friend std::shared_ptr<lok::Document> getLOKDocumentForAndroidOnly();
 #endif

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1693,22 +1693,55 @@ public:
             << "\n\tdocPasswordType: " << (int)_docPasswordType
             << "\n\teditorId: " << _editorId
             << "\n\teditorChangeWarning: " << _editorChangeWarning
+            << "\n\tmobileAppDocId: " << _mobileAppDocId
+            << "\n\tinputProcessingEnabled: " << _inputProcessingEnabled
             << "\n";
 
         // dumpState:
         // TODO: _websocketHandler - but this is an odd one.
-        // TODO: std::shared_ptr<TileQueue> _tileQueue;
-        // TODO: PngCache _pngCache;
-        // TODO: std::map<int, std::unique_ptr<CallbackDescriptor>> _viewIdToCallbackDescr;
-        // ThreadPool _pngPool;
+        _tileQueue->dumpState(oss);
+        _pngCache.dumpState(oss);
+        oss << "\tviewIdToCallbackDescr:";
+        for (const auto &it : _viewIdToCallbackDescr)
+        {
+            oss << "\n\t\tviewId: " << it.first
+                << " editorId: " << it.second->getDoc()->getEditorId()
+                << " mobileAppDocId: " << it.second->getDoc()->getMobileAppDocId();
+        }
+        oss << "\n";
 
+        _pngPool.dumpState(oss);
         _sessions.dumpState(oss);
 
-        // TODO: std::map<int, std::chrono::steady_clock::time_point> _lastUpdatedAt;
-        // TODO: std::map<int, int> _speedCount;
+        oss << "\tlastUpdatedAt:";
+        for (const auto &it : _lastUpdatedAt)
+        {
+            auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                        it.second.time_since_epoch()).count();
+            oss << "\n\t\tviewId: " << it.first
+                << " last update time(ms): " << ms;
+        }
+        oss << "\n";
+
+        oss << "\tspeedCount:";
+        for (const auto &it : _speedCount)
+        {
+            oss << "\n\t\tviewId: " << it.first
+                << " speed: " << it.second;
+        }
+        oss << "\n";
 
         /// For showing disconnected user info in the doc repair dialog.
-        // TODO: std::map<int, UserInfo> _sessionUserInfo;
+        oss << "\tsessionUserInfo:";
+        for (const auto &it : _sessionUserInfo)
+        {
+            oss << "\n\t\tviewId: " << it.first
+                << " userId: " << it.second.getUserId()
+                << " userName: " << it.second.getUserName()
+                << " userExtraInfo: " << it.second.getUserExtraInfo()
+                << " readOnly: " << it.second.isReadOnly();
+        }
+        oss << "\n";
         // TODO: std::chrono::steady_clock::time_point _lastMemStatsTime;
     }
 


### PR DESCRIPTION
* Resolves: #1234
* Target version: master 

### Summary
Add `dumpState` methods to `TileQueue`, `PngCache`, `ThreadPool` classes
and call them from Document::dumpState method within kit.Kit.cpp.
Because `dumpState` method of `_websocketHandler` is protected,
currently we can't dump its internals.

Also dump the other members of the `Document` class. Note that as
`_lastMemStatsTime` is never used, we don't dump it. It seems we could
simply delete it.

### TODO

- [ ] Dump `_websocketHandler`
- [x] Get rid of `_lastMemStatsTime` if it is not required for anything

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required
