### PR TITLE
wsd: fix: use only alias_groups entries when defined

### DIFF
--- a/wsd/HostUtil.cpp
+++ b/wsd/HostUtil.cpp
@@ -59,6 +59,8 @@ bool HostUtil::allowedWopiHost(const std::string& host)
 
 void HostUtil::parseAliases(Poco::Util::LayeredConfiguration& conf)
 {
+    WopiEnabled = conf.getBool("storage.wopi[@allow]", false);
+
     //set alias_groups mode to compat
     if (!conf.has("storage.wopi.alias_groups"))
     {

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -90,7 +90,11 @@ void StorageBase::initialize()
     const auto& app = Poco::Util::Application::instance();
     FilesystemEnabled = app.config().getBool("storage.filesystem[@allow]", false);
 
-    HostUtil::parseWopiHost(app.config());
+    //parse wopi.storage.host only when there is no storage.wopi.alias_groups entry in config
+    if (!app.config().has("storage.wopi.alias_groups"))
+    {
+        HostUtil::parseWopiHost(app.config());
+    }
 
 #ifdef ENABLE_FEATURE_LOCK
     CommandControl::LockManager::parseLockedHost(app.config());


### PR DESCRIPTION
…_groups entry in config

Signed-off-by: Rash419 <rashesh.padia@collabora.com>
Change-Id: I7ea73f147e283077b02bdacb37f8850f7613c0c3

* Target version: master 
It can happen that admin has old configuration (wopi.storage.host) and new configuration (wopi.storage.alais_groups.group) so we should not parse the wopi.storage.host entries at all 