### PR TITLE
private/pedro/jssidebar css fixes

### DIFF
--- a/loleaflet/css/btns.css
+++ b/loleaflet/css/btns.css
@@ -5,7 +5,7 @@
 }
 
 .loleaflet-annotation-edit #annotation-cancel,
-.ui-pushbutton.jsdialog:not(#ok),
+.ui-pushbutton.jsdialog:not(#ok):not(.sidebar),
 .ui-button-box.jsdialog #cancel,
 .ui-button-box.autofilter #cancel,
 .cell.jsdialog > button:not(#ok),

--- a/loleaflet/css/jssidebar.css
+++ b/loleaflet/css/jssidebar.css
@@ -46,7 +46,7 @@
 }
 
 .sidebar.ui-drawing-area {
-	max-width: 330px;
+	max-width: 280px;
 }
 
 .sidebar.ui-expander-label {

--- a/loleaflet/css/jssidebar.css
+++ b/loleaflet/css/jssidebar.css
@@ -97,9 +97,13 @@ td.jsdialog .jsdialog.cell.sidebar {
 	border: 1px solid transparent;
 	margin-right: 5px;
 }
+#table-textorientbox.sidebar .jsdialog .radiobutton {
+	border: 1px solid transparent;
+}
 .sidebar.unotoolbutton:hover,
 .sidebar #resetattr:hover,
-.sidebar #FormatPaintbrush:hover {
+.sidebar #FormatPaintbrush:hover,
+#table-textorientbox.sidebar .jsdialog .radiobutton:hover {
 	border-color: #cccccc;
 	background-color: #eeeeee;
 	border-radius: 4px;
@@ -123,4 +127,10 @@ td.jsdialog .jsdialog.cell.sidebar {
 
 .ui-expander.jsdialog.sidebar .ui-expander-icon-right:hover img {
 	filter: none;
+}
+
+#table-textorientbox.sidebar .jsdialog input[type='radio'] {
+	background: none !important;
+	width: auto;
+	height: auto;
 }

--- a/loleaflet/css/mobilewizard.css
+++ b/loleaflet/css/mobilewizard.css
@@ -361,6 +361,7 @@ p.mobile-wizard.ui-combobox-text.selected {
 .unotoolbutton.disabled img, .mobile-wizard-widebutton.disabled img {
 	-webkit-filter: grayscale(90%) brightness(120%);
 	filter: grayscale(90%) brightness(120%);
+	opacity: 0.75;
 }
 
 .mobile-wizard.unotoolbutton .arrowbackground {


### PR DESCRIPTION
- JS Sidebar: Impress: Fix drawing-area width
- JS Sidebar: Do not add extra margins to pushbuttons
- JS Sidebar: Fix textorientbox (calc)
- Make it clear when unotoolbutton is disabled
