### PR TITLE
Remove non-abstract unix socket files on shutdown.

### DIFF
--- a/net/ServerSocket.hpp
+++ b/net/ServerSocket.hpp
@@ -129,9 +129,14 @@ public:
         ServerSocket(Socket::Type::Unix, clientPoller, std::move(sockFactory))
     {
     }
+    ~LocalServerSocket();
+
     virtual bool bind(Type, int) override { assert(false); return false; }
     virtual std::shared_ptr<Socket> accept() override;
     std::string bind();
+
+private:
+    std::string _name;
 };
 
 #endif

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -975,9 +975,19 @@ std::string LocalServerSocket::bind()
     } while (rc < 0 && errno == EADDRINUSE);
 
     if (rc >= 0)
+    {
+        _name = std::string(&addrunix.sun_path[0]);
         return std::string(&addrunix.sun_path[1]);
+    }
 
     return std::string();
+}
+
+LocalServerSocket::~LocalServerSocket()
+{
+#ifndef HAVE_ABSTRACT_UNIX_SOCKETS
+    ::unlink(_name.c_str());
+#endif
 }
 
 // For a verbose life, tweak here:

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -53,6 +53,9 @@ constexpr std::chrono::microseconds WebSocketHandler::PingFrequencyMicroS;
 std::atomic<bool> SocketPoll::InhibitThreadChecks(false);
 std::atomic<bool> Socket::InhibitThreadChecks(false);
 
+#ifdef __linux__
+#define HAVE_ABSTRACT_UNIX_SOCKETS
+#endif
 #define SOCKET_ABSTRACT_UNIX_NAME "0loolwsd-"
 
 int Socket::createSocket(Socket::Type type)
@@ -518,7 +521,7 @@ void SocketPoll::insertNewUnixSocket(
     struct sockaddr_un addrunix;
     std::memset(&addrunix, 0, sizeof(addrunix));
     addrunix.sun_family = AF_UNIX;
-#ifdef __linux__
+#ifdef HAVE_ABSTRACT_UNIX_SOCKETS
     addrunix.sun_path[0] = '\0'; // abstract name
 #else
     addrunix.sun_path[0] = '0';
@@ -959,7 +962,7 @@ std::string LocalServerSocket::bind()
         std::memset(&addrunix, 0, sizeof(addrunix));
         addrunix.sun_family = AF_UNIX;
         std::memcpy(addrunix.sun_path, socketAbstractUnixName.c_str(), socketAbstractUnixName.length());
-#ifdef __linux__
+#ifdef HAVE_ABSTRACT_UNIX_SOCKETS
         addrunix.sun_path[0] = '\0'; // abstract name
 #endif
 


### PR DESCRIPTION
* Target version: master 

This required reverting 0dd30ba28ffd4482ea21e2495862e7979f0a4137, it was silly of me to push it so early. Sorry for that.

### Checklist

- [X] Code is properly formatted
- [X] All commits have Change-Id
- [X] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

