### PR TITLE
wsd: improve SSL error reporting

### DIFF
--- a/net/SslSocket.hpp
+++ b/net/SslSocket.hpp
@@ -361,7 +361,7 @@ private:
                     LOG_TRC("SSL error: UNKNOWN (" << sslError << ") " << getBioError(rc));
 
                 // The error is coming from BIO. Find out what happened.
-                const long bioError = ERR_get_error();
+                const long bioError = ERR_peek_error();
 
                 std::ostringstream oss;
                 oss << '#' << getFD();
@@ -385,9 +385,14 @@ private:
                         oss << ": unknown. ";
                     }
                 }
+                else
+                {
+                    oss << ": unknown. ";
+                }
 
                 oss << getBioError(rc);
-                std::string msg = oss.str();
+                const std::string msg = oss.str();
+                LOG_TRC("Throwing SSL Error: " << msg); // Locate the source of the exception.
                 errno = last_errno; // Restore errno.
                 throw std::runtime_error(msg);
             }
@@ -401,7 +406,7 @@ private:
     std::string getBioError(const int rc) const
     {
         // The error is coming from BIO. Find out what happened.
-        const long bioError = ERR_get_error();
+        const long bioError = ERR_peek_error();
 
         std::ostringstream oss;
         oss << "BIO error: " << bioError << ", rc: " << rc;


### PR DESCRIPTION
ERR_get_error cleared the returned error,
which meant the subsequent call to print
the error in string form, using
ERR_print_errors_cb, didn't find anything
to report.

Change-Id: If131a8cc0d2c1d8bbf705ed38f144b38abf6c8c6
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
