### PR TITLE
Use var(--border-radius)

### DIFF
--- a/browser/css/color-palette.css
+++ b/browser/css/color-palette.css
@@ -11,4 +11,6 @@
 	--gray-lighter-bg-color: #F7F7F7;
 	--gray-color: #b6b6b6;
 	--white-bg-color: #fff;
+
+	--border-radius: 4px;
 }

--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -21,7 +21,7 @@
 .sidebar .spinfieldcontainer input {
 	width: 85px;
 	border: 1px solid var(--gray-color);
-	border-radius: 4px;
+	border-radius: var(--border-radius);
 	height: 28px;
 	padding-left: 4px;
 	position: relative;
@@ -191,7 +191,7 @@ td.jsdialog .jsdialog.cell.sidebar {
 	background-color: transparent;
 	border: 2px solid transparent;
 	color: var(--gray-light-txt--color);
-	border-radius: 4px;
+	border-radius: var(--border-radius);
 }
 /* selected */
 .hasnotebookbar .ui-content.unotoolbutton.selected.has-label,
@@ -199,9 +199,9 @@ td.jsdialog .jsdialog.cell.sidebar {
 .hasnotebookbar .ui-content.unotoolbutton.selected:not(.has-label):not(.inline),
 .sidebar.unotoolbutton.selected {
 	background-color: var(--gray-light-bg-color);
-	border: 2px solid var(--gray-light-bg-color);
+	border: 2px solid transparent;
 	color: var(--gray-light-txt--color);
-	border-radius: 4px;
+	border-radius: var(--border-radius);
 }
 /* selected hover */
 .hasnotebookbar .ui-content.unotoolbutton.selected:hover,
@@ -214,7 +214,7 @@ td.jsdialog .jsdialog.cell.sidebar {
 #table-textorientbox.sidebar .jsdialog .radiobutton:hover {
 	outline: 1px solid var(--gray-light-txt--color);
 	color: var(--gray-light-txt--color);
-	border-radius: 4px;
+	border-radius: var(--border-radius);
 }
 
 .sidebar #font select,


### PR DESCRIPTION
add a --border-radius: 4px value
and use it for sidebar and notebookbar
other stuff will follow, but I want to test where the value was visible
selected-inline values in notebookbar use border-radius

**test change**
- use notebookbar in writer
- goto tab review
- Automatic Spell Checking use now the border-radius: 4px

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I3083cd2ff2cc3efd784aafb0c71cb2f823b9b79d

value name is similar to https://github.com/nextcloud/server/blob/master/core/css/css-variables.scss#L57