### PR TITLE
fix sidebar can be visible on pdf

### DIFF
--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -10,6 +10,7 @@ window.app = { // Shouldn't have any functions defined.
 	file: {
 		editComment: false,
 		readOnly: true,
+		disableSidebar: false,
 		size: {
 			pixels: [0, 0], // This can change according to the zoom level and document's size.
 			twips: [0, 0]

--- a/browser/src/control/Control.Sidebar.js
+++ b/browser/src/control/Control.Sidebar.js
@@ -121,7 +121,7 @@ L.Control.Sidebar = L.Control.extend({
 		this.builder.setWindowId(sidebarData.id);
 		$(this.container).empty();
 
-		if (sidebarData.action === 'close' || window.app.file.fileBasedView || this.map.isPermissionReadOnly()) {
+		if (sidebarData.action === 'close' || window.app.file.disableSidebar || this.map.isPermissionReadOnly()) {
 			this.closeSidebar();
 		} else if (sidebarData.children) {
 			for (var i = sidebarData.children.length - 1; i >= 0; i--) {

--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -582,6 +582,7 @@ app.definitions.Socket = L.Class.extend({
 				this._map.setPermission(this._map.options.permission);
 			}
 
+			app.file.disableSidebar = perm !== 'edit';
 			app.file.readOnly = this._map.options.permission === 'readonly';
 			return;
 		}


### PR DESCRIPTION
it appears that sidebar callback can arrive before
docloaded message when it is already loaded in the background
Also app.file.fileBasedView parameter is set after docloaded
so it wasnt a correct fix. perm: message arrives before document
initialization and we can hide sidebar unless the arrived messsage is
not 'edit'. if the user have edit mode, it will be up to the users preference

Signed-off-by: Mert Tumer <mert.tumer@collabora.com>
Change-Id: Ifb220d8bb8baad0078bcd32f71ee6853d31adfb8


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

