### PR TITLE
JSsidebar: Fix alignment options, too many in one row

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -149,6 +149,12 @@ td.jsdialog .jsdialog.cell.sidebar {
 	width: auto;
 }
 
+.spreadsheet-document + #sidebar-dock-wrapper #ScAlignmentPropertyPanelPanelExpander #box3 > div:last-of-type,
+.presentation-doctype + #sidebar-dock-wrapper #ParaPropertyPanelPanelExpander #box1 > div:last-of-type,
+.drawing-doctype + #sidebar-dock-wrapper #ParaPropertyPanelPanelExpander #box1 > div:last-of-type {
+	display: table-row;
+}
+
 .sidebar.jsdialog.checkbutton {
 	font-size: 13px;
 }


### PR DESCRIPTION
This was affecting spreadsheet, presentation and drawing doc type

Make sure the alignment container does not contain too many
elements in one row.

- 1st normal alignment properties; 2nd left-to-right/left icons
- and then ensure the last parent goes into a new row

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Iaa9f1fa12f577d5ae9dddb0597f060dd7f4019ae
