### PR TITLE
Notebookbar: Do not set items at 32 px

### DIFF
--- a/loleaflet/css/notebookbar.css
+++ b/loleaflet/css/notebookbar.css
@@ -377,8 +377,7 @@
 }
 
 .unotoolbutton.notebookbar.has-label:not(.inline) img {
-	width: 32px !important;
-	height: 32px !important;
+	width: 24px !important;
 	margin: auto !important;
 }
 


### PR DESCRIPTION
Update bigtoolitem outdated CSS rule

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ie74c3a2d9226804eb9469cfa0d9cc25aa6bd2487
