### PR TITLE
disable LanguageStatus dropdown in readonly mode, because readonly us…

### DIFF
--- a/browser/src/control/Control.StatusBar.js
+++ b/browser/src/control/Control.StatusBar.js
@@ -390,6 +390,9 @@ L.Control.StatusBar = L.Control.extend({
 
 		this._updateToolbarsVisibility();
 
+		if (isReadOnly)
+			statusbar.disable('LanguageStatus');
+
 		if (statusbar)
 			statusbar.refresh();
 


### PR DESCRIPTION
…er can't change Language

Signed-off-by: Andras Timar <andras.timar@collabora.com>
Change-Id: I46ee87c89f5e0271aae1649794f674d038242b7a


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

