### PR TITLE
Fix StatisticsMenu arrow

### DIFF
--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -236,13 +236,6 @@
 	padding: 0px 5px !important;
 }
 
-/*Adjust arrow for statistics menu (has icon, label stacked up)*/
-.unospan-Data-StatisticsMenu .unoarrow {
-	display: block;
-	float: right;
-	margin-top: -28px;
-}
-
 .unotoolbutton.notebookbar:hover .unoarrow {
 	border-top: 5px solid var(--color-border-darker);
 }


### PR DESCRIPTION
Before we needed an exception for the StatisticsMenu, to position the
arrow. Now this is no longer needed. The component get well placed by
default

- Remove CSS exception and fix the inconsistency:
https://archive.org/download/cool-nb-bug-arrow-statistics/cool-nb-bug-arrow-statistics.png

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I7cf46c7c3d2593b571c91c0dedc197fdcae3a7ee
