### PR TITLE
wsd: use hostname, port and scheme in doc key

### DIFF
--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -204,6 +204,13 @@
             <locking desc="Locking settings">
                 <refresh desc="How frequently we should re-acquire a lock with the storage server, in seconds (default 15 mins) or 0 for no refresh" type="int" default="900">900</refresh>
             </locking>
+
+            <!-- <group>
+                <host desc="hostname to allow or deny." allow="true">hostname</host>
+                <alias>aliasname1</alias>
+                <alias>aliasname2</alias>
+            </group> -->
+
         </wopi>
         <ssl desc="SSL settings">
             <as_scheme type="bool" default="true" desc="When set we exclusively use the WOPI URI's scheme to enable SSL for storage">true</as_scheme>

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -102,6 +102,7 @@ wsd_sources = \
             ../common/Authorization.cpp \
             ../kit/Kit.cpp \
             ../kit/TestStubs.cpp \
+            ../wsd/Storage.cpp \
             ../wsd/FileServerUtil.cpp \
             ../wsd/RequestDetails.cpp \
             ../wsd/TileCache.cpp \

--- a/wsd/RequestDetails.cpp
+++ b/wsd/RequestDetails.cpp
@@ -10,6 +10,7 @@
 #include "COOLWSD.hpp"
 #include "RequestDetails.hpp"
 #include "common/Log.hpp"
+#include "Storage.hpp"
 
 #include <Poco/URI.h>
 #include "Exceptions.hpp"
@@ -283,15 +284,15 @@ Poco::URI RequestDetails::sanitizeURI(const std::string& uri)
 
 std::string RequestDetails::getDocKey(const Poco::URI& uri)
 {
-    // If multiple host-names are used to access us, then
-    // they must be aliases. Permission to access aliased hosts
-    // is checked at the point of accepting incoming connections.
-    // At this point storing the hostname artificially discriminates
-    // between aliases and forces same document (when opened from
-    // alias hosts) to load as separate documents and sharing doesn't
-    // work. Worse, saving overwrites one another.
     std::string docKey;
-    Poco::URI::encode(uri.getPath(), "", docKey);
+    std::string newUri = uri.getPath();
+
+    // resolve aliases
+#if !MOBILEAPP
+    newUri = StorageBase::getNewUri(uri);
+#endif
+
+    Poco::URI::encode(newUri, "", docKey);
     LOG_INF("DocKey from URI [" << uri.toString() << "] => [" << docKey << ']');
     return docKey;
 }

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -330,6 +330,16 @@ public:
 
     static void parseWopiHost(Poco::Util::LayeredConfiguration& conf);
 
+    static void parseAliases(Poco::Util::LayeredConfiguration& conf);
+
+    /// if request uri is an alias, replace request uri host and port with
+    /// original hostname and port defined by group tag from coolwsd.xml
+    /// to avoid possibility of opening the same file as two if the WOPI host
+    /// is accessed using different aliases
+    static std::string getNewUri(const Poco::URI& uri);
+
+    static void addWopiHost(std::string host, bool allow);
+
 protected:
 
     /// Sanitize a URI by removing authorization tokens.
@@ -390,6 +400,12 @@ private:
     static bool SSLEnabled;
     /// Allowed/denied WOPI hosts, if any and if WOPI is enabled.
     static Util::RegexListMatcher WopiHosts;
+    /// mapping of alias host and port to real host and port
+    static std::map<std::string, std::string> AliasHosts;
+    /// When group configuration is not defined only the firstHost gets access
+    static std::string FirstHost;
+    /// This contains all real and aliases host from group configuration
+    static std::set<std::string> AllHosts;
 };
 
 /// Trivial implementation of local storage that does not need do anything.


### PR DESCRIPTION
This allows us to use multiple hosts using same coolwsd instance.

added aliases configuration to coolwsd.xml to avoid
possibility of opening the same file as two if the
WOPI host is accessed using different aliases

Signed-off-by: Rash419 <rashesh.padia@collabora.com>
Change-Id: I32913015c15fd396cecc702b76e0dcaa8bcafad3


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

