### PR TITLE
comments: when zoom is used close popup with preview

### DIFF
--- a/browser/src/layer/tile/CommentListSection.ts
+++ b/browser/src/layer/tile/CommentListSection.ts
@@ -93,6 +93,7 @@ class CommentSection {
 		this.map.on('AnnotationScrollDown', this.onAnnotationScrollDown, this);
 
 		this.map.on('zoomend', function() {
+			this.map.fire('mobilewizardpopupclose');
 			this.checkCollapseState();
 			this.layout(true);
 		}, this);


### PR DESCRIPTION
if comment is a bubble with opened preview and we zoom out
so bubbles will become full comments - we need to hide old popup
