### PR TITLE
logging: let the log text colour be selected by the browser

### DIFF
--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -267,9 +267,9 @@ app.definitions.Socket = L.Class.extend({
 		if (!window.bundlejsLoaded)
 			status += '[!bundlejsLoaded]';
 
-		var color = type === 'OUTGOING' ? 'color:red' : 'color:blue';
+		var color = type === 'OUTGOING' ? 'color:red' : 'color:#2e67cf';
 		window.app.console.log(+new Date() + ' %c' + type + status + '%c: ' + msg.concat(' ').replace(' ', '%c '),
-			     'background:#ddf;color:black', color, 'color:black');
+			     'background:#ddf;color:black', color, 'color:');
 	},
 
 	_queueSlurpEventEmission: function() {


### PR DESCRIPTION
browsers having different themes make it hard to read the logs
this will help make logs more readable irrespective of themes

Signed-off-by: Pranam Lashkari <lpranam@collabora.com>
Change-Id: I9e48f75d0f1ed20221c969db6d4a6ea00910717e


* Target version: distro/collabora/co-21-11 



### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

