### PR TITLE
Scroll buttons are right aligned for faster nav

### DIFF
--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -58,6 +58,13 @@
 	border-spacing: 0px;
 }
 
+/* scroll buttons */
+.hasnotebookbar .w2ui-scroll-left,
+.hasnotebookbar .w2ui-scroll-right {
+	top: 9px;
+	margin-right: 5px;
+}
+
 /* shortcuts bar */
 
 .notebookbar-shortcuts-bar {

--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -194,6 +194,30 @@ w2ui-toolbar {
 .w2ui-scroll-left,
 .w2ui-scroll-right {
 	z-index: 1001;
+	background-color: var(--color-background-lighter) !important;
+	box-shadow: var(--color-box-shadow);
+	border: 1px solid var(--color-border-dark);
+	height: 30px;
+	width: 30px;
+	top: 6px;
+}
+.w2ui-scroll-left:hover,
+.w2ui-scroll-right:hover {
+	background-color: var(--color-background-dark) !important;
+}
+
+.w2ui-scroll-left {
+	background: url('images/lc_prevrecord.svg') center;
+	border-top-left-radius: 100%;
+	border-bottom-left-radius: 100%;
+	right: 29px;
+	left: auto;
+}
+.w2ui-scroll-right {
+	background: url('images/lc_nextrecord.svg') center;
+	border-top-right-radius: 100%;
+	border-bottom-right-radius: 100%;
+	right: 0px;
 }
 
 /* center the toolbar */

--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -342,8 +342,8 @@ L.Control.Notebookbar = L.Control.extend({
 		var left = L.DomUtil.create('div', 'w2ui-scroll-left', parent);
 		var right = L.DomUtil.create('div', 'w2ui-scroll-right', parent);
 
-		$(left).css({'height': '72px'});
-		$(right).css({'height': '72px'});
+		$(left).css({'height': '30px'});
+		$(right).css({'height': '30px'});
 
 		$(left).click(function () {
 			var scroll = $('.notebookbar-scroll-wrapper').scrollLeft() - 300;


### PR DESCRIPTION
As the scroll buttons are left for move left
and right for move right, the mouse movement
is very long to move the toolbars left/right
this PR move all commands to the right

In addition the layout change to some
32px large buttons (bigger in width)
and borders are rounded for faster
visual feedback.

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I9cfddfc682fe634985087f550eada32f7ec32478


* Resolves: #4302
* Target version: master 

#### classic toolbar
![Screenshot_20220415_231554](https://user-images.githubusercontent.com/8517736/163636076-23e443e2-0508-495a-ba34-306f9dd91ef5.png)

#### notebookbar
![Screenshot_20220415_234210](https://user-images.githubusercontent.com/8517736/163636096-e1fc7e2b-84fc-48e9-96c8-c4aa21f4b2cc.png)

