### PR TITLE
Add back removed breaks from TopToolbar, see #3184

### DIFF
--- a/browser/src/control/Control.TopToolbar.js
+++ b/browser/src/control/Control.TopToolbar.js
@@ -97,6 +97,7 @@ L.Control.TopToolbar = L.Control.extend({
 			{type: 'button',  id: 'formatpaintbrush',  img: 'copyformat', hint: _UNO('.uno:FormatPaintbrush'), uno: '.uno:FormatPaintbrush', mobile: false},
 			{type: 'button',  id: 'reset',  img: 'deleteformat', hint: _UNO('.uno:ResetAttributes', 'text'), hidden: true, uno: '.uno:ResetAttributes', mobile: false},
 			{type: 'button',  id: 'resetimpress',  img: 'deleteformat', hint: _UNO('.uno:SetDefault', 'presentation', 'true'), hidden: true, uno: '.uno:SetDefault', mobile: false},
+			{type: 'break', id: 'breakreset', mobile: false, tablet: false,},
 			{type: 'html', id: 'styles',
 				html: '<select id="styles-select" class="styles-select"><option>' + _('Default Style') + '</option></select>',
 				onRefresh: function (edata) {
@@ -131,6 +132,7 @@ L.Control.TopToolbar = L.Control.extend({
 						}});
 					}
 				}, mobile: false},
+			{type: 'break', id: 'breakfontsizes', mobile: false, tablet: false,},
 			{type: 'button', id: 'languagecode', desktop: false, mobile: true, tablet: false},
 			{type: 'button',  id: 'bold',  img: 'bold', hint: _UNO('.uno:Bold'), uno: '.uno:Bold'},
 			{type: 'button',  id: 'italic', img: 'italic', hint: _UNO('.uno:Italic'), uno: '.uno:Italic'},


### PR DESCRIPTION
Breaks were removed in commit df925222a2c4ce94024b8df7eeb0d014e2d82271

Signed-off-by: Kristopher Maxwell <kristophermaxwellc@gmail.com>
Change-Id: I376207d654ccbe98fc1d1b4b84363748190ab646


* Resolves: # 3184
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

