### PR TITLE
Remove leftover tiles in the iOS app already when the document is closed

### DIFF
--- a/common/MobileApp.cpp
+++ b/common/MobileApp.cpp
@@ -9,35 +9,79 @@
 #include <map>
 #include <mutex>
 
+#include "Log.hpp"
 #include "MobileApp.hpp"
 
 #if MOBILEAPP
 
-static std::map<unsigned, DocumentData> idToDocDataMap;
+static std::map<unsigned, DocumentData*> idToDocDataMap;
 static std::mutex idToDocDataMapMutex;
 
-DocumentData &allocateDocumentDataForMobileAppDocId(unsigned docId)
+DocumentData &DocumentData::allocate(unsigned docId)
 {
     const std::lock_guard<std::mutex> lock(idToDocDataMapMutex);
 
     assert(idToDocDataMap.find(docId) == idToDocDataMap.end());
-    idToDocDataMap[docId] = DocumentData();
-    return idToDocDataMap[docId];
+    auto p = new DocumentData();
+    idToDocDataMap[docId] = p;
+    return *p;
 }
 
-DocumentData &getDocumentDataForMobileAppDocId(unsigned docId)
+DocumentData & DocumentData::get(unsigned docId)
 {
     const std::lock_guard<std::mutex> lock(idToDocDataMapMutex);
 
     assert(idToDocDataMap.find(docId) != idToDocDataMap.end());
-    return idToDocDataMap[docId];
+    return *idToDocDataMap[docId];
 }
 
-void deallocateDocumentDataForMobileAppDocId(unsigned docId)
+void DocumentData::deallocate(unsigned docId)
 {
     assert(idToDocDataMap.find(docId) != idToDocDataMap.end());
+    DocumentData &d = get(docId);
+#if 0
+    if (d.inFlightTiles.size() > 0)
+        NSLog(@"==== Leftover tiles:");
+    for (const auto& tile : d.inFlightTiles)
+    {
+        NSLog(@"     %s", tile.c_str());
+        if (unlink([[[NSURL URLWithString:[NSString stringWithUTF8String:tile.c_str()]] path] UTF8String]) == -1 && errno != ENOENT) {
+            LOG_SYS("Could not unlink tile " << tile);
+        }
+    }
+#endif
+    auto p = idToDocDataMap.find(docId);
+    delete p->second;
     idToDocDataMap.erase(docId);
 }
+
+#ifdef IOS
+
+int DocumentData::numberOfInFlightTiles(unsigned docId)
+{
+    const std::lock_guard<std::mutex> lock(idToDocDataMapMutex);
+
+    assert(idToDocDataMap.find(docId) != idToDocDataMap.end());
+    return idToDocDataMap[docId]->inFlightTiles.size();
+}
+
+void DocumentData::addInFlightTile(unsigned docId, const std::string& tileURL)
+{
+    const std::lock_guard<std::mutex> lock(idToDocDataMapMutex);
+
+    assert(idToDocDataMap.find(docId) != idToDocDataMap.end());
+    idToDocDataMap[docId]->inFlightTiles.insert(tileURL);
+}
+
+void DocumentData::removeInFlightTile(unsigned docId, const std::string& tileURL)
+{
+    const std::lock_guard<std::mutex> lock(idToDocDataMapMutex);
+
+    assert(idToDocDataMap.find(docId) != idToDocDataMap.end());
+    idToDocDataMap[docId]->inFlightTiles.erase(tileURL);
+}
+
+#endif
 
 #endif
 

--- a/common/RenderTiles.hpp
+++ b/common/RenderTiles.hpp
@@ -507,7 +507,8 @@ namespace RenderTiles
                                             size_t pixmapWidth, size_t pixmapHeight,
                                             int pixelWidth, int pixelHeight,
                                             LibreOfficeKitTileMode mode)>& blendWatermark,
-                  const std::function<void (const char *buffer, size_t length)>& outputMessage)
+                  const std::function<void (const char *buffer, size_t length)>& outputMessage,
+                  unsigned mobileAppDocId)
     {
         auto& tiles = tileCombined.getTiles();
 
@@ -618,17 +619,22 @@ namespace RenderTiles
                        pixmap.data() + (offsetY + y) * pixmapWidth * 4 + offsetX * 4,
                        pixelWidth * 4);
 
+            std::string tileURL([[mmapFileURL absoluteString] UTF8String]);
+
+            DocumentData::addInFlightTile(mobileAppDocId, tileURL);
+
             if (munmap(mmapMemory, mmapFileSize) == -1)
             {
                 LOG_SYS("Could not unmap file " << [[mmapFileURL path] UTF8String]);
                 return false;
             }
 
-            std::string tileMsg = tiles[i].serialize("tile:", ADD_DEBUG_RENDERID) + std::string([[mmapFileURL absoluteString] UTF8String]);
+            std::string tileMsg = tiles[i].serialize("tile:", ADD_DEBUG_RENDERID) + tileURL;
             outputMessage(tileMsg.c_str(), tileMsg.length());
         }
 
 #else
+        (void) mobileAppDocId;
 
         const auto mode = static_cast<LibreOfficeKitTileMode>(document->getTileMode());
 

--- a/ios/Mobile/CODocument.mm
+++ b/ios/Mobile/CODocument.mm
@@ -71,7 +71,7 @@ static std::atomic<unsigned> appDocIdCounter(1);
 
     NSURL *url = [[NSBundle mainBundle] URLForResource:@"loleaflet" withExtension:@"html"];
     NSURLComponents *components = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:NO];
-    allocateDocumentDataForMobileAppDocId(appDocId).coDocument = self;
+    DocumentData::allocate(appDocId).coDocument = self;
     components.queryItems = @[ [NSURLQueryItem queryItemWithName:@"file_path" value:[copyFileURL absoluteString]],
                                [NSURLQueryItem queryItemWithName:@"closebutton" value:@"1"],
                                [NSURLQueryItem queryItemWithName:@"permission" value:@"edit"],

--- a/ios/Mobile/DocumentViewController.mm
+++ b/ios/Mobile/DocumentViewController.mm
@@ -365,7 +365,7 @@ static IMP standardImpOfInputAccessoryView = nil;
             self.slideshowFile = FileUtil::createRandomTmpDir() + "/slideshow.svg";
             self.slideshowURL = [NSURL fileURLWithPath:[NSString stringWithUTF8String:self.slideshowFile.c_str()] isDirectory:NO];
 
-            getDocumentDataForMobileAppDocId(self.document->appDocId).loKitDocument->saveAs([[self.slideshowURL absoluteString] UTF8String], "svg", nullptr);
+            DocumentData::get(self.document->appDocId).loKitDocument->saveAs([[self.slideshowURL absoluteString] UTF8String], "svg", nullptr);
 
             // Add a new full-screen WebView displaying the slideshow.
 
@@ -419,7 +419,7 @@ static IMP standardImpOfInputAccessoryView = nil;
 
             std::string printFile = FileUtil::createRandomTmpDir() + "/print.pdf";
             NSURL *printURL = [NSURL fileURLWithPath:[NSString stringWithUTF8String:printFile.c_str()] isDirectory:NO];
-            getDocumentDataForMobileAppDocId(self.document->appDocId).loKitDocument->saveAs([[printURL absoluteString] UTF8String], "pdf", nullptr);
+            DocumentData::get(self.document->appDocId).loKitDocument->saveAs([[printURL absoluteString] UTF8String], "pdf", nullptr);
 
             UIPrintInteractionController *pic = [UIPrintInteractionController sharedPrintController];
             UIPrintInfo *printInfo = [UIPrintInfo printInfo];
@@ -502,7 +502,7 @@ static IMP standardImpOfInputAccessoryView = nil;
 
                 std::remove([[downloadAsTmpURL path] UTF8String]);
 
-                getDocumentDataForMobileAppDocId(self.document->appDocId).loKitDocument->saveAs([[downloadAsTmpURL absoluteString] UTF8String], [format UTF8String], nullptr);
+                DocumentData::get(self.document->appDocId).loKitDocument->saveAs([[downloadAsTmpURL absoluteString] UTF8String], [format UTF8String], nullptr);
 
                 // Then verify that it indeed was saved, and then use an
                 // UIDocumentPickerViewController to ask the user where to store the exported
@@ -535,6 +535,9 @@ static IMP standardImpOfInputAccessoryView = nil;
 
             if (unlink([[tile path] UTF8String]) == -1) {
                 LOG_SYS("Could not unlink tile " << [[tile path] UTF8String]);
+            } else {
+                const std::string tileURL = std::string([[tile absoluteString] UTF8String]);
+                DocumentData::removeInFlightTile(self.document->appDocId, tileURL);
             }
             return;
         }
@@ -587,7 +590,7 @@ static IMP standardImpOfInputAccessoryView = nil;
     // Close one end of the socket pair, that will wake up the forwarding thread above
     fakeSocketClose(closeNotificationPipeForForwardingThread[0]);
 
-    // deallocateDocumentDataForMobileAppDocId(self.document->appDocId);
+    // DocumentData::deallocate(self.document->appDocId);
 
     if (![[NSFileManager defaultManager] removeItemAtURL:self.document->copyFileURL error:nil]) {
         LOG_SYS("Could not remove copy of document at " << [[self.document->copyFileURL path] UTF8String]);

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -2793,7 +2793,7 @@ void ChildSession::loKitCallback(const int type, const std::string& payload)
             if (!success.isEmpty() && success.toString() == "true")
             {
 #if defined(IOS)
-                CODocument *document = getDocumentDataForMobileAppDocId(_docManager->getMobileAppDocId()).coDocument;
+                CODocument *document = DocumentData::get(_docManager->getMobileAppDocId()).coDocument;
                 [document saveToURL:[document fileURL]
                    forSaveOperation:UIDocumentSaveForOverwriting
                   completionHandler:^(BOOL success) {

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -617,7 +617,7 @@ public:
         }
 
 #ifdef IOS
-        deallocateDocumentDataForMobileAppDocId(_mobileAppDocId);
+        DocumentData::deallocate(_mobileAppDocId);
 #endif
     }
 
@@ -796,7 +796,7 @@ public:
         };
 
         if (!RenderTiles::doRender(_loKitDocument, tileCombined, _pngCache, _pngPool, combined,
-                                   blenderFunc, postMessageFunc))
+                                   blenderFunc, postMessageFunc, _mobileAppDocId))
         {
             LOG_DBG("All tiles skipped, not producing empty tilecombine: message");
             return;
@@ -1317,7 +1317,7 @@ private:
             LOG_DBG("Returned lokit::documentLoad(" << FileUtil::anonymizeUrl(pURL) << ") in "
                                                     << elapsed);
 #ifdef IOS
-            getDocumentDataForMobileAppDocId(_mobileAppDocId).loKitDocument = _loKitDocument.get();
+            DocumentData::get(_mobileAppDocId).loKitDocument = _loKitDocument.get();
 #endif
             if (!_loKitDocument || !_loKitDocument->get())
             {


### PR DESCRIPTION
Normally (ideally), tiles (.bmp files) are removed as soon as the JS
has displayed them. But occasionally something goes wrong and they are
left behind. (For instance, it seems to happen if the user closes the
document immediately when it shows up.)

Do not leave them on disk until the app starts the next time.

Change-Id: I0c764280a69a16ad3b7b67c329832fd5331c2e1e
Signed-off-by: Tor Lillqvist <tml@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

