### PR TITLE
Add log directory (typescript) to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ cscope*
 *.orig
 coolwsd.log
 *.log.*.gz
+.log
 *.lo
 *.mo
 


### PR DESCRIPTION
Automatically generated .log folder relate to typescript
was not being ignored

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I0fa8bcbe9e3a9eeae8f1549d6d073865d06eb41d
