### PR TITLE
browser: Add proper id to StyleApply buttons on notebookbar

### DIFF
--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -637,16 +637,19 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 						'type': 'toolbox',
 						'children': [
 							{
+								'id': 'StyleApplyDefault',
 								'type': 'toolitem',
 								'text': _('Default'),
 								'command': '.uno:StyleApply?Style:string=Default&FamilyName:string=CellStyles'
 							},
 							{
+								'id': 'StyleApplyHeading1',
 								'type': 'toolitem',
 								'text': _('Heading 1'),
 								'command': '.uno:StyleApply?Style:string=Heading 1&FamilyName:string=CellStyles'
 							},
 							{
+								'id': 'StyleApplyHeading2',
 								'type': 'toolitem',
 								'text': _('Heading 2'),
 								'command': '.uno:StyleApply?Style:string=Heading 2&FamilyName:string=CellStyles'
@@ -658,16 +661,19 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 						'type': 'toolbox',
 						'children': [
 							{
+								'id': 'StyleApplyGood',
 								'type': 'toolitem',
 								'text': _('Good'),
 								'command': '.uno:StyleApply?Style:string=Good&FamilyName:string=CellStyles'
 							},
 							{
+								'id': 'StyleApplyNeutral',
 								'type': 'toolitem',
 								'text': _('Neutral'),
 								'command': '.uno:StyleApply?Style:string=Neutral&FamilyName:string=CellStyles'
 							},
 							{
+								'id': 'StyleApplyBad',
 								'type': 'toolitem',
 								'text': _('Bad'),
 								'command': '.uno:StyleApply?Style:string=Bad&FamilyName:string=CellStyles'


### PR DESCRIPTION
Signed-off-by: Julius Härtl <jus@bitgrid.net>
Change-Id: Ic654c9b3316a73a09033f58414c2e98043ccf0de


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

Use proper ids instead of the generated ones from the uno command which are not valid otherwise:

Before: `StyleApply%3FStyle%3Astring%3DDefault%26FamilyName%3Astring%3DCellStyles`
After: `StyleApplyDefault`


### TODO

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

