### PR TITLE
Don't generate useless loleaflet._emitSlurpedEvents-to-idle async tra…

### DIFF
--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -328,10 +328,6 @@ app.definitions.Socket = L.Class.extend({
 					break;
 				}
 			}
-			var asyncEvent = this.createAsyncTraceEvent('loleaflet._emitSlurpedEvents-to-idle',
-								    {'_slurpQueue.length' : String(queueLength)});
-			if (asyncEvent)
-				setTimeout(function() { asyncEvent.finish(); }, 0);
 		}
 		finally {
 			if (completeEventWholeFunction)


### PR DESCRIPTION
…ce events

The resulting Trace Event JSON ends up with tons of such async events
for which the viewer in Edge (i.e. Chromium) just says "Did Not
Finish".

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: I29ae233bf16086ffd464567660954ac4c171c7fb


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

