### PR TITLE
Use `cp -a` instead of `cp -ar`.

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -640,7 +640,7 @@ $(DIST_FOLDER)/admin/%: $(srcdir)/admin/%
 
 install-data-hook:
 	mkdir -p $(DESTDIR)$(pkgdatadir)/browser; \
-	cp -ar dist/ $(DESTDIR)$(pkgdatadir)/browser/;
+	cp -a dist/ $(DESTDIR)$(pkgdatadir)/browser/;
 
 libs:
 	@mkdir -p $(abs_srcdir)/libs


### PR DESCRIPTION
According to Linux man, `-r` and `-R` are synonims and `-a` implies `-R`.
However, FreeBSD `cp` errors out when both `-r` and `-a` are given.
This fixes `make install` on FreeBSD.

Signed-off-by: Gleb Popov <6yearold@gmail.com>
Change-Id: I5b325eb654ca52ad0f988e777c5bf5447d385ab5
