### PR TITLE
Calc font list in sidebar loses focus (21.11)

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -3576,7 +3576,14 @@ L.CanvasTileLayer = L.Layer.extend({
 	},
 
 	_isAnyInputFocused: function() {
-		return $('input:focus').length > 0;
+		var hasTunneledDialogOpened = this._map.dialog ? this._map.dialog.hasOpenedDialog() : false;
+		var hasJSDialogOpened = this._map.jsdialog ? this._map.jsdialog.hasDialogOpened() : false;
+		var hasJSDialogFocused = L.DomUtil.hasClass(document.activeElement, 'jsdialog');
+		var commentHasFocus = app.view.commentHasFocus;
+		var inputHasFocus = $('input:focus').length > 0 || $('textarea.jsdialog:focus').length > 0;
+
+		return hasTunneledDialogOpened || hasJSDialogOpened || hasJSDialogFocused
+			|| commentHasFocus || inputHasFocus;
 	},
 
 	// enable or disable blinking cursor and  the cursor overlay depending on
@@ -4271,10 +4278,7 @@ L.CanvasTileLayer = L.Layer.extend({
 
 			this._addDropDownMarker();
 
-			var hasTunneledDialogOpened = this._map.dialog ? this._map.dialog.hasOpenedDialog() : false;
-			var hasJSDialogOpened = this._map.jsdialog ? this._map.jsdialog.hasDialogOpened() : false;
-
-			var dontFocusDocument = hasTunneledDialogOpened || hasJSDialogOpened || app.view.commentHasFocus || this._isAnyInputFocused();
+			var dontFocusDocument = this._isAnyInputFocused();
 
 			// when the cell cursor is moving, the user is in the document,
 			// and the focus should leave the cell input bar

--- a/browser/src/map/Map.js
+++ b/browser/src/map/Map.js
@@ -1377,7 +1377,7 @@ L.Map = L.Evented.extend({
 				app.socket.sendMessage('useractive');
 				this._active = true;
 				var docLayer = this._docLayer;
-				if (docLayer.isCalc() && docLayer.options.sheetGeometryDataEnabled) {
+				if (docLayer && docLayer.isCalc() && docLayer.options.sheetGeometryDataEnabled) {
 					docLayer.requestSheetGeometryData();
 				}
 				app.socket.sendMessage('commandvalues command=.uno:ViewAnnotations');


### PR DESCRIPTION
- Open eg. the hello world spreadsheet,
- In the sidebar, open the font list, and wait a few seconds.

The font list closes. If you reopen it, it closes immediately, this can go on a few times, then it stays on as expected.
