### PR TITLE
Implemented an option to pass PostMessageOrigin

### DIFF
--- a/loleaflet/html/loleaflet.html.m4
+++ b/loleaflet/html/loleaflet.html.m4
@@ -264,6 +264,7 @@ m4_ifelse(MOBILEAPP,[true],
       window.accessToken = '';
       window.accessTokenTTL = '';
       window.accessHeader = '';
+      window.postMessageOriginExt = '';
       window.loleafletLogging = 'true';
       window.enableWelcomeMessage = false;
       window.enableWelcomeMessageButton = false;
@@ -281,6 +282,7 @@ m4_ifelse(MOBILEAPP,[true],
       window.accessToken = '%ACCESS_TOKEN%';
       window.accessTokenTTL = '%ACCESS_TOKEN_TTL%';
       window.accessHeader = '%ACCESS_HEADER%';
+      window.postMessageOriginExt = '%POSTMESSAGE_ORIGIN%';
       window.loleafletLogging = '%LOLEAFLET_LOGGING%';
       window.enableWelcomeMessage = %ENABLE_WELCOME_MSG%;
       window.enableWelcomeMessageButton = %ENABLE_WELCOME_MSG_BTN%;

--- a/loleaflet/src/map/handler/Map.WOPI.js
+++ b/loleaflet/src/map/handler/Map.WOPI.js
@@ -8,7 +8,7 @@ L.Map.WOPI = L.Handler.extend({
 	// If the CheckFileInfo call fails on server side, we won't have any PostMessageOrigin.
 	// So use '*' because we still needs to send 'close' message to the parent frame which
 	// wouldn't be possible otherwise.
-	PostMessageOrigin: '*',
+	PostMessageOrigin: window.postmessageOriginExt || '*',
 	BaseFileName: '',
 	BreadcrumbDocName: '',
 	DocumentLoadedTime: false,

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -672,13 +672,15 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     LOG_TRC("ui_defaults=" << uiDefaults);
     const std::string cssVars = form.get("css_variables", "");
     LOG_TRC("css_variables=" << cssVars);
-
+    const std::string postMessageOrigin = form.get("postmessage_origin", "");
+    LOG_TRC("postmessage_origin" << postMessageOrigin);
     // Escape bad characters in access token.
     // This is placed directly in javascript in loleaflet.html, we need to make sure
     // that no one can do anything nasty with their clever inputs.
-    std::string escapedAccessToken, escapedAccessHeader;
+    std::string escapedAccessToken, escapedAccessHeader, escapedPostmessageOrigin;
     Poco::URI::encode(accessToken, "'", escapedAccessToken);
     Poco::URI::encode(accessHeader, "'", escapedAccessHeader);
+    Poco::URI::encode(postMessageOrigin, "'", escapedPostmessageOrigin);
 
     unsigned long tokenTtl = 0;
     if (!accessToken.empty())
@@ -715,6 +717,7 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     Poco::replaceInPlace(preprocess, std::string("%VERSION%"), std::string(LOOLWSD_VERSION_HASH));
     Poco::replaceInPlace(preprocess, std::string("%SERVICE_ROOT%"), responseRoot);
     Poco::replaceInPlace(preprocess, std::string("%UI_DEFAULTS%"), uiDefaultsToJSON(uiDefaults, userInterfaceMode));
+    Poco::replaceInPlace(preprocess, std::string("%POSTMESSAGE_ORIGIN%"), escapedPostmessageOrigin);
 
     const auto& config = Application::instance().config();
     std::string protocolDebug = "false";


### PR DESCRIPTION
External apps load loolwsd inside the iframe
and loolwsd makes postmessages to parent window.
We receive the postMessageOrigin from checkfileInfo yet
we still send some messages before we even go to the WOPI Api
in that case, if parent window runs on a different domain, we
end up with CORS blocking by the browser. To prevent that we can
allow safely passing the origin inside the first post like access_token
and sanitize it with Poco::URI::encode.

Signed-off-by: Mert Tumer <mert.tumer@collabora.com>
Change-Id: I5724f2d103603a599d45b7f61da81fb30834ef0e


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

