### PR TITLE
Remove toggle prefix from status bar and ruler

### DIFF
--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -951,7 +951,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 			{
 				'id': 'showstatusbar',
 				'type': 'menubartoolitem',
-				'text': _('Toggle Status Bar'),
+				'text': _('Status Bar'),
 				'command': _('Show Status Bar')
 			}
 		];

--- a/browser/src/control/Control.NotebookbarDraw.js
+++ b/browser/src/control/Control.NotebookbarDraw.js
@@ -269,7 +269,7 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 			{
 				'id': 'showstatusbar',
 				'type': 'menubartoolitem',
-				'text': _('Toggle Status Bar'),
+				'text': _('Status Bar'),
 				'command': _('Show Status Bar')
 			}
 		];

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -339,7 +339,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 			{
 				'id': 'showstatusbar',
 				'type': 'menubartoolitem',
-				'text': _('Toggle Status Bar'),
+				'text': _('Status Bar'),
 				'command': _('Show Status Bar')
 			}
 		];

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -1005,7 +1005,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 							{
 								'id': 'showruler',
 								'type': 'menubartoolitem',
-								'text': _('Toggle Ruler'),
+								'text': _('Ruler'),
 								'command': _('Show Ruler')
 							}
 						]
@@ -1016,7 +1016,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 							{
 								'id': 'showstatusbar',
 								'type': 'menubartoolitem',
-								'text': _('Toggle Status Bar'),
+								'text': _('Status Bar'),
 								'command': _('Show Status Bar')
 							}
 						]


### PR DESCRIPTION
No need to indicate that those components are toggles since they
visually communicate there. Plus we are not using that prefix for
other toggles like "sidebar"

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Idb99d1e8505feb3adaa9378f0f96309cd3cf7158
