### PR TITLE
ssl: setup hostname for SNI

### DIFF
--- a/net/SslSocket.hpp
+++ b/net/SslSocket.hpp
@@ -44,6 +44,9 @@ public:
             throw std::runtime_error("Failed to create SSL.");
         }
 
+        if (!SSL_set_tlsext_host_name(_ssl, hostname.c_str()))
+            LOG_WRN("Failed to set hostname for Server Name Indication [" << hostname << ']');
+
         SSL_set_bio(_ssl, _bio, _bio);
 
         if (isClient)


### PR DESCRIPTION
For some servers we receive failure with HTTP 403 Forbidden in WOPI::CheckFileInfo

"Reason: The client software did not provide a hostname using Server
Name Indication (SNI), which is required to access this server"

fixes #2771 : https://github.com/CollaboraOnline/online/issues/2771
fixes #2752 : https://github.com/CollaboraOnline/online/issues/2752