### PR TITLE
Add missing highlight color to clear n paste Formatting

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -247,6 +247,8 @@ td.jsdialog .jsdialog.cell.sidebar {
 .hasnotebookbar .ui-content.unotoolbutton.selected:hover,
 .unotoolbutton.notebookbar:hover,
 .hasnotebookbar .ui-content.unotoolbutton.selected:not(.has-label):not(.inline):hover,
+#clearFormatting:hover,
+#FormatPaintbrush:hover,
 .sidebar.unotoolbutton:hover,
 .sidebar.unotoolbutton.selected:hover,
 .sidebar #resetattr:hover,


### PR DESCRIPTION
This complements the rework of highlights (mouse hover) from
b199fd0f8777afa002ad82e8cfb60bd95d1429c6 by adding the missing elmts

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I632470b088c7e8775849933b657583fc908f7bcc
