### PR TITLE
Sidebar Calc Cell Appearance smaler height usage

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -220,6 +220,14 @@ div#box5.row.jsdialog.sidebar > .sidebar.jsdialog.cell {
 	width: 100%;
 }
 
+#ScCellAppearancePropertyPanelPanelExpander #CellAppearancePropertyPanel table.jsdialog.sidebar.ui-grid,
+#CellAppearancePropertyPanel table.jsdialog.sidebar.ui-grid tr.jsdialog.sidebar {
+	display: flex;
+}
+#ScCellAppearancePropertyPanelPanelExpander #CellAppearancePropertyPanel table.jsdialog.sidebar.ui-grid {
+	justify-content: space-between;
+}
+
 .sidebar-container > .root-container.jsdialog.sidebar {
 	margin: 0;
 }


### PR DESCRIPTION
The cell Appearance in calc sidebar show the following commands:
- background color
- border arrange with border width
- border color

in master there is a lot of vertical space used
without additional feature
so the height was shrinked to one row only

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I0831995ccfc18bc6625304d8faeb65fae0fea9f2

![image](https://user-images.githubusercontent.com/8517736/153510774-feb04ca8-3e05-414f-bbbd-fd4df9e42b1f.png)
