### PR TITLE
test: increase buffer size in SocketProcessor()

### DIFF
--- a/test/helpers.hpp
+++ b/test/helpers.hpp
@@ -777,7 +777,7 @@ inline void SocketProcessor(const std::string& testname,
     const Poco::Timespan waitTime(std::chrono::microseconds(timeoutMs).count());
     int flags = 0;
     int n = 0;
-    char buffer[READ_BUFFER_SIZE];
+    char buffer[READ_BUFFER_SIZE * 8];
     do
     {
         if (!socket->poll(waitTime, Poco::Net::Socket::SELECT_READ))


### PR DESCRIPTION
The webframe buffer size used to be READ_BUFFER_SIZE (64k), but that's
no longer enough in unit-uno-command since
<https://github.com/libreoffice/core/commit/a20e761cb1112357bfae35e24b49fae872bce3f6>
(jsdialog: fix toolboxes with children, 2022-03-17) if you have enough
fonts installed locally, because one toolbox in Writer is the font
dropdown, and that lists all the fonts you have.

getResponseMessage() already uses this increased buffer size, so this
also improves consistency.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Ic2ad0e8e7443365395b16618d6c82465252ba455
