### PR TITLE
Sidebar Effect Section Color width fix

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -280,14 +280,7 @@ td.jsdialog .jsdialog.cell.sidebar {
 	top: 6px;
 }
 
-#LB_SHADOW_COLOR, #LB_GLOW_COLOR {
-	padding: 4px 10px;
-	width: 130px;
-	position: relative;
-	left: -11px;
-}
-
-#fillgrad2 {
+#LB_SHADOW_COLOR, #LB_GLOW_COLOR, #fillgrad2 {
 	padding: 4px 10px;
 	width: 160px;
 	position: relative;


### PR DESCRIPTION
### Steps to reproduce
- Draw a Shape
- open Sidebar
- open Effect Section
- Change color to Light Gray 4
- width is to small for the label / cause of the preview rectangular
- as fillcolor1 and fillcolor2 has the same layout than #LB_GLOW_COLOR
  so width width was synced

Signed-off-by: andreas kainz <kainz.a@gmail.com>

Change-Id: I2c1ea98bd462cac899d9e118d520cc51749f3ba4

**before**
![Screenshot_20211221_205852](https://user-images.githubusercontent.com/8517736/146991980-a9a299a2-23e3-415b-a1b3-896020dd88fd.png)

**after**
![Screenshot_20211221_210012](https://user-images.githubusercontent.com/8517736/146992005-a6360a6a-74a4-453b-9e24-f69992c0c3f7.png)