### PR TITLE
fix firefox zooms in whole page on mobile

### DIFF
--- a/browser/html/cool.html.m4
+++ b/browser/html/cool.html.m4
@@ -10,7 +10,7 @@ m4_define(_YEAR_,m4_esyscmd(date +%Y|tr -d '\n'))
 <html %UI_RTL_SETTINGS% style="height:100%"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <title>Online Editor</title>
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="viewport" content="width=device-width, initial-scale=1.0 minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
 
 <script>
 m4_dnl# Define MOBILEAPP as true if this is either for the iOS app or for the gtk+ "app" testbed

--- a/browser/html/debug.html
+++ b/browser/html/debug.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0 minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>Online</title>
     <style>
         html, body, iframe


### PR DESCRIPTION
textarea focus makes firefox zoom in without
specifying viewport scale properties

Signed-off-by: Mert Tumer <mert.tumer@collabora.com>
Change-Id: Iea5c0e61af14dc8f05319570f84681ca2b76aed1


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

