### PR TITLE
Admin: introduce docstats subsection in logging in config

### DIFF
--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -83,6 +83,7 @@
             <anonymize_user_data type="bool" desc="Enable to anonymize/obfuscate of user-data in logs. If default is true, it was forced at compile-time and cannot be disabled." default="@COOLWSD_ANONYMIZE_USER_DATA@">@COOLWSD_ANONYMIZE_USER_DATA@</anonymize_user_data>
             <anonymization_salt type="uint" desc="The salt used to anonymize/obfuscate user-data in logs. Use a secret 64-bit random number." default="82589933">82589933</anonymization_salt>
         </anonymize>
+        <docstats type="bool" desc="Enable to see document handling information in logs." default="false">false</docstats>
     </logging>
 
     <!--

--- a/wsd/AdminModel.cpp
+++ b/wsd/AdminModel.cpp
@@ -551,11 +551,18 @@ void AdminModel::addDocument(const std::string& docKey, pid_t pid,
     }
 
     oss << memoryAllocated << ' ' << wopiHost;
-
-    LOG_INF("Adding a new document : " << filename
-                                       << " created by : " << COOLWSD::anonymizeUsername(userName)
-                                       << " using WopiHost : " << COOLWSD::anonymizeUrl(wopiHost)
-                                       << " allocating memory of : " << memoryAllocated);
+    if (COOLWSD::getConfigValue<bool>("logging.docstats", false))
+    {
+        Log::StreamLogger logger = Log::trace();
+        if (logger.enabled())
+        {
+            logger << "docstats : adding a document : " << filename
+                   << " created by : " << COOLWSD::anonymizeUsername(userName)
+                   << " using WopiHost : " << COOLWSD::anonymizeUrl(wopiHost)
+                   << " allocating memory of : " << memoryAllocated;
+        }
+        logger.flush();
+    }
     notify(oss.str());
 }
 


### PR DESCRIPTION
Change-Id: Icccc9d842703b3159965f67be2bf16404d50bad6
Signed-off-by: Yunusemre Şentürk <yunusemre@collabora.com>


* Target version: master 

### Summary
So that the logging about administrative document handling requires intentional configuration to see the data.


### TODO
put this check in front of every admin level logging ?

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

