### PR TITLE
android: show gridlines if background color not set

### DIFF
--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -216,7 +216,10 @@ L.TileSectionManager = L.Class.extend({
 
 	shouldDrawCalcGrid: function () {
 		var defaultBG = 'ffffff';
-		return (this._layer.coreDocBGColor === defaultBG);
+		if (this._layer.coreDocBGColor)
+			return (this._layer.coreDocBGColor === defaultBG);
+		else
+			return true;
 	},
 
 	_onDrawGridSection: function () {


### PR DESCRIPTION
when we don't receive background color we need to assume we want gridlines.
In snapshot android builds gridline was missing.