### PR TITLE
Cypress: Toggle bulleted list test: scroll before testing

### DIFF
--- a/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
@@ -251,6 +251,9 @@ describe('Top toolbar tests.', function() {
 	});
 
 	it('Toggle bulleted list.', function() {
+		cy.get('#toolbar-up .w2ui-scroll-right')
+			.click();
+
 		cy.get('#tb_editbar_item_defaultbullet')
 			.click();
 


### PR DESCRIPTION
Default cypress view is too small, scroll first and then
attempt clicking in the bullet icon. This fixes failing tests
on this spec. No need to skip the test anymore.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Idffbfec94f94c784b03815c21ece0b8d38a8ba0e
