### PR TITLE
Mobile:remove padding n width from color panel

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -318,7 +318,7 @@ td.jsdialog .jsdialog.cell.sidebar {
 	left: -7px;
 }
 
-#LB_SHADOW_COLOR, #LB_GLOW_COLOR {
+#LB_SHADOW_COLOR:not(.mobile-wizard), #LB_GLOW_COLOR:not(.mobile-wizard) {
 	padding: 4px 10px;
 	width: 130px;
 	position: relative;


### PR DESCRIPTION
Changes introduced in 46a7f6ba98b46f3e653830fb85f1144172efc696
and intended only for desktop were affecting mobile as well.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Iedc11d3a4a4fabdf45e82c0b112ba040ecd4e154
