### PR TITLE
Tests, logs, and non-functional improvements

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -275,6 +275,7 @@ shared_headers = common/Common.hpp \
                  common/JailUtil.hpp \
                  common/Log.hpp \
                  common/Protocol.hpp \
+                 common/StateEnum.hpp \
                  common/StringVector.hpp \
                  common/Seccomp.hpp \
                  common/Session.hpp \

--- a/common/FileUtil.cpp
+++ b/common/FileUtil.cpp
@@ -81,7 +81,7 @@ namespace FileUtil
 {
     std::string createRandomDir(const std::string& path)
     {
-        const std::string name = Util::rng::getFilename(64);
+        std::string name = Util::rng::getFilename(64);
 #if HAVE_STD_FILESYSTEM
         filesystem::create_directory(path + '/' + name);
 #else

--- a/common/Log.hpp
+++ b/common/Log.hpp
@@ -393,4 +393,33 @@ namespace Log
         }                                                                                          \
     } while (false)
 
+/// Assert the truth of a condition, with a custom message.
+#define LOG_ASSERT_INTERNAL(condition, message, LOG)                                               \
+    do                                                                                             \
+    {                                                                                              \
+        auto&& cond##__LINE__ = !!(condition);                                                     \
+        if (!cond##__LINE__)                                                                       \
+        {                                                                                          \
+            std::ostringstream oss##__LINE__;                                                      \
+            oss##__LINE__ << message;                                                              \
+            const auto msg##__LINE__ = oss##__LINE__.str();                                        \
+            LOG("ERROR: Assertion failure: "                                                       \
+                << (msg##__LINE__.empty() ? "" : msg##__LINE__ + ". ")                             \
+                << "Condition: " << (#condition));                                                 \
+            assert(cond##__LINE__);                                                                \
+        }                                                                                          \
+    } while (false)
+
+/// Assert the truth of a condition.
+#if defined(NDEBUG)
+// In release mode assertions are logged as debug-level, since they are for developers.
+#define LOG_ASSERT_MSG(condition, message)                                                         \
+    LOG_ASSERT_INTERNAL(condition, "Precondition failed", LOG_DBG)
+#define LOG_ASSERT(condition) LOG_ASSERT_MSG(condition, "Precondition failed")
+#else
+// In debug mode assertions are errors.
+#define LOG_ASSERT_MSG(condition, message) LOG_ASSERT_INTERNAL(condition, message, LOG_ERR)
+#define LOG_ASSERT(condition) LOG_ASSERT_MSG(condition, "Precondition failed")
+#endif
+
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/common/Log.hpp
+++ b/common/Log.hpp
@@ -237,14 +237,17 @@ namespace Log
 #else
 // We know that when building with Xcode, __FILE__ will always be a full path, with several slashes,
 // so this will always work. We want just the file name, they are unique anyway.
-#define LOG_FILE_NAME(f) (strrchr(f, '/') + 1)
+#define LOG_FILE_NAME(f) << (strrchr(f, '/') + 1) <<
 #endif
+
+#define STRINGIFY(X) #X
+#define STRING(X) STRINGIFY(X)
 
 #define LOG_END(LOG, FILEP)                                                                        \
     do                                                                                             \
     {                                                                                              \
         if (FILEP)                                                                                 \
-            LOG << "| " << LOG_FILE_NAME(__FILE__) << ':' << __LINE__;                             \
+            LOG << "| " LOG_FILE_NAME(__FILE__) ":" STRING(__LINE__);                              \
         LOG.flush();                                                                               \
     } while (false)
 

--- a/common/StateEnum.hpp
+++ b/common/StateEnum.hpp
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <iosfwd>
+#include <type_traits>
 #include <string>
 
 /// Enum macro specifically for state-machines.
@@ -48,17 +50,26 @@
 /// NAME is the name of the state enum followed by the state names.
 #define STATE_ENUM(NAME, ...)                                                                      \
     enum class NAME : char;                                                                        \
-    static const char* name(NAME e)                                                                \
+    static inline const char* name(NAME e)                                                         \
     {                                                                                              \
         static const char* const NAME##_names[] = { FOR_EACH(STRINGIFY2, NAME, __VA_ARGS__) };     \
         assert(static_cast<unsigned>(e) < sizeof(NAME##_names) / sizeof(NAME##_names[0]) &&        \
                "Enum value is out of range.");                                                     \
         return NAME##_names[static_cast<int>(e)];                                                  \
     }                                                                                              \
-    static std::string toString(NAME e) { return name(e); }                                        \
+    static inline std::string toString(NAME e) { return name(e); }                                 \
     enum class NAME : char                                                                         \
     {                                                                                              \
         __VA_ARGS__                                                                                \
     }
+
+/// Support seemless serialization of STATE_ENUM to ostream.
+template <typename T, typename std::enable_if<
+                          std::is_same<decltype(name(T())), const char*>::value>::type* = nullptr>
+inline std::ostream& operator<<(std::ostream& os, const T state)
+{
+    os << name(state);
+    return os;
+}
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/common/StateEnum.hpp
+++ b/common/StateEnum.hpp
@@ -16,7 +16,7 @@
 /// Some ideas from https://stackoverflow.com/questions/28828957/enum-to-string-in-modern-c11-c14-c17-and-future-c20
 /// and from https://github.com/pfultz2/Cloak/wiki/C-Preprocessor-tricks,-tips,-and-idioms
 
-#define STRINGIFY(NAME, e) #NAME "::" #e,
+#define STRINGIFY2(NAME, e) #NAME "::" #e,
 #define CONCAT(X, Y) X##Y
 #define CALL(X, ...) X(__VA_ARGS__)
 
@@ -50,7 +50,7 @@
     enum class NAME : char;                                                                        \
     static const char* name(NAME e)                                                                \
     {                                                                                              \
-        static const char* const NAME##_names[] = { FOR_EACH(STRINGIFY, NAME, __VA_ARGS__) };      \
+        static const char* const NAME##_names[] = { FOR_EACH(STRINGIFY2, NAME, __VA_ARGS__) };     \
         assert(static_cast<unsigned>(e) < sizeof(NAME##_names) / sizeof(NAME##_names[0]) &&        \
                "Enum value is out of range.");                                                     \
         return NAME##_names[static_cast<int>(e)];                                                  \

--- a/common/StateEnum.hpp
+++ b/common/StateEnum.hpp
@@ -1,0 +1,64 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <string>
+
+/// Enum macro specifically for state-machines.
+/// Has several limitations, some intentional. For example,
+/// the states must have automatic, sequential, values.
+/// But also has some advantages, for example it can be used inside classes.
+/// Some ideas from https://stackoverflow.com/questions/28828957/enum-to-string-in-modern-c11-c14-c17-and-future-c20
+/// and from https://github.com/pfultz2/Cloak/wiki/C-Preprocessor-tricks,-tips,-and-idioms
+
+#define STRINGIFY(NAME, e) #NAME "::" #e,
+#define CONCAT(X, Y) X##Y
+#define CALL(X, ...) X(__VA_ARGS__)
+
+#define APPLY1(MACRO, NAME, e) MACRO(NAME, e)
+#define APPLY2(MACRO, NAME, e, ...) MACRO(NAME, e) APPLY1(MACRO, NAME, __VA_ARGS__)
+#define APPLY3(MACRO, NAME, e, ...) MACRO(NAME, e) APPLY2(MACRO, NAME, __VA_ARGS__)
+#define APPLY4(MACRO, NAME, e, ...) MACRO(NAME, e) APPLY3(MACRO, NAME, __VA_ARGS__)
+#define APPLY5(MACRO, NAME, e, ...) MACRO(NAME, e) APPLY4(MACRO, NAME, __VA_ARGS__)
+#define APPLY6(MACRO, NAME, e, ...) MACRO(NAME, e) APPLY5(MACRO, NAME, __VA_ARGS__)
+#define APPLY7(MACRO, NAME, e, ...) MACRO(NAME, e) APPLY6(MACRO, NAME, __VA_ARGS__)
+#define APPLY8(MACRO, NAME, e, ...) MACRO(NAME, e) APPLY7(MACRO, NAME, __VA_ARGS__)
+#define APPLY9(MACRO, NAME, e, ...) MACRO(NAME, e) APPLY8(MACRO, NAME, __VA_ARGS__)
+#define APPLY10(MACRO, NAME, e, ...) MACRO(NAME, e) APPLY9(MACRO, NAME, __VA_ARGS__)
+#define APPLY11(MACRO, NAME, e, ...) MACRO(NAME, e) APPLY10(MACRO, NAME, __VA_ARGS__)
+#define APPLY12(MACRO, NAME, e, ...) MACRO(NAME, e) APPLY11(MACRO, NAME, __VA_ARGS__)
+#define APPLY13(MACRO, NAME, e, ...) MACRO(NAME, e) APPLY12(MACRO, NAME, __VA_ARGS__)
+#define APPLY14(MACRO, NAME, e, ...) MACRO(NAME, e) APPLY13(MACRO, NAME, __VA_ARGS__)
+#define APPLY15(MACRO, NAME, e, ...) MACRO(NAME, e) APPLY14(MACRO, NAME, __VA_ARGS__)
+
+// Credit to Anton Bachin for this trick.
+#define GET_COUNT(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, c, ...) c
+#define COUNT_ARGS(...) GET_COUNT(__VA_ARGS__, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1)
+
+#define APPLY(MACRO, NAME, ...)                                                                    \
+    CALL(CONCAT, APPLY, COUNT_ARGS(__VA_ARGS__))(MACRO, NAME, __VA_ARGS__)
+#define FOR_EACH(MACRO, NAME, ...) APPLY(MACRO, NAME, __VA_ARGS__)
+
+/// Define a state-machine with various independent states.
+/// NAME is the name of the state enum followed by the state names.
+#define STATE_ENUM(NAME, ...)                                                                      \
+    enum class NAME : char;                                                                        \
+    static const char* name(NAME e)                                                                \
+    {                                                                                              \
+        static const char* const NAME##_names[] = { FOR_EACH(STRINGIFY, NAME, __VA_ARGS__) };      \
+        assert(static_cast<unsigned>(e) < sizeof(NAME##_names) / sizeof(NAME##_names[0]) &&        \
+               "Enum value is out of range.");                                                     \
+        return NAME##_names[static_cast<int>(e)];                                                  \
+    }                                                                                              \
+    static std::string toString(NAME e) { return name(e); }                                        \
+    enum class NAME : char                                                                         \
+    {                                                                                              \
+        __VA_ARGS__                                                                                \
+    }
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -514,6 +514,6 @@ public:
 
 #define LOK_ASSERT_STATE(VAR, STATE)                                                               \
     LOK_ASSERT_MESSAGE("Expected " #VAR " to be in " #STATE " but was " + toString(VAR),           \
-                       _phase == STATE)
+                       VAR == STATE)
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -14,6 +14,7 @@
 #include <string>
 #include <vector>
 
+#include <common/StateEnum.hpp>
 #include "net/Socket.hpp"
 
 #include <test/testlog.hpp>
@@ -496,59 +497,6 @@ public:
     }
     virtual ~UnitTool() {}
 };
-
-/// Enum macro specifically for state-machines.
-/// Has several limitations, some intentional. For example,
-/// the states must have automatic, sequential, values.
-/// But also has some advantages, for example it can be used inside classes.
-/// Some ideas from https://stackoverflow.com/questions/28828957/enum-to-string-in-modern-c11-c14-c17-and-future-c20
-/// and from https://github.com/pfultz2/Cloak/wiki/C-Preprocessor-tricks,-tips,-and-idioms
-
-#define STRINGIFY(NAME, e) #NAME "::" #e,
-#define CONCAT(X, Y) X##Y
-#define CALL(X, ...) X(__VA_ARGS__)
-
-#define APPLY1(MACRO, NAME, e) MACRO(NAME, e)
-#define APPLY2(MACRO, NAME, e, ...) MACRO(NAME, e) APPLY1(MACRO, NAME, __VA_ARGS__)
-#define APPLY3(MACRO, NAME, e, ...) MACRO(NAME, e) APPLY2(MACRO, NAME, __VA_ARGS__)
-#define APPLY4(MACRO, NAME, e, ...) MACRO(NAME, e) APPLY3(MACRO, NAME, __VA_ARGS__)
-#define APPLY5(MACRO, NAME, e, ...) MACRO(NAME, e) APPLY4(MACRO, NAME, __VA_ARGS__)
-#define APPLY6(MACRO, NAME, e, ...) MACRO(NAME, e) APPLY5(MACRO, NAME, __VA_ARGS__)
-#define APPLY7(MACRO, NAME, e, ...) MACRO(NAME, e) APPLY6(MACRO, NAME, __VA_ARGS__)
-#define APPLY8(MACRO, NAME, e, ...) MACRO(NAME, e) APPLY7(MACRO, NAME, __VA_ARGS__)
-#define APPLY9(MACRO, NAME, e, ...) MACRO(NAME, e) APPLY8(MACRO, NAME, __VA_ARGS__)
-#define APPLY10(MACRO, NAME, e, ...) MACRO(NAME, e) APPLY9(MACRO, NAME, __VA_ARGS__)
-#define APPLY11(MACRO, NAME, e, ...) MACRO(NAME, e) APPLY10(MACRO, NAME, __VA_ARGS__)
-#define APPLY12(MACRO, NAME, e, ...) MACRO(NAME, e) APPLY11(MACRO, NAME, __VA_ARGS__)
-#define APPLY13(MACRO, NAME, e, ...) MACRO(NAME, e) APPLY12(MACRO, NAME, __VA_ARGS__)
-#define APPLY14(MACRO, NAME, e, ...) MACRO(NAME, e) APPLY13(MACRO, NAME, __VA_ARGS__)
-#define APPLY15(MACRO, NAME, e, ...) MACRO(NAME, e) APPLY14(MACRO, NAME, __VA_ARGS__)
-
-// Credit to Anton Bachin for this trick.
-#define GET_COUNT(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, c, ...) c
-#define COUNT_ARGS(...) GET_COUNT(__VA_ARGS__, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1)
-
-#define APPLY(MACRO, NAME, ...)                                                                    \
-    CALL(CONCAT, APPLY, COUNT_ARGS(__VA_ARGS__))(MACRO, NAME, __VA_ARGS__)
-#define FOR_EACH(MACRO, NAME, ...) APPLY(MACRO, NAME, __VA_ARGS__)
-
-/// Define a state-machine states, typically used to organize the phases
-/// of a multi-stage test.
-/// NAME is the name of the state enum, VAR is the name of the enum variable,
-/// followed by the names of the states.
-#define STATES_ENUM(NAME, VAR, ...)                                                                \
-    enum class NAME : char                                                                         \
-    {                                                                                              \
-        __VA_ARGS__                                                                                \
-    } VAR;                                                                                         \
-    static const char* name(NAME e)                                                                \
-    {                                                                                              \
-        static const char* const NAME##_names[] = { FOR_EACH(STRINGIFY, NAME, __VA_ARGS__) };      \
-        assert(static_cast<unsigned>(e) < sizeof(NAME##_names) / sizeof(NAME##_names[0]) &&        \
-               "Enum value is out of range.");                                                     \
-        return NAME##_names[static_cast<int>(e)];                                                  \
-    }                                                                                              \
-    static std::string toString(NAME e) { return name(e); }
 
 /// Transition the test state of VAR to STATE, with a prefix message, and resume the test.
 /// This will wake up all polls and the new state may be processed in parallel.

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -1054,7 +1054,8 @@ bool StreamSocket::parseHeader(const char *clientName,
                               marker.begin(), marker.end());
     if (itBody == _inBuffer.end())
     {
-        LOG_TRC('#' << getFD() << " doesn't have enough data for the header yet.");
+        LOG_TRC('#' << getFD() << ": " << clientName
+                    << " doesn't have enough data for the header yet.");
         return false;
     }
 

--- a/test/TileCacheTests.cpp
+++ b/test/TileCacheTests.cpp
@@ -933,7 +933,7 @@ void TileCacheTests::checkBlackTile(std::stringstream& tile)
     }
 
     LOK_ASSERT_MESSAGE("The tile is 100% black", black != height * width);
-    assert(height * width != 0);
+    LOK_ASSERT(height * width != 0);
     LOK_ASSERT_MESSAGE("The tile is 90% black", (black * 100) / (height * width) < 90);
 }
 

--- a/test/UnitStorage.cpp
+++ b/test/UnitStorage.cpp
@@ -14,12 +14,12 @@ using namespace helpers;
 
 class UnitStorage : public WopiTestServer
 {
-    STATES_ENUM(Phase, _phase,
-                Load, // load the document
-                Filter, // throw filter exception
-                Reload, // re-load the document
-                Done
-    );
+    STATE_ENUM(Phase,
+               Load, // load the document
+               Filter, // throw filter exception
+               Reload, // re-load the document
+               Done)
+    _phase;
 
 public:
     UnitStorage()

--- a/test/UnitWOPIAsyncUpload_Close.cpp
+++ b/test/UnitWOPIAsyncUpload_Close.cpp
@@ -26,8 +26,9 @@
 // Modify, Save, Upload fails, close -> Upload.
 class UnitWOPIAsyncUpload_Close : public WopiTestServer
 {
-    STATES_ENUM(Phase, _phase, Load, WaitLoadStatus, Modify, WaitModifiedStatus, WaitFirstPutFile,
-                Close, WaitSecondPutFile, Polling);
+    STATE_ENUM(Phase, Load, WaitLoadStatus, Modify, WaitModifiedStatus, WaitFirstPutFile, Close,
+               WaitSecondPutFile, Polling)
+    _phase;
 
 public:
     UnitWOPIAsyncUpload_Close()

--- a/test/UnitWOPICrashModified.cpp
+++ b/test/UnitWOPICrashModified.cpp
@@ -16,7 +16,7 @@
 /// Test crashing a document after modifications.
 class UnitWOPICrashModified : public WopiTestServer
 {
-    STATES_ENUM(Phase, _phase, Load, WaitLoadStatus, WaitModifiedStatus, WaitDocClose);
+    STATE_ENUM(Phase, Load, WaitLoadStatus, WaitModifiedStatus, WaitDocClose) _phase;
 
     /// The PID of the Kit process.
     int _pid;

--- a/test/UnitWOPILock.cpp
+++ b/test/UnitWOPILock.cpp
@@ -18,7 +18,7 @@
 
 class UnitWopiLock : public WopiTestServer
 {
-    STATES_ENUM(Phase, _phase, Load, LockDocument, UnlockDocument, Done);
+    STATE_ENUM(Phase, Load, LockDocument, UnlockDocument, Done) _phase;
 
     std::string _lockState;
     std::string _lockString;

--- a/test/UnitWOPISlow.cpp
+++ b/test/UnitWOPISlow.cpp
@@ -38,7 +38,7 @@
 /// Modify, Save, Modify, Close -> No data loss.
 class UnitWOPISlow : public WopiTestServer
 {
-    STATES_ENUM(Phase, _phase, Load, WaitLoadStatus, WaitModifiedStatus, WaitPutFile);
+    STATE_ENUM(Phase, Load, WaitLoadStatus, WaitModifiedStatus, WaitPutFile) _phase;
 
     static constexpr auto LargeDocumentFilename = "large-six-hundred.odt";
 

--- a/test/UnitWOPIVersionRestore.cpp
+++ b/test/UnitWOPIVersionRestore.cpp
@@ -26,7 +26,7 @@
  */
 class UnitWOPIVersionRestore : public WopiTestServer
 {
-    STATES_ENUM(Phase, _phase, Load, WaitLoadStatus, WaitPutFile);
+    STATE_ENUM(Phase, Load, WaitLoadStatus, WaitPutFile) _phase;
 
     bool _isDocumentSaved = false;
 

--- a/test/UnitWopiOwnertermination.cpp
+++ b/test/UnitWopiOwnertermination.cpp
@@ -17,7 +17,7 @@
 
 class UnitWopiOwnertermination : public WopiTestServer
 {
-    STATES_ENUM(Phase, _phase, Load, WaitLoadStatus, WaitDocClose);
+    STATE_ENUM(Phase, Load, WaitLoadStatus, WaitDocClose) _phase;
 
     static constexpr int RepeatCount = 2;
 

--- a/test/WOPIUploadConflictCommon.hpp
+++ b/test/WOPIUploadConflictCommon.hpp
@@ -42,11 +42,11 @@ private:
     std::size_t _expectedPutFile;
 
 protected:
-    STATES_ENUM(Phase, _phase, Load, WaitLoadStatus, WaitModifiedStatus, WaitDocClose);
+    STATE_ENUM(Phase, Load, WaitLoadStatus, WaitModifiedStatus, WaitDocClose) _phase;
 
     /// The different test scenarios. All but VerifyOverwrite modify the document.
-    STATES_ENUM(Scenario, _scenario, Disconnect, SaveDiscard, CloseDiscard, SaveOverwrite,
-                VerifyOverwrite);
+    STATE_ENUM(Scenario, Disconnect, SaveDiscard, CloseDiscard, SaveOverwrite, VerifyOverwrite)
+    _scenario;
 
     static constexpr auto OriginalDocContent = "Original contents";
     static constexpr auto ModifiedOriginalDocContent = "\ufeffaOriginal contents\n";

--- a/test/testlog.hpp
+++ b/test/testlog.hpp
@@ -74,7 +74,7 @@ inline void tstLog(const std::ostringstream& stream) { writeTestLog(stream.str()
 #define TST_LOG_END_X(OSS)                                                                         \
     do                                                                                             \
     {                                                                                              \
-        OSS << "| " __FILE__ ":" << __LINE__ << '\n';                                              \
+        OSS << "| " __FILE__ ":" STRING(__LINE__) "\n";                                            \
         tstLog(OSS);                                                                               \
     } while (false)
 

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -1642,7 +1642,8 @@ void COOLWSD::innerInitialize(Application& self)
     }
 
     ServerName = config().getString("server_name");
-    LOG_INF("Initializing coolwsd server [" << ServerName << "].");
+    LOG_INF("Initializing coolwsd server [" << ServerName << "]. Experimental features are "
+                                            << (EnableExperimental ? "enabled." : "disabled."));
 
     // Get anonymization settings.
 #if COOLWSD_ANONYMIZE_USER_DATA

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -113,30 +113,16 @@ ClientSession::~ClientSession()
     GlobalSessionMap.erase(getId());
 }
 
-static const char *stateToString(ClientSession::SessionState s)
-{
-    switch (s)
-    {
-    case ClientSession::SessionState::DETACHED:        return "detached";
-    case ClientSession::SessionState::LOADING:         return "loading";
-    case ClientSession::SessionState::LIVE:            return "live";
-    case ClientSession::SessionState::WAIT_DISCONNECT: return "wait_disconnect";
-    }
-    return "invalid";
-}
-
 void ClientSession::setState(SessionState newState)
 {
-    LOG_TRC(getName() << ": transition from " << stateToString(_state) << " to "
-                      << stateToString(newState));
+    LOG_TRC(getName() << ": transition from " << name(_state) << " to " << name(newState));
 
     // we can get incoming messages while our disconnection is in transit.
     if (_state == SessionState::WAIT_DISCONNECT)
     {
         if (newState != SessionState::WAIT_DISCONNECT)
-            LOG_WRN("Unusual race - attempts to transition from " <<
-                    stateToString(_state) << " to " <<
-                    stateToString(newState));
+            LOG_WRN("Unusual race - attempts to transition from " << name(_state) << " to "
+                                                                  << name(newState));
         return;
     }
 
@@ -1699,8 +1685,9 @@ bool ClientSession::handleKitToClientMessage(const char* buffer, const int lengt
         // 'download' and/or providing our helpful / user page.
 
         // for now just for remote sockets.
-        LOG_TRC("Got clipboard content of size " << payload->size() << " to send to " <<
-                _clipSockets.size() << " sockets in state " << stateToString(_state));
+        LOG_TRC("Got clipboard content of size " << payload->size() << " to send to "
+                                                 << _clipSockets.size() << " sockets in state "
+                                                 << name(_state));
 
         postProcessCopyPayload(payload);
 
@@ -2074,7 +2061,7 @@ void ClientSession::dumpState(std::ostream& os)
 
     os << "\t\tisReadOnly: " << isReadOnly()
        << "\n\t\tisDocumentOwner: " << isDocumentOwner()
-       << "\n\t\tstate: " << stateToString(_state)
+       << "\n\t\tstate: " << name(_state)
        << "\n\t\tkeyEvents: " << _keyEvents
 //       << "\n\t\tvisibleArea: " << _clientVisibleArea
        << "\n\t\tclientSelectedPart: " << _clientSelectedPart

--- a/wsd/ClientSession.hpp
+++ b/wsd/ClientSession.hpp
@@ -42,12 +42,12 @@ public:
 
     void setLockFailed(const std::string& sReason);
 
-    enum SessionState {
-        DETACHED,        // initial
-        LOADING,         // attached to a DocBroker & waiting for load
-        LIVE,            // Document is loaded & editable or viewable.
-        WAIT_DISCONNECT  // closed and waiting for Kit's disconnected message
-    };
+    STATE_ENUM(SessionState,
+               DETACHED, // initial
+               LOADING, // attached to a DocBroker & waiting for load
+               LIVE, // Document is loaded & editable or viewable.
+               WAIT_DISCONNECT // closed and waiting for Kit's disconnected message
+    );
 
     /// Returns true if this session has loaded a view (i.e. we got status message).
     bool isViewLoaded() const { return _state == SessionState::LIVE; }

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -659,7 +659,7 @@ bool DocumentBroker::download(const std::shared_ptr<ClientSession>& session, con
         firstInstance = true;
     }
 
-    assert(_storage != nullptr);
+    LOG_ASSERT(_storage);
 
     // Call the storage specific fileinfo functions
     std::string userId, username;
@@ -2254,8 +2254,8 @@ std::size_t DocumentBroker::removeSession(const std::string& id)
         }
         else if (activeSessionCount > 0)
         {
-            assert(!_docState.isMarkedToDestroy() &&
-                   "Have active sessions while marked to destroy.");
+            LOG_ASSERT_MSG(!_docState.isMarkedToDestroy(),
+                           "Have active sessions while marked to destroy");
         }
     }
     catch (const std::exception& ex)
@@ -2283,7 +2283,8 @@ void DocumentBroker::disconnectSessionInternal(const std::string& id)
             if (_docState.isUnloadRequested())
             {
                 // We must be the last session, flag to destroy if unload is requested.
-                assert(countActiveSessions() <= 1 && "Unload-requested with multiple sessions.");
+                LOG_ASSERT_MSG(countActiveSessions() <= 1,
+                               "Unload-requested with multiple sessions");
                 _docState.markToDestroy();
                 LOG_TRC("Unload requested while disconnecting session ["
                         << id << "], having " << _sessions.size()

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -763,7 +763,12 @@ private:
         std::size_t saveFailureCount() const { return _request.lastRequestFailureCount(); }
 
         /// Sets whether the last save was successful or not.
-        void setLastSaveResult(bool success) { _request.setLastRequestResult(success); }
+        void setLastSaveResult(bool success)
+        {
+            LOG_DBG("Save " << (success ? "succeeded" : "failed") << " after "
+                            << _request.timeSinceLastRequest());
+            _request.setLastRequestResult(success);
+        }
 
         /// Returns the last save request time.
         std::chrono::steady_clock::time_point lastSaveRequestTime() const
@@ -924,7 +929,12 @@ private:
         bool lastUploadSuccessful() const { return _request.lastRequestSuccessful(); }
 
         /// Sets whether the last upload was successful or not.
-        void setLastUploadResult(bool success) { _request.setLastRequestResult(success); }
+        void setLastUploadResult(bool success)
+        {
+            LOG_DBG("Upload " << (success ? "succeeded" : "failed") << " after "
+                              << _request.timeSinceLastRequest());
+            _request.setLastRequestResult(success);
+        }
 
         /// Returns the number of previous upload failures. 0 for success.
         std::size_t uploadFailureCount() const { return _request.lastRequestFailureCount(); }

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -514,12 +514,12 @@ private:
     void terminateChild(const std::string& closeReason);
 
     /// Encodes whether or not uploading is needed.
-    enum class NeedToUpload
-    {
+    STATE_ENUM(
+        NeedToUpload,
         No, //< No need to upload, data up-to-date.
         Yes, //< Data is out of date.
         Force //< Force uploading, typically because always_save_on_exit is set.
-    };
+    );
 
     /// Returns true if, for any reason, we need to upload.
     /// This includes out-of-date Document in Storage or
@@ -1015,66 +1015,26 @@ private:
         /// Strictly speaking, these are phases that are directional.
         /// A document starts as New and progresses towards Unloaded.
         /// Upon error, intermediary states may be skipped.
-        enum class Status
-        {
-            None, //< Doesn't exist, pending downloading.
-            Downloading, //< Download from Storage to disk. Synchronous.
-            Loading, //< Loading the document in Core.
-            Live, //< General availability for viewing/editing.
-            Destroying, //< End-of-life, marked to destroy.
-            Destroyed //< Unloading complete, destruction pending.
-        };
+        STATE_ENUM(Status,
+                   None, //< Doesn't exist, pending downloading.
+                   Downloading, //< Download from Storage to disk. Synchronous.
+                   Loading, //< Loading the document in Core.
+                   Live, //< General availability for viewing/editing.
+                   Destroying, //< End-of-life, marked to destroy.
+                   Destroyed //< Unloading complete, destruction pending.
+        );
 
         /// The current activity taking place.
         /// Meaningful only when Status is Status::Live, but
         /// we may Save and Upload during Status::Destroying.
-        enum class Activity
-        {
-            None, //< No particular activity.
-            Rename, //< The document is being renamed.
-            SaveAs, //< The document format is being converted.
-            Conflict, //< The document is conflicted in storaged.
-            Save, //< The document is being saved, manually or auto-save.
-            Upload, //< The document is being uploaded to storage.
-        };
-
-        static std::string toString(Status status)
-        {
-#define CASE(X)                                                                                    \
-    case X:                                                                                        \
-        return #X;
-            switch (status)
-            {
-                CASE(Status::None);
-                CASE(Status::Downloading);
-                CASE(Status::Loading);
-                CASE(Status::Live);
-                CASE(Status::Destroying);
-                CASE(Status::Destroyed);
-            }
-
-#undef CASE
-            return "Unknown Document Status";
-        }
-
-        static std::string toString(Activity activity)
-        {
-#define CASE(X)                                                                                    \
-    case X:                                                                                        \
-        return #X;
-            switch (activity)
-            {
-                CASE(Activity::None);
-                CASE(Activity::Rename);
-                CASE(Activity::SaveAs);
-                CASE(Activity::Conflict);
-                CASE(Activity::Save);
-                CASE(Activity::Upload);
-            }
-
-#undef CASE
-            return "Unknown Document Activity";
-        }
+        STATE_ENUM(Activity,
+                   None, //< No particular activity.
+                   Rename, //< The document is being renamed.
+                   SaveAs, //< The document format is being converted.
+                   Conflict, //< The document is conflicted in storaged.
+                   Save, //< The document is being saved, manually or auto-save.
+                   Upload, //< The document is being uploaded to storage.
+        );
 
         DocumentState()
             : _status(Status::None)


### PR DESCRIPTION
Misc test, logging, assertions, and similar improvements.

All of these changes are non-functional and any functional change should be flagged in the review.

- wsd: move tokenizer helpers into StringVector
- wsd: log the duration of save and upload when done
- wsd: move STATE_ENUM to common/StateEnum.hpp
- wsd: use STATE_ENUM for DocBroker states
- wsd: minor improvements to logging and macros
- wsd: modernize UnitWOPI
- wsd: logging and minor cosmetics
- wsd: add LOG_ASSERT to replace assert with extra logging
- wsd: include the ClientSession name in logs
- wsd: use STATE_ENUM for SessionState
- wsd: support serializing STATE_ENUM to ostream 
- wsd: use STATE_ENUM for http