### PR TITLE
unit-test: fix crash-on-shutdown

### DIFF
--- a/test/UnitTimeout.cpp
+++ b/test/UnitTimeout.cpp
@@ -35,18 +35,23 @@ public:
 
     virtual void returnValue(int & retValue) override
     {
+        bool timedOut = _timedOut;
+        bool setRetValue = _setRetValue;
+        int retVal = _retValue;
+
         UnitWSD::returnValue(retValue); // Always call base.
-        if (!_timedOut)
+        // Note that at this point 'this' is deleted.
+        if (!timedOut)
         {
             LOG_TST("ERROR: Failed to timeout");
             retValue = EX_SOFTWARE;
         }
         else
         {
-            assert(_setRetValue);
-            assert(_retValue == EX_SOFTWARE);
+            assert(setRetValue);
+            assert(retVal == EX_SOFTWARE);
             // we wanted a timeout.
-            LOG_TST("Test passed by timing-out as expected");
+            // Test passed by timing-out as expected.
             retValue = EX_OK;
         }
     }


### PR DESCRIPTION
A problem since c6561a99d8c2a7a7941543dd4655675b6a0a1030 (wsd: test:
correctly stop SocketPoll in UnitTimeout, 2022-04-21), the trouble was
that calling UnitWSD::returnValue() from UnitTimeout::returnValue()
deletes the 'this' pointer, so we need to copy the interesting data
members to the stack before calling the base.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I86583ae516e2b2f367fbf5cb2a9401cc21f1b1cf
