### PR TITLE
freemium: fixed the TypeError for IE11

### DIFF
--- a/loleaflet/src/control/Control.Freemium.js
+++ b/loleaflet/src/control/Control.Freemium.js
@@ -98,8 +98,8 @@ L.Map.include({
 		else if (item.uno) { // in classic mode uno commands are stored as uno in menus
 			if (typeof item.uno === 'string')
 				command = item.uno;
-			else if (this.Freemium.freemiumDenyList.includes(item.uno.textCommand)
-			|| this.Freemium.freemiumDenyList.includes(item.uno.objectCommand)) // some unos have multiple commands
+			else if (this.Freemium.freemiumDenyList.indexOf(item.uno.textCommand) >= 0
+			|| this.Freemium.freemiumDenyList.indexOf(item.uno.objectCommand) >= 0) // some unos have multiple commands
 				return true;
 		}
 		else if (item.id)
@@ -107,7 +107,7 @@ L.Map.include({
 		else if (item.unosheet)
 			command = item.unosheet;
 
-		if (this.Freemium.freemiumDenyList.includes(command))
+		if (this.Freemium.freemiumDenyList.indexOf(command) >= 0)
 			return true;
 
 		return false;


### PR DESCRIPTION


Signed-off-by: Pranam Lashkari <lpranam@collabora.com>
Change-Id: I4b90c3f540daaa03f4ace5a6f42b5776884c3abe


* Target version: master 

### Summary
IE11: does not support 'includes'



### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

