### PR TITLE
wsd: do not enqueue messages on closed sessions

### DIFF
--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1923,6 +1923,12 @@ bool ClientSession::forwardToClient(const std::shared_ptr<Message>& payload)
 
 void ClientSession::enqueueSendMessage(const std::shared_ptr<Message>& data)
 {
+    if (isCloseFrame())
+    {
+        LOG_TRC(getName() << ": Connection closed, dropping message " << data->id());
+        return;
+    }
+
     const std::shared_ptr<DocumentBroker> docBroker = _docBroker.lock();
     LOG_CHECK_RET(docBroker && "Null DocumentBroker instance", );
     docBroker->assertCorrectThread();

--- a/wsd/ClientSession.hpp
+++ b/wsd/ClientSession.hpp
@@ -82,9 +82,13 @@ public:
 
     bool sendBinaryFrame(const char* buffer, int length) override
     {
-        auto payload = std::make_shared<Message>(buffer, length, Message::Dir::Out);
-        enqueueSendMessage(payload);
-        return true;
+        if (!isCloseFrame())
+        {
+            enqueueSendMessage(std::make_shared<Message>(buffer, length, Message::Dir::Out));
+            return true;
+        }
+
+        return false;
     }
 
     bool sendTile(const std::string &header, const TileCache::Tile &tile)
@@ -101,9 +105,13 @@ public:
 
     bool sendTextFrame(const char* buffer, const int length) override
     {
-        auto payload = std::make_shared<Message>(buffer, length, Message::Dir::Out);
-        enqueueSendMessage(payload);
-        return true;
+        if (!isCloseFrame())
+        {
+            enqueueSendMessage(std::make_shared<Message>(buffer, length, Message::Dir::Out));
+            return true;
+        }
+
+        return false;
     }
 
 

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -3256,7 +3256,7 @@ std::size_t DocumentBroker::broadcastMessage(const std::string& message) const
     std::size_t count = 0;
     for (const auto& sessionIt : _sessions)
     {
-        count += sessionIt.second->sendTextFrame(message);
+        count += (!sessionIt.second->isCloseFrame() && sessionIt.second->sendTextFrame(message));
     }
 
     return count;


### PR DESCRIPTION
Also corrects the counting of number of active
sessions when broadcasting messages.

Change-Id: I5ab5995ed2cbc18b215542d0b2c9568957fd6a3a
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
