### PR TITLE
Sidebar fixed with and no jumping frame in frame no additional padding

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -93,7 +93,16 @@
 }
 
 .sidebar.ui-expander-content {
+	width: 309px;
 	padding-inline: 10px;
+}
+
+/* frame inside frame */
+#ChartElementsPanel .sidebar.ui-expander-content,
+#softedgeframe .sidebar.ui-expander-content,
+#glowframe .sidebar.ui-expander-content {
+	width: 100% !important;
+	padding-inline: 0px;
 }
 
 #selectcolor {
@@ -342,11 +351,6 @@ button#button2.ui-pushbutton.jsdialog.sidebar {
 #writedirection, #backgroundcolor {
 	justify-content: end;
 	margin-right: 0;
-}
-
-#softedgeframe .sidebar.ui-expander-content,
-#glowframe .sidebar.ui-expander-content {
-	width: 100% !important; /* frame inside frame */
 }
 
 #LB_SHADOW_COLOR {


### PR DESCRIPTION
`.sidebar.ui-expander-content` get fixed `with: 309px;`
frame inside frame remove `padding-inline: 10px;`

**fixed with** can be shown best at sidebar table context
**frame inside frame** issue was at effects sidebar section and chart section

#### Before
https://user-images.githubusercontent.com/8517736/175432924-c7167ff5-6857-48f3-8e47-ca94386c410d.mp4

#### After
https://user-images.githubusercontent.com/8517736/175432956-89f621c0-2554-4b60-b039-58c1e5101c99.mp4

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I263bb6cf33337e9dd1471e68142ba909d777d13f