### PR TITLE
Send error on failed load and/or exception during document load

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1038,12 +1038,16 @@ private:
         try
         {
             if (!load(session, renderOpts))
+            {
+                session->sendTextFrameAndLogError("error: cmd=load kind=faileddocloading");
                 return false;
+            }
         }
         catch (const std::exception &exc)
         {
             LOG_ERR("Exception while loading url [" << uriAnonym <<
                     "] for session [" << sessionId << "]: " << exc.what());
+            session->sendTextFrameAndLogError("error: cmd=load kind=faileddocloading");
             return false;
         }
 


### PR DESCRIPTION
This avoids an endless spinner for the loading mobile app in this case.

Change-Id: I047797cbdb066a236afc40337d2eba08f9c0c84b


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

