### PR TITLE
private/pedro/shortcutsbar ports n improvements porting from 6 4

### DIFF
--- a/loleaflet/css/notebookbar.css
+++ b/loleaflet/css/notebookbar.css
@@ -270,8 +270,7 @@
 .hasnotebookbar .ui-content.unotoolbutton.selected:hover,
 .unotoolbutton.notebookbar:hover,
 .hasnotebookbar .ui-content.unotoolbutton.selected:not(.has-label):not(.inline):hover {
-	outline: 1px solid var(--gray-color);
-	border-radius: 0.1px;
+	box-shadow: 0 0 0 1px var(--gray-color);
 }
 
 /* avoid bug with arrow in new line when window is small */
@@ -335,12 +334,6 @@
 	width: 18px !important;
 	height: 18px !important;
 	padding: 4px;
-}
-.unotoolbutton.notebookbar:not(.disabled):hover, #clearFormatting.notebookbar div img:hover, #FormatPaintbrush.notebookbar div img:hover {
-	background-color: #e6e6e6b0;
-	cursor: pointer;
-	outline: 1px solid var(--gray-color);
-	border-radius: 0.1px;
 }
 
 .unotoolbutton.notebookbar .unobutton.selected + .ui-content.unolabel {

--- a/loleaflet/css/notebookbar.css
+++ b/loleaflet/css/notebookbar.css
@@ -144,11 +144,21 @@
 	filter: hue-rotate(305deg);
 }
 /* Hamburger icon: from shortcutsbar (notebookbar) */
-.hasnotebookbar #shortcuts-menubar-icon,
-.hasnotebookbar #shortcuts-menubar-icon:before,
-.hasnotebookbar #shortcuts-menubar-icon:after {
+.hasnotebookbar.text-color-indicator #shortcuts-menubar-icon {
 	background: rgb(3, 105, 163);
 	background: rgb(var(--blue1-txt-primary-color));
+}
+.hasnotebookbar.spreadsheet-color-indicator #shortcuts-menubar-iconr {
+	background: rgb(16, 104, 2);
+	background: rgb(var(--green0-txt-primary-color));
+}
+.hasnotebookbar.presentation-color-indicator #shortcuts-menubar-icon {
+	background: rgb(163, 62, 3);
+	background: rgb(var(--orange1-txt-primary-color));
+}
+.hasnotebookbar.drawing-color-indicator #shortcuts-menubar-icon {
+	background: rgb(135, 105, 0);
+	background: rgb(var(--yellow0-txt-primary-color));
 }
 
 .hasnotebookbar .notebookbar-shortcuts-bar #Menubar,
@@ -163,6 +173,12 @@
 	cursor: pointer;
 	border: none;
 	height: 27px;
+	width: 24px;
+	padding: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex-direction: column;
 }
 
 .hasnotebookbar #shortcuts-menubar-icon {
@@ -175,28 +191,8 @@
 	transition: all 0.25s;
 }
 
-.hasnotebookbar #shortcuts-menubar-icon:before,
-.hasnotebookbar #shortcuts-menubar-icon:after {
-	position: absolute;
-	top: 52%;
-	left: 0px;
-	height: 2px;
-	width: 16px;
-	-webkit-transition: all 0.25s;
-	transition: all 0.25s;
-}
 
-.hasnotebookbar #shortcuts-menubar-icon:before {
-	content: '';
-	top: -6px;
-	left: 0;
-}
 
-.hasnotebookbar #shortcuts-menubar-icon:after {
-	content: '';
-	top: 6px;
-	left: 0;
-}
 
 .hasnotebookbar.spreadsheet-color-indicator #table-shortcutstoolbox {
 	-webkit-filter: hue-rotate(290deg);

--- a/loleaflet/css/notebookbar.css
+++ b/loleaflet/css/notebookbar.css
@@ -128,6 +128,21 @@
 	align-content: center;
 }
 
+.text-color-indicator.hasnotebookbar #Save img.savemodified {
+	filter: hue-rotate(135deg);
+}
+
+.presentation-color-indicator.hasnotebookbar #Save img.savemodified{
+	filter: hue-rotate(315deg);
+}
+
+.spreadsheet-color-indicator.hasnotebookbar #Save img.savemodified{
+	filter: hue-rotate(225deg);
+}
+
+.drawing-color-indicator.hasnotebookbar #Save img.savemodified{
+	filter: hue-rotate(305deg);
+}
 /* Hamburger icon: from shortcutsbar (notebookbar) */
 .hasnotebookbar #shortcuts-menubar-icon,
 .hasnotebookbar #shortcuts-menubar-icon:before,

--- a/loleaflet/css/notebookbar.css
+++ b/loleaflet/css/notebookbar.css
@@ -123,9 +123,11 @@
 .notebookbar-shortcuts-bar #Redo {
 	height: 27px;
 	width: 24px;
-	display: grid;
+	display: flex;
 	margin: 0px !important;
-	align-content: center;
+	align-items: center;
+	justify-content: center;
+	flex-direction: column;
 }
 
 .text-color-indicator.hasnotebookbar #Save img.savemodified {

--- a/loleaflet/images/lc_hamburger.svg
+++ b/loleaflet/images/lc_hamburger.svg
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg11"
+   sodipodi:docname="lc_hamburger.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <metadata
+     id="metadata17">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs15" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1019"
+     id="namedview13"
+     showgrid="false"
+     inkscape:zoom="11.8125"
+     inkscape:cx="38.006248"
+     inkscape:cy="8.5621657"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="symbol" />
+  <g
+     id="symbol"
+     fill="#63bbee"
+     stroke="#0369a3"
+     stroke-linecap="round"
+     stroke-linejoin="round">
+    <path
+       id="path2"
+       d="m 2.5,2.5 v 1 h 14 5 v -1 h -4 -2 z" />
+    <path
+       id="path847"
+       d="m 2.5,11.5 v 1 h 14 5 v -1 h -4 -2 z" />
+    <path
+       id="path849"
+       d="m 2.5,20.5 v 1 h 14 5 v -1 h -4 -2 z" />
+  </g>
+</svg>

--- a/loleaflet/images/lc_redo.svg
+++ b/loleaflet/images/lc_redo.svg
@@ -1,14 +1,63 @@
-<?xml-stylesheet type="text/css" href="icons.css" ?>
-<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-  <g id="symbol"
-	 class="icn icn--highlight-color-line"  
-     fill="none" 
-     stroke="#1e8bcd" 
-	 stroke-linecap="round" 
-	 stroke-linejoin="round"
-	 stroke-width="2"
-     >
-      <path d="m 15.3,14.5 5,-5 -5,-5" />
-      <path d="m 20.3,9.5 h -11.5 c -3,0 -5.5,2.5 -5.5,5.5 0,3 2.5,5.5 5.5,5.5" />
-  </g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="lc_redo.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1019"
+     id="namedview8"
+     showgrid="false"
+     inkscape:zoom="23.625"
+     inkscape:cx="12"
+     inkscape:cy="12"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6"
+     inkscape:document-rotation="0" />
+  <path
+     d="m8 9a6 6 0 0 0 -6 6 6 6 0 0 0 6 6c.554 0 1-.446 1-1s-.446-1-1-1a4 4 0 0 1 -4-4 4 4 0 0 1 4-4h12v-2z"
+     fill="#4d82b8"
+     id="path4"
+     style="fill:#83beec;fill-opacity:1" />
+  <path
+     d="m15.000041 4 6 6-6 6"
+     fill="none"
+     stroke="#4d82b8"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     stroke-width="2"
+     id="path2"
+     style="stroke:#1e8bcd;stroke-opacity:1" />
 </svg>

--- a/loleaflet/images/lc_undo.svg
+++ b/loleaflet/images/lc_undo.svg
@@ -1,14 +1,63 @@
-<?xml-stylesheet type="text/css" href="icons.css" ?>
-<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-  <g id="symbol"
-	 class="icn icn--highlight-color-line"  
-	 fill="none" 
-	 stroke="#1e8bcd" 
-	 stroke-linecap="round" 
-	 stroke-linejoin="round"
-	 stroke-width="2"
-	 >
-      <path d="m 8.5,14.5 -5,-5 5,-5" />
-      <path d="M 3.5,9.5 H 15 c 3,0 5.5,2.5 5.5,5.5 0,3 -2.5,5.5 -5.5,5.5" />
-  </g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="lc_undo.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1019"
+     id="namedview8"
+     showgrid="false"
+     inkscape:zoom="23.625"
+     inkscape:cx="12"
+     inkscape:cy="12"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6"
+     inkscape:document-rotation="0" />
+  <path
+     d="m4 9v2h12a4 4 0 0 1 4 4 4 4 0 0 1 -4 4c-.554 0-1 .446-1 1s.446 1 1 1a6 6 0 0 0 6-6 6 6 0 0 0 -6-6z"
+     fill="#4d82b8"
+     id="path4"
+     style="fill:#83beec;fill-opacity:1" />
+  <path
+     d="m9 4-6 6 6 6"
+     fill="none"
+     stroke="#4d82b8"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     stroke-width="2"
+     id="path2"
+     style="stroke:#1e8bcd;stroke-opacity:1" />
 </svg>

--- a/loleaflet/src/control/Control.NotebookbarBuilder.js
+++ b/loleaflet/src/control/Control.NotebookbarBuilder.js
@@ -834,7 +834,7 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 			subIndicatorsText: '&#8250;'
 		});
 
-		$(menuHtml[0]).children('a').html('<span id="shortcuts-menubar-icon"></span>');
+		$(menuHtml[0]).children('a').html('<img class="ui-content unobutton" src="images/lc_hamburger.svg" id="Hamburgerimg" alt="Menu">');
 		$(menuHtml[0]).children('a').click(function () {
 			$(control.container).smartmenus('menuHideAll');
 		});


### PR DESCRIPTION
- Notebookbar: unotoolbutton hover: remove duplicated rules and
- Notebookbar: Introduce modified status for the save icon
- Notebookbar: Set menu button with an icon instead of building it from spans
- Notebookbar: Adjust icons to follow the same color as its neighbors
- Notebookbar: shortcutsbar: switch to flex for icon parents
