### PR TITLE
Avoid using only "real" paths for the tmpfont thing

### DIFF
--- a/coolwsd-systemplate-setup
+++ b/coolwsd-systemplate-setup
@@ -15,6 +15,12 @@ test -d "$INSTDIR" || { echo "$0: No such directory: $INSTDIR"; exit 1; }
 
 mkdir -p $CHROOT || exit 1
 
+# For the tmpfonts we need to use the pathnames as used by the
+# configure script, which does *not* look up realpaths, because the
+# Makefile.am uses @SYSTEMPLATE_PATH@ which uses abs_top_builddir
+# which uses ac_pwd which is not based on use of realpath.
+CHROOT_AS_GIVEN=$CHROOT
+
 # Resolve the real paths, in case they are relative and/or symlinked.
 # INSTDIR_LOGICAL will contain the logical path, if there are symlinks,
 # while INSTDIR is the physical one. Both will most likely be the same,
@@ -117,9 +123,18 @@ done
 # stored. Such are downloaded from other servers based on a separate
 # configuration file. They need to be accessible using the same
 # pathname both in the ForKit process and in the Kit processes.
+
 mkdir -p $CHROOT/tmpfonts
 mkdir -p $CHROOT$CHROOT
 ln -f -s `${REALPATH} --relative-to=$CHROOT$CHROOT $CHROOT/tmpfonts` $CHROOT$CHROOT
+
+# To be safe we do this both for $CHROOT and $CHROOT_AS_GIVEN, in case they differ.
+
+if [ "$CHROOT_AS_GIVEN" != "$CHROOT" ]; then
+    mkdir -p $CHROOT_AS_GIVEN/tmpfonts
+    mkdir -p $CHROOT_AS_GIVEN$CHROOT_AS_GIVEN
+    ln -f -s `${REALPATH} --relative-to=$CHROOT_AS_GIVEN$CHROOT_AS_GIVEN $CHROOT_AS_GIVEN/tmpfonts` $CHROOT_AS_GIVEN$CHROOT_AS_GIVEN
+fi
 
 # /usr/share/fonts needs to be taken care of separately because the
 # directory time stamps must be preserved for fontconfig to trust


### PR DESCRIPTION
If I have used a path with symlinks in it when changing directory to
my build directory, what gets put in config.status as ac_pwd is that
path, not a realpath version. That then propagates to
ac_abs_to_builddir and to SYSTEMPLATE_PATH, which is what Makefile.am
passes for the --o:sys_template_path option to coolwsd.

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: I7575120090986e6207497c5ce740aedd6075e48f


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

