### PR TITLE
Sidebar .ui-expander-content have left and right same padding

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -89,12 +89,11 @@
 .sidebar.ui-expander {
 	display: flex;
 	justify-content: space-between;
-	width: calc(100% - 10px);
 	align-items: center;
 }
 
 .sidebar.ui-expander-content {
-	width: calc(100% - 10px);
+	padding-inline: 10px;
 }
 
 #selectcolor {
@@ -291,6 +290,7 @@ td.jsdialog .jsdialog.cell.sidebar {
 	display: block;
 	width: 10px;
 	height: 10px;
+	margin-inline-end: 10px;
 }
 
 .ui-expander.jsdialog.sidebar .ui-expander-icon-right img {


### PR DESCRIPTION
The left padding was there before and is needed for the scrollbar. I suggest to have also an right padding so that the sidebar expander-content elements are better visual interacting with the ui-expander.

![image](https://user-images.githubusercontent.com/8517736/173697632-917fcb8f-9147-4b1b-822c-9c9b916c2a87.png)

Also for the ui-expander (header area) the width calculation was removed, cause than the separator line was not 100% of the sidebar. To have the img for the dialog button not hidden by an scrollbar the 10px was added as marign-inline-end element.

![image](https://user-images.githubusercontent.com/8517736/173698338-9de08b1d-9a1e-45ec-a01a-041d23147b3d.png)

As you can see the light bottom border line was 100% of the sidebar width and didn't stop 10px before.

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: Ifbeecbaef00963498ac3a1bafd2a42075856d9ca