### PR TITLE
update cypress_test/README and use make's -C argument

### DIFF
--- a/cypress_test/README
+++ b/cypress_test/README
@@ -153,8 +153,8 @@ There are two spec files which you can to update the screenshots in help dialog
 2. cypress_test/integration_tests/desktop/calc/help_dialog_update_spec.js
 
 You can run the specfile individually using:
-    1. cd cypress_test && make UPDATE_SCREENSHOT=true check-desktop spec=writer/help_dialog_update_spec.js
-    2. cd cypress_test && make UPDATE_SCREENSHOT=true check-desktop spec=calc/help_dialog_update_spec.js
+    1. make -C cypress_test UPDATE_SCREENSHOT=true check-desktop spec=writer/help_dialog_update_spec.js
+    2. make -C cypress_test UPDATE_SCREENSHOT=true check-desktop spec=calc/help_dialog_update_spec.js
 
 If UPDATE_SCREENSHOT is true then only cypress will run the spec file and replace the original screenshot with new screenshot, the default value of UPDATE_SCREENSHOT is false
 


### PR DESCRIPTION
Signed-off-by: Bayram Çiçek <bayram.cicek@libreoffice.org>
Change-Id: I2c03535d5f27cffeffc75a0f101d0280cc6e50ae


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
- after changes in #4304, two uses of `cd cypress_test && make` replaced with `make -C cypress_test` in `cypress_test/README`.

### Checklist

- [ ] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

