### PR TITLE
Fix blinking dialog & warnings about notebookbar in Impress (21.11)

### DIFF
--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -24,6 +24,7 @@ L.Control.Notebookbar = L.Control.extend({
 		// log and test window.ThisIsTheiOSApp = true;
 		this.map = map;
 		this._currentScrollPosition = 0;
+		var docType = this._map.getDocType();
 
 		if (document.documentElement.dir === 'rtl')
 			this._RTL = true;
@@ -53,20 +54,20 @@ L.Control.Notebookbar = L.Control.extend({
 
 		$('#toolbar-wrapper').addClass('hasnotebookbar');
 		$('.main-nav').addClass('hasnotebookbar');
-		$('.main-nav').addClass(this._map.getDocType() + '-color-indicator');
+		$('.main-nav').addClass(docType + '-color-indicator');
 		document.getElementById('document-container').classList.add('notebookbar-active');
 
 		var docLogoHeader = L.DomUtil.create('div', '');
 		docLogoHeader.id = 'document-header';
 
 		var iconClass = 'document-logo';
-		if (this.map._docLayer._docType === 'text') {
+		if (docType === 'text') {
 			iconClass += ' writer-icon-img';
-		} else if (this.map._docLayer._docType === 'spreadsheet') {
+		} else if (docType === 'spreadsheet') {
 			iconClass += ' calc-icon-img';
-		} else if (this.map._docLayer._docType === 'presentation') {
+		} else if (docType === 'presentation') {
 			iconClass += ' impress-icon-img';
-		} else if (this.map._docLayer._docType === 'drawing') {
+		} else if (docType === 'drawing') {
 			iconClass += ' draw-icon-img';
 		}
 		var docLogo = L.DomUtil.create('div', iconClass, docLogoHeader);
@@ -75,8 +76,9 @@ L.Control.Notebookbar = L.Control.extend({
 		$('.main-nav').prepend(docLogoHeader);
 
 		var that = this;
+		var usesNotebookbarWidgetsInCore = docType === 'text' || docType === 'spreadsheet';
 		var retryNotebookbarInit = function() {
-			if (!that.map._isNotebookbarLoadedOnCore) {
+			if (!that.map._isNotebookbarLoadedOnCore && usesNotebookbarWidgetsInCore) {
 				// if notebookbar doesn't have any welded controls it can trigger false alarm here
 				window.app.console.warn('notebookbar might be not initialized, retrying');
 				that.map.sendUnoCommand('.uno:ToolbarMode?Mode:string=notebookbar_online.ui');

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -357,7 +357,7 @@ L.Map.include({
 
 		if (this.uiManager.isUIBlocked())
 			return;
-		if (this.dialog.hasOpenedDialog())
+		if (this.dialog.hasOpenedDialog() && !command.startsWith('.uno:ToolbarMode'))
 			this.dialog.blinkOpenDialog();
 		else if (this.isPermissionEdit() || isAllowedInReadOnly) {
 			if (!this.messageNeedsToBeRedirected(command)) {


### PR DESCRIPTION
notebookbar: retry to activate when needed
    
    Don't generate spam in the console log with warnings about not
    activated notebookbar in apps where we don't use any welded widgets.



Allow to send view mode command when dialog is opened
    
    We automatically send notebookbar activation command in some cases.
    Allow this command when dialog is opened and don't blink.