### PR TITLE
JSsidebar: spinfields n edge elms: Fix alignments

### DIFF
--- a/loleaflet/css/jsdialogs.css
+++ b/loleaflet/css/jsdialogs.css
@@ -90,7 +90,7 @@ td.jsdialog .jsdialog.cell,
 	padding: 4px;
 }
 
-.jsdialog.vertical {
+.jsdialog.vertical:not(.sidebar) {
 	width: max-content;
 }
 

--- a/loleaflet/css/jssidebar.css
+++ b/loleaflet/css/jssidebar.css
@@ -15,6 +15,7 @@
 	padding: 0;
 	border-left: 1px solid var(--gray-color) !important;
 	margin-top: 0 !important;
+	box-sizing: border-box;
 }
 
 .sidebar.spinfield {
@@ -103,12 +104,10 @@ div#thousandseparator.checkbutton.jsdialog.sidebar {
 }
 
 #settransparency, #fontheight,
-.sidebar.jsdialog.vertical > .sidebar.jsdialog.row > table.sidebar.ui-grid > tr.sidebar > td.sidebar:last-child,
+#document-container:not(.presentation-doctype) ~ #sidebar-dock-wrapper .sidebar.jsdialog.vertical > .sidebar.jsdialog.row > table.sidebar.ui-grid > tr.sidebar > td.sidebar:last-child,
 .sidebar.jsdialog.cell > #table-box3 > .sidebar.jsdialog.row > .sidebar.jsdialog.cell:last-child,
 .sidebar.jsdialog.cell > #table-box4 > .sidebar.jsdialog.row > .sidebar.jsdialog.cell:last-child,
-.sidebar.jsdialog.cell > #table-box4 > .sidebar.jsdialog.row > .sidebar.jsdialog.cell:nth-child(4),
-td.sidebar.jsdialog > #table-box1 > .sidebar.jsdialog.row > .sidebar.jsdialog.cell:nth-child(2),
-td.sidebar.jsdialog > #table-box2 > .sidebar.jsdialog.row > .sidebar.jsdialog.cell:last-child {
+.sidebar.jsdialog.cell > #table-box4 > .sidebar.jsdialog.row > .sidebar.jsdialog.cell:nth-child(4) {
 	display: flex;
 	justify-content: flex-end;
 }
@@ -296,4 +295,13 @@ button#button2.ui-pushbutton.jsdialog.sidebar {
 	padding: 4px;
 	position: relative;
 	left: -10px;
+}
+
+#writedirection, #backgroundcolor, #table-indentfieldbox * {
+	justify-content: end;
+	margin-right: 0;
+}
+
+.sidebar .spinfieldcontainer input {
+	width: calc(100% - 28px);
 }


### PR DESCRIPTION
Many elements are too wide (as a group) which breakes the sidebar
layout:
- Spinfields and their labels (example cm) occupy too much width
- Many other elements are getting some with: max-content rules
from the geenric jsdialog.css file which is affecting and also
breaking the sidebar

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ie6c18e829cbe32319e77ce031521c6ccc7c6a5c9
