### PR TITLE
Workaround a mysterious Cypress bug

### DIFF
--- a/cypress_test/integration_tests/desktop/calc/autofilter_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/autofilter_spec.js
@@ -81,10 +81,10 @@ describe('AutoFilter', function() {
 
 		cy.get('.autofilter .vertical').should('be.visible');
 
-		cy.get('.autofilter .ui-treeview-checkbox').eq(0)
+		cy.get('.autofilter .ui-treeview-checkbox').eq(1)
 			.uncheck();
 
-		cy.get('.autofilter .ui-treeview-checkbox').eq(1)
+		cy.get('.autofilter .ui-treeview-checkbox').eq(0)
 			.uncheck();
 
 		cy.get('.autofilter .ui-button-box-right #ok')


### PR DESCRIPTION
For some reason, uncheck() can turn a checkbox into a plain string item;
that would make all checkboxes below shifted in the list. That made a
test fail e.g. in PR#5175, with

 AssertionError: expected [ 'Test 2', 'Fail' ] to deeply equal [ 'Test 1', 'Pass' ]

The failure sequence was this: before the first call to unselect(), the
list returned by selector '.autofilter .ui-treeview-checkbox' was
  '(empty)'
  'Fail'
  'Pass'

The first unselect() on item #0 '(empty)' made it not a checkbox,and
the next time, the same selector only returned
  'Fail'
  'Pass'

and calling unselect() on item #1 from this list unchecked the 'Pass',
while expectation was to unselect 'Fail'.

The failure looks completely unrelated to the PR in question, likely
some Cypress bug.

Signed-off-by: Mike Kaganski <mike.kaganski@collabora.com>
Change-Id: I8727ce49d55c06538b0176aebe8c97a4b7842c45
