### PR TITLE
No need to use a separate 'that' variable in the _slurpMessage function

### DIFF
--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -358,13 +358,12 @@ app.definitions.Socket = L.Class.extend({
 	// buffer of web-socket messages in the client that we can't
 	// process so - slurp and the emit at idle - its faster to delay!
 	_slurpMessage: function(e) {
-		var that = this;
 		if (!this._slurpQueue || !this._slurpQueue.length) {
 			this._queueSlurpEventEmission();
-			that._slurpQueue = [];
+			this._slurpQueue = [];
 		}
 		this._extractTextImg(e);
-		that._slurpQueue.push(e);
+		this._slurpQueue.push(e);
 	},
 
 	// make profiling easier


### PR DESCRIPTION
Storing 'this' into a separate variable, typically called 'that,' is
needed only to enable it to be captured in a (callback) function that
you create in the scope of the 'that' variable. No callback or other
function is created inside the _slurpMessage function.

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: Iae2c6844a3dfb0ff486ee6762ee129893829f272


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

