### PR TITLE
Introduce --enable-bundle to decouple bundling from --enable-debug

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -104,6 +104,10 @@ AC_ARG_ENABLE([debug],
               AS_HELP_STRING([--enable-debug],
                              [Enable debugging, link with debugging version of Poco libraries]))
 
+AC_ARG_ENABLE([bundle],
+              AS_HELP_STRING([--enable-bundle],
+                             [Enable creating bundled JS and CSS even with --enable-debug]))
+
 AC_ARG_ENABLE([debug-protocol],
     AS_HELP_STRING([--disable-debug-protocol],
         [Disables JS protocol logging by default, otherwise it is slaved to enable-debug.])
@@ -345,6 +349,7 @@ AS_IF([test "$enable_debug" = yes -a -n "$with_poco_libs"],
 
 ENABLE_DEBUG=false
 ENABLE_DEBUG_PROTOCOL=false
+ENABLE_BUNDLE=true
 LOOLWSD_LOGLEVEL="warning"
 LOOLWSD_LOG_TO_FILE="false"
 LOOLWSD_LOGFILE="/var/log/loolwsd.log"
@@ -353,6 +358,7 @@ LOOLWSD_ANONYMIZE_USER_DATA=false
 LOLEAFLET_LOGGING="false"
 debug_msg="secure mode: product build"
 anonym_msg=""
+bundle_msg="using uglified bundled JS and CSS"
 if test "$enable_debug" = "yes"; then
    AC_DEFINE([ENABLE_DEBUG],1,[Whether to compile in some extra debugging support code and disable some security pieces])
    ENABLE_DEBUG=true
@@ -364,10 +370,15 @@ if test "$enable_debug" = "yes"; then
    LOOLWSD_ANONYMIZE_USER_DATA=false
    LOLEAFLET_LOGGING="true"
    debug_msg="low security debugging mode"
+   if test "$enable_bundle" != "yes"; then
+      ENABLE_BUNDLE=false
+      bundle_msg="using individual JS and CSS files"
+   fi
 else
     AC_DEFINE([ENABLE_DEBUG],0,[Whether to compile in some extra debugging support code and disable some security pieces])
 fi
 AC_SUBST(ENABLE_DEBUG)
+AC_SUBST(ENABLE_BUNDLE)
 AC_SUBST(LOOLWSD_LOGLEVEL)
 AC_SUBST(LOOLWSD_LOG_TO_FILE)
 AC_SUBST(LOLEAFLET_LOGGING)
@@ -1459,15 +1470,16 @@ AS_IF([test "$ENABLE_IOSAPP" = "true"],
       [
        echo "
 Configuration:
-    LOKit path              ${lokit_msg}
-    LO path                 $LO_PATH
-    LO integration tests    ${lo_msg}
-    SSL support             $ssl_msg
-    Debug & low security    $debug_msg
-    Anonymization           $anonym_msg
-    Set capabilities        $setcap_msg
-    Browsersync             $browsersync_msg
-    cypress                 $cypress_msg
+    LOKit path                ${lokit_msg}
+    LO path                   $LO_PATH
+    LO integration tests      ${lo_msg}
+    SSL support               $ssl_msg
+    Debug & low security      $debug_msg
+    Uglification and bundling $bundle_msg
+    Anonymization             $anonym_msg
+    Set capabilities          $setcap_msg
+    Browsersync               $browsersync_msg
+    cypress                   $cypress_msg
 
     \$ make # to compile"
 if test -n "$with_lo_path"; then

--- a/loleaflet/Makefile.am
+++ b/loleaflet/Makefile.am
@@ -3,8 +3,8 @@ CTAGS = ctags
 BUILT_SOURCES = node_modules
 
 L10N_PO = $(wildcard $(srcdir)/po/*.po)
-BUNDLE ?= $(if $(filter true,$(ENABLE_DEBUG)),DEBUG,RELEASE)
-IS_DEBUG = $(if $(filter DEBUG,$(BUNDLE)),true,)
+IS_BUNDLE = $(if $(filter true,$(ENABLE_BUNDLE)),true,)
+IS_SEPARATE = $(if $(filter false,$(ENABLE_BUNDLE)),true,)
 
 DIST_FOLDER ?= $(builddir)/dist
 TYPESCRIPT_JS_DIR = $(builddir)/typescript_js
@@ -159,7 +159,7 @@ LOLEAFLET_CSS_M4 = $(strip $(foreach file,$(LOLEAFLET_CSS),$(notdir $(file))))
 $(eval $(call file_targets,$(LOLEAFLET_CSS)))
 
 NODE_MODULES_JS =\
-	$(if $(IS_DEBUG),node_modules/hammerjs/hammer.js,node_modules/hammerjs/hammer.min.js) \
+	$(if $(IS_SEPARATE),node_modules/hammerjs/hammer.js,node_modules/hammerjs/hammer.min.js) \
 	node_modules/jquery/dist/jquery.js \
 	node_modules/jquery-mousewheel/jquery.mousewheel.js \
 	node_modules/jquery-contextmenu/dist/jquery.contextMenu.js \
@@ -385,12 +385,12 @@ COMMA := ,
 EMPTY :=
 SPACE := $(EMPTY) $(EMPTY)
 LOLEAFLET_VERSION = $(shell cd $(srcdir) && git log -1 --pretty=format:"%h")
-INTERMEDIATE_DIR ?= $(if $(IS_DEBUG),$(abs_builddir)/debug,$(abs_builddir)/release)
+INTERMEDIATE_DIR ?= $(if $(IS_SEPARATE),$(abs_builddir)/debug,$(abs_builddir)/release)
 
 EXTRA_DIST = $(shell find . -type f -not -path './.git/*' -not -path './node_modules/*' | sed 's/.\///')
 
 define bundle_loleaflet
-	$(if $(IS_DEBUG),\
+	$(if $(IS_SEPARATE),\
 		@touch $@,
 		@m4 -PE -DIOSAPP=$(ENABLE_IOSAPP) \
 			-DGTKAPP=$(ENABLE_GTKAPP) \
@@ -403,22 +403,22 @@ define bundle_loleaflet
 endef
 
 define prereq_loleaflet
-	$(if $(IS_DEBUG),$(LOLEAFLET_JS_DST),$(LOLEAFLET_JS_SRC))
+	$(if $(IS_SEPARATE),$(LOLEAFLET_JS_DST),$(LOLEAFLET_JS_SRC))
 endef
 
 define bundle_css
-	$(if $(IS_DEBUG),\
+	$(if $(IS_SEPARATE),\
 		@touch $@,\
 		@echo "Uglify loleaflet css files..."
 		@$(NODE) node_modules/uglifycss/uglifycss $(LOLEAFLET_CSS) > $@)
 endef
 
 define prereq_css
-	$(if $(IS_DEBUG),$(LOLEAFLET_CSS_DST),$(LOLEAFLET_CSS))
+	$(if $(IS_SEPARATE),$(LOLEAFLET_CSS_DST),$(LOLEAFLET_CSS))
 endef
 
 define bundle_all
-	$(if $(IS_DEBUG),\
+	$(if $(IS_SEPARATE),\
 		@touch $@,\
 		@echo "Uglify loleaflet js files..."
 		@m4 -PE -DL10N_IOS_ALL_JS=$(L10N_IOS_ALL_JS) \
@@ -432,12 +432,12 @@ define bundle_all
 endef
 
 define prereq_all
-	$(if $(IS_DEBUG),$(NODE_MODULES_JS_DST) $(LOLEAFLET_LIBS_JS_DST),\
+	$(if $(IS_SEPARATE),$(NODE_MODULES_JS_DST) $(LOLEAFLET_LIBS_JS_DST),\
 		$(NODE_MODULES_JS_SRC) $(LOLEAFLET_LIBS_JS_SRC))
 endef
 
 define global_file
-	$(if $(IS_DEBUG),
+	$(if $(IS_SEPARATE),
 		@cp $< $@,
 		@echo "Uglify global.js file..."
 		@$(NODE) node_modules/uglify-js/bin/uglifyjs $< --output $@)
@@ -486,7 +486,7 @@ endif
 
 $(DIST_FOLDER)/admin-bundle.js: $(LOLEAFLET_ADMIN_DST) \
 	$(INTERMEDIATE_DIR)/admin-src.js
-	@NODE_PATH=$(abs_builddir)/node_modules:$(INTERMEDIATE_DIR) $(NODE) node_modules/browserify/bin/cmd.js -g browserify-css $(if $(IS_DEBUG),--debug,-g uglifyify) -o $@ $(srcdir)/admin/main-admin.js
+	@NODE_PATH=$(abs_builddir)/node_modules:$(INTERMEDIATE_DIR) $(NODE) node_modules/browserify/bin/cmd.js -g browserify-css $(if $(IS_SEPARATE),--debug,-g uglifyify) -o $@ $(srcdir)/admin/main-admin.js
 
 $(INTERMEDIATE_DIR)/admin-src.js: $(LOLEAFLET_ADMIN_TS_JS) $(LOLEAFLET_ADMIN_JS)
 	@mkdir -p $(dir $@)
@@ -526,7 +526,7 @@ $(DIST_FOLDER)/loleaflet.html: $(srcdir)/html/loleaflet.html.m4 \
 	$(DIST_FOLDER)/global.js \
 	$(DIST_FOLDER)/bundle.js
 	@echo "Generating loleaflet.html..."
-	@m4 -PE -DDEBUG=$(IS_DEBUG) \
+	m4 -PE -DBUNDLE=$(IS_BUNDLE) \
 		-DENABLE_FEEDBACK=$(ENABLE_FEEDBACK) \
 		-DIOSAPP=$(ENABLE_IOSAPP) \
 		-DGTKAPP=$(ENABLE_GTKAPP) \

--- a/loleaflet/html/loleaflet.html.m4
+++ b/loleaflet/html/loleaflet.html.m4
@@ -117,8 +117,8 @@ window.isLocalStorageAllowed = (function() {
 })();
 </script>
 
-m4_dnl In the debug case, just write all the .css files here
-m4_ifelse(DEBUG,[true],
+m4_ifelse(BUNDLE,[],
+  <!-- Using individual CSS files -->
   m4_foreachq([fileCSS],[LOLEAFLET_CSS],[<link rel="stylesheet" href="][m4_ifelse(MOBILEAPP,[],[%SERVICE_ROOT%/loleaflet/%VERSION%/])][fileCSS" />
 ]),
   [<!-- Dynamically load the bundle.css -->
@@ -298,6 +298,8 @@ m4_ifelse(MOBILEAPP,[true],
       window.socketProxy = %SOCKET_PROXY%;
       window.tileSize = 256;
       window.uiDefaults = %UI_DEFAULTS%;])
+
+// This is GLOBAL_JS:
 m4_syscmd([cat ]GLOBAL_JS)m4_dnl
 
 m4_ifelse(IOSAPP,[true],
@@ -328,15 +330,20 @@ document.getElementsByTagName("head")[[0]].appendChild(brandingLink);
 </script>
 
 m4_ifelse(MOBILEAPP,[true],
-  m4_ifelse(DEBUG,[true],m4_foreachq([fileJS],[LOLEAFLET_JS],
+  <!-- This is for a mobile app so the script files are in the same folder -->
+  m4_ifelse(BUNDLE,[],m4_foreachq([fileJS],[LOLEAFLET_JS],
   [    <script src="fileJS" defer></script>
   ]),
   [    <script src="bundle.js" defer></script>
   ]),
-  m4_ifelse(DEBUG,[true],m4_foreachq([fileJS],[LOLEAFLET_JS],
-  [    <script src="%SERVICE_ROOT%/loleaflet/%VERSION%/fileJS" defer></script>
-  ]),
-  [    <script src="%SERVICE_ROOT%/loleaflet/%VERSION%/bundle.js" defer></script>
+  m4_ifelse(BUNDLE,[],
+      <!-- Using indivisual JS files -->
+      m4_foreachq([fileJS],[LOLEAFLET_JS],
+      [ <script src="%SERVICE_ROOT%/loleaflet/%VERSION%/fileJS" defer></script>
+      ]),
+  [
+       <!-- Using bundled JS files -->
+       <script src="%SERVICE_ROOT%/loleaflet/%VERSION%/bundle.js" defer></script>
   ])
 )m4_dnl
     <!--%BRANDING_JS%--> <!-- logo onclick handler -->


### PR DESCRIPTION
Without --enable-bundle, --enable-debug works as before: Individual JS
and CSS files are sourced in loleaflet.html.

But with both --enable-debug and --enable-bundle, a non-empty
bundle.js and bundle.css is produced and that is used instead. It is
important for developers to be able to test also the use of bundle.js
because there can be significant differences in behaviour. Developers
typically have to use --enable-debug because otherwise there are
various stict run-time checks in the C++ code that you don't want to
bother with when developing, like having a separate login for COOL.

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: If7d0220b7910fe0f7a2f391b856cd0dedc788152


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

