### PR TITLE
Sidebar: Fix Split Button dropdown hover state

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -726,10 +726,16 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	width: 15px;
 	height: 23px;
 	display: inline-block;
+	border-left: 1px solid transparent;
 }
 
 .arrowbackground:hover {
-	border: 1px solid lightgrey;
+	border-left-color: var(--gray-color);
+	background-color: #eee;
+}
+
+.arrowbackground:hover .unoarrow {
+	border-top-color: #333;
 }
 
 /* menu button */


### PR DESCRIPTION
- Fix hover state: before, hovering into the arrow component would
	affect its parent's width
- Make it more visible that the dropdown has two action in it (it is a
	split button dropdown) by:
	- adding background color
	- adding divider, to emphasize that we are talking about two different
		btns
- Use CSS var instead of random gray

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I841749d143bcc240a1b4d820868b6a7af53db599
