### PR TITLE
Bin misleading ERROR message

### DIFF
--- a/tools/Replay.hpp
+++ b/tools/Replay.hpp
@@ -219,7 +219,9 @@ protected:
                     }
                     else
                     {
-                        std::cout << "ERROR: Doc [" << uri << "] does not exist.\n";
+                        // There is one EndSession record for each session that edited the same
+                        // document. We have removed the item from the _sessions map already for the
+                        // first EndSession record.
                     }
                 }
             }


### PR DESCRIPTION
There is one EndSession record for each session that edited the same
document. That is not an error.

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: I9042411ad465fe07a8f88a29923f0dc051c755aa
Signed-off-by: Tor Lillqvist <tml@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

