### PR TITLE
Calc sidebar NumberFormat section alignment

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -125,6 +125,31 @@ div#thousandseparator.checkbutton.jsdialog.sidebar {
 	max-width: 290px;
 }
 
+div#decimalplaces {
+	text-align: right;
+}
+
+div#numberformatcombobox.jsdialog.sidebar.ui-listbox-container {
+	position: relative;
+	left: 2px;
+}
+
+div#leadingzeroes.jsdialog.sidebar.spinfieldcontainer {
+	text-align: right;
+	position: relative;
+	right: 4px;
+}
+
+p#decimalplaceslabel.jsdialog.sidebar.ui-text,
+p#denominatorplaceslabel.jsdialog.sidebar.ui-text {
+	position: absolute;
+}
+
+div#box2.row.jsdialog.sidebar > .sidebar.jsdialog.row > .sidebar.jsdialog.cell,
+div#box5.row.jsdialog.sidebar > .sidebar.jsdialog.cell {
+	padding: 0 14px 0 0;
+}
+
 .sidebar.ui-expander-label {
 	color: var(--gray-light-txt--color);
 	font-size: 11px;


### PR DESCRIPTION
spinboxes are right aligned
labels are vertical center aligned
remove padding at table element 
so all commands have the same row height

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: If5b89cac71e2918d3d870066f2b895136286b8b2

**after**
![image](https://user-images.githubusercontent.com/8517736/147407601-f69e7409-422b-440c-9196-7c1ee8fcc94f.png)


