### PR TITLE
Keep map focus after zoom animation end

### DIFF
--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -585,6 +585,7 @@ L.TileSectionManager = L.Class.extend({
 					painter.setWaitForTiles(false);
 					painter._sectionContainer.setZoomChanged(false);
 					map.enableTextInput();
+					map.focus(map.canAcceptKeyboardInput());
 					// Paint everything.
 					painter._sectionContainer.requestReDraw();
 					// Don't let a subsequent pinchZoom start before finishing all steps till this point.
@@ -598,7 +599,6 @@ L.TileSectionManager = L.Class.extend({
 			}
 
 			finishingRAF = requestAnimationFrame(finishAnimation);
-
 		};
 		finishAnimation();
 	},


### PR DESCRIPTION
When we had focus and cursor in the document and we click
zoom in/out on the statusbar on the desktop - in result we lost
focus and we cannot type.

Zoom animation disabled textarea used for input so it loses focus.
This change restores focus for it after animation end.

