### PR TITLE
use pragma instead of header guards in freemium header files

### DIFF
--- a/common/Freemium.hpp
+++ b/common/Freemium.hpp
@@ -5,8 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-#ifndef ONLINE_COMMON_FREEMIUM
-#define ONLINE_COMMON_FREEMIUM
+#pragma once
 
 #include <string>
 #include <vector>
@@ -40,6 +39,5 @@ public:
     static std::string getDrawHighlights() { return config::getString("freemium.draw_subscription_highlights", ""); }
 };
 } // namespace Freemium
-#endif
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */


### PR DESCRIPTION
Signed-off-by: Pranam Lashkari <lpranam@collabora.com>
Change-Id: I5b55c2de4a2467503108e4172de84a27e207ba3c


* Target version: distro/collabora/co-6-4 


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

