### PR TITLE
Fix Calc tab positions, sidebar width and Status bar

### DIFF
--- a/loleaflet/css/loleaflet.css
+++ b/loleaflet/css/loleaflet.css
@@ -34,7 +34,6 @@
 	width: 1px;
 }
 #document-container {
-	border-top: 1px solid var(--gray-color);
 	background: #DFDFDF;
 	position: relative;
 	top: 0;
@@ -46,7 +45,7 @@
 }
 
 #document-container.sidebar-open {
-	width: calc(100vw - 351px);
+	width: calc(100vw - 336px);
 }
 
 #document-container.presentation-doctype.sidebar-open {
@@ -67,6 +66,7 @@
 	cursor: auto;
 	background-color: transparent;
 	margin: 0;
+	border-top: 1px solid var(--gray-color);
 }
 
 .leaflet-progress-layer

--- a/loleaflet/css/spreadsheet.css
+++ b/loleaflet/css/spreadsheet.css
@@ -7,7 +7,7 @@
 	width: 100%;
 	white-space: nowrap;
 	text-align: left;
-	background-color: var(--gray-light-bg-color);
+	background-color: transparent;
 	vertical-align: middle;
 }
 
@@ -20,24 +20,23 @@
 }
 
 .spreadsheet-tab {
-	margin: 5px 3px 0px 0px !important;
-	padding: 8px 9px 5px !important;
+	margin: 0 8px 0 0 !important;
+	padding: 4px 9px 2px !important;
 	text-decoration: none;
 
 	font: 12px/1.5 var(--loleaflet-font);
 	display: inline-block;
-	border: 1px solid darkgrey;
-	background-color: lightgrey;
+	border: 1px solid rgba(var(--green0-txt-primary-color),0.3);
+	background-color: rgba(var(--green0-txt-primary-color),0.1);
 	color: black;
 }
 
 .spreadsheet-tab.spreadsheet-tab-selected {
-	background: white !important;
+	background: transparent !important;
 	color: black !important;
-	padding-top: 7px;
+	padding-top: 12px !important;
 	padding-bottom: 5px;
-	margin-top: 2px;
-	border: 1px solid #dfdfdf;
+	border: 1px solid rgba(var(--green0-txt-primary-color),0.5);
 	border-top: 0px;
 }
 

--- a/loleaflet/css/toolbar.css
+++ b/loleaflet/css/toolbar.css
@@ -13,7 +13,7 @@
 	left: 0;
 	right: 0;
 	text-align: center;
-	padding: 0;
+	padding: 1px 2px 0;
 	bottom: 0;
 	z-index: 0;
 	border-top: 1px solid #bbbbbb;
@@ -83,7 +83,9 @@ w2ui-toolbar {
 #spreadsheet-toolbar {
 	width: 100%;
 	text-align: center;
-	padding: 7px 0px 0px;
+	padding: 0;
+	box-shadow: inset -1px -2px 0 0 white, inset 0 0 0 1px rgba(var(--green0-txt-primary-color),0.5);
+	z-index: 10;
 }
 
 #formulabar {

--- a/loleaflet/css/w2ui-1.5.rc1.css
+++ b/loleaflet/css/w2ui-1.5.rc1.css
@@ -2913,7 +2913,7 @@ button.w2ui-btn-small:focus:before {
 */
 .w2ui-toolbar {
   margin: 0px;
-  padding: 2px;
+  padding: 3px 3px 3px 4px;
   outline: 0px;
   position: relative;
   background-color: #ffffff;
@@ -2946,7 +2946,7 @@ button.w2ui-btn-small:focus:before {
   width: 22px;
   height: 16px;
   padding: 0;
-  margin: 0px 1px!important;
+  margin: 1px!important;
   border: 0!important;
   text-align: center;
 }


### PR DESCRIPTION
- Calc: Fixes Tab list that was out of place and not visible
- Calc: Fixes inconsistency with background colours
- Calc: Fixes selected tab status by improving styling
  - Also use CSS vars instead
- Fixes overall (for all applications) toolbar-down (status bar)
  - Border was being overlapped and thus not being displayed

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I766ca3ee3d82c89343a318d3adcf2d2e3a7dcf46
