### PR TITLE
Allow one more url source for images

### DIFF
--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -813,7 +813,7 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     // Document signing: if endpoint URL is configured, whitelist that for
     // iframe purposes.
     std::ostringstream cspOss;
-    cspOss << "Content-Security-Policy: default-src 'none'; "
+    cspOss << "Content-Security-Policy: default-src 'none'; img-src 'self' data: https://www.collaboraoffice.com/;"
 #ifdef ENABLE_FEEDBACK
         "frame-src 'self' " << FEEDBACK_LOCATION << " blob: " << documentSigningURL << "; "
 #else


### PR DESCRIPTION
By adding this img-src to the content-security-policy it
makes possible updating images from a dialog without requiring
updating Collabora Online

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I3ca8934c3e6eb0ee78a36a483f45eaf5649c84d5
