### PR TITLE
Improve the scrollbars

### DIFF
--- a/browser/src/layer/tile/ScrollSection.ts
+++ b/browser/src/layer/tile/ScrollSection.ts
@@ -449,6 +449,15 @@ class ScrollSection {
 		const docWidth: number = this.map.getPixelBoundsCore().getSize().x;
 		const startX = this.isCalcRTL() ? docWidth - scrollProps.startX - sizeX : scrollProps.startX;
 
+		if (this.sectionProperties.drawScrollBarRailway) {
+			this.context.globalAlpha = this.sectionProperties.scrollBarRailwayOpacity;
+			this.context.fillStyle = this.sectionProperties.scrollBarRailwayColor;
+			this.context.fillRect(this.sectionProperties.xMin, startY, this.sectionProperties.xMax - this.sectionProperties.yMax, this.sectionProperties.scrollBarRailwayThickness);
+		}
+
+		this.context.fillStyle = '#7E8182';
+
+
 		this.context.fillRect(startX, startY, sizeX, this.sectionProperties.scrollBarThickness);
 
 		this.context.globalAlpha = 1.0;

--- a/browser/src/layer/tile/ScrollSection.ts
+++ b/browser/src/layer/tile/ScrollSection.ts
@@ -272,7 +272,7 @@ class ScrollSection {
 		}
 
 		result.ratio = app.view.size.pixels[1] / result.scrollLength; // 1px scrolling = xpx document height.
-		result.startY = Math.round(this.documentTopLeft[1] / result.ratio + this.sectionProperties.scrollBarThickness * 0.5 + this.sectionProperties.yOffset);
+		result.startY = Math.round(this.documentTopLeft[1] / result.ratio + this.sectionProperties.yOffset);
 
 		return result;
 	}
@@ -335,7 +335,7 @@ class ScrollSection {
 		}
 
 		result.ratio = app.view.size.pixels[0] / result.scrollLength;
-		result.startX = Math.round(this.documentTopLeft[0] / result.ratio + this.sectionProperties.scrollBarThickness * 0.5 + this.sectionProperties.xOffset);
+		result.startX = Math.round(this.documentTopLeft[0] / result.ratio + this.sectionProperties.xOffset);
 
 		return result;
 	}

--- a/browser/src/layer/tile/ScrollSection.ts
+++ b/browser/src/layer/tile/ScrollSection.ts
@@ -73,7 +73,7 @@ class ScrollSection {
 
 		this.sectionProperties.usableThickness = 20 * app.roundedDpiScale;
 		this.sectionProperties.scrollBarThickness = 12 * app.roundedDpiScale;
-		this.sectionProperties.edgeOffset = 10 * app.roundedDpiScale;
+		this.sectionProperties.edgeOffset = 0;
 
 		this.sectionProperties.drawScrollBarRailway = true;
 		this.sectionProperties.scrollBarRailwayThickness = 12 * app.roundedDpiScale;

--- a/browser/src/layer/tile/ScrollSection.ts
+++ b/browser/src/layer/tile/ScrollSection.ts
@@ -78,7 +78,7 @@ class ScrollSection {
 		this.sectionProperties.drawScrollBarRailway = true;
 		this.sectionProperties.scrollBarRailwayThickness = 12 * app.roundedDpiScale;
 		this.sectionProperties.scrollBarRailwayAlpha = this.map._docLayer._docType === 'spreadsheet' ? 1.0 : 0.5;
-		this.sectionProperties.scrollBarRailwayColor = '#ffffff';
+		this.sectionProperties.scrollBarRailwayColor = '#EFEFEF';
 
 		this.sectionProperties.drawVerticalScrollBar = ((<any>window).mode.isDesktop() ? true: false);
 		this.sectionProperties.drawHorizontalScrollBar = ((<any>window).mode.isDesktop() ? true: false);

--- a/browser/src/layer/tile/ScrollSection.ts
+++ b/browser/src/layer/tile/ScrollSection.ts
@@ -77,7 +77,7 @@ class ScrollSection {
 
 		this.sectionProperties.drawScrollBarRailway = true;
 		this.sectionProperties.scrollBarRailwayThickness = 12 * app.roundedDpiScale;
-		this.sectionProperties.scrollBarRailwayOpacity = 1;
+		this.sectionProperties.scrollBarRailwayAlpha = this.map._docLayer._docType === 'spreadsheet' ? 1.0 : 0.5;
 		this.sectionProperties.scrollBarRailwayColor = '#ffffff';
 
 		this.sectionProperties.drawVerticalScrollBar = ((<any>window).mode.isDesktop() ? true: false);
@@ -401,7 +401,7 @@ class ScrollSection {
 		var startX = this.isCalcRTL() ? this.sectionProperties.edgeOffset : this.size[0] - this.sectionProperties.scrollBarThickness - this.sectionProperties.edgeOffset;
 
 		if (this.sectionProperties.drawScrollBarRailway) {
-			this.context.globalAlpha = this.sectionProperties.scrollBarRailwayOpacity;
+			this.context.globalAlpha = this.sectionProperties.scrollBarRailwayAlpha;
 			this.context.fillStyle = this.sectionProperties.scrollBarRailwayColor;
 			this.context.fillRect(startX, this.sectionProperties.yMin, this.sectionProperties.scrollBarRailwayThickness, this.sectionProperties.yMax - this.sectionProperties.yMin);
 		}
@@ -450,7 +450,7 @@ class ScrollSection {
 		const startX = this.isCalcRTL() ? docWidth - scrollProps.startX - sizeX : scrollProps.startX;
 
 		if (this.sectionProperties.drawScrollBarRailway) {
-			this.context.globalAlpha = this.sectionProperties.scrollBarRailwayOpacity;
+			this.context.globalAlpha = this.sectionProperties.scrollBarRailwayAlpha;
 			this.context.fillStyle = this.sectionProperties.scrollBarRailwayColor;
 			this.context.fillRect(this.sectionProperties.xMin, startY, this.sectionProperties.xMax - this.sectionProperties.yMax, this.sectionProperties.scrollBarRailwayThickness);
 		}

--- a/browser/src/layer/tile/ScrollSection.ts
+++ b/browser/src/layer/tile/ScrollSection.ts
@@ -72,7 +72,7 @@ class ScrollSection {
 		this.sectionProperties.previousDragDistance = null;
 
 		this.sectionProperties.usableThickness = 20 * app.roundedDpiScale;
-		this.sectionProperties.scrollBarThickness = 12 * app.roundedDpiScale;
+		this.sectionProperties.scrollBarThickness = 6 * app.roundedDpiScale;
 		this.sectionProperties.edgeOffset = 0;
 
 		this.sectionProperties.drawScrollBarRailway = true;

--- a/browser/src/layer/tile/ScrollSection.ts
+++ b/browser/src/layer/tile/ScrollSection.ts
@@ -75,6 +75,11 @@ class ScrollSection {
 		this.sectionProperties.scrollBarThickness = 12 * app.roundedDpiScale;
 		this.sectionProperties.edgeOffset = 10 * app.roundedDpiScale;
 
+		this.sectionProperties.drawScrollBarRailway = true;
+		this.sectionProperties.scrollBarRailwayThickness = 12 * app.roundedDpiScale;
+		this.sectionProperties.scrollBarRailwayOpacity = 1;
+		this.sectionProperties.scrollBarRailwayColor = '#ffffff';
+
 		this.sectionProperties.drawVerticalScrollBar = ((<any>window).mode.isDesktop() ? true: false);
 		this.sectionProperties.drawHorizontalScrollBar = ((<any>window).mode.isDesktop() ? true: false);
 
@@ -393,14 +398,22 @@ class ScrollSection {
 	private drawVerticalScrollBar () {
 		var scrollProps: any = this.getVerticalScrollProperties();
 
-		if (this.sectionProperties.animatingVerticalScrollBar)
+		var startX = this.isCalcRTL() ? this.sectionProperties.edgeOffset : this.size[0] - this.sectionProperties.scrollBarThickness - this.sectionProperties.edgeOffset;
+
+		if (this.sectionProperties.drawScrollBarRailway) {
+			this.context.globalAlpha = this.sectionProperties.scrollBarRailwayOpacity;
+			this.context.fillStyle = this.sectionProperties.scrollBarRailwayColor;
+			this.context.fillRect(startX, this.sectionProperties.yMin, this.sectionProperties.scrollBarRailwayThickness, this.sectionProperties.yMax - this.sectionProperties.yMin);
+		}
+
+		if (this.sectionProperties.animatingVerticalScrollBar) {
 			this.context.globalAlpha = this.sectionProperties.currentAlpha;
-		else
+		} else {
 			this.context.globalAlpha = this.sectionProperties.clickScrollVertical ? this.sectionProperties.alphaWhenBeingUsed: this.sectionProperties.alphaWhenVisible;
+		}
 
 		this.context.fillStyle = '#7E8182';
 
-		var startX = this.isCalcRTL() ? this.sectionProperties.edgeOffset : this.size[0] - this.sectionProperties.scrollBarThickness - this.sectionProperties.edgeOffset;
 
 		this.context.fillRect(startX, scrollProps.startY, this.sectionProperties.scrollBarThickness, scrollProps.scrollSize - this.sectionProperties.scrollBarThickness);
 

--- a/browser/src/layer/tile/ScrollSection.ts
+++ b/browser/src/layer/tile/ScrollSection.ts
@@ -436,13 +436,6 @@ class ScrollSection {
 	private drawHorizontalScrollBar () {
 		var scrollProps: any = this.getHorizontalScrollProperties();
 
-		if (this.sectionProperties.animatingHorizontalScrollBar)
-			this.context.globalAlpha = this.sectionProperties.currentAlpha;
-		else
-			this.context.globalAlpha = this.sectionProperties.clickScrollHorizontal ? this.sectionProperties.alphaWhenBeingUsed: this.sectionProperties.alphaWhenVisible;
-
-		this.context.fillStyle = '#7E8182';
-
 		var startY = this.size[1] - this.sectionProperties.scrollBarThickness - this.sectionProperties.edgeOffset;
 
 		const sizeX = scrollProps.scrollSize - this.sectionProperties.scrollBarThickness;
@@ -454,6 +447,11 @@ class ScrollSection {
 			this.context.fillStyle = this.sectionProperties.scrollBarRailwayColor;
 			this.context.fillRect(this.sectionProperties.xMin, startY, this.sectionProperties.xMax - this.sectionProperties.yMax, this.sectionProperties.scrollBarRailwayThickness);
 		}
+
+		if (this.sectionProperties.animatingHorizontalScrollBar)
+			this.context.globalAlpha = this.sectionProperties.currentAlpha;
+		else
+			this.context.globalAlpha = this.sectionProperties.clickScrollHorizontal ? this.sectionProperties.alphaWhenBeingUsed: this.sectionProperties.alphaWhenVisible;
 
 		this.context.fillStyle = '#7E8182';
 

--- a/browser/src/layer/tile/ScrollSection.ts
+++ b/browser/src/layer/tile/ScrollSection.ts
@@ -403,7 +403,12 @@ class ScrollSection {
 		if (this.sectionProperties.drawScrollBarRailway) {
 			this.context.globalAlpha = this.sectionProperties.scrollBarRailwayAlpha;
 			this.context.fillStyle = this.sectionProperties.scrollBarRailwayColor;
-			this.context.fillRect(startX, this.sectionProperties.yMin, this.sectionProperties.scrollBarRailwayThickness, this.sectionProperties.yMax - this.sectionProperties.yMin);
+			this.context.fillRect(
+				startX,
+				this.sectionProperties.yMin + this.sectionProperties.yOffset,
+				this.sectionProperties.scrollBarRailwayThickness,
+				this.sectionProperties.yMax - this.sectionProperties.yMin - this.sectionProperties.yOffset
+			);
 		}
 
 		if (this.sectionProperties.animatingVerticalScrollBar) {
@@ -445,7 +450,12 @@ class ScrollSection {
 		if (this.sectionProperties.drawScrollBarRailway) {
 			this.context.globalAlpha = this.sectionProperties.scrollBarRailwayAlpha;
 			this.context.fillStyle = this.sectionProperties.scrollBarRailwayColor;
-			this.context.fillRect(this.sectionProperties.xMin, startY, this.sectionProperties.xMax - this.sectionProperties.yMax, this.sectionProperties.scrollBarRailwayThickness);
+			this.context.fillRect(
+				this.sectionProperties.xMin + this.sectionProperties.xOffset,
+				startY,
+				this.sectionProperties.xMax - this.sectionProperties.xMin - this.sectionProperties.xOffset,
+				this.sectionProperties.scrollBarRailwayThickness
+			);
 		}
 
 		if (this.sectionProperties.animatingHorizontalScrollBar)

--- a/cypress_test/integration_tests/desktop/calc/scrolling_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/scrolling_spec.js
@@ -21,7 +21,7 @@ describe('Scroll through document', function() {
 	});
 
 	it('Scrolling to bottom/top', function() {
-		desktopHelper.assertScrollbarPosition('vertical', 26, 29);
+		desktopHelper.assertScrollbarPosition('vertical', 19, 21);
 
 		desktopHelper.pressKey(3,'pagedown');
 
@@ -29,7 +29,7 @@ describe('Scroll through document', function() {
 
 		desktopHelper.pressKey(3,'pageup');
 
-		desktopHelper.assertScrollbarPosition('vertical', 26, 29);
+		desktopHelper.assertScrollbarPosition('vertical', 19, 21);
 	});
 
 	it('Scrolling to left/right', function() {
@@ -37,12 +37,12 @@ describe('Scroll through document', function() {
 
 		helper.typeIntoDocument('{home}');
 
-		desktopHelper.assertScrollbarPosition('horizontal', 55, 68);
+		desktopHelper.assertScrollbarPosition('horizontal', 48, 60);
 
 		helper.typeIntoDocument('{end}');
 
 		cy.wait(500);
 
-		desktopHelper.assertScrollbarPosition('horizontal', 129, 155);
+		desktopHelper.assertScrollbarPosition('horizontal', 121, 148);
 	});
 });

--- a/cypress_test/integration_tests/desktop/impress/scrolling_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/scrolling_spec.js
@@ -45,7 +45,7 @@ describe('Scroll through document', function() {
 		desktopHelper.pressKey(9,'uparrow');
 
 		cy.get('#test-div-vertical-scrollbar')
-			.should('have.text', '6');
+			.should('have.text', '0');
 
 		desktopHelper.pressKey(18,'downarrow');
 
@@ -66,7 +66,7 @@ describe('Scroll through document', function() {
 		helper.typeIntoDocument('{home}');
 
 		cy.get('#test-div-horizontal-scrollbar')
-			.should('have.text', '6').wait(500);
+			.should('have.text', '0').wait(500);
 
 		helper.typeIntoDocument('{end}');
 

--- a/cypress_test/integration_tests/desktop/writer/scrolling_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/scrolling_spec.js
@@ -67,10 +67,10 @@ describe('Scroll through document', function() {
 		helper.typeIntoDocument('{home}{end}{home}');
 
 		cy.get('#test-div-horizontal-scrollbar')
-			.should('have.text', '6');
+			.should('have.text', '0');
 
 		helper.typeIntoDocument('{end}{home}{end}');
 
-		desktopHelper.assertScrollbarPosition('horizontal', 577, 660);
+		desktopHelper.assertScrollbarPosition('horizontal', 570, 653);
 	});
 });


### PR DESCRIPTION
- Draw the railway for vertical and horizontal scrollbars
    - The railway should be 50% transparent on all apps, except for calc which should have a fully opaque railway

Signed-off-by: Skyler Grey <skyler3665@gmail.com>
Change-Id: I57975e52700f3b91782f9be40ad9864fc8c3baf2

* Target version: master 

### TODO
- [x] Display railways
- [x] Make the scrollbars attach to the side of the window (particularly in calc where a small part of the spreadsheet displays past the scrollbar railway)
- [x] Make the scrollbar railway have lower opacity on apps other than calc
- [x] Rewrite the writer/scrolling_spec cypress test
- [ ] ~~Make thumbs thinner when the scrollbar is not being used~~
- [ ] ~~(possibly) Make the trail thinner when the scrollbar is not being used~~
- [ ] ~~Fix the animating scrollbar resizing~~
- [ ] ~~Don't let the railway overflow the bounds (i.e. clip onto the column/row headers in calc)~~
- [ ] ~~Write new cypress tests for scrollbars (copy writer test over to calc to check the scrollbar is opaque etc.)~~

*Note: Crossed out tasks were planned but have (on request) been moved to be in a later PR [not yet opened]*

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required
