### PR TITLE
Notebookbar: fix sidebar icon alignment

### DIFF
--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -147,10 +147,8 @@
 }
 
 /* options section */
-.notebookbar-options-section {
-	display: inline;
-	height: 32px;
-	padding: 2px;
+.notebookbar-options-section .cell.notebookbar {
+	padding: 0;
 }
 
 /* root container */


### PR DESCRIPTION
Subcontainer `root-container notebookbar` was not able to vertical align
contents even thought it has vertical-align: middle
	- Fix it by removing parents' (notebookbar-options-section) height and
		padding

The alignment is still off due to:
sub cell is inheriting automatic padding (useful in all other places)
	- Fix it by remove padding for the cell under
		.notebookbar-options-section

Display inline seems not be needed here, we can just inherit it.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Iafb4f83acfff5ae0923afb972cefe1201080c79e
