### PR TITLE
wsd: support PDF comment saving during unload with test

### DIFF
--- a/cypress_test/integration_tests/common/desktop_helper.js
+++ b/cypress_test/integration_tests/common/desktop_helper.js
@@ -283,6 +283,63 @@ function deleteImage() {
 		.should('not.exist');
 }
 
+function insertMultipleCommentEx(docType, numberOfComments = 1, isMobile = false) {
+	var mode = Cypress.env('USER_INTERFACE');
+
+	if (docType === 'calc') {
+		cy.wait(1000);
+	}
+
+	if (docType !== 'draw') {
+		cy.get('#toolbar-up .w2ui-scroll-right').then($button => {
+			if ($button.is(':visible'))	{
+				$button.click();
+			}
+		});
+	}
+
+	if (mode === 'notebookbar') {
+		cy.wait(500);
+
+		cy.get('#Insert-tab-label').then($button => {
+			if (!$button.hasClass('selected')) {
+				$button.click();
+			}
+		});
+	}
+
+	if (docType === 'writer' && mode !== 'notebookbar') {
+		cy.get('#toolbar-up .w2ui-scroll-right').click();
+	}
+
+	for (var n=0;n<numberOfComments;n++) {
+
+		if (docType === 'draw') {
+			cy.get('#menu-insert').click().get('#menu-insertcomment').click();
+		} else {
+			actionOnSelector('insertAnnotation', (selector) => {
+				cy.get(selector).click();
+			});
+		}
+
+		cy.wait(100);
+
+		cy.get('.loleaflet-annotation-table').should('exist');
+
+		if (isMobile) {
+			cy.get('#new-mobile-comment-input-area').type('some text' + n);
+
+			cy.get('.vex-dialog-button-primary').click();
+		} else {
+			cy.get('#annotation-modify-textarea-new').type('some text' + n);
+
+			cy.wait(500);
+
+			cy.get('#annotation-save-new').click();
+		}
+	}
+}
+
 function actionOnSelector(name,func) {
 	cy.task('getSelectors', {
 		mode: Cypress.env('USER_INTERFACE'),
@@ -308,4 +365,5 @@ module.exports.resetZoomLevel = resetZoomLevel;
 module.exports.insertMultipleComment = insertMultipleComment;
 module.exports.insertImage = insertImage;
 module.exports.deleteImage = deleteImage;
+module.exports.insertMultipleCommentEx = insertMultipleCommentEx;
 module.exports.actionOnSelector = actionOnSelector;

--- a/cypress_test/integration_tests/desktop/draw/pdf_page_up_down_spec.js
+++ b/cypress_test/integration_tests/desktop/draw/pdf_page_up_down_spec.js
@@ -1,6 +1,7 @@
 /* global describe it cy require afterEach beforeEach */
 
 var helper = require('../../common/helper');
+var desktopHelper = require('../../common/desktop_helper');
 
 describe('PDF View Tests', function() {
 	var origTestFileName = 'pdf_page_up_down.pdf';
@@ -20,5 +21,20 @@ describe('PDF View Tests', function() {
 
 		cy.get('#map').type('{pageup}');
 		cy.get('#preview-frame-part-0').should('have.attr', 'style', 'border: 2px solid darkgrey;');
+	});
+
+	it('PDF insert comment', { env: { 'pdf-view': true } }, function() {
+
+		// Insert some comment into the PDF.
+		desktopHelper.insertMultipleCommentEx('draw', 1, false);
+		cy.get('.loleaflet-annotation-content-wrapper').should('exist');
+		cy.get('#annotation-content-area-1').should('contain','some text0');
+
+		// Reload to close and save. PDFs cannot really be edited,
+		// only comments can be inserted, so they are not saved
+		// directly, rather save-as is used. This failed because
+		// DocBroker expected to get ModifiedStatus=false, which
+		// never happens with save-as and so we couldn't unload.
+		helper.reload(testFileName, 'draw', true);
 	});
 });

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -562,7 +562,22 @@ private:
     /// since there are race conditions vis-a-vis user activity while saving.
     bool isPossiblyModified() const
     {
-        return isModified() || haveActivityAfterSaveRequest();
+        if (haveActivityAfterSaveRequest())
+        {
+            // Always assume possible modification when we have
+            // user input after sending a .uno:Save, due to racing.
+            return true;
+        }
+
+        if (_isViewFileExtension)
+        {
+            // ViewFileExtensions do not update the ModifiedStatus,
+            // but, we want a success save anyway (including unmodified).
+            return !_saveManager.lastSaveSuccessful();
+        }
+
+        // Regulard editable files, rely on the ModifiedStatus.
+        return isModified();
     }
 
     /// True iff there is at least one non-readonly session other than the given.
@@ -1106,6 +1121,10 @@ private:
     /// Set to true when document changed in storage and we are waiting
     /// for user's command to act.
     bool _documentChangedInStorage;
+
+    /// True for file that COOLWSD::IsViewFileExtension return true.
+    /// These files, such as PDF, don't have a reliable ModifiedStatus.
+    bool _isViewFileExtension;
 
     /// Manage saving in Core.
     SaveManager _saveManager;


### PR DESCRIPTION
PDFs are view_comment type documents where
editing is not supported, but adding comments
are. This means that we do get ModifiedStatus=true
but we never get ModifiedStatus=false after
.uno:Save. This is because the save command is
handled in a special way in Core by invoking
save-as instead, which doesn't reset the
ModifiedStatus.

The issue with this was that DocBroker was
stuck on trying to save the document
before unloading, thinking it was modified
due to the stuck ModifiedStatus. Here,
we change the definition of isPossiblyModified()
to ignore the ModifiedStatus for such documents.
Instead, we rely on the last save being successful
and that no new user input exists past the last
save request.

In addition, we now have a new Cypress test
that reproduced the failure without the fix
and now passes with the fix.

Change-Id: Ida9d486ac93a588b9007c5e4583d8bf3c090a62d
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
