### PR TITLE
calc: fix commentsPos field is empty string instead of empty array

### DIFF
--- a/loleaflet/src/layer/tile/CalcTileLayer.js
+++ b/loleaflet/src/layer/tile/CalcTileLayer.js
@@ -716,11 +716,17 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 		} else if (values.comments) {
 			app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).clearList();
 			app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).importComments(values.comments);
-		} else if (values.commentsPos) {
+		} else if (values.commentsPos === '' || values.commentsPos) {
+			// as of co-2021 we use a new jsonwriter for json callbacks and it generates an empty array.
+			// but in cp-6.4 we use boost for generating json and it cannot create an empty array but instead it creates empty string
+			if (values.commentsPos === '')
+				values.commentsPos = [];
 			var section = app.sectionContainer.getSectionWithName(L.CSections.CommentList.name);
-			section.sectionProperties.commentList.forEach(function (comment) {
-				comment.valid = false;
-			});
+			if (section) {
+				section.sectionProperties.commentList.forEach(function (comment) {
+					comment.valid = false;
+				});
+			}
 			for (var index in values.commentsPos) {
 				comment = values.commentsPos[index];
 				if (section)


### PR DESCRIPTION
as of co-2021 we use a new jsonwriter for json callbacks and it generates an empty array.
but in cp-6.4 we use boost for generating json and it cannot create an empty array
but instead it creates an empty string

The previous fix was taking advantage of it being an empty array

Signed-off-by: Mert Tumer <mert.tumer@collabora.com>
Change-Id: I0b4a4b39c3cff0b2f054765dbc47527633b56151


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

