### PR TITLE
Update highlight color layout

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -173,26 +173,39 @@ td.jsdialog .jsdialog.cell.sidebar {
 #table-textorientbox.sidebar .jsdialog .radiobutton {
 	border: 1px solid transparent;
 }
+
+/* non selected */
+.hasnotebookbar .ui-content.unotoolbutton.has-label,
+.hasnotebookbar .ui-content.unotoolbutton.inline,
+.hasnotebookbar .ui-content.unotoolbutton:not(.has-label):not(.inline),
+.sidebar.unotoolbutton {
+	background-color: transparent;
+	border: 2px solid transparent;
+	color: var(--gray-light-txt--color);
+	border-radius: 4px;
+}
+/* selected */
+.hasnotebookbar .ui-content.unotoolbutton.selected.has-label,
+.hasnotebookbar .ui-content.unotoolbutton.selected.inline,
+.hasnotebookbar .ui-content.unotoolbutton.selected:not(.has-label):not(.inline),
+.sidebar.unotoolbutton.selected {
+	background-color: var(--gray-light-bg-color);
+	border: 2px solid var(--gray-light-bg-color);
+	color: var(--gray-light-txt--color);
+	border-radius: 4px;
+}
+/* selected hover */
+.hasnotebookbar .ui-content.unotoolbutton.selected:hover,
+.unotoolbutton.notebookbar:hover,
+.hasnotebookbar .ui-content.unotoolbutton.selected:not(.has-label):not(.inline):hover,
 .sidebar.unotoolbutton:hover,
+.sidebar.unotoolbutton.selected:hover,
 .sidebar #resetattr:hover,
 .sidebar #FormatPaintbrush:hover,
 #table-textorientbox.sidebar .jsdialog .radiobutton:hover {
-	border-color: var(--gray-light-txt--color);
-	background-color: var(--gray-light-bg-color);
-	border-radius: 0.1px;
-}
-
-.sidebar.unotoolbutton.selected {
-	background-color: var(--gray-light-bg-color);
-	outline: 2px solid var(--gray-light-bg-color);
+	outline: 1px solid var(--gray-light-txt--color);
 	color: var(--gray-light-txt--color);
-}
-
-.sidebar.unotoolbutton.selected:hover {
-	background-color: var(--gray-light-bg-color);
-	outline: 1px solid var(--gray-light-bg-color);
-	color: var(--gray-light-txt--color);
-	border-radius: 0.1px;
+	border-radius: 4px;
 }
 
 .sidebar #font select,

--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -260,20 +260,6 @@
 	vertical-align: middle;
 }
 
-.hasnotebookbar .ui-content.unotoolbutton.selected.has-label,
-.hasnotebookbar .ui-content.unotoolbutton.selected.inline,
-.hasnotebookbar .ui-content.unotoolbutton.selected:not(.has-label):not(.inline) {
-	background-color: var(--gray-light-bg-color);
-	outline: 2px solid var(--gray-light-bg-color);
-	color: var(--gray-light-txt--color);
-}
-
-.hasnotebookbar .ui-content.unotoolbutton.selected:hover,
-.unotoolbutton.notebookbar:hover,
-.hasnotebookbar .ui-content.unotoolbutton.selected:not(.has-label):not(.inline):hover {
-	box-shadow: 0 0 0 1px var(--gray-color);
-}
-
 /* avoid bug with arrow in new line when window is small */
 #table-Home-Section-Insert #table-LineB9 #InsertGraphic.notebookbar,
 #table-Home-Section-Insert #table-GroupB20 #InsertTable.notebookbar {
@@ -423,11 +409,11 @@
 }
 
 #fontsize.notebookbar .select2.select2-container {
-	width: 60px !important;
+	width: 65px !important;
 }
 
 #fontnamecombobox.notebookbar .select2 {
-	width: 170px !important;
+	width: 195px !important;
 	top: -1px;
 }
 

--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -504,6 +504,23 @@ button.leaflet-control-search-next
 	border: 1px solid #888;
 }
 
+.w2ui-toolbar table.w2ui-button {
+	background-color: transparent;
+	border: 1px solid transparent;
+	color: var(--gray-light-txt--color);
+}
+.w2ui-toolbar table.w2ui-button.checked {
+	background-color: var(--gray-light-bg-color);
+	border: 1px solid var(--gray-light-bg-color);
+	color: var(--gray-light-txt--color);
+}
+.select2-container--default .select2-selection--single:hover,
+.sidebar.jsdialog.ui-listbox:hover,
+.w2ui-toolbar table.w2ui-button.checked:hover {
+	background-color: var(--gray-light-bg-color);
+	border: 1px solid var(--gray-light-txt--color);
+}
+
 .w2ui-icon.basicshapes_rectangle { background: url('images/lc_rect.svg') no-repeat center !important; }
 .w2ui-icon.basicshapes_round-rectangle { background: url('images/lc_rect_rounded.svg') no-repeat center !important; }
 .w2ui-icon.basicshapes_quadrat { background: url('images/lc_square.svg') no-repeat center !important; }


### PR DESCRIPTION
Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I0cb4a98b322dcfd9de036a618866ec8fef1a4a98


* Resolves: #3716
* Target version: master 

### Summary
synchronize the select, hover and select:hover layout between classic toolbar, notebookbar and sidebar. Each action has it's own layout. 

### TODO

**select | hover | select**
![Screenshot_20211203_012403](https://user-images.githubusercontent.com/8517736/144524264-ae2d31f9-e796-4c07-8366-462e0f21ba3e.png)
**select and hover | unselect | select**
![Screenshot_20211203_012410-1](https://user-images.githubusercontent.com/8517736/144524282-2d7269a3-8971-446d-996a-dc8efe4b9b03.png)

layout is the same at toolbar, notebookbar and sidebar.
