### PR TITLE
Synchronize map with TilesSection: Fix CSS

### DIFF
--- a/loleaflet/css/leaflet.css
+++ b/loleaflet/css/leaflet.css
@@ -869,6 +869,7 @@ input.clipboard {
 	height: 20px;
 	width: 100vw;
 	margin: 0px;
+	position: fixed;
 }
 
 .loleaflet-ruler-breakcontainer {

--- a/loleaflet/css/loleaflet.css
+++ b/loleaflet/css/loleaflet.css
@@ -201,6 +201,7 @@ nav.spreadsheet-color-indicator ~ #sidebar-dock-wrapper {
 	width: 100%;
 	border-top: none;
 	z-index: 11;
+	border-bottom: 1px solid var(--gray-color);
 }
 
 #toolbar-logo {

--- a/loleaflet/css/notebookbar.css
+++ b/loleaflet/css/notebookbar.css
@@ -233,6 +233,7 @@
 	background: var(--white-bg-color);
 	position: relative;
 	z-index: 11;
+	background-color: white;
 }
 
 .cell.notebookbar {


### PR DESCRIPTION
- Fixes map z-index so annotation can be have higher z-index
- Now map and due to the latest changes introduced in:
8ca57fad3344f6da1b42158944bf9903f0ac528b we cannot use
container's border-top as our bezel divider
  - Elements such as annotation need to go under
  - So Fix toolbar-wrapper to use bottom border
- Notebookbar: Fix toolbar-wrapper background-Color which
was being set as transparent and thus elements passing under
were being visible
- Ruler: fix cropped ruler (was not going full width)

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I8778619da43c51d1994dbb12d1112d4f1d42ff43
