### PR TITLE
Add a remote font configuration thing

### DIFF
--- a/coolwsd-systemplate-setup
+++ b/coolwsd-systemplate-setup
@@ -5,7 +5,10 @@ test $# -eq 2 || { echo "Usage: $0 <chroot template directory for system libs to
 
 # No provision for spaces or other weird characters in pathnames. So sue me.
 
+# First parameter is the pathname where this script will create the "systemplate" tree
 CHROOT=$1
+
+# Second parameter is the instdir directory of the LibreOffice installation to be used
 INSTDIR=$2
 
 test -d "$INSTDIR" || { echo "$0: No such directory: $INSTDIR"; exit 1; }
@@ -81,7 +84,7 @@ mkdir -p $CHROOT/etc/
 for file in hosts nsswitch.conf resolv.conf passwd group host.conf timezone localtime
 do
     # echo "Linking/Copying /etc/$file"
-    # Prefer hard-linking, fallback to just copying (do *not* use soft-linking because that would be relative to the jail).
+    # Prefer hard-linking, fallback to just copying (do *not* use symlinking because that would be relative to the jail).
     # When copying, we must make sure that we copy the source and not a symlink. Otherwise, the source won't be accessible from the jail.
     # In addition, we flag that at least one file is copied by creating the 'copied' file, so that we do check for updates.
     ln -f `${REALPATH} /etc/$file` $CHROOT/etc/$file 2> /dev/null || (${CP} --dereference --preserve=all /etc/$file $CHROOT/etc/$file && touch $CHROOT/etc/copied) || echo "$0: Failed to link or copy /etc/$file"
@@ -93,7 +96,7 @@ mkdir -p $CHROOT/dev
 mkdir -p $CHROOT/tmp/dev
 for file in random urandom
 do
-    # This link is relative anyway, so can be soft.
+    # This link is relative anyway, so can be symbolic.
     ln -f ../tmp/dev/$file $CHROOT/dev/ 2> /dev/null || ln -f -s ../tmp/dev/$file $CHROOT/dev/ || echo "$0: Failed to link dev/$file"
 done
 
@@ -104,11 +107,19 @@ mkdir -p $CHROOT/lo
 # In case the original path is different from
 for path in $INSTDIR $INSTDIR_LOGICAL
 do
-    # Create a soft-link, as it's a relative directory path (can't be a hard-link).
+    # Create a symlink, as it's a relative directory path (can't be a hard-link).
     INSTDIR_PARENT="$(dirname "$CHROOT/$path")"
     mkdir -p $INSTDIR_PARENT
     ln -f -s `${REALPATH} --relative-to=$INSTDIR_PARENT $CHROOT/lo` $CHROOT/$path
 done
+
+# A similar dance also for the directory where "temporary" fonts are
+# stored. Such are downloaded from other servers based on a separate
+# configuration file. They need to be accessible using the same
+# pathname both in the ForKit process and in the Kit processes.
+mkdir -p $CHROOT/tmpfonts
+mkdir -p $CHROOT$CHROOT
+ln -f -s `${REALPATH} --relative-to=$CHROOT$CHROOT $CHROOT/tmpfonts` $CHROOT$CHROOT
 
 # /usr/share/fonts needs to be taken care of separately because the
 # directory time stamps must be preserved for fontconfig to trust

--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -241,6 +241,10 @@
         <remote_url desc="remote server to which you will send resquest to get remote config in response" type="string" default=""></remote_url>
     </remote_config>
 
+    <remote_font_config>
+        <url desc="URL of optional JSON file that lists fonts to be included in Online" type="string" default=""></url>
+    </remote_font_config>
+
     @LOCK_CONFIGURATION@
 
     @FEATURE_RESTRICTION_CONFIGURATION@

--- a/kit/ForKit.cpp
+++ b/kit/ForKit.cpp
@@ -170,6 +170,14 @@ protected:
                 LOG_ERR("Unknown setconfig command: " << message);
             }
         }
+        else if (tokens.size() == 2 && tokens.equals(0, "addfont"))
+        {
+            // Tell core to use that font file
+            std::string fontFile = tokens[1];
+
+            assert(loKitPtr);
+            loKitPtr->pClass->setOption(loKitPtr, "addfont", Poco::URI(Poco::Path(fontFile)).toString().c_str());
+        }
         else if (tokens.equals(0, "exit"))
         {
             LOG_INF("Setting TerminationFlag due to 'exit' command from parent.");

--- a/kit/Kit.hpp
+++ b/kit/Kit.hpp
@@ -144,4 +144,6 @@ std::string anonymizeUsername(const std::string& username);
 std::shared_ptr<lok::Document> getLOKDocumentForAndroidOnly();
 #endif
 
+extern _LibreOfficeKit* loKitPtr;
+
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -1392,7 +1392,7 @@ public:
                 LOG_WRN("Element in fonts array is not a string");
             else
             {
-                fonts[std::string(fontPtr)].active = true;
+                fonts[fontPtr.toString()].active = true;
             }
         }
 

--- a/wsd/COOLWSD.hpp
+++ b/wsd/COOLWSD.hpp
@@ -246,6 +246,7 @@ public:
     static std::string ServerName;
     static std::string FileServerRoot;
     static std::string ServiceRoot; ///< There are installations that need prefixing every page with some path.
+    static std::string TmpFontDir;
     static std::string LOKitVersion;
     static bool EnableTraceEventLogging;
     static FILE *TraceEventFile;


### PR DESCRIPTION
The coolwsd.xml file can contain a URI of a JSON file on some server
that contains URIs of fonts. These fonts are downloaded. Just like the
remote configuration thing, the URIs are checked once a minute and the
JSON or the fonts are re-downloaded if their contents change.

If a font has been removed from the JSON then the corresponding
downloaded file is removed, too.

It is still unclear how exactly handle this with LibreOffice core and
Fontconfig.

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: If78058ddff5ed05c7a82d7ea465a7a414fd0d861


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

