### PR TITLE
I think the delay variable needs to be signed

### DIFF
--- a/tools/Replay.hpp
+++ b/tools/Replay.hpp
@@ -147,7 +147,7 @@ protected:
 
             const std::chrono::microseconds::rep deltaCurrent = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - epochCurrent).count();
             const unsigned deltaFile = rec.getTimestampNs() - epochFile;
-            const unsigned delay = (_ignoreTiming ? 0 : deltaFile - deltaCurrent);
+            const int delay = (_ignoreTiming ? 0 : deltaFile - deltaCurrent);
             if (delay > 0)
             {
                 if (delay > 1e6)


### PR DESCRIPTION
I otherwise get values like this:
    epochFile=18682409
    deltaCurrent=34
    rec.getTimestampNs()=18682409
    deltaFile=0
    delay=4294967262

Leading to the idiotic:
    Sleeping for 4294967 ms

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: I06530c31bc70bb7dcf3cd34c4684aa9f1f8036cb


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

