### PR TITLE
Dialog style update

### DIFF
--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -4,6 +4,12 @@
 	text-transform: full-size-kana;
 }
 
+.jsdialog *[disabled] {
+	color: var(--color-text-lighter) !important;
+	background-color: var(--color-background-lighter) !important;
+	border: 1px solid var(--color-border-lighter) !important;
+}
+
 .cool-annotation-edit #annotation-cancel,
 .ui-pushbutton.jsdialog:not(#ok):not(.sidebar),
 .ui-button-box.jsdialog #cancel,
@@ -21,16 +27,37 @@
 .vex.vex-theme-plain .vex-dialog-button.vex-dialog-button-secondary {
 	height: 32px;
 	line-height: 0em;
-	color: #222;
+	color: var(--color-main-text);
 	min-width: 62px;
-	background-color: #f1f1f1 !important;
-	border: 1px solid #ccc;
-	border-radius: 3px;
+	background-color: var(--color-background-dark);
+	border: 1px solid var(--color-border);
+	border-radius: var(--border-radius);
 	margin: 5px;
 	vertical-align: middle;
 	display: flex;
 	align-items: center;
 	justify-content: center;
+}
+
+.cool-annotation-edit #annotation-cancel:hover,
+.ui-pushbutton.jsdialog:not(#ok):not(.sidebar):hover,
+.ui-button-box.jsdialog #cancel:hover,
+.ui-button-box.autofilter #cancel:hover,
+.cell.jsdialog > button:not(#ok):hover,
+.ui-button-box.jsdialog button:not(#ok):hover,
+.jsdialog-container #source-button:hover,
+.jsdialog-container #destination-button:hover,
+.jsdialog-container #refbutton:hover,
+.jsdialog-container #assign:hover,
+.jsdialog-container #input-range-button:hover,
+.jsdialog-container #output-range-button:hover,
+.jsdialog-container #variable1-range-button:hover,
+.jsdialog-container #variable2-range-button:hover,
+.vex.vex-theme-plain .vex-dialog-button.vex-dialog-button-secondary:hover {
+	cursor: pointer;
+	color: var(--color-text-darker) !important;
+	background-color: var(--color-background-darker) !important;
+	border: 1px solid var(--color-border-darker);
 }
 
 .cool-annotation-edit .annotation-button,
@@ -57,10 +84,8 @@
 
 .jsdialog.ui-button-box.end {
 	margin-top: 8px;
-}
-
-.jsdialog *[disabled] {
-	color: var(--gray-light-txt--color) !important;
+	display: flex;
+	justify-content: space-between;
 }
 
 .jsdialog.ui-button-box button[disabled='disabled'] {

--- a/browser/css/infobar.css
+++ b/browser/css/infobar.css
@@ -16,3 +16,12 @@
 	height: 42px;
 	border: none;
 }
+
+.ui-widget-header {
+	background: var(--color-background-darker);
+	border: none;
+	color: var(--color-text-darker);
+}
+.ui-widget-content {
+	color: var(--color-main-text);
+}

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -37,8 +37,10 @@
 }
 
 .jsdialog-container .ui-dialog-content {
-	background-color: white !important;
+	background-color: var(--color-main-background) !important;
 	font-family: var(--jquery-ui-font);
+	-webkit-box-shadow: 0 0 3px var(--color-border);
+	box-shadow: 0 0 3px var(--color-border);
 }
 
 .jsdialog.vertical p, .ui-frame-label {
@@ -47,6 +49,13 @@
 	font-size: 10px;
 	font-weight: bold;
 	text-transform: uppercase;
+}
+
+.lokdialog_container.ui-dialog.ui-widget-content, .autofilter-container {
+	border: 1px solid var(--color-border-dark);
+	-webkit-box-shadow: 0 0 3px var(--color-border);
+	box-shadow: 0 0 3px var(--color-border);
+	border-radius: var(--border-radius);
 }
 
 .jsdialog.ui-separator.vertical {
@@ -91,7 +100,7 @@ td.jsdialog .jsdialog.cell:not(.sidebar),
 }
 
 .jsdialog.vertical:not(.sidebar) {
-	width: max-content;
+	width: 100%;
 }
 
 .jsdialog.vertical:not([id^='table-dialog-action_area']) > .jsdialog.row,
@@ -107,6 +116,7 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 
 .jsdialog.ui-grid {
 	border-spacing: 0px;
+	width: 100%;
 }
 
 /* Tabs */
@@ -318,6 +328,9 @@ input[type='checkbox']:checked.autofilter, .jsdialog input[type='checkbox']:chec
 .jsdialog.ui-edit {
 	line-height: 28px;
 	max-height: 32px;
+	width: 100%;
+	border: 1px solid var(--color-border);
+	border-radius: var(--border-radius);
 }
 
 #search_edit.ui-edit.autofilter {
@@ -339,8 +352,8 @@ input[type='checkbox']:checked.autofilter, .jsdialog input[type='checkbox']:chec
 
 .jsdialog.checkbutton label {
 	padding: 0px 2px;
+	line-height: 28px;
 }
-
 /* Radio button */
 
 .jsdialog input[type='radio'] {


### PR DESCRIPTION
bottom buttons are better align with
buttons get hover effect with correct color vars
display: flex; and justify-content: space-between;
dialog get a border and a box-shadow
widget-header use --color-background-darker colors

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I1e77434b1d4fc166a22a9774bb3168852456d3d3

![image](https://user-images.githubusercontent.com/8517736/153730593-3cf1da90-025b-4eb0-81c9-2ed133d439ac.png)