### PR TITLE
Fix IconView breakage on gecko based browsers (e.g.:FF)

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -496,7 +496,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 /* Icon View */
 
 .ui-iconview {
-	overflow: overlay;
+	overflow: auto;
 	display: inline-flex;
 	display: -ms-inline-flexbox;
 	flex-wrap: wrap;


### PR DESCRIPTION
Example: Fontwork dialog

Avoid using webKit and Blink only values such as "overlay" for overflow
instead, use auto which in practice has the same behavior.
Fixes:
https://archive.org/download/4d-1475b-46-fix-icon-view-breakage/4d1475b46-Fix-IconView-breakage.png

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I35e27204f0653f8eae973e830dcc701d0ca782b0
