### PR TITLE
http response: simplify the condition if the result would fit

### DIFF
--- a/net/HttpRequest.cpp
+++ b/net/HttpRequest.cpp
@@ -553,7 +553,8 @@ int64_t Response::readData(const char* p, int64_t len)
                     if (digit < 0)
                         break;
 
-                    if (chunkLen >= (std::numeric_limits<int64_t>::max() - digit) / 16)
+                    // Can assume that digit is always less than 16.
+                    if (chunkLen >= std::numeric_limits<int64_t>::max() / 16)
                     {
                         // Would not fit into chunkLen.
                         return len - available;


### PR DESCRIPTION
Given that "digit" is always less than 16, we can avoid the "- digit"
in the condition (because the division turns that into 0 anyway), making
it effectively constexpr.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Iaf9e53d3543f2237c00768f214114a02a4746020
