### PR TITLE
jsdialog: fixes#3615 keep focus in the updated input

### DIFF
--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -271,6 +271,9 @@ L.Control.JSDialog = L.Control.extend({
 			return;
 
 		var scrollTop = control.scrollTop;
+		var focusedElement = document.activeElement;
+		var focusedElementInDialog = focusedElement ? dialog.querySelector('[id=\'' + focusedElement.id + '\']') : null;
+		var focusedId = focusedElementInDialog ? focusedElementInDialog.id : null;
 
 		control.style.visibility = 'hidden';
 		var builder = new L.control.jsDialogBuilder({windowId: data.id,
@@ -286,6 +289,9 @@ L.Control.JSDialog = L.Control.extend({
 		var newControl = dialog.querySelector('[id=\'' + data.control.id + '\']');
 		if (newControl)
 			newControl.scrollTop = scrollTop;
+
+		if (focusedId)
+			dialog.querySelector('[id=\'' + focusedId + '\']').focus();
 	},
 
 	onJSAction: function (e) {

--- a/browser/src/control/Control.Sidebar.js
+++ b/browser/src/control/Control.Sidebar.js
@@ -69,6 +69,9 @@ L.Control.Sidebar = L.Control.extend({
 			return;
 
 		var scrollTop = control.scrollTop;
+		var focusedElement = document.activeElement;
+		var focusedElementInDialog = focusedElement ? this.container.querySelector('[id=\'' + focusedElement.id + '\']') : null;
+		var focusedId = focusedElementInDialog ? focusedElementInDialog.id : null;
 		control.style.visibility = 'hidden';
 
 		var temporaryParent = L.DomUtil.create('div');
@@ -79,6 +82,9 @@ L.Control.Sidebar = L.Control.extend({
 		var newControl = this.container.querySelector('[id=\'' + data.control.id + '\']');
 		if (newControl)
 			newControl.scrollTop = scrollTop;
+
+		if (focusedId)
+			this.container.querySelector('[id=\'' + focusedId + '\']').focus();
 	},
 
 	onJSAction: function (e) {


### PR DESCRIPTION
When widget is updated and rrecreated - keep focus in the same space.