### PR TITLE
browser: add missing error method for logging

### DIFF
--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -68,7 +68,7 @@ window.app = { // Shouldn't have any functions defined.
 	// enable later toggling
 	global.setLogging = function(doLogging)
 	{
-		var loggingMethods = ['warn', 'info', 'debug', 'trace', 'log', 'assert', 'time', 'timeEnd', 'group', 'groupEnd'];
+		var loggingMethods = ['error', 'warn', 'info', 'debug', 'trace', 'log', 'assert', 'time', 'timeEnd', 'group', 'groupEnd'];
 		if (!doLogging) {
 			var noop = function() {};
 


### PR DESCRIPTION
Signed-off-by: Alexandru Vlăduţu <alexandru.vladutu@1and1.ro>
Change-Id: Id4aa67e98779dd0d5c92172425baa753fcaca27c


* Resolves: relates to #3883 
* Target version: master 

### Summary

The `.error()` method was missing from the logging ones, so `window.app.console.error()` would not work. 

### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

