### PR TITLE
Check endpoint to validate WOPI configuration from integrators

### DIFF
--- a/common/Common.hpp
+++ b/common/Common.hpp
@@ -49,6 +49,8 @@ constexpr const char FORKIT_URI[] = "/coolws/forkit";
 
 constexpr const char CAPABILITIES_END_POINT[] = "/hosting/capabilities";
 
+constexpr const char CHECK_END_POINT[] = "/hosting/check";
+
 /// The file suffix used to mark the file slated for uploading.
 constexpr const char TO_UPLOAD_SUFFIX[] = ".upload";
 /// The file suffix used to mark the file being uploaded.

--- a/wsd/RequestDetails.cpp
+++ b/wsd/RequestDetails.cpp
@@ -78,6 +78,7 @@ RequestDetails::RequestDetails(Poco::Net::HTTPRequest &request, const std::strin
     const std::string &method = request.getMethod();
     _isGet = method == "GET";
     _isHead = method == "HEAD";
+    _isPost = method == "POST";
     auto it = request.find("ProxyPrefix");
 	_isProxy = it != request.end();
     if (_isProxy)
@@ -96,6 +97,7 @@ RequestDetails::RequestDetails(Poco::Net::HTTPRequest &request, const std::strin
 RequestDetails::RequestDetails(const std::string &mobileURI)
     : _isGet(true)
     , _isHead(false)
+    , _isPost(false)
     , _isProxy(false)
     , _isWebSocket(false)
 {

--- a/wsd/RequestDetails.hpp
+++ b/wsd/RequestDetails.hpp
@@ -110,6 +110,7 @@ private:
 
     bool _isGet : 1;
     bool _isHead : 1;
+    bool _isPost : 1;
     bool _isProxy : 1;
     bool _isWebSocket : 1;
     bool _isMobile : 1;
@@ -182,6 +183,10 @@ public:
     bool isGet(const char *path) const
     {
         return _isGet && _uriString == path;
+    }
+    bool isPost(const char *path) const
+    {
+        return _isPost && _uriString == path;
     }
     bool isGetOrHead(const char *path) const
     {


### PR DESCRIPTION
* Target version: master 

### Summary

The idea of this is that integrators like Nextcloud can easily verify potential setup issues like Collabora not being able to connect back to the storage during configuration, so that we can give the admin more helpful hints on why the setup is not working properly

### TODO

This is an early draft PR so there might be additional things
- [ ] See if we can avoid duplicate code between the host checks in the check method and actual wopi handling
- [ ] Cleanup code
- [ ] Proper format for the json response

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

