### PR TITLE
cypress: fix: inconsistent text wrapping text in calc

### DIFF
--- a/cypress_test/integration_tests/desktop/writer/delete_objects_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/delete_objects_spec.js
@@ -2,7 +2,7 @@
 
 var helper = require('../../common/helper');
 
-describe('Delete Objects', {retries: 2}, function() {
+describe('Delete Objects', function() {
 	var origTestFileName = 'delete_objects.odt';
 	var testFileName;
 

--- a/cypress_test/integration_tests/mobile/calc/alignment_options_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/alignment_options_spec.js
@@ -26,12 +26,12 @@ describe('Change alignment settings.', function() {
 		helper.getCursorPos('left', 'currentTextEndPos');
 
 		//remove text selection
-		cy.get('#tb_actionbar_item_acceptformula').then($ele =>{
-			cy.wait(1000);
-			if (Cypress.dom.isVisible($ele)) {
-				cy.wrap($ele).click();
-			}
-		});
+		cy.get('#tb_actionbar_item_acceptformula').should('be.visible')
+			.then($ele =>{
+				if (Cypress.dom.isVisible($ele)) {
+					cy.wrap($ele).click();
+				}
+			});
 
 		cy.get('.cursor-overlay .blinking-cursor')
 			.should('not.exist');

--- a/cypress_test/integration_tests/mobile/calc/bottom_toolbar_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/bottom_toolbar_spec.js
@@ -28,12 +28,12 @@ describe('Interact with bottom toolbar.', function() {
 
 		helper.getCursorPos('left', 'currentTextEndPos');
 
-		cy.get('#tb_actionbar_item_acceptformula').then($ele =>{
-			cy.wait(1000);
-			if (Cypress.dom.isVisible($ele)) {
-				cy.wrap($ele).click();
-			}
-		});
+		cy.get('#tb_actionbar_item_acceptformula').should('be.visible')
+			.then($ele =>{
+				if (Cypress.dom.isVisible($ele)) {
+					cy.wrap($ele).click();
+				}
+			});
 
 		cy.get('.cursor-overlay .blinking-cursor')
 			.should('not.exist');

--- a/cypress_test/integration_tests/multiuser/calc/repair_document_spec.js
+++ b/cypress_test/integration_tests/multiuser/calc/repair_document_spec.js
@@ -66,11 +66,11 @@ describe.skip('Repair Document', function() {
 		helper.expectTextForClipboard('Hello World', frameId1);
 	}
 
-	it('Repair by user-2', { retries : 2 }, function() {
+	it('Repair by user-2', function() {
 		repairDoc('#iframe1', '#iframe2');
 	});
 
-	it('Repair by user-1', { retries : 2 }, function() {
+	it('Repair by user-1', function() {
 		repairDoc('#iframe2', '#iframe1');
 	});
 });

--- a/cypress_test/integration_tests/multiuser/impress/repair_document_spec.js
+++ b/cypress_test/integration_tests/multiuser/impress/repair_document_spec.js
@@ -62,11 +62,11 @@ describe.skip('Repair Document', function() {
 		helper.expectTextForClipboard('Hello', frameId1);
 	}
 
-	it('Repair by user-2', { retries : 2 }, function() {
+	it('Repair by user-2', function() {
 		repairDoc('#iframe1', '#iframe2');
 	});
 
-	it('Repair by user-1', { retries : 2 }, function() {
+	it('Repair by user-1', function() {
 		repairDoc('#iframe2', '#iframe1');
 	});
 });

--- a/cypress_test/integration_tests/multiuser/writer/repair_document_spec.js
+++ b/cypress_test/integration_tests/multiuser/writer/repair_document_spec.js
@@ -43,11 +43,11 @@ describe('Repair Document', function() {
 		helper.expectTextForClipboard('\nHello \n', frameId1);
 	}
 
-	it('Repair by user-2', { retries : 2 }, function() {
+	it('Repair by user-2', function() {
 		repairDoc('#iframe1', '#iframe2');
 	});
 
-	it('Repair by user-1', { retries : 2 }, function() {
+	it('Repair by user-1', function() {
 		repairDoc('#iframe2', '#iframe1');
 	});
 


### PR DESCRIPTION
removed unnecessary 'retries' parameters from the tests we already
have default global value for retries no need for specific tests
Signed-off-by: Rash419 <rashesh.padia@collabora.com>
Change-Id: Idc78831ce240d4d840f3dbc785e66165c6e07d3d


* Target version: master 





