### PR TITLE
wsd: browser: handle 413 Entity Too Large from storage

### DIFF
--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -825,6 +825,9 @@ app.definitions.Socket = L.Class.extend({
 			if (command.errorKind === 'savediskfull') {
 				storageError = errorMessages.storage.savediskfull;
 			}
+			else if (command.errorKind === 'savetoolarge') {
+				storageError = errorMessages.storage.savetoolarge;
+			}
 			else if (command.errorKind === 'savefailed') {
 				storageError = errorMessages.storage.savefailed;
 			}

--- a/browser/src/errormessages.js
+++ b/browser/src/errormessages.js
@@ -31,6 +31,7 @@ if (window.ThisIsAMobileApp) {
 	errorMessages.storage = {
 		loadfailed: _('Failed to load document.'),
 		savediskfull: _('Save failed due to no disk space left. Document will now be read-only.'),
+		savetoolarge: _('The document is too large or no disk space left to save. Document will now be read-only.'),
 		saveunauthorized: _('Document cannot be saved due to expired or invalid access token.'),
 		savefailed: _('Document cannot be saved.'),
 		renamefailed: _('Document cannot be renamed.')
@@ -39,6 +40,7 @@ if (window.ThisIsAMobileApp) {
 	errorMessages.storage = {
 		loadfailed: _('Failed to read document from storage. Please contact your storage server (%storageserver) administrator.'),
 		savediskfull: _('Save failed due to no disk space left on storage server. Document will now be read-only. Please contact the server (%storageserver) administrator to continue editing.'),
+		savetoolarge: _('Save failed because the document is too large or disk quota exceeded. Document will now be read-only but you may still download it now to preserve a copy locally. Please contact the server (%storageserver) administrator to resolve the issue.'),
 		saveunauthorized: _('Document cannot be saved due to expired or invalid access token.'),
 		savefailed: _('Document cannot be saved. Check your permissions or contact the storage server administrator.'),
 		renamefailed: _('Document cannot be renamed. Check your permissions or contact the storage server administrator.'),

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -1458,7 +1458,7 @@ WopiStorage::handleUploadToStorageResponse(const WopiUploadDetails& details,
         }
         else if (details.httpResponseCode == Poco::Net::HTTPResponse::HTTP_REQUEST_ENTITY_TOO_LARGE)
         {
-            result.setResult(StorageBase::UploadResult::Result::DISKFULL);
+            result.setResult(StorageBase::UploadResult::Result::TOO_LARGE);
         }
         else if (details.httpResponseCode == Poco::Net::HTTPResponse::HTTP_UNAUTHORIZED
                  || details.httpResponseCode == Poco::Net::HTTPResponse::HTTP_FORBIDDEN)

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -111,9 +111,10 @@ public:
         {
             OK = 0,
             DISKFULL,
-            UNAUTHORIZED,
+            TOO_LARGE, //< 413
+            UNAUTHORIZED, //< 401, 403
             DOC_CHANGED, /**< Document changed in storage */
-            CONFLICT,
+            CONFLICT, //< 409
             FAILED
         };
 


### PR DESCRIPTION
It seems at least some storage hosts report disk-full
errors via 413. This logic of handling 413 error as
disk-full was introduced in
https://github.com/CollaboraOnline/online/commit/f8e0b8c11e94810fdde73f8b4d27b80a989670cb.

Here we handle 413 as it is defined, as Entity Too Large.