### PR TITLE
Revert "browser: css: add '#lokit-logo' style to fetch lokit-extra-img.svg"

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -892,17 +892,6 @@ nav.spreadsheet-color-indicator ~ #sidebar-dock-wrapper {
 	background-size: 82px;
 	background-position: right center;
 }
-
-#lokit-logo {
-	align-items: center;
-	justify-content: right;
-	flex-grow: 1;
-	background-repeat: no-repeat;
-	background-size: 82px;
-	background-position: right center;
-	background-image: url('remote/lokit-extra-img.svg');
-}
-
 #about-dialog-info-container {
 	align-items: center;
 	justify-content: flex-start;


### PR DESCRIPTION
This reverts commit dd83984896d62f8c0441b2058cffa5e9d6e7ce0c.

The logo style already exists and to avoid override rule.
