### PR TITLE
wsd: don't re-render tiles while closing a session.

### DIFF
--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -2100,6 +2100,12 @@ void ClientSession::handleTileInvalidation(const std::string& message,
         return;
     }
 
+    // While saving / shutting down we can get big invalidatiions: ignore them
+    if (isCloseFrame()) {
+        LOG_TRC("Session [" << getId() << "] ignoring invalidation during close: '" << message);
+        return;
+    }
+
     std::pair<int, Util::Rectangle> result = TileCache::parseInvalidateMsg(message);
     int part = result.first;
     Util::Rectangle& invalidateRect = result.second;


### PR DESCRIPTION
During the save during shutdown we can get big invalidation
emissions, there is no point in re-rendering the view at that
stage; so skip it.

Change-Id: Ie85ef57648815a1872ca35dcb1bdfc9fa54e64c0


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

