### PR TITLE
Mobile BottomBar fix height

### DIFF
--- a/loleaflet/css/device-mobile.css
+++ b/loleaflet/css/device-mobile.css
@@ -402,7 +402,7 @@ button.vex-dialog-button-secondary.vex-dialog-button.vex-last {
 }
 #tb_actionbar_item_fullscreen{display: none;}
 #toolbar-down {
-	height: 34px !important;
+	height: 37px !important;
 	border-top: 1px solid #f1f1f1 !important;
 }
 #toolbar-down > .w2ui-scroll-wrapper {
@@ -486,7 +486,7 @@ button.vex-dialog-button-secondary.vex-dialog-button.vex-last {
 	border-color: #fff transparent;
 }
 #toolbar-down table.w2ui-button .w2ui-tb-image {
-	margin: 5px 9px 3px !important;
+	margin: 5px 9px !important;
 }
 .w2ui-toolbar .w2ui-break{
 	background-image: none;


### PR DESCRIPTION
The height of the bottom bar items is 35px the height of BottomBar was defined with 34px so that it look always as the bottomBar was cutted.

Height is changed from 34px to 37px (check the blue select frame, it now wasn't cuted)

Signed-off-by: Andreas-Kainz <kainz.a@gmail.com>
Change-Id: If30e56c582ca652cb35e73f669f440696c6b03b4
