### PR TITLE
writer notebookbar stylesview previews no padding

### DIFF
--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -400,6 +400,7 @@
 #stylesview .ui-iconview-entry {
 	width: 30%;
 	box-sizing: border-box;
+	padding-top: 0px;
 }
 
 #stylesview .ui-iconview-entry.selected {


### PR DESCRIPTION
remove padding-top: 5px so there is no scrolling
needed for two rows.

![image](https://user-images.githubusercontent.com/8517736/163650333-2139e9da-825e-41e7-a951-27fe5982b347.png)


Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I9a0450074cc55486d0f7de8a39b7edff8e66c752