### PR TITLE
Fix reconnecting after rename

### DIFF
--- a/browser/src/main.js
+++ b/browser/src/main.js
@@ -44,7 +44,7 @@ var notWopiButIframe = getParameterByName('NotWOPIButIframe') != '';
 var map = L.map('map', {
 	server: host,
 	doc: docURL,
-	options: { docParams: docParams },
+	docParams: docParams,
 	permission: permission,
 	timestamp: timestamp,
 	documentContainer: 'document-container',


### PR DESCRIPTION
Regression from f92e85dacce713ff019d5360c50e74703f9c9688
Ensure that options are always initialized.

Socket.js code expects that access_token and other params
are under map.options.docParams not map.options.options.docParams.