### PR TITLE
Menubar use transparent background and correct border color

### DIFF
--- a/browser/css/menubar.css
+++ b/browser/css/menubar.css
@@ -65,7 +65,7 @@
 .main-nav {
 	height: 38px; /* on mouseover menubar items, border emerges */
 	width: auto;
-	background: #ffffff;
+	background: transparent;
 	padding: 3px 3px 3px 0;
 	white-space: nowrap;
 	z-index: 12;
@@ -74,7 +74,7 @@
 }
 .main-nav.readonly {
 	position: relative;
-	border-bottom: 1px solid var(--gray-light-bg-color);
+	border-bottom: 1px solid var(--color-border);
 }
 .main-nav.hasnotebookbar {
 	height: 32px;


### PR DESCRIPTION
Menubar use transparent background color,
so the menubar use the color of the toolbar

In read only mode the bottom-border use --color-border var

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I0f5b612cc2af7f10e62442b3568778be2ce4e52f

![image](https://user-images.githubusercontent.com/8517736/153776135-a9fa26aa-7d7f-4671-83c4-4d84401aa727.png)
