### PR TITLE
automatically migrate old config during package upgrade (6.4 -> 21.11)

### DIFF
--- a/coolwsd.spec.in
+++ b/coolwsd.spec.in
@@ -188,6 +188,7 @@ echo "   Done."
 %post
 setcap cap_fowner,cap_chown,cap_mknod,cap_sys_chroot=ep /usr/bin/coolforkit
 setcap cap_sys_admin=ep /usr/bin/coolmount
+/usr/bin/coolconfig migrateconfig --write
 
 %if 0%{?rhel} >= 7
 %systemd_post coolwsd.service

--- a/debian/coolwsd.postinst.in
+++ b/debian/coolwsd.postinst.in
@@ -6,6 +6,7 @@ case "$1" in
     configure)
 	setcap cap_fowner,cap_chown,cap_mknod,cap_sys_chroot=ep /usr/bin/coolforkit || true
 	setcap cap_sys_admin=ep /usr/bin/coolmount || true
+	/usr/bin/coolconfig migrateconfig --write
 
 	adduser --quiet --system --group --home /opt/cool cool
 	chown cool: /etc/coolwsd/coolwsd.xml


### PR DESCRIPTION
Signed-off-by: Andras Timar <andras.timar@collabora.com>
Change-Id: I76d06ca68dbb7e62fd4f5e31215d4ba3f753dce9


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

