### PR TITLE
cypress: re-enable impress/table_operation_spec.js

### DIFF
--- a/cypress_test/integration_tests/mobile/impress/table_operation_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/table_operation_spec.js
@@ -104,8 +104,15 @@ describe('Table Operation', function() {
 			.should('have.attr', 'y', '5644');
 	});
 
-	it.skip('Insert column before.', function() {
+	it('Insert column before.', function() {
 		selectFullTable();
+
+		helper.typeIntoDocument('{downarrow}');
+
+		clickOnTableOperation('deleterows');
+
+		cy.get('.leaflet-marker-icon.table-row-resize-marker')
+			.should('have.length', 2);
 
 		clickOnTableOperation('insertcolumnsbefore');
 
@@ -120,7 +127,7 @@ describe('Table Operation', function() {
 		//assert the number of cells
 		cy.get('g.Page path[fill^="rgb"]')
 			.should(function(cells) {
-				expect(cells).to.have.lengthOf(9);
+				expect(cells).to.have.lengthOf(6);
 			});
 
 		cy.get('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition')
@@ -130,8 +137,15 @@ describe('Table Operation', function() {
 			.should('have.attr', 'y', '5644');
 	});
 
-	it.skip('Insert column after.', function() {
+	it('Insert column after.', function() {
 		selectFullTable();
+
+		helper.typeIntoDocument('{downarrow}');
+
+		clickOnTableOperation('deleterows');
+
+		cy.get('.leaflet-marker-icon.table-row-resize-marker')
+			.should('have.length', 2);
 
 		clickOnTableOperation('insertcolumnsafter');
 
@@ -146,7 +160,7 @@ describe('Table Operation', function() {
 		//assert the number of cells
 		cy.get('g.Page path[fill^="rgb"]')
 			.should(function(cells) {
-				expect(cells).to.have.lengthOf(9);
+				expect(cells).to.have.lengthOf(6);
 			});
 
 		cy.get('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition')


### PR DESCRIPTION
modify the test to use 2x2 table when testing 'insert column before/after' tests
no idea why we don't get svg when there is 3x2 table

Signed-off-by: Rash419 <rashesh.padia@collabora.com>
Change-Id: Id927fede691c4483206fa2b65c450f11cc980581
* Target version: master 

