### PR TITLE
Fix WOPISrc generation after save as

### DIFF
--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -1150,6 +1150,7 @@ app.definitions.Socket = L.Class.extend({
 			this._map.options.doc = docUrl;
 			this._map.options.previousWopiSrc = this._map.options.wopiSrc; // After save-as op, we may connect to another server, then code will think that server has restarted. In this case, we don't want to reload the page (detect the file name is different).
 			this._map.options.wopiSrc = encodeURIComponent(docUrl);
+			window.wopiSrc = this._map.options.wopiSrc;
 
 			if (textMsg.startsWith('renamefile:')) {
 				this._map.fire('postMessage', {


### PR DESCRIPTION
This fixes regression from:
https://github.com/CollaboraOnline/online/commit/293081a6317f551315c49055475c33bb0fc9792e
commit 293081a6317f551315c49055475c33bb0fc9792e
leaflet: centralize wopiSrc URL forming

global.wopiSrc is used to generate new URL but it is not updated
after we do save as action. It was always equal to initial value
which was set on the app load. Because of that we generated URL
with not matching file ids in the WOPISrc parameter.

WOPISrc parameter is used for load balancing so it was possible
that after save as the new session will be directed to the different
node.
