### PR TITLE
Calc: spreadsheet tab bar smaler height

### DIFF
--- a/loleaflet/css/device-mobile.css
+++ b/loleaflet/css/device-mobile.css
@@ -188,7 +188,7 @@ div#w2ui-overlay-actionbar.w2ui-overlay{
 	}
 }
 
-.spreadsheet-tab{
+.spreadsheet-tab {
 	background-color: #eaf5ff;
 	color: #4c4c4c;
 	border-radius: 3px;
@@ -196,6 +196,7 @@ div#w2ui-overlay-actionbar.w2ui-overlay{
 	padding-top: 2px;
 	padding-bottom: 6px;
 	margin-top: 4px;
+	height: 100%;
 }
 
 .spreadsheet-tab-selected{
@@ -232,7 +233,7 @@ div#w2ui-overlay-actionbar.w2ui-overlay{
 	bottom: 0;
 	background-color: #fbfbfb;
 	border-top: 1px solid #eceff4;
-	height: 40px;
+	height: 36px;
 	padding-top: 6px;
 	padding-left: 1px;
 	padding-bottom: 0px;
@@ -243,6 +244,7 @@ div#w2ui-overlay-actionbar.w2ui-overlay{
 	margin-top: 0px !important;
 	margin-bottom: 0px !important;
 }
+
 #toolbar-down table.w2ui-button.over {
 	border: 1px solid #eee;
 	background-color: #eeeeee;

--- a/loleaflet/css/spreadsheet.css
+++ b/loleaflet/css/spreadsheet.css
@@ -2,7 +2,7 @@
 	border-top: 1px solid var(--gray-color);
 	top: 137px;
 	left: 50px;
-	bottom: 68px;
+	bottom: 56px;
 }
 
 #document-container.spreadsheet-document.readonly {
@@ -16,15 +16,14 @@
 .spreadsheet-tabs-container {
 	margin: 0;
 	padding: 0;
-	left: 142px;
+	left: 144px;
 	right: 0;
-	bottom: 36px;
+	bottom: 29px;
 	position: absolute;
 	cursor: pointer;
-	height: 39px;
+	height: 36px;
 	overflow: hidden;
 	white-space: nowrap;
-
 	background-color: var(--gray-light-bg-color);
 }
 
@@ -32,7 +31,7 @@
 	width: 100%;
 	height: 100%;
 	overflow: auto;
-	padding-bottom: 20px; /* to hide the horizontal scrollbar */
+	padding-bottom: 29px; /* to hide the horizontal scrollbar */
 	margin-left: 6px;
 }
 

--- a/loleaflet/css/spreadsheet.css
+++ b/loleaflet/css/spreadsheet.css
@@ -36,8 +36,8 @@
 }
 
 .spreadsheet-tab {
-	margin: 5px 3px 0px 0px !important;
-	padding: 8px 9px 5px !important;
+	margin: 0px 3px 0px 0px !important;
+	padding: 5px 9px !important;
 	text-decoration: none;
 
 	font: 12px/1.5 var(--loleaflet-font);

--- a/loleaflet/css/toolbar.css
+++ b/loleaflet/css/toolbar.css
@@ -83,8 +83,7 @@ w2ui-toolbar {
 #spreadsheet-toolbar {
 	left: 0;
 	text-align: center;
-	bottom: 35px;
-	padding: 7px 0px 0px;
+	bottom: 29px;
 	position: absolute;
 }
 
@@ -786,7 +785,7 @@ button.leaflet-control-search-next
 .w2ui-icon.equal{ background: url('images/lc26049.svg') no-repeat center !important; }
 .w2ui-icon.help{ background: url('images/lc_helpindex.svg') no-repeat center !important; }
 .w2ui-icon.insertpage{ background: url('images/lc_insertpage.svg') no-repeat center !important; }
-.w2ui-icon.insertsheet{ background: url('images/plus.svg') no-repeat center !important; }
+.w2ui-icon.insertsheet{ background: url('images/plus.svg') no-repeat center !important; height: 16px !important; }
 .w2ui-icon.conditionalformatdialog{ background: url('images/lc_conditionalformatdialog.svg') no-repeat center !important; }
 .w2ui-icon.search{ background: url('images/sc_recsearch.svg') no-repeat center !important; }
 .w2ui-icon.next{ background: url('images/lc_downsearch.svg') no-repeat center !important; }
@@ -799,10 +798,10 @@ button.leaflet-control-search-next
 .w2ui-icon.zoomout{ background: url('images/minus.svg') no-repeat center !important; }
 .w2ui-icon.zoomreset{ background: url('images/lc_view100.svg') no-repeat center !important; }
 .w2ui-icon.more{ background: url('images/lc_downsearch.svg') no-repeat center !important; }
-.w2ui-icon.firstrecord{ background: url('images/lc_firstrecord.svg') no-repeat center !important; }
-.w2ui-icon.nextrecord{ background: url('images/lc_nextrecord.svg') no-repeat center !important; }
-.w2ui-icon.prevrecord{ background: url('images/lc_prevrecord.svg') no-repeat center !important; }
-.w2ui-icon.lastrecord{ background: url('images/lc_lastrecord.svg') no-repeat center !important; }
+.w2ui-icon.firstrecord{ background: url('images/lc_firstrecord.svg') no-repeat center !important; height: 16px !important; }
+.w2ui-icon.nextrecord{ background: url('images/lc_nextrecord.svg') no-repeat center !important; height: 16px !important; }
+.w2ui-icon.prevrecord{ background: url('images/lc_prevrecord.svg') no-repeat center !important; height: 16px !important; }
+.w2ui-icon.lastrecord{ background: url('images/lc_lastrecord.svg') no-repeat center !important; height: 16px !important; }
 .w2ui-icon.sortascending{ background: url('images/lc_sortascending.svg') no-repeat center !important; }
 .w2ui-icon.sortdescending{ background: url('images/lc_sortdescending.svg') no-repeat center !important; }
 .w2ui-icon.selected{ background: url('images/lc_ok.svg') no-repeat center !important; }


### PR DESCRIPTION
icons in the calc tab bar: 16px height
tabs move down so that the height can be shrinked

save around 10 px for content stuff

Signed-off-by: Andreas-Kainz <kainz.a@gmail.com>
Change-Id: I21a43244674bf80a20cc3e9de295ba77ba20b686
