### PR TITLE
ENABLE_WELCOME_MESSAGE should now be 0 for iOS, not "false"

### DIFF
--- a/ios/config.h.in
+++ b/ios/config.h.in
@@ -24,7 +24,7 @@
 
 /* Should the Release notes message on startup should be enabled be default?
    */
-#define ENABLE_WELCOME_MESSAGE "false"
+#define ENABLE_WELCOME_MESSAGE 0
 
 /* Should the Release notes message on startup have a dismiss button instead of an x button to close by default?
    */


### PR DESCRIPTION
Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: I3d8e38aac0ed7bd783cc0d8c79b2d4d08fa478a1


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

