### PR TITLE
Backport of the IsModifiedByUser Flag

### DIFF
--- a/common/Protocol.hpp
+++ b/common/Protocol.hpp
@@ -230,6 +230,29 @@ namespace COOLProtocol
                 token != "userinactive");
     }
 
+    /// Returns true if the token is a likely document modifying command.
+    /// This is never 100% accurate, but it is needed to filter out tokens
+    /// that certainly do not modify the document, such as 'load' and 'save'
+    /// commands. Some commands are certainly modifying, e.g. 'key', others
+    /// can only potentially be modifying, e.g. 'mouse' while dragging.
+    /// Note: this is only used when we don't have the modified flag from
+    /// Core so we flag the document as user-modified more accurately.
+    inline bool tokenIndicatesDocumentModification(const std::string& token)
+    {
+        // These keywords are chosen to cover the largest set of
+        // commands that may potentially modify the document.
+        // We need to assume modification rather than not.
+        return (
+            token.find("mouse") != std::string::npos || token.find("key") != std::string::npos ||
+            token.find("command") != std::string::npos ||
+            token.find("select") != std::string::npos || token.find("set") != std::string::npos ||
+            token.find("uno") != std::string::npos || token.find("input") != std::string::npos ||
+            token.find("move") != std::string::npos || token.find("paste") != std::string::npos ||
+            token.find("insert") != std::string::npos ||
+            token.find("resize") != std::string::npos ||
+            token.find("remove") != std::string::npos || token.find("sign") != std::string::npos);
+    }
+
     /// Returns the first line of a message.
     inline
     std::string getFirstLine(const char *message, const int length)

--- a/test/UnitWOPISlow.cpp
+++ b/test/UnitWOPISlow.cpp
@@ -168,11 +168,7 @@ public:
         // Triggered while closing.
         LOK_ASSERT_EQUAL(std::string("false"), request.get("X-LOOL-WOPI-IsAutosave"));
 
-        // Unfortunately, we clobber the modified flag when uploading.
-        // So, if we had a user-modified upload that failed, the subsequent
-        // try will have dropped the modified flag, and this assertion will fail.
-        //FIXME: do not clobber the storage flags (modified, forced, etc.) when retrying.
-        // LOK_ASSERT_EQUAL(std::string("true"), request.get("X-LOOL-WOPI-IsModifiedByUser"));
+        LOK_ASSERT_EQUAL(std::string("true"), request.get("X-LOOL-WOPI-IsModifiedByUser"));
 
         passTest("Document uploaded on closing as expected.");
         return nullptr;

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -454,6 +454,10 @@ bool ClientSession::_handleInput(const char *buffer, int length)
         // Keep track of timestamps of incoming client messages that indicate user activity.
         updateLastActivityTime();
         docBroker->updateLastActivityTime();
+        if (COOLProtocol::tokenIndicatesDocumentModification(tokens[0]))
+        {
+            docBroker->updateLastModifyingActivityTime();
+        }
 
         if (isWritable() && isViewLoaded())
         {

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1504,9 +1504,9 @@ void DocumentBroker::uploadToStorageInternal(const std::string& sessionId,
                 broadcastSaveResult(false, "Could not upload document to storage");
         }
 
-        //FIXME: flag the failure so we retry.
         LOG_WRN("Failed to upload [" << _docKey << "] asynchronously. "
                                      << DocumentState::toString(_docState.activity()));
+        _storageManager.setLastUploadResult(false);
 
         switch (_docState.activity())
         {

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -3591,7 +3591,10 @@ void DocumentBroker::dumpState(std::ostream& os)
     os << "\n  canSave: " << name(canSaveToDisk());
     os << "\n  canUpload: " << name(canUploadToStorage());
     os << "\n  needToUpload: " << name(needToUploadToStorage());
+    os << "\n  lastActivityTime: " << Util::getTimeForLog(now, _lastActivityTime);
     os << "\n  haveActivityAfterSaveRequest: " << haveActivityAfterSaveRequest();
+    os << "\n  lastModifyActivityTime: " << Util::getTimeForLog(now, _lastModifyActivityTime);
+    os << "\n  haveModifyActivityAfterSaveRequest: " << haveModifyActivityAfterSaveRequest();
     os << "\n  isViewFileExtension: " << _isViewFileExtension;
 
     if (_limitLifeSeconds > std::chrono::seconds::zero())

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1964,8 +1964,8 @@ bool DocumentBroker::autoSave(const bool force, const bool dontSaveIfUnmodified)
         bool save = false;
         // Zero or negative config value disables save.
         // Either we've been idle long enough, or it's auto-save time.
-        if (MaxIdleSaveDurationMs > std::chrono::milliseconds::zero()
-            && inactivityTimeMs >= MaxIdleSaveDurationMs)
+        if (MaxIdleSaveDurationMs > std::chrono::milliseconds::zero() &&
+            inactivityTimeMs >= MaxIdleSaveDurationMs)
         {
             save = true;
         }
@@ -2112,14 +2112,15 @@ bool DocumentBroker::sendUnoSave(const std::string& sessionId, bool dontTerminat
         // Invalidate the timestamp to force persisting.
         _saveManager.setLastModifiedTime(std::chrono::system_clock::time_point());
 
-        // We do not want save to terminate editing mode if we are in edit mode now
-
         std::ostringstream oss;
         // arguments init
         oss << '{';
 
         if (dontTerminateEdit)
         {
+            // We do not want save to terminate editing mode if we are in edit mode now.
+            //TODO: Perhaps we want to terminate if forced by the user,
+            // otherwise autosave doesn't terminate?
             oss << "\"DontTerminateEdit\":"
                    "{"
                    "\"type\":\"boolean\","

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -934,7 +934,8 @@ bool DocumentBroker::download(const std::shared_ptr<ClientSession>& session, con
         // Only lock the document on storage for editing sessions
         // FIXME: why not lock before downloadStorageFileToLocal? Would also prevent race conditions
         if (!session->isReadOnly() &&
-            !_storage->updateLockState(session->getAuthorization(), *_lockCtx, true))
+            !_storage->updateLockState(session->getAuthorization(), *_lockCtx, true,
+                                       _currentStorageAttrs))
         {
             LOG_ERR("Failed to lock!");
             session->setLockFailed(_lockCtx->_lockFailureReason);
@@ -1141,7 +1142,8 @@ void DocumentBroker::endRenameFileCommand()
 
 bool DocumentBroker::attemptLock(const ClientSession& session, std::string& failReason)
 {
-    const bool bResult = _storage->updateLockState(session.getAuthorization(), *_lockCtx, true);
+    const bool bResult = _storage->updateLockState(session.getAuthorization(), *_lockCtx, true,
+                                                   _currentStorageAttrs);
     if (!bResult)
         failReason = _lockCtx->_lockFailureReason;
     return bResult;
@@ -1268,6 +1270,16 @@ void DocumentBroker::handleSaveResponse(const std::string& sessionId, bool succe
     // Record that we got a response to avoid timing out on saving.
     _saveManager.setLastSaveResult(success || result == "unmodified");
 
+    if (success && !isAsyncUploading())
+    {
+        // Update the storage attributes to capture what's
+        // new and applies to this new version and reset.
+        // These are the attributes of the next version to be uploaded.
+        // Note: these are owned by us and this is thread-safe.
+        _currentStorageAttrs.merge(_nextStorageAttrs);
+        _nextStorageAttrs.reset();
+    }
+
     // The the clients know of any save failures.
     if (!success && result != "unmodified")
     {
@@ -1362,9 +1374,11 @@ void DocumentBroker::uploadToStorage(const std::string& sessionId, bool force)
 {
     assertCorrectThread();
 
-    if (force && _storage)
+    if (force)
     {
-        _storage->forceSave();
+        // Don't reset the force flag if it was set
+        // (which would imply we failed to upload).
+        _currentStorageAttrs.setForced(force);
     }
 
     if (force || _storageManager.lastUploadSuccessful() ||
@@ -1531,7 +1545,8 @@ void DocumentBroker::uploadToStorageInternal(const std::string& sessionId,
     };
 
     _storage->uploadLocalFileToStorageAsync(session->getAuthorization(), *_lockCtx, saveAsPath,
-                                            saveAsFilename, isRename, *_poll, asyncUploadCallback);
+                                            saveAsFilename, isRename, _currentStorageAttrs, *_poll,
+                                            asyncUploadCallback);
 }
 
 void DocumentBroker::handleUploadToStorageResponse(const StorageBase::UploadResult& uploadResult)
@@ -1582,6 +1597,9 @@ void DocumentBroker::handleUploadToStorageResponse(const StorageBase::UploadResu
 
             // After a successful save, we are sure that document in the storage is same as ours
             _documentChangedInStorage = false;
+
+            // Reset the storage attributes; They've been used and we can discard them.
+            _currentStorageAttrs.reset();
 
             LOG_DBG("Uploaded docKey ["
                     << _docKey << "] to URI [" << _uploadRequest->uriAnonym()
@@ -1853,7 +1871,8 @@ void DocumentBroker::refreshLock()
     else
     {
         std::shared_ptr<ClientSession> session = it->second;
-        if (!session || !_storage->updateLockState(session->getAuthorization(), *_lockCtx, true))
+        if (!session || !_storage->updateLockState(session->getAuthorization(), *_lockCtx, true,
+                                                   _currentStorageAttrs))
             LOG_ERR("Failed to refresh lock");
     }
 }
@@ -2143,15 +2162,13 @@ bool DocumentBroker::sendUnoSave(const std::string& sessionId, bool dontTerminat
         // arguments end
         oss << '}';
 
-        if (_storage)
-        {
-            // If we can't upload, we will quarantine.
-            //FIXME: these must be tracked in DocBroker as they will
-            // get clobbered when uploading fails and we save again.
-            _storage->setIsAutosave(isAutosave || UnitWSD::get().isAutosave());
-            _storage->setIsExitSave(isExitSave);
-            _storage->setExtendedData(extendedData);
-        }
+        // At this point, if we have any potential modifications, we need to capture the fact.
+        _nextStorageAttrs.setUserModified(isModified() || haveModifyActivityAfterSaveRequest());
+
+        //FIXME: It's odd to capture these here, but this function is used from ClientSession too.
+        _nextStorageAttrs.setIsAutosave(isAutosave || UnitWSD::get().isAutosave());
+        _nextStorageAttrs.setIsExitSave(isExitSave);
+        _nextStorageAttrs.setExtendedData(extendedData);
 
         const std::string saveArgs = oss.str();
         LOG_TRC(".uno:Save arguments: " << saveArgs);
@@ -2388,7 +2405,8 @@ void DocumentBroker::disconnectSessionInternal(const std::string& id)
             // Unlock the document, if last editable sessions, before we lose a token that can unlock.
             if (lastEditableSession && _lockCtx->_isLocked && _storage)
             {
-                if (!_storage->updateLockState(it->second->getAuthorization(), *_lockCtx, false))
+                if (!_storage->updateLockState(it->second->getAuthorization(), *_lockCtx, false,
+                                               _currentStorageAttrs))
                     LOG_ERR("Failed to unlock!");
             }
 
@@ -3081,13 +3099,6 @@ void DocumentBroker::setModified(const bool value)
     }
 #endif
 
-    if (value || _storageManager.lastUploadSuccessful())
-    {
-        // Set the X-COOL-WOPI-IsModifiedByUser header flag sent to storage.
-        // But retain the last value if we failed to upload, so we don't clobber it.
-        _storage->setUserModified(value);
-    }
-
     LOG_DBG("Modified state set to " << value << " for Doc [" << _docId << ']');
     _isModified = value;
 }
@@ -3615,6 +3626,11 @@ void DocumentBroker::dumpState(std::ostream& os)
 
     os << "\n  StorageManager:";
     _storageManager.dumpState(os, "\n    ");
+
+    os << "\n    Current StorageAttributes:";
+    _currentStorageAttrs.dumpState(os, "\n      ");
+    os << "\n    Next StorageAttributes:";
+    _nextStorageAttrs.dumpState(os, "\n      ");
 
     _lockCtx->dumpState(os);
 

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -1286,6 +1286,15 @@ private:
     std::set<std::string> _isInitialStateSet;
 
     std::unique_ptr<StorageBase> _storage;
+
+    /// The current upload request's attributes. Re-used to retry after failure.
+    /// Updated right before uploading.
+    StorageBase::Attributes _currentStorageAttrs;
+    /// The next upload request's attributes. Avoids clobbering
+    /// _currentStorageAttrs until the current request succeeds.
+    /// Updated right before saving.
+    StorageBase::Attributes _nextStorageAttrs;
+
     std::unique_ptr<TileCache> _tileCache;
     std::atomic<bool> _isModified;
     int _cursorPosX;

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -427,6 +427,12 @@ public:
 
     void updateLastActivityTime();
 
+    /// Sets the last activity timestamp that is most likely to modify the document.
+    void updateLastModifyingActivityTime()
+    {
+        _lastModifyActivityTime = std::chrono::steady_clock::now();
+    }
+
     /// This updates the editing sessionId which is used for auto-saving.
     void updateEditingSessionId(const std::string& viewId)
     {
@@ -607,6 +613,13 @@ private:
     bool haveActivityAfterSaveRequest() const
     {
         return _saveManager.lastSaveRequestTime() < _lastActivityTime;
+    }
+
+    /// True if there has been potentially *document-modifying* activity from a client
+    /// after we last *requested* saving, since there are race conditions while saving.
+    bool haveModifyActivityAfterSaveRequest() const
+    {
+        return _saveManager.lastSaveRequestTime() < _lastModifyActivityTime;
     }
 
     /// Encodes whether or not saving is needed.
@@ -1291,6 +1304,10 @@ private:
     int _debugRenderedTileCount;
 
     std::chrono::steady_clock::time_point _lastActivityTime;
+
+    /// Time of the last interactive event that very likely modified the document.
+    std::chrono::steady_clock::time_point _lastModifyActivityTime;
+
     std::chrono::steady_clock::time_point _threadStart;
     std::chrono::milliseconds _loadDuration;
     std::chrono::milliseconds _wopiDownloadDuration;

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -391,7 +391,7 @@ void LocalStorage::uploadLocalFileToStorageAsync(const Authorization& /*auth*/,
                                                  LockContext& /*lockCtx*/,
                                                  const std::string& /*saveAsPath*/,
                                                  const std::string& /*saveAsFilename*/,
-                                                 bool /*isRename*/, SocketPoll&,
+                                                 bool /*isRename*/, const Attributes&, SocketPoll&,
                                                  const AsyncUploadCallback& asyncUploadCallback)
 {
     const std::string path = getUri().getPath();
@@ -917,7 +917,8 @@ WopiStorage::WOPIFileInfo::WOPIFileInfo(const FileInfo &fileInfo,
         _disableExport = true;
 }
 
-bool WopiStorage::updateLockState(const Authorization& auth, LockContext& lockCtx, bool lock)
+bool WopiStorage::updateLockState(const Authorization& auth, LockContext& lockCtx, bool lock,
+                                  const Attributes& attribs)
 {
     lockCtx._lockFailureReason.clear();
     if (!lockCtx._supportsLocks)
@@ -944,10 +945,10 @@ bool WopiStorage::updateLockState(const Authorization& auth, LockContext& lockCt
 
         request.set("X-WOPI-Override", lock ? "LOCK" : "UNLOCK");
         request.set("X-WOPI-Lock", lockCtx._lockToken);
-        if (!getExtendedData().empty())
+        if (!attribs.getExtendedData().empty())
         {
-            request.set("X-COOL-WOPI-ExtendedData", getExtendedData());
-            request.set("X-LOOL-WOPI-ExtendedData", getExtendedData());
+            request.set("X-COOL-WOPI-ExtendedData", attribs.getExtendedData());
+            request.set("X-LOOL-WOPI-ExtendedData", attribs.getExtendedData());
         }
 
         // IIS requires content-length for POST requests: see https://forums.iis.net/t/1119456.aspx
@@ -1181,7 +1182,8 @@ private:
 void WopiStorage::uploadLocalFileToStorageAsync(const Authorization& auth, LockContext& lockCtx,
                                                 const std::string& saveAsPath,
                                                 const std::string& saveAsFilename,
-                                                const bool isRename, SocketPoll& socketPoll,
+                                                const bool isRename, const Attributes& attribs,
+                                                SocketPoll& socketPoll,
                                                 const AsyncUploadCallback& asyncUploadCallback)
 {
     ProfileZone profileZone("WopiStorage::uploadLocalFileToStorage", { {"url", _fileUrl} });
@@ -1243,21 +1245,21 @@ void WopiStorage::uploadLocalFileToStorageAsync(const Authorization& auth, LockC
         {
             // normal save
             httpHeader.set("X-WOPI-Override", "PUT");
-            httpHeader.set("X-COOL-WOPI-IsModifiedByUser", isUserModified() ? "true" : "false");
-            httpHeader.set("X-LOOL-WOPI-IsModifiedByUser", isUserModified() ? "true" : "false");
-            httpHeader.set("X-COOL-WOPI-IsAutosave", isAutosave() ? "true" : "false");
-            httpHeader.set("X-LOOL-WOPI-IsAutosave", isAutosave() ? "true" : "false");
-            httpHeader.set("X-COOL-WOPI-IsExitSave", isExitSave() ? "true" : "false");
-            httpHeader.set("X-LOOL-WOPI-IsExitSave", isExitSave() ? "true" : "false");
-            if (isExitSave())
+            httpHeader.set("X-COOL-WOPI-IsModifiedByUser", attribs.isUserModified() ? "true" : "false");
+            httpHeader.set("X-LOOL-WOPI-IsModifiedByUser", attribs.isUserModified() ? "true" : "false");
+            httpHeader.set("X-COOL-WOPI-IsAutosave", attribs.isAutosave() ? "true" : "false");
+            httpHeader.set("X-LOOL-WOPI-IsAutosave", attribs.isAutosave() ? "true" : "false");
+            httpHeader.set("X-COOL-WOPI-IsExitSave", attribs.isExitSave() ? "true" : "false");
+            httpHeader.set("X-LOOL-WOPI-IsExitSave", attribs.isExitSave() ? "true" : "false");
+            if (attribs.isExitSave())
                 httpHeader.set("Connection", "close"); // Don't maintain the socket if we are exiting.
-            if (!getExtendedData().empty())
+            if (!attribs.getExtendedData().empty())
             {
-                httpHeader.set("X-COOL-WOPI-ExtendedData", getExtendedData());
-                httpHeader.set("X-LOOL-WOPI-ExtendedData", getExtendedData());
+                httpHeader.set("X-COOL-WOPI-ExtendedData", attribs.getExtendedData());
+                httpHeader.set("X-LOOL-WOPI-ExtendedData", attribs.getExtendedData());
             }
 
-            if (!getForceSave())
+            if (!attribs.isForced())
             {
                 // Request WOPI host to not overwrite if timestamps mismatch
                 httpHeader.set("X-COOL-WOPI-Timestamp", getFileInfo().getLastModifiedTime());
@@ -1446,9 +1448,6 @@ WopiStorage::handleUploadToStorageResponse(const WopiUploadDetails& details,
 
                     result.setSaveAsResult(name, url);
                 }
-                // Reset the force save flag now, if any, since we are done saving
-                // Next saves shouldn't be saved forcefully unless commanded
-                forceSave(false);
             }
             else
             {

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -101,6 +101,92 @@ public:
         std::string _modifiedTime; //< Opaque modified timestamp as received from the server.
     };
 
+    /// Represents attributes of interest to the storage.
+    /// These are typically set in the PUT headers.
+    /// They include flags to indicate auto-save, exit-save,
+    /// forced-uploading, and whether or not the document
+    /// had been modified, amongst others.
+    /// The reason for this class is to avoid clobbering
+    /// these attributes when uploading fails--or indeed
+    /// racing with uploading.
+    class Attributes
+    {
+    public:
+        Attributes()
+            : _forced(false)
+            , _isUserModified(false)
+            , _isAutosave(false)
+            , _isExitSave(false)
+        {}
+
+        /// Reset the attributes to clear them after using them.
+        void reset()
+        {
+            _forced = false;
+            _isUserModified = false;
+            _isAutosave = false;
+            _isExitSave = false;
+            _extendedData.clear();
+        }
+
+        void merge(const Attributes& lhs)
+        {
+            // Whichever is true.
+            _forced = lhs._forced ? true : _forced;
+            _isUserModified = lhs._isUserModified ? true : _isUserModified;
+            _isAutosave = lhs._isAutosave ? true : _isAutosave;
+            _isExitSave = lhs._isExitSave ? true : _isExitSave;
+
+            // Clobber with the lhs, assuming it's newer.
+            if (!lhs._extendedData.empty())
+                _extendedData = lhs._extendedData;
+        }
+
+        /// Asks the storage object to force overwrite
+        /// even if document turned out to be changed in storage.
+        /// Used to resolve storage conflicts by clobbering.
+        void setForced(bool forced = true) { _forced = forced; }
+        bool isForced() const { return _forced; }
+
+        /// To be able to set the WOPI extension header appropriately.
+        void setUserModified(bool userModified) { _isUserModified = userModified; }
+        bool isUserModified() const { return _isUserModified; }
+
+        /// To be able to set the WOPI 'is autosave/is exitsave?' headers appropriately.
+        void setIsAutosave(bool newIsAutosave) { _isAutosave = newIsAutosave; }
+        bool isAutosave() const { return _isAutosave; }
+
+        /// Set only when saving on exit.
+        void setIsExitSave(bool exitSave) { _isExitSave = exitSave; }
+        bool isExitSave() const { return _isExitSave; }
+
+        /// Misc extended data.
+        void setExtendedData(const std::string& extendedData) { _extendedData = extendedData; }
+        const std::string& getExtendedData() const { return _extendedData; }
+
+        /// Dump the internals of this instance.
+        void dumpState(std::ostream& os, const std::string& indent = "\n  ")
+        {
+            os << indent << "forced: " << std::boolalpha << isForced();
+            os << indent << "user-modified: " << std::boolalpha << isUserModified();
+            os << indent << "auto-save: " << std::boolalpha << isAutosave();
+            os << indent << "exit-save: " << std::boolalpha << isExitSave();
+            os << indent << "extended-data: " << getExtendedData();
+        }
+
+    private:
+        /// Whether or not we want to force uploading.
+        bool _forced;
+        /// The document has been modified by the user.
+        bool _isUserModified;
+        /// This save operation is an autosave.
+        bool _isAutosave;
+        /// Saving on exit (when the document is cleaned up from memory)
+        bool _isExitSave;
+        /// The client-provided saving extended data to send to the WOPI host.
+        std::string _extendedData;
+    };
+
     /// Represents the upload request result, with a Result code
     /// and a reason message (typically for errors).
     /// Note: the reason message may be displayed to the clients.
@@ -195,11 +281,7 @@ public:
         _localStorePath(localStorePath),
         _jailPath(jailPath),
         _fileInfo(std::string(), "cool", std::string()),
-        _isDownloaded(false),
-        _forceSave(false),
-        _isUserModified(false),
-        _isAutosave(false),
-        _isExitSave(false)
+        _isDownloaded(false)
     {
         setUri(uri);
         LOG_DBG("Storage ctor: " << COOLWSD::anonymizeUrl(_uri.toString()));
@@ -242,24 +324,6 @@ public:
 
     bool isDownloaded() const { return _isDownloaded; }
 
-    /// Asks the storage object to force overwrite to storage upon next save
-    /// even if document turned out to be changed in storage
-    void forceSave(bool newSave = true) { _forceSave = newSave; }
-
-    bool getForceSave() const { return _forceSave; }
-
-    /// To be able to set the WOPI extension header appropriately.
-    void setUserModified(bool userModified) { _isUserModified = userModified; }
-
-    bool isUserModified() const { return _isUserModified; }
-
-    /// To be able to set the WOPI 'is autosave/is exitsave?' headers appropriately.
-    void setIsAutosave(bool newIsAutosave) { _isAutosave = newIsAutosave; }
-    bool isAutosave() const { return _isAutosave; }
-    void setIsExitSave(bool exitSave) { _isExitSave = exitSave; }
-    bool isExitSave() const { return _isExitSave; }
-    void setExtendedData(const std::string& extendedData) { _extendedData = extendedData; }
-
     void setFileInfo(const FileInfo& fileInfo) { _fileInfo = fileInfo; }
 
     /// Returns the basic information about the file.
@@ -269,7 +333,8 @@ public:
     std::string getFileExtension() const { return Poco::Path(_fileInfo.getFilename()).getExtension(); }
 
     /// Update the locking state (check-in/out) of the associated file
-    virtual bool updateLockState(const Authorization& auth, LockContext& lockCtx, bool lock) = 0;
+    virtual bool updateLockState(const Authorization& auth, LockContext& lockCtx, bool lock,
+                                 const Attributes& attribs) = 0;
 
     /// Returns a local file path for the given URI.
     /// If necessary copies the file locally first.
@@ -285,7 +350,7 @@ public:
     virtual void uploadLocalFileToStorageAsync(const Authorization& auth, LockContext& lockCtx,
                                                const std::string& saveAsPath,
                                                const std::string& saveAsFilename,
-                                               const bool isRename, SocketPoll&,
+                                               const bool isRename, const Attributes&, SocketPoll&,
                                                const AsyncUploadCallback& asyncUploadCallback) = 0;
 
     /// Get the progress state of an asynchronous LocalFileToStorage upload.
@@ -342,9 +407,6 @@ protected:
     /// Returns the root path of the jail directory of docs.
     std::string getLocalRootPath() const;
 
-    /// Returns the client-provided extended data to send to the WOPI host.
-    const std::string& getExtendedData() const { return _extendedData; }
-
 private:
     Poco::URI _uri;
     const std::string _localStorePath;
@@ -353,17 +415,6 @@ private:
     std::string _jailedFilePathAnonym;
     FileInfo _fileInfo;
     bool _isDownloaded;
-    bool _forceSave;
-
-    /// The document has been modified by the user.
-    bool _isUserModified;
-
-    /// This save operation is an autosave.
-    bool _isAutosave;
-    /// Saving on exit (when the document is cleaned up from memory)
-    bool _isExitSave;
-    /// The client-provided saving extended data to send to the WOPI host.
-    std::string _extendedData;
 
     static bool FilesystemEnabled;
     /// If true, use only the WOPI URL for whether to use SSL to talk to storage server
@@ -409,7 +460,7 @@ public:
     /// obtained using getFileInfo method
     std::unique_ptr<LocalFileInfo> getLocalFileInfo();
 
-    bool updateLockState(const Authorization&, LockContext&, bool) override
+    bool updateLockState(const Authorization&, LockContext&, bool, const Attributes&) override
     {
         return true;
     }
@@ -420,7 +471,7 @@ public:
     void uploadLocalFileToStorageAsync(const Authorization& auth, LockContext& lockCtx,
                                        const std::string& saveAsPath,
                                        const std::string& saveAsFilename, const bool isRename,
-                                       SocketPoll&,
+                                       const Attributes&, SocketPoll&,
                                        const AsyncUploadCallback& asyncUploadCallback) override;
 
 private:
@@ -571,7 +622,8 @@ public:
                                                         unsigned redirectLimit);
 
     /// Update the locking state (check-in/out) of the associated file
-    bool updateLockState(const Authorization& auth, LockContext& lockCtx, bool lock) override;
+    bool updateLockState(const Authorization& auth, LockContext& lockCtx, bool lock,
+                         const Attributes& attribs) override;
 
     /// uri format: http://server/<...>/wopi*/files/<id>/content
     std::string downloadStorageFileToLocal(const Authorization& auth, LockContext& lockCtx,
@@ -580,7 +632,7 @@ public:
     void uploadLocalFileToStorageAsync(const Authorization& auth, LockContext& lockCtx,
                                        const std::string& saveAsPath,
                                        const std::string& saveAsFilename, const bool isRename,
-                                       SocketPoll& socketPoll,
+                                       const Attributes&, SocketPoll& socketPoll,
                                        const AsyncUploadCallback& asyncUploadCallback) override;
 
     /// Total time taken for making WOPI calls during uploading.

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -276,13 +276,6 @@ public:
     virtual std::string downloadStorageFileToLocal(const Authorization& auth, LockContext& lockCtx,
                                                    const std::string& templateUri) = 0;
 
-    /// Writes the contents of the file back to the source.
-    /// @param savedFile When the operation was saveAs, this is the path to the file that was saved.
-    virtual UploadResult uploadLocalFileToStorage(const Authorization& auth, LockContext& lockCtx,
-                                                  const std::string& saveAsPath,
-                                                  const std::string& saveAsFilename,
-                                                  const bool isRename) = 0;
-
     /// The asynchronous upload completion callback function.
     using AsyncUploadCallback = std::function<void(const AsyncUpload&)>;
 
@@ -293,14 +286,7 @@ public:
                                                const std::string& saveAsPath,
                                                const std::string& saveAsFilename,
                                                const bool isRename, SocketPoll&,
-                                               const AsyncUploadCallback& asyncUploadCallback)
-    {
-        // By default do a synchronous save.
-        const UploadResult res =
-            uploadLocalFileToStorage(auth, lockCtx, saveAsPath, saveAsFilename, isRename);
-        if (asyncUploadCallback)
-            asyncUploadCallback(AsyncUpload(AsyncUpload::State::Complete, res));
-    }
+                                               const AsyncUploadCallback& asyncUploadCallback) = 0;
 
     /// Get the progress state of an asynchronous LocalFileToStorage upload.
     virtual AsyncUpload queryLocalFileToStorageAsyncUploadState()
@@ -431,10 +417,11 @@ public:
     std::string downloadStorageFileToLocal(const Authorization& auth, LockContext& lockCtx,
                                            const std::string& templateUri) override;
 
-    UploadResult uploadLocalFileToStorage(const Authorization& auth, LockContext& lockCtx,
-                                          const std::string& saveAsPath,
-                                          const std::string& saveAsFilename,
-                                          const bool isRename) override;
+    void uploadLocalFileToStorageAsync(const Authorization& auth, LockContext& lockCtx,
+                                       const std::string& saveAsPath,
+                                       const std::string& saveAsFilename, const bool isRename,
+                                       SocketPoll&,
+                                       const AsyncUploadCallback& asyncUploadCallback) override;
 
 private:
     /// True if we the source file a temporary that we own.
@@ -589,11 +576,6 @@ public:
     /// uri format: http://server/<...>/wopi*/files/<id>/content
     std::string downloadStorageFileToLocal(const Authorization& auth, LockContext& lockCtx,
                                            const std::string& templateUri) override;
-
-    UploadResult uploadLocalFileToStorage(const Authorization& auth, LockContext& lockCtx,
-                                          const std::string& saveAsPath,
-                                          const std::string& saveAsFilename,
-                                          const bool isRename) override;
 
     void uploadLocalFileToStorageAsync(const Authorization& auth, LockContext& lockCtx,
                                        const std::string& saveAsPath,


### PR DESCRIPTION
- wsd: remove unused uploadLocalFileToStorage
- wsd: mark last-upload as failed in early-failure
- wsd: track modifying user commands
- wsd: state-dumping and comments
- wsd: move storage attributes to DocBroker
- wsd: test: modernize UnitWOPIAsyncUpload_ModifyClose
- wsd: test: enable IsModifiedByUser assertion
