### PR TITLE
Notebookbar Tab hover use primary color

### DIFF
--- a/loleaflet/css/notebookbar.css
+++ b/loleaflet/css/notebookbar.css
@@ -59,11 +59,24 @@
 	text-shadow: 0px 0px 0.2px rgb(135, 105, 0);
 	text-shadow: 0px 0px 0.2px rgb(var(--yellow0-txt-primary-color));
 }
-.ui-tab.notebookbar:hover:not(.selected) {
-	border-radius: 0.1px;
-	background-color: #f9f9f9;
+.main-nav.hasnotebookbar.text-color-indicator .ui-tab.notebookbar:hover {
+	color: rgb(var(--blue1-txt-primary-color));
+	box-shadow: 0 2px rgb(var(--blue1-txt-primary-color));
+}
+.main-nav.hasnotebookbar.spreadsheet-color-indicator .ui-tab.notebookbar:hover {
+	color: rgb(var(--green0-txt-primary-color));
+	box-shadow: 0 2px rgb(var(--green0-txt-primary-color));
+}
+.main-nav.hasnotebookbar.presentation-color-indicator .ui-tab.notebookbar:hover {
+	color: rgb(var(--orange1-txt-primary-color));
+	box-shadow: 0 2px rgb(var(--orange1-txt-primary-color));
+}
+.main-nav.hasnotebookbar.drawing-color-indicator .ui-tab.notebookbar:hover {
+	color: rgb(var(--yellow0-txt-primary-color));
+	box-shadow: 0 2px rgb(var(--yellow0-txt-primary-color));
+}
+.ui-tab.notebookbar:hover {
 	cursor: pointer;
-	color: #555;
 }
 /* Document Logo */
 .main-nav.hasnotebookbar #document-header {


### PR DESCRIPTION
As the tab hover effect used an defined color and the plan is to use var colors, I implement another hover style for tabs.

Hover on notebookbar tabs show a 2px bottom line in primary-color depend on the app and the tab label color switch also to primary-color. The layout follow the cool color vars and look very consistent.

Signed-off-by: Andreas-Kainz <kainz.a@gmail.com>
Change-Id: Ia8da2472f7feee97c198c14a9cb059a257168b3e
