### PR TITLE
fix double encoding url on convert-to

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -2212,6 +2212,7 @@ bool ChildSession::saveAs(const char* /*buffer*/, int /*length*/, const StringVe
 
     // if the url is a 'wopi:///something/blah.odt', then save to a temporary
     Poco::URI wopiURL(url);
+    bool encodeURL = false;
     if (wopiURL.getScheme() == "wopi")
     {
         std::vector<std::string> pathSegments;
@@ -2233,6 +2234,9 @@ bool ChildSession::saveAs(const char* /*buffer*/, int /*length*/, const StringVe
         const std::string tmpDir = FileUtil::createRandomDir(jailDoc);
         const Poco::Path filenameParam(pathSegments[pathSegments.size() - 1]);
         url = std::string("file://") + jailDoc + tmpDir + "/" + filenameParam.getFileName();
+        // url becomes decoded at this stage
+        // on saveAs we should send encoded!
+        encodeURL = true;
         wopiFilename = wopiURL.getPath();
     }
 
@@ -2264,8 +2268,14 @@ bool ChildSession::saveAs(const char* /*buffer*/, int /*length*/, const StringVe
 
     getLOKitDocument()->setView(_viewId);
 
-    std::string encodedURL, encodedWopiFilename;
-    Poco::URI::encode(url, "", encodedURL);
+    std::string encodedURL;
+    if (encodeURL)
+        Poco::URI::encode(url, "", encodedURL);
+    else
+        // url is already encoded
+        encodedURL = url;
+
+    std::string encodedWopiFilename;
     Poco::URI::encode(wopiFilename, "", encodedWopiFilename);
 
     success = getLOKitDocument()->saveAs(encodedURL.c_str(),


### PR DESCRIPTION
Problem is, all save-as requests received urlencoded
but when it is a wopi request we change the url bit of the message
with correct path jail filename parts. At that stage it becomes decoded
already. saveAs in the core also decodes the url and thats why we should
re-encode it. But unless it is a wopi request it should be already
encoded and we should not re-encode it again.

Signed-off-by: Mert Tumer <mert.tumer@collabora.com>
Change-Id: I08b3a1cff6c3aa9271222c255f4a35aa5b984819


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

