### PR TITLE
Calc: Fix additional empty bezel appearing above formulabar

### DIFF
--- a/browser/css/device-mobile.css
+++ b/browser/css/device-mobile.css
@@ -99,7 +99,7 @@ div#w2ui-overlay-actionbar.w2ui-overlay{
 	top: 0;
 }
 #toolbar-logo {
-	width: 0px !important;
+	display: none !important;
 }
 #document-header{
 	display: none !important;


### PR DESCRIPTION
It seems this element is not used at all on mobile devices and it seems
to be useful for in terms of: d7b834dd7c953ca27344b244942c43fb2049e0a0
but again it seems pretty safe to set to display none on mobile

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I92e4b85147dd98d47f27a1ddd72bb222494864d8
