### PR TITLE
Fix the close button on windows without a title

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -757,6 +757,10 @@ nav.spreadsheet-color-indicator ~ #sidebar-dock-wrapper {
 	display: none;
 }
 
+.ui-dialog-title {
+	min-height: 1em;
+}
+
 .lokdialog_container.ui-dialog.ui-widget-content {
 	padding: 0px;
 	overflow: visible;


### PR DESCRIPTION
* Target version: master 

### Summary

- Previously going into Help > About > View widgets would show a window
  where the close button was rendered slightly out of the top of the
  window
- This was because without the title taking up a line, the title bar
  shrunk to be too small to contain the close button
- This PR makes sure that the title can never take up less than a
  line in height

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

