### PR TITLE
Attempt to fix a codeql error

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -6,4 +6,4 @@ queries:
 # Ignore these from being scanned
 paths-ignore:
   - '**/*w2ui-1.5.rc1.js'
-  - '/loleaflet/'
+  - 'loleaflet'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,7 +16,7 @@ on:
     # see the .github/codeql/codeql-config.yml configuration file
     paths-ignore:
       - '**/*w2ui-1.5.rc1.js'
-      - 'loleaflet/'
+      - 'loleaflet'
 
   schedule:
     - cron: '0 22 * * 3'


### PR DESCRIPTION
Running command in /home/runner/work/online/online: [/opt/hostedtoolcache/CodeQL/0.0.0-20220311/x64/codeql/javascript/tools/autobuild.sh]
[2022-04-05 08:02:27] [build-stderr] Skipping path /home/runner/work/online/online/**/*w2ui-1.5.rc1.js, which does not exist.
[2022-04-05 08:02:27] [build-stderr] Skipping path /loleaflet, which does not exist.
[2022-04-05 08:02:27] [build-stderr] Illegal '//' in exclude path
Error: 4-05 08:02:27] [ERROR] Spawned process exited abnormally (code 1; tried to run: [/opt/hostedtoolcache/CodeQL/0.0.0-20220311/x64/codeql/javascript/tools/autobuild.sh])
A fatal error occurred: Exit status 1 from command: [/opt/hostedtoolcache/CodeQL/0.0.0-20220311/x64/codeql/javascript/tools/autobuild.sh]

Signed-off-by: Jan Holesovsky <kendy@collabora.com>
Change-Id: I3bcaba31d24e9010af7d4736722cd2413d9e2ce9
