### PR TITLE
sidebar: fix alignment in chart deck

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -21,7 +21,7 @@
 	z-index: 2001;
 }
 
-.jsdialog.root-container {
+.jsdialog.root-container:not(.autofilter):not(.sidebar) {
 	margin: .5em 1em; /*same as in .ui-dialog */
 }
 
@@ -197,9 +197,10 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 
 .ui-expander-label::before,
 .ui-treeview-expandable.collapsed > .ui-treeview-expander::before {
+	display: inline-block;
 	content: 'V';
 	color: transparent;
-	margin-right: 7px;
+	margin-inline-end: 7px;
 	background: transparent url('images/lc_menu_chevron.svg') no-repeat center right;
 	filter: brightness(0.5);
 }
@@ -208,19 +209,16 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 .ui-treeview-expandable:not(.collapsed) > .ui-treeview-expander::before  {
 	content: 'V';
 	color: transparent;
-	margin: 0px;
-	position: absolute;
+	margin-inline-end: 7px;
 	transform: rotate(90deg);
-	left: 16px;
 	background: transparent url('images/lc_menu_chevron.svg') no-repeat center;
 	filter: brightness(0.5);
 }
 
 .ui-treeview-expandable > .ui-treeview-expander::before {
-	margin-right: 6px !important;
+	margin-inline-end: 7px !important;
 	display: inline-block;
 	position: relative !important;
-	left: 0px !important;
 }
 
 .ui-expander-label.expanded {

--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -117,8 +117,12 @@
 .sidebar.ui-expander {
 	display: flex;
 	justify-content: space-between;
-	width: 290px;
+	width: calc(100% - 10px);
 	align-items: center;
+}
+
+.sidebar.ui-expander-content {
+	width: calc(100% - 10px);
 }
 
 #selectcolor {
@@ -234,12 +238,6 @@ div#thousandseparator.checkbutton.jsdialog.sidebar {
 	padding-right: 8px; /* for RTL mode */
 }
 
-.sidebar.ui-expander-label:before {
-	position: absolute;
-	margin-inline-start: -16px;
-	left: unset !important;
-}
-
 .sidebar.root-container.jsdialog > .jsdialog.sidebar {
 	width: 100%;
 }
@@ -257,7 +255,7 @@ div#thousandseparator.checkbutton.jsdialog.sidebar {
 }
 
 td.jsdialog .jsdialog.cell.sidebar {
-	padding: 2px;
+	padding: 2px 0px;
 	width: auto;
 }
 
@@ -399,7 +397,7 @@ button#button2.ui-pushbutton.jsdialog.sidebar {
 
 .sidebar #linetransparency {
 	position: relative;
-	left: -18px;
+	margin-inline-end: 18px;
 }
 
 .sidebar #horizontalpos,
@@ -407,7 +405,7 @@ button#button2.ui-pushbutton.jsdialog.sidebar {
 .sidebar #selectwidth,
 .sidebar #selectheight {
 	position: relative;
-	right: 24px;
+	margin-inline-end: 24px;
 }
 
 .sidebar #fillgrad1 {


### PR DESCRIPTION
changes, mainly in Chart Editing Panel
(select chart -> press "edit chart")

- simplified sidebar panel label with arrow
  arrow has simpler rules without left/right (for RTL)
- turned off margins for .jsdialog.root-container
  what caused elements to overflow in chart panel
  (eg drawingarea with chart types)
- changed panel width definition from fixed pixels to
  "100% - scrollbar"
- RTL: converted left/right -> margin-inline-* for some
  spinfields in chart panel

also includes :not(autofilter) in one rule which is changed in not merged PR...:
https://github.com/CollaboraOnline/online/pull/4541
