### PR TITLE
calcRTL: dark-overlay incorrectly covers the chart

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -2030,6 +2030,14 @@ L.CanvasTileLayer = L.Layer.extend({
 		var northEastPoint = this._latLngToCorePixels(this._graphicSelection.getNorthEast(), zoom);
 		var southWestPoint = this._latLngToCorePixels(this._graphicSelection.getSouthWest(), zoom);
 
+		if (this.isCalcRTL()) {
+			// Dark overlays (like any other overlay) need regular document coordinates.
+			// But in calc-rtl mode, charts (like shapes) have negative x document coordinate
+			// internal representation.
+			northEastPoint.x = Math.abs(northEastPoint.x);
+			southWestPoint.x = Math.abs(southWestPoint.x);
+		}
+
 		var bounds = new L.Bounds(northEastPoint, southWestPoint);
 
 		this._oleCSelections.setPointSet(CPointSet.fromBounds(bounds));


### PR DESCRIPTION
Dark overlays like any other overlay need regular document coordinates.
But in calc-rtl mode, charts (like shapes) have negative x document
coordinate internal representation.

Before this fix, the CDarkOverlay used to get negative x coordinates
hence the positions of the four dark rectangles were wrong.

Signed-off-by: Dennis Francis <dennis.francis@collabora.com>
Change-Id: Iea3202e2a0c0594cd8f894ee96123a0281cf2f38


* Resolves: # <!-- related github issue -->
* Target version: master 

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

