### PR TITLE
Use correct formatting for string variables

### DIFF
--- a/browser/html/cool.html.m4
+++ b/browser/html/cool.html.m4
@@ -214,7 +214,7 @@ m4_ifelse(MOBILEAPP,[true],
 
     <!--%DOCUMENT_SIGNING_DIV%-->
     <script>
-      window.documentSigningURL = '%DOCUMENT_SIGNING_URL%';
+      window.documentSigningURL = decodeURIComponent('%DOCUMENT_SIGNING_URL%');
     </script>
 
     <input id="insertgraphic" aria-labelledby="menu-insertgraphic" type="file" accept="image/*" style="position: fixed; top: -100em">
@@ -315,7 +315,7 @@ m4_ifelse(MOBILEAPP,[true],
       window.outOfFocusTimeoutSecs = %OUT_OF_FOCUS_TIMEOUT_SECS%;
       window.idleTimeoutSecs = %IDLE_TIMEOUT_SECS%;
       window.protocolDebug = %PROTOCOL_DEBUG%;
-      window.frameAncestors = '%FRAME_ANCESTORS%';
+      window.frameAncestors = decodeURIComponent('%FRAME_ANCESTORS%');
       window.socketProxy = %SOCKET_PROXY%;
       window.tileSize = 256;
       window.uiDefaults = %UI_DEFAULTS%;])

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -705,6 +705,12 @@ void FileServerRequestHandler::handleRequest(const HTTPRequest& request,
         sendError(404, request, socket, "404 - file not found!",
                   "There seems to be a problem locating");
     }
+    catch (Poco::SyntaxException& exc)
+    {
+        LOG_ERR("Incorrect config value: " << exc.displayText());
+        sendError(500, request, socket, "500 - Internal Server Error!",
+                  "Cannot process the request");
+    }
 }
 
 void FileServerRequestHandler::sendError(int errorCode, const Poco::Net::HTTPRequest& request,
@@ -944,9 +950,8 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     Poco::replaceInPlace(preprocess, std::string("%POSTMESSAGE_ORIGIN%"), escapedPostmessageOrigin);
 
     const auto& config = Application::instance().config();
-    std::string protocolDebug = "false";
-    if (config.getBool("logging.protocol"))
-        protocolDebug = "true";
+
+    std::string protocolDebug = stringifyBoolFromConfig(config, "logging.protocol", false);
     Poco::replaceInPlace(preprocess, std::string("%PROTOCOL_DEBUG%"), protocolDebug);
 
     static const std::string hexifyEmbeddedUrls =
@@ -976,29 +981,27 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
 
     // Customization related to document signing.
     std::string documentSigningDiv;
+    std::string escapedDocumentSigningURL;
     const std::string documentSigningURL = config.getString("per_document.document_signing_url", "");
     if (!documentSigningURL.empty())
     {
         documentSigningDiv = "<div id=\"document-signing-bar\"></div>";
+        Poco::URI::encode(documentSigningURL, "'", escapedDocumentSigningURL);
     }
     Poco::replaceInPlace(preprocess, std::string("<!--%DOCUMENT_SIGNING_DIV%-->"), documentSigningDiv);
-    Poco::replaceInPlace(preprocess, std::string("%DOCUMENT_SIGNING_URL%"), documentSigningURL);
+    Poco::replaceInPlace(preprocess, std::string("%DOCUMENT_SIGNING_URL%"), escapedDocumentSigningURL);
 
-    const auto coolLogging = config.getString("browser_logging", "false");
+    const auto coolLogging = stringifyBoolFromConfig(config, "browser_logging", false);
     Poco::replaceInPlace(preprocess, std::string("%BROWSER_LOGGING%"), coolLogging);
-    const std::string outOfFocusTimeoutSecs= config.getString("per_view.out_of_focus_timeout_secs", "60");
-    Poco::replaceInPlace(preprocess, std::string("%OUT_OF_FOCUS_TIMEOUT_SECS%"), outOfFocusTimeoutSecs);
-    const std::string idleTimeoutSecs= config.getString("per_view.idle_timeout_secs", "900");
-    Poco::replaceInPlace(preprocess, std::string("%IDLE_TIMEOUT_SECS%"), idleTimeoutSecs);
+    const unsigned int outOfFocusTimeoutSecs = config.getUInt("per_view.out_of_focus_timeout_secs", 60);
+    Poco::replaceInPlace(preprocess, std::string("%OUT_OF_FOCUS_TIMEOUT_SECS%"), std::to_string(outOfFocusTimeoutSecs));
+    const unsigned int idleTimeoutSecs = config.getUInt("per_view.idle_timeout_secs", 900);
+    Poco::replaceInPlace(preprocess, std::string("%IDLE_TIMEOUT_SECS%"), std::to_string(idleTimeoutSecs));
 
-    std::string enableWelcomeMessage = "false";
-    if (config.getBool("welcome.enable", false))
-        enableWelcomeMessage = "true";
+    std::string enableWelcomeMessage = stringifyBoolFromConfig(config, "welcome.enable", false);
     Poco::replaceInPlace(preprocess, std::string("%ENABLE_WELCOME_MSG%"), enableWelcomeMessage);
 
-    std::string enableWelcomeMessageButton = "false";
-    if (config.getBool("welcome.enable_button", false))
-        enableWelcomeMessageButton = "true";
+    std::string enableWelcomeMessageButton = stringifyBoolFromConfig(config, "welcome.enable_button", false);
     Poco::replaceInPlace(preprocess, std::string("%ENABLE_WELCOME_MSG_BTN%"), enableWelcomeMessageButton);
 
     // the config value of 'notebookbar' or 'classic' overrides the UIMode
@@ -1014,9 +1017,7 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
 
     Poco::replaceInPlace(preprocess, std::string("%USER_INTERFACE_MODE%"), userInterfaceMode);
 
-    std::string enableMacrosExecution = "false";
-    if (config.getBool("security.enable_macros_execution", false))
-        enableMacrosExecution = "true";
+    std::string enableMacrosExecution = stringifyBoolFromConfig(config, "security.enable_macros_execution", false);
     Poco::replaceInPlace(preprocess, std::string("%ENABLE_MACROS_EXECUTION%"), enableMacrosExecution);
 
 #ifdef ENABLE_FEEDBACK
@@ -1075,7 +1076,9 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
         // frame anchestors are also allowed for img-src in order to load the views avatars
         cspOss << imgSrc << frameAncestors << "; "
                 << "frame-ancestors " << frameAncestors;
-        Poco::replaceInPlace(preprocess, std::string("%FRAME_ANCESTORS%"), frameAncestors);
+        std::string escapedFrameAncestors;
+        Poco::URI::encode(frameAncestors, "'", escapedFrameAncestors);
+        Poco::replaceInPlace(preprocess, std::string("%FRAME_ANCESTORS%"), escapedFrameAncestors);
     }
     else
     {

--- a/wsd/FileServer.hpp
+++ b/wsd/FileServer.hpp
@@ -11,6 +11,7 @@
 #include "Socket.hpp"
 
 #include <Poco/MemoryStream.h>
+#include <Poco/Util/LayeredConfiguration.h>
 
 class RequestDetails;
 /// Handles file requests over HTTP(S).
@@ -35,6 +36,10 @@ class FileServerRequestHandler
     static std::string uiDefaultsToJSON(const std::string& uiDefaults, std::string& uiMode);
 
     static std::string cssVarsToStyle(const std::string& cssVars);
+
+    static std::string stringifyBoolFromConfig(const Poco::Util::LayeredConfiguration& config,
+                                               std::string propertyName,
+                                               bool defaultValue);
 
 public:
     /// Evaluate if the cookie exists, and if not, ask for the credentials.

--- a/wsd/FileServerUtil.cpp
+++ b/wsd/FileServerUtil.cpp
@@ -173,4 +173,15 @@ std::string FileServerRequestHandler::cssVarsToStyle(const std::string& cssVars)
     return previousStyle;
 }
 
+std::string FileServerRequestHandler::stringifyBoolFromConfig(
+                                                const Poco::Util::LayeredConfiguration& config,
+                                                std::string propertyName,
+                                                bool defaultValue)
+{
+    std::string value = "false";
+    if (config.getBool(propertyName, defaultValue))
+        value = "true";
+    return value;
+}
+
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */


### PR DESCRIPTION
- when reading from config use correct type so SyntaxException
  is thrown when we type non-number into uint field
- handle SyntaxException and send 500 so user will get response
  (previously we left request without response until timeout)
- log about incorrect value in the config
- simplify repeated bool -> string conversion after config read

Signed-off-by: Szymon Kłos <szymon.klos@collabora.com>
Change-Id: I1c50de263ffdb1d97eb9381754bc7cf3bd05dbfa


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

