### PR TITLE
sidebar width is 330px and duplicate borders removed

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -183,7 +183,6 @@ body {
 	display: none;
 	background: var(--color-main-background);
 	position: relative;
-	border-top: 1px solid var(--color-border);
 	border-left: 1px solid var(--color-border);
 	overflow: hidden;
 	z-index: 990;

--- a/browser/css/impress-mobile.css
+++ b/browser/css/impress-mobile.css
@@ -2,3 +2,7 @@
 	background-color: #c2d5ed;
 	box-shadow: inset 0px 0px 5px 0px #4a96d3;
 }
+
+#presentation-controls-wrapper {
+	border-top: 1px solid var(--color-border) !important;
+}

--- a/browser/css/impress.css
+++ b/browser/css/impress.css
@@ -8,5 +8,4 @@
 }
 #presentation-controls-wrapper {
 	background: var(--color-background-dark) !important;
-	border-top: 1px solid var(--color-border) !important;
 }

--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -11,7 +11,7 @@
 }
 
 #document-container:not(.mobile) + #sidebar-dock-wrapper {
-	width: 322px;
+	width: 330px;
 	padding: 0;
 	border-left: 1px solid var(--gray-color) !important;
 	border-right: 1px solid var(--gray-color) !important; /* for RTL mode */

--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -7,7 +7,6 @@
 	z-index: 999;
 	overflow: visible !important;
 	background-color: var(--color-main-background);
-	border-bottom: 1px solid var(--color-border);
 }
 
 #toolbar-down {


### PR DESCRIPTION
The sidebar width is 330px and not 322px.
330px is the default width with 322px the sidebar width is smaler
than needed which causes issues of symetry AND issues when
there is an additional scrallbar needed.

Top borders at the sidebar's were removed
cause there is already an border at the top toolbar.

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I6c53132b273a2b83fd89c58778577e1b47cda125