### PR TITLE
New callback for calc document background color (master)

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -2932,6 +2932,8 @@ void ChildSession::loKitCallback(const int type, const std::string& payload)
     case LOK_CALLBACK_INVALIDATE_SHEET_GEOMETRY:
         sendTextFrame("invalidatesheetgeometry: " + payload);
         break;
+    case LOK_CALLBACK_DOCUMENT_BACKGROUND_COLOR:
+        sendTextFrame("documentbackgroundcolor: " + payload);
 
 #if !ENABLE_DEBUG
     // we want a compilation-time failure in the debug builds; but ERR in the

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -2934,6 +2934,7 @@ void ChildSession::loKitCallback(const int type, const std::string& payload)
         break;
     case LOK_CALLBACK_DOCUMENT_BACKGROUND_COLOR:
         sendTextFrame("documentbackgroundcolor: " + payload);
+        break;
 
 #if !ENABLE_DEBUG
     // we want a compilation-time failure in the debug builds; but ERR in the

--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -364,11 +364,19 @@ L.TileSectionManager = L.Class.extend({
 		canvasOverlay.setOverlaySection(this._sectionContainer.getSectionWithName(L.CSections.Overlays.name));
 	},
 
+	shouldDrawCalcGrid: function () {
+		var defaultBG = 'ffffff';
+		return (this._layer.coreDocBGColor === defaultBG);
+	},
+
 	_onDrawGridSection: function () {
 		if (this.containerObject.isInZoomAnimation() || this.sectionProperties.tsManager.waitForTiles())
 			return;
-		// grid-section's onDrawArea is TileSectionManager's _drawGridSectionArea().
-		this.onDrawArea();
+
+		if (this.sectionProperties.tsManager.shouldDrawCalcGrid()) {
+			// grid-section's onDrawArea is TileSectionManager's _drawGridSectionArea().
+			this.onDrawArea();
+		}
 	},
 
 	_drawGridSectionArea: function (repaintArea, paneTopLeft, canvasCtx) {
@@ -1669,8 +1677,8 @@ L.CanvasTileLayer = L.Layer.extend({
 		}
 		else if (textMsg.startsWith('documentbackgroundcolor:')) {
 			if (this.isCalc()) {
-				var bgColor = textMsg.substring('documentbackgroundcolor:'.length + 1).trim();
-				app.sectionContainer.setClearColor('#' + bgColor);
+				this.coreDocBGColor = textMsg.substring('documentbackgroundcolor:'.length + 1).trim();
+				app.sectionContainer.setClearColor('#' + this.coreDocBGColor);
 			}
 		}
 	},

--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -213,7 +213,7 @@ L.TileSectionManager = L.Class.extend({
 		this._sectionContainer = new CanvasSectionContainer(this._canvas, this._layer.isCalc() /* disableDrawing? */);
 
 		if (this._layer.isCalc())
-			this._sectionContainer.setClearColor('white');
+			this._sectionContainer.setClearColor('white'); // will be overridden by 'documentbackgroundcolor' msg.
 
 		app.sectionContainer = this._sectionContainer;
 		if (L.Browser.cypressTest) // If cypress is active, create test divs.
@@ -1666,6 +1666,12 @@ L.CanvasTileLayer = L.Layer.extend({
 		else if (textMsg.startsWith('redlinetablechanged:')) {
 			obj = JSON.parse(textMsg.substring('redlinetablechanged:'.length + 1));
 			app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).onACKComment(obj);
+		}
+		else if (textMsg.startsWith('documentbackgroundcolor:')) {
+			if (this.isCalc()) {
+				var bgColor = textMsg.substring('documentbackgroundcolor:'.length + 1).trim();
+				app.sectionContainer.setClearColor('#' + bgColor);
+			}
 		}
 	},
 


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
Introduce new callback for calc document background color. (Forward port from co-6-4)

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

