### PR TITLE
fixed master slide previews not being updated

### DIFF
--- a/browser/src/control/Control.PartsPreview.js
+++ b/browser/src/control/Control.PartsPreview.js
@@ -523,18 +523,6 @@ L.Control.PartsPreview = L.Control.extend({
 		}
 	},
 
-	_showMasterSlides: function() {
-		for (var i = this._map._docLayer._masterPageCount; i < this._previewTiles.length; ++i) {
-			$(this._previewTiles[i]).hide();
-		}
-	},
-
-	_hideMasterSlides: function() {
-		for (var i = this._map._docLayer._masterPageCount; i < this._previewTiles.length; ++i) {
-			$(this._previewTiles[i]).show();
-		}
-	},
-
 	_onScroll: function (e) {
 		setTimeout(L.bind(function (e) {
 			var scrollOffset = 0;

--- a/browser/src/control/Parts.js
+++ b/browser/src/control/Parts.js
@@ -73,8 +73,8 @@ L.Map.include({
 		docLayer._updateOnChangePart();
 		docLayer._pruneTiles();
 		docLayer._prevSelectedPartNeedsUpdate = true;
-		if (docLayer._invalidatePreview) {
-			docLayer._invalidatePreview();
+		if (docLayer._invalidatePreviews) {
+			docLayer._invalidatePreviews();
 		}
 		docLayer._drawSearchResults();
 		if (!this._searchRequested) {
@@ -206,7 +206,7 @@ L.Map.include({
 	},
 
 	// getCustomPreview
-	// Triggers the creation of a preview with the given id, of width X height size, of the [(tilePosX,tilePosY), 
+	// Triggers the creation of a preview with the given id, of width X height size, of the [(tilePosX,tilePosY),
 	// (tilePosX + tileWidth, tilePosY + tileHeight)] section of the document.
 	getCustomPreview: function (id, part, width, height, tilePosX, tilePosY, tileWidth, tileHeight, options) {
 		if (!this._docPreviews) {

--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -1655,8 +1655,6 @@ app.definitions.Socket = L.Class.extend({
 			else if (tokens[i] === 'nopng') {
 				command.nopng = true;
 			}
-			else if (tokens[i].startsWith('masterpagecount='))
-				command.masterPageCount = parseInt(tokens[i].substring(16));
 			else if (tokens[i].substring(0, 9) === 'username=') {
 				command.username = tokens[i].substring(9);
 			}

--- a/browser/src/layer/tile/ImpressTileLayer.js
+++ b/browser/src/layer/tile/ImpressTileLayer.js
@@ -286,7 +286,6 @@ L.ImpressTileLayer = L.CanvasTileLayer.extend({
 			this._viewId = parseInt(command.viewid);
 			this._selectedPart = command.selectedPart;
 			this._selectedParts = command.selectedParts || [command.selectedPart];
-			this._masterPageCount = command.masterPageCount;
 			this._resetPreFetching(true);
 			this._update();
 			var partMatch = textMsg.match(/[^\r\n]+/g);

--- a/browser/src/map/handler/Map.StateChanges.js
+++ b/browser/src/map/handler/Map.StateChanges.js
@@ -27,11 +27,12 @@ L.Map.StateChangeHandler = L.Handler.extend({
 	},
 
 	_onStateChanged: function(e) {
+		var slideMasterPageItem = this._map['stateChangeHandler'].getItemValue('.uno:SlideMasterPage');
 		var state;
 
-		if (typeof(e.state) == 'object') {
+		if (typeof (e.state) == 'object') {
 			state = e.state;
-		} else if (typeof(e.state) == 'string') {
+		} else if (typeof (e.state) == 'string') {
 			var index = e.state.indexOf('{');
 			state = index !== -1 ? JSON.parse(e.state.substring(index)) : e.state;
 		}
@@ -43,19 +44,13 @@ L.Map.StateChangeHandler = L.Handler.extend({
 		}
 		$('#document-container').removeClass('slide-master-mode');
 		$('#document-container').addClass('slide-normal-mode');
-
-		if (e.commandName === '.uno:SlideMasterPage') {
-			var slideMasterPageItem = this._map['stateChangeHandler'].getItemValue('.uno:SlideMasterPage');
-			if (slideMasterPageItem === 'true') {
-				$('#document-container').removeClass('slide-normal-mode');
-				$('#document-container').addClass('slide-master-mode');
-				this._map._docLayer._preview._showMasterSlides();
-			}
-			if (!slideMasterPageItem  || slideMasterPageItem  == 'false' || slideMasterPageItem  == 'undefined') {
-				$('#document-container').removeClass('slide-master-mode');
-				$('#document-container').addClass('slide-normal-mode');
-				this._map._docLayer._preview._hideMasterSlides();
-			}
+		if (slideMasterPageItem) {
+			$('#document-container').removeClass('slide-normal-mode');
+			$('#document-container').addClass('slide-master-mode');
+		}
+		if (!slideMasterPageItem || slideMasterPageItem == 'false' || slideMasterPageItem == 'undefined') {
+			$('#document-container').removeClass('slide-master-mode');
+			$('#document-container').addClass('slide-normal-mode');
 		}
 	},
 

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -2799,6 +2799,16 @@ void ChildSession::loKitCallback(const int type, const std::string& payload)
         break;
     case LOK_CALLBACK_STATE_CHANGED:
         sendTextFrame("statechanged: " + payload);
+        if (Util::startsWith(payload, ".uno:SlideMasterPage"))
+        {
+            std::string status = LOKitHelper::documentStatus(getLOKitDocument()->get());
+            sendTextFrame("status: " + status);
+            for (int i = 0; i < getLOKitDocument()->getParts(); i++)
+            {
+                const std::string parts = std::to_string(i);
+                sendTextFrame("invalidatetiles: EMPTY, " + parts);
+            }
+        }
         break;
     case LOK_CALLBACK_SEARCH_NOT_FOUND:
         sendTextFrame("searchnotfound: " + payload);

--- a/kit/KitHelper.hpp
+++ b/kit/KitHelper.hpp
@@ -65,7 +65,6 @@ namespace LOKitHelper
         {
             std::ostringstream hposs;
             std::ostringstream sposs;
-            std::ostringstream mposs;
             std::ostringstream rtlposs;
             for (int i = 0; i < parts; ++i)
             {
@@ -84,11 +83,6 @@ namespace LOKitHelper
                     {
                         if (prop.second == "1")
                             sposs << i << ',';
-                    }
-                    else if (name == "masterPageCount")
-                    {
-                        if (mposs.str().empty())
-                            mposs << prop.second;
                     }
                     else if (name == "rtllayout")
                     {
@@ -110,12 +104,6 @@ namespace LOKitHelper
             {
                 selectedparts.pop_back(); // Remove last ','
                 oss << " selectedparts=" << selectedparts;
-            }
-
-            std::string masterpagecount = mposs.str();
-            if (!masterpagecount.empty())
-            {
-                oss << " masterpagecount=" << masterpagecount;
             }
 
             std::string rtlparts = rtlposs.str();


### PR DESCRIPTION
after switching to master view previews would remain unchanged
this patch will invalidate tiles for all the previews

Signed-off-by: Pranam Lashkari <lpranam@collabora.com>
Change-Id: Ie7320d625bd95fe80fc76a459b576d6148b39276


* Resolves: # <!-- related github issue -->
* Target version: master 


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

