### PR TITLE
loleaflet: avoid creating an empty dialog

### DIFF
--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -742,11 +742,8 @@ app.definitions.Socket = L.Class.extend({
 					return false;
 				};
 				dialogOptions.afterClose = restartConnectionFn;
-			}
 
-			var dialogOpened = vex.dialog.open(dialogOptions);
-
-			if (textMsg === 'idle' || textMsg === 'oom') {
+				var dialogOpened = vex.dialog.open(dialogOptions);
 				this._map._textInput.hideCursor();
 				dialogOpened.contentEl.onclick = restartConnectionFn;
 				$('.vex-overlay').addClass('loleaflet-user-idle-overlay');


### PR DESCRIPTION
When a document is reconnecting, it shows an empty dialog.

Change-Id: I00b8d47b2fee67175d2e2936d93e121b10c38389
Signed-off-by: Henry Castro <hcastro@collabora.com>
