### PR TITLE
ie11: do not use Array.includes

### DIFF
--- a/loleaflet/js/global.js
+++ b/loleaflet/js/global.js
@@ -749,7 +749,7 @@
 		window.TheFakeWebSocket = global.socket;
 	} else {
 		// The URL may already contain a query (e.g., 'http://server.tld/foo/wopi/files/bar?desktop=baz') - then just append more params
-		var docParamsPart = docParams ? (global.docURL.includes('?') ? '&' : '?') + docParams : '';
+		var docParamsPart = docParams ? ((global.docURL.indexOf('?') >= 0) ? '&' : '?') + docParams : '';
 		var websocketURI = global.host + global.serviceRoot + '/lool/' + encodeURIComponent(global.docURL + docParamsPart) + '/ws' + wopiSrc;
 
 		try {


### PR DESCRIPTION
Signed-off-by: Michael Meeks <michael.meeks@collabora.com>
Change-Id: I0f253d68b4c78c5a7b29fa9d14c02e049af0b14e
(cherry picked from commit 4730ad5e08bc43d4ce85d3b69e8734ce46969ec5)


* Resolves: # <!-- related github issue -->
* Target version: co-6-4-9