### PR TITLE
Make the TranslateId things compile against co-22.05

### DIFF
--- a/ios/Mobile/L10n.h
+++ b/ios/Mobile/L10n.h
@@ -8,7 +8,7 @@
 
 #define _(id, catalog) app_translate(id, catalog)
 
-#if (LIBO_VERSION_MAJOR > 7 && LIBO_VERSION_MAJOR < 21) || (LIBO_VERSION_MAJOR == 7 && LIBO_VERSION_MINOR >= 3)
+#if (LIBO_VERSION_MAJOR > 7 && LIBO_VERSION_MAJOR < 21) || (LIBO_VERSION_MAJOR >= 22) || (LIBO_VERSION_MAJOR == 7 && LIBO_VERSION_MINOR >= 3)
 
 #define LIBO_INTERNAL_ONLY
 

--- a/ios/Mobile/L10n.mm
+++ b/ios/Mobile/L10n.mm
@@ -15,7 +15,7 @@
 #import "L10n.h"
 
 char *app_translate(
-#if (LIBO_VERSION_MAJOR > 7 && LIBO_VERSION_MAJOR < 21) || (LIBO_VERSION_MAJOR == 7 && LIBO_VERSION_MINOR >= 3)
+#if (LIBO_VERSION_MAJOR > 7 && LIBO_VERSION_MAJOR < 21) || (LIBO_VERSION_MAJOR >= 22) || (LIBO_VERSION_MAJOR == 7 && LIBO_VERSION_MINOR >= 3)
                     TranslateId id,
 #else
                     const char *id,

--- a/ios/Mobile/TemplateCollectionViewController.mm
+++ b/ios/Mobile/TemplateCollectionViewController.mm
@@ -4,8 +4,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#import "svtools/strings.hrc"
-
 #import <LibreOfficeKit/LibreOfficeKitInit.h>
 
 #import "ios.h"
@@ -13,6 +11,8 @@
 #import "L10n.h"
 #import "TemplateCollectionViewController.h"
 #import "TemplateSectionHeaderView.h"
+
+#import "svtools/strings.hrc"
 
 static NSString *mapTemplateExtensionToActual(NSString *templateName) {
     NSString *baseName = [templateName stringByDeletingPathExtension];


### PR DESCRIPTION
The ifdef conditions seems a bit over-complicated but as long as it
compiles it is good enough for me. I don't remember the details from
my earlier work on this.

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: I9a1873dc3676c15c7fb4cde84c0e14bf56653443


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

