### PR TITLE
Sidebar scrollbar-width: thin

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -199,7 +199,7 @@ nav.spreadsheet-color-indicator ~ #sidebar-dock-wrapper {
 	overflow-x: hidden;
 	overflow-y: auto;
 	z-index: 1200;
-	scrollbar-width: auto;
+	scrollbar-width: thin;
 	scrollbar-color: var(--color-border) transparent;
 }
 


### PR DESCRIPTION
The sidebar isn't a main navigation area,
so the width of the scrollbar should be thin.

In addition the width of the sidebar is "limited"
so an large scrollbar didn't help that much

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I8a8ab9ca7866004c8e581c5bbe88125830e2ba7b