### PR TITLE
Temporarily disable unit-tiletest

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -24,7 +24,6 @@ AM_CXXFLAGS = $(CPPUNIT_CFLAGS) -DTDOC=\"$(abs_top_srcdir)/test/data\" \
 # When adding new tests, please maintain order.
 all_la_unit_tests = \
 	unit-insert-delete.la \
-	unit-tiletest.la \
 	unit-httpws.la \
 	unit-password-protected.la \
 	unit-wopi-fail-upload.la \


### PR DESCRIPTION
Due to this error:
[ coolwsd ] TST  testTileProcessed  [testTileProcessed] (+12566ms):
ERROR: Assertion failure: Expected exactly the requested number of
tiles Expected arrivedTile == [25] but got [28]
| TileCacheTests.cpp:1580

Probably since 2cc955f9109c0fc8443c9f93c1bf6bd317043cb5 (core)

Signed-off-by: Aron Budea <aron.budea@collabora.com>
Change-Id: Ie854a57e4241f2c8fbf8e3d769aba8a19981feb1

* Target version: master 