### PR TITLE
fix: comments sometimes overlap the document

### DIFF
--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -804,6 +804,13 @@ L.CanvasTileLayer = L.TileLayer.extend({
 
 			if (!heightIncreased)
 				this._onUpdateCursor(true);
+
+			// Center the view w.r.t the new map-pane position using the current zoom.
+			if (!window.mode.isMobile()) {
+				// FIXME: In mobile view, this causes an incorrect offset in annotations-marker positions in impress/draw.
+				// Remove this isMobile() condition after this is fixed.
+				this._map.setView(this._map.getCenter());
+			}
 		}
 	},
 


### PR DESCRIPTION
When map's position is changed via ResizeObserver, remember to center
the view by calculating the new center and calling setView() with that.

Signed-off-by: Dennis Francis <dennis.francis@collabora.com>
Change-Id: I12afbfd59e6acafab91027c6038c1eeeedaea661


* Resolves: # <!-- related github issue -->
* Target version: co-6-4

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

