### PR TITLE
sanitizers: fix unit-base

### DIFF
--- a/wsd/RequestDetails.cpp
+++ b/wsd/RequestDetails.cpp
@@ -282,6 +282,7 @@ Poco::URI RequestDetails::sanitizeURI(const std::string& uri)
     return uriPublic;
 }
 
+#if !defined(BUILDING_TESTS)
 std::string RequestDetails::getDocKey(const Poco::URI& uri)
 {
     std::string docKey;
@@ -296,5 +297,6 @@ std::string RequestDetails::getDocKey(const Poco::URI& uri)
     LOG_INF("DocKey from URI [" << uri.toString() << "] => [" << docKey << ']');
     return docKey;
 }
+#endif // !defined(BUILDING_TESTS)
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -60,6 +60,7 @@
 #include "androidapp.hpp"
 #endif
 
+#if !defined(BUILDING_TESTS)
 bool StorageBase::FilesystemEnabled;
 bool StorageBase::WopiEnabled;
 bool StorageBase::SSLAsScheme = true;
@@ -68,6 +69,7 @@ Util::RegexListMatcher StorageBase::WopiHosts;
 std::map<std::string, std::string> StorageBase::AliasHosts;
 std::set<std::string> StorageBase::AllHosts;
 std::string StorageBase::FirstHost;
+#endif // !defined(BUILDING_TESTS)
 
 #if !MOBILEAPP
 
@@ -87,6 +89,7 @@ std::string StorageBase::getLocalRootPath() const
     return rootPath.toString();
 }
 
+#if !defined(BUILDING_TESTS)
 void StorageBase::parseWopiHost(Poco::Util::LayeredConfiguration& conf)
 {
     // Parse the WOPI settings.
@@ -201,6 +204,7 @@ std::string StorageBase::getNewUri(const Poco::URI& uri)
     }
     return newUri;
 }
+#endif // !defined(BUILDING_TESTS)
 
 #endif
 


### PR DESCRIPTION
==30332==ERROR: AddressSanitizer: odr-violation (0x0000020b9b20):
  [1] size=1 'StorageBase::SSLAsScheme' ../wsd/Storage.cpp:67:19
  [2] size=1 'StorageBase::SSLAsScheme' wsd/Storage.cpp:67:19
These globals were registered at these points:
  [1]:
    #0 0x71d0f8 in __asan_register_globals.part.13 lode/packages/llvm-llvmorg-9.0.1.src/compiler-rt/lib/asan/asan_globals.cc:362
    #1 0x7f4c362ed33b in asan.module_ctor (online-san/test/../test/.libs/unit-base.so+0x10eb33b)

  [2]:
    #0 0x71d0f8 in __asan_register_globals.part.13 lode/packages/llvm-llvmorg-9.0.1.src/compiler-rt/lib/asan/asan_globals.cc:362
    #1 0x11c709e in asan.module_ctor (online-san/coolwsd+0x11c709e)

==30332==HINT: if you don't care about these errors you may set ASAN_OPTIONS=detect_odr_violation=0
SUMMARY: AddressSanitizer: odr-violation: global 'StorageBase::SSLAsScheme' at ../wsd/Storage.cpp:67:19
==30332==ABORTING

Resolve the conflict by not providing these definitions when building
tests.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I6a8f74bd0b78a76f46b5401acaa816dd0b185aa9


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

