### PR TITLE
Vex Replacement

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -142,6 +142,7 @@ COOL_CSS_LST =\
 	$(srcdir)/css/btns.css \
 	$(srcdir)/css/notebookbar.css \
 	$(srcdir)/css/jssidebar.css \
+	$(srcdir)/css/idialog.css \
 	$(srcdir)/css/override-vex.css \
 	$(srcdir)/css/override-smartmenus.css \
 	$(srcdir)/css/jquery-ui-lightness.css

--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -299,6 +299,7 @@ COOL_JS_LST =\
 	src/layer/marker/Marker.Drag.js \
 	src/control/Control.Toolbar.js \
 	src/control/Control.Command.js \
+	src/control/IDialog.js \
 	src/control/Control.js \
 	src/control/Control.PartsPreview.js \
 	src/control/Control.GroupBase.js \

--- a/browser/css/idialog.css
+++ b/browser/css/idialog.css
@@ -23,3 +23,16 @@
 	background: #fff;
 }
 
+.idialog-footer {
+	display: flex;
+	margin-right: -5px;
+	flex-direction: row;
+	justify-content: space-between;
+}
+
+.idialog-button {
+	display: flex;
+	margin: 5px;
+	align-items: center;
+	height: 32px;
+}

--- a/browser/css/idialog.css
+++ b/browser/css/idialog.css
@@ -1,0 +1,25 @@
+.idialog-wrap {
+	position: fixed;
+	overflow: auto;
+	left: 0;
+	right: 0;
+	top: 0;
+	bottom: 0;
+	box-sizing: border-box;
+	z-index: 1106;
+}
+
+.idialog-content {
+	position: fixed;
+	margin: 0 auto;
+	top: 50%;
+	left: 50%;
+	-webkit-transform: translate(-50%, -50%);
+	transform: translate(-50%, -50%);
+	max-width: 100%;
+	width: 100px;
+	border: 1px solid #a4a4a4;
+	border-radius: 4px;
+	background: #fff;
+}
+

--- a/browser/src/control/IDialog.js
+++ b/browser/src/control/IDialog.js
@@ -4,35 +4,33 @@
  */
 
 L.IDialog = L.Class.extend({
-	options: {
-		prefix: 'idialog'
-	},
+	statics: {
+		container: {},
 
-	show: function (options) {
-		var container, content;
+		show: function (options) {
+			var container, content;
 
-		container = L.DomUtil.create('div', this.options.prefix + '-wrap');
-		content = L.DomUtil.create('div', this.options.prefix + '-content', container);
-		content.innerHTML = this.innerHtml(options.message);
-		document.body.appendChild(container);
-	},
+			container = L.DomUtil.create('div', options.prefix + '-wrap');
+			content = L.DomUtil.create('div', options.prefix + '-content', container);
+			content.innerHTML = L.IDialog.innerHtml(options.message);
+			document.body.appendChild(container);
+			L.IDialog.container = container;
+		},
 
-	innerHtml: function (string) {
-		if (typeof string === 'undefined')
-			return '';
+		innerHtml: function (string) {
+			if (typeof string === 'undefined')
+				return '';
 
-		var elem = L.DomUtil.create('div', '');
-		elem.appendChild(document.createTextNode(string));
-		return elem.innerHTML;
-	},
+			var elem = L.DomUtil.create('div', '');
+			elem.appendChild(document.createTextNode(string));
+			return elem.innerHTML;
+		},
 
-	isVisible: function () {
-		var elem = document.body.querySelector('.' + this.options.prefix + '-wrap');
-		return elem && elem.style.display !== 'none';
+		isVisible: function () {
+			var elem = L.IDialog.container;
+			return elem && elem.parentNode == document.body &&
+				elem.style.display !== 'none';
+		}
 	}
 });
-
-L.iDialog = function (options) {
-	return new L.IDialog(options);
-};
 

--- a/browser/src/control/IDialog.js
+++ b/browser/src/control/IDialog.js
@@ -33,7 +33,8 @@ L.IDialog = L.Class.extend({
 			container = L.DomUtil.create('div', prefix + '-footer');
 			for (item in buttons) {
 				data = buttons[item];
-				button = L.DomUtil.create(data.type, data.className, container);
+				button = L.DomUtil.create('button', data.className, container);
+				button.type = data.type;
 				button.textContent = data.text;
 			}
 			return container;

--- a/browser/src/control/IDialog.js
+++ b/browser/src/control/IDialog.js
@@ -27,9 +27,7 @@ L.IDialog = L.Class.extend({
 		},
 
 		isVisible: function () {
-			var elem = L.IDialog.container;
-			return elem && elem.parentNode == document.body &&
-				elem.style.display !== 'none';
+			return L.IDialog.container && L.IDialog.container.parentNode == document.body;
 		}
 	}
 });

--- a/browser/src/control/IDialog.js
+++ b/browser/src/control/IDialog.js
@@ -45,6 +45,10 @@ L.IDialog = L.Class.extend({
 				button = L.DomUtil.create('button', data.className, container);
 				button.type = data.type;
 				button.textContent = data.text;
+
+				if (data.click) {
+					button.addEventListener('click', data.click);
+				}
 			}
 			return container;
 		},

--- a/browser/src/control/IDialog.js
+++ b/browser/src/control/IDialog.js
@@ -13,7 +13,17 @@ L.IDialog = L.Class.extend({
 
 		container = L.DomUtil.create('div', this.options.prefix + '-wrap');
 		content = L.DomUtil.create('div', this.options.prefix + '-content', container);
+		content.innerHTML = this.innerHtml(options.message);
 		document.body.appendChild(container);
+	},
+
+	innerHtml: function (string) {
+		if (typeof string === 'undefined')
+			return '';
+
+		var elem = L.DomUtil.create('div', '');
+		elem.appendChild(document.createTextNode(string));
+		return elem.innerHTML;
 	},
 
 	isVisible: function () {

--- a/browser/src/control/IDialog.js
+++ b/browser/src/control/IDialog.js
@@ -22,6 +22,11 @@ L.IDialog = L.Class.extend({
 			}
 		},
 
+		close: function () {
+			if (L.IDialog.container)
+				document.body.removeChild(L.IDialog.container);
+		},
+
 		innerHtml: function (string) {
 			if (typeof string === 'undefined')
 				return '';

--- a/browser/src/control/IDialog.js
+++ b/browser/src/control/IDialog.js
@@ -7,7 +7,7 @@ L.IDialog = L.Class.extend({
 	statics: {
 		container: {},
 
-		show: function (options) {
+		open: function (options) {
 			var container, content;
 
 			container = L.DomUtil.create('div', options.prefix + '-wrap');

--- a/browser/src/control/IDialog.js
+++ b/browser/src/control/IDialog.js
@@ -13,6 +13,7 @@ L.IDialog = L.Class.extend({
 			container = L.DomUtil.create('div', options.prefix + '-wrap');
 			content = L.DomUtil.create('div', options.prefix + '-content', container);
 			content.innerHTML = L.IDialog.innerHtml(options.message);
+			content.appendChild(L.IDialog.createButtons(options.prefix, options.buttons));
 			document.body.appendChild(container);
 			L.IDialog.container = container;
 		},
@@ -24,6 +25,18 @@ L.IDialog = L.Class.extend({
 			var elem = L.DomUtil.create('div', '');
 			elem.appendChild(document.createTextNode(string));
 			return elem.innerHTML;
+		},
+
+		createButtons: function (prefix, buttons) {
+			var container, button, item, data;
+
+			container = L.DomUtil.create('div', prefix + '-footer');
+			for (item in buttons) {
+				data = buttons[item];
+				button = L.DomUtil.create(data.type, data.className, container);
+				button.textContent = data.text;
+			}
+			return container;
 		},
 
 		isVisible: function () {

--- a/browser/src/control/IDialog.js
+++ b/browser/src/control/IDialog.js
@@ -1,0 +1,28 @@
+/* -*- js-indent-level: 8 -*- */
+/*
+ * L.IDialog
+ */
+
+L.IDialog = L.Class.extend({
+	options: {
+		prefix: 'idialog'
+	},
+
+	show: function (options) {
+		var container, content;
+
+		container = L.DomUtil.create('div', this.options.prefix + '-wrap');
+		content = L.DomUtil.create('div', this.options.prefix + '-content', container);
+		document.body.appendChild(container);
+	},
+
+	isVisible: function () {
+		var elem = document.body.querySelector('.' + this.options.prefix + '-wrap');
+		return elem && elem.style.display !== 'none';
+	}
+});
+
+L.iDialog = function (options) {
+	return new L.IDialog(options);
+};
+

--- a/browser/src/control/IDialog.js
+++ b/browser/src/control/IDialog.js
@@ -16,6 +16,10 @@ L.IDialog = L.Class.extend({
 			content.appendChild(L.IDialog.createButtons(options.prefix, options.buttons));
 			document.body.appendChild(container);
 			L.IDialog.container = container;
+
+			if (options.afterOpen && typeof options.afterOpen === 'function') {
+				options.afterOpen.call(container);
+			}
 		},
 
 		innerHtml: function (string) {


### PR DESCRIPTION
- browser: add initial IDialog class
- browser: add initial idialog.css
- browser: insert content to the dialog
- browser: use statics methods
- browser: simplify isVisible
- browser: rename 'show' -> 'open'
- browser: create dialog buttons
- browser: fix button type
- browser: initial CSS to buttons
- browser: add 'afterOpen' callback
- browser: add 'close' function
- browser: add button 'click' event listener
