### PR TITLE
jsdialog: use open/close instead of toggle for dropdowns (code 22.05)

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2594,8 +2594,16 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			var arrow = L.DomUtil.create('i', 'unoarrow', arrowbackground);
 			controls['arrow'] = arrow;
 			$(arrowbackground).click(function (event) {
+				var isOpened = $(div).hasClass('menu-opened');
 				if (!$(div).hasClass('disabled')) {
-					builder.callback('toolbox', 'togglemenu', parentContainer, data.command, builder);
+					if (isOpened) {
+						$(div).removeClass('menu-opened');
+						builder.callback('toolbox', 'closemenu', parentContainer, data.command, builder);
+					} else {
+						$(div).addClass('menu-opened');
+						builder.callback('toolbox', 'openmenu', parentContainer, data.command, builder);
+					}
+
 					event.stopPropagation();
 				}
 			});


### PR DESCRIPTION
This helps us to be in sync with core especially with
problematic dropdowns like:
Sidebar in shape context -> Line Panel -> Line Width
This will close and not reopen the popup when we click outside.

requires core change: https://gerrit.libreoffice.org/c/core/+/136570