### PR TITLE
browser: add last modification and document status at the bottom

### DIFF
--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -1815,3 +1815,12 @@ menu-entry-with-icon.padding-left + menu-entry-icon.width */
 	font-size: var(--default-font-size);
 	color: var(--color-main-text);
 }
+
+#saved-status-label {
+	background-image: url("data:image/svg+xml,%3Csvg id='Icons' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Cdefs%3E%3Cstyle%3E.cls-1%7Bfill:%235cb82a;%7D.cls-2%7Bfill:%23fff;%7D%3C/style%3E%3C/defs%3E%3Ctitle%3E_%3C/title%3E%3Cg id='Funktions-Icons_24' data-name='Funktions-Icons 24'%3E%3Ccircle class='cls-1' cx='10' cy='10' r='10'/%3E%3Crect class='cls-2' x='3.36' y='10.52' width='6.75' height='2.5' rx='0.5' ry='0.5' transform='translate(10.29 -1.31) rotate(45)'/%3E%3Crect class='cls-2' x='5.63' y='8.75' width='11.75' height='2.5' rx='0.5' ry='0.5' transform='translate(-3.7 11.06) rotate(-45)'/%3E%3C/g%3E%3C/svg%3E");
+	background-position: left center;
+	background-repeat: no-repeat;
+	padding-left: 18px;
+	margin-left: 15px;
+	white-space: nowrap;
+}

--- a/browser/html/cool.html.m4
+++ b/browser/html/cool.html.m4
@@ -253,6 +253,7 @@ m4_ifelse(MOBILEAPP, [true],
       data-enable-accessibility = "%ENABLE_ACCESSIBILITY%"
       data-out-of-focus-timeout-secs = "%OUT_OF_FOCUS_TIMEOUT_SECS%"
       data-idle-timeout-secs = "%IDLE_TIMEOUT_SECS%"
+      data-min-saved-message-timeout-secs = %MIN_SAVED_MESSAGE_TIMEOUT_SECS%;
       data-protocol-debug = "%PROTOCOL_DEBUG%"
       data-enable-debug = "%ENABLE_DEBUG%"
       data-frame-ancestors = "%FRAME_ANCESTORS%"

--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -2574,6 +2574,7 @@ L.Control.Menubar = L.Control.extend({
 	_onInitModificationIndicator: function(lastmodtime) {
 		var lastModButton = L.DomUtil.get('menu-last-mod');
 		if (lastModButton !== null && lastModButton !== undefined
+			&& lastModButton.firstChild
 			&& lastModButton.firstChild.innerHTML !== null
 			&& lastModButton.firstChild.childElementCount == 0) {
 			if (lastmodtime == null) {
@@ -2584,8 +2585,6 @@ L.Control.Menubar = L.Control.extend({
 			var mainSpan = document.createElement('span');
 			this.lastModIndicator = document.createElement('span');
 			mainSpan.appendChild(this.lastModIndicator);
-
-			//this._map.updateModificationIndicator(this._lastmodtime);
 
 			// Replace menu button body with new content
 			lastModButton.firstChild.replaceChildren();
@@ -2600,7 +2599,7 @@ L.Control.Menubar = L.Control.extend({
 	},
 	_onUpdateModificationIndicator: function(e) {
 		if (this.lastModIndicator !== null && this.lastModIndicator !== undefined) {
-			this.lastModIndicator.innerHTML = e.lastSaved;
+			this.lastModIndicator.textContent = e.lastSaved;
 		}
 	}
 });

--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -1394,6 +1394,8 @@ L.Control.Menubar = L.Control.extend({
 		map.on('addmenu', this._addMenu, this);
 		map.on('languagesupdated', this._onInitLanguagesMenu, this);
 		map.on('updatetoolbarcommandvalues', this._onStyleMenu, this);
+		map.on('initmodificationindicator', this._onInitModificationIndicator, this);
+		map.on('updatemodificationindicator', this._onUpdateModificationIndicator, this);
 	},
 
 	onRemove: function() {
@@ -1402,6 +1404,8 @@ L.Control.Menubar = L.Control.extend({
 		this._map.off('addmenu', this._addMenu, this);
 		this._map.off('languagesupdated', this._onInitLanguagesMenu, this);
 		this._map.off('updatetoolbarcommandvalues', this._onStyleMenu, this);
+		this._map.off('initmodificationindicator', this._onInitModificationIndicator, this);
+		this._map.off('updatemodificationindicator', this._onUpdateModificationIndicator, this);
 
 		this._menubarCont.remove();
 		this._menubarCont = null;
@@ -2566,6 +2570,39 @@ L.Control.Menubar = L.Control.extend({
 		}
 		return null;
 	},
+
+	_onInitModificationIndicator: function(lastmodtime) {
+		var lastModButton = L.DomUtil.get('menu-last-mod');
+		if (lastModButton !== null && lastModButton !== undefined
+			&& lastModButton.firstChild.innerHTML !== null
+			&& lastModButton.firstChild.childElementCount == 0) {
+			if (lastmodtime == null) {
+				// No modification time -> hide the indicator
+				L.DomUtil.setStyle(lastModButton, 'display', 'none');
+				return;
+			}
+			var mainSpan = document.createElement('span');
+			this.lastModIndicator = document.createElement('span');
+			mainSpan.appendChild(this.lastModIndicator);
+
+			//this._map.updateModificationIndicator(this._lastmodtime);
+
+			// Replace menu button body with new content
+			lastModButton.firstChild.replaceChildren();
+			lastModButton.firstChild.appendChild(mainSpan);
+
+			if (L.Params.revHistoryEnabled) {
+				L.DomUtil.setStyle(lastModButton, 'cursor', 'pointer');
+			}
+
+			this._map.fire('modificationindicatorinitialized');
+		}
+	},
+	_onUpdateModificationIndicator: function(e) {
+		if (this.lastModIndicator !== null && this.lastModIndicator !== undefined) {
+			this.lastModIndicator.innerHTML = e.lastSaved;
+		}
+	}
 });
 
 L.control.menubar = function (options) {

--- a/browser/src/control/Control.StatusBar.js
+++ b/browser/src/control/Control.StatusBar.js
@@ -242,6 +242,7 @@ class StatusBar extends JSDialog.Toolbar {
 			this._generateHtmlItem('permissionmode'),					// spreadsheet, text, presentation
 			{type: 'toolitem', id: 'signstatus', command: '.uno:Signature', w2icon: '', text: _UNO('.uno:Signature'), visible: false},
 			{type: 'spacer',  id: 'permissionspacer'},
+			{type: 'customtoolitem',  id: 'documentstatus'},
 			{type: 'customtoolitem',  id: 'prev', command: 'prev', text: _UNO('.uno:PageUp', 'text'), pressAndHold: true},
 			{type: 'customtoolitem',  id: 'next', command: 'next', text: _UNO('.uno:PageDown', 'text'), pressAndHold: true},
 			{type: 'separator', id: 'prevnextbreak', orientation: 'vertical'},

--- a/browser/src/control/Control.StatusBar.js
+++ b/browser/src/control/Control.StatusBar.js
@@ -25,6 +25,8 @@ class StatusBar extends JSDialog.Toolbar {
 		map.on('updatestatepagenumber', this.onPageChange, this);
 		map.on('search', this.onSearch, this);
 		map.on('zoomend', this.onZoomEnd, this);
+		map.on('initmodificationindicator', this.onInitModificationIndicator, this);
+		map.on('updatemodificationindicator', this.onUpdateModificationIndicator, this);
 	}
 
 	localizeStateTableCell(text) {
@@ -242,7 +244,7 @@ class StatusBar extends JSDialog.Toolbar {
 			this._generateHtmlItem('permissionmode'),					// spreadsheet, text, presentation
 			{type: 'toolitem', id: 'signstatus', command: '.uno:Signature', w2icon: '', text: _UNO('.uno:Signature'), visible: false},
 			{type: 'spacer',  id: 'permissionspacer'},
-			{type: 'customtoolitem',  id: 'documentstatus'},
+			this._generateHtmlItem('documentstatus'),					// spreadsheet, text, presentation, drawing
 			{type: 'customtoolitem',  id: 'prev', command: 'prev', text: _UNO('.uno:PageUp', 'text'), pressAndHold: true},
 			{type: 'customtoolitem',  id: 'next', command: 'next', text: _UNO('.uno:PageDown', 'text'), pressAndHold: true},
 			{type: 'separator', id: 'prevnextbreak', orientation: 'vertical'},
@@ -293,6 +295,7 @@ class StatusBar extends JSDialog.Toolbar {
 				this.showItem('StateTableCellMenu', !app.map.isReadOnlyMode());
 				this.showItem('statetablebreak', !app.map.isReadOnlyMode());
 				this.showItem('permissionmode-container', true);
+				this.showItem('documentstatus-container', true);
 			}
 			break;
 
@@ -305,6 +308,7 @@ class StatusBar extends JSDialog.Toolbar {
 				this.showItem('languagestatus', !app.map.isReadOnlyMode());
 				this.showItem('languagestatusbreak', !app.map.isReadOnlyMode());
 				this.showItem('permissionmode-container', true);
+				this.showItem('documentstatus-container', true);
 			}
 			break;
 
@@ -314,6 +318,7 @@ class StatusBar extends JSDialog.Toolbar {
 				this.showItem('languagestatus', !app.map.isReadOnlyMode());
 				this.showItem('languagestatusbreak', !app.map.isReadOnlyMode());
 				this.showItem('permissionmode-container', true);
+				this.showItem('documentstatus-container', true);
 			}
 			break;
 		case 'drawing':
@@ -322,6 +327,7 @@ class StatusBar extends JSDialog.Toolbar {
 				this.showItem('languagestatus', !app.map.isReadOnlyMode());
 				this.showItem('languagestatusbreak', !app.map.isReadOnlyMode());
 				this.showItem('permissionmode-container', true);
+				this.showItem('documentstatus-container', true);
 			}
 			break;
 		}
@@ -524,6 +530,33 @@ class StatusBar extends JSDialog.Toolbar {
 		}
 
 		JSDialog.MenuDefinitions.set('LanguageStatusMenu', menuEntries);
+	}
+
+	onInitModificationIndicator(lastmodtime) {
+		const docstatcontainer = document.getElementById('documentstatus-container');
+		if (lastmodtime == null) {
+			if (docstatcontainer !== null && docstatcontainer !== undefined) {
+				docstatcontainer.classList.add('hidden');
+			}
+			return;
+		}
+		docstatcontainer.classList.remove('hidden');
+
+		this.map.fire('modificationindicatorinitialized');
+	}
+
+	// status can be '', 'SAVING', 'MODIFIED' or 'SAVED'
+	onUpdateModificationIndicator(e) {
+		if (this._lastModstatus !== e.status) {
+			this.updateHtmlItem('DocumentStatus', e.status);
+			this._lastModStatus = e.status;
+		}
+		if (e.lastSaved !== null && e.lastSaved !== undefined) {
+			const lastSaved = document.getElementById('last-saved');
+			if (lastSaved !== null && lastSaved !== undefined) {
+				lastSaved.textContent = e.lastSaved;
+			}
+		}
 	}
 }
 

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -329,7 +329,7 @@ L.Map.include({
 	},
 
 	save: function(dontTerminateEdit, dontSaveIfUnmodified, extendedData) {
-		this.setDocumentStatus('SAVING');
+		this.fire('updatemodificationindicator', { status: 'SAVING' });
 
 		var msg = 'save' +
 					' dontTerminateEdit=' + (dontTerminateEdit ? 1 : 0) +

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -329,6 +329,8 @@ L.Map.include({
 	},
 
 	save: function(dontTerminateEdit, dontSaveIfUnmodified, extendedData) {
+		this.setDocumentStatus('SAVING');
+
 		var msg = 'save' +
 					' dontTerminateEdit=' + (dontTerminateEdit ? 1 : 0) +
 					' dontSaveIfUnmodified=' + (dontSaveIfUnmodified ? 1 : 0);

--- a/browser/src/control/jsdialog/Widget.HTMLContent.ts
+++ b/browser/src/control/jsdialog/Widget.HTMLContent.ts
@@ -118,6 +118,30 @@ function getPageStatusElements(text: string) {
 	return getStatusbarItemElements('PageStatus', _('Number of Pages'), text);
 }
 
+function getDocumentStatusElements(text: string) {
+	const docstat = getStatusbarItemElements(
+		'DocumentStatus',
+		_('Your changes have been saved'),
+		'',
+	);
+
+	if (text === 'SAVING') docstat.textContent = _('Saving...');
+	else if (text === 'SAVED') {
+		const lastSaved = document.createElement('span');
+		lastSaved.id = 'last-saved';
+		lastSaved.title = _('Your changes have been saved') + '.';
+		lastSaved.textContent = '';
+		docstat.appendChild(lastSaved);
+
+		const savedStatus = document.createElement('span');
+		savedStatus.id = 'saved-status-label';
+		savedStatus.textContent = _('Document saved');
+		docstat.appendChild(savedStatus);
+	}
+
+	return docstat;
+}
+
 var getElementsFromId = function (
 	id: string,
 	closeCallback: EventListenerOrEventListenerObject,
@@ -159,6 +183,7 @@ var getElementsFromId = function (
 	else if (id === 'statetablecell') return getStateTableCellElements(data.text);
 	else if (id === 'slidestatus') return getSlideStatusElements(data.text);
 	else if (id === 'pagestatus') return getPageStatusElements(data.text);
+	else if (id === 'documentstatus') return getDocumentStatusElements(data.text);
 };
 
 function htmlContent(

--- a/browser/src/map/Map.js
+++ b/browser/src/map/Map.js
@@ -448,7 +448,7 @@ L.Map = L.Evented.extend({
 
 		clearTimeout(this._modTimeout);
 
-		if (this._modIndicatorInitialized) {
+		if (this._modIndicatorInitialized && this._lastmodtime) {
 			var dateTime = new Date(this._lastmodtime.replace(/,.*/, 'Z'));
 			var dateValue;
 

--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -82,6 +82,7 @@
         <out_of_focus_timeout_secs desc="The maximum number of seconds before dimming and stopping updates when the browser tab is no longer in focus. Defaults to 300 seconds." type="uint" default="300">300</out_of_focus_timeout_secs>
         <idle_timeout_secs desc="The maximum number of seconds before dimming and stopping updates when the user is no longer active (even if the browser is in focus). Defaults to 15 minutes." type="uint" default="900">900</idle_timeout_secs>
         <custom_os_info desc="Custom string shown as OS version in About dialog, get from system if empty." type="string" default=""></custom_os_info>
+        <min_saved_message_timeout_secs type="uint" desc="The minimum number of seconds before the last modified message is being displayed." default="6">6</min_saved_message_timeout_secs>
     </per_view>
 
     <ver_suffix desc="Appended to etags to allow easy refresh of changed files during development" type="string" default=""></ver_suffix>

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -2115,6 +2115,7 @@ void COOLWSD::innerInitialize(Application& self)
         { "per_view.idle_timeout_secs", "900" },
         { "per_view.out_of_focus_timeout_secs", "300" },
         { "per_view.custom_os_info", "" },
+        { "per_view.min_saved_message_timeout_secs", "0"},
         { "security.capabilities", "true" },
         { "security.seccomp", "true" },
         { "security.jwt_expiry_secs", "1800" },

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -1344,6 +1344,8 @@ FileServerRequestHandler::ResourceAccessDetails FileServerRequestHandler::prepro
     Poco::replaceInPlace(preprocess, std::string("%OUT_OF_FOCUS_TIMEOUT_SECS%"), std::to_string(outOfFocusTimeoutSecs));
     const unsigned int idleTimeoutSecs = config.getUInt("per_view.idle_timeout_secs", 900);
     Poco::replaceInPlace(preprocess, std::string("%IDLE_TIMEOUT_SECS%"), std::to_string(idleTimeoutSecs));
+    const unsigned int minSavedMessTimeoutSecs = config.getUInt("per_view.min_saved_message_timeout_secs", 0);
+    Poco::replaceInPlace(preprocess, std::string("%MIN_SAVED_MESSAGE_TIMEOUT_SECS%"), std::to_string(minSavedMessTimeoutSecs));
 
     #if ENABLE_WELCOME_MESSAGE
         std::string enableWelcomeMessage = "true";


### PR DESCRIPTION
Signed-off-by: Alexandru Vlăduţu <alexandru.vladutu@1and1.ro>
Change-Id: I04891ce23e0f250243d9453bfecb0570683cae7a

- adds a last modification setting as well in coolwsd.xml so that it
displays the last modified after a certain delay
- moves the last modification text to the bottom as well as adds a new
text related to the document status (if saved)

Change-Id: I3b21274ed7557b37789f63751e0b9db583469355


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

