### PR TITLE
wsd: forced exit after --help and --version-hash

### DIFF
--- a/wsd/LOOLWSD.cpp
+++ b/wsd/LOOLWSD.cpp
@@ -1743,14 +1743,14 @@ void LOOLWSD::handleOption(const std::string& optionName,
     if (optionName == "help")
     {
         displayHelp();
-        std::exit(EX_OK);
+        Util::forcedExit(EX_OK);
     }
     else if (optionName == "version-hash")
     {
         std::string version, hash;
         Util::getVersionInfo(version, hash);
         std::cout << hash << std::endl;
-        std::exit(EX_OK);
+        Util::forcedExit(EX_OK);
     }
     else if (optionName == "version")
         ; // ignore for compatibility


### PR DESCRIPTION
This extends 231fae4ebd990cb344143759cbdfa19c4f30d4f2
to cover the --help and --version-hash command
line options.

Fixes #4662.