### PR TITLE
kit: fix build

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -2935,13 +2935,8 @@ void ChildSession::loKitCallback(const int type, const std::string& payload)
     case LOK_CALLBACK_INVALIDATE_SHEET_GEOMETRY:
         sendTextFrame("invalidatesheetgeometry: " + payload);
         break;
-
-#if !ENABLE_DEBUG
-    // we want a compilation-time failure in the debug builds; but ERR in the
-    // log in the release ones
     default:
         LOG_ERR("Unknown callback event (" << lokCallbackTypeToString(type) << "): " << payload);
-#endif
     }
 }
 


### PR DESCRIPTION
When building against core.git master:

kit/ChildSession.cpp:2668:13: error: enumeration value 'LOK_CALLBACK_SC_FOLLOW_JUMP' not handled in switch [-Werror,-Wswitch]

It's not clear how we want to handle this in Online, so have a default
label in debug builds as well.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Ia0b1cef33e8a5a7fbc1518586ea1e3bb13aa5f22
