### PR TITLE
change blinking cursor color to black

### DIFF
--- a/browser/css/leaflet.css
+++ b/browser/css/leaflet.css
@@ -681,7 +681,7 @@ div.leaflet-cursor-container:hover > .leaflet-cursor-header {
 
 @keyframes blink {
 	from, to {
-		background: var(--color-background-darker);
+		background: #000;
 	}
 	50% {
 		background: transparent;
@@ -690,7 +690,7 @@ div.leaflet-cursor-container:hover > .leaflet-cursor-header {
 
 @-moz-keyframes blink {
 	from, to {
-		background: var(--color-background-darker);
+		background: #000;
 	}
 	50% {
 		background: transparent;
@@ -699,7 +699,7 @@ div.leaflet-cursor-container:hover > .leaflet-cursor-header {
 
 @-webkit-keyframes blink {
 	from, to {
-		background: var(--color-background-darker);
+		background: #000;
 	}
 	50% {
 		background: transparent;
@@ -708,7 +708,7 @@ div.leaflet-cursor-container:hover > .leaflet-cursor-header {
 
 @-ms-keyframes blink {
 	from, to {
-		background: var(--color-background-darker);
+		background: #000;
 	}
 	50% {
 		background: transparent;
@@ -717,7 +717,7 @@ div.leaflet-cursor-container:hover > .leaflet-cursor-header {
 
 @-o-keyframes blink {
 	from, to {
-		background: var(--color-background-darker);
+		background: #000;
 	}
 	50% {
 		background: transparent;


### PR DESCRIPTION
now, it uses a css theme variable for the color
but it is a kind of light grayish and it is harder
to see in a crowded document.

Signed-off-by: Mert Tumer <mert.tumer@collabora.com>
Change-Id: Iec5a7efdb4cb385512226841b036eba3b3212427


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

