### PR TITLE
wsd: Allow to pass ui defaults for drawings

### DIFF
--- a/loleaflet/src/map/Map.js
+++ b/loleaflet/src/map/Map.js
@@ -293,8 +293,7 @@ L.Map = L.Evented.extend({
 			this.initializeModificationIndicator();
 
 			// Show sidebar.
-			if (this._docLayer && !this._docLoadedOnce &&
-				(this._docLayer._docType === 'spreadsheet' || this._docLayer._docType === 'text' || this._docLayer._docType === 'presentation')) {
+			if (this._docLayer && !this._docLoadedOnce) {
 				// Let the first page finish loading then load the sidebar.
 				var map = this;
 				setTimeout(function () {

--- a/test/WhiteBoxTests.cpp
+++ b/test/WhiteBoxTests.cpp
@@ -1975,6 +1975,10 @@ void WhiteBoxTests::testUIDefaults()
 
     LOK_ASSERT_EQUAL(std::string("{\"presentation\":{\"ShowStatusbar\":false},\"spreadsheet\":{\"ShowSidebar\":false},\"text\":{\"ShowRuler\":true},\"uiMode\":\"notebookbar\"}"),
                      FileServerRequestHandler::uiDefaultsToJSON(";;UIMode=notebookbar;;PresentationStatusbar=false;;TextRuler=true;;bah=ugh;;SpreadsheetSidebar=false", uiMode));
+
+    LOK_ASSERT_EQUAL(std::string("{\"drawing\":{\"ShowStatusbar\":true},\"presentation\":{\"ShowStatusbar\":false},\"spreadsheet\":{\"ShowSidebar\":false},\"text\":{\"ShowRuler\":true},\"uiMode\":\"notebookbar\"}"),
+                     FileServerRequestHandler::uiDefaultsToJSON(";;UIMode=notebookbar;;PresentationStatusbar=false;;TextRuler=true;;bah=ugh;;SpreadsheetSidebar=false;;DrawingStatusbar=true", uiMode));
+
     LOK_ASSERT_EQUAL(std::string("notebookbar"), uiMode);
 }
 

--- a/wsd/FileServerUtil.cpp
+++ b/wsd/FileServerUtil.cpp
@@ -28,6 +28,7 @@ std::string FileServerRequestHandler::uiDefaultsToJSON(const std::string& uiDefa
     Poco::JSON::Object textDefs;
     Poco::JSON::Object spreadsheetDefs;
     Poco::JSON::Object presentationDefs;
+    Poco::JSON::Object drawingDefs;
 
     uiMode = "";
     StringVector tokens(Util::tokenize(uiDefaults, ';'));
@@ -65,6 +66,11 @@ std::string FileServerRequestHandler::uiDefaultsToJSON(const std::string& uiDefa
             currentDef = &presentationDefs;
             key = keyValue[0].substr(12);
         }
+        else if (Util::startsWith(keyValue[0], "Drawing"))
+        {
+            currentDef = &drawingDefs;
+            key = keyValue[0].substr(7);
+        }
         else
         {
             LOG_ERR("unknown UI default's component " << keyValue[0]);
@@ -97,6 +103,9 @@ std::string FileServerRequestHandler::uiDefaultsToJSON(const std::string& uiDefa
 
     if (presentationDefs.size() > 0)
         json.set("presentation", presentationDefs);
+
+    if (drawingDefs.size() > 0)
+        json.set("drawing", drawingDefs);
 
     std::ostringstream oss;
     Poco::JSON::Stringifier::stringify(json, oss);


### PR DESCRIPTION
* Target version: master 

### Summary

This implements passing ui defaults to the draw application similar how it is done for others.

### TODO

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

