### PR TITLE
wds: enable experimental blocks unconditionally

### DIFF
--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -1293,7 +1293,7 @@ protected:
         // FIXME: need to close input, but not output (?)
         bool closed = (events & (POLLHUP | POLLERR | POLLNVAL));
 
-        if (!EnableExperimental || events & POLLIN)
+        if (events & POLLIN)
         {
             // readIncomingData returns false only if the read len is 0 (closed).
             // Oddly enough, we don't necessarily get POLLHUP after read(2) returns 0.
@@ -1302,7 +1302,7 @@ protected:
             LOG_TRC('#' << getFD() << " Incoming data buffer " << _inBuffer.size()
                         << " bytes, closeSocket? " << closed << ", events: " << std::hex << events
                         << std::dec);
-            if (EnableExperimental && closed && reading)
+            if (closed && reading)
             {
                 // We might have outstanding data to read, wait until readIncomingData returns false.
                 LOG_DBG('#' << getFD() << ": Closed but will drain incoming data per POLLIN.");
@@ -1367,7 +1367,7 @@ protected:
                 if (writeOutgoingData() < 0)
                 {
                     const int last_errno = errno;
-                    if (last_errno == EPIPE || (EnableExperimental && last_errno == ECONNRESET))
+                    if (last_errno == EPIPE || last_errno == ECONNRESET)
                     {
                         LOG_DBG('#' << getFD() << ": Disconnected while writing ("
                                     << Util::symbolicErrno(last_errno)

--- a/net/SslSocket.hpp
+++ b/net/SslSocket.hpp
@@ -177,7 +177,7 @@ public:
         // SSL's needs. Only when SSL is done negotiating
         // (i.e. wants neither to read, nor to write) do we see
         // what data activity we have.
-        if (EnableExperimental && _doHandshake)
+        if (_doHandshake)
         {
             if (_sslWantsTo == SslWantsTo::Write)
             {
@@ -229,18 +229,12 @@ private:
                     return rc != 0;
             }
 
-            if (!EnableExperimental)
-                _doHandshake = false;
-
             if (rc == 1)
             {
                 // Successful handshake; TLS/SSL connection established.
                 LOG_TRC("SSL handshake completed successfully");
-                if (EnableExperimental)
-                {
-                    _doHandshake = false;
-                    _sslWantsTo = SslWantsTo::Neither; // Reset until we are told otherwise.
-                }
+                _doHandshake = false;
+                _sslWantsTo = SslWantsTo::Neither; // Reset until we are told otherwise.
 
                 if (!verifyCertificate())
                 {

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -273,7 +273,7 @@ void DocumentBroker::pollThread()
         _poll->poll(unloading ? SocketPoll::DefaultPollTimeoutMicroS / 16
                               : SocketPoll::DefaultPollTimeoutMicroS);
 
-        if (EnableExperimental && _stop)
+        if (_stop)
         {
             LOG_DBG("Doc [" << _docKey << "] is flagged to stop after returning from poll.");
             break;


### PR DESCRIPTION
This enables code that was protected with
EnableExperimental in the socket logic (and one
case in DocBroker). These changes are now deemed
safe to enable permanently.

Change-Id: Ie62f5d7bd281ade90f38d654b51b104b8d1f14bc
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
