### PR TITLE
wsd: use the default DH parameters in SSL

### DIFF
--- a/net/Ssl.cpp
+++ b/net/Ssl.cpp
@@ -214,6 +214,10 @@ void SslContext::dynlockDestroy(struct CRYPTO_dynlock_value* lock, const char* /
 void SslContext::initDH()
 {
 #ifndef OPENSSL_NO_DH
+// On OpenSSL 1.1 and newer use the auto parameters.
+#if OPENSSL_VERSION_NUMBER >= 0x10100003L
+    SSL_CTX_set_dh_auto(_ctx, 1);
+#else
     // 2048-bit MODP Group with 256-bit prime order subgroup (RFC5114)
 
     static const unsigned char dh2048_p[] =
@@ -297,6 +301,7 @@ void SslContext::initDH()
     SSL_CTX_set_tmp_dh(_ctx, dh);
     SSL_CTX_set_options(_ctx, SSL_OP_SINGLE_DH_USE);
     DH_free(dh);
+#endif
 #endif
 }
 


### PR DESCRIPTION
OpenSSL 3 deprecated the manual DH parameter
functions. Instead, it encourages the use
of the built-in parameters. Since this
API also works on the 1.1 version, we only
need the manual parameters for older versions.

Change-Id: I900cc11c3ca09f1d85b7d88cfbf537d802f69846
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

