### PR TITLE
Hexify URLs

### DIFF
--- a/common/Util.cpp
+++ b/common/Util.cpp
@@ -311,27 +311,6 @@ namespace Util
 
 #endif
 
-    bool dataFromHexString(const std::string& hexString, std::vector<unsigned char>& data)
-    {
-        if (hexString.length() % 2 != 0)
-        {
-            return false;
-        }
-
-        data.clear();
-        std::stringstream stream;
-        unsigned value;
-        for (unsigned long offset = 0; offset < hexString.size(); offset += 2)
-        {
-            stream.clear();
-            stream << std::hex << hexString.substr(offset, 2);
-            stream >> value;
-            data.push_back(static_cast<unsigned char>(value));
-        }
-
-        return true;
-    }
-
     std::string encodeId(const std::uint64_t number, const int padding)
     {
         std::ostringstream oss;

--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -77,8 +77,52 @@ namespace Util
 
 #endif
 
+    /// Convert unsigned char data to hex.
+    /// @buffer can be either std::vector<char> or std::string.
+    /// @offset the offset within the buffer to start from.
+    /// @length is the number of bytes to convert.
+    template <typename T>
+    inline std::string dataToHexString(const T& buffer, const std::size_t offset,
+                                       const std::size_t length)
+    {
+        char scratch[64];
+        std::stringstream os;
+
+        for (unsigned int i = 0; i < length; i++)
+        {
+            if ((offset + i) >= buffer.size())
+                break;
+
+            sprintf(scratch, "%.2x", static_cast<unsigned char>(buffer[offset + i]));
+            os << scratch;
+        }
+
+        return os.str();
+    }
+
     /// Hex to unsigned char
-    bool dataFromHexString(const std::string& hexString, std::vector<unsigned char>& data);
+    template <typename T>
+    bool dataFromHexString(const std::string& hexString, T& data)
+    {
+        if (hexString.length() % 2 != 0)
+        {
+            return false;
+        }
+
+        data.clear();
+        std::stringstream stream;
+        unsigned value;
+        for (unsigned long offset = 0; offset < hexString.size(); offset += 2)
+        {
+            stream.clear();
+            stream << std::hex << hexString.substr(offset, 2);
+            stream >> value;
+            data.push_back(static_cast<typename T::value_type>(value));
+        }
+
+        return true;
+    }
+
     /// Encode an integral ID into a string, with padding support.
     std::string encodeId(const std::uint64_t number, const int padding = 5);
     /// Decode an integral ID from a string.

--- a/loleaflet/html/loleaflet.html.m4
+++ b/loleaflet/html/loleaflet.html.m4
@@ -260,6 +260,7 @@ m4_ifelse(MOBILEAPP,[true],
 m4_ifelse(MOBILEAPP,[true],
      [window.host = '';
       window.serviceRoot = '';
+      window.hexifyUrl = false;
       window.versionPath = '%VERSION%';
       window.accessToken = '';
       window.accessTokenTTL = '';
@@ -277,6 +278,7 @@ m4_ifelse(MOBILEAPP,[true],
       window.uiDefaults = {};],
      [window.host = '%HOST%';
       window.serviceRoot = '%SERVICE_ROOT%';
+      window.hexifyUrl = %HEXIFY_URL%;
       window.versionPath = '%VERSION%';
       window.accessToken = '%ACCESS_TOKEN%';
       window.accessTokenTTL = '%ACCESS_TOKEN_TTL%';

--- a/loleaflet/js/global.js
+++ b/loleaflet/js/global.js
@@ -768,10 +768,9 @@ window.app = { // Shouldn't have any functions defined.
 
 	var docParams, wopiParams;
 	var filePath = global.getParameterByName('file_path');
-	var wopiSrc = global.getParameterByName('WOPISrc');
-	if (wopiSrc != '') {
-		global.docURL = decodeURIComponent(wopiSrc);
-		wopiSrc = '?WOPISrc=' + wopiSrc + '&compat=';
+	global.wopiSrc = global.getParameterByName('WOPISrc');
+	if (global.wopiSrc != '') {
+		global.docURL = decodeURIComponent(global.wopiSrc);
 		if (global.accessToken !== '') {
 			wopiParams = { 'access_token': global.accessToken, 'access_token_ttl': global.accessTokenTTL };
 		}
@@ -801,6 +800,20 @@ window.app = { // Shouldn't have any functions defined.
 	global.makeWsUrl = function (path) {
 		console.assert(global.host.startsWith('ws'), 'host is not ws: ' + global.host);
 		return global.host + global.serviceRoot + path;
+	};
+
+	// Form a valid WS URL to the host with the given path.
+	global.makeWsUrlWopiSrc = function (path, docUrlParams) {
+		var websocketURI = global.makeWsUrl(path);
+		var wopiSrc = '';
+		if (global.wopiSrc != '') {
+			wopiSrc = '?WOPISrc=' + global.wopiSrc + '&compat=';
+		}
+
+		var encodedDocUrl = encodeURIComponent(docUrlParams) + '/ws' + wopiSrc;
+		if (global.hexifyUrl)
+			encodedDocUrl = global.hexEncode(encodedDocUrl);
+		return websocketURI + encodedDocUrl + '/ws';
 	};
 
 	// Form a valid HTTP URL to the host with the given path.
@@ -837,7 +850,7 @@ window.app = { // Shouldn't have any functions defined.
 		// The URL may already contain a query (e.g., 'http://server.tld/foo/wopi/files/bar?desktop=baz') - then just append more params
 		var docParamsPart = docParams ? ((global.docURL.indexOf('?') >= 0) ? '&' : '?') + docParams : '';
 		var websocketURI = global.makeWsUrl('/lool/');
-		var encodedDocUrl = encodeURIComponent(global.docURL + docParamsPart) + '/ws' + wopiSrc;
+		var encodedDocUrl = encodeURIComponent(global.docURL + docParamsPart) + '/ws' + '?WOPISrc=' + global.wopiSrc + '&compat=';
 		if (global.hexifyUrl)
 			encodedDocUrl = global.hexEncode(encodedDocUrl);
 

--- a/loleaflet/js/global.js
+++ b/loleaflet/js/global.js
@@ -757,7 +757,7 @@ window.app = { // Shouldn't have any functions defined.
 
 	// Some global variables are defined in loleaflet.html, among them:
 	// global.host: the host URL, with ws(s):// protocol
-	// global.serviceRoot:
+	// global.serviceRoot: an optional root path on the server, typically blank.
 
 	// Setup global.webserver: the host URL, with http(s):// protocol (used to fetch files).
 	if (global.webserver === undefined) {

--- a/loleaflet/js/global.js
+++ b/loleaflet/js/global.js
@@ -797,8 +797,9 @@ window.app = { // Shouldn't have any functions defined.
 		global.docURL = filePath;
 	}
 
-	// Form a valid URL to the host with the given path.
-	global.makeURL = function (path) {
+	// Form a valid HTTP URL to the host with the given path.
+	global.makeHttpUrl = function (path) {
+		console.assert(global.webserver.startsWith('http'), 'webserver is not http: ' + global.webserver);
 		return global.webserver + global.serviceRoot + path;
 	};
 

--- a/loleaflet/js/global.js
+++ b/loleaflet/js/global.js
@@ -786,6 +786,11 @@ window.app = { // Shouldn't have any functions defined.
 		global.docURL = filePath;
 	}
 
+	// Form a valid URL to the host with the given path.
+	global.makeURL = function (path) {
+		return global.webserver + global.serviceRoot + path;
+	};
+
 	if (window.ThisIsAMobileApp) {
 		global.socket = new global.FakeWebSocket();
 		window.TheFakeWebSocket = global.socket;

--- a/loleaflet/js/global.js
+++ b/loleaflet/js/global.js
@@ -797,6 +797,12 @@ window.app = { // Shouldn't have any functions defined.
 		global.docURL = filePath;
 	}
 
+	// Form a valid WS URL to the host with the given path.
+	global.makeWsUrl = function (path) {
+		console.assert(global.host.startsWith('ws'), 'host is not ws: ' + global.host);
+		return global.host + global.serviceRoot + path;
+	};
+
 	// Form a valid HTTP URL to the host with the given path.
 	global.makeHttpUrl = function (path) {
 		console.assert(global.webserver.startsWith('http'), 'webserver is not http: ' + global.webserver);
@@ -830,7 +836,7 @@ window.app = { // Shouldn't have any functions defined.
 	} else {
 		// The URL may already contain a query (e.g., 'http://server.tld/foo/wopi/files/bar?desktop=baz') - then just append more params
 		var docParamsPart = docParams ? ((global.docURL.indexOf('?') >= 0) ? '&' : '?') + docParams : '';
-		var websocketURI = global.host + global.serviceRoot + '/lool/';
+		var websocketURI = global.makeWsUrl('/lool/');
 		var encodedDocUrl = encodeURIComponent(global.docURL + docParamsPart) + '/ws' + wopiSrc;
 		if (global.hexifyUrl)
 			encodedDocUrl = global.hexEncode(encodedDocUrl);

--- a/loleaflet/js/global.js
+++ b/loleaflet/js/global.js
@@ -760,7 +760,7 @@ window.app = { // Shouldn't have any functions defined.
 	var wopiSrc = global.getParameterByName('WOPISrc');
 	if (wopiSrc != '') {
 		global.docURL = decodeURIComponent(wopiSrc);
-		wopiSrc = '?WOPISrc=' + wopiSrc + '&compat=/ws';
+		wopiSrc = '?WOPISrc=' + wopiSrc + '&compat=';
 		if (global.accessToken !== '') {
 			wopiParams = { 'access_token': global.accessToken, 'access_token_ttl': global.accessTokenTTL };
 		}
@@ -791,14 +791,39 @@ window.app = { // Shouldn't have any functions defined.
 		return global.webserver + global.serviceRoot + path;
 	};
 
+	// Encode a string to hex.
+	global.hexEncode = function (string) {
+		var bytes = new TextEncoder().encode(string);
+		var hex = '0x';
+		for (i = 0; i < bytes.length; ++i) {
+			hex += bytes[i].toString(16);
+		}
+		return hex;
+	};
+
+	// Decode hexified string back to plain text.
+	global.hexDecode = function (hex) {
+		if (hex.startsWith('0x'))
+			hex = hex.substr(2);
+		var bytes = new Uint8Array(hex.length / 2);
+		for (i = 0; i < bytes.length; i++) {
+			bytes[i] = parseInt(hex.substr(i * 2, 2), 16);
+		}
+		return new TextDecoder().decode(bytes);
+	};
+
 	if (window.ThisIsAMobileApp) {
 		global.socket = new global.FakeWebSocket();
 		window.TheFakeWebSocket = global.socket;
 	} else {
 		// The URL may already contain a query (e.g., 'http://server.tld/foo/wopi/files/bar?desktop=baz') - then just append more params
 		var docParamsPart = docParams ? ((global.docURL.indexOf('?') >= 0) ? '&' : '?') + docParams : '';
-		var websocketURI = global.host + global.serviceRoot + '/lool/' + encodeURIComponent(global.docURL + docParamsPart) + '/ws' + wopiSrc;
+		var websocketURI = global.host + global.serviceRoot + '/lool/';
+		var encodedDocUrl = encodeURIComponent(global.docURL + docParamsPart) + '/ws' + wopiSrc;
+		if (global.hexifyUrl)
+			encodedDocUrl = global.hexEncode(encodedDocUrl);
 
+		websocketURI += encodedDocUrl + '/ws';
 		try {
 			global.socket = global.createWebSocket(websocketURI);
 		} catch (err) {

--- a/loleaflet/js/global.js
+++ b/loleaflet/js/global.js
@@ -755,6 +755,17 @@ window.app = { // Shouldn't have any functions defined.
 		}
 	};
 
+	// Some global variables are defined in loleaflet.html, among them:
+	// global.host: the host URL, with ws(s):// protocol
+	// global.serviceRoot:
+
+	// Setup global.webserver: the host URL, with http(s):// protocol (used to fetch files).
+	if (global.webserver === undefined) {
+		var protocol = window.location.protocol === 'file:' ? 'https:' : window.location.protocol;
+		global.webserver = global.host.replace(/^(ws|wss):/i, protocol);
+		global.webserver = global.webserver.replace(/\/*$/, ''); // Remove trailing slash.
+	}
+
 	var docParams, wopiParams;
 	var filePath = global.getParameterByName('file_path');
 	var wopiSrc = global.getParameterByName('WOPISrc');

--- a/loleaflet/js/global.js
+++ b/loleaflet/js/global.js
@@ -802,24 +802,44 @@ window.app = { // Shouldn't have any functions defined.
 		return global.host + global.serviceRoot + path;
 	};
 
-	// Form a valid WS URL to the host with the given path.
-	global.makeWsUrlWopiSrc = function (path, docUrlParams) {
-		var websocketURI = global.makeWsUrl(path);
+	// Form a URI from the docUrl and wopiSrc and encodes.
+	// The docUrlParams, suffix, and wopiSrc are optionally hexified.
+	global.makeDocAndWopiSrcUrl = function (root, docUrlParams, suffix, wopiSrcParam) {
 		var wopiSrc = '';
 		if (global.wopiSrc != '') {
 			wopiSrc = '?WOPISrc=' + global.wopiSrc + '&compat=';
+			if (wopiSrcParam && wopiSrcParam.length > 0)
+				wopiSrc += '&' + wopiSrcParam;
+		}
+		else if (wopiSrcParam && wopiSrcParam.length > 0) {
+			wopiSrc = '?' + wopiSrcParam;
 		}
 
-		var encodedDocUrl = encodeURIComponent(docUrlParams) + '/ws' + wopiSrc;
+		suffix = suffix || '/ws';
+		var encodedDocUrl = encodeURIComponent(docUrlParams) + suffix + wopiSrc;
 		if (global.hexifyUrl)
 			encodedDocUrl = global.hexEncode(encodedDocUrl);
-		return websocketURI + encodedDocUrl + '/ws';
+		return root + encodedDocUrl + '/ws';
+	};
+
+	// Form a valid WS URL to the host with the given path and
+	// encode the document URL and params.
+	global.makeWsUrlWopiSrc = function (path, docUrlParams, suffix, wopiSrcParam) {
+		var websocketURI = global.makeWsUrl(path);
+		return global.makeDocAndWopiSrcUrl(websocketURI, docUrlParams, suffix, wopiSrcParam);
 	};
 
 	// Form a valid HTTP URL to the host with the given path.
 	global.makeHttpUrl = function (path) {
 		console.assert(global.webserver.startsWith('http'), 'webserver is not http: ' + global.webserver);
 		return global.webserver + global.serviceRoot + path;
+	};
+
+	// Form a valid HTTP URL to the host with the given path and
+	// encode the document URL and params.
+	global.makeHttpUrlWopiSrc = function (path, docUrlParams, suffix, wopiSrcParam) {
+		var httpURI = window.makeHttpUrl(path);
+		return global.makeDocAndWopiSrcUrl(httpURI, docUrlParams, suffix, wopiSrcParam);
 	};
 
 	// Encode a string to hex.
@@ -849,12 +869,7 @@ window.app = { // Shouldn't have any functions defined.
 	} else {
 		// The URL may already contain a query (e.g., 'http://server.tld/foo/wopi/files/bar?desktop=baz') - then just append more params
 		var docParamsPart = docParams ? ((global.docURL.indexOf('?') >= 0) ? '&' : '?') + docParams : '';
-		var websocketURI = global.makeWsUrl('/lool/');
-		var encodedDocUrl = encodeURIComponent(global.docURL + docParamsPart) + '/ws' + '?WOPISrc=' + global.wopiSrc + '&compat=';
-		if (global.hexifyUrl)
-			encodedDocUrl = global.hexEncode(encodedDocUrl);
-
-		websocketURI += encodedDocUrl + '/ws';
+		var websocketURI = global.makeWsUrlWopiSrc('/lool/', global.docURL + docParamsPart);
 		try {
 			global.socket = global.createWebSocket(websocketURI);
 		} catch (err) {

--- a/loleaflet/src/control/Toolbar.js
+++ b/loleaflet/src/control/Toolbar.js
@@ -422,7 +422,7 @@ L.Map.include({
 						for (var p = 0; p < imgList.length; p++) {
 							var imgSrc = imgList[p].src;
 							imgSrc = imgSrc.substring(imgSrc.indexOf('/images'));
-							imgList[p].src = window.host + window.serviceRoot + '/loleaflet/dist'+ imgSrc;
+							imgList[p].src = window.makeWsUrl('/loleaflet/dist'+ imgSrc);
 						}
 					}
 					// Display help according to document opened
@@ -536,7 +536,7 @@ L.Map.include({
 		}
 		var helpLocation = 'loleaflet-help.html';
 		if (window.socketProxy)
-			helpLocation = window.host + window.serviceRoot + '/loleaflet/dist/' + helpLocation;
+			helpLocation = window.makeWsUrl('/loleaflet/dist/' + helpLocation);
 		$.get(helpLocation, function(data) {
 			map._doVexOpenHelpFile(data, id, map);
 		});
@@ -613,7 +613,7 @@ L.Map.include({
 		console.log('showWelcomeDialog, calledFromMenu: ' + calledFromMenu);
 		var welcomeLocation = 'welcome/welcome-' + String.locale + '.html';
 		if (window.socketProxy)
-			welcomeLocation = window.host + window.serviceRoot + '/loleaflet/dist/' + welcomeLocation;
+			welcomeLocation = window.makeWsUrl('/loleaflet/dist/' + welcomeLocation);
 
 		var map = this;
 

--- a/loleaflet/src/core/LOUtil.js
+++ b/loleaflet/src/core/LOUtil.js
@@ -83,8 +83,7 @@ L.LOUtil = {
 		if (window.host === '' && window.serviceRoot === '')
 			return path; // mobile
 
-		var realHost = window.host.replace(/^ws/i, 'http');
-		var url = realHost + window.serviceRoot + '/loleaflet/' + window.versionPath;
+		var url = window.makeHttpUrl('/loleaflet/' + window.versionPath);
 		if (path.substr(0,1) !== '/')
 			url += '/';
 		url += path;

--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -34,7 +34,7 @@ app.definitions.Socket = L.Class.extend({
 	},
 
 	getWebSocketBaseURI: function(map) {
-		return window.host + map.options.serviceRoot + '/lool/' + encodeURIComponent(map.options.doc + '?' + $.param(map.options.docParams)) + '/ws';
+		return window.host + window.serviceRoot + '/lool/' + encodeURIComponent(map.options.doc + '?' + $.param(map.options.docParams)) + '/ws';
 	},
 
 	connect: function(socket) {

--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -34,7 +34,7 @@ app.definitions.Socket = L.Class.extend({
 	},
 
 	getWebSocketBaseURI: function(map) {
-		return window.makeWsUrl('/lool/' + encodeURIComponent(map.options.doc + '?' + $.param(map.options.docParams)) + '/ws');
+		return window.makeWsUrlWopiSrc('/lool/', map.options.doc + '?' + $.param(map.options.docParams));
 	},
 
 	connect: function(socket) {
@@ -50,13 +50,8 @@ app.definitions.Socket = L.Class.extend({
 		} else if (window.ThisIsAMobileApp) {
 			// We have already opened the FakeWebSocket over in global.js
 		} else	{
-			var wopiSrc = '';
-			if (map.options.wopiSrc != '') {
-				wopiSrc = '?WOPISrc=' + map.options.wopiSrc + '&compat=/ws';
-			}
-
 			try {
-				this.socket = window.createWebSocket(this.getWebSocketBaseURI(map) + wopiSrc);
+				this.socket = window.createWebSocket(this.getWebSocketBaseURI(map));
 			} catch (e) {
 				// On IE 11 there is a limitation on the number of WebSockets open to a single domain (6 by default and can go to 128).
 				// Detect this and hint the user.

--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -490,6 +490,7 @@ app.definitions.Socket = L.Class.extend({
 				oldId = this.WSDServer.Id;
 				oldVersion = this.WSDServer.Version;
 
+				console.assert(map.options.wopiSrc === window.wopiSrc, 'wopiSrc mismatch!: ' + map.options.wopiSrc + ' != ' + window.wopiSrc);
 				// If another file is opened, we will not refresh the page.
 				if (this._map.options.previousWopiSrc && this._map.options.wopiSrc) {
 					if (this._map.options.previousWopiSrc !== this._map.options.wopiSrc)
@@ -524,7 +525,6 @@ app.definitions.Socket = L.Class.extend({
 
 			if (!window.ThisIsAMobileApp) {
 				var idUri = window.makeHttpUrl('/hosting/discovery');
-				console.assert(idUri.startsWith('http'), 'Invalid URL from makeHttpUrl: ' + idUri);
 				$('#loolwsd-id').html(_('Served by:') + ' <a target="_blank" href="' + idUri + '">' + this.WSDServer.Id + '</a>');
 			}
 
@@ -1139,6 +1139,8 @@ app.definitions.Socket = L.Class.extend({
 			this._map.options.doc = docUrl;
 			this._map.options.previousWopiSrc = this._map.options.wopiSrc; // After save-as op, we may connect to another server, then code will think that server has restarted. In this case, we don't want to reload the page (detect the file name is different).
 			this._map.options.wopiSrc = encodeURIComponent(docUrl);
+			window.wopiSrc = this._map.options.wopiSrc;
+			window.docURL = this._map.options.doc;
 
 			if (textMsg.startsWith('renamefile:')) {
 				this._map.fire('postMessage', {

--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -523,9 +523,10 @@ app.definitions.Socket = L.Class.extend({
 			}
 
 			if (!window.ThisIsAMobileApp) {
-				var idUri = this._map.options.server + this._map.options.serviceRoot + '/hosting/discovery';
-				idUri = idUri.replace(/^ws:/, 'http:');
-				idUri = idUri.replace(/^wss:/, 'https:');
+				var idUri = window.makeURL('/hosting/discovery');
+				console.assert(idUri.startsWith('http'), 'Invalid URL from makeURL: ' + idUri);
+				idUri = idUri.replace(/^ws:/, 'http:'); //TODO: Remove.
+				idUri = idUri.replace(/^wss:/, 'https:'); //TODO: Remove.
 				$('#loolwsd-id').html(_('Served by:') + ' <a target="_blank" href="' + idUri + '">' + this.WSDServer.Id + '</a>');
 			}
 

--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -523,10 +523,8 @@ app.definitions.Socket = L.Class.extend({
 			}
 
 			if (!window.ThisIsAMobileApp) {
-				var idUri = window.makeURL('/hosting/discovery');
-				console.assert(idUri.startsWith('http'), 'Invalid URL from makeURL: ' + idUri);
-				idUri = idUri.replace(/^ws:/, 'http:'); //TODO: Remove.
-				idUri = idUri.replace(/^wss:/, 'https:'); //TODO: Remove.
+				var idUri = window.makeHttpUrl('/hosting/discovery');
+				console.assert(idUri.startsWith('http'), 'Invalid URL from makeHttpUrl: ' + idUri);
 				$('#loolwsd-id').html(_('Served by:') + ' <a target="_blank" href="' + idUri + '">' + this.WSDServer.Id + '</a>');
 			}
 

--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -34,7 +34,7 @@ app.definitions.Socket = L.Class.extend({
 	},
 
 	getWebSocketBaseURI: function(map) {
-		return map.options.server + map.options.serviceRoot + '/lool/' + encodeURIComponent(map.options.doc + '?' + $.param(map.options.docParams)) + '/ws';
+		return window.host + map.options.serviceRoot + '/lool/' + encodeURIComponent(map.options.doc + '?' + $.param(map.options.docParams)) + '/ws';
 	},
 
 	connect: function(socket) {

--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -34,7 +34,7 @@ app.definitions.Socket = L.Class.extend({
 	},
 
 	getWebSocketBaseURI: function(map) {
-		return window.host + window.serviceRoot + '/lool/' + encodeURIComponent(map.options.doc + '?' + $.param(map.options.docParams)) + '/ws';
+		return window.makeWsUrl('/lool/' + encodeURIComponent(map.options.doc + '?' + $.param(map.options.docParams)) + '/ws');
 	},
 
 	connect: function(socket) {

--- a/loleaflet/src/layer/tile/TileLayer.js
+++ b/loleaflet/src/layer/tile/TileLayer.js
@@ -1127,14 +1127,8 @@ L.TileLayer = L.GridLayer.extend({
 		var parser = document.createElement('a');
 		parser.href = window.host;
 
-		var wopiSrc = '';
-		console.assert(this._map.options.wopiSrc === window.wopiSrc, 'wopiSrc mismatch!: ' + this._map.options.wopiSrc + ' != ' + window.wopiSrc);
-		if (this._map.options.wopiSrc != '') {
-			wopiSrc = '?WOPISrc=' + this._map.options.wopiSrc;
-		}
-		var url = window.makeHttpUrl('/' + this._map.options.urlPrefix + '/' +
-						encodeURIComponent(this._map.options.doc) + '/download/' +
-						command.downloadid + wopiSrc);
+		var url = window.makeHttpUrlWopiSrc('/' + this._map.options.urlPrefix + '/',
+						this._map.options.doc, '/download/' + command.downloadid);
 
 		this._map.hideBusy();
 		if (this._map['wopi'].DownloadAsPostMessage) {
@@ -1146,9 +1140,10 @@ L.TileLayer = L.GridLayer.extend({
 				// due to a pdf.js issue - https://github.com/mozilla/pdf.js/issues/5397
 				// open the pdf file in a new tab so that that user can print it directly in the browser's
 				// pdf viewer
-				var param = wopiSrc !== '' ? '&' : '?';
-				param += 'attachment=0';
-				window.open(url + param, '_blank');
+				url = window.makeHttpUrlWopiSrc('/' + this._map.options.urlPrefix + '/',
+								this._map.options.doc, '/download/' + command.downloadid,
+									'attachment=0');
+				window.open(url, '_blank');
 			}
 			else {
 				this._map.fire('filedownloadready', {url: url});

--- a/loleaflet/src/layer/tile/TileLayer.js
+++ b/loleaflet/src/layer/tile/TileLayer.js
@@ -1128,6 +1128,7 @@ L.TileLayer = L.GridLayer.extend({
 		parser.href = window.host;
 
 		var wopiSrc = '';
+		console.assert(this._map.options.wopiSrc === window.wopiSrc, 'wopiSrc mismatch!: ' + this._map.options.wopiSrc + ' != ' + window.wopiSrc);
 		if (this._map.options.wopiSrc != '') {
 			wopiSrc = '?WOPISrc=' + this._map.options.wopiSrc;
 		}

--- a/loleaflet/src/layer/tile/TileLayer.js
+++ b/loleaflet/src/layer/tile/TileLayer.js
@@ -1131,7 +1131,7 @@ L.TileLayer = L.GridLayer.extend({
 		if (this._map.options.wopiSrc != '') {
 			wopiSrc = '?WOPISrc=' + this._map.options.wopiSrc;
 		}
-		var url = window.makeURL('/' + this._map.options.urlPrefix + '/' +
+		var url = window.makeHttpUrl('/' + this._map.options.urlPrefix + '/' +
 						encodeURIComponent(this._map.options.doc) + '/download/' +
 						command.downloadid + wopiSrc);
 

--- a/loleaflet/src/layer/tile/TileLayer.js
+++ b/loleaflet/src/layer/tile/TileLayer.js
@@ -1125,7 +1125,7 @@ L.TileLayer = L.GridLayer.extend({
 	_onDownloadAsMsg: function (textMsg) {
 		var command = app.socket.parseServerCmd(textMsg);
 		var parser = document.createElement('a');
-		parser.href = this._map.options.server;
+		parser.href = window.host;
 
 		var wopiSrc = '';
 		if (this._map.options.wopiSrc != '') {

--- a/loleaflet/src/layer/tile/TileLayer.js
+++ b/loleaflet/src/layer/tile/TileLayer.js
@@ -1131,8 +1131,9 @@ L.TileLayer = L.GridLayer.extend({
 		if (this._map.options.wopiSrc != '') {
 			wopiSrc = '?WOPISrc=' + this._map.options.wopiSrc;
 		}
-		var url = this._map.options.webserver + this._map.options.serviceRoot + '/' + this._map.options.urlPrefix + '/' +
-			encodeURIComponent(this._map.options.doc) + '/download/' + command.downloadid + wopiSrc;
+		var url = window.makeURL('/' + this._map.options.urlPrefix + '/' +
+						encodeURIComponent(this._map.options.doc) + '/download/' +
+						command.downloadid + wopiSrc);
 
 		this._map.hideBusy();
 		if (this._map['wopi'].DownloadAsPostMessage) {

--- a/loleaflet/src/main.js
+++ b/loleaflet/src/main.js
@@ -1,6 +1,6 @@
 /* -*- js-indent-level: 8 -*- */
 /* global errorMessages getParameterByName accessToken accessTokenTTL accessHeader reuseCookies */
-/* global app vex host serviceRoot idleTimeoutSecs outOfFocusTimeoutSecs*/
+/* global app vex host idleTimeoutSecs outOfFocusTimeoutSecs*/
 /*eslint indent: [error, "tab", { "outerIIFEBody": 0 }]*/
 (function (global) {
 
@@ -52,7 +52,6 @@ var notWopiButIframe = getParameterByName('NotWOPIButIframe') != '';
 var map = L.map('map', {
 	server: host,
 	doc: docURL,
-	serviceRoot: serviceRoot,
 	docParams: docParams,
 	permission: permission,
 	timestamp: timestamp,

--- a/loleaflet/src/map/Clipboard.js
+++ b/loleaflet/src/map/Clipboard.js
@@ -88,7 +88,7 @@ L.Clipboard = L.Class.extend({
 	},
 
 	getMetaBase: function() {
-		return window.webserver + this._map.options.serviceRoot;
+		return window.webserver + window.serviceRoot;
 	},
 
 	getMetaPath: function(idx) {

--- a/loleaflet/src/map/Clipboard.js
+++ b/loleaflet/src/map/Clipboard.js
@@ -88,7 +88,7 @@ L.Clipboard = L.Class.extend({
 	},
 
 	getMetaBase: function() {
-		return this._map.options.webserver + this._map.options.serviceRoot;
+		return window.webserver + this._map.options.serviceRoot;
 	},
 
 	getMetaPath: function(idx) {

--- a/loleaflet/src/map/Clipboard.js
+++ b/loleaflet/src/map/Clipboard.js
@@ -88,7 +88,7 @@ L.Clipboard = L.Class.extend({
 	},
 
 	getMetaBase: function() {
-		return window.webserver + window.serviceRoot;
+		return window.makeHttpUrl('');
 	},
 
 	getMetaPath: function(idx) {

--- a/loleaflet/src/map/Map.js
+++ b/loleaflet/src/map/Map.js
@@ -109,7 +109,7 @@ L.Map = L.Evented.extend({
 
 		if (options.webserver === undefined) {
 			var protocol = window.location.protocol === 'file:' ? 'https:' : window.location.protocol;
-			options.webserver = options.server.replace(/^(ws|wss):/i, protocol);
+			options.webserver = window.host.replace(/^(ws|wss):/i, protocol);
 		}
 
 		// we are adding components like '/insertfile' at the end which would

--- a/loleaflet/src/map/Map.js
+++ b/loleaflet/src/map/Map.js
@@ -115,7 +115,8 @@ L.Map = L.Evented.extend({
 		// we are adding components like '/insertfile' at the end which would
 		// lead to URL's of the form <webserver>//insertfile/...
 		options.webserver = options.webserver.replace(/\/*$/, '');
-		window.webserver = options.webserver;
+		console.assert(options.webserver === window.webserver,
+				{ 'options.webserver': options.webserver, 'window.webserver': window.webserver });
 		/* private members */
 		this._handlers = [];
 		this._layers = {};

--- a/loleaflet/src/map/Map.js
+++ b/loleaflet/src/map/Map.js
@@ -107,16 +107,6 @@ L.Map = L.Evented.extend({
 
 		Cursor.imagePath = options.cursorURL;
 
-		if (options.webserver === undefined) {
-			var protocol = window.location.protocol === 'file:' ? 'https:' : window.location.protocol;
-			options.webserver = window.host.replace(/^(ws|wss):/i, protocol);
-		}
-
-		// we are adding components like '/insertfile' at the end which would
-		// lead to URL's of the form <webserver>//insertfile/...
-		options.webserver = options.webserver.replace(/\/*$/, '');
-		console.assert(options.webserver === window.webserver,
-				{ 'options.webserver': options.webserver, 'window.webserver': window.webserver });
 		/* private members */
 		this._handlers = [];
 		this._layers = {};

--- a/loleaflet/src/map/Map.js
+++ b/loleaflet/src/map/Map.js
@@ -115,6 +115,7 @@ L.Map = L.Evented.extend({
 		// we are adding components like '/insertfile' at the end which would
 		// lead to URL's of the form <webserver>//insertfile/...
 		options.webserver = options.webserver.replace(/\/*$/, '');
+		window.webserver = options.webserver;
 		/* private members */
 		this._handlers = [];
 		this._layers = {};

--- a/loleaflet/src/map/handler/Map.FileInserter.js
+++ b/loleaflet/src/map/handler/Map.FileInserter.js
@@ -26,7 +26,7 @@ L.Map.FileInserter = L.Handler.extend({
 		if (map.options.wopiSrc != '') {
 			wopiSrc = '?WOPISrc=' + map.options.wopiSrc;
 		}
-		return window.webserver + map.options.serviceRoot + '/' + map.options.urlPrefix +
+		return window.webserver + window.serviceRoot + '/' + map.options.urlPrefix +
 			'/' + encodeURIComponent(map.options.doc) + '/insertfile' + wopiSrc;
 	},
 

--- a/loleaflet/src/map/handler/Map.FileInserter.js
+++ b/loleaflet/src/map/handler/Map.FileInserter.js
@@ -26,7 +26,7 @@ L.Map.FileInserter = L.Handler.extend({
 		if (map.options.wopiSrc != '') {
 			wopiSrc = '?WOPISrc=' + map.options.wopiSrc;
 		}
-		return map.options.webserver + map.options.serviceRoot + '/' + map.options.urlPrefix +
+		return window.webserver + map.options.serviceRoot + '/' + map.options.urlPrefix +
 			'/' + encodeURIComponent(map.options.doc) + '/insertfile' + wopiSrc;
 	},
 

--- a/loleaflet/src/map/handler/Map.FileInserter.js
+++ b/loleaflet/src/map/handler/Map.FileInserter.js
@@ -18,7 +18,7 @@ L.Map.FileInserter = L.Handler.extend({
 		this._toInsertURL = {};
 		this._toInsertBackground = {};
 		var parser = document.createElement('a');
-		parser.href = map.options.server;
+		parser.href = window.host;
 	},
 
 	getWopiUrl: function (map) {

--- a/loleaflet/src/map/handler/Map.FileInserter.js
+++ b/loleaflet/src/map/handler/Map.FileInserter.js
@@ -22,13 +22,7 @@ L.Map.FileInserter = L.Handler.extend({
 	},
 
 	getWopiUrl: function (map) {
-		var wopiSrc = '';
-		console.assert(map.options.wopiSrc === window.wopiSrc, 'wopiSrc mismatch!: ' + map.options.wopiSrc + ' != ' + window.wopiSrc);
-		if (map.options.wopiSrc != '') {
-			wopiSrc = '?WOPISrc=' + map.options.wopiSrc;
-		}
-		return window.makeHttpUrl('/' + map.options.urlPrefix +
-			'/' + encodeURIComponent(map.options.doc) + '/insertfile' + wopiSrc);
+		return window.makeHttpUrlWopiSrc('/' + map.options.urlPrefix + '/', map.options.doc, '/insertfile');
 	},
 
 	addHooks: function () {

--- a/loleaflet/src/map/handler/Map.FileInserter.js
+++ b/loleaflet/src/map/handler/Map.FileInserter.js
@@ -23,6 +23,7 @@ L.Map.FileInserter = L.Handler.extend({
 
 	getWopiUrl: function (map) {
 		var wopiSrc = '';
+		console.assert(map.options.wopiSrc === window.wopiSrc, 'wopiSrc mismatch!: ' + map.options.wopiSrc + ' != ' + window.wopiSrc);
 		if (map.options.wopiSrc != '') {
 			wopiSrc = '?WOPISrc=' + map.options.wopiSrc;
 		}

--- a/loleaflet/src/map/handler/Map.FileInserter.js
+++ b/loleaflet/src/map/handler/Map.FileInserter.js
@@ -26,8 +26,8 @@ L.Map.FileInserter = L.Handler.extend({
 		if (map.options.wopiSrc != '') {
 			wopiSrc = '?WOPISrc=' + map.options.wopiSrc;
 		}
-		return window.webserver + window.serviceRoot + '/' + map.options.urlPrefix +
-			'/' + encodeURIComponent(map.options.doc) + '/insertfile' + wopiSrc;
+		return window.makeHttpUrl('/' + map.options.urlPrefix +
+			'/' + encodeURIComponent(map.options.doc) + '/insertfile' + wopiSrc);
 	},
 
 	addHooks: function () {

--- a/loolwsd.xml.in
+++ b/loolwsd.xml.in
@@ -15,6 +15,7 @@
 
     <server_name desc="External hostname:port of the server running loolwsd. If empty, it's derived from the request (please set it if this doesn't work). Must be specified when behind a reverse-proxy or when the hostname is not reachable directly." type="string" default=""></server_name>
     <file_server_root_path desc="Path to the directory that should be considered root for the file server. This should be the directory containing loleaflet." type="path" relative="true" default="loleaflet/../"></file_server_root_path>
+    <hexify_embedded_urls desc="Enable to protect encoded URLs from getting decoded by intermediate hops. Particularly useful on Azure deployments" type="bool" default="false"></hexify_embedded_urls>
 
     <memproportion desc="The maximum percentage of system memory consumed by all of the @APP_NAME@, after which we start cleaning up idle documents" type="double" default="80.0"></memproportion>
     <num_prespawn_children desc="Number of child processes to keep started in advance and waiting for new clients." type="uint" default="1">1</num_prespawn_children>

--- a/net/HttpRequest.cpp
+++ b/net/HttpRequest.cpp
@@ -17,6 +17,7 @@
 #include <fstream>
 #include <memory>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <sys/types.h>
 #include <netdb.h>
@@ -650,7 +651,7 @@ std::shared_ptr<Session> Session::create(std::string host, Protocol protocol, in
     if (!net::parseUri(host, scheme, hostname, portString))
     {
         LOG_ERR("Invalid URI [" << host << "] to http::Session::create.");
-        return nullptr;
+        throw std::runtime_error("Invalid URI [" + host + "] to http::Session::create.");
     }
 
     scheme = Util::toLower(std::move(scheme));

--- a/test/HttpRequestTests.cpp
+++ b/test/HttpRequestTests.cpp
@@ -159,8 +159,16 @@ constexpr std::chrono::seconds HttpRequestTests::DefTimeoutSeconds;
 
 void HttpRequestTests::testInvalidURI()
 {
-    // Cannot create from a blank URI.
-    LOK_ASSERT(http::Session::createHttp(std::string()) == nullptr);
+    try
+    {
+        // Cannot create from a blank URI.
+        http::Session::createHttp(std::string());
+        LOK_ASSERT_FAIL("Exception expected from http::Session::createHttp for invalid URI");
+    }
+    catch (const std::exception& ex)
+    {
+        // Pass.
+    }
 }
 
 void HttpRequestTests::testSimpleGet()

--- a/test/WhiteBoxTests.cpp
+++ b/test/WhiteBoxTests.cpp
@@ -7,6 +7,8 @@
 
 #include <config.h>
 
+#include <cppunit/TestAssert.h>
+#include <cstddef>
 #include <test/lokassert.hpp>
 
 #include <Auth.hpp>
@@ -55,6 +57,7 @@ class WhiteBoxTests : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST(testTime);
     CPPUNIT_TEST(testBufferClass);
     CPPUNIT_TEST(testStringVector);
+    CPPUNIT_TEST(testHexify);
     CPPUNIT_TEST(testRequestDetails_DownloadURI);
     CPPUNIT_TEST(testRequestDetails_loleafletURI);
     CPPUNIT_TEST(testRequestDetails_local);
@@ -89,6 +92,7 @@ class WhiteBoxTests : public CPPUNIT_NS::TestFixture
     void testTime();
     void testBufferClass();
     void testStringVector();
+    void testHexify();
     void testRequestDetails_DownloadURI();
     void testRequestDetails_loleafletURI();
     void testRequestDetails_local();
@@ -1181,6 +1185,27 @@ void WhiteBoxTests::testStringVector()
         CPPUNIT_ASSERT(tokens.getNameIntegerPair(2, name, value));
         CPPUNIT_ASSERT_EQUAL(std::string("a"), name);
         CPPUNIT_ASSERT_EQUAL(11, value);
+    }
+}
+
+void WhiteBoxTests::testHexify()
+{
+    const std::string s1 = "some ascii text with !@#$%^&*()_+/-\\|";
+    const auto hex = Util::dataToHexString(s1, 0, s1.size());
+    std::string decoded;
+    CPPUNIT_ASSERT(Util::dataFromHexString(hex, decoded));
+    CPPUNIT_ASSERT_EQUAL(s1, decoded);
+
+    for (std::size_t randStrLen = 1; randStrLen < 129; ++randStrLen)
+    {
+        const auto s2 = Util::rng::getBytes(randStrLen);
+        CPPUNIT_ASSERT_EQUAL(randStrLen, s2.size());
+        const auto hex2 = Util::dataToHexString(s2, 0, s2.size());
+        CPPUNIT_ASSERT_EQUAL(randStrLen * 2, hex2.size());
+        std::vector<char> decoded2;
+        CPPUNIT_ASSERT(Util::dataFromHexString(hex2, decoded2));
+        CPPUNIT_ASSERT_EQUAL(randStrLen, decoded2.size());
+        CPPUNIT_ASSERT_EQUAL(s2, decoded2);
     }
 }
 

--- a/test/WhiteBoxTests.cpp
+++ b/test/WhiteBoxTests.cpp
@@ -1472,7 +1472,7 @@ void WhiteBoxTests::testRequestDetails_local_hexified()
         LOK_ASSERT_EQUAL(static_cast<std::size_t>(6), details.size());
         LOK_ASSERT_EQUAL(std::string("lool"), details[0]);
         LOK_ASSERT(details.equals(0, "lool"));
-        LOK_ASSERT_EQUAL(fileUrlHex, details[1]);
+        LOK_ASSERT_EQUAL(fileUrl, details[1]);
         LOK_ASSERT_EQUAL(std::string("ws"), details[2]);
         LOK_ASSERT_EQUAL(std::string("open"), details[3]);
         LOK_ASSERT_EQUAL(std::string("open"), details[4]);
@@ -1511,7 +1511,7 @@ void WhiteBoxTests::testRequestDetails_local_hexified()
         LOK_ASSERT_EQUAL(static_cast<std::size_t>(5), details.size());
         LOK_ASSERT_EQUAL(std::string("lool"), details[0]);
         LOK_ASSERT(details.equals(0, "lool"));
-        LOK_ASSERT_EQUAL(fileUrlHex, details[1]);
+        LOK_ASSERT_EQUAL(fileUrl, details[1]);
         LOK_ASSERT_EQUAL(std::string("ws"), details[2]);
         LOK_ASSERT_EQUAL(std::string("write"), details[3]); // SessionId, since the real SessionId is blank.
         LOK_ASSERT_EQUAL(std::string("2"), details[4]); // Command, since SessionId was blank.
@@ -1549,7 +1549,7 @@ void WhiteBoxTests::testRequestDetails_local_hexified()
         LOK_ASSERT_EQUAL(static_cast<std::size_t>(5), details.size());
         LOK_ASSERT_EQUAL(std::string("lool"), details[0]);
         LOK_ASSERT(details.equals(0, "lool"));
-        LOK_ASSERT_EQUAL(fileUrlHex, details[1]);
+        LOK_ASSERT_EQUAL(fileUrl, details[1]);
         LOK_ASSERT_EQUAL(std::string("ws"), details[2]);
         LOK_ASSERT_EQUAL(std::string("write"), details[3]); // SessionId, since the real SessionId is blank.
         LOK_ASSERT_EQUAL(std::string("2"), details[4]); // Command, since SessionId was blank.

--- a/test/WhiteBoxTests.cpp
+++ b/test/WhiteBoxTests.cpp
@@ -61,6 +61,7 @@ class WhiteBoxTests : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST(testRequestDetails_DownloadURI);
     CPPUNIT_TEST(testRequestDetails_loleafletURI);
     CPPUNIT_TEST(testRequestDetails_local);
+    CPPUNIT_TEST(testRequestDetails_local_hexified);
     CPPUNIT_TEST(testRequestDetails);
     CPPUNIT_TEST(testUIDefaults);
     CPPUNIT_TEST(testCSSVars);
@@ -96,6 +97,7 @@ class WhiteBoxTests : public CPPUNIT_NS::TestFixture
     void testRequestDetails_DownloadURI();
     void testRequestDetails_loleafletURI();
     void testRequestDetails_local();
+    void testRequestDetails_local_hexified();
     void testRequestDetails();
     void testUIDefaults();
     void testCSSVars();
@@ -1419,6 +1421,135 @@ void WhiteBoxTests::testRequestDetails_local()
             std::string(
                 "file%3A%2F%2F%2Fhome%2Fash%2Fprj%2Flo%2Fonline%2Ftest%2Fdata%2Fhello-world.odt"),
             details[1]);
+        LOK_ASSERT_EQUAL(std::string("ws"), details[2]);
+        LOK_ASSERT_EQUAL(std::string("write"), details[3]); // SessionId, since the real SessionId is blank.
+        LOK_ASSERT_EQUAL(std::string("2"), details[4]); // Command, since SessionId was blank.
+
+        LOK_ASSERT_EQUAL(std::string("lool"), details.getField(RequestDetails::Field::Type));
+        LOK_ASSERT(details.equals(RequestDetails::Field::Type, "lool"));
+        LOK_ASSERT_EQUAL(std::string("write"), details.getField(RequestDetails::Field::SessionId));
+        LOK_ASSERT(details.equals(RequestDetails::Field::SessionId, "write"));
+        LOK_ASSERT_EQUAL(std::string("2"), details.getField(RequestDetails::Field::Command));
+        LOK_ASSERT(details.equals(RequestDetails::Field::Command, "2"));
+        LOK_ASSERT_EQUAL(std::string(""), details.getField(RequestDetails::Field::Serial));
+        LOK_ASSERT(details.equals(RequestDetails::Field::Serial, ""));
+    }
+}
+
+void WhiteBoxTests::testRequestDetails_local_hexified()
+{
+    static const std::string Root = "localhost:9980";
+
+    static const std::string ProxyPrefix
+        = "http://localhost/nextcloud/apps/richdocuments/proxy.php?req=";
+
+    static const std::string docUri = "file:///home/ash/prj/lo/online/test/data/hello-world.odt";
+    static const std::string fileUrl =
+        "file%3A%2F%2F%2Fhome%2Fash%2Fprj%2Flo%2Fonline%2Ftest%2Fdata%2Fhello-world.odt";
+
+    const std::string fileUrlHex = "0x" + Util::dataToHexString(fileUrl, 0, fileUrl.size());
+
+    {
+        const std::string URI = "/lool/" + fileUrlHex + "/ws/open/open/0";
+
+        Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, URI,
+                                       Poco::Net::HTTPMessage::HTTP_1_1);
+        request.setHost(Root);
+        request.set("User-Agent", WOPI_AGENT_STRING);
+        request.set("ProxyPrefix", ProxyPrefix);
+
+        RequestDetails details(request, "");
+        LOK_ASSERT_EQUAL(true, details.isProxy());
+        LOK_ASSERT_EQUAL(ProxyPrefix, details.getProxyPrefix());
+
+        LOK_ASSERT_EQUAL(Root, details.getHostUntrusted());
+        LOK_ASSERT_EQUAL(false, details.isWebSocket());
+        LOK_ASSERT_EQUAL(true, details.isGet());
+
+        LOK_ASSERT_EQUAL(docUri, details.getLegacyDocumentURI());
+        LOK_ASSERT_EQUAL(docUri, details.getDocumentURI());
+
+        LOK_ASSERT_EQUAL(static_cast<std::size_t>(6), details.size());
+        LOK_ASSERT_EQUAL(std::string("lool"), details[0]);
+        LOK_ASSERT(details.equals(0, "lool"));
+        LOK_ASSERT_EQUAL(fileUrlHex, details[1]);
+        LOK_ASSERT_EQUAL(std::string("ws"), details[2]);
+        LOK_ASSERT_EQUAL(std::string("open"), details[3]);
+        LOK_ASSERT_EQUAL(std::string("open"), details[4]);
+        LOK_ASSERT_EQUAL(std::string("0"), details[5]);
+
+        LOK_ASSERT_EQUAL(std::string("lool"), details.getField(RequestDetails::Field::Type));
+        LOK_ASSERT(details.equals(RequestDetails::Field::Type, "lool"));
+        LOK_ASSERT_EQUAL(std::string("open"), details.getField(RequestDetails::Field::SessionId));
+        LOK_ASSERT(details.equals(RequestDetails::Field::SessionId, "open"));
+        LOK_ASSERT_EQUAL(std::string("open"), details.getField(RequestDetails::Field::Command));
+        LOK_ASSERT(details.equals(RequestDetails::Field::Command, "open"));
+        LOK_ASSERT_EQUAL(std::string("0"), details.getField(RequestDetails::Field::Serial));
+        LOK_ASSERT(details.equals(RequestDetails::Field::Serial, "0"));
+    }
+
+    {
+        // Blank entries are skipped.
+        static const std::string URI = "/lool/" + fileUrlHex + "/ws//write/2";
+
+        Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, URI,
+                                       Poco::Net::HTTPMessage::HTTP_1_1);
+        request.setHost(Root);
+        request.set("User-Agent", WOPI_AGENT_STRING);
+        request.set("ProxyPrefix", ProxyPrefix);
+
+        RequestDetails details(request, "");
+        LOK_ASSERT_EQUAL(true, details.isProxy());
+        LOK_ASSERT_EQUAL(ProxyPrefix, details.getProxyPrefix());
+
+        LOK_ASSERT_EQUAL(Root, details.getHostUntrusted());
+        LOK_ASSERT_EQUAL(false, details.isWebSocket());
+        LOK_ASSERT_EQUAL(true, details.isGet());
+
+        LOK_ASSERT_EQUAL(docUri, details.getDocumentURI());
+
+        LOK_ASSERT_EQUAL(static_cast<std::size_t>(5), details.size());
+        LOK_ASSERT_EQUAL(std::string("lool"), details[0]);
+        LOK_ASSERT(details.equals(0, "lool"));
+        LOK_ASSERT_EQUAL(fileUrlHex, details[1]);
+        LOK_ASSERT_EQUAL(std::string("ws"), details[2]);
+        LOK_ASSERT_EQUAL(std::string("write"), details[3]); // SessionId, since the real SessionId is blank.
+        LOK_ASSERT_EQUAL(std::string("2"), details[4]); // Command, since SessionId was blank.
+
+        LOK_ASSERT_EQUAL(std::string("lool"), details.getField(RequestDetails::Field::Type));
+        LOK_ASSERT(details.equals(RequestDetails::Field::Type, "lool"));
+        LOK_ASSERT_EQUAL(std::string("write"), details.getField(RequestDetails::Field::SessionId));
+        LOK_ASSERT(details.equals(RequestDetails::Field::SessionId, "write"));
+        LOK_ASSERT_EQUAL(std::string("2"), details.getField(RequestDetails::Field::Command));
+        LOK_ASSERT(details.equals(RequestDetails::Field::Command, "2"));
+        LOK_ASSERT_EQUAL(std::string(""), details.getField(RequestDetails::Field::Serial));
+        LOK_ASSERT(details.equals(RequestDetails::Field::Serial, ""));
+    }
+
+    {
+        // Apparently, the initial / can be missing -- all the tests do that.
+        static const std::string URI = "lool/" + fileUrlHex + "/ws//write/2";
+
+        Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, URI,
+                                       Poco::Net::HTTPMessage::HTTP_1_1);
+        request.setHost(Root);
+        request.set("User-Agent", WOPI_AGENT_STRING);
+        request.set("ProxyPrefix", ProxyPrefix);
+
+        RequestDetails details(request, "");
+        LOK_ASSERT_EQUAL(true, details.isProxy());
+        LOK_ASSERT_EQUAL(ProxyPrefix, details.getProxyPrefix());
+
+        LOK_ASSERT_EQUAL(Root, details.getHostUntrusted());
+        LOK_ASSERT_EQUAL(false, details.isWebSocket());
+        LOK_ASSERT_EQUAL(true, details.isGet());
+
+        LOK_ASSERT_EQUAL(docUri, details.getDocumentURI());
+
+        LOK_ASSERT_EQUAL(static_cast<std::size_t>(5), details.size());
+        LOK_ASSERT_EQUAL(std::string("lool"), details[0]);
+        LOK_ASSERT(details.equals(0, "lool"));
+        LOK_ASSERT_EQUAL(fileUrlHex, details[1]);
         LOK_ASSERT_EQUAL(std::string("ws"), details[2]);
         LOK_ASSERT_EQUAL(std::string("write"), details[3]); // SessionId, since the real SessionId is blank.
         LOK_ASSERT_EQUAL(std::string("2"), details[4]); // Command, since SessionId was blank.

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -722,6 +722,7 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     Poco::replaceInPlace(preprocess, std::string("%ACCESS_TOKEN_TTL%"), std::to_string(tokenTtl));
     Poco::replaceInPlace(preprocess, std::string("%ACCESS_HEADER%"), escapedAccessHeader);
     Poco::replaceInPlace(preprocess, std::string("%HOST%"), cnxDetails.getWebSocketUrl());
+    Poco::replaceInPlace(preprocess, std::string("%HEXIFY_URL%"), std::string("false"));
     Poco::replaceInPlace(preprocess, std::string("%VERSION%"), std::string(LOOLWSD_VERSION_HASH));
     Poco::replaceInPlace(preprocess, std::string("%SERVICE_ROOT%"), responseRoot);
     Poco::replaceInPlace(preprocess, std::string("%UI_DEFAULTS%"), uiDefaultsToJSON(uiDefaults, userInterfaceMode));

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -722,7 +722,6 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     Poco::replaceInPlace(preprocess, std::string("%ACCESS_TOKEN_TTL%"), std::to_string(tokenTtl));
     Poco::replaceInPlace(preprocess, std::string("%ACCESS_HEADER%"), escapedAccessHeader);
     Poco::replaceInPlace(preprocess, std::string("%HOST%"), cnxDetails.getWebSocketUrl());
-    Poco::replaceInPlace(preprocess, std::string("%HEXIFY_URL%"), std::string("false"));
     Poco::replaceInPlace(preprocess, std::string("%VERSION%"), std::string(LOOLWSD_VERSION_HASH));
     Poco::replaceInPlace(preprocess, std::string("%SERVICE_ROOT%"), responseRoot);
     Poco::replaceInPlace(preprocess, std::string("%UI_DEFAULTS%"), uiDefaultsToJSON(uiDefaults, userInterfaceMode));
@@ -732,6 +731,10 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     if (config.getBool("logging.protocol"))
         protocolDebug = "true";
     Poco::replaceInPlace(preprocess, std::string("%PROTOCOL_DEBUG%"), protocolDebug);
+
+    static const std::string hexifyEmbeddedUrls =
+        LOOLWSD::getConfigValue<bool>("hexify_embedded_urls", false) ? "true" : "false";
+    Poco::replaceInPlace(preprocess, std::string("%HEXIFY_URL%"), hexifyEmbeddedUrls);
 
     static const std::string linkCSS("<link rel=\"stylesheet\" href=\"%s/loleaflet/" LOOLWSD_VERSION_HASH "/%s.css\">");
     static const std::string scriptJS("<script src=\"%s/loleaflet/" LOOLWSD_VERSION_HASH "/%s.js\"></script>");

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -945,6 +945,7 @@ void LOOLWSD::initialize(Application& self)
             { "admin_console.enable_pam", "false" },
             { "child_root_path", "jails" },
             { "file_server_root_path", "loleaflet/.." },
+            { "hexify_embedded_urls", "false" },
             { "lo_jail_subpath", "lo" },
             { "logging.protocol", "false" },
             { "logging.anonymize.filenames", "false" }, // Deprecated.

--- a/wsd/RequestDetails.cpp
+++ b/wsd/RequestDetails.cpp
@@ -140,6 +140,17 @@ void RequestDetails::processURI()
     _fields[Field::Type] = _uriString.substr(off, posDocUri - off); // The first is always the type.
     std::string uriRes = _uriString.substr(posDocUri + 1);
 
+    // Decode hexified component, if any.
+    if (Util::startsWith(uriRes, "0x"))
+    {
+        // Find the end.
+        const auto end = uriRes.find_first_of('/');
+
+        std::string encoded;
+        Util::dataFromHexString(uriRes.substr(2, end - 2), encoded);
+        uriRes = encoded + uriRes.substr(end); // Reconstruct.
+    }
+
     const auto posLastWS = uriRes.rfind("/ws");
     // DocumentURI is the second segment in lool URIs.
     if (_pathSegs.equals(0, "lool"))

--- a/wsd/RequestDetails.cpp
+++ b/wsd/RequestDetails.cpp
@@ -7,6 +7,7 @@
 
 #include <config.h>
 
+#include "LOOLWSD.hpp"
 #include "RequestDetails.hpp"
 #include "common/Log.hpp"
 
@@ -72,6 +73,7 @@ RequestDetails::RequestDetails(Poco::Net::HTTPRequest &request, const std::strin
 
     // re-writes ServiceRoot out of request
     _uriString = request.getURI().substr(serviceRoot.length());
+    dehexify();
     request.setURI(_uriString);
     const std::string &method = request.getMethod();
     _isGet = method == "GET";
@@ -99,8 +101,36 @@ RequestDetails::RequestDetails(const std::string &mobileURI)
 {
     _isMobile = true;
     _uriString = mobileURI;
-
+    dehexify();
     processURI();
+}
+
+void RequestDetails::dehexify()
+{
+    // For now, we only hexify lool/ URLs.
+    constexpr auto Prefix = "lool/0x";
+    constexpr auto PrefixLen = sizeof(Prefix) - 1;
+
+    const auto hexPos = _uriString.find(Prefix);
+    if (hexPos != std::string::npos)
+    {
+        // The start of the hex token.
+        const auto start = hexPos + PrefixLen;
+        // Find the next '/' after the hex token.
+        const auto end = _uriString.find_first_of('/', start);
+
+        std::string res = _uriString.substr(0, start - 2); // The prefix, without '0x'.
+
+        const std::string encoded =
+            _uriString.substr(start, (end == std::string::npos) ? end : end - start);
+        std::string decoded;
+        Util::dataFromHexString(encoded, decoded);
+        res += decoded;
+
+        res += _uriString.substr(end); // Concatinate the remainder.
+
+        _uriString = res; // Replace the original uri with the decoded one.
+    }
 }
 
 void RequestDetails::processURI()
@@ -139,17 +169,6 @@ void RequestDetails::processURI()
 
     _fields[Field::Type] = _uriString.substr(off, posDocUri - off); // The first is always the type.
     std::string uriRes = _uriString.substr(posDocUri + 1);
-
-    // Decode hexified component, if any.
-    if (Util::startsWith(uriRes, "0x"))
-    {
-        // Find the end.
-        const auto end = uriRes.find_first_of('/');
-
-        std::string encoded;
-        Util::dataFromHexString(uriRes.substr(2, end - 2), encoded);
-        uriRes = encoded + uriRes.substr(end); // Reconstruct.
-    }
 
     const auto posLastWS = uriRes.rfind("/ws");
     // DocumentURI is the second segment in lool URIs.

--- a/wsd/RequestDetails.hpp
+++ b/wsd/RequestDetails.hpp
@@ -122,6 +122,7 @@ private:
     std::map<Field, std::string> _fields;
     std::map<std::string, std::string> _docUriParams;
 
+    void dehexify();
     void processURI();
 
 public:

--- a/wsd/RequestDetails.hpp
+++ b/wsd/RequestDetails.hpp
@@ -85,6 +85,9 @@
  *       |--------documentURI---------|            |-------WOPISrc------|        |--------------compat--------------|
  *                            |options|                                               |sessionId| |command| |serial|
  *       |---------------------------LegacyDocumentURI---------------------------|
+ *
+ * Alternatively, the LegacyDocumentURI (encoded) could be hexified, as follows:
+ * /lool/0x123456789/ws?WOPISrc=<encoded-document-URI>&compat=/ws[/<sessionId>/<command>/<serial>]
  */
 class RequestDetails
 {


### PR DESCRIPTION
This resolves #3086 and #3084.

- wsd: hexifying helpers and tests
- wsd: hexified URL support
- leaflet: move url manipulation to helper
- leaflet: support hexifying the body of the lool URI
- leaflet: replicate options.webserver in window.webserver
- leaflet: move map.options.server to window.host
- leaflet: move map.options.webserver to window.webserver
- leaflet: move map.options.serviceRoot to window.serviceRoot
- leaflet: makeURL -> makeHttpUrl
- leaflet: makeWsUrl
- wsd: configuration setting to control embedded-url hexifying
- wsd: throw when an invalid URL is used to create an http session
- leaflet: move wopiSrc into window and central URL maker
- wsd: improved dehexifying of URLs
- leaflet: centralize wopiSrc URL forming
