### PR TITLE
test: fix sanitizers detection

### DIFF
--- a/test/helpers.hpp
+++ b/test/helpers.hpp
@@ -533,8 +533,10 @@ bool isDocumentLoaded(LOOLWebSocket& ws, const std::string& testname, bool isVie
 {
     const std::string prefix = isView ? "status:" : "statusindicatorfinish:";
     std::chrono::seconds timeout(60);
-#if defined(__SANITIZE_ADDRESS__)
+#if defined(__has_feature)
+#if __has_feature(address_sanitizer)
     timeout = std::chrono::seconds(120);
+#endif
 #endif
     const auto message = getResponseString(ws, prefix, testname, timeout);
     bool success = LOOLProtocol::matchPrefix(prefix, message);


### PR DESCRIPTION
The old code worked for "gcc -fsanitize=address", but the sanitizers
tinderbox builds with "clang -fsanitize=address".

Follow-up to commit f67b8901dd34e9c6d041a1d9797b861f95f90445 (test:
double the timeout in isDocumentLoaded() for sanitizers, 2021-11-03).

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I4b802ec0d3d20516e3d58cc1c65d7e1422632b2b
