### PR TITLE
fix tile invalidation for tiles of other zooms

### DIFF
--- a/loleaflet/src/layer/tile/CalcTileLayer.js
+++ b/loleaflet/src/layer/tile/CalcTileLayer.js
@@ -381,9 +381,7 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 		var needsNewTiles = false;
 		for (var key in this._tiles) {
 			var coords = this._tiles[key].coords;
-			var tileTopLeft = this._coordsToTwips(coords);
-			var tileBottomRight = new L.Point(this._tileWidthTwips, this._tileHeightTwips);
-			var bounds = new L.Bounds(tileTopLeft, tileTopLeft.add(tileBottomRight));
+			var bounds = this._coordsToTileBounds(coords);
 			if (coords.part === command.part && invalidBounds.intersects(bounds)) {
 				if (this._tiles[key]._invalidCount) {
 					this._tiles[key]._invalidCount += 1;
@@ -418,7 +416,7 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 				continue;
 			}
 
-			bounds = this._coordsToTwipsBoundsAtZoom(coords, this._map.getZoom());
+			bounds = this._coordsToTileBounds(coords);
 			if (invalidBounds.intersects(bounds)) {
 				delete this._tileCache[key];
 			}

--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -1390,21 +1390,6 @@ L.CanvasTileLayer = L.Layer.extend({
 		app.socket.sendMessage(msg, '');
 	},
 
-	_coordsToTwipsBoundsAtZoom: function (coords, zoom) {
-		console.assert(typeof zoom === 'number', 'invalid zoom');
-		// FIXME: this is highly inaccurate for tiles near the bottom/right when zoom != coords.z.
-		// Use sheet geometry data instead (but will need to pre-compute tiletwips positions in
-		// L.SheetDimension for at least the recently used zoom levels to avoid a linear scan of its spans.)
-		var scale = this._map.getZoomScale(coords.z, zoom);
-		var pxBounds = this._coordsToPixBounds(coords);
-		pxBounds.min._divideBy(scale);
-		pxBounds.max._divideBy(scale);
-
-		var topLeftTwips = this._pixelsToTwips(pxBounds.min);
-		var bottomRightTwips = this._pixelsToTwips(pxBounds.max);
-		return new L.Bounds(topLeftTwips, bottomRightTwips);
-	},
-
 	getMaxDocSize: function () {
 		return undefined;
 	},
@@ -6246,6 +6231,15 @@ L.CanvasTileLayer = L.Layer.extend({
 
 	getTileSectionPos: function () {
 		return this._painter.getTileSectionPos();
+	},
+
+	_coordsToTileBounds: function (coords) {
+		var zoomFactor = this._map.zoomToFactor(coords.z);
+		var tileTopLeft = new L.Point(
+			coords.x * this.options.tileWidthTwips / this._tileSize / zoomFactor,
+			coords.y * this.options.tileHeightTwips / this._tileSize / zoomFactor);
+		var tileSize = new L.Point(this.options.tileWidthTwips / zoomFactor, this.options.tileHeightTwips / zoomFactor);
+		return new L.Bounds(tileTopLeft, tileTopLeft.add(tileSize));
 	}
 
 });

--- a/loleaflet/src/layer/tile/ImpressTileLayer.js
+++ b/loleaflet/src/layer/tile/ImpressTileLayer.js
@@ -194,9 +194,7 @@ L.ImpressTileLayer = L.CanvasTileLayer.extend({
 		var needsNewTiles = false;
 		for (var key in this._tiles) {
 			var coords = this._tiles[key].coords;
-			var tileTopLeft = this._coordsToTwips(coords);
-			var tileBottomRight = new L.Point(this._tileWidthTwips, this._tileHeightTwips);
-			var bounds = new L.Bounds(tileTopLeft, tileTopLeft.add(tileBottomRight));
+			var bounds = this._coordsToTileBounds(coords);
 			if (coords.part === command.part && invalidBounds.intersects(bounds)) {
 				if (this._tiles[key]._invalidCount) {
 					this._tiles[key]._invalidCount += 1;
@@ -229,14 +227,7 @@ L.ImpressTileLayer = L.CanvasTileLayer.extend({
 			if (coords.part !== command.part) {
 				continue;
 			}
-			var scale = this._map.getZoomScale(coords.z);
-			topLeftTwips = new L.Point(
-				this.options.tileWidthTwips / scale * coords.x,
-				this.options.tileHeightTwips / scale * coords.y);
-			bottomRightTwips = topLeftTwips.add(new L.Point(
-				this.options.tileWidthTwips / scale,
-				this.options.tileHeightTwips / scale));
-			bounds = new L.Bounds(topLeftTwips, bottomRightTwips);
+			bounds = this._coordsToTileBounds(coords);
 			if (invalidBounds.intersects(bounds)) {
 				delete this._tileCache[key];
 			}

--- a/loleaflet/src/layer/tile/WriterTileLayer.js
+++ b/loleaflet/src/layer/tile/WriterTileLayer.js
@@ -154,9 +154,7 @@ L.WriterTileLayer = L.CanvasTileLayer.extend({
 		var needsNewTiles = false;
 		for (var key in this._tiles) {
 			var coords = this._tiles[key].coords;
-			var tileTopLeft = this._coordsToTwips(coords);
-			var tileBottomRight = new L.Point(this._tileWidthTwips, this._tileHeightTwips);
-			var bounds = new L.Bounds(tileTopLeft, tileTopLeft.add(tileBottomRight));
+			var bounds = this._coordsToTileBounds(coords);
 			if (coords.part === command.part && invalidBounds.intersects(bounds)) {
 				if (this._tiles[key]._invalidCount) {
 					this._tiles[key]._invalidCount += 1;
@@ -186,14 +184,7 @@ L.WriterTileLayer = L.CanvasTileLayer.extend({
 			// compute the rectangle that each tile covers in the document based
 			// on the zoom level
 			coords = this._keyToTileCoords(key);
-			var scale = this._map.getZoomScale(coords.z);
-			topLeftTwips = new L.Point(
-				this.options.tileWidthTwips / scale * coords.x,
-				this.options.tileHeightTwips / scale * coords.y);
-			bottomRightTwips = topLeftTwips.add(new L.Point(
-				this.options.tileWidthTwips / scale,
-				this.options.tileHeightTwips / scale));
-			bounds = new L.Bounds(topLeftTwips, bottomRightTwips);
+			bounds = this._coordsToTileBounds(coords);
 			if (invalidBounds.intersects(bounds)) {
 				delete this._tileCache[key];
 			}


### PR DESCRIPTION
tile-size is always 256 core pixels, so twips size of a tile in
different zooms are different depending on zoom scale. But the document
coordinates of the tiles in twips are zoom invariant.

Conflicts:
	loleaflet/src/layer/tile/GridLayer.js
	loleaflet/src/layer/tile/ImpressTileLayer.js
	loleaflet/src/layer/tile/WriterTileLayer.js

Signed-off-by: Dennis Francis <dennis.francis@collabora.com>
Change-Id: I648134aaf84d451d93dad54d62b66062fb1d9204
(cherry picked from commit 7a1f1866d0b18fca2c08cdb8cc8984c41c507d50)


* Resolves: # <!-- related github issue -->
* Target version: master 


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

