### PR TITLE
Fix button order on HyperlinkDialog

### DIFF
--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -716,8 +716,8 @@ L.Map.include({
 				_('Link') + '<input name="link" id="hyperlink-link-box" type="text" value="' + link + '"/>'
 			].join(''),
 			buttons: [
-				$.extend({}, vex.dialog.buttons.YES, { text: _('OK') }),
-				$.extend({}, vex.dialog.buttons.NO, { text: _('Cancel') })
+				$.extend({}, vex.dialog.buttons.NO, { text: _('Cancel') }),
+				$.extend({}, vex.dialog.buttons.YES, { text: _('OK') })
 			],
 			callback: function(data) {
 				if (data && data.link != '') {

--- a/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
@@ -340,7 +340,7 @@ describe('Top toolbar tests.', function() {
 		cy.get('#hyperlink-link-box')
 			.type('www.something.com');
 
-		cy.get('.vex-dialog-button-primary.vex-dialog-button.vex-first')
+		cy.get('.vex-dialog-button-primary.vex-dialog-button')
 			.click();
 
 		writerHelper.selectAllTextOfDoc();


### PR DESCRIPTION
Follow the same order as anywhere else such as annotations, JSdialog or
even tunneled dialogs:
primary action aligned to the left

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Iac209aa343f22ddfdbd5662eba43d7adaa3f0892
