### PR TITLE
Additional control for ResizeObserver for NodeJS tests

### DIFF
--- a/loleaflet/js/ResizeObserverPolyfill.js
+++ b/loleaflet/js/ResizeObserverPolyfill.js
@@ -6,7 +6,7 @@
 
 var isIE11_ = !!window.MSInputMethodContext && !!document.documentMode;
 
-if (isIE11_) {
+if (isIE11_ || typeof ResizeObserver === 'undefined') {
     (function (global, factory) {
         typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
         typeof define === 'function' && define.amd ? define(factory) :


### PR DESCRIPTION
ResizeObserver is not defined for JSDOM as well
Better to check that not only for IE11.

Signed-off-by: Mert Tumer <mert.tumer@collabora.com>
Change-Id: Idb080f1a320c291dca71a73e76b8d754a76e1108


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

