### PR TITLE
Don't output errno information when a syscall hasn't failed

### DIFF
--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -1080,10 +1080,9 @@ public:
                 len = readData(buf, sizeof(buf));
                 last_errno = errno;
 
-                LOG_TRC('#' << getFD() << ": Read incoming data " << len << " bytes in addition to "
-                            << _inBuffer.size() << " buffered bytes ("
-                            << Util::symbolicErrno(last_errno) << ": " << std::strerror(last_errno)
-                            << ')');
+                if (len > 0)
+                    LOG_TRC('#' << getFD() << ": Read incoming data " << len << " bytes in addition to "
+                            << _inBuffer.size() << " buffered bytes");
 
                 if (len < 0 && last_errno != EAGAIN && last_errno != EWOULDBLOCK)
                     LOG_SYS_ERRNO(last_errno, '#' << getFD() << ": Socket read returned " << len);
@@ -1337,10 +1336,9 @@ public:
                 len = writeData(_outBuffer.getBlock(), size);
                 last_errno = errno; // Save right after the syscall.
 
-                LOG_TRC('#' << getFD() << ": Wrote outgoing data " << len << " bytes of "
-                            << _outBuffer.size() << " buffered bytes ("
-                            << Util::symbolicErrno(last_errno) << ": " << std::strerror(last_errno)
-                            << ')');
+                if (len > 0)
+                    LOG_TRC('#' << getFD() << ": Wrote outgoing data " << len << " bytes of "
+                            << _outBuffer.size() << " buffered bytes");
 
 #ifdef LOG_SOCKET_DATA
                 if (len > 0 && !_outBuffer.empty())


### PR DESCRIPTION
Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: I90a65c444d9a300f7dd446db6c3617d7f580855c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

