### PR TITLE
NB: collpasing tabs: hide container instead of child

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -13,10 +13,13 @@
 #document-container:not(.mobile) + #sidebar-dock-wrapper {
 	width: 330px;
 	padding: 0;
-	border-left: 1px solid var(--color-border) !important;
-	border-right: 1px solid var(--color-border) !important; /* for RTL mode */
 	margin-top: 0 !important;
 	box-sizing: border-box;
+}
+
+[data-userinterfacemode='classic'] #document-container:not(.mobile) + #sidebar-dock-wrapper,
+#document-container.spreadsheet-doctype:not(.mobile) + #sidebar-dock-wrapper {
+	border-inline-start: 1px solid var(--color-border) !important;
 }
 
 .sidebar .spinfieldcontainer input {

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -496,7 +496,7 @@ L.Control.UIManager = L.Control.extend({
 			return;
 
 		this.moveObjectVertically($('#formulabar'), -1);
-		$('#toolbar-up').css('display', 'none');
+		$('#toolbar-wrapper').css('display', 'none');
 
 		$('#document-container').addClass('tabs-collapsed');
 
@@ -508,7 +508,7 @@ L.Control.UIManager = L.Control.extend({
 			return;
 
 		this.moveObjectVertically($('#formulabar'), 1);
-		$('#toolbar-up').css('display', '');
+		$('#toolbar-wrapper').css('display', '');
 
 		$('#document-container').removeClass('tabs-collapsed');
 


### PR DESCRIPTION
We can hid the whole container and avoid the background of that
container to be visible (when collpased)
 - This was useful in the before when the tabs were visually "connected"
 to the content
 - Also it was done like that before to give a "clue" to the user that
 something is there and can be expanded but probably by now it's not
 needed and if the user actively collpased them then he/she would know
 how to expand them

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ib586f4aa3e83e650276b25c2ac13d45f475816e3
