### PR TITLE
leaflet: notebookbar: removed title property from notebook content div

### DIFF
--- a/loleaflet/src/control/Control.JSDialogBuilder.js
+++ b/loleaflet/src/control/Control.JSDialogBuilder.js
@@ -919,7 +919,6 @@ L.Control.JSDialogBuilder = L.Control.extend({
 				label.innerHTML = title;
 
 				var contentDiv = L.DomUtil.create('div', 'ui-content level-' + builder._currentDepth + ' ' + builder.options.cssClass, contentsContainer);
-				contentDiv.title = title;
 				contentDiv.id = item.name;
 
 				if (!isSelectedTab)


### PR DESCRIPTION


Signed-off-by: Pranam Lashkari <lpranam@collabora.com>
Change-Id: I2e9d61f98d9cf4e96ae720cc660278f8bf0c6df8


* Resolves: #2171
* Target version: master 

### Summary
problem:
Jquery tooltip uses title property for tooltip content
this tooltip property is also applied to all the child element,
if they do not have their own title
resulting into false tooltips in many cases



### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

