### PR TITLE
Mobile css remove clear after shadow

### DIFF
--- a/loleaflet/css/mobilewizard.css
+++ b/loleaflet/css/mobilewizard.css
@@ -702,7 +702,7 @@ a.leaflet-control-zoom-in {
 	float: left;
 }
 
-#mobile-wizard #Shadowed, #mobile-wizard #StyleNewByExample + div, #mobile-wizard #AlignTop,
+#mobile-wizard #StyleNewByExample + div, #mobile-wizard #AlignTop,
 #mobile-wizard #AlignBottom + p, #mobile-wizard #mergecells, #mobile-wizard #BackgroundColor + p,
 #mobile-wizard #LineSpacing, #mobile-wizard #indentlabel, #mobile-wizard #spacinglabel,
 #mobile-wizard #sizelabel {


### PR DESCRIPTION
no command line break needed shadow is part of bold, italic, underline

Signed-off-by: Andreas-Kainz <kainz.a@gmail.com>
Change-Id: I0538a0a5499829f472f4cef078bf4db1ef9877fc
