### PR TITLE
Strip shell string syntax quotes from the PRETTY_NAME line in /etc/os…

### DIFF
--- a/common/Util.cpp
+++ b/common/Util.cpp
@@ -987,7 +987,30 @@ namespace Util
             auto it = releaseInfo.find("PRETTY_NAME");
             if (it != releaseInfo.end())
             {
-                return it->second;
+                std::string name = it->second;
+
+                // See os-release(5). It says that the lines are "environment-like shell-compatible
+                // variable assignments". What that means, *exactly*, is up for debate, but probably
+                // of mainly academic interest. (It does say that variable expansion at least is not
+                // supported, that is a relief.)
+
+                // The value of PRETTY_NAME might be quoted with double-quotes or
+                // single-quotes.
+
+                // FIXME: In addition, it might contain backslash-escaped special
+                // characters, but we ignore that possibility for now.
+
+                // FIXME: In addition, if it really does support shell syntax (except variable
+                // expansion), it could for instance consist of multiple concatenated quoted strings (with no
+                // whitespace inbetween), as in:
+                // PRETTY_NAME="Foo "'bar'" mumble"
+                // But I guess that is a pretty remote possibility and surely no other code that
+                // reads /etc/os-release handles that like a proper shell, either.
+
+                if (name.length() >= 2 && ((name[0] == '"' && name[name.length()-1] == '"') ||
+                                           (name[0] == '\'' && name[name.length()-1] == '\'')))
+                    name = name.substr(1, name.length()-2);
+                return name;
             }
             else
             {


### PR DESCRIPTION
…-release

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: I5cb6f294d6d4bf62c2e16fc88bc6195695595ba5


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

