### PR TITLE
Fix typo in coolwsd.xml.in

### DIFF
--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -17,7 +17,7 @@
     <languagetool desc="LanguageTool Remote API settings for grammar checking">
         <enabled desc="Enable LanguageTool Remote Grammar Checker" type="bool" default="false"></enabled>
         <base_url desc="Http endpoint for the LanguageTool API server, without /check or /languages postfix at the end." type="string" default=""></base_url>
-        <user_name desc="LangueTool account username for premium usage." type="string" default=""></user_name>
+        <user_name desc="LanguageTool account username for premium usage." type="string" default=""></user_name>
         <api_key desc="Api key provided by LanguageTool account for premium usage." type="string" default=""></api_key>
         <ssl_verification desc="Enable or disable SSL verification" type="string" default="true"></ssl_verification>
     </languagetool>


### PR DESCRIPTION
- coolwsd.xml.in is the file copied to coolwsd.xml to become the configuration file for COOL
- this PR fixes a typo in the languagetool section

Signed-off-by: Skyler Grey <skyler3665@gmail.com>

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

