### PR TITLE
check enable_ssl for testSslHostname test

### DIFF
--- a/test/HttpRequestTests.cpp
+++ b/test/HttpRequestTests.cpp
@@ -44,8 +44,9 @@
 class HttpRequestTests final : public CPPUNIT_NS::TestFixture
 {
     CPPUNIT_TEST_SUITE(HttpRequestTests);
-
+#if ENABLE_SSL
     CPPUNIT_TEST(testSslHostname);
+#endif
     CPPUNIT_TEST(testInvalidURI);
     CPPUNIT_TEST(testBadResponse);
     CPPUNIT_TEST(testGoodResponse);
@@ -62,8 +63,9 @@ class HttpRequestTests final : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST(testOnFinished_Timeout);
 
     CPPUNIT_TEST_SUITE_END();
-
+#if ENABLE_SSL
     void testSslHostname();
+#endif
     void testInvalidURI();
     void testBadResponse();
     void testGoodResponse();
@@ -168,6 +170,7 @@ public:
 
 constexpr std::chrono::seconds HttpRequestTests::DefTimeoutSeconds;
 
+#if ENABLE_SSL
 void HttpRequestTests::testSslHostname()
 {
     constexpr auto testname = __func__;
@@ -180,6 +183,7 @@ void HttpRequestTests::testSslHostname()
         LOK_ASSERT_EQUAL(host, socket->getSslServername());
     }
 }
+#endif
 
 void HttpRequestTests::testInvalidURI()
 {


### PR DESCRIPTION
Fixes build error when configured with flag --disable-ssl

Signed-off-by: Mert Tumer <mert.tumer@collabora.com>
Change-Id: I18f60edd4fb42bccb28e4ef29f68bc7e2952f060


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

