### PR TITLE
Main-document-content: Prevent over-sizing.

### DIFF
--- a/loleaflet/css/partsPreviewControl.css
+++ b/loleaflet/css/partsPreviewControl.css
@@ -3,6 +3,7 @@
 	overflow-x: hidden;
 	overflow-y: visible;
 	background: #dfdfdf;
+	max-height: 100%;
 	scrollbar-color: #ccc #dfdfdf;
 	scrollbar-width: thin;
 }

--- a/loleaflet/html/loleaflet.html.m4
+++ b/loleaflet/html/loleaflet.html.m4
@@ -204,7 +204,7 @@ m4_ifelse(MOBILEAPP,[true],
       <div class="closebuttonimage" id="closebutton"></div>
     </div>
 
-    <div id="main-document-content" style="display:flex; flex-direction: row; flex: 1; margin: 0; padding: 0">
+    <div id="main-document-content" style="display:flex; flex-direction: row; flex: 1; margin: 0; padding: 0; min-height: 0">
       <div id="presentation-controls-wrapper" class="readonly">
         <div id="slide-sorter"></div>
         <div id="presentation-toolbar" style="display: none"></div>


### PR DESCRIPTION
Set min-height property to prevent exceeding the available size.

slide-sorter: Set max-height to prevent over-sizing relative its parent.

Signed-off-by: Gökay ŞATIR <gokaysatir@gmail.com>
Change-Id: Ib8c50bc9f6f6ac4311cefa3b0e016da728efe95b


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

