### PR TITLE
autofilter: use gridwindow instead of screen offset

### DIFF
--- a/browser/src/control/Control.AutofilterDropdown.js
+++ b/browser/src/control/Control.AutofilterDropdown.js
@@ -3,7 +3,7 @@
  * L.Control.AutofilterDropdown
  */
 
-/* global $ */
+/* global app $ */
 L.Control.AutofilterDropdown = L.Control.extend({
 	container: null,
 	subMenu: null,
@@ -84,26 +84,17 @@ L.Control.AutofilterDropdown = L.Control.extend({
 		if (!isSubMenu && this.subMenu)
 			L.DomUtil.remove(this.subMenu);
 
-		var scale = this._map.getZoomScale(this._map.getZoom(), this._map.options.defaultZoom);
+		var scale = this._map.zoomToFactor(this._map.getZoom());
 		var origin = this._map.getPixelOrigin();
 		var panePos = this._map._getMapPanePos();
-		var cursorPos = this._map._docLayer.getCursorPos();
 
-		// autofilter docking window position is relative to the main window
-		// we have to take into account calc input bar and notebookbar height (where spreadsheet starts)
-		// best to base on input bar position and size (it can be also expanded)
-		var spreadsheetAreaOffset = new L.Point(35, 75); // in classic toolbar mode
-
-		var calcInputBar = this._map.dialog._calcInputBar;
-		var offsetX = spreadsheetAreaOffset.x;
-		var offsetY = calcInputBar ?
-			(spreadsheetAreaOffset.y + (calcInputBar.top - 28) + (calcInputBar.height - 29))
-			: spreadsheetAreaOffset.y;
+		var offsetX = app.sectionContainer.getSectionWithName(L.CSections.RowHeader.name).size[0];
+		var offsetY = app.sectionContainer.getSectionWithName(L.CSections.ColumnHeader.name).size[1];
 
 		if (parseInt(data.posx) === 0 && parseInt(data.posy) === 0)
 			var corePoint = new L.Point(this.position.x, this.position.y);
 		else
-			corePoint = new L.Point(parseInt(data.posx) - offsetX, parseInt(data.posy) - offsetY);
+			corePoint = new L.Point(parseInt(data.posx) + offsetX, parseInt(data.posy) + offsetY);
 
 		var left = corePoint.x * scale;
 		var top = corePoint.y * scale;
@@ -121,15 +112,6 @@ L.Control.AutofilterDropdown = L.Control.extend({
 		var newTop = top + panePos.y - origin.y;
 		if (top >= splitPos.y && newTop >= 0)
 			top = newTop;
-
-		// some documents with split panes have coordinates increased by split position...
-		if (left >= L.Map.THIS._docLayer._painter._sectionContainer.getSectionWithName(L.CSections.ColumnHeader.name).size[0]) {
-			if (cursorPos.x >= splitPos.x && left >= splitPos.x)
-				left = left - splitPos.x;
-
-			if (cursorPos.y >= splitPos.y && top >= splitPos.y)
-				top = top - splitPos.y;
-		}
 
 		if (this._map._docLayer.isCalcRTL()) {
 			left = this._map._size.x - left;

--- a/browser/src/control/Control.AutofilterDropdown.js
+++ b/browser/src/control/Control.AutofilterDropdown.js
@@ -84,11 +84,15 @@ L.Control.AutofilterDropdown = L.Control.extend({
 		if (!isSubMenu && this.subMenu)
 			L.DomUtil.remove(this.subMenu);
 
+		// only difference is when file is RTL not UI
+		// var isViewRTL = document.documentElement.dir === 'rtl';
+		var isSpreadsheetRTL = this._map._docLayer.isCalcRTL();
+
 		var scale = this._map.zoomToFactor(this._map.getZoom());
 		var origin = this._map.getPixelOrigin();
 		var panePos = this._map._getMapPanePos();
 
-		var offsetX = app.sectionContainer.getSectionWithName(L.CSections.RowHeader.name).size[0];
+		var offsetX = isSpreadsheetRTL ? 0 : app.sectionContainer.getSectionWithName(L.CSections.RowHeader.name).size[0];
 		var offsetY = app.sectionContainer.getSectionWithName(L.CSections.ColumnHeader.name).size[1];
 
 		if (parseInt(data.posx) === 0 && parseInt(data.posy) === 0)
@@ -98,6 +102,9 @@ L.Control.AutofilterDropdown = L.Control.extend({
 
 		var left = corePoint.x * scale;
 		var top = corePoint.y * scale;
+
+		if (left < 0)
+			left = -1 * left;
 
 		var splitPanesContext = this._map.getSplitPanesContext();
 		var splitPos = new L.Point(0, 0);
@@ -113,9 +120,8 @@ L.Control.AutofilterDropdown = L.Control.extend({
 		if (top >= splitPos.y && newTop >= 0)
 			top = newTop;
 
-		if (this._map._docLayer.isCalcRTL()) {
+		if (isSpreadsheetRTL)
 			left = this._map._size.x - left;
-		}
 
 		var mainContainer = null;
 		var builder = null;
@@ -151,6 +157,7 @@ L.Control.AutofilterDropdown = L.Control.extend({
 		L.DomUtil.setStyle(mainContainer, 'margin-top', top + 'px');
 
 		builder.build(mainContainer, [data]);
+		mainContainer.firstChild.dir = document.documentElement.dir;
 
 		var height = $(mainContainer).height();
 		if (top + height > $('#document-container').height()) {

--- a/browser/src/control/Control.AutofilterDropdown.js
+++ b/browser/src/control/Control.AutofilterDropdown.js
@@ -95,13 +95,8 @@ L.Control.AutofilterDropdown = L.Control.extend({
 		var offsetX = isSpreadsheetRTL ? 0 : app.sectionContainer.getSectionWithName(L.CSections.RowHeader.name).size[0];
 		var offsetY = app.sectionContainer.getSectionWithName(L.CSections.ColumnHeader.name).size[1];
 
-		if (parseInt(data.posx) === 0 && parseInt(data.posy) === 0)
-			var corePoint = new L.Point(this.position.x, this.position.y);
-		else
-			corePoint = new L.Point(parseInt(data.posx) + offsetX, parseInt(data.posy) + offsetY);
-
-		var left = corePoint.x * scale;
-		var top = corePoint.y * scale;
+		var left = parseInt(data.posx) * scale;
+		var top = parseInt(data.posy) * scale;
 
 		if (left < 0)
 			left = -1 * left;
@@ -122,6 +117,9 @@ L.Control.AutofilterDropdown = L.Control.extend({
 
 		if (isSpreadsheetRTL)
 			left = this._map._size.x - left;
+
+		left = left + offsetX;
+		top = top + offsetY;
 
 		var mainContainer = null;
 		var builder = null;

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2988,7 +2988,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			}
 
 			var hasManyChildren = childData.children && childData.children.length > 1;
-			if (hasManyChildren && childData.type !== 'buttonbox') {
+			if (hasManyChildren && childData.type !== 'buttonbox' && childData.type !== 'treelistbox') {
 				// TODO: remove 'table-' prefix, we need exactly the same id so events coming from core
 				// will reach the elements, for postprocess we need to temporary switch the id in childData
 				var backupId = childData.id;


### PR DESCRIPTION
core is adjusted to send offset for autofilter popup
related to gridwindow (spreadsheet area) instead of
absolute screen coordinates - what helps to simplify
code.

requires: https://gerrit.libreoffice.org/c/core/+/130528