### PR TITLE
cypress: fix sheetoperation spec

### DIFF
--- a/cypress_test/integration_tests/desktop/calc/sheet_operation_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/sheet_operation_spec.js
@@ -2,7 +2,7 @@
 
 var helper = require('../../common/helper');
 
-describe('Apply font changes.', function () {
+describe('Sheet Operations.', function () {
 	var testFileName = 'sheet_operation.ods';
 
 	beforeEach(function () {
@@ -25,6 +25,8 @@ describe('Apply font changes.', function () {
 	}
 
 	function selectOptionFromContextMenu(contextMenu) {
+		cy.wait(1000);
+
 		cy.get('.spreadsheet-tab.spreadsheet-tab-selected')
 			.rightclick();
 

--- a/loleaflet/src/control/Control.Tabs.js
+++ b/loleaflet/src/control/Control.Tabs.js
@@ -68,7 +68,6 @@ L.Control.Tabs = L.Control.extend({
 			'.uno:Show': {
 				name: _UNO('.uno:Show', 'spreadsheet', true),
 				callback: (this._showSheet).bind(this),
-				visible: areTabsMultiple
 			},
 			'.uno:Hide': {
 				name: _UNO('.uno:Hide', 'spreadsheet', true),
@@ -142,6 +141,7 @@ L.Control.Tabs = L.Control.extend({
 							'insertsheetbefore' : this._menuItem['insertsheetbefore'],
 							'insertsheetafter'  :   this._menuItem['insertsheetafter'],
 							'.uno:Name' : this._menuItem['.uno:Name'],
+							'.uno:Show' : this._menuItem['.uno:Show'],
 						}
 					);
 				} else {


### PR DESCRIPTION
leaflet: show option hidden when only one sheet
Signed-off-by: Rash419 <rashesh.padia@collabora.com>
Change-Id: I885e64ce328b7d90777ec14e7cb24fa492490386

