### PR TITLE
HTTP 302 Found - redirrect support for getWOPIFileInfo

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -45,7 +45,8 @@ noinst_LTLIBRARIES = \
 	unit-wopi-loadencoded.la \
 	unit-wopi-temp.la \
 	unit-wopi-fileurl.la \
-	unit-wopi-httpheaders.la
+	unit-wopi-httpheaders.la \
+	unit-wopi-httpredirect.la
 
 MAGIC_TO_FORCE_SHLIB_CREATION = -rpath /dummy
 AM_LDFLAGS = -pthread -module $(MAGIC_TO_FORCE_SHLIB_CREATION) $(ZLIB_LIBS)
@@ -176,6 +177,8 @@ unit_wopi_fileurl_la_SOURCES = UnitWOPIFileUrl.cpp
 unit_wopi_fileurl_la_LIBADD = $(CPPUNIT_LIBS)
 unit_wopi_httpheaders_la_SOURCES = UnitWOPIHttpHeaders.cpp
 unit_wopi_httpheaders_la_LIBADD = $(CPPUNIT_LIBS)
+unit_wopi_httpredirect_la_SOURCES = UnitWOPIHttpRedirect.cpp
+unit_wopi_httpredirect_la_LIBADD = $(CPPUNIT_LIBS)
 unit_tiff_load_la_SOURCES = UnitTiffLoad.cpp
 unit_tiff_load_la_LIBADD = $(CPPUNIT_LIBS)
 unit_large_paste_la_SOURCES = UnitLargePaste.cpp
@@ -257,6 +260,7 @@ TESTS = \
 	unit-wopi-temp.la \
 	unit-wopi-fileurl.la \
 	unit-wopi-httpheaders.la \
+	unit-wopi-httpredirect.la \
 	unithttplib
 # TESTS += unit-admin.test
 # TESTS += unit-storage.test

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -46,7 +46,8 @@ noinst_LTLIBRARIES = \
 	unit-wopi-temp.la \
 	unit-wopi-fileurl.la \
 	unit-wopi-httpheaders.la \
-	unit-wopi-httpredirect.la
+	unit-wopi-httpredirect.la \
+	unit-wopi-httpredirectloop.la
 
 MAGIC_TO_FORCE_SHLIB_CREATION = -rpath /dummy
 AM_LDFLAGS = -pthread -module $(MAGIC_TO_FORCE_SHLIB_CREATION) $(ZLIB_LIBS)
@@ -179,6 +180,8 @@ unit_wopi_httpheaders_la_SOURCES = UnitWOPIHttpHeaders.cpp
 unit_wopi_httpheaders_la_LIBADD = $(CPPUNIT_LIBS)
 unit_wopi_httpredirect_la_SOURCES = UnitWOPIHttpRedirect.cpp
 unit_wopi_httpredirect_la_LIBADD = $(CPPUNIT_LIBS)
+unit_wopi_httpredirectloop_la_SOURCES = UnitWOPIHttpRedirectLoop.cpp
+unit_wopi_httpredirectloop_la_LIBADD = $(CPPUNIT_LIBS)
 unit_tiff_load_la_SOURCES = UnitTiffLoad.cpp
 unit_tiff_load_la_LIBADD = $(CPPUNIT_LIBS)
 unit_large_paste_la_SOURCES = UnitLargePaste.cpp
@@ -261,6 +264,7 @@ TESTS = \
 	unit-wopi-fileurl.la \
 	unit-wopi-httpheaders.la \
 	unit-wopi-httpredirect.la \
+	unit-wopi-httpredirectloop.la \
 	unithttplib
 # TESTS += unit-admin.test
 # TESTS += unit-storage.test

--- a/test/UnitWOPIHttpRedirect.cpp
+++ b/test/UnitWOPIHttpRedirect.cpp
@@ -22,6 +22,7 @@ class UnitWopiHttpRedirect : public WopiTestServer
         Load,
         Redirected,
         GetFile,
+        Redirected2,
         Loaded
     } _phase;
 
@@ -44,6 +45,8 @@ public:
         std::string redirectUri = "/wopi/files/0";
         Poco::RegularExpression regRedirected(redirectUri);
         Poco::RegularExpression regContents("/wopi/files/0/contents");
+        std::string redirectUri2 = "/wopi/files/2/contents";
+        Poco::RegularExpression regContentsRedirected(redirectUri2);
 
         LOG_INF("Fake wopi host request URI [" << uriReq.toString() << "]:\n");
 
@@ -112,7 +115,7 @@ public:
 
             return true;
         }
-        // GetFile - for redirected URI
+        // GetFile - first try
         else if (request.getMethod() == "GET" && regContents.match(uriReq.getPath()))
         {
             LOG_TST("Fake wopi host request, handling GetFile: " << uriReq.getPath());
@@ -120,6 +123,26 @@ public:
             assertGetFileRequest(request);
 
             LOK_ASSERT_MESSAGE("Expected to be in Phase::GetFile", _phase == Phase::GetFile);
+            _phase = Phase::Redirected2;
+
+            std::ostringstream oss;
+            oss << "HTTP/1.1 302 Found\r\n"
+                "Location: " << helpers::getTestServerURI() << redirectUri2 << "?" << params << "\r\n"
+                "\r\n";
+
+            socket->send(oss.str());
+            socket->shutdown();
+
+            return true;
+        }
+        // GetFile - redirected
+        else if (request.getMethod() == "GET" && regContentsRedirected.match(uriReq.getPath()))
+        {
+            LOG_TST("Fake wopi host request, handling GetFile: " << uriReq.getPath());
+
+            assertGetFileRequest(request);
+
+            LOK_ASSERT_MESSAGE("Expected to be in Phase::Redirected2", _phase == Phase::Redirected2);
             _phase = Phase::Loaded;
 
             const std::string mimeType = "text/plain; charset=utf-8";
@@ -158,6 +181,7 @@ public:
                 break;
             }
             case Phase::Redirected:
+            case Phase::Redirected2:
             case Phase::GetFile:
             {
                 break;

--- a/test/UnitWOPIHttpRedirect.cpp
+++ b/test/UnitWOPIHttpRedirect.cpp
@@ -1,0 +1,139 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <config.h>
+
+#include "WopiTestServer.hpp"
+#include <Log.hpp>
+#include <Unit.hpp>
+#include <UnitHTTP.hpp>
+#include <helpers.hpp>
+
+#include <Poco/Net/HTTPRequest.h>
+
+class UnitWopiHttpRedirect : public WopiTestServer
+{
+    enum class Phase
+    {
+        Load,
+        Redirected,
+    } _phase;
+
+    const std::string params = "access_token=anything";
+    static constexpr auto testname = "UnitWopiHttpRedirect";
+
+public:
+    UnitWopiHttpRedirect()
+        : WopiTestServer(testname)
+        , _phase(Phase::Load)
+    {
+    }
+
+    virtual bool handleHttpRequest(const Poco::Net::HTTPRequest& request,
+                                   Poco::MemoryInputStream& message,
+                                   std::shared_ptr<StreamSocket>& socket) override
+    {
+        Poco::URI uriReq(request.getURI());
+        Poco::RegularExpression regInfo("/wopi/files/1");
+        Poco::RegularExpression regContents("/wopi/files/[0-9]/contents");
+        std::string redirectUri = "/wopi/files/0";
+        Poco::RegularExpression regRedirected(redirectUri);
+
+        LOG_INF("Fake wopi host request URI [" << uriReq.toString() << "]:\n");
+
+        // CheckFileInfo - returns redirect response
+        if (request.getMethod() == "GET" && regInfo.match(uriReq.getPath()) && !regContents.match(uriReq.getPath()))
+        {
+            LOG_INF("Fake wopi host request, handling CheckFileInfo (1/2)");
+            LOK_ASSERT_MESSAGE("Expected to be in Phase::Load", _phase == Phase::Load);
+
+            assertCheckFileInfoRequest(request);
+
+            std::ostringstream oss;
+            oss << "HTTP/1.1 302 Found\r\n"
+                "Location: " << helpers::getTestServerURI() << redirectUri << "?" << params << "\r\n"
+                "\r\n";
+
+            socket->send(oss.str());
+            socket->shutdown();
+
+            _phase = Phase::Redirected;
+
+            return true;
+        }
+        // CheckFileInfo - for redirected URI
+        else if (request.getMethod() == "GET" && regRedirected.match(uriReq.getPath()) && !regContents.match(uriReq.getPath()))
+        {
+            LOG_INF("Fake wopi host request, handling CheckFileInfo: (2/2)");
+            LOK_ASSERT_MESSAGE("Expected to be in Phase::Redirected", _phase == Phase::Redirected);
+
+            assertCheckFileInfoRequest(request);
+
+            Poco::LocalDateTime now;
+            const std::string fileName(uriReq.getPath() == "/wopi/files/3" ? "he%llo.txt" : "hello.txt");
+            Poco::JSON::Object::Ptr fileInfo = new Poco::JSON::Object();
+            fileInfo->set("BaseFileName", fileName);
+            fileInfo->set("Size", _fileContent.size());
+            fileInfo->set("Version", "1.0");
+            fileInfo->set("OwnerId", "test");
+            fileInfo->set("UserId", "test");
+            fileInfo->set("UserFriendlyName", "test");
+            fileInfo->set("UserCanWrite", "true");
+            fileInfo->set("PostMessageOrigin", "localhost");
+            fileInfo->set("LastModifiedTime", Util::getIso8601FracformatTime(_fileLastModifiedTime));
+            fileInfo->set("EnableOwnerTermination", "true");
+
+            std::ostringstream jsonStream;
+            fileInfo->stringify(jsonStream);
+            std::string responseString = jsonStream.str();
+
+            const std::string mimeType = "application/json; charset=utf-8";
+
+            std::ostringstream oss;
+            oss << "HTTP/1.1 200 OK\r\n"
+                "Last-Modified: " << Util::getHttpTime(_fileLastModifiedTime) << "\r\n"
+                "User-Agent: " WOPI_AGENT_STRING "\r\n"
+                "Content-Length: " << responseString.size() << "\r\n"
+                "Content-Type: " << mimeType << "\r\n"
+                "\r\n"
+                << responseString;
+
+            socket->send(oss.str());
+            socket->shutdown();
+
+            exitTest(TestResult::Ok);
+
+            return true;
+        }
+
+        return WopiTestServer::handleHttpRequest(request, message, socket);
+    }
+
+    void invokeWSDTest() override
+    {
+        switch (_phase)
+        {
+            case Phase::Load:
+            {
+                initWebsocket("/wopi/files/1?" + params);
+
+                WSD_CMD("load url=" + getWopiSrc());
+                SocketPoll::wakeupWorld();
+
+                break;
+            }
+            case Phase::Redirected:
+            {
+                break;
+            }
+        }
+    }
+};
+
+UnitBase* unit_create_wsd(void) { return new UnitWopiHttpRedirect(); }
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/test/UnitWOPIHttpRedirectLoop.cpp
+++ b/test/UnitWOPIHttpRedirectLoop.cpp
@@ -1,0 +1,105 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <config.h>
+
+#include "WopiTestServer.hpp"
+#include <Log.hpp>
+#include <Unit.hpp>
+#include <UnitHTTP.hpp>
+#include <helpers.hpp>
+
+#include <Poco/Net/HTTPRequest.h>
+
+class UnitWopiHttpRedirectLoop : public WopiTestServer
+{
+    enum class Phase
+    {
+        Load,
+        Redirected,
+        Polling
+    } _phase;
+
+    const std::string params = "access_token=anything";
+    static constexpr auto testname = "UnitWopiHttpRedirectLoop";
+
+public:
+    UnitWopiHttpRedirectLoop()
+        : WopiTestServer(testname)
+        , _phase(Phase::Load)
+    {
+    }
+
+    virtual bool handleHttpRequest(const Poco::Net::HTTPRequest& request,
+                                   Poco::MemoryInputStream& /*message*/,
+                                   std::shared_ptr<StreamSocket>& socket) override
+    {
+        Poco::URI uriReq(request.getURI());
+        Poco::RegularExpression regInfo("/wopi/files/[0-9]+");
+        std::string redirectUri = "/wopi/files/";
+        static unsigned fileId = 1;
+
+        LOG_INF("Fake wopi host request URI [" << uriReq.toString() << "]:\n");
+
+        // CheckFileInfo - always returns redirect response
+        if (request.getMethod() == "GET" && regInfo.match(uriReq.getPath()))
+        {
+            LOG_INF("Fake wopi host request, handling CheckFileInfo");
+
+            assertCheckFileInfoRequest(request);
+
+            LOK_ASSERT_MESSAGE("It is expected to stop requesting after 21 redirections", fileId <= 22);
+
+            LOK_ASSERT_MESSAGE("Expected to be in Phase::Load or Phase::Redirected", _phase == Phase::Load || _phase == Phase::Redirected);
+            _phase = Phase::Redirected;
+
+            if (fileId == 22)
+                _phase = Phase::Polling;
+
+            std::ostringstream oss;
+            oss << "HTTP/1.1 302 Found\r\n"
+                "Location: " << helpers::getTestServerURI() << redirectUri << fileId++ << "?" << params << "\r\n"
+                "\r\n";
+
+            socket->send(oss.str());
+            socket->shutdown();
+
+            return true;
+        }
+
+        return false;
+    }
+
+    void invokeWSDTest() override
+    {
+        switch (_phase)
+        {
+            case Phase::Load:
+            {
+                initWebsocket("/wopi/files/0?" + params);
+
+                WSD_CMD("load url=" + getWopiSrc());
+                SocketPoll::wakeupWorld();
+
+                break;
+            }
+            case Phase::Redirected:
+            {
+                break;
+            }
+            case Phase::Polling:
+            {
+                exitTest(TestResult::Ok);
+                break;
+            }
+        }
+    }
+};
+
+UnitBase* unit_create_wsd(void) { return new UnitWopiHttpRedirectLoop(); }
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/test/WopiTestServer.hpp
+++ b/test/WopiTestServer.hpp
@@ -37,13 +37,14 @@ private:
     /// Websocket to communicate.
     std::unique_ptr<UnitWebSocket> _ws;
 
+protected:
+
     /// Content of the file.
     std::string _fileContent;
 
     /// Last modified time of the file
     std::chrono::system_clock::time_point _fileLastModifiedTime;
 
-protected:
     const std::string& getWopiSrc() const { return _wopiSrc; }
 
     const std::unique_ptr<UnitWebSocket>& getWs() const { return _ws; }

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -1079,6 +1079,15 @@ std::string WopiStorage::downloadDocument(const Poco::URI& uriObject, const std:
             LOG_END(logger, true);
         }
     }
+    else if (httpResponse->statusLine().statusCode() == Poco::Net::HTTPResponse::HTTP_FOUND ||
+            httpResponse->statusLine().statusCode() == Poco::Net::HTTPResponse::HTTP_MOVED_PERMANENTLY)
+    {
+        const std::string& location = httpResponse->get("Location");
+        LOG_TRC("WOPI::downloadDocument redirect to URI [" << LOOLWSD::anonymizeUrl(location) << "]:\n");
+
+        Poco::URI redirectUriObject(location);
+        return downloadDocument(redirectUriObject, uriAnonym, auth, cookies);
+    }
     else
     {
         const std::string responseString = httpResponse->getBody();

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -671,7 +671,9 @@ std::unique_ptr<WopiStorage::WOPIFileInfo> WopiStorage::getWOPIFileInfoForUri(Po
             std::chrono::steady_clock::now() - startTime);
 
         if (httpResponse->statusLine().statusCode() == Poco::Net::HTTPResponse::HTTP_FOUND ||
-            httpResponse->statusLine().statusCode() == Poco::Net::HTTPResponse::HTTP_MOVED_PERMANENTLY)
+            httpResponse->statusLine().statusCode() == Poco::Net::HTTPResponse::HTTP_MOVED_PERMANENTLY ||
+            httpResponse->statusLine().statusCode() == Poco::Net::HTTPResponse::HTTP_TEMPORARY_REDIRECT ||
+            httpResponse->statusLine().statusCode() == Poco::Net::HTTPResponse::HTTP_PERMANENT_REDIRECT)
         {
             const std::string& location = httpResponse->get("Location");
             LOG_TRC("WOPI::CheckFileInfo redirect to URI [" << LOOLWSD::anonymizeUrl(location) << "]:\n");
@@ -1080,7 +1082,9 @@ std::string WopiStorage::downloadDocument(const Poco::URI& uriObject, const std:
         }
     }
     else if (httpResponse->statusLine().statusCode() == Poco::Net::HTTPResponse::HTTP_FOUND ||
-            httpResponse->statusLine().statusCode() == Poco::Net::HTTPResponse::HTTP_MOVED_PERMANENTLY)
+            httpResponse->statusLine().statusCode() == Poco::Net::HTTPResponse::HTTP_MOVED_PERMANENTLY ||
+            httpResponse->statusLine().statusCode() == Poco::Net::HTTPResponse::HTTP_TEMPORARY_REDIRECT ||
+            httpResponse->statusLine().statusCode() == Poco::Net::HTTPResponse::HTTP_PERMANENT_REDIRECT)
     {
         const std::string& location = httpResponse->get("Location");
         LOG_TRC("WOPI::downloadDocument redirect to URI [" << LOOLWSD::anonymizeUrl(location) << "]:\n");

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -677,6 +677,7 @@ std::unique_ptr<WopiStorage::WOPIFileInfo> WopiStorage::getWOPIFileInfoForUri(Po
             LOG_TRC("WOPI::CheckFileInfo redirect to URI [" << LOOLWSD::anonymizeUrl(location) << "]:\n");
 
             Poco::URI redirectUriObject(location);
+            setUri(redirectUriObject);
             return getWOPIFileInfoForUri(redirectUriObject, auth, cookies, lockCtx);
         }
 

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -630,14 +630,14 @@ http::Request WopiStorage::initHttpRequest(const Poco::URI& uri, const Authoriza
     return httpRequest;
 }
 
-std::unique_ptr<WopiStorage::WOPIFileInfo> WopiStorage::getWOPIFileInfo(const Authorization& auth,
-                                                                        const std::string& cookies,
-                                                                        LockContext& lockCtx)
+std::unique_ptr<WopiStorage::WOPIFileInfo> WopiStorage::getWOPIFileInfoForUri(Poco::URI uriObject,
+                                                                              const Authorization& auth,
+                                                                              const std::string& cookies,
+                                                                              LockContext& lockCtx)
 {
     ProfileZone profileZone("WopiStorage::getWOPIFileInfo", { {"url", _fileUrl} });
 
     // update the access_token to the one matching to the session
-    Poco::URI uriObject(getUri());
     auth.authorizeURI(uriObject);
     const std::string uriAnonym = LOOLWSD::anonymizeUrl(uriObject.toString());
 
@@ -669,6 +669,16 @@ std::unique_ptr<WopiStorage::WOPIFileInfo> WopiStorage::getWOPIFileInfo(const Au
 
         callDurationMs = std::chrono::duration_cast<std::chrono::milliseconds>(
             std::chrono::steady_clock::now() - startTime);
+
+        if (httpResponse->statusLine().statusCode() == Poco::Net::HTTPResponse::HTTP_FOUND ||
+            httpResponse->statusLine().statusCode() == Poco::Net::HTTPResponse::HTTP_MOVED_PERMANENTLY)
+        {
+            const std::string& location = httpResponse->get("Location");
+            LOG_TRC("WOPI::CheckFileInfo redirect to URI [" << LOOLWSD::anonymizeUrl(location) << "]:\n");
+
+            Poco::URI redirectUriObject(location);
+            return getWOPIFileInfoForUri(redirectUriObject, auth, cookies, lockCtx);
+        }
 
         // Note: we don't log the response if obfuscation is enabled, except for failures.
         wopiResponse = httpResponse->getBody();
@@ -752,6 +762,14 @@ std::unique_ptr<WopiStorage::WOPIFileInfo> WopiStorage::getWOPIFileInfo(const Au
 
         throw UnauthorizedRequestException("Access denied. WOPI::CheckFileInfo failed on: " + uriAnonym);
     }
+}
+
+std::unique_ptr<WopiStorage::WOPIFileInfo> WopiStorage::getWOPIFileInfo(const Authorization& auth,
+                                                                        const std::string& cookies,
+                                                                        LockContext& lockCtx)
+{
+    Poco::URI uriObject(getUri());
+    return getWOPIFileInfoForUri(uriObject, auth, cookies, lockCtx);
 }
 
 void WopiStorage::WOPIFileInfo::init()

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -338,6 +338,9 @@ public:
 
 protected:
 
+    /// Saves new URI when resource was moved
+    void setUri(const Poco::URI& uri) { _uri = uri; }
+
     /// Returns the root path of the jail directory of docs.
     std::string getLocalRootPath() const;
 
@@ -345,7 +348,7 @@ protected:
     const std::string& getExtendedData() const { return _extendedData; }
 
 private:
-    const Poco::URI _uri;
+    Poco::URI _uri;
     const std::string _localStorePath;
     const std::string _jailPath;
     std::string _jailedFilePath;

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -577,7 +577,8 @@ public:
                                                   const std::string& cookies, LockContext& lockCtx);
     /// Implementation of getWOPIFileInfo for specific URI
     std::unique_ptr<WOPIFileInfo> getWOPIFileInfoForUri(Poco::URI uriObject, const Authorization& auth,
-                                                  const std::string& cookies, LockContext& lockCtx);
+                                                  const std::string& cookies, LockContext& lockCtx,
+                                                  unsigned redirectLimit = 21);
 
     /// Update the locking state (check-in/out) of the associated file
     bool updateLockState(const Authorization& auth, const std::string& cookies,
@@ -631,7 +632,8 @@ private:
     /// Download the document from the given URI.
     /// Does not add authorization tokens or any other logic.
     std::string downloadDocument(const Poco::URI& uriObject, const std::string& uriAnonym,
-                                 const Authorization& auth, const std::string& cookies);
+                                 const Authorization& auth, const std::string& cookies,
+                                 unsigned redirectLimit = 21);
 
 private:
     /// A URl provided by the WOPI host to use for GetFile.

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -572,6 +572,9 @@ public:
     /// Also sets up the locking context for future operations.
     std::unique_ptr<WOPIFileInfo> getWOPIFileInfo(const Authorization& auth,
                                                   const std::string& cookies, LockContext& lockCtx);
+    /// Implementation of getWOPIFileInfo for specific URI
+    std::unique_ptr<WOPIFileInfo> getWOPIFileInfoForUri(Poco::URI uriObject, const Authorization& auth,
+                                                  const std::string& cookies, LockContext& lockCtx);
 
     /// Update the locking state (check-in/out) of the associated file
     bool updateLockState(const Authorization& auth, const std::string& cookies,


### PR DESCRIPTION
With some loadbalancers it may happen that HTTP 302 Found
response with redirect location will appear.
