### PR TITLE
android: Attempt to fix modification time issue

### DIFF
--- a/android/lib/src/main/java/org/libreoffice/androidlib/LOActivity.java
+++ b/android/lib/src/main/java/org/libreoffice/androidlib/LOActivity.java
@@ -117,8 +117,6 @@ public class LOActivity extends AppCompatActivity {
     private boolean isDocEditable = false;
     private boolean isDocDebuggable = BuildConfig.DEBUG;
     private boolean documentLoaded = false;
-    private boolean modifiedStatus = false;
-    private boolean shouldCopyTempBack = false;
 
     private ClipboardManager clipboardManager;
     private ClipData clipData;
@@ -418,7 +416,7 @@ public class LOActivity extends AppCompatActivity {
             public void run() {
                 documentLoaded = false;
                 postMobileMessageNative("BYE");
-                copyTempBackToIntent();
+                //copyTempBackToIntent();
                 runOnUiThread(new Runnable() {
                     @Override
                     public void run() {
@@ -531,11 +529,6 @@ public class LOActivity extends AppCompatActivity {
     private void copyTempBackToIntent() {
         if (!isDocEditable || mTempFile == null || getIntent().getData() == null || !getIntent().getData().getScheme().equals(ContentResolver.SCHEME_CONTENT))
             return;
-        // no need to write back unmodified file
-        // this will prevent file from updating the modification time.
-        if (!shouldCopyTempBack) {
-            return;
-        }
 
         ContentResolver contentResolver = getContentResolver();
         InputStream inputStream = null;
@@ -568,7 +561,6 @@ public class LOActivity extends AppCompatActivity {
                 }
 
                 Log.i(TAG, "Success copying " + bytes + " bytes from " + mTempFile + " to " + uri);
-                shouldCopyTempBack = modifiedStatus;
             } finally {
                 if (inputStream != null)
                     inputStream.close();
@@ -775,7 +767,7 @@ public class LOActivity extends AppCompatActivity {
             public void run() {
                 documentLoaded = false;
                 postMobileMessageNative("BYE");
-                copyTempBackToIntent();
+                //copyTempBackToIntent();
 
                 runOnUiThread(new Runnable() {
                     @Override
@@ -971,19 +963,6 @@ public class LOActivity extends AppCompatActivity {
                     }
                 }
             });
-        } else if (message.startsWith("'statechanged: .uno:ModifiedStatus=")) {
-            final String modifiedStatusString = "'statechanged: .uno:ModifiedStatus=";
-            int start = modifiedStatusString.length();
-            int end = message.indexOf("'", start);
-            try {
-                modifiedStatus = Boolean.parseBoolean(message.substring(start, end));
-                // dont set it to false just yet because we may not write it back by the time .uno:Save is processed and set it to false
-                if (modifiedStatus)
-                    shouldCopyTempBack = true;
-            } catch (Exception e) {
-                // better be safe than sorry
-                shouldCopyTempBack = true;
-            }
         }
     }
 


### PR DESCRIPTION
the issue is when there's no change in the document, the modification time is
still being updated. The current approach was using the modified status
message but appearently due to it's sent delayed, it caused the changes
being not saved. We already upload the changes on uno callback result
of uno:Save command if it is sucessfull and it should be enough.
No need to copy back the temp file on after killing the document because
it also saves the file thus it updates the original file before the exit.

Signed-off-by: Mert Tumer <mert.tumer@collabora.com>
Change-Id: I2a26a3bc6d55ac0a090c4e4d89e47544c545f8d1


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

