### PR TITLE
browser: add source maps to bundle.js

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -428,7 +428,7 @@ define bundle_all
 			$(srcdir)/bundle.js.m4 > $(INTERMEDIATE_DIR)/bundle.js
 		@$(NODE) node_modules/uglify-js/bin/uglifyjs \
 			$(INTERMEDIATE_DIR)/bundle.js \
-			--output $@)
+			--source-map --output $@)
 endef
 
 define prereq_all


### PR DESCRIPTION
In order to find the javascript exception
bundle.js:1:X

Change-Id: Idaf596d5b64519ba1e54a4da7f42dccc382d0cc7
Signed-off-by: Henry Castro <hcastro@collabora.com>
