### PR TITLE
wsd: hostname is needed for SSL SNI

### DIFF
--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -915,7 +915,7 @@ public:
     };
 
     /// Create a StreamSocket from native FD.
-    StreamSocket(const std::string hostname, const int fd, bool /* isClient */,
+    StreamSocket(std::string hostname, const int fd, bool /* isClient */,
                  std::shared_ptr<ProtocolHandlerInterface> socketHandler,
                  ReadType readType = NormalRead) :
         Socket(fd),

--- a/net/SslSocket.hpp
+++ b/net/SslSocket.hpp
@@ -20,10 +20,10 @@
 class SslStreamSocket final : public StreamSocket
 {
 public:
-    SslStreamSocket(std::string hostname, const int fd, bool isClient,
+    SslStreamSocket(const std::string& hostname, const int fd, bool isClient,
                     std::shared_ptr<ProtocolHandlerInterface> responseClient,
                     ReadType readType = NormalRead)
-        : StreamSocket(std::move(hostname), fd, isClient, std::move(responseClient), readType)
+        : StreamSocket(hostname, fd, isClient, std::move(responseClient), readType)
         , _bio(nullptr)
         , _ssl(nullptr)
         , _sslWantsTo(SslWantsTo::Neither)
@@ -48,8 +48,13 @@ public:
             throw std::runtime_error("Failed to create SSL.");
         }
 
-        if (!hostname.empty() && !SSL_set_tlsext_host_name(_ssl, hostname.c_str()))
-            LOG_WRN("Failed to set hostname for Server Name Indication [" << hostname << ']');
+        if (!hostname.empty())
+        {
+            if (!SSL_set_tlsext_host_name(_ssl, hostname.c_str()))
+                LOG_WRN("Failed to set hostname for Server Name Indication [" << hostname << ']');
+            else
+                LOG_TRC("Set [" << hostname << "] as TLS hostname.");
+        }
 
         SSL_set_bio(_ssl, _bio, _bio);
 


### PR DESCRIPTION
While chasing #4480, I was able to produce `handshake failure` error that this patch resolved.

```
#26 SSL error: SSL (1) BIO error: 336151568, rc: -1: error:14094410:SSL routines:ssl3_read_bytes:sslv3 alert handshake failure:| ./net/SslSocket.hpp:345                                                                                                                                              
#26 Error while handling poll at 0 in HttpSynReqPoll: #26: socket closed unexpectedly. BIO error: 0, rc: -1: error:00000000:lib(0):func(0):reason(0):| net/Socket.cpp:466                
```

Since the hostname argument is passed
to both the base class of SslStreamSocket
and SSL_set_tlsext_host_name, and since
the base class's getter, also called
hostname(), is hidden by the argument,
we cannot move it.

An empty hostname can result in 403 Forbidden
from the server due to missing Server Name
Indication (SNI).
