### PR TITLE
Remove leftover incorrect usage hint

### DIFF
--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -688,8 +688,6 @@ inline std::string getLaunchURI(const std::string &document)
     oss << "?file_path=file://";
     oss << DEBUG_ABSSRCDIR "/";
     oss << document;
-    if (LOOLWSD::EnableTraceEventLogging)
-        oss << "&enabletraceeventlogging=yes";
 
     return oss.str();
 }


### PR DESCRIPTION
loleaflet does not look for a &enabletraceeventlogging=yes query
parameter. That was removed many weeks ago.

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: I33b36191f1d21c2c0177061ff704aa9bcd5f9ef3


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

