### PR TITLE
Private/pedro/improvements n fixes user list popover backporting

### DIFF
--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -1270,7 +1270,7 @@ html[dir='rtl'] #userListPopover::after {
 }
 
 #userListPopover #follow-editor {
-	padding: 6px 4px;
+	padding: 8px;
 }
 
 #userListPopover #follow-editor .follow-editor-checkbox {

--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -1265,6 +1265,8 @@ html[dir='rtl'] #userListPopover::after {
 
 #userListPopover .user-list-item.selected-user {
 	background-color: var(--color-background-dark);
+	display: grid;
+	grid-template-columns: 0fr 1fr;
 }
 
 #userListPopover #follow-editor {
@@ -1279,6 +1281,22 @@ html[dir='rtl'] #userListPopover::after {
 	width: 16px;
 	box-shadow: none !important;
 	background-position: center;
+}
+
+#userListPopover .user-list-item:not(.selected-user) .user-list-item--following-label {
+	display: none;
+}
+
+#userListPopover .user-list-item.selected-user .user-list-item--following-label {
+	display: flex;
+	padding-inline-start: 8px;
+	font-size: var(--default-font-size);
+	padding-block-end: 4px;
+	color: var(--color-text-lighter);
+}
+
+#userListPopover .user-list-item.selected-user .user-list-item--name {
+	padding: 4px 0 0 8px;
 }
 
 @media only screen and (max-width: 600px) {

--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -1252,6 +1252,11 @@ html[dir='rtl'] #userListPopover::after {
 	padding: 4px 8px;
 }
 
+#userListPopover .user-list-item:hover {
+	cursor: pointer;
+	background-color: var(--color-background-dark);
+}
+
 #userListPopover .user-list-item--name {
 	display: flex;
 	flex-grow: 1;

--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -1216,7 +1216,7 @@ menu-entry-with-icon.padding-left + menu-entry-icon.width */
 	top: 38px;
 	right: 5px;
 	color: var(--color-main-text);
-	background-color: var(--color-background-lighter);
+	background-color: var(--color-main-background);
 	border-radius: var(--border-radius);
 	filter: drop-shadow(0 1px 3px var(--color-box-shadow));
 	min-width: 150px;

--- a/browser/src/control/Control.Toolbar.js
+++ b/browser/src/control/Control.Toolbar.js
@@ -1097,6 +1097,7 @@ function editorUpdate(e) { // eslint-disable-line no-unused-vars
 		docLayer._followThis = -1;
 	}
 	$('#tb_actionbar_item_userlist').w2overlay('');
+	$('#userListPopover').hide();
 }
 
 global.editorUpdate = editorUpdate;

--- a/browser/src/control/Control.UserList.js
+++ b/browser/src/control/Control.UserList.js
@@ -60,6 +60,7 @@ L.Control.UserList = L.Control.extend({
 	},
 
 	followUser: function(viewId) {
+		$('#userListPopover').hide();
 		var docLayer = this.map._docLayer;
 		this.map._goToViewId(viewId);
 

--- a/browser/src/control/Control.UserList.js
+++ b/browser/src/control/Control.UserList.js
@@ -155,11 +155,17 @@ L.Control.UserList = L.Control.extend({
 			var userLabel = L.DomUtil.create('div', 'user-list-item--name');
 			userLabel.innerText = user.userName;
 
+			var userFollowingLabel = L.DomUtil.create('div', 'user-list-item--following-label');
+			userFollowingLabel.innerText = _('Following');
+			var userLabelContainer = L.DomUtil.create('div', 'user-list-item--name-container');
+			userLabelContainer.appendChild(userLabel);
+			userLabelContainer.appendChild(userFollowingLabel);
+
 			var listItem = L.DomUtil.create('div', 'user-list-item');
 			listItem.setAttribute('data-view-id', user.viewId);
 			listItem.setAttribute('role', 'button');
 			listItem.appendChild(L.control.createAvatar(user.viewId, user.userName, user.extraInfo, user.color));
-			listItem.appendChild(userLabel);
+			listItem.appendChild(userLabelContainer);
 			listItem.addEventListener('click', function () {
 				that.followUser(user.viewId);
 			}, false);


### PR DESCRIPTION
Backport of https://github.com/CollaboraOnline/online/pull/4965

commit 7540608786e18168e43cbf51d76746b8cfb3f19d (HEAD -> private/pedro/improvements-n-fixes-userListPopover-backporting, origin/private/pedro/improvements-n-fixes-userListPopover-backporti
ng, distro/collabora/co-21-11)
Date:   Wed Jun 29 14:48:47 2022 +0200

    Fix padding in follow editor's entry (userListPopover)
    
    Use the same padding as the user names and thus fixing the
    alignment (vertical: checkbox vs avatars)
    
    Change-Id: I1acb8cf5e3e5dc8aad083151c9c54b38aa552d6c

-----


commit 433035bfc56abe039aa1498525988c646416ff47
Date:   Wed Jun 29 14:44:51 2022 +0200

    Add following label to userListPopover (avatar list)
    
    Until now user was reporting not fully understanding all the
    features that user userListPopover offers. Namely, not knowing
    that not only is possible to follow the editor (checkbox) but
    that it is also possible to follow a specific user from the list
    
    Make it easier to understand what's the current following status
    by adding "Following" under the selected user name in the list
    
    Change-Id: I0beba5df06f2cc7a9a349ef8f93db6b403befb9b

-----


commit d3c3b663e2a0a530380a6b096f660e8ccdec0259
Date:   Wed Jun 29 10:15:30 2022 +0200

    Hide avatars list when follow editor changes status
    
    Get rid of the popover once the user completes the action
    Probably better to avoid having hanging popover (that have no
    close btn) and instead close them, specially because this
    one can always be re-opened at anytime from omnipresent
    toolbar and without risk of triggering any additional change
    
    Change-Id: Id7946512e6c54622e3ed20b28d56178c05b18b5c

-----


commit 74b4756a647b266f6117f1c7925113df7831bf1c
Date:   Wed Jun 29 09:46:16 2022 +0200

    Hide avatars list when a user entry is selected
    
    Make sure the avatar list popover automatically gets out of the
    way once the user selects an entry (follow user)
    
    Change-Id: Ie83a587e4f9900ffb0d70cadbfb13cfe81d8b849

-----


commit 27da1d5c7e7417af0398dd6c08582c52ab0fe88e
Date:   Tue Jun 28 16:07:57 2022 +0200

    Avatars list: Add missing hover styles
    
    Change-Id: I6a5b215316a988ad0649982415c2d8ce6fab1212

-----


commit 58f045910fe16259c11e81db3afa5cec0a241350
Date:   Tue Jun 28 15:44:07 2022 +0200

    Use the same bg for #userListPopover and its pointing triangle
    
    Before the triangle was getting a different bg when compared
    to #userListPopover
    
    Change-Id: If110d9e1178bedb7e858804e169689ee97a5a385

-----

