### PR TITLE
JS btn: fix disabled status

### DIFF
--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -4,10 +4,18 @@
 	text-transform: full-size-kana;
 }
 
+button.jsdialog {
+	color: var(--color-text);
+	background-color: var(--color-background);
+	border: 1px solid var(--color-btn-border);
+	border-radius: var(--border-radius);
+	box-sizing: border-box;
+}
 .jsdialog *[disabled] {
-	color: var(--color-text-lighter) !important;
-	background-color: var(--color-background-lighter) !important;
-	border: 1px solid var(--color-border-lighter) !important;
+	color: var(--color-text-lighter);
+	border: 1px solid var(--color-btn-border-dis);
+	filter: grayscale(1);
+	opacity: 0.7;
 }
 
 .cool-annotation-edit #annotation-cancel,

--- a/browser/css/color-palette.css
+++ b/browser/css/color-palette.css
@@ -28,6 +28,9 @@
 	--color-border-darker: #c0bfbc;  /* hover */
 	--color-border-lighter: #f1f1f1; /* disabled */
 
+	--color-btn-border: #b6b6b6;
+	--color-btn-border-dis: #c0bfbc;
+
 	--color-error: #e9322d;
 	--color-warning: #eca700;
 	--color-success: #46ba61;


### PR DESCRIPTION
With changes from 76121778cac405508839484bae120dfa78a70a61
- We started to overwrite default user agent styles and with it
decreasing the difference between disabled and enabled buttons making it
very difficult to distinguish between the two.
- Also border width was set to different values (disabled btn getting it
from our stylesheet and enabled from browsers styles) causing the btn to
"jump" in size and position when changing between states

Fix those and add new css vars for btns so to avoid mistakes
in the future

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I3ec865ecbbff44c90357d1d6de44a2e6f633bc3f
