### PR TITLE
Remove Character spacing margin-left at writer BackColor

### DIFF
--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -435,7 +435,7 @@
 	padding-right: 0px;
 }
 
-#BackColor.notebookbar, #CharBackColor.notebookbar { /* remove when #2149 is fixed*/
+#CharBackColor.notebookbar { /* remove when #2149 is fixed in impress/draw*/
 	margin-left: 44px !important;
 }
 


### PR DESCRIPTION
Signed-off-by: Andreas Kainz <kainz.a@gmail.com>
Change-Id: I50feec0c4bef0646fc3bea3a40bbd326ab12099f

As pedro added Character Spacing to writer #2149 the page margin-left: 44px isn't needed any more, cause with the additional command the alignment fit's perfect.

If character spacing will be available within impress/draw also #CharBackColor.notebookbar can be removed from notebookbar.css.

**before**
![Screenshot_20211124_222841](https://user-images.githubusercontent.com/8517736/143315039-c5fb37ff-8f8d-40cc-a118-7194fbf70b7c.png)

**after**
![Screenshot_20211124_222755](https://user-images.githubusercontent.com/8517736/143314970-7e987ed2-18b4-4d14-a582-fc54d41b22f1.png)

