### PR TITLE
wsd: reduce polling when blocked on ssl handshake

### DIFF
--- a/common/Common.hpp
+++ b/common/Common.hpp
@@ -77,8 +77,11 @@ constexpr const char UPLOADING_SUFFIX[] = "ing";
 /// The HTTP response Server. Used only in Responses.
 #define HTTP_SERVER_STRING "COOLWSD HTTP Server " COOLWSD_VERSION
 
-// The client port number, both coolwsd and the kits have this.
+/// The client port number, both coolwsd and the kits have this.
 extern int ClientPortNumber;
 extern std::string MasterLocation;
+
+/// Controls whether experimental features/behavior is enabled or not.
+extern bool EnableExperimental;
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/common/Unit.cpp
+++ b/common/Unit.cpp
@@ -33,6 +33,9 @@ static std::thread TimeoutThread;
 static std::atomic<bool> TimeoutThreadRunning(false);
 std::timed_mutex TimeoutThreadMutex;
 
+/// Controls whether experimental features/behavior is enabled or not.
+bool EnableExperimental = false;
+
 UnitBase *UnitBase::linkAndCreateUnit(UnitType type, const std::string &unitLibPath)
 {
 #if !MOBILEAPP

--- a/configure.ac
+++ b/configure.ac
@@ -352,6 +352,10 @@ AC_ARG_ENABLE([feature-restriction],
               AS_HELP_STRING([--enable-feature-restriction],
                              [Enable control over which uno-commands/feature to disable completely.]))
 
+AC_ARG_ENABLE([experimental],
+              AS_HELP_STRING([--enable-experimental],
+                             [Enable experimental features and behavior]))
+
 
 # Handle options
 AS_IF([test "$enable_debug" = yes -a -n "$with_poco_libs"],
@@ -369,6 +373,8 @@ COOLWSD_ANONYMIZE_USER_DATA=false
 BROWSER_LOGGING="false"
 debug_msg="secure mode: product build"
 anonym_msg=""
+ENABLE_EXPERIMENTAL=false
+experimental_msg="disabled by default"
 bundle_msg="using uglified bundled JS and CSS"
 LOK_LOG_ASSERTIONS=0
 log_asserts_msg="disabled"
@@ -442,6 +448,12 @@ AC_SUBST(LOK_LOG_ASSERTIONS)
 if test -z "$anonym_msg";  then
   anonym_msg="anonymization of user-data is disabled"
 fi
+
+if test "$enable_experimental" = "yes" ; then
+  ENABLE_EXPERIMENTAL=true
+  experimental_msg="enabled by default"
+fi
+AC_SUBST(ENABLE_EXPERIMENTAL)
 
 # macOS: When configuring for building the app itself, on macOS, we need these.
 # But not when just configuring for building the JS on Linux, for copying over
@@ -1531,6 +1543,7 @@ Configuration:
     LO integration tests      ${lo_msg}
     SSL support               $ssl_msg
     Debug & low security      $debug_msg
+    Experimental features     $experimental_msg
     Test assertion logging    $log_asserts_msg
     Uglification and bundling $bundle_msg
     Anonymization             $anonym_msg

--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -16,6 +16,7 @@
     <server_name desc="External hostname:port of the server running coolwsd. If empty, it's derived from the request (please set it if this doesn't work). May be specified when behind a reverse-proxy or when the hostname is not reachable directly." type="string" default=""></server_name>
     <file_server_root_path desc="Path to the directory that should be considered root for the file server. This should be the directory containing cool." type="path" relative="true" default="browser/../"></file_server_root_path>
     <hexify_embedded_urls desc="Enable to protect encoded URLs from getting decoded by intermediate hops. Particularly useful on Azure deployments" type="bool" default="false"></hexify_embedded_urls>
+    <experimental_features desc="Enable/Disable experimental features" type="bool" default="@ENABLE_EXPERIMENTAL@">@ENABLE_EXPERIMENTAL@</experimental_features>
 
     <memproportion desc="The maximum percentage of system memory consumed by all of the @APP_NAME@, after which we start cleaning up idle documents" type="double" default="80.0"></memproportion>
     <num_prespawn_children desc="Number of child processes to keep started in advance and waiting for new clients." type="uint" default="1">1</num_prespawn_children>

--- a/kit/ForKit.cpp
+++ b/kit/ForKit.cpp
@@ -712,6 +712,7 @@ int main(int argc, char** argv)
     // Parse the configuration.
     const auto conf = std::getenv("COOL_CONFIG");
     config::initialize(std::string(conf ? conf : std::string()));
+    EnableExperimental = config::getBool("experimental_features", false);
 #endif
 
     Util::setThreadName("forkit");

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -1282,11 +1282,13 @@ protected:
         // FIXME: need to close input, but not output (?)
         bool closed = (events & (POLLHUP | POLLERR | POLLNVAL));
 
-        // Always try to read.
-        closed = !readIncomingData() || closed;
-
-        LOG_TRC('#' << getFD() << ": Incoming data buffer " << _inBuffer.size()
-                    << " bytes, closeSocket? " << closed << ", events: " << std::hex << events);
+        if (!EnableExperimental || events & POLLIN)
+        {
+            closed = !readIncomingData() || closed;
+            LOG_TRC('#' << getFD() << " Incoming data buffer " << _inBuffer.size()
+                        << " bytes, closeSocket? " << closed << ", events: " << std::hex << events
+                        << std::dec);
+        }
 
 #ifdef LOG_SOCKET_DATA
         if (!_inBuffer.empty())

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -1387,6 +1387,7 @@ void COOLWSD::innerInitialize(Application& self)
         { "child_root_path", "jails" },
         { "file_server_root_path", "browser/.." },
         { "hexify_embedded_urls", "false" },
+        { "experimental_features", "false" },
         { "lo_jail_subpath", "lo" },
         { "logging.protocol", "false" },
         { "logging.anonymize.filenames", "false" }, // Deprecated.
@@ -1543,6 +1544,9 @@ void COOLWSD::innerInitialize(Application& self)
 
     // Allow UT to manipulate before using configuration values.
     UnitWSD::get().configure(config());
+
+    // Experimental features.
+    EnableExperimental = getConfigValue<bool>(conf, "experimental_features", false);
 
     // Setup user interface mode
     UserInterface = getConfigValue<std::string>(conf, "user_interface.mode", "default");


### PR DESCRIPTION
While SSL is handshaking, there can be no general
application data communication. During that early
stage of connecting we have data to send (the
request, headers, etc.) and so we poll on POLLOUT.
Naturally, we also always want to poll on POLLIN,
because we can never know when there is data to
read (especially true for web-sockets).

The problem is when SSL will not send data just
yet because it is handshaking. It is typically
waiting for handshake negotiation data to read,
so when we POLLOUT, poll immediately returns, but
writing (via SSL_write) fails with WANTS_READ
error. This goes on in a busy-loop until the
negotiation data is available for read and the
handshake is completed. Very inefficient.

The solution is to poll on whatever SSL needs
during the handshake, exclusively. Once the
handshake is complete, we poll on whatever we
need. However, SSL can renegotiate at any time,
so we also merge with what it needs.

In addition, we avoid the unnecessary read when
poll doesn't give us POLLIN in revents, since the
read will more likely than not fail (except in
the rare case when data becomes available in the
interim). Notice that SSL_read will return
SSL_WANTS_READ when there is no data, which
is misleading (since SSL isn't in need of data to
read at all, nor are we, for that matter).
Best not to do noisy reads unnecessarily.

Change-Id: I6a7ed7d871ed257b30062cc720a8b8c7acbab3b7
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
