### PR TITLE
Notebookbar: Set ruler toggle to react to visibility

### DIFF
--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -47,6 +47,7 @@ L.Control.Notebookbar = L.Control.extend({
 		this.map.on('jsdialogupdate', this.onJSUpdate, this);
 		this.map.on('jsdialogaction', this.onJSAction, this);
 		this.map.on('statusbarchanged', this.onStatusbarChange, this);
+		this.map.on('rulerchanged', this.onRulerChange, this);
 
 
 		$('#toolbar-wrapper').addClass('hasnotebookbar');
@@ -439,6 +440,15 @@ L.Control.Notebookbar = L.Control.extend({
 		}
 		else {
 			$('#showstatusbar').addClass('selected');
+		}
+	},
+
+	onRulerChange: function() {
+		if (this._map.uiManager.isRulerVisible()) {
+			$('#showruler').removeClass('selected');
+		}
+		else {
+			$('#showruler').addClass('selected');
 		}
 	},
 

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -444,6 +444,7 @@ L.Control.UIManager = L.Control.extend({
 	},
 
 	toggleRuler: function() {
+		this.map.fire('rulerchanged');
 		if (this.isRulerVisible())
 			this.hideRuler();
 		else


### PR DESCRIPTION
- Make sure a trigger is fired no matter the UI mode
	- Handle it (do anything) just from withing the NB widget
	(get proper css classes)

Note: similar to what we did with statusbar in:
e384c561798e7616f10e763788e92acec6caff9c

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I6c8a38f2e426f20cc5b7a06241f7a92fa4d938e4
