### PR TITLE
Try harder to get translation of keyboard shortcuts

### DIFF
--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -478,7 +478,17 @@ L.Map.include({
 				}
 				translatableContent = $vexContent.find('td');
 				for (i = 0, max = translatableContent.length; i < max; i++) {
-					translatableContent[i].innerHTML = translatableContent[i].innerHTML.toLocaleString();
+					var orig = translatableContent[i].innerHTML;
+					var trans = translatableContent[i].innerHTML.toLocaleString();
+					// Try harder to get translation of keyboard shortcuts (html2po trims starting <kbd> and ending </kbd>)
+					if (orig === trans && orig.indexOf('kbd') != -1) {
+						var trimmedOrig = orig.replace(/^(<kbd>)/,'').replace(/(<\/kbd>$)/,'');
+						var trimmedTrans = trimmedOrig.toLocaleString();
+						if (trimmedOrig !== trimmedTrans) {
+							trans = '<kbd>' + trimmedTrans + '</kbd>';
+						}
+					}
+					translatableContent[i].innerHTML = trans;
 				}
 				translatableContent = $vexContent.find('p');
 				for (i = 0, max = translatableContent.length; i < max; i++) {


### PR DESCRIPTION
html2po trims starting &lt;kbd&gt; and ending &lt;/kbd&gt;

Signed-off-by: Andras Timar <andras.timar@collabora.com>
Change-Id: Ia685cfe3bac301b991314c5108b688a20175dcea


