### PR TITLE
Prevent from error on LanguageStatus and use translation

### DIFF
--- a/loleaflet/src/map/handler/Map.StateChanges.js
+++ b/loleaflet/src/map/handler/Map.StateChanges.js
@@ -32,8 +32,13 @@ L.Map.StateChangeHandler = L.Handler.extend({
 		if (typeof(e.state) == 'object') {
 			state = e.state;
 		} else if (typeof(e.state) == 'string') {
-			var index = e.state.indexOf('{');
-			state = index !== -1 ? JSON.parse(e.state.substring(index)) : e.state;
+			var isLanguageStatus = e.commandName === 'LanguageStatus';
+			var index = e.state.indexOf('{') && !isLanguageStatus;
+			try {
+				state = index !== -1 ? JSON.parse(e.state.substring(index)) : e.state;
+			} catch (exception) {
+				state = e.state;
+			}
 		}
 
 		this._items[e.commandName] = state;


### PR DESCRIPTION
sometimes core send "{en-US}" as a LanguageStatus
prevent from trying to parse it as JSON and remember
translated names for language codes so we can reuse it
and show in the statusbar for such codes
