### PR TITLE
cypress: clipboard formatting new lines fix 2

### DIFF
--- a/cypress_test/integration_tests/desktop/writer/searchbar_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/searchbar_spec.js
@@ -22,8 +22,7 @@ describe('Searching via search bar' ,function() {
 		// Part of the text should be selected
 		helper.textSelectionShouldExist();
 
-		cy.get('#copy-paste-container p')
-			.should('have.text', '\na');
+		helper.expectTextForClipboard('a');
 	});
 
 	it('Search not existing word.', function() {
@@ -53,8 +52,7 @@ describe('Searching via search bar' ,function() {
 
 		helper.textSelectionShouldExist();
 
-		cy.get('#copy-paste-container p')
-			.should('have.text', '\na');
+		helper.expectTextForClipboard('a');
 
 		cy.get('#copy-paste-container p b')
 			.should('not.exist');
@@ -67,8 +65,7 @@ describe('Searching via search bar' ,function() {
 
 		helper.textSelectionShouldExist();
 
-		cy.get('#copy-paste-container p')
-			.should('have.text', '\na');
+		helper.expectTextForClipboard('a');
 
 		// Search prev instance
 		searchHelper.searchPrevDesktop();
@@ -78,16 +75,14 @@ describe('Searching via search bar' ,function() {
 
 		helper.textSelectionShouldExist();
 
-		cy.get('#copy-paste-container p')
-			.should('have.text', '\na');
+		helper.expectTextForClipboard('a');
 	});
 	it('Search wrap at document end.', function() {
 		searchHelper.typeIntoSearchFieldDesktop('a');
 
 		helper.textSelectionShouldExist();
 
-		cy.get('#copy-paste-container p')
-			.should('have.text', '\na');
+		helper.expectTextForClipboard('a');
 
 		cy.get('#copy-paste-container p b')
 			.should('not.exist');
@@ -100,8 +95,7 @@ describe('Searching via search bar' ,function() {
 
 		helper.textSelectionShouldExist();
 
-		cy.get('#copy-paste-container p')
-			.should('have.text', '\na');
+		helper.expectTextForClipboard('a');
 
 		// Search next instance, which is in the beginning of the document.
 		searchHelper.searchNextDesktop();
@@ -111,8 +105,7 @@ describe('Searching via search bar' ,function() {
 
 		helper.textSelectionShouldExist();
 
-		cy.get('#copy-paste-container p')
-			.should('have.text', '\na');
+		helper.expectTextForClipboard('a');
 	});
 
 	it('Cancel search.', function() {
@@ -121,8 +114,7 @@ describe('Searching via search bar' ,function() {
 		// Part of the text should be selected
 		helper.textSelectionShouldExist();
 
-		cy.get('#copy-paste-container p')
-			.should('have.text', '\na');
+		helper.expectTextForClipboard('a');
 
 		// Cancel search -> selection removed
 		searchHelper.cancelSearchDesktop();

--- a/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
@@ -321,8 +321,7 @@ describe('Top toolbar tests.', function() {
 	});
 
 	it('Insert hyperlink.', function() {
-		cy.get('#copy-paste-container p')
-			.should('have.text', '\ntext text1');
+		helper.expectTextForClipboard('text text1');
 
 		mode === 'notebookbar' ? cy.get('#Insert-tab-label').click() : '';
 
@@ -345,8 +344,7 @@ describe('Top toolbar tests.', function() {
 
 		writerHelper.selectAllTextOfDoc();
 
-		cy.get('#copy-paste-container p')
-			.should('have.text', '\ntext text1link');
+		helper.expectTextForClipboard('text text1link');
 
 		cy.get('#copy-paste-container p a')
 			.should('have.attr', 'href', 'http://www.something.com/');

--- a/cypress_test/integration_tests/mobile/writer/hamburger_menu_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/hamburger_menu_spec.js
@@ -253,8 +253,7 @@ describe('Trigger hamburger menu options.', function() {
 		helper.textSelectionShouldExist();
 
 		// We should have 'q' selected.
-		cy.get('#copy-paste-container p')
-			.should('have.text', '\nq');
+		helper.expectTextForClipboard('q');
 
 		// Then disable recording.
 		mobileHelper.selectHamburgerMenuItem(['Track Changes', 'Record']);
@@ -266,8 +265,7 @@ describe('Trigger hamburger menu options.', function() {
 		helper.textSelectionShouldExist();
 
 		// We should have 'q' selected.
-		cy.get('#copy-paste-container p')
-			.should('have.text', '\nq');
+		helper.expectTextForClipboard('q');
 	});
 
 	it('Show track changes.', function() {
@@ -283,8 +281,7 @@ describe('Trigger hamburger menu options.', function() {
 		writerHelper.selectAllTextOfDoc();
 
 		// No actual text sent from core because of the removal.
-		cy.get('#copy-paste-container p')
-			.should('have.text', '\n\n\n');
+		helper.expectTextForClipboard('\n\n');
 
 		// We have a multiline selection
 		cy.get('.leaflet-selection-marker-start')
@@ -349,8 +346,7 @@ describe('Trigger hamburger menu options.', function() {
 		writerHelper.selectAllTextOfDoc();
 
 		// We don't have actual text content.
-		cy.get('#copy-paste-container p')
-			.should('have.text', '\n\n\n');
+		helper.expectTextForClipboard('\n\n');
 
 		// Reject removal.
 		mobileHelper.selectHamburgerMenuItem(['Track Changes', 'Reject All']);
@@ -374,20 +370,17 @@ describe('Trigger hamburger menu options.', function() {
 		// Find second change using prev.
 		mobileHelper.selectHamburgerMenuItem(['Track Changes', 'Previous']);
 
-		cy.get('#copy-paste-container p')
-			.should('have.text', '\nw');
+		helper.expectTextForClipboard('w');
 
 		// Find first change using prev.
 		mobileHelper.selectHamburgerMenuItem(['Track Changes', 'Previous']);
 
-		cy.get('#copy-paste-container p')
-			.should('have.text', '\nq');
+		helper.expectTextForClipboard('q');
 
 		// Find second change using next.
 		mobileHelper.selectHamburgerMenuItem(['Track Changes', 'Next']);
 
-		cy.get('#copy-paste-container p')
-			.should('have.text', '\nw');
+		helper.expectTextForClipboard('w');
 	});
 
 	it('Search some word.', function() {
@@ -408,8 +401,7 @@ describe('Trigger hamburger menu options.', function() {
 		// Part of the text should be selected
 		helper.textSelectionShouldExist();
 
-		cy.get('#copy-paste-container p')
-			.should('have.text', '\na');
+		helper.expectTextForClipboard('a');
 
 		cy.get('#copy-paste-container p b')
 			.should('not.exist');

--- a/cypress_test/integration_tests/mobile/writer/insert_object_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/insert_object_spec.js
@@ -291,8 +291,7 @@ describe('Insert objects via insertion wizard.', function() {
 
 		writerHelper.selectAllTextOfDoc();
 
-		cy.get('#copy-paste-container p')
-			.should('have.text', '\nsome text');
+		helper.expectTextForClipboard('some text');
 
 		cy.get('#copy-paste-container p a')
 			.should('have.attr', 'href', 'http://www.something.com/');

--- a/cypress_test/integration_tests/mobile/writer/searchbar_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/searchbar_spec.js
@@ -27,8 +27,7 @@ describe('Searching via search bar.', function() {
 		// Part of the text should be selected
 		helper.textSelectionShouldExist();
 
-		cy.get('#copy-paste-container p')
-			.should('have.text', '\na');
+		helper.expectTextForClipboard('a');
 	});
 
 	it('Search not existing word.', function() {
@@ -44,8 +43,7 @@ describe('Searching via search bar.', function() {
 
 		helper.textSelectionShouldExist();
 
-		cy.get('#copy-paste-container p')
-			.should('have.text', '\na');
+		helper.expectTextForClipboard('a');
 
 		cy.get('#copy-paste-container p b')
 			.should('not.exist');
@@ -58,8 +56,7 @@ describe('Searching via search bar.', function() {
 
 		helper.textSelectionShouldExist();
 
-		cy.get('#copy-paste-container p')
-			.should('have.text', '\na');
+		helper.expectTextForClipboard('a');
 
 		// Search prev instance
 		searchHelper.searchPrev();
@@ -69,8 +66,7 @@ describe('Searching via search bar.', function() {
 
 		helper.textSelectionShouldExist();
 
-		cy.get('#copy-paste-container p')
-			.should('have.text', '\na');
+		helper.expectTextForClipboard('a');
 	});
 
 	it('Search at the document end.', function() {
@@ -78,8 +74,7 @@ describe('Searching via search bar.', function() {
 
 		helper.textSelectionShouldExist();
 
-		cy.get('#copy-paste-container p')
-			.should('have.text', '\na');
+		helper.expectTextForClipboard('a');
 
 		cy.get('#copy-paste-container p b')
 			.should('not.exist');
@@ -92,8 +87,7 @@ describe('Searching via search bar.', function() {
 
 		helper.textSelectionShouldExist();
 
-		cy.get('#copy-paste-container p')
-			.should('have.text', '\na');
+		helper.expectTextForClipboard('a');
 
 		// Search next instance, which is in the beginning of the document.
 		searchHelper.searchNext();
@@ -103,8 +97,7 @@ describe('Searching via search bar.', function() {
 
 		helper.textSelectionShouldExist();
 
-		cy.get('#copy-paste-container p')
-			.should('have.text', '\na');
+		helper.expectTextForClipboard('a');
 	});
 
 	it('Cancel search.', function() {
@@ -113,8 +106,7 @@ describe('Searching via search bar.', function() {
 		// Part of the text should be selected
 		helper.textSelectionShouldExist();
 
-		cy.get('#copy-paste-container p')
-			.should('have.text', '\na');
+		helper.expectTextForClipboard('a');
 
 		// Cancel search -> selection removed
 		searchHelper.cancelSearch();
@@ -131,8 +123,7 @@ describe('Searching via search bar.', function() {
 		// Part of the text should be selected
 		helper.textSelectionShouldExist();
 
-		cy.get('#copy-paste-container p')
-			.should('have.text', '\na');
+		helper.expectTextForClipboard('a');
 
 		// Close search -> search bar is closed
 		searchHelper.closeSearchBar();


### PR DESCRIPTION
Our plain text clipboard output generated additional newlines
at the beginning of every paragraph. To fix that we need
fix in core side which now fails due to expected bad format in cypress.
This is interim state where we accept both old and new format.

see for reference: https://gerrit.libreoffice.org/c/core/+/136893
lok: don't pretty print html for online
Change-Id: I2b17d62398d947fcf1d3fb1ed6005c3063d114f2
