### PR TITLE
browser: fixed broken show row/col after hiding

### DIFF
--- a/browser/src/control/Control.Header.js
+++ b/browser/src/control/Control.Header.js
@@ -129,14 +129,16 @@ L.Control.Header = L.Class.extend({
 	},
 
 	hideRow: function(index) {
-		if (!this._headerInfo.getElementData(index).isCurrent) {
+		if (!this._headerInfo.getElementData(index).isCurrent
+		&& !this._headerInfo.getElementData(index).isHighlighted) {
 			this._selectRow(index, 0);
 		}
 		this._map.sendUnoCommand('.uno:HideRow');
 	},
 
 	showRow: function(index) {
-		if (!this._headerInfo.getElementData(index).isCurrent) {
+		if (!this._headerInfo.getElementData(index).isCurrent
+		&& !this._headerInfo.getElementData(index).isHighlighted) {
 			this._selectRow(index, 0);
 		}
 		this._map.sendUnoCommand('.uno:ShowRow');
@@ -246,7 +248,8 @@ L.Control.Header = L.Class.extend({
 	},
 
 	hideColumn: function(index) {
-		if (!this._headerInfo.getElementData(index).isCurrent) {
+		if (!this._headerInfo.getElementData(index).isCurrent
+		&& !this._headerInfo.getElementData(index).isHighlighted) {
 			this._selectColumn(index, 0);
 		}
 		this._map.sendUnoCommand('.uno:HideColumn');
@@ -254,7 +257,8 @@ L.Control.Header = L.Class.extend({
 	},
 
 	showColumn: function(index) {
-		if (!this._headerInfo.getElementData(index).isCurrent) {
+		if (!this._headerInfo.getElementData(index).isCurrent
+		&& !this._headerInfo.getElementData(index).isHighlighted) {
 			this._selectColumn(index, 0);
 		}
 		this._map.sendUnoCommand('.uno:ShowColumn');


### PR DESCRIPTION
Signed-off-by: Pranam Lashkari <lpranam@collabora.com>
Change-Id: I141dd097e326c99021f5f85b95113e79c57cadd8


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
there can only be one isCurrent row/col
in case of multiple row/col selected,
original condition may fail as row/col maybe selected
but not the current.

added condition to also check if the row/col is selected


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

