### PR TITLE
Render grid-lines in horizontal strips for performance.

### DIFF
--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -350,7 +350,6 @@ L.TileSectionManager = L.Class.extend({
 		context.lineWidth = 1.0;
 
 		var ctx = this.sectionProperties.tsManager._paintContext();
-		context.beginPath();
 		for (var i = 0; i < ctx.paneBoundsList.length; ++i) {
 			// co-ordinates of this pane in core document pixels
 			var paneBounds = ctx.paneBoundsList[i];
@@ -374,27 +373,40 @@ L.TileSectionManager = L.Class.extend({
 				paneOffset = paneTopLeft.clone();
 			}
 
-			// URGH -> zooming etc. (!?) ...
-			this.sectionProperties.docLayer.sheetGeometry._columns.forEachInCorePixelRange(
-				repaintArea.min.x, repaintArea.max.x,
-				function(pos) {
-					context.moveTo(pos - paneOffset.x - 0.5, repaintArea.min.y - paneOffset.y + 0.5);
-					context.lineTo(pos - paneOffset.x - 0.5, repaintArea.max.y - paneOffset.y - 0.5);
-					context.stroke();
-				});
+			// Vertical line rendering on large areas is ~10x as expensive
+			// as horizontal line rendering: due to cache effects - so to
+			// help our poor CPU renderers - render in horizontal strips.
+			var bandSize = 256;
+			for (var miny = repaintArea.min.y; miny < repaintArea.max.y; miny += bandSize)
+			{
+				var maxy = Math.min(repaintArea.max.y, miny + bandSize);
 
-			this.sectionProperties.docLayer.sheetGeometry._rows.forEachInCorePixelRange(
-				repaintArea.min.y, repaintArea.max.y,
-				function(pos) {
-					context.moveTo(repaintArea.min.x - paneOffset.x + 0.5, pos - paneOffset.y - 0.5);
-					context.lineTo(repaintArea.max.x - paneOffset.x - 0.5, pos - paneOffset.y - 0.5);
-					context.stroke();
-				});
+				context.beginPath();
+
+				// vertical lines
+				this.sectionProperties.docLayer.sheetGeometry._columns.forEachInCorePixelRange(
+					repaintArea.min.x, repaintArea.max.x,
+					function(pos) {
+						context.moveTo(pos - paneOffset.x - 0.5, miny - paneOffset.y + 0.5);
+						context.lineTo(pos - paneOffset.x - 0.5, maxy - paneOffset.y - 0.5);
+						context.stroke();
+					});
+
+				// horizontal lines
+				this.sectionProperties.docLayer.sheetGeometry._rows.forEachInCorePixelRange(
+					miny, maxy,
+					function(pos) {
+						context.moveTo(repaintArea.min.x - paneOffset.x + 0.5, pos - paneOffset.y - 0.5);
+						context.lineTo(repaintArea.max.x - paneOffset.x - 0.5, pos - paneOffset.y - 0.5);
+						context.stroke();
+					});
+
+				context.closePath();
+			}
 
 			if (doOnePane)
 				break;
 		}
-		context.closePath();
 	},
 
 	// This section is added when debug is enabled. Splits are enabled for only Calc for now.


### PR DESCRIPTION
Interestingly for large CPU rendered skia surfaces - as used by
many browsers, rendering well spaced vertical lines is inordinately
expensive: 10x slower than horizontal ones, presumably due to cache
effects.

Grid rendering is around ~40% of our rendering performance measured
by knocking out various elements we render and re-timing.

By banding our vertical lines to re-use pixels close to where we
are drawing horizontal lines, and by creating more smaller paths
we get at ~25% overall performance improvement - 70ms -> 53ms
avg of ~10 frames.

Change-Id: I8ad1007b74866bd3d7b1b838f226a3efadcccbed
Signed-off-by: Michael Meeks <michael.meeks@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

