### PR TITLE
browser: add a cancel button to the dialog

### DIFF
--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -828,6 +828,11 @@ app.definitions.Socket = L.Class.extend({
 						click: function() {
 							this.value = 'overwrite';
 							this.close();
+						}}),
+					$.extend({}, vex.dialog.buttons.YES, { text: _('Cancel'),
+						click: function() {
+							this.value = 'cancel';
+							this.close();
 						}})
 				];
 


### PR DESCRIPTION
When process an error document conflict,
the vex dialog will show an option to cancel the dialog.

Change-Id: If4ee9ad756d18761001919d253886e912b010fe9
Signed-off-by: Henry Castro <hcastro@collabora.com>
