### PR TITLE
make sure modifiedTimeUs calculates with enough precision

### DIFF
--- a/common/FileUtil.hpp
+++ b/common/FileUtil.hpp
@@ -169,9 +169,10 @@ namespace FileUtil
         }
 
         /// Returns the modified unix-time in microseconds since epoch.
-        std::size_t modifiedTimeUs() const
+        int64_t modifiedTimeUs() const
         {
-            return (modifiedTime().tv_sec * 1000 * 1000) + (modifiedTime().tv_nsec / 1000);
+            // cast to make sure the calculation happens with enough bits
+            return (static_cast<int64_t>(modifiedTime().tv_sec) * 1000 * 1000) + (modifiedTime().tv_nsec / 1000);
         }
 
         /// Returns the modified unix-time in milliseconds since epoch.


### PR DESCRIPTION
otherwise, on some platforms, the calculation might occur with 32-bits, but we really need 64 bits for microseconds.
Also tweak the return type to make sure we use 64 bits.

Signed-off-by: Noel Grandin <noel.grandin@collabora.co.uk>
Change-Id: Ie8b8a49938c7ac2cfe7c5fc1dd6629e6ea347115


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

