### PR TITLE
spinfield and dropdown widget use the same width

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -20,7 +20,7 @@
 }
 
 .sidebar .spinfieldcontainer input {
-	width: 85px;
+	width: 121px;
 	border: 1px solid var(--color-border-dark);
 	border-radius: var(--border-radius);
 	height: 28px;
@@ -30,9 +30,13 @@
 	color: var(--color-text-dark);
 	background-color: var(--color-background-dark);
 }
+#TableEditPanelPanelExpander .sidebar .spinfieldcontainer input,
+#ParaPropertyPanelPanelExpander .sidebar .spinfieldcontainer input {
+	width: 85px;
+}
 
 .sidebar.spinfield {
-	max-width: 104px;
+	max-width: 121px;
 	padding: 4px 0 4px 4px;
 	height: 28px;
 	box-sizing: border-box;


### PR DESCRIPTION
spinfield and dropdown widget have the same width
(when possible) so there is no jumping widget alignment

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I0148295285a4174464de5ccea6bfa11a387de9a6

* Resolves: #4260 

![image](https://user-images.githubusercontent.com/8517736/155233489-27a37c56-34b0-4fa4-aca6-0fe9ebd01fc0.png)
