### PR TITLE
Use custom local branch name as explicit remote user branch name for PR

### DIFF
--- a/g
+++ b/g
@@ -15,6 +15,21 @@
 # 3) Uses './g review' to submit a pull request against <branch>.
 #
 
+# not_in_standard_branches $BRANCH $REMOTE
+not_in_standard_branches() {
+    # e.g., with $1 = co-4-2, and $2 = origin
+    # check for origin/co-4-2 branch
+    if git rev-parse --quiet --verify $2/$1 >/dev/null; then
+        return 1 # indicate failure - there's a top-level branch named that way
+    fi
+    # check for origin/distro/*/co-4-2 branches
+    local distro_branch
+    for distro_branch in $(git branch --remotes --list "$2/distro/*/$1"); do
+        return 2 # indicate failure - there's a distro branch named that way
+    done
+    return 0
+}
+
 if [ -z "$(type -p gh)" ]; then
     echo "'gh' not found, install it from <https://github.com/cli/cli/blob/trunk/docs/install_linux.md>."
     exit 1
@@ -38,6 +53,12 @@ if [ "$1" == "review" ]; then
     if [ -n "$2" ]; then
         REMOTE_BRANCH=private/$USER/$2
         CUSTOM_BRANCH=y
+    elif [ "$TRACKED_BRANCH" != "$BRANCH" ]; then
+        if not_in_standard_branches "$BRANCH" "$REMOTE"; then
+            # there's no top-level or distro-specific remote branch named as local branch: use its name
+            REMOTE_BRANCH=private/$USER/$BRANCH
+            CUSTOM_BRANCH=y
+        fi
     fi
 
     # So that we have an up to date view on what remote branches exist.


### PR DESCRIPTION
In a scenario where onee has several parallel PRs, one needs to use
several local branches, and when updating PRs, *needs to provide PR
branch name explicitly* each time (my-PR-name-* in the example):

  git checkout my-local-branch-1
  <edit session>
  git commit
  ./g review my-PR-name-1
  git checkout my-local-branch-2
  <edit session>
  git commit
  ./g review my-PR-name-2

This changes the processing, so that when the user's local branch name
is different from the tracked branch name, it is treated as if user
used that name explicitly in a call:

  git checkout -b my-local-branch-1 origin/master
  git checkout -b my-local-branch-2 origin/co-6.4
  <...>
  git checkout my-local-branch-1
  <edit session>
  git commit
  ./g review # this uses "my-local-branch-1" as implicit second argument
  git checkout my-local-branch-2
  <edit session>
  git commit
  ./g review # this uses "my-local-branch-2" as implicit second argument

so no need to remember which PR name was used where.
This only works for local branch names that do not co-incide with an existing
remote standard branch name.

Signed-off-by: Mike Kaganski <mike.kaganski@collabora.com>
Change-Id: I8b95f92f6e205e3c93ef30f4813f3549c2315872
