### PR TITLE
Host: header don't append port for standard ports.

### DIFF
--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -1153,7 +1153,15 @@ private:
         _response.reset(new Response(onFinished));
 
         _request = std::move(req);
-        _request.set("Host", host() + ':' + port()); // Make sure the host is set.
+
+        std::string host = _host;
+
+        if (_port != "80" && _port != "443")
+        {
+            host.append(":");
+            host.append(_port);
+        }
+        _request.set("Host", host); // Make sure the host is set.
         _request.set("Date", Util::getHttpTimeNow());
         _request.set("User-Agent", HTTP_AGENT_STRING);
     }


### PR DESCRIPTION
HA Proxy doesn't tolerate this very happily cf.

https: //serverfault.com/questions/502443/ignore-port-numbers-in-haproxy-host-header-matches/502630
Change-Id: Id285f8acd0e168a734cabd9eccc4a01fe323ab84
Signed-off-by: Michael Meeks <michael.meeks@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

