### PR TITLE
wsd: cleanup firsthost code

### DIFF
--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -1095,6 +1095,11 @@ int main(int argc, char**argv)
                     Util::matchRegex(_denied, subject));
         }
 
+        bool empty() const
+        {
+            return _allowed.empty() && _denied.empty();
+        }
+
     private:
         const bool _allowByDefault;
         std::set<std::string> _allowed;

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -1751,8 +1751,6 @@ void COOLWSD::innerInitialize(Application& self)
         { "ssl.termination", "true" },
         { "storage.filesystem[@allow]", "false" },
         // "storage.ssl.enable" - deliberately not set; for back-compat
-        { "storage.wopi.host[0]", "localhost" },
-        { "storage.wopi.host[0][@allow]", "true" },
         { "storage.wopi.max_file_size", "0" },
         { "storage.wopi[@allow]", "true" },
         { "storage.wopi.locking.refresh", "900" },

--- a/wsd/HostUtil.hpp
+++ b/wsd/HostUtil.hpp
@@ -21,8 +21,6 @@ private:
     static std::map<std::string, std::string> AliasHosts;
     /// When group configuration is not defined only the firstHost gets access
     static std::string FirstHost;
-    /// This contains all real and aliases host from group configuration
-    static std::set<std::string> AllHosts;
 
     static bool WopiEnabled;
 
@@ -42,8 +40,6 @@ public:
     /// add host to WopiHosts
     static void addWopiHost(std::string host, bool allow);
 
-    static bool allowedAlias(const Poco::URI& uri);
-
     static bool allowedWopiHost(const std::string& host);
 
     static bool isWopiEnabled() { return WopiEnabled; }
@@ -51,7 +47,6 @@ public:
     /// replace the authority of aliashost to realhost if it matches
     static const Poco::URI getNewLockedUri(Poco::URI& uri);
 
-    /// set FirstHost
     static void setFirstHost(const Poco::URI& uri);
 };
 

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -236,7 +236,7 @@ std::unique_ptr<StorageBase> StorageBase::create(const Poco::URI& uri, const std
         const auto& targetHost = uri.getHost();
         bool allowed(false);
         HostUtil::setFirstHost(uri);
-        if ((HostUtil::allowedAlias(uri) && HostUtil::allowedWopiHost(targetHost)) ||
+        if (HostUtil::allowedWopiHost(targetHost) ||
             isLocalhost(targetHost))
         {
             allowed = true;
@@ -247,7 +247,7 @@ std::unique_ptr<StorageBase> StorageBase::create(const Poco::URI& uri, const std
             const auto hostAddresses(Poco::Net::DNS::resolve(targetHost));
             for (auto &address : hostAddresses.addresses())
             {
-                if (HostUtil::allowedAlias(uri) && HostUtil::allowedWopiHost(address.toString()))
+                if (HostUtil::allowedWopiHost(address.toString()))
                 {
                     allowed = true;
                     break;


### PR DESCRIPTION
we added AllHosts to give admin the err log that host is not in alias_groups but now as we removed the host list entries from configuration we don't need that log

Signed-off-by: Rash419 <rashesh.padia@collabora.com>
Change-Id: I8b5e9e6b7df7df59befb496c12966c7ddc60c707

* Target version: master 