### PR TITLE
enable source maps for debug mode

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -583,8 +583,13 @@ $(DIST_FOLDER)/welcome/%.html: $(srcdir)/welcome/%.html
 		`ln -sf $(abs_srcdir)/$< $@`; \
 	fi
 
+
+if ENABLE_DEBUG
+SourceMap=--allowJs true --sourceMap true
+endif
+
 tscompile.done: $(COOL_JS_SRC) $(COOL_TS_SRC)
-	$(builddir)/node_modules/typescript/bin/tsc --typeRoots $(builddir)/node_modules/@types --outDir $(DIST_FOLDER)/src --rootDir $(srcdir)/src --checkJs false --project $(srcdir)/tsconfig.json
+	$(builddir)/node_modules/typescript/bin/tsc --typeRoots $(builddir)/node_modules/@types --outDir $(DIST_FOLDER)/src --rootDir $(srcdir)/src --checkJs false --project $(srcdir)/tsconfig.json $(SourceMap)
 	@touch $@
 
 $(COOL_TS_JS_DST): tscompile.done


### PR DESCRIPTION
enabling source maps helps while debugging through the IDEs

it becomes necessary with typescript

Signed-off-by: Pranam Lashkari <lpranam@collabora.com>
Change-Id: Ia5f09595ed9726e0076d1837024868a651d92361


* Target version: master 


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

