### PR TITLE
Dont give option to saveas when UserCannotWriteRelative is true

### DIFF
--- a/loleaflet/src/control/Permission.js
+++ b/loleaflet/src/control/Permission.js
@@ -149,6 +149,13 @@ L.Map.include({
 			var fileName = this['wopi'].BaseFileName;
 			var extension = this._getFileExtension(fileName);
 			var extensionInfo = this.readonlyStartingFormats[extension];
+
+			var buttonList = [];
+			if (!this['wopi'].UserCanNotWriteRelative) {
+				buttonList.push($.extend({}, vex.dialog.buttons.YES, { text: _('Save as ODF format') }));
+			}
+			buttonList.push($.extend({}, vex.dialog.buttons.NO, { text: extensionInfo.canEdit ? _('Continue editing') : _('Continue read only')}));
+
 			vex.dialog.open({
 				message: _('This document may contain formatting or content that cannot be saved in the current file format.'),
 				overlayClosesOnClick: false,
@@ -160,10 +167,7 @@ L.Map.include({
 						this._proceedEditMode();
 					}
 				}, that),
-				buttons: [
-					$.extend({}, vex.dialog.buttons.YES, { text: _('Save as ODF format') }),
-					$.extend({}, vex.dialog.buttons.NO, { text: extensionInfo.canEdit ? _('Continue editing') : _('Continue read only')})
-				]
+				buttons: buttonList
 			});
 		} else {
 			this._proceedEditMode();


### PR DESCRIPTION
Signed-off-by: Mert Tumer <mert.tumer@collabora.com>
Change-Id: I0ab4d4b8a79cf2d96fb47874dc7962718d279bb6


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

