### PR TITLE
browser: allow cursor jump if text selection is empty

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -2854,6 +2854,8 @@ L.CanvasTileLayer = L.Layer.extend({
 		else {
 			this._textCSelections.clear();
 			this._cellCSelections.clear();
+			if (this._map._clip && this._map._clip._selectionType === 'complex')
+				this._map._clip.clearSelection();
 		}
 
 		this._onUpdateTextSelection();


### PR DESCRIPTION
Otherwise, if the user selects all the document,
the clipboard blocks Page Up or Page Down cursor jumps.

Change-Id: Ia9c432646c51063775bb7cca6a998e7d1cdcdbf2
Signed-off-by: Henry Castro <hcastro@collabora.com>
