### PR TITLE
configure: extend --enable-fuzzers description

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -148,7 +148,9 @@ AC_ARG_ENABLE([gtkapp],
 
 AC_ARG_ENABLE(fuzzers,
     AS_HELP_STRING([--enable-fuzzers],
-        [Enables building libfuzzer targets for fuzz testing.])
+        [Enables building libfuzzer targets for fuzz testing. It is useful to enable this switch
+         only in a separate build tree, since the switch disables the creation of a loolwsd
+         binary.])
 )
 
 AC_ARG_ENABLE([androidapp],


### PR DESCRIPTION
To make it more clear that if you enable this in an existing build tree,
you'll get an outdated loolwsd binary, which is confusing.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Iaf6e747a9d7ac4262732c3df69bb5012bc7dc352
