### PR TITLE
Hamburger icon update

### DIFF
--- a/browser/images/lc_hamburger.svg
+++ b/browser/images/lc_hamburger.svg
@@ -1,65 +1,15 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   viewBox="0 0 24 24"
-   version="1.1"
-   id="svg11"
-   sodipodi:docname="lc_hamburger.svg"
-   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
-  <metadata
-     id="metadata17">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <defs
-     id="defs15" />
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1019"
-     id="namedview13"
-     showgrid="false"
-     inkscape:zoom="11.8125"
-     inkscape:cx="38.006248"
-     inkscape:cy="8.5621657"
-     inkscape:window-x="0"
-     inkscape:window-y="32"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="symbol" />
-  <g
-     id="symbol"
-     fill="#63bbee"
-     stroke="#0369a3"
-     stroke-linecap="round"
-     stroke-linejoin="round">
+<?xml-stylesheet type="text/css" href="icons.css" ?>
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
     <path
-       id="path2"
-       d="m 2.5,2.5 v 1 h 14 5 v -1 h -4 -2 z" />
+       d="M 3,3 H 21"
+       style="stroke:#333333;stroke-width:2;stroke-linecap:round"
+       />
     <path
-       id="path847"
-       d="m 2.5,11.5 v 1 h 14 5 v -1 h -4 -2 z" />
+       d="M 3,12 H 21"
+       style="stroke:#333333;stroke-width:2;stroke-linecap:round"
+       />
     <path
-       id="path849"
-       d="m 2.5,20.5 v 1 h 14 5 v -1 h -4 -2 z" />
-  </g>
+       d="M 3,21 H 21"
+       style="stroke:#333333;stroke-width:2;stroke-linecap:round"
+       />
 </svg>


### PR DESCRIPTION
icon
 - hamburger menu use --color-main-text
 - so all stuff in the header area use the same color

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: Id3361c0f58d5ce12bd1d312bd7aa303fe2071282

follow up to #4200

#### Notebookbar
![image](https://user-images.githubusercontent.com/8517736/153958180-674ba166-c393-40a3-8947-5caa7d72de1e.png)