### PR TITLE
Include X-WOPI-Lock header to rename

### DIFF
--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -1228,12 +1228,14 @@ void WopiStorage::uploadLocalFileToStorageAsync(const Authorization& auth,
 
         http::Header& httpHeader = httpRequest.header();
 
+        // must include this header except for SaveAs
+        if (!isSaveAs && lockCtx._supportsLocks)
+            httpHeader.set("X-WOPI-Lock", lockCtx._lockToken);
+
         if (!isSaveAs && !isRename)
         {
             // normal save
             httpHeader.set("X-WOPI-Override", "PUT");
-            if (lockCtx._supportsLocks)
-                httpHeader.set("X-WOPI-Lock", lockCtx._lockToken);
             httpHeader.set("X-LOOL-WOPI-IsModifiedByUser", isUserModified() ? "true" : "false");
             httpHeader.set("X-LOOL-WOPI-IsAutosave", isAutosave() ? "true" : "false");
             httpHeader.set("X-LOOL-WOPI-IsExitSave", isExitSave() ? "true" : "false");


### PR DESCRIPTION
bug is described here: #3208
Missing Lock header according to the wopi specs on rename
operation

Signed-off-by: Mert Tumer <mert.tumer@collabora.com>
Change-Id: I6c73f4f1a0a057935a6885cea274ce66c73365d4
(cherry picked from commit 73ea638d1dbc4f9ba25a7c43e99e2534c8577d9d)
