### PR TITLE
Toolbar padding similar to menubar padding

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -219,6 +219,7 @@ nav.spreadsheet-color-indicator ~ #sidebar-dock-wrapper {
 	border-top: none;
 	z-index: 11 !important;
 	border-bottom: 1px solid var(--color-border);
+	padding: 3px 0;
 }
 
 #toolbar-logo {


### PR DESCRIPTION
menubar padding: 3px 3px 3px 0;
so toolbar padding: 3px 0; similar to what menubar use
harmonize padding. Fit's also well when menubar was shrinked.

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: Iaced9d5a647267139eca26daa4793e83732f969e

![image](https://user-images.githubusercontent.com/8517736/154867995-cea85a7f-ee70-468c-8181-ec1b19aba7ef.png)