### PR TITLE
Cypress: Fix Insert, Remove image

### DIFF
--- a/cypress_test/integration_tests/common/desktop_helper.js
+++ b/cypress_test/integration_tests/common/desktop_helper.js
@@ -243,7 +243,11 @@ function insertImage() {
 		.attachFile('/desktop/writer/image_to_insert.png');
 
 	// hide the menu so it will not cover document area
-	cy.get('#menu-insert').click();
+	cy.get('#menu-insert > a.has-submenu').then(($submenu) => {
+		if ($submenu.hasClass('highlighted')) {
+			cy.get('#menu-insert').click();
+		}
+	});
 
 	cy.wait(1000);
 


### PR DESCRIPTION
Do not click blindly again in the insert menu once again in the hopes
of closing it in the case it's still opened, instead:
- Check if the menu is open (has highlighted)
- And if it's opened go ahead and click it again to close it

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I326848b396916dd6b2113f92c31d31d44920fc4c
