### PR TITLE
Drowdown arrow without inline border and with hover effect

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -730,11 +730,11 @@ input[type='number']:hover::-webkit-outer-spin-button {
 }
 
 .arrowbackground:hover {
-	border-left-color: var(--gray-color);
-	background-color: #eee;
+	border-left-color: transparent;
+	background-color: transparent;
 }
 
-.arrowbackground:hover .unoarrow {
+.unoarrow:hover, .arrowbackground:hover .unoarrow {
 	border-top-color: var(--color-text-darker);
 }
 


### PR DESCRIPTION
The dropdown elements show an left-border and background color
when hover over an dropdown element arrow in the sidebar
this color was replaced with transparant

As the arrow is an border element, the arrow use
the text color and has an hover effect.
Arrow follow Text color

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I890121a25408789472d7591edf1a4277d0823c4e

![image](https://user-images.githubusercontent.com/8517736/153701424-0d6e1935-c5f2-4aee-a240-fcd83a8fd5fe.png)