### PR TITLE
Notebookbar: Fix smartmenus visibility and set overflow dynamically

### DIFF
--- a/browser/css/menubar.css
+++ b/browser/css/menubar.css
@@ -77,7 +77,7 @@
 }
 .main-nav.hasnotebookbar {
 	height: 32px;
-	overflow: scroll hidden;
+	/* overflow is set dynamically */
 	scrollbar-width: none;
 	-ms-scrollbar: none;
 }

--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -1394,6 +1394,9 @@ L.Control.Menubar = L.Control.extend({
 		}
 	},
 
+	_onMouseOut: function() {
+		$('.main-nav.hasnotebookbar').css('overflow', 'scroll hidden');
+	},
 	_checkedMenu: function(uno, item) {
 		var constChecked = 'lo-menu-item-checked';
 		var state = this._map['stateChangeHandler'].getItemValue(uno);

--- a/browser/src/control/Control.NotebookbarBuilder.js
+++ b/browser/src/control/Control.NotebookbarBuilder.js
@@ -920,6 +920,7 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 		$(menuHtml[0]).children('a').html('<img class="ui-content unobutton" src="' + L.LOUtil.getImageURL('lc_hamburger.svg') + '" id="Hamburgerimg" alt="Menu">');
 		$(menuHtml[0]).children('a').click(function () {
 			$(control.container).smartmenus('menuHideAll');
+			$('.main-nav.hasnotebookbar').css('overflow', 'visible');
 		});
 
 		$(control.container).bind('beforeshow.smapi', {self: menubar}, menubar._beforeShow);
@@ -928,6 +929,7 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 		$(control.container).bind('mouseenter.smapi', {self: menubar}, menubar._onMouseEnter);
 		$(control.container).bind('mouseleave.smapi', {self: menubar}, menubar._onMouseLeave);
 		$(control.container).bind('keydown', {self: menubar}, menubar._onKeyDown);
+		$(control.container).bind('hideAll.smapi', {self: menubar}, menubar._onMouseOut);
 
 		// initialize languages list
 		builder.map.on('commandvalues', menubar._onInitLanguagesMenu, menubar);


### PR DESCRIPTION
c9b4b619cfde85553761662f9a7d5914e246b2f4 fixed the tabs overlap issue
but for the smartmenus on notebookbar (hamburger menu) to work the CSS
overflow property needs to be set (both for x and y) to visible, any
other value and the smartmenus' visibility suffers (gets cropped).
- Make set the CSS overflow property of .main-nav elm dynamically
	depending on menu state.
		- If it's open: set to `visible`
			(this disables the .main nav scroll but that's completely fine
			for when the Hamburger menu is open since it's not needed)
		- If it's close: back to `scroll hidden`.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I8a5522cb4a107d0583cde252e2ee551124c06f02
