### PR TITLE
Broadcast save-as to other views

### DIFF
--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -426,6 +426,9 @@ public:
     /// Sends a message to all sessions
     void broadcastMessage(const std::string& message) const;
 
+    /// Sends a message to all sessions except for the session passed as the param
+    void broadcastMessageToOthers(const std::string& message, const std::shared_ptr<ClientSession>& _session) const;
+
     /// Broadcasts 'blockui' command to all users with an optional message.
     void blockUI(const std::string& msg)
     {


### PR DESCRIPTION
We ask for save as for the plain/text type documents
such as csv or txt. Notify other views about it so
they can follow one to the new document

Signed-off-by: merttumer <mert.tumer@collabora.com>
Change-Id: I4cdcec6148d1064ad4e90ad9be2ce483c19a8eda


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

