### PR TITLE
fix: avoid crash in non writer apps

### DIFF
--- a/loleaflet/src/layer/tile/TileLayer.TableOverlay.js
+++ b/loleaflet/src/layer/tile/TileLayer.TableOverlay.js
@@ -28,6 +28,8 @@ L.CanvasTileLayer.include({
 		return point;
 	},
 	hasTableSelection: function () {
+		if (!this._currentTableData)
+			return false;
 		return this._currentTableData.rows != null || this._currentTableData.columns != null;
 	},
 	_initMoveMarkers: function () {


### PR DESCRIPTION
when calling hasTableSelection(). Do not depend on stray/duplicate
tableselection messages that can ensure a valid _currentTableData
member of TileLayer.

Signed-off-by: Dennis Francis <dennis.francis@collabora.com>
Change-Id: I957fdfc43c1435ca98eb204dcb3ec1e76b85ce89


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

