### PR TITLE
Welcome message related configuration options

### DIFF
--- a/browser/html/cool.html.m4
+++ b/browser/html/cool.html.m4
@@ -303,7 +303,6 @@ m4_ifelse(MOBILEAPP,[true],
       window.accessHeader = '';
       window.postMessageOriginExt = '';
       window.coolLogging = 'true';
-      window.enableWelcomeMessage = false;
       window.wecolmeCustom = null;
       window.outOfFocusTimeoutSecs = 1000000;
       window.idleTimeoutSecs = 1000000;
@@ -323,7 +322,6 @@ m4_ifelse(MOBILEAPP,[true],
       window.postMessageOriginExt = '%POSTMESSAGE_ORIGIN%';
       window.coolLogging = '%BROWSER_LOGGING%';
       window.coolwsdVersion = '%COOLWSD_VERSION%';
-      window.enableWelcomeMessage = %ENABLE_WELCOME_MSG%;
       window.wecolmeCustom = '%WELCOME_CUSTOM%';
       window.userInterfaceMode = '%USER_INTERFACE_MODE%';
       window.useIntegrationTheme = '%USE_INTEGRATION_THEME%';

--- a/browser/html/cool.html.m4
+++ b/browser/html/cool.html.m4
@@ -304,7 +304,6 @@ m4_ifelse(MOBILEAPP,[true],
       window.postMessageOriginExt = '';
       window.coolLogging = 'true';
       window.enableWelcomeMessage = false;
-      window.enableWelcomeMessageButton = false;
       window.outOfFocusTimeoutSecs = 1000000;
       window.idleTimeoutSecs = 1000000;
       window.protocolDebug = false;
@@ -324,7 +323,6 @@ m4_ifelse(MOBILEAPP,[true],
       window.coolLogging = '%BROWSER_LOGGING%';
       window.coolwsdVersion = '%COOLWSD_VERSION%';
       window.enableWelcomeMessage = %ENABLE_WELCOME_MSG%;
-      window.enableWelcomeMessageButton = %ENABLE_WELCOME_MSG_BTN%;
       window.userInterfaceMode = '%USER_INTERFACE_MODE%';
       window.useIntegrationTheme = '%USE_INTEGRATION_THEME%';
       window.enableMacrosExecution = '%ENABLE_MACROS_EXECUTION%';

--- a/browser/html/cool.html.m4
+++ b/browser/html/cool.html.m4
@@ -304,6 +304,7 @@ m4_ifelse(MOBILEAPP,[true],
       window.postMessageOriginExt = '';
       window.coolLogging = 'true';
       window.enableWelcomeMessage = false;
+      window.wecolmeCustom = null;
       window.outOfFocusTimeoutSecs = 1000000;
       window.idleTimeoutSecs = 1000000;
       window.protocolDebug = false;
@@ -323,6 +324,7 @@ m4_ifelse(MOBILEAPP,[true],
       window.coolLogging = '%BROWSER_LOGGING%';
       window.coolwsdVersion = '%COOLWSD_VERSION%';
       window.enableWelcomeMessage = %ENABLE_WELCOME_MSG%;
+      window.wecolmeCustom = '%WELCOME_CUSTOM%';
       window.userInterfaceMode = '%USER_INTERFACE_MODE%';
       window.useIntegrationTheme = '%USE_INTEGRATION_THEME%';
       window.enableMacrosExecution = '%ENABLE_MACROS_EXECUTION%';

--- a/browser/src/map/handler/Map.Welcome.js
+++ b/browser/src/map/handler/Map.Welcome.js
@@ -14,7 +14,11 @@ L.Map.Welcome = L.Handler.extend({
 		L.Handler.prototype.initialize.call(this, map);
 		this._map.on('statusindicator', this.onStatusIndicator, this);
 
-		this._url = window.feedbackLocation.replace(/Rate\/feedback.html/g, 'Welcome/welcome.html');
+		if (window.wecolmeCustom)
+			this._url = window.wecolmeCustom;
+		else
+			this._url = window.feedbackLocation.replace(/Rate\/feedback.html/g, 'Welcome/welcome.html');
+
 		this._retries = 2;
 		this._fallback = false;
 	},

--- a/browser/src/map/handler/Map.Welcome.js
+++ b/browser/src/map/handler/Map.Welcome.js
@@ -118,7 +118,7 @@ L.Map.Welcome = L.Handler.extend({
 	}
 });
 
-if (window.enableWelcomeMessage && window.feedbackLocation && window.isLocalStorageAllowed) {
+if (window.feedbackLocation && window.isLocalStorageAllowed) {
 	L.Map.addInitHook('addHandler', 'welcome', L.Map.Welcome);
 }
 

--- a/browser/test/load.js
+++ b/browser/test/load.js
@@ -79,7 +79,6 @@ data = data.replace(/%ACCESS_HEADER%/g, '');
 data = data.replace(/%BROWSER_LOGGING%/g, 'true');
 data = data.replace(/%ENABLE_WELCOME_MSG%/g, 'false');
 data = data.replace(/%ENABLE_WELCOME_MSG%/g, 'false');
-data = data.replace(/%ENABLE_WELCOME_MSG_BTN%/g, 'false');
 data = data.replace(/%USER_INTERFACE_MODE%/g, '');
 data = data.replace(/%USE_INTEGRATION_THEME%/g, 'true');
 data = data.replace(/%OUT_OF_FOCUS_TIMEOUT_SECS%/g, '1000000');

--- a/configure.ac
+++ b/configure.ac
@@ -290,10 +290,6 @@ AC_ARG_WITH([feedback-location],
             AS_HELP_STRING([--with-feedback-location=<url>],
                            [User feedback URL location. Default to http://127.0.0.1:8000/Rate/feedback.html]))
 
-AC_ARG_WITH([welcome-location],
-            AS_HELP_STRING([--with-welcome-location=<url>],
-                           [User welcome dialog URL location.]))
-
 AC_ARG_ENABLE(feedback,
     AS_HELP_STRING([--enable-feedback],
         [Enables feedback, user rating.])
@@ -787,15 +783,6 @@ AC_DEFINE_UNQUOTED([ENABLE_FEEDBACK],["$ENABLE_FEEDBACK"],[User feedback rating]
 AC_DEFINE_UNQUOTED([FEEDBACK_LOCATION],["$FEEDBACK_LOCATION"],[User feedback URL location])
 AC_SUBST(ENABLE_FEEDBACK)
 AM_CONDITIONAL([ENABLE_FEEDBACK], [test "$ENABLE_FEEDBACK" = "true"])
-
-WELCOME_LOCATION=
-
-if test -n "$with_welcome_location"; then
-    WELCOME_LOCATION=$with_welcome_location
-fi
-
-AC_DEFINE_UNQUOTED([WELCOME_LOCATION],["$WELCOME_LOCATION"],[User welcome dialog URL location])
-AC_SUBST(WELCOME_LOCATION)
 
 VEREIGN_URL=
 if test "$enable_vereign" = "yes"; then

--- a/configure.ac
+++ b/configure.ac
@@ -771,7 +771,7 @@ AS_IF([test "$MAX_DOCUMENTS" -lt "2"],
 AC_DEFINE_UNQUOTED([MAX_DOCUMENTS],[$MAX_DOCUMENTS],[Limit the maximum number of open documents])
 AC_SUBST(MAX_DOCUMENTS)
 
-ENABLE_WELCOME_MESSAGE=false
+ENABLE_WELCOME_MESSAGE="false"
 AS_IF([test "$enable_welcome_message" = "yes"],
       [ENABLE_WELCOME_MESSAGE="true"])
 AC_DEFINE_UNQUOTED([ENABLE_WELCOME_MESSAGE],["$ENABLE_WELCOME_MESSAGE"],[Should the Release notes message on startup be enabled by default?])

--- a/configure.ac
+++ b/configure.ac
@@ -294,11 +294,6 @@ AC_ARG_WITH([welcome-location],
             AS_HELP_STRING([--with-welcome-location=<url>],
                            [User welcome dialog URL location.]))
 
-AC_ARG_ENABLE(welcome-message,
-    AS_HELP_STRING([--enable-welcome-message],
-        [Enables welcome message on version update. Can be changed later in coolwsd.xml.])
-)
-
 AC_ARG_ENABLE(feedback,
     AS_HELP_STRING([--enable-feedback],
         [Enables feedback, user rating.])
@@ -774,12 +769,6 @@ AS_IF([test "$MAX_DOCUMENTS" -lt "2"],
       [MAX_DOCUMENTS="2"])
 AC_DEFINE_UNQUOTED([MAX_DOCUMENTS],[$MAX_DOCUMENTS],[Limit the maximum number of open documents])
 AC_SUBST(MAX_DOCUMENTS)
-
-ENABLE_WELCOME_MESSAGE="false"
-AS_IF([test "$enable_welcome_message" = "yes"],
-      [ENABLE_WELCOME_MESSAGE="true"])
-AC_DEFINE_UNQUOTED([ENABLE_WELCOME_MESSAGE],["$ENABLE_WELCOME_MESSAGE"],[Should the Release notes message on startup be enabled by default?])
-AC_SUBST(ENABLE_WELCOME_MESSAGE)
 
 ENABLE_FEEDBACK=
 FEEDBACK_LOCATION=

--- a/configure.ac
+++ b/configure.ac
@@ -795,12 +795,6 @@ AC_DEFINE_UNQUOTED([FEEDBACK_LOCATION],["$FEEDBACK_LOCATION"],[User feedback URL
 AC_SUBST(ENABLE_FEEDBACK)
 AM_CONDITIONAL([ENABLE_FEEDBACK], [test "$ENABLE_FEEDBACK" = "true"])
 
-ENABLE_WELCOME_MESSAGE_BUTTON=false
-AS_IF([test "$enable_welcome_message_button" = "yes"],
-      [ENABLE_WELCOME_MESSAGE_BUTTON="true"])
-AC_DEFINE_UNQUOTED([ENABLE_WELCOME_MESSAGE_BUTTON],["$ENABLE_WELCOME_MESSAGE_BUTTON"],[Should the Release notes message on startup should have a dismiss button instead of an x button to close by default?])
-AC_SUBST(ENABLE_WELCOME_MESSAGE_BUTTON)
-
 VEREIGN_URL=
 if test "$enable_vereign" = "yes"; then
     VEREIGN_URL="https://app.vereign.com"

--- a/configure.ac
+++ b/configure.ac
@@ -290,6 +290,10 @@ AC_ARG_WITH([feedback-location],
             AS_HELP_STRING([--with-feedback-location=<url>],
                            [User feedback URL location. Default to http://127.0.0.1:8000/Rate/feedback.html]))
 
+AC_ARG_WITH([welcome-location],
+            AS_HELP_STRING([--with-welcome-location=<url>],
+                           [User welcome dialog URL location.]))
+
 AC_ARG_ENABLE(welcome-message,
     AS_HELP_STRING([--enable-welcome-message],
         [Enables welcome message on version update. Can be changed later in coolwsd.xml.])
@@ -794,6 +798,15 @@ AC_DEFINE_UNQUOTED([ENABLE_FEEDBACK],["$ENABLE_FEEDBACK"],[User feedback rating]
 AC_DEFINE_UNQUOTED([FEEDBACK_LOCATION],["$FEEDBACK_LOCATION"],[User feedback URL location])
 AC_SUBST(ENABLE_FEEDBACK)
 AM_CONDITIONAL([ENABLE_FEEDBACK], [test "$ENABLE_FEEDBACK" = "true"])
+
+WELCOME_LOCATION=
+
+if test -n "$with_welcome_location"; then
+    WELCOME_LOCATION=$with_welcome_location
+fi
+
+AC_DEFINE_UNQUOTED([WELCOME_LOCATION],["$WELCOME_LOCATION"],[User welcome dialog URL location])
+AC_SUBST(WELCOME_LOCATION)
 
 VEREIGN_URL=
 if test "$enable_vereign" = "yes"; then

--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -180,7 +180,7 @@
     </watermark>
 
     <welcome>
-
+      <!-- <custom desc="Custom Welcome URI">http://custom.com/welcome.html</custom> -->
     </welcome>
 
     <user_interface>

--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -179,10 +179,6 @@
       <text desc="Watermark text to be displayed on the document if entered" type="string"></text>
     </watermark>
 
-    <welcome>
-      <!-- <custom desc="Custom Welcome URI">http://custom.com/welcome.html</custom> -->
-    </welcome>
-
     <user_interface>
       <mode type="string" desc="Controls the user interface style. The 'default' means: Take the value from ui_defaults, or decide for one of classic or notebookbar (default|classic|notebookbar)" default="default">default</mode>
       <use_integration_theme desc="Use theme from the integrator" type="bool" default="true">true</use_integration_theme>

--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -181,7 +181,6 @@
 
     <welcome>
       <enable type="bool" desc="Controls whether the welcome screen should be shown to the users on new install and updates." default="@ENABLE_WELCOME_MESSAGE@">@ENABLE_WELCOME_MESSAGE@</enable>
-      <enable_button type="bool" desc="Controls whether the welcome screen should have an explanatory button instead of an X button to close the dialog." default="@ENABLE_WELCOME_MESSAGE_BUTTON@">@ENABLE_WELCOME_MESSAGE_BUTTON@</enable_button>
       <path desc="Path to 'welcome-$lang.html' files served on first start or when the version changes. When empty, defaults to the Release notes." type="path" relative="true" default="browser/welcome"></path>
     </welcome>
 

--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -179,6 +179,10 @@
       <text desc="Watermark text to be displayed on the document if entered" type="string"></text>
     </watermark>
 
+    <welcome>
+      <!-- <custom desc="Custom Welcome URI">http://custom.com/welcome.html</custom> -->
+    </welcome>
+
     <user_interface>
       <mode type="string" desc="Controls the user interface style. The 'default' means: Take the value from ui_defaults, or decide for one of classic or notebookbar (default|classic|notebookbar)" default="default">default</mode>
       <use_integration_theme desc="Use theme from the integrator" type="bool" default="true">true</use_integration_theme>

--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -180,7 +180,6 @@
     </watermark>
 
     <welcome>
-      <enable type="bool" desc="Controls whether the welcome screen should be shown to the users on new install and updates." default="@ENABLE_WELCOME_MESSAGE@">@ENABLE_WELCOME_MESSAGE@</enable>
       <path desc="Path to 'welcome-$lang.html' files served on first start or when the version changes. When empty, defaults to the Release notes." type="path" relative="true" default="browser/welcome"></path>
     </welcome>
 

--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -180,7 +180,7 @@
     </watermark>
 
     <welcome>
-      <path desc="Path to 'welcome-$lang.html' files served on first start or when the version changes. When empty, defaults to the Release notes." type="path" relative="true" default="browser/welcome"></path>
+
     </welcome>
 
     <user_interface>

--- a/ios/config.h.in
+++ b/ios/config.h.in
@@ -23,10 +23,6 @@
    */
 #define ENABLE_WELCOME_MESSAGE "false"
 
-/* Should the Release notes message on startup have a dismiss button instead of an x button to close by default?
-   */
-#define ENABLE_WELCOME_MESSAGE_BUTTON "false"
-
 /* Define to 1 if you have the <dlfcn.h> header file. */
 #define HAVE_DLFCN_H 0
 

--- a/ios/config.h.in
+++ b/ios/config.h.in
@@ -19,10 +19,6 @@
 /* Whether to enable support key */
 #define ENABLE_SUPPORT_KEY 0
 
-/* Should the Release notes message on startup should be enabled be default?
-   */
-#define ENABLE_WELCOME_MESSAGE "false"
-
 /* Define to 1 if you have the <dlfcn.h> header file. */
 #define HAVE_DLFCN_H 0
 

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -1476,7 +1476,6 @@ void COOLWSD::innerInitialize(Application& self)
         { "trace.path[@snapshot]", "false" },
         { "trace[@enable]", "false" },
         { "welcome.enable", ENABLE_WELCOME_MESSAGE },
-        { "welcome.enable_button", ENABLE_WELCOME_MESSAGE_BUTTON },
         { "welcome.path", "browser/welcome" },
 #ifdef ENABLE_FEATURE_LOCK
         { "feature_lock.locked_hosts[@allow]", "false"},

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -1843,6 +1843,22 @@ void COOLWSD::innerInitialize(Application& self)
         Quarantine::createQuarantineMap();
     }
 
+    try
+    {
+        if (conf.hasProperty("welcome.custom"))
+        {
+            Poco::URI customURI(conf.getString("welcome.custom"));
+            if (customURI.getAuthority().empty())
+                throw Poco::Exception("Invalid Host:Port");
+
+            conf.setString("welcome.authority", customURI.getAuthority());
+        }
+    }
+    catch (const Poco::Exception& exc)
+    {
+        LOG_WRN("Invalid: " << exc.displayText());
+        conf.remove("welcome.custom");
+    }
 
     NumPreSpawnedChildren = getConfigValue<int>(conf, "num_prespawn_children", 1);
     if (NumPreSpawnedChildren < 1)

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -866,7 +866,6 @@ std::string COOLWSD::LoTemplate = LO_PATH;
 std::string COOLWSD::ChildRoot;
 std::string COOLWSD::ServerName;
 std::string COOLWSD::FileServerRoot;
-std::string COOLWSD::WelcomeFilesRoot;
 std::string COOLWSD::ServiceRoot;
 std::string COOLWSD::LOKitVersion;
 std::string COOLWSD::ConfigFile = COOLWSD_CONFIGDIR "/coolwsd.xml";
@@ -1475,7 +1474,6 @@ void COOLWSD::innerInitialize(Application& self)
         { "trace.path[@compress]", "true" },
         { "trace.path[@snapshot]", "false" },
         { "trace[@enable]", "false" },
-        { "welcome.path", "browser/welcome" },
 #ifdef ENABLE_FEATURE_LOCK
         { "feature_lock.locked_hosts[@allow]", "false"},
         { "feature_lock.locked_hosts.fallback[@read_only]", "false"},
@@ -1845,9 +1843,6 @@ void COOLWSD::innerInitialize(Application& self)
         Quarantine::createQuarantineMap();
     }
 
-    WelcomeFilesRoot = getPathFromConfig("welcome.path");
-    if (!getConfigValue<bool>(conf, "welcome.enable", true))
-        WelcomeFilesRoot = "";
 
     NumPreSpawnedChildren = getConfigValue<int>(conf, "num_prespawn_children", 1);
     if (NumPreSpawnedChildren < 1)
@@ -4396,7 +4391,6 @@ public:
            << "\n  LoTemplate: " << COOLWSD::LoTemplate
            << "\n  ChildRoot: " << COOLWSD::ChildRoot
            << "\n  FileServerRoot: " << COOLWSD::FileServerRoot
-           << "\n  WelcomeFilesRoot: " << COOLWSD::WelcomeFilesRoot
            << "\n  ServiceRoot: " << COOLWSD::ServiceRoot
            << "\n  LOKitVersion: " << COOLWSD::LOKitVersion
            << "\n  HostIdentifier: " << Util::getProcessIdentifier()

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -866,8 +866,6 @@ std::string COOLWSD::LoTemplate = LO_PATH;
 std::string COOLWSD::ChildRoot;
 std::string COOLWSD::ServerName;
 std::string COOLWSD::FileServerRoot;
-std::string COOLWSD::WelcomeLocation;
-std::string COOLWSD::WelcomeAuthority;
 std::string COOLWSD::ServiceRoot;
 std::string COOLWSD::LOKitVersion;
 std::string COOLWSD::ConfigFile = COOLWSD_CONFIGDIR "/coolwsd.xml";
@@ -1847,16 +1845,19 @@ void COOLWSD::innerInitialize(Application& self)
 
     try
     {
-        Poco::URI customURI(WELCOME_LOCATION);
-        if (customURI.getAuthority().empty())
-            throw Poco::Exception("Invalid Host:Port");
+        if (conf.hasProperty("welcome.custom"))
+        {
+            Poco::URI customURI(conf.getString("welcome.custom"));
+            if (customURI.getAuthority().empty())
+                throw Poco::Exception("Invalid Host:Port");
 
-        WelcomeLocation = customURI.toString();
-        WelcomeAuthority = customURI.getAuthority();
+            conf.setString("welcome.authority", customURI.getAuthority());
+        }
     }
     catch (const Poco::Exception& exc)
     {
         LOG_WRN("Invalid: " << exc.displayText());
+        conf.remove("welcome.custom");
     }
 
     NumPreSpawnedChildren = getConfigValue<int>(conf, "num_prespawn_children", 1);

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -1475,7 +1475,6 @@ void COOLWSD::innerInitialize(Application& self)
         { "trace.path[@compress]", "true" },
         { "trace.path[@snapshot]", "false" },
         { "trace[@enable]", "false" },
-        { "welcome.enable", ENABLE_WELCOME_MESSAGE },
         { "welcome.path", "browser/welcome" },
 #ifdef ENABLE_FEATURE_LOCK
         { "feature_lock.locked_hosts[@allow]", "false"},

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -866,6 +866,8 @@ std::string COOLWSD::LoTemplate = LO_PATH;
 std::string COOLWSD::ChildRoot;
 std::string COOLWSD::ServerName;
 std::string COOLWSD::FileServerRoot;
+std::string COOLWSD::WelcomeLocation;
+std::string COOLWSD::WelcomeAuthority;
 std::string COOLWSD::ServiceRoot;
 std::string COOLWSD::LOKitVersion;
 std::string COOLWSD::ConfigFile = COOLWSD_CONFIGDIR "/coolwsd.xml";
@@ -1845,19 +1847,16 @@ void COOLWSD::innerInitialize(Application& self)
 
     try
     {
-        if (conf.hasProperty("welcome.custom"))
-        {
-            Poco::URI customURI(conf.getString("welcome.custom"));
-            if (customURI.getAuthority().empty())
-                throw Poco::Exception("Invalid Host:Port");
+        Poco::URI customURI(WELCOME_LOCATION);
+        if (customURI.getAuthority().empty())
+            throw Poco::Exception("Invalid Host:Port");
 
-            conf.setString("welcome.authority", customURI.getAuthority());
-        }
+        WelcomeLocation = customURI.toString();
+        WelcomeAuthority = customURI.getAuthority();
     }
     catch (const Poco::Exception& exc)
     {
         LOG_WRN("Invalid: " << exc.displayText());
-        conf.remove("welcome.custom");
     }
 
     NumPreSpawnedChildren = getConfigValue<int>(conf, "num_prespawn_children", 1);

--- a/wsd/COOLWSD.hpp
+++ b/wsd/COOLWSD.hpp
@@ -249,8 +249,6 @@ public:
     static std::string ChildRoot;
     static std::string ServerName;
     static std::string FileServerRoot;
-    static std::string WelcomeLocation;
-    static std::string WelcomeAuthority;
     static std::string ServiceRoot; ///< There are installations that need prefixing every page with some path.
     static std::string LOKitVersion;
     static bool EnableTraceEventLogging;

--- a/wsd/COOLWSD.hpp
+++ b/wsd/COOLWSD.hpp
@@ -249,7 +249,6 @@ public:
     static std::string ChildRoot;
     static std::string ServerName;
     static std::string FileServerRoot;
-    static std::string WelcomeFilesRoot; ///< From where we should serve the release notes (or otherwise useful content) that is shown on first install or version update.
     static std::string ServiceRoot; ///< There are installations that need prefixing every page with some path.
     static std::string LOKitVersion;
     static bool EnableTraceEventLogging;

--- a/wsd/COOLWSD.hpp
+++ b/wsd/COOLWSD.hpp
@@ -249,6 +249,8 @@ public:
     static std::string ChildRoot;
     static std::string ServerName;
     static std::string FileServerRoot;
+    static std::string WelcomeLocation;
+    static std::string WelcomeAuthority;
     static std::string ServiceRoot; ///< There are installations that need prefixing every page with some path.
     static std::string LOKitVersion;
     static bool EnableTraceEventLogging;

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -1040,9 +1040,6 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     std::string enableWelcomeMessage = stringifyBoolFromConfig(config, "welcome.enable", false);
     Poco::replaceInPlace(preprocess, std::string("%ENABLE_WELCOME_MSG%"), enableWelcomeMessage);
 
-    std::string enableWelcomeMessageButton = stringifyBoolFromConfig(config, "welcome.enable_button", false);
-    Poco::replaceInPlace(preprocess, std::string("%ENABLE_WELCOME_MSG_BTN%"), enableWelcomeMessageButton);
-
     // the config value of 'notebookbar' or 'classic' overrides the UIMode
     // from the WOPI
     std::string userInterfaceModeConfig = config.getString("user_interface.mode", "default");

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -993,6 +993,7 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     Poco::replaceInPlace(preprocess, std::string("%IDLE_TIMEOUT_SECS%"), std::to_string(idleTimeoutSecs));
 
     Poco::replaceInPlace(preprocess, std::string("%ENABLE_WELCOME_MSG%"), std::string(ENABLE_WELCOME_MESSAGE));
+    Poco::replaceInPlace(preprocess, std::string("%WELCOME_CUSTOM%"), config.getString("welcome.custom", ""));
 
     // the config value of 'notebookbar' or 'classic' overrides the UIMode
     // from the WOPI
@@ -1030,9 +1031,10 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     std::ostringstream cspOss;
     cspOss << "Content-Security-Policy: default-src 'none'; "
 #ifdef ENABLE_FEEDBACK
-        "frame-src 'self' " << uriFeedback.getAuthority() << " blob: " << documentSigningURL << "; "
+        "frame-src 'self' " << uriFeedback.getAuthority() << " "
+           << config.getString("welcome.authority", "") << " blob: " << documentSigningURL << "; "
 #else
-        "frame-src 'self' blob: " << documentSigningURL << "; "
+        "frame-src 'self' " << config.getString("welcome.authority", "") << " blob: " << documentSigningURL << "; "
 #endif
            "connect-src 'self' " << cnxDetails.getWebSocketUrl() << "; "
            "script-src 'unsafe-inline' 'self'; "

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -992,7 +992,6 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     const unsigned int idleTimeoutSecs = config.getUInt("per_view.idle_timeout_secs", 900);
     Poco::replaceInPlace(preprocess, std::string("%IDLE_TIMEOUT_SECS%"), std::to_string(idleTimeoutSecs));
 
-    Poco::replaceInPlace(preprocess, std::string("%ENABLE_WELCOME_MSG%"), std::string(ENABLE_WELCOME_MESSAGE));
     Poco::replaceInPlace(preprocess, std::string("%WELCOME_CUSTOM%"), COOLWSD::WelcomeLocation);
 
     // the config value of 'notebookbar' or 'classic' overrides the UIMode

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -1037,8 +1037,7 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     const unsigned int idleTimeoutSecs = config.getUInt("per_view.idle_timeout_secs", 900);
     Poco::replaceInPlace(preprocess, std::string("%IDLE_TIMEOUT_SECS%"), std::to_string(idleTimeoutSecs));
 
-    std::string enableWelcomeMessage = stringifyBoolFromConfig(config, "welcome.enable", false);
-    Poco::replaceInPlace(preprocess, std::string("%ENABLE_WELCOME_MSG%"), enableWelcomeMessage);
+    Poco::replaceInPlace(preprocess, std::string("%ENABLE_WELCOME_MSG%"), std::string(ENABLE_WELCOME_MESSAGE));
 
     // the config value of 'notebookbar' or 'classic' overrides the UIMode
     // from the WOPI

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -992,8 +992,6 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     const unsigned int idleTimeoutSecs = config.getUInt("per_view.idle_timeout_secs", 900);
     Poco::replaceInPlace(preprocess, std::string("%IDLE_TIMEOUT_SECS%"), std::to_string(idleTimeoutSecs));
 
-    Poco::replaceInPlace(preprocess, std::string("%WELCOME_CUSTOM%"), COOLWSD::WelcomeLocation);
-
     // the config value of 'notebookbar' or 'classic' overrides the UIMode
     // from the WOPI
     std::string userInterfaceModeConfig = config.getString("user_interface.mode", "default");
@@ -1031,9 +1029,9 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     cspOss << "Content-Security-Policy: default-src 'none'; "
 #ifdef ENABLE_FEEDBACK
         "frame-src 'self' " << uriFeedback.getAuthority() << " "
-           << COOLWSD::WelcomeAuthority << " blob: " << documentSigningURL << "; "
+           << config.getString("welcome.authority", "") << " blob: " << documentSigningURL << "; "
 #else
-        "frame-src 'self' " << COOLWSD::WelcomeAuthority << " blob: " << documentSigningURL << "; "
+        "frame-src 'self' " << config.getString("welcome.authority", "") << " blob: " << documentSigningURL << "; "
 #endif
            "connect-src 'self' " << cnxDetails.getWebSocketUrl() << "; "
            "script-src 'unsafe-inline' 'self'; "

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -993,7 +993,7 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     Poco::replaceInPlace(preprocess, std::string("%IDLE_TIMEOUT_SECS%"), std::to_string(idleTimeoutSecs));
 
     Poco::replaceInPlace(preprocess, std::string("%ENABLE_WELCOME_MSG%"), std::string(ENABLE_WELCOME_MESSAGE));
-    Poco::replaceInPlace(preprocess, std::string("%WELCOME_CUSTOM%"), config.getString("welcome.custom", ""));
+    Poco::replaceInPlace(preprocess, std::string("%WELCOME_CUSTOM%"), COOLWSD::WelcomeLocation);
 
     // the config value of 'notebookbar' or 'classic' overrides the UIMode
     // from the WOPI
@@ -1032,9 +1032,9 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     cspOss << "Content-Security-Policy: default-src 'none'; "
 #ifdef ENABLE_FEEDBACK
         "frame-src 'self' " << uriFeedback.getAuthority() << " "
-           << config.getString("welcome.authority", "") << " blob: " << documentSigningURL << "; "
+           << COOLWSD::WelcomeAuthority << " blob: " << documentSigningURL << "; "
 #else
-        "frame-src 'self' " << config.getString("welcome.authority", "") << " blob: " << documentSigningURL << "; "
+        "frame-src 'self' " << COOLWSD::WelcomeAuthority << " blob: " << documentSigningURL << "; "
 #endif
            "connect-src 'self' " << cnxDetails.getWebSocketUrl() << "; "
            "script-src 'unsafe-inline' 'self'; "


### PR DESCRIPTION
- config: remote obsolete ENABLE_WELCOME_MESSAGE_BUTTON var
- config: remove "enableWelcomeMessageButton" global variable
- config: remove welcome.enable entry
- wsd: remove WELCOME_ENDPOINT var
- config: add welcome.custom entry
- welcome: query the welcome.custom entry


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

