### PR TITLE
rename 'lool' -> 'cool'

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -15,17 +15,17 @@ task:
     - tar -xzf LibreOfficeKit-includes-co-2021.tar.gz
   build_script:
     - mkdir .git/hooks
-    - pw useradd -n lool -d /tmp/loolhome -m
+    - pw useradd -n cool -d /tmp/loolhome -m
     - chmod -R o+rwx ./
-    - su -m lool -c './autogen.sh'
-    - 'su -m lool -c ''env HOME=/tmp/loolhome MAKE=gmake
+    - su -m cool -c './autogen.sh'
+    - 'su -m cool -c ''env HOME=/tmp/loolhome MAKE=gmake
         CPPFLAGS="-isystem /usr/local/include" CFLAGS="-I/usr/local/include"
         CXXFLAGS="-I/usr/local/include" LDFLAGS=-L/usr/local/lib ./configure
         --with-lo-path=/usr/local/lib/libreoffice/
         --with-lokit-path=./libreoffice-src/include
         --disable-seccomp --disable-setcap --enable-debug'' '
-    - su -m lool -c 'env HOME=/tmp/loolhome gmake -j`sysctl -n hw.ncpu`'
+    - su -m cool -c 'env HOME=/tmp/loolhome gmake -j`sysctl -n hw.ncpu`'
     - chown root ./loolmount
     - chmod +s ./loolmount
   test_script:
-#    - su -m lool -c 'env HOME=/tmp/loolhome gmake check'
+#    - su -m cool -c 'env HOME=/tmp/loolhome gmake check'

--- a/android/lib/src/main/cpp/androidapp.cpp
+++ b/android/lib/src/main/cpp/androidapp.cpp
@@ -196,7 +196,7 @@ Java_org_libreoffice_androidlib_LOActivity_postMobileMessageNative(JNIEnv *env, 
 
     if (string_value)
     {
-        LOG_DBG("From JS: lool: " << string_value);
+        LOG_DBG("From JS: cool: " << string_value);
 
         // we need a copy, because we can get a new one while we are still
         // taking down the old one
@@ -295,7 +295,7 @@ Java_org_libreoffice_androidlib_LOActivity_postMobileMessageNative(JNIEnv *env, 
         }
     }
     else
-        LOG_DBG("From JS: lool: some object");
+        LOG_DBG("From JS: cool: some object");
 }
 
 extern "C" jboolean libreofficekit_initialize(JNIEnv* env, jstring dataDir, jstring cacheDir, jstring apkFile, jobject assetManager);

--- a/android/lib/src/main/java/org/libreoffice/androidlib/LOActivity.java
+++ b/android/lib/src/main/java/org/libreoffice/androidlib/LOActivity.java
@@ -93,7 +93,7 @@ public class LOActivity extends AppCompatActivity {
     private static final String KEY_IS_EDITABLE = "isEditable";
     private static final String KEY_INTENT_URI = "intentUri";
     private static final String CLIPBOARD_FILE_PATH = "LibreofficeClipboardFile.data";
-    private static final String CLIPBOARD_LOOL_SIGNATURE = "lool-clip-magic-4a22437e49a8-";
+    private static final String CLIPBOARD_LOOL_SIGNATURE = "cool-clip-magic-4a22437e49a8-";
     public static final String RECENT_DOCUMENTS_KEY = "RECENT_DOCUMENTS_LIST";
     private static String USER_NAME_KEY = "USER_NAME";
 

--- a/browser/admin/admintemplate.html
+++ b/browser/admin/admintemplate.html
@@ -55,7 +55,7 @@
     <script>
         if (typeof brandProductName !== 'undefined') {l10nstrings.strProductName = brandProductName}
         document.title = l10nstrings.strProductName + ' - ' + l10nstrings.strAdminConsole;
-        var host = (window.location.protocol === 'https:' ? 'wss://': 'ws://') + window.location.host + '%SERVICE_ROOT%/lool/adminws/';
+        var host = (window.location.protocol === 'https:' ? 'wss://': 'ws://') + window.location.host + '%SERVICE_ROOT%/cool/adminws/';
     </script>
 
     <div class="is-fullwidth has-text-white" style="height:62px;background-color:#17191E;line-height:50px;">

--- a/browser/html/load.doc.html
+++ b/browser/html/load.doc.html
@@ -63,7 +63,7 @@
       <input name="NotWOPIButIframe" value="true" type="hidden" />
 
       <label for="file_path">Document Path:</label>
-      <input id="file_path" name="file_path" value="file:///home/lool/online/test/data/hello-world.odt" type="text" size="80" /></br>
+      <input id="file_path" name="file_path" value="file:///home/cool/online/test/data/hello-world.odt" type="text" size="80" /></br>
       </br>
       <input type="submit" value="Load Collabora Online" />
     </form>

--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -828,7 +828,7 @@ window.app = { // Shouldn't have any functions defined.
 	} else {
 		// The URL may already contain a query (e.g., 'http://server.tld/foo/wopi/files/bar?desktop=baz') - then just append more params
 		var docParamsPart = docParams ? (global.docURL.includes('?') ? '&' : '?') + docParams : '';
-		var websocketURI = global.makeWsUrlWopiSrc('/lool/', global.docURL + docParamsPart);
+		var websocketURI = global.makeWsUrlWopiSrc('/cool/', global.docURL + docParamsPart);
 		try {
 			global.socket = global.createWebSocket(websocketURI);
 		} catch (err) {

--- a/browser/package.json
+++ b/browser/package.json
@@ -39,7 +39,7 @@
   "keywords": [
     "office",
     "libreoffice",
-    "lool",
+    "cool",
     "collabora"
   ],
   "license": "BSD-2-Clause",

--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -34,7 +34,7 @@ app.definitions.Socket = L.Class.extend({
 	},
 
 	getWebSocketBaseURI: function(map) {
-		return window.makeWsUrlWopiSrc('/lool/', map.options.doc + '?' + $.param(map.options.docParams));
+		return window.makeWsUrlWopiSrc('/cool/', map.options.doc + '?' + $.param(map.options.docParams));
 	},
 
 	connect: function(socket) {

--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -76,7 +76,7 @@ L.Clipboard = L.Class.extend({
 	getMetaPath: function(idx) {
 		if (!idx)
 			idx = 0;
-		return '/lool/clipboard?WOPISrc=' + encodeURIComponent(this._map.options.doc) +
+		return '/cool/clipboard?WOPISrc=' + encodeURIComponent(this._map.options.doc) +
 			'&ServerId=' + app.socket.WSDServer.Id +
 			'&ViewId=' + this._map._docLayer._viewId +
 			'&Tag=' + this._accessKey[idx];

--- a/browser/src/map/Map.js
+++ b/browser/src/map/Map.js
@@ -51,7 +51,7 @@ L.Map = L.Evented.extend({
 		// 256x256 pixels tile).Unless you know what you are doing, this should not be modified;
 		// this means twips value for 256 pixels at 96dpi.
 		tileHeightTwips: window.tileSize * 15,
-		urlPrefix: 'lool',
+		urlPrefix: 'cool',
 		wopiSrc: '',
 		cursorURL: L.LOUtil.getURL('cursors'),
 		// cursorURL

--- a/common/FileUtil.cpp
+++ b/common/FileUtil.cpp
@@ -201,7 +201,7 @@ namespace FileUtil
         Poco::File(root).createDirectories();
 
         // Don't const to allow for automatic move on return.
-        std::string newTmp = root + "/lool-" + Util::rng::getFilename(16);
+        std::string newTmp = root + "/cool-" + Util::rng::getFilename(16);
         if (::mkdir(newTmp.c_str(), S_IRWXU) < 0)
         {
             LOG_SYS("Failed to create random temp directory [" << newTmp << ']');

--- a/common/Protocol.hpp
+++ b/common/Protocol.hpp
@@ -237,7 +237,7 @@ namespace LOOLProtocol
     }
 
     /// Returns an abbreviation of the message (the first line, indicating truncation). We assume
-    /// that it adhers to the LOOL protocol, i.e. that there is always a first (or only) line that
+    /// that it adhers to the COOL protocol, i.e. that there is always a first (or only) line that
     /// is in printable UTF-8. I.e. no encoding of binary bytes is done. The format of the result is
     /// not guaranteed to be stable. It is to be used for logging purposes only, not for decoding
     /// protocol frames.

--- a/configure.ac
+++ b/configure.ac
@@ -1170,7 +1170,7 @@ AC_SUBST(LOOLWSD_CONFIGDIR)
 LOOLWSD_DATADIR=${datadir}/${PACKAGE}
 AC_SUBST(LOOLWSD_DATADIR)
 
-COOL_USER_ID="lool"
+COOL_USER_ID="cool"
 if test -n "$with_user_id"; then
    COOL_USER_ID="$with_user_id"
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -191,7 +191,7 @@ AC_ARG_WITH([app-name],
                              [Set the user-visible name of the app you build.]))
 
 AC_ARG_WITH([user-id],
-              AS_HELP_STRING([--with-user-id=lool],
+              AS_HELP_STRING([--with-user-id=cool],
                              [Set the account name of the user required to run the app (outside debug mode).]))
 
 AC_ARG_WITH([icon-theme],

--- a/debian/loolwsd.postinst.in
+++ b/debian/loolwsd.postinst.in
@@ -7,15 +7,15 @@ case "$1" in
 	setcap cap_fowner,cap_chown,cap_mknod,cap_sys_chroot=ep /usr/bin/loolforkit || true
 	setcap cap_sys_admin=ep /usr/bin/loolmount || true
 
-	adduser --quiet --system --group --home /opt/cool lool
-	chown lool: /etc/loolwsd/loolwsd.xml
+	adduser --quiet --system --group --home /opt/cool cool
+	chown cool: /etc/loolwsd/loolwsd.xml
 	chmod 640 /etc/loolwsd/loolwsd.xml
 
 	# We assume that the LibreOffice to be used is built TDF-style
 	# and installs in @LO_PATH@, and that /opt/cool is
 	# on the same file system
 
-	rm -rf /opt/lool
+	rm -rf /opt/cool
 	mkdir -p /opt/cool/child-roots
 	chown cool: /opt/cool
 	chown cool: /opt/cool/child-roots

--- a/debian/loolwsd.postinst.in
+++ b/debian/loolwsd.postinst.in
@@ -16,17 +16,17 @@ case "$1" in
 	# on the same file system
 
 	rm -rf /opt/lool
-	mkdir -p /opt/lool/child-roots
-	chown lool: /opt/lool
-	chown lool: /opt/lool/child-roots
+	mkdir -p /opt/cool/child-roots
+	chown cool: /opt/cool
+	chown cool: /opt/cool/child-roots
 
 	fc-cache @LO_PATH@/share/fonts/truetype
 
-	loolwsd-systemplate-setup /opt/lool/systemplate @LO_PATH@ >/dev/null 2>&1
+	loolwsd-systemplate-setup /opt/cool/systemplate @LO_PATH@ >/dev/null 2>&1
 	loolwsd-generate-proof-key >/dev/null 2>&1
     cat << EOF > /etc/apt/apt.conf.d/25loolwsd
 // Rebuild systemplate of @APP_NAME@
-DPkg::Post-Invoke { "echo Updating loolwsd systemplate;loolwsd-systemplate-setup /opt/lool/systemplate @LO_PATH@ >/dev/null 2>&1 || true"; };
+DPkg::Post-Invoke { "echo Updating loolwsd systemplate;loolwsd-systemplate-setup /opt/cool/systemplate @LO_PATH@ >/dev/null 2>&1 || true"; };
 EOF
 	;;
 

--- a/debian/loolwsd.postinst.in
+++ b/debian/loolwsd.postinst.in
@@ -7,12 +7,12 @@ case "$1" in
 	setcap cap_fowner,cap_chown,cap_mknod,cap_sys_chroot=ep /usr/bin/loolforkit || true
 	setcap cap_sys_admin=ep /usr/bin/loolmount || true
 
-	adduser --quiet --system --group --home /opt/lool lool
+	adduser --quiet --system --group --home /opt/cool lool
 	chown lool: /etc/loolwsd/loolwsd.xml
 	chmod 640 /etc/loolwsd/loolwsd.xml
 
 	# We assume that the LibreOffice to be used is built TDF-style
-	# and installs in @LO_PATH@, and that /opt/lool is
+	# and installs in @LO_PATH@, and that /opt/cool is
 	# on the same file system
 
 	rm -rf /opt/lool

--- a/debian/loolwsd.service
+++ b/debian/loolwsd.service
@@ -13,7 +13,7 @@ Restart=always
 LimitNOFILE=infinity:infinity
 
 ProtectSystem=strict
-ReadWritePaths=/opt/lool /var/log
+ReadWritePaths=/opt/cool /var/log
 
 ProtectHome=yes
 PrivateTmp=yes

--- a/debian/loolwsd.service
+++ b/debian/loolwsd.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 EnvironmentFile=-/etc/sysconfig/loolwsd
-ExecStart=/usr/bin/loolwsd --version --o:sys_template_path=/opt/lool/systemplate --o:child_root_path=/opt/lool/child-roots --o:file_server_root_path=/usr/share/loolwsd
+ExecStart=/usr/bin/loolwsd --version --o:sys_template_path=/opt/cool/systemplate --o:child_root_path=/opt/cool/child-roots --o:file_server_root_path=/usr/share/loolwsd
 KillSignal=SIGINT
 TimeoutStopSec=120
 User=lool

--- a/debian/loolwsd.service
+++ b/debian/loolwsd.service
@@ -7,7 +7,7 @@ EnvironmentFile=-/etc/sysconfig/loolwsd
 ExecStart=/usr/bin/loolwsd --version --o:sys_template_path=/opt/cool/systemplate --o:child_root_path=/opt/cool/child-roots --o:file_server_root_path=/usr/share/loolwsd
 KillSignal=SIGINT
 TimeoutStopSec=120
-User=lool
+User=cool
 KillMode=control-group
 Restart=always
 LimitNOFILE=infinity:infinity

--- a/docker/from-packages/RHEL8
+++ b/docker/from-packages/RHEL8
@@ -37,7 +37,7 @@ ADD /scripts/start-collabora-online.sh /
 
 EXPOSE 9980
 
-# switch to lool user (use numeric user id to be compatible with Kubernetes Pod Security Policies)
+# switch to cool user (use numeric user id to be compatible with Kubernetes Pod Security Policies)
 USER 998
 
 # Entry point

--- a/docker/from-packages/Ubuntu
+++ b/docker/from-packages/Ubuntu
@@ -37,7 +37,7 @@ ADD /scripts/start-collabora-online.sh /
 
 EXPOSE 9980
 
-# switch to lool user (use numeric user id to be compatible with Kubernetes Pod Security Policies)
+# switch to cool user (use numeric user id to be compatible with Kubernetes Pod Security Policies)
 USER 104
 
 # Entry point

--- a/docker/from-packages/scripts/install-collabora-online-rhel8.sh
+++ b/docker/from-packages/scripts/install-collabora-online-rhel8.sh
@@ -65,7 +65,7 @@ rm -rf /etc/loolwsd/proof_key*
 # Fix permissions
 # cf. start-collabora-online.sh that is run by lool user
 # # Fix domain name resolution from jails
-# cp /etc/resolv.conf /etc/hosts /opt/lool/systemplate/etc/
-chown lool:lool /opt/lool/systemplate/etc/hosts /opt/lool/systemplate/etc/resolv.conf
+# cp /etc/resolv.conf /etc/hosts /opt/cool/systemplate/etc/
+chown cool:cool /opt/cool/systemplate/etc/hosts /opt/cool/systemplate/etc/resolv.conf
 # generated ssl cert/key and WOPI proof key go into /etc/loolwsd
-chown lool:lool /etc/loolwsd
+chown cool:cool /etc/loolwsd

--- a/docker/from-packages/scripts/install-collabora-online-rhel8.sh
+++ b/docker/from-packages/scripts/install-collabora-online-rhel8.sh
@@ -63,7 +63,7 @@ dnf clean all
 rm -rf /etc/loolwsd/proof_key*
 
 # Fix permissions
-# cf. start-collabora-online.sh that is run by lool user
+# cf. start-collabora-online.sh that is run by cool user
 # # Fix domain name resolution from jails
 # cp /etc/resolv.conf /etc/hosts /opt/cool/systemplate/etc/
 chown cool:cool /opt/cool/systemplate/etc/hosts /opt/cool/systemplate/etc/resolv.conf

--- a/docker/from-packages/scripts/install-collabora-online-ubuntu.sh
+++ b/docker/from-packages/scripts/install-collabora-online-ubuntu.sh
@@ -80,7 +80,7 @@ rm -rf /etc/loolwsd/proof_key*
 # Fix permissions
 # cf. start-collabora-online.sh that is run by lool user
 # # Fix domain name resolution from jails
-# cp /etc/resolv.conf /etc/hosts /opt/lool/systemplate/etc/
-chown lool:lool /opt/lool/systemplate/etc/hosts /opt/lool/systemplate/etc/resolv.conf
+# cp /etc/resolv.conf /etc/hosts /opt/cool/systemplate/etc/
+chown cool:cool /opt/cool/systemplate/etc/hosts /opt/cool/systemplate/etc/resolv.conf
 # generated ssl cert/key and WOPI proof key go into /etc/loolwsd
-chown lool:lool /etc/loolwsd
+chown cool:cool /etc/loolwsd

--- a/docker/from-packages/scripts/install-collabora-online-ubuntu.sh
+++ b/docker/from-packages/scripts/install-collabora-online-ubuntu.sh
@@ -78,7 +78,7 @@ rm -rf /var/lib/apt/lists/*
 rm -rf /etc/loolwsd/proof_key*
 
 # Fix permissions
-# cf. start-collabora-online.sh that is run by lool user
+# cf. start-collabora-online.sh that is run by cool user
 # # Fix domain name resolution from jails
 # cp /etc/resolv.conf /etc/hosts /opt/cool/systemplate/etc/
 chown cool:cool /opt/cool/systemplate/etc/hosts /opt/cool/systemplate/etc/resolv.conf

--- a/docker/from-packages/scripts/start-collabora-online.sh
+++ b/docker/from-packages/scripts/start-collabora-online.sh
@@ -4,14 +4,14 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 # Fix domain name resolution from jails
-cp /etc/resolv.conf /etc/hosts /opt/lool/systemplate/etc/
+cp /etc/resolv.conf /etc/hosts /opt/cool/systemplate/etc/
 
 if test "${DONT_GEN_SSL_CERT-set}" = set; then
 # Generate new SSL certificate instead of using the default
 mkdir -p /tmp/ssl/
 cd /tmp/ssl/
 mkdir -p certs/ca
-openssl rand -writerand /opt/lool/.rnd
+openssl rand -writerand /opt/cool/.rnd
 openssl genrsa -out certs/ca/root.key.pem 2048
 openssl req -x509 -new -nodes -key certs/ca/root.key.pem -days 9131 -out certs/ca/root.crt.pem -subj "/C=DE/ST=BW/L=Stuttgart/O=Dummy Authority/CN=Dummy Authority"
 mkdir -p certs/servers
@@ -67,4 +67,4 @@ fi
 loolwsd-generate-proof-key
 
 # Start loolwsd
-exec /usr/bin/loolwsd --version --o:sys_template_path=/opt/lool/systemplate --o:child_root_path=/opt/lool/child-roots --o:file_server_root_path=/usr/share/loolwsd --o:logging.color=false ${extra_params}
+exec /usr/bin/loolwsd --version --o:sys_template_path=/opt/cool/systemplate --o:child_root_path=/opt/cool/child-roots --o:file_server_root_path=/usr/share/loolwsd --o:logging.color=false ${extra_params}

--- a/docker/from-source/Debian
+++ b/docker/from-source/Debian
@@ -31,13 +31,13 @@ RUN setcap cap_fowner,cap_chown,cap_mknod,cap_sys_chroot=ep /usr/bin/loolforkit 
     mkdir -p /opt/cool/child-roots && \
     loolwsd-systemplate-setup /opt/cool/systemplate /opt/lokit >/dev/null 2>&1 && \
     touch /var/log/loolwsd.log && \
-    chown lool:lool /var/log/loolwsd.log && \
-    chown -R lool:lool /opt/ && \
-    chown -R lool:lool /etc/loolwsd
+    chown cool:cool /var/log/loolwsd.log && \
+    chown -R cool:cool /opt/ && \
+    chown -R cool:cool /etc/loolwsd
 
 EXPOSE 9980
 
-# switch to lool user (use numeric user id to be compatible with Kubernetes Pod Security Policies)
+# switch to cool user (use numeric user id to be compatible with Kubernetes Pod Security Policies)
 USER 101
 
 CMD ["/start-collabora-online.sh"]

--- a/docker/from-source/Debian
+++ b/docker/from-source/Debian
@@ -26,8 +26,8 @@ COPY /start-collabora-online.sh /
 # Fix permissions
 RUN setcap cap_fowner,cap_chown,cap_mknod,cap_sys_chroot=ep /usr/bin/loolforkit && \
     setcap cap_sys_admin=ep /usr/bin/loolmount && \
-    adduser --quiet --system --group --home /opt/lool lool && \
-    rm -rf /opt/lool && \
+    adduser --quiet --system --group --home /opt/cool cool && \
+    rm -rf /opt/cool && \
     mkdir -p /opt/cool/child-roots && \
     loolwsd-systemplate-setup /opt/cool/systemplate /opt/lokit >/dev/null 2>&1 && \
     touch /var/log/loolwsd.log && \

--- a/docker/from-source/Debian
+++ b/docker/from-source/Debian
@@ -28,8 +28,8 @@ RUN setcap cap_fowner,cap_chown,cap_mknod,cap_sys_chroot=ep /usr/bin/loolforkit 
     setcap cap_sys_admin=ep /usr/bin/loolmount && \
     adduser --quiet --system --group --home /opt/lool lool && \
     rm -rf /opt/lool && \
-    mkdir -p /opt/lool/child-roots && \
-    loolwsd-systemplate-setup /opt/lool/systemplate /opt/lokit >/dev/null 2>&1 && \
+    mkdir -p /opt/cool/child-roots && \
+    loolwsd-systemplate-setup /opt/cool/systemplate /opt/lokit >/dev/null 2>&1 && \
     touch /var/log/loolwsd.log && \
     chown lool:lool /var/log/loolwsd.log && \
     chown -R lool:lool /opt/ && \

--- a/docker/from-source/Ubuntu
+++ b/docker/from-source/Ubuntu
@@ -32,13 +32,13 @@ RUN setcap cap_fowner,cap_chown,cap_mknod,cap_sys_chroot=ep /usr/bin/loolforkit 
     mkdir -p /opt/cool/child-roots && \
     loolwsd-systemplate-setup /opt/cool/systemplate /opt/lokit >/dev/null 2>&1 && \
     touch /var/log/loolwsd.log && \
-    chown lool:lool /var/log/loolwsd.log && \
-    chown -R lool:lool /opt/ && \
-    chown -R lool:lool /etc/loolwsd
+    chown cool:cool /var/log/loolwsd.log && \
+    chown -R cool:cool /opt/ && \
+    chown -R cool:cool /etc/loolwsd
 
 EXPOSE 9980
 
-# switch to lool user (use numeric user id to be compatible with Kubernetes Pod Security Policies)
+# switch to cool user (use numeric user id to be compatible with Kubernetes Pod Security Policies)
 USER 101
 
 CMD ["/start-collabora-online.sh"]

--- a/docker/from-source/Ubuntu
+++ b/docker/from-source/Ubuntu
@@ -28,9 +28,9 @@ COPY /start-collabora-online.sh /
 RUN setcap cap_fowner,cap_chown,cap_mknod,cap_sys_chroot=ep /usr/bin/loolforkit && \
     setcap cap_sys_admin=ep /usr/bin/loolmount && \
     adduser --quiet --system --group --home /opt/lool lool && \
-    rm -rf /opt/lool && \
-    mkdir -p /opt/lool/child-roots && \
-    loolwsd-systemplate-setup /opt/lool/systemplate /opt/lokit >/dev/null 2>&1 && \
+    rm -rf /opt/cool && \
+    mkdir -p /opt/cool/child-roots && \
+    loolwsd-systemplate-setup /opt/cool/systemplate /opt/lokit >/dev/null 2>&1 && \
     touch /var/log/loolwsd.log && \
     chown lool:lool /var/log/loolwsd.log && \
     chown -R lool:lool /opt/ && \

--- a/docker/from-source/Ubuntu
+++ b/docker/from-source/Ubuntu
@@ -27,7 +27,7 @@ COPY /start-collabora-online.sh /
 # Fix permissions
 RUN setcap cap_fowner,cap_chown,cap_mknod,cap_sys_chroot=ep /usr/bin/loolforkit && \
     setcap cap_sys_admin=ep /usr/bin/loolmount && \
-    adduser --quiet --system --group --home /opt/lool lool && \
+    adduser --quiet --system --group --home /opt/cool cool && \
     rm -rf /opt/cool && \
     mkdir -p /opt/cool/child-roots && \
     loolwsd-systemplate-setup /opt/cool/systemplate /opt/lokit >/dev/null 2>&1 && \

--- a/docker/from-source/openSUSE
+++ b/docker/from-source/openSUSE
@@ -27,13 +27,13 @@ RUN setcap cap_fowner,cap_chown,cap_mknod,cap_sys_chroot=ep /usr/bin/loolforkit 
     mkdir -p /opt/cool/child-roots && \
     loolwsd-systemplate-setup /opt/cool/systemplate /opt/lokit >/dev/null 2>&1 && \
     touch /var/log/loolwsd.log && \
-    chown lool:lool /var/log/loolwsd.log && \
-    chown -R lool:lool /opt/ && \
-    chown -R lool:lool /etc/loolwsd
+    chown cool:cool /var/log/loolwsd.log && \
+    chown -R cool:cool /opt/ && \
+    chown -R cool:cool /etc/loolwsd
 
 EXPOSE 9980
 
-# switch to lool user (use numeric user id to be compatible with Kubernetes Pod Security Policies)
+# switch to cool user (use numeric user id to be compatible with Kubernetes Pod Security Policies)
 USER 481
 
 CMD ["/start-collabora-online.sh"]

--- a/docker/from-source/openSUSE
+++ b/docker/from-source/openSUSE
@@ -24,8 +24,8 @@ RUN setcap cap_fowner,cap_chown,cap_mknod,cap_sys_chroot=ep /usr/bin/loolforkit 
     groupadd -r lool && \
     useradd -g lool -r lool -d /opt/lool -s /bin/bash && \
     rm -rf /opt/lool && \
-    mkdir -p /opt/lool/child-roots && \
-    loolwsd-systemplate-setup /opt/lool/systemplate /opt/lokit >/dev/null 2>&1 && \
+    mkdir -p /opt/cool/child-roots && \
+    loolwsd-systemplate-setup /opt/cool/systemplate /opt/lokit >/dev/null 2>&1 && \
     touch /var/log/loolwsd.log && \
     chown lool:lool /var/log/loolwsd.log && \
     chown -R lool:lool /opt/ && \

--- a/docker/from-source/openSUSE
+++ b/docker/from-source/openSUSE
@@ -21,9 +21,9 @@ COPY /start-collabora-online.sh /
 # Fix permissions
 RUN setcap cap_fowner,cap_chown,cap_mknod,cap_sys_chroot=ep /usr/bin/loolforkit && \
     setcap cap_sys_admin=ep /usr/bin/loolmount && \
-    groupadd -r lool && \
-    useradd -g lool -r lool -d /opt/lool -s /bin/bash && \
-    rm -rf /opt/lool && \
+    groupadd -r cool && \
+    useradd -g cool -r cool -d /opt/cool -s /bin/bash && \
+    rm -rf /opt/cool && \
     mkdir -p /opt/cool/child-roots && \
     loolwsd-systemplate-setup /opt/cool/systemplate /opt/lokit >/dev/null 2>&1 && \
     touch /var/log/loolwsd.log && \

--- a/etc/apache2/loolwsd.conf
+++ b/etc/apache2/loolwsd.conf
@@ -31,5 +31,5 @@
   ProxyPass   /cool/adminws ws://127.0.0.1:9980/cool/adminws
 
   # Download as, Fullscreen presentation and Image upload operations
-  ProxyPass           /lool http://127.0.0.1:9980/lool
-  ProxyPassReverse    /lool http://127.0.0.1:9980/lool
+  ProxyPass           /cool http://127.0.0.1:9980/cool
+  ProxyPassReverse    /cool http://127.0.0.1:9980/cool

--- a/etc/apache2/loolwsd.conf
+++ b/etc/apache2/loolwsd.conf
@@ -25,10 +25,10 @@
   ProxyPassReverse    /hosting/capabilities http://127.0.0.1:9980/hosting/capabilities
 
   # Main websocket
-  ProxyPassMatch "/lool/(.*)/ws$" ws://127.0.0.1:9980/lool/$1/ws nocanon
+  ProxyPassMatch "/cool/(.*)/ws$" ws://127.0.0.1:9980/cool/$1/ws nocanon
 
   # Admin Console websocket
-  ProxyPass   /lool/adminws ws://127.0.0.1:9980/lool/adminws
+  ProxyPass   /cool/adminws ws://127.0.0.1:9980/cool/adminws
 
   # Download as, Fullscreen presentation and Image upload operations
   ProxyPass           /lool http://127.0.0.1:9980/lool

--- a/etc/nginx/loolwsd.conf
+++ b/etc/nginx/loolwsd.conf
@@ -26,7 +26,7 @@
     }
 
     # download, presentation and image upload
-    location ~ ^/lool {
+    location ~ ^/cool {
         proxy_pass http://localhost:9980;
         proxy_set_header Host $http_host;
     }

--- a/etc/nginx/loolwsd.conf
+++ b/etc/nginx/loolwsd.conf
@@ -17,7 +17,7 @@
     }
 
     # main websocket
-    location ~ ^/lool/(.*)/ws$ {
+    location ~ ^/cool/(.*)/ws$ {
         proxy_pass http://localhost:9980;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";
@@ -32,7 +32,7 @@
     }
 
     # Admin Console websocket
-    location ^~ /lool/adminws {
+    location ^~ /cool/adminws {
         proxy_pass http://localhost:9980;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";

--- a/gtk/mobile.cpp
+++ b/gtk/mobile.cpp
@@ -153,7 +153,7 @@ static void handle_lool_message(WebKitUserContentManager *manager,
 
     if (string_value)
     {
-        LOG_TRC_NOFILE("From JS: lool: " << string_value);
+        LOG_TRC_NOFILE("From JS: cool: " << string_value);
 
         if (strcmp(string_value, "HULLO") == 0)
         {
@@ -253,7 +253,7 @@ static void handle_lool_message(WebKitUserContentManager *manager,
         g_free(string_value);
     }
     else
-        LOG_TRC_NOFILE("From JS: lool: some object");
+        LOG_TRC_NOFILE("From JS: cool: some object");
 }
 
 static void handle_debug_message(WebKitUserContentManager *manager,
@@ -313,11 +313,11 @@ int main(int argc, char* argv[])
     WebKitUserContentManager *userContentManager = WEBKIT_USER_CONTENT_MANAGER(webkit_user_content_manager_new());
 
     g_signal_connect(userContentManager, "script-message-received::debug", G_CALLBACK(handle_debug_message), nullptr);
-    g_signal_connect(userContentManager, "script-message-received::lool",  G_CALLBACK(handle_lool_message), nullptr);
+    g_signal_connect(userContentManager, "script-message-received::cool",  G_CALLBACK(handle_lool_message), nullptr);
     g_signal_connect(userContentManager, "script-message-received::error", G_CALLBACK(handle_error_message), nullptr);
 
     webkit_user_content_manager_register_script_message_handler(userContentManager, "debug");
-    webkit_user_content_manager_register_script_message_handler(userContentManager, "lool");
+    webkit_user_content_manager_register_script_message_handler(userContentManager, "cool");
     webkit_user_content_manager_register_script_message_handler(userContentManager, "error");
 
     webView = WEBKIT_WEB_VIEW(webkit_web_view_new_with_user_content_manager(userContentManager));

--- a/indexing/Server.py
+++ b/indexing/Server.py
@@ -79,7 +79,7 @@ def callConvertToIndexingXml(filename, filepath):
     filesDict = {
         'data': (filepath, open(filepath, 'rb'), None, {})
     }
-    response = requests.post("{}/lool/convert-to/xml".format(coolServerUrl), files=filesDict)
+    response = requests.post("{}/cool/convert-to/xml".format(coolServerUrl), files=filesDict)
     if response.ok:
         return response.content
     return None
@@ -151,7 +151,7 @@ def callRenderImageService(resultJsonString):
         "document": (filename, open(documentPath + filename, 'rb'), None, {}),
         "result" : ("json", resultJsonProcessed, None, {})
     }
-    response = requests.post("{}/lool/render-search-result".format(coolServerUrl), files=filesDict)
+    response = requests.post("{}/cool/render-search-result".format(coolServerUrl), files=filesDict)
     return base64.b64encode(response.content)
 
 # HTTP Server - Handle HTTP requests

--- a/ios/Mobile/DocumentViewController.mm
+++ b/ios/Mobile/DocumentViewController.mm
@@ -80,7 +80,7 @@ static IMP standardImpOfInputAccessoryView = nil;
     WKUserContentController *userContentController = [[WKUserContentController alloc] init];
 
     [userContentController addScriptMessageHandler:self name:@"debug"];
-    [userContentController addScriptMessageHandler:self name:@"lool"];
+    [userContentController addScriptMessageHandler:self name:@"cool"];
     [userContentController addScriptMessageHandler:self name:@"error"];
 
     configuration.userContentController = userContentController;
@@ -196,7 +196,7 @@ static IMP standardImpOfInputAccessoryView = nil;
             [self.document closeWithCompletionHandler:^(BOOL success){
                     LOG_TRC("close completion handler gets " << (success?"YES":"NO"));
                     [self.webView.configuration.userContentController removeScriptMessageHandlerForName:@"debug"];
-                    [self.webView.configuration.userContentController removeScriptMessageHandlerForName:@"lool"];
+                    [self.webView.configuration.userContentController removeScriptMessageHandlerForName:@"cool"];
                     [self.webView.configuration.userContentController removeScriptMessageHandlerForName:@"error"];
                     self.webView.configuration.userContentController = nil;
                     [self.webView removeFromSuperview];
@@ -277,7 +277,7 @@ static IMP standardImpOfInputAccessoryView = nil;
         LOG_ERR("Error from WebView: " << [message.body UTF8String]);
     } else if ([message.name isEqualToString:@"debug"]) {
         std::cerr << "==> " << [message.body UTF8String] << std::endl;
-    } else if ([message.name isEqualToString:@"lool"]) {
+    } else if ([message.name isEqualToString:@"cool"]) {
         NSString *subBody = [message.body substringToIndex:std::min(100ul, ((NSString*)message.body).length)];
         if (subBody.length < ((NSString*)message.body).length)
             subBody = [subBody stringByAppendingString:@"..."];
@@ -387,7 +387,7 @@ static IMP standardImpOfInputAccessoryView = nil;
             WKWebViewConfiguration *configuration = [[WKWebViewConfiguration alloc] init];
             WKUserContentController *userContentController = [[WKUserContentController alloc] init];
 
-            [userContentController addScriptMessageHandler:self name:@"lool"];
+            [userContentController addScriptMessageHandler:self name:@"cool"];
 
             configuration.userContentController = userContentController;
 

--- a/kit/ForKit.cpp
+++ b/kit/ForKit.cpp
@@ -456,7 +456,7 @@ int main(int argc, char** argv)
 {
     /*WARNING: PRIVILEGED CODE CHECKING START */
 
-    /*WARNING*/ // early check for avoiding the security check for username 'lool'
+    /*WARNING*/ // early check for avoiding the security check for username 'cool'
     /*WARNING*/ // (deliberately only this, not moving the entire parameter parsing here)
     /*WARNING*/ bool checkLoolUser = true;
     /*WARNING*/ std::string disableLoolUserChecking("--disable-lool-user-checking");
@@ -496,13 +496,13 @@ int main(int argc, char** argv)
     /*WARNING*/         return EX_SOFTWARE;
     /*WARNING*/     }
 
-    /*WARNING*/     LOG_ERR("Security: Check for the 'lool' username overridden on the command line.");
+    /*WARNING*/     LOG_ERR("Security: Check for the 'cool' username overridden on the command line.");
     /*WARNING*/ }
 
     /*WARNING: PRIVILEGED CODE CHECKING END */
 
     // Continue in privileged mode, but only if:
-    // * the user is 'lool' (privileged user)
+    // * the user is 'cool' (privileged user)
     // * the user is 'root', and --disable-lool-user-checking was provided
     // Alternatively allow running in non-privileged mode (with --nocaps), if:
     // * the user is a non-priviled user, the binary is not privileged

--- a/kit/ForKit.cpp
+++ b/kit/ForKit.cpp
@@ -459,7 +459,7 @@ int main(int argc, char** argv)
     /*WARNING*/ // early check for avoiding the security check for username 'cool'
     /*WARNING*/ // (deliberately only this, not moving the entire parameter parsing here)
     /*WARNING*/ bool checkLoolUser = true;
-    /*WARNING*/ std::string disableLoolUserChecking("--disable-lool-user-checking");
+    /*WARNING*/ std::string disableLoolUserChecking("--disable-cool-user-checking");
     /*WARNING*/ for (int i = 1; checkLoolUser && (i < argc); ++i)
     /*WARNING*/ {
     /*WARNING*/     if (disableLoolUserChecking == argv[i])
@@ -469,7 +469,7 @@ int main(int argc, char** argv)
     /*WARNING*/ if (!hasCorrectUID("loolforkit"))
     /*WARNING*/ {
     /*WARNING*/     // don't allow if any capability is set (unless root; who runs this
-    /*WARNING*/     // as root or runs this in a container and provides --disable-lool-user-checking knows what they
+    /*WARNING*/     // as root or runs this in a container and provides --disable-cool-user-checking knows what they
     /*WARNING*/     // are doing)
     /*WARNING*/     if (hasUID("root"))
     /*WARNING*/     {
@@ -482,14 +482,14 @@ int main(int argc, char** argv)
     /*WARNING*/     else if (hasAnyCapability())
     /*WARNING*/     {
     /*WARNING*/         if (!checkLoolUser)
-    /*WARNING*/             LOG_FTL("Security: --disable-lool-user-checking failed, loolforkit has some capabilities set.");
+    /*WARNING*/             LOG_FTL("Security: --disable-cool-user-checking failed, loolforkit has some capabilities set.");
 
     /*WARNING*/         LOG_FTL("Aborting.");
     /*WARNING*/         return EX_SOFTWARE;
     /*WARNING*/     }
 
     /*WARNING*/     // even without the capabilities, don't run unless the user really knows
-    /*WARNING*/     // what they are doing, and provided a --disable-lool-user-checking
+    /*WARNING*/     // what they are doing, and provided a --disable-cool-user-checking
     /*WARNING*/     if (checkLoolUser)
     /*WARNING*/     {
     /*WARNING*/         LOG_FTL("Aborting.");

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -2513,7 +2513,7 @@ void lokit_main(
 
                 // tmpdir inside the jail for added sercurity.
                 const std::string tempRoot = Poco::Path(childRoot, "tmp").toString();
-                const std::string tmpSubDir = Poco::Path(tempRoot, "lool-" + jailId).toString();
+                const std::string tmpSubDir = Poco::Path(tempRoot, "cool-" + jailId).toString();
                 Poco::File(tmpSubDir).createDirectories();
                 const std::string jailTmpDir = Poco::Path(jailPath, "tmp").toString();
                 LOG_INF("Mounting random temp dir " << tmpSubDir << " -> " << jailTmpDir);

--- a/kubernetes/helm/collabora-online/values.yaml
+++ b/kubernetes/helm/collabora-online/values.yaml
@@ -15,7 +15,7 @@ global:
     monitoring:
       activate: false
       port: 9980
-      path: "/lool/getMetrics"
+      path: "/cool/getMetrics"
     service:
       name: collabora-online
       type: ClusterIP

--- a/loolwsd-generate-proof-key
+++ b/loolwsd-generate-proof-key
@@ -22,10 +22,10 @@ if hash ssh-keygen 2>/dev/null; then
     if [ $? -ne 0 ] ; then
         exit $?
 	fi
-    if id -u lool >/dev/null 2>&1; then
+    if id -u cool >/dev/null 2>&1; then
         $SUDO chown lool: /etc/loolwsd/proof_key
     else
-        echo "User lool does not exist. Please reinstall loolwsd package, or in case of manual installation from source, create the lool user manually."
+        echo "User lool does not exist. Please reinstall loolwsd package, or in case of manual installation from source, create the cool user manually."
     fi
 else
 	echo "ssh-keygen command not found. Please install openssh client tools."

--- a/loolwsd-generate-proof-key
+++ b/loolwsd-generate-proof-key
@@ -23,7 +23,7 @@ if hash ssh-keygen 2>/dev/null; then
         exit $?
 	fi
     if id -u cool >/dev/null 2>&1; then
-        $SUDO chown lool: /etc/loolwsd/proof_key
+        $SUDO chown cool: /etc/loolwsd/proof_key
     else
         echo "User cool does not exist. Please reinstall loolwsd package, or in case of manual installation from source, create the cool user manually."
     fi

--- a/loolwsd-generate-proof-key
+++ b/loolwsd-generate-proof-key
@@ -25,7 +25,7 @@ if hash ssh-keygen 2>/dev/null; then
     if id -u cool >/dev/null 2>&1; then
         $SUDO chown lool: /etc/loolwsd/proof_key
     else
-        echo "User lool does not exist. Please reinstall loolwsd package, or in case of manual installation from source, create the cool user manually."
+        echo "User cool does not exist. Please reinstall loolwsd package, or in case of manual installation from source, create the cool user manually."
     fi
 else
 	echo "ssh-keygen command not found. Please install openssh client tools."

--- a/loolwsd.init.rhel6
+++ b/loolwsd.init.rhel6
@@ -10,7 +10,7 @@
 # Start the service loolwsd
 start() {
         echo -n $"Starting loolwsd server: "
-        su lool -c "/usr/bin/loolwsd --version --o:logging.file[@enable]=true" &
+        su cool -c "/usr/bin/loolwsd --version --o:logging.file[@enable]=true" &
         ### Create the lock file ###
         touch /var/lock/subsys/loolwsd
         success $"loolwsd server startup"

--- a/loolwsd.service
+++ b/loolwsd.service
@@ -13,7 +13,7 @@ Restart=always
 LimitNOFILE=infinity:infinity
 
 ProtectSystem=strict
-ReadWritePaths=/opt/lool /var/log
+ReadWritePaths=/opt/cool /var/log
 
 ProtectHome=yes
 PrivateTmp=yes

--- a/loolwsd.service
+++ b/loolwsd.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 EnvironmentFile=-/etc/sysconfig/loolwsd
-ExecStart=/usr/bin/loolwsd --version --o:sys_template_path=/opt/lool/systemplate --o:child_root_path=/opt/lool/child-roots --o:file_server_root_path=/usr/share/loolwsd
+ExecStart=/usr/bin/loolwsd --version --o:sys_template_path=/opt/cool/systemplate --o:child_root_path=/opt/cool/child-roots --o:file_server_root_path=/usr/share/loolwsd
 KillSignal=SIGINT
 TimeoutStopSec=120
 User=lool

--- a/loolwsd.service
+++ b/loolwsd.service
@@ -7,7 +7,7 @@ EnvironmentFile=-/etc/sysconfig/loolwsd
 ExecStart=/usr/bin/loolwsd --version --o:sys_template_path=/opt/cool/systemplate --o:child_root_path=/opt/cool/child-roots --o:file_server_root_path=/usr/share/loolwsd
 KillSignal=SIGINT
 TimeoutStopSec=120
-User=lool
+User=cool
 KillMode=control-group
 Restart=always
 LimitNOFILE=infinity:infinity

--- a/loolwsd.spec.in
+++ b/loolwsd.spec.in
@@ -130,7 +130,7 @@ echo "account    required     pam_unix.so" >>  %{buildroot}/etc/pam.d/loolwsd
 %endif
 
 %config(noreplace) /etc/pam.d/loolwsd
-%config(noreplace) %attr(640, lool, root) /etc/loolwsd/loolwsd.xml
+%config(noreplace) %attr(640, cool, root) /etc/loolwsd/loolwsd.xml
 %config /etc/loolwsd/loolkitconfig.xcu
 %config(noreplace) /etc/nginx/snippets/loolwsd.conf
 %if 0%{?suse_version} > 0

--- a/loolwsd.spec.in
+++ b/loolwsd.spec.in
@@ -167,8 +167,8 @@ loolparent=`cd ${loroot} && cd .. && /bin/pwd`
 
 rm -rf ${loolparent}/cool
 mkdir -p ${loolparent}/cool/child-roots
-chown lool:lool ${loolparent}/cool
-chown lool:lool ${loolparent}/cool/child-roots
+chown cool:cool ${loolparent}/cool
+chown cool:cool ${loolparent}/cool/child-roots
 
 fc-cache ${loroot}/share/fonts/truetype
 loolwsd-systemplate-setup ${loolparent}/cool/systemplate ${loroot} >/dev/null 2>&1

--- a/loolwsd.spec.in
+++ b/loolwsd.spec.in
@@ -150,7 +150,7 @@ echo "account    required     pam_unix.so" >>  %{buildroot}/etc/pam.d/loolwsd
 getent group lool >/dev/null || groupadd -r lool
 getent passwd lool >/dev/null || useradd -g lool -r lool -d /opt/lool -s /bin/bash
 
-# for filename in `find /opt/lool/systemplate -type f`;do stripped=$(echo -ne $filename | sed -e "s|/opt/lool/systemplate||");rpm -qf --qf="%{NAME}\n" $stripped;done | grep -v devel | grep -v 32bit | grep -v -- -fonts | sort | uniq
+# for filename in `find /opt/cool/systemplate -type f`;do stripped=$(echo -ne $filename | sed -e "s|/opt/cool/systemplate||");rpm -qf --qf="%{NAME}\n" $stripped;done | grep -v devel | grep -v 32bit | grep -v -- -fonts | sort | uniq
 %triggerin -- expat fontconfig freetype freetype2 glibc glibc-locale kernel keyutils-libs krb5 krb5-libs libbz2-1 libcap libcap-ng libcap2 libexpat1 libfreetype6 libgcc libgcc_s1 libgcrypt libiscsi libpng libpng12 libpng12-0 libpng15-15 libpng16-16 libstdc++ libstdc++6 libuuid libuuid1 libz1 lsb nss-mdns nss-softokn-freebl pcre sssd sssd-client systemd-libs timezone tzdata zlib
 
 echo -ne "Triggered update of loolwsd systemplate..."
@@ -165,13 +165,13 @@ if [ $LOOLWSD_IS_ACTIVE == "1" ]; then systemctl stop loolwsd; fi
 loroot=/opt/collaboraoffice
 loolparent=`cd ${loroot} && cd .. && /bin/pwd`
 
-rm -rf ${loolparent}/lool
-mkdir -p ${loolparent}/lool/child-roots
-chown lool:lool ${loolparent}/lool
-chown lool:lool ${loolparent}/lool/child-roots
+rm -rf ${loolparent}/cool
+mkdir -p ${loolparent}/cool/child-roots
+chown lool:lool ${loolparent}/cool
+chown lool:lool ${loolparent}/cool/child-roots
 
 fc-cache ${loroot}/share/fonts/truetype
-loolwsd-systemplate-setup ${loolparent}/lool/systemplate ${loroot} >/dev/null 2>&1
+loolwsd-systemplate-setup ${loolparent}/cool/systemplate ${loroot} >/dev/null 2>&1
 loolwsd-generate-proof-key >/dev/null 2>&1
 
 %if 0%{?rhel} || 0%{?suse_version}

--- a/loolwsd.spec.in
+++ b/loolwsd.spec.in
@@ -147,8 +147,8 @@ echo "account    required     pam_unix.so" >>  %{buildroot}/etc/pam.d/loolwsd
 %service_add_pre loolwsd.service
 %endif
 
-getent group lool >/dev/null || groupadd -r lool
-getent passwd lool >/dev/null || useradd -g lool -r lool -d /opt/lool -s /bin/bash
+getent group cool >/dev/null || groupadd -r cool
+getent passwd cool >/dev/null || useradd -g cool -r cool -d /opt/cool -s /bin/bash
 
 # for filename in `find /opt/cool/systemplate -type f`;do stripped=$(echo -ne $filename | sed -e "s|/opt/cool/systemplate||");rpm -qf --qf="%{NAME}\n" $stripped;done | grep -v devel | grep -v 32bit | grep -v -- -fonts | sort | uniq
 %triggerin -- expat fontconfig freetype freetype2 glibc glibc-locale kernel keyutils-libs krb5 krb5-libs libbz2-1 libcap libcap-ng libcap2 libexpat1 libfreetype6 libgcc libgcc_s1 libgcrypt libiscsi libpng libpng12 libpng12-0 libpng15-15 libpng16-16 libstdc++ libstdc++6 libuuid libuuid1 libz1 lsb nss-mdns nss-softokn-freebl pcre sssd sssd-client systemd-libs timezone tzdata zlib

--- a/loolwsd.xml.in
+++ b/loolwsd.xml.in
@@ -156,7 +156,7 @@
       <jwt_expiry_secs desc="Time in seconds before the Admin Console's JWT token expires" type="int" default="1800">1800</jwt_expiry_secs>
       <enable_macros_execution desc="Specifies whether the macro execution is enabled in general. This will enable Basic, Beanshell, Javascript and Python scripts. If it is set to false, the macro_security_level is ignored. If it is set to true, the mentioned entry specified the level of macro security." type="bool" default="false">false</enable_macros_execution>
       <macro_security_level desc="Level of Macro security. 1 (Medium) Confirmation required before executing macros from untrusted sources. 0 (Low, not recommended) All macros will be executed without confirmation." type="int" default="1">1</macro_security_level>
-      <enable_metrics_unauthenticated desc="When enabled, the /lool/getMetrics endpoint will not require authentication." type="bool" default="false">false</enable_metrics_unauthenticated>
+      <enable_metrics_unauthenticated desc="When enabled, the /cool/getMetrics endpoint will not require authentication." type="bool" default="false">false</enable_metrics_unauthenticated>
     </security>
 
     <watermark>

--- a/man/loolconvert.1
+++ b/man/loolconvert.1
@@ -12,7 +12,7 @@ loolconvert OPTIONS FILE(S)
 .PP
 \fB\-\-parallelism\fR=\fIthreads\fR   number of simultaneous threads to use
 .PP
-\fB\-\-server\fR=\fIuri\fR            URI of LOOL server
+\fB\-\-server\fR=\fIuri\fR            URI of COOL server
 .PP
 \fB\-\-no\-check\-certificate\fR  Disable checking of SSL certs
 .PP

--- a/test/TileCacheTests.cpp
+++ b/test/TileCacheTests.cpp
@@ -1373,7 +1373,7 @@ void TileCacheTests::requestTiles(std::shared_ptr<http::WebSocketSession>& socke
 
     // Note: this code tests tile requests in the wrong way.
 
-    // This code does NOT match what was the idea how the LOOL protocol should/could be used. The
+    // This code does NOT match what was the idea how the COOL protocol should/could be used. The
     // intent was never that the protocol would need to be, or should be, used in a strict
     // request/reply fashion. If a client needs n tiles, it should just send the requests, one after
     // another. There is no need to do n roundtrips. A client should all the time be reading
@@ -1527,7 +1527,7 @@ void TileCacheTests::requestTiles(std::shared_ptr<LOOLWebSocket>& socket,
 
     // Note: this code tests tile requests in the wrong way.
 
-    // This code does NOT match what was the idea how the LOOL protocol should/could be used. The
+    // This code does NOT match what was the idea how the COOL protocol should/could be used. The
     // intent was never that the protocol would need to be, or should be, used in a strict
     // request/reply fashion. If a client needs n tiles, it should just send the requests, one after
     // another. There is no need to do n roundtrips. A client should all the time be reading

--- a/test/UnitAdmin.cpp
+++ b/test/UnitAdmin.cpp
@@ -125,7 +125,7 @@ private:
     {
         // try connecting without authentication; should result in NotAuthenticated
         HTTPResponse response;
-        HTTPRequest request(HTTPRequest::HTTP_GET, "/lool/adminws/");
+        HTTPRequest request(HTTPRequest::HTTP_GET, "/cool/adminws/");
         std::unique_ptr<HTTPClientSession> session(UnitHTTP::createSession());
 
         _adminWs = std::make_shared<LOOLWebSocket>(*session, request, response);
@@ -156,7 +156,7 @@ private:
     {
         // try connecting with incorrect auth token; should result in InvalidToken
         HTTPResponse response;
-        HTTPRequest request(HTTPRequest::HTTP_GET, "/lool/adminws/");
+        HTTPRequest request(HTTPRequest::HTTP_GET, "/cool/adminws/");
         std::unique_ptr<HTTPClientSession> session(UnitHTTP::createSession());
 
         _adminWs = std::make_shared<LOOLWebSocket>(*session, request, response);
@@ -187,7 +187,7 @@ private:
     {
         // Authenticate first
         HTTPResponse response;
-        HTTPRequest request(HTTPRequest::HTTP_GET, "/lool/adminws/");
+        HTTPRequest request(HTTPRequest::HTTP_GET, "/cool/adminws/");
         std::unique_ptr<HTTPClientSession> session(UnitHTTP::createSession());
 
         _adminWs = std::make_shared<LOOLWebSocket>(*session, request, response);

--- a/test/UnitConvert.cpp
+++ b/test/UnitConvert.cpp
@@ -54,7 +54,7 @@ public:
 
     void sendConvertTo(std::unique_ptr<Poco::Net::HTTPClientSession>& session, const std::string& filename)
     {
-        Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_POST, "/lool/convert-to/pdf");
+        Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_POST, "/cool/convert-to/pdf");
         Poco::Net::HTMLForm form;
         form.setEncoding(Poco::Net::HTMLForm::ENCODING_MULTIPART);
         form.set("format", "txt");

--- a/test/UnitHTTP.cpp
+++ b/test/UnitHTTP.cpp
@@ -48,7 +48,7 @@ public:
 
             std::string sent = "Hello world test\n";
 
-            Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_POST, "/lool/convert-to/txt");
+            Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_POST, "/cool/convert-to/txt");
 
             switch(i)
             {
@@ -120,7 +120,7 @@ public:
 
         writeString(
             socket,
-            "POST /lool/convert-to/txt HTTP/1.1\r\n"
+            "POST /cool/convert-to/txt HTTP/1.1\r\n"
             "Host: localhost:9980\r\n"
             "User-Agent: looltests/1.2.3\r\n"
             "Accept: */*\r\n"

--- a/test/UnitSession.cpp
+++ b/test/UnitSession.cpp
@@ -204,7 +204,7 @@ UnitBase::TestResult UnitSession::testSlideShow()
         std::string encodedDoc;
         Poco::URI::encode(documentPath, ":/?", encodedDoc);
         const std::string ignoredSuffix = "%3FWOPISRC=madness"; // cf. iPhone.
-        const std::string path = "/lool/" + encodedDoc + "/download/" + downloadId + '/' + ignoredSuffix;
+        const std::string path = "/cool/" + encodedDoc + "/download/" + downloadId + '/' + ignoredSuffix;
         std::unique_ptr<Poco::Net::HTTPClientSession> session(
             helpers::createSession(Poco::URI(helpers::getTestServerURI())));
         Poco::Net::HTTPRequest requestSVG(Poco::Net::HTTPRequest::HTTP_GET, path);

--- a/test/WhiteBoxTests.cpp
+++ b/test/WhiteBoxTests.cpp
@@ -1364,8 +1364,8 @@ void WhiteBoxTests::testRequestDetails_local()
         LOK_ASSERT_EQUAL(docUri, details.getDocumentURI());
 
         LOK_ASSERT_EQUAL(static_cast<std::size_t>(6), details.size());
-        LOK_ASSERT_EQUAL(std::string("lool"), details[0]);
-        LOK_ASSERT(details.equals(0, "lool"));
+        LOK_ASSERT_EQUAL(std::string("cool"), details[0]);
+        LOK_ASSERT(details.equals(0, "cool"));
         LOK_ASSERT_EQUAL(
             std::string(
                 "file%3A%2F%2F%2Fhome%2Fash%2Fprj%2Flo%2Fonline%2Ftest%2Fdata%2Fhello-world.odt"),
@@ -1375,8 +1375,8 @@ void WhiteBoxTests::testRequestDetails_local()
         LOK_ASSERT_EQUAL(std::string("open"), details[4]);
         LOK_ASSERT_EQUAL(std::string("0"), details[5]);
 
-        LOK_ASSERT_EQUAL(std::string("lool"), details.getField(RequestDetails::Field::Type));
-        LOK_ASSERT(details.equals(RequestDetails::Field::Type, "lool"));
+        LOK_ASSERT_EQUAL(std::string("cool"), details.getField(RequestDetails::Field::Type));
+        LOK_ASSERT(details.equals(RequestDetails::Field::Type, "cool"));
         LOK_ASSERT_EQUAL(std::string("open"), details.getField(RequestDetails::Field::SessionId));
         LOK_ASSERT(details.equals(RequestDetails::Field::SessionId, "open"));
         LOK_ASSERT_EQUAL(std::string("open"), details.getField(RequestDetails::Field::Command));
@@ -1410,8 +1410,8 @@ void WhiteBoxTests::testRequestDetails_local()
         LOK_ASSERT_EQUAL(docUri, details.getDocumentURI());
 
         LOK_ASSERT_EQUAL(static_cast<std::size_t>(5), details.size());
-        LOK_ASSERT_EQUAL(std::string("lool"), details[0]);
-        LOK_ASSERT(details.equals(0, "lool"));
+        LOK_ASSERT_EQUAL(std::string("cool"), details[0]);
+        LOK_ASSERT(details.equals(0, "cool"));
         LOK_ASSERT_EQUAL(
             std::string(
                 "file%3A%2F%2F%2Fhome%2Fash%2Fprj%2Flo%2Fonline%2Ftest%2Fdata%2Fhello-world.odt"),
@@ -1420,8 +1420,8 @@ void WhiteBoxTests::testRequestDetails_local()
         LOK_ASSERT_EQUAL(std::string("write"), details[3]); // SessionId, since the real SessionId is blank.
         LOK_ASSERT_EQUAL(std::string("2"), details[4]); // Command, since SessionId was blank.
 
-        LOK_ASSERT_EQUAL(std::string("lool"), details.getField(RequestDetails::Field::Type));
-        LOK_ASSERT(details.equals(RequestDetails::Field::Type, "lool"));
+        LOK_ASSERT_EQUAL(std::string("cool"), details.getField(RequestDetails::Field::Type));
+        LOK_ASSERT(details.equals(RequestDetails::Field::Type, "cool"));
         LOK_ASSERT_EQUAL(std::string("write"), details.getField(RequestDetails::Field::SessionId));
         LOK_ASSERT(details.equals(RequestDetails::Field::SessionId, "write"));
         LOK_ASSERT_EQUAL(std::string("2"), details.getField(RequestDetails::Field::Command));
@@ -1455,8 +1455,8 @@ void WhiteBoxTests::testRequestDetails_local()
         LOK_ASSERT_EQUAL(docUri, details.getDocumentURI());
 
         LOK_ASSERT_EQUAL(static_cast<std::size_t>(5), details.size());
-        LOK_ASSERT_EQUAL(std::string("lool"), details[0]);
-        LOK_ASSERT(details.equals(0, "lool"));
+        LOK_ASSERT_EQUAL(std::string("cool"), details[0]);
+        LOK_ASSERT(details.equals(0, "cool"));
         LOK_ASSERT_EQUAL(
             std::string(
                 "file%3A%2F%2F%2Fhome%2Fash%2Fprj%2Flo%2Fonline%2Ftest%2Fdata%2Fhello-world.odt"),
@@ -1465,8 +1465,8 @@ void WhiteBoxTests::testRequestDetails_local()
         LOK_ASSERT_EQUAL(std::string("write"), details[3]); // SessionId, since the real SessionId is blank.
         LOK_ASSERT_EQUAL(std::string("2"), details[4]); // Command, since SessionId was blank.
 
-        LOK_ASSERT_EQUAL(std::string("lool"), details.getField(RequestDetails::Field::Type));
-        LOK_ASSERT(details.equals(RequestDetails::Field::Type, "lool"));
+        LOK_ASSERT_EQUAL(std::string("cool"), details.getField(RequestDetails::Field::Type));
+        LOK_ASSERT(details.equals(RequestDetails::Field::Type, "cool"));
         LOK_ASSERT_EQUAL(std::string("write"), details.getField(RequestDetails::Field::SessionId));
         LOK_ASSERT(details.equals(RequestDetails::Field::SessionId, "write"));
         LOK_ASSERT_EQUAL(std::string("2"), details.getField(RequestDetails::Field::Command));
@@ -1510,16 +1510,16 @@ void WhiteBoxTests::testRequestDetails_local_hexified()
         LOK_ASSERT_EQUAL(docUri, details.getDocumentURI());
 
         LOK_ASSERT_EQUAL(static_cast<std::size_t>(6), details.size());
-        LOK_ASSERT_EQUAL(std::string("lool"), details[0]);
-        LOK_ASSERT(details.equals(0, "lool"));
+        LOK_ASSERT_EQUAL(std::string("cool"), details[0]);
+        LOK_ASSERT(details.equals(0, "cool"));
         LOK_ASSERT_EQUAL(fileUrl, details[1]);
         LOK_ASSERT_EQUAL(std::string("ws"), details[2]);
         LOK_ASSERT_EQUAL(std::string("open"), details[3]);
         LOK_ASSERT_EQUAL(std::string("open"), details[4]);
         LOK_ASSERT_EQUAL(std::string("0"), details[5]);
 
-        LOK_ASSERT_EQUAL(std::string("lool"), details.getField(RequestDetails::Field::Type));
-        LOK_ASSERT(details.equals(RequestDetails::Field::Type, "lool"));
+        LOK_ASSERT_EQUAL(std::string("cool"), details.getField(RequestDetails::Field::Type));
+        LOK_ASSERT(details.equals(RequestDetails::Field::Type, "cool"));
         LOK_ASSERT_EQUAL(std::string("open"), details.getField(RequestDetails::Field::SessionId));
         LOK_ASSERT(details.equals(RequestDetails::Field::SessionId, "open"));
         LOK_ASSERT_EQUAL(std::string("open"), details.getField(RequestDetails::Field::Command));
@@ -1549,15 +1549,15 @@ void WhiteBoxTests::testRequestDetails_local_hexified()
         LOK_ASSERT_EQUAL(docUri, details.getDocumentURI());
 
         LOK_ASSERT_EQUAL(static_cast<std::size_t>(5), details.size());
-        LOK_ASSERT_EQUAL(std::string("lool"), details[0]);
-        LOK_ASSERT(details.equals(0, "lool"));
+        LOK_ASSERT_EQUAL(std::string("cool"), details[0]);
+        LOK_ASSERT(details.equals(0, "cool"));
         LOK_ASSERT_EQUAL(fileUrl, details[1]);
         LOK_ASSERT_EQUAL(std::string("ws"), details[2]);
         LOK_ASSERT_EQUAL(std::string("write"), details[3]); // SessionId, since the real SessionId is blank.
         LOK_ASSERT_EQUAL(std::string("2"), details[4]); // Command, since SessionId was blank.
 
-        LOK_ASSERT_EQUAL(std::string("lool"), details.getField(RequestDetails::Field::Type));
-        LOK_ASSERT(details.equals(RequestDetails::Field::Type, "lool"));
+        LOK_ASSERT_EQUAL(std::string("cool"), details.getField(RequestDetails::Field::Type));
+        LOK_ASSERT(details.equals(RequestDetails::Field::Type, "cool"));
         LOK_ASSERT_EQUAL(std::string("write"), details.getField(RequestDetails::Field::SessionId));
         LOK_ASSERT(details.equals(RequestDetails::Field::SessionId, "write"));
         LOK_ASSERT_EQUAL(std::string("2"), details.getField(RequestDetails::Field::Command));
@@ -1587,15 +1587,15 @@ void WhiteBoxTests::testRequestDetails_local_hexified()
         LOK_ASSERT_EQUAL(docUri, details.getDocumentURI());
 
         LOK_ASSERT_EQUAL(static_cast<std::size_t>(5), details.size());
-        LOK_ASSERT_EQUAL(std::string("lool"), details[0]);
-        LOK_ASSERT(details.equals(0, "lool"));
+        LOK_ASSERT_EQUAL(std::string("cool"), details[0]);
+        LOK_ASSERT(details.equals(0, "cool"));
         LOK_ASSERT_EQUAL(fileUrl, details[1]);
         LOK_ASSERT_EQUAL(std::string("ws"), details[2]);
         LOK_ASSERT_EQUAL(std::string("write"), details[3]); // SessionId, since the real SessionId is blank.
         LOK_ASSERT_EQUAL(std::string("2"), details[4]); // Command, since SessionId was blank.
 
-        LOK_ASSERT_EQUAL(std::string("lool"), details.getField(RequestDetails::Field::Type));
-        LOK_ASSERT(details.equals(RequestDetails::Field::Type, "lool"));
+        LOK_ASSERT_EQUAL(std::string("cool"), details.getField(RequestDetails::Field::Type));
+        LOK_ASSERT(details.equals(RequestDetails::Field::Type, "cool"));
         LOK_ASSERT_EQUAL(std::string("write"), details.getField(RequestDetails::Field::SessionId));
         LOK_ASSERT(details.equals(RequestDetails::Field::SessionId, "write"));
         LOK_ASSERT_EQUAL(std::string("2"), details.getField(RequestDetails::Field::Command));
@@ -1684,10 +1684,10 @@ void WhiteBoxTests::testRequestDetails()
         LOK_ASSERT_EQUAL(wopiSrc, details.getField(RequestDetails::Field::WOPISrc));
 
         LOK_ASSERT_EQUAL(static_cast<std::size_t>(8), details.size());
-        LOK_ASSERT_EQUAL(std::string("lool"), details[0]);
-        LOK_ASSERT_EQUAL(std::string("lool"), details.getField(RequestDetails::Field::Type));
-        LOK_ASSERT(details.equals(RequestDetails::Field::Type, "lool"));
-        LOK_ASSERT(details.equals(0, "lool"));
+        LOK_ASSERT_EQUAL(std::string("cool"), details[0]);
+        LOK_ASSERT_EQUAL(std::string("cool"), details.getField(RequestDetails::Field::Type));
+        LOK_ASSERT(details.equals(RequestDetails::Field::Type, "cool"));
+        LOK_ASSERT(details.equals(0, "cool"));
         LOK_ASSERT_EQUAL(
             std::string(
                 "http%3A%2F%2Flocalhost%2Fnextcloud%2Findex.php%2Fapps%2Frichdocuments%2Fwopi%"
@@ -1709,8 +1709,8 @@ void WhiteBoxTests::testRequestDetails()
         LOK_ASSERT_EQUAL(std::string("close"), details[6]);
         LOK_ASSERT_EQUAL(std::string("31"), details[7]);
 
-        LOK_ASSERT_EQUAL(std::string("lool"), details.getField(RequestDetails::Field::Type));
-        LOK_ASSERT(details.equals(RequestDetails::Field::Type, "lool"));
+        LOK_ASSERT_EQUAL(std::string("cool"), details.getField(RequestDetails::Field::Type));
+        LOK_ASSERT(details.equals(RequestDetails::Field::Type, "cool"));
         LOK_ASSERT_EQUAL(std::string("b26112ab1b6f2ed98ce1329f0f344791"), details.getField(RequestDetails::Field::SessionId));
         LOK_ASSERT(details.equals(RequestDetails::Field::SessionId, "b26112ab1b6f2ed98ce1329f0f344791"));
         LOK_ASSERT_EQUAL(std::string("close"), details.getField(RequestDetails::Field::Command));
@@ -1767,8 +1767,8 @@ void WhiteBoxTests::testRequestDetails()
         LOK_ASSERT_EQUAL(wopiSrc, details.getField(RequestDetails::Field::WOPISrc));
 
         LOK_ASSERT_EQUAL(static_cast<std::size_t>(8), details.size());
-        LOK_ASSERT_EQUAL(std::string("lool"), details[0]);
-        LOK_ASSERT(details.equals(0, "lool"));
+        LOK_ASSERT_EQUAL(std::string("cool"), details[0]);
+        LOK_ASSERT(details.equals(0, "cool"));
         LOK_ASSERT_EQUAL(
             std::string("http%3A%2F%2Flocalhost%2Fowncloud%2Findex.php%2Fapps%2Frichdocuments%"
                         "2Fwopi%2Ffiles%2F165_ocgdpzbkm39u%3Faccess_token%"
@@ -1785,8 +1785,8 @@ void WhiteBoxTests::testRequestDetails()
         LOK_ASSERT_EQUAL(std::string("write"), details[6]);
         LOK_ASSERT_EQUAL(std::string("2"), details[7]);
 
-        LOK_ASSERT_EQUAL(std::string("lool"), details.getField(RequestDetails::Field::Type));
-        LOK_ASSERT(details.equals(RequestDetails::Field::Type, "lool"));
+        LOK_ASSERT_EQUAL(std::string("cool"), details.getField(RequestDetails::Field::Type));
+        LOK_ASSERT(details.equals(RequestDetails::Field::Type, "cool"));
         LOK_ASSERT_EQUAL(std::string("1c99a7bcdbf3209782d7eb38512e6564"), details.getField(RequestDetails::Field::SessionId));
         LOK_ASSERT(details.equals(RequestDetails::Field::SessionId, "1c99a7bcdbf3209782d7eb38512e6564"));
         LOK_ASSERT_EQUAL(std::string("write"), details.getField(RequestDetails::Field::Command));
@@ -1823,15 +1823,15 @@ void WhiteBoxTests::testRequestDetails()
         LOK_ASSERT_EQUAL(std::string(), details.getField(RequestDetails::Field::WOPISrc));
 
         LOK_ASSERT_EQUAL(static_cast<std::size_t>(5), details.size());
-        LOK_ASSERT_EQUAL(std::string("lool"), details[0]);
-        LOK_ASSERT(details.equals(0, "lool"));
+        LOK_ASSERT_EQUAL(std::string("cool"), details[0]);
+        LOK_ASSERT(details.equals(0, "cool"));
         LOK_ASSERT_EQUAL(std::string("%2Ftmp%2Fslideshow_b8c3225b_setclientpart.odp"), details[1]);
         LOK_ASSERT_EQUAL(std::string("Ar3M1X89mVaryYkh"), details[2]);
         LOK_ASSERT_EQUAL(std::string("UjaCGP4cYHlU6TvUGdnFTPi8hjOS87uFym7ruWMq3F3jBr0kSPgVhbKz5CwUyV8R"), details[3]);
         LOK_ASSERT_EQUAL(std::string("slideshow.svg"), details[4]);
 
-        LOK_ASSERT_EQUAL(std::string("lool"), details.getField(RequestDetails::Field::Type));
-        LOK_ASSERT(details.equals(RequestDetails::Field::Type, "lool"));
+        LOK_ASSERT_EQUAL(std::string("cool"), details.getField(RequestDetails::Field::Type));
+        LOK_ASSERT(details.equals(RequestDetails::Field::Type, "cool"));
         LOK_ASSERT_EQUAL(std::string(""), details.getField(RequestDetails::Field::SessionId));
         LOK_ASSERT(details.equals(RequestDetails::Field::SessionId, ""));
         LOK_ASSERT_EQUAL(std::string(""), details.getField(RequestDetails::Field::Command));
@@ -1865,12 +1865,12 @@ void WhiteBoxTests::testRequestDetails()
         LOK_ASSERT_EQUAL(docUri, details.getDocumentURI());
 
         LOK_ASSERT_EQUAL(static_cast<std::size_t>(3), details.size());
-        LOK_ASSERT_EQUAL(std::string("lool"), details[0]);
-        LOK_ASSERT(details.equals(0, "lool"));
+        LOK_ASSERT_EQUAL(std::string("cool"), details[0]);
+        LOK_ASSERT(details.equals(0, "cool"));
         LOK_ASSERT_EQUAL(std::string("clipboard"), details[1]);
 
-        LOK_ASSERT_EQUAL(std::string("lool"), details.getField(RequestDetails::Field::Type));
-        LOK_ASSERT(details.equals(RequestDetails::Field::Type, "lool"));
+        LOK_ASSERT_EQUAL(std::string("cool"), details.getField(RequestDetails::Field::Type));
+        LOK_ASSERT(details.equals(RequestDetails::Field::Type, "cool"));
         LOK_ASSERT_EQUAL(std::string(""), details.getField(RequestDetails::Field::SessionId));
         LOK_ASSERT(details.equals(RequestDetails::Field::SessionId, ""));
         LOK_ASSERT_EQUAL(std::string(""), details.getField(RequestDetails::Field::Command));
@@ -1936,8 +1936,8 @@ void WhiteBoxTests::testRequestDetails()
         LOK_ASSERT_EQUAL(permission, it != params.end() ? it->second : "");
 
         LOK_ASSERT_EQUAL(static_cast<std::size_t>(11), details.size());
-        LOK_ASSERT_EQUAL(std::string("lool"), details[0]);
-        LOK_ASSERT(details.equals(0, "lool"));
+        LOK_ASSERT_EQUAL(std::string("cool"), details[0]);
+        LOK_ASSERT(details.equals(0, "cool"));
 
         const std::string encodedDocUri
             = "https%3A%2F%2Fexample.com%3A8443%2Frest%2Ffiles%2Fwopi%2Ffiles%"
@@ -1950,8 +1950,8 @@ void WhiteBoxTests::testRequestDetails()
 
         LOK_ASSERT_EQUAL(encodedDocUri, details[1]);
 
-        LOK_ASSERT_EQUAL(std::string("lool"), details.getField(RequestDetails::Field::Type));
-        LOK_ASSERT(details.equals(RequestDetails::Field::Type, "lool"));
+        LOK_ASSERT_EQUAL(std::string("cool"), details.getField(RequestDetails::Field::Type));
+        LOK_ASSERT(details.equals(RequestDetails::Field::Type, "cool"));
         LOK_ASSERT_EQUAL(std::string(""), details.getField(RequestDetails::Field::SessionId));
         LOK_ASSERT(details.equals(RequestDetails::Field::SessionId, ""));
         LOK_ASSERT_EQUAL(std::string(""), details.getField(RequestDetails::Field::Command));

--- a/test/WhiteBoxTests.cpp
+++ b/test/WhiteBoxTests.cpp
@@ -445,7 +445,7 @@ void WhiteBoxTests::testTokenizer()
     LOK_ASSERT_EQUAL(std::string("XYZ"), tokens[2]);
 
     static const std::string URI
-        = "/lool/"
+        = "/cool/"
           "http%3A%2F%2Flocalhost%2Fnextcloud%2Findex.php%2Fapps%2Frichdocuments%2Fwopi%2Ffiles%"
           "2F593_ocqiesh0cngs%3Faccess_token%3DMN0KXXDv9GJ1wCCLnQcjVQT2T7WrfYpA%26access_token_ttl%"
           "3D0%26reuse_cookies%3Doc_sessionPassphrase%"
@@ -1340,7 +1340,7 @@ void WhiteBoxTests::testRequestDetails_local()
         = "http://localhost/nextcloud/apps/richdocuments/proxy.php?req=";
 
     {
-        static const std::string URI = "/lool/"
+        static const std::string URI = "/cool/"
                                        "file%3A%2F%2F%2Fhome%2Fash%2Fprj%2Flo%2Fonline%2Ftest%"
                                        "2Fdata%2Fhello-world.odt/ws/open/open/0";
 
@@ -1387,7 +1387,7 @@ void WhiteBoxTests::testRequestDetails_local()
 
     {
         // Blank entries are skipped.
-        static const std::string URI = "/lool/"
+        static const std::string URI = "/cool/"
                                        "file%3A%2F%2F%2Fhome%2Fash%2Fprj%2Flo%2Fonline%2Ftest%"
                                        "2Fdata%2Fhello-world.odt/ws//write/2";
 
@@ -1432,7 +1432,7 @@ void WhiteBoxTests::testRequestDetails_local()
 
     {
         // Apparently, the initial / can be missing -- all the tests do that.
-        static const std::string URI = "lool/"
+        static const std::string URI = "cool/"
                                        "file%3A%2F%2F%2Fhome%2Fash%2Fprj%2Flo%2Fonline%2Ftest%"
                                        "2Fdata%2Fhello-world.odt/ws//write/2";
 
@@ -1490,7 +1490,7 @@ void WhiteBoxTests::testRequestDetails_local_hexified()
     const std::string fileUrlHex = "0x" + Util::dataToHexString(fileUrl, 0, fileUrl.size());
 
     {
-        const std::string URI = "/lool/" + fileUrlHex + "/ws/open/open/0";
+        const std::string URI = "/cool/" + fileUrlHex + "/ws/open/open/0";
 
         Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, URI,
                                        Poco::Net::HTTPMessage::HTTP_1_1);
@@ -1530,7 +1530,7 @@ void WhiteBoxTests::testRequestDetails_local_hexified()
 
     {
         // Blank entries are skipped.
-        static const std::string URI = "/lool/" + fileUrlHex + "/ws//write/2";
+        static const std::string URI = "/cool/" + fileUrlHex + "/ws//write/2";
 
         Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, URI,
                                        Poco::Net::HTTPMessage::HTTP_1_1);
@@ -1568,7 +1568,7 @@ void WhiteBoxTests::testRequestDetails_local_hexified()
 
     {
         // Apparently, the initial / can be missing -- all the tests do that.
-        static const std::string URI = "lool/" + fileUrlHex + "/ws//write/2";
+        static const std::string URI = "cool/" + fileUrlHex + "/ws//write/2";
 
         Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, URI,
                                        Poco::Net::HTTPMessage::HTTP_1_1);
@@ -1614,7 +1614,7 @@ void WhiteBoxTests::testRequestDetails()
 
     {
         static const std::string URI
-            = "/lool/"
+            = "/cool/"
               "http%3A%2F%2Flocalhost%2Fnextcloud%2Findex.php%2Fapps%2Frichdocuments%2Fwopi%"
               "2Ffiles%"
               "2F593_ocqiesh0cngs%3Faccess_token%3DMN0KXXDv9GJ1wCCLnQcjVQT2T7WrfYpA%26access_token_"
@@ -1721,7 +1721,7 @@ void WhiteBoxTests::testRequestDetails()
 
     {
         static const std::string URI
-            = "/lool/"
+            = "/cool/"
               "http%3A%2F%2Flocalhost%2Fowncloud%2Findex.php%2Fapps%2Frichdocuments%2Fwopi%2Ffiles%"
               "2F165_ocgdpzbkm39u%3Faccess_token%3DODhIXdJdbsVYQoKKCuaYofyzrovxD3MQ%26access_token_"
               "ttl%"
@@ -1797,7 +1797,7 @@ void WhiteBoxTests::testRequestDetails()
 
     {
         static const std::string URI
-            = "/lool/%2Ftmp%2Fslideshow_b8c3225b_setclientpart.odp/Ar3M1X89mVaryYkh/"
+            = "/cool/%2Ftmp%2Fslideshow_b8c3225b_setclientpart.odp/Ar3M1X89mVaryYkh/"
               "UjaCGP4cYHlU6TvUGdnFTPi8hjOS87uFym7ruWMq3F3jBr0kSPgVhbKz5CwUyV8R/slideshow.svg";
 
         Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, URI,
@@ -1841,7 +1841,7 @@ void WhiteBoxTests::testRequestDetails()
     }
 
     {
-        static const std::string URI = "/lool/"
+        static const std::string URI = "/cool/"
                                        "clipboard?WOPISrc=file%3A%2F%2F%2Ftmp%2Fcopypasteef324307_"
                                        "empty.ods&ServerId=7add98ed&ViewId=0&Tag=5f7972ce4e6a37dd";
 
@@ -1881,7 +1881,7 @@ void WhiteBoxTests::testRequestDetails()
 
     {
         static const std::string URI
-        = "/lool/"
+        = "/cool/"
           "https%3A%2F%2Fexample.com%3A8443%2Frest%2Ffiles%2Fwopi%2Ffiles%"
           "2F8ac75551de4d89e60002%3Faccess_header%3DAuthorization%253A%252520Bearer%"
           "252520poiuytrewq%25250D%25250A%25250D%25250AX-Requested-"

--- a/test/WopiTestServer.hpp
+++ b/test/WopiTestServer.hpp
@@ -87,16 +87,16 @@ public:
         _wopiSrc.clear();
         Poco::URI::encode(wopiURL.toString(), ":/?", _wopiSrc);
 
-        LOG_TST("Connecting to the fake WOPI server: /lool/" << _wopiSrc << "/ws");
+        LOG_TST("Connecting to the fake WOPI server: /cool/" << _wopiSrc << "/ws");
 
-        const auto& _ws = _wsList.emplace(_wsList.begin(), std::unique_ptr<UnitWebSocket>(new UnitWebSocket("/lool/" + _wopiSrc + "/ws")));
+        const auto& _ws = _wsList.emplace(_wsList.begin(), std::unique_ptr<UnitWebSocket>(new UnitWebSocket("/cool/" + _wopiSrc + "/ws")));
         assert((*_ws).get());
     }
 
     void addWebSocket()
     {
-        LOG_TST("Addigin additional socket to the fake WOPI server: /lool/" << _wopiSrc << "/ws");
-        const auto& _ws = _wsList.emplace(_wsList.end(), std::unique_ptr<UnitWebSocket>(new UnitWebSocket("/lool/" + _wopiSrc + "/ws")));
+        LOG_TST("Addigin additional socket to the fake WOPI server: /cool/" << _wopiSrc << "/ws");
+        const auto& _ws = _wsList.emplace(_wsList.end(), std::unique_ptr<UnitWebSocket>(new UnitWebSocket("/cool/" + _wopiSrc + "/ws")));
 
         assert((*_ws).get());
     }
@@ -300,7 +300,7 @@ protected:
 
             return true;
         }
-        else if (!Util::startsWith(uriReq.getPath(), "/lool/")) // Skip requests to the websrv.
+        else if (!Util::startsWith(uriReq.getPath(), "/cool/")) // Skip requests to the websrv.
         {
             // Complain if we are expected to handle something that we don't.
             LOG_TST("ERROR: Fake wopi host request, cannot handle request: " << uriReq.getPath());

--- a/test/countloolkits.hpp
+++ b/test/countloolkits.hpp
@@ -43,7 +43,7 @@ static int countLoolKitProcesses(const int expected,
             break;
         }
 
-        // Give polls in the lool processes time to time out etc
+        // Give polls in the cool processes time to time out etc
         std::this_thread::sleep_for(std::chrono::milliseconds(sleepMs));
 
         const int newCount = getLoolKitProcessCount();

--- a/test/helpers.hpp
+++ b/test/helpers.hpp
@@ -47,7 +47,7 @@
 constexpr int COMMAND_RETRY_COUNT = 5;
 
 /// Common helper testing functions.
-/// Avoid the temptation to reuse from LOOL code!
+/// Avoid the temptation to reuse from COOL code!
 /// These are supposed to be testing the latter.
 namespace helpers
 {

--- a/test/helpers.hpp
+++ b/test/helpers.hpp
@@ -122,7 +122,7 @@ inline void getDocumentPathAndURL(const std::string& docFilename, std::string& d
     std::string encodedUri;
     Poco::URI::encode("file://" + Poco::Path(documentPath).makeAbsolute().toString(), ":/?",
                       encodedUri);
-    documentURL = "lool/" + encodedUri + "/ws";
+    documentURL = "cool/" + encodedUri + "/ws";
     TST_LOG("Test file: " << documentPath);
 }
 

--- a/test/integration-http-server.cpp
+++ b/test/integration-http-server.cpp
@@ -247,7 +247,7 @@ void HTTPServerTest::testConvertTo()
 
     TST_LOG("Convert-to odt -> txt");
 
-    Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_POST, "/lool/convert-to");
+    Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_POST, "/cool/convert-to");
     Poco::Net::HTMLForm form;
     form.setEncoding(Poco::Net::HTMLForm::ENCODING_MULTIPART);
     form.set("format", "txt");
@@ -293,7 +293,7 @@ void HTTPServerTest::testConvertTo2()
 
     TST_LOG("Convert-to #2 xlsx -> png");
 
-    Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_POST, "/lool/convert-to");
+    Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_POST, "/cool/convert-to");
     Poco::Net::HTMLForm form;
     form.setEncoding(Poco::Net::HTMLForm::ENCODING_MULTIPART);
     form.set("format", "png");
@@ -340,7 +340,7 @@ void HTTPServerTest::testConvertToWithForwardedIP_Deny()
         std::unique_ptr<Poco::Net::HTTPClientSession> session(helpers::createSession(_uri));
         session->setTimeout(Poco::Timespan(TimeoutSeconds, 0));
 
-        Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_POST, "/lool/convert-to");
+        Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_POST, "/cool/convert-to");
         LOK_ASSERT(!request.has("X-Forwarded-For"));
         request.add("X-Forwarded-For", getNotAllowedTestServerURI().getHost() + ", " + _uri.getHost());
         Poco::Net::HTMLForm form;
@@ -390,7 +390,7 @@ void HTTPServerTest::testConvertToWithForwardedIP_Allow()
         std::unique_ptr<Poco::Net::HTTPClientSession> session(helpers::createSession(_uri));
         session->setTimeout(Poco::Timespan(TimeoutSeconds, 0));
 
-        Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_POST, "/lool/convert-to");
+        Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_POST, "/cool/convert-to");
         LOK_ASSERT(!request.has("X-Forwarded-For"));
         request.add("X-Forwarded-For", _uri.getHost() + ", " + _uri.getHost());
         Poco::Net::HTMLForm form;
@@ -448,7 +448,7 @@ void HTTPServerTest::testConvertToWithForwardedIP_DenyMulti()
         std::unique_ptr<Poco::Net::HTTPClientSession> session(helpers::createSession(_uri));
         session->setTimeout(Poco::Timespan(TimeoutSeconds, 0));
 
-        Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_POST, "/lool/convert-to");
+        Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_POST, "/cool/convert-to");
         LOK_ASSERT(!request.has("X-Forwarded-For"));
         request.add("X-Forwarded-For", _uri.getHost() + ", "
                                        + getNotAllowedTestServerURI().getHost() + ", "
@@ -494,7 +494,7 @@ void HTTPServerTest::testRenderSearchResult()
     std::unique_ptr<Poco::Net::HTTPClientSession> session(helpers::createSession(_uri));
     session->setTimeout(Poco::Timespan(10, 0)); // 10 seconds.
 
-    Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_POST, "/lool/render-search-result");
+    Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_POST, "/cool/render-search-result");
     Poco::Net::HTMLForm form;
     form.setEncoding(Poco::Net::HTMLForm::ENCODING_MULTIPART);
     form.addPart("document", new Poco::Net::FilePartSource(srcPathDoc));

--- a/tools/Config.cpp
+++ b/tools/Config.cpp
@@ -362,7 +362,7 @@ int Config::main(const std::vector<std::string>& args)
     }
     else if (args[0] == "update-system-template")
     {
-        const char command[] = "loolwsd-systemplate-setup /opt/lool/systemplate " LO_PATH " >/dev/null 2>&1";
+        const char command[] = "loolwsd-systemplate-setup /opt/cool/systemplate " LO_PATH " >/dev/null 2>&1";
         std::cout << "Running the following command:" << std::endl
                   << command << std::endl;
 

--- a/tools/Connect.cpp
+++ b/tools/Connect.cpp
@@ -163,7 +163,7 @@ protected:
 #endif
         std::string encodedUri;
         URI::encode(args[0], ":/?", encodedUri);
-        HTTPRequest request(HTTPRequest::HTTP_GET, "/lool/" + encodedUri + "/ws");
+        HTTPRequest request(HTTPRequest::HTTP_GET, "/cool/" + encodedUri + "/ws");
         HTTPResponse response;
         LOOLWebSocket ws(cs, request, response);
 

--- a/tools/Connect.cpp
+++ b/tools/Connect.cpp
@@ -124,7 +124,7 @@ private:
     LOOLWebSocket& _ws;
 };
 
-/// Program for interactive or scripted testing of a lool server.
+/// Program for interactive or scripted testing of a cool server.
 class Connect: public Poco::Util::Application
 {
 public:
@@ -192,7 +192,7 @@ protected:
             }
             else if (line == "exit")
             {
-                // While hacking on LOOL and editing input files for this program back and forth it
+                // While hacking on COOL and editing input files for this program back and forth it
                 // is a good idea to be able to add an enforced exit in the middle of the input
                 // file.
                 {

--- a/tools/KitClient.cpp
+++ b/tools/KitClient.cpp
@@ -93,7 +93,7 @@ protected:
             if (tokens.equals(0, "?") || tokens.equals(0, "help"))
             {
                 std::cout <<
-                    "Commands mimic LOOL protocol but we talk directly to LOKit:" << std::endl <<
+                    "Commands mimic COOL protocol but we talk directly to LOKit:" << std::endl <<
                     "    status" << std::endl <<
                     "        calls LibreOfficeKitDocument::getDocumentType, getParts, getPartName, getDocumentSize" << std::endl <<
                     "    tile part pixelwidth pixelheight docposx docposy doctilewidth doctileheight" << std::endl <<

--- a/tools/Replay.hpp
+++ b/tools/Replay.hpp
@@ -288,7 +288,7 @@ public:
         std::string fileabs = Poco::Path(filePath).makeAbsolute().toString();
         Poco::URI::encode("file://" + fileabs, ":/?", file);
         Poco::URI::encode(file, ":/?", wrap); // double encode.
-        std::string uri = server + "/lool/" + wrap + "/ws";
+        std::string uri = server + "/cool/" + wrap + "/ws";
 
         auto handler = std::make_shared<StressSocketHandler>(optStats, file, tracePath);
         poll.insertNewWebSocketSync(Poco::URI(uri), handler);

--- a/tools/Tool.cpp
+++ b/tools/Tool.cpp
@@ -160,7 +160,7 @@ void Tool::displayHelp()
               << "  --extension=format          File format to convert to\n"
               << "  --outdir=directory          Output directory for converted files\n"
               << "  --parallelism=threads       Number of simultaneous threads to use\n"
-              << "  --server=uri                URI of LOOL server\n"
+              << "  --server=uri                URI of COOL server\n"
               << "  --no-check-certificate      Disable checking of SSL certificate\n"
               << "In addition, the options taken by the libreoffice command for its --convert-to\n"
               << "functionality can be used (but are ignored if irrelevant to this command)." << std::endl;

--- a/tools/Tool.cpp
+++ b/tools/Tool.cpp
@@ -98,7 +98,7 @@ public:
         else
             session = new Poco::Net::HTTPClientSession(uri.getHost(), uri.getPort());
 
-        Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_POST, "/lool/convert-to");
+        Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_POST, "/cool/convert-to");
 
         try {
             Poco::Net::HTMLForm form;

--- a/wsd/Admin.cpp
+++ b/wsd/Admin.cpp
@@ -120,7 +120,7 @@ void AdminSocketHandler::handleMessage(const std::vector<char> &payload)
     }
     else if (tokens.equals(0, "version"))
     {
-        // Send LOOL version information
+        // Send COOL version information
         sendTextFrame("loolserver " + Util::getVersionJSON());
         // Send LOKit version information
         sendTextFrame("lokitversion " + LOOLWSD::LOKitVersion);
@@ -746,7 +746,7 @@ void Admin::triggerMemoryCleanup(const size_t totalMem)
         return;
     }
 
-    LOG_TRC("Total memory consumed: " << totalMem << " KB. Configured LOOL memory proportion: " <<
+    LOG_TRC("Total memory consumed: " << totalMem << " KB. Configured COOL memory proportion: " <<
             memLimit << "% (" << static_cast<size_t>(_totalSysMemKb * memLimit / 100.) << " KB).");
 
     const double memToFreePercentage = (totalMem / static_cast<double>(_totalSysMemKb)) - memLimit / 100.;

--- a/wsd/Auth.hpp
+++ b/wsd/Auth.hpp
@@ -59,7 +59,7 @@ private:
     const std::string _alg = "RS256";
     const std::string _typ = "JWT";
 
-    const std::string _iss = "lool";
+    const std::string _iss = "cool";
     const std::string _name;
     const std::string _sub;
     const std::string _aud;

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -513,7 +513,7 @@ bool ClientSession::_handleInput(const char *buffer, int length)
             }
         }
 
-        // Send LOOL version information
+        // Send COOL version information
         sendTextFrame("loolserver " + Util::getVersionJSON());
         // Send LOKit version information
         sendTextFrame("lokitversion " + LOOLWSD::LOKitVersion);

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -219,7 +219,7 @@ std::string ClientSession::getClipboardURI(bool encode)
     Poco::URI::encode(wopiSrc.toString(), encodeChars, encodedFrom);
 
     std::string meta = _serverURL.getSubURLForEndpoint(
-        "/lool/clipboard?WOPISrc=" + encodedFrom +
+        "/cool/clipboard?WOPISrc=" + encodedFrom +
         "&ServerId=" + Util::getProcessIdentifier() +
         "&ViewId=" + std::to_string(getKitViewId()) +
         "&Tag=" + _clipboardKeys[0]);

--- a/wsd/ClientSession.hpp
+++ b/wsd/ClientSession.hpp
@@ -23,7 +23,7 @@
 
 class DocumentBroker;
 
-/// Represents a session to a LOOL client, in the WSD process.
+/// Represents a session to a COOL client, in the WSD process.
 class ClientSession final : public Session
 {
 public:

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1899,7 +1899,7 @@ std::size_t DocumentBroker::addSessionInternal(const std::shared_ptr<ClientSessi
     {
         LOG_ERR("Out of storage while loading document with URI [" << session->getPublicUri().toString() << "].");
 
-        // We use the same message as is sent when some of lool's own locations are full,
+        // We use the same message as is sent when some of cool's own locations are full,
         // even if in this case it might be a totally different location (file system, or
         // some other type of storage somewhere). This message is not sent to all clients,
         // though, just to all sessions of this document.

--- a/wsd/Exceptions.hpp
+++ b/wsd/Exceptions.hpp
@@ -13,7 +13,7 @@
 #include <exception>
 #include <stdexcept>
 
-// Generic LOOL errors and base for others.
+// Generic COOL errors and base for others.
 class LoolException : public std::runtime_error
 {
 public:

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -16,7 +16,7 @@
 #define LOOLWSD_TEST_ADMIN_CONSOLE "/browser/dist/admin/admin.html"
 
 /* Default cool UI used in for monitoring URI */
-#define LOOLWSD_TEST_METRICS "/lool/getMetrics"
+#define LOOLWSD_TEST_METRICS "/cool/getMetrics"
 
 /* Default cool UI used in the start test URI */
 #define LOOLWSD_TEST_COOL_UI "/browser/" LOOLWSD_VERSION_HASH "/debug.html"

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -1782,7 +1782,7 @@ void LOOLWSD::defineOptions(OptionSet& optionSet)
                         .required(false)
                         .repeatable(false));
 
-    optionSet.addOption(Option("disable-lool-user-checking", "", "Don't check whether loolwsd is running under the user 'lool'.  NOTE: This is insecure, use only when you know what you are doing!")
+    optionSet.addOption(Option("disable-lool-user-checking", "", "Don't check whether loolwsd is running under the user 'cool'.  NOTE: This is insecure, use only when you know what you are doing!")
                         .required(false)
                         .repeatable(false));
 
@@ -2797,7 +2797,7 @@ private:
 
             else if (!requestDetails.isWebSocket() && requestDetails.equals(RequestDetails::Field::Type, "lool"))
             {
-                // All post requests have url prefix 'lool'.
+                // All post requests have url prefix 'cool'.
                 handlePostRequest(requestDetails, request, message, disposition, socket);
             }
             else

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -30,8 +30,8 @@
 /* Default ciphers used, when not specified otherwise */
 #define DEFAULT_CIPHER_SET "ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH"
 
-// This is the main source for the loolwsd program. LOOL uses several loolwsd processes: one main
-// parent process that listens on the TCP port and accepts connections from LOOL clients, and a
+// This is the main source for the loolwsd program. COOL uses several loolwsd processes: one main
+// parent process that listens on the TCP port and accepts connections from COOL clients, and a
 // number of child processes, each which handles a viewing (editing) session for one document.
 
 #include <unistd.h>
@@ -999,7 +999,7 @@ void LOOLWSD::innerInitialize(Application& self)
 #if !MOBILEAPP
     if (geteuid() == 0 && CheckLoolUser)
     {
-        throw std::runtime_error("Do not run as root. Please run as lool user.");
+        throw std::runtime_error("Do not run as root. Please run as cool user.");
     }
 #endif
 

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -2708,7 +2708,7 @@ private:
                 FileServerRequestHandler::handleRequest(request, requestDetails, message, socket);
                 socket->shutdown();
             }
-            else if (requestDetails.equals(RequestDetails::Field::Type, "lool") &&
+            else if (requestDetails.equals(RequestDetails::Field::Type, "cool") &&
                      requestDetails.equals(1, "adminws"))
             {
                 // Admin connections
@@ -2721,7 +2721,7 @@ private:
                         });
                 }
             }
-            else if (requestDetails.equals(RequestDetails::Field::Type, "lool") &&
+            else if (requestDetails.equals(RequestDetails::Field::Type, "cool") &&
                      requestDetails.equals(1, "getMetrics"))
             {
                 // See metrics.txt
@@ -2781,7 +2781,7 @@ private:
             else if (requestDetails.isGet("/robots.txt"))
                 handleRobotsTxtRequest(request, socket);
 
-            else if (requestDetails.equals(RequestDetails::Field::Type, "lool") &&
+            else if (requestDetails.equals(RequestDetails::Field::Type, "cool") &&
                      requestDetails.equals(1, "clipboard"))
             {
 //              Util::dumpHex(std::cerr, socket->getInBuffer(), "clipboard:\n"); // lots of data ...
@@ -2791,11 +2791,11 @@ private:
             else if (requestDetails.isProxy() && requestDetails.equals(2, "ws"))
                 handleClientProxyRequest(request, requestDetails, message, disposition);
 
-            else if (requestDetails.equals(RequestDetails::Field::Type, "lool") &&
+            else if (requestDetails.equals(RequestDetails::Field::Type, "cool") &&
                      requestDetails.equals(2, "ws") && requestDetails.isWebSocket())
                 handleClientWsUpgrade(request, requestDetails, disposition, socket);
 
-            else if (!requestDetails.isWebSocket() && requestDetails.equals(RequestDetails::Field::Type, "lool"))
+            else if (!requestDetails.isWebSocket() && requestDetails.equals(RequestDetails::Field::Type, "cool"))
             {
                 // All post requests have url prefix 'cool'.
                 handlePostRequest(requestDetails, request, message, disposition, socket);

--- a/wsd/ProxyProtocol.cpp
+++ b/wsd/ProxyProtocol.cpp
@@ -9,7 +9,7 @@
  * The ProxyProtocol creates a web-socket like connection over HTTP
  * requests. URLs are formed like this:
  *      0              1           2      3          4         5
- *   /lool/<encoded-document-url>/ws/<session-id>/<command>/<serial>
+ *   /cool/<encoded-document-url>/ws/<session-id>/<command>/<serial>
  * <session-id> can be 'unknown'
  * <command> can be 'open', 'write', 'wait', or 'close'
  */

--- a/wsd/QuarantineUtil.cpp
+++ b/wsd/QuarantineUtil.cpp
@@ -133,7 +133,7 @@ namespace Quarantine
         const auto timeNow = std::chrono::system_clock::now();
         const std::string ts = std::to_string(std::chrono::duration_cast<std::chrono::seconds>(timeNow.time_since_epoch()).count());
 
-        std::string sourcefilePath = LOOLWSD::ChildRoot + "tmp/lool-" + docBroker->getJailId() + "/user/docs/" + docBroker->getJailId() + "/" + docName;
+        std::string sourcefilePath = LOOLWSD::ChildRoot + "tmp/cool-" + docBroker->getJailId() + "/user/docs/" + docBroker->getJailId() + "/" + docName;
 
         std::string linkedFileName = ts + "_" + std::to_string(docBroker->getPid()) + "_" + docKey;
         std::string linkedFilePath = LOOLWSD::QuarantinePath + linkedFileName;

--- a/wsd/README
+++ b/wsd/README
@@ -121,7 +121,7 @@ flag, the parent directory of loolwsd/ is assumed to be the
 file_server_root_path. So, for development purposes, you can access the
 COOL files (using /browser/), but it is advised to explicitly set
 the file_server_root_path to prevent any unwanted files from reading,
-especially when lool is deployed for normal public usage on servers.
+especially when cool is deployed for normal public usage on servers.
 
 Please note that it is necessary that all the COOL files that are
 meant to be served is under a directory named 'browser'. Since, the

--- a/wsd/RequestDetails.cpp
+++ b/wsd/RequestDetails.cpp
@@ -171,7 +171,7 @@ void RequestDetails::processURI()
     std::string uriRes = _uriString.substr(posDocUri + 1);
 
     const auto posLastWS = uriRes.rfind("/ws");
-    // DocumentURI is the second segment in lool URIs.
+    // DocumentURI is the second segment in cool URIs.
     if (_pathSegs.equals(0, "lool"))
     {
         //FIXME: For historic reasons the DocumentURI includes the WOPISrc.

--- a/wsd/RequestDetails.cpp
+++ b/wsd/RequestDetails.cpp
@@ -107,7 +107,7 @@ RequestDetails::RequestDetails(const std::string &mobileURI)
 
 void RequestDetails::dehexify()
 {
-    // For now, we only hexify lool/ URLs.
+    // For now, we only hexify cool/ URLs.
     constexpr auto Prefix = "lool/0x";
     constexpr auto PrefixLen = sizeof(Prefix) - 1;
 
@@ -189,7 +189,7 @@ void RequestDetails::processURI()
         {
             end = (posLastWS != std::string::npos ? posLastWS : uriRes.find('/'));
             if (end == std::string::npos)
-                end = uriRes.find('?'); // e.g. /lool/clipboard?WOPISrc=file%3A%2F%2F%2Ftmp%2Fcopypasteef324307_empty.ods...
+                end = uriRes.find('?'); // e.g. /cool/clipboard?WOPISrc=file%3A%2F%2F%2Ftmp%2Fcopypasteef324307_empty.ods...
         }
 
         const std::string docUri = uriRes.substr(0, end);

--- a/wsd/RequestDetails.cpp
+++ b/wsd/RequestDetails.cpp
@@ -108,7 +108,7 @@ RequestDetails::RequestDetails(const std::string &mobileURI)
 void RequestDetails::dehexify()
 {
     // For now, we only hexify cool/ URLs.
-    constexpr auto Prefix = "lool/0x";
+    constexpr auto Prefix = "cool/0x";
     constexpr auto PrefixLen = sizeof(Prefix) - 1;
 
     const auto hexPos = _uriString.find(Prefix);

--- a/wsd/RequestDetails.cpp
+++ b/wsd/RequestDetails.cpp
@@ -172,7 +172,7 @@ void RequestDetails::processURI()
 
     const auto posLastWS = uriRes.rfind("/ws");
     // DocumentURI is the second segment in cool URIs.
-    if (_pathSegs.equals(0, "lool"))
+    if (_pathSegs.equals(0, "cool"))
     {
         //FIXME: For historic reasons the DocumentURI includes the WOPISrc.
         // This is problematic because decoding a URI that embedds not one, but

--- a/wsd/RequestDetails.hpp
+++ b/wsd/RequestDetails.hpp
@@ -42,14 +42,14 @@
  * lool URI: used to load the document.
  * Origin: cool.html
  * Format:
- *  /lool/<encoded-document-URI+options>/ws?WOPISrc=<encoded-document-URI>&compat=/ws[/<sessionId>/<command>/<serial>]
- * Identifier: /lool/.
+ *  /cool/<encoded-document-URI+options>/ws?WOPISrc=<encoded-document-URI>&compat=/ws[/<sessionId>/<command>/<serial>]
+ * Identifier: /cool/.
  *
  * The 'document-URI' is the original URL in the client that is used to load the document page.
  * The optional section at the end, in square-brackets, is for richproxy.
  *
  * Example:
- *  /lool/http%3A%2F%2Flocalhost%2Fowncloud%2Findex.php%2Fapps%2Frichdocuments%2Fwopi%2Ffiles%2F165_ocgdpzbkm39u%3F
+ *  /cool/http%3A%2F%2Flocalhost%2Fowncloud%2Findex.php%2Fapps%2Frichdocuments%2Fwopi%2Ffiles%2F165_ocgdpzbkm39u%3F
  *  access_token%3DODhIXdJdbsVYQoKKCuaYofyzrovxD3MQ%26access_token_ttl%3D0/ws?
  *  WOPISrc=http%3A%2F%2Flocalhost%2Fowncloud%2Findex.php%2Fapps%2Frichdocuments%2Fwopi%2F
  *  files%2F165_ocgdpzbkm39u&compat=/ws/1c99a7bcdbf3209782d7eb38512e6564/write/2
@@ -81,13 +81,13 @@
  * The different sections are henceforth given names to help both in documenting and
  * communicating them, and to facilitate parsing them.
  *
- * /lool/<encoded-document-URI+options>/ws?WOPISrc=<encoded-document-URI>&compat=/ws[/<sessionId>/<command>/<serial>]
+ * /cool/<encoded-document-URI+options>/ws?WOPISrc=<encoded-document-URI>&compat=/ws[/<sessionId>/<command>/<serial>]
  *       |--------documentURI---------|            |-------WOPISrc------|        |--------------compat--------------|
  *                            |options|                                               |sessionId| |command| |serial|
  *       |---------------------------LegacyDocumentURI---------------------------|
  *
  * Alternatively, the LegacyDocumentURI (encoded) could be hexified, as follows:
- * /lool/0x123456789/ws?WOPISrc=<encoded-document-URI>&compat=/ws[/<sessionId>/<command>/<serial>]
+ * /cool/0x123456789/ws?WOPISrc=<encoded-document-URI>&compat=/ws[/<sessionId>/<command>/<serial>]
  */
 class RequestDetails
 {
@@ -141,7 +141,7 @@ public:
     static std::string getDocKey(const std::string& uri) { return getDocKey(sanitizeURI(uri)); }
 
     // matches the WOPISrc if used. For load balancing
-    // must be 2nd element in the path after /lool/<here>
+    // must be 2nd element in the path after /cool/<here>
     std::string getLegacyDocumentURI() const { return getField(Field::LegacyDocumentURI); }
 
     /// The DocumentURI, decoded. Doesn't contain WOPISrc or any other appendages.

--- a/wsd/RequestDetails.hpp
+++ b/wsd/RequestDetails.hpp
@@ -39,7 +39,7 @@
  *  /browser/49c225146/src/map/Clipboard.js
  *  /browser/49c225146/cool.html?WOPISrc=http%3A%2F%2Flocalhost%2Fnextcloud%2Findex.php%2Fapps%2Frichdocuments%2Fwopi%2Ffiles%2F593_ocqiesh0cngs&title=empty.odt&lang=en-us&closebutton=1&revisionhistory=1
  *
- * lool URI: used to load the document.
+ * cool URI: used to load the document.
  * Origin: cool.html
  * Format:
  *  /cool/<encoded-document-URI+options>/ws?WOPISrc=<encoded-document-URI>&compat=/ws[/<sessionId>/<command>/<serial>]

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -549,7 +549,7 @@ void LockContext::initSupportsLocks()
 
     // first time token setup
     _supportsLocks = true;
-    _lockToken = "lool-lock" + Util::rng::getHexString(8);
+    _lockToken = "cool-lock" + Util::rng::getHexString(8);
 #endif
 }
 

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -197,7 +197,7 @@ public:
                 const std::string& jailPath) :
         _localStorePath(localStorePath),
         _jailPath(jailPath),
-        _fileInfo("", "lool", std::chrono::system_clock::time_point(), 0),
+        _fileInfo("", "cool", std::chrono::system_clock::time_point(), 0),
         _isDownloaded(false),
         _forceSave(false),
         _isUserModified(false),


### PR DESCRIPTION
- wsd: rename comments 'lool' -> 'cool'
- wsd: rename 'lool' -> 'cool'
- tools: rename 'lool' -> 'cool'
- test: rename 'lool' -> 'cool'
- misc: config: rename 'lool' -> 'cool'
- distro: rename 'lool' -> 'cool'
- browser: rename 'lool' -> 'cool'
- indexing: rename 'lool' -> 'cool'
- distro: more renames 'lool' -> 'cool'
- wsd: more comments rename 'lool' -> 'cool'
- misc: more renames 'lool' -> 'cool'
- misc: more renames 'lool' -> 'cool'
- misc: more renames 'lool' -> 'cool'
- wsd: rename 'lool' -> 'cool'
- mobile: rename 'lool' -> 'cool'
- kit: rename 'lool' -> 'cool'
- config: rename 'lool' -> 'cool'
