### PR TITLE
calc: fix comment addition - wrong coordinates [master]

### DIFF
--- a/loleaflet/src/geometry/Bounds.ts
+++ b/loleaflet/src/geometry/Bounds.ts
@@ -236,6 +236,18 @@ export class Bounds {
 		return this.min.equals(bounds.min) && this.max.equals(bounds.max);
 	}
 
+	public toRectangle(): number[] {
+		return [
+			this.min.x, this.min.y,
+			this.max.x - this.min.x,
+			this.max.y - this.min.y
+		];
+	}
+
+	public toCoreString(): string {
+		return this.min.x + ', ' + this.min.y + ', ' + (this.max.x - this.min.x) + ', ' + (this.max.y - this.min.y);
+	}
+
 	public static toBounds(a: Bounds | PointConvertable | PointConvertable[], b?: PointConvertable): Bounds {
 		if (!a || a instanceof Bounds) {
 			return <Bounds>a;

--- a/loleaflet/src/layer/tile/CalcTileLayer.js
+++ b/loleaflet/src/layer/tile/CalcTileLayer.js
@@ -714,10 +714,9 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 			app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).clearList();
 			app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).importComments(values.comments);
 		} else if (values.commentsPos) {
+			var section = app.sectionContainer.getSectionWithName(L.CSections.CommentList.name);
 			for (var index in values.commentsPos) {
 				comment = values.commentsPos[index];
-
-				var section = app.sectionContainer.getSectionWithName(L.CSections.CommentList.name);
 				if (section)
 				{
 					var commentObject;
@@ -733,6 +732,10 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 						commentObject.sectionProperties.data.cellPos = section.stringToRectangles(comment.cellPos)[0];
 				}
 			}
+
+			if (section)
+				section.onCommentsDataUpdate();
+
 		} else {
 			L.CanvasTileLayer.prototype._onCommandValuesMsg.call(this, textMsg);
 		}

--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -1634,6 +1634,12 @@ L.CanvasTileLayer = L.Layer.extend({
 		}
 		else if (textMsg.startsWith('comment:')) {
 			var obj = JSON.parse(textMsg.substring('comment:'.length + 1));
+			if (obj.comment.cellPos) {
+				// cellPos is in print-twips so convert to display twips.
+				var cellPos = L.Bounds.parse(obj.comment.cellPos);
+				cellPos = this._convertToTileTwipsSheetArea(cellPos);
+				obj.comment.cellPos = cellPos.toCoreString();
+			}
 			app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).onACKComment(obj);
 		}
 		else if (textMsg.startsWith('redlinetablemodified:')) {
@@ -2116,7 +2122,7 @@ L.CanvasTileLayer = L.Layer.extend({
 			this._cellCursorPixels = L.LOUtil.createRectangle(start.x, start.y, offsetPixels.x, offsetPixels.y);
 			app.file.calc.cellCursor.address = [parseInt(strTwips[4]), parseInt(strTwips[5])];
 			app.file.calc.cellCursor.rectangle.pixels = [Math.round(start.x), Math.round(start.y), Math.round(offsetPixels.x), Math.round(offsetPixels.y)];
-			app.file.calc.cellCursor.rectangle.twips = [parseInt(strTwips[0]), parseInt(strTwips[1]), parseInt(strTwips[2]), parseInt(strTwips[3])];
+			app.file.calc.cellCursor.rectangle.twips = this._cellCursorTwips.toRectangle();
 			app.file.calc.cellCursor.visible = true;
 			if (autofillMarkerSection)
 				autofillMarkerSection.calculatePositionViaCellCursor([this._cellCursorPixels.getX2(), this._cellCursorPixels.getY2()]);
@@ -2124,7 +2130,7 @@ L.CanvasTileLayer = L.Layer.extend({
 			this._cellCursorXY = new L.Point(parseInt(strTwips[4]), parseInt(strTwips[5]));
 
 			app.file.calc.cellCursor.visible = true;
-			app.file.calc.cellCursor.rectangle.twips = [parseInt(strTwips[0]), parseInt(strTwips[1]), parseInt(strTwips[2]), parseInt(strTwips[3])];
+			app.file.calc.cellCursor.rectangle.twips = this._cellCursorTwips.toRectangle();
 			app.file.calc.cellCursor.rectangle.pixels = [start.x, start.y, offsetPixels.x, offsetPixels.y];
 			app.file.calc.cellCursor.address = [parseInt(strTwips[4]), parseInt(strTwips[5])];
 		}

--- a/loleaflet/src/layer/tile/CommentListSection.ts
+++ b/loleaflet/src/layer/tile/CommentListSection.ts
@@ -1726,6 +1726,12 @@ class CommentSection {
 		this.checkSize();
 	}
 
+	public onCommentsDataUpdate() {
+		for (var i: number = this.sectionProperties.commentList.length -1; i > -1; i--) {
+			this.sectionProperties.commentList[i].onCommentDataUpdate();
+		}
+	}
+
 	public onMouseUp () { return; }
 	public onMouseDown () { return; }
 	public onMouseEnter () { return; }

--- a/loleaflet/src/layer/tile/CommentSection.ts
+++ b/loleaflet/src/layer/tile/CommentSection.ts
@@ -487,8 +487,8 @@ class Comment {
 	}
 
 	private updatePosition () {
-		if (this.convertRectanglesToCoreCoordinates())
-			this.setPositionAndSize();
+		this.convertRectanglesToCoreCoordinates();
+		this.setPositionAndSize();
 	}
 
 	private updateAnnotationMarker () {
@@ -911,6 +911,11 @@ class Comment {
 	}
 
 	public onNewDocumentTopLeft () {
+		this.doPendingInitializationInView();
+		this.updatePosition();
+	}
+
+	public onCommentDataUpdate() {
 		this.doPendingInitializationInView();
 		this.updatePosition();
 	}


### PR DESCRIPTION
Fixes:

1. 'comment:' message will have cellPos in print-twips so convert that
   to display twips before using it to draw.

2. use cursor-bounds in display twips for comments.

3. update display positions of comments whenever we receive commentPos
   update from core.

4. Comment.updatePosition() must call both
   convertRectanglesToCoreCoordinates() and setPositionAndSize().
   Previously we called setPositionAndSize() only if the rectangle is
   within view. This is not enough for the case of new comments added
   via UI.

Conflicts:
	loleaflet/src/geometry/Bounds.js
	loleaflet/src/layer/tile/CommentListSection.ts
	loleaflet/src/layer/tile/TileLayer.js

Signed-off-by: Dennis Francis <dennis.francis@collabora.com>
Change-Id: Ia21724c3fd60161387c9c0e819e019d63dfab43f

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

