### PR TITLE
Aboud: Ipad: Fix git hash formatting

### DIFF
--- a/browser/css/device-tablet.css
+++ b/browser/css/device-tablet.css
@@ -160,12 +160,12 @@
 	margin: 0;
 }
 
-#loolwsd-version span:before,
+#coolwsd-version span:before,
 #lokit-version > span:before {
 	content: ' (';
 	white-space: pre;
 }
-#loolwsd-version span:after,
+#coolwsd-version span:after,
 #lokit-version > span:after {
 	content: ')';
 }


### PR DESCRIPTION
In the wsd version git hash was getting set right after the previous
word (completely adjacent and without space and brackets)
- Fix outdated "loolwsd-*" class name and make sure the CSS rules does
	get applied

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I77ea5ac19a5dbaa798437ec70489a1aee1051b1f
