### PR TITLE
Don't show 'reconnecting' on idle

### DIFF
--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -1419,7 +1419,8 @@ app.definitions.Socket = L.Class.extend({
 		setTimeout(function () {
 			if (!that._reconnecting) {
 				that._reconnecting = true;
-				that._map.showBusy(_('Reconnecting...'), false);
+				if (!that._map._documentIdle)
+					that._map.showBusy(_('Reconnecting...'), false);
 				that._map._activate();
 			}
 		}, 1 /* ms */);


### PR DESCRIPTION
When document become idle we had 2 different popups visible.
One about idle state and second: 'reconnecting'. We want only
idle one.
