### PR TITLE
trace: hard filter out tileprocessed.

### DIFF
--- a/wsd/TraceFile.hpp
+++ b/wsd/TraceFile.hpp
@@ -230,7 +230,8 @@ public:
                 }
             }
 
-            writeLocked(id, sessionId, data, static_cast<char>(TraceFileRecord::Direction::Incoming));
+            if (!LOOLProtocol::matchPrefix("tileprocessed ", data))
+                writeLocked(id, sessionId, data, static_cast<char>(TraceFileRecord::Direction::Incoming));
         }
     }
 


### PR DESCRIPTION
This makes up most of the trace, and we have to simulate it anyway.

Change-Id: I3820e1d2281e696c119edb9ce989fda5ca4170e6


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

