### PR TITLE
kill reuse_cookies

### DIFF
--- a/loleaflet/html/loleaflet.html.m4
+++ b/loleaflet/html/loleaflet.html.m4
@@ -271,7 +271,6 @@ m4_ifelse(MOBILEAPP,[true],
       window.enableWelcomeMessageButton = false;
       window.outOfFocusTimeoutSecs = 1000000;
       window.idleTimeoutSecs = 1000000;
-      window.reuseCookies = '';
       window.protocolDebug = false;
       window.frameAncestors = '';
       window.socketProxy = false;
@@ -292,7 +291,6 @@ m4_ifelse(MOBILEAPP,[true],
       window.enableMacrosExecution = '%ENABLE_MACROS_EXECUTION%';
       window.outOfFocusTimeoutSecs = %OUT_OF_FOCUS_TIMEOUT_SECS%;
       window.idleTimeoutSecs = %IDLE_TIMEOUT_SECS%;
-      window.reuseCookies = '%REUSE_COOKIES%';
       window.protocolDebug = %PROTOCOL_DEBUG%;
       window.frameAncestors = '%FRAME_ANCESTORS%';
       window.socketProxy = %SOCKET_PROXY%;

--- a/loleaflet/js/global.js
+++ b/loleaflet/js/global.js
@@ -746,15 +746,6 @@ window.app = { // Shouldn't have any functions defined.
 			wopiParams = { 'access_header': global.accessHeader };
 		}
 
-		if (global.reuseCookies !== '') {
-			if (wopiParams) {
-				wopiParams['reuse_cookies'] = global.reuseCookies;
-			}
-			else {
-				wopiParams = { 'reuse_cookies': global.reuseCookies };
-			}
-		}
-
 		if (wopiParams) {
 			docParams = Object.keys(wopiParams).map(function(key) {
 				return encodeURIComponent(key) + '=' + encodeURIComponent(wopiParams[key]);

--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -1141,11 +1141,6 @@ app.definitions.Socket = L.Class.extend({
 		if (command !== undefined && command.url !== undefined && command.url !== '') {
 			var url = command.url;
 
-			var reuseCookies = this._getParameterByName(url, 'reuse_cookies');
-			if (reuseCookies !== '') {
-				this._map.options.docParams['reuse_cookies'] = reuseCookies;
-			}
-
 			// setup for loading the new document, and trigger the load
 			var docUrl = url.split('?')[0];
 			this._map.options.doc = docUrl;

--- a/loleaflet/src/main.js
+++ b/loleaflet/src/main.js
@@ -1,5 +1,5 @@
 /* -*- js-indent-level: 8 -*- */
-/* global errorMessages getParameterByName accessToken accessTokenTTL accessHeader reuseCookies */
+/* global errorMessages getParameterByName accessToken accessTokenTTL accessHeader */
 /* global app L vex host idleTimeoutSecs outOfFocusTimeoutSecs _ */
 /*eslint indent: [error, "tab", { "outerIIFEBody": 0 }]*/
 (function (global) {
@@ -13,15 +13,6 @@ if (wopiSrc !== '' && accessToken !== '') {
 }
 else if (wopiSrc !== '' && accessHeader !== '') {
 	wopiParams = { 'access_header': accessHeader };
-}
-
-if (reuseCookies !== '') {
-	if (wopiParams) {
-		wopiParams['reuse_cookies'] = reuseCookies;
-	}
-	else {
-		wopiParams = { 'reuse_cookies': reuseCookies };
-	}
 }
 
 var filePath = getParameterByName('file_path');

--- a/loolwsd.xml.in
+++ b/loolwsd.xml.in
@@ -184,7 +184,6 @@
             <host desc="Regex pattern of hostname to allow or deny." allow="true">192\.168\.[0-9]{1,3}\.[0-9]{1,3}</host>
             <host desc="Regex pattern of hostname to allow or deny." allow="false">192\.168\.1\.1</host>
             <max_file_size desc="Maximum document size in bytes to load. 0 for unlimited." type="uint">0</max_file_size>
-            <reuse_cookies desc="When enabled, cookies from the browser will be captured and set on WOPI requests." type="bool" default="false">false</reuse_cookies>
             <locking desc="Locking settings">
                 <refresh desc="How frequently we should re-acquire a lock with the storage server, in seconds (default 15 mins) or 0 for no refresh" type="int" default="900">900</refresh>
             </locking>

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -78,17 +78,6 @@ ClientSession::ClientSession(
     LOG_INF("ClientSession ctor [" << getName() << "] for URI: [" << _uriPublic.toString()
                                    << "], current number of connections: " << curConnections);
 
-    for (const auto& param : _uriPublic.getQueryParameters())
-    {
-        if (param.first == "reuse_cookies")
-        {
-            // Cache the cookies to avoid re-parsing the URI again.
-            _cookies = param.second;
-            LOG_INF("ClientSession [" << getName() << "] has cookies: [" << _cookies << "].");
-            break;
-        }
-    }
-
     // populate with random values.
     for (auto it : _clipboardKeys)
         rotateClipboardKey(false);

--- a/wsd/ClientSession.hpp
+++ b/wsd/ClientSession.hpp
@@ -121,8 +121,6 @@ public:
     /// The access token of this session.
     Authorization getAuthorization() const { return _auth; }
 
-    const std::string& getCookies() const { return _cookies; }
-
     /// Set WOPI fileinfo object
     void setWopiFileInfo(std::unique_ptr<WopiStorage::WOPIFileInfo>& wopiFileInfo) { _wopiFileInfo = std::move(wopiFileInfo); }
 
@@ -249,9 +247,6 @@ private:
 
     /// Authorization data - either access_token or access_header.
     const Authorization _auth;
-
-    /// The cookies we should pass on to the storage on saving.
-    std::string _cookies;
 
     /// Whether this session is the owner of currently opened document
     bool _isDocumentOwner;

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -638,8 +638,8 @@ bool DocumentBroker::download(const std::shared_ptr<ClientSession>& session, con
     if (wopiStorage != nullptr)
     {
         std::chrono::steady_clock::time_point start = std::chrono::steady_clock::now();
-        std::unique_ptr<WopiStorage::WOPIFileInfo> wopifileinfo = wopiStorage->getWOPIFileInfo(
-            session->getAuthorization(), session->getCookies(), *_lockCtx);
+        std::unique_ptr<WopiStorage::WOPIFileInfo> wopifileinfo =
+            wopiStorage->getWOPIFileInfo(session->getAuthorization(), *_lockCtx);
 
         checkFileInfoCallDurationMs = std::chrono::duration_cast<std::chrono::milliseconds>(
             std::chrono::steady_clock::now() - start);
@@ -860,8 +860,8 @@ bool DocumentBroker::download(const std::shared_ptr<ClientSession>& session, con
     if (!_storage->isDownloaded())
     {
         std::chrono::steady_clock::time_point start = std::chrono::steady_clock::now();
-        std::string localPath = _storage->downloadStorageFileToLocal(
-            session->getAuthorization(), session->getCookies(), *_lockCtx, templateSource);
+        std::string localPath = _storage->downloadStorageFileToLocal(session->getAuthorization(),
+                                                                     *_lockCtx, templateSource);
 
         getFileCallDurationMs = std::chrono::duration_cast<std::chrono::milliseconds>(
             std::chrono::steady_clock::now() - start);
@@ -871,7 +871,7 @@ bool DocumentBroker::download(const std::shared_ptr<ClientSession>& session, con
         // Only lock the document on storage for editing sessions
         // FIXME: why not lock before downloadStorageFileToLocal? Would also prevent race conditions
         if (!session->isReadOnly() &&
-            !_storage->updateLockState(session->getAuthorization(), session->getCookies(), *_lockCtx, true))
+            !_storage->updateLockState(session->getAuthorization(), *_lockCtx, true))
         {
             LOG_ERR("Failed to lock!");
             session->setLockFailed(_lockCtx->_lockFailureReason);
@@ -1076,8 +1076,7 @@ void DocumentBroker::endRenameFileCommand()
 
 bool DocumentBroker::attemptLock(const ClientSession& session, std::string& failReason)
 {
-    const bool bResult = _storage->updateLockState(session.getAuthorization(), session.getCookies(),
-                                                  *_lockCtx, true);
+    const bool bResult = _storage->updateLockState(session.getAuthorization(), *_lockCtx, true);
     if (!bResult)
         failReason = _lockCtx->_lockFailureReason;
     return bResult;
@@ -1403,9 +1402,8 @@ void DocumentBroker::uploadToStorageInternal(const std::string& sessionId, bool 
         }
     };
 
-    _storage->uploadLocalFileToStorageAsync(session->getAuthorization(), session->getCookies(),
-                                            *_lockCtx, saveAsPath, saveAsFilename, isRename, *_poll,
-                                            asyncUploadCallback);
+    _storage->uploadLocalFileToStorageAsync(session->getAuthorization(), *_lockCtx, saveAsPath,
+                                            saveAsFilename, isRename, *_poll, asyncUploadCallback);
 }
 
 void DocumentBroker::handleUploadToStorageResponse(const StorageBase::UploadResult& uploadResult)
@@ -1706,7 +1704,7 @@ void DocumentBroker::refreshLock()
     else
     {
         std::shared_ptr<ClientSession> session = it->second;
-        if (!session || !_storage->updateLockState(session->getAuthorization(), session->getCookies(), *_lockCtx, true))
+        if (!session || !_storage->updateLockState(session->getAuthorization(), *_lockCtx, true))
             LOG_ERR("Failed to refresh lock");
     }
 }
@@ -2068,7 +2066,7 @@ void DocumentBroker::disconnectSessionInternal(const std::string& id)
             if (_docState.isMarkedToDestroy() && // last session to remove; FIXME: Editable?
                 _lockCtx->_isLocked && _storage)
             {
-                if (!_storage->updateLockState(it->second->getAuthorization(), it->second->getCookies(), *_lockCtx, false))
+                if (!_storage->updateLockState(it->second->getAuthorization(), *_lockCtx, false))
                     LOG_ERR("Failed to unlock!");
             }
 

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -794,20 +794,6 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     Poco::replaceInPlace(preprocess, std::string("%FEEDBACK_LOCATION%"), tokens.size() > 0 ? tokens[0] : "");
 #endif
 
-    // Capture cookies so we can optionally reuse them for the storage requests.
-    {
-        NameValueCollection cookies;
-        request.getCookies(cookies);
-        std::ostringstream cookieTokens;
-        for (auto it = cookies.begin(); it != cookies.end(); it++)
-            cookieTokens << (*it).first << '=' << (*it).second << (std::next(it) != cookies.end() ? ":" : "");
-
-        const std::string cookiesString = cookieTokens.str();
-        if (!cookiesString.empty())
-            LOG_DBG("Captured cookies: " << cookiesString);
-        Poco::replaceInPlace(preprocess, std::string("%REUSE_COOKIES%"), cookiesString);
-    }
-
     const std::string mimeType = "text/html";
 
     // Document signing: if endpoint URL is configured, whitelist that for

--- a/wsd/RequestDetails.hpp
+++ b/wsd/RequestDetails.hpp
@@ -50,14 +50,13 @@
  *
  * Example:
  *  /lool/http%3A%2F%2Flocalhost%2Fowncloud%2Findex.php%2Fapps%2Frichdocuments%2Fwopi%2Ffiles%2F165_ocgdpzbkm39u%3F
- *  access_token%3DODhIXdJdbsVYQoKKCuaYofyzrovxD3MQ%26access_token_ttl%3D0%26reuse_cookies%3DXCookieName%253DXCookieValue%253
- *  ASuperCookieName%253DBAZINGA/ws?WOPISrc=http%3A%2F%2Flocalhost%2Fowncloud%2Findex.php%2Fapps%2Frichdocuments%2Fwopi%2F
+ *  access_token%3DODhIXdJdbsVYQoKKCuaYofyzrovxD3MQ%26access_token_ttl%3D0/ws?
+ *  WOPISrc=http%3A%2F%2Flocalhost%2Fowncloud%2Findex.php%2Fapps%2Frichdocuments%2Fwopi%2F
  *  files%2F165_ocgdpzbkm39u&compat=/ws/1c99a7bcdbf3209782d7eb38512e6564/write/2
  *  Where:
  *      encoded-document-URI+options:
  *          http%3A%2F%2Flocalhost%2Fowncloud%2Findex.php%2Fapps%2Frichdocuments%2Fwopi%2Ffiles%2F165_ocgdpzbkm39u%3F
- *          access_token%3DODhIXdJdbsVYQoKKCuaYofyzrovxD3MQ%26access_token_ttl%3D0%26reuse_cookies%3DXCookieName%253DXCookieValue%253
- *          ASuperCookieName%253DBAZINGA
+ *          access_token%3DODhIXdJdbsVYQoKKCuaYofyzrovxD3MQ%26access_token_ttl%3D0
  *      encoded-document-URI:
  *          http%3A%2F%2Flocalhost%2Fowncloud%2Findex.php%2Fapps%2Frichdocuments%2Fwopi%2Ffiles%2F165_ocgdpzbkm39u
  *      sessionId:
@@ -69,7 +68,7 @@
  *  In decoded form:
  *      document-URI+options:
  *          http://localhost/owncloud/index.php/apps/richdocuments/wopi/files/165_ocgdpzbkm39u?access_token=
- *          ODhIXdJdbsVYQoKKCuaYofyzrovxD3MQ&access_token_ttl=0&reuse_cookies=XCookieName%3DXCookieValue%3ASuperCookieName%3DBAZINGA
+ *          ODhIXdJdbsVYQoKKCuaYofyzrovxD3MQ&access_token_ttl=0
  *      document-URI:
  *          http://localhost/owncloud/index.php/apps/richdocuments/wopi/files/165_ocgdpzbkm39u
  *


### PR DESCRIPTION
This remove reuse_cookies as a setting and feature
altogether. It was originally a workaround to aid
with authentication, prior to having access_token.
However, it proved to be less useful than originally
anticipated, primarily because cookies nowadays have
security restrictions in browsers. In addition to
the fact that access_token simply deprecated it.

While the documentation has also been updated,
tests still have reuse_cookies in input data.
This is intentional to ensure the code is
backwards compatible with any deployment that might
still pass URLs with reuse_cookies around.

Change-Id: If214b299b34a910face8cabc7c1335621990c85e
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
