### PR TITLE
jsdialog: allow boolean as treeview entry state

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -1850,7 +1850,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		if (entry.selected && (entry.selected === 'true' || entry.selected === true))
 			$(span).addClass('selected');
 
-		if (entry.state) {
+		if (entry.state !== undefined) {
 			var checkbox = L.DomUtil.create('input', builder.options.cssClass + ' ui-treeview-checkbox', span);
 			checkbox.type = 'checkbox';
 

--- a/cypress_test/integration_tests/desktop/calc/autofilter_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/autofilter_spec.js
@@ -74,7 +74,7 @@ describe('AutoFilter', function() {
 			});
 	}
 
-	it.skip('Enable/Disable autofilter', function() {
+	it('Enable/Disable autofilter', function() {
 		//it gets enable before the test body starts
 		//filter by pass
 		openAutoFilterMenu(true);


### PR DESCRIPTION
after core commit:
https://cgit.freedesktop.org/libreoffice/core/commit/?h=distro/collabora/co-22.05&id=62d5622540c7251bb870a837b5ca6a836fac6f01
DumpAsPropertyTree: use more efficient overloads of JsonWriter::put

we use boolean not string

this also enables test broken by that core commit