### PR TITLE
private/pedro/fomulabar unotoolbutton n expander improvements

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1193,3 +1193,10 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	width: 24px !important;
 	min-width: unset !important;
 }
+
+#expand.formulabar {
+	height: 29px !important;
+	margin: 0 5px 0 0 !important;
+	border-radius: 0 !important;
+	border-inline-start-color: transparent;
+}

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1180,6 +1180,10 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	height: 72px !important;
 }
 
+.expanded .formulabar.unotoolbutton {
+	margin-block-start: 2px;
+}
+
 .formulabar.unotoolbutton {
 	margin-inline-end: 4px !important;
 }

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1184,7 +1184,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	margin-inline-end: 4px !important;
 }
 
-.formulabar.unotoolbutton:not(.has-dropdown), .formulabar.unotoolbutton img, .formulabar.ui-pushbutton {
+.formulabar.unotoolbutton img, .formulabar.ui-pushbutton {
 	height: 24px !important;
 	width: 24px !important;
 	min-width: unset !important;

--- a/browser/src/control/Control.FormulaBarJSDialog.js
+++ b/browser/src/control/Control.FormulaBarJSDialog.js
@@ -100,6 +100,7 @@ L.Control.FormulaBarJSDialog = L.Control.extend({
 	toggleMultiLine: function(input) {
 		if (L.DomUtil.hasClass(input, 'expanded')) {
 			L.DomUtil.removeClass(input, 'expanded');
+			L.DomUtil.removeClass(L.DomUtil.get('calc-inputbar-wrapper'), 'expanded');
 			this.onJSUpdate({
 				data: {
 					jsontype: 'formulabar',
@@ -115,6 +116,7 @@ L.Control.FormulaBarJSDialog = L.Control.extend({
 			});
 		} else {
 			L.DomUtil.addClass(input, 'expanded');
+			L.DomUtil.addClass(L.DomUtil.get('calc-inputbar-wrapper'), 'expanded');
 			this.onJSUpdate({
 				data: {
 					jsontype: 'formulabar',


### PR DESCRIPTION
- Formulabar: don't force img parent to be a certain size
- Formulabar: Fix unotoolbutton juggling
- Formulabar: Make expander look like it's attached to input
