### PR TITLE
fix calc's incorrect sheet switch

### DIFF
--- a/loleaflet/src/control/Parts.js
+++ b/loleaflet/src/control/Parts.js
@@ -42,13 +42,6 @@ L.Map.include({
 			return;
 		}
 
-		this.fire('updateparts', {
-			selectedPart: docLayer._selectedPart,
-			selectedParts: docLayer._selectedParts,
-			parts: docLayer._parts,
-			docType: docLayer._docType
-		});
-
 		this.fire('scrolltopart');
 
 		docLayer._selectedParts.push(docLayer._selectedPart);
@@ -62,6 +55,13 @@ L.Map.include({
 		if (!external) {
 			app.socket.sendMessage('setclientpart part=' + docLayer._selectedPart);
 		}
+
+		this.fire('updateparts', {
+			selectedPart: docLayer._selectedPart,
+			selectedParts: docLayer._selectedParts,
+			parts: docLayer._parts,
+			docType: docLayer._docType
+		});
 
 		docLayer.eachView(docLayer._viewCursors, docLayer._onUpdateViewCursor, docLayer);
 


### PR DESCRIPTION
'updateparts' event must be fired only after requesting new part to
core, else both tiles and sheet-geometry will be wrong after the user
triggers sheet switch.

The move of 'updateparts' firing code was done in
commit 6da00622d08060b45452f0e6cbbf6077b117503b
  Fix PDF view: Switching pages using buttons

but that move became unnecessary after the next PDF related commit
commit 9ca5d68ba21fbaf94049f85b1730390573b80184
  Make page buttons scrollby view height instead instead of switching the page directly

Signed-off-by: Dennis Francis <dennis.francis@collabora.com>
Change-Id: Ib806e31965ecada5305f4ea647f1de6236b27486


* Resolves: # <!-- related github issue -->
* Target version: master 

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

