### PR TITLE
Mobile: Comments: Fix empty state's height

### DIFF
--- a/browser/css/mobilewizard.css
+++ b/browser/css/mobilewizard.css
@@ -1110,6 +1110,15 @@ input[type='checkbox'][disabled] {
 	grid-row: 1;
 }
 
+#mobile-wizard-content.content-has-no-comments {
+	height: calc(100% - 48px);
+	min-height: auto;
+}
+
+#mobile-wizard-content.content-has-no-comments #mobile-wizard-scroll-indicator {
+	display: none;
+}
+
 #mobile-wizard-popup .empty-comment-wizard-container,
 #mobile-wizard .empty-comment-wizard-container {
 	height: 100%;

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2178,6 +2178,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 	},
 
 	_emptyCommentWizard: function(parentContainer, data, builder) {
+		L.DomUtil.addClass(parentContainer, 'content-has-no-comments');
 		var emptyCommentWizard = L.DomUtil.create('figure', 'empty-comment-wizard-container', parentContainer);
 		var imgNode = L.DomUtil.create('img', 'empty-comment-wizard-img', emptyCommentWizard);
 		imgNode.src = L.LOUtil.getImageURL('lc_showannotations.svg');


### PR DESCRIPTION
Before we were not passing any additional class to mobile-wizard-content
as a result and, even thought child elements were set to 100% height,
the empty state was still cropped. Pass additional class to parent and
make sure child is set to full height (minus header bar).

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I42013bfc9976edcf13680fe428484a086dcf1074
