### PR TITLE
Fix InsertFile returns 400 after an idle reload

### DIFF
--- a/loleaflet/src/map/handler/Map.FileInserter.js
+++ b/loleaflet/src/map/handler/Map.FileInserter.js
@@ -161,6 +161,12 @@ L.Map.FileInserter = L.Handler.extend({
 				formData.append('file', file);
 			}
 			xmlHttp.send(formData);
+
+			// Set it to null in case server restarts/shuts down or the user reconnects after being idle
+			// these change the childId but it would be cached already with the old one if a previous insertfile is made.
+			// in that case we would get http error 400 because of the wrong childId.
+			// when it's null we ask for a new childId before uploading.
+			this._childId = null;
 		}
 	},
 


### PR DESCRIPTION
Signed-off-by: Mert Tumer <mert.tumer@collabora.com>
Change-Id: I56d38f05d8da4fc55393203764692ca2b5f864f2


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

