### PR TITLE
Move avatar list to the header

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -394,6 +394,10 @@ nav.spreadsheet-color-indicator ~ #sidebar-dock-wrapper {
 	top: -6px;
 }
 
+#main-document-content {
+	z-index: 0;
+}
+
 nav.text-color-indicator ~ #main-document-content .cool-annotation-reply-count-collapsed {
 	background: rgb(var(--blue1-txt-primary-color));
 }

--- a/browser/css/menubar.css
+++ b/browser/css/menubar.css
@@ -25,7 +25,7 @@
 }
 .document-logo {
 	position: relative;
-	width: 22px;
+	width: 30px;
 	height: 30px;
 }
 
@@ -42,14 +42,11 @@
 }
 
 #document-titlebar {
-	position: relative;
 	display: inline-table; /*new*/
 	table-layout: fixed;
 	border-spacing: 5px 0;
 	max-height: 39px;
-	z-index: 1000;
-	width: calc(100% - 890px);
-	right: 0px;
+	flex-grow: 1;
 }
 
 .readonly #document-titlebar {
@@ -72,6 +69,7 @@
 	padding: 3px 3px 3px 0;
 	white-space: nowrap;
 	z-index: 12;
+	display: flex;
 }
 .main-nav.readonly {
 	position: relative;

--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -203,10 +203,8 @@
 /* options section */
 .notebookbar-options-section {
 	display: inline;
-	position: fixed;
 	height: 32px;
-	right: 0px;
-	z-index: 1000;
+	padding: 2px;
 }
 
 /* root container */

--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -22,7 +22,6 @@
 }
 #toolbar-down *{
 	font-family: var(--cool-font);
-	max-height: 35px !important;
 }
 #tb_actionbar_item_LanguageStatus table table td:first-of-type{
 	min-width: max-content !important;
@@ -318,7 +317,7 @@ td[id^='tb_editbar_item_sidebar']{
 }
 
 .main-nav:not(.hasnotebookbar) ~ #closebuttonwrapper #closebutton {
-	background: url('images/closedoc.svg') no-repeat center/24px !important;
+	background: url('images/closedoc.svg') no-repeat center/35px !important;
 }
 
 #closebutton:hover {
@@ -1047,4 +1046,132 @@ tr.useritem > td > img {
 menu-entry-with-icon.padding-left + menu-entry-icon.width */
 .menu-entry-no-icon {
 	padding-left: 42px;
+}
+
+#userListHeader {
+	position: fixed;
+	z-index: 1050;
+	height: 38px;
+	background-color: transparent;
+	display: flex !important;
+	right: 80px;
+	top: 5px;
+	align-items: center;
+}
+
+#userListSummary {
+	display: flex;
+}
+#userListPopover {
+	display: none;
+	position: absolute;
+	padding: 12px 16px;
+	z-index: 1;
+	top: 40px;
+	left: -140px;
+	color: #222;
+	background-color: #fff;
+	border-radius: 3px;
+	filter: drop-shadow(0 1px 3px rgba(77, 77, 77, 0.5));
+	min-width: 150px;
+	font-size: 15px;
+}
+
+#userListHeader:hover #userListPopover {
+	display: block;
+}
+
+.document-title {
+	justify-content: space-between;
+}
+
+#user-avt {
+	width: 35px;
+	height: 35px;
+	border-radius: 100%;
+}
+
+#userListPopover::after {
+	border: 10px solid transparent;
+	border-bottom-color: var(--color-main-background);
+	bottom: 100%;
+	content: ' ';
+	height: 0;
+	width: 0;
+	position: absolute;
+	pointer-events: none;
+	color: #f9f9f9;
+	right: 16px;
+}
+
+.user-item-wrapper {
+	display: flex;
+	justify-content: flex-start;
+	align-items: center;
+	font-family: var(--loleaflet-font);
+	height: 32px;
+	padding: 6px 12px;
+	cursor: pointer;
+}
+
+.user-item {
+	background-position: center;
+	background-size: cover;
+	background-repeat: no-repeat;
+	border-width: 2px;
+	border-style: solid;
+	width: 25px;
+	height: 25px;
+	border-radius: 100%;
+	margin-right: 5px;
+}
+
+.user-top {
+	width: 32px;
+	height: 32px;
+	background-color: white;
+	border-radius: 100%;
+	margin-right: -10px;
+	background-size: cover;
+	background-repeat: no-repeat;
+	border-style: solid;
+	border-width: 2px;
+}
+
+.follow-editor-checkbox {
+	margin-right: 16px;
+	margin-left: 7px;
+	border-radius: 1px;
+	height: 16px;
+	width: 16px;
+	box-shadow: none !important;
+	background-position: center;
+}
+
+#follow-editor {
+	cursor: pointer;
+	font-family: var(--loleaflet-font);
+	padding: 6px 8px;
+}
+
+.follow-editor-label::before {
+	border-radius: 1px;
+	height: 14px;
+	width: 14px;
+	box-shadow: none !important;
+	background-position: center;
+	content: ' ';
+	border: 1px solid #878787;
+}
+
+@media only screen and (max-width: 600px) {
+	#userListSummary,
+	#userListHeader
+	{
+		display: none;
+	}
+}
+
+#w2ui-overlay-actionbar {
+	top: 270px;
 }

--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -1056,38 +1056,45 @@ menu-entry-with-icon.padding-left + menu-entry-icon.width */
 	font-family: var(--cool-font);
 	padding-right: 12px;
 	margin-right: 10px;
+	margin-left: 10px;
 	font-size: 12px;
+}
+
+#userListHeader .user-info,
+#userListHeader .avatar-img {
+	width: 24px;
+	height: 24px;
+	background-color: white;
+	background-position: center;
+	background-size: cover;
+	background-repeat: no-repeat;
+	border-style: solid;
+	border-width: 2px;
+	border-radius: 100%;
+	margin-right: 5px;
 }
 
 #userListSummary {
 	display: flex;
 }
+
+#userListSummary .user-info,
+#userListSummary .avatar-img {
+	margin-left: -10px;
+}
+
 #userListPopover {
 	display: none;
 	position: absolute;
 	z-index: 1;
 	top: 38px;
-	right: -10px;
+	right: 5px;
 	color: #222;
 	background-color: #fff;
 	border-radius: 3px;
-	filter: drop-shadow(0 1px 3px rgba(77, 77, 77, 0.5));
+	filter: drop-shadow(0 1px 3px rgba(87, 54, 54, 0.5));
 	min-width: 150px;
-	font-size: 15px;
-}
-
-#userListHeader:hover #userListPopover {
-	display: block;
-}
-
-.document-title {
-	justify-content: space-between;
-}
-
-#user-avt {
-	width: 35px;
-	height: 35px;
-	border-radius: 100%;
+	font-size: 12px;
 }
 
 #userListPopover::after {
@@ -1103,63 +1110,34 @@ menu-entry-with-icon.padding-left + menu-entry-icon.width */
 	right: 16px;
 }
 
-.user-item-wrapper {
+#userListPopover .user-list-item {
 	display: flex;
-	justify-content: flex-start;
-	align-items: center;
-	font-family: var(--cool-font);
-	height: 32px;
-	padding: 6px 12px;
-	cursor: pointer;
+	max-width: 100%;
+	padding: 4px 8px;
 }
 
-.user-item {
-	background-position: center;
-	background-size: cover;
-	background-repeat: no-repeat;
-	border-width: 2px;
-	border-style: solid;
-	width: 25px;
-	height: 25px;
-	border-radius: 100%;
-	margin-right: 5px;
+#userListPopover .user-list-item--name {
+	display: flex;
+	flex-grow: 1;
+	padding: 8px;
 }
 
-.user-top {
-	width: 24px;
-	height: 24px;
-	background-color: white;
-	border-radius: 100%;
-	margin-right: -10px;
-	background-size: cover;
-	background-repeat: no-repeat;
-	border-style: solid;
-	border-width: 2px;
+#userListPopover .user-list-item.selected-user {
+	background-color: var(--gray-lighter-bg-color);
 }
 
-.follow-editor-checkbox {
-	margin-right: 16px;
+#userListPopover #follow-editor {
+	padding: 6px 4px;
+}
+
+#userListPopover #follow-editor .follow-editor-checkbox {
+	margin-right: 12px;
 	margin-left: 7px;
 	border-radius: 1px;
 	height: 16px;
 	width: 16px;
 	box-shadow: none !important;
 	background-position: center;
-}
-
-#follow-editor {
-	cursor: pointer;
-	padding: 6px 8px;
-}
-
-.follow-editor-label::before {
-	border-radius: 1px;
-	height: 14px;
-	width: 14px;
-	box-shadow: none !important;
-	background-position: center;
-	content: ' ';
-	border: 1px solid #878787;
 }
 
 @media only screen and (max-width: 600px) {

--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -1049,14 +1049,14 @@ menu-entry-with-icon.padding-left + menu-entry-icon.width */
 }
 
 #userListHeader {
-	position: fixed;
-	z-index: 1050;
-	height: 38px;
+	position: relative;
 	background-color: transparent;
 	display: flex !important;
-	right: 80px;
-	top: 5px;
 	align-items: center;
+	font-family: var(--cool-font);
+	padding-right: 12px;
+	margin-right: 10px;
+	font-size: 12px;
 }
 
 #userListSummary {
@@ -1065,10 +1065,9 @@ menu-entry-with-icon.padding-left + menu-entry-icon.width */
 #userListPopover {
 	display: none;
 	position: absolute;
-	padding: 12px 16px;
 	z-index: 1;
-	top: 40px;
-	left: -140px;
+	top: 38px;
+	right: -10px;
 	color: #222;
 	background-color: #fff;
 	border-radius: 3px;
@@ -1108,7 +1107,7 @@ menu-entry-with-icon.padding-left + menu-entry-icon.width */
 	display: flex;
 	justify-content: flex-start;
 	align-items: center;
-	font-family: var(--loleaflet-font);
+	font-family: var(--cool-font);
 	height: 32px;
 	padding: 6px 12px;
 	cursor: pointer;
@@ -1127,8 +1126,8 @@ menu-entry-with-icon.padding-left + menu-entry-icon.width */
 }
 
 .user-top {
-	width: 32px;
-	height: 32px;
+	width: 24px;
+	height: 24px;
 	background-color: white;
 	border-radius: 100%;
 	margin-right: -10px;
@@ -1150,7 +1149,6 @@ menu-entry-with-icon.padding-left + menu-entry-icon.width */
 
 #follow-editor {
 	cursor: pointer;
-	font-family: var(--loleaflet-font);
 	padding: 6px 8px;
 }
 

--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -302,14 +302,9 @@ td[id^='tb_editbar_item_sidebar']{
 }
 
 #closebuttonwrapper {
-	position: fixed;
-	z-index: 1050;
-	right: 4px;
-	top: 0px;
-	width: 32px;
+	width: 37px;
 	height: 32px;
 	background-color: transparent;
-	display: none;
 }
 
 .main-nav:not(.hasnotebookbar) ~ #closebuttonwrapper {

--- a/browser/html/cool.html.m4
+++ b/browser/html/cool.html.m4
@@ -178,6 +178,11 @@ m4_ifelse(MOBILEAPP,[true],
         </div>
       </div>
 
+      <div id="userListHeader">
+        <div id="userListSummary"></div>
+        <div id="userListPopover"></div>
+      </div>
+
       <div id="closebuttonwrapper">
         <div class="closebuttonimage" id="closebutton"></div>
       </div>

--- a/browser/html/cool.html.m4
+++ b/browser/html/cool.html.m4
@@ -166,17 +166,21 @@ m4_ifelse(MOBILEAPP,[true],
         and width, this being inside the smaller "document-container" will
         cause the content to overflow, creating scrollbars -->
 
-     <nav class="main-nav" role="navigation">
-       <!-- Mobile menu toggle button (hamburger/x icon) -->
-       <input id="main-menu-state" type="checkbox" style="display: none"/>
-       <ul id="main-menu" class="sm sm-simple lo-menu readonly"></ul>
-       <div id="document-titlebar">
-         <div class="document-title">
-           <!-- visuallyhidden: hide it visually but keep it available to screen reader and other assistive technology -->
-           <label class="visuallyhidden" for="document-name-input" aria-hidden="false">Document name</label>
-           <input id="document-name-input" type="text" disabled="true" style="display: none"/>
-         </div>
-       </div>
+    <nav class="main-nav" role="navigation">
+      <!-- Mobile menu toggle button (hamburger/x icon) -->
+      <input id="main-menu-state" type="checkbox" style="display: none"/>
+      <ul id="main-menu" class="sm sm-simple lo-menu readonly"></ul>
+      <div id="document-titlebar">
+        <div class="document-title">
+          <!-- visuallyhidden: hide it visually but keep it available to screen reader and other assistive technology -->
+          <label class="visuallyhidden" for="document-name-input" aria-hidden="false">Document name</label>
+          <input id="document-name-input" type="text" disabled="true" style="display: none"/>
+        </div>
+      </div>
+
+      <div id="closebuttonwrapper">
+        <div class="closebuttonimage" id="closebutton"></div>
+      </div>
      </nav>
 
      <table id="toolbar-wrapper">
@@ -201,10 +205,6 @@ m4_ifelse(MOBILEAPP,[true],
 
     <input id="insertgraphic" aria-labelledby="menu-insertgraphic" type="file" accept="image/*" style="position: fixed; top: -100em">
     <input id="selectbackground" aria-labelledby="menu-selectbackground" type="file" accept="image/*" style="position: fixed; top: -100em">
-
-    <div id="closebuttonwrapper">
-      <div class="closebuttonimage" id="closebutton"></div>
-    </div>
 
     <div id="main-document-content" style="display:flex; flex-direction: row; flex: 1; margin: 0; padding: 0; min-height: 0">
       <div id="presentation-controls-wrapper" class="readonly">

--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -467,10 +467,7 @@ L.Control.Notebookbar = L.Control.extend({
 		$('.notebookbar-options-section').remove();
 
 		var optionsSection = L.DomUtil.create('div', 'notebookbar-options-section');
-		$('#document-titlebar').parent().append(optionsSection);
-
-		if (L.Params.closeButtonEnabled)
-			$(optionsSection).css('right', '30px');
+		$(optionsSection).insertBefore('#closebuttonwrapper');
 
 		var builderOptions = {
 			mobileWizard: this,

--- a/browser/src/control/Control.UserList.js
+++ b/browser/src/control/Control.UserList.js
@@ -120,7 +120,20 @@ L.Control.UserList = L.Control.extend({
 		});
 	},
 
+	hideUserList: function() {
+		return window.ThisIsAMobileApp ||
+		(this.map['wopi'].HideUserList !== null && this.map['wopi'].HideUserList !== undefined &&
+			($.inArray('true', this.map['wopi'].HideUserList) >= 0) ||
+			(window.mode.isMobile() && $.inArray('mobile', this.map['wopi'].HideUserList) >= 0) ||
+			(window.mode.isTablet() && $.inArray('tablet', this.map['wopi'].HideUserList) >= 0) ||
+			(window.mode.isDesktop() && $.inArray('desktop', this.map['wopi'].HideUserList) >= 0));
+	},
+
 	renderHeaderAvatars: function() {
+		if (!window.mode.isDesktop() || this.hideUserList() || this.options.listUser.length === 1) {
+			return;
+		}
+
 		var that = this;
 
 		// Summary rendering
@@ -203,15 +216,7 @@ L.Control.UserList = L.Control.extend({
 
 		w2ui['actionbar'].refresh();
 
-		var hideUserList =
-			window.ThisIsAMobileApp ||
-			(this.map['wopi'].HideUserList !== null && this.map['wopi'].HideUserList !== undefined &&
-				($.inArray('true', this.map['wopi'].HideUserList) >= 0) ||
-				(window.mode.isMobile() && $.inArray('mobile', this.map['wopi'].HideUserList) >= 0) ||
-				(window.mode.isTablet() && $.inArray('tablet', this.map['wopi'].HideUserList) >= 0) ||
-				(window.mode.isDesktop() && $.inArray('desktop', this.map['wopi'].HideUserList) >= 0));
-
-		if (!hideUserList && count > 1) {
+		if (!this.hideUserList() && count > 1 && !window.mode.isDesktop()) {
 			actionbar.show('userlist');
 			actionbar.show('userlistbreak');
 		} else {


### PR DESCRIPTION
Taken over https://github.com/CollaboraOnline/online/pull/3529 for some further adjustments as discussed with @luka-nextcloud 

### Summary

- As per discussion with @pedropintosilva the main navigation has been moved to a flex layout which makes positioning within it easier with the different elements that are part of it (main menu, last saved indicator, document title, avatarlist, closebutton)
- Avatar list implementation in the main navigation (from https://github.com/CollaboraOnline/online/pull/3529)
- Only show the new avatar list on desktop
  - It might be worth to consider to also enable it on tablet mode
- The avatars shown in the header are limited to 3

### Screenshots:

![image](https://user-images.githubusercontent.com/3404133/142468043-aabf5d92-416d-464c-8512-f97d0d1bbc62.png)
![image](https://user-images.githubusercontent.com/3404133/142467943-f78ae6b2-ec38-44d6-9b20-3918d286239b.png)
![image](https://user-images.githubusercontent.com/3404133/142468008-9fbfea08-ae29-4018-b2f8-13c4b930817f.png)



### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

