### PR TITLE
android: hide mobile-wizard slidesorter also in drawing

### DIFF
--- a/loleaflet/src/control/Control.MobileWizard.js
+++ b/loleaflet/src/control/Control.MobileWizard.js
@@ -164,7 +164,7 @@ L.Control.MobileWizard = L.Control.extend({
 		if (window.pageMobileWizard === true)
 			window.pageMobilewizard = false;
 
-		if (this._map.getDocType() === 'presentation')
+		if (this._map.getDocType() === 'presentation' || this._map.getDocType() === 'drawing')
 			this._hideSlideSorter();
 
 		if (window.commentWizard === true)


### PR DESCRIPTION
When opened pdf in android app, in comment wizard there was
slidesorter visible. Apply the same code as for presentation
which hides it.
