### PR TITLE
Revert "Menubar: Do not allow Insert menu on readonly mode"

### DIFF
--- a/loleaflet/src/control/Control.Menubar.js
+++ b/loleaflet/src/control/Control.Menubar.js
@@ -1041,7 +1041,7 @@ L.Control.Menubar = L.Control.extend({
 		commandStates: {},
 
 		// Only these menu options will be visible in readonly mode
-		allowedReadonlyMenus: ['file', 'downloadas', 'view', 'help'],
+		allowedReadonlyMenus: ['file', 'downloadas', 'view', 'insert', 'help'],
 
 		allowedViewModeActions: [
 			'savecomments', 'shareas', 'print', // file menu


### PR DESCRIPTION
This reverts commit 2739dfe44ca4063802044c8a0d6cd0e1dc1bfb11.

PDF view needs Insert menu to be able to insert comments.

Change-Id: I475aa95974d97fce6efb6b2bcffc997170adb255
Signed-off-by: Aron Budea <aron.budea@collabora.com>

* Target version: co-6-4