### PR TITLE
Don't hide download progress when async download has started

### DIFF
--- a/loleaflet/src/control/Control.DownloadProgress.js
+++ b/loleaflet/src/control/Control.DownloadProgress.js
@@ -159,7 +159,7 @@ L.Control.DownloadProgress = L.Control.extend({
 	_download: function () {
 		var that = this;
 		this._map._clip._doAsyncDownload(
-			'GET', that._uri, null,
+			'GET', that._uri, null, true,
 			function(response) {
 				console.log('clipboard async download done');
 				// annoying async parse of the blob ...


### PR DESCRIPTION
Also make sure to not show the "Confirm copy to clipboard" in the end
of the download which is not intended for the local clipboard, but is
immediately uploaded to the target document

Signed-off-by: Mike Kaganski <mike.kaganski@collabora.com>
Change-Id: I09f27a234cc92fd0700bf29654f44cbaa158de47
