### PR TITLE
pr/distro/collabora/co 21 11/01

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -124,6 +124,7 @@ coolwsd_sources = common/Crypto.cpp \
                   wsd/COOLWSD.cpp \
                   wsd/ClientSession.cpp \
                   wsd/FileServer.cpp \
+                  wsd/ProxyRequestHandler.cpp \
                   wsd/FileServerUtil.cpp \
                   wsd/RequestDetails.cpp \
                   wsd/Storage.cpp \
@@ -248,6 +249,7 @@ wsd_headers = wsd/Admin.hpp \
               wsd/ProxyProtocol.hpp \
               wsd/Exceptions.hpp \
               wsd/FileServer.hpp \
+              wsd/ProxyRequestHandler.hpp \
               wsd/COOLWSD.hpp \
               wsd/ProofKey.hpp \
               wsd/RequestDetails.hpp \

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -970,6 +970,7 @@ public:
     /// Get the timeout, in microseconds.
     std::chrono::microseconds getTimeout() const { return _timeout; }
 
+    std::shared_ptr<Response> response() { return _response; }
     std::shared_ptr<const Response> response() const { return _response; }
     const std::string& getUrl() const { return _request.getUrl(); }
 

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -971,6 +971,7 @@ public:
     std::chrono::microseconds getTimeout() const { return _timeout; }
 
     std::shared_ptr<const Response> response() const { return _response; }
+    const std::string& getUrl() const { return _request.getUrl(); }
 
     /// The onFinished callback handler signature.
     using FinishedCallback = std::function<void(const std::shared_ptr<Session>& session)>;

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -903,7 +903,7 @@ std::unique_ptr<ClipboardCache> COOLWSD::SavedClipboards;
 /// This thread polls basic web serving, and handling of
 /// websockets before upgrade: when upgraded they go to the
 /// relevant DocumentBroker poll instead.
-static std::unique_ptr<TerminatingPoll> WebServerPoll;
+static std::shared_ptr<TerminatingPoll> WebServerPoll;
 
 class PrisonPoll : public TerminatingPoll
 {
@@ -5302,6 +5302,11 @@ int COOLWSD::innerMain()
     Util::forcedExit(returnValue);
 
     return returnValue;
+}
+
+std::shared_ptr<TerminatingPoll> COOLWSD:: getWebServerPoll ()
+{
+    return WebServerPoll;
 }
 
 void COOLWSD::cleanup()

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -3429,7 +3429,7 @@ private:
             {
                 // File server
                 assert(socket && "Must have a valid socket");
-                constexpr auto ProxyRemote = "/remote/";
+                constexpr auto ProxyRemote = "/remote/static/";
                 constexpr auto ProxyRemoteLen = sizeof(ProxyRemote) - 1;
                 const auto uri = requestDetails.getURI();
                 const auto pos = uri.find(ProxyRemote);

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -123,6 +123,7 @@ using Poco::Net::PartHandler;
 #include "DocumentBroker.hpp"
 #include "Exceptions.hpp"
 #include "FileServer.hpp"
+#include "ProxyRequestHandler.hpp"
 #include <common/JsonUtil.hpp>
 #include <common/FileUtil.hpp>
 #include <common/JailUtil.hpp>
@@ -3428,8 +3429,19 @@ private:
             {
                 // File server
                 assert(socket && "Must have a valid socket");
-                FileServerRequestHandler::handleRequest(request, requestDetails, message, socket);
-                socket->shutdown();
+                constexpr auto ProxyRemote = "/remote/";
+                constexpr auto ProxyRemoteLen = sizeof(ProxyRemote) - 1;
+                const auto uri = requestDetails.getURI();
+                const auto pos = uri.find(ProxyRemote);
+                if (pos != std::string::npos)
+                {
+                    ProxyRequestHandler::handleRequest(uri.substr(pos + ProxyRemoteLen), socket);
+                }
+                else
+                {
+                    FileServerRequestHandler::handleRequest(request, requestDetails, message, socket);
+                    socket->shutdown();
+                }
             }
             else if (requestDetails.equals(RequestDetails::Field::Type, "cool") &&
                      requestDetails.equals(1, "adminws"))

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -3429,10 +3429,11 @@ private:
             {
                 // File server
                 assert(socket && "Must have a valid socket");
-                constexpr auto ProxyRemote = "/remote/static/";
+                constexpr auto ProxyRemote = "/remote/";
                 constexpr auto ProxyRemoteLen = sizeof(ProxyRemote) - 1;
+                constexpr auto ProxyRemoteStatic = "/remote/static/";
                 const auto uri = requestDetails.getURI();
-                const auto pos = uri.find(ProxyRemote);
+                const auto pos = uri.find(ProxyRemoteStatic);
                 if (pos != std::string::npos)
                 {
                     ProxyRequestHandler::handleRequest(uri.substr(pos + ProxyRemoteLen), socket);

--- a/wsd/COOLWSD.hpp
+++ b/wsd/COOLWSD.hpp
@@ -311,6 +311,8 @@ public:
 #endif
     }
 
+    static std::shared_ptr<TerminatingPoll> getWebServerPoll();
+
     /// Return true if extension is marked as view action in discovery.xml.
     static bool IsViewFileExtension(const std::string& extension)
     {

--- a/wsd/ProxyRequestHandler.cpp
+++ b/wsd/ProxyRequestHandler.cpp
@@ -14,4 +14,22 @@
 #include <net/HttpRequest.hpp>
 #include <net/HttpHelper.hpp>
 
+void ProxyRequestHandler::handleRequest(const std::string& relPath,
+                                        const std::shared_ptr<StreamSocket>& socket)
+{
+    Poco::URI uriProxy(ProxyServer);
+
+    uriProxy.setPath(relPath);
+    auto sessionProxy = http::Session::create(uriProxy.getHost(),
+                                              http::Session::Protocol::HttpSsl,
+                                              uriProxy.getPort());
+    sessionProxy->setTimeout(std::chrono::seconds(10));
+    http::Request requestProxy(uriProxy.getPathAndQuery());
+
+    if (!sessionProxy->asyncRequest(requestProxy, *COOLWSD::getWebServerPoll()))
+    {
+        HttpHelper::sendErrorAndShutdown(400, socket);
+    }
+}
+
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/ProxyRequestHandler.cpp
+++ b/wsd/ProxyRequestHandler.cpp
@@ -68,9 +68,14 @@ void ProxyRequestHandler::handleRequest(const std::string& relPath,
                         HttpHelper::sendErrorAndShutdown(400, socket);
                     }
                 }
+                catch(std::exception& exc)
+                {
+                    LOG_ERR("ProxyCallback: " << exc.what());
+                    HttpHelper::sendErrorAndShutdown(400, socket);
+                }
                 catch(...)
                 {
-                    LOG_DBG("ProxyCallback: Unknown exception");
+                    LOG_ERR("ProxyCallback: Unknown exception");
                     HttpHelper::sendErrorAndShutdown(400, socket);
                 }
             };

--- a/wsd/ProxyRequestHandler.cpp
+++ b/wsd/ProxyRequestHandler.cpp
@@ -14,7 +14,7 @@
 #include <net/HttpRequest.hpp>
 #include <net/HttpHelper.hpp>
 
-std::map<std::string, std::shared_ptr<http::Response>> ProxyRequestHandler::CacheFileHash;
+std::unordered_map<std::string, std::shared_ptr<http::Response>> ProxyRequestHandler::CacheFileHash;
 std::chrono::system_clock::time_point ProxyRequestHandler::MaxAge;
 
 void ProxyRequestHandler::handleRequest(const std::string& relPath,

--- a/wsd/ProxyRequestHandler.cpp
+++ b/wsd/ProxyRequestHandler.cpp
@@ -1,0 +1,17 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <config.h>
+
+#include <Poco/URI.h>
+
+#include <COOLWSD.hpp>
+#include "ProxyRequestHandler.hpp"
+#include <net/HttpRequest.hpp>
+#include <net/HttpHelper.hpp>
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/ProxyRequestHandler.cpp
+++ b/wsd/ProxyRequestHandler.cpp
@@ -57,6 +57,9 @@ void ProxyRequestHandler::handleRequest(const std::string& relPath,
                         }
 
                         CacheFileHash[httpSession->getUrl()] = httpResponse;
+
+                        httpResponse->add("Server", HTTP_SERVER_STRING);
+                        httpResponse->add("Date", Util::getHttpTimeNow());
                         socket->sendAndShutdown(*httpResponse);
                     }
                     else

--- a/wsd/ProxyRequestHandler.hpp
+++ b/wsd/ProxyRequestHandler.hpp
@@ -18,7 +18,7 @@ public:
 
 private:
     static std::chrono::system_clock::time_point MaxAge;
-    static constexpr auto ProxyServer = "https://www.collaboraoffice.com";
+    static constexpr auto ProxyServer = "https://rating.collaboraonline.com";
     static std::unordered_map<std::string, std::shared_ptr<http::Response>> CacheFileHash;
 };
 

--- a/wsd/ProxyRequestHandler.hpp
+++ b/wsd/ProxyRequestHandler.hpp
@@ -18,6 +18,7 @@ public:
 
 private:
     static constexpr auto ProxyServer = "https://www.collaboraoffice.com";
+    static std::map<std::string, std::shared_ptr<http::Response>> CacheFileHash;
 };
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/ProxyRequestHandler.hpp
+++ b/wsd/ProxyRequestHandler.hpp
@@ -17,6 +17,7 @@ public:
                               const std::shared_ptr<StreamSocket>& socket);
 
 private:
+    static std::chrono::system_clock::time_point MaxAge;
     static constexpr auto ProxyServer = "https://www.collaboraoffice.com";
     static std::map<std::string, std::shared_ptr<http::Response>> CacheFileHash;
 };

--- a/wsd/ProxyRequestHandler.hpp
+++ b/wsd/ProxyRequestHandler.hpp
@@ -19,7 +19,7 @@ public:
 private:
     static std::chrono::system_clock::time_point MaxAge;
     static constexpr auto ProxyServer = "https://www.collaboraoffice.com";
-    static std::map<std::string, std::shared_ptr<http::Response>> CacheFileHash;
+    static std::unordered_map<std::string, std::shared_ptr<http::Response>> CacheFileHash;
 };
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/ProxyRequestHandler.hpp
+++ b/wsd/ProxyRequestHandler.hpp
@@ -12,6 +12,12 @@
 
 class ProxyRequestHandler
 {
+public:
+    static void handleRequest(const std::string& relPath,
+                              const std::shared_ptr<StreamSocket>& socket);
+
+private:
+    static constexpr auto ProxyServer = "https://www.collaboraoffice.com";
 };
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/ProxyRequestHandler.hpp
+++ b/wsd/ProxyRequestHandler.hpp
@@ -1,0 +1,17 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <string>
+#include "Socket.hpp"
+
+class ProxyRequestHandler
+{
+};
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */


### PR DESCRIPTION
- wsd: proxy: add ProxyRequestHandler files
- wsd: proxy: add handler request function
- net: add getter funtion "getUrl"
- net: add "response" getter function
- wsd: proxy: add a callback response handler
- wsd: proxy: add cache response
- wsd: proxy: handle cache max age
- wsd: proxy: modify basic headers to forward
- wsd: proxy: handle the proxy request
- wsd: proxy: simplify time_point
- wsd: proxy: add missing catcher exception
- wsd: proxy: replace std::map -> std::std::unordered_map
- wsd: proxy: ensure to forward only static files
- wsd: proxy: fix length static string
