### PR TITLE
make mobilewizard fullscreen for dialogs visible before document load

### DIFF
--- a/loleaflet/src/control/Control.MobileWizard.js
+++ b/loleaflet/src/control/Control.MobileWizard.js
@@ -466,7 +466,12 @@ L.Control.MobileWizard = L.Control.extend({
 				$('#mobile-wizard').height(this.options.maxHeight);
 				$('#mobile-wizard').css('top', '');
 			}
-
+			if (!this.map._docLoaded) {
+				$('#mobile-wizard').height('100%');
+				// Turn backButton icon from down to actually back
+				// since it does not hide it, instead it goes back in this case
+				this.backButton.removeClass('close-button');
+			}
 			if (this._isActive && currentPath.length) {
 				this._goToPath(currentPath);
 				this._scrollToPosition(lastScrollPosition);


### PR DESCRIPTION
Also changed the Down Arrow icon for GoBack button because
at this stage, it closes the document

Signed-off-by: merttumer <mert.tumer@collabora.com>
Change-Id: I5f32939996ee1f21fcedab6468e47aa51251bd9d


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

