### PR TITLE
Include X-WOPI-Lock header to rename

### DIFF
--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -1237,12 +1237,14 @@ void WopiStorage::uploadLocalFileToStorageAsync(const Authorization& auth,
 
         http::Header& httpHeader = httpRequest.header();
 
+        // must include this header except for SaveAs
+        if (!isSaveAs && lockCtx._supportsLocks)
+            httpHeader.set("X-WOPI-Lock", lockCtx._lockToken);
+
         if (!isSaveAs && !isRename)
         {
             // normal save
             httpHeader.set("X-WOPI-Override", "PUT");
-            if (lockCtx._supportsLocks)
-                httpHeader.set("X-WOPI-Lock", lockCtx._lockToken);
             httpHeader.set("X-LOOL-WOPI-IsModifiedByUser", isUserModified() ? "true" : "false");
             httpHeader.set("X-LOOL-WOPI-IsAutosave", isAutosave() ? "true" : "false");
             httpHeader.set("X-LOOL-WOPI-IsExitSave", isExitSave() ? "true" : "false");


### PR DESCRIPTION
bug is described here: #3208
Missing Lock header according to the wopi specs on rename
operation

Signed-off-by: Mert Tumer <mert.tumer@collabora.com>
Change-Id: I6c73f4f1a0a057935a6885cea274ce66c73365d4


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

