### PR TITLE
don't set cursor to IBeam unless textinput has the focus

### DIFF
--- a/browser/src/layer/marker/Cursor.ts
+++ b/browser/src/layer/marker/Cursor.ts
@@ -66,7 +66,7 @@ class Cursor {
 	}
 
 	setMouseCursor() {
-		if (this.container.querySelector('.blinking-cursor') !== null) {
+		if (this.domAttached && this.container && this.container.querySelector('.blinking-cursor') !== null) {
 			if (this.map._docLayer._docType === 'presentation') {
 				$('.leaflet-interactive').css('cursor', 'text');
 			} else {


### PR DESCRIPTION
When the focus is lost, TextInput actually removes the mouse cursor
but there are other functions that sets the cursor and we need to
check whether the cursor is deleted or not before we set it.

Signed-off-by: Mert Tumer <mert.tumer@collabora.com>
Change-Id: I57622d9a7156148ce2a3cdbedc1af551581d0f8a


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

