### PR TITLE
Prevent errors on document load

### DIFF
--- a/browser/src/control/Control.MobileTopBar.js
+++ b/browser/src/control/Control.MobileTopBar.js
@@ -126,7 +126,9 @@ L.Control.MobileTopBar = L.Control.extend({
 		else if (id === 'comment_wizard') {
 			if (window.commentWizard) {
 				window.commentWizard = false;
-				app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).removeHighlighters();
+				var section = app.sectionContainer.getSectionWithName(L.CSections.CommentList.name);
+				if (section)
+					section.removeHighlighters();
 				this.map.fire('closemobilewizard');
 				toolbar.uncheck(id);
 			}

--- a/browser/src/control/Control.MobileWizard.js
+++ b/browser/src/control/Control.MobileWizard.js
@@ -145,7 +145,9 @@ L.Control.MobileWizard = L.Control.extend({
 		}
 
 		if (window.commentWizard === true && app.sectionContainer) {
-			app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).removeHighlighters();
+			var section = app.sectionContainer.getSectionWithName(L.CSections.CommentList.name);
+			if (section)
+				section.removeHighlighters();
 		}
 
 		$('#mobile-wizard').hide();
@@ -340,7 +342,9 @@ L.Control.MobileWizard = L.Control.extend({
 				}
 			}
 			if (window.commentWizard === true) {
-				app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).removeHighlighters();
+				var section = app.sectionContainer.getSectionWithName(L.CSections.CommentList.name);
+				if (section)
+					section.removeHighlighters();
 			}
 		}
 	},

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -576,7 +576,6 @@ L.Control.UIManager = L.Control.extend({
 		}
 
 		var enableNotebookbar = this.shouldUseNotebookbarMode();
-		console.error(enableNotebookbar);
 		if (enableNotebookbar && !window.mode.isMobile()) {
 			if (e.perm === 'edit') {
 				if (this.map.menubar) {

--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -18,7 +18,11 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 	},
 
 	newAnnotation: function (comment) {
-		var commentList = app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).sectionProperties.commentList;
+		var commentListSection = app.sectionContainer.getSectionWithName(L.CSections.CommentList.name);
+		if (!commentListSection)
+			return;
+
+		var commentList = commentListSection.sectionProperties.commentList;
 		var comment = null;
 
 		for (var i = 0; i < commentList.length; i++) {
@@ -39,10 +43,10 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 				dateTime: new Date().toDateString(),
 				author: this._map.getViewName(this._viewId)
 			};
-			comment = app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).add(newComment);
+			comment = commentListSection.add(newComment);
 			comment.show();
 		}
-		app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).modify(comment);
+		commentListSection.modify(comment);
 		comment.focus();
 	},
 
@@ -219,7 +223,9 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 			this._replayPrintTwipsMsgAllViews('cellviewcursor');
 			this._replayPrintTwipsMsgAllViews('textviewselection');
 			// Hide previous tab's shown comment (if any).
-			app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).hideAllComments();
+			var section = app.sectionContainer.getSectionWithName(L.CSections.CommentList.name);
+			if (section)
+				section.hideAllComments();
 		}
 	},
 
@@ -553,14 +559,19 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 				columnGroupSection.anchor = ['top', [L.CSections.CornerGroup.name, '-left', 'right']];
 			}
 
-			cornerHeaderSection.anchor = [[L.CSections.ColumnGroup.name, 'bottom', 'top'], [L.CSections.RowGroup.name, '-left', 'right']];
+			if (cornerHeaderSection)
+				cornerHeaderSection.anchor = [[L.CSections.ColumnGroup.name, 'bottom', 'top'], [L.CSections.RowGroup.name, '-left', 'right']];
 
-			rowHeaderSection.anchor = [[L.CSections.CornerHeader.name, 'bottom', 'top'], [L.CSections.RowGroup.name, '-left', 'right']];
+			if (rowHeaderSection)
+				rowHeaderSection.anchor = [[L.CSections.CornerHeader.name, 'bottom', 'top'], [L.CSections.RowGroup.name, '-left', 'right']];
 
-			columnHeaderSection.anchor = [[L.CSections.ColumnGroup.name, 'bottom', 'top'], [L.CSections.CornerHeader.name, '-left', 'right']];
-			columnHeaderSection.expand = ['left'];
+			if (columnHeaderSection) {
+				columnHeaderSection.anchor = [[L.CSections.ColumnGroup.name, 'bottom', 'top'], [L.CSections.CornerHeader.name, '-left', 'right']];
+				columnHeaderSection.expand = ['left'];
+			}
 
-			tilesSection.anchor = [[L.CSections.ColumnHeader.name, 'bottom', 'top'], [L.CSections.RowHeader.name, '-left', 'right']];
+			if (tilesSection)
+				tilesSection.anchor = [[L.CSections.ColumnHeader.name, 'bottom', 'top'], [L.CSections.RowHeader.name, '-left', 'right']];
 
 			this._layoutIsRTL = true;
 
@@ -592,14 +603,19 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 				columnGroupSection.anchor = ['top', [L.CSections.CornerGroup.name, 'right', 'left']];
 			}
 
-			cornerHeaderSection.anchor = [[L.CSections.ColumnGroup.name, 'bottom', 'top'], [L.CSections.RowGroup.name, 'right', 'left']];
+			if (cornerHeaderSection)
+				cornerHeaderSection.anchor = [[L.CSections.ColumnGroup.name, 'bottom', 'top'], [L.CSections.RowGroup.name, 'right', 'left']];
 
-			rowHeaderSection.anchor = [[L.CSections.CornerHeader.name, 'bottom', 'top'], [L.CSections.RowGroup.name, 'right', 'left']];
+			if (rowHeaderSection)
+				rowHeaderSection.anchor = [[L.CSections.CornerHeader.name, 'bottom', 'top'], [L.CSections.RowGroup.name, 'right', 'left']];
 
-			columnHeaderSection.anchor = [[L.CSections.ColumnGroup.name, 'bottom', 'top'], [L.CSections.CornerHeader.name, 'right', 'left']];
-			columnHeaderSection.expand = ['right'];
+			if (columnHeaderSection) {
+				columnHeaderSection.anchor = [[L.CSections.ColumnGroup.name, 'bottom', 'top'], [L.CSections.CornerHeader.name, 'right', 'left']];
+				columnHeaderSection.expand = ['right'];
+			}
 
-			tilesSection.anchor = [[L.CSections.ColumnHeader.name, 'bottom', 'top'], [L.CSections.RowHeader.name, 'right', 'left']];
+			if (tilesSection)
+				tilesSection.anchor = [[L.CSections.ColumnHeader.name, 'bottom', 'top'], [L.CSections.RowHeader.name, 'right', 'left']];
 
 			sectionContainer.reNewAllSections(true);
 
@@ -801,6 +817,7 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 			return;
 		}
 
+		var section = app.sectionContainer.getSectionWithName(L.CSections.CommentList.name);
 		var comment;
 		if (values.commandName === '.uno:ViewRowColumnHeaders') {
 			this._updateHeadersGridLines(values);
@@ -809,10 +826,11 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 			this._handleSheetGeometryDataMsg(values);
 
 		} else if (values.comments) {
-			app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).clearList();
-			app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).importComments(values.comments);
+			if (section) {
+				section.clearList();
+				section.importComments(values.comments);
+			}
 		} else if (values.commentsPos) {
-			var section = app.sectionContainer.getSectionWithName(L.CSections.CommentList.name);
 			// invalidate all comments
 			section.sectionProperties.commentList.forEach(function (comment) {
 				comment.valid = false;

--- a/browser/src/layer/tile/CanvasSectionContainer.ts
+++ b/browser/src/layer/tile/CanvasSectionContainer.ts
@@ -1529,6 +1529,8 @@ class CanvasSectionContainer {
 				var targetSection: CanvasSectionObject = null;
 				var targetEdge: string = null;
 				for (var i: number = 0; i < count - 1; i++) {
+					if (!this.doesSectionExist(section.anchor[index][i]))
+						continue;
 					targetSection = this.getSectionWithName(section.anchor[index][i]);
 					if (targetSection) {
 						targetEdge = section.anchor[index][i + 1];

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1673,15 +1673,21 @@ L.CanvasTileLayer = L.Layer.extend({
 				cellPos = this._convertToTileTwipsSheetArea(cellPos);
 				obj.comment.cellPos = cellPos.toCoreString();
 			}
-			app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).onACKComment(obj);
+			var commentSection = app.sectionContainer.getSectionWithName(L.CSections.CommentList.name);
+			if (commentSection)
+				commentSection.onACKComment(obj);
 		}
 		else if (textMsg.startsWith('redlinetablemodified:')) {
 			obj = JSON.parse(textMsg.substring('redlinetablemodified:'.length + 1));
-			app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).onACKComment(obj);
+			commentSection = app.sectionContainer.getSectionWithName(L.CSections.CommentList.name);
+			if (commentSection)
+				commentSection.onACKComment(obj);
 		}
 		else if (textMsg.startsWith('redlinetablechanged:')) {
 			obj = JSON.parse(textMsg.substring('redlinetablechanged:'.length + 1));
-			app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).onACKComment(obj);
+			commentSection = app.sectionContainer.getSectionWithName(L.CSections.CommentList.name);
+			if (commentSection)
+				commentSection.onACKComment(obj);
 		}
 		else if (textMsg.startsWith('documentbackgroundcolor:')) {
 			if (this.isCalc()) {
@@ -3504,7 +3510,9 @@ L.CanvasTileLayer = L.Layer.extend({
 			We want to keep the cursor position at the same point relative to screen.
 			*/
 			var y = this._cursorCorePixels.min.y - this._cursorPreviousPositionCorePixels.min.y;
-			this._painter._sectionContainer.getSectionWithName(L.CSections.Scroll.name).scrollVerticalWithOffset(y);
+			var section = this._painter._sectionContainer.getSectionWithName(L.CSections.Scroll.name);
+			if (section)
+				section.scrollVerticalWithOffset(y);
 		}
 
 		this._updateCursorAndOverlay();
@@ -4941,7 +4949,9 @@ L.CanvasTileLayer = L.Layer.extend({
 				menuStructure['customTitle'] = customTitleBar;
 		}
 
-		app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).createCommentStructure(menuStructure, onlyThread);
+		var section = app.sectionContainer.getSectionWithName(L.CSections.CommentList.name);
+		if (section)
+			section.createCommentStructure(menuStructure, onlyThread);
 
 		if (menuStructure.children.length === 0) {
 			var noComments = {
@@ -5153,10 +5163,10 @@ L.CanvasTileLayer = L.Layer.extend({
 			var widthIncreased = oldSize.x < newSize.x;
 
 			if (this._docType === 'spreadsheet') {
-				if (this._painter._sectionContainer.doesSectionExist(L.CSections.RowHeader.name)) {
+				if (this._painter._sectionContainer.doesSectionExist(L.CSections.RowHeader.name))
 					this._painter._sectionContainer.getSectionWithName(L.CSections.RowHeader.name)._updateCanvas();
+				if (this._painter._sectionContainer.doesSectionExist(L.CSections.ColumnHeader.name))
 					this._painter._sectionContainer.getSectionWithName(L.CSections.ColumnHeader.name)._updateCanvas();
-				}
 			}
 
 			if (oldSize.x !== newSize.x || oldSize.y !== newSize.y) {

--- a/browser/src/layer/tile/CommentListSection.ts
+++ b/browser/src/layer/tile/CommentListSection.ts
@@ -20,7 +20,9 @@ L.Map.include({
 	showResolvedComments: function(on: any) {
 		var unoCommand = '.uno:ShowResolvedAnnotations';
 		this.sendUnoCommand(unoCommand);
-		app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).setViewResolved(on);
+		var section = app.sectionContainer.getSectionWithName(L.CSections.CommentList.name);
+		if (section)
+			section.setViewResolved(on);
 		this.uiManager.setSavedState('ShowResolved', on ? true : false);
 	}
 });

--- a/browser/src/layer/tile/ImpressTileLayer.js
+++ b/browser/src/layer/tile/ImpressTileLayer.js
@@ -75,8 +75,11 @@ L.ImpressTileLayer = L.CanvasTileLayer.extend({
 		comment.rectangle = [docTopLeft[0], docTopLeft[1], 566, 566];
 
 		comment.parthash = this._partHashes[this._selectedPart];
-		var annotation = app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).add(comment);
-		app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).modify(annotation);
+		var commentListSection = app.sectionContainer.getSectionWithName(L.CSections.CommentList.name);
+		if (commentListSection) {
+			var annotation = commentListSection.add(comment);
+			commentListSection.modify(annotation);
+		}
 	},
 
 	beforeAdd: function (map) {
@@ -136,7 +139,9 @@ L.ImpressTileLayer = L.CanvasTileLayer.extend({
 		if (isAnyVexDialogActive()) // Need this check else vex loses focus
 			return;
 
-		app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).onPartChange();
+		var section = app.sectionContainer.getSectionWithName(L.CSections.CommentList.name);
+		if (section)
+			section.onPartChange();
 	},
 
 	onUpdatePermission: function (e) {
@@ -162,8 +167,11 @@ L.ImpressTileLayer = L.CanvasTileLayer.extend({
 		}
 
 		if (values.comments) {
-			app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).clearList();
-			app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).importComments(values.comments);
+			var commentListSection = app.sectionContainer.getSectionWithName(L.CSections.CommentList.name);
+			if (commentListSection) {
+				commentListSection.clearList();
+				commentListSection.importComments(values.comments);
+			}
 		} else {
 			L.CanvasTileLayer.prototype._onCommandValuesMsg.call(this, textMsg);
 		}

--- a/browser/src/layer/tile/WriterTileLayer.js
+++ b/browser/src/layer/tile/WriterTileLayer.js
@@ -16,8 +16,11 @@ L.WriterTileLayer = L.CanvasTileLayer.extend({
 			comment.anchorPos = [temp.x, temp.y];
 		}
 
-		var annotation = app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).add(comment);
-		app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).modify(annotation);
+		var commentListSection = app.sectionContainer.getSectionWithName(L.CSections.CommentList.name);
+		if (commentListSection) {
+			var annotation = commentListSection.add(comment);
+			commentListSection.modify(annotation);
+		}
 	},
 
 	beforeAdd: function (map) {
@@ -35,15 +38,19 @@ L.WriterTileLayer = L.CanvasTileLayer.extend({
 			return;
 		}
 
+		var commentListSection = app.sectionContainer.getSectionWithName(L.CSections.CommentList.name);
+
 		if (values.comments) {
 			values.comments.forEach(function(comment) {
 				comment.id = comment.id.toString();
 				comment.parent = comment.parent.toString();
 			});
-			app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).importComments(values.comments);
+			if (commentListSection)
+				commentListSection.importComments(values.comments);
 		}
 		else if (values.redlines && values.redlines.length > 0) {
-			app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).importChanges(values.redlines);
+			if (commentListSection)
+				commentListSection.importChanges(values.redlines);
 		}
 		else {
 			L.CanvasTileLayer.prototype._onCommandValuesMsg.call(this, textMsg);

--- a/browser/src/map/Map.js
+++ b/browser/src/map/Map.js
@@ -1029,7 +1029,7 @@ L.Map = L.Evented.extend({
 		var mapPanePos = this._getMapPanePos();
 		var result = L.point(point).clone();
 		var pointX = point.x;
-		if (this._docLayer.isCalcRTL()) {
+		if (this._docLayer.isCalcRTL && this._docLayer.isCalcRTL()) {
 			pointX = this._container.clientWidth - pointX;
 			result.x = pointX;
 		}
@@ -1351,7 +1351,7 @@ L.Map = L.Evented.extend({
 				app.socket.sendMessage('useractive');
 				this._active = true;
 				var docLayer = this._docLayer;
-				if (docLayer.isCalc() && docLayer.options.sheetGeometryDataEnabled) {
+				if (docLayer.isCalc && docLayer.isCalc() && docLayer.options.sheetGeometryDataEnabled) {
 					docLayer.requestSheetGeometryData();
 				}
 				app.socket.sendMessage('commandvalues command=.uno:ViewAnnotations');


### PR DESCRIPTION
Prevent errors on load when section may be missing
    
    In the past I've seen very often that for example
    commentList section was missing but used without any
    check.
    
    This commit checks if section exists before use and
    warns if it doesn't so we can see that in the console
    logs.

Second commit:
    removed unnecessary console.error with notebookbar state used for debugging and commited by mistake