### PR TITLE
leaflet: disable resizeable property from clipboard-container

### DIFF
--- a/loleaflet/src/layer/marker/TextInput.js
+++ b/loleaflet/src/layer/marker/TextInput.js
@@ -386,6 +386,7 @@ L.TextInput = L.Layer.extend({
 			this._textArea.style.width = '1px';
 			this._textArea.style.height = '1px';
 			this._textArea.style.caretColor = 'transparent';
+			this._textArea.style.resize = 'none';
 
 			if (L.Browser.isInternetExplorer || L.Browser.edge)
 			{


### PR DESCRIPTION
Signed-off-by: Rash419 <rashesh.padia@collabora.com>
Change-Id: I0a1e807a2872e83d654fb7564aa1e9f4a2b5b88e

* Target version: master 

### Summary
When you try to hover over a caret resize element of the clipboard textarea was visible 

