### PR TITLE
canvas: refresh when view size modified

### DIFF
--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -829,6 +829,7 @@ L.CanvasTileLayer = L.TileLayer.extend({
 
 			var newSize = this._getRealMapSize();
 			var heightIncreased = oldSize.y < newSize.y;
+			var widthIncreased = oldSize.x < newSize.x;
 
 			if (this._docType === 'spreadsheet') {
 				if (this._painter._sectionContainer.doesSectionExist(L.CSections.RowHeader.name)) {
@@ -868,6 +869,9 @@ L.CanvasTileLayer = L.TileLayer.extend({
 				if (!cursorPositionInView)
 					this._map.panTo(cursorPos);
 			}
+
+			if (heightIncreased || widthIncreased)
+				this._painter._sectionContainer.requestReDraw();
 		}
 	},
 


### PR DESCRIPTION
When on mobile we hide keyboard it was visible that
content "under the keyboard" wasn't refreshed.
So be sure we draw everything after we detected resized view
and we did all the view position setup keeping cursor on the screen.
