### PR TITLE
Statusbar use hue-rotate styles svg icons

### DIFF
--- a/loleaflet/css/notebookbar.css
+++ b/loleaflet/css/notebookbar.css
@@ -121,29 +121,11 @@
 }
 
 /* Hamburger icon: from shortcutsbar (notebookbar) */
-.hasnotebookbar.text-color-indicator #shortcuts-menubar-icon,
-.hasnotebookbar.text-color-indicator #shortcuts-menubar-icon:before,
-.hasnotebookbar.text-color-indicator #shortcuts-menubar-icon:after {
+.hasnotebookbar #shortcuts-menubar-icon,
+.hasnotebookbar #shortcuts-menubar-icon:before,
+.hasnotebookbar #shortcuts-menubar-icon:after {
 	background: rgb(3, 105, 163);
 	background: rgb(var(--blue1-txt-primary-color));
-}
-.hasnotebookbar.spreadsheet-color-indicator #shortcuts-menubar-icon,
-.hasnotebookbar.spreadsheet-color-indicator #shortcuts-menubar-icon:before,
-.hasnotebookbar.spreadsheet-color-indicator #shortcuts-menubar-icon:after {
-	background: rgb(16, 104, 2);
-	background: rgb(var(--green0-txt-primary-color));
-}
-.hasnotebookbar.presentation-color-indicator #shortcuts-menubar-icon,
-.hasnotebookbar.presentation-color-indicator #shortcuts-menubar-icon:before,
-.hasnotebookbar.presentation-color-indicator #shortcuts-menubar-icon:after {
-	background: rgb(163, 62, 3);
-	background: rgb(var(--orange1-txt-primary-color));
-}
-.hasnotebookbar.drawing-color-indicator #shortcuts-menubar-icon,
-.hasnotebookbar.drawing-color-indicator #shortcuts-menubar-icon:before,
-.hasnotebookbar.drawing-color-indicator #shortcuts-menubar-icon:after {
-	background: rgb(135, 105, 0);
-	background: rgb(var(--yellow0-txt-primary-color));
 }
 
 .hasnotebookbar .notebookbar-shortcuts-bar #Menubar,
@@ -164,7 +146,7 @@
 	position: absolute;
 	top: 50%;
 	left: 6px;
-	height: 1px;
+	height: 2px;
 	width: 16px;
 	-webkit-transition: all 0.25s;
 	transition: all 0.25s;
@@ -175,7 +157,7 @@
 	position: absolute;
 	top: 52%;
 	left: 0px;
-	height: 1px;
+	height: 2px;
 	width: 16px;
 	-webkit-transition: all 0.25s;
 	transition: all 0.25s;
@@ -191,6 +173,33 @@
 	content: '';
 	top: 6px;
 	left: 0;
+}
+
+.hasnotebookbar.spreadsheet-color-indicator #shortcuts-menubar-icon,
+.hasnotebookbar.spreadsheet-color-indicator #Save,
+.hasnotebookbar.spreadsheet-color-indicator #FullScreen,
+.hasnotebookbar.spreadsheet-color-indicator #Undo,
+.hasnotebookbar.spreadsheet-color-indicator #Redo {
+	-webkit-filter: hue-rotate(290deg);
+	filter: hue-rotate(290deg);
+}
+
+.hasnotebookbar.presentation-color-indicator #shortcuts-menubar-icon,
+.hasnotebookbar.presentation-color-indicator #Save,
+.hasnotebookbar.presentation-color-indicator #Presentation,
+.hasnotebookbar.presentation-color-indicator #Undo,
+.hasnotebookbar.presentation-color-indicator #Redo {
+	-webkit-filter: hue-rotate(190deg);
+	filter: hue-rotate(190deg);
+}
+
+.hasnotebookbar.drawing-color-indicator #shortcuts-menubar-icon,
+.hasnotebookbar.drawing-color-indicator #Save,
+.hasnotebookbar.drawing-color-indicator #FullScreen,
+.hasnotebookbar.drawing-color-indicator #Undo,
+.hasnotebookbar.drawing-color-indicator #Redo {
+	-webkit-filter: hue-rotate(210deg);
+	filter: hue-rotate(210deg);
 }
 
 /* options section */

--- a/loleaflet/images/lc_fullscreen.svg
+++ b/loleaflet/images/lc_fullscreen.svg
@@ -1,9 +1,8 @@
 <?xml-stylesheet type="text/css" href="icons.css" ?>
 <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
   <g id="symbol"
-	 class="icn icn--highlight-color"  
-     fill="#83beec" 
-     stroke="#1e8bcd" 
+     fill="#63BBEE" 
+     stroke="#0369A3" 
 	 stroke-linecap="round" 
 	 stroke-linejoin="round"
       >

--- a/loleaflet/images/lc_presentation.svg
+++ b/loleaflet/images/lc_presentation.svg
@@ -1,18 +1,19 @@
 <?xml-stylesheet type="text/css" href="icons.css" ?>
-<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
-  <g id="symbol"
-	 class="icn icn--highlight-color"  
-     fill="#83beec" 
-     stroke="#1e8bcd" 
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <g id="background"
+     fill="#63BBEE" 
+     stroke="#0369A3" 
 	 stroke-linecap="round" 
 	 stroke-linejoin="round"
       >
-      <path d="M 15.5,8 A 7.5,7.5 0 0 1 8,15.5 7.5,7.5 0 0 1 0.5,8 7.5,7.5 0 0 1 8,0.5 7.5,7.5 0 0 1 15.5,8 Z" />
+      <path d="M 21.5,12 A 9.5,9.5 0 0 1 12,21.5 9.5,9.5 0 0 1 2.5,12 9.5,9.5 0 0 1 12,2.5 9.5,9.5 0 0 1 21.5,12 Z" />
   </g>
   <g id="background"
-     class="icn icn--area-color"
      fill="#fafafa"
-     >
-      <path d="M 6,12 V 4 l 6,4 z" />
+     stroke="#0369A3" 
+	 stroke-linecap="round" 
+	 stroke-linejoin="round"
+      >
+      <path d="m 8.5,17.5 v -11 l 9,5.5 z" />
   </g>
 </svg>

--- a/loleaflet/images/lc_save.svg
+++ b/loleaflet/images/lc_save.svg
@@ -1,9 +1,8 @@
 <?xml-stylesheet type="text/css" href="icons.css" ?>
 <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
   <g id="background"
-	 class="icn icn--highlight-color"  
-     fill="#83beec" 
-     stroke="#1e8bcd" 
+     fill="#63BBEE" 
+     stroke="#0369A3" 
 	 stroke-linecap="round" 
 	 stroke-linejoin="round"
       >
@@ -19,8 +18,8 @@
   </g>
   <g id="background"
 	 class="icn icn--highlight-color"  
-     fill="#83beec" 
-     stroke="#1e8bcd" 
+     fill="#63BBEE" 
+     stroke="#0369A3" 
 	 stroke-linecap="round" 
 	 stroke-linejoin="round"
       >


### PR DESCRIPTION
By default all Statusbar icons use blue1-txt-primary-color
instead of use green0-txt-primary-color, yellow0-txt-primary-color and orange1-txt-primary-color hue-rotate svg filter was used.
-> Simplify codebase

Signed-off-by: Andreas-Kainz <kainz.a@gmail.com>
Change-Id: I5f675c25b4711c2ecc2c04612b3a95682dc17ad9
