### PR TITLE
wsd: Only add one img-src rule to the CSP header

### DIFF
--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -1019,7 +1019,7 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     // Document signing: if endpoint URL is configured, whitelist that for
     // iframe purposes.
     std::ostringstream cspOss;
-    cspOss << "Content-Security-Policy: default-src 'none'; img-src 'self' data: https://www.collaboraoffice.com/;"
+    cspOss << "Content-Security-Policy: default-src 'none'; "
 #ifdef ENABLE_FEEDBACK
         "frame-src 'self' " << FEEDBACK_LOCATION << " blob: " << documentSigningURL << "; "
 #else
@@ -1056,19 +1056,21 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
         }
     }
 
+    std::string imgSrc = "img-src 'self' data: https://www.collaboraoffice.com/";
     if (!frameAncestors.empty())
     {
         LOG_TRC("Allowed frame ancestors: " << frameAncestors);
         // X-Frame-Options supports only one ancestor, ignore that
         //(it's deprecated anyway and CSP works in all major browsers)
-        cspOss << "img-src 'self' data: " << frameAncestors << "; "
+        // frame anchestors are also allowed for img-src in order to load the views avatars
+        cspOss << imgSrc << frameAncestors << "; "
                 << "frame-ancestors " << frameAncestors;
         Poco::replaceInPlace(preprocess, std::string("%FRAME_ANCESTORS%"), frameAncestors);
     }
     else
     {
         LOG_TRC("Denied all frame ancestors");
-        cspOss << "img-src 'self' data: none;";
+        cspOss << imgSrc << "; ";
     }
 
     cspOss << "\r\n";


### PR DESCRIPTION
* Target version: master 

### Summary

Starting with 352d1d1f40c96cc76968ec657ad096ee36d7ca72 the CSP header contained two entries for img-src which caused the second to no longer take effect. This change brings back the rendering of avatars that may be loaded from external sources as provided by the WOPI integrator. 

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

