### PR TITLE
fix tile invalidation for tiles of other zooms

### DIFF
--- a/loleaflet/src/layer/tile/CalcTileLayer.js
+++ b/loleaflet/src/layer/tile/CalcTileLayer.js
@@ -385,9 +385,7 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 		var needsNewTiles = false;
 		for (var key in this._tiles) {
 			var coords = this._tiles[key].coords;
-			var tileTopLeft = this._coordsToTwips(coords);
-			var tileBottomRight = new L.Point(this._tileWidthTwips, this._tileHeightTwips);
-			var bounds = new L.Bounds(tileTopLeft, tileTopLeft.add(tileBottomRight));
+			var bounds = this._coordsToTileBounds(coords);
 			if (coords.part === command.part && invalidBounds.intersects(bounds)) {
 				if (this._tiles[key]._invalidCount) {
 					this._tiles[key]._invalidCount += 1;
@@ -422,7 +420,7 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 				continue;
 			}
 
-			bounds = this._coordsToTwipsBoundsAtZoom(coords, this._map.getZoom());
+			bounds = this._coordsToTileBounds(coords);
 			if (invalidBounds.intersects(bounds)) {
 				delete this._tileCache[key];
 			}

--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -1806,6 +1806,15 @@ L.CanvasTileLayer = L.TileLayer.extend({
 
 	getTileSectionPos: function () {
 		return this._painter.getTileSectionPos();
+	},
+
+	_coordsToTileBounds: function (coords) {
+		var zoomFactor = this._map.zoomToFactor(coords.z);
+		var tileTopLeft = new L.Point(
+			coords.x * this.options.tileWidthTwips / this._tileSize / zoomFactor,
+			coords.y * this.options.tileHeightTwips / this._tileSize / zoomFactor);
+		var tileSize = new L.Point(this.options.tileWidthTwips / zoomFactor, this.options.tileHeightTwips / zoomFactor);
+		return new L.Bounds(tileTopLeft, tileTopLeft.add(tileSize));
 	}
 
 });

--- a/loleaflet/src/layer/tile/GridLayer.js
+++ b/loleaflet/src/layer/tile/GridLayer.js
@@ -1350,21 +1350,6 @@ L.GridLayer = L.Layer.extend({
 		return new L.Bounds(topLeft, bottomRight);
 	},
 
-	_coordsToTwipsBoundsAtZoom: function (coords, zoom) {
-		console.assert(typeof zoom === 'number', 'invalid zoom');
-		// FIXME: this is highly inaccurate for tiles near the bottom/right when zoom != coords.z.
-		// Use sheet geometry data instead (but will need to pre-compute tiletwips positions in
-		// L.SheetDimension for at least the recently used zoom levels to avoid a linear scan of its spans.)
-		var scale = this._map.getZoomScale(coords.z, zoom);
-		var pxBounds = this._coordsToPixBounds(coords);
-		pxBounds.min._divideBy(scale);
-		pxBounds.max._divideBy(scale);
-
-		var topLeftTwips = this._pixelsToTwips(pxBounds.min);
-		var bottomRightTwips = this._pixelsToTwips(pxBounds.max);
-		return new L.Bounds(topLeftTwips, bottomRightTwips);
-	},
-
 	getMaxDocSize: function () {
 		return undefined;
 	},

--- a/loleaflet/src/layer/tile/ImpressTileLayer.js
+++ b/loleaflet/src/layer/tile/ImpressTileLayer.js
@@ -197,9 +197,7 @@ L.ImpressTileLayer = L.CanvasTileLayer.extend({
 		var needsNewTiles = false;
 		for (var key in this._tiles) {
 			var coords = this._tiles[key].coords;
-			var tileTopLeft = this._coordsToTwips(coords);
-			var tileBottomRight = new L.Point(this._tileWidthTwips, this._tileHeightTwips);
-			var bounds = new L.Bounds(tileTopLeft, tileTopLeft.add(tileBottomRight));
+			var bounds = this._coordsToTileBounds(coords);
 			if (coords.part === command.part && invalidBounds.intersects(bounds)) {
 				if (this._tiles[key]._invalidCount) {
 					this._tiles[key]._invalidCount += 1;
@@ -232,14 +230,7 @@ L.ImpressTileLayer = L.CanvasTileLayer.extend({
 			if (coords.part !== command.part) {
 				continue;
 			}
-			var scale = this._map.getZoomScale(coords.z);
-			topLeftTwips = new L.Point(
-					this.options.tileWidthTwips / scale * coords.x,
-					this.options.tileHeightTwips / scale * coords.y);
-			bottomRightTwips = topLeftTwips.add(new L.Point(
-					this.options.tileWidthTwips / scale,
-					this.options.tileHeightTwips / scale));
-			bounds = new L.Bounds(topLeftTwips, bottomRightTwips);
+			bounds = this._coordsToTileBounds(coords);
 			if (invalidBounds.intersects(bounds)) {
 				delete this._tileCache[key];
 			}

--- a/loleaflet/src/layer/tile/WriterTileLayer.js
+++ b/loleaflet/src/layer/tile/WriterTileLayer.js
@@ -150,9 +150,7 @@ L.WriterTileLayer = L.CanvasTileLayer.extend({
 		var needsNewTiles = false;
 		for (var key in this._tiles) {
 			var coords = this._tiles[key].coords;
-			var tileTopLeft = this._coordsToTwips(coords);
-			var tileBottomRight = new L.Point(this._tileWidthTwips, this._tileHeightTwips);
-			var bounds = new L.Bounds(tileTopLeft, tileTopLeft.add(tileBottomRight));
+			var bounds = this._coordsToTileBounds(coords);
 			if (coords.part === command.part && invalidBounds.intersects(bounds)) {
 				if (this._tiles[key]._invalidCount) {
 					this._tiles[key]._invalidCount += 1;
@@ -182,14 +180,7 @@ L.WriterTileLayer = L.CanvasTileLayer.extend({
 			// compute the rectangle that each tile covers in the document based
 			// on the zoom level
 			coords = this._keyToTileCoords(key);
-			var scale = this._map.getZoomScale(coords.z);
-			topLeftTwips = new L.Point(
-					this.options.tileWidthTwips / scale * coords.x,
-					this.options.tileHeightTwips / scale * coords.y);
-			bottomRightTwips = topLeftTwips.add(new L.Point(
-					this.options.tileWidthTwips / scale,
-					this.options.tileHeightTwips / scale));
-			bounds = new L.Bounds(topLeftTwips, bottomRightTwips);
+			bounds = this._coordsToTileBounds(coords);
 			if (invalidBounds.intersects(bounds)) {
 				delete this._tileCache[key];
 			}


### PR DESCRIPTION
tile-size is always 256 core pixels, so twips size of a tile in
different zooms are different depending on zoom scale. But the document
coordinates of the tiles in twips are zoom invariant.

Problem it resolves: Open any writer/impress document, switch to 85%, 120% zooms and then back to 100%.
Make a very noticeable change like color change. Now switch to 85% or 120% zoom, the change is not there completely or there are blank tiles.

Signed-off-by: Dennis Francis <dennis.francis@collabora.com>
Change-Id: I648134aaf84d451d93dad54d62b66062fb1d9204


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

