### PR TITLE
private/pedro/fix T34772

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -475,11 +475,12 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	background: url('images/jquery-ui-lightness/ui-icons_222222_256x240.png') no-repeat transparent;
 	background-position: -67px -18px;
 	display: inline-block;
-	position: relative;
+	position: absolute;
 	width: 11px;
 	height: 11px;
 	cursor: pointer;
 	pointer-events: none;
+	margin-block-start: 8px;
 	margin-inline-start: -16px;
 }
 

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -422,6 +422,28 @@ input[type='checkbox']:checked.autofilter, .jsdialog input[type='checkbox']:chec
 .jsdialog input[type='radio'][disabled='disabled'] ~ label {
 	color: var(--color-text-lighter);
 }
+/* spinfield */
+
+.spinfieldcontainer input:hover {
+	border: 1px solid var(--color-border-darker);
+	color: var(--color-text-darker);
+	background-color: var(--color-background-lighter);
+}
+
+.spinfield {
+	padding: 4px 0 4px 4px;
+	height: 28px;
+	box-sizing: border-box;
+	margin-right: 1px;
+}
+
+.spinfieldunit {
+	font-size: var(--default-font-size);
+	color: var(--color-text-dark);
+	margin: 5px;
+	position: absolute;
+	margin-inline-start: calc(-40px);
+}
 /* spinfield (number) */
 input[type='number'] {
 	padding-top: 0 !important;

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -471,7 +471,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	min-width: 100px;
 	height: 28px;
 	line-height: normal;
-	font-size: calc(var(--default-font-size)*1.2);
+	font-size: var(--default-font-size);
 	font-family: var(--jquery-ui-font);
 	border: 1px solid #CCC;
 	border-radius: var(--border-radius);

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -464,6 +464,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 }
 /* listbox */
 .jsdialog.ui-listbox {
+	box-sizing: border-box;
 	-webkit-appearance: none;
 	-moz-appearance: none;
 	appearance: none;
@@ -860,6 +861,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 
 /* menu button */
 .jsdialog.menubutton {
+	box-sizing: border-box;
 	line-height: normal;
 	font-size: calc(var(--default-font-size)*1.2);
 	font-family: var(--jquery-ui-font);

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -475,9 +475,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	font-family: var(--jquery-ui-font);
 	border: 1px solid #CCC;
 	border-radius: var(--border-radius);
-	padding-right: 2em;
-	padding-left: 0.4em;
-	margin: 2px 0px;
+	padding: 0 4px;
 	background-color: #F1F1F1;
 }
 

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -469,7 +469,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	-moz-appearance: none;
 	appearance: none;
 	min-width: 100px;
-	height: 32px;
+	height: 28px;
 	line-height: normal;
 	font-size: calc(var(--default-font-size)*1.2);
 	font-family: var(--jquery-ui-font);

--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -42,21 +42,10 @@
 	max-width: 121px;
 }
 
-.sidebar.ui-listbox {
-	font-size: var(--default-font-size);
-	height: 28px;
-	box-sizing: border-box;
-	padding: 0 0px 0 4px;
-	min-width: auto;
-}
-.sidebar.jsdialog.menubutton {
-	padding: 4px 10px;
-}
 .sidebar.jsdialog.ui-listbox,
 .sidebar.jsdialog.menubutton {
 	min-width: 121px;
 	max-width: 121px;
-	box-sizing: border-box;
 }
 
 .menubutton.sidebar span {

--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -40,23 +40,6 @@
 
 .sidebar.spinfield {
 	max-width: 121px;
-	padding: 4px 0 4px 4px;
-	height: 28px;
-	box-sizing: border-box;
-	margin-right: 1px;
-}
-.sidebar .spinfieldcontainer input:hover {
-	border: 1px solid var(--color-border-darker);
-	color: var(--color-text-darker);
-	background-color: var(--color-background-lighter);
-}
-
-.spinfieldunit {
-	font-size: var(--default-font-size);
-	color: var(--color-text-dark);
-	margin: 5px;
-	position: absolute;
-	margin-inline-start: calc(-40px);
 }
 
 .sidebar.ui-listbox {

--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -55,7 +55,7 @@
 	font-size: var(--default-font-size);
 	color: var(--color-text-dark);
 	margin: 5px;
-	position: relative;
+	position: absolute;
 	margin-inline-start: calc(-40px);
 }
 

--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -401,9 +401,7 @@ button#button2.ui-pushbutton.jsdialog.sidebar {
 }
 
 .sidebar #horizontalpos,
-.sidebar #verticalpos,
-.sidebar #selectwidth,
-.sidebar #selectheight {
+.sidebar #verticalpos {
 	position: relative;
 	margin-inline-end: 24px;
 }
@@ -435,10 +433,7 @@ button#button2.ui-pushbutton.jsdialog.sidebar {
 .sidebar #leftindent,
 .sidebar #LB_GLOW_TRANSPARENCY,
 .sidebar #LB_DISTANCE,
-.sidebar #LB_SHADOW_BLUR,
-.sidebar #setbrightness,
-.sidebar #setcontrast,
-.sidebar #setgraphtransparency {
+.sidebar #LB_SHADOW_BLUR {
 	position: relative;
 	right: 18px;
 }


### PR DESCRIPTION
commit da1927a0ebd6d797acf37547c2128b7ae1d59b26 (HEAD -> private/pedro/fix-T34772, origin/private/pedro/fix-T34772)

Listbox: remove unnecessary margin and fix padding

The additional margin was affecting the surrounding elements in some
browsers in the sidebar

Better to not call padding-right or padding-left specifically:
- Better to use shorthand and make sure how the final padding will be
- Better for RTL

----

commit a3d2ac5e9176734005e59e30c09d2677e2aad669

Listbox: do not multiple font-size

use the same font-size for listox no matter where it's placeholder
- Multiplying would make it look too big in some places

----

commit 15fac252a0c6d26a1f6a5c8a3bc41ce6e2956337

Listbox: reduce height

with refactoring from 2da8de38df1660b205392391ebada7759ee8e2d6
and with the code now in onw place we can now use the 28px height that
was used only in the sidebar to have the same visual component be that
on a dialog or on the sidebar
- Reduce from 32px to 28px (the opposite would make the component too
big in the sidebar)

----

commit be1d7915c3564f0844400d79122f0096d7a04151

Refactoring and generalize listbox, menubutton: share more CSS

----

commit 438b3152868d35e5e0b53167a2300cd319dbe18b

Refactoring and generalize spinfield: share more CSS

Avoid to place rules within jssidebar.css that should be global
(it should affect any jsdialog class) and let jssidebar-only exceptions
in jssidebar file

----

commit 7cb6269df8f4abff928b014031e2e058875b5b0b

Fix sidebar select (dropdown) alignments

When using position relative the elements will still occupy and affect
space around. This was flagrant when using chromium.

https://archive.org/download/t-34772-writer-selected-img/T34772-relative-shouldbe-absolute.png
as you can see dropdown with arrow are being dragged outside

Also use margin-block-start to add vertical start margin (e.g. top) to
element depending on the element's writing mode, directionality,
and text orientation.

----

commit f340e3ffb191fa11bfc658ad2c68d25eb1537272

Fix sidebar spinner units alignments

When using position relative the elements will still occupy and affect
space around. This was flagrant when using chromium.

https://archive.org/download/t-34772-writer-selected-img/T34772-relative-shouldbe-absolute.png
as you can see the spinner with units are being dragged outside of the
screen

----

commit be833774ba256a4846daf8ae4298543558acd7b4

Fix sidebar alignments when image is selected

Remove additional margins and right positions that were affecting FF
https://archive.org/download/t-34772-writer-selected-img/T34772-writer-selected-img.png
