### PR TITLE
Configurable Delayed Save and Upload

### DIFF
--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -52,6 +52,7 @@
         <limit_load_secs desc="Maximum number of seconds to wait for a document load to succeed. 0 for unlimited." type="uint" default="100">100</limit_load_secs>
         <limit_store_failures desc="Maximum number of consecutive save-and-upload to storage failures when unloading the document. 0 for unlimited (not recommended)." type="uint" default="5">5</limit_store_failures>
         <limit_convert_secs desc="Maximum number of seconds to wait for a document conversion to succeed. 0 for unlimited." type="uint" default="100">100</limit_convert_secs>
+        <min_time_between_saves_ms desc="Minimum number of milliseconds between saving the document on disk." type="uint" default="500">500</min_time_between_saves_ms>
         <cleanup desc="Checks for resource consuming (bad) documents and kills associated kit process. A document is considered resource consuming (bad) if is in idle state for idle_time_secs period and memory usage passed limit_dirty_mem_mb or CPU usage passed limit_cpu_per" enable="true">
             <cleanup_interval_ms desc="Interval between two checks" type="uint" default="10000">10000</cleanup_interval_ms>
             <bad_behavior_period_secs desc="Minimum time period for a document to be in bad state before associated kit process is killed. If in this period the condition for bad document is not met once then this period is reset" type="uint" default="60">60</bad_behavior_period_secs>

--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -53,6 +53,7 @@
         <limit_store_failures desc="Maximum number of consecutive save-and-upload to storage failures when unloading the document. 0 for unlimited (not recommended)." type="uint" default="5">5</limit_store_failures>
         <limit_convert_secs desc="Maximum number of seconds to wait for a document conversion to succeed. 0 for unlimited." type="uint" default="100">100</limit_convert_secs>
         <min_time_between_saves_ms desc="Minimum number of milliseconds between saving the document on disk." type="uint" default="500">500</min_time_between_saves_ms>
+        <min_time_between_uploads_ms desc="Minimum number of milliseconds between uploading the document to storage." type="uint" default="5000">5000</min_time_between_uploads_ms>
         <cleanup desc="Checks for resource consuming (bad) documents and kills associated kit process. A document is considered resource consuming (bad) if is in idle state for idle_time_secs period and memory usage passed limit_dirty_mem_mb or CPU usage passed limit_cpu_per" enable="true">
             <cleanup_interval_ms desc="Interval between two checks" type="uint" default="10000">10000</cleanup_interval_ms>
             <bad_behavior_period_secs desc="Minimum time period for a document to be in bad state before associated kit process is killed. If in this period the condition for bad document is not met once then this period is reset" type="uint" default="60">60</bad_behavior_period_secs>

--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -40,10 +40,8 @@
         <redlining_as_comments desc="If true show red-lines as comments" type="bool" default="false">false</redlining_as_comments>
         <pdf_resolution_dpi desc="The resolution, in DPI, used to render PDF documents as image. Memory consumption grows proportionally. Must be a positive value less than 385. Defaults to 96." type="uint" default="96">96</pdf_resolution_dpi>
         <idle_timeout_secs desc="The maximum number of seconds before unloading an idle document. Defaults to 1 hour." type="uint" default="3600">3600</idle_timeout_secs>
-        <!-- Idle save and auto save are checked every 30 seconds -->
-        <!-- They are disabled when the value is zero or negative. -->
-        <idlesave_duration_secs desc="The number of idle seconds after which document, if modified, should be saved. Defaults to 30 seconds." type="int" default="30">30</idlesave_duration_secs>
-        <autosave_duration_secs desc="The number of seconds after which document, if modified, should be saved. Defaults to 5 minutes." type="int" default="300">300</autosave_duration_secs>
+        <idlesave_duration_secs desc="The number of idle seconds after which document, if modified, should be saved. Disabled when 0. Defaults to 30 seconds." type="uint" default="30">30</idlesave_duration_secs>
+        <autosave_duration_secs desc="The number of seconds after which document, if modified, should be saved. Disabled when 0. Defaults to 5 minutes." type="uint" default="300">300</autosave_duration_secs>
         <always_save_on_exit desc="On exiting the last editor, always perform the save, even if the document is not modified." type="bool" default="false">false</always_save_on_exit>
         <limit_virt_mem_mb desc="The maximum virtual memory allowed to each document process. 0 for unlimited." type="uint">0</limit_virt_mem_mb>
         <limit_stack_mem_kb desc="The maximum stack size allowed to each document process. 0 for unlimited." type="uint">8000</limit_stack_mem_kb>

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -1798,6 +1798,7 @@ void COOLWSD::innerInitialize(Application& self)
         { "per_document.limit_stack_mem_kb", "8000" },
         { "per_document.limit_virt_mem_mb", "0" },
         { "per_document.max_concurrency", "4" },
+        { "per_document.min_time_between_saves_ms", "500" },
         { "per_document.batch_priority", "5" },
         { "per_document.pdf_resolution_dpi", "96" },
         { "per_document.redlining_as_comments", "false" },

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -1799,6 +1799,7 @@ void COOLWSD::innerInitialize(Application& self)
         { "per_document.limit_virt_mem_mb", "0" },
         { "per_document.max_concurrency", "4" },
         { "per_document.min_time_between_saves_ms", "500" },
+        { "per_document.min_time_between_uploads_ms", "5000" },
         { "per_document.batch_priority", "5" },
         { "per_document.pdf_resolution_dpi", "96" },
         { "per_document.redlining_as_comments", "false" },

--- a/wsd/COOLWSD.hpp
+++ b/wsd/COOLWSD.hpp
@@ -356,6 +356,15 @@ public:
         return getConfigValue(Application::instance().config(), name, def);
     }
 
+    /// Returns the value of the specified application configuration,
+    /// or the default, if one doesn't exist.
+    template <typename T> static T getConfigValueNonZero(const std::string& name, const T def)
+    {
+        static_assert(std::is_integral<T>::value, "Meaningless on non-integral types");
+        const T res = getConfigValue(Application::instance().config(), name, def);
+        return res <= T(0) ? T(0) : res;
+    }
+
     /// Reads and processes path entries with the given property
     /// from the configuration.
     /// Converts relative paths to absolute.

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -109,35 +109,33 @@ public:
 
 std::atomic<unsigned> DocumentBroker::DocBrokerId(1);
 
-DocumentBroker::DocumentBroker(ChildType type,
-                               const std::string& uri,
-                               const Poco::URI& uriPublic,
-                               const std::string& docKey,
-                               unsigned mobileAppDocId) :
-    _limitLifeSeconds(std::chrono::seconds::zero()),
-    _uriOrig(uri),
-    _type(type),
-    _uriPublic(uriPublic),
-    _docKey(docKey),
-    _docId(Util::encodeId(DocBrokerId++, 3)),
-    _documentChangedInStorage(false),
-    _isViewFileExtension(false),
-    _saveManager(std::chrono::seconds(
+DocumentBroker::DocumentBroker(ChildType type, const std::string& uri, const Poco::URI& uriPublic,
+                               const std::string& docKey, unsigned mobileAppDocId)
+    : _limitLifeSeconds(std::chrono::seconds::zero())
+    , _uriOrig(uri)
+    , _type(type)
+    , _uriPublic(uriPublic)
+    , _docKey(docKey)
+    , _docId(Util::encodeId(DocBrokerId++, 3))
+    , _documentChangedInStorage(false)
+    , _isViewFileExtension(false)
+    , _saveManager(std::chrono::seconds(
           std::getenv("COOL_NO_AUTOSAVE") != nullptr
               ? 0
-              : COOLWSD::getConfigValueNonZero<int>("per_document.autosave_duration_secs", 300))),
-    _isModified(false),
-    _cursorPosX(0),
-    _cursorPosY(0),
-    _cursorWidth(0),
-    _cursorHeight(0),
-    _poll(new DocumentBrokerPoll("doc" SHARED_DOC_THREADNAME_SUFFIX + _docId, *this)),
-    _stop(false),
-    _lockCtx(new LockContext()),
-    _tileVersion(0),
-    _debugRenderedTileCount(0),
-    _wopiDownloadDuration(0),
-    _mobileAppDocId(mobileAppDocId)
+              : COOLWSD::getConfigValueNonZero<int>("per_document.autosave_duration_secs", 300)))
+    , _isModified(false)
+    , _cursorPosX(0)
+    , _cursorPosY(0)
+    , _cursorWidth(0)
+    , _cursorHeight(0)
+    , _poll(
+          Util::make_unique<DocumentBrokerPoll>("doc" SHARED_DOC_THREADNAME_SUFFIX + _docId, *this))
+    , _stop(false)
+    , _lockCtx(Util::make_unique<LockContext>())
+    , _tileVersion(0)
+    , _debugRenderedTileCount(0)
+    , _wopiDownloadDuration(0)
+    , _mobileAppDocId(mobileAppDocId)
 {
     assert(!_docKey.empty());
     assert(!COOLWSD::ChildRoot.empty());

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -125,6 +125,8 @@ DocumentBroker::DocumentBroker(ChildType type, const std::string& uri, const Poc
                                                   "per_document.autosave_duration_secs", 300)),
                    std::chrono::milliseconds(COOLWSD::getConfigValueNonZero<int>(
                        "per_document.min_time_between_saves_ms", 500)))
+    , _storageManager(std::chrono::milliseconds(
+          COOLWSD::getConfigValueNonZero<int>("per_document.min_time_between_uploads_ms", 5000)))
     , _isModified(false)
     , _cursorPosX(0)
     , _cursorPosY(0)
@@ -1378,9 +1380,6 @@ void DocumentBroker::uploadToStorage(const std::string& sessionId, bool force)
         _storage->forceSave();
     }
 
-    static const auto minTimeBetweenUploads = std::chrono::milliseconds(
-        COOLWSD::getConfigValue<int>("per_document.min_time_between_uploads_ms", 5000));
-
     if (force || _storageManager.lastUploadSuccessful() || _storageManager.canUploadNow())
     {
         constexpr bool isRename = false;
@@ -1396,7 +1395,7 @@ void DocumentBroker::uploadToStorage(const std::string& sessionId, bool force)
     {
         LOG_TRC("Last upload had failed and it's only been "
                 << _storageManager.timeSinceLastUploadResponse()
-                << " since. Min time between uploads: " << minTimeBetweenUploads);
+                << " since. Min time between uploads: " << _storageManager.minTimeBetweenUploads());
     }
 }
 

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -119,10 +119,12 @@ DocumentBroker::DocumentBroker(ChildType type, const std::string& uri, const Poc
     , _docId(Util::encodeId(DocBrokerId++, 3))
     , _documentChangedInStorage(false)
     , _isViewFileExtension(false)
-    , _saveManager(std::chrono::seconds(
-          std::getenv("COOL_NO_AUTOSAVE") != nullptr
-              ? 0
-              : COOLWSD::getConfigValueNonZero<int>("per_document.autosave_duration_secs", 300)))
+    , _saveManager(std::chrono::seconds(std::getenv("COOL_NO_AUTOSAVE") != nullptr
+                                            ? 0
+                                            : COOLWSD::getConfigValueNonZero<int>(
+                                                  "per_document.autosave_duration_secs", 300)),
+                   std::chrono::milliseconds(COOLWSD::getConfigValueNonZero<int>(
+                       "per_document.min_time_between_saves_ms", 500)))
     , _isModified(false)
     , _cursorPosX(0)
     , _cursorPosY(0)
@@ -1379,8 +1381,7 @@ void DocumentBroker::uploadToStorage(const std::string& sessionId, bool force)
     static const auto minTimeBetweenUploads = std::chrono::milliseconds(
         COOLWSD::getConfigValue<int>("per_document.min_time_between_uploads_ms", 5000));
 
-    if (force || _storageManager.lastUploadSuccessful() ||
-        _storageManager.canUploadNow(minTimeBetweenUploads))
+    if (force || _storageManager.lastUploadSuccessful() || _storageManager.canUploadNow())
     {
         constexpr bool isRename = false;
         uploadToStorageInternal(sessionId, /*saveAsPath*/ std::string(),
@@ -2064,11 +2065,8 @@ void DocumentBroker::autoSaveAndStop(const std::string& reason)
         }
     }
 
-    static const auto minTimeBetweenSaves = std::chrono::milliseconds(
-        COOLWSD::getConfigValue<int>("per_document.min_time_between_saves_ms", 500));
-
     // Don't hammer on saving.
-    if (!canStop && _saveManager.canSaveNow(minTimeBetweenSaves))
+    if (!canStop && _saveManager.canSaveNow())
     {
         // Stop if there is nothing to save.
         const bool possiblyModified = isPossiblyModified();
@@ -2110,7 +2108,8 @@ void DocumentBroker::autoSaveAndStop(const std::string& reason)
         LOG_TRC("Too soon to issue another save on ["
                 << getDocKey() << "]: " << _saveManager.timeSinceLastSaveRequest()
                 << " since last save request and " << _saveManager.timeSinceLastSaveRequest()
-                << " since last save response. Min time between saves: " << minTimeBetweenSaves);
+                << " since last save response. Min time between saves: "
+                << _saveManager.minTimeBetweenSaves());
     }
 
     if (canStop)

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -2063,8 +2063,11 @@ void DocumentBroker::autoSaveAndStop(const std::string& reason)
         }
     }
 
+    static const auto minTimeBetweenSaves = std::chrono::milliseconds(
+        COOLWSD::getConfigValue<int>("per_document.min_time_between_saves_ms", 500));
+
     // Don't hammer on saving.
-    if (!canStop && _saveManager.canSaveNow(std::chrono::milliseconds(500)))
+    if (!canStop && _saveManager.canSaveNow(minTimeBetweenSaves))
     {
         // Stop if there is nothing to save.
         const bool possiblyModified = isPossiblyModified();
@@ -2106,7 +2109,7 @@ void DocumentBroker::autoSaveAndStop(const std::string& reason)
         LOG_TRC("Too soon to issue another save on ["
                 << getDocKey() << "]: " << _saveManager.timeSinceLastSaveRequest()
                 << " since last save request and " << _saveManager.timeSinceLastSaveRequest()
-                << " since last save response");
+                << " since last save response. Min time between saves: " << minTimeBetweenSaves);
     }
 
     if (canStop)

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1584,7 +1584,6 @@ void DocumentBroker::handleUploadToStorageResponse(const StorageBase::UploadResu
         {
             // Saved and stored; update flags.
             _saveManager.setLastModifiedTime(_uploadRequest->newFileModifiedTime());
-            _storageManager.markLastUploadTime();
 
             // Save the storage timestamp.
             _storageManager.setLastModifiedTime(_storage->getFileInfo().getLastModifiedTime());
@@ -1975,11 +1974,11 @@ bool DocumentBroker::autoSave(const bool force, const bool dontSaveIfUnmodified)
         const std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
         const std::chrono::milliseconds inactivityTimeMs
             = std::chrono::duration_cast<std::chrono::milliseconds>(now - _lastActivityTime);
-        const auto timeSinceLastSaveMs = std::chrono::duration_cast<std::chrono::milliseconds>(
-            now - _storageManager.getLastUploadTime());
-        LOG_TRC("Time since last save of docKey [" << _docKey << "] is " << timeSinceLastSaveMs
-                                                   << " and most recent activity was "
-                                                   << inactivityTimeMs << " ago.");
+        const auto timeSinceLastSave = std::min(_saveManager.timeSinceLastSaveRequest(),
+                                                _storageManager.timeSinceLastUploadResponse());
+        LOG_TRC("Time since last save of docKey [" << _docKey << "] is " << timeSinceLastSave
+                                                     << " and most recent activity was "
+                                                     << inactivityTimeMs << " ago.");
 
         bool save = false;
         // Zero or negative config value disables save.
@@ -1990,8 +1989,9 @@ bool DocumentBroker::autoSave(const bool force, const bool dontSaveIfUnmodified)
             save = true;
         }
 
+        // Save if it's been long enough since the last save and/or upload.
         if (_saveManager.isAutosaveEnabled() &&
-            timeSinceLastSaveMs >= _saveManager.autosaveInterval())
+            timeSinceLastSave >= _saveManager.autosaveInterval())
         {
             save = true;
         }

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -122,6 +122,10 @@ DocumentBroker::DocumentBroker(ChildType type,
     _docId(Util::encodeId(DocBrokerId++, 3)),
     _documentChangedInStorage(false),
     _isViewFileExtension(false),
+    _saveManager(std::chrono::seconds(
+          std::getenv("COOL_NO_AUTOSAVE") != nullptr
+              ? 0
+              : COOLWSD::getConfigValueNonZero<int>("per_document.autosave_duration_secs", 300))),
     _isModified(false),
     _cursorPosX(0),
     _cursorPosY(0),
@@ -1970,10 +1974,6 @@ bool DocumentBroker::autoSave(const bool force, const bool dontSaveIfUnmodified)
         static const std::chrono::milliseconds MaxIdleSaveDurationMs = std::chrono::seconds(
             COOLWSD::getConfigValue<int>("per_document.idlesave_duration_secs", 30));
 
-        // The configured maximum duration before saving. Zero to disable.
-        static const std::chrono::milliseconds MaxAutoSaveDurationMs = std::chrono::seconds(
-            COOLWSD::getConfigValue<int>("per_document.autosave_duration_secs", 300));
-
         const std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
         const std::chrono::milliseconds inactivityTimeMs
             = std::chrono::duration_cast<std::chrono::milliseconds>(now - _lastActivityTime);
@@ -1992,8 +1992,8 @@ bool DocumentBroker::autoSave(const bool force, const bool dontSaveIfUnmodified)
             save = true;
         }
 
-        if (MaxAutoSaveDurationMs > std::chrono::milliseconds::zero()
-            && timeSinceLastSaveMs >= MaxAutoSaveDurationMs)
+        if (_saveManager.isAutosaveEnabled() &&
+            timeSinceLastSaveMs >= _saveManager.autosaveInterval())
         {
             save = true;
         }

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1374,9 +1374,11 @@ void DocumentBroker::uploadToStorage(const std::string& sessionId, bool force)
         _storage->forceSave();
     }
 
+    static const auto minTimeBetweenUploads = std::chrono::milliseconds(
+        COOLWSD::getConfigValue<int>("per_document.min_time_between_uploads_ms", 5000));
+
     if (force || _storageManager.lastUploadSuccessful() ||
-        (_storageManager.timeSinceLastUploadRequest() > std::chrono::seconds(5) &&
-         _storageManager.timeSinceLastUploadResponse() > std::chrono::seconds(5)))
+        _storageManager.canUploadNow(minTimeBetweenUploads))
     {
         constexpr bool isRename = false;
         uploadToStorageInternal(sessionId, /*saveAsPath*/ std::string(),
@@ -1390,7 +1392,8 @@ void DocumentBroker::uploadToStorage(const std::string& sessionId, bool force)
     else
     {
         LOG_TRC("Last upload had failed and it's only been "
-                << _storageManager.timeSinceLastUploadResponse() << " since. ");
+                << _storageManager.timeSinceLastUploadResponse()
+                << " since. Min time between uploads: " << minTimeBetweenUploads);
     }
 }
 

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -1025,10 +1025,16 @@ private:
     class StorageManager final
     {
     public:
-        StorageManager()
-            : _request(std::chrono::seconds(300))
+        StorageManager(std::chrono::milliseconds minTimeBetweenUploads)
+            : _request(minTimeBetweenUploads)
             , _lastUploadTime(RequestManager::now())
         {
+            if (Log::traceEnabled())
+            {
+                std::ostringstream oss;
+                dumpState(oss, ", ");
+                LOG_TRC("Created StorageManager: " << oss.str());
+            }
         }
 
         /// Marks the last time we attempted to upload, regardless of outcome, to now.
@@ -1090,6 +1096,12 @@ private:
             return _request.lastRequestDuration();
         }
 
+        /// Returns the minimum time between uploads.
+        std::chrono::milliseconds minTimeBetweenUploads() const
+        {
+            return _request.minTimeBetweenRequests();
+        }
+
         /// True if we aren't uploading and the minimum time since last upload has elapsed.
         bool canUploadNow() const { return _request.canRequestNow(); }
 
@@ -1103,6 +1115,7 @@ private:
             os << indent << "last modified time (on server): " << _lastModifiedTime;
             os << indent << "since last upload request: " << timeSinceLastUploadRequest();
             os << indent << "since last upload response: " << timeSinceLastUploadResponse();
+            os << indent << "min time between uploads: " << minTimeBetweenUploads();
             os << indent
                << "file last modified: " << Util::getTimeForLog(now, _lastUploadedFileModifiedTime);
         }

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -699,9 +699,10 @@ private:
 
         /// How much time passed since the last request,
         /// regardless of whether we got a response or not.
-        const std::chrono::milliseconds timeSinceLastRequest() const
+        const std::chrono::milliseconds timeSinceLastRequest(
+            const std::chrono::steady_clock::time_point now = RequestManager::now()) const
         {
-            return std::chrono::duration_cast<std::chrono::milliseconds>(now() - _lastRequestTime);
+            return std::chrono::duration_cast<std::chrono::milliseconds>(now - _lastRequestTime);
         }
 
         /// True iff there is an active request and it has timed out.
@@ -727,15 +728,26 @@ private:
 
         /// How much time passed since the last response,
         /// regardless of whether there is a newer request or not.
-        const std::chrono::milliseconds timeSinceLastResponse() const
+        const std::chrono::milliseconds timeSinceLastResponse(
+            const std::chrono::steady_clock::time_point now = RequestManager::now()) const
         {
-            return std::chrono::duration_cast<std::chrono::milliseconds>(now() - _lastResponseTime);
+            return std::chrono::duration_cast<std::chrono::milliseconds>(now - _lastResponseTime);
         }
 
 
         /// Returns true iff there is an active request in progress.
         bool isActive() const { return _lastResponseTime < _lastRequestTime; }
 
+        /// Checks whether or not we can issue a new request now.
+        /// Returns true iff there is no active request and sufficient
+        /// time has elapsed since the last request, including that
+        /// more time than the last request's duration has passe.
+        bool canRequestNow(std::chrono::milliseconds minTime) const
+        {
+            const auto now = RequestManager::now();
+            return !isActive() && std::min(timeSinceLastRequest(now), timeSinceLastResponse(now)) >=
+                                      std::max(minTime, _lastRequestDuration);
+        }
 
         /// Sets the last request's result, either to success or failure.
         /// And marks the last response time.
@@ -905,12 +917,7 @@ private:
         /// True if we aren't saving and the minimum time since last save has elapsed.
         bool canSaveNow(std::chrono::milliseconds minTime) const
         {
-            // Can't save if save is in progress, or when it the time elapsed
-            // since the last response, or request, hasn't been that long, or
-            // if it hasn't been longer than the time the last save took.
-            return !isSaving() &&
-                   std::min(_request.timeSinceLastRequest(), _request.timeSinceLastResponse()) >=
-                       std::max(minTime, lastSaveDuration());
+            return _request.canRequestNow(minTime);
         }
 
         void dumpState(std::ostream& os, const std::string& indent = "\n  ")
@@ -1021,6 +1028,9 @@ private:
             _request.setLastRequestResult(success);
         }
 
+        /// True iff an upload is in progress (requested but not completed).
+        bool isUploading() const { return _request.isActive(); }
+
         /// The duration elapsed since we sent the last upload request to storage.
         std::chrono::milliseconds timeSinceLastUploadRequest() const
         {
@@ -1054,9 +1064,23 @@ private:
         /// Returns the last modified time of the document.
         const std::string& getLastModifiedTime() const { return _lastModifiedTime; }
 
+        /// Returns how long the last upload took.
+        std::chrono::milliseconds lastUploadDuration() const
+        {
+            return _request.lastRequestDuration();
+        }
+
+        /// True if we aren't uploading and the minimum time since last upload has elapsed.
+        bool canUploadNow(std::chrono::milliseconds minTime) const
+        {
+            return _request.canRequestNow(minTime);
+        }
+
+
         void dumpState(std::ostream& os, const std::string& indent = "\n  ")
         {
             const auto now = std::chrono::steady_clock::now();
+            os << indent << "isUploading now: " << std::boolalpha << isUploading();
             os << indent << "last upload time: " << Util::getTimeForLog(now, getLastUploadTime());
             os << indent << "last upload was successful: " << lastUploadSuccessful();
             os << indent << "upload failure count: " << uploadFailureCount();

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -802,15 +802,18 @@ private:
     class SaveManager final
     {
     public:
-        SaveManager()
-            : _autosaveInterval(std::chrono::seconds(30))
+        SaveManager(std::chrono::milliseconds autosaveInterval)
+            : _autosaveInterval(autosaveInterval)
             , _lastAutosaveCheckTime(RequestManager::now())
-            , _isAutosaveEnabled(std::getenv("COOL_NO_AUTOSAVE") == nullptr)
         {
+            LOG_TRC("Created SaveManager with auto-save interval of " << _autosaveInterval);
         }
 
-        /// Return true iff auto save is enabled.
-        bool isAutosaveEnabled() const { return _isAutosaveEnabled; }
+        /// Returns true iff auto save is enabled.
+        bool isAutosaveEnabled() const { return _autosaveInterval > std::chrono::seconds::zero(); }
+
+        /// Returns the autosave interval.
+        std::chrono::milliseconds autosaveInterval() const { return _autosaveInterval; }
 
         /// Returns true if we should issue an auto-save.
         bool needAutosaveCheck() const
@@ -924,7 +927,7 @@ private:
         {
             const auto now = std::chrono::steady_clock::now();
             os << indent << "isSaving now: " << std::boolalpha << isSaving();
-            os << indent << "auto-save enabled: " << std::boolalpha << _isAutosaveEnabled;
+            os << indent << "auto-save enabled: " << std::boolalpha << isAutosaveEnabled();
             os << indent << "auto-save interval: " << _autosaveInterval;
             os << indent
                << "last auto-save check time: " << Util::getTimeForLog(now, _lastAutosaveCheckTime);
@@ -950,14 +953,11 @@ private:
         /// The document's last-modified time.
         std::chrono::system_clock::time_point _lastModifiedTime;
 
-        /// The number of seconds between autosave checks for modification.
-        const std::chrono::seconds _autosaveInterval;
+        /// The number of milliseconds between autosave checks for modification.
+        const std::chrono::milliseconds _autosaveInterval;
 
         /// The last autosave check time.
         std::chrono::steady_clock::time_point _lastAutosaveCheckTime;
-
-        /// Whether auto-saving is enabled at all or not.
-        const bool _isAutosaveEnabled;
     };
 
     /// Represents an upload request.

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -1027,7 +1027,6 @@ private:
     public:
         StorageManager(std::chrono::milliseconds minTimeBetweenUploads)
             : _request(minTimeBetweenUploads)
-            , _lastUploadTime(RequestManager::now())
         {
             if (Log::traceEnabled())
             {
@@ -1036,12 +1035,6 @@ private:
                 LOG_TRC("Created StorageManager: " << oss.str());
             }
         }
-
-        /// Marks the last time we attempted to upload, regardless of outcome, to now.
-        void markLastUploadTime() { _lastUploadTime = RequestManager::now(); }
-
-        // Gets the last time we attempted to upload.
-        std::chrono::steady_clock::time_point getLastUploadTime() const { return _lastUploadTime; }
 
         /// Returns whether the last upload was successful or not.
         bool lastUploadSuccessful() const { return _request.lastRequestSuccessful(); }
@@ -1109,12 +1102,12 @@ private:
         {
             const auto now = std::chrono::steady_clock::now();
             os << indent << "isUploading now: " << std::boolalpha << isUploading();
-            os << indent << "last upload time: " << Util::getTimeForLog(now, getLastUploadTime());
             os << indent << "last upload was successful: " << lastUploadSuccessful();
             os << indent << "upload failure count: " << uploadFailureCount();
             os << indent << "last modified time (on server): " << _lastModifiedTime;
             os << indent << "since last upload request: " << timeSinceLastUploadRequest();
             os << indent << "since last upload response: " << timeSinceLastUploadResponse();
+            os << indent << "last upload duration: " << lastUploadDuration();
             os << indent << "min time between uploads: " << minTimeBetweenUploads();
             os << indent
                << "file last modified: " << Util::getTimeForLog(now, _lastUploadedFileModifiedTime);
@@ -1123,15 +1116,6 @@ private:
     private:
         /// Request tracking logic.
         RequestManager _request;
-
-        /// The last time we tried uploading, regardless of whether the
-        /// document was modified and a newer version saved
-        /// and uploaded or not. In effect, this tracks the time we
-        /// synchronized with Storage (i.e. the last time we either uploaded
-        /// or had nothing new to upload). It is redundant as it is
-        /// equivalent to the larger of 'Last Save Response Time' and
-        /// 'Last Storage Response Time', and should be removed.
-        std::chrono::steady_clock::time_point _lastUploadTime;
 
         /// The modified-timestamp of the local file on disk we uploaded last.
         std::chrono::system_clock::time_point _lastUploadedFileModifiedTime;

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -686,6 +686,7 @@ private:
         RequestManager()
             : _lastRequestTime(now())
             , _lastResponseTime(now())
+            , _lastRequestDuration(0)
             , _lastRequestFailureCount(0)
         {
         }
@@ -711,10 +712,18 @@ private:
 
 
         /// Sets the time the last response was received to now.
-        void markLastResponseTime() { _lastResponseTime = now(); }
+        void markLastResponseTime()
+        {
+            _lastResponseTime = now();
+            _lastRequestDuration = std::chrono::duration_cast<std::chrono::milliseconds>(
+                _lastResponseTime - _lastRequestTime);
+        }
 
         /// Returns the time the last response was received.
         std::chrono::steady_clock::time_point lastResponseTime() const { return _lastResponseTime; }
+
+        /// Returns the duration of the last request.
+        std::chrono::milliseconds lastRequestDuration() const { return _lastRequestDuration; }
 
         /// How much time passed since the last response,
         /// regardless of whether there is a newer request or not.
@@ -763,7 +772,10 @@ private:
         /// The last time we received a response.
         std::chrono::steady_clock::time_point _lastResponseTime;
 
-        /// Counts the number of previous request that failed.
+        /// The time we spent in the last request.
+        std::chrono::milliseconds _lastRequestDuration;
+
+        /// Counts the number of previous requests that failed.
         /// Note that this is interpretted by the request in question.
         /// For example, Core's Save operation turns 'false' for success
         /// when the file is unmodified, but that is still a successful result.
@@ -884,11 +896,21 @@ private:
             return _request.timeSinceLastResponse();
         }
 
+        /// Returns how long the last save took.
+        std::chrono::milliseconds lastSaveDuration() const
+        {
+            return _request.lastRequestDuration();
+        }
+
         /// True if we aren't saving and the minimum time since last save has elapsed.
         bool canSaveNow(std::chrono::milliseconds minTime) const
         {
-            return !isSaving() && std::min(_request.timeSinceLastRequest(),
-                                           _request.timeSinceLastResponse()) >= minTime;
+            // Can't save if save is in progress, or when it the time elapsed
+            // since the last response, or request, hasn't been that long, or
+            // if it hasn't been longer than the time the last save took.
+            return !isSaving() &&
+                   std::min(_request.timeSinceLastRequest(), _request.timeSinceLastResponse()) >=
+                       std::max(minTime, lastSaveDuration());
         }
 
         void dumpState(std::ostream& os, const std::string& indent = "\n  ")
@@ -905,9 +927,7 @@ private:
                << "last save request: " << Util::getTimeForLog(now, lastSaveRequestTime());
             os << indent
                << "last save response: " << Util::getTimeForLog(now, lastSaveResponseTime());
-
-            os << indent << "since last save request: " << timeSinceLastSaveRequest();
-            os << indent << "since last save response: " << timeSinceLastSaveResponse();
+            os << indent << "last save duration: " << lastSaveDuration();
 
             os << indent
                << "file last modified time: " << Util::getTimeForLog(now, _lastModifiedTime);


### PR DESCRIPTION
Adds support to configure the minimum time between save and upload (in case of retrying failed attempts).

- wsd: add min_time_between_save_ms config
- wsd: add min_time_between_upload_ms config
- wsd: config: merge auto- and idle-save comment and make uint
- wsd: move the autosave interval into SaveManager
- wsd: cosmetic and logging 
- wsd: move minTimeBetweenSaves into SaveManager 
- wsd: move minTimeBetweenUploads into StorageManager 
- wsd: remove lastUploadTime as it is redundant
