### PR TITLE
Toolbars use var(--color-toolbar) and var(--color-border)

### DIFF
--- a/browser/css/color-palette.css
+++ b/browser/css/color-palette.css
@@ -12,5 +12,8 @@
 	--gray-color: #b6b6b6;
 	--white-bg-color: #fff;
 
+	--color-main-background: #fff;
+	--color-border: #b6b6b6;
+
 	--border-radius: 4px;
 }

--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -218,7 +218,7 @@ nav.spreadsheet-color-indicator ~ #sidebar-dock-wrapper {
 	width: 100%;
 	border-top: none;
 	z-index: 11 !important;
-	border-bottom: 1px solid var(--gray-color);
+	border-bottom: 1px solid var(--color-border);
 }
 
 #toolbar-logo {

--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -233,10 +233,9 @@
 }
 
 #toolbar-wrapper.hasnotebookbar {
-	background: var(--white-bg-color);
+	background: var(--color-main-background);
 	position: relative;
 	z-index: 11;
-	background-color: white;
 }
 
 .cell.notebookbar {

--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -17,11 +17,14 @@
 	padding: 0;
 	bottom: 0;
 	z-index: 11;
-	border-top: 1px solid #bbbbbb;
+	border-top: 1px solid var(--color-border);
 	display: block;
 }
 #toolbar-down *{
 	font-family: var(--cool-font);
+}
+#toolbar-down table {
+	background: var(--color-main-background);
 }
 #tb_actionbar_item_LanguageStatus table table td:first-of-type{
 	min-width: max-content !important;
@@ -132,7 +135,7 @@ w2ui-toolbar {
 .w2ui-toolbar .w2ui-break {
 	height: 18px;
 	background-image: none;
-	background-color: #f1f1f1;
+	background-color: var(--color-border);
 }
 
 /* For MS Edge 40, the select2 combo boxes need to have higher z-index than #map


### PR DESCRIPTION
You can simple modify the background colors of the toolbars
for now NB and bottom toolbar
You can edit the borders and separators with --color-border
so it's very easy to remove focus for separators

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I661513031eb231d6ffc5036df38381d7fdcac5a7

result look the same than before, 
but the values names are easier to understood 
and changes like in https://github.com/nextcloud/richdocuments/issues/1976
are more simple.