### PR TITLE
git-hooks: pre-commit: clean up not needed tweak of the perl library path

### DIFF
--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -6,9 +6,6 @@
 # if it wants to stop the commit.
 
 use strict;
-use lib "solenv/clang-format";
-#use File::Copy;
-#use Cwd;
 
 $ENV{LC_ALL} = "C";
 


### PR DESCRIPTION
This was copied from core.git, but it's not relevant for online.git.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I8b9c0c3039e55dee46f30dc1afc8276f7bbd55c9
