### PR TITLE
Mobile: applystyle: Set different string for static label

### DIFF
--- a/loleaflet/src/control/Control.JSDialogBuilder.js
+++ b/loleaflet/src/control/Control.JSDialogBuilder.js
@@ -1637,6 +1637,8 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			data.text = _('Font Name');
 		} else if (data.command == '.uno:FontHeight') {
 			data.text = _('Font Size');
+		} else if (data.command == '.uno:StyleApply') {
+			data.text = _('Style');
 		}
 	},
 


### PR DESCRIPTION
Reuse existent font to set a different label for applystyle command.
- Avoid duplicates (icon value-string      value-string  > )
- Fixes layout breakage (no space)
- Set it as "translatable" string
- Translation needs to be updated

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I2d10c772a15fcb36a7169d77ff72cb5e5f6f7ed1
