### PR TITLE
notebookbar: keep old toolbox implementation

### DIFF
--- a/loleaflet/src/control/Control.NotebookbarBuilder.js
+++ b/loleaflet/src/control/Control.NotebookbarBuilder.js
@@ -18,6 +18,7 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 		this._controlHandlers['tabcontrol'] = this._overriddenTabsControlHandler;
 		this._controlHandlers['menubartoolitem'] = this._menubarToolItemHandler;
 		this._controlHandlers['bigtoolitem'] = this._bigtoolitemHandler;
+		this._controlHandlers['toolbox'] = this._toolboxHandler;
 
 		this._controlHandlers['pushbutton'] = function() { return false; };
 		this._controlHandlers['spinfield'] = function() { return false; };
@@ -366,6 +367,16 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 	_overriddenTabsControlHandler: function(parentContainer, data, builder) {
 		data.tabs = builder.wizard.getTabs();
 		return builder._tabsControlHandler(parentContainer, data, builder);
+	},
+
+	_toolboxHandler: function(parentContainer, data) {
+		if (data.enabled === false || data.enabled === 'false') {
+			for (var index in data.children) {
+				data.children[index].enabled = false;
+			}
+		}
+
+		return true;
 	},
 
 	_menubarToolItemHandler: function(parentContainer, data, builder) {


### PR DESCRIPTION
structure for JSDialogBuilder has been changed and doesn't
fit notebookbar needs

Signed-off-by: Szymon Kłos <szymon.klos@collabora.com>
Change-Id: Ib040edd32f2e039cb8d0395abdc2bfb39a3b43d8
