### PR TITLE
Save and Upload Improvements: Part 1

### DIFF
--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -1355,9 +1355,12 @@ protected:
             if ((events & POLLOUT) && !_outBuffer.empty())
             {
                 writeOutgoingData();
-                if (errno == EPIPE)
+                const int last_errno = errno;
+                if (last_errno == EPIPE || (EnableExperimental && last_errno == ECONNRESET))
                 {
-                    LOG_DBG('#' << getFD() << ": Disconnected while writing (EPIPE).");
+                    LOG_DBG('#' << getFD() << ": Disconnected while writing ("
+                                << Util::symbolicErrno(last_errno)
+                                << "): " << std::strerror(last_errno) << ')');
                     closed = true;
                     break;
                 }

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -2059,7 +2059,9 @@ void ClientSession::dumpState(std::ostream& os)
 {
     Session::dumpState(os);
 
-    os << "\t\tisReadOnly: " << isReadOnly()
+    os << "\t\tisLive: " << isLive()
+       << "\n\t\tisReadOnly: " << isReadOnly()
+       << "\n\t\tisAllowChangeComments: " << isAllowChangeComments()
        << "\n\t\tisDocumentOwner: " << isDocumentOwner()
        << "\n\t\tstate: " << name(_state)
        << "\n\t\tkeyEvents: " << _keyEvents

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -452,9 +452,9 @@ bool ClientSession::_handleInput(const char *buffer, int length)
         updateLastActivityTime();
         docBroker->updateLastActivityTime();
 
-        if (!isReadOnly() && isViewLoaded())
+        if (isWritable() && isViewLoaded())
         {
-            assert(!inWaitDisconnected() && "A loaded view can't also be waiting disconnection.");
+            assert(!inWaitDisconnected() && "A writable view can't be waiting disconnection.");
             docBroker->updateEditingSessionId(getId());
         }
     }
@@ -2060,8 +2060,10 @@ void ClientSession::dumpState(std::ostream& os)
     Session::dumpState(os);
 
     os << "\t\tisLive: " << isLive()
+       << "\n\t\tisViewLoaded: " << isViewLoaded()
        << "\n\t\tisReadOnly: " << isReadOnly()
        << "\n\t\tisAllowChangeComments: " << isAllowChangeComments()
+       << "\n\t\tisWritable: " << isWritable()
        << "\n\t\tisDocumentOwner: " << isDocumentOwner()
        << "\n\t\tstate: " << name(_state)
        << "\n\t\tkeyEvents: " << _keyEvents

--- a/wsd/ClientSession.hpp
+++ b/wsd/ClientSession.hpp
@@ -61,6 +61,10 @@ public:
     void setDocumentOwner(const bool documentOwner) { _isDocumentOwner = documentOwner; }
     bool isDocumentOwner() const { return _isDocumentOwner; }
 
+    /// Returns true iff the view is loaded and not disconnected
+    /// from either the client or the Kit.
+    bool isLive() const { return _state == SessionState::LIVE && !isCloseFrame(); }
+
     /// Handle kit-to-client message.
     bool handleKitToClientMessage(const char* data, const int size);
 

--- a/wsd/ClientSession.hpp
+++ b/wsd/ClientSession.hpp
@@ -65,6 +65,9 @@ public:
     /// from either the client or the Kit.
     bool isLive() const { return _state == SessionState::LIVE && !isCloseFrame(); }
 
+    /// Returns true iff the view is either not readonly or can change comments.
+    bool isWritable() const { return !isReadOnly() || isAllowChangeComments(); }
+
     /// Handle kit-to-client message.
     bool handleKitToClientMessage(const char* data, const int size);
 

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -274,6 +274,12 @@ void DocumentBroker::pollThread()
         _poll->poll(unloading ? SocketPoll::DefaultPollTimeoutMicroS / 16
                               : SocketPoll::DefaultPollTimeoutMicroS);
 
+        if (EnableExperimental && _stop)
+        {
+            LOG_DBG("Doc [" << _docKey << "] is flagged to stop after returning from poll.");
+            break;
+        }
+
 #if !MOBILEAPP
         const auto now = std::chrono::steady_clock::now();
 

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1731,6 +1731,8 @@ void DocumentBroker::handleUploadToStorageResponse(const StorageBase::UploadResu
         const std::size_t activeClients = broadcastMessage(message);
         broadcastSaveResult(false, "Conflict: Document changed in storage",
                             uploadResult.getReason());
+        LOG_TRC("There are " << activeClients
+                             << " active clients after broadcasting documentconflict");
         if (activeClients == 0)
         {
             // No clients were contacted; we will never resolve this conflict.
@@ -2981,7 +2983,7 @@ std::size_t DocumentBroker::countActiveSessions() const
     std::size_t count = 0;
     for (const auto& it : _sessions)
     {
-        if (it.second->isViewLoaded() && !it.second->inWaitDisconnected())
+        if (it.second->isLive())
         {
             ++count;
         }

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -478,6 +478,7 @@ public:
 
 private:
     /// get the session id of a session that can write the document for save / locking.
+    /// Note that if there is no loaded and writable session, the first will be returned.
     std::string getWriteableSessionId() const;
 
     void refreshLock();


### PR DESCRIPTION
**Part 1**

A number of fixes and improvements to Save and Upload cases. Each commit explains the need for the change.
Where appropriate, `ExperimentalEnabled` is used.

Most were found through tests (a few through reviewing code). Improved test coverage included (which fail without these fixes) in part-3 #4567. Please review part-2 #4566 after this.

_Best to review each commit separately._

- wsd: detect ECONNRESET and EPIPE after reads and writes
- wsd: check the stop flag immediately after poll
- wsd: correct active-session counting
- wsd: add and use isWritable helper in session
- wsd: do not close the socket while have data to read