### PR TITLE
Fix insert comment dialog's avatar size

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -558,6 +558,7 @@ nav.drawing-color-indicator ~ #main-document-content .cool-annotation-reply-coun
 }
 
 .cool-annotation-img {
+	box-sizing: content-box !important;
 	max-width: 32px;
 	display: inline-block;
 	border: solid 2px;


### PR DESCRIPTION
Avatar images was not aligned to its parent element and looked like it
was out of that parent "circle". A box size property was getting inherit
from generic vex style sheet
	-Make sure the box size of the parent avatar image:
	.cool-annotation-img is calculated with the width of any border or
	padding added to the final rendered width, making the element wider
	than 32px.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ia32c06fd6dea23feb431c2afbe9cdb591063a732
