### PR TITLE
Added support for setting the timezone in Docker

### DIFF
--- a/docker/README
+++ b/docker/README
@@ -5,6 +5,9 @@ working docker container with Collabora Online.
 
 Docker image can be built from packages or from source code.
 
+All docker images built from this directory can be run with a TZ environment variable
+to set the server timezone to something other than UTC.
+
 Examples:
 
 1. Build latest CODE based on Ubuntu 18.04 LTS

--- a/docker/from-packages/scripts/install-collabora-online-ubuntu.sh
+++ b/docker/from-packages/scripts/install-collabora-online-ubuntu.sh
@@ -9,6 +9,9 @@ apt-get update
 # Install HTTPS transport
 apt-get -y install apt-transport-https
 
+# Install tzdata to accept the TZ environment variable
+apt-get -y install tzdata
+
 # Install some more fonts
 apt-get -y install fonts-open-sans
 

--- a/docker/from-source/Ubuntu
+++ b/docker/from-source/Ubuntu
@@ -7,10 +7,11 @@ FROM ubuntu:18.04
 # refresh repos otherwise installations later may fail
 # install LibreOffice run-time dependencies
 # install adduser, findutils, openssl and cpio that we need later
+# install tzdata to accept the TZ environment variable
 # install an editor
 # tdf#117557 - Add CJK Fonts to Collabora Online Docker Image
 RUN apt-get update && \
-    apt-get -y install libpng16-16 fontconfig adduser cpio \
+    apt-get -y install libpng16-16 fontconfig adduser cpio tzdata \
                findutils nano \
                libcap2-bin openssl openssh-client inotify-tools procps \
                libxcb-shm0 libxcb-render0 libxrender1 libxext6 \

--- a/docker/from-source/openSUSE
+++ b/docker/from-source/openSUSE
@@ -6,10 +6,11 @@ FROM opensuse/leap
 
 # refresh repos otherwise installations later may fail
 # install LibreOffice run-time dependencies
+# install timezone data to accept the TZ environment variable
 # install an editor
 # tdf#117557 - Add CJK Fonts to Collabora Online Docker Image
 RUN zypper ref && \
-    zypper --non-interactive install libcap-progs libpng16-16 fontconfig nano openssh inotify-tools
+    zypper --non-interactive install libcap-progs libpng16-16 fontconfig nano openssh inotify-tools timezone
 
 # copy freshly built LOKit and Collabora Online
 COPY /instdir /


### PR DESCRIPTION
### Summary

Several functions in Collabora Online depend on the server timezone setting.
The most common is possibly the rendering of dates and times using the `<text:date>`
tag in order to include the current date and time in the header or footer of documents.

Unfortunately current docker images do not provide any means to change the timezone
from the default UTC. Linux docker users should be able to mount the system's `/etc/localtime`
and similar system files, but this is a hack, does not support users in other platforms, and
does not seem to work in recent versions of the docker images.

This commit adds the the `tzdata` package to Ubuntu-based docker builds and the
`timezone` package to openSUSE builds. This allows docker users to run the containers
with a custom timezone by simply passing a TZ env variable. For example:

```
docker run -e TZ=Australia/Sydney collabora/code
```

Docker images based on Debian already include the `tzdata` package, therefore no change is needed.

### Checklist

- [X] Code is properly formatted
- [X] All commits have Change-Id
- [X] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

