### PR TITLE
Avoid maximum/minimum logging level terminology for newly introduced …

### DIFF
--- a/loleaflet/src/control/Toolbar.js
+++ b/loleaflet/src/control/Toolbar.js
@@ -699,18 +699,15 @@ L.Map.include({
 			} else if (event.key === 'l') {
 				// L toggges the Online logging level between the default (whatever
 				// is set in loolwsd.xml or on the loolwsd command line) and the
-				// minumum a client is allowed to set (which also can be set in
+				// most verbose a client is allowed to set (which also can be set in
 				// loolwsd.xml or on the loolwsd command line).
-				//
-				// "Minumum" here means "most verbose", i.e. the lowest priority of
-				// messages that get printed.
 				//
 				// In a typical developer "make run" setup, the default is "trace"
 				// so there is nothing more verbose. But presumably it is different
 				// in production setups.
 
 				app.socket.sendMessage('loggingleveloverride '
-						       + (app.socket.threadLocalLoggingLevelToggle ? 'default' : 'min'));
+						       + (app.socket.threadLocalLoggingLevelToggle ? 'default' : 'verbose'));
 
 				app.socket.threadLocalLoggingLevelToggle = !app.socket.threadLocalLoggingLevelToggle;
 			} else if (event.key === 't') {

--- a/loolwsd.xml.in
+++ b/loolwsd.xml.in
@@ -53,9 +53,9 @@
 
     <logging>
         <color type="bool">true</color>
-        <level type="string" desc="Can be 0-8, or none (turns off logging), fatal, critical, error, warning, notice, information, debug, trace" default="@LOOLWSD_LOGLEVEL@">@LOOLWSD_LOGLEVEL@</level>
-        <min_level_settable_from_client type="string" desc="The lowest log level that can be set in a message from a client" default="notice">notice</min_level_settable_from_client>
-        <max_level_settable_from_client type="string" desc="The highest log level that can be set in a message from a client" default="fatal">fatal</max_level_settable_from_client>
+        <level type="string" desc="Can be 0-8 (with the lowest numbers being the least verbose), or none (turns off logging), fatal, critical, error, warning, notice, information, debug, trace" default="@LOOLWSD_LOGLEVEL@">@LOOLWSD_LOGLEVEL@</level>
+        <most_verbose_level_settable_from_client type="string" desc="A loggingleveloverride message from the client can not set a more verbose log level than this" default="notice">notice</most_verbose_level_settable_from_client>
+        <least_verbose_level_settable_from_client type="string" desc="A loggingleveloverride message from a client can not set a less verbose log level than this" default="fatal">fatal</least_verbose_level_settable_from_client>
         <protocol type="bool" desc="Enable minimal client-site JS protocol logging from the start">@ENABLE_DEBUG_PROTOCOL@</protocol>
         <!-- lokit_sal_log example: Log WebDAV-related messages, that is interesting for debugging Insert - Image operation: "+TIMESTAMP+INFO.ucb.ucp.webdav+WARN.ucb.ucp.webdav"
              See also: https://docs.libreoffice.org/sal/html/sal_log.html -->

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -816,36 +816,34 @@ bool ClientSession::_handleInput(const char *buffer, int length)
             {
                 try
                 {
-                    auto minAllowed = Poco::Logger::parseLevel(LOOLWSD::MinLogLevelSettableFromClient);
-                    auto maxAllowed = Poco::Logger::parseLevel(LOOLWSD::MaxLogLevelSettableFromClient);
+                    auto leastVerboseAllowed = Poco::Logger::parseLevel(LOOLWSD::LeastVerboseLogLevelSettableFromClient);
+                    auto mostVerboseAllowed = Poco::Logger::parseLevel(LOOLWSD::MostVerboseLogLevelSettableFromClient);
 
-                    if (tokens.equals(1, "min"))
+                    if (tokens.equals(1, "verbose"))
                     {
-                        LOG_INF("Thread-local logging level being set to ["
-                                << LOOLWSD::MinLogLevelSettableFromClient
+                        LOG_INF("Client sets thread-local logging level to the most verbose allowed ["
+                                << LOOLWSD::MostVerboseLogLevelSettableFromClient
                                 << "]");
-                        Log::setThreadLocalLogLevel(LOOLWSD::MinLogLevelSettableFromClient);
+                        Log::setThreadLocalLogLevel(LOOLWSD::MostVerboseLogLevelSettableFromClient);
                         LOG_INF("Thread-local logging level was set to ["
-                                << LOOLWSD::MinLogLevelSettableFromClient
+                                << LOOLWSD::MostVerboseLogLevelSettableFromClient
                                 << "]");
                     }
-                    else if (tokens.equals(1, "max"))
+                    else if (tokens.equals(1, "terse"))
                     {
-                        LOG_INF("Thread-local logging level being set to ["
-                                << LOOLWSD::MaxLogLevelSettableFromClient
+                        LOG_INF("Client sets thread-local logging level to the least verbose allowed ["
+                                << LOOLWSD::LeastVerboseLogLevelSettableFromClient
                                 << "]");
-                        Log::setThreadLocalLogLevel(LOOLWSD::MaxLogLevelSettableFromClient);
+                        Log::setThreadLocalLogLevel(LOOLWSD::LeastVerboseLogLevelSettableFromClient);
                         LOG_INF("Thread-local logging level was set to ["
-                                << LOOLWSD::MaxLogLevelSettableFromClient
+                                << LOOLWSD::LeastVerboseLogLevelSettableFromClient
                                 << "]");
                     }
                     else
                     {
                         auto level = Poco::Logger::parseLevel(tokens[1]);
-                        // Note that numerically the higher priority levels are lower in value. Our
-                        // "min" and "max" terminology refers to priority, not numeric value. Thus
-                        // the seemingly weird check here.
-                        if (level >= maxAllowed && level <= minAllowed)
+                        // Note that numerically the higher priority levels are lower in value.
+                        if (level >= leastVerboseAllowed && level <= mostVerboseAllowed)
                         {
                             LOG_INF("Thread-local logging level being set to ["
                                     << tokens[1]
@@ -857,8 +855,8 @@ bool ClientSession::_handleInput(const char *buffer, int length)
                             LOG_WRN("Client tries to set logging level to ["
                                     << tokens[1]
                                     << "] which is outside of bounds ["
-                                    << LOOLWSD::MinLogLevelSettableFromClient << ","
-                                    << LOOLWSD::MaxLogLevelSettableFromClient << "]");
+                                    << LOOLWSD::LeastVerboseLogLevelSettableFromClient << ","
+                                    << LOOLWSD::MostVerboseLogLevelSettableFromClient << "]");
                         }
                     }
                 }

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -761,8 +761,8 @@ std::string LOOLWSD::ConfigDir = LOOLWSD_CONFIGDIR "/conf.d";
 bool LOOLWSD::EnableTraceEventLogging = false;
 FILE *LOOLWSD::TraceEventFile = NULL;
 std::string LOOLWSD::LogLevel = "trace";
-std::string LOOLWSD::MaxLogLevelSettableFromClient = "notice";
-std::string LOOLWSD::MinLogLevelSettableFromClient = "fatal";
+std::string LOOLWSD::MostVerboseLogLevelSettableFromClient = "notice";
+std::string LOOLWSD::LeastVerboseLogLevelSettableFromClient = "fatal";
 std::string LOOLWSD::UserInterface = "classic";
 bool LOOLWSD::AnonymizeUserData = false;
 bool LOOLWSD::CheckLoolUser = true;
@@ -1052,8 +1052,8 @@ void LOOLWSD::innerInitialize(Application& self)
 
     // Set the log-level after complete initialization to force maximum details at startup.
     LogLevel = getConfigValue<std::string>(conf, "logging.level", "trace");
-    MaxLogLevelSettableFromClient = getConfigValue<std::string>(conf, "logging.max_level_settable_from_client", "notice");
-    MinLogLevelSettableFromClient = getConfigValue<std::string>(conf, "logging.min_level_settable_from_client", "fatal");
+    MostVerboseLogLevelSettableFromClient = getConfigValue<std::string>(conf, "logging.most_verbose_level_settable_from_client", "notice");
+    LeastVerboseLogLevelSettableFromClient = getConfigValue<std::string>(conf, "logging.least_verbose_level_settable_from_client", "fatal");
 
     setenv("LOOL_LOGLEVEL", LogLevel.c_str(), true);
 

--- a/wsd/LOOLWSD.hpp
+++ b/wsd/LOOLWSD.hpp
@@ -253,8 +253,8 @@ public:
     static bool EnableTraceEventLogging;
     static FILE *TraceEventFile;
     static std::string LogLevel;
-    static std::string MaxLogLevelSettableFromClient;
-    static std::string MinLogLevelSettableFromClient;
+    static std::string MostVerboseLogLevelSettableFromClient;
+    static std::string LeastVerboseLogLevelSettableFromClient;
     static bool AnonymizeUserData;
     static bool CheckLoolUser;
     static bool CleanupOnly;

--- a/wsd/protocol.txt
+++ b/wsd/protocol.txt
@@ -337,17 +337,18 @@ sallogoverride <string>
     Overrides the SAL_LOG value, or stops overriding if no parameter
     or parameter is "default".
 
-loggingleveloverride <default|max|min|none|fatal|critical|error|warning|notice|information|debug|trace>
+loggingleveloverride <default|max|verbose|terse|none|fatal|critical|error|warning|notice|information|debug|trace>
 
     Override the Online logging level for the thread(s) and Kit
     processes handling this particular client.
 
     The value is either one of the log level names, or the special
     value "default" (meaning whatever is the log level specified in
-    the "logging.level" configuration setting), "min", or "max)
-    (meaning the minimum or maximum allowed, the
-    "logging.min_settable_from_client" or
-    "logging.max_settable_from_client" configuration setting).
+    the "logging.level" configuration setting), "verbose", or "terse")
+    (meaning the most or least verbose level allowed, the
+    "logging.most_verbose_level_settable_from_client" or
+    "logging.least_verbose_level_settable_from_client" configuration
+    setting).
 
 
 server -> client


### PR DESCRIPTION
…settings

(Also in variable names.)

Better to just use terms that say what we mean, i.e. most verbose and
least verbose.

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: I80d74fda8b80bd34d194c3df97d246a41368189b


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

