### PR TITLE
Mobile add BottomBar for drawing

### DIFF
--- a/loleaflet/css/toolbar.css
+++ b/loleaflet/css/toolbar.css
@@ -751,6 +751,8 @@ button.leaflet-control-search-next
 .w2ui-icon.bullet{ background: url('images/lc_defaultbullet.svg') no-repeat center !important; }
 .w2ui-icon.incrementindent{ background: url('images/lc_incrementindent.svg') no-repeat center !important; }
 .w2ui-icon.decrementindent{ background: url('images/lc_decrementindent.svg') no-repeat center !important; }
+.w2ui-icon.outlineleft{ background: url('images/lc_outlineleft.svg') no-repeat center !important; }
+.w2ui-icon.outlineright{ background: url('images/lc_outlineright.svg') no-repeat center !important; }
 .w2ui-icon.text{ background: url('images/lc_text.svg') no-repeat center !important; }
 .w2ui-icon.annotation{ background: url('images/lc_shownote.svg') no-repeat center !important; }
 .w2ui-icon.inserttable{ background: url('images/lc_inserttable.svg') no-repeat center !important; }

--- a/loleaflet/src/control/Control.MobileBottomBar.js
+++ b/loleaflet/src/control/Control.MobileBottomBar.js
@@ -33,6 +33,7 @@ L.Control.MobileBottomBar = L.Control.extend({
 				{type: 'break'},
 				{type: 'button',  id: 'fontcolor', img: 'textcolor', hint: _UNO('.uno:FontColor')},
 				{type: 'button',  id: 'backcolor', img: 'backcolor', hint: _UNO('.uno:BackgroundColor')},
+				{type: 'break'},
 				{type: 'button',  id: 'leftpara',  img: 'alignleft', hint: _UNO('.uno:LeftPara', '', true),
 					uno: {textCommand: 'LeftPara', objectCommand: 'ObjectAlignLeft'},
 					unosheet: 'AlignLeft', disabled: true},
@@ -79,7 +80,7 @@ L.Control.MobileBottomBar = L.Control.extend({
 				{type: 'button',  id: 'sum',  img: 'autosum', hint: _('Sum')},
 				{type: 'break',   id: 'break-number'}, */
 			];
-		} else if (docType == 'presentation') {
+		} else if ((docType == 'presentation') || (docType == 'drawing')) {
 			return [
 				{type: 'button',  id: 'showsearchbar',  img: 'search', hint: _('Show the search bar')},
 				{type: 'break'},
@@ -100,6 +101,8 @@ L.Control.MobileBottomBar = L.Control.extend({
 				{type: 'button', id: 'justifypara', img: 'alignblock', hint: _UNO('.uno:JustifyPara', '', true), uno: 'JustifyPara'},
 				{type: 'break'},
 				{type: 'button',  id: 'defaultbullet',  img: 'bullet', hint: _UNO('.uno:DefaultBullet', '', true), uno: 'DefaultBullet', disabled: true},
+				{type: 'button',  id: 'outlineright',  img: 'outlineright', hint: _UNO('.uno:OutlineRight', '', true), uno: 'OutlineRight', disabled: true},
+				{type: 'button',  id: 'outlineleft',  img: 'outlineleft', hint: _UNO('.uno:OutlineLeft', '', true), uno: 'OutlineLeft', disabled: true},
 			];
 		}
 	},

--- a/loleaflet/src/unocommands.js
+++ b/loleaflet/src/unocommands.js
@@ -339,6 +339,8 @@ var unoCommandsArray = {
 	'OnlineAutoFormat':{text:{menu:_('~While Typing'),},},
 	'OpenHyperlinkOnCursor':{global:{menu:_('Open Hyperlink'),},},
 	'OutlineBullet':{global:{menu:_('~Bullets and Numbering...'),},},
+	'OutlineLeft':{global:{menu:_('Promote'),},},
+	'OutlineRight':{global:{menu:_('Demote'),},},
 	'OutlineFont':{global:{menu:_('Outline'),},},
 	'Overline':{global:{menu:_('Overline'),},},
 	'PageDialog':{global:{menu:_('~Page...'),},text:{menu:_('~Page Style...'),},},


### PR DESCRIPTION
Presentation has a BottomBar, but drawing not as both can use the same BottomBar I add the presentation BottomBar to be used for drawing too.
If you check LibreOffice Draw and Impress they use OutlineRight and OutlineLeft instead of IncrementItem and DecrementItem so OutlineRight and OutlineLeft was added to BottomBar

Signed-off-by: Andreas-Kainz <kainz.a@gmail.com>
Change-Id: I65a9e2b0b8aff21861daf24a5bbd6bb971f50629
