### PR TITLE
Classic Toolbar Menubar no juming up at hover menu element

### DIFF
--- a/browser/css/menubar.css
+++ b/browser/css/menubar.css
@@ -123,9 +123,7 @@
 .lo-menu > li > a, .lo-menu > li > a.has-submenu {
 	padding: 8px;
 	z-index: 400;
-	border-left: 1px solid transparent;
-	border-right: 1px solid transparent;
-	border-top: 1px solid transparent;
+	border: 1px solid transparent;
 }
 
 .lo-menu a, .lo-menu a:hover, .lo-menu a:focus, .lo-menu a:active, .lo-menu a.highlighted {


### PR DESCRIPTION
If you hover at the classic toolbar at the menubar,
a border was shown and the string jump at 1px size.

Signed-off-by: Andreas_K <andreas_k@abwesend.de>
Change-Id: I5d03a380c2bfa34bd169bb12295d535875e54a5f
