### PR TITLE
Notebookbar: Remove ellipsis from generated uno button labels

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -362,6 +362,8 @@ L.Control.JSDialogBuilder = L.Control.extend({
 	_cleanText: function(text) {
 		if (!text)
 			return '';
+		if (text.endsWith('...'))
+			text = text.slice(0, -3);
 		return text.replace('~', '');
 	},
 
@@ -2303,7 +2305,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 				$(div).addClass('inline');
 				label = L.DomUtil.create('span', 'ui-content unolabel', div);
 				label.for = buttonId;
-				label.textContent = data.text;
+				label.textContent = builder._cleanText(data.text);
 
 				controls['label'] = label;
 			}


### PR DESCRIPTION
* Target version: master 

### Summary

Contributes to the temporary solution of https://github.com/CollaboraOnline/online/issues/1285#issuecomment-824547942 by applying the removal of potentially existing ellipsis on a wider range by performing this cleanup in the JSDialogBuilder.

I could imagine that this also has an effect on other jsdialog based components, however I could not see any noticeable impact on the sidebar for example.

What do you think about that approach @pedropintosilva @Andreas-Kainz 

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

