### PR TITLE
Sidebar alignment fixes

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -57,7 +57,7 @@
 }
 
 #gradientstyle > .sidebar.jsdialog.ui-listbox {
-	width: 104px;
+	width: 74px;
 }
 
 .sidebar.jsdialog.row > table.sidebar.jsdialog.ui-grid {
@@ -276,6 +276,7 @@ td.jsdialog .jsdialog.cell.sidebar {
 }
 
 #orientationcontrol,
+#rotation,
 #misc_label {
 	visibility: hidden;
 	height: 16px;
@@ -303,7 +304,7 @@ button#button2.ui-pushbutton.jsdialog.sidebar {
 	left: -10px;
 }
 
-#writedirection, #backgroundcolor, #table-indentfieldbox * {
+#writedirection, #backgroundcolor {
 	justify-content: end;
 	margin-right: 0;
 }


### PR DESCRIPTION
Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I825900d31c4e6ac20d5b8946859c477f4eb026ea

first elements are always left align
![image](https://user-images.githubusercontent.com/8517736/144669529-f4421354-f826-46d8-a4ae-1eaa1b5b11ed.png)

hide rotate setting cause it didn't work and the sizing isn't good
![image](https://user-images.githubusercontent.com/8517736/144669626-7682e00a-0a71-45bb-a672-689ff7871236.png)

fix dropdown element
![image](https://user-images.githubusercontent.com/8517736/144669752-82869722-89a7-4138-a020-ee3729c52164.png)
