### PR TITLE
Notebookbar add outline for hover commands

### DIFF
--- a/loleaflet/css/notebookbar.css
+++ b/loleaflet/css/notebookbar.css
@@ -239,6 +239,13 @@
 	color: var(--gray-light-txt--color);
 }
 
+.hasnotebookbar .ui-content.unotoolbutton.selected:hover,
+.unotoolbutton.notebookbar:hover,
+.hasnotebookbar .ui-content.unotoolbutton.selected:not(.has-label):not(.inline):hover {
+	outline: 1px solid var(--gray-color);
+	border-radius: 0.1px;
+}
+
 /* avoid bug with arrow in new line when window is small */
 #table-Home-Section-Insert #table-LineB9 #InsertGraphic.notebookbar,
 #table-Home-Section-Insert #table-GroupB20 #InsertTable.notebookbar {
@@ -315,6 +322,8 @@
 .unotoolbutton.notebookbar:not(.disabled):hover, #clearFormatting.notebookbar div img:hover {
 	background-color: #e6e6e6b0;
 	cursor: pointer;
+	outline: 1px solid var(--gray-color);
+	border-radius: 0.1px;
 }
 
 .unotoolbutton.notebookbar .selected-color {


### PR DESCRIPTION
With an 1px gray-color outline it's better visible where the mouse is hover an command.
When the user hover over an selected command it's also better visible.

Signed-off-by: Andreas-Kainz <kainz.a@gmail.com>
Change-Id: I993888bd81a9f18f6d1746a42c9db4f165055e41
