### PR TITLE
Don't generate useless loleaflet._emitSlurpedEvents-to-idle async tra…

### DIFF
--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -328,10 +328,6 @@ app.definitions.Socket = L.Class.extend({
 						if (completeEventOneMessage)
 							completeEventOneMessage.finish();
 					}
-					var asyncEvent = this.createAsyncTraceEvent('loleaflet._emitSlurpedEvents-to-idle',
-										    {'_slurpQueue.length' : String(queueLen)});
-					if (asyncEvent)
-						setTimeout(function() { asyncEvent.finish(); }, 0);
 				}
 				else {
 					// Stop emitting, continue in the next timer from where we left off.


### PR DESCRIPTION
…ce events

The resulting Trace Event JSON ends up with tons of such async events
for which the viewer in Edge (i.e. Chromium) just says "Did Not
Finish".

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: I29ae233bf16086ffd464567660954ac4c171c7fb


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

