### PR TITLE
Notebookbar: Set menu button without hardcoded px

### DIFF
--- a/loleaflet/css/notebookbar.css
+++ b/loleaflet/css/notebookbar.css
@@ -170,13 +170,7 @@
 .hasnotebookbar .notebookbar-shortcuts-bar #Menubar > li > a {
 	cursor: pointer;
 	border: none;
-	height: 27px;
-	width: 24px;
-	padding: 0;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	flex-direction: column;
+	padding: 4px;
 }
 
 .hasnotebookbar #shortcuts-menubar-icon {


### PR DESCRIPTION
Also avoid using flex (so smartmenu
to show and hide can still work)

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I002b0fc9c5cc0a20f8fa4f0d72757c4b6ffd9697
