### PR TITLE
browser: add optional function to process the URLs (internal and user generated)

### DIFF
--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -704,6 +704,10 @@ window.app = { // Shouldn't have any functions defined.
 	}
 
 	global.createWebSocket = function(uri) {
+		if ('processCoolUrl' in window) {
+			uri = window.processCoolUrl({ url: uri, type: 'ws' });
+		}
+
 		if (global.socketProxy) {
 			window.socketProxy = true;
 			return new global.ProxySocket(uri);

--- a/browser/src/control/Control.AlertDialog.js
+++ b/browser/src/control/Control.AlertDialog.js
@@ -77,6 +77,10 @@ L.Control.AlertDialog = L.Control.extend({
 					type: 'button',
 					className: 'vex-dialog-button-primary',
 					click: function() {
+						if ('processCoolUrl' in window) {
+							url = window.processCoolUrl({ url: url, type: 'doc' });
+						}
+
 						window.open(url, '_blank');
 						vex.closeAll();
 					}

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1896,9 +1896,18 @@ L.CanvasTileLayer = L.Layer.extend({
 				url = window.makeHttpUrlWopiSrc('/' + this._map.options.urlPrefix + '/',
 					this._map.options.doc, '/download/' + command.downloadid,
 					'attachment=0');
+
+				if ('processCoolUrl' in window) {
+					url = window.processCoolUrl({ url: url, type: 'print' });
+				}
+
 				window.open(url, '_blank');
 			}
 			else {
+				if ('processCoolUrl' in window) {
+					url = window.processCoolUrl({ url: url, type: 'print' });
+				}
+
 				this._map.fire('filedownloadready', {url: url});
 			}
 		}
@@ -1906,6 +1915,10 @@ L.CanvasTileLayer = L.Layer.extend({
 			this._map.fire('slidedownloadready', {url: url});
 		}
 		else if (command.id === 'export') {
+			if ('processCoolUrl' in window) {
+				url = window.processCoolUrl({ url: url, type: 'export' });
+			}
+
 			// Don't do a real download during testing
 			if (!L.Browser.cypressTest)
 				this._map._fileDownloader.src = url;

--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -236,6 +236,11 @@ L.Clipboard = L.Class.extend({
 					that._downloadProgress._onUpdateProgress(progress);
 				}
 			}, false);
+
+			if ('processCoolUrl' in window) {
+				url = window.processCoolUrl({ url: url, type: 'clipboard' });
+			}
+
 			request.open(type, url, true /* isAsync */);
 			request.timeout = 20 * 1000; // 20 secs ...
 			request.responseType = 'blob';

--- a/browser/src/map/handler/Map.FileInserter.js
+++ b/browser/src/map/handler/Map.FileInserter.js
@@ -96,6 +96,10 @@ L.Map.FileInserter = L.Handler.extend({
 		var map = this._map;
 		var url = this.getWopiUrl(map);
 
+		if ('processCoolUrl' in window) {
+			url = window.processCoolUrl({ url: url, type: 'insertfile' });
+		}
+
 		if (!(file.filename && file.url) && (file.name === '' || file.size === 0)) {
 			var errMsg =  _('The file of type: %0 cannot be uploaded to server since the file has no name');
 			if (file.size === 0)


### PR DESCRIPTION
Signed-off-by: Alexandru Vlăduţu <alexandru.vladutu@1and1.ro>
Change-Id: If83611cc17d00dd049093de0a35caa7739f10400


* Resolves: #4066
* Target version: master 

### Summary

This commits adds a function call to `window.processCoolUrl` if that function is present each time it encounters an URL (internal for backend calls to Cool or inside a document, user generated). The function take an object that contains the `url` (string) and the `type` (string) of the url. 

The `type` can be one of the following:
- 'ws' (websocket url)
- 'doc' (hyperlinks in documents, processed as the user clicks on 'open link')
- 'print' (basically the same as 'export' to pdf)
- 'export' ('download as' in various formats),
- 'clipboard' (backend request when the user pastes into the document)
- 'insertfile' (when inserting a photo into a document for example)
- 'slideshow' (backend request to download the current presentation into svg format to display it as a slideshow)
- 'slide' (for links inside the slideshow, processed right after downloading the slideshow svg)

The function is called in different moments based on that `type` param, namely:

- for internal calls to the backend endpoints ('ws', 'print', 'export', 'insertfile', 'clipboard', 'slideshow') it's called when the url is formed, right before establishing the request
- for user generated links ('doc') the function is called as the user clicks on the 'open link', and not before (we are doing this because we want to keep displaying the correct link to the user and not the link that is generated by a dereferer for example)
- for 'slide' (links embedded in the slideshow - created when the user clicks on the slideshow icon for the presentation type files) these are generated just after the slideshow svg loads

You can easily test that out by inserting the following snippet into `global.js` for example:

```js
window.processCoolUrl = function(opts) {
	console.log('>>> url: %s, \n-> type: %s', opts.url, opts.type);
	return opts.url;
}
```

### TODO

- [ ] ...

Please let me know if I have forgotten to call this `processCoolUrl` in other areas of the code and if I should add any documentation with this new feature anywhere.

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

