### PR TITLE
fix trackchange comments are not displayed on docload

### DIFF
--- a/browser/src/layer/tile/CommentListSection.ts
+++ b/browser/src/layer/tile/CommentListSection.ts
@@ -1757,7 +1757,7 @@ class CommentSection {
 	private clearChanges() {
 		this.containerObject.pauseDrawing();
 		for (var i: number = this.sectionProperties.commentList.length -1; i > -1; i--) {
-			if (this.sectionProperties.commentList[i].trackchange) {
+			if (this.sectionProperties.commentList[i].sectionProperties.data.trackchange) {
 				this.containerObject.removeSection(this.sectionProperties.commentList[i].name);
 				this.sectionProperties.commentList.splice(i, 1);
 			}
@@ -1773,7 +1773,7 @@ class CommentSection {
 	private clearList () {
 		this.containerObject.pauseDrawing();
 		for (var i: number = this.sectionProperties.commentList.length -1; i > -1; i--) {
-			if (!this.sectionProperties.commentList[i].trackchange) {
+			if (!this.sectionProperties.commentList[i].sectionProperties.data.trackchange) {
 				this.containerObject.removeSection(this.sectionProperties.commentList[i].name);
 				this.sectionProperties.commentList.splice(i, 1);
 			}

--- a/browser/src/layer/tile/WriterTileLayer.js
+++ b/browser/src/layer/tile/WriterTileLayer.js
@@ -40,7 +40,6 @@ L.WriterTileLayer = L.CanvasTileLayer.extend({
 				comment.id = comment.id.toString();
 				comment.parent = comment.parent.toString();
 			});
-			app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).clearList();
 			app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).importComments(values.comments);
 		}
 		else if (values.redlines && values.redlines.length > 0) {


### PR DESCRIPTION
fix typo on clearList loop that prevents skipping trackchange
comments from being deleted

Also I removed the line in WriterTileLayer.js containing
clearList because clearList is already called on importComments
function so it was unnecessary

Signed-off-by: Mert Tumer <mert.tumer@collabora.com>
Change-Id: Ic4086a80b126aec62e382078f53d68bc17da8a1c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

