### PR TITLE
Keep custom buttons when switching the view

### DIFF
--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -23,6 +23,7 @@ L.Control.Notebookbar = L.Control.extend({
 	onAdd: function (map) {
 		// log and test window.ThisIsTheiOSApp = true;
 		this.map = map;
+		this.additionalShortcutButtons = [];
 		this._currentScrollPosition = 0;
 		var docType = this._map.getDocType();
 

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -9,6 +9,7 @@ L.Control.UIManager = L.Control.extend({
 	mobileWizard: null,
 	blockedUI: false,
 	busyPopupTimer: null,
+	customButtons: [], // added by WOPI InsertButton
 
 	onAdd: function (map) {
 		this.map = map;
@@ -337,6 +338,7 @@ L.Control.UIManager = L.Control.extend({
 
 		this.setSavedState('CompactMode', uiMode.mode === 'classic');
 		this.initializeSidebar();
+		this.insertCustomButtons();
 	},
 
 	// UI modification
@@ -380,11 +382,30 @@ L.Control.UIManager = L.Control.extend({
 		}
 	},
 
+	// called by the WOPI API to register new custom button
 	insertButton: function(button) {
+		for (var i in this.customButtons) {
+			var item = this.customButtons[i];
+			if (item.id === button.id)
+				return;
+		}
+
+		this.customButtons.push(button);
+		this.insertCustomButton(button);
+	},
+
+	// insert custom button to the current UI
+	insertCustomButton: function(button) {
 		if (!this.notebookbar)
 			this.insertButtonToClassicToolbar(button);
 		else
 			this.notebookbar.insertButtonToShortcuts(button);
+	},
+
+	// add all custom buttons to the current UI - on view mode change
+	insertCustomButtons: function() {
+		for (var i in this.customButtons)
+			this.insertCustomButton(this.customButtons[i]);
 	},
 
 	showButtonInClassicToolbar: function(buttonId, show) {


### PR DESCRIPTION
When we use API call InsertButton and we add custom buttons
we want to keep them when we switch between compact/tabbed view.
