### PR TITLE
jsdialog: use correct codes for shortcuts CTRL + char

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -1492,8 +1492,16 @@ L.Control.JSDialogBuilder = L.Control.extend({
 					event.key === 'Backspace' ||
 					event.key === 'Space') {
 					// skip
-				} else
-					builder.callback('edit', 'keypress', edit, event.keyCode, builder);
+				} else {
+					var keyCode = event.keyCode;
+					if (event.ctrlKey) {
+						keyCode = event.key.toUpperCase().charCodeAt(0);
+						keyCode = builder.map.keyboard._toUNOKeyCode(keyCode);
+						keyCode |= UNOModifier.CTRL;
+					}
+
+					builder.callback('edit', 'keypress', edit, keyCode, builder);
+				}
 
 				event.preventDefault();
 			});


### PR DESCRIPTION
Handles for example: CTRL + "i" in the formulabar what triggers italic font

we should do the same for other modifiers: shift, alt...