### PR TITLE
Improve cell cursor/selection/autofill-marker style

### DIFF
--- a/loleaflet/css/loleaflet.css
+++ b/loleaflet/css/loleaflet.css
@@ -21,6 +21,9 @@
 	--gray-light-txt--color: #696969;
 	--gray-light-bg-color: #EFEFEF;
 	--gray-color: #b6b6b6;
+
+	/* Shared color for cell and selection border */
+	--cell-cursor-selection-border-color: #0074e8;
 }
 /* clip technique: hide visually but keep it available to screen readers */
 .visuallyhidden {
@@ -686,7 +689,7 @@ nav.spreadsheet-color-indicator ~ #sidebar-dock-wrapper {
 	border-style: solid; /* required for ie11 */
 	display: none; /* prevent cypress failure */
 
-	border-top-color: #000000; /* color */
+	border-top-color: var(--cell-cursor-selection-border-color); /* color */
 	border-top-width: 2px; /* weight */
 }
 
@@ -694,9 +697,9 @@ nav.spreadsheet-color-indicator ~ #sidebar-dock-wrapper {
 	border-style: solid; /* required for ie11 */
 	display: none; /* prevent cypress failure */
 
-	background-color: #43ACE8; /* fill color */
+	background-color: var(--cell-cursor-selection-border-color); /* fill color */
 	opacity: 0.25; /* opacity */
-	border-top-width: 2px; /* weight */
+	border-top-width: 1px; /* weight */
 }
 
 .leaflet-canvas-container .splitters-data {

--- a/loleaflet/src/layer/marker/TextInput.js
+++ b/loleaflet/src/layer/marker/TextInput.js
@@ -428,7 +428,7 @@ L.TextInput = L.Layer.extend({
 
 		// Move and display under-caret marker
 		if (L.Browser.touch) {
-			if (this._map._docLayer._selections.empty()) {
+			if (this._map._docLayer._textCSelections.empty()) {
 				this._cursorHandler.setLatLng(bottom).addTo(this._map);
 			} else {
 				this._map.removeLayer(this._cursorHandler);

--- a/loleaflet/src/layer/tile/CalcTileLayer.js
+++ b/loleaflet/src/layer/tile/CalcTileLayer.js
@@ -275,10 +275,10 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 	},
 
 	_getSelectionHeaderData: function() {
-		if (this._selections.empty())
+		if (this._cellCSelections.empty())
 			return { hasSelection: false };
 
-		var bounds = this._selections.getBounds();
+		var bounds = this._cellCSelections.getBounds();
 		console.assert(bounds.isValid(), 'Non empty selection should have valid bounds');
 		return {
 			hasSelection: true,

--- a/loleaflet/src/layer/tile/GridLayer.js
+++ b/loleaflet/src/layer/tile/GridLayer.js
@@ -49,9 +49,14 @@ L.GridLayer = L.Layer.extend({
 		this._clearPreFetch();
 		clearTimeout(this._previewInvalidator);
 
-		if (!this._selections.empty()) {
-			this._selections.clear();
+		if (!this._cellCSelections.empty()) {
+			this._cellCSelections.clear();
 		}
+
+		if (!this._textCSelections.empty()) {
+			this._textCSelections.clear();
+		}
+
 		if (this._cursorMarker && this._cursorMarker.isDomAttached()) {
 			this._cursorMarker.remove();
 		}

--- a/loleaflet/src/layer/tile/TileLayer.js
+++ b/loleaflet/src/layer/tile/TileLayer.js
@@ -105,9 +105,10 @@ var CSelections = L.Class.extend({
 			var attributes = {
 				name: this._name,
 				pointerEvents: 'none',
+				color: fillColor,
 				fillColor: fillColor,
 				fillOpacity: opacity,
-				opacity: opacity,
+				opacity: 1.0,
 				weight: Math.round(weight * this._dpiScale)
 			};
 			this._cellSelection = new CCellSelection(this._pointSet, attributes);

--- a/loleaflet/src/layer/tile/TileLayer.js
+++ b/loleaflet/src/layer/tile/TileLayer.js
@@ -6,7 +6,7 @@
 // Implement String::startsWith which is non-portable (Firefox only, it seems)
 // See http://stackoverflow.com/questions/646628/how-to-check-if-a-string-startswith-another-string#4579228
 
-/* global app vex $ L _ isAnyVexDialogActive CPointSet CPolyUtil CPolygon Cursor CBounds CCellCursor CCellSelection */
+/* global app vex $ L _ isAnyVexDialogActive CPointSet CPolyUtil CPolygon Cursor CBounds CCellCursor CCellSelection PathGroupType */
 /*eslint no-extend-native:0*/
 if (typeof String.prototype.startsWith !== 'function') {
 	String.prototype.startsWith = function (str) {
@@ -104,6 +104,8 @@ var CSelections = L.Class.extend({
 			var opacity = this._styleData.getFloatPropValue('opacity');
 			var weight = this._styleData.getFloatPropWithoutUnit('border-top-width');
 			var attributes = this._isText ? {
+				viewId: this._isView ? this._viewId : undefined,
+				groupType: PathGroupType.TextSelection,
 				name: this._name,
 				pointerEvents: 'none',
 				fillColor: fillColor,
@@ -114,6 +116,7 @@ var CSelections = L.Class.extend({
 				fill: true,
 				weight: 1.0
 			} : {
+				viewId: this._isView ? this._viewId : undefined,
 				name: this._name,
 				pointerEvents: 'none',
 				color: fillColor,
@@ -1672,6 +1675,7 @@ L.TileLayer = L.GridLayer.extend({
 			if (!cellViewCursorMarker) {
 				var backgroundColor = L.LOUtil.rgbToHex(this._map.getViewColor(viewId));
 				cellViewCursorMarker = new CCellCursor(this._cellViewCursors[viewId].corePixelBounds, {
+					viewId: viewId,
 					fill: false,
 					color: backgroundColor,
 					weight: 2 * (this._painter ? this._painter._dpiScale : 1),
@@ -2956,7 +2960,7 @@ L.TileLayer = L.GridLayer.extend({
 				viewSelection.setPointSet(viewPointSet);
 			} else {
 				viewSelection = new CSelections(viewPointSet, this._canvasOverlay,
-					this._painter._dpiScale, this._selectionsDataDiv, this._map, true, viewId, true);
+					this._painter._dpiScale, this._selectionsDataDiv, this._map, true /* isView */, viewId, true /* isText */);
 				this._viewSelections[viewId].selection = viewSelection;
 			}
 		}

--- a/loleaflet/src/layer/tile/TileLayer.js
+++ b/loleaflet/src/layer/tile/TileLayer.js
@@ -1999,7 +1999,8 @@ L.TileLayer = L.GridLayer.extend({
 	_onTextSelectionMsg: function (textMsg) {
 
 		var rectArray = this._getTextSelectionRectangles(textMsg);
-		var isTextSelection = this.isCursorVisible();
+		var inTextSearch = $('input#search-input').is(':focus');
+		var isTextSelection = this.isCursorVisible() || inTextSearch;
 		if (rectArray.length) {
 
 			var rectangles = rectArray.map(function (rect) {

--- a/loleaflet/src/layer/vector/CPath.ts
+++ b/loleaflet/src/layer/vector/CPath.ts
@@ -24,6 +24,8 @@ abstract class CPath extends CEventsHandler {
 	fixed: boolean = false; // CPath coordinates are the same as overlay section coordinates.
 	cursorType: string;
 	thickness: number = 2;
+	viewId: number = -1;
+	groupType: PathGroupType = PathGroupType.Other;
 	toCompatUnits: Function;
 
 	radius: number = 0;
@@ -51,10 +53,21 @@ abstract class CPath extends CEventsHandler {
 		this.point = options.point !== undefined ? options.point : this.point;
 		this.toCompatUnits = options.toCompatUnits !== undefined ? options.toCompatUnits : this.toCompatUnits;
 
+		this.viewId = CPath.getViewId(options);
+		if (options.groupType !== undefined)
+			this.groupType = options.groupType;
+
 		CPath.countObjects += 1;
 		this.id = CPath.countObjects;
 		this.zIndex = this.id;
 		this.addSupportedEvents(['popupopen', 'popupclose']);
+	}
+
+	static getViewId(options: any): number {
+		if (options.viewId === undefined || options.viewId === null) // Own cell cursor/selection
+			return -1;
+		else
+			return parseInt(options.viewId);
 	}
 
 	setStyleOptions(options: any) {
@@ -315,6 +328,14 @@ abstract class CPath extends CEventsHandler {
 	}
 
 };
+
+// This also defines partial rendering order.
+enum PathGroupType {
+	CellSelection, // bottom.
+	TextSelection,
+	CellCursor,
+	Other  // top.
+}
 
 class CPathGroup {
 	private paths: CPath[];

--- a/loleaflet/src/layer/vector/CRectangle.ts
+++ b/loleaflet/src/layer/vector/CRectangle.ts
@@ -51,6 +51,8 @@ class CCellCursor extends CPathGroup {
 		this.options = options;
 		this.options.lineJoin = 'miter';
 		this.options.lineCap = 'butt';
+		this.options.viewId = CPath.getViewId(options);
+		this.options.groupType = PathGroupType.CellCursor;
 
 		this.setBounds(bounds);
 	}
@@ -126,6 +128,8 @@ class CCellSelection extends CPathGroup {
 		this.options = options;
 		this.options.lineJoin = 'miter';
 		this.options.lineCap = 'butt';
+		this.options.viewId = CPath.getViewId(options);
+		this.options.groupType = PathGroupType.CellSelection;
 
 		this.setPointSet(pointSet);
 	}

--- a/loleaflet/src/map/handler/Map.Keyboard.js
+++ b/loleaflet/src/map/handler/Map.Keyboard.js
@@ -427,7 +427,7 @@ L.Map.Keyboard = L.Handler.extend({
 				map.fire('scrollby', {x: this._panKeys[key][0], y: this._panKeys[key][1]});
 			}
 			else if (key in this._panKeys && ev.shiftKey &&
-					!docLayer._selections.empty()) {
+					!docLayer._textCSelections.empty()) {
 				// if there is a selection and the user wants to modify it
 				keyEventFn('input', charCode, unoKeyCode);
 			}


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: co-6-4

### Summary
Improved styling of cell cursor/selection autofill-marker.

1. Improve styling of cursor/selection/autofill-marker
    
    * Autofillmaker should follow the grid (not go overboard as it is now)
    * Add one white border to the selection (but very discreet, 1 pixel)
    * The autofillmarker, selected outline and cell cursor should share the
      same color. That color should come from css var (so it fits better
      with surrounding elements, cell headers etc).
    
    Caveats:
    
    * Autofill-marker in mobile devices was positioned and sized
      differently. With this change, they stay the same except for the color
      and the contrast border. Styling this needs more thought.

2. Separate the styling of cell and text selections
    
    We now have a very specific design for cell-area selections which
    involves many paths. However we don't need the same styling for text
    selections. Use a simple CPolygon based drawing for text-selections till
    we come up with a better styling for them.

3. Fix render ordering of CPaths based on groups [cell-cursor, cell-selection etc..] and viewId.

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

