### PR TITLE
Async Backports from Master

### DIFF
--- a/common/Common.hpp
+++ b/common/Common.hpp
@@ -38,6 +38,11 @@ constexpr const char FORKIT_URI[] = "/loolws/forkit";
 
 constexpr const char CAPABILITIES_END_POINT[] = "/hosting/capabilities";
 
+/// The file suffix used to mark the file slated for uploading.
+constexpr const char TO_UPLOAD_SUFFIX[] = ".upload";
+/// The file suffix used to mark the file being uploaded.
+constexpr const char UPLOADING_SUFFIX[] = "ing";
+
 /// A shared threadname suffix in both the WSD and Kit processes
 /// is highly helpful for filtering the logs for the same document
 /// by simply grepping for this shared suffix+ID. e.g. 'grep "broker_123" loolwsd.log'

--- a/common/Util.cpp
+++ b/common/Util.cpp
@@ -875,16 +875,6 @@ namespace Util
         return std::string::npos;
     }
 
-    std::chrono::system_clock::time_point getFileTimestamp(const std::string& str_path)
-    {
-        struct stat file;
-        stat(str_path.c_str(), &file);
-        std::chrono::seconds ns{file.st_mtime};
-        std::chrono::system_clock::time_point mod_time_point{ns};
-
-        return mod_time_point;
-    }
-
     std::string getIso8601FracformatTime(std::chrono::system_clock::time_point time){
         char time_modified[64];
         std::time_t lastModified_us_t = std::chrono::system_clock::to_time_t(time);

--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -1053,9 +1053,6 @@ int main(int argc, char**argv)
     //// Return time in HTTP format.
     std::string getHttpTime(std::chrono::system_clock::time_point time);
 
-    //// Return timestamp of file
-    std::chrono::system_clock::time_point getFileTimestamp(const std::string& str_path);
-
     //// Return time in ISO8061 fraction format
     std::string getIso8601FracformatTime(std::chrono::system_clock::time_point time);
 

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -705,6 +705,21 @@ bool ChildSession::loadDocument(const char * /*buffer*/, int /*length*/, const S
             LOG_ERR("Failed to save template [" << url << "].");
             return false;
         }
+
+#if !MOBILEAPP
+            // Create the 'upload' file so DocBroker picks up and uploads.
+            const std::string oldName = Poco::URI(url).getPath();
+            const std::string newName = oldName + TO_UPLOAD_SUFFIX;
+            if (rename(oldName.c_str(), newName.c_str()) < 0)
+            {
+                // It's not an error if there was no file to rename, when the document isn't modified.
+                LOG_TRC("Failed to renamed [" << oldName << "] to [" << newName << ']');
+            }
+            else
+            {
+                LOG_TRC("Renamed [" << oldName << "] to [" << newName << ']');
+            }
+#endif //!MOBILEAPP
     }
 
     getLOKitDocument()->setView(_viewId);

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -2627,21 +2627,39 @@ void ChildSession::loKitCallback(const int type, const std::string& payload)
         sendTextFrame("setpart: " + payload);
         break;
     case LOK_CALLBACK_UNO_COMMAND_RESULT:
+    {
         sendTextFrame("unocommandresult: " + payload);
-#if MOBILEAPP
+
+        Parser parser;
+        Poco::Dynamic::Var var = parser.parse(payload);
+        Object::Ptr object = var.extract<Object::Ptr>();
+
+        auto commandName = object->get("commandName");
+        auto success = object->get("success");
+
+        if (!commandName.isEmpty() && commandName.toString() == ".uno:Save")
         {
+#if !MOBILEAPP
+            // Create the 'upload' file regardless of success or failure,
+            // because we don't know if the last upload worked or not.
+            // DocBroker will have to decide to upload or skip.
+            const std::string oldName = Poco::URI(getJailedFilePath()).getPath();
+            const std::string newName = oldName + TO_UPLOAD_SUFFIX;
+            if (rename(oldName.c_str(), newName.c_str()) < 0)
+            {
+                // It's not an error if there was no file to rename, when the document isn't modified.
+                LOG_TRC("Failed to renamed [" << oldName << "] to [" << newName << ']');
+            }
+            else
+            {
+                LOG_TRC("Renamed [" << oldName << "] to [" << newName << ']');
+            }
+
+#else // MOBILEAPP
             // After the document has been saved (into the temporary copy that we set up in
             // -[CODocument loadFromContents:ofType:error:]), save it also using the system API so
             // that file provider extensions notice.
-
-            Parser parser;
-            Poco::Dynamic::Var var = parser.parse(payload);
-            Object::Ptr object = var.extract<Object::Ptr>();
-
-            auto commandName = object->get("commandName");
-            auto success = object->get("success");
-
-            if (!commandName.isEmpty() && commandName.toString() == ".uno:Save" && !success.isEmpty() && success.toString() == "true")
+            if (!success.isEmpty() && success.toString() == "true")
             {
 #if defined(IOS)
                 CODocument *document = getDocumentDataForMobileAppDocId(_docManager->getMobileAppDocId()).coDocument;
@@ -2654,9 +2672,10 @@ void ChildSession::loKitCallback(const int type, const std::string& payload)
                 postDirectMessage("SAVE " + payload);
 #endif
             }
-        }
 #endif
-        break;
+        }
+    }
+    break;
     case LOK_CALLBACK_ERROR:
         {
             LOG_ERR("CALLBACK_ERROR: " << payload);

--- a/loleaflet/src/control/Control.DocumentNameInput.js
+++ b/loleaflet/src/control/Control.DocumentNameInput.js
@@ -28,8 +28,7 @@ L.Control.DocumentNameInput = L.Control.extend({
 						// same extension, just rename the file
 						// file name must be without the extension for rename
 						value = value.substr(0, value.lastIndexOf('.'));
-						this.map._renameFilename = value;
-						this.map.sendUnoCommand('.uno:Save');
+						this.map.renameFile(value);
 					}
 				}
 			} else {

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -510,7 +510,7 @@ public:
     {
         if (_stage == Stage::Header)
         {
-            LOG_TRC("performWrites (header).");
+            LOG_TRC("performWrites (request header).");
 
             out.append(getVerb());
             out.append(" ");
@@ -527,6 +527,8 @@ public:
 
         if (_stage == Stage::Body)
         {
+            LOG_TRC("performWrites (request body).");
+
             // Get the data to write into the socket
             // from the client's callback. This is
             // used to upload files, or other data.
@@ -543,14 +545,14 @@ public:
 
                 if (read == 0)
                 {
-                    LOG_TRC("performWrites (body): finished, total: " << wrote);
+                    LOG_TRC("performWrites (request body): finished, total: " << wrote);
                     _stage = Stage::Finished;
                     return true;
                 }
 
                 out.append(buffer, read);
                 wrote += read;
-                LOG_TRC("performWrites (body): " << read << " bytes, total: " << wrote);
+                LOG_TRC("performWrites (request body): " << read << " bytes, total: " << wrote);
             } while (wrote < capacity);
         }
 

--- a/net/NetUtil.cpp
+++ b/net/NetUtil.cpp
@@ -58,6 +58,12 @@ connect(const std::string& host, const std::string& port, const bool isSSL,
             if (ai->ai_addrlen && ai->ai_addr)
             {
                 int fd = ::socket(ai->ai_addr->sa_family, SOCK_STREAM | SOCK_NONBLOCK, 0);
+                if (fd < 0)
+                {
+                    LOG_SYS("Failed to create socket");
+                    continue;
+                }
+
                 int res = ::connect(fd, ai->ai_addr, ai->ai_addrlen);
                 if (fd < 0 || (res < 0 && errno != EINPROGRESS))
                 {
@@ -86,7 +92,7 @@ connect(const std::string& host, const std::string& port, const bool isSSL,
         freeaddrinfo(ainfo);
     }
     else
-        LOG_ERR("Failed to lookup host [" << host << "]. Skipping.");
+        LOG_SYS("Failed to lookup host [" << host << "]. Skipping");
 
     return socket;
 }

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -609,6 +609,18 @@ bool StreamSocket::send(http::Request& request)
     }
 }
 
+bool StreamSocket::sendAndShutdown(http::Response& response)
+{
+    response.set("Connection", "close");
+    if (send(response))
+    {
+        shutdown();
+        return true;
+    }
+
+    return false;
+}
+
 void SocketPoll::dumpState(std::ostream& os)
 {
     // FIXME: NOT thread-safe! _pollSockets is modified from the polling thread!

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -938,6 +938,12 @@ public:
     /// Will shutdown the socket upon error and return false.
     bool send(const http::Response& response);
 
+    /// Send an http::Response, flush, and shutdown.
+    /// Will set 'Connection: close' header.
+    /// Returns true if no errors are encountered.
+    /// Will always shutdown the socket.
+    bool sendAndShutdown(http::Response& response);
+
     /// Safely flush any outgoing data.
     inline void flush()
     {

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -22,6 +22,7 @@ noinst_LTLIBRARIES = \
 	unit-admin.la unit-tilecache.la \
 	unit-fuzz.la unit-oob.la unit-http.la unit-oauth.la \
 	unit-wopi.la unit-wopi-saveas.la \
+	unit-wopi-async-upload-close.la \
 	unit-wopi-ownertermination.la unit-wopi-versionrestore.la \
 	unit-wopi-documentconflict.la unit_wopi_renamefile.la unit_wopi_watermark.la \
 	unit-tiff-load.la \
@@ -151,6 +152,8 @@ unit_oauth_la_SOURCES = UnitOAuth.cpp
 unit_oauth_la_LIBADD = $(CPPUNIT_LIBS)
 unit_wopi_la_SOURCES = UnitWOPI.cpp
 unit_wopi_la_LIBADD = $(CPPUNIT_LIBS)
+unit_wopi_async_upload_close_la_SOURCES = UnitWOPIAsyncUpload_Close.cpp
+unit_wopi_async_upload_close_la_LIBADD = $(CPPUNIT_LIBS)
 unit_wopi_saveas_la_SOURCES = UnitWOPISaveAs.cpp
 unit_wopi_saveas_la_LIBADD = $(CPPUNIT_LIBS)
 unit_wopi_ownertermination_la_SOURCES = UnitWopiOwnertermination.cpp
@@ -227,6 +230,7 @@ TESTS = \
 	unit-integration.la unit-httpws.la unit-crash.la \
 	unit-copy-paste.la unit-typing.la unit-convert.la unit-prefork.la unit-tilecache.la unit-timeout.la \
 	unit-oauth.la unit-wopi.la unit-wopi-saveas.la \
+	unit-wopi-async-upload-close.la \
 	unit-wopi-ownertermination.la unit-wopi-versionrestore.la \
 	unit-wopi-documentconflict.la unit_wopi_renamefile.la unit_wopi_watermark.la \
 	unit-http.la \

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -22,7 +22,7 @@ noinst_LTLIBRARIES = \
 	unit-admin.la unit-tilecache.la \
 	unit-fuzz.la unit-oob.la unit-http.la unit-oauth.la \
 	unit-wopi.la unit-wopi-saveas.la \
-	unit-wopi-async-upload-close.la \
+	unit-wopi-async-upload-close.la unit-wopi-async-upload-modify.la \
 	unit-wopi-ownertermination.la unit-wopi-versionrestore.la \
 	unit-wopi-documentconflict.la unit_wopi_renamefile.la unit_wopi_watermark.la \
 	unit-tiff-load.la \
@@ -154,6 +154,8 @@ unit_wopi_la_SOURCES = UnitWOPI.cpp
 unit_wopi_la_LIBADD = $(CPPUNIT_LIBS)
 unit_wopi_async_upload_close_la_SOURCES = UnitWOPIAsyncUpload_Close.cpp
 unit_wopi_async_upload_close_la_LIBADD = $(CPPUNIT_LIBS)
+unit_wopi_async_upload_modify_la_SOURCES = UnitWOPIAsyncUpload_Modify.cpp
+unit_wopi_async_upload_modify_la_LIBADD = $(CPPUNIT_LIBS)
 unit_wopi_saveas_la_SOURCES = UnitWOPISaveAs.cpp
 unit_wopi_saveas_la_LIBADD = $(CPPUNIT_LIBS)
 unit_wopi_ownertermination_la_SOURCES = UnitWopiOwnertermination.cpp
@@ -230,7 +232,7 @@ TESTS = \
 	unit-integration.la unit-httpws.la unit-crash.la \
 	unit-copy-paste.la unit-typing.la unit-convert.la unit-prefork.la unit-tilecache.la unit-timeout.la \
 	unit-oauth.la unit-wopi.la unit-wopi-saveas.la \
-	unit-wopi-async-upload-close.la \
+	unit-wopi-async-upload-close.la unit-wopi-async-upload-modify.la \
 	unit-wopi-ownertermination.la unit-wopi-versionrestore.la \
 	unit-wopi-documentconflict.la unit_wopi_renamefile.la unit_wopi_watermark.la \
 	unit-http.la \

--- a/test/UnitWOPI.cpp
+++ b/test/UnitWOPI.cpp
@@ -55,7 +55,8 @@ public:
         return res;
     }
 
-    void assertPutFileRequest(const Poco::Net::HTTPRequest& request) override
+    std::unique_ptr<http::Response>
+    assertPutFileRequest(const Poco::Net::HTTPRequest& request) override
     {
         if (_savingPhase == SavingPhase::Unmodified)
         {
@@ -88,6 +89,8 @@ public:
 
         if (_finishedSaveUnmodified && _finishedSaveModified)
             passTest("Headers for both modified and unmodified received as expected.");
+
+        return nullptr;
     }
 
     bool onDocumentLoaded(const std::string& message) override

--- a/test/UnitWOPIAsyncUpload_Close.cpp
+++ b/test/UnitWOPIAsyncUpload_Close.cpp
@@ -1,0 +1,169 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <config.h>
+
+#include "HttpRequest.hpp"
+#include "Util.hpp"
+#include "lokassert.hpp"
+
+#include <WopiTestServer.hpp>
+#include <Log.hpp>
+#include <Unit.hpp>
+#include <UnitHTTP.hpp>
+#include <helpers.hpp>
+#include <Poco/Net/HTTPRequest.h>
+#include <Poco/Util/LayeredConfiguration.h>
+
+/// Test Async uploading with simulated failing.
+/// We modify the document, save, and attempt to upload,
+/// which fails. We close the document and verify
+/// that the document is uploaded upon closing.
+// Modify, Save, Upload fails, close -> Upload.
+class UnitWOPIAsyncUpload_Close : public WopiTestServer
+{
+    enum class Phase
+    {
+        Load,
+        WaitLoadStatus,
+        Modify,
+        WaitModifiedStatus,
+        WaitFirstPutFile,
+        Close,
+        WaitSecondPutFile,
+        Polling
+    } _phase;
+
+public:
+    UnitWOPIAsyncUpload_Close()
+        : WopiTestServer("UnitWOPIAsyncUpload_Close")
+        , _phase(Phase::Load)
+    {
+    }
+
+    std::unique_ptr<http::Response>
+    assertPutFileRequest(const Poco::Net::HTTPRequest& request) override
+    {
+        // We save twice. First right after loading, unmodified.
+        if (_phase == Phase::WaitFirstPutFile)
+        {
+            LOG_TST("assertPutFileRequest: First PutFile, which will fail");
+
+            LOG_TST("WaitFirstPutFile => Close");
+            _phase = Phase::Close;
+
+            LOK_ASSERT_EQUAL(std::string("true"), request.get("X-LOOL-WOPI-IsModifiedByUser"));
+
+            // We requested the save.
+            LOK_ASSERT_EQUAL(std::string("false"), request.get("X-LOOL-WOPI-IsAutosave"));
+
+            // Fail with error.
+            return Util::make_unique<http::Response>(http::StatusLine(404));
+        }
+
+        // This during closing the document.
+        LOG_TST("assertPutFileRequest: Second PutFile, which will succeed");
+        LOK_ASSERT_MESSAGE("Expected to be in Phase::WaitSecondPutFile",
+                           _phase == Phase::WaitSecondPutFile);
+
+        // the document is modified
+        LOK_ASSERT_EQUAL(std::string("true"), request.get("X-LOOL-WOPI-IsModifiedByUser"));
+
+        // Triggered while closing.
+        LOK_ASSERT_EQUAL(std::string("false"), request.get("X-LOOL-WOPI-IsAutosave"));
+
+        passTest("Document uploaded on closing as expected.");
+
+        return nullptr;
+    }
+
+    /// The document is loaded.
+    bool onDocumentLoaded(const std::string& message) override
+    {
+        LOG_TST("onDocumentLoaded: [" << message << ']');
+        LOK_ASSERT_MESSAGE("Expected to be in Phase::WaitLoadStatus",
+                           _phase == Phase::WaitLoadStatus);
+
+        LOG_TST("onDocumentModified: Switching to Phase::WaitLoadStatus, SavingPhase::Modify");
+        _phase = Phase::Modify;
+
+        SocketPoll::wakeupWorld();
+        return true;
+    }
+
+    /// The document is modified. Save it.
+    bool onDocumentModified(const std::string& message) override
+    {
+        LOG_TST("onDocumentModified: Doc (WaitModifiedStatus): [" << message << ']');
+        LOK_ASSERT_MESSAGE("Expected to be in Phase::WaitModified",
+                           _phase == Phase::WaitModifiedStatus);
+        {
+            LOG_TST("onDocumentModified: Switching to Phase::WaitModifiedStatus, "
+                    "SavingPhase::WaitFirstPutFile");
+            _phase = Phase::WaitFirstPutFile;
+
+            WSD_CMD("save dontTerminateEdit=0 dontSaveIfUnmodified=0 "
+                    "extendedData=CustomFlag%3DCustom%20Value%3BAnotherFlag%3DAnotherValue");
+
+            SocketPoll::wakeupWorld();
+        }
+
+        return true;
+    }
+
+    void invokeWSDTest() override
+    {
+        switch (_phase)
+        {
+            case Phase::Load:
+            {
+                LOG_TST("Load => WaitLoadStatus");
+                _phase = Phase::WaitLoadStatus;
+
+                LOG_TST("Load: initWebsocket.");
+                initWebsocket("/wopi/files/0?access_token=anything");
+
+                WSD_CMD("load url=" + getWopiSrc());
+                break;
+            }
+            case Phase::WaitLoadStatus:
+                break;
+            case Phase::Modify:
+            {
+                LOG_TST("Modify => WaitModified");
+                _phase = Phase::WaitModifiedStatus;
+
+                WSD_CMD("key type=input char=97 key=0");
+                WSD_CMD("key type=up char=0 key=512");
+                break;
+            }
+            case Phase::WaitModifiedStatus:
+                break;
+            case Phase::WaitFirstPutFile:
+                break;
+            case Phase::Close:
+            {
+                LOG_TST("Close => WaitSecondPutFile");
+                _phase = Phase::WaitSecondPutFile;
+
+                WSD_CMD("closedocument");
+                break;
+            }
+            case Phase::WaitSecondPutFile:
+                break;
+            case Phase::Polling:
+            {
+                // just wait for the results
+                break;
+            }
+        }
+    }
+};
+
+UnitBase* unit_create_wsd(void) { return new UnitWOPIAsyncUpload_Close(); }
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/test/UnitWOPIAsyncUpload_Modify.cpp
+++ b/test/UnitWOPIAsyncUpload_Modify.cpp
@@ -1,0 +1,171 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <config.h>
+
+#include "HttpRequest.hpp"
+#include "Util.hpp"
+#include "lokassert.hpp"
+
+#include <WopiTestServer.hpp>
+#include <Log.hpp>
+#include <Unit.hpp>
+#include <UnitHTTP.hpp>
+#include <helpers.hpp>
+#include <Poco/Net/HTTPRequest.h>
+#include <Poco/Util/LayeredConfiguration.h>
+
+/// Test Async uploading with simulated failing.
+/// We modify the document, save, and attempt to upload,
+/// which fails. We then modify the document again
+/// and save. We expect another upload attemp,
+/// which will succeed.
+/// Modify, Save, Upload fails, Modify, Save -> Upload.
+class UnitWOPIAsyncUpload_Modify : public WopiTestServer
+{
+    enum class Phase
+    {
+        Load,
+        WaitLoadStatus,
+        Modify,
+        WaitModifiedStatus,
+        WaitFirstPutFile,
+        Close,
+        WaitSecondPutFile,
+        Polling
+    } _phase;
+
+public:
+    UnitWOPIAsyncUpload_Modify()
+        : WopiTestServer("UnitWOPIAsyncUpload_Modify")
+        , _phase(Phase::Load)
+    {
+    }
+
+    std::unique_ptr<http::Response>
+    assertPutFileRequest(const Poco::Net::HTTPRequest& request) override
+    {
+        // We save twice. First right after loading, unmodified.
+        if (_phase == Phase::WaitFirstPutFile)
+        {
+            LOG_TST("assertPutFileRequest: First PutFile, which will fail");
+
+            LOG_TST("WaitFirstPutFile => Close");
+            _phase = Phase::Close;
+
+            LOK_ASSERT_EQUAL(std::string("true"), request.get("X-LOOL-WOPI-IsModifiedByUser"));
+
+            // We requested the save.
+            LOK_ASSERT_EQUAL(std::string("false"), request.get("X-LOOL-WOPI-IsAutosave"));
+
+            // Fail with error.
+            LOG_TST("assertPutFileRequest: returning 404 to simulate PutFile failure");
+            return Util::make_unique<http::Response>(http::StatusLine(404));
+        }
+
+        // This during closing the document.
+        LOG_TST("assertPutFileRequest: Second PutFile, which will succeed");
+        LOK_ASSERT_MESSAGE("Expected to be in Phase::WaitSecondPutFile",
+                           _phase == Phase::WaitSecondPutFile);
+
+        // the document is modified
+        LOK_ASSERT_EQUAL(std::string("true"), request.get("X-LOOL-WOPI-IsModifiedByUser"));
+
+        // Triggered while closing.
+        LOK_ASSERT_EQUAL(std::string("false"), request.get("X-LOOL-WOPI-IsAutosave"));
+
+        passTest("Document uploaded on closing as expected.");
+
+        return nullptr;
+    }
+
+    /// The document is loaded.
+    bool onDocumentLoaded(const std::string& message) override
+    {
+        LOG_TST("onDocumentLoaded: [" << message << ']');
+        LOK_ASSERT_MESSAGE("Expected to be in Phase::WaitLoadStatus",
+                           _phase == Phase::WaitLoadStatus);
+
+        LOG_TST("onDocumentModified: Switching to Phase::WaitLoadStatus, SavingPhase::Modify");
+        _phase = Phase::Modify;
+
+        SocketPoll::wakeupWorld();
+        return true;
+    }
+
+    /// The document is modified. Save it.
+    bool onDocumentModified(const std::string& message) override
+    {
+        LOG_TST("onDocumentModified: Doc (WaitModifiedStatus): [" << message << ']');
+        LOK_ASSERT_MESSAGE("Expected to be in Phase::WaitModified",
+                           _phase == Phase::WaitModifiedStatus);
+        {
+            LOG_TST("onDocumentModified: Switching to Phase::WaitModifiedStatus, "
+                    "SavingPhase::WaitFirstPutFile");
+            _phase = Phase::WaitFirstPutFile;
+
+            WSD_CMD("save dontTerminateEdit=0 dontSaveIfUnmodified=0 "
+                    "extendedData=CustomFlag%3DCustom%20Value%3BAnotherFlag%3DAnotherValue");
+
+            SocketPoll::wakeupWorld();
+        }
+
+        return true;
+    }
+
+    void invokeWSDTest() override
+    {
+        switch (_phase)
+        {
+            case Phase::Load:
+            {
+                LOG_TST("Load => WaitLoadStatus");
+                _phase = Phase::WaitLoadStatus;
+
+                LOG_TST("Load: initWebsocket.");
+                initWebsocket("/wopi/files/0?access_token=anything");
+
+                WSD_CMD("load url=" + getWopiSrc());
+                break;
+            }
+            case Phase::WaitLoadStatus:
+                break;
+            case Phase::Modify:
+            {
+                LOG_TST("Modify => WaitModified");
+                _phase = Phase::WaitModifiedStatus;
+
+                WSD_CMD("key type=input char=97 key=0");
+                WSD_CMD("key type=up char=0 key=512");
+                break;
+            }
+            case Phase::WaitModifiedStatus:
+                break;
+            case Phase::WaitFirstPutFile:
+                break;
+            case Phase::Close:
+            {
+                LOG_TST("Close => WaitSecondPutFile");
+                _phase = Phase::WaitSecondPutFile;
+
+                WSD_CMD("closedocument");
+                break;
+            }
+            case Phase::WaitSecondPutFile:
+                break;
+            case Phase::Polling:
+            {
+                // just wait for the results
+                break;
+            }
+        }
+    }
+};
+
+UnitBase* unit_create_wsd(void) { return new UnitWOPIAsyncUpload_Modify(); }
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/test/UnitWOPIHttpHeaders.cpp
+++ b/test/UnitWOPIHttpHeaders.cpp
@@ -35,10 +35,12 @@ protected:
         exitTest(TestResult::Ok); //TODO: Remove when we add put/rename cases.
     }
 
-    void assertPutFileRequest(const Poco::Net::HTTPRequest& request) override
+    std::unique_ptr<http::Response>
+    assertPutFileRequest(const Poco::Net::HTTPRequest& request) override
     {
         assertHeaders(request);
         exitTest(TestResult::Ok);
+        return nullptr;
     }
 
     void assertPutRelativeFileRequest(const Poco::Net::HTTPRequest& request) override

--- a/test/UnitWOPIVersionRestore.cpp
+++ b/test/UnitWOPIVersionRestore.cpp
@@ -44,13 +44,16 @@ public:
     {
     }
 
-    void assertPutFileRequest(const Poco::Net::HTTPRequest& /*request*/) override
+    std::unique_ptr<http::Response>
+    assertPutFileRequest(const Poco::Net::HTTPRequest& /*request*/) override
     {
         if (_phase == Phase::WaitPutFile)
         {
             LOG_TST("assertPutFileRequest: document saved.");
             _isDocumentSaved = true;
         }
+
+        return nullptr;
     }
 
     bool onDocumentLoaded(const std::string& message) override

--- a/test/UnitWopiOwnertermination.cpp
+++ b/test/UnitWopiOwnertermination.cpp
@@ -49,7 +49,8 @@ public:
     {
     }
 
-    void assertPutFileRequest(const Poco::Net::HTTPRequest& /*request*/) override
+    std::unique_ptr<http::Response>
+    assertPutFileRequest(const Poco::Net::HTTPRequest& /*request*/) override
     {
         if (_phase == Phase::Polling)
         {
@@ -60,6 +61,8 @@ public:
         {
             failTest("Saving in an unexpected phase: " + toString(_phase));
         }
+
+        return nullptr;
     }
 
     bool onDocumentLoaded(const std::string& message) override

--- a/test/WopiTestServer.hpp
+++ b/test/WopiTestServer.hpp
@@ -263,15 +263,21 @@ protected:
             std::unique_ptr<http::Response> response = assertPutFileRequest(request);
             if (response)
             {
+                LOG_TST("Fake wopi host response to POST "
+                        << uriReq.getPath() << ": " << response->statusLine().statusCode()
+                        << response->statusLine().reasonPhrase());
                 socket->sendAndShutdown(*response);
             }
             else
             {
                 // By default we return success.
+                const std::string body = "{\"LastModifiedTime\": \"" +
+                                         Util::getIso8601FracformatTime(_fileLastModifiedTime) +
+                                         "\" }";
+                LOG_TST("Fake wopi host response to POST " << uriReq.getPath() << ": 200 OK "
+                                                           << body);
                 http::Response httpResponse(http::StatusLine(200));
-                httpResponse.setBody("{\"LastModifiedTime\": \"" +
-                                     Util::getIso8601FracformatTime(_fileLastModifiedTime) +
-                                     "\" }");
+                httpResponse.setBody(body);
                 socket->sendAndShutdown(httpResponse);
             }
 

--- a/test/WopiTestServer.hpp
+++ b/test/WopiTestServer.hpp
@@ -239,7 +239,7 @@ protected:
         {
             LOG_TST("Fake wopi host request, handling PutFile: " << uriReq.getPath());
 
-            std::string wopiTimestamp = request.get("X-LOOL-WOPI-Timestamp");
+            std::string wopiTimestamp = request.get("X-LOOL-WOPI-Timestamp", std::string());
             if (!wopiTimestamp.empty())
             {
 

--- a/test/WopiTestServer.hpp
+++ b/test/WopiTestServer.hpp
@@ -264,7 +264,7 @@ protected:
             if (response)
             {
                 LOG_TST("Fake wopi host response to POST "
-                        << uriReq.getPath() << ": " << response->statusLine().statusCode()
+                        << uriReq.getPath() << ": " << response->statusLine().statusCode() << ' '
                         << response->statusLine().reasonPhrase());
                 socket->sendAndShutdown(*response);
             }

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -803,9 +803,17 @@ bool ClientSession::_handleInput(const char *buffer, int length)
             sendTextFrameAndLogError("error: cmd=renamefile kind=syntax");
             return false;
         }
+
         std::string wopiFilename;
         Poco::URI::decode(encodedWopiFilename, wopiFilename);
-        docBroker->uploadAsToStorage(getId(), "", wopiFilename, true);
+        const std::string error =
+            docBroker->handleRenameFileCommand(getId(), std::move(wopiFilename));
+        if (!error.empty())
+        {
+            sendTextFrameAndLogError(error);
+            return false;
+        }
+
         return true;
     }
     else if (tokens.equals(0, "dialogevent") ||

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -20,7 +20,6 @@
 
 #include "DocumentBroker.hpp"
 #include "LOOLWSD.hpp"
-#include "Storage.hpp"
 #include <common/Common.hpp>
 #include <common/Log.hpp>
 #include <common/Protocol.hpp>
@@ -1733,9 +1732,9 @@ bool ClientSession::handleKitToClientMessage(const char* buffer, const int lengt
             // Wopi post load actions
             if (_wopiFileInfo && !_wopiFileInfo->getTemplateSource().empty())
             {
-                std::string result;
-                LOG_DBG("Saving template [" << _wopiFileInfo->getTemplateSource() << "] to storage");
-                docBroker->uploadToStorage(getId(), true, result, /*force=*/false);
+                LOG_DBG("Uploading template [" << _wopiFileInfo->getTemplateSource()
+                                               << "] to storage after loading.");
+                docBroker->uploadAfterLoadingTemplate(getId());
             }
 
             for(auto &token : tokens)

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -405,14 +405,16 @@ void DocumentBroker::pollThread()
 
 #if !MOBILEAPP
         if (std::chrono::duration_cast<std::chrono::minutes>(now - lastClipboardHashUpdateTime).count() >= 2)
-        for (auto &it : _sessions)
         {
-            if (it.second->staleWaitDisconnect(now))
+            for (auto &it : _sessions)
             {
-                std::string id = it.second->getId();
-                LOG_WRN("Unusual, Kit session " + id + " failed its disconnect handshake, killing");
-                finalRemoveSession(id);
-                break; // it invalid.
+                if (it.second->staleWaitDisconnect(now))
+                {
+                    std::string id = it.second->getId();
+                    LOG_WRN("Unusual, Kit session " + id + " failed its disconnect handshake, killing");
+                    finalRemoveSession(id);
+                    break; // it invalid.
+                }
             }
         }
 
@@ -441,8 +443,9 @@ void DocumentBroker::pollThread()
                 }
             }
         }
+        else
 #endif
-        else if (_sessions.empty() && (isLoaded() || _docState.isMarkedToDestroy()))
+        if (_sessions.empty() && (isLoaded() || _docState.isMarkedToDestroy()))
         {
             // If all sessions have been removed, no reason to linger.
             LOG_INF("Terminating dead DocumentBroker for docKey [" << getDocKey() << "].");

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -391,8 +391,11 @@ void DocumentBroker::pollThread()
         if (SigUtil::getShutdownRequestFlag() || _docState.isCloseRequested())
         {
             const std::string reason = SigUtil::getShutdownRequestFlag() ? "recycling" : _closeReason;
-            LOG_INF("Autosaving DocumentBroker for docKey [" << getDocKey() << "] for " << reason);
-            if (!autoSave(isPossiblyModified()))
+            const bool possiblyModified = isPossiblyModified();
+            LOG_INF("Autosaving DocumentBroker for docKey ["
+                    << getDocKey() << "], possiblyModified: " << (possiblyModified ? "yes" : "no")
+                    << ", for " << reason);
+            if (!autoSave(possiblyModified))
             {
                 LOG_INF("Terminating DocumentBroker for docKey [" << getDocKey() << "].");
                 stop(reason);
@@ -1175,9 +1178,11 @@ void DocumentBroker::handleUploadToStorageResponse(const StorageBase::UploadResu
 
     // Storage save is considered successful when either storage returns OK or the document on the storage
     // was changed and it was used to overwrite local changes
-    _storageManager.setLastUploadResult(
-        uploadResult.getResult() == StorageBase::UploadResult::Result::OK
-        || uploadResult.getResult() == StorageBase::UploadResult::Result::DOC_CHANGED);
+    const bool lastUploadSuccessful =
+        uploadResult.getResult() == StorageBase::UploadResult::Result::OK ||
+        uploadResult.getResult() == StorageBase::UploadResult::Result::DOC_CHANGED;
+    LOG_TRC("lastUploadSuccessful: " << lastUploadSuccessful);
+    _storageManager.setLastUploadResult(lastUploadSuccessful);
 
     if (uploadResult.getResult() == StorageBase::UploadResult::Result::OK)
     {
@@ -2372,6 +2377,7 @@ void DocumentBroker::setModified(const bool value)
 
     // Set the X-LOOL-WOPI-IsModifiedByUser header flag sent to storage.
     _storage->setUserModified(value);
+    LOG_TRC("Modified state set to " << value << " for Doc [" << _docId << ']');
 }
 
 bool DocumentBroker::isInitialSettingSet(const std::string& name) const

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -884,7 +884,8 @@ bool DocumentBroker::download(const std::shared_ptr<ClientSession>& session, con
         }
 #endif
 
-        std::ifstream istr(localPath, std::ios::binary);
+        const std::string localFilePath = Poco::Path(getJailRoot(), localPath).toString();
+        std::ifstream istr(localFilePath, std::ios::binary);
         Poco::SHA1Engine sha1;
         Poco::DigestOutputStream dos(sha1);
         Poco::StreamCopier::copyStream(istr, dos);

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1187,6 +1187,30 @@ void DocumentBroker::uploadAsToStorage(const std::string& sessionId,
                             /*force=*/false);
 }
 
+void DocumentBroker::uploadAfterLoadingTemplate(const std::string& sessionId)
+{
+#if !MOBILEAPP
+    // Create the 'upload' file as it gets created only when
+    // handling .uno:Save, which isn't issued for templates
+    // (save is done in Kit right after loading a template).
+    const std::string oldName = _storage->getRootFilePathToUpload();
+    const std::string newName = _storage->getRootFilePathUploading();
+    if (rename(oldName.c_str(), newName.c_str()) < 0)
+    {
+        // It's not an error if there was no file to rename, when the document isn't modified.
+        LOG_SYS("Expected to renamed the document [" << oldName << "] after template-loading to ["
+                                                     << newName << ']');
+    }
+    else
+    {
+        LOG_TRC("Renamed [" << oldName << "] to [" << newName << ']');
+    }
+#endif //!MOBILEAPP
+
+    std::string result;
+    uploadToStorage(sessionId, true, result, /*force=*/false);
+}
+
 void DocumentBroker::uploadToStorageInternal(const std::string& sessionId, bool success,
                                              const std::string& result,
                                              const std::string& saveAsPath,

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1146,9 +1146,8 @@ void DocumentBroker::uploadToStorageInternal(const std::string& sessionId, bool 
 
             case StorageBase::AsyncUpload::State::Complete:
             {
-                LOG_DBG("Successfully uploaded [" << _docKey << "], processing results.");
-                const StorageBase::UploadResult& uploadResult = asyncUp.result();
-                return handleUploadToStorageResponse(uploadResult);
+                LOG_DBG("Finished uploading [" << _docKey << "], processing results.");
+                return handleUploadToStorageResponse(asyncUp.result());
             }
 
         case StorageBase::AsyncUpload::State::None: // Unexpected: fallback.
@@ -1170,6 +1169,7 @@ void DocumentBroker::handleUploadToStorageResponse(const StorageBase::UploadResu
     if (!_uploadRequest)
     {
         // We shouldn't get here if there is no active upload request.
+        LOG_ERR("No active upload request while handling upload result.");
         return;
     }
 

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1335,7 +1335,7 @@ void DocumentBroker::uploadToStorageInternal(const std::string& sessionId, bool 
         }
 
         //FIXME: flag the failure so we retry.
-        LOG_ERR("Failed to upload [" << _docKey << "] asynchronously.");
+        LOG_WRN("Failed to upload [" << _docKey << "] asynchronously.");
 
         switch (_docState.activity())
         {

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -931,10 +931,20 @@ bool DocumentBroker::download(const std::shared_ptr<ClientSession>& session, con
 
         _filename = fileInfo.getFilename();
 
-        // Use the local temp file's timestamp.
-        _saveManager.setLastModifiedTime(
-            templateSource.empty() ? FileUtil::Stat(_storage->getRootFilePath()).modifiedTimepoint()
-                                   : std::chrono::system_clock::time_point());
+        if (!templateSource.empty())
+        {
+            // Invalid timestamp for templates, to force uploading once we save-after-loading.
+            _saveManager.setLastModifiedTime(std::chrono::system_clock::time_point());
+            _storageManager.setLastUploadedFileModifiedTime(
+                std::chrono::system_clock::time_point());
+        }
+        else
+        {
+            // Use the local temp file's timestamp.
+            const auto timepoint = FileUtil::Stat(localFilePath).modifiedTimepoint();
+            _saveManager.setLastModifiedTime(timepoint);
+            _storageManager.setLastUploadedFileModifiedTime(timepoint); // Used to detect modifications.
+        }
 
         bool dontUseCache = false;
 #if MOBILEAPP

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -382,6 +382,14 @@ void DocumentBroker::pollThread()
             refreshLock();
 #endif
 
+        //TODO: Review if we need this here.
+        if (_saveManager.isSaving() && !_saveManager.hasSavingTimedOut())
+        {
+            // We are saving, nothing more to do but wait (until we save or we timeout).
+            continue;
+        }
+
+        LOG_TRC("Poll: current activity: " << DocumentState::toString(_docState.activity()));
         switch (_docState.activity())
         {
             case DocumentState::Activity::None:
@@ -393,37 +401,37 @@ void DocumentBroker::pollThread()
                     // Nothing more to do until the save is complete.
                     continue;
                 }
+                else if (SigUtil::getShutdownRequestFlag() || _docState.isCloseRequested())
+                {
+                    const std::string reason =
+                        SigUtil::getShutdownRequestFlag() ? "recycling" : _closeReason;
+                    const bool possiblyModified = isPossiblyModified();
+                    LOG_INF("Autosaving DocumentBroker for docKey ["
+                            << getDocKey() << "], possiblyModified: "
+                            << (possiblyModified ? "yes" : "no") << ", for " << reason);
+                    if (!autoSave(possiblyModified))
+                    {
+                        LOG_INF("Terminating DocumentBroker for docKey [" << getDocKey()
+                                                                          << "]: " << reason);
+                        stop(reason);
+                    }
+                }
+                else if (!_stop && _saveManager.needAutosaveCheck())
+                {
+                    LOG_TRC("Triggering an autosave.");
+                    autoSave(false);
+                }
             }
             break;
 
+            // We have some activity ongoing.
             default:
-                break;
-        }
-
-        //TODO: Review if we need this here.
-        if (_saveManager.isSaving() && !_saveManager.hasSavingTimedOut())
-        {
-            // We are saving, nothing more to do but wait (until we save or we timeout).
-            continue;
-        }
-
-        if (SigUtil::getShutdownRequestFlag() || _docState.isCloseRequested())
-        {
-            const std::string reason = SigUtil::getShutdownRequestFlag() ? "recycling" : _closeReason;
-            const bool possiblyModified = isPossiblyModified();
-            LOG_INF("Autosaving DocumentBroker for docKey ["
-                    << getDocKey() << "], possiblyModified: " << (possiblyModified ? "yes" : "no")
-                    << ", for " << reason);
-            if (!autoSave(possiblyModified))
             {
-                LOG_INF("Terminating DocumentBroker for docKey [" << getDocKey() << "].");
-                stop(reason);
+                constexpr std::chrono::seconds postponeAutosaveDuration(30);
+                LOG_TRC("Postponing autosave check by " << postponeAutosaveDuration);
+                _saveManager.postponeAutosave(postponeAutosaveDuration);
             }
-        }
-        else if (!_stop && _saveManager.needAutosaveCheck())
-        {
-            LOG_TRC("Triggering an autosave.");
-            autoSave(false);
+            break;
         }
 
 #if !MOBILEAPP

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1087,7 +1087,6 @@ void DocumentBroker::uploadToStorageInternal(const std::string& sessionId, bool 
     }
 
     const bool isSaveAs = !saveAsPath.empty();
-    const Authorization auth = session->getAuthorization();
     const std::string uri = isSaveAs ? saveAsPath : session->getPublicUri().toString();
 
     // Map the FileId from the docKey to the new filename to anonymize the new filename as the FileId.
@@ -1150,8 +1149,9 @@ void DocumentBroker::uploadToStorageInternal(const std::string& sessionId, bool 
         LOG_ERR("Failed to upload [" << _docKey << "] asynchronously.");
     };
 
-    _storage->uploadLocalFileToStorageAsync(auth, session->getCookies(), *_lockCtx, saveAsPath,
-                                            saveAsFilename, isRename, *_poll, asyncUploadCallback);
+    _storage->uploadLocalFileToStorageAsync(session->getAuthorization(), session->getCookies(),
+                                            *_lockCtx, saveAsPath, saveAsFilename, isRename, *_poll,
+                                            asyncUploadCallback);
 }
 
 void DocumentBroker::handleUploadToStorageResponse(const StorageBase::UploadResult& uploadResult)

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1107,21 +1107,23 @@ void DocumentBroker::uploadToStorageInternal(const std::string& sessionId, bool 
 
     _uploadRequest = Util::make_unique<UploadRequest>(uriAnonym, newFileModifiedTime, it->second,
                                                       isSaveAs, isRename);
-    const StorageBase::AsyncUpload asyncUp = _storage->uploadLocalFileToStorageAsync(
-        auth, it->second->getCookies(), *_lockCtx, saveAsPath, saveAsFilename, isRename);
 
-    switch (asyncUp.state())
+    StorageBase::AsyncUploadCallback asyncUploadCallback =
+        [this](const StorageBase::AsyncUpload& asyncUp)
     {
-        case StorageBase::AsyncUpload::State::Running:
-            LOG_DBG("Async upload of [" << _docKey << "] is in progress.");
-            return;
-
-        case StorageBase::AsyncUpload::State::Complete:
+        LOG_TRC("onAsyncUploadCallback");
+        switch (asyncUp.state())
         {
-            LOG_DBG("Successfully uploaded [" << _docKey << "], processing results.");
-            const StorageBase::UploadResult& uploadResult = asyncUp.result();
-            return handleUploadToStorageResponse(uploadResult);
-        }
+            case StorageBase::AsyncUpload::State::Running:
+                LOG_DBG("Async upload of [" << _docKey << "] is in progress.");
+                return;
+
+            case StorageBase::AsyncUpload::State::Complete:
+            {
+                LOG_DBG("Successfully uploaded [" << _docKey << "], processing results.");
+                const StorageBase::UploadResult& uploadResult = asyncUp.result();
+                return handleUploadToStorageResponse(uploadResult);
+            }
 
         case StorageBase::AsyncUpload::State::None: // Unexpected: fallback.
         case StorageBase::AsyncUpload::State::Error:
@@ -1129,11 +1131,12 @@ void DocumentBroker::uploadToStorageInternal(const std::string& sessionId, bool 
             break;
     }
 
-    LOG_ERR("Failed to upload [" << _docKey
-                                 << "] asynchronously, will fallback to synchronous uploading.");
-    const StorageBase::UploadResult& uploadResult = _storage->uploadLocalFileToStorage(
-        auth, it->second->getCookies(), *_lockCtx, saveAsPath, saveAsFilename, isRename);
-    handleUploadToStorageResponse(uploadResult);
+        //FIXME: flag the failure so we retry.
+        LOG_ERR("Failed to upload [" << _docKey << "] asynchronously.");
+    };
+
+    _storage->uploadLocalFileToStorageAsync(auth, it->second->getCookies(), *_lockCtx, saveAsPath,
+                                            saveAsFilename, isRename, *_poll, asyncUploadCallback);
 }
 
 void DocumentBroker::handleUploadToStorageResponse(const StorageBase::UploadResult& uploadResult)

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -476,9 +476,17 @@ private:
     /// with the child and cleans up ChildProcess etc.
     void terminateChild(const std::string& closeReason);
 
+    /// Encodes whether or not uploading is needed.
+    enum class NeedToUpload
+    {
+        No, //< No need to upload, data up-to-date.
+        Yes, //< Data is out of date.
+        Force //< Force uploading, typically because always_save_on_exit is set.
+    };
+
     /// Returns true iff the Document in Storage is
     /// out-of-date and we must upload the last file on disk.
-    bool needToUploadToStorage() const;
+    NeedToUpload needToUploadToStorage() const;
 
     /// Upload the doc to the storage.
     void uploadToStorageInternal(const std::string& sessionId, bool success,

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -494,6 +494,7 @@ private:
                                  const std::string& saveAsFilename, const bool isRename,
                                  const bool force);
 
+    /// Handles the completion of uploading to storage, both success and failure cases.
     void handleUploadToStorageResponse(const StorageBase::UploadResult& uploadResult);
 
     /**

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -300,12 +300,12 @@ public:
 
     /// Upload the document to Storage if it needs persisting.
     /// Results are logged and broadcast to users.
-    void uploadToStorage(const std::string& sesionId, bool success, const std::string& result,
+    void uploadToStorage(const std::string& sessionId, bool success, const std::string& result,
                          bool force);
 
     /// UploadAs the document to Storage, with a new name.
     /// @param uploadAsPath Absolute path to the jailed file.
-    void uploadAsToStorage(const std::string& sesionId, const std::string& uploadAsPath,
+    void uploadAsToStorage(const std::string& sessionId, const std::string& uploadAsPath,
                            const std::string& uploadAsFilename, const bool isRename);
 
     bool isModified() const { return _isModified; }
@@ -476,7 +476,7 @@ private:
     void terminateChild(const std::string& closeReason);
 
     /// Upload the doc to the storage.
-    bool uploadToStorageInternal(const std::string& sesionId, bool success,
+    bool uploadToStorageInternal(const std::string& sessionId, bool success,
                                  const std::string& result, const std::string& saveAsPath,
                                  const std::string& saveAsFilename, const bool isRename,
                                  const bool force);

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -313,6 +313,11 @@ public:
     void uploadAsToStorage(const std::string& sessionId, const std::string& uploadAsPath,
                            const std::string& uploadAsFilename, const bool isRename);
 
+    /// Uploads the document right after loading from a template.
+    /// Template-loading requires special handling because the
+    /// document changes once loaded into a non-template format.
+    void uploadAfterLoadingTemplate(const std::string& sessionId);
+
     bool isModified() const { return _isModified; }
     void setModified(const bool value);
 

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -45,7 +45,7 @@ class Message;
 
 #include "LOOLWSD.hpp"
 
-/// A ChildProcess object represents a KIT process that hosts a document and manipulates the
+/// A ChildProcess object represents a Kit process that hosts a document and manipulates the
 /// document using the LibreOfficeKit API. It isn't actually a child of the WSD process, but a
 /// grandchild. The comments loosely talk about "child" anyway.
 
@@ -58,13 +58,11 @@ public:
                  const std::string& jailId,
                  const std::shared_ptr<StreamSocket>& socket,
                  const Poco::Net::HTTPRequest &request) :
-
         WSProcess("ChildProcess", pid, socket, std::make_shared<WebSocketHandler>(socket, request)),
         _jailId(jailId),
         _smapsFD(-1)
     {
     }
-
 
     ChildProcess(ChildProcess&& other) = delete;
 
@@ -431,6 +429,18 @@ public:
     /// Sends a message to all sessions except for the session passed as the param
     void broadcastMessageToOthers(const std::string& message, const std::shared_ptr<ClientSession>& _session) const;
 
+    /// Broadcasts 'blockui' command to all users with an optional message.
+    void blockUI(const std::string& msg)
+    {
+        broadcastMessage("blockui: " + msg);
+    }
+
+    /// Broadcasts 'unblockui' command to all users.
+    void unblockUI()
+    {
+        broadcastMessage("unblockui: ");
+    }
+
     /// Returns true iff an initial setting by the given name is already initialized.
     bool isInitialSettingSet(const std::string& name) const;
 
@@ -480,6 +490,9 @@ private:
 
     /// Invoked to issue a save before renaming the document filename.
     void startRenameFileCommand();
+
+    /// Finish handling the renamefile command.
+    void endRenameFileCommand();
 
     /// Shutdown all client connections with the given reason.
     void shutdownClients(const std::string& closeReason);
@@ -1010,6 +1023,36 @@ private:
         std::atomic<bool> _closeRequested; //< Owner-Termination flag.
         std::atomic<bool> _loaded; //< If the document ever loaded (check isLive to see if it still is).
     };
+
+    /// Transition to a given activity. Returns false if an activity exists.
+    bool startActivity(DocumentState::Activity activity)
+    {
+        if (activity == DocumentState::Activity::None)
+        {
+            LOG_DBG("Error: Cannot start 'None' activity.");
+            assert(!"Cannot start 'None' activity.");
+            return false;
+        }
+
+        if (_docState.activity() != DocumentState::Activity::None)
+        {
+            LOG_DBG("Error: Cannot start new activity ["
+                    << DocumentState::toString(activity) << "] while executing ["
+                    << DocumentState::toString(_docState.activity()) << ']');
+            assert(!"Cannot start new activity while executing another.");
+            return false;
+        }
+
+        _docState.setActivity(activity);
+        return true;
+    }
+
+    /// Ends the current activity.
+    void endActivity()
+    {
+        LOG_DBG("Ending [" << DocumentState::toString(_docState.activity()) << "] activity.");
+        _docState.setActivity(DocumentState::Activity::None);
+    }
 
     /// The main state of the document.
     DocumentState _docState;

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -295,6 +295,10 @@ public:
 
     bool isLastStorageUploadSuccessful() { return _storageManager.lastUploadSuccessful(); }
 
+    /// Invoked by the client to rename the document filename.
+    /// Returns an error message in case of failure, otherwise an empty string.
+    std::string handleRenameFileCommand(std::string sessionId, std::string newFilename);
+
     /// Handle the save response from Core and upload to storage as necessary.
     /// Also notifies clients of the result.
     void handleSaveResponse(const std::string& sessionId, bool success, const std::string& result);
@@ -468,6 +472,9 @@ private:
     void handleDialogPaintResponse(const std::vector<char>& payload, bool child);
     void handleTileCombinedResponse(const std::vector<char>& payload);
     void handleDialogRequest(const std::string& dialogCmd);
+
+    /// Invoked to issue a save before renaming the document filename.
+    void startRenameFileCommand();
 
     /// Shutdown all client connections with the given reason.
     void shutdownClients(const std::string& closeReason);
@@ -1013,6 +1020,8 @@ private:
     std::atomic<bool> _stop;
     std::string _closeReason;
     std::unique_ptr<LockContext> _lockCtx;
+    std::string _renameFilename; //< The new filename to rename to.
+    std::string _renameSessionId; //< The sessionId used for renaming.
 
     /// Versioning is used to prevent races between
     /// painting and invalidation.

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -476,6 +476,10 @@ private:
     /// with the child and cleans up ChildProcess etc.
     void terminateChild(const std::string& closeReason);
 
+    /// Returns true iff the Document in Storage is
+    /// out-of-date and we must upload the last file on disk.
+    bool needToUploadToStorage() const;
+
     /// Upload the doc to the storage.
     void uploadToStorageInternal(const std::string& sessionId, bool success,
                                  const std::string& result, const std::string& saveAsPath,

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -476,7 +476,7 @@ private:
     void terminateChild(const std::string& closeReason);
 
     /// Upload the doc to the storage.
-    bool uploadToStorageInternal(const std::string& sessionId, bool success,
+    void uploadToStorageInternal(const std::string& sessionId, bool success,
                                  const std::string& result, const std::string& saveAsPath,
                                  const std::string& saveAsFilename, const bool isRename,
                                  const bool force);
@@ -490,7 +490,7 @@ private:
         const bool isRename;
     };
 
-    bool handleUploadToStorageResponse(const StorageUploadDetails& details,
+    void handleUploadToStorageResponse(const StorageUploadDetails& details,
                                        const StorageBase::UploadResult& uploadResult);
 
     /**

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -18,6 +18,7 @@
 #include <mutex>
 #include <string>
 #include <thread>
+#include <utility>
 
 #include <Poco/URI.h>
 
@@ -481,17 +482,7 @@ private:
                                  const std::string& saveAsFilename, const bool isRename,
                                  const bool force);
 
-    struct StorageUploadDetails
-    {
-        const std::string uriAnonym;
-        const std::chrono::system_clock::time_point newFileModifiedTime;
-        const std::weak_ptr<class ClientSession> session;
-        const bool isSaveAs;
-        const bool isRename;
-    };
-
-    void handleUploadToStorageResponse(const StorageUploadDetails& details,
-                                       const StorageBase::UploadResult& uploadResult);
+    void handleUploadToStorageResponse(const StorageBase::UploadResult& uploadResult);
 
     /**
      * Report back the save result to PostMessage users (Action_Save_Resp)
@@ -723,6 +714,48 @@ private:
         const bool _isAutosaveEnabled;
     };
 
+    /// Represents an upload request.
+    class UploadRequest final
+    {
+    public:
+        UploadRequest(std::string uriAnonym,
+                      std::chrono::system_clock::time_point newFileModifiedTime,
+                      const std::shared_ptr<class ClientSession>& session, bool isSaveAs,
+                      bool isRename)
+            : _startTime(std::chrono::steady_clock::now())
+            , _uriAnonym(std::move(uriAnonym))
+            , _newFileModifiedTime(newFileModifiedTime)
+            , _session(session)
+            , _isSaveAs(isSaveAs)
+            , _isRename(isRename)
+        {
+        }
+
+        const std::chrono::milliseconds timeSinceRequest() const
+        {
+            return std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::steady_clock::now() - _startTime);
+        }
+
+        const std::string& uriAnonym() const { return _uriAnonym; }
+        const std::chrono::system_clock::time_point& newFileModifiedTime() const
+        {
+            return _newFileModifiedTime;
+        }
+
+        std::shared_ptr<class ClientSession> session() const { return _session.lock(); }
+        bool isSaveAs() const { return _isSaveAs; }
+        bool isRename() const { return _isRename; }
+
+    private:
+        const std::chrono::steady_clock::time_point _startTime; //< The time we made the request.
+        const std::string _uriAnonym;
+        const std::chrono::system_clock::time_point _newFileModifiedTime;
+        const std::weak_ptr<class ClientSession> _session;
+        const bool _isSaveAs;
+        const bool _isRename;
+    };
+
     /// Responsible for managing document uploading into storage.
     class StorageManager final
     {
@@ -898,6 +931,10 @@ private:
 
     /// Manage saving in Core.
     SaveManager _saveManager;
+
+    /// The current upload request, if any.
+    /// For now we can only have one at a time.
+    std::unique_ptr<UploadRequest> _uploadRequest;
 
     /// Manage uploading to Storage.
     StorageManager _storageManager;

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -870,6 +870,19 @@ private:
             Destroyed //< Unloading complete, destruction pending.
         };
 
+        /// The current activity taking place.
+        /// Meaningful only when Status is Status::Live, but
+        /// we may Save and Upload during Status::Destroying.
+        enum class Activity
+        {
+            None, //< No particular activity.
+            Rename, //< The document is being renamed.
+            SaveAs, //< The document format is being converted.
+            Conflict, //< The document is conflicted in storaged.
+            Save, //< The document is being saved, manually or auto-save.
+            Upload, //< The document is being uploaded to storage.
+        };
+
         static std::string toString(Status status)
         {
 #define CASE(X)                                                                                    \
@@ -889,8 +902,28 @@ private:
             return "Unknown Document Status";
         }
 
+        static std::string toString(Activity activity)
+        {
+#define CASE(X)                                                                                    \
+    case X:                                                                                        \
+        return #X;
+            switch (activity)
+            {
+                CASE(Activity::None);
+                CASE(Activity::Rename);
+                CASE(Activity::SaveAs);
+                CASE(Activity::Conflict);
+                CASE(Activity::Save);
+                CASE(Activity::Upload);
+            }
+
+#undef CASE
+            return "Unknown Document Activity";
+        }
+
         DocumentState()
             : _status(Status::None)
+            , _activity(Activity::None)
             , _closeRequested(false)
             , _loaded(false)
         {
@@ -903,6 +936,14 @@ private:
                                                   << toString(newStatus));
             assert(newStatus >= _status && "The document status cannot regress");
             _status = newStatus;
+        }
+
+        DocumentState::Activity activity() const { return _activity; }
+        void setActivity(Activity newActivity)
+        {
+            LOG_TRC("Setting Document Activity from " << toString(_activity) << " to "
+                                                      << toString(newActivity));
+            _activity = newActivity;
         }
 
         /// True iff the document had ever loaded completely, without implying it's still loaded.
@@ -931,6 +972,7 @@ private:
 
     private:
         Status _status;
+        Activity _activity;
         std::atomic<bool> _closeRequested; //< Owner-Termination flag.
         std::atomic<bool> _loaded; //< If the document ever loaded (check isLive to see if it still is).
     };

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -1047,8 +1047,6 @@ std::string WopiStorage::downloadDocument(const Poco::URI& uriObject, const std:
     const std::chrono::milliseconds diff = std::chrono::duration_cast<std::chrono::milliseconds>(
         std::chrono::steady_clock::now() - startTime);
 
-    _wopiLoadDuration += diff;
-
     if (httpResponse->statusLine().statusCode() == Poco::Net::HTTPResponse::HTTP_OK)
     {
         // Log the response header.

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -409,8 +409,8 @@ StorageBase::UploadResult LocalStorage::uploadLocalFileToStorage(
                                                                      << getRootFilePathAnonym());
 
         // Copy the file back.
-        if (_isCopy && Poco::File(getRootFilePath()).exists())
-            FileUtil::copyFileTo(getRootFilePath(), path);
+        if (_isCopy && Poco::File(getRootFilePathUploading()).exists())
+            FileUtil::copyFileTo(getRootFilePathUploading(), path);
 
         // update its fileinfo object. This is used later to check if someone else changed the
         // document while we are/were editing it
@@ -1133,7 +1133,7 @@ void WopiStorage::uploadLocalFileToStorageAsync(const Authorization& auth,
     }
 
     const bool isSaveAs = !saveAsPath.empty() && !saveAsFilename.empty();
-    const std::string filePath(isSaveAs ? saveAsPath : getRootFilePath());
+    const std::string filePath(isSaveAs ? saveAsPath : getRootFilePathUploading());
     const std::string filePathAnonym = LOOLWSD::anonymizeUrl(filePath);
 
     const FileUtil::Stat fileStat(filePath);

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -1163,6 +1163,7 @@ void WopiStorage::uploadLocalFileToStorageAsync(const Authorization& auth,
     const auto startTime = std::chrono::steady_clock::now();
     try
     {
+        assert(!_uploadHttpSession && "Unexpected to have an upload http::session");
         _uploadHttpSession = getHttpSession(uriObject);
 
         http::Request httpRequest = initHttpRequest(uriObject, auth, cookies);
@@ -1244,10 +1245,15 @@ void WopiStorage::uploadLocalFileToStorageAsync(const Authorization& auth,
         http::Session::FinishedCallback finishedCallback =
             [=](const std::shared_ptr<http::Session>& httpSession)
         {
+            // Retire.
+            _uploadHttpSession.reset();
+
+            assert(httpSession && "Expected a valid http::Session");
             const std::shared_ptr<const http::Response> httpResponse = httpSession->response();
 
             _wopiSaveDuration = std::chrono::duration_cast<std::chrono::milliseconds>(
                 std::chrono::steady_clock::now() - startTime);
+            LOG_DBG("Finished async uploading in " << _wopiSaveDuration);
 
             WopiUploadDetails details = { filePathAnonym,
                                           uriAnonym,
@@ -1263,9 +1269,6 @@ void WopiStorage::uploadLocalFileToStorageAsync(const Authorization& auth,
 
             // Fire the callback to our client (DocBroker, typically).
             asyncUploadCallback(AsyncUpload(AsyncUpload::State::Complete, res));
-
-            // Retire.
-            _uploadHttpSession.reset(); //FIXME: use a state machine.
         };
 
         _uploadHttpSession->setFinishedHandler(finishedCallback);

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -1085,14 +1085,54 @@ std::string WopiStorage::downloadDocument(const Poco::URI& uriObject, const std:
         return Poco::Path(getJailPath(), getFileInfo().getFilename()).toString();
 }
 
-StorageBase::UploadResult
-WopiStorage::uploadLocalFileToStorage(const Authorization& auth, const std::string& cookies,
-                                      LockContext& lockCtx, const std::string& saveAsPath,
-                                      const std::string& saveAsFilename, const bool isRename)
+/// A helper class to invoke the AsyncUploadCallback
+/// when it exits its scope.
+/// By default it invokes the callback with a failure state.
+class ScopedInvokeAsyncUploadCallback
+{
+public:
+    ScopedInvokeAsyncUploadCallback(StorageBase::AsyncUploadCallback asyncUploadCallback)
+        : _asyncUploadCallback(std::move(asyncUploadCallback))
+        , _arg(StorageBase::AsyncUpload(
+              StorageBase::AsyncUpload::State::Error,
+              StorageBase::UploadResult(StorageBase::UploadResult::Result::FAILED)))
+    {
+    }
+
+    ~ScopedInvokeAsyncUploadCallback()
+    {
+        if (_asyncUploadCallback)
+            _asyncUploadCallback(_arg);
+    }
+
+    /// Set a new callback argument.
+    void setArg(StorageBase::AsyncUpload arg) { _arg = std::move(arg); }
+
+private:
+    StorageBase::AsyncUploadCallback _asyncUploadCallback;
+    StorageBase::AsyncUpload _arg;
+};
+
+void WopiStorage::uploadLocalFileToStorageAsync(const Authorization& auth,
+                                                const std::string& cookies, LockContext& lockCtx,
+                                                const std::string& saveAsPath,
+                                                const std::string& saveAsFilename,
+                                                const bool isRename, SocketPoll& socketPoll,
+                                                const AsyncUploadCallback& asyncUploadCallback)
 {
     ProfileZone profileZone("WopiStorage::uploadLocalFileToStorage", { {"url", _fileUrl} });
 
     // TODO: Check if this URI has write permission (canWrite = true)
+
+    // Always invoke the callback with the result of the async upload.
+    ScopedInvokeAsyncUploadCallback scopedInvokeCallback(asyncUploadCallback);
+
+    //TODO: replace with state machine.
+    if (_uploadHttpSession)
+    {
+        LOG_ERR("Upload is already in progress.");
+        return;
+    }
 
     const bool isSaveAs = !saveAsPath.empty() && !saveAsFilename.empty();
     const std::string filePath(isSaveAs ? saveAsPath : getRootFilePath());
@@ -1102,7 +1142,10 @@ WopiStorage::uploadLocalFileToStorage(const Authorization& auth, const std::stri
     if (!fileStat.good())
     {
         LOG_ERR("Cannot access file [" << filePathAnonym << "] to upload to wopi storage.");
-        return UploadResult(UploadResult::Result::FAILED, "File not found.");
+        scopedInvokeCallback.setArg(
+            AsyncUpload(AsyncUpload::State::Error,
+                        UploadResult(UploadResult::Result::FAILED, "File not found.")));
+        return;
     }
 
     const std::size_t size = (fileStat.good() ? fileStat.size() : 0);
@@ -1120,7 +1163,7 @@ WopiStorage::uploadLocalFileToStorage(const Authorization& auth, const std::stri
     const auto startTime = std::chrono::steady_clock::now();
     try
     {
-        std::shared_ptr<http::Session> httpSession = getHttpSession(uriObject);
+        _uploadHttpSession = getHttpSession(uriObject);
 
         http::Request httpRequest = initHttpRequest(uriObject, auth, cookies);
         httpRequest.setVerb(http::Request::VERB_POST);
@@ -1198,22 +1241,43 @@ WopiStorage::uploadLocalFileToStorage(const Authorization& auth, const std::stri
 
         httpRequest.setBodyFile(filePath);
 
+        http::Session::FinishedCallback finishedCallback =
+            [=](const std::shared_ptr<http::Session>& httpSession)
+        {
+            const std::shared_ptr<const http::Response> httpResponse = httpSession->response();
+
+            _wopiSaveDuration = std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::steady_clock::now() - startTime);
+
+            WopiUploadDetails details = { filePathAnonym,
+                                          uriAnonym,
+                                          httpResponse->statusLine().reasonPhrase(),
+                                          httpResponse->statusLine().statusCode(),
+                                          size,
+                                          isSaveAs,
+                                          isRename };
+
+            // Handle the response.
+            const StorageBase::UploadResult res =
+                handleUploadToStorageResponse(details, httpResponse->getBody());
+
+            // Fire the callback to our client (DocBroker, typically).
+            asyncUploadCallback(AsyncUpload(AsyncUpload::State::Complete, res));
+
+            // Retire.
+            _uploadHttpSession.reset(); //FIXME: use a state machine.
+        };
+
+        _uploadHttpSession->setFinishedHandler(finishedCallback);
+
+        LOG_DBG("Async upload request: " << httpRequest.header().toString());
+
         // Make the request.
-        const std::shared_ptr<const http::Response> httpResponse
-            = httpSession->syncRequest(httpRequest);
+        _uploadHttpSession->asyncRequest(httpRequest, socketPoll);
 
-        _wopiSaveDuration = std::chrono::duration_cast<std::chrono::milliseconds>(
-            std::chrono::steady_clock::now() - startTime);
-
-        WopiUploadDetails details = { filePathAnonym,
-                                      uriAnonym,
-                                      httpResponse->statusLine().reasonPhrase(),
-                                      httpResponse->statusLine().statusCode(),
-                                      size,
-                                      isSaveAs,
-                                      isRename };
-
-        return handleUploadToStorageResponse(details, httpResponse->getBody());
+        scopedInvokeCallback.setArg(
+            AsyncUpload(AsyncUpload::State::Running, UploadResult(UploadResult::Result::OK)));
+        return;
     }
     catch (const Poco::Exception& ex)
     {
@@ -1226,7 +1290,16 @@ WopiStorage::uploadLocalFileToStorage(const Authorization& auth, const std::stri
         LOG_ERR("Cannot upload file to WOPI storage uri [" + uriAnonym + "]. Error: " << ex.what());
     }
 
-    return UploadResult(UploadResult::Result::FAILED, "Internal error.");
+    scopedInvokeCallback.setArg(AsyncUpload(
+        AsyncUpload::State::Error, UploadResult(UploadResult::Result::FAILED, "Internal error.")));
+}
+
+StorageBase::UploadResult WopiStorage::uploadLocalFileToStorage(const Authorization&,
+                                                                const std::string&, LockContext&,
+                                                                const std::string&,
+                                                                const std::string&, const bool)
+{
+    return UploadResult(UploadResult::Result::FAILED);
 }
 
 StorageBase::UploadResult
@@ -1276,8 +1349,8 @@ WopiStorage::handleUploadToStorageResponse(const WopiUploadDetails& details,
                 }
             }
 
-            LOG_INF(wopiLog << " uploaded " << details.size << " bytes from ["
-                            << details.filePathAnonym << "] -> [" << details.uriAnonym
+            LOG_INF(wopiLog << " uploaded " << details.size << " bytes in " << _wopiSaveDuration
+                            << " from [" << details.filePathAnonym << "] -> [" << details.uriAnonym
                             << "]: " << details.httpResponseCode << ' '
                             << details.httpResponseReason << ": " << responseString);
         }

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -1128,7 +1128,7 @@ void WopiStorage::uploadLocalFileToStorageAsync(const Authorization& auth,
     //TODO: replace with state machine.
     if (_uploadHttpSession)
     {
-        LOG_ERR("Upload is already in progress.");
+        LOG_WRN("Upload is already in progress.");
         return;
     }
 

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -18,6 +18,7 @@
 #include <Poco/JSON/Object.h>
 
 #include "Auth.hpp"
+#include "HttpRequest.hpp"
 #include "LOOLWSD.hpp"
 #include "Log.hpp"
 #include "Util.hpp"
@@ -152,6 +153,35 @@ public:
         std::string _reason;
     };
 
+    /// The state of an asynchronous upload request.
+    class AsyncUpload final
+    {
+    public:
+        enum class State
+        {
+            None, //< No async upload in progress or isn't supported.
+            Running, //< An async upload request is in progress.
+            Error, //< Failed to make an async upload request or timed out, no UploadResult.
+            Complete //< The last async upload request completed (regardless of the server's response).
+        };
+
+        AsyncUpload(State state, UploadResult result = UploadResult(UploadResult::Result::FAILED))
+            : _state(state)
+            , _result(std::move(result))
+        {
+        }
+
+        /// Returns the state of the async upload.
+        State state() const { return _state; }
+
+        /// Returns the result of the async upload.
+        const UploadResult& result() const { return _result; }
+
+    private:
+        const State _state;
+        UploadResult _result;
+    };
+
     enum class LOOLStatusCode
     {
         DOC_CHANGED = 1010 // Document changed externally in storage
@@ -250,6 +280,33 @@ public:
                              LockContext& lockCtx, const std::string& saveAsPath,
                              const std::string& saveAsFilename, const bool isRename)
         = 0;
+
+    /// Writes the contents of the file back to the source asynchronously, if possible.
+    /// @param cookies A string representing key=value pairs that are set as cookies.
+    /// @param savedFile When the operation was saveAs, this is the path to the file that was saved.
+    virtual AsyncUpload
+    uploadLocalFileToStorageAsync(const Authorization& auth, const std::string& cookies,
+                                  LockContext& lockCtx, const std::string& saveAsPath,
+                                  const std::string& saveAsFilename, const bool isRename)
+    {
+        // By default do a synchronous save.
+        const UploadResult res = uploadLocalFileToStorage(auth, cookies, lockCtx, saveAsPath,
+                                                          saveAsFilename, isRename);
+        return AsyncUpload(AsyncUpload::State::Complete, res);
+    }
+
+    /// Get the progress state of an asynchronous LocalFileToStorage upload.
+    virtual AsyncUpload queryLocalFileToStorageAsyncUploadState()
+    {
+        // Unsupported.
+        return AsyncUpload(AsyncUpload::State::None);
+    }
+
+    /// Cancels an active asynchronous LocalFileToStorage upload.
+    virtual void cancelLocalFileToStorageAsyncUpload()
+    {
+        // By default, nothing to do.
+    }
 
     /// Must be called at startup to configure.
     static void initialize();

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -165,7 +165,7 @@ public:
             Complete //< The last async upload request completed (regardless of the server's response).
         };
 
-        AsyncUpload(State state, UploadResult result = UploadResult(UploadResult::Result::FAILED))
+        AsyncUpload(State state, UploadResult result)
             : _state(state)
             , _result(std::move(result))
         {
@@ -178,7 +178,7 @@ public:
         const UploadResult& result() const { return _result; }
 
     private:
-        const State _state;
+        State _state;
         UploadResult _result;
     };
 
@@ -281,25 +281,32 @@ public:
                              const std::string& saveAsFilename, const bool isRename)
         = 0;
 
+    /// The asynchronous upload completion callback function.
+    using AsyncUploadCallback = std::function<void(const AsyncUpload&)>;
+
     /// Writes the contents of the file back to the source asynchronously, if possible.
     /// @param cookies A string representing key=value pairs that are set as cookies.
     /// @param savedFile When the operation was saveAs, this is the path to the file that was saved.
-    virtual AsyncUpload
-    uploadLocalFileToStorageAsync(const Authorization& auth, const std::string& cookies,
-                                  LockContext& lockCtx, const std::string& saveAsPath,
-                                  const std::string& saveAsFilename, const bool isRename)
+    /// @param asyncUploadCallback Used to communicate the result back to the caller.
+    virtual void uploadLocalFileToStorageAsync(const Authorization& auth,
+                                               const std::string& cookies, LockContext& lockCtx,
+                                               const std::string& saveAsPath,
+                                               const std::string& saveAsFilename,
+                                               const bool isRename, SocketPoll&,
+                                               const AsyncUploadCallback& asyncUploadCallback)
     {
         // By default do a synchronous save.
-        const UploadResult res = uploadLocalFileToStorage(auth, cookies, lockCtx, saveAsPath,
-                                                          saveAsFilename, isRename);
-        return AsyncUpload(AsyncUpload::State::Complete, res);
+        const UploadResult res =
+            uploadLocalFileToStorage(auth, cookies, lockCtx, saveAsPath, saveAsFilename, isRename);
+        if (asyncUploadCallback)
+            asyncUploadCallback(AsyncUpload(AsyncUpload::State::Complete, res));
     }
 
     /// Get the progress state of an asynchronous LocalFileToStorage upload.
     virtual AsyncUpload queryLocalFileToStorageAsyncUploadState()
     {
         // Unsupported.
-        return AsyncUpload(AsyncUpload::State::None);
+        return AsyncUpload(AsyncUpload::State::None, UploadResult(UploadResult::Result::OK));
     }
 
     /// Cancels an active asynchronous LocalFileToStorage upload.
@@ -571,7 +578,13 @@ public:
                                           const std::string& saveAsFilename,
                                           const bool isRename) override;
 
-    /// Total time taken for making WOPI calls during saving.
+    void uploadLocalFileToStorageAsync(const Authorization& auth, const std::string& cookies,
+                                       LockContext& lockCtx, const std::string& saveAsPath,
+                                       const std::string& saveAsFilename, const bool isRename,
+                                       SocketPoll& socketPoll,
+                                       const AsyncUploadCallback& asyncUploadCallback) override;
+
+    /// Total time taken for making WOPI calls during uploading.
     std::chrono::milliseconds getWopiSaveDuration() const { return _wopiSaveDuration; }
 
 protected:
@@ -611,6 +624,10 @@ private:
 
     // Time spend in saving the file from storage
     std::chrono::milliseconds _wopiSaveDuration;
+
+    /// The http::Session used for uploading asynchronously.
+    std::shared_ptr<http::Session> _uploadHttpSession;
+
     /// Whether or not to re-use cookies from the browser for the WOPI requests.
     bool _reuseCookies;
 };

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -88,8 +88,10 @@ public:
 
         const std::string& getOwnerId() const { return _ownerId; }
 
+        /// Set the modified time as reported to the WOPI host.
         void setModifiedTime(const std::chrono::system_clock::time_point& modifiedTime) { _modifiedTime = modifiedTime; }
 
+        /// Get the modified time as reported by the WOPI host.
         const std::chrono::system_clock::time_point& getModifiedTime() const { return _modifiedTime; }
 
     private:

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -571,8 +571,7 @@ public:
                                           const std::string& saveAsFilename,
                                           const bool isRename) override;
 
-    /// Total time taken for making WOPI calls during load
-    std::chrono::milliseconds getWopiLoadDuration() const { return _wopiLoadDuration; }
+    /// Total time taken for making WOPI calls during saving.
     std::chrono::milliseconds getWopiSaveDuration() const { return _wopiSaveDuration; }
 
 protected:
@@ -610,8 +609,7 @@ private:
     /// A URl provided by the WOPI host to use for GetFile.
     std::string _fileUrl;
 
-    // Time spend in loading the file from storage
-    std::chrono::milliseconds _wopiLoadDuration;
+    // Time spend in saving the file from storage
     std::chrono::milliseconds _wopiSaveDuration;
     /// Whether or not to re-use cookies from the browser for the WOPI requests.
     bool _reuseCookies;

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -216,6 +216,15 @@ public:
     /// Returns the root path to the jailed file.
     const std::string& getRootFilePath() const { return _jailedFilePath; };
 
+    /// Returns the root path to the jailed file to be uploaded.
+    std::string getRootFilePathToUpload() const { return _jailedFilePath + TO_UPLOAD_SUFFIX; };
+
+    /// Returns the root path to the jailed file being uploaded.
+    std::string getRootFilePathUploading() const
+    {
+        return _jailedFilePath + TO_UPLOAD_SUFFIX + UPLOADING_SUFFIX;
+    };
+
     /// Set the root path of the jailed file, only for use in cases where we actually have converted
     /// it to another format, in the same directory
     void setRootFilePath(const std::string& newPath)


### PR DESCRIPTION
- wsd: document ModifiedTime getter/setter
- wsd: typo in argument name sessionId
- wsd: correct sha1 logging of the downloaded doc
- wsd: http: simplify sending response and shutting down the socket
- wsd: http: better logging of errors
- wsd: http: better logs
- wsd: correct conditional scope
- wsd: add async API to Storage
- wsd: remove unsused return values
- wsd: support asynchronous upload requests to storage
- wsd: correct GetFile duration tracking
- wsd: handle async upload callback
- wsd: upload after saving only if necessary
- wsd: better logging of upload state
- wsd: better logging of autosave, upload, and modified states
- wsd: test: use http objects instead of manual strings
- wsd: test: assertPutFileRequest returns the http response
- wsd: test: safe header reader
- wsd: test: log the fake wopi response
- wsd: test: add async upload test on closing
- wsd: test: add async upload test to modify after fail
- wsd: DocumentBroker::needToUploadToStorage now returns an enum
- wsd: stop after successfully uploading
- wsd: name session variable instead of opaque iterator
- wsd: simply passing the authorization object to the storage
- wsd: logs and assertion in upload completion handler
- wsd: track user issued activities on the document
- wsd: handle renameFile command with async uploading
- wsd: set the timestamp of the file in storage after downloading
- wsd: resuse Stat where possible
- wsd: rename file after saving to support async uploading
- wsd: support uploading after loading from a template
- wsd: postpone autosave
- wsd: no autosaving during other activities
- wsd: un/block the UI during renaming
- wsd: failure to upload is not an error
