### PR TITLE
cypress: fix mobile repair test

### DIFF
--- a/cypress_test/integration_tests/mobile/calc/hamburger_menu_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/hamburger_menu_spec.js
@@ -163,8 +163,6 @@ describe('Trigger hamburger menu options.', function() {
 			.should('contain.text', 'q');
 
 		// Revert one undo step via Repair
-		mobileHelper.selectHamburgerMenuItem(['Edit', 'Repair']);
-
 		repairHelper.rollbackPastChange('Undo', undefined, true);
 
 		cy.get('input#addressInput')


### PR DESCRIPTION
rollbackPastChange function already opens the menu so don't do it twice

regression from: https://github.com/CollaboraOnline/online/commit/fd0c49a0be757c047674164a941914d15c18fd17