### PR TITLE
unit test for save-as files with encoding characters in the name

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -21,7 +21,7 @@ noinst_LTLIBRARIES = \
 	unit-timeout.la unit-prefork.la unit-storage.la \
 	unit-admin.la unit-tilecache.la \
 	unit-fuzz.la unit-oob.la unit-http.la unit-oauth.la \
-	unit-wopi.la unit-wopi-saveas.la \
+	unit-wopi.la unit-wopi-saveas.la unit-wopi-saveas-with-encoded-file-name.la \
 	unit-wopi-async-upload-close.la unit-wopi-async-upload-modify.la \
 	unit-wopi-async-upload-modifyclose.la \
 	unit-wopi-ownertermination.la unit-wopi-versionrestore.la \
@@ -165,6 +165,8 @@ unit_wopi_async_upload_modifyclose_la_SOURCES = UnitWOPIAsyncUpload_ModifyClose.
 unit_wopi_async_upload_modifyclose_la_LIBADD = $(CPPUNIT_LIBS)
 unit_wopi_saveas_la_SOURCES = UnitWOPISaveAs.cpp
 unit_wopi_saveas_la_LIBADD = $(CPPUNIT_LIBS)
+unit_wopi_saveas_with_encoded_file_name_la_SOURCES = UnitWOPISaveAsWithEncodedFileName.cpp
+unit_wopi_saveas_with_encoded_file_name_la_LIBADD = $(CPPUNIT_LIBS)
 unit_wopi_ownertermination_la_SOURCES = UnitWopiOwnertermination.cpp
 unit_wopi_ownertermination_la_LIBADD = $(CPPUNIT_LIBS)
 unit_wopi_versionrestore_la_SOURCES = UnitWOPIVersionRestore.cpp
@@ -244,7 +246,7 @@ TESTS = \
 	unit-base.la unit-tiletest.la \
 	unit-integration.la unit-httpws.la unit-crash.la \
 	unit-copy-paste.la unit-typing.la unit-convert.la unit-prefork.la unit-tilecache.la unit-timeout.la \
-	unit-oauth.la unit-wopi.la unit-wopi-saveas.la \
+	unit-oauth.la unit-wopi.la unit-wopi-saveas.la unit-wopi-saveas-with-encoded-file-name.la \
 	unit-wopi-async-upload-close.la unit-wopi-async-upload-modify.la \
 	unit-wopi-async-upload-modifyclose.la \
 	unit-wopi-ownertermination.la unit-wopi-versionrestore.la \

--- a/test/UnitWOPISaveAsWithEncodedFileName.cpp
+++ b/test/UnitWOPISaveAsWithEncodedFileName.cpp
@@ -1,0 +1,94 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <config.h>
+
+#include <WopiTestServer.hpp>
+#include <Log.hpp>
+#include <Unit.hpp>
+#include <UnitHTTP.hpp>
+#include <helpers.hpp>
+#include <Poco/Net/HTTPRequest.h>
+#include <Poco/Util/LayeredConfiguration.h>
+
+class UnitWOPISaveAsWithEncodedFileName : public WopiTestServer
+{
+    enum class Phase
+    {
+        LoadAndSaveAs,
+        Polling
+    } _phase;
+
+public:
+    UnitWOPISaveAsWithEncodedFileName()
+        : WopiTestServer("UnitWOPISaveAsWithEncodedFileName")
+        , _phase(Phase::LoadAndSaveAs)
+    {
+    }
+
+    void assertPutRelativeFileRequest(const Poco::Net::HTTPRequest& request) override
+    {
+        // spec says UTF-7...
+        LOK_ASSERT_EQUAL(std::string("/path/to/hello+ACU-20world.pdf"), request.get("X-WOPI-SuggestedTarget"));
+
+        // make sure it is a pdf - or at least that it is larger than what it
+        // used to be
+        LOK_ASSERT(std::stoul(request.get("X-WOPI-Size")) > getFileContent().size());
+    }
+
+    bool onFilterSendMessage(const char* data, const std::size_t len, const WSOpCode /* code */,
+                             const bool /* flush */, int& /*unitReturn*/) override
+    {
+        const std::string message(data, len);
+
+        if (message.find("saveas: url=") != std::string::npos &&
+            message.find(helpers::getTestServerURI()) != std::string::npos &&
+            message.find("filename=hello%20world%251.pdf") != std::string::npos)
+        {
+            // successfully exit the test if we also got the outgoing message
+            // notifying about saving the file
+            exitTest(TestResult::Ok);
+        }
+
+        return false;
+    }
+
+    void invokeWSDTest() override
+    {
+        constexpr char testName[] = "UnitWOPISaveAsWithEncodedFilename";
+
+        switch (_phase)
+        {
+            case Phase::LoadAndSaveAs:
+            {
+                initWebsocket("/wopi/files/0?access_token=anything");
+
+                helpers::sendTextFrame(*getWs()->getLOOLWebSocket(), "load url=" + getWopiSrc(), testName);
+
+                // file name we want to save as is = hello%20world.pdf -> it is not encoded! and in the end we must expect like this.
+                // we would send it encoded like hello%2520world.pdf
+                helpers::sendTextFrame(*getWs()->getLOOLWebSocket(), "saveas url=wopi:///path/to/hello%2520world.pdf", testName);
+                SocketPoll::wakeupWorld();
+
+                _phase = Phase::Polling;
+                break;
+            }
+            case Phase::Polling:
+            {
+                // just wait for the results
+                break;
+            }
+        }
+    }
+};
+
+UnitBase *unit_create_wsd(void)
+{
+    return new UnitWOPISaveAsWithEncodedFileName();
+}
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */


### PR DESCRIPTION
this test ensures that double encoded filenames are not a problem.
file names can already be encoded like a%20b and this was causing
problems and fixed with #3786

Signed-off-by: Mert Tumer <mert.tumer@collabora.com>
Change-Id: Ibaf0456f26c3a2e8d3c2863c2b925c7a5b9fc79c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

