### PR TITLE
Unique ids and proper label for row height / column width

### DIFF
--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -730,13 +730,13 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				'enabled': 'true'
 			},
 			{
-				'id': 'Data-RowMenu:MenuRowHeight',
+				'id': 'Data-RowMenuHeight:MenuRowHeight',
 				'type': 'menubutton',
-				'text': _('Row Width'),
+				'text': _('Row Height'),
 				'enabled': 'true'
 			},
 			{
-				'id': 'Data-RowMenu:MenuColumnWidth',
+				'id': 'Data-ColumnMenuWidth:MenuColumnWidth',
 				'type': 'menubutton',
 				'text': _('Column Width'),
 				'enabled': 'true'


### PR DESCRIPTION
Signed-off-by: Julius Härtl <jus@bitgrid.net>
Change-Id: I486c2709fd2dd5d133c4c46416dcea5ef0479fc1


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

- Use unique ids for the row height and column width menus
- Use proper label "Row height" instead of "Row width"

### TODO


### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

