### PR TITLE
wsd: fix uninitialized DocumentBroker::_savingTimeout

### DIFF
--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -936,7 +936,7 @@ private:
         const std::chrono::seconds _autosaveInterval;
 
         /// The maximum time to wait for saving to finish.
-        std::chrono::seconds _savingTimeout;
+        std::chrono::seconds _savingTimeout{};
 
         /// The last autosave check time.
         std::chrono::steady_clock::time_point _lastAutosaveCheckTime;


### PR DESCRIPTION
(cherry picked from commit c9cb1f4e01142c4b0eb7bdf48468ff500c6bbda3)

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Id004b635cfd8e77de85f932a3035870300ba1c47
