### PR TITLE
Calc: Add missing class to toolbar-wrapper when on tabbed view

### DIFF
--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -166,6 +166,7 @@ L.Control.UIManager = L.Control.extend({
 			var formulabar = L.control.formulaBarJSDialog();
 			this.map.formulabar = formulabar;
 			this.map.addControl(formulabar);
+			$('#toolbar-wrapper').addClass('spreadsheet');
 
 			// remove unused elements
 			L.DomUtil.remove(L.DomUtil.get('presentation-controls-wrapper'));


### PR DESCRIPTION
This is needed so 584aa5b8f624f3871a94d5294ab754d7b03cff2f
is also applied on tabbed view.
Until now we were just adding that class when on compact view
(Control.TopToolbar.js)

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I8c0ac3d909f64025f301651564b3c2b1ae130e1c
