### PR TITLE
require C++17

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -851,8 +851,8 @@ AM_CONDITIONAL([ENABLE_LIBFUZZER], [test "$LIBFUZZER" = "1"])
 
 # check for C++11 support
 HAVE_CXX11=
-AC_MSG_CHECKING([whether $CXX supports C++17, C++14 or C++11])
-for flag in -std=c++17 -std=gnu++14 -std=gnu++1y -std=c++14 -std=c++1y -std=gnu++11 -std=gnu++0x -std=c++11 -std=c++0x ; do
+AC_MSG_CHECKING([whether $CXX supports C++17])
+for flag in -std=c++17 -std=c++1z ; do
     save_CXXFLAGS=$CXXFLAGS
     CXXFLAGS="$CXXFLAGS $flag -Werror"
     AC_LANG_PUSH([C++])


### PR DESCRIPTION
As discussed during today's COOL meeting. Even cp-6.4 now requires
C++17, so this should be always satisfied.

Signed-off-by: Luboš Luňák <l.lunak@collabora.com>
Change-Id: I7b4f96b6de54a747e42069f0fc839393cf3d1bec
