### PR TITLE
Fix leaflet-control alignment

### DIFF
--- a/browser/css/leaflet.css
+++ b/browser/css/leaflet.css
@@ -139,7 +139,7 @@
 .leaflet-right .leaflet-control {
 	float: right;
 	margin-right: 10px;
-	line-height: 28px;
+	line-height: initial;
 
 }
 .leaflet-top .leaflet-control {


### PR DESCRIPTION
context: https://archive.org/download/repair-doc-close-misaligned/repair-doc-close-misaligned.png

line-height, if the hard-coded px is needed, then it should be the
same value as the width and height so not 28px but 32px
as it's the values used in a.leaflet-popup-close-button.

But better to just rely on the unitless value that line-height can
accept then it will fit whatever the font-size and width the anchor has:
- Fix it by letting the web browsers align the content for us. Web
browser multiplies our number by the font-size value (1 times font-size)
, so no need to depend on specific px values for that.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I4145231241a9acc540c684971e3bde46adb2304b
