### PR TITLE
Private/pedro/fix annotation btns

### DIFF
--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -31,14 +31,6 @@ button.jsdialog {
 .ui-button-box.autofilter #cancel,
 .cell.jsdialog > button:not(#ok),
 .ui-button-box.jsdialog button:not(#ok),
-.jsdialog-container #source-button,
-.jsdialog-container #destination-button,
-.jsdialog-container #refbutton,
-.jsdialog-container #assign,
-.jsdialog-container #input-range-button,
-.jsdialog-container #output-range-button,
-.jsdialog-container #variable1-range-button,
-.jsdialog-container #variable2-range-button,
 .vex.vex-theme-plain .vex-dialog-button.vex-dialog-button-secondary {
 	height: 32px;
 	line-height: 0em;
@@ -58,14 +50,6 @@ button.jsdialog {
 .ui-button-box.autofilter #cancel:hover,
 .cell.jsdialog > button:not(#ok):hover,
 .ui-button-box.jsdialog button:not(#ok):hover,
-.jsdialog-container #source-button:hover,
-.jsdialog-container #destination-button:hover,
-.jsdialog-container #refbutton:hover,
-.jsdialog-container #assign:hover,
-.jsdialog-container #input-range-button:hover,
-.jsdialog-container #output-range-button:hover,
-.jsdialog-container #variable1-range-button:hover,
-.jsdialog-container #variable2-range-button:hover,
 .vex.vex-theme-plain .vex-dialog-button.vex-dialog-button-secondary:hover {
 	cursor: pointer;
 	color: var(--color-text-darker) !important;

--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -25,7 +25,7 @@ button.jsdialog {
 	justify-content: end;
 }
 
-.cool-annotation-edit #annotation-cancel,
+.cool-annotation-edit [id^='annotation-cancel'],
 .ui-pushbutton.jsdialog:not(#ok):not([id*='select_current']):not(.sidebar),
 .ui-button-box.jsdialog #cancel,
 .ui-button-box.autofilter #cancel,
@@ -52,7 +52,7 @@ button.jsdialog {
 	vertical-align: middle;
 }
 
-.cool-annotation-edit #annotation-cancel:hover,
+.cool-annotation-edit [id^='annotation-cancel']:hover,
 .ui-pushbutton.jsdialog:not(#ok):not(.sidebar):hover,
 .ui-button-box.jsdialog #cancel:hover,
 .ui-button-box.autofilter #cancel:hover,

--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -18,6 +18,13 @@ button.jsdialog {
 	opacity: 0.7;
 }
 
+.annotation-btns-container,
+.vex-dialog-buttons {
+	display: flex;
+	flex-direction: row;
+	justify-content: end;
+}
+
 .cool-annotation-edit #annotation-cancel,
 .ui-pushbutton.jsdialog:not(#ok):not([id*='select_current']):not(.sidebar),
 .ui-button-box.jsdialog #cancel,
@@ -43,9 +50,6 @@ button.jsdialog {
 	border-radius: var(--border-radius);
 	margin: 5px;
 	vertical-align: middle;
-	display: flex;
-	align-items: center;
-	justify-content: center;
 }
 
 .cool-annotation-edit #annotation-cancel:hover,

--- a/browser/css/device-mobile.css
+++ b/browser/css/device-mobile.css
@@ -379,16 +379,12 @@ button.vex-dialog-button-secondary.vex-dialog-button.vex-last {
 	min-height: 24px !important;
 }
 
-.vex-content.vex-3btns .vex-dialog-buttons {
+.vex-dialog-buttons {
 	flex-direction: column !important;
 }
 
 .vex-close:not(.vex-close-m) {
 	display: none;
-}
-
-.vex-content.vex-3btns .vex-dialog-buttons .vex-dialog-button-cancel {
-	display: block !important;
 }
 
 /* Related to toolbar.css */

--- a/browser/src/layer/tile/CommentSection.ts
+++ b/browser/src/layer/tile/CommentSection.ts
@@ -119,7 +119,7 @@ class Comment {
 		if (!force && !this.convertRectanglesToCoreCoordinates())
 			return;
 
-		var button = L.DomUtil.create('div', '', this.sectionProperties.nodeModify);
+		var button = L.DomUtil.create('div', 'annotation-btns-container', this.sectionProperties.nodeModify);
 		L.DomEvent.on(this.sectionProperties.nodeModifyText, 'blur', this.onLostFocus, this);
 		L.DomEvent.on(this.sectionProperties.nodeReplyText, 'blur', this.onLostFocusReply, this);
 		this.createButton(button, 'annotation-cancel-' + this.sectionProperties.data.id, _('Cancel'), this.onCancelClick);


### PR DESCRIPTION
commit 9eb3f385b4a36d8da3ce517da9d11fd2e93b108b
Author: Pedro Pinto Silva <pedro.silva@collabora.com>
Date:   Thu Mar 17 11:05:08 2022 +0100

    Buttons: Remove unnecessary CSS on calc
    
    Many of those CSS rules were added in the past where not all main btns
    had the same class.
    
    All of those are now generated and stamped with
    `.ui-pushbutton` class. Thus we can now remove those very specific
    and outdated rules.
    
    imgs:
    https://archive.org/download/cool-github-commit-imgs/statistics-dailog-define-name-pushbutton.png
    https://archive.org/download/cool-github-commit-imgs/statistics-dailog-ftest-pushbutton.png
    https://archive.org/download/cool-github-commit-imgs/statistics-dailog-manage-names-pushbutton.png
    https://archive.org/download/cool-github-commit-imgs/statistics-dailog-sampling-pushbutton.png
    
    Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
    Change-Id: Ief0211c2825c23f113fccb88e1ce6fea59d1500c

commit 96a777277368fd2a23f39c710b99f0f677dddac1
Author: Pedro Pinto Silva <pedro.silva@collabora.com>
Date:   Thu Mar 17 10:03:15 2022 +0100

    Simplify CSS for vex btns on mobile, flex
    
    Now with changes from 451d11ebacaa72307ea6b70c57a83544cbd65ce5
    change-id: Ia4ab1de407ca7658242282181eeb215fb6dc0d99 we can now safely
    target all the vex buttons for mobile without exception
    
    Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
    Change-Id: I660463733fa9e6ce8feb46a08e9217f7c9f414da

commit fe3c973cf63ce49a4d68639cef107db09d5b7c5c
Author: Pedro Pinto Silva <pedro.silva@collabora.com>
Date:   Thu Mar 17 10:02:07 2022 +0100

    Target all buttons, fix mixed display properties
    
    Now with annotations btns being created with new ids it's crucial to
    make sure we target them all
    
    Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
    Change-Id: I8c2dc9d0a088290fa0c2b9b3cbf83ee2f7d0dd76

commit 451d11ebacaa72307ea6b70c57a83544cbd65ce5
Author: Pedro Pinto Silva <pedro.silva@collabora.com>
Date:   Wed Mar 16 12:13:30 2022 +0100

    Annotations: Fix cancel confirm btns flex CSS and add class for container
    
    This affects annotations (vex) and jsdialogs
    
    - Set annotations btns' container to flex so we can reduce CSS rules
    around specific buttons
    
    ----
    
    Before we were relying solely on cancel button to change the layout,
    by setting it to flex and let ok/submit/confirm btn untouched. This
    was causing some inconsistencies plus it was forcing us to add CSS on a
    case by case instead of fixing the root cause
    
    Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
    Change-Id: Ia4ab1de407ca7658242282181eeb215fb6dc0d99
