### PR TITLE
browser: Give formulabar a fixed button width to avoid jumping

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1198,6 +1198,10 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	opacity: 0.8;
 }
 
+#acceptformula {
+	margin-inline-start: 3px;
+}
+
 .formulabar.unotoolbutton:hover {
 	opacity: 1;
 }


### PR DESCRIPTION
Signed-off-by: Julius Härtl <jus@bitgrid.net>
Change-Id: Id38951ddc79e99573008c63d4e6c7ed36fcc52a2


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

The unoAutoSumMenu button has a different size than unoacceptformula button, which leads to a minor jump when clicking into the input field. Setting a fixed width solves this.

### TODO


### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

