### PR TITLE
Allow easy configuation of the user-id that is accepted.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -413,6 +413,14 @@ clean-local:
 	if test "z@JAILS_PATH@" != "z"; then rm -rf "@JAILS_PATH@"; fi
 	if test "z@SYSTEMPLATE_PATH@" != "z"; then rm -rf "@SYSTEMPLATE_PATH@"; fi
 
+if ENABLE_DEBUG
+# can write to /tmp/loolwsd.log
+  OUTPUT_TO_FILE=true
+else
+# can't write to /var/log/loolwsd.log
+  OUTPUT_TO_FILE=false
+endif
+
 run: all @JAILS_PATH@
 	@echo "Launching loolwsd"
 	@fc-cache "@LO_PATH@"/share/fonts/truetype
@@ -427,7 +435,7 @@ run: all @JAILS_PATH@
 			  --o:ssl.key_file_path="$(abs_top_srcdir)/etc/key.pem" \
 			  --o:ssl.ca_file_path="$(abs_top_srcdir)/etc/ca-chain.cert.pem" \
 			  --o:admin_console.username=admin --o:admin_console.password=admin \
-			  --o:logging.file[@enable]=true --o:logging.level=trace
+			  --o:logging.file[@enable]=${OUTPUT_TO_FILE} --o:logging.level=trace
 
 if ENABLE_DEBUG
 run-one: all @JAILS_PATH@

--- a/common/security.h
+++ b/common/security.h
@@ -18,7 +18,9 @@
 #include <string.h>
 #include <stdio.h>
 
-#define LOOL_USER_ID "lool"
+#ifndef COOL_USER_ID
+#  error "include config.h for user id";
+#endif
 
 #ifndef KIT_IN_PROCESS
 inline int hasUID(const char *userId)
@@ -61,10 +63,10 @@ inline int hasCorrectUID(const char *appName)
     (void)appName;
     return 1; // insecure but easy to use.
 #else
-    if (hasUID(LOOL_USER_ID))
+    if (hasUID(COOL_USER_ID))
         return 1;
     else {
-        fprintf(stderr, "Security: %s incorrect user-name, other than '" LOOL_USER_ID "'\n", appName);
+        fprintf(stderr, "Security: %s incorrect user-name, other than '" COOL_USER_ID "'\n", appName);
         return 0;
     }
 #endif

--- a/configure.ac
+++ b/configure.ac
@@ -182,6 +182,10 @@ AC_ARG_WITH([app-name],
               AS_HELP_STRING([--with-app-name=<name>],
                              [Set the user-visible name of the app you build.]))
 
+AC_ARG_WITH([user-id],
+              AS_HELP_STRING([--with-user-id=lool],
+                             [Set the account name of the user required to run the app (outside debug mode).]))
+
 AC_ARG_WITH([icon-theme],
               AS_HELP_STRING([--with-icon-theme=<path>],
                              [Path to custom icon theme (similar to loleflet/images).]))
@@ -1080,6 +1084,12 @@ AC_SUBST(LOOLWSD_CONFIGDIR)
 
 LOOLWSD_DATADIR=${datadir}/${PACKAGE}
 AC_SUBST(LOOLWSD_DATADIR)
+
+COOL_USER_ID="lool"
+if test -n "$with_user_id"; then
+   COOL_USER_ID="$with_user_id"
+fi
+AC_DEFINE_UNQUOTED([COOL_USER_ID],["$COOL_USER_ID"],[The user-name which is allowed to run loolwsd and its tools])
 
 AM_CONDITIONAL([ENABLE_SETCAP], [test "$enable_setcap" != "no"])
 


### PR DESCRIPTION
So if you're debugging the product build you can use:

 --with-user-id=`whoami`

Change-Id: I3f753b83c0806729d36d45293bc2b6a38d50fdbb


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

