### PR TITLE
Kill Poco

### DIFF
--- a/test/TileCacheTests.cpp
+++ b/test/TileCacheTests.cpp
@@ -982,7 +982,7 @@ void TileCacheTests::checkBlackTiles(std::shared_ptr<COOLWebSocket>& socket, con
     // Current cap of table size ends at 257280 twips (for load12.ods),
     // otherwise 2035200 should be rendered successfully.
     const char* req = "tile nviewid=0 part=0 width=256 height=256 tileposx=0 tileposy=253440 tilewidth=3840 tileheight=3840";
-    sendTextFrame(socket, req);
+    sendTextFrame(socket, req, testname);
 
     const std::vector<char> tile = getResponseMessage(socket, "tile:", testname);
     if (!tile.size())

--- a/test/UnitBadDocLoad.cpp
+++ b/test/UnitBadDocLoad.cpp
@@ -20,6 +20,7 @@
 #include <Png.hpp>
 #include <Unit.hpp>
 #include <helpers.hpp>
+#include <net/WebSocketSession.hpp>
 
 // Include config.h last, so the test server URI is still HTTP, even in SSL builds.
 #include <config.h>
@@ -92,14 +93,18 @@ UnitBase::TestResult UnitBadDocLoad::testMaxDocuments()
 
     try
     {
+        std::shared_ptr<SocketPoll> socketPoll = std::make_shared<SocketPoll>("BadDocLoadPoll");
+        socketPoll->startThread();
+
         // Load a document.
-        std::vector<std::shared_ptr<COOLWebSocket>> docs;
+        std::vector<std::shared_ptr<http::WebSocketSession>> docs;
 
         std::cerr << "Loading max number of documents: " << MAX_DOCUMENTS << std::endl;
+        Poco::URI uri(helpers::getTestServerURI());
         for (int it = 1; it <= MAX_DOCUMENTS; ++it)
         {
-            Poco::URI uri(helpers::getTestServerURI());
-            docs.emplace_back(helpers::loadDocAndGetSocket("empty.odt", uri, testname));
+            docs.emplace_back(
+                helpers::loadDocAndGetSession(socketPoll, "empty.odt", uri, testname));
             std::cerr << "Loaded document #" << it << " of " << MAX_DOCUMENTS << std::endl;
         }
 
@@ -107,16 +112,15 @@ UnitBase::TestResult UnitBadDocLoad::testMaxDocuments()
 
         // try to open MAX_DOCUMENTS + 1
         std::string docPath;
-        std::string docURL;
-        helpers::getDocumentPathAndURL("empty.odt", docPath, docURL, testname);
-        Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, docURL);
-        Poco::URI uri(helpers::getTestServerURI());
+        std::string documentURL;
+        helpers::getDocumentPathAndURL("empty.odt", docPath, documentURL, testname);
+        Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, documentURL);
         std::unique_ptr<Poco::Net::HTTPClientSession> session(helpers::createSession(uri));
         Poco::Net::HTTPResponse httpResponse;
         auto socket = std::make_shared<COOLWebSocket>(*session, request, httpResponse);
 
         // Send load request, which will fail.
-        helpers::sendTextFrame(socket, "load url=" + docURL, testname);
+        helpers::sendTextFrame(socket, "load url=" + documentURL, testname);
 
         helpers::assertResponseString(socket, "error:", testname);
 
@@ -152,12 +156,18 @@ UnitBase::TestResult UnitBadDocLoad::testMaxConnections()
 
         // Load a document.
         std::string docPath;
-        std::string docURL;
+        std::string documentURL;
 
-        helpers::getDocumentPathAndURL("empty.odt", docPath, docURL, testname);
-        Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, docURL);
+        helpers::getDocumentPathAndURL("empty.odt", docPath, documentURL, testname);
+        Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, documentURL);
         Poco::URI uri(helpers::getTestServerURI());
-        std::shared_ptr<COOLWebSocket> socket = helpers::loadDocAndGetSocket(uri, docURL, testname);
+
+        std::shared_ptr<SocketPoll> socketPoll = std::make_shared<SocketPoll>("BadDocLoadPoll");
+        socketPoll->startThread();
+
+        std::shared_ptr<http::WebSocketSession> socket =
+            helpers::loadDocAndGetSession(socketPoll, uri, documentURL, testname);
+
         std::cerr << "Opened connection #1 of " << MAX_CONNECTIONS << std::endl;
 
         std::vector<std::shared_ptr<COOLWebSocket>> views;
@@ -179,7 +189,7 @@ UnitBase::TestResult UnitBadDocLoad::testMaxConnections()
         auto socketN = std::make_shared<COOLWebSocket>(*session, request, httpResponse);
 
         // Send load request, which will fail.
-        helpers::sendTextFrame(socketN, "load url=" + docURL, testname);
+        helpers::sendTextFrame(socketN, "load url=" + documentURL, testname);
 
         std::string message;
         const int statusCode = helpers::getErrorCode(socketN, message, testname);
@@ -213,18 +223,25 @@ UnitBase::TestResult UnitBadDocLoad::testMaxViews()
 
         // Load a document.
         std::string docPath;
-        std::string docURL;
+        std::string documentURL;
 
-        helpers::getDocumentPathAndURL("empty.odt", docPath, docURL, testname);
-        Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, docURL);
+        helpers::getDocumentPathAndURL("empty.odt", docPath, documentURL, testname);
+        Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, documentURL);
         Poco::URI uri(helpers::getTestServerURI());
-        std::shared_ptr<COOLWebSocket> socket = helpers::loadDocAndGetSocket(uri, docURL, testname);
+
+        std::shared_ptr<SocketPoll> socketPoll = std::make_shared<SocketPoll>("BadDocLoadPoll");
+        socketPoll->startThread();
+
+        std::shared_ptr<http::WebSocketSession> socket =
+            helpers::loadDocAndGetSession(socketPoll, uri, documentURL, testname);
+
         std::cerr << "Opened view #1 of " << MAX_CONNECTIONS << std::endl;
 
-        std::vector<std::shared_ptr<COOLWebSocket>> views;
+        std::vector<std::shared_ptr<http::WebSocketSession>> views;
         for (int it = 1; it < MAX_CONNECTIONS; ++it)
         {
-            views.emplace_back(helpers::loadDocAndGetSocket(uri, docURL, testname));
+            views.emplace_back(
+                helpers::loadDocAndGetSession(socketPoll, uri, documentURL, testname));
             std::cerr << "Opened view #" << (it + 1) << " of " << MAX_CONNECTIONS << std::endl;
         }
 
@@ -236,7 +253,7 @@ UnitBase::TestResult UnitBadDocLoad::testMaxViews()
         auto socketN = std::make_shared<COOLWebSocket>(*session, request, httpResponse);
 
         // Send load request, which will fail.
-        helpers::sendTextFrame(socketN, "load url=" + docURL, testname);
+        helpers::sendTextFrame(socketN, "load url=" + documentURL, testname);
 
         std::string message;
         const int statusCode = helpers::getErrorCode(socketN, message, testname);

--- a/test/UnitCalc.cpp
+++ b/test/UnitCalc.cpp
@@ -274,7 +274,7 @@ UnitBase::TestResult UnitCalc::testColumnRowResize()
             = helpers::loadDocAndGetSocket(uri, documentURL, testname);
 
         const std::string commandValues = "commandvalues command=.uno:ViewRowColumnHeaders";
-        helpers::sendTextFrame(socket, commandValues);
+        helpers::sendTextFrame(socket, commandValues, testname);
         response = helpers::getResponseMessage(socket, "commandvalues:", testname);
         LOK_ASSERT_MESSAGE("did not receive a commandvalues: message as expected",
                                !response.empty());

--- a/test/UnitCursor.cpp
+++ b/test/UnitCursor.cpp
@@ -143,7 +143,7 @@ UnitBase::TestResult UnitCursor::testMaxColumn()
                 const std::string text = "key type=input char=0 key=1027";
                 while (cursorX <= docWidth)
                 {
-                    helpers::sendTextFrame(socket, text);
+                    helpers::sendTextFrame(socket, text, testname);
                     cursorX += cursorWidth;
                 }
             },
@@ -179,7 +179,7 @@ UnitBase::TestResult UnitCursor::testMaxRow()
                 const std::string text = "key type=input char=0 key=1024";
                 while (cursorY <= docHeight)
                 {
-                    helpers::sendTextFrame(socket, text);
+                    helpers::sendTextFrame(socket, text, testname);
                     cursorY += cursorHeight;
                 }
             },

--- a/test/UnitEachView.cpp
+++ b/test/UnitEachView.cpp
@@ -134,7 +134,7 @@ UnitBase::TestResult UnitEachView::testViewCursorVisible()
 
 UnitBase::TestResult UnitEachView::testCellViewCursor()
 {
-    testEachView("empty.ods", "spreadsheet", "cellcursor:", "cellviewcursor:", "cellViewCursor");
+    testEachView("empty.ods", "spreadsheet", "cellcursor:", "cellviewcursor:", "cellViewCursor ");
     return TestResult::Ok;
 }
 

--- a/test/UnitInsertDelete.cpp
+++ b/test/UnitInsertDelete.cpp
@@ -249,10 +249,15 @@ UnitBase::TestResult UnitInsertDelete::testGetTextSelection()
         helpers::getDocumentPathAndURL("hello.odt", documentPath, documentURL, testname);
 
         Poco::URI uri(helpers::getTestServerURI());
-        std::shared_ptr<COOLWebSocket> socket
-            = helpers::loadDocAndGetSocket(uri, documentURL, testname);
-        std::shared_ptr<COOLWebSocket> socket2
-            = helpers::loadDocAndGetSocket(uri, documentURL, testname);
+
+        std::shared_ptr<SocketPoll> socketPoll = std::make_shared<SocketPoll>("InsertDeletePoll");
+        socketPoll->startThread();
+
+        std::shared_ptr<http::WebSocketSession> socket =
+            helpers::loadDocAndGetSession(socketPoll, uri, documentURL, testname);
+
+        std::shared_ptr<http::WebSocketSession> socket2 =
+            helpers::loadDocAndGetSession(socketPoll, uri, documentURL, testname);
 
         static const std::string expected = "Hello world";
         const std::string selection = helpers::getAllText(socket, testname, expected);
@@ -271,13 +276,17 @@ UnitBase::TestResult UnitInsertDelete::testCursorPosition()
     {
         // Load a document.
         std::string docPath;
-        std::string docURL;
+        std::string documentURL;
         std::string response;
 
-        helpers::getDocumentPathAndURL("Example.odt", docPath, docURL, testname);
+        helpers::getDocumentPathAndURL("Example.odt", docPath, documentURL, testname);
         Poco::URI uri(helpers::getTestServerURI());
-        std::shared_ptr<COOLWebSocket> socket0
-            = helpers::loadDocAndGetSocket(uri, docURL, testname);
+
+        std::shared_ptr<SocketPoll> socketPoll = std::make_shared<SocketPoll>("InsertDeletePoll");
+        socketPoll->startThread();
+
+        std::shared_ptr<http::WebSocketSession> socket0 =
+            helpers::loadDocAndGetSession(socketPoll, uri, documentURL, testname);
 
         // receive cursor position
         response = helpers::getResponseString(socket0, "invalidatecursor:", testname);
@@ -292,8 +301,8 @@ UnitBase::TestResult UnitInsertDelete::testCursorPosition()
         LOK_ASSERT_EQUAL(static_cast<size_t>(4), cursorTokens.size());
 
         // Create second view
-        std::shared_ptr<COOLWebSocket> socket1
-            = helpers::loadDocAndGetSocket(uri, docURL, testname);
+        std::shared_ptr<http::WebSocketSession> socket1 =
+            helpers::loadDocAndGetSession(socketPoll, uri, documentURL, testname);
 
         //receive view cursor position
         response = helpers::getResponseString(socket1, "invalidateviewcursor:", testname);

--- a/test/UnitInsertDelete.cpp
+++ b/test/UnitInsertDelete.cpp
@@ -103,15 +103,11 @@ UnitBase::TestResult UnitInsertDelete::testInsertDelete()
         std::string documentPath, documentURL;
         helpers::getDocumentPathAndURL("insert-delete.odp", documentPath, documentURL, testname);
 
-        Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, documentURL);
-        Poco::URI uri(helpers::getTestServerURI());
-        Poco::Net::HTTPResponse httpResponse;
-        std::shared_ptr<COOLWebSocket> socket
-            = helpers::connectLOKit(uri, request, httpResponse, testname);
+        std::shared_ptr<SocketPoll> socketPoll = std::make_shared<SocketPoll>(testname);
+        socketPoll->startThread();
 
-        helpers::sendTextFrame(socket, "load url=" + documentURL, testname);
-        LOK_ASSERT_MESSAGE("cannot load the document " + documentURL,
-                               helpers::isDocumentLoaded(socket, testname));
+        std::shared_ptr<http::WebSocketSession> socket = helpers::loadDocAndGetSession(
+            socketPoll, Poco::URI(helpers::getTestServerURI()), documentURL, testname);
 
         // check total slides 1
         TST_LOG("Expecting 1 slide.");
@@ -213,7 +209,6 @@ UnitBase::TestResult UnitInsertDelete::testPasteBlank()
         helpers::getDocumentPathAndURL("hello.odt", documentPath, documentURL, testname);
 
         std::shared_ptr<SocketPoll> socketPoll = std::make_shared<SocketPoll>(testname);
-
         socketPoll->startThread();
 
         std::shared_ptr<http::WebSocketSession> wsSession = helpers::loadDocAndGetSession(

--- a/test/UnitInsertDelete.cpp
+++ b/test/UnitInsertDelete.cpp
@@ -109,13 +109,13 @@ UnitBase::TestResult UnitInsertDelete::testInsertDelete()
         std::shared_ptr<COOLWebSocket> socket
             = helpers::connectLOKit(uri, request, httpResponse, testname);
 
-        helpers::sendTextFrame(socket, "load url=" + documentURL);
+        helpers::sendTextFrame(socket, "load url=" + documentURL, testname);
         LOK_ASSERT_MESSAGE("cannot load the document " + documentURL,
                                helpers::isDocumentLoaded(socket, testname));
 
         // check total slides 1
         TST_LOG("Expecting 1 slide.");
-        helpers::sendTextFrame(socket, "status");
+        helpers::sendTextFrame(socket, "status", testname);
         response = helpers::getResponseString(socket, "status:", testname);
         LOK_ASSERT_MESSAGE("did not receive a status: message as expected", !response.empty());
         getPartHashCodes(testname, response.substr(7), parts);
@@ -127,7 +127,7 @@ UnitBase::TestResult UnitInsertDelete::testInsertDelete()
         TST_LOG("Inserting 10 slides.");
         for (size_t it = 1; it <= 10; it++)
         {
-            helpers::sendTextFrame(socket, "uno .uno:InsertPage");
+            helpers::sendTextFrame(socket, "uno .uno:InsertPage", testname);
             response = helpers::getResponseString(socket, "status:", testname);
             LOK_ASSERT_MESSAGE("did not receive a status: message as expected",
                                    !response.empty());
@@ -144,8 +144,8 @@ UnitBase::TestResult UnitInsertDelete::testInsertDelete()
         for (size_t it = 1; it <= 10; it++)
         {
             // Explicitly delete the nth slide.
-            helpers::sendTextFrame(socket, "setclientpart part=" + std::to_string(it));
-            helpers::sendTextFrame(socket, "uno .uno:DeletePage");
+            helpers::sendTextFrame(socket, "setclientpart part=" + std::to_string(it), testname);
+            helpers::sendTextFrame(socket, "uno .uno:DeletePage", testname);
             response = helpers::getResponseString(socket, "status:", testname);
             LOK_ASSERT_MESSAGE("did not receive a status: message as expected",
                                    !response.empty());
@@ -160,7 +160,7 @@ UnitBase::TestResult UnitInsertDelete::testInsertDelete()
         TST_LOG("Undoing 10 slide deletes.");
         for (size_t it = 1; it <= 10; it++)
         {
-            helpers::sendTextFrame(socket, "uno .uno:Undo");
+            helpers::sendTextFrame(socket, "uno .uno:Undo", testname);
             response = helpers::getResponseString(socket, "status:", testname);
             LOK_ASSERT_MESSAGE("did not receive a status: message as expected",
                                    !response.empty());
@@ -178,7 +178,7 @@ UnitBase::TestResult UnitInsertDelete::testInsertDelete()
         TST_LOG("Redoing 10 slide deletes.");
         for (size_t it = 1; it <= 10; it++)
         {
-            helpers::sendTextFrame(socket, "uno .uno:Redo");
+            helpers::sendTextFrame(socket, "uno .uno:Redo", testname);
             response = helpers::getResponseString(socket, "status:", testname);
             LOK_ASSERT_MESSAGE("did not receive a status: message as expected",
                                    !response.empty());
@@ -191,7 +191,7 @@ UnitBase::TestResult UnitInsertDelete::testInsertDelete()
 
         // check total slides 1
         TST_LOG("Expecting 1 slide.");
-        helpers::sendTextFrame(socket, "status");
+        helpers::sendTextFrame(socket, "status", testname);
         response = helpers::getResponseString(socket, "status:", testname);
         LOK_ASSERT_MESSAGE("did not receive a status: message as expected", !response.empty());
         getPartHashCodes(testname, response.substr(7), parts);

--- a/test/UnitLargePaste.cpp
+++ b/test/UnitLargePaste.cpp
@@ -39,8 +39,12 @@ void UnitLargePaste::invokeWSDTest()
     std::string documentPath;
     std::string documentURL;
     helpers::getDocumentPathAndURL("hello.odt", documentPath, documentURL, testname);
-    std::shared_ptr<COOLWebSocket> socket = helpers::loadDocAndGetSocket(
-        Poco::URI(helpers::getTestServerURI()), documentURL, testname);
+
+    std::shared_ptr<SocketPoll> socketPoll = std::make_shared<SocketPoll>("LargePastePoll");
+    socketPoll->startThread();
+
+    std::shared_ptr<http::WebSocketSession> socket = helpers::loadDocAndGetSession(
+        socketPoll, Poco::URI(helpers::getTestServerURI()), documentURL, testname);
 
     helpers::sendTextFrame(socket, "uno .uno:SelectAll", testname);
     helpers::sendTextFrame(socket, "uno .uno:Delete", testname);

--- a/test/UnitLoad.cpp
+++ b/test/UnitLoad.cpp
@@ -147,7 +147,7 @@ UnitBase::TestResult UnitLoad::testBadLoad()
             = helpers::connectLOKit(uri, request, response, testname);
 
         // Before loading request status.
-        helpers::sendTextFrame(socket, "status");
+        helpers::sendTextFrame(socket, "status", testname);
 
         const auto line = helpers::assertResponseString(socket, "error:", testname);
         LOK_ASSERT_EQUAL(std::string("error: cmd=status kind=nodocloaded"), line);

--- a/test/UnitLoad.cpp
+++ b/test/UnitLoad.cpp
@@ -32,13 +32,15 @@ void loadDoc(const std::string& documentURL, const std::string& testname)
 {
     try
     {
+        std::shared_ptr<SocketPoll> socketPoll = std::make_shared<SocketPoll>(testname + "Poll");
+        socketPoll->startThread();
+
         // Load a document and wait for the status.
         // Don't replace with helpers, so we catch status.
-        Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, documentURL);
         Poco::URI uri(helpers::getTestServerURI());
-        Poco::Net::HTTPResponse response;
-        std::shared_ptr<COOLWebSocket> socket
-            = helpers::connectLOKit(uri, request, response, testname);
+        std::shared_ptr<http::WebSocketSession> socket =
+            helpers::connectLOKit(socketPoll, uri, documentURL, testname);
+
         helpers::sendTextFrame(socket, "load url=" + documentURL, testname);
 
         helpers::assertResponseString(socket, "status:", testname);
@@ -85,13 +87,15 @@ UnitBase::TestResult UnitLoad::testConnectNoLoad()
     std::string documentPath, documentURL;
     helpers::getDocumentPathAndURL("hello.odt", documentPath, documentURL, "connectNoLoad ");
 
-    // Connect and disconnect without loading.
-    Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, documentURL);
-    TST_LOG_NAME(testname1, "Connecting first to disconnect without loading.");
-    Poco::Net::HTTPResponse response;
+    std::shared_ptr<SocketPoll> socketPoll = std::make_shared<SocketPoll>(testname + "Poll");
+    socketPoll->startThread();
+
     Poco::URI uri(helpers::getTestServerURI());
-    std::shared_ptr<COOLWebSocket> socket
-        = helpers::connectLOKit(uri, request, response, testname1);
+
+    // Connect and disconnect without loading.
+    TST_LOG_NAME(testname1, "Connecting first to disconnect without loading.");
+    std::shared_ptr<http::WebSocketSession> socket =
+        helpers::connectLOKit(socketPoll, uri, documentURL, testname1);
     LOK_ASSERT_MESSAGE("Failed to connect.", socket);
     TST_LOG_NAME(testname1, "Disconnecting first.");
     socket.reset();
@@ -100,8 +104,8 @@ UnitBase::TestResult UnitLoad::testConnectNoLoad()
 
     // Connect and load first view.
     TST_LOG_NAME(testname2, "Connecting second to load first view.");
-    std::shared_ptr<COOLWebSocket> socket1
-        = helpers::connectLOKit(uri, request, response, testname2);
+    std::shared_ptr<http::WebSocketSession> socket1 =
+        helpers::connectLOKit(socketPoll, uri, documentURL, testname2);
     LOK_ASSERT_MESSAGE("Failed to connect.", socket1);
     helpers::sendTextFrame(socket1, "load url=" + documentURL, testname2);
     LOK_ASSERT_MESSAGE("cannot load the document " + documentURL,
@@ -109,8 +113,8 @@ UnitBase::TestResult UnitLoad::testConnectNoLoad()
 
     // Connect but don't load second view.
     TST_LOG_NAME(testname3, "Connecting third to disconnect without loading.");
-    std::shared_ptr<COOLWebSocket> socket2
-        = helpers::connectLOKit(uri, request, response, testname3);
+    std::shared_ptr<http::WebSocketSession> socket2 =
+        helpers::connectLOKit(socketPoll, uri, documentURL, testname3);
     LOK_ASSERT_MESSAGE("Failed to connect.", socket2);
     TST_LOG_NAME(testname3, "Disconnecting third.");
     socket2.reset();
@@ -140,11 +144,12 @@ UnitBase::TestResult UnitLoad::testBadLoad()
         std::string documentPath, documentURL;
         helpers::getDocumentPathAndURL("hello.odt", documentPath, documentURL, testname);
 
-        Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, documentURL);
+        std::shared_ptr<SocketPoll> socketPoll = std::make_shared<SocketPoll>(testname + "Poll");
+        socketPoll->startThread();
+
         Poco::URI uri(helpers::getTestServerURI());
-        Poco::Net::HTTPResponse response;
-        std::shared_ptr<COOLWebSocket> socket
-            = helpers::connectLOKit(uri, request, response, testname);
+        std::shared_ptr<http::WebSocketSession> socket =
+            helpers::connectLOKit(socketPoll, uri, documentURL, testname);
 
         // Before loading request status.
         helpers::sendTextFrame(socket, "status", testname);
@@ -166,7 +171,7 @@ UnitBase::TestResult UnitLoad::testExcelLoad()
         // Load a document and get status.
         Poco::URI uri(helpers::getTestServerURI());
 
-        std::shared_ptr<SocketPoll> socketPoll = std::make_shared<SocketPoll>("LoadPoll");
+        std::shared_ptr<SocketPoll> socketPoll = std::make_shared<SocketPoll>("ExcelLoadPoll");
         socketPoll->startThread();
 
         std::shared_ptr<http::WebSocketSession> socket =
@@ -203,7 +208,7 @@ UnitBase::TestResult UnitLoad::testLoad()
     std::string documentPath, documentURL;
     helpers::getDocumentPathAndURL("hello.odt", documentPath, documentURL, testname);
 
-    std::shared_ptr<SocketPoll> socketPollPtr = std::make_shared<SocketPoll>("UnitLoadPoll");
+    std::shared_ptr<SocketPoll> socketPollPtr = std::make_shared<SocketPoll>("LoadPoll");
     socketPollPtr->startThread();
 
     auto wsSession

--- a/test/UnitLoad.cpp
+++ b/test/UnitLoad.cpp
@@ -165,8 +165,12 @@ UnitBase::TestResult UnitLoad::testExcelLoad()
     {
         // Load a document and get status.
         Poco::URI uri(helpers::getTestServerURI());
-        std::shared_ptr<COOLWebSocket> socket
-            = helpers::loadDocAndGetSocket("timeline.xlsx", uri, testname);
+
+        std::shared_ptr<SocketPoll> socketPoll = std::make_shared<SocketPoll>("LoadPoll");
+        socketPoll->startThread();
+
+        std::shared_ptr<http::WebSocketSession> socket =
+            helpers::loadDocAndGetSession(socketPoll, "timeline.xlsx", uri, testname);
 
         helpers::sendTextFrame(socket, "status", testname);
         const auto status = helpers::assertResponseString(socket, "status:", testname);

--- a/test/UnitPasswordProtected.cpp
+++ b/test/UnitPasswordProtected.cpp
@@ -52,7 +52,7 @@ UnitBase::TestResult UnitPasswordProtected::testPasswordProtectedDocumentWithout
             Poco::URI(helpers::getTestServerURI()), request, httpResponse, testname);
 
         // Send a load request without password first
-        helpers::sendTextFrame(socket, "load url=" + documentURL);
+        helpers::sendTextFrame(socket, "load url=" + documentURL, testname);
 
         auto response = helpers::getResponseString(socket, "error:", testname);
         StringVector tokens(StringVector::tokenize(response, ' '));
@@ -91,7 +91,7 @@ UnitBase::TestResult UnitPasswordProtected::testPasswordProtectedDocumentWithWro
             Poco::URI(helpers::getTestServerURI()), request, httpResponse, testname);
 
         // Send a load request with incorrect password
-        helpers::sendTextFrame(socket, "load url=" + documentURL + " password=2");
+        helpers::sendTextFrame(socket, "load url=" + documentURL + " password=2", testname);
 
         const auto response = helpers::getResponseString(socket, "error:", testname);
         StringVector tokens(StringVector::tokenize(response, ' '));
@@ -126,7 +126,7 @@ UnitBase::TestResult UnitPasswordProtected::testPasswordProtectedDocumentWithCor
             Poco::URI(helpers::getTestServerURI()), request, response, testname);
 
         // Send a load request with correct password
-        helpers::sendTextFrame(socket, "load url=" + documentURL + " password=1");
+        helpers::sendTextFrame(socket, "load url=" + documentURL + " password=1", testname);
 
         LOK_ASSERT_MESSAGE("cannot load the document with correct password " + documentURL,
                                helpers::isDocumentLoaded(socket, testname));
@@ -158,7 +158,7 @@ UnitBase::TestResult UnitPasswordProtected::testPasswordProtectedOOXMLDocument()
             Poco::URI(helpers::getTestServerURI()), request, response, testname);
 
         // Send a load request with correct password
-        helpers::sendTextFrame(socket, "load url=" + documentURL + " password=abc");
+        helpers::sendTextFrame(socket, "load url=" + documentURL + " password=abc", testname);
 
         LOK_ASSERT_MESSAGE("cannot load the document with correct password " + documentURL,
                                helpers::isDocumentLoaded(socket, testname));
@@ -185,7 +185,7 @@ UnitBase::TestResult UnitPasswordProtected::testPasswordProtectedBinaryMSOfficeD
             Poco::URI(helpers::getTestServerURI()), request, response, testname);
 
         // Send a load request with correct password
-        helpers::sendTextFrame(socket, "load url=" + documentURL + " password=abc");
+        helpers::sendTextFrame(socket, "load url=" + documentURL + " password=abc", testname);
 
         LOK_ASSERT_MESSAGE("cannot load the document with correct password " + documentURL,
                                helpers::isDocumentLoaded(socket, testname));

--- a/test/UnitPasswordProtected.cpp
+++ b/test/UnitPasswordProtected.cpp
@@ -46,10 +46,11 @@ UnitBase::TestResult UnitPasswordProtected::testPasswordProtectedDocumentWithout
         helpers::getDocumentPathAndURL("password-protected.ods", documentPath, documentURL,
                                        testname);
 
-        Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, documentURL);
-        Poco::Net::HTTPResponse httpResponse;
-        std::shared_ptr<COOLWebSocket> socket = helpers::connectLOKit(
-            Poco::URI(helpers::getTestServerURI()), request, httpResponse, testname);
+        std::shared_ptr<SocketPoll> socketPoll = std::make_shared<SocketPoll>("WithoutPasswordPoll");
+        socketPoll->startThread();
+
+        std::shared_ptr<http::WebSocketSession> socket = helpers::connectLOKit(
+            socketPoll, Poco::URI(helpers::getTestServerURI()), documentURL, testname);
 
         // Send a load request without password first
         helpers::sendTextFrame(socket, "load url=" + documentURL, testname);
@@ -85,10 +86,11 @@ UnitBase::TestResult UnitPasswordProtected::testPasswordProtectedDocumentWithWro
         helpers::getDocumentPathAndURL("password-protected.ods", documentPath, documentURL,
                                        testname);
 
-        Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, documentURL);
-        Poco::Net::HTTPResponse httpResponse;
-        std::shared_ptr<COOLWebSocket> socket = helpers::connectLOKit(
-            Poco::URI(helpers::getTestServerURI()), request, httpResponse, testname);
+        std::shared_ptr<SocketPoll> socketPoll = std::make_shared<SocketPoll>("WrongPasswordPoll");
+        socketPoll->startThread();
+
+        std::shared_ptr<http::WebSocketSession> socket = helpers::connectLOKit(
+            socketPoll, Poco::URI(helpers::getTestServerURI()), documentURL, testname);
 
         // Send a load request with incorrect password
         helpers::sendTextFrame(socket, "load url=" + documentURL + " password=2", testname);
@@ -120,10 +122,12 @@ UnitBase::TestResult UnitPasswordProtected::testPasswordProtectedDocumentWithCor
         helpers::getDocumentPathAndURL("password-protected.ods", documentPath, documentURL,
                                        testname);
 
-        Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, documentURL);
-        Poco::Net::HTTPResponse response;
-        std::shared_ptr<COOLWebSocket> socket = helpers::connectLOKit(
-            Poco::URI(helpers::getTestServerURI()), request, response, testname);
+        std::shared_ptr<SocketPoll> socketPoll =
+            std::make_shared<SocketPoll>("CorrectPasswordPoll");
+        socketPoll->startThread();
+
+        std::shared_ptr<http::WebSocketSession> socket = helpers::connectLOKit(
+            socketPoll, Poco::URI(helpers::getTestServerURI()), documentURL, testname);
 
         // Send a load request with correct password
         helpers::sendTextFrame(socket, "load url=" + documentURL + " password=1", testname);
@@ -152,10 +156,11 @@ UnitBase::TestResult UnitPasswordProtected::testPasswordProtectedOOXMLDocument()
         helpers::getDocumentPathAndURL("password-protected.docx", documentPath, documentURL,
                                        testname);
 
-        Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, documentURL);
-        Poco::Net::HTTPResponse response;
-        std::shared_ptr<COOLWebSocket> socket = helpers::connectLOKit(
-            Poco::URI(helpers::getTestServerURI()), request, response, testname);
+        std::shared_ptr<SocketPoll> socketPoll = std::make_shared<SocketPoll>("PasswordOOXMLPoll");
+        socketPoll->startThread();
+
+        std::shared_ptr<http::WebSocketSession> socket = helpers::connectLOKit(
+            socketPoll, Poco::URI(helpers::getTestServerURI()), documentURL, testname);
 
         // Send a load request with correct password
         helpers::sendTextFrame(socket, "load url=" + documentURL + " password=abc", testname);
@@ -179,10 +184,12 @@ UnitBase::TestResult UnitPasswordProtected::testPasswordProtectedBinaryMSOfficeD
         helpers::getDocumentPathAndURL("password-protected.doc", documentPath, documentURL,
                                        testname);
 
-        Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, documentURL);
-        Poco::Net::HTTPResponse response;
-        std::shared_ptr<COOLWebSocket> socket = helpers::connectLOKit(
-            Poco::URI(helpers::getTestServerURI()), request, response, testname);
+        std::shared_ptr<SocketPoll> socketPoll =
+            std::make_shared<SocketPoll>("PasswordMSOfficePoll");
+        socketPoll->startThread();
+
+        std::shared_ptr<http::WebSocketSession> socket = helpers::connectLOKit(
+            socketPoll, Poco::URI(helpers::getTestServerURI()), documentURL, testname);
 
         // Send a load request with correct password
         helpers::sendTextFrame(socket, "load url=" + documentURL + " password=abc", testname);

--- a/test/UnitPaste.cpp
+++ b/test/UnitPaste.cpp
@@ -37,8 +37,12 @@ void UnitPaste::invokeWSDTest()
     std::string documentPath;
     std::string documentURL;
     helpers::getDocumentPathAndURL("hello.odt", documentPath, documentURL, testname);
-    std::shared_ptr<COOLWebSocket> socket = helpers::loadDocAndGetSocket(
-        Poco::URI(helpers::getTestServerURI()), documentURL, testname);
+
+    std::shared_ptr<SocketPoll> socketPoll = std::make_shared<SocketPoll>("PastePoll");
+    socketPoll->startThread();
+
+    std::shared_ptr<http::WebSocketSession> socket = helpers::loadDocAndGetSession(
+        socketPoll, Poco::URI(helpers::getTestServerURI()), documentURL, testname);
 
     for (int i = 0; i < 5; ++i)
     {

--- a/test/UnitRenderSearchResult.cpp
+++ b/test/UnitRenderSearchResult.cpp
@@ -38,7 +38,12 @@ void UnitRenderSearchResult::invokeWSDTest()
         std::string documentURL;
         helpers::getDocumentPathAndURL("RenderSearchResultTest.odt", documentPath, documentURL, testname);
 
-        std::shared_ptr<COOLWebSocket> socket = helpers::loadDocAndGetSocket(Poco::URI(helpers::getTestServerURI()), documentURL, testname);
+        std::shared_ptr<SocketPoll> socketPoll =
+            std::make_shared<SocketPoll>("RenderSearchResultPoll");
+        socketPoll->startThread();
+
+        std::shared_ptr<http::WebSocketSession> socket = helpers::loadDocAndGetSession(
+            socketPoll, Poco::URI(helpers::getTestServerURI()), documentURL, testname);
 
         helpers::sendTextFrame(socket,
                                "rendersearchresult <indexing><paragraph node_type=\"writer\" "

--- a/test/UnitRenderSearchResult.cpp
+++ b/test/UnitRenderSearchResult.cpp
@@ -40,7 +40,10 @@ void UnitRenderSearchResult::invokeWSDTest()
 
         std::shared_ptr<COOLWebSocket> socket = helpers::loadDocAndGetSocket(Poco::URI(helpers::getTestServerURI()), documentURL, testname);
 
-        helpers::sendTextFrame(socket, "rendersearchresult <indexing><paragraph node_type=\"writer\" index=\"19\"/></indexing>");
+        helpers::sendTextFrame(socket,
+                               "rendersearchresult <indexing><paragraph node_type=\"writer\" "
+                               "index=\"19\"/></indexing>",
+                               testname);
         std::vector<char> responseMessage = helpers::getResponseMessage(socket, "rendersearchresult:", testname);
 
        // LOK_ASSERT(responseMessage.size() >= 100);

--- a/test/UnitRenderShape.cpp
+++ b/test/UnitRenderShape.cpp
@@ -89,8 +89,11 @@ UnitBase::TestResult UnitRenderShape::testRenderShapeSelectionImpress()
         std::string documentPath, documentURL;
         helpers::getDocumentPathAndURL("shapes.odp", documentPath, documentURL, testname);
 
-        std::shared_ptr<COOLWebSocket> socket = helpers::loadDocAndGetSocket(
-            Poco::URI(helpers::getTestServerURI()), documentURL, testname);
+        std::shared_ptr<SocketPoll> socketPoll = std::make_shared<SocketPoll>("RenderShapePoll");
+        socketPoll->startThread();
+
+        std::shared_ptr<http::WebSocketSession> socket = helpers::loadDocAndGetSession(
+            socketPoll, Poco::URI(helpers::getTestServerURI()), documentURL, testname);
 
         int major = 0;
         int minor = 0;
@@ -131,8 +134,11 @@ UnitBase::TestResult UnitRenderShape::testRenderShapeSelectionWriterImage()
         std::string documentPath, documentURL;
         helpers::getDocumentPathAndURL("non-shape-image.odt", documentPath, documentURL, testname);
 
-        std::shared_ptr<COOLWebSocket> socket = helpers::loadDocAndGetSocket(
-            Poco::URI(helpers::getTestServerURI()), documentURL, testname);
+        std::shared_ptr<SocketPoll> socketPoll = std::make_shared<SocketPoll>("RenderShapePoll");
+        socketPoll->startThread();
+
+        std::shared_ptr<http::WebSocketSession> socket = helpers::loadDocAndGetSession(
+            socketPoll, Poco::URI(helpers::getTestServerURI()), documentURL, testname);
 
         // Select the shape with SHIFT + F4
         helpers::sendKeyPress(socket, 0, 771 | helpers::SpecialKey::skShift, testname);

--- a/test/UnitRenderingOptions.cpp
+++ b/test/UnitRenderingOptions.cpp
@@ -43,10 +43,11 @@ void UnitRenderingOptions::invokeWSDTest()
         const std::string options
             = "{\"rendering\":{\".uno:HideWhitespace\":{\"type\":\"boolean\",\"value\":\"true\"}}}";
 
-        Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, documentURL);
-        Poco::Net::HTTPResponse response;
-        std::shared_ptr<COOLWebSocket> socket = helpers::connectLOKit(
-            Poco::URI(helpers::getTestServerURI()), request, response, testname);
+        std::shared_ptr<SocketPoll> socketPoll = std::make_shared<SocketPoll>("WithoutPasswordPoll");
+        socketPoll->startThread();
+
+        std::shared_ptr<http::WebSocketSession> socket = helpers::connectLOKit(
+            socketPoll, Poco::URI(helpers::getTestServerURI()), documentURL, testname);
 
         helpers::sendTextFrame(socket, "load url=" + documentURL + " options=" + options, testname);
         helpers::sendTextFrame(socket, "status", testname);

--- a/test/UnitRenderingOptions.cpp
+++ b/test/UnitRenderingOptions.cpp
@@ -48,8 +48,8 @@ void UnitRenderingOptions::invokeWSDTest()
         std::shared_ptr<COOLWebSocket> socket = helpers::connectLOKit(
             Poco::URI(helpers::getTestServerURI()), request, response, testname);
 
-        helpers::sendTextFrame(socket, "load url=" + documentURL + " options=" + options);
-        helpers::sendTextFrame(socket, "status");
+        helpers::sendTextFrame(socket, "load url=" + documentURL + " options=" + options, testname);
+        helpers::sendTextFrame(socket, "status", testname);
         const auto status = helpers::assertResponseString(socket, "status:", testname);
 
         // Expected format is something like 'status: type=text parts=2 current=0 width=12808 height=1142'.

--- a/test/UnitSession.cpp
+++ b/test/UnitSession.cpp
@@ -156,14 +156,11 @@ UnitBase::TestResult UnitSession::testSlideShow()
         std::string response;
         helpers::getDocumentPathAndURL("setclientpart.odp", documentPath, documentURL, testname);
 
-        Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, documentURL);
-        Poco::Net::HTTPResponse httpResponse;
-        std::shared_ptr<COOLWebSocket> socket = helpers::connectLOKit(
-            Poco::URI(helpers::getTestServerURI()), request, httpResponse, testname);
+        std::shared_ptr<SocketPoll> socketPoll = std::make_shared<SocketPoll>(testname);
+        socketPoll->startThread();
 
-        helpers::sendTextFrame(socket, "load url=" + documentURL, testname);
-        LOK_ASSERT_MESSAGE("cannot load the document " + documentURL,
-                               helpers::isDocumentLoaded(socket, testname));
+        std::shared_ptr<http::WebSocketSession> socket = helpers::loadDocAndGetSession(
+            socketPoll, Poco::URI(helpers::getTestServerURI()), documentURL, testname);
 
         // request slide show
         helpers::sendTextFrame(

--- a/test/UnitTiffLoad.cpp
+++ b/test/UnitTiffLoad.cpp
@@ -39,8 +39,12 @@ void UnitTiffLoad::invokeWSDTest()
     std::string documentPath;
     std::string documentURL;
     helpers::getDocumentPathAndURL("tiff.odt", documentPath, documentURL, testname);
-    std::shared_ptr<COOLWebSocket> socket = helpers::loadDocAndGetSocket(
-        Poco::URI(helpers::getTestServerURI()), documentURL, testname);
+
+    std::shared_ptr<SocketPoll> socketPoll = std::make_shared<SocketPoll>("TiffLoadPoll");
+    socketPoll->startThread();
+
+    std::shared_ptr<http::WebSocketSession> socket = helpers::loadDocAndGetSession(
+        socketPoll, Poco::URI(helpers::getTestServerURI()), documentURL, testname);
 
     // Select the image.
     helpers::sendTextFrame(socket, "uno .uno:JumpToNextFrame", testname);

--- a/test/UnitTyping.cpp
+++ b/test/UnitTyping.cpp
@@ -20,6 +20,7 @@
 #include <COOLWSD.hpp>
 
 #include <wsd/TileDesc.hpp>
+#include <net/WebSocketSession.hpp>
 
 using namespace ::helpers;
 
@@ -53,8 +54,7 @@ public:
 
     TestResult testWriterTyping()
     {
-        std::string serverURL = COOLWSD::getServerURL();
-        const Poco::URI uri(serverURL);
+        Poco::URI uri(helpers::getTestServerURI());
 
         LOG_TRC("test writer typing");
 
@@ -63,7 +63,11 @@ public:
         helpers::getDocumentPathAndURL(
             "empty.odt", documentPath, documentURL, testname);
 
-        std::shared_ptr<COOLWebSocket> socket = helpers::loadDocAndGetSocket(uri, documentURL, testname);
+        std::shared_ptr<SocketPoll> socketPoll = std::make_shared<SocketPoll>("TypingPoll");
+        socketPoll->startThread();
+
+        std::shared_ptr<http::WebSocketSession> socket =
+            helpers::loadDocAndGetSession(socketPoll, uri, documentURL, testname);
 
         // We input two Bopomofo (Mandarin Phonetic Symbols) characters and a grave accent using
         // textinput messages and then delete them and then input a fourth character. Apparently
@@ -224,26 +228,30 @@ public:
 
     TestResult testCalcTyping()
     {
-        std::string serverURL = COOLWSD::getServerURL();
-        const Poco::URI uri(serverURL);
+        Poco::URI uri(helpers::getTestServerURI());
 
         // Load a doc with the cursor saved at a top row.
         std::string documentPath, documentURL;
         helpers::getDocumentPathAndURL("empty.ods", documentPath, documentURL, testname);
 
+        std::shared_ptr<SocketPoll> socketPoll = std::make_shared<SocketPoll>("TypingPoll");
+        socketPoll->startThread();
+
         const int numRender = 2;
         const int numTyping = 6;
         const int numSocket = numRender + numTyping;
-        std::vector<std::shared_ptr<COOLWebSocket>> sockets;
+        std::vector<std::shared_ptr<http::WebSocketSession>> sockets;
 
-        LOG_TRC("Connecting first client to " << serverURL << " doc: " << documentURL);
-        sockets.push_back(helpers::loadDocAndGetSocket(uri, documentURL, testname));
+        LOG_TRC("Connecting first client to " << uri.toString() << " doc: " << documentURL);
+        sockets.emplace_back(helpers::loadDocAndGetSession(socketPoll, uri, documentURL, testname));
 
         for (int i = 1; i < numSocket; ++i)
         {
             LOG_TRC("Connecting client " << i);
-            std::shared_ptr<COOLWebSocket> socket = helpers::loadDocAndGetSocket(uri, documentURL, testname);
-            sockets.push_back(socket);
+            std::shared_ptr<http::WebSocketSession> socket =
+                helpers::loadDocAndGetSession(socketPoll, uri, documentURL, testname);
+            sockets.emplace_back(
+                helpers::loadDocAndGetSession(socketPoll, uri, documentURL, testname));
             for (int j = 0; j < i * 3; ++j)
             {
                 // cursor down some multiple of times
@@ -295,7 +303,7 @@ public:
         for (int i = 0; i < numRender; ++i)
             threads.emplace_back([&,i] {
                     std::mt19937 randDev(numRender * 257);
-                    std::shared_ptr<COOLWebSocket> sock = sockets[numTyping + i];
+                    std::shared_ptr<http::WebSocketSession> sock = sockets[numTyping + i];
                     while (!started || liveTyping > 0)
                     {
                         std::ostringstream oss;
@@ -318,7 +326,7 @@ public:
         {
             threads.emplace_back([&,which] {
                     std::mt19937 randDev(which * 16);
-                    std::shared_ptr<COOLWebSocket> sock = sockets[which];
+                    std::shared_ptr<http::WebSocketSession> sock = sockets[which];
                     liveTyping++;
                     started = true;
                     for (size_t i = 0; i < messages[which].size(); ++i)

--- a/test/UnitUNOCommand.cpp
+++ b/test/UnitUNOCommand.cpp
@@ -30,7 +30,11 @@ void testStateChanged(const std::string& filename, std::set<std::string>& comman
 
     Poco::RegularExpression reUno("\\.[a-zA-Z]*\\:[a-zA-Z]*\\=");
 
-    std::shared_ptr<COOLWebSocket> socket = helpers::loadDocAndGetSocket(filename, Poco::URI(helpers::getTestServerURI()), testname);
+    std::shared_ptr<SocketPoll> socketPoll = std::make_shared<SocketPoll>("UnitEachView");
+    socketPoll->startThread();
+
+    std::shared_ptr<http::WebSocketSession> socket = helpers::loadDocAndGetSession(
+        socketPoll, filename, Poco::URI(helpers::getTestServerURI()), testname);
     helpers::SocketProcessor(testname, socket,
         [&](const std::string& msg)
         {

--- a/test/UnitWOPISaveAs.cpp
+++ b/test/UnitWOPISaveAs.cpp
@@ -17,11 +17,7 @@
 
 class UnitWOPISaveAs : public WopiTestServer
 {
-    enum class Phase
-    {
-        LoadAndSaveAs,
-        Polling
-    } _phase;
+    STATE_ENUM(Phase, LoadAndSaveAs, Polling) _phase;
 
 public:
     UnitWOPISaveAs()
@@ -60,19 +56,16 @@ public:
 
     void invokeWSDTest() override
     {
-        constexpr char testName[] = "UnitWOPISaveAs";
-
         switch (_phase)
         {
             case Phase::LoadAndSaveAs:
             {
                 initWebsocket("/wopi/files/0?access_token=anything");
 
-                helpers::sendTextFrame(*getWs()->getCOOLWebSocket(), "load url=" + getWopiSrc(), testName);
-                helpers::sendTextFrame(*getWs()->getCOOLWebSocket(), "saveas url=wopi:///jan/hole%C5%A1ovsk%C3%BD/hello%20world%251.pdf", testName);
-                SocketPoll::wakeupWorld();
+                TRANSITION_STATE(_phase, Phase::Polling);
 
-                _phase = Phase::Polling;
+                WSD_CMD("load url=" + getWopiSrc());
+                WSD_CMD("saveas url=wopi:///jan/hole%C5%A1ovsk%C3%BD/hello%20world%251.pdf");
                 break;
             }
             case Phase::Polling:

--- a/test/helpers.hpp
+++ b/test/helpers.hpp
@@ -133,10 +133,10 @@ void sendTextFrame(COOLWebSocket& socket, const std::string& string, const std::
     socket.sendFrame(string.data(), string.size());
 }
 
-inline
-void sendTextFrame(const std::shared_ptr<COOLWebSocket>& socket, const std::string& string, const std::string& name = "")
+inline void sendTextFrame(const std::shared_ptr<COOLWebSocket>& socket, const std::string& string,
+                          const std::string& testname)
 {
-    sendTextFrame(*socket, string, name);
+    sendTextFrame(*socket, string, testname);
 }
 
 inline void sendTextFrame(const std::shared_ptr<http::WebSocketSession>& ws,

--- a/test/helpers.hpp
+++ b/test/helpers.hpp
@@ -966,10 +966,9 @@ inline void saveTileAs(const std::vector<char> &tileResponse,
     TST_LOG("Saved [" << firstLine << "] to [" << filename << ']');
 }
 
-inline std::vector<char> getTileAndSave(std::shared_ptr<COOLWebSocket>& socket,
-                                        const std::string& req,
-                                        const std::string& filename,
-                                        const std::string& testname)
+template <typename T>
+std::vector<char> getTileAndSave(T& socket, const std::string& req, const std::string& filename,
+                                 const std::string& testname)
 {
     TST_LOG("Requesting: " << req);
     sendTextFrame(socket, req, testname);

--- a/test/helpers.hpp
+++ b/test/helpers.hpp
@@ -988,9 +988,8 @@ inline std::vector<char> getTileAndSave(std::shared_ptr<COOLWebSocket>& socket,
     return res;
 }
 
-inline void getServerVersion(COOLWebSocket& socket,
-                             int& major, int& minor,
-                             const std::string& testname)
+template <typename T>
+inline void getServerVersion(T& socket, int& major, int& minor, const std::string& testname)
 {
     const std::string clientVersion = "coolclient 0.1";
     sendTextFrame(socket, clientVersion, testname);


### PR DESCRIPTION
Remove Poco sockets from many tests in favor of our async sockets. These tests now run faster and are more stable.

- wsd: test: remove default testname arg from helpers
- wsd: test: killpoco for UnitEachView
- wsd: test: killpoco for UnitCursor
- wsd: test: killpoco for UnitInsertDelete
- wsd: test: killpoco for UnitInsertDelete
- wsd: test: killpoco for UnitLargePaste
- wsd: test: killpoco for UnitLoad
- wsd: test: killpoco for UnitLoad
- wsd: test: killpoco for UnitPaste
- wsd: test: killpoco for UnitRenderSearchResult
- wsd: test: killpoco for UnitRenderShape
- wsd: test: killpoco for UnitTiffLoad
- wsd: test: killpoco for UnitUNOCommand
- wsd: test: killpoco for UnitTyping
- wsd: test: killpoco for UnitBadDocLoad
- wsd: test: killpoco for UnitCalc
- wsd: test: killpoco for TileCacheTests
- wsd: test: killpoco for UnitPasswordProtected
- wsd: test: killpoco for UnitRenderingOptions
- wsd: test: killpoco for UnitSession
- wsd: test: modernize UnitWOPISaveAS
