### PR TITLE
Make some shortcuts on Mac clients match expectations better

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1,4 +1,4 @@
-/* -*- js-indent-level: 8 -*- */
+/* -*- js-indent-level: 8; fill-column: 100 -*- */
 /*
  * L.CanvasTileLayer is a layer with canvas based rendering.
  */
@@ -783,6 +783,8 @@ L.TileSectionManager = L.Class.extend({
 });
 
 L.CanvasTileLayer = L.Layer.extend({
+
+	isMacClient: (navigator.appVersion.indexOf('Mac') != -1 || navigator.userAgent.indexOf('Mac') != -1),
 
 	options: {
 		pane: 'tilePane',
@@ -3325,6 +3327,31 @@ L.CanvasTileLayer = L.Layer.extend({
 	postKeyboardEvent: function(type, charCode, unoKeyCode) {
 		if (!this._map._docLoaded)
 			return;
+
+		if (this.isMacClient) {
+			// Map Mac standard shortcuts to the LO shortcuts for the corresponding
+			// functions when possible.
+
+			// Cmd+UpArrow -> Ctrl+Home
+			if (unoKeyCode == 1025 + 8192)
+				unoKeyCode = 1028 + 8192;
+			// Cmd+DownArrow -> Ctrl+End
+			else if (unoKeyCode == 1024 + 8192)
+				unoKeyCode = 1029 + 8192;
+			// Cmd+LeftArrow -> Home
+			else if (unoKeyCode == 1026 + 8192)
+				unoKeyCode = 1028;
+			// Cmd+RightArrow -> End
+			else if (unoKeyCode == 1027 + 8192)
+				unoKeyCode = 1029;
+			// Option+LeftArrow -> Ctrl+LeftArrow
+			else if (unoKeyCode == 1026 + 16384)
+				unoKeyCode = 1026 + 8192;
+			// Option+RightArrow -> Ctrl+RightArrow (Not entirely equivalent, should go
+			// to end of word (or next), LO goes to beginning of next word.)
+			else if (unoKeyCode == 1027 + 16384)
+				unoKeyCode = 1027 + 8192;
+		}
 
 		var completeEvent = app.socket.createCompleteTraceEvent('L.TileSectionManager.postKeyboardEvent', { type: type, charCode: charCode });
 


### PR DESCRIPTION
The expected shortcuts are documented in
https://support.apple.com/en-us/HT201236 . This patch handles a small
subset of those:

Command–Up Arrow: Move the insertion point to the beginning of the
document.

Command–Down Arrow: Move the insertion point to the end of the
document.

Command–Left Arrow: Move the insertion point to the beginning of the
current line.

Command–Right Arrow: Move the insertion point to the end of the
current line.

Option–Left Arrow: Move the insertion point to the beginning of the
previous word.

Option–Right Arrow: This should move the insertion point to the end of
the next word. But I don't think LO has such a shortcut so we move to
the beginning of the next word instead.

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: I6b0d36b0842388f0d49adf9b75fa9480df79c805


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

