### PR TITLE
Fix Sidebar scroll bar width and improve consistency

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -200,6 +200,16 @@ nav.spreadsheet-color-indicator ~ #sidebar-dock-wrapper {
 	overflow-x: hidden;
 	overflow-y: auto;
 	z-index: 1200;
+	scrollbar-width: auto;
+	scrollbar-color: #bec0c0 transparent;
+}
+
+#sidebar-panel::-webkit-scrollbar {
+	width: 8px;
+}
+
+#sidebar-panel::-webkit-scrollbar-thumb {
+	background-color: #bec0c0;
 }
 
 #toolbar-wrapper {


### PR DESCRIPTION
On Chrome the scroll bar was overlapping some sidebar icons; The
scroll bar thumb was not the same color as the document scroll bar.
Additionally on Firefox (using Windows) the sidebar-panel's scroll bar
would also overlap a bit of those sidebar icons.

- Fix sidebar scroll bar width and make sure is not too big
	- Done in different ways for Chrome and FF since they do not posses the
		same CSS spec (plus FF does not allow the use of exact widths)
- Fix sidebars inconsistencies regarding color
	- Use the same #bec0c0 used in the document's scroll bar albeit only
		on mouseover. In the default state it stays with the browser's default
		opacity and thus looks lighter than the document's scroll bar. This
		is not only fine but desirable so to avoid taking to much attention
		from the document itself.

First reported:
https://github.com/CollaboraOnline/online/issues/3725

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I7b4f2aeaf2a3b7a1af88b01e36f82d1cb7746f0d
