### PR TITLE
CSS color-palette vars are within a separate css file

### DIFF
--- a/loleaflet/Makefile.am
+++ b/loleaflet/Makefile.am
@@ -118,6 +118,7 @@ LOLEAFLET_CSS =\
 	$(srcdir)/css/leaflet.css \
 	$(srcdir)/css/leaflet-spinner.css \
 	$(srcdir)/css/selectionMarkers.css \
+	$(srcdir)/css/color-palette.css \
 	$(srcdir)/css/loleaflet.css \
 	$(srcdir)/css/toolbar.css \
 	$(srcdir)/css/toolbar-mobile.css \

--- a/loleaflet/css/color-palette.css
+++ b/loleaflet/css/color-palette.css
@@ -1,0 +1,13 @@
+:root {
+	/*LibreOffice Colors: https://wiki.documentfoundation.org/Marketing/Branding#Colors
+	----------------------------------[to do]*/
+	--blue1-txt-primary-color: 3, 105, 163;
+	--green0-txt-primary-color: 16, 104, 2; /*green1 lacks contrast against white*/
+	--orange1-txt-primary-color: 163, 62, 3;
+	--yellow0-txt-primary-color: 135, 105, 0; /*yellow1 lacks contrast against white*/
+
+	--gray-light-txt--color: #696969;
+	--gray-light-bg-color: #EFEFEF;
+	--gray-color: #b6b6b6;
+	--white-bg-color: #fff;
+}

--- a/loleaflet/css/loleaflet.css
+++ b/loleaflet/css/loleaflet.css
@@ -10,18 +10,6 @@
 
 	--docs-font: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
 	--docs--pre-font: 'Consolas', 'Menlo', 'Lucida Console', 'Courier New', monospace;
-
-	/*LibreOffice Colors: https://wiki.documentfoundation.org/Marketing/Branding#Colors
-	----------------------------------[to do]*/
-	--blue1-txt-primary-color: 3, 105, 163;
-	--green0-txt-primary-color: 16, 104, 2; /*green1 lacks contrast against white*/
-	--orange1-txt-primary-color: 163, 62, 3;
-	--yellow0-txt-primary-color: 135, 105, 0; /*yellow1 lacks contrast against white*/
-
-	--gray-light-txt--color: #696969;
-	--gray-light-bg-color: #EFEFEF;
-	--gray-color: #b6b6b6;
-	--white-bg-color: #fff;
 }
 /* clip technique: hide visually but keep it available to screen readers */
 .visuallyhidden {


### PR DESCRIPTION
move loleaflet.css .root color varaibles into a separate color-palette.css file so all var colors are at a dedicated file and branding is easier.

Signed-off-by: Andreas-Kainz <kainz.a@gmail.com>
Change-Id: I6fe879fbb09e2d5170c028820974bdda0466805d
