### PR TITLE
comment bubbles: don't use undefined container on comment remove

### DIFF
--- a/browser/src/control/Control.MobileWizardPopup.js
+++ b/browser/src/control/Control.MobileWizardPopup.js
@@ -276,9 +276,11 @@ L.Control.MobileWizardPopup = L.Control.extend({
 								});
 						}
 					}
-				} else {
+				} else if (this._container) {
 					posX = window.innerWidth/2 - this._container.offsetWidth/2;
 					posY = window.innerHeight/2 - this._container.offsetHeight/2;
+				} else {
+					console.error('no _container objet in mobile wizard popup');
 				}
 			};
 

--- a/browser/src/layer/tile/CommentListSection.ts
+++ b/browser/src/layer/tile/CommentListSection.ts
@@ -1616,7 +1616,7 @@ class CommentSection {
 		}
 
 		var commentsData = this.map._docLayer.getCommentWizardStructure(undefined, annotation); // thread only
-		if (commentsData.children.length) {
+		if (commentsData.children.length && commentsData.children[0].id !== 'emptyWizard') {
 			commentsData.popupParent = annotation.sectionProperties.container.id;
 			this.map.fire('mobilewizardpopup', {data: commentsData});
 		} else {


### PR DESCRIPTION
- Show error instead of throwing an TypeError exception.
- Prevent us from showing empty popup when removed comment.

noticed when testing: https://gerrit.libreoffice.org/c/core/+/138398