### PR TITLE
fix saveAs for files with encoding characters

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -2391,7 +2391,11 @@ bool ChildSession::saveAs(const char* /*buffer*/, int /*length*/, const StringVe
 
     getLOKitDocument()->setView(_viewId);
 
-    success = getLOKitDocument()->saveAs(url.c_str(),
+    std::string encodedURL, encodedWopiFilename;
+    Poco::URI::encode(url, "", encodedURL);
+    Poco::URI::encode(wopiFilename, "", encodedWopiFilename);
+
+    success = getLOKitDocument()->saveAs(encodedURL.c_str(),
                                          format.empty() ? nullptr : format.c_str(),
                                          filterOptions.empty() ? nullptr : filterOptions.c_str());
 
@@ -2414,15 +2418,11 @@ bool ChildSession::saveAs(const char* /*buffer*/, int /*length*/, const StringVe
                     (format.size() == 0 ? "(nullptr)" : format.c_str()) << "', '" <<
                     (filterOptions.size() == 0 ? "(nullptr)" : filterOptions.c_str()) << "'.");
 
-            success = getLOKitDocument()->saveAs(url.c_str(),
+            success = getLOKitDocument()->saveAs(encodedURL.c_str(),
                     format.size() == 0 ? nullptr :format.c_str(),
                     filterOptions.size() == 0 ? nullptr : filterOptions.c_str());
         }
     }
-
-    std::string encodedURL, encodedWopiFilename;
-    Poco::URI::encode(url, "", encodedURL);
-    Poco::URI::encode(wopiFilename, "", encodedWopiFilename);
 
     if (success)
         sendTextFrame("saveas: url=" + encodedURL + " filename=" + encodedWopiFilename);


### PR DESCRIPTION
Appearently core expects encoded path for filenames on saveas
and decodes it at the end.

So if the file name is something like a%20b
and it becomes a b in the storage.

Signed-off-by: Mert Tumer <mert.tumer@collabora.com>
Change-Id: Ib200c92859b4ab3f262cfe88747563c42e2c6a5c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

