### PR TITLE
Avoid fixed statusbar height

### DIFF
--- a/browser/css/device-mobile.css
+++ b/browser/css/device-mobile.css
@@ -421,7 +421,6 @@ nav:not(.spreadsheet-color-indicator) ~ #toolbar-wrapper #toolbar-up.w2ui-toolba
 }
 #tb_actionbar_item_fullscreen{display: none;}
 #toolbar-down {
-	height: 39px !important;
 	border-top: 1px solid var(--gray-color) !important;
 }
 #toolbar-down > .w2ui-scroll-wrapper {


### PR DESCRIPTION
* Target version: master 

### Summary

Make sure the status bar adjusts properly to the content height to fix misalignment of the icons on mobile:

<img src="https://user-images.githubusercontent.com/3404133/155118693-1b66bf6a-10ab-466b-a0dd-e65f9d41d906.png" width="200">
<img src="https://user-images.githubusercontent.com/3404133/155118697-a6596207-f48b-48bb-9938-a5c7b2a42012.png" width="200">


### TODO

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

