### PR TITLE
Revert "common: add tag string to extract backtrace logs"

### DIFF
--- a/common/Log.cpp
+++ b/common/Log.cpp
@@ -285,7 +285,7 @@ namespace Log
     void signalLogPrefix()
     {
         char buffer[1024];
-        prefix<sizeof(buffer) - 1>(buffer, "[ERR]");
+        prefix<sizeof(buffer) - 1>(buffer, "SIG");
         signalLog(buffer);
     }
 

--- a/common/SigUtil.cpp
+++ b/common/SigUtil.cpp
@@ -242,7 +242,6 @@ namespace SigUtil
         else
             Log::signalLog(" Fatal signal received: ");
         Log::signalLog(signalName(signal));
-        Log::signalLog("\n");
 
         struct sigaction action;
 
@@ -262,8 +261,7 @@ namespace SigUtil
     void dumpBacktrace()
     {
 #if !defined(__ANDROID__)
-        Log::signalLogPrefix();
-        Log::signalLog(" Backtrace ");
+        Log::signalLog("\nBacktrace ");
         Log::signalLogNumber(getpid());
         if (VersionInfo)
         {
@@ -274,21 +272,10 @@ namespace SigUtil
 
         const int maxSlots = 50;
         void *backtraceBuffer[maxSlots];
-        char **symbols;
-
         const int numSlots = backtrace(backtraceBuffer, maxSlots);
-        symbols = backtrace_symbols(backtraceBuffer, numSlots);
-        if (symbols)
+        if (numSlots > 0)
         {
-            for (int symbol = 0; symbol < numSlots; symbol++)
-            {
-                Log::signalLogPrefix();
-                Log::signalLog(" ");
-                Log::signalLog(symbols[symbol]);
-                Log::signalLog("\n");
-            }
-
-            free(symbols);
+            backtrace_symbols_fd(backtraceBuffer, numSlots, STDERR_FILENO);
         }
 #else
         LOG_INF("Backtrace not available on Android.");


### PR DESCRIPTION
It was a request an approved by @kendy despite the signal
handler limitations. After several tries, we were blind
when we introduce the commit using the heap.

This reverts commit 9720eb0f81e1dfb10fa4e0860041b909bc5ced88.
