### PR TITLE
scroll buttons use var colors and update design

### DIFF
--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -194,6 +194,19 @@ w2ui-toolbar {
 .w2ui-scroll-left,
 .w2ui-scroll-right {
 	z-index: 1001;
+	width: 32px;
+	background-color: var(--color-background-lighter) !important;
+	box-shadow: none;
+}
+.w2ui-scroll-left {
+	border-right: 1px solid var(--color-border-dark);
+}
+.w2ui-scroll-right {
+	border-left: 1px solid var(--color-border-dark);
+}
+.w2ui-scroll-left:hover,
+.w2ui-scroll-right:hover {
+	background-color: var(--color-background-dark) !important;
 }
 
 /* center the toolbar */

--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -349,8 +349,8 @@ L.Control.Notebookbar = L.Control.extend({
 		var left = L.DomUtil.create('div', 'w2ui-scroll-left', parent);
 		var right = L.DomUtil.create('div', 'w2ui-scroll-right', parent);
 
-		$(left).css({'height': '72px'});
-		$(right).css({'height': '72px'});
+		$(left).css({'height': '80px'});
+		$(right).css({'height': '80px'});
 
 		$(left).click(function () {
 			var scroll = $('.notebookbar-scroll-wrapper').scrollLeft() - 300;


### PR DESCRIPTION
scroll buttons when the window size is to small,
use var colors

the design was updated to be more like a regular
button. width was larger, 32px like other commands
vertical line like we have in toolbars

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I9448c596f473dff29e322b040dd95755bf5aefb6