### PR TITLE
A more robust resizeobserver polyfill detection.

### DIFF
--- a/loleaflet/js/ResizeObserverPolyfill.js
+++ b/loleaflet/js/ResizeObserverPolyfill.js
@@ -9,7 +9,7 @@ var isIE11_ = !!window.MSInputMethodContext && !!document.documentMode;
 var match = window.navigator.userAgent.match(/Firefox\/([0-9]+)\./);
 var firefoxVer = match ? parseInt(match[1]) : 69;
 
-if (isIE11_ || firefoxVer < 69) {
+if (isIE11_ || firefoxVer < 69 || typeof ResizeObserver === 'undefined') {
     (function (global, factory) {
         typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
         typeof define === 'function' && define.amd ? define(factory) :


### PR DESCRIPTION
Instead of messing with parsing useragent - lets just check whether
the type exists.

Change-Id: Ib654dc71ec12fd643c906bc50fa9dff1791dc14e


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

