### PR TITLE
wsd: forced exit after cleaning up jails

### DIFF
--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -1328,7 +1328,7 @@ void LOOLWSD::initialize(Application& self)
         {
             // Cleanup and exit.
             JailUtil::cleanupJails(ChildRoot);
-            std::exit(EX_OK);
+            Util::forcedExit(EX_OK);
         }
 #endif
         if (ChildRoot[ChildRoot.size() - 1] != '/')


### PR DESCRIPTION
The static instances cause a lot of grief
when they aren't called in the correct order.
Worse, when we are cleaning up, we don't
even initialize some of them (Admin, for one).
This means that a normal exit will destroy
what isn't created, in some cases (Admin) it
will even force creating instances when we
are destroying others.

This avoid all this by simply exiting bluntly.

Change-Id: I6a9443ca5ab999ed6ca1d27314136472cfc6ddb6
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
