### PR TITLE
comments: do not show grey background for bubbles

### DIFF
--- a/loleaflet/src/layer/tile/CommentListSection.ts
+++ b/loleaflet/src/layer/tile/CommentListSection.ts
@@ -212,7 +212,7 @@ class CommentSection {
 			|| this.sectionProperties.commentList.length === 0)
 			return;
 
-		this.size[0] = 70 * app.dpiScale;
+		this.size[0] = 1 * app.dpiScale;
 	}
 
 	public setExpanded() {
@@ -1486,6 +1486,9 @@ class CommentSection {
 			if (this.containerObject.getDocumentAnchorSection().size[0] > app.file.size.pixels[0]) {
 				x = topRight[0] - Math.round((this.containerObject.getDocumentAnchorSection().size[0] - app.file.size.pixels[0]) * 0.5);
 			}
+
+			if (this.isCollapsed)
+				x -= 70;
 
 			if (this.sectionProperties.selectedComment) {
 				selectedIndex = this.getRootIndexOf(this.sectionProperties.selectedComment.sectionProperties.data.id);


### PR DESCRIPTION
It simply makes section 1px wide and moves DOM elements 70px
to the left so it will be placed over the document's content.

before /after:
![beforeaftercomment](https://user-images.githubusercontent.com/5307369/138253358-341ac27a-45a9-48fa-8e42-786e1e6ff2b5.png)

(see grey area cropping the document on the left, sorry for not so good screenshot)
