### PR TITLE
formulabar: mobile input fix

### DIFF
--- a/browser/src/control/Control.FormulaBar.js
+++ b/browser/src/control/Control.FormulaBar.js
@@ -18,6 +18,7 @@ L.Control.FormulaBar = L.Control.extend({
 				// if the user is not editing the address field
 				L.DomUtil.get('addressInput').value = e.address;
 			}
+			map.formulabarSetDirty();
 		});
 	},
 

--- a/browser/src/control/Control.FormulaBarJSDialog.js
+++ b/browser/src/control/Control.FormulaBarJSDialog.js
@@ -7,6 +7,7 @@
 L.Control.FormulaBarJSDialog = L.Control.extend({
 	container: null,
 	builder: null,
+	dirty: true, // if we should allow to update based on servers setText
 
 	onAdd: function (map) {
 		this.map = map;
@@ -74,7 +75,8 @@ L.Control.FormulaBarJSDialog = L.Control.extend({
 						id: 'sc_input_window',
 						type: 'multilineedit',
 						text: text ? text : '',
-						rawKeyEvents: true
+						rawKeyEvents: window.mode.isDesktop() ? true : undefined,
+						useTextInput: window.mode.isDesktop() ? undefined : true
 					},
 					{
 						id: 'expand',
@@ -95,6 +97,13 @@ L.Control.FormulaBarJSDialog = L.Control.extend({
 		this.container.style.width = '100%';
 
 		this.builder.build(this.container, data);
+
+		var inputField = this.getInputField();
+		inputField.setAttribute('autocapitalize', 'off');
+		inputField.setAttribute('autocorrect', 'off');
+		inputField.setAttribute('autocomplete', 'off');
+		inputField.setAttribute('spellcheck', 'false');
+		inputField.setAttribute('wrap', 'off');
 	},
 
 	toggleMultiLine: function(input) {
@@ -137,7 +146,7 @@ L.Control.FormulaBarJSDialog = L.Control.extend({
 
 	callback: function(objectType, eventType, object, data, builder) {
 		if (object.id === 'expand') {
-			var input = document.getElementById('sc_input_window');
+			var input = this.getInputField();
 			if (input)
 				this.toggleMultiLine(input);
 			return;
@@ -148,27 +157,36 @@ L.Control.FormulaBarJSDialog = L.Control.extend({
 			objectType = 'drawingarea';
 			if (eventType === 'keypress' && data === UNOKey.RETURN || data === UNOKey.ESCAPE)
 				builder.map.focus();
+			else if (eventType === 'grab_focus')
+				builder.map.onFormulaBarFocus();
 		}
 
 		builder._defaultCallbackHandler(objectType, eventType, object, data, builder);
 	},
 
 	focus: function() {
+		var that = this;
 		setTimeout(function() {
-			var input = document.getElementById('sc_input_window');
+			var input = that.getInputField();
 			if (input && document.activeElement !== input)
 				input.focus();
 		}, 0);
 	},
 
 	blur: function() {
-		var input = document.getElementById('sc_input_window');
+		if (!window.mode.isDesktop()) {
+			var textInput = this.map && this.map._textInput;
+			if (textInput && textInput._isComposing)
+				textInput._abortComposition();
+		}
+
+		var input = this.getInputField();
 		if (input)
 			input.blur();
 	},
 
 	hasFocus: function() {
-		var input = document.getElementById('sc_input_window');
+		var input = this.getInputField();
 		return document.activeElement === input;
 	},
 
@@ -194,6 +212,37 @@ L.Control.FormulaBarJSDialog = L.Control.extend({
 			});
 	},
 
+	getControl: function(controlId) {
+		if (!this.container)
+			return;
+
+		var control = this.container.querySelector('[id=\'' + controlId + '\']');
+		if (!control)
+			window.app.console.warn('formulabar update: not found control with id: "' + controlId + '"');
+
+		return control;
+	},
+
+	getInputField: function() {
+		return this.getControl('sc_input_window');
+	},
+
+	getValue: function() {
+		var control = this.getInputField();
+		if (!control)
+			return;
+
+		return this.map._textInput._preSpaceChar + control.value + this.map._textInput._postSpaceChar;
+	},
+
+	setValue: function(newValue) {
+		var control = this.getInputField();
+		if (!control)
+			return;
+
+		control.value = newValue;
+	},
+
 	onFormulaBar: function(e) {
 		var data = e.data;
 		if (data.jsontype !== 'formulabar')
@@ -208,14 +257,9 @@ L.Control.FormulaBarJSDialog = L.Control.extend({
 		if (data.jsontype !== 'formulabar')
 			return;
 
-		if (!this.container)
+		var control = this.getControl(data.control.id);
+		if (!control)
 			return;
-
-		var control = this.container.querySelector('[id=\'' + data.control.id + '\']');
-		if (!control) {
-			window.app.console.warn('jsdialogupdate: not found control with id: "' + data.control.id + '"');
-			return;
-		}
 
 		var parent = control.parentNode;
 		if (!parent)
@@ -239,16 +283,35 @@ L.Control.FormulaBarJSDialog = L.Control.extend({
 
 		this.builder.setWindowId(data.id);
 
-		if (this.container) {
-			var keepInputFocus = data.data && data.data.control_id === 'sc_input_window'
-				&& this.hasFocus();
+		var innerData = data ? data.data : null;
 
-			this.builder.executeAction(this.container, data.data);
+		if (this.container) {
+			var messageForInputField = innerData && innerData.control_id === 'sc_input_window';
+			var isSetTextMessage = innerData && innerData.action_type === 'setText';
+			var keepInputFocus = messageForInputField && this.hasFocus();
+			var textInput = this.map._textInput;
+
+			// on desktop we display what we get from the server
+			// on touch devices we allow to type into the field directly, so we cannot update always
+			var allowUpdate = window.mode.isDesktop()
+				|| !this.hasFocus() || (this.hasFocus() && this.dirty);
+
+			if (!allowUpdate && messageForInputField && isSetTextMessage)
+				return;
+
+			this.dirty = false;
+
+			this.builder.executeAction(this.container, innerData);
+
+			if (!window.mode.isDesktop() && messageForInputField && this.hasFocus()) {
+				var newContent = textInput.getValueAsCodePoints().slice(1, -1);
+				textInput.setupLastContent(newContent);
+			}
 
 			if (keepInputFocus)
 				this.focus();
 		} else
-			this.createFormulabar(data.data.text);
+			this.createFormulabar(innerData.text);
 	},
 });
 

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -768,6 +768,11 @@ L.Map.include({
 		this.formulabar.focus();
 	},
 
+	formulabarSetDirty: function() {
+		if (this.formulabar)
+			this.formulabar.dirty = true;
+	},
+
 	// map.dispatch() will be used to call some actions so we can share the code
 	dispatch: function(action) {
 		switch (action) {
@@ -784,6 +789,7 @@ L.Map.include({
 
 				this.onFormulaBarBlur();
 				this.formulabarBlur();
+				this.formulabarSetDirty();
 			}
 			break;
 		case 'cancelformula':
@@ -791,6 +797,7 @@ L.Map.include({
 				this.sendUnoCommand('.uno:Cancel');
 				this.onFormulaBarBlur();
 				this.formulabarBlur();
+				this.formulabarSetDirty();
 			}
 			break;
 		case 'startformula':
@@ -798,6 +805,7 @@ L.Map.include({
 				this.sendUnoCommand('.uno:StartFormula');
 				this.onFormulaBarFocus();
 				this.formulabarFocus();
+				this.formulabarSetDirty();
 			}
 			break;
 		case 'functiondialog':
@@ -805,6 +813,7 @@ L.Map.include({
 				if (window.mode.isMobile() && this._functionWizardData) {
 					this._docLayer._closeMobileWizard();
 					this._docLayer._openMobileWizard(this._functionWizardData);
+					this.formulabarSetDirty();
 				} else {
 					this.sendUnoCommand('.uno:FunctionDialog');
 				}

--- a/browser/src/map/Map.js
+++ b/browser/src/map/Map.js
@@ -290,7 +290,8 @@ L.Map = L.Evented.extend({
 					commentSection.clearList();
 			}
 
-			this.initializeModificationIndicator();
+			if (!window.mode.isMobile())
+				this.initializeModificationIndicator();
 
 			// Show sidebar.
 			if (this._docLayer && !this._docLoadedOnce) {

--- a/browser/src/map/Map.js
+++ b/browser/src/map/Map.js
@@ -947,18 +947,20 @@ L.Map = L.Evented.extend({
 
 	// Getter for the winId, see setWinId() for more.
 	getWinId: function () {
+		if (this.formulabar && this.formulabar.hasFocus())
+			return 0;
 		return this._winId;
 	},
 
 	// Returns true iff the document has input focus,
 	// as opposed to a dialog, sidebar, formula bar, etc.
 	editorHasFocus: function () {
-		return this.getWinId() === 0;
+		return this.getWinId() === 0 && !this.calcInputBarHasFocus();
 	},
 
 	// Returns true iff the formula-bar has the focus.
 	calcInputBarHasFocus: function () {
-		return this.formulabar && !this.editorHasFocus() && this.formulabar.hasFocus();
+		return this.formulabar && this.formulabar.hasFocus();
 	},
 
 	// TODO replace with universal implementation after refactoring projections


### PR DESCRIPTION
formulabar: mobile: reuse TextInput for mobile IME
    
    Fixes typing on Android using GBoard in Chrome
    before this patch we didn't get any input due to
    lack of keyCode, we need to use 'input' events
    which are already handled in TextInput.js
    
    This patch does that only for mobile case, later
    we can try to unify it with desktop so we remove
    our custom formulabar input even there.

mobile: fix TypeError, missing Intl API
    
    this error was shown on socket disconnect on mobile Chrome in older
    phone