### PR TITLE
wsd: rename 'docisdisconnected' -> 'docdisconnected'

### DIFF
--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -2363,7 +2363,7 @@ private:
             if (docBroker->isAsyncSaveInProgress())
                 LOG_DBG("Don't stop DocumentBroker on disconnect: async saving in progress.");
             else
-                docBroker->stop("docisdisconnected");
+                docBroker->stop("docdisconnected");
         }
     }
 


### PR DESCRIPTION
Otherwise, the Integrator will not receive the document
disconnection on client side.

Change-Id: I2280d90df7b915838462f119e962b0420b5cf41f
Signed-off-by: Henry Castro <hcastro@collabora.com>
