### PR TITLE
clientsession_fuzzer: fix missing UnitWSD

### DIFF
--- a/fuzzer/ClientSession.cpp
+++ b/fuzzer/ClientSession.cpp
@@ -7,6 +7,7 @@
 bool DoInitialization()
 {
     COOLWSD::ChildRoot = "/fuzz/child-root";
+    UnitBase::init(UnitBase::UnitType::Wsd, std::string());
     return true;
 }
 


### PR DESCRIPTION
An alternative would be to tweak online-fuzz/wsd/DocumentBroker.cpp:534
to check for Util::isFuzzing(), but this is probably a better & more
generic way.

'./clientsession_fuzzer fuzzer/data/load' now works again.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I4d9fa387597695ff0802b268bc4d86be51dbabb2
