### PR TITLE
renamefile: Respond with reload instead

### DIFF
--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -691,6 +691,10 @@ app.definitions.Socket = L.Class.extend({
 					showMsgAndReload = true;
 				}
 			}
+			else if (textMsg.startsWith('reloadafterrename')) {
+				msg = _('Reloading the document after rename');
+				showMsgAndReload = true;
+			}
 
 			if (showMsgAndReload) {
 				if (this._map._docLayer) {
@@ -1110,7 +1114,6 @@ app.definitions.Socket = L.Class.extend({
 	_renameOrSaveAsCallback: function(textMsg, command) {
 		this._map.hideBusy();
 		if (command !== undefined && command.url !== undefined && command.url !== '') {
-			this.close();
 			var url = command.url;
 			var accessToken = this._getParameterByName(url, 'access_token');
 			var accessTokenTtl = this._getParameterByName(url, 'access_token_ttl');
@@ -1134,17 +1137,6 @@ app.definitions.Socket = L.Class.extend({
 			var docUrl = url.split('?')[0];
 			this._map.options.doc = docUrl;
 			this._map.options.previousWopiSrc = this._map.options.wopiSrc; // After save-as op, we may connect to another server, then code will think that server has restarted. In this case, we don't want to reload the page (detect the file name is different).
-			this._map.options.wopiSrc = encodeURIComponent(docUrl);
-
-			// if this is save-as, we need to load the document with edit permission
-			// otherwise the user has to close the doc then re-open it again
-			// in order to be able to edit.
-			if (textMsg.startsWith('saveas:'))
-				this._map.options.permission = 'edit';
-			this._map.loadDocument();
-			this._map.sendInitUNOCommands();
-
-
 			if (textMsg.startsWith('renamefile:')) {
 				this._map.fire('postMessage', {
 					msgId: 'File_Rename',
@@ -1153,6 +1145,13 @@ app.definitions.Socket = L.Class.extend({
 					}
 				});
 			} else if (textMsg.startsWith('saveas:')) {
+				// if this is save-as, we need to load the document with edit permission
+				// otherwise the user has to close the doc then re-open it again
+				// in order to be able to edit.
+				this._map.options.permission = 'edit';
+				this.close();
+				this._map.loadDocument();
+				this._map.sendInitUNOCommands();
 				this._map.fire('postMessage', {
 					msgId: 'Action_Save_Resp',
 					args: {

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1490,10 +1490,10 @@ void DocumentBroker::handleUploadToStorageResponse(const StorageBase::UploadResu
             std::string encodedName;
             Poco::URI::encode(filename, "", encodedName);
             const std::string filenameAnonym = LOOLWSD::anonymizeUrl(filename);
-
             std::ostringstream oss;
             oss << "renamefile: " << "filename=" << encodedName << " url=" << url;
             broadcastMessage(oss.str());
+            broadcastMessage("close: reloadafterrename");
         }
         else
         {


### PR DESCRIPTION
This way it will reload the document without getting
additional errors like "this is embaressing.."
and not timed out on large files due to retrying for a limited
time.

Signed-off-by: Mert Tumer <mert.tumer@collabora.com>
Change-Id: Ied341200ca21e1b7243daaf62813bc9ed69fecd3


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

