### PR TITLE
Make coolwsd-generate-proof-key prepared for a custom prefix.

### DIFF
--- a/coolwsd-generate-proof-key
+++ b/coolwsd-generate-proof-key
@@ -1,7 +1,19 @@
 #!/usr/bin/env bash
 
+if [ "$1" == "-h" ]; then
+    echo "Usage: coolwsd-generate-proof-key [-h] [CONFIGDIR]"
+    echo "CONFIGDIR defaults to /etc/coolwsd"
+    exit 0
+fi
+
+if [ "$1" ]; then
+    CONFIGDIR="$1"
+else
+    CONFIGDIR="/etc/coolwsd"
+fi
+
 SUDO=''
-if [ ! -w "/etc/coolwsd" ]; then
+if [ ! -w "$CONFIGDIR" ]; then
     if (( $EUID != 0 )); then
         if hash sudo 2>/dev/null; then
             SUDO='sudo'
@@ -12,23 +24,23 @@ if [ ! -w "/etc/coolwsd" ]; then
     fi
 fi
 
-if [ -f /etc/coolwsd/proof_key ]; then
-    echo "/etc/coolwsd/proof_key exists already."
+if [ -f $CONFIGDIR/proof_key ]; then
+    echo "$CONFIGDIR/proof_key exists already."
     exit 0
 fi
 
 if hash ssh-keygen 2>/dev/null; then
-    $SUDO ssh-keygen -t rsa -N "" -m PEM -f /etc/coolwsd/proof_key
+    $SUDO ssh-keygen -t rsa -N "" -m PEM -f $CONFIGDIR/proof_key
     if [ $? -ne 0 ] ; then
         exit $?
-	fi
+    fi
     if id -u cool >/dev/null 2>&1; then
-        $SUDO chown cool: /etc/coolwsd/proof_key
+        $SUDO chown cool: $CONFIGDIR/proof_key
     else
         echo "User cool does not exist. Please reinstall coolwsd package, or in case of manual installation from source, create the cool user manually."
     fi
 else
-	echo "ssh-keygen command not found. Please install openssh client tools."
+    echo "ssh-keygen command not found. Please install openssh client tools."
     exit 127
 fi
 


### PR DESCRIPTION
The downstream packagers can patch the "PREFIX=/" line to their liking.

While there, converts tabs into spaces for consistency.

Signed-off-by: Gleb Popov <6yearold@gmail.com>
Change-Id: I424f6fe6efac8e51f74f5848586e7fd10fa40904
