### PR TITLE
private/pedro/formula bar padding fixes

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -249,6 +249,10 @@ nav.spreadsheet-color-indicator ~ #sidebar-dock-wrapper {
 #toolbar-wrapper:not(.mobile) {
 	padding: 3px 0;
 }
+/* Remove bottom padding in calc as it affects formulabar*/
+#toolbar-wrapper.spreadsheet:not(.mobile) {
+	padding-block-end: 0;
+}
 
 #toolbar-logo {
 	width: 0;

--- a/browser/css/device-mobile.css
+++ b/browser/css/device-mobile.css
@@ -182,10 +182,6 @@ div#w2ui-overlay-actionbar.w2ui-overlay{
 #document-name-input {
 	display: none;
 }
-
-#tb_formulabar_item_address {
-	vertical-align: middle;
-}
 /* Related to selectionMarkers.css */
 .inputbar_multiline #tb_formulabar_item_formula > div,
 .inputbar_multiline #tb_formulabar_item_address > div {

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1169,7 +1169,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 
 /* formulabar */
 #sc_input_window.formulabar {
-	height: 29px;
+	height: 28px;
 	border: 1px solid var(--color-border);
 	flex-grow: 1;
 	resize: none !important;
@@ -1190,10 +1190,6 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	border-radius: var(--border-radius) 0 var(--border-radius) var(--border-radius) !important;
 }
 
-.expanded .formulabar.unotoolbutton {
-	margin-block-start: 5px;
-}
-
 .formulabar.unotoolbutton {
 	margin-inline-end: 4px !important;
 	opacity: 0.8;
@@ -1210,7 +1206,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 }
 
 #expand.formulabar {
-	height: 29px !important;
+	height: 28px !important;
 	margin: 0 !important;
 	border-radius: 0 var(--border-radius) var(--border-radius) 0 !important;
 	border-inline-start: none !important;

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1211,7 +1211,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 
 #expand.formulabar {
 	height: 29px !important;
-	margin: 0 5px 0 0 !important;
+	margin: 0 !important;
 	border-radius: 0 var(--border-radius) var(--border-radius) 0 !important;
 	border-inline-start: none !important;
 	background-color: var(--color-main-background) !important;

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1175,7 +1175,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	resize: none !important;
 	max-width: unset !important;
 	font-size: calc(var(--default-font-size)*1.2) !important;
-	line-height: calc(var(--default-font-size)*1.6);
+	line-height: 1.2;
 	color: var(--color-main-text);
 	background-color: var(--color-background-lighter);
 	border-radius: var(--border-radius) 0 0 var(--border-radius);

--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -151,6 +151,7 @@ w2ui-toolbar {
 	background-color: var(--color-main-background);
 	border-top: 1px solid var(--color-border);
 	height: 30px;
+	padding: 0 4px;
 }
 
 #tb_formulabar_item_address {

--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -163,6 +163,10 @@ w2ui-toolbar {
 	vertical-align: top;
 }
 
+#formulabar.expanded #tb_formulabar_item_address * {
+	vertical-align: top;
+}
+
 #presentation-toolbar {
 	bottom: 0;
 	background-color: var(--color-main-background);

--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -154,8 +154,11 @@ w2ui-toolbar {
 	padding: 0 4px;
 }
 
+#formulabar.expanded {
+	padding-block: 5px;
+}
+
 #tb_formulabar_item_address {
-	padding-block-start: 2px;
 	padding-inline-end: 5px;
 	vertical-align: top;
 }
@@ -210,7 +213,7 @@ w2ui-toolbar {
 }
 
 #addressInput {
-	height: 29px;
+	height: 28px;
 	width: 100px;
 	color: var(--color-main-text);
 	background-color: var(--color-background-lighter);
@@ -220,7 +223,6 @@ w2ui-toolbar {
 
 #tb_formulabar_item_formula {
 	width: 100%;
-	padding-top: 4px;
 }
 
 #tb_formulabar_item_formula div table {

--- a/browser/src/control/Control.FormulaBarJSDialog.js
+++ b/browser/src/control/Control.FormulaBarJSDialog.js
@@ -101,6 +101,7 @@ L.Control.FormulaBarJSDialog = L.Control.extend({
 		if (L.DomUtil.hasClass(input, 'expanded')) {
 			L.DomUtil.removeClass(input, 'expanded');
 			L.DomUtil.removeClass(L.DomUtil.get('calc-inputbar-wrapper'), 'expanded');
+			L.DomUtil.removeClass(L.DomUtil.get('formulabar'), 'expanded');
 			this.onJSUpdate({
 				data: {
 					jsontype: 'formulabar',
@@ -117,6 +118,7 @@ L.Control.FormulaBarJSDialog = L.Control.extend({
 		} else {
 			L.DomUtil.addClass(input, 'expanded');
 			L.DomUtil.addClass(L.DomUtil.get('calc-inputbar-wrapper'), 'expanded');
+			L.DomUtil.addClass(L.DomUtil.get('formulabar'), 'expanded');
 			this.onJSUpdate({
 				data: {
 					jsontype: 'formulabar',

--- a/cypress_test/integration_tests/desktop/calc/scrolling_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/scrolling_spec.js
@@ -25,7 +25,7 @@ describe('Scroll through document', function() {
 
 		desktopHelper.pressKey(3,'pagedown');
 
-		desktopHelper.assertScrollbarPosition('vertical', 191, 224);
+		desktopHelper.assertScrollbarPosition('vertical', 191, 230);
 
 		desktopHelper.pressKey(3,'pageup');
 


### PR DESCRIPTION
- Fix horizontal padding around formulabar
- Fix formulabar vertical padding and odd numbers
- Fix formulabar's item address input field vertical alignment
- Formulabar: no need to use calc for line-height
- Fix formulabar's address input vertical pos on mobile
- Formulabar: remove bottom padding from toolbar-wrapper
