### PR TITLE
cypress:fix: number_format_spec.js failure

### DIFF
--- a/cypress_test/integration_tests/common/mobile_helper.js
+++ b/cypress_test/integration_tests/common/mobile_helper.js
@@ -313,7 +313,10 @@ function selectListBoxItem2(listboxSelector, item) {
 
 	helper.clickOnIdle(listboxSelector);
 
-	helper.clickOnIdle('.ui-combobox-text', item);
+	helper.waitUntilIdle('.ui-combobox-text');
+
+	cy.contains('.ui-combobox-text', new RegExp('^' + item + '$'))
+		.click();
 
 	cy.get(listboxSelector + ' .ui-header-left')
 		.should('have.text', item);


### PR DESCRIPTION
'Select time from list' test was failing because to click on 'Time' option, cypress's contains() will search for element with class .ui-combobox-next having 'Time' substring but there are two element containing 'Time' substring having same class. By adding regex we make sure that the selection and click on element happens on exact string not on class containing substring.

Signed-off-by: Rash419 <rashesh.padia@collabora.com>
Change-Id: If44a1a535d4e08d40cc069308c2a637c6bd07048

