### PR TITLE
comments: remember 'show resolved comments' state

### DIFF
--- a/loleaflet/src/control/Control.UIManager.js
+++ b/loleaflet/src/control/Control.UIManager.js
@@ -171,6 +171,10 @@ L.Control.UIManager = L.Control.extend({
 				var interactiveRuler = this.map.isPermissionEdit();
 				L.control.ruler({position:'topleft', interactive:interactiveRuler, showruler: showRuler}).addTo(this.map);
 			}
+
+			var showResolved = this.getSavedStateOrDefault('ShowResolved');
+			if (showResolved === false || showResolved === 'false')
+				this.map.sendUnoCommand('.uno:ShowResolvedAnnotations');
 		}
 
 		if (this.map.isPresentationOrDrawing() && (isDesktop || window.mode.isTablet())) {

--- a/loleaflet/src/control/Toolbar.js
+++ b/loleaflet/src/control/Toolbar.js
@@ -327,7 +327,8 @@ L.Map.include({
 
 		var isAllowedInReadOnly = false;
 		var allowedCommands = ['.uno:Save', '.uno:WordCountDialog', '.uno:EditAnnotation',
-			'.uno:InsertAnnotation', '.uno:DeleteAnnotation', '.uno:Signature'];
+			'.uno:InsertAnnotation', '.uno:DeleteAnnotation', '.uno:Signature',
+			'.uno:ShowResolvedAnnotations'];
 
 		for (var i in allowedCommands) {
 			if (allowedCommands[i] === command) {

--- a/loleaflet/src/layer/tile/CommentListSection.ts
+++ b/loleaflet/src/layer/tile/CommentListSection.ts
@@ -22,6 +22,7 @@ L.Map.include({
 		var unoCommand = '.uno:ShowResolvedAnnotations';
 		this.sendUnoCommand(unoCommand);
 		app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).setViewResolved(on);
+		this.uiManager.setSavedState('ShowResolved', on ? true : false);
 	}
 });
 


### PR DESCRIPTION
When we reopen document, 'show resolved comments' option state will be remembered.