### PR TITLE
Annotations: fix collapsed comment container

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -458,10 +458,10 @@ nav.drawing-color-indicator ~ #main-document-content .cool-annotation-reply-coun
 	box-shadow: 0 0 3px 5px white, 0 0 1px 5px grey;
 }
 
-.jsdialog-container.cool-annotation-collapsed.modalpopup {
+#mobile-wizard-popup.jsdialog-container.cool-annotation-collapsed.modalpopup {
 	border-radius: 8px !important;
 	border: 1px solid var(--gray-color) !important;
-	background: white !important;
+	background-color: white !important;
 }
 
 .jsdialog-container.cool-annotation-collapsed.modalpopup .lokdialog.ui-dialog-content {


### PR DESCRIPTION
with some recent colors changes (css vars) the container of collapsed
annotations (comment and reply) and its background was superseded with
another css rule:
 - Add to the rule the id so it does not get overruled
 - Also add background-color instead of just bg

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: If8c847a80d761e177ad1d12b6c4f7ea9f7690ad2
