### PR TITLE
Color-Scheme add header-font-size and default-height

### DIFF
--- a/browser/css/color-palette.css
+++ b/browser/css/color-palette.css
@@ -40,6 +40,8 @@
 	--border-radius-large: 10px;
 
 	--default-font-size: 12px;
+	--header-font-size: 16px;
 
+	--default-height: 24px;
 	--header-height: 38px;
 }


### PR DESCRIPTION
--header-font-size is for the user of font in header sections
--default-height is used for the height of --default-font-size elements

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I16b7f0b5755cb54ceb26b6af66d13a8411fa0d84