### PR TITLE
SSL Certificate Verification

### DIFF
--- a/net/NetUtil.cpp
+++ b/net/NetUtil.cpp
@@ -21,6 +21,8 @@
 
 #include <netdb.h>
 
+#include <Poco/Net/SocketAddress.h>
+
 namespace net
 {
 

--- a/net/NetUtil.cpp
+++ b/net/NetUtil.cpp
@@ -130,10 +130,10 @@ connect(const std::string& host, const std::string& port, const bool isSSL,
                 {
 #if ENABLE_SSL
                     if (isSSL)
-                        socket = StreamSocket::create<SslStreamSocket>(fd, true, protocolHandler);
+                        socket = StreamSocket::create<SslStreamSocket>(host, fd, true, protocolHandler);
 #endif
                     if (!socket && !isSSL)
-                        socket = StreamSocket::create<StreamSocket>(fd, true, protocolHandler);
+                        socket = StreamSocket::create<StreamSocket>(host, fd, true, protocolHandler);
 
                     if (socket)
                         break;

--- a/net/NetUtil.hpp
+++ b/net/NetUtil.hpp
@@ -19,6 +19,17 @@ class ProtocolHandlerInterface;
 
 namespace net
 {
+
+#if !MOBILEAPP
+
+/// Resolves the IP of the given hostname. On failure, returns @targetHost.
+std::string resolveHostAddress(const std::string& targetHost);
+
+/// Returns true if @targetHost is on the same host.
+bool isLocalhost(const std::string& targetHost);
+
+#endif
+
 /// Connect to an end-point at the given host and port and return StreamSocket.
 std::shared_ptr<StreamSocket>
 connect(const std::string& host, const std::string& port, const bool isSSL,

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -108,6 +108,11 @@ bool SslStreamSocket::simulateSocketError(bool read)
 #if ENABLE_SSL
 bool SslStreamSocket::verifyCertificate()
 {
+    if (_verification == ssl::CertificateVerification::Disabled)
+    {
+        return true;
+    }
+
     X509* x509 = SSL_get_peer_certificate(_ssl);
     if (x509)
     {
@@ -115,7 +120,8 @@ bool SslStreamSocket::verifyCertificate()
         return cert.verify(hostname());
     }
 
-    return false;
+    // No certificate; acceptable only if verification is not strictly required.
+    return (_verification == ssl::CertificateVerification::IfProvided);
 }
 #endif //ENABLE_SSL
 

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -40,6 +40,7 @@
 #include "ServerSocket.hpp"
 #if !MOBILEAPP && ENABLE_SSL
 #include <net/SslSocket.hpp>
+#include <openssl/x509v3.h>
 #endif
 #include "WebSocketHandler.hpp"
 #include <net/HttpRequest.hpp>
@@ -106,18 +107,62 @@ bool SslStreamSocket::simulateSocketError(bool read)
 #endif //ENABLE_DEBUG
 
 #if ENABLE_SSL
+static std::string X509_NAME_to_utf8(X509_NAME* name)
+{
+    BIO* bio = BIO_new(BIO_s_mem());
+    X509_NAME_print_ex(bio, name, 0,
+                       (ASN1_STRFLGS_RFC2253 | XN_FLAG_SEP_COMMA_PLUS | XN_FLAG_FN_SN |
+                        XN_FLAG_DUMP_UNKNOWN_FIELDS) &
+                           ~ASN1_STRFLGS_ESC_MSB);
+    BUF_MEM* buf;
+    BIO_get_mem_ptr(bio, &buf);
+    std::string text = std::string(buf->data, buf->length);
+    BIO_free(bio);
+    return text;
+}
+
 bool SslStreamSocket::verifyCertificate()
 {
-    if (_verification == ssl::CertificateVerification::Disabled)
+    if (_verification == ssl::CertificateVerification::Disabled || net::isLocalhost(hostname()))
     {
         return true;
     }
 
+    LOG_TRC("Verifying certificate of [" << hostname() << ']');
     X509* x509 = SSL_get_peer_certificate(_ssl);
     if (x509)
     {
+        // Dump cert info, for debugging only.
+        const std::string issuerName = X509_NAME_to_utf8(X509_get_issuer_name(x509));
+        const std::string subjectName = X509_NAME_to_utf8(X509_get_subject_name(x509));
+        std::string serialNumber;
+        BIGNUM* pBN = ASN1_INTEGER_to_BN(X509_get_serialNumber(const_cast<X509*>(x509)), 0);
+        if (pBN)
+        {
+            char* pSN = BN_bn2hex(pBN);
+            if (pSN)
+            {
+                serialNumber = pSN;
+                OPENSSL_free(pSN);
+            }
+
+            BN_free(pBN);
+        }
+
+        LOG_TRC("SSL cert issuer: " << issuerName << ", subject: " << subjectName
+                                    << ", serial: " << serialNumber);
+
         Poco::Net::X509Certificate cert(x509);
-        return cert.verify(hostname());
+        if (cert.verify(hostname()))
+        {
+            LOG_TRC("SSL cert verified for host [" << hostname() << ']');
+            return true;
+        }
+        else
+        {
+            LOG_INF("SSL cert failed verification for host [" << hostname() << ']');
+            return false;
+        }
     }
 
     // No certificate; acceptable only if verification is not strictly required.

--- a/net/Ssl.cpp
+++ b/net/Ssl.cpp
@@ -80,11 +80,11 @@ static inline void lock(int mode, int n, const char* /*file*/, int /*line*/)
 std::unique_ptr<SslContext> ssl::Manager::ServerInstance(nullptr);
 std::unique_ptr<SslContext> ssl::Manager::ClientInstance(nullptr);
 
-SslContext::SslContext(const std::string& certFilePath,
-                       const std::string& keyFilePath,
-                       const std::string& caFilePath,
-                       const std::string& cipherList) :
-    _ctx(nullptr)
+SslContext::SslContext(const std::string& certFilePath, const std::string& keyFilePath,
+                       const std::string& caFilePath, const std::string& cipherList,
+                       ssl::CertificateVerification verification)
+    : _ctx(nullptr)
+    , _verification(verification)
 {
     const std::vector<char> rand = Util::rng::getBytes(512);
     RAND_seed(&rand[0], rand.size());

--- a/net/SslSocket.hpp
+++ b/net/SslSocket.hpp
@@ -35,7 +35,8 @@ public:
 
         BIO_set_fd(_bio, fd, BIO_NOCLOSE);
 
-        _ssl = isClient ? ssl::Manager::newClientSsl() : ssl::Manager::newServerSsl();
+        _ssl = isClient ? ssl::Manager::newClientSsl(_verification)
+                        : ssl::Manager::newServerSsl(_verification);
         if (!_ssl)
         {
             BIO_free(_bio);
@@ -352,6 +353,8 @@ private:
 private:
     BIO* _bio;
     SSL* _ssl;
+    ssl::CertificateVerification _verification; //< The certificate verification requirement.
+
     /// During handshake SSL might want to read
     /// on write, or write on read.
     SslWantsTo _sslWantsTo;

--- a/test/HttpRequestTests.cpp
+++ b/test/HttpRequestTests.cpp
@@ -115,12 +115,12 @@ public:
 #if ENABLE_SSL
             if (helpers::haveSsl())
                 return StreamSocket::create<SslStreamSocket>(
-                    fd, false, std::make_shared<ServerRequestHandler>());
+                    std::string(), fd, false, std::make_shared<ServerRequestHandler>());
             else
-                return StreamSocket::create<StreamSocket>(fd, false,
+                return StreamSocket::create<StreamSocket>(std::string(), fd, false,
                                                           std::make_shared<ServerRequestHandler>());
 #else
-            return StreamSocket::create<StreamSocket>(fd, false,
+            return StreamSocket::create<StreamSocket>(std::string(), fd, false,
                                                       std::make_shared<ServerRequestHandler>());
 #endif
         }

--- a/test/HttpRequestTests.cpp
+++ b/test/HttpRequestTests.cpp
@@ -468,7 +468,7 @@ void HttpRequestTests::testSimplePost_External()
 
     httpRequest.setBodyFile(path);
 
-    auto httpSession = http::Session::createHttp(Host);
+    auto httpSession = http::Session::createHttpSsl(Host);
     httpSession->setTimeout(DefTimeoutSeconds);
 
     std::condition_variable cv;

--- a/test/WopiTestServer.hpp
+++ b/test/WopiTestServer.hpp
@@ -126,7 +126,8 @@ protected:
 
         {
             std::ostringstream oss;
-            oss << "Fake wopi host request URI [" << uriReq.toString() << "]:\n";
+            oss << "Fake wopi host " << request.getMethod() << " request URI [" << uriReq.toString()
+                << "]:\n";
             for (const auto& pair : request)
             {
                 oss << '\t' << pair.first << ": " << pair.second << " / ";

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -111,7 +111,8 @@ int main(int argc, char** argv)
 
         // Initialize the non-blocking socket SSL.
         ssl::Manager::initializeServerContext(ssl_cert_file_path, ssl_key_file_path,
-                                              ssl_ca_file_path, ssl_cipher_list);
+                                              ssl_ca_file_path, ssl_cipher_list,
+                                              ssl::CertificateVerification::Disabled);
     }
     catch (const std::exception& ex)
     {

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -113,6 +113,10 @@ int main(int argc, char** argv)
         ssl::Manager::initializeServerContext(ssl_cert_file_path, ssl_key_file_path,
                                               ssl_ca_file_path, ssl_cipher_list,
                                               ssl::CertificateVerification::Disabled);
+
+        ssl::Manager::initializeClientContext(ssl_cert_file_path, ssl_key_file_path,
+                                              ssl_ca_file_path, ssl_cipher_list,
+                                              ssl::CertificateVerification::Required);
     }
     catch (const std::exception& ex)
     {
@@ -120,10 +124,15 @@ int main(int argc, char** argv)
     }
 
     if (!ssl::Manager::isServerContextInitialized())
-        LOG_ERR("Failed to initialize SSL. Set the path to the certificates via --cert-path. "
-                "HTTPS tests will be disabled in unit-tests.");
+        LOG_ERR("Failed to initialize Server SSL. Set the path to the certificates via "
+                "--cert-path. HTTPS tests will be disabled in unit-tests.");
     else
-        LOG_INF("Initialized SSL.");
+        LOG_INF("Initialized Server SSL.");
+
+    if (!ssl::Manager::isClientContextInitialized())
+        LOG_ERR("Failed to initialize Client SSL.");
+    else
+        LOG_INF("Initialized Client SSL.");
 #else
     LOG_INF("SSL is unsupported in this build.");
 #endif

--- a/tools/WebSocketDump.cpp
+++ b/tools/WebSocketDump.cpp
@@ -201,11 +201,13 @@ public:
     {
 #if ENABLE_SSL
         if (_isSSL)
-            return StreamSocket::create<SslStreamSocket>(physicalFd, false, std::make_shared<ClientRequestDispatcher>());
+            return StreamSocket::create<SslStreamSocket>(
+                std::string(), physicalFd, false, std::make_shared<ClientRequestDispatcher>());
 #else
-        (void) _isSSL;
+        (void)_isSSL;
 #endif
-        return StreamSocket::create<StreamSocket>(physicalFd, false, std::make_shared<ClientRequestDispatcher>());
+        return StreamSocket::create<StreamSocket>(std::string(), physicalFd, false,
+                                                  std::make_shared<ClientRequestDispatcher>());
     }
 };
 

--- a/tools/WebSocketDump.cpp
+++ b/tools/WebSocketDump.cpp
@@ -262,7 +262,8 @@ int main (int argc, char **argv)
     // Initialize the non-blocking socket SSL.
     if (isSSL)
         ssl::Manager::initializeServerContext(ssl_cert_file_path, ssl_key_file_path,
-                                              ssl_ca_file_path, ssl_cipher_list);
+                                              ssl_ca_file_path, ssl_cipher_list,
+                                              ssl::CertificateVerification::Disabled);
 #endif
 
     SocketPoll acceptPoll("accept");

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -1556,6 +1556,9 @@ void LOOLWSD::innerInitialize(Application& self)
 void LOOLWSD::initializeSSL()
 {
 #if ENABLE_SSL
+    if (!LOOLWSD::isSSLEnabled())
+        return;
+
     const std::string ssl_cert_file_path = getPathFromConfig("ssl.cert_file_path");
     LOG_INF("SSL Cert file: " << ssl_cert_file_path);
 

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -3681,11 +3681,8 @@ class PlainSocketFactory final : public SocketFactory
         if (SimulatedLatencyMs > 0)
             fd = Delay::create(SimulatedLatencyMs, physicalFd);
 #endif
-        std::shared_ptr<Socket> socket =
-            StreamSocket::create<StreamSocket>(
-                fd, false, std::make_shared<ClientRequestDispatcher>());
-
-        return socket;
+        return StreamSocket::create<StreamSocket>(std::string(), fd, false,
+                                                  std::make_shared<ClientRequestDispatcher>());
     }
 };
 
@@ -3701,8 +3698,8 @@ class SslSocketFactory final : public SocketFactory
             fd = Delay::create(SimulatedLatencyMs, physicalFd);
 #endif
 
-        return StreamSocket::create<SslStreamSocket>(
-            fd, false, std::make_shared<ClientRequestDispatcher>());
+        return StreamSocket::create<SslStreamSocket>(std::string(), fd, false,
+                                                     std::make_shared<ClientRequestDispatcher>());
     }
 };
 #endif
@@ -3712,7 +3709,8 @@ class PrisonerSocketFactory final : public SocketFactory
     std::shared_ptr<Socket> create(const int fd) override
     {
         // No local delay.
-        return StreamSocket::create<StreamSocket>(fd, false, std::make_shared<PrisonerRequestDispatcher>(),
+        return StreamSocket::create<StreamSocket>(std::string(), fd, false,
+                                                  std::make_shared<PrisonerRequestDispatcher>(),
                                                   StreamSocket::ReadType::UseRecvmsgExpectFD);
     }
 };

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -1575,7 +1575,7 @@ void LOOLWSD::initializeSSL()
 
     // Initialize the non-blocking server socket SSL context.
     ssl::Manager::initializeServerContext(ssl_cert_file_path, ssl_key_file_path, ssl_ca_file_path,
-                                          ssl_cipher_list);
+                                          ssl_cipher_list, ssl::CertificateVerification::Disabled);
 
     if (!ssl::Manager::isServerContextInitialized())
         LOG_ERR("Failed to initialize Server SSL.");

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -170,9 +170,11 @@ void StorageBase::initialize()
     Poco::Net::SSLManager::instance().initializeClient(consoleClientHandler, invalidClientCertHandler, sslClientContext);
 
     // Initialize our client SSL context.
-    ssl::Manager::initializeClientContext(sslClientParams.certificateFile,
-                                          sslClientParams.privateKeyFile,
-                                          sslClientParams.caLocation, sslClientParams.cipherList);
+    ssl::Manager::initializeClientContext(
+        sslClientParams.certificateFile, sslClientParams.privateKeyFile, sslClientParams.caLocation,
+        sslClientParams.cipherList,
+        sslClientParams.caLocation.empty() ? ssl::CertificateVerification::Disabled
+                                           : ssl::CertificateVerification::Required);
     if (!ssl::Manager::isClientContextInitialized())
         LOG_ERR("Failed to initialize Client SSL.");
     else


### PR DESCRIPTION
- wsd: move isLocalhost to a common area 
- Revert "wsd: initialize SSL if enabled or termination is enabled" 
- wsd: support certificate verification 
- wsd: ssl certificate verification requirements 
- wsd: killpoco: cert verification 
- wsd: test: improve modify test 
- wsd: prevent recycling the listening port during tests 
