### PR TITLE
Stop clipboard copy operation on selection change

### DIFF
--- a/loleaflet/src/control/Control.DownloadProgress.js
+++ b/loleaflet/src/control/Control.DownloadProgress.js
@@ -85,6 +85,17 @@ L.Control.DownloadProgress = L.Control.extend({
 		return this._started;
 	},
 
+	currentStatus: function () {
+		if (this._closed)
+			return 'closed';
+		if (this._content.contains(this._downloadButton))
+			return 'downloadButton';
+		if (this._content.contains(this._progress))
+			return 'progress';
+		if (this._content.contains(this._confirmPasteButton))
+			return 'confirmPasteButton';
+	},
+
 	setURI: function (uri) {
 		// set up data uri to be downloaded
 		this._uri = uri;


### PR DESCRIPTION
So that when user decided to not start download or copy to clipboard,
and moved to other things, the notification gets disposed.

Signed-off-by: Mike Kaganski <mike.kaganski@collabora.com>
Change-Id: Ifebd61594a87a37e83b0ec81b62c501792913a98
