### PR TITLE
Private/pedro/improvements n fixes user list popover

### DIFF
--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -1234,6 +1234,8 @@ html[dir='rtl'] #userListPopover::after {
 
 #userListPopover .user-list-item.selected-user {
 	background-color: var(--color-background-dark);
+	display: grid;
+	grid-template-columns: 0fr 1fr;
 }
 
 #userListPopover #follow-editor {
@@ -1248,6 +1250,22 @@ html[dir='rtl'] #userListPopover::after {
 	width: 16px;
 	box-shadow: none !important;
 	background-position: center;
+}
+
+#userListPopover .user-list-item:not(.selected-user) .user-list-item--following-label {
+	display: none;
+}
+
+#userListPopover .user-list-item.selected-user .user-list-item--following-label {
+	display: flex;
+	padding-inline-start: 8px;
+	font-size: var(--default-font-size);
+	padding-block-end: 4px;
+	color: var(--color-text-lighter);
+}
+
+#userListPopover .user-list-item.selected-user .user-list-item--name {
+	padding: 4px 0 0 8px;
 }
 
 @media only screen and (max-width: 600px) {

--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -1190,7 +1190,7 @@ menu-entry-with-icon.padding-left + menu-entry-icon.width */
 	z-index: 1;
 	top: 38px;
 	color: var(--color-main-text);
-	background-color: var(--color-background-lighter);
+	background-color: var(--color-main-background);
 	border-radius: var(--border-radius);
 	filter: drop-shadow(0 1px 3px var(--color-box-shadow));
 	min-width: 150px;

--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -1239,7 +1239,7 @@ html[dir='rtl'] #userListPopover::after {
 }
 
 #userListPopover #follow-editor {
-	padding: 6px 4px;
+	padding: 8px;
 }
 
 #userListPopover #follow-editor .follow-editor-checkbox {

--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -1221,6 +1221,11 @@ html[dir='rtl'] #userListPopover::after {
 	padding: 4px 8px;
 }
 
+#userListPopover .user-list-item:hover {
+	cursor: pointer;
+	background-color: var(--color-background-dark);
+}
+
 #userListPopover .user-list-item--name {
 	display: flex;
 	flex-grow: 1;

--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -1152,13 +1152,13 @@ menu-entry-with-icon.padding-left + menu-entry-icon.width */
 	position: relative;
 	background-color: transparent;
 	display: flex !important;
-	flex-grow: 1;
 	align-items: center;
 	font-family: var(--cool-font);
 	padding-right: 12px;
 	margin-right: 10px;
 	margin-left: 10px;
 	font-size: var(--default-font-size);
+	justify-content: end;
 }
 
 #userListHeader .user-info,
@@ -1189,18 +1189,12 @@ menu-entry-with-icon.padding-left + menu-entry-icon.width */
 	position: absolute;
 	z-index: 1;
 	top: 38px;
-	right: 5px;
 	color: var(--color-main-text);
 	background-color: var(--color-background-lighter);
 	border-radius: var(--border-radius);
 	filter: drop-shadow(0 1px 3px var(--color-box-shadow));
 	min-width: 150px;
 	font-size: var(--default-font-size);
-}
-
-html[dir='rtl'] #userListPopover {
-	right: unset !important;
-	left: 5px;
 }
 
 #userListPopover::after {

--- a/browser/src/control/Control.Toolbar.js
+++ b/browser/src/control/Control.Toolbar.js
@@ -1097,6 +1097,7 @@ function editorUpdate(e) { // eslint-disable-line no-unused-vars
 		docLayer._followThis = -1;
 	}
 	$('#tb_actionbar_item_userlist').w2overlay('');
+	$('#userListPopover').hide();
 }
 
 global.editorUpdate = editorUpdate;

--- a/browser/src/control/Control.UserList.js
+++ b/browser/src/control/Control.UserList.js
@@ -60,6 +60,7 @@ L.Control.UserList = L.Control.extend({
 	},
 
 	followUser: function(viewId) {
+		$('#userListPopover').hide();
 		var docLayer = this.map._docLayer;
 		this.map._goToViewId(viewId);
 

--- a/browser/src/control/Control.UserList.js
+++ b/browser/src/control/Control.UserList.js
@@ -155,11 +155,17 @@ L.Control.UserList = L.Control.extend({
 			var userLabel = L.DomUtil.create('div', 'user-list-item--name');
 			userLabel.innerText = user.userName;
 
+			var userFollowingLabel = L.DomUtil.create('div', 'user-list-item--following-label');
+			userFollowingLabel.innerText = _('Following');
+			var userLabelContainer = L.DomUtil.create('div', 'user-list-item--name-container');
+			userLabelContainer.appendChild(userLabel);
+			userLabelContainer.appendChild(userFollowingLabel);
+
 			var listItem = L.DomUtil.create('div', 'user-list-item');
 			listItem.setAttribute('data-view-id', user.viewId);
 			listItem.setAttribute('role', 'button');
 			listItem.appendChild(L.control.createAvatar(user.viewId, user.userName, user.extraInfo, user.color));
-			listItem.appendChild(userLabel);
+			listItem.appendChild(userLabelContainer);
 			listItem.addEventListener('click', function () {
 				that.followUser(user.viewId);
 			}, false);


### PR DESCRIPTION
commit da9f10df79ec63b86af625d820c0cc8c0866d6f1 (HEAD -> private/pedro/improvements-n-fixes-userListPopover, origin/private/pedro/improvements-n-fixes-userListPopover)

    Fix padding in follow editor's entry (userListPopover)
    
    Use the same padding as the user names and thus fixing the
    alignment (vertical: checkbox vs avatars)
    
    Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
    Change-Id: I1acb8cf5e3e5dc8aad083151c9c54b38aa552d6c

commit 58a1ec616fe5c9787751aaa1fd5aa8eca2ca9412

    Add following label to userListPopover (avatar list)
    
    Until now user was reporting not fully understanding all the
    features that user userListPopover offers. Namely, not knowing
    that not only is possible to follow the editor (checkbox) but
    that it is also possible to follow a specific user from the list
    
    Make it easier to understand what's the current following status
    by adding "Following" under the selected user name in the list
    
    Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
    Change-Id: I0beba5df06f2cc7a9a349ef8f93db6b403befb9b

commit 36ea2ca662410d968928a0481cc4f554e53e566e

    Hide avatars list when follow editor changes status
    
    Get rid of the popover once the user completes the action
    Probably better to avoid having hanging popover (that have no
    close btn) and instead close them, specially because this
    one can always be re-opened at anytime from omnipresent
    toolbar and without risk of triggering any additional change
    
    Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
    Change-Id: Id7946512e6c54622e3ed20b28d56178c05b18b5c

commit 47aa7fc950a04d0ca52506fd225a9fb61a5f8c56

    Hide avatars list when a user entry is selected
    
    Make sure the avatar list popover automatically gets out of the
    way once the user selects an entry (follow user)
    
    Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
    Change-Id: Ie83a587e4f9900ffb0d70cadbfb13cfe81d8b849

commit 9a45988e82e0c3d0280d8361960de2ec7be6ac79

    Avatars list: Add missing hover styles
    
    Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
    Change-Id: I6a5b215316a988ad0649982415c2d8ce6fab1212

commit 62fe226aaf62c3e811a5fec027ad4dc7dbbe710c

    Use the same bg for #userListPopover and its pointing triangle
    
    Before the triangle was getting a different bg when compared
    to #userListPopover
    
    Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
    Change-Id: If110d9e1178bedb7e858804e169689ee97a5a385

commit 58afa7b12d58ced2dffba145ea13ff7a5b126778

    Fix position of avatar list
    
    Instead of trying to re-position #userListPopover for every case
    (compact view, tabbed view and rtl), use flex to align the elements
    - This also fixes the positioning discrepancy of both the popover
    but also the arrow (triangle)
