### PR TITLE
Sidebar Table Paragraph vertical alignment commands next row

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -243,10 +243,14 @@ td.jsdialog .jsdialog.cell.sidebar {
 	width: auto;
 }
 
-.spreadsheet-document + #sidebar-dock-wrapper #ScAlignmentPropertyPanelPanelExpander #box3 > div:last-of-type,
-.presentation-doctype + #sidebar-dock-wrapper #ParaPropertyPanelPanelExpander #box1 > div:last-of-type,
-.drawing-doctype + #sidebar-dock-wrapper #ParaPropertyPanelPanelExpander #box1 > div:last-of-type {
+#sidebar-dock-wrapper #ParaPropertyPanelPanelExpander #box1 > div:last-of-type,
+.spreadsheet-document + #sidebar-dock-wrapper #ScAlignmentPropertyPanelPanelExpander #box3 > div:last-of-type {
 	display: table-row;
+}
+
+#sidebar-dock-wrapper #ParaPropertyPanelPanelExpander #box1 > div:last-of-type > div,
+.spreadsheet-document + #sidebar-dock-wrapper #ScAlignmentPropertyPanelPanelExpander #box3 > div:last-of-type > div {
+	padding: 2px;
 }
 
 .sidebar.jsdialog.checkbutton {


### PR DESCRIPTION
when you insert an table there is in the sidebar paragraph section
alignment horizontal LtR RtL and alignment vertical
overall there are 9 command
which are to much for the sidebar width

therefore if there is alignment-vertical available,
it was moved to the next row with display: table-row

as the new command for writer work also for impress and draw
the setting for impress/draw only was removed

for prefext alignment padding: 2px was added

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: Ic030cab180921e238c44a4fb62962e69542beee5

* Resolves: #3805 
* Target version: master 

#### Sidebar writer text mode
![Screenshot_20220218_003536](https://user-images.githubusercontent.com/8517736/154591109-8dd4195b-9ef5-4ae3-9c3d-fd2091de1ac2.png)

#### Sidebar writer insert table
![Screenshot_20220218_003526](https://user-images.githubusercontent.com/8517736/154591034-03f8f0ae-9a47-4c57-a07a-fbf4fa1b0997.png)

#### Sidebar impress insert table
![Screenshot_20220218_004416](https://user-images.githubusercontent.com/8517736/154591146-2be56b57-3424-44aa-b877-7b0f9f80b97c.png)

