### PR TITLE
Toolbar Separators use the same color than sidebar separators

### DIFF
--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -121,6 +121,12 @@ w2ui-toolbar {
 	box-sizing: border-box;
 }
 
+.w2ui-toolbar .w2ui-break {
+	height: 18px;
+	background-image: none;
+	background-color: #f1f1f1;
+}
+
 /* For MS Edge 40, the select2 combo boxes need to have higher z-index than #map
  * Ideal would be to add the class to select2-container <span>, but
  * https://github.com/select2/select2/issues/285


### PR DESCRIPTION
Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I82aeae9f7cb2d6352546b39f3ed008fc19da3020

![image](https://user-images.githubusercontent.com/8517736/144719996-8d3075a5-b9ad-450a-bf66-2a38a15f24bd.png)
