### PR TITLE
Add a ProfileZone around two more WopiStorage member functions

### DIFF
--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -654,7 +654,7 @@ std::unique_ptr<WopiStorage::WOPIFileInfo> WopiStorage::getWOPIFileInfo(const Au
                                                                         const std::string& cookies,
                                                                         LockContext& lockCtx)
 {
-    ProfileZone profileZone("getWOPIFileInfo", { {"url", _fileUrl} });
+    ProfileZone profileZone("WopiStorage::getWOPIFileInfo", { {"url", _fileUrl} });
 
     // update the access_token to the one matching to the session
     Poco::URI uriObject(getUri());
@@ -977,6 +977,8 @@ std::string WopiStorage::downloadStorageFileToLocal(const Authorization& auth,
                                                     LockContext& /*lockCtx*/,
                                                     const std::string& templateUri)
 {
+    ProfileZone profileZone("WopiStorage::downloadStorageFileToLocal", { {"url", _fileUrl} });
+
     if (!templateUri.empty())
     {
         // Download the template file and load it normally.
@@ -1107,6 +1109,8 @@ WopiStorage::uploadLocalFileToStorage(const Authorization& auth, const std::stri
                                       LockContext& lockCtx, const std::string& saveAsPath,
                                       const std::string& saveAsFilename, const bool isRename)
 {
+    ProfileZone profileZone("WopiStorage::uploadLocalFileToStorage", { {"url", _fileUrl} });
+
     // TODO: Check if this URI has write permission (canWrite = true)
 
     const bool isSaveAs = !saveAsPath.empty() && !saveAsFilename.empty();


### PR DESCRIPTION
As requested by mmeeks.

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: Iba04bc5255479b9b0998a385d558bf07279bf00c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

