### PR TITLE
sidebar: Don't show sidebar on pdf regardless of the permisson

### DIFF
--- a/browser/src/control/Control.Sidebar.js
+++ b/browser/src/control/Control.Sidebar.js
@@ -121,7 +121,7 @@ L.Control.Sidebar = L.Control.extend({
 		this.builder.setWindowId(sidebarData.id);
 		$(this.container).empty();
 
-		if (sidebarData.action === 'close' || this.map.isPermissionReadOnly()) {
+		if (sidebarData.action === 'close' || window.app.file.fileBasedView || this.map.isPermissionReadOnly()) {
 			this.closeSidebar();
 		} else if (sidebarData.children) {
 			for (var i = sidebarData.children.length - 1; i >= 0; i--) {


### PR DESCRIPTION
To be safe, we can ignore the idea of this.map.isPermissionReadOnly()
control would always return true for PDF views and add
additional check for app.file.fileBasedView which is always
true and readonly true for PDF view

Signed-off-by: Mert Tumer <mert.tumer@collabora.com>
Change-Id: I8f0a4401087c735508534404ee987bb35c3bb0fd


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

