### PR TITLE
use the more efficient getSelectionTypeAndText()

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -1137,11 +1137,12 @@ bool ChildSession::getTextSelection(const StringVector& tokens)
         return true;
     }
 
-    std::string selection;
     getLOKitDocument()->setView(_viewId);
-    const int selectionType = getLOKitDocument()->getSelectionType();
-    if (selectionType == LOK_SELTYPE_LARGE_TEXT || selectionType == LOK_SELTYPE_COMPLEX ||
-        (selection = getTextSelectionInternal(mimeType)).size() >= 1024 * 1024) // Don't return huge data.
+    char* textSelection = nullptr;
+    const int selectionType = getLOKitDocument()->getSelectionTypeAndText(mimeType.c_str(), &textSelection);
+    std::string selection(textSelection ? textSelection : "");
+    free(textSelection);
+    if (selectionType == LOK_SELTYPE_LARGE_TEXT || selectionType == LOK_SELTYPE_COMPLEX)
     {
         // Flag complex data so the client will download async.
         sendTextFrame("complexselection:");


### PR DESCRIPTION
Otherwise calling getSelectionType() first and then getTextSelection()
creates the XTransferable2 twice, and then possibly converts it
to the text format twice, which may be expensive.

Also some cypress tests use selectEntireSheet() and then check
the clipboard contents, which with the switch to 16k columns in Calc
may be slow enough in debug builds when done twice to time out
the test, and this helps a bit there.

Signed-off-by: Luboš Luňák <l.lunak@centrum.cz>
Change-Id: If166f67c216281d32dbb1d3e10b51177b42a9668

This requires https://gerrit.libreoffice.org/c/core/+/134615 .
