### PR TITLE
Simplified DocKey processing in incoming requests

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -87,21 +87,6 @@ void DocumentBroker::broadcastLastModificationTime(
     broadcastMessage(message);
 }
 
-std::string DocumentBroker::getDocKey(const Poco::URI& uri)
-{
-    // If multiple host-names are used to access us, then
-    // they must be aliases. Permission to access aliased hosts
-    // is checked at the point of accepting incoming connections.
-    // At this point storing the hostname artificially discriminates
-    // between aliases and forces same document (when opened from
-    // alias hosts) to load as separate documents and sharing doesn't
-    // work. Worse, saving overwrites one another.
-    std::string docKey;
-    Poco::URI::encode(uri.getPath(), "", docKey);
-    LOG_INF("DocKey from URI [" << uri.getPath() << "] => [" << docKey << ']');
-    return docKey;
-}
-
 /// The Document Broker Poll - one of these in a thread per document
 class DocumentBroker::DocumentBrokerPoll final : public TerminatingPoll
 {

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -98,6 +98,7 @@ std::string DocumentBroker::getDocKey(const Poco::URI& uri)
     // work. Worse, saving overwrites one another.
     std::string docKey;
     Poco::URI::encode(uri.getPath(), "", docKey);
+    LOG_INF("DocKey from URI [" << uri.getPath() << "] => [" << docKey << ']');
     return docKey;
 }
 

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -231,10 +231,6 @@ public:
         Interactive, Batch
     };
 
-    /// Returns a document-specific key based
-    /// on the URI of the document.
-    static std::string getDocKey(const Poco::URI& uri);
-
     /// Dummy document broker that is marked to destroy.
     DocumentBroker();
 

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -231,11 +231,6 @@ public:
         Interactive, Batch
     };
 
-    static Poco::URI sanitizeURI(const std::string& uri)
-    {
-        return RequestDetails::sanitizeURI(uri);
-    }
-
     /// Returns a document-specific key based
     /// on the URI of the document.
     static std::string getDocKey(const Poco::URI& uri);

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -2974,7 +2974,7 @@ private:
             return;
         }
 
-        const auto docKey = DocumentBroker::getDocKey(RequestDetails::sanitizeURI(WOPISrc));
+        const auto docKey = RequestDetails::getDocKey(WOPISrc);
 
         std::shared_ptr<DocumentBroker> docBroker;
         {
@@ -3246,7 +3246,7 @@ private:
             if (!fromPath.empty() && !format.empty())
             {
                 Poco::URI uriPublic = RequestDetails::sanitizeURI(fromPath);
-                const std::string docKey = DocumentBroker::getDocKey(uriPublic);
+                const std::string docKey = RequestDetails::getDocKey(uriPublic);
 
                 std::string options;
                 const bool fullSheetPreview
@@ -3293,7 +3293,7 @@ private:
 
                 // Validate the docKey
                 const std::string decodedUri = requestDetails.getDocumentURI();
-                const std::string docKey = DocumentBroker::getDocKey(RequestDetails::sanitizeURI(decodedUri));
+                const std::string docKey = RequestDetails::getDocKey(decodedUri);
 
                 std::unique_lock<std::mutex> docBrokersLock(DocBrokersMutex);
                 auto docBrokerIt = DocBrokers.find(docKey);
@@ -3337,7 +3337,7 @@ private:
 
             // 1. Validate the dockey
             const std::string decodedUri = requestDetails.getDocumentURI();
-            const std::string docKey = DocumentBroker::getDocKey(RequestDetails::sanitizeURI(decodedUri));
+            const std::string docKey = RequestDetails::getDocKey(decodedUri);
 
             std::unique_lock<std::mutex> docBrokersLock(DocBrokersMutex);
             auto docBrokerIt = DocBrokers.find(docKey);
@@ -3425,7 +3425,7 @@ private:
                 return;
 
             Poco::URI uriPublic = RequestDetails::sanitizeURI(fromPath);
-            const std::string docKey = DocumentBroker::getDocKey(uriPublic);
+            const std::string docKey = RequestDetails::getDocKey(uriPublic);
 
             // This lock could become a bottleneck.
             // In that case, we can use a pool and index by publicPath.
@@ -3462,7 +3462,7 @@ private:
 
         LOG_INF("URL [" << url << "] for Proxy request.");
         const auto uriPublic = RequestDetails::sanitizeURI(url);
-        const auto docKey = DocumentBroker::getDocKey(uriPublic);
+        const auto docKey = RequestDetails::getDocKey(uriPublic);
         const std::string fileId = Util::getFilenameFromURL(docKey);
         Util::mapAnonymized(fileId, fileId); // Identity mapping, since fileId is already obfuscated
 
@@ -3561,7 +3561,7 @@ private:
 
             LOG_INF("URL [" << url << "] for WS Request.");
             const auto uriPublic = RequestDetails::sanitizeURI(url);
-            const auto docKey = DocumentBroker::getDocKey(uriPublic);
+            const auto docKey = RequestDetails::getDocKey(uriPublic);
             const std::string fileId = Util::getFilenameFromURL(docKey);
             Util::mapAnonymized(fileId, fileId); // Identity mapping, since fileId is already obfuscated
 

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -2974,7 +2974,7 @@ private:
             return;
         }
 
-        const auto docKey = DocumentBroker::getDocKey(DocumentBroker::sanitizeURI(WOPISrc));
+        const auto docKey = DocumentBroker::getDocKey(RequestDetails::sanitizeURI(WOPISrc));
 
         std::shared_ptr<DocumentBroker> docBroker;
         {
@@ -3245,7 +3245,7 @@ private:
             LOG_INF("Conversion request for URI [" << fromPath << "] format [" << format << "].");
             if (!fromPath.empty() && !format.empty())
             {
-                Poco::URI uriPublic = DocumentBroker::sanitizeURI(fromPath);
+                Poco::URI uriPublic = RequestDetails::sanitizeURI(fromPath);
                 const std::string docKey = DocumentBroker::getDocKey(uriPublic);
 
                 std::string options;
@@ -3293,7 +3293,7 @@ private:
 
                 // Validate the docKey
                 const std::string decodedUri = requestDetails.getDocumentURI();
-                const std::string docKey = DocumentBroker::getDocKey(DocumentBroker::sanitizeURI(decodedUri));
+                const std::string docKey = DocumentBroker::getDocKey(RequestDetails::sanitizeURI(decodedUri));
 
                 std::unique_lock<std::mutex> docBrokersLock(DocBrokersMutex);
                 auto docBrokerIt = DocBrokers.find(docKey);
@@ -3337,7 +3337,7 @@ private:
 
             // 1. Validate the dockey
             const std::string decodedUri = requestDetails.getDocumentURI();
-            const std::string docKey = DocumentBroker::getDocKey(DocumentBroker::sanitizeURI(decodedUri));
+            const std::string docKey = DocumentBroker::getDocKey(RequestDetails::sanitizeURI(decodedUri));
 
             std::unique_lock<std::mutex> docBrokersLock(DocBrokersMutex);
             auto docBrokerIt = DocBrokers.find(docKey);
@@ -3424,7 +3424,7 @@ private:
             if (fromPath.empty())
                 return;
 
-            Poco::URI uriPublic = DocumentBroker::sanitizeURI(fromPath);
+            Poco::URI uriPublic = RequestDetails::sanitizeURI(fromPath);
             const std::string docKey = DocumentBroker::getDocKey(uriPublic);
 
             // This lock could become a bottleneck.
@@ -3460,11 +3460,9 @@ private:
         //FIXME: The DocumentURI includes the WOPISrc, which makes it potentially invalid URI.
         const std::string url = requestDetails.getLegacyDocumentURI();
 
-        LOG_INF("URL [" << url << "].");
-        const auto uriPublic = DocumentBroker::sanitizeURI(url);
-        LOG_INF("URI [" << uriPublic.getPath() << "].");
+        LOG_INF("URL [" << url << "] for Proxy request.");
+        const auto uriPublic = RequestDetails::sanitizeURI(url);
         const auto docKey = DocumentBroker::getDocKey(uriPublic);
-        LOG_INF("DocKey [" << docKey << "].");
         const std::string fileId = Util::getFilenameFromURL(docKey);
         Util::mapAnonymized(fileId, fileId); // Identity mapping, since fileId is already obfuscated
 
@@ -3561,11 +3559,9 @@ private:
 #endif
             }
 
-            LOG_INF("URL [" << url << "].");
-            const auto uriPublic = DocumentBroker::sanitizeURI(url);
-            LOG_INF("URI [" << uriPublic.getPath() << "].");
+            LOG_INF("URL [" << url << "] for WS Request.");
+            const auto uriPublic = RequestDetails::sanitizeURI(url);
             const auto docKey = DocumentBroker::getDocKey(uriPublic);
-            LOG_INF("DocKey [" << docKey << "].");
             const std::string fileId = Util::getFilenameFromURL(docKey);
             Util::mapAnonymized(fileId, fileId); // Identity mapping, since fileId is already obfuscated
 

--- a/wsd/RequestDetails.cpp
+++ b/wsd/RequestDetails.cpp
@@ -276,6 +276,8 @@ Poco::URI RequestDetails::sanitizeURI(const std::string& uri)
     }
 
     uriPublic.setQueryParameters(queryParams);
+
+    LOG_DBG("Sanitized URI [" << uri << "] to [" << uriPublic.toString() << ']');
     return uriPublic;
 }
 

--- a/wsd/RequestDetails.cpp
+++ b/wsd/RequestDetails.cpp
@@ -281,4 +281,19 @@ Poco::URI RequestDetails::sanitizeURI(const std::string& uri)
     return uriPublic;
 }
 
+std::string RequestDetails::getDocKey(const Poco::URI& uri)
+{
+    // If multiple host-names are used to access us, then
+    // they must be aliases. Permission to access aliased hosts
+    // is checked at the point of accepting incoming connections.
+    // At this point storing the hostname artificially discriminates
+    // between aliases and forces same document (when opened from
+    // alias hosts) to load as separate documents and sharing doesn't
+    // work. Worse, saving overwrites one another.
+    std::string docKey;
+    Poco::URI::encode(uri.getPath(), "", docKey);
+    LOG_INF("DocKey from URI [" << uri.toString() << "] => [" << docKey << ']');
+    return docKey;
+}
+
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/RequestDetails.hpp
+++ b/wsd/RequestDetails.hpp
@@ -134,12 +134,25 @@ public:
     /// Decode and sanitize a URI.
     static Poco::URI sanitizeURI(const std::string& uri);
 
+    /// Returns a document-specific key, based
+    /// on the URI of the document (aka the wopiSrc).
+    static std::string getDocKey(const Poco::URI& uri);
+
+    /// Sanitize the URI and return the document-specific key.
+    static std::string getDocKey(const std::string& uri) { return getDocKey(sanitizeURI(uri)); }
+
     // matches the WOPISrc if used. For load balancing
     // must be 2nd element in the path after /lool/<here>
     std::string getLegacyDocumentURI() const { return getField(Field::LegacyDocumentURI); }
 
     /// The DocumentURI, decoded. Doesn't contain WOPISrc or any other appendages.
     std::string getDocumentURI() const { return getField(Field::DocumentURI); }
+
+    /// The DocumentURI, decoded and sanitized. Doesn't contain WOPISrc or any other appendages.
+    std::string getDocumentURISanitized() const
+    {
+        return sanitizeURI(getField(Field::DocumentURI)).toString();
+    }
 
     const std::map<std::string, std::string>& getDocumentURIParams() const { return _docUriParams; }
 

--- a/wsd/RequestDetails.hpp
+++ b/wsd/RequestDetails.hpp
@@ -131,6 +131,9 @@ public:
     RequestDetails(Poco::Net::HTTPRequest &request, const std::string& serviceRoot);
     RequestDetails(const std::string &mobileURI);
 
+    /// Decode and sanitize a URI.
+    static Poco::URI sanitizeURI(const std::string& uri);
+
     // matches the WOPISrc if used. For load balancing
     // must be 2nd element in the path after /lool/<here>
     std::string getLegacyDocumentURI() const { return getField(Field::LegacyDocumentURI); }
@@ -222,9 +225,6 @@ public:
         oss << "\nfull URI: " << _uriString;
         return oss.str();
     }
-
-    /// Sanitize the given URI.
-    static Poco::URI sanitizeURI(const std::string& uri);
 };
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */


### PR DESCRIPTION
Resolves #3085

- wsd: move sanitizeURI into RequestDetails
- wsd: move getDocKey into RequestDetails
