### PR TITLE
Fix view jump flicker on docload in Calc (co-6-4)

### DIFF
--- a/loleaflet/src/layer/tile/CalcTileLayer.js
+++ b/loleaflet/src/layer/tile/CalcTileLayer.js
@@ -779,6 +779,12 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 	_onCellCursorMsg: function (textMsg) {
 		L.CanvasTileLayer.prototype._onCellCursorMsg.call(this, textMsg);
 		this._refreshRowColumnHeaders();
+		if (!this._gotFirstCellCursor && !textMsg.match('EMPTY')) {
+			// Drawing is disabled from CalcTileLayer construction, enable it now.
+			this._gotFirstCellCursor = true;
+			this._update();
+			this.enableDrawing();
+		}
 	},
 
 	_getEditCursorRectangle: function (msgObj) {

--- a/loleaflet/src/layer/tile/CalcTileLayer.js
+++ b/loleaflet/src/layer/tile/CalcTileLayer.js
@@ -69,6 +69,8 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 		this.insertMode = false;
 		this._cellSelections = Array(0);
 		this._cellCursorXY = {x: -1, y: -1};
+		this._gotFirstCellCursor = false;
+		this.requestCellCursor();
 	},
 
 	isHiddenPart: function (part) {

--- a/loleaflet/src/layer/tile/CanvasSectionContainer.ts
+++ b/loleaflet/src/layer/tile/CanvasSectionContainer.ts
@@ -279,6 +279,7 @@ class CanvasSectionContainer {
 	private documentAnchor: Array<number> = null; // This is the point where document starts inside canvas element. Initial value shouldn't be [0, 0].
 	// Above 2 properties can be used with documentBounds.
 	private drawingPaused: number = 0;
+	private drawingEnabled: boolean = true;
 	private dirty: boolean = false;
 	private sectionsDirty: boolean = false;
 
@@ -295,7 +296,7 @@ class CanvasSectionContainer {
 	private stoppingFunctionList: Array<EventListener>; // Event listeners need to be removed from the canvas object. So we keep track of their functions.
 	private stoppingEventTypes: Array<string>; // Events those stop the animation.
 
-	constructor (canvasDOMElement: HTMLCanvasElement) {
+	constructor (canvasDOMElement: HTMLCanvasElement, disableDrawing?: boolean) {
 		this.canvas = canvasDOMElement;
 		this.context = canvasDOMElement.getContext('2d', { alpha: false , desynchronized: true });
 		this.context.setTransform(1,0,0,1,0,0);
@@ -325,6 +326,9 @@ class CanvasSectionContainer {
 		document.body.appendChild(tempElement);
 		this.scrollLineHeight = parseInt(window.getComputedStyle(tempElement).fontSize);
 		document.body.removeChild(tempElement); // Remove the temporary element.
+
+		if (disableDrawing)
+			this.disableDrawing();
 	}
 
 	getContext () {
@@ -374,11 +378,32 @@ class CanvasSectionContainer {
 		return this.zoomChanged;
 	}
 
-	isDrawingPaused (): boolean {
-		return this.drawingPaused > 0;
+	drawingAllowed (): boolean {
+		return this.drawingEnabled && this.drawingPaused <= 0;
+	}
+
+	// This is used for making sure rendering does not happen for multiple runs of
+	// Socket._emitSlurpedEvents(). Currently this is used in Calc to disable rendering
+	// from docload till we get tiles of the correct view area to render.
+	// After calling this, only enableDrawing() can undo this call.
+	disableDrawing () {
+		this.drawingEnabled = false;
+	}
+
+	enableDrawing () {
+		if (this.drawingEnabled)
+			return;
+
+		this.drawingEnabled = true;
+		if (this.drawingPaused === 0) {
+			// Trigger a forced repaint as drawing is not paused currently.
+			this.dirty = true;
+			this.paintOnResumeOrEnable();
+		}
 	}
 
 	pauseDrawing () {
+
 		if (this.drawingPaused++ === 0) {
 			this.dirty = false;
 		}
@@ -387,28 +412,32 @@ class CanvasSectionContainer {
 	// set topLevel if we are sure that we are the top of call nesting
 	// eg. in a browser event handler. Avoids JS exceptions poisoning
 	// the count, since we have no RAII helpers here.
-	resumeDrawing(topLevel: boolean) {
+	resumeDrawing(topLevel?: boolean) {
 		var wasNonZero: boolean = this.drawingPaused !== 0;
 		if (topLevel)
 		   this.drawingPaused = 0;
-		else
+		else if (this.drawingPaused > 0)  // ensure non-negative value.
 		   this.drawingPaused--;
 
-		if (wasNonZero && this.drawingPaused === 0) {
-			if (this.sectionsDirty) {
-				this.updateBoundSectionLists();
-				this.reNewAllSections(false);
-				this.sectionsDirty = false;
-			}
+		if (this.drawingEnabled && wasNonZero && this.drawingPaused === 0) {
+			this.paintOnResumeOrEnable();
+		}
+	}
 
-			var scrollSection = <any>this.getSectionWithName(L.CSections.Scroll.name)
-			if (scrollSection)
-				scrollSection.completePendingScroll(); // No painting, only dirtying.
+	private paintOnResumeOrEnable() {
+		if (this.sectionsDirty) {
+			this.updateBoundSectionLists();
+			this.reNewAllSections(false);
+			this.sectionsDirty = false;
+		}
 
-			if (this.dirty) {
-				this.requestReDraw();
-				this.dirty = false;
-			}
+		var scrollSection = <any>this.getSectionWithName(L.CSections.Scroll.name)
+		if (scrollSection)
+			scrollSection.completePendingScroll(); // No painting, only dirtying.
+
+		if (this.dirty) {
+			this.requestReDraw();
+			this.dirty = false;
 		}
 	}
 
@@ -598,7 +627,7 @@ class CanvasSectionContainer {
 	}
 
 	public requestReDraw() {
-		if (this.isDrawingPaused()) {
+		if (!this.drawingAllowed()) {
 			// Someone requested a redraw, but we're paused => schedule a redraw.
 			this.setDirty();
 			return;
@@ -1773,7 +1802,7 @@ class CanvasSectionContainer {
 		this.sections.push(newSection);
 		this.addSectionFunctions(newSection);
 		newSection.onInitialize();
-		if (!this.isDrawingPaused()) {
+		if (this.drawingAllowed()) {
 			this.updateBoundSectionLists();
 			this.reNewAllSections();
 		}
@@ -1799,7 +1828,7 @@ class CanvasSectionContainer {
 		}
 
 		if (found) {
-			if (this.isDrawingPaused())
+			if (!this.drawingAllowed())
 			    this.sectionsDirty = true;
 			else {
 			    this.updateBoundSectionLists();

--- a/loleaflet/src/layer/tile/CanvasSectionContainer.ts
+++ b/loleaflet/src/layer/tile/CanvasSectionContainer.ts
@@ -282,6 +282,7 @@ class CanvasSectionContainer {
 	private drawingEnabled: boolean = true;
 	private dirty: boolean = false;
 	private sectionsDirty: boolean = false;
+	private paintedEver: boolean = false;
 
 	// For window sections.
 	private windowSectionList: Array<CanvasSectionObject> = [];
@@ -329,6 +330,12 @@ class CanvasSectionContainer {
 
 		if (disableDrawing)
 			this.disableDrawing();
+	}
+
+	private clearCanvas() {
+		this.context.fillStyle = this.clearColor;
+		this.context.clearRect(0, 0, this.canvas.width, this.canvas.height);
+		this.context.fillRect(0, 0, this.canvas.width, this.canvas.height);
 	}
 
 	getContext () {
@@ -1241,6 +1248,11 @@ class CanvasSectionContainer {
 		this.canvas.style.width = cssWidth.toFixed(4) + 'px';
 		this.canvas.style.height = cssHeight.toFixed(4) + 'px';
 
+		// Avoid black default background if canvas was never painted
+		// since construction.
+		if (!this.paintedEver)
+			this.clearCanvas();
+
 		this.clearMousePositions();
 		this.right = this.canvas.width;
 		this.bottom = this.canvas.height;
@@ -1398,7 +1410,7 @@ class CanvasSectionContainer {
 		this.applyDrawingOrders();
 		if (this.testing)
 			this.createUpdateDivElements();
-		if (redraw)
+		if (redraw && this.drawingAllowed())
 			this.drawSections();
 	}
 
@@ -1616,9 +1628,7 @@ class CanvasSectionContainer {
 		this.context.setTransform(1, 0, 0, 1, 0, 0);
 
 		if (!this.zoomChanged) {
-			this.context.fillStyle = this.clearColor;
-			this.context.clearRect(0, 0, this.canvas.width, this.canvas.height);
-			this.context.fillRect(0, 0, this.canvas.width, this.canvas.height);
+			this.clearCanvas();
 		}
 
 		this.context.font = String(20 * this.dpiScale) + "px Verdana";
@@ -1643,6 +1653,8 @@ class CanvasSectionContainer {
 				this.context.translate(-this.sections[i].myTopLeft[0], -this.sections[i].myTopLeft[1]);
 			}
 		}
+
+		this.paintedEver = true;
 		//this.drawSectionBorders();
 	}
 

--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -1348,6 +1348,10 @@ L.CanvasTileLayer = L.TileLayer.extend({
 			return;
 		}
 
+		// Calc: do not set view area too early after load and before we get the cursor position.
+		if (this.isCalc() && !this._gotFirstCellCursor)
+			return;
+
 		if (app.file.fileBasedView) {
 			this._updateFileBasedView();
 			return;

--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -46,7 +46,7 @@ L.TileSectionManager = L.Class.extend({
 		this._oscCtxs = [];
 		this._tilesSection = null; // Shortcut.
 
-		this._sectionContainer = new CanvasSectionContainer(this._canvas);
+		this._sectionContainer = new CanvasSectionContainer(this._canvas, this._layer.isCalc() /* disableDrawing? */);
 
 		if (this._layer.isCalc())
 			this._sectionContainer.setClearColor('white');
@@ -729,6 +729,11 @@ L.CanvasTileLayer = L.TileLayer.extend({
 	resumeDrawing: function (topLevel) {
 		if (this._painter && this._painter._sectionContainer)
 			this._painter._sectionContainer.resumeDrawing(topLevel);
+	},
+
+	enableDrawing: function () {
+		if (this._painter && this._painter._sectionContainer)
+			this._painter._sectionContainer.enableDrawing();
 	},
 
 	_getUIWidth: function () {

--- a/loleaflet/src/layer/tile/ScrollSection.ts
+++ b/loleaflet/src/layer/tile/ScrollSection.ts
@@ -110,7 +110,7 @@ class ScrollSection {
 	}
 
 	public onScrollTo (e: any, force: boolean = false) {
-		if (!force && this.containerObject.isDrawingPaused()) {
+		if (!force && !this.containerObject.drawingAllowed()) {
 			// Only remember the last scroll-to position.
 			this.pendingScrollEvent = e;
 			return;

--- a/loleaflet/src/layer/tile/TileLayer.js
+++ b/loleaflet/src/layer/tile/TileLayer.js
@@ -1372,7 +1372,9 @@ L.TileLayer = L.GridLayer.extend({
 			this._prevCellCursorXY = new L.Point(-1, -1);
 		}
 
-		if (textMsg.match('EMPTY') || !this._map.isPermissionEdit()) {
+		var empty = textMsg.match('EMPTY');
+
+		if (empty || !this._map.isPermissionEdit()) {
 			this._cellCursorTwips = new L.Bounds(new L.Point(0, 0), new L.Point(0, 0));
 			this._cellCursor = L.LatLngBounds.createDefault();
 			this._cellCursorXY = new L.Point(-1, -1);
@@ -1433,6 +1435,11 @@ L.TileLayer = L.GridLayer.extend({
 
 		// Remove input help if there is any:
 		this._removeInputHelpMarker();
+
+		if (!empty && !this._gotFirstCellCursor) {
+			this._gotFirstCellCursor = true;
+			this._update();
+		}
 	},
 
 	_removeInputHelpMarker: function() {
@@ -3822,12 +3829,16 @@ L.TileLayer = L.GridLayer.extend({
 	// hence we need to request an updated cell cursor position for this level.
 	_onCellCursorShift: function (force) {
 		if ((this._cellCursorMarker && !this.options.sheetGeometryDataEnabled) || force) {
-			app.socket.sendMessage('commandvalues command=.uno:CellCursor'
-			                     + '?outputHeight=' + this._tileWidthPx
-			                     + '&outputWidth=' + this._tileHeightPx
-			                     + '&tileHeight=' + this._tileWidthTwips
-			                     + '&tileWidth=' + this._tileHeightTwips);
+			this.requestCellCursor();
 		}
+	},
+
+	requestCellCursor: function() {
+		app.socket.sendMessage('commandvalues command=.uno:CellCursor'
+			+ '?outputHeight=' + this._tileWidthPx
+			+ '&outputWidth=' + this._tileHeightPx
+			+ '&tileHeight=' + this._tileWidthTwips
+			+ '&tileWidth=' + this._tileHeightTwips);
 	},
 
 	_invalidatePreviews: function () {

--- a/loleaflet/src/layer/tile/TileLayer.js
+++ b/loleaflet/src/layer/tile/TileLayer.js
@@ -1437,8 +1437,10 @@ L.TileLayer = L.GridLayer.extend({
 		this._removeInputHelpMarker();
 
 		if (!empty && !this._gotFirstCellCursor) {
+			// Drawing is disabled from CalcTileLayer construction, enable it now.
 			this._gotFirstCellCursor = true;
 			this._update();
+			this.enableDrawing();
 		}
 	},
 

--- a/loleaflet/src/layer/tile/TileLayer.js
+++ b/loleaflet/src/layer/tile/TileLayer.js
@@ -1372,9 +1372,7 @@ L.TileLayer = L.GridLayer.extend({
 			this._prevCellCursorXY = new L.Point(-1, -1);
 		}
 
-		var empty = textMsg.match('EMPTY');
-
-		if (empty || !this._map.isPermissionEdit()) {
+		if (textMsg.match('EMPTY') || !this._map.isPermissionEdit()) {
 			this._cellCursorTwips = new L.Bounds(new L.Point(0, 0), new L.Point(0, 0));
 			this._cellCursor = L.LatLngBounds.createDefault();
 			this._cellCursorXY = new L.Point(-1, -1);
@@ -1435,13 +1433,6 @@ L.TileLayer = L.GridLayer.extend({
 
 		// Remove input help if there is any:
 		this._removeInputHelpMarker();
-
-		if (!empty && !this._gotFirstCellCursor) {
-			// Drawing is disabled from CalcTileLayer construction, enable it now.
-			this._gotFirstCellCursor = true;
-			this._update();
-			this.enableDrawing();
-		}
 	},
 
 	_removeInputHelpMarker: function() {


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: co-6-4

### Summary

Fixes view area jump (looks like a flicker) during document load in Calc.
Note that without the fix, the view jump is apparent only if last edited cell in the sheet is not in a view containing A1. 
So try something like A250.
The root cause of the jump is that the initial view area always the default (ie. starting cell A1) unless the client gets a cell cursor message and it adjusts the view such that it contains it. In this patch set we request for cell cursor early on during CalcTileLayer initialization. We avoid any canvas painting (except for clearing of the canvas during resizes) till we get the first cell cursor.

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

