### PR TITLE
Use make's -C argument instead of cd in cypress_test/run_parallel.sh

### DIFF
--- a/cypress_test/run_parallel.sh
+++ b/cypress_test/run_parallel.sh
@@ -89,23 +89,23 @@ print_error() {
         echo -e "\n\
         CypressError: a test failed, please do one of the following:\n\n\
         Run the failing test in headless mode:\n\
-        \tcd cypress_test && make USER_INTERFACE=notebookbar check-${COMMAND} spec=${SPEC}\n" >> ${ERROR_LOG}
+        \tmake -C cypress_test USER_INTERFACE=notebookbar check-${COMMAND} spec=${SPEC}\n" >> ${ERROR_LOG}
     else
         echo -e "\n\
         CypressError: a test failed, please do one of the following:\n\n\
         Run the failing test in headless mode:\n\
-        \tcd cypress_test && make check-${COMMAND} spec=${SPEC}\n" >> ${ERROR_LOG}
+        \tmake -C cypress_test check-${COMMAND} spec=${SPEC}\n" >> ${ERROR_LOG}
     fi
 
     if [ "${TEST_TYPE}" == "mobile" -o "${TEST_TYPE}" == "desktop" ]; then
         if [ "${USER_INTERFACE}" == "notebookbar" ]; then
             echo -e "\
         Run the failing test with video recording:\n\
-            \tcd cypress_test && ENABLE_VIDEO_REC="1" make USER_INTERFACE=notebookbar check-${COMMAND} spec=${SPEC}\n" >> ${ERROR_LOG}
+            \tmake -C cypress_test ENABLE_VIDEO_REC="1" USER_INTERFACE=notebookbar check-${COMMAND} spec=${SPEC}\n" >> ${ERROR_LOG}
         else
             echo -e "\
             Run the failing test with video recording:\n\
-            \tcd cypress_test && ENABLE_VIDEO_REC="1" make check-${COMMAND} spec=${SPEC}\n" >> ${ERROR_LOG}
+            \tmake -C cypress_test ENABLE_VIDEO_REC="1" check-${COMMAND} spec=${SPEC}\n" >> ${ERROR_LOG}
         fi
     fi
 
@@ -113,20 +113,20 @@ print_error() {
     if [ "${USER_INTERFACE}" == "notebookbar" ]; then
         echo -e "\
         Open the failing test in the interactive test runner:\n\
-        \tcd cypress_test && make USER_INTERFACE=notebookbar run-${COMMAND} spec=${SPEC}\n" >> ${ERROR_LOG}
+        \tmake -C cypress_test USER_INTERFACE=notebookbar run-${COMMAND} spec=${SPEC}\n" >> ${ERROR_LOG}
     else
         echo -e "\
         Open the failing test in the interactive test runner:\n\
-        \tcd cypress_test && make run-${COMMAND} spec=${SPEC}\n" >> ${ERROR_LOG}
+        \tmake -C cypress_test run-${COMMAND} spec=${SPEC}\n" >> ${ERROR_LOG}
     fi
     elif [[ ${TEST_FILE} == *"user1"* ]]; then
     echo -e "\
     Open the failing test in the interactive test runner:\n\
-    \tcd cypress_test && make run-${COMMAND} spec=${SPEC} user=1\n" >> ${ERROR_LOG}
+    \tmake -C cypress_test run-${COMMAND} spec=${SPEC} user=1\n" >> ${ERROR_LOG}
     else
     echo -e "\
     Open the failing test in the interactive test runner:\n\
-    \tcd cypress_test && make run-${COMMAND} spec=${SPEC} user=2\n" >> ${ERROR_LOG}
+    \tmake -C cypress_test run-${COMMAND} spec=${SPEC} user=2\n" >> ${ERROR_LOG}
     fi
 }
 


### PR DESCRIPTION
Signed-off-by: Bayram Çiçek <bayram.cicek@libreoffice.org>
Change-Id: I781070c32d89c329effbc233cf356fe983b85c1e


* Resolves: #2720
* Target version: master 

### Summary

- `cd cypress_test && make` is equal to `make -C cypress_test`
-  current directory will remain unchanged with `make -C`. 

### Checklist

- [ ] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

