### PR TITLE
Fix styles dropdown: make all styles searchable, remove one separator

### DIFF
--- a/browser/src/control/Control.TopToolbar.js
+++ b/browser/src/control/Control.TopToolbar.js
@@ -433,8 +433,6 @@ L.Control.TopToolbar = L.Control.extend({
 				return;
 			var commands = commandValues.Commands;
 			if (commands && commands.length > 0) {
-				// Inserts a separator element
-				data = data.concat({text: '\u2500\u2500\u2500\u2500\u2500\u2500', disabled: true});
 
 				commands.forEach(function (command) {
 					var translated = command.text;
@@ -447,7 +445,7 @@ L.Control.TopToolbar = L.Control.extend({
 			}
 
 			if (this.map.getDocType() === 'text') {
-				styles = commandValues.ParagraphStyles.slice(7, 19);
+				styles = commandValues.ParagraphStyles.slice(7);
 				topStyles = commandValues.ParagraphStyles.slice(0, 7);
 			}
 			else if (this.map.getDocType() === 'spreadsheet') {


### PR DESCRIPTION
Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I5f1809858c5aecdef04d9c736711dbb25c80afaa


* Resolves: #3764
* Target version: master 

### Summary
3 sections
1. section predefined styles
2. section favorite styles
3. section ALL available styles

As there is a search (compare to the sidebar) I listed all styles so the search result will find all styles that are available.
separator between predefined styles (default and clear) was removed to have less separations.

Fix is for writer (tested also for the other apps) maybe add favorites to the other apps to.