### PR TITLE
mocha-tests: fix build for CPointSet.test.ts

### DIFF
--- a/browser/mocha_tests/CPointSet.test.ts
+++ b/browser/mocha_tests/CPointSet.test.ts
@@ -1,5 +1,6 @@
 /// <reference path="./refs/globals.ts"/>
 /// <reference path="../src/geometry/Point.ts" />
+/// <reference path="../src/geometry/Bounds.ts" />
 /// <reference path="../src/layer/vector/CPointSet.ts" />
 
 var assert = require('assert');


### PR DESCRIPTION
Include Bounds.ts (definition of cool.Bounds) to fix the following build error of CPointSet.test.ts

```
./node_modules/typescript/bin/tsc mocha_tests/CPointSet.test.ts --outfile mocha_tests/CPointSet.test.js --module none --lib dom,es2016 --target ES5
src/layer/vector/CPointSet.ts:23:33 - error TS2694: Namespace 'cool' has no exported member 'Bounds'.

23  static fromBounds(bounds: cool.Bounds) {
                                   ~~~~~~
```
Signed-off-by: Dennis Francis <dennis.francis@collabora.com>
Change-Id: I8853995544c56c9a3bd522bacbf572bc1084cb17


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

