### PR TITLE
loleaflet: add edit option in link dialog

### DIFF
--- a/loleaflet/src/control/Control.AlertDialog.js
+++ b/loleaflet/src/control/Control.AlertDialog.js
@@ -64,6 +64,16 @@ L.Control.AlertDialog = L.Control.extend({
 
 			if (isLinkValid) {
 				buttonsList.push({
+					text: _('Edit'),
+					type: 'button',
+					className: 'vex-dialog-button-secondary',
+					click: function() {
+						e.map.toggleCommandState('HyperlinkDialog');
+						vex.closeAll();
+					}
+				});
+
+				buttonsList.push({
 					text: _('Open link'),
 					type: 'button',
 					className: 'vex-dialog-button-primary',


### PR DESCRIPTION
closes #3152

Signed-off-by: Alexandru Vlăduţu alexandru.vladutu@1and1.ro
Change-Id: Ie1125f6f25f1264cbab18fd39b15a1e50ed03781


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

Adds 'Edit' button to dialog that opens when clicking a link. The new edit button will open the edit link widget. Screenshots attached to feature request which this PR implements.

### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

