### PR TITLE
wsd: move convert-to docs into the jail

### DIFF
--- a/test/UnitConvert.cpp
+++ b/test/UnitConvert.cpp
@@ -50,6 +50,7 @@ public:
 
         config.setBool("ssl.enable", true);
         config.setInt("per_document.limit_load_secs", 30);
+        config.setBool("storage.filesystem[@allow]", false);
     }
 
     void sendConvertTo(std::unique_ptr<Poco::Net::HTTPClientSession>& session, const std::string& filename)

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -635,7 +635,8 @@ bool DocumentBroker::download(const std::shared_ptr<ClientSession>& session, con
 
         try
         {
-            _storage = StorageBase::create(uriPublic, jailRoot, jailPath.toString());
+            _storage = StorageBase::create(uriPublic, jailRoot, jailPath.toString(),
+                                           /*takeOwnership=*/isConvertTo());
         }
         catch (...)
         {

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -573,6 +573,12 @@ private:
     /// Sum the I/O stats from all connected sessions
     void getIOStats(uint64_t &sent, uint64_t &recv);
 
+    /// Returns true iff this is a Convert-To request.
+    /// This is needed primarily for security reasons,
+    /// because we can't trust the given file-path is
+    /// a convert-to request or doctored to look like one.
+    virtual bool isConvertTo() const { return false; }
+
 private:
     /// Request manager.
     /// Encapsulates common fields for
@@ -1161,6 +1167,9 @@ public:
 
     /// Cleanup path and its parent
     static void removeFile(const std::string &uri);
+
+private:
+    bool isConvertTo() const override { return true; }
 };
 #endif
 

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -660,7 +660,8 @@ public:
 
         // FIXME: needs wrapping - until then - keep in sync with ~ConvertToBroker
         Path tempPath = Path::forDirectory(
-            Poco::TemporaryFile::tempName(_convertTo ? "/tmp/convert-to" : "") + '/');
+            Poco::TemporaryFile::tempName(_convertTo ? LOOLWSD::ChildRoot + "/tmp/convert-to" : "")
+            + '/');
         LOG_TRC("Creating temporary convert-to path: " << tempPath.toString());
         File(tempPath).createDirectories();
         chmod(tempPath.toString().c_str(), S_IXUSR | S_IWUSR | S_IRUSR);
@@ -669,7 +670,7 @@ public:
         // A "filename" should always be a filename, not a path
         const Path filenameParam(params.get("filename"));
         tempPath.setFileName(filenameParam.getFileName());
-        _filename = tempPath.toString();
+        _filename = tempPath.toString(); // For convert-to this is bogus.
 
         // Copy the stream to _filename.
         std::ofstream fileStream;

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -331,9 +331,10 @@ public:
     static void initialize();
 
     /// Storage object creation factory.
-    static std::unique_ptr<StorageBase> create(const Poco::URI& uri,
-                                               const std::string& jailRoot,
-                                               const std::string& jailPath);
+    /// @takeOwnership is for local files that are temporary,
+    /// such as convert-to requests.
+    static std::unique_ptr<StorageBase> create(const Poco::URI& uri, const std::string& jailRoot,
+                                               const std::string& jailPath, bool takeOwnership);
 
     static bool allowedWopiHost(const std::string& host);
     static Poco::Net::HTTPClientSession* getHTTPClientSession(const Poco::URI& uri);
@@ -405,11 +406,11 @@ private:
 class LocalStorage : public StorageBase
 {
 public:
-    LocalStorage(const Poco::URI& uri,
-                 const std::string& localStorePath,
-                 const std::string& jailPath) :
-        StorageBase(uri, localStorePath, jailPath),
-        _isCopy(false)
+    LocalStorage(const Poco::URI& uri, const std::string& localStorePath,
+                 const std::string& jailPath, bool isTemporaryFile)
+        : StorageBase(uri, localStorePath, jailPath)
+        , _isTemporaryFile(isTemporaryFile)
+        , _isCopy(false)
     {
         LOG_INF("LocalStorage ctor with localStorePath: [" << localStorePath <<
                 "], jailPath: [" << jailPath << "], uri: [" << LOOLWSD::anonymizeUrl(uri.toString()) << "].");
@@ -453,6 +454,9 @@ public:
                                           const bool isRename) override;
 
 private:
+    /// True if we the source file a temporary that we own.
+    /// Typically for convert-to requests.
+    const bool _isTemporaryFile;
     /// True if the jailed file is not linked but copied.
     bool _isCopy;
     static std::atomic<unsigned> LastLocalStorageId;


### PR DESCRIPTION
We now download the convert-to files into the
child-root/tmp directory and then move it into
the jail that will convert it. This way ownership
and cleanup become contained within our child-root
and jail subsystems. This reduces the chances of
leaking convert-to files and simplifies the design.

In addition, we avoid an extra file copy and improve
the security of the convert-to API.

Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
(cherry picked from commit fad4222a2a91785e714df7ffad1ffd4ddb8f4142)

Change-Id: I450c24d0d0dc0da447c8072b0701c3b48d07c81b
