### PR TITLE
cypress: fix: close sidebar so elements don't overlap

### DIFF
--- a/cypress_test/integration_tests/desktop/impress/annotation_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/annotation_spec.js
@@ -177,6 +177,13 @@ describe('Comment Scrolling',function() {
 
 	beforeEach(function() {
 		helper.beforeAll(testFileName, 'impress');
+
+		if (Cypress.env('USER_INTERFACE') === 'notebookbar') {
+			cy.get('#ModifyPage').click();
+		} else {
+			desktopHelper.hideSidebar();
+		}
+		desktopHelper.selectZoomLevel('50');
 	});
 
 	afterEach(function() {

--- a/cypress_test/integration_tests/multiuser/calc/repair_document_spec.js
+++ b/cypress_test/integration_tests/multiuser/calc/repair_document_spec.js
@@ -32,6 +32,8 @@ describe('Repair Document', function() {
 
 		helper.typeIntoDocument('Hello{enter}', frameId2);
 
+		cy.wait(1000);
+
 		cy.customGet('#menu-editmenu', frameId2).click()
 			.customGet('#menu-repair', frameId2).click();
 


### PR DESCRIPTION
Signed-off-by: Rash419 <rashesh.padia@collabora.com>
Change-Id: Iab554b3866edb4dec0c42f501b9d62e2b5369929

* Target version: master 

