### PR TITLE
mobile: don't trigger keyboard hiding when panning

### DIFF
--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -828,7 +828,7 @@ L.CanvasTileLayer = L.TileLayer.extend({
 			tileContainer.style.height = rectangle.getPxHeight() + 'px';
 
 			var newSize = this._getRealMapSize();
-			var heightIncreased = oldSize < newSize.y;
+			var heightIncreased = oldSize.y < newSize.y;
 
 			if (this._docType === 'spreadsheet') {
 				if (this._painter._sectionContainer.doesSectionExist(L.CSections.RowHeader.name)) {
@@ -841,8 +841,13 @@ L.CanvasTileLayer = L.TileLayer.extend({
 				this._map.invalidateSize();
 			}
 
-			if (!heightIncreased && window.mode.isMobile())
-				this._onUpdateCursor(true);
+			if (window.mode.isMobile()) {
+				if (heightIncreased) {
+					// if the keyboard is hidden - be sure we setup correct state in TextInput
+					this._map.focus(false);
+				} else
+					this._onUpdateCursor(true);
+			}
 
 			this._fitWidthZoom();
 

--- a/loleaflet/src/map/handler/Map.TouchGesture.js
+++ b/loleaflet/src/map/handler/Map.TouchGesture.js
@@ -486,8 +486,9 @@ L.Map.TouchGesture = L.Handler.extend({
 			this._map.dragging._draggable._onDown(this._constructFakeEvent(point, 'mousedown'));
 		}
 
-		// No keyboard while dragging.
-		this._map.focus(false);
+		// Keep the same keyboard state
+		var acceptInput = this._map.canAcceptKeyboardInput();
+		this._map.focus(acceptInput);
 	},
 
 	_onPan: function (e) {
@@ -549,8 +550,9 @@ L.Map.TouchGesture = L.Handler.extend({
 			this._map.dragging._draggable._onUp(this._constructFakeEvent(point, 'mouseup'));
 		}
 
-		// No keyboard after dragging.
-		this._map.focus(false);
+		// Keep the same keyboard state
+		var acceptInput = this._map.canAcceptKeyboardInput();
+		this._map.focus(acceptInput);
 	},
 
 	_onPinchStart: function (e) {


### PR DESCRIPTION
on mobile when keyboard is shown and user starts panning
keyboard shouldn't be hidden - it caused view to flicker
and keyboard was shown after short time again
