### PR TITLE
autofilter: fix closing on out-of-popup click

### DIFF
--- a/browser/src/control/Control.AutofilterDropdown.js
+++ b/browser/src/control/Control.AutofilterDropdown.js
@@ -225,7 +225,7 @@ L.Control.AutofilterDropdown = L.Control.extend({
 		this.subMenu = null;
 
 		if (this.builder.windowId)
-			this.builder.callback('button', 'click', {id: 'cancel'}, null, this.builder);
+			this.builder.callback('pushbutton', 'click', {id: 'cancel'}, null, this.builder);
 		this.builder.setWindowId(null);
 		this.subMenuBuilder.setWindowId(null);
 	}


### PR DESCRIPTION
fixes bug:
- open autofilter popup
- click somewhere outside to close it
- try to type something using keyboard to the cell

result: popup closed but cannot type, no jsdialog message about
        autofilter close in the browser console

button is not a valid type in jsdialog executor:
vcl/jsdialog/executor.cxx

