### PR TITLE
Log Last 4 Uno Commands During a Fatal Crash

### DIFF
--- a/common/SigUtil.cpp
+++ b/common/SigUtil.cpp
@@ -78,6 +78,14 @@ namespace SigUtil
 #endif
     }
 
+    UnoCommandsDumperFn dumpUnoCommandsInfoFn = nullptr;
+
+    void registerUnoCommandInfoHandler(UnoCommandsDumperFn dumpUnoCommandsInfo)
+    {
+        dumpUnoCommandsInfoFn = dumpUnoCommandsInfo;
+    }
+
+
 #if !MOBILEAPP
     /// This traps the signal-handler so we don't _Exit
     /// while dumping stack trace. It's re-entrant.
@@ -242,6 +250,11 @@ namespace SigUtil
         else
             Log::signalLog(" Fatal signal received: ");
         Log::signalLog(signalName(signal));
+
+        if (dumpUnoCommandsInfoFn != nullptr)
+        {
+            dumpUnoCommandsInfoFn();
+        }
 
         struct sigaction action;
 

--- a/common/SigUtil.hpp
+++ b/common/SigUtil.hpp
@@ -48,6 +48,12 @@ namespace SigUtil
 
     void checkDumpGlobalState(GlobalDumpStateFn dumpState);
 
+    typedef void (*UnoCommandsDumperFn)(void);
+
+    extern UnoCommandsDumperFn dumpUnoCommandsInfoFn;
+
+    void registerUnoCommandInfoHandler(UnoCommandsDumperFn dumpUnoCommandsInfo);
+
 #if !MOBILEAPP
     /// Wait for the signal handler, if any,
     /// and prevent _Exit while collecting backtrace.

--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -886,6 +886,27 @@ int main(int argc, char**argv)
         return std::string(message, size);
     }
 
+    /// Eliminates the prefix from str(if present) and returns a copy of the modified string
+    inline
+    std::string eliminatePrefix(const std::string& str, const std::string& prefix)
+    {
+        std::string::const_iterator prefix_pos;
+        std::string::const_iterator str_pos;
+
+        std::tie(prefix_pos,str_pos) = std::mismatch(prefix.begin(), prefix.end(), str.begin());
+
+        if (prefix_pos == prefix.end())
+        {
+            // Non-Prefix part
+            return std::string(str_pos, str.end());
+        }
+        else
+        {
+            // Return the original string as it is
+            return str;
+        }
+    }
+
     /// Split a string in two at the delimiter, removing it.
     inline
     std::pair<std::string, std::string> split(const char* s, const int length, const char delimiter = ' ', bool removeDelim = true)

--- a/kit/ChildSession.hpp
+++ b/kit/ChildSession.hpp
@@ -10,6 +10,8 @@
 #include <unordered_map>
 #include <queue>
 
+#include <atomic>
+
 #define LOK_USE_UNSTABLE_API
 #include <LibreOfficeKit/LibreOfficeKit.hxx>
 
@@ -184,6 +186,22 @@ public:
     }
 };
 
+class UnoCommandsRecorder
+{
+public:
+    static const int NUM_UNO_COMMANDS = 4;
+
+    UnoCommandsRecorder();
+
+    void addUnoCommandInfo(const std::string& unoCommandInfo);
+    std::atomic<char*>* getRecordedCommands();
+
+private:
+    std::atomic<char*> _unocommands[NUM_UNO_COMMANDS];
+    std::atomic<unsigned long long> _currentpos;
+
+};
+
 /// Represents a session to the WSD process, in a Kit process. Note that this is not a singleton.
 class ChildSession final : public Session
 {
@@ -307,6 +325,8 @@ private:
     virtual void disconnect() override;
     virtual bool _handleInput(const char* buffer, int length) override;
 
+    static void dumpRecordedUnoCommands();
+
     std::shared_ptr<lok::Document> getLOKitDocument() const
     {
         return _docManager->getLOKitDocument();
@@ -360,6 +380,8 @@ private:
     bool _copyToClipboard;
 
     std::vector<uint64_t> _pixmapCache;
+
+    static UnoCommandsRecorder unoCommandsRecorder;
 };
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */


### PR DESCRIPTION
Records the uno commands from different instances of Child Session and
dumps the last 4 uno commands into the Crash log during a fatal crash

Signed-off-by: Gopi Krishna Menon <krishnagopi487.github@outlook.com>
Change-Id: I838f71769dc08df7076c040f3d72c15f7607e9d3


### Checklist

- [X ] Code is properly formatted
- [X] All commits have Change-Id
- [X] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

