### PR TITLE
canvas: avoid cursor update on window resize

### DIFF
--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -5038,7 +5038,7 @@ L.CanvasTileLayer = L.Layer.extend({
 				this._map.invalidateSize();
 			}
 
-			if (!heightIncreased)
+			if (!heightIncreased && window.mode.isMobile())
 				this._onUpdateCursor(true);
 
 			this._fitWidthZoom();


### PR DESCRIPTION
though cursor update is still required for the mobile on resize
because when the virtual keyboard appears cursor should be scrolled into viewing area

for more details: 3f04cd81835ac7e4af056363f68ba41c72d14a29

Signed-off-by: Pranam Lashkari <lpranam@collabora.com>
Change-Id: I08b54008d232d8a8d5277cf2acb5003f4c2a551a


* Target version: master 



### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

