### PR TITLE
make cypress tests work also with 16384 columns

### DIFF
--- a/cypress_test/integration_tests/common/calc_helper.js
+++ b/cypress_test/integration_tests/common/calc_helper.js
@@ -149,7 +149,7 @@ function removeTextSelection() {
 					.click(posX, posY + moveY);
 
 				moveY += 1.0;
-				var regex = /A([0-9]+):AMJ\1$/;
+				var regex = /A([0-9]+):(AMJ|XFD)\1$/;
 				return cy.get('input#addressInput')
 					.should('have.prop', 'value')
 					.then(function(value) {
@@ -188,8 +188,12 @@ function selectEntireSheet() {
 			.should('be.visible');
 	});
 
+	var regex = /^A1:(AMJ|XFD)1048576$/;
 	cy.get('input#addressInput')
-		.should('have.prop', 'value', 'A1:AMJ1048576');
+		.should('have.prop', 'value')
+		.then(function(value) {
+			return regex.test(value);
+		});
 
 	cy.log('Selecting entire sheet - end.');
 }

--- a/cypress_test/integration_tests/mobile/calc/calc_mobile_helper.js
+++ b/cypress_test/integration_tests/mobile/calc/calc_mobile_helper.js
@@ -17,8 +17,12 @@ function selectFirstRow() {
 	cy.get('.spreadsheet-cell-resize-marker:nth-of-type(2)')
 		.should('not.be.visible');
 
+	var regex = /^A1:(AMJ|XFD)1$/;
 	cy.get('input#addressInput')
-		.should('have.prop', 'value', 'A1:AMJ1');
+		.should('have.prop', 'value')
+		.then(function(value) {
+			return regex.test(value);
+		});
 }
 
 module.exports.selectFirstRow = selectFirstRow;


### PR DESCRIPTION
Some places tested for AMJ being the last column, but with 16k
columns it's XFD. Without this those tests run in an endless
loop when run with Calc set to 16k columns.

Signed-off-by: Luboš Luňák <l.lunak@centrum.cz>
Change-Id: I6249e0ec975634b60aaf3291e021b74b4aa3cc5d
