### PR TITLE
Sidebar padding-inline instead of -left -right for RTL support

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -195,8 +195,7 @@ div#thousandseparator.checkbutton.jsdialog.sidebar {
 	color: var(--color-main-text);
 	font-size: var(--header-font-size);
 	line-height: var(--header-height);
-	padding-left: 8px;
-	padding-right: 8px; /* for RTL mode */
+	padding-inline: 8px;
 }
 
 .sidebar.root-container.jsdialog > .jsdialog.sidebar {


### PR DESCRIPTION
No visual change only switch from `padding-left` and `-right` to `padding-inline`

`padding-inline` was supported by all browsers
https://developer.mozilla.org/en-US/docs/Web/CSS/padding-inline

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: Ib694d2acf60b2f0058f5ef0633e19aa086498c77