### PR TITLE
Quarantine followup: quarantine file on exit too

### DIFF
--- a/common/FileUtil.hpp
+++ b/common/FileUtil.hpp
@@ -151,6 +151,7 @@ namespace FileUtil
         bool isFile() const { return S_ISREG(_sb.st_mode); }
         bool isLink() const { return S_ISLNK(_sb.st_mode); }
         std::size_t hardLinkCount() const { return _sb.st_nlink; }
+        ino_t inodeNumber() const { return _sb.st_ino; }
 
         /// Returns the filesize in bytes.
         std::size_t size() const { return _sb.st_size; }

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1125,7 +1125,6 @@ void DocumentBroker::handleSaveResponse(const std::string& sessionId, bool succe
     const std::string oldName = _storage->getRootFilePathToUpload();
     const std::string newName = _storage->getRootFilePathUploading();
 
-
     if (rename(oldName.c_str(), newName.c_str()) < 0)
     {
         // It's not an error if there was no file to rename, when the document isn't modified.
@@ -2890,6 +2889,10 @@ void DocumentBroker::childSocketTerminated()
 void DocumentBroker::terminateChild(const std::string& closeReason)
 {
     assertCorrectThread();
+
+#if !MOBILEAPP
+    Quarantine::quarantineFile(this, _filename);
+#endif
 
     LOG_INF("Terminating doc [" << _docKey << "] with reason: " << closeReason);
 


### PR DESCRIPTION
* Target version: master 

### Summary
added method to get inode number from Stat object
quarantine file on exit too 



### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

