### PR TITLE
loleaflet: fix builddir != srcdir

### DIFF
--- a/loleaflet/Makefile.am
+++ b/loleaflet/Makefile.am
@@ -568,7 +568,7 @@ $(DIST_FOLDER)/welcome/%.html: $(srcdir)/welcome/%.html
 	fi
 
 tscompile.done: $(LOLEAFLET_JS_SRC) $(LOLEAFLET_TS_SRC)
-	$(builddir)/node_modules/typescript/bin/tsc --outDir $(DIST_FOLDER)/src --rootDir $(srcdir)/src --allowJs true --checkJs false --project $(srcdir)/tsconfig.json
+	$(builddir)/node_modules/typescript/bin/tsc --typeRoots $(builddir)/node_modules/@types --outDir $(DIST_FOLDER)/src --rootDir $(srcdir)/src --allowJs true --checkJs false --project $(srcdir)/tsconfig.json
 	@touch $@
 
 $(LOLEAFLET_TS_JS_DST): tscompile.done


### PR DESCRIPTION
error TS2503: Cannot find namespace 'NodeJS'

Change-Id: Id4f9fba48095d80725de97ef3bc464602707bf91
Signed-off-by: Henry Castro <hcastro@collabora.com>
