### PR TITLE
jsdialog: use open/close instead of toggle for dropdowns (master)

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2593,9 +2593,19 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			var arrowbackground = L.DomUtil.create('div', 'arrowbackground', div);
 			var arrow = L.DomUtil.create('i', 'unoarrow', arrowbackground);
 			controls['arrow'] = arrow;
+			var menuIsOpened = false;
 			$(arrowbackground).click(function (event) {
 				if (!$(div).hasClass('disabled')) {
-					builder.callback('toolbox', 'togglemenu', parentContainer, data.command, builder);
+					if (menuIsOpened) {
+						builder.callback('toolbox', 'closemenu', parentContainer, data.command, builder);
+						menuIsOpened = false;
+						$(div).removeClass('menu-opened');
+					} else {
+						menuIsOpened = true;
+						builder.callback('toolbox', 'openmenu', parentContainer, data.command, builder);
+						$(div).addClass('menu-opened');
+					}
+
 					event.stopPropagation();
 				}
 			});


### PR DESCRIPTION
This helps us to be in sync with core especially with
problematic dropdowns like:
Sidebar in shape context -> Line Panel -> Line Width
This will close and not reopen the popup when we click outside.

requires core change: https://gerrit.libreoffice.org/c/core/+/136570