### PR TITLE
iOS app fixes

### DIFF
--- a/ios/Mobile/CODocument.h
+++ b/ios/Mobile/CODocument.h
@@ -18,6 +18,7 @@
     int fakeClientFd;
     NSURL *copyFileURL;
     unsigned appDocId;
+    bool readOnly;
 }
 
 @property (weak) DocumentViewController *viewController;

--- a/ios/Mobile/CODocument.mm
+++ b/ios/Mobile/CODocument.mm
@@ -74,7 +74,7 @@ static std::atomic<unsigned> appDocIdCounter(1);
     DocumentData::allocate(appDocId).coDocument = self;
     components.queryItems = @[ [NSURLQueryItem queryItemWithName:@"file_path" value:[copyFileURL absoluteString]],
                                [NSURLQueryItem queryItemWithName:@"closebutton" value:@"1"],
-                               [NSURLQueryItem queryItemWithName:@"permission" value:@"edit"],
+                               [NSURLQueryItem queryItemWithName:@"permission" value:(readOnly ? @"readonly" : @"edit")],
                                [NSURLQueryItem queryItemWithName:@"lang" value:app_locale],
                                [NSURLQueryItem queryItemWithName:@"appdocid" value:[NSString stringWithFormat:@"%u", appDocId]],
                                [NSURLQueryItem queryItemWithName:@"userinterfacemode" value:([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad ? @"notebookbar" : @"classic")],

--- a/ios/Mobile/DocumentBrowserViewController.mm
+++ b/ios/Mobile/DocumentBrowserViewController.mm
@@ -89,6 +89,7 @@
     DocumentViewController *documentViewController = [storyBoard instantiateViewControllerWithIdentifier:@"DocumentViewController"];
     documentViewController.document = [[CODocument alloc] initWithFileURL:documentURL];
     documentViewController.document->fakeClientFd = -1;
+    documentViewController.document->readOnly = false;
     documentViewController.document.viewController = documentViewController;
     [self presentViewController:documentViewController animated:YES completion:nil];
 }

--- a/ios/Mobile/SceneDelegate.mm
+++ b/ios/Mobile/SceneDelegate.mm
@@ -16,7 +16,7 @@ static UIViewController *bottomPresentedViewController(UIViewController *vc) {
     return bottomPresentedViewController([vc presentedViewController]);
 }
 
-static UIViewController *newDocumentViewControllerFor(NSURL *url) {
+static DocumentViewController *newDocumentViewControllerFor(NSURL *url) {
     UIStoryboard *storyBoard = [UIStoryboard storyboardWithName:@"Main" bundle:nil];
     DocumentViewController *documentViewController = [storyBoard instantiateViewControllerWithIdentifier:@"DocumentViewController"];
     documentViewController.document = [[CODocument alloc] initWithFileURL:url];

--- a/ios/Mobile/SceneDelegate.mm
+++ b/ios/Mobile/SceneDelegate.mm
@@ -16,11 +16,12 @@ static UIViewController *bottomPresentedViewController(UIViewController *vc) {
     return bottomPresentedViewController([vc presentedViewController]);
 }
 
-static DocumentViewController *newDocumentViewControllerFor(NSURL *url) {
+static DocumentViewController *newDocumentViewControllerFor(NSURL *url, bool readOnly) {
     UIStoryboard *storyBoard = [UIStoryboard storyboardWithName:@"Main" bundle:nil];
     DocumentViewController *documentViewController = [storyBoard instantiateViewControllerWithIdentifier:@"DocumentViewController"];
     documentViewController.document = [[CODocument alloc] initWithFileURL:url];
     documentViewController.document->fakeClientFd = -1;
+    documentViewController.document->readOnly = readOnly;
     documentViewController.document.viewController = documentViewController;
 
     return documentViewController;
@@ -37,7 +38,7 @@ static DocumentViewController *newDocumentViewControllerFor(NSURL *url) {
         return;
 
     for (UIOpenURLContext* context in connectionOptions.URLContexts) {
-        DocumentViewController *documentViewController = newDocumentViewControllerFor(context.URL);
+        DocumentViewController *documentViewController = newDocumentViewControllerFor(context.URL, !context.options.openInPlace);
         [windowScene.windows[0].rootViewController presentViewController:documentViewController animated:NO completion:nil];
     }
     if ([connectionOptions.URLContexts count] > 0)
@@ -52,7 +53,7 @@ static DocumentViewController *newDocumentViewControllerFor(NSURL *url) {
         return;
 
     for (UIOpenURLContext* context in URLContexts) {
-        DocumentViewController *documentViewController = newDocumentViewControllerFor(context.URL);
+        DocumentViewController *documentViewController = newDocumentViewControllerFor(context.URL, !context.options.openInPlace);
         [bottomPresentedViewController(windowScene.windows[0].rootViewController) presentViewController:documentViewController animated:NO completion:nil];
     }
     if ([URLContexts count] > 0)


### PR DESCRIPTION
Fixes the issue where you can edit a document that was opened directly from the Mail app (where it was an attachment to an email message). Now we open such documents read-only.


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

