### PR TITLE
calc: fix comment addition - wrong coordinates

### DIFF
--- a/loleaflet/src/geometry/Bounds.js
+++ b/loleaflet/src/geometry/Bounds.js
@@ -220,6 +220,18 @@ L.Bounds.prototype = {
 	equals: function (bounds) { // (Bounds) -> Boolean
 		return this.min.equals(bounds.min) && this.max.equals(bounds.max);
 	},
+
+	toRectangle: function () { // () -> Number[]
+		return [
+			this.min.x, this.min.y,
+			this.max.x - this.min.x,
+			this.max.y - this.min.y
+		];
+	},
+
+	toCoreString: function () { // () -> String
+		return this.min.x + ', ' + this.min.y + ', ' + (this.max.x - this.min.x) + ', ' + (this.max.y - this.min.y);
+	}
 };
 
 L.bounds = function (a, b) { // (Bounds) or (Point, Point) or (Point[])

--- a/loleaflet/src/layer/tile/CalcTileLayer.js
+++ b/loleaflet/src/layer/tile/CalcTileLayer.js
@@ -717,10 +717,9 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 			app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).clearList();
 			app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).importComments(values.comments);
 		} else if (values.commentsPos) {
+			var section = app.sectionContainer.getSectionWithName(L.CSections.CommentList.name);
 			for (var index in values.commentsPos) {
 				comment = values.commentsPos[index];
-
-				var section = app.sectionContainer.getSectionWithName(L.CSections.CommentList.name);
 				if (section)
 				{
 					var commentObject;
@@ -736,6 +735,10 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 						commentObject.sectionProperties.data.cellPos = section.stringToRectangles(comment.cellPos)[0];
 				}
 			}
+
+			if (section)
+				section.onCommentsDataUpdate();
+
 		} else {
 			L.TileLayer.prototype._onCommandValuesMsg.call(this, textMsg);
 		}

--- a/loleaflet/src/layer/tile/CommentListSection.ts
+++ b/loleaflet/src/layer/tile/CommentListSection.ts
@@ -1603,6 +1603,12 @@ class CommentSection {
 		this.checkSize();
 	}
 
+	public onCommentsDataUpdate() {
+		for (var i: number = this.sectionProperties.commentList.length -1; i > -1; i--) {
+			this.sectionProperties.commentList[i].onCommentDataUpdate();
+		}
+	}
+
 	public onMouseUp () {}
 	public onMouseDown () {}
 	public onMouseEnter () {}

--- a/loleaflet/src/layer/tile/CommentSection.ts
+++ b/loleaflet/src/layer/tile/CommentSection.ts
@@ -467,8 +467,8 @@ class Comment {
 	}
 
 	private updatePosition () {
-		if (this.convertRectanglesToCoreCoordinates())
-			this.setPositionAndSize();
+		this.convertRectanglesToCoreCoordinates();
+		this.setPositionAndSize();
 	}
 
 	private updateAnnotationMarker () {
@@ -876,6 +876,11 @@ class Comment {
 	}
 
 	public onNewDocumentTopLeft () {
+		this.doPendingInitializationInView();
+		this.updatePosition();
+	}
+
+	public onCommentDataUpdate() {
 		this.doPendingInitializationInView();
 		this.updatePosition();
 	}

--- a/loleaflet/src/layer/tile/TileLayer.js
+++ b/loleaflet/src/layer/tile/TileLayer.js
@@ -921,6 +921,12 @@ L.TileLayer = L.GridLayer.extend({
 		}
 		else if (textMsg.startsWith('comment:')) {
 			var obj = JSON.parse(textMsg.substring('comment:'.length + 1));
+			if (obj.comment.cellPos) {
+				// cellPos is in print-twips so convert to display twips.
+				var cellPos = L.Bounds.parse(obj.comment.cellPos);
+				cellPos = this._convertToTileTwipsSheetArea(cellPos);
+				obj.comment.cellPos = cellPos.toCoreString();
+			}
 			app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).onACKComment(obj);
 		}
 		else if (textMsg.startsWith('redlinetablemodified:')) {
@@ -1400,7 +1406,7 @@ L.TileLayer = L.GridLayer.extend({
 			this._cellCursorPixels = L.LOUtil.createRectangle(start.x, start.y, offsetPixels.x, offsetPixels.y);
 			app.file.calc.cellCursor.address = [parseInt(strTwips[4]), parseInt(strTwips[5])];
 			app.file.calc.cellCursor.rectangle.pixels = [Math.round(start.x), Math.round(start.y), Math.round(offsetPixels.x), Math.round(offsetPixels.y)];
-			app.file.calc.cellCursor.rectangle.twips = [parseInt(strTwips[0]), parseInt(strTwips[1]), parseInt(strTwips[2]), parseInt(strTwips[3])];
+			app.file.calc.cellCursor.rectangle.twips = this._cellCursorTwips.toRectangle();
 			app.file.calc.cellCursor.visible = true;
 			if (autofillMarkerSection)
 				autofillMarkerSection.calculatePositionViaCellCursor([this._cellCursorPixels.getX2(), this._cellCursorPixels.getY2()]);


### PR DESCRIPTION
### Issues fixed

1. Select a cell and add comment via menu etc. The popup for adding comment is wrongly positioned (invisible when cell is far away from A1).

2. Hover over area of cell with comment with mouse. The popup may not appear esp. when cell is far away from A1.

### Fixes made

1. 'comment:' message will have cellPos in print-twips so convert that
   to display twips before using it to draw.

2. use cursor-bounds in display twips for comments.

3. update display positions of comments whenever we receive commentPos
   update from core.

4. Comment.updatePosition() must call both
   convertRectanglesToCoreCoordinates() and setPositionAndSize().
   Previously we called setPositionAndSize() only if the rectangle is
   within view. This is not enough for the case of new comments added
   via UI.

Signed-off-by: Dennis Francis <dennis.francis@collabora.com>
Change-Id: Ia21724c3fd60161387c9c0e819e019d63dfab43f

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

