### PR TITLE
wsd: fix malformed img-src field

### DIFF
--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -892,7 +892,7 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
         // X-Frame-Options supports only one ancestor, ignore that
         //(it's deprecated anyway and CSP works in all major browsers)
         // frame anchestors are also allowed for img-src in order to load the views avatars
-        cspOss << imgSrc << frameAncestors << "; "
+        cspOss << imgSrc << " " << frameAncestors << "; "
                 << "frame-ancestors " << frameAncestors;
         std::string escapedFrameAncestors;
         Poco::URI::encode(frameAncestors, "'", escapedFrameAncestors);


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

Fix a `CSP` formatting error introduced with 7e94149ec476445a445ffcd0922d83b1c60c5c64.

Spottet this error in cp-6.4.16-2 (however, this tag is not in the merge base but the name sounds legit).

### TODO

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check` (also fail before my change; `common/ConfigUtil.cpp:34:15: error: ‘class Poco::AutoPtr<Poco::Util::XMLConfiguration>’ has no member named ‘reset’`)
- [ ] I have issued `make run` and manually verified that everything looks okay (Fails with the above error)
- [x] Documentation (manuals or wiki) has been updated or is not required

