### PR TITLE
Fix wopi-lock release problem

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -27,6 +27,7 @@ noinst_LTLIBRARIES = \
 	unit-wopi-async-upload-modifyclose.la \
 	unit-wopi-ownertermination.la unit-wopi-versionrestore.la \
 	unit-wopi-documentconflict.la unit_wopi_renamefile.la unit_wopi_watermark.la \
+	unit-wopi-lock.la \
 	unit-tiff-load.la \
 	unit-large-paste.la \
 	unit-paste.la \
@@ -173,6 +174,8 @@ unit_wopi_documentconflict_la_SOURCES = UnitWOPIDocumentConflict.cpp
 unit_wopi_documentconflict_la_LIBADD = $(CPPUNIT_LIBS)
 unit_wopi_renamefile_la_SOURCES = UnitWOPIRenameFile.cpp
 unit_wopi_renamefile_la_LIBADD = $(CPPUNIT_LIBS)
+unit_wopi_lock_la_SOURCES = UnitWOPILock.cpp
+unit_wopi_lock_la_LIBADD = $(CPPUNIT_LIBS)
 unit_wopi_watermark_la_SOURCES = UnitWOPIWatermark.cpp
 unit_wopi_watermark_la_LIBADD = $(CPPUNIT_LIBS)
 unit_wopi_loadencoded_la_SOURCES = UnitWOPILoadEncoded.cpp
@@ -247,6 +250,7 @@ TESTS = \
 	unit-wopi-async-upload-modifyclose.la \
 	unit-wopi-ownertermination.la unit-wopi-versionrestore.la \
 	unit-wopi-documentconflict.la unit_wopi_renamefile.la unit_wopi_watermark.la \
+	unit-wopi-lock.la \
 	unit-http.la \
 	unit-tiff-load.la \
 	unit-large-paste.la \

--- a/test/UnitWOPILock.cpp
+++ b/test/UnitWOPILock.cpp
@@ -1,0 +1,193 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <config.h>
+
+#include <WopiTestServer.hpp>
+#include <Log.hpp>
+#include <Unit.hpp>
+#include <UnitHTTP.hpp>
+#include <helpers.hpp>
+#include <Poco/Net/HTTPRequest.h>
+#include <Poco/Util/LayeredConfiguration.h>
+
+class UnitWopiLock : public WopiTestServer
+{
+    enum class Phase
+    {
+        Load,
+        LockDocument,
+        UnlockDocument,
+        Polling
+    } _phase;
+
+    std::string _lockState;
+    std::string _lockString;
+
+public:
+    UnitWopiLock()
+        : WopiTestServer("UnitWopiLock")
+        , _phase(Phase::Load)
+        , _lockState("UNLOCK")
+    {
+    }
+
+    virtual bool handleHttpRequest(const Poco::Net::HTTPRequest& request, Poco::MemoryInputStream& /*message*/, std::shared_ptr<StreamSocket>& socket) override
+    {
+        Poco::URI uriReq(request.getURI());
+        Poco::RegularExpression regInfo("/wopi/files/[0-9]");
+        Poco::RegularExpression regContent("/wopi/files/[0-9]/contents");
+        LOG_INF("Fake wopi host request: " << uriReq.toString());
+
+        // CheckFileInfo
+        if (request.getMethod() == "GET" && regInfo.match(uriReq.getPath()))
+        {
+            LOG_INF("Fake wopi host request, handling CheckFileInfo: " << uriReq.getPath());
+            static int requestCount = 0;
+
+            const std::string fileName(uriReq.getPath() == "/wopi/files/3" ? "he%llo.txt" : "hello.txt");
+            Poco::JSON::Object::Ptr fileInfo = new Poco::JSON::Object();
+            fileInfo->set("BaseFileName", fileName);
+            fileInfo->set("Size", getFileContent().size());
+            fileInfo->set("Version", "1.0");
+            fileInfo->set("OwnerId", "test");
+            fileInfo->set("UserId", "test");
+
+            fileInfo->set("UserFriendlyName", "test");
+            /// First session will be only session with the edit permission
+            fileInfo->set("UserCanWrite", requestCount < 1 ? "true" : "false");
+            fileInfo->set("PostMessageOrigin", "localhost");
+            fileInfo->set("LastModifiedTime", Util::getIso8601FracformatTime(getFileLastModifiedTime()));
+            fileInfo->set("EnableOwnerTermination", "true");
+            fileInfo->set("SupportsLocks", "true");
+
+            std::ostringstream jsonStream;
+            fileInfo->stringify(jsonStream);
+            std::string responseString = jsonStream.str();
+
+            const std::string mimeType = "application/json; charset=utf-8";
+
+            std::ostringstream oss;
+            oss << "HTTP/1.1 200 OK\r\n"
+                "Last-Modified: " << Util::getHttpTime(getFileLastModifiedTime()) << "\r\n"
+                "User-Agent: " WOPI_AGENT_STRING "\r\n"
+                "Content-Length: " << responseString.size() << "\r\n"
+                "Content-Type: " << mimeType << "\r\n"
+                "\r\n"
+                << responseString;
+
+            socket->send(oss.str());
+            socket->shutdown();
+            requestCount++;
+
+            return true;
+        }
+        // GetFile
+        else if (request.getMethod() == "GET" && regContent.match(uriReq.getPath()))
+        {
+            LOG_INF("Fake wopi host request, handling GetFile: " << uriReq.getPath());
+
+            const std::string mimeType = "text/plain; charset=utf-8";
+
+            std::ostringstream oss;
+            oss << "HTTP/1.1 200 OK\r\n"
+                "Last-Modified: " << Util::getHttpTime(getFileLastModifiedTime()) << "\r\n"
+                "User-Agent: " WOPI_AGENT_STRING "\r\n"
+                "Content-Length: " << getFileContent().size() << "\r\n"
+                "Content-Type: " << mimeType << "\r\n"
+                "\r\n"
+                << getFileContent();
+
+            socket->send(oss.str());
+            socket->shutdown();
+
+            return true;
+        }
+        // X-WOPI-Lock
+        else if (request.getMethod() == "POST" && regInfo.match(uriReq.getPath()))
+        {
+            LOG_INF("Fake wopi host request, handling Update Lock State: " << uriReq.getPath());
+
+            assertLockRequest(request);
+
+            const std::string mimeType = "text/html";
+            std::ostringstream oss;
+            oss << "HTTP/1.1 200 OK\r\n"
+                "Last-Modified: " << Util::getHttpTime(getFileLastModifiedTime()) << "\r\n"
+                "User-Agent: " WOPI_AGENT_STRING "\r\n"
+                "Content-Length: 0 \r\n"
+                "Content-Type: " << mimeType << "\r\n"
+                "\r\n";
+
+            socket->send(oss.str());
+            socket->shutdown();
+            return true;
+        }
+
+        return false;
+    }
+
+    void assertLockRequest(const Poco::Net::HTTPRequest& request)
+    {
+        std::string newLockState = request.get("X-WOPI-Override", std::string());
+        std::string lock = request.get("X-WOPI-Lock", std::string());
+        if (_phase == Phase::LockDocument && newLockState == "LOCK")
+        {
+            LOK_ASSERT_MESSAGE("Lock String cannot be empty", lock != std::string());
+            _phase = Phase::UnlockDocument;
+            _lockState = newLockState;
+            _lockString = lock;
+
+        }
+        else if (_phase == Phase::UnlockDocument && newLockState == "UNLOCK")
+        {
+            LOK_ASSERT_MESSAGE("Document it not locked", _lockState != "UNLOCK");
+            LOK_ASSERT_EQUAL(_lockString, lock);
+            _phase = Phase::Polling;
+            exitTest(TestResult::Ok);
+        }
+    }
+
+    void invokeWSDTest() override
+    {
+        constexpr char testName[] = "UnitWopiLock";
+
+        switch (_phase)
+        {
+            case Phase::Load:
+            {
+                _phase = Phase::LockDocument;
+                initWebsocket("/wopi/files/0?access_token=anything");
+                addWebSocket();
+                helpers::sendTextFrame(*getWs()->getLOOLWebSocket(), "load url=" + getWopiSrc(), testName);
+                helpers::sendTextFrame(*getWsAt(1)->getLOOLWebSocket(), "load url=" + getWopiSrc(), testName);
+                SocketPoll::wakeupWorld();
+                break;
+            }
+            case Phase::LockDocument:
+                break;
+            case Phase::UnlockDocument:
+            {
+                // force kill the session with edit permission
+                deleteSocketAt(0);
+                break;
+            }
+            case Phase::Polling:
+            {
+                // just wait for the results
+                break;
+            }
+        }
+    }
+};
+
+UnitBase *unit_create_wsd(void)
+{
+    return new UnitWopiLock();
+}
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/test/WopiTestServer.hpp
+++ b/test/WopiTestServer.hpp
@@ -21,6 +21,7 @@
 #include <Poco/URI.h>
 #include <Poco/Util/LayeredConfiguration.h>
 #include <sstream>
+#include <vector>
 
 class WopiTestServer : public UnitWSD
 {
@@ -33,8 +34,8 @@ private:
     /// The WOPISrc URL.
     std::string _wopiSrc;
 
-    /// Websocket to communicate.
-    std::unique_ptr<UnitWebSocket> _ws;
+    /// Websockets to communicate.
+    std::vector< std::unique_ptr<UnitWebSocket> > _wsList;
 
 protected:
 
@@ -46,7 +47,15 @@ protected:
 
     const std::string& getWopiSrc() const { return _wopiSrc; }
 
-    const std::unique_ptr<UnitWebSocket>& getWs() const { return _ws; }
+    const std::unique_ptr<UnitWebSocket>& getWs() const { return _wsList.at(0); }
+
+    const std::unique_ptr<UnitWebSocket>& getWsAt(int index) { return _wsList.at(index); }
+
+    void deleteSocketAt(int index)
+    {
+        std::unique_ptr<UnitWebSocket>& socket = _wsList.at(index);
+        socket.reset();
+    }
 
     const std::string& getFileContent() const { return _fileContent; }
 
@@ -80,8 +89,16 @@ public:
 
         LOG_TST("Connecting to the fake WOPI server: /lool/" << _wopiSrc << "/ws");
 
-        _ws.reset(new UnitWebSocket("/lool/" + _wopiSrc + "/ws"));
-        assert(_ws.get());
+        const auto& _ws = _wsList.emplace(_wsList.begin(), std::unique_ptr<UnitWebSocket>(new UnitWebSocket("/lool/" + _wopiSrc + "/ws")));
+        assert((*_ws).get());
+    }
+
+    void addWebSocket()
+    {
+        LOG_TST("Addigin additional socket to the fake WOPI server: /lool/" << _wopiSrc << "/ws");
+        const auto& _ws = _wsList.emplace(_wsList.end(), std::unique_ptr<UnitWebSocket>(new UnitWebSocket("/lool/" + _wopiSrc + "/ws")));
+
+        assert((*_ws).get());
     }
 
     virtual void assertCheckFileInfoRequest(const Poco::Net::HTTPRequest& /*request*/)


### PR DESCRIPTION
If the last session is readonly on a document that
is already locked by a edit the file stays locked.

Signed-off-by: Mert Tumer <mert.tumer@collabora.com>
Change-Id: Ia48e73fffd7962da2e18acfa0f1259d237c72fa8


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

