### PR TITLE
Rewrite testing of splitting table cells

### DIFF
--- a/cypress_test/integration_tests/desktop/writer/table_operation_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/table_operation_spec.js
@@ -312,7 +312,7 @@ describe('Table operations', function() {
 			.should('have.attr', 'width', '50%');
 	});
 
-	/*it('Split Cells', function() {
+	it('Split Cells', function() {
 		helper.typeIntoDocument('{downarrow}');
 
 		helper.typeIntoDocument('{ctrl}{a}');
@@ -330,12 +330,13 @@ describe('Table operations', function() {
 		cy.get('.unospan-split_merge.unoSplitCell')
 			.click();
 
-		cy.get('.lokdialog_canvas').should('exist');
+		cy.get('.lokdialog.ui-dialog-content.ui-widget-content').should('exist');
 
-		cy.get('.lokdialog_canvas').click();
+		cy.get('.lokdialog.ui-dialog-content.ui-widget-content').click();
 
-		//to close the lokdialog
-		helper.typeIntoDocument('{shift}{enter}');
+		cy.get('#ok.ui-pushbutton.jsdialog').should('exist');
+
+		cy.get('#ok.ui-pushbutton.jsdialog').click();
 
 		helper.typeIntoDocument('{ctrl}{a}');
 
@@ -346,7 +347,5 @@ describe('Table operations', function() {
 
 		cy.get('#copy-paste-container tbody').find('tr')
 			.should('have.length', 4);
-	});*/
-	// TODO: Rewrite this test to use the new JSDialogs dialog as opposed to this tunneled dialog
-	// Blocked by https://gerrit.libreoffice.org/c/core/+/137791
+	});
 });


### PR DESCRIPTION
- This is a followup to 3ce47b0c1607b715fc300293789164608a49648e
  (https://github.com/CollaboraOnline/online/pull/5106)
- This commit rewrites the split cells test to work with JSDialogs
  (merged in https://gerrit.libreoffice.org/c/core/+/137791) and
  re-enables that test

Signed-off-by: Skyler Grey <skyler3665@gmail.com>
Change-Id: I7901cfa1489618d005faffe68af0883e0ca998a1

* Target version: master 

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

CC: @pedropintosilva @eszkadev 