### PR TITLE
Don't populate font size combobox with select2

### DIFF
--- a/loleaflet/src/control/Control.TopToolbar.js
+++ b/loleaflet/src/control/Control.TopToolbar.js
@@ -148,7 +148,6 @@ L.Control.TopToolbar = L.Control.extend({
 						edata.isCancelled = true;
 					} else {
 						$.extend(edata, { onComplete: function (e) {
-							$('#fontsizes-select').select2({ dropdownAutoWidth: true, width: 'auto'});
 							e.item.html = undefined;
 						}});
 					}

--- a/loleaflet/src/control/Toolbar.js
+++ b/loleaflet/src/control/Toolbar.js
@@ -121,23 +121,33 @@ L.Map.include({
 			22, 24, 26, 28, 32, 36, 40, 44, 48, 54, 60, 66, 72, 80, 88, 96];
 
 		var fontsizecombobox = $(nodeSelector);
+		if (!fontsizecombobox.hasClass('select2')) {
+			fontsizecombobox.select2({
+				dropdownAutoWidth: true,
+				width: 'auto',
+				placeholder: _('Font Size'),
+				//Allow manually entered font size.
+				createTag: function(query) {
+					return {
+						id: query.term,
+						text: query.term,
+						tag: true
+					};
+				},
+				tags: true,
+				sorter: function(data) { return data.sort(function(a, b) {
+					return parseFloat(a.text) - parseFloat(b.text);
+				});}
+			});
+		}
 
-		fontsizecombobox.select2({
-			data: data,
-			placeholder: ' ',
-			//Allow manually entered font size.
-			createTag: function(query) {
-				return {
-					id: query.term,
-					text: query.term,
-					tag: true
-				};
-			},
-			tags: true,
-			sorter: function(data) { return data.sort(function(a, b) {
-				return parseFloat(a.text) - parseFloat(b.text);
-			});}
-		});
+		fontsizecombobox.empty();
+		for (var i = 0; i < data.length; ++i) {
+			var option = document.createElement('option');
+			option.text = data[i];
+			option.value = data[i];
+			fontsizecombobox.append(option);
+		}
 		fontsizecombobox.off('select2:select', this.onFontSizeSelect.bind(this)).on('select2:select', this.onFontSizeSelect.bind(this));
 
 		var onCommandStateChanged = function(e) {


### PR DESCRIPTION
We dont need to use select2 for this since
we only use the simple values of each option
this way we spend 50% less time on creating the list

Signed-off-by: Mert Tumer <mert.tumer@collabora.com>
Change-Id: I470cfc7df1fa38246355acae9cb6cb0f4a1ab316


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

