### PR TITLE
Display selection fix

### DIFF
--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -384,7 +384,11 @@ L.Control.UIManager = L.Control.extend({
 		this.initializeSidebar();
 		this.insertCustomButtons();
 
+		// this code ensures that elements in the notebookbar have their "selected" status
+		// displayed correctly
 		this.map.fire('darkmodechanged');
+		this.map.fire('rulerchanged');
+		this.map.fire('statusbarchanged');
 	},
 
 	// UI modification


### PR DESCRIPTION
* Resolves: "Selected" state not displayed correctly after UI mode changed
* Target version: master 

### Summary
This code added to the uiManager ensures that the Ruler, Statusbar and DarkMode toggle remain selected on the Notebookbar, after the UI mode has been changed. 

### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

