### PR TITLE
Mobile: Hamburger menu: latestupdates: Fix missing icon

### DIFF
--- a/loleaflet/src/control/Control.Menubar.js
+++ b/loleaflet/src/control/Control.Menubar.js
@@ -256,7 +256,7 @@ L.Control.Menubar = L.Control.extend({
 				{name: _('Online Help'), id: 'online-help', type: 'action', iosapp: false},
 				{name: _('Keyboard shortcuts'), id: 'keyboard-shortcuts', type: 'action', iosapp: false},
 				{name: _('Report an issue'), id: 'report-an-issue', type: 'action', iosapp: false},
-				{name: _('Latest Updates'), id: 'latest-updates', type: 'action', iosapp: false},
+				{name: _('Latest Updates'), id: 'latestupdates', type: 'action', iosapp: false},
 				{name: _('About'), id: 'about', type: 'action'}]
 			},
 			{name: _('Last modification'), id: 'last-mod', type: 'action', tablet: false}
@@ -384,7 +384,7 @@ L.Control.Menubar = L.Control.extend({
 				{name: _('Online Help'), id: 'online-help', type: 'action', iosapp: false},
 				{name: _('Keyboard shortcuts'), id: 'keyboard-shortcuts', type: 'action', iosapp: false},
 				{name: _('Report an issue'), id: 'report-an-issue', type: 'action', iosapp: false},
-				{name: _('Latest Updates'), id: 'latest-updates', type: 'action', iosapp: false},
+				{name: _('Latest Updates'), id: 'latestupdates', type: 'action', iosapp: false},
 				{name: _('About'), id: 'about', type: 'action'}]
 			},
 			{name: _('Last modification'), id: 'last-mod', type: 'action', tablet: false}
@@ -494,7 +494,7 @@ L.Control.Menubar = L.Control.extend({
 				{name: _('Online Help'), id: 'online-help', type: 'action', iosapp: false},
 				{name: _('Keyboard shortcuts'), id: 'keyboard-shortcuts', type: 'action', iosapp: false},
 				{name: _('Report an issue'), id: 'report-an-issue', type: 'action', iosapp: false},
-				{name: _('Latest Updates'), id: 'latest-updates', type: 'action', iosapp: false},
+				{name: _('Latest Updates'), id: 'latestupdates', type: 'action', iosapp: false},
 				{name: _('About'), id: 'about', type: 'action'}]
 			},
 			{name: _('Last modification'), id: 'last-mod', type: 'action', tablet: false}
@@ -705,7 +705,7 @@ L.Control.Menubar = L.Control.extend({
 				{name: _('Online Help'), id: 'online-help', type: 'action', iosapp: false},
 				{name: _('Keyboard shortcuts'), id: 'keyboard-shortcuts', type: 'action', iosapp: false},
 				{name: _('Report an issue'), id: 'report-an-issue', type: 'action', iosapp: false},
-				{name: _('Latest Updates'), id: 'latest-updates', type: 'action', iosapp: false},
+				{name: _('Latest Updates'), id: 'latestupdates', type: 'action', iosapp: false},
 				{name: _('About'), id: 'about', type: 'action'}]
 			},
 			{name: _('Last modification'), id: 'last-mod', type: 'action', tablet: false}
@@ -760,7 +760,7 @@ L.Control.Menubar = L.Control.extend({
 			{name: _('Page Setup'), id: 'pagesetup', type: 'action'},
 			{uno: '.uno:WordCountDialog'},
 			{name: _UNO('.uno:RunMacro'), id: 'runmacro', uno: '.uno:RunMacro'},
-			{name: _('Latest Updates'), id: 'latest-updates', type: 'action', iosapp: false},
+			{name: _('Latest Updates'), id: 'latestupdates', type: 'action', iosapp: false},
 			{name: _('About'), id: 'about', type: 'action'},
 		],
 
@@ -810,7 +810,7 @@ L.Control.Menubar = L.Control.extend({
 			{name: _UNO('.uno:RunMacro'), id: 'runmacro', uno: '.uno:RunMacro'},
 			{name: _('Fullscreen presentation'), id: 'fullscreen-presentation', type: 'action'},
 			{name: _UNO('.uno:FullScreen', 'presentation'), id: 'fullscreen', type: 'action', mobileapp: false},
-			{name: _('Latest Updates'), id: 'latest-updates', type: 'action', iosapp: false},
+			{name: _('Latest Updates'), id: 'latestupdates', type: 'action', iosapp: false},
 			{name: _('About'), id: 'about', type: 'action'},
 		],
 
@@ -855,7 +855,7 @@ L.Control.Menubar = L.Control.extend({
 			{uno: '.uno:SpellOnline'},
 			{name: _UNO('.uno:RunMacro'), id: 'runmacro', uno: '.uno:RunMacro'},
 			{name: _UNO('.uno:FullScreen', 'presentation'), id: 'fullscreen', type: 'action', mobileapp: false},
-			{name: _('Latest Updates'), id: 'latest-updates', type: 'action', iosapp: false},
+			{name: _('Latest Updates'), id: 'latestupdates', type: 'action', iosapp: false},
 			{name: _('About'), id: 'about', type: 'action'},
 		],
 
@@ -924,7 +924,7 @@ L.Control.Menubar = L.Control.extend({
 			{uno: '.uno:SpellOnline'},
 			{name: _UNO('.uno:RunMacro'), id: 'runmacro', uno: '.uno:RunMacro'},
 			{name: _UNO('.uno:FullScreen', 'spreadsheet'), id: 'fullscreen', type: 'action', mobileapp: false},
-			{name: _('Latest Updates'), id: 'latest-updates', type: 'action', iosapp: false},
+			{name: _('Latest Updates'), id: 'latestupdates', type: 'action', iosapp: false},
 			{name: _('About'), id: 'about', type: 'action'},
 		],
 
@@ -1044,7 +1044,7 @@ L.Control.Menubar = L.Control.extend({
 			'downloadas-odp', 'downloadas-ppt', 'downloadas-pptx', 'downloadas-odg', 'print', // file menu
 			'downloadas-ods', 'downloadas-xls', 'downloadas-xlsx', 'downloadas-csv', 'closedocument', // file menu
 			'fullscreen', 'zoomin', 'zoomout', 'zoomreset', 'showresolved', // view menu
-			'about', 'keyboard-shortcuts', 'latest-updates', 'online-help', 'report-an-issue', // help menu
+			'about', 'keyboard-shortcuts', 'latestupdates', 'online-help', 'report-an-issue', // help menu
 			'insertcomment'
 		]
 	},
@@ -1569,7 +1569,7 @@ L.Control.Menubar = L.Control.extend({
 			});
 		} else if (id === 'about') {
 			this._map.showLOAboutDialog();
-		} else if (id === 'latest-updates') {
+		} else if (id === 'latestupdates') {
 			this._map.showWelcomeDialog(/*calledFromMenu=*/true);
 		} else if (id === 'report-an-issue') {
 			window.open('https://github.com/CollaboraOnline/online/issues', '_blank');
@@ -1732,7 +1732,7 @@ L.Control.Menubar = L.Control.extend({
 		if (menuItem.type === 'action') {
 			if ((menuItem.id === 'rev-history' && !L.Params.revHistoryEnabled) ||
 				(menuItem.id === 'closedocument' && !L.Params.closeButtonEnabled) ||
-				(menuItem.id === 'latest-updates' && !window.enableWelcomeMessage)) {
+				(menuItem.id === 'latestupdates' && !window.enableWelcomeMessage)) {
 				return false;
 			}
 		}


### PR DESCRIPTION
Fixes the used id by removing `-` (to be the same as used by
`_onlineHelpControl` control in the desktop:Notebookbar).
In return the id is then used to call the correct svg file name.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I63951d20b204b61e64a6c0d7e394465e230b7377
