### PR TITLE
leaflet:NB:added hyperlink in copy,paste and cut button

### DIFF
--- a/loleaflet/src/control/Control.JSDialogBuilder.js
+++ b/loleaflet/src/control/Control.JSDialogBuilder.js
@@ -2449,7 +2449,14 @@ L.Control.JSDialogBuilder = L.Control.extend({
 
 		var controls = {};
 
-		var div = this._createIdentifiable('div', 'unotoolbutton ' + builder.options.cssClass + ' ui-content unospan', parentContainer, data);
+		var div;
+		if (data.command === '.uno:Paste' || data.command === '.uno:Cut' || data.command === '.uno:Copy') {
+			var hyperlink = L.DomUtil.create('a', '', parentContainer);
+			div = this._createIdentifiable('div', 'unotoolbutton ' + builder.options.cssClass + ' ui-content unospan', hyperlink, data);
+		} else {
+			div = this._createIdentifiable('div', 'unotoolbutton ' + builder.options.cssClass + ' ui-content unospan', parentContainer, data);
+		}
+
 		controls['container'] = div;
 
 		var isRealUnoCommand = true;


### PR DESCRIPTION
Signed-off-by: Rash419 <rashesh.padia@collabora.com>
Change-Id: Ia2aa29bf064fb2bb518b80a6d5fa5617a1334f2c

* Target version: master 

### Summary

As we discovered when we implemented this for the menu bar, it is really important in some browsers - particularly Safari, but others - to have the right security context for 'paste' to be able to work when you click it.

In order to do that we need to have a hyperlink to '#' for the buttons in the notebookbar - at least, any of those that want to be able to cut/copy but particularly paste.
