### PR TITLE
Mobile TopBar update layout

### DIFF
--- a/loleaflet/css/toolbar.css
+++ b/loleaflet/css/toolbar.css
@@ -817,6 +817,7 @@ button.leaflet-control-search-next
 .w2ui-icon.sidebar_master_slides{ background: url('images/lc_slidemasterpage.svg') no-repeat center !important; }
 .w2ui-icon.mobile_wizard{ background: url('images/lc_mobile_wizard.svg') no-repeat center !important; }
 .w2ui-icon.fullscreen-presentation{ background: url('images/lc_fullscreen-presentation-toolbar-mobile.svg') no-repeat center !important;}
+.w2ui-icon.mobile_comment_wizard{ background: url('images/lc_mobile_comment_wizard.svg') no-repeat center !important; }
 .w2ui-icon.insertion_mobile_wizard{ background: url('images/lc_insertion_mobile_wizard.svg') no-repeat center !important; }
 .w2ui-icon.viewcomments{ background: url('images/lc_viewcomment.svg') no-repeat center !important; }
 .w2ui-icon.insertcomment{ background: url('images/lc_insertcomment.svg') no-repeat center !important; }

--- a/loleaflet/images/lc_mobile_comment_wizard.svg
+++ b/loleaflet/images/lc_mobile_comment_wizard.svg
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg40"
+   sodipodi:docname="lc_mobile_comment_wizard.svg"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)">
+  <metadata
+     id="metadata46">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs44" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1379"
+     id="namedview42"
+     showgrid="true"
+     inkscape:zoom="22.627417"
+     inkscape:cx="17.725544"
+     inkscape:cy="11.237093"
+     inkscape:window-x="0"
+     inkscape:window-y="34"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg40">
+    <inkscape:grid
+       type="xygrid"
+       id="grid881" />
+  </sodipodi:namedview>
+  <path
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#555555;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="M 3.5 2 C 2.5259855 2 2 2.6171661 2 3.5 L 2 15.5 C 2 16.42714 2.5859158 16.964844 3.5 17 L 5 17 L 5 21 C 5 21.611139 5.277793 22.005859 5.7324219 22 C 6.1637506 22.0059 6.5189927 21.876527 6.7792969 21.677734 L 11.041016 18 L 13.126953 18 L 16.412109 20.570312 C 16.414009 20.571613 16.415969 20.572919 16.417969 20.574219 C 16.767521 20.84117 17.236297 21.003404 17.767578 20.998047 C 18.138626 21.000547 18.501015 20.812517 18.708984 20.525391 C 18.918081 20.236612 19 19.881328 19 19.5 L 19 18 L 20 18 C 20.0065 18.000127 20.013021 18.000127 20.019531 18 C 20.570297 17.97882 21.076263 17.79811 21.441406 17.441406 C 21.806552 17.084703 22 16.568897 22 16 L 22 3.5 C 21.999912 2.7000734 21.35303 2 20.5 2 L 3.5 2 z M 7 7 L 20 7 C 20.628549 7 21 7.5381131 21 8 L 21 16 C 21 16.358243 20.90048 16.57384 20.744141 16.726562 C 20.587805 16.879285 20.343787 16.986027 19.980469 17 L 18.5 17 C 18.223869 17.000028 18.000028 17.223869 18 17.5 L 18 19.5 C 18 19.729811 17.94181 19.877612 17.898438 19.9375 C 17.855058 19.99739 17.854768 20.00105 17.773438 20 C 17.768838 19.999938 17.764336 19.999938 17.759766 20 C 17.432935 20.0045 17.194393 19.90793 17.025391 19.779297 L 17.023438 19.779297 L 13.607422 17.105469 C 13.519762 17.037227 13.411873 17.000118 13.300781 17 L 7 17 C 6.365273 17 6 16.609003 6 16 L 6 8 C 6 7.3917423 6.5146884 7 7 7 z "
+     id="path853" />
+</svg>

--- a/loleaflet/images/lc_mobile_wizard.svg
+++ b/loleaflet/images/lc_mobile_wizard.svg
@@ -1,1 +1,52 @@
-<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><g fill="#555"><path d="m11.289062 7-3.4101558 9.025391h1.625l.7109378-2.025391h3.55664l.705078 2.025391h1.634766l-3.419922-9.025391zm.710938 1.9160156 1.421875 4.0839844h-2.855469z" stroke-width="1.02887"/><path d="m22 4a2 2 0 0 1 -2 2 2 2 0 0 1 -2-2 2 2 0 0 1 2-2 2 2 0 0 1 2 2z"/><path d="m19 7h2v2h-2z"/><path d="m19 11h2v2h-2z"/><path d="m6 4a2 2 0 0 1 -2 2 2 2 0 0 1 -2-2 2 2 0 0 1 2-2 2 2 0 0 1 2 2z"/><path d="m19 15h2v2h-2z"/><path d="m3 7h2v2h-2z"/><path d="m3 11h2v2h-2z"/><path d="m3 15h2v2h-2z"/><g transform="rotate(90)"><path d="m19-17h2v2h-2z"/><path d="m19-13h2v2h-2z"/><path d="m19-9h2v2h-2z"/><path d="m3-17h2v2h-2z"/><path d="m3-13h2v2h-2z"/><path d="m3-9h2v2h-2z"/></g><path d="m22 20a2 2 0 0 1 -2 2 2 2 0 0 1 -2-2 2 2 0 0 1 2-2 2 2 0 0 1 2 2z"/><path d="m6 20a2 2 0 0 1 -2 2 2 2 0 0 1 -2-2 2 2 0 0 1 2-2 2 2 0 0 1 2 2z"/></g></svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg40"
+   sodipodi:docname="lc_mobile_wizard.svg"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)">
+  <metadata
+     id="metadata46">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs44" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1379"
+     id="namedview42"
+     showgrid="false"
+     inkscape:zoom="32"
+     inkscape:cx="11.567097"
+     inkscape:cy="7.3032155"
+     inkscape:window-x="0"
+     inkscape:window-y="34"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg40" />
+  <path
+     style="fill:#555555;fill-opacity:1"
+     d="M 8.8984375 4 L 3 20 L 4.6875 20 C 4.8709758 20 5.0266615 19.94733 5.1542969 19.841797 C 5.2899094 19.736267 5.3818242 19.614565 5.4296875 19.476562 L 6.6328125 16 L 11.878906 16 L 14.546875 13.332031 L 11.113281 4 L 8.8984375 4 z M 10 6.09375 L 12.671875 14 L 7.328125 14 L 9.5332031 7.6289062 C 9.6049931 7.4340813 9.6799936 7.2070326 9.7597656 6.9472656 C 9.8395376 6.6874987 9.920228 6.402223 10 6.09375 z M 19.492188 10 C 19.3623 10.0021 19.238317 10.05461 19.146484 10.146484 C 16.821124 12.471514 14.496614 14.797395 12.171875 17.123047 C 12.102335 17.200797 12.071698 17.248986 12.037109 17.3125 C 12.037109 17.3125 12.035156 17.314453 12.035156 17.314453 L 10.035156 22.314453 C 9.8710502 22.723045 10.276955 23.12895 10.685547 22.964844 L 15.685547 20.964844 C 15.772047 20.925494 15.798506 20.915189 15.851562 20.855469 C 18.288672 18.415281 20.766225 15.94071 22.853516 13.853516 C 23.048701 13.658251 23.048701 13.341749 22.853516 13.146484 L 19.853516 10.146484 C 19.75785 10.050783 19.627489 9.9979277 19.492188 10 z M 19.5 11.207031 L 21.792969 13.5 L 20.5 14.792969 L 18.207031 12.5 L 19.5 11.207031 z M 17.5 13.207031 L 19.792969 15.5 L 15.5 19.792969 L 13.207031 17.5 L 17.5 13.207031 z M 12.683594 18.390625 L 14.609375 20.316406 L 11.398438 21.601562 L 12.683594 18.390625 z "
+     id="path2-7" />
+</svg>

--- a/loleaflet/images/lc_ok.svg
+++ b/loleaflet/images/lc_ok.svg
@@ -1,1 +1,1 @@
-<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="m5.0111434 14.000039 4.9999996 4 10.000001-11.9999998" fill="none" stroke="#18ab50" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/></svg>
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M 3,15 9,20 21,5" fill="none" stroke="#18ab50" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/></svg>

--- a/loleaflet/images/lc_ok_white.svg
+++ b/loleaflet/images/lc_ok_white.svg
@@ -1,1 +1,1 @@
-<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="m5.0111434 14.000039 4.9999996 4 10.000001-11.9999998" fill="none" stroke="#fafafa" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/></svg>
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M 3,15 9,20 21,5" fill="none" stroke="#fafafa" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/></svg>

--- a/loleaflet/images/lc_redo.svg
+++ b/loleaflet/images/lc_redo.svg
@@ -1,5 +1,5 @@
 <?xml-stylesheet type="text/css" href="icons.css" ?>
-<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
   <g id="symbol"
 	 class="icn icn--highlight-color-line"  
      fill="none" 
@@ -7,7 +7,7 @@
 	 stroke-linecap="round" 
 	 stroke-linejoin="round"
      >
-      <path d="M 10.5,8.5 15.5,4.5 10.5,0.5" />
-      <path d="M 15.5,4.5 H 6 c -3,0 -5.5,2.5 -5.5,5.5 0,3 2.5,5.5 5.5,5.5" />
+      <path d="m 15.3,14.5 5,-5 -5,-5" />
+      <path d="m 20.3,9.5 h -11.5 c -3,0 -5.5,2.5 -5.5,5.5 0,3 2.5,5.5 5.5,5.5" />
   </g>
 </svg>

--- a/loleaflet/images/lc_undo.svg
+++ b/loleaflet/images/lc_undo.svg
@@ -1,13 +1,13 @@
 <?xml-stylesheet type="text/css" href="icons.css" ?>
-<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
   <g id="symbol"
 	 class="icn icn--highlight-color-line"  
-     fill="none" 
-     stroke="#1e8bcd" 
+	 fill="none" 
+	 stroke="#1e8bcd" 
 	 stroke-linecap="round" 
 	 stroke-linejoin="round"
-     >
-      <path d="m 5.5,8.5 -5,-4 5,-4" />
-      <path d="m 0.5,4.5 h 9.5 c 3,0 5.5,2.5 5.5,5.5 0,3 -2.5,5.5 -5.5,5.5" />
+	 >
+      <path d="m 8.5,14.5 -5,-5 5,-5" />
+      <path d="M 3.5,9.5 H 15 c 3,0 5.5,2.5 5.5,5.5 0,3 -2.5,5.5 -5.5,5.5" />
   </g>
 </svg>

--- a/loleaflet/src/control/Control.MobileTopBar.js
+++ b/loleaflet/src/control/Control.MobileTopBar.js
@@ -26,51 +26,47 @@ L.Control.MobileTopBar = L.Control.extend({
 		if (docType == 'text') {
 			return [
 				{type: 'button',  id: 'closemobile',  img: 'closemobile'},
-				{type: 'spacer'},
 				{type: 'button',  id: 'undo',  img: 'undo', hint: _UNO('.uno:Undo'), uno: 'Undo', disabled: true},
 				{type: 'button',  id: 'redo',  img: 'redo', hint: _UNO('.uno:Redo'), uno: 'Redo', disabled: true},
+				{type: 'spacer'},
 				{type: 'button',  id: 'mobile_wizard', img: 'mobile_wizard', disabled: true},
 				{type: 'button',  id: 'insertion_mobile_wizard', img: 'insertion_mobile_wizard', disabled: true},
-				{type: 'button',  id: 'comment_wizard', img: 'viewcomments'},
-				{type: 'button',  id: 'fullscreen', img: 'fullscreen', hint: _UNO('.uno:FullScreen', 'text')},
+				{type: 'button',  id: 'comment_wizard', img: 'mobile_comment_wizard'},
 				{type: 'drop', id: 'userlist', img: 'users', hidden: true, html: L.control.createUserListWidget()},
 			];
 		} else if (docType == 'spreadsheet') {
 			return [
 				{type: 'button',  id: 'closemobile',  img: 'closemobile'},
-				{type: 'spacer'},
 				{type: 'button',  id: 'undo',  img: 'undo', hint: _UNO('.uno:Undo'), uno: 'Undo', disabled: true},
 				{type: 'button',  id: 'redo',  img: 'redo', hint: _UNO('.uno:Redo'), uno: 'Redo', disabled: true},
+				{type: 'spacer'},
 				{type: 'button', hidden: true, id: 'acceptformula',  img: 'ok', hint: _('Accept')},
 				{type: 'button', hidden: true, id: 'cancelformula',  img: 'cancel', hint: _('Cancel')},
 				{type: 'button',  id: 'mobile_wizard', img: 'mobile_wizard', disabled: true},
 				{type: 'button',  id: 'insertion_mobile_wizard', img: 'insertion_mobile_wizard', disabled: true},
-				{type: 'button',  id: 'comment_wizard', img: 'viewcomments'},
-				{type: 'button',  id: 'fullscreen', img: 'fullscreen', hint: _UNO('.uno:FullScreen', 'text')},
+				{type: 'button',  id: 'comment_wizard', img: 'mobile_comment_wizard'},
 				{type: 'drop', id: 'userlist', img: 'users', hidden: true, html: L.control.createUserListWidget()},
 			];
 		} else if (docType == 'presentation') {
 			return [
 				{type: 'button',  id: 'closemobile',  img: 'closemobile'},
-				{type: 'spacer'},
 				{type: 'button',  id: 'undo',  img: 'undo', hint: _UNO('.uno:Undo'), uno: 'Undo', disabled: true},
 				{type: 'button',  id: 'redo',  img: 'redo', hint: _UNO('.uno:Redo'), uno: 'Redo', disabled: true},
+				{type: 'spacer'},
 				{type: 'button',  id: 'mobile_wizard', img: 'mobile_wizard', disabled: true},
 				{type: 'button',  id: 'insertion_mobile_wizard', img: 'insertion_mobile_wizard', disabled: true},
-				{type: 'button',  id: 'comment_wizard', img: 'viewcomments'},
-				{type: 'button',  id: 'fullscreen-presentation', img: 'fullscreen-presentation', hint: _UNO('.uno:FullScreen', 'presentation')},
+				{type: 'button',  id: 'comment_wizard', img: 'mobile_comment_wizard'},
 				{type: 'drop', id: 'userlist', img: 'users', hidden: true, html: L.control.createUserListWidget()},
 			];
 		} else if (docType == 'drawing') {
 			return [
 				{type: 'button',  id: 'closemobile',  img: 'closemobile'},
-				{type: 'spacer'},
 				{type: 'button',  id: 'undo',  img: 'undo', hint: _UNO('.uno:Undo'), uno: 'Undo', disabled: true},
 				{type: 'button',  id: 'redo',  img: 'redo', hint: _UNO('.uno:Redo'), uno: 'Redo', disabled: true},
+				{type: 'spacer'},
 				{type: 'button',  id: 'mobile_wizard', img: 'mobile_wizard', disabled: true},
 				{type: 'button',  id: 'insertion_mobile_wizard', img: 'insertion_mobile_wizard', disabled: true},
-				{type: 'button',  id: 'comment_wizard', img: 'viewcomments'},
-				{type: 'button',  id: 'fullscreen', img: 'fullscreen', hint: _UNO('.uno:FullScreen', 'drawing')},
+				{type: 'button',  id: 'comment_wizard', img: 'mobile_comment_wizard'},
 				{type: 'drop', id: 'userlist', img: 'users', hidden: true, html: L.control.createUserListWidget()},
 			];
 		}


### PR DESCRIPTION
Fullscreen and presentation was removed (they are available at the hamburger menu)
Spacer after undo/redo so that there are 3 buttons on the left and 3 on the right
Update TopBar icons. All are now monochrome

Signed-off-by: Andreas-Kainz <kainz.a@gmail.com>
Change-Id: Iff79bc24a4fcfacee63d87ecefea76c00b1dfdab
