### PR TITLE
Fix Font size jumping width #3773

### DIFF
--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -452,6 +452,9 @@ button.leaflet-control-search-next
 	line-height: 24px;
 	padding-right: 8px;
 }
+#tb_editbar_item_fontsizes .select2-container{
+	min-width: 55px !important;
+}
 .fontsizes-select {
 	width: 55px !important;
 }


### PR DESCRIPTION
Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: Ie8b470dc597f4e9e7199550fe57cb98a9e5d42f1


* Resolves: #3773 
* Target version: master 

### Summary
define a min-width solve the issue that the UI will jump if you switch between 10 and 10,5 font size width.