### PR TITLE
Private/pedro/porting 4536 from master

### DIFF
--- a/browser/css/mobilewizard.css
+++ b/browser/css/mobilewizard.css
@@ -279,6 +279,7 @@ p.mobile-wizard.ui-combobox-text.selected {
 
 #mobile-wizard.menuwizard {
 	z-index: 1001;
+	background-color: var(--color-background-lighter);
 }
 
 #mobile-wizard-content *{

--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -1372,6 +1372,8 @@ L.Control.Menubar = L.Control.extend({
 							self._map.fire('mobilewizard', {data: menuData});
 							$('#toolbar-hamburger').removeClass('menuwizard-closed').addClass('menuwizard-opened');
 							$('#mobile-wizard-header').hide();
+							$('#toolbar-mobile-back').hide();
+							$('#formulabar').hide();
 						}
 					} else if (!window.mode.isMobile()) {
 						// Ditto.
@@ -1382,6 +1384,8 @@ L.Control.Menubar = L.Control.extend({
 						window.mobileMenuWizard = false;
 						self._map.fire('closemobilewizard');
 						$('#toolbar-hamburger').removeClass('menuwizard-opened').addClass('menuwizard-closed');
+						$('#toolbar-mobile-back').show();
+						$('#formulabar').show();
 					}
 				});
 				// hide mobile menu beforeunload


### PR DESCRIPTION
commit be437fb9f31c02ace2dc465c3460d30d8a639518 (HEAD -> private/pedro/porting-4536-from-master, origin/private/pedro/porting-4536-from-master)
Author: Pedro Pinto Silva <pedro.silva@collabora.com>
Date:   Mon Apr 4 16:41:20 2022 +0200

Mobile: Fix save icon and back icon overlay

Save icon (blue tick) should not be visible at all when the hamburger
menu is open

On Calc and it is also needed to hide formularbar while hamburger menu
is open because otherwise the it affects the size of the toolbar-wrapper
and consequently affect the flex box and how the hamburger menu gets
aligned

before: https://archive.org/download/cool-bug-mobile-save-above-back/cool-bug-mobile-save-above-back.png

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ifa5406a5a5c31172cde82e843949671fa95c6596

-----

commit c7b245375477369c76d9a712993760daa424ea24
Author: Pedro Pinto Silva <pedro.silva@collabora.com>
Date:   Mon Apr 4 16:49:53 2022 +0200

Fix mobile hamburger menu color

Due to recent changes on the color palette mobile wizard has changed
color from white to gray which causes the hamburger menu to appear not
going full height:
https://archive.org/download/cool-bug-mobile-hamburger-bg/cool-bug-mobile-hamburger-bg.png

Make sure hamburger menu uses the right color

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I4263ebf8f92979ffd5a5657fceb76843594d4d54