### PR TITLE
docker: update start-collabora-online.pl to allow regex

### DIFF
--- a/docker/from-packages/scripts/start-collabora-online.pl
+++ b/docker/from-packages/scripts/start-collabora-online.pl
@@ -50,11 +50,6 @@ sub generate_aliases() {
         if (@hosts) {
             my $i = 0;
             foreach (@hosts) {
-                if ($_ =~ /[^a-zA-Z0-9\_.\-\/]/)
-                {
-                    print "WARNING: $_ seems to be regex, If you want to use regex please use aliasgroupX env variable where X=1,2,3... \nMore information:\n    https://sdk.collaboraonline.com/docs/installation/CODE_Docker_image.html\n";
-                    exit 1;
-                }
                 $i++;
                 $message .= "   aliasgroup".$i."=https://$_:443\n";
                 $output .= "                <group>\n";


### PR DESCRIPTION
because we now support having regex in alias_groups.group.host
for more info: https://github.com/CollaboraOnline/online/commit/45891d0ded75b69a29b6ac3b25339da98a5b3eda

Signed-off-by: Rash419 <rashesh.padia@collabora.com>
Change-Id: Ib8c16cd7db18719076d62347738e23bbefaa9204

* Target version: master 