### PR TITLE
Private/pedro/fix mwizard base64img

### DIFF
--- a/browser/css/mobilewizard.css
+++ b/browser/css/mobilewizard.css
@@ -724,7 +724,7 @@ a.leaflet-control-zoom-in {
 	float: left;
 	padding: 20px !important;
 }
-#mobile-wizard #belowparaspacing, #mobile-wizard #spacinglabel, #mobile-wizard #OutlineRight,
+#mobile-wizard #spacinglabel, #mobile-wizard #OutlineRight,
 #mobile-wizard #DefaultBullet, #mobile-wizard #CellVertTop, #mobile-wizard #rowheight,
 #mobile-wizard #columnwidth {
 	float: left;
@@ -1231,6 +1231,7 @@ label.disabled {
 /* Paragraph properties */
 #mobile-wizard #paraspacingimg,
 #mobile-wizard #aboveparaspacingimg,
+#mobile-wizard #belowparaspacingimg,
 #mobile-wizard #indentimg,
 #mobile-wizard #beforetextindentimg,
 #mobile-wizard #aftertextindentimg {

--- a/browser/css/mobilewizard.css
+++ b/browser/css/mobilewizard.css
@@ -1232,6 +1232,7 @@ label.disabled {
 #mobile-wizard #paraspacingimg,
 #mobile-wizard #aboveparaspacingimg,
 #mobile-wizard #belowparaspacingimg,
+#mobile-wizard #firstlineindentimg,
 #mobile-wizard #indentimg,
 #mobile-wizard #beforetextindentimg,
 #mobile-wizard #aftertextindentimg {

--- a/browser/css/mobilewizard.css
+++ b/browser/css/mobilewizard.css
@@ -1229,11 +1229,11 @@ label.disabled {
 }
 
 /* Paragraph properties */
-#mobile-wizard #paraspacing + #image6,
-#mobile-wizard #aboveparaspacing + #image7,
-#mobile-wizard #indent + #image8,
-#mobile-wizard #beforetextindent + #image9,
-#mobile-wizard #aftertextindent + #image10 {
+#mobile-wizard #paraspacingimg,
+#mobile-wizard #aboveparaspacingimg,
+#mobile-wizard #indentimg,
+#mobile-wizard #beforetextindentimg,
+#mobile-wizard #aftertextindentimg {
 	display: none;
 }
 


### PR DESCRIPTION
commit d87452be1a2be2679c2dde4b48d410b38c013318 (HEAD -> private/pedro/fix-mwizard-base64img, origin/pri
vate/pedro/fix-mwizard-base64img, distro/collabora/co-21-11-3)
Author: Pedro Pinto Silva <pedro.silva@collabora.com>
Date:   Mon Apr 4 14:09:39 2022 +0200

Mobilewizard: hide firstlineident base64 img

Add to elements that should be hidden on mobile

--------------

commit be877ede616e4bed27ab62177c9a78956ded4f55
Author: Pedro Pinto Silva <pedro.silva@collabora.com>
Date:   Mon Apr 4 14:08:06 2022 +0200

Mobilewizard: fix #belowparaspacing visibility

It should not be visible:
- Update id (it now has img as sufix)
- Add to display none elements

--------------

commit 5f6b8154d808e9d6e4651c091fd67df12c7c7725
Author: Pedro Pinto Silva <pedro.silva@collabora.com>
Date:   Mon Apr 4 14:04:57 2022 +0200

Mobilewizard: Update hidden elements rules

Some elements were being on purposed set to be hidden but the ids have
changed and now the sufix img was added and so the CSS were not taking
affect anymore:
https://archive.org/download/cool-bug-mwizard-base64images/cool-bug-mwizard-base64images.png

Add sufix, update rules

--------------
