### PR TITLE
For some reson we need more vertical space for the logo in the iOS app

### DIFF
--- a/browser/html/cool.html.m4
+++ b/browser/html/cool.html.m4
@@ -257,7 +257,7 @@ m4_ifelse(MOBILEAPP,[true],
             <div id="loolwsd-id" style="visibility: hidden;"></div>
             <div>LOKit version:</div>
             <div id="lokit-version"></div>
-            m4_ifelse(MOBILEAPP,[],[<div id="os-info"></div>])
+            m4_ifelse(MOBILEAPP,[],[<div id="os-info"></div>],[<p></p>])
             <div id="slow-proxy"></div>
             <p>Copyright © _YEAR_, VENDOR.</p>
           </div>


### PR DESCRIPTION
Probably because we don't show the os-info? So use an empty paragraph
instead. Sad that the space for the logo doesn't expand automatically
to make space for it.

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: I429df1eee32fd454409731612b48f422529cece0


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

