### PR TITLE
Add profilezone around kitPoll function and SocketPoll constructor

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -2009,6 +2009,8 @@ public:
     // returns the number of events signalled
     int kitPoll(int timeoutMicroS)
     {
+        ProfileZone profileZone("KitSocketPoll::kitPoll");
+
         if (SigUtil::getTerminationFlag())
         {
             LOG_TRC("Termination of unipoll mainloop flagged");

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -124,6 +124,8 @@ SocketPoll::SocketPoll(const std::string& threadName)
       _runOnClientThread(false),
       _owner(std::this_thread::get_id())
 {
+    ProfileZone profileZone("SocketPoll::SocketPoll");
+
     // Create the wakeup fd.
     if (
 #if !MOBILEAPP


### PR DESCRIPTION
Add profile zone around kitPoll function and SocketPoll constructor to
improve trace event generation

Signed-off-by: Gopi Krishna Menon <krishnagopi487.github@outlook.com>
Change-Id: Ia46e9add59a57935997649fe39861a8d851e1ff0
