### PR TITLE
Notebookbar: Fix Tabs' overlapping into other elements

### DIFF
--- a/browser/css/menubar.css
+++ b/browser/css/menubar.css
@@ -77,6 +77,12 @@
 }
 .main-nav.hasnotebookbar {
 	height: 32px;
+	overflow: scroll hidden;
+	scrollbar-width: none;
+	-ms-scrollbar: none;
+}
+.main-nav.hasnotebookbar::-webkit-scrollbar {
+	height: 0;
 }
 .main-nav.hasnotebookbar:not(.readonly) {
 	background: var(--gray-light-bg-color);

--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -6,14 +6,13 @@
 }
 
 .ui-tabs.notebookbar {
-	display: inline-block;
+	display: inline-flex;
 	z-index: 999;
 	padding: 0px;
 	height: 100%;
 }
 
 .ui-tab.notebookbar {
-	float: left;
 	font-size: 12pt;
 	font-family: var(--cool-font);
 	line-height: normal;

--- a/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
@@ -61,13 +61,6 @@ describe('Top toolbar tests.', function() {
 
 
 	it('Apply font name.', function() {
-		//for notebookbar the tab button overlap on change font button so cypress fails
-		//below condition skips the test for notebookbar
-		//remove below condition after https://github.com/CollaboraOnline/online/issues/3935
-		//get solved
-		if (mode === 'notebookbar') {
-			return;
-		}
 		desktopHelper.actionOnSelector('fontName', (selector) => { cy.get(selector).click(); });
 
 		desktopHelper.selectFromListbox('Alef');


### PR DESCRIPTION
Make the whole nav bar scroll-able, specially important when still on
desktop but using small factor screen or simply when resizing window

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ib0011c8353a5c4d09f5f150032088bc69e0f7d90
