### PR TITLE
backports 21.11: jsdialog improvements

### DIFF
--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -18,6 +18,11 @@ button.jsdialog {
 	opacity: 0.7;
 }
 
+/*limit icon to button height*/
+button.jsdialog img {
+	max-height: 100%;
+}
+
 .annotation-btns-container,
 .vex-dialog-buttons {
 	display: flex;

--- a/browser/images/symbol_SPIN_DOWN.svg
+++ b/browser/images/symbol_SPIN_DOWN.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg"><path d="m.48736098 4.4873578 6.51263912 6.0301722 6.5126389-6.0301722" fill="none" stroke="#3a3a38" stroke-linecap="round" stroke-linejoin="round" stroke-width=".964975"/></svg>

--- a/browser/images/symbol_SPIN_UP.svg
+++ b/browser/images/symbol_SPIN_UP.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg"><path d="M 0.48736098,10.517512 7.0000001,4.4873403 13.512639,10.517512" fill="none" stroke="#3a3a38" stroke-linecap="round" stroke-linejoin="round" stroke-width="0.964975"/></svg>

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -1932,41 +1932,43 @@ L.Control.JSDialogBuilder = L.Control.extend({
 	},
 
 	_drawingAreaControl: function(parentContainer, data, builder) {
-		if (data.image) {
-			var container = L.DomUtil.create('div', builder.options.cssClass + ' ui-drawing-area-container', parentContainer);
-			container.id = data.id;
+		var container = L.DomUtil.create('div', builder.options.cssClass + ' ui-drawing-area-container', parentContainer);
+		container.id = data.id;
 
-			var image = L.DomUtil.create('img', builder.options.cssClass + ' ui-drawing-area', container);
-			image.src = data.image.replace(/\\/g, '');
-			image.alt = data.text;
-			image.title = data.text;
-			builder.map.uiManager.enableTooltip(image);
+		if (!data.image)
+			return;
 
-			if (data.loading && data.loading === 'true') {
-				var loaderContainer = L.DomUtil.create('div', 'ui-drawing-area-loader-container', container);
-				L.DomUtil.create('div', 'ui-drawing-area-loader', loaderContainer);
-			}
-			if (data.placeholderText && data.placeholderText === 'true') {
-				var spanContainer = L.DomUtil.create('div', 'ui-drawing-area-placeholder-container', container);
-				var span = L.DomUtil.create('span', 'ui-drawing-area-placeholder', spanContainer);
-				span.innerText = data.text;
-			}
-			L.DomEvent.on(image, 'click touchend', function(e) {
-				var x = 0;
-				var y = 0;
+		var image = L.DomUtil.create('img', builder.options.cssClass + ' ui-drawing-area', container);
+		image.src = data.image.replace(/\\/g, '');
+		image.alt = data.text;
+		image.title = data.text;
+		builder.map.uiManager.enableTooltip(image);
 
-				if (e.offsetX) {
-					x = e.offsetX;
-					y = e.offsetY;
-				} else if (e.changedTouches && e.changedTouches.length) {
-					x = e.changedTouches[e.changedTouches.length-1].pageX - $(image).offset().left;
-					y = e.changedTouches[e.changedTouches.length-1].pageY - $(image).offset().top;
-				}
-
-				var coordinates = (x / image.offsetWidth) + ';' + (y / image.offsetHeight);
-				builder.callback('drawingarea', 'click', container, coordinates, builder);
-			}, this);
+		if (data.loading && data.loading === 'true') {
+			var loaderContainer = L.DomUtil.create('div', 'ui-drawing-area-loader-container', container);
+			L.DomUtil.create('div', 'ui-drawing-area-loader', loaderContainer);
 		}
+		if (data.placeholderText && data.placeholderText === 'true') {
+			var spanContainer = L.DomUtil.create('div', 'ui-drawing-area-placeholder-container', container);
+			var span = L.DomUtil.create('span', 'ui-drawing-area-placeholder', spanContainer);
+			span.innerText = data.text;
+		}
+		L.DomEvent.on(image, 'click touchend', function(e) {
+			var x = 0;
+			var y = 0;
+
+			if (e.offsetX) {
+				x = e.offsetX;
+				y = e.offsetY;
+			} else if (e.changedTouches && e.changedTouches.length) {
+				x = e.changedTouches[e.changedTouches.length-1].pageX - $(image).offset().left;
+				y = e.changedTouches[e.changedTouches.length-1].pageY - $(image).offset().top;
+			}
+
+			var coordinates = (x / image.offsetWidth) + ';' + (y / image.offsetHeight);
+			builder.callback('drawingarea', 'click', container, coordinates, builder);
+		}, this);
+
 		return false;
 	},
 

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -245,6 +245,8 @@ L.Control.JSDialogBuilder = L.Control.extend({
 				window.app.console.warn('Unsupported toolitem type: "' + data.command + '"');
 		}
 
+		builder.postProcess(parentContainer, data);
+
 		return false;
 	},
 
@@ -2292,7 +2294,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		var isRealUnoCommand = true;
 
 		if (data.command || data.postmessage === true) {
-			var id = data.id;
+			var id = data.id ? data.id : (data.text && data.text !== '') ? data.text : data.command;
 			var isUnoCommand = data.command && data.command.indexOf('.uno:') >= 0;
 			if (isUnoCommand)
 				id = encodeURIComponent(data.command.substr('.uno:'.length));
@@ -2306,9 +2308,11 @@ L.Control.JSDialogBuilder = L.Control.extend({
 
 			L.DomUtil.addClass(div, 'uno' + id);
 
-			id = builder._makeIdUnique(id);
+			if (isRealUnoCommand)
+				id = builder._makeIdUnique(id);
 
 			div.id = id;
+			data.id = id; // change in input data for postprocess
 
 			var icon = data.icon ? data.icon : builder._createIconURL(data.command);
 			var buttonId = id + 'img';

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -1413,6 +1413,9 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		});
 
 		edit.addEventListener('keydown', function(event) {
+			if (edit.disabled)
+				return;
+
 			if (data.rawKeyEvents) {
 				if (event.key === 'Enter') {
 					builder.callback('edit', 'keypress', edit, UNOKey.RETURN, builder);
@@ -1437,6 +1440,9 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		});
 
 		edit.addEventListener('keypress', function(event) {
+			if (edit.disabled)
+				return;
+
 			if (data.rawKeyEvents) {
 				if (event.key === 'Enter' ||
 					event.key === 'Escape' ||
@@ -1458,6 +1464,8 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		if (data.rawKeyEvents) {
 			'select click'.split(' ').forEach(function(eventName) {
 				edit.addEventListener(eventName, function(event) {
+					if (edit.disabled)
+						return;
 					var selection = event.target.selectionStart + ';' + event.target.selectionEnd;
 					builder.callback('edit', 'textselection', edit, selection, builder);
 				});
@@ -3027,6 +3035,19 @@ L.Control.JSDialogBuilder = L.Control.extend({
 
 		case 'hide':
 			$(control).addClass('hidden');
+			break;
+
+		case 'setText':
+			control.value = this._cleanText(data.text);
+			if (data.selection) {
+				var selection = data.selection.split(';');
+				if (selection.length === 2)
+					control.setSelectionRange(parseInt(selection[0]), parseInt(selection[1]));
+			}
+			break;
+
+		default:
+			console.error('unknown action: "' + data.action_type + '"');
 			break;
 		}
 	},

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -3121,7 +3121,9 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			}
 
 			var hasManyChildren = childData.children && childData.children.length > 1;
-			if (hasManyChildren && childData.type !== 'buttonbox' && childData.type !== 'treelistbox') {
+			var isContainer = childData.type !== 'buttonbox' && childData.type !== 'treelistbox'
+				&& childData.type !== 'iconview';
+			if (hasManyChildren && isContainer) {
 				var table = L.DomUtil.createWithId('div', childData.id, td);
 				$(table).addClass(this.options.cssClass);
 				$(table).addClass('vertical');

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2296,11 +2296,8 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			var isUnoCommand = data.command && data.command.indexOf('.uno:') >= 0;
 			if (isUnoCommand)
 				id = encodeURIComponent(data.command.substr('.uno:'.length));
-			else {
-				if (data.command)
-					id = data.command;
+			else
 				isRealUnoCommand = false;
-			}
 
 			if (id)
 				id.replace(/\%/g, '').replace(/\./g, '-').replace(' ', '');

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -3018,11 +3018,14 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			$(control).children('.selected').removeClass('selected');
 
 			var pos = parseInt(data.position);
-			var entry = $(control).children().eq(pos);
+			var entry = control.children.length > pos ? control.children[pos] : null;
 
-			entry.addClass('selected');
-			var blockOption = this._scrollIntoViewBlockOption('nearest');
-			$(entry).get(0).scrollIntoView({behavior: 'smooth', block: blockOption, inline: 'nearest'});
+			if (entry) {
+				L.DomUtil.addClass(entry, 'selected');
+				var blockOption = this._scrollIntoViewBlockOption('nearest');
+				entry.scrollIntoView({behavior: 'smooth', block: blockOption, inline: 'nearest'});
+			} else
+				console.warn('not found entry: "' + pos + '" in: "' + data.control_id + '"');
 
 			break;
 

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -1436,6 +1436,9 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		} else if (data.image) {
 			var image = L.DomUtil.create('img', '', pushbutton);
 			image.src = data.image;
+		} else if (data.symbol) {
+			var image = L.DomUtil.create('img', '', pushbutton);
+			image.src = L.LOUtil.getImageURL('symbol_' + data.symbol + '.svg');
 		} else {
 			pushbutton.innerText = pushbuttonText;
 		}

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -4,7 +4,7 @@
  * from the JSON description provided by the server.
  */
 
-/* global app $ w2ui _ _UNO L */
+/* global app $ w2ui _ _UNO UNOKey L */
 
 L.Control.JSDialogBuilder = L.Control.extend({
 
@@ -1411,6 +1411,58 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			else
 				builder.callback('edit', 'change', edit, this.value, builder);
 		});
+
+		edit.addEventListener('keydown', function(event) {
+			if (data.rawKeyEvents) {
+				if (event.key === 'Enter') {
+					builder.callback('edit', 'keypress', edit, UNOKey.RETURN, builder);
+					event.preventDefault();
+				} else if (event.key === 'Escape' || event.key === 'Esc') {
+					builder.callback('edit', 'keypress', edit, UNOKey.ESCAPE, builder);
+					event.preventDefault();
+				} else if (event.key === 'Left' || event.key === 'ArrowLeft') {
+					builder.callback('edit', 'keypress', edit, UNOKey.LEFT, builder);
+					event.preventDefault();
+				} else if (event.key === 'Right' || event.key === 'ArrowRight') {
+					builder.callback('edit', 'keypress', edit, UNOKey.RIGHT, builder);
+					event.preventDefault();
+				} else if (event.key === 'Backspace') {
+					builder.callback('edit', 'keypress', edit, UNOKey.BACKSPACE, builder);
+					event.preventDefault();
+				} else if (event.key === 'Space') {
+					builder.callback('edit', 'keypress', edit, UNOKey.SPACE, builder);
+					event.preventDefault();
+				}
+			}
+		});
+
+		edit.addEventListener('keypress', function(event) {
+			if (data.rawKeyEvents) {
+				if (event.key === 'Enter' ||
+					event.key === 'Escape' ||
+					event.key === 'Esc' ||
+					event.key === 'Left' ||
+					event.key === 'ArrowLeft' ||
+					event.key === 'Right' ||
+					event.key === 'ArrowRight' ||
+					event.key === 'Backspace' ||
+					event.key === 'Space') {
+					// skip
+				} else
+					builder.callback('edit', 'keypress', edit, event.keyCode, builder);
+
+				event.preventDefault();
+			}
+		});
+
+		if (data.rawKeyEvents) {
+			'select click'.split(' ').forEach(function(eventName) {
+				edit.addEventListener(eventName, function(event) {
+					var selection = event.target.selectionStart + ';' + event.target.selectionEnd;
+					builder.callback('edit', 'textselection', edit, selection, builder);
+				});
+			});
+		}
 
 		if (data.hidden)
 			$(edit).hide();

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -1462,13 +1462,11 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		});
 
 		if (data.rawKeyEvents) {
-			'select click'.split(' ').forEach(function(eventName) {
-				edit.addEventListener(eventName, function(event) {
-					if (edit.disabled)
-						return;
-					var selection = event.target.selectionStart + ';' + event.target.selectionEnd;
-					builder.callback('edit', 'textselection', edit, selection, builder);
-				});
+			edit.addEventListener('mouseup', function(event) {
+				if (edit.disabled)
+					return;
+				var selection = event.target.selectionStart + ';' + event.target.selectionEnd;
+				builder.callback('edit', 'textselection', edit, selection, builder);
 			});
 		}
 

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2933,8 +2933,8 @@ L.Control.JSDialogBuilder = L.Control.extend({
 	// executes actions like changing the selection without rebuilding the widget
 	executeAction: function(container, data) {
 		var control = container.querySelector('[id=\'' + data.control_id + '\']');
-		if (!control)
-			control = container.querySelector('[id=\'table-' + data.control.id + '\']');
+		if (!control && data.control)
+			control = container.querySelector('[id=\'' + data.control.id + '\']');
 		if (!control) {
 			window.app.console.warn('executeAction: not found control with id: "' + data.control_id + '"');
 			return;
@@ -3030,20 +3030,12 @@ L.Control.JSDialogBuilder = L.Control.extend({
 
 			var hasManyChildren = childData.children && childData.children.length > 1;
 			if (hasManyChildren && childData.type !== 'buttonbox' && childData.type !== 'treelistbox') {
-				// TODO: remove 'table-' prefix, we need exactly the same id so events coming from core
-				// will reach the elements, for postprocess we need to temporary switch the id in childData
-				var backupId = childData.id;
-				childData.id = childData.id ? 'table-' + String(childData.id).replace(' ', '') : '';
-
 				var table = L.DomUtil.createWithId('div', childData.id, td);
 				$(table).addClass(this.options.cssClass);
 				$(table).addClass('vertical');
 				var childObject = L.DomUtil.create('div', 'row ' + this.options.cssClass, table);
 
 				this.postProcess(td, childData);
-
-				// revert correct id
-				childData.id = backupId;
 			} else {
 				childObject = td;
 			}

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2984,7 +2984,10 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		}
 
 		// natural tab-order when using keyboard navigation
-		if (control && !control.hasAttribute('tabIndex'))
+		if (control && !control.hasAttribute('tabIndex')
+			&& data.type !== 'container'
+			&& data.type !== 'grid'
+			&& data.type !== 'toolbox')
 			control.setAttribute('tabIndex', '0');
 	},
 

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -109,6 +109,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		this._controlHandlers['spinnerimg'] = this._spinnerImgControl;
 		this._controlHandlers['image'] = this._imageHandler;
 		this._controlHandlers['scrollwindow'] = this._scrollWindowControl;
+		this._controlHandlers['customtoolitem'] = this._mapDispatchToolItem;
 
 		this._controlHandlers['mainmenu'] = this._containerHandler;
 		this._controlHandlers['submenu'] = this._subMenuHandler;
@@ -2429,6 +2430,20 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		builder.map.disableLockedItem(data, controls['container'], controls['container']);
 
 		return controls;
+	},
+
+	_mapDispatchToolItem: function (parentContainer, data, builder) {
+		if (!data.command)
+			data.command = data.id;
+
+		var control = builder._unoToolButton(parentContainer, data, builder);
+
+		$(control.container).unbind('click.toolbutton');
+		if (!builder.map.isLockedItem(data)) {
+			$(control.container).click(function () {
+				builder.map.dispatch(data.command);
+			});
+		}
 	},
 
 	_divContainerHandler: function (parentContainer, data, builder) {

--- a/browser/src/control/Control.MobileTopBar.js
+++ b/browser/src/control/Control.MobileTopBar.js
@@ -118,19 +118,10 @@ L.Control.MobileTopBar = L.Control.extend({
 			}
 		}
 		else if (id === 'cancelformula') {
-			this.map.sendUnoCommand('.uno:Cancel');
-			w2ui['actionbar'].hide('acceptformula', 'cancelformula');
-			w2ui['actionbar'].show('undo', 'redo');
+			this.map.dispatch('cancelformula');
 		}
 		else if (id === 'acceptformula') {
-			// focus on map, and press enter
-			this.map.focus();
-			this.map._docLayer.postKeyboardEvent('input',
-				this.map.keyboard.keyCodes.enter,
-				this.map.keyboard._toUNOKeyCode(this.map.keyboard.keyCodes.enter));
-
-			w2ui['actionbar'].hide('acceptformula', 'cancelformula');
-			w2ui['actionbar'].show('undo', 'redo');
+			this.map.dispatch('acceptformula');
 		}
 		else if (id === 'comment_wizard') {
 			if (window.commentWizard) {

--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -296,6 +296,10 @@ L.Control.Notebookbar = L.Control.extend({
 				return;
 		}
 
+		var isUnoCommand = button.unoCommand && button.unoCommand.indexOf('.uno:') >= 0;
+		if (button.unoCommand && !isUnoCommand)
+			button.unoCommand = '.uno:' + button.unoCommand;
+
 		this.additionalShortcutButtons.push(
 			{
 				id: button.id,

--- a/browser/src/control/Control.NotebookbarBuilder.js
+++ b/browser/src/control/Control.NotebookbarBuilder.js
@@ -584,11 +584,12 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 	},
 
 	_onlineHelpControl: function(parentContainer, data, builder) {
+		var originalDataId = data.id; // builder can change this
 		var control = builder._unoToolButton(parentContainer, data, builder);
 
 		$(control.container).unbind('click.toolbutton');
 		$(control.container).click(function () {
-			L.control.menubar()._executeAction.bind({_map: builder.options.map})(undefined, {id: data.id});
+			L.control.menubar()._executeAction.bind({_map: builder.options.map})(undefined, {id: originalDataId});
 		});
 		builder._preventDocumentLosingFocusOnClick(control.container);
 	},

--- a/browser/src/control/Control.NotebookbarBuilder.js
+++ b/browser/src/control/Control.NotebookbarBuilder.js
@@ -257,7 +257,7 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 	},
 
 	_createiOsFontButton: function(parentContainer, data, builder) {
-		var table = L.DomUtil.createWithId('div', 'table-fontnamecombobox', parentContainer);
+		var table = L.DomUtil.createWithId('div', 'fontnamecombobox', parentContainer);
 		var row = L.DomUtil.create('div', 'notebookbar row', table);
 		var button = L.DomUtil.createWithId('button', data.id, row);
 
@@ -1066,7 +1066,7 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 
 			var hasManyChildren = childData.children && childData.children.length > 1;
 			if (hasManyChildren) {
-				var tableId = childData.id ? 'table-' + childData.id.replace(' ', '') : '';
+				var tableId = childData.id ? childData.id.replace(' ', '') : '';
 				var table = L.DomUtil.createWithId('div', tableId, td);
 				$(table).addClass(this.options.cssClass);
 				$(table).addClass('vertical');

--- a/browser/src/control/Control.Sidebar.js
+++ b/browser/src/control/Control.Sidebar.js
@@ -58,10 +58,6 @@ L.Control.Sidebar = L.Control.extend({
 		var controlId = data.control.id;
 		var control = this.container.querySelector('[id=\'' + controlId + '\']');
 		if (!control) {
-			controlId = 'table-' + controlId;
-			control = this.container.querySelector('[id=\'' + controlId + '\']');
-		}
-		if (!control) {
 			window.app.console.warn('jsdialogupdate: not found control with id: "' + data.control.id + '"');
 			return;
 		}

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -3,7 +3,7 @@
  * Toolbar handler
  */
 
-/* global app $ window vex sanitizeUrl brandProductName brandProductURL _ Hammer */
+/* global app $ w2ui window vex sanitizeUrl brandProductName brandProductURL _ Hammer */
 L.Map.include({
 
 	// a mapping of uno commands to more readable toolbar items
@@ -768,5 +768,34 @@ L.Map.include({
 	openSaveAs: function () {
 		var map = this;
 		map.fire('postMessage', {msgId: 'UI_SaveAs'});
+	},
+
+	// map.dispatch() will be used to call some actions so we can share the code
+	dispatch: function(action) {
+		switch (action) {
+		case 'acceptformula':
+			{
+				// focus on map, and press enter
+				this.focus();
+				this._docLayer.postKeyboardEvent('input',
+					this.keyboard.keyCodes.enter,
+					this.keyboard._toUNOKeyCode(this.keyboard.keyCodes.enter));
+
+				if (window.mode.isMobile()) {
+					w2ui['actionbar'].hide('acceptformula', 'cancelformula');
+					w2ui['actionbar'].show('undo', 'redo');
+				}
+			}
+			break;
+		case 'cancelformula':
+			{
+				this.sendUnoCommand('.uno:Cancel');
+				if (window.mode.isMobile()) {
+					w2ui['actionbar'].hide('acceptformula', 'cancelformula');
+					w2ui['actionbar'].show('undo', 'redo');
+				}
+			}
+			break;
+		}
 	},
 });

--- a/cypress_test/integration_tests/desktop/calc/row_column_operation_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/row_column_operation_spec.js
@@ -37,7 +37,7 @@ describe('Row Column Operation', function() {
 	it('Insert/Delete row' , function() {
 		//Insert row above
 		mode === 'notebookbar' ?
-			cy.get('#table-Home-Section-Cell1 #InsertRowsBefore').click() :
+			cy.get('#Home-Section-Cell1 #InsertRowsBefore').click() :
 			selectOption('Insert Rows', 'Rows Above');
 
 		calcHelper.selectEntireSheet();
@@ -48,7 +48,7 @@ describe('Row Column Operation', function() {
 		calcHelper.clickOnFirstCell(true, false);
 
 		mode === 'notebookbar' ?
-			cy.get('#table-Home-Section-Cell1 #DeleteRows').click() :
+			cy.get('#Home-Section-Cell1 #DeleteRows').click() :
 			selectOption('Delete Rows');
 
 		calcHelper.selectEntireSheet();
@@ -59,7 +59,7 @@ describe('Row Column Operation', function() {
 		calcHelper.clickOnFirstCell(true, false);
 
 		mode === 'notebookbar' ?
-			cy.get('#table-Home-Section-Cell1 #InsertRowsAfter').click() :
+			cy.get('#Home-Section-Cell1 #InsertRowsAfter').click() :
 			selectOption('Insert Rows', 'Rows Below');
 
 		calcHelper.selectEntireSheet();
@@ -70,7 +70,7 @@ describe('Row Column Operation', function() {
 	it('Insert/Delete Column', function() {
 		//insert column before
 		mode === 'notebookbar' ?
-			cy.get('#table-Home-Section-Cell1 #InsertColumnsBefore').click() :
+			cy.get('#Home-Section-Cell1 #InsertColumnsBefore').click() :
 			selectOption('Insert Columns', 'Columns Before');
 
 		calcHelper.selectEntireSheet();
@@ -81,7 +81,7 @@ describe('Row Column Operation', function() {
 
 		//delete column
 		mode === 'notebookbar' ?
-			cy.get('#table-Home-Section-Cell1 #DeleteColumns').click() :
+			cy.get('#Home-Section-Cell1 #DeleteColumns').click() :
 			selectOption('Delete Columns');
 
 		calcHelper.selectEntireSheet();
@@ -94,7 +94,7 @@ describe('Row Column Operation', function() {
 
 		//insert column after
 		mode === 'notebookbar' ?
-			cy.get('#table-Home-Section-Cell1 #InsertColumnsAfter').click() :
+			cy.get('#Home-Section-Cell1 #InsertColumnsAfter').click() :
 			selectOption('Insert Columns', 'Columns After');
 
 		calcHelper.selectEntireSheet();

--- a/cypress_test/integration_tests/desktop/writer/table_operation_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/table_operation_spec.js
@@ -28,7 +28,7 @@ describe('Table operations', function() {
 
 	it('Insert row before.', function() {
 
-		helper.clickOnIdle('#table-insert .unoInsertRowsBefore');
+		helper.clickOnIdle('#insert .unoInsertRowsBefore');
 
 		cy.get('.leaflet-marker-icon.table-row-resize-marker')
 			.should('have.length', 4);
@@ -48,7 +48,7 @@ describe('Table operations', function() {
 
 	it('Insert row after.', function() {
 
-		helper.clickOnIdle('#table-insert .unoInsertRowsAfter');
+		helper.clickOnIdle('#insert .unoInsertRowsAfter');
 
 		cy.get('.leaflet-marker-icon.table-row-resize-marker')
 			.should('have.length', 4);
@@ -68,7 +68,7 @@ describe('Table operations', function() {
 
 	it('Insert column before.', function() {
 
-		helper.clickOnIdle('#table-insert .unoInsertColumnsBefore');
+		helper.clickOnIdle('#insert .unoInsertColumnsBefore');
 
 		cy.get('.leaflet-marker-icon.table-column-resize-marker')
 			.should('have.length', 4);
@@ -88,7 +88,7 @@ describe('Table operations', function() {
 	});
 
 	it('Insert column after.', function() {
-		helper.clickOnIdle('#table-insert .unoInsertColumnsAfter');
+		helper.clickOnIdle('#insert .unoInsertColumnsAfter');
 
 		cy.get('.leaflet-marker-icon.table-column-resize-marker')
 			.should('have.length', 4);
@@ -107,7 +107,7 @@ describe('Table operations', function() {
 	});
 
 	it('Delete row.', function() {
-		helper.clickOnIdle('#table-delete .unoDeleteRows');
+		helper.clickOnIdle('#delete .unoDeleteRows');
 
 		cy.get('.leaflet-marker-icon.table-row-resize-marker')
 			.should('have.length', 2);
@@ -127,20 +127,20 @@ describe('Table operations', function() {
 
 	it('Delete column.', function() {
 		// Insert column first
-		helper.clickOnIdle('#table-insert .unoInsertColumnsBefore');
+		helper.clickOnIdle('#insert .unoInsertColumnsBefore');
 
 		cy.get('.leaflet-marker-icon.table-column-resize-marker')
 			.should('have.length', 4);
 
 		// Then delete it
-		helper.clickOnIdle('#table-delete .unoDeleteColumns');
+		helper.clickOnIdle('#delete .unoDeleteColumns');
 
 		cy.get('.leaflet-marker-icon.table-column-resize-marker')
 			.should('have.length', 3);
 	});
 
 	it('Delete table.', function() {
-		helper.clickOnIdle('#table-delete .unoDeleteTable');
+		helper.clickOnIdle('#delete .unoDeleteTable');
 
 		cy.get('.leaflet-marker-icon.table-column-resize-marker')
 			.should('not.exist');
@@ -155,7 +155,7 @@ describe('Table operations', function() {
 		// We use cursor position as the indicator of layout change.
 		helper.getCursorPos('top', 'origCursorPos');
 
-		helper.clickOnIdle('#table-split_merge .unoMergeCells');
+		helper.clickOnIdle('#split_merge .unoMergeCells');
 
 		// Cursor was in the second row originally.
 		// With merging two rows, the cursor is moved into the first row.
@@ -212,7 +212,7 @@ describe('Table operations', function() {
 		helper.moveCursor('down', 'shift');
 		helper.moveCursor('right', 'shift');
 
-		helper.clickOnIdle('#table-rowsizing .unoSetMinimalRowHeight');
+		helper.clickOnIdle('#rowsizing .unoSetMinimalRowHeight');
 
 		selectFullTable();
 
@@ -228,7 +228,7 @@ describe('Table operations', function() {
 		helper.moveCursor('down', 'shift');
 		helper.moveCursor('right', 'shift');
 
-		helper.clickOnIdle('#table-rowsizing .unoSetOptimalRowHeight');
+		helper.clickOnIdle('#rowsizing .unoSetOptimalRowHeight');
 
 		selectFullTable();
 
@@ -251,7 +251,7 @@ describe('Table operations', function() {
 		helper.moveCursor('down', 'shift');
 		helper.moveCursor('right', 'shift');
 
-		helper.clickOnIdle('#table-rowsizing .unoDistributeRows');
+		helper.clickOnIdle('#rowsizing .unoDistributeRows');
 
 		selectFullTable();
 
@@ -274,7 +274,7 @@ describe('Table operations', function() {
 		helper.moveCursor('down', 'shift');
 		helper.moveCursor('right', 'shift');
 
-		helper.clickOnIdle('#table-columnsizing .unoSetMinimalColumnWidth');
+		helper.clickOnIdle('#columnsizing .unoSetMinimalColumnWidth');
 
 		selectFullTable();
 
@@ -288,7 +288,7 @@ describe('Table operations', function() {
 		helper.moveCursor('down', 'shift');
 		helper.moveCursor('right', 'shift');
 
-		helper.clickOnIdle('#table-columnsizing .unoSetOptimalColumnWidth');
+		helper.clickOnIdle('#columnsizing .unoSetOptimalColumnWidth');
 
 		selectFullTable();
 
@@ -304,7 +304,7 @@ describe('Table operations', function() {
 		helper.moveCursor('down', 'shift');
 		helper.moveCursor('right', 'shift');
 
-		helper.clickOnIdle('#table-columnsizing .unoDistributeColumns');
+		helper.clickOnIdle('#columnsizing .unoDistributeColumns');
 
 		selectFullTable();
 


### PR DESCRIPTION
- build drawingarea even if is empty (so we can later apply update events)
- remove old hack which added "table-" prefix to some widgets
- implemented textarea with raw keyboard handling (by the core, user cannot type directly into the field, only see the result from server) `not used in 21.11`
- implemented buttons with "symbol" instead of image `not used in 21.11`
- implemented `toolitem` which can easily share code with eg. menubar `customtoolitem` and `map.dispatch(command)`

This PR is for unifying jsdialog code between 21.11 and master so cherry-picking will be easier