### PR TITLE
Separate SSL Context for Client and Server Sockets

### DIFF
--- a/net/Ssl.cpp
+++ b/net/Ssl.cpp
@@ -28,8 +28,6 @@ extern "C"
     };
 }
 
-std::unique_ptr<SslContext> SslContext::Instance(nullptr);
-
 namespace ssl
 {
 
@@ -74,6 +72,9 @@ static inline void lock(int mode, int n, const char* /*file*/, int /*line*/)
 
 #endif
 } // namespace ssl
+
+std::unique_ptr<SslContext> ssl::Manager::ServerInstance(nullptr);
+std::unique_ptr<SslContext> ssl::Manager::ClientInstance(nullptr);
 
 SslContext::SslContext(const std::string& certFilePath,
                        const std::string& keyFilePath,
@@ -178,12 +179,6 @@ SslContext::~SslContext()
     CRYPTO_set_id_callback(0);
 
     CONF_modules_free();
-}
-
-void SslContext::uninitialize()
-{
-    assert (Instance);
-    Instance.reset();
 }
 
 unsigned long SslContext::id()

--- a/net/Ssl.cpp
+++ b/net/Ssl.cpp
@@ -30,6 +30,51 @@ extern "C"
 
 std::unique_ptr<SslContext> SslContext::Instance(nullptr);
 
+namespace ssl
+{
+
+// The locking API is removed from 1.1 onward.
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+
+/// Manages the SSL locks.
+class Lock
+{
+public:
+    Lock()
+    {
+        for (int x = 0; x < CRYPTO_num_locks(); ++x)
+        {
+            _mutexes.emplace_back(new std::mutex);
+        }
+    }
+
+    void lock(int mode, int n)
+    {
+        assert(n < CRYPTO_num_locks() && "Unexpected lock index");
+        if (mode & CRYPTO_LOCK)
+        {
+            _mutexes[n]->lock();
+        }
+        else
+        {
+            _mutexes[n]->unlock();
+        }
+    }
+
+private:
+    std::vector<std::unique_ptr<std::mutex>> _mutexes;
+};
+
+/// Locks are shared across SSL Contexts (by openssl design).
+static inline void lock(int mode, int n, const char* /*file*/, int /*line*/)
+{
+    static ssl::Lock lock;
+    lock.lock(mode, n);
+}
+
+#endif
+} // namespace ssl
+
 SslContext::SslContext(const std::string& certFilePath,
                        const std::string& keyFilePath,
                        const std::string& caFilePath,
@@ -38,12 +83,6 @@ SslContext::SslContext(const std::string& certFilePath,
 {
     const std::vector<char> rand = Util::rng::getBytes(512);
     RAND_seed(&rand[0], rand.size());
-
-    // Initialize multi-threading support.
-    for (int x = 0; x < CRYPTO_num_locks(); ++x)
-    {
-        _mutexes.emplace_back(new std::mutex);
-    }
 
 #if OPENSSL_VERSION_NUMBER >= 0x0907000L && OPENSSL_VERSION_NUMBER < 0x10100003L
     OPENSSL_config(nullptr);
@@ -57,7 +96,7 @@ SslContext::SslContext(const std::string& certFilePath,
     OpenSSL_add_all_algorithms();
 #endif
 
-    CRYPTO_set_locking_callback(&SslContext::lock);
+    CRYPTO_set_locking_callback(&ssl::lock);
     CRYPTO_set_id_callback(&SslContext::id);
     CRYPTO_set_dynlock_create_callback(&SslContext::dynlockCreate);
     CRYPTO_set_dynlock_lock_callback(&SslContext::dynlock);
@@ -139,30 +178,12 @@ SslContext::~SslContext()
     CRYPTO_set_id_callback(0);
 
     CONF_modules_free();
-
-    _mutexes.clear();
 }
 
 void SslContext::uninitialize()
 {
     assert (Instance);
     Instance.reset();
-}
-
-void SslContext::lock(int mode, int n, const char* /*file*/, int /*line*/)
-{
-    assert(n < CRYPTO_num_locks());
-    if (Instance)
-    {
-        if (mode & CRYPTO_LOCK)
-        {
-            Instance->_mutexes[n]->lock();
-        }
-        else
-        {
-            Instance->_mutexes[n]->unlock();
-        }
-    }
 }
 
 unsigned long SslContext::id()

--- a/net/Ssl.hpp
+++ b/net/Ssl.hpp
@@ -62,7 +62,6 @@ private:
 
     // Multithreading support for OpenSSL.
     // Not needed in recent (1.x?) versions.
-    static void lock(int mode, int n, const char* file, int line);
     static unsigned long id();
     static struct CRYPTO_dynlock_value* dynlockCreate(const char* file, int line);
     static void dynlock(int mode, struct CRYPTO_dynlock_value* lock, const char* file, int line);
@@ -70,8 +69,6 @@ private:
 
 private:
     static std::unique_ptr<SslContext> Instance;
-
-    std::vector<std::unique_ptr<std::mutex>> _mutexes;
 
     SSL_CTX* _ctx;
 };

--- a/net/SslSocket.hpp
+++ b/net/SslSocket.hpp
@@ -35,7 +35,7 @@ public:
 
         BIO_set_fd(_bio, fd, BIO_NOCLOSE);
 
-        _ssl = SslContext::newSsl();
+        _ssl = isClient ? ssl::Manager::newClientSsl() : ssl::Manager::newServerSsl();
         if (!_ssl)
         {
             BIO_free(_bio);

--- a/test/helpers.hpp
+++ b/test/helpers.hpp
@@ -304,7 +304,7 @@ inline int connectToLocalServer(int portNumber, int socketTimeOutMS, bool blocki
 inline bool haveSsl()
 {
 #if ENABLE_SSL
-    return SslContext::isInitialized();
+    return ssl::Manager::isClientContextInitialized();
 #else
     return false;
 #endif

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -110,15 +110,15 @@ int main(int argc, char** argv)
         const std::string ssl_cipher_list = "ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH";
 
         // Initialize the non-blocking socket SSL.
-        SslContext::initialize(ssl_cert_file_path, ssl_key_file_path, ssl_ca_file_path,
-                               ssl_cipher_list);
+        ssl::Manager::initializeServerContext(ssl_cert_file_path, ssl_key_file_path,
+                                              ssl_ca_file_path, ssl_cipher_list);
     }
     catch (const std::exception& ex)
     {
         LOG_ERR("Exception while initializing SslContext: " << ex.what());
     }
 
-    if (!SslContext::isInitialized())
+    if (!ssl::Manager::isServerContextInitialized())
         LOG_ERR("Failed to initialize SSL. Set the path to the certificates via --cert-path. "
                 "HTTPS tests will be disabled in unit-tests.");
     else

--- a/tools/WebSocketDump.cpp
+++ b/tools/WebSocketDump.cpp
@@ -263,10 +263,8 @@ int main (int argc, char **argv)
 
     // Initialize the non-blocking socket SSL.
     if (isSSL)
-        SslContext::initialize(ssl_cert_file_path,
-                               ssl_key_file_path,
-                               ssl_ca_file_path,
-                               ssl_cipher_list);
+        ssl::Manager::initializeServerContext(ssl_cert_file_path, ssl_key_file_path,
+                                              ssl_ca_file_path, ssl_cipher_list);
 #endif
 
     SocketPoll acceptPoll("accept");

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -1564,16 +1564,14 @@ void LOOLWSD::initializeSSL()
             ssl_cipher_list = DEFAULT_CIPHER_SET;
     LOG_INF("SSL Cipher list: " << ssl_cipher_list);
 
-    // Initialize the non-blocking socket SSL.
-    SslContext::initialize(ssl_cert_file_path,
-                           ssl_key_file_path,
-                           ssl_ca_file_path,
-                           ssl_cipher_list);
+    // Initialize the non-blocking server socket SSL context.
+    ssl::Manager::initializeServerContext(ssl_cert_file_path, ssl_key_file_path, ssl_ca_file_path,
+                                          ssl_cipher_list);
 
-    if (!SslContext::isInitialized())
-        LOG_ERR("Failed to initialize SSL.");
+    if (!ssl::Manager::isServerContextInitialized())
+        LOG_ERR("Failed to initialize Server SSL.");
     else
-        LOG_INF("Initialized SSL.");
+        LOG_INF("Initialized Server SSL.");
 #else
     LOG_INF("SSL is unavailable in this build.");
 #endif
@@ -2602,7 +2600,8 @@ private:
                 if (!LOOLWSD::AdminEnabled)
                     throw Poco::FileAccessDeniedException("Admin console disabled");
 
-                try{
+                try
+                {
                     if (!FileServerRequestHandler::isAdminLoggedIn(request, *response))
                         throw Poco::Net::NotAuthenticatedException("Invalid admin login");
                 }
@@ -2894,6 +2893,7 @@ private:
                                        + serverId + " vs. " + Util::getProcessIdentifier()
                                        + "on request to URL: " + request.getURI();
             LOG_ERR(errMsg);
+
             // we got the wrong request.
             std::ostringstream oss;
             oss << "HTTP/1.1 400\r\n"
@@ -4323,7 +4323,8 @@ void LOOLWSD::cleanup()
     {
         Poco::Net::uninitializeSSL();
         Poco::Crypto::uninitializeCrypto();
-        SslContext::uninitialize();
+        ssl::Manager::uninitializeClientContext();
+        ssl::Manager::uninitializeServerContext();
     }
 #endif
 #endif

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -170,6 +170,15 @@ void StorageBase::initialize()
                                        Poco::Net::Context::Protocols::PROTO_SSLV3 |
                                        Poco::Net::Context::Protocols::PROTO_TLSV1);
     Poco::Net::SSLManager::instance().initializeClient(consoleClientHandler, invalidClientCertHandler, sslClientContext);
+
+    // Initialize our client SSL context.
+    ssl::Manager::initializeClientContext(sslClientParams.certificateFile,
+                                          sslClientParams.privateKeyFile,
+                                          sslClientParams.caLocation, sslClientParams.cipherList);
+    if (!ssl::Manager::isClientContextInitialized())
+        LOG_ERR("Failed to initialize Client SSL.");
+    else
+        LOG_INF("Initialized Client SSL.");
 #endif
 #else
     FilesystemEnabled = true;


### PR DESCRIPTION
- wsd: separate the SSL locks from the context
- wsd: separate client SSL context from the server
