### PR TITLE
increase timeout for isDocumentLoaded response

### DIFF
--- a/test/helpers.hpp
+++ b/test/helpers.hpp
@@ -545,7 +545,7 @@ inline bool isDocumentLoaded(const std::shared_ptr<http::WebSocketSession>& ws,
                              const std::string& testname, bool isView = true)
 {
     const std::string prefix = isView ? "status:" : "statusindicatorfinish:";
-    constexpr std::chrono::milliseconds timeout = std::chrono::seconds(20); // Allow 20 secs to load
+    constexpr std::chrono::milliseconds timeout = std::chrono::seconds(40); // Allow 40 secs to load
     const std::string message = getResponseString(ws, prefix, testname, timeout.count());
 
     const bool success = LOOLProtocol::matchPrefix(prefix, message);


### PR DESCRIPTION
just an attempt to fix timeout issue on unit-httpws test

Signed-off-by: Mert Tumer <mert.tumer@collabora.com>
Change-Id: I41a1527d32a120197b7aa136e22087de63a5ba02


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

