### PR TITLE
formulabar fixes: backward selection, focus on Gnome Web / Safari

### DIFF
--- a/browser/src/control/Control.FormulaBarJSDialog.js
+++ b/browser/src/control/Control.FormulaBarJSDialog.js
@@ -238,11 +238,12 @@ L.Control.FormulaBarJSDialog = L.Control.extend({
 		this.builder.setWindowId(data.id);
 
 		if (this.container) {
-			var keepFocus = this.hasFocus();
+			var keepInputFocus = data.data && data.data.control_id === 'sc_input_window'
+				&& this.hasFocus();
 
 			this.builder.executeAction(this.container, data.data);
 
-			if (keepFocus)
+			if (keepInputFocus)
 				this.focus();
 		} else
 			this.createFormulabar(data.data.text);

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -3215,7 +3215,8 @@ L.Control.JSDialogBuilder = L.Control.extend({
 				if (selection.length === 2) {
 					var start = parseInt(selection[0]);
 					var end = parseInt(selection[1]);
-					control.setSelectionRange(start, end);
+					if (document.activeElement === control) // Safari/Gnome Web compatibility
+						control.setSelectionRange(start, end);
 				} else if (selection.length === 4) {
 					var startPos = parseInt(selection[0]);
 					var endPos = parseInt(selection[1]);
@@ -3244,7 +3245,8 @@ L.Control.JSDialogBuilder = L.Control.extend({
 
 					end += endPos;
 
-					control.setSelectionRange(start, end);
+					if (document.activeElement === control) // Safari/Gnome Web compatibility
+						control.setSelectionRange(start, end);
 				}
 			}
 			break;

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -3215,6 +3215,13 @@ L.Control.JSDialogBuilder = L.Control.extend({
 				if (selection.length === 2) {
 					var start = parseInt(selection[0]);
 					var end = parseInt(selection[1]);
+
+					if (start > end) {
+						var tmp = start;
+						start = end;
+						end = tmp;
+					}
+
 					if (document.activeElement === control) // Safari/Gnome Web compatibility
 						control.setSelectionRange(start, end);
 				} else if (selection.length === 4) {
@@ -3244,6 +3251,12 @@ L.Control.JSDialogBuilder = L.Control.extend({
 					}
 
 					end += endPos;
+
+					if (start > end) {
+						var tmp = start;
+						start = end;
+						end = tmp;
+					}
 
 					if (document.activeElement === control) // Safari/Gnome Web compatibility
 						control.setSelectionRange(start, end);


### PR DESCRIPTION
    jsdialog: formulabar: fix backward selection using shift+arrow
    
    When editing formulabar using keyboard - try to use shift + arrow
    to make selection from the end in backward direction.
    
    This patch makes it possible (visible).
    
    Signed-off-by: Szymon K\u0142os <szymon.klos@collabora.com>
    Change-Id: I48073214545892d98be097b38c60251ff95082f3

-------------------------------------------------------------------------------------------------

    jsdialog: formulabar: unify behaviour of Safari/Gnome Web with other browsers
    
    eg. Chrome setups selection only if element has focus
    it prevents us from stealing focus by formulabar when
    switching cells
