### PR TITLE
wsd: fix crash-on-shutdown in LOOLWSD::doHousekeeping()

### DIFF
--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -1993,7 +1993,10 @@ bool LOOLWSD::checkAndRestoreForKit()
 
 void LOOLWSD::doHousekeeping()
 {
-    LOOLWSD::PrisonerPoll->wakeup();
+    if (LOOLWSD::PrisonerPoll)
+    {
+        LOOLWSD::PrisonerPoll->wakeup();
+    }
 }
 
 void LOOLWSD::closeDocument(const std::string& docKey, const std::string& message)


### PR DESCRIPTION
wsd/LOOLWSD.cpp:1996:28: runtime error: member call on null pointer of type 'SocketPoll'
    #0 0xcd8799 in LOOLWSD::doHousekeeping() wsd/LOOLWSD.cpp:1996:28

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I3f5f8ad0d8a09a0f4244a32897c59d8a772a8d17
