### PR TITLE
coolconvert: fix stack-use-after-scope

### DIFF
--- a/tools/Tool.cpp
+++ b/tools/Tool.cpp
@@ -260,7 +260,7 @@ int Tool::main(const std::vector<std::string>& origArgs)
             std::vector< std::string > files( toCopy );
             std::copy( args.begin() + offset, args.begin() + offset + toCopy, files.begin() );
             offset += toCopy;
-            clients.emplace_back([this, &files]{Worker(*this, files).run();});
+            clients.emplace_back([this, files]{Worker(*this, files).run();});
         }
     }
 


### PR DESCRIPTION
The vector is allocated on the stack in a for loop, so it's not valid to
refer to its address in the lambda that is executed on a thread. Rather
copy it.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Ie1f85d6efb27a4aa44b181f8d9f134e9fa41d508
