### PR TITLE
browser: enhance postMessage for UI_Save

### DIFF
--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -1583,7 +1583,8 @@ L.Control.Menubar = L.Control.extend({
 		if (id === 'save') {
 			// Save only when not read-only.
 			if (!this._map.isPermissionReadOnly()) {
-				this._map.fire('postMessage', {msgId: 'UI_Save'});
+				this._map.fire('postMessage', {msgId: 'UI_Save', args: { source: 'filemenu' }});
+
 				if (!this._map._disableDefaultAction['UI_Save']) {
 					this._map.save(false, false);
 				}

--- a/browser/src/control/Control.NotebookbarBuilder.js
+++ b/browser/src/control/Control.NotebookbarBuilder.js
@@ -734,7 +734,7 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 		$(control.container).click(function () {
 			// Save only when not read-only.
 			if (!builder.map.isPermissionReadOnly()) {
-				builder.map.fire('postMessage', {msgId: 'UI_Save'});
+				builder.map.fire('postMessage', {msgId: 'UI_Save', args: { source: 'notebookbar' }});
 				if (!builder.map._disableDefaultAction['UI_Save']) {
 					builder.map.save(false, false);
 				}

--- a/browser/src/control/Control.Toolbar.js
+++ b/browser/src/control/Control.Toolbar.js
@@ -87,6 +87,9 @@ function onClick(e, id, item) {
 		map.fire('postMessage', {msgId: 'Clicked_Button', args: {Id: item.id} });
 	}
 	else if (item.uno) {
+		if (id === 'save') {
+			map.fire('postMessage', {msgId: 'UI_Save', args: { source: 'toolbar' }});
+		}
 		if (item.unosheet && map.getDocType() === 'spreadsheet') {
 			map.toggleCommandState(item.unosheet);
 		}
@@ -100,7 +103,7 @@ function onClick(e, id, item) {
 	else if (id === 'save') {
 		// Save only when not read-only.
 		if (!map.isPermissionReadOnly()) {
-			map.fire('postMessage', {msgId: 'UI_Save'});
+			map.fire('postMessage', {msgId: 'UI_Save', args: { source: 'toolbar' }});
 			if (!map._disableDefaultAction['UI_Save']) {
 				map.save(false /* An explicit save should terminate cell edit */, false /* An explicit save should save it again */);
 			}

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -2764,10 +2764,10 @@ L.CanvasTileLayer = L.Layer.extend({
 		textMsg = textMsg.substring(18);
 		var obj = JSON.parse(textMsg);
 		var commandName = obj.commandName;
-		if (obj.success === 'true') {
+		if (obj.success === 'true' || obj.success === true) {
 			var success = true;
 		}
-		else if (obj.success === 'false') {
+		else if (obj.success === 'false' || obj.success === false) {
 			success = false;
 		}
 

--- a/browser/src/map/handler/Map.Keyboard.js
+++ b/browser/src/map/handler/Map.Keyboard.js
@@ -605,7 +605,7 @@ L.Map.Keyboard = L.Handler.extend({
 		case 83: // s
 			// Save only when not read-only.
 			if (!this._map.isPermissionReadOnly()) {
-				this._map.fire('postMessage', {msgId: 'UI_Save'});
+				this._map.fire('postMessage', {msgId: 'UI_Save', args: { source: 'keyboard' }});
 				if (!this._map._disableDefaultAction['UI_Save']) {
 					this._map.save(false /* An explicit save should terminate cell edit */,
 					               false /* An explicit save should save it again */);


### PR DESCRIPTION
closes #4230

Signed-off-by: Alexandru Vlăduţu <alexandru.vladutu@1and1.ro>
Change-Id: Ibcc0a3c8bb17dc78775362bc4fd61601d186e822


* Resolves: #4230 
* Target version: master 

### Summary

Added a new `source` param to the `postMessage` API for `UI_Save`, so that it can be differentiated between saving from keyboard, file menu or toolbar.

### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

