### PR TITLE
Mobile: Fix vex dialogs that still need vex-close

### DIFF
--- a/loleaflet/css/device-mobile.css
+++ b/loleaflet/css/device-mobile.css
@@ -353,7 +353,7 @@ button.vex-dialog-button-secondary.vex-dialog-button.vex-last {
 	flex-direction: column !important;
 }
 
-.vex-close {
+.vex-close:not(.vex-close-m) {
 	display: none;
 }
 

--- a/loleaflet/src/control/Toolbar.js
+++ b/loleaflet/src/control/Toolbar.js
@@ -779,6 +779,7 @@ L.Map.include({
 		vex.open({
 			unsafeContent: content[0].outerHTML,
 			showCloseButton: true,
+			closeClassName: 'vex-close-m',
 			escapeButtonCloses: true,
 			overlayClosesOnClick: true,
 			buttons: {},


### PR DESCRIPTION
context: with 95bd65d all vex dialogs on mobile have vex-close hidden

About dialog on mobile is still the only case where we need to have the
the close button:
	- Add generic CSS class that can be later re-used if needed for other
		cases

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ibf13350c892a77c87ffa2c9a67dcbfe02a3e20f6


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

