### PR TITLE
Remove config option loleaflet_html

### DIFF
--- a/.gitpod-files/loolwsd-gitpod.xml
+++ b/.gitpod-files/loolwsd-gitpod.xml
@@ -45,8 +45,6 @@
         <idle_timeout_secs desc="The maximum number of seconds before dimming and stopping updates when the user is no longer active (even if the browser is in focus). Defaults to 15 minutes." type="uint" default="900">900</idle_timeout_secs>
     </per_view>
 
-    <loleaflet_html desc="Allows UI customization by replacing the single endpoint of cool.html" type="string" default="cool.html">cool.html</loleaflet_html>
-
     <logging>
         <color type="bool">true</color>
         <level type="string" desc="Can be 0-8, or none (turns off logging), fatal, critical, error, warning, notice, information, debug, trace" default="trace">trace</level>

--- a/loolwsd.xml.in
+++ b/loolwsd.xml.in
@@ -52,7 +52,6 @@
         <idle_timeout_secs desc="The maximum number of seconds before dimming and stopping updates when the user is no longer active (even if the browser is in focus). Defaults to 15 minutes." type="uint" default="900">900</idle_timeout_secs>
     </per_view>
 
-    <loleaflet_html desc="Allows UI customization by replacing the single endpoint of cool.html" type="string" default="loleaflet.html">cool.html</loleaflet_html>
     <ver_suffix desc="Appended to etags to allow easy refresh of changed files during development" type="string" default=""></ver_suffix>
 
     <logging>

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -554,8 +554,7 @@ void FileServerRequestHandler::handleRequest(const HTTPRequest& request,
         if (FileHash.find(relPath) == FileHash.end())
             throw Poco::FileNotFoundException("Invalid URI request: [" + requestUri.toString() + "].");
 
-        const std::string coolHtml = config.getString("loleaflet_html", "cool.html");
-        if (endPoint == coolHtml ||
+        if (endPoint == "cool.html" ||
                 endPoint == "help-localizations.json" ||
                 endPoint == "localizations.json" ||
                 endPoint == "locore-localizations.json" ||

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -1053,7 +1053,6 @@ void LOOLWSD::innerInitialize(Application& self)
             { "logging.file[@enable]", "false" },
             { "logging.level", "trace" },
             { "logging.lokit_sal_log", "-INFO-WARN" },
-            { "loleaflet_html", "cool.html" },
             { "loleaflet_logging", "false" },
             { "mount_jail_tree", "true" },
             { "net.connection_timeout_secs", "30" },
@@ -3723,16 +3722,13 @@ private:
             discoveryPath = LOOLWSD::FileServerRoot + "/discovery.xml";
         }
 
-        const auto& config = Application::instance().config();
-        const std::string coolHtml = config.getString("loleaflet_html", "cool.html");
-
         const std::string action = "action";
         const std::string favIconUrl = "favIconUrl";
         const std::string urlsrc = "urlsrc";
 
         const std::string rootUriValue = "%SRV_URI%";
         const std::string uriBaseValue = rootUriValue + "/browser/" LOOLWSD_VERSION_HASH "/";
-        const std::string uriValue = uriBaseValue + coolHtml + '?';
+        const std::string uriValue = uriBaseValue + "cool.html?";
 
         InputSource inputSrc(discoveryPath);
         DOMParser parser;


### PR DESCRIPTION
This means that we will no longer read loleaflet_html from old config files, which is
a good thing in 99.9% of the cases, because it contains a wrong default: loleaflet.html
For those integrators, who used this setting, we will offer an alternative slution later.

Signed-off-by: Andras Timar <andras.timar@collabora.com>
Change-Id: Ia82f812a5d3e522a9d33e7fcafcaa45130312d60
