### PR TITLE
Make Notebookbar the default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -783,10 +783,6 @@ AS_IF([test "$enable_welcome_message_button" = "yes"],
 AC_DEFINE_UNQUOTED([ENABLE_WELCOME_MESSAGE_BUTTON],["$ENABLE_WELCOME_MESSAGE_BUTTON"],[Should the Release notes message on startup should have a dismiss button instead of an x button to close by default?])
 AC_SUBST(ENABLE_WELCOME_MESSAGE_BUTTON)
 
-USER_INTERFACE_MODE='classic'
-AC_DEFINE_UNQUOTED([USER_INTERFACE_MODE],["$USER_INTERFACE_MODE"],[Which user interface mode should be activated])
-AC_SUBST(USER_INTERFACE_MODE)
-
 VEREIGN_URL=
 if test "$enable_vereign" = "yes"; then
     VEREIGN_URL="https://app.vereign.com"

--- a/ios/config.h.in
+++ b/ios/config.h.in
@@ -121,9 +121,6 @@
 /* Define to 1 if you have the ANSI C header files. */
 #define STDC_HEADERS 1
 
-/* Which user interface mode should be activated */
-#define USER_INTERFACE_MODE "classic"
-
 /* Default value of per_documents.document_signing_url */
 #define VEREIGN_URL ""
 

--- a/loolwsd.xml.in
+++ b/loolwsd.xml.in
@@ -171,7 +171,7 @@
     </welcome>
 
     <user_interface>
-      <mode type="string" desc="Controls the user interface style (classic|notebookbar)" default="@USER_INTERFACE_MODE@">@USER_INTERFACE_MODE@</mode>
+      <mode type="string" desc="Controls the user interface style (classic|notebookbar)" default="notebookbar">notebookbar</mode>
     </user_interface>
 
     <storage desc="Backend storage">

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -1127,7 +1127,7 @@ void LOOLWSD::innerInitialize(Application& self)
 #ifdef ENABLE_FEATURE_RESTRICTION
             { "restricted_commands", "" },
 #endif
-            { "user_interface.mode", USER_INTERFACE_MODE },
+            { "user_interface.mode", "notebookbar" },
             { "quarantine_files[@enable]", "false" },
             { "quarantine_files.limit_dir_size_mb", "250" },
             { "quarantine_files.max_versions_to_maintain", "2" },


### PR DESCRIPTION
With a default config, Notebookbar is shown.
With an old config without user_interface.mode set, classic
toolbar is shown.

Signed-off-by: Aron Budea <aron.budea@collabora.com>
Change-Id: I398d97fa975a0c52391547d2e791ff17e7effde6

* Target version: master 