### PR TITLE
avoid rendering for execution of ~every message

### DIFF
--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -269,6 +269,9 @@ L.Socket = L.Class.extend({
 	},
 
 	_emitSlurpedEvents: function() {
+		if (this._map && this._map._docLayer) {
+			this._map._docLayer.pauseDrawing();
+		}
 		// console.log2('Slurp events ' + that._slurpQueue.length);
 		for (var i = 0; i < this._slurpQueue.length; ++i) {
 			var evt = this._slurpQueue[i];
@@ -282,6 +285,11 @@ L.Socket = L.Class.extend({
 				// event stopping an unknown number of others.
 				console.log2('Exception ' + e + ' emitting event ' + evt.data);
 			}
+		}
+
+		if (this._map && this._map._docLayer) {
+			// Resume with redraw if dirty due to previous _onMessage() calls.
+			this._map._docLayer.resumeDrawing();
 		}
 	},
 

--- a/loleaflet/src/layer/tile/CanvasSectionContainer.ts
+++ b/loleaflet/src/layer/tile/CanvasSectionContainer.ts
@@ -305,6 +305,10 @@ class CanvasSectionContainer {
 		return this.zoomChanged;
 	}
 
+	isDrawingPaused (): boolean {
+		return this.drawingPaused;
+	}
+
 	pauseDrawing () {
 		if (!this.drawingPaused) {
 			this.dirty = false;
@@ -314,6 +318,10 @@ class CanvasSectionContainer {
 
 	resumeDrawing() {
 		if (this.drawingPaused) {
+			var scrollSection = <any>this.getSectionWithName(L.CSections.Scroll.name)
+			if (scrollSection)
+				scrollSection.completePendingScroll(); // No painting, only dirtying.
+
 			this.drawingPaused = false;
 			if (this.dirty) {
 				this.requestReDraw();

--- a/loleaflet/src/layer/tile/CanvasSectionContainer.ts
+++ b/loleaflet/src/layer/tile/CanvasSectionContainer.ts
@@ -232,6 +232,8 @@ class CanvasSectionContainer {
 	private mouseIsInside: boolean = false;
 	private inZoomAnimation: boolean = false;
 	private zoomChanged: boolean = false;
+	private drawingPaused: boolean = false;
+	private dirty: boolean = false;
 
 	// Below variables are related to animation feature.
 	private animatingSectionName: string = null; // The section that called startAnimating function. This variable is null when animations are not running.
@@ -301,6 +303,27 @@ class CanvasSectionContainer {
 
 	isZoomChanged (): boolean {
 		return this.zoomChanged;
+	}
+
+	pauseDrawing () {
+		if (!this.drawingPaused) {
+			this.dirty = false;
+			this.drawingPaused = true;
+		}
+	}
+
+	resumeDrawing() {
+		if (this.drawingPaused) {
+			this.drawingPaused = false;
+			if (this.dirty) {
+				this.requestReDraw();
+				this.dirty = false;
+			}
+		}
+	}
+
+	private setDirty() {
+		this.dirty = true;
 	}
 
 	/**
@@ -444,6 +467,12 @@ class CanvasSectionContainer {
 	}
 
 	requestReDraw() {
+		if (this.drawingPaused) {
+			// Someone requested a redraw, but we're paused => schedule a redraw.
+			this.setDirty();
+			return;
+		}
+
 		if (!this.getAnimatingSectionName())
 			this.drawSections();
 	}

--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -671,6 +671,16 @@ L.CanvasTileLayer = L.TileLayer.extend({
 		}
 	},
 
+	pauseDrawing: function () {
+		if (this._painter && this._painter._sectionContainer)
+			this._painter._sectionContainer.pauseDrawing();
+	},
+
+	resumeDrawing: function () {
+		if (this._painter && this._painter._sectionContainer)
+			this._painter._sectionContainer.resumeDrawing();
+	},
+
 	_getUIWidth: function () {
 		var section = this._painter._sectionContainer.getSectionWithName(L.CSections.RowHeader.name);
 		if (section) {

--- a/loleaflet/src/layer/tile/ScrollSection.ts
+++ b/loleaflet/src/layer/tile/ScrollSection.ts
@@ -31,6 +31,7 @@ class ScrollSection {
 	resetAnimation: Function; // Implemented by container.
 	map: any;
 	autoScrollTimer: any;
+	pendingScrollEvent: any = null;
 
 	constructor () {
 		this.name = L.CSections.Scroll.name;
@@ -105,7 +106,19 @@ class ScrollSection {
 		this.sectionProperties.animatingHorizontalScrollBar = false;
 	}
 
-	public onScrollTo (e: any) {
+	public completePendingScroll() {
+		if (this.pendingScrollEvent) {
+			this.onScrollTo(this.pendingScrollEvent, true /* force */)
+			this.pendingScrollEvent = null;
+		}
+	}
+
+	public onScrollTo (e: any, force: boolean = false) {
+		if (!force && this.containerObject.isDrawingPaused()) {
+			// Only remember the last scroll-to position.
+			this.pendingScrollEvent = e;
+			return;
+		}
 		// Triggered by the document (e.g. search result out of the viewing area).
 		this.map.scrollTop(e.y, {});
 		this.map.scrollLeft(e.x, {});


### PR DESCRIPTION
Send the canvas container into a paused state just before a batch of
queued messages are going to be executed. During this state the
container dirties itself for every requestRedraw() call. After all
messages in the current slurp batch is executed, resume rendering
starting with a re-render if necessary based on dirty flag.

Signed-off-by: Dennis Francis <dennis.francis@collabora.com>
Change-Id: Ice5347aac78f4f19642b96edb929836b15c55599


* Resolves: # <!-- related github issue -->
* Target version: master 

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

