### PR TITLE
Introduce security.enable_metrics_unauthenticated config item

### DIFF
--- a/loolwsd.xml.in
+++ b/loolwsd.xml.in
@@ -157,6 +157,7 @@
       <jwt_expiry_secs desc="Time in seconds before the Admin Console's JWT token expires" type="int" default="1800">1800</jwt_expiry_secs>
       <enable_macros_execution desc="Specifies whether the macro execution is enabled in general. This will enable Basic, Beanshell, Javascript and Python scripts. If it is set to false, the macro_security_level is ignored. If it is set to true, the mentioned entry specified the level of macro security." type="bool" default="false">false</enable_macros_execution>
       <macro_security_level desc="Level of Macro security. 1 (Medium) Confirmation required before executing macros from untrusted sources. 0 (Low, not recommended) All macros will be executed without confirmation." type="int" default="1">1</macro_security_level>
+      <enable_metrics_unauthenticated desc="When enabled, the /lool/getMetrics endpoint will not require authentication." type="bool" default="false">false</enable_metrics_unauthenticated>
     </security>
 
     <watermark>

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -1089,6 +1089,7 @@ void LOOLWSD::innerInitialize(Application& self)
             { "security.capabilities", "true" },
             { "security.seccomp", "true" },
             { "security.jwt_expiry_secs", "1800" },
+            { "security.enable_metrics_unauthenticated", "false" },
             { "server_name", "" },
             { "ssl.ca_file_path", LOOLWSD_CONFIGDIR "/ca-chain.cert.pem" },
             { "ssl.cert_file_path", LOOLWSD_CONFIGDIR "/cert.pem" },
@@ -2732,8 +2733,11 @@ private:
 
                 try
                 {
-                    if (!FileServerRequestHandler::isAdminLoggedIn(request, *response))
-                        throw Poco::Net::NotAuthenticatedException("Invalid admin login");
+                    /* WARNING: security point, we may skip authentication */
+                    bool skipAuthentication = LOOLWSD::getConfigValue<bool>("security.enable_metrics_unauthenticated", false);
+                    if (!skipAuthentication)
+                        if (!FileServerRequestHandler::isAdminLoggedIn(request, *response))
+                            throw Poco::Net::NotAuthenticatedException("Invalid admin login");
                 }
                 catch (const Poco::Net::NotAuthenticatedException& exc)
                 {


### PR DESCRIPTION
When enabled, the /lool/getMetrics endpoint will not require authentication.
By default authentication is required and this setting is set to "false".

Signed-off-by: Andras Timar <andras.timar@collabora.com>
Change-Id: I801130cf552eb14c231fcc0a0bdd39d9ebb6db7f


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

