### PR TITLE
cursor: hide current not all

### DIFF
--- a/browser/src/layer/marker/Cursor.ts
+++ b/browser/src/layer/marker/Cursor.ts
@@ -99,9 +99,9 @@ class Cursor {
 
 	addCursorClass(visible: boolean) {
 		if (visible)
-			$('.leaflet-cursor').removeClass('blinking-cursor-hidden');
+			L.DomUtil.removeClass(this.cursor, 'blinking-cursor-hidden');
 		else
-			$('.leaflet-cursor').addClass('blinking-cursor-hidden');
+			L.DomUtil.addClass(this.cursor, 'blinking-cursor-hidden');
 	}
 
 	isVisible(): boolean {


### PR DESCRIPTION
when other view moved cursor outside out view - all of
them were hidden because we used selector for all the
elements matching cursor class - instead of current
instance