### PR TITLE
Hyperlink dialog: use textarea to handle line breaks

### DIFF
--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -855,7 +855,7 @@ L.Map.include({
 			message: _('Insert hyperlink'),
 			overlayClosesOnClick: false,
 			input: [
-				_('Text') + '<input name="text" id="hyperlink-text-box" type="text" value="' + text + '"/>',
+				_('Text') + '<textarea name="text" id="hyperlink-text-box" style="resize: none" type="text"></textarea>',
 				_('Link') + '<input name="link" id="hyperlink-link-box" type="text" value="' + link + '"/>'
 			].join(''),
 			buttons: [
@@ -883,11 +883,13 @@ L.Map.include({
 			},
 			afterOpen: function() {
 				setTimeout(function() {
-					if (document.getElementById('hyperlink-text-box').value.trim() !== '') {
+					var textBox = document.getElementById('hyperlink-text-box');
+					textBox.textContent = text ? text.trim() : '';
+					if (textBox.textContent.trim() !== '') {
 						document.getElementById('hyperlink-link-box').focus();
 					}
 					else {
-						document.getElementById('hyperlink-text-box').focus();
+						textBox.focus();
 					}
 				}, 0);
 			}

--- a/cypress_test/integration_tests/mobile/calc/insertion_wizard_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/insertion_wizard_spec.js
@@ -66,7 +66,7 @@ describe('Calc insertion wizard.', function() {
 			.should('exist');
 
 		// Type text and link
-		cy.get('.vex-content.hyperlink-dialog input[name="text"]')
+		cy.get('.vex-content.hyperlink-dialog textarea[name="text"]')
 			.clear()
 			.type('some text');
 		cy.get('.vex-content.hyperlink-dialog input[name="link"]')

--- a/cypress_test/integration_tests/mobile/impress/insertion_wizard_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/insertion_wizard_spec.js
@@ -156,7 +156,7 @@ describe('Impress insertion wizard.', function() {
 			.should('exist');
 
 		// Type text and link
-		cy.get('.vex-content.hyperlink-dialog input[name="text"]')
+		cy.get('.vex-content.hyperlink-dialog textarea[name="text"]')
 			.type('some text');
 		cy.get('.vex-content.hyperlink-dialog input[name="link"]')
 			.type('www.something.com');
@@ -353,7 +353,7 @@ describe('Impress insertion wizard.', function() {
 			.should('exist');
 
 		// Type text and link
-		cy.get('.vex-content.hyperlink-dialog input[name="text"]')
+		cy.get('.vex-content.hyperlink-dialog textarea[name="text"]')
 			.type('some text');
 		cy.get('.vex-content.hyperlink-dialog input[name="link"]')
 			.type('www.something.com');

--- a/cypress_test/integration_tests/mobile/writer/insert_object_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/insert_object_spec.js
@@ -279,7 +279,7 @@ describe('Insert objects via insertion wizard.', function() {
 			.should('exist');
 
 		// Type text and link
-		cy.get('.vex-content.hyperlink-dialog input[name="text"]')
+		cy.get('.vex-content.hyperlink-dialog textarea[name="text"]')
 			.type('some text');
 		cy.get('.vex-content.hyperlink-dialog input[name="link"]')
 			.type('www.something.com');


### PR DESCRIPTION
Related to:
https://github.com/CollaboraOnline/online/issues/3645

When we select text with multiple lines - line break
is ignered in the result. Paragraphs will be concatenated.
