### PR TITLE
jsdialog: correct popup close in 21.11

### DIFF
--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -68,6 +68,13 @@ L.Control.JSDialog = L.Control.extend({
 		var builder = this.dialogs[id].builder;
 
 		if (sendCloseEvent) {
+			// try to toggle the dropdown first
+			if (clickToClose && L.DomUtil.hasClass(clickToClose, 'has-dropdown')) {
+				var dropdownArrow = clickToClose.querySelector('.arrowbackground');
+				dropdownArrow.click();
+				return;
+			}
+
 			if (clickToClose && L.DomUtil.hasClass(clickToClose, 'menubutton'))
 				clickToClose.click();
 			else
@@ -239,6 +246,8 @@ L.Control.JSDialog = L.Control.extend({
 		if (clickToCloseId && clickToCloseId.indexOf('.uno:') === 0)
 			clickToCloseId = clickToCloseId.substr('.uno:'.length);
 
+		var popupParent = data.popupParent ? L.DomUtil.get(data.popupParent) : null;
+
 		var setupPosition = function(force) {
 			if (isModalPopup && data.popupParent) {
 				// in case of toolbox we want to create popup positioned by toolitem not toolbox
@@ -324,13 +333,24 @@ L.Control.JSDialog = L.Control.extend({
 				console.error('cannot get focus for widget: "' + focusWidgetId + '"');
 		};
 
+		var clickToCloseElement = null;
+		if (clickToCloseId && popupParent) {
+			clickToCloseElement = popupParent.querySelector('[id=\'' + clickToCloseId + '\']');
+			// we avoid duplicated ids in unotoolbuttons - try with class
+			if (!clickToCloseElement)
+				clickToCloseElement = popupParent.querySelector('.uno' + clickToCloseId);
+		} else if (clickToCloseId) {
+			// fallback
+			clickToCloseElement = L.DomUtil.get(clickToCloseId);
+		}
+
 		this.dialogs[data.id] = {
 			container: container,
 			builder: builder,
 			tabs: tabs,
 			startX: posX,
 			startY: posY,
-			clickToClose: clickToCloseId ? L.DomUtil.get(clickToCloseId) : null,
+			clickToClose: clickToCloseElement,
 			overlay: overlay,
 			isPopup: isModalPopup,
 			invalidated: false,


### PR DESCRIPTION
    jsdialog: be sure popup overlay will not block user
    
    Don't add multiple overlays with the same id.
    Remove overlay always when it exists and we close.
    Close dropdown entires by dropdown click - specific to 21.11
    where popups in the core are handled differently.

------------------------------------------------------------------------------------------------------------

    jsdialog: use correct element to close popup
    
    For toolitems with dropdowns we should toggle the button.
    Use correct parent so we don't use button from other component.
    Later we send toggle event to properly close the popup on the server.
    
    example: Calc sidebar, Underline popup
    Before this patch when we clicked in outside the popup it dissapeared
    but app was completly blocked.