### PR TITLE
image operation: make sure embedded svgs are shown in writer only

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1973,7 +1973,7 @@ L.CanvasTileLayer = L.Layer.extend({
 			var wasVisibleSVG = this._graphicMarker._hasVisibleEmbeddedSVG();
 			this._graphicMarker.removeEmbeddedSVG();
 			this._graphicMarker.addEmbeddedSVG(textMsg);
-			if (wasVisibleSVG)
+			if (wasVisibleSVG && this._graphicSelection.extraInfo.isWriterGraphic)
 				this._graphicMarker._showEmbeddedSVG();
 		}
 	},


### PR DESCRIPTION
Signed-off-by: Pranam Lashkari <lpranam@collabora.com>
Change-Id: I1b3cfefdd6abb7f81ff741eee4edab7e349c932d

* Target version: master 

### Summary
fixed regression caused by https://github.com/CollaboraOnline/online/commit/1c86fd2ff869d36156bb97b3f44fc0cf7fec037c
regression: while we move textbox in impress previews would not go away


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

