### PR TITLE
android: fix unable to exit modified document

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1283,7 +1283,7 @@ void DocumentBroker::checkAndUploadToStorage(const std::string& sessionId)
         default:
         break;
     }
-
+#if !MOBILEAPP
     // Avoid multiple uploads during unloading if we know we need to save a new version.
     if (_docState.isUnloadRequested() && isPossiblyModified())
     {
@@ -1293,7 +1293,7 @@ void DocumentBroker::checkAndUploadToStorage(const std::string& sessionId)
                                 "upload to save again before unloading.");
         return;
     }
-
+#endif
     if (needToUploadState != NeedToUpload::No)
     {
         uploadToStorage(sessionId, /*force=*/needToUploadState == NeedToUpload::Force);


### PR DESCRIPTION
We dont upload to storage on mobile we save as locally
and copy the temp file into original on uno save result callback
Doing that once during close is enough since there is no
turning back and it cannot be possibly modified after

Signed-off-by: Mert Tumer <mert.tumer@collabora.com>
Change-Id: I047626be862cdbcb86e083534555e45530f417a2


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

