### PR TITLE
Prefer "(no message)" etc to "[object Object]"

### DIFF
--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -88,7 +88,7 @@ window.app = { // Shouldn't have any functions defined.
 				line: row,
 				column: col
 			};
-			var desc = err ? err.message || {}: {}, stack = err ? err.stack || {}: {};
+			var desc = err ? err.message || '(no message)': '(no err)', stack = err ? err.stack || '(no stack)': '(no err)';
 			var log = 'jserror ' + JSON.stringify(data, null, 2) + '\n' + desc + '\n' + stack + '\n';
 			global.logServer(log);
 


### PR DESCRIPTION
At least for me, whenever I have seen the result of that code logged
in Xcode when debugging the iOS app, the lines for the "description"
and "stack" have said just "[object Object]". It is unclear whether
that is because the code explicitly assigns the empty object {} to the
desc and stack variables here, or because err.message and/or err.stack
do exist but are objects, not strings.

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: I08a2fa361baf20814a40249d30ff49ba39292aa6


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

