### PR TITLE
annotation: fix layouting problem on selected comments

### DIFF
--- a/browser/src/layer/tile/CommentListSection.ts
+++ b/browser/src/layer/tile/CommentListSection.ts
@@ -576,6 +576,7 @@ class CommentSection {
 			}
 		}
 		else {
+			this.unselect();
 			annotation.reply();
 			this.select(annotation);
 			annotation.focus();
@@ -591,6 +592,7 @@ class CommentSection {
 				this.save(annotation);
 			}.bind(this), /* isMod */ true);
 		} else {
+			this.unselect();
 			annotation.edit();
 			this.select(annotation);
 			annotation.focus();


### PR DESCRIPTION
modify and reply causes relayouting due to expansion of the
commentsections but it is based on whether they are selected or not
currently. If they are already selected we dont relayout them again
and it causes overlapping. To avoid that we can simply unselect
comments just before reply or modify.

Signed-off-by: Mert Tumer <mert.tumer@collabora.com>
Change-Id: Ifc2e546504b36b46f98a9b22ce791b4279239457


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

