### PR TITLE
private/pedro/sidebar css clean up plus spinfields

### DIFF
--- a/loleaflet/css/jssidebar.css
+++ b/loleaflet/css/jssidebar.css
@@ -148,7 +148,7 @@ td.jsdialog .jsdialog.cell.sidebar {
 	height: auto;
 }
 
-.jsdialog.ui-separator.horizontal {
+.sidebar.jsdialog.ui-separator.horizontal {
 	padding-top: 0;
 }
 

--- a/loleaflet/css/jssidebar.css
+++ b/loleaflet/css/jssidebar.css
@@ -18,12 +18,22 @@
 }
 
 .sidebar.spinfield {
-	max-width: 100px;
+	max-width: 104px;
 	border: 1px solid #CCC;
-	padding: 0.2em 0 0.2em 0.2em;
+	padding: 4px 0 4px 4px;
 	border-radius: 3px;
 	height: 28px;
 	box-sizing: border-box;
+	margin-right: 1px;
+}
+.sidebar.spinfield:hover {
+	border: 1px solid var(--gray-color);
+}
+
+.spinfieldunit {
+	font-size: 12px;
+	color: var(--gray-light-txt--color);
+	margin: 5px;
 }
 
 .sidebar.ui-listbox {

--- a/loleaflet/css/jssidebar.css
+++ b/loleaflet/css/jssidebar.css
@@ -1,7 +1,3 @@
-.sidebar.cell {
-	display: inline-flex;
-}
-
 .sidebar * {
 	font-family: var(--jquery-ui-font);
 	text-transform: none !important;

--- a/loleaflet/css/jssidebar.css
+++ b/loleaflet/css/jssidebar.css
@@ -8,7 +8,7 @@
 }
 
 .sidebar .ui-content .unobutton {
-	margin: 0px;
+	margin: 0;
 	width: 24px;
 	height: 24px;
 	vertical-align: middle;
@@ -18,7 +18,7 @@
 	width: 322px;
 	padding: 0;
 	border-left: 1px solid var(--gray-color) !important;
-	margin-top: 0px !important;
+	margin-top: 0 !important;
 }
 
 .sidebar.spinfield {
@@ -153,7 +153,7 @@ td.jsdialog .jsdialog.cell.sidebar {
 }
 
 #spacinglabel {
-	padding-top: 0px;
+	padding-top: 0;
 }
 
 


### PR DESCRIPTION
- JS Sidebar: Add missing .sidebar
- JS Sidebar: clean up unit identifiers
- JS Sidebar: Pointless to use inline-flex when everything is a table
- JS Sidebar: Spinfield: Easier to interact
