### PR TITLE
Save and Upload Improvements: Part 2

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1834,7 +1834,7 @@ bool DocumentBroker::autoSave(const bool force, const bool dontSaveIfUnmodified)
 
     LOG_TRC("autoSave(): forceful? " << force
                                      << ", dontSaveIfUnmodified: " << dontSaveIfUnmodified);
-    if (_sessions.empty() || _storage == nullptr || !isLoaded() || (!isModified() && !force))
+    if (_sessions.empty() || !isLoaded() || (!isModified() && !force))
     {
         // Nothing to do.
         LOG_TRC("Nothing to autosave [" << _docKey << "].");
@@ -2075,10 +2075,15 @@ bool DocumentBroker::sendUnoSave(const std::string& sessionId, bool dontTerminat
         // arguments end
         oss << '}';
 
-        assert(_storage);
-        _storage->setIsAutosave(isAutosave || UnitWSD::get().isAutosave());
-        _storage->setIsExitSave(isExitSave);
-        _storage->setExtendedData(extendedData);
+        if (_storage)
+        {
+            // If we can't upload, we will quarantine.
+            //FIXME: these must be tracked in DocBroker as they will
+            // get clobbered when uploading fails and we save again.
+            _storage->setIsAutosave(isAutosave || UnitWSD::get().isAutosave());
+            _storage->setIsExitSave(isExitSave);
+            _storage->setExtendedData(extendedData);
+        }
 
         const std::string saveArgs = oss.str();
         LOG_TRC(".uno:Save arguments: " << saveArgs);

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1833,16 +1833,18 @@ bool DocumentBroker::autoSave(const bool force, const bool dontSaveIfUnmodified)
 
     LOG_TRC("autoSave(): forceful? " << force
                                      << ", dontSaveIfUnmodified: " << dontSaveIfUnmodified);
-    if (_sessions.empty() || !isLoaded() || (!isModified() && !force))
+
+    const CanSave canSave = canSaveToDisk();
+    if (canSave != CanSave::Yes)
     {
-        // Nothing to do.
-        LOG_TRC("Nothing to autosave [" << _docKey << "].");
+        LOG_DBG("Cannot save to disk: " << name(canSave));
         return false;
     }
 
-    if (_docState.isDisconnected())
+    if (!isModified() && !force)
     {
-        LOG_DBG("Cannot autosave when disconnected from Kit.");
+        // Nothing to do.
+        LOG_TRC("Nothing to autosave [" << _docKey << "].");
         return false;
     }
 
@@ -3515,6 +3517,7 @@ void DocumentBroker::dumpState(std::ostream& os)
     os << "\n  thread start: " << Util::getTimeForLog(now, _threadStart);
     os << "\n  modified?: " << isModified();
     os << "\n  possibly-modified: " << isPossiblyModified();
+    os << "\n  canSave: " << name(canSaveToDisk());
     os << "\n  canUpload: " << name(canUploadToStorage());
     os << "\n  needToUpload: " << name(needToUploadToStorage());
     os << "\n  haveActivityAfterSaveRequest: " << haveActivityAfterSaveRequest();

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1134,9 +1134,11 @@ bool DocumentBroker::attemptLock(const ClientSession& session, std::string& fail
 
 DocumentBroker::NeedToUpload DocumentBroker::needToUploadToStorage() const
 {
-    if (_storage == nullptr)
+    const CanUpload canUpload = canUploadToStorage();
+    if (canUpload != CanUpload::Yes)
     {
         // This can happen when we reject the connection (unauthorized).
+        LOG_TRC("Cannot upload to storage: " << name(canUpload));
         return NeedToUpload::No;
     }
 
@@ -1270,14 +1272,11 @@ void DocumentBroker::checkAndUploadToStorage(const std::string& sessionId)
     LOG_TRC("checkAndUploadToStorage with session " << sessionId);
 
     // See if we have anything to upload.
-    NeedToUpload needToUploadState = needToUploadToStorage();
+    const NeedToUpload needToUploadState = needToUploadToStorage();
 
     // Handle activity-specific logic.
     switch (_docState.activity())
     {
-        case DocumentState::Activity::None:
-            break;
-
         case DocumentState::Activity::Rename:
         {
             // If we have nothing to upload, do the rename now.
@@ -3516,6 +3515,8 @@ void DocumentBroker::dumpState(std::ostream& os)
     os << "\n  thread start: " << Util::getTimeForLog(now, _threadStart);
     os << "\n  modified?: " << isModified();
     os << "\n  possibly-modified: " << isPossiblyModified();
+    os << "\n  canUpload: " << name(canUploadToStorage());
+    os << "\n  needToUpload: " << name(needToUploadToStorage());
     os << "\n  haveActivityAfterSaveRequest: " << haveActivityAfterSaveRequest();
     os << "\n  isViewFileExtension: " << _isViewFileExtension;
 

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1302,9 +1302,10 @@ void DocumentBroker::checkAndUploadToStorage(const std::string& sessionId)
         default:
         break;
     }
+
 #if !MOBILEAPP
     // Avoid multiple uploads during unloading if we know we need to save a new version.
-    if (_docState.isUnloadRequested() && isPossiblyModified())
+    if (_docState.isUnloadRequested() && needToSaveToDisk() != NeedToSave::No)
     {
         // We are unloading but have possible modifications. Save again (done in poll).
         LOG_DBG("Document [" << getDocKey()
@@ -1313,6 +1314,7 @@ void DocumentBroker::checkAndUploadToStorage(const std::string& sessionId)
         return;
     }
 #endif
+
     if (needToUploadState != NeedToUpload::No)
     {
         uploadToStorage(sessionId, /*force=*/needToUploadState == NeedToUpload::Force);
@@ -1825,6 +1827,41 @@ void DocumentBroker::refreshLock()
     }
 }
 
+DocumentBroker::NeedToSave DocumentBroker::needToSaveToDisk() const
+{
+    // Cannot save without a kit, a loaded doc, and a valid session.
+    if (canSaveToDisk() == CanSave::Yes)
+    {
+        if (!_saveManager.lastSaveSuccessful())
+        {
+            // When saving is attempted and fails, we have no file on disk.
+            return NeedToSave::Yes_LastSaveFailed;
+        }
+
+        if (isModified())
+        {
+            // ViewFileExtensions do not update the ModifiedStatus, but,
+            // we expect a successful save anyway (including unmodified).
+            if (!_isViewFileExtension)
+            {
+                return NeedToSave::Yes_Modified;
+            }
+
+            assert(_isViewFileExtension && "Not a view-file");
+            // Fallback to check for activity post-saving.
+        }
+
+        assert(_saveManager.lastSaveSuccessful() && "Last save failed");
+
+        if (haveActivityAfterSaveRequest())
+        {
+            return NeedToSave::Maybe;
+        }
+    }
+
+    return NeedToSave::No;
+}
+
 bool DocumentBroker::autoSave(const bool force, const bool dontSaveIfUnmodified)
 {
     assertCorrectThread();
@@ -1930,15 +1967,16 @@ void DocumentBroker::autoSaveAndStop(const std::string& reason)
         return;
     }
 
-    if (_docState.isDisconnected() && !isStorageOutdated())
+    const NeedToSave needToSave = needToSaveToDisk();
+    const NeedToUpload needToUpload = needToUploadToStorage();
+    bool canStop = (needToSave == NeedToSave::No && needToUpload == NeedToUpload::No);
+
+    if (!canStop && needToSave == NeedToSave::No && !isStorageOutdated())
     {
-        LOG_DBG("Disconnected from Kit and nothing to upload. Stopping");
-        stop(reason);
-        return;
+        canStop = true;
     }
 
-    bool canStop = false;
-    if (needToUploadToStorage() == NeedToUpload::No)
+    if (!canStop && needToUpload == NeedToUpload::No)
     {
         // Here we don't check for the modified flag because it can come in
         // very late, or not at all. We care that there is nothing to upload

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -609,6 +609,18 @@ private:
         return _saveManager.lastSaveRequestTime() < _lastActivityTime;
     }
 
+    /// Encodes whether or not saving is needed.
+    STATE_ENUM(NeedToSave,
+               No, //< No need to save, data up-to-date.
+               Maybe, //< We have activity post saving.
+               Yes_Modified, //< Data is out of date.
+               Yes_LastSaveFailed, //< Yes, need to produce file on disk.
+               Force //< Force saving, typically because the user requested.
+    );
+
+    /// Returns the state of the need to save.
+    NeedToSave needToSaveToDisk() const;
+
     /// True if we know the doc is modified or
     /// if there has been activity from a client after we last *requested* saving,
     /// since there are race conditions vis-a-vis user activity while saving.

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -1001,6 +1001,18 @@ private:
             _request.setLastRequestResult(success);
         }
 
+        /// The duration elapsed since we sent the last upload request to storage.
+        std::chrono::milliseconds timeSinceLastUploadRequest() const
+        {
+            return _request.timeSinceLastRequest();
+        }
+
+        /// The duration elapsed since we received the last upload response from storage.
+        std::chrono::milliseconds timeSinceLastUploadResponse() const
+        {
+            return _request.timeSinceLastResponse();
+        }
+
         /// Returns the number of previous upload failures. 0 for success.
         std::size_t uploadFailureCount() const { return _request.lastRequestFailureCount(); }
 
@@ -1029,6 +1041,8 @@ private:
             os << indent << "last upload was successful: " << lastUploadSuccessful();
             os << indent << "upload failure count: " << uploadFailureCount();
             os << indent << "last modified time (on server): " << _lastModifiedTime;
+            os << indent << "since last upload request: " << timeSinceLastUploadRequest();
+            os << indent << "since last upload response: " << timeSinceLastUploadResponse();
             os << indent
                << "file last modified: " << Util::getTimeForLog(now, _lastUploadedFileModifiedTime);
         }

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -514,6 +514,26 @@ private:
     /// with the child and cleans up ChildProcess etc.
     void terminateChild(const std::string& closeReason);
 
+    /// Encodes whether or not uploading is possible.
+    /// (regardless of whether we need to or not).
+    STATE_ENUM(
+        CanUpload,
+        Yes, //< Uploading is possible.
+        NoStorage, //< Storage instance missing.
+    );
+
+    /// Returns the state of whether uploading is possible.
+    /// (regardless of whether we need to or not).
+    CanUpload canUploadToStorage() const
+    {
+        if (!_storage)
+        {
+            return CanUpload::NoStorage;
+        }
+
+        return CanUpload::Yes;
+    }
+
     /// Encodes whether or not uploading is needed.
     STATE_ENUM(
         NeedToUpload,
@@ -522,7 +542,7 @@ private:
         Force //< Force uploading, typically because always_save_on_exit is set.
     );
 
-    /// Returns true if, for any reason, we need to upload.
+    /// Returns the state of the need to upload.
     /// This includes out-of-date Document in Storage or
     /// always_save_on_exit.
     NeedToUpload needToUploadToStorage() const;
@@ -1092,7 +1112,7 @@ private:
         void setInteractive(bool value) { _interactive = value; }
         bool isInteractive() const { return _interactive; }
 
-        /// Flag to unload the document. May be reset when a new view is opened.
+        /// Flag to unload the document. Irreversible.
         void setUnloadRequested() { _unloadRequested = true; }
         bool isUnloadRequested() const { return _unloadRequested; }
 

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -514,6 +514,38 @@ private:
     /// with the child and cleans up ChildProcess etc.
     void terminateChild(const std::string& closeReason);
 
+    /// Encodes whether or not saving is possible
+    /// (regardless of whether we need to or not).
+    STATE_ENUM(
+        CanSave,
+        Yes, //< Saving is possible.
+        NoKit, //< There is no Kit.
+        NotLoaded, //< No document is loaded.
+        NoWriteSession, //< No available session can write.
+    );
+
+    /// Returns the state of whether saving is possible.
+    /// (regardless of whether we need to or not).
+    CanSave canSaveToDisk() const
+    {
+        if (_docState.isDisconnected() || getPid() <= 0)
+        {
+            return CanSave::NoKit;
+        }
+
+        if (!isLoaded())
+        {
+            return CanSave::NotLoaded;
+        }
+
+        if (_sessions.empty() || getWriteableSessionId().empty())
+        {
+            return CanSave::NoWriteSession;
+        }
+
+        return CanSave::Yes;
+    }
+
     /// Encodes whether or not uploading is possible.
     /// (regardless of whether we need to or not).
     STATE_ENUM(


### PR DESCRIPTION
**Part 2**

A number of fixes and improvements to Save and Upload cases. Each commit explains the need for the change.

Most were found through tests (a few through reviewing code). Improved test coverage included (which fail without these fixes) in part-3 #4567.

- wsd: do not prevent saving when storage is missing
- wsd: add canUploadToStorage helper
- wsd: add canSaveToDisk helper
- wsd: needToSaveToDisk helper and improved autoSaveAndStop
- wsd: delay uploading if the last attempt had failed