### PR TITLE
calcRTL: chart selection's svg does not match the tile

### DIFF
--- a/loleaflet/src/layer/vector/SVGGroup.js
+++ b/loleaflet/src/layer/vector/SVGGroup.js
@@ -248,7 +248,7 @@ L.SVGGroup = L.Layer.extend({
 	_hasVisibleEmbeddedSVG: function () {
 		var result = false;
 		this._forEachSVGNode(function (svgNode) {
-			if (svgNode.getAttribute('opacity') !== 0)
+			if (parseInt(svgNode.getAttribute('opacity')) !== 0)
 				result = true;
 		});
 


### PR DESCRIPTION
The svg sent from core does not exactly match the corresponding contents
in tile of the shape - especially the legend texts. This commit does not
attempt to fix that.

Before the commit e64ff372fc54e42fb1337ac3b76200c021018c96, the svg
embedded image was always hidden when a shape/chart/ole is merely
selected and it is only shown while the shape is being resized or moved.
Because of the strict inequality used with getAttribute('opacity') this
condition is always true at least in Chrome as getAttribute() returns a
string.  Comparing the parsed integer version of that results in the
intended behaviour and also hides the svg preview when chart/shape is
not dragged or resized.

Signed-off-by: Dennis Francis <dennis.francis@collabora.com>
Change-Id: I0aef873e392b0959e93057e6399e8f77cf70042c
(cherry picked from commit bb1035e49a78cd4befe1ae7070acc20e37f43492)

* Target version: 6.4
