### PR TITLE
Can't open password-protected files

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1029,10 +1029,7 @@ private:
         try
         {
             if (!load(session, renderOpts))
-            {
-                session->sendTextFrameAndLogError("error: cmd=load kind=faileddocloading");
                 return false;
-            }
         }
         catch (const std::exception &exc)
         {

--- a/test/UnitPasswordProtected.cpp
+++ b/test/UnitPasswordProtected.cpp
@@ -54,7 +54,7 @@ UnitBase::TestResult UnitPasswordProtected::testPasswordProtectedDocumentWithout
         // Send a load request without password first
         helpers::sendTextFrame(socket, "load url=" + documentURL);
 
-        const auto response = helpers::getResponseString(socket, "error:", testname);
+        auto response = helpers::getResponseString(socket, "error:", testname);
         StringVector tokens(Util::tokenize(response, ' '));
         LOK_ASSERT_EQUAL(static_cast<size_t>(3), tokens.size());
 
@@ -64,6 +64,9 @@ UnitBase::TestResult UnitPasswordProtected::testPasswordProtectedDocumentWithout
         COOLProtocol::getTokenString(tokens[2], "kind", errorKind);
         LOK_ASSERT_EQUAL(std::string("load"), errorCommand);
         LOK_ASSERT_EQUAL(std::string("passwordrequired:to-view"), errorKind);
+
+        response = helpers::getResponseString(socket, "error:", testname);
+        LOK_ASSERT_MESSAGE("Unexpected second error message", !response.size());
     }
     catch (const Poco::Exception& exc)
     {


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
Reproduction:

    Opening a password protected document gives an error corresponding to
    'faileddocloading' and then a blank file is displayed.
    
Fix:

    Since 0b76383346887fa6fbf732e680a79a8d5e38411b, when Document::load()
    fails without any exception, onLoad() sends
    
    "error: cmd=load kind=faileddocloading"
    
    to the client. This is a problem when load() fails just because the
    client did not provide password for a password protected document.
    Besides for all "exception free cases" load() already sends the correct
    error message(s) to the client. So this patch also avoids sending
    duplicate error messages.

This PR also adds a check for this case in the relevant unit test.

### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

