### PR TITLE
CSS: Remove typo (partly revert)

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -841,7 +841,6 @@ nav.drawing-color-indicator ~ #main-document-content .cool-annotation-reply-coun
 	align-items: center;
 	justify-content: right;
 	flex-grow: 1;
-	background-image: url('images/toolbar-bg-logo.svg');
 	background-repeat: no-repeat;
 	background-size: 82px;
 	background-position: right center;


### PR DESCRIPTION
Remove bg image of a nonexistent asset introduced in
ba9feca725c357ab8a48de430263e10c78834821

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I485afc3ff22a16d7bb212cb55ba8636fbfeea5a3
