### PR TITLE
Optimize startsWith calls on StringVector elements

### DIFF
--- a/common/StringVector.hpp
+++ b/common/StringVector.hpp
@@ -136,6 +136,33 @@ public:
         return _string.compare(token._index, token._length, string, N) == 0;
     }
 
+    // Checks if the token text at index starts with the given string
+    template <std::size_t N>
+    bool startsWith(std::size_t index, const char (&string)[N]) const
+    {
+        if (index >= _tokens.size())
+        {
+            return false;
+        }
+
+        const StringToken& token = _tokens[index];
+        const auto len = N - 1; // we don't want to compare the '\0'
+        return token._length >= len && _string.compare(token._index, len, string) == 0;
+    }
+
+    // Checks if the token text starts with the given string
+    template <std::size_t N>
+    bool startsWith(const StringToken& token, const char (&string)[N]) const
+    {
+        if (token._index >= _tokens.size())
+        {
+            return false;
+        }
+
+        const auto len = N - 1; // we don't want to compare the '\0'
+        return token._length >= len && _string.compare(token._index, len, string) == 0;
+    }
+
     /// Compares the nth token with the mth token from another StringVector.
     bool equals(std::size_t index, const StringVector& other, std::size_t otherIndex);
 

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -1750,7 +1750,7 @@ bool ChildSession::unoCommand(const char* /*buffer*/, int /*length*/, const Stri
     const bool bNotify = (tokens[1] == ".uno:Save" ||
                           tokens[1] == ".uno:Undo" ||
                           tokens[1] == ".uno:Redo" ||
-                          Util::startsWith(tokens[1], "vnd.sun.star.script:"));
+                          tokens.startsWith(1, "vnd.sun.star.script:"));
 
     getLOKitDocument()->setView(_viewId);
 

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1591,7 +1591,7 @@ public:
                 {
                     renderCombinedTiles(tokens);
                 }
-                else if (Util::startsWith(tokens[0], "child-"))
+                else if (tokens.startsWith(0, "child-"))
                 {
                     forwardToChild(tokens[0], input);
                 }
@@ -2183,10 +2183,10 @@ protected:
             for (const auto& token : tokens)
             {
                 // Don't log user-data, there are anonymized versions that get logged instead.
-                if (Util::startsWith(tokens.getParam(token), "jail") ||
-                    Util::startsWith(tokens.getParam(token), "author") ||
-                    Util::startsWith(tokens.getParam(token), "name") ||
-                    Util::startsWith(tokens.getParam(token), "url"))
+                if (tokens.startsWith(token, "jail") ||
+                    tokens.startsWith(token, "author") ||
+                    tokens.startsWith(token, "name") ||
+                    tokens.startsWith(token, "url"))
                     continue;
 
                 logger << tokens.getParam(token) << ' ';

--- a/wsd/FileServerUtil.cpp
+++ b/wsd/FileServerUtil.cpp
@@ -50,17 +50,17 @@ std::string FileServerRequestHandler::uiDefaultsToJSON(const std::string& uiDefa
 
             continue;
         }
-        else if (Util::startsWith(keyValue[0], "Text"))
+        else if (keyValue.startsWith(0, "Text"))
         {
             currentDef = &textDefs;
             key = keyValue[0].substr(4);
         }
-        else if (Util::startsWith(keyValue[0], "Spreadsheet"))
+        else if (keyValue.startsWith(0, "Spreadsheet"))
         {
             currentDef = &spreadsheetDefs;
             key = keyValue[0].substr(11);
         }
-        else if (Util::startsWith(keyValue[0], "Presentation"))
+        else if (keyValue.startsWith(0, "Presentation"))
         {
             currentDef = &presentationDefs;
             key = keyValue[0].substr(12);


### PR DESCRIPTION
* Resolves: #2697 
* Target version: master 

### Summary

There was a pattern of calling Util::startsWith on StringVector
elements:

- Util::startsWith(tokens[0], "boo")
- Util::startsWith(tokens.getParam(token), "boo")

These two expressions would cause a new string to be allocated and
immediately released. To optimize this, a StringVector::startsWith
method is introduced.

This method works by calling compare directly on the underlying
StringVector string, avoiding creating a temporary string.


### TODO

~manually check that things work; I don't seem to be able to `make run` (no such rule), must have missed a step. Tests pass, and I checked that they break with a wrong startsWith implementation, so I have some confidence that this works, but would appreciate confirmation.~

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required