### PR TITLE
mobile: request correct number of tiles on init

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -5708,6 +5708,13 @@ L.CanvasTileLayer = L.Layer.extend({
 		if (this.isCalc() && !this._gotFirstCellCursor)
 			return;
 
+		// be sure canvas is initialized already and has correct size
+		var size = map.getSize();
+		if (size.x === 0 || size.y === 0) {
+			setTimeout(function () { this._update(); }.bind(this), 1);
+			return;
+		}
+
 		if (app.file.fileBasedView) {
 			this._updateFileBasedView();
 			return;


### PR DESCRIPTION
Issue sometimes on mobile only one tile was initially requested.
To make other tiles visible it was required to pan/zoom.
For me it was reproducible only using Android Nextcloud app,
probably it depends on device and browser.

Problem was caused by early call to _update() in CanvasTileLayer.js
Canvas was not initialized yet and map returned size of (0,0),
also _getTopLeftPoint() returned some point with negative coordinates
what caused that calculated tile positions were out of a valid range.
In result we requested only one tile with coorinates (0,0).

old log was like:
```
canceltiles
// one tile 0,0
tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0 tileposy=0 tilewidth=1920 tileheight=1920
...
tileprocessed tile=0:0:0:1920:1920:0
...
// more tiles but position outsize screen - prefetching, notice gap in posx 0 -> 5760
tilecombine nviewid=0 part=0 width=256 height=256 tileposx=5760,5760,5760,5760,5760,0,1920,3840,5760,0
```
log after patch:
```
canceltiles
// tiles for whole screen
tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0,1920,3840,0,1920,3840,0,1920,3840,0,1920,3840,0,1920,3840 tileposy=0,0,0,1920,1920,1920,3840,3840,3840,5760,5760,5760,7680,7680,7680 tilewidth=1920 tileheight=1920
...
// serie of tileprocessed
tileprocessed tile=0:3840:1920:1920:1920:0
tileprocessed tile=0:0:1920:1920:1920:0
...
// more tiles outside screen - prefetching
tilecombine nviewid=0 part=0 width=256 height=256 tileposx=7680,7680,7680,7680,7680,7680,1920,3840,5760,7680 tileposy=0,1920,3840,5760,7680,9600,11520,11520,11520,11520 tilewidth=1920 tileheight=1920
```
