### PR TITLE
Revert "wsd: exclude deprecated openssl API"

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -68,7 +68,6 @@ include_paths = -I${top_srcdir}/common -I${top_srcdir}/net -I${top_srcdir}/wsd -
 AM_CPPFLAGS = -pthread -DCOOLWSD_DATADIR='"@COOLWSD_DATADIR@"' \
 	      -DCOOLWSD_CONFIGDIR='"@COOLWSD_CONFIGDIR@"' \
 	      -DDEBUG_ABSSRCDIR='"@abs_srcdir@"' \
-	      -DOPENSSL_NO_DEPRECATED \
 	      ${include_paths}
 
 if !ENABLE_DEBUG


### PR DESCRIPTION
Apparently this breaks the build on at least
CentOS. Reverting for now.

This reverts commit 23f02b89294bd03b5add402d097df62d9651b0c8.
