### PR TITLE
private/pedro/fix snackbar n improvements

### DIFF
--- a/browser/css/device-mobile.css
+++ b/browser/css/device-mobile.css
@@ -834,6 +834,13 @@ td[id^='tb_spreadsheet-toolbar_item']:focus table.w2ui-button div.w2ui-icon, td[
 	margin: 16px 5% !important;
 	width: 90%;
 	position: absolute;
+	border-radius: var(--border-radius);
+}
+#mobile-wizard.popup.snackbar #label {
+	font-size: var(--default-font-size) !important;
+}
+#mobile-wizard.popup.snackbar #button {
+	font-size: 14px !important;
 }
 /*   - Import text */
 #mobile-wizard-content #separatoroptions {

--- a/browser/css/device-mobile.css
+++ b/browser/css/device-mobile.css
@@ -802,7 +802,7 @@ td[id^='tb_spreadsheet-toolbar_item']:focus table.w2ui-button div.w2ui-icon, td[
 
 /* busy popup */
 
-#mobile-wizard.popup {
+#mobile-wizard.popup:not(.snackbar) {
 	border-radius: 16px 16px 0 0;
 }
 #mobile-wizard.popup #mobile-wizard-content {

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1074,6 +1074,9 @@ input[type='number']:hover::-webkit-outer-spin-button {
 }
 
 /* snackbar */
+#snackbar {
+	border: none !important;
+}
 #mobile-wizard.popup.snackbar,
 .snackbar.jsdialog-container .ui-dialog-content {
 	min-width: 200px;

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1080,12 +1080,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 #mobile-wizard.popup.snackbar,
 .snackbar.jsdialog-container .ui-dialog-content {
 	min-width: 200px;
-	background-color: #565f77 !important;
-	border-radius: var(--border-radius) !important;
-}
-
-.snackbar.jsdialog-container .lokdialog.ui-dialog-content.ui-widget-content {
-	border-radius: 0 !important;
+	background-color: #323232 !important;
 }
 
 #mobile-wizard.popup.snackbar #label,
@@ -1127,10 +1122,15 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	padding-right: 0;
 }
 
-#mobile-wizard.popup.snackbar #button span,
-.snackbar.jsdialog-container #button span {
-	color: #c8e7f9ff;
-	font-weight: bold;
+#mobile-wizard.popup.snackbar #button,
+#snackbar.jsdialog-container #button {
+	color: #469cff !important;
+	font-weight: 600;
+	font-size: var(--header-font-size) !important;
+	padding: 8px;
+}
+#snackbar.jsdialog-container #button:hover {
+	background-color: #ffffff15 !important;
 }
 
 /* toolbuttons */

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -68,7 +68,7 @@
 	border: 1px solid var(--color-border-dark);
 	-webkit-box-shadow: 0 0 3px var(--color-border);
 	box-shadow: 0 0 3px var(--color-box-shadow);
-	border-radius: calc(var(--border-radius)/2);
+	border-radius: var(--border-radius);
 	background: var(--color-background-darker);
 }
 


### PR DESCRIPTION
- jsDialogs: Avoid uncertain border radius
- Remove snackbar's border
- Snackbar: Fix contrast, remove unnecessary rules
- Mobile: Do not allow rules from busypopup to affect snackbar
