### PR TITLE
Sidebar add padding to td and cell elements

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -212,6 +212,7 @@ div#box5.row.jsdialog.sidebar > .sidebar.jsdialog.cell {
 }
 
 td.jsdialog .jsdialog.cell.sidebar {
+	padding: 2px;
 	width: auto;
 }
 


### PR DESCRIPTION
In the past there was a padding which was removed
now padding was added again.

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I52f11aa3e36e331e47bee345212d103f2ebf1b65

#### Before
![Screenshot_20220202_224022](https://user-images.githubusercontent.com/8517736/152242309-16d44cb9-5f02-4698-a6e5-b44cc6164cdc.png)

#### After
![Screenshot_20220202_224036](https://user-images.githubusercontent.com/8517736/152242330-c899d34c-3fc3-416e-8239-d3aa86ffa8cb.png)


