### PR TITLE
WopiStorage: log what is the final suggested target for save-as

### DIFF
--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -1280,6 +1280,7 @@ void WopiStorage::uploadLocalFileToStorageAsync(const Authorization& auth, LockC
                 // save as
                 httpHeader.set("X-WOPI-Override", "PUT_RELATIVE");
                 httpHeader.set("X-WOPI-Size", std::to_string(size));
+                LOG_TRC("Save as: suggested target is '" << suggestedTarget << "'.");
                 httpHeader.set("X-WOPI-SuggestedTarget", suggestedTarget);
             }
         }


### PR DESCRIPTION
unit-wopi-saveas sometimes fails on me with sanitizers. The reason is
still not yet clear (the test is quite stable without them), but at
least try to find out if the suggested target is already wrong when we
put them to the HTTP header or it goes wrong later.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I25f65fd6e211022aa93c699cdaef49eb8978fdee
