### PR TITLE
Sidebar select and hover 1px border as everywhere

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -279,7 +279,7 @@ td.jsdialog .jsdialog.cell.sidebar {
 .hasnotebookbar .ui-content.unotoolbutton:not(.has-label):not(.inline),
 .sidebar.unotoolbutton {
 	background-color: transparent;
-	border: 2px solid transparent;
+	border: 1px solid transparent;
 	color: var(--color-main-text);
 	border-radius: var(--border-radius);
 }
@@ -289,7 +289,7 @@ td.jsdialog .jsdialog.cell.sidebar {
 .hasnotebookbar .ui-content.unotoolbutton.selected:not(.has-label):not(.inline),
 .sidebar.unotoolbutton.selected {
 	background-color: var(--color-background-dark);
-	border: 2px solid transparent;
+	border: 1px solid transparent;
 	color: var(--color-text-dark);
 	border-radius: var(--border-radius);
 }


### PR DESCRIPTION
the borders are ordinary 1px so it was update for
jsdialog.cell.sidebar to be also 1px border size.

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: Ie85a82fecd608edd25d5c3314e70a8b91c0a31bb

![image](https://user-images.githubusercontent.com/8517736/154750278-0cd4d6aa-7481-4d5f-a033-ce534f886251.png)
