### PR TITLE
private/pedro/jsdialog tabs fixes

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -155,6 +155,8 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 	align-items: center;
 	padding: 0px 1em;
 	border-radius: var(--border-radius);
+	background-color: var(--color-main-background);
+	margin-inline-end: 12px;
 }
 
 .ui-tab.jsdialog:first-child {

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -150,7 +150,7 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 	line-height: normal;
 	color: dimgray;
 	color: var(--color-text-dark);
-	height: 32px;
+	height: 24px;
 	display: flex;
 	align-items: center;
 	padding: 0px 1em;

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -157,7 +157,7 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 	border-radius: var(--border-radius);
 }
 
-.ui-tab.jsdialog:first-child.selected {
+.ui-tab.jsdialog:first-child {
 	margin-inline-start: 12px;
 }
 

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -171,7 +171,7 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 	box-shadow: 0 0 2px 1px #cfcfcf;
 }
 
-.ui-tab.jsdialog:hover {
+.ui-tab.jsdialog:not(.selected):hover {
 	cursor: pointer;
 	background-color: var(--color-background-darker);
 	color: var(--color-text-darker);


### PR DESCRIPTION
- Remove hover effect on selected tabs
- Remove tab's repositioning
- Make tabs shorter
- Add background to all tabs and add space in between them
