### PR TITLE
loolmount: Mimic the Linux behavior of umount2() on FreeBSD.

### DIFF
--- a/tools/mount.cpp
+++ b/tools/mount.cpp
@@ -100,6 +100,25 @@ int mount_wrapper(const char *source, const char *target,
 
 int umount2(const char *target, int flags)
 {
+    struct statfs* mntbufs;
+    int numInfos = getmntinfo(&mntbufs, MNT_WAIT);
+    bool targetMounted = false;
+
+    for (int i = 0; i < numInfos; i++)
+    {
+        if (!strcmp(target, mntbufs[i].f_mntonname))
+        {
+            targetMounted = true;
+            break;
+        }
+    }
+
+    if (!targetMounted)
+    {
+        errno = EINVAL;
+        return -1;
+    }
+
     if(flags == MNT_DETACH)
         flags = 0;
 


### PR DESCRIPTION
On FreeBSD the mounting operations are allowed to be performed only by root
by default. When `loolwsd --cleanup` is called during normal compilation process,
it tries to unmount "jails" directory and spits EPERM-related errors.

Fix this by checking if the directory being unmounted is actually mounted and
return EINVAL in this case, just like Linux unmount2() does.

Signed-off-by: Gleb Popov <6yearold@gmail.com>
Change-Id: I0f72d265e33fb1e6129332bfa8e17e7d888d30b5

### Checklist

- [X] Code is properly formatted
- [X] All commits have Change-Id
- [X] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

