### PR TITLE
calc: Fix new comments do not check tabid on insert

### DIFF
--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -23,8 +23,10 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 
 		for (var i = 0; i < commentList.length; i++) {
 			if (this._cellCursorTwips.contains(commentList[i].sectionProperties.data.cellPos)) {
-				comment = commentList[i];
-				break;
+				if (commentList[i].tab == this._selectedPart) {
+					comment = commentList[i];
+					break;
+				}
 			}
 		}
 


### PR DESCRIPTION
it only checks the cellPos and this can cause
modifying the existing comment when we try to add
a new one if the same cell has a comment in another
tab already.

Signed-off-by: Mert Tumer <mert.tumer@collabora.com>
Change-Id: I69fd607b487fe18c9a48420b7df202b7d3db311d


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

