### PR TITLE
Nb: shortcuts: increase savemodified contrast n simplify CSS

### DIFF
--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -125,21 +125,39 @@
 	flex-direction: column;
 }
 
-.text-color-indicator.hasnotebookbar #Save img.savemodified {
-	filter: hue-rotate(135deg);
+#Save.savemodified:after {
+	content: '';
+	display: block;
+	width: 4px;
+	height: 4px;
+	border-radius: 2px;
+	filter: none !important;
+	background: #f12131;
+	box-shadow: 0 0 2px 2px #efefef;
+	position: absolute;
+	top: 8px;
+	margin-left: 11px;
 }
 
-.presentation-color-indicator.hasnotebookbar #Save img.savemodified{
-	filter: hue-rotate(315deg);
+.hasnotebookbar.spreadsheet-color-indicator #table-shortcutstoolbox .unotoolbutton:not(.integrator-shortcut) img {
+	-webkit-filter: hue-rotate(290deg);
+	filter: hue-rotate(290deg);
 }
 
-.spreadsheet-color-indicator.hasnotebookbar #Save img.savemodified{
-	filter: hue-rotate(225deg);
+.hasnotebookbar.presentation-color-indicator #table-shortcutstoolbox .unotoolbutton:not(.integrator-shortcut) img {
+	-webkit-filter: hue-rotate(190deg);
+	filter: hue-rotate(190deg);
 }
 
-.drawing-color-indicator.hasnotebookbar #Save img.savemodified{
-	filter: hue-rotate(305deg);
+.hasnotebookbar.drawing-color-indicator #table-shortcutstoolbox .unotoolbutton:not(.integrator-shortcut) img {
+	-webkit-filter: hue-rotate(210deg);
+	filter: hue-rotate(210deg);
 }
+
+.hasnotebookbar #table-shortcutstoolbox .unotoolbutton.savemodified:not(.integrator-shortcut) img {
+	filter: hue-rotate(508deg) contrast(1.5);
+}
+
 /* Hamburger icon: from shortcutsbar (notebookbar) */
 .hasnotebookbar.text-color-indicator #shortcuts-menubar-icon {
 	background: rgb(3, 105, 163);
@@ -180,24 +198,6 @@
 	width: 16px;
 	-webkit-transition: all 0.25s;
 	transition: all 0.25s;
-}
-
-
-
-
-.hasnotebookbar.spreadsheet-color-indicator #table-shortcutstoolbox .unotoolbutton:not(.integrator-shortcut){
-	-webkit-filter: hue-rotate(290deg);
-	filter: hue-rotate(290deg);
-}
-
-.hasnotebookbar.presentation-color-indicator #table-shortcutstoolbox{
-	-webkit-filter: hue-rotate(190deg);
-	filter: hue-rotate(190deg);
-}
-
-.hasnotebookbar.drawing-color-indicator #table-shortcutstoolbox {
-	-webkit-filter: hue-rotate(210deg);
-	filter: hue-rotate(210deg);
 }
 
 /* options section */

--- a/browser/src/control/Control.NotebookbarBuilder.js
+++ b/browser/src/control/Control.NotebookbarBuilder.js
@@ -243,10 +243,10 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 		}
 		else if (commandName === '.uno:ModifiedStatus') {
 			if (e.state === 'true') {
-				$('#Saveimg').addClass('savemodified');
+				$('#Save').addClass('savemodified');
 			}
 			else {
-				$('#Saveimg').removeClass('savemodified');
+				$('#Save').removeClass('savemodified');
 			}
 		}
 	},


### PR DESCRIPTION
The status for unsaved documents was lacking contrast and was solely
relying on color which can be a problem for some people (deuteranopia).

Improve this by:
- Increasing color contrast
- Adjusting hue rotation and make sure it only affects img elements
- Adding visual element (red dot) as an extra visual difference between
	saved/unsaved status
	- Use shadow to increase legibility between one and the other
- Instead of adding .savemodified class to img add it to its parent
	(#save.unotoolbutton)
	- So we can style more stuff (including the new ::after element)
	without extra work
	- So we can simplify all the rules for the 3 apps (unsaved status) to
	one simple one
		- Bonus: we are then sure everything is consistent on that front

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I557a8cd9a5207d44ed3d380f96644f4ec1e99f6f
