### PR TITLE
Disable testing splitting cells

### DIFF
--- a/cypress_test/integration_tests/desktop/writer/table_operation_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/table_operation_spec.js
@@ -312,7 +312,7 @@ describe('Table operations', function() {
 			.should('have.attr', 'width', '50%');
 	});
 
-	it('Split Cells', function() {
+	/*it('Split Cells', function() {
 		helper.typeIntoDocument('{downarrow}');
 
 		helper.typeIntoDocument('{ctrl}{a}');
@@ -346,5 +346,7 @@ describe('Table operations', function() {
 
 		cy.get('#copy-paste-container tbody').find('tr')
 			.should('have.length', 4);
-	});
+	});*/
+	// TODO: Rewrite this test to use the new JSDialogs dialog as opposed to this tunneled dialog
+	// Blocked by https://gerrit.libreoffice.org/c/core/+/137791
 });


### PR DESCRIPTION
- The split cells test currently uses tunneled dialogs to make sure that
  we can split table cells
- There is an open gerrit review to switch the split cells dialog to
  JSDialogs (https://gerrit.libreoffice.org/c/core/+/137791) which is
  blocked because the tunneled dialog needs to be removed in it, and
  that fails this test
- This test needs to be temporarily disabled to give coreside a chance
  to merge that review and build a new version of the libreoffice
  archive. Once that has happened, this test should be replaced with a
  rewritten version

Signed-off-by: Skyler Grey <skyler3665@gmail.com>
Change-Id: I0bb51e3cdbc04020e03c8d87696d014a0f693554

* Target version: master 

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

CC: @eszkadev @pedropintosilva 