### PR TITLE
Use tokens.equals() instead of tokens[] ==

### DIFF
--- a/common/MessageQueue.hpp
+++ b/common/MessageQueue.hpp
@@ -89,7 +89,7 @@ protected:
     virtual void put_impl(const Payload& value)
     {
         StringVector tokens = Util::tokenize(value.data(), value.size());
-        if (tokens[1] == "textinput")
+        if (tokens.equals(1, "textinput"))
         {
             const std::string newMsg = combineTextInput(tokens);
             if (!newMsg.empty())
@@ -98,7 +98,7 @@ protected:
                 return;
             }
         }
-        else if (tokens[1] == "removetextcontext")
+        else if (tokens.equals(1, "removetextcontext"))
         {
             const std::string newMsg = combineRemoveText(tokens);
             if (!newMsg.empty())
@@ -149,17 +149,17 @@ protected:
             // If any messages of these types are present before the current ("textinput") message,
             // no combination is possible.
             if (queuedTokens.size() == 1 ||
-                (queuedTokens[0] == tokens[0] &&
-                 (queuedTokens[1] == "key" ||
-                  queuedTokens[1] == "mouse" ||
-                  queuedTokens[1] == "removetextcontext" ||
-                  queuedTokens[1] == "windowkey")))
+                (queuedTokens.equals(0, tokens, 0) &&
+                 (queuedTokens.equals(1, "key") ||
+                  queuedTokens.equals(1, "mouse") ||
+                  queuedTokens.equals(1, "removetextcontext") ||
+                  queuedTokens.equals(1, "windowkey"))))
                 return std::string();
 
             std::string queuedId;
             std::string queuedText;
-            if (queuedTokens[0] == tokens[0] &&
-                queuedTokens[1] == "textinput" &&
+            if (queuedTokens.equals(0, tokens, 0) &&
+                queuedTokens.equals(1, "textinput") &&
                 LOOLProtocol::getTokenString(queuedTokens, "id", queuedId) &&
                 queuedId == id &&
                 LOOLProtocol::getTokenString(queuedTokens, "text", queuedText))
@@ -208,18 +208,18 @@ protected:
             // If any messages of these types are present before the current (removetextcontext)
             // message, no combination is possible.
             if (queuedTokens.size() == 1 ||
-                (queuedTokens[0] == tokens[0] &&
-                 (queuedTokens[1] == "key" ||
-                  queuedTokens[1] == "mouse" ||
-                  queuedTokens[1] == "textinput" ||
-                  queuedTokens[1] == "windowkey")))
+                (queuedTokens.equals(0, tokens, 0) &&
+                 (queuedTokens.equals(1, "key") ||
+                  queuedTokens.equals(1, "mouse") ||
+                  queuedTokens.equals(1, "textinput") ||
+                  queuedTokens.equals(1, "windowkey"))))
                 return std::string();
 
             std::string queuedId;
             int queuedBefore;
             int queuedAfter;
-            if (queuedTokens[0] == tokens[0] &&
-                queuedTokens[1] == "removetextcontext" &&
+            if (queuedTokens.equals(0, tokens, 0) &&
+                queuedTokens.equals(1, "removetextcontext") &&
                 LOOLProtocol::getTokenStringFromMessage(queuedMessage, "id", queuedId) &&
                 queuedId == id &&
                 LOOLProtocol::getTokenIntegerFromMessage(queuedMessage, "before", queuedBefore) &&

--- a/common/Seccomp.cpp
+++ b/common/Seccomp.cpp
@@ -291,21 +291,21 @@ void setRLimit(rlim_t confLim, int resource, const std::string &resourceText, co
 
 bool handleSetrlimitCommand(const StringVector& tokens)
 {
-    if (tokens.size() == 3 && tokens[0] == "setconfig")
+    if (tokens.size() == 3 && tokens.equals(0, "setconfig"))
     {
-        if (tokens[1] == "limit_virt_mem_mb")
+        if (tokens.equals(1, "limit_virt_mem_mb"))
         {
             setRLimit(std::stoi(tokens[2]) * 1024 * 1024, RLIMIT_AS, "RLIMIT_AS", "bytes");
         }
-        else if (tokens[1] == "limit_stack_mem_kb")
+        else if (tokens.equals(1, "limit_stack_mem_kb"))
         {
             setRLimit(std::stoi(tokens[2]) * 1024, RLIMIT_STACK, "RLIMIT_STACK", "bytes");
         }
-        else if (tokens[1] == "limit_file_size_mb")
+        else if (tokens.equals(1, "limit_file_size_mb"))
         {
             setRLimit(std::stoi(tokens[2]) * 1024 * 1024, RLIMIT_FSIZE, "RLIMIT_FSIZE", "bytes");
         }
-        else if (tokens[1] == "limit_num_open_files")
+        else if (tokens.equals(1, "limit_num_open_files"))
         {
             setRLimit(std::stoi(tokens[2]), RLIMIT_NOFILE, "RLIMIT_NOFILE", "files");
         }

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -1747,22 +1747,22 @@ bool ChildSession::unoCommand(const char* /*buffer*/, int /*length*/, const Stri
     unoCommandsRecorder.addUnoCommandInfo(formatUnoCommandInfo(getId(), tokens[1]));
 
     // we need to get LOK_CALLBACK_UNO_COMMAND_RESULT callback when saving
-    const bool bNotify = (tokens[1] == ".uno:Save" ||
-                          tokens[1] == ".uno:Undo" ||
-                          tokens[1] == ".uno:Redo" ||
+    const bool bNotify = (tokens.equals(1, ".uno:Save") ||
+                          tokens.equals(1, ".uno:Undo") ||
+                          tokens.equals(1, ".uno:Redo") ||
                           tokens.startsWith(1, "vnd.sun.star.script:"));
 
     getLOKitDocument()->setView(_viewId);
 
     if (tokens.size() == 2)
     {
-        if (tokens[1] == ".uno:fakeDiskFull")
+        if (tokens.equals(1, ".uno:fakeDiskFull"))
         {
             _docManager->alertAllUsers("internal", "diskfull");
         }
         else
         {
-            if (tokens[1] == ".uno:Copy" || tokens[1] == ".uno:CopyHyperlinkLocation")
+            if (tokens.equals(1, ".uno:Copy") || tokens.equals(1, ".uno:CopyHyperlinkLocation"))
                 _copyToClipboard = true;
 
             getLOKitDocument()->postUnoCommand(tokens[1].c_str(), nullptr, bNotify);
@@ -1997,9 +1997,9 @@ bool ChildSession::sendWindowCommand(const char* /*buffer*/, int /*length*/, con
 
     getLOKitDocument()->setView(_viewId);
 
-    if (tokens.size() > 2 && tokens[2] == "close")
+    if (tokens.size() > 2 && tokens.equals(2, "close"))
         getLOKitDocument()->postWindow(winId, LOK_WINDOW_CLOSE, nullptr);
-    else if (tokens.size() > 3 && tokens[2] == "paste")
+    else if (tokens.size() > 3 && tokens.equals(2, "paste"))
         getLOKitDocument()->postWindow(winId, LOK_WINDOW_PASTE, tokens[3].c_str());
 
     return true;

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -962,38 +962,38 @@ bool ClientSession::_handleInput(const char *buffer, int length)
     {
         return forwardToChild(std::string(buffer, length), docBroker);
     }
-    else if (tokens[0] == "outlinestate" ||
-             tokens[0] == "downloadas" ||
-             tokens[0] == "getchildid" ||
-             tokens[0] == "gettextselection" ||
-             tokens[0] == "paste" ||
-             tokens[0] == "insertfile" ||
-             tokens[0] == "key" ||
-             tokens[0] == "textinput" ||
-             tokens[0] == "windowkey" ||
-             tokens[0] == "mouse" ||
-             tokens[0] == "windowmouse" ||
-             tokens[0] == "windowgesture" ||
-             tokens[0] == "requestloksession" ||
-             tokens[0] == "resetselection" ||
-             tokens[0] == "saveas" ||
-             tokens[0] == "selectgraphic" ||
-             tokens[0] == "selecttext" ||
-             tokens[0] == "windowselecttext" ||
-             tokens[0] == "setpage" ||
-             tokens[0] == "uno" ||
-             tokens[0] == "useractive" ||
-             tokens[0] == "userinactive" ||
-             tokens[0] == "paintwindow" ||
-             tokens[0] == "windowcommand" ||
-             tokens[0] == "signdocument" ||
-             tokens[0] == "asksignaturestatus" ||
-             tokens[0] == "uploadsigneddocument" ||
-             tokens[0] == "exportsignanduploaddocument" ||
-             tokens[0] == "rendershapeselection" ||
-             tokens[0] == "resizewindow" ||
-             tokens[0] == "removetextcontext" ||
-             tokens[0] == "rendersearchresult")
+    else if (tokens.equals(0, "outlinestate") ||
+             tokens.equals(0, "downloadas") ||
+             tokens.equals(0, "getchildid") ||
+             tokens.equals(0, "gettextselection") ||
+             tokens.equals(0, "paste") ||
+             tokens.equals(0, "insertfile") ||
+             tokens.equals(0, "key") ||
+             tokens.equals(0, "textinput") ||
+             tokens.equals(0, "windowkey") ||
+             tokens.equals(0, "mouse") ||
+             tokens.equals(0, "windowmouse") ||
+             tokens.equals(0, "windowgesture") ||
+             tokens.equals(0, "requestloksession") ||
+             tokens.equals(0, "resetselection") ||
+             tokens.equals(0, "saveas") ||
+             tokens.equals(0, "selectgraphic") ||
+             tokens.equals(0, "selecttext") ||
+             tokens.equals(0, "windowselecttext") ||
+             tokens.equals(0, "setpage") ||
+             tokens.equals(0, "uno") ||
+             tokens.equals(0, "useractive") ||
+             tokens.equals(0, "userinactive") ||
+             tokens.equals(0, "paintwindow") ||
+             tokens.equals(0, "windowcommand") ||
+             tokens.equals(0, "signdocument") ||
+             tokens.equals(0, "asksignaturestatus") ||
+             tokens.equals(0, "uploadsigneddocument") ||
+             tokens.equals(0, "exportsignanduploaddocument") ||
+             tokens.equals(0, "rendershapeselection") ||
+             tokens.equals(0, "resizewindow") ||
+             tokens.equals(0, "removetextcontext") ||
+             tokens.equals(0, "rendersearchresult"))
     {
         if (tokens.equals(0, "key"))
             _keyEvents++;
@@ -1426,7 +1426,7 @@ bool ClientSession::handleKitToClientMessage(const char* buffer, const int lengt
 #endif
 
     const auto& tokens = payload->tokens();
-    if (tokens[0] == "unocommandresult:")
+    if (tokens.equals(0, "unocommandresult:"))
     {
         const std::string stringMsg(buffer, length);
         LOG_INF(getName() << ": Command: " << stringMsg);
@@ -1463,7 +1463,7 @@ bool ClientSession::handleKitToClientMessage(const char* buffer, const int lengt
             LOG_WRN("Expected json unocommandresult. Ignoring: " << stringMsg);
         }
     }
-    else if (tokens[0] == "error:")
+    else if (tokens.equals(0, "error:"))
     {
         std::string errorCommand;
         std::string errorKind;
@@ -1504,13 +1504,13 @@ bool ClientSession::handleKitToClientMessage(const char* buffer, const int lengt
             }
         }
     }
-    else if (tokens[0] == "curpart:" && tokens.size() == 2)
+    else if (tokens.equals(0, "curpart:") && tokens.size() == 2)
     {
         //TODO: Should forward to client?
         int curPart;
         return getTokenInteger(tokens[1], "part", curPart);
     }
-    else if (tokens[0] == "setpart:" && tokens.size() == 2)
+    else if (tokens.equals(0, "setpart:") && tokens.size() == 2)
     {
         if(!_isTextDocument)
         {
@@ -1530,7 +1530,7 @@ bool ClientSession::handleKitToClientMessage(const char* buffer, const int lengt
          }
     }
 #if !MOBILEAPP
-    else if (tokens.size() == 3 && tokens[0] == "saveas:")
+    else if (tokens.size() == 3 && tokens.equals(0, "saveas:"))
     {
 
         std::string encodedURL;
@@ -1685,12 +1685,12 @@ bool ClientSession::handleKitToClientMessage(const char* buffer, const int lengt
                 }
             }
         }
-    } else if (tokens[0] == "textselectioncontent:") {
+    } else if (tokens.equals(0, "textselectioncontent:")) {
 
         postProcessCopyPayload(payload);
         return forwardToClient(payload);
 
-    } else if (tokens[0] == "clipboardcontent:") {
+    } else if (tokens.equals(0, "clipboardcontent:")) {
 
 #if !MOBILEAPP // Most likely nothing of this makes sense in a mobile app
 
@@ -1745,13 +1745,13 @@ bool ClientSession::handleKitToClientMessage(const char* buffer, const int lengt
 #endif
         _clipSockets.clear();
         return true;
-    } else if (tokens[0] == "disconnected:") {
+    } else if (tokens.equals(0, "disconnected:")) {
 
         LOG_INF("End of disconnection handshake for " << getId());
         docBroker->finalRemoveSession(getId());
         return true;
     }
-    else if (tokens[0] == "formfieldbutton:") {
+    else if (tokens.equals(0, "formfieldbutton:")) {
         // Do not send redundant messages
         if (_lastSentFormFielButtonMessage == firstLine)
             return true;
@@ -1760,15 +1760,15 @@ bool ClientSession::handleKitToClientMessage(const char* buffer, const int lengt
 
     if (!isDocPasswordProtected())
     {
-        if (tokens[0] == "tile:")
+        if (tokens.equals(0, "tile:"))
         {
             assert(false && "Tile traffic should go through the DocumentBroker-LoKit WS.");
         }
-        else if (tokens[0] == "jsdialog:" && _state == ClientSession::SessionState::LOADING)
+        else if (tokens.equals(0, "jsdialog:") && _state == ClientSession::SessionState::LOADING)
         {
             docBroker->setInteractive(true);
         }
-        else if (tokens[0] == "status:")
+        else if (tokens.equals(0, "status:"))
         {
             setState(ClientSession::SessionState::LIVE);
             docBroker->setInteractive(false);
@@ -1812,7 +1812,7 @@ bool ClientSession::handleKitToClientMessage(const char* buffer, const int lengt
             // Forward the status response to the client.
             return forwardToClient(payload);
         }
-        else if (tokens[0] == "commandvalues:")
+        else if (tokens.equals(0, "commandvalues:"))
         {
             const std::string stringMsg(buffer, length);
             const std::size_t index = stringMsg.find_first_of('{');
@@ -1831,7 +1831,7 @@ bool ClientSession::handleKitToClientMessage(const char* buffer, const int lengt
                 }
             }
         }
-        else if (tokens[0] == "invalidatetiles:")
+        else if (tokens.equals(0, "invalidatetiles:"))
         {
             assert(firstLine.size() == static_cast<std::string::size_type>(length));
 
@@ -1841,7 +1841,7 @@ bool ClientSession::handleKitToClientMessage(const char* buffer, const int lengt
             handleTileInvalidation(firstLine, docBroker);
             return ret;
         }
-        else if (tokens[0] == "invalidatecursor:")
+        else if (tokens.equals(0, "invalidatecursor:"))
         {
             assert(firstLine.size() == static_cast<std::string::size_type>(length));
 
@@ -1870,7 +1870,7 @@ bool ClientSession::handleKitToClientMessage(const char* buffer, const int lengt
                 LOG_ERR("Unable to parse " << firstLine);
             }
         }
-        else if (tokens[0] == "renderfont:")
+        else if (tokens.equals(0, "renderfont:"))
         {
             std::string font, text;
             if (tokens.size() < 3 ||

--- a/wsd/FileServerUtil.cpp
+++ b/wsd/FileServerUtil.cpp
@@ -38,9 +38,9 @@ std::string FileServerRequestHandler::uiDefaultsToJSON(const std::string& uiDefa
         std::string key;
 
         // detect the UIMode or component
-        if (keyValue[0] == "UIMode")
+        if (keyValue.equals(0, "UIMode"))
         {
-            if (keyValue[1] == "classic" || keyValue[1] == "notebookbar")
+            if (keyValue.equals(1, "classic") || keyValue.equals(1, "notebookbar"))
             {
                 json.set("uiMode", keyValue[1]);
                 uiMode = keyValue[1];
@@ -77,7 +77,7 @@ std::string FileServerRequestHandler::uiDefaultsToJSON(const std::string& uiDefa
         if (key == "Ruler" || key == "Sidebar" || key == "Statusbar")
         {
             bool value(true);
-            if (keyValue[1] == "false" || keyValue[1] == "False" || keyValue[1] == "0")
+            if (keyValue.equals(1, "false") || keyValue.equals(1, "False") || keyValue.equals(1, "0"))
                 value = false;
 
             currentDef->set("Show" + key, value);


### PR DESCRIPTION
### Summary

I noticed that there are still some instances of tokens[1] == "blerp" that could be replaced with tokens.equals(1, "blerp"),
and some instances of tokens[1] == othertokens[2] that could be tokens.equals(1, othertokens, 2).

This change prevents additional strings from being allocated.

First mentioned here: https://github.com/CollaboraOnline/online/issues/2697#issuecomment-943224452

I did `make run` and checked that things worked, but I can't tell which part these affect so I'd appreciate a closer look into the change to see if I missed something.

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

