### PR TITLE
Don't send unnecessary resizewindow message for the Calc input bar

### DIFF
--- a/browser/src/control/Control.LokDialog.js
+++ b/browser/src/control/Control.LokDialog.js
@@ -961,6 +961,9 @@ L.Control.LokDialog = L.Control.extend({
 		this._postLaunch(id, container, handles);
 		this._setupCalcInputBarGestures(id, handles, startHandle, endHandle);
 
+		this._calcInputbarContainerWidth = width;
+		this._calcInputbarContainerHeight = height;
+
 		// console.log('_createCalcInputBar: end');
 	},
 
@@ -1411,8 +1414,12 @@ L.Control.LokDialog = L.Control.extend({
 					var width = calcInputbarContainer.clientWidth;
 					var height = calcInputbarContainer.clientHeight;
 					if (width !== 0 && height !== 0) {
-						// console.log('_resizeCalcInputBar: id: ' + id + ', width: ' + width + ', height: ' + height);
-						app.socket.sendMessage('resizewindow ' + id + ' size=' + width + ',' + height);
+						if (width != this._calcInputbarContainerWidth || height != this._calcInputbarContainerHeight) {
+							// console.log('_resizeCalcInputBar: id: ' + id + ', width: ' + width + ', height: ' + height);
+							app.socket.sendMessage('resizewindow ' + id + ' size=' + width + ',' + height);
+							this._calcInputbarContainerWidth = width;
+							this._calcInputbarContainerHeight = height;
+						}
 					}
 				}
 			}

--- a/browser/src/map/Map.js
+++ b/browser/src/map/Map.js
@@ -1340,7 +1340,11 @@ L.Map = L.Evented.extend({
 					}
 					if (width > 0 && height > 0 && sizeChanged) {
 						console.log('_onResize: container width: ' + width + ', container height: ' + height + ', _calcInputBar width: ' + this.dialog._calcInputBar.width);
-						app.socket.sendMessage('resizewindow ' + id + ' size=' + width + ',' + height);
+						if (width != this.dialog._calcInputbarContainerWidth || height != this.dialog._calcInputbarContainerHeight) {
+							app.socket.sendMessage('resizewindow ' + id + ' size=' + width + ',' + height);
+							this.dialog._calcInputbarContainerWidth = width;
+							this.dialog._calcInputbarContainerHeight = height;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
If the size is the same as last time we sent the message, don't send
it. This fixes ugly flashing of the input bar tunnelled dialog when
the symbols displayed in front of the input field change.

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: I6532d85fddede54f416ee6686958bb650fdcb4f1


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

