### PR TITLE
Mobile explorable-entry use the same padding-left than ui-header

### DIFF
--- a/loleaflet/css/mobilewizard.css
+++ b/loleaflet/css/mobilewizard.css
@@ -179,6 +179,9 @@ p.mobile-wizard.ui-combobox-text {
 	padding-left: 2% !important;
 	width: 100%;
 }
+.ui-explorable-entry {
+	padding-left: 2% !important;
+}
 #BackgroundColor > .ui-header-left {
 	width: 100% !important;
 }


### PR DESCRIPTION
Signed-off-by: Andreas-Kainz <kainz.a@gmail.com>
Change-Id: Ib767bf26c21bfc2d0b35a0a3f6af82d1112ff580


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

