### PR TITLE
CSS Var's update for color selector

### DIFF
--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -94,16 +94,8 @@ w2ui-toolbar {
 }
 .w2ui-toolbar table.w2ui-button .w2ui-tb-down > div,
 .select2-container--default .select2-selection--single .select2-selection__arrow b {
-	border-top: 5px solid var(--color-text-dark);
+	border-top: 5px solid var(--color-main-text);
 }
-
-.select2-container--default.select2-container--open .select2-selection--single .select2-selection__arrow b {
-	border-color: transparent transparent var(--color-text-dark) transparent;
-}
-.select2-container--default .select2-selection--single .select2-selection__arrow b {
-	border-color: var(--color-text-dark) transparent transparent transparent;
-}
-
 #toolbar-down .ToolbarStatusInactive {
 	color: var(--color-text-lighter);
 	box-shadow: inset 0px 0px 0px 10px #f2f2f2, 0px 0px 0px 2px #f2f2f2, 4px 0px 0px 1px #fff, -4px 0px 0px 1px #fff, 0px 0px 0px 5px #fff;
@@ -456,6 +448,7 @@ button.leaflet-control-search-next
 .select2-results__option {
 	padding: 5px;
 	font-family: var(--cool-font);
+	color: var(--color-main-text);
 	font-size: 12px;
 	overflow: hidden;
 	text-overflow: ellipsis;
@@ -480,6 +473,27 @@ button.leaflet-control-search-next
 .select2-container--default .select2-selection--single .select2-selection__rendered:hover {
 	background-color: var(--color-background-darker);
 	color: var(--color-text-darker);
+}
+.select2-dropdown {
+	background-color: var(--color-main-background);
+	border: 1px solid var(--color-border-dark);
+	border-radius: var(--border-radius);
+}
+.select2-container--default .select2-results__option[aria-selected='true'] {
+	background-color: var(--color-background-dark);
+	color: var(--color-text-dark);
+}
+.select2-container--default .select2-results__option--highlighted[aria-selected] {
+	background-color: var(--color-background-darker);
+	color: var(--color-text-darker);
+}
+.select2-container--default .select2-search--dropdown .select2-search__field {
+	background-color: var(--color-background-lighter);
+	border: 1px solid var(--color-border);
+	border-radius: var(--border-radius);
+}
+.select2-container--default .select2-results__option[aria-disabled='true'] {
+	color: var(--color-border-lighter);
 }
 .styles-select {
 	width: 150px !important;


### PR DESCRIPTION
color selector use css var's.
- border-radius
- outline use --color-main-background

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: Ic6187da6230e67025c670b596134766bf9a0c899

No visual change but it use the css var's
![image](https://user-images.githubusercontent.com/8517736/154850764-18474b87-4a43-47a2-a81e-75c6f2fc094f.png)
