### PR TITLE
Make some temporary debug output use speech synthesis instead of NSLog()

### DIFF
--- a/ios/Mobile.xcodeproj/project.pbxproj
+++ b/ios/Mobile.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		BE5EB5DC2140480B00E0826C /* ICU.dat in Resources */ = {isa = PBXBuildFile; fileRef = BE5EB5DB2140480B00E0826C /* ICU.dat */; };
 		BE6362C22153B5B500F4237E /* CoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BE6362C12153B5B500F4237E /* CoreServices.framework */; };
 		BE7228E22417BC9F000ADABD /* StringVector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BE7228E02417BC9F000ADABD /* StringVector.cpp */; };
+		BE7B6A0326E62C1800517092 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BE7B6A0226E62C1800517092 /* AVFoundation.framework */; };
 		BE7D6A6B23FAA8B500C2E605 /* loolkitconfig.xcu in Resources */ = {isa = PBXBuildFile; fileRef = BE7D6A6A23FAA8B500C2E605 /* loolkitconfig.xcu */; };
 		BE80E43221AD92F700859C97 /* Fonts in Resources */ = {isa = PBXBuildFile; fileRef = BE80E43121AD92F600859C97 /* Fonts */; };
 		BE80E45821B68F5700859C97 /* TemplateCollectionViewController.mm in Sources */ = {isa = PBXBuildFile; fileRef = BE80E45721B68F5700859C97 /* TemplateCollectionViewController.mm */; };
@@ -604,6 +605,7 @@
 		BE6C48672524A19C0066A166 /* vclxdevice.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = vclxdevice.cxx; path = "../../ios-device/toolkit/source/awt/vclxdevice.cxx"; sourceTree = "<group>"; };
 		BE7228E02417BC9F000ADABD /* StringVector.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StringVector.cpp; sourceTree = "<group>"; };
 		BE7228E12417BC9F000ADABD /* StringVector.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = StringVector.hpp; sourceTree = "<group>"; };
+		BE7B6A0226E62C1800517092 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
 		BE7D6A2123FA9C2300C2E605 /* winreg.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = winreg.cxx; path = "../../ios-device/configmgr/source/winreg.cxx"; sourceTree = "<group>"; };
 		BE7D6A2223FA9C2300C2E605 /* propertynode.hxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; name = propertynode.hxx; path = "../../ios-device/configmgr/source/propertynode.hxx"; sourceTree = "<group>"; };
 		BE7D6A2323FA9C2300C2E605 /* childaccess.hxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; name = childaccess.hxx; path = "../../ios-device/configmgr/source/childaccess.hxx"; sourceTree = "<group>"; };
@@ -1491,6 +1493,7 @@
 			files = (
 				BE512CBA2518DE6E00921C15 /* libsqlite3.tbd in Frameworks */,
 				BE6362C22153B5B500F4237E /* CoreServices.framework in Frameworks */,
+				BE7B6A0326E62C1800517092 /* AVFoundation.framework in Frameworks */,
 				BEA2835A21470A1C00848631 /* WebKit.framework in Frameworks */,
 				BE00F8B7213ED573001CE2D4 /* libz.tbd in Frameworks */,
 				BE00F8B5213ED543001CE2D4 /* libiconv.tbd in Frameworks */,
@@ -1534,6 +1537,7 @@
 		BE00F8B3213ED542001CE2D4 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				BE7B6A0226E62C1800517092 /* AVFoundation.framework */,
 				BE512CB92518DE6400921C15 /* libsqlite3.tbd */,
 				BE6362C12153B5B500F4237E /* CoreServices.framework */,
 				BEA2835921470A1C00848631 /* WebKit.framework */,

--- a/ios/Mobile/AppDelegate.h
+++ b/ios/Mobile/AppDelegate.h
@@ -4,6 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#import <AVFAudio/AVFAudio.h>
 #import <UIKit/UIKit.h>
 
 #import <LibreOfficeKit/LibreOfficeKit.h>
@@ -15,6 +16,8 @@
 @end
 
 extern NSString *app_locale;
+
+extern AVSpeechSynthesizer *speechSynthesizer;
 
 // vim:set shiftwidth=4 softtabstop=4 expandtab:
 

--- a/ios/Mobile/AppDelegate.mm
+++ b/ios/Mobile/AppDelegate.mm
@@ -31,6 +31,8 @@
 
 NSString *app_locale;
 
+AVSpeechSynthesizer *speechSynthesizer;
+
 static void download(NSURL *source, NSURL *destination) {
     [[[NSURLSession sharedSession] downloadTaskWithURL:source
                                      completionHandler:^(NSURL *location, NSURLResponse *response, NSError *error) {
@@ -232,6 +234,8 @@ static void updateTemplates(NSData *data, NSURLResponse *response)
         app_locale = [NSString stringWithUTF8String:lang];
     else
         app_locale = [[NSLocale preferredLanguages] firstObject];
+
+    speechSynthesizer = [[AVSpeechSynthesizer alloc] init];
 
     lo_kit = lok_init_2(nullptr, nullptr);
 


### PR DESCRIPTION
As a debugging aid, use iOS speech synthesis to speak the amount of
disk space used by the app and its data. This is to help trace spae
wasted by leaked tile bmp files. (Sure, sure, the leaks should be
fixed.)

But it is still normally inside #if 0. Will have to figure out some
way for the user to turn it on at will. For instance by creating a
document with some very specific name. Like CO-DEBUG-FLAG.odt.

Change-Id: I594f5155ca92051f18ac59ede679951a92ba0846
Signed-off-by: Tor Lillqvist <tml@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

