### PR TITLE
http response: if the result doesn't fit, then consider that a fatal error

### DIFF
--- a/net/HttpRequest.cpp
+++ b/net/HttpRequest.cpp
@@ -557,7 +557,8 @@ int64_t Response::readData(const char* p, int64_t len)
                     if (chunkLen >= std::numeric_limits<int64_t>::max() / 16)
                     {
                         // Would not fit into chunkLen.
-                        return len - available;
+                        LOG_ERR("Unexpected chunk length: " << chunkLen);
+                        return -1;
                     }
                     chunkLen = chunkLen * 16 + digit;
                 }


### PR DESCRIPTION
This is really a garbage in -> garbage out situation.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Ic1c33f44081f259e5cf5994ad901e1593fe8dfcf
