### PR TITLE
jsdialog: formulabar: reset shift key state after focus is lost

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -1523,6 +1523,10 @@ L.Control.JSDialogBuilder = L.Control.extend({
 				}
 			});
 
+			edit.addEventListener('blur', function() {
+				modifier = 0;
+			});
+
 			edit.addEventListener('keypress', function(event) {
 				if (edit.disabled)
 					return;


### PR DESCRIPTION
this happens something when selecting column or row with shift or control key. then all next keypress events send not valid modifier....