### PR TITLE
Fix app.sectionContainer being null

### DIFF
--- a/browser/src/control/Control.MobileWizard.js
+++ b/browser/src/control/Control.MobileWizard.js
@@ -135,7 +135,7 @@ L.Control.MobileWizard = L.Control.extend({
 			window.mobileDialogId = undefined;
 		}
 
-		if (window.commentWizard === true) {
+		if (window.commentWizard === true && app.sectionContainer) {
 			app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).removeHighlighters();
 		}
 


### PR DESCRIPTION
Similar to 4764937ad44a5cca99a7d5b962e661f491d18cb1

* Resolves: #4264
* Target version: master 

### Summary
Should avoid issues like
```
Uncaught TypeError: app.sectionContainer.getSectionWithName(...) is null
    _hideWizard https://coolwsd.xxx.org/browser/e4d06c2/bundle.js:1
[bundle.js:1:2264150](https://coolwsd.framasoft.org/browser/e4d06c2/bundle.js)
    _hideWizard https://coolwsd.xxx.org/browser/e4d06c2/bundle.js:1
    _hideWizard self-hosted:1184
```

### Checklist

- [ ] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

