### PR TITLE
clipboard: fix partial content read for text/html [co64]

### DIFF
--- a/wsd/ClientSession.hpp
+++ b/wsd/ClientSession.hpp
@@ -241,6 +241,10 @@ private:
     /// If this session is read-only because of failed lock, try to unlock and make it read-write.
     bool attemptLock(const std::shared_ptr<DocumentBroker>& docBroker);
 
+    /// Removes the <meta name="origin" ...> tag which was added in
+    /// ClientSession::postProcessCopyPayload().
+    static void preProcessSetClipboardPayload(std::string& payload);
+
 private:
     std::weak_ptr<DocumentBroker> _docBroker;
 


### PR DESCRIPTION
Problem:
In ClientSession::postProcessCopyPayload() the serialized form of
clipboard's text/html is modified to inject meta origin and sent to the
client. When this data is sent back from client to the server(possibly a
different one) to set the core clipboard via "setclipboard", the parser
gets confused because the 'text/html' part/flavour's data length as
originally set by the core the first time does not agree with the actual
length due to the meta origin injection done previously. As a result the
parsed results of 'text/html' is only partial and possibly the parsing
of subsequent flavours are affected.

Fix:
Add a preprocess step for the payload for setclipboard to
remove the meta origin tag from the payload before parsing is done
(in ChildSession).

Signed-off-by: Dennis Francis <dennis.francis@collabora.com>
Change-Id: I285f133829ea0f2dd1cd07d17e90f794ba9a6caf


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

