### PR TITLE
Split config.h into separate headers to avoid extensive rebuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,9 @@ coolwsd.xml
 aclocal.m4
 autom4te.cache
 config.h
-config.h.in
+config_unused.h
+config_unused.h.in
+config_version.h
 ios/config.h
 config.log
 config.guess

--- a/common/Util.cpp
+++ b/common/Util.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <config.h>
+#include <config_version.h>
 
 #include "Util.hpp"
 

--- a/config.h.in
+++ b/config.h.in
@@ -1,0 +1,104 @@
+/* Variables that usually don't change once configured */
+
+/* The user-visible name of the app you build. */
+#undef APP_NAME
+
+/* Default value of feature_lock.calc_unlock_highlights */
+#undef CALC_UNLOCK_HIGHLIGHTS
+
+/* Define to 1 if this is a code-coverage build. */
+#undef CODE_COVERAGE
+
+/* Enable permanent anonymization in logs */
+#undef COOLWSD_ANONYMIZE_USER_DATA
+
+/* Destination for Trace Event output */
+#undef COOLWSD_TRACEEVENTFILE
+
+/* The user-name which is allowed to run coolwsd and its tools */
+#undef COOL_USER_ID
+
+/* Whether to disable SECCOMP */
+#undef DISABLE_SECCOMP
+
+/* Default value of feature_lock.draw_unlock_highlights */
+#undef DRAW_UNLOCK_HIGHLIGHTS
+
+/* Whether to compile in some extra debugging support code and disable some
+   security pieces */
+#undef ENABLE_DEBUG
+
+/* Whether to compile and enable feature locking */
+#undef ENABLE_FEATURE_LOCK
+
+/* Whether to compile and enable feature restrictions */
+#undef ENABLE_FEATURE_RESTRICTION
+
+/* Whether to enable SSL */
+#undef ENABLE_SSL
+
+/* Whether to enable support key */
+#undef ENABLE_SUPPORT_KEY
+
+/* Should the Release notes message be shown on upgrade */
+#undef ENABLE_WELCOME_MESSAGE
+
+/* User feedback URL. */
+#undef FEEDBACK_URL
+
+/* Whether OpenSSL has PKCS5_PBKDF2_HMAC() */
+#undef HAVE_PKCS5_PBKDF2_HMAC
+
+/* Define to 1 if you have the `ppoll' function. */
+#undef HAVE_PPOLL
+
+/* Whether the used C++ has support for std::filesystem. */
+#undef HAVE_STD_FILESYSTEM
+
+/* Whether the std::filesystem is in the experimental header. */
+#undef HAVE_STD_FILESYSTEM_EXPERIMENTAL
+
+/* Default value of feature_lock.impress_unlock_highlights */
+#undef IMPRESS_UNLOCK_HIGHLIGHTS
+
+/* Infobar URL. */
+#undef INFOBAR_URL
+
+/* Define to 1 if this is a libfuzzer build. */
+#undef LIBFUZZER
+
+/* Default value of feature_lock.locked_commands */
+#undef LOCKED_COMMANDS
+
+/* Enable logging of test assertions */
+#undef LOK_LOG_ASSERTIONS
+
+/* Path to LibreOffice installation */
+#undef LO_PATH
+
+/* Limit the maximum number of open connections */
+#undef MAX_CONNECTIONS
+
+/* Limit the maximum number of open documents */
+#undef MAX_DOCUMENTS
+
+/* Define to 1 if this is a mobileapp (eg. Android) build. */
+#undef MOBILEAPP
+
+/* Default value of feature_lock.unlock_description */
+#undef UNLOCK_DESCRIPTION
+
+/* Default value of feature_lock.unlock_link */
+#undef UNLOCK_LINK
+
+/* Default value of feature_lock.unlock_title */
+#undef UNLOCK_TITLE
+
+/* Default value of per_documents.document_signing_url */
+#undef VEREIGN_URL
+
+/* The welcome url of the build. */
+#undef WELCOME_URL
+
+/* Default value of feature_lock.writer_unlock_highlights */
+#undef WRITER_UNLOCK_HIGHLIGHTS

--- a/config_version.h.in
+++ b/config_version.h.in
@@ -1,0 +1,7 @@
+/* Version-related variables */
+
+/* Collabora Online WebSocket server version */
+#undef COOLWSD_VERSION
+
+/* Collabora Online git hash if present */
+#undef COOLWSD_VERSION_HASH

--- a/configure.ac
+++ b/configure.ac
@@ -58,7 +58,15 @@ AC_DEFINE_UNQUOTED([COOLWSD_VERSION_HASH],[["$COOLWSD_VERSION_HASH"]],[Collabora
 
 AC_CONFIG_SRCDIR([wsd/COOLWSD.cpp])
 
+# this is a dummy header, autoheader adds all entries to it
+# don't include config_unused.h anywhere!
+AC_CONFIG_HEADERS([config_unused.h])
+
+# maintain config.h.in and config_version.h.in manually
+# config.h.in is for configurable variables that are stable if configure parameters are unchanged
 AC_CONFIG_HEADERS([config.h])
+# config_version.h.in is for version/hash related variables
+AC_CONFIG_HEADERS([config_version.h])
 
 # Checks for programs.
 AC_PROG_CXX

--- a/kit/ForKit.cpp
+++ b/kit/ForKit.cpp
@@ -10,6 +10,7 @@
  */
 
 #include <config.h>
+#include <config_version.h>
 
 #ifndef __FreeBSD__
 #include <sys/capability.h>

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -10,6 +10,7 @@
  */
 
 #include <config.h>
+#include <config_version.h>
 
 #include <dlfcn.h>
 #ifdef __linux__

--- a/net/HttpHelper.cpp
+++ b/net/HttpHelper.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <config.h>
+#include <config_version.h>
 
 #include "HttpHelper.hpp"
 

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <config_version.h>
+
 #include <chrono>
 #include <cstdint>
 #include <iostream>
@@ -29,7 +31,7 @@
 #include "Log.hpp"
 #include "Util.hpp"
 
-#ifndef COOLWSD_VERSION
+#ifndef APP_NAME
 static_assert(false, "config.h must be included in the .cpp being compiled");
 #endif
 

--- a/test/RequestDetailsTests.cpp
+++ b/test/RequestDetailsTests.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <config.h>
+#include <config_version.h>
 
 #include <test/lokassert.hpp>
 

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <config.h>
+#include <config_version.h>
 #include <stdexcept>
 #include "COOLWSD.hpp"
 #include "ProofKey.hpp"

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <config.h>
+#include <config_version.h>
 
 #include <iomanip>
 #include <string>


### PR DESCRIPTION
Eg. if only the version was changed, config.h was updated, and
everything was recompiled.

New structure, maintain these manually:
config.h.in - for configured variables that are stable if
              configuration parameters are unchanged
config_version.h.in - for version/hash related variables

----
config_unused.h.in - still generated by autoheader with all
                     variables, don't use it

Signed-off-by: Aron Budea <aron.budea@collabora.com>
Change-Id: Id9a50a9f1e798a3b3814778d8683b7d7cb57bb29

* Target version: master 

### Checklist

- [X] Code is properly formatted
- [X] All commits have Change-Id
- [ ] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

