### PR TITLE
Notebookbar: Help Tab: promote items to bigtoolitem: fix

### DIFF
--- a/loleaflet/src/control/Control.NotebookbarWriter.js
+++ b/loleaflet/src/control/Control.NotebookbarWriter.js
@@ -239,9 +239,9 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 						'children': [
 							{
 								'id': 'latest-updates',
-								'type': 'menubartoolitem',
+								'type': 'bigtoolitem',
 								'text': _('Latest Updates'),
-								'command': ''
+								'command': '.uno:LatestUpdates'
 							}
 						]
 					} : {},


### PR DESCRIPTION
LatestUpdates was correctly calling the intended function but
the json was missing the updated values:

- Change item type
- Use already existent custom command

also related to #2232 issue

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ie1ed5ed48db22420347c9d9df432c6c9bc5fd342
