### PR TITLE
Remove ie11 polyfills conditionals

### DIFF
--- a/loleaflet/admin/src/AdminSocketBase.js
+++ b/loleaflet/admin/src/AdminSocketBase.js
@@ -5,13 +5,6 @@
 
 /* global _ Util vex Base */
 
-// polyfill startsWith for IE11
-if (typeof String.prototype.startsWith !== 'function') {
-	String.prototype.startsWith = function (str) {
-		return this.slice(0, str.length) === str;
-	};
-}
-
 var AdminSocketBase = Base.extend({
 	socket: null,
 

--- a/loleaflet/js/ResizeObserverPolyfill.js
+++ b/loleaflet/js/ResizeObserverPolyfill.js
@@ -4,9 +4,7 @@
 	https://github.com/que-etc/resize-observer-polyfill/blob/master/dist/ResizeObserver.js
 */
 
-var isIE11_ = !!window.MSInputMethodContext && !!document.documentMode;
-
-if (isIE11_ || typeof ResizeObserver === 'undefined') {
+if (typeof ResizeObserver === 'undefined') {
     (function (global, factory) {
         typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
         typeof define === 'function' && define.amd ? define(factory) :

--- a/loleaflet/js/global.js
+++ b/loleaflet/js/global.js
@@ -358,55 +358,10 @@ window.app = { // Shouldn't have any functions defined.
 		};
 		this.onmessage = function() {
 		};
-		// IE11 compatibility ...
-		if (!!window.MSInputMethodContext && !!document.documentMode) {
-			this.decoder = {};
-			this.decoder.decode = function(bytes) {
-				var decoded = '';
-				var code = 0;
-				for (var i = 0; i < bytes.length;) {
-					var b = bytes[i];
-					var seqLen = 1;
-					// get bits off the top.
-					if (b <= 0x7f)
-						code = b & 0xff;
-					else if (b <= 0xdf) {
-						code = b & 0x1f;
-						seqLen = 2;
-					} else if (b <= 0xef) {
-						code = b & 0x0f;
-						seqLen = 3;
-					} else if (b <= 0xf7) {
-						code = b & 0x07;
-						seqLen = 4;
-					}
-					var left = bytes.length - i;
-					if (left >= seqLen) {
-						for (var j = 1; j < seqLen; ++j)
-							code = (code << 6) | (bytes[i + j] & 0x3f);
-					} else { // skip to end
-						seqLen = left;
-						code = 0xfffd;
-					}
-					if (code <= 0xFFFF)
-						decoded += String.fromCharCode(code);
-					else
-						decoded += String.fromCharCode(((code - 0x10000) >> 10) + 0xD800,
-									       ((code - 0x10000) % 0x400) + 0xDC00);
-					i += seqLen;
-				}
-				return decoded;
-			};
-			this.doSlice = function(bytes,start,end) {
-				var data = new Uint8Array(end - start + 1);
-				for (var i = 0; i <= (end - start); ++i)
-					data[i] = bytes[start + i];
-				return data;
-			};
-		} else {
-			this.decoder = new TextDecoder();
-			this.doSlice = function(bytes,start,end) { return bytes.slice(start,end); };
-		}
+		
+		this.decoder = new TextDecoder();
+		this.doSlice = function(bytes,start,end) { return bytes.slice(start,end); };
+		
 		this.decode = function(bytes,start,end) {
 			return this.decoder.decode(this.doSlice(bytes, start,end));
 		};

--- a/loleaflet/src/control/Control.LokDialog.js
+++ b/loleaflet/src/control/Control.LokDialog.js
@@ -1459,21 +1459,11 @@ L.Control.LokDialog = L.Control.extend({
 		var containerLeft = dialogContainer.getBoundingClientRect().left + dialogContainer.ownerDocument.defaultView.pageXOffset;
 		var grandParentID = dialogContainer.parentNode.id;
 
-		var isIE11 = !!window.MSInputMethodContext && !!document.documentMode; // https://stackoverflow.com/questions/21825157/internet-explorer-11-detection
-
 		if (grandParentID.indexOf('calc-inputbar') >= 0) {
 			// This is the calculator input bar.
 			L.DomUtil.setStyle(floatingCanvas, 'left', (containerLeft + left) + 'px');
 			L.DomUtil.setStyle(floatingCanvas, 'top', (containerTop + 20) + 'px');
-		}
-		else if (isIE11)
-		{
-			// child positions are relative to their container.
-			L.DomUtil.setStyle(floatingCanvas, 'left', (containerLeft + left) + 'px');
-			L.DomUtil.setStyle(floatingCanvas, 'top', (containerTop + top) + 'px');
-		}
-		else
-		{
+		} else {
 			// Add header height..
 			var addition = 40;
 			L.DomUtil.setStyle(floatingCanvas, 'left', left + 'px');

--- a/loleaflet/src/control/Control.Menubar.js
+++ b/loleaflet/src/control/Control.Menubar.js
@@ -1772,15 +1772,6 @@ L.Control.Menubar = L.Control.extend({
 		if (menuItem.id === 'changesmenu' && this._map['wopi'].HideChangeTrackingControls)
 			return false;
 
-		// polyfill endsWidth for IE11
-		if (!String.prototype.endsWith) {
-			String.prototype.endsWith = function(search, thisLen) {
-				if (thisLen === undefined || thisLen > this.length) {
-					thisLen = this.length;
-				}
-				return this.substring(thisLen - search.length, thisLen) === search;
-			};
-		}
 
 		// Keep track of all 'downloadas-' options and register them as
 		// export formats with docLayer which can then be publicly accessed unlike

--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -58,14 +58,7 @@ app.definitions.Socket = L.Class.extend({
 			try {
 				this.socket = window.createWebSocket(this.getWebSocketBaseURI(map) + wopiSrc);
 			} catch (e) {
-				// On IE 11 there is a limitation on the number of WebSockets open to a single domain (6 by default and can go to 128).
-				// Detect this and hint the user.
-				var msgHint = '';
-				var isIE11 = !!window.MSInputMethodContext && !!document.documentMode; // https://stackoverflow.com/questions/21825157/internet-explorer-11-detection
-				if (isIE11)
-					msgHint = _('IE11 has reached its maximum number of connections. Please see this document to increase this limit if needed: https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/general-info/ee330736(v=vs.85)#websocket-maximum-server-connections');
-
-				this._map.fire('error', {msg: _('Oops, there is a problem connecting to %productName: ').replace('%productName', (typeof brandProductName !== 'undefined' ? brandProductName : 'Collabora Online Development Edition')) + e + msgHint, cmd: 'socket', kind: 'failed', id: 3});
+				this._map.fire('error', {msg: _('Oops, there is a problem connecting to %productName: ').replace('%productName', (typeof brandProductName !== 'undefined' ? brandProductName : 'Collabora Online Development Edition')) + e, cmd: 'socket', kind: 'failed', id: 3});
 				return;
 			}
 		}

--- a/loleaflet/src/layer/marker/Cursor.ts
+++ b/loleaflet/src/layer/marker/Cursor.ts
@@ -55,10 +55,6 @@ class Cursor {
 		this.visible = true;
 		this.domAttached = true;
 
-		var isIE11 = !!window.MSInputMethodContext && !!(<any>document).documentMode;
-		if (!isIE11)
-			this.onFocusBlur(new FocusEvent('focus'));
-
 		this.update();
 		if (this.map._docLayer.isCalc())
 			this.map.on('splitposchanged move', this.update, this);

--- a/loleaflet/src/map/Clipboard.js
+++ b/loleaflet/src/map/Clipboard.js
@@ -513,18 +513,6 @@ L.Clipboard = L.Class.extend({
 		return false;
 	},
 
-	// only used by IE.
-	_beforePasteIE: function(ev) {
-		console.log('IE11 work ...');
-
-		if (this._isAnyInputFieldSelected())
-			return;
-
-		this._beforeSelect(ev);
-		this._dummyDiv.focus();
-		// Now wait for the paste ...
-	},
-
 	// Does the selection of text before an event comes in
 	_beforeSelect: function(ev) {
 		console.log('Got event ' + ev.type + ' setting up selection');


### PR DESCRIPTION
* Resolves: [#2686](https://github.com/CollaboraOnline/online/issues/2686)
* Target version: master 

### Summary

Removes legacy code supporting internet explorer, including polyfills and various other conditionals for IE.


Side note: I branched off the wrong branch so commits upto [Make IE warning translateable](https://github.com/CollaboraOnline/online/commit/81d47cfcfba9fbf31704de1279596466f73e1c41) were already merged in [#3101](https://github.com/CollaboraOnline/online/pull/3101)

### TODO

- [x] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

