### PR TITLE
Calc Sidebar: Number Format Section Decimal places alignment

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -329,3 +329,12 @@ button#button2.ui-pushbutton.jsdialog.sidebar {
 .sidebar .spinfieldcontainer input {
 	width: calc(100% - 28px);
 }
+
+#NumberFormatPropertyPanel > tr:nth-child(1) > td:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2),
+#NumberFormatPropertyPanel > tr:nth-child(1) > td:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(1) > div:nth-child(1) > div:nth-child(1) {
+	display: none;
+}
+
+#NumberFormatPropertyPanel > tr:nth-child(1) > td:nth-child(1) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div:nth-child(1) {
+	padding: 0 4px 0 0;
+}


### PR DESCRIPTION
Check out Calc default Sidebar there is the Number Format section.
In the Decimal places group there are two div elements that should
be not displayed. With this PR the elements get property
display: none

In addition one line has a height of 44px in the sidebar
As the height is 52px the additional padding was removed

The result is that all rows in the sidebar are well aligned
and use a height of 44px.

Fix helps also NextCloud office.

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I813d3a270096a0cc3d8c0740b6ac346bd8e2564a

**result**
![image](https://user-images.githubusercontent.com/8517736/145475673-db4ca514-736f-40e7-82dc-74a5d56e75ff.png)
