### PR TITLE
fix(remote_config_pull): nullpointer if host not defined in json

### DIFF
--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -1227,11 +1227,11 @@ public:
             }
             catch (const Poco::NullPointerException&)
             {
-                LOG_INF("Not overwriting any wopi host pattern because the storage->wopi->hosts section does not exist");
+                LOG_INF("Not overwriting any wopi host pattern because the storage->wopi section does not exist");
                 return;
             }
 
-            if (wopiHostPatterns->size() == 0)
+            if (!wopiHostPatterns || wopiHostPatterns->size() == 0)
             {
                 LOG_INF("Not overwriting any wopi host pattern because JSON contains empty array");
                 return;
@@ -1347,11 +1347,11 @@ public:
             }
             catch (const Poco::NullPointerException&)
             {
-                LOG_INF("Not overwriting any alias groups because storage->wopi->alias_groups->groups array does not exist");
+                LOG_INF("Not overwriting any alias groups because storage->wopi->alias_groups section does not exist");
                 return;
             }
 
-            if (groups->size() == 0)
+            if (!groups || groups->size() == 0)
             {
                 LOG_INF("Not overwriting any alias groups because alias_group array is empty");
                 return;


### PR DESCRIPTION
Change-Id: 206e9e3ff1fa33f2073e12fc5adf1ef0bb14d61a

Signed-off-by: genofire <geno+dev@fireorbit.de>


* Resolves: #5235 
* Target version: master 

### Summary

Maybe fix Null-Pointer.
**Suggestion:** drop `fetchWopiHostPatterns`, it is undocumented and not needed.

### TODO

- [ ] drop `fetchWopiHostPatterns`

### Checklist

- [ ] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

