### PR TITLE
wsd, convert-to: allow specifying filter options as JSON

### DIFF
--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -3290,6 +3290,12 @@ private:
                 const std::string docKey = RequestDetails::getDocKey(uriPublic);
 
                 std::string options;
+                if (form.has("options"))
+                {
+                    // Allow specifying options as-is, in case only data + format are used.
+                    options = form.get("options");
+                }
+
                 const bool fullSheetPreview
                     = (form.has("FullSheetPreview") && form.get("FullSheetPreview") == "true");
                 if (fullSheetPreview && format == "pdf" && isSpreadsheet(fromPath))


### PR DESCRIPTION
For example, to skip exporting the first page of a document:

curl -k -F "data=@3page.odg" -F "format=pdf" -F "options={\"PageRange\":{\"type\":\"string\",\"value\":\"2-\"}}" https://localhost:9980/cool/convert-to > out.pdf

https://gerrit.libreoffice.org/c/core/+/128849 has more examples.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I6c4ce25bc580dac041f2865f74c856780d6fe137
