### PR TITLE
Cypress: wait before some checks and deselect text

### DIFF
--- a/cypress_test/integration_tests/common/helper.js
+++ b/cypress_test/integration_tests/common/helper.js
@@ -373,6 +373,8 @@ function selectAllText() {
 	cy.log('Select all text - start');
 
 	typeIntoDocument('{ctrl}a');
+	cy.log('wait after selecting');
+	cy.wait(100);
 
 	textSelectionShouldExist();
 

--- a/cypress_test/integration_tests/common/mobile_helper.js
+++ b/cypress_test/integration_tests/common/mobile_helper.js
@@ -50,8 +50,7 @@ function enableEditingMobile() {
 	// In writer, we should have the blinking cursor visible
 	// after stepping into editing mode.
 	helper.doIfInWriter(function() {
-		cy.get('.blinking-cursor')
-			.should('be.visible');
+		cy.get('.blinking-cursor', { timeout: 200 }).should('be.visible');
 	});
 
 	cy.log('Enabling editing mode - end.');

--- a/cypress_test/integration_tests/mobile/writer/track_changes_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/track_changes_spec.js
@@ -70,7 +70,10 @@ describe('Track Changes', function() {
 
 		confirmChange('Accept All');
 
+		cy.log('Typing into document - ctrl + a.');
 		helper.typeIntoDocument('{ctrl}a');
+		cy.log('Typing into document - leftarrow.');
+		helper.typeIntoDocument('{leftarrow}');
 
 		helper.textSelectionShouldNotExist();
 	});


### PR DESCRIPTION
Attempt to avoid random errors by:
- Wait before checking selection
- Wait before checking blinking-cursor
- Also press leftarrow key before checking that there is no selection
  - I wonder why we have ctrl + a before in the first place

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: If196ba79c36776c3add4600a58997055489b0eed
