### PR TITLE
Parameters for perf-test

### DIFF
--- a/loleaflet/Makefile.am
+++ b/loleaflet/Makefile.am
@@ -723,6 +723,14 @@ check-local: $(MOCHA_TS_JS_FILES)
 
 SSL_FLAG = `xmllint --xpath 'string(/config/ssl/enable)' $(abs_top_builddir)/loolwsd.xml`
 
+# the delay (in miliseconds) between each emulated key stroke for each view
+typing_speed=100
+# The duration of the typing (in miliseconds)
+typing_duration=30000
+# By default 6 views are spawned in the document.
+single_view="false"
+# --inspect flag for the first view. Ideally should be used with single_view=true
+node_inspect="false"
 perf-test:
 	@echo "Running perf tests..."
 	@mkdir -p $(abs_top_builddir)/test/data
@@ -730,18 +738,6 @@ perf-test:
 		echo 'Making fresh copy of the perf-test-edit.odt document'; \
 		cp $(abs_top_srcdir)/test/data/perf-test.odt $(abs_top_builddir)/test/data/perf-test-edit.odt; \
 	fi
-	for a in 2 3 4 5 6; do \
-		$(NODE) $(abs_srcdir)/test/load.js $(SSL_FLAG) $(abs_top_builddir) $(abs_top_builddir)/test/data/perf-test-edit.odt testEdit_$$a & \
-	done
-	$(NODE) $(abs_srcdir)/test/load.js $(SSL_FLAG) $(abs_top_builddir) $(abs_top_builddir)/test/data/perf-test-edit.odt testEdit_1
-
-new-perf-test:
-	@echo "Running new perf tests..."
-	@mkdir -p $(abs_top_builddir)/test/data
-	@if [ ! -f $(abs_top_srcdir)/test/data/perf-test-edit.odt -o "`md5sum <$(abs_top_srcdir)/test/data/perf-test.odt`" != "`md5sum <$(abs_top_srcdir)/test/data/perf-test-edit.odt`" ]; then \
-		echo 'Making fresh copy of the perf-test-edit.odt document'; \
-		cp $(abs_top_srcdir)/test/data/perf-test.odt $(abs_top_builddir)/test/data/perf-test-edit.odt; \
-	fi
-	$(NODE) $(abs_srcdir)/test/bootstrap.js $(SSL_FLAG) $(abs_top_builddir) $(abs_srcdir)
+	$(NODE) $(abs_srcdir)/test/bootstrap.js $(SSL_FLAG) $(abs_top_builddir) $(abs_srcdir) $(typing_speed) $(single_view) $(typing_duration) $(node_inspect)
 # for now - unwinding ts and js deps for different targets is a real pain.
 .NOTPARALLEL:

--- a/loleaflet/test/bootstrap.js
+++ b/loleaflet/test/bootstrap.js
@@ -6,6 +6,10 @@ if (process.argv.length < 5 || process.argv[2] == '--help') {
 const ssl_flag = process.argv[2];
 const top_builddir = process.argv[3];
 const srcdir = process.argv[4];
+const typing_speed = process.argv[5];
+const single_view = process.argv[6];
+const typing_duration = process.argv[7];
+const inspect = process.argv[8];
 /* dont use the default port (9980)*/
 const port = '9999';
 let args = [
@@ -43,10 +47,19 @@ loolwsd.on('exit', (code) => {
 });
 
 let childNodes = [];
-for (let i = 1; i <= 6; i++) {
-	childNodes.push(
-		fork(`${srcdir}/test/load.js`, [ssl_flag, top_builddir, `${top_builddir}/test/data/perf-test-edit.odt`, `testEdit_${i}`, `${port}`])
-	);
+
+let execArgs = [];
+if (inspect === 'true')
+	execArgs.push('--inspect');
+childNodes.push(
+	fork(`${srcdir}/test/load.js`, [ssl_flag, top_builddir, `${top_builddir}/test/data/perf-test-edit.odt`, `testEdit_1`, `${port}`, `${typing_speed}`, `${typing_duration}`], {execArgv: execArgs})
+);
+if(single_view !== "true") {
+	for (let i = 2; i <= 6; i++) {
+		childNodes.push(
+			fork(`${srcdir}/test/load.js`, [ssl_flag, top_builddir, `${top_builddir}/test/data/perf-test-edit.odt`, `testEdit_${i}`, `${port}`, `${typing_speed}`, `${typing_duration}`])
+		);
+	}
 }
 
 function vacuumCleaner(kill, message, code) {

--- a/loleaflet/test/load.js
+++ b/loleaflet/test/load.js
@@ -31,6 +31,15 @@ if (process.argv.length > 6) {
 	port = process.argv[6];
 }
 
+let typing_speed = 30;
+if (process.argv.length > 7) {
+	typing_speed = parseInt(process.argv[7]);
+}
+
+let typing_duration = 5000;
+if (process.argv.length > 8) {
+	typing_duration = parseInt(process.argv[8]);
+}
 // jsdom for browser emulation
 const jsdom = require('jsdom');
 const { JSDOM } = jsdom;
@@ -139,15 +148,20 @@ window.onload = function() {
 				// mesh the keyboard:
 				let dummyInput = 'askdjf ,asdhflkas r;we f;akdn.adh ;o wh;fa he;qw e.fkahsd ;vbawe.kguday;f vas.,mdb kaery kejraerga';
 				map.focus();
-				for (let i = 0; i < dummyInput.length; i++)
-				{
-					console.debug('sending input key: ' + dummyInput.charCodeAt(i));
+				let timeStart = new Date().getTime();
+				let inputIndex = 0;
+				while (true) {
+					let now = new Date().getTime();
+					if (timeStart + typing_duration < now)
+						break;
+					console.debug('sending input key: ' + dummyInput.charCodeAt(inputIndex));
 					window.app.socket.sendMessage(
 						'key' +
 						' type=' + 'input' +
-						' char=' + dummyInput.charCodeAt(i) + ' key=0\n'
+						' char=' + dummyInput.charCodeAt(inputIndex) + ' key=0\n'
 					);
-					await sleep(30);
+					inputIndex = (inputIndex + 1) % dummyInput.length;
+					await sleep(typing_speed);
 				}
 			}
 			else


### PR DESCRIPTION
now it's possible to pass parameters
typing_speed, typing_duration, single_view, node_inspect

also replaced the old perf-test with new-perf-test

Signed-off-by: Mert Tumer <mert.tumer@collabora.com>
Change-Id: I03f1f14db4ddd9afb9d4a9a60a87c135497db70c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

