### PR TITLE
fuzzers: avoid setcap

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1239,10 +1239,10 @@ if test -n "$with_user_id"; then
 fi
 AC_DEFINE_UNQUOTED([COOL_USER_ID],["$COOL_USER_ID"],[The user-name which is allowed to run coolwsd and its tools])
 
-AM_CONDITIONAL([ENABLE_SETCAP], [test "$enable_setcap" != "no" -a `uname -s` = "Linux"])
+AM_CONDITIONAL([ENABLE_SETCAP], [test "$enable_setcap" != "no" -a `uname -s` = "Linux" -a "$enable_fuzzers" != "yes"])
 
 ENABLE_SETCAP=
-if test "$enable_setcap" != "no" -a `uname -s` = "Linux"; then
+if test "$enable_setcap" != "no" -a `uname -s` = "Linux" -a "$enable_fuzzers" != "yes"; then
     ENABLE_SETCAP=true
     setcap_msg="setcap enabled"
 else


### PR DESCRIPTION
fuzzers use the code as a library, so we don't produce binaries like
coolwsd in such a config, leading to:

	Failed to set capabilities on file `coolforkit' (No such file or directory)

when building from scratch.

Just disable setcap in the fuzzers case, it's fine to not have these
binaries.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I178ec7d8fa4d582e5d7289764a6ce2227c049205
