### PR TITLE
Add ui mode to body for easier styling rules

### DIFF
--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -137,6 +137,8 @@ L.Control.UIManager = L.Control.extend({
 		var isDesktop = window.mode.isDesktop();
 		var enableNotebookbar = window.userInterfaceMode === 'notebookbar';
 
+		document.body.setAttribute('data-userInterfaceMode', window.userInterfaceMode);
+
 		if (window.mode.isMobile()) {
 			$('#mobile-edit-button').show();
 			this.map.addControl(L.control.mobileBottomBar(docType));
@@ -296,6 +298,8 @@ L.Control.UIManager = L.Control.extend({
 
 		if (uiMode.mode !== 'classic' && uiMode.mode !== 'notebookbar')
 			return;
+
+		document.body.setAttribute('data-userInterfaceMode', uiMode.mode);
 
 		switch (window.userInterfaceMode) {
 		case 'classic':


### PR DESCRIPTION
* Target version: master 

### Summary

This allows simpler targeting of different ui modes (classic/notebookbar) through css by adding the currently applied mode to the body element as a data-userinterfacemode attribute.

e.g.:

```
body[data-userinterfacemode="classic"] {
  .some-css { ... }
}

body[data-userinterfacemode="notebookbar"] {
  .some-css { ... }
}
```

@pedropintosilva What do you think about this? I think this could make styling easier to target and be more structured.

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

