### PR TITLE
tools: fix -Werror,-Wfortify-source

### DIFF
--- a/tools/map.cpp
+++ b/tools/map.cpp
@@ -51,7 +51,7 @@ bool DumpAll = false;
 bool DumpStrings = false;
 int  DumpWidth = 32;
 
-#define MAP_SIZE 20
+#define MAP_SIZE 21
 #define PATH_SIZE 1000 // No harm in having it much larger than strictly necessary. Avoids compiler warning.
 #define BUFFER_SIZE 9600
 


### PR DESCRIPTION
'sscanf' may overflow; destination buffer in 'smap_key' has size 20, but
the corresponding specifier in tools/map.cpp:570 may require size 21.

Change-Id: Ie7356db924193777869a39b882512a864c0e10c5
