### PR TITLE
fix Lintian errors: binary-or-shlib-defines-rpath

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -72,7 +72,7 @@ if !ENABLE_DEBUG
 AM_CPPFLAGS += -DNDEBUG
 endif
 
-AM_LDFLAGS = -pthread -Wl,-E,-rpath,/snap/loolwsd/current/usr/lib -lpam $(ZLIB_LIBS)
+AM_LDFLAGS = -pthread -Wl,-E -lpam $(ZLIB_LIBS)
 
 if ENABLE_SSL
 AM_LDFLAGS += -lssl -lcrypto

--- a/configure.ac
+++ b/configure.ac
@@ -943,7 +943,7 @@ AS_IF([test -n "$with_cppunit_libs"],
       [LDFLAGS="$LDFLAGS -L${with_cppunit_libs}"])
 
 AS_IF([test `uname -s` = Linux -o `uname -s` = FreeBSD],
-      [AS_IF([test -n "$with_poco_libs"],
+      [AS_IF([test -n "$with_poco_libs" -a -f "$with_poco_libs/libPocoFoundation.so"],
              [LDFLAGS="$LDFLAGS -Wl,-rpath,${with_poco_libs}"])])
 
 AS_IF([test `uname -s` = Linux -o `uname -s` = FreeBSD],


### PR DESCRIPTION
E: loolwsd: binary-or-shlib-defines-rpath usr/bin/loolconvert /snap/loolwsd/current/usr/lib
E: loolwsd: binary-or-shlib-defines-rpath usr/bin/loolconvert /opt/poco/lib

These RPATHs are not needed when we statically link poco, as we do with production
packages.

Signed-off-by: Andras Timar <andras.timar@collabora.com>
Change-Id: I5050fe1f1925937388793d443020fdc6a14ec97d

