### PR TITLE
Mobile Calc Property Sidebar

### DIFF
--- a/loleaflet/css/mobilewizard.css
+++ b/loleaflet/css/mobilewizard.css
@@ -228,19 +228,8 @@ p.mobile-wizard.ui-combobox-text.selected {
 	flex-wrap: wrap !important;
 	margin-top: 25px;
 }
-#rotationlabel, #cellbackgroundlabel, #NumberFormatCurrency > .unolabel, #NumberFormatPercent > .unolabel, #NumberFormatDecimal > .unolabel{
+#rotationlabel, #cellbackgroundlabel {
 	display: none;
-}
-#NumberFormatDecimal, #NumberFormatPercent{
-	margin-left: 20%;
-}
-#NumberFormatCurrency {
-	margin-left: 4%;
-}
-#ScNumberFormatPropertyPanel + .ui-content .unospan-numberformat {
-	width: 32px;
-	float: left;
-	margin-bottom: 4%;
 }
 .menuwizard #mobile-wizard-back {
 	background-position-x: 22px;
@@ -346,7 +335,6 @@ p.mobile-wizard.ui-combobox-text.selected {
 #mobile-wizard .ui-content .unobutton {
 	width: 32px;
 	height: 32px;
-	margin-right: 5px;
 	vertical-align: middle;
 }
 
@@ -671,10 +659,18 @@ a.leaflet-control-zoom-in {
 #mobile-wizard #SendToBack > span, #mobile-wizard #ObjectBackOne > span, #mobile-wizard  #ObjectForwardOne > span, #mobile-wizard #BringToFront > span, #mobile-wizard #SetObjectToBackground > span, #mobile-wizard #SetObjectToForeground > #mobile-wizard span, #mobile-wizard #FlipVertical > span, #mobile-wizard #FlipHorizontal > span, #mobile-wizard #Bold > span, #mobile-wizard #Italic > span, #mobile-wizard #Underline > span, #mobile-wizard #Strikeout > span, #mobile-wizard #StyleApply > span, #mobile-wizard #StyleUpdateByExample > span, #mobile-wizard #StyleNewByExample > span, #mobile-wizard #Shadowed > span, #mobile-wizard #Grow > span, #mobile-wizard #Shrink > span, #mobile-wizard #Color > span, #mobile-wizard #Spacing > span, #mobile-wizard #SuperScript > span, #mobile-wizard #SubScript > span, #mobile-wizard #AlignLeft > span, #mobile-wizard #AlignRight > span, #mobile-wizard #AlignHorizontalCenter > span, #mobile-wizard #AlignBlock > span, #mobile-wizard #ParaLeftToRight > span, #mobile-wizard #ParaRightToLeft > span, #mobile-wizard #AlignTop > span, #mobile-wizard #AlignVCenter > span, #mobile-wizard #AlignBottom > span, #mobile-wizard #IncrementIndent > span, #mobile-wizard #DecrementIndent > span, #mobile-wizard #LeftPara > span, #mobile-wizard #RightPara > span, #mobile-wizard #CenterPara > span, #mobile-wizard #JustifyPara > span, #mobile-wizard #DefaultBullet > span, #mobile-wizard #DefaultNumbering > span, #mobile-wizard #ParaspaceIncrease > span, #mobile-wizard #ParaspaceDecrease > span, #mobile-wizard #LineSpacing > span, #mobile-wizard #HangingIndent > span, #mobile-wizard #CellVertTop > span, #mobile-wizard #CellVertCenter > span, #mobile-wizard #CellVertBottom > span, #mobile-wizard div[id*='Table'] > span, #mobile-wizard div[id*='Row'] > span,  #mobile-wizard div[id*='Column'] > span, #mobile-wizard div[id*='Cell'] > span, #mobile-wizard div[id^='Outline'] > span, #mobile-wizard #nolines > img, #mobile-wizard #SetObjectToForeground > span {
 	display: none !important;
 }
-#mobile-wizard #SendToBack, #mobile-wizard #ObjectBackOne, #mobile-wizard #ObjectForwardOne, #mobile-wizard #BringToFront, #mobile-wizard #SetObjectToBackground, #mobile-wizard #SetObjectToForeground, #mobile-wizard #FlipVertical, #mobile-wizard #FlipHorizontal, #mobile-wizard #Bold, #mobile-wizard #Italic, #mobile-wizard #Underline, #Strikeout, #mobile-wizard #StyleApply, #mobile-wizard #StyleUpdateByExample, #mobile-wizard #StyleNewByExample, #mobile-wizard #Shadowed, #mobile-wizard #Grow, #mobile-wizard #Shrink, #mobile-wizard #Spacing, #mobile-wizard #SuperScript, #mobile-wizard #SubScript, #mobile-wizard #AlignLeft, #mobile-wizard #AlignRight, #mobile-wizard #AlignHorizontalCenter, #mobile-wizard #AlignBlock, #mobile-wizard #ParaRightToLeft, #mobile-wizard #ParaLeftToRight, #mobile-wizard #AlignTop, #mobile-wizard #AlignVCenter, #mobile-wizard #AlignBottom, #mobile-wizard #IncrementIndent, #mobile-wizard #DecrementIndent, #mobile-wizard #LeftPara, #mobile-wizard #RightPara, #mobile-wizard #CenterPara, #mobile-wizard #JustifyPara, #mobile-wizard #DefaultBullet, #mobile-wizard #DefaultNumbering, #mobile-wizard #ParaspaceIncrease, #mobile-wizard #ParaspaceDecrease, #mobile-wizard #LineSpacing, #mobile-wizard #HangingIndent, #mobile-wizard #CellVertTop, #mobile-wizard #CellVertCenter, #mobile-wizard #CellVertBottom, #mobile-wizard div[id*='Row'], #mobile-wizard div[id*='Column'], #mobile-wizard #DeleteTable, #mobile-wizard #MergeCells, #mobile-wizard div[id^='Outline'], #mobile-wizard #EntireCell, #mobile-wizard #SelectTable, #mobile-wizard #EntireColumn, #mobile-wizard #EntireRow, #mobile-wizard #SplitCell, #mobile-wizard #SplitTable{
-	padding: 16px 28px 16px 4% !important;
+.unospan-borderstyle, .unospan-numberformat, #mobile-wizard #SendToBack, #mobile-wizard #ObjectBackOne, #mobile-wizard #ObjectForwardOne, #mobile-wizard #BringToFront, #mobile-wizard #SetObjectToBackground, #mobile-wizard #SetObjectToForeground, #mobile-wizard #FlipVertical, #mobile-wizard #FlipHorizontal, #mobile-wizard #Bold, #mobile-wizard #Italic, #mobile-wizard #Underline, #Strikeout, #mobile-wizard #StyleApply, #mobile-wizard #StyleUpdateByExample, #mobile-wizard #StyleNewByExample, #mobile-wizard #Shadowed, #mobile-wizard #Grow, #mobile-wizard #Shrink, #mobile-wizard #Spacing, #mobile-wizard #SuperScript, #mobile-wizard #SubScript, #mobile-wizard #AlignLeft, #mobile-wizard #AlignRight, #mobile-wizard #AlignHorizontalCenter, #mobile-wizard #AlignBlock, #mobile-wizard #ParaRightToLeft, #mobile-wizard #ParaLeftToRight, #mobile-wizard #AlignTop, #mobile-wizard #AlignVCenter, #mobile-wizard #AlignBottom, #mobile-wizard #IncrementIndent, #mobile-wizard #DecrementIndent, #mobile-wizard #LeftPara, #mobile-wizard #RightPara, #mobile-wizard #CenterPara, #mobile-wizard #JustifyPara, #mobile-wizard #DefaultBullet, #mobile-wizard #DefaultNumbering, #mobile-wizard #ParaspaceIncrease, #mobile-wizard #ParaspaceDecrease, #mobile-wizard #LineSpacing, #mobile-wizard #HangingIndent, #mobile-wizard #CellVertTop, #mobile-wizard #CellVertCenter, #mobile-wizard #CellVertBottom, #mobile-wizard div[id*='Row'], #mobile-wizard div[id*='Column'], #mobile-wizard #DeleteTable, #mobile-wizard #MergeCells, #mobile-wizard div[id^='Outline'], #mobile-wizard #EntireCell, #mobile-wizard #SelectTable, #mobile-wizard #EntireColumn, #mobile-wizard #EntireRow, #mobile-wizard #SplitCell, #mobile-wizard #SplitTable{
+	padding: 12px !important;
 	margin: 0px !important;
 	float: left;
+}
+.unospan-borderstyle {
+	width: 32px;
+	height: 32px;
+	vertical-align: middle;
+}
+.unospan-numberformat{
+	text-align: center;
 }
 #MergeCells > span{
 	color: rgb(var(--blue1-txt-primary-color));
@@ -703,7 +699,7 @@ a.leaflet-control-zoom-in {
 	float: left;
 }
 
-#mobile-wizard #Shadowed, #mobile-wizard #StyleNewByExample + div, #mobile-wizard #AlignTop,
+#mobile-wizard #StyleNewByExample + div, #mobile-wizard #AlignTop,
 #mobile-wizard #AlignBottom + p, #mobile-wizard #mergecells, #mobile-wizard #BackgroundColor + p,
 #mobile-wizard #LineSpacing, #mobile-wizard #indentlabel, #mobile-wizard #spacinglabel,
 #mobile-wizard #sizelabel {


### PR DESCRIPTION
Icon size and alignment is now well at Number Format and Cell Appearance (Borders)
As on mobile there is a huge padding, there is no 5px padding-right needed.
Everything is well center aligned.

Signed-off-by: Andreas-Kainz <kainz.a@gmail.com>
Change-Id: I03f50fc4a87199666a1cf654c91c9f1aded59c47
