### PR TITLE
Mobile: Replace lc_viewcomment with lc_mobile_comment_wizzard

### DIFF
--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -903,7 +903,7 @@ button.leaflet-control-search-next
 .w2ui-icon.fullscreen-presentation{ background: url('images/lc_fullscreen-presentation-toolbar-mobile.svg') no-repeat center !important;}
 .w2ui-icon.mobile_comment_wizard{ background: url('images/lc_mobile_comment_wizard.svg') no-repeat center !important; }
 .w2ui-icon.insertion_mobile_wizard{ background: url('images/lc_insertion_mobile_wizard.svg') no-repeat center !important; }
-.w2ui-icon.viewcomments{ background: url('images/lc_viewcomment.svg') no-repeat center !important; }
+.w2ui-icon.viewcomments{ background: url('images/lc_mobile_comment_wizard.svg') no-repeat center !important; }
 .w2ui-icon.insertcomment{ background: url('images/lc_insertcomment.svg') no-repeat center !important; }
 .w2ui-icon.freezepanes{ background: url('images/lc_freezepanes.svg') no-repeat center !important; }
 .w2ui-icon.freezepanescolumn{ background: url('images/lc_freezepanescolumn.svg') no-repeat center !important; }


### PR DESCRIPTION
lc_viewcomment was used ONLY at MobileTopBar and there
all other icons are monochrome. So this request suggest
to use the monochrome mobile specific comment icon.

As click on the viewcomments starts also the comment wizard,
the old icon wasn't the correct one.

Second option would be to add the mobile icon at toolbar-mobile.css
but as the command wasn't used anywhere else. The correct icon
can be used already in toolbar.css.

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I750a9a7f0eb3dbfc466e6a36ce2e4ad998811023