### PR TITLE
Fix comment reply count color

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -423,7 +423,7 @@ nav.spreadsheet-color-indicator ~ #sidebar-dock-wrapper {
 }
 
 .cool-annotation-reply-count-collapsed {
-	background-color: var(--color-primary-lighter);
+	background-color: var(--color-primary);
 	color: var(--color-primary-text);
 	font-weight: bold;
 	font-family: var(--cool-font);
@@ -440,10 +440,6 @@ nav.spreadsheet-color-indicator ~ #sidebar-dock-wrapper {
 
 #main-document-content {
 	z-index: 0;
-}
-
-#main-document-content .cool-annotation-reply-count-collapsed {
-	background: rgb(var(--color-primary));
 }
 
 .cool-annotation-collapsed {


### PR DESCRIPTION
- Partly revert 7e705fcf09cd30159d0703fbfbe5a89dce1f2e82
  - RGB expects rgb values. Hex annotation does not work: renders it
 transparent
- Avoid low contrast between font and background (white with light bg)
  - Use instead primary color

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Iad24d6bf30d2e62505254c70b174e9b9971cbeb1
