### PR TITLE
fix: dont give an option to saveas if UserCannotWriteRelative is true

### DIFF
--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -824,27 +824,32 @@ app.definitions.Socket = L.Class.extend({
 
 				vex.closeAll();
 
+				var dialogButtons = [
+					$.extend({}, vex.dialog.buttons.YES, { text: _('Discard'),
+						click: function() {
+							this.value = 'discard';
+							this.close();
+						}}),
+					$.extend({}, vex.dialog.buttons.YES, { text: _('Overwrite'),
+						click: function() {
+							this.value = 'overwrite';
+							this.close();
+						}})
+				];
+
+				if (!that._map['wopi'].UserCanNotWriteRelative) {
+					dialogButtons.push($.extend({}, vex.dialog.buttons.YES, { text: _('Save to new file'),
+						click: function() {
+							this.value = 'saveas';
+							this.close();
+						}}));
+				}
+
 				vex.dialog.open({
 					message: _('Document has been changed in storage. What would you like to do with your unsaved changes?'),
 					escapeButtonCloses: false,
 					overlayClosesOnClick: false,
-					buttons: [
-						$.extend({}, vex.dialog.buttons.YES, { text: _('Discard'),
-						                                      click: function() {
-							                                      this.value = 'discard';
-							                                      this.close();
-						                                      }}),
-						$.extend({}, vex.dialog.buttons.YES, { text: _('Overwrite'),
-						                                      click: function() {
-							                                      this.value = 'overwrite';
-							                                      this.close();
-						                                      }}),
-						$.extend({}, vex.dialog.buttons.YES, { text: _('Save to new file'),
-						                                      click: function() {
-							                                      this.value = 'saveas';
-							                                      this.close();
-						                                      }})
-					],
+					buttons: dialogButtons,
 					callback: function(value) {
 						if (value === 'discard') {
 							// They want to refresh the page and load document again for all


### PR DESCRIPTION
On documentconflict, we give 3 options;
discard, overwrite, save-as
the third option should be impossible if the user is not allowed

Signed-off-by: Mert Tumer <mert.tumer@collabora.com>
Change-Id: I30571d885259a02c4170ccf7e291d4456bf1880c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

