### PR TITLE
calc: correctly detect complete row was selected

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -3109,7 +3109,7 @@ L.CanvasTileLayer = L.Layer.extend({
 			return false; // Selection doesn't start at first column.
 
 		var rangeEnd = this._getStringPart(startEnd[1]);
-		if (rangeEnd === 'AMJ') // Last column's code.
+		if (rangeEnd === 'XFD') // Last column's code.
 			return true;
 		else
 			return false;


### PR DESCRIPTION
After commit:
change default Calc number of columns to 16384 (tdf#50916)
https://cgit.freedesktop.org/libreoffice/core/commit/?id=4c5f8ccf0a2320432b8fe91add1dcadf54d9fd58

Last column code is 'XFD'