### PR TITLE
wsd: fix log message typo in COOLWSD::innerMain()

### DIFF
--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -5233,7 +5233,7 @@ int COOLWSD::innerMain()
     int returnValue = EX_OK;
     UnitWSD::get().returnValue(returnValue);
 
-    LOG_INF("Process [loolwsd] finished with exit status: " << returnValue);
+    LOG_INF("Process [coolwsd] finished with exit status: " << returnValue);
 
     // At least on centos7, Poco deadlocks while
     // cleaning up its SSL context singleton.


### PR DESCRIPTION
This went wrong when the forward-port of commit
b96e8b7c77a1739f36e5f17ab7770052282dc158 (wsd: correct use the exit code
from UnitWSD, 2021-11-29) didn't adapt the string to the updated
filename.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Ica8047dc05dedf9e075663f405dea89913cf789a
