### PR TITLE
mobilewizard.css #fontsizecombobox.mobile-wizard only

### DIFF
--- a/browser/css/mobilewizard.css
+++ b/browser/css/mobilewizard.css
@@ -39,7 +39,7 @@ span#main-menu-btn-icon {
 	display: flex;
 }
 
-#fontsizecombobox {
+#fontsizecombobox.mobile-wizard {
 	width: 100%;
 }
 


### PR DESCRIPTION
the css rule for #fontsizecombobox at file `mobilewizard.css` change also the behaviour at desktop sidebar so added `.mobile-wizard` and than the rule was for mobile only.

#### Mobile
![Screenshot_20220624_004131](https://user-images.githubusercontent.com/8517736/175427103-94d990c3-110d-4540-80d2-e864bd578cbe.png)

#### Desktop before
![Screenshot_20220624_004035](https://user-images.githubusercontent.com/8517736/175427152-ad40956f-a3ec-49ca-9b1a-f3b22fc91e05.png)

#### Desktop after
![Screenshot_20220624_004046](https://user-images.githubusercontent.com/8517736/175427171-45387493-0b7d-4039-9e60-b7ae5413d1d0.png)

After the change the right alignment work as it should.

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I704857bca49556abebca018ef7a284c7b2159530