### PR TITLE
wsd: log unmount errors only when mounting is enabled

### DIFF
--- a/common/JailUtil.cpp
+++ b/common/JailUtil.cpp
@@ -69,7 +69,17 @@ static bool unmount(const std::string& target)
     if (res)
         LOG_TRC("Unmounted [" << target << "] successfully.");
     else
-        LOG_ERR("Failed to unmount [" << target << ']');
+    {
+        // If bind-mounting is enabled, noisily log failures.
+        // Otherwise, it's a cleanup attempt of earlier mounts,
+        // which may be left-over and now the config has changed.
+        // This happens more often in dev labs than in prod.
+        if (JailUtil::isBindMountingEnabled())
+            LOG_ERR("Failed to unmount [" << target << ']');
+        else
+            LOG_DBG("Failed to unmount [" << target << ']');
+    }
+
     return res;
 }
 


### PR DESCRIPTION
When bind-mounting is disabled, we do a best-effort
to unmount any lingering mount-points. This is a
cleanup that helps with leftovers. Here, we
do a debug log level in case the unmounting fails,
and error, otherwise, when bind-mounting is enabled.

Change-Id: I199d6234aebfd84e6be812e5b7d3758273086815
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
