### PR TITLE
Fixes #3647 : hyperlink dialog closed when window gets focus

### DIFF
--- a/loleaflet/src/control/Toolbar.js
+++ b/loleaflet/src/control/Toolbar.js
@@ -853,6 +853,7 @@ L.Map.include({
 		vex.dialog.open({
 			contentClassName: 'hyperlink-dialog',
 			message: _('Insert hyperlink'),
+			overlayClosesOnClick: false,
 			input: [
 				_('Text') + '<input name="text" id="hyperlink-text-box" type="text" value="' + text + '"/>',
 				_('Link') + '<input name="link" id="hyperlink-link-box" type="text" value="' + link + '"/>'


### PR DESCRIPTION
Insert hyperlink dialog was closed when we tried to copy link from
other window (after we losed focus and then focused Collabora Online
again).
