### PR TITLE
wsd: preserve the original modified time as string

### DIFF
--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -670,12 +670,6 @@ private:
         bool lastRequestSuccessful() const { return _lastRequestSuccessful; }
 
 
-        /// Set the modified time of the document.
-        void setModifiedTime(std::chrono::system_clock::time_point time) { _modifiedTime = time; }
-
-        /// Returns the modified time of the document.
-        std::chrono::system_clock::time_point getModifiedTime() const { return _modifiedTime; }
-
 
         /// Helper to get the current time.
         static std::chrono::steady_clock::time_point now()
@@ -775,16 +769,10 @@ private:
         }
 
         /// Set the last modified time of the document.
-        void setLastModifiedTime(std::chrono::system_clock::time_point time)
-        {
-            _request.setModifiedTime(time);
-        }
+        void setLastModifiedTime(std::chrono::system_clock::time_point time) { _modifiedTime = time; }
 
         /// Returns the last modified time of the document.
-        std::chrono::system_clock::time_point getLastModifiedTime() const
-        {
-            return _request.getModifiedTime();
-        }
+        std::chrono::system_clock::time_point getLastModifiedTime() const { return _modifiedTime; }
 
         /// True iff a save is in progress (requested but not completed).
         bool isSaving() const { return _request.isActive(); }
@@ -811,6 +799,9 @@ private:
     private:
         /// Request tracking logic.
         RequestManager _request;
+
+        /// The document's last-modified time.
+        std::chrono::system_clock::time_point _modifiedTime;
 
         /// The number of seconds between autosave checks for modification.
         const std::chrono::seconds _autosaveInterval;
@@ -899,16 +890,10 @@ private:
         }
 
         /// Set the last modified time of the document.
-        void setLastModifiedTime(std::chrono::system_clock::time_point time)
-        {
-            _request.setModifiedTime(time);
-        }
+        void setLastModifiedTime(const std::string& time) { _lastModifiedTime = time; }
 
         /// Returns the last modified time of the document.
-        std::chrono::system_clock::time_point getLastModifiedTime() const
-        {
-            return _request.getModifiedTime();
-        }
+        const std::string& getLastModifiedTime() const { return _lastModifiedTime; }
 
     private:
         /// Request tracking logic.
@@ -925,6 +910,9 @@ private:
 
         /// The modified-timestamp of the local file on disk we uploaded last.
         std::chrono::system_clock::time_point _lastUploadedFileModifiedTime;
+
+        /// The modified time of the document in storage, as reported by the server.
+        std::string _lastModifiedTime;
     };
 
 protected:

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -72,13 +72,10 @@ public:
     class FileInfo
     {
     public:
-        FileInfo(const std::string& filename,
-                 const std::string& ownerId,
-                 const std::chrono::system_clock::time_point& modifiedTime,
-                 std::size_t /*size*/)
-            : _filename(filename),
-              _ownerId(ownerId),
-              _modifiedTime(modifiedTime)
+        FileInfo(std::string filename, std::string ownerId, std::string modifiedTime)
+            : _filename(std::move(filename))
+            , _ownerId(std::move(ownerId))
+            , _modifiedTime(std::move(modifiedTime))
         {
         }
 
@@ -92,16 +89,16 @@ public:
 
         const std::string& getOwnerId() const { return _ownerId; }
 
-        /// Set the modified time as reported to the WOPI host.
-        void setModifiedTime(const std::chrono::system_clock::time_point& modifiedTime) { _modifiedTime = modifiedTime; }
+        /// Set the last modified time as reported to the WOPI host.
+        void setLastModifiedTime(const std::string& modifiedTime) { _modifiedTime = modifiedTime; }
 
-        /// Get the modified time as reported by the WOPI host.
-        const std::chrono::system_clock::time_point& getModifiedTime() const { return _modifiedTime; }
+        /// Get the last modified time as reported by the WOPI host.
+        const std::string& getLastModifiedTime() const { return _modifiedTime; }
 
     private:
         std::string _filename;
         std::string _ownerId;
-        std::chrono::system_clock::time_point _modifiedTime;
+        std::string _modifiedTime; //< Opaque modified timestamp as received from the server.
     };
 
     /// Represents the upload request result, with a Result code
@@ -197,7 +194,7 @@ public:
                 const std::string& jailPath) :
         _localStorePath(localStorePath),
         _jailPath(jailPath),
-        _fileInfo("", "cool", std::chrono::system_clock::time_point(), 0),
+        _fileInfo(std::string(), "cool", std::string()),
         _isDownloaded(false),
         _forceSave(false),
         _isUserModified(false),


### PR DESCRIPTION
We no store the origina modified time of the document
as we receive from the storage server in string
form and send it back as-is. This avoids any
potential issues with the roundtrip of conversion
to and from a timestamp.

Change-Id: I524bea8f36c3ce62dcd00c4fe6a1e7e083287ed1
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
