### PR TITLE
fix android build failure

### DIFF
--- a/android/lib/src/main/cpp/CMakeLists.txt.in
+++ b/android/lib/src/main/cpp/CMakeLists.txt.in
@@ -22,6 +22,7 @@ add_library(androidapp SHARED
             ../../../../../kit/Kit.cpp
             ../../../../../net/FakeSocket.cpp
             ../../../../../net/Socket.cpp
+            ../../../../../wsd/Exceptions.cpp
             ../../../../../wsd/ClientSession.cpp
             ../../../../../wsd/DocumentBroker.cpp
             ../../../../../wsd/LOOLWSD.cpp

--- a/wsd/Exceptions.hpp
+++ b/wsd/Exceptions.hpp
@@ -13,6 +13,7 @@
 #include <atomic>
 #include <exception>
 #include <stdexcept>
+#include <string>
 
 // not beautiful
 #define EXCEPTION_DECL(type,parent_cl)  \


### PR DESCRIPTION
CMakeLists.txt lacks recently added Exceptions.cpp
file and also needed <string> header in Exceptions.hpp

Signed-off-by: Mert Tumer <mert.tumer@collabora.com>
Change-Id: I183cc9d71e3f98e63d2a0d0b79229b8311bfd611


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

