### PR TITLE
MobileWizard: avoid re-scaling ui-drawing-area

### DIFF
--- a/browser/css/mobilewizard.css
+++ b/browser/css/mobilewizard.css
@@ -1017,9 +1017,8 @@ input[type='checkbox'][disabled] {
 	width: 30% !important;
 }
 
-.mobile-wizard.ui-drawing-area {
+.mobile-wizard .ui-drawing-area-container:not(:only-of-type) .ui-drawing-area {
 	margin: 10px 5% !important;
-	width: 90%;
 }
 
 #TableEditPanel + .ui-content #misc_label.mobile-wizard {


### PR DESCRIPTION
Drawing areas such as those found in impress lists: chart type or slide
layout were being downsized and thus blurriness was evident.
-> Remove old CSS rule that does not serve any purpose now and fix that.

Top level drawing areas (where the whole panel is occupied by it:
slide layout) were being set with wrong position (not center
aligned).
-> Always aligned to the center without extra margins that, otherwise
would offset them

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: If4f4057cffb566026374d4d2e725dc663ff6f3e5
