### PR TITLE
Mobile: Fix missing icon on lists within mobilewizard panels

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -3164,7 +3164,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		if (commandName && commandName.length && L.LOUtil.existsIconForCommand(commandName, builder.map.getDocType())) {
 			var iconName = builder._generateMenuIconName(commandName);
 			var iconSpan = L.DomUtil.create('span', 'menu-entry-icon ' + iconName, menuEntry);
-			var iconURL = L.LOUtil.getImageURL('lc_' + iconName + '.svg');
+			var iconURL = builder._createIconURL(iconName, true);
 			icon = L.DomUtil.create('img', '', iconSpan);
 			icon.src = iconURL;
 			icon.alt = '';


### PR DESCRIPTION
Reuse createIconURL so it runs through the iconURLAliases before
inserting image url

Example: Chart icon

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ia87b064c967df00c796d36fee577f4fd0f260a6f
