### PR TITLE
Separate SSL Context for Client and Server Sockets

### DIFF
--- a/net/Ssl.cpp
+++ b/net/Ssl.cpp
@@ -32,8 +32,6 @@ extern "C"
     };
 }
 
-std::unique_ptr<SslContext> SslContext::Instance(nullptr);
-
 namespace ssl
 {
 
@@ -78,6 +76,9 @@ static inline void lock(int mode, int n, const char* /*file*/, int /*line*/)
 
 #endif
 } // namespace ssl
+
+std::unique_ptr<SslContext> ssl::Manager::ServerInstance(nullptr);
+std::unique_ptr<SslContext> ssl::Manager::ClientInstance(nullptr);
 
 SslContext::SslContext(const std::string& certFilePath,
                        const std::string& keyFilePath,
@@ -182,12 +183,6 @@ SslContext::~SslContext()
     CRYPTO_set_id_callback(0);
 
     CONF_modules_free();
-}
-
-void SslContext::uninitialize()
-{
-    assert (Instance);
-    Instance.reset();
 }
 
 unsigned long SslContext::id()

--- a/net/Ssl.hpp
+++ b/net/Ssl.hpp
@@ -62,7 +62,6 @@ private:
 
     // Multithreading support for OpenSSL.
     // Not needed in recent (1.x?) versions.
-    static void lock(int mode, int n, const char* file, int line);
     static unsigned long id();
     static struct CRYPTO_dynlock_value* dynlockCreate(const char* file, int line);
     static void dynlock(int mode, struct CRYPTO_dynlock_value* lock, const char* file, int line);
@@ -70,8 +69,6 @@ private:
 
 private:
     static std::unique_ptr<SslContext> Instance;
-
-    std::vector<std::unique_ptr<std::mutex>> _mutexes;
 
     SSL_CTX* _ctx;
 };

--- a/net/SslSocket.hpp
+++ b/net/SslSocket.hpp
@@ -35,7 +35,7 @@ public:
 
         BIO_set_fd(_bio, fd, BIO_NOCLOSE);
 
-        _ssl = SslContext::newSsl();
+        _ssl = isClient ? ssl::Manager::newClientSsl() : ssl::Manager::newServerSsl();
         if (!_ssl)
         {
             BIO_free(_bio);

--- a/test/helpers.hpp
+++ b/test/helpers.hpp
@@ -307,7 +307,7 @@ inline int connectToLocalServer(int portNumber, int socketTimeOutMS, bool blocki
 inline bool haveSsl()
 {
 #if ENABLE_SSL
-    return SslContext::isInitialized();
+    return ssl::Manager::isClientContextInitialized();
 #else
     return false;
 #endif

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -110,15 +110,15 @@ int main(int argc, char** argv)
         const std::string ssl_cipher_list = "ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH";
 
         // Initialize the non-blocking socket SSL.
-        SslContext::initialize(ssl_cert_file_path, ssl_key_file_path, ssl_ca_file_path,
-                               ssl_cipher_list);
+        ssl::Manager::initializeServerContext(ssl_cert_file_path, ssl_key_file_path,
+                                              ssl_ca_file_path, ssl_cipher_list);
     }
     catch (const std::exception& ex)
     {
         LOG_ERR("Exception while initializing SslContext: " << ex.what());
     }
 
-    if (!SslContext::isInitialized())
+    if (!ssl::Manager::isServerContextInitialized())
         LOG_ERR("Failed to initialize SSL. Set the path to the certificates via --cert-path. "
                 "HTTPS tests will be disabled in unit-tests.");
     else

--- a/tools/WebSocketDump.cpp
+++ b/tools/WebSocketDump.cpp
@@ -259,10 +259,8 @@ int main (int argc, char **argv)
 
     // Initialize the non-blocking socket SSL.
     if (isSSL)
-        SslContext::initialize(ssl_cert_file_path,
-                               ssl_key_file_path,
-                               ssl_ca_file_path,
-                               ssl_cipher_list);
+        ssl::Manager::initializeServerContext(ssl_cert_file_path, ssl_key_file_path,
+                                              ssl_ca_file_path, ssl_cipher_list);
 #endif
 
     SocketPoll acceptPoll("accept");

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -1570,16 +1570,14 @@ void LOOLWSD::initializeSSL()
             ssl_cipher_list = DEFAULT_CIPHER_SET;
     LOG_INF("SSL Cipher list: " << ssl_cipher_list);
 
-    // Initialize the non-blocking socket SSL.
-    SslContext::initialize(ssl_cert_file_path,
-                           ssl_key_file_path,
-                           ssl_ca_file_path,
-                           ssl_cipher_list);
+    // Initialize the non-blocking server socket SSL context.
+    ssl::Manager::initializeServerContext(ssl_cert_file_path, ssl_key_file_path, ssl_ca_file_path,
+                                          ssl_cipher_list);
 
-    if (!SslContext::isInitialized())
-        LOG_ERR("Failed to initialize SSL.");
+    if (!ssl::Manager::isServerContextInitialized())
+        LOG_ERR("Failed to initialize Server SSL.");
     else
-        LOG_INF("Initialized SSL.");
+        LOG_INF("Initialized Server SSL.");
 #else
     LOG_INF("SSL is unavailable in this build.");
 #endif
@@ -4276,7 +4274,8 @@ void LOOLWSD::cleanup()
         {
             Poco::Net::uninitializeSSL();
             Poco::Crypto::uninitializeCrypto();
-            SslContext::uninitialize();
+            ssl::Manager::uninitializeClientContext();
+            ssl::Manager::uninitializeServerContext();
         }
 #endif
 #endif

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -168,6 +168,15 @@ void StorageBase::initialize()
                                        Poco::Net::Context::Protocols::PROTO_SSLV3 |
                                        Poco::Net::Context::Protocols::PROTO_TLSV1);
     Poco::Net::SSLManager::instance().initializeClient(consoleClientHandler, invalidClientCertHandler, sslClientContext);
+
+    // Initialize our client SSL context.
+    ssl::Manager::initializeClientContext(sslClientParams.certificateFile,
+                                          sslClientParams.privateKeyFile,
+                                          sslClientParams.caLocation, sslClientParams.cipherList);
+    if (!ssl::Manager::isClientContextInitialized())
+        LOG_ERR("Failed to initialize Client SSL.");
+    else
+        LOG_INF("Initialized Client SSL.");
 #endif
 #else
     FilesystemEnabled = true;


### PR DESCRIPTION
- wsd: separate the SSL locks from the context
- wsd: separate client SSL context from the server
