### PR TITLE
Revert "wsd: initialize SSL if enabled or termination is enabled"

### DIFF
--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -1547,7 +1547,7 @@ void LOOLWSD::initialize(Application& self)
 void LOOLWSD::initializeSSL()
 {
 #if ENABLE_SSL
-    if (!LOOLWSD::isSSLEnabled() && !LOOLWSD::isSSLTermination())
+    if (!LOOLWSD::isSSLEnabled())
         return;
 
     const std::string ssl_cert_file_path = getPathFromConfig("ssl.cert_file_path");


### PR DESCRIPTION
The original behavior must be preserved, which is not to
initialize SSL when termination is enabled but SSL is disabled.

This reverts commit 1c9541a6a636647086397e1310084cc990b6ed70.
