### PR TITLE
Makefile: use separate rules for TS files with deps [co-6-4 only]

### DIFF
--- a/loleaflet/Makefile.am
+++ b/loleaflet/Makefile.am
@@ -29,13 +29,21 @@ endif
 
 DIRECTORY_TS = $(srcdir)/src/layer/tile $(srcdir)/src/control # Add ts directories here.
 SRC_TS_ALL := $(foreach dir, $(DIRECTORY_TS), $(wildcard $(dir)/*.ts))
-SRC_TS_JS_FILES = $(SRC_TS_ALL:.ts=.js) $(srcdir)/src/layer/vector/CanvasOverlay.js
+SRC_TS_JS_FILES = $(SRC_TS_ALL:.ts=.js)
 SRC_TS_JS_DST = $(patsubst $(srcdir)/%.js,$(DIST_FOLDER)/%.js,$(SRC_TS_JS_FILES))
 
-GENERATED_JS_FILES = $(if $(IS_DEBUG),$(SRC_TS_JS_DST),$(SRC_TS_JS_FILES))
+SRC_TS_JS_FILES_WITH_DEPS = $(srcdir)/src/layer/vector/CanvasOverlay.js
+SRC_TS_JS_DST_WITH_DEPS = $(patsubst $(srcdir)/%.js,$(DIST_FOLDER)/%.js,$(SRC_TS_JS_FILES_WITH_DEPS))
 
+GENERATED_JS_FILES = $(if $(IS_DEBUG),$(SRC_TS_JS_DST) $(SRC_TS_JS_DST_WITH_DEPS),$(SRC_TS_JS_FILES) $(SRC_TS_JS_FILES_WITH_DEPS))
+
+## Compilation of typescript files without dependencies.
 $(SRC_TS_JS_FILES): %.js: %.ts
 	$(builddir)/node_modules/typescript/bin/tsc $(@:.js=.ts) --outfile $@ --module none --lib dom,es2016 --target ES5
+
+## Individual rules for typescript files with dependencies.
+$(srcdir)/src/layer/vector/CanvasOverlay.js: $(wildcard $(srcdir)/src/layer/vector/*.ts) $(wildcard $(srcdir)/src/layer/marker/*.ts)
+	$(builddir)/node_modules/typescript/bin/tsc $(srcdir)/src/layer/vector/CanvasOverlay.ts --outfile $(srcdir)/src/layer/vector/CanvasOverlay.js --module none --lib dom,es2016 --target ES5
 
 MOCHA_DIR = $(srcdir)/mocha_tests
 MOCHA_TS_FILES = $(wildcard $(MOCHA_DIR)/*.ts)


### PR DESCRIPTION
When typescript files depend on other typescript files, we need
individual rules for each because make should know about the
dependencies to do compilation whenever there is a change in the
dependencies.

It may be possible to use the main rule for these files using custom
macro functions to calculate dependencies, but this became difficult to
read and understand when I tried to do that way.

Such problems do not exist in master branch where we let tsc to manage
compilation of all files as a project and dependencies are taken care
of.

Signed-off-by: Dennis Francis <dennis.francis@collabora.com>
Change-Id: If9376837844609f985db9cf204aa06f6ae4f4228


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

