### PR TITLE
Admin: alternate std::localtime

### DIFF
--- a/wsd/AdminModel.cpp
+++ b/wsd/AdminModel.cpp
@@ -555,10 +555,13 @@ void AdminModel::addDocument(const std::string& docKey, pid_t pid,
     {
         std::ostringstream osst;
         Poco::AutoPtr<Poco::Channel> channel = Log::logger().getChannel();
-        const auto now = std::chrono::system_clock::now();
-        const auto current = std::chrono::system_clock::to_time_t(now);
-        osst << std::put_time(std::localtime(&current), "%F %T")
-             << " docstats : adding a document : " << filename
+        char output[64];
+        std::chrono::system_clock::time_point now = std::chrono::system_clock::now();
+        std::time_t current = std::chrono::system_clock::to_time_t(now);
+        std::tm tm;
+        gmtime_r(&current, &tm);
+        strftime(output, sizeof(output), "%F %T", &tm);
+        osst << output << " docstats : adding a document : " << filename
              << ", created by : " << COOLWSD::anonymizeUsername(userName)
              << ", using WopiHost : " << COOLWSD::anonymizeUrl(wopiHost)
              << ", allocating memory of : " << memoryAllocated;


### PR DESCRIPTION
I saw similar implementations in Util.cpp

Change-Id: I3927ef9989de2217dee6c4b3034c9ffbd8fb184d
Signed-off-by: Yunusemre Şentürk <yunusemre@collabora.com>

* Target version: master 

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

