### PR TITLE
docker: map domain env variable to alias_groups

### DIFF
--- a/docker/from-packages/scripts/start-collabora-online.pl
+++ b/docker/from-packages/scripts/start-collabora-online.pl
@@ -95,7 +95,17 @@ sub rewrite_config($) {
 
     my $in_aliases = 0;
     while (<CONFIG>) {
-        if (/<alias_groups/) {
+        if (/<remote_url (.*)>.*<\/remote_url>/) {
+            my $remoteurl = $ENV{'remoteconfigurl'};
+            if ($remoteurl) {
+                s/<remote_url (.*)>.*<\/remote_url>/<remote_url $1>$remoteurl<\/remote_url>/;
+                $output .= $_;
+            }
+            else {
+                $output .= $_;
+            }
+        }
+        elsif (/<alias_groups/) {
             $in_aliases = 1;
 
             my $groups = generate_aliases();

--- a/docker/from-packages/scripts/start-collabora-online.sh
+++ b/docker/from-packages/scripts/start-collabora-online.sh
@@ -35,12 +35,8 @@ SAL_LOG="-INFO-WARN"
 fi
 
 # Replace trusted host and set admin username and password - only if they are set
-if test -n "${domain}"; then
-    echo -e "ERR: Use of domain variable is not supported. First host/domain who tries to connect to COOL is always allowed.\nTo allow multiple host and its aliases use something like this and pass it as env variable:\naliasgroup1=https://domain1:443,https://its-alias|its-second-alias:443 \naliasgroup2=https://domain2:443,https://its-alias:443 \nFor more info: https://sdk.collaboraonline.com/docs/installation/CODE_Docker_image.html"
-    exit 1
-fi
-if test -n "${aliasgroup1}"; then
-    perl -w /start-collabora-online.pl
+if test -n "${aliasgroup1}" -o -n "${domain}" -o -n "${remoteconfigurl}"; then
+    perl -w /start-collabora-online.pl || { exit 1; }
 fi
 if test -n "${username}"; then
     perl -pi -e "s/<username (.*)>.*<\/username>/<username \1>${username}<\/username>/" /etc/coolwsd/coolwsd.xml


### PR DESCRIPTION
show a verbose warning about using domain

Signed-off-by: Rash419 <rashesh.padia@collabora.com>
Change-Id: I41fdea3419eb2719fa665a62de33e3a237cf3df8

This is what the message look like in docker logs:
![image](https://user-images.githubusercontent.com/26241069/166262377-19687ad7-5faf-4742-996f-f6f0caba6446.png)

