### PR TITLE
Revert "Attempt to fix FreeBSD node convas module not found error"

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -23,7 +23,7 @@ task:
         CXXFLAGS="-I/usr/local/include" LDFLAGS=-L/usr/local/lib ./configure
         --with-lo-path=/usr/local/lib/libreoffice/
         --with-lokit-path=./libreoffice-src/include
-        --disable-seccomp --disable-werror --disable-setcap --enable-debug'' '
+        --disable-seccomp --disable-setcap --enable-debug'' '
     - su -m cool -c 'env HOME=/tmp/coolhome gmake -j`sysctl -n hw.ncpu`'
     - chown root ./coolmount
     - chmod +s ./coolmount


### PR DESCRIPTION
This reverts commit 869f7f73af0a998e9c924ea70e19c887436fa125.


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

