### PR TITLE
jsdialog: a11y: make widgets focusable fixes #2965

### DIFF
--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -280,6 +280,8 @@ L.Control.JSDialog = L.Control.extend({
 				container.querySelector('[id=\'' + focusWidgetId + '\']') : null;
 			if (focusWidget)
 				focusWidget.focus();
+			if (focusWidget && document.activeElement !== focusWidget)
+				console.error('cannot get focus for widget: "' + focusWidgetId + '"');
 		};
 
 		this.dialogs[data.id] = {

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2961,13 +2961,17 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		if (!parent || !data || !data.id || data.id === '')
 			return;
 
+		var control = parent.querySelector('[id=\'' + data.id + '\']');
 		if (data.visible === 'false' || data.visible === false) {
-			var control = parent.querySelector('[id=\'' + data.id + '\']');
 			if (control)
 				L.DomUtil.addClass(control, 'hidden');
 			else if (parent.id === data.id)
 				L.DomUtil.addClass(parent, 'hidden');
 		}
+
+		// natural tab-order when using keyboard navigation
+		if (control && !control.hasAttribute('tabIndex'))
+			control.setAttribute('tabIndex', '0');
 	},
 
 	build: function(parent, data, hasVerticalParent, parentHasManyChildren) {


### PR DESCRIPTION
- now widgets are accessible using tab key
- can close all dialogs with ESC key
