### PR TITLE
Calc Notebookbar: Add missing Define and Manage Names

### DIFF
--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -1017,6 +1017,8 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				'command': '.uno:HyperlinkDialog'
 			},
 			{
+				'id': 'Insert-Section-NameRangesTable-Ext',
+				'type': 'container',
 				'children': [
 					{
 						'type': 'toolbox',


### PR DESCRIPTION
With the reorganization of Calc tabs:
584e139bbdfd1870c15cb5ad141ee15421e9aefc both Define and Manage names
disappear form the notebookbar. Add it back following the same new
organization.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I06740e225090407117e8b5a6aff54b476368e358
