### PR TITLE
Fix slow loading/editing of sheet with ~800 comments [master]

### DIFF
--- a/loleaflet/src/layer/tile/CommentListSection.ts
+++ b/loleaflet/src/layer/tile/CommentListSection.ts
@@ -64,6 +64,9 @@ class CommentSection {
 	setPosition: (x: number, y: number) => void;
 	map: any;
 
+	// To associate comment id with its index in commentList array.
+	private idIndexMap: Map<any, number>;
+
 	constructor () {
 		this.map = L.Map.THIS;
 		this.anchor = ['top', 'right'];
@@ -78,6 +81,7 @@ class CommentSection {
 		this.sectionProperties.layoutTimer = null;
 		this.sectionProperties.width = Math.round(300 * app.dpiScale); // Configurable variable.
 		this.sectionProperties.scrollAnnotation = null; // For impress, when 1 or more comments exist.
+		this.idIndexMap = new Map<any, number>();
 	}
 
 	public onInitialize () {
@@ -456,6 +460,7 @@ class CommentSection {
 			if (annotation.sectionProperties.data.id === id) {
 				this.containerObject.removeSection(annotation.name);
 				this.sectionProperties.commentList.splice(i, 1);
+				this.updateIdIndexMap();
 				break;
 			}
 		}
@@ -720,12 +725,8 @@ class CommentSection {
 	}
 
 	public getIndexOf (id: any): number {
-		for (var index = 0; index < this.sectionProperties.commentList.length; index++) {
-			if (this.sectionProperties.commentList[index].sectionProperties.data.id === id) {
-				return index;
-			}
-		}
-		return -1;
+		const index = this.idIndexMap.get(id);
+		return (index === undefined) ? -1 : index;
 	}
 
 	public isThreadResolved (annotation: any) {
@@ -892,6 +893,7 @@ class CommentSection {
 
 			this.containerObject.addSection(annotation);
 			this.sectionProperties.commentList.splice(parentIdx + 1, 0, annotation);
+			this.updateIdIndexMap();
 
 			this.updateResolvedState(annotation);
 			this.showHideComment(annotation);
@@ -941,12 +943,8 @@ class CommentSection {
 	}
 
 	public getComment (id: any) {
-		for (var i = 0; i < this.sectionProperties.commentList.length; i++) {
-			if (this.sectionProperties.commentList[i].sectionProperties.data.id === id) {
-				return this.sectionProperties.commentList[i];
-			}
-		}
-		return null;
+		const index = this.getIndexOf(id);
+		return index == -1 ? null : this.sectionProperties.commentList[index];
 	}
 
 	// Adjust parent-child relationship, if required, after `comment` is added
@@ -1621,6 +1619,19 @@ class CommentSection {
 			return Math.abs(a.sectionProperties.data.anchorPos[1]) - Math.abs(b.sectionProperties.data.anchorPos[1]) ||
 				Math.abs(a.sectionProperties.data.anchorPos[0]) - Math.abs(b.sectionProperties.data.anchorPos[0]);
 		});
+
+		// idIndexMap is now invalid, update it.
+		this.updateIdIndexMap();
+	}
+
+	private updateIdIndexMap() {
+		this.idIndexMap.clear();
+		const commentList = this.sectionProperties.commentList;
+		for (var idx = 0; idx < commentList.length; idx++) {
+			const comment = commentList[idx];
+			console.assert(comment.sectionProperties && comment.sectionProperties.data, 'no sectionProperties.data!');
+			this.idIndexMap.set(comment.sectionProperties.data.id, idx);
+		}
 	}
 
 	private turnIntoAList (commentList: any) {
@@ -1654,6 +1665,7 @@ class CommentSection {
 				var commentSection = new app.definitions.Comment(comment, {}, this);
 				this.containerObject.addSection(commentSection);
 				this.sectionProperties.commentList.push(commentSection);
+				this.idIndexMap.set(commentSection.sectionProperties.data.id, i);
 				this.updateResolvedState(this.sectionProperties.commentList[i]);
 			}
 
@@ -1705,6 +1717,7 @@ class CommentSection {
 				this.sectionProperties.commentList.splice(i, 1);
 			}
 		}
+		this.updateIdIndexMap();
 		this.containerObject.resumeDrawing();
 
 		this.sectionProperties.selectedComment = null;
@@ -1720,6 +1733,7 @@ class CommentSection {
 				this.sectionProperties.commentList.splice(i, 1);
 			}
 		}
+		this.updateIdIndexMap();
 		this.containerObject.resumeDrawing();
 
 		this.sectionProperties.selectedComment = null;


### PR DESCRIPTION
Profiling points to updateReplyCount() as the bottleneck where it does
O(N^3) work where N is the number of comments. The innermost loop is
used to find the index of a comment-section in an array using its 'id'.
Turns out that flattening this loop to a < log(N) lookup via a js map
from id -> index pretty much cures the perceived 'slowness'. But we need
to ensure the correctness of the map by updating it whenever
'commentList' is mutated.

Time to load the document with 800 comments (arranged in 50 rows x 16
cols table):

Before the patch: 1min 31 sec
After the patch:  3.5 sec

After-load performance (comment popup/hide/scroll) with this patch is
similar to how it feels in co-6-4 which does not have this issue.

Signed-off-by: Dennis Francis <dennis.francis@collabora.com>
Change-Id: I4c47f14767cac4c7e9744344d24f646dd27302a6


* Resolves: #3520
* Target version: master 


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

