### PR TITLE
notebookbar: reduce importance of 'not initialized' message

### DIFF
--- a/loleaflet/src/control/Control.Notebookbar.js
+++ b/loleaflet/src/control/Control.Notebookbar.js
@@ -69,7 +69,8 @@ L.Control.Notebookbar = L.Control.extend({
 		var that = this;
 		var retryNotebookbarInit = function() {
 			if (!that.map._isNotebookbarLoadedOnCore) {
-				console.error('notebookbar is not initialized, retrying');
+				// if notebookbar doesn't have any welded controls it can trigger false alarm here
+				console.warn('notebookbar might be not initialized, retrying');
 				that.map.sendUnoCommand('.uno:ToolbarMode?Mode:string=notebookbar_online.ui');
 			}
 		};
@@ -101,6 +102,8 @@ L.Control.Notebookbar = L.Control.extend({
 
 		if (!this.container)
 			return;
+
+		this.map._isNotebookbarLoadedOnCore = true;
 
 		var control = this.container.querySelector('#' + data.control.id);
 		if (!control) {
@@ -138,6 +141,8 @@ L.Control.Notebookbar = L.Control.extend({
 
 		if (!this.container)
 			return;
+
+		this.map._isNotebookbarLoadedOnCore = true;
 
 		this.builder.executeAction(this.container, data.data);
 	},

--- a/loleaflet/src/control/Control.NotebookbarDraw.js
+++ b/loleaflet/src/control/Control.NotebookbarDraw.js
@@ -67,13 +67,6 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 		];
 	},
 
-	/// override to not load tabs from core
-	onNotebookbar: function(data) {
-		this.map._isNotebookbarLoadedOnCore = true;
-		// setup id for events
-		this.builder.setWindowId(data.id);
-	},
-
 	getTabs: function() {
 		return [
 			{


### PR DESCRIPTION
- when we receive any notification - mark notebookbar as initialized
- if we haven't received any information eg. in impress - warn
  reduce importance of this from error to warn as it is not important
  probably there is no widget which sends updates (correct for draw and
impress)

Signed-off-by: Szymon Kłos <szymon.klos@collabora.com>
Change-Id: I88ae3a090014dd25e59e04993c0c244d8830435e
