### PR TITLE
calc: fix cells become empty after closing sidebar

### DIFF
--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -66,6 +66,14 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 			}
 		}.bind(this));
 
+		// This is called when page size is increased
+		// the content of the cells that become visible may stay empty
+		// unless we have the tiles in the cache already
+		// This will only fetch the tiles which are invalid or does not exist
+		map.on('sizeincreased', function() {
+			this._update();
+		}.bind(this));
+
 		app.sectionContainer.addSection(new app.definitions.AutoFillMarkerSection());
 
 		this.insertMode = false;

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -5195,8 +5195,10 @@ L.CanvasTileLayer = L.Layer.extend({
 					this._map.panTo(cursorPos);
 			}
 
-			if (heightIncreased || widthIncreased)
+			if (heightIncreased || widthIncreased) {
 				this._painter._sectionContainer.requestReDraw();
+				this._map.fire('sizeincreased');
+			}
 		}
 	},
 


### PR DESCRIPTION
this patch not only fixes the issue in the title
also fixes similar problems such as lets say the
browser page is not maximized and then it is decided
to be maximized. This operation normally does trigger redrawing
but it only draws tiles that are in the cache already and does not
trigger tile invalidation and cells can stay empty until something
retriggers tile invalidation again

Signed-off-by: Mert Tumer <mert.tumer@collabora.com>
Change-Id: I5981aa36c77a87626809c92e72e1cd6263826953


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

