### PR TITLE
Make the repair document dialog into a JSDialog

### DIFF
--- a/browser/src/control/Control.DocumentRepair.js
+++ b/browser/src/control/Control.DocumentRepair.js
@@ -2,89 +2,108 @@
 /*
  * L.Control.DocumentRepair.
  */
-/* global _ _UNO */
+/* global _ */
 L.Control.DocumentRepair = L.Control.extend({
-	options: {
-		position: 'topright'
-	},
+	builder: null,
+	actions: null,
+	selected: null,
 
-	initialize: function (options) {
-		L.setOptions(this, options);
-	},
+	addTo: function (map) {
+		this.remove();
 
-	onAdd: function () {
-		this._initLayout();
+		var data = {
+			id: 'DocumentRepairDialog',
+			dialogid: 'DocumentRepairDialog',
+			type: 'dialog',
+			text: 'Repair Document',
+			title: 'Repair Document',
+			jsontype: 'dialog',
+			responses: [
+				{
+					id: 'ok',
+					response: 1
+				},
+				{
+					id: 'cancel',
+					response: 0
+				},
+			],
+			enabled: true,
+			children: [
+				{
+					id: 'dialog-vbox1',
+					type: 'container',
+					text: '',
+					enabled: true,
+					vertical: true,
+					children: [
+						{
+							type: 'treelistbox',
+							id: 'versions',
+							enabled: false,
+						},
+						{
+							id: 'dialog-action_area1',
+							type: 'container',
+							text: '',
+							enabled: true,
+							vertical: true,
+							children: [
+								{
+									id: '',
+									type: 'buttonbox',
+									text: '',
+									enabled: true,
+									children: [
+										{
+											id: 'cancel',
+											type: 'pushbutton',
+											text: '~Cancel',
+											enabled: true
+										},
+										{
+											id: 'ok',
+											type: 'pushbutton',
+											text: '~Ok',
+											enabled: true,
+											'has_default': true,
+										}
+									],
+									vertical: false,
+									layoutstyle: 'end'
+								},
+							],
+						},
+					]
+				},
+			],
+		};
 
-		return this._container;
-	},
+		this._map = map;
+		this.actions = [];
 
-	_initLayout: function () {
-		this._container = L.DomUtil.create('div', 'leaflet-control-layers');
-		this._container.style.visibility = 'hidden';
+		var dialogBuildEvent = {
+			data: data,
+			callback: this._onAction.bind(this),
+		};
 
-		var closeButton = L.DomUtil.create('a', 'leaflet-popup-close-button', this._container);
-		closeButton.href = '#close';
-		closeButton.innerHTML = '&#215;';
-		L.DomEvent.on(closeButton, 'click', this._onCloseClick, this);
 
-		var wrapper = L.DomUtil.create('div', 'leaflet-popup-content-wrapper', this._container);
-		var content = L.DomUtil.create('div', 'leaflet-popup-content', wrapper);
-		var labelTitle = document.createElement('span');
-		labelTitle.innerHTML = '<b>' + _('Repair Document') + '</b>';
-		content.appendChild(labelTitle);
-		content.appendChild(document.createElement('br'));
-		content.appendChild(document.createElement('br'));
-		var table = L.DomUtil.create('table', '', content);
-		var tbody = this._tbody = L.DomUtil.create('tbody', '', table);
-		var tr = L.DomUtil.create('tr', '', tbody);
-		var th = L.DomUtil.create('th', '', tr);
-		L.DomUtil.setStyle(th, 'display', 'none');
-		th.appendChild(document.createTextNode(''));
-		th = L.DomUtil.create('th', '', tr);
-		th.appendChild(document.createTextNode(_('Type')));
-		th = L.DomUtil.create('th', '', tr);
-		th.appendChild(document.createTextNode(_('Index')));
-		th = L.DomUtil.create('th', '', tr);
-		th.appendChild(document.createTextNode(_('Comment')));
-		th = L.DomUtil.create('th', '', tr);
-		th.appendChild(document.createTextNode(_('User name')));
-		th = L.DomUtil.create('th', '', tr);
-		th.appendChild(document.createTextNode(_('Timestamp')));
+		this._map.fire(window.mode.isMobile() ? 'mobilewizard' : 'jsdialog', dialogBuildEvent);
 
-		var inputButton = document.createElement('input');
-		inputButton.type = 'button';
-		inputButton.value = _('Jump to state');
-		L.DomEvent.on(inputButton, 'click', this._onJumpClick, this);
-		content.appendChild(document.createElement('br'));
-		content.appendChild(document.createElement('br'));
-		content.appendChild(inputButton);
+		return this;
 	},
 
 	createAction: function (type, index, comment, viewId, dateTime) {
-		var row = L.DomUtil.create('tr', '', this._tbody);
-		var td = L.DomUtil.create('td', '', row);
-		L.DomUtil.setStyle(td, 'display', 'none');
-		td.appendChild(document.createTextNode(type));
-		td = L.DomUtil.create('td', '', row);
-		td.appendChild(document.createTextNode(_UNO('.uno:'+type)));
-		td = L.DomUtil.create('td', '', row);
-		td.appendChild(document.createTextNode(index));
-		td = L.DomUtil.create('td', '', row);
-		td.appendChild(document.createTextNode(comment));
-		td = L.DomUtil.create('td', '', row);
-		td.appendChild(document.createTextNode(viewId));
-
-		// Show relative date by default, absolute one as tooltip.
-		td = L.DomUtil.create('td', '', row);
-		var d = new Date(dateTime.replace(/,.*/, 'Z'));
-		var dateOptions = { year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' };
-		var span = document.createElement('span');
-		span.title = dateTime;
-		span.appendChild(document.createTextNode(d.toLocaleDateString(String.locale, dateOptions)));
-		td.appendChild(span);
-
-		L.DomEvent.on(row, 'click', this._onRowClick, this);
-		L.DomEvent.on(row, 'dblclick', this._onJumpClick, this);
+		this.actions.push({ 'text': comment, 'columns': [
+			type,
+			comment,
+			viewId,
+			dateTime
+		].map(
+			function (item) {
+				return { text: item };
+			}
+		), 'row': index});
 	},
 
 	fillAction: function (actions, type) {
@@ -98,54 +117,85 @@ L.Control.DocumentRepair = L.Control.extend({
 		}
 	},
 
+	show: function () {
+		if (this.actions.length !== 0) {
+			var dialogUpdateEvent = {
+				data: {
+					jsontype: 'dialog',
+					action: 'update',
+					id: 'DocumentRepairDialog',
+					control: {
+						id: 'versions',
+						type: 'treelistbox',
+						headers: ['Type', 'What?', 'Who?', 'When?'].map(
+							function(item) { return { text: item }; }
+						),
+						text: '',
+						enabled: true,
+						entries: this.actions,
+					},
+				},
+				callback: this._onAction.bind(this)
+			};
+		} else {
+			var dialogUpdateEvent = {
+				data: {
+					jsontype: 'dialog',
+					action: 'update',
+					id: 'DocumentRepairDialog',
+					control: {
+						id: 'versions',
+						type: 'fixedtext',
+						text: 'You haven\'t done anything to rollback yet...',
+					},
+				},
+			};
+		}
+		if (window.mode.isMobile()) window.mobileDialogId = dialogUpdateEvent.data.id;
+		this._map.fire('jsdialogupdate', dialogUpdateEvent);
+	},
+
 	fillActions: function (data) {
 		this.fillAction(data.Redo.actions, 'Redo');
 		this.fillAction(data.Undo.actions, 'Undo');
 	},
 
-	show: function () {
-		this._tbody.setAttribute('style', 'max-height:' + this._map.getSize().y / 2 + 'px');
-		this._container.style.visibility = '';
-	},
-
-
-	_selectRow: function (row) {
-		if (this._selected) {
-			L.DomUtil.removeClass(this._selected, 'leaflet-popup-selected');
-		}
-
-		this._selected = row;
-		L.DomUtil.addClass(this._selected, 'leaflet-popup-selected');
-	},
-
-	_onCloseClick: function () {
-		this._map.focus();
-		this.remove();
-	},
-
-	_onRowClick: function (e) {
-		if (e.currentTarget && this._selected !== e.currentTarget) {
-			this._selectRow(e.currentTarget);
-		}
-	},
-
-	_onJumpClick: function () {
-		if (this._selected) {
-			var action = this._selected.childNodes[0].innerHTML;
-			var index = parseInt(this._selected.childNodes[2].innerHTML);
-			var command = {
-				Repair: {
-					type: 'boolean',
-					value: true
-				}
+	_onAction: function(element, action, data, index) {
+		if (element === 'dialog' && action === 'close') return;
+		if (element === 'treeview') {
+			var entry = data.entries[parseInt(index)];
+			this.selected = {
+				action: entry.columns[0].text,
+				index: parseInt(entry.row),
 			};
-			command[action] = {
-				type: 'unsigned short',
-				value: index + 1
-			};
-			this._map.sendUnoCommand('.uno:' + action, command);
-			this._onCloseClick();
+			return;
 		}
+		if (element === 'responsebutton' && data.id == 'ok' && this.selected) {
+			this._onOk(this.selected.action, this.selected.index);
+		}
+
+		var closeEvent = {
+		    data: {
+				action: 'close',
+				id: 'DocumentRepairDialog',
+			}
+		};
+		this._map.fire(window.mode.isMobile() ? 'closemobilewizard' : 'jsdialog', closeEvent);
+		console.log('Closed after' + element + ' ' + action);
+	},
+
+	_onOk: function (action, index) {
+		var command = {
+			Repair: {
+				type: 'boolean',
+				value: true
+			}
+		};
+		command[action] = {
+			type: 'unsigned short',
+			value: index + 1
+		};
+		this._map.sendUnoCommand('.uno:' + action, command);
 	}
 });
 

--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -491,7 +491,9 @@ L.Control.JSDialog = L.Control.extend({
 		var builder = new L.control.jsDialogBuilder({windowId: data.id,
 			mobileWizard: this,
 			map: this.map,
-			cssClass: 'jsdialog'});
+			cssClass: 'jsdialog',
+			callback: e.callback
+		});
 
 		var temporaryParent = L.DomUtil.create('div');
 		builder.build(temporaryParent, [data.control], false);

--- a/browser/src/control/Control.MobileWizard.js
+++ b/browser/src/control/Control.MobileWizard.js
@@ -503,7 +503,7 @@ L.Control.MobileWizard = L.Control.extend({
 			this._isPopup = isPopupJson;
 
 			var mWizardContentLength = 0;
-			if (data.children.length > 0) {
+			if (data.children && data.children.length > 0) {
 				if (data.children[0].type == 'menuitem' || data.children[0].children === undefined)
 					mWizardContentLength = data.children.length;
 				else mWizardContentLength = data.children[0].children.length;

--- a/cypress_test/integration_tests/common/repair_document_helper.js
+++ b/cypress_test/integration_tests/common/repair_document_helper.js
@@ -1,0 +1,53 @@
+'use strict';
+/* global cy require */
+
+var mobileHelper = require('./mobile_helper');
+
+/**
+ * Opens the document repair dialog in the given frame
+ *
+ * @param {string|undefined} frameId - The ID of the frame to execute in, or undefined if you're not running in a framed environment
+ * @param {boolean} mobile - True if this is a mobile test, otherwise false
+ * @returns {void}
+ */
+function openRepairDialog(frameId = undefined, mobile = false) {
+	if (mobile) {
+		return mobileHelper.selectHamburgerMenuItem(['Edit', 'Repair']);
+	}
+
+	cy.customGet('#menu-editmenu', frameId)
+		.click()
+		.customGet('#menu-repair', frameId)
+		.click();
+}
+
+/**
+ * Rolls back past the last change matching the selector using the repair document dialog
+ *
+ * @param {string} selector - Something to identify the change you want to rollback past. Can be the comment (i.e. 'Typing "World"') or another field (i.e. 'Undo'). The first change that matches this selector will be picked
+ * @param {string|undefined} frameId - The ID of the frame to execute in, or undefined if you're not running in a framed environment
+ * @param {boolean} mobile - True if this is a mobile test, otherwise false
+ * @returns {void}
+ */
+function rollbackPastChange(selector, frameId = undefined, mobile = false) {
+	openRepairDialog(frameId, mobile);
+
+	cy.customGet('#DocumentRepairDialog', frameId).should('exist');
+	
+	const versions = cy.customGet('#versions', frameId);
+
+	versions
+		.contains('.ui-listview-entry', selector)
+		.click();
+
+	if (mobile) {
+		cy.customGet('#ok.ui-pushbutton.mobile-wizard', frameId).click();
+	} else {
+		cy.customGet('#ok.ui-pushbutton.jsdialog', frameId).click();
+	}
+}
+
+module.exports = {
+	openRepairDialog,
+	rollbackPastChange,
+};

--- a/cypress_test/integration_tests/desktop/calc/undo_redo_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/undo_redo_spec.js
@@ -1,7 +1,8 @@
-/* global describe it cy beforeEach require afterEach*/
+/* global describe it beforeEach require afterEach*/
 
 var helper = require('../../common/helper');
 var calcHelper = require('../../common/calc_helper');
+var repairHelper = require('../../common/repair_document_helper');
 
 describe('Editing Operations', function() {
 	var testFileName = 'undo_redo.ods';
@@ -51,15 +52,7 @@ describe('Editing Operations', function() {
 
 		helper.typeIntoDocument('{enter}');
 
-		cy.get('#menu-editmenu').click()
-			.get('#menu-repair').click();
-
-		cy.get('.leaflet-popup-content table').should('exist');
-
-		cy.contains('.leaflet-popup-content table tbody tr','Undo').eq(0)
-			.click();
-
-		cy.get('.leaflet-popup-content > input').click();
+		repairHelper.rollbackPastChange('Undo');
 
 		calcHelper.dblClickOnFirstCell();
 

--- a/cypress_test/integration_tests/desktop/impress/undo_redo_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/undo_redo_spec.js
@@ -3,6 +3,7 @@
 var helper = require('../../common/helper');
 var impressHelper = require('../../common/impress_helper');
 var desktopHelper = require('../../common/desktop_helper');
+var repairHelper = require('../../common/repair_document_helper');
 
 describe('Editing Operations', function() {
 	var testFileName = 'undo_redo.odp';
@@ -63,15 +64,7 @@ describe('Editing Operations', function() {
 
 		cy.wait(1000);
 
-		cy.get('#menu-editmenu').click()
-			.get('#menu-repair').click();
-
-		cy.get('.leaflet-popup-content table').should('exist');
-
-		cy.contains('.leaflet-popup-content table tbody tr','Undo').eq(0)
-			.click();
-
-		cy.get('.leaflet-popup-content > input').click();
+		repairHelper.rollbackPastChange('Undo');
 
 		impressHelper.selectTextShapeInTheCenter();
 

--- a/cypress_test/integration_tests/desktop/writer/undo_redo_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/undo_redo_spec.js
@@ -1,6 +1,7 @@
-/* global describe it cy beforeEach require afterEach*/
+/* global describe it beforeEach require afterEach*/
 
 var helper = require('../../common/helper');
+var repairHelper = require('../../common/repair_document_helper');
 
 describe('Editing Operations', function() {
 	var testFileName = 'undo_redo.odt';
@@ -40,13 +41,7 @@ describe('Editing Operations', function() {
 	it('Repair Document', function() {
 		helper.typeIntoDocument('Hello World');
 
-		cy.get('#menu-editmenu').click()
-			.get('#menu-repair').click();
-
-		cy.get('.leaflet-popup-content table').should('exist');
-
-		cy.contains('.leaflet-popup-content table tbody tr','Typing: “World”')
-			.dblclick();
+		repairHelper.rollbackPastChange('Typing: “World”');
 
 		helper.selectAllText();
 

--- a/cypress_test/integration_tests/mobile/calc/hamburger_menu_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/hamburger_menu_spec.js
@@ -3,6 +3,7 @@
 var helper = require('../../common/helper');
 var calcHelper = require('../../common/calc_helper');
 var mobileHelper = require('../../common/mobile_helper');
+var repairHelper = require('../../common/repair_document_helper');
 
 describe('Trigger hamburger menu options.', function() {
 	var testFileName;
@@ -148,7 +149,7 @@ describe('Trigger hamburger menu options.', function() {
 			.should('contain.text', 'q');
 	});
 
-	it('Repair.', function() {
+	it('Repair Document', function() {
 		before('hamburger_menu.ods');
 
 		// Type a new character
@@ -164,17 +165,7 @@ describe('Trigger hamburger menu options.', function() {
 		// Revert one undo step via Repair
 		mobileHelper.selectHamburgerMenuItem(['Edit', 'Repair']);
 
-		cy.get('.leaflet-popup-content')
-			.should('be.visible');
-
-		cy.get('.leaflet-popup-content table tr:nth-of-type(2)')
-			.should('contain.text', 'Undo');
-
-		cy.get('.leaflet-popup-content table tr:nth-of-type(2)')
-			.click();
-
-		cy.get('.leaflet-popup-content input[value=\'Jump to state\']')
-			.click();
+		repairHelper.rollbackPastChange('Undo', undefined, true);
 
 		cy.get('input#addressInput')
 			.should('have.prop', 'value', 'A1');

--- a/cypress_test/integration_tests/mobile/calc/undo_redo_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/undo_redo_spec.js
@@ -3,6 +3,7 @@
 var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
 var calcHelper = require('../../common/calc_helper');
+var repairHelper = require('../../common/repair_document_helper');
 
 describe('Editing Operations', function() {
 	var testFileName = 'undo_redo.ods';
@@ -78,17 +79,7 @@ describe('Editing Operations', function() {
 
 		cy.get('#tb_actionbar_item_acceptformula').click();
 
-		cy.get('#toolbar-hamburger')
-			.click()
-			.get('.menu-entry-icon.editmenu').parent()
-			.click()
-			.get('.menu-entry-icon.repair').parent()
-			.click();
-
-		cy.contains('.leaflet-popup-content table tbody tr','Undo').eq(0)
-			.click();
-
-		cy.get('.leaflet-popup-content > input').click();
+		repairHelper.rollbackPastChange('Undo', undefined, true);
 
 		calcHelper.dblClickOnFirstCell();
 

--- a/cypress_test/integration_tests/mobile/impress/hamburger_menu_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/hamburger_menu_spec.js
@@ -3,6 +3,7 @@
 var helper = require('../../common/helper');
 var impressHelper = require('../../common/impress_helper');
 var mobileHelper = require('../../common/mobile_helper');
+var repairHelper = require('../../common/repair_document_helper');
 
 describe('Trigger hamburger menu options.', function() {
 	var testFileName = '';
@@ -165,20 +166,7 @@ describe('Trigger hamburger menu options.', function() {
 		cy.get('.leaflet-pane.leaflet-overlay-pane g.Page .TextPosition tspan')
 			.should('have.text', 'Xq');
 
-		// Revert one undo step via Repair
-		mobileHelper.selectHamburgerMenuItem(['Edit', 'Repair']);
-
-		cy.get('.leaflet-popup-content')
-			.should('be.visible');
-
-		cy.get('.leaflet-popup-content table tr:nth-of-type(2)')
-			.should('contain.text', 'Undo');
-
-		cy.get('.leaflet-popup-content table tr:nth-of-type(2)')
-			.click();
-
-		cy.get('.leaflet-popup-content input[value=\'Jump to state\']')
-			.click();
+		repairHelper.rollbackPastChange('Undo', undefined, true);
 
 		impressHelper.triggerNewSVGForShapeInTheCenter();
 

--- a/cypress_test/integration_tests/mobile/impress/undo_redo_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/undo_redo_spec.js
@@ -3,6 +3,7 @@
 var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
 var impressHelper = require('../../common/impress_helper');
+var repairHelper = require('../../common/repair_document_helper');
 
 describe('Editing Operations', function() {
 	var testFileName = 'undo_redo.odp';
@@ -70,20 +71,7 @@ describe('Editing Operations', function() {
 		helper.typeIntoDocument('Overwrite');
 		helper.typeIntoDocument('{esc}');
 
-		// Now trigger the "repair" function and revert to the first change
-		cy.get('#toolbar-hamburger')
-			.click()
-			.get('.menu-entry-icon.editmenu').parent()
-			.click()
-			.get('.menu-entry-icon.repair').parent()
-			.click();
-
-		cy.get('.leaflet-popup-content table').should('exist');
-
-		cy.contains('.leaflet-popup-content table tbody tr','Undo').eq(0)
-			.click();
-
-		cy.get('.leaflet-popup-content > input').click();
+		repairHelper.rollbackPastChange('Undo', undefined, true);
 
 		// Check the text in the shape reverted to "Hello World"
 		impressHelper.selectTextShapeInTheCenter();

--- a/cypress_test/integration_tests/mobile/writer/hamburger_menu_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/hamburger_menu_spec.js
@@ -3,6 +3,7 @@
 var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
 var writerHelper = require('../../common/writer_helper');
+var repairHelper = require('../../common/repair_document_helper');
 
 describe('Trigger hamburger menu options.', function() {
 	var origTestFileName = 'hamburger_menu.odt';
@@ -171,6 +172,17 @@ describe('Trigger hamburger menu options.', function() {
 
 		cy.get('#copy-paste-container p')
 			.should('contain.text', 'q');
+	});
+
+
+	it('Repair Document', function() {
+		helper.typeIntoDocument('Hello World');
+		
+		repairHelper.rollbackPastChange('Typing: “World”', undefined, true);
+
+		helper.selectAllText();
+
+		helper.expectTextForClipboard('Hello \n');
 	});
 
 	it('Cut.', function() {

--- a/cypress_test/integration_tests/mobile/writer/undo_redo_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/undo_redo_spec.js
@@ -2,6 +2,7 @@
 
 var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
+var repairHelper = require('../../common/repair_document_helper');
 
 describe('Editing Operations', function() {
 	var testFileName = 'undo_redo.odt';
@@ -47,19 +48,7 @@ describe('Editing Operations', function() {
 	it('Repair Document', function() {
 		helper.typeIntoDocument('Hello World');
 
-		cy.get('#toolbar-hamburger')
-			.click()
-			.get('.menu-entry-icon.editmenu').parent()
-			.click()
-			.get('.menu-entry-icon.repair').parent()
-			.click();
-
-		cy.get('.leaflet-popup-content table').should('exist');
-
-		cy.contains('.leaflet-popup-content table tbody tr','Typing: “World”')
-			.click();
-
-		cy.get('.leaflet-popup-content > input').click();
+		repairHelper.rollbackPastChange('Typing: “World”', undefined, true);
 
 		helper.selectAllText();
 

--- a/cypress_test/integration_tests/multiuser/calc/repair_document_spec.js
+++ b/cypress_test/integration_tests/multiuser/calc/repair_document_spec.js
@@ -16,54 +16,39 @@ describe.skip('Repair Document', function() {
 	});
 
 	function repairDoc(frameId1, frameId2) {
-		cy.wait(1000);
 
 		helper.typeIntoDocument('Hello World{enter}', frameId1);
 
-		//wait for the popup to disappear
-		cy.wait(5000);
+		calcHelper.selectEntireSheet(frameId2);
 
-		cy.customGet('.leaflet-layer', frameId2)
-			.click('center', {force:true})
-			.wait(500);
+		calcHelper.assertDataClipboardTable(['Hello World\n'], frameId2);
 
-		calcHelper.dblClickOnFirstCell(frameId2);
+		calcHelper.selectEntireSheet(frameId1);
 
-		helper.clearAllText(frameId2);
-
-		helper.typeIntoDocument('Hello{enter}', frameId2);
-
-		cy.wait(1000);
+		calcHelper.assertDataClipboardTable(['Hello World\n'], frameId1);
 
 		cy.customGet('#menu-editmenu', frameId2).click()
 			.customGet('#menu-repair', frameId2).click();
 
-		cy.customGet('.leaflet-popup-content table', frameId2).should('exist');
+		cy.customGet('#DocumentRepairDialog', frameId2).should('exist');
+		cy.customGet('#versions', frameId2).should('exist');
 
-		cy.iframe(frameId2).contains('.leaflet-popup-content table tbody tr','Undo').eq(0)
+		cy.iframe(frameId2).contains('#versions .ui-treeview-body .ui-listview-entry td','Input')
 			.click();
 
-		cy.customGet('.leaflet-popup-content > input', frameId2)
-			.click()
-			.wait(1000);
+		cy.customGet('#ok.ui-pushbutton.jsdialog', frameId2).should('exist');
 
-		calcHelper.dblClickOnFirstCell(frameId2);
+		cy.customGet('#ok.ui-pushbutton.jsdialog', frameId2).click();
 
-		helper.selectAllText(frameId2);
+		cy.wait(500);
 
-		helper.expectTextForClipboard('Hello World', frameId2);
+		calcHelper.selectEntireSheet(frameId2);
 
-		cy.customGet('.leaflet-layer', frameId1)
-			.click('center', {force:true})
-			.wait(500);
+		helper.expectTextForClipboard('', frameId2);
 
-		helper.typeIntoDocument('{end}{enter}', frameId1);
+		calcHelper.selectEntireSheet(frameId1);
 
-		calcHelper.dblClickOnFirstCell(frameId1);
-
-		helper.selectAllText(frameId1);
-
-		helper.expectTextForClipboard('Hello World', frameId1);
+		helper.expectTextForClipboard('', frameId1);
 	}
 
 	it('Repair by user-2', function() {

--- a/cypress_test/integration_tests/multiuser/impress/repair_document_spec.js
+++ b/cypress_test/integration_tests/multiuser/impress/repair_document_spec.js
@@ -32,17 +32,18 @@ describe.skip('Repair Document', function() {
 
 		cy.customGet('#menu-editmenu', frameId2).click()
 			.customGet('#menu-repair', frameId2).click();
-		cy.customGet('.leaflet-popup-content table', frameId2).should('exist');
 
-		cy.iframe(frameId2).contains('.leaflet-popup-content table tbody tr','Undo').eq(0).click();
 
-		cy.customGet('.leaflet-popup-content > input', frameId2).click();
+		cy.customGet('#DocumentRepairDialog', frameId2).should('exist');
+		cy.customGet('#versions', frameId2).should('exist');
 
-		cy.customGet('.leaflet-layer', frameId2).click('center', {force:true});
+		cy.iframe(frameId2).contains('#versions .ui-treeview-body .ui-listview-entry td','Typing: “World”')
+			.click();
 
-		cy.customGet('g.leaflet-control-buttons-disabled svg', frameId2).dblclick({force:true});
+		cy.customGet('#ok.ui-pushbutton.jsdialog', frameId2).should('exist');
 
-		cy.wait(1000);
+		cy.customGet('#ok.ui-pushbutton.jsdialog', frameId2).click();
+
 
 		helper.typeIntoDocument('{ctrl}{a}', frameId2);
 

--- a/cypress_test/integration_tests/multiuser/writer/repair_document_spec.js
+++ b/cypress_test/integration_tests/multiuser/writer/repair_document_spec.js
@@ -1,6 +1,7 @@
 /* global describe it cy beforeEach require afterEach */
 
 var helper = require('../../common/helper');
+var repairHelper = require('../../common/repair_document_helper');
 
 describe('Repair Document', function() {
 	var origTestFileName = 'repair_doc.odt';
@@ -20,13 +21,9 @@ describe('Repair Document', function() {
 
 		helper.typeIntoDocument('Hello World', frameId1);
 
-		cy.customGet('#menu-editmenu', frameId2).click()
-			.customGet('#menu-repair', frameId2).click();
+		cy.wait(2000);
 
-		cy.customGet('.leaflet-popup-content table', frameId2).should('exist');
-
-		cy.iframe(frameId2).contains('.leaflet-popup-content table tbody tr','Typing: “World”')
-			.dblclick();
+		repairHelper.rollbackPastChange('Typing: “World”', frameId2);
 
 		cy.customGet('.leaflet-layer', frameId2).click();
 
@@ -50,5 +47,4 @@ describe('Repair Document', function() {
 	it('Repair by user-1', function() {
 		repairDoc('#iframe2', '#iframe1');
 	});
-
 });


### PR DESCRIPTION
- The repair document dialog is a leaflet dialog
- As this dialog is online-side only, I'll use the JSDialog builder
  directly rather than writing a UI file
- Most of the code to build the dialogs is already very adaptable from
  looking at the protocol of existing JSDialogs that come from the
  server & where the code goes, however a small change had to be made to
  dialog modifications to allow us a callback function, as otherwise we
  would send off to the server whenever we pressed on a list item
- Finally, if there's no list to show, we'll show a bit of text saying
  that there's nothing, as otherwise it looks like an empty/broken dialog

Signed-off-by: Skyler Grey <skyler.grey@collabora.com>
Change-Id: Iab9e943a428e66b05e28819c2ee1001a2deffd2c

* Target version: master 

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

![a gif of it working](https://user-images.githubusercontent.com/34243578/186934333-b44e5835-ee50-4687-999c-7bb27e14b40b.gif)
![a screenshot of multiple clients using it](https://user-images.githubusercontent.com/34243578/186936254-144bcfb0-4e74-4659-b41e-7a7d55f144a7.png)
