### PR TITLE
Comments: make textarea re-sizable again

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -370,7 +370,8 @@ nav.spreadsheet-color-indicator ~ #sidebar-dock-wrapper {
 	width: 240px;
 }
 
-.annotation-active .cool-annotation-content-wrapper {
+.annotation-active.modify-annotation-container .cool-annotation-content-wrapper,
+.annotation-active.reply-annotation-container .cool-annotation-content-wrapper {
 	min-width: 240px;
 	width: auto;
 }

--- a/browser/src/layer/tile/CommentSection.ts
+++ b/browser/src/layer/tile/CommentSection.ts
@@ -684,7 +684,7 @@ class Comment {
 
 	public onLostFocus (e: any) {
 		if (!this.sectionProperties.isRemoved) {
-			$(this.sectionProperties.container).removeClass('annotation-active');
+			$(this.sectionProperties.container).removeClass('annotation-active reply-annotation-container modify-annotation-container');
 			if (this.sectionProperties.contentText.origText !== this.sectionProperties.nodeModifyText.value) {
 				this.onSaveComment(e);
 			}
@@ -722,6 +722,7 @@ class Comment {
 	}
 
 	public reply () {
+		this.sectionProperties.container.classList.add('reply-annotation-container');
 		this.sectionProperties.container.style.visibility = '';
 		this.sectionProperties.contentNode.style.display = '';
 		this.sectionProperties.nodeModify.style.display = 'none';
@@ -731,6 +732,7 @@ class Comment {
 
 	public edit () {
 		this.doPendingInitializationInView(true /* force */);
+		this.sectionProperties.container.classList.add('modify-annotation-container');
 		this.sectionProperties.nodeModify.style.display = '';
 		this.sectionProperties.nodeReply.style.display = 'none';
 		this.sectionProperties.container.style.visibility = '';


### PR DESCRIPTION
What was introduced in 263c8e8e8924a1f2abe3d59e3d2ebeae114a36f5
didn't work anymore and instead active comments (simply focuses,
not editing nor replying) were getting those css changes making them
auto width (result: super long width)

Fix that, by adding CSS classes to the container and making sure only
annotations with those textareas can be re-sizable

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I109867505eba3aa4193d342a0a53d48dd772f807
