### PR TITLE
Private/pedro/jsformulabar input height n width

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1169,7 +1169,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 /* formulabar */
 #sc_input_window.formulabar {
 	border: 1px solid var(--color-border);
-	width: 95% !important;
+	flex-grow: 1;
 	resize: none !important;
 	max-width: unset !important;
 	font-size: var(--default-font-size) !important;

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1168,6 +1168,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 
 /* formulabar */
 #sc_input_window.formulabar {
+	height: 29px;
 	border: 1px solid var(--color-border);
 	flex-grow: 1;
 	resize: none !important;


### PR DESCRIPTION
commit bf9754eb3d5b7bedcc3a5a15cb0ebc14d94b7186

Formulabar: fix sc_input_window height (when collapsed)
    
Formula input window (textarea) had different height from address 
input
  - Set it at the same height as seen in toolbar.css:211

----

commit df1dafe3f69d5030f30ab53feeb19126f05f08d6

Fix formulabar width, use flex property
    
Avoid using percentages when we can already use the grow property
(it avoids different results across browsers)
