### PR TITLE
cleanup: don't assume that the web-server poll is still alive.

### DIFF
--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -3795,7 +3795,8 @@ public:
     void stop()
     {
         _acceptPoll.joinThread();
-        LOOLWSD::WebServerPoll->joinThread();
+        if (LOOLWSD::WebServerPoll)
+            LOOLWSD::WebServerPoll->joinThread();
     }
 
     void dumpState(std::ostream& os)


### PR DESCRIPTION
Since a99edb5d29 this gets a different lifecycle, and is often
joined and gone by the time we get to cleanup.

Change-Id: Ic21ca837d484a9a853c7f8f683e876406b00a943


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

