### PR TITLE
loleaflet: use different name for 'Move or Copy Sheet' option when there is only one sheet

### DIFF
--- a/loleaflet/src/control/Control.Tabs.js
+++ b/loleaflet/src/control/Control.Tabs.js
@@ -94,8 +94,18 @@ L.Control.Tabs = L.Control.extend({
 			// no blacklisting available for this context menu so only add when needed
 			this._menuItem['.uno:Move'] = {
 				name: _UNO('.uno:Move', 'spreadsheet', true),
-				callback: function() {this._map.sendUnoCommand('.uno:Move');}.bind(this)
+				callback: function() {this._map.sendUnoCommand('.uno:Move');}.bind(this),
+				visible: areTabsMultiple
 			};
+
+			this._menuItem['.uno:CopyTab'] = {
+				name: _UNO('.uno:CopyTab', 'spreadsheet', true),
+				callback: function() {this._map.sendUnoCommand('.uno:Move');}.bind(this),
+				visible: function() {
+					return !areTabsMultiple();
+				}
+			};
+
 			L.installContextMenu({
 				selector: '.spreadsheet-tab',
 				className: 'loleaflet-font',

--- a/loleaflet/src/unocommands.js
+++ b/loleaflet/src/unocommands.js
@@ -313,6 +313,7 @@ var unoCommandsArray = {
 	'MergeCells':{presentation:{menu:_('Merge Cells'),},spreadsheet:{menu:_('Merge Cells'),},text:{menu:_('Merge Cells'),},},
 	'ModifyPage':{presentation:{menu:_('Slide ~Layout'),},},
 	'Move':{spreadsheet:{menu:_('~Move or Copy Sheet...'),},},
+	'CopyTab':{spreadsheet:{menu:_('Copy Sheet...'),},},
 	'MoveDown':{text:{menu:_('Move Down'),},},
 	'MoveDownSubItems':{text:{menu:_('Move Down with Subpoints'),},},
 	'MoveUp':{text:{menu:_('Move Up'),},},


### PR DESCRIPTION

Signed-off-by: Rash419 <rashesh.padia@collabora.com>
Change-Id: Iea110a5c3e66e8ae1693b42bfedce81d19c6247f

* Target version: master 
