### PR TITLE
Mobile explorable-entry use the same padding-left than ui-header

### DIFF
--- a/loleaflet/css/mobilewizard.css
+++ b/loleaflet/css/mobilewizard.css
@@ -175,7 +175,8 @@ p.mobile-wizard.ui-combobox-text {
 .menuwizard #mobile-wizard-content > div .ui-widget {
 	padding-left: 0px !important;
 }
-#mobile-wizard:not(.menuwizard) #mobile-wizard-content > .ui-header.level-0.mobile-wizard.ui-widget{
+#mobile-wizard:not(.menuwizard) #mobile-wizard-content > .ui-header.level-0.mobile-wizard.ui-widget,
+.ui-explorable-entry.level-0.mobile-wizard {
 	padding-left: 2% !important;
 	width: 100%;
 }


### PR DESCRIPTION
Signed-off-by: Andreas-Kainz <kainz.a@gmail.com>
Change-Id: Ice1994ddcd5e87e64afe85a623e4a276f0e032f9
