### PR TITLE
New callback for calc document background color (co64)

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -2855,6 +2855,8 @@ void ChildSession::loKitCallback(const int type, const std::string& payload)
     case LOK_CALLBACK_INVALIDATE_SHEET_GEOMETRY:
         sendTextFrame("invalidatesheetgeometry: " + payload);
         break;
+    case LOK_CALLBACK_DOCUMENT_BACKGROUND_COLOR:
+        sendTextFrame("documentbackgroundcolor: " + payload);
 
 #if !ENABLE_DEBUG
     // we want a compilation-time failure in the debug builds; but ERR in the

--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -49,7 +49,7 @@ L.TileSectionManager = L.Class.extend({
 		this._sectionContainer = new CanvasSectionContainer(this._canvas, this._layer.isCalc() /* disableDrawing? */);
 
 		if (this._layer.isCalc())
-			this._sectionContainer.setClearColor('white');
+			this._sectionContainer.setClearColor('white'); // will be overridden by 'documentbackgroundcolor' msg.
 
 		app.sectionContainer = this._sectionContainer;
 		if (L.Browser.cypressTest) // If cypress is active, create test divs.

--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -214,11 +214,19 @@ L.TileSectionManager = L.Class.extend({
 		canvasOverlay.setOverlaySection(this._sectionContainer.getSectionWithName(L.CSections.Overlays.name));
 	},
 
+	shouldDrawCalcGrid: function () {
+		var defaultBG = 'ffffff';
+		return (this._layer.coreDocBGColor === defaultBG);
+	},
+
 	_onDrawGridSection: function () {
 		if (this.containerObject.isInZoomAnimation() || this.sectionProperties.tsManager.waitForTiles())
 			return;
-		// grid-section's onDrawArea is TileSectionManager's _drawGridSectionArea().
-		this.onDrawArea();
+
+		if (this.sectionProperties.tsManager.shouldDrawCalcGrid()) {
+			// grid-section's onDrawArea is TileSectionManager's _drawGridSectionArea().
+			this.onDrawArea();
+		}
 	},
 
 	_drawGridSectionArea: function (repaintArea, paneTopLeft, canvasCtx) {

--- a/loleaflet/src/layer/tile/TileLayer.js
+++ b/loleaflet/src/layer/tile/TileLayer.js
@@ -931,6 +931,12 @@ L.TileLayer = L.GridLayer.extend({
 			obj = JSON.parse(textMsg.substring('redlinetablechanged:'.length + 1));
 			app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).onACKComment(obj);
 		}
+		else if (textMsg.startsWith('documentbackgroundcolor:')) {
+			if (this.isCalc()) {
+				var bgColor = textMsg.substring('documentbackgroundcolor:'.length + 1).trim();
+				app.sectionContainer.setClearColor('#' + bgColor);
+			}
+		}
 	},
 
 	_onTabStopListUpdate: function (textMsg) {

--- a/loleaflet/src/layer/tile/TileLayer.js
+++ b/loleaflet/src/layer/tile/TileLayer.js
@@ -933,8 +933,8 @@ L.TileLayer = L.GridLayer.extend({
 		}
 		else if (textMsg.startsWith('documentbackgroundcolor:')) {
 			if (this.isCalc()) {
-				var bgColor = textMsg.substring('documentbackgroundcolor:'.length + 1).trim();
-				app.sectionContainer.setClearColor('#' + bgColor);
+				this.coreDocBGColor = textMsg.substring('documentbackgroundcolor:'.length + 1).trim();
+				app.sectionContainer.setClearColor('#' + this.coreDocBGColor);
 			}
 		}
 	},


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: co64

### Summary
Introduce new callback for calc document background color.

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

