### PR TITLE
Backports and minor fixes

### DIFF
--- a/common/SigUtil.cpp
+++ b/common/SigUtil.cpp
@@ -60,13 +60,19 @@ namespace SigUtil
 
     void setTerminationFlag()
     {
+        // Set the forced-termination flag.
         TerminationFlag = true;
+#if !MOBILEAPP
+        // And request shutting down and wake-up the thread.
+        requestShutdown();
+#endif
     }
 
 #if MOBILEAPP
-    void resetTerminationFlag()
+    void resetTerminationFlags()
     {
         TerminationFlag = false;
+        ShutdownRequestFlag = false;
     }
 #endif
 #endif // !IOS

--- a/common/SigUtil.hpp
+++ b/common/SigUtil.hpp
@@ -21,12 +21,12 @@ namespace SigUtil
     /// Get the flag to stop pump loops forcefully.
     /// If this returns true, getShutdownRequestFlag() must also return true.
     bool getTerminationFlag();
-    /// Set the flag to stop pump loops forcefully.
+    /// Set the flag to stop pump loops forcefully and request shutting down.
     void setTerminationFlag();
 #if MOBILEAPP
-    /// Reset the flag to stop pump loops forcefully.
+    /// Reset the flags to stop pump loops forcefully.
     /// Only necessary in Mobile.
-    void resetTerminationFlag();
+    void resetTerminationFlags();
 #endif
 #else
     // In the mobile apps we have no need to shut down the app.

--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -462,6 +462,13 @@ namespace Util
         return false;
     }
 
+    /// Return true iff s ends with t.
+    inline bool endsWith(const std::string& s, const std::string& t)
+    {
+        return s.length() >= t.length() &&
+               memcmp(s.c_str() + s.length() - t.length(), t.c_str(), t.length()) == 0;
+    }
+
     /// Tokenize delimited values until we hit new-line or the end.
     inline void tokenize(const char* data, const std::size_t size, const char delimiter,
                          std::vector<StringToken>& tokens)

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -1372,7 +1372,9 @@ bool ChildSession::keyEvent(const char* /*buffer*/, int /*length*/,
                             const StringVector& tokens,
                             const LokEventTargetEnum target)
 {
-    int type, charcode, keycode;
+    int type = 0;
+    int charcode = 0;
+    int keycode = 0;
     unsigned winId = 0;
     unsigned counter = 1;
     unsigned expectedTokens = 4; // cmdname(key), type, char, key are strictly required
@@ -2337,8 +2339,8 @@ bool ChildSession::setClientPart(const char* /*buffer*/, int /*length*/, const S
 
 bool ChildSession::selectClientPart(const char* /*buffer*/, int /*length*/, const StringVector& tokens)
 {
-    int nPart;
-    int nSelect;
+    int nPart = 0;
+    int nSelect = 0;
     if (tokens.size() < 3 ||
         !getTokenInteger(tokens[1], "part", nPart) ||
         !getTokenInteger(tokens[2], "how", nSelect))
@@ -2371,7 +2373,7 @@ bool ChildSession::selectClientPart(const char* /*buffer*/, int /*length*/, cons
 
 bool ChildSession::moveSelectedClientParts(const char* /*buffer*/, int /*length*/, const StringVector& tokens)
 {
-    int nPosition;
+    int nPosition = 0;
     if (tokens.size() < 2 ||
         !getTokenInteger(tokens[1], "position", nPosition))
     {

--- a/test/WhiteBoxTests.cpp
+++ b/test/WhiteBoxTests.cpp
@@ -2024,6 +2024,14 @@ void WhiteBoxTests::testStringCompare()
     LOK_ASSERT(!Util::iequal("abc", "abcd"));
 
     LOK_ASSERT(!Util::iequal("abc", 3, "abcd", 4));
+
+    LOK_ASSERT(!Util::startsWith("abc", "abcd"));
+    LOK_ASSERT(Util::startsWith("abcd", "abc"));
+    LOK_ASSERT(Util::startsWith("abcd", "abcd"));
+
+    LOK_ASSERT(!Util::endsWith("abc", "abcd"));
+    LOK_ASSERT(Util::endsWith("abcd", "bcd"));
+    LOK_ASSERT(Util::endsWith("abcd", "abcd"));
 }
 
 void WhiteBoxTests::testParseUri()

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -4420,7 +4420,7 @@ void LOOLWSD::cleanup()
 int LOOLWSD::main(const std::vector<std::string>& /*args*/)
 {
 #if MOBILEAPP && !defined IOS
-    SigUtil::resetTerminationFlag();
+    SigUtil::resetTerminationFlags();
 #endif
 
     int returnValue;

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -4385,11 +4385,16 @@ int LOOLWSD::innerMain()
     JailUtil::cleanupJails(ChildRoot);
 #endif // !MOBILEAPP
 
+    int returnValue = EX_OK;
+    UnitWSD::get().returnValue(returnValue);
+
+    LOG_INF("Process [loolwsd] finished with exit status: " << returnValue);
+
     // At least on centos7, Poco deadlocks while
     // cleaning up its SSL context singleton.
-    Util::forcedExit(EX_OK);
+    Util::forcedExit(returnValue);
 
-    return EX_OK;
+    return returnValue;
 }
 
 void LOOLWSD::cleanup()

--- a/wsd/TileCache.cpp
+++ b/wsd/TileCache.cpp
@@ -249,6 +249,8 @@ bool TileCache::getTextStream(StreamType type, const std::string& fileName, std:
     Tile textStream = lookupCachedStream(type, fileName);
     if (!textStream)
     {
+        // This is not an error because the first time
+        // we lookup a file, it won't be in the cache.
         LOG_INF("Could not open " << fileName);
         return false;
     }


### PR DESCRIPTION
- wsd: Termination flag requires having ShutdownRequested
- wsd: fix 'potentially uninitialized' variables
- wsd: cache misses are not errors
- wsd: add endsWith helper with tests
- wsd: correct use the exit code from UnitWSD
