### PR TITLE
comments: don't show bubble preview on typing above

### DIFF
--- a/browser/src/layer/tile/CommentListSection.ts
+++ b/browser/src/layer/tile/CommentListSection.ts
@@ -1079,7 +1079,7 @@ class CommentSection {
 				modified.setData(modifiedObj);
 				modified.update();
 				this.update();
-				if (!(<any>window).mode.isMobile() && this.isCollapsed) {
+				if (!(<any>window).mode.isMobile() && this.isCollapsed && this.sectionProperties.selectedComment) {
 					var parent = this.sectionProperties.commentList[this.getRootIndexOf(modified.sectionProperties.data.id)];
 					this.openMobileWizardPopup(parent);
 				}


### PR DESCRIPTION
When comments were present in the document and collapsed into bubbles
- when user pressed "enter" above comment's target so paragraph position
was changed - bubble preview was shown.

After the patch we don't show preview in that case.
