### PR TITLE
Help dialogs: avoid closing it by mistake and make it selectable

### DIFF
--- a/loleaflet/css/override-vex.css
+++ b/loleaflet/css/override-vex.css
@@ -74,6 +74,15 @@
 	outline: none;
 }
 
+.vex-selectable {
+	-webkit-touch-callout: text;
+	-webkit-user-select: text;
+	-khtml-user-select: text;
+	-moz-user-select: text;
+	-ms-user-select: text;
+	user-select: text;
+}
+
 .vex.vex-theme-plain .vex-close:before {
 	width: 20px;
 	height: 20px;

--- a/loleaflet/src/control/Toolbar.js
+++ b/loleaflet/src/control/Toolbar.js
@@ -375,8 +375,9 @@ L.Map.include({
 			unsafeContent: data,
 			showCloseButton: true,
 			escapeButtonCloses: true,
-			overlayClosesOnClick: true,
+			overlayClosesOnClick: false,
 			closeAllOnPopState: false,
+			contentClassName: 'vex-content vex-selectable',
 			buttons: {},
 			afterOpen: function() {
 				var $vexContent = $(this.contentEl);


### PR DESCRIPTION
- Only close when user expressly pressed the close button
- Make it possible to select text

This type of dialogs with a lot of text should only be close when
pressing close button so to avoid accidentally closing it. The text
should also be selectable, allowing the user to save it in his own notes
, to share or to use it to simply report something

Fixes https://github.com/CollaboraOnline/online/issues/2357

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I88e01904bad4d0fa2504296c892e28ba6df9d112
