### PR TITLE
private/pedro/readonly improvements porting

### DIFF
--- a/loleaflet/css/menubar.css
+++ b/loleaflet/css/menubar.css
@@ -52,9 +52,7 @@
 	/* half of #document-name-input height: */
 	top: -9px;
 }
-.main-nav.readonly #document-titlebar {
-	top: 1px;
-}
+
 .main-nav.readonly #table-optionstoolboxdown {
 	display: none;
 }
@@ -67,8 +65,8 @@
 	z-index: 12;
 }
 .main-nav.readonly {
-	top: -1px; /*update .main-nav.readonly #document-titlebar*/
 	position: relative;
+	border-bottom: 1px solid var(--gray-light-bg-color);
 }
 .main-nav.hasnotebookbar:not(.readonly) {
 	background: var(--gray-light-bg-color);

--- a/loleaflet/css/menubar.css
+++ b/loleaflet/css/menubar.css
@@ -37,6 +37,10 @@
 	justify-content: flex-start;
 }
 
+.readonly .document-title {
+	justify-content: flex-end;
+}
+
 #document-titlebar {
 	position: relative;
 	display: inline-table; /*new*/
@@ -46,6 +50,11 @@
 	z-index: 1000;
 	width: calc(100% - 890px);
 	right: 0px;
+}
+
+.readonly #document-titlebar {
+	float: right;
+	margin-right: 52px;
 }
 
 .main-nav.hasnotebookbar:not(.readonly) #document-titlebar {

--- a/loleaflet/css/toolbar.css
+++ b/loleaflet/css/toolbar.css
@@ -30,6 +30,16 @@
 #tb_actionbar_item_LanguageStatus .w2ui-tb-caption{
 	float: none;
 }
+#toolbar-down.readonly #tb_actionbar_item_InsertMode,
+#toolbar-down.readonly #tb_actionbar_item_InsertMode + td[id^='tb_actionbar_item_break'],
+#toolbar-down.readonly #tb_actionbar_item_StatusSelectionMode,
+#toolbar-down.readonly #tb_actionbar_item_StatusSelectionMode + td[id^='tb_actionbar_item_break'],
+#toolbar-down.readonly #tb_actionbar_item_LanguageStatus .w2ui-button .w2ui-tb-down {
+	display: none;
+}
+#toolbar-down.readonly #tb_actionbar_item_LanguageStatus .w2ui-button {
+	border-color: transparent !important;
+}
 #tb_actionbar_item_StateTableCellMenu .w2ui-tb-down {
 	padding: 4px;
 }

--- a/loleaflet/css/toolbar.css
+++ b/loleaflet/css/toolbar.css
@@ -296,10 +296,18 @@ td[id^='tb_editbar_item_sidebar']{
 	display: none;
 }
 
+.main-nav:not(.hasnotebookbar) ~ #closebuttonwrapper {
+	height: 38px;
+}
+
 #closebutton {
 	width: 100%;
 	height: 100%;
 	background: url('images/closedoc.svg') no-repeat 6px 4px/24px !important;
+}
+
+.main-nav:not(.hasnotebookbar) ~ #closebuttonwrapper #closebutton {
+	background: url('images/closedoc.svg') no-repeat center/24px !important;
 }
 
 #closebutton:hover {

--- a/loleaflet/css/toolbar.css
+++ b/loleaflet/css/toolbar.css
@@ -33,7 +33,8 @@
 #tb_actionbar_item_StateTableCellMenu .w2ui-tb-down {
 	padding: 4px;
 }
-#InsertMode.insert-mode-false {
+#InsertMode.insert-mode-false,
+#PermissionMode.status-readonly-mode {
 	background-color: var(--gray-light-txt--color);
 	color: white;
 }

--- a/loleaflet/css/toolbar.css
+++ b/loleaflet/css/toolbar.css
@@ -265,6 +265,11 @@ w2ui-toolbar {
 	text-align: left;
 }
 
+.readonly #document-name-input.editable:focus {
+	flex: 1;
+	text-align: center;
+}
+
 #document-name-input.editable:hover:not(:focus) {
 	border: none;
 	box-shadow: 0 0 0.1px 1px #d7d7d7, 0 0 3px 2px #f0f0f0;

--- a/loleaflet/src/control/Control.Menubar.js
+++ b/loleaflet/src/control/Control.Menubar.js
@@ -1041,7 +1041,7 @@ L.Control.Menubar = L.Control.extend({
 		commandStates: {},
 
 		// Only these menu options will be visible in readonly mode
-		allowedReadonlyMenus: ['file', 'downloadas', 'view', 'insert', 'help'],
+		allowedReadonlyMenus: ['file', 'downloadas', 'view', 'help'],
 
 		allowedViewModeActions: [
 			'savecomments', 'shareas', 'print', // file menu

--- a/loleaflet/src/control/Control.StatusBar.js
+++ b/loleaflet/src/control/Control.StatusBar.js
@@ -281,6 +281,7 @@ L.Control.StatusBar = L.Control.extend({
 	onDocLayerInit: function () {
 		var statusbar = w2ui['actionbar'];
 		var docType = this.map.getDocType();
+		var isReadOnly = this.map.isPermissionReadOnly();
 
 		switch (docType) {
 		case 'spreadsheet':
@@ -330,7 +331,14 @@ L.Control.StatusBar = L.Control.extend({
 							{id: '1', text: _('None')}
 						], tablet: false
 					},
-					{type: 'break', id: 'break9', mobile: false}
+					{type: 'break', id: 'break9', mobile: false},
+					{
+						type: 'html', id: 'PermissionMode', mobile: false, tablet: false,
+						html: '<div id="PermissionMode" class="loleaflet-font ' +
+						(isReadOnly
+							? ' status-readonly-mode" title="' + _('Permission Mode') + '" style="padding: 5px 5px;"> ' + _('Read-only') + ' </div>'
+							: ' status-edit-mode" title="' + _('Permission Mode') + '" style="padding: 5px 5px;"> ' + _('Edit') + ' </div>')
+					}
 				]);
 			}
 			break;
@@ -362,7 +370,14 @@ L.Control.StatusBar = L.Control.extend({
 					{type: 'menu-radio', id: 'LanguageStatus',
 						mobile: false
 					},
-					{type: 'break', id: 'break8', mobile: false}
+					{type: 'break', id: 'break8', mobile: false},
+					{
+						type: 'html', id: 'PermissionMode', mobile: false, tablet: false,
+						html: '<div id="PermissionMode" class="loleaflet-font ' +
+						(isReadOnly
+							? ' status-readonly-mode" title="' + _('Permission Mode') + '" style="padding: 5px 5px;"> ' + _('Read-only') + ' </div>'
+							: ' status-edit-mode" title="' + _('Permission Mode') + '" style="padding: 5px 5px;"> ' + _('Edit') + ' </div>')
+					}
 				]);
 			}
 			break;
@@ -379,7 +394,14 @@ L.Control.StatusBar = L.Control.extend({
 					{type: 'menu-radio', id: 'LanguageStatus',
 						mobile: false
 					},
-					{type: 'break', id: 'break8', mobile: false}
+					{type: 'break', id: 'break8', mobile: false},
+					{
+						type: 'html', id: 'PermissionMode', mobile: false, tablet: false,
+						html: '<div id="PermissionMode" class="loleaflet-font ' +
+						(isReadOnly
+							? ' status-readonly-mode" title="' + _('Permission Mode') + '" style="padding: 5px 5px;"> ' + _('Read-only') + ' </div>'
+							: ' status-edit-mode" title="' + _('Permission Mode') + '" style="padding: 5px 5px;"> ' + _('Edit') + ' </div>')
+					}
 				]);
 			}
 

--- a/loleaflet/src/control/Control.Toolbar.js
+++ b/loleaflet/src/control/Control.Toolbar.js
@@ -1038,8 +1038,10 @@ function onUpdatePermission(e) {
 					toolbar.enable(items[idx].id);
 				}
 				$('.main-nav').removeClass('readonly');
+				$('#toolbar-down').removeClass('readonly');
 			} else if (!alwaysEnable) {
 				$('.main-nav').addClass('readonly');
+				$('#toolbar-down').addClass('readonly');
 				toolbar.disable(items[idx].id);
 			}
 		}

--- a/loleaflet/src/control/Control.UIManager.js
+++ b/loleaflet/src/control/Control.UIManager.js
@@ -169,10 +169,9 @@ L.Control.UIManager = L.Control.extend({
 			L.DomUtil.remove(L.DomUtil.get('spreadsheet-toolbar'));
 			L.DomUtil.remove(L.DomUtil.get('presentation-controls-wrapper'));
 
-			if ((window.mode.isTablet() || window.mode.isDesktop())) {
+			if ((window.mode.isTablet() || window.mode.isDesktop()) && this.map.isPermissionEdit()) {
 				var showRuler = this.getSavedStateOrDefault('ShowRuler');
-				var interactiveRuler = this.map.isPermissionEdit();
-				L.control.ruler({position:'topleft', interactive:interactiveRuler, showruler: showRuler}).addTo(this.map);
+				L.control.ruler({position:'topleft', interactive:true, showruler: showRuler}).addTo(this.map);
 			}
 		}
 


### PR DESCRIPTION
- Readonly mode: Do not display ruler
- Readonly mode: Remove unnecessary pixel positions
- Readonly mode: Fix close button alignment
- Readonly mode: Align document title to the right
- Status bar: Display Permission mode
- Menubar: Do not allow Insert menu on readonly mode
- Status bar: Add readonly class and hide inactive items
