### PR TITLE
jails: kit: name temporary directory with jail is instead random name

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -2511,10 +2511,10 @@ void lokit_main(
                     return false;
                 }
 
-                // Hard-random tmpdir inside the jail for added sercurity.
+                // tmpdir inside the jail for added sercurity.
                 const std::string tempRoot = Poco::Path(childRoot, "tmp").toString();
-                Poco::File(tempRoot).createDirectories();
-                const std::string tmpSubDir = FileUtil::createRandomTmpDir(tempRoot);
+                const std::string tmpSubDir = Poco::Path(tempRoot, "lool-" + jailId).toString();
+                Poco::File(tmpSubDir).createDirectories();
                 const std::string jailTmpDir = Poco::Path(jailPath, "tmp").toString();
                 LOG_INF("Mounting random temp dir " << tmpSubDir << " -> " << jailTmpDir);
                 if (!JailUtil::bind(tmpSubDir, jailTmpDir))


### PR DESCRIPTION
jail-id is already used a sub-directory of each tmp dir,
so there is no more "information leak" in making the tmp directory name itself match the jail-id

further naming it with jail id helps in referencing that directory for hard linking when quarantining a file

Signed-off-by: Pranam Lashkari <lpranam@collabora.com>
Change-Id: Iaa635f44d1cd99571a9571113ce1cc92e203fddb

* Target version: master 

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

