### PR TITLE
wsd: fetch external resource in debug build, but not for unit tests

### DIFF
--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -2396,10 +2396,12 @@ void COOLWSD::innerInitialize(Application& self)
                   << getServiceURI("/hosting/discovery") << '\n';
 
     std::cerr << std::endl;
-#else
-    // ---------------- from here on we start getting external messages ----------------
-    FileServerRequestHandler::fetchExternal();
 #endif
+    if (!UnitWSD::isUnitTesting())
+    {
+        // ---------------- from here on we start getting external messages ----------------
+        FileServerRequestHandler::fetchExternal();
+    }
 
 #endif
 }


### PR DESCRIPTION
Signed-off-by: Andras Timar <andras.timar@collabora.com>
Change-Id: I208dce052ba02a4ccfc283fbb5ff3af8d8bf38bb


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

