### PR TITLE
Notebookbar: context tabs: fix alignment

### DIFF
--- a/loleaflet/css/notebookbar.css
+++ b/loleaflet/css/notebookbar.css
@@ -25,12 +25,15 @@
 	padding: 0px 1em;
 }
 
+.ui-tab.notebookbar[style*='block'] {
+	display: inline-flex !important;
+}
+
 .ui-tab.hidden.notebookbar {
 	display: none;
 }
 
 .ui-tab.selected.notebookbar {
-	display: flex !important;
 	border: 0px;
 	border-radius: 0px;
 	background: var(--white-bg-color);


### PR DESCRIPTION
Context tabs were being shown via JS by setting display property to block
a previous fix has been pushed targeting only active tabs:
d64a16d74de74f4356a769677b64e36d07ccee9b
Related to #2385

- Do not single out active/selected context tabs
- Re-set proper flex property for all if block has been set (via jquery)
  - with a plus that we can keep using .show()

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I8b2bf89aaea9fffaf1d4079929156f3ded48cfc2
