### PR TITLE
mobile-wizard: count visible panels correctly

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -1026,11 +1026,17 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		var tabsContainer = L.DomUtil.create('div', 'ui-tabs ' + builder.options.cssClass + ' ui-widget');
 		var contentsContainer = L.DomUtil.create('div', 'ui-tabs-content ' + builder.options.cssClass + ' ui-widget', parentContainer);
 
+		for (var tabIdx = data.length - 1; tabIdx >= 0; tabIdx--) {
+			var item = data[tabIdx];
+			if (item.hidden === true)
+				data.splice(tabIdx, 1);
+		}
+
 		var tabs = [];
 		var contentDivs = [];
 		var labels = [];
-		for (var tabIdx = 0; tabIdx < data.length; tabIdx++) {
-			var item = data[tabIdx];
+		for (tabIdx = 0; tabIdx < data.length; tabIdx++) {
+			item = data[tabIdx];
 
 			var title = builder._cleanText(item.text);
 

--- a/browser/src/control/Control.MobileWizardBuilder.js
+++ b/browser/src/control/Control.MobileWizardBuilder.js
@@ -674,6 +674,16 @@ L.Control.MobileWizardBuilder = L.Control.JSDialogBuilder.extend({
 		}
 	},
 
+	_countVisiblePanels: function(panels) {
+		var count = 0;
+
+		for (var i in panels)
+			if (panels[i].type === 'panel' && (!panels[i].hidden || panels[i].hidden === false))
+				count++;
+
+		return count;
+	},
+
 	build: function(parent, data) {
 		this._modifySidebarNodes(data);
 
@@ -703,16 +713,11 @@ L.Control.MobileWizardBuilder = L.Control.JSDialogBuilder.extend({
 			}
 
 			var handler = this._controlHandlers[childType];
-			var twoPanelsAsChildren =
-					childData.children && childData.children.length == 2
-					&& childData.children[0] && childData.children[0].type == 'panel'
-					&& childData.children[1] && childData.children[1].type == 'panel';
 
-			if (childData.children && childData.children.length == 1
-				&& childData.children[0] && childData.children[0].type == 'panel') {
+			if (childData.children && this._countVisiblePanels(childData.children) == 1) {
 				handler = this._controlHandlers['singlepanel'];
 				processChildren = handler(childObject, childData.children, this);
-			} else if (twoPanelsAsChildren) {
+			} else if (childData.children && this._countVisiblePanels(childData.children) == 2) {
 				handler = this._controlHandlers['paneltabs'];
 				processChildren = handler(childObject, childData.children, this);
 			} else {


### PR DESCRIPTION
When opened mobile wizard with shape selected and then
selected some text and reopened mobile wizard - only
one panel was visible.

With new welded sidebar panels can be added to JSON but
not visible
