### PR TITLE
wsd: Adjust log levels

### DIFF
--- a/common/FileUtil.cpp
+++ b/common/FileUtil.cpp
@@ -321,7 +321,7 @@ namespace FileUtil
         if (access(path, W_OK) == 0)
             return true;
 
-        LOG_ERR("Cannot access path [" << path << "]: " << strerror(errno));
+        LOG_INF("No write access to path [" << path << "]: " << strerror(errno));
         return false;
     }
 

--- a/common/JailUtil.cpp
+++ b/common/JailUtil.cpp
@@ -369,7 +369,7 @@ bool updateDynamicFilesImpl(const std::string& sysTemplate)
         {
             disableBindMounting(); // We can't mount from incomplete systemplate that can't be updated.
             LinkDynamicFiles = false;
-            LOG_INF("The systemplate directory ["
+            LOG_WRN("The systemplate directory ["
                     << sysTemplate << "] is read-only, and at least [" << dstFilename
                     << "] is out-of-date. Will have to copy sysTemplate to jails. To restore "
                        "optimal performance, make sure the files in ["


### PR DESCRIPTION
A non-writable path isn't an error in itself.

The reason why the service tried to write the systemplate,
and the perf implications is worth reporting even on default
log level.

Signed-off-by: Aron Budea <aron.budea@collabora.com>
Change-Id: Ie168875ceb4e501291676a5aa4ddc21b88c5761f

* Target version: master 
