### PR TITLE
added option to group save-as

### DIFF
--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -556,58 +556,58 @@
 	font-size: calc(var(--default-font-size)*1.5);
 }
 
-.downloadas-odt-submenu-icon {
+[class*='as-odt-submenu-icon'] {
 	background: url('images/lc_downloadas-odt.svg') center;
 }
 
-.downloadas-ods-submenu-icon {
+[class*='as-ods-submenu-icon'] {
 	background: url('images/lc_downloadas-ods.svg') center;
 }
 
-.downloadas-odp-submenu-icon {
+[class*='as-odp-submenu-icon'] {
 	background: url('images/lc_downloadas-odp.svg') center;
 }
 
-.downloadas-odg-submenu-icon {
+[class*='as-odg-submenu-icon'] {
 	background: url('images/lc_downloadas-odg.svg') center;
 }
 
-.downloadas-rtf-submenu-icon {
+[class*='as-rtf-submenu-icon'] {
 	background: url('images/lc_downloadas-rtf.svg') center;
 }
 
-.downloadas-doc-submenu-icon {
+[class*='as-doc-submenu-icon'] {
 	background: url('images/lc_downloadas-doc.svg') center;
 }
 
-.downloadas-docx-submenu-icon {
+[class*='as-docx-submenu-icon'] {
 	background: url('images/lc_downloadas-docx.svg') center;
 }
 
-.downloadas-pdf-submenu-icon {
+[class*='as-pdf-submenu-icon'] {
 	background: url('images/lc_downloadas-pdf.svg') center;
 }
 
-.downloadas-epub-submenu-icon {
+[class*='as-epub-submenu-icon'] {
 	background: url('images/lc_downloadas-epub.svg') center;
 }
 
-.downloadas-xls-submenu-icon {
+[class*='as-xls-submenu-icon'] {
 	background: url('images/lc_downloadas-xls.svg') center;
 }
 
-.downloadas-xlsx-submenu-icon {
+[class*='as-xlsx-submenu-icon'] {
 	background: url('images/lc_downloadas-xlsx.svg') center;
 }
 
-.downloadas-csv-submenu-icon {
+[class*='as-csv-submenu-icon'] {
 	background: url('images/lc_downloadas-csv.svg') center;
 }
 
-.downloadas-ppt-submenu-icon {
+[class*='as-ppt-submenu-icon'] {
 	background: url('images/lc_downloadas-ppt.svg') center;
 }
 
-.downloadas-pptx-submenu-icon {
+[class*='as-pptx-submenu-icon'] {
 	background: url('images/lc_downloadas-pptx.svg') center;
 }

--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -63,7 +63,12 @@ L.Control.Menubar = L.Control.extend({
 		text:  [
 			{name: _UNO('.uno:PickList', 'text'), id: 'file', type: 'menu', menu: [
 				{name: L.Control.MenubarShortcuts.addShortcut(_UNO('.uno:Save', 'text'), L.Control.MenubarShortcuts.shortcuts.SAVE), id: 'save', type: 'action'},
-				{name: _UNO('.uno:SaveAs', 'text'), id: 'saveas', type: 'action'},
+				{name: _UNO('.uno:SaveAs', 'text'), id: 'saveas', type: window.uiDefaults && window.uiDefaults.saveAsMode === 'group' ? 'menu' : 'action', menu: [
+					{name: _('ODF text document (.odt)'), id: 'saveas-odt', type: 'action'},
+					{name: _('Word 2003 Document (.doc)'), id: 'saveas-doc', type: 'action'},
+					{name: _('Word Document (.docx)'), id: 'saveas-docx', type: 'action'},
+					{name: _('Rich Text (.rtf)'), id: 'saveas-rtf', type: 'action'},
+				]},
 				{name: _('Share...'), id:'shareas', type: 'action'},
 				{name: _('See revision history'), id: 'rev-history', type: 'action'},
 				{name: !window.ThisIsAMobileApp ? _('Download as') : _('Export as'), id: 'downloadas', type: 'menu', menu: [
@@ -335,7 +340,11 @@ L.Control.Menubar = L.Control.extend({
 		presentation: [
 			{name: _UNO('.uno:PickList', 'presentation'), id: 'file', type: 'menu', menu: [
 				{name: L.Control.MenubarShortcuts.addShortcut(_UNO('.uno:Save', 'presentation'), L.Control.MenubarShortcuts.shortcuts.SAVE), id: 'save', type: 'action'},
-				{name: _UNO('.uno:SaveAs', 'presentation'), id: 'saveas', type: 'action'},
+				{name: _UNO('.uno:SaveAs', 'presentation'), id: 'saveas', type: window.uiDefaults && window.uiDefaults.saveAsMode === 'group' ? 'menu' : 'action', menu: [
+					{name: _('ODF presentation (.odp)'), id: 'saveas-odp', type: 'action'},
+					{name: _('PowerPoint 2003 Presentation (.ppt)'), id: 'saveas-ppt', type: 'action'},
+					{name: _('PowerPoint Presentation (.pptx)'), id: 'saveas-pptx', type: 'action'},
+				]},
 				{name: _('Save Comments'), id: 'savecomments', type: 'action'},
 				{name: _('Share...'), id:'shareas', type: 'action'},
 				{name: _('See revision history'), id: 'rev-history', type: 'action'},
@@ -589,7 +598,11 @@ L.Control.Menubar = L.Control.extend({
 		spreadsheet: [
 			{name: _UNO('.uno:PickList', 'spreadsheet'), id: 'file', type: 'menu', menu: [
 				{name: L.Control.MenubarShortcuts.addShortcut(_UNO('.uno:Save', 'spreadsheet'), L.Control.MenubarShortcuts.shortcuts.SAVE), id: 'save', type: 'action'},
-				{name: _UNO('.uno:SaveAs', 'spreadsheet'), id: 'saveas', type: 'action'},
+				{name: _UNO('.uno:SaveAs', 'spreadsheet'), id: 'saveas', type: window.uiDefaults && window.uiDefaults.saveAsMode === 'group' ? 'menu' : 'action', menu: [
+					{name: _('ODF spreadsheet (.ods)'), id: 'saveas-ods', type: 'action'},
+					{name: _('Excel 2003 Spreadsheet (.xls)'), id: 'saveas-xls', type: 'action'},
+					{name: _('Excel Spreadsheet (.xlsx)'), id: 'saveas-xlsx', type: 'action'},
+				]},
 				{name: _('Share...'), id:'shareas', type: 'action'},
 				{name: _('See revision history'), id: 'rev-history', type: 'action'},
 				{name: !window.ThisIsAMobileApp ? _('Download as') : _('Export as'), id:'downloadas', type: 'menu', menu: [
@@ -1666,7 +1679,7 @@ L.Control.Menubar = L.Control.extend({
 	},
 
 	_executeAction: function(itNode, itWizard) {
-		var id, postmessage;
+		var id, postmessage, type;
 		if (itNode === undefined)
 		{ // called from JSDialogBuilder
 			id = itWizard.id;
@@ -1675,6 +1688,7 @@ L.Control.Menubar = L.Control.extend({
 		else
 		{ // called from
 			id = $(itNode).data('id');
+			type = $(itNode).data('type');
 			postmessage = ($(itNode).data('postmessage') === 'true');
 		}
 
@@ -1687,7 +1701,7 @@ L.Control.Menubar = L.Control.extend({
 					this._map.save(false, false);
 				}
 			}
-		} else if (id === 'saveas') {
+		} else if (id === 'saveas' && type === 'action') {
 			this._map.openSaveAs();
 		} else if (id === 'savecomments') {
 			if (this._map.isPermissionEditForComments()) {
@@ -1706,6 +1720,12 @@ L.Control.Menubar = L.Control.extend({
 			fileName = fileName.substr(0, fileName.lastIndexOf('.'));
 			fileName = fileName === '' ? 'document' : fileName;
 			this._map.downloadAs(fileName + '.' + format, format);
+		} else if (id.startsWith('saveas-')) {
+			var format = id.substring('saveas-'.length);
+			var fileName = this._map['wopi'].BaseFileName;
+			fileName = fileName.substr(0, fileName.lastIndexOf('.'));
+			fileName = fileName === '' ? 'document' : fileName;
+			this._map.openSaveAs(format);
 		} else if (id === 'signdocument') {
 			this._map.showSignDocument();
 		} else if (id === 'insertcomment') {
@@ -1942,7 +1962,7 @@ L.Control.Menubar = L.Control.extend({
 		if (menuItem.id === 'save' && this._map['wopi'].HideSaveOption)
 			return false;
 
-		if (menuItem.id === 'saveas' && this._map['wopi'].UserCanNotWriteRelative)
+		if (menuItem.id && (menuItem.id === 'saveas' || menuItem.id.startsWith('saveas-')) && this._map['wopi'].UserCanNotWriteRelative)
 			return false;
 
 		if ((menuItem.id === 'shareas' || menuItem.id === 'ShareAs') && !this._map['wopi'].EnableShare)

--- a/browser/src/control/Control.NotebookbarBuilder.js
+++ b/browser/src/control/Control.NotebookbarBuilder.js
@@ -407,8 +407,9 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 		data.command = data.id;
 
 		var isDownloadAsGroup = data.id === 'downloadas';
+		var isSaveAsGroup = data.id === 'saveas';
 		var options = {};
-		if (isDownloadAsGroup) {
+		if (isDownloadAsGroup || isSaveAsGroup) {
 			options.hasDropdownArrow = true;
 		}
 
@@ -417,15 +418,15 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 		$(control.container).unbind('click.toolbutton');
 		if (!builder.map.isLockedItem(data)) {
 			$(control.container).click(function () {
-				if (!isDownloadAsGroup) {
+				if (!isDownloadAsGroup && !isSaveAsGroup) {
 					L.control.menubar()._executeAction.bind({_map: builder.options.map})(undefined, {id: data.id});
 					return;
 				}
 
-				var downloadasSubmenuOpts = builder._getDownloadAsSubmenuOpts(builder.options.map._docLayer._docType);
+				var submenuOpts = builder._getSubmenuOpts(builder.options.map._docLayer._docType, data.id, builder);
 
 				$(control.container).w2menu({
-					items: downloadasSubmenuOpts,
+					items: submenuOpts,
 					onSelect: function (event) {
 						L.control.menubar()._executeAction.bind({_map: builder.options.map})(undefined, {id: event.item.id});
 					}
@@ -454,6 +455,15 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 		builder.options.noLabelsForUnoButtons = noLabels;
 
 		return false;
+	},
+
+	_getSubmenuOpts: function(docType, id, builder) {
+		switch (id) {
+		case 'downloadas':
+			return builder._getDownloadAsSubmenuOpts(docType);
+		case 'saveas':
+			return builder._getSaveAsSubmenuOpts(docType);
+		}
 	},
 
 	_getDownloadAsSubmenuOpts: function(docType) {
@@ -530,6 +540,67 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 				{
 					'id': 'downloadas-pdf',
 					'text': _('PDF Document (.pdf)')
+				}
+			];
+		}
+
+		submenuOpts.forEach(function mapIconToItem(menuItem) {
+			menuItem.icon = menuItem.id + '-submenu-icon';
+		});
+
+		return submenuOpts;
+	},
+
+	_getSaveAsSubmenuOpts: function(docType) {
+		var submenuOpts = [];
+
+		if (docType === 'text') {
+			submenuOpts = [
+				{
+					'id': 'saveas-odt',
+					'text': _('ODF text document (.odt)')
+				},
+				{
+					'id': 'saveas-rtf',
+					'text': _('Rich Text (.rtf)')
+				},
+				{
+					'id': 'saveas-docx',
+					'text': _('Word Document (.docx)')
+				},
+				{
+					'id': 'saveas-doc',
+					'text': _('Word 2003 Document (.doc)')
+				}
+			];
+		} else if (docType === 'spreadsheet') {
+			submenuOpts = [
+				{
+					'id': 'saveas-ods',
+					'text': _('ODF spreadsheet (.ods)')
+				},
+				{
+					'id': 'saveas-xlsx',
+					'text': _('Excel Spreadsheet (.xlsx)')
+				},
+				{
+					'id': 'saveas-xls',
+					'text': _('Excel 2003 Spreadsheet (.xls)')
+				}
+			];
+		} else if (docType === 'presentation') {
+			submenuOpts = [
+				{
+					'id': 'saveas-odp',
+					'text': _('ODF presentation (.odp)')
+				},
+				{
+					'id': 'saveas-pptx',
+					'text': _('PowerPoint Presentation (.pptx)')
+				},
+				{
+					'id': 'saveas-ppt',
+					'text': _('PowerPoint 2003 Presentation (.ppt)')
 				}
 			];
 		}

--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -85,29 +85,43 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 		var hasSaveAs = !this._map['wopi'].UserCanNotWriteRelative;
 		var hasShare = this._map['wopi'].EnableShare;
 		var hasGroupedDownloadAs = !!window.groupDownloadAsForNb;
+		var hasGroupedSaveAs = window.uiDefaults && window.uiDefaults.saveAsMode === 'group';
 		var hasRunMacro = !(window.enableMacrosExecution  === 'false');
 		var hasSave = !this._map['wopi'].HideSaveOption;
+		var content = [];
 
-		var content = [
-			hasSave ?
-				{
-					'type': 'toolbox',
-					'children': [
-						{
-							'id': 'file-save',
-							'type': 'bigtoolitem',
-							'text': _('Save'),
-							'command': '.uno:Save'
-						}
-					]
-				} : {},
-			hasSaveAs ?
-				{
+		if (hasSave) {
+			content.push({
+				'type': 'toolbox',
+				'children': [
+					{
+						'id': 'file-save',
+						'type': 'bigtoolitem',
+						'text': _('Save'),
+						'command': '.uno:Save'
+					}
+				]
+			});
+		}
+
+		if (hasSaveAs) {
+			if (hasGroupedSaveAs) {
+				content.push({
+					'id': 'saveas',
+					'type': 'bigmenubartoolitem',
+					'text': _('Save As'),
+				});
+			} else {
+				content.push({
 					'id': 'file-saveas',
 					'type': 'bigtoolitem',
 					'text': _UNO('.uno:SaveAs', 'spreadsheet'),
 					'command': '.uno:SaveAs'
-				} : {},
+				});
+			}
+		}
+
+		content = content.concat([
 			{
 				'id': 'file-shareas-rev-history',
 				'type': 'container',
@@ -148,7 +162,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 						}
 					]
 				} : {}
-		];
+		]);
 
 		if (hasGroupedDownloadAs) {
 			content.push({

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -137,29 +137,43 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 		var hasSaveAs = !this._map['wopi'].UserCanNotWriteRelative;
 		var hasShare = this._map['wopi'].EnableShare;
 		var hasGroupedDownloadAs = !!window.groupDownloadAsForNb;
+		var hasGroupedSaveAs = window.uiDefaults && window.uiDefaults.saveAsMode === 'group';
 		var hasRunMacro = !(window.enableMacrosExecution  === 'false');
 		var hasSave = !this._map['wopi'].HideSaveOption;
+		var content = [];
 
-		var content = [
-			hasSave ?
-				{
-					'type': 'toolbox',
-					'children': [
-						{
-							'id': 'file-save',
-							'type': 'bigtoolitem',
-							'text': _('Save'),
-							'command': '.uno:Save'
-						}
-					]
-				} : {},
-			hasSaveAs ?
-				{
+		if (hasSave) {
+			content.push({
+				'type': 'toolbox',
+				'children': [
+					{
+						'id': 'file-save',
+						'type': 'bigtoolitem',
+						'text': _('Save'),
+						'command': '.uno:Save'
+					}
+				]
+			});
+		}
+
+		if (hasSaveAs) {
+			if (hasGroupedSaveAs) {
+				content.push({
+					'id': 'saveas',
+					'type': 'bigmenubartoolitem',
+					'text': _('Save As'),
+				});
+			} else {
+				content.push({
 					'id': 'file-saveas',
 					'type': 'bigtoolitem',
 					'text': _UNO('.uno:SaveAs', 'presentation'),
 					'command': '.uno:SaveAs'
-				} : {},
+				});
+			}
+		}
+
+		var content = content.concat([
 			{
 				'id': 'file-shareas-rev-history',
 				'type': 'container',
@@ -200,7 +214,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 						}
 					]
 				} : {}
-		];
+		]);
 
 		if (hasGroupedDownloadAs) {
 			content.push({

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -99,29 +99,43 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 		var hasSaveAs = !this._map['wopi'].UserCanNotWriteRelative;
 		var hasShare = this._map['wopi'].EnableShare;
 		var hasGroupedDownloadAs = !!window.groupDownloadAsForNb;
+		var hasGroupedSaveAs = window.uiDefaults && window.uiDefaults.saveAsMode === 'group';
 		var hasRunMacro = !(window.enableMacrosExecution  === 'false');
 		var hasSave = !this._map['wopi'].HideSaveOption;
+		var content = [];
 
-		var content = [
-			hasSave ?
-				{
-					'type': 'toolbox',
-					'children': [
-						{
-							'id': 'file-save',
-							'type': 'bigtoolitem',
-							'text': _('Save'),
-							'command': '.uno:Save'
-						}
-					]
-				} : {},
-			hasSaveAs ?
-				{
+		if (hasSave) {
+			content.push({
+				'type': 'toolbox',
+				'children': [
+					{
+						'id': 'file-save',
+						'type': 'bigtoolitem',
+						'text': _('Save'),
+						'command': '.uno:Save'
+					}
+				]
+			});
+		}
+
+		if (hasSaveAs) {
+			if (hasGroupedSaveAs) {
+				content.push({
+					'id': 'saveas',
+					'type': 'bigmenubartoolitem',
+					'text': _('Save As'),
+				});
+			} else {
+				content.push({
 					'id': 'file-saveas',
 					'type': 'bigtoolitem',
 					'text': _UNO('.uno:SaveAs', 'text'),
 					'command': '.uno:SaveAs'
-				} : {},
+				});
+			}
+		}
+
+		content = content.concat([
 			{
 				'type': 'container',
 				'children': [
@@ -161,7 +175,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 						}
 					]
 				} : {}
-		];
+		]);
 
 		if (hasGroupedDownloadAs) {
 			content.push({

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -774,9 +774,9 @@ L.Map.include({
 		var map = this;
 		map.fire('postMessage', {msgId: 'UI_Share'});
 	},
-	openSaveAs: function () {
+	openSaveAs: function (format) {
 		var map = this;
-		map.fire('postMessage', {msgId: 'UI_SaveAs'});
+		map.fire('postMessage', {msgId: 'UI_SaveAs', args: {format: format}});
 	},
 
 	formulabarBlur: function() {

--- a/wsd/FileServerUtil.cpp
+++ b/wsd/FileServerUtil.cpp
@@ -58,6 +58,14 @@ std::string FileServerRequestHandler::uiDefaultsToJSON(const std::string& uiDefa
 
             continue;
         }
+        if (keyValue.equals(0, "SaveAsMode"))
+        {
+            if (keyValue.equals(1, "group"))
+            {
+                json.set("saveAsMode", "group");
+            }
+            continue;
+        }
         else if (keyValue.startsWith(0, "Text"))
         {
             currentDef = &textDefs;


### PR DESCRIPTION
We can provide doctype extensions for save-as much like downloadAs but this will load the new file in the integration. instead of downloading

To achive this, args: {format: '<extension>' } parameter needs to be sent inside UI_SaveAs postmessage. Because the integration provides dialog with filename, there the extension will be set after the filename. Our save-as work flow already handles the rest.

Signed-off-by: Mert Tumer <mert.tumer@collabora.com>
Change-Id: I6005846047fc0b26ea07e8eeea965965ed1b87e7


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

