### PR TITLE
private/pedro/formulabarfixes

### DIFF
--- a/browser/css/toolbar-mobile.css
+++ b/browser/css/toolbar-mobile.css
@@ -1,6 +1,5 @@
 @-moz-document url-prefix() {
 	#formulabar #formulaInput, #formulabar #addressInput{
-		margin-left: 5px;
 		color: var(--color-main-text);
 		background-color: var(--color-main-background);
 		border: 1px solid var(--color-border) !important;

--- a/browser/css/toolbar-mobile.css
+++ b/browser/css/toolbar-mobile.css
@@ -1,14 +1,3 @@
-@-moz-document url-prefix() {
-	#formulabar #formulaInput, #formulabar #addressInput{
-		color: var(--color-main-text);
-		background-color: var(--color-main-background);
-		border: 1px solid var(--color-border) !important;
-		border-radius: 0px;
-	}
-	#toolbar-up{
-		top: -1px;
-	}
-}
 #tb_actionbar_item_redo.disabled, #tb_actionbar_item_undo.disabled, #tb_actionbar_item_mobile_wizard.disabled, #tb_actionbar_item_insertion_mobile_wizard.disabled {
 	display: none;
 }

--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -148,7 +148,6 @@ w2ui-toolbar {
 }
 
 #formulabar {
-	background-color: var(--color-main-background);
 	border-top: 1px solid var(--color-border);
 	height: 30px;
 }

--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -152,10 +152,16 @@ w2ui-toolbar {
 	height: 30px;
 }
 
-#tb_formulabar_item_address, #tb_formulabar_item_item_2, #tb_formulabar_item_functiondialog {
-	padding-top: 2px;
+.inputbar_multiline #tb_formulabar_item_address,
+.inputbar_multiline #tb_formulabar_item_item_2,
+.inputbar_multiline #tb_formulabar_item_functiondialog {
 	vertical-align: top;
 }
+
+.inputbar_multiline #tb_formulabar_item_functiondialog {
+	padding-top: 4px;
+}
+
 
 #presentation-toolbar {
 	bottom: 0;
@@ -201,8 +207,10 @@ w2ui-toolbar {
 }
 
 #addressInput {
-	height: 29px;
+	height: 22px;
 	width: 100px;
+	padding: 2px 4px;
+	margin-top: 1px;
 }
 
 #formulaInput {

--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -212,6 +212,8 @@ w2ui-toolbar {
 	padding: 2px 4px;
 	margin-top: 1px;
 	margin-left: 5px;
+	/* Remove or change depending on core side */
+	border: 1px solid black;
 }
 
 #formulaInput {

--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -211,6 +211,7 @@ w2ui-toolbar {
 	width: 100px;
 	padding: 2px 4px;
 	margin-top: 1px;
+	margin-left: 5px;
 }
 
 #formulaInput {


### PR DESCRIPTION
commit 7825802342fdb5f20a752cd0765589022423b3e2 (HEAD -> distro/collabora/co-21-11)
Author: Pedro Pinto Silva <pedro.silva@collabora.com>
Date:   Fri Apr 22 12:12:23 2022 +0200

Formulabar: Remove FF-only rules

It's not needed anymore plus it was also affecting desktop.

----

commit e7b577e7566812c443f060c3c7c31275ce97ca67
Author: Pedro Pinto Silva <pedro.silva@collabora.com>
Date:   Fri Apr 22 12:10:16 2022 +0200

formulabar InputAddress: Use the same border style as used in core

This might need to be removed once we change the way we render formulabar
- So if it is render natively we can just use a more nuanced color
across the board

----

commit 79ea15df320095c54a965bd1e1d8d17609799e7b
Author: Pedro Pinto Silva <pedro.silva@collabora.com>
Date:   Fri Apr 22 12:06:37 2022 +0200

Formulabar inputAdd: Add missing margin left

Before it seems that only FF was getting that margin
- Yes even though that rule is supposed to only affect mobile

Fix it. And use the same margin everywhere.

----

commit bcf4234cd422494f29b6b1cb31ba58d348f5e0e8
Author: Pedro Pinto Silva <pedro.silva@collabora.com>
Date:   Fri Apr 22 11:50:01 2022 +0200

Fix formulabar and formulabar items' misalignment

It seems Formulabar and surrounding items were being aligned with
multiline mode (when input is expanded) in mind but:
- This affecting the standard view (when is collapsed) and causing
misalignment
- On top of that, when the input is expanded the alignment was not 100%
effective

https://archive.org/download/formulabar-misalignment/formulabar-misalignment.png

Fix it:
- Align everything to the top but only when the input field is expanded
- Remove padding for alignments that can get automatically aligned, and
use padding just for the function icon and just when needed (multiline)
- Fix AdressInput's size padding and margin

fixes issue #4620

----

commit 3998ac1e4f318cb4ed12ac2425eb6fdc10caeb77
Author: Pedro Pinto Silva <pedro.silva@collabora.com>
Date:   Fri Apr 22 10:09:27 2022 +0200

Fix formulabar background discrepancy

For now and because formula bar comes from core side and thus it's
via canvas we have no way to change its background (it comes in white).
Currently we have a color discrepancy:
https://archive.org/download/formulabar-bg-discrepancy/formulabar-bg-discrepancy.png

Fix it. Remove background of its container element which we were
forcing another color other than white and let it inherit the #fff from
wui toolbar.
