### PR TITLE
Convert from Uint8Array to String without blowing the stack.

### DIFF
--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -401,6 +401,16 @@ app.definitions.Socket = L.Class.extend({
 		e.imgIndex = index + 1;
 	},
 
+	// convert to string of bytes without blowing the stack if data is large.
+	_strFromUint8: function(data) {
+		var i, chunk = 4096;
+		var strBytes = '';
+		for (i = 0; i < data.length; i += chunk)
+			strBytes += String.fromCharCode.apply(null, data.slice(i, i + chunk));
+		strBytes += String.fromCharCode.apply(null, data.slice(i));
+		return strBytes;
+	},
+
 	_extractImage: function(e) {
 		var img;
 		if (window.ThisIsTheiOSApp) {
@@ -415,9 +425,7 @@ app.definitions.Socket = L.Class.extend({
 		{
 			var data = e.imgBytes.subarray(e.imgIndex);
 			console.assert(data.length == 0 || data[0] != 68 /* D */, 'Socket: got a delta image, not supported !');
-
-			var strBytes = String.fromCharCode.apply(null, data);
-			img = 'data:image/png;base64,' + window.btoa(strBytes);
+			img = 'data:image/png;base64,' + window.btoa(this._strFromUint8(data));
 		}
 		return img;
 	},


### PR DESCRIPTION
Uncaught RangeError: Maximum call stack size exceeded
    at NewClass._extractImage (Socket.js:419)

Change-Id: I9e0f98d269a0ea1388e4c5385f7b369df6a24fde


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

