### PR TITLE
Mobile: Fix BottomToolbar height

### DIFF
--- a/browser/css/device-mobile.css
+++ b/browser/css/device-mobile.css
@@ -385,9 +385,12 @@ button.vex-dialog-button-secondary.vex-dialog-button.vex-last {
 	padding: 0px !important;
 	border-top: 1px solid #bbbbbb !important;
 }
+#toolbar-search {
+	height: 39px !important;
+}
 #tb_actionbar_item_fullscreen{display: none;}
 #toolbar-down {
-	height: 35px !important;
+	height: 39px !important;
 	border-top: 1px solid var(--gray-color) !important;
 }
 #toolbar-down > .w2ui-scroll-wrapper {

--- a/cypress_test/integration_tests/mobile/writer/shape_properties_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/shape_properties_spec.js
@@ -4,7 +4,7 @@ var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
 
 describe('Change shape properties via mobile wizard.', function() {
-	const defaultStartPoint = [1953, 4875];
+	const defaultStartPoint = [1953, 4800];
 	const defaultBase = 5992;
 	const defaultAltitude = 5992;
 	const unitScale = 2540.37;


### PR DESCRIPTION
In master the toolbar height is smaler than a selected command
With this request the toolbar height has the same height
than a selected command at the bottom toolbar

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I147237b9a68730dc5a3655a752ee0231275b55e4

**BottomToolbar before**
![Screenshot_20211209_163915](https://user-images.githubusercontent.com/8517736/145428622-b22328ab-d74a-4d45-aafb-beb9f33a4646.png)

**BottomToolbar after**
![Screenshot_20211209_164320](https://user-images.githubusercontent.com/8517736/145428668-89f00f4b-add8-4b58-865f-eef14d40b4ba.png)

**BottomToolbar search after**
![Screenshot_20211209_164332](https://user-images.githubusercontent.com/8517736/145428735-55138b91-d2c0-41d4-8b34-4c8f7c0e0173.png)

