### PR TITLE
private/vmiklos/master

### DIFF
--- a/fuzzer/ClientSession.cpp
+++ b/fuzzer/ClientSession.cpp
@@ -41,6 +41,9 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
         session->handleMessage(lineVector);
     }
 
+    // The DocumentBroker dtor grows SocketPoll::_newCallbacks.
+    docBroker.reset();
+
     // Make sure SocketPoll::_newCallbacks does not grow forever, leading to OOM.
     Admin::instance().poll(std::chrono::microseconds(0));
 

--- a/test/UnitFuzz.cpp
+++ b/test/UnitFuzz.cpp
@@ -26,6 +26,7 @@ class UnitFuzz : public UnitWSD
     std::uniform_int_distribution<> _dist;
 public:
     UnitFuzz() :
+        UnitWSD("fuzz"),
         _mt(_rd()),
         _dist(0, 1000)
     {
@@ -118,7 +119,7 @@ public:
 class UnitKitFuzz : public UnitKit
 {
 public:
-    UnitKitFuzz()
+    UnitKitFuzz() : UnitKit("fuzz")
     {
         std::cerr << "\n\nYour Kit process has fuzzing hooks\n\n\n";
         setTimeout(std::chrono::hours(1));


### PR DESCRIPTION
- fuzz: cleanup constructors.
- client session fuzzer: try harder to empty SocketPoll::_newCallbacks on shutdown
