### PR TITLE
Fix for notebookbar-shortcuts-bar vertical alignment

### DIFF
--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -125,6 +125,10 @@
 	flex-direction: column;
 }
 
+.notebookbar-shortcuts-bar .cell.notebookbar {
+	padding: 0 2px;
+}
+
 #Save.savemodified:after {
 	content: '';
 	display: block;


### PR DESCRIPTION
Removes additional vertical padding that was conflicting with overall
vertical alignment (specially affecting hamburger icon but also save...)

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Iccfc308c689cd2f522709143fbbe692ec537a625
