### PR TITLE
Adapt addSection function with pauseDrawing.

### DIFF
--- a/loleaflet/src/layer/tile/CanvasSectionContainer.ts
+++ b/loleaflet/src/layer/tile/CanvasSectionContainer.ts
@@ -280,6 +280,7 @@ class CanvasSectionContainer {
 	// Above 2 properties can be used with documentBounds.
 	private drawingPaused: boolean = false;
 	private dirty: boolean = false;
+	private sectionsDirty: boolean = false;
 
 	// For window sections.
 	private windowSectionList: Array<CanvasSectionObject> = [];
@@ -386,6 +387,12 @@ class CanvasSectionContainer {
 
 	resumeDrawing() {
 		if (this.drawingPaused) {
+			if (this.sectionsDirty) {
+				this.updateBoundSectionLists();
+				this.reNewAllSections(false);
+				this.sectionsDirty = false;
+			}
+
 			var scrollSection = <any>this.getSectionWithName(L.CSections.Scroll.name)
 			if (scrollSection)
 				scrollSection.completePendingScroll(); // No painting, only dirtying.
@@ -1797,10 +1804,15 @@ class CanvasSectionContainer {
 		newSection.sectionProperties.section = newSection;
 		this.sections.push(newSection);
 		this.addSectionFunctions(newSection);
-		this.updateBoundSectionLists();
 		newSection.onInitialize();
-		this.reNewAllSections(false);
-		this.drawSections();
+		if (!this.isDrawingPaused()) {
+			this.updateBoundSectionLists();
+			this.reNewAllSections();
+		}
+		else {
+			this.sectionsDirty = true;
+			this.dirty = true;
+		}
 	}
 
 	removeSection (name: string) {


### PR DESCRIPTION
User can pause drawing before adding multiple sections.
When resumeDrawing is called, reNewAllSections function will be called automatically.

Signed-off-by: Gökay ŞATIR <gokaysatir@gmail.com>
Change-Id: Ie83265b5a57c11bd828a980c1797d6bfa3d6e287


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

