### PR TITLE
USR2 to Backtrace and Signal-Safe Logging

### DIFF
--- a/common/Common.hpp
+++ b/common/Common.hpp
@@ -46,7 +46,6 @@ constexpr int MAX_MESSAGE_SIZE = 2 * 1024 * READ_BUFFER_SIZE;
 constexpr const char JAILED_DOCUMENT_ROOT[] = "/tmp/user/docs/";
 constexpr const char CHILD_URI[] = "/coolws/child?";
 constexpr const char NEW_CHILD_URI[] = "/coolws/newchild";
-constexpr const char LO_JAIL_SUBPATH[] = "lo";
 constexpr const char FORKIT_URI[] = "/coolws/forkit";
 
 constexpr const char CAPABILITIES_END_POINT[] = "/hosting/capabilities";

--- a/common/JailUtil.cpp
+++ b/common/JailUtil.cpp
@@ -196,11 +196,11 @@ void cleanupJails(const std::string& root)
         LOG_WRN("Jails root directory [" << root << "] is not empty. Will not remove it.");
 }
 
-void setupJails(bool bindMount, const std::string& jailRoot, const std::string& sysTemplate)
+void setupChildRoot(bool bindMount, const std::string& childRoot, const std::string& sysTemplate)
 {
     // Start with a clean slate.
-    cleanupJails(jailRoot);
-    Poco::File(jailRoot + JAIL_TMP_INCOMING_PATH).createDirectories();
+    cleanupJails(childRoot);
+    Poco::File(childRoot + CHILDROOT_TMP_INCOMING_PATH).createDirectories();
 
     disableBindMounting(); // Clear to avoid surprises.
 
@@ -209,7 +209,7 @@ void setupJails(bool bindMount, const std::string& jailRoot, const std::string& 
     {
         // Test mounting to verify it actually works,
         // as it might not function in some systems.
-        const std::string target = Poco::Path(jailRoot, "cool_test_mount").toString();
+        const std::string target = Poco::Path(childRoot, "cool_test_mount").toString();
         if (bind(sysTemplate, target))
         {
             enableBindMounting();

--- a/common/JailUtil.cpp
+++ b/common/JailUtil.cpp
@@ -156,8 +156,7 @@ void cleanupJails(const std::string& root)
         return;
     }
 
-    // FIXME: technically, the loTemplate directory may have any name.
-    if (FileUtil::Stat(root + "/lo").exists())
+    if (FileUtil::Stat(root + '/' + LO_JAIL_SUBPATH).exists())
     {
         // This is a jail.
         removeJail(root);

--- a/common/JailUtil.cpp
+++ b/common/JailUtil.cpp
@@ -23,6 +23,7 @@
 #include <string>
 
 #include "Log.hpp"
+#include <SigUtil.hpp>
 
 namespace JailUtil
 {
@@ -122,7 +123,7 @@ static bool safeRemoveDir(const std::string& path)
 
 void removeJail(const std::string& root)
 {
-    LOG_INF("Removing jail [" << root << "].");
+    LOG_INF("Removing jail [" << root << ']');
 
     // Unmount the tmp directory. Don't care if we fail.
     const std::string tmpPath = Poco::Path(root, "tmp").toString();

--- a/common/JailUtil.hpp
+++ b/common/JailUtil.hpp
@@ -21,6 +21,9 @@ constexpr const char CHILDROOT_TMP_PATH[] = "/tmp";
 /// Files uploaded by users are stored in this sub-directory of child-root.
 constexpr const char CHILDROOT_TMP_INCOMING_PATH[] = "/tmp/incoming";
 
+/// The LO installation directory with jail.
+constexpr const char LO_JAIL_SUBPATH[] = "lo";
+
 /// Bind mount a jail directory.
 bool bind(const std::string& source, const std::string& target);
 

--- a/common/JailUtil.hpp
+++ b/common/JailUtil.hpp
@@ -15,8 +15,11 @@
 namespace JailUtil
 {
 
+/// General temporary directory owned by us.
+constexpr const char CHILDROOT_TMP_PATH[] = "/tmp";
+
 /// Files uploaded by users are stored in this sub-directory of child-root.
-constexpr const char JAIL_TMP_INCOMING_PATH[] = "/tmp/incoming";
+constexpr const char CHILDROOT_TMP_INCOMING_PATH[] = "/tmp/incoming";
 
 /// Bind mount a jail directory.
 bool bind(const std::string& source, const std::string& target);
@@ -36,8 +39,8 @@ void removeJail(const std::string& root);
 /// Remove all jails.
 void cleanupJails(const std::string& jailRoot);
 
-/// Setup the jails.
-void setupJails(bool bindMount, const std::string& jailRoot, const std::string& sysTemplate);
+/// Setup the Child-Root directory.
+void setupChildRoot(bool bindMount, const std::string& jailRoot, const std::string& sysTemplate);
 
 /// Setup /dev/random and /dev/urandom in the given jail path.
 void setupJailDevNodes(const std::string& root);

--- a/common/Log.cpp
+++ b/common/Log.cpp
@@ -91,50 +91,6 @@ namespace Log
 
     bool IsShutdown = false;
 
-    // We need a signal safe means of writing messages
-    //   $ man 7 signal
-    void signalLog(const char *message)
-    {
-        while (true)
-        {
-            const int length = std::strlen(message);
-            const int written = write(STDERR_FILENO, message, length);
-            if (written < 0)
-            {
-                if (errno == EINTR)
-                    continue; // ignore.
-                else
-                    break;
-            }
-
-            message += written;
-            if (message[0] == '\0')
-                break;
-        }
-    }
-
-    // We need a signal safe means of writing messages
-    //   $ man 7 signal
-    void signalLogNumber(std::size_t num, int base)
-    {
-        int i;
-        char buf[22];
-        if (num == 0)
-        {
-            signalLog("0");
-            return;
-        }
-        buf[21] = '\0';
-        assert (base == 10 || base == 16);
-        for (i = 20; i > 0 && num > 0; --i)
-        {
-            int d = num % base;
-            buf[i] = (d < 10) ? ('0' + d) : ('a' + d - 10);
-            num /= base;
-        }
-        signalLog(buf + i + 1);
-    }
-
     /// Convert an unsigned number to ascii with 0 padding.
     template <int Width> void to_ascii_fixed(char* buf, std::size_t num)
     {
@@ -306,13 +262,6 @@ namespace Log
         pos[2] = '\0';
 
         return buffer;
-    }
-
-    void signalLogPrefix()
-    {
-        char buffer[1024];
-        prefix<sizeof(buffer) - 1>(buffer, "SIG");
-        signalLog(buffer);
     }
 
     void initialize(const std::string& name,

--- a/common/Log.hpp
+++ b/common/Log.hpp
@@ -74,13 +74,6 @@ namespace Log
 
     const std::string& getLevel();
 
-    /// Signal safe prefix logging
-    void signalLogPrefix();
-    /// Signal safe logging
-    void signalLog(const char* message);
-    /// Signal log number
-    void signalLogNumber(std::size_t num, int base = 10);
-
     /// The following is to write streaming logs.
     /// Log::info() << "Value: 0x" << std::hex << value
     ///             << ", pointer: " << this << Log::end;

--- a/common/Seccomp.cpp
+++ b/common/Seccomp.cpp
@@ -68,6 +68,7 @@ static void handleSysSignal(int /* signal */,
 {
 	ucontext_t *uctx = static_cast<ucontext_t *>(context);
 
+    SigUtil::signalLogOpen();
     SigUtil::signalLogPrefix();
     SigUtil::signalLog("SIGSYS trapped with code: ");
     SigUtil::signalLogNumber(info->si_code);
@@ -86,6 +87,7 @@ static void handleSysSignal(int /* signal */,
     SigUtil::signalLog("\n");
 
     SigUtil::dumpBacktrace();
+    SigUtil::signalLogClose();
 
     Log::shutdown();
     _exit(1);

--- a/common/Seccomp.cpp
+++ b/common/Seccomp.cpp
@@ -68,22 +68,22 @@ static void handleSysSignal(int /* signal */,
 {
 	ucontext_t *uctx = static_cast<ucontext_t *>(context);
 
-    Log::signalLogPrefix();
-    Log::signalLog("SIGSYS trapped with code: ");
-    Log::signalLogNumber(info->si_code);
-    Log::signalLog(" and context ");
-    Log::signalLogNumber(reinterpret_cast<size_t>(context));
-    Log::signalLog("\n");
+    SigUtil::signalLogPrefix();
+    SigUtil::signalLog("SIGSYS trapped with code: ");
+    SigUtil::signalLogNumber(info->si_code);
+    SigUtil::signalLog(" and context ");
+    SigUtil::signalLogNumber(reinterpret_cast<size_t>(context));
+    SigUtil::signalLog("\n");
 
 	if (info->si_code != SYS_SECCOMP || !uctx)
 		return;
 
     unsigned int syscall = SECCOMP_SYSCALL (uctx);
 
-    Log::signalLogPrefix();
-    Log::signalLog(" seccomp trapped signal, un-authorized sys-call: ");
-    Log::signalLogNumber(syscall);
-    Log::signalLog("\n");
+    SigUtil::signalLogPrefix();
+    SigUtil::signalLog(" seccomp trapped signal, un-authorized sys-call: ");
+    SigUtil::signalLogNumber(syscall);
+    SigUtil::signalLog("\n");
 
     SigUtil::dumpBacktrace();
 

--- a/common/SigUtil.cpp
+++ b/common/SigUtil.cpp
@@ -418,6 +418,13 @@ namespace SigUtil
         action.sa_handler = handleUserSignal;
 
         sigaction(SIGUSR1, &action, nullptr);
+
+#if !defined(__ANDROID__)
+        // Prime backtrace to make sure libgcc is loaded.
+        constexpr int maxSlots = 1;
+        void* backtraceBuffer[maxSlots + 1];
+        backtrace(backtraceBuffer, maxSlots);
+#endif
     }
 
     void setDebuggerSignal()

--- a/common/SigUtil.cpp
+++ b/common/SigUtil.cpp
@@ -241,20 +241,6 @@ namespace SigUtil
         SocketPoll::wakeupWorld();
     }
 
-    void setTerminationSignals()
-    {
-        struct sigaction action;
-
-        sigemptyset(&action.sa_mask);
-        action.sa_flags = 0;
-        action.sa_handler = handleTerminationSignal;
-
-        sigaction(SIGINT, &action, nullptr);
-        sigaction(SIGTERM, &action, nullptr);
-        sigaction(SIGQUIT, &action, nullptr);
-        sigaction(SIGHUP, &action, nullptr);
-    }
-
     static char *VersionInfo = nullptr;
     static char FatalGdbString[256] = { '\0' };
 
@@ -369,6 +355,7 @@ namespace SigUtil
 
         setVersionInfo(versionInfo);
 
+        // Set up the fatal-signal handler. (N.B. three-argument handler)
         sigemptyset(&action.sa_mask);
         action.sa_flags = SA_SIGINFO;
         action.sa_sigaction = handleFatalSignal;
@@ -378,6 +365,16 @@ namespace SigUtil
         sigaction(SIGABRT, &action, nullptr);
         sigaction(SIGILL, &action, nullptr);
         sigaction(SIGFPE, &action, nullptr);
+
+        // Set up the terminatio-signal handler. (N.B. single-argument handler)
+        sigemptyset(&action.sa_mask);
+        action.sa_flags = 0;
+        action.sa_handler = handleTerminationSignal;
+
+        sigaction(SIGINT, &action, nullptr);
+        sigaction(SIGTERM, &action, nullptr);
+        sigaction(SIGQUIT, &action, nullptr);
+        sigaction(SIGHUP, &action, nullptr);
 
         // Prepare this in advance just in case.
         std::ostringstream stream;

--- a/common/SigUtil.cpp
+++ b/common/SigUtil.cpp
@@ -109,6 +109,8 @@ namespace SigUtil
     }
 
 #if !MOBILEAPP
+    static int SignalLogFD(STDERR_FILENO); //< The FD where signalLogs are dumped.
+
     void signalLogPrefix()
     {
         char buffer[1024];
@@ -123,7 +125,7 @@ namespace SigUtil
         while (true)
         {
             const int length = std::strlen(message);
-            const int written = write(STDERR_FILENO, message, length);
+            const int written = write(SignalLogFD, message, length);
             if (written < 0)
             {
                 if (errno == EINTR)
@@ -363,7 +365,7 @@ namespace SigUtil
         const int numSlots = backtrace(backtraceBuffer, maxSlots);
         if (numSlots > 0)
         {
-            backtrace_symbols_fd(backtraceBuffer, numSlots, STDERR_FILENO);
+            backtrace_symbols_fd(backtraceBuffer, numSlots, SignalLogFD);
         }
 #else
         LOG_INF("Backtrace not available on Android.");

--- a/common/SigUtil.hpp
+++ b/common/SigUtil.hpp
@@ -58,6 +58,13 @@ namespace SigUtil
     void setUnattended();
 
 #if !MOBILEAPP
+    /// Signal safe prefix logging
+    void signalLogPrefix();
+    /// Signal safe logging
+    void signalLog(const char* message);
+    /// Signal log number
+    void signalLogNumber(std::size_t num, int base = 10);
+
     /// Wait for the signal handler, if any,
     /// and prevent _Exit while collecting backtrace.
     void waitSigHandlerTrap();

--- a/common/SigUtil.hpp
+++ b/common/SigUtil.hpp
@@ -67,9 +67,6 @@ namespace SigUtil
 
     /// Register a wakeup function when changing
 
-    /// Trap signals to cleanup and exit the process gracefully.
-    void setTerminationSignals();
-
     /// Trap all fatal signals to assist debugging.
     void setFatalSignals(const std::string &versionInfo);
 

--- a/common/SigUtil.hpp
+++ b/common/SigUtil.hpp
@@ -58,6 +58,12 @@ namespace SigUtil
     void setUnattended();
 
 #if !MOBILEAPP
+
+    /// Open the signalLog file.
+    void signalLogOpen();
+    /// Close the signalLog file.
+    void signalLogClose();
+
     /// Signal safe prefix logging
     void signalLogPrefix();
     /// Signal safe logging

--- a/common/SigUtil.hpp
+++ b/common/SigUtil.hpp
@@ -49,6 +49,10 @@ namespace SigUtil
 
     void checkDumpGlobalState(GlobalDumpStateFn dumpState);
 
+    extern "C" { typedef void (*ForwardSigUsr2Fn)(void); }
+
+    void checkForwardSigUsr2(ForwardSigUsr2Fn forwardSigUsr2);
+
     /// Add a message to a round-robin buffer to be dumped on fatal signal
     void addActivity(const std::string &message);
 

--- a/kit/ForKit.cpp
+++ b/kit/ForKit.cpp
@@ -541,7 +541,6 @@ int main(int argc, char** argv)
     }
 
     SigUtil::setFatalSignals("forkit startup of " COOLWSD_VERSION " " COOLWSD_VERSION_HASH);
-    SigUtil::setTerminationSignals();
 
     Util::setApplicationPath(Poco::Path(argv[0]).parent().toString());
 

--- a/kit/ForKit.cpp
+++ b/kit/ForKit.cpp
@@ -366,7 +366,6 @@ static void cleanupChildren()
 static int createLibreOfficeKit(const std::string& childRoot,
                                 const std::string& sysTemplate,
                                 const std::string& loTemplate,
-                                const std::string& loSubPath,
                                 bool queryVersion = false)
 {
     // Generate a jail ID to be used for in the jail path.
@@ -405,7 +404,7 @@ static int createLibreOfficeKit(const std::string& childRoot,
             }
         }
 
-        lokit_main(childRoot, jailId, sysTemplate, loTemplate, loSubPath, NoCapsForKit, NoSeccomp,
+        lokit_main(childRoot, jailId, sysTemplate, loTemplate, NoCapsForKit, NoSeccomp,
                    queryVersion, DisplayVersion, spareKitId);
     }
     else
@@ -432,7 +431,6 @@ static int createLibreOfficeKit(const std::string& childRoot,
 void forkLibreOfficeKit(const std::string& childRoot,
                         const std::string& sysTemplate,
                         const std::string& loTemplate,
-                        const std::string& loSubPath,
                         int limit)
 {
     LOG_TRC("forkLibreOfficeKit limit: " << limit);
@@ -455,8 +453,7 @@ void forkLibreOfficeKit(const std::string& childRoot,
         const size_t retry = count * 2;
         for (size_t i = 0; ForkCounter > 0 && i < retry; ++i)
         {
-            if (ForkCounter-- <= 0
-                || createLibreOfficeKit(childRoot, sysTemplate, loTemplate, loSubPath) < 0)
+            if (ForkCounter-- <= 0 || createLibreOfficeKit(childRoot, sysTemplate, loTemplate) < 0)
             {
                 LOG_ERR("Failed to create a kit process.");
                 ++ForkCounter;
@@ -567,7 +564,6 @@ int main(int argc, char** argv)
     }
 
     std::string childRoot;
-    std::string loSubPath;
     std::string sysTemplate;
     std::string loTemplate;
 
@@ -575,12 +571,7 @@ int main(int argc, char** argv)
     {
         char *cmd = argv[i];
         char *eq;
-        if (std::strstr(cmd, "--losubpath=") == cmd)
-        {
-            eq = std::strchr(cmd, '=');
-            loSubPath = std::string(eq+1);
-        }
-        else if (std::strstr(cmd, "--systemplate=") == cmd)
+        if (std::strstr(cmd, "--systemplate=") == cmd)
         {
             eq = std::strchr(cmd, '=');
             sysTemplate = std::string(eq+1);
@@ -646,7 +637,6 @@ int main(int argc, char** argv)
             SingleKit = true;
         }
 #endif
-
         // we are running in a lower-privilege mode - with no chroot
         else if (std::strstr(cmd, "--nocaps") == cmd)
         {
@@ -670,8 +660,7 @@ int main(int argc, char** argv)
         }
     }
 
-    if (loSubPath.empty() || sysTemplate.empty() ||
-        loTemplate.empty() || childRoot.empty())
+    if (sysTemplate.empty() || loTemplate.empty() || childRoot.empty())
     {
         printArgumentHelp();
         return EX_USAGE;
@@ -728,8 +717,7 @@ int main(int argc, char** argv)
     // We must have at least one child, more are created dynamically.
     // Ask this first child to send version information to master process and trace startup.
     ::setenv("COOL_TRACE_STARTUP", "1", 1);
-    const pid_t forKitPid
-        = createLibreOfficeKit(childRoot, sysTemplate, loTemplate, loSubPath, true);
+    const pid_t forKitPid = createLibreOfficeKit(childRoot, sysTemplate, loTemplate, true);
     if (forKitPid < 0)
     {
         LOG_FTL("Failed to create a kit process.");
@@ -781,7 +769,7 @@ int main(int argc, char** argv)
 #if ENABLE_DEBUG
         if (!SingleKit)
 #endif
-            forkLibreOfficeKit(childRoot, sysTemplate, loTemplate, loSubPath);
+            forkLibreOfficeKit(childRoot, sysTemplate, loTemplate);
     }
 
     int returnValue = EX_OK;

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -163,7 +163,7 @@ namespace
     };
     LinkOrCopyType linkOrCopyType;
     std::string sourceForLinkOrCopy;
-    Path destinationForLinkOrCopy;
+    Poco::Path destinationForLinkOrCopy;
     bool forceInitialCopy; // some stackable file-systems have very slow first hard link creation
     std::string linkableForLinkOrCopy; // Place to stash copies that we can hard-link from
     std::chrono::time_point<std::chrono::steady_clock> linkOrCopyStartTime;
@@ -382,13 +382,13 @@ namespace
 
         assert(fpath[strlen(sourceForLinkOrCopy.c_str())] == '/');
         const char *relativeOldPath = fpath + strlen(sourceForLinkOrCopy.c_str()) + 1;
-        const Path newPath(destinationForLinkOrCopy, Path(relativeOldPath));
+        const Poco::Path newPath(destinationForLinkOrCopy, Poco::Path(relativeOldPath));
 
         switch (typeflag)
         {
         case FTW_F:
         case FTW_SLN:
-            File(newPath.parent()).createDirectories();
+            Poco::File(newPath.parent()).createDirectories();
 
             if (shouldLinkFile(relativeOldPath))
                 linkOrCopyFile(fpath, newPath.toString());
@@ -406,7 +406,8 @@ namespace
                     LOG_TRC("nftw: Skipping redundant path: " << relativeOldPath);
                     return FTW_SKIP_SUBTREE;
                 }
-                File(newPath).createDirectories();
+
+                Poco::File(newPath).createDirectories();
                 struct utimbuf ut;
                 ut.actime = st.st_atime;
                 ut.modtime = st.st_mtime;
@@ -430,7 +431,7 @@ namespace
                 }
                 target[written] = '\0';
 
-                File(newPath.parent()).createDirectories();
+                Poco::File(newPath.parent()).createDirectories();
                 if (symlink(target, newPath.toString().c_str()) == -1)
                 {
                     LOG_SYS("nftw: symlink(\"" << target << "\", \"" << newPath.toString()
@@ -455,7 +456,7 @@ namespace
     }
 
     void linkOrCopy(std::string source,
-                    const Path& destination,
+                    const Poco::Path& destination,
                     std::string linkable,
                     LinkOrCopyType type)
     {
@@ -539,10 +540,10 @@ namespace
         cap_free(caps);
     }
 #endif // __FreeBSD__
-#endif
-}
+#endif // BUILDING_TESTS
+} // namespace
 
-#endif
+#endif // !MOBILEAPP
 
 /// A document container.
 /// Owns LOKitDocument instance and connections.
@@ -615,6 +616,7 @@ public:
 #ifdef IOS
         DocumentData::deallocate(_mobileAppDocId);
 #endif
+
     }
 
     const std::string& getUrl() const { return _url; }
@@ -2834,6 +2836,7 @@ void lokit_main(
         }
 
         LOG_INF("Kit unipoll loop run");
+
         loKit->runLoop(pollCallback, wakeCallback, mainKit.get());
 
         LOG_INF("Kit unipoll loop run terminated.");
@@ -2961,6 +2964,7 @@ bool globalPreinit(const std::string &loTemplate)
         LOG_FTL("No lok_preinit_2 symbol in " << loadedLibrary << ": " << dlerror());
         return false;
     }
+
     initFunction = reinterpret_cast<LokHookFunction2 *>(dlsym(handle, "libreofficekit_hook_2"));
     if (!initFunction)
     {

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -2470,7 +2470,6 @@ void lokit_main(
 #if !MOBILEAPP
 
     SigUtil::setFatalSignals("kit startup of " COOLWSD_VERSION " " COOLWSD_VERSION_HASH);
-    SigUtil::setTerminationSignals();
 
     Util::setThreadName("kit_spare_" + Util::encodeId(numericIdentifier, 3));
 

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -2454,7 +2454,6 @@ void lokit_main(
                 const std::string& jailId,
                 const std::string& sysTemplate,
                 const std::string& loTemplate,
-                const std::string& loSubPath,
                 bool noCapabilities,
                 bool noSeccomp,
                 bool queryVersion,
@@ -2506,7 +2505,6 @@ void lokit_main(
     assert(!childRoot.empty());
     assert(!sysTemplate.empty());
     assert(!loTemplate.empty());
-    assert(!loSubPath.empty());
 
     LOG_INF("Kit process for Jail [" << jailId << "] started.");
 
@@ -2536,9 +2534,9 @@ void lokit_main(
                 = std::chrono::steady_clock::now();
 
             userdir_url = "file:///tmp/user";
-            instdir_path = '/' + loSubPath + "/program";
+            instdir_path = '/' + std::string(JailUtil::LO_JAIL_SUBPATH) + "/program";
 
-            Poco::Path jailLOInstallation(jailPath, loSubPath);
+            Poco::Path jailLOInstallation(jailPath, JailUtil::LO_JAIL_SUBPATH);
             jailLOInstallation.makeDirectory();
             const std::string loJailDestPath = jailLOInstallation.toString();
 

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -2470,6 +2470,7 @@ void lokit_main(
 #if !MOBILEAPP
 
     SigUtil::setFatalSignals("kit startup of " COOLWSD_VERSION " " COOLWSD_VERSION_HASH);
+    SigUtil::setUserSignals();
 
     Util::setThreadName("kit_spare_" + Util::encodeId(numericIdentifier, 3));
 

--- a/kit/Kit.hpp
+++ b/kit/Kit.hpp
@@ -30,7 +30,6 @@ void lokit_main(
                 const std::string& jailId,
                 const std::string& sysTemplate,
                 const std::string& loTemplate,
-                const std::string& loSubPath,
                 bool noCapabilities,
                 bool noSeccomp,
                 bool queryVersionInfo,
@@ -130,7 +129,6 @@ private:
 void forkLibreOfficeKit(const std::string& childRoot,
                         const std::string& sysTemplate,
                         const std::string& loTemplate,
-                        const std::string& loSubPath,
                         int limit = 0);
 
 /// Anonymize the basename of filenames, preserving the path and extension.

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -428,8 +428,7 @@ static int forkChildren(const int number)
         COOLWSD::checkDiskSpaceAndWarnClients(false);
 
 #ifdef KIT_IN_PROCESS
-        forkLibreOfficeKit(COOLWSD::ChildRoot, COOLWSD::SysTemplate, COOLWSD::LoTemplate,
-                           JailUtil::LO_JAIL_SUBPATH, number);
+        forkLibreOfficeKit(COOLWSD::ChildRoot, COOLWSD::SysTemplate, COOLWSD::LoTemplate, number);
 #else
         const std::string aMessage = "spawn " + std::to_string(number) + '\n';
         LOG_DBG("MasterToForKit: " << aMessage.substr(0, aMessage.length() - 1));
@@ -2877,7 +2876,6 @@ bool COOLWSD::createForKit()
     FileUtil::copy(parentPath + "coolforkit", nocapsCopy, true, true);
     args.push_back(nocapsCopy);
 #endif
-    args.push_back("--losubpath=" + std::string(JailUtil::LO_JAIL_SUBPATH));
     args.push_back("--systemplate=" + SysTemplate);
     args.push_back("--lotemplate=" + LoTemplate);
     args.push_back("--childroot=" + ChildRoot);

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -429,7 +429,7 @@ static int forkChildren(const int number)
 
 #ifdef KIT_IN_PROCESS
         forkLibreOfficeKit(COOLWSD::ChildRoot, COOLWSD::SysTemplate, COOLWSD::LoTemplate,
-                           LO_JAIL_SUBPATH, number);
+                           JailUtil::LO_JAIL_SUBPATH, number);
 #else
         const std::string aMessage = "spawn " + std::to_string(number) + '\n';
         LOG_DBG("MasterToForKit: " << aMessage.substr(0, aMessage.length() - 1));
@@ -663,7 +663,7 @@ public:
         if (!params.has("filename"))
             return;
 
-        // The temporary directory is child-root/<JAIL_TMP_INCOMING_PATH>.
+        // The temporary directory is child-root/<CHILDROOT_TMP_INCOMING_PATH>.
         // Always create a random sub-directory to avoid file-name collision.
         Path tempPath = Path::forDirectory(
             FileUtil::createRandomTmpDir(COOLWSD::ChildRoot + JailUtil::CHILDROOT_TMP_INCOMING_PATH)
@@ -2877,7 +2877,7 @@ bool COOLWSD::createForKit()
     FileUtil::copy(parentPath + "coolforkit", nocapsCopy, true, true);
     args.push_back(nocapsCopy);
 #endif
-    args.push_back("--losubpath=" + std::string(LO_JAIL_SUBPATH));
+    args.push_back("--losubpath=" + std::string(JailUtil::LO_JAIL_SUBPATH));
     args.push_back("--systemplate=" + SysTemplate);
     args.push_back("--lotemplate=" + LoTemplate);
     args.push_back("--childroot=" + ChildRoot);

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -4975,7 +4975,6 @@ int COOLWSD::innerMain()
 #if !MOBILEAPP
     SigUtil::setUserSignals();
     SigUtil::setFatalSignals("wsd " COOLWSD_VERSION " " COOLWSD_VERSION_HASH);
-    SigUtil::setTerminationSignals();
 #endif
 
 #if !MOBILEAPP

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -666,7 +666,7 @@ public:
         // The temporary directory is child-root/<JAIL_TMP_INCOMING_PATH>.
         // Always create a random sub-directory to avoid file-name collision.
         Path tempPath = Path::forDirectory(
-            FileUtil::createRandomTmpDir(COOLWSD::ChildRoot + JailUtil::JAIL_TMP_INCOMING_PATH)
+            FileUtil::createRandomTmpDir(COOLWSD::ChildRoot + JailUtil::CHILDROOT_TMP_INCOMING_PATH)
             + '/');
         LOG_TRC("Created temporary convert-to/insert path: " << tempPath.toString());
 
@@ -735,9 +735,10 @@ public:
 
             // The temporary directory is child-root/<JAIL_TMP_INCOMING_PATH>.
             // Always create a random sub-directory to avoid file-name collision.
-            Path tempPath = Path::forDirectory(
-                FileUtil::createRandomTmpDir(COOLWSD::ChildRoot + JailUtil::JAIL_TMP_INCOMING_PATH)
-                + '/');
+            Path tempPath =
+                Path::forDirectory(FileUtil::createRandomTmpDir(
+                                       COOLWSD::ChildRoot + JailUtil::CHILDROOT_TMP_INCOMING_PATH) +
+                                   '/');
 
             LOG_TRC("Created temporary render-search-result file path: " << tempPath.toString());
 
@@ -2197,8 +2198,8 @@ void COOLWSD::innerInitialize(Application& self)
     config::initialize(&config());
 
     // Setup the jails.
-    JailUtil::setupJails(getConfigValue<bool>(conf, "mount_jail_tree", true), ChildRoot,
-                         SysTemplate);
+    JailUtil::setupChildRoot(getConfigValue<bool>(conf, "mount_jail_tree", true), ChildRoot,
+                             SysTemplate);
 
     LOG_DBG("FileServerRoot before config: " << FileServerRoot);
     FileServerRoot = getPathFromConfig("file_server_root_path");

--- a/wsd/COOLWSD.hpp
+++ b/wsd/COOLWSD.hpp
@@ -30,6 +30,7 @@
 #include "RequestDetails.hpp"
 #include "WebSocketHandler.hpp"
 #include "QuarantineUtil.hpp"
+
 class ChildProcess;
 class TraceFileWriter;
 class DocumentBroker;

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -176,9 +176,9 @@ void DocumentBroker::assertCorrectThread() const
 // The inner heart of the DocumentBroker - our poll loop.
 void DocumentBroker::pollThread()
 {
-    LOG_INF("Starting docBroker polling thread for docKey [" << _docKey << "].");
-
     _threadStart = std::chrono::steady_clock::now();
+
+    LOG_INF("Starting docBroker polling thread for docKey [" << _docKey << ']');
 
     // Request a kit process for this doc.
 #if !MOBILEAPP


### PR DESCRIPTION
These patches implement SIGUSR2 to backtrace the stack of the receiving process. For the moment, we backtrace the main thread only. In addition, we implement a long-desired, signal-safe method for capturing stack-traces in log files. Here we dump the backtrace in question into a special signalLog file and we then extract it (outside of the signal handler) and dump into the log file.

The changes are large mostly to accommodate these changes. That is, there is quite a bit of refactoring that isn't functional.

- wsd: jail: rename jails to childroot to distinguish them
- wsd: jail: move LO_JAIL_SUBPATH to JailUtil
- wsd: jail: no need to pass loSubPath between processes
- wsd: jail: add Poco namespace where missing in LinkOrCopy
- wsd: minor cleanup of addNewChild
- wsd: sig: prime libgcc and backtrace
- wsd: sig: merge setTerminationSignals with setFatalSignals
- wsd: sig: move signalLog helpers to SigUtil
- wsd: sig: write signalLog to SignalLogFD
- wsd: sig: support writing signalLog to files
- wsd: sig: dump signal logs into files and extract later
