### PR TITLE
make run should log to the console in product mode.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -403,6 +403,14 @@ clean-local:
 	if test "z@JAILS_PATH@" != "z"; then rm -rf "@JAILS_PATH@"; fi
 	if test "z@SYSTEMPLATE_PATH@" != "z"; then rm -rf "@SYSTEMPLATE_PATH@"; fi
 
+if ENABLE_DEBUG
+# can write to /tmp/loolwsd.log
+  OUTPUT_TO_FILE=true
+else
+# can't write to /var/log/loolwsd.log
+  OUTPUT_TO_FILE=false
+endif
+
 run: all @JAILS_PATH@
 	@echo "Launching loolwsd"
 	@fc-cache "@LO_PATH@"/share/fonts/truetype
@@ -417,7 +425,7 @@ run: all @JAILS_PATH@
 			  --o:ssl.key_file_path="$(abs_top_srcdir)/etc/key.pem" \
 			  --o:ssl.ca_file_path="$(abs_top_srcdir)/etc/ca-chain.cert.pem" \
 			  --o:admin_console.username=admin --o:admin_console.password=admin \
-			  --o:logging.file[@enable]=true --o:logging.level=trace \
+			  --o:logging.file[@enable]=${OUTPUT_TO_FILE} --o:logging.level=trace \
 			  --enable-trace-event-logging
 
 if ENABLE_DEBUG


### PR DESCRIPTION
We don't have permission for /var/log/loolwsd.log typically.

Change-Id: I37c04bfba25c4c8241b2d92d77d93e5a3b662d82
Signed-off-by: Michael Meeks <michael.meeks@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

