### PR TITLE
private/pedro/jsdialog tabs improvements

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -136,7 +136,7 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 .jsdialog-tabs {
 	display: flex;
 	width: 100%;
-	background: var(--color-main-background);
+	background: var(--color-background-lighter);
 }
 
 .jsdialog-tabs:empty {
@@ -149,7 +149,7 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 	font-family: var(--cool-font);
 	line-height: normal;
 	color: dimgray;
-	color: var(--color-text-lighter);
+	color: var(--color-text-dark);
 	height: 32px;
 	display: flex;
 	align-items: center;
@@ -167,7 +167,7 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 
 .ui-tab.selected.jsdialog {
 	background-color: var(--color-background-lighter);
-	color: var(--color-text-lighter);
+	color: var(--color-text-darker);
 	box-shadow: 0 0 2px 1px #cfcfcf;
 }
 

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -134,17 +134,13 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 
 /* Tabs */
 .jsdialog-tabs {
-	display: inline-flex;
+	display: flex;
 	width: 100%;
 	background: var(--color-main-background);
 }
 
 .jsdialog-tabs:empty {
 	display: none;
-}
-
-.jsdialog-tabs .ui-tabs.jsdialog {
-	display: inline-block;
 }
 
 .ui-tab.jsdialog {

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -154,6 +154,11 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 	display: flex;
 	align-items: center;
 	padding: 0px 1em;
+	border-radius: var(--border-radius);
+}
+
+.ui-tab.jsdialog:first-child.selected {
+	margin-inline-start: 12px;
 }
 
 .ui-tab.hidden.jsdialog {
@@ -163,6 +168,7 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 .ui-tab.selected.jsdialog {
 	background-color: var(--color-background-lighter);
 	color: var(--color-text-lighter);
+	box-shadow: 0 0 2px 1px #cfcfcf;
 }
 
 .ui-tab.jsdialog:hover {

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -36,6 +36,10 @@
 	box-shadow: 0 -1px 2px 0 rgba(0, 0, 0, 0.15), 0 2px 2px 0 rgba(0, 0, 0, 0.1);
 }
 
+.jsdialog-container .ui-dialog-titlebar {
+	background-color: var(--color-background-lighter);
+}
+
 .jsdialog-container .ui-dialog-content {
 	background-color: var(--color-background-lighter) !important;
 	font-family: var(--jquery-ui-font);

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -59,7 +59,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 
 		// list of types which can have multiple children but are not considered as containers
 		this._nonContainerType = ['buttonbox', 'treelistbox', 'iconview', 'combobox', 'listbox',
-			'scrollwindow', 'grid'];
+			'scrollwindow', 'grid', 'tabcontrol'];
 
 		this._controlHandlers = {};
 		this._controlHandlers['radiobutton'] = this._radiobuttonControl;


### PR DESCRIPTION
- Remove gray block bellow JSDialog tabs
- Increase jsdialog tab btn contrast
- Increase jsdialog tab btn text contrast
- Fix jsdialog title background and re-use CSS var
