### PR TITLE
Detect storage conflict with no clients

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -324,6 +324,7 @@ noinst_HEADERS = $(wsd_headers) $(shared_headers) $(kit_headers) \
                  test/test.hpp \
                  test/testlog.hpp \
                  test/HttpTestServer.hpp \
+                 test/WOPIUploadConflictCommon.hpp \
                  test/helpers.hpp
 
 dist-hook:

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -9,7 +9,7 @@ noinst_PROGRAMS = fakesockettest unittest unithttplib
 
 AM_CXXFLAGS = $(CPPUNIT_CFLAGS) -DTDOC=\"$(abs_top_srcdir)/test/data\" \
 	-I${top_srcdir}/common -I${top_srcdir}/net -I${top_srcdir}/wsd -I${top_srcdir}/kit \
-	-I${top_srcdir} \
+	-I${top_srcdir} -I${top_srcdir}/test \
 	-pthread -DCOOLWSD_DATADIR='"@COOLWSD_DATADIR@"' \
 	-DCOOLWSD_CONFIGDIR='"@COOLWSD_CONFIGDIR@"' \
 	-DDEBUG_ABSSRCDIR='"@abs_srcdir@"' \
@@ -26,8 +26,8 @@ noinst_LTLIBRARIES = \
 	unit-wopi-async-upload-close.la unit-wopi-async-upload-modify.la \
 	unit-wopi-async-upload-modifyclose.la \
 	unit-wopi-async-slow.la \
-	unit-wopi-ownertermination.la unit-wopi-versionrestore.la \
-	unit-wopi-documentconflict.la unit_wopi_renamefile.la unit_wopi_watermark.la \
+	unit-wopi-ownertermination.la unit-wopi-versionrestore.la unit-wopi-documentconflict.la \
+	unit-wopi-save-on-exit.la unit_wopi_renamefile.la unit_wopi_watermark.la \
 	unit-wopi-lock.la \
 	unit-tiff-load.la \
 	unit-large-paste.la \
@@ -178,6 +178,8 @@ unit_wopi_versionrestore_la_SOURCES = UnitWOPIVersionRestore.cpp
 unit_wopi_versionrestore_la_LIBADD = $(CPPUNIT_LIBS)
 unit_wopi_documentconflict_la_SOURCES = UnitWOPIDocumentConflict.cpp
 unit_wopi_documentconflict_la_LIBADD = $(CPPUNIT_LIBS)
+unit_wopi_save_on_exit_la_SOURCES = UnitWOPISaveOnExit.cpp
+unit_wopi_save_on_exit_la_LIBADD = $(CPPUNIT_LIBS)
 unit_wopi_renamefile_la_SOURCES = UnitWOPIRenameFile.cpp
 unit_wopi_renamefile_la_LIBADD = $(CPPUNIT_LIBS)
 unit_wopi_lock_la_SOURCES = UnitWOPILock.cpp
@@ -255,8 +257,8 @@ TESTS = \
 	unit-wopi-async-upload-close.la unit-wopi-async-upload-modify.la \
 	unit-wopi-async-upload-modifyclose.la \
 	unit-wopi-async-slow.la \
-	unit-wopi-ownertermination.la unit-wopi-versionrestore.la \
-	unit-wopi-documentconflict.la unit_wopi_renamefile.la unit_wopi_watermark.la \
+	unit-wopi-ownertermination.la unit-wopi-versionrestore.la unit-wopi-documentconflict.la \
+	unit-wopi-save-on-exit.la unit_wopi_renamefile.la unit_wopi_watermark.la \
 	unit-wopi-lock.la \
 	unit-http.la \
 	unit-tiff-load.la \

--- a/test/UnitWOPIDocumentConflict.cpp
+++ b/test/UnitWOPIDocumentConflict.cpp
@@ -145,15 +145,21 @@ public:
     {
         LOG_TST("onDocumentError: Doc " << (_docLoaded == DocLoaded::Doc1 ? "1" : "2")
                                         << "(WaitSaveResponse): [" << message << ']');
-        LOK_ASSERT_MESSAGE("Expected to be in Phase::WaitSaveResponse but was " + toString(_phase),
-                           _phase == Phase::WaitSaveResponse);
 
-        _phase = Phase::WaitDocClose;
-        LOG_TST("onDocumentError: Switching to Phase::WaitDocClose");
+        if (_phase == Phase::WaitSaveResponse)
+        {
+            LOK_ASSERT_MESSAGE("Expected to be in Phase::WaitSaveResponse but was " +
+                                   toString(_phase),
+                               _phase == Phase::WaitSaveResponse);
 
-        // we don't want to save current changes because doing so would
-        // overwrite the document which was changed underneath us
-        WSD_CMD("closedocument");
+            _phase = Phase::WaitDocClose;
+            LOG_TST("onDocumentError: Switching to Phase::WaitDocClose");
+
+            // we don't want to save current changes because doing so would
+            // overwrite the document which was changed underneath us
+            WSD_CMD("closedocument");
+        }
+
         return true;
     }
 

--- a/test/UnitWOPISaveOnExit.cpp
+++ b/test/UnitWOPISaveOnExit.cpp
@@ -1,0 +1,107 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <config.h>
+
+#include "WOPIUploadConflictCommon.hpp"
+
+#include <string>
+#include <memory>
+
+#include <Poco/Net/HTTPRequest.h>
+
+#include "Util.hpp"
+#include "Log.hpp"
+#include "Unit.hpp"
+#include "UnitHTTP.hpp"
+#include "helpers.hpp"
+#include "lokassert.hpp"
+
+class UnitWOPISaveOnExit : public WOPIUploadConflictCommon
+{
+    using WOPIUploadConflictCommon::Phase;
+    using WOPIUploadConflictCommon::Scenario;
+
+    using WOPIUploadConflictCommon::OriginalDocContent;
+    using WOPIUploadConflictCommon::ModifiedOriginalDocContent;
+    using WOPIUploadConflictCommon::ConflictingDocContent;
+
+public:
+    UnitWOPISaveOnExit()
+        : WOPIUploadConflictCommon("UnitWOPISaveOnExit", OriginalDocContent)
+    {
+    }
+
+    void configure(Poco::Util::LayeredConfiguration& config)
+    {
+        WopiTestServer::configure(config);
+
+        config.setBool("per_document.always_save_on_exit", true);
+    }
+
+    void assertGetFileRequest(const Poco::Net::HTTPRequest& /*request*/)
+    {
+        LOG_TST("Testing " << toString(_scenario));
+        LOK_ASSERT_STATE(_phase, Phase::WaitLoadStatus);
+
+        // Note: the expected contents for each scenario
+        // is the result of the *previous* phase!
+        std::string expectedContents;
+        switch (_scenario)
+        {
+            case Scenario::Disconnect:
+                expectedContents = OriginalDocContent;
+                break;
+            case Scenario::SaveDiscard:
+                expectedContents = ModifiedOriginalDocContent; // Disconnect will clobber.
+                break;
+            case Scenario::CloseDiscard:
+            case Scenario::SaveOverwrite:
+                LOK_ASSERT_EQUAL_MESSAGE("Unexpected contents in storage",
+                                         std::string(ConflictingDocContent), getFileContent());
+                setFileContent(OriginalDocContent); // Reset to test overwriting.
+                expectedContents = OriginalDocContent;
+                break;
+            case Scenario::VerifyOverwrite:
+                expectedContents = ModifiedOriginalDocContent;
+                break;
+        }
+
+        LOK_ASSERT_EQUAL_MESSAGE("Unexpected contents in storage", expectedContents,
+                                 getFileContent());
+    }
+
+    std::unique_ptr<http::Response> assertPutFileRequest(const Poco::Net::HTTPRequest& /*request*/)
+    {
+        LOG_TST("Testing " << toString(_scenario));
+        LOK_ASSERT_STATE(_phase, Phase::WaitDocClose);
+
+        switch (_scenario)
+        {
+            case Scenario::Disconnect:
+                LOG_TST("Clobbered in the disconnect scenario");
+                break;
+            case Scenario::SaveDiscard:
+            case Scenario::CloseDiscard:
+            case Scenario::VerifyOverwrite:
+                LOK_ASSERT_FAIL("Unexpectedly overwritting the document in storage");
+                break;
+            case Scenario::SaveOverwrite:
+                LOK_ASSERT_EQUAL_MESSAGE("Unexpected contents in storage",
+                                         std::string(ModifiedOriginalDocContent), getFileContent());
+                LOG_TST("Closing the document to verify its contents after reloading");
+                WSD_CMD("closedocument");
+                break;
+        }
+
+        return nullptr;
+    }
+};
+
+UnitBase* unit_create_wsd(void) { return new UnitWOPISaveOnExit(); }
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -362,21 +362,10 @@ void DocumentBroker::pollThread()
                 else if (SigUtil::getShutdownRequestFlag() || _docState.isCloseRequested())
                 {
                     const std::string reason =
-                        SigUtil::getShutdownRequestFlag() ? "recycling" : _closeReason;
-                    const bool possiblyModified = isPossiblyModified();
-                    // If we failed the last upload, save even if unmodified so we upload.
-                    const bool dontSaveIfUnmodified = _storageManager.lastUploadSuccessful();
-                    LOG_INF("Autosave before closing DocumentBroker for docKey ["
-                            << getDocKey()
-                            << "], possiblyModified: " << (possiblyModified ? "yes" : "no")
-                            << ", dontSaveIfUnmodified: " << (dontSaveIfUnmodified ? "yes" : "no")
-                            << ", for " << reason);
-                    if (!autoSave(possiblyModified, dontSaveIfUnmodified))
-                    {
-                        LOG_INF("Terminating DocumentBroker for docKey [" << getDocKey()
-                                                                          << "]: " << reason);
-                        stop(reason);
-                    }
+                        SigUtil::getShutdownRequestFlag()
+                            ? "recycling"
+                            : (!_closeReason.empty() ? _closeReason : "unloading");
+                    autoSaveAndStop(reason);
                 }
                 else if (!_stop && _saveManager.needAutosaveCheck())
                 {

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -433,8 +433,9 @@ public:
                      bool dontSaveIfUnmodified = true, bool isAutosave = false,
                      bool isExitSave = false, const std::string& extendedData = std::string());
 
-    /// Sends a message to all sessions
-    void broadcastMessage(const std::string& message) const;
+    /// Sends a message to all sessions.
+    /// Returns the number of sessions sent the message to.
+    std::size_t broadcastMessage(const std::string& message) const;
 
     /// Sends a message to all sessions except for the session passed as the param
     void broadcastMessageToOthers(const std::string& message, const std::shared_ptr<ClientSession>& _session) const;


### PR DESCRIPTION
- wsd: wait for the modified flag before giving up 
- wsd: improved removeSession
- wsd: do not force uploading when in conflict
- wsd: detect storage conflict with no clients
- wsd: reuse autoSaveAndStop for consistentcy
- wsd: merge unloading logic and centralize
- wsd: test: rework and extend UnitWOPIDocumentConflict
- wsd: test: add discarding after closing test to DocumentConflict
- wsd: test: add SaveOnExit test