### PR TITLE
Sidebar/Paragraph Table selection vertical align commands new row

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -275,9 +275,8 @@ td.jsdialog .jsdialog.cell.sidebar {
 	left: -7px;
 }
 
-#table-verticalalignment {
-	position: relative;
-	top: 6px;
+#table-box1 > #box1 > div:nth-child(3) {
+	display: table-row;
 }
 
 #LB_SHADOW_COLOR, #LB_GLOW_COLOR {


### PR DESCRIPTION
BUG #3805

Vertical Alignment commands move to the next table-row
cause there is not enough space for 9 commands.

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I9455ec2d5a5990be2a17c9e7eac1320858ed5824


* Resolves: #3805
* Target version: master 

**Screenshot Result**
![image](https://user-images.githubusercontent.com/8517736/146467127-96e4342c-e825-401e-b097-a7e012160cc9.png)