### PR TITLE
Fix async copy to clipboard

### DIFF
--- a/loleaflet/src/control/Control.DownloadProgress.js
+++ b/loleaflet/src/control/Control.DownloadProgress.js
@@ -159,7 +159,7 @@ L.Control.DownloadProgress = L.Control.extend({
 	_download: function () {
 		var that = this;
 		this._map._clip._doAsyncDownload(
-			'GET', that._uri, null,
+			'GET', that._uri, null, true,
 			function(response) {
 				console.log('clipboard async download done');
 				// annoying async parse of the blob ...

--- a/loleaflet/src/map/Clipboard.js
+++ b/loleaflet/src/map/Clipboard.js
@@ -423,7 +423,7 @@ L.Clipboard = L.Class.extend({
 			formData.append('file', content);
 
 			var that = this;
-			this._doAsyncDownload('POST', this.getMetaURL(), formData, true,
+			this._doAsyncDownload('POST', this.getMetaURL(), formData, false,
 							function() {
 								console.log('Posted ' + content.size + ' bytes successfully');
 								that._doInternalPaste(that._map, usePasteKeyEvent);


### PR DESCRIPTION
... after 1aea12bed0313e4e54f82646c8a77556a68c2407, where I blindly
assumed that the _doAsyncDownload is only called from one file. The
affected code path was in loleaflet/src/control/Control.DownloadProgress.js,
and one place in loleaflet/src/map/Clipboard.js was wrong marking
a "POST" operation as "for clipboard".

Signed-off-by: Mike Kaganski <mike.kaganski@collabora.com>
Change-Id: I5bc1e68603ab8281716bcec6f8586524b6e01c95
