### PR TITLE
Fix Insertcontentcontrols strings on tabbed view

### DIFF
--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -949,7 +949,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 						'children': [
 							{
 								'type': 'toolitem',
-								'text': _UNO('.uno:InsertContentControl', 'text'),
+								'text':  _('Rich Text'),
 								'command': '.uno:InsertContentControl'
 							}
 						]
@@ -959,7 +959,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 						'children': [
 							{
 								'type': 'toolitem',
-								'text': _UNO('.uno:InsertCheckboxContentControl', 'text'),
+								'text': _('Checkbox'),
 								'command': '.uno:InsertCheckboxContentControl'
 							}
 						]


### PR DESCRIPTION
Don't use strings coming from uno commands as they include
"Insert":
1. There is no need to say that these actions will "Insert", they
are already in the Insert tab
2. All other actions do not have Insert so it would be not consistent
3. On top of that with Insert in each icon the labels look quite long

Signed-off-by: Pedro Pinto da Silva <pedro.silva@collabora.com>
Change-Id: I286e95187d5df08cdf2d71bd99f3b77a17ef12ad
