### PR TITLE
wsd: return status from writeOutgoingData

### DIFF
--- a/net/SslSocket.hpp
+++ b/net/SslSocket.hpp
@@ -125,18 +125,18 @@ public:
         return StreamSocket::readIncomingData();
     }
 
-    void writeOutgoingData() override
+    int writeOutgoingData() override
     {
         ASSERT_CORRECT_SOCKET_THREAD(this);
 
         const int rc = doHandshake();
         if (rc <= 0)
         {
-            return;
+            return rc;
         }
 
         // Default implementation.
-        StreamSocket::writeOutgoingData();
+        return StreamSocket::writeOutgoingData();
     }
 
     virtual int readData(char* buf, int len) override


### PR DESCRIPTION
Without knowing whether the write succeeded
or failed, we cannot trust errno has our
error or some earlier and unrelated error.

This was caught when there were two sockets,
one of which disconnected. The write to the
disconnected one returned -1 and set errno
to ECONNRESET. We subsequently wrote to the
second socket, which succeeded. However,
because errno wasn't reset, and since
writeOutgoingData didn't return anything
to indicate the success, errno's ECONNRESET
value meant the second socket was also
disconnected, which was incorrect.

writeOutgoingData now returns the last return
value from writeData so we can make informed
decision as to whether to check errno or not.

Also, to avoid incorrecly propagating errno,
we now capture errno only when readData and
writeData return -1. This has the nice
side-effect that we reset errno to 0 when
no errors occur during our call.

Change-Id: I911b31390f37cc71938bc4a6ae75393dbf24bb9d
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
(cherry picked from commit dec21487859873c416ecd7191501973f36dc9cf4)

Backported from #4708