### PR TITLE
coolconfig: allow set command to create new config settings

### DIFF
--- a/tools/Config.cpp
+++ b/tools/Config.cpp
@@ -373,11 +373,14 @@ int Config::main(const std::vector<std::string>& args)
                 const std::string val = _coolConfig.getString(args[1]);
                 std::cout << "Previous value found in config file: \""  << val << '"' << std::endl;
                 std::cout << "Changing value to: \"" << args[2] << '"' << std::endl;
-                _coolConfig.setString(args[1], args[2]);
-                changed = true;
             }
             else
-                std::cerr << "No property, \"" << args[1] << "\"," << " found in config file." << std::endl;
+            {
+                std::cout << "No property, \"" << args[1] << "\"," << " found in config file." << std::endl;
+                std::cout << "Adding it as new with value: \"" << args[2] << '"' << std::endl;
+            }
+            _coolConfig.setString(args[1], args[2]);
+            changed = true;
         }
         else
             std::cerr << "set expects a key and value as arguments" << std::endl


### PR DESCRIPTION
Signed-off-by: Andras Timar <andras.timar@collabora.com>
Change-Id: I1efcca7a773df366a2cca1d56f1d6fb967402deb


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

