### PR TITLE
wsd: test: exclude SSL test when not built with --enable-ssl

### DIFF
--- a/test/HttpRequestTests.cpp
+++ b/test/HttpRequestTests.cpp
@@ -170,6 +170,7 @@ constexpr std::chrono::seconds HttpRequestTests::DefTimeoutSeconds;
 
 void HttpRequestTests::testSslHostname()
 {
+#ifdef ENABLE_SSL
     constexpr auto testname = __func__;
 
     if (helpers::haveSsl())
@@ -179,6 +180,7 @@ void HttpRequestTests::testSslHostname()
             host, _port, false, std::make_shared<ServerRequestHandler>());
         LOK_ASSERT_EQUAL(host, socket->getSslServername());
     }
+#endif // ENABLE_SSL
 }
 
 void HttpRequestTests::testInvalidURI()


### PR DESCRIPTION
Fixes the build failure reported in #4517.