### PR TITLE
Fix repair document item on notebookbar writer

### DIFF
--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -216,25 +216,38 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 			]);
 		}
 
-		content.push({
-			'type': 'container',
-			'children': [
-				{
-					'id': 'repair',
-					'type': 'menubartoolitem',
-					'text': _('Repair'),
-					'command': _('Repair')
-				},
-				hasSigning ?
+		if (hasSigning === false) {
+			content.push({
+				'type': 'container',
+				'children': [
+					{
+						'id': 'repair',
+						'type': 'bigmenubartoolitem',
+						'text': _('Repair'),
+						'command': _('Repair')
+					}
+				]
+			});
+		} else {
+			content.push({
+				'type': 'container',
+				'children': [
+					{
+						'id': 'repair',
+						'type': 'menubartoolitem',
+						'text': _('Repair'),
+						'command': _('Repair')
+					},
 					{
 						'id': 'signdocument',
 						'type': 'menubartoolitem',
 						'text': _('Sign document'),
 						'command': ''
-					} : {},
-			],
-			'vertical': 'true'
-		});
+					}
+				],
+				'vertical': 'true'
+			});
+		}
 
 		return this.getTabPage('File', content);
 	},


### PR DESCRIPTION
  Context:
  Repair document on the Notebookbar is currently always a small item
  
  https://archive.org/download/repairdoc-writer-smallitem/repairdoc-writer-smallitem.png
  
  ,it should be a bigtooltiem when the extra additional/optional item
  Sign document is not available:
  - Set it to small item and vertically stacked when hasSigning is true
  - Set it to bigtoolitem when hasSigning is false

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I26a8e1b721bf2550127eff1ccfdc44ab4876db52
