### PR TITLE
wsd: correctly stop DocBroker from interactive mode

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -285,6 +285,15 @@ void DocumentBroker::pollThread()
 
         if (isInteractive())
         {
+            // It is possible to dismiss the interactive dialog,
+            // exit the Kit process, or even crash. We would deadlock.
+            if (isUnloading())
+            {
+                // We expect to have either isMarkedToDestroy() or
+                // isCloseRequested() in that case.
+                stop("abortedinteractive");
+            }
+
             // Extend the deadline while we are interactiving with the user.
             loadDeadline = now + std::chrono::seconds(limit_load_secs);
             continue;


### PR DESCRIPTION
When in interactive mode, the user has a dialog
to interact with. The issue is that the user may
dismiss said dialog, the Kit process may stop,
crash, or otherwise exit. This basically leaves
DocBroker in a deadlocked state, expecting
input from the interactive document, which
will never materialize.

Here, we rely on the machinery already in place
for flagging such a DocBroker that has no Kit.
We check for said flag and stop DocBroker if
such a case is detected, exiting clearly.

Change-Id: Iecb91c49226da08567cdd2c5d050d458e2f0fc9b
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
