### PR TITLE
Set group_download_as to true as default

### DIFF
--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -69,7 +69,7 @@
     </per_document>
 
     <per_view desc="View-specific settings.">
-        <group_download_as desc="If set to true, groups download as icons into a dropdown for the notebookbar view." type="bool" default="false">false</group_download_as>
+        <group_download_as desc="If set to true, groups download as icons into a dropdown for the notebookbar view." type="bool" default="true">true</group_download_as>
         <out_of_focus_timeout_secs desc="The maximum number of seconds before dimming and stopping updates when the browser tab is no longer in focus. Defaults to 120 seconds." type="uint" default="120">120</out_of_focus_timeout_secs>
         <idle_timeout_secs desc="The maximum number of seconds before dimming and stopping updates when the user is no longer active (even if the browser is in focus). Defaults to 15 minutes." type="uint" default="900">900</idle_timeout_secs>
     </per_view>


### PR DESCRIPTION
There are now too many download options to have each format as
an individual icon on the tabbed view. Plus with improvements
introduced in cbf5f1ad712a3d1eaff71a04ec022fe6424ba310
we can now safely set group_download_as to true as the default
value. Of course, it can still be switched to false if so
desired.

Notes:
Ideally, and if no one objects to it, we can later on and after
a period of testing remove this option and have only one way of
implementing/showing download options (as dropdown).

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I1130684ec2ec54832f5a13648754d29ac71b9d35
