### PR TITLE
browser: fix WOPI empty params

### DIFF
--- a/browser/src/main.js
+++ b/browser/src/main.js
@@ -5,7 +5,7 @@
 (function (global) {
 
 
-var wopiParams;
+var wopiParams = {};
 var wopiSrc = getParameterByName('WOPISrc');
 
 if (wopiSrc !== '' && accessToken !== '') {


### PR DESCRIPTION
fix "Uncaught TypeError: Cannot set property 'permission' of undefined"

Change-Id: Id3844d1fe5ac309b0a7c703f6913f6e632d46dff
Signed-off-by: Henry Castro <hcastro@collabora.com>
