### PR TITLE
Fix views after the first one change spellOnline status

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1532,8 +1532,11 @@ private:
         }
 
         // By default we enable spell-checking, unless it's disabled explicitly.
-        const bool bSet = (spellOnline != "false");
-        renderOptsObj->set(".uno:SpellOnline", makePropertyValue("boolean", bSet));
+        if (!spellOnline.empty())
+        {
+            const bool bSet = (spellOnline != "false");
+            renderOptsObj->set(".uno:SpellOnline", makePropertyValue("boolean", bSet));
+        }
 
         if (renderOptsObj)
         {


### PR DESCRIPTION
the state is explicitly set by the first view but on makeRenderParams
function we dont check if the spellonline is empty or not, if empty
we should not change the state. It is only empty for views after the
first one

Signed-off-by: Mert Tumer <mert.tumer@collabora.com>
Change-Id: Ief5754bdae2eb952c2df9485fa323fc957da40a6


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

