### PR TITLE
notebookbar: use more advanced optioned Conditional Formatting control

### DIFF
--- a/browser/js/w2ui-1.5.rc1.js
+++ b/browser/js/w2ui-1.5.rc1.js
@@ -2529,7 +2529,7 @@ w2utils.event = {
             if (typeof options.onRender === 'function' && typeof options.render !== 'function') options.render = options.onRender;
             // since only one overlay can exist at a time
             $.fn.w2menuClick = function (event, index) {
-                var keepOpen = false;
+                var keepOpen = options.keepOpen || false;
                 if (['radio', 'check'].indexOf(options.type) != -1) {
                     if (event.shiftKey || event.metaKey || event.ctrlKey) keepOpen = true;
                 }

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -206,15 +206,6 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			{text: _UNO('.uno:JumpUpThisLevel', 'text'), uno: 'JumpUpThisLevel'},
 			{text: _UNO('.uno:ContinueNumbering', 'text'), uno: 'ContinueNumbering'}
 		];
-		this._menus['ConditionalFormatMenu'] = [
-			{text: _UNO('.uno:ConditionalFormatDialog', 'spreadsheet'), uno: 'ConditionalFormatDialog'},
-			{text: _UNO('.uno:ColorScaleFormatDialog', 'spreadsheet'), uno: 'ColorScaleFormatDialog'},
-			{text: _UNO('.uno:DataBarFormatDialog', 'spreadsheet'), uno: 'DataBarFormatDialog'},
-			{text: _UNO('.uno:IconSetFormatDialog', 'spreadsheet'), uno: 'IconSetFormatDialog'},
-			{text: _UNO('.uno:CondDateFormatDialog', 'spreadsheet'), uno: 'CondDateFormatDialog'},
-			{type: 'separator'},
-			{text: _UNO('.uno:ConditionalFormatManagerDialog', 'spreadsheet'), uno: 'ConditionalFormatManagerDialog'}
-		];
 
 		this._currentDepth = 0;
 	},

--- a/browser/src/control/Control.NotebookbarBuilder.js
+++ b/browser/src/control/Control.NotebookbarBuilder.js
@@ -849,17 +849,8 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 						{name: _UNO('.uno:LanguageMenu'), type: 'menu', menu: [
 							{name: _('None (Do not check spelling)'), id: 'nonelanguage', uno: '.uno:LanguageStatus?Language:string=Default_LANGUAGE_NONE'}]},
 						{uno: '.uno:GoalSeekDialog'},
-						{type: 'separator'},
-						{uno: '.uno:RunMacro', hidden: disabledMacros},
 						{type: 'separator', hidden: disabledMacros},
-						{name: _UNO('.uno:ConditionalFormatMenu', 'spreadsheet'), type: 'menu', menu: [
-							{uno: '.uno:ConditionalFormatDialog'},
-							{uno: '.uno:ColorScaleFormatDialog'},
-							{uno: '.uno:DataBarFormatDialog'},
-							{uno: '.uno:IconSetFormatDialog'},
-							{uno: '.uno:CondDateFormatDialog'},
-							{type: 'separator'},
-							{uno: '.uno:ConditionalFormatManagerDialog'}]}
+						{uno: '.uno:RunMacro', hidden: disabledMacros}
 					]}
 				]}
 			],

--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -1365,8 +1365,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				'command': '.uno:FormatCellDialog'
 			},
 			{
-				'id': 'ConditionalFormatMenu:ConditionalFormatMenu',
-				'type': 'menubutton',
+				'type': 'bigtoolitem',
 				'text': _UNO('.uno:ConditionalFormatMenu', 'spreadsheet'),
 				'command': '.uno:ConditionalFormatMenu'
 			},

--- a/browser/src/control/Control.Toolbar.js
+++ b/browser/src/control/Control.Toolbar.js
@@ -253,15 +253,20 @@ function setConditionalFormatIconSet(num) {
 
 global.setConditionalFormatIconSet = setConditionalFormatIconSet;
 
-function getConditionalFormatMenuHtml() {
-	return '<table id="conditionalformatmenu-grid"><tr>' +
+function getConditionalFormatMenuHtml(more) {
+	var table = '<table id="conditionalformatmenu-grid"><tr>' +
 	'<td class="w2ui-tb-image w2ui-icon iconset00" onclick="setConditionalFormatIconSet(0)"/><td class="w2ui-tb-image w2ui-icon iconset01" onclick="setConditionalFormatIconSet(1)"/><td class="w2ui-tb-image w2ui-icon iconset02" onclick="setConditionalFormatIconSet(2)"/></tr><tr>' +
 	'<td class="w2ui-tb-image w2ui-icon iconset03" onclick="setConditionalFormatIconSet(3)"/><td class="w2ui-tb-image w2ui-icon iconset04" onclick="setConditionalFormatIconSet(4)"/><td class="w2ui-tb-image w2ui-icon iconset05" onclick="setConditionalFormatIconSet(5)"/></tr><tr>' +
 	'<td class="w2ui-tb-image w2ui-icon iconset06" onclick="setConditionalFormatIconSet(6)"/><td class="w2ui-tb-image w2ui-icon iconset08" onclick="setConditionalFormatIconSet(8)"/><td class="w2ui-tb-image w2ui-icon iconset09" onclick="setConditionalFormatIconSet(9)"/></tr><tr>' + // iconset07 deliberately left out, see the .css for the reason
 	'<td class="w2ui-tb-image w2ui-icon iconset10" onclick="setConditionalFormatIconSet(10)"/><td class="w2ui-tb-image w2ui-icon iconset11" onclick="setConditionalFormatIconSet(11)"/><td class="w2ui-tb-image w2ui-icon iconset12" onclick="setConditionalFormatIconSet(12)"/></tr><tr>' +
 	'<td class="w2ui-tb-image w2ui-icon iconset13" onclick="setConditionalFormatIconSet(13)"/><td class="w2ui-tb-image w2ui-icon iconset14" onclick="setConditionalFormatIconSet(14)"/><td class="w2ui-tb-image w2ui-icon iconset15" onclick="setConditionalFormatIconSet(15)"/></tr><tr>' +
 	'<td class="w2ui-tb-image w2ui-icon iconset16" onclick="setConditionalFormatIconSet(16)"/><td class="w2ui-tb-image w2ui-icon iconset17" onclick="setConditionalFormatIconSet(17)"/><td class="w2ui-tb-image w2ui-icon iconset18" onclick="setConditionalFormatIconSet(18)"/></tr><tr>' +
-	'<td class="w2ui-tb-image w2ui-icon iconset19" onclick="setConditionalFormatIconSet(19)"/><td class="w2ui-tb-image w2ui-icon iconset20" onclick="setConditionalFormatIconSet(20)"/><td class="w2ui-tb-image w2ui-icon iconset21" onclick="setConditionalFormatIconSet(21)"/></tr></table>';
+	'<td class="w2ui-tb-image w2ui-icon iconset19" onclick="setConditionalFormatIconSet(19)"/><td class="w2ui-tb-image w2ui-icon iconset20" onclick="setConditionalFormatIconSet(20)"/><td class="w2ui-tb-image w2ui-icon iconset21" onclick="setConditionalFormatIconSet(21)"/></tr>';
+	if (more) {
+		table += '<tr><td id="' + more + '">' + _('More...') + '</td></tr>';
+	}
+	table += '</table>';
+	return table;
 }
 
 global.getConditionalFormatMenuHtml = getConditionalFormatMenuHtml;


### PR DESCRIPTION
Home tab's contitional formatting control is old and is not the same
as Format's tabs control. Now they are the same.

Signed-off-by: Mert Tumer <mert.tumer@collabora.com>
Change-Id: I9a08cda3a2ff98a18e711ba4a17bd8ebb8b4027b


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

