### PR TITLE
private/pedro/color indicators ui fixes

### DIFF
--- a/loleaflet/css/jsdialogs.css
+++ b/loleaflet/css/jsdialogs.css
@@ -688,6 +688,8 @@ input[type='checkbox']:checked.autofilter, .jsdialog input[type='checkbox']:chec
 	position: relative;
 	top: -6px;
 	border: 1px solid var(--gray-color);
+	border-radius: 7px;
+	outline: 1px solid white;
 }
 
 /* dropdown arrow */

--- a/loleaflet/css/mobilewizard.css
+++ b/loleaflet/css/mobilewizard.css
@@ -653,9 +653,7 @@ a.leaflet-control-zoom-in {
 .mobile-wizard.ui-combobox-text.checked {
 	color: #0b87e7 !important;
 }
-#BackColor .w2ui-tb-caption > div, #FontColor .w2ui-tb-caption > div, #BackgroundColor .w2ui-tb-caption > div, #FrameLineColor div, #Color div{
-	border-radius: 100px !important;
-}
+
 #toolbar-down table.w2ui-button.checked .w2ui-tb-image{
 	-webkit-filter: grayscale(100%) brightness(80%) sepia(100%) hue-rotate(-190deg) saturate(900%) contrast(0.8);
 	filter: grayscale(100%) brightness(80%) sepia(100%) hue-rotate(-190deg) saturate(900%) contrast(0.8);

--- a/loleaflet/src/control/Control.JSDialogBuilder.js
+++ b/loleaflet/src/control/Control.JSDialogBuilder.js
@@ -2362,6 +2362,18 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		return false;
 	},
 
+	setPickerOutline: function(bgColor) {
+		// Make sure the border around the color indicator is not too bright
+		// when the color is black so to avoid weird contast artifacts
+		if (bgColor) {
+			if (bgColor.style.backgroundColor == '#000000' || bgColor.style.backgroundColor == 'rgb(0, 0, 0)') {
+				bgColor.style.borderColor = '#6a6a6a';
+			} else {
+				bgColor.style.borderColor = 'var(--gray-color)';
+			}
+		}
+	},
+
 	_colorSampleControl: function (parentContainer, data, builder) {
 		var sampleSizeClass = 'color-sample-small';
 		if (data.size === 'big')
@@ -2666,6 +2678,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			var updateFunction = function (color) {
 				selectedColor = builder._getCurrentColor(data, builder);
 				valueNode.style.backgroundColor = color ? color : selectedColor;
+				builder.setPickerOutline(valueNode);
 			};
 
 			updateFunction();


### PR DESCRIPTION
- Mobile: Remove unused rules, were affecting desktop
- Color picker: UI, fix radius n add visual padding
- Color picker: Don't set indicator's border so bright
