### PR TITLE
Tablet: Fix Save icon floating when in presence of changes

### DIFF
--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -107,7 +107,7 @@
 	margin-left: 11px;
 }
 
-#Save1.savemodified:after {
+#File .unoSave.savemodified:after {
 	content: '';
 	display: block;
 	width: 6px;

--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -107,6 +107,9 @@
 	margin-left: 11px;
 }
 
+#File .unoSave.savemodified {
+	position: relative;
+}
 #File .unoSave.savemodified:after {
 	content: '';
 	display: block;
@@ -118,7 +121,7 @@
 	box-shadow: 0 0 0 2px var(--color-main-background);
 	border: 1px solid var(--color-primary);
 	position: absolute;
-	top: 18px;
+	top: 0;
 	margin-left: 28px;
 }
 


### PR DESCRIPTION
The dot above the save icon was not scrolling together
with its parent:
     - Make sure the little dot is always under a parent with
       position set to relative
     - Adjust top position due to that ^ change
     - It also fixes for narrow window on desktop.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I24278d09ace6e54769771fafb6f113ce9d4f1542
