### PR TITLE
wsd: invoke handlePoll on all sockets

### DIFF
--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -435,8 +435,7 @@ int SocketPoll::poll(int64_t timeoutMaxMicroS)
                     << " at index " << _pollStartIndex << " (of " << size << "): " << std::hex
                     << _pollFds[i].revents << std::dec);
 
-        size_t previ = size;
-        while (previ != _pollStartIndex)
+        for (std::size_t j = 0; j < size; ++j)
         {
             SocketDisposition disposition(_pollSockets[i]);
             try
@@ -457,7 +456,6 @@ int SocketPoll::poll(int64_t timeoutMaxMicroS)
 
             disposition.execute();
 
-            previ = i;
             if (i == 0)
                 i = size - 1;
             else
@@ -474,7 +472,7 @@ int SocketPoll::poll(int64_t timeoutMaxMicroS)
             }
         }
 
-        // In case we remved sockets the new _pollStartIndex might be out of bounds, but we check it
+        // In case we removed sockets the new _pollStartIndex might be out of bounds, but we check it
         // before using it above anyway.
         _pollStartIndex = (_pollStartIndex + 1) % size;
     }


### PR DESCRIPTION
### Summary

Before ed5569da30a3f1d4cd29562c7d14eecd0ce512a8
we invoked handlePoll on all sockets in
each poll. But that's not true anymore.

Since i = _pollStartIndex; (line 432),
when we assigned previ = i; (line 451)
we made previ == _pollStartIndex, which
immediately broke the loop
while (previ != _pollStartIndex)
at line 438, causing handlePoll to be
called on one socket at a time (and
likely *not* the socket that had an event).

It's inefficient to poll and ignore the
result.

Now we do handle revents on multiple
sockets correctly and efficiently for
each ppoll() by going through all sockets
and handling based on whatever revents
gave us. We need to invoke the handler
of each socket to handle timeouts (i.e.
if we don't call the handler until
the socket gets an revent, we wouldn't
be able to support timeouts properly).

Notice that we still start at
a different socket each time (although
it's not entirely clear what advantage
that has, it's maintained all the same)
as the aforementioned patch does.

### Checklist

- [X] Code is properly formatted
- [X] All commits have Change-Id
- [X] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

