### PR TITLE
fix selecting redline comment jumps to scroll to beginning

### DIFF
--- a/browser/src/layer/tile/CommentListSection.ts
+++ b/browser/src/layer/tile/CommentListSection.ts
@@ -616,9 +616,9 @@ class CommentSection {
 				if (this.sectionProperties.docLayer._docType === 'text') {
 					// check it is visible in the screen and not a new comment
 					const id = this.sectionProperties.selectedComment.sectionProperties.data.id;
-					if (id.indexOf('new') < 0 && !this.isInViewPort(this.sectionProperties.selectedComment)) {
-						const scrollToPos = this.sectionProperties.selectedComment.position[1];
-						this.map.scrollTop(scrollToPos < 0 ? 0 : scrollToPos);
+					const position = this.sectionProperties.selectedComment.getPosition();
+					if (id.indexOf('new') < 0 && !this.isInViewPort(this.sectionProperties.selectedComment) && position[1] !== 0) {
+						this.map.scrollTop(position[1] < 0 ? 0 : position[1]);
 					}
 				}
 			}
@@ -635,8 +635,9 @@ class CommentSection {
 		const scrollSection = app.sectionContainer.getSectionWithName(L.CSections.Scroll.name);
 		const screenTop = scrollSection.containerObject.getDocumentTopLeft()[1];
 		const screenBottom = screenTop + (window.innerHeight || document.documentElement.clientHeight);
-		const annotationTop = annotation.position[1];
-		const annotationBottom = annotation.position[1] + rect.bottom - rect.top;
+		const position = annotation.getPosition();
+		const annotationTop = position[1];
+		const annotationBottom = position[1] + rect.bottom - rect.top;
 
 		return (
 			screenTop <= annotationTop &&

--- a/browser/src/layer/tile/CommentSection.ts
+++ b/browser/src/layer/tile/CommentSection.ts
@@ -482,20 +482,43 @@ class Comment {
 		} else if (this.sectionProperties.data.trackchange && this.sectionProperties.data.anchorPos) {
 			// For redline comments there are no 'rectangles' or 'rectangleOriginal' properties in sectionProperties.data
 			// So use the comment rectangle stored in anchorPos (in display? twips).
-			var anchorPos = this.sectionProperties.data.anchorPos;
-			pos = [
-				Math.round(anchorPos[0] * ratio),
-				Math.round(anchorPos[1] * ratio)
-			];
-			size = [
-				Math.round(anchorPos[2] * ratio),
-				Math.round(anchorPos[3] * ratio)
-			];
+			pos = this.getPosition();
+			size = this.getSize();
 
 			intersectsVisibleArea = Comment.doesRectIntersectView(pos, size, viewContext);
 		}
 
 		return intersectsVisibleArea;
+	}
+
+	public getPosition () {
+		// For redline comments there are no 'rectangles' or 'rectangleOriginal' properties in sectionProperties.data
+		// So use the comment rectangle stored in anchorPos (in display? twips).
+		if (this.sectionProperties.data.trackchange && this.sectionProperties.data.anchorPos) {
+			var ratio: number = (app.tile.size.pixels[0] / app.tile.size.twips[0]);
+			var anchorPos = this.sectionProperties.data.anchorPos;
+			return [
+				Math.round(anchorPos[0] * ratio),
+				Math.round(anchorPos[1] * ratio)
+			];
+		} else {
+			return this.position;
+		}
+	}
+
+	public getSize() {
+		// For redline comments there are no 'rectangles' or 'rectangleOriginal' properties in sectionProperties.data
+		// So use the comment rectangle stored in anchorPos (in display? twips).
+		if (this.sectionProperties.data.trackchange && this.sectionProperties.data.anchorPos) {
+			var ratio: number = (app.tile.size.pixels[0] / app.tile.size.twips[0]);
+			var anchorPos = this.sectionProperties.data.anchorPos;
+			return [
+				Math.round(anchorPos[2] * ratio),
+				Math.round(anchorPos[3] * ratio)
+			];
+		} else {
+			return this.size;
+		}
 	}
 
 	private updatePosition () {


### PR DESCRIPTION
redline comments dont have position properties set
and some calculation needed in order to have it
and scrolling to comment relies on position property.

We have now instead getter for it and if it is a redline
comment it is calculated otherwise the default one is returned
because it is already set.

Signed-off-by: Mert Tumer <mert.tumer@collabora.com>
Change-Id: I6a3cefdd1c881783832de3de8fc1df7c849aad09


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

