### PR TITLE
Handle poll results in SocketPoll in a round-robin order

### DIFF
--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -186,6 +186,7 @@ namespace {
 
 SocketPoll::SocketPoll(const std::string& threadName)
     : _name(threadName),
+      _pollStartIndex(0),
       _stop(false),
       _threadStarted(0),
       _threadFinished(false),
@@ -437,30 +438,60 @@ int SocketPoll::poll(int64_t timeoutMaxMicroS)
     std::chrono::steady_clock::time_point newNow =
         std::chrono::steady_clock::now();
 
-    for (int i = static_cast<int>(size) - 1; i >= 0; --i)
+    if (size > 0)
     {
-        SocketDisposition disposition(_pollSockets[i]);
-        try
+        // We use the _pollStartIndex to start the polling at a different index each time. Do some
+        // sanity check first to handle the case where we removed one or several sockets last time.
+        if (_pollStartIndex > size - 1)
+            _pollStartIndex = size - 1;
+
+        std::vector<int> toErase;
+
+        LOG_DBG("Starting handling poll results of " << _name << " at index " << _pollStartIndex << " (of " << size << ")");
+
+        size_t i = _pollStartIndex;
+        size_t previ = size;
+        while (previ != _pollStartIndex)
         {
-            _pollSockets[i]->handlePoll(disposition, newNow,
-                                        _pollFds[i].revents);
+            SocketDisposition disposition(_pollSockets[i]);
+            try
+            {
+                _pollSockets[i]->handlePoll(disposition, newNow,
+                                            _pollFds[i].revents);
+            }
+            catch (const std::exception& exc)
+            {
+                LOG_ERR("Error while handling poll for socket #" <<
+                        _pollFds[i].fd << " at " << i << " in " << _name << ": " << exc.what());
+                disposition.setClosed();
+                rc = -1;
+            }
+
+            if (!disposition.isContinue())
+                toErase.push_back(i);
+
+            disposition.execute();
+
+            previ = i;
+            if (i == 0)
+                i = size - 1;
+            else
+                i--;
         }
-        catch (const std::exception& exc)
+        if (!toErase.empty())
         {
-            LOG_ERR("Error while handling poll for socket #" <<
-                    _pollFds[i].fd << " in " << _name << ": " << exc.what());
-            disposition.setClosed();
-            rc = -1;
+            std::sort(toErase.begin(), toErase.end(), [](int a, int b) { return a > b; });
+            for (int eraseIndex : toErase)
+            {
+                LOG_DBG("Removing socket #" << _pollFds[eraseIndex].fd << " (at " << eraseIndex << " of " <<
+                        _pollSockets.size() << ") from " << _name);
+                _pollSockets.erase(_pollSockets.begin() + eraseIndex);
+            }
         }
 
-        if (!disposition.isContinue())
-        {
-            LOG_DBG("Removing socket #" << _pollFds[i].fd << " (of " <<
-                    _pollSockets.size() << ") from " << _name);
-            _pollSockets.erase(_pollSockets.begin() + i);
-        }
-
-        disposition.execute();
+        // In case we remved sockets the new _pollStartIndex might be out of bounds, but we check it
+        // before using it above anyway.
+        _pollStartIndex = (_pollStartIndex + 1) % size;
     }
 
     return rc;

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -862,6 +862,9 @@ private:
     int _wakeup[2];
     /// The sockets we're controlling
     std::vector<std::shared_ptr<Socket>> _pollSockets;
+    /// We start handling the poll results of the above sockets at a different index each time, to
+    /// not arbitrarily prioritize some
+    size_t _pollStartIndex;
     /// Protects _newSockets and _newCallbacks
     std::mutex _mutex;
     std::vector<std::shared_ptr<Socket>> _newSockets;


### PR DESCRIPTION
We don't want to always start with the most recently added socket.

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: Ic4b4bf6c19c5d119e6e6f9b398789a4c77b47a10


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

