### PR TITLE
RTL: incorrect cell selection to mouse clicks...

### DIFF
--- a/browser/html/cool.html.m4
+++ b/browser/html/cool.html.m4
@@ -225,7 +225,7 @@ m4_ifelse(MOBILEAPP,[true],
         <div id="slide-sorter"></div>
         <div id="presentation-toolbar" style="display: none"></div>
       </div>
-      <div id="document-container" class="readonly">
+      <div id="document-container" class="readonly" dir="ltr">
         <div id="map"></div>
       </div>
       <div id="sidebar-dock-wrapper" style="display: none;">


### PR DESCRIPTION
when we set ui language to ar or any other rtl language via url.

When language is RTL, since the commit:

RTL: Serve html with correct RTL settings
a3c5c71107a1eda32c39d11ba6ee1c3aaca29e6a

The dir attribute of body will be "rtl". The div "document-container"
itself occupies full width of the viewport but one of its children div
with id="map" has to "track" the document area of the canvas
element(canvas element occupies full width). The positioning of "map"
div is done in js assuming an "ltr" case. We could change all that based
on RTL flag, but at the moment a less riskier fix is to set the dir
attribute of "document-container" unconditionally to "ltr".

This also fixes all wrong svg based marker-selections too - for instance
shape/chart selections.

Comment cell hover popups were also affected by the same issue hence
fixed by this commit as well.

Signed-off-by: Dennis Francis <dennis.francis@collabora.com>
Change-Id: I5e20474d5b010976de12f7beee40a5c44df1b867


* Target version: master 

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

