### PR TITLE
add 'Connection: close' header to http responses.

### DIFF
--- a/net/HttpHelper.cpp
+++ b/net/HttpHelper.cpp
@@ -39,7 +39,7 @@ void sendError(int errorCode, const std::shared_ptr<StreamSocket>& socket, const
 void sendErrorAndShutdown(int errorCode, const std::shared_ptr<StreamSocket>& socket,
                           const std::string& body, const std::string& extraHeader)
 {
-    sendError(errorCode, socket, body, extraHeader);
+    sendError(errorCode, socket, body, extraHeader + "Connection: close\r\n");
     socket->shutdown();
     socket->ignoreInput();
 }
@@ -114,6 +114,9 @@ void sendFileAndShutdown(const std::shared_ptr<StreamSocket>& socket, const std:
 
     response->setContentType(mediaType);
     response->add("X-Content-Type-Options", "nosniff");
+    //Should we add the header anyway ?
+    if (headerOnly)
+        response->add("Connection", "close");
 
     int bufferSize = std::min<std::size_t>(st.size(), Socket::MaximumSendBufferSize);
     if (static_cast<long>(st.size()) >= socket->getSendBufferSize())

--- a/wsd/Admin.cpp
+++ b/wsd/Admin.cpp
@@ -923,6 +923,7 @@ void Admin::getMetrics(std::ostringstream &metrics)
 void Admin::sendMetrics(const std::shared_ptr<StreamSocket>& socket, const std::shared_ptr<Poco::Net::HTTPResponse>& response)
 {
     std::ostringstream oss;
+    response->add("Connection", "close");
     response->write(oss);
     getMetrics(oss);
     socket->send(oss.str());

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -278,6 +278,7 @@ void ClientSession::handleClipboardRequest(DocumentBroker::ClipboardRequest     
                 << "Date: " << Util::getHttpTimeNow() << "\r\n"
                 << "User-Agent: " << WOPI_AGENT_STRING << "\r\n"
                 << "Content-Length: 0\r\n"
+                << "Connection: close\r\n"
                 << "\r\n";
             socket->send(oss.str());
             socket->closeConnection(); // Shutdown socket.
@@ -304,6 +305,7 @@ void ClientSession::handleClipboardRequest(DocumentBroker::ClipboardRequest     
                 << "Date: " << Util::getHttpTimeNow() << "\r\n"
                 << "User-Agent: " << WOPI_AGENT_STRING << "\r\n"
                 << "Content-Length: 0\r\n"
+                << "Connection: close\r\n"
                 << "\r\n";
             socket->send(oss.str());
             socket->shutdown();
@@ -1784,6 +1786,7 @@ bool ClientSession::handleKitToClientMessage(const std::shared_ptr<Message>& pay
                 << "Content-Length: " << (empty ? 0 : (payload->size() - header)) << "\r\n"
                 << "Content-Type: application/octet-stream\r\n"
                 << "X-Content-Type-Options: nosniff\r\n"
+                << "Connection: close\r\n"
                 << "\r\n";
 
             if (!empty)

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -2881,6 +2881,7 @@ bool DocumentBroker::lookupSendClipboardTag(const std::shared_ptr<StreamSocket> 
                 << "Content-Length: " << saved->length() << "\r\n"
                 << "Content-Type: application/octet-stream\r\n"
                 << "X-Content-Type-Options: nosniff\r\n"
+                << "Connection: close\r\n"
                 << "\r\n";
             oss.write(saved->c_str(), saved->length());
             socket->setSocketBufferSize(
@@ -2897,7 +2898,7 @@ bool DocumentBroker::lookupSendClipboardTag(const std::shared_ptr<StreamSocket> 
 
 #if !MOBILEAPP
     // Bad request.
-    HttpHelper::sendError(400, socket, "Failed to find this clipboard");
+    HttpHelper::sendError(400, socket, "Failed to find this clipboard", "Connection: close\r\n");
 #endif
     socket->shutdown();
     socket->ignoreInput();

--- a/wsd/ProxyProtocol.cpp
+++ b/wsd/ProxyProtocol.cpp
@@ -59,6 +59,7 @@ void DocumentBroker::handleProxyRequest(
             "Content-Length: " << sessionId.size() << "\r\n"
             "Content-Type: application/json; charset=utf-8\r\n"
             "X-Content-Type-Options: nosniff\r\n"
+            "Connection: close\r\n"
             "\r\n" << sessionId;
 
         socket->send(oss.str());


### PR DESCRIPTION
If the connection is closed right after the response was sent then it's wise to add 'Connection: close' header to the response so that the client optimizes its behaviour: e.g. does not reuse the socket for further http requests. Normally  a client should retry a request if the reuse of an old socket fails and that should solve the problem but still this is an overhead.

Signed-off-by: Gabriel Masei <gabriel.masei@1and1.ro>
Change-Id: I29f1498610c567024def3beb1ad7014f2c15a232


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

