### PR TITLE
_refreshRowColumnHeaders: Function is calc-only.

### DIFF
--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -3002,7 +3002,8 @@ L.CanvasTileLayer = L.Layer.extend({
 			this._cellSelections = Array(0);
 			this._map.wholeColumnSelected = false; // Message related to whole column/row selection should be on the way, we should update the variables now.
 			this._map.wholeRowSelected = false;
-			this._refreshRowColumnHeaders();
+			if (this._refreshRowColumnHeaders)
+				this._refreshRowColumnHeaders();
 		}
 	},
 


### PR DESCRIPTION
Thanks to cypress tests. It was being called in Impress document.

Signed-off-by: Gökay ŞATIR <gokaysatir@gmail.com>
Change-Id: I4681486cdd0930429f824c5636a2becb26700ff6


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

