### PR TITLE
color-palette UI elements update

### DIFF
--- a/browser/css/color-palette.css
+++ b/browser/css/color-palette.css
@@ -15,10 +15,10 @@
 	--color-text-darker: #000;  /* hover */
 	--color-text-lighter: #696969;
 
-	--color-main-background: #fff;
-	--color-background-dark: #F7F7F7;  /* select */
-	--color-background-darker: #e4e4e4;  /* hover */
-	--color-background-lighter: #f8f9fa;
+	--color-main-background: #F8F9FA;
+	--color-background-dark: #e8e8e8;  /* select */
+	--color-background-darker: #c0bfbc;  /* hover */
+	--color-background-lighter: #fff; /* toolbar */
 
 	--color-primary: #1C99E0;
 	--color-primary-text: #fff;
@@ -27,8 +27,8 @@
 	--color-primary-lighter: #63BBEE;
 
 	--color-border: #b6b6b6;
-	--color-border-dark: #959595; /* select */
-	--color-border-darker: #696969;  /* hover */
+	--color-border-dark: #cecece; /* select */
+	--color-border-darker: #c0bfbc;  /* hover */
 	--color-border-lighter: #f1f1f1;
 
 	--color-error: #e9322d;

--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -220,6 +220,7 @@ nav.spreadsheet-color-indicator ~ #sidebar-dock-wrapper {
 	z-index: 11 !important;
 	border-bottom: 1px solid var(--color-border);
 	padding: 3px 0;
+	background-color: var(--color-background-lighter);
 }
 
 #toolbar-logo {

--- a/browser/css/impress.css
+++ b/browser/css/impress.css
@@ -7,5 +7,5 @@
 	background: transparent !important;
 }
 #presentation-controls-wrapper {
-	background: var(--color-background-dark) !important;
+	background: var(--color-main-background) !important;
 }

--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -13,8 +13,8 @@
 #document-container:not(.mobile) + #sidebar-dock-wrapper {
 	width: 330px;
 	padding: 0;
-	border-left: 1px solid var(--gray-color) !important;
-	border-right: 1px solid var(--gray-color) !important; /* for RTL mode */
+	border-left: 1px solid var(--color-border) !important;
+	border-right: 1px solid var(--color-border) !important; /* for RTL mode */
 	margin-top: 0 !important;
 	box-sizing: border-box;
 }

--- a/browser/css/leaflet.css
+++ b/browser/css/leaflet.css
@@ -865,7 +865,7 @@ input.clipboard {
 	margin: 0px; /*Ruler styling*/
 }
 .cool-ruler {
-	background-color: var(--color-background-lighter);
+	background-color: var(--color-main-background);
 	height: 20px;
 	width: 100vw;
 	margin: 0px !important;
@@ -934,7 +934,7 @@ input.clipboard {
 
 .cool-ruler-face {
 	height: 100%;
-	background-color: var(--color-main-background);
+	background-color: var(--color-background-lighter);
 }
 
 .cool-ruler-maj {
@@ -983,7 +983,7 @@ input.clipboard {
 
 .cool-ruler-margin {
 	height: 100%;
-	background-color: var(--color-background-lighter);
+	background-color: var(--color-main-background);
 }
 
 .cool-ruler-left {

--- a/browser/css/menubar.css
+++ b/browser/css/menubar.css
@@ -64,7 +64,7 @@
 .main-nav {
 	height: 38px; /* on mouseover menubar items, border emerges */
 	width: auto;
-	background: transparent;
+	background: var(--color-background-lighter);
 	padding: 3px 3px 3px 0;
 	white-space: nowrap;
 	z-index: 12;
@@ -76,7 +76,7 @@
 	border-bottom: 1px solid var(--color-border);
 }
 .main-nav.hasnotebookbar {
-	height: 32px;
+	height: 38px;
 	/* overflow is set dynamically */
 	scrollbar-width: none;
 	-ms-scrollbar: none;
@@ -85,7 +85,7 @@
 	height: 0;
 }
 .main-nav.hasnotebookbar:not(.readonly) {
-	background: var(--gray-light-bg-color);
+	background: var(--color-main-background);
 	padding: 0px;
 }
 

--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -175,7 +175,7 @@
 }
 
 #toolbar-wrapper.hasnotebookbar {
-	background: var(--color-main-background);
+	background: var(--color-background-lighter);
 	position: relative;
 	z-index: 11;
 }

--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -6,7 +6,6 @@
 	text-align: center;
 	z-index: 999;
 	overflow: visible !important;
-	background-color: var(--color-main-background);
 }
 
 #toolbar-down {
@@ -143,7 +142,7 @@ w2ui-toolbar {
 
 #presentation-toolbar {
 	bottom: 0;
-	background-color: var(--color-background-lighter);
+	background-color: var(--color-main-background);
 	text-align: center;
 	position: absolute;
 	z-index: 500;
@@ -260,7 +259,7 @@ w2ui-toolbar {
 }
 
 #document-name-input {
-	color: var(--color-main-text);
+	color: var(--color-text-darker);
 	font-size: 16px;
 	border: 1px solid transparent;
 	background-color: transparent;


### PR DESCRIPTION
- color-main-background LibO document background was used
- color-main-backgroud was used for all elements
- only select, hover and toolbar's use other background colors
- color-background-lighter is the color for toolbars
- better contrast for select stuff

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I1e8be68aa1f6e73fb03994dac0ad634725e2aef0