### PR TITLE
calc: misaligned selection if sheet geometry changed while idle

### DIFF
--- a/browser/src/map/Map.js
+++ b/browser/src/map/Map.js
@@ -1371,6 +1371,10 @@ L.Map = L.Evented.extend({
 				// window.app.console.debug('sending useractive');
 				app.socket.sendMessage('useractive');
 				this._active = true;
+				var docLayer = this._docLayer;
+				if (docLayer.isCalc() && docLayer.options.sheetGeometryDataEnabled) {
+					docLayer.requestSheetGeometryData();
+				}
 				app.socket.sendMessage('commandvalues command=.uno:ViewAnnotations');
 
 				if (isAnyVexDialogActive()) {


### PR DESCRIPTION
Steps to reproduce the issue:

1. Set per_document / idle_timeout_secs to something small, like 30,
2. Open a spreadsheet with various row heights,
3. Wait until you idle out of the session,
4. Open the same file from another browser tab/window, add an empty row near the top, then close it,
5. Wait a little bit (let's say ~5s), and click into the original session, then select various cells.

-> Note how the selection is misaligned.

Root cause:

When a session becomes idle (at least for the current use-case) the
corresponding lok-view is terminated and when the js-view is resumed a
new lok view is created! In this case there is no one to one
correspondence between a js-view and lok-view. So there is no
remembering of events or replaying of events.

Fix:
Ask for sheetgeometry whenever the cool-client resumes.

Signed-off-by: Dennis Francis <dennis.francis@collabora.com>
Change-Id: If445cf28f8add46ce478e3a87e2ad8ada6cf2eb0


* Target version: master 

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

