### PR TITLE
Document header: remove unnecessary margin

### DIFF
--- a/browser/css/menubar.css
+++ b/browser/css/menubar.css
@@ -17,7 +17,6 @@
 #document-header {
 	position: relative;
 	background: transparent;
-	margin-inline-end: 5px;
 }
 /*avoid multiple document-headers in readonly mode*/
 .main-nav.hasnotebookbar.readonly > #main-menu #document-header {


### PR DESCRIPTION
Now that both classic and notebookbar mode have the document header
without background color and effects, we can safely remove the initial
margin that is not needed anymore

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Id3f653c42d6099753bc852ac75f454698b6ffdc2
