### PR TITLE
Script to rewrite coolwsd.xml based on the aliasgroup<number> envvars

### DIFF
--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -1110,9 +1110,9 @@ int main(int argc, char**argv)
     /// Mainly used to match WOPI hosts patterns
     bool matchRegex(const std::set<std::string>& set, const std::string& subject);
 
-    /// Return true if the subject matches in given map. It uses regex
+    /// Return value from key:value pair if the subject matches in given map. It uses regex
     /// Mainly used to match WOPI hosts patterns
-    bool matchRegex(const std::map<std::string, std::string>& map, const std::string& subject);
+    std::string getValue(const std::map<std::string, std::string>& map, const std::string& subject);
 
     /// Given one or more patterns to allow, and one or more to deny,
     /// the match member will return true if, and only if, the subject

--- a/docker/from-packages/RHEL8
+++ b/docker/from-packages/RHEL8
@@ -24,7 +24,6 @@ ARG type
 ARG secret_key
 
 # Environment variables
-ENV domain localhost
 ENV LC_CTYPE C.UTF-8
 
 # Setup scripts for Collabora Online
@@ -34,6 +33,7 @@ RUN rm -rf /install-collabora-online-rhel8.sh
 
 # Start script for Collabora Online
 ADD /scripts/start-collabora-online.sh /
+ADD /scripts/start-collabora-online.pl /
 
 EXPOSE 9980
 

--- a/docker/from-packages/Ubuntu
+++ b/docker/from-packages/Ubuntu
@@ -24,7 +24,6 @@ ARG type
 ARG secret_key
 
 # Environment variables
-ENV domain localhost
 ENV LC_CTYPE C.UTF-8
 
 # Setup scripts for Collabora Online
@@ -34,6 +33,7 @@ RUN rm -rf /install-collabora-online-ubuntu.sh
 
 # Start script for Collabora Online
 ADD /scripts/start-collabora-online.sh /
+ADD /scripts/start-collabora-online.pl /
 
 EXPOSE 9980
 

--- a/docker/from-packages/scripts/start-collabora-online.pl
+++ b/docker/from-packages/scripts/start-collabora-online.pl
@@ -1,0 +1,84 @@
+#!/usr/bin/perl -w
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# At some stage, the hope is that the functionality of
+# start-collabora-online.sh will be moved here; for the moment
+# it only rewrites the alias_groups in coolwsd.xml according to
+# the envvar settings
+
+use strict;
+
+# create the part of the config that contains aliases based on the aliasgroupN envvars
+sub generate_aliases() {
+    my $output = '';
+    foreach (sort keys(%ENV)) {
+        if (/^aliasgroup/) {
+            my $value = $ENV{$_};
+            my @aliases = split(',', $value);
+
+            if (@aliases) {
+                $output .= "                <group>\n";
+
+                my $first = 1;
+                foreach (@aliases) {
+                    if ($first) {
+                        $output .= "                    <host desc=\"hostname to allow or deny.\" allow=\"true\">$_</host>\n";
+                        $first = 0;
+                    }
+                    else {
+                        $output .= "                    <alias desc=\"regex pattern of aliasname\">$_</alias>\n";
+                    }
+                }
+
+                $output .= "                </group>\n";
+            }
+        }
+    }
+
+    return $output;
+}
+
+# Update the /etc/coolwsd/coolwsd.xml according to the env. variables from the YAML file
+sub rewrite_config($) {
+    my ($config) = @_;
+    my $output = '';
+
+    open(CONFIG, '<', $config) or die $!;
+
+    my $in_aliases = 0;
+    while (<CONFIG>) {
+        if (/<alias_groups/) {
+            $in_aliases = 1;
+
+            my $groups = generate_aliases();
+
+            # add the aliases if there are any
+            if ($groups ne "") {
+                s/mode="[^"]*"/mode="groups"/;
+                $output .= $_;
+                $output .= $groups;
+            }
+            else {
+                s/mode="[^"]*"/mode="first"/;
+                $output .= $_;
+            }
+        }
+        elsif ($in_aliases && /<\/alias_groups>/) {
+            $in_aliases = 0;
+            $output .= $_;
+        }
+        elsif (!$in_aliases) {
+            $output .= $_;
+        }
+    }
+
+    close(CONFIG);
+
+    open(CONFIG, '>', $config) or die $!;
+    print(CONFIG $output);
+    close(CONFIG);
+}
+
+rewrite_config('/etc/coolwsd/coolwsd.xml');

--- a/docker/from-packages/scripts/start-collabora-online.sh
+++ b/docker/from-packages/scripts/start-collabora-online.sh
@@ -36,7 +36,11 @@ fi
 
 # Replace trusted host and set admin username and password - only if they are set
 if test -n "${domain}"; then
-    perl -pi -e "s/localhost<\/host>/${domain}<\/host>/g" /etc/coolwsd/coolwsd.xml
+    echo -e "ERR: Use of domain variable is not supported. First host/domain who tries to connect to COOL is always allowed.\nTo allow multiple host and its aliases use something like this and pass it as env variable:\naliasgroup1=https://domain1:443,https://its-alias|its-second-alias:443 \naliasgroup2=https://domain2:443,https://its-alias:443 \nFor more info: https://sdk.collaboraonline.com/docs/installation/CODE_Docker_image.html"
+    exit 1
+fi
+if test -n "${aliasgroup1}"; then
+    perl -w /start-collabora-online.pl
 fi
 if test -n "${username}"; then
     perl -pi -e "s/<username (.*)>.*<\/username>/<username \1>${username}<\/username>/" /etc/coolwsd/coolwsd.xml

--- a/docker/from-source/.gitignore
+++ b/docker/from-source/.gitignore
@@ -1,1 +1,2 @@
 start-collabora-online.sh
+start-collabora-online.pl

--- a/docker/from-source/Debian
+++ b/docker/from-source/Debian
@@ -21,6 +21,7 @@ COPY /instdir /
 
 # copy the shell script which can start Collabora Online (coolwsd)
 COPY /start-collabora-online.sh /
+COPY /start-collabora-online.pl /
 
 # set up Collabora Online (normally done by postinstall script of package)
 # Fix permissions

--- a/docker/from-source/Ubuntu
+++ b/docker/from-source/Ubuntu
@@ -22,6 +22,7 @@ COPY /instdir /
 
 # copy the shell script which can start Collabora Online (coolwsd)
 COPY /start-collabora-online.sh /
+COPY /start-collabora-online.pl /
 
 # set up Collabora Online (normally done by postinstall script of package)
 # Fix permissions

--- a/docker/from-source/build.sh
+++ b/docker/from-source/build.sh
@@ -131,6 +131,7 @@ cp -a core/instdir "$INSTDIR"/opt/lokit
 if [ -z "$NO_DOCKER_IMAGE" ]; then
   cd "$SRCDIR"
   cp ../from-packages/scripts/start-collabora-online.sh .
+  cp ../from-packages/scripts/start-collabora-online.pl .
   docker build --no-cache -t $DOCKER_HUB_REPO:$DOCKER_HUB_TAG -f $HOST_OS . || exit 1
 else
   echo "Skipping docker image build"

--- a/docker/from-source/openSUSE
+++ b/docker/from-source/openSUSE
@@ -16,6 +16,7 @@ COPY /instdir /
 
 # copy the shell script which can start Collabora Online (coolwsd)
 COPY /start-collabora-online.sh /
+COPY /start-collabora-online.pl /
 
 # set up Collabora Online (normally done by postinstall script of package)
 # Fix permissions


### PR DESCRIPTION
This is to be able to define the alias groups via YAML easily, like:

    environment:
      - aliasgroup1=https://servername:443,https://its-alias:443,https://its-second-alias:443
      - aliasgroup2=https://second-servername:443,https://seconds-alias:443

Signed-off-by: Jan Holesovsky <kendy@collabora.com>
Change-Id: Ib653f7ab420fed342a00f5f5997a113da9739866
