### PR TITLE
Merge textinput and removetextcontext messages when possible

### DIFF
--- a/common/MessageQueue.hpp
+++ b/common/MessageQueue.hpp
@@ -181,16 +181,17 @@ protected:
             // If any messages of these types are present before the current ("textinput") message,
             // no combination is possible.
             if (queuedTokens.size() == 1 ||
-                queuedTokens[1] == "key" ||
-                queuedTokens[1] == "mouse" ||
-                queuedTokens[1] == "removetextcontext" ||
-                queuedTokens[1] == "windowkey" ||
-                (queuedTokens[0] != tokens[0] && queuedTokens[1] == "textinput"))
+                (queuedTokens[0] == tokens[0] &&
+                 (queuedTokens[1] == "key" ||
+                  queuedTokens[1] == "mouse" ||
+                  queuedTokens[1] == "removetextcontext" ||
+                  queuedTokens[1] == "windowkey")))
                 return std::string();
 
             std::string queuedId;
             std::string queuedText;
-            if (queuedTokens[1] == "textinput" &&
+            if (queuedTokens[0] == tokens[0] &&
+                queuedTokens[1] == "textinput" &&
                 LOOLProtocol::getTokenString(queuedTokens, "id", queuedId) &&
                 queuedId == id &&
                 LOOLProtocol::getTokenString(queuedTokens, "text", queuedText))
@@ -239,17 +240,18 @@ protected:
             // If any messages of these types are present before the current (removetextcontext)
             // message, no combination is possible.
             if (queuedTokens.size() == 1 ||
-                queuedTokens[1] == "key" ||
-                queuedTokens[1] == "mouse" ||
-                queuedTokens[1] == "textinput" ||
-                queuedTokens[1] == "windowkey" ||
-                (queuedTokens[0] != tokens[0] && queuedTokens[1] == "removetextcontext"))
+                (queuedTokens[0] == tokens[0] &&
+                 (queuedTokens[1] == "key" ||
+                  queuedTokens[1] == "mouse" ||
+                  queuedTokens[1] == "textinput" ||
+                  queuedTokens[1] == "windowkey")))
                 return std::string();
 
             std::string queuedId;
             int queuedBefore;
             int queuedAfter;
-            if (queuedTokens[1] == "removetextcontext" &&
+            if (queuedTokens[0] == tokens[0] &&
+                queuedTokens[1] == "removetextcontext" &&
                 LOOLProtocol::getTokenStringFromMessage(queuedMessage, "id", queuedId) &&
                 queuedId == id &&
                 LOOLProtocol::getTokenIntegerFromMessage(queuedMessage, "before", queuedBefore) &&

--- a/common/MessageQueue.hpp
+++ b/common/MessageQueue.hpp
@@ -122,6 +122,15 @@ protected:
                 return;
             }
         }
+        else if (tokens[1] == "removetextcontext")
+        {
+            const std::string newMsg = combineRemoveText(tokens);
+            if (!newMsg.empty())
+            {
+                _queue.push_back(Payload(newMsg.data(), newMsg.data() + newMsg.size()));
+                return;
+            }
+        }
 
         _queue.push_back(value);
     }
@@ -190,6 +199,68 @@ protected:
                 getQueue().erase(getQueue().begin() + i);
 
                 std::string newMsg = queuedTokens[0] + " textinput id=" + id + " text=" + queuedText + text;
+
+                LOG_TRC("Combined [" << queuedMessage << "] with current message to [" << newMsg << "]");
+
+                return newMsg;
+            }
+
+            --i;
+        }
+
+        return std::string();
+    }
+
+    /// Search the queue for a previous removetextcontext message (which actually means "remove text
+    /// content", the word "context" is becaue of some misunderstanding lost in history) and if
+    /// found, remove it and combine its input with that in the current removetextcontext message.
+    /// We check that there aren't any interesting messages inbetween that would make it wrong to
+    /// merge the removetextcontext messages.
+    ///
+    /// @return New message to put into the queue. If empty, use what we got.
+    std::string combineRemoveText(const StringVector& tokens)
+    {
+        std::string id;
+        int before;
+        int after;
+        if (!LOOLProtocol::getTokenString(tokens, "id", id) ||
+            !LOOLProtocol::getTokenInteger(tokens, "before", before) ||
+            !LOOLProtocol::getTokenInteger(tokens, "after", after))
+            return std::string();
+
+        int i = getQueue().size() - 1;
+        while (i >= 0)
+        {
+            auto& it = getQueue()[i];
+
+            const std::string queuedMessage(it.data(), it.size());
+            StringVector queuedTokens = Util::tokenize(it.data(), it.size());
+
+            // If any messages of these types are present before the current (removetextcontext)
+            // message, no combination is possible.
+            if (queuedTokens.size() == 1 ||
+                queuedTokens[1] == "key" ||
+                queuedTokens[1] == "mouse" ||
+                queuedTokens[1] == "textinput" ||
+                queuedTokens[1] == "windowkey" ||
+                (queuedTokens[0] != tokens[0] && queuedTokens[1] == "removetextcontext"))
+                return std::string();
+
+            std::string queuedId;
+            int queuedBefore;
+            int queuedAfter;
+            if (queuedTokens[1] == "removetextcontext" &&
+                LOOLProtocol::getTokenStringFromMessage(queuedMessage, "id", queuedId) &&
+                queuedId == id &&
+                LOOLProtocol::getTokenIntegerFromMessage(queuedMessage, "before", queuedBefore) &&
+                LOOLProtocol::getTokenIntegerFromMessage(queuedMessage, "after", queuedAfter))
+            {
+                // Remove the queued removetextcontext message and combine it with the current one
+                getQueue().erase(getQueue().begin() + i);
+
+                std::string newMsg = queuedTokens[0] + " removetextcontext id=" + id +
+                    " before=" + std::to_string(queuedBefore + before) +
+                    " after=" + std::to_string(queuedAfter + after);
 
                 LOG_TRC("Combined [" << queuedMessage << "] with current message to [" << newMsg << "]");
 

--- a/test/UnitTyping.cpp
+++ b/test/UnitTyping.cpp
@@ -137,6 +137,7 @@ public:
 
         queue.put("child-foo textinput id=0 text=a");
         queue.put("child-bar textinput id=0 text=b");
+        queue.put("child-foo textinput id=0 text=c");
 
         v = queue.get(1);
         if (queue.isEmpty())
@@ -145,10 +146,25 @@ public:
             return TestResult::Failed;
         }
 
+        // Verify that the earlier textinput was removed and its contents merged with the later one
+        s = std::string(v.data(), v.size());
+        if (s != "child-bar textinput id=0 text=b")
+        {
+            LOG_ERR("Merge of textinput messages done incorrectly");
+            return TestResult::Failed;
+        }
+
         v = queue.get(1);
         if (!queue.isEmpty())
         {
-            LOG_ERR("MessageQueue contains more than was put into it");
+            LOG_ERR("Merge of textinput messages did not happen");
+            return TestResult::Failed;
+        }
+
+        s = std::string(v.data(), v.size());
+        if (s != "child-foo textinput id=0 text=ac")
+        {
+            LOG_ERR("Merge of textinput messages done incorrectly");
             return TestResult::Failed;
         }
 

--- a/test/UnitTyping.cpp
+++ b/test/UnitTyping.cpp
@@ -66,22 +66,18 @@ public:
 
         static const char *commands[] = {
             "key type=up char=0 key=17",
-            "textinput id=0 type=input text=%E3%84%98",
-            "textinput id=0 type=end text=%E3%84%98",
+            "textinput id=0 text=%E3%84%98",
             "key type=up char=0 key=519",
 
-            "textinput id=0 type=input text=%E3%84%9C",
-            "textinput id=0 type=end text=%E3%84%9C",
+            "textinput id=0 text=%E3%84%9C",
             "key type=up char=0 key=522",
 
-            "textinput id=0 type=input text=%CB%8B",
-            "textinput id=0 type=end text=%CB%8B",
+            "textinput id=0 text=%CB%8B",
             "key type=up char=0 key=260",
 
             // replace with the complete character
             "removetextcontext id=0 before=3 after=0",
-            "textinput id=0 type=input text=%E6%B8%AC",
-            "textinput id=0 type=end text=%E6%B8%AC",
+            "textinput id=0 text=%E6%B8%AC",
             "key type=up char=0 key=259"
         };
         static const unsigned char correct[] = {

--- a/test/UnitTyping.cpp
+++ b/test/UnitTyping.cpp
@@ -110,6 +110,90 @@ public:
         return TestResult::Ok;
     }
 
+    TestResult testMessageQueueMerging()
+    {
+        MessageQueue queue;
+
+        queue.put("child-foo textinput id=0 text=a");
+        queue.put("child-foo textinput id=0 text=b");
+
+        MessageQueue::Payload v;
+        v = queue.get(1);
+
+        if (!queue.isEmpty())
+        {
+            LOG_ERR("Merge of textinput messages did not happen");
+            return TestResult::Failed;
+        }
+
+        std::string s;
+        s = std::string(v.data(), v.size());
+
+        if (s != "child-foo textinput id=0 text=ab")
+        {
+            LOG_ERR("Merge of textinput messages produced unexpected result '" << s << "'");
+            return TestResult::Failed;
+        }
+
+        queue.put("child-foo textinput id=0 text=a");
+        queue.put("child-bar textinput id=0 text=b");
+
+        v = queue.get(1);
+        if (queue.isEmpty())
+        {
+            LOG_ERR("Merge of textinput messages for different clients that should not have happened");
+            return TestResult::Failed;
+        }
+
+        v = queue.get(1);
+        if (!queue.isEmpty())
+        {
+            LOG_ERR("MessageQueue contains more than was put into it");
+            return TestResult::Failed;
+        }
+
+        queue.put("child-foo textinput id=0 text=a");
+        queue.put("child-foo key type=input char=97 key=0");
+        queue.put("child-foo textinput id=0 text=b");
+
+        v = queue.get(1);
+        v = queue.get(1);
+        if (queue.isEmpty())
+        {
+            LOG_ERR("Merge of textinput messages with a key message inbetween that should not have happened");
+            return TestResult::Failed;
+        }
+        v = queue.get(1);
+        if (!queue.isEmpty())
+        {
+            LOG_ERR("MessageQueue contains more than was put into it");
+            return TestResult::Failed;
+        }
+
+        queue.put("child-foo textinput id=0 text=abcdef");
+        queue.put("child-foo removetextcontext id=0 before=1 after=0");
+        queue.put("child-foo removetextcontext id=0 before=1 after=0");
+
+        v = queue.get(1);
+        v = queue.get(1);
+
+        if (!queue.isEmpty())
+        {
+            LOG_ERR("Merge of removetextcontext messages did not happen");
+            return TestResult::Failed;
+        }
+
+        s = std::string(v.data(), v.size());
+
+        if (s != "child-foo removetextcontext id=0 before=2 after=0")
+        {
+            LOG_ERR("Merge of removetextcontext messages produced unexpected result '" << s << "'");
+            return TestResult::Failed;
+        }
+
+        return TestResult::Ok;
+    }
+
     TestResult testCalcTyping()
     {
         const char* testname = "calcMultiViewEdit ";
@@ -279,6 +363,11 @@ public:
         res = testWriterTyping();
         if (res != TestResult::Ok)
             return res;
+
+        res = testMessageQueueMerging();
+        if (res != TestResult::Ok)
+            return res;
+
 //        res = testCalcTyping();
         return res;
     }


### PR DESCRIPTION
When adding a freshly arrived textinput message to the queue, check if
there is any outstanding one queued, and if so, remove it, and prefix
its text text to the text in the fresh message.

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: I712eebfb10d410bb424157c8df46b2848a236d88


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

