### PR TITLE
test: fix deleting log files

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -295,3 +295,5 @@ all-local: unittest
 	@UNITTEST=1 ${top_builddir}/test/unittest
 	echo "Done test all-local"
 	$(CLEANUP_COMMAND)
+
+.PRECIOUS: $(TEST_LOGS)


### PR DESCRIPTION
if make is killed or interrupted during the execution
of their recipes, the target is not deleted.  So there is
an opportunity to check the logs, why are taking to long
time to finish the test.

Change-Id: I6e8176a48ff721ecb2b2efc01b1f149907dd359b
Signed-off-by: Henry Castro <hcastro@collabora.com>
