### PR TITLE
Save different sidebar states for Impress.

### DIFF
--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -1822,12 +1822,6 @@ L.Control.Menubar = L.Control.extend({
 			return;
 		}
 
-		if (unoCommand.startsWith('.uno:Sidebar') || unoCommand.startsWith('.uno:SlideMasterPage') ||
-			unoCommand.startsWith('.uno:ModifyPage') || unoCommand.startsWith('.uno:SlideChangeWindow') ||
-			unoCommand.startsWith('.uno:CustomAnimation') || unoCommand.startsWith('.uno:MasterSlidesPanel')) {
-			window.initSidebarState = true;
-		}
-
 		this._map.sendUnoCommand(unoCommand);
 	},
 

--- a/browser/src/control/Control.Sidebar.js
+++ b/browser/src/control/Control.Sidebar.js
@@ -116,6 +116,13 @@ L.Control.Sidebar = L.Control.extend({
 		wrapper.style.maxHeight = document.getElementById('document-container').getBoundingClientRect().height + 'px';
 	},
 
+	unsetSelectedSidebar: function() {
+		this.map.uiManager.setSavedState('PropertyDeck', false);
+		this.map.uiManager.setSavedState('SdSlideTransitionDeck', false);
+		this.map.uiManager.setSavedState('SdCustomAnimationDeck', false);
+		this.map.uiManager.setSavedState('SdMasterPagesDeck', false);
+	},
+
 	onSidebar: function(data) {
 		var sidebarData = data.data;
 		this.builder.setWindowId(sidebarData.id);
@@ -133,6 +140,11 @@ L.Control.Sidebar = L.Control.extend({
 				var wrapper = document.getElementById('sidebar-dock-wrapper');
 
 				this.onResize();
+
+				if (this.map.getDocType() === 'presentation' && sidebarData.children && sidebarData.children[0] && sidebarData.children[0].id) {
+					this.unsetSelectedSidebar();
+					this.map.uiManager.setSavedState(sidebarData.children[0].id, true);
+				}
 
 				this.builder.build(this.container, [sidebarData]);
 				if (wrapper.style.display === 'none')

--- a/browser/src/control/Control.Toolbar.js
+++ b/browser/src/control/Control.Toolbar.js
@@ -77,12 +77,6 @@ function onClick(e, id, item) {
 	// dont reassign the item if we already have it
 	item = item || getToolbarItemById(id);
 
-	if (id === 'sidebar' || id === 'modifypage' || id === 'slidechangewindow' || id === 'customanimation' || id === 'masterslidespanel') {
-		if (!map.uiManager.getSavedStateOrDefault('ShowSidebar', false))
-			map.sendUnoCommand('.uno:SidebarShow');
-		window.initSidebarState = true;
-	}
-
 	// In the iOS app we don't want clicking on the toolbar to pop up the keyboard.
 	if (!window.ThisIsTheiOSApp && id !== 'zoomin' && id !== 'zoomout' && id !== 'mobile_wizard' && id !== 'insertion_mobile_wizard') {
 		map.focus(map.canAcceptKeyboardInput()); // Maintain same keyboard state.

--- a/browser/src/control/Control.Toolbar.js
+++ b/browser/src/control/Control.Toolbar.js
@@ -78,6 +78,8 @@ function onClick(e, id, item) {
 	item = item || getToolbarItemById(id);
 
 	if (id === 'sidebar' || id === 'modifypage' || id === 'slidechangewindow' || id === 'customanimation' || id === 'masterslidespanel') {
+		if (!map.uiManager.getSavedStateOrDefault('ShowSidebar', false))
+			map.sendUnoCommand('.uno:SidebarShow');
 		window.initSidebarState = true;
 	}
 

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -221,6 +221,15 @@ L.Control.UIManager = L.Control.extend({
 		if (window.mode.isDesktop() && !window.ThisIsAMobileApp) {
 			var showSidebar = this.getSavedStateOrDefault('ShowSidebar');
 
+			if (this.map.getDocType() === 'presentation') {
+				if (this.getSavedStateOrDefault('SdSlideTransitionDeck'))
+					app.socket.sendMessage('uno .uno:SlideChangeWindow');
+				else if (this.getSavedStateOrDefault('SdCustomAnimationDeck'))
+					app.socket.sendMessage('uno .uno:CustomAnimation');
+				else if (this.getSavedStateOrDefault('SdMasterPagesDeck'))
+					app.socket.sendMessage('uno .uno:MasterSlidesPanel');
+			}
+
 			if (showSidebar === false)
 				app.socket.sendMessage('uno .uno:SidebarHide');
 		}

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -322,6 +322,12 @@ L.Map.include({
 	},
 
 	sendUnoCommand: function (command, json) {
+		if (command.startsWith('.uno:Sidebar') || command.startsWith('.uno:SlideMasterPage') ||
+			command.startsWith('.uno:ModifyPage') || command.startsWith('.uno:SlideChangeWindow') ||
+			command.startsWith('.uno:CustomAnimation') || command.startsWith('.uno:MasterSlidesPanel')) {
+			window.initSidebarState = true;
+		}
+
 		// To exercise the Trace Event functionality, uncomment this
 		// app.socket.emitInstantTraceEvent('cool-unocommand:' + command);
 

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -322,9 +322,14 @@ L.Map.include({
 	},
 
 	sendUnoCommand: function (command, json) {
-		if (command.startsWith('.uno:Sidebar') || command.startsWith('.uno:SlideMasterPage') ||
+		if ((command.startsWith('.uno:Sidebar') && !command.startsWith('.uno:SidebarShow')) ||
+			command.startsWith('.uno:SlideMasterPage') ||
 			command.startsWith('.uno:ModifyPage') || command.startsWith('.uno:SlideChangeWindow') ||
 			command.startsWith('.uno:CustomAnimation') || command.startsWith('.uno:MasterSlidesPanel')) {
+
+			if (!this.uiManager.getSavedStateOrDefault('ShowSidebar', false))
+				this.sendUnoCommand('.uno:SidebarShow');
+
 			window.initSidebarState = true;
 		}
 


### PR DESCRIPTION
Remember them on opening if local storage is enabled.

Signed-off-by: Gökay Şatır <gokaysatir@collabora.com>
Change-Id: I0c3e4eb65dfc16807d2a9a654d8e71f64341df67


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

