### PR TITLE
compile SSL tests only when SSL is enabled

### DIFF
--- a/test/HttpRequestTests.cpp
+++ b/test/HttpRequestTests.cpp
@@ -44,8 +44,9 @@
 class HttpRequestTests final : public CPPUNIT_NS::TestFixture
 {
     CPPUNIT_TEST_SUITE(HttpRequestTests);
-
+#if ENABLE_SSL
     CPPUNIT_TEST(testSslHostname);
+#endif
     CPPUNIT_TEST(testInvalidURI);
     CPPUNIT_TEST(testBadResponse);
     CPPUNIT_TEST(testGoodResponse);
@@ -62,8 +63,9 @@ class HttpRequestTests final : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST(testOnFinished_Timeout);
 
     CPPUNIT_TEST_SUITE_END();
-
+#if ENABLE_SSL
     void testSslHostname();
+#endif
     void testInvalidURI();
     void testBadResponse();
     void testGoodResponse();
@@ -168,6 +170,7 @@ public:
 
 constexpr std::chrono::seconds HttpRequestTests::DefTimeoutSeconds;
 
+#if ENABLE_SSL
 void HttpRequestTests::testSslHostname()
 {
     constexpr auto testname = __func__;
@@ -180,6 +183,7 @@ void HttpRequestTests::testSslHostname()
         LOK_ASSERT_EQUAL(host, socket->getSslServername());
     }
 }
+#endif
 
 void HttpRequestTests::testInvalidURI()
 {


### PR DESCRIPTION
Signed-off-by: Pranam Lashkari <lpranam@collabora.com>
Change-Id: I05d532d38e4f439987e558897ab552e8df3bb3ab

* Target version: master 

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

