### PR TITLE
Fix missing icons by creating iconURL aliases

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2208,11 +2208,21 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		if (!name)
 			return '';
 
+		var iconURLAliases = {
+			'AlignLeft': 'LeftPara',
+			'AlignRight': 'RightPara',
+			'AlignHorizontalCenter': 'CenterPara',
+			'AlignBlock': 'JustifyPara'
+		};
 		var cleanName = name;
 		var prefixLength = '.uno:'.length;
 		if (name.substr(0, prefixLength) == '.uno:')
 			cleanName = name.substr(prefixLength);
 		cleanName = encodeURIComponent(cleanName).replace(/\%/g, '');
+
+		if (iconURLAliases[cleanName]) {
+			cleanName = iconURLAliases[cleanName];
+		}
 		return L.LOUtil.getImageURL('lc_' + cleanName.toLowerCase() + '.svg');
 	},
 


### PR DESCRIPTION
- add possibility to specify name alias for icons that are
  generated via jsbuilder (sidebar, notebookbar). The goal here is to
  avoid having multiple duplicated icons with different names:
  Example: 2 identical SVG files were being used just because of their
  name.

Context: When unifying icons between sidebar and toolbar PR #4426 ,
9576137df51725b677342c606dcad8749eaf0622 we end up with icons without
images on:
  - Calc: Notebookbar
  - Calc: Sidebar
This happens because even though we want to use the same icons the uno
commands are actually different from ones used in writer and elsewhere
(uno.AlignLeft <> uno.LeftPara)

Note: Since the sidebar uno.commands come from core we really need to
use icon url alias. If that was not the case we could have used here the
newest compatibilityAliases introduced in
7e6f3d5590c7055f248c80376d23e6f6dfa0d8fc

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I49647f8a32665d0363259151c09131d8c5063783
