### PR TITLE
support for a custom path to NSS certdb files for sign/encrypt

### DIFF
--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -159,6 +159,10 @@
       <enable_metrics_unauthenticated desc="When enabled, the /cool/getMetrics endpoint will not require authentication." type="bool" default="false">false</enable_metrics_unauthenticated>
     </security>
 
+    <certificates>
+      <database_path type="string" desc="Path to the NSS certificates that are used for signing documents" default=""></database_path>
+    </certificates>
+
     <watermark>
       <opacity desc="Opacity of on-screen watermark from 0.0 to 1.0" type="double" default="0.2"></opacity>
       <text desc="Watermark text to be displayed on the document if entered" type="string"></text>

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -1097,6 +1097,7 @@ void COOLWSD::innerInitialize(Application& self)
             { "security.seccomp", "true" },
             { "security.jwt_expiry_secs", "1800" },
             { "security.enable_metrics_unauthenticated", "false" },
+            { "certificates.database_path", "" },
             { "server_name", "" },
             { "ssl.ca_file_path", COOLWSD_CONFIGDIR "/ca-chain.cert.pem" },
             { "ssl.cert_file_path", COOLWSD_CONFIGDIR "/cert.pem" },


### PR DESCRIPTION
The path of the NSS certdb is defined in the coolwsd.xml config
file and if the config file is set and contains the certdb files,
then the db files are copied to the jail into /tmp/certdb folder.
Also the /tmp/certdb path is set to LO_CERTIFICATE_DATABASE_PATH
env. var, which is then used as the default certdb in LibreOffice
when LOKit starts up.

Signed-off-by: Tomaž Vajngerl <tomaz.vajngerl@collabora.co.uk>
Change-Id: I72e8f28f27a0306fef9319bc6212cd99cb3f8212


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

