### PR TITLE
Remove more leftover files taking space in the iOS app

### DIFF
--- a/common/RenderTiles.hpp
+++ b/common/RenderTiles.hpp
@@ -571,7 +571,7 @@ namespace RenderTiles
             const int offsetX = positionX * pixelWidth;
             const int offsetY = positionY * pixelHeight;
 
-            NSString *mmapFileBaseName = [NSString stringWithFormat:@"%d.bmp", bmpId];
+            NSString *mmapFileBaseName = [NSString stringWithFormat:@"tiles/%d.bmp", bmpId];
             NSURL *mmapFileURL = [[NSFileManager.defaultManager temporaryDirectory] URLByAppendingPathComponent:mmapFileBaseName];
 
             int fd = open([[mmapFileURL path] UTF8String], O_RDWR|O_CREAT, 0666);

--- a/ios/Mobile/AppDelegate.mm
+++ b/ios/Mobile/AppDelegate.mm
@@ -290,6 +290,16 @@ static void updateTemplates(NSData *data, NSURLResponse *response)
     if (user_name == nullptr)
         user_name = [[[NSUserDefaults standardUserDefaults] stringForKey:@"userName"] UTF8String];
 
+    // Remove any leftover tile .bmp files by removing the whole folder
+    NSURL *tileFolderURL = [[[NSFileManager defaultManager] temporaryDirectory] URLByAppendingPathComponent:@"tiles"];
+    if (![[NSFileManager defaultManager] removeItemAtURL:tileFolderURL error:nil]) {
+        NSLog(@"Could not remove tile bitmap folder %@", tileFolderURL);
+    }
+
+    if (![[NSFileManager defaultManager] createDirectoryAtURL:tileFolderURL withIntermediateDirectories:YES attributes:nil error:nil]) {
+        NSLog(@"Could not create tile bitmap folder %@", tileFolderURL);
+    }
+
     fakeSocketSetLoggingCallback([](const std::string& line)
                                  {
                                      LOG_INF_NOFILE(line);

--- a/ios/Mobile/DocumentBrowserViewController.mm
+++ b/ios/Mobile/DocumentBrowserViewController.mm
@@ -34,6 +34,24 @@
     // Do any additional setup after loading the view, typically from a nib.
 }
 
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+
+#if 0
+    NSLog(@"Contents of NSHomeDirectory:");
+    auto enumerator = [[NSFileManager defaultManager] enumeratorAtPath:NSHomeDirectory()];
+    NSString *file;
+    while ((file = [enumerator nextObject])) {
+        NSString *suffix = @"";
+        if ([enumerator fileAttributes][NSFileType] == NSFileTypeRegular)
+            suffix = [NSString stringWithFormat:@"  %@", [enumerator fileAttributes][NSFileSize]];
+        else if ([enumerator fileAttributes][NSFileType] == NSFileTypeDirectory)
+            suffix = @"/";
+        NSLog(@"%@%@%@", [NSString stringWithFormat:@"%*s", (int)[enumerator level] * 2, ""], [file lastPathComponent], suffix);
+    }
+#endif
+}
+
 - (void)documentBrowser:(UIDocumentBrowserViewController *)controller didRequestDocumentCreationWithHandler:(void (^)(NSURL * _Nullable, UIDocumentBrowserImportMode))importHandler {
     UIStoryboard *storyBoard = [UIStoryboard storyboardWithName:@"Main" bundle:nil];
     TemplateCollectionViewController *templateCollectionViewController = [storyBoard instantiateViewControllerWithIdentifier:@"TemplateCollectionViewController"];

--- a/ios/Mobile/DocumentViewController.mm
+++ b/ios/Mobile/DocumentViewController.mm
@@ -589,7 +589,9 @@ static IMP standardImpOfInputAccessoryView = nil;
 
     // deallocateDocumentDataForMobileAppDocId(self.document->appDocId);
 
-    [[NSFileManager defaultManager] removeItemAtURL:self.document->copyFileURL error:nil];
+    if (![[NSFileManager defaultManager] removeItemAtURL:self.document->copyFileURL error:nil]) {
+        LOG_SYS("Could not remove copy of document at " << [[self.document->copyFileURL path] UTF8String]);
+    }
 
     // The dismissViewControllerAnimated must be done on the main queue.
     dispatch_async(dispatch_get_main_queue(),

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -2798,6 +2798,9 @@ void ChildSession::loKitCallback(const int type, const std::string& payload)
                    forSaveOperation:UIDocumentSaveForOverwriting
                   completionHandler:^(BOOL success) {
                         LOG_TRC("ChildSession::loKitCallback() save completion handler gets " << (success?"YES":"NO"));
+                        if (![[NSFileManager defaultManager] removeItemAtURL:document->copyFileURL error:nil]) {
+                            LOG_SYS("Could not remove copy of document at " << [[document->copyFileURL path] UTF8String]);
+                        }
                     }];
 #elif defined(__ANDROID__)
                 postDirectMessage("SAVE " + payload);


### PR DESCRIPTION
Remove the app's copy of the document after core has saved it and we
have stored the edited version at its real location.

Remove possible leftover tile bitmaps when the app starts.

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: Ibc41be38c2cfb689c532640d148116bc06a248ab


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

