### PR TITLE
Show verbose feedback when toggling log level and Trace Event generation

### DIFF
--- a/loleaflet/html/loleaflet.html.m4
+++ b/loleaflet/html/loleaflet.html.m4
@@ -249,6 +249,8 @@ m4_ifelse(MOBILEAPP,[true],
       <div id="lokit-version"></div>
       m4_ifelse(MOBILEAPP,[],[<div id="os-info" style="text-align:center"></div>])
       <div id="slow-proxy"></div>
+      <p id="log-level-state">
+      <p id="trace-event-state">
       <p>Copyright © _YEAR_, VENDOR.</p>
     </div>
 


### PR DESCRIPTION
Sadly I had to use a global variable to access the actual
contents of the Help>About window as being displayed in its key event
handler. If somebody can figure out the correct clean way to do it, be
my guest. (Look for the ExpertlyTrickForLOAbout.)

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: I88582e490d566d127d60226e045535e12c172e9c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

