### PR TITLE
Promote content control properties to bigtoolitem in tabbed view

### DIFF
--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -1020,20 +1020,10 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				'vertical': 'true'
 			},
 			{
-				'type': 'container',
-				'children': [
-					{
-						'type': 'toolbox',
-						'children': [
-							{
-								'type': 'toolitem',
-								'text': _('Content Control Properties'),
-								'command': '.uno:ContentControlProperties'
-							}
-						]
-					},
-				],
-				'vertical': 'true'
+				'id': 'ContentControlProperties',
+				'type': 'bigtoolitem',
+				'text': _('Content Control Properties'),
+				'command': '.uno:ContentControlProperties'
 			},
 		];
 


### PR DESCRIPTION
Content control properties is not stacked on top of any other button
and it will probably never be. Promote it to bigtoolitem so it can use
more vertical space

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I39b624b3930611f91f98d413646062a773183eec
