### PR TITLE
Document has been changed: set cancel btn on mobile to block

### DIFF
--- a/browser/css/device-mobile.css
+++ b/browser/css/device-mobile.css
@@ -363,7 +363,7 @@ button.vex-dialog-button-secondary.vex-dialog-button.vex-last {
 }
 
 .vex-content.vex-3btns .vex-dialog-buttons .vex-dialog-button-cancel {
-	display: flex !important;
+	display: block !important;
 }
 
 /* Related to toolbar.css */


### PR DESCRIPTION
Even though the on mobile the display set to flex seems to work
introduced with 95bd65d2f658ca8c378b50f4ff09ef1424c15c13
the fact is that we do not need flex here and it might cause different
unexpected results depending on the device

This commit is not needed on 6.4 (as it was already fixed while cherry
picking Document has been changed related commits)

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ib50d6fa9e1e456c3dfdceaae802c2fe1edad15a7
