### PR TITLE
Make a fresh perf-test-edit.odt copy only when needed

### DIFF
--- a/loleaflet/Makefile.am
+++ b/loleaflet/Makefile.am
@@ -727,7 +727,10 @@ SSL_FLAG = `xmllint --xpath 'string(/config/ssl/enable)' $(abs_top_builddir)/loo
 perf-test:
 	@echo "Running perf tests..."
 	@mkdir -p $(abs_top_builddir)/test/data
-	@cp $(abs_top_srcdir)/test/data/perf-test.odt $(abs_top_builddir)/test/data/perf-test-edit.odt
+	@if [ ! -f $(abs_top_srcdir)/test/data/perf-test-edit.odt -o "`md5sum <$(abs_top_srcdir)/test/data/perf-test.odt`" != "`md5sum <$(abs_top_srcdir)/test/data/perf-test-edit.odt`" ]; then \
+		echo 'Making fresh copy of the perf-test-edit.odt document'; \
+		cp $(abs_top_srcdir)/test/data/perf-test.odt $(abs_top_builddir)/test/data/perf-test-edit.odt; \
+	fi
 	for a in 2 3 4 5 6; do \
 		$(NODE) $(abs_srcdir)/test/load.js $(SSL_FLAG) $(abs_top_builddir) $(abs_top_builddir)/test/data/perf-test-edit.odt testEdit_$$a & \
 	done


### PR DESCRIPTION
Hopefully will reduce the amount of "Document has changed in storage"
irritation if following the progress of the script in a normal
browser. Make a fresh copy manually before running `make run` and
opening the document in your browser.

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: Icba6dd80fb202fce3f2ff288af0d1759bc7789be


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

