### PR TITLE
Avoid higlighting additional rows/cols

### DIFF
--- a/loleaflet/src/control/Control.Header.js
+++ b/loleaflet/src/control/Control.Header.js
@@ -588,7 +588,7 @@ L.Control.Header.HeaderInfo = L.Class.extend({
 							pos: data.startpos + data.size, // end position on the header canvas
 							size: data.size,
 							origsize: data.size,
-							isHighlighted: that.isHeaderEntryHighLighted(cellSelections, data.startpos + data.size * 0.5),
+							isHighlighted: that.isHeaderEntryHighLighted(cellSelections, data.startpos - startPx + data.size * 0.5),
 							isCurrent: idx === currentIndex ? true: false
 						};
 					}.bind(this)
@@ -614,7 +614,7 @@ L.Control.Header.HeaderInfo = L.Class.extend({
 			pos: firstFreeEnd, // end position on the header canvas
 			size: firstFreeSize,
 			origsize: dataFirstFree.size,
-			isHighlighted: that.isHeaderEntryHighLighted(cellSelections, dataFirstFree.startpos + dataFirstFree.size * 0.5),
+			isHighlighted: that.isHeaderEntryHighLighted(cellSelections, dataFirstFree.startpos - startPx + dataFirstFree.size * 0.5),
 			isCurrent: startIdx === currentIndex ? true: false
 		};
 
@@ -625,7 +625,7 @@ L.Control.Header.HeaderInfo = L.Class.extend({
 					pos: data.startpos - startPx + data.size, // end position on the header canvas
 					size: data.size,
 					origsize: data.size,
-					isHighlighted: that.isHeaderEntryHighLighted(cellSelections, data.startpos + data.size * 0.5),
+					isHighlighted: that.isHeaderEntryHighLighted(cellSelections, data.startpos - startPx + data.size * 0.5),
 					isCurrent: idx === currentIndex ? true: false
 				};
 			}.bind(this));


### PR DESCRIPTION
When used 120% zoom and selected any row after 50
there were multiple rows highlighted.

Change-Id: I4bc5f4272bf65fb0f9d00d96527890281377c0a8
Signed-off-by: Szymon Kłos <szymon.klos@collabora.com>
