### PR TITLE
android: mark "Guest User" for l10n

### DIFF
--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -30,6 +30,7 @@
     <string name="pref_show_debug_info_summary">Enable to show debug information in document viewer</string>
     <string name="pref_user_name">User Name</string>
     <string name="pref_user_name_info">Used when adding a comment</string>
+    <string name="pref_user_name_guest">Guest User</string>
     <string name="pref_enable_chrome_debugger">Chrome Debugging</string>
     <string name="pref_enable_chrome_debugger_info">Enable to use Chrome\'s debugging tool in the document</string>
 

--- a/android/app/src/main/res/xml/libreoffice_preferences.xml
+++ b/android/app/src/main/res/xml/libreoffice_preferences.xml
@@ -52,7 +52,7 @@
         <EditTextPreference
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:defaultValue="Guest User"
+            android:defaultValue="@string/pref_user_name_guest"
             android:key="USER_NAME"
             android:summary="@string/pref_user_name_info"
             android:title="@string/pref_user_name"


### PR DESCRIPTION
i18n issue: android:defaultValue="Guest User" is not localizable.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Id80b01e7d7a1059476a688ebdf1ce848c6838cc4
