### PR TITLE
Show visual indicator for print ranges in Calc (master)

### DIFF
--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -129,9 +129,33 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 				flags[param] = true;
 			});
 			this.requestSheetGeometryData(flags);
+		} else if (textMsg.startsWith('printranges:')) {
+			this._onPrintRangesMsg(textMsg);
 		} else {
 			L.CanvasTileLayer.prototype._onMessage.call(this, textMsg, img);
 		}
+	},
+
+	// This is used to read and parse printranges so that the next
+	// canvas grid paint will show the visual indication of the print range
+	// in the current sheet if any.
+	_onPrintRangesMsg: function (textMsg) {
+		textMsg = textMsg.substr('printranges:'.length);
+		var msgData = JSON.parse(textMsg);
+		if (!msgData['printranges'] || !Array.isArray(msgData['printranges']))
+			return;
+
+		if (!this._printRanges) {
+			this._printRanges = [];
+		}
+
+		msgData['printranges'].forEach(function (sheetPrintRange) {
+			if (typeof sheetPrintRange['sheet'] !== 'number' || !Array.isArray(sheetPrintRange['ranges'])) {
+				return;
+			}
+
+			this._printRanges[sheetPrintRange['sheet']] = sheetPrintRange['ranges'];
+		}, this);
 	},
 
 	_onInvalidateTilesMsg: function (textMsg) {

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -440,6 +440,26 @@ L.TileSectionManager = L.Class.extend({
 			return isRTL ? sectionWidth - xcoord : xcoord;
 		};
 
+		// This is called just before and after the dashed line drawing.
+		var startEndDash = function (ctx2D, end) {
+			// Style the dashed lines.
+			var dashLen = 5;
+			var gapLen = 5;
+
+			// Restart the path to apply the dashed line style.
+			ctx2D.closePath();
+			ctx2D.beginPath();
+			ctx2D.setLineDash(end ? [] : [dashLen, gapLen]);
+		};
+
+		var docLayer = this.sectionProperties.docLayer;
+		var currentPart = docLayer._selectedPart;
+		// Draw the print range with dashed line if singleton to match desktop Calc.
+		var printRange = [];
+		if (docLayer._printRanges && docLayer._printRanges.length > currentPart
+			&& docLayer._printRanges[currentPart].length == 1)
+			printRange = docLayer._printRanges[currentPart][0];
+
 		for (var i = 0; i < ctx.paneBoundsList.length; ++i) {
 			// co-ordinates of this pane in core document pixels
 			var paneBounds = ctx.paneBoundsList[i];
@@ -467,6 +487,7 @@ L.TileSectionManager = L.Class.extend({
 			// as horizontal line rendering: due to cache effects - so to
 			// help our poor CPU renderers - render in horizontal strips.
 			var bandSize = 256;
+			var clearDash = false;
 			for (var miny = repaintArea.min.y; miny < repaintArea.max.y; miny += bandSize)
 			{
 				var maxy = Math.min(repaintArea.max.y, miny + bandSize);
@@ -476,17 +497,36 @@ L.TileSectionManager = L.Class.extend({
 				// vertical lines
 				this.sectionProperties.docLayer.sheetGeometry._columns.forEachInCorePixelRange(
 					repaintArea.min.x, repaintArea.max.x,
-					function(pos) {
+					function(pos, colIndex) {
 						var xcoord = xTransform(Math.floor(scale * (pos - paneOffset.x)) - 0.5);
+
+						clearDash = false;
+						if (printRange.length === 4
+							&& (printRange[0] === colIndex || printRange[2] + 1 === colIndex)) {
+							clearDash = true;
+							startEndDash(context, false /* end? */);
+						}
+
 						context.moveTo(xcoord, Math.floor(scale * (miny - paneOffset.y)) + 0.5);
 						context.lineTo(xcoord, Math.floor(scale * (maxy - paneOffset.y)) - 0.5);
 						context.stroke();
+
+						if (clearDash)
+							startEndDash(context, true /* end? */);
 					});
 
 				// horizontal lines
 				this.sectionProperties.docLayer.sheetGeometry._rows.forEachInCorePixelRange(
 					miny, maxy,
-					function(pos) {
+					function(pos, rowIndex) {
+
+						clearDash = false;
+						if (printRange.length === 4
+							&& (printRange[1] === rowIndex || printRange[3] + 1 === rowIndex)) {
+							clearDash = true;
+							startEndDash(context, false /* end? */);
+						}
+
 						context.moveTo(
 							xTransform(Math.floor(scale * (repaintArea.min.x - paneOffset.x)) + 0.5),
 							Math.floor(scale * (pos - paneOffset.y)) - 0.5);
@@ -494,6 +534,9 @@ L.TileSectionManager = L.Class.extend({
 							xTransform(Math.floor(scale * (repaintArea.max.x - paneOffset.x)) - 0.5),
 							Math.floor(scale * (pos - paneOffset.y)) - 0.5);
 						context.stroke();
+
+						if (clearDash)
+							startEndDash(context, true /* end? */);
 					});
 
 				context.closePath();

--- a/browser/src/layer/tile/SheetGeometry.ts
+++ b/browser/src/layer/tile/SheetGeometry.ts
@@ -629,8 +629,8 @@ export class SheetDimension {
 		}.bind(this));
 	}
 
-	// callback with a position for each grid line in this pixel range
-	public forEachInCorePixelRange(startPix: number, endPix: number, callback: ((startPosCorePx: number) => void)): void {
+	// callback with a position and index for each grid line in this pixel range
+	public forEachInCorePixelRange(startPix: number, endPix: number, callback: ((startPosCorePx: number, index: number) => void)): void {
 		this._visibleSizes.forEachSpan(function (spanData: any) {
 			// do we overlap ?
 			var spanFirstCorePx = spanData.data.poscorepx -
@@ -642,8 +642,10 @@ export class SheetDimension {
 					((startPix - spanFirstCorePx) % spanData.data.sizecore));
 				var lastCorePx = Math.min(endPix, spanData.data.poscorepx);
 
+				var index = spanData.start + Math.floor((firstCorePx - spanFirstCorePx) / spanData.data.sizecore);
 				for (var pos = firstCorePx; pos <= lastCorePx; pos += spanData.data.sizecore) {
-					callback(pos);
+					callback(pos, index);
+					index += 1;
 				}
 			}
 		});

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -3017,6 +3017,9 @@ void ChildSession::loKitCallback(const int type, const std::string& payload)
 #endif
         }
         break;
+    case LOK_CALLBACK_PRINT_RANGES:
+        sendTextFrame("printranges: " + payload);
+        break;
     default:
         LOG_ERR("Unknown callback event (" << lokCallbackTypeToString(type) << "): " << payload);
     }


### PR DESCRIPTION
* Target version: master 

### Summary

* Introduce new callback LOK_CALLBACK_PRINT_RANGES
* Read the print ranges for the current sheet from LOK_CALLBACK_PRINT_RANGES message and draw dashed grid lines for the rows/columns bordering the range.

Caveats:

* Desktop calc does not draw print ranges on document load if there are
print ranges set previously on save. Cool also has the same behaviour.

* If there are multiple print ranges in the same sheet desktop calc does
not show any dashed lines indicating the ranges. Cool also adopts this
behaviour for now.

* Styling of the dashed lines was not investigated much for writing this
patch hence it uses the same drawing style as normal grids.



### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

