### PR TITLE
Turn ctrl-left-click into right-click for browsers on macOS

### DIFF
--- a/browser/src/map/handler/Map.Mouse.js
+++ b/browser/src/map/handler/Map.Mouse.js
@@ -92,6 +92,14 @@ L.Map.Mouse = L.Handler.extend({
 		buttons |= e.originalEvent.button === this.JSButtons.middle ? this.LOButtons.middle : 0;
 		buttons |= e.originalEvent.button === this.JSButtons.right ? this.LOButtons.right : 0;
 
+		// Turn ctrl-left-click into right-click for browsers on macOS
+		if (navigator.appVersion.indexOf('Mac') != -1 || navigator.userAgent.indexOf('Mac') != -1) {
+			if (modifier == UNOModifier.CTRL && buttons == this.LOButtons.left) {
+				modifier = 0;
+				buttons = this.LOButtons.right;
+			}
+		}
+
 		var mouseEnteringLeavingMap = this._map._mouseEnteringLeaving;
 
 		if (mouseEnteringLeavingMap && e.type === 'mouseover' && this._mouseDown) {


### PR DESCRIPTION
Not sure why the browser doesn't do it automatically. Ctrl-left-click
works on normal webpages just fine, it is equivalent to a tap with two
fingers on a trackpad. (Which, I think, is what Mac users most often
use. That is equivalent to a right-click.)

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: I1f0daf0929b41e25a58456bd995f1463c873c42c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

