### PR TITLE
Allow pasting into document even when DisableCopy is active

### DIFF
--- a/loleaflet/src/map/Clipboard.js
+++ b/loleaflet/src/map/Clipboard.js
@@ -358,9 +358,6 @@ L.Clipboard = L.Class.extend({
 			return true;
 		}
 
-		if (this._map['wopi'].DisableCopy)
-			return true;
-
 		// Do we have a remote Online we can suck rich data from ?
 		if (meta !== '')
 		{
@@ -687,18 +684,9 @@ L.Clipboard = L.Class.extend({
 			return false;
 		}
 
-		if (this._map['wopi'].DisableCopy) {
+		if (this._map['wopi'].DisableCopy && (cmd === '.uno:Copy' || cmd === '.uno:Cut')) {
 			// perform internal operations
-
-			if (cmd === '.uno:Copy' || cmd === '.uno:Cut') {
-				app.socket.sendMessage('uno ' + cmd);
-			} else if (cmd === '.uno:Paste') {
-				var dummyEvent = {preventDefault: function() {}};
-				this.paste(dummyEvent);
-			} else {
-				return false;
-			}
-
+			app.socket.sendMessage('uno ' + cmd);
 			return true;
 		}
 
@@ -765,14 +753,6 @@ L.Clipboard = L.Class.extend({
 
 		if (this._map._activeDialog)
 			ev.usePasteKeyEvent = true;
-
-		if (this._map['wopi'].DisableCopy)
-		{
-			ev.preventDefault();
-			this._doInternalPaste(this._map, ev.usePasteKeyEvent);
-
-			return false;
-		}
 
 		var that = this;
 		if (L.Browser.isInternetExplorer)

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -204,9 +204,6 @@ bool ClientSession::staleWaitDisconnect(const std::chrono::steady_clock::time_po
 
 void ClientSession::rotateClipboardKey(bool notifyClient)
 {
-    if (_wopiFileInfo && _wopiFileInfo->getDisableCopy())
-        return;
-
     if (_state == SessionState::WAIT_DISCONNECT)
         return;
 
@@ -221,9 +218,6 @@ void ClientSession::rotateClipboardKey(bool notifyClient)
 
 std::string ClientSession::getClipboardURI(bool encode)
 {
-    if (_wopiFileInfo && _wopiFileInfo->getDisableCopy())
-        return std::string();
-
     std::string encodedFrom;
     Poco::URI wopiSrc = getDocumentBroker()->getPublicUri();
     wopiSrc.setQueryParameters(Poco::URI::QueryParameters());


### PR DESCRIPTION
From our API description:
DisableCopy
Disables copying from the document in libreoffice online backend.
Pasting into the document would still be possible.

Change-Id: I1f7e272ad3b04208b534eff990fed895951b4751
