### PR TITLE
fix infinite scrolling

### DIFF
--- a/loleaflet/src/layer/tile/ScrollSection.ts
+++ b/loleaflet/src/layer/tile/ScrollSection.ts
@@ -125,9 +125,10 @@ class ScrollSection {
 	}
 
 	public onScrollBy (e: any) {
-		if (this.map._docLayer._docType !== 'spreadsheet')
-			this.map.panBy(new L.Point(e.x, e.y), {animate: false});
-		else {
+		if (this.map._docLayer._docType !== 'spreadsheet') {
+			this.scrollVerticalWithOffset(e.y);
+			this.scrollHorizontalWithOffset(e.x);
+		} else {
 			// For Calc, top position shouldn't be below zero, for others, we can activate a similar check if needed (while keeping in mind that top position may be below zero for others).
 			var docTopLef = this.containerObject.getDocumentTopLeft();
 


### PR DESCRIPTION
it is possible to scroll outside the document
with anything that uses onScrollBy function because
it does not respect the scroll area.

Signed-off-by: Mert Tumer <mert.tumer@collabora.com>
Change-Id: Ia8609311b8ead97f5866ff6300ddebb0d3f5b14d


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

