### PR TITLE
wsd: enforce TLSv1.2 as the minimum acceptable version

### DIFF
--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -152,6 +152,10 @@
             <pin></pin>
             </pins>
         </hpkp>
+        <sts desc="Strict-Transport-Security settings, per rfc6797. Subdomains are always included.">
+            <enabled desc="Whether or not Strict-Transport-Security is enabled. Enable only when ready for production. Cannot be disabled without resetting the browsers." type="bool" default="false">false</enabled>
+            <max_age desc="Strict-Transport-Security max-age directive, in seconds. 0 is allowed; please see rfc6797 for details. Defaults to 1 year." type="int" default="31536000">31536000</max_age>
+        </sts>
     </ssl>
 
     <security desc="Altering these defaults potentially opens you to significant risk">

--- a/net/Ssl.cpp
+++ b/net/Ssl.cpp
@@ -111,10 +111,13 @@ SslContext::SslContext(const std::string& certFilePath, const std::string& keyFi
     // as we don't expect/support different servers in same process.
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
     _ctx = SSL_CTX_new(TLS_method());
-    SSL_CTX_set_min_proto_version(_ctx, TLS1_VERSION);
+    SSL_CTX_set_min_proto_version(_ctx, TLS1_2_VERSION); // TLS v1.2 is the minimum.
 #else
     _ctx = SSL_CTX_new(SSLv23_method());
+    SSL_CTX_set_options(_ctx, SSL_OP_NO_SSLv2);
     SSL_CTX_set_options(_ctx, SSL_OP_NO_SSLv3);
+    SSL_CTX_set_options(_ctx, SSL_OP_NO_TLSv1);
+    SSL_CTX_set_options(_ctx, SSL_OP_NO_TLSv1_1);
 #endif
 
     // SSL_CTX_set_default_passwd_cb(_ctx, &privateKeyPassphraseCallback);

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -1106,6 +1106,8 @@ void COOLWSD::innerInitialize(Application& self)
             { "ssl.hpkp.report_uri[@enable]", "false" },
             { "ssl.hpkp[@enable]", "false" },
             { "ssl.hpkp[@report_only]", "false" },
+            { "ssl.sts.enabled", "false" },
+            { "ssl.sts.max_age", "31536000" },
             { "ssl.key_file_path", COOLWSD_CONFIGDIR "/key.pem" },
             { "ssl.termination", "true" },
             { "storage.filesystem[@allow]", "false" },

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -490,6 +490,22 @@ void FileServerRequestHandler::handleRequest(const HTTPRequest& request,
         noCache = true;
 #endif
         Poco::Net::HTTPResponse response;
+
+        const auto& config = Application::instance().config();
+
+        // HSTS hardening. Disabled in debug builds.
+#if !ENABLE_DEBUG
+        if (COOLWSD::isSSLEnabled() || COOLWSD::isSSLTermination())
+        {
+            if (config.getBool("ssl.sts.enabled", false))
+            {
+                const auto maxAge = config.getInt("ssl.sts.max_age", 31536000); // Default 1 year.
+                response.add("Strict-Transport-Security",
+                             "max-age=" + std::to_string(maxAge) + "; includeSubDomains");
+            }
+        }
+#endif
+
         Poco::URI requestUri(request.getURI());
         LOG_TRC("Fileserver request: " << requestUri.toString());
         requestUri.normalize(); // avoid .'s and ..'s
@@ -507,7 +523,6 @@ void FileServerRequestHandler::handleRequest(const HTTPRequest& request,
 
         std::string relPath = getRequestPathname(request);
         std::string endPoint = requestSegments[requestSegments.size() - 1];
-        const auto& config = Application::instance().config();
 
         static std::string etagString = "\"" COOLWSD_VERSION_HASH +
             config.getString("ver_suffix", "") + "\"";


### PR DESCRIPTION
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
(cherry picked from commit dad7ed85e97afe0e4f5229b1de125aada9a8c2e8)

Change-Id: I5683f835f37f67ee353a0b629a4662c7c78787a6
