### PR TITLE
notebookbar: activate in core when default ui mode

### DIFF
--- a/kit/ForKit.cpp
+++ b/kit/ForKit.cpp
@@ -640,6 +640,8 @@ int main(int argc, char** argv)
         {
             eq = std::strchr(cmd, '=');
             UserInterface = std::string(eq+1);
+            if (UserInterface != "classic" && UserInterface != "notebookbar")
+                UserInterface = "notebookbar";
         }
     }
 


### PR DESCRIPTION
Core needs "notebookbar" ui mode string to activate
notebookbar widgets. If we pass "default" notebookbar
is not activated and style previews widget doesn't work.

followup for https://github.com/CollaboraOnline/online/commit/b4f588ea3cadad124f1c99718fb7f63e82c91953