### PR TITLE
Bail out of getPixmap gracefully, when rendering failed.

### DIFF
--- a/kit/Watermark.hpp
+++ b/kit/Watermark.hpp
@@ -110,10 +110,6 @@ private:
             return &_pixmaps[key];
         }
 
-        _pixmaps[key] = std::vector<unsigned char>();
-
-        std::vector<unsigned char>& _pixmap = _pixmaps[key];
-
         // renderFont returns a buffer based on RGBA mode, where r, g, b
         // are always set to 0 (black) and the alpha level is 0 everywhere
         // except on the text area; the alpha level take into account of
@@ -123,6 +119,7 @@ private:
         if (!textPixels)
         {
             LOG_ERR("Watermark: rendering failed.");
+            return nullptr;
         }
 
         const unsigned int pixel_count = width * height * 4;
@@ -131,6 +128,7 @@ private:
         // No longer needed.
         std::free(textPixels);
 
+        std::vector<unsigned char>& _pixmap = _pixmaps[key]; // create a new vector here
         _pixmap.reserve(pixel_count);
 
         /*


### PR DESCRIPTION
And only insert the new pixmap after the check.

Signed-off-by: Mike Kaganski <mike.kaganski@collabora.com>
Change-Id: I310d321443152967b3aed8992ece3b55287d01cc
