### PR TITLE
fix fontname/fontsize comboboxes shows first element on mixed selection

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -1556,7 +1556,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			if ($(this).val())
 				builder.callback('combobox', 'selected', data, $(this).val()+ ';' + $(this).children('option:selected').text(), builder);
 		});
-
+		var hasSelectedEntry = false;
 		if (typeof(data.entries) === 'object') {
 			for (var index in data.entries) {
 				var isSelected = false;
@@ -1569,10 +1569,15 @@ L.Control.JSDialogBuilder = L.Control.extend({
 				var option = L.DomUtil.create('option', '', listbox);
 				option.value = index;
 				option.innerText = data.entries[index];
-				if (isSelected)
-					option.selected = 'true';
+				if (isSelected) {
+					option.selected = true;
+					hasSelectedEntry = true;
+				}
 			}
 		}
+		// no selected entry; set the visible value to empty string
+		if (!hasSelectedEntry)
+			$(listbox).val('');
 
 		return false;
 	},


### PR DESCRIPTION
these boxes should display empty string when there's a mixed of font name
and/or sized text selected as the desktop application.

to test it, it needs a core change: https://gerrit.libreoffice.org/c/core/+/128551

Signed-off-by: Mert Tumer <mert.tumer@collabora.com>
Change-Id: I2564f14f9411711b5a1791d08a90d85235863b18


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

