### PR TITLE
tablet: Fix close button can be partially visible

### DIFF
--- a/browser/css/device-tablet.css
+++ b/browser/css/device-tablet.css
@@ -98,7 +98,7 @@
 	-ms-flex-wrap: nowrap;
 	flex-wrap: nowrap;
 	word-wrap: nowrap;
-	max-width: 60%;
+	max-width: 50%;
 }
 
 .main-nav.readonly.hasnotebookbar .notebookbar-tabs-container {


### PR DESCRIPTION
depending on the tablet's screen size, the close button
is placed at the very right and it may become partially
visible because notebookvar-tabs-container can take up
more space than needed. We can make it a bit more smaller
to fit the items right.

Signed-off-by: Mert Tumer <mert.tumer@collabora.com>
Change-Id: I0adefd1389dc9e639b923162f8dcb084c0b8b39d


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

