### PR TITLE
loleaflet: fix: Calc: Dragging scrollbar and releasing button over formula bar keeps drag mode active

### DIFF
--- a/loleaflet/src/control/Control.LokDialog.js
+++ b/loleaflet/src/control/Control.LokDialog.js
@@ -990,7 +990,7 @@ L.Control.LokDialog = L.Control.extend({
 		}, this);
 
 		L.DomEvent.on(canvas, 'mousedown mouseup', function(e) {
-			L.DomEvent.stop(e);
+			L.DomEvent.preventDefault(e);
 
 			if (this._map.uiManager.isUIBlocked())
 				return;


### PR DESCRIPTION
Signed-off-by: Rash419 <rashesh.padia@collabora.com>
Change-Id: Ibea42d1fa9c3c7fe8abc6b5efdb5dc93cab1a491

* Target version: master 
