### PR TITLE
Zoom-out animation improvements

### DIFF
--- a/loleaflet/Makefile.am
+++ b/loleaflet/Makefile.am
@@ -31,7 +31,7 @@ DIRECTORY_TS = $(srcdir)/src/layer/tile $(srcdir)/src/control # Add ts directori
 SRC_TS_ALL := $(foreach dir, $(DIRECTORY_TS), $(wildcard $(dir)/*.ts))
 SRC_TS_JS_FILES := $(SRC_TS_ALL:.ts=.js)
 
-$(SRC_TS_ALL:.ts=.js): $(SRC_TS_ALL:.ts=.ts)
+$(SRC_TS_JS_FILES): %.js: %.ts
 	$(builddir)/node_modules/typescript/bin/tsc $(@:.js=.ts) --outfile $@ --module none --lib dom,es2016 --target ES5
 
 MOCHA_DIR = $(srcdir)/mocha_tests

--- a/loleaflet/src/layer/tile/CalcTileLayer.js
+++ b/loleaflet/src/layer/tile/CalcTileLayer.js
@@ -1136,6 +1136,30 @@ L.SheetGeometry = L.Class.extend({
 			this._rows.getTileTwipsAtZoom(point.y, zoomScale));
 	},
 
+	// accepts a point in core-pixel coordinates at current zoom
+	// and returns the equivalent point in core-pixels at the given zoomScale.
+	getCorePixelsAtZoom: function (point, zoomScale) { // (L.Point, number) -> L.Point
+		if (!(point instanceof L.Point)) {
+			console.error('Bad argument type, expected L.Point');
+			return point;
+		}
+
+		return new L.Point(this._columns.getCorePixelsAtZoom(point.x, zoomScale),
+			this._rows.getCorePixelsAtZoom(point.y, zoomScale));
+	},
+
+	// accepts a point in core-pixel coordinates at *given* zoomScale
+	// and returns the equivalent point in core-pixels at the current zoom.
+	getCorePixelsFromZoom: function (point, zoomScale) { // (L.Point, number) -> L.Point
+		if (!(point instanceof L.Point)) {
+			console.error('Bad argument type, expected L.Point');
+			return point;
+		}
+
+		return new L.Point(this._columns.getCorePixelsFromZoom(point.x, zoomScale),
+			this._rows.getCorePixelsFromZoom(point.y, zoomScale));
+	},
+
 	// accepts a point in print twips coordinates and returns the equivalent point
 	// in tile-twips.
 	getTileTwipsPointFromPrint: function (point) { // (L.Point) -> L.Point
@@ -1640,6 +1664,84 @@ L.SheetDimension = L.Class.extend({
 
 		var posPT = this.getPrintTwipsPosFromTile(posTT);
 		return this.getTileTwipsPosFromPrint(posPT, zoomScale);
+	},
+
+	// Accepts a position in core-pixels at current zoom and returns corresponding
+	// core-pixels position at the given zoomScale.
+	getCorePixelsAtZoom: function (posCP, zoomScale) {
+		if (typeof posCP !== 'number' || typeof zoomScale !== 'number') {
+			console.error('Wrong argument types');
+			return;
+		}
+
+		var posCPZ = 0; // Position in core-pixels at zoomScale.
+		var posCPRem = posCP; // Unconverted core-pixels position at current zoom.
+		this._visibleSizes.forEachSpan(function (span) {
+			var elementCount = span.end - span.start + 1;
+			var sizeOneCP = span.data.sizecore;
+			var sizeOneCPZ = Math.floor(span.size / 15.0 * zoomScale);
+			var sizeCP = sizeOneCP * elementCount;
+			var sizeCPZ = sizeOneCPZ * elementCount;
+
+			if (posCPRem < sizeOneCP) {
+				// Done converting. FIXME: make this callback return false to end the forEachSpan when done.
+				return;
+			}
+
+			if (posCPRem >= sizeCP) {
+				// Whole span can be converted.
+				posCPRem -= sizeCP;
+				posCPZ += sizeCPZ;
+				return;
+			}
+
+			// Only part of the span can be converted.
+			// sizeOneCP <= posCPRem < sizeCP.
+			var elems = Math.floor(posCPRem / sizeOneCP);
+			posCPRem -= (elems * sizeOneCP);
+			posCPZ += (elems * sizeOneCPZ);
+		});
+
+		return posCPZ + (posCPRem * zoomScale / this._coreZoomFactor);
+	},
+
+	// Accepts a position in core-pixels at *given* zoomScale and returns corresponding
+	// core-pixels position at the current zoom.
+	getCorePixelsFromZoom: function (posCPZ, zoomScale) {
+		if (typeof posCPZ !== 'number' || typeof zoomScale !== 'number') {
+			console.error('Wrong argument types');
+			return;
+		}
+
+		var posCP = 0; // Position in core-pixels at current zoom.
+		var posCPZRem = posCPZ; // Unconverted core-pixels position at zoomScale.
+		this._visibleSizes.forEachSpan(function (span) {
+			var elementCount = span.end - span.start + 1;
+			var sizeOneCP = span.data.sizecore;
+			var sizeOneCPZ = Math.floor(span.size / 15.0 * zoomScale);
+			var sizeCP = sizeOneCP * elementCount;
+			var sizeCPZ = sizeOneCPZ * elementCount;
+
+			if (posCPZRem < sizeOneCPZ) {
+				// Done converting.
+				return;
+			}
+
+			if (posCPZRem >= sizeCPZ) {
+				// Whole span can be converted.
+				posCPZRem -= sizeCPZ;
+				posCP += sizeCP;
+				return;
+			}
+
+			// Only part of the span can be converted.
+			// sizeOneCPZ <= posCPZRem < sizeCPZ.
+			var elems = Math.floor(posCPZRem / sizeOneCPZ);
+			posCPZRem -= (elems * sizeOneCPZ);
+			posCP += (elems * sizeOneCP);
+		});
+
+		return posCP + (posCPZRem * this._coreZoomFactor / zoomScale);
 	},
 
 	// Accepts a position in print twips and returns the corresponding position in tile twips.

--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -428,7 +428,8 @@ L.TileSectionManager = L.Class.extend({
 			center.y = pinchCenter.y;
 
 		var xMin = 0;
-		if (paneBounds.min.x < 0)
+		var hasXMargin = !this._layer.isCalc();
+		if (hasXMargin)
 			xMin = -Infinity;
 		else if (paneBounds.min.x > 0)
 			xMin = splitPos.x;

--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -45,6 +45,7 @@ L.TileSectionManager = L.Class.extend({
 		var mapSize = this._map.getPixelBoundsCore().getSize();
 		this._oscCtxs = [];
 		this._tilesSection = null; // Shortcut.
+		this._drawDebugZoomFrames = true;
 
 		this._sectionContainer = new CanvasSectionContainer(this._canvas, this._layer.isCalc() /* disableDrawing? */);
 
@@ -468,59 +469,12 @@ L.TileSectionManager = L.Class.extend({
 	_zoomAnimation: function () {
 		var painter = this;
 		var ctx = this._paintContext();
-		var paneBoundsList = ctx.paneBoundsList;
-		var splitPos = ctx.splitPos;
 		var canvasOverlay = this._layer._canvasOverlay;
 
 		var rafFunc = function (timeStamp, final) {
-			painter._sectionContainer.setPenPosition(painter._tilesSection);
-			for (var i = 0; i < paneBoundsList.length; ++i) {
-				var paneBounds = paneBoundsList[i];
-				var paneSize = paneBounds.getSize();
-				var extendedBounds = painter._tilesSection.extendedPaneBounds(paneBounds);
-				var paneBoundsOffset = paneBounds.min.subtract(extendedBounds.min);
-				var scale = painter._zoomFrameScale;
-
-				// Top left in document coordinates.
-				var docPos = painter._getZoomDocPos(painter._newCenter, paneBounds, splitPos, scale, false /* findFreePaneCenter? */);
-				var docTopLeft = docPos.topLeft;
-
-				// Top left position in the offscreen canvas.
-				var sourceTopLeft = docTopLeft.subtract(paneBounds.min).add(paneBoundsOffset);
-
-				var destPos = new L.Point(0, 0);
-				if (paneBoundsList.length > 1) {
-					// Has freeze-panes, so recalculate the main canvas position to draw the pane
-					// and compute the adjusted paneSizes.
-					if (paneBounds.min.x) {
-						// Pane is free to move in X direction.
-						destPos.x = splitPos.x * scale;
-						paneSize.x -= (splitPos.x * (scale - 1));
-					} else {
-						// Pane is fixed in X direction.
-						paneSize.x += (splitPos.x * (scale - 1));
-					}
-
-					if (paneBounds.min.y) {
-						// Pane is free to move in Y direction.
-						destPos.y = splitPos.y * scale;
-						paneSize.y -= (splitPos.y * (scale - 1));
-					} else {
-						// Pane is fixed in Y direction.
-						paneSize.y += (splitPos.y * (scale - 1));
-					}
-				}
-
-				painter._tilesSection.context.drawImage(painter._tilesSection.offscreenCanvases[i],
-					sourceTopLeft.x, sourceTopLeft.y,
-					// sourceWidth, sourceHeight
-					paneSize.x / scale, paneSize.y / scale,
-					// destX, destY
-					destPos.x, destPos.y,
-					// destWidth, destHeight
-					paneSize.x, paneSize.y);
-			}
-
+			// TODO: Draw grids if Calc.
+			// draw zoom frame directly from the tiles.
+			painter._tilesSection.drawZoomFrame(ctx);
 			canvasOverlay.onDraw();
 
 			if (!final)
@@ -559,7 +513,6 @@ L.TileSectionManager = L.Class.extend({
 		if (!this._inZoomAnim) {
 			this._sectionContainer.setInZoomAnimation(true);
 			this._inZoomAnim = true;
-			this._layer._prefetchTilesSync();
 			// Start RAF loop for zoom-animation
 			this._zoomAnimation();
 		}
@@ -577,8 +530,7 @@ L.TileSectionManager = L.Class.extend({
 		// the final integral zoom, but maintain the same center.
 		var steps = 10;
 		var stepId = 0;
-		// This buys us time till new tiles arrive.
-		var intervalGap = 20;
+
 		var startZoom = this._zoomFrameScale;
 		var endZoom = this._calcZoomFrameScale(zoom);
 		var painter = this;
@@ -587,14 +539,13 @@ L.TileSectionManager = L.Class.extend({
 		// Calculate the final center at final zoom in advance.
 		var newMapCenter = this._getZoomMapCenter(zoom);
 		var newMapCenterLatLng = map.unproject(newMapCenter, zoom);
-		// Fetch tiles for the new zoom and center as we start final animation.
-		// But this does not update the map.
-		this._layer._update(newMapCenterLatLng, zoom);
+		painter._sectionContainer.setZoomChanged(true);
 
 		var stopAnimation = false;
 		var waitForTiles = false;
 		var waitTries = 30;
-		var intervalId = setInterval(function () {
+		var finishingRAF = undefined;
+		var finishAnimation = function () {
 
 			if (stepId < steps) {
 				// continue animating till we reach "close" to 'final zoom'.
@@ -602,7 +553,6 @@ L.TileSectionManager = L.Class.extend({
 				stepId += 1;
 				if (stepId >= steps)
 					stopAnimation = true;
-				return;
 			}
 
 			if (stopAnimation) {
@@ -614,13 +564,9 @@ L.TileSectionManager = L.Class.extend({
 				painter._zoomFrameScale = undefined;
 				painter._sectionContainer.setInZoomAnimation(false);
 				painter._inZoomAnim = false;
-
-				painter._sectionContainer.setZoomChanged(true);
 				painter.setWaitForTiles(true);
-				// Set view and paint the tiles if all available.
 				mapUpdater(newMapCenterLatLng);
 				waitForTiles = true;
-				return;
 			}
 
 			if (waitForTiles) {
@@ -628,7 +574,7 @@ L.TileSectionManager = L.Class.extend({
 				if (waitTries <= 0 || painter._tilesSection.haveAllTilesInView()) {
 					// All done.
 					waitForTiles = false;
-					clearInterval(intervalId);
+					cancelAnimationFrame(finishingRAF);
 					painter.setWaitForTiles(false);
 					painter._sectionContainer.setZoomChanged(false);
 					map.enableTextInput();
@@ -638,12 +584,16 @@ L.TileSectionManager = L.Class.extend({
 					painter._finishingZoom = false;
 					// Run the finish callback.
 					runAtFinish();
+					return;
 				}
 				else
 					waitTries -= 1;
 			}
 
-		}, intervalGap);
+			finishingRAF = requestAnimationFrame(finishAnimation);
+
+		};
+		finishAnimation();
 	},
 
 	getTileSectionPos : function () {

--- a/loleaflet/src/layer/tile/TilesSection.ts
+++ b/loleaflet/src/layer/tile/TilesSection.ts
@@ -308,6 +308,116 @@ class TilesSection {
 		});
 	}
 
+	private forEachTileInArea(area: any, zoom: number, part: number, ctx: any,
+		callback: (tile: any, coords: any) => boolean) {
+		var docLayer = this.sectionProperties.docLayer;
+		var tileRange = docLayer._pxBoundsToTileRange(area);
+
+		for (var j = tileRange.min.y; j <= tileRange.max.y; ++j) {
+			for (var i = tileRange.min.x; i <= tileRange.max.x; ++i) {
+				var coords = new L.TileCoordData(
+					i * ctx.tileSize.x,
+					j * ctx.tileSize.y,
+					zoom,
+					part);
+
+				var key = coords.key();
+				var tile = docLayer._tiles[key];
+				callback(tile, coords);
+			}
+		}
+	}
+
+	// Called by tsManager to draw a zoom animation frame.
+	public drawZoomFrame(ctx?: any) {
+		var tsManager = this.sectionProperties.tsManager;
+		if (!tsManager._inZoomAnim)
+			return;
+
+		var scale = tsManager._zoomFrameScale;
+		if (!scale || !tsManager._newCenter)
+			return;
+
+		ctx = ctx || this.sectionProperties.tsManager._paintContext();
+		var docLayer = this.sectionProperties.docLayer;
+		var zoom = Math.round(this.map.getZoom());
+		var part = docLayer._selectedPart;
+		var splitPos = ctx.splitPos;
+
+		this.containerObject.setPenPosition(this);
+		var viewSize = ctx.viewBounds.getSize();
+		// clear the document area first.
+		this.context.fillStyle = this.containerObject.getClearColor();
+		this.context.fillRect(0, 0, viewSize.x, viewSize.y);
+
+		var paneBoundsList = ctx.paneBoundsList;
+
+		for (var k = 0; k < paneBoundsList.length ; ++k) {
+			var paneBounds = paneBoundsList[k];
+			var paneSize = paneBounds.getSize();
+
+			// Calculate top-left in doc core-pixels for the frame.
+			var docPos = tsManager._getZoomDocPos(tsManager._newCenter, paneBounds, splitPos, scale, false /* findFreePaneCenter? */);
+
+			var destPos = new L.Point(0, 0);
+			var docAreaSize = paneSize.divideBy(scale);
+			if (paneBoundsList.length > 1) {
+				if (paneBounds.min.x) {
+					// Pane is free to move in X direction.
+					destPos.x = splitPos.x;
+					paneSize.x -= splitPos.x;
+				} else {
+					// Pane is fixed in X direction.
+					docAreaSize.x = paneSize.x;
+				}
+
+				if (paneBounds.min.y) {
+					// Pane is free to move in Y direction.
+					destPos.y = splitPos.y;
+					paneSize.y -= splitPos.y;
+				} else {
+					// Pane is fixed in Y direction.
+					docAreaSize.y = paneSize.y;
+				}
+			}
+
+			var docRange = new L.Bounds(docPos.topLeft, docPos.topLeft.add(docAreaSize));
+			var canvasContext = this.context;
+
+			this.forEachTileInArea(docRange, zoom, part, ctx, function (tile: any, coords: any): boolean {
+				if (!tile || !tile.loaded || !docLayer._isValidTile(coords))
+					return false;
+
+				var tileBounds = new L.Bounds(tile.coords.getPos(), tile.coords.getPos().add(ctx.tileSize));
+				var crop = new L.Bounds(tileBounds.min, tileBounds.max);
+				crop.min.x = Math.max(docRange.min.x, tileBounds.min.x);
+				crop.min.y = Math.max(docRange.min.y, tileBounds.min.y);
+				crop.max.x = Math.min(docRange.max.x, tileBounds.max.x);
+				crop.max.y = Math.min(docRange.max.y, tileBounds.max.y);
+
+				var cropWidth = crop.max.x - crop.min.x;
+				var cropHeight = crop.max.y - crop.min.y;
+
+				var tileOffset = crop.min.subtract(tileBounds.min);
+				var paneOffset = crop.min.subtract(docRange.min.subtract(destPos));
+				if (cropWidth && cropHeight) {
+					canvasContext.drawImage(tile.el,
+						tileOffset.x, tileOffset.y, // source x, y
+						cropWidth, cropHeight, // source size
+						// Destination x, y, w, h (In non-Chrome browsers it leaves lines without the 0.5 correction).
+						Math.floor(paneOffset.x * scale) + 0.5, // Destination x
+						Math.floor(paneOffset.y * scale) + 0.5, // Destination y
+						Math.floor(cropWidth * scale) + 1.5,    // Destination width
+						Math.floor(cropHeight * scale) + 1.5);  // Destination height
+				}
+
+				return true;
+			}); // end of forEachTileInArea call.
+
+		} // End of pane bounds list loop.
+
+	}
+
 	public onMouseWheel () {}
 	public onMouseMove () {}
 	public onMouseDown () {}

--- a/loleaflet/src/layer/tile/TilesSection.ts
+++ b/loleaflet/src/layer/tile/TilesSection.ts
@@ -388,7 +388,7 @@ class TilesSection {
 		var docLayer = this.sectionProperties.docLayer;
 		var targetZoom = this.map.getScaleZoom(frameScale, areaZoom);
 		var bestZoomLevel = targetZoom;
-		var missingAreaScoreAtBestZL = Infinity; // Lower the better.
+		var availAreaScoreAtBestZL = -Infinity; // Higher the better.
 		var area = area.clone();
 		if (area.min.x < 0)
 			area.min.x = 0;
@@ -398,7 +398,7 @@ class TilesSection {
 		var minZoom = <number>this.map.options.minZoom;
 		var maxZoom = <number>this.map.options.maxZoom;
 		for (var zoom = minZoom; zoom <= maxZoom; ++zoom) {
-			var missingAreaScore = 0; // Lower the better.
+			var availAreaScore = 0; // Higher the better.
 			var hasTiles = false;
 
 			// To scale up missing-area scores to maxZoom as we need an
@@ -410,10 +410,8 @@ class TilesSection {
 			var relScale = this.map.getZoomScale(zoom, areaZoom);
 
 			this.forEachTileInArea(areaAtZoom, zoom, part, ctx, function(tile, coords) {
-				if (!tile || !tile.loaded) {
+				if (tile && tile.el) {
 					var tilePos = coords.getPos();
-					if (tilePos.x < 0 || tilePos.y < 0)
-						return true;
 
 					if (app.file.fileBasedView) {
 						var ratio = ctx.tileSize.y * relScale / docLayer._tileHeightTwips;
@@ -424,25 +422,28 @@ class TilesSection {
 					var tileBounds = new L.Bounds(tilePos, tilePos.add(ctx.tileSize));
 					var interFrac = TilesSection.getTileIntersectionAreaFraction(tileBounds, areaAtZoom);
 
-					// Add to score how much of tile area is missing with a correction factor
-					// to make area scores comparable b/w zoom levels.
-					missingAreaScore += interFrac;
-
-				} else if (!hasTiles) {
-					hasTiles = true;
+					// Add to score how much of tile area is available.
+					availAreaScore += interFrac;
+					if (!hasTiles)
+						hasTiles = true;
 				}
+
 				return true;
 			});
 
-			missingAreaScore = hasTiles ? Math.round(missingAreaScore * dimensionCorrection /* width */ * dimensionCorrection /* height */ / 100) : Infinity;
+			// Scale up with a correction factor to make area scores comparable b/w zoom levels.
+			availAreaScore = hasTiles ? Math.round(availAreaScore
+				* dimensionCorrection /* width */
+				* dimensionCorrection /* height */
+				/ 10 /* resolution control */) : -Infinity;
 
-			console.log('DEBUG: zoom:' + zoom + ' missingAreaScore = ' + missingAreaScore);
+			console.log('DEBUG: zoom:' + zoom + ' availAreaScore = ' + availAreaScore);
 
 			// Accept this zoom if it has a lower missing-area score
 			// In case of a tie we prefer tiles from a zoom level closer to targetZoom.
-			if (missingAreaScore < missingAreaScoreAtBestZL ||
-				(missingAreaScore == missingAreaScoreAtBestZL && Math.abs(targetZoom - bestZoomLevel) > Math.abs(targetZoom - zoom))) {
-				missingAreaScoreAtBestZL = missingAreaScore;
+			if (availAreaScore > availAreaScoreAtBestZL ||
+				(availAreaScore == availAreaScoreAtBestZL && Math.abs(targetZoom - bestZoomLevel) > Math.abs(targetZoom - zoom))) {
+				availAreaScoreAtBestZL = availAreaScore;
 				bestZoomLevel = zoom;
 			}
 		}

--- a/loleaflet/src/layer/tile/TilesSection.ts
+++ b/loleaflet/src/layer/tile/TilesSection.ts
@@ -382,6 +382,9 @@ class TilesSection {
 			}
 
 			var docRange = new L.Bounds(docPos.topLeft, docPos.topLeft.add(docAreaSize));
+			if (tsManager._calcGridSection) {
+				tsManager._calcGridSection.onDrawArea(docRange, docRange.min.subtract(destPos), this.context);
+			}
 			var canvasContext = this.context;
 
 			this.forEachTileInArea(docRange, zoom, part, ctx, function (tile: any, coords: any): boolean {

--- a/loleaflet/src/layer/tile/TilesSection.ts
+++ b/loleaflet/src/layer/tile/TilesSection.ts
@@ -438,8 +438,6 @@ class TilesSection {
 				* dimensionCorrection /* height */
 				/ 10 /* resolution control */) : -Infinity;
 
-			console.log('DEBUG: zoom:' + zoom + ' availAreaScore = ' + availAreaScore);
-
 			// Accept this zoom if it has a lower missing-area score
 			// In case of a tie we prefer tiles from a zoom level closer to targetZoom.
 			if (availAreaScore > availAreaScoreAtBestZL ||
@@ -517,7 +515,6 @@ class TilesSection {
 			if (scale < 1.0) {
 				useSheetGeometry = !!sheetGeometry;
 				bestZoomSrc = this.zoomLevelWithMaxContentInArea(docRange, zoom, part, ctx);
-				console.log('DEBUG: bestZoomSrc = ' + bestZoomSrc);
 			}
 
 			var docRangeScaled = (bestZoomSrc == zoom) ? docRange : this.scaleBoundsForZoom(docRange, bestZoomSrc, zoom);

--- a/loleaflet/src/layer/tile/TilesSection.ts
+++ b/loleaflet/src/layer/tile/TilesSection.ts
@@ -333,12 +333,18 @@ class TilesSection {
 		var docLayer = this.sectionProperties.docLayer;
 
 		if (app.file.fileBasedView) {
-			var coordList: Array<any> = docLayer._updateFileBasedView(true, area);
+			var coordList: Array<any> = docLayer._updateFileBasedView(true, area, zoom);
 
 			for (var k: number = 0; k < coordList.length; k++) {
-				var key = coordList[k].key();
+				var coords = coordList[k];
+				var key = coords.key();
 				var tile = docLayer._tiles[key];
-				callback(tile, coordList[k]);
+				if (!tile) {
+					var img = docLayer._tileCache[key];
+					if (img)
+						tile = { el: img, loaded: true, coords: coords };
+				}
+				callback(tile, coords);
 			}
 
 			return;
@@ -379,6 +385,7 @@ class TilesSection {
 		areaZoom: number, part: number, ctx: any): number {
 
 		var frameScale = this.sectionProperties.tsManager._zoomFrameScale;
+		var docLayer = this.sectionProperties.docLayer;
 		var targetZoom = this.map.getScaleZoom(frameScale, areaZoom);
 		var bestZoomLevel = targetZoom;
 		var missingAreaScoreAtBestZL = Infinity; // Lower the better.
@@ -400,12 +407,19 @@ class TilesSection {
 
 			// Compute area for zoom-level 'zoom'.
 			var areaAtZoom = this.scaleBoundsForZoom(area, zoom, areaZoom);
+			var relScale = this.map.getZoomScale(zoom, areaZoom);
 
 			this.forEachTileInArea(areaAtZoom, zoom, part, ctx, function(tile, coords) {
 				if (!tile || !tile.loaded) {
 					var tilePos = coords.getPos();
 					if (tilePos.x < 0 || tilePos.y < 0)
 						return true;
+
+					if (app.file.fileBasedView) {
+						var ratio = ctx.tileSize.y * relScale / docLayer._tileHeightTwips;
+						var partHeightPixels = Math.round((docLayer._partHeightTwips + docLayer._spaceBetweenParts) * ratio);
+						tilePos.y = coords.part * partHeightPixels + tilePos.y;
+					}
 
 					var tileBounds = new L.Bounds(tilePos, tilePos.add(ctx.tileSize));
 					var interFrac = TilesSection.getTileIntersectionAreaFraction(tileBounds, areaAtZoom);


### PR DESCRIPTION
* Target version: co-6-4

### Summary
* Zoom frames are drawn directly using tiles in tile-array or cache. 
* Draws grid before drawing tiles every zoom frame.
* A zoom level is chosen for every zoom-frame which has tiles that has maximum coverage for the zoom-frame area based on a score indicator. Tile of this zoom level is used to paint the frame.
* draw/pdf-zoomframe: needs special treatment of y coordinates
* adds SheetGeometry methods convert b/w core-pixels between zooms needed for Calc.
* Use sheetGeometry to transform the view coordinates for the chosen zoom-level for the frame. However this is not done for indivdual tiles. As a result there could be small alignment discrepancies between tiles and other stuff we draw using sheetGeometry such as grids and overlays.

### Tested on
* Desktop/Mobile Chrome browser
* Desktop/Mobile Firefox browser

### Caveats
* In Mobile Firefox, pinch zooming in general is noticeably slow. On doing this quickly it misses render frames and in most cases it is perceived as a view jump. Rendering is done with requestAnimationFrame API and it works well in Chrome.
* There is no change in tile prefetch code yet. For the first zoom-out, if some tiles are missing for all zoom levels,  the area appears  with default background (or empty grid in Calc).
* For non-Calc apps there is no definite info about the margins surrounding the page area in the client, so it is not possible to draw the zoom-frames at the "expected" centered position when zooming out from a view where there is no left (and / or) right margin. In such cases after the pinch zoom is finished the view will jump to make the page centered.
    * This lack of information can also impact the scoring of zoom-levels and it may sometimes choose a non-optimal zoom-level to draw the frame.
* For Calc, sheetGeometry conversions are not done for each tile to calculate its position on the frame at the frame scale, so there will be small discrepancies between tile contents and the overlays/grids.

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

