### PR TITLE
Sidebar background color

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -181,7 +181,7 @@ body {
 
 #sidebar-dock-wrapper {
 	display: none;
-	background: var(--color-background-lighter);
+	background: var(--color-main-background);
 	position: relative;
 	border-top: 1px solid var(--color-border);
 	border-left: 1px solid var(--color-border);


### PR DESCRIPTION
The sidebar background color was replaced to
var(--color-main-background)
cause otherwise we don't have the same contrast
than for the toolbar / notebookbar

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: Ic6b1229f958479ef3abe9dd5b00991f0c2784a5b