### PR TITLE
Make welcome screen configurable again

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -292,7 +292,7 @@ AC_ARG_WITH([feedback-location],
 
 AC_ARG_ENABLE(welcome-message,
     AS_HELP_STRING([--enable-welcome-message],
-        [Ensures welcome message is enabled on version update.])
+        [Enables welcome message on version update. Can be changed later in coolwsd.xml.])
 )
 
 AC_ARG_ENABLE(feedback,
@@ -783,11 +783,14 @@ AS_IF([test "$MAX_DOCUMENTS" -lt "2"],
 AC_DEFINE_UNQUOTED([MAX_DOCUMENTS],[$MAX_DOCUMENTS],[Limit the maximum number of open documents])
 AC_SUBST(MAX_DOCUMENTS)
 
+ENABLE_WELCOME_MESSAGE=false
+AS_IF([test "$enable_welcome_message" = "yes"],
+      [ENABLE_WELCOME_MESSAGE="true"])
+AC_DEFINE_UNQUOTED([ENABLE_WELCOME_MESSAGE],["$ENABLE_WELCOME_MESSAGE"],[Should the Release notes message on startup be enabled by default?])
+AC_SUBST(ENABLE_WELCOME_MESSAGE)
+
 ENABLE_FEEDBACK=
 FEEDBACK_LOCATION=
-
-WELCOME_CONFIG_FRAGMENT=/dev/null
-ENABLE_WELCOME_MESSAGE=0
 
 if test "$enable_feedback" = "yes"; then
    ENABLE_FEEDBACK="true"
@@ -797,12 +800,6 @@ if test "$enable_feedback" = "yes"; then
    else
        FEEDBACK_LOCATION="http://127.0.0.1:8000/Rate/feedback.html"
    fi
-
-   if test "$enable_welcome_message" = "yes"; then # allow configuration
-      ENABLE_WELCOME_MESSAGE=1
-   else
-      WELCOME_CONFIG_FRAGMENT=$srcdir/coolwsd-welcome.xml
-   fi
 fi
 
 AC_DEFINE_UNQUOTED([ENABLE_FEEDBACK],["$ENABLE_FEEDBACK"],[User feedback rating])
@@ -810,9 +807,11 @@ AC_DEFINE_UNQUOTED([FEEDBACK_LOCATION],["$FEEDBACK_LOCATION"],[User feedback URL
 AC_SUBST(ENABLE_FEEDBACK)
 AM_CONDITIONAL([ENABLE_FEEDBACK], [test "$ENABLE_FEEDBACK" = "true"])
 
-AC_SUBST_FILE([WELCOME_CONFIG_FRAGMENT])
-AC_DEFINE_UNQUOTED([ENABLE_WELCOME_MESSAGE],$ENABLE_WELCOME_MESSAGE,[Should the Release notes message be shown on upgrade])
-AC_SUBST(ENABLE_WELCOME)
+ENABLE_WELCOME_MESSAGE_BUTTON=false
+AS_IF([test "$enable_welcome_message_button" = "yes"],
+      [ENABLE_WELCOME_MESSAGE_BUTTON="true"])
+AC_DEFINE_UNQUOTED([ENABLE_WELCOME_MESSAGE_BUTTON],["$ENABLE_WELCOME_MESSAGE_BUTTON"],[Should the Release notes message on startup should have a dismiss button instead of an x button to close by default?])
+AC_SUBST(ENABLE_WELCOME_MESSAGE_BUTTON)
 
 VEREIGN_URL=
 if test "$enable_vereign" = "yes"; then

--- a/coolwsd-welcome.xml
+++ b/coolwsd-welcome.xml
@@ -1,5 +1,0 @@
-    <welcome>
-      <enable type="bool" desc="Controls whether the welcome screen should be shown to the users on new install and updates." default="false">false</enable>
-      <enable_button type="bool" desc="Controls whether the welcome screen should have an explanatory button instead of an X button to close the dialog." default="true">true</enable_button>
-      <path desc="Path to 'welcome-$lang.html' files served on first start or when the version changes. When empty, defaults to the Release notes." type="path" relative="true" default="browser/welcome"></path>
-    </welcome>

--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -180,7 +180,11 @@
       <text desc="Watermark text to be displayed on the document if entered" type="string"></text>
     </watermark>
 
-    @WELCOME_CONFIG_FRAGMENT@
+    <welcome>
+      <enable type="bool" desc="Controls whether the welcome screen should be shown to the users on new install and updates." default="@ENABLE_WELCOME_MESSAGE@">@ENABLE_WELCOME_MESSAGE@</enable>
+      <enable_button type="bool" desc="Controls whether the welcome screen should have an explanatory button instead of an X button to close the dialog." default="@ENABLE_WELCOME_MESSAGE_BUTTON@">@ENABLE_WELCOME_MESSAGE_BUTTON@</enable_button>
+      <path desc="Path to 'welcome-$lang.html' files served on first start or when the version changes. When empty, defaults to the Release notes." type="path" relative="true" default="browser/welcome"></path>
+    </welcome>
 
     <user_interface>
       <mode type="string" desc="Controls the user interface style. The 'default' means: Take the value from ui_defaults, or decide for one of classic or notebookbar (default|classic|notebookbar)" default="default">default</mode>

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -1486,8 +1486,8 @@ void COOLWSD::innerInitialize(Application& self)
         { "trace.path[@compress]", "true" },
         { "trace.path[@snapshot]", "false" },
         { "trace[@enable]", "false" },
-        { "welcome.enable", "false" },
-        { "welcome.enable_button", "true" },
+        { "welcome.enable", ENABLE_WELCOME_MESSAGE },
+        { "welcome.enable_button", ENABLE_WELCOME_MESSAGE_BUTTON },
         { "welcome.path", "browser/welcome" },
 #ifdef ENABLE_FEATURE_LOCK
         { "feature_lock.locked_hosts[@allow]", "false"},
@@ -1862,11 +1862,6 @@ void COOLWSD::innerInitialize(Application& self)
         Quarantine::createQuarantineMap();
     }
 
-#if ENABLE_WELCOME_MESSAGE
-    conf.setString("welcome.enable", "true");
-    conf.setString("welcome.enable_button", "false");
-    conf.setString("welcome.path", "browser/welcome");
-#endif
     WelcomeFilesRoot = getPathFromConfig("welcome.path");
     if (!getConfigValue<bool>(conf, "welcome.enable", true))
         WelcomeFilesRoot = "";

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -1036,15 +1036,10 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     const unsigned int idleTimeoutSecs = config.getUInt("per_view.idle_timeout_secs", 900);
     Poco::replaceInPlace(preprocess, std::string("%IDLE_TIMEOUT_SECS%"), std::to_string(idleTimeoutSecs));
 
-#if ENABLE_WELCOME_MESSAGE
-    std::string enableWelcomeMessage = "true";
-    std::string enableWelcomeMessageButton = "false";
-#else // configurable
     std::string enableWelcomeMessage = stringifyBoolFromConfig(config, "welcome.enable", false);
-    std::string enableWelcomeMessageButton = stringifyBoolFromConfig(config, "welcome.enable_button", false);
-#endif
-
     Poco::replaceInPlace(preprocess, std::string("%ENABLE_WELCOME_MSG%"), enableWelcomeMessage);
+
+    std::string enableWelcomeMessageButton = stringifyBoolFromConfig(config, "welcome.enable_button", false);
     Poco::replaceInPlace(preprocess, std::string("%ENABLE_WELCOME_MSG_BTN%"), enableWelcomeMessageButton);
 
     // the config value of 'notebookbar' or 'classic' overrides the UIMode


### PR DESCRIPTION
This reverts commit 16386b9aaf2a92a0661d3689078de86285894486.

Forcibly enabling the welcome screen at build-time introduces usability
and accessibility issues for some people.

* Resolves: #4489
* Target version: master 

### Summary

Commit 16386b9aaf2a92a0661d3689078de86285894486 forcibly enables the welcome screen at build time for some builds. This is not a good idea as it breaks both usabilty and accessibility.

Main usability issue: People do not know how to close the welcome dialog (I noticed that especially with older people in my family)

Accessibility issue: The welcome-screen is not keyboard-closable (through Esc). People with limited vision or limited mouse capabilities cannot use Collabora Online as they used to be any more.

### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

