### PR TITLE
Idle typing

### DIFF
--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -308,7 +308,7 @@ L.Control.UIManager = L.Control.extend({
 
 		document.body.setAttribute('data-userInterfaceMode', uiMode.mode);
 
-		this.map.fire('postMessage', {msgId: 'Action_ChangeUIMode_Resp', args: {Mode: uiMode}});
+		this.map.fire('postMessage', {msgId: 'Action_ChangeUIMode_Resp', args: {Mode: uiMode.mode}});
 
 		switch (currentMode) {
 		case 'classic':

--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -680,6 +680,7 @@ app.definitions.Socket = L.Class.extend({
 					msg = _('Idle document - please tap to reload and resume editing');
 				}
 				this._map._documentIdle = true;
+				this._map._docLayer._documentInfo = undefined;
 				postMsgData['Reason'] = 'DocumentIdle';
 				if (textMsg === 'oom')
 					postMsgData['Reason'] = 'OOM';


### PR DESCRIPTION
Reset document info on idle

resetting document info will force to use new status of the document

problem:
reconnecting after idle, user could not type anything in document,
this was due to some properties were to set assuming they existed from last session (i.e: clientzoom)
resetting document info will force to use new status message and set all the properties again correctly


* Target version: master 


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

