### PR TITLE
browser: add fzstd lib

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -167,7 +167,8 @@ NODE_MODULES_JS =\
 	node_modules/jquery-contextmenu/dist/jquery.contextMenu.js \
 	node_modules/jquery-ui-dist/jquery-ui.js \
 	node_modules/smartmenus/dist/jquery.smartmenus.js \
-	node_modules/pako/dist/pako_inflate.es5.js
+	node_modules/pako/dist/pako_inflate.es5.js \
+	node_modules/fzstd/umd/index.js
 
 COOL_LIBS_JS =\
 	ResizeObserverPolyfill.js \

--- a/browser/package.json
+++ b/browser/package.json
@@ -21,6 +21,7 @@
     "json-js": "1.1.2",
     "l10n-for-node": "0.0.1",
     "mocha": "8.2.1",
+    "fzstd": "0.0.4",
     "select2": "4.0.13",
     "shrinkpack": "1.0.0-alpha",
     "smartmenus": "1.0.0",


### PR DESCRIPTION
usage

	var decompressed = fzstd.decompress(compressed);
	// Second argument is optional: custom output buffer
	var outBuf = new Uint8Array(100000);

	// IMPORTANT: fzstd will assume the buffer is sufficiently sized, so it
	// will yield corrupt data if the buffer is too small. It is highly
	// recommended to only specify this if you know the maximum output size.
	window.fzstd.decompress(compressed, outBuf);

Change-Id: I0b378f9395b2442bac9f0790f7633e6a6cb0402e
Signed-off-by: Henry Castro <hcastro@collabora.com>
