### PR TITLE
Notebookbar: context tabs when selected: fix alignment

### DIFF
--- a/loleaflet/css/notebookbar.css
+++ b/loleaflet/css/notebookbar.css
@@ -30,6 +30,7 @@
 }
 
 .ui-tab.selected.notebookbar {
+	display: flex !important;
 	border: 0px;
 	border-radius: 0px;
 	background: #fff;


### PR DESCRIPTION
Context tabs were being shown via JS by setting display property to block
this in turn was maligning the tab's title ( as it's expecting flex)

Fixes #2385

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I28e56f3f78390a626780bfbd1a302fef9c90ba38
