### PR TITLE
fix build of HttpRequestTests when SSL is disabled

### DIFF
--- a/test/HttpRequestTests.cpp
+++ b/test/HttpRequestTests.cpp
@@ -170,6 +170,7 @@ constexpr std::chrono::seconds HttpRequestTests::DefTimeoutSeconds;
 
 void HttpRequestTests::testSslHostname()
 {
+#if ENABLE_SSL
     constexpr auto testname = __func__;
 
     if (helpers::haveSsl())
@@ -179,6 +180,7 @@ void HttpRequestTests::testSslHostname()
             host, _port, false, std::make_shared<ServerRequestHandler>());
         LOK_ASSERT_EQUAL(host, socket->getSslServername());
     }
+#endif
 }
 
 void HttpRequestTests::testInvalidURI()


### PR DESCRIPTION
We can't test SSL when SSL is disabled.

Signed-off-by: Tomaž Vajngerl <tomaz.vajngerl@collabora.co.uk>
Change-Id: I231a3c7d32f848870e90594e2d1151d3a0911f9a


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

