### PR TITLE
NB add SelectAll command to Layout tab

### DIFF
--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -796,6 +796,11 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				'vertical': 'true'
 			},
 			{
+				'type': 'bigtoolitem',
+				'text': _UNO('.uno:SelectAll'),
+				'command': '.uno:SelectAll'
+			},
+			{
 				'id': 'Layout-Section-Align',
 				'type': 'container',
 				'children': [

--- a/browser/src/control/Control.NotebookbarDraw.js
+++ b/browser/src/control/Control.NotebookbarDraw.js
@@ -728,6 +728,11 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 				'vertical': 'true'
 			},
 			{
+				'type': 'bigtoolitem',
+				'text': _UNO('.uno:SelectAll'),
+				'command': '.uno:SelectAll'
+			},
+			{
 				'type': 'container',
 				'children': [
 					{

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -1050,6 +1050,11 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'vertical': 'true'
 			},
 			{
+				'type': 'bigtoolitem',
+				'text': _UNO('.uno:SelectAll'),
+				'command': '.uno:SelectAll'
+			},
+			{
 				'type': 'container',
 				'children': [
 					{

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -1088,6 +1088,11 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				'vertical': 'true'
 			},
 			{
+				'type': 'bigtoolitem',
+				'text': _UNO('.uno:SelectAll'),
+				'command': '.uno:SelectAll'
+			},
+			{
 				'type': 'container',
 				'children': [
 					{


### PR DESCRIPTION
In the layout tab there are the object related stuff like
align and front/back. So I add there SelectAll command.

![image](https://user-images.githubusercontent.com/8517736/151462883-9bf9bf53-87fc-4457-9cbd-ee1829a775d3.png)

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I4cdd9fbb0351cede9cd78dd1edd50e0612d895f0

see https://github.com/nextcloud/richdocuments/issues/1976 moved command from the hamburger menu to the tab.