### PR TITLE
co-6-4: 'SaveAs' Document Templates

### DIFF
--- a/kit/KitHelper.hpp
+++ b/kit/KitHelper.hpp
@@ -61,6 +61,10 @@ namespace LOKitHelper
             << " height=" << height
             << " viewid=" << loKitDocument->pClass->getView(loKitDocument);
 
+        ptrValue = loKitDocument->pClass->getCommandValues(loKitDocument, ".uno:DocProps");
+        oss << " props=" << (ptrValue ? ptrValue : "{}");
+        std::free(ptrValue);
+
         if (type == LOK_DOCTYPE_SPREADSHEET || type == LOK_DOCTYPE_PRESENTATION || type == LOK_DOCTYPE_DRAWING)
         {
             std::ostringstream hposs;

--- a/loleaflet/src/control/Control.Menubar.js
+++ b/loleaflet/src/control/Control.Menubar.js
@@ -1509,9 +1509,14 @@ L.Control.Menubar = L.Control.extend({
 		if (id === 'save') {
 			// Save only when not read-only.
 			if (!this._map.isPermissionReadOnly()) {
-				this._map.fire('postMessage', {msgId: 'UI_Save'});
-				if (!this._map._disableDefaultAction['UI_Save']) {
-					this._map.save(false, false);
+				if (this._map._docLayer && this._map._docLayer._docProps &&
+				    this._map._docLayer._docProps.AsTemplate)
+					this._map.openSaveAs();
+				else {
+					this._map.fire('postMessage', {msgId: 'UI_Save'});
+					if (!this._map._disableDefaultAction['UI_Save']) {
+						this._map.save(false, false);
+					}
 				}
 			}
 		} else if (id === 'saveas') {

--- a/loleaflet/src/control/Control.Toolbar.js
+++ b/loleaflet/src/control/Control.Toolbar.js
@@ -100,9 +100,14 @@ function onClick(e, id, item) {
 	else if (id === 'save') {
 		// Save only when not read-only.
 		if (!map.isPermissionReadOnly()) {
-			map.fire('postMessage', {msgId: 'UI_Save'});
-			if (!map._disableDefaultAction['UI_Save']) {
-				map.save(false /* An explicit save should terminate cell edit */, false /* An explicit save should save it again */);
+			if (this._map._docLayer && this._map._docLayer._docProps &&
+			    this._map._docLayer._docProps.AsTemplate)
+				this._map.openSaveAs();
+			else {
+				map.fire('postMessage', {msgId: 'UI_Save'});
+				if (!map._disableDefaultAction['UI_Save']) {
+					map.save(false /* An explicit save should terminate cell edit */, false /* An explicit save should save it again */);
+				}
 			}
 		}
 	}

--- a/loleaflet/src/core/Socket.js
+++ b/loleaflet/src/core/Socket.js
@@ -1620,6 +1620,9 @@ app.definitions.Socket = L.Class.extend({
 					command.hiddenparts.push(parseInt(item));
 				});
 			}
+			else if (tokens[i].substring(0, 6) === 'props=') {
+				command.props = JSON.parse(tokens[i].substring('props='.length));
+			}
 			else if (tokens[i].startsWith('selectedparts=')) {
 				var selectedParts = tokens[i].substring(14).split(',');
 				command.selectedParts = [];

--- a/loleaflet/src/layer/tile/CalcTileLayer.js
+++ b/loleaflet/src/layer/tile/CalcTileLayer.js
@@ -300,6 +300,7 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 			app.view.size.pixels = app.file.size.pixels.slice();
 			this._docType = command.type;
 			this._parts = command.parts;
+			this._docProps = command.props;
 			if (this._selectedPart !== command.selectedPart) {
 				app.socket.sendMessage('resetselection');
 			}

--- a/loleaflet/src/layer/tile/ImpressTileLayer.js
+++ b/loleaflet/src/layer/tile/ImpressTileLayer.js
@@ -261,6 +261,7 @@ L.ImpressTileLayer = L.CanvasTileLayer.extend({
 			this._docWidthTwips = command.width;
 			this._docHeightTwips = command.height;
 			this._docType = command.type;
+			this._docProps = command.props;
 			if (this._docType === 'drawing') {
 				L.DomUtil.addClass(L.DomUtil.get('presentation-controls-wrapper'), 'drawing');
 			}

--- a/loleaflet/src/layer/tile/WriterTileLayer.js
+++ b/loleaflet/src/layer/tile/WriterTileLayer.js
@@ -151,6 +151,7 @@ L.WriterTileLayer = L.CanvasTileLayer.extend({
 		this._parts = 1;
 		this._currentPage = command.selectedPart;
 		this._pages = command.parts;
+		this._docProps = command.props;
 		this._map.fire('pagenumberchanged', {
 			currentPage: this._currentPage,
 			pages: this._pages,

--- a/test/UnitInsertDelete.cpp
+++ b/test/UnitInsertDelete.cpp
@@ -35,7 +35,7 @@ void getPartHashCodes(const std::string& testname, const std::string& response,
 
     TST_LOG("Reading parts from [" << response << "].");
 
-    // Expected format is something like 'type= parts= current= width= height= viewid= [hiddenparts=]'.
+    // Expected format is something like 'type= parts= current= width= height= viewid= props={} [hiddenparts=]'.
     StringVector tokens(Util::tokenize(line, ' '));
 #if defined CPPUNIT_ASSERT_GREATEREQUAL
     CPPUNIT_ASSERT_GREATEREQUAL(static_cast<size_t>(7), tokens.size());

--- a/test/UnitRenderingOptions.cpp
+++ b/test/UnitRenderingOptions.cpp
@@ -49,10 +49,10 @@ void UnitRenderingOptions::invokeWSDTest()
         helpers::sendTextFrame(socket, "status");
         const auto status = helpers::assertResponseString(socket, "status:", testname);
 
-        // Expected format is something like 'status: type=text parts=2 current=0 width=12808 height=1142'.
+        // Expected format is something like 'status: type=text parts=2 current=0 width=12808 height=1142 viewid= props={}'.
 
         StringVector tokens(Util::tokenize(status, ' '));
-        LOK_ASSERT_EQUAL(static_cast<size_t>(7), tokens.size());
+        LOK_ASSERT_EQUAL(static_cast<size_t>(8), tokens.size());
 
         const std::string token = tokens[5];
         const std::string prefix = "height=";


### PR DESCRIPTION
- kit: include document properties to "status:" message
- lolealfet: parse new document properties
- loleaflet: only 'saveAs' action is allowed if document
