### PR TITLE
jquery-ui-lightness/ui-icons_ for dark mode

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -485,11 +485,15 @@ input[type='number']:hover::-webkit-outer-spin-button {
 .ui-listbox::-ms-expand {
 	display: none;
 }
-
+@media (prefers-color-scheme: dark) {
+	.ui-listbox-arrow {
+		background: url('images/jquery-ui-lightness/ui-icons_ffffff_256x240.png') no-repeat transparent !important;
+	}
+}
 .ui-listbox-arrow {
 	content: '';
 	background: url('images/jquery-ui-lightness/ui-icons_222222_256x240.png') no-repeat transparent;
-	background-position: -67px -18px;
+	background-position: -67px -18px !important;
 	display: inline-block;
 	position: absolute;
 	width: 11px;


### PR DESCRIPTION
switch to ffffff instead of 222222 when the prefers-color-scheme is dark

![image](https://user-images.githubusercontent.com/8517736/167222977-8a1b9032-5305-48f9-8273-f5efe24d4112.png)


Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I3e3c68879c6b6a831d5fbf095597ddae6eb51f77