### PR TITLE
fix: no painting on switching to earlier slides (co-6-4)

### DIFF
--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -1299,8 +1299,15 @@ L.CanvasTileLayer = L.TileLayer.extend({
 					'tileheight=' + this._tileHeightTwips;
 
 				this._map._socket.sendMessage(message, '');
+			} else {
+				// We have all necessary tile images in the cache, schedule a paint..
+				// This may not be immediate if we are now in a slurp events call.
+				this._painter.update();
 			}
 
+		} else {
+			// We have all necessary tiles in the tile array, schedule a paint.
+			this._painter.update();
 		}
 
 		if (typeof (this._prevSelectedPart) === 'number' &&


### PR DESCRIPTION
Before slurping events work, on switching parts the canvas was getting
painted as side effect of other events triggered from
Parts.js:setPart(). Let us enforce an explicit and possibly immediate
canvas update on part/slide switch in case we have all the necessary
tiles in the tile array or the cache in the doclayer method
_updateOnChangePart().

Signed-off-by: Dennis Francis <dennis.francis@collabora.com>
Change-Id: I776c1a2476adb1db2054eecdbba78feff290981a


* Resolves: # <!-- related github issue -->
* Target version: co-6-4

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

