### PR TITLE
leaflet: correct map reference in socket

### DIFF
--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -479,7 +479,8 @@ app.definitions.Socket = L.Class.extend({
 				oldId = this.WSDServer.Id;
 				oldVersion = this.WSDServer.Version;
 
-				console.assert(map.options.wopiSrc === window.wopiSrc, 'wopiSrc mismatch!: ' + map.options.wopiSrc + ' != ' + window.wopiSrc);
+				console.assert(this._map.options.wopiSrc === window.wopiSrc,
+					'wopiSrc mismatch!: ' + this._map.options.wopiSrc + ' != ' + window.wopiSrc);
 				// If another file is opened, we will not refresh the page.
 				if (this._map.options.previousWopiSrc && this._map.options.wopiSrc) {
 					if (this._map.options.previousWopiSrc !== this._map.options.wopiSrc)


### PR DESCRIPTION
This caused an exception which prevented
the WSDServer member from updating after
a saveas operation that ended up on a
different server (in a load-balanced setup).

Change-Id: Ibf8f69d53dc3cb14fa004201660e3997ad5c298e
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
(cherry picked from commit 2b0180c4104ccf1a3e7da94cfc2d2f35c09d0684)
