### PR TITLE
wsd: log stopping-although-modified as warning

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -502,7 +502,7 @@ void DocumentBroker::pollThread()
     {
         std::stringstream state;
         dumpState(state);
-        LOG_ERR("DocumentBroker stopping although modified " << state.str());
+        LOG_WRN("DocumentBroker stopping although flagged as modified " << state.str());
     }
 
     // Flush socket data first.
@@ -3117,7 +3117,7 @@ void DocumentBroker::dumpState(std::ostream& os)
        << Util::getSteadyClockAsString(_saveManager.lastSaveRequestTime());
     os << "\n  last save response: "
        << Util::getSteadyClockAsString(_saveManager.lastSaveResponseTime());
-    os << "\n  last storage save was successful: " << isLastStorageUploadSuccessful();
+    os << "\n  last storage upload was successful: " << isLastStorageUploadSuccessful();
     os << "\n  last modified: " << Util::getHttpTime(_storageManager.getLastModifiedTime());
     os << "\n  file last modified: " << Util::getHttpTime(_saveManager.getLastModifiedTime());
     os << "\n  isSaving now: " << std::boolalpha << _saveManager.isSaving();


### PR DESCRIPTION
This log entry can be misleading on its own.
When shutting down, the modified flag is not reset,
and that in itself is not a cause for concern.
So this log entry is seen much more often than we
expect. If we truely fail to save/upload, there
will be other errors that will be the tell-tale
signs of a serious issue. So it's reasonable to
downgrade this error to a warning (and watch for
other errors).

Change-Id: Ic879c3fbac887ed5b64bdd1a31aa38bcfd863850
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
