### PR TITLE
Update welcome screen for smaler sizes and mobile

### DIFF
--- a/browser/css/device-mobile.css
+++ b/browser/css/device-mobile.css
@@ -904,14 +904,3 @@ div#fontstyletoolbox + div#style.mobile-wizard {
 	margin: 2px;
 	font-size: 29px;
 }
-
-/* Welcome Dialog */
-.iframe-welcome-modal {
-	display: block;
-	border-radius: 0;
-}
-.iframe-welcome-modal,
-.iframe-welcome-content {
-	width: 100%;
-	height: 100%;
-}

--- a/browser/css/welcome.css
+++ b/browser/css/welcome.css
@@ -1,4 +1,5 @@
-.iframe-welcome-wrap {
+.iframe-welcome-wrap,
+.iframe-welcome-content {
 	position: absolute;
 	z-index: 1106;
 	display: flex;
@@ -6,11 +7,17 @@
 	height: 100%;
 	justify-content: center;
 	align-items: center;
+	background-color: var(--color-overlay);
 }
 
 .iframe-welcome-modal {
-	height: 512px;
-	width: 700px;
+	display: flex;
+	width: 95%;
+	height: 95%;
+	max-width: 700px;
+	max-height: 512px;
+	justify-content: center;
+	align-items: center;
 	-webkit-box-shadow: 0 0 3px var(--color-box-shadow);
 	box-shadow: 0 0 3px var(--color-box-shadow);
 	border-width: 0;

--- a/browser/welcome/welcome.css
+++ b/browser/welcome/welcome.css
@@ -21,7 +21,7 @@
 
 .slider,
 .slides > div {
-  width: 600px;
+  width: 96%;
 }
 
 .slider {
@@ -141,9 +141,15 @@ body {
   color: #222;
 }
 
+.slides a {
+  text-decoration: none;
+  color: #0b87e7;
+}
+
 .slides fig {
   height: 232px;
   display: block;
+  margin: 16px auto 12px auto;
 }
 
 #slide-1 fig {
@@ -187,7 +193,6 @@ body {
   background: url("slide3.png") no-repeat center;
   box-shadow: 0 0 8px 1px #e5e5e5;
   width: 342px;
-  margin: 12px auto;
   border-radius: 8px;
 }
 
@@ -312,6 +317,11 @@ button:hover .arrow.left.close {
     border-bottom-right-radius: 0;
   }
 
+  .slides p {
+    margin-left: 14px;
+    margin-right: 14px;
+  }
+
   .arrow {
     padding: 4px;
   }
@@ -358,6 +368,11 @@ button:hover .arrow.left.close {
   html,
   body {
     overflow-y: scroll;
+  }
+
+  .slides p {
+    margin-left: 14px;
+    margin-right: 14px;
   }
 
   .slides fig {


### PR DESCRIPTION
* Resolves: #3790
* Target version: master 

devices-mobiles.css
- rules for mobile wasn't needed
  everywthing is in welcome.css

welcome.css
- screen behind welcome dialog use --color-overlay
  as at every dialog
- no fixed width and height
  max-width and max-height was the old width/height
  width and height are now 95%
  dialog window was center justify
- content width is 96%
  when smaler than 500px padding was added to <p>
- fig get top an bottom margin
  so now all fig's have the same height
- hyperlinks use --color-primary
  and not underline

Change-Id: If921bc2abc3977930f7d60256d8011d8986a22c9
Signed-off-by: andreas kainz <kainz.a@gmail.com>