### PR TITLE
fix:comment doesnot appear in wizard after reload in writer

### DIFF
--- a/cypress_test/integration_tests/mobile/writer/annotation_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/annotation_spec.js
@@ -18,7 +18,7 @@ describe('Annotation tests.', function() {
 	});
 
 
-	it.skip('Saving comment.', function() {
+	it('Saving comment.', function() {
 		mobileHelper.insertComment();
 
 		mobileHelper.selectHamburgerMenuItem(['File', 'Save']);

--- a/loleaflet/src/layer/tile/WriterTileLayer.js
+++ b/loleaflet/src/layer/tile/WriterTileLayer.js
@@ -98,6 +98,10 @@ L.WriterTileLayer = L.CanvasTileLayer.extend({
 		}
 
 		if (values.comments) {
+			values.comments.forEach(function(comment) {
+				comment.id = comment.id.toString();
+				comment.parent = comment.parent.toString();
+			});
 			this._annotations.fill(values.comments);
 		}
 		else if (values.redlines) {


### PR DESCRIPTION
Signed-off-by: Rash419 <rashesh.padia@collabora.com>
Change-Id: If72e6f98acf5fcad1202332fa6521d7ad0e35e83



* Target version: master 

### Summary
when we insert the comment in writer the value of parent,id coming from core is typeof string but after reload the value of parent,id coming from the core is typeof number 

