### PR TITLE
Transfer LOK callback processing into our main thread if necessary.

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -137,6 +137,11 @@ static std::string JailRoot;
 static void flushTraceEventRecordings();
 #endif
 
+// Abnormally we get LOK events from another thread, which must be
+// push safely into our main poll loop to process to keep all
+// socket buffer & event processing in a single, thread.
+bool pushToMainThread(LibreOfficeKitCallback cb, int type, const char *p, void *data);
+
 #if !MOBILEAPP
 
 static LokHookFunction2* initFunction = nullptr;
@@ -795,9 +800,12 @@ public:
     static void GlobalCallback(const int type, const char* p, void* data)
     {
         if (SigUtil::getTerminationFlag())
-        {
             return;
-        }
+
+        // unusual LOK event from another thread,
+        // pData - is Document with process' lifetime.
+        if (pushToMainThread(GlobalCallback, type, p, data))
+            return;
 
         const std::string payload = p ? p : "(nil)";
         Document* self = static_cast<Document*>(data);
@@ -862,9 +870,12 @@ public:
     static void ViewCallback(const int type, const char* p, void* data)
     {
         if (SigUtil::getTerminationFlag())
-        {
             return;
-        }
+
+        // unusual LOK event from another thread.
+        // pData - is CallbackDescriptors which share process' lifetime.
+        if (pushToMainThread(ViewCallback, type, p, data))
+            return;
 
         CallbackDescriptor* descriptor = static_cast<CallbackDescriptor*>(data);
         assert(descriptor && "Null callback data.");
@@ -1055,7 +1066,7 @@ private:
         // Since callback messages are processed on idle-timer,
         // we could receive callbacks after destroying a view.
         // Retain the CallbackDescriptor object, which is shared with Core.
-        // _viewIdToCallbackDescr.erase(viewId);
+        // Do not: _viewIdToCallbackDescr.erase(viewId);
 
         viewCount = _loKitDocument->getViewsCount();
         LOG_INF("Document [" << anonymizeUrl(_url) << "] session [" <<
@@ -1384,6 +1395,7 @@ private:
 
         _loKitDocument->setViewLanguage(viewId, lang.c_str());
 
+        // viewId's monotonically increase, and CallbackDescriptors are never freed.
         _viewIdToCallbackDescr.emplace(viewId,
                                        std::unique_ptr<CallbackDescriptor>(new CallbackDescriptor({ this, viewId })));
         _loKitDocument->registerCallback(ViewCallback, _viewIdToCallbackDescr[viewId].get());
@@ -1966,6 +1978,24 @@ public:
         _document = std::move(document);
     }
 
+    // unusual LOK event from another thread, push into our loop to process.
+    static bool pushToMainThread(LibreOfficeKitCallback callback, int type, const char *p, void *data)
+    {
+        if (mainPoll && mainPoll->getThreadOwner() != std::this_thread::get_id())
+        {
+            LOG_TRC("Unusual push callback to main thread");
+            std::shared_ptr<std::string> pCopy;
+            if (p)
+                pCopy = std::make_shared<std::string>(p, strlen(p));
+            mainPoll->addCallback([=]{
+                LOG_TRC("Unusual process callback in main thread");
+                callback(type, pCopy ? pCopy->c_str() : nullptr, data);
+            });
+            return true;
+        }
+        return false;
+    }
+
 #ifdef IOS
     static std::mutex KSPollsMutex;
     // static std::condition_variable KSPollsCV;
@@ -1978,6 +2008,11 @@ public:
 };
 
 KitSocketPoll *KitSocketPoll::mainPoll = nullptr;
+
+bool pushToMainThread(LibreOfficeKitCallback cb, int type, const char *p, void *data)
+{
+    return KitSocketPoll::pushToMainThread(cb, type, p, data);
+}
 
 #ifdef IOS
 
@@ -2616,7 +2651,6 @@ void lokit_main(
         }
 
         LOG_INF("Kit unipoll loop run");
-
         loKit->runLoop(pollCallback, wakeCallback, mainKit.get());
 
         LOG_INF("Kit unipoll loop run terminated.");

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -627,8 +627,8 @@ public:
     void checkAndReThread()
     {
         if (InhibitThreadChecks)
-            return;
-        std::thread::id us = std::this_thread::get_id();
+            return; // in late shutdown
+        const std::thread::id us = std::this_thread::get_id();
         if (_owner == us)
             return; // all well
         LOG_DBG("Unusual - SocketPoll used from a new thread");


### PR DESCRIPTION
While we are processing data in the poll handler, we can have
another helpful thread from the core sending things to us:

loolforkit(Socket::assertCorrectThread(char const*, int))
loolforkit(WebSocketHandler::sendFrame(std::shared_ptr<StreamSocket> const&, char const*, unsigned long, unsigned char, bool) const)
loolforkit(WebSocketHandler::sendMessage(char const*, unsigned long, WSOpCode, bool) const)
loolforkit(Document::postMessage(char const*, int, WSOpCode) const)
loolforkit(Document::sendFrame(char const*, int, WSOpCode))
loolforkit(ChildSession::sendTextFrame(char const*, int))
loolforkit(ChildSession::loKitCallback(int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&))
loolforkit(Document::GlobalCallback(int, char const*, void*))
/core/instdir/program/libsofficeapp.so()
/core/instdir/program/../program/libfwklo.so()
/core/instdir/program/libscfiltlo.so()
/core/instdir/program/libexpwraplo.so()
/core/instdir/program/libooxlo.so(oox::core::FastParser::parseStream(com::sun::star::xml::sax::InputSource const&, bool))
/core/instdir/program/libooxlo.so(oox::core::FastParser::parseStream(com::sun::star::uno::Reference<com::sun::star::io::XInputStream> const&, rtl::OUString const&))
/core/instdir/program/libooxlo.so(oox::core::XmlFilterBase::importFragment(rtl::Reference<oox::core::FragmentHandler> const&, oox::core::FastParser&))
/core/instdir/program/libscfiltlo.so()
/core/instdir/program/libcomphelper.so(comphelper::ThreadTask::exec())
/core/instdir/program/libcomphelper.so()
/core/instdir/program/libuno_salhelpergcc3.so.3(salhelper::Thread::run())
/core/instdir/program/libuno_salhelpergcc3.so.3()
/core/instdir/program/libuno_sal.so.3()
/lib/x86_64-linux-gnu/libpthread.so.0()
/lib/x86_64-linux-gnu/libc.so.6(clone)

This is most likely from eg. threaded parsing of various file formats,
or progress messages while loading / saving, sent while the SolarMutex
is locked.

We assume that:
  + there will only ever be one thread running inside kitPoll
    this is enforced by vcl/headless.
  + and so, we can safely mutate SocketPoll and Socket buffer
    state from this thread.
  + there are only two entry points for callbacks from threads
    in core - which are both instrumented, and if necessary
    their work is shifted to this thread.

Memory corruptions matching the above trace, suggesting that
multiple writes have collided between kitPoll and an event
callback have been seen in the wild.

Change-Id: I5b084cbfec1ea326b6e17c9e5590a8c8e35b3854
Signed-off-by: Michael Meeks <michael.meeks@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

