### PR TITLE
cypress: allow correct plain text clipboard formatting 3

### DIFF
--- a/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
@@ -587,7 +587,7 @@ describe('Top toolbar tests.', function() {
 		helper.selectAllText();
 
 		var data = [];
-		var expectedData = ['\ntext \n', '\ntext1'];
+		var expectedData = ['text ', 'text1'];
 
 		helper.waitUntilIdle('#copy-paste-container');
 
@@ -598,7 +598,16 @@ describe('Top toolbar tests.', function() {
 					data.push(text);
 				});
 			cy.log(data);
-		}).then(() => expect(data).to.deep.eq(expectedData));
+		}).then(() => {
+			expect(data.length).eq(expectedData.length);
+			var isEqual = true;
+			for (var i = 0; i < data.length; i++) {
+				isEqual = isEqual && ((data[i] == expectedData[i]) ||
+					(data[i] == '\n' + expectedData[i]) ||
+					(data[i] == '\n' + expectedData[i] + '\n'));
+			}
+			expect(isEqual).to.be.true;
+		});
 
 	});
 


### PR DESCRIPTION
Our plain text clipboard output generated additional newlines
at the beginning of every paragraph. To fix that we need
fix in core side which now fails due to expected bad format in cypress.
This is interim state where we accept both old and new format.

see for reference: https://gerrit.libreoffice.org/c/core/+/136893
lok: don't pretty print html for online
I2b17d62398d947fcf1d3fb1ed6005c3063d114f2
