### PR TITLE
Remove isInternetExplorer code paths

### DIFF
--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -386,16 +386,10 @@ app.definitions.Socket = L.Class.extend({
 		e.imgBytes = new Uint8Array(e.data);
 
 		// search for the first newline which marks the end of the message
-		if (L.Browser.isInternetExplorer) {
-			index = 0;
-			while (index < e.imgBytes.length && e.imgBytes[index] !== 10) {
-				index++;
-			}
-		} else {
-			index = e.imgBytes.indexOf(10);
-			if (index < 0)
-				index = e.imgBytes.length;
-		}
+		index = e.imgBytes.indexOf(10);
+		if (index < 0)
+			index = e.imgBytes.length;
+		
 		e.textMsg = String.fromCharCode.apply(null, e.imgBytes.subarray(0, index));
 
 		e.imgIndex = index + 1;

--- a/loleaflet/src/layer/marker/TextInput.js
+++ b/loleaflet/src/layer/marker/TextInput.js
@@ -387,14 +387,6 @@ L.TextInput = L.Layer.extend({
 			this._textArea.style.height = '1px';
 			this._textArea.style.caretColor = 'transparent';
 			this._textArea.style.resize = 'none';
-
-			if (L.Browser.isInternetExplorer || L.Browser.edge)
-			{
-				// Setting the font-size to zero is the only reliable
-				// way to hide the caret in MSIE11, as the CSS "caret-color"
-				// property is not implemented.
-				this._textArea.style.fontSize = '0';
-			}
 		}
 	},
 

--- a/loleaflet/src/main.js
+++ b/loleaflet/src/main.js
@@ -4,6 +4,8 @@
 /*eslint indent: [error, "tab", { "outerIIFEBody": 0 }]*/
 (function (global) {
 
+
+
 var wopiParams;
 var wopiSrc = getParameterByName('WOPISrc');
 
@@ -89,5 +91,15 @@ window.addEventListener('beforeunload', function () {
 
 window.docPermission = permission;
 window.bundlejsLoaded = true;
+
+
+var isInternetExplorer = (navigator.userAgent.toLowerCase().indexOf('msie') != -1 ||
+			navigator.userAgent.toLowerCase().indexOf('trident') != -1);
+		
+if (isInternetExplorer) {
+	if (window.confirm('Warning! The browser you are using is not supported. Click confirm to see more')) {
+		window.location.href='https://github.com/CollaboraOnline/online/issues/2685'; // TODO: add link for support
+	}
+}
 
 }(window));

--- a/loleaflet/src/main.js
+++ b/loleaflet/src/main.js
@@ -1,6 +1,6 @@
 /* -*- js-indent-level: 8 -*- */
 /* global errorMessages getParameterByName accessToken accessTokenTTL accessHeader reuseCookies */
-/* global app L vex host serviceRoot idleTimeoutSecs outOfFocusTimeoutSecs */
+/* global app L vex host serviceRoot idleTimeoutSecs outOfFocusTimeoutSecs _ */
 /*eslint indent: [error, "tab", { "outerIIFEBody": 0 }]*/
 (function (global) {
 
@@ -95,7 +95,7 @@ window.bundlejsLoaded = true;
 ////// Unsuported Browser Warning /////
 		
 if (L.Browser.isInternetExplorer) {
-	vex.dialog.alert('Warning! The browser you are using is not supported.');
+	vex.dialog.alert(_('Warning! The browser you are using is not supported.'));
 }
 
 }(window));

--- a/loleaflet/src/main.js
+++ b/loleaflet/src/main.js
@@ -93,6 +93,8 @@ window.docPermission = permission;
 window.bundlejsLoaded = true;
 
 
+////// Unsuported Browser Warning /////
+
 var isInternetExplorer = (navigator.userAgent.toLowerCase().indexOf('msie') != -1 ||
 			navigator.userAgent.toLowerCase().indexOf('trident') != -1);
 		

--- a/loleaflet/src/main.js
+++ b/loleaflet/src/main.js
@@ -95,7 +95,7 @@ window.bundlejsLoaded = true;
 ////// Unsuported Browser Warning /////
 		
 if (L.Browser.isInternetExplorer) {
-	vex.dialog.alert('Warning! The browser you are using is not supported');
+	vex.dialog.alert('Warning! The browser you are using is not supported.');
 }
 
 }(window));

--- a/loleaflet/src/main.js
+++ b/loleaflet/src/main.js
@@ -1,9 +1,8 @@
 /* -*- js-indent-level: 8 -*- */
 /* global errorMessages getParameterByName accessToken accessTokenTTL accessHeader reuseCookies */
-/* global app vex host serviceRoot idleTimeoutSecs outOfFocusTimeoutSecs*/
+/* global app L vex host serviceRoot idleTimeoutSecs outOfFocusTimeoutSecs */
 /*eslint indent: [error, "tab", { "outerIIFEBody": 0 }]*/
 (function (global) {
-
 
 
 var wopiParams;
@@ -94,14 +93,9 @@ window.bundlejsLoaded = true;
 
 
 ////// Unsuported Browser Warning /////
-
-var isInternetExplorer = (navigator.userAgent.toLowerCase().indexOf('msie') != -1 ||
-			navigator.userAgent.toLowerCase().indexOf('trident') != -1);
 		
-if (isInternetExplorer) {
-	if (window.confirm('Warning! The browser you are using is not supported. Click confirm to see more')) {
-		window.location.href='https://github.com/CollaboraOnline/online/issues/2685'; // TODO: add link for support
-	}
+if (L.Browser.isInternetExplorer) {
+	vex.dialog.alert('Warning! The browser you are using is not supported');
 }
 
 }(window));

--- a/loleaflet/src/map/Clipboard.js
+++ b/loleaflet/src/map/Clipboard.js
@@ -532,10 +532,10 @@ L.Clipboard = L.Class.extend({
 		if (this._isAnyInputFieldSelected())
 			return;
 
-		this._beforeSelectImpl(ev.type);
+		this._beforeSelectImpl();
 	},
 
-	_beforeSelectImpl: function(operation) {
+	_beforeSelectImpl: function() {
 		// We need some spaces in there ...
 		this._resetDiv();
 
@@ -731,8 +731,6 @@ L.Clipboard = L.Class.extend({
 
 		if (this._map._activeDialog)
 			ev.usePasteKeyEvent = true;
-
-		var that = this;
 
 		if (ev.clipboardData) {
 			ev.preventDefault();


### PR DESCRIPTION
* Resolves:  [#2685](https://github.com/CollaboraOnline/online/issues/2685)
* Target version: master 

### Summary
 Removes any code referencing isInternetExplorer, excluding a popup in `/loleaflet/src/main.js
`
In `Clipboard.js` also inlines `compatRemoveNode` as it only exists for to handle IE.

### TODO

- [ ] Confirm if the code for the alert is in the correct place (currently in `main.js`) I don't know if this is the responsibility of `main.js` or if should be another file
- [ ] The alert could also be a confirm dialog that redirects to a page with more information about supported browsers/IE

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

