### PR TITLE
Fix missing sparklines icon on notebookbar, format tab

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2232,7 +2232,8 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			'AlignLeft': 'LeftPara',
 			'AlignRight': 'RightPara',
 			'AlignHorizontalCenter': 'CenterPara',
-			'AlignBlock': 'JustifyPara'
+			'AlignBlock': 'JustifyPara',
+			'FormatSparklineMenu': 'InsertSparkline',
 		};
 		var cleanName = name;
 		var prefixLength = '.uno:'.length;


### PR DESCRIPTION
Add iconAlias and avoid duplicating svg

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I4a14da88c9e97e5541d224c2d1f29a99df19a7f9
