### PR TITLE
IWYU: Clean up includes in common/*

### DIFF
--- a/common/Authorization.cpp
+++ b/common/Authorization.cpp
@@ -5,14 +5,14 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-#include <config.h>
-
 #include "Authorization.hpp"
 #include "Log.hpp"
 #include "StringVector.hpp"
 
 #include <Poco/Net/HTTPRequest.h>
 #include <Poco/URI.h>
+
+#include <vector>
 
 void Authorization::authorizeURI(Poco::URI& uri) const
 {

--- a/common/Authorization.hpp
+++ b/common/Authorization.hpp
@@ -10,7 +10,7 @@
 #pragma once
 
 #include <string>
-#include <vector>
+#include <utility>
 
 namespace Poco
 {

--- a/common/CommandControl.cpp
+++ b/common/CommandControl.cpp
@@ -6,11 +6,15 @@
  */
 
 #include <config.h>
-#include <string>
-#include <unordered_set>
+
 #include "ConfigUtil.hpp"
 #include "Util.hpp"
 #include "CommandControl.hpp"
+
+#include <Poco/Util/LayeredConfiguration.h>
+
+#include <string>
+#include <unordered_set>
 
 namespace CommandControl
 {

--- a/common/CommandControl.hpp
+++ b/common/CommandControl.hpp
@@ -7,13 +7,17 @@
 
 #pragma once
 
-#include <string>
-#include <unordered_set>
 #include "ConfigUtil.hpp"
-#include <Poco/Util/LayeredConfiguration.h>
+#include <Log.hpp>
+
 #include <Poco/URI.h>
 #include <Poco/Exception.h>
-#include <Log.hpp>
+
+#include <map>
+#include <string>
+#include <unordered_set>
+
+namespace Poco { namespace Util { class LayeredConfiguration; } }
 
 namespace CommandControl
 {

--- a/common/Common.hpp
+++ b/common/Common.hpp
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <config.h>
+
 #include <string>
 #include <vector>
 #include <memory>

--- a/common/ConfigUtil.cpp
+++ b/common/ConfigUtil.cpp
@@ -16,6 +16,7 @@
 
 #include <Poco/Util/AbstractConfiguration.h>
 #include <Poco/Util/XMLConfiguration.h>
+#include <Poco/AutoPtr.h>
 
 namespace config
 {

--- a/common/FileUtil.cpp
+++ b/common/FileUtil.cpp
@@ -8,9 +8,13 @@
 #include <config.h>
 
 #include "FileUtil.hpp"
+#include "Log.hpp"
+#include "Util.hpp"
+#include "Unit.hpp"
+
+#include <Poco/File.h>
 
 #include <dirent.h>
-#include <exception>
 #include <ftw.h>
 #include <stdexcept>
 #include <sys/time.h>
@@ -25,6 +29,7 @@
 
 #include <fcntl.h>
 #include <chrono>
+#include <cstddef>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -43,13 +48,6 @@ namespace filesystem = ::std::filesystem;
 #else
 # include <Poco/TemporaryFile.h>
 #endif
-
-#include <Poco/File.h>
-#include <Poco/Path.h>
-
-#include "Log.hpp"
-#include "Util.hpp"
-#include "Unit.hpp"
 
 namespace
 {

--- a/common/JailUtil.cpp
+++ b/common/JailUtil.cpp
@@ -9,21 +9,25 @@
 
 #include "FileUtil.hpp"
 #include "JailUtil.hpp"
+#include "Log.hpp"
 
-#include <sys/types.h>
+#include <Poco/File.h>
+#include <Poco/Path.h>
+
 #include <fcntl.h>
 #include <unistd.h>
 #ifdef __linux__
 #include <sys/sysmacros.h>
+#include <sys/stat.h>
 #endif
 
-#include <cstdio>
+#include <cerrno>
 #include <cstdlib>
 #include <cstring>
+#include <exception>
+#include <initializer_list>
 #include <string>
-
-#include "Log.hpp"
-#include <SigUtil.hpp>
+#include <vector>
 
 namespace JailUtil
 {

--- a/common/JailUtil.hpp
+++ b/common/JailUtil.hpp
@@ -9,9 +9,6 @@
 
 #include <string>
 
-#include <Poco/File.h>
-#include <Poco/Path.h>
-
 namespace JailUtil
 {
 

--- a/common/Log.cpp
+++ b/common/Log.cpp
@@ -7,30 +7,21 @@
 
 #include <config.h>
 
-#ifdef __linux__
-#include <sys/prctl.h>
-#include <sys/syscall.h>
-#endif
-#include <unistd.h>
-
-#include <atomic>
-#include <cassert>
-#include <cstring>
-#include <ctime>
-#include <iomanip>
-#include <iostream>
-#include <sstream>
-#include <string>
+#include "Log.hpp"
+#include "Util.hpp"
 
 #include <Poco/AutoPtr.h>
 #include <Poco/ConsoleChannel.h>
 #include <Poco/FileChannel.h>
-#include <Poco/FormattingChannel.h>
-#include <Poco/PatternFormatter.h>
-#include <Poco/SplitterChannel.h>
 
-#include "Log.hpp"
-#include "Util.hpp"
+#include <unistd.h>
+
+#include <atomic>
+#include <cstdio>
+#include <ctime>
+#include <iomanip>
+#include <iostream>
+#include <string>
 
 namespace Log
 {

--- a/common/Log.hpp
+++ b/common/Log.hpp
@@ -7,21 +7,19 @@
 
 #pragma once
 
-#include <sys/syscall.h>
-#include <unistd.h>
+#include <Poco/LocalDateTime.h>
+#include <Poco/Logger.h>
+#include <Poco/Message.h>
 
+#include <cassert>
 #include <cerrno>
-#include <cstddef>
+#include <chrono>
 #include <functional>
 #include <iostream>
-#include <thread>
-#include <sstream>
+#include <map>
 #include <string>
-
-#include <Poco/LocalDateTime.h>
-#include <Poco/DateTimeFormat.h>
-#include <Poco/DateTimeFormatter.h>
-#include <Poco/Logger.h>
+#include <thread>
+#include <utility>
 
 #ifdef __ANDROID__
 #include <android/log.h>

--- a/common/Protocol.cpp
+++ b/common/Protocol.cpp
@@ -5,17 +5,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-#include <config.h>
-
 #include "Protocol.hpp"
+#include "StringVector.hpp"
 
-#include <cassert>
-#include <cstring>
 #include <map>
 #include <string>
-
-#define LOK_USE_UNSTABLE_API
-#include <LibreOfficeKit/LibreOfficeKitEnums.h>
+#include <utility>
 
 namespace COOLProtocol
 {

--- a/common/Protocol.hpp
+++ b/common/Protocol.hpp
@@ -7,21 +7,17 @@
 
 #pragma once
 
+#include "StringVector.hpp"
+#include "Util.hpp"
+
+#include <algorithm>
 #include <cstdint>
 #include <cstdlib>
-#include <cstring>
-#include <iomanip>
 #include <map>
-#include <regex>
 #include <sstream>
 #include <string>
+#include <tuple>
 #include <vector>
-
-#include <StringVector.hpp>
-#include <Util.hpp>
-
-#define LOK_USE_UNSTABLE_API
-#include <LibreOfficeKit/LibreOfficeKitEnums.h>
 
 namespace COOLProtocol
 {

--- a/common/Seccomp.cpp
+++ b/common/Seccomp.cpp
@@ -12,17 +12,19 @@
 #include <config.h>
 
 #include "Seccomp.hpp"
+#include "StringVector.hpp"
 
-#include <dlfcn.h>
-#include <ftw.h>
+#include <common/Log.hpp>
+#include <common/SigUtil.hpp>
+
 #ifdef __linux__
 #include <linux/audit.h>
 #include <linux/filter.h>
 #if DISABLE_SECCOMP == 0
 #include <linux/seccomp.h>
 #endif
-#include <malloc.h>
 #include <signal.h>
+#include <string>
 #include <sys/capability.h>
 #include <sys/prctl.h>
 #include <sys/syscall.h>
@@ -30,10 +32,6 @@
 #include <sys/resource.h>
 #include <sys/time.h>
 #include <unistd.h>
-#include <utime.h>
-
-#include <common/Log.hpp>
-#include <common/SigUtil.hpp>
 
 #if DISABLE_SECCOMP == 0
 #ifndef SYS_SECCOMP

--- a/common/Seccomp.hpp
+++ b/common/Seccomp.hpp
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <Protocol.hpp>
+class StringVector;
 
 namespace Seccomp {
     enum Type { KIT, WSD };

--- a/common/Session.cpp
+++ b/common/Session.cpp
@@ -5,19 +5,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-#include <config.h>
-
 #include "Session.hpp"
 
-#include <Poco/Exception.h>
-#include <Poco/Path.h>
-#include <Poco/String.h>
-#include <Poco/URI.h>
-
-#include "Common.hpp"
 #include "Protocol.hpp"
 #include "Log.hpp"
+#include "StringVector.hpp"
+#include "Unit.hpp"
 #include "Util.hpp"
+
+#include <Poco/Exception.h>
+#include <Poco/URI.h>
 
 using namespace COOLProtocol;
 

--- a/common/Session.hpp
+++ b/common/Session.hpp
@@ -7,24 +7,24 @@
 
 #pragma once
 
+#include "Log.hpp"
+#include "WebSocketHandler.hpp"
+
 #include <atomic>
 #include <cassert>
+#include <chrono>
+#include <cstring>
+#include <cstdint>
 #include <memory>
 #include <map>
 #include <ostream>
+#include <string>
 #include <type_traits>
-
-#include <Poco/Path.h>
-#include <Poco/Types.h>
-
-#include "Protocol.hpp"
-#include "Log.hpp"
-#include "MessageQueue.hpp"
-#include "Message.hpp"
-#include "TileCache.hpp"
-#include "WebSocketHandler.hpp"
+#include <utility>
+#include <vector>
 
 class Session;
+class StringVector;
 
 template<class T>
 class SessionMap : public std::map<std::string, std::shared_ptr<T> >

--- a/common/SigUtil.cpp
+++ b/common/SigUtil.cpp
@@ -9,35 +9,28 @@
 
 #include "SigUtil.hpp"
 
+#include "Common.hpp"
+#include "Log.hpp"
+#include <net/Socket.hpp>
+
 #if !defined(__ANDROID__)
 #  include <execinfo.h>
 #endif
-#include <csignal>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
-#include <sys/poll.h>
-#include <sys/uio.h>
 #include <unistd.h>
 
+#include <algorithm>
+#include <array>
 #include <atomic>
 #include <cassert>
+#include <cerrno>
 #include <chrono>
+#include <csignal>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <fstream>
-#include <iomanip>
 #include <iostream>
-#include <mutex>
-#include <sstream>
 #include <string>
 #include <thread>
-#include <array>
-
-#include <Socket.hpp>
-#include "Common.hpp"
-#include "Log.hpp"
 
 #ifndef IOS
 static std::atomic<bool> TerminationFlag(false);

--- a/common/SigUtil.hpp
+++ b/common/SigUtil.hpp
@@ -7,9 +7,9 @@
 
 #pragma once
 
-#include <atomic>
-#include <mutex>
+#include <cstddef>
 #include <signal.h>
+#include <string>
 
 namespace SigUtil
 {

--- a/common/SpookyV2.cpp
+++ b/common/SpookyV2.cpp
@@ -9,10 +9,9 @@
 //   July 30 2012: I reintroduced the buffer overflow
 //   August 5 2012: SpookyV2: d = should be d += in short hash, and remove extra mix from long hash
 
-#include <config.h>
-
-#include <memory.h>
 #include "SpookyV2.h"
+
+#include <cstring>
 
 #define ALLOW_UNALIGNED_READS true
 

--- a/common/StringVector.cpp
+++ b/common/StringVector.cpp
@@ -9,6 +9,8 @@
 
 #include "Util.hpp"
 
+#include <limits>
+
 bool StringVector::equals(std::size_t index, const StringVector& other, std::size_t otherIndex)
 {
     if (index >= _tokens.size())

--- a/common/StringVector.hpp
+++ b/common/StringVector.hpp
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <algorithm>
+#include <cstdint>
 #include <cstring>
 #include <string>
 #include <utility>

--- a/common/Unit.cpp
+++ b/common/Unit.cpp
@@ -9,23 +9,24 @@
 
 #include "Unit.hpp"
 
-#include <iostream>
-#include <cassert>
-#include <dlfcn.h>
-#include <fstream>
-#include <sstream>
-#include <sysexits.h>
-#include <thread>
+#include "Log.hpp"
+#include "Util.hpp"
+#include <common/SigUtil.hpp>
+#include <net/Socket.hpp>
 
+#include <Poco/Dynamic/Var.h>
 #include <Poco/JSON/Object.h>
 #include <Poco/JSON/Parser.h>
 #include <Poco/Util/LayeredConfiguration.h>
 
-#include "Log.hpp"
-#include "Util.hpp"
-
-#include <common/SigUtil.hpp>
-#include <common/Message.hpp>
+#include <atomic>
+#include <cassert>
+#include <cstring>
+#include <dlfcn.h>
+#include <fstream>
+#include <mutex>
+#include <sysexits.h>
+#include <thread>
 
 UnitBase *UnitBase::Global = nullptr;
 UnitKit *GlobalKit = nullptr;

--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -7,18 +7,20 @@
 
 #pragma once
 
-#include <atomic>
-#include <cassert>
-#include <chrono>
-#include <memory>
-#include <string>
-#include <vector>
-
-#include <common/StateEnum.hpp>
+#include "Log.hpp"
 #include "Util.hpp"
 #include "net/Socket.hpp"
 
 #include <test/testlog.hpp>
+
+#include <Poco/Exception.h>
+
+#include <cassert>
+#include <chrono>
+#include <exception>
+#include <memory>
+#include <string>
+#include <vector>
 
 class UnitBase;
 class UnitWSD;
@@ -36,8 +38,7 @@ namespace Poco
 
     namespace Net
     {
-        class HTTPServerRequest;
-        class HTTPServerResponse;
+        class HTTPRequest;
     }
 
     namespace Util

--- a/common/Util.cpp
+++ b/common/Util.cpp
@@ -9,12 +9,24 @@
 
 #include "Util.hpp"
 
-#include <csignal>
-#include <sys/poll.h>
+#include "Log.hpp"
+#include "Protocol.hpp"
+#include "StringVector.hpp"
+#include "TraceEvent.hpp"
+
+#include <Poco/Dynamic/Var.h>
+#include <Poco/Base64Encoder.h>
+#include <Poco/HexBinaryEncoder.h>
+#include <Poco/Exception.h>
+#include <Poco/Path.h>
+#include <Poco/RegularExpression.h>
+#include <Poco/JSON/Object.h>
+#include <Poco/JSON/Parser.h>
+#include <Poco/RandomStream.h>
+
 #ifdef __linux__
 #  include <sys/prctl.h>
 #  include <sys/syscall.h>
-#  include <sys/vfs.h>
 #  include <sys/resource.h>
 #elif defined __FreeBSD__
 #  include <sys/resource.h>
@@ -22,8 +34,6 @@
 #elif defined IOS
 #import <Foundation/Foundation.h>
 #endif
-#include <sys/stat.h>
-#include <sys/uio.h>
 #include <sys/types.h>
 #include <unistd.h>
 #include <dirent.h>
@@ -36,33 +46,19 @@
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
+#include <exception>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
+#include <iterator>
 #include <mutex>
 #include <unordered_map>
 #include <random>
+#include <ratio>
 #include <sstream>
 #include <string>
 #include <thread>
 #include <limits>
-
-#include <Poco/Base64Encoder.h>
-#include <Poco/HexBinaryEncoder.h>
-#include <Poco/ConsoleChannel.h>
-#include <Poco/Exception.h>
-#include <Poco/Format.h>
-#include <Poco/JSON/JSON.h>
-#include <Poco/JSON/Object.h>
-#include <Poco/JSON/Parser.h>
-#include <Poco/RandomStream.h>
-#include <Poco/TemporaryFile.h>
-#include <Poco/Util/Application.h>
-
-#include "Common.hpp"
-#include "Log.hpp"
-#include "Protocol.hpp"
-#include "TraceEvent.hpp"
 
 namespace Util
 {

--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -7,40 +7,42 @@
 
 #pragma once
 
+#include <config.h>
+
+#include <sys/types.h>
+#include <algorithm>
+#include <atomic>
 #include <cassert>
+#include <cctype>
 #include <cerrno>
 #include <chrono>
 #include <cinttypes>
 #include <cstddef>
 #include <cstdint>
+#include <cstdio>
+#include <cstdlib>
 #include <cstring>
-#include <algorithm>
-#include <atomic>
-#include <functional>
+#include <initializer_list>
+#include <limits>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <set>
 #include <sstream>
+#include <stdexcept>
 #include <string>
-#include <map>
+#include <tuple>
 #include <utility>
-#include <inttypes.h>
-#include <cctype>
-
-#include <memory.h>
+#include <vector>
 
 #ifndef __linux__
 #include <thread>
 #endif
 
-#include <Poco/File.h>
-#include <Poco/Path.h>
-#include <Poco/RegularExpression.h>
+class StringVector;
 
 #define LOK_USE_UNSTABLE_API
 #include <LibreOfficeKit/LibreOfficeKitEnums.h>
-
-#include <StringVector.hpp>
 
 /// Format seconds with the units suffix until we migrate to C++20.
 inline std::ostream& operator<<(std::ostream& os, const std::chrono::seconds& s)

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -25,6 +25,7 @@
 #include <Poco/BinaryReader.h>
 #include <Poco/Base64Decoder.h>
 #if !MOBILEAPP
+#include <Poco/Net/HTTPRequest.h>
 #include <Poco/Net/HTTPResponse.h>
 #include <Poco/Net/HTTPSClientSession.h>
 #include <Poco/Net/SSLManager.h>

--- a/kit/ChildSession.hpp
+++ b/kit/ChildSession.hpp
@@ -17,6 +17,7 @@
 
 #include "Common.hpp"
 #include "Kit.hpp"
+#include "MessageQueue.hpp"
 #include "Session.hpp"
 #include "Watermark.hpp"
 

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -75,6 +75,7 @@
 #include "Watermark.hpp"
 #include "RenderTiles.hpp"
 #include "SetupKitEnvironment.hpp"
+#include "WebSocketHandler.hpp"
 #include <common/ConfigUtil.hpp>
 #include <common/TraceEvent.hpp>
 

--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <chrono>
+#include <cstddef>
 #include <memory>
 #include <vector>
 

--- a/test/WhiteBoxTests.cpp
+++ b/test/WhiteBoxTests.cpp
@@ -24,6 +24,7 @@
 
 #include <common/Message.hpp>
 #include <wsd/FileServer.hpp>
+#include <wsd/TileCache.hpp>
 #include <net/Buffer.hpp>
 #include <net/NetUtil.hpp>
 

--- a/tools/COOLWebSocket.hpp
+++ b/tools/COOLWebSocket.hpp
@@ -10,6 +10,7 @@
 #include <test/testlog.hpp>
 
 #include <cstdlib>
+#include <iomanip>
 #include <mutex>
 #include <thread>
 

--- a/tools/Replay.hpp
+++ b/tools/Replay.hpp
@@ -10,6 +10,7 @@
 #include <math.h>
 #include <chrono>
 #include <cstring>
+#include <iomanip>
 #include <unordered_map>
 
 #include "Socket.hpp"

--- a/wsd/AdminModel.hpp
+++ b/wsd/AdminModel.hpp
@@ -11,6 +11,7 @@
 #include <ctime>
 #include <list>
 #include <memory>
+#include <regex>
 #include <set>
 #include <string>
 #include <utility>

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -16,6 +16,8 @@
 #include <unordered_map>
 
 #include <Poco/Net/HTTPResponse.h>
+#include <Poco/File.h>
+#include <Poco/Path.h>
 #include <Poco/StreamCopier.h>
 #include <Poco/URI.h>
 #include <Poco/JSON/Object.h>

--- a/wsd/ClientSession.hpp
+++ b/wsd/ClientSession.hpp
@@ -9,6 +9,7 @@
 
 #include "Session.hpp"
 #include "Storage.hpp"
+#include "Message.hpp"
 #include "MessageQueue.hpp"
 #include "SenderQueue.hpp"
 #include "ServerURL.hpp"

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -23,6 +23,7 @@
 #include <Poco/URI.h>
 
 #include "Log.hpp"
+#include "TileCache.hpp"
 #include "TileDesc.hpp"
 #include "Util.hpp"
 #include "net/Socket.hpp"

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -23,6 +23,7 @@
 #include <Poco/DateTimeFormat.h>
 #include <Poco/DateTimeFormatter.h>
 #include <Poco/Exception.h>
+#include <Poco/File.h>
 #include <Poco/FileStream.h>
 #include <Poco/Net/HTMLForm.h>
 #include <Poco/Net/HTTPBasicCredentials.h>
@@ -31,6 +32,7 @@
 #include <Poco/Net/HTTPResponse.h>
 #include <Poco/Net/NameValueCollection.h>
 #include <Poco/Net/NetException.h>
+#include <Poco/Path.h>
 #include <Poco/RegularExpression.h>
 #include <Poco/Runnable.h>
 #include <Poco/StreamCopier.h>

--- a/wsd/QuarantineUtil.cpp
+++ b/wsd/QuarantineUtil.cpp
@@ -7,6 +7,7 @@
 
 #include "QuarantineUtil.hpp"
 
+#include <Poco/File.h>
 #include <Poco/Path.h>
 #include <Poco/URI.h>
 #include "ClientSession.hpp"

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -20,6 +20,8 @@
 #include <string>
 
 #include <Poco/Exception.h>
+#include <Poco/File.h>
+#include <Poco/Path.h>
 #include <Poco/JSON/Object.h>
 #include <Poco/JSON/Parser.h>
 

--- a/wsd/TileCache.cpp
+++ b/wsd/TileCache.cpp
@@ -14,6 +14,7 @@
 #include <cstddef>
 #include <cstdio>
 #include <fstream>
+#include <iomanip>
 #include <iostream>
 #include <memory>
 #include <sstream>


### PR DESCRIPTION
By first running
 bear make -j8
...then on individual files:
 iwyu_tool.py -v -p . <filename>
(some suggestions were disregarded)

Also:
- reordered includes, first from this project,
  then from Poco, finally from std,
- removed unnecessary 'config.h' include from:
   Authorization.cpp, Protocol.cpp, Session.cpp, SpookyV2.cpp
- 'config.h' include was missing from these, haven't added them
   as they haven't been causing a problem:
   Log.hpp, SigUtile.hpp, Util.hpp
- removed unnecessary LibreOfficeKitEnums.h include from
   Protocol.hpp/cpp

Signed-off-by: Aron Budea <aron.budea@collabora.com>
Change-Id: Iaf3e095b66622a4f3483ee478a7c531521b3bc91

* Target version: master 

### Checklist

- [X] Code is properly formatted
- [X] All commits have Change-Id
- [X] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

