### PR TITLE
Escape strings in JSON

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -61,6 +61,7 @@
 #include <MobileApp.hpp>
 #include <FileUtil.hpp>
 #include <common/JailUtil.hpp>
+#include <common/JsonUtil.hpp>
 #include "KitHelper.hpp"
 #include "Kit.hpp"
 #include <Protocol.hpp>
@@ -1144,9 +1145,9 @@ private:
             }
             else
             {
-                oss << "\"userid\":\"" << itView->second.getUserId() << "\",";
+                oss << "\"userid\":\"" << JsonUtil::escapeJSONValue(itView->second.getUserId()) << "\",";
                 const std::string username = itView->second.getUserName();
-                oss << "\"username\":\"" << username << "\",";
+                oss << "\"username\":\"" << JsonUtil::escapeJSONValue(username) << "\",";
                 if (!itView->second.getUserExtraInfo().empty())
                     oss << "\"userextrainfo\":" << itView->second.getUserExtraInfo() << ',';
                 const bool readonly = itView->second.isReadOnly();


### PR DESCRIPTION
This should take care e.g. for SharePoint user IDs, which have the
form of "domain\username", and the backslash must be escaped.

Signed-off-by: Mike Kaganski <mike.kaganski@collabora.com>
Change-Id: I75936070ad1661dc9b03e05a19b64159b0758018
