### PR TITLE
support for a custom path to NSS certdb files for sign/encrypt

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -2339,6 +2339,50 @@ void wakeCallback(void* pData)
 
 #ifndef BUILDING_TESTS
 
+namespace
+{
+#if !MOBILEAPP
+void copyCertificateDatabaseToTmp(Poco::Path const& jailPath)
+{
+    std::string aCertificatePathString = config::getString("certificates.database_path", "");
+    if (!aCertificatePathString.empty())
+    {
+        auto aFileStat = FileUtil::Stat(aCertificatePathString);
+
+        if (!aFileStat.exists() || !aFileStat.isDirectory())
+        {
+            LOG_WRN("Certificate database wasn't copied into the jail as path '" << aCertificatePathString << "' doesn't exist");
+            return;
+        }
+
+        Poco::Path aCertificatePath(aCertificatePathString);
+
+        Poco::Path aJailedCertDBPath(jailPath, "/tmp/certdb");
+        Poco::File(aJailedCertDBPath).createDirectories();
+
+        bool bCopied = false;
+        for (const char* pFilename : { "cert8.db", "cert9.db", "secmod.db", "key3.db", "key4.db" })
+        {
+            bool bResult = FileUtil::copy(Poco::Path(aCertificatePath, pFilename).toString(),
+                                Poco::Path(aJailedCertDBPath, pFilename).toString(), false, false);
+            bCopied |= bResult;
+        }
+        if (bCopied)
+        {
+            LOG_INF("Certificate database files found in '" << aCertificatePathString << "' and were copied to the jail");
+            ::setenv("LO_CERTIFICATE_DATABASE_PATH", "/tmp/certdb", 1);
+        }
+        else
+        {
+            LOG_WRN("No Certificate database files could be found in path '" << aCertificatePathString << "'");
+        }
+    }
+}
+#endif
+}
+
+
+
 void lokit_main(
 #if !MOBILEAPP
                 const std::string& childRoot,
@@ -2517,6 +2561,8 @@ void lokit_main(
             // Setup the devices inside /tmp and set TMPDIR.
             JailUtil::setupJailDevNodes(Poco::Path(jailPath, "/tmp").toString());
             ::setenv("TMPDIR", "/tmp", 1);
+
+            copyCertificateDatabaseToTmp(jailPath);
 
             // HOME must be writable, so create it in /tmp.
             constexpr const char* HomePathInJail = "/tmp/home";

--- a/loolwsd.xml.in
+++ b/loolwsd.xml.in
@@ -148,6 +148,10 @@
       <enable_metrics_unauthenticated desc="When enabled, the /lool/getMetrics endpoint will not require authentication." type="bool" default="false">false</enable_metrics_unauthenticated>
     </security>
 
+    <certificates>
+      <database_path type="string" desc="Path to the NSS certificates that are used for signing documents" default=""></database_path>
+    </certificates>
+
     <watermark>
       <opacity desc="Opacity of on-screen watermark from 0.0 to 1.0" type="double" default="0.2"></opacity>
       <text desc="Watermark text to be displayed on the document if entered" type="string"></text>

--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -1009,6 +1009,7 @@ void LOOLWSD::initialize(Application& self)
             { "security.seccomp", "true" },
             { "security.jwt_expiry_secs", "1800" },
             { "security.enable_metrics_unauthenticated", "false" },
+            { "certificates.database_path", "" },
             { "server_name", "" },
             { "ssl.ca_file_path", LOOLWSD_CONFIGDIR "/ca-chain.cert.pem" },
             { "ssl.cert_file_path", LOOLWSD_CONFIGDIR "/cert.pem" },


### PR DESCRIPTION
The path of the NSS certdb is defined in the coolwsd.xml config
file and if the config file is set and contains the certdb files,
then the db files are copied to the jail into /tmp/certdb folder.
Also the /tmp/certdb path is set to LO_CERTIFICATE_DATABASE_PATH
env. var, which is then used as the default certdb in LibreOffice
when LOKit starts up.

Signed-off-by: Tomaž Vajngerl <tomaz.vajngerl@collabora.co.uk>
Change-Id: I72e8f28f27a0306fef9319bc6212cd99cb3f8212


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

