### PR TITLE
Notebookbar: set overflow visible before removing notebookbar when ch…

### DIFF
--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -94,6 +94,7 @@ L.Control.Notebookbar = L.Control.extend({
 		this.map.off('jsdialogupdate', this.onJSUpdate, this);
 		this.map.off('jsdialogaction', this.onJSAction, this);
 		$('.main-nav #document-header').remove();
+		$('.main-nav.hasnotebookbar').css('overflow', 'visible');
 		$('.main-nav').removeClass('hasnotebookbar');
 		$('#toolbar-wrapper').removeClass('hasnotebookbar');
 		$('.main-nav').removeClass(this._map.getDocType() + '-color-indicator');


### PR DESCRIPTION
…anging layout

Signed-off-by: Gabriel Masei <gabriel.masei@1and1.ro>
Change-Id: Ifde1603e33399a50173c78b37f20d1c30db9f536


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
When changing the layout from notebookbar to classic the popup menus associated with main menu options are not visible.

### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

