### PR TITLE
mobile-wizard: hide not usefull style options on mobile

### DIFF
--- a/browser/css/device-mobile.css
+++ b/browser/css/device-mobile.css
@@ -823,3 +823,8 @@ td[id^='tb_spreadsheet-toolbar_item']:focus table.w2ui-button div.w2ui-icon, td[
 #coolwsd-version, #lokit-version {
 	flex-direction: column;
 }
+
+/* hide not usefull style options on mobile */
+div#fontstyletoolbox + div#style.mobile-wizard {
+	display: none !important;
+}


### PR DESCRIPTION
it was hidden in 6.4, now when it appears - other buttons are
positioned incorrectly
