### PR TITLE
wsd: alias: fix a case when regex with '*' is added in host tag of al…

### DIFF
--- a/common/Util.cpp
+++ b/common/Util.cpp
@@ -1161,6 +1161,39 @@ namespace Util
 
         return std::string();
     }
+
+    std::string getValue(const std::set<std::string>& set, const std::string& subject)
+    {
+        auto search = set.find(subject);
+        if (search != set.end())
+        {
+            return *search;
+        }
+
+        // Not a perfect match, try regex.
+        for (const auto& value : set)
+        {
+            try
+            {
+                // Not performance critical to warrant caching.
+                Poco::RegularExpression re(value, Poco::RegularExpression::RE_CASELESS);
+                Poco::RegularExpression::Match reMatch;
+
+                // Must be a full match.
+                if (re.match(subject, reMatch) && reMatch.offset == 0 &&
+                    reMatch.length == subject.size())
+                {
+                    return value;
+                }
+            }
+            catch (const std::exception& exc)
+            {
+                // Nothing to do; skip.
+            }
+        }
+
+        return std::string();
+    }
 }
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -1030,6 +1030,8 @@ int main(int argc, char**argv)
     /// Mainly used to match WOPI hosts patterns
     std::string getValue(const std::map<std::string, std::string>& map, const std::string& subject);
 
+    std::string getValue(const std::set<std::string>& set, const std::string& subject);
+
     /// Given one or more patterns to allow, and one or more to deny,
     /// the match member will return true if, and only if, the subject
     /// matches the allowed list, but not the deny.

--- a/wsd/HostUtil.hpp
+++ b/wsd/HostUtil.hpp
@@ -21,6 +21,8 @@ private:
     static std::map<std::string, std::string> AliasHosts;
     /// When group configuration is not defined only the firstHost gets access
     static std::string FirstHost;
+    /// list of host (not aliases) in alias_groups
+    static std::set<std::string> hostList;
 
     static bool WopiEnabled;
 


### PR DESCRIPTION
…ias_group

if added regex in host has '*' in it and group has no aliases, when we receive first request from host pattern we considered it as original host and all the host following first request which matches the pattern are considered as aliases
for example:
<group>
	<host>https://.*:80</host>
</group>
if we receives first request from asustuf then behaviour will similar to the following config:
<group>
	<host>https://asustuf:80</host>
	<alias>https://.*:80</alias>
</group>

Signed-off-by: Rash419 <rashesh.padia@collabora.com>
Change-Id: I70fb91a4bb7bf38ed79db9efd9fe4bc46db325e1
