### PR TITLE
common: introduce COOLProtocol::getNonNegTokenInteger()

### DIFF
--- a/common/Protocol.hpp
+++ b/common/Protocol.hpp
@@ -101,6 +101,13 @@ namespace COOLProtocol
         return false;
     }
 
+    /// Extracts a name and value from token. Returns true if value is a non-negative integer.
+    template <std::size_t N>
+    inline bool getNonNegTokenInteger(const std::string& token, const char (&name)[N], int& value)
+    {
+        return getTokenInteger(token, name, value) && value >= 0;
+    }
+
     inline bool getTokenString(const StringVector& tokens,
                                const std::string& name,
                                std::string& value)

--- a/wsd/TileCache.cpp
+++ b/wsd/TileCache.cpp
@@ -351,14 +351,10 @@ std::pair<int, Util::Rectangle> TileCache::parseInvalidateMsg(const std::string&
         int height = 0;
         if (tokens.size() == 6 &&
             getTokenInteger(tokens[1], "part", part) &&
-            getTokenInteger(tokens[2], "x", x) &&
-            x >= 0 &&
-            getTokenInteger(tokens[3], "y", y) &&
-            y >= 0 &&
-            getTokenInteger(tokens[4], "width", width) &&
-            width >= 0 &&
-            getTokenInteger(tokens[5], "height", height) &&
-            height >= 0)
+            getNonNegTokenInteger(tokens[2], "x", x) &&
+            getNonNegTokenInteger(tokens[3], "y", y) &&
+            getNonNegTokenInteger(tokens[4], "width", width) &&
+            getNonNegTokenInteger(tokens[5], "height", height))
         {
             return std::pair<int, Util::Rectangle>(part, Util::Rectangle(x, y, width, height));
         }


### PR DESCRIPTION
To simplify code that wants to extract a non-negative number from a
token value. See
<https://github.com/CollaboraOnline/online/pull/3788#pullrequestreview-826099897>.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I389dfa1a2838e501fc308dbfd7927b142a361922
