### PR TITLE
File perm: Handle message properly.

### DIFF
--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -519,13 +519,12 @@ app.definitions.Socket = L.Class.extend({
 		else if (textMsg.startsWith('perm:')) {
 			var perm = textMsg.substring('perm:'.length).trim();
 
-			// This message is often received very early before doclayer is initialized
-			// Change options.permission so that when docLayer is initialized, it
-			// picks up the new value of permission rather than something else
-			this._map.options.permission = 'readonly';
-			// Lets also try to set the permission ourself since this can well be received
-			// after doclayer is initialized. There's no harm to call this in any case.
-			this._map.setPermission(perm);
+			if (this._map._docLayer) {
+				this._map.setPermission(perm);
+			}
+			else {
+				this._map.options.permission = perm;
+			}
 
 			app.file.readOnly = perm === 'readonly' ? true: false;
 			return;


### PR DESCRIPTION
If doclayer is initialized, call setpermission, if not, update
options.permission. So doclayer will get the value from
options.permission while it is initialized.

Signed-off-by: Gökay Şatır <gokay.satir@collabora.com>
Change-Id: Ic8d0687a1e98f597b89cbc389407710d268dc6d4


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

