### PR TITLE
cypress: temporarily disable autofilter test

### DIFF
--- a/cypress_test/integration_tests/desktop/calc/autofilter_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/autofilter_spec.js
@@ -74,7 +74,7 @@ describe('AutoFilter', function() {
 			});
 	}
 
-	it('Enable/Disable autofilter', function() {
+	it.skip('Enable/Disable autofilter', function() {
 		//it gets enable before the test body starts
 		//filter by pass
 		openAutoFilterMenu(true);


### PR DESCRIPTION
problem: when we click on checkbox to filter the data in autofilter dialog the checkbox itself disappear
if that is expected behaviour then cypress test needs to modified if not bug needs to be fixed first before
enabling this test

Signed-off-by: Rash419 <rashesh.padia@collabora.com>
Change-Id: I4dbfcf8abebe1c65e27c8c090bfce3ed0c59d086

![image](https://user-images.githubusercontent.com/26241069/186090132-e30a63b3-c319-461f-b3ac-b7dc9ec0df76.png)


* Resolves: # <!-- related github issue -->
* Target version: master 