### PR TITLE
cypress: restore shape text alignment test

### DIFF
--- a/cypress_test/integration_tests/common/helper.js
+++ b/cypress_test/integration_tests/common/helper.js
@@ -1076,6 +1076,14 @@ class Bounds {
 			&& this.height !== undefined);
 	}
 
+	get right() {
+		return this.left + this.width;
+	}
+
+	get bottom() {
+		return this.top + this.height;
+	}
+
 	static parseBoundsJson(boundsJsonString) {
 		var jsonObject = JSON.parse(boundsJsonString);
 		return new Bounds(jsonObject.top, jsonObject.left, jsonObject.width, jsonObject.height);
@@ -1163,6 +1171,14 @@ function typeIntoInputField(selector, text, clearBefore = true, prop = true)
 	cy.log('Typing into input field - end.');
 }
 
+function getVisibleBounds(domRect) {
+	return new Bounds(
+		Math.max(0, domRect.top),
+		Math.max(0, domRect.left),
+		domRect.width,
+		domRect.height);
+}
+
 module.exports.loadTestDoc = loadTestDoc;
 module.exports.checkIfDocIsLoaded = checkIfDocIsLoaded;
 module.exports.assertCursorAndFocus = assertCursorAndFocus;
@@ -1202,3 +1218,4 @@ module.exports.getOverlayItemBounds = getOverlayItemBounds;
 module.exports.overlayItemHasBounds = overlayItemHasBounds;
 module.exports.overlayItemHasDifferentBoundsThan = overlayItemHasDifferentBoundsThan;
 module.exports.typeIntoInputField = typeIntoInputField;
+module.exports.getVisibleBounds = getVisibleBounds;

--- a/cypress_test/integration_tests/common/impress_helper.js
+++ b/cypress_test/integration_tests/common/impress_helper.js
@@ -170,8 +170,12 @@ function selectTextOfShape() {
 		cy.get('svg g .leaflet-interactive')
 			.then(function(items) {
 				expect(items).to.have.length(1);
-				var XPos = (items[0].getBoundingClientRect().left + items[0].getBoundingClientRect().right) / 2;
-				var YPos = (items[0].getBoundingClientRect().top + items[0].getBoundingClientRect().bottom) / 2;
+				// Slide does not fit the viewport in cypress.
+				// Use the center of the visible area of the svg group element else the click
+				// event could go to other elements like slide sorter.
+				const clientRect = helper.getVisibleBounds(items[0].getBoundingClientRect());
+				const XPos = (clientRect.left + clientRect.right) / 2;
+				const YPos = (clientRect.top + clientRect.bottom) / 2;
 				cy.get('body')
 					.dblclick(XPos, YPos);
 			});

--- a/cypress_test/integration_tests/desktop/impress/top_toolbar_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/top_toolbar_spec.js
@@ -115,11 +115,9 @@ describe('Top toolbar tests.', function() {
 			.should('have.attr', 'font-size', '776px');
 	});
 
-	it.skip('Apply left/right alignment on selected text.', function() {
+	it('Apply left/right alignment on text selected text.', function() {
 		cy.get('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition')
 			.should('have.attr', 'x', '1400');
-
-		// FIXME: This test was coordinate based and didn't work because of the size of the document. Disabled for now.
 
 		// Set right alignment first
 		impressHelper.selectTextOfShape();


### PR DESCRIPTION
There is a problem with slides that does not fit into cypress tests
viewport.  Use the center of the visible area of the svg to
click/dblclick else clicking on the true center the event will not end
up in the svg. For example the click event could hit the slide
sorter(empty space in this case) or the invisible area outside the
viewport.

Signed-off-by: Dennis Francis <dennis.francis@collabora.com>
Change-Id: Iefa73f56b67be0b4c251921aa91404dbbfbed671


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

