### PR TITLE
Unit test for &lang=es-419 style code, disliked by boost gettext.

### DIFF
--- a/test/helpers.hpp
+++ b/test/helpers.hpp
@@ -712,7 +712,8 @@ std::shared_ptr<COOLWebSocket> loadDocAndGetSocket(const std::string& docFilenam
 inline std::shared_ptr<http::WebSocketSession>
 loadDocAndGetSession(std::shared_ptr<SocketPoll> socketPoll, const Poco::URI& uri,
                      const std::string& documentURL, const std::string& testname,
-                     bool isView = true, bool isAssert = true)
+                     bool isView = true, bool isAssert = true,
+                     const std::string &loadParams = "")
 {
     try
     {
@@ -721,7 +722,7 @@ loadDocAndGetSession(std::shared_ptr<SocketPoll> socketPoll, const Poco::URI& ur
         http::Request req(documentURL);
         ws->asyncRequest(req, std::move(socketPoll));
 
-        sendTextFrame(ws, "load url=" + documentURL, testname);
+        sendTextFrame(ws, "load url=" + documentURL + loadParams, testname);
         const bool isLoaded = isDocumentLoaded(ws, testname, isView);
         if (!isLoaded && !isAssert)
         {

--- a/test/httpwstest.cpp
+++ b/test/httpwstest.cpp
@@ -40,6 +40,7 @@ class HTTPWSTest : public CPPUNIT_NS::TestFixture
 
     CPPUNIT_TEST_SUITE(HTTPWSTest);
 
+    CPPUNIT_TEST(testExoticLang);
     CPPUNIT_TEST(testSaveOnDisconnect);
     CPPUNIT_TEST(testSavePassiveOnDisconnect);
     // This test is failing
@@ -50,6 +51,7 @@ class HTTPWSTest : public CPPUNIT_NS::TestFixture
 
     CPPUNIT_TEST_SUITE_END();
 
+    void testExoticLang();
     void testSaveOnDisconnect();
     void testSavePassiveOnDisconnect();
     void testReloadWhileDisconnecting();
@@ -95,6 +97,27 @@ public:
         resetTestStartTime();
     }
 };
+
+void HTTPWSTest::testExoticLang()
+{
+    const std::string testname = "saveOnDisconnect- ";
+
+    std::string documentPath, documentURL;
+    getDocumentPathAndURL("hello.odt", documentPath, documentURL, testname);
+
+    try
+    {
+        std::shared_ptr<http::WebSocketSession> socket
+            = loadDocAndGetSession(_socketPoll, _uri, documentURL,
+                                   "exoticlocale", true, true,
+                                   " lang=es-419");
+        socket->asyncShutdown();
+    }
+    catch (const Poco::Exception& exc)
+    {
+        LOK_ASSERT_FAIL(exc.displayText());
+    }
+}
 
 void HTTPWSTest::testSaveOnDisconnect()
 {


### PR DESCRIPTION
Change-Id: I2f1c39d03d61ef2074fe6e946a79fc2f07ffd27b
Signed-off-by: Michael Meeks <michael.meeks@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

