### PR TITLE
Use a loolwsd.xml setting instead of --enable-trace-event-logging

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -418,7 +418,7 @@ run: all @JAILS_PATH@
 			  --o:ssl.ca_file_path="$(abs_top_srcdir)/etc/ca-chain.cert.pem" \
 			  --o:admin_console.username=admin --o:admin_console.password=admin \
 			  --o:logging.file[@enable]=true --o:logging.level=trace \
-			  --enable-trace-event-logging
+			  --o:trace_event[@enable]=true
 
 if ENABLE_DEBUG
 run-one: all @JAILS_PATH@

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -35,6 +35,7 @@
 #include <androidapp.hpp>
 #endif
 
+#include <common/ConfigUtil.hpp>
 #include <common/FileUtil.hpp>
 #include <common/JsonUtil.hpp>
 #include <common/Authorization.hpp>
@@ -461,19 +462,19 @@ bool ChildSession::_handleInput(const char *buffer, int length)
         }
         else if (tokens.equals(0, "traceeventrecording"))
         {
-            if (EnableTraceEventLogging)
+            if (config::getBool("trace_event[@enable]", false))
             {
                 if (tokens.size() > 0)
                 {
                     if (tokens.equals(1, "start"))
                         {
                             getLOKit()->setOption("traceeventrecording", "start");
-                            LOG_INF("Trace Event recording in this kit process turned on (might have been on all the time)");
+                            LOG_INF("Trace Event recording in this kit process turned on (might have been on already)");
                         }
                     else if (tokens.equals(1, "stop"))
                     {
                         getLOKit()->setOption("traceeventrecording", "stop");
-                        LOG_INF("Trace Event recording in this kit process turned off");
+                        LOG_INF("Trace Event recording in this kit process turned off (might have been off already)");
                     }
                 }
             }

--- a/kit/ForKit.cpp
+++ b/kit/ForKit.cpp
@@ -642,12 +642,6 @@ int main(int argc, char** argv)
             eq = std::strchr(cmd, '=');
             UserInterface = std::string(eq+1);
         }
-
-        else if (std::strstr(cmd, "--enable-trace-event-logging") == cmd)
-        {
-            EnableTraceEventLogging = true;
-        }
-
     }
 
     if (loSubPath.empty() || sysTemplate.empty() ||

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -2769,6 +2769,4 @@ void dump_kit_state()
     LOG_TRC(msg);
 }
 
-bool EnableTraceEventLogging = false;
-
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/kit/Kit.hpp
+++ b/kit/Kit.hpp
@@ -144,6 +144,4 @@ std::string anonymizeUsername(const std::string& username);
 std::shared_ptr<lok::Document> getLOKDocumentForAndroidOnly();
 #endif
 
-extern bool EnableTraceEventLogging;
-
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/loleaflet/src/control/Toolbar.js
+++ b/loleaflet/src/control/Toolbar.js
@@ -717,8 +717,8 @@ L.Map.include({
 					map._docLayer.toggleTileDebugMode();
 
 					// Triple-clicking turns Trace Event recording on in the kit
-					// process for this document, as long as loolwsd has been
-					// started with the --enable-trace-event-logging option.
+					// process for this document, as long as loolwsd is running
+					// with the trace_event[@enable] config option as true.
 					// Triple-clicking again turns it off.
 
 					if (app.socket.enableTraceEventLogging) {

--- a/loolwsd.xml.in
+++ b/loolwsd.xml.in
@@ -73,8 +73,8 @@
         </anonymize>
     </logging>
 
-    <trace_event>
-      <path type="string" desc="Trace Event file path." default="@LOOLWSD_TRACEEVENTFILE@">@LOOLWSD_TRACEEVENTFILE@</path>
+    <trace_event desc="The possibility to turn on generation of a Chrome Trace Event file" enable="false">
+      <path desc="Output path for the Trace Event file, to which they will be written if turned on at run-time" type="string" default="@LOOLWSD_TRACEEVENTFILE@">@LOOLWSD_TRACEEVENTFILE@</path>
     </trace_event>
 
     <loleaflet_logging desc="Logging in the browser console" default="@LOLEAFLET_LOGGING@">@LOLEAFLET_LOGGING@</loleaflet_logging>

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -992,6 +992,7 @@ void LOOLWSD::innerInitialize(Application& self)
             { "storage.wopi[@allow]", "true" },
             { "storage.wopi.locking.refresh", "900" },
             { "sys_template_path", "systemplate" },
+            { "trace_event[@enable]", "false" },
             { "trace.path[@compress]", "true" },
             { "trace.path[@snapshot]", "false" },
             { "trace[@enable]", "false" },
@@ -1072,8 +1073,6 @@ void LOOLWSD::innerInitialize(Application& self)
         }
     }
 
-    const auto traceEventFile = getConfigValue<std::string>(conf, "trace_event.path", LOOLWSD_TRACEEVENTFILE);
-
     // Setup the logfile envar for the kit processes.
     if (logToFile)
     {
@@ -1095,8 +1094,11 @@ void LOOLWSD::innerInitialize(Application& self)
                 << LogLevel << "] until after WSD initialization.");
     }
 
+    EnableTraceEventLogging = getConfigValue<bool>(conf, "trace_event[@enable]", false);
+
     if (EnableTraceEventLogging)
     {
+        const auto traceEventFile = getConfigValue<std::string>(conf, "trace_event.path", LOOLWSD_TRACEEVENTFILE);
         LOG_INF("Trace Event file is " << traceEventFile << ".");
         TraceEventFile = fopen(traceEventFile.c_str(), "w");
         if (TraceEventFile != NULL)
@@ -1647,13 +1649,6 @@ void LOOLWSD::defineOptions(OptionSet& optionSet)
                         .repeatable(false)
                         .argument("path"));
 
-    optionSet.addOption(Option("enable-trace-event-logging", "",
-                               "Enable turning Trace Event recording and logging on and off. "
-                               "Note that this option does not turn it on, that needs to be done at run-time "
-                               "for a specific client.")
-                        .required(false)
-                        .repeatable(false));
-
 #if ENABLE_DEBUG
     optionSet.addOption(Option("unitlib", "", "Unit testing library path.")
                         .required(false)
@@ -1723,8 +1718,6 @@ void LOOLWSD::handleOption(const std::string& optionName,
         ConfigDir = value;
     else if (optionName == "lo-template-path")
         LoTemplate = value;
-    else if (optionName == "enable-trace-event-logging")
-        EnableTraceEventLogging = true;
 #if ENABLE_DEBUG
     else if (optionName == "unitlib")
         UnitTestLibrary = value;
@@ -2004,9 +1997,6 @@ bool LOOLWSD::createForKit()
 
     if (!CheckLoolUser)
         args.push_back("--disable-lool-user-checking");
-
-    if (EnableTraceEventLogging)
-        args.push_back("--enable-trace-event-logging");
 
 #if ENABLE_DEBUG
     if (SingleKit)


### PR DESCRIPTION
That is our convention, and this also avoids a global variable in the
kit process.

Change-Id: I37d2d53aa7eb24f9848fa8ef98bc57d75db90d13
Signed-off-by: Tor Lillqvist <tml@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

