### PR TITLE
Add more detail to error logs.

### DIFF
--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -724,7 +724,7 @@ void FileServerRequestHandler::handleRequest(const HTTPRequest& request,
     {
         LOG_ERR("Incorrect config value: " << exc.displayText());
         sendError(500, request, socket, "500 - Internal Server Error!",
-                  "Cannot process the request");
+                  "Cannot process the request - " + exc.displayText());
     }
 }
 


### PR DESCRIPTION
 We get a syntax error message in the logs - but have no indication as
 to what in the config file caused this issue. Bringing back both more
 detail to the browser and logging the extended details.

Signed-off-by: stellarpower <5004545+stellarpower@users.noreply.github.com>
Change-Id: Ib8ddb20a1968f879558e59f50579ee4b18db0f09
Signed-off-by: Michael Meeks <michael.meeks@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

