### PR TITLE
common: fix leftover debug output

### DIFF
--- a/common/SigUtil.cpp
+++ b/common/SigUtil.cpp
@@ -304,7 +304,6 @@ namespace SigUtil
             sleep(60);
             LOG_ERR("Finished sleeping to allow debugging of: " << getpid());
             std::cerr << "Finished sleeping to allow debugging of: " << getpid() << "\n";
-            std::cerr << "Sleeping 60s to allow debugging: attach " << getpid() << "\n";
         }
     }
 


### PR DESCRIPTION
Assuming that the intention is to output a pair of strings on start and
a pair of string on finish.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I1ab3b03c353a8d0875e2fee451ca34965fc3038e
