### PR TITLE
Notebookbar: Set statusbar toggle's status on loading

### DIFF
--- a/browser/src/control/Control.StatusBar.js
+++ b/browser/src/control/Control.StatusBar.js
@@ -395,7 +395,7 @@ L.Control.StatusBar = L.Control.extend({
 
 		var showStatusbar = this.map.uiManager.getSavedStateOrDefault('ShowStatusbar');
 		if (showStatusbar)
-			$('#toolbar-down').show();
+			this.map.uiManager.toggleStatusBar();
 		else
 			this.map.uiManager.hideStatusBar(true);
 	},


### PR DESCRIPTION
Make sure the toggle also reacts not only to the user interaction¹ but
also at the startup time

1 Which is already done with:
- e384c561798e7616f10e763788e92acec6caff9c
 - from PR: https://github.com/CollaboraOnline/online/pull/4088/

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I29e401eede4fc11c821da91b66430ba99d1ec1aa
