### PR TITLE
loleaflet: fix: scroll buttons still appear when toolbar is narrower then window

### DIFF
--- a/loleaflet/src/control/Control.NotebookbarBuilder.js
+++ b/loleaflet/src/control/Control.NotebookbarBuilder.js
@@ -358,6 +358,7 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 				}
 			}
 			$(contentDivs[t]).show();
+			$(window).resize();
 			builder.wizard.selectedTab(tabIds[t]);
 		};
 	},


### PR DESCRIPTION
Signed-off-by: Rash419 <rashesh.padia@collabora.com>
Change-Id: Ic66ed15c90c1f012138a29b81ee0a8540667acf5


* Resolves: #2992 
* Target version: master 


