### PR TITLE
fix(remote_config_pull): nullpointer if alieses not defined in host groups json

### DIFF
--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -1380,14 +1380,17 @@ public:
 #endif
                 Poco::JSON::Array::Ptr aliases = group->getArray("aliases");
 
-                auto it = aliases->begin();
 
-                size_t j;
-                for (j = 0; j < aliases->size(); j++)
-                {
-                    const std::string aliasPath = path + ".alias[" + std::to_string(j) + ']';
-                    newAppConfig.insert(std::make_pair(aliasPath, it->toString()));
-                    it++;
+                size_t j = 0;
+                if (aliases) {
+                    auto it = aliases->begin();
+
+                    for (; j < aliases->size(); j++)
+                    {
+                        const std::string aliasPath = path + ".alias[" + std::to_string(j) + ']';
+                        newAppConfig.insert(std::make_pair(aliasPath, it->toString()));
+                        it++;
+                    }
                 }
                 for (;; j++)
                 {


### PR DESCRIPTION
### Summary

Maybe solves NullPointer-Problem with this configuration:
```
{
    "kind": "configuration",
    "storage":
    {
        "wopi":
        {
            "alias_groups":
            {
                "mode" : "groups",
                "groups":
                [
                    {
                        "host": "scheme://hostname:port",
                        "allow": "true"
                    },
                ]
            }
        },
    }
}
```
(PS: I am not a good C++ Programmer, so that is untested Code with an Idea to solve it - e.g. i do not know, if the `if` works that way)

Current we use as **workaround**:
```diff
{
    "kind": "configuration",
    "storage":
    {
        "wopi":
        {
            "alias_groups":
            {
                "mode" : "groups",
                "groups":
                [
                    {
                        "host": "scheme://hostname:port",
                        "allow": "true" ,
+                       "aliases": []
                    },
                ]
            }
        },
    }
}
```

### Checklist

- [ ] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

---
For @mmeeks :
We got NullPointer again (like told on wednesday), with Workaround is everything fine.
We believe that we find the Bug, and maybe this solve it.

 