### PR TITLE
Revert "Attempt to solve FreeBSD issue" and fix freebsd check

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -23,7 +23,7 @@ task:
         CXXFLAGS="-I/usr/local/include" LDFLAGS=-L/usr/local/lib ./configure
         --with-lo-path=/usr/local/lib/libreoffice/
         --with-lokit-path=./libreoffice-src/include
-        --disable-seccomp --disable-setcap --enable-debug'' '
+        --disable-seccomp --disable-werror --disable-setcap --enable-debug'' '
     - su -m cool -c 'env HOME=/tmp/coolhome gmake -j`sysctl -n hw.ncpu`'
     - chown root ./coolmount
     - chmod +s ./coolmount

--- a/browser/package.json
+++ b/browser/package.json
@@ -45,6 +45,7 @@
   ],
   "license": "BSD-2-Clause",
   "dependencies": {
+    "canvas": "^2.6.1",
     "jsdom": "^16.4.0",
     "tmp": "^0.2.1"
   },


### PR DESCRIPTION
canvas module is needed for make check. --disable-werror is required, because npm canvas module is not available as a binary package on all target platforms, and it does not compile without warnings from source.

Signed-off-by: Yunusemre Şentürk <yunusemre@collabora.com>
Change-Id: I03e1d72d96ec0d6863ccd6236223a87ee481eb09


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

