### PR TITLE
Header area DocumentName without cutted extension

### DIFF
--- a/browser/src/control/Control.DocumentNameInput.js
+++ b/browser/src/control/Control.DocumentNameInput.js
@@ -125,7 +125,7 @@ L.Control.DocumentNameInput = L.Control.extend({
 		var documentNameInput = $('#document-name-input');
 		var content = (typeof tail === 'string') ? documentNameInput.val() + tail : documentNameInput.val();
 		var font = documentNameInput.css('font');
-		var textWidth = L.getTextWidth(content, font) + 24;
+		var textWidth = L.getTextWidth(content, font) + 48;
 		var maxWidth = this._getMaxAvailableWidth();
 		//console.log('_setNameInputWidth: textWidth: ' + textWidth + ', maxWidth: ' + maxWidth);
 		textWidth = Math.min(textWidth, maxWidth);


### PR DESCRIPTION
there is hardcoded at the input#document-name-input a fixed width
with the defined fixed width the extension was cutted
this MR get 24px additional width so that the extension was
shown with it has 4 letters.

**before**
![Screenshot_20211226_102622](https://user-images.githubusercontent.com/8517736/147404456-f7529586-b105-4e1f-8119-1ce6005951ab.png)

**after**
![Screenshot_20211226_103021](https://user-images.githubusercontent.com/8517736/147404465-9ddef2bb-b6d0-4a7e-9cdb-335e06754d37.png)


Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I8736ac08e2f4ab27703b6dcedf3e1d28d73de516