### PR TITLE
cypress: fix:ui-expander-label getting detached from dom

### DIFF
--- a/cypress_test/integration_tests/desktop/calc/image_operation_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/image_operation_spec.js
@@ -30,6 +30,8 @@ describe('Image Operation Tests', function() {
 		//when Keep ratio is unchecked
 		assertImageSize(248, 63);
 
+		helper.waitUntilIdle('.ui-expander-label');
+
 		cy.contains('.ui-expander-label', 'Position and Size')
 			.click();
 


### PR DESCRIPTION
Signed-off-by: Rash419 <rashesh.padia@collabora.com>
Change-Id: I471d220cd15b66693b6e43bcf5ee83276921ff9c

* Target version: master 