### PR TITLE
Save and Upload Improvements: Part 3

### DIFF
--- a/test/WOPIUploadConflictCommon.hpp
+++ b/test/WOPIUploadConflictCommon.hpp
@@ -160,8 +160,8 @@ public:
         if (getExpectedPutFile() < getCountPutFile())
         {
             //FIXME: unreliable in SaveOnExit, which sometimes does 2 PutFile requests.
-            // LOK_ASSERT_EQUAL_MESSAGE("Too many PutFile requests", getExpectedPutFile(),
-            //                          getCountPutFile());
+            LOK_ASSERT_EQUAL_MESSAGE("Too many PutFile requests", getExpectedPutFile(),
+                                     getCountPutFile());
         }
     }
 


### PR DESCRIPTION
**Part 3**

**_Requires #4565 and #4566 for the tests to pass._**

A number of fixes and improvements to Save and Upload cases. Each commit explains the need for the change.

Most were found through tests (a few through reviewing code). Improved test coverage included (which fail without these fixes).

_Best to review each commit separately._

- wsd: do not enqueue messages on closed sessions
- wsd: detect lost upload on exit and dumpState once only
- wsd: test: better PutFile assertion
