### PR TITLE
Notebookbar Font style selector update

### DIFF
--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -448,46 +448,25 @@
 /* Styles preview */
 
 #stylesview {
-	height: 60px;
+	height: 64px;
 	width: 530px;
 	overflow-x: hidden;
-	padding: 5px;
 	padding: 0px;
-	border: 1px solid var(--gray-color);
+	border: 1px solid var(--color-border);
+	border-radius: var(--border-radius);
 	border-collapse: separate; /*To use box-shadow in Internet Explorer 9 or later*/
-	-webkit-box-shadow: 0 0 3px var(--gray-color);
-	box-shadow: inset 0 0 3px var(--gray-color);
+	-webkit-box-shadow: 0 0 3px var(--color-border);
+	box-shadow: 0 0 3px var(--color-border);
 }
 
 #stylesview .ui-iconview-entry {
 	width: 30%;
 	box-sizing: border-box;
-	border-radius: 0;
 }
 
 #stylesview .ui-iconview-entry.selected {
-	border: 1px solid var(--gray-light-txt--color);
+	border: 1px solid var(--color-border-dark);
 	border-collapse: separate; /*To use box-shadow in Internet Explorer 9 or later*/
-	-webkit-box-shadow: 0 0 2px var(--gray-light-txt--color);
-	box-shadow: 0 0 2px var(--gray-light-txt--color);
-}
-
-#stylesview .ui-iconview-icon img {
-	height: 30px;
-}
-
-#stylesview .ui-iconview-icon img:after {
-	display: block;
-	position: absolute;
-	top: 0;
-	left: 0;
-	width: 100%;
-	height: 30px;
-	background-color: var(--white-bg-color);
-	overflow: hidden;
-	white-space: nowrap;
-	text-align: center;
-	content: attr(alt);
 }
 
 #stylesview .ui-iconview-entry:not(.selected) {
@@ -495,12 +474,10 @@
 }
 
 #stylesview .ui-iconview-entry:hover {
-	border: 1px solid var(--gray-color);
-	border-collapse: separate; /*To use box-shadow in Internet Explorer 9 or later*/
-	-webkit-box-shadow: 0 0 3px 1px #8080804f, inset -0.5px -0.5px 0 0.5px #ccc, inset 0.5px 0.5px 0 0.5px #ccc;
-	box-shadow: 0 0 3px 1px #8080804f, inset -0.5px -0.5px 0 0.5px #ccc, inset 0.5px 0.5px 0 0.5px #ccc;
+	border: 1px solid var(--color-border-darker);
+	-webkit-box-shadow: 0 0 5px var(--color-background-darker);
+	box-shadow: 0 0 5px var(--color-background-darker);
 	cursor: pointer;
-	height: 30px;
 }
 
 #stylesview .ui-iconview-icon {


### PR DESCRIPTION
use correct var's inkl. border-radius
remove not used css definitions

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: Iaad11a5ace1bdc1c2fccc2ea9f1ef6828e8442af

![image](https://user-images.githubusercontent.com/8517736/153675105-f95c164e-542f-4b75-a009-e6190665cbbd.png)
