### PR TITLE
sanitizers: fix unit-base, again

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -102,7 +102,6 @@ wsd_sources = \
             ../common/Authorization.cpp \
             ../kit/Kit.cpp \
             ../kit/TestStubs.cpp \
-            ../wsd/HostUtil.cpp \
             ../wsd/FileServerUtil.cpp \
             ../wsd/RequestDetails.cpp \
             ../wsd/TileCache.cpp \

--- a/wsd/RequestDetails.cpp
+++ b/wsd/RequestDetails.cpp
@@ -282,6 +282,7 @@ Poco::URI RequestDetails::sanitizeURI(const std::string& uri)
     return uriPublic;
 }
 
+#if !defined(BUILDING_TESTS)
 std::string RequestDetails::getDocKey(const Poco::URI& uri)
 {
     std::string docKey;
@@ -296,5 +297,6 @@ std::string RequestDetails::getDocKey(const Poco::URI& uri)
     LOG_INF("DocKey from URI [" << uri.toString() << "] => [" << docKey << ']');
     return docKey;
 }
+#endif // !defined(BUILDING_TESTS)
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */


### PR DESCRIPTION
==4544==ERROR: AddressSanitizer: odr-violation (0x000002c40140):
  [1] size=104 'HostUtil::WopiHosts' ../wsd/HostUtil.cpp:12:34
  [2] size=104 'HostUtil::WopiHosts' wsd/HostUtil.cpp:12:34
These globals were registered at these points:
  [1]:
    #0 0x71f618 in __asan_register_globals.part.13 /home/vmiklos/git/libreoffice/lode/packages/llvm-llvmorg-9.0.1.src/compiler-rt/lib/asan/asan_globals.cc:362
    #1 0x7f00cb0f3d7b in asan.module_ctor (/home/vmiklos/git/libreoffice/online-san/test/../test/.libs/unit-base.so+0x10e0d7b)

  [2]:
    #0 0x71f618 in __asan_register_globals.part.13 /home/vmiklos/git/libreoffice/lode/packages/llvm-llvmorg-9.0.1.src/compiler-rt/lib/asan/asan_globals.cc:362
    #1 0x120e2ae in asan.module_ctor (/home/vmiklos/git/libreoffice/online-san/coolwsd+0x120e2ae)

==4544==HINT: if you don't care about these errors you may set ASAN_OPTIONS=detect_odr_violation=0
SUMMARY: AddressSanitizer: odr-violation: global 'HostUtil::WopiHosts' at ../wsd/HostUtil.cpp:12:34
==4544==ABORTING

All of HostUtil was duplicated between the test shared objects and
coolwsd, so remove it from the test objects and rather exclude
RequestDetails::getDocKey() from the test objects instead, which was
linked in but was not used in practice.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Ia2147c89cf4230df97a8f45ac7d509aa11cdca97
