### PR TITLE
[docker] Be consistent in number of processors used to build

### DIFF
--- a/docker/from-source/build.sh
+++ b/docker/from-source/build.sh
@@ -111,7 +111,7 @@ if [ "$CORE_BRANCH" == "distro/collabora/co-22.05" ]; then
 else
   ( cd core && ./autogen.sh --with-distro=LibreOfficeOnline ) || exit 1
 fi
-( cd core && make -j $(nproc) $CORE_BUILD_TARGET ) || exit 1
+( cd core && make $CORE_BUILD_TARGET ) || exit 1
 
 # copy stuff
 mkdir -p "$INSTDIR"/opt/


### PR DESCRIPTION
Signed-off-by: Marco Marinello <contact+nohuman@marinello.bz.it>
Change-Id: I063b82ad9ee7b8795637ea058e1e15b8331c8818


* Target version: master, possibly distro/collabora/co-6-4

### Summary

Switched to `-j $(nproc)` in all `make` calls.

### Checklist

- [X ] Code is properly formatted
- [ X] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ X] Documentation (manuals or wiki) has been updated or is not required

