### PR TITLE
sidebar: keep the same state after idle or mode switch

### DIFF
--- a/loleaflet/src/control/Control.LokDialog.js
+++ b/loleaflet/src/control/Control.LokDialog.js
@@ -1064,8 +1064,10 @@ L.Control.LokDialog = L.Control.extend({
 			else
 				$(panel).parent().hide();
 
-			if (window.initSidebarState)
+			if (window.initSidebarState) {
 				this._map.uiManager.setSavedState('ShowSidebar', width > 1);
+				window.initSidebarState = false;
+			}
 
 			// Render window.
 			this._sendPaintWindowRect(id);
@@ -1116,8 +1118,10 @@ L.Control.LokDialog = L.Control.extend({
 		this._createDialogCursor(strId);
 
 		this._postLaunch(id, panelContainer, panelCanvas);
-		if (window.initSidebarState)
+		if (window.initSidebarState) {
 			this._map.uiManager.setSavedState('ShowSidebar', true);
+			window.initSidebarState = false;
+		}
 	},
 
 	_postLaunch: function(id, panelContainer, panelCanvas) {
@@ -1389,8 +1393,10 @@ L.Control.LokDialog = L.Control.extend({
 			this._map.focus();
 		}
 
-		if (window.initSidebarState)
+		if (window.initSidebarState) {
 			this._map.uiManager.setSavedState('ShowSidebar', false);
+			window.initSidebarState = false;
+		}
 	},
 
 	_onCalcInputBarClose: function(dialogId) {

--- a/loleaflet/src/control/Control.UIManager.js
+++ b/loleaflet/src/control/Control.UIManager.js
@@ -186,6 +186,26 @@ L.Control.UIManager = L.Control.extend({
 		this.map.on('changeuimode', this.onChangeUIMode, this);
 	},
 
+	initializeSidebar: function() {
+		// Hide the sidebar on start if saved state or UIDefault is set.
+		if (window.mode.isDesktop() && !window.ThisIsAMobileApp) {
+			var showSidebar = this.getSavedStateOrDefault('ShowSidebar');
+
+			if (showSidebar === false)
+				app.socket.sendMessage('uno .uno:SidebarHide');
+		}
+		else if (window.mode.isChromebook()) {
+			// HACK - currently the sidebar shows when loaded,
+			// with the exception of mobile phones & tablets - but
+			// there, it does not show only because they start
+			// with read/only mode which hits an early exit in
+			// _launchSidebar() in Control.LokDialog.js
+			// So for the moment, let's just hide it on
+			// Chromebooks early
+			app.socket.sendMessage('uno .uno:SidebarHide');
+		}
+	},
+
 	removeClassicUI: function() {
 		if (this.map.menubar)
 		{
@@ -276,6 +296,8 @@ L.Control.UIManager = L.Control.extend({
 			this.addNotebookbarUI();
 			break;
 		}
+
+		this.initializeSidebar();
 	},
 
 	// UI modification

--- a/loleaflet/src/map/Map.js
+++ b/loleaflet/src/map/Map.js
@@ -296,26 +296,7 @@ L.Map = L.Evented.extend({
 			if (this._docLayer && !this._docLoadedOnce &&
 				(this._docLayer._docType === 'spreadsheet' || this._docLayer._docType === 'text' || this._docLayer._docType === 'presentation')) {
 				// Let the first page finish loading then load the sidebar.
-				var map = this;
-				setTimeout(function () {
-					// Hide the sidebar on start if saved state or UIDefault is set.
-					if (window.mode.isDesktop() && !window.ThisIsAMobileApp) {
-						var showSidebar = map.uiManager.getSavedStateOrDefault('ShowSidebar');
-
-						if (showSidebar === false)
-							app.socket.sendMessage('uno .uno:SidebarHide');
-					}
-					else if (window.mode.isChromebook()) {
-						// HACK - currently the sidebar shows when loaded,
-						// with the exception of mobile phones & tablets - but
-						// there, it does not show only because they start
-						// with read/only mode which hits an early exit in
-						// _launchSidebar() in Control.LokDialog.js
-						// So for the moment, let's just hide it on
-						// Chromebooks early
-						app.socket.sendMessage('uno .uno:SidebarHide');
-					}
-				}, 200);
+				setTimeout(this.uiManager.initializeSidebar.bind(this.uiManager), 200);
 			}
 
 			// We have loaded.


### PR DESCRIPTION
- reset window.initSidebarState marker after it's use
- apply sidebar visibility update after mode change or idle