### PR TITLE
kit: removed back compatibility of textinput message

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -1407,7 +1407,7 @@ bool ChildSession::insertFile(const char* /*buffer*/, int /*length*/, const Stri
 bool ChildSession::extTextInputEvent(const char* /*buffer*/, int /*length*/,
                                      const StringVector& tokens)
 {
-    int id = -1, type = -1;
+    int id = -1;
     std::string text;
     bool error = false;
 
@@ -1416,13 +1416,7 @@ bool ChildSession::extTextInputEvent(const char* /*buffer*/, int /*length*/,
     else if (!getTokenInteger(tokens[1], "id", id) || id < 0)
         error = true;
     else {
-        // back-compat 'type'
-        if (getTokenKeyword(tokens[2], "type",
-                            {{"input", LOK_EXT_TEXTINPUT}, {"end", LOK_EXT_TEXTINPUT_END}},
-                            type))
-            error = !getTokenString(tokens[3], "text", text);
-        else // normal path:
-            error = !getTokenString(tokens[2], "text", text);
+        error = !getTokenString(tokens[2], "text", text);
     }
 
     if (error)
@@ -1435,13 +1429,8 @@ bool ChildSession::extTextInputEvent(const char* /*buffer*/, int /*length*/,
     URI::decode(text, decodedText);
 
     getLOKitDocument()->setView(_viewId);
-    if (type >= 0)
-        getLOKitDocument()->postWindowExtTextInputEvent(id, type, decodedText.c_str());
-    else
-    {
-        getLOKitDocument()->postWindowExtTextInputEvent(id, LOK_EXT_TEXTINPUT, decodedText.c_str());
-        getLOKitDocument()->postWindowExtTextInputEvent(id, LOK_EXT_TEXTINPUT_END, decodedText.c_str());
-    }
+    getLOKitDocument()->postWindowExtTextInputEvent(id, LOK_EXT_TEXTINPUT, decodedText.c_str());
+    getLOKitDocument()->postWindowExtTextInputEvent(id, LOK_EXT_TEXTINPUT_END, decodedText.c_str());
 
     return true;
 }


### PR DESCRIPTION
removed support for parameter "type" which is no longer sent with textinput

Signed-off-by: Pranam Lashkari <lpranam@collabora.com>
Change-Id: I97bb7e80fe9cc3bb0768fd37b0c15983310a538c

* Target version: master 


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

