### PR TITLE
jsdialog: focus map after popup is closed

### DIFF
--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -78,8 +78,10 @@ L.Control.JSDialog = L.Control.extend({
 			else
 				builder.callback('popover', 'close', {id: '__POPOVER__'}, null, builder);
 		}
-		else
+		else {
 			this.clearDialog(id);
+			this.map.focus();
+		}
 	},
 
 	setTabs: function(tabs, builder) {


### PR DESCRIPTION
So we can type after we closed popup in the sidebar.