### PR TITLE
android: fix closing the document on interactive dialogs

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -2405,9 +2405,11 @@ void DocumentBroker::disconnectSessionInternal(const std::string& id)
                     // csv import dialogs), it will wait for their
                     // dismissal indefinetely. Neither would our
                     // load-timeout kick in, since we would be gone.
+#if !MOBILEAPP
                     LOG_INF("Session [" << id << "] disconnected but DocKey [" << _docKey
                                         << "] isn't loaded yet. Terminating the child roughly.");
                     _childProcess->terminate();
+#endif
                 }
             }
 


### PR DESCRIPTION
We get stuck on exitting the app progressbar on mobile
with the interactive dialogs such as csv import or macro security
dialog, we have a different use case for killing the document
as in the normal case. We are not running a separate process
but a thread and we dont trigger regular killing use case.

This piece is not relevant for android because we always have
one connection through fakesocket until the main thread is killed
and it is waiting on the mutex to finish before we finally exit the
document activity.

Signed-off-by: Mert Tumer <mert.tumer@collabora.com>
Change-Id: I99bd333152d40a04f95d4747705a721112317bb2


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

