### PR TITLE
android: Blind fix for 0 byte output file after close

### DIFF
--- a/android/lib/src/main/java/org/libreoffice/androidlib/LOActivity.java
+++ b/android/lib/src/main/java/org/libreoffice/androidlib/LOActivity.java
@@ -543,6 +543,11 @@ public class LOActivity extends AppCompatActivity {
             try {
                 inputStream = new FileInputStream(mTempFile);
 
+                int len = inputStream.available();
+                if (len <= 0)
+                    // empty for some reason & do not write it back
+                    return;
+
                 Uri uri = getIntent().getData();
                 try {
                     outputStream = contentResolver.openOutputStream(uri, "wt");


### PR DESCRIPTION
for some reason if the input stream of the temp file becomes 0 byte
we should not try to write it back to the original file

Signed-off-by: Mert Tumer <mert.tumer@collabora.com>
Change-Id: Id1d2f623d5c7262c06f2c72dc813a8a81c786bc6


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

