### PR TITLE
private/pedro/cleanup buttons

### DIFF
--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -24,8 +24,8 @@ button.jsdialog img {
 	flex-wrap: wrap;
 }
 
-[class*='button-secondary'],
-.vex.vex-theme-plain .vex-dialog-button.vex-dialog-button-secondary {
+.button-secondary,
+button:not(.ui-corner-all):not(.button-primary) {
 	box-sizing: border-box;
 	height: 32px;
 	line-height: 0em;
@@ -40,20 +40,15 @@ button.jsdialog img {
 	vertical-align: middle;
 }
 
-[class*='button-secondary']:hover,
-.ui-pushbutton.jsdialog:not(#ok):not(.sidebar):hover,
-.ui-button-box.jsdialog #cancel:hover,
-.cell.jsdialog > button:not(#ok):hover,
-.ui-button-box.jsdialog button:not(#ok):hover,
-.vex.vex-theme-plain .vex-dialog-button.vex-dialog-button-secondary:hover {
+.button-secondary:hover,
+button:not(.ui-corner-all):not(.button-primary):hover {
 	cursor: pointer;
 	color: var(--color-text-darker) !important;
 	background-color: var(--color-background-lighter) !important;
 	border: 1px solid var(--color-border-darker);
 }
 
-[class*='button-primary'],
-.vex.vex-theme-plain .vex-dialog-button.vex-dialog-button-primary {
+.button-primary {
 	height: 32px;
 	line-height: 0em;
 	color: var(--color-primary-text);
@@ -65,7 +60,7 @@ button.jsdialog img {
 	vertical-align: middle;
 }
 
-[class*='button-primary']:hover {
+.button-primary:hover {
 	background-color: var(--color-primary-lighter);
 }
 

--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -1,3 +1,5 @@
+/* For btns hover status see device-desktop.css */
+
 .jsdialog-container .ui-button-box button,
 .vex.vex-theme-plain .vex-dialog-button {
 	font-family: var(--jquery-ui-font);
@@ -40,14 +42,6 @@ button:not(.ui-corner-all):not(.button-primary) {
 	vertical-align: middle;
 }
 
-.button-secondary:hover,
-button:not(.ui-corner-all):not(.button-primary):hover {
-	cursor: pointer;
-	color: var(--color-text-darker) !important;
-	background-color: var(--color-background-lighter) !important;
-	border: 1px solid var(--color-border-darker);
-}
-
 .button-primary {
 	height: 32px;
 	line-height: 0em;
@@ -58,10 +52,6 @@ button:not(.ui-corner-all):not(.button-primary):hover {
 	border-radius: var(--border-radius);
 	margin: 5px;
 	vertical-align: middle;
-}
-
-.button-primary:hover {
-	background-color: var(--color-primary-lighter);
 }
 
 .vex.vex-theme-plain .vex-dialog-form .vex-dialog-buttons {

--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -4,13 +4,6 @@
 	text-transform: full-size-kana;
 }
 
-button.jsdialog {
-	color: var(--color-main-text);
-	background-color: var(--color-main-background);
-	border: 1px solid var(--color-btn-border);
-	border-radius: var(--border-radius);
-	box-sizing: border-box;
-}
 .jsdialog *[disabled] {
 	color: var(--color-text-lighter);
 	border: 1px solid var(--color-btn-border-dis);
@@ -32,17 +25,15 @@ button.jsdialog img {
 }
 
 [class*='button-secondary'],
-.ui-pushbutton.jsdialog:not(#ok):not([id*='select_current']):not(.sidebar),
-.ui-button-box.jsdialog #cancel,
-.cell.jsdialog > button:not(#ok),
-.ui-button-box.jsdialog button:not(#ok),
 .vex.vex-theme-plain .vex-dialog-button.vex-dialog-button-secondary {
+	box-sizing: border-box;
 	height: 32px;
 	line-height: 0em;
 	color: var(--color-main-text);
 	font-size: var(--default-font-size);
 	min-width: 62px;
 	background-color: var(--color-background-dark);
+	border: 1px solid var(--color-btn-border);
 	border: 1px solid var(--color-border-dark);
 	border-radius: var(--border-radius);
 	margin: 5px;
@@ -61,10 +52,7 @@ button.jsdialog img {
 	border: 1px solid var(--color-border-darker);
 }
 
-.ui-button-box.jsdialog #ok,
 [class*='button-primary'],
-.cell.jsdialog > button,
-.ui-button-box.jsdialog button,
 .vex.vex-theme-plain .vex-dialog-button.vex-dialog-button-primary {
 	height: 32px;
 	line-height: 0em;
@@ -77,9 +65,6 @@ button.jsdialog img {
 	vertical-align: middle;
 }
 
-button#ok:hover,
-.cell.jsdialog > button:hover,
-.ui-button-box.jsdialog button:hover,
 [class*='button-primary']:hover {
 	background-color: var(--color-primary-lighter);
 }

--- a/browser/css/device-desktop.css
+++ b/browser/css/device-desktop.css
@@ -22,3 +22,18 @@
 #lokit-version > span:after {
 	content: ')';
 }
+
+/* btns hover status
+   Rules not intended for touch devices */
+
+.button-secondary:hover,
+button:not(.ui-corner-all):not(.button-primary):hover {
+	cursor: pointer;
+	color: var(--color-text-darker) !important;
+	background-color: var(--color-background-lighter) !important;
+	border: 1px solid var(--color-border-darker);
+}
+
+.button-primary:hover {
+	background-color: var(--color-primary-lighter);
+}

--- a/browser/css/device-mobile.css
+++ b/browser/css/device-mobile.css
@@ -345,13 +345,13 @@ textarea.cool-annotation-textarea {
 	min-width: -webkit-fill-available !important;
 	min-width: fill-available !important;
 }
-button.vex-dialog-button-primary.vex-dialog-button.vex-first {
+button.button-primary.vex-dialog-button.vex-first {
 	border: 1px solid var(--color-primary) !important;
 	border-radius: var(--border-radius) !important;
 	background-color: var(--color-primary-lighter) !important;
 	color: var(--color-primary-text) !important;
 }
-button.vex-dialog-button-secondary.vex-dialog-button.vex-last {
+button.button-secondary.vex-dialog-button.vex-last {
 	border-radius: var(--border-radius);
 	background-color: var(--color-background-lighter) !important;
 	border: 1px solid var(--color-border-lighter) !important;
@@ -372,7 +372,7 @@ button.vex-dialog-button-secondary.vex-dialog-button.vex-last {
 	padding: 0;
 }
 
-.vex-welcome-mobile .vex-dialog-button-primary {
+.vex-welcome-mobile .button-primary {
 	width: 100%;
 }
 /* Vex: Document document conflict */

--- a/browser/css/device-mobile.css
+++ b/browser/css/device-mobile.css
@@ -941,3 +941,22 @@ div#fontstyletoolbox + div#style.mobile-wizard {
 	margin: 2px;
 	font-size: 29px;
 }
+
+/* Mobile specific buttons */
+.mobile-wizard-titlebar-btn {
+	height: 24px !important;
+	display: block;
+	text-align: center;
+	margin: 0 8px 0 0 !important;
+	padding: 0 !important;
+	min-width: 24px !important;
+	width: 24px !important;
+	border-radius: 50% !important;
+	background-color: var(--color-primary) !important;
+}
+
+.mobile-wizard-titlebar-btn-container{
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+}

--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -151,9 +151,6 @@
 #masterslidebutton {
 	line-height: 22px;
 	min-width: 121px;
-	border: 1px solid var(--color-border);
-	border-radius: var(--border-radius);
-	color: var(--color-main-text);
 }
 
 div#negativenumbersred.checkbutton.jsdialog.sidebar,

--- a/browser/css/mobilewizard.css
+++ b/browser/css/mobilewizard.css
@@ -1049,14 +1049,6 @@ label.disabled {
 
 /* Annotations - comments */
 
-#insert_comment {
-	right: 0px;
-	position: absolute;
-	top: 20%;
-	height: initial !important;
-	width: initial !important;
-}
-
 #mobile-wizard-popup .cool-annotation-content-author,
 #mobile-wizard .cool-annotation-content-author {
 	font-weight: bold;

--- a/browser/css/override-vex.css
+++ b/browser/css/override-vex.css
@@ -90,7 +90,7 @@
 	flex-direction: row;
 	justify-content: space-between;
 }
-.vex-content.vex-3btns .vex-dialog-buttons > button:not(.vex-dialog-button-secondary) {
+.vex-content.vex-3btns .vex-dialog-buttons > button:not(.button-secondary) {
 	flex: 1;
 }
 .vex.vex-theme-plain .vex-content,
@@ -242,14 +242,14 @@ kbd,
 	height: 288px;
 }
 
-.vex.vex-theme-plain .vex-content.vex-locking .vex-dialog-button-primary {
+.vex.vex-theme-plain .vex-content.vex-locking .button-primary {
 	background-color: var(--color-primary);
 	color: var(--color-primary-text);
 	border-color: var(--color-primary-dark);
 	text-shadow: 0 0 8px var(--color-primary-dark);
 }
 
-.vex.vex-theme-plain .vex-content.vex-locking .vex-dialog-button-primary:hover {
+.vex.vex-theme-plain .vex-content.vex-locking .button-primary:hover {
 	border-color: var(--color-primary-darker) !important;
 	background-color: var(--color-primary-darker);
 	color: var(--color-primary-text);
@@ -284,7 +284,7 @@ kbd,
 	height: 238px;
 	background-position: center;
 }
-.vex.vex-theme-plain .vex-content.vex-locking.mobile .vex-dialog-button-primary {
+.vex.vex-theme-plain .vex-content.vex-locking.mobile .button-primary {
 	background-color: #fda918 !important;
 	border-color: #cc8202 !important;
 	text-shadow: 0 0 0.5px #cc8202;

--- a/browser/css/override-vex.css
+++ b/browser/css/override-vex.css
@@ -91,7 +91,7 @@
 	justify-content: space-between;
 }
 .vex-content.vex-3btns .vex-dialog-buttons > button:not(.button-secondary) {
-	flex: 1;
+	flex: 1 auto;
 }
 .vex.vex-theme-plain .vex-content,
 .vex-dialog-message {

--- a/browser/js/vex.combined.js
+++ b/browser/js/vex.combined.js
@@ -1076,7 +1076,6 @@ var buttonsToDOM = function buttonsToDOM (buttons) {
     domButton.type = button.type
     domButton.textContent = button.text
     domButton.className = button.className
-    domButton.classList.add('vex-dialog-button')
     if (i === 0) {
       domButton.classList.add('vex-first')
     } else if (i === buttons.length - 1) {
@@ -1213,7 +1212,7 @@ var plugin = function plugin (vex) {
     YES: {
       text: 'OK',
       type: 'submit',
-      className: 'vex-dialog-button-primary',
+      className: 'button-primary',
       click: function yesClick () {
         this.value = true
       }
@@ -1222,7 +1221,7 @@ var plugin = function plugin (vex) {
     NO: {
       text: 'Cancel',
       type: 'button',
-      className: 'vex-dialog-button-secondary',
+      className: 'button-secondary',
       click: function noClick () {
         this.value = false
         this.close()

--- a/browser/src/control/Control.AlertDialog.js
+++ b/browser/src/control/Control.AlertDialog.js
@@ -24,7 +24,7 @@ L.Control.AlertDialog = L.Control.extend({
 				buttonsList.push({
 					text: _('Close'),
 					type: 'button',
-					className: 'vex-dialog-button-primary',
+					className: 'button-primary',
 					click: function() {
 						window.postMobileMessage('BYE');
 						vex.closeAll();
@@ -65,7 +65,7 @@ L.Control.AlertDialog = L.Control.extend({
 				buttonsList.push({
 					text: _('Open link'),
 					type: 'button',
-					className: 'vex-dialog-button-primary',
+					className: 'button-primary',
 					click: function() {
 						if ('processCoolUrl' in window) {
 							url = window.processCoolUrl({ url: url, type: 'doc' });

--- a/browser/src/control/Control.Command.js
+++ b/browser/src/control/Control.Command.js
@@ -89,8 +89,8 @@ L.Map.include({
 					window.open(that.Locking.unlockLink, '_blank');
 			},
 			buttons: [
-				$.extend({}, vex.dialog.buttons.YES, { text: _('Unlock') }),
-				$.extend({}, vex.dialog.buttons.NO, { text: _('Cancel') })
+				$.extend({}, vex.dialog.buttons.NO, { text: _('Cancel') }),
+				$.extend({}, vex.dialog.buttons.YES, { text: _('Unlock') })
 			]
 		});
 

--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -1758,8 +1758,8 @@ L.Control.Menubar = L.Control.extend({
 			vex.dialog.open({
 				message: msg,
 				buttons: [
-					$.extend({}, vex.dialog.buttons.YES, { text: _('OK') }),
-					$.extend({}, vex.dialog.buttons.NO, { text: _('Cancel') })
+					$.extend({}, vex.dialog.buttons.NO, { text: _('Cancel') }),
+					$.extend({}, vex.dialog.buttons.YES, { text: _('OK') })
 				],
 				callback: function(e) {
 					if (e === true) {

--- a/browser/src/control/Control.PresentationBar.js
+++ b/browser/src/control/Control.PresentationBar.js
@@ -106,8 +106,8 @@ L.Control.PresentationBar = L.Control.extend({
 			vex.dialog.confirm({
 				message: msg,
 				buttons: [
+					$.extend({}, vex.dialog.buttons.NO, { text: _('Cancel') }),
 					$.extend({}, vex.dialog.buttons.YES, { text: _('OK') }),
-					$.extend({}, vex.dialog.buttons.NO, { text: _('Cancel') })
 				],
 				callback: this.onDelete.bind(this)
 			});

--- a/browser/src/control/Control.Tabs.js
+++ b/browser/src/control/Control.Tabs.js
@@ -302,8 +302,8 @@ L.Control.Tabs = L.Control.extend({
 		vex.dialog.confirm({
 			message: _('Are you sure you want to delete sheet, %sheet%?').replace('%sheet%', $('#spreadsheet-tab' + this._tabForContextMenu).text()),
 			buttons: [
-				$.extend({}, vex.dialog.buttons.YES, { text: _('OK') }),
-				$.extend({}, vex.dialog.buttons.NO, { text: _('Cancel') })
+				$.extend({}, vex.dialog.buttons.NO, { text: _('Cancel') }),
+				$.extend({}, vex.dialog.buttons.YES, { text: _('OK') })
 			],
 			callback: function(data) {
 				if (data) {
@@ -320,8 +320,8 @@ L.Control.Tabs = L.Control.extend({
 			contentClassName: 'vex-has-inputs',
 			message: _('Enter new sheet name'),
 			buttons: [
-				$.extend({}, vex.dialog.buttons.YES, { text: _('OK') }),
-				$.extend({}, vex.dialog.buttons.NO, { text: _('Cancel') })
+				$.extend({}, vex.dialog.buttons.NO, { text: _('Cancel') }),
+				$.extend({}, vex.dialog.buttons.YES, { text: _('OK') })
 			],
 			input: '<input name="sheetname" id="rename-calc-sheet-modal" type="text" value="' + $('#spreadsheet-tab' + this._tabForContextMenu).text() + '" required />',
 			afterOpen: function() { document.getElementById('rename-calc-sheet-modal').select(); },

--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -872,14 +872,14 @@ app.definitions.Socket = L.Class.extend({
 				var dialogButtons = [
 					$.extend({}, vex.dialog.buttons.YES, {
 						text: _('Discard'),
-						className: 'vex-dialog-button-secondary',
+						className: 'button-secondary',
 						click: function() {
 							this.value = 'discard';
 							this.close();
 						}}),
 					$.extend({}, vex.dialog.buttons.YES, {
 						text: _('Overwrite'),
-						className: 'vex-dialog-button-secondary',
+						className: 'button-secondary',
 						click: function() {
 							this.value = 'overwrite';
 							this.close();
@@ -894,14 +894,14 @@ app.definitions.Socket = L.Class.extend({
 					dialogButtons.push(
 						$.extend({}, vex.dialog.buttons.YES, {
 							text: _('Save to new file'),
-							className: 'vex-dialog-button-primary',
+							className: 'button-primary',
 							click: function() {
 								this.value = 'saveas';
 								this.close();
 							}}),
 						$.extend({}, vex.dialog.buttons.YES, {
 							text: _('Cancel'),
-							className: 'vex-dialog-button-secondary vex-dialog-button-cancel',
+							className: 'button-secondary vex-dialog-button-cancel',
 							click: function() {
 								this.value = 'cancel';
 								this.close();
@@ -911,7 +911,7 @@ app.definitions.Socket = L.Class.extend({
 					dialogButtons.push(
 						$.extend({}, vex.dialog.buttons.YES, {
 							text: _('Cancel'),
-							className: 'vex-dialog-button-primary vex-dialog-button-cancel',
+							className: 'button-primary vex-dialog-button-cancel',
 							click: function() {
 								this.value = 'cancel';
 								this.close();

--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -1040,8 +1040,8 @@ app.definitions.Socket = L.Class.extend({
 					message: msg,
 					input: '<input name="password" type="password" required />',
 					buttons: [
-						$.extend({}, vex.dialog.buttons.YES, { text: _('OK') }),
-						$.extend({}, vex.dialog.buttons.NO, { text: _('Cancel') })
+						$.extend({}, vex.dialog.buttons.NO, { text: _('Cancel') }),
+						$.extend({}, vex.dialog.buttons.YES, { text: _('OK') })
 					],
 					callback: L.bind(function(data) {
 						if (data) {

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -5004,9 +5004,11 @@ L.CanvasTileLayer = L.Layer.extend({
 	/// onlyThread - takes annotation indicating which thread will be generated
 	getCommentWizardStructure: function(menuStructure, onlyThread) {
 		var customTitleBar = L.DomUtil.create('div');
+		L.DomUtil.addClass(customTitleBar, 'mobile-wizard-titlebar-btn-container');
 		var title = L.DomUtil.create('span', '', customTitleBar);
 		title.innerText = _('Comment');
 		var button = L.DomUtil.createWithId('button', 'insert_comment', customTitleBar);
+		L.DomUtil.addClass(button, 'mobile-wizard-titlebar-btn');
 		button.innerText = '+';
 		button.onclick = this._map.insertComment.bind(this._map);
 

--- a/browser/src/layer/tile/CommentListSection.ts
+++ b/browser/src/layer/tile/CommentListSection.ts
@@ -395,8 +395,8 @@ class CommentSection {
 				'<textarea name="comment" id="new-mobile-comment-input-area" class="cool-annotation-textarea" required>' + (commentData.text && isMod ? commentData.text: '') + '</textarea>'
 			].join(''),
 			buttons: [
-				$.extend({}, vex.dialog.buttons.YES, { text: _('Save') }),
-				$.extend({}, vex.dialog.buttons.NO, { text: _('Cancel') })
+				$.extend({}, vex.dialog.buttons.NO, { text: _('Cancel') }),
+				$.extend({}, vex.dialog.buttons.YES, { text: _('Save') })
 			],
 			callback: function (data: any) {
 				if (data) {

--- a/cypress_test/integration_tests/common/desktop_helper.js
+++ b/cypress_test/integration_tests/common/desktop_helper.js
@@ -182,11 +182,11 @@ function doZoom(zoomIn) {
 		});
 
 	if (zoomIn) {
-		cy.get('.w2ui-tb-image.w2ui-icon.zoomin')
-			.click();
+		cy.get('.w2ui-tb-image.w2ui-icon.zoomin').click({force: true});
+		cy.wait(500);
 	} else {
-		cy.get('.w2ui-tb-image.w2ui-icon.zoomout')
-			.click();
+		cy.get('.w2ui-tb-image.w2ui-icon.zoomout').click({force: true});
+		cy.wait(500);
 	}
 
 	cy.get('#tb_actionbar_item_zoom .w2ui-tb-caption')

--- a/cypress_test/integration_tests/common/desktop_helper.js
+++ b/cypress_test/integration_tests/common/desktop_helper.js
@@ -322,7 +322,7 @@ function insertMultipleComment(docType, numberOfComments = 1, isMobile = false) 
 		if (isMobile) {
 			cy.get('#new-mobile-comment-input-area').type('some text' + n);
 
-			cy.get('.vex-dialog-button-primary').click();
+			cy.get('.vex-dialog-buttons .button-primary').click();
 		} else {
 			cy.get('#annotation-modify-textarea-new').type('some text' + n);
 

--- a/cypress_test/integration_tests/common/desktop_helper.js
+++ b/cypress_test/integration_tests/common/desktop_helper.js
@@ -386,6 +386,7 @@ module.exports.hideSidebarIfVisible = hideSidebarIfVisible;
 module.exports.selectColorFromPalette = selectColorFromPalette;
 module.exports.selectFromListbox = selectFromListbox;
 module.exports.checkDialogAndClose = checkDialogAndClose;
+module.exports.makeZoomItemsVisible = makeZoomItemsVisible;
 module.exports.zoomIn = zoomIn;
 module.exports.zoomOut = zoomOut;
 module.exports.shouldHaveZoomLevel = shouldHaveZoomLevel;

--- a/cypress_test/integration_tests/common/mobile_helper.js
+++ b/cypress_test/integration_tests/common/mobile_helper.js
@@ -173,7 +173,7 @@ function executeCopyFromContextMenu(XPos, YPos) {
 		.click();
 
 	// Close warning about clipboard operations
-	cy.get('.vex-dialog-button-primary.vex-dialog-button')
+	cy.get('.vex-dialog-buttons .button-primary')
 		.click();
 
 	// Wait until it's closed
@@ -337,7 +337,7 @@ function insertComment() {
 
 	cy.get('#new-mobile-comment-input-area').type('some text');
 
-	cy.get('.vex-dialog-button-primary').click();
+	cy.get('.vex-dialog-buttons .button-primary').click();
 
 	cy.get('#comment-container-1').should('exist')
 		.wait(300);

--- a/cypress_test/integration_tests/desktop/calc/bottom_bar_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/bottom_bar_spec.js
@@ -2,6 +2,7 @@
 
 var helper = require('../../common/helper');
 var calcHelper = require('../../common/calc_helper');
+var desktophelper = require('../../common/desktop_helper');
 
 describe('Calc bottom bar tests.', function() {
 	var origTestFileName = 'BottomBar.ods';
@@ -18,6 +19,7 @@ describe('Calc bottom bar tests.', function() {
 	it('Bottom tool bar.', function() {
 		cy.get('#map').focus();
 		calcHelper.clickOnFirstCell();
+		desktophelper.makeZoomItemsVisible();
 		cy.get('#tb_actionbar_item_StateTableCellMenu .w2ui-button').click();
 		// If it clicks, it passes.
 		cy.contains('.w2ui-drop-menu .menu-text', 'CountA').click();

--- a/cypress_test/integration_tests/desktop/calc/sheet_operation_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/sheet_operation_spec.js
@@ -22,7 +22,7 @@ describe('Sheet Operations.', function () {
 	function clickVexDialogButton(buttonText) {
 		cy.get('.vex-content').should('exist');
 
-		cy.contains('button.vex-dialog-button', buttonText)
+		cy.contains('.vex-dialog-buttons button', buttonText)
 			.click();
 	}
 

--- a/cypress_test/integration_tests/desktop/impress/slide_operations_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/slide_operations_spec.js
@@ -32,7 +32,7 @@ describe('Slide operations', function() {
 			.should('not.have.class', 'disabled')
 			.click();
 
-		cy.get('.vex-dialog-button-primary').click();
+		cy.get('.vex-dialog-buttons .button-primary').click();
 
 		cy.get('#tb_presentation-toolbar_item_deletepage')
 			.should('have.class', 'disabled');

--- a/cypress_test/integration_tests/desktop/writer/help_dialog_update_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/help_dialog_update_spec.js
@@ -89,7 +89,7 @@ describe('Help dialog screenshot updation', function() {
 
 		cy.get('#new-mobile-comment-input-area').type('comment added');
 
-		cy.get('.vex-dialog-button-primary').click();
+		cy.get('.vex-dialog-buttons .button-primary').click();
 
 		cy.wait(1000);
 

--- a/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
@@ -339,7 +339,7 @@ describe('Top toolbar tests.', function() {
 		cy.get('#hyperlink-link-box')
 			.type('www.something.com');
 
-		cy.get('.vex-dialog-button-primary.vex-dialog-button')
+		cy.get('.vex-dialog-buttons .button-primary')
 			.click();
 
 		writerHelper.selectAllTextOfDoc();

--- a/cypress_test/integration_tests/mobile/calc/annotation_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/annotation_spec.js
@@ -54,7 +54,7 @@ describe('Annotation Tests',function() {
 
 		cy.get('#new-mobile-comment-input-area').type('modified ');
 
-		cy.get('.vex-dialog-button-primary').click();
+		cy.get('.vex-dialog-buttons .button-primary').click();
 
 		cy.get('#comment-container-1').should('exist');
 
@@ -87,10 +87,10 @@ describe('Annotation Tests',function() {
 		cy.get('.cool-annotation-textarea')
 			.should('have.text', '');
 
-		cy.get('.vex-dialog-button-primary')
+		cy.get('.vex-dialog-buttons .button-primary')
 			.click();
 
-		cy.get('.vex-dialog-button-secondary')
+		cy.get('.vex-dialog-buttons .button-secondary')
 			.click();
 
 		cy.get('.cool-annotation-content-wrapper.wizard-comment-box')

--- a/cypress_test/integration_tests/mobile/calc/hamburger_menu_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/hamburger_menu_spec.js
@@ -200,7 +200,7 @@ describe('Trigger hamburger menu options.', function() {
 		cy.get('.vex-dialog-message')
 			.should('have.text', 'Please use the copy/paste buttons on your on-screen keyboard.');
 
-		cy.get('.vex-dialog-button-primary.vex-dialog-button')
+		cy.get('.vex-dialog-buttons .button-primary')
 			.click();
 
 		cy.get('.vex-dialog-form')
@@ -222,7 +222,7 @@ describe('Trigger hamburger menu options.', function() {
 		cy.get('.vex-dialog-message')
 			.should('have.text', 'Please use the copy/paste buttons on your on-screen keyboard.');
 
-		cy.get('.vex-dialog-button-primary.vex-dialog-button')
+		cy.get('.vex-dialog-buttons .button-primary')
 			.click();
 
 		cy.get('.vex-dialog-form')
@@ -244,7 +244,7 @@ describe('Trigger hamburger menu options.', function() {
 		cy.get('.vex-dialog-message')
 			.should('have.text', 'Please use the copy/paste buttons on your on-screen keyboard.');
 
-		cy.get('.vex-dialog-button-primary.vex-dialog-button')
+		cy.get('.vex-dialog-buttons .button-primary')
 			.click();
 
 		cy.get('.vex-dialog-form')

--- a/cypress_test/integration_tests/mobile/calc/insertion_wizard_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/insertion_wizard_spec.js
@@ -74,7 +74,7 @@ describe('Calc insertion wizard.', function() {
 			.type('www.something.com');
 
 		// Insert
-		cy.get('.vex-content.hyperlink-dialog .vex-dialog-button-primary')
+		cy.get('.vex-content.hyperlink-dialog .button-primary')
 			.click();
 
 		cy.get('.blinking-cursor')

--- a/cypress_test/integration_tests/mobile/calc/sheet_operation_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/sheet_operation_spec.js
@@ -24,7 +24,7 @@ describe('Sheet Operation', function () {
 	function clickVexDialogButton(buttonText) {
 		cy.get('.vex-content').should('exist');
 
-		cy.contains('button.vex-dialog-button', buttonText)
+		cy.contains('.vex-dialog-buttons button', buttonText)
 			.click();
 	}
 

--- a/cypress_test/integration_tests/mobile/impress/annotation_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/annotation_spec.js
@@ -55,7 +55,7 @@ describe('Annotation tests.', function() {
 		cy.get('.vex-dialog-form .cool-annotation-textarea')
 			.type('modified ');
 
-		cy.get('.vex-dialog-button-primary')
+		cy.get('.vex-dialog-buttons .button-primary')
 			.click();
 
 		cy.get('#mobile-wizard .wizard-comment-box.cool-annotation-content-wrapper')
@@ -95,10 +95,10 @@ describe('Annotation tests.', function() {
 		cy.get('.cool-annotation-textarea')
 			.should('have.text', '');
 
-		cy.get('.vex-dialog-button-primary')
+		cy.get('.button-primary')
 			.click();
 
-		cy.get('.vex-dialog-button-secondary')
+		cy.get('.button-secondary')
 			.click();
 
 		cy.get('.cool-annotation-content-wrapper.wizard-comment-box')

--- a/cypress_test/integration_tests/mobile/impress/hamburger_menu_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/hamburger_menu_spec.js
@@ -202,7 +202,7 @@ describe('Trigger hamburger menu options.', function() {
 		cy.get('.vex-dialog-message')
 			.should('have.text', 'Please use the copy/paste buttons on your on-screen keyboard.');
 
-		cy.get('.vex-dialog-button-primary.vex-dialog-button')
+		cy.get('.vex-dialog-buttons .button-primary')
 			.click();
 
 		cy.get('.vex-dialog-form')
@@ -225,7 +225,7 @@ describe('Trigger hamburger menu options.', function() {
 		cy.get('.vex-dialog-message')
 			.should('have.text', 'Please use the copy/paste buttons on your on-screen keyboard.');
 
-		cy.get('.vex-dialog-button-primary.vex-dialog-button.vex-first')
+		cy.get('.vex-dialog-buttons .button-primary.vex-first')
 			.click();
 
 		cy.get('.vex-dialog-form')
@@ -248,7 +248,7 @@ describe('Trigger hamburger menu options.', function() {
 		cy.get('.vex-dialog-message')
 			.should('have.text', 'Please use the copy/paste buttons on your on-screen keyboard.');
 
-		cy.get('.vex-dialog-button-primary.vex-dialog-button')
+		cy.get('.vex-dialog-buttons .button-primary')
 			.click();
 
 		cy.get('.vex-dialog-form')
@@ -330,7 +330,7 @@ describe('Trigger hamburger menu options.', function() {
 		cy.get('.vex-content')
 			.should('exist');
 
-		cy.get('.vex-dialog-button-primary')
+		cy.get('.button-primary')
 			.click();
 
 		cy.get('.vex-content')

--- a/cypress_test/integration_tests/mobile/impress/insertion_wizard_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/insertion_wizard_spec.js
@@ -81,7 +81,7 @@ describe('Impress insertion wizard.', function() {
 		// Add some comment
 		cy.get('#new-mobile-comment-input-area').type('some text');
 
-		cy.get('.vex-dialog-button-primary').click();
+		cy.get('.button-primary').click();
 
 		cy.get('#comment-container-1').should('exist');
 
@@ -163,7 +163,7 @@ describe('Impress insertion wizard.', function() {
 			.type('www.something.com');
 
 		// Insert
-		cy.get('.vex-content.hyperlink-dialog .vex-dialog-button-primary')
+		cy.get('.vex-content.hyperlink-dialog .button-primary')
 			.click();
 
 		// TODO: we have some wierd shape here instead of a text shape with the link
@@ -360,7 +360,7 @@ describe('Impress insertion wizard.', function() {
 			.type('www.something.com');
 
 		// Insert
-		cy.get('.vex-content.hyperlink-dialog .vex-dialog-button-primary')
+		cy.get('.vex-content.hyperlink-dialog .button-primary')
 			.click();
 
 		// Check the text

--- a/cypress_test/integration_tests/mobile/impress/slide_operation_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/slide_operation_spec.js
@@ -41,7 +41,7 @@ describe('Slide operations', function() {
 		cy.get('.menu-entry-icon.deletepage').parent()
 			.click();
 
-		cy.get('.vex-dialog-button-primary').click();
+		cy.get('.button-primary').click();
 
 		impressHelper.assertNumberOfSlidePreviews(1);
 	});

--- a/cypress_test/integration_tests/mobile/writer/annotation_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/annotation_spec.js
@@ -55,7 +55,7 @@ describe.skip('Annotation tests.', function() {
 
 		cy.get('#new-mobile-comment-input-area').type('{home}modified ');
 
-		cy.get('.vex-dialog-button-primary').click();
+		cy.get('.button-primary').click();
 
 		cy.get('#comment-container-1').should('exist');
 
@@ -73,7 +73,7 @@ describe.skip('Annotation tests.', function() {
 
 		cy.get('#new-mobile-comment-input-area').type('reply');
 
-		cy.get('.vex-dialog-button-primary').click();
+		cy.get('.button-primary').click();
 
 		cy.get('#comment-container-2').should('exist');
 
@@ -103,10 +103,10 @@ describe.skip('Annotation tests.', function() {
 		cy.get('.cool-annotation-textarea')
 			.should('have.text', '');
 
-		cy.get('.vex-dialog-button-primary')
+		cy.get('.button-primary')
 			.click();
 
-		cy.get('.vex-dialog-button-secondary')
+		cy.get('.button-secondary')
 			.click();
 
 		cy.get('#mobile-wizard .wizard-comment-box.cool-annotation-content-wrapper')

--- a/cypress_test/integration_tests/mobile/writer/hamburger_menu_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/hamburger_menu_spec.js
@@ -186,7 +186,7 @@ describe('Trigger hamburger menu options.', function() {
 		cy.get('.vex-dialog-message')
 			.should('have.text', 'Please use the copy/paste buttons on your on-screen keyboard.');
 
-		cy.get('.vex-dialog-button-primary.vex-dialog-button')
+		cy.get('.vex-dialog-buttons .button-primary')
 			.click();
 
 		cy.get('.vex-dialog-form')
@@ -206,7 +206,7 @@ describe('Trigger hamburger menu options.', function() {
 		cy.get('.vex-dialog-message')
 			.should('have.text', 'Please use the copy/paste buttons on your on-screen keyboard.');
 
-		cy.get('.vex-dialog-button-primary.vex-dialog-button.vex-first')
+		cy.get('.vex-dialog-buttons .button-primary.vex-first')
 			.click();
 
 		cy.get('.vex-dialog-form')
@@ -226,7 +226,7 @@ describe('Trigger hamburger menu options.', function() {
 		cy.get('.vex-dialog-message')
 			.should('have.text', 'Please use the copy/paste buttons on your on-screen keyboard.');
 
-		cy.get('.vex-dialog-button-primary.vex-dialog-button')
+		cy.get('.vex-dialog-buttons .button-primary')
 			.click();
 
 		cy.get('.vex-dialog-form')
@@ -598,4 +598,3 @@ describe('Trigger hamburger menu options.', function() {
 			.should('not.exist');
 	});
 });
-

--- a/cypress_test/integration_tests/mobile/writer/insert_object_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/insert_object_spec.js
@@ -45,7 +45,7 @@ describe('Insert objects via insertion wizard.', function() {
 		// Add some comment
 		cy.get('#new-mobile-comment-input-area').type('some text');
 
-		cy.get('.vex-dialog-button-primary').click();
+		cy.get('.button-primary').click();
 
 		cy.get('#comment-container-1').should('exist');
 
@@ -286,7 +286,7 @@ describe('Insert objects via insertion wizard.', function() {
 			.type('www.something.com');
 
 		// Insert
-		cy.get('.vex-content.hyperlink-dialog .vex-dialog-button-primary')
+		cy.get('.vex-content.hyperlink-dialog .button-primary')
 			.click();
 
 		writerHelper.selectAllTextOfDoc();

--- a/cypress_test/integration_tests/multiuser/calc/sheet_operations_spec.js
+++ b/cypress_test/integration_tests/multiuser/calc/sheet_operations_spec.js
@@ -55,7 +55,7 @@ describe('Multiuser sheet operations', function() {
 		cy.iframe(frameId2).contains('.context-menu-link', 'Delete Sheet...')
 			.click();
 
-		cy.customGet('.vex-dialog-form .vex-dialog-button-primary', frameId2)
+		cy.customGet('.vex-dialog-form .button-primary', frameId2)
 			.click();
 
 		//assert for user-1/2


### PR DESCRIPTION
- Reduce CSS selectors targeting buttons
- Don't use vex btn default btn CSS classes (rename) 
- Remove master slides sidebar's btn CSS declarations
- Add mobile-wizard-titlebar-btn and remove hard coded rules
- Fix button order on newAnnotationVex
- Don't load btn hover status CSS rules when on mobile
