### PR TITLE
Removed unused CSS related to old formulabar.

### DIFF
--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -212,24 +212,6 @@ w2ui-toolbar {
 	width: 100px;
 }
 
-#formulaInput {
-	height: 29px;
-	width: 100%;
-}
-
-#calc-inputbar-wrapper {
-	display: block;
-	border: none;
-}
-
-#calc-inputbar {
-	display: block;
-	width: 100%;
-	position: relative;
-	padding: 0px;
-	margin: 0px;
-}
-
 #tb_formulabar_item_formula {
 	width: 100%;
 	padding-top: 4px;


### PR DESCRIPTION
Resolves: Issue #4821
Target version: master

Summary
Removed CSS bits that are targeting elements that do not exist anymore and were left over from the formulabar in the browser calc editor being converted from html canvas to normal. Expected there to be more unused bits, but everything else was in use.

TODO:
N/A

Checklist
[x] Code is properly formatted
[x] All commits have Change-Id
[x] I have run tests with make check
[x] I have issued make run and manually verified that everything looks okay
[x] Documentation (manuals or wiki) has been updated or is not required
Signed-off-by: Dekota Nelson [nelson.dekota@gmail.com](mailto:nelson.dekota@gmail.com)

