### PR TITLE
Code-Coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,11 @@ coolwsd.log
 *.lo
 *.mo
 
+gcov/*
+*.gcno
+*.gcda
+*.gcov
+
 # browser
 browser/debug
 browser/release

--- a/Makefile.am
+++ b/Makefile.am
@@ -327,6 +327,9 @@ noinst_HEADERS = $(wsd_headers) $(shared_headers) $(kit_headers) \
                  test/WOPIUploadConflictCommon.hpp \
                  test/helpers.hpp
 
+GIT_BRANCH := $(shell git symbolic-ref --short HEAD)
+GIT_HASH := $(shell git log -1 --format=%h)
+
 dist-hook:
 	git log -1 --format=%h > $(distdir)/dist_git_hash 2> /dev/null || rm $(distdir)/dist_git_hash
 	mkdir -p $(distdir)/bundled/include/LibreOfficeKit/
@@ -418,6 +421,8 @@ clean-local:
 	rm -rf "${top_srcdir}/loleaflet"
 	rm -rf loolconfig loolconvert loolforkit loolmap loolmount # kill old binaries
 	rm -rf loolwsd loolwsd_fuzzer coolwsd_fuzzer loolstress loolsocketdump
+	rm -rf ${abs_top_srcdir}/gcov
+	find . -iname "*.gc??" -delete
 
 if ENABLE_DEBUG
 # can write to /tmp/coolwsd.log
@@ -611,6 +616,23 @@ stress:
 		$(stress_file) $(trace_dir)/writer-mash-text-table.txt \
 		$(stress_file) $(trace_dir)/writer-hello-shape.txt \
 		$(stress_file) $(trace_dir)/writer-quick.txt
+
+if ENABLE_CODE_COVERAGE
+GEN_COVERAGE_COMMAND=mkdir -p ${abs_top_srcdir}/gcov && \
+lcov --no-external --capture --rc 'lcov_excl_line=' --rc 'lcov_excl_br_line=LOG_|TST_|LOK_|WSD_|TRANSITION|assert' \
+--compat libtool=on --directory ${abs_top_srcdir}/. --output-file ${abs_top_srcdir}/gcov/cool.coverage.test.info && \
+genhtml --prefix ${abs_top_srcdir}/. --ignore-errors source ${abs_top_srcdir}/gcov/cool.coverage.test.info \
+--legend --title "${GIT_BRANCH} @ ${GIT_HASH}" --output-directory=${abs_top_srcdir}/gcov/html && \
+echo "Code-Coverage report generated in ${abs_top_srcdir}/gcov/html"
+else
+GEN_COVERAGE_COMMAND=true
+endif
+
+check: check-recursive
+	$(GEN_COVERAGE_COMMAND)
+
+coverage-report:
+	$(GEN_COVERAGE_COMMAND)
 
 czech: check
 	@echo "This should do something much cooler"

--- a/common/Common.hpp
+++ b/common/Common.hpp
@@ -26,13 +26,14 @@ constexpr int TRACE_MULTIPLIER = 20;
 constexpr int TRACE_MULTIPLIER = 1;
 #endif
 
-constexpr int COMMAND_TIMEOUT_MS = 5000 * TRACE_MULTIPLIER;
+constexpr int COMMAND_TIMEOUT_SECS = 5 * TRACE_MULTIPLIER;
+constexpr int COMMAND_TIMEOUT_MS = COMMAND_TIMEOUT_SECS * 1000;
 constexpr int CHILD_TIMEOUT_MS = COMMAND_TIMEOUT_MS;
 constexpr int CHILD_REBALANCE_INTERVAL_MS = CHILD_TIMEOUT_MS / 10;
 constexpr int POLL_TIMEOUT_MICRO_S = (COMMAND_TIMEOUT_MS / 5) * 1000;
 constexpr int WS_SEND_TIMEOUT_MS = 1000 * TRACE_MULTIPLIER;
 
-constexpr int TILE_ROUNDTRIP_TIMEOUT_MS = 5000 * TRACE_MULTIPLIER;
+constexpr int TILE_ROUNDTRIP_TIMEOUT_MS = COMMAND_TIMEOUT_MS;
 
 /// Pipe and Socket read buffer size.
 /// Should be large enough for ethernet packets

--- a/common/Common.hpp
+++ b/common/Common.hpp
@@ -22,6 +22,8 @@ constexpr int DEFAULT_CLIENT_PORT_NUMBER = 9980;
 
 #if VALGRIND_COOLFORKIT
 constexpr int TRACE_MULTIPLIER = 20;
+#elif CODE_COVERAGE
+constexpr int TRACE_MULTIPLIER = 5;
 #else
 constexpr int TRACE_MULTIPLIER = 1;
 #endif

--- a/common/SigUtil.cpp
+++ b/common/SigUtil.cpp
@@ -227,6 +227,7 @@ namespace SigUtil
 
     const char *signalName(const int signo)
     {
+        // LCOV_EXCL_START Coverage for these is not very useful.
         switch (signo)
         {
 #define CASE(x) case SIG##x: return "SIG" #x
@@ -283,6 +284,7 @@ namespace SigUtil
         default:
             return "unknown";
         }
+        // LCOV_EXCL_STOP Coverage for these is not very useful.
     }
 
     static
@@ -561,8 +563,8 @@ namespace SigUtil
 
         LOG_SYS("Error when trying to kill PID: " << pid << ". Will wait for termination.");
 
-        const int sleepMs = 50;
-        const int count = std::max(CHILD_REBALANCE_INTERVAL_MS / sleepMs, 2);
+        constexpr int sleepMs = 50;
+        constexpr int count = std::max(CHILD_REBALANCE_INTERVAL_MS / sleepMs, 2);
         for (int i = 0; i < count; ++i)
         {
             if (kill(pid, 0) == 0 || errno == ESRCH)

--- a/common/SigUtil.cpp
+++ b/common/SigUtil.cpp
@@ -317,6 +317,10 @@ namespace SigUtil
             SocketPoll::wakeupWorld();
         else
         {
+#if CODE_COVERAGE
+            __gcov_dump();
+#endif
+
             ::signal (signal, SIG_DFL);
             ::raise (signal);
         }

--- a/common/Unit.cpp
+++ b/common/Unit.cpp
@@ -201,7 +201,7 @@ void UnitBase::setTimeout(std::chrono::milliseconds timeoutMilliSeconds)
 
 UnitBase::~UnitBase()
 {
-    LOG_TST(getTestname() << ": ~UnitBase");
+    LOG_TST(getTestname() << ": ~UnitBase: " << (_retValue ? "FAILED" : "SUCCESS"));
 
 // FIXME: we should really clean-up properly.
 //    if (_dlHandle)
@@ -359,7 +359,8 @@ void UnitBase::exitTest(TestResult result)
     _setRetValue = true;
     _retValue = result == TestResult::Ok ? EX_OK : EX_SOFTWARE;
 #if !MOBILEAPP
-    LOG_INF("Setting ShutdownRequestFlag: " << getTestname() << " test has finished.");
+    LOG_INF("Setting ShutdownRequestFlag: " << getTestname() << " test has finished: "
+                                            << (_retValue ? "FAILED" : "SUCCESS"));
     SigUtil::setTerminationFlag(); // And wakupWorld.
 #else
     SocketPoll::wakeupWorld();

--- a/common/Util.cpp
+++ b/common/Util.cpp
@@ -1095,6 +1095,11 @@ namespace Util
     {
         LOG_FTL("Forced Exit with code: " << code);
         Log::shutdown();
+
+#if CODE_COVERAGE
+        __gcov_dump();
+#endif
+
         std::_Exit(code);
     }
 

--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -42,6 +42,15 @@
 
 #include <StringVector.hpp>
 
+#if CODE_COVERAGE
+extern "C"
+{
+    void __gcov_reset(void);
+    void __gcov_flush(void);
+    void __gcov_dump(void);
+}
+#endif
+
 /// Format seconds with the units suffix until we migrate to C++20.
 inline std::ostream& operator<<(std::ostream& os, const std::chrono::seconds& s)
 {

--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -668,6 +668,7 @@ int main(int argc, char**argv)
     /// Return the symbolic name for an errno value, or in decimal if not handled here.
     inline std::string symbolicErrno(int e)
     {
+        // LCOV_EXCL_START Coverage for these is not very useful.
         // Errnos from <asm-generic/errno-base.h> and <asm-generic/errno.h> on Linux.
         switch (e)
         {
@@ -892,6 +893,7 @@ int main(int argc, char**argv)
 #endif
         default: return std::to_string(e);
         }
+        // LCOV_EXCL_STOP Coverage for these is not very useful.
     }
 
     inline size_t getDelimiterPosition(const char* message, const int length, const char delim)

--- a/configure.ac
+++ b/configure.ac
@@ -299,6 +299,11 @@ AC_ARG_WITH([infobar-url],
             AS_HELP_STRING([--with-infobar-url=<url>],
                            [Infobar URL.]))
 
+AC_ARG_WITH([coverage],
+             AS_HELP_STRING([--with-coverage=<gcov>],
+                            [Enable a code-coverage method. Currently only gcov is supported (works with both gcc and clang).
+                            Output HTML in gcov/ directory.]))
+
 AC_ARG_WITH([sanitizer],
              AS_HELP_STRING([--with-sanitizer],
                            [Enable one or more compatible sanitizers. E.g. --with-sanitizer=address,undefined,leak]))
@@ -842,6 +847,23 @@ if test -z "$enable_werror" -o "$enable_werror" = "yes"; then
 else
     AC_MSG_RESULT([no])
 fi
+
+# Code Coverage.
+AC_MSG_CHECKING([whether code-coverage is enabled])
+if test "x$with_coverage" != "x"; then
+    AC_MSG_RESULT([yes ($with_coverage)])
+    CODE_COVERAGE=1
+    CXXFLAGS="$CXXFLAGS --coverage"
+    CFLAGS="$CFLAGS --coverage"
+    LDFLAGS="$LDFLAGS -Wl,--dynamic-list-data --coverage"
+    coverage_msg="Code-Coverage is enabled"
+else
+    AC_MSG_RESULT([no])
+    CODE_COVERAGE=0
+    coverage_msg="Code-Coverage is disabled"
+fi
+AC_DEFINE_UNQUOTED([CODE_COVERAGE],[$CODE_COVERAGE],[Define to 1 if this is a code-coverage build.])
+AM_CONDITIONAL([ENABLE_CODE_COVERAGE], [test "$CODE_COVERAGE" = "1"])
 
 # Fuzzing.
 AC_MSG_CHECKING([whether to build fuzzers])
@@ -1585,6 +1607,7 @@ Configuration:
     Browsersync               $browsersync_msg
     cypress                   $cypress_msg
     C++ compiler flags        $CXXFLAGS
+    Code-Coverage             $coverage_msg
 
     \$ make # to compile"
 if test -n "$with_lo_path"; then

--- a/gtk/mobile.cpp
+++ b/gtk/mobile.cpp
@@ -276,7 +276,7 @@ int main(int argc, char* argv[])
     if (argc != 2)
     {
         fprintf(stderr, "Usage: %s document\n", argv[0]);
-        Util::forcedExit(EX_SOFTWARE); // avoid log cleanup
+        _exit(1); // avoid log cleanup
     }
 
     Log::initialize("Mobile", "trace", false, false, {});

--- a/kit/ForKit.cpp
+++ b/kit/ForKit.cpp
@@ -748,7 +748,7 @@ int main(int argc, char** argv)
     const int parentPid = getppid();
     LOG_INF("ForKit process is ready. Parent: " << parentPid);
 
-    while (!SigUtil::getTerminationFlag())
+    while (!SigUtil::getShutdownRequestFlag() && !SigUtil::getTerminationFlag())
     {
         UnitKit::get().invokeForKitTest();
 

--- a/test/UnitTimeout.cpp
+++ b/test/UnitTimeout.cpp
@@ -24,7 +24,7 @@ public:
         : UnitWSD("UnitTimeout")
         , _timedOut(false)
     {
-        setTimeout(std::chrono::milliseconds(10));
+        setTimeout(std::chrono::seconds(1));
     }
 
     virtual void timeout() override

--- a/test/helpers.hpp
+++ b/test/helpers.hpp
@@ -547,7 +547,8 @@ inline bool isDocumentLoaded(const std::shared_ptr<http::WebSocketSession>& ws,
                              const std::string& testname, bool isView = true)
 {
     const std::string prefix = isView ? "status:" : "statusindicatorfinish:";
-    constexpr auto timeout = std::chrono::seconds(20); // Allow 20 secs to load
+    constexpr auto timeout =
+        std::chrono::seconds(COMMAND_TIMEOUT_SECS * 4); // Allow longer for loading.
     const std::string message = getResponseString(ws, prefix, testname, timeout);
 
     const bool success = COOLProtocol::matchPrefix(prefix, message);

--- a/test/integration-http-server.cpp
+++ b/test/integration-http-server.cpp
@@ -254,7 +254,7 @@ void HTTPServerTest::testConvertTo()
     const char *testname = "testConvertTo";
     const std::string srcPath = FileUtil::getTempFileCopyPath(TDOC, "hello.odt", "convertTo_");
     std::unique_ptr<Poco::Net::HTTPClientSession> session(helpers::createSession(_uri));
-    session->setTimeout(Poco::Timespan(5, 0)); // 5 seconds.
+    session->setTimeout(Poco::Timespan(COMMAND_TIMEOUT_SECS, 0)); // 5 seconds.
 
     TST_LOG("Convert-to odt -> txt");
 
@@ -271,7 +271,7 @@ void HTTPServerTest::testConvertTo()
     catch (const std::exception& ex)
     {
         // In case the server is still starting up.
-        sleep(5);
+        sleep(COMMAND_TIMEOUT_SECS);
         form.write(session->sendRequest(request));
     }
 
@@ -300,7 +300,7 @@ void HTTPServerTest::testConvertTo2()
     const char *testname = "testConvertTo2";
     const std::string srcPath = FileUtil::getTempFileCopyPath(TDOC, "convert-to.xlsx", "convertTo_");
     std::unique_ptr<Poco::Net::HTTPClientSession> session(helpers::createSession(_uri));
-    session->setTimeout(Poco::Timespan(10, 0)); // 10 seconds.
+    session->setTimeout(Poco::Timespan(COMMAND_TIMEOUT_SECS * 2, 0)); // 10 seconds.
 
     TST_LOG("Convert-to #2 xlsx -> png");
 
@@ -317,7 +317,7 @@ void HTTPServerTest::testConvertTo2()
     catch (const std::exception& ex)
     {
         // In case the server is still starting up.
-        sleep(5);
+        sleep(COMMAND_TIMEOUT_SECS);
         form.write(session->sendRequest(request));
     }
 
@@ -340,7 +340,7 @@ void HTTPServerTest::testConvertTo2()
 void HTTPServerTest::testConvertToWithForwardedIP_Deny()
 {
     const std::string testname = "convertToWithForwardedClientIP-Deny";
-    constexpr int TimeoutSeconds = 10; // Sometimes dns resolving is slow.
+    constexpr int TimeoutSeconds = COMMAND_TIMEOUT_SECS * 2; // Sometimes dns resolving is slow.
 
     // Test a forwarded IP which is not allowed to use convert-to feature
     try
@@ -366,7 +366,7 @@ void HTTPServerTest::testConvertToWithForwardedIP_Deny()
         catch (const std::exception& ex)
         {
             // In case the server is still starting up.
-            sleep(2);
+            sleep(COMMAND_TIMEOUT_SECS);
             form.write(session->sendRequest(request));
         }
 
@@ -390,7 +390,7 @@ void HTTPServerTest::testConvertToWithForwardedIP_Deny()
 void HTTPServerTest::testConvertToWithForwardedIP_Allow()
 {
     const std::string testname = "convertToWithForwardedClientIP-Allow";
-    constexpr int TimeoutSeconds = 10; // Sometimes dns resolving is slow.
+    constexpr int TimeoutSeconds = COMMAND_TIMEOUT_SECS * 2; // Sometimes dns resolving is slow.
 
     // Test a forwarded IP which is allowed to use convert-to feature
     try
@@ -416,7 +416,7 @@ void HTTPServerTest::testConvertToWithForwardedIP_Allow()
         catch (const std::exception& ex)
         {
             // In case the server is still starting up.
-            sleep(5);
+            sleep(COMMAND_TIMEOUT_SECS);
             form.write(session->sendRequest(request));
         }
 
@@ -448,7 +448,7 @@ void HTTPServerTest::testConvertToWithForwardedIP_Allow()
 void HTTPServerTest::testConvertToWithForwardedIP_DenyMulti()
 {
     const std::string testname = "convertToWithForwardedClientIP-DenyMulti";
-    constexpr int TimeoutSeconds = 10; // Sometimes dns resolving is slow.
+    constexpr int TimeoutSeconds = COMMAND_TIMEOUT_SECS * 2; // Sometimes dns resolving is slow.
 
     // Test a forwarded header with three IPs, one is not allowed -> request is denied.
     try
@@ -476,7 +476,7 @@ void HTTPServerTest::testConvertToWithForwardedIP_DenyMulti()
         catch (const std::exception& ex)
         {
             // In case the server is still starting up.
-            sleep(5);
+            sleep(COMMAND_TIMEOUT_SECS);
             form.write(session->sendRequest(request));
         }
 
@@ -503,7 +503,7 @@ void HTTPServerTest::testRenderSearchResult()
     const std::string srcPathDoc = FileUtil::getTempFileCopyPath(TDOC, "RenderSearchResultTest.odt", testname);
     const std::string srcPathXml = FileUtil::getTempFileCopyPath(TDOC, "RenderSearchResultFragment.xml", testname);
     std::unique_ptr<Poco::Net::HTTPClientSession> session(helpers::createSession(_uri));
-    session->setTimeout(Poco::Timespan(10, 0)); // 10 seconds.
+    session->setTimeout(Poco::Timespan(COMMAND_TIMEOUT_SECS * 2, 0)); // 10 seconds.
 
     Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_POST, "/cool/render-search-result");
     Poco::Net::HTMLForm form;
@@ -518,7 +518,7 @@ void HTTPServerTest::testRenderSearchResult()
     catch (const std::exception& ex)
     {
         // In case the server is still starting up.
-        sleep(5);
+        sleep(COMMAND_TIMEOUT_SECS);
         form.write(session->sendRequest(request));
     }
 

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -2268,6 +2268,10 @@ void COOLWSD::innerInitialize(Application& self)
         if (ChildRoot[ChildRoot.size() - 1] != '/')
             ChildRoot += '/';
 
+#if CODE_COVERAGE
+        ::setenv("BASE_CHILD_ROOT", Poco::Path(ChildRoot).absolute().toString().c_str(), 1);
+#endif
+
         // Create a custom sub-path for parallelized unit tests.
         if (UnitBase::isUnitTesting())
         {
@@ -2307,9 +2311,18 @@ void COOLWSD::innerInitialize(Application& self)
     // Initialize the config subsystem too.
     config::initialize(&config());
 
+    bool bindMount = getConfigValue<bool>(conf, "mount_jail_tree", true);
+#if CODE_COVERAGE
+    // Code coverage is not supported with bind-mounting.
+    if (bindMount)
+    {
+        LOG_WRN("Mounting is not compatible with code-coverage. Disabling.");
+        bindMount = false;
+    }
+#endif // CODE_COVERAGE
+
     // Setup the jails.
-    JailUtil::setupChildRoot(getConfigValue<bool>(conf, "mount_jail_tree", true), ChildRoot,
-                             SysTemplate);
+    JailUtil::setupChildRoot(bindMount, ChildRoot, SysTemplate);
 
     LOG_DBG("FileServerRoot before config: " << FileServerRoot);
     FileServerRoot = getPathFromConfig("file_server_root_path");
@@ -5436,7 +5449,12 @@ int COOLWSD::innerMain()
 #if !defined(KIT_IN_PROCESS) && !MOBILEAPP
     // Terminate child processes
     LOG_INF("Requesting forkit process " << ForKitProcId << " to terminate.");
-    SigUtil::killChild(ForKitProcId, SIGKILL);
+#if CODE_COVERAGE
+    constexpr auto signal = SIGTERM;
+#else
+    constexpr auto signal = SIGKILL;
+#endif
+    SigUtil::killChild(ForKitProcId, signal);
 #endif
 
     Server->stopPrisoners();
@@ -5559,6 +5577,11 @@ int COOLWSD::main(const std::vector<std::string>& /*args*/)
     UnitWSD::get().returnValue(returnValue);
 
     LOG_INF("Process [coolwsd] finished with exit status: " << returnValue);
+
+#if CODE_COVERAGE
+    __gcov_dump();
+#endif
+
     return returnValue;
 }
 

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -526,8 +526,12 @@ static size_t addNewChild(std::shared_ptr<ChildProcess> child)
     if (OutstandingForks < 0)
         ++OutstandingForks;
 
-    // Reset the child-spawn timeout to the default, now that we're set.
-    ChildSpawnTimeoutMs = CHILD_TIMEOUT_MS;
+    if (COOLWSD::IsBindMountingEnabled)
+    {
+        // Reset the child-spawn timeout to the default, now that we're set.
+        // But only when mounting is enabled. Otherwise, copying is always slow.
+        ChildSpawnTimeoutMs = CHILD_TIMEOUT_MS;
+    }
 
     LOG_TRC("Adding a new child " << pid << " to NewChildren");
     NewChildren.emplace_back(std::move(child));
@@ -894,6 +898,7 @@ unsigned COOLWSD::MaxDocuments;
 std::string COOLWSD::OverrideWatermark;
 std::set<const Poco::Util::AbstractConfiguration*> COOLWSD::PluginConfigurations;
 std::chrono::steady_clock::time_point COOLWSD::StartTime;
+bool COOLWSD::IsBindMountingEnabled = true;
 
 // If you add global state please update dumpState below too
 
@@ -2311,18 +2316,18 @@ void COOLWSD::innerInitialize(Application& self)
     // Initialize the config subsystem too.
     config::initialize(&config());
 
-    bool bindMount = getConfigValue<bool>(conf, "mount_jail_tree", true);
+    IsBindMountingEnabled = getConfigValue<bool>(conf, "mount_jail_tree", true);
 #if CODE_COVERAGE
     // Code coverage is not supported with bind-mounting.
-    if (bindMount)
+    if (IsBindMountingEnabled)
     {
         LOG_WRN("Mounting is not compatible with code-coverage. Disabling.");
-        bindMount = false;
+        IsBindMountingEnabled = false;
     }
 #endif // CODE_COVERAGE
 
     // Setup the jails.
-    JailUtil::setupChildRoot(bindMount, ChildRoot, SysTemplate);
+    JailUtil::setupChildRoot(IsBindMountingEnabled, ChildRoot, SysTemplate);
 
     LOG_DBG("FileServerRoot before config: " << FileServerRoot);
     FileServerRoot = getPathFromConfig("file_server_root_path");

--- a/wsd/COOLWSD.hpp
+++ b/wsd/COOLWSD.hpp
@@ -279,6 +279,7 @@ public:
     static std::chrono::steady_clock::time_point StartTime;
     static std::string LatestVersion;
     static std::mutex FetchUpdateMutex;
+    static bool IsBindMountingEnabled;
 #if MOBILEAPP
 #ifndef IOS
     /// This is used to be able to wait until the lokit main thread has finished (and it is safe to load a new document).

--- a/wsd/COOLWSD.hpp
+++ b/wsd/COOLWSD.hpp
@@ -117,7 +117,12 @@ public:
         if (::kill(_pid, 0) == 0)
         {
             LOG_INF("Killing child [" << _pid << "].");
-            if (!SigUtil::killChild(_pid, SIGKILL))
+#if CODE_COVERAGE
+            constexpr auto signal = SIGTERM;
+#else
+            constexpr auto signal = SIGKILL;
+#endif
+            if (!SigUtil::killChild(_pid, signal))
             {
                 LOG_ERR("Cannot terminate lokit [" << _pid << "]. Abandoning.");
             }


### PR DESCRIPTION
This adds code-coverage reporting in HTML via --with-coverage configuration. Here is the text summary that I get:
```
Overall coverage rate:
  lines......: 72.8% (17748 of 24367 lines)
  functions..: 83.1% (2330 of 2804 functions)
  branches...: 39.4% (20080 of 51024 branches)
Code-Coverage report generated in /home/cool/online/gcov/html
```

- wsd: always use Util::forcedExit to properly cleanup
- wsd: remove default arg from SigUtil::killChild
- wsd: test: replace hard-coded test timeouts
- wsd: mark copied jails early
- wsd: support code-coverage report via --with-coverage
- wsd: minor code-coverage improvements
- wsd: extend the fork timeout when copying systemplate
