### PR TITLE
clipboard: fix partial content read for text/html [master]

### DIFF
--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -318,6 +318,7 @@ void ClientSession::handleClipboardRequest(DocumentBroker::ClipboardRequest     
         LOG_TRC("Session [" << getId() << "] sending setclipboard");
         if (data.get())
         {
+            preProcessSetClipboardPayload(*data);
             docBroker->forwardToChild(getId(), "setclipboard\n" + *data);
 
             // FIXME: work harder for error detection ?
@@ -1379,6 +1380,8 @@ void ClientSession::writeQueuedMessages(std::size_t capacity)
 }
 
 // NB. also see loleaflet/src/map/Clipboard.js that does this in JS for stubs.
+// See also ClientSession::preProcessSetClipboardPayload() which removes the
+// <meta name="origin"...>  tag added here.
 void ClientSession::postProcessCopyPayload(const std::shared_ptr<Message>& payload)
 {
     // Insert our meta origin if we can
@@ -2285,6 +2288,30 @@ void ClientSession::traceTileBySend(const TileDesc& tile, bool deduplicated)
     // Record that the tile is sent
     if (!deduplicated)
         addTileOnFly(tile);
+}
+
+// This removes the <meta name="origin" ...> tag which was added in
+// ClientSession::postProcessCopyPayload(), else the payload parsing
+// in ChildSession::setClipboard() will fail.
+// To see why, refer
+// 1. ChildSession::getClipboard() where the data for various
+//    flavours along with flavour-type and length fields are packed into the payload.
+// 2. The clipboard payload parsing code in ClipboardData::read().
+void ClientSession::preProcessSetClipboardPayload(std::string& payload)
+{
+    std::size_t start = payload.find("<meta name=\"origin\" content=\"");
+    if (start != std::string::npos)
+    {
+        std::size_t end = payload.find("\"/>\n", start);
+        if (end == std::string::npos)
+        {
+            LOG_DBG("Found unbalanced <meta name=\"origin\".../> tag in setclipboard payload.");
+            return;
+        }
+
+        std::size_t len = end - start + 4;
+        payload.erase(start, len);
+    }
 }
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/ClientSession.hpp
+++ b/wsd/ClientSession.hpp
@@ -241,6 +241,10 @@ private:
     /// If this session is read-only because of failed lock, try to unlock and make it read-write.
     bool attemptLock(const std::shared_ptr<DocumentBroker>& docBroker);
 
+    /// Removes the <meta name="origin" ...> tag which was added in
+    /// ClientSession::postProcessCopyPayload().
+    static void preProcessSetClipboardPayload(std::string& payload);
+
 private:
     std::weak_ptr<DocumentBroker> _docBroker;
 


### PR DESCRIPTION
Problem:
In ClientSession::postProcessCopyPayload() the serialized form of
clipboard's text/html is modified to inject meta origin and sent to the
client. When this data is sent back from client to the server(possibly a
different one) to set the core clipboard via "setclipboard", the parser
gets confused because the 'text/html' part/flavour's data length as
originally set by the core the first time does not agree with the actual
length due to the meta origin injection done previously. As a result the
parsed results of 'text/html' is only partial and possibly the parsing
of subsequent flavours are affected.

Fix:
Add a preprocess step for the payload for setclipboard to
remove the meta origin tag from the payload before parsing is done
(in ChildSession).

Signed-off-by: Dennis Francis <dennis.francis@collabora.com>
Change-Id: I285f133829ea0f2dd1cd07d17e90f794ba9a6caf


* Resolves: # <!-- related github issue -->
* Target version: master 

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

