### PR TITLE
Notebookbar: Fix bigtoolitem size and keep ratio

### DIFF
--- a/loleaflet/css/notebookbar.css
+++ b/loleaflet/css/notebookbar.css
@@ -376,7 +376,8 @@
 }
 
 .unotoolbutton.notebookbar.has-label:not(.inline) img {
-	width: 24px !important;
+	width: 32px !important;
+	height: 32px !important;
 	margin: auto !important;
 }
 


### PR DESCRIPTION
Some bigtoolitem icons (namely About) were being skewed and others
were being set at a smaller size to what they were supposed to have.
Fix it by adding height value

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I5ec375358e9dcf46a6b8b17570bea78963e188c8
