### PR TITLE
systemplate: ensure we have write access to directories before cleaning.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -393,7 +393,7 @@ endif
 $(SYSTEM_STAMP): ${top_srcdir}/loolwsd-systemplate-setup $(CLEANUP_DEPS)
 	$(SET_CAPS_COMMAND)
 	$(CLEANUP_COMMAND)
-	if test "z@SYSTEMPLATE_PATH@" != "z"; then rm -rf "@SYSTEMPLATE_PATH@" && \
+	if test "z@SYSTEMPLATE_PATH@" != "z"; then chmod u+w -R "@SYSTEMPLATE_PATH@" ; rm -rf "@SYSTEMPLATE_PATH@" && \
 	${top_srcdir}/loolwsd-systemplate-setup "@SYSTEMPLATE_PATH@" "@LO_PATH@" && touch $@; fi
 
 @JAILS_PATH@:


### PR DESCRIPTION
Some of the folders we setup from the system are:

dr-xr-xr-x 1 michael users 2824 Jun  9 21:05 systemplate/usr/share/fonts/

before adjustment, and resist removal.

Signed-off-by: Michael Meeks <michael.meeks@collabora.com>
Change-Id: I8e5a96264b98d8091b205f7469bc46c401f47ab1


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

