### PR TITLE
wsd: test: better PutFile assertion

### DIFF
--- a/test/WOPIUploadConflictCommon.hpp
+++ b/test/WOPIUploadConflictCommon.hpp
@@ -160,8 +160,8 @@ public:
         if (getExpectedPutFile() < getCountPutFile())
         {
             //FIXME: unreliable in SaveOnExit, which sometimes does 2 PutFile requests.
-            // LOK_ASSERT_EQUAL_MESSAGE("Too many PutFile requests", getExpectedPutFile(),
-            //                          getCountPutFile());
+            LOK_ASSERT_EQUAL_MESSAGE("Too many PutFile requests", getExpectedPutFile(),
+                                     getCountPutFile());
         }
     }
 
@@ -281,7 +281,7 @@ public:
         LOK_ASSERT_EQUAL(getExpectedCheckFileInfo(), getCountCheckFileInfo());
         LOK_ASSERT_EQUAL(getExpectedGetFile(), getCountGetFile());
         LOK_ASSERT_EQUAL(getExpectedPutRelative(), getCountPutRelative());
-        // LOK_ASSERT_EQUAL(getExpectedPutFile(), getCountPutFile()); //FIXME: unreliable for some tests.
+        LOK_ASSERT_EQUAL(getExpectedPutFile(), getCountPutFile());
 
         switch (_scenario)
         {

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1366,11 +1366,6 @@ void DocumentBroker::uploadToStorage(const std::string& sessionId, bool force)
         constexpr bool isRename = false;
         uploadToStorageInternal(sessionId, /*saveAsPath*/ std::string(),
                                 /*saveAsFilename*/ std::string(), isRename, force);
-
-        // If marked to destroy, or session is disconnected, remove.
-        const auto it = _sessions.find(sessionId);
-        if (_docState.isMarkedToDestroy() || (it != _sessions.end() && it->second->isCloseFrame()))
-            disconnectSessionInternal(sessionId);
     }
     else
     {


### PR DESCRIPTION
This enabled previously-disabled PutFile
assertions, now that these cases are fixed.

Also, removes a premature session cleanup
that was preventing retrying when the
in-flight upload failed.

Change-Id: I77a0d552b43c73534cd4fbd066e34025d924f793
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
