### PR TITLE
android: use lower clang optimization for release build

### DIFF
--- a/android/lib/src/main/cpp/CMakeLists.txt.in
+++ b/android/lib/src/main/cpp/CMakeLists.txt.in
@@ -126,3 +126,5 @@ target_link_libraries(androidapp
                       ${POCOLIB_ABI}/libPocoFoundation@POCODEBUG@.a
                       "${CMAKE_CURRENT_SOURCE_DIR}/lib/${ANDROID_ABI}/liblo-native-code.so"
 )
+
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O1")


### PR DESCRIPTION
We had bug in android v7a release builds.
Due to high optimization app was not working correctly:
- formula bar was not initialized
- mobile-wizard didn't work
- typing into cells was not possible
- no blinking cursor
- in general editing didn't work

looks like webview -> native code - path was not working
but native code -> webview - path was working because I was able to see tiles after loading document