### PR TITLE
Classic: shortened size of menus

### DIFF
--- a/browser/css/menubar.css
+++ b/browser/css/menubar.css
@@ -63,7 +63,7 @@
 	display: none;
 }
 .main-nav {
-	height: 32px; /* on mouseover menubar items, border emerges */
+	height: 38px; /* on mouseover menubar items, border emerges */
 	width: auto;
 	background: #ffffff;
 	padding: 3px 3px 3px 0;
@@ -74,6 +74,9 @@
 .main-nav.readonly {
 	position: relative;
 	border-bottom: 1px solid var(--gray-light-bg-color);
+}
+.main-nav.hasnotebookbar {
+	height: 32px;
 }
 .main-nav.hasnotebookbar:not(.readonly) {
 	background: var(--gray-light-bg-color);
@@ -111,9 +114,7 @@
 }
 
 .lo-menu > li > a, .lo-menu > li > a.has-submenu {
-	padding-left: 15px;
-	padding-right: 15px;
-	padding-top: 8px;
+	padding: 8px;
 	z-index: 400;
 	border-left: 1px solid #ffffff;
 	border-right: 1px solid #ffffff;

--- a/cypress_test/integration_tests/common/desktop_helper.js
+++ b/cypress_test/integration_tests/common/desktop_helper.js
@@ -333,13 +333,13 @@ function actionOnSelector(name,func) {
 //type represent horizontal/vertical scrollbar
 //arr : In both cypress GUI and CLI the scrollposition are slightly different
 //so we are passing both in array and assert using oneOf
-function assertScrollbarPosition(type, arr) {
+function assertScrollbarPosition(type, lowerBound, upperBound) {
 	cy.wait(500);
 
 	cy.get('#test-div-' + type + '-scrollbar')
 		.then(function($item) {
 			const x = parseInt($item.text());
-			expect(x).to.be.oneOf(arr);
+			expect(x).to.be.within(lowerBound, upperBound);
 		});
 }
 

--- a/cypress_test/integration_tests/desktop/calc/scrolling_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/scrolling_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach expect require afterEach */
+/* global describe it cy beforeEach require afterEach */
 
 var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
@@ -21,15 +21,15 @@ describe('Scroll through document', function() {
 	});
 
 	it('Scrolling to bottom/top', function() {
-		desktopHelper.assertScrollbarPosition('vertical', [29, 26]);
+		desktopHelper.assertScrollbarPosition('vertical', 26, 29);
 
 		desktopHelper.pressKey(3,'pagedown');
 
-		desktopHelper.assertScrollbarPosition('vertical', [224, 201, 191]);
+		desktopHelper.assertScrollbarPosition('vertical', 191, 224);
 
 		desktopHelper.pressKey(3,'pageup');
 
-		desktopHelper.assertScrollbarPosition('vertical', [29, 26]);
+		desktopHelper.assertScrollbarPosition('vertical', 26, 29);
 	});
 
 	it('Scrolling to left/right', function() {
@@ -37,16 +37,12 @@ describe('Scroll through document', function() {
 
 		helper.typeIntoDocument('{home}');
 
-		desktopHelper.assertScrollbarPosition('horizontal', [62, 55, 68]);
+		desktopHelper.assertScrollbarPosition('horizontal', 55, 68);
 
 		helper.typeIntoDocument('{end}');
 
 		cy.wait(500);
 
-		cy.get('#test-div-horizontal-scrollbar')
-			.then(function($item) {
-				const x = parseInt($item.text());
-				expect(x).to.be.within(129, 155);
-			});
+		desktopHelper.assertScrollbarPosition('horizontal', 129, 155);
 	});
 });

--- a/cypress_test/integration_tests/desktop/impress/scrolling_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/scrolling_spec.js
@@ -29,11 +29,10 @@ describe('Scroll through document', function() {
 				var XPos = (items[0].getBoundingClientRect().left + items[0].getBoundingClientRect().right) / 2;
 				var YPos = (items[0].getBoundingClientRect().top + items[0].getBoundingClientRect().bottom) / 2;
 				cy.get('body')
-					.click(XPos, YPos)
+					.dblclick(XPos, YPos)
 					.wait(500);
 			});
 	}
-
 	it('Scrolling to bottom/top', function() {
 		//show vertical scrollbar
 		cy.get('.leaflet-layer')
@@ -50,7 +49,7 @@ describe('Scroll through document', function() {
 
 		desktopHelper.pressKey(18,'downarrow');
 
-		desktopHelper.assertScrollbarPosition('vertical', [384, 337]);
+		desktopHelper.assertScrollbarPosition('vertical', 335, 384);
 	});
 
 	it('Scrolling to left/right', function() {
@@ -62,13 +61,15 @@ describe('Scroll through document', function() {
 
 		clickOnTheCenter();
 
-		helper.typeIntoDocument('{home}{end}{home}');
+		cy.wait(500);
+
+		helper.typeIntoDocument('{home}');
 
 		cy.get('#test-div-horizontal-scrollbar')
 			.should('have.text', '6').wait(500);
 
-		helper.typeIntoDocument('{end}{home}{end}');
+		helper.typeIntoDocument('{end}');
 
-		desktopHelper.assertScrollbarPosition('horizontal', [660, 581]);
+		desktopHelper.assertScrollbarPosition('horizontal', 581, 660);
 	});
 });

--- a/cypress_test/integration_tests/desktop/writer/scrolling_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/scrolling_spec.js
@@ -71,6 +71,6 @@ describe('Scroll through document', function() {
 
 		helper.typeIntoDocument('{end}{home}{end}');
 
-		desktopHelper.assertScrollbarPosition('horizontal', [660, 577]);
+		desktopHelper.assertScrollbarPosition('horizontal', 577, 660);
 	});
 });


### PR DESCRIPTION
To occupy less space critical in some languages where the last save
string is quite long also increase its height so the click target
is not too small

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I16affef5b5ecb484a14c7f6ff03ba8a28b3eef63
