### PR TITLE
Introduce 'mode' property to the tile requests

### DIFF
--- a/browser/src/control/Parts.js
+++ b/browser/src/control/Parts.js
@@ -192,9 +192,11 @@ L.Map.include({
 		}
 
 		if (fetchThumbnail) {
+			var mode = docLayer._selectedMode;
 			this._addPreviewToQueue(part, 'tile ' +
 							'nviewid=0' + ' ' +
 							'part=' + part + ' ' +
+							((mode !== 0) ? ('mode=' + mode + ' ') : '') +
 							'width=' + maxWidth * app.roundedDpiScale + ' ' +
 							'height=' + maxHeight * app.roundedDpiScale + ' ' +
 							'tileposx=' + tilePosX + ' ' +
@@ -220,9 +222,11 @@ L.Map.include({
 		this._docPreviews[id] = {id: id, part: part, width: width, height: height, tilePosX: tilePosX,
 			tilePosY: tilePosY, tileWidth: tileWidth, tileHeight: tileHeight, autoUpdate: autoUpdate, invalid: false};
 
+		var mode = this._docLayer._selectedMode;
 		this._addPreviewToQueue(part, 'tile ' +
 							'nviewid=0' + ' ' +
 							'part=' + part + ' ' +
+							((mode !== 0) ? ('mode=' + mode + ' ') : '') +
 							'width=' + width * app.roundedDpiScale + ' ' +
 							'height=' + height * app.roundedDpiScale + ' ' +
 							'tileposx=' + tilePosX + ' ' +

--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -1589,6 +1589,9 @@ app.definitions.Socket = L.Class.extend({
 			else if (tokens[i].substring(0, 6) === 'parts=') {
 				command.parts = parseInt(tokens[i].substring(6));
 			}
+			else if (tokens[i].substring(0, 5) === 'mode=') {
+				command.mode = parseInt(tokens[i].substring(5));
+			}
 			else if (tokens[i].substring(0, 8) === 'current=') {
 				command.selectedPart = parseInt(tokens[i].substring(8));
 			}

--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -168,6 +168,10 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 			command.height = parseInt(strTwips[3]);
 			command.part = this._selectedPart;
 		}
+
+		if (command.mode === undefined)
+			command.mode = this._selectedMode;
+
 		var topLeftTwips = new L.Point(command.x, command.y);
 		var offset = new L.Point(command.width, command.height);
 		var bottomRightTwips = topLeftTwips.add(offset);
@@ -190,7 +194,8 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 		for (var key in this._tiles) {
 			var coords = this._tiles[key].coords;
 			var bounds = this._coordsToTileBounds(coords);
-			if (coords.part === command.part && invalidBounds.intersects(bounds)) {
+			if (coords.part === command.part && coords.mode === command.mode &&
+				invalidBounds.intersects(bounds)) {
 				if (this._tiles[key]._invalidCount) {
 					this._tiles[key]._invalidCount += 1;
 				}
@@ -211,7 +216,8 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 			}
 		}
 
-		if (needsNewTiles && command.part === this._selectedPart && this._debug)
+		if (needsNewTiles && command.part === this._selectedPart
+			&& command.mode === this._selectedMode && this._debug)
 		{
 			this._debugAddInvalidationMessage(textMsg);
 		}
@@ -220,7 +226,7 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 			// compute the rectangle that each tile covers in the document based
 			// on the zoom level
 			coords = this._keyToTileCoords(key);
-			if (coords.part !== command.part) {
+			if (coords.part !== command.part || coords.mode !== command.mode) {
 				continue;
 			}
 

--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -336,6 +336,7 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 			this._docType = command.type;
 			this._parts = command.parts;
 			this._selectedPart = command.selectedPart;
+			this._selectedMode = (command.mode !== undefined) ? command.mode : 0;
 			if (this.sheetGeometry && this._selectedPart != this.sheetGeometry.getPart()) {
 				// Core initiated sheet switch, need to get full sheetGeometry data for the selected sheet.
 				this.requestSheetGeometryData();

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -68,6 +68,7 @@ var CSelections = L.Class.extend({
 		this._isOle = selectionType === 'ole';
 		this._selection = undefined;
 		this._updateSelection();
+		this._selectedMode = 0;
 	},
 
 	empty: function () {
@@ -202,11 +203,12 @@ var CReferences = L.Class.extend({
 
 L.TileCoordData = L.Class.extend({
 
-	initialize: function (left, top, zoom, part) {
+	initialize: function (left, top, zoom, part, mode) {
 		this.x = left;
 		this.y = top;
 		this.z = zoom;
 		this.part = part;
+		this.mode = (mode !== undefined) ? mode : 0;
 	},
 
 	getPos: function () {
@@ -214,12 +216,13 @@ L.TileCoordData = L.Class.extend({
 	},
 
 	key: function () {
-		return this.x + ':' + this.y + ':' + this.z + ':' + this.part;
+		return this.x + ':' + this.y + ':' + this.z + ':' + this.part + ':'
+			+ ((this.mode !== undefined) ? this.mode : 0);
 	},
 
 	toString: function () {
 		return '{ left : ' + this.x + ', top : ' + this.y +
-			', z : ' + this.z + ', part : ' + this.part + ' }';
+			', z : ' + this.z + ', part : ' + this.part + ', mode : ' + this.mode + ' }';
 	}
 });
 
@@ -227,8 +230,9 @@ L.TileCoordData.parseKey = function (keyString) {
 
 	window.app.console.assert(typeof keyString === 'string', 'key should be a string');
 	var k = keyString.split(':');
-	window.app.console.assert(k.length >= 4, 'invalid key format');
-	return new L.TileCoordData(+k[0], +k[1], +k[2], +k[3]);
+	var mode = (k.length === 4) ? +k[4] : 0;
+	window.app.console.assert(k.length >= 5, 'invalid key format');
+	return new L.TileCoordData(+k[0], +k[1], +k[2], +k[3], mode);
 };
 
 L.TileSectionManager = L.Class.extend({
@@ -1175,12 +1179,12 @@ L.CanvasTileLayer = L.Layer.extend({
 		}
 	},
 
-	_retainParent: function (x, y, z, part, minZoom) {
+	_retainParent: function (x, y, z, part, mode, minZoom) {
 		var x2 = Math.floor(x / 1.2),
 		    y2 = Math.floor(y / 1.2),
 		    z2 = z - 1;
 
-		var key = x2 + ':' + y2 + ':' + z2 + ':' + part,
+		var key = x2 + ':' + y2 + ':' + z2 + ':' + part + ':' + mode,
 		    tile = this._tiles[key];
 
 		if (tile && tile.active) {
@@ -1192,19 +1196,19 @@ L.CanvasTileLayer = L.Layer.extend({
 		}
 
 		if (z2 > minZoom) {
-			return this._retainParent(x2, y2, z2, part, minZoom);
+			return this._retainParent(x2, y2, z2, part, mode, minZoom);
 		}
 
 		return false;
 	},
 
-	_retainChildren: function (x, y, z, part, maxZoom) {
+	_retainChildren: function (x, y, z, part, mode, maxZoom) {
 
 		for (var i = 1.2 * x; i < 1.2 * x + 2; i++) {
 			for (var j = 1.2 * y; j < 1.2 * y + 2; j++) {
 
 				var key = Math.floor(i) + ':' + Math.floor(j) + ':' +
-					(z + 1) + ':' + part,
+					(z + 1) + ':' + part + ':' + mode,
 				    tile = this._tiles[key];
 
 				if (tile && tile.active) {
@@ -1216,7 +1220,7 @@ L.CanvasTileLayer = L.Layer.extend({
 				}
 
 				if (z + 1 < maxZoom) {
-					this._retainChildren(i, j, z + 1, part, maxZoom);
+					this._retainChildren(i, j, z + 1, part, mode, maxZoom);
 				}
 			}
 		}
@@ -1424,10 +1428,11 @@ L.CanvasTileLayer = L.Layer.extend({
 		return true;
 	},
 
-	_sendTileCombineRequest: function(part, tilePositionsX, tilePositionsY) {
+	_sendTileCombineRequest: function(part, mode, tilePositionsX, tilePositionsY) {
 		var msg = 'tilecombine ' +
 			'nviewid=0 ' +
 			'part=' + part + ' ' +
+			((mode !== 0) ? ('mode=' + mode + ' ') : '') +
 			'width=' + this._tileWidthPx + ' ' +
 			'height=' + this._tileHeightPx + ' ' +
 			'tileposx=' + tilePositionsX + ' '	+
@@ -1578,8 +1583,14 @@ L.CanvasTileLayer = L.Layer.extend({
 				if (this.isWriter()) {
 					msg += 'part=0 ';
 				} else {
-					var partNumber = parseInt(payload.substring('EMPTY'.length + 1));
-					msg += 'part=' + (isNaN(partNumber) ? this._selectedPart : partNumber) + ' ';
+					var tokens = payload.substring('EMPTY'.length + 1);
+					tokens = tokens.split(' ');
+					var part = parseInt(tokens[0] ? tokens[0] : '');
+					var mode = parseInt(tokens[1] ? tokens[1] : '');
+					mode = (isNaN(mode) ? this._selectedMode : mode);
+					msg += 'part=' + (isNaN(part) ? this._selectedPart : part)
+						+ ((mode !== 0) ? (' mode=' + mode) : '')
+						+ ' ';
 				}
 				msg += 'x=0 y=0 ';
 				msg += 'width=' + this._docWidthTwips + ' ';
@@ -5593,8 +5604,8 @@ L.CanvasTileLayer = L.Layer.extend({
 			tile = this._tiles[key];
 			if (tile.current && !tile.active) {
 				var coords = tile.coords;
-				if (!this._retainParent(coords.x, coords.y, coords.z, coords.part, coords.z - 5)) {
-					this._retainChildren(coords.x, coords.y, coords.z, coords.part, coords.z + 2);
+				if (!this._retainParent(coords.x, coords.y, coords.z, coords.part, coords.mode, coords.z - 5)) {
+					this._retainChildren(coords.x, coords.y, coords.z, coords.part, coords.mode, coords.z + 2);
 				}
 			}
 		}
@@ -5621,7 +5632,8 @@ L.CanvasTileLayer = L.Layer.extend({
 			this._wrapX ? L.Util.wrapNum(coords.x, this._wrapX) : coords.x,
 			this._wrapY ? L.Util.wrapNum(coords.y, this._wrapY) : coords.y,
 			coords.z,
-			coords.part);
+			coords.part,
+			coords.mode);
 	},
 
 	_pxBoundsToTileRanges: function (bounds) {
@@ -5793,9 +5805,11 @@ L.CanvasTileLayer = L.Layer.extend({
 		return mostVisiblePart;
 	},
 
-	_doesQueueIncludeTileInfo: function (queue, part, x, y) {
+	// TODO: unused method?
+	_doesQueueIncludeTileInfo: function (queue, part, mode, x, y) {
 		for (var i = 0; i < queue.length; i++) {
-			if (queue[i].part === part && queue[i].x === x && queue[i].y === y)
+			if (queue[i].part === part && queue[i].mode === mode &&
+				queue[i].x === x && queue[i].y === y)
 				return true;
 		}
 		return false;
@@ -5881,6 +5895,7 @@ L.CanvasTileLayer = L.Layer.extend({
 		var ratio = this._tileSize * relScale / this._tileHeightTwips;
 		var partHeightPixels = Math.round((this._partHeightTwips + this._spaceBetweenParts) * ratio);
 		var partWidthPixels = Math.round((this._partWidthTwips) * ratio);
+		var mode = 0; // mode is different only in Impress MasterPage mode so far
 
 		var intersectionAreaRectangle = L.LOUtil._getIntersectionRectangle(app.file.viewedRectangle, [0, 0, partWidthPixels, partHeightPixels * this._parts]);
 
@@ -5904,7 +5919,7 @@ L.CanvasTileLayer = L.Layer.extend({
 				for (var j = minLocalX; j <= maxLocalX; j += app.tile.size.pixels[0]) {
 					for (var k = 0; k <= vTileCountPerPart * app.tile.size.pixels[0]; k += app.tile.size.pixels[1])
 						if ((i !== startPart || k >= startY) && (i !== endPart || k <= endY))
-							queue.push(new L.TileCoordData(j, k, zoom, i));
+							queue.push(new L.TileCoordData(j, k, zoom, i, mode));
 				}
 			}
 
@@ -5952,11 +5967,11 @@ L.CanvasTileLayer = L.Layer.extend({
 						tile.el = this._tileCache[key];
 					}
 					else {
-						this._sendTileCombineRequest(queue[i].part, (queue[i].x / this._tileSize) * this._tileWidthTwips, (queue[i].y / this._tileSize) * this._tileHeightTwips);
+						this._sendTileCombineRequest(queue[i].part, queue[i].mode, (queue[i].x / this._tileSize) * this._tileWidthTwips, (queue[i].y / this._tileSize) * this._tileHeightTwips);
 					}
 				}
 				else if (!tile.loaded) {
-					this._sendTileCombineRequest(queue[i].part, (queue[i].x / this._tileSize) * this._tileWidthTwips, (queue[i].y / this._tileSize) * this._tileHeightTwips);
+					this._sendTileCombineRequest(queue[i].part, queue[i].mode, (queue[i].x / this._tileSize) * this._tileWidthTwips, (queue[i].y / this._tileSize) * this._tileHeightTwips);
 				}
 			}
 		}
@@ -5994,7 +6009,8 @@ L.CanvasTileLayer = L.Layer.extend({
 		for (var key in this._tiles) {
 			var thiscoords = this._keyToTileCoords(key);
 			if (thiscoords.z !== zoom ||
-				thiscoords.part !== this._selectedPart) {
+				thiscoords.part !== this._selectedPart ||
+				thiscoords.mode !== this._selectedMode) {
 				this._tiles[key].current = false;
 			}
 		}
@@ -6012,7 +6028,8 @@ L.CanvasTileLayer = L.Layer.extend({
 						i * this._tileSize,
 						j * this._tileSize,
 						zoom,
-						this._selectedPart);
+						this._selectedPart,
+						this._selectedMode);
 
 					if (!this._isValidTile(coords)) { continue; }
 
@@ -6109,7 +6126,8 @@ L.CanvasTileLayer = L.Layer.extend({
 		for (key in this._tiles) {
 			var thiscoords = this._keyToTileCoords(key);
 			if (thiscoords.z !== zoom ||
-				thiscoords.part !== this._selectedPart) {
+				thiscoords.part !== this._selectedPart ||
+				thiscoords.mode !== this._selectedMode) {
 				this._tiles[key].current = false;
 			}
 		}
@@ -6127,7 +6145,8 @@ L.CanvasTileLayer = L.Layer.extend({
 						i * this._tileSize,
 						j * this._tileSize,
 						zoom,
-						this._selectedPart);
+						this._selectedPart,
+						this._selectedMode);
 
 					if (!this._isValidTile(coords)) { continue; }
 
@@ -6161,7 +6180,7 @@ L.CanvasTileLayer = L.Layer.extend({
 				coords = queue[i];
 				key = this._tileCoordsToKey(coords);
 				tile = undefined;
-				if (coords.part === this._selectedPart) {
+				if (coords.part === this._selectedPart && coords.mode === this._selectedMode) {
 					var tileImg = this.createTile(this._wrapCoords(coords), L.bind(this._tileReady, this, coords));
 
 					// if createTile is defined with a second argument ("done" callback),
@@ -6202,7 +6221,7 @@ L.CanvasTileLayer = L.Layer.extend({
 			}
 
 			if (tilePositionsX !== '' && tilePositionsY !== '') {
-				this._sendTileCombineRequest(this._selectedPart, tilePositionsX, tilePositionsY);
+				this._sendTileCombineRequest(this._selectedPart, this._selectedMode, tilePositionsX, tilePositionsY);
 			}
 			else {
 				// We have all necessary tile images in the cache, schedule a paint..
@@ -6261,7 +6280,7 @@ L.CanvasTileLayer = L.Layer.extend({
 
 			key = this._tileCoordsToKey(coords);
 
-			if (coords.part === this._selectedPart) {
+			if (coords.part === this._selectedPart && coords.mode === this._selectedMode) {
 				if (!this._tiles[key]) {
 					var tileImg = this.createTile(this._wrapCoords(coords), L.bind(this._tileReady, this, coords));
 
@@ -6304,7 +6323,9 @@ L.CanvasTileLayer = L.Layer.extend({
 
 			// tiles that do not interest us
 			key = this._tileCoordsToKey(coords);
-			if (this._tileCache[key] || coords.part !== this._selectedPart) {
+			if (this._tileCache[key]
+				|| coords.part !== this._selectedPart
+				|| coords.mode !== this._selectedMode) {
 				coordsQueue.splice(0, 1);
 				continue;
 			}
@@ -6391,7 +6412,7 @@ L.CanvasTileLayer = L.Layer.extend({
 			}
 
 			twips = this._coordsToTwips(coords);
-			this._sendTileCombineRequest(coords.part, tilePositionsX, tilePositionsY);
+			this._sendTileCombineRequest(coords.part, this._selectedMode, tilePositionsX, tilePositionsY);
 		}
 	},
 
@@ -6409,7 +6430,7 @@ L.CanvasTileLayer = L.Layer.extend({
 
 			var dropTile = !tile.loaded;
 			var coords = tile.coords;
-			if (coords.part === this._selectedPart) {
+			if (coords.part === this._selectedPart && coords.mode === this._selectedMode) {
 
 				var tileBounds;
 				if (!this._splitPanesContext) {
@@ -6452,7 +6473,8 @@ L.CanvasTileLayer = L.Layer.extend({
 			typeof msgObj.y !== 'number' ||
 			typeof msgObj.tileWidth !== 'number' ||
 			typeof msgObj.tileHeight !== 'number' ||
-			typeof msgObj.part !== 'number') {
+			typeof msgObj.part !== 'number' ||
+			(typeof msgObj.mode !== 'number' && typeof msgObj.mode !== 'undefined')) {
 			window.app.console.error('Unexpected content in the parsed tile message.');
 		}
 	},
@@ -6461,6 +6483,7 @@ L.CanvasTileLayer = L.Layer.extend({
 		var coords = this._twipsToCoords(tileMsg);
 		coords.z = tileMsg.zoom;
 		coords.part = tileMsg.part;
+		coords.mode = tileMsg.mode;
 		return coords;
 	},
 
@@ -6750,6 +6773,7 @@ L.CanvasTileLayer = L.Layer.extend({
 				width: tileMsgObj.width,
 				height: tileMsgObj.height,
 				part: tileMsgObj.part,
+				mode: (tileMsgObj.mode !== undefined) ? tileMsgObj.mode : 0,
 				docType: this._docType
 			});
 		}
@@ -6775,7 +6799,9 @@ L.CanvasTileLayer = L.Layer.extend({
 		L.Log.log(textMsg, 'INCOMING', key);
 
 		// Queue acknowledgment, that the tile message arrived
-		var tileID = tileMsgObj.part + ':' + tileMsgObj.x + ':' + tileMsgObj.y + ':' + tileMsgObj.tileWidth + ':' + tileMsgObj.tileHeight + ':' + tileMsgObj.nviewid;
+		var mode = (tileMsgObj.mode !== undefined) ? tileMsgObj.mode : 0;
+		var tileID = tileMsgObj.part + ':' + mode + ':' + tileMsgObj.x + ':' + tileMsgObj.y + ':'
+			+ tileMsgObj.tileWidth + ':' + tileMsgObj.tileHeight + ':' + tileMsgObj.nviewid;
 		this._queuedProcessed.push(tileID);
 	},
 
@@ -6890,6 +6916,7 @@ L.TilesPreFetcher = L.Class.extend({
 		var center = this._map.getCenter();
 		var zoom = this._map.getZoom();
 		var part = this._docLayer._selectedPart;
+		var mode = this._docLayer._selectedMode;
 		var hasEditPerm = this._map.isPermissionEdit();
 
 		if (this._zoom === undefined) {
@@ -6898,6 +6925,10 @@ L.TilesPreFetcher = L.Class.extend({
 
 		if (this._preFetchPart === undefined) {
 			this._preFetchPart = part;
+		}
+
+		if (this._preFetchMode === undefined) {
+			this._preFetchMode = mode;
 		}
 
 		if (this._hasEditPerm === undefined) {
@@ -6934,12 +6965,14 @@ L.TilesPreFetcher = L.Class.extend({
 			!this._borders || this._borders.length === 0 ||
 			zoom !== this._zoom ||
 			part !== this._preFetchPart ||
+			mode !== this._preFetchMode ||
 			hasEditPerm !== this._hasEditPerm ||
 			!pixelBounds.equals(this._pixelBounds) ||
 			!splitPos.equals(this._splitPos)) {
 
 			this._zoom = zoom;
 			this._preFetchPart = part;
+			this._preFetchMode = mode;
 			this._hasEditPerm = hasEditPerm;
 			this._pixelBounds = pixelBounds;
 			this._splitPos = splitPos;
@@ -7051,6 +7084,7 @@ L.TilesPreFetcher = L.Class.extend({
 					coords = queue[i];
 					coords.z = zoom;
 					coords.part = this._preFetchPart;
+					coords.mode = this._preFetchMode;
 					var key = this._docLayer._tileCoordsToKey(coords);
 
 					if (!this._docLayer._isValidTile(coords) ||
@@ -7137,6 +7171,7 @@ L.TilesPreFetcher = L.Class.extend({
 		var interval = 750;
 		var idleTime = 5000;
 		this._preFetchPart = this._docLayer._selectedPart;
+		this._preFetchMode = this._docLayer._selectedMode;
 		this._preFetchIdle = setTimeout(L.bind(function () {
 			this._tilesPreFetcher = setInterval(L.bind(this.preFetchTiles, this), interval);
 			this._preFetchIdle = undefined;

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -2208,6 +2208,7 @@ L.CanvasTileLayer = L.Layer.extend({
 		var strTwips = obj.selection.match(/\d+/g);
 		this._graphicViewMarkers[viewId] = this._graphicViewMarkers[viewId] || {};
 		this._graphicViewMarkers[viewId].part = parseInt(obj.part);
+		this._graphicViewMarkers[viewId].mode = (obj.mode !== undefined) ? parseInt(obj.mode) : 0;
 		if (strTwips != null) {
 			var topLeftTwips = new L.Point(parseInt(strTwips[0]), parseInt(strTwips[1]));
 			var offset = new L.Point(parseInt(strTwips[2]), parseInt(strTwips[3]));
@@ -2490,6 +2491,7 @@ L.CanvasTileLayer = L.Layer.extend({
 			this._twipsToLatLng(rectangle.getBottomRight(), this._map.getZoom())),
 		this._viewCursors[viewId].corepxBounds = this._twipsToCorePixelsBounds(rectangle);
 		this._viewCursors[viewId].part = parseInt(obj.part);
+		this._viewCursors[viewId].mode = (obj.mode !== undefined) ? parseInt(obj.mode) : 0;
 
 		// FIXME. Server not sending view visible cursor
 		if (typeof this._viewCursors[viewId].visible === 'undefined') {
@@ -2557,8 +2559,11 @@ L.CanvasTileLayer = L.Layer.extend({
 
 		var cellViewCursorMarker = this._cellViewCursors[viewId].marker;
 		var viewPart = this._cellViewCursors[viewId].part;
+		var viewMode = this._cellViewCursors[viewId].mode;
 
-		if (!this._isEmptyRectangle(this._cellViewCursors[viewId].bounds) && this._selectedPart === viewPart && this._map.hasInfoForView(viewId)) {
+		if (!this._isEmptyRectangle(this._cellViewCursors[viewId].bounds)
+			&& this._selectedPart === viewPart && this._selectedMode === viewMode
+			&& this._map.hasInfoForView(viewId)) {
 			if (!cellViewCursorMarker) {
 				var backgroundColor = L.LOUtil.rgbToHex(this._map.getViewColor(viewId));
 				cellViewCursorMarker = new CCellCursor(this._cellViewCursors[viewId].corePixelBounds, {
@@ -2941,6 +2946,7 @@ L.CanvasTileLayer = L.Layer.extend({
 		var obj = JSON.parse(textMsg.substring('textviewselection:'.length + 1));
 		var viewId = parseInt(obj.viewId);
 		var viewPart = parseInt(obj.part);
+		var viewMode = (obj.mode !== undefined) ? parseInt(obj.mode) : 0;
 
 		// Ignore if viewid is same as ours or not in our db
 		if (viewId === this._viewId || !this._map._viewInfo[viewId]) {
@@ -2957,6 +2963,7 @@ L.CanvasTileLayer = L.Layer.extend({
 			});
 
 			this._viewSelections[viewId].part = viewPart;
+			this._viewSelections[viewId].mode = viewMode;
 			var docLayer = this;
 			this._viewSelections[viewId].pointSet = CPolyUtil.rectanglesToPointSet(rectangles,
 				function (twipsPoint) {
@@ -3666,12 +3673,13 @@ L.CanvasTileLayer = L.Layer.extend({
 		var viewCursorMarker = this._viewCursors[viewId].marker;
 		var viewCursorVisible = this._viewCursors[viewId].visible;
 		var viewPart = this._viewCursors[viewId].part;
+		var viewMode = this._viewCursors[viewId].mode;
 
 		if (!this._map.isViewReadOnly(viewId) &&
 		    viewCursorVisible &&
 		    !this._isZooming &&
 		    !this._isEmptyRectangle(this._viewCursors[viewId].bounds) &&
-		    (this.isWriter() || this._selectedPart === viewPart)) {
+		    (this.isWriter() || (this._selectedPart === viewPart && this._selectedMode === viewMode))) {
 			if (!viewCursorMarker) {
 				var viewCursorOptions = {
 					color: L.LOUtil.rgbToHex(this._map.getViewColor(viewId)),
@@ -3700,9 +3708,15 @@ L.CanvasTileLayer = L.Layer.extend({
 	},
 
 	updateAllViewCursors: function() {
-		for (var key in this._viewCursors) {
-			this._onUpdateViewCursor(key);
-		}
+		this.eachView(this._viewCursors, this._onUpdateViewCursor, this, false);
+	},
+
+	updateAllTextViewSelection: function() {
+		this.eachView(this._viewSelections, this._onUpdateTextViewSelection, this, false);
+	},
+
+	updateAllGraphicViewSelections: function () {
+		this.eachView(this._graphicViewMarkers, this._onUpdateGraphicViewSelection, this, false);
 	},
 
 	isCursorVisible: function() {
@@ -3735,9 +3749,10 @@ L.CanvasTileLayer = L.Layer.extend({
 		var viewPointSet = this._viewSelections[viewId].pointSet;
 		var viewSelection = this._viewSelections[viewId].selection;
 		var viewPart = this._viewSelections[viewId].part;
+		var viewMode = this._viewSelections[viewId].mode;
 
 		if (viewPointSet &&
-		    (this.isWriter() || this._selectedPart === viewPart)) {
+		    (this.isWriter() || (this._selectedPart === viewPart && this._selectedMode === viewMode))) {
 
 			if (viewSelection) {
 				if (!this._map.hasInfoForView(viewId)) {
@@ -3761,9 +3776,10 @@ L.CanvasTileLayer = L.Layer.extend({
 		var viewBounds = this._graphicViewMarkers[viewId].bounds;
 		var viewMarker = this._graphicViewMarkers[viewId].marker;
 		var viewPart = this._graphicViewMarkers[viewId].part;
+		var viewMode = this._graphicViewMarkers[viewId].mode;
 
 		if (!this._isEmptyRectangle(viewBounds) &&
-		   (this.isWriter() || this._selectedPart === viewPart)) {
+		   (this.isWriter() || (this._selectedPart === viewPart && this._selectedMode === viewMode))) {
 			if (!viewMarker) {
 				var color = L.LOUtil.rgbToHex(this._map.getViewColor(viewId));
 				viewMarker = L.rectangle(viewBounds, {

--- a/browser/src/layer/tile/ImpressTileLayer.js
+++ b/browser/src/layer/tile/ImpressTileLayer.js
@@ -285,6 +285,7 @@ L.ImpressTileLayer = L.CanvasTileLayer.extend({
 			this._documentInfo = textMsg;
 			this._viewId = parseInt(command.viewid);
 			this._selectedPart = command.selectedPart;
+			this._selectedMode = (command.mode !== undefined) ? command.mode : 0;
 			this._selectedParts = command.selectedParts || [command.selectedPart];
 			this._resetPreFetching(true);
 			this._update();

--- a/browser/src/layer/tile/ImpressTileLayer.js
+++ b/browser/src/layer/tile/ImpressTileLayer.js
@@ -179,6 +179,10 @@ L.ImpressTileLayer = L.CanvasTileLayer.extend({
 			command.height = parseInt(strTwips[3]);
 			command.part = this._selectedPart;
 		}
+
+		if (command.mode === undefined)
+			command.mode = this._selectedMode;
+
 		var topLeftTwips = new L.Point(command.x, command.y);
 		var offset = new L.Point(command.width, command.height);
 		var bottomRightTwips = topLeftTwips.add(offset);
@@ -193,7 +197,8 @@ L.ImpressTileLayer = L.CanvasTileLayer.extend({
 		for (var key in this._tiles) {
 			var coords = this._tiles[key].coords;
 			var bounds = this._coordsToTileBounds(coords);
-			if (coords.part === command.part && invalidBounds.intersects(bounds)) {
+			if (coords.part === command.part && invalidBounds.intersects(bounds) &&
+				coords.mode === command.mode) {
 				if (this._tiles[key]._invalidCount) {
 					this._tiles[key]._invalidCount += 1;
 				}
@@ -222,7 +227,7 @@ L.ImpressTileLayer = L.CanvasTileLayer.extend({
 			// compute the rectangle that each tile covers in the document based
 			// on the zoom level
 			coords = this._keyToTileCoords(key);
-			if (coords.part !== command.part) {
+			if (coords.part !== command.part || coords.mode !== command.mode) {
 				continue;
 			}
 			bounds = this._coordsToTileBounds(coords);
@@ -231,6 +236,7 @@ L.ImpressTileLayer = L.CanvasTileLayer.extend({
 			}
 		}
 		if (command.part === this._selectedPart &&
+			command.mode === this._selectedMode &&
 			command.part !== this._lastValidPart) {
 			this._map.fire('updatepart', {part: this._lastValidPart, docType: this._docType});
 			this._lastValidPart = command.part;

--- a/browser/src/layer/tile/TilesSection.ts
+++ b/browser/src/layer/tile/TilesSection.ts
@@ -249,7 +249,7 @@ class TilesSection {
 			this.paintSimple(tile, ctx, async);
 	}
 
-	private forEachTileInView(zoom: number, part: number, ctx: any,
+	private forEachTileInView(zoom: number, part: number, mode: number, ctx: any,
 		callback: (tile: any, coords: any) => boolean) {
 		var docLayer = this.sectionProperties.docLayer;
 		var tileRanges = ctx.paneBoundsList.map(docLayer._pxBoundsToTileRange, docLayer);
@@ -273,7 +273,8 @@ class TilesSection {
 							i * ctx.tileSize.x,
 							j * ctx.tileSize.y,
 							zoom,
-							part);
+							part,
+							mode);
 
 						var key = coords.key();
 						var tile = docLayer._tiles[key];
@@ -286,13 +287,13 @@ class TilesSection {
 		}
 	}
 
-	public haveAllTilesInView(zoom?: number, part?: number, ctx?: any): boolean {
+	public haveAllTilesInView(zoom?: number, part?: number, mode?: number, ctx?: any): boolean {
 		zoom = zoom || Math.round(this.map.getZoom());
 		part = part || this.sectionProperties.docLayer._selectedPart;
 		ctx = ctx || this.sectionProperties.tsManager._paintContext();
 
 		var allTilesLoaded = true;
-		this.forEachTileInView(zoom, part, ctx, function (tile: any): boolean {
+		this.forEachTileInView(zoom, part, mode, ctx, function (tile: any): boolean {
 			// Ensure tile is loaded.
 			if (!tile || !tile.loaded) {
 				allTilesLoaded = false;
@@ -403,12 +404,13 @@ class TilesSection {
 
 		var zoom = Math.round(this.map.getZoom());
 		var part = this.sectionProperties.docLayer._selectedPart;
+		var mode = this.sectionProperties.docLayer._selectedMode;
 
 		// Calculate all this here intead of doing it per tile.
 		var ctx = this.sectionProperties.tsManager._paintContext();
 
 		if (this.sectionProperties.tsManager.waitForTiles()) {
-			if (!this.haveAllTilesInView(zoom, part, ctx))
+			if (!this.haveAllTilesInView(zoom, part, mode, ctx))
 				return;
 		} else if (!this.containerObject.isZoomChanged()) {
 			// Don't show page border and page numbers (drawn by drawPageBackgrounds) if zoom is changing
@@ -423,7 +425,7 @@ class TilesSection {
 
 		var docLayer = this.sectionProperties.docLayer;
 		var doneTiles = new Set();
-		this.forEachTileInView(zoom, part, ctx, function (tile: any, coords: any): boolean {
+		this.forEachTileInView(zoom, part, mode, ctx, function (tile: any, coords: any): boolean {
 			if (doneTiles.has(coords.key()))
 				return true;
 
@@ -462,7 +464,7 @@ class TilesSection {
 		return Math.max(0, interSize.x) * Math.max(0, interSize.y) / (size.x * size.y);
 	}
 
-	private forEachTileInArea(area: any, zoom: number, part: number, ctx: any,
+	private forEachTileInArea(area: any, zoom: number, part: number, mode: number, ctx: any,
 		callback: (tile: any, coords: any) => boolean) {
 		var docLayer = this.sectionProperties.docLayer;
 
@@ -492,7 +494,8 @@ class TilesSection {
 					i * ctx.tileSize.x,
 					j * ctx.tileSize.y,
 					zoom,
-					part);
+					part,
+					mode);
 
 				var key = coords.key();
 				var tile = docLayer._tiles[key];
@@ -516,7 +519,7 @@ class TilesSection {
 	 * @returns the zoom-level with maximum tile content.
 	 */
 	private zoomLevelWithMaxContentInArea(area: any,
-		areaZoom: number, part: number, ctx: any): number {
+		areaZoom: number, part: number, mode: number, ctx: any): number {
 
 		var frameScale = this.sectionProperties.tsManager._zoomFrameScale;
 		var docLayer = this.sectionProperties.docLayer;
@@ -544,7 +547,7 @@ class TilesSection {
 			//console.log('DEBUG:: areaAtZoom = ' + areaAtZoom);
 			var relScale = this.map.getZoomScale(zoom, areaZoom);
 
-			this.forEachTileInArea(areaAtZoom, zoom, part, ctx, function(tile, coords) {
+			this.forEachTileInArea(areaAtZoom, zoom, part, mode, ctx, function(tile, coords) {
 				if (tile && tile.el) {
 					var tilePos = coords.getPos();
 
@@ -598,6 +601,7 @@ class TilesSection {
 		var docLayer = this.sectionProperties.docLayer;
 		var zoom = Math.round(this.map.getZoom());
 		var part = docLayer._selectedPart;
+		var mode = docLayer._selectedMode;
 		var splitPos = ctx.splitPos;
 
 		this.containerObject.setPenPosition(this);
@@ -648,7 +652,7 @@ class TilesSection {
 			var useSheetGeometry = false;
 			if (scale < 1.0) {
 				useSheetGeometry = !!sheetGeometry;
-				bestZoomSrc = this.zoomLevelWithMaxContentInArea(docRange, zoom, part, ctx);
+				bestZoomSrc = this.zoomLevelWithMaxContentInArea(docRange, zoom, part, mode, ctx);
 			}
 
 			var docRangeScaled = (bestZoomSrc == zoom) ? docRange : this.scaleBoundsForZoom(docRange, bestZoomSrc, zoom);
@@ -656,7 +660,7 @@ class TilesSection {
 			var relScale = (bestZoomSrc == zoom) ? 1 : this.map.getZoomScale(bestZoomSrc, zoom);
 
 			this.beforeDraw(canvasContext);
-			this.forEachTileInArea(docRangeScaled, bestZoomSrc, part, ctx, function (tile: any, coords: any): boolean {
+			this.forEachTileInArea(docRangeScaled, bestZoomSrc, part, mode, ctx, function (tile: any, coords: any): boolean {
 				if (!tile || !tile.loaded || !docLayer._isValidTile(coords))
 					return false;
 

--- a/browser/src/layer/tile/WriterTileLayer.js
+++ b/browser/src/layer/tile/WriterTileLayer.js
@@ -147,6 +147,7 @@ L.WriterTileLayer = L.CanvasTileLayer.extend({
 
 		this._documentInfo = textMsg;
 		this._selectedPart = 0;
+		this._selectedMode = (command.mode !== undefined) ? command.mode : 0;
 		this._parts = 1;
 		this._currentPage = command.selectedPart;
 		this._pages = command.parts;

--- a/browser/src/layer/tile/WriterTileLayer.js
+++ b/browser/src/layer/tile/WriterTileLayer.js
@@ -60,6 +60,10 @@ L.WriterTileLayer = L.CanvasTileLayer.extend({
 			command.height = parseInt(strTwips[3]);
 			command.part = this._selectedPart;
 		}
+
+		if (command.mode === undefined)
+			command.mode = this._selectedMode;
+
 		command.part = 0;
 		var topLeftTwips = new L.Point(command.x, command.y);
 		var offset = new L.Point(command.width, command.height);
@@ -75,7 +79,8 @@ L.WriterTileLayer = L.CanvasTileLayer.extend({
 		for (var key in this._tiles) {
 			var coords = this._tiles[key].coords;
 			var bounds = this._coordsToTileBounds(coords);
-			if (coords.part === command.part && invalidBounds.intersects(bounds)) {
+			if (coords.part === command.part && coords.mode === command.mode &&
+				invalidBounds.intersects(bounds)) {
 				if (this._tiles[key]._invalidCount) {
 					this._tiles[key]._invalidCount += 1;
 				}

--- a/browser/src/map/handler/Map.StateChanges.js
+++ b/browser/src/map/handler/Map.StateChanges.js
@@ -45,6 +45,7 @@ L.Map.StateChangeHandler = L.Handler.extend({
 
 		if (e.commandName === '.uno:SlideMasterPage') {
 			this._map._docLayer._masterPageChanged = true;
+			this._map._docLayer._selectedMode = (state === true || state === 'true') ? 1 : 0;
 			// clear the old tiles because they are saved in the same place
 			// since the part no will be the same for both views and it will think it is cached
 			this._map._docLayer._onMessage('invalidatetiles: EMPTY', null);

--- a/browser/src/map/handler/Map.StateChanges.js
+++ b/browser/src/map/handler/Map.StateChanges.js
@@ -49,6 +49,9 @@ L.Map.StateChangeHandler = L.Handler.extend({
 			// clear the old tiles because they are saved in the same place
 			// since the part no will be the same for both views and it will think it is cached
 			this._map._docLayer._onMessage('invalidatetiles: EMPTY', null);
+			this._map._docLayer.updateAllGraphicViewSelections();
+			this._map._docLayer.updateAllViewCursors();
+			this._map._docLayer.updateAllTextViewSelection();
 		}
 
 		if (e.commandName === '.uno:FormatPaintbrush') {

--- a/common/Unit.cpp
+++ b/common/Unit.cpp
@@ -303,16 +303,16 @@ void UnitWSD::configure(Poco::Util::LayeredConfiguration &config)
     }
 }
 
-void UnitWSD::lookupTile(int part, int width, int height, int tilePosX, int tilePosY,
+void UnitWSD::lookupTile(int part, int mode, int width, int height, int tilePosX, int tilePosY,
                          int tileWidth, int tileHeight,
                          std::shared_ptr<TileData> &tile)
 {
     if (isUnitTesting())
     {
         if (tile)
-            onTileCacheHit(part, width, height, tilePosX, tilePosY, tileWidth, tileHeight);
+            onTileCacheHit(part, mode, width, height, tilePosX, tilePosY, tileWidth, tileHeight);
         else
-            onTileCacheMiss(part, width, height, tilePosX, tilePosY, tileWidth, tileHeight);
+            onTileCacheMiss(part, mode, width, height, tilePosX, tilePosY, tileWidth, tileHeight);
     }
 }
 

--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -364,7 +364,7 @@ public:
 
     // ---------------- TileCache hooks ----------------
     /// Called before the lookupTile call returns. Should always be called to fire events.
-    virtual void lookupTile(int part, int width, int height, int tilePosX, int tilePosY,
+    virtual void lookupTile(int part, int mode, int width, int height, int tilePosX, int tilePosY,
                             int tileWidth, int tileHeight,
                             std::shared_ptr<TileData> &tile);
 
@@ -417,13 +417,16 @@ public:
     virtual void onDocBrokerDestroy(const std::string&) {}
 
     // ---------------- TileCache events ----------------
-    virtual void onTileCacheHit(int /*part*/, int /*width*/, int /*height*/,
+    virtual void onTileCacheHit(int /*part*/, int /*mode*/,
+                                int /*width*/, int /*height*/,
                                 int /*tilePosX*/, int /*tilePosY*/,
                                 int /*tileWidth*/, int /*tileHeight*/) {}
-    virtual void onTileCacheMiss(int /*part*/, int /*width*/, int /*height*/,
+    virtual void onTileCacheMiss(int /*part*/, int /*mode*/,
+                                 int /*width*/, int /*height*/,
                                  int /*tilePosX*/, int /*tilePosY*/,
                                  int /*tileWidth*/, int /*tileHeight*/) {}
-    virtual void onTileCacheSubscribe(int /*part*/, int /*width*/, int /*height*/,
+    virtual void onTileCacheSubscribe(int /*part*/, int /*mode*/,
+                                      int /*width*/, int /*height*/,
                                       int /*tilePosX*/, int /*tilePosY*/,
                                       int /*tileWidth*/, int /*tileHeight*/) {}
 private:

--- a/kit/KitHelper.hpp
+++ b/kit/KitHelper.hpp
@@ -66,6 +66,7 @@ namespace LOKitHelper
             std::ostringstream hposs;
             std::ostringstream sposs;
             std::ostringstream rtlposs;
+            std::string mode;
             for (int i = 0; i < parts; ++i)
             {
                 ptrValue = loKitDocument->pClass->getPartInfo(loKitDocument, i);
@@ -89,8 +90,17 @@ namespace LOKitHelper
                         if (prop.second == "1")
                             rtlposs << i << ',';
                     }
+                    else if (name == "mode" && mode.empty())
+                    {
+                        std::ostringstream modess;
+                        modess << prop.second;
+                        mode = modess.str();
+                    }
                 }
             }
+
+            if (!mode.empty())
+                oss << " mode=" << mode;
 
             std::string hiddenparts = hposs.str();
             if (!hiddenparts.empty())

--- a/test/TileCacheTests.cpp
+++ b/test/TileCacheTests.cpp
@@ -196,7 +196,7 @@ bool TileCacheTests::getPartFromInvalidateMessage(const std::string& message, in
         part = -1;
         return true;
     }
-    if (tokens.size() == 3 && tokens.equals(1, "EMPTY,"))
+    if ((tokens.size() == 3 || tokens.size() == 4) && tokens.equals(1, "EMPTY,"))
         return COOLProtocol::stringToInteger(tokens[2], part);
     return COOLProtocol::getTokenInteger(tokens, "part", part);
 }
@@ -205,8 +205,8 @@ void TileCacheTests::testDesc()
 {
     constexpr auto testname = __func__;
 
-    TileDesc descA = TileDesc(0, 0, 256, 256, 0, 0, 3200, 3200, /* ignored in cache */ 0, 1234, 1, true);
-    TileDesc descB = TileDesc(0, 0, 256, 256, 0, 0, 3200, 3200, /* ignored in cache */ 1, 1235, 2, false);
+    TileDesc descA = TileDesc(0, 0, 0, 256, 256, 0, 0, 3200, 3200, /* ignored in cache */ 0, 1234, 1, true);
+    TileDesc descB = TileDesc(0, 0, 0, 256, 256, 0, 0, 3200, 3200, /* ignored in cache */ 1, 1235, 2, false);
 
     TileDescCacheCompareEq pred;
     LOK_ASSERT_MESSAGE("TileDesc versions do match", descA.getVersion() != descB.getVersion());
@@ -229,13 +229,14 @@ void TileCacheTests::testSimple()
 
     int nviewid = 0;
     int part = 0;
+    int mode = 0;
     int width = 256;
     int height = 256;
     int tilePosX = 0;
     int tilePosY = 0;
     int tileWidth = 3840;
     int tileHeight = 3840;
-    TileDesc tile(nviewid, part, width, height, tilePosX, tilePosY, tileWidth, tileHeight, -1, 0, -1, false);
+    TileDesc tile(nviewid, part, mode, width, height, tilePosX, tilePosY, tileWidth, tileHeight, -1, 0, -1, false);
 
     // No Cache
     Tile tileData = tc.lookupTile(tile);
@@ -317,6 +318,7 @@ void TileCacheTests::testSize()
 
     int nviewid = 0;
     int part = 0;
+    int mode = 0;
     int width = 256;
     int height = 256;
     int tilePosX = 0;
@@ -330,7 +332,7 @@ void TileCacheTests::testSize()
     tc.setMaxCacheSize(maxSize);
     for (int tilePosY = 0; tilePosY < 20; tilePosY++)
     {
-        TileDesc tile(nviewid, part, width, height, tilePosX, tilePosY * tileHeight,
+        TileDesc tile(nviewid, part, mode, width, height, tilePosX, tilePosY * tileHeight,
                       tileWidth, tileHeight, -1, 0, -1, false);
         tile.setWireId(id++);
         tc.saveTileAndNotify(tile, data.data(), data.size());

--- a/test/UnitTileCache.cpp
+++ b/test/UnitTileCache.cpp
@@ -33,12 +33,12 @@ public:
     {
     }
 
-    virtual void lookupTile(int part, int width, int height, int tilePosX, int tilePosY,
+    virtual void lookupTile(int part, int mode, int width, int height, int tilePosX, int tilePosY,
                             int tileWidth, int tileHeight,
                             std::shared_ptr<TileData> &tile)
     {
         // Call base to fire events.
-        UnitWSD::lookupTile(part, width, height, tilePosX, tilePosY, tileWidth, tileHeight, tile);
+        UnitWSD::lookupTile(part, mode, width, height, tilePosX, tilePosY, tileWidth, tileHeight, tile);
 
         // Fail the lookup to force subscription and rendering.
         tile.reset();

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -67,6 +67,7 @@ ClientSession::ClientSession(
     _splitX(0),
     _splitY(0),
     _clientSelectedPart(-1),
+    _clientSelectedMode(0),
     _tileWidthPixel(0),
     _tileHeightPixel(0),
     _tileWidthTwips(0),
@@ -1851,6 +1852,10 @@ bool ClientSession::handleKitToClientMessage(const std::shared_ptr<Message>& pay
                     resetWireIdMap();
                 }
 
+                int mode = 0;
+                if(getTokenInteger(tokens.getParam(token), "mode", mode))
+                    _clientSelectedMode = mode;
+
                 // Get document type too
                 std::string docType;
                 if(getTokenString(tokens.getParam(token), "type", docType))
@@ -2152,7 +2157,8 @@ void ClientSession::dumpState(std::ostream& os)
        << "\n\t\tclipboardKeys[0]: " << _clipboardKeys[0]
        << "\n\t\tclipboardKeys[1]: " << _clipboardKeys[1]
        << "\n\t\tclip sockets: " << _clipSockets.size()
-       << "\n\t\tproxy access:: " << _proxyAccess;
+       << "\n\t\tproxy access:: " << _proxyAccess
+       << "\n\t\tclientSelectedMode: " << _clientSelectedMode;
 
     if (_protocol)
     {
@@ -2195,8 +2201,9 @@ void ClientSession::handleTileInvalidation(const std::string& message,
         return;
     }
 
-    std::pair<int, Util::Rectangle> result = TileCache::parseInvalidateMsg(message);
-    int part = result.first;
+    std::pair<TileCache::PartModePair, Util::Rectangle> result = TileCache::parseInvalidateMsg(message);
+    int part = result.first.first;
+    int mode = result.first.second;
     Util::Rectangle& invalidateRect = result.second;
 
     constexpr SplitPaneName panes[4] = {
@@ -2228,7 +2235,7 @@ void ClientSession::handleTileInvalidation(const std::string& message,
     int normalizedViewId = getCanonicalViewId();
 
     std::vector<TileDesc> invalidTiles;
-    if(part == _clientSelectedPart || _isTextDocument)
+    if((part == _clientSelectedPart && mode == _clientSelectedMode) || _isTextDocument)
     {
         for(int paneIdx = 0; paneIdx < numPanes; ++paneIdx)
         {
@@ -2244,7 +2251,8 @@ void ClientSession::handleTileInvalidation(const std::string& message,
                     Util::Rectangle tileRect (j * _tileWidthTwips, i * _tileHeightTwips, _tileWidthTwips, _tileHeightTwips);
                     if(invalidateRect.intersects(tileRect))
                     {
-                        TileDesc desc(normalizedViewId, part, _tileWidthPixel, _tileHeightPixel,
+                        TileDesc desc(normalizedViewId, part, mode,
+                                      _tileWidthPixel, _tileHeightPixel,
                                       j * _tileWidthTwips, i * _tileHeightTwips,
                                       _tileWidthTwips, _tileHeightTwips, -1, 0, -1, false);
 

--- a/wsd/ClientSession.hpp
+++ b/wsd/ClientSession.hpp
@@ -336,6 +336,9 @@ private:
     /// Selected part of the document viewed by the client (no parts in Writer)
     int _clientSelectedPart;
 
+    /// Selected mode of the presentation viewed by the client (in Impress)
+    int _clientSelectedMode;
+
     /// Zoom properties of the client
     int _tileWidthPixel;
     int _tileHeightPixel;

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -2755,7 +2755,7 @@ void DocumentBroker::handleTileRequest(const StringVector &tokens, bool forceKey
 
     // Forward to child to render.
     LOG_DBG("Sending render request for tile (" << tile.getPart() << ',' <<
-            tile.getTilePosX() << ',' << tile.getTilePosY() << ").");
+            tile.getEditMode() << ',' << tile.getTilePosX() << ',' << tile.getTilePosY() << ").");
     const std::string request = "tile " + tileMsg;
     _childProcess->sendTextFrame(request);
     _debugRenderedTileCount++;

--- a/wsd/TileCache.cpp
+++ b/wsd/TileCache.cpp
@@ -170,7 +170,8 @@ Tile TileCache::lookupTile(const TileDesc& tile)
 
     Tile ret = findTile(tile);
 
-    UnitWSD::get().lookupTile(tile.getPart(), tile.getWidth(), tile.getHeight(),
+    UnitWSD::get().lookupTile(tile.getPart(), tile.getEditMode(),
+                              tile.getWidth(), tile.getHeight(),
                               tile.getTilePosX(), tile.getTilePosY(),
                               tile.getTileWidth(), tile.getTileHeight(), ret);
 
@@ -283,9 +284,9 @@ Blob TileCache::lookupCachedStream(StreamType type, const std::string& name)
     return Blob();
 }
 
-void TileCache::invalidateTiles(int part, int x, int y, int width, int height, int normalizedViewId)
+void TileCache::invalidateTiles(int part, int mode, int x, int y, int width, int height, int normalizedViewId)
 {
-    LOG_TRC("Removing invalidated tiles: part: " << part <<
+    LOG_TRC("Removing invalidated tiles: part: " << part << ", mode: " << mode <<
             ", x: " << x << ", y: " << y <<
             ", width: " << width <<
             ", height: " << height <<
@@ -295,7 +296,7 @@ void TileCache::invalidateTiles(int part, int x, int y, int width, int height, i
 
     for (auto it = _cache.begin(); it != _cache.end();)
     {
-        if (intersectsTile(it->first, part, x, y, width, height, normalizedViewId))
+        if (intersectsTile(it->first, part, mode, x, y, width, height, normalizedViewId))
         {
             // FIXME: only want to keep as invalid keyframes in the view area(s)
             it->second->invalidate();
@@ -317,13 +318,15 @@ void TileCache::invalidateTiles(int part, int x, int y, int width, int height, i
 
 void TileCache::invalidateTiles(const std::string& tiles, int normalizedViewId)
 {
-    const std::pair<int, Util::Rectangle> result = TileCache::parseInvalidateMsg(tiles);
+    const std::pair<TileCache::PartModePair, Util::Rectangle> result = TileCache::parseInvalidateMsg(tiles);
     const Util::Rectangle& invalidateRect = result.second;
-    invalidateTiles(result.first, invalidateRect.getLeft(), invalidateRect.getTop(),
+    int part = result.first.first;
+    int mode = result.first.second;
+    invalidateTiles(part, mode, invalidateRect.getLeft(), invalidateRect.getTop(),
                     invalidateRect.getWidth(), invalidateRect.getHeight(), normalizedViewId);
 }
 
-std::pair<int, Util::Rectangle> TileCache::parseInvalidateMsg(const std::string& tiles)
+std::pair<TileCache::PartModePair, Util::Rectangle> TileCache::parseInvalidateMsg(const std::string& tiles)
 {
     StringVector tokens = StringVector::tokenize(tiles);
 
@@ -331,18 +334,31 @@ std::pair<int, Util::Rectangle> TileCache::parseInvalidateMsg(const std::string&
 
     if (tokens.size() == 2 && tokens.equals(1, "EMPTY"))
     {
-        return std::pair<int, Util::Rectangle>(-1, Util::Rectangle(0, 0, INT_MAX, INT_MAX));
+        return std::pair<PartModePair, Util::Rectangle>(
+            std::make_pair<int, int>(-1, 0), Util::Rectangle(0, 0, INT_MAX, INT_MAX));
     }
 
+    int mode = 0;
+    int part = 0;
     if (tokens.size() == 3 && tokens.equals(1, "EMPTY,"))
     {
-        int part = 0;
         if (stringToInteger(tokens[2], part))
-            return std::pair<int, Util::Rectangle>(part, Util::Rectangle(0, 0, INT_MAX, INT_MAX));
+            return std::pair<PartModePair, Util::Rectangle>(
+                std::make_pair(part, mode), Util::Rectangle(0, 0, INT_MAX, INT_MAX));
+    }
+    else if (tokens.size() == 4 && tokens.equals(1, "EMPTY,"))
+    {
+        if (stringToInteger(tokens[2], part))
+        {
+            if (stringToInteger(tokens[3], mode))
+            {
+                return std::pair<PartModePair, Util::Rectangle>(
+                    std::make_pair(part, mode), Util::Rectangle(0, 0, INT_MAX, INT_MAX));
+            }
+        }
     }
     else
     {
-        int part = 0;
         int x = 0;
         int y = 0;
         int width = 0;
@@ -354,35 +370,52 @@ std::pair<int, Util::Rectangle> TileCache::parseInvalidateMsg(const std::string&
             getNonNegTokenInteger(tokens[4], "width", width) &&
             getNonNegTokenInteger(tokens[5], "height", height))
         {
-            return std::pair<int, Util::Rectangle>(part, Util::Rectangle(x, y, width, height));
+            return std::pair<PartModePair, Util::Rectangle>(
+                std::make_pair(part, mode), Util::Rectangle(x, y, width, height));
+        }
+        else if (tokens.size() == 7 &&
+            getTokenInteger(tokens[1], "part", part) &&
+            getTokenInteger(tokens[2], "mode", mode) &&
+            getNonNegTokenInteger(tokens[3], "x", x) &&
+            getNonNegTokenInteger(tokens[4], "y", y) &&
+            getNonNegTokenInteger(tokens[5], "width", width) &&
+            getNonNegTokenInteger(tokens[6], "height", height))
+        {
+            return std::pair<PartModePair, Util::Rectangle>(
+                std::make_pair(part, mode), Util::Rectangle(x, y, width, height));
         }
     }
 
     LOG_ERR("Unexpected invalidatetiles request [" << tiles << "].");
-    return std::pair<int, Util::Rectangle>(-1, Util::Rectangle(0, 0, 0, 0));
+    return std::pair<PartModePair, Util::Rectangle>(
+        std::make_pair<int, int>(-1, 0), Util::Rectangle(0, 0, 0, 0));
 }
 
 std::string TileCache::cacheFileName(const TileDesc& tile)
 {
     std::ostringstream oss;
-    oss << tile.getNormalizedViewId() << '_' << tile.getPart() << '_' << tile.getWidth() << 'x' << tile.getHeight() << '.'
+    oss << tile.getNormalizedViewId() << '_' << tile.getPart() << '_' << tile.getEditMode() << '_'
+        << tile.getWidth() << 'x' << tile.getHeight() << '.'
         << tile.getTilePosX() << ',' << tile.getTilePosY() << '.'
         << tile.getTileWidth() << 'x' << tile.getTileHeight() << ".png";
     return oss.str();
 }
 
-bool TileCache::parseCacheFileName(const std::string& fileName, int& part, int& width, int& height,
+bool TileCache::parseCacheFileName(const std::string& fileName, int& part, int& mode, int& width, int& height,
                                    int& tilePosX, int& tilePosY, int& tileWidth, int& tileHeight,
                                    int& nviewid)
 {
-    return std::sscanf(fileName.c_str(), "%d_%d_%dx%d.%d,%d.%dx%d.png", &nviewid, &part, &width,
-                       &height, &tilePosX, &tilePosY, &tileWidth, &tileHeight)
+    return std::sscanf(fileName.c_str(), "%d_%d_%d_%dx%d.%d,%d.%dx%d.png", &nviewid, &part, &mode,
+                       &width, &height, &tilePosX, &tilePosY, &tileWidth, &tileHeight)
            == 8;
 }
 
-bool TileCache::intersectsTile(const TileDesc &tileDesc, int part, int x, int y, int width, int height, int normalizedViewId)
+bool TileCache::intersectsTile(const TileDesc &tileDesc, int part, int mode, int x, int y, int width, int height, int normalizedViewId)
 {
     if (part != -1 && tileDesc.getPart() != part)
+        return false;
+
+    if (mode != tileDesc.getEditMode())
         return false;
 
     if (normalizedViewId != tileDesc.getNormalizedViewId())

--- a/wsd/TileCache.hpp
+++ b/wsd/TileCache.hpp
@@ -34,7 +34,8 @@ struct TileDescCacheCompareEq final
                l.getTilePosY() == r.getTilePosY() &&
                l.getTileWidth() == r.getTileWidth() &&
                l.getTileHeight() == r.getTileHeight() &&
-               l.getNormalizedViewId() == r.getNormalizedViewId();
+               l.getNormalizedViewId() == r.getNormalizedViewId() &&
+               l.getEditMode() == r.getEditMode();
     }
 };
 
@@ -45,6 +46,7 @@ struct TileDescCacheHasher final
     {
         size_t hash = t.getPart();
 
+        hash = (hash << 5) + hash + t.getEditMode();
         hash = (hash << 5) + hash + t.getWidth();
         hash = (hash << 5) + hash + t.getHeight();
         hash = (hash << 5) + hash + t.getTilePosX();
@@ -184,6 +186,8 @@ class TileCache
     std::shared_ptr<TileBeingRendered> findTileBeingRendered(const TileDesc& tile);
 
 public:
+    typedef std::pair<int, int> PartModePair;
+
     /// When the docURL is a non-file:// url, the timestamp has to be provided by the caller.
     /// For file:// url's, it's ignored.
     /// When it is missing for non-file:// url, it is assumed the document must be read, and no cached value used.
@@ -235,7 +239,7 @@ public:
     void invalidateTiles(const std::string& tiles, int normalizedViewId);
 
     /// Parse invalidateTiles message to a part number and a rectangle of the invalidated area
-    static std::pair<int, Util::Rectangle> parseInvalidateMsg(const std::string& tiles);
+    static std::pair<PartModePair, Util::Rectangle> parseInvalidateMsg(const std::string& tiles);
 
     /// Forget the tile being rendered if it is the latest version we expect.
     void forgetTileBeingRendered(const TileDesc& descForKitReply,
@@ -263,16 +267,19 @@ private:
     void ensureCacheSize();
     static size_t itemCacheSize(const Tile &tile);
 
-    void invalidateTiles(int part, int x, int y, int width, int height, int normalizedViewId);
+    void invalidateTiles(int part, int mode, int x, int y, int width, int height, int normalizedViewId);
 
     /// Lookup tile in our cache.
     Tile findTile(const TileDesc &desc);
 
     static std::string cacheFileName(const TileDesc& tileDesc);
-    static bool parseCacheFileName(const std::string& fileName, int& part, int& width, int& height, int& tilePosX, int& tilePosY, int& tileWidth, int& tileHeight, int& nviewid);
+    static bool parseCacheFileName(const std::string& fileName, int& part, int& mode,
+                                   int& width, int& height, int& tilePosX, int& tilePosY,
+                                   int& tileWidth, int& tileHeight, int& nviewid);
 
     /// Extract location from fileName, and check if it intersects with [x, y, width, height].
-    static bool intersectsTile(const TileDesc &tileDesc, int part, int x, int y, int width, int height, int normalizedViewId);
+    static bool intersectsTile(const TileDesc &tileDesc, int part, int mode, int x, int y,
+                               int width, int height, int normalizedViewId);
 
     Tile saveDataToCache(const TileDesc& desc, const char* data, size_t size);
     void saveDataToStreamCache(StreamType type, const std::string& fileName, const char* data,

--- a/wsd/TileDesc.hpp
+++ b/wsd/TileDesc.hpp
@@ -26,11 +26,11 @@ using TileBinaryHash = uint64_t;
 class TileDesc final
 {
 public:
-    TileDesc(int normalizedViewId, int part, int width, int height, int tilePosX, int tilePosY, int tileWidth,
+    TileDesc(int normalizedViewId, int part, int mode, int width, int height, int tilePosX, int tilePosY, int tileWidth,
              int tileHeight, int ver, int imgSize, int id, bool broadcast)
         : _normalizedViewId(normalizedViewId)
         , _part(part)
-        , _mode(0) // TODO
+        , _mode(mode)
         , _width(width)
         , _height(height)
         , _tilePosX(tilePosX)
@@ -94,7 +94,8 @@ public:
                _tileHeight == other._tileHeight &&
                _id == other._id &&
                _broadcast == other._broadcast &&
-               _normalizedViewId == other._normalizedViewId;
+               _normalizedViewId == other._normalizedViewId &&
+               _mode == other._mode;
     }
 
     static bool rectanglesIntersect(int x1, int y1, int w1, int h1, int x2, int y2, int w2, int h2)
@@ -119,6 +120,7 @@ public:
     bool isAdjacent(const TileDesc& other) const
     {
         if (other.getPart() != getPart() ||
+            other.getEditMode() != getEditMode() ||
             other.getWidth() != getWidth() ||
             other.getHeight() != getHeight() ||
             other.getTileWidth() != getTileWidth() ||
@@ -133,6 +135,7 @@ public:
     bool onSameRow(const TileDesc& other) const
     {
         if (other.getPart() != getPart() ||
+            other.getEditMode() != getEditMode() ||
             other.getWidth() != getWidth() ||
             other.getHeight() != getHeight() ||
             other.getTileWidth() != getTileWidth() ||
@@ -194,6 +197,11 @@ public:
             oss << " broadcast=yes";
         }
 
+        if (_mode)
+        {
+            oss << " mode=" << _mode;
+        }
+
         oss << suffix;
         return oss.str();
     }
@@ -217,6 +225,7 @@ public:
         pairs["ver"] = -1;
         pairs["imgsize"] = 0;
         pairs["id"] = -1;
+        pairs["mode"] = 0;
 
         TileWireId oldWireId = 0;
         TileWireId wireId = 0;
@@ -241,7 +250,8 @@ public:
         const bool broadcast = (COOLProtocol::getTokenString(tokens, "broadcast", s) &&
                                 s == "yes");
 
-        TileDesc result(pairs["nviewid"], pairs["part"], pairs["width"], pairs["height"],
+        TileDesc result(pairs["nviewid"], pairs["part"], pairs["mode"],
+                        pairs["width"], pairs["height"],
                         pairs["tileposx"], pairs["tileposy"],
                         pairs["tilewidth"], pairs["tileheight"],
                         pairs["ver"],
@@ -269,7 +279,7 @@ public:
 private:
     int _normalizedViewId;
     int _part;
-    int _mode;
+    int _mode; //< Used in Impress for EditMode::(Page|MasterPage), 0 = default
     int _width;
     int _height;
     int _tilePosX;
@@ -290,7 +300,7 @@ private:
 class TileCombined final
 {
 private:
-    TileCombined(int normalizedViewId, int part, int width, int height,
+    TileCombined(int normalizedViewId, int part, int mode, int width, int height,
                  const std::string& tilePositionsX, const std::string& tilePositionsY,
                  int tileWidth, int tileHeight, const std::string& vers,
                  const std::string& imgSizes,
@@ -298,12 +308,14 @@ private:
                  const std::string& wireIds) :
         _normalizedViewId(normalizedViewId),
         _part(part),
+        _mode(mode),
         _width(width),
         _height(height),
         _tileWidth(tileWidth),
         _tileHeight(tileHeight)
     {
         if (_part < 0 ||
+            _mode < 0 ||
             _width <= 0 ||
             _height <= 0 ||
             _tileWidth <= 0 ||
@@ -369,7 +381,7 @@ private:
                 throw BadArgumentException("Invalid tilecombine descriptor.");
             }
 
-            _tiles.emplace_back(_normalizedViewId, _part, _width, _height, x, y, _tileWidth, _tileHeight, ver, imgSize, -1, false);
+            _tiles.emplace_back(_normalizedViewId, _part, _mode, _width, _height, x, y, _tileWidth, _tileHeight, ver, imgSize, -1, false);
             _tiles.back().setOldWireId(oldWireId);
             _tiles.back().setWireId(wireId);
         }
@@ -378,6 +390,7 @@ private:
 public:
     int getNormalizedViewId() const { return _normalizedViewId; }
     int getPart() const { return _part; }
+    int getEditMode() const { return _mode; }
     int getWidth() const { return _width; }
     int getHeight() const { return _height; }
     int getTileWidth() const { return _tileWidth; }
@@ -402,6 +415,7 @@ public:
         {
             const auto &a = _tiles[i];
             assert(a.getPart() == _part);
+            assert(a.getEditMode() == _mode);
             assert(a.getWidth() == _width);
             assert(a.getHeight() == _height);
             assert(a.getTileWidth() == _tileWidth);
@@ -484,6 +498,9 @@ public:
             comma = true;
         }
 
+        if (_mode)
+            oss << " mode=" << _mode;
+
         oss << suffix;
         return oss.str();
     }
@@ -543,7 +560,8 @@ public:
             }
         }
 
-        return TileCombined(pairs["nviewid"], pairs["part"], pairs["width"], pairs["height"],
+        return TileCombined(pairs["nviewid"], pairs["part"], pairs["mode"],
+                            pairs["width"], pairs["height"],
                             tilePositionsX, tilePositionsY,
                             pairs["tilewidth"], pairs["tileheight"],
                             versions, imgSizes, oldwireIds, wireIds);
@@ -575,7 +593,8 @@ public:
         }
 
         vers.seekp(-1, std::ios_base::cur); // Remove last comma.
-        return TileCombined(tiles[0].getNormalizedViewId(), tiles[0].getPart(), tiles[0].getWidth(), tiles[0].getHeight(),
+        return TileCombined(tiles[0].getNormalizedViewId(), tiles[0].getPart(), tiles[0].getEditMode(),
+                            tiles[0].getWidth(), tiles[0].getHeight(),
                             xs.str(), ys.str(), tiles[0].getTileWidth(), tiles[0].getTileHeight(),
                             vers.str(), "", oldhs.str(), hs.str());
     }
@@ -584,6 +603,7 @@ public:
     explicit TileCombined(const TileDesc &desc)
     {
         _part = desc.getPart();
+        _mode = desc.getEditMode();
         _width = desc.getWidth();
         _height = desc.getHeight();
         _tileWidth = desc.getTileWidth();
@@ -596,6 +616,7 @@ private:
     std::vector<TileDesc> _tiles;
     int _normalizedViewId;
     int _part;
+    int _mode;
     int _width;
     int _height;
     int _tileWidth;

--- a/wsd/TileDesc.hpp
+++ b/wsd/TileDesc.hpp
@@ -30,6 +30,7 @@ public:
              int tileHeight, int ver, int imgSize, int id, bool broadcast)
         : _normalizedViewId(normalizedViewId)
         , _part(part)
+        , _mode(0) // TODO
         , _width(width)
         , _height(height)
         , _tilePosX(tilePosX)
@@ -45,6 +46,7 @@ public:
     {
         if (_normalizedViewId < 0 ||
             _part < 0 ||
+            _mode < 0 ||
             _width <= 0 ||
             _height <= 0 ||
             _tilePosX < 0 ||
@@ -60,6 +62,7 @@ public:
     int getNormalizedViewId() const { return _normalizedViewId; }
     void setNormalizedViewId(const int normalizedViewId) { _normalizedViewId = normalizedViewId; }
     int getPart() const { return _part; }
+    int getEditMode() const { return _mode; }
     int getWidth() const { return _width; }
     int getHeight() const { return _height; }
     int getTilePosX() const { return _tilePosX; }
@@ -199,7 +202,7 @@ public:
     std::string debugName() const
     {
         std::ostringstream oss;
-        oss << '(' << getNormalizedViewId() << ',' << getPart() << ',' << getTilePosX() << ',' << getTilePosY() << ')';
+        oss << '(' << getNormalizedViewId() << ',' << getPart() << ',' << getEditMode() << ',' << getTilePosX() << ',' << getTilePosY() << ')';
         return oss.str();
     }
 
@@ -258,14 +261,15 @@ public:
     std::string generateID() const
     {
         std::ostringstream tileID;
-        tileID << getPart() << ':' << getTilePosX() << ':' << getTilePosY() << ':'
-               << getTileWidth() << ':' << getTileHeight() << ':' << getNormalizedViewId();
+        tileID << getPart() << ':' << getEditMode() << ':' << getTilePosX() << ':' << getTilePosY()
+                << ':' << getTileWidth() << ':' << getTileHeight() << ':' << getNormalizedViewId();
         return tileID.str();
     }
 
 private:
     int _normalizedViewId;
     int _part;
+    int _mode;
     int _width;
     int _height;
     int _tilePosX;


### PR DESCRIPTION
It is needed for Impress Master Page mode to provide different types of tile for the same part.

// Idea here is to keep CI green, this change doesn't change behaviour - it added optional 'mode' parameter for different tile commands with default/ignored value 0.