### PR TITLE
jsdialog: find also controls with modified id

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2909,6 +2909,8 @@ L.Control.JSDialogBuilder = L.Control.extend({
 	// executes actions like changing the selection without rebuilding the widget
 	executeAction: function(container, data) {
 		var control = container.querySelector('[id=\'' + data.control_id + '\']');
+		if (!control)
+			control = container.querySelector('[id=\'table-' + data.control.id + '\']');
 		if (!control) {
 			window.app.console.warn('executeAction: not found control with id: "' + data.control_id + '"');
 			return;

--- a/browser/src/control/Control.Sidebar.js
+++ b/browser/src/control/Control.Sidebar.js
@@ -55,7 +55,12 @@ L.Control.Sidebar = L.Control.extend({
 		if (!this.container)
 			return;
 
-		var control = this.container.querySelector('[id=\'' + data.control.id + '\']');
+		var controlId = data.control.id;
+		var control = this.container.querySelector('[id=\'' + controlId + '\']');
+		if (!control) {
+			controlId = 'table-' + controlId;
+			control = this.container.querySelector('[id=\'' + controlId + '\']');
+		}
 		if (!control) {
 			window.app.console.warn('jsdialogupdate: not found control with id: "' + data.control.id + '"');
 			return;
@@ -76,10 +81,10 @@ L.Control.Sidebar = L.Control.extend({
 
 		var temporaryParent = L.DomUtil.create('div');
 		this.builder.build(temporaryParent, [data.control], false);
-		parent.insertBefore(temporaryParent.firstChild, control.nextSibling);
+		parent.insertBefore(temporaryParent.querySelector('[id=\'' + controlId + '\']'), control.nextSibling);
 		L.DomUtil.remove(control);
 
-		var newControl = this.container.querySelector('[id=\'' + data.control.id + '\']');
+		var newControl = this.container.querySelector('[id=\'' + controlId + '\']');
 		if (newControl)
 			newControl.scrollTop = scrollTop;
 


### PR DESCRIPTION
In some cases we add 'table-' prefix for toolboxes due to
some old requirements in the mobile-wizard. We need to find these
modified ids in a fallback on widget update.

In the future we should get rid of 'table-' prefix.

This fixes missing numbering/bullets items in the impress sidebar