### PR TITLE
Guard against REMOVE messages for data: URLs for tunnelled dialogs in…

### DIFF
--- a/ios/Mobile/DocumentViewController.mm
+++ b/ios/Mobile/DocumentViewController.mm
@@ -527,6 +527,12 @@ static IMP standardImpOfInputAccessoryView = nil;
             NSArray<NSString*> *messageBodyItems = [message.body componentsSeparatedByString:@" "];
             assert([messageBodyItems count] == 2);
             NSURL *tile = [NSURL URLWithString:messageBodyItems[1]];
+
+            // For some reason tunnelled dialogs still use PNG tiles inside data: URLs and not BMP
+            // files pointed to by file: URLs. Guard against getting REMOVE messages for such.
+            if (![[tile scheme] isEqualToString:@"file"])
+                return;
+
             if (unlink([[tile path] UTF8String]) == -1) {
                 LOG_SYS("Could not unlink tile " << [[tile path] UTF8String]);
             }


### PR DESCRIPTION
… iOS app

Trying to remove such a "file" caused a crash.

Sure, loleaflet should ideally not send such REMOVE messages at all.

No idea why the image for a tunnelled dialog shows up as a data: URL
and not as a file: URL pointing to a BMP file, like the document
tiles.

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: I4866ae2c94c626f1947a14353803a9c3d75d5ffa


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

