### PR TITLE
Sidebar: hide separator and margin for frame-label

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -44,7 +44,7 @@
 }
 
 .jsdialog.vertical p, .ui-frame-label {
-	margin: 0px;
+	margin: 10px 0 2px;
 	color: var(--color-main-text);
 	font-size: 10px;
 	font-weight: bold;
@@ -70,6 +70,7 @@
 }
 
 .jsdialog.ui-separator.horizontal {
+	display: none;
 	width: 100%;
 	padding-top: 6px;
 	/* border-left: 1px dashed #888; */

--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -341,12 +341,12 @@ td.jsdialog .jsdialog.cell.sidebar {
 }
 
 #spacinglabel {
-	padding-top: 0;
+	margin-top: -4px;
 }
 
 
 #indentlabel {
-	padding-top: 8px;
+	margin-top: 2px;
 }
 
 #fillattrhb {


### PR DESCRIPTION
Issue #4260

separators are nice, but didn't bring that much  for visual separation.
it's more visual noise than help for separation

compare to separators margins are a good idea for separation
so the frame-label get an margin which make also the label
layout better.

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I402591327e6cdd5328bd95e5e2c342a56b66471d

#### writer default sidebar layout
![Screenshot_20220221_203224](https://user-images.githubusercontent.com/8517736/155018164-0dfdf268-6455-4933-ad12-9928f38bf208.png)

#### writer table sidebar layout
![Screenshot_20220221_203055](https://user-images.githubusercontent.com/8517736/155018213-c8a50aab-8cd0-4b28-ad90-8adb45b06510.png)

