### PR TITLE
comments: don't lose focus if is edited

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -2313,8 +2313,9 @@ L.CanvasTileLayer = L.Layer.extend({
 		// Remove input help if there is any:
 		this._removeInputHelpMarker();
 
+		var commentHasFocus = app.view.commentHasFocus;
 		// unselect if anything is selected already
-		if (app.sectionContainer.doesSectionExist(L.CSections.CommentList.name)) {
+		if (!commentHasFocus && app.sectionContainer.doesSectionExist(L.CSections.CommentList.name)) {
 			app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).unselect();
 		}
 	},


### PR DESCRIPTION
When spreadsheet was opened after few seconds we received CellCursor
message.
If comment was opened end edited at that time - it dissapeared
