### PR TITLE
kit: preload: enable module 'ucpgio1'

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -2912,7 +2912,7 @@ bool globalPreinit(const std::string &loTemplate)
     // desktop or developer's install if env. var not set.
     ::setenv("UNODISABLELIBRARY",
              "abp avmediagst avmediavlc cmdmail losessioninstall OGLTrans PresenterScreen "
-             "syssh ucpftp1 ucpgio1 ucphier1 ucpimage updatecheckui updatefeed updchk"
+             "syssh ucpftp1 ucphier1 ucpimage updatecheckui updatefeed updchk"
              // Database
              "dbaxml dbmm dbp dbu deployment firebird_sdbc mork "
              "mysql mysqlc odbc postgresql-sdbc postgresql-sdbc-impl sdbc2 sdbt"


### PR DESCRIPTION
Otherwise opening a document template crash the kit,
because the provider does not exists.

i.e. loading file Alizarin.otp

Change-Id: Icd8911d75e5e699d864a328218787ae0b29cd117
