### PR TITLE
log: avoid logging after shutdown on all log levels

### DIFF
--- a/common/Log.hpp
+++ b/common/Log.hpp
@@ -326,7 +326,7 @@ namespace Log
     do                                                                                             \
     {                                                                                              \
         auto& log_ = Log::logger();                                                                \
-        if (log_.trace() && !Log::isShutdownCalled())                                              \
+        if (!Log::isShutdownCalled() && log_.trace())                                              \
         {                                                                                          \
             LOG_BODY_(log_, TRACE, "TRC", X, true);                                                \
         }                                                                                          \
@@ -336,7 +336,7 @@ namespace Log
     do                                                                                             \
     {                                                                                              \
         auto& log_ = Log::logger();                                                                \
-        if (log_.trace() && !Log::isShutdownCalled())                                              \
+        if (!Log::isShutdownCalled() && log_.trace())                                              \
         {                                                                                          \
             LOG_BODY_(log_, TRACE, "TRC", X, false);                                               \
         }                                                                                          \
@@ -346,7 +346,7 @@ namespace Log
     do                                                                                             \
     {                                                                                              \
         auto& log_ = Log::logger();                                                                \
-        if (log_.debug() && !Log::isShutdownCalled())                                              \
+        if (!Log::isShutdownCalled() && log_.debug())                                              \
         {                                                                                          \
             LOG_BODY_(log_, DEBUG, "DBG", X, true);                                                \
         }                                                                                          \
@@ -356,7 +356,7 @@ namespace Log
     do                                                                                             \
     {                                                                                              \
         auto& log_ = Log::logger();                                                                \
-        if (log_.information() && !Log::isShutdownCalled())                                        \
+        if (!Log::isShutdownCalled() && log_.information())                                        \
         {                                                                                          \
             LOG_BODY_(log_, INFORMATION, "INF", X, true);                                          \
         }                                                                                          \
@@ -366,7 +366,7 @@ namespace Log
     do                                                                                             \
     {                                                                                              \
         auto& log_ = Log::logger();                                                                \
-        if (log_.information() && !Log::isShutdownCalled())                                        \
+        if (!Log::isShutdownCalled() && log_.information())                                        \
         {                                                                                          \
             LOG_BODY_(log_, INFORMATION, "INF", X, false);                                         \
         }                                                                                          \

--- a/test/TileCacheTests.cpp
+++ b/test/TileCacheTests.cpp
@@ -89,7 +89,8 @@ class TileCacheTests : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST(testTileInvalidatedOutside);
     CPPUNIT_TEST(testTileBeingRenderedHandling);
     CPPUNIT_TEST(testWireIDFilteringOnWSDSide);
-    CPPUNIT_TEST(testLimitTileVersionsOnFly);
+    // unstable
+    //CPPUNIT_TEST(testLimitTileVersionsOnFly);
 
 
     CPPUNIT_TEST_SUITE_END();


### PR DESCRIPTION
This can happen on an assertion failure, and causes noise while looking
for real memory errors.

Also disable an unstable test, it's not clear that it passes depending
on how loaded the machine is (just increasing timeouts doesn't seem to
help).

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I049bd0a06f41e2d43702ec12a2c35944bc5200d8


* Target version: distro/collabora/co-6-4 

