### PR TITLE
revert: add edit option in link dialog...

### DIFF
--- a/browser/src/control/Control.AlertDialog.js
+++ b/browser/src/control/Control.AlertDialog.js
@@ -63,16 +63,6 @@ L.Control.AlertDialog = L.Control.extend({
 
 			if (isLinkValid) {
 				buttonsList.push({
-					text: _('Edit'),
-					type: 'button',
-					className: 'vex-dialog-button-secondary',
-					click: function() {
-						vex.closeAll();
-						e.map.showHyperlinkDialog();
-					}
-				});
-
-				buttonsList.push({
 					text: _('Open link'),
 					type: 'button',
 					className: 'vex-dialog-button-primary',


### PR DESCRIPTION
commit eb387cc7b1e7d8389e138fa42372a38eea3a6148

At least in current master it is possible to right click on the link and
select 'Edit hyperlink' context menu item and the edit dialog(JS)
appears. So it seems there is no need for this workaround edit button
inside the warning 'JS' dialog box anymore.

Additional reason is that when help button is clicked on any
dialog(tunnelled or not) it shows a warning 'link' dialog that it is
about to open a external url, but this dialog has an unneeded edit
button because of the original commit.

Signed-off-by: Dennis Francis <dennis.francis@collabora.com>
Change-Id: I2d8434746c698deefe69b38bf9947202f4f95862


* Resolves: # <!-- related github issue -->
* Target version: master 

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

