### PR TITLE
Sidebar Impress widget right align as everywhere else

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -180,7 +180,7 @@ div#thousandseparator.checkbutton.jsdialog.sidebar {
 }
 
 #settransparency, #fontheight,
-#document-container:not(.presentation-doctype) ~ #sidebar-dock-wrapper .sidebar.jsdialog.vertical > .sidebar.jsdialog.row > table.sidebar.ui-grid > tr.sidebar > td.sidebar:last-child,
+#document-container ~ #sidebar-dock-wrapper .sidebar.jsdialog.vertical > .sidebar.jsdialog.row > table.sidebar.ui-grid > tr.sidebar > td.sidebar:last-child,
 .sidebar.jsdialog.cell > #table-box3 > .sidebar.jsdialog.row > .sidebar.jsdialog.cell:last-child,
 .sidebar.jsdialog.cell > #table-box4 > .sidebar.jsdialog.row > .sidebar.jsdialog.cell:last-child,
 .sidebar.jsdialog.cell > #table-box4 > .sidebar.jsdialog.row > .sidebar.jsdialog.cell:nth-child(4) {


### PR DESCRIPTION
In all apps the sidebar widgets are justified: flex-end
only in impress the rule wasn't selected. But than the
alignment didn't work in impress.

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I5f44496bb570f64a0b21d14fb4493665dbd31d07

#### before
![Screenshot_20220222_231540](https://user-images.githubusercontent.com/8517736/155229305-2109fbb5-f820-4aab-906f-4caaae4627ab.png)

#### after
![Screenshot_20220222_231757](https://user-images.githubusercontent.com/8517736/155229318-0c2d5e20-8de7-4a98-88da-535c118f9074.png)

