### PR TITLE
config: move version/hash from defines to getter functions

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -157,6 +157,7 @@ noinst_PROGRAMS += \
 endif
 
 connect_SOURCES = tools/Connect.cpp \
+		  common/ConfigUtil.cpp \
                   common/DummyTraceEventEmitter.cpp \
                   common/Log.cpp \
                   common/Protocol.cpp \
@@ -164,6 +165,7 @@ connect_SOURCES = tools/Connect.cpp \
                   common/Util.cpp
 
 lokitclient_SOURCES = common/Log.cpp \
+		      common/ConfigUtil.cpp \
                       common/DummyTraceEventEmitter.cpp \
                       tools/KitClient.cpp \
                       common/Protocol.cpp \
@@ -226,6 +228,7 @@ httpecho_fuzzer_LDFLAGS = -fsanitize=fuzzer $(AM_LDFLAGS)
 endif # ENABLE_LIBFUZZER
 
 clientnb_SOURCES = net/clientnb.cpp \
+		   common/ConfigUtil.cpp \
                    common/DummyTraceEventEmitter.cpp \
                    common/Log.cpp \
                    common/StringVector.cpp \
@@ -245,6 +248,7 @@ coolstress_SOURCES = tools/Stress.cpp \
 coolconfig_SOURCES = tools/Config.cpp \
 		     tools/ConfigMigrationAssistant.cpp \
 		     common/DummyTraceEventEmitter.cpp \
+		     common/ConfigUtil.cpp \
 		     common/Crypto.cpp \
 		     common/Log.cpp \
 		     common/StringVector.cpp \

--- a/common/ConfigUtil.cpp
+++ b/common/ConfigUtil.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <config.h>
+#include <config_version.h>
 
 #include <ConfigUtil.hpp>
 #include <Util.hpp>
@@ -66,4 +67,17 @@ bool isSslEnabled()
     return false;
 #endif
 }
+
+const std::string& getVersion()
+{
+    static std::string Version("" COOLWSD_VERSION);
+    return Version;
+}
+
+const std::string& getVersionHash()
+{
+    static std::string VersionHash("" COOLWSD_VERSION_HASH);
+    return VersionHash;
+}
+
 } // namespace config

--- a/common/ConfigUtil.hpp
+++ b/common/ConfigUtil.hpp
@@ -45,4 +45,10 @@ bool getBool(const std::string& key, const bool def);
 /// Return true if SSL is enabled in the config and no fuzzing is enabled.
 bool isSslEnabled();
 
+/// Returns version
+const std::string& getVersion();
+
+/// Returns version hash
+const std::string& getVersionHash();
+
 } // namespace config

--- a/common/Util.cpp
+++ b/common/Util.cpp
@@ -6,7 +6,6 @@
  */
 
 #include <config.h>
-#include <config_version.h>
 
 #include "Util.hpp"
 
@@ -61,6 +60,7 @@
 #include <Poco/Util/Application.h>
 
 #include "Common.hpp"
+#include "ConfigUtil.hpp"
 #include "Log.hpp"
 #include "Protocol.hpp"
 #include "TraceEvent.hpp"
@@ -618,8 +618,8 @@ namespace Util
 
     void getVersionInfo(std::string& version, std::string& hash)
     {
-        version = std::string(COOLWSD_VERSION);
-        hash = std::string(COOLWSD_VERSION_HASH);
+        version = config::getVersion();
+        hash = config::getVersionHash();
         hash.resize(std::min(8, (int)hash.length()));
     }
 

--- a/kit/ForKit.cpp
+++ b/kit/ForKit.cpp
@@ -10,7 +10,6 @@
  */
 
 #include <config.h>
-#include <config_version.h>
 
 #ifndef __FreeBSD__
 #include <sys/capability.h>
@@ -541,7 +540,7 @@ int main(int argc, char** argv)
         }
     }
 
-    SigUtil::setFatalSignals("forkit startup of " COOLWSD_VERSION " " COOLWSD_VERSION_HASH);
+    SigUtil::setFatalSignals("forkit startup of " + config::getVersion() + " " + config::getVersionHash());
 
     Util::setApplicationPath(Poco::Path(argv[0]).parent().toString());
 

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -10,7 +10,6 @@
  */
 
 #include <config.h>
-#include <config_version.h>
 
 #include <dlfcn.h>
 #ifdef __linux__
@@ -2570,7 +2569,7 @@ void lokit_main(
 {
 #if !MOBILEAPP
 
-    SigUtil::setFatalSignals("kit startup of " COOLWSD_VERSION " " COOLWSD_VERSION_HASH);
+    SigUtil::setFatalSignals("kit startup of " + config::getVersion() + " " + config::getVersionHash());
     SigUtil::setUserSignals();
 
     Util::setThreadName("kit_spare_" + Util::encodeId(numericIdentifier, 3));

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -162,7 +162,7 @@ unit_base_la_LIBADD += -lssl -lcrypto
 endif
 
 fakesockettest_CPPFLAGS = -g
-fakesockettest_SOURCES = fakesockettest.cpp  ../net/FakeSocket.cpp ../common/DummyTraceEventEmitter.cpp ../common/Log.cpp ../common/Util.cpp
+fakesockettest_SOURCES = fakesockettest.cpp  ../net/FakeSocket.cpp ../common/DummyTraceEventEmitter.cpp ../common/Log.cpp ../common/ConfigUtil.cpp ../common/Util.cpp
 fakesockettest_LDADD = $(CPPUNIT_LIBS)
 
 # old-style unit tests - bootstrapped via UnitClient

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -6,11 +6,12 @@
  */
 
 #include <config.h>
-#include <config_version.h>
+
 #include <stdexcept>
 #include "COOLWSD.hpp"
 #include "ProofKey.hpp"
 #include "CommandControl.hpp"
+#include "ConfigUtil.hpp"
 #include "HostUtil.hpp"
 
 /* Default host used in the start test URI */
@@ -23,7 +24,7 @@
 #define COOLWSD_TEST_METRICS "/cool/getMetrics"
 
 /* Default cool UI used in the start test URI */
-#define COOLWSD_TEST_COOL_UI "/browser/" COOLWSD_VERSION_HASH "/debug.html"
+#define COOLWSD_TEST_COOL_UI "/browser/" + config::getVersionHash() + "/debug.html"
 
 /* Default document used in the start test URI */
 #define COOLWSD_TEST_DOCUMENT_RELATIVE_PATH_WRITER  "test/data/hello-world.odt"
@@ -4712,9 +4713,9 @@ private:
         const std::string favIconUrl = "favIconUrl";
         const std::string urlsrc = "urlsrc";
 
-        const std::string rootUriValue = "%SRV_URI%";
-        const std::string uriBaseValue = rootUriValue + "/browser/" COOLWSD_VERSION_HASH "/";
-        const std::string uriValue = uriBaseValue + "cool.html?";
+        const std::string rootUriValue("%SRV_URI%");
+        const std::string uriBaseValue(rootUriValue + "/browser/" + config::getVersionHash() + "/");
+        const std::string uriValue(uriBaseValue + "cool.html?");
 
         InputSource inputSrc(discoveryPath);
         DOMParser parser;
@@ -5133,7 +5134,7 @@ void COOLWSD::processFetchUpdate()
 
         Poco::URI uriFetch(url);
         uriFetch.addQueryParameter("product", APP_NAME);
-        uriFetch.addQueryParameter("version", COOLWSD_VERSION);
+        uriFetch.addQueryParameter("version", config::getVersion());
         LOG_TRC("Infobar update request from " << uriFetch.toString());
         std::shared_ptr<http::Session> sessionFetch = StorageBase::getHttpSession(uriFetch);
         if (!sessionFetch)
@@ -5182,7 +5183,7 @@ int COOLWSD::innerMain()
 {
 #if !MOBILEAPP
     SigUtil::setUserSignals();
-    SigUtil::setFatalSignals("wsd " COOLWSD_VERSION " " COOLWSD_VERSION_HASH);
+    SigUtil::setFatalSignals("wsd " + config::getVersion() + " " + config::getVersionHash());
 #endif
 
 #if !MOBILEAPP

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -6,7 +6,6 @@
  */
 
 #include <config.h>
-#include <config_version.h>
 
 #include <iomanip>
 #include <string>
@@ -506,10 +505,10 @@ void FileServerRequestHandler::handleRequest(const HTTPRequest& request,
         LOG_TRC("Fileserver request: " << requestUri.toString());
         requestUri.normalize(); // avoid .'s and ..'s
 
-        if (requestUri.getPath().find("browser/" COOLWSD_VERSION_HASH "/") == std::string::npos)
+        if (requestUri.getPath().find("browser/" + config::getVersionHash() + "/") == std::string::npos)
         {
             LOG_WRN("Client - server version mismatch, disabling browser cache. "
-                    "Expected: " COOLWSD_VERSION_HASH "; Actual URI path with version hash: "
+                    "Expected: " + config::getVersionHash() + "; Actual URI path with version hash: "
                     << requestUri.getPath());
             noCache = true;
         }
@@ -522,7 +521,7 @@ void FileServerRequestHandler::handleRequest(const HTTPRequest& request,
         const std::string relPath = getRequestPathname(request);
         const std::string endPoint = requestSegments[requestSegments.size() - 1];
 
-        static std::string etagString = "\"" COOLWSD_VERSION_HASH +
+        static std::string etagString = "\"" + config::getVersionHash() +
             config.getString("ver_suffix", "") + "\"";
 
 #if ENABLE_DEBUG
@@ -949,8 +948,8 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     Poco::replaceInPlace(preprocess, std::string("%ACCESS_TOKEN_TTL%"), std::to_string(tokenTtl));
     Poco::replaceInPlace(preprocess, std::string("%ACCESS_HEADER%"), escapedAccessHeader);
     Poco::replaceInPlace(preprocess, std::string("%HOST%"), cnxDetails.getWebSocketUrl());
-    Poco::replaceInPlace(preprocess, std::string("%VERSION%"), std::string(COOLWSD_VERSION_HASH));
-    Poco::replaceInPlace(preprocess, std::string("%COOLWSD_VERSION%"), std::string(COOLWSD_VERSION));
+    Poco::replaceInPlace(preprocess, std::string("%VERSION%"), config::getVersionHash());
+    Poco::replaceInPlace(preprocess, std::string("%COOLWSD_VERSION%"), config::getVersion());
     Poco::replaceInPlace(preprocess, std::string("%SERVICE_ROOT%"), responseRoot);
     Poco::replaceInPlace(preprocess, std::string("%UI_DEFAULTS%"), uiDefaultsToJSON(uiDefaults, userInterfaceMode));
     Poco::replaceInPlace(preprocess, std::string("%POSTMESSAGE_ORIGIN%"), escapedPostmessageOrigin);
@@ -968,8 +967,8 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     bool useIntegrationTheme = config.getBool("user_interface.use_integration_theme", true);
     bool hasIntegrationTheme = (theme != "") && FileUtil::Stat(COOLWSD::FileServerRoot + "/browser/dist/" + theme).exists();
     const std::string themePreFix = hasIntegrationTheme && useIntegrationTheme ? theme + "/" : "";
-    const std::string linkCSS("<link rel=\"stylesheet\" href=\"%s/browser/" COOLWSD_VERSION_HASH "/" + themePreFix + "%s.css\">");
-    const std::string scriptJS("<script src=\"%s/browser/" COOLWSD_VERSION_HASH "/" + themePreFix + "%s.js\"></script>");
+    const std::string linkCSS("<link rel=\"stylesheet\" href=\"%s/browser/" + config::getVersionHash() + "/" + themePreFix + "%s.css\">");
+    const std::string scriptJS("<script src=\"%s/browser/" + config::getVersionHash() + "/" + themePreFix + "%s.js\"></script>");
 
     std::string brandCSS(Poco::format(linkCSS, responseRoot, std::string(BRANDING)));
     std::string brandJS(Poco::format(scriptJS, responseRoot, std::string(BRANDING)));
@@ -1132,7 +1131,7 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
         "Last-Modified: " << Util::getHttpTimeNow() << "\r\n"
         "User-Agent: " << WOPI_AGENT_STRING << "\r\n"
         "Cache-Control:max-age=11059200\r\n"
-        "ETag: \"" COOLWSD_VERSION_HASH "\"\r\n"
+        "ETag: \"" << config::getVersionHash() << "\"\r\n"
         "Content-Length: " << preprocess.size() << "\r\n"
         "Content-Type: " << mimeType << "\r\n"
         "X-Content-Type-Options: nosniff\r\n"
@@ -1250,7 +1249,7 @@ void FileServerRequestHandler::preprocessAdminFile(const HTTPRequest& request,
     ServerURL cnxDetails(requestDetails);
     std::string responseRoot = cnxDetails.getResponseRoot();
 
-    static const std::string scriptJS("<script src=\"%s/browser/" COOLWSD_VERSION_HASH "/%s.js\"></script>");
+    static const std::string scriptJS("<script src=\"%s/browser/" + config::getVersionHash() + "/%s.js\"></script>");
     static const std::string footerPage("<footer class=\"footer has-text-centered\"><strong>Key:</strong> %s &nbsp;&nbsp;<strong>Expiry Date:</strong> %s</footer>");
 
     const std::string relPath = getRequestPathname(request);
@@ -1278,7 +1277,7 @@ void FileServerRequestHandler::preprocessAdminFile(const HTTPRequest& request,
 
     Poco::replaceInPlace(templateFile, std::string("<!--%BRANDING_JS%-->"), brandJS);
     Poco::replaceInPlace(templateFile, std::string("<!--%FOOTER%-->"), brandFooter);
-    Poco::replaceInPlace(templateFile, std::string("%VERSION%"), std::string(COOLWSD_VERSION_HASH));
+    Poco::replaceInPlace(templateFile, std::string("%VERSION%"), config::getVersionHash());
     Poco::replaceInPlace(templateFile, std::string("%SERVICE_ROOT%"), responseRoot);
 
     // Ask UAs to block if they detect any XSS attempt


### PR DESCRIPTION
Except for server/agent strings for now, those are lots of changes.

Signed-off-by: Aron Budea <aron.budea@collabora.com>
Change-Id: Idea0d8bcf5162d8976df60bc2797bb87f8915eac


* Target version: master 