### PR TITLE
Impress: Center the document on initialization.

### DIFF
--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -809,6 +809,8 @@ L.CanvasTileLayer = L.TileLayer.extend({
 			if (!heightIncreased)
 				this._onUpdateCursor(true);
 
+			this._fitWidthZoom();
+
 			// Center the view w.r.t the new map-pane position using the current zoom.
 			this._map.setView(this._map.getCenter());
 		}

--- a/loleaflet/src/layer/tile/TileLayer.js
+++ b/loleaflet/src/layer/tile/TileLayer.js
@@ -3702,6 +3702,10 @@ L.TileLayer = L.GridLayer.extend({
 		if (this._firstFitDone)
 			zoom = this._map._zoom;
 		this._firstFitDone = true;
+
+		if (zoom > 1)
+			zoom = Math.floor(zoom);
+
 		this._map.setZoom(zoom, {animate: false});
 	},
 


### PR DESCRIPTION
It seems that fitWidthZoom function is impress-only.
I will turn back to this later.

Signed-off-by: Gökay ŞATIR <gokaysatir@gmail.com>
Change-Id: I95b02d53299bf1b8ce7daf31121b67dccd1c817c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

