### PR TITLE
Sidebar use inline elements for RTL and simplyfication

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -3,6 +3,11 @@
 	text-transform: none !important;
 }
 
+#sidebar-panel {
+	padding: 0px;
+	margin-inline: 8px;
+}
+
 .sidebar .ui-content .unobutton {
 	margin: 0;
 	width: 24px;
@@ -89,12 +94,7 @@
 .sidebar.ui-expander {
 	display: flex;
 	justify-content: space-between;
-	width: calc(100% - 10px);
 	align-items: center;
-}
-
-.sidebar.ui-expander-content {
-	width: calc(100% - 10px);
 }
 
 #selectcolor {
@@ -206,8 +206,7 @@ div#thousandseparator.checkbutton.jsdialog.sidebar {
 	color: var(--color-main-text);
 	font-size: var(--header-font-size);
 	line-height: var(--header-height);
-	padding-left: 8px;
-	padding-right: 8px; /* for RTL mode */
+	padding-inline: 4px;
 }
 
 .sidebar.root-container.jsdialog > .jsdialog.sidebar {


### PR DESCRIPTION
sidebar-panel get margin-inline: 8px;
therefore with: calc(100% - 10px); isn't needed anymore

instead of padding-left and padding-right we use
padding-inline for RTL support

| before | after |
| --------- | ----- |
|![Screenshot_20220602_010305](https://user-images.githubusercontent.com/8517736/171517032-8fed6b34-dc55-4d9c-b569-5d06d470ac3b.png) | ![Screenshot_20220602_011205](https://user-images.githubusercontent.com/8517736/171517057-2521d440-f9e7-45f6-bee1-a59af59555f4.png)|

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: Ic718fb80dcdeddc679eb7a961cc67bb7714677cd