### PR TITLE
nftw() does not set errno on failure

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -486,7 +486,7 @@ namespace
 
         if (nftw(source.c_str(), linkOrCopyFunction, 10, FTW_ACTIONRETVAL|FTW_PHYS) == -1)
         {
-            LOG_SYS("linkOrCopy: nftw() failed for '" << source << '\'');
+            LOG_ERR("linkOrCopy: nftw() failed for '" << source << '\'');
         }
 
         if (linkOrCopyVerboseLogging)


### PR DESCRIPTION
Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: I7e768416b5113d71330148227aeceb941013c578


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

