### PR TITLE
Add an Android setting for the user's name or nickname

### DIFF
--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -28,6 +28,8 @@
     <string name="pref_filter_summary">Set which file filter should be used by default.</string>
     <string name="pref_show_debug_info">Show Debug Info</string>
     <string name="pref_show_debug_info_summary">Enable to show debug information in document viewer</string>
+    <string name="pref_user_name">User Name</string>
+    <string name="pref_user_name_info">Used when adding a comment</string>
     <string name="pref_enable_chrome_debugger">Chrome Debugging</string>
     <string name="pref_enable_chrome_debugger_info">Enable to use Chrome\'s debugging tool in the document</string>
 

--- a/android/app/src/main/res/xml/libreoffice_preferences.xml
+++ b/android/app/src/main/res/xml/libreoffice_preferences.xml
@@ -49,6 +49,14 @@
         android:key="PREF_CATEGORY_EDITOR"
         app:iconSpaceReserved="false" >
 
+        <EditTextPreference
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:defaultValue="Guest User"
+            android:key="USER_NAME"
+            android:summary="@string/pref_user_name_info"
+            android:title="@string/pref_user_name"
+            app:iconSpaceReserved="false" />
         <CheckBoxPreference
             android:title="@string/pref_show_debug_info"
             android:key="ENABLE_SHOW_DEBUG_INFO"

--- a/android/lib/src/main/cpp/androidapp.cpp
+++ b/android/lib/src/main/cpp/androidapp.cpp
@@ -28,6 +28,8 @@ const int SHOW_JS_MAXLEN = 70;
 
 int loolwsd_server_socket_fd = -1;
 
+const char* user_name;
+
 static std::string fileURL;
 static int fakeClientFd;
 static int closeNotificationPipeForForwardingThread[2] = {-1, -1};
@@ -298,7 +300,7 @@ extern "C" jboolean libreofficekit_initialize(JNIEnv* env, jstring dataDir, jstr
 
 /// Create the LOOLWSD instance.
 extern "C" JNIEXPORT void JNICALL
-Java_org_libreoffice_androidlib_LOActivity_createLOOLWSD(JNIEnv *env, jobject instance, jstring dataDir, jstring cacheDir, jstring apkFile, jobject assetManager, jstring loadFileURL, jstring uiMode)
+Java_org_libreoffice_androidlib_LOActivity_createLOOLWSD(JNIEnv *env, jobject instance, jstring dataDir, jstring cacheDir, jstring apkFile, jobject assetManager, jstring loadFileURL, jstring uiMode, jstring userName)
 {
     fileURL = std::string(env->GetStringUTFChars(loadFileURL, nullptr));
 
@@ -319,6 +321,8 @@ Java_org_libreoffice_androidlib_LOActivity_createLOOLWSD(JNIEnv *env, jobject in
     }
     const std::string userInterfaceMode = std::string(env->GetStringUTFChars(uiMode, nullptr));
     setupKitEnvironment(userInterfaceMode);
+    static const std::string userNameString = std::string(env->GetStringUTFChars(userName, nullptr));
+    user_name = userNameString.c_str();
     lokInitialized = true;
     libreofficekit_initialize(env, dataDir, cacheDir, apkFile, assetManager);
 

--- a/android/lib/src/main/cpp/androidapp.hpp
+++ b/android/lib/src/main/cpp/androidapp.hpp
@@ -7,6 +7,8 @@
 
 extern int loolwsd_server_socket_fd;
 
+extern const char* user_name;
+
 /** Equivalent of postMobileMessage(), but called directly from the native code. */
 void postDirectMessage(std::string message);
 

--- a/android/lib/src/main/java/org/libreoffice/androidlib/LOActivity.java
+++ b/android/lib/src/main/java/org/libreoffice/androidlib/LOActivity.java
@@ -95,6 +95,7 @@ public class LOActivity extends AppCompatActivity {
     private static final String CLIPBOARD_FILE_PATH = "LibreofficeClipboardFile.data";
     private static final String CLIPBOARD_LOOL_SIGNATURE = "lool-clip-magic-4a22437e49a8-";
     public static final String RECENT_DOCUMENTS_KEY = "RECENT_DOCUMENTS_LIST";
+    private static String USER_NAME_KEY = "USER_NAME";
 
     private File mTempFile = null;
 
@@ -810,7 +811,8 @@ public class LOActivity extends AppCompatActivity {
         String apkFile = getApplication().getPackageResourcePath();
         AssetManager assetManager = getResources().getAssets();
         String uiMode = (isLargeScreen() && !isChromeOS()) ? "notebookbar" : "classic";
-        createLOOLWSD(dataDir, cacheDir, apkFile, assetManager, urlToLoad, uiMode);
+        String userName = getPrefs().getString(USER_NAME_KEY, "Guest User");
+        createLOOLWSD(dataDir, cacheDir, apkFile, assetManager, urlToLoad, uiMode, userName);
 
         // trigger the load of the document
         String finalUrlToLoad = "file:///android_asset/dist/loleaflet.html?file_path=" +
@@ -861,7 +863,7 @@ public class LOActivity extends AppCompatActivity {
     /**
      * Initialize the LOOLWSD to load 'loadFileURL'.
      */
-    public native void createLOOLWSD(String dataDir, String cacheDir, String apkFile, AssetManager assetManager, String loadFileURL, String uiMode);
+    public native void createLOOLWSD(String dataDir, String cacheDir, String apkFile, AssetManager assetManager, String loadFileURL, String uiMode, String userName);
 
     /**
      * Passing messages from JS (instead of the websocket communication).

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -54,6 +54,8 @@
 
 #ifdef IOS
 #include <ios.h>
+#elif defined(__ANDROID__)
+#include "androidapp.hpp"
 #endif
 
 using std::size_t;
@@ -320,7 +322,7 @@ std::unique_ptr<LocalStorage::LocalFileInfo> LocalStorage::getLocalFileInfo()
     // Set automatic userid and username
     std::string userNameString;
 
-#ifdef IOS
+#if MOBILEAPP
     if (user_name != nullptr)
         userNameString = std::string(user_name);
 #endif


### PR DESCRIPTION
This was already worked on iOS since commit
75a3ab02ca072bb09ec39623730eecc4db71d1cf (Add an iOS setting for the
user's name or nickname, 2021-04-07), start using the same API on
Android as well.

(cherry picked from commit c415fcbcce6ead73e1caf2eff76391769aea8514)

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I37825d143b0ed92bd84f9a1512313e51ff5e761c
