### PR TITLE
Notify server about visible slide

### DIFF
--- a/loleaflet/src/control/Control.PartsPreview.js
+++ b/loleaflet/src/control/Control.PartsPreview.js
@@ -377,12 +377,13 @@ L.Control.PartsPreview = L.Control.extend({
 	_setPart: function (e) {
 		var part = this._findClickedPart(e.target.parentNode);
 		if (part !== null) {
+			var partId = parseInt(part) - 1; // The first part is just a drop-site for reordering.
+
 			if (app.file.fileBasedView) {
+				this._map.setPart(partId);
 				this._scrollViewToPartPosition(part - 1);
 				return;
 			}
-
-			var partId = parseInt(part) - 1; // The first part is just a drop-site for reordering.
 
 			if (e.ctrlKey) {
 				this._map.selectPart(partId, 2, false); // Toggle selection on ctrl+click.

--- a/loleaflet/src/control/Parts.js
+++ b/loleaflet/src/control/Parts.js
@@ -31,6 +31,13 @@ L.Map.include({
 			return;
 		}
 
+		var notifyServer = function (part) {
+			// If this wasn't triggered from the server,
+			// then notify the server of the change.
+			if (!external)
+				app.socket.sendMessage('setclientpart part=' + part);
+		};
+
 		if (app.file.fileBasedView)
 		{
 			docLayer._selectedPart = docLayer._prevSelectedPart;
@@ -39,6 +46,7 @@ L.Map.include({
 				return;
 			}
 			docLayer._preview._scrollViewToPartPosition(docLayer._selectedPart);
+			notifyServer(part);
 			return;
 		}
 
@@ -50,11 +58,7 @@ L.Map.include({
 			app.socket.sendMessage('resetselection');
 		}
 
-		// If this wasn't triggered from the server,
-		// then notify the server of the change.
-		if (!external) {
-			app.socket.sendMessage('setclientpart part=' + docLayer._selectedPart);
-		}
+		notifyServer(docLayer._selectedPart);
 
 		this.fire('updateparts', {
 			selectedPart: docLayer._selectedPart,

--- a/loleaflet/src/layer/tile/CanvasTileLayer.js
+++ b/loleaflet/src/layer/tile/CanvasTileLayer.js
@@ -1303,6 +1303,7 @@ L.CanvasTileLayer = L.TileLayer.extend({
 					this._selectedPart = partToSelect;
 					this._preview._scrollToPart();
 					this.highlightCurrentPart(partToSelect);
+					app.socket.sendMessage('setclientpart part=' + this._selectedPart);
 				}
 			}
 


### PR DESCRIPTION
Fixes problem with:
- showing wrong slide number in statusbar
- inserting comment at correct page
in pdfs where we see slides in continuous mode.

Sending slide id from online to server is much easier
than calculating based on visible area on the server
where we have to put that data into TabControl widget
which is used in different places.

It updates visible slide on scroll and also when selected
from the previews bar.
