### PR TITLE
Extract file_path from debug.html and pass other query parameters

### DIFF
--- a/browser/html/debug.html
+++ b/browser/html/debug.html
@@ -24,8 +24,11 @@
         function constructWopiUrl() {
             var wopiUrl = window.location.protocol + "//" + window.location.host + window.location.pathname + "?";
             wopiUrl = wopiUrl.replace("debug.html", "cool.html");
-            var wopiSrc = window.location.protocol + "//" + window.location.host + "/wopi/files/" + encodeURIComponent(window.location.search.substring(window.location.search.indexOf("=")+2));
-            wopiUrl = wopiUrl + "WOPISrc=" + wopiSrc;
+            var params = new URLSearchParams(window.location.search);
+            var filePath = params.get('file_path').substr(1);
+            params.delete('file_path');
+            var wopiSrc = window.location.protocol + "//" + window.location.host + "/wopi/files/" + encodeURIComponent(filePath);
+            wopiUrl = wopiUrl + "WOPISrc=" + wopiSrc + '&' + params.toString();
             return wopiUrl
         }
        var form = document.getElementById("form");


### PR DESCRIPTION
Signed-off-by: Julius Härtl <jus@bitgrid.net>
Change-Id: I48d22e08f1f312033d49d315489f2404e48e4dd7

### Summary

Make it a bit easier to test certain parameters by passing them to the actual frame and extracting just the file path search query parameter in debug.html

This will make appending `&ui_defaults=UIMode=notebookbar` to the existing debug.html url work again as it used before the rename:

`https://localhost:9980/browser/05638f9c2/debug.html?file_path=/home/jus/repos/collaboraonline/online/test/data/hello-world.ods&ui_defaults=UIMode=notebookbar`



### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

