### PR TITLE
Image operations fixes (co-6-4)

### DIFF
--- a/loleaflet/src/layer/tile/TileLayer.js
+++ b/loleaflet/src/layer/tile/TileLayer.js
@@ -1207,8 +1207,11 @@ L.TileLayer = L.GridLayer.extend({
 			if (extraInfo.id) {
 				this._map._cacheSVG[extraInfo.id] = textMsg;
 			}
+			var wasVisibleSVG = this._graphicMarker._hasVisibleEmbeddedSVG();
 			this._graphicMarker.removeEmbeddedSVG();
 			this._graphicMarker.addEmbeddedSVG(textMsg);
+			if (wasVisibleSVG)
+				this._graphicMarker._showEmbeddedSVG();
 		}
 	},
 

--- a/loleaflet/src/layer/vector/Path.Transform.js
+++ b/loleaflet/src/layer/vector/Path.Transform.js
@@ -574,6 +574,11 @@ L.Handler.PathTransform = L.Handler.extend({
 	*/
 	_transformPoints: function(path, angle, scale, rotationOrigin, scaleOrigin) {
 		var map = path._map;
+		if (!map) {
+			console.warn('Cannot get map from path in _transformPoints');
+			return;
+		}
+
 		var zoom = map.getMaxZoom() || this.options.maxZoom;
 		var i, len;
 

--- a/loleaflet/src/layer/vector/SVGGroup.js
+++ b/loleaflet/src/layer/vector/SVGGroup.js
@@ -244,6 +244,16 @@ L.SVGGroup = L.Layer.extend({
 		});
 	},
 
+	_hasVisibleEmbeddedSVG: function () {
+		var result = false;
+		this._forEachSVGNode(function (svgNode) {
+			if (svgNode.getAttribute('opacity') !== 0)
+				result = true;
+		});
+
+		return result;
+	},
+
 	_transform: function(matrix) {
 		if (this._renderer) {
 			if (matrix) {


### PR DESCRIPTION
- fixes error sometimes shown in the console
- fixes preview update - before it was leaving empty rectangle when new preview arrived during rotation

(for more info how to reproduce see the commit message)
