### PR TITLE
Calc Formular bar alignment #809

### DIFF
--- a/loleaflet/css/toolbar.css
+++ b/loleaflet/css/toolbar.css
@@ -93,6 +93,14 @@ w2ui-toolbar {
 	height: 30px;
 }
 
+.w2ui-reset * {
+	vertical-align: top;
+}
+
+#tb_formulabar_item_address, #tb_formulabar_item_item_2, #tb_formulabar_item_functiondialog {
+	padding-top: 2px;
+}
+
 #presentation-toolbar {
 	background-color: #dfdfdf;
 	text-align: center;
@@ -150,11 +158,12 @@ w2ui-toolbar {
 	width: 100%;
 	position: relative;
 	padding: 0px;
-	margin: 0px 0px -4px;
+	margin: 0px;
 }
 
 #tb_formulabar_item_formula {
 	width: 100%;
+	padding-top: 4px;
 }
 
 #tb_formulabar_item_formula div table {


### PR DESCRIPTION
When the formular toolbar was extended the tunneled toolbar missed the bottom horizontal line, the reason was the bottom margin was defined with -4px. That was fixed.
The toolbar .w2ui-reset was vertical-align center but at extended formular input field is has to be top aligned + some padding fixes

Signed-off-by: Andreas-Kainz <kainz.a@gmail.com>
Change-Id: Ibd94b3beb815bce8a1e5e6de09d89b47be19df2a
