### PR TITLE
Spinfield: improve input number (webkit)

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -355,6 +355,24 @@ input[type='checkbox']:checked.autofilter, .jsdialog input[type='checkbox']:chec
 .jsdialog input[type='radio'][disabled='disabled'] ~ label {
 	color: var(--gray-light-txt--color);
 }
+/* spinfield (number) */
+input[type='number'] {
+	padding-top: 0 !important;
+	padding-bottom: 0 !important;
+}
+
+input[type='number']::-webkit-inner-spin-button,
+input[type='number']::-webkit-outer-spin-button {
+	opacity: 0.5;
+	height: 28px;
+	margin: 0;
+}
+
+input[type='number']:hover::-webkit-inner-spin-button,
+input[type='number']:hover::-webkit-outer-spin-button {
+	opacity: 1;
+	cursor: pointer;
+}
 /* listbox */
 .jsdialog.ui-listbox {
 	-webkit-appearance: none;


### PR DESCRIPTION
On webkit based browsers spinfield controls (up an down) are hidden by
default and only appear on hover on top of that they look a bit wonky
(too small and not well positioned)

This improves that by sill using the same web native control while
styling those pseudo (vendor) classes. Extras:
- Mouse cursor change
- Different opacity values (so we retaining that visual difference
	between hover and normal state)
- Increase size of those arrows

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I07aacfc387cbf42efec1d302094bbfdfae4da4ed
