### PR TITLE
Impress: Fix untranslated strings on UI

### DIFF
--- a/loleaflet/src/control/Control.NotebookbarImpress.js
+++ b/loleaflet/src/control/Control.NotebookbarImpress.js
@@ -569,7 +569,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 						'children': [
 							{
 								'type': 'toolitem',
-								'text': 'Connectors',
+								'text': _('Connectors'),
 								'command': '.uno:ConnectorToolbox'
 							}
 						]
@@ -646,7 +646,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 			},
 			{
 				'type': 'bigtoolitem',
-				'text': _UNO('.uno:Presentation'),
+				'text': _('Start Presentation'),
 				'command': '.uno:Presentation'
 			},
 			{
@@ -1398,7 +1398,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 						'children': [
 							{
 								'type': 'toolitem',
-								'text': 'Connectors',
+								'text': _('Connectors'),
 								'command': '.uno:ConnectorToolbox'
 							}
 						]


### PR DESCRIPTION
When using Notebookbar, the following texts were not shown
 translated:
- Home and Draw / Connectors,
- Home / Presentation

Signed-off-by: Aron Budea <aron.budea@collabora.com>
Change-Id: I580b73dd51f18e33115415708eed23aaadf625e5

* Target version: 6.4