### PR TITLE
Calc, mobile: fixed formula bar size (hide it on readonly)

### DIFF
--- a/cypress_test/integration_tests/common/calc_helper.js
+++ b/cypress_test/integration_tests/common/calc_helper.js
@@ -13,6 +13,10 @@ function clickFormulaBar() {
 	// canvas, which is accurately sized.
 	// N.B. Setting the width of the inputbar_container
 	// is futile because it messes the size of the canvas.
+	helper.doIfOnMobile(function() {
+		helper.waitUntilIdle('.inputbar_container');
+	});
+
 	cy.get('.inputbar_canvas')
 		.then(function(items) {
 			expect(items).to.have.lengthOf(1);

--- a/cypress_test/integration_tests/mobile/calc/formulabar_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/formulabar_spec.js
@@ -70,7 +70,7 @@ describe('Formula bar tests.', function() {
 
 		cy.get('#calc-inputbar .lokdialog-cursor')
 			.should(function(cursor) {
-				expect(cursor.offset().left).to.be.equal(103);
+				expect(cursor.offset().left).to.be.equal(93);
 			});
 	});
 
@@ -157,7 +157,7 @@ describe('Formula bar tests.', function() {
 			});
 
 		// Switch to multiline mode.
-		var arrowPos = [250, 10];
+		var arrowPos = [255, 10];
 		cy.get('#calc-inputbar')
 			.click(arrowPos[0], arrowPos[1]);
 

--- a/cypress_test/integration_tests/mobile/impress/impress_focus_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/impress_focus_spec.js
@@ -44,6 +44,8 @@ describe('Impress focus tests', function() {
 		cy.document().its('activeElement.tagName')
 			.should('be.eq', 'BODY');
 
+		cy.wait(1000);
+
 		// Shape selection.
 		cy.get('.leaflet-pane.leaflet-overlay-pane svg g')
 			.should('exist');

--- a/cypress_test/integration_tests/mobile/writer/track_changes_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/track_changes_spec.js
@@ -57,6 +57,8 @@ describe('Track Changes', function() {
 	it('Accept All', function() {
 		helper.typeIntoDocument('Hello World');
 
+		cy.wait(1000);
+
 		enableRecord();
 
 		helper.selectAllText();
@@ -77,6 +79,8 @@ describe('Track Changes', function() {
 
 	it('Reject All',function() {
 		helper.typeIntoDocument('Hello World');
+
+		cy.wait(1000);
 
 		enableRecord();
 

--- a/loleaflet/css/device-mobile.css
+++ b/loleaflet/css/device-mobile.css
@@ -164,16 +164,6 @@ div#w2ui-overlay-actionbar.w2ui-overlay{
 	vertical-align: middle;
 }
 /* Related to selectionMarkers.css */
-#tb_formulabar_item_formula, #tb_formulabar_item_address {
-	height: 44px !important;
-	padding-top: 0px !important;
-}
-#tb_formulabar_item_formula > div, #tb_formulabar_item_address > div {
-	margin-top: -16px;
-}
-#tb_formulabar_item_functiondialog > div {
-	margin-top: -20px;
-}
 .inputbar_multiline #tb_formulabar_item_formula > div,
 .inputbar_multiline #tb_formulabar_item_address > div {
 	margin-top: 0px;
@@ -403,12 +393,10 @@ button.vex-dialog-button-secondary.vex-dialog-button.vex-last {
 	transform: rotate(180deg);
 }
 #addressInput{
-	width: 60px !important;
-	border: 1px solid #bbbbbb;
-	border-bottom: none;
-	border-top: none;
-	border-left: none;
-	height: 35px !important;
+	width: 50px;
+	height: 23px;
+	text-align: center;
+	border-color: 1px solid #808080 !important;
 }
 .w2ui-icon.equal, .w2ui-icon.autosum{width: 38px !important;}
 #formulaInput{

--- a/loleaflet/css/loleaflet.css
+++ b/loleaflet/css/loleaflet.css
@@ -25,6 +25,10 @@
 	position: absolute;
 	width: 1px;
 }
+#document-container.readonly.mobile.spreadsheet-doctype {
+	top: 36px;
+	position: fixed;
+}
 #document-container {
 	background: #DFDFDF;
 	position: relative;

--- a/loleaflet/src/layer/tile/CanvasSectionContainer.ts
+++ b/loleaflet/src/layer/tile/CanvasSectionContainer.ts
@@ -1380,7 +1380,7 @@ class CanvasSectionContainer {
 			document.body.appendChild(element);
 		}
 		element.style.position = 'fixed';
-		element.style.zIndex = '0';
+		element.style.zIndex = '-1';
 		element.style.left = String(bcr.left + Math.round(section.myTopLeft[0] / app.dpiScale)) + 'px';
 		element.style.top = String(bcr.top + Math.round(section.myTopLeft[1] / app.dpiScale)) + 'px';
 		element.style.width = String(Math.round(section.size[0] / app.dpiScale)) + 'px';


### PR DESCRIPTION
- Remove negative margins (no need for that anymore) and instead use
the ideal height values from the get go
- Also Remove parent's height rule (better to follow children's value)
- Remove rules that are never applied (since they are always superseded
by others)
- Align addressInput to left column header
- addressInput: Use the same text alignment as used in column header
- Set the addressInput border color to the same color as in formula
input field

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: If2ed681e408fb12dadc33ed47e3c68d8237324f9
