### PR TITLE
Fix images' alignment within pushbutton control, add flex classes

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -14,6 +14,31 @@
 	/* Shared color for cell and selection border */
 	--cell-cursor-selection-border-color: var(--color-primary);
 }
+
+/* Flexbox */
+.d-flex {
+	display: flex;
+}
+.flex-column {
+	/* Initial value */
+	flex-direction: column;
+}
+.flex-row {
+	flex-direction: row;
+}
+.align-items-center {
+	align-items: center;
+}
+.justify-items-center {
+	justify-items: center;
+}
+.align-content-center {
+	align-content: center;
+}
+.justify-content-center {
+	justify-content: center;
+}
+
 /* clip technique: hide visually but keep it available to screen readers */
 .visuallyhidden {
 	border: 0;

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -1541,14 +1541,17 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		var pushbuttonText = builder._customPushButtonTextForId(data.id) !== '' ? builder._customPushButtonTextForId(data.id) : builder._cleanText(data.text);
 
 		if (data.image && pushbuttonText !== '') {
+			L.DomUtil.addClass(pushbutton, 'has-img d-flex align-content-center justify-content-center align-items-center');
 			var image = L.DomUtil.create('img', '', pushbutton);
 			image.src = data.image;
 			var text = L.DomUtil.create('span', '', pushbutton);
 			text.innerText = pushbuttonText;
 		} else if (data.image) {
+			L.DomUtil.addClass(pushbutton, 'has-img d-flex align-content-center justify-content-center align-items-center');
 			var image = L.DomUtil.create('img', '', pushbutton);
 			image.src = data.image;
 		} else if (data.symbol) {
+			L.DomUtil.addClass(pushbutton, 'has-img d-flex align-content-center justify-content-center align-items-center');
 			var image = L.DomUtil.create('img', '', pushbutton);
 			image.src = L.LOUtil.getImageURL('symbol_' + data.symbol + '.svg');
 		} else {


### PR DESCRIPTION
Bug
- pushbuttons with images get misaligned. Namely the inner image that
it's position well. Visible in some places within the sidebar
impress, calc:
https://archive.org/download/bug-pushbutton-with-img-alignments/bug-pushbutton-with-img-alignments.png

Fix
- Pushbuttons with images are now classified with .has-img and inherit
the respective global flexbox CSS classes.
  - Add global flex box CSS classes so we can avoid code duplication
- Also make sure other pushbuttons with image don't butchered with this
change (e.g. calc > pivot table dialog)

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ie37680eb02c15417c505402074bbe01d302910cb
