### PR TITLE
private/ash/tests64

### DIFF
--- a/common/Unit.cpp
+++ b/common/Unit.cpp
@@ -172,7 +172,7 @@ bool UnitBase::isUnitTesting()
     return Global && Global->_dlHandle;
 }
 
-void UnitBase::setTimeout(int timeoutMilliSeconds)
+void UnitBase::setTimeout(std::chrono::milliseconds timeoutMilliSeconds)
 {
     assert(!TimeoutThreadRunning);
     _timeoutMilliSeconds = timeoutMilliSeconds;

--- a/common/Unit.cpp
+++ b/common/Unit.cpp
@@ -278,7 +278,8 @@ void UnitBase::timeout()
     // Don't timeout if we had already finished.
     if (isUnitTesting() && !_setRetValue)
     {
-        LOG_ERR(getTestname() << ": Timed out waiting for unit test to complete");
+        LOG_ERR(getTestname() << ": Timed out waiting for unit test to complete within "
+                              << _timeoutMilliSeconds);
         exitTest(TestResult::TimedOut);
     }
 }

--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <test/testlog.hpp>
 
 #include <atomic>
@@ -68,7 +69,7 @@ public:
 protected:
     // ---------------- Helper API ----------------
     /// After this time we invoke 'timeout' default 30 seconds
-    void setTimeout(int timeoutMilliSeconds);
+    void setTimeout(std::chrono::milliseconds timeoutMilliSeconds);
 
     enum class TestResult
     {
@@ -115,7 +116,7 @@ protected:
         : _dlHandle(nullptr)
         , _setRetValue(false)
         , _retValue(0)
-        , _timeoutMilliSeconds(30000)
+        , _timeoutMilliSeconds(std::chrono::seconds(30))
         , _type(type)
         , _testname(std::move(name))
         , _socketPoll(std::make_shared<SocketPoll>(_testname))
@@ -219,7 +220,7 @@ public:
 
     int getTimeoutMilliSeconds() const
     {
-        return _timeoutMilliSeconds;
+        return _timeoutMilliSeconds.count();
     }
 
     static UnitBase& get()
@@ -262,7 +263,7 @@ private:
     static char *UnitLibPath;
     bool _setRetValue;
     int _retValue;
-    int _timeoutMilliSeconds;
+    std::chrono::milliseconds _timeoutMilliSeconds;
     static UnitBase *Global;
     UnitType _type;
 

--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -434,4 +434,70 @@ public:
     }
 };
 
+/// Enum macro specifically for state-machines.
+/// Has several limitations, some intentional. For example,
+/// the states must have automatic, sequential, values.
+/// But also has some advantages, for example it can be used inside classes.
+/// Some ideas from https://stackoverflow.com/questions/28828957/enum-to-string-in-modern-c11-c14-c17-and-future-c20
+/// and from https://github.com/pfultz2/Cloak/wiki/C-Preprocessor-tricks,-tips,-and-idioms
+
+#define STRINGIFY(NAME, e) #NAME "::" #e,
+#define CONCAT(X, Y) X##Y
+#define CALL(X, ...) X(__VA_ARGS__)
+
+#define APPLY1(MACRO, NAME, e) MACRO(NAME, e)
+#define APPLY2(MACRO, NAME, e, ...) MACRO(NAME, e) APPLY1(MACRO, NAME, __VA_ARGS__)
+#define APPLY3(MACRO, NAME, e, ...) MACRO(NAME, e) APPLY2(MACRO, NAME, __VA_ARGS__)
+#define APPLY4(MACRO, NAME, e, ...) MACRO(NAME, e) APPLY3(MACRO, NAME, __VA_ARGS__)
+#define APPLY5(MACRO, NAME, e, ...) MACRO(NAME, e) APPLY4(MACRO, NAME, __VA_ARGS__)
+#define APPLY6(MACRO, NAME, e, ...) MACRO(NAME, e) APPLY5(MACRO, NAME, __VA_ARGS__)
+#define APPLY7(MACRO, NAME, e, ...) MACRO(NAME, e) APPLY6(MACRO, NAME, __VA_ARGS__)
+#define APPLY8(MACRO, NAME, e, ...) MACRO(NAME, e) APPLY7(MACRO, NAME, __VA_ARGS__)
+#define APPLY9(MACRO, NAME, e, ...) MACRO(NAME, e) APPLY8(MACRO, NAME, __VA_ARGS__)
+#define APPLY10(MACRO, NAME, e, ...) MACRO(NAME, e) APPLY9(MACRO, NAME, __VA_ARGS__)
+#define APPLY11(MACRO, NAME, e, ...) MACRO(NAME, e) APPLY10(MACRO, NAME, __VA_ARGS__)
+#define APPLY12(MACRO, NAME, e, ...) MACRO(NAME, e) APPLY11(MACRO, NAME, __VA_ARGS__)
+#define APPLY13(MACRO, NAME, e, ...) MACRO(NAME, e) APPLY12(MACRO, NAME, __VA_ARGS__)
+#define APPLY14(MACRO, NAME, e, ...) MACRO(NAME, e) APPLY13(MACRO, NAME, __VA_ARGS__)
+#define APPLY15(MACRO, NAME, e, ...) MACRO(NAME, e) APPLY14(MACRO, NAME, __VA_ARGS__)
+
+// Credit to Anton Bachin for this trick.
+#define GET_COUNT(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, c, ...) c
+#define COUNT_ARGS(...) GET_COUNT(__VA_ARGS__, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1)
+
+#define APPLY(MACRO, NAME, ...)                                                                    \
+    CALL(CONCAT, APPLY, COUNT_ARGS(__VA_ARGS__))(MACRO, NAME, __VA_ARGS__)
+#define FOR_EACH(MACRO, NAME, ...) APPLY(MACRO, NAME, __VA_ARGS__)
+
+/// Define a state-machine states, typically used to organize the phases
+/// of a multi-stage test.
+/// NAME is the name of the state enum, VAR is the name of the enum variable,
+/// followed by the names of the states.
+#define STATES_ENUM(NAME, VAR, ...)                                                                \
+    enum class NAME : char                                                                         \
+    {                                                                                              \
+        __VA_ARGS__                                                                                \
+    } VAR;                                                                                         \
+    static const char* toString(NAME e)                                                            \
+    {                                                                                              \
+        static const char* const NAME##_names[] = { FOR_EACH(STRINGIFY, NAME, __VA_ARGS__) };      \
+        assert(static_cast<unsigned>(e) < sizeof(NAME##_names) / sizeof(NAME##_names[0]) &&        \
+               "Enum value is out of range.");                                                     \
+        return NAME##_names[static_cast<int>(e)];                                                  \
+    }
+
+/// Transition the test state of VAR to STATE, with a prefix message, and resume the test.
+/// This will wake up all polls and the new state may be processed in parallel.
+#define TRANSITION_STATE_MSG(VAR, STATE, MSG)                                                      \
+    do                                                                                             \
+    {                                                                                              \
+        LOG_TST(MSG << " " << toString(VAR) << " -> " #STATE);                                     \
+        VAR = STATE;                                                                               \
+        SocketPoll::wakeupWorld();                                                                 \
+    } while (false)
+
+/// Transition the test state of VAR to STATE and resume the test.
+/// This will wake up all polls and the new state may be processed in parallel.
+#define TRANSITION_STATE(VAR, STATE) TRANSITION_STATE_MSG(VAR, STATE, "Transitioning from");
+
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -1266,6 +1266,29 @@ int main(int argc, char**argv)
         return std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::system_clock::now()).time_since_epoch().count();
     }
 
+    /// Convert a vector to a string. Useful for conversion in templates.
+    template <typename T> inline std::string toString(const T& x)
+    {
+        std::ostringstream oss;
+        oss << x;
+        return oss.str();
+    }
+
+    /// Convert a vector to a string. Useful for conversion in templates.
+    inline std::string toString(const std::vector<char>& x)
+    {
+        return std::string(x.data(), x.size());
+    }
+
+    /// No-op string conversion. Useful for conversion in templates.
+    inline std::string toString(const std::string& s) { return s; }
+
+    /// Create a string from a literal. Useful for conversion in templates.
+    template <std::size_t N> inline std::string toString(const char (&s)[N])
+    {
+        return std::string(s);
+    }
+
     /**
      * Constructs an object of type T and wraps it in a std::unique_ptr.
      *

--- a/configure.ac
+++ b/configure.ac
@@ -296,6 +296,10 @@ AC_ARG_WITH([sanitizer],
              AS_HELP_STRING([--with-sanitizer],
                            [Enable one or more compatible sanitizers. E.g. --with-sanitizer=address,undefined,leak]))
 
+AC_ARG_ENABLE([logging-test-asserts],
+                AS_HELP_STRING([--enable-logging-test-asserts],
+                            [Enable logging of passing test assertions.]))
+
 AC_ARG_WITH([compiler-plugins],
             AS_HELP_STRING([--with-compiler-plugins=<path>],
                 [Experimental! Unlikely to work for anyone except Noel! Enable compiler plugins that will perform additional checks during
@@ -352,6 +356,8 @@ LOOLWSD_ANONYMIZE_USER_DATA=false
 LOLEAFLET_LOGGING="false"
 debug_msg="secure mode: product build"
 anonym_msg=""
+LOK_LOG_ASSERTIONS=0
+log_asserts_msg="disabled"
 if test "$enable_debug" = "yes"; then
    AC_DEFINE([ENABLE_DEBUG],1,[Whether to compile in some extra debugging support code and disable some security pieces])
    ENABLE_DEBUG=true
@@ -363,6 +369,11 @@ if test "$enable_debug" = "yes"; then
    LOOLWSD_ANONYMIZE_USER_DATA=false
    LOLEAFLET_LOGGING="true"
    debug_msg="low security debugging mode"
+   if test "$enable_logging_test_asserts" != "no"; then
+      LOK_LOG_ASSERTIONS=1
+      log_asserts_msg="enabled"
+      AC_MSG_RESULT([Enabling logging of passing test assertions in debug build (default), override with --disable-logging-test-asserts])
+    fi
 else
     AC_DEFINE([ENABLE_DEBUG],0,[Whether to compile in some extra debugging support code and disable some security pieces])
 fi
@@ -401,6 +412,13 @@ if test "$enable_anonymization" = "yes" ; then
 fi
 AC_DEFINE_UNQUOTED([LOOLWSD_ANONYMIZE_USER_DATA],[$LOOLWSD_ANONYMIZE_USER_DATA],[Enable permanent anonymization in logs])
 AC_SUBST(LOOLWSD_ANONYMIZE_USER_DATA)
+
+if test "$enable_logging_test_asserts" = "yes" ; then
+   LOK_LOG_ASSERTIONS=1
+   log_asserts_msg="enabled"
+fi
+AC_DEFINE_UNQUOTED([LOK_LOG_ASSERTIONS],[$LOK_LOG_ASSERTIONS],[Enable logging of test assertions])
+AC_SUBST(LOK_LOG_ASSERTIONS)
 
 if test -z "$anonym_msg";  then
   anonym_msg="anonymization of user-data is disabled"
@@ -1422,15 +1440,16 @@ AS_IF([test "$ENABLE_IOSAPP" = "true"],
       [
        echo "
 Configuration:
-    LOKit path              ${lokit_msg}
-    LO path                 $LO_PATH
-    LO integration tests    ${lo_msg}
-    SSL support             $ssl_msg
-    Debug & low security    $debug_msg
-    Anonymization           $anonym_msg
-    Set capabilities        $setcap_msg
-    Browsersync             $browsersync_msg
-    cypress                 $cypress_msg
+    LOKit path                ${lokit_msg}
+    LO path                   $LO_PATH
+    LO integration tests      ${lo_msg}
+    SSL support               $ssl_msg
+    Debug & low security      $debug_msg
+    Test assertion logging    $log_asserts_msg
+    Anonymization             $anonym_msg
+    Set capabilities          $setcap_msg
+    Browsersync               $browsersync_msg
+    cypress                   $cypress_msg
 
     \$ make # to compile"
 if test -n "$with_lo_path"; then

--- a/test/UnitAdmin.cpp
+++ b/test/UnitAdmin.cpp
@@ -406,7 +406,7 @@ public:
     UnitAdmin()
         : _uri(helpers::getTestServerURI() + "/loleaflet/dist/admin/admin.html")
     {
-        setTimeout(60 * 1000);
+        setTimeout(std::chrono::minutes(60));
 
         // Register tests here.
         _tests.push_back(&UnitAdmin::testIncorrectPassword);

--- a/test/UnitClient.cpp
+++ b/test/UnitClient.cpp
@@ -28,8 +28,7 @@ public:
         : UnitWSD("UnitClient")
         , _workerStarted(false)
     {
-        int timeout_minutes = 5;
-        setTimeout(timeout_minutes * 60 * 1000);
+        setTimeout(std::chrono::minutes(5));
     }
     ~UnitClient()
     {

--- a/test/UnitClose.cpp
+++ b/test/UnitClose.cpp
@@ -212,8 +212,7 @@ UnitBase::TestResult UnitClose::testAlertAllUsers()
 
 UnitClose::UnitClose()
 {
-    int timeout_minutes = 2;
-    setTimeout(timeout_minutes * 60 * 1000);
+    setTimeout(std::chrono::minutes(2));
 }
 
 void UnitClose::invokeWSDTest()

--- a/test/UnitConvert.cpp
+++ b/test/UnitConvert.cpp
@@ -36,7 +36,7 @@ public:
         _workerStarted(false)
     {
         setHasKitHooks();
-        setTimeout(3600 * 1000); /* one hour */
+        setTimeout(std::chrono::hours(1));
     }
     ~UnitConvert()
     {
@@ -112,7 +112,7 @@ class UnitKitConvert : public UnitKit
 public:
     UnitKitConvert()
     {
-        setTimeout(3600 * 1000); /* one hour */
+        setTimeout(std::chrono::hours(1));
     }
 };
 

--- a/test/UnitEachView.cpp
+++ b/test/UnitEachView.cpp
@@ -162,7 +162,7 @@ UnitBase::TestResult UnitEachView::testGraphicViewSelectionImpress()
 UnitEachView::UnitEachView()
 {
     // 8 times larger then the default.
-    setTimeout(240 * 1000);
+    setTimeout(std::chrono::seconds(30 * 8));
 }
 
 void UnitEachView::invokeWSDTest()

--- a/test/UnitFuzz.cpp
+++ b/test/UnitFuzz.cpp
@@ -33,7 +33,7 @@ public:
     {
         std::cerr << "\n\nYour WSD process is being randomly fuzzed\n\n\n";
         setHasKitHooks();
-        setTimeout(3600 * 1000); /* one hour */
+        setTimeout(std::chrono::hours(1));
     }
 
     std::string corruptString(const std::string &str)
@@ -123,7 +123,7 @@ public:
     UnitKitFuzz()
     {
         std::cerr << "\n\nYour KIT process has fuzzing hooks\n\n\n";
-        setTimeout(3600 * 1000); /* one hour */
+        setTimeout(std::chrono::hours(1));
     }
     virtual bool filterKitMessage(WebSocketHandler *, std::string & /* message */) override
     {

--- a/test/UnitInsertDelete.cpp
+++ b/test/UnitInsertDelete.cpp
@@ -5,6 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include <chrono>
 #include <config.h>
 
 #include <memory>
@@ -205,18 +206,30 @@ UnitBase::TestResult UnitInsertDelete::testPasteBlank()
     try
     {
         // Load a document and make it empty, then paste nothing into it.
-        Poco::URI uri(helpers::getTestServerURI());
-        std::shared_ptr<LOOLWebSocket> socket
-            = helpers::loadDocAndGetSocket("hello.odt", uri, testname);
+        std::string documentPath, documentURL;
+        helpers::getDocumentPathAndURL("hello.odt", documentPath, documentURL, testname);
 
-        helpers::deleteAll(socket, testname);
+        std::shared_ptr<SocketPoll> socketPoll = std::make_shared<SocketPoll>(testname);
+
+        socketPoll->startThread();
+
+        std::shared_ptr<http::WebSocketSession> wsSession = helpers::loadDocAndGetSession(
+            socketPoll, Poco::URI(helpers::getTestServerURI()), documentURL, testname);
+
+        TST_LOG("deleteAll");
+        helpers::deleteAll(wsSession, testname, std::chrono::seconds(3));
 
         // Paste nothing into it.
-        helpers::sendTextFrame(socket, "paste mimetype=text/plain;charset=utf-8\n", testname);
+        TST_LOG("paste mimetype=text/plain;charset=utf-8");
+        helpers::sendTextFrame(wsSession, "paste mimetype=text/plain;charset=utf-8\n", testname);
 
         // Check if the document contains the pasted text.
-        const std::string selection = helpers::getAllText(socket, testname);
+        TST_LOG("getAllText");
+        const std::string selection = helpers::getAllText(wsSession, testname);
+        TST_LOG("getAllText => " << selection);
         LOK_ASSERT_EQUAL(std::string("textselectioncontent: "), selection);
+
+        socketPoll->joinThread();
     }
     catch (const Poco::Exception& exc)
     {
@@ -309,7 +322,9 @@ UnitBase::TestResult UnitInsertDelete::testCursorPosition()
 
 void UnitInsertDelete::invokeWSDTest()
 {
-    UnitBase::TestResult result = testInsertDelete();
+    UnitBase::TestResult result = TestResult::Ok;
+
+    result = testInsertDelete();
     if (result != TestResult::Ok)
         exitTest(result);
 

--- a/test/UnitLoadTorture.cpp
+++ b/test/UnitLoadTorture.cpp
@@ -209,8 +209,7 @@ UnitBase::TestResult UnitLoadTorture::testLoadTorture()
 UnitLoadTorture::UnitLoadTorture()
 {
     // Double of the default.
-    int timeout_minutes = 1;
-    setTimeout(timeout_minutes * 60 * 1000);
+    setTimeout(std::chrono::seconds(60));
 }
 
 void UnitLoadTorture::invokeWSDTest()

--- a/test/UnitPrefork.cpp
+++ b/test/UnitPrefork.cpp
@@ -22,7 +22,7 @@ public:
     UnitPrefork()
         : _childSockets(0)
     {
-        setTimeout(60 * 1000);
+        setTimeout(std::chrono::seconds(60));
     }
 
     virtual void configure(Poco::Util::LayeredConfiguration& config) override

--- a/test/UnitTimeout.cpp
+++ b/test/UnitTimeout.cpp
@@ -23,7 +23,7 @@ public:
     UnitTimeout()
         : _timedOut(false)
     {
-        setTimeout(10);
+        setTimeout(std::chrono::milliseconds(10));
     }
     virtual void timeout() override
     {

--- a/test/UnitTyping.cpp
+++ b/test/UnitTyping.cpp
@@ -33,8 +33,7 @@ public:
     UnitTyping() :
         _workerStarted(false)
     {
-        int timeout_minutes = 5;
-        setTimeout(timeout_minutes * 60 * 1000);
+        setTimeout(std::chrono::minutes(5));
     }
     ~UnitTyping()
     {

--- a/test/WopiTestServer.hpp
+++ b/test/WopiTestServer.hpp
@@ -293,8 +293,8 @@ protected:
                 const std::string body = "{\"LastModifiedTime\": \"" +
                                          Util::getIso8601FracformatTime(_fileLastModifiedTime) +
                                          "\" }";
-                LOG_TST("Fake wopi host response to POST " << uriReq.getPath() << ": 200 OK "
-                                                           << body);
+                LOG_TST("Fake wopi host (default) response to POST " << uriReq.getPath()
+                                                                     << ": 200 OK " << body);
                 http::Response httpResponse(http::StatusLine(200));
                 httpResponse.setBody(body);
                 socket->sendAndShutdown(httpResponse);
@@ -313,12 +313,13 @@ protected:
 
 };
 
-/// Send a command message to WSD from a WopiTestServer.
+/// Send a command message to WSD from a WopiTestServer and wake polls.
 #define WSD_CMD(MSG)                                                                               \
     do                                                                                             \
     {                                                                                              \
         LOG_TST("Sending: " << MSG);                                                               \
         helpers::sendTextFrame(*getWs()->getLOOLWebSocket(), MSG, getTestname());                  \
+        SocketPoll::wakeupWorld();                                                                 \
     } while (false)
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/test/WopiTestServer.hpp
+++ b/test/WopiTestServer.hpp
@@ -274,10 +274,10 @@ protected:
                 }
             }
 
-            std::streamsize size = request.getContentLength();
-            char buffer[size];
-            message.read(buffer, size);
-            setFileContent(std::string(buffer, size));
+            const std::streamsize size = request.getContentLength();
+            std::vector<char> buffer(size);
+            message.read(buffer.data(), size);
+            setFileContent(Util::toString(buffer));
 
             std::unique_ptr<http::Response> response = assertPutFileRequest(request);
             if (response)

--- a/test/WopiTestServer.hpp
+++ b/test/WopiTestServer.hpp
@@ -317,7 +317,7 @@ protected:
 #define WSD_CMD(MSG)                                                                               \
     do                                                                                             \
     {                                                                                              \
-        LOG_TST(": Sending: " << MSG);                                                             \
+        LOG_TST("Sending: " << MSG);                                                               \
         helpers::sendTextFrame(*getWs()->getLOOLWebSocket(), MSG, getTestname());                  \
     } while (false)
 

--- a/test/helpers.hpp
+++ b/test/helpers.hpp
@@ -1105,7 +1105,7 @@ inline void deleteAll(const std::shared_ptr<http::WebSocketSession>& ws,
                       std::chrono::milliseconds timeoutPerAttempt = std::chrono::seconds(10),
                       int repeat = COMMAND_RETRY_COUNT)
 {
-    selectAll(ws, testname);
+    selectAll(ws, testname, timeoutPerAttempt, repeat);
 
     sendAndWait(ws, testname, "uno .uno:Delete", "textselection:", timeoutPerAttempt, repeat);
 }

--- a/test/lokassert.hpp
+++ b/test/lokassert.hpp
@@ -66,6 +66,21 @@ std::string inline lokFormatAssertEq(const std::string& expected, const std::str
 #define LOK_ASSERT_IMPL(X)
 #endif //LOK_ABORT_ON_ASSERTION
 
+// When enabled, assertions that pass will be logged.
+// configure with --enable-logging-test-assert
+#if LOK_LOG_ASSERTIONS
+#define LOK_TRACE(X)                                                                               \
+    do                                                                                             \
+    {                                                                                              \
+        TST_LOG_NAME("unittest", X);                                                               \
+    } while (false)
+#else
+#define LOK_TRACE(X)                                                                               \
+    do                                                                                             \
+    {                                                                                              \
+    } while (false)
+#endif
+
 /// Assert the truth of a condition. WARNING: Multiple evaluations!
 #define LOK_ASSERT(condition)                                                                      \
     do                                                                                             \
@@ -76,6 +91,8 @@ std::string inline lokFormatAssertEq(const std::string& expected, const std::str
             LOK_ASSERT_IMPL(condition);                                                            \
             CPPUNIT_ASSERT(condition);                                                             \
         }                                                                                          \
+        else                                                                                       \
+            LOK_TRACE("PASS: " << (#condition));                                                   \
     } while (false)
 
 /// Assert the equality of two expressions. WARNING: Multiple evaluations!
@@ -99,6 +116,8 @@ std::string inline lokFormatAssertEq(const std::string& expected, const std::str
             LOK_ASSERT_IMPL((expected) == (actual));                                               \
             CPPUNIT_ASSERT_EQUAL_MESSAGE(msg##__LINE__, (expected), (actual));                     \
         }                                                                                          \
+        else                                                                                       \
+            LOK_TRACE("PASS: [" << (expected) << "] == [" << (actual) << ']');                     \
     } while (false)
 
 /// Assert the equality of two expressions, and a custom message, with guaranteed single evaluation.
@@ -131,17 +150,19 @@ std::string inline lokFormatAssertEq(const std::string& expected, const std::str
     {                                                                                              \
         if (!(condition))                                                                          \
         {                                                                                          \
-            TST_LOG_NAME("unittest", "ERROR: Assertion failure: " << (message) << ". Condition: "  \
-                                                                  << (#condition));                \
+            TST_LOG_NAME("unittest", "ERROR: Assertion failure: ["                                 \
+                                         << (message) << "] Condition: " << (#condition));         \
             LOK_ASSERT_IMPL(condition);                                                            \
             CPPUNIT_ASSERT_MESSAGE((message), (condition));                                        \
         }                                                                                          \
+        else                                                                                       \
+            LOK_TRACE("PASS: " << (#condition));                                                   \
     } while (false)
 
 #define LOK_ASSERT_FAIL(message)                                                                   \
     do                                                                                             \
     {                                                                                              \
         TST_LOG_NAME("unittest", "ERROR: Forced failure: " << (message));                          \
-        LOK_ASSERT_IMPL(!"Forced failure");                                                        \
+        LOK_ASSERT_IMPL(!"Forced failure: " #message);                                             \
         CPPUNIT_FAIL((message));                                                                   \
     } while (false)

--- a/test/lokassert.hpp
+++ b/test/lokassert.hpp
@@ -26,6 +26,40 @@ inline std::ostream& operator<<(std::ostream& os, const std::vector<char>& v)
     return os;
 }
 
+template <typename T, typename U>
+inline std::string lokFormatAssertEq(const T& expected, const U& actual)
+{
+    std::ostringstream oss;
+    oss << "Expected [" << (expected) << "] but got [" << (actual) << ']';
+    return oss.str();
+}
+
+template <>
+std::string inline lokFormatAssertEq(const std::string& expected, const std::string& actual)
+{
+    std::ostringstream oss;
+    oss << '\n';
+    oss << "Expected: [" << expected << "]\n";
+    oss << "Actual:   [" << actual << "]\n";
+    oss << "          [";
+
+    const auto minSize = std::min(expected.size(), actual.size());
+    for (std::size_t i = 0; i < minSize; ++i)
+    {
+        oss << (expected[i] == actual[i] ? ' ' : '^');
+    }
+
+    const auto maxSize = std::max(expected.size(), actual.size());
+    for (std::size_t i = minSize; i < maxSize; ++i)
+    {
+        oss << '^';
+    }
+
+    oss << "]\n";
+
+    return oss.str();
+}
+
 #ifdef LOK_ABORT_ON_ASSERTION
 #define LOK_ASSERT_IMPL(X) assert(X);
 #else
@@ -48,8 +82,8 @@ inline std::ostream& operator<<(std::ostream& os, const std::vector<char>& v)
     {                                                                                              \
         if (!((expected) == (actual)))                                                             \
         {                                                                                          \
-            TST_LOG_NAME("unittest", "ERROR: Assertion failure: Expected ["                        \
-                                         << (expected) << "] but got [" << (actual) << ']');       \
+            TST_LOG_NAME("unittest",                                                               \
+                         "ERROR: Assertion failure: " << lokFormatAssertEq(expected, actual));     \
             LOK_ASSERT_IMPL((expected) == (actual));                                               \
             CPPUNIT_ASSERT_EQUAL((expected), (actual));                                            \
         }                                                                                          \

--- a/test/testlog.hpp
+++ b/test/testlog.hpp
@@ -50,7 +50,7 @@ inline void tstLog(const std::ostringstream& stream) { writeTestLog(stream.str()
     do                                                                                             \
     {                                                                                              \
         char b_[1024];                                                                             \
-        OSS << Log::prefix<sizeof(b_) - 1>(b_, "TST") << NAME << " (+"                             \
+        OSS << Log::prefix<sizeof(b_) - 1>(b_, "TST") << NAME << " [" << __FUNCTION__ << "] (+"    \
             << helpers::timeSinceTestStartMs() << "): " << X;                                      \
         if (FLUSH)                                                                                 \
             tstLog(OSS);                                                                           \


### PR DESCRIPTION
- wsd: test: visual marker for mismatched strings in failed tests
- wsd: test: safer assertions without side-effects
- wsd: test: more informative string assertion in TileQueueTests
- wsd: test: support logging passing test assertions
- wsd: test: killpoco web-sockets in testHandshake
- wsd: test: use dynamic memory for large buffers
- wsd: test: use chrono
- wsd: test: better logging
- wsd: test: improved test state machine
- wsd: test: kill poco in pasteBlank
