### PR TITLE
Remove leftover temp files harder in the iOS app when it starts

### DIFF
--- a/ios/Mobile/AppDelegate.mm
+++ b/ios/Mobile/AppDelegate.mm
@@ -299,7 +299,7 @@ static void updateTemplates(NSData *data, NSURLResponse *response)
     }
 
     if (![[NSFileManager defaultManager] createDirectoryAtURL:tempFolderURL withIntermediateDirectories:YES attributes:nil error:nil]) {
-        NSLog(@"Could not create tile bitmap folder %@", tempFolderURL);
+        NSLog(@"Could not create tmp folder %@", tempFolderURL);
     }
 
     fakeSocketSetLoggingCallback([](const std::string& line)

--- a/ios/Mobile/AppDelegate.mm
+++ b/ios/Mobile/AppDelegate.mm
@@ -290,6 +290,18 @@ static void updateTemplates(NSData *data, NSURLResponse *response)
     if (user_name == nullptr)
         user_name = [[[NSUserDefaults standardUserDefaults] stringForKey:@"userName"] UTF8String];
 
+    // Remove any leftover allegedly temporary folders with copies of documents left behind from
+    // previous instances of the app that were killed while editing, various random files that for
+    // instance NSS seems to love to create, etc, by removing the whole tmp folder.
+    NSURL *tempFolderURL = [[NSFileManager defaultManager] temporaryDirectory];
+    if (![[NSFileManager defaultManager] removeItemAtURL:tempFolderURL error:nil]) {
+        NSLog(@"Could not remove tmp folder %@", tempFolderURL);
+    }
+
+    if (![[NSFileManager defaultManager] createDirectoryAtURL:tempFolderURL withIntermediateDirectories:YES attributes:nil error:nil]) {
+        NSLog(@"Could not create tile bitmap folder %@", tempFolderURL);
+    }
+
     fakeSocketSetLoggingCallback([](const std::string& line)
                                  {
                                      LOG_INF_NOFILE(line);


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

