### PR TITLE
Aboud: Fix Desktop-only rules, affect also tablets

### DIFF
--- a/loleaflet/css/device-tablet.css
+++ b/loleaflet/css/device-tablet.css
@@ -160,3 +160,13 @@
 	min-width: 24px;
 	margin: 0;
 }
+
+#loolwsd-version span:before,
+#lokit-version > span:before {
+	content: ' (';
+	white-space: pre;
+}
+#loolwsd-version span:after,
+#lokit-version > span:after {
+	content: ')';
+}


### PR DESCRIPTION
Those spaces and brackets are also needed when using tables

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I9af86ecddc335e212ad76700ce66531453db2274
