### PR TITLE
Allow buttons in vex dialogs to wrap

### DIFF
--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -28,6 +28,7 @@ button.jsdialog img {
 	display: flex;
 	flex-direction: row;
 	justify-content: end;
+	flex-wrap: wrap;
 }
 
 [class*='button-secondary'],


### PR DESCRIPTION
ported from:
PR: https://github.com/CollaboraOnline/online/pull/4976

In cases when the button text is too long
or when using CO in, for example, DE language and when
the length of the parent dialog was not enough the btns
would not stack up, instead that would overlap. This would
make reading those btns impossible.

![vex-btns-overlap](https://archive.org/download/csv-overlap-btn-labels/CSV-overlap-btn-labels.png)

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I801ea330db21add35d0a81466a1fba9501a61899
