### PR TITLE
HTTP 302 Found - redirrect support for getWOPIFileInfo

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -45,7 +45,8 @@ noinst_LTLIBRARIES = \
 	unit-wopi-temp.la \
 	unit-wopi-fileurl.la \
 	unit-wopi-httpheaders.la \
-	unit-wopi-httpredirect.la
+	unit-wopi-httpredirect.la \
+	unit-wopi-httpredirectloop.la
 
 MAGIC_TO_FORCE_SHLIB_CREATION = -rpath /dummy
 AM_LDFLAGS = -pthread -module $(MAGIC_TO_FORCE_SHLIB_CREATION) $(ZLIB_LIBS)
@@ -159,6 +160,8 @@ unit_wopi_httpheaders_la_SOURCES = UnitWOPIHttpHeaders.cpp
 unit_wopi_httpheaders_la_LIBADD = $(CPPUNIT_LIBS)
 unit_wopi_httpredirect_la_SOURCES = UnitWOPIHttpRedirect.cpp
 unit_wopi_httpredirect_la_LIBADD = $(CPPUNIT_LIBS)
+unit_wopi_httpredirectloop_la_SOURCES = UnitWOPIHttpRedirectLoop.cpp
+unit_wopi_httpredirectloop_la_LIBADD = $(CPPUNIT_LIBS)
 unit_tiff_load_la_SOURCES = UnitTiffLoad.cpp
 unit_tiff_load_la_LIBADD = $(CPPUNIT_LIBS)
 unit_large_paste_la_SOURCES = UnitLargePaste.cpp
@@ -239,7 +242,9 @@ TESTS = \
 	unit-wopi-temp.la \
 	unit-wopi-fileurl.la \
 	unit-wopi-httpheaders \
-	unit-wopi-httpredirect.la
+	unit-wopi-httpredirect.la \
+	unit-wopi-httpredirectloop.la
+
 # TESTS += unit-admin.test
 # TESTS += unit-storage.test
 
@@ -304,7 +309,7 @@ group1.log: unit-tiletest.log unit-crash.log unit-insert-delete.log unit-each-vi
 			unit-session.log unit-uno-command.log unit-load.log unit-cursor.log unit-calc.log \
 			unit-bad-doc-load.log unit-hosting.log unit-wopi-loadencoded.log unit-integration.log \
 			unit-convert.log unit-typing.log unit-tilecache.log unit-timeout.log unit-base.log \
-			unit-wopi-httpheaders.log unit-wopi-httpredirect.log
+			unit-wopi-httpheaders.log unit-wopi-httpredirect.log unit-wopi-httpredirectloop.log
 	$(CLEANUP_COMMAND)
 	touch $@
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -44,7 +44,8 @@ noinst_LTLIBRARIES = \
 	unit-wopi-loadencoded.la \
 	unit-wopi-temp.la \
 	unit-wopi-fileurl.la \
-	unit-wopi-httpheaders.la
+	unit-wopi-httpheaders.la \
+	unit-wopi-httpredirect.la
 
 MAGIC_TO_FORCE_SHLIB_CREATION = -rpath /dummy
 AM_LDFLAGS = -pthread -module $(MAGIC_TO_FORCE_SHLIB_CREATION) $(ZLIB_LIBS)
@@ -156,6 +157,8 @@ unit_wopi_fileurl_la_SOURCES = UnitWOPIFileUrl.cpp
 unit_wopi_fileurl_la_LIBADD = $(CPPUNIT_LIBS)
 unit_wopi_httpheaders_la_SOURCES = UnitWOPIHttpHeaders.cpp
 unit_wopi_httpheaders_la_LIBADD = $(CPPUNIT_LIBS)
+unit_wopi_httpredirect_la_SOURCES = UnitWOPIHttpRedirect.cpp
+unit_wopi_httpredirect_la_LIBADD = $(CPPUNIT_LIBS)
 unit_tiff_load_la_SOURCES = UnitTiffLoad.cpp
 unit_tiff_load_la_LIBADD = $(CPPUNIT_LIBS)
 unit_large_paste_la_SOURCES = UnitLargePaste.cpp
@@ -235,7 +238,8 @@ TESTS = \
 	unit-wopi-loadencoded.la \
 	unit-wopi-temp.la \
 	unit-wopi-fileurl.la \
-	unit-wopi-httpheaders
+	unit-wopi-httpheaders \
+	unit-wopi-httpredirect.la
 # TESTS += unit-admin.test
 # TESTS += unit-storage.test
 
@@ -300,7 +304,7 @@ group1.log: unit-tiletest.log unit-crash.log unit-insert-delete.log unit-each-vi
 			unit-session.log unit-uno-command.log unit-load.log unit-cursor.log unit-calc.log \
 			unit-bad-doc-load.log unit-hosting.log unit-wopi-loadencoded.log unit-integration.log \
 			unit-convert.log unit-typing.log unit-tilecache.log unit-timeout.log unit-base.log \
-			unit-wopi-httpheaders.log
+			unit-wopi-httpheaders.log unit-wopi-httpredirect.log
 	$(CLEANUP_COMMAND)
 	touch $@
 

--- a/test/UnitWOPIHttpRedirect.cpp
+++ b/test/UnitWOPIHttpRedirect.cpp
@@ -1,0 +1,145 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <config.h>
+
+#include "WopiTestServer.hpp"
+#include <Log.hpp>
+#include <Unit.hpp>
+#include <UnitHTTP.hpp>
+#include <helpers.hpp>
+
+#include <Poco/Net/HTTPRequest.h>
+
+class UnitWopiHttpRedirect : public WopiTestServer
+{
+    enum class Phase
+    {
+        Load,
+        Redirected,
+        Loaded
+    } _phase;
+
+    const std::string params = "access_token=anything";
+    static constexpr auto testname = "UnitWopiHttpRedirect";
+
+protected:
+    void assertGetFileRequest(const Poco::Net::HTTPRequest&) override
+    {
+        exitTest(TestResult::Ok);
+    }
+
+public:
+    UnitWopiHttpRedirect()
+        : _phase(Phase::Load)
+    {
+    }
+
+    virtual bool handleHttpRequest(const Poco::Net::HTTPRequest& request,
+                                   Poco::MemoryInputStream& message,
+                                   std::shared_ptr<StreamSocket>& socket) override
+    {
+        Poco::URI uriReq(request.getURI());
+        Poco::RegularExpression regInfo("/wopi/files/1");
+        std::string redirectUri = "/wopi/files/0";
+        Poco::RegularExpression regRedirected(redirectUri);
+
+        LOG_INF("Fake wopi host request URI [" << uriReq.toString() << "]:\n");
+
+        // CheckFileInfo - returns redirect response
+        if (request.getMethod() == "GET" && regInfo.match(uriReq.getPath()))
+        {
+            LOG_INF("Fake wopi host request, handling CheckFileInfo (1/2)");
+            LOK_ASSERT_MESSAGE("Expected to be in Phase::Load", _phase == Phase::Load);
+
+            assertCheckFileInfoRequest(request);
+
+            std::ostringstream oss;
+            oss << "HTTP/1.1 302 Found\r\n"
+                "Location: " << helpers::getTestServerURI() << redirectUri << "?" << params << "\r\n"
+                "\r\n";
+
+            socket->send(oss.str());
+            socket->shutdown();
+
+            _phase = Phase::Redirected;
+
+            return true;
+        }
+        // CheckFileInfo - for redirected URI
+        else if (request.getMethod() == "GET" && regRedirected.match(uriReq.getPath()))
+        {
+            LOG_INF("Fake wopi host request, handling CheckFileInfo: (2/2)");
+            LOK_ASSERT_MESSAGE("Expected to be in Phase::Redirected", _phase == Phase::Redirected);
+
+            assertCheckFileInfoRequest(request);
+
+            Poco::LocalDateTime now;
+            const std::string fileName(uriReq.getPath() == "/wopi/files/3" ? "he%llo.txt" : "hello.txt");
+            Poco::JSON::Object::Ptr fileInfo = new Poco::JSON::Object();
+            fileInfo->set("BaseFileName", fileName);
+            fileInfo->set("Size", _fileContent.size());
+            fileInfo->set("Version", "1.0");
+            fileInfo->set("OwnerId", "test");
+            fileInfo->set("UserId", "test");
+            fileInfo->set("UserFriendlyName", "test");
+            fileInfo->set("UserCanWrite", "true");
+            fileInfo->set("PostMessageOrigin", "localhost");
+            fileInfo->set("LastModifiedTime", Util::getIso8601FracformatTime(_fileLastModifiedTime));
+            fileInfo->set("EnableOwnerTermination", "true");
+
+            std::ostringstream jsonStream;
+            fileInfo->stringify(jsonStream);
+            std::string responseString = jsonStream.str();
+
+            const std::string mimeType = "application/json; charset=utf-8";
+
+            std::ostringstream oss;
+            oss << "HTTP/1.1 200 OK\r\n"
+                "Last-Modified: " << Util::getHttpTime(_fileLastModifiedTime) << "\r\n"
+                "User-Agent: " WOPI_AGENT_STRING "\r\n"
+                "Content-Length: " << responseString.size() << "\r\n"
+                "Content-Type: " << mimeType << "\r\n"
+                "\r\n"
+                << responseString;
+
+            socket->send(oss.str());
+            socket->shutdown();
+
+            _phase = Phase::Loaded;
+
+            return true;
+        }
+
+        return WopiTestServer::handleHttpRequest(request, message, socket);
+    }
+
+    void invokeTest() override
+    {
+        switch (_phase)
+        {
+            case Phase::Load:
+            {
+                initWebsocket("/wopi/files/1?" + params);
+
+                WSD_CMD("load url=" + getWopiSrc());
+                SocketPoll::wakeupWorld();
+
+                break;
+            }
+            case Phase::Redirected:
+            case Phase::Loaded:
+            {
+                break;
+            }
+        }
+    }
+};
+
+UnitBase* unit_create_wsd(void) { return new UnitWopiHttpRedirect(); }
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/test/UnitWOPIHttpRedirectLoop.cpp
+++ b/test/UnitWOPIHttpRedirectLoop.cpp
@@ -1,0 +1,104 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <config.h>
+
+#include "WopiTestServer.hpp"
+#include <Log.hpp>
+#include <Unit.hpp>
+#include <UnitHTTP.hpp>
+#include <helpers.hpp>
+
+#include <Poco/Net/HTTPRequest.h>
+
+class UnitWopiHttpRedirectLoop : public WopiTestServer
+{
+    enum class Phase
+    {
+        Load,
+        Redirected,
+        Polling
+    } _phase;
+
+    const std::string params = "access_token=anything";
+    static constexpr auto testname = "UnitWopiHttpRedirectLoop";
+
+public:
+    UnitWopiHttpRedirectLoop()
+        : _phase(Phase::Load)
+    {
+    }
+
+    virtual bool handleHttpRequest(const Poco::Net::HTTPRequest& request,
+                                   Poco::MemoryInputStream& /*message*/,
+                                   std::shared_ptr<StreamSocket>& socket) override
+    {
+        Poco::URI uriReq(request.getURI());
+        Poco::RegularExpression regInfo("/wopi/files/[0-9]+");
+        std::string redirectUri = "/wopi/files/";
+        static unsigned fileId = 1;
+
+        LOG_INF("Fake wopi host request URI [" << uriReq.toString() << "]:\n");
+
+        // CheckFileInfo - always returns redirect response
+        if (request.getMethod() == "GET" && regInfo.match(uriReq.getPath()))
+        {
+            LOG_INF("Fake wopi host request, handling CheckFileInfo");
+
+            assertCheckFileInfoRequest(request);
+
+            LOK_ASSERT_MESSAGE("It is expected to stop requesting after 21 redirections", fileId <= 22);
+
+            LOK_ASSERT_MESSAGE("Expected to be in Phase::Load or Phase::Redirected", _phase == Phase::Load || _phase == Phase::Redirected);
+            _phase = Phase::Redirected;
+
+            if (fileId == 22)
+                _phase = Phase::Polling;
+
+            std::ostringstream oss;
+            oss << "HTTP/1.1 302 Found\r\n"
+                "Location: " << helpers::getTestServerURI() << redirectUri << fileId++ << "?" << params << "\r\n"
+                "\r\n";
+
+            socket->send(oss.str());
+            socket->shutdown();
+
+            return true;
+        }
+
+        return false;
+    }
+
+    void invokeTest() override
+    {
+        switch (_phase)
+        {
+            case Phase::Load:
+            {
+                initWebsocket("/wopi/files/0?" + params);
+
+                WSD_CMD("load url=" + getWopiSrc());
+                SocketPoll::wakeupWorld();
+
+                break;
+            }
+            case Phase::Redirected:
+            {
+                break;
+            }
+            case Phase::Polling:
+            {
+                exitTest(TestResult::Ok);
+                break;
+            }
+        }
+    }
+};
+
+UnitBase* unit_create_wsd(void) { return new UnitWopiHttpRedirectLoop(); }
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/test/WopiTestServer.hpp
+++ b/test/WopiTestServer.hpp
@@ -35,13 +35,14 @@ private:
     /// Websocket to communicate.
     std::unique_ptr<UnitWebSocket> _ws;
 
+protected:
+
     /// Content of the file.
     std::string _fileContent;
 
     /// Last modified time of the file
     std::chrono::system_clock::time_point _fileLastModifiedTime;
 
-protected:
     const std::string& getWopiSrc() const { return _wopiSrc; }
 
     const std::unique_ptr<UnitWebSocket>& getWs() const { return _ws; }

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -1018,7 +1018,16 @@ std::string WopiStorage::downloadDocument(const Poco::URI& uriObject, const std:
             LOG_END(logger, true);
         }
 
-    if (response.getStatus() != Poco::Net::HTTPResponse::HTTP_OK)
+    if (response.getStatus() == Poco::Net::HTTPResponse::HTTP_FOUND ||
+        response.getStatus() == Poco::Net::HTTPResponse::HTTP_MOVED_PERMANENTLY)
+    {
+        const std::string& location = response.get("Location");
+        LOG_TRC("WOPI::downloadDocument redirect to URI [" << LOOLWSD::anonymizeUrl(location) << "]:\n");
+
+        Poco::URI redirectUriObject(location);
+        return downloadDocument(redirectUriObject, uriAnonym, auth, cookies);
+    }
+    else if (response.getStatus() != Poco::Net::HTTPResponse::HTTP_OK)
     {
         std::ostringstream oss;
         Poco::StreamCopier::copyStream(rs, oss);

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -642,6 +642,7 @@ std::unique_ptr<WopiStorage::WOPIFileInfo> WopiStorage::getWOPIFileInfoForUri(Po
             LOG_TRC("WOPI::CheckFileInfo redirect to URI [" << LOOLWSD::anonymizeUrl(location) << "]:\n");
 
             Poco::URI redirectUriObject(location);
+            setUri(redirectUriObject);
             return getWOPIFileInfoForUri(redirectUriObject, auth, cookies, lockCtx);
         }
 

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -636,7 +636,9 @@ std::unique_ptr<WopiStorage::WOPIFileInfo> WopiStorage::getWOPIFileInfoForUri(Po
         }
 
         if (response.getStatus() == Poco::Net::HTTPResponse::HTTP_FOUND ||
-            response.getStatus() == Poco::Net::HTTPResponse::HTTP_MOVED_PERMANENTLY)
+            response.getStatus() == Poco::Net::HTTPResponse::HTTP_MOVED_PERMANENTLY ||
+            response.getStatus() == Poco::Net::HTTPResponse::HTTP_TEMPORARY_REDIRECT ||
+            response.getStatus() == Poco::Net::HTTPResponse::HTTP_PERMANENT_REDIRECT)
         {
             const std::string& location = response.get("Location");
             LOG_TRC("WOPI::CheckFileInfo redirect to URI [" << LOOLWSD::anonymizeUrl(location) << "]:\n");
@@ -1019,7 +1021,9 @@ std::string WopiStorage::downloadDocument(const Poco::URI& uriObject, const std:
         }
 
     if (response.getStatus() == Poco::Net::HTTPResponse::HTTP_FOUND ||
-        response.getStatus() == Poco::Net::HTTPResponse::HTTP_MOVED_PERMANENTLY)
+        response.getStatus() == Poco::Net::HTTPResponse::HTTP_MOVED_PERMANENTLY ||
+        response.getStatus() == Poco::Net::HTTPResponse::HTTP_TEMPORARY_REDIRECT ||
+        response.getStatus() == Poco::Net::HTTPResponse::HTTP_PERMANENT_REDIRECT)
     {
         const std::string& location = response.get("Location");
         LOG_TRC("WOPI::downloadDocument redirect to URI [" << LOOLWSD::anonymizeUrl(location) << "]:\n");

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -269,6 +269,9 @@ public:
 
 protected:
 
+    /// Saves new URI when resource was moved
+    void setUri(const Poco::URI& uri) { _uri = uri; }
+
     /// Returns the root path of the jail directory of docs.
     std::string getLocalRootPath() const;
 
@@ -276,7 +279,7 @@ protected:
     const std::string& getExtendedData() const { return _extendedData; }
 
 private:
-    const Poco::URI _uri;
+    Poco::URI _uri;
     const std::string _localStorePath;
     const std::string _jailPath;
     std::string _jailedFilePath;

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -510,7 +510,8 @@ public:
                                                   const std::string& cookies, LockContext& lockCtx);
     /// Implementation of getWOPIFileInfo for specific URI
     std::unique_ptr<WOPIFileInfo> getWOPIFileInfoForUri(Poco::URI uriObject, const Authorization& auth,
-                                                  const std::string& cookies, LockContext& lockCtx);
+                                                  const std::string& cookies, LockContext& lockCtx,
+                                                  unsigned redirectLimit = 21);
 
     /// Update the locking state (check-in/out) of the associated file
     bool updateLockState(const Authorization& auth, const std::string& cookies,
@@ -539,7 +540,8 @@ private:
     /// Download the document from the given URI.
     /// Does not add authorization tokens or any other logic.
     std::string downloadDocument(const Poco::URI& uriObject, const std::string& uriAnonym,
-                                 const Authorization& auth, const std::string& cookies);
+                                 const Authorization& auth, const std::string& cookies,
+                                 unsigned redirectLimit = 21);
 
 private:
     /// A URl provided by the WOPI host to use for GetFile.

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -505,6 +505,9 @@ public:
     /// Also sets up the locking context for future operations.
     std::unique_ptr<WOPIFileInfo> getWOPIFileInfo(const Authorization& auth,
                                                   const std::string& cookies, LockContext& lockCtx);
+    /// Implementation of getWOPIFileInfo for specific URI
+    std::unique_ptr<WOPIFileInfo> getWOPIFileInfoForUri(Poco::URI uriObject, const Authorization& auth,
+                                                  const std::string& cookies, LockContext& lockCtx);
 
     /// Update the locking state (check-in/out) of the associated file
     bool updateLockState(const Authorization& auth, const std::string& cookies,


### PR DESCRIPTION
With some loadbalancers it may happen that HTTP 302 Found
response with redirect location will appear.