### PR TITLE
restore redline as comments functionality

### DIFF
--- a/loleaflet/src/layer/tile/CommentListSection.ts
+++ b/loleaflet/src/layer/tile/CommentListSection.ts
@@ -887,6 +887,10 @@ class CommentSection {
 	public onACKComment (obj: any) {
 		var id;
 		var changetrack = obj.redline ? true : false;
+		var dataroot = changetrack ? 'redline' : 'comment';
+		if (changetrack) {
+			obj.redline.id = 'change-' + obj.redline.index;
+		}
 		var action = changetrack ? obj.redline.action : obj.comment.action;
 
 		if (changetrack && obj.redline.author in this.map._viewInfoByUserName) {
@@ -897,9 +901,9 @@ class CommentSection {
 		}
 
 		if ((<any>window).mode.isMobile()) {
-			var annotation = this.sectionProperties.commentList[this.getRootIndexOf(obj.comment.id)];
+			var annotation = this.sectionProperties.commentList[this.getRootIndexOf(obj[dataroot].id)];
 			if (!annotation)
-				annotation = this.sectionProperties.commentList[this.getRootIndexOf(obj.comment.parent)]; //this is required for reload after reply in writer
+				annotation = this.sectionProperties.commentList[this.getRootIndexOf(obj[dataroot].parent)]; //this is required for reload after reply in writer
 		}
 		if (action === 'Add') {
 			if (changetrack) {
@@ -916,18 +920,18 @@ class CommentSection {
 			if (this.sectionProperties.selectedComment && !this.sectionProperties.selectedComment.isEdit()) {
 				this.map.focus();
 			}
-			annotation = this.sectionProperties.commentList[this.getRootIndexOf(obj.comment.id)];
+			annotation = this.sectionProperties.commentList[this.getRootIndexOf(obj[dataroot].id)];
 			if (!(<any>window).mode.isMobile())
 				this.layout();
 		} else if (action === 'Remove') {
-			if ((<any>window).mode.isMobile() && obj.comment.id === annotation.sectionProperties.data.id) {
-				var child = this.sectionProperties.commentList[this.getIndexOf(obj.comment.id) + 1];
+			if ((<any>window).mode.isMobile() && obj[dataroot].id === annotation.sectionProperties.data.id) {
+				var child = this.sectionProperties.commentList[this.getIndexOf(obj[dataroot].id) + 1];
 				if (child && child.sectionProperties.data.parent === annotation.sectionProperties.data.id)
 					annotation = child;
 				else
 					annotation = undefined;
 			}
-			id = changetrack ? 'change-' + obj.redline.index : obj.comment.id;
+			id = obj[dataroot].id;
 			var removed = this.getComment(id);
 			if (removed) {
 				this.adjustParentRemove(removed);
@@ -939,7 +943,7 @@ class CommentSection {
 				}
 			}
 		} else if (action === 'Modify') {
-			id = changetrack ? 'change-' + obj.redline.index : obj.comment.id;
+			id = obj[dataroot].id;
 			var modified = this.getComment(id);
 			if (modified) {
 				var modifiedObj;
@@ -958,7 +962,7 @@ class CommentSection {
 				this.update();
 			}
 		} else if (action === 'Resolve') {
-			id = changetrack ? 'change-' + obj.redline.index : obj.comment.id;
+			id = obj[dataroot].id;
 			var resolved = this.getComment(id);
 			if (resolved) {
 				var resolvedObj;

--- a/loleaflet/src/layer/tile/CommentListSection.ts
+++ b/loleaflet/src/layer/tile/CommentListSection.ts
@@ -826,8 +826,8 @@ class CommentSection {
 
 		// transform change tracking index into an id
 		redline.id = 'change-' + redline.index;
-		redline.anchorPos = L.LOUtil.stringToBounds(redline.textRange);
-		redline.anchorPix = this.sectionProperties.docLayer._twipsToPixels(redline.anchorPos.min);
+		redline.anchorPos = this.stringToRectangles(redline.textRange)[0];
+		redline.anchorPix = this.numberArrayToCorePixFromTwips(redline.anchorPos, 0, 2);
 		redline.trackchange = true;
 		redline.text = redline.comment;
 		var rectangles = L.PolyUtil.rectanglesToPolygons(L.LOUtil.stringToRectangles(redline.textRange), this.sectionProperties.docLayer);
@@ -1499,6 +1499,49 @@ class CommentSection {
 
 		if (this.sectionProperties.docLayer._docType === 'spreadsheet')
 			this.hideAllComments(); // Apply drawing orders.
+	}
+
+	// Accepts redlines/changes comments.
+	public importChanges (changesList: any) {
+		var changeComment;
+		this.clearChanges();
+		changesList = this.turnIntoAList(changesList);
+
+		if (changesList.length > 0) {
+			for (var i = 0; i < changesList.length; i++) {
+				changeComment = changesList[i];
+				if (!this.adjustRedLine(changeComment))
+					// something wrong in this redline, skip this one
+					continue;
+
+				if (changeComment.author in this.map._viewInfoByUserName) {
+					changeComment.avatar = this.map._viewInfoByUserName[changeComment.author].userextrainfo.avatar;
+				}
+				var commentSection = new app.definitions.Comment(changeComment, {}, this);
+				this.containerObject.addSection(commentSection);
+				this.sectionProperties.commentList.push(commentSection);
+			}
+
+			this.orderCommentList();
+			this.checkSize();
+			this.layout();
+		}
+
+		if (this.sectionProperties.docLayer._docType === 'spreadsheet')
+			this.hideAllComments(); // Apply drawing orders.
+	}
+
+	// Remove redline comments.
+	private clearChanges() {
+		for (var i: number = this.sectionProperties.commentList.length -1; i > -1; i--) {
+			if (this.sectionProperties.commentList[i].trackchange) {
+				this.containerObject.removeSection(this.sectionProperties.commentList[i].name);
+				this.sectionProperties.commentList.splice(i, 1);
+			}
+		}
+
+		this.sectionProperties.selectedComment = null;
+		this.checkSize();
 	}
 
 	// Remove only text comments from the document (excluding change tracking comments)

--- a/loleaflet/src/layer/tile/WriterTileLayer.js
+++ b/loleaflet/src/layer/tile/WriterTileLayer.js
@@ -44,7 +44,7 @@ L.WriterTileLayer = L.CanvasTileLayer.extend({
 			app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).importComments(values.comments);
 		}
 		else if (values.redlines && values.redlines.length > 0) {
-			this._annotations.fillChanges(values.redlines);
+			app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).importChanges(values.redlines);
 		}
 		else {
 			L.TileLayer.prototype._onCommandValuesMsg.call(this, textMsg);


### PR DESCRIPTION
- Introduce missing redline methods.
- Fix anchorPos, anchorPix computation.

Signed-off-by: Dennis Francis <dennis.francis@collabora.com>
Change-Id: Ifce70f4e9fc9f751035d86f1da9a05774e9d69dd


* Resolves: # <!-- related github issue -->
* Target version: co-6-4

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

