### PR TITLE
Mobile FontWorkShapes same alignment and padding than everywhere

### DIFF
--- a/loleaflet/css/mobilewizard.css
+++ b/loleaflet/css/mobilewizard.css
@@ -1100,10 +1100,13 @@ input[type='checkbox'][disabled] {
 
 #FontworkShapeType-fontwork-plain-text, #FontworkShapeType-fontwork-wave, #FontworkShapeType-fontwork-inflate, #FontworkShapeType-fontwork-stop, #FontworkShapeType-fontwork-curve-up, #FontworkShapeType-fontwork-curve-down, #FontworkShapeType-fontwork-triangle-up, #FontworkShapeType-fontwork-triangle-down, #FontworkShapeType-fontwork-fade-right, #FontworkShapeType-fontwork-fade-left, #FontworkShapeType-fontwork-fade-up, #FontworkShapeType-fontwork-fade-down, #FontworkShapeType-fontwork-slant-up, #FontworkShapeType-fontwork-slant-down, #FontworkShapeType-fontwork-fade-up-and-right, #FontworkShapeType-fontwork-fade-up-and-left, #FontworkShapeType-fontwork-chevron-up, #FontworkShapeType-fontwork-chevron-down, #FontworkShapeType-fontwork-arch-up-curve, #FontworkShapeType-fontwork-arch-down-curve, #FontworkShapeType-fontwork-arch-left-curve, #FontworkShapeType-fontwork-arch-right-curve, #FontworkShapeType-fontwork-circle-curve, #FontworkShapeType-fontwork-open-circle-curve, #FontworkShapeType-fontwork-arch-up-pour, #FontworkShapeType-fontwork-arch-down-pour, #FontworkShapeType-fontwork-arch-right-pour, #FontworkShapeType-fontwork-circle-pour, #FontworkShapeType-fontwork-open-circle-pour
 {
-	padding: 16px 28px 16px 4% !important;
+	padding: 4% !important;
 	margin: 0px !important;
 	float: left;
-	width: 20%;
+}
+
+.unospan-fontworkshape > span {
+	display: none !important;
 }
 
 #fontworkproperties + .ui-content {


### PR DESCRIPTION
padding, margin, icon size same as everywhere else
label isn't realy needed and cause only additional space.

Signed-off-by: Andreas-Kainz <kainz.a@gmail.com>
Change-Id: I2be56c64f7b9c0f15a62e8264fe9d8d3c474e65f
