### PR TITLE
SSL logging and other improvements

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -68,6 +68,7 @@ include_paths = -I${top_srcdir}/common -I${top_srcdir}/net -I${top_srcdir}/wsd -
 AM_CPPFLAGS = -pthread -DCOOLWSD_DATADIR='"@COOLWSD_DATADIR@"' \
 	      -DCOOLWSD_CONFIGDIR='"@COOLWSD_CONFIGDIR@"' \
 	      -DDEBUG_ABSSRCDIR='"@abs_srcdir@"' \
+	      -DOPENSSL_NO_DEPRECATED \
 	      ${include_paths}
 
 if !ENABLE_DEBUG

--- a/browser/src/map/handler/Map.Keyboard.js
+++ b/browser/src/map/handler/Map.Keyboard.js
@@ -273,7 +273,7 @@ L.Map.Keyboard = L.Handler.extend({
 			return;
 		}
 		var docLayer = this._map._docLayer;
-		if (!keyEventFn) {
+		if (!keyEventFn && docLayer.postKeyboardEvent) {
 			// default is to post keyboard events on the document
 			keyEventFn = L.bind(docLayer.postKeyboardEvent, docLayer);
 		}
@@ -339,8 +339,11 @@ L.Map.Keyboard = L.Handler.extend({
 		if (this.modifier) {
 			unoKeyCode |= this.modifier;
 			if (ev.type !== 'keyup' && (this.modifier !== shift || (keyCode === 32 && !this._map._isCursorVisible))) {
-				keyEventFn('input', charCode, unoKeyCode);
-				ev.preventDefault();
+				if (keyEventFn) {
+					keyEventFn('input', charCode, unoKeyCode);
+					ev.preventDefault();
+				}
+
 				return;
 			}
 		}
@@ -359,8 +362,10 @@ L.Map.Keyboard = L.Handler.extend({
 			else if (ev.type === 'keydown') {
 				// window.app.console.log(e);
 				if (this.handleOnKeyDownKeys[keyCode] && charCode === 0) {
-					keyEventFn('input', charCode, unoKeyCode);
-					ev.preventDefault();
+					if (keyEventFn) {
+						keyEventFn('input', charCode, unoKeyCode);
+						ev.preventDefault();
+					}
 				}
 			}
 			else if ((ev.type === 'keypress') && (!this.handleOnKeyDownKeys[keyCode] || charCode !== 0)) {
@@ -381,13 +386,17 @@ L.Map.Keyboard = L.Handler.extend({
 					docLayer._debugKeypressQueue.push(+new Date());
 				}
 
-				keyEventFn('input', charCode, unoKeyCode);
+				if (keyEventFn) {
+					keyEventFn('input', charCode, unoKeyCode);
+				}
 			}
 			else if (ev.type === 'keyup') {
 				if ((this.handleOnKeyDownKeys[keyCode] && charCode === 0) ||
 				    (this.modifier) ||
 				    unoKeyCode === UNOKey.RETURN) {
-					keyEventFn('up', charCode, unoKeyCode);
+					if (keyEventFn) {
+						keyEventFn('up', charCode, unoKeyCode);
+					}
 				} else {
 					// was handled as textinput
 				}
@@ -426,7 +435,9 @@ L.Map.Keyboard = L.Handler.extend({
 			else if (key in this._panKeys && ev.shiftKey &&
 					!docLayer._textCSelections.empty()) {
 				// if there is a selection and the user wants to modify it
-				keyEventFn('input', charCode, unoKeyCode);
+				if (keyEventFn) {
+					keyEventFn('input', charCode, unoKeyCode);
+				}
 			}
 			else if (key in this._zoomKeys) {
 				map.setZoom(map.getZoom() + (ev.shiftKey ? 3 : 1) * this._zoomKeys[key], null, true /* animate? */);

--- a/common/StringVector.hpp
+++ b/common/StringVector.hpp
@@ -112,7 +112,7 @@ public:
     }
 
     /// Compares the nth token with string.
-    bool equals(std::size_t index, const char* string) const
+    template <typename T> bool equals(std::size_t index, const T& string) const
     {
         if (index >= _tokens.size())
         {
@@ -124,8 +124,7 @@ public:
     }
 
     /// Compares the nth token with string.
-    template <std::size_t N>
-    bool equals(std::size_t index, const char (&string)[N]) const
+    template <std::size_t N> bool equals(std::size_t index, const char (&string)[N]) const
     {
         if (index >= _tokens.size())
         {
@@ -133,7 +132,7 @@ public:
         }
 
         const StringToken& token = _tokens[index];
-        return _string.compare(token._index, token._length, string, N) == 0;
+        return _string.compare(token._index, token._length, string, N - 1) == 0;
     }
 
     // Checks if the token text at index starts with the given string
@@ -146,7 +145,7 @@ public:
         }
 
         const StringToken& token = _tokens[index];
-        const auto len = N - 1; // we don't want to compare the '\0'
+        constexpr auto len = N - 1; // we don't want to compare the '\0'
         return token._length >= len && _string.compare(token._index, len, string) == 0;
     }
 

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -1307,9 +1307,8 @@ private:
         {
             std::shared_ptr<StreamSocket> socket = _socket.lock();
             const int fd = socket ? socket->getFD() : 0;
-            LOG_WRN("Socket #" << fd << " has timed out while requesting ["
-                               << _request.getVerb() << ' ' << _host << _request.getUrl()
-                               << "] after " << duration);
+            LOG_WRN('#' << fd << " has timed out while requesting [" << _request.getVerb() << ' '
+                        << _host << _request.getUrl() << "] after " << duration);
 
             // Flag that we timed out.
             _response->timeout();

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -1209,7 +1209,6 @@ private:
     int getPollEvents(std::chrono::steady_clock::time_point /*now*/,
                       int64_t& /*timeoutMaxMicroS*/) override
     {
-        LOG_TRC("getPollEvents");
         int events = POLLIN;
         if (_request.stage() != Request::Stage::Finished)
             events |= POLLOUT;

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -447,10 +447,11 @@ int SocketPoll::poll(int64_t timeoutMaxMicroS)
 
         std::vector<int> toErase;
 
-        LOG_TRC("Starting handling poll results of " << _name << " at index " << _pollStartIndex
-                                                     << " (of " << size << ")");
-
         size_t i = _pollStartIndex;
+        LOG_TRC("Starting handling poll results of "
+                << _name << " #" << _pollFds[i].fd << " at index " << _pollStartIndex << " (of "
+                << size << "): " << std::hex << _pollFds[i].revents << std::dec);
+
         size_t previ = size;
         while (previ != _pollStartIndex)
         {

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -848,6 +848,8 @@ private:
             _pollFds[i].fd = _pollSockets[i]->getFD();
             _pollFds[i].events = events;
             _pollFds[i].revents = 0;
+            LOG_TRC('#' << _pollFds[i].fd << ": setupPollFds getPollEvents: 0x" << std::hex
+                        << events << std::dec);
         }
 
         // Add the read-end of the wake pipe.
@@ -1275,6 +1277,8 @@ protected:
                     const int events) override
     {
         ASSERT_CORRECT_SOCKET_THREAD(this);
+
+        LOG_TRC('#' << getFD() << ": revents: 0x" << std::hex << events << std::dec);
 
         _socketHandler->checkTimeout(now);
 

--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -180,7 +180,7 @@ protected:
 
         if (socket->isClosed())
         {
-            LOG_DBG("Socket #" << socket->getFD() << " is closed. Cannot send Close Frame.");
+            LOG_DBG('#' << socket->getFD() << " is closed. Cannot send Close Frame.");
             return;
         }
 
@@ -722,7 +722,7 @@ protected:
 
         if (socket->isClosed())
         {
-            LOG_DBG("Socket #" << socket->getFD() << " is closed. Cannot send WS frame.");
+            LOG_DBG('#' << socket->getFD() << " is closed. Cannot send WS frame.");
             return 0;
         }
 
@@ -790,7 +790,7 @@ protected:
                 socket->writeOutgoingData();
                 if (!out.empty())
                 {
-                    LOG_WRN("Socket #"
+                    LOG_WRN('#'
                             << socket->getFD() << " is shutting down but " << out.size()
                             << " bytes couldn't be flushed and still remain in the output buffer.");
                 }

--- a/test/lokassert.hpp
+++ b/test/lokassert.hpp
@@ -96,7 +96,7 @@ std::string inline lokFormatAssertEq(const std::string& expected, const char*,
                     << (msg##__LINE__.empty() ? "" : msg##__LINE__ + ". ")                         \
                     << "Condition: " << (#condition));                                             \
             LOK_ASSERT_IMPL(cond##__LINE__);                                                       \
-            CPPUNIT_ASSERT_MESSAGE((message), cond##__LINE__);                                     \
+            CPPUNIT_ASSERT_MESSAGE((msg##__LINE__), cond##__LINE__);                               \
         }                                                                                          \
         else                                                                                       \
         {                                                                                          \

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -2371,7 +2371,7 @@ bool COOLWSD::checkAndRestoreForKit()
             }
             else
             {
-                LOG_WRN("Unknown status returned by waitpid: " << std::hex << status << '.');
+                LOG_WRN("Unknown status returned by waitpid: " << std::hex << status << std::dec);
             }
 
             return true;
@@ -4055,7 +4055,7 @@ private:
                             // Set WebSocketHandler's socket after its construction for shared_ptr goodness.
                             streamSocket->setHandler(ws);
 
-                            LOG_DBG("Socket #" << moveSocket->getFD() << " handler is " << clientSession->getName());
+                            LOG_DBG('#' << moveSocket->getFD() << " handler is " << clientSession->getName());
 
                             // Add and load the session.
                             docBroker->addSession(clientSession);

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -175,8 +175,7 @@ bool isConfigAuthOk(const std::string& userProvidedUsr, const std::string& userP
             stream << std::hex << std::setw(2) << std::setfill('0') << static_cast<int>(userProvidedPwdHash[j]);
 
         // now compare the hashed user-provided pwd against the stored hash
-        std::string string = stream.str();
-        return tokens.equals(4, string.c_str());
+        return tokens.equals(4, stream.str());
 #else
         const std::string pass = config.getString("admin_console.password", "");
         LOG_ERR("The config file has admin_console.secure_password setting, "


### PR DESCRIPTION
- browser: protect against undefined keyEventFn
- wsd: always include the BIO errors in SSL logs
- wsd: trace poll events and revents flags arround ppoll
- wsd: test: correctly show the failing code in the assertion message
- wsd: minor improvements to StringVector::equals overloads
- wsd: exclude deprecated openssl API
