### PR TITLE
Increase button click target in toolbars

### DIFF
--- a/loleaflet/css/device-mobile.css
+++ b/loleaflet/css/device-mobile.css
@@ -357,6 +357,7 @@ button.vex-dialog-button-secondary.vex-dialog-button.vex-last {
 	padding-top: 0px;
 	padding-bottom: 0px;
 	background: transparent;
+	height: 40px;
 }
 #formulabar {
 	padding: 0px !important;
@@ -364,7 +365,6 @@ button.vex-dialog-button-secondary.vex-dialog-button.vex-last {
 }
 #tb_actionbar_item_fullscreen{display: none;}
 #toolbar-down {
-	height: 35px !important;
 	border-top: 1px solid var(--gray-color) !important;
 }
 #toolbar-down > .w2ui-scroll-wrapper {

--- a/loleaflet/css/loleaflet.css
+++ b/loleaflet/css/loleaflet.css
@@ -26,7 +26,7 @@
 	width: 1px;
 }
 #document-container.readonly.mobile.spreadsheet-doctype {
-	top: 36px;
+	top: 40px;
 	position: fixed;
 }
 #document-container {
@@ -204,7 +204,7 @@ nav.spreadsheet-color-indicator ~ #sidebar-dock-wrapper {
 
 #toolbar-wrapper {
 	table-layout: fixed;
-	border-collapse: collapse;
+	border-spacing: 0;
 	width: 100%;
 	border-top: none;
 	z-index: 11 !important;

--- a/loleaflet/css/toolbar-mobile.css
+++ b/loleaflet/css/toolbar-mobile.css
@@ -3,9 +3,6 @@
 		border-radius: 0px;
 		border: 1px solid #bbbbbb !important;
 	}
-	#toolbar-up{
-		top: -1px;
-	}
 }
 #tb_actionbar_item_redo.disabled, #tb_actionbar_item_undo.disabled, #tb_actionbar_item_mobile_wizard.disabled, #tb_actionbar_item_insertion_mobile_wizard.disabled {
 	display: none;

--- a/loleaflet/css/toolbar.css
+++ b/loleaflet/css/toolbar.css
@@ -7,14 +7,13 @@
 	z-index: 999;
 	overflow: visible !important;
 	background-color: white;
-	border-bottom: 1px solid var(--gray-color);
 }
 
 #toolbar-down {
 	left: 0;
 	right: 0;
 	text-align: center;
-	padding: 0;
+	padding: 0 !important;
 	bottom: 0;
 	z-index: 11;
 	border-top: 1px solid #bbbbbb;
@@ -22,7 +21,6 @@
 }
 #toolbar-down *{
 	font-family: var(--loleaflet-font);
-	max-height: 35px !important;
 }
 #tb_actionbar_item_LanguageStatus table table td:first-of-type{
 	min-width: max-content !important;

--- a/loleaflet/css/w2ui-1.5.rc1.css
+++ b/loleaflet/css/w2ui-1.5.rc1.css
@@ -2942,6 +2942,7 @@ button.w2ui-btn-small:focus:before {
   min-width: 24px;
   border: 1px solid transparent;
   background-color: transparent;
+  padding: 2px;
 }
 .w2ui-toolbar table.w2ui-button .w2ui-tb-image {
   width: 22px;

--- a/loleaflet/css/w2ui-1.5.rc1.css
+++ b/loleaflet/css/w2ui-1.5.rc1.css
@@ -2934,6 +2934,7 @@ button.w2ui-btn-small:focus:before {
 }
 .w2ui-toolbar table td {
   border: 0px !important;
+  padding-right: 1px;
 }
 .w2ui-toolbar table.w2ui-button {
   margin: 0 1px 0 0;


### PR DESCRIPTION
* Target version: master 

### Summary

As from previous discussion with @pedropintosilva this PR increases the click/touch target of toolbar icons to at least 32px. Furthermore on mobile the fixed height on the bottom toolbar was removed to make it dynamically adjust to the button size (currently at 42px)

#### Desktop
Before:
![image](https://user-images.githubusercontent.com/3404133/140896263-6ef49022-fe16-469c-8a84-51422aa73fc1.png)

After:
![image](https://user-images.githubusercontent.com/3404133/140896208-d17f11ef-3dec-4d24-95b6-cdf935a06bc4.png)


#### Mobile

Before:
![image](https://user-images.githubusercontent.com/3404133/140895955-c005fd64-8fac-4a1c-ac5b-c29e28a563e9.png)

After:
![image](https://user-images.githubusercontent.com/3404133/140896039-22098d7e-9fd0-4e9a-92f6-ff69252850b8.png)



### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

