### PR TITLE
Remove residual 'callback except-' code

### DIFF
--- a/cypress_test/integration_tests/desktop/calc/macro_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/macro_spec.js
@@ -10,8 +10,7 @@ describe('macro dialog tests', function() {
 		cy.get('#MacroWarnMedium.jsdialog')
 			.should('exist');
 
-		cy.get('#MacroWarnMedium.jsdialog #ok')
-			.click();
+		helper.clickOnIdle('#MacroWarnMedium.jsdialog #ok');
 	}
 
 	beforeEach(function() {

--- a/cypress_test/integration_tests/desktop/calc/open_different_file_types_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/open_different_file_types_spec.js
@@ -72,8 +72,7 @@ describe('Open different file types', function () {
 		cy.get('form.jsdialog-container.lokdialog_container')
 			.should('exist');
 
-		cy.contains('.ui-pushbutton', 'OK')
-			.click();
+		helper.clickOnIdle('.ui-pushbutton', 'OK');
 
 		//check doc is loaded
 		cy.get('.leaflet-canvas-container canvas', {timeout : Cypress.config('defaultCommandTimeout') * 2.0});

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1715,16 +1715,10 @@ public:
                     {
                         bool broadcast = false;
                         int viewId = -1;
-                        int exceptViewId = -1;
 
                         const std::string& target = tokens[1];
                         if (target == "all")
                         {
-                            broadcast = true;
-                        }
-                        else if (COOLProtocol::matchPrefix("except-", target))
-                        {
-                            exceptViewId = std::stoi(target.substr(7));
                             broadcast = true;
                         }
                         else
@@ -1747,8 +1741,7 @@ public:
                                 continue;
 
                             ChildSession& session = *it.second;
-                            if ((broadcast && (session.getViewId() != exceptViewId))
-                                || (!broadcast && (session.getViewId() == viewId)))
+                            if (broadcast || (!broadcast && (session.getViewId() == viewId)))
                             {
                                 if (!session.isCloseFrame())
                                 {


### PR DESCRIPTION
'callback except-' is not used anywhere anymore.
Initially implemented in 68e597b to handle a certain invalid cursor event.
Removed in 986bcce due to a bug.
Not used anywhere else in the codebase.

Signed-off-by: NickWingate <nicholas.wingate03@gmail.com>
Change-Id: Ib620e6a33639f510c8f2415cf009e4d183a353fd


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

