### PR TITLE
Add outline to color indicator for classic mode

### DIFF
--- a/browser/css/device-mobile.css
+++ b/browser/css/device-mobile.css
@@ -517,6 +517,22 @@ nav:not(.spreadsheet-color-indicator) ~ #toolbar-wrapper #toolbar-up.w2ui-toolba
 #toolbar-down table.w2ui-button .w2ui-tb-image {
 	margin: 5px 9px !important;
 }
+#toolbar-down table.w2ui-button .textcolor {
+	margin-bottom: 0px !important;
+}
+#toolbar-down table.w2ui-button .backcolor {
+	margin-bottom: 0px !important;
+}
+#toolbar-down table.w2ui-button .selected-color-classic {
+	height: 5px;
+	width: 26px;
+	margin: auto;
+	position: relative;
+	top: -6px;
+	border: 1px solid var(--color-border-dark);
+	border-radius: 7px;
+	outline: 1px solid var(--color-background-lighter);
+}
 .w2ui-toolbar .w2ui-break{
 	background-image: none;
 	background-color: #dae6f3;

--- a/browser/css/w2ui-1.5.rc1.css
+++ b/browser/css/w2ui-1.5.rc1.css
@@ -2943,6 +2943,15 @@ button.w2ui-btn-small:focus:before {
   border: 1px solid transparent;
   background-color: transparent;
 }
+.w2ui-toolbar table.w2ui-button .selected-color-classic {
+  height: 7px;
+  width: 26px;
+  position: relative;
+  top: -6px;
+  border: 1px solid var(--color-border-dark);
+  border-radius: 7px;
+  outline: 1px solid var(--color-background-lighter);
+}
 .w2ui-toolbar table.w2ui-button .w2ui-tb-image {
   width: 22px;
   height: 16px;

--- a/browser/js/w2ui-1.5.rc1.js
+++ b/browser/js/w2ui-1.5.rc1.js
@@ -6231,7 +6231,36 @@ w2utils.event = {
             var img  = '<td>&#160;</td>';
             var text = item.text;
             if (typeof text == 'function') text = text.call(this, item);
-            if (item.img)  img = '<td><div class="w2ui-tb-image w2ui-icon '+ item.img +'"></div></td>';
+
+            if (item.img) {
+                // color indicator container for classic mode
+                var colorContainer = '<div class="selected-color-classic"></div>';
+
+                /**
+                 * @css class="textcolor" used in:
+                 *  - Writer, Calc, Impress, Draw
+                 *  - as "Font Color"
+                 *
+                 * @css class="backcolor" used in:
+                 *  - Writer, Impress, Draw
+                 *  - as "Character Highlighting Color"
+                 *
+                 * @css class="backgroundcolor" used in:
+                 *  - Calc
+                 *  - as "Background Color"
+                 *  - (on mobile Calc uses "backcolor")
+                 *
+                 * It would be appropriate to place color indicator to below
+                 * of those classes' container.
+                 *
+                 * We have to filter where to add the color indicator,
+                 * otherwise it will be added to below of each toolbar
+                 * elements.
+                 */
+                img = (item.img == 'textcolor' || item.img == 'backcolor' || item.img == 'backgroundcolor') ?
+                '<td><div class="w2ui-tb-image w2ui-icon '+ item.img +'"></div>' + colorContainer + '</td>' :
+                '<td><div class="w2ui-tb-image w2ui-icon '+ item.img +'"></div></td>';
+            }
             if (item.icon) img = '<td><div class="w2ui-tb-image"><span class="'+ item.icon +'"></span></div></td>';
 
             if (html === '') switch (item.type) {

--- a/browser/src/control/Control.Toolbar.js
+++ b/browser/src/control/Control.Toolbar.js
@@ -858,7 +858,7 @@ function processStateChangedCommand(commandName, state) {
 			color = color.toString(16);
 			color = '#' + Array(7 - color.length).join('0') + color;
 		}
-		$('#tb_editbar_item_fontcolor .w2ui-tb-image').css('box-shadow', 'inset 0 -2px #ffffff, inset 0px -6px ' + color);
+		$('#tb_editbar_item_fontcolor table.w2ui-button .selected-color-classic').css('background-color', color);
 		$('#tb_editbar_item_fontcolor .w2ui-tb-caption').css('display', 'none');
 
 		div = L.DomUtil.get('fontcolorindicator');
@@ -877,10 +877,11 @@ function processStateChangedCommand(commandName, state) {
 			color = '#' + Array(7 - color.length).join('0') + color;
 		}
 		//writer
-		$('#tb_editbar_item_backcolor .w2ui-tb-image').css('box-shadow', 'inset 0 -2px #ffffff, inset 0px -6px ' + color);
+		$('#tb_editbar_item_backcolor table.w2ui-button .selected-color-classic').css('background-color', color);
 		$('#tb_editbar_item_backcolor .w2ui-tb-caption').css('display', 'none');
+
 		//calc?
-		$('#tb_editbar_item_backgroundcolor .w2ui-tb-image').css('box-shadow', 'inset 0 -2px #ffffff, inset 0px -6px ' + color);
+		$('#tb_editbar_item_backgroundcolor table.w2ui-button .selected-color-classic').css('background-color', color);
 		$('#tb_editbar_item_backgroundcolor .w2ui-tb-caption').css('display', 'none');
 
 		div = L.DomUtil.get('backcolorindicator');


### PR DESCRIPTION
- In classic mode, toolbar color indicators weren't visible when no
  text is selected. The reason is that color indicators didn't have
  border(outline) color.
- In fact, color indicators were just a box-shadow property. So,
  it was not possible(?) to add properties like border and
  border-radius.
- No need to use box-shadow property. A `<div>` tag can represent
  color indicators.
- Removed box-shadow property.
- Added `<div>` tag that has `class="selected-color-classic"`.

Signed-off-by: Bayram Çiçek <bayram.cicek@libreoffice.org>
Change-Id: I1b1b68fdc015fd3719d1c59ef7f782036a5934a5


* Resolves: #2809
* Target version: master 

### Summary

- Outline/border added to color indicator by creating `<div>` element.
- This commit only resolves outline/border issue in classic mode.

### Other issues

In classic mode: 
- [ ] Changes in toolbar's font&highlighting color, doesn't change the sidebar's font&highlighting color.
- [ ] In toolbar, selecting the same color, resets the color indicator to white.
- [x] In Calc's toolbar, there is no icon/image for Background Color (`class="backgroundcolor"`).
- [ ] In Draw's toolbar, font&highlighting color components doesn't work at all.

* Issues listed above still exist regardless of this patch. 

### Checklist

- [ ] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

