### PR TITLE
Make space for scrollbar in the sidebar

### DIFF
--- a/loleaflet/src/control/Control.LokDialog.js
+++ b/loleaflet/src/control/Control.LokDialog.js
@@ -1606,7 +1606,8 @@ L.Control.LokDialog = L.Control.extend({
 	},
 
 	_resizeSidebar: function(strId, width) {
-		document.getElementById('sidebar-dock-wrapper').style.minWidth = String(width) + 'px';
+		var minWidth = width > 0 ? width + 10 : width; // we need some space for scrollbar
+		document.getElementById('sidebar-dock-wrapper').style.minWidth = String(minWidth) + 'px';
 		this._currentDeck.width = width;
 		var deckOffset = 0;
 		var sidebar = L.DomUtil.get(strId);


### PR DESCRIPTION
Scrollbar is shown by the browser on top of a canvas.
Increase width for sidebar to keeps some space for it
when needed. Keep this space also when scrollbar is not
shown so we don't flicker and change size of sidebar when
it will be needed after resizing the window.
