### PR TITLE
sidebar: show Misc panel with Table Cell Color

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -311,8 +311,7 @@ td.jsdialog .jsdialog.cell.sidebar {
 }
 
 #orientationcontrol,
-#rotation,
-#misc_label {
+#rotation {
 	visibility: hidden;
 	height: 16px;
 }

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -137,7 +137,6 @@ L.Control.JSDialogBuilder = L.Control.extend({
 
 		this._toolitemHandlers['.uno:InsertFormula'] = function () {};
 		this._toolitemHandlers['.uno:SetBorderStyle'] = function () {};
-		this._toolitemHandlers['.uno:TableCellBackgroundColor'] = function () {};
 
 		this._menus = {};
 		this._menus['AutoSumMenu'] = [
@@ -2561,6 +2560,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			'configuredialog': 'sidebar',
 			'modifypage': 'sidebar',
 			'parapropertypanel': 'paragraphdialog',
+			'tablecellbackgroundcolor': 'fillcolor'
 		};
 		if (iconURLAliases[cleanName]) {
 			cleanName = iconURLAliases[cleanName];


### PR DESCRIPTION
It was removed in:
mobile wizard: hide unsupported items in table panel
commit 1aed5ddaa440c0d687708bd0ba7819499dd247fc

but now works

related to: https://github.com/CollaboraOnline/online/issues/4942