### PR TITLE
kit: disable parallel processing at higher levels

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -791,7 +791,8 @@ public:
         _stop(false),
         _isLoading(0),
         _editorId(-1),
-        _editorChangeWarning(false)
+        _editorChangeWarning(false),
+        _inputProcessingEnabled(true)
     {
         LOG_INF("Document ctor for [" << _docKey <<
                 "] url [" << anonymizeUrl(_url) << "] on child [" << _jailId <<
@@ -1946,6 +1947,9 @@ private:
     }
 
 public:
+    void enableProcessInput(bool enable = true){ _inputProcessingEnabled = enable; }
+    bool processInputEnabled() { return _inputProcessingEnabled; }
+
     bool hasQueueItems() const
     {
         return _tileQueue && !_tileQueue->isEmpty();
@@ -1955,7 +1959,7 @@ public:
     {
         try
         {
-            while (hasQueueItems())
+            while (processInputEnabled() && hasQueueItems())
             {
                 if (_stop || SigUtil::getTerminationFlag())
                 {
@@ -2197,6 +2201,8 @@ private:
 #ifdef __ANDROID__
     friend std::shared_ptr<lok::Document> getLOKDocumentForAndroidOnly();
 #endif
+
+    bool _inputProcessingEnabled;
 };
 
 #ifdef __ANDROID__
@@ -2473,6 +2479,9 @@ protected:
     virtual void enableProcessInput(bool enable = true) override
     {
         WebSocketHandler::enableProcessInput(enable);
+        if (_document)
+            _document->enableProcessInput(enable);
+
         // Wake up poll to process data from socket input buffer
         if (enable)
         {

--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -415,7 +415,7 @@ public:
 #endif
         else
         {
-            while (handleTCPStream(socket))
+            while (socket->processInputEnabled() && handleTCPStream(socket))
                 ; // might have multiple messages in the accumulated buffer.
         }
     }


### PR DESCRIPTION
Sometimes multiple messages are processed in a single iteration
at socket level. This happens in WebSocketHandler and when draining
Document queue.Just covered these cases.

Change-Id: Ifa46f5d484b67015cca64008b2c89426cc839e64
Reviewed-on: https://gerrit.libreoffice.org/c/online/+/99387
Tested-by: Jenkins
Tested-by: Gabriel Masei <gabriel.masei@1and1.ro>
Reviewed-by: Michael Meeks <michael.meeks@collabora.com>
Reviewed-by: Gabriel Masei <gabriel.masei@1and1.ro>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

