### PR TITLE
leaflet: notebookbar: removed title property from notebook content div

### DIFF
--- a/loleaflet/src/control/Control.JSDialogBuilder.js
+++ b/loleaflet/src/control/Control.JSDialogBuilder.js
@@ -915,7 +915,6 @@ L.Control.JSDialogBuilder = L.Control.extend({
 				label.innerHTML = title;
 
 				var contentDiv = L.DomUtil.create('div', 'ui-content level-' + builder._currentDepth + ' ' + builder.options.cssClass, contentsContainer);
-				contentDiv.title = title;
 				contentDiv.id = item.name;
 
 				if (!isSelectedTab)


### PR DESCRIPTION
problem:
Jquery tooltip uses title property for tooltip content
this tooltip property is also applied to all the child element,
if they do not have their own title
resulting into false tooltips in many cases

fixes #2171

Signed-off-by: Pranam Lashkari <lpranam@collabora.com>
Change-Id: I2e9d61f98d9cf4e96ae720cc660278f8bf0c6df8
