### PR TITLE
Use edit hyperlink dialog from online not core

### DIFF
--- a/browser/src/control/Control.AlertDialog.js
+++ b/browser/src/control/Control.AlertDialog.js
@@ -67,8 +67,8 @@ L.Control.AlertDialog = L.Control.extend({
 					type: 'button',
 					className: 'vex-dialog-button-secondary',
 					click: function() {
-						e.map.toggleCommandState('HyperlinkDialog');
 						vex.closeAll();
+						e.map.showHyperlinkDialog();
 					}
 				});
 


### PR DESCRIPTION
This changes commit eb387cc7b1e7d8389e138fa42372a38eea3a6148.

Edit dialog is not working, causes crashes and shows features
that doesn't work (linking to other documents in core).

Use dialog from online instead.