### PR TITLE
wsd: log error if path is not empty

### DIFF
--- a/wsd/ProofKey.cpp
+++ b/wsd/ProofKey.cpp
@@ -144,7 +144,7 @@ Proof::Proof()
                 "\nor if your config dir is not /etc, you can run ssh-keygen manually:"
                 "\n    ssh-keygen -t rsa -N \"\" -m PEM -f \"" + keyPath + "\""
                 "\nNote: the proof_key file must be readable by the loolwsd process.";
-            LOG_ERR(msg);
+            LOG_WRN(msg);
         }
         catch (const Poco::Exception& e)
         {


### PR DESCRIPTION
The default is empty

Change-Id: I43b6c5ed6633b35e58ec3e1b1cc222756a9a47d8
Signed-off-by: Henry Castro <hcastro@collabora.com>
