### PR TITLE
RTL: user list: target rtl attribute instead of class

### DIFF
--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -1131,7 +1131,7 @@ menu-entry-with-icon.padding-left + menu-entry-icon.width */
 	font-size: 12px;
 }
 
-#userListPopover.rtl {
+html[dir='rtl'] #userListPopover {
 	right: unset !important;
 	left: 5px;
 }
@@ -1149,7 +1149,7 @@ menu-entry-with-icon.padding-left + menu-entry-icon.width */
 	right: 16px;
 }
 
-#userListPopover.rtl::after {
+html[dir='rtl'] #userListPopover::after {
 	right: unset !important;
 	left: 16px;
 }

--- a/browser/src/control/Control.UserList.js
+++ b/browser/src/control/Control.UserList.js
@@ -43,12 +43,6 @@ L.Control.UserList = L.Control.extend({
 
 
 		this.registerHeaderAvatarEvents();
-
-		var isRTL = document.documentElement.dir === 'rtl';
-		if (isRTL) {
-			var popover = document.querySelector('#userListPopover');
-			L.DomUtil.addClass(popover, 'rtl');
-		}
 	},
 
 	escapeHtml: function(input) {


### PR DESCRIPTION
Improvement on top of 89f55aaa183ed8a301b64a45b3146c3ef30ac23e
- no need to add additional classes to each element when we
	can target html element's rtl attribute

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I719b9c8b02add7948bc4ae819ae5e48f1aa33342
