### PR TITLE
HTTP fixes based on fuzzing

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -857,7 +857,7 @@ AS_IF([test -n "$LOKIT_PATH"],
       [CPPFLAGS="$CPPFLAGS -I${LOKIT_PATH}"])
 lokit_msg="$LOKIT_PATH"
 
-AS_IF([test "$ENABLE_IOSAPP" != "true" -a "$ENABLE_ANDROIDAPP" != "true" -a "$enable_fuzzers" != "yes"],
+AS_IF([test "$ENABLE_IOSAPP" != "true" -a "$ENABLE_ANDROIDAPP" != "true"],
       [AC_MSG_CHECKING([for LibreOffice path])
       if test -n "$with_lo_path"; then
           # strip trailing '/' from LO_PATH, 'ln -s' with such path will otherwise fail
@@ -865,7 +865,8 @@ AS_IF([test "$ENABLE_IOSAPP" != "true" -a "$ENABLE_ANDROIDAPP" != "true" -a "$en
           AC_MSG_RESULT([found])
       else
           AC_MSG_RESULT([not found])
-          AC_MSG_ERROR([LibreOffice path must be configured: --with-lo-path])
+          AS_IF([test "$enable_fuzzers" != "yes"],
+                [AC_MSG_ERROR([LibreOffice path must be configured: --with-lo-path])])
       fi
       ])
 

--- a/net/HttpRequest.cpp
+++ b/net/HttpRequest.cpp
@@ -384,7 +384,6 @@ int64_t Request::readData(const char* p, const int64_t len)
         const int64_t read = _header.parse(p, available);
         if (read < 0)
         {
-            // _state = State::Error;
             return read;
         }
 
@@ -436,7 +435,6 @@ int64_t Response::readData(const char* p, int64_t len)
             case FieldParseState::Incomplete:
                 return 0;
             case FieldParseState::Invalid:
-                _state = State::Error;
                 return -1;
             case FieldParseState::Valid:
                 if (read <= 0)
@@ -457,7 +455,6 @@ int64_t Response::readData(const char* p, int64_t len)
         const int64_t read = _header.parse(p, available);
         if (read < 0)
         {
-            _state = State::Error;
             return read;
         }
 
@@ -503,8 +500,7 @@ int64_t Response::readData(const char* p, int64_t len)
                         LOG_ERR("Unexpected Content-Length header in response: "
                                 << _header.getContentLength()
                                 << ", Transfer-Encoding: " << _header.getTransferEncoding());
-                        _state = State::Error;
-                        _parserStage = ParserStage::Finished;
+                        return -1;
                     }
                     else if (_header.getContentLength() == 0)
                         _parserStage = ParserStage::Finished; // No body, we are done.
@@ -580,7 +576,6 @@ int64_t Response::readData(const char* p, int64_t len)
                         LOG_ERR("Error writing http response payload. Write "
                                 "handler returned "
                                 << read << " instead of " << chunkLen);
-                        _state = State::Error;
                         return -1;
                     }
 
@@ -614,7 +609,6 @@ int64_t Response::readData(const char* p, int64_t len)
             {
                 LOG_ERR("Error writing http response payload. Write handler returned "
                         << wrote << " instead of " << available);
-                _state = State::Error;
                 return wrote;
             }
 

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -920,8 +920,17 @@ public:
 
         scheme = Util::toLower(std::move(scheme));
         const bool secure = (scheme == "https://" || scheme == "wss://");
-        return create(hostname, secure ? Protocol::HttpSsl : Protocol::HttpUnencrypted,
-                      std::stoi(portString));
+        const auto protocol = secure ? Protocol::HttpSsl : Protocol::HttpUnencrypted;
+        if (portString.empty())
+            return create(hostname, protocol, getDefaultPort(protocol));
+
+        const std::pair<std::int32_t, bool> portPair = Util::i32FromString(portString);
+        if (portPair.second && portPair.first > 0)
+            return create(hostname, protocol, portPair.first);
+
+        LOG_ERR("Invalid port [" << portString << "] in URI [" << uri
+                                 << "] to http::Session::create.");
+        return nullptr;
     }
 
     /// Returns the given protocol's default port.

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -839,7 +839,7 @@ private:
 
     StatusLine _statusLine;
     Header _header;
-    State _state; //< The state of the Response.
+    std::atomic<State> _state; //< The state of the Response.
     ParserStage _parserStage; //< The parser's state.
     int64_t _recvBodySize; //< The amount of data we received (compared to the Content-Length).
     std::string _body; //< Used when _bodyHandling is InMemory.
@@ -1276,11 +1276,11 @@ private:
     const Protocol _protocol;
     std::chrono::microseconds _timeout;
     std::chrono::steady_clock::time_point _startTime;
-    std::shared_ptr<StreamSocket> _socket;
-    Request _request;
-    std::shared_ptr<Response> _response;
-    FinishedCallback _onFinished;
     bool _connected;
+    Request _request;
+    FinishedCallback _onFinished;
+    std::shared_ptr<Response> _response;
+    std::shared_ptr<StreamSocket> _socket; //< Must be the last member.
 };
 
 /// HTTP Get a URL synchronously.

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -807,6 +807,14 @@ public:
         finish(State::Timeout);
     }
 
+    /// If not already in done state, finish with State::Error.
+    void finish()
+    {
+        // We expect to have completed successfully, or timed out,
+        // anything else means we didn't get complete data.
+        finish(State::Error);
+    }
+
 private:
     void finish(State newState)
     {
@@ -1221,10 +1229,11 @@ private:
             _socket->shutdown(); // Flag for shutdown for housekeeping in SocketPoll.
             _socket->closeConnection(); // Immediately disconnect.
             _socket.reset();
-            _response->complete();
         }
 
         _connected = false;
+        if (_response)
+            _response->finish();
     }
 
     bool connect()

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -1170,12 +1170,16 @@ private:
 
     void performWrites(std::size_t capacity) override
     {
-        Buffer& out = _socket->getOutBuffer();
-        LOG_TRC("performWrites: " << out.size() << " bytes, capacity: " << capacity);
-
-        if (!_socket->send(_request))
+        // We may get called after disconnecting and freeing the Socket instance.
+        if (_socket)
         {
-            LOG_ERR('#' << _socket->getFD() << " Error while writing to socket.");
+            Buffer& out = _socket->getOutBuffer();
+            LOG_TRC("performWrites: " << out.size() << " bytes, capacity: " << capacity);
+
+            if (!_socket->send(_request))
+            {
+                LOG_ERR('#' << _socket->getFD() << " Error while writing to socket.");
+            }
         }
     }
 


### PR DESCRIPTION
- configure: allow for setting --with-lo-path with --enable-fuzzers
- wsd: http: performWrites can be called after destroying the socket
- wsd: better handling of invalid port in URL
- wsd: http: sync requests accept external poller
- wsd: http: an incomplete response is an error
- wsd: http: always destroy the socket last
- wsd: http: do not set the state explicitly on parsing error
