### PR TITLE
Backports from Master

### DIFF
--- a/test/TileCacheTests.cpp
+++ b/test/TileCacheTests.cpp
@@ -1770,10 +1770,12 @@ void TileCacheTests::testTileInvalidatedOutside()
     sendChar(socket, 'x', skNone, testname);
 
     // First wsd forwards the invalidation
-    std::string sInvalidate = assertResponseString(socket, "invalidatetiles:", testname);
+    const std::string sInvalidate = assertResponseString(socket, "invalidatetiles:", testname);
+    LOK_ASSERT_MESSAGE("Expected invalidatetiles message.", !sInvalidate.empty());
     StringVector tokens(Util::tokenize(sInvalidate, ' '));
-    int y = std::stoi(tokens[3].substr(std::string("y=").size()));
-    int height = std::stoi(tokens[5].substr(std::string("height=").size()));
+    LOK_ASSERT_MESSAGE("Expected at least 6 tokens.", tokens.size() >= 6);
+    const int y = std::stoi(tokens[3].substr(std::string("y=").size()));
+    const int height = std::stoi(tokens[5].substr(std::string("height=").size()));
 
 
     // Set client visible area to make it not having intersection with the invalidate rectangle, but having shared tiles

--- a/test/UnitWOPILock.cpp
+++ b/test/UnitWOPILock.cpp
@@ -17,13 +17,7 @@
 
 class UnitWopiLock : public WopiTestServer
 {
-    enum class Phase
-    {
-        Load,
-        LockDocument,
-        UnlockDocument,
-        Polling
-    } _phase;
+    STATES_ENUM(Phase, _phase, Load, LockDocument, UnlockDocument, Polling);
 
     std::string _lockState;
     std::string _lockString;
@@ -41,7 +35,7 @@ public:
         Poco::URI uriReq(request.getURI());
         Poco::RegularExpression regInfo("/wopi/files/[0-9]");
         Poco::RegularExpression regContent("/wopi/files/[0-9]/contents");
-        LOG_INF("Fake wopi host request: " << uriReq.toString());
+        LOG_INF("Fake wopi host request: " << request.getMethod() << ' ' << uriReq.toString());
 
         // CheckFileInfo
         if (request.getMethod() == "GET" && regInfo.match(uriReq.getPath()))
@@ -133,12 +127,14 @@ public:
 
     void assertLockRequest(const Poco::Net::HTTPRequest& request)
     {
+        LOG_TST("assertLockRequest: " << request.getURI());
+
         std::string newLockState = request.get("X-WOPI-Override", std::string());
         std::string lock = request.get("X-WOPI-Lock", std::string());
         if (_phase == Phase::LockDocument && newLockState == "LOCK")
         {
             LOK_ASSERT_MESSAGE("Lock String cannot be empty", lock != std::string());
-            _phase = Phase::UnlockDocument;
+            TRANSITION_STATE(_phase, Phase::UnlockDocument);
             _lockState = newLockState;
             _lockString = lock;
 
@@ -147,7 +143,7 @@ public:
         {
             LOK_ASSERT_MESSAGE("Document it not locked", _lockState != "UNLOCK");
             LOK_ASSERT_EQUAL(_lockString, lock);
-            _phase = Phase::Polling;
+            TRANSITION_STATE(_phase, Phase::Polling);
             exitTest(TestResult::Ok);
         }
     }
@@ -160,12 +156,11 @@ public:
         {
             case Phase::Load:
             {
-                _phase = Phase::LockDocument;
                 initWebsocket("/wopi/files/0?access_token=anything");
                 addWebSocket();
                 helpers::sendTextFrame(*getWs()->getLOOLWebSocket(), "load url=" + getWopiSrc(), testName);
                 helpers::sendTextFrame(*getWsAt(1)->getLOOLWebSocket(), "load url=" + getWopiSrc(), testName);
-                SocketPoll::wakeupWorld();
+                TRANSITION_STATE(_phase, Phase::LockDocument);
                 break;
             }
             case Phase::LockDocument:

--- a/test/WopiTestServer.hpp
+++ b/test/WopiTestServer.hpp
@@ -96,7 +96,7 @@ public:
 
     void addWebSocket()
     {
-        LOG_TST("Addigin additional socket to the fake WOPI server: /lool/" << _wopiSrc << "/ws");
+        LOG_TST("Adding additional socket to the fake WOPI server: /lool/" << _wopiSrc << "/ws");
         const auto& _ws = _wsList.emplace(_wsList.end(), std::unique_ptr<UnitWebSocket>(new UnitWebSocket("/lool/" + _wopiSrc + "/ws")));
 
         assert((*_ws).get());

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -2295,7 +2295,7 @@ std::shared_ptr<ClientSession> DocumentBroker::createNewClientSession(
 {
     try
     {
-        if (isMarkedToDestroy())
+        if (isMarkedToDestroy() || _docState.isUnloadRequested())
         {
             LOG_INF("DocumentBroker ["
                     << getDocKey()

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1137,6 +1137,12 @@ DocumentBroker::NeedToUpload DocumentBroker::needToUploadToStorage() const
         return NeedToUpload::Force;
     }
 
+    if (_storage == nullptr)
+    {
+        // This can happen when we reject the connection (unauthorized).
+        return NeedToUpload::No;
+    }
+
     // Get the modified-time of the file on disk.
     const auto st = FileUtil::Stat(_storage->getRootFilePathUploading());
     const std::chrono::system_clock::time_point currentModifiedTime = st.modifiedTimepoint();


### PR DESCRIPTION
- wsd: test: improve and disable TileCacheTests::testTileInvalidatedOutside
- wsd: dump the state of the sessions of DocBroker
- wsd: do not load a new view when unloading
- wsd: test: improve lock tests
- wsd: handle no-storage when shutting down 