### PR TITLE
Sidebar Shadow Section alignment

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -104,6 +104,21 @@
 	justify-content: flex-end;
 }
 
+#ShadowPropertyPanel div#table-grid3 table#grid3 td:nth-child(1) {
+	justify-content: flex-start;
+}
+
+#FIELD_TRANSPARENCY {
+	height: 0;
+	position: relative;
+	bottom: 22px;
+}
+
+#transparency_label {
+	position: relative;
+	top: 12px;
+}
+
 #table-box4.sidebar.jsdialog.vertical {
 	width: auto;
 }


### PR DESCRIPTION
Endable checkbox use flex-start
Transparancy label and spinfieldcontainer are vertical aligned

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I49cfdf4b3b508b7f178d76a4c5e61c4b21fdf2bb


* Resolves: # <!-- related github issue -->
* Target version: master 

**Screenshot after**
![Screenshot_20211226_212938](https://user-images.githubusercontent.com/8517736/147419367-c207558b-f668-4a96-a66e-abbb3af7a609.png)

