### PR TITLE
Revert "Draw/Impress sidebar paragraph topalignment space"

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -121,6 +121,7 @@ div#thousandseparator.checkbutton.jsdialog.sidebar {
 	display: flex;
 	justify-content: flex-end;
 }
+
 .sidebar.ui-drawing-area {
 	max-width: 290px;
 }
@@ -273,11 +274,6 @@ td.jsdialog .jsdialog.cell.sidebar {
 	width: 160px;
 	position: relative;
 	left: -7px;
-}
-
-#table-verticalalignment {
-	position: relative;
-	top: 6px;
 }
 
 #LB_SHADOW_COLOR, #LB_GLOW_COLOR {


### PR DESCRIPTION
This reverts commit 27be41fb787762111cd1212524e3f3c48b4d8cb1 which introduce regression (align buttons in the sidebar calc overlap each other)

