### PR TITLE
Cypress: Do not hard target buttons based on their position

### DIFF
--- a/cypress_test/integration_tests/common/mobile_helper.js
+++ b/cypress_test/integration_tests/common/mobile_helper.js
@@ -173,7 +173,7 @@ function executeCopyFromContextMenu(XPos, YPos) {
 		.click();
 
 	// Close warning about clipboard operations
-	cy.get('.vex-dialog-button-primary.vex-dialog-button.vex-first')
+	cy.get('.vex-dialog-button-primary.vex-dialog-button')
 		.click();
 
 	// Wait until it's closed

--- a/cypress_test/integration_tests/mobile/calc/hamburger_menu_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/hamburger_menu_spec.js
@@ -200,7 +200,7 @@ describe('Trigger hamburger menu options.', function() {
 		cy.get('.vex-dialog-message')
 			.should('have.text', 'Please use the copy/paste buttons on your on-screen keyboard.');
 
-		cy.get('.vex-dialog-button-primary.vex-dialog-button.vex-first')
+		cy.get('.vex-dialog-button-primary.vex-dialog-button')
 			.click();
 
 		cy.get('.vex-dialog-form')
@@ -222,7 +222,7 @@ describe('Trigger hamburger menu options.', function() {
 		cy.get('.vex-dialog-message')
 			.should('have.text', 'Please use the copy/paste buttons on your on-screen keyboard.');
 
-		cy.get('.vex-dialog-button-primary.vex-dialog-button.vex-first')
+		cy.get('.vex-dialog-button-primary.vex-dialog-button')
 			.click();
 
 		cy.get('.vex-dialog-form')
@@ -244,7 +244,7 @@ describe('Trigger hamburger menu options.', function() {
 		cy.get('.vex-dialog-message')
 			.should('have.text', 'Please use the copy/paste buttons on your on-screen keyboard.');
 
-		cy.get('.vex-dialog-button-primary.vex-dialog-button.vex-first')
+		cy.get('.vex-dialog-button-primary.vex-dialog-button')
 			.click();
 
 		cy.get('.vex-dialog-form')

--- a/cypress_test/integration_tests/mobile/impress/hamburger_menu_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/hamburger_menu_spec.js
@@ -202,7 +202,7 @@ describe('Trigger hamburger menu options.', function() {
 		cy.get('.vex-dialog-message')
 			.should('have.text', 'Please use the copy/paste buttons on your on-screen keyboard.');
 
-		cy.get('.vex-dialog-button-primary.vex-dialog-button.vex-first')
+		cy.get('.vex-dialog-button-primary.vex-dialog-button')
 			.click();
 
 		cy.get('.vex-dialog-form')
@@ -248,7 +248,7 @@ describe('Trigger hamburger menu options.', function() {
 		cy.get('.vex-dialog-message')
 			.should('have.text', 'Please use the copy/paste buttons on your on-screen keyboard.');
 
-		cy.get('.vex-dialog-button-primary.vex-dialog-button.vex-first')
+		cy.get('.vex-dialog-button-primary.vex-dialog-button')
 			.click();
 
 		cy.get('.vex-dialog-form')

--- a/cypress_test/integration_tests/mobile/writer/hamburger_menu_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/hamburger_menu_spec.js
@@ -186,7 +186,7 @@ describe('Trigger hamburger menu options.', function() {
 		cy.get('.vex-dialog-message')
 			.should('have.text', 'Please use the copy/paste buttons on your on-screen keyboard.');
 
-		cy.get('.vex-dialog-button-primary.vex-dialog-button.vex-first')
+		cy.get('.vex-dialog-button-primary.vex-dialog-button')
 			.click();
 
 		cy.get('.vex-dialog-form')
@@ -226,7 +226,7 @@ describe('Trigger hamburger menu options.', function() {
 		cy.get('.vex-dialog-message')
 			.should('have.text', 'Please use the copy/paste buttons on your on-screen keyboard.');
 
-		cy.get('.vex-dialog-button-primary.vex-dialog-button.vex-first')
+		cy.get('.vex-dialog-button-primary.vex-dialog-button')
 			.click();
 
 		cy.get('.vex-dialog-form')


### PR DESCRIPTION
No need to specify if it's first or second button as there is always
only one primary button. On top of that this avoids maintenance work
whenever for some reason the button is not the first in line.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Idd3ef60023e88d1a9a8fd6f465dc4c63c068debd
