### PR TITLE
test: log timeout limit when the document fails to load

### DIFF
--- a/test/helpers.hpp
+++ b/test/helpers.hpp
@@ -532,11 +532,11 @@ inline
 bool isDocumentLoaded(LOOLWebSocket& ws, const std::string& testname, bool isView = true)
 {
     const std::string prefix = isView ? "status:" : "statusindicatorfinish:";
-    // Allow 60 secs to load
-    const auto message = getResponseString(ws, prefix, testname, std::chrono::seconds(60));
+    std::chrono::seconds timeout(60);
+    const auto message = getResponseString(ws, prefix, testname, timeout);
     bool success = LOOLProtocol::matchPrefix(prefix, message);
     if (!success)
-        TST_LOG("ERR: Timed out loading document");
+        TST_LOG("ERR: Timed out loading document after " << timeout);
     return success;
 }
 


### PR DESCRIPTION
The sanitizers tinderbox regularly times out, and it's good to know if
the timeout value is an agressive one or the load is really that slow.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I2903481ea9efde68aca3f4ec00bd6e7e2d3b840a
