### PR TITLE
Remove unused Poco/Timestamp include

### DIFF
--- a/test/WopiTestServer.hpp
+++ b/test/WopiTestServer.hpp
@@ -19,7 +19,6 @@
 #include <Poco/RegularExpression.h>
 #include <Poco/Net/HTTPRequest.h>
 #include <Poco/URI.h>
-#include <Poco/Timestamp.h>
 #include <Poco/Util/LayeredConfiguration.h>
 #include <sstream>
 


### PR DESCRIPTION
* Resolves: #115 
* Target version: master 

### Summary

There was a stray include in `test/WopiTestServer.hpp`. I removed it, and things still build / tests pass. I think this doesn't affect the runtime at all, being limited to the `test/` directory, so it should be safe to merge.

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

