### PR TITLE
private/pedro/about dialog porting n improvements

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -827,6 +827,10 @@ nav.drawing-color-indicator ~ #main-document-content .cool-annotation-reply-coun
 	align-items: stretch;
 }
 
+#about-dialog-container .spacer {
+	height: 54px;
+}
+
 #about-dialog-logos {
 	flex-grow: 1;
 	flex-flow: column nowrap;

--- a/browser/css/device-mobile.css
+++ b/browser/css/device-mobile.css
@@ -841,3 +841,9 @@ div#fontstyletoolbox + div#style.mobile-wizard {
 #user-welcome--buttons {
 	display: none;
 }
+
+/* About Dialog */
+#about-dialog-logos * {
+	background-size: 68%;
+}
+

--- a/browser/css/device-mobile.css
+++ b/browser/css/device-mobile.css
@@ -847,3 +847,7 @@ div#fontstyletoolbox + div#style.mobile-wizard {
 	background-size: 68%;
 }
 
+#product-name {
+	margin: 2px;
+	font-size: 29px;
+}

--- a/browser/css/device-tablet.css
+++ b/browser/css/device-tablet.css
@@ -159,3 +159,13 @@
 	min-width: 24px;
 	margin: 0;
 }
+
+#loolwsd-version span:before,
+#lokit-version > span:before {
+	content: ' (';
+	white-space: pre;
+}
+#loolwsd-version span:after,
+#lokit-version > span:after {
+	content: ')';
+}

--- a/browser/html/cool.html.m4
+++ b/browser/html/cool.html.m4
@@ -271,7 +271,7 @@ m4_ifelse(MOBILEAPP,[true],
             <div class="spacer"></div>
             <div id="lokit-version-label"></div>
             <div id="lokit-version"></div>
-            m4_ifelse(MOBILEAPP,[],[<div id="served-by-label"></div><div id="served-by"><span id="os-info"></span>&nbsp;<wbr><span id="coolwsd-id"></span></div>],[<p></p>])
+            m4_ifelse(MOBILEAPP,[],[<div id="served-by"><span id="served-by-label"></span>&nbsp;<span id="os-info"></span>&nbsp;<wbr><span id="coolwsd-id"></span></div>],[<p></p>])
             <div id="slow-proxy"></div>
             <p>Copyright © _YEAR_, VENDOR.</p>
           </div>

--- a/browser/html/cool.html.m4
+++ b/browser/html/cool.html.m4
@@ -366,6 +366,9 @@ m4_ifelse(MOBILEAPP,[true],
        <script src="%SERVICE_ROOT%/browser/%VERSION%/bundle.js" defer></script>
   ])
 )m4_dnl
-    <!--%BRANDING_JS%--> <!-- logo onclick handler -->
-    <!--%CSS_VARIABLES%-->
+
+    m4_ifelse(MOBILEAPP,[true],
+    [<script src="m4_ifelse(IOSAPP,[true],[Branding/])branding.js"></script>],
+    [<!--%BRANDING_JS%--> <!-- logo onclick handler -->
+    <!--%CSS_VARIABLES%-->])
 </body></html>

--- a/browser/html/cool.html.m4
+++ b/browser/html/cool.html.m4
@@ -336,15 +336,21 @@ link.setAttribute("type", "text/css");
 var brandingLink = document.createElement('link');
 brandingLink.setAttribute("rel", "stylesheet");
 brandingLink.setAttribute("type", "text/css");
+
+var theme_name = document.getElementsByName("theme")[[0]] ? document.getElementsByName("theme")[[0]].value : '';
+var theme_prefix = '';
+if(theme_name.includes("nextcloud"));
+  theme_prefix = 'nextcloud/';
+
 if (window.mode.isMobile()) {
     [link.setAttribute("href", ']m4_ifelse(MOBILEAPP,[],[%SERVICE_ROOT%/browser/%VERSION%/])[device-mobile.css');]
-    [brandingLink.setAttribute("href", ']m4_ifelse(MOBILEAPP,[],[%SERVICE_ROOT%/browser/%VERSION%/])m4_ifelse(IOSAPP,[true],[Branding/])[branding-mobile.css');]
+    [brandingLink.setAttribute("href", ']m4_ifelse(MOBILEAPP,[],[%SERVICE_ROOT%/browser/%VERSION%/])m4_ifelse(IOSAPP,[true],[Branding/])[' + theme_prefix + 'branding-mobile.css');]
 } else if (window.mode.isTablet()) {
     [link.setAttribute("href", ']m4_ifelse(MOBILEAPP,[],[%SERVICE_ROOT%/browser/%VERSION%/])[device-tablet.css');]
-    [brandingLink.setAttribute("href", ']m4_ifelse(MOBILEAPP,[],[%SERVICE_ROOT%/browser/%VERSION%/])m4_ifelse(IOSAPP,[true],[Branding/])[branding-tablet.css');]
+    [brandingLink.setAttribute("href", ']m4_ifelse(MOBILEAPP,[],[%SERVICE_ROOT%/browser/%VERSION%/])m4_ifelse(IOSAPP,[true],[Branding/])[' + theme_prefix + 'branding-tablet.css');]
 } else {
     [link.setAttribute("href", ']m4_ifelse(MOBILEAPP,[],[%SERVICE_ROOT%/browser/%VERSION%/])[device-desktop.css');]
-    [brandingLink.setAttribute("href", ']m4_ifelse(MOBILEAPP,[],[%SERVICE_ROOT%/browser/%VERSION%/])[branding-desktop.css');]
+    [brandingLink.setAttribute("href", ']m4_ifelse(MOBILEAPP,[],[%SERVICE_ROOT%/browser/%VERSION%/])[' + theme_prefix + 'branding-desktop.css');]
 }
 document.getElementsByTagName("head")[[0]].appendChild(link);
 document.getElementsByTagName("head")[[0]].appendChild(brandingLink);

--- a/browser/html/cool.html.m4
+++ b/browser/html/cool.html.m4
@@ -268,6 +268,7 @@ m4_ifelse(MOBILEAPP,[true],
           <div id="about-dialog-info">
             <div id="coolwsd-version-label"></div>
             <div id="coolwsd-version"></div>
+            <div class="spacer"></div>
             <div id="lokit-version-label"></div>
             <div id="lokit-version"></div>
             m4_ifelse(MOBILEAPP,[],[<div id="served-by-label"></div><div id="served-by"><span id="os-info"></span>&nbsp;<wbr><span id="coolwsd-id"></span></div>],[<p></p>])


### PR DESCRIPTION
- Use the branding.js also in the mobile apps
- Aboud: Fix Desktop-only rules, affect also tablets
- About dialog: add spacer
- About dialog: label should not be a main parent elm
- About dialog: change images sizes to % on mobile
- About dialog: No need to use desktop heading sizes
