### PR TITLE
 wsd: use hostname, port and scheme in doc key

### DIFF
--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -204,6 +204,13 @@
             <locking desc="Locking settings">
                 <refresh desc="How frequently we should re-acquire a lock with the storage server, in seconds (default 15 mins) or 0 for no refresh" type="int" default="900">900</refresh>
             </locking>
+
+            <!-- <group>
+                <host desc="hostname to allow or deny." allow="true">hostname</host>
+                <alias>aliasname1</alias>
+                <alias>aliasname2</alias>
+            </group> -->
+
         </wopi>
         <ssl desc="SSL settings">
             <as_scheme type="bool" default="true" desc="When set we exclusively use the WOPI URI's scheme to enable SSL for storage">true</as_scheme>

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -102,6 +102,7 @@ wsd_sources = \
             ../common/Authorization.cpp \
             ../kit/Kit.cpp \
             ../kit/TestStubs.cpp \
+            ../wsd/Storage.cpp \
             ../wsd/FileServerUtil.cpp \
             ../wsd/RequestDetails.cpp \
             ../wsd/TileCache.cpp \

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -1138,14 +1138,23 @@ public:
 
         fetchWopiHostPatterns(newAppConfig, remoteJson);
 
+        fetchAliasGroups(newAppConfig, remoteJson);
+
 #ifdef ENABLE_FEATURE_LOCK
         fetchLockedHostPatterns(newAppConfig, remoteJson);
 #endif
+
+        for(auto x : newAppConfig)
+        {
+            std::cerr << x.first << " " << x.second << "\n";
+        }
 
         AutoPtr<AppConfigMap> newConfig(new AppConfigMap(newAppConfig));
         conf.addWriteable(newConfig, PRIO_JSON);
 
         StorageBase::parseWopiHost(conf);
+
+        StorageBase::parseAliases(conf);
 
 #ifdef ENABLE_FEATURE_LOCK
         CommandControl::LockManager::parseLockedHost(conf);
@@ -1158,7 +1167,7 @@ public:
         //wopi host patterns
         if (!conf.getBool("storage.wopi[@allow]", false))
         {
-            LOG_INF("WOPI host feature is disabled in coolwsd.xml");
+            LOG_INF("WOPI host feature is disabled in configuration");
             return;
         }
         try
@@ -1211,7 +1220,7 @@ public:
     {
         if (!conf.getBool("feature_lock.locked_hosts[@allow]", false))
         {
-            LOG_INF("locked_hosts feature is disabled from coolwsd.xml");
+            LOG_INF("locked_hosts feature is disabled from configuration");
             return;
         }
 
@@ -1264,6 +1273,73 @@ public:
         catch (const std::exception& exc)
         {
             LOG_ERR("Failed to fetch locked_hosts, please check JSON format: " << exc.what());
+        }
+    }
+
+    void fetchAliasGroups(std::map<std::string, std::string>& newAppConfig,
+                          Poco::JSON::Object::Ptr remoteJson)
+    {
+        try
+        {
+            Poco::JSON::Array::Ptr aliasGroups =
+                remoteJson->getObject("storage")->getObject("wopi")->getArray("alias_groups");
+
+            if (aliasGroups->size() == 0)
+            {
+                LOG_WRN("Not overwriting any alias groups because alias_group array is empty");
+                return;
+            }
+
+            std::size_t i;
+            for (i = 0; i < aliasGroups->size(); i++)
+            {
+                Poco::JSON::Object::Ptr group = aliasGroups->getObject(i);
+                std::string host;
+                JsonUtil::findJSONValue(group, "host", host);
+                Poco::Dynamic::Var allow = group->get("allow");
+                const std::string path = "storage.wopi.group[" + std::to_string(i) + ']';
+
+                newAppConfig.insert(std::make_pair(path + ".host", host));
+                newAppConfig.insert(std::make_pair(path + ".host[@allow]", booleanToString(allow)));
+
+                Poco::JSON::Array::Ptr aliases = group->getArray("aliases");
+
+                auto it = aliases->begin();
+
+                size_t j;
+                for (j = 0; j < aliases->size(); j++)
+                {
+                    const std::string aliasPath = path + ".alias[" + std::to_string(j) + ']';
+                    newAppConfig.insert(std::make_pair(aliasPath, it->toString()));
+                    it++;
+                }
+                for (;; j++)
+                {
+                    const std::string aliasPath = path + ".alias[" + std::to_string(j) + ']';
+                    if (!conf.has(aliasPath))
+                    {
+                        break;
+                    }
+                    newAppConfig.insert(std::make_pair(aliasPath, ""));
+                }
+            }
+            //if number of alias_groups defined in configuration are greater than number of alias_group
+            //fetched from json, overwrite the remaining alias_groups from config file to empty strings and
+            for (;; i++)
+            {
+                const std::string path = "storage.wopi.group[" + std::to_string(i) + "].host";
+                if (!conf.has(path))
+                {
+                    break;
+                }
+                newAppConfig.insert(std::make_pair(path , ""));
+                newAppConfig.insert(std::make_pair(path + "[@allowed]", "false"));
+            }
+        }
+        catch (const std::exception& exc)
+        {
+            LOG_ERR("Fetching of alias groups failed with error: " << exc.what()
+                                                                << "please check JSON format");
         }
     }
 

--- a/wsd/RequestDetails.cpp
+++ b/wsd/RequestDetails.cpp
@@ -10,6 +10,7 @@
 #include "COOLWSD.hpp"
 #include "RequestDetails.hpp"
 #include "common/Log.hpp"
+#include "Storage.hpp"
 
 #include <Poco/URI.h>
 #include "Exceptions.hpp"
@@ -283,15 +284,22 @@ Poco::URI RequestDetails::sanitizeURI(const std::string& uri)
 
 std::string RequestDetails::getDocKey(const Poco::URI& uri)
 {
-    // If multiple host-names are used to access us, then
-    // they must be aliases. Permission to access aliased hosts
-    // is checked at the point of accepting incoming connections.
-    // At this point storing the hostname artificially discriminates
-    // between aliases and forces same document (when opened from
-    // alias hosts) to load as separate documents and sharing doesn't
-    // work. Worse, saving overwrites one another.
     std::string docKey;
-    Poco::URI::encode(uri.getPath(), "", docKey);
+    std::string uriHost = uri.getHost();
+    std::string uriPort = std::to_string(uri.getPort());
+
+    std::cerr << "Uri" << uri.toString() << "\n";
+    std::cerr << "Before: "<< "\n";
+    std::cerr << "uriHost: " << uriHost << "\n";
+    std::cerr << "uriPort: " << uriPort << "\n";
+
+    StorageBase::getHostAndPort(uriHost, uriPort);
+
+    std::cerr << "After: " << "\n";
+    std::cerr << "uriHost: " << uriHost << "\n";
+    std::cerr << "uriPort: " << uriPort << "\n";
+
+    Poco::URI::encode(uri.getScheme() + "://" + uriHost + ":" + uriPort + uri.getPath(), "",docKey);
     LOG_INF("DocKey from URI [" << uri.toString() << "] => [" << docKey << ']');
     return docKey;
 }

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -65,6 +65,9 @@ bool StorageBase::WopiEnabled;
 bool StorageBase::SSLAsScheme = true;
 bool StorageBase::SSLEnabled = false;
 Util::RegexListMatcher StorageBase::WopiHosts;
+std::map<std::string, std::string> StorageBase::aliasHosts;
+std::set<std::string> StorageBase::allHosts;
+std::string StorageBase::firstHost;
 
 #if !MOBILEAPP
 
@@ -116,7 +119,98 @@ void StorageBase::parseWopiHost(Poco::Util::LayeredConfiguration& conf)
     }
 }
 
+void StorageBase::addWopiHost(std::string host, bool allow)
+{
+    if (!host.empty())
+    {
+        if (allow)
+        {
+            LOG_INF("Adding trusted WOPI host: [" << host << "].");
+            WopiHosts.allow(host);
+        }
+        else
+        {
+            LOG_INF("Adding blocked WOPI host: [" << host << "].");
+            WopiHosts.deny(host);
+        }
+    }
+}
+
+void StorageBase::parseAliases(Poco::Util::LayeredConfiguration& conf)
+{
+    aliasHosts.clear();
+
+    for (size_t i = 0;; i++)
+    {
+        const std::string path = "storage.wopi.group[" + std::to_string(i) + ']';
+        if (!conf.has(path + ".host"))
+        {
+            break;
+        }
+
+        const std::string hostAndPort = conf.getString(path + ".host", "");
+        if (hostAndPort.empty())
+        {
+            continue;
+        }
+
+        StringVector tokens = Util::tokenize(hostAndPort, ":");
+        bool allow = conf.getBool(path + ".host[@allow]", false);
+        StorageBase::addWopiHost(tokens[0], allow);
+        allHosts.insert(tokens[0]);
+
+        for (size_t j = 0;; j++)
+        {
+            const std::string aliasPath = path + ".alias[" + std::to_string(j) + ']';
+            if (!conf.has(aliasPath))
+            {
+                break;
+            }
+            const std::string aliasHostAndPort = conf.getString(aliasPath, "");
+            if (!aliasHostAndPort.empty())
+            {
+                aliasHosts.insert({ aliasHostAndPort, hostAndPort });
+            }
+
+            tokens = Util::tokenize(aliasHostAndPort, ":");
+            allHosts.insert(tokens[0]);
+            StorageBase::addWopiHost(tokens[0], allow);
+        }
+    }
+
+    for (auto x : aliasHosts)
+    {
+        std::cerr << x.first << " " << x.second << "\n";
+    }
+}
+
+void StorageBase::getHostAndPort(std::string& uriHost, std::string& uriPort)
+{
+    const std::string key = uriHost + ":" + uriPort;
+    if (aliasHosts.find(key) != aliasHosts.end())
+    {
+        const std::string aliasDetails = aliasHosts[key];
+        StringVector tokens = Util::tokenize(aliasDetails, ':');
+
+        if (!tokens[0].empty())
+        {
+            uriHost = tokens[0];
+        }
+
+        if (!tokens[1].empty())
+        {
+            uriPort = tokens[1];
+        }
+    }
+    else
+    {
+        LOG_ERR("hostname: " << uriHost << " does not exist in alias group configuration");
+    }
+}
+
 #endif
+
+#if !defined(BUILDING_TESTS)
 
 void StorageBase::initialize()
 {
@@ -125,6 +219,8 @@ void StorageBase::initialize()
     FilesystemEnabled = app.config().getBool("storage.filesystem[@allow]", false);
 
     parseWopiHost(app.config());
+
+    parseAliases(app.config());
 
 #ifdef ENABLE_FEATURE_LOCK
     CommandControl::LockManager::parseLockedHost(app.config());
@@ -197,7 +293,30 @@ void StorageBase::initialize()
 
 bool StorageBase::allowedWopiHost(const std::string& host)
 {
-    return WopiEnabled && WopiHosts.match(host);
+    bool allow = WopiEnabled && WopiHosts.match(host);
+    if (!allow)
+    {
+        return false;
+    }
+    if (aliasHosts.empty())
+    {
+        if (firstHost.empty())
+        {
+            firstHost = host;
+        }
+        else if (firstHost != host)
+        {
+            LOG_ERR("Only allowed host is: " << firstHost
+                                             << ", no aliases groups are defined in configuration");
+            return false;
+        }
+    }
+    else if (allHosts.find(host) == allHosts.end())
+    {
+        LOG_ERR("Host: " << host << " is not allowed, It is not part of aliases group");
+        return false;
+    }
+    return allow;
 }
 
 #if !MOBILEAPP
@@ -263,7 +382,7 @@ std::unique_ptr<StorageBase> StorageBase::create(const Poco::URI& uri, const std
         LOG_INF("Public URI [" << COOLWSD::anonymizeUrl(uri.toString()) << "] considered WOPI.");
         const auto& targetHost = uri.getHost();
         bool allowed(false);
-        if (WopiHosts.match(targetHost) || isLocalhost(targetHost))
+        if (StorageBase::allowedWopiHost(targetHost) || isLocalhost(targetHost))
         {
             allowed = true;
         }
@@ -273,7 +392,7 @@ std::unique_ptr<StorageBase> StorageBase::create(const Poco::URI& uri, const std
             const auto hostAddresses(Poco::Net::DNS::resolve(targetHost));
             for (auto &address : hostAddresses.addresses())
             {
-                if (WopiHosts.match(address.toString()))
+                if (StorageBase::allowedWopiHost(address.toString()))
                 {
                     allowed = true;
                     break;
@@ -1534,4 +1653,5 @@ WopiStorage::handleUploadToStorageResponse(const WopiUploadDetails& details,
 
 #endif // !MOBILEAPP
 
+#endif // !defined(BUILDING_TESTS)
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -330,6 +330,16 @@ public:
 
     static void parseWopiHost(Poco::Util::LayeredConfiguration& conf);
 
+    static void parseAliases(Poco::Util::LayeredConfiguration& conf);
+
+    /// if request uri is an alias, replace request uri host and port with
+    /// original hostname and port defined by aliases tag from coolwsd.xml
+    /// to avoid possibility of opening the same file as two if the WOPI host
+    /// is accessed using different aliases
+    static void getHostAndPort(std::string& uriHost, std::string& uriPort);
+
+    static void addWopiHost(std::string host, bool allow);
+
 protected:
 
     /// Sanitize a URI by removing authorization tokens.
@@ -390,6 +400,10 @@ private:
     static bool SSLEnabled;
     /// Allowed/denied WOPI hosts, if any and if WOPI is enabled.
     static Util::RegexListMatcher WopiHosts;
+
+    static std::map<std::string, std::string> aliasHosts;
+    static std::string firstHost;
+    static std::set<std::string> allHosts;
 };
 
 /// Trivial implementation of local storage that does not need do anything.


### PR DESCRIPTION
to avoid different WOPI hosts using same coolwsd instance sharing a
file because the path of the file (file id etc.) is same in both of
WOPI hosts.

added aliases configuration to coolwsd.xml to avoid
possibility of opening the same file as two if the
WOPI host is accessed using different aliases

Signed-off-by: Rash419 <rashesh.padia@collabora.com>
Change-Id: I03d92c121dc388e19e6458873aba8ecf7a7fcbaa

* Target version: master 


