### PR TITLE
HAProxy: better load balancing

### DIFF
--- a/kubernetes/helm/collabora-online/templates/ingress.yaml
+++ b/kubernetes/helm/collabora-online/templates/ingress.yaml
@@ -5,6 +5,12 @@ metadata:
   namespace: {{ .Values.namespace.collabora }}
   annotations:
     nginx.ingress.kubernetes.io/upstream-hash-by: "$arg_WOPISrc"
+    haproxy.org/backend-config-snippet: |
+      balance leastconn
+      stick store-request url_param(WOPISrc)
+      stick-table type string len 2048 size 1k store conn_cur
+      http-request track-sc1 url_param(WOPISrc)
+      stick match url_param(WOPISrc) if { sc1_conn_cur gt 1 }
 spec:
   rules:
   - host: {{ .Values.hosts.host }}

--- a/kubernetes/helm/collabora-online/templates/service.yaml
+++ b/kubernetes/helm/collabora-online/templates/service.yaml
@@ -7,11 +7,6 @@ metadata:
     app: {{ template "name" . }}
     chart: {{ template "chartname" . }}
     release: {{ .Release.Name }}
-  annotations:
-    haproxy.org/timeout-tunnel: "3600s"
-    haproxy.org/backend-config-snippet: |
-      balance url_param WOPISrc check_post
-      hash-type consistent
 spec:
   type: {{ .Values.global.app.service.type }}
   ports:


### PR DESCRIPTION
Instead of using URL parameter hash to direct all the users on same document to same server,
use stick-tables for it

original problem:
Problem was load balancer provided us with required persistence and balance both.
we directed traffic based on the url_param which means,
all the traffic with same url_param will go to same pod/server.
All the new values of url_param will be directed to different servers in round-robin way
this can be less efficient in a high traffic environment

solution:
this new method allows us to balance and manage persistence separately
so we can specify our desired algorithm for load balancing
and persistence is managed using stick-table

Signed-off-by: Pranam Lashkari <lpranam@collabora.com>
Change-Id: I80d63a2fc33f796c4534d94fb8de1e44c62ee9e2

* Target version: master 


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

