### PR TITLE
Fix helm host binding to path in ingress.yaml

### DIFF
--- a/kubernetes/helm/collabora-online/templates/ingress.yaml
+++ b/kubernetes/helm/collabora-online/templates/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   rules:
   - host: {{ .Values.hosts.host }}
-  - http:
+    http:
       paths:
       - path: "/"
         pathType: Prefix


### PR DESCRIPTION
* Target version: master 

### Summary
Without this change I get 404 since host name is not set properly 
