### PR TITLE
Fix a CodeQL problem

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -79,6 +79,7 @@ jobs:
         tar xvf core-co-2021-assets.tar.gz && rm core-co-2021-assets.tar.gz && export LOCOREPATH=$(pwd)
         cd online && ./autogen.sh
         ./configure --enable-silent-rules --with-lokit-path=${LOCOREPATH}/include --with-lo-path=${LOCOREPATH}/instdir --enable-debug --disable-setcap
+        cd browser && npm update
 
     - if: matrix.language == 'cpp'
       name: Build


### PR DESCRIPTION
It was complaining:

npm WARN tarball tarball data for
vex-js@file:/home/runner/work/online/online/browser/archived-packages/vex-js-4.1.0-9ff760927.tar
(sha512-t8cpwh28HrmrkcqqvFTJl+xjLuPnusW3Eb3zczPm2RzX0Q8HbjHiywq1+ttQL+tLVob80CaQYOmmFY8rhtPEug==
sha512-n/dgknlD5CVl+Bn87kARnjwSknxZvSMflwzrBdgV0LLdLXpgmF6AKQ//bEEBBwK2JLXR0wG2R+il1zjcBtOi6Q==)
seems to be corrupted. Trying again.

npm WARN old lockfile Error:
sha512-t8cpwh28HrmrkcqqvFTJl+xjLuPnusW3Eb3zczPm2RzX0Q8HbjHiywq1+ttQL+tLVob80CaQYOmmFY8rhtPEug==
sha512-n/dgknlD5CVl+Bn87kARnjwSknxZvSMflwzrBdgV0LLdLXpgmF6AKQ//bEEBBwK2JLXR0wG2R+il1zjcBtOi6Q==
integrity checksum failed when using sha512: wanted
sha512-t8cpwh28HrmrkcqqvFTJl+xjLuPnusW3Eb3zczPm2RzX0Q8HbjHiywq1+ttQL+tLVob80CaQYOmmFY8rhtPEug==,sha512-n/dgknlD5CVl+Bn87kARnjwSknxZvSMflwzrBdgV0LLdLXpgmF6AKQ//bEEBBwK2JLXR0wG2R+il1zjcBtOi6Q==
but got
sha512-dCY//NzVfd5UmSGVLyoaIYEhZgeB8i3UoK/Ji4PfIf3OQnGs+BElehb1oYt00Gzr5XUkLv7bsHvQcGmQXdLteg==.
(2689536 bytes)

Signed-off-by: Jan Holesovsky <kendy@collabora.com>
Change-Id: Ifb81de8e3f7d8cec5117ee68f38dbe635f9109ed
