### PR TITLE
Toolbar Dropdown Widget arrow use --color-main-text

### DIFF
--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -92,6 +92,10 @@ w2ui-toolbar {
 	display: none;
 	overflow: visible !important;
 }
+.w2ui-toolbar table.w2ui-button .w2ui-tb-down > div,
+.select2-container--default .select2-selection--single .select2-selection__arrow b {
+	border-top: 5px solid var(--color-main-text);
+}
 #toolbar-down .ToolbarStatusInactive {
 	color: var(--color-text-lighter);
 	box-shadow: inset 0px 0px 0px 10px #f2f2f2, 0px 0px 0px 2px #f2f2f2, 4px 0px 0px 1px #fff, -4px 0px 0px 1px #fff, 0px 0px 0px 5px #fff;


### PR DESCRIPTION
Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I5cc8e47148df5b5a68fed75d4b0298ee930b7792

![image](https://user-images.githubusercontent.com/8517736/154594315-cc63f4ed-8ba8-4979-b61f-55146eea4e56.png)
arrows in the screenshot get `--color-main-text`