### PR TITLE
quarantine: add the original file name to the quarantined file name

### DIFF
--- a/wsd/QuarantineUtil.cpp
+++ b/wsd/QuarantineUtil.cpp
@@ -142,7 +142,7 @@ namespace Quarantine
 
         std::string sourcefilePath = COOLWSD::ChildRoot + "tmp/cool-" + docBroker->getJailId() + "/user/docs/" + docBroker->getJailId() + "/" + docName;
 
-        std::string linkedFileName = ts + "_" + std::to_string(docBroker->getPid()) + "_" + docKey;
+        std::string linkedFileName = ts + '_' + std::to_string(docBroker->getPid()) + '_' + docKey + '_' + docName;
         std::string linkedFilePath = COOLWSD::QuarantinePath + linkedFileName;
 
         auto& fileList = COOLWSD::QuarantineMap[docBroker->getDocKey()];


### PR DESCRIPTION
Instead of
1638118271_12013_%2Findex.php%2Fapps%2Frichdocuments%2Fwopi%2Ffiles%2F289_ocvq040ushf2
we would get
1638118271_12013_%2Findex.php%2Fapps%2Frichdocuments%2Fwopi%2Ffiles%2F289_ocvq040ushf2_bad.docx
I find it more useful.

Signed-off-by: Andras Timar <andras.timar@collabora.com>
Change-Id: I50918908173adeb68964b2aa542592b57ec82020


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

