### PR TITLE
Print a header in front of the list of last UNO commands

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -870,6 +870,8 @@ void ChildSession::dumpRecordedUnoCommands()
 {
     std::atomic<char*>* recordedCommands = unoCommandsRecorder.getRecordedCommands();
 
+    Log::signalLog("List of last UNO commands:\n");
+
     for (int i = 0; i < unoCommandsRecorder.NUM_UNO_COMMANDS; i++)
     {
         // Set the slot to null to prevent other threads from deleting


### PR DESCRIPTION
Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: I1f7194edb833d8569ca7bd87cadd903deb84ef0e


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

