### PR TITLE
Fix bug in StringVector::startsWith and add tests

### DIFF
--- a/common/StringVector.hpp
+++ b/common/StringVector.hpp
@@ -154,7 +154,7 @@ public:
     template <std::size_t N>
     bool startsWith(const StringToken& token, const char (&string)[N]) const
     {
-        if (token._index >= _tokens.size())
+        if (token._index >= _string.size())
         {
             return false;
         }

--- a/test/WhiteBoxTests.cpp
+++ b/test/WhiteBoxTests.cpp
@@ -1162,6 +1162,31 @@ void WhiteBoxTests::testStringVector()
     CPPUNIT_ASSERT(vector.equals(0, vector2, 0));
     CPPUNIT_ASSERT(!vector.equals(0, vector2, 1));
 
+    // Test stringEquals().
+    StringVector vector3;
+    vector3.push_back("hello, world");
+    vector3.push_back("goodbye, world");
+
+    CPPUNIT_ASSERT(vector3.startsWith(0, "hello"));
+    CPPUNIT_ASSERT(vector3.startsWith(0, "hello, world"));
+    CPPUNIT_ASSERT(!vector3.startsWith(0, "hello, world!"));
+    CPPUNIT_ASSERT(!vector3.startsWith(0, "hello, world! super long text"));
+    CPPUNIT_ASSERT(vector3.startsWith(1, "goodbye"));
+    CPPUNIT_ASSERT(!vector3.startsWith(1, "hello"));
+
+    // Test stringEquals(), StringToken argument version
+    StringToken hello = *vector3.begin();
+    StringToken goodbye = *std::next(vector3.begin());
+    StringToken unrelated(50, 10); // out of vector3 range
+
+    CPPUNIT_ASSERT(vector3.startsWith(hello, "hello"));
+    CPPUNIT_ASSERT(vector3.startsWith(hello, "hello, world"));
+    CPPUNIT_ASSERT(!vector3.startsWith(hello, "hello, world!"));
+    CPPUNIT_ASSERT(!vector3.startsWith(hello, "hello, world! super long text"));
+    CPPUNIT_ASSERT(vector3.startsWith(goodbye, "goodbye"));
+    CPPUNIT_ASSERT(!vector3.startsWith(goodbye, "hello"));
+    CPPUNIT_ASSERT(!vector3.startsWith(unrelated, "hello"));
+
     {
         StringVector tokens;
         tokens.push_back("a=1");


### PR DESCRIPTION
* Resolves: #3428 
* Target version: master 

### Summary

The startsWith method that receives a StringToken was doing a bounds
check on the wrong parameter. This caused most calls to return false.

This commit adds some tests to both versions of StringVector::startsWith.

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

