### PR TITLE
ignore if comment is selected while pasting

### DIFF
--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -515,7 +515,7 @@ L.Clipboard = L.Class.extend({
 		if (isAnyVexDialogActive() && !(this.pasteSpecialVex && this.pasteSpecialVex.isOpen))
 			return true;
 
-		if ($('.annotation-active').length)
+		if ($('.annotation-active').length && $('.cool-annotation-edit').is(':visible'))
 		    return true;
 
 		return false;


### PR DESCRIPTION
if comment is selected but is not in editing,
proceed to normal pasting in document

problem:
while pasting content multiple times with comment,
previously pasted comment stays selected and can't further normally

Signed-off-by: Pranam Lashkari <lpranam@collabora.com>
Change-Id: Ia594c725f4fe7108d6aea1591d88b2c306202be3


* Target version: master 

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

