### PR TITLE
NB: fix contrast n blurriness in the selected tab

### DIFF
--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -38,29 +38,28 @@
 	border-radius: 0px;
 	background: var(--white-bg-color);
 }
+.main-nav.hasnotebookbar .ui-tab.selected.notebookbar {
+	text-shadow: 0px 0px 1px #0004;
+}
 .main-nav.hasnotebookbar.text-color-indicator .ui-tab.selected.notebookbar{
 	color: rgb(3, 105, 163);
 	color: rgb(var(--blue1-txt-primary-color));
-	text-shadow: 0px 0px 0.2px rgb(3, 105, 163);
-	text-shadow: 0px 0px 0.2px rgb(var(--blue1-txt-primary-color));
+	box-shadow: -1px -1px 1px rgba(var(--blue1-txt-primary-color),0.3), 1px -1px 1px rgba(var(--blue1-txt-primary-color),0.3);
 }
 .main-nav.hasnotebookbar.spreadsheet-color-indicator .ui-tab.selected.notebookbar{
 	color: rgb(16, 104, 2);
 	color: rgb(var(--green0-txt-primary-color));
-	text-shadow: 0px 0px 0.2px rgb(16, 104, 2);
-	text-shadow: 0px 0px 0.2px rgb(var(--green0-txt-primary-color));
+	box-shadow: -1px -1px 1px rgba(var(--green0-txt-primary-color),0.3), 1px -1px 1px rgba(var(--green0-txt-primary-color),0.3);
 }
 .main-nav.hasnotebookbar.presentation-color-indicator .ui-tab.selected.notebookbar{
 	color: rgb(163, 62, 3);
 	color: rgb(var(--orange1-txt-primary-color));
-	text-shadow: 0px 0px 0.2px rgb(163, 62, 3);
-	text-shadow: 0px 0px 0.2px rgb(var(--orange1-txt-primary-color));
+	box-shadow: -1px -1px 1px rgba(var(--orange1-txt-primary-color),0.3), 1px -1px 1px rgba(var(--orange1-txt-primary-color),0.3);
 }
 .main-nav.hasnotebookbar.drawing-color-indicator .ui-tab.selected.notebookbar{
 	color: rgb(135, 105, 0);
 	color: rgb(var(--yellow0-txt-primary-color));
-	text-shadow: 0px 0px 0.2px rgb(135, 105, 0);
-	text-shadow: 0px 0px 0.2px rgb(var(--yellow0-txt-primary-color));
+	box-shadow: -1px -1px 1px rgba(var(--yellow0-txt-primary-color),0.3), 1px -1px 1px rgba(var(--yellow0-txt-primary-color),0.3);
 }
 .main-nav.hasnotebookbar.text-color-indicator .ui-tab.notebookbar:hover {
 	color: rgb(var(--blue1-txt-primary-color));


### PR DESCRIPTION
The title of the selected tab is not crisp.

- Do not use colorful text shadows since it does not help with contrast
	and in turn makes it blurry
	- Instead use gray just as a way to
		increase contrast and visually make it look like it's semi-bold (since
		that font doesn't have anything in the middle between normal and 700)
- Also help user understand which tab is selected by increase the
	contrast between the selected tab (rectangle) and the background via
	box shadow

Resolves issue #3609

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I4140a789df6418fed3484d96625bbbe3a99ab98f
