### PR TITLE
wsd: improve logging when kit disconnects

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -2167,6 +2167,7 @@ class KitWebSocketHandler final : public WebSocketHandler
     std::string _socketName;
     std::shared_ptr<lok::Office> _loKit;
     std::string _jailId;
+    std::string _docKey; //< When we get it while creating a new view.
     std::shared_ptr<Document> _document;
     std::shared_ptr<KitSocketPoll> _ksPoll;
     const unsigned _mobileAppDocId;
@@ -2228,14 +2229,14 @@ protected:
         else if (tokens.equals(0, "session"))
         {
             const std::string& sessionId = tokens[1];
-            const std::string& docKey = tokens[2];
+            _docKey = tokens[2];
             const std::string& docId = tokens[3];
             const int canonicalViewId = std::stoi(tokens[4]);
-            const std::string fileId = Util::getFilenameFromURL(docKey);
+            const std::string fileId = Util::getFilenameFromURL(_docKey);
             Util::mapAnonymized(fileId, fileId); // Identity mapping, since fileId is already obfuscated
 
             std::string url;
-            URI::decode(docKey, url);
+            URI::decode(_docKey, url);
             LOG_INF("New session [" << sessionId << "] request on url [" << url << "] with viewId " << canonicalViewId);
 #ifndef IOS
             Util::setThreadName("kit" SHARED_DOC_THREADNAME_SUFFIX + docId);
@@ -2243,7 +2244,7 @@ protected:
             if (!_document)
             {
                 _document = std::make_shared<Document>(
-                    _loKit, _jailId, docKey, docId, url, _queue,
+                    _loKit, _jailId, _docKey, docId, url, _queue,
                     std::static_pointer_cast<WebSocketHandler>(shared_from_this()),
                     _mobileAppDocId);
                 _ksPoll->setDocument(_document);
@@ -2336,7 +2337,10 @@ protected:
     void onDisconnect() override
     {
 #if !MOBILEAPP
-        LOG_ERR("Kit connection lost without exit arriving from wsd. Setting TerminationFlag");
+        //FIXME: We could try to recover.
+        LOG_ERR("Kit for DocBroker ["
+                << _docKey
+                << "] connection lost without exit arriving from wsd. Setting TerminationFlag");
         SigUtil::setTerminationFlag();
 #endif
 #ifdef IOS

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -3229,9 +3229,15 @@ private:
         std::shared_ptr<DocumentBroker> docBroker = child ? child->getDocumentBroker() : nullptr;
         if (docBroker)
         {
+            LOG_WRN("DocBroker [" << docBroker->getDocKey() << "] got disconnected from its Kit ("
+                                  << child->getPid() << "). Closing.");
             std::unique_lock<std::mutex> lock = docBroker->getLock();
             docBroker->disconnectedFromKit();
         }
+        else if (child)
+            LOG_WRN("Kit (" << child->getPid() << ") disconnected. No DocBroker associated.");
+        else
+            LOG_WRN("An unassociated Kit disconnected.");
     }
 
     /// Called after successful socket reads.

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -3309,7 +3309,7 @@ void DocumentBroker::closeDocument(const std::string& reason)
 
 void DocumentBroker::disconnectedFromKit()
 {
-    LOG_DBG("DocBroker " << _docKey << " Disconnected from Kit. Flagging to close.");
+    LOG_INF("DocBroker " << _docKey << " Disconnected from Kit. Flagging to close.");
     _docState.setDisconnected();
     closeDocument("docdisconnected");
 }
@@ -3620,7 +3620,7 @@ void DocumentBroker::dumpState(std::ostream& os)
     const auto now = std::chrono::steady_clock::now();
 
     os << std::boolalpha;
-    os << " Broker: " << COOLWSD::anonymizeUrl(_filename) << " pid: " << getPid();
+    os << " Broker: " << getDocKey() << " pid: " << getPid();
     if (_docState.isMarkedToDestroy())
         os << " *** Marked to destroy ***";
     else
@@ -3630,6 +3630,7 @@ void DocumentBroker::dumpState(std::ostream& os)
     else
         os << "\n  still loading... "
            << std::chrono::duration_cast<std::chrono::seconds>(now - _threadStart);
+    os << "\n  child PID: " << (_childProcess ? _childProcess->getPid() : 0);
     os << "\n  sent: " << sent;
     os << "\n  recv: " << recv;
     os << "\n  jail id: " << _jailId;
@@ -3640,6 +3641,8 @@ void DocumentBroker::dumpState(std::ostream& os)
     os << "\n  doc id: " << _docId;
     os << "\n  num sessions: " << _sessions.size();
     os << "\n  thread start: " << Util::getTimeForLog(now, _threadStart);
+    os << "\n  stop: " << _stop;
+    os << "\n  closeReason: " << _closeReason;
     os << "\n  modified?: " << isModified();
     os << "\n  possibly-modified: " << isPossiblyModified();
     os << "\n  canSave: " << name(canSaveToDisk());


### PR DESCRIPTION
Should make it more obvious which Kit disconnected from which DocBroker. Improved dumpState too.