### PR TITLE
Logging, documentation, tests, and minor fixes

### DIFF
--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -182,6 +182,37 @@ namespace Util
     // Extract all json entries into a map.
     std::map<std::string, std::string> JsonToMap(const std::string& jsonString);
 
+    inline unsigned short hexFromByte(unsigned char byte)
+    {
+        constexpr auto hex = "0123456789ABCDEF";
+        return (hex[byte >> 4] << 8) | hex[byte & 0xf];
+    }
+
+    inline std::string bytesToHexString(const uint8_t* data, size_t size)
+    {
+        std::string s;
+        s.resize(size * 2); // Each byte is two hex digits.
+        for (size_t i = 0; i < size; ++i)
+        {
+            const unsigned short hex = hexFromByte(data[i]);
+            const size_t off = i * 2;
+            s[off] = hex >> 8;
+            s[off + 1] = hex & 0xff;
+        }
+
+        return s;
+    }
+
+    inline std::string bytesToHexString(const char* data, size_t size)
+    {
+        return bytesToHexString(reinterpret_cast<const uint8_t*>(data), size);
+    }
+
+    inline std::string bytesToHexString(const std::string& s)
+    {
+        return bytesToHexString(s.c_str(), s.size());
+    }
+
     inline int hexDigitFromChar(char c)
     {
         if (c >= '0' && c <= '9')
@@ -192,6 +223,35 @@ namespace Util
             return c - 'A' + 10;
         else
             return -1;
+    }
+
+    inline std::string hexStringToBytes(const uint8_t* data, size_t size)
+    {
+        assert(data && (size % 2 == 0) && "Invalid hex digits to convert.");
+
+        std::string s;
+        s.resize(size / 2); // Each pair of hex digits is a single byte.
+        for (size_t i = 0; i < size; i += 2)
+        {
+            const int high = hexDigitFromChar(data[i]);
+            assert(high >= 0 && high <= 16);
+            const int low = hexDigitFromChar(data[i + 1]);
+            assert(low >= 0 && low <= 16);
+            const size_t off = i / 2;
+            s[off] = ((high << 4) | low) & 0xff;
+        }
+
+        return s;
+    }
+
+    inline std::string hexStringToBytes(const char* data, size_t size)
+    {
+        return hexStringToBytes(reinterpret_cast<const uint8_t*>(data), size);
+    }
+
+    inline std::string hexStringToBytes(const std::string& s)
+    {
+        return hexStringToBytes(s.c_str(), s.size());
     }
 
     /// Dump a line of data as hex.

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -510,7 +510,7 @@ public:
     {
         if (_stage == Stage::Header)
         {
-            LOG_TRC("performWrites (header).");
+            LOG_TRC("performWrites (request header).");
 
             out.append(getVerb());
             out.append(" ");
@@ -527,6 +527,8 @@ public:
 
         if (_stage == Stage::Body)
         {
+            LOG_TRC("performWrites (request body).");
+
             // Get the data to write into the socket
             // from the client's callback. This is
             // used to upload files, or other data.
@@ -543,14 +545,14 @@ public:
 
                 if (read == 0)
                 {
-                    LOG_TRC("performWrites (body): finished, total: " << wrote);
+                    LOG_TRC("performWrites (request body): finished, total: " << wrote);
                     _stage = Stage::Finished;
                     return true;
                 }
 
                 out.append(buffer, read);
                 wrote += read;
-                LOG_TRC("performWrites (body): " << read << " bytes, total: " << wrote);
+                LOG_TRC("performWrites (request body): " << read << " bytes, total: " << wrote);
             } while (wrote < capacity);
         }
 

--- a/net/NetUtil.cpp
+++ b/net/NetUtil.cpp
@@ -58,6 +58,12 @@ connect(const std::string& host, const std::string& port, const bool isSSL,
             if (ai->ai_addrlen && ai->ai_addr)
             {
                 int fd = ::socket(ai->ai_addr->sa_family, SOCK_STREAM | SOCK_NONBLOCK, 0);
+                if (fd < 0)
+                {
+                    LOG_SYS("Failed to create socket");
+                    continue;
+                }
+
                 int res = ::connect(fd, ai->ai_addr, ai->ai_addrlen);
                 if (fd < 0 || (res < 0 && errno != EINPROGRESS))
                 {
@@ -86,7 +92,7 @@ connect(const std::string& host, const std::string& port, const bool isSSL,
         freeaddrinfo(ainfo);
     }
     else
-        LOG_ERR("Failed to lookup host [" << host << "]. Skipping.");
+        LOG_SYS("Failed to lookup host [" << host << "]. Skipping");
 
     return socket;
 }

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -37,7 +37,8 @@
 #include "Buffer.hpp"
 #include "SigUtil.hpp"
 
-#define LOG_SOCKET_DATA ENABLE_DEBUG
+// Enable to dump socket traffic as hex in logs.
+// #define LOG_SOCKET_DATA ENABLE_DEBUG
 
 namespace http
 {

--- a/test/HttpTestServer.hpp
+++ b/test/HttpTestServer.hpp
@@ -111,6 +111,15 @@ private:
             {
                 // Don't send anything back.
             }
+            else if (Util::startsWith(request.getUrl(), "/inject"))
+            {
+                // /inject/<hex data> sends back the data (in binary form)
+                // verbatum. It doesn't add headers or anything at all.
+                const std::string hex = request.getUrl().substr(sizeof("/inject"));
+                const std::string bytes = Util::hexStringToBytes(
+                    reinterpret_cast<const uint8_t*>(hex.data()), hex.size());
+                socket->send(bytes);
+            }
             else
             {
                 http::Response response(http::StatusLine(200));

--- a/test/UnitWOPITemplate.cpp
+++ b/test/UnitWOPITemplate.cpp
@@ -118,6 +118,7 @@ public:
                 // First, we expect to get a PutFile right after loading.
                 LOK_ASSERT_EQUAL(static_cast<int>(Phase::SaveDoc), static_cast<int>(_phase));
                 _savedTemplate = true;
+                LOG_TST("SaveDoc => CloseDoc");
                 _phase = Phase::CloseDoc;
             }
             else
@@ -142,6 +143,8 @@ public:
             return true;
         }
 
+        LOG_TST("Fake wopi host unknown request "
+                << request.getMethod() << " request: " << uriReq.toString() << ". Defaulting.");
         return false;
     }
 
@@ -152,6 +155,7 @@ public:
         {
             case Phase::LoadTemplate:
             {
+                LOG_TST("LoadTemplate => SaveDoc");
                 _phase = Phase::SaveDoc;
 
                 initWebsocket("/wopi/files/10?access_token=anything");
@@ -162,6 +166,7 @@ public:
             }
             case Phase::CloseDoc:
             {
+                LOG_TST("CloseDoc => Polling");
                 _phase = Phase::Polling;
                 WSD_CMD("closedocument");
                 break;

--- a/test/WhiteBoxTests.cpp
+++ b/test/WhiteBoxTests.cpp
@@ -67,6 +67,7 @@ class WhiteBoxTests : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST(testParseUriUrl);
     CPPUNIT_TEST(testParseUrl);
     CPPUNIT_TEST(testSafeAtoi);
+    CPPUNIT_TEST(testBytesToHex);
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -100,6 +101,7 @@ class WhiteBoxTests : public CPPUNIT_NS::TestFixture
     void testParseUriUrl();
     void testParseUrl();
     void testSafeAtoi();
+    void testBytesToHex();
 };
 
 void WhiteBoxTests::testLOOLProtocolFunctions()
@@ -2059,6 +2061,16 @@ void WhiteBoxTests::testSafeAtoi()
     }
     {
         LOK_ASSERT_EQUAL(0, Util::safe_atoi(nullptr, 0));
+    }
+}
+
+void WhiteBoxTests::testBytesToHex()
+{
+    {
+        const std::string d("Some text");
+        const std::string hex = Util::bytesToHexString(d);
+        const std::string s = Util::hexStringToBytes(hex);
+        LOK_ASSERT_EQUAL(d, s);
     }
 }
 

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -893,7 +893,8 @@ bool DocumentBroker::download(const std::shared_ptr<ClientSession>& session, con
         }
 #endif
 
-        std::ifstream istr(localPath, std::ios::binary);
+        const std::string localFilePath = Poco::Path(getJailRoot(), localPath).toString();
+        std::ifstream istr(localFilePath, std::ios::binary);
         Poco::SHA1Engine sha1;
         Poco::DigestOutputStream dos(sha1);
         Poco::StreamCopier::copyStream(istr, dos);

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -800,7 +800,6 @@ private:
     const std::string _docKey;
     /// Short numerical ID. Unique during the lifetime of WSD.
     const std::string _docId;
-    const std::string _childRoot;
     std::shared_ptr<ChildProcess> _childProcess;
     std::string _uriJailed;
     std::string _uriJailedAnonym;

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -303,7 +303,7 @@ public:
 
     /// UploadAs the document to Storage, with a new name.
     /// @param uploadAsPath Absolute path to the jailed file.
-    void uploadAsToStorage(const std::string& sesionId, const std::string& uploadAsPath,
+    void uploadAsToStorage(const std::string& sessionId, const std::string& uploadAsPath,
                            const std::string& uploadAsFilename, const bool isRename);
 
     bool isModified() const { return _isModified; }

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -88,8 +88,10 @@ public:
 
         const std::string& getOwnerId() const { return _ownerId; }
 
+        /// Set the modified time as reported to the WOPI host.
         void setModifiedTime(const std::chrono::system_clock::time_point& modifiedTime) { _modifiedTime = modifiedTime; }
 
+        /// Get the modified time as reported by the WOPI host.
         const std::chrono::system_clock::time_point& getModifiedTime() const { return _modifiedTime; }
 
     private:


### PR DESCRIPTION
- wsd: disable socket traffic logging
- wsd: document ModifiedTime getter/setter
- wsd: typo
- wsd: remove unused DocumentBroker member
- wsd: correct sha1 logging of the downloaded doc
- wsd: test: log state transition in UnitWOPITemplate
- wsd: http: better logging of errors
- wsd: better handling of invalid port in URL
- wsd: add hexify-data utility
- wsd: http: better logs
