### PR TITLE
 NB: Simplify group_download_as implementation and make it bigtoolitem

### DIFF
--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -152,18 +152,9 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 
 		if (hasGroupedDownloadAs) {
 			content.push({
-				'id': 'downloadas-container',
-				'type': 'container',
-				'text': '',
-				'enabled': 'true',
-				'children': [
-					{
-						'id': 'downloadas',
-						'type': 'menubartoolitem',
-						'text': _('Download'),
-						'command': '.uno:InsertGraphic'
-					}
-				]
+				'id': 'downloadas',
+				'type': 'bigmenubartoolitem',
+				'text': _('Download')
 			});
 
 			content.push({

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -217,18 +217,9 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 
 		if (hasGroupedDownloadAs) {
 			content.push({
-				'id': 'downloadas-container',
-				'type': 'container',
-				'text': '',
-				'enabled': 'true',
-				'children': [
-					{
-						'id': 'downloadas',
-						'type': 'menubartoolitem',
-						'text': _('Download'),
-						'command': '.uno:InsertGraphic'
-					}
-				]
+				'id': 'downloadas',
+				'type': 'bigmenubartoolitem',
+				'text': _('Download')
 			});
 
 			content.push({

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -165,18 +165,9 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 
 		if (hasGroupedDownloadAs) {
 			content.push({
-				'id': 'downloadas-container',
-				'type': 'container',
-				'text': '',
-				'enabled': 'true',
-				'children': [
-					{
-						'id': 'downloadas',
-						'type': 'menubartoolitem',
-						'text': _('Download'),
-						'command': '.uno:InsertGraphic'
-					}
-				]
+				'id': 'downloadas',
+				'type': 'bigmenubartoolitem',
+				'text': _('Download')
 			});
 		} else {
 			content = content.concat([


### PR DESCRIPTION
Revamped https://github.com/CollaboraOnline/online/pull/4576

commit 2d3313813488d23b7fd675e7ac08f2dfb07713bb (HEAD -> private/pedro/group_download_as-v2, origin/private/pedro/group_download_as-v2)
Author: Pedro Pinto Silva <pedro.silva@collabora.com>
Date:   Fri Apr 8 18:19:37 2022 +0200

     NB: Simplify group_download_as implementation and make it bigtoolitem
    
    - Avoid using random UNO command (InsertGraphic) for download action
    - Centralize download option (re-use bigmenubartoolitem)
    
    Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
    Change-Id: Ie9cb8564acee8611221e0ff6f841de7b31b777e4


