### PR TITLE
Copy documentation into source code as comments of remaining Options

### DIFF
--- a/docker/from-packages/scripts/install-collabora-online-ubuntu.sh
+++ b/docker/from-packages/scripts/install-collabora-online-ubuntu.sh
@@ -32,23 +32,24 @@ fi
 # Add Collabora repos
 if [ "$type" == "cool" ] && [ -n ${secret_key+set} ]; then
     echo "Based on the provided build arguments Collabora Online from customer repo will be used."
-    echo "deb https://collaboraoffice.com/${repo:-repos}/CollaboraOnline/${version:-6.4}/customer-ubuntu1804-${secret_key} /" >> /etc/apt/sources.list.d/collabora.list
+    echo "deb [signed-by=/usr/share/keyrings/collaboraonline-release-keyring.gpg] https://collaboraoffice.com/${repo:-repos}/CollaboraOnline/${version:-6.4}/customer-ubuntu1804-${secret_key} /" >> /etc/apt/sources.list.d/collabora.list
 elif [ "$type" == "key" ]; then
     echo "Based on the provided build arguments license key enabled Collabora Online will be used."
-    echo "deb https://collaboraoffice.com/${repo:-repos}/CollaboraOnline/${version:-6.4}-key /" >> /etc/apt/sources.list.d/collabora.list
+    echo "deb [signed-by=/usr/share/keyrings/collaboraonline-release-keyring.gpg] https://collaboraoffice.com/${repo:-repos}/CollaboraOnline/${version:-6.4}-key /" >> /etc/apt/sources.list.d/collabora.list
 else
     echo "Based on the provided build arguments Collabora Online Development Edition will be used."
     if [ $(uname -i) == "aarch64" ]; then
-        echo "deb https://collaboraoffice.com/${repo:-repos}/CollaboraOnline/CODE-arm64-ubuntu1804 /" >> /etc/apt/sources.list.d/collabora.list
+        echo "deb [signed-by=/usr/share/keyrings/collaboraonline-release-keyring.gpg] https://collaboraoffice.com/${repo:-repos}/CollaboraOnline/CODE-arm64-ubuntu1804 /" >> /etc/apt/sources.list.d/collabora.list
     else
-        echo "deb https://collaboraoffice.com/${repo:-repos}/CollaboraOnline/CODE-ubuntu1804 /" > /etc/apt/sources.list.d/collabora.list
+        echo "deb [signed-by=/usr/share/keyrings/collaboraonline-release-keyring.gpg] https://collaboraoffice.com/${repo:-repos}/CollaboraOnline/CODE-ubuntu1804 /" > /etc/apt/sources.list.d/collabora.list
     fi
 fi
 
 if [ "$repo" == "repos-snapshot" ]; then
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys E79CEF780135B53B
+    curl https://www.collaboraoffice.com/downloads/gpg/collaboraonline-snapshot-keyring.gpg --output /usr/share/keyrings/collaboraonline-snapshot-keyring.gpg
+    sed -i "s/collaboraonline-release-keyring/collaboraonline-snapshot-keyring/" /etc/apt/sources.list.d/collabora.list
 else
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0C54D189F4BA284D
+    curl https://www.collaboraoffice.com/downloads/gpg/collaboraonline-release-keyring.gpg --output /usr/share/keyrings/collaboraonline-release-keyring.gpg
 fi
 apt-get update
 

--- a/loleaflet/js/global.js
+++ b/loleaflet/js/global.js
@@ -104,6 +104,8 @@ window.app = { // Shouldn't have any functions defined.
 	var ua = navigator.userAgent.toLowerCase(),
 	    uv = navigator.vendor.toLowerCase(),
 	    doc = document.documentElement,
+		// doc
+		// Document URL, the server should be able to access the document.
 
 	    ie = 'ActiveXObject' in window,
 
@@ -821,6 +823,8 @@ window.app = { // Shouldn't have any functions defined.
 			if (global.socket.readyState === 1) {
 				var ProtocolVersionNumber = '0.1';
 				var timestamp = global.getParameterByName('timestamp');
+				// timestamp
+				// A timestamp of the last modification to the document.
 				var msg = 'load url=' + encodeURIComponent(global.docURL);
 
 				var now0 = Date.now();

--- a/loleaflet/loleaflet-api.html
+++ b/loleaflet/loleaflet-api.html
@@ -133,14 +133,6 @@ unexpected behaviour.</h5>
 		<td>An outer div, containing the map div, that is used internally for the creation of the toolbar.</td>
 	</tr>
 	<tr>
-		<td><code><b>toolbarContainer</b></code></td>
-		<td><code>String / DOM element</code></td>
-		<td><code><span class="literal">undefined</span></code></td>
-		<td>A div used by the default toolbar elements (bold, italic, search, etc.) in loleaflet. If you implement
-           your own toolbar and use controls that do not require a toolbar (like the dialog or scroll control) you
-          can ignore this.</td>
-	</tr>
-	<tr>
 		<td><code><b>renderingOptions</b></code></td>
 		<td><code>Object</code></td>
 		<td><code><span class="literal">undefined</span></code></td>

--- a/loleaflet/src/control/Control.Toolbar.js
+++ b/loleaflet/src/control/Control.Toolbar.js
@@ -95,6 +95,8 @@ function onClick(e, id, item) {
 		}
 	}
 	else if (id === 'print') {
+		// print
+		// Whether the print handler is active (for Chrome).
 		map.print();
 	}
 	else if (id === 'save') {

--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -211,6 +211,9 @@ app.definitions.Socket = L.Class.extend({
 			msg += ' deviceFormFactor=' + window.deviceFormFactor;
 		}
 		if (this._map.options.renderingOptions) {
+			// renderingOptions
+			// Enables the continuous, web view, of the document, 
+			// see the UNO commands below for this parameter.
 			var options = {
 				'rendering': this._map.options.renderingOptions
 			};
@@ -527,6 +530,9 @@ app.definitions.Socket = L.Class.extend({
 
 			if (!window.ThisIsAMobileApp) {
 				var idUri = this._map.options.server + this._map.options.serviceRoot + '/hosting/discovery';
+				// server
+				// The websocket server hosting loolwsd using the ws: protocol. Example: wss://localhost:9980
+
 				idUri = idUri.replace(/^ws:/, 'http:');
 				idUri = idUri.replace(/^wss:/, 'https:');
 				$('#loolwsd-id').html(_('Served by:') + ' <a target="_blank" href="' + idUri + '">' + this.WSDServer.Id + '</a>');

--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -5102,6 +5102,9 @@ L.CanvasTileLayer = L.Layer.extend({
 		map.on('requestloksession', this._onRequestLOKSession, this);
 		map.on('error', this._mapOnError, this);
 		if (map.options.autoFitWidth !== false) {
+			// autoFitWidth
+			// Whether the document is automatically zoomed so that the width fits the viewing area when the window is resized. 
+			// The document will not be zoomed in more than map.options.zoom.
 			// always true since autoFitWidth is never set
 			map.on('resize', this._fitWidthZoom, this);
 		}

--- a/loleaflet/src/main.js
+++ b/loleaflet/src/main.js
@@ -26,6 +26,8 @@ if (reuseCookies !== '') {
 
 var filePath = getParameterByName('file_path');
 var permission = getParameterByName('permission') || 'edit';
+// permission
+// The document's permission.
 var timestamp = getParameterByName('timestamp');
 // Should the document go inactive or not
 var alwaysActive = getParameterByName('alwaysactive');
@@ -58,6 +60,9 @@ var map = L.map('map', {
 	permission: permission,
 	timestamp: timestamp,
 	documentContainer: 'document-container',
+	// documentContainer
+	// An outer div, containing the map div
+	// that is used internally for the creation of the toolbar.
 	debug: debugMode,
 	// the wopi and wopiSrc properties are in sync: false/true : empty/non-empty
 	wopi: isWopi,

--- a/loleaflet/src/map/Map.js
+++ b/loleaflet/src/map/Map.js
@@ -53,6 +53,8 @@ L.Map = L.Evented.extend({
 		urlPrefix: 'lool',
 		wopiSrc: '',
 		cursorURL: L.LOUtil.getURL('cursors'),
+		// cursorURL
+		// The path (local to the server) where custom cursor files are stored.
 	},
 
 	// Control.UIManager instance, set in main.js

--- a/loleaflet/src/map/Map.js
+++ b/loleaflet/src/map/Map.js
@@ -109,6 +109,9 @@ L.Map = L.Evented.extend({
 		Cursor.imagePath = options.cursorURL;
 
 		if (options.webserver === undefined) {
+			// webserver
+			// The webserver access to hosting loolwsd. Normally it is derived from 'server'
+			// but can be overridden with an own value in case of proxying. Example: http://localhost:9980
 			var protocol = window.location.protocol === 'file:' ? 'https:' : window.location.protocol;
 			options.webserver = options.server.replace(/^(ws|wss):/i, protocol);
 		}


### PR DESCRIPTION
* Resolves: # [loleaflet-api.html: Copy documentation into source code as comments #2160](https://github.com/CollaboraOnline/online/issues/2160)
* Target version: master 

* Added the comments of the remaining  **Options**  from the documentation
* Removed the `toolbarContainer` from **loleaflet-api.html** as per reference of commit id [4358d2a04ec5465d55e336aa826788c17df96d71](https://github.com/CollaboraOnline/online/commit/4358d2a04ec5465d55e336aa826788c17df96d71)