### PR TITLE
remove suffix digit

### DIFF
--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -533,11 +533,12 @@
 	text-align: center;
 }
 
-#style1 img ~ .ui-drawing-area-placeholder-container .ui-drawing-area-placeholder {
-	font-family: Liberation Serif;
-	font-size: var(--default-font-size);
+#style img ~ .ui-drawing-area-placeholder-container .ui-drawing-area-placeholder {
+	font-family: Liberation Sans;
+	font-size: calc(var(--default-font-size)*2);
+	font-weight: bold;
 }
-
+/* 
 #style2 img ~ .ui-drawing-area-placeholder-container .ui-drawing-area-placeholder {
 	font-family: Liberation Serif;
 	font-size: var(--default-font-size);
@@ -552,7 +553,7 @@
 #style4 img ~ .ui-drawing-area-placeholder-container .ui-drawing-area-placeholder {
 	font-family: Liberation Sans;
 	font-size: calc(var(--default-font-size)*1.5);
-}
+} */
 
 .downloadas-odt-submenu-icon {
 	background: url('images/lc_downloadas-odt.svg') center;


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* #5053
* Target version: master 

### Summary
I went through all the CSS files, I only find suffix in digit in `browser/css/notebook.css`
the `#style1`, `#style2`,` #style3` they aren't defined yet inside the HTML or JavaScript files. So I rename the `#style1' to 
 `#style`, I have commented the duplicates out because it's not defined, if I done this right, I will delete those function or make them in one line.
Please tell me if I did right.

### TODO
* I see two files  `browser/css/color-palette-dark.css` and `browser/css/color-palette.css` they are actually the same just 2 lines of codes are different, I was thinking to make them one, inside `browser/css/color-palette-dark.css` there's this `@media (prefers-color-scheme: dark)` if I make another function and change the `dark` to `light` and put these two function inside one file lets say `color-palette.css` I'm pretty sure, It would work.

* We can speed up our CSS files if we minify them.

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

