### PR TITLE
fix deadlock loading same document by multiple...

### DIFF
--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -1168,6 +1168,26 @@ int main(int argc, char**argv)
     /// conversion from steady_clock for debugging / tracing
     std::string getSteadyClockAsString(const std::chrono::steady_clock::time_point &time);
 
+    /// Automatically execute code at end of current scope.
+    /// Used for exception-safe code.
+    class ScopeGuard
+    {
+    public:
+        template <typename T>
+        explicit ScopeGuard(T const &func) : m_func(func) {}
+
+        ~ScopeGuard()
+        {
+            if (m_func)
+                m_func();
+        }
+    private:
+        ScopeGuard(const ScopeGuard &) = delete;
+        ScopeGuard &operator=(const ScopeGuard &) = delete;
+
+        std::function<void()> m_func;
+    };
+
     /**
      * Avoid using the configuration layer and rely on defaults which is only useful for special
      * test tool targets (typically fuzzing) where start-up speed is critical.

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1567,6 +1567,11 @@ public:
         ProcessToIdleDeadline = std::chrono::steady_clock::now() - std::chrono::milliseconds(10);
     }
 
+    bool isLoading() const
+    {
+        return _isLoading;
+    }
+
     void drainQueue()
     {
         try
@@ -2008,7 +2013,7 @@ public:
     {
         SigUtil::checkDumpGlobalState(dump_kit_state);
 
-        if (_document)
+        if (_document && !_document->isLoading())
             _document->drainQueue();
     }
 


### PR DESCRIPTION
views in the same thread for xlsx documents.

This can happen if core crashes due to some reason before it had
multiple views on the same document. All views request loading of the
document via queue. When one request of 'load' is being handled, the
xlsx filter code yields to update progress bar,

```
void importSheetFragments( WorkbookFragment& rWorkbookHandler, SheetFragmentVector& rSheets )
{
...
comphelper::ThreadPool &rSharedPool = comphelper::ThreadPool::getSharedOptimalPool();
std::shared_ptr<comphelper::ThreadTaskTag> pTag = comphelper::ThreadPool::createThreadTaskTag();
...
 while( nSheetsLeft > 0)
 {
     // This is a much more controlled re-enterancy hazard than
     // allowing a yield deeper inside the filter code for progress
     // bar updating.
     Application::Yield();
 }
 rSharedPool.waitUntilDone(pTag);
```

** but it also starts drainQueue() in that yield, which will attempt
another Document::onLoad() which has reentry protection, resulting in a
deadlock.

The proposed solution is to postpone all requests in the document queue
while a load is in progress. When the load finishes, the other requests
will just use the already loaded document.

Signed-off-by: Dennis Francis <dennis.francis@collabora.com>
Change-Id: I7a554a50c69e14dd2c49685995d655abd646d5f2


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

