### PR TITLE
test: run test with capabilities disabled

### DIFF
--- a/test/run_unit.sh.in
+++ b/test/run_unit.sh.in
@@ -19,6 +19,11 @@ jails_path="@JAILS_PATH@"
 lo_path="@LO_PATH@"
 valgrind_cmd="valgrind --tool=memcheck --trace-children=no -v --read-var-info=yes"
 verbose=''
+capabilities="@ENABLE_SETCAP@"
+
+if test "h$capabilities" != "htrue"; then
+    capabilities=false
+fi
 
 # Note that these options are used by commands in the Makefile that
 # Automake generates. Don't be mislead by 'git grep' not showing any


### PR DESCRIPTION
If the Forkit process dies very early due
to Fatal error (i.e. No capabilities ),
the WSD process will wait a long time for children.

In this case the ForKit will never recover,
so exit fail the unit test (high probability).

Change-Id: I402c84c1e11c971d546536090b5962c741204588
