### PR TITLE
Improved Save and Upload corner-case handling

### DIFF
--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -677,7 +677,7 @@ bool ClientSession::_handleInput(const char *buffer, int length)
         // The savetostorage command is really only used to resolve save conflicts
         // and it seems to always have force=1. However, we should still honor the
         // contract and do as told, not as we expect the API to be used. Use force if provided.
-        docBroker->uploadToStorage(getId(), true, "" /* This is irrelevant when success is true*/, force);
+        docBroker->uploadToStorage(getId(), force);
     }
     else if (tokens.equals(0, "clientvisiblearea"))
     {

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -266,7 +266,7 @@ void DocumentBroker::pollThread()
     {
         // Poll more frequently while unloading to cleanup sooner.
         const bool unloading = isMarkedToDestroy() || _docState.isUnloadRequested();
-        _poll->poll(unloading ? SocketPoll::DefaultPollTimeoutMicroS / 8
+        _poll->poll(unloading ? SocketPoll::DefaultPollTimeoutMicroS / 16
                               : SocketPoll::DefaultPollTimeoutMicroS);
 
 #if !MOBILEAPP
@@ -1929,8 +1929,7 @@ void DocumentBroker::autoSaveAndStop(const std::string& reason)
     }
 
     // Don't hammer on saving.
-    if (!canStop && _saveManager.timeSinceLastSaveRequest() >= std::chrono::seconds(1) &&
-        _saveManager.timeSinceLastSaveResponse() >= std::chrono::seconds(2))
+    if (!canStop && _saveManager.canSaveNow(std::chrono::milliseconds(500)))
     {
         // Stop if there is nothing to save.
         const bool possiblyModified = isPossiblyModified();

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -570,8 +570,18 @@ void DocumentBroker::joinThread()
 
 void DocumentBroker::stop(const std::string& reason)
 {
-    LOG_DBG("Stopping DocumentBroker for docKey [" << _docKey << "] with reason: " << reason);
-    _closeReason = reason; // used later in the polling loop
+    if (_closeReason.empty())
+    {
+        LOG_DBG("Stopping DocumentBroker for docKey [" << _docKey << "] with reason: " << reason);
+        _closeReason = reason; // used later in the polling loop
+    }
+    else
+    {
+        LOG_DBG("Stopping DocumentBroker for docKey ["
+                << _docKey << "] with existing close reason: " << _closeReason
+                << " (ignoring requested reason: " << reason << ')');
+    }
+
     _stop = true;
     _poll->wakeup();
 }

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -293,12 +293,11 @@ public:
 
     /// Check if uploading is needed, and start uploading.
     /// The current state of uploading must be introspected separately.
-    void checkAndUploadToStorage(const std::string& sessionId, bool success, const std::string& result);
+    void checkAndUploadToStorage(const std::string& sessionId);
 
     /// Upload the document to Storage if it needs persisting.
     /// Results are logged and broadcast to users.
-    void uploadToStorage(const std::string& sesionId, bool success, const std::string& result,
-                         bool force);
+    void uploadToStorage(const std::string& sesionId, bool force);
 
     /// UploadAs the document to Storage, with a new name.
     /// @param uploadAsPath Absolute path to the jailed file.
@@ -533,8 +532,7 @@ private:
     bool isStorageOutdated() const;
 
     /// Upload the doc to the storage.
-    void uploadToStorageInternal(const std::string& sesionId, bool success,
-                                 const std::string& result, const std::string& saveAsPath,
+    void uploadToStorageInternal(const std::string& sesionId, const std::string& saveAsPath,
                                  const std::string& saveAsFilename, const bool isRename,
                                  const bool force);
 

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -816,6 +816,13 @@ private:
             return _request.timeSinceLastResponse();
         }
 
+        /// True if we aren't saving and the minimum time since last save has elapsed.
+        bool canSaveNow(std::chrono::milliseconds minTime) const
+        {
+            return !isSaving() && std::min(_request.timeSinceLastRequest(),
+                                           _request.timeSinceLastResponse()) >= minTime;
+        }
+
         void dumpState(std::ostream& os, const std::string& indent = "\n  ")
         {
             os << indent << "isSaving now: " << std::boolalpha << isSaving();

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -398,6 +398,14 @@ public:
     static bool lookupSendClipboardTag(const std::shared_ptr<StreamSocket> &socket,
                                        const std::string &tag, bool sendError = false);
 
+    /// True if any flag to unload or terminate is set.
+    bool isUnloading() const
+    {
+        return _docState.isMarkedToDestroy() || _stop || _docState.isUnloadRequested() ||
+               _docState.isCloseRequested() || SigUtil::getShutdownRequestFlag() ||
+               SigUtil::getTerminationFlag();
+    }
+
     bool isMarkedToDestroy() const { return _docState.isMarkedToDestroy() || _stop; }
 
     virtual bool handleInput(const std::vector<char>& payload);

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -516,9 +516,13 @@ private:
         Force //< Force uploading, typically because always_save_on_exit is set.
     };
 
-    /// Returns true iff the Document in Storage is
-    /// out-of-date and we must upload the last file on disk.
+    /// Returns true if, for any reason, we need to upload.
+    /// This includes out-of-date Document in Storage or
+    /// always_save_on_exit.
     NeedToUpload needToUploadToStorage() const;
+
+    /// Returns true iff the document on disk is newer than the one in Storage.
+    bool isStorageOutdated() const;
 
     /// Upload the doc to the storage.
     void uploadToStorageInternal(const std::string& sesionId, bool success,


### PR DESCRIPTION
- wsd: stop if unloading and have no sessions to upload
- wsd: send the client 'docunloading' for all unloading cases
- wsd: do not clobber closeReason
- wsd: do not skip uploading when last save skipped
- wsd: faster save and exit when unloading
