### PR TITLE
Enable building the iOS app completely on macOS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -75,7 +75,7 @@ for MODULE in lxml polib; do
         AC_MSG_RESULT([yes])
     else
         AC_MSG_RESULT([no])
-        AS_IF([test `uname -s` = Linux -o `uname -s` = FreeBSD],
+        AS_IF([test `uname -s` = Linux -o `uname -s` = FreeBSD -o `uname -s`= Darwin],
               [AC_MSG_ERROR([${MODULE} for python3 is needed. It might be in a package called python3-${MODULE}.])],
               [AC_MSG_WARN([${MODULE} for python3 is needed. It might be in a package called python3-${MODULE}. But
                if you are building the JS bits on another (Linux) machine, that doesn't matter])])
@@ -116,9 +116,7 @@ AC_ARG_ENABLE([anonymization],
 
 AC_ARG_ENABLE([iosapp],
               AS_HELP_STRING([--enable-iosapp],
-                             [Use in a tree where the only purpose is to build the HTML and CSS stuff
-                              to be copied to a Mac where the iOS app is being built, *or* in a tree where
-                              you will build the iOS app.]))
+                             [Use on a Mac where you will build the iOS app.]))
 
 AC_ARG_WITH([iosapp-appicon],
               AS_HELP_STRING([--with-iosapp-appicon=<path>],
@@ -592,8 +590,12 @@ AC_DEFINE_UNQUOTED([CORE_VERSION_HASH],[["$CORE_VERSION_HASH"]],[LibreOffice cor
 
 LIBPNG_INCLUDES="$with_libpng_includes"
 LIBPNG_LIBS="$with_libpng_libs"
-LOKIT_PATH=`readlink -f $with_lokit_path`
-if test "$enable_androidapp" = "yes"; then
+
+if test "$enable_iosapp" != yes -a "$enable_androidapp" != yes; then
+   LOKIT_PATH=`readlink -f $with_lokit_path`
+fi
+
+if test "$enable_iosapp" = "yes" -o "$enable_androidapp" = "yes"; then
    if test -n "$LIBPNG_INCLUDES" ; then
       AC_MSG_ERROR([--with-libpng-includes is ignored on Android, please remove the parameter.])
    fi
@@ -1060,29 +1062,36 @@ AS_IF([test "$ENABLE_IOSAPP" != "true" -a "$ENABLE_ANDROIDAPP" != "true"],
 
        ])
 
-AS_IF([test `uname -s` = "Linux" -o `uname -s` = "FreeBSD"],
-      # We need npm and node only on Linux, both in the normal Online case,
-      # and when only building JS for the iOS app. When building the iOS app itself on macOS,
-      # don't do this.
-      [AC_PATH_PROG(NPM, npm, no)
-       if test "$NPM" = "no"; then
-           AC_MSG_ERROR([npm required to build loleaflet, but not installed])
-       else
-           NPM_VER=`npm -v | awk -F. '{ print (($1 * 100) + $2) * 100 + $3;}'`
-           if test "$NPM_VER" -lt 50000; then
-               AC_MSG_ERROR([This npm version is too old, upgrade to >= 5.0.0])
-           fi
-       fi
-
-       AC_PATH_PROG(NODE, node, no)
+AS_IF([test `uname -s` = "Linux" -o `uname -s` = "FreeBSD" -o `uname -s` = "Darwin"],
+      # We need npm and node unconditionally only on Linux, both in the normal Online case, and when
+      # only building loleaflet for the iOS app. When building the iOS app itself on macOS, this is
+      # optional. If node and npm are not available, loleaflet will have to be built on a Linux box.
+      [AC_PATH_PROG(NODE, node, no)
        if test "$NODE" = "no"; then
-           AC_MSG_ERROR([node required to build loleaflet, but not installed])
+           if test `uname -s` = "Darwin"; then
+               AC_MSG_WARN([The loleaflet bits will have to be built on a Linux machine and copied over])
+           else
+               AC_MSG_ERROR([node required to build loleaflet, but not installed])
+           fi
        else
            NODE_VER=`node --version | sed 's/^v//' | awk -F. '{ print (($1 * 100) + $2) * 100 + $3;}'`
            if test "$NODE_VER" -lt 100000; then
                AC_MSG_ERROR([This node version is old, upgrade to >= 10.0.0])
            fi
        fi
+
+       if test "$NODE" != "no"; then
+           AC_PATH_PROG(NPM, npm, no)
+           if test "$NPM" = "no"; then
+               AC_MSG_ERROR([npm required to build loleaflet, but not installed])
+           else
+               NPM_VER=`npm -v | awk -F. '{ print (($1 * 100) + $2) * 100 + $3;}'`
+               if test "$NPM_VER" -lt 50000; then
+                   AC_MSG_ERROR([This npm version is too old, upgrade to >= 5.0.0])
+               fi
+           fi
+       fi
+
        if test "$enable_cypress" = "yes"; then
            AC_PATH_PROGS(CHROME, chromium chromium-browser chrome google-chrome, no)
            if test "$CHROME" = "no"; then

--- a/loleaflet/Makefile.am
+++ b/loleaflet/Makefile.am
@@ -43,9 +43,8 @@ JQUERY_MINIFIED_DIST_IMAGES = $(patsubst $(JQUERY_MINIFIED_IMAGE_PATH)/%.png,$(D
 
 LOLEAFLET_IMAGES_SRC = $(shell find $(srcdir)/images -name '*.*')
 LOLEAFLET_IMAGES_DST = $(patsubst $(srcdir)/%,$(DIST_FOLDER)/%,$(LOLEAFLET_IMAGES_SRC))
-LOLEAFLET_IMAGES_CUSTOM_SRC = $(shell find $(CUSTOM_ICONS_DIRECTORY) -name '*.*')
+LOLEAFLET_IMAGES_CUSTOM_SRC = $(shell if test -n "$(CUSTOM_ICONS_DIRECTORY)"; then find $(CUSTOM_ICONS_DIRECTORY) -name '*.*'; fi)
 LOLEAFLET_IMAGES_CUSTOM_DST = $(patsubst $(CUSTOM_ICONS_DIRECTORY)/%,$(DIST_FOLDER)/images/%,$(LOLEAFLET_IMAGES_CUSTOM_SRC))
-
 LOLEAFLET_L10N_SRC = $(shell find $(srcdir)/l10n -name '*.*')
 if !ENABLE_MOBILEAPP
 LOLEAFLET_L10N_DST =  $(patsubst $(srcdir)/l10n/%,$(DIST_FOLDER)/l10n/%,$(LOLEAFLET_L10N_SRC))
@@ -473,7 +472,7 @@ $(INTERMEDIATE_DIR)/admin-src.js: $(LOLEAFLET_ADMIN_TS_JS) $(LOLEAFLET_ADMIN_JS)
 $(INTERMEDIATE_DIR)/loleaflet-src.js: tscompile.done $(call prereq_loleaflet) $(LOLEAFLET_JS_DST)
 	@mkdir -p $(dir $@)
 	$(abs_top_srcdir)/scripts/unocommands.py --check $(abs_top_srcdir)
-	@echo -n "Checking for obsolete JS build intermediates in this makefile... "
+	@printf "Checking for obsolete JS build intermediates in this makefile... "
 	@if ! test "z$(LOLEAFLET_ASSERT_INTERSECT)" == "z"; then echo; echo "Error: please remove obsolete files:"; echo "$(LOLEAFLET_ASSERT_INTERSECT)"; exit 1; else echo "clean"; fi
 	@echo "Checking for loleaflet JS errors..."
 	@$(NODE) node_modules/eslint/bin/eslint.js $(srcdir)/src \
@@ -572,7 +571,7 @@ tscompile.done: $(LOLEAFLET_JS_SRC) $(LOLEAFLET_TS_SRC)
 	@touch $@
 
 $(LOLEAFLET_TS_JS_DST): tscompile.done
-	@echo -n ""
+	@:
 
 $(DIST_FOLDER)/src/%.js: $(srcdir)/src/%.js
 	@mkdir -p $(dir $@)


### PR DESCRIPTION
The intent is that it should no longer be necessary to do the
JavaScript part on a Linux machine. For the configury and "make" part,
mostly just some minor portability issues had to be handled:

The readlink command on macOS has no -f option. But that use of
readlink is not necessary anyway in a tree for building a mobile app,
so bypass.

The find command on macOS always requires at least one directory name.
So when $(CUSTOM_ICONS_DIRECTORY) is empty the "find
$(CUSTOM_ICONS_DIRECTORY) -name '*.*'" command produced an annoying
error message. Handle that in a trivial way.

The echo command in /bin/sh on macOS does not have the -n option. Use
the more portable printf command instead.

To then configure and run the make (before you can do the actual build
in Xcode9, you need have Node.js installed. Personally I just
downloaded the macOS Node.js binary tarball and unpacked into
/opt/node so that /opt/node/bin/node and /opt/node/bin/npm are the
relevant executables.

You will also need to add the lxml and polib Python modules to your
user Python module library with pip3, as in "pip3 install --user lxml"
and "pip3 install --user polib".

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: I263a318181125fa37ac174fa36cb0e44e56a6607


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

