### PR TITLE
moved initializing fontcombobox with select2 to Toolbar.js

### DIFF
--- a/loleaflet/src/control/Control.TopToolbar.js
+++ b/loleaflet/src/control/Control.TopToolbar.js
@@ -137,9 +137,6 @@ L.Control.TopToolbar = L.Control.extend({
 						edata.isCancelled = true;
 					} else {
 						$.extend(edata, { onComplete: function (e) {
-							$('#fonts-select').select2({
-								placeholder: _('Font')
-							});
 							e.item.html = undefined;
 						}});
 					}

--- a/loleaflet/src/control/Toolbar.js
+++ b/loleaflet/src/control/Toolbar.js
@@ -40,6 +40,11 @@ L.Map.include({
 		var that = this;
 
 		var fontcombobox = $(nodeSelector);
+		if (!fontcombobox.hasClass('select2')) {
+			fontcombobox.select2({
+				placeholder: _('Font')
+			});
+		}
 
 		var createSelector = function() {
 			var commandValues = that.getToolbarCommandValues('.uno:CharFontName');


### PR DESCRIPTION
This way both notebookbar and classic toolbar will have the select2
styling

Signed-off-by: Mert Tumer <mert.tumer@collabora.com>
Change-Id: I9b8294cb1c0308fcfeeed8f9e886e3075c2eb3a1


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

