### PR TITLE
Test CI cypress test stability without waitUntil() optimization

### DIFF
--- a/cypress_test/support/index.js
+++ b/cypress_test/support/index.js
@@ -31,13 +31,3 @@ if (Cypress.browser.isHeaded) {
 		});
 	});
 }
-
-// reduce poll interval when waiting.
-Cypress.Commands.overwrite('waitUntil', function(originalFn, subject, checkFunction, originalOptions) {
-	var options = originalOptions;
-	if (!options)
-		options = {};
-	if (!options.interval)
-		options.interval = 10; // ms
-	return originalFn(subject, checkFunction, options);
-});


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

