### PR TITLE
mobile: reset IgnorePanning on touch end

### DIFF
--- a/loleaflet/src/map/handler/Map.TouchGesture.js
+++ b/loleaflet/src/map/handler/Map.TouchGesture.js
@@ -208,6 +208,8 @@ L.Map.TouchGesture = L.Handler.extend({
 		if (!this._map.touchGesture.enabled()) {
 			this._map.touchGesture.enable();
 		}
+
+		window.IgnorePanning = undefined;
 	},
 
 	_onPress: function (e) {


### PR DESCRIPTION
When we move marker we set IgnorePanning to true.
Unfortunately onUp handler is not called as Map.TouchGesture
overrides that event - so release variable there too.