### PR TITLE
Mobile: menuwizard (hamburger): Fixes contents position

### DIFF
--- a/loleaflet/css/device-mobile.css
+++ b/loleaflet/css/device-mobile.css
@@ -695,7 +695,7 @@ td[id^='tb_spreadsheet-toolbar_item']:focus table.w2ui-button div.w2ui-icon, td[
 }
 
 #mobile-wizard.menuwizard {
-	position: relative;
+	position: absolute;
 	top: 0;
 	bottom: 0;
 	left: 0;

--- a/loleaflet/css/toolbar-mobile.css
+++ b/loleaflet/css/toolbar-mobile.css
@@ -3,10 +3,12 @@
 		border-radius: 0px;
 		border: 1px solid #bbbbbb !important;
 	}
-	#toolbar-wrapper{
-		border-top: none;
-	}
 	#toolbar-up{
 		top: -1px;
 	}
+}
+
+#toolbar-wrapper.mobile{
+	border-top: none;
+	z-index: auto;
 }

--- a/loleaflet/src/control/Control.Menubar.js
+++ b/loleaflet/src/control/Control.Menubar.js
@@ -1231,8 +1231,10 @@ L.Control.Menubar = L.Control.extend({
 
 		$('#main-menu').bind('keydown', {self: this}, this._onKeyDown);
 
-		if (window.mode.isMobile())
+		if (window.mode.isMobile()) {
 			$('#main-menu').parent().css('height', '0');
+			$('#toolbar-wrapper').addClass('mobile');
+		}
 
 		var self = this;
 		// Also the vertical menu displayed when tapping the hamburger button is produced by SmartMenus


### PR DESCRIPTION
- Add mobile class to #toolbar-wrapper to avoid targeting anything else
  - Sets Menuwizard so it goes above toolbar (position absolute) so to be
  properly aligned from the top
  - Sets toolbarwrapper with normal z-index (according to its parent) so
  menuwizard can be above it

Note, no need to touch #toolbar-hamburger.menuwizard-opened has it comes
already with z-index properly set

Behavior might be related with changes from
ff20ec7

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I1a66057b7827309a6ad3871927099ac1c9339657
