### PR TITLE
Copy documentation into source code as comments of remaining options

### DIFF
--- a/loleaflet/js/global.js
+++ b/loleaflet/js/global.js
@@ -820,6 +820,8 @@ window.app = { // Shouldn't have any functions defined.
 		global.socket.onopen = function () {
 			if (global.socket.readyState === 1) {
 				var ProtocolVersionNumber = '0.1';
+				// timestamp
+				// A timestamp of the last modification to the document.
 				var timestamp = global.getParameterByName('timestamp');
 				var msg = 'load url=' + encodeURIComponent(global.docURL);
 

--- a/loleaflet/loleaflet-api.html
+++ b/loleaflet/loleaflet-api.html
@@ -133,14 +133,6 @@ unexpected behaviour.</h5>
 		<td>An outer div, containing the map div, that is used internally for the creation of the toolbar.</td>
 	</tr>
 	<tr>
-		<td><code><b>toolbarContainer</b></code></td>
-		<td><code>String / DOM element</code></td>
-		<td><code><span class="literal">undefined</span></code></td>
-		<td>A div used by the default toolbar elements (bold, italic, search, etc.) in loleaflet. If you implement
-           your own toolbar and use controls that do not require a toolbar (like the dialog or scroll control) you
-          can ignore this.</td>
-	</tr>
-	<tr>
 		<td><code><b>renderingOptions</b></code></td>
 		<td><code>Object</code></td>
 		<td><code><span class="literal">undefined</span></code></td>

--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -210,6 +210,9 @@ app.definitions.Socket = L.Class.extend({
 		if (window.deviceFormFactor) {
 			msg += ' deviceFormFactor=' + window.deviceFormFactor;
 		}
+		// renderingOptions
+		// Enables the continuous, web view, of the document, 
+		// see the UNO commands below for this parameter.
 		if (this._map.options.renderingOptions) {
 			var options = {
 				'rendering': this._map.options.renderingOptions
@@ -526,6 +529,8 @@ app.definitions.Socket = L.Class.extend({
 			}
 
 			if (!window.ThisIsAMobileApp) {
+				// server
+				// The websocket server hosting loolwsd using the ws: protocol. Example: wss://localhost:9980
 				var idUri = this._map.options.server + this._map.options.serviceRoot + '/hosting/discovery';
 				idUri = idUri.replace(/^ws:/, 'http:');
 				idUri = idUri.replace(/^wss:/, 'https:');

--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -5101,6 +5101,9 @@ L.CanvasTileLayer = L.Layer.extend({
 		map.on('dragstart', this._onDragStart, this);
 		map.on('requestloksession', this._onRequestLOKSession, this);
 		map.on('error', this._mapOnError, this);
+		// autoFitWidth
+		// Whether the document is automatically zoomed so that the width fits the viewing area when the window is resized. 
+		// The document will not be zoomed in more than map.options.zoom.
 		if (map.options.autoFitWidth !== false) {
 			// always true since autoFitWidth is never set
 			map.on('resize', this._fitWidthZoom, this);

--- a/loleaflet/src/main.js
+++ b/loleaflet/src/main.js
@@ -25,6 +25,8 @@ if (reuseCookies !== '') {
 }
 
 var filePath = getParameterByName('file_path');
+// permission
+// The document's permission.
 var permission = getParameterByName('permission') || 'edit';
 var timestamp = getParameterByName('timestamp');
 // Should the document go inactive or not
@@ -57,6 +59,9 @@ var map = L.map('map', {
 	docParams: docParams,
 	permission: permission,
 	timestamp: timestamp,
+	// documentContainer
+	// An outer div, containing the map div
+	// that is used internally for the creation of the toolbar.
 	documentContainer: 'document-container',
 	debug: debugMode,
 	// the wopi and wopiSrc properties are in sync: false/true : empty/non-empty

--- a/loleaflet/src/map/Map.js
+++ b/loleaflet/src/map/Map.js
@@ -107,7 +107,9 @@ L.Map = L.Evented.extend({
 		}
 
 		Cursor.imagePath = options.cursorURL;
-
+		// webserver
+		// The webserver access to hosting loolwsd. Normally it is derived from 'server'
+		// but can be overridden with an own value in case of proxying. Example: http://localhost:9980
 		if (options.webserver === undefined) {
 			var protocol = window.location.protocol === 'file:' ? 'https:' : window.location.protocol;
 			options.webserver = options.server.replace(/^(ws|wss):/i, protocol);


### PR DESCRIPTION
* Resolves: # [loleaflet-api.html: Copy documentation into source code as comments #2160](https://github.com/CollaboraOnline/online/issues/2160)
* Target version: master 
* Added the comments of the remaining Options from the documentation
* Removed the toolbarContainer from loleaflet-api.html as per reference of commit id [4358d2a04ec5465d55e336aa826788c17df96d71](https://github.com/CollaboraOnline/online/commit/4358d2a04ec5465d55e336aa826788c17df96d71)

