### PR TITLE
fix build with --enable-anonymization #2464

### DIFF
--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -1279,7 +1279,7 @@ void LOOLWSD::innerInitialize(Application& self)
     }
 #endif
 
-    if (AnonymizeUserData && LogLevel == "trace")
+    if (AnonymizeUserData && LogLevel == "trace" && !CleanupOnly)
     {
         if (getConfigValue<bool>(conf, "logging.anonymize.allow_logging_user_data", false))
         {


### PR DESCRIPTION
Do not check for incompatibility of trace level logging and user data anonymization
when cleaning up jails. The --cleanup switch of loolwsd is special and not used
normally in production.

Signed-off-by: Andras Timar <andras.timar@collabora.com>
Change-Id: If95c8c87c5fc2a278ee7d85e7e9089807a06602b


* Resolves: #2464 
* Target version: master 

