### PR TITLE
mobile: don't focus document when dialog opened

### DIFF
--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -3459,8 +3459,9 @@ L.CanvasTileLayer = L.Layer.extend({
 				this._map._textInput.showCursor();
 			}
 
+			var hasMobileWizardOpened = this._map.uiManager.mobileWizard ? this._map.uiManager.mobileWizard.isOpen() : false;
 			// Don't show the keyboard when the Wizard is visible.
-			if (!window.mobileWizard && !window.pageMobileWizard && !window.insertionMobileWizard) {
+			if (!window.mobileWizard && !window.pageMobileWizard && !window.insertionMobileWizard && !hasMobileWizardOpened) {
 				// If the user is editing, show the keyboard, but don't change
 				// anything if nothing is changed.
 
@@ -5039,7 +5040,8 @@ L.CanvasTileLayer = L.Layer.extend({
 				this._map.invalidateSize();
 			}
 
-			if (window.mode.isMobile()) {
+			var hasMobileWizardOpened = this._map.uiManager.mobileWizard ? this._map.uiManager.mobileWizard.isOpen() : false;
+			if (window.mode.isMobile() && !hasMobileWizardOpened) {
 				if (heightIncreased) {
 					// if the keyboard is hidden - be sure we setup correct state in TextInput
 					this._map.focus(false);


### PR DESCRIPTION
On mobile in hamburger menu > search when we focused input field
the focus was set to document so when user started typing we
received new characters in the document instead of input field.

Also it doesn't trigger showing the keyboard when 'next' button
is clicked in search dialog.
