### PR TITLE
Fix Draw Mobile UI has full screen slideshow button

### DIFF
--- a/loleaflet/src/control/Control.MobileTopBar.js
+++ b/loleaflet/src/control/Control.MobileTopBar.js
@@ -47,7 +47,7 @@ L.Control.MobileTopBar = L.Control.extend({
 				{type: 'button',  id: 'comment_wizard', img: 'viewcomments'},
 				{type: 'drop', id: 'userlist', img: 'users', hidden: true, html: L.control.createUserListWidget()},
 			];
-		} else if ((docType == 'presentation') || (docType == 'drawing')) {
+		} else if (docType == 'presentation') {
 			return [
 				{type: 'button',  id: 'closemobile',  img: 'closemobile'},
 				{type: 'button',  id: 'undo',  img: 'undo', hint: _UNO('.uno:Undo'), uno: 'Undo', disabled: true},
@@ -57,6 +57,17 @@ L.Control.MobileTopBar = L.Control.extend({
 				{type: 'button',  id: 'insertion_mobile_wizard', img: 'insertion_mobile_wizard', disabled: true},
 				{type: 'button',  id: 'comment_wizard', img: 'viewcomments'},
 				{type: 'button', id: 'fullscreen-' + docType, img: 'fullscreen-presentation', hint: _UNO('.uno:FullScreen', docType)},
+				{type: 'drop', id: 'userlist', img: 'users', hidden: true, html: L.control.createUserListWidget()},
+			];
+		} else if (docType == 'drawing') {
+			return [
+				{type: 'button',  id: 'closemobile',  img: 'closemobile'},
+				{type: 'button',  id: 'undo',  img: 'undo', hint: _UNO('.uno:Undo'), uno: 'Undo', disabled: true},
+				{type: 'button',  id: 'redo',  img: 'redo', hint: _UNO('.uno:Redo'), uno: 'Redo', disabled: true},
+				{type: 'spacer'},
+				{type: 'button',  id: 'mobile_wizard', img: 'mobile_wizard', disabled: true},
+				{type: 'button',  id: 'insertion_mobile_wizard', img: 'insertion_mobile_wizard', disabled: true},
+				{type: 'button',  id: 'comment_wizard', img: 'viewcomments'},
 				{type: 'drop', id: 'userlist', img: 'users', hidden: true, html: L.control.createUserListWidget()},
 			];
 		}


### PR DESCRIPTION
Make drawing buttons separete from presentation
It may be different for other items later not just slideshow
in the future

Signed-off-by: Mert Tumer <mert.tumer@collabora.com>
Change-Id: I1ae3bcc0cbb39e14ddd0a4192fecb7acbf0e4767


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

