### PR TITLE
Fix vex dialogs that cannot be set to flex on mobile

### DIFF
--- a/browser/css/device-mobile.css
+++ b/browser/css/device-mobile.css
@@ -289,6 +289,8 @@ div#w2ui-overlay-actionbar.w2ui-overlay{
 	border: none;
 	box-shadow: none;
 	border-radius: none;
+}
+.vex.vex-theme-plain:not(.vex-about-dialog, .vex-welcome-mobile) .vex-content {
 	display: flex;
 }
 .vex.vex-theme-plain .vex-content:not(.vex-has-inputs) .vex-dialog-form {
@@ -358,7 +360,7 @@ button.vex-dialog-button-secondary.vex-dialog-button.vex-last {
 	flex-direction: column !important;
 }
 
-.vex-close {
+.vex-close:not(.about-dialog) {
 	display: none;
 }
 

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -777,6 +777,8 @@ L.Map.include({
 		vex.open({
 			unsafeContent: content[0].outerHTML,
 			showCloseButton: true,
+			className: 'vex-theme-plain vex-about-dialog',
+			closeClassName: 'about-dialog',
 			escapeButtonCloses: true,
 			overlayClosesOnClick: true,
 			buttons: {},


### PR DESCRIPTION
- About dialog was not centered anymore
- About dialog was missing close button
- Welcome dialog was not getting resized properly

These two dialogs need to be excluded from the changes introduced in
95bd65d2f658ca8c378b50f4ff09ef1424c15c13

About dialog on mobile is still the only case where we need to have the
the close button; The main vex cntainer of Welcome and About dialogs
cannot be set to flex since they do have a custom structure different
from the other ones.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Iadd9e866d33de1ae945f3383a289b7b0b7113337
