### PR TITLE
test: increase timeout in isDocumentLoaded()

### DIFF
--- a/test/helpers.hpp
+++ b/test/helpers.hpp
@@ -532,8 +532,8 @@ inline
 bool isDocumentLoaded(LOOLWebSocket& ws, const std::string& testname, bool isView = true)
 {
     const std::string prefix = isView ? "status:" : "statusindicatorfinish:";
-    // Allow 30 secs to load
-    const auto message = getResponseString(ws, prefix, testname, std::chrono::seconds(30));
+    // Allow 60 secs to load
+    const auto message = getResponseString(ws, prefix, testname, std::chrono::seconds(60));
     bool success = LOOLProtocol::matchPrefix(prefix, message);
     if (!success)
         TST_LOG("ERR: Timed out loading document");


### PR DESCRIPTION
https://cpci.cbg.collabora.co.uk:8080/job/online-master-sanitizer/2513/console
and in general
https://cpci.cbg.collabora.co.uk:8080/job/online-master-sanitizer/
regularly fails with a timeout, allow it to actually catch real badness.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Ic3862bc44d507afd34903be87f1019fc6d0e4b58
