### PR TITLE
Fix confusing wording in message when server is restarted

### DIFF
--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -510,7 +510,7 @@ app.definitions.Socket = L.Class.extend({
 
 			if (oldId && oldVersion && sameFile) {
 				if (this.WSDServer.Id !== oldId || this.WSDServer.Version !== oldVersion) {
-					alert(_('Server has been restarted. We have to refresh the page now.'));
+					alert(_('Server is now reachable. We have to refresh the page now.'));
 					// We use this function instead of window.location.reload() to ensure that the browser cache is cleared (as done with CTRL + F5).
 					this.forceReload();
 				}


### PR DESCRIPTION
Avoids the use of the words `restarted` and `refresh` in the same message
that might cause confusion for the user that quick scans the message:
`Server has been restarted. We have to refresh the page now.` and could
induce in error (the page is already refreshed).

Maintains factual of this message but uses instead the word `reachable`.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I294e36bd121e0f84f1b5373b29de78084b4707f2
