### PR TITLE
leaflet: show table markers when table has no entry

### DIFF
--- a/loleaflet/src/layer/tile/TileLayer.TableOverlay.js
+++ b/loleaflet/src/layer/tile/TileLayer.TableOverlay.js
@@ -148,7 +148,7 @@ L.CanvasTileLayer.include({
 		this._clearTableMarkers();
 
 		// Create markers
-		if (this._currentTableData.rows && this._currentTableData.rows.entries.length > 0 && this._currentTableData.columns && this._currentTableData.columns.entries.length > 0) {
+		if (this._currentTableData.rows && this._currentTableData.columns) {
 			this._tablePositionColumnOffset = parseInt(this._currentTableData.columns.tableOffset);
 			this._tablePositionRowOffset = parseInt(this._currentTableData.rows.tableOffset);
 			var firstRowPosition = parseInt(this._currentTableData.rows.left) + this._tablePositionRowOffset;


### PR DESCRIPTION


Signed-off-by: Pranam Lashkari <lpranam@collabora.com>
Change-Id: Idcf62a2f787d098b1fcc78b57b4d07f9de685b31


* Target version: master 

### Summary
Problem:
First row/column are treated specially as headings,
that's why heading are not sent through the entry.

Due to that if table has only single column or row,
entry will be empty and marker will never appear


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

