### PR TITLE
Sidebar Writer Table Edit Panel

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -163,6 +163,10 @@ div#thousandseparator.checkbutton.jsdialog.sidebar {
 	justify-content: flex-end;
 }
 
+#TableEditPanel #table-grid1 #grid1 > tr > td:nth-child(2) {
+	display: inherit;
+}
+
 .sidebar.ui-drawing-area {
 	max-width: 290px;
 }


### PR DESCRIPTION
In the Writer Sidebar when the user insert an table, 
the table edit panel was shown.

As flex-end isn't needed for this panel, 
`display: inheret;` was used

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I5238c6efda7d58d8eb7612eb91329ac9b45d11db

![image](https://user-images.githubusercontent.com/8517736/152871612-610e9cd1-7c0a-4d6d-aff8-113b0607b418.png)
