### PR TITLE
jsdialog: find real input on setText action

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -3305,6 +3305,11 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			break;
 
 		case 'setText':
+			// eg. in mobile wizard input is inside spin button div
+			var innerInput = control.querySelector('input');
+			if (innerInput)
+				control = innerInput;
+
 			var currentText = this._cleanText(data.text);
 			control.value = currentText;
 			if (data.selection) {


### PR DESCRIPTION
- it is needed for mobile wizard spin fields

Removes annoying bug in Chrome. When using spinfields in sidebar - when you click on "arrow up" it focuses "arrow down" what causes revert of the last change on next click.

requires code change: https://gerrit.libreoffice.org/c/core/+/138700