### PR TITLE
Remove border color from #toolbar-up on mobile

### DIFF
--- a/browser/css/device-mobile.css
+++ b/browser/css/device-mobile.css
@@ -391,6 +391,7 @@ button.vex-dialog-button-secondary.vex-dialog-button.vex-last {
 	padding-top: 0px;
 	padding-bottom: 0px;
 	background: transparent;
+	border-color: transparent;
 }
 #formulabar {
 	padding: 0px !important;


### PR DESCRIPTION
This was affecting some themes and plus is not used anywhere on mobile
it was just causing troubles for no benefit

On mobile we rely on the bottom border of toolbar wrapper and thus
toolbar-up doesn't need any border. For now I opted to just make
transparent to avoid any bad outcomes with positions etc.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Idd4f08c15ac252ffd410bc7e919975e35512963c
