### PR TITLE
Don't show disconnected message when DisableInactiveMessages

### DIFF
--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -493,7 +493,10 @@ app.definitions.Socket = L.Class.extend({
 						reloadMessage = _('Server is now reachable...');
 
 					var reloadFunc = function() { window.location.reload(); };
-					this._map.uiManager.showSnackbar(reloadMessage, _('RELOAD'), reloadFunc);
+					if (!this._map['wopi'].DisableInactiveMessages)
+						this._map.uiManager.showSnackbar(reloadMessage, _('RELOAD'), reloadFunc);
+					else
+						this._map.fire('postMessage', {msgId: 'Reloading', args: {Reason: 'Reconnected'}});
 					setTimeout(reloadFunc, 5000);
 				}
 			}
@@ -1424,7 +1427,8 @@ app.definitions.Socket = L.Class.extend({
 			}
 		}, 1 /* ms */);
 
-		this._map.uiManager.showSnackbar(_('The server has been disconnected.'));
+		if (!this._map['wopi'].DisableInactiveMessages)
+			this._map.uiManager.showSnackbar(_('The server has been disconnected.'));
 	},
 
 	parseServerCmd: function (msg) {


### PR DESCRIPTION
Snackbar message for 'disconnected' or 'connected again'
shouldn't be shown if DisableInactiveMessages is set.
Send 'Reloading' postmessage when reconnected with the server
and starting reload in 5s.
