### PR TITLE
private/pedro/private/pedro/backporting 4427

### DIFF
--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -31,14 +31,6 @@ button.jsdialog {
 .ui-button-box.autofilter #cancel,
 .cell.jsdialog > button:not(#ok),
 .ui-button-box.jsdialog button:not(#ok),
-.jsdialog-container #source-button,
-.jsdialog-container #destination-button,
-.jsdialog-container #refbutton,
-.jsdialog-container #assign,
-.jsdialog-container #input-range-button,
-.jsdialog-container #output-range-button,
-.jsdialog-container #variable1-range-button,
-.jsdialog-container #variable2-range-button,
 .vex.vex-theme-plain .vex-dialog-button.vex-dialog-button-secondary {
 	height: 32px;
 	line-height: 0em;
@@ -58,14 +50,6 @@ button.jsdialog {
 .ui-button-box.autofilter #cancel:hover,
 .cell.jsdialog > button:not(#ok):hover,
 .ui-button-box.jsdialog button:not(#ok):hover,
-.jsdialog-container #source-button:hover,
-.jsdialog-container #destination-button:hover,
-.jsdialog-container #refbutton:hover,
-.jsdialog-container #assign:hover,
-.jsdialog-container #input-range-button:hover,
-.jsdialog-container #output-range-button:hover,
-.jsdialog-container #variable1-range-button:hover,
-.jsdialog-container #variable2-range-button:hover,
 .vex.vex-theme-plain .vex-dialog-button.vex-dialog-button-secondary:hover {
 	cursor: pointer;
 	color: var(--color-text-darker) !important;

--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -25,7 +25,7 @@ button.jsdialog {
 	justify-content: end;
 }
 
-.cool-annotation-edit #annotation-cancel,
+.cool-annotation-edit [id^='annotation-cancel'],
 .ui-pushbutton.jsdialog:not(#ok):not([id*='select_current']):not(.sidebar),
 .ui-button-box.jsdialog #cancel,
 .ui-button-box.autofilter #cancel,
@@ -52,7 +52,7 @@ button.jsdialog {
 	vertical-align: middle;
 }
 
-.cool-annotation-edit #annotation-cancel:hover,
+.cool-annotation-edit [id^='annotation-cancel']:hover,
 .ui-pushbutton.jsdialog:not(#ok):not(.sidebar):hover,
 .ui-button-box.jsdialog #cancel:hover,
 .ui-button-box.autofilter #cancel:hover,

--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -18,6 +18,13 @@ button.jsdialog {
 	opacity: 0.7;
 }
 
+.annotation-btns-container,
+.vex-dialog-buttons {
+	display: flex;
+	flex-direction: row;
+	justify-content: end;
+}
+
 .cool-annotation-edit #annotation-cancel,
 .ui-pushbutton.jsdialog:not(#ok):not([id*='select_current']):not(.sidebar),
 .ui-button-box.jsdialog #cancel,
@@ -43,9 +50,6 @@ button.jsdialog {
 	border-radius: var(--border-radius);
 	margin: 5px;
 	vertical-align: middle;
-	display: flex;
-	align-items: center;
-	justify-content: center;
 }
 
 .cool-annotation-edit #annotation-cancel:hover,

--- a/browser/css/device-mobile.css
+++ b/browser/css/device-mobile.css
@@ -379,16 +379,12 @@ button.vex-dialog-button-secondary.vex-dialog-button.vex-last {
 	min-height: 24px !important;
 }
 
-.vex-content.vex-3btns .vex-dialog-buttons {
+.vex-dialog-buttons {
 	flex-direction: column !important;
 }
 
 .vex-close:not(.vex-close-m) {
 	display: none;
-}
-
-.vex-content.vex-3btns .vex-dialog-buttons .vex-dialog-button-cancel {
-	display: block !important;
 }
 
 /* Related to toolbar.css */

--- a/browser/src/layer/tile/CommentSection.ts
+++ b/browser/src/layer/tile/CommentSection.ts
@@ -119,7 +119,7 @@ class Comment {
 		if (!force && !this.convertRectanglesToCoreCoordinates())
 			return;
 
-		var button = L.DomUtil.create('div', '', this.sectionProperties.nodeModify);
+		var button = L.DomUtil.create('div', 'annotation-btns-container', this.sectionProperties.nodeModify);
 		L.DomEvent.on(this.sectionProperties.nodeModifyText, 'blur', this.onLostFocus, this);
 		L.DomEvent.on(this.sectionProperties.nodeReplyText, 'blur', this.onLostFocusReply, this);
 		this.createButton(button, 'annotation-cancel-' + this.sectionProperties.data.id, _('Cancel'), this.onCancelClick);


### PR DESCRIPTION
- Annotations: Fix cancel confirm btns flex CSS and add class for container
- Target all buttons, fix mixed display properties
- Simplify CSS for vex btns on mobile, flex
- Buttons: Remove unnecessary CSS on calc
