### PR TITLE
Add a version suffix configuration option.

### DIFF
--- a/loolwsd.xml.in
+++ b/loolwsd.xml.in
@@ -53,6 +53,7 @@
     </per_view>
 
     <loleaflet_html desc="Allows UI customization by replacing the single endpoint of loleaflet.html" type="string" default="loleaflet.html">loleaflet.html</loleaflet_html>
+    <ver_suffix desc="Appended to etags to allow easy refresh of changed files during development" type="string" default=""></ver_suffix>
 
     <logging>
         <color type="bool">true</color>

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -495,6 +495,9 @@ void FileServerRequestHandler::handleRequest(const HTTPRequest& request,
         std::string endPoint = requestSegments[requestSegments.size() - 1];
         const auto& config = Application::instance().config();
 
+        static std::string etagString = "\"" LOOLWSD_VERSION_HASH +
+            config.getString("ver_suffix", "") + "\"";
+
 #if ENABLE_DEBUG
         const Poco::Path path = requestUri.getPath();
         if (Util::startsWith(path.toString(), std::string("/wopi/files"))) {
@@ -616,7 +619,7 @@ void FileServerRequestHandler::handleRequest(const HTTPRequest& request,
             if (it != request.end())
             {
                 // if ETags match avoid re-sending the file.
-                if (!noCache && it->second == "\"" LOOLWSD_VERSION_HASH "\"")
+                if (!noCache && it->second == etagString)
                 {
                     // TESTME: harder ... - do we even want ETag support ?
                     std::ostringstream oss;
@@ -658,7 +661,7 @@ void FileServerRequestHandler::handleRequest(const HTTPRequest& request,
             {
                 // 60 * 60 * 24 * 128 (days) = 11059200
                 response.set("Cache-Control", "max-age=11059200");
-                response.set("ETag", "\"" LOOLWSD_VERSION_HASH "\"");
+                response.set("ETag", etagString);
             }
             response.setContentType(mimeType);
             response.add("X-Content-Type-Options", "nosniff");


### PR DESCRIPTION
This allows people to perturb the etags for now, and in future the
URL sub-path to make it easier to develop with binaries where the
git hash doens't change.

Signed-off-by: Michael Meeks <michael.meeks@collabora.com>
Change-Id: I6082a71cde5d3a34cca29fa5858feaf6fdb7f4d6


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

