### PR TITLE
co-6.4: open templates read-only and do not let export them

### DIFF
--- a/discovery.xml
+++ b/discovery.xml
@@ -9,10 +9,10 @@
             <action name="edit" default="true" ext="fodt"/>
             <!-- Text template documents -->
             <action name="view" default="true" ext="stw"/>
-            <action name="edit" default="true" ext="ott"/>
+            <action name="view" default="true" ext="ott"/>
             <!-- MS Word -->
             <action name="edit" default="true" ext="doc"/>
-            <action name="edit" default="true" ext="dot"/>
+            <action name="view" default="true" ext="dot"/>
             <!-- OOXML wordprocessing -->
             <action name="edit" default="true" ext="docx"/>
             <action name="edit" default="true" ext="docm"/>
@@ -40,7 +40,7 @@
             <action name="view" default="true" ext="sxg"/>
             <action name="edit" default="true" ext="odm"/>
             <!-- Writer master document templates -->
-            <action name="edit" default="true" ext="otm"/>
+            <action name="view" default="true" ext="otm"/>
         </app>
 
         <app name="writer-web">
@@ -54,7 +54,7 @@
             <action name="edit" default="true" ext="fods"/>
             <!-- Spreadsheet template documents -->
             <action name="view" default="true" ext="stc"/>
-            <action name="edit" default="true" ext="ots"/>
+            <action name="view" default="true" ext="ots"/>
             <!-- MS Excel -->
             <action name="edit" default="true" ext="xls"/>
             <action name="edit" default="true" ext="xla"/>
@@ -81,15 +81,15 @@
             <action name="edit" default="true" ext="fodp"/>
             <!-- Presentation template documents -->
             <action name="view" default="true" ext="sti"/>
-            <action name="edit" default="true" ext="otp"/>
+            <action name="view" default="true" ext="otp"/>
             <!-- MS PowerPoint -->
             <action name="edit" default="true" ext="ppt"/>
-            <action name="edit" default="true" ext="pot"/>
+            <action name="view" default="true" ext="pot"/>
             <!-- OOXML presentation -->
             <action name="edit" default="true" ext="pptx"/>
             <action name="edit" default="true" ext="pptm"/>
-            <action name="edit" default="true" ext="potx"/>
-            <action name="edit" default="true" ext="potm"/>
+            <action name="view" default="true" ext="potx"/>
+            <action name="view" default="true" ext="potm"/>
             <action name="edit" default="true" ext="ppsx"/>
             <!-- Others -->
             <action name="view" default="true" ext="cgm"/>
@@ -103,7 +103,7 @@
             <action name="edit" default="true" ext="fodg"/>
             <!-- Drawing template documents -->
             <action name="view" default="true" ext="std"/>
-            <action name="edit" default="true" ext="otg"/>
+            <action name="view" default="true" ext="otg"/>
             <!-- Others -->
             <action name="view" ext="svg"/>
             <action name="view" default="true" ext="dxf"/>
@@ -219,12 +219,12 @@
             <action name="view" default="true" ext=""/>
         </app>
         <app name="application/vnd.oasis.opendocument.text-template">
-            <action name="edit" default="true" ext=""/>
+            <action name="view" default="true" ext=""/>
         </app>
 
         <!-- Writer master document templates -->
         <app name="application/vnd.oasis.opendocument.text-master-template">
-            <action name="edit" default="true" ext=""/>
+            <action name="view" default="true" ext=""/>
         </app>
 
         <!-- Spreadsheet template documents -->
@@ -232,7 +232,7 @@
             <action name="view" default="true" ext=""/>
         </app>
         <app name="application/vnd.oasis.opendocument.spreadsheet-template">
-            <action name="edit" default="true" ext=""/>
+            <action name="view" default="true" ext=""/>
         </app>
 
         <!-- Presentation template documents -->
@@ -240,7 +240,7 @@
             <action name="view" default="true" ext=""/>
         </app>
         <app name="application/vnd.oasis.opendocument.presentation-template">
-            <action name="edit" default="true" ext=""/>
+            <action name="view" default="true" ext=""/>
         </app>
 
         <!-- Drawing template documents -->
@@ -248,7 +248,7 @@
             <action name="view" default="true" ext=""/>
         </app>
         <app name="application/vnd.oasis.opendocument.graphics-template">
-            <action name="edit" default="true" ext=""/>
+            <action name="view" default="true" ext=""/>
         </app>
 
         <!-- MS Word -->
@@ -308,10 +308,10 @@
             <action name="edit" default="true" ext=""/>
         </app>
         <app name="application/vnd.openxmlformats-officedocument.presentationml.template">
-            <action name="edit" default="true" ext=""/>
+            <action name="view" default="true" ext=""/>
         </app>
         <app name="application/vnd.ms-powerpoint.template.macroEnabled.12">
-            <action name="edit" default="true" ext=""/>
+            <action name="view" default="true" ext=""/>
         </app>
 
         <!-- Others -->

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -213,6 +213,15 @@ bool isLocalhost(const std::string& targetHost)
 
 #endif
 
+bool isTemplate(const std::string& filename)
+{
+    std::vector<std::string> templateExtensions {".stw", ".ott", ".dot", ".dotx", ".dotm", ".otm", ".stc", ".ots", ".xltx", ".xltm", ".sti", ".otp", ".potx", ".potm", ".std", ".otg"};
+    for (auto & extension : templateExtensions)
+        if (Util::endsWith(filename, extension))
+            return true;
+    return false;
+}
+
 std::unique_ptr<StorageBase> StorageBase::create(const Poco::URI& uri, const std::string& jailRoot,
                                                  const std::string& jailPath, bool takeOwnership)
 {
@@ -916,6 +925,8 @@ WopiStorage::WOPIFileInfo::WOPIFileInfo(const FileInfo &fileInfo,
     std::string overrideWatermarks = LOOLWSD::getConfigValue<std::string>("watermark.text", "");
     if (!overrideWatermarks.empty())
         _watermarkText = overrideWatermarks;
+    if (isTemplate(filename))
+        _disableExport = true;
 }
 
 bool WopiStorage::updateLockState(const Authorization& auth, const std::string& cookies,


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

