### PR TITLE
android: fix uncaught exception documentSigningUrl

### DIFF
--- a/browser/html/cool.html.m4
+++ b/browser/html/cool.html.m4
@@ -221,7 +221,10 @@ m4_ifelse(MOBILEAPP,[true],
 
     <!--%DOCUMENT_SIGNING_DIV%-->
     <script>
-      window.documentSigningURL = decodeURIComponent('%DOCUMENT_SIGNING_URL%');
+    m4_ifelse(MOBILEAPP,[true],
+      [ window.documentSigningURL = ''; ],
+      [ window.documentSigningURL = decodeURIComponent('%DOCUMENT_SIGNING_URL%'); ]
+    )
     </script>
 
     <input id="insertgraphic" aria-labelledby="menu-insertgraphic" type="file" accept="image/*" style="position: fixed; top: -100em">


### PR DESCRIPTION
use empty string in mobile app since it is not used

Signed-off-by: Mert Tumer <mert.tumer@collabora.com>
Change-Id: I699c348c01ad06b7e720499a615e2c9a27bbf630


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

