### PR TITLE
Correctly hide keyboard on mobile wizard

### DIFF
--- a/browser/src/control/Control.MobileWizard.js
+++ b/browser/src/control/Control.MobileWizard.js
@@ -191,7 +191,7 @@ L.Control.MobileWizard = L.Control.extend({
 	},
 
 	_hideKeyboard: function() {
-		document.activeElement.blur();
+		this.map.blur();
 	},
 
 	_updateToolbarItemStateByClose: function() {


### PR DESCRIPTION
current approach is lacking the acceptInput state
because when we close the keyboard we need to set it
to false when we hide the keyboard otherwise canAcceptInput is not going
to change and controls for that will fail such as panStart and panEnd in
TouchGesture. Pannig while the mobile wizard is on causes keyboard going
on top of the mobile wizard and after that it causes endless screen
flickering.

Signed-off-by: Mert Tumer <mert.tumer@collabora.com>
Change-Id: I3248ef7f344fe53a57b7c77f4222d1fed5740896


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

