### PR TITLE
fix deadlock loading same document by multiple...

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1537,6 +1537,11 @@ public:
         return _tileQueue && !_tileQueue->isEmpty();
     }
 
+    bool isLoading() const
+    {
+        return _isLoading;
+    }
+
     void drainQueue(const std::chrono::steady_clock::time_point &/*now*/)
     {
         try
@@ -1935,7 +1940,7 @@ public:
     {
         SigUtil::checkDumpGlobalState(dump_kit_state);
 
-        if (_document)
+        if (_document && !_document->isLoading())
             _document->drainQueue(now);
     }
 


### PR DESCRIPTION
views in the same thread for xlsx documents.

This can happen if core crashes due to some reason before it had
multiple views on the same document. All views request loading of the
document via queue. When one request of 'load' is being handled, the
xlsx filter code yields to update progress bar,

```
void importSheetFragments( WorkbookFragment& rWorkbookHandler, SheetFragmentVector& rSheets )
{
...
comphelper::ThreadPool &rSharedPool = comphelper::ThreadPool::getSharedOptimalPool();
std::shared_ptr<comphelper::ThreadTaskTag> pTag = comphelper::ThreadPool::createThreadTaskTag();
...
 while( nSheetsLeft > 0)
 {
     // This is a much more controlled re-enterancy hazard than
     // allowing a yield deeper inside the filter code for progress
     // bar updating.
     Application::Yield();
 }
 rSharedPool.waitUntilDone(pTag);
```

** but it also starts drainQueue() in that yield, which will attempt
another Document::onLoad() which has reentry protection, resulting in a
deadlock.

The proposed solution is to postpone all requests in the document queue
while a load is in progress. When the load finishes, the other requests
will just use the already loaded document.

Signed-off-by: Dennis Francis <dennis.francis@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

