### PR TITLE
fix: empty tiles on zoom back to previous level (co-6-4)

### DIFF
--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -1244,26 +1244,26 @@ L.CanvasTileLayer = L.TileLayer.extend({
 			for (i = 0; i < queue.length; i++) {
 				coords = queue[i];
 				key = this._tileCoordsToKey(coords);
-
+				tile = undefined;
 				if (coords.part === this._selectedPart) {
-					tile = this.createTile(this._wrapCoords(coords), L.bind(this._tileReady, this, coords));
+					var tileImg = this.createTile(this._wrapCoords(coords), L.bind(this._tileReady, this, coords));
 
 					// if createTile is defined with a second argument ("done" callback),
 					// we know that tile is async and will be ready later; otherwise
 					if (this.createTile.length < 2) {
 						// mark tile as ready, but delay one frame for opacity animation to happen
-						setTimeout(L.bind(this._tileReady, this, coords, null, tile), 0);
+						setTimeout(L.bind(this._tileReady, this, coords, null, tileImg), 0);
 					}
 
 					// save tile in cache
-					this._tiles[key] = {
-						el: tile,
+					this._tiles[key] = tile = {
+						el: tileImg,
 						coords: coords,
 						current: true
 					};
 
 					this.fire('tileloadstart', {
-						tile: tile,
+						tile: tileImg,
 						coords: coords
 					});
 				}
@@ -1279,7 +1279,7 @@ L.CanvasTileLayer = L.TileLayer.extend({
 					}
 					tilePositionsY += twips.y;
 				}
-				else {
+				else if (tile) {
 					tile.el = this._tileCache[key];
 					tile.loaded = true;
 				}
@@ -1362,7 +1362,7 @@ L.CanvasTileLayer = L.TileLayer.extend({
 	},
 
 	_addTiles: function (coordsQueue) {
-		var coords, key;
+		var coords, key, tile;
 		// first take care of the DOM
 		for (var i = 0; i < coordsQueue.length; i++) {
 			coords = coordsQueue[i];
@@ -1371,25 +1371,25 @@ L.CanvasTileLayer = L.TileLayer.extend({
 
 			if (coords.part === this._selectedPart) {
 				if (!this._tiles[key]) {
-					var tile = this.createTile(this._wrapCoords(coords), L.bind(this._tileReady, this, coords));
+					var tileImg = this.createTile(this._wrapCoords(coords), L.bind(this._tileReady, this, coords));
 
 					// if createTile is defined with a second argument ("done" callback),
 					// we know that tile is async and will be ready later; otherwise
 					if (this.createTile.length < 2) {
 						// mark tile as ready, but delay one frame for opacity animation to happen
-						setTimeout(L.bind(this._tileReady, this, coords, null, tile), 0);
+						setTimeout(L.bind(this._tileReady, this, coords, null, tileImg), 0);
 					}
 
 					// save tile in cache
-					this._tiles[key] = {
-						el: tile,
+					this._tiles[key] = tile = {
+						el: tileImg,
 						wid: 0,
 						coords: coords,
 						current: true
 					};
 
 					this.fire('tileloadstart', {
-						tile: tile,
+						tile: tileImg,
 						coords: coords
 					});
 


### PR DESCRIPTION
Don't confuse between tile object and the tile image element.
Assign the tile object to tile array correctly and update the tile image
using the tileCache.

Signed-off-by: Dennis Francis <dennis.francis@collabora.com>
Change-Id: I014cc47c7b6e4086384a66158fb8eb2534714b99


* Resolves: # <!-- related github issue -->
* Target version: co-6-4

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

