### PR TITLE
Calc: address bar, remove w2ui break

### DIFF
--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -154,7 +154,9 @@ w2ui-toolbar {
 
 .inputbar_multiline #tb_formulabar_item_address,
 .inputbar_multiline #tb_formulabar_item_item_2,
-.inputbar_multiline #tb_formulabar_item_functiondialog {
+.inputbar_multiline #tb_formulabar_item_functiondialog,
+#tb_formulabar_item_address {
+	padding-inline-end: 5px;
 	vertical-align: top;
 }
 
@@ -1321,4 +1323,3 @@ html[dir='rtl'] #userListPopover::after {
 	font-size: var(--default-font-size);
 	color: var(--color-main-text);
 }
-

--- a/browser/src/control/Control.FormulaBar.js
+++ b/browser/src/control/Control.FormulaBar.js
@@ -30,7 +30,6 @@ L.Control.FormulaBar = L.Control.extend({
 			items: [
 				{type: 'html',  id: 'left'},
 				{type: 'html', id: 'address', html: '<input id="addressInput" type="text">'},
-				{type: 'break'},
 				{type: 'button', id: 'functiondialog', img: 'functiondialog', hint: _('Function Wizard')},
 				{type: 'html', id: 'formula', html: '<div id="calc-inputbar-wrapper"><div id="calc-inputbar"></div></div>'}
 			],


### PR DESCRIPTION
unclutter formula bar surrouding elements by removing the visual
break and instead add padding. This is a partly cherry-pick
from 8f0f1c700

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I4a9990a5709918d7cacfac2ef41b91281f9af54a
