### PR TITLE
Misc fixes

### DIFF
--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -458,13 +458,13 @@ bool FileServerRequestHandler::isAdminLoggedIn(const HTTPRequest& request,
             }
 
             std::streamsize size = request.getContentLength();
-            char buffer[size];
-            message.read(buffer, size);
+            std::vector<char> buffer(size);
+            message.read(buffer.data(), size);
             LocalFileInfo::fileInfoVec[i].fileLastModifiedTime = std::chrono::system_clock::now();
 
             std::ofstream outfile;
             outfile.open(LocalFileInfo::fileInfoVec[i].localPath, std::ofstream::binary);
-            outfile.write(buffer, size);
+            outfile.write(buffer.data(), size);
             outfile.close();
 
             const std::string body = "{\"LastModifiedTime\": \"" +

--- a/wsd/TileCache.cpp
+++ b/wsd/TileCache.cpp
@@ -249,7 +249,9 @@ bool TileCache::getTextStream(StreamType type, const std::string& fileName, std:
     Tile textStream = lookupCachedStream(type, fileName);
     if (!textStream)
     {
-        LOG_ERR("Could not open " << fileName);
+        // This is not an error because the first time
+        // we lookup a file, it won't be in the cache.
+        LOG_INF("Could not open " << fileName);
         return false;
     }
 


### PR DESCRIPTION
- wsd: allocate temporary buffer dynamically
- wsd: cache misses are not errors
