### PR TITLE
Revert "Sidebar Widget right alignment with text-align"

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -47,7 +47,6 @@
 	color: var(--color-main-text);
 	font-size: var(--default-font-size);
 	line-height: var(--default-height);
-	text-align: left;
 }
 #glowframe > div.ui-frame.jsdialog.sidebar > span,
 #softedgeframe > div.ui-frame.jsdialog.sidebar > span {

--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -57,7 +57,6 @@
 	margin: 5px;
 	position: relative;
 	margin-inline-start: calc(-40px);
-	text-align: left;
 }
 
 .sidebar.ui-listbox {
@@ -69,7 +68,6 @@
 }
 .sidebar.jsdialog.menubutton {
 	padding: 4px 10px;
-	text-align: left;
 }
 .sidebar.jsdialog.ui-listbox,
 .sidebar.jsdialog.menubutton {
@@ -126,7 +124,6 @@
 #selectcolor {
 	display: flex;
 	justify-content: flex-end;
-	text-align: right;
 }
 
 .sidebar.jsdialog.cell > #table-box3 {
@@ -137,7 +134,6 @@
 .sidebar.jsdialog.cell > #table-box4 {
 	display: flex;
 	justify-content: flex-end;
-	text-align: right;
 }
 
 #ShadowPropertyPanel div#table-grid3 table#grid3 td:nth-child(1) {
@@ -203,13 +199,11 @@ div#thousandseparator.checkbutton.jsdialog.sidebar {
 .sidebar.jsdialog.cell > #table-box4 > .sidebar.jsdialog.row > .sidebar.jsdialog.cell:nth-child(4) {
 	display: flex;
 	justify-content: flex-end;
-	text-align: right;
 }
 
 #table-paperformat, #table-orientation, #table-fillstyle, #table-masterslide,
 #table-marginLB, #displaymasterbackground, #displaymasterobjects, #table-box1 {
 	width: 100%;
-	text-align: left;
 }
 
 #TableEditPanel #table-grid1 #grid1 > tr > td:nth-child(2) {


### PR DESCRIPTION
This reverts commit 32f5c874e71c347fa0eaad3c7a9489353efb9744.
The text alignment is causing some problems both on the sidebar and in
the mobile wizard:
- Sidebar arrows (from dropdown menus) position are affected due to this
- Mobilewizard: content is getting wrongly aligned to the right
- On top of that we should preffer start and end due to RTL instead of
right or left

https://archive.org/details/cool-txt-align-bug

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I02f22da0b14b02e7431ea26c16930554e3c13aa2


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

