### PR TITLE
Convert strings far more quickly with apply.

### DIFF
--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -410,14 +410,9 @@ app.definitions.Socket = L.Class.extend({
 		else
 		{
 			var data = e.imgBytes.subarray(e.imgIndex);
-
 			console.assert(data.length == 0 || data[0] != 68 /* D */, 'Socket: got a delta image, not supported !');
 
-			// read the tile data
-			var strBytes = '';
-			for (var i = 0; i < data.length; i++) {
-				strBytes += String.fromCharCode(data[i]);
-			}
+			var strBytes = String.fromCharCode.apply(null, data);
 			img = 'data:image/png;base64,' + window.btoa(strBytes);
 		}
 		return img;


### PR DESCRIPTION
Reduces memory pressure from 24Mb + expensive GC's to 11.5Mb by
avoiding allocating large numbers of strings during UInt8 conversion.

Change-Id: Ia3fc5079f76abfc94e78d61b74b20cb394bcdc9e


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

