### PR TITLE
Add tooltip to close document button

### DIFF
--- a/browser/src/control/Control.Toolbar.js
+++ b/browser/src/control/Control.Toolbar.js
@@ -1160,6 +1160,7 @@ function setupToolbar(e) {
 
 	if (map.options.wopi && L.Params.closeButtonEnabled && !window.mode.isMobile()) {
 		$('#closebuttonwrapper').css('display', 'block');
+		$('#closebuttonwrapper').prop('title', _('Close document'));
 	} else if (!L.Params.closeButtonEnabled) {
 		$('#closebuttonwrapper').hide();
 	} else if (L.Params.closeButtonEnabled && !window.mode.isMobile()) {


### PR DESCRIPTION
Normally these kind of button wouldn't need a tooltip but:
1. Doesn't hurt to add it
2. It helps the user with understanding what that btn does:
  - The button doesn't remove the current opened document
  - The button doesn't save and close
  - The button closes the document

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I45e63c4c7f42d314743702e6ff50b777527c4367
