### PR TITLE
fixes##3412 show arrow line when adding new annotation

### DIFF
--- a/loleaflet/src/layer/tile/CommentListSection.ts
+++ b/loleaflet/src/layer/tile/CommentListSection.ts
@@ -1410,7 +1410,7 @@ class CommentSection {
 				yOrigin = this.sectionProperties.commentList[selectedIndex].sectionProperties.data.anchorPix[1] - this.documentTopLeft[1];
 				var tempCrd: Array<number> = this.sectionProperties.commentList[selectedIndex].sectionProperties.data.anchorPix;
 				var resolved:string = this.sectionProperties.commentList[selectedIndex].sectionProperties.data.resolved;
-				if (resolved === 'false'|| this.sectionProperties.showResolved)
+				if (!resolved || resolved === 'false' || this.sectionProperties.showResolved)
 					this.showArrow([tempCrd[0], tempCrd[1]], [x, tempCrd[1]]);
 			}
 			else {


### PR DESCRIPTION
it allows to show line pointing from the place in document
where comment is inserted to the annotation "window"

