### PR TITLE
browser: fix 'rulerupdate:' missing message

### DIFF
--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -77,7 +77,7 @@ app.definitions.Socket = L.Class.extend({
 	_emptyQueue: function () {
 		if (window.queueMsg && window.queueMsg.length > 0) {
 			for (var it = 0; it < window.queueMsg.length; it++) {
-				this._onMessage({data: window.queueMsg[it], textMsg: window.queueMsg[it]});
+				this._slurpMessage({data: window.queueMsg[it], textMsg: window.queueMsg[it]});
 			}
 			window.queueMsg = [];
 		}


### PR DESCRIPTION
Otherwise, the 'rulerupdate:' message, it never processed
and the ruler show like an empty box.

Change-Id: Ibe0e76e3615c2c9460aba65dbe76fbad51e9bf42
