### PR TITLE
Saving improvements

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -2751,7 +2751,10 @@ void ChildSession::loKitCallback(const int type, const std::string& payload)
             if (rename(oldName.c_str(), newName.c_str()) < 0)
             {
                 // It's not an error if there was no file to rename, when the document isn't modified.
-                LOG_TRC("Failed to renamed [" << oldName << "] to [" << newName << ']');
+                const auto onrre = errno;
+                LOG_TRC("Failed to renamed [" << oldName << "] to [" << newName << "] ("
+                                              << Util::symbolicErrno(onrre) << ": "
+                                              << std::strerror(onrre) << ')');
             }
             else
             {

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -24,6 +24,7 @@ noinst_LTLIBRARIES = \
 	unit-fuzz.la unit-oob.la unit-http.la unit-oauth.la \
 	unit-wopi.la unit-wopi-saveas.la \
 	unit-wopi-async-upload-close.la unit-wopi-async-upload-modify.la \
+	unit-wopi-async-upload-modifyclose.la \
 	unit-wopi-ownertermination.la unit-wopi-versionrestore.la \
 	unit-wopi-documentconflict.la unit_wopi_renamefile.la unit_wopi_watermark.la \
 	unit-tiff-load.la \
@@ -160,6 +161,8 @@ unit_wopi_async_upload_close_la_SOURCES = UnitWOPIAsyncUpload_Close.cpp
 unit_wopi_async_upload_close_la_LIBADD = $(CPPUNIT_LIBS)
 unit_wopi_async_upload_modify_la_SOURCES = UnitWOPIAsyncUpload_Modify.cpp
 unit_wopi_async_upload_modify_la_LIBADD = $(CPPUNIT_LIBS)
+unit_wopi_async_upload_modifyclose_la_SOURCES = UnitWOPIAsyncUpload_ModifyClose.cpp
+unit_wopi_async_upload_modifyclose_la_LIBADD = $(CPPUNIT_LIBS)
 unit_wopi_saveas_la_SOURCES = UnitWOPISaveAs.cpp
 unit_wopi_saveas_la_LIBADD = $(CPPUNIT_LIBS)
 unit_wopi_ownertermination_la_SOURCES = UnitWopiOwnertermination.cpp
@@ -241,6 +244,7 @@ TESTS = \
 	unit-copy-paste.la unit-typing.la unit-convert.la unit-prefork.la unit-tilecache.la unit-timeout.la \
 	unit-oauth.la unit-wopi.la unit-wopi-saveas.la \
 	unit-wopi-async-upload-close.la unit-wopi-async-upload-modify.la \
+	unit-wopi-async-upload-modifyclose.la \
 	unit-wopi-ownertermination.la unit-wopi-versionrestore.la \
 	unit-wopi-documentconflict.la unit_wopi_renamefile.la unit_wopi_watermark.la \
 	unit-http.la \

--- a/test/UnitWOPIAsyncUpload_Close.cpp
+++ b/test/UnitWOPIAsyncUpload_Close.cpp
@@ -88,7 +88,7 @@ public:
         LOK_ASSERT_MESSAGE("Expected to be in Phase::WaitLoadStatus",
                            _phase == Phase::WaitLoadStatus);
 
-        LOG_TST("onDocumentModified: Switching to Phase::WaitLoadStatus, SavingPhase::Modify");
+        LOG_TST("onDocumentModified: Switching to Phase::Modify");
         _phase = Phase::Modify;
 
         SocketPoll::wakeupWorld();
@@ -102,8 +102,7 @@ public:
         LOK_ASSERT_MESSAGE("Expected to be in Phase::WaitModified",
                            _phase == Phase::WaitModifiedStatus);
         {
-            LOG_TST("onDocumentModified: Switching to Phase::WaitModifiedStatus, "
-                    "SavingPhase::WaitFirstPutFile");
+            LOG_TST("onDocumentModified: Switching to Phase::WaitFirstPutFile");
             _phase = Phase::WaitFirstPutFile;
 
             WSD_CMD("save dontTerminateEdit=0 dontSaveIfUnmodified=0 "

--- a/test/UnitWOPIAsyncUpload_Modify.cpp
+++ b/test/UnitWOPIAsyncUpload_Modify.cpp
@@ -90,7 +90,7 @@ public:
         LOK_ASSERT_MESSAGE("Expected to be in Phase::WaitLoadStatus",
                            _phase == Phase::WaitLoadStatus);
 
-        LOG_TST("onDocumentModified: Switching to Phase::WaitLoadStatus, SavingPhase::Modify");
+        LOG_TST("onDocumentModified: Switching to Phase::Modify");
         _phase = Phase::Modify;
 
         SocketPoll::wakeupWorld();
@@ -104,8 +104,7 @@ public:
         LOK_ASSERT_MESSAGE("Expected to be in Phase::WaitModified",
                            _phase == Phase::WaitModifiedStatus);
         {
-            LOG_TST("onDocumentModified: Switching to Phase::WaitModifiedStatus, "
-                    "SavingPhase::WaitFirstPutFile");
+            LOG_TST("onDocumentModified: Switching to Phase::WaitFirstPutFile");
             _phase = Phase::WaitFirstPutFile;
 
             WSD_CMD("save dontTerminateEdit=0 dontSaveIfUnmodified=0 "

--- a/test/UnitWOPIAsyncUpload_Modify.cpp
+++ b/test/UnitWOPIAsyncUpload_Modify.cpp
@@ -80,7 +80,11 @@ public:
 
         passTest("Document uploaded on closing as expected.");
 
-        return nullptr;
+        LOG_TST("WaitSecondPutFile => Polling");
+        _phase = Phase::Polling; // To detect multiple uploads after the last successful one.
+
+        // Success.
+        return Util::make_unique<http::Response>(http::StatusLine(200));
     }
 
     /// The document is loaded.

--- a/test/UnitWOPIAsyncUpload_ModifyClose.cpp
+++ b/test/UnitWOPIAsyncUpload_ModifyClose.cpp
@@ -1,0 +1,130 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <config.h>
+
+#include "HttpRequest.hpp"
+#include "Util.hpp"
+#include "lokassert.hpp"
+
+#include <WopiTestServer.hpp>
+#include <Log.hpp>
+#include <Unit.hpp>
+#include <UnitHTTP.hpp>
+#include <helpers.hpp>
+#include <Poco/Net/HTTPRequest.h>
+#include <Poco/Util/LayeredConfiguration.h>
+
+/// Test Saving and Async uploading after modifying and immediately closing.
+/// We modify the document and close immediately.
+class UnitWOPIAsyncUpload_ModifyClose : public WopiTestServer
+{
+    enum class Phase
+    {
+        Load,
+        WaitLoadStatus,
+        ModifyAndClose,
+        WaitPutFile,
+        Polling
+    } _phase;
+
+public:
+    UnitWOPIAsyncUpload_ModifyClose()
+        : WopiTestServer("UnitWOPIAsyncUpload_ModifyClose")
+        , _phase(Phase::Load)
+    {
+    }
+
+    std::unique_ptr<http::Response>
+    assertPutFileRequest(const Poco::Net::HTTPRequest& request) override
+    {
+        // Expect PutFile after closing, since the document is modified.
+        if (_phase == Phase::WaitPutFile)
+        {
+            LOG_TST("assertPutFileRequest: First PutFile, which will fail");
+
+            LOG_TST("WaitPutFile => Polling");
+            _phase = Phase::Polling;
+
+            // We requested the save.
+            LOK_ASSERT_EQUAL(std::string("false"), request.get("X-LOOL-WOPI-IsAutosave"));
+
+            if (request.get("X-LOOL-WOPI-IsModifiedByUser") != "true")
+            {
+                // There is a race when closing the document right after modifying,
+                // so the modified flag may not be set, but there should be no data
+                // loss, as this test demonstrates.
+                LOG_TST("WARNING: file is not marked as modified");
+            }
+
+            passTest("Document uploaded on closing as expected.");
+
+            return Util::make_unique<http::Response>(http::StatusLine(200));
+        }
+
+        // This during closing the document.
+        LOG_TST("assertPutFileRequest: Second PutFile, unexpected");
+
+        failTest("PutFile multiple times.");
+
+        return nullptr;
+    }
+
+    /// The document is loaded.
+    bool onDocumentLoaded(const std::string& message) override
+    {
+        LOG_TST("onDocumentLoaded: [" << message << ']');
+        LOK_ASSERT_MESSAGE("Expected to be in Phase::WaitLoadStatus",
+                           _phase == Phase::WaitLoadStatus);
+
+        LOG_TST("onDocumentModified: Switching to Phase::WaitLoadStatus, SavingPhase::Modify");
+        _phase = Phase::ModifyAndClose;
+
+        SocketPoll::wakeupWorld();
+        return true;
+    }
+
+    void invokeWSDTest() override
+    {
+        switch (_phase)
+        {
+            case Phase::Load:
+            {
+                LOG_TST("Load => WaitLoadStatus");
+                _phase = Phase::WaitLoadStatus;
+
+                LOG_TST("Load: initWebsocket.");
+                initWebsocket("/wopi/files/0?access_token=anything");
+
+                WSD_CMD("load url=" + getWopiSrc());
+                break;
+            }
+            case Phase::WaitLoadStatus:
+                break;
+            case Phase::ModifyAndClose:
+            {
+                LOG_TST("ModifyAndClose => WaitPutFile");
+                _phase = Phase::WaitPutFile;
+
+                WSD_CMD("key type=input char=97 key=0");
+                WSD_CMD("key type=up char=0 key=512");
+                WSD_CMD("closedocument");
+                break;
+            }
+            case Phase::WaitPutFile:
+            case Phase::Polling:
+            {
+                // just wait for the results
+                break;
+            }
+        }
+    }
+};
+
+UnitBase* unit_create_wsd(void) { return new UnitWOPIAsyncUpload_ModifyClose(); }
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -32,6 +32,7 @@
 #if !MOBILEAPP
 #include <net/HttpHelper.hpp>
 #endif
+
 using namespace LOOLProtocol;
 
 static constexpr int SYNTHETIC_LOLEAFLET_PID_OFFSET = 10000000;
@@ -1621,18 +1622,9 @@ bool ClientSession::handleKitToClientMessage(const char* buffer, const int lengt
         StringVector stateTokens(Util::tokenize(tokens[1], '='));
         if (stateTokens.size() == 2 && stateTokens.equals(0, ".uno:ModifiedStatus"))
         {
-            // When the document is saved internally, but saving to storage failed,
-            // don't update the client's modified status
-            // (otherwise client thinks document is unmodified b/c saving was successful)
-            const bool isModified = stateTokens.equals(1, "true");
-            if (!docBroker->isLastStorageUploadSuccessful())
-            {
-                LOG_DBG("Skipping ModifiedStatus (" << std::boolalpha << isModified
-                                                    << ") because last storage upload failed.");
-                return false;
-            }
-
-            docBroker->setModified(isModified);
+            // Always update the modified flag in the DocBroker faithfully.
+            // Let it deal with the upload failure scenario and the admin console.
+            docBroker->setModified(stateTokens.equals(1, "true"));
         }
         else
         {

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1406,6 +1406,16 @@ void DocumentBroker::handleUploadToStorageResponse(const StorageBase::UploadResu
     LOG_TRC("lastUploadSuccessful: " << lastUploadSuccessful);
     _storageManager.setLastUploadResult(lastUploadSuccessful);
 
+#if !MOBILEAPP
+    if (lastUploadSuccessful && !isModified())
+    {
+        // Flag the document as un-modified in the admin console.
+        // But only when we have uploaded successfully and the document
+        // is current not flagged as modified by Core.
+        Admin::instance().modificationAlert(_docKey, getPid(), false);
+    }
+#endif
+
     if (uploadResult.getResult() == StorageBase::UploadResult::Result::OK)
     {
 #if !MOBILEAPP
@@ -2626,17 +2636,24 @@ bool DocumentBroker::haveAnotherEditableSession(const std::string& id) const
 
 void DocumentBroker::setModified(const bool value)
 {
-    if (_isModified != value)
-    {
-        _isModified = value;
 #if !MOBILEAPP
+    if (value)
+    {
+        // Flag the document as modified in the admin console.
+        // But only flag it as unmodified when we do upload it.
         Admin::instance().modificationAlert(_docKey, getPid(), value);
+    }
 #endif
+
+    if (value || _storageManager.lastUploadSuccessful())
+    {
+        // Set the X-LOOL-WOPI-IsModifiedByUser header flag sent to storage.
+        // But retain the last value if we failed to upload, so we don't clobber it.
+        _storage->setUserModified(value);
     }
 
-    // Set the X-LOOL-WOPI-IsModifiedByUser header flag sent to storage.
-    _storage->setUserModified(value);
     LOG_TRC("Modified state set to " << value << " for Doc [" << _docId << ']');
+    _isModified = value;
 }
 
 bool DocumentBroker::isInitialSettingSet(const std::string& name) const

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1165,6 +1165,12 @@ void DocumentBroker::handleSaveResponse(const std::string& sessionId, bool succe
         }
         break;
 
+        case DocumentState::Activity::Save:
+        {
+            // Done saving.
+            endActivity();
+        }
+
         default:
         break;
     }
@@ -1807,8 +1813,17 @@ bool DocumentBroker::sendUnoSave(const std::string& sessionId, bool dontTerminat
         const std::string saveArgs = oss.str();
         LOG_TRC(".uno:Save arguments: " << saveArgs);
         const auto command = "uno .uno:Save " + saveArgs;
-        forwardToChild(sessionId, command);
-        _saveManager.markLastSaveRequestTime(); //TODO: Don't update when forwarding fails!
+        if (forwardToChild(sessionId, command))
+        {
+            _saveManager.markLastSaveRequestTime();
+            if (_docState.activity() == DocumentState::Activity::None)
+            {
+                // If we aren't in the midst of any particular activity,
+                // then this is a generic save on its own.
+                startActivity(DocumentState::Activity::Save);
+            }
+        }
+
         return true;
     }
 

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -410,10 +410,14 @@ void DocumentBroker::pollThread()
                     const std::string reason =
                         SigUtil::getShutdownRequestFlag() ? "recycling" : _closeReason;
                     const bool possiblyModified = isPossiblyModified();
-                    LOG_INF("Autosaving DocumentBroker for docKey ["
-                            << getDocKey() << "], possiblyModified: "
-                            << (possiblyModified ? "yes" : "no") << ", for " << reason);
-                    if (!autoSave(possiblyModified))
+                    // If we failed the last upload, save even if unmodified so we upload.
+                    const bool dontSaveIfUnmodified = _storageManager.lastUploadSuccessful();
+                    LOG_INF("Autosave before closing DocumentBroker for docKey ["
+                            << getDocKey()
+                            << "], possiblyModified: " << (possiblyModified ? "yes" : "no")
+                            << ", dontSaveIfUnmodified: " << (dontSaveIfUnmodified ? "yes" : "no")
+                            << ", for " << reason);
+                    if (!autoSave(possiblyModified, dontSaveIfUnmodified))
                     {
                         LOG_INF("Terminating DocumentBroker for docKey [" << getDocKey()
                                                                           << "]: " << reason);


### PR DESCRIPTION
- wsd: test: correct logging of phase change
- wsd: test close-after-modify to confirm no data loss
- wsd: better logging of the document activity
- wsd: correctly update the modified flag
- wsd: track saving activity
- wsd: test: detect multiple uploads in test
- wsd: before closing save a copy to upload
