### PR TITLE
Don't require https when ENABLE_DEBUG for the remote config thing

### DIFF
--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -1036,11 +1036,13 @@ public:
             LOG_INF("Remote config url is not specified in coolwsd.xml");
             return; // no remote config server setup.
         }
-        else if (!Util::iequal(remoteServerURI.getScheme(), "https"))
+#if !ENABLE_DEBUG
+        if (Util::iequal(remoteServerURI.getScheme(),"http"))
         {
-            LOG_ERR("Remote config url should only use HTTPS protocol");
+            LOG_ERR("Remote config url should only use HTTPS protocol: " << remoteServerURI.toString());
             return;
         }
+#endif
 
         startThread();
     }


### PR DESCRIPTION
Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: I8b71d4e5a06e2c0a7fcd7dedc370cc4810a204fd


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

