### PR TITLE
Revert "image operation: make sure embedded svgs are shown in writer..."

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1973,7 +1973,7 @@ L.CanvasTileLayer = L.Layer.extend({
 			var wasVisibleSVG = this._graphicMarker._hasVisibleEmbeddedSVG();
 			this._graphicMarker.removeEmbeddedSVG();
 			this._graphicMarker.addEmbeddedSVG(textMsg);
-			if (wasVisibleSVG && this._graphicSelection.extraInfo.isWriterGraphic)
+			if (wasVisibleSVG)
 				this._graphicMarker._showEmbeddedSVG();
 		}
 	},


### PR DESCRIPTION
Reason: bug was properly fixed via
bb1035e49a78cd4befe1ae7070acc20e37f43492.

This reverts commit 7821ce536890af8312c927d1203d01c6a15498c7.

Signed-off-by: Aron Budea <aron.budea@collabora.com>
Change-Id: I9de75def4889c8a18fa98b592c08759f478e7e19

* Target version: master 