### PR TITLE
js: reduce keyup emission to allow event de-duplication.

### DIFF
--- a/loleaflet/src/map/handler/Map.Keyboard.js
+++ b/loleaflet/src/map/handler/Map.Keyboard.js
@@ -392,7 +392,12 @@ L.Map.Keyboard = L.Handler.extend({
 				keyEventFn('input', charCode, unoKeyCode);
 			}
 			else if (ev.type === 'keyup') {
-				keyEventFn('up', charCode, unoKeyCode);
+				if ((this.handleOnKeyDownKeys[keyCode] && charCode === 0) ||
+				    (this.modifier)) {
+					keyEventFn('up', charCode, unoKeyCode);
+				} else {
+					// was handled as textinput
+				}
 			}
 			if (keyCode === 9) {
 				// tab would change focus to other DOM elements


### PR DESCRIPTION
We emit lots of 'keyup' events that don't match any keydown
event like this:

OUTGOING: textinput id=0 text=a
OUTGOING: textinput id=0 text=l
OUTGOING: key type=up char=0 key=517
OUTGOING: key type=up char=0 key=523

since we emit a textinput instead. So just emit events
when we have modifiers, or already sent an input event.

Change-Id: I0f86438d093497668bb5b749ff63ecd87d9b7636


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

