### PR TITLE
jsdialog: handle tab key in autofilter popup fixes #4716

### DIFF
--- a/browser/src/control/Control.AutofilterDropdown.js
+++ b/browser/src/control/Control.AutofilterDropdown.js
@@ -78,6 +78,8 @@ L.Control.AutofilterDropdown = L.Control.extend({
 
 			this.builder.setWindowId(null);
 			this.subMenuBuilder.setWindowId(null);
+
+			this.map.focus();
 			return;
 		}
 
@@ -174,6 +176,27 @@ L.Control.AutofilterDropdown = L.Control.extend({
 			L.DomUtil.setStyle(mainContainer, 'margin-left', newLeftPosition + 'px');
 			this.position.x = newLeftPosition;
 		}
+
+		var okButton = mainContainer.querySelector('#ok');
+		if (okButton)
+			okButton.focus();
+
+		// close when focus goes out using 'tab' key
+		var that = this;
+
+		var beginMarker = L.DomUtil.create('div', 'jsdialog autofilter jsdialog-begin-marker');
+		var endMarker = L.DomUtil.create('div', 'jsdialog autofilter jsdialog-end-marker');
+
+		beginMarker.tabIndex = 0;
+		endMarker.tabIndex = 0;
+
+		mainContainer.insertBefore(beginMarker, mainContainer.firstChild);
+		mainContainer.appendChild(endMarker);
+
+		mainContainer.addEventListener('focusin', function(event) {
+			if (event.target == beginMarker || event.target == endMarker)
+				that.onClosePopup();
+		});
 	},
 
 	onJSUpdate: function (e) {
@@ -216,18 +239,8 @@ L.Control.AutofilterDropdown = L.Control.extend({
 	},
 
 	onClosePopup: function() {
-		if (this.container)
-			L.DomUtil.remove(this.container);
-		if (this.subMenu)
-			L.DomUtil.remove(this.subMenu);
-
-		this.container = null;
-		this.subMenu = null;
-
 		if (this.builder.windowId)
 			this.builder.callback('pushbutton', 'click', {id: 'cancel'}, null, this.builder);
-		this.builder.setWindowId(null);
-		this.subMenuBuilder.setWindowId(null);
 	}
 });
 


### PR DESCRIPTION
This added begin and end mark to the popup so we can detect
we are leaving the popup and we should close.

This prevents us from blocking the whole UI by focusing
map and typing before popup was closed.

Also close popup when server confirmed it should be closed.

Fixes #4716
