### PR TITLE
Use variables for text colors

### DIFF
--- a/browser/css/color-palette.css
+++ b/browser/css/color-palette.css
@@ -12,8 +12,12 @@
 	--gray-color: #b6b6b6;
 	--white-bg-color: #fff;
 
-	--color-main-background: #fff;
-	--color-border: #b6b6b6;
+	--color-main-text: #696969;
+	--color-text-accent: #333333;
+	--color-text-lighter: #636363;
 
+	--color-main-background: #fff;
+
+	--color-border: #b6b6b6;
 	--border-radius: 4px;
 }

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -43,7 +43,7 @@
 
 .jsdialog.vertical p, .ui-frame-label {
 	margin: 0px;
-	color: #666;
+	color: var(--color-text-lighter);
 	font-size: 10px;
 	font-weight: bold;
 	text-transform: uppercase;
@@ -73,7 +73,7 @@
 
 td.jsdialog:hover *,
 #table-box3:hover p {
-	color: #333;
+	color: var(--color-text-accent);
 }
 
 .jsdialog.row {

--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -27,6 +27,7 @@
 	padding-inline-start: 4px;
 	position: relative;
 	margin-inline-start: 8px;
+	color: var(--color-main-text);
 }
 
 .sidebar.spinfield {
@@ -42,7 +43,7 @@
 
 .spinfieldunit {
 	font-size: 12px;
-	color: var(--gray-light-txt--color);
+	color: var(--color-main-text);
 	margin: 5px;
 	position: relative;
 	margin-inline-start: calc(-40px);
@@ -188,7 +189,7 @@ div#box5.row.jsdialog.sidebar > .sidebar.jsdialog.cell {
 }
 
 .sidebar.ui-expander-label {
-	color: var(--gray-light-txt--color);
+	color: var(--color-main-text);
 	font-size: 11px;
 	line-height: 23px;
 	font-weight: bold;
@@ -275,7 +276,7 @@ td.jsdialog .jsdialog.cell.sidebar {
 .sidebar #FormatPaintbrush:hover,
 #table-textorientbox.sidebar .jsdialog .radiobutton:hover {
 	outline: 1px solid var(--gray-light-txt--color);
-	color: var(--gray-light-txt--color);
+	color: var(--color-text-accent);
 	border-radius: var(--border-radius);
 }
 

--- a/browser/css/menubar.css
+++ b/browser/css/menubar.css
@@ -130,22 +130,22 @@
 
 .lo-menu a, .lo-menu a:hover, .lo-menu a:focus, .lo-menu a:active, .lo-menu a.highlighted {
 	padding: 5px 22px;
-	color: #000;
+	color: var(--color-main-text);
 }
 .lo-menu a:hover, .lo-menu a:focus, .lo-menu a:active, .lo-menu a.highlighted {
 	background: #0b87e7;
-	color: #fff;
+	color: var(--color-text-accent);
 }
 .lo-menu > li, .lo-menu > li > .disabled {
 	background: transparent; /* top-level menus remain greyish */
 	border-left-color: transparent;
 }
 .lo-menu > li .disabled {
-	color: var(--gray-light-txt--color);
+	color: var(--color-text-lighter);
 }
 .lo-menu > li > a:hover, .lo-menu > li > a:focus, .lo-menu > li > a:active, .lo-menu > li > a.highlighted {
 	background: #fff;
-	color: #000;
+	color: var(--color-text-accent);
 	border-color: #bbbbbb;
 	border-bottom: 1px solid #bbb;
 }
@@ -309,7 +309,7 @@
 }
 
 #menu-last-mod a {
-	color: darkslateblue;
+	color: var(--color-text-lighter);
 	text-decoration: underline;
 	padding: 8px 15px 7px;
 	z-index: 400;

--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -41,38 +41,38 @@
 }
 .main-nav.hasnotebookbar.text-color-indicator .ui-tab.selected.notebookbar{
 	color: rgb(3, 105, 163);
-	color: rgb(var(--blue1-txt-primary-color));
+	color: var(--color-text-accent);
 	box-shadow: -1px -1px 1px rgba(var(--blue1-txt-primary-color),0.3), 1px -1px 1px rgba(var(--blue1-txt-primary-color),0.3);
 }
 .main-nav.hasnotebookbar.spreadsheet-color-indicator .ui-tab.selected.notebookbar{
 	color: rgb(16, 104, 2);
-	color: rgb(var(--green0-txt-primary-color));
+	color: var(--color-text-accent);
 	box-shadow: -1px -1px 1px rgba(var(--green0-txt-primary-color),0.3), 1px -1px 1px rgba(var(--green0-txt-primary-color),0.3);
 }
 .main-nav.hasnotebookbar.presentation-color-indicator .ui-tab.selected.notebookbar{
 	color: rgb(163, 62, 3);
-	color: rgb(var(--orange1-txt-primary-color));
+	color: var(--color-text-accent);
 	box-shadow: -1px -1px 1px rgba(var(--orange1-txt-primary-color),0.3), 1px -1px 1px rgba(var(--orange1-txt-primary-color),0.3);
 }
 .main-nav.hasnotebookbar.drawing-color-indicator .ui-tab.selected.notebookbar{
 	color: rgb(135, 105, 0);
-	color: rgb(var(--yellow0-txt-primary-color));
+	color: var(--color-text-accent);
 	box-shadow: -1px -1px 1px rgba(var(--yellow0-txt-primary-color),0.3), 1px -1px 1px rgba(var(--yellow0-txt-primary-color),0.3);
 }
 .main-nav.hasnotebookbar.text-color-indicator .ui-tab.notebookbar:hover {
-	color: rgb(var(--blue1-txt-primary-color));
+	color: var(--color-text-accent);
 	box-shadow: 0 2px rgb(var(--blue1-txt-primary-color));
 }
 .main-nav.hasnotebookbar.spreadsheet-color-indicator .ui-tab.notebookbar:hover {
-	color: rgb(var(--green0-txt-primary-color));
+	color: var(--color-text-accent);
 	box-shadow: 0 2px rgb(var(--green0-txt-primary-color));
 }
 .main-nav.hasnotebookbar.presentation-color-indicator .ui-tab.notebookbar:hover {
-	color: rgb(var(--orange1-txt-primary-color));
+	color: var(--color-text-accent);
 	box-shadow: 0 2px rgb(var(--orange1-txt-primary-color));
 }
 .main-nav.hasnotebookbar.drawing-color-indicator .ui-tab.notebookbar:hover {
-	color: rgb(var(--yellow0-txt-primary-color));
+	color: var(--color-text-accent);
 	box-shadow: 0 2px rgb(var(--yellow0-txt-primary-color));
 }
 .ui-tab.notebookbar:hover {
@@ -325,8 +325,7 @@
 }
 
 .unotoolbutton.notebookbar .unobutton.selected + .ui-content.unolabel {
-	color: rgb(3, 105, 163) !important;
-	color: var(--blue1-txt-primary-color) !important;
+	color: var(--color-text-accent);
 }
 
 .unotoolbutton.notebookbar.disabled:not(.unospan-shortcutstoolbox),

--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -16,8 +16,7 @@
 	font-size: 12pt;
 	font-family: var(--cool-font);
 	line-height: normal;
-	color: dimgray;
-	color: var(--gray-light-txt--color);
+	color: var(--color-main-text);
 	height: 32px;
 	display: flex;
 	align-items: center;
@@ -286,8 +285,9 @@
 }
 
 .unotoolbutton.notebookbar .unolabel {
+	font-size: 12pt;
 	font-family: var(--cool-font);
-	color: var(--gray-light-txt--color);
+	color: var(--color-main-text);
 	padding: 0px 5px !important;
 }
 

--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -22,6 +22,10 @@
 }
 #toolbar-down *{
 	font-family: var(--cool-font);
+	color: var(--color-main-text);
+}
+#toolbar-down *:hover {
+	color: var(--color-text-accent);
 }
 #toolbar-down table {
 	background: var(--color-main-background);
@@ -238,6 +242,7 @@ w2ui-toolbar {
 }
 
 #document-name-input {
+	color: var(--color-text-accent);
 	font-size: 16px;
 	border: 1px solid transparent;
 	background-color: transparent;
@@ -451,9 +456,14 @@ button.leaflet-control-search-next
 .select2-container--default .select2-selection--single,
 .sidebar.jsdialog.ui-listbox {
 	background-color: var(--gray-lighter-bg-color);
+	color: var(--color-main-text);
 }
 .select2-container--default .select2-selection--single .select2-selection__rendered {
 	line-height: 24px;
+	color: var(--color-main-text);
+}
+.select2-container--default .select2-selection--single .select2-selection__rendered:hover {
+	color: var(--color-text-accent);
 }
 .styles-select {
 	width: 150px !important;
@@ -536,6 +546,7 @@ button.leaflet-control-search-next
 .w2ui-toolbar table.w2ui-button.checked:hover {
 	background-color: var(--gray-light-bg-color);
 	border: 1px solid var(--gray-light-txt--color);
+	color: var(--color-text-accent);
 }
 
 .w2ui-icon.basicshapes_rectangle { background: url('images/lc_rect.svg') no-repeat center !important; }
@@ -1033,6 +1044,11 @@ button.leaflet-control-search-next
 	background-color: rgba(128, 128, 128, 0.1);
 	position: static;
 	line-height: 30px;
+	color: var(--color-main-text);
+}
+
+.insertshape-grid:hover div {
+	color: var(--color-text-accent);
 }
 
 .insertshape-grid .col:hover {

--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -270,22 +270,6 @@ w2ui-toolbar {
 	font-size: 10pt !important;
 	padding-bottom: 2px;
 }
-.text-color-indicator #document-name-input {
-	color: rgb(3, 105, 163);
-	color: rgb(var(--blue1-txt-primary-color));
-}
-.spreadsheet-color-indicator  #document-name-input {
-	color: rgb(16, 104, 2);
-	color: rgb(var(--green0-txt-primary-color));
-}
-.presentation-color-indicator  #document-name-input {
-	color: rgb(163, 62, 3);
-	color: rgb(var(--orange1-txt-primary-color));
-}
-.drawing-color-indicator  #document-name-input {
-	color: rgb(135, 105, 0);
-	color: rgb(var(--yellow0-txt-primary-color));
-}
 
 #document-name-input.editable:focus {
 	border: none;


### PR DESCRIPTION
there are 3 color var's added

var(--color-main-text)
this is the default text color EVERYWHERE

var(--color-text-accent)
will be used when a label was selected, or during hover
also for the filename accent text color was used

var(--color-text-lighter)
was use for saved date or when a label was disabled

PR was tested for classic and notebookbar
for the sidebar and dropdown elements.

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I21795875e58b956081f2020422e77ccecd9bfba3

![image](https://user-images.githubusercontent.com/8517736/151085719-7c1de3bc-f476-425f-ba9e-80bc80798ea6.png)