### PR TITLE
jsdialog: autofilter: fix fox co-22.05

### DIFF
--- a/browser/src/control/Control.AutofilterDropdown.js
+++ b/browser/src/control/Control.AutofilterDropdown.js
@@ -1,6 +1,9 @@
 /* -*- js-indent-level: 8 -*- */
 /*
- * L.Control.AutofilterDropdown
+ * L.Control.AutofilterDropdown - DEPRECATED
+ * handles autofilter dropdown in core versions < 22.05
+ * in newer core autofilter is a regular popup handled in Control.JSDialog.js
+ * TODO: remove this file when co-2021 support will be not needed
  */
 
 /* global app $ */
@@ -169,8 +172,8 @@ L.Control.AutofilterDropdown = L.Control.extend({
 		var width = $(mainContainer).width();
 		if (left + width > $('#document-container').width()) {
 			var newLeftPosition = left - width;
-			if (newTopPosition < 0)
-				newTopPosition = 0;
+			if (newLeftPosition < 0)
+				newLeftPosition = 0;
 			L.DomUtil.setStyle(mainContainer, 'margin-left', newLeftPosition + 'px');
 			this.position.x = newLeftPosition;
 		}

--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -58,15 +58,19 @@ L.Control.JSDialog = L.Control.extend({
 			builder.callback('dialog', 'close', {id: '__DIALOG__'}, null, builder);
 	},
 
+	// sendCloseEvent means that we only send a command to the server
+	// we want to kill HTML popup when we receive feedback from the server
 	closePopover: function(id, sendCloseEvent) {
-		if (!this.dialogs[id]) {
+		if (!id || !this.dialogs[id]) {
 			console.warn('missing popover data');
 			return;
 		}
 
-		L.DomUtil.remove(this.dialogs[id].overlay);
+		if (!sendCloseEvent)
+			L.DomUtil.remove(this.dialogs[id].overlay);
+
 		var clickToClose = this.dialogs[id].clickToClose;
-		var builder = this.clearDialog(id);
+		var builder = this.dialogs[id].builder;
 
 		if (sendCloseEvent) {
 			if (clickToClose && L.DomUtil.hasClass(clickToClose, 'menubutton'))
@@ -74,6 +78,8 @@ L.Control.JSDialog = L.Control.extend({
 			else
 				builder.callback('popover', 'close', {id: '__POPOVER__'}, null, builder);
 		}
+		else
+			this.clearDialog(id);
 	},
 
 	setTabs: function(tabs, builder) {


### PR DESCRIPTION
jsdialog: autofilter: unify with regular popup (from co-22.05)
- in 22.05 core autofilter was welded and converted into regular popup
- for now we have to support both versions for 2021 and 22.05:
    - for 22.05 handled in Control.JSDialog.js
    - for 2021 handled in Control.AutofilterDropdown.js
- leter we need to remove Control.AutofilterDropdown.js
- special handling in Control.JSDialog.js should be separated later...

requires core changes:
https://gerrit.libreoffice.org/c/core/+/132538
https://gerrit.libreoffice.org/c/core/+/132539
https://gerrit.libreoffice.org/c/core/+/132619