### PR TITLE
Do not include js files in TS compilation

### DIFF
--- a/loleaflet/Makefile.am
+++ b/loleaflet/Makefile.am
@@ -563,7 +563,7 @@ $(DIST_FOLDER)/welcome/%.html: $(srcdir)/welcome/%.html
 	fi
 
 tscompile.done: $(LOLEAFLET_JS_SRC) $(LOLEAFLET_TS_SRC)
-	$(builddir)/node_modules/typescript/bin/tsc --typeRoots $(builddir)/node_modules/@types --outDir $(DIST_FOLDER)/src --rootDir $(srcdir)/src --allowJs true --checkJs false --project $(srcdir)/tsconfig.json
+	$(builddir)/node_modules/typescript/bin/tsc --typeRoots $(builddir)/node_modules/@types --outDir $(DIST_FOLDER)/src --rootDir $(srcdir)/src --checkJs false --project $(srcdir)/tsconfig.json
 	@touch $@
 
 $(LOLEAFLET_TS_JS_DST): tscompile.done


### PR DESCRIPTION
Signed-off-by: Pranam Lashkari <lpranam@collabora.com>
Change-Id: Ie2df89ba09597a34aca9221bf082b1f2df3c7d07

* Target version: master 

### Summary
problem:
in compilation tsc removes blank lines from the file
this causes problem in debugging and mapping with IDEs

https://github.com/microsoft/TypeScript/issues/843


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

