### PR TITLE
Fix endless keyboard show/hide flicker

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -5170,7 +5170,7 @@ L.CanvasTileLayer = L.Layer.extend({
 			if (window.mode.isMobile() && !hasMobileWizardOpened) {
 				if (heightIncreased) {
 					// if the keyboard is hidden - be sure we setup correct state in TextInput
-					this._map.focus(false);
+					this._map.setAcceptInput(false);
 				} else
 					this._onUpdateCursor(true);
 			}

--- a/browser/src/map/Map.js
+++ b/browser/src/map/Map.js
@@ -1113,6 +1113,13 @@ L.Map = L.Evented.extend({
 		this._textInput.focus(acceptInput);
 	},
 
+	// just set the keyboard state for mobile
+	// we dont want to change the focus, we know that keyboard is closed
+	// and we are just setting the state here
+	setAcceptInput: function (acceptInput) {
+		this._textInput._setAcceptInput(acceptInput);
+	},
+
 	// Lose focus to stop accepting keyboard input.
 	// On mobile, it will hide the virtual keyboard.
 	blur: function () {


### PR DESCRIPTION
when we decide the keyboard is closed by checking the screen size
we should not force keyboard to close again instead we just need to
set the state

Signed-off-by: Mert Tumer <mert.tumer@collabora.com>
Change-Id: I486cda0598ab02e426aefd726475f0e70e0eee52


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

