### PR TITLE
Don't use the obsolete 'type' parameter in 'textinput' messages

### DIFF
--- a/test/UnitTyping.cpp
+++ b/test/UnitTyping.cpp
@@ -65,26 +65,32 @@ public:
 
         std::shared_ptr<LOOLWebSocket> socket = helpers::loadDocAndGetSocket(uri, documentURL, testname);
 
+        // We input two Bopomofo (Mandarin Phonetic Symbols) characters and a grave accent using
+        // textinput messages and then delete them and then input a fourth character. Apparently
+        // this is supposed to mimic what happens when input is coming from an IME for Traditional
+        // Chinese? Unclear whether the 'key' messages here really match what the JS generates in
+        // such a case.
         static const char *commands[] = {
             "key type=up char=0 key=17",
-            "textinput id=0 type=input text=%E3%84%98",
-            "textinput id=0 type=end text=%E3%84%98",
+            // BOPOMOFO LETTER C
+            "textinput id=0 text=%E3%84%98",
             "key type=up char=0 key=519",
 
-            "textinput id=0 type=input text=%E3%84%9C",
-            "textinput id=0 type=end text=%E3%84%9C",
+            // BOPOMOFO LETTER E
+            "textinput id=0 text=%E3%84%9C",
             "key type=up char=0 key=522",
 
-            "textinput id=0 type=input text=%CB%8B",
-            "textinput id=0 type=end text=%CB%8B",
+            // MODIFIER LETTER GRAVE ACCENT
+            // Huh?
+            "textinput id=0 text=%CB%8B",
             "key type=up char=0 key=260",
 
             // replace with the complete character
             "removetextcontext id=0 before=3 after=0",
-            "textinput id=0 type=input text=%E6%B8%AC",
-            "textinput id=0 type=end text=%E6%B8%AC",
+            "textinput id=0 text=%E6%B8%AC",
             "key type=up char=0 key=259"
         };
+        // CJK UNIFIED IDEOGRAPH-6E2C
         static const unsigned char correct[] = {
             0xe6, 0xb8, 0xac
         };


### PR DESCRIPTION
Our JS code does not send 'textinput' messages with a 'type' parameter
either, so it is pointless to do it in a unit test.

(We still have code that checks for the 'type' parameter in received
'textinput' messages. That is pointless, too, and should be removed.)

Also, document what testWriterTyping() apparently is doing.

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: I4954379339f14e4a310a76788521001048d84e37


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

