### PR TITLE
Mobile: Impress: Fullscreen: Promote to topbar btn

### DIFF
--- a/loleaflet/src/control/Control.MobileTopBar.js
+++ b/loleaflet/src/control/Control.MobileTopBar.js
@@ -56,6 +56,7 @@ L.Control.MobileTopBar = L.Control.extend({
 				{type: 'button',  id: 'mobile_wizard', img: 'mobile_wizard', disabled: true},
 				{type: 'button',  id: 'insertion_mobile_wizard', img: 'insertion_mobile_wizard', disabled: true},
 				{type: 'button',  id: 'comment_wizard', img: 'viewcomments'},
+				{type: 'button', id: 'fullscreen-' + docType, img: 'fullscreen-presentation', hint: _UNO('.uno:FullScreen', docType)},
 				{type: 'drop', id: 'userlist', img: 'users', hidden: true, html: L.control.createUserListWidget()},
 			];
 		}
@@ -144,7 +145,7 @@ L.Control.MobileTopBar = L.Control.extend({
 			// Call global onClick handler
 			window.onClick(e, id, item);
 		}
-		else if (id === 'fullscreen') {
+		else if (id === 'fullscreen-drawing') {
 			if (item.checked) {
 				toolbar.uncheck(id);
 			}


### PR DESCRIPTION
Partly revert changes from c7b76b164f2b83f6355bb53bff13c55a84d0b2a6
By adding back fullscreen button to the top of the mobile bar.

Reason: I'm all in favour for consistency across document types but
we need to think twice about what the user uses in each specific app
(specially on mobile where forcing additional steps on frequent actions
can be really detrimental for the UX)

In this case it makes sense to display an additional top bar icon on
presentation documents where, probably, the user will not be using the
phone to create a whole presentation from scratch but rather to:
- review (and possibly do small adjustments)
- Practice
- And maybe adding comments

For this is quite important to have the fullscreen button up-front

Note: This commit also restores the ability the fullscreen button to
Drawing even though I don't think Drawing needs that since we do not
have the functionality of actual drawing with a brush or pencil). If
needed we can then remove it from Drawing as well but for now let's have
them identical.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ied3f46315e31a8a355c91b0a0431f21bc71f5ca2