### PR TITLE
wsd: consider possibly-modified docs when handling conflicts (backport)

### DIFF
--- a/cypress_test/integration_tests/common/desktop_helper.js
+++ b/cypress_test/integration_tests/common/desktop_helper.js
@@ -231,19 +231,6 @@ function resetZoomLevel() {
 	shouldHaveZoomLevel('100');
 }
 
-function insertMultipleComment(numberOfComments) {
-	numberOfComments = numberOfComments || 1;
-	for (var n=0;n<numberOfComments;n++) {
-
-		cy.get('#menu-insert').click().get('#menu-insertcomment').click();
-
-		cy.get('.loleaflet-annotation-table').should('exist');
-
-		cy.get('#annotation-modify-textarea-new').type('some text' + n);
-
-		cy.get('#annotation-save-new').click();
-	}
-}
 function insertImage() {
 	selectZoomLevel('50');
 
@@ -283,12 +270,8 @@ function deleteImage() {
 		.should('not.exist');
 }
 
-function insertMultipleCommentEx(docType, numberOfComments = 1, isMobile = false) {
+function insertMultipleComment(docType, numberOfComments = 1) {
 	var mode = Cypress.env('USER_INTERFACE');
-
-	if (docType === 'calc') {
-		cy.wait(1000);
-	}
 
 	if (docType !== 'draw') {
 		cy.get('#toolbar-up .w2ui-scroll-right').then($button => {
@@ -308,8 +291,12 @@ function insertMultipleCommentEx(docType, numberOfComments = 1, isMobile = false
 		});
 	}
 
-	if (docType === 'writer' && mode !== 'notebookbar') {
-		cy.get('#toolbar-up .w2ui-scroll-right').click();
+	if (docType === 'writer') {
+		cy.get('#toolbar-up .w2ui-scroll-right').then($button => {
+			if ($button.is(':visible'))	{
+				$button.click();
+			}
+		});
 	}
 
 	for (var n=0;n<numberOfComments;n++) {
@@ -326,17 +313,11 @@ function insertMultipleCommentEx(docType, numberOfComments = 1, isMobile = false
 
 		cy.get('.loleaflet-annotation-table').should('exist');
 
-		if (isMobile) {
-			cy.get('#new-mobile-comment-input-area').type('some text' + n);
+		cy.get('#annotation-modify-textarea-new').type('some text' + n);
 
-			cy.get('.vex-dialog-button-primary').click();
-		} else {
-			cy.get('#annotation-modify-textarea-new').type('some text' + n);
+		cy.wait(500);
 
-			cy.wait(500);
-
-			cy.get('#annotation-save-new').click();
-		}
+		cy.get('#annotation-save-new').click();
 	}
 }
 
@@ -365,5 +346,5 @@ module.exports.resetZoomLevel = resetZoomLevel;
 module.exports.insertMultipleComment = insertMultipleComment;
 module.exports.insertImage = insertImage;
 module.exports.deleteImage = deleteImage;
-module.exports.insertMultipleCommentEx = insertMultipleCommentEx;
+module.exports.insertMultipleComment = insertMultipleComment;
 module.exports.actionOnSelector = actionOnSelector;

--- a/cypress_test/integration_tests/common/impress_helper.js
+++ b/cypress_test/integration_tests/common/impress_helper.js
@@ -217,6 +217,7 @@ function dblclickOnSelectedShape() {
 
 //add multiple slides
 function addSlide(numberOfSlides) {
+	helper.waitUntilIdle('#tb_presentation-toolbar_item_insertpage');
 	var insertSlideButton = cy.get('#tb_presentation-toolbar_item_insertpage');
 	for (let i=0;i<numberOfSlides;i++) {
 		insertSlideButton.should('not.have.class', 'disabled')

--- a/cypress_test/integration_tests/desktop/calc/annotation_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/annotation_spec.js
@@ -9,12 +9,6 @@ describe('Annotation Tests', function() {
 	beforeEach(function() {
 		testFileName = helper.beforeAll(origTestFileName, 'calc');
 
-		cy.get('#toolbar-up .w2ui-scroll-right')
-			.click();
-
-		cy.get('#tb_editbar_item_sidebar')
-			.click();
-
 		selectZoomLevel('50');
 	});
 
@@ -24,7 +18,7 @@ describe('Annotation Tests', function() {
 
 
 	it('Insert',function() {
-		insertMultipleComment();
+		insertMultipleComment('calc');
 
 		cy.get('.loleaflet-annotation').should('exist');
 
@@ -38,7 +32,7 @@ describe('Annotation Tests', function() {
 	});
 
 	it('Modify',function() {
-		insertMultipleComment();
+		insertMultipleComment('calc');
 
 		cy.get('#comment-container-1').should('exist');
 
@@ -70,7 +64,7 @@ describe('Annotation Tests', function() {
 	});
 
 	it('Reply should not be possible', function() {
-		insertMultipleComment();
+		insertMultipleComment('calc');
 
 		cy.get('#comment-container-1').should('exist');
 
@@ -88,7 +82,7 @@ describe('Annotation Tests', function() {
 	});
 
 	it('Remove',function() {
-		insertMultipleComment();
+		insertMultipleComment('calc');
 
 		cy.get('#comment-container-1').should('exist');
 

--- a/cypress_test/integration_tests/desktop/draw/pdf_page_up_down_spec.js
+++ b/cypress_test/integration_tests/desktop/draw/pdf_page_up_down_spec.js
@@ -26,7 +26,7 @@ describe('PDF View Tests', function() {
 	it('PDF insert comment', { env: { 'pdf-view': true } }, function() {
 
 		// Insert some comment into the PDF.
-		desktopHelper.insertMultipleCommentEx('draw', 1, false);
+		desktopHelper.insertMultipleComment('draw', 1, false);
 		cy.get('.loleaflet-annotation-content-wrapper').should('exist');
 		cy.get('#annotation-content-area-1').should('contain','some text0');
 

--- a/cypress_test/integration_tests/desktop/writer/annotation_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/annotation_spec.js
@@ -10,12 +10,6 @@ describe('Annotation Tests', function() {
 	beforeEach(function() {
 		testFileName = helper.beforeAll(origTestFileName, 'writer');
 
-		cy.get('#toolbar-up .w2ui-scroll-right')
-			.click();
-
-		cy.get('#tb_editbar_item_sidebar')
-			.click();
-
 		selectZoomLevel('50');
 	});
 
@@ -24,7 +18,7 @@ describe('Annotation Tests', function() {
 	});
 
 	it('Insert',function() {
-		insertMultipleComment();
+		insertMultipleComment('writer');
 
 		cy.get('.loleaflet-annotation-content-wrapper').should('exist');
 
@@ -32,7 +26,7 @@ describe('Annotation Tests', function() {
 	});
 
 	it('Modify',function() {
-		insertMultipleComment();
+		insertMultipleComment('writer');
 
 		cy.get('.loleaflet-annotation-content-wrapper').should('exist');
 
@@ -52,7 +46,7 @@ describe('Annotation Tests', function() {
 	});
 
 	it('Reply',function() {
-		insertMultipleComment();
+		insertMultipleComment('writer');
 
 		cy.get('.loleaflet-annotation-content-wrapper').should('exist');
 
@@ -70,7 +64,7 @@ describe('Annotation Tests', function() {
 	});
 
 	it('Remove',function() {
-		insertMultipleComment();
+		insertMultipleComment('writer');
 
 		cy.get('.loleaflet-annotation-content-wrapper').should('exist');
 

--- a/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
@@ -273,25 +273,11 @@ describe('Top toolbar tests.', function() {
 	});
 
 	it('Insert comment.', function() {
-		cy.get('#toolbar-up .w2ui-scroll-right')
-			.click();
+		desktopHelper.insertMultipleComment('writer');
 
-		mode === 'notebookbar' ? cy.get('#toolbar-up .w2ui-scroll-right').click() : '';
+		cy.get('.loleaflet-annotation-content-wrapper').should('exist');
 
-		desktopHelper.actionOnSelector('insertAnnotation', (selector) => { cy.get(selector).click(); });
-
-		// Comment insertion dialog is opened
-		cy.get('.loleaflet-annotation-table')
-			.should('exist');
-
-		// Add some comment
-		cy.get('#annotation-modify-textarea-new').type('some text');
-
-		cy.get('#annotation-save-new').click();
-
-		cy.get('#comment-container-1').should('exist');
-
-		cy.get('#annotation-content-area-1').should('have.text', 'some text');
+		cy.get('#annotation-content-area-1').should('contain','some text0');
 	});
 
 	it('Insert table.', function() {

--- a/cypress_test/plugins/selectorList.js
+++ b/cypress_test/plugins/selectorList.js
@@ -15,7 +15,7 @@ module.exports.list = {
 	bulletList: ['#DefaultBullet', '#tb_editbar_item_defaultbullet'],
 	incrementIndent: ['#IncrementIndent', '#tb_editbar_item_incrementindent'],
 	decrementIndent: ['#DecrementIndent', '#tb_editbar_item_decrementindent'],
-	insertAnnotation: ['#InsertAnnotation', '#tb_editbar_item_insertannotation'],
+	insertAnnotation: ['#InsertAnnotation.no-label.inline', '#tb_editbar_item_insertannotation'],
 	insertTable: ['#InsertTable', '#tb_editbar_item_inserttable'],
 	insertGraphic: ['#InsertGraphic', '#tb_editbar_item_insertgraphic'],
 	clearFormat: ['#clearFormatting', '#tb_editbar_item_reset'],

--- a/cypress_test/plugins/whitelists.js
+++ b/cypress_test/plugins/whitelists.js
@@ -4,6 +4,9 @@ var notebookbarOnlyList = [
 	'desktop/writer/table_operation_spec.js',
 	'desktop/impress/table_operation_spec.js',
 	'desktop/calc/autofilter_spec.js',
+	'desktop/writer/annotation_spec.js',
+	'desktop/calc/annotation_spec.js',
+	'desktop/impress/annotation_spec.js',
 ];
 
 module.exports.notebookbarOnlyList = notebookbarOnlyList;

--- a/loleaflet/src/control/Control.TopToolbar.js
+++ b/loleaflet/src/control/Control.TopToolbar.js
@@ -385,7 +385,7 @@ L.Control.TopToolbar = L.Control.extend({
 			if (toolbarUp) {
 				toolbarUp.show('resetimpress', 'breaksidebar', 'modifypage',
 					'leftpara', 'centerpara', 'rightpara', 'justifypara', 'breakpara', 'linespacing',
-					'breakspacing', 'defaultbullet', 'defaultnumbering', 'breakbullet', 'inserttextbox', 'inserttable', 'backcolor',
+					'breakspacing', 'defaultbullet', 'defaultnumbering', 'breakbullet', 'inserttextbox', 'inserttable',  'insertannotation', 'backcolor',
 					'breaksidebar', 'modifypage', 'slidechangewindow', 'customanimation', 'masterslidespanel');
 			}
 			break;

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1690,7 +1690,7 @@ void DocumentBroker::handleUploadToStorageResponse(const StorageBase::UploadResu
         LOG_ERR("PutFile says that Document changed in storage");
         _documentChangedInStorage = true;
         const std::string message
-            = isModified() ? "error: cmd=storage kind=documentconflict" : "close: documentconflict";
+            = isPossiblyModified() ? "error: cmd=storage kind=documentconflict" : "close: documentconflict";
 
         broadcastMessage(message);
         broadcastSaveResult(false, "Conflict: Document changed in storage",


### PR DESCRIPTION
When the storage returns modified-in-storage or conflict status
to an upload attempt, we prompt the user to handle the conflict
when the document is modified. Previously, we only prompted
when we had the modified flag set, ignoring the possibility of
having a race with the modified flag, in case the document was
just modified, or potentially modified.

We now prompt the user even when the document is potentially
modified, giving the user the opportunity to decide what to do.

Signed-off-by: Rash419 <rashesh.padia@collabora.com>
Change-Id: I699aaed92d41f76a8eb9de6bdb65608099802663