### PR TITLE
mobilewizard input checkbox disabled no gray background

### DIFF
--- a/browser/css/mobilewizard.css
+++ b/browser/css/mobilewizard.css
@@ -968,11 +968,6 @@ label.disabled {
 	color: grey !important;
 }
 
-input[type='checkbox'][disabled] {
-	background-color: grey !important;
-	border-color: grey !important;
-}
-
 .ui-checkbox.mobile-wizard {
 	margin-top: 25px;
 	padding-left: 2% !important;


### PR DESCRIPTION
there is a light text effect on mobile for commands
that aren't available (disabled) which work fine
but the additional gray background and border color
is not easy to recognize
and it cause visual issues on desktops

general everywhere in cool lighter text mean not available,
so no additional stuff is needed.

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I5315e1d6a84ae3caf037ec7ab4c1ab81dcfbe44d

#### mobile after
![image](https://user-images.githubusercontent.com/8517736/153778069-f126f41b-48f8-47cb-a31b-5f076314720e.png)


#### desktop after
![image](https://user-images.githubusercontent.com/8517736/153778106-d32ce917-12d3-47f6-a2f7-5206dc9d10cc.png)
