### PR TITLE
Cleanup disconnecting sessions while recovering an unloading document

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1063,13 +1063,16 @@ private:
         if (viewCount == 1)
         {
 #if !MOBILEAPP
-            if (_sessions.empty())
-            {
-                LOG_INF("Document [" << anonymizeUrl(_url) << "] has no more views, exiting bluntly.");
-                flushTraceEventRecordings();
-                Log::shutdown();
-                std::_Exit(EX_OK);
-            }
+            LOG_INF("Document [" << anonymizeUrl(_url) << "] has no more views"
+                                 << (_sessions.size()
+                                         ? ", but has " + std::to_string(_sessions.size()) +
+                                               " sessions still"
+                                         : "")
+                                 << ", exiting bluntly.");
+
+            flushTraceEventRecordings();
+            Log::shutdown();
+            std::_Exit(EX_OK);
 #endif
             LOG_INF("Document [" << anonymizeUrl(_url) << "] has no more views, but has " <<
                     _sessions.size() << " sessions still. Destroying the document.");

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -2061,6 +2061,7 @@ std::size_t DocumentBroker::removeSession(const std::string& id)
                                      << " active). IsReadOnly: " << session->isReadOnly()
                                      << ", IsViewLoaded: " << session->isViewLoaded()
                                      << ", IsWaitDisconnected: " << session->inWaitDisconnected()
+                                     << ", Unloading: " << _docState.isUnloadRequested()
                                      << ", MarkToDestroy: " << _docState.isMarkedToDestroy()
                                      << ", LastEditableSession: " << lastEditableSession
                                      << ", DontSaveIfUnmodified: " << dontSaveIfUnmodified
@@ -3328,6 +3329,7 @@ void DocumentBroker::dumpState(std::ostream& os)
 
     auto now = std::chrono::steady_clock::now();
 
+    os << std::boolalpha;
     os << " Broker: " << COOLWSD::anonymizeUrl(_filename) << " pid: " << getPid();
     if (_docState.isMarkedToDestroy())
         os << " *** Marked to destroy ***";
@@ -3356,6 +3358,7 @@ void DocumentBroker::dumpState(std::ostream& os)
     if (_docState.activity() == DocumentState::Activity::Rename)
         os << "\n  (new name: " << _renameFilename << ')';
     os << "\n  unload requested: " << _docState.isUnloadRequested();
+    os << "\n  marked to destroy: " << _docState.isMarkedToDestroy();
     os << "\n  last saved: " << Util::getSteadyClockAsString(_storageManager.getLastUploadTime());
     os << "\n  last save request: "
        << Util::getSteadyClockAsString(_saveManager.lastSaveRequestTime());
@@ -3379,12 +3382,15 @@ void DocumentBroker::dumpState(std::ostream& os)
 
 #if !MOBILEAPP
     // Bit nasty - need a cleaner way to dump state.
+    os << "\n  Sessions:";
     for (auto &it : _sessions)
     {
         auto proto = it.second->getProtocol();
         auto proxy = dynamic_cast<ProxyProtocolHandler *>(proto.get());
         if (proxy)
             proxy->dumpProxyState(os);
+        else
+            std::static_pointer_cast<MessageHandlerInterface>(it.second)->dumpState(os);
     }
 #endif
 }

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -255,6 +255,11 @@ public:
     /// Hard removes a session by ID, only for ClientSession.
     void finalRemoveSession(const std::string& id);
 
+    /// Remove any pending sessions that were used for saving and uploading
+    /// as the last session. This is necessary when we recover an unloading
+    /// document when a new client connects while we are unloading.
+    void cleanupPendingSaveSessions();
+
     /// Create new client session
     std::shared_ptr<ClientSession> createNewClientSession(
         const std::shared_ptr<ProtocolHandlerInterface> &ws,


### PR DESCRIPTION
This still allows recovering from unloading, if a new client connects to the same document, but it does still seem to suffer corner cases. #3998 avoids all the corner-cases by pushing back on the new connection while unloading, so that the client will have to retry again later.

- wsd: dump the state of the sessions of DocBroker
- wsd: cleanup disconnecting sessions when a new session connects
- wsd: exit the Kit process when the last active session is disconnected
