### PR TITLE
Impress:

### DIFF
--- a/loleaflet/css/device-mobile.css
+++ b/loleaflet/css/device-mobile.css
@@ -582,19 +582,17 @@ td[id^='tb_spreadsheet-toolbar_item']:focus table.w2ui-button div.w2ui-icon, td[
 	height: 60px;
 	overflow-x: scroll;
 	overflow-y: hidden;
+	line-height: 60px;
 }
 
-.preview-img-portrait {
+#slide-sorter.portrait .preview-img {
 	min-width: 37px;
 	max-width: 60px;
-	margin-left: 0px;
-	margin-right: 0px;
-	margin-bottom: 5px;
-	margin-top: 2px;
 	max-height: 45px;
+	margin: 0;
 }
 
-.preview-frame-portrait {
+#slide-sorter.portrait .preview-frame {
 	max-height: 60px;
 	max-width: 100%;
 	display: inline-block;
@@ -602,7 +600,7 @@ td[id^='tb_spreadsheet-toolbar_item']:focus table.w2ui-button div.w2ui-icon, td[
 	margin: 0;
 }
 
-.preview-frame-portrait.preview-img-dropsite {
+#slide-sorter.portrait .preview-frame.preview-img-dropsite {
 	padding-right: 0px;
 	border-right: 20px solid var(--gray-color);
 	border-bottom: none;
@@ -617,20 +615,21 @@ td[id^='tb_spreadsheet-toolbar_item']:focus table.w2ui-button div.w2ui-icon, td[
 	overflow-y: scroll;
 }
 
-.preview-img-landscape {
+#slide-sorter.landscape .preview-img {
 	min-width: 20px;
 	max-width: 60px;
-	margin-left: 1px;
+	margin: 0;
 }
 
-.preview-frame-landscape {
+#slide-sorter.landscape .preview-frame {
 	max-height: initial;
 	max-width: 66px;
 	display: block;
+	margin: 1em 3px;
 }
 
 /* Highlight where a slide can be dropped when reordering by drag-and-drop. */
-.preview-frame-landscape.preview-img-dropsite {
+#slide-sorter.landscape .preview-frame.preview-img-dropsite {
 	border-bottom: 10px solid var(--gray-color);
 }
 

--- a/loleaflet/css/loleaflet.css
+++ b/loleaflet/css/loleaflet.css
@@ -237,7 +237,7 @@ nav.spreadsheet-color-indicator ~ #sidebar-dock-wrapper {
 	transition: transform 0.5s;
 }
 
-#mobile-edit-button.impress {
+#mobile-edit-button.impress.portrait{
 	bottom: 70px;
 }
 

--- a/loleaflet/css/menubar.css
+++ b/loleaflet/css/menubar.css
@@ -249,10 +249,6 @@
 	display: block;
 }
 
-.readonly {
-	top: 3px;
-}
-
 /* Some more lo-menu specific customizations */
 
 /* The smartmenus plugin doesn't seem to have support for icons, so implement our own pseudo-elements */

--- a/loleaflet/css/toolbar.css
+++ b/loleaflet/css/toolbar.css
@@ -94,6 +94,7 @@ w2ui-toolbar {
 }
 
 #presentation-toolbar {
+	bottom: 0;
 	background-color: #dfdfdf;
 	text-align: center;
 	position: absolute;

--- a/loleaflet/src/control/Control.MobileWizard.js
+++ b/loleaflet/src/control/Control.MobileWizard.js
@@ -407,9 +407,6 @@ L.Control.MobileWizard = L.Control.extend({
 				window.mobileDialogId = data.id;
 			}
 
-			if (this.map.getDocType() === 'presentation' && this._isSlidePropertyPanel(data))
-				this._showSlideSorter();
-
 			this._isActive = true;
 			var currentPath = null;
 			var lastScrollPosition = null;
@@ -485,13 +482,6 @@ L.Control.MobileWizard = L.Control.extend({
 
 			this._inBuilding = false;
 		}
-	},
-
-	// These 2 functions show/hide mobile-slide-sorter.
-	_showSlideSorter: function() {
-		document.getElementById('mobile-wizard-header').style.display = 'block';
-		document.getElementById('mobile-wizard-header').style.whiteSpace = 'nowrap';
-		document.getElementById('mobile-wizard-header').style.overflowX = 'auto';
 	},
 
 	_hideSlideSorter: function() {

--- a/loleaflet/src/control/Control.PartsPreview.js
+++ b/loleaflet/src/control/Control.PartsPreview.js
@@ -256,12 +256,6 @@ L.Control.PartsPreview = L.Control.extend({
 			previewFrameTop = this._previewContTop + this._previewFrameMargin + i * (this._previewFrameHeight + this._previewFrameMargin);
 			previewFrameTop -= this._scrollY;
 			previewFrameBottom = previewFrameTop + this._previewFrameHeight;
-
-			if (this._direction === 'x') {
-				L.DomUtil.setStyle(img, 'width', this._previewImgWidth + 'px');
-			} else {
-				L.DomUtil.setStyle(img, 'height', this._previewImgHeight + 'px');
-			}
 		}
 
 		var imgSize;

--- a/loleaflet/src/layer/tile/ImpressTileLayer.js
+++ b/loleaflet/src/layer/tile/ImpressTileLayer.js
@@ -105,12 +105,18 @@ L.ImpressTileLayer = L.CanvasTileLayer.extend({
 	onResizeImpress: function () {
 		L.DomUtil.updateElementsOrientation(['presentation-controls-wrapper', 'document-container', 'slide-sorter']);
 
+		var mobileEditButton = document.getElementById('mobile-edit-button');
+
 		if (window.mode.isMobile()) {
 			if (L.DomUtil.isPortrait()) {
 				this._putPCWOutsideFlex();
+				if (mobileEditButton)
+					mobileEditButton.classList.add('portrait');
 			}
 			else {
 				this._putPCWInsideFlex();
+				if (mobileEditButton)
+					mobileEditButton.classList.remove('portrait');
 			}
 		}
 	},


### PR DESCRIPTION
* Use lineHeight rule for centering the elements on mobile.
* Use parent element's rules for setting the styles of img and preview elements.
* Disable mobile-slide-sorter. It is not in use for a long while.

Signed-off-by: Gökay ŞATIR <gokaysatir@gmail.com>
Change-Id: I06517467f269669c70294fb5a4dd0960eb16feb5


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

