### PR TITLE
jsdialog: mobile-wizard: handle standard buttons, hide close

### DIFF
--- a/browser/src/control/Control.MobileWizardBuilder.js
+++ b/browser/src/control/Control.MobileWizardBuilder.js
@@ -734,10 +734,14 @@ L.Control.MobileWizardBuilder = L.Control.JSDialogBuilder.extend({
 				for (var i in childData.responses) {
 					var buttonId = childData.responses[i].id;
 					var response = childData.responses[i].response;
-					var button = $('#' + buttonId);
+					var button = parent.querySelector('[id=\'' + buttonId + '\']');
 					var isHelp = response === '-11' || response === -11 || buttonId === 'help';
-					if (button && isHelp)
-						button.hide();
+					var isClose = response === '7' || response === 7;
+					var isCancel = response === '0' || response === 0;
+					if (button && (isHelp || isClose || isCancel))
+						button.style.display = 'none';
+					else if (button)
+						this.setupStandardButtonHandler(button, response, this);
 				}
 			}
 		}


### PR DESCRIPTION
- setup standard responses for buttons in mobile-wizard
- by default hide close or cancel buttons in mobile-wizard
  because it can be closed using 'v' button or by tap on document