### PR TITLE
Use larger write buffer size for UDS from kit -> wsd.

### DIFF
--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -467,6 +467,9 @@ void SocketPoll::insertNewUnixSocket(
 
     std::static_pointer_cast<ProtocolHandlerInterface>(websocketHandler)->onConnect(socket);
     insertNewSocket(socket);
+
+    // We send lots of data back via this local UDS'
+    socket->setSocketBufferSize(Socket::MaximumSendBufferSize);
 }
 
 #else


### PR DESCRIPTION
We send lots of large tile data this way, this should help
accelerate tile data transfer marginally.

Change-Id: I1deab7845c09dc65b1f44e9f9fc762f70ce94cc3


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

