### PR TITLE
Document name: Remove hard coded width in pixels

### DIFF
--- a/browser/src/control/Control.DocumentNameInput.js
+++ b/browser/src/control/Control.DocumentNameInput.js
@@ -11,7 +11,6 @@ L.Control.DocumentNameInput = L.Control.extend({
 
 		map.on('doclayerinit', this.onDocLayerInit, this);
 		map.on('wopiprops', this.onWopiProps, this);
-		map.on('resize', this.onResize, this);
 	},
 
 	documentNameConfirm: function() {
@@ -41,13 +40,10 @@ L.Control.DocumentNameInput = L.Control.extend({
 
 	documentNameCancel: function() {
 		$('#document-name-input').val(this.map['wopi'].BreadcrumbDocName);
-		this._setNameInputWidth();
 		this.map._onGotFocus();
 	},
 
 	onDocumentNameKeyPress: function(e) {
-		var tail = (e.keyCode !== 13 && e.keyCode !== 27) ? 'X' : null;
-		this._setNameInputWidth(tail);
 		if (e.keyCode === 13) { // Enter key
 			this.documentNameConfirm();
 		} else if (e.keyCode === 27) { // Escape key
@@ -67,7 +63,6 @@ L.Control.DocumentNameInput = L.Control.extend({
 	},
 
 	onDocLayerInit: function() {
-		this._setNameInputWidth();
 
 		var el = $('#document-name-input');
 
@@ -126,10 +121,6 @@ L.Control.DocumentNameInput = L.Control.extend({
 		}
 	},
 
-	onResize: function() {
-		this._setNameInputWidth();
-	},
-
 	_getMaxAvailableWidth: function() {
 		var x = $('#document-titlebar').prop('offsetLeft') + $('.document-title').prop('offsetLeft') + $('#document-name-input').prop('offsetLeft');
 		var containerWidth = parseInt($('.main-nav').css('width'));
@@ -138,16 +129,6 @@ L.Control.DocumentNameInput = L.Control.extend({
 		return maxWidth;
 	},
 
-	_setNameInputWidth: function(tail) {
-		var documentNameInput = $('#document-name-input');
-		var content = (typeof tail === 'string') ? documentNameInput.val() + tail : documentNameInput.val();
-		var font = documentNameInput.css('font');
-		var textWidth = L.getTextWidth(content, font) + 24;
-		var maxWidth = this._getMaxAvailableWidth();
-		//console.log('_setNameInputWidth: textWidth: ' + textWidth + ', maxWidth: ' + maxWidth);
-		textWidth = Math.min(textWidth, maxWidth);
-		documentNameInput.css('width', textWidth + 'px');
-	}
 });
 
 L.control.documentNameInput = function () {


### PR DESCRIPTION
_setNameInputWidth() was create to set the width for document name
input and it seems to be not necessary now. Plus this is now causing
the document name to be cropped unnecessary when accessing using then
notebookbar UI mode both on editmode and &permission=readonly.
 - Remove those hardcoded pixels and its function.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I2329c55e1c9b0e8a0d0cb90e29b2796984b0bb2e
