### PR TITLE
Toolbar color update

### DIFF
--- a/browser/css/color-palette.css
+++ b/browser/css/color-palette.css
@@ -31,6 +31,10 @@
 	--color-border-darker: #696969;  /* hover */
 	--color-border-lighter: #f1f1f1;
 
+	--color-error: #e9322d;
+	--color-warning: #eca700;
+	--color-success: #46ba61;
+
 	--border-radius: 4px;
 	--border-radius-large: 10px;
 }

--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -73,7 +73,7 @@
 	position: fixed;
 	bottom: 0;
 	z-index: 1000;
-	border-top: 1px solid #bbbbbb;
+	border-top: 1px solid var(--color-border);
 }
 
 #tb_actionbar_item_prev .w2ui-icon.prev {

--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -51,8 +51,9 @@
 }
 #InsertMode.insert-mode-false,
 #PermissionMode.status-readonly-mode {
-	background-color: var(--gray-light-txt--color);
+	background-color: var(--color-warning);
 	color: white;
+	border-radius: var(--border-radius);
 }
 #tb_actionbar_item_zoom .w2ui-tb-caption{
 	min-width: 43px;

--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -62,7 +62,7 @@
 	content: '%';
 }
 #document-signing-bar {
-	background-color: #ef324e;
+	background-color: var(--color-error);
 }
 
 #toolbar-search {

--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -88,7 +88,7 @@ w2ui-toolbar {
 	position: absolute;
 	right: 10px;
 	top: 40px;
-	border: 1px solid darkgrey;
+	border: 1px solid var(--color-border);
 	z-index: 1000;
 	display: none;
 	overflow: visible !important;


### PR DESCRIPTION
In status-readonly-mode the element on the down toolbar
use --color-warning background color and --border-radius

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I55782f5632f55f5923d53ec9a03628e048fa45da

![image](https://user-images.githubusercontent.com/8517736/153776739-41ac6fe0-1e92-439c-804c-2f002fa8771f.png)
