### PR TITLE
Mobile: fontnamecombobox use no left padding at mobile sidebar

### DIFF
--- a/loleaflet/css/mobilewizard.css
+++ b/loleaflet/css/mobilewizard.css
@@ -38,6 +38,9 @@ span.menu-entry-icon img {
 span#main-menu-btn-icon {
 	filter: none !important;
 }
+#fontnamecombobox {
+	padding-right: 0px;
+}
 
 .ui-header.level-1.mobile-wizard.ui-widget img[src='images/lc_downloadas-pdf.svg']{
 	visibility: visible;


### PR DESCRIPTION
the left padding come from toolbar.css on mobile it was replaced to have all arrows vertical aligned

Signed-off-by: Andreas-Kainz <kainz.a@gmail.com>
Change-Id: I5f5d5bb9de9f1b4ef604778077db35ea5546357f
