### PR TITLE
fix copy comments breaking the canvassection completely

### DIFF
--- a/browser/src/layer/tile/CommentListSection.ts
+++ b/browser/src/layer/tile/CommentListSection.ts
@@ -923,7 +923,8 @@ class CommentSection {
 			this.showHideComment(annotation);
 		}
 		else {
-			this.containerObject.addSection(annotation);
+			if (!this.containerObject.addSection(annotation))
+				return;
 			this.sectionProperties.commentList.push(annotation);
 		}
 
@@ -1699,7 +1700,8 @@ class CommentSection {
 					comment.avatar = this.map._viewInfoByUserName[comment.author].userextrainfo.avatar;
 				}
 				var commentSection = new app.definitions.Comment(comment, {}, this);
-				this.containerObject.addSection(commentSection);
+				if (!this.containerObject.addSection(commentSection))
+					continue;
 				this.sectionProperties.commentList.push(commentSection);
 				this.idIndexMap.set(commentSection.sectionProperties.data.id, i);
 				this.updateResolvedState(this.sectionProperties.commentList[i]);


### PR DESCRIPTION
core sends same id for copy comments and this breaks the
existing implementation because sections are named based on the id.

Signed-off-by: Mert Tumer <mert.tumer@collabora.com>
Change-Id: Ia410227b7a42ac8ea7682f12aa980b34ee5c940b


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

