### PR TITLE
Check directly that the result is exactly what we expect

### DIFF
--- a/test/UnitTyping.cpp
+++ b/test/UnitTyping.cpp
@@ -109,10 +109,11 @@ public:
         const std::string result
             = getResponseString(socket, response, testname, std::chrono::seconds(5));
 
-        LOG_TRC("length " << result.length() << " vs. " << (responseLen + 4));
+        // The result string should contain "textselectioncontent:\n" followed by the UTF-8 bytes
+        LOG_TRC("length " << result.length() << " vs. " << (responseLen + 1 + sizeof(correct)));
         if (strncmp(result.c_str(), response, responseLen) ||
-            result.length() < responseLen + 4 ||
-            strncmp(result.c_str() + responseLen + 1, (const char *)correct, 3))
+            result.length() != responseLen + 1 + sizeof(correct) ||
+            memcmp(result.c_str() + responseLen + 1, (const char *)correct, sizeof(correct)))
         {
             LOK_ASSERT_FAIL("Error: wrong textselectioncontent:\n" + Util::dumpHex(result));
             return TestResult::Failed;


### PR DESCRIPTION
At least I didn't fully understand what the old code actually was
checking.

Also, use sizeof instead of magic numbers.

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: I01602a2e256b1fbe39793c9f1439e025461c5a72


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

