### PR TITLE
Fix crash in iOS app

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -114,9 +114,11 @@ using namespace LOOLProtocol;
 
 extern "C" { void dump_kit_state(void); /* easy for gdb */ }
 
+#if !MOBILEAPP
 // A Kit process hosts only a single document in its lifetime.
 class Document;
 static Document *singletonDocument = nullptr;
+#endif
 
 #ifndef BUILDING_TESTS
 static bool AnonymizeUserData = false;
@@ -138,7 +140,9 @@ static uint64_t AnonymizationSalt = 82589933;
 /// system root, not the jail.
 static std::string JailRoot;
 
+#if !MOBILEAPP
 static void flushTraceEventRecordings();
+#endif
 
 #if !MOBILEAPP
 
@@ -580,8 +584,10 @@ public:
                 "] url [" << anonymizeUrl(_url) << "] on child [" << _jailId <<
                 "] and id [" << _docId << "].");
         assert(_loKit);
+#if !MOBILEAPP
         assert(singletonDocument == nullptr);
         singletonDocument = this;
+#endif
     }
 
     virtual ~Document()
@@ -1849,7 +1855,7 @@ void TraceEvent::emitOneRecording(const std::string &recording)
     traceEventRecordings.emplace_back(recording);
 }
 
-#else
+#elif !MOBILEAPP
 
 static void flushTraceEventRecordings()
 {


### PR DESCRIPTION
No separate Kit process in the mobile apps, and the iOS app even can
have several documents open simultaneously, so the singletonDocument
variable does not make sense.

If we at some stage want to generate Trace Event log files also in the
iOS or Android app (perhaps not likely), will have to handle it in a
different fashion. All the code runs in one process anyway in the
mobile apps, so it wouldn't make sense to "send" collected Trace
Events to the code standing in for the WSD process.

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: I5777b48e98121c3ed55e590d5009e2658af2ef22


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

