### PR TITLE
NB: Fix big unotoolbutton dropdown with image

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -718,7 +718,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	line-height: 0;
 	border: 4px solid transparent;
 	border-top: 5px solid var(--gray-light-txt--color);
-	display: inline-block;
+	display: inline-block !important;
 	margin-left: 3px;
 }
 

--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -376,6 +376,12 @@
 .unotoolbutton.notebookbar.has-label:not(.inline) img {
 	width: 24px !important;
 	margin: auto !important;
+	display: block;
+}
+.has-label.has-dropdown:not(.inline) .unolabel{
+	display: inline-block;
+	clear: both;
+	float: left;
 }
 
 /* unobuttons with inline labels */


### PR DESCRIPTION
Buttons with image and text stacked up plus arrow:
Some browsers (chrome/chromium) were not displaying the arrow correctly,
it was appearing as a gray block and also badly positioned.

This change fixes that.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I144aa39eb17361309683592928720986e8476f36
