### PR TITLE
Support aborting unloading

### DIFF
--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -926,7 +926,11 @@ app.definitions.Socket = L.Class.extend({
 					} catch (error) {
 						console.warn('Cannot activate map');
 					}
-				}, 1000);
+				// .5, 2, 4.5, 8, 12.5, 18, 24.5, 32, 40.5 seconds
+				}, 500 * this.ReconnectCount * this.ReconnectCount); // Exponential back-off.
+
+
+				this._map.fire('error', {msg: errorMessages.docunloading});
 			}
 
 			if (passwordNeeded) {

--- a/loleaflet/src/errormessages.js
+++ b/loleaflet/src/errormessages.js
@@ -24,6 +24,7 @@ errorMessages.faileddocloading = _('Failed to load the document. Please ensure t
 errorMessages.invalidLink = _('Invalid link: \'%url\'');
 errorMessages.leaving = _('You are leaving the editor, are you sure you want to visit %url?');
 errorMessages.docloadtimeout = _('Failed to load the document. This document is either malformed or is taking more resources than allowed. Please contact the administrator.');
+errorMessages.docunloading = _('We are in the process of cleaning up this document from the last session, please be patient and try again later.');
 
 if (window.ThisIsAMobileApp) {
 	errorMessages.storage = {

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -482,7 +482,7 @@ void DocumentBroker::pollThread()
 #endif
         if (_sessions.empty() && (isLoaded() || _docState.isMarkedToDestroy()))
         {
-            if (isAsyncSaveInProgress())
+            if (_saveManager.isSaving() || isAsyncSaveInProgress())
             {
                 LOG_DBG("Don't terminate dead DocumentBroker: async saving in progress for docKey [" << getDocKey() << "].");
                 continue;
@@ -1089,7 +1089,8 @@ bool DocumentBroker::attemptLock(const ClientSession& session, std::string& fail
 DocumentBroker::NeedToUpload DocumentBroker::needToUploadToStorage() const
 {
     // When destroying, we might have to force uploading if always_save_on_exit=true.
-    if (isMarkedToDestroy())
+    // If unloadRequested is set, assume we will unload after uploading and exit.
+    if (isMarkedToDestroy() || _docState.isUnloadRequested())
     {
         static const bool always_save
             = LOOLWSD::getConfigValue<bool>("per_document.always_save_on_exit", false);
@@ -1541,6 +1542,13 @@ void DocumentBroker::handleUploadToStorageResponse(const StorageBase::UploadResu
 
         broadcastLastModificationTime();
 
+        if (_docState.isUnloadRequested())
+        {
+            // We just uploaded, flag to destroy if unload is requested.
+            _docState.markToDestroy();
+            LOG_TRC("Unload requested after uploading, marking to destroy.");
+        }
+
         // If marked to destroy, then this was the last session.
         if (_docState.isMarkedToDestroy() || _sessions.empty())
         {
@@ -1940,11 +1948,7 @@ size_t DocumentBroker::removeSession(const std::string& id)
         }
         std::shared_ptr<ClientSession> session = it->second;
 
-        // Last view going away, can destroy.
-        if (_sessions.size() <= 1)
-            _docState.markToDestroy();
-        else
-            assert(!_docState.isMarkedToDestroy());
+        const bool isLastSession = (_sessions.size() == 1);
 
         const bool lastEditableSession = (!session->isReadOnly() || session->isAllowChangeComments()) && !haveAnotherEditableSession(id);
         static const bool dontSaveIfUnmodified = !LOOLWSD::getConfigValue<bool>("per_document.always_save_on_exit", false);
@@ -1981,6 +1985,28 @@ size_t DocumentBroker::removeSession(const std::string& id)
         // If last editable, save and don't remove until after uploading to storage.
         if (!lastEditableSession || !autoSave(isPossiblyModified(), dontSaveIfUnmodified))
             disconnectSessionInternal(id);
+
+        // Last view going away; can destroy?
+        if (isLastSession)
+        {
+            if (_saveManager.isSaving() || isAsyncSaveInProgress())
+            {
+                // Don't destroy just yet, wait until save and upload are done.
+                // Notice that the save and/or upload could have been triggered
+                // earlier, and not necessarily here when removing this last session.
+                _docState.setUnloadRequested();
+                LOG_DBG("Removing last session and will unload after saving. Setting "
+                        "UnloadRequested flag.");
+            }
+            else if (_sessions.empty())
+            {
+                // Nothing to save, and we were the last.
+                _docState.markToDestroy();
+                LOG_DBG("No more sessions after removing last. Setting MarkToDestroy flag.");
+            }
+        }
+        else
+            assert(!_docState.isMarkedToDestroy());
     }
     catch (const std::exception& ex)
     {
@@ -2004,6 +2030,16 @@ void DocumentBroker::disconnectSessionInternal(const std::string& id)
 #if !MOBILEAPP
             LOOLWSD::dumpEndSessionTrace(getJailId(), id, _uriOrig);
 #endif
+
+            if (_docState.isUnloadRequested())
+            {
+                // We must be the last session, flag to destroy if unload is requested.
+                assert(_sessions.size() == 1 && "Unload-requested with multiple sessions.");
+                _docState.markToDestroy();
+                LOG_TRC("Unload requested while disconnecting session ["
+                        << id << "], having " << _sessions.size()
+                        << " sessions, marking to destroy.");
+            }
 
             LOG_TRC("Disconnect session internal " << id <<
                     " destroy? " << _docState.isMarkedToDestroy() <<
@@ -2115,6 +2151,9 @@ std::shared_ptr<ClientSession> DocumentBroker::createNewClientSession(
 {
     try
     {
+        _docState.resetUnloadRequested(); // We can't unload, if it was requested.
+        LOG_TRC("Creating new session. Resetting UnloadRequested flag.");
+
         // Now we have a DocumentBroker and we're ready to process client commands.
         if (ws)
         {
@@ -3072,6 +3111,7 @@ void DocumentBroker::dumpState(std::ostream& os)
     os << "\n  doc activity: " << DocumentState::toString(_docState.activity());
     if (_docState.activity() == DocumentState::Activity::Rename)
         os << "\n  (new name: " << _renameFilename << ')';
+    os << "\n  unload requested: " << _docState.isUnloadRequested();
     os << "\n  last saved: " << Util::getSteadyClockAsString(_storageManager.getLastSaveTime());
     os << "\n  last save request: "
        << Util::getSteadyClockAsString(_saveManager.lastSaveRequestTime());

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -975,6 +975,7 @@ private:
             , _activity(Activity::None)
             , _closeRequested(false)
             , _loaded(false)
+            , _unloadRequested(false)
         {
         }
 
@@ -1019,11 +1020,17 @@ private:
         void setCloseRequested() { _closeRequested = true; }
         bool isCloseRequested() const { return _closeRequested; }
 
+        /// Flag to unload the document. May be reset when a new view is opened.
+        void setUnloadRequested() { _unloadRequested = true; }
+        void resetUnloadRequested() { _unloadRequested = false; }
+        bool isUnloadRequested() const { return _unloadRequested; }
+
     private:
         Status _status;
         Activity _activity;
         std::atomic<bool> _closeRequested; //< Owner-Termination flag.
         std::atomic<bool> _loaded; //< If the document ever loaded (check isLive to see if it still is).
+        std::atomic<bool> _unloadRequested; //< Unload-Requested flag, which may be reset.
     };
 
     /// Transition to a given activity. Returns false if an activity exists.

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -2844,7 +2844,7 @@ private:
             "\r\n"
             << xml;
 
-        LOG_ERR("Sending back: " << oss.str());
+        LOG_TRC("Sending back discovery.xml: " << oss.str());
         socket->send(oss.str());
         socket->shutdown();
         LOG_INF("Sent discovery.xml successfully.");


### PR DESCRIPTION
- leaflet: explanatory message when loading fails while unloading
- wsd: allow new views while unloading
- wsd: log discovery.xml response at trace level
