### PR TITLE
prevent division by zero

### DIFF
--- a/wsd/AdminModel.cpp
+++ b/wsd/AdminModel.cpp
@@ -149,7 +149,7 @@ void Document::updateMemoryDirty()
 void Document::setLastJiffies(size_t newJ)
 {
     const auto now = std::chrono::steady_clock::now();
-    if (_lastJiffy)
+    if (_lastJiffy && now != _lastJiffyTime)
         _lastCpuPercentage = (100 * 1000 * (newJ - _lastJiffy) / ::sysconf(_SC_CLK_TCK))
                             / std::chrono::duration_cast<std::chrono::milliseconds>(now - _lastJiffyTime).count();
     _lastJiffy = newJ;


### PR DESCRIPTION
Signed-off-by: Andras Timar <andras.timar@collabora.com>
Change-Id: I9f9523336ddcbe24906787cfc3210f3471768ea8


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
We saw this backtrace in logs:
 ```
wsd-10294-10397 2021-09-20 08:38:39.226851 [ admin ] SIG   Fatal signal received: SIGFPE
Backtrace pid: 10294 - wsd 6.4.12snapshot c1e85d9:

/usr/bin/loolwsd
	SigUtil::dumpBacktrace()
		./common/SigUtil.cpp:276
/usr/bin/loolwsd
	handleFatalSignal
		./common/SigUtil.cpp:255
/lib/x86_64-linux-gnu/libpthread.so.0
	__restore_rt
		??:?
/usr/bin/loolwsd
	Document::setLastJiffies(unsigned long)
		./wsd/AdminModel.cpp:154
/usr/bin/loolwsd
	AdminModel::getKitsJiffies()
		/usr/include/c++/7/bits/stl_tree.h:287
/usr/bin/loolwsd
	Admin::getTotalCpuUsage()
		./wsd/Admin.cpp:581
/usr/bin/loolwsd
	Admin::pollingThread()
		./wsd/Admin.cpp:437
/usr/bin/loolwsd
	SocketPoll::pollingThreadEntry()
		./net/Socket.cpp:288
/usr/lib/x86_64-linux-gnu/libstdc++.so.6
	std::error_code::default_error_condition() const
		??:?
/lib/x86_64-linux-gnu/libpthread.so.0
	start_thread
		/build/glibc-S9d2JN/glibc-2.27/nptl/pthread_create.c:463
/lib/x86_64-linux-gnu/libc.so.6
	clone
		/build/glibc-S9d2JN/glibc-2.27/misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:97

```