### PR TITLE
CSS Var: fix for toolbar dropdown menu border radius

### DIFF
--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -467,6 +467,7 @@ button.leaflet-control-search-next
 	line-height: 24px;
 	background-color: var(--color-background-dark);
 	color: var(--color-text-dark);
+	border-radius: var(--border-radius);
 }
 .select2-container--default .select2-selection--single .select2-selection__rendered:hover {
 	background-color: var(--color-background-darker);


### PR DESCRIPTION
the border-radius was needed at .select2.container--default and
.select2.selection--single and __rendered to have nice borders

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I6ae386d65f45c49f221a3c987b101132eb4d56c7

![image](https://user-images.githubusercontent.com/8517736/154793787-e438617b-2d0a-4926-b292-13a7c3b4d288.png)