### PR TITLE
fix wrongly sized shape selection overlay

### DIFF
--- a/browser/src/layer/vector/SVGGroup.js
+++ b/browser/src/layer/vector/SVGGroup.js
@@ -45,6 +45,7 @@ L.SVGGroup = L.Layer.extend({
 		this._forEachSVGNode(function (svgNode) {
 			svgNode.setAttribute('width', size.x);
 			svgNode.setAttribute('height', size.y);
+			svgNode.setAttribute('preserveAspectRatio', 'none');
 		});
 	},
 


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

