### PR TITLE
Notebookbar Shortcut bar add Fullscreen #2417

### DIFF
--- a/loleaflet/src/control/Control.Notebookbar.js
+++ b/loleaflet/src/control/Control.Notebookbar.js
@@ -242,6 +242,12 @@ L.Control.Notebookbar = L.Control.extend({
 						'command': '.uno:Save'
 					},
 					{
+						'id': 'fullscreen',
+						'type': 'toolitem',
+						'text': _UNO('.uno:FullScreen'),
+						'command': '.uno:FullScreen'
+					},
+					{
 						'id': 'undo',
 						'type': 'toolitem',
 						'text': _('Undo'),

--- a/loleaflet/src/control/Control.NotebookbarBuilder.js
+++ b/loleaflet/src/control/Control.NotebookbarBuilder.js
@@ -64,6 +64,7 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 		this._toolitemHandlers['.uno:ReportIssue'] = this._onlineHelpControl;
 		this._toolitemHandlers['.uno:LatestUpdates'] = this._onlineHelpControl;
 		this._toolitemHandlers['.uno:About'] = this._onlineHelpControl;
+		this._toolitemHandlers['.uno:FullScreen'] = this._onlineHelpControl;
 
 		this._toolitemHandlers['.uno:SelectWidth'] = function() {};
 		this._toolitemHandlers['.uno:SetOutline'] = function() {};

--- a/loleaflet/src/control/Control.NotebookbarDraw.js
+++ b/loleaflet/src/control/Control.NotebookbarDraw.js
@@ -25,6 +25,12 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 						'command': '.uno:Save'
 					},
 					{
+						'id': 'fullscreen',
+						'type': 'toolitem',
+						'text': _UNO('.uno:FullScreen'),
+						'command': '.uno:FullScreen'
+					},
+					{
 						'id': 'undo',
 						'type': 'toolitem',
 						'text': _('Undo'),


### PR DESCRIPTION
As Fullscreen mode can be very usefull #2416 to save space, I suggest to add Fullscreen command to the Shortcut bar at writer, calc and draw. So also the number of items in the shortcut bar is always the same.

Signed-off-by: Andreas-Kainz <kainz.a@gmail.com>
Change-Id: I5f37c8d1f9a42527372abcf99bac14b0f539c663
