### PR TITLE
About dialog: No need to use desktop heading sizes

### DIFF
--- a/loleaflet/css/device-mobile.css
+++ b/loleaflet/css/device-mobile.css
@@ -823,3 +823,8 @@ td[id^='tb_spreadsheet-toolbar_item']:focus table.w2ui-button div.w2ui-icon, td[
 #about-dialog-logos * {
 	background-size: 68%;
 }
+
+#product-name {
+	margin: 2px;
+	font-size: 29px;
+}


### PR DESCRIPTION
Reduce size of dialog title and its margins since we do not want
the heading to be so big and prominent that we end up to overshadow
the content and worst, be required to scroll (often when using
landscape view)

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Id6414ecb6beac00bccf2345d2c244ddb9582a67b
