### PR TITLE
Comments: bubbles: avatars with different sizes

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -515,6 +515,7 @@ nav.drawing-color-indicator ~ #main-document-content .cool-annotation-reply-coun
 	border-radius: 50%;
 	height: 32px;
 	width: 32px;
+	padding: 0;
 }
 .cool-annotation-img .avatar-img{
 	border: none;


### PR DESCRIPTION
Make sure .cool-annotation-img does get inherit default padding
so both .cool-annotation-collapsed and .cool-annotation-img have the
same size

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ib0fd5cfd3b8eb124d39e3f7f36ad3e834b908b78
