### PR TITLE
NB: Fix Save savemodified indicators' contrast

### DIFF
--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -100,9 +100,10 @@
 	border-radius: 2px;
 	filter: none !important;
 	background: var(--color-primary-lighter);
+	box-shadow: 1px -1px 0 2px var(--color-main-background);
 	border: 1px solid var(--color-primary);
 	position: absolute;
-	top: 8px;
+	top: 6px;
 	margin-left: 11px;
 }
 


### PR DESCRIPTION
Context:
With the f4cde4a18c8a402f5028971987193a2b28aa3d69 there is no visual
delimiter between the icon and the indicator which results in lack of
contrast.

- Add back shadow and tweak it so we do have better contrast between
them
- Also tweak indicators' position so it's aligned to the top and so it
feels more like an indicator (notifying the user)

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I2ff6e00383a7ad7305680c92b587fc1b6890a886
