### PR TITLE
android: Dismiss progress dialog on doc load

### DIFF
--- a/loleaflet/src/map/Map.js
+++ b/loleaflet/src/map/Map.js
@@ -277,6 +277,9 @@ L.Map = L.Evented.extend({
 					this.focus();
 				}
 				this._activate();
+				if (window.ThisIsTheAndroidApp) {
+					window.postMobileMessage('hideProgressbar');
+				}
 			} else if (this._docLayer) {
 				// remove the comments and changes
 				this._docLayer.clearAnnotations();


### PR DESCRIPTION
Some formats like PDF does not have progressbar implemented
in that case the progress dialog gets stuck at loading
We should dismiss that if the document is loaded

Signed-off-by: merttumer <mert.tumer@collabora.com>
Change-Id: I6d6f5fae4da092c2605d85d014c634f3f12e0854


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

