### PR TITLE
NB: stylesview: fix hover bg and shadows

### DIFF
--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -414,19 +414,21 @@
 }
 
 #stylesview .ui-iconview-entry.selected {
-	border: 1px solid var(--color-border-dark);
+	border: 1px solid var(--color-border-darker);
 	border-collapse: separate; /*To use box-shadow in Internet Explorer 9 or later*/
+	background-color: transparent;
 }
 
 #stylesview .ui-iconview-entry:not(.selected) {
 	border: 1px solid transparent;
 }
 
-#stylesview .ui-iconview-entry:hover {
-	border: 1px solid var(--color-border-darker);
-	-webkit-box-shadow: 0 0 5px var(--color-background-darker);
-	box-shadow: 0 0 5px var(--color-background-darker);
+#stylesview .ui-iconview-entry:not(.selected):hover {
+	border: 1px solid var(--color-border-dark);
+	-webkit-box-shadow: 0 0 2px 0 var(--color-background-darker);
+	box-shadow: 0 0 2px 0 var(--color-background-darker);
 	cursor: pointer;
+	background-color: transparent;
 }
 
 #stylesview .ui-iconview-icon {


### PR DESCRIPTION
Make sure gray background or any bg for that matter is used on hover
 - It shouldn't be used because each style is an image with white bg

Decrease hover status prominence so it's still visible which style is
selected

Also do not add hover status for the selected style, as clicking on it
would not change the selected style

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ie66abada24a7c6491987d9052dc94bba920d5a7f
