### PR TITLE
Sidebar alignment commands main sections

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -33,6 +33,8 @@
 	color: var(--color-text-dark);
 	background-color: var(--color-background-dark);
 }
+
+#fontsizecombobox > .sidebar.jsdialog.ui-listbox,
 #TableEditPanelPanelExpander .sidebar .spinfieldcontainer input,
 #ParaPropertyPanelPanelExpander .sidebar .spinfieldcontainer input {
 	width: 85px;
@@ -110,28 +112,21 @@
 	width: 10px;
 }
 
-#fontsizecombobox > .sidebar.jsdialog.ui-listbox {
-	min-width: 86px;
-}
-
 .sidebar.ui-expander {
 	display: flex;
 	justify-content: space-between;
-	width: calc(100% - 10px);
 	align-items: center;
 }
 
 .sidebar.ui-expander-content {
-	width: calc(100% - 10px);
+	width: calc(100% - 16px);
+	padding-left: 8px;
+	padding-right: 8px;
 }
 
 #selectcolor {
 	display: flex;
 	justify-content: flex-end;
-}
-
-.sidebar.jsdialog.cell > #table-box3 {
-	width: 292px;
 }
 
 .sidebar.jsdialog.cell > #table-box3,
@@ -164,7 +159,6 @@
 #ParaPropertyPanelPanelExpander #grid4 > tr:last-child {
 	display: flex;
 	justify-content: space-between;
-	width: 275px;
 }
 
 .sidebar #orientationdegrees {
@@ -330,6 +324,7 @@ td.jsdialog .jsdialog.cell.sidebar {
 	display: block;
 	width: 10px;
 	height: 10px;
+	margin-right: 10px;
 }
 
 .ui-expander.jsdialog.sidebar .ui-expander-icon-right img {


### PR DESCRIPTION
the sidebar alignments didn't work again
this will simplyfy the global .sidebar.ui-exmander
and the .sidebar.ui-expander-content

Now there will be left and right 8px padding
and the ui-expander use 100%. So everything
will be mirrored.

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I4a8f94ffd404501dbb24b458f1210066769b9897