### PR TITLE
Fix Debian 8 / gcc-4.9 warnings (overlayfs part)

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -170,7 +170,11 @@ namespace
     bool detectSlowStackingFileSystem(const std::string &directory)
     {
 #ifdef __linux__
-        struct statfs fs = {};
+#ifndef OVERLAYFS_SUPER_MAGIC
+// From linux/magic.h.
+#define OVERLAYFS_SUPER_MAGIC   0x794c7630
+#endif
+        struct statfs fs;
         if (::statfs(directory.c_str(), &fs) != 0)
         {
             LOG_SYS("statfs failed on '" << directory << "'");


### PR DESCRIPTION
Remainder missing from 8083fb9cf73d2e8d125a328ff96108268eff1587

kit/Kit.cpp:171:14: error: 'OVERLAYFS_SUPER_MAGIC' was not declared in this scope

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
(cherry picked from commit 656eb310bb39ebd125f2ad6629c46625f1c00219)
Signed-off-by: Aron Budea <aron.budea@collabora.com>
Change-Id: I659f37e04eb3d494579e2b451d31d69ab6cb21f5

* Target version: 6.4