### PR TITLE
fix selectedFont is not shown on sidebar

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -1575,9 +1575,16 @@ L.Control.JSDialogBuilder = L.Control.extend({
 				}
 			}
 		}
-		// no selected entry; set the visible value to empty string
-		if (!hasSelectedEntry)
-			$(listbox).val('');
+		// no selected entry; set the visible value to empty string unless the font is not included in the entries
+		if (!hasSelectedEntry) {
+			if (title) {
+				var newOption = L.DomUtil.create('option', '', listbox);
+				newOption.value = ++index;
+				newOption.innerText = title;
+				newOption.selected = true;
+			} else
+				$(listbox).val('');
+		}
 
 		return false;
 	},


### PR DESCRIPTION
if the font is not includede in the core and already exists
in the document, we need to display that as menubar's fontnamebox
does

Signed-off-by: Mert Tumer <mert.tumer@collabora.com>
Change-Id: Ia725fb5d031aca9382f0247772bdc9e7bbe95729


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

