### PR TITLE
Wait for async save result on DocumentBroker stop

### DIFF
--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -327,6 +327,8 @@ public:
     /// and receives save notification. Otherwise, false.
     bool autoSave(const bool force, const bool dontSaveIfUnmodified = true);
 
+    bool isAsyncSaveInProgress() const;
+
     Poco::URI getPublicUri() const { return _uriPublic; }
     const std::string& getJailId() const { return _jailId; }
     const std::string& getDocKey() const { return _docKey; }

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -2237,7 +2237,10 @@ private:
         {
             std::unique_lock<std::mutex> lock = docBroker->getLock();
             docBroker->assertCorrectThread();
-            docBroker->stop("docisdisconnected");
+            if (docBroker->isAsyncSaveInProgress())
+                LOG_DBG("Don't stop DocumentBroker on disconnect: async saving in progress.");
+            else
+                docBroker->stop("docisdisconnected");
         }
     }
 

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -627,6 +627,14 @@ public:
     /// Total time taken for making WOPI calls during uploading.
     std::chrono::milliseconds getWopiSaveDuration() const { return _wopiSaveDuration; }
 
+    virtual AsyncUpload queryLocalFileToStorageAsyncUploadState() override
+    {
+        if (_uploadHttpSession)
+            return AsyncUpload(AsyncUpload::State::Running, UploadResult(UploadResult::Result::OK));
+        else
+            return AsyncUpload(AsyncUpload::State::None, UploadResult(UploadResult::Result::OK));
+    }
+
 protected:
     struct WopiUploadDetails
     {


### PR DESCRIPTION
WIP, should be merged on top of https://github.com/CollaboraOnline/online/pull/2930

When async save was started but we want to stop DocumentBroker we shouldn't kill the socket which listens to save result.
Because when we kill socket we will destroy DocumentBroker before saving is completed, this allows for a minimal time to connect again to the document and receive old content from the WOPI storage.
When we wait for async save result we will keep DocumentBroker alive and next session can be connected and receive correct content.