### PR TITLE
Clipboard.js: paste: avoid item types that has no data

### DIFF
--- a/loleaflet/src/map/Clipboard.js
+++ b/loleaflet/src/map/Clipboard.js
@@ -48,7 +48,6 @@ L.Clipboard = L.Class.extend({
 		document.onbeforecut = beforeSelect;
 		document.onbeforecopy = beforeSelect;
 		document.onbeforepaste = beforeSelect;
-		
 	},
 
 	// We can do a much better job when we fetch text/plain too.
@@ -172,7 +171,11 @@ L.Clipboard = L.Class.extend({
 		for (var t = 0; t < types.length; ++t) {
 			if (types[t] === 'Files')
 				continue; // images handled elsewhere.
-			var data = new Blob([dataTransfer.getData(types[t])]);
+			var dataStr = dataTransfer.getData(types[t]);
+			// Avoid types that has no content.
+			if (!dataStr.length)
+				continue;
+			var data = new Blob([dataStr]);
 			console.log('type ' + types[t] + ' length ' + data.size +
 				    ' -> 0x' + data.size.toString(16) + '\n');
 			content.push((types[t] === 'text' ? 'text/plain' : types[t]) + '\n');


### PR DESCRIPTION
In my case core's ScViewFunc::PasteDataFormat() attempts OLE clipboard
creation even though there is no data and raises exception(caught) and
the paste fails with a dialog.

![online-paste-error](https://user-images.githubusercontent.com/132960/138031448-3d1fe4ef-8a62-4b90-8c7c-35be187ad86d.png)


Signed-off-by: Dennis Francis <dennis.francis@collabora.com>
Change-Id: Ib0b9b860f100261f0bc0e4dc20791e8f3d8c1df1


* Resolves: # <!-- related github issue -->
* Target version: master 

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

