### PR TITLE
Show updated previews for Impress images on rotation

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1973,7 +1973,7 @@ L.CanvasTileLayer = L.Layer.extend({
 			var wasVisibleSVG = this._graphicMarker._hasVisibleEmbeddedSVG();
 			this._graphicMarker.removeEmbeddedSVG();
 			this._graphicMarker.addEmbeddedSVG(textMsg);
-			if (wasVisibleSVG && this._graphicSelection.extraInfo.isWriterGraphic)
+			if (wasVisibleSVG && !this._graphicSelection.extraInfo.isTextObject)
 				this._graphicMarker._showEmbeddedSVG();
 		}
 	},


### PR DESCRIPTION
followup for:
commit 7821ce536890af8312c927d1203d01c6a15498c7
Author: Pranam Lashkari <lpranam@collabora.com>
Date:   Fri Mar 18 17:06:45 2022 +0530

    image operation: make sure embedded svgs are shown in writer only

requires:
https://gerrit.libreoffice.org/c/core/+/131742

test with big images, try to rotate to trigger preview generation,
then rotate again but hold the button to see the preview all the time.
previously preview dissapeared on update, now it is updated correctly
