### PR TITLE
Ignore conversion error from std::stoull for "busypopup"

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -1533,7 +1533,20 @@ bool ChildSession::dialogEvent(const char* /*buffer*/, int /*length*/, const Str
         return false;
     }
 
-    unsigned long long int nLOKWindowId = std::stoull(tokens[1].c_str());
+    unsigned long long int nLOKWindowId;
+    try
+    {
+        nLOKWindowId = std::stoull(tokens[1].c_str());
+    }
+    catch (const std::exception&)
+    {
+        // Let's just silently ignore the conversion error. (We used to log an ERR message about the
+        // exception, which presumably is misleading, as the JS code intentionally sends tokens[1]
+        // as "busypopup". No idea whether that is wrong or whether the parsing here is too strict.)
+        // FIXME: The dialogevent message is undocumented.
+        return true;
+    }
+
     if (_isDocLoaded)
     {
         getLOKitDocument()->setView(_viewId);


### PR DESCRIPTION
Avoids logging an ERR message about it.

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: If9e9627b3a10362e415edf2bfa6abf1f37c0b650


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

