### PR TITLE
browser: Avoid important property on sidebar border

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -19,7 +19,7 @@
 
 [data-userinterfacemode='classic'] #document-container:not(.mobile) + #sidebar-dock-wrapper,
 #document-container.spreadsheet-doctype:not(.mobile) + #sidebar-dock-wrapper {
-	border-inline-start: 1px solid var(--color-border) !important;
+	border-inline-start: 1px solid var(--color-border);
 }
 
 .sidebar .spinfieldcontainer input {


### PR DESCRIPTION
Signed-off-by: Julius Härtl <jus@bitgrid.net>
Change-Id: Ia9cd8db9dcfa580f049c7212cfb01384d957d5cc


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

This will ensure that branding can hide the border more easily and it does not seem to be necessary to force this with !important


### TODO


### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

