### PR TITLE
Add missing Run Macro action to tabbed view

### DIFF
--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -85,6 +85,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 		var hasSaveAs = !this._map['wopi'].UserCanNotWriteRelative;
 		var hasShare = this._map['wopi'].EnableShare;
 		var hasGroupedDownloadAs = !!window.groupDownloadAsForNb;
+		var hasRunMacro = !(window.enableMacrosExecution  === 'false');
 
 		var content = [
 			{
@@ -132,6 +133,18 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 					'type': 'bigtoolitem',
 					'text': _UNO('.uno:Print', 'spreadsheet'),
 					'command': '.uno:Print'
+				} : {},
+			hasRunMacro ?
+				{
+					'type': 'toolbox',
+					'children': [
+						{
+							'id': 'runmacro',
+							'type': 'bigtoolitem',
+							'text': _UNO('.uno:RunMacro', 'text'),
+							'command': '.uno:RunMacro'
+						}
+					]
 				} : {}
 		];
 

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -141,6 +141,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 		var hasSaveAs = !this._map['wopi'].UserCanNotWriteRelative;
 		var hasShare = this._map['wopi'].EnableShare;
 		var hasGroupedDownloadAs = !!window.groupDownloadAsForNb;
+		var hasRunMacro = !(window.enableMacrosExecution  === 'false');
 
 		var content = [
 			{
@@ -188,6 +189,18 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 					'type': 'bigtoolitem',
 					'text': _UNO('.uno:Print', 'presentation'),
 					'command': '.uno:Print'
+				} : {},
+			hasRunMacro ?
+				{
+					'type': 'toolbox',
+					'children': [
+						{
+							'id': 'runmacro',
+							'type': 'bigtoolitem',
+							'text': _UNO('.uno:RunMacro', 'text'),
+							'command': '.uno:RunMacro'
+						}
+					]
 				} : {}
 		];
 

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -99,6 +99,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 		var hasSaveAs = !this._map['wopi'].UserCanNotWriteRelative;
 		var hasShare = this._map['wopi'].EnableShare;
 		var hasGroupedDownloadAs = !!window.groupDownloadAsForNb;
+		var hasRunMacro = !(window.enableMacrosExecution  === 'false');
 
 		var content = [
 			{
@@ -145,6 +146,18 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 					'type': 'bigtoolitem',
 					'text': _UNO('.uno:Print', 'text'),
 					'command': '.uno:Print'
+				} : {},
+			hasRunMacro ?
+				{
+					'type': 'toolbox',
+					'children': [
+						{
+							'id': 'runmacro',
+							'type': 'bigtoolitem',
+							'text': _UNO('.uno:RunMacro', 'text'),
+							'command': '.uno:RunMacro'
+						}
+					]
 				} : {}
 		];
 


### PR DESCRIPTION
- Only visible when macros is switched on (coolwsd.xml)
- Added to the File tab because:
  - We do not have Tools tab and it seems we do not have a need or
  more > 1 action that justifies an yet another new tab
  - Run Macro could fall into Review or insert category but and
  since the icon when pressed Runs a Macro, best to place it
  within File tab since it affects the file. Plus user that is used
  to operate within classic view it's more likely to go to File tab

Signed-off-by: Pedro Pinto da Silva <pedro.silva@collabora.com>
Change-Id: I8110fc259860d285f0c911b9b553bdc67235f4e2
