### PR TITLE
3 new build-time configurable settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 .vscode
 Makefile
 Makefile.in
+loolkitconfig.xcu
 loolwsd.spec
 loolwsd.xml
 aclocal.m4

--- a/configure.ac
+++ b/configure.ac
@@ -307,6 +307,22 @@ AC_ARG_ENABLE([vereign],
 AC_ARG_ENABLE([cypress],
             AS_HELP_STRING([--enable-cypress],
                            [Enable cypress tests.]))
+
+AC_ARG_WITH([help-url],
+            AS_HELP_STRING([--with-help-url=<url>],
+                [Set the base URL of the online help. Default is https://help.collaboraoffice.com/help.html?])
+                [--without-help-url Help buttons of dialogs will be disabled, external help website will not be used.],,)
+
+AC_ARG_WITH([core-icon-theme],
+            AS_HELP_STRING([--with-core-icon-theme=<theme>],
+                [Set the icon theme coming from core (tunneled sidebar, tunneled dialogs). The default is colibre.]))
+
+AC_ARG_WITH([dictionaries],
+            AS_HELP_STRING([--with-dictionaries=<language list>],
+                [List of supported languages of Writing Aids (spell checker, grammar checker, thesaurus, hyphenation)
+                 on this instance. Allowing too many has negative effect on startup performance. Default: de_DE en_GB
+                 en_US es_ES fr_FR it nl pt_BR pt_PT ru.]))
+
 # Handle options
 AS_IF([test "$enable_debug" = yes -a -n "$with_poco_libs"],
       [POCO_DEBUG_SUFFIX=d],
@@ -1110,7 +1126,6 @@ fi
 AC_SUBST(ENABLE_SETCAP)
 
 AC_CONFIG_LINKS([discovery.xml:discovery.xml])
-AC_CONFIG_LINKS([loolkitconfig.xcu:loolkitconfig.xcu])
 AC_CONFIG_LINKS([loleaflet/package.json:loleaflet/package.json])
 AC_CONFIG_LINKS([cypress_test/package.json:cypress_test/package.json])
 AC_CONFIG_LINKS([cypress_test/cypress.json:cypress_test/cypress.json])
@@ -1195,12 +1210,45 @@ else
 fi
 AM_CONDITIONAL([ENABLE_CYPRESS], [$ENABLE_CYPRESS])
 
+AC_MSG_CHECKING([for URL of online help])
+if test -n "$with_help_url" -a "$with_help_url" != "no"; then
+    HELP_URL="$with_help_url"
+    AC_MSG_RESULT([custom: $HELP_URL])
+elif test "$with_help_url" = "no"; then
+    HELP_URL=
+    AC_MSG_RESULT([none, help buttons are disabled])
+else
+    HELP_URL="https://help.collaboraoffice.com/help.html?"
+    AC_MSG_RESULT([default: $HELP_URL])
+fi
+AC_SUBST(HELP_URL)
+
+AC_MSG_CHECKING([for icon theme from core (tunneled sidebar, tunneled dialogs)])
+if test -n "$with_core_icon_theme" -a "$with_core_icon_theme" != "no"; then
+    ICON_THEME="$with_core_icon_theme"
+    AC_MSG_RESULT([custom: $ICON_THEME])
+else
+    ICON_THEME="colibre"
+    AC_MSG_RESULT([default: $ICON_THEME])
+fi
+AC_SUBST(ICON_THEME)
+
+AC_MSG_CHECKING([for allowed languages for Writing Aids])
+if test -n "$with_dictionaries" -a "$with_dictionaries" != "no"; then
+    ALLOWED_LANGUAGES="$with_dictionaries"
+else
+    ALLOWED_LANGUAGES="de_DE en_GB en_US es_ES fr_FR it nl pt_BR pt_PT ru"
+fi
+AC_MSG_RESULT([$ALLOWED_LANGUAGES])
+AC_SUBST(ALLOWED_LANGUAGES)
+
 AC_CONFIG_FILES([Makefile
                  cypress_test/Makefile
                  gtk/Makefile
                  test/Makefile
                  loleaflet/Makefile
                  loleaflet/npm-shrinkwrap.json
+                 loolkitconfig.xcu
                  loolwsd.spec
                  loolwsd.xml
                  debian/loolwsd.postinst])

--- a/loolkitconfig.xcu.in
+++ b/loolkitconfig.xcu.in
@@ -11,7 +11,7 @@
 <item oor:path="/org.openoffice.Office.Common/AutoCorrect"><prop oor:name="TwoCapitalsAtStart" oor:op="fuse"><value>false</value></prop></item>
 
 <!-- The Help root URL, or empty for no help (hides the help buttons) -->
-<item oor:path="/org.openoffice.Office.Common/Help"><prop oor:name="HelpRootURL" oor:op="fuse"><value>https://help.collaboraoffice.com/help.html?</value></prop></item>
+<item oor:path="/org.openoffice.Office.Common/Help"><prop oor:name="HelpRootURL" oor:op="fuse"><value>@HELP_URL@</value></prop></item>
 
 <!-- Enable spell-checking by default -->
 <item oor:path="/org.openoffice.Office.Linguistic/SpellChecking"><prop oor:name="IsSpellAuto" oor:op="fuse"><value>true</value></prop></item>
@@ -25,8 +25,8 @@
 <!-- Enable thumbnail generation by default (disabling saves CPU time) -->
 <item oor:path="/org.openoffice.Office.Common/Save/Document"><prop oor:name="GenerateThumbnail" oor:op="fuse"><value>true</value></prop></item>
 
-<!-- Use the colibre theme for the sidebar -->
-<item oor:path="/org.openoffice.Office.Common/Misc"><prop oor:name="SymbolStyle" oor:op="fuse"><value>colibre</value></prop></item>
+<!-- Set the theme and icon size for the sidebar -->
+<item oor:path="/org.openoffice.Office.Common/Misc"><prop oor:name="SymbolStyle" oor:op="fuse"><value>@ICON_THEME@</value></prop></item>
 <item oor:path="/org.openoffice.Office.Common/Misc"><prop oor:name="SidebarIconSize" oor:op="fuse"><value>2</value></prop></item>
 
 <!-- To show Hidden Characters and Hiddent Text/Paragraph fields -->

--- a/loolwsd.xml.in
+++ b/loolwsd.xml.in
@@ -3,7 +3,7 @@
     <!-- Note: 'default' attributes are used to document a setting's default value as well as to use as fallback. -->
     <!-- Note: When adding a new entry, a default must be set in WSD in case the entry is missing upon deployment. -->
 
-    <allowed_languages desc="List of supported languages of Writing Aids (spell checker, grammar checker, thesaurus, hyphenation) on this instance. Allowing too many has negative effect on startup performance." default="de_DE en_GB en_US es_ES fr_FR it nl pt_BR pt_PT ru">de_DE en_GB en_US es_ES fr_FR it nl pt_BR pt_PT ru</allowed_languages>
+    <allowed_languages desc="List of supported languages of Writing Aids (spell checker, grammar checker, thesaurus, hyphenation) on this instance. Allowing too many has negative effect on startup performance." default="de_DE en_GB en_US es_ES fr_FR it nl pt_BR pt_PT ru">@ALLOWED_LANGUAGES@</allowed_languages>
 
     <sys_template_path desc="Path to a template tree with shared libraries etc to be used as source for chroot jails for child processes." type="path" relative="true" default="systemplate"></sys_template_path>
     <child_root_path desc="Path to the directory under which the chroot jails for the child processes will be created. Should be on the same file system as systemplate and lotemplate. Must be an empty directory." type="path" relative="true" default="jails"></child_root_path>


### PR DESCRIPTION
Now it is possible:
- to disable Help buttons and jumping to external website of Online Help (--without-help-url)
- set the icon theme of tunneled dialogs and sidebar (--with-core-icon-theme=<theme>)
- set the list of allowed dictionaries (--with-dictionaries=<language list>)

This patch obsoletes the packaging hacks that we had to use for certain customers.

Signed-off-by: Andras Timar <andras.timar@collabora.com>
Change-Id: I450f66ac133f6fcefae2bda9f29e04405ef3a6b7


