### PR TITLE
Make it possible to generate Trace Events already when loading the do…

### DIFF
--- a/common/Session.cpp
+++ b/common/Session.cpp
@@ -52,7 +52,8 @@ Session::Session(const std::shared_ptr<ProtocolHandlerInterface> &protocol,
     _isAllowChangeComments(false),
     _haveDocPassword(false),
     _isDocPasswordProtected(false),
-    _watermarkOpacity(0.2)
+    _watermarkOpacity(0.2),
+    _traceEventRecordingAtStart(false)
 {
 }
 
@@ -203,6 +204,17 @@ void Session::parseDocOptions(const StringVector& tokens, int& part, std::string
         else if (name == "macroSecurityLevel")
         {
             _macroSecurityLevel = value;
+            ++offset;
+        }
+        else if (name == "traceeventrecording")
+        {
+            // Ignore value, it is there only becaue the silly code doesn't accept parameters without a value
+            _traceEventRecordingAtStart = true;
+            ++offset;
+        }
+        else
+        {
+            LOG_WRN("Unrecognized load option " << name);
             ++offset;
         }
     }

--- a/common/Session.hpp
+++ b/common/Session.hpp
@@ -233,6 +233,8 @@ public:
 
     const std::string& getMacroSecurityLevel() const { return _macroSecurityLevel; }
 
+    bool getTraceEventRecordingAtStart () const { return _traceEventRecordingAtStart; }
+
 protected:
     Session(const std::shared_ptr<ProtocolHandlerInterface> &handler,
             const std::string& name, const std::string& id, bool readonly);
@@ -340,6 +342,10 @@ private:
 
     /// Level of Macro security.
     std::string _macroSecurityLevel;
+
+    /// Whether Trace Event recording is turned on right from the start (this is not relevant if it is turned on after the document
+    /// is already loaded, which is the normal case)
+    bool _traceEventRecordingAtStart;
 };
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -648,6 +648,17 @@ bool ChildSession::loadDocument(const char * /*buffer*/, int /*length*/, const S
     std::string timestamp, doctemplate;
     parseDocOptions(tokens, part, timestamp, doctemplate);
 
+    if (getTraceEventRecordingAtStart())
+    {
+            static const bool traceEventsEnabled = config::getBool("trace_event[@enable]", false);
+            if (traceEventsEnabled)
+            {
+                getLOKit()->setOption("traceeventrecording", "start");
+                TraceEvent::startRecording();
+                LOG_INF("Trace Event recording in this Kit process turned on");
+            }
+    }
+
     std::string renderOpts;
     if (!getDocOptions().empty())
     {

--- a/loleaflet/js/global.js
+++ b/loleaflet/js/global.js
@@ -105,6 +105,8 @@ window.app.definitions = {};
 
 		/// Shows revision history file menu option
 		revHistoryEnabled: global.getParameterByName('revisionhistory'),
+
+		traceEventsRequested: global.getParameterByName('traceevents') !== '',
 	};
 
 	global.L.Browser = {

--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -222,8 +222,16 @@ app.definitions.Socket = L.Class.extend({
 				msg += ' spellOnline=' + spellOnline;
 			}
 		}
+		// If there was a query parameter requesting Trace Event recording right from the
+		// start, forward that request to the server. Note that if Trace Event recording is
+		// not enabled for the server, this will have no effect.
+		if (L.Params.traceEventsRequested) {
+			this.traceEventRecordingToggle = true;
+			msg += ' traceeventrecording=yes';
+		}
 
 		this._doSend(msg);
+
 		for (var i = 0; i < this._msgQueue.length; i++) {
 			this._doSend(this._msgQueue[i]);
 		}

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -918,21 +918,9 @@ bool ClientSession::_handleInput(const char *buffer, int length)
     }
     else if (tokens.equals(0, "traceeventrecording"))
     {
-        if (LOOLWSD::getConfigValue<bool>("trace_event[@enable]", false))
+        static const bool traceEventsEnabled = LOOLWSD::getConfigValue<bool>("trace_event[@enable]", false);
+        if (traceEventsEnabled)
         {
-            if (tokens.size() > 0)
-            {
-                if (tokens.equals(1, "start"))
-                {
-                    TraceEvent::startRecording();
-                    LOG_INF("Trace Event recording in this WSD process turned on (might have been on already)");
-                }
-                else if (tokens.equals(1, "stop"))
-                {
-                    TraceEvent::stopRecording();
-                    LOG_INF("Trace Event recording in this WSD process turned off (might have been off already)");
-                }
-            }
             forwardToChild(firstLine, docBroker);
         }
         return true;
@@ -1094,6 +1082,11 @@ bool ClientSession::loadDocument(const char* /*buffer*/, int /*length*/,
         if (LOOLWSD::hasProperty("security.macro_security_level"))
         {
             oss << " macroSecurityLevel=" << LOOLWSD::getConfigValue<int>("security.macro_security_level", 1);
+        }
+
+        if (getTraceEventRecordingAtStart())
+        {
+            oss << " traceeventrecording=yes";
         }
 
         if (!getDocOptions().empty())


### PR DESCRIPTION
…cument

By passing a traceevent=yes query parameter in the URL. Note that if
Trace Event generation is not enabled in loolwsd.xml this will have no
effect.

It is a bit silly to notice this query parameter only in loleaflet and
then send the information back to the server. Would be better if the
server noticed it itself before sending the URL to loleaflet.

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: I985bfd1e2dbd14aa5a55b386b4762fb64bcb4008


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

