### PR TITLE
NB Writer Stylesview show only preview and no label

### DIFF
--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -462,8 +462,6 @@
 
 #stylesview .ui-iconview-entry {
 	width: 30%;
-	height: 60px;
-	padding: 2px;
 	box-sizing: border-box;
 	border-radius: 0;
 }
@@ -503,17 +501,11 @@
 	-webkit-box-shadow: 0 0 3px 1px #8080804f, inset -0.5px -0.5px 0 0.5px #ccc, inset 0.5px 0.5px 0 0.5px #ccc;
 	box-shadow: 0 0 3px 1px #8080804f, inset -0.5px -0.5px 0 0.5px #ccc, inset 0.5px 0.5px 0 0.5px #ccc;
 	cursor: pointer;
+	height: 30px;
 }
 
 #stylesview .ui-iconview-icon {
-	height: 35px;
-}
-
-#stylesview .ui-iconview-text {
-	font-size: 10pt;
-	overflow: hidden;
-	white-space: nowrap;
-	text-overflow: ellipsis;
+	height: 30px;
 }
 
 /* Insert Tab */

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -1776,9 +1776,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		if (entry.image)
 			img.src = entry.image;
 		img.alt = entry.text;
-
-		var text = L.DomUtil.create('div', builder.options.cssClass + ' ui-iconview-text', parentContainer);
-		text.innerText = entry.text;
+		img.title = entry.text;
 
 		if (!disabled) {
 			$(parentContainer).click(function() {


### PR DESCRIPTION
In writer with notebookbar toolbar there is an option to show
previews of writer styles within the stylesview element.

Now there is an img with the preview AND the text name of the style
with this patch the text was removed and shown as tooltip

The benefit is that you see ONLY an preview of Default Paragr
but not in addition the name which is simple a duplicate

after the patch you see more previews and it's simplier to select

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I18605af2daf3c47aee9902164060f530e71fad60

![image](https://user-images.githubusercontent.com/8517736/150959008-9afb2dc9-7446-46be-bb27-34e7a6cf17fe.png)

recommendation come from https://github.com/nextcloud/richdocuments/issues/1976