### PR TITLE
Variable names for the color-palette

### DIFF
--- a/browser/css/color-palette.css
+++ b/browser/css/color-palette.css
@@ -11,13 +11,28 @@
 	--gray-lighter-bg-color: #F7F7F7;
 	--gray-color: #b6b6b6;
 	--white-bg-color: #fff;
+	--color-text-accent: #333333;
 
 	--color-main-text: #696969;
-	--color-text-accent: #333333;
-	--color-text-lighter: #636363;
+	--color-text-dark: #636363;
+	--color-text-darker: #333333;
+	--color-text-lighter: #b6b6b6;
 
 	--color-main-background: #fff;
+	--color-background-dark: #EFEFEF;
+	--color-background-darker: #b6b6b6;
+	--color-background-lighter: #F7F7F7;
+
+	--color-primary: #1C99E0;
+	--color-primary-text: #fff;
+	--color-primary-dark: #0369A3;
+	--color-primary-darker: #023F62;
+	--color-primary-lighter: #63BBEE;
 
 	--color-border: #b6b6b6;
+	--color-border-dark: #EFEFEF;
+	--color-border-darker: #b6b6b6;
+	--color-border-lighter: #f1f1f1;
+
 	--border-radius: 4px;
 }


### PR DESCRIPTION
there are 4 type of color sections:
1. text
2. background
3. border
4. primary

and for each section there are
1. without extension for default color usage
2. -dark suffix for selected
3. -darker suffix for hover
4. -lighter for non available

with this setting the developer can choose
easy the section and the -suffix.

In addition there is primary color
which bring color the the apps and should depend
on the app so
- writer = LibO brand color blue,
- calc = LibO brand color green,
- ...

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I668b5505abd5d70345221bc79d921071c4a49cd7

* Resolves: #3772

