### PR TITLE
make stringifyHexLine() simply work on std::string

### DIFF
--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -307,31 +307,34 @@ namespace Util
     inline std::string stringifyHexLine(const T& buffer, std::size_t offset,
                                         const std::size_t width = 32)
     {
-        char scratch[64];
-        std::stringstream os;
+        std::string str;
+        str.reserve(width * 4 + width / 8 + 3 + 1);
 
         for (unsigned int i = 0; i < width; i++)
         {
             if (i && (i % 8) == 0)
-                os << ' ';
+                str.push_back(' ');
             if ((offset + i) < buffer.size())
-                sprintf (scratch, "%.2x ", (unsigned char)buffer[offset+i]);
+            {
+                const unsigned short hex = hexFromByte(buffer[offset+i]);
+                str.push_back(hex >> 8);
+                str.push_back(hex & 0xff);
+                str.push_back(' ');
+            }
             else
-                sprintf (scratch, "   ");
-            os << scratch;
+                str.append(3, ' ');
         }
-        os << " | ";
+        str.append(" | ");
 
         for (unsigned int i = 0; i < width; i++)
         {
             if ((offset + i) < buffer.size())
-                sprintf(scratch, "%c", ::isprint(buffer[offset + i]) ? buffer[offset + i] : '.');
+                str.push_back(::isprint(buffer[offset + i]) ? buffer[offset + i] : '.');
             else
-                sprintf(scratch, " "); // Leave blank if we are out of data.
-            os << scratch;
+                str.push_back(' '); // Leave blank if we are out of data.
         }
 
-        return os.str();
+        return str;
     }
 
     /// Dump data as hex and chars to stream.

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -81,6 +81,7 @@ test_base_source = \
 	WhiteBoxTests.cpp \
 	HttpWhiteBoxTests.cpp \
 	DeltaTests.cpp \
+	UtilTests.cpp \
 	WopiProofTests.cpp \
 	$(wsd_sources)
 

--- a/test/UtilTests.cpp
+++ b/test/UtilTests.cpp
@@ -1,0 +1,39 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <config.h>
+
+#include <test/lokassert.hpp>
+
+#include <Util.hpp>
+
+/// Util unit-tests.
+class UtilTests : public CPPUNIT_NS::TestFixture
+{
+    CPPUNIT_TEST_SUITE(UtilTests);
+
+    CPPUNIT_TEST(testStringifyHexLine);
+
+    CPPUNIT_TEST_SUITE_END();
+
+    void testStringifyHexLine();
+};
+
+void UtilTests::testStringifyHexLine()
+{
+    std::string test("hello here\ntest");
+    std::string result1("68 65 6C 6C 6F 20 68 65  72 65 0A 74 65 73 74"
+                        "                                                       "
+                        "| hello here.test                 ");
+    std::string result2("68 65 72 65 0A 74  | here.t");
+    LOK_ASSERT_EQUAL(result1, Util::stringifyHexLine(test, 0));
+    LOK_ASSERT_EQUAL(result2, Util::stringifyHexLine(test, 6, 6));
+}
+
+CPPUNIT_TEST_SUITE_REGISTRATION(UtilTests);
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */


### PR DESCRIPTION
Trying to construct a string using sprintf() and std::stringstream
is unnecessarily complicated for something as simple as this,
and it shows up in my profiling. This commit makes the hex values
change to uppercase because that's what hexFromByte() returns,
but I don't think it matters.

Signed-off-by: Luboš Luňák <l.lunak@collabora.com>
Change-Id: I31c7b8e7cf4c2a495eca0bf03ae4cab53b26a04b
