### PR TITLE
fix(css):Improve dark-mode contrast, remove hover for jsdialog

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -87,10 +87,6 @@
 	padding-top: 6px;
 }
 
-td.jsdialog:hover * {
-	color: var(--color-text-darker);
-}
-
 .jsdialog.row {
 	display: table-row;
 }
@@ -152,8 +148,7 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 	font-size: var(--default-font-size);
 	font-family: var(--cool-font);
 	line-height: normal;
-	color: dimgray;
-	color: var(--color-text-lighter);
+	color: var(--color-main-text);
 	height: 32px;
 	display: flex;
 	align-items: center;


### PR DESCRIPTION
Signed-off-by: hanswang123456 <50556568+hanswang123456@users.noreply.github.com>


* Resolves: #5128
* Target version: feature/dark-mode

### Summary


### TODO

- [x] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

