### PR TITLE
On load: Do now show presentation-controls-wrapper

### DIFF
--- a/loleaflet/css/loleaflet.css
+++ b/loleaflet/css/loleaflet.css
@@ -183,7 +183,7 @@ body {
 	bottom: 33px;
 	max-width: 194px;
 	border-top: 1px solid var(--gray-color);
-	display: block;
+	display: none;
 }
 
 #presentation-controls-wrapper.readonly {

--- a/loleaflet/src/control/Control.UIManager.js
+++ b/loleaflet/src/control/Control.UIManager.js
@@ -169,6 +169,7 @@ L.Control.UIManager = L.Control.extend({
 		if (this.map.isPresentationOrDrawing()) {
 			// remove unused elements
 			L.DomUtil.remove(L.DomUtil.get('spreadsheet-toolbar'));
+			$('#presentation-controls-wrapper').show();
 		}
 
 		if (docType === 'text') {


### PR DESCRIPTION
unless we are in presence of a presentation or drawing.

- Hide it by default
- Use UIManager to show element

Fixes the glitch responsible by presentation-controls-wrapper
being shown right at the initialization time no matter the doc type

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I74c8ac615282774a7fdb35f5e79e5bec329ad774
