### PR TITLE
add text prop to mobilebottombar menu items

### DIFF
--- a/browser/src/control/Control.MobileBottomBar.js
+++ b/browser/src/control/Control.MobileBottomBar.js
@@ -281,6 +281,14 @@ L.Control.MobileBottomBar = L.Control.extend({
 	create: function() {
 		var toolItems = this.getToolItems(this.options.docType);
 
+		for (var i = 0; i < toolItems.length; i++) {
+			if (toolItems[i].type === 'menu' && toolItems[i].items) {
+				for (var j = 0; j < toolItems[i].items.length; j++) {
+					toolItems[i].items[j].text = toolItems[i].items[j].text || toolItems[i].items[j].hint;
+				}
+			}
+		}
+
 		var toolbar = $('#toolbar-down');
 		toolbar.w2toolbar({
 			name: 'editbar',


### PR DESCRIPTION
most of them don't have the text where they need to have
otherwise the text is defaulted to id. We can use hint prop
to text because it has the same output due to the uno command
name convention.

Signed-off-by: Mert Tumer <mert.tumer@collabora.com>
Change-Id: I0dd38ebdaaa95c41225c49e02d7615007e8a4049


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

