### PR TITLE
net: show call-site file/line for assertCorrect...

### DIFF
--- a/net/SslSocket.hpp
+++ b/net/SslSocket.hpp
@@ -85,7 +85,7 @@ public:
 
     bool readIncomingData() override
     {
-        assertCorrectThread();
+        ASSERT_CORRECT_SOCKET_THREAD(this);
 
         const int rc = doHandshake();
         if (rc <= 0)
@@ -97,7 +97,7 @@ public:
 
     void writeOutgoingData() override
     {
-        assertCorrectThread();
+        ASSERT_CORRECT_SOCKET_THREAD(this);
 
         const int rc = doHandshake();
         if (rc <= 0)
@@ -111,7 +111,7 @@ public:
 
     virtual int readData(char* buf, int len) override
     {
-        assertCorrectThread();
+        ASSERT_CORRECT_SOCKET_THREAD(this);
 
 #if ENABLE_DEBUG
         if (simulateSocketError(true))
@@ -122,7 +122,7 @@ public:
 
     virtual int writeData(const char* buf, const int len) override
     {
-        assertCorrectThread();
+        ASSERT_CORRECT_SOCKET_THREAD(this);
 
         assert (len > 0); // Never write 0 bytes.
 
@@ -136,7 +136,7 @@ public:
     int getPollEvents(std::chrono::steady_clock::time_point now,
                       int64_t & timeoutMaxMicroS) override
     {
-        assertCorrectThread();
+        ASSERT_CORRECT_SOCKET_THREAD(this);
         int events = StreamSocket::getPollEvents(now, timeoutMaxMicroS); // Default to base.
         if (_sslWantsTo == SslWantsTo::Write) // If OpenSSL wants to write (and we don't).
             events |= POLLOUT;
@@ -160,7 +160,7 @@ private:
 
     int doHandshake()
     {
-        assertCorrectThread();
+        ASSERT_CORRECT_SOCKET_THREAD(this);
 
         if (_doHandshake)
         {
@@ -188,7 +188,7 @@ private:
     /// Handles the state of SSL after read or write.
     int handleSslState(const int rc)
     {
-        assertCorrectThread();
+        ASSERT_CORRECT_SOCKET_THREAD(this);
 
         if (rc > 0)
         {

--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -695,7 +695,7 @@ protected:
             return 0;
         }
 
-        socket->assertCorrectThread();
+        ASSERT_CORRECT_SOCKET_THREAD(socket);
         Buffer& out = socket->getOutBuffer();
 
         LOG_TRC("WebSocketHandler::sendFrame: Writing to #"


### PR DESCRIPTION
...Thread.

TODO: enable the assert after fixing the crash in

HTTPServerTest::testConvertTo2

Signed-off-by: Dennis Francis <dennis.francis@collabora.com>
Change-Id: I92b8f4b52e7bd60b69305c1916eed8a14a4c1560


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

