### PR TITLE
prometheus: don't export string values.

### DIFF
--- a/wsd/AdminModel.cpp
+++ b/wsd/AdminModel.cpp
@@ -1166,14 +1166,15 @@ void AdminModel::getMetrics(std::ostringstream &oss)
     for (const auto& it : _documents)
     {
         const Document &doc = *it.second;
-        std::string suffix = "{pid=" + std::to_string(doc.getPid()) + "} ";
-        oss << "doc_host" << suffix << "= \"" << doc.getHostName() << "\"\n";
-        oss << "doc_key" << suffix << "= \"" << doc.getDocKey() << "\"\n"; // often WOPISrc
+        std::string pid = std::to_string(doc.getPid());
 
         std::string encodedFilename;
         Poco::URI::encode(doc.getFilename(), " ", encodedFilename);
-        oss << "doc_filename" << suffix << "= \"" << encodedFilename << "\"\n";
+        oss << "doc_pid{host=\"" << doc.getHostName() << "\","
+               "key=\"" << doc.getDocKey() << "\","
+               "filename=\"" << encodedFilename << "\"} " << pid << "\n";
 
+        std::string suffix = "{pid=" + pid + "} ";
         oss << "doc_views" << suffix << doc.getViews().size() << "\n";
         oss << "doc_views_active" << suffix << doc.getActiveViews() << "\n";
         oss << "doc_is_modified" << suffix << doc.getModifiedStatus() << "\n";

--- a/wsd/metrics.txt
+++ b/wsd/metrics.txt
@@ -174,8 +174,10 @@ SELECTED ERRORS - all integer counts
 
 PER DOCUMENT DETAILS - suffixed by {pid=<pid>} for each document:
 
-    doc_host - host this document was fetched from
-    doc_key - key often WOPISrc used to fetch the document
+    doc_pid - define the pid of the related document with these labels:
+        host= - host this document was fetched from
+        key= - key often WOPISrc used to fetch the document
+	filename= - filename of the document
     doc_active_views - number of views/users currently
     doc_is_modified - is the document modified, or not ie. saved/readonly
     doc_memory_used_bytes - bytes of memory dirtied by this process


### PR DESCRIPTION
continue to use the pid as a short-ish label to disambiguate metrics,
but also define the pid with more labels in the 1st instance.

doc_pid{host="localhost",key="https://localhost:9980/.../hello-world.odt",filename="hello-world.odt"} 1261609
doc_views{pid=1261609} 2
doc_views_active{pid=1261609} 2
doc_is_modified{pid=1261609} 1
...

Change-Id: I573f6d5c8ceb9a7daee83d1f2ee9f42b8e0cd089
Signed-off-by: Michael Meeks <michael.meeks@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

