### PR TITLE
Notebookbar Cut, Copy commands without label

### DIFF
--- a/loleaflet/css/notebookbar.css
+++ b/loleaflet/css/notebookbar.css
@@ -463,12 +463,6 @@
 	height: 22px;
 }
 
-#Copy.notebookbar,
-#clearFormatting.notebookbar,
-#FormatPaintbrush.notebookbar {
-	margin-top: 6px;
-}
-
 /* Styles preview */
 
 #stylesview {

--- a/loleaflet/src/control/Control.NotebookbarCalc.js
+++ b/loleaflet/src/control/Control.NotebookbarCalc.js
@@ -185,42 +185,16 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				'command': '.uno:Paste'
 			},
 			{
-				'id': 'GroupB9',
 				'type': 'container',
 				'children': [
 					{
-						'id': 'LineA6',
 						'type': 'toolbox',
 						'children': [
 							{
 								'type': 'toolitem',
 								'text': _UNO('.uno:Cut', true),
 								'command': '.uno:Cut'
-							}
-						]
-					},
-					{
-						'id': 'LineB7',
-						'type': 'toolbox',
-						'children': [
-							{
-								'type': 'toolitem',
-								'text': _UNO('.uno:Copy', true),
-								'command': '.uno:Copy'
-							}
-						]
-					}
-				],
-				'vertical': 'true'
-			},
-			{
-				'id': 'Home-Section-Style',
-				'type': 'container',
-				'children': [
-					{
-						'id': 'LineA7',
-						'type': 'toolbox',
-						'children': [
+							},
 							{
 								'type': 'toolitem',
 								'text': _UNO('.uno:FormatPaintbrush'),
@@ -229,9 +203,13 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 						]
 					},
 					{
-						'id': 'LineB8',
 						'type': 'toolbox',
 						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:Copy', true),
+								'command': '.uno:Copy'
+							},
 							{
 								'type': 'toolitem',
 								'text': _UNO('.uno:ResetAttributes'),

--- a/loleaflet/src/control/Control.NotebookbarDraw.js
+++ b/loleaflet/src/control/Control.NotebookbarDraw.js
@@ -244,36 +244,13 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 				'type': 'container',
 				'children': [
 					{
-						'id': 'LineA6',
 						'type': 'toolbox',
 						'children': [
 							{
 								'type': 'toolitem',
 								'text': _UNO('.uno:Cut'),
 								'command': '.uno:Cut'
-							}
-						]
-					},
-					{
-						'id': 'LineB7',
-						'type': 'toolbox',
-						'children': [
-							{
-								'type': 'toolitem',
-								'text': _UNO('.uno:Copy'),
-								'command': '.uno:Copy'
-							}
-						]
-					}
-				],
-				'vertical': 'true'
-			},
-			{
-				'type': 'container',
-				'children': [
-					{
-						'type': 'toolbox',
-						'children': [
+							},
 							{
 								'type': 'toolitem',
 								'text': _UNO('.uno:FormatPaintbrush'),
@@ -284,6 +261,11 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 					{
 						'type': 'toolbox',
 						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:Copy'),
+								'command': '.uno:Copy'
+							},
 							{
 								'type': 'toolitem',
 								'text': _UNO('.uno:SetDefault'),

--- a/loleaflet/src/control/Control.NotebookbarImpress.js
+++ b/loleaflet/src/control/Control.NotebookbarImpress.js
@@ -268,36 +268,13 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'type': 'container',
 				'children': [
 					{
-						'id': 'LineA6',
 						'type': 'toolbox',
 						'children': [
 							{
 								'type': 'toolitem',
 								'text': _UNO('.uno:Cut'),
 								'command': '.uno:Cut'
-							}
-						]
-					},
-					{
-						'id': 'LineB7',
-						'type': 'toolbox',
-						'children': [
-							{
-								'type': 'toolitem',
-								'text': _UNO('.uno:Copy'),
-								'command': '.uno:Copy'
-							}
-						]
-					}
-				],
-				'vertical': 'true'
-			},
-			{
-				'type': 'container',
-				'children': [
-					{
-						'type': 'toolbox',
-						'children': [
+							},
 							{
 								'type': 'toolitem',
 								'text': _UNO('.uno:FormatPaintbrush'),
@@ -308,6 +285,11 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 					{
 						'type': 'toolbox',
 						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:Copy'),
+								'command': '.uno:Copy'
+							},
 							{
 								'type': 'toolitem',
 								'text': _UNO('.uno:SetDefault'),

--- a/loleaflet/src/control/Control.NotebookbarWriter.js
+++ b/loleaflet/src/control/Control.NotebookbarWriter.js
@@ -287,28 +287,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 								'type': 'toolitem',
 								'text': _UNO('.uno:Cut'),
 								'command': '.uno:Cut'
-							}
-						]
-					},
-					{
-						'type': 'toolbox',
-						'children': [
-							{
-								'type': 'toolitem',
-								'text': _UNO('.uno:Copy'),
-								'command': '.uno:Copy'
-							}
-						]
-					}
-				],
-				'vertical': 'true'
-			},
-			{
-				'type': 'container',
-				'children': [
-					{
-						'type': 'toolbox',
-						'children': [
+							},
 							{
 								'type': 'toolitem',
 								'text': _UNO('.uno:FormatPaintbrush'),
@@ -319,6 +298,11 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 					{
 						'type': 'toolbox',
 						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:Copy'),
+								'command': '.uno:Copy'
+							},
 							{
 								'type': 'toolitem',
 								'text': _UNO('.uno:ResetAttributes'),


### PR DESCRIPTION
Sure Cut, Copy and Clone, Clear are two separate groups cause Clone and Clear are related to other stuff, but have them within one group, mean also icon only and that was the idea behind.
Cut, Copy symbols are very well know, so a label isn't needed from a usability point of view.
Have icons + label mean always that string translations will change the UI and Home tab has ordinary more content. However on the home tab there should be commands/icons which are well know only, so home tab without labels will improve a unified home tab on all languages.

Signed-off-by: Andreas-Kainz <kainz.a@gmail.com>
Change-Id: I1c20091f616f5aac57bc802b30db629c9bacd66c
