### PR TITLE
JSDialog: remove duplicated shadow

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -39,8 +39,6 @@
 .jsdialog-container .ui-dialog-content {
 	background-color: var(--color-main-background) !important;
 	font-family: var(--jquery-ui-font);
-	-webkit-box-shadow: 0 0 3px var(--color-box-shadow);
-	box-shadow: 0 0 3px var(--color-box-shadow);
 	line-height: 1.5;
 }
 


### PR DESCRIPTION
Content parent was being set with shadow while the main parent element
also has shadow

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I4f8f13f579e5b1205433801e95cc482c63f1fcc7
