### PR TITLE
Fix outdated svg references in CSS files

### DIFF
--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -856,14 +856,14 @@ button.leaflet-control-search-next
 .w2ui-icon.undo{ background: url('images/lc_undo.svg') no-repeat center !important; }
 .w2ui-icon.redo{ background: url('images/lc_redo.svg') no-repeat center !important; }
 .w2ui-icon.copyformat{ background: url('images/lc_formatpaintbrush.svg') no-repeat center !important; }
-.w2ui-icon.deleteformat{ background: url('images/lc_resetattributes.svg') no-repeat center !important; }
+.w2ui-icon.deleteformat{ background: url('images/lc_setdefault.svg') no-repeat center !important; }
 .w2ui-icon.bold{ background: url('images/lc_bold.svg') no-repeat center !important; }
 .w2ui-icon.italic{ background: url('images/lc_italic.svg') no-repeat center !important; }
 .w2ui-icon.underline{ background: url('images/lc_underline.svg') no-repeat center !important; }
 .w2ui-icon.strikeout{ background: url('images/lc_strikeout.svg') no-repeat center !important; }
 .w2ui-icon.textcolor{ background: url('images/lc_fontcolor.svg') no-repeat center !important; }
 .w2ui-icon.backcolor{ background: url('images/lc_backcolor.svg') no-repeat center !important; }
-.w2ui-icon.backgroundcolor{ background: url('images/lc_backgroundcolor.svg') no-repeat center !important; }
+.w2ui-icon.backgroundcolor{ background: url('images/lc_fillcolor.svg') no-repeat center !important; }
 .w2ui-icon.alignleft{ background: url('images/lc_leftpara.svg') no-repeat center !important; }
 .w2ui-icon.alignhorizontal{ background: url('images/lc_centerpara.svg') no-repeat center !important; }
 .w2ui-icon.alignright{ background: url('images/lc_rightpara.svg') no-repeat center !important; }
@@ -881,7 +881,7 @@ button.leaflet-control-search-next
 .w2ui-icon.paraspacedecrease{ background: url('images/lc_paraspacedecrease.svg') no-repeat center !important; }
 .w2ui-icon.numbering{ background: url('images/lc_defaultnumbering.svg') no-repeat center !important; }
 .w2ui-icon.bullet{ background: url('images/lc_defaultbullet.svg') no-repeat center !important; }
-.w2ui-icon.incrementindent{ background: url('images/lc_incrementindent.svg') no-repeat center !important; }
+.w2ui-icon.incrementindent{ background: url('images/lc_leftindent.svg') no-repeat center !important; }
 .w2ui-icon.decrementindent{ background: url('images/lc_decrementindent.svg') no-repeat center !important; }
 .w2ui-icon.outlineleft{ background: url('images/lc_outlineleft.svg') no-repeat center !important; }
 .w2ui-icon.outlineright{ background: url('images/lc_outlineright.svg') no-repeat center !important; }
@@ -938,7 +938,7 @@ button.leaflet-control-search-next
 .w2ui-icon.help{ background: url('images/lc_helpindex.svg') no-repeat center !important; }
 .w2ui-icon.insertpage{ background: url('images/lc_insertpage.svg') no-repeat center !important; }
 .w2ui-icon.insertsheet{ background: url('images/plus.svg') no-repeat center !important; }
-.w2ui-icon.conditionalformatdialog{ background: url('images/lc_conditionalformatdialog.svg') no-repeat center !important; }
+.w2ui-icon.conditionalformatdialog{ background: url('images/lc_conditionalformatmenu.svg') no-repeat center !important; }
 .w2ui-icon.search{ background: url('images/sc_recsearch.svg') no-repeat center !important; }
 .w2ui-icon.next{ background: url('images/lc_downsearch.svg') no-repeat center !important; }
 .w2ui-icon.presentation{ background: url('images/lc_dia.svg') no-repeat center !important; }
@@ -964,10 +964,10 @@ button.leaflet-control-search-next
 .w2ui-icon.closemobile{ background: url('images/lc_closedocmobile.svg') no-repeat center !important; }
 .w2ui-icon.editmode { background: url('images/lc_listitem-selected.svg') no-repeat center / 28px !important; }
 .w2ui-icon.closetoolbar{ background: url('images/close_toolbar.svg') no-repeat center !important; }
-.w2ui-icon.sidebar_modify_page{ background: url('images/lc_configuredialog.svg') no-repeat center !important; }
+.w2ui-icon.sidebar_modify_page{ background: url('images/lc_sidebar.svg') no-repeat center !important; }
 .w2ui-icon.sidebar_slide_change{ background: url('images/lc_slidechangewindow.svg') no-repeat center !important; }
 .w2ui-icon.sidebar_custom_animation{ background: url('images/lc_customanimation.svg') no-repeat center !important; }
-.w2ui-icon.sidebar_master_slides{ background: url('images/lc_slidemasterpage.svg') no-repeat center !important; }
+.w2ui-icon.sidebar_master_slides{ background: url('images/lc_masterslide.svg') no-repeat center !important; }
 .w2ui-icon.mobile_wizard{ background: url('images/lc_mobile_wizard.svg') no-repeat center !important; }
 .w2ui-icon.fullscreen-presentation{ background: url('images/lc_fullscreen-presentation-toolbar-mobile.svg') no-repeat center !important;}
 .w2ui-icon.mobile_comment_wizard{ background: url('images/lc_mobile_comment_wizard.svg') no-repeat center !important; }
@@ -1298,4 +1298,3 @@ html[dir='rtl'] #userListPopover::after {
 	font-size: var(--default-font-size);
 	color: var(--color-main-text);
 }
-


### PR DESCRIPTION
Follow up on the changes introduced in
4e075146b91c6ca3197fdf96d7bb5d75a73b350e
- Update toolbar.css with current valid aliases
- Which fixes all a couple of missing SVG console errors

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I4eb96175d297b2a6962aa0ec6ab46b82cf060a34
