### PR TITLE
mobile: fix fullscreen-presentation does not work on readonly mode

### DIFF
--- a/browser/src/control/Control.Toolbar.js
+++ b/browser/src/control/Control.Toolbar.js
@@ -53,7 +53,8 @@ function onClose() {
 	}
 }
 
-function onClick(e, id, item) {
+function getToolbarItemById(id) {
+	var item;
 	if (w2ui['editbar'].get(id) !== null) {
 		var toolbar = w2ui['editbar'];
 		item = toolbar.get(id);
@@ -69,6 +70,12 @@ function onClick(e, id, item) {
 	else {
 		throw new Error('unknown id: ' + id);
 	}
+	return item;
+}
+
+function onClick(e, id, item) {
+	// dont reassign the item if we already have it
+	item = item || getToolbarItemById(id);
 
 	if (id === 'sidebar' || id === 'modifypage' || id === 'slidechangewindow' || id === 'customanimation' || id === 'masterslidespanel') {
 		window.initSidebarState = true;


### PR DESCRIPTION
we send the slideshow buttons reference to onClick function
in that item.disabled is false but later we reassign it from
w2ui get function and then it becomes disabled true on readonlymode
The logic is incorrect because onClick function does not respect
wheter the item is passed or not and tries to reassign it anyway.

Signed-off-by: Mert Tumer <mert.tumer@collabora.com>
Change-Id: I025e26c455a7673a002f894f49452b360550b178


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

