### PR TITLE
Sidebar .toolbox items get flex-end aligned

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -165,7 +165,9 @@ div#thousandseparator.checkbutton.jsdialog.sidebar {
 #document-container ~ #sidebar-dock-wrapper .sidebar.jsdialog.vertical > .sidebar.jsdialog.row > table.sidebar.ui-grid > tr.sidebar > td.sidebar:last-child:not(:first-child),
 .sidebar.jsdialog.cell > #table-box3 > .sidebar.jsdialog.row > .sidebar.jsdialog.cell:last-child,
 .sidebar.jsdialog.cell > #table-box4 > .sidebar.jsdialog.row > .sidebar.jsdialog.cell:last-child,
-.sidebar.jsdialog.cell > #table-box4 > .sidebar.jsdialog.row > .sidebar.jsdialog.cell:nth-child(4) {
+.sidebar.jsdialog.cell > #table-box4 > .sidebar.jsdialog.row > .sidebar.jsdialog.cell:nth-child(4),
+.sidebar.cell:not(:nth-child(1)) > .vertical > .row > .toolbox,
+.sidebar.cell:not(:nth-child(1)) > .toolbox {
 	display: flex;
 	justify-content: flex-end;
 }


### PR DESCRIPTION
If there are more than one `.toolbox` element at an `.sidebar.cell` the `div.toolbox` get `flex-end` aligned.

It's a very generic approach and the goal is, that with additional PR's some css rules can be removed.

#### Before
![Screenshot_20220624_015527](https://user-images.githubusercontent.com/8517736/175434224-00fd90ae-916d-4748-a610-8cc0d1f065ad.png)

#### After
![Screenshot_20220624_015533](https://user-images.githubusercontent.com/8517736/175434240-0466fbad-0c18-4d71-b924-9182829ee710.png)

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: Ic2f1268a6bc55f5f500a35e224fa69faa8a60652