### PR TITLE
Classic: Add missing split cell dialog trigger to writer

### DIFF
--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -274,6 +274,7 @@ L.Control.Menubar = L.Control.extend({
 					{uno: '.uno:EntireRow'},
 					{uno: '.uno:EntireColumn'},
 					{uno: '.uno:EntireCell'}]},
+				{uno: '.uno:SplitCell'},
 				{uno: '.uno:MergeCells'},
 				{type: 'separator'},
 				{uno: '.uno:TableDialog'}


### PR DESCRIPTION
When working with tables it is now possible to to slip cells
where: Top menu: Table -> Split Cell...

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ia242358245cebb6bded55aa995bd8c80900b9aaa
