### PR TITLE
Improve keyboard focus

### DIFF
--- a/browser/html/cool.html.m4
+++ b/browser/html/cool.html.m4
@@ -198,7 +198,7 @@ m4_ifelse(MOBILEAPP,[true],
       </div>
 
       <div id="closebuttonwrapper">
-        <div class="closebuttonimage" id="closebutton"></div>
+        <button class="closebuttonimage" id="closebutton"></button>
       </div>
      </nav>
 

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -998,9 +998,10 @@ L.Control.JSDialogBuilder = L.Control.extend({
 
 				var title = builder._cleanText(item.text);
 
-				var tab = L.DomUtil.create('div', 'ui-tab ' + builder.options.cssClass, tabsContainer);
+				var tab = L.DomUtil.create('button', 'ui-tab ' + builder.options.cssClass, tabsContainer);
 				tab.id = item.name + '-tab-label';
 				tab.number = item.id - 1;
+				tab.setAttribute('tabindex', 0);
 
 				var isSelectedTab = data.selected == item.id;
 				if (isSelectedTab) {
@@ -1046,6 +1047,12 @@ L.Control.JSDialogBuilder = L.Control.extend({
 						};
 					};
 					$(tabs[t]).click(fn(t));
+					$(tabs[t]).on('keypress',function(e) {
+						if (e.which == 13) {
+							(fn(t));
+						}
+					});
+
 				}
 			} else {
 				window.app.console.debug('Builder used outside of mobile wizard: please implement the click handler');


### PR DESCRIPTION
Signed-off-by: Julius Härtl <jus@bitgrid.net>
Change-Id: I712d5457b65c0c8a84efdfb3d031160c8455ea3c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [x] Convert notebook bar tabs to buttons
- [x] Convert close button to an actual button
- [ ] Fix styling of close button
- [ ] Figure out why the focus is brought back to the leaflet container after some time
- [ ] Find a way to register a global keyboard shortcut to move the focus out of leaflet to the menu bar
- [ ] Extend further cases of the JSDialogBuilder to use proper elements

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

