### PR TITLE
Keep branding theme dynamic

### DIFF
--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -939,8 +939,8 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     Poco::replaceInPlace(preprocess, std::string("%HEXIFY_URL%"), hexifyEmbeddedUrls);
 
     std::string themePreFix = (theme == "nextcloud") ? theme + "/" : "";
-    static const std::string linkCSS("<link rel=\"stylesheet\" href=\"%s/loleaflet/" LOOLWSD_VERSION_HASH "/" + themePreFix + "%s.css\">");
-    static const std::string scriptJS("<script src=\"%s/loleaflet/" LOOLWSD_VERSION_HASH "/" + themePreFix+ "%s.js\"></script>");
+    const std::string linkCSS("<link rel=\"stylesheet\" href=\"%s/loleaflet/" LOOLWSD_VERSION_HASH "/" + themePreFix + "%s.css\">");
+    const std::string scriptJS("<script src=\"%s/loleaflet/" LOOLWSD_VERSION_HASH "/" + themePreFix + "%s.js\"></script>");
 
     std::string brandCSS(Poco::format(linkCSS, responseRoot, std::string(BRANDING)));
     std::string brandJS(Poco::format(scriptJS, responseRoot, std::string(BRANDING)));


### PR DESCRIPTION
Should resolve the issue I've noticed back when testing https://github.com/CollaboraOnline/online/pull/3201 but when retesting it again now i think I've catched the issue there, but would appreciate some double checking if this really makes sense.

As far as I remember local static variables would be kept even when leaving the block so that seems to have caused that once the css/js links were initialized a change of the theme url parameter was not taking any effect.