### PR TITLE
Mobile: jsdialogs: Text import: Fix separator btn position

### DIFF
--- a/loleaflet/css/device-mobile.css
+++ b/loleaflet/css/device-mobile.css
@@ -781,3 +781,12 @@ td[id^='tb_spreadsheet-toolbar_item']:focus table.w2ui-button div.w2ui-icon, td[
 	width: 90%;
 	position: absolute;
 }
+/*   - Import text */
+#mobile-wizard-content #separatoroptions {
+	margin-top: 54px;
+}
+
+#mobile-wizard-content #toseparatedby.checkbutton {
+	margin-top: -74px;
+	margin-bottom: 24px;
+}


### PR DESCRIPTION
Depends on: https://gerrit.libreoffice.org/c/core/+/116265

Fixes checkbutton (Use separators) position by placing it
before divider label ('separatoroptions') thus, improving readability. User
can now see it clearly that all those separator options are related
and hierarchically under a main option: #toseparatedby.checkbutton.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I97b133e3e873a76ca75290728adaf1a45c9bcece
