### PR TITLE
fix wrongly sized shape selection overlay

### DIFF
--- a/loleaflet/src/layer/vector/SVGGroup.js
+++ b/loleaflet/src/layer/vector/SVGGroup.js
@@ -45,6 +45,7 @@ L.SVGGroup = L.Layer.extend({
 		this._forEachSVGNode(function (svgNode) {
 			svgNode.setAttribute('width', size.x);
 			svgNode.setAttribute('height', size.y);
+			svgNode.setAttribute('preserveAspectRatio', 'none');
 		});
 	},
 


### PR DESCRIPTION
we need to add preserveAspectRatio none attribute
for shape/image selection previews

Signed-off-by: Mert Tumer <mert.tumer@collabora.com>
Change-Id: I8611d9ac79caa86a39f9773f5e44e53fdc8a8c00


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

