### PR TITLE
Add toggle for UI mode to menubar and notebookbar

### DIFF
--- a/browser/images/lc_toggleuimode.svg
+++ b/browser/images/lc_toggleuimode.svg
@@ -1,0 +1,14 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <path
+     d="M 3,4 V 20 H 21 V 4 Z"
+     style="fill:#ffffff" />
+  <path
+     d="M 3,3 C 2.446,3 2,3.446 2,4 v 16 c 0,0.554 0.446,1 1,1 h 18 c 0.554,0 1,-0.446 1,-1 V 4 C 22,3.446 21.554,3 21,3 Z M 3,4 H 21 V 20 H 3 Z"
+     style="fill:#3a3a38" />
+  <path
+     d="M 22,4 C 22,3.446 21.554,3 21,3 H 3 C 2.446,3 2,3.446 2,4 v 2 c 0,0.554 0.446,1 1,1 h 18 c 0.554,0 1,-0.446 1,-1 z M 21,4 V 6 H 3 V 4 Z"
+     style="fill:#1e8bcd" />
+  <path
+     d="M 21,4 H 3 v 2 h 18 z"
+     style="fill:#83beec" />
+</svg>

--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -1159,9 +1159,12 @@ L.Control.Menubar = L.Control.extend({
 		map.on('addmenu', this._addMenu, this);
 		map.on('commandvalues', this._onInitLanguagesMenu, this);
 		map.on('updatetoolbarcommandvalues', this._onStyleMenu, this);
+
+		this._resetOverflow();
 	},
 
 	onRemove: function() {
+
 		this._map.off('doclayerinit', this._onDocLayerInit, this);
 		this._map.off('updatepermission', this._onRefresh, this);
 		this._map.off('addmenu', this._addMenu, this);
@@ -1170,6 +1173,8 @@ L.Control.Menubar = L.Control.extend({
 
 		this._menubarCont.remove();
 		this._menubarCont = null;
+
+		this._resetOverflow();
 	},
 
 	_addMenu: function (e) {
@@ -1432,10 +1437,22 @@ L.Control.Menubar = L.Control.extend({
 		}
 	},
 
-	_onMouseOut: function() {
-		$('.main-nav.hasnotebookbar').css('overflow', 'scroll hidden');
+	// needed for smartmenus to work inside notebookbar
+	_setupOverflow: function() {
+		$('.main-nav.hasnotebookbar').css('overflow', 'visible');
+		$('.notebookbar-scroll-wrapper').css('overflow', 'visible');
+	},
+
+	_resetOverflow: function() {
+		$('.main-nav').css('overflow', '');
 		$('.notebookbar-scroll-wrapper').css('overflow', '');
 	},
+
+	_onMouseOut: function(e) {
+		var self = e.data.self;
+		self._resetOverflow();
+	},
+
 	_checkedMenu: function(uno, item) {
 		var constChecked = 'lo-menu-item-checked';
 		var state = this._map['stateChangeHandler'].getItemValue(uno);
@@ -1449,9 +1466,8 @@ L.Control.Menubar = L.Control.extend({
 	},
 
 	_beforeShow: function(e, menu) {
-		$('.main-nav').css('overflow', 'visible');
-		$('.notebookbar-scroll-wrapper').css('overflow', 'visible');
 		var self = e.data.self;
+		self._setupOverflow();
 		var items = $(menu).children().children('a').not('.has-submenu');
 		$(items).each(function() {
 			var aItem = this;

--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -111,8 +111,8 @@ L.Control.Menubar = L.Control.extend({
 					{name: _UNO('.uno:ZoomMinus', 'text'), id: 'zoomout', type: 'action',},
 					{name: _('Reset zoom'), id: 'zoomreset', type: 'action'},
 					{type: 'separator'},
-					{name: _('Show Ruler'), id: 'showruler', type: 'action'},
 					{name: _('Toggle UI Mode'), id: 'toggleuimode', type: 'action'},
+					{name: _('Show Ruler'), id: 'showruler', type: 'action'},
 					{name: _('Show Status Bar'), id: 'showstatusbar', type: 'action'},
 				]).concat([
 					{uno: '.uno:Sidebar'},
@@ -1449,7 +1449,7 @@ L.Control.Menubar = L.Control.extend({
 	},
 
 	_beforeShow: function(e, menu) {
-		$('.main-nav.hasnotebookbar').css('overflow', 'visible');
+		$('.main-nav').css('overflow', 'visible');
 		$('.notebookbar-scroll-wrapper').css('overflow', 'visible');
 		var self = e.data.self;
 		var items = $(menu).children().children('a').not('.has-submenu');
@@ -1532,9 +1532,9 @@ L.Control.Menubar = L.Control.extend({
 
 					} else if (id === 'toggleuimode') {
 						if (window.userInterfaceMode === 'notebookbar') {
-							$(aItem).text(_('Use Classic UI'));
+							$(aItem).text(_('Use Classic view'));
 						} else {
-							$(aItem).text(_('Use Notebookbar UI'));
+							$(aItem).text(_('Use NotebookBar view'));
 						}
 
 					} else if (self._map.getDocType() === 'presentation' && (id === 'deletepage' || id === 'insertpage' || id === 'duplicatepage')) {

--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -112,6 +112,7 @@ L.Control.Menubar = L.Control.extend({
 					{name: _('Reset zoom'), id: 'zoomreset', type: 'action'},
 					{type: 'separator'},
 					{name: _('Show Ruler'), id: 'showruler', type: 'action'},
+					{name: _('Toggle UI Mode'), id: 'toggleuimode', type: 'action'},
 					{name: _('Show Status Bar'), id: 'showstatusbar', type: 'action'},
 				]).concat([
 					{uno: '.uno:Sidebar'},
@@ -1529,6 +1530,13 @@ L.Control.Menubar = L.Control.extend({
 							$(aItem).removeClass(constChecked);
 						}
 
+					} else if (id === 'toggleuimode') {
+						if (window.userInterfaceMode === 'notebookbar') {
+							$(aItem).text(_('Use Classic UI'));
+						} else {
+							$(aItem).text(_('Use Notebookbar UI'));
+						}
+
 					} else if (self._map.getDocType() === 'presentation' && (id === 'deletepage' || id === 'insertpage' || id === 'duplicatepage')) {
 						if (id === 'deletepage') {
 							itemState = self._map['stateChangeHandler'].getItemValue('.uno:DeletePage');
@@ -1666,6 +1674,12 @@ L.Control.Menubar = L.Control.extend({
 			L.toggleFullScreen();
 		} else if (id === 'showruler') {
 			this._map.uiManager.toggleRuler();
+		} else if (id === 'toggleuimode') {
+			if (window.userInterfaceMode === 'notebookbar') {
+				this._map.uiManager.onChangeUIMode({mode: 'classic', force: true});
+			} else {
+				this._map.uiManager.onChangeUIMode({mode: 'notebookbar', force: true});
+			}
 		} else if (id === 'showstatusbar') {
 			this._map.uiManager.toggleStatusBar();
 		} else if (id === 'fullscreen-presentation' && this._map.getDocType() === 'presentation') {

--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -49,6 +49,7 @@ L.Control.Notebookbar = L.Control.extend({
 		this.map.on('statusbarchanged', this.onStatusbarChange, this);
 		this.map.on('rulerchanged', this.onRulerChange, this);
 
+		this.map.sendUnoCommand('.uno:ToolbarMode?Mode:string=notebookbar_online.ui');
 
 		$('#toolbar-wrapper').addClass('hasnotebookbar');
 		$('.main-nav').addClass('hasnotebookbar');

--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -79,6 +79,7 @@ L.Control.Notebookbar = L.Control.extend({
 				// if notebookbar doesn't have any welded controls it can trigger false alarm here
 				window.app.console.warn('notebookbar might be not initialized, retrying');
 				that.map.sendUnoCommand('.uno:ToolbarMode?Mode:string=notebookbar_online.ui');
+				that.retry = setTimeout(retryNotebookbarInit, 3000);
 			}
 		};
 
@@ -87,6 +88,7 @@ L.Control.Notebookbar = L.Control.extend({
 
 	onRemove: function() {
 		clearTimeout(this.retry);
+		this.map._isNotebookbarLoadedOnCore = false;
 		this.map.sendUnoCommand('.uno:ToolbarMode?Mode:string=Default');
 		this.map.off('contextchange', this.onContextChange, this);
 		this.map.off('updatepermission', this.onUpdatePermission, this);

--- a/browser/src/control/Control.NotebookbarBuilder.js
+++ b/browser/src/control/Control.NotebookbarBuilder.js
@@ -16,7 +16,8 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 		this._controlHandlers['combobox'] = this._comboboxControlHandler;
 		this._controlHandlers['listbox'] = this._comboboxControlHandler;
 		this._controlHandlers['tabcontrol'] = this._overriddenTabsControlHandler;
-		this._controlHandlers['menubartoolitem'] = this._menubarToolItemHandler;
+		this._controlHandlers['menubartoolitem'] = this._inlineMenubarToolItemHandler;
+		this._controlHandlers['bigmenubartoolitem'] = this._bigMenubarToolItemHandler;
 		this._controlHandlers['bigtoolitem'] = this._bigtoolitemHandler;
 		this._controlHandlers['toolbox'] = this._toolboxHandler;
 
@@ -398,9 +399,6 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 				return false;
 		}
 
-		var originalInLineState = builder.options.useInLineLabelsForUnoButtons;
-		builder.options.useInLineLabelsForUnoButtons = true;
-
 		data.command = data.id;
 
 		var isDownloadAsGroup = data.id === 'downloadas';
@@ -410,8 +408,6 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 		}
 
 		var control = builder._unoToolButton(parentContainer, data, builder, options);
-
-		builder.options.useInLineLabelsForUnoButtons = originalInLineState;
 
 		$(control.container).unbind('click.toolbutton');
 		if (!builder.map.isLockedItem(data)) {
@@ -431,6 +427,28 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 				});
 			});
 		}
+	},
+
+	_inlineMenubarToolItemHandler: function(parentContainer, data, builder) {
+		var originalInLineState = builder.options.useInLineLabelsForUnoButtons;
+		builder.options.useInLineLabelsForUnoButtons = true;
+
+		builder._menubarToolItemHandler(parentContainer, data, builder);
+
+		builder.options.useInLineLabelsForUnoButtons = originalInLineState;
+
+		return false;
+	},
+
+	_bigMenubarToolItemHandler: function(parentContainer, data, builder) {
+		var noLabels = builder.options.noLabelsForUnoButtons;
+		builder.options.noLabelsForUnoButtons = false;
+
+		builder._menubarToolItemHandler(parentContainer, data, builder);
+
+		builder.options.noLabelsForUnoButtons = noLabels;
+
+		return false;
 	},
 
 	_getDownloadAsSubmenuOpts: function(docType) {

--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -951,7 +951,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 			{
 				'id': 'toggleuimode',
 				'type': 'menubartoolitem',
-				'text': _('Classic UI'),
+				'text': _('Classic view'),
 				'command': _('Toggle UI Mode')
 			},
 			{

--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -950,7 +950,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 			},
 			{
 				'id': 'toggleuimode',
-				'type': 'menubartoolitem',
+				'type': 'bigmenubartoolitem',
 				'text': _('Classic view'),
 				'command': _('Toggle UI Mode')
 			},

--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -949,6 +949,12 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				'command': '.uno:Sidebar'
 			},
 			{
+				'id': 'toggleuimode',
+				'type': 'menubartoolitem',
+				'text': _('Classic UI'),
+				'command': _('Toggle UI Mode')
+			},
+			{
 				'id': 'showstatusbar',
 				'type': 'menubartoolitem',
 				'text': _('Toggle Status Bar'),

--- a/browser/src/control/Control.NotebookbarDraw.js
+++ b/browser/src/control/Control.NotebookbarDraw.js
@@ -268,7 +268,7 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 			},
 			{
 				'id': 'toggleuimode',
-				'type': 'menubartoolitem',
+				'type': 'bigmenubartoolitem',
 				'text': _('Classic view'),
 				'command': _('Toggle UI Mode')
 			},

--- a/browser/src/control/Control.NotebookbarDraw.js
+++ b/browser/src/control/Control.NotebookbarDraw.js
@@ -269,7 +269,7 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 			{
 				'id': 'toggleuimode',
 				'type': 'menubartoolitem',
-				'text': _('Classic UI'),
+				'text': _('Classic view'),
 				'command': _('Toggle UI Mode')
 			},
 			{

--- a/browser/src/control/Control.NotebookbarDraw.js
+++ b/browser/src/control/Control.NotebookbarDraw.js
@@ -267,6 +267,12 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 				'command': '.uno:Sidebar'
 			},
 			{
+				'id': 'toggleuimode',
+				'type': 'menubartoolitem',
+				'text': _('Classic UI'),
+				'command': _('Toggle UI Mode')
+			},
+			{
 				'id': 'showstatusbar',
 				'type': 'menubartoolitem',
 				'text': _('Toggle Status Bar'),

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -337,6 +337,12 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'command': '.uno:Sidebar'
 			},
 			{
+				'id': 'toggleuimode',
+				'type': 'menubartoolitem',
+				'text': _('Classic UI'),
+				'command': _('Toggle UI Mode')
+			},
+			{
 				'id': 'showstatusbar',
 				'type': 'menubartoolitem',
 				'text': _('Toggle Status Bar'),

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -339,7 +339,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 			{
 				'id': 'toggleuimode',
 				'type': 'menubartoolitem',
-				'text': _('Classic UI'),
+				'text': _('Classic view'),
 				'command': _('Toggle UI Mode')
 			},
 			{

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -338,7 +338,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 			},
 			{
 				'id': 'toggleuimode',
-				'type': 'menubartoolitem',
+				'type': 'bigmenubartoolitem',
 				'text': _('Classic view'),
 				'command': _('Toggle UI Mode')
 			},

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -595,18 +595,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 			{
 				'id': 'stylesview',
 				'type': 'iconview',
-				'entries': [
-					{
-						'text': _('Default Style'),
-						'selected': 'true'
-					},
-					{
-						'text': _('Text Body'),
-					},
-					{
-						'text': _('Title'),
-					}
-				],
+				'entries': [],
 				'vertical': 'false'
 			},
 			{

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -998,7 +998,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 			},
 			{
 				'id': 'toggleuimode',
-				'type': 'menubartoolitem',
+				'type': 'bigmenubartoolitem',
 				'text': _('Classic view'),
 				'command': _('Toggle UI Mode')
 			},

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -999,7 +999,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 			{
 				'id': 'toggleuimode',
 				'type': 'menubartoolitem',
-				'text': _('Classic UI'),
+				'text': _('Classic view'),
 				'command': _('Toggle UI Mode')
 			},
 			{

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -997,6 +997,12 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				'command': '.uno:Sidebar'
 			},
 			{
+				'id': 'toggleuimode',
+				'type': 'menubartoolitem',
+				'text': _('Classic UI'),
+				'command': _('Toggle UI Mode')
+			},
+			{
 				'type': 'container',
 				'children': [
 					{

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -301,6 +301,8 @@ L.Control.UIManager = L.Control.extend({
 
 		document.body.setAttribute('data-userInterfaceMode', uiMode.mode);
 
+		this.map.fire('postMessage', {msgId: 'Action_ChangeUIMode_Resp', args: {Mode: uiMode}});
+
 		switch (window.userInterfaceMode) {
 		case 'classic':
 			this.removeClassicUI();

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -145,19 +145,7 @@ L.Control.UIManager = L.Control.extend({
 			this.map.addControl(L.control.mobileTopBar(docType));
 			this.map.addControl(L.control.searchBar());
 		} else if (enableNotebookbar) {
-			if (docType === 'spreadsheet') {
-				var notebookbar = L.control.notebookbarCalc();
-			} else if (docType === 'presentation') {
-				notebookbar = L.control.notebookbarImpress();
-			} else if (docType === 'drawing') {
-				notebookbar = L.control.notebookbarDraw();
-			} else {
-				notebookbar = L.control.notebookbarWriter();
-			}
-
-			this.notebookbar = notebookbar;
-			this.map.addControl(notebookbar);
-
+			this.createNotebookbarControl(docType);
 			// makeSpaceForNotebookbar call in onUpdatePermission
 		}
 
@@ -256,12 +244,12 @@ L.Control.UIManager = L.Control.extend({
 		this.map.topToolbar.updateControlsState();
 	},
 
-	addNotebookbarUI: function() {
-		if (this.map.getDocType() === 'spreadsheet') {
+	createNotebookbarControl: function(docType) {
+		if (docType === 'spreadsheet') {
 			var notebookbar = L.control.notebookbarCalc();
-		} else if (this.map.getDocType() === 'presentation') {
+		} else if (docType === 'presentation') {
 			notebookbar = L.control.notebookbarImpress();
-		} else if (this.map.getDocType() === 'drawing') {
+		} else if (docType === 'drawing') {
 			notebookbar = L.control.notebookbarDraw();
 		} else {
 			notebookbar = L.control.notebookbarWriter();
@@ -269,9 +257,13 @@ L.Control.UIManager = L.Control.extend({
 
 		this.notebookbar = notebookbar;
 		this.map.addControl(notebookbar);
+	},
 
-		notebookbar._showNotebookbar = true;
-		notebookbar.showTabs();
+	addNotebookbarUI: function() {
+		this.createNotebookbarControl(this.map.getDocType());
+
+		this.notebookbar._showNotebookbar = true;
+		this.notebookbar.showTabs();
 		$('.main-nav').removeClass('readonly');
 
 		$('#map').addClass('notebookbar-opened');

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -328,7 +328,8 @@ L.Map.include({
 		var isAllowedInReadOnly = false;
 		var allowedCommands = ['.uno:Save', '.uno:WordCountDialog', '.uno:EditAnnotation',
 			'.uno:InsertAnnotation', '.uno:DeleteAnnotation', '.uno:Signature',
-			'.uno:ShowResolvedAnnotations'];
+			'.uno:ShowResolvedAnnotations', '.uno:ToolbarMode?Mode:string=notebookbar_online.ui',
+			'.uno:ToolbarMode?Mode:string=Default'];
 
 		for (var i in allowedCommands) {
 			if (allowedCommands[i] === command) {


### PR DESCRIPTION
* Resolves: #3955 
* Target version: master 

### Summary

This implements a toggleuimode action that allows switching between classic and notebookbar UI mode which is then exposed in the menubar (View > Use Notebookbar UI) and notebookbar (View > Classic UI).

@eszkadev I'd be interested about feedback on the implementation as I could not get a clear understanding on how the actions are shared between the menubar and notebookbar and if the approach to trigger them in the way done is the best.

@pedropintosilva Do you have a suggestion for a good icon from the existing ones maybe? For now I added a temporary commit with a material icon, but should be something matching the upstream icon theme there of course.


https://user-images.githubusercontent.com/3404133/154939267-0169e562-9cb8-4d58-9062-5f1512b9fe95.mov



### TODO

- [x] Switching the mode should also notify the integrator by post message. In UIManager we should send in onChangeUIMode: eg. `map.fire('postMessage', {msgId: 'Action_ChangeUIMode_Resp', args: {Mode: 'notebookbar'}});`
- [x] Find a proper icon for the notebookbar to switch to classic UI
- [x] Figure out why the menu bar is not expanded after switching from notebookbar to classic
- [x] Move **before** or after the regular view toggle options in the menu/notebookbar tab

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

