### PR TITLE
Expose a11y check online

### DIFF
--- a/browser/images/lc_accessibilitycheck.svg
+++ b/browser/images/lc_accessibilitycheck.svg
@@ -1,0 +1,5 @@
+<?xml-stylesheet type="text/css" href="icons.css" ?>
+<svg version="1.1" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+ <path d="m12 2.5a9.5 9.5 0 0 0-9.5 9.5 9.5 9.5 0 0 0 9.5 9.5 9.5 9.5 0 0 0 9.5-9.5 9.5 9.5 0 0 0-9.5-9.5z" fill="#83beec" stroke="#1e8bcd" stroke-linecap="round" stroke-linejoin="round"/>
+ <path d="m12 5c0.77 0 1.4 0.63 1.4 1.4 0 0.77-0.63 1.4-1.4 1.4s-1.4-0.63-1.4-1.4c0-0.77 0.63-1.4 1.4-1.4zm6.3 4.9h-4.2v9.1h-1.4v-4.2h-1.4v4.2h-1.4v-9.1h-4.2v-1.4h12.6z" fill="#fafafa" stroke-width=".7"/>
+</svg>

--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -287,6 +287,7 @@ L.Control.Menubar = L.Control.extend({
 						{name: _('None (Do not check spelling)'), id: 'nonelanguage', uno: '.uno:LanguageStatus?Language:string=Default_LANGUAGE_NONE'}]}
 				]},
 				{uno: '.uno:WordCountDialog'},
+				{uno: '.uno:AccessibilityCheck'},
 				{type: 'separator'},
 				{name: _UNO('.uno:AutoFormatMenu', 'text'), type: 'menu', menu: [
 					{uno: '.uno:OnlineAutoFormat'}]},

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -1601,6 +1601,11 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				'type': 'bigtoolitem',
 				'text': _UNO('.uno:AcceptTrackedChanges', 'text'),
 				'command': '.uno:AcceptTrackedChanges'
+			},
+			{
+				'type': 'bigtoolitem',
+				'text': _UNO('.uno:AccessibilityCheck', 'text'),
+				'command': '.uno:AccessibilityCheck'
 			}
 		];
 

--- a/browser/src/unocommands.js
+++ b/browser/src/unocommands.js
@@ -5,6 +5,7 @@ var unoCommandsArray = {
 	'AcceptTrackedChange':{text:{context:_('Accept Change'),menu:_('Accept'),},},
 	'AcceptTrackedChangeToNext':{text:{context:_('Accept Track Change and select the next one'),menu:_('Accept and Move to Next'),},},
 	'AcceptTrackedChanges':{text:{context:_('Manage Track Changes'),menu:_('~Manage...'),},},
+	'AccessibilityCheck':{text:{menu:_('~Accessibility Check...'),},},
 	'AddName':{spreadsheet:{menu:_('~Define...'),},},
 	'AlignBlock':{spreadsheet:{menu:_('Justified'),},},
 	'AlignBottom':{spreadsheet:{menu:_('Align Bottom'),},text:{menu:_('Align Bottom to Anchor'),},},


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

Exposes the accessibility checker used in LO writer and core for use in COOL Writer.
Can be accessed in Notebookbar under review and also the hamburger drop down in the top left under tools>accessibility check.
Also added in the menubar, but I don't see this anywhere in the actual UI- possibly not used not sure?


Note I just used the svg for the a11y logo from [their website](https://www.a11yproject.com/) and changed the color, don't know if we want this to be something else

### TODO

- [ ] Possibly change logo
- [x] Does mobile need accessibility checker?
- [ ] Should the checker be enabled when the document is readonly?
- [ ] Update [online help menu](https://help.collaboraoffice.com/21.06/en-US/text/shared/05/err_html.html?System=&DbPAR=WRITER&HID=svx/ui/accessibilitycheckdialog/dialogButtons) with content from [libre office help menu](https://help.libreoffice.org/7.3/en-GB/text/swriter/01/accessibility_check.html?&DbPAR=WRITER&System=WIN)

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

