### PR TITLE
browser: add file path tooltip

### DIFF
--- a/browser/src/control/Control.DocumentNameInput.js
+++ b/browser/src/control/Control.DocumentNameInput.js
@@ -3,7 +3,7 @@
  * L.Control.DocumentNameInput
  */
 
-/* global $ */
+/* global $ _ */
 L.Control.DocumentNameInput = L.Control.extend({
 
 	onAdd: function (map) {
@@ -69,21 +69,38 @@ L.Control.DocumentNameInput = L.Control.extend({
 	onDocLayerInit: function() {
 		this._setNameInputWidth();
 
+		var el = $('#document-name-input');
+
+		try {
+			var fileNameFullPath = new URL(
+				new URLSearchParams(window.location.search).get('WOPISrc')
+			)
+				.pathname
+				.replace('/wopi/files', '');
+			
+			var basePath = fileNameFullPath.replace(this.map['wopi'].BaseFileName , '').replace(/\/$/, '');
+			var title = this.map['wopi'].BaseFileName + '\n' + _('Path') + ': ' + basePath;
+
+			el.prop('title', title);
+		} catch (e) {
+			// purposely ignore the error for legacy browsers
+		}
+
 		// FIXME: Android app would display a temporary filename, not the actual filename
 		if (window.ThisIsTheAndroidApp) {
-			$('#document-name-input').hide();
+			el.hide();
 		} else {
-			$('#document-name-input').show();
+			el.show();
 		}
 
 		if (window.ThisIsAMobileApp) {
 			// We can now set the document name in the menu bar
-			$('#document-name-input').prop('disabled', false);
-			$('#document-name-input').removeClass('editable');
-			$('#document-name-input').focus(function() { $(this).blur(); });
+			el.prop('disabled', false);
+			el.removeClass('editable');
+			el.focus(function() { $(this).blur(); });
 			// Call decodeURIComponent twice: Reverse both our encoding and the encoding of
 			// the name in the file system.
-			$('#document-name-input').val(decodeURIComponent(decodeURIComponent(this.map.options.doc.replace(/.*\//, '')))
+			el.val(decodeURIComponent(decodeURIComponent(this.map.options.doc.replace(/.*\//, '')))
 							  // To conveniently see the initial visualViewport scale and size, un-comment the following line.
 							  // + ' (' + window.visualViewport.scale + '*' + window.visualViewport.width + 'x' + window.visualViewport.height + ')'
 							  // TODO: Yes, it would be better to see it change as you rotate the device or invoke Split View.


### PR DESCRIPTION
Signed-off-by: Alexandru Vlăduţu <alexandru.vladutu@1and1.ro>
Change-Id: Ie163ee479ee62d314248a8b891751a3755eca4ca


* Resolves: #3880
* Target version: master 

### Summary

Adds the file path as a title attribute so that it shows up as a tooltip when you mouse over the file name. It show up as the following:

```
File_name.extension
Path: Path/to/folder/containing/file
```

Added the translation for the most popular languages for 'Path': English, French, Spanish, Italian (bonus: Romanian).

### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

