### PR TITLE
TileLocation::hash(): shift when the input size_t already

### DIFF
--- a/kit/Delta.hpp
+++ b/kit/Delta.hpp
@@ -37,8 +37,13 @@ struct TileLocation {
     }
     size_t hash() const
     {
-        return (_left << 20) ^ _top ^ (_part << 15) ^ (_size << 7) ^
-               (_canonicalViewId << 24);
+        size_t left = _left;
+        size_t top = _top;
+        size_t part = _part;
+        size_t size = _size;
+        size_t canonicalViewId = _canonicalViewId;
+        return (left << 20) ^ top ^ (part << 15) ^ (size << 7) ^
+               (canonicalViewId << 24);
     }
     bool operator==(const TileLocation& other) const
     {


### PR DESCRIPTION
Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: If4b18b96f3188489f1e5a027e08523722a2d85dc
