### PR TITLE
loleaflet: restore log2 function

### DIFF
--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -327,7 +327,7 @@ app.definitions.Socket = L.Class.extend({
 					{
 						// unpleasant - but stops this one problem
 						// event stopping an unknown number of others.
-						console.logException('Exception ' + e + ' emitting event ' + evt.data);
+						console.log2('Exception ' + e + ' emitting event ' + evt.data);
 					}
 					finally {
 						if (completeEventOneMessage)


### PR DESCRIPTION
console.logException is used only for debugging
purposes

Change-Id: I7d761d0cd7b55c820b7b7dea4079dae0f6d09043
Signed-off-by: Henry Castro <hcastro@collabora.com>
