### PR TITLE
Remove border color from #toolbar-up on mobile except calc

### DIFF
--- a/browser/css/device-mobile.css
+++ b/browser/css/device-mobile.css
@@ -408,6 +408,8 @@ button.vex-dialog-button-secondary.vex-dialog-button.vex-last {
 	padding-top: 0px;
 	padding-bottom: 0px;
 	background: transparent;
+}
+nav:not(.spreadsheet-color-indicator) ~ #toolbar-wrapper #toolbar-up.w2ui-toolbar {
 	border-color: transparent;
 }
 #formulabar {


### PR DESCRIPTION
improvement upon d9e766c19af1d0236cb4065daa53ff9c30b3ba4c
- On calc we need that border since we have the formula bar component

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I7d4c255654bf570a2fa4ac11a9df978f36f22971
