### PR TITLE
wsd: handle socket closed on read better

### DIFF
--- a/net/SslSocket.hpp
+++ b/net/SslSocket.hpp
@@ -113,13 +113,13 @@ public:
         Socket::shutdown();
     }
 
-    bool readIncomingData() override
+    int readIncomingData() override
     {
         ASSERT_CORRECT_SOCKET_THREAD(this);
 
         const int rc = doHandshake();
         if (rc <= 0)
-            return rc != 0;
+            return rc;
 
         // Default implementation.
         return StreamSocket::readIncomingData();


### PR DESCRIPTION
A corner case where read doesn't return 0
on a closed socket can result in a stuck
state where we attempt to read when we
do get ECONNRESET (which we didn't check
on reads).

This makes the interface of readIncomingData
the same as writeOutgoingData by returning
the actual return value of the read syscall.

So now we handle both return 0 as well as
error codes returned on failed calls.

The logic hasn't changed, just that now
we handle errors better and similar to the
write case.

Change-Id: I0b38a63da4e6c92a482948478d5d8d446e0b8b58
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
