### PR TITLE
Don't add hover states to generated jsdialogbuilder td elements

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -91,10 +91,6 @@
 	padding-top: 6px;
 }
 
-td.jsdialog:hover * {
-	color: var(--color-text-darker);
-}
-
 .jsdialog.row {
 	display: table-row;
 }


### PR DESCRIPTION
- This is too generic
- If in the beginning this made sense now we have to many elements
and many should not have hover states (invisible, labels etc)

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ice27ccb41cff73fa34b89453d99e3bb1fbc03edf
