### PR TITLE
Make 'l' toggle between the default and minimum (not maximum) permitt…

### DIFF
--- a/loleaflet/src/control/Toolbar.js
+++ b/loleaflet/src/control/Toolbar.js
@@ -699,11 +699,18 @@ L.Map.include({
 			} else if (event.key === 'l') {
 				// L toggges the Online logging level between the default (whatever
 				// is set in loolwsd.xml or on the loolwsd command line) and the
-				// maximum a client is allowed to set (which also can be set in
+				// minumum a client is allowed to set (which also can be set in
 				// loolwsd.xml or on the loolwsd command line).
+				//
+				// "Minumum" here means "most verbose", i.e. the lowest priority of
+				// messages that get printed.
+				//
+				// In a typical developer "make run" setup, the default is "trace"
+				// so there is nothing more verbose. But presumably it is different
+				// in production setups.
 
 				app.socket.sendMessage('loggingleveloverride '
-						       + (app.socket.threadLocalLoggingLevelToggle ? 'default' : 'max'));
+						       + (app.socket.threadLocalLoggingLevelToggle ? 'default' : 'min'));
 
 				app.socket.threadLocalLoggingLevelToggle = !app.socket.threadLocalLoggingLevelToggle;
 			} else if (event.key === 't') {


### PR DESCRIPTION
…ed levels

"Default" here means the value of the logging.level parameter in
loolwsd.xml.

"Minumum" means "most verbose", and it is the value of the
logging.min_level_settable_from_client parameter in loolwsd.xml.

In a typical developer "make run" setup, the default logging.level is
"trace" so there is nothing more verbose. But presumably it is
different in production setups.

Gosh, it is hard to decide whether "maximum" in this context refers to
maximum priority or maximum verbosity... and correspondingly for
"minumum". Maybe I should avoid that terminology completely and use
something more explicit?

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: I9231a59100668bd82ba3ee2160a57e8b5483c572


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

