### PR TITLE
Revert "image operation: make sure embedded svgs are shown in writer …

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1973,7 +1973,7 @@ L.CanvasTileLayer = L.Layer.extend({
 			var wasVisibleSVG = this._graphicMarker._hasVisibleEmbeddedSVG();
 			this._graphicMarker.removeEmbeddedSVG();
 			this._graphicMarker.addEmbeddedSVG(textMsg);
-			if (wasVisibleSVG && this._graphicSelection.extraInfo.isWriterGraphic)
+			if (wasVisibleSVG)
 				this._graphicMarker._showEmbeddedSVG();
 		}
 	},


### PR DESCRIPTION
…only"

This reverts commit 7821ce536890af8312c927d1203d01c6a15498c7.

it is not needed, and blocks update of the image preview in Impress
