### PR TITLE
Ensure that we get the file-name right before sending the save result.

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -2733,8 +2733,6 @@ void ChildSession::loKitCallback(const int type, const std::string& payload)
         break;
     case LOK_CALLBACK_UNO_COMMAND_RESULT:
     {
-        sendTextFrame("unocommandresult: " + payload);
-
         Parser parser;
         Poco::Dynamic::Var var = parser.parse(payload);
         Object::Ptr object = var.extract<Object::Ptr>();
@@ -2779,6 +2777,8 @@ void ChildSession::loKitCallback(const int type, const std::string& payload)
             }
 #endif
         }
+
+        sendTextFrame("unocommandresult: " + payload);
     }
     break;
     case LOK_CALLBACK_ERROR:


### PR DESCRIPTION
We cannot rely on wsd being slower than the kit - and the rename
happening before wsd / DocumentBroker gets to trying to access the
filename. fixes #2874.

Change-Id: Ie1e67cd059fb6a663048967c47759238c067172d
Signed-off-by: Michael Meeks <michael.meeks@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

