### PR TITLE
last-mod string removed underline and add hover accent color

### DIFF
--- a/browser/css/menubar.css
+++ b/browser/css/menubar.css
@@ -310,12 +310,14 @@
 
 #menu-last-mod a {
 	color: var(--color-text-lighter);
-	text-decoration: underline;
 	padding: 8px 15px 7px;
 	z-index: 400;
 	border: 1px solid transparent;
 }
 
+#menu-last-mod a:hover {
+	color: var(--color-text-accent);
+}
 
 /* For classic mode */
 #main-menu .freemium-disabled, #menu-nb-hamburger .freemium-disabled {


### PR DESCRIPTION
if you hover over the last-mod string the color switch from
var(--color-text-lighter) to var(--color-text-accent).

In addition the text-decoration: underline was removed
cause it use text-lighter the focus shouldn't be there
with an underline.

Signed-off-by: Andreas_K <andreas_k@abwesend.de>
Change-Id: I750981730b6daa8605f8d70ebd3df4029f990e36
