### PR TITLE
Simplify comments switching to bubbles

### DIFF
--- a/cypress_test/integration_tests/desktop/writer/annotation_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/annotation_spec.js
@@ -1,7 +1,7 @@
 /* global describe it Cypress cy require afterEach beforeEach */
 
 var helper = require('../../common/helper');
-var { insertMultipleComment, hideSidebar } = require('../../common/desktop_helper');
+var { insertMultipleComment, hideSidebar, selectZoomLevel } = require('../../common/desktop_helper');
 
 describe('Annotation Tests', function() {
 	var testFileName = 'annotation.odt';
@@ -22,6 +22,7 @@ describe('Annotation Tests', function() {
 		} else {
 			hideSidebar();
 		}
+		selectZoomLevel('50');
 	});
 
 	afterEach(function() {

--- a/loleaflet/src/layer/tile/CanvasSectionContainer.ts
+++ b/loleaflet/src/layer/tile/CanvasSectionContainer.ts
@@ -158,8 +158,6 @@ class CanvasSectionObject {
 	isVisible: boolean = false; // Is section visible on the viewed area of the document? This property is valid for document objects. This is managed by the section container.
 	showSection: boolean = true; // Show / hide section.
 	position: Array<number> = new Array(0);
-	minSize: Array<number> = new Array(0); // Try to provide minimal size by collapsing other sections
-	canCollapse: boolean = false;
 	isCollapsed: boolean = false;
 	size: Array<number> = new Array(0);
 	expand: Array<string> = new Array(0);
@@ -257,12 +255,6 @@ class CanvasSectionObject {
 
 	/// Document objects only. Do not implement this. This function is added by section container.
 	setPosition: (x: number, y: number) => void;
-
-	/// collapse the section to provide more space for other sections
-	setCollapsed: () => void;
-
-	/// allow to use more space
-	setExpanded: () => void;
 
 	constructor (options: any) {
 		this.name = options.name;
@@ -1489,47 +1481,9 @@ class CanvasSectionContainer {
 		}
 	}
 
-	// applies minimal size by collapsing other sections if there is space missing
-	// returns true if sections should be relocated
-	private applySectionsSizeRequirements() : boolean {
-		var ret = false;
-
-		for (var i: number = 0; i < this.sections.length; i++) {
-			if (this.sections[i].minSize && this.sections[i].minSize.length) {
-				if (this.sections[i].minSize[0] > this.sections[i].size[0]) {
-					var neededSpace = this.sections[i].minSize[0] - this.sections[i].size[0];
-					for (var j: number = 0; j < this.sections.length && neededSpace > 0; j++) {
-						if (this.sections[j].isLocated &&
-							this.sections[j].zIndex === this.sections[i].zIndex &&
-							this.sections[j].name !== this.sections[i].name &&
-							this.sections[j].canCollapse) {
-
-							neededSpace -= this.sections[j].size[0];
-							this.sections[j].setCollapsed();
-							neededSpace += this.sections[j].size[0];
-
-							ret = true;
-						}
-					}
-				}
-			}
-		}
-
-		return ret;
-	}
-
 	public reNewAllSections(redraw: boolean = true) {
 		this.orderSections();
-
-		for (var i: number = 0; i < this.sections.length; i++) {
-			if (this.sections[i].setExpanded)
-				this.sections[i].setExpanded();
-		}
-
 		this.locateSections();
-
-		if (this.applySectionsSizeRequirements())
-			this.locateSections();
 
 		for (var i: number = 0; i < this.sections.length; i++) {
 			this.sections[i].onResize();

--- a/loleaflet/src/layer/tile/CommentSection.ts
+++ b/loleaflet/src/layer/tile/CommentSection.ts
@@ -188,6 +188,8 @@ class Comment {
 		this.sectionProperties.container.style.visibility = 'hidden';
 
 		this.doPendingInitializationInView();
+
+		this.setExpanded();
 	}
 
 	private createContainerAndWrapper () {

--- a/loleaflet/src/layer/tile/TilesSection.ts
+++ b/loleaflet/src/layer/tile/TilesSection.ts
@@ -18,7 +18,6 @@ class TilesSection {
 	boundToSection: string = null;
 	anchor: Array<any> = new Array(0);
 	position: Array<number> = new Array(0);
-	minSize: Array<number> = new Array(0);
 	size: Array<number> = new Array(0);
 	expand: Array<string> = new Array(0);
 	isLocated: boolean = false;
@@ -36,7 +35,6 @@ class TilesSection {
 		// Below anchor list may be expanded. For example, Writer may have ruler section. Then ruler section should also be added here.
 		this.anchor = [[L.CSections.ColumnHeader.name, 'bottom', 'top'], [L.CSections.RowHeader.name, 'right', 'left']];
 		this.position = [0, 0]; // This section's myTopLeft will be anchored to other sections^. No initial position is needed.
-		this.minSize = [1000, 0];
 		this.size = [0, 0]; // Going to be expanded, no initial width or height is necessary.
 		this.expand = ['top', 'left', 'bottom', 'right'];
 		this.processingOrder = L.CSections.Tiles.processingOrder;


### PR DESCRIPTION
- now we switch to minified mode also depending on document size
  (not only window size) so when zoom is used we will also switch.
- no longer needed to use minSize property as comments section doesn't
  change it's size
