### PR TITLE
wsd: always subscribe when proactively rendering tiles

### DIFF
--- a/test/TileCacheTests.cpp
+++ b/test/TileCacheTests.cpp
@@ -1731,8 +1731,7 @@ void TileCacheTests::testTileProcessed()
 
     } while(gotTile);
 
-    LOK_ASSERT_MESSAGE("We expect two tiles at least!", arrivedTile > 1);
-    LOK_ASSERT_MESSAGE("We expect that wsd can't send all the tiles!", arrivedTile < 25);
+    LOK_ASSERT_EQUAL_MESSAGE("Expected exactly the requested number of tiles", 25, arrivedTile);
 
     for(std::string& tileID : tileIDs)
     {

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -2384,6 +2384,7 @@ void DocumentBroker::handleTileCombinedRequest(TileCombined& tileCombined,
     }
 
     // Check which newly requested tiles need rendering.
+    const auto now = std::chrono::steady_clock::now();
     std::vector<TileDesc> tilesNeedsRendering;
     for (auto& tile : tileCombined.getTiles())
     {
@@ -2395,7 +2396,7 @@ void DocumentBroker::handleTileCombinedRequest(TileCombined& tileCombined,
             // Not cached, needs rendering.
             tilesNeedsRendering.push_back(tile);
             _debugRenderedTileCount++;
-            tileCache().registerTileBeingRendered(tile);
+            tileCache().subscribeToTileRendering(tile, session, now);
         }
     }
 


### PR DESCRIPTION
When issuing tile render requests proactively (upon
getting invalidatetile event), if the registered
request has no subscriber, TileCache::saveTileAndNotify
simply drops the tiles!

New call sequence:
ClientSession::handleTileInvalidation
    docBroker->handleTileCombinedRequest
	tileCache().subscribeToTileRendering //< fix

The end result was that we rendered tiles only
to discard them, potentially leaving the clients with
stale tiles (unless they requested new tiles themselves).
If they do request them, we still benefit from the cached
copies of the internal requests we had issued (and dropped).
The issue is that we are wasting an opportunity for efficiency
and relying on the client to request tiles when we normally
push on invalidation, adding latency and being inconsistent.

Change-Id: I4d3aa3739c5324ffca15c80b20dce29ac03eef73
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
