### PR TITLE
leaflet: hide all comments in the document if part not specified

### DIFF
--- a/loleaflet/src/layer/tile/CalcTileLayer.js
+++ b/loleaflet/src/layer/tile/CalcTileLayer.js
@@ -185,8 +185,17 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 	},
 
 	hideAnnotations: function (part) {
+		if (part === undefined) { // remove all the comments from all tabs
+			for (var tab in this._annotations) {
+				for (var key in this._annotations[tab]) {
+					this.hideAnnotation(this._annotations[tab][key]);
+				}
+			}
+			return;
+		}
+
 		var annotations = this._annotations[part];
-		for (var key in annotations) {
+		for (key in annotations) {
 			this.hideAnnotation(annotations[key]);
 		}
 	},


### PR DESCRIPTION


Signed-off-by: Pranam Lashkari <lpranam@collabora.com>
Change-Id: I6f260f87fadfd371b095784538473e8c728c95e3


* Target version: distro/collabora/co-6-4 

### Summary
problem:
in some cases comments were not hidden
where specifying which part's comment to hide

i.e: when we add new sheet it is not possible to know which was previous sheet
so couldn't hide the comments from previous sheet after adding new sheet
in such cases hide all the comments
later showAnnotations handles which comments to show

fixes #2197


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

