### PR TITLE
browser: fix to show cursor blinking

### DIFF
--- a/browser/src/layer/marker/Cursor.ts
+++ b/browser/src/layer/marker/Cursor.ts
@@ -97,15 +97,19 @@ class Cursor {
 		return this.domAttached;
 	}
 
+	addCursorClass(visible: boolean) {
+		if (visible)
+			$('.leaflet-cursor').removeClass('blinking-cursor-hidden');
+		else
+			$('.leaflet-cursor').addClass('blinking-cursor-hidden');
+	}
+
 	isVisible(): boolean {
 		return this.visible;
 	}
 
 	onFocusBlur(ev: FocusEvent) {
-		if (ev.type === 'blur')
-			$('.leaflet-cursor').addClass('blinking-cursor-hidden');
-		else
-			$('.leaflet-cursor').removeClass('blinking-cursor-hidden');
+		this.addCursorClass(ev.type !== 'blur');
 	}
 
 	// position and size should be in core pixels.
@@ -161,6 +165,7 @@ class Cursor {
 			if (!paneBounds.contains(cursorBounds)) {
 				this.container.style.visibility = 'hidden';
 				this.visible = false;
+				this.addCursorClass(this.visible);
 				this.showCursorHeader();
 				return;
 			}
@@ -168,6 +173,7 @@ class Cursor {
 
 		this.container.style.visibility = 'visible';
 		this.visible = true;
+		this.addCursorClass(this.visible);
 
 		var tileSectionPos = this.map._docLayer.getTileSectionPos();
 		// Compute tile-section offset in css pixels.


### PR DESCRIPTION
When an image is inserted, the cursor is not shown.

Change-Id: Iea305a9a666bf06c68e7407eac3252f7faab627a
Signed-off-by: Henry Castro <hcastro@collabora.com>
