### PR TITLE
Mobile unobuttons no additional padding needed

### DIFF
--- a/loleaflet/css/mobilewizard.css
+++ b/loleaflet/css/mobilewizard.css
@@ -346,7 +346,6 @@ p.mobile-wizard.ui-combobox-text.selected {
 #mobile-wizard .ui-content .unobutton {
 	width: 32px;
 	height: 32px;
-	margin-right: 5px;
 	vertical-align: middle;
 }
 


### PR DESCRIPTION
As on mobile there is huge padding, there is no additional 5px padding needed.

Signed-off-by: Andreas-Kainz <kainz.a@gmail.com>
Change-Id: Iaa3765ca2b6b3010cac69562e847cc252efea564
