### PR TITLE
android fix: use correct instance for Unit classes getter

### DIFF
--- a/android/lib/src/main/cpp/CMakeLists.txt.in
+++ b/android/lib/src/main/cpp/CMakeLists.txt.in
@@ -126,5 +126,3 @@ target_link_libraries(androidapp
                       ${POCOLIB_ABI}/libPocoFoundation@POCODEBUG@.a
                       "${CMAKE_CURRENT_SOURCE_DIR}/lib/${ANDROID_ABI}/liblo-native-code.so"
 )
-
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O1")

--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -58,6 +58,13 @@ class UnitBase
     friend UnitWSD;
     friend UnitKit;
 
+public:
+    enum class UnitType
+    {
+        Wsd,
+        Kit
+    };
+
 protected:
     // ---------------- Helper API ----------------
     /// After this time we invoke 'timeout' default 30 seconds
@@ -104,12 +111,12 @@ protected:
     }
 
     /// Construct a UnitBase instance with a default name.
-    explicit UnitBase(std::string name)
+    explicit UnitBase(std::string name, UnitType type)
         : _dlHandle(nullptr)
         , _setRetValue(false)
         , _retValue(0)
         , _timeoutMilliSeconds(30000)
-        , _type(UnitType::Wsd)
+        , _type(type)
         , _testname(std::move(name))
         , _socketPoll(std::make_shared<SocketPoll>(_testname))
     {
@@ -118,11 +125,6 @@ protected:
     virtual ~UnitBase();
 
 public:
-    enum class UnitType
-    {
-        Wsd,
-        Kit
-    };
     /// Load unit test hook shared library from this path
     static bool init(UnitType type, const std::string& unitLibPath);
 
@@ -251,8 +253,10 @@ private:
         return false;
     }
 
+    static UnitBase* get(UnitType type);
+
     /// setup global instance for get() method
-    static void rememberGlobalInstance(UnitType type, UnitBase* instance);
+    static void rememberInstance(UnitType type, UnitBase* instance);
 
     void *_dlHandle;
     static char *UnitLibPath;
@@ -279,6 +283,8 @@ public:
     virtual ~UnitWSD();
 
     static UnitWSD& get();
+
+    virtual void returnValue(int& /* retValue */);
 
     enum class TestRequest
     {
@@ -391,6 +397,8 @@ public:
     explicit UnitKit(std::string testname = std::string());
     virtual ~UnitKit();
     static UnitKit& get();
+
+    virtual void returnValue(int& /* retValue */);
 
     // ---------------- ForKit hooks ----------------
 

--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -251,6 +251,9 @@ private:
         return false;
     }
 
+    /// setup global instance for get() method
+    static void rememberGlobalInstance(UnitType type, UnitBase* instance);
+
     void *_dlHandle;
     static char *UnitLibPath;
     bool _setRetValue;
@@ -275,11 +278,7 @@ public:
 
     virtual ~UnitWSD();
 
-    static UnitWSD& get()
-    {
-        assert(Global && Global->_type == UnitType::Wsd);
-        return *static_cast<UnitWSD *>(Global);
-    }
+    static UnitWSD& get();
 
     enum class TestRequest
     {
@@ -391,14 +390,7 @@ class UnitKit : public UnitBase
 public:
     explicit UnitKit(std::string testname = std::string());
     virtual ~UnitKit();
-    static UnitKit& get()
-    {
-        assert(Global);
-#if !MOBILEAPP && !defined(KIT_IN_PROCESS)
-        assert(Global->_type == UnitType::Kit);
-#endif
-        return *static_cast<UnitKit *>(Global);
-    }
+    static UnitKit& get();
 
     // ---------------- ForKit hooks ----------------
 


### PR DESCRIPTION
On android we had issue with not working release builds
(worked when optimization flag -O0 was used for Unit.cpp).

Global which stored instance of UnitBase subtype was returned
after cast to a choosen subtype. Unfortunately in case when
android didn't work UnitWSD was returned in UnitKit::get() !

Thich patch makes us sure we don't cast to not-correct type.