### PR TITLE
Stop using .bmp files for tiles on iOS

### DIFF
--- a/common/MobileApp.cpp
+++ b/common/MobileApp.cpp
@@ -39,46 +39,10 @@ void DocumentData::deallocate(unsigned docId)
 {
     assert(idToDocDataMap.find(docId) != idToDocDataMap.end());
     DocumentData &d = get(docId);
-#ifdef IOS
-    for (const auto& tile : d.inFlightTiles)
-    {
-        if (unlink([[[NSURL URLWithString:[NSString stringWithUTF8String:tile.c_str()]] path] UTF8String]) == -1 && errno != ENOENT) {
-            LOG_SYS("Could not unlink tile " << tile);
-        }
-    }
-#endif
     auto p = idToDocDataMap.find(docId);
     delete p->second;
     idToDocDataMap.erase(docId);
 }
-
-#ifdef IOS
-
-int DocumentData::numberOfInFlightTiles(unsigned docId)
-{
-    const std::lock_guard<std::mutex> lock(idToDocDataMapMutex);
-
-    assert(idToDocDataMap.find(docId) != idToDocDataMap.end());
-    return idToDocDataMap[docId]->inFlightTiles.size();
-}
-
-void DocumentData::addInFlightTile(unsigned docId, const std::string& tileURL)
-{
-    const std::lock_guard<std::mutex> lock(idToDocDataMapMutex);
-
-    assert(idToDocDataMap.find(docId) != idToDocDataMap.end());
-    idToDocDataMap[docId]->inFlightTiles.insert(tileURL);
-}
-
-void DocumentData::removeInFlightTile(unsigned docId, const std::string& tileURL)
-{
-    const std::lock_guard<std::mutex> lock(idToDocDataMapMutex);
-
-    assert(idToDocDataMap.find(docId) != idToDocDataMap.end());
-    idToDocDataMap[docId]->inFlightTiles.erase(tileURL);
-}
-
-#endif
 
 #endif
 

--- a/common/MobileApp.hpp
+++ b/common/MobileApp.hpp
@@ -37,10 +37,6 @@
 class DocumentData
 {
 private:
-#ifdef IOS
-    std::set<std::string> inFlightTiles;
-#endif
-
 public:
     DocumentData() :
         loKitDocument(nullptr)
@@ -58,10 +54,6 @@ public:
 
 #ifdef IOS
     CODocument *coDocument;
-
-    static int numberOfInFlightTiles(unsigned docId);
-    static void addInFlightTile(unsigned docId, const std::string& tileURL);
-    static void removeInFlightTile(unsigned docId, const std::string& tileURL);
 #endif
 };
 

--- a/common/RenderTiles.hpp
+++ b/common/RenderTiles.hpp
@@ -14,12 +14,6 @@
 #include <unordered_map>
 #include <vector>
 
-#ifdef IOS
-#import <fcntl.h>
-#import <sys/mman.h>
-#import <unistd.h>
-#endif
-
 #include "Png.hpp"
 #include "Rectangle.hpp"
 #include "TileDesc.hpp"
@@ -385,7 +379,6 @@ namespace RenderTiles
         unsigned char *data() { return _data; }
     };
 
-#ifndef IOS
     static void pushRendered(std::vector<TileDesc> &renderedTiles,
                              const TileDesc &desc, TileWireId wireId, size_t imgSize)
     {
@@ -393,109 +386,6 @@ namespace RenderTiles
         renderedTiles.back().setWireId(wireId);
         renderedTiles.back().setImgSize(imgSize);
     }
-#endif
-
-#ifdef IOS
-
-#pragma pack(push)
-#pragma pack(2)
-    typedef struct
-    {
-        uint16_t bfType;
-        uint32_t bfSize;
-        uint16_t bfReserved1;
-        uint16_t bfReserved2;
-        uint32_t bfOffBits;
-    } BITMAPFILEHEADER;
-#pragma pack(pop)
-
-    typedef uint32_t FXPT2DOT30; // Fixed point 2.30, whatever that means
-
-    typedef struct
-    {
-        FXPT2DOT30 ciexyzX;
-        FXPT2DOT30 ciexyzY;
-        FXPT2DOT30 ciexyzZ;
-    } CIEXYZ;
-
-    typedef struct
-    {
-        CIEXYZ ciexyzRed;
-        CIEXYZ ciexyzGreen;
-        CIEXYZ ciexyzBlue;
-    } CIEXYZTRIPLE;
-
-    // We must use the BITMAPV5HEADER to get proper alpha handling.
-    typedef struct
-    {
-        uint32_t bV5Size;
-        int32_t bV5Width;
-        int32_t bV5Height;
-        uint16_t bV5Planes;
-        uint16_t bV5BitCount;
-        uint32_t bV5Compression;
-        uint32_t bV5SizeImage;
-        int32_t bV5XPelsPerMeter;
-        int32_t bV5YPelsPerMeter;
-        uint32_t bV5ClrUsed;
-        uint32_t bV5ClrImportant;
-        uint32_t bV5RedMask;
-        uint32_t bV5GreenMask;
-        uint32_t bV5BlueMask;
-        uint32_t bV5AlphaMask;
-        uint32_t bV5CSType;
-        CIEXYZTRIPLE bV5Endpoints;
-        uint32_t bV5GammaRed;
-        uint32_t bV5GammaGreen;
-        uint32_t bV5GammaBlue;
-        uint32_t bV5Intent;
-        uint32_t bV5ProfileData;
-        uint32_t bV5ProfileSize;
-        uint32_t bV5Reserved;
-    } BITMAPV5HEADER;
-
-#define BI_BITFIELDS 3
-
-#define LCS_sRGB 0x73524742
-#define LCS_GM_IMAGES 4
-
-    static size_t bmpFileSize(int width, int height)
-    {
-        return sizeof(BITMAPFILEHEADER) + sizeof(BITMAPV5HEADER) + width * height * 4;
-    }
-
-    static void generateBmpHeader(char *buffer, int width, int height)
-    {
-        BITMAPFILEHEADER *bf = (BITMAPFILEHEADER*)buffer;
-        bf->bfType = ('B' | ('M' << 8));
-        bf->bfSize = bmpFileSize(width, height);
-        bf->bfReserved1 = 0;
-        bf->bfReserved2 = 0;
-        bf->bfOffBits = sizeof(BITMAPFILEHEADER) + sizeof(BITMAPV5HEADER);
-
-        BITMAPV5HEADER *bV5 = (BITMAPV5HEADER*) (buffer + sizeof(BITMAPFILEHEADER));
-        bV5->bV5Size = sizeof(BITMAPV5HEADER);
-        bV5->bV5Width = width;
-        bV5->bV5Height = -height;
-        bV5->bV5Planes = 1;
-        bV5->bV5BitCount = 32;
-        bV5->bV5Compression = BI_BITFIELDS;
-        bV5->bV5SizeImage = 0;
-        bV5->bV5XPelsPerMeter = 1000; // Dummy
-        bV5->bV5YPelsPerMeter = 1000;
-        bV5->bV5ClrUsed = 0;
-        bV5->bV5ClrImportant = 0;
-        bV5->bV5RedMask = 0x00FF0000;
-        bV5->bV5GreenMask = 0x0000FF00;
-        bV5->bV5BlueMask = 0x000000FF;
-        bV5->bV5AlphaMask = 0xFF000000;
-        bV5->bV5CSType = LCS_sRGB;
-        // Leave out fields that are ignored with above settings.
-        bV5->bV5Intent = LCS_GM_IMAGES; // ???
-        bV5->bV5Reserved = 0;
-    }
-
-#endif
 
     bool doRender(std::shared_ptr<lok::Document> document,
                   TileCombined &tileCombined,
@@ -565,75 +455,6 @@ namespace RenderTiles
                 << renderArea.getWidth() << ", " << renderArea.getHeight() << ") "
                 << " rendered in " << elapsedMs << " (" << area / elapsedMics << " MP/s).");
 
-#ifdef IOS
-
-        for (int i = 0; i < tiles.size(); i++)
-        {
-            static int bmpFileCounter = 0;
-            const int bmpId = bmpFileCounter++;
-
-            const size_t positionX = (tileRecs[i].getLeft() - renderArea.getLeft()) / tileCombined.getTileWidth();
-            const size_t positionY = (tileRecs[i].getTop() - renderArea.getTop()) / tileCombined.getTileHeight();
-
-            const int offsetX = positionX * pixelWidth;
-            const int offsetY = positionY * pixelHeight;
-
-            NSString *mmapFileBaseName = [NSString stringWithFormat:@"tiles/%d.bmp", bmpId];
-            NSURL *mmapFileURL = [[NSFileManager.defaultManager temporaryDirectory] URLByAppendingPathComponent:mmapFileBaseName];
-
-            int fd = open([[mmapFileURL path] UTF8String], O_RDWR|O_CREAT, 0666);
-            if (fd == -1)
-            {
-                LOG_SYS("Could not create file " << [[mmapFileURL path] UTF8String]);
-                return false;
-            }
-
-            const size_t mmapFileSize = bmpFileSize(pixelWidth, pixelHeight);
-
-            if (lseek(fd, mmapFileSize-1, SEEK_SET) == -1)
-            {
-                LOG_SYS("Could not seek in file " << [[mmapFileURL path] UTF8String]);
-                return false;
-            }
-
-            if (write(fd, "", 1) == -1)
-            {
-                LOG_SYS("Could not write at end of " << [[mmapFileURL path] UTF8String]);
-                return false;
-            }
-
-            char *mmapMemory = (char *)mmap(NULL, mmapFileSize, PROT_READ|PROT_WRITE, MAP_FILE|MAP_SHARED, fd, 0);
-            if (mmapMemory == MAP_FAILED)
-            {
-                LOG_SYS("Could not map in file " << [[mmapFileURL path] UTF8String]);
-                close(fd);
-                return false;
-            }
-
-            close(fd);
-
-            generateBmpHeader(mmapMemory, pixelWidth, pixelHeight);
-
-            for (int y = 0; y < pixelHeight; y++)
-                memcpy(mmapMemory + sizeof(BITMAPFILEHEADER) + sizeof(BITMAPV5HEADER) + y * pixelWidth * 4,
-                       pixmap.data() + (offsetY + y) * pixmapWidth * 4 + offsetX * 4,
-                       pixelWidth * 4);
-
-            std::string tileURL([[mmapFileURL absoluteString] UTF8String]);
-
-            DocumentData::addInFlightTile(mobileAppDocId, tileURL);
-
-            if (munmap(mmapMemory, mmapFileSize) == -1)
-            {
-                LOG_SYS("Could not unmap file " << [[mmapFileURL path] UTF8String]);
-                return false;
-            }
-
-            std::string tileMsg = tiles[i].serialize("tile:", ADD_DEBUG_RENDERID) + tileURL;
-            outputMessage(tileMsg.c_str(), tileMsg.length());
-        }
-
-#else
         (void) mobileAppDocId;
 
         const auto mode = static_cast<LibreOfficeKitTileMode>(document->getTileMode());
@@ -810,7 +631,6 @@ namespace RenderTiles
                 outputOffset += i.getImgSize();
             }
         }
-#endif
         return true;
     }
 }

--- a/ios/Mobile/AppDelegate.mm
+++ b/ios/Mobile/AppDelegate.mm
@@ -290,16 +290,6 @@ static void updateTemplates(NSData *data, NSURLResponse *response)
     if (user_name == nullptr)
         user_name = [[[NSUserDefaults standardUserDefaults] stringForKey:@"userName"] UTF8String];
 
-    // Remove any leftover tile .bmp files by removing the whole folder
-    NSURL *tileFolderURL = [[[NSFileManager defaultManager] temporaryDirectory] URLByAppendingPathComponent:@"tiles"];
-    if (![[NSFileManager defaultManager] removeItemAtURL:tileFolderURL error:nil]) {
-        NSLog(@"Could not remove tile bitmap folder %@", tileFolderURL);
-    }
-
-    if (![[NSFileManager defaultManager] createDirectoryAtURL:tileFolderURL withIntermediateDirectories:YES attributes:nil error:nil]) {
-        NSLog(@"Could not create tile bitmap folder %@", tileFolderURL);
-    }
-
     fakeSocketSetLoggingCallback([](const std::string& line)
                                  {
                                      LOG_INF_NOFILE(line);

--- a/ios/Mobile/DocumentViewController.mm
+++ b/ios/Mobile/DocumentViewController.mm
@@ -537,24 +537,6 @@ static IMP standardImpOfInputAccessoryView = nil;
                                  completion:nil];
                 return;
             }
-        } else if ([message.body hasPrefix:@"REMOVE "]) {
-            // Sent from the img element's onload event handler. Remove tile file once it has been loaded.
-            NSArray<NSString*> *messageBodyItems = [message.body componentsSeparatedByString:@" "];
-            assert([messageBodyItems count] == 2);
-            NSURL *tile = [NSURL URLWithString:messageBodyItems[1]];
-
-            // For some reason tunnelled dialogs still use PNG tiles inside data: URLs and not BMP
-            // files pointed to by file: URLs. Guard against getting REMOVE messages for such.
-            if (![[tile scheme] isEqualToString:@"file"])
-                return;
-
-            if (unlink([[tile path] UTF8String]) == -1) {
-                LOG_SYS("Could not unlink tile " << [[tile path] UTF8String]);
-            } else {
-                const std::string tileURL = std::string([[tile absoluteString] UTF8String]);
-                DocumentData::removeInFlightTile(self.document->appDocId, tileURL);
-            }
-            return;
         }
 
         const char *buf = [message.body UTF8String];

--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -408,7 +408,7 @@ app.definitions.Socket = L.Class.extend({
 	_extractImage: function(e) {
 		var img;
 		if (window.ThisIsTheiOSApp) {
-			// In the iOS app, the native code sends us the URL of the BMP for the tile after the newline
+			// In the iOS app, the native code sends us the PNG tile already as a data: URL after the newline
 			var newlineIndex = e.textMsg.indexOf('\n');
 			if (newlineIndex > 0) {
 				img = e.textMsg.substring(newlineIndex+1);
@@ -455,9 +455,6 @@ app.definitions.Socket = L.Class.extend({
 		e.image = new Image();
 		e.image.onload = function() {
 			e.imageIsComplete = true;
-			if (window.ThisIsTheiOSApp) {
-				window.webkit.messageHandlers.lool.postMessage('REMOVE ' + e.image.src, '*');
-			}
 			that._queueSlurpEventEmission();
 			if (e.image.completeTraceEvent)
 				e.image.completeTraceEvent.finish();
@@ -466,9 +463,6 @@ app.definitions.Socket = L.Class.extend({
 			console.log('Failed to load image ' + img + ' fun ' + err);
 			e.imageIsComplete = true;
 			that._queueSlurpEventEmission();
-			if (window.ThisIsTheiOSApp) {
-				window.webkit.messageHandlers.lool.postMessage('REMOVE ' + e.image.src, '*');
-			}
 			if (e.image.completeTraceEvent)
 				e.image.completeTraceEvent.abort();
 		};


### PR DESCRIPTION
We don't want leaking tiles to take up valuable space on the device.
Not even just while a document is open.

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: I761c2bb2ab121ee76b5535e96bd5702d0fce6856


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

