### PR TITLE
unit-wopi-async-slow: increase timeout

### DIFF
--- a/test/UnitWOPISlow.cpp
+++ b/test/UnitWOPISlow.cpp
@@ -55,7 +55,7 @@ public:
         , _inputCount(0)
     {
         // We need more time than the default.
-        setTimeout(std::chrono::minutes(5));
+        setTimeout(std::chrono::minutes(10));
 
         // Read the document data and store as string in memory.
         const auto data = helpers::readDataFromFile(LargeDocumentFilename);


### PR DESCRIPTION
When running this test against a debug core.git, then this test times
out for me. But if I increase the timeout, then it passes after 316s
just fine.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I1cd0d227dd9aac7279f991493b9aaa7c07468fdd
