### PR TITLE
perf-test: Performance updates

### DIFF
--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -1423,9 +1423,6 @@ L.CanvasTileLayer = L.Layer.extend({
 		// 'tile:' is the most common message type; keep this the first.
 		if (textMsg.startsWith('tile:')) {
 			this._onTileMsg(textMsg, img);
-			if (window.perfTests) {
-				this._map.fire('tilearrived');
-			}
 		}
 		else if (textMsg.startsWith('commandvalues:')) {
 			this._onCommandValuesMsg(textMsg);


### PR DESCRIPTION
a) removed event firing for catching tile messages
    - injected socket onmessage function and made a middleware instead
    - the middleware can catch any socket messages
b) Replaced "fake sleep" and while loop for keystroke messages
   with setInterval function.
c) disabled processing incoming messages for multiple views
    - Optimizing the front end for JSDOM seems to be hopeless.
      the benchmark numbers for JSDOM and Real browser does not match
      and most of the time are unrelevant. In most cases where JSDOM is
      slower take almost no time for Real browser. These cases will not
      make real experience smoother if somehow fixed. In addition,
      rendering hundereds of socket messages makes nodejs use 100% of the cpu
      and benchmarking the loolwsd or loolforkit properly becomes impossible
      since nodejs cannnot handle messages in time and send keystroke messages
      with respecting the interval.
    - This way we can only focus on the backend performance and find the
      problems that "mesh the keyboard" events produce.
d) Recording stats will now count the num of socket messages received

Signed-off-by: Mert Tumer <mert.tumer@collabora.com>
Change-Id: If7d11ecea00ca175463a5d3b8bbe7c29a4b6b32e


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

