### PR TITLE
Remove jump in impress anim sidebar when adding the first anim

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -251,7 +251,8 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 	color: var(--color-text-lighter) !important;
 }
 
-.ui-treeview-body {
+.ui-treeview-body,
+#custom_animation_label_parent {
 	color: var(--color-main-text);
 	font-size: var(--default-font-size);
 	line-height: var(--default-height);


### PR DESCRIPTION
Force placeholder to inherit the same rules as ui-treeview-body

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I61ecde9e35812026683c655f6a2f9ead18e10d02
