### PR TITLE
leaflet: reconnect with a small delay when disconnected

### DIFF
--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -1389,8 +1389,21 @@ app.definitions.Socket = L.Class.extend({
 		this._map.fire('docloaded', {status: false});
 
 		if (!this._reconnecting) {
-			this._reconnecting = true;
-			this._map._activate();
+			// Prevent reconnecting at the same time.
+			var min = 500;
+			var max = 2000;
+			var timeoutMs = Math.floor(Math.random() * (max - min) + min);
+
+			var that = this;
+			clearTimeout(vex.timer);
+			vex.timer = setInterval(function () {
+				clearTimeout(vex.timer);
+
+				if (!that._reconnecting) {
+					that._reconnecting = true;
+					that._map._activate();
+				}
+			}, timeoutMs);
 		}
 	},
 


### PR DESCRIPTION
This avoids hammering the server, especially when multiple
clients are dropped at the same time or the server isn't
able to accept connections just yet.

Change-Id: Id3e27164fb00de69f661ba7580075b36100a03c1
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
