### PR TITLE
Save different sidebar states for Impress. (Szymon's version)

### DIFF
--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -1792,12 +1792,6 @@ L.Control.Menubar = L.Control.extend({
 			return;
 		}
 
-		if (unoCommand.startsWith('.uno:Sidebar') || unoCommand.startsWith('.uno:SlideMasterPage') ||
-			unoCommand.startsWith('.uno:ModifyPage') || unoCommand.startsWith('.uno:SlideChangeWindow') ||
-			unoCommand.startsWith('.uno:CustomAnimation') || unoCommand.startsWith('.uno:MasterSlidesPanel')) {
-			window.initSidebarState = true;
-		}
-
 		this._map.sendUnoCommand(unoCommand);
 	},
 

--- a/browser/src/control/Control.Sidebar.js
+++ b/browser/src/control/Control.Sidebar.js
@@ -3,7 +3,7 @@
  * L.Control.Sidebar
  */
 
-/* global $ */
+/* global $ app */
 L.Control.Sidebar = L.Control.extend({
 
 	options: {
@@ -12,6 +12,7 @@ L.Control.Sidebar = L.Control.extend({
 
 	container: null,
 	builder: null,
+	targetDeckCommand: null,
 
 	onAdd: function (map) {
 		this.map = map;
@@ -30,6 +31,10 @@ L.Control.Sidebar = L.Control.extend({
 		this.map.off('jsdialogaction', this.onJSAction, this);
 	},
 
+	isVisible: function() {
+		return $('#sidebar-dock-wrapper').is(':visible');
+	},
+
 	closeSidebar: function() {
 		$('#sidebar-dock-wrapper').hide();
 		this.map._onResize();
@@ -40,10 +45,7 @@ L.Control.Sidebar = L.Control.extend({
 			this.map.focus();
 		}
 
-		if (window.initSidebarState) {
-			this.map.uiManager.setSavedState('ShowSidebar', false);
-			window.initSidebarState = false;
-		}
+		this.map.uiManager.setSavedState('ShowSidebar', false);
 	},
 
 	onJSUpdate: function (e) {
@@ -124,6 +126,31 @@ L.Control.Sidebar = L.Control.extend({
 		this.map.uiManager.setSavedState('SdMasterPagesDeck', false);
 	},
 
+	commandForDeck: function(deckId) {
+		if (deckId === 'PropertyDeck')
+			return ''; // not important for us
+		else if (deckId === 'SdSlideTransitionDeck')
+			return '.uno:SlideChangeWindow';
+		else if (deckId === 'SdCustomAnimationDeck')
+			return '.uno:CustomAnimation';
+		else if (deckId === 'SdMasterPagesDeck')
+			return '.uno:MasterSlidesPanel';
+		return '';
+	},
+
+	setupTargetDeck: function(unoCommand) {
+		this.targetDeckCommand = unoCommand;
+	},
+
+	getTargetDeck: function() {
+		return this.targetDeckCommand;
+	},
+
+	changeDeck: function(unoCommand) {
+		app.socket.sendMessage('uno ' + unoCommand);
+		this.setupTargetDeck(unoCommand);
+	},
+
 	onSidebar: function(data) {
 		var sidebarData = data.data;
 		this.builder.setWindowId(sidebarData.id);
@@ -145,17 +172,28 @@ L.Control.Sidebar = L.Control.extend({
 
 				if (this.map.getDocType() === 'presentation' && sidebarData.children && sidebarData.children[0] && sidebarData.children[0].id) {
 					this.unsetSelectedSidebar();
-					this.map.uiManager.setSavedState(sidebarData.children[0].id, true);
+					var currentDeck = sidebarData.children[0].id;
+					this.map.uiManager.setSavedState(currentDeck, true);
+					if (this.targetDeckCommand) {
+						var stateHandler = this.map['stateChangeHandler'];
+						var isCurrent = stateHandler ?
+							stateHandler.getItemValue(this.targetDeckCommand) : false;
+						// just to be sure chack with other method
+						if (isCurrent === 'false' || !isCurrent)
+							isCurrent = this.targetDeckCommand === this.commandForDeck(currentDeck);
+						if (this.targetDeckCommand &&
+							(isCurrent === 'false' || !isCurrent))
+							this.changeDeck(this.targetDeckCommand);
+					} else {
+						this.changeDeck(this.targetDeckCommand);
+					}
 				}
 
 				this.builder.build(this.container, [sidebarData]);
 				if (wrapper.style.display === 'none')
 					$('#sidebar-dock-wrapper').show(this.options.animSpeed);
 
-				if (window.initSidebarState) {
-					this.map.uiManager.setSavedState('ShowSidebar', true);
-					window.initSidebarState = false;
-				}
+				this.map.uiManager.setSavedState('ShowSidebar', true);
 			} else {
 				this.closeSidebar();
 			}

--- a/browser/src/control/Control.Sidebar.js
+++ b/browser/src/control/Control.Sidebar.js
@@ -117,6 +117,13 @@ L.Control.Sidebar = L.Control.extend({
 		wrapper.style.maxHeight = document.getElementById('document-container').getBoundingClientRect().height + 'px';
 	},
 
+	unsetSelectedSidebar: function() {
+		this.map.uiManager.setSavedState('PropertyDeck', false);
+		this.map.uiManager.setSavedState('SdSlideTransitionDeck', false);
+		this.map.uiManager.setSavedState('SdCustomAnimationDeck', false);
+		this.map.uiManager.setSavedState('SdMasterPagesDeck', false);
+	},
+
 	onSidebar: function(data) {
 		var sidebarData = data.data;
 		this.builder.setWindowId(sidebarData.id);
@@ -135,6 +142,11 @@ L.Control.Sidebar = L.Control.extend({
 
 				this.onResize();
 				this.map.dialog._resizeCalcInputBar();
+
+				if (this.map.getDocType() === 'presentation' && sidebarData.children && sidebarData.children[0] && sidebarData.children[0].id) {
+					this.unsetSelectedSidebar();
+					this.map.uiManager.setSavedState(sidebarData.children[0].id, true);
+				}
 
 				this.builder.build(this.container, [sidebarData]);
 				if (wrapper.style.display === 'none')

--- a/browser/src/control/Control.Toolbar.js
+++ b/browser/src/control/Control.Toolbar.js
@@ -77,12 +77,6 @@ function onClick(e, id, item) {
 	// dont reassign the item if we already have it
 	item = item || getToolbarItemById(id);
 
-	if (id === 'sidebar' || id === 'modifypage' || id === 'slidechangewindow' || id === 'customanimation' || id === 'masterslidespanel') {
-		if (!map.uiManager.getSavedStateOrDefault('ShowSidebar', false))
-			map.sendUnoCommand('.uno:SidebarShow');
-		window.initSidebarState = true;
-	}
-
 	// In the iOS app we don't want clicking on the toolbar to pop up the keyboard.
 	if (!window.ThisIsTheiOSApp && id !== 'zoomin' && id !== 'zoomout' && id !== 'mobile_wizard' && id !== 'insertion_mobile_wizard') {
 		map.focus(map.canAcceptKeyboardInput()); // Maintain same keyboard state.

--- a/browser/src/control/Control.Toolbar.js
+++ b/browser/src/control/Control.Toolbar.js
@@ -78,6 +78,8 @@ function onClick(e, id, item) {
 	item = item || getToolbarItemById(id);
 
 	if (id === 'sidebar' || id === 'modifypage' || id === 'slidechangewindow' || id === 'customanimation' || id === 'masterslidespanel') {
+		if (!map.uiManager.getSavedStateOrDefault('ShowSidebar', false))
+			map.sendUnoCommand('.uno:SidebarShow');
 		window.initSidebarState = true;
 	}
 

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -213,16 +213,27 @@ L.Control.UIManager = L.Control.extend({
 		if (window.mode.isDesktop() && !window.ThisIsAMobileApp) {
 			var showSidebar = this.getSavedStateOrDefault('ShowSidebar');
 
-			if (this.map.getDocType() === 'presentation') {
-				if (this.getSavedStateOrDefault('SdSlideTransitionDeck'))
-					app.socket.sendMessage('uno .uno:SlideChangeWindow');
-				else if (this.getSavedStateOrDefault('SdCustomAnimationDeck'))
-					app.socket.sendMessage('uno .uno:CustomAnimation');
-				else if (this.getSavedStateOrDefault('SdMasterPagesDeck'))
-					app.socket.sendMessage('uno .uno:MasterSlidesPanel');
+			if (this.getSavedStateOrDefault('PropertyDeck')) {
+				app.socket.sendMessage('uno .uno:SidebarShow');
 			}
 
-			if (showSidebar === false)
+			if (this.map.getDocType() === 'presentation') {
+				if (this.getSavedStateOrDefault('SdSlideTransitionDeck', false)) {
+					app.socket.sendMessage('uno .uno:SidebarShow');
+					app.socket.sendMessage('uno .uno:SlideChangeWindow');
+					this.map.sidebar.setupTargetDeck('.uno:SlideChangeWindow');
+				} else if (this.getSavedStateOrDefault('SdCustomAnimationDeck', false)) {
+					app.socket.sendMessage('uno .uno:SidebarShow');
+					app.socket.sendMessage('uno .uno:CustomAnimation');
+					this.map.sidebar.setupTargetDeck('.uno:CustomAnimation');
+				} else if (this.getSavedStateOrDefault('SdMasterPagesDeck', false)) {
+					app.socket.sendMessage('uno .uno:SidebarShow');
+					app.socket.sendMessage('uno .uno:MasterSlidesPanel');
+					this.map.sidebar.setupTargetDeck('.uno:MasterSlidesPanel');
+				}
+			}
+
+			if (!showSidebar)
 				app.socket.sendMessage('uno .uno:SidebarHide');
 		}
 		else if (window.mode.isChromebook()) {

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -213,6 +213,15 @@ L.Control.UIManager = L.Control.extend({
 		if (window.mode.isDesktop() && !window.ThisIsAMobileApp) {
 			var showSidebar = this.getSavedStateOrDefault('ShowSidebar');
 
+			if (this.map.getDocType() === 'presentation') {
+				if (this.getSavedStateOrDefault('SdSlideTransitionDeck'))
+					app.socket.sendMessage('uno .uno:SlideChangeWindow');
+				else if (this.getSavedStateOrDefault('SdCustomAnimationDeck'))
+					app.socket.sendMessage('uno .uno:CustomAnimation');
+				else if (this.getSavedStateOrDefault('SdMasterPagesDeck'))
+					app.socket.sendMessage('uno .uno:MasterSlidesPanel');
+			}
+
 			if (showSidebar === false)
 				app.socket.sendMessage('uno .uno:SidebarHide');
 		}

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -323,14 +323,25 @@ L.Map.include({
 
 	sendUnoCommand: function (command, json) {
 		if ((command.startsWith('.uno:Sidebar') && !command.startsWith('.uno:SidebarShow')) ||
-			command.startsWith('.uno:SlideMasterPage') ||
-			command.startsWith('.uno:ModifyPage') || command.startsWith('.uno:SlideChangeWindow') ||
-			command.startsWith('.uno:CustomAnimation') || command.startsWith('.uno:MasterSlidesPanel')) {
+			command.startsWith('.uno:SlideMasterPage') || command.startsWith('.uno:SlideChangeWindow') ||
+			command.startsWith('.uno:CustomAnimation') || command.startsWith('.uno:MasterSlidesPanel') ||
+			command.startsWith('.uno:ModifyPage')) {
 
-			if (!this.uiManager.getSavedStateOrDefault('ShowSidebar', false))
-				this.sendUnoCommand('.uno:SidebarShow');
+			// sidebar control is present only in desktop/tablet case
+			if (this.sidebar) {
+				if (this.sidebar.isVisible()) {
+					this.sidebar.setupTargetDeck(command);
+				} else {
+					// we don't know which deck was active last, show first then switch if needed
+					app.socket.sendMessage('uno .uno:SidebarShow');
 
-			window.initSidebarState = true;
+					if (this.sidebar.getTargetDeck() == null)
+						app.socket.sendMessage('uno ' + command);
+
+					this.sidebar.setupTargetDeck(command);
+					return;
+				}
+			}
 		}
 
 		// To exercise the Trace Event functionality, uncomment this

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -322,6 +322,12 @@ L.Map.include({
 	},
 
 	sendUnoCommand: function (command, json) {
+		if (command.startsWith('.uno:Sidebar') || command.startsWith('.uno:SlideMasterPage') ||
+			command.startsWith('.uno:ModifyPage') || command.startsWith('.uno:SlideChangeWindow') ||
+			command.startsWith('.uno:CustomAnimation') || command.startsWith('.uno:MasterSlidesPanel')) {
+			window.initSidebarState = true;
+		}
+
 		// To exercise the Trace Event functionality, uncomment this
 		// app.socket.emitInstantTraceEvent('cool-unocommand:' + command);
 

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -322,9 +322,14 @@ L.Map.include({
 	},
 
 	sendUnoCommand: function (command, json) {
-		if (command.startsWith('.uno:Sidebar') || command.startsWith('.uno:SlideMasterPage') ||
+		if ((command.startsWith('.uno:Sidebar') && !command.startsWith('.uno:SidebarShow')) ||
+			command.startsWith('.uno:SlideMasterPage') ||
 			command.startsWith('.uno:ModifyPage') || command.startsWith('.uno:SlideChangeWindow') ||
 			command.startsWith('.uno:CustomAnimation') || command.startsWith('.uno:MasterSlidesPanel')) {
+
+			if (!this.uiManager.getSavedStateOrDefault('ShowSidebar', false))
+				this.sendUnoCommand('.uno:SidebarShow');
+
 			window.initSidebarState = true;
 		}
 

--- a/cypress_test/integration_tests/common/mobile_helper.js
+++ b/cypress_test/integration_tests/common/mobile_helper.js
@@ -230,6 +230,7 @@ function closeInsertionWizard() {
 	cy.log('Closing insertion wizard - end.');
 }
 
+/// deprecated: see selectFromColorPicker function instead
 function selectFromColorPalette(paletteNum, groupNum, paletteAfterChangeNum, colorNum) {
 	cy.log('Selecting a color from the color palette - start.');
 
@@ -240,6 +241,27 @@ function selectFromColorPalette(paletteNum, groupNum, paletteAfterChangeNum, col
 
 	if (paletteAfterChangeNum !== undefined && colorNum !== undefined) {
 		cy.get('#color-picker-' + paletteAfterChangeNum.toString() + '-tint-' + colorNum.toString())
+			.click();
+	}
+
+	cy.wait(1000);
+
+	cy.get('#mobile-wizard-back')
+		.click();
+
+	cy.log('Selecting a color from the color palette - end.');
+}
+
+function selectFromColorPicker(pickerId, groupNum, colorNum) {
+	cy.log('Selecting a color from the color palette - start.');
+
+	cy.get(pickerId + ' [id^=color-picker-][id$=-basic-color-' + groupNum.toString() + ']')
+		.click();
+
+	cy.wait(1000);
+
+	if (colorNum !== undefined) {
+		cy.get(pickerId + ' [id^=color-picker-][id$=-tint-' + colorNum.toString() + ']')
 			.click();
 	}
 
@@ -391,6 +413,7 @@ module.exports.executeCopyFromContextMenu = executeCopyFromContextMenu;
 module.exports.openInsertionWizard = openInsertionWizard;
 module.exports.closeInsertionWizard = closeInsertionWizard;
 module.exports.selectFromColorPalette = selectFromColorPalette;
+module.exports.selectFromColorPicker = selectFromColorPicker;
 module.exports.openTextPropertiesPanel = openTextPropertiesPanel;
 module.exports.selectListBoxItem = selectListBoxItem;
 module.exports.selectListBoxItem2 = selectListBoxItem2;

--- a/cypress_test/integration_tests/mobile/calc/alignment_options_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/alignment_options_spec.js
@@ -43,7 +43,7 @@ describe('Change alignment settings.', function() {
 
 		helper.clickOnIdle('#ScAlignmentPropertyPanel');
 
-		cy.get('#AlignLeft')
+		cy.get('.unoAlignLeft')
 			.should('be.visible');
 	}
 
@@ -51,7 +51,7 @@ describe('Change alignment settings.', function() {
 		openAlignmentPaneForFirstCell();
 
 		// Set right aligment first
-		helper.clickOnIdle('#AlignRight');
+		helper.clickOnIdle('.unoAlignRight');
 
 		calcHelper.selectEntireSheet();
 
@@ -65,7 +65,7 @@ describe('Change alignment settings.', function() {
 
 		helper.clickOnIdle('#ScAlignmentPropertyPanel');
 
-		helper.clickOnIdle('#AlignLeft');
+		helper.clickOnIdle('.unoAlignLeft');
 
 		calcHelper.selectEntireSheet();
 
@@ -76,7 +76,7 @@ describe('Change alignment settings.', function() {
 	it('Align to center horizontally.', function() {
 		openAlignmentPaneForFirstCell();
 
-		helper.clickOnIdle('#AlignHorizontalCenter');
+		helper.clickOnIdle('.unoAlignHorizontalCenter');
 
 		calcHelper.selectEntireSheet();
 
@@ -87,7 +87,7 @@ describe('Change alignment settings.', function() {
 	it('Change to block alignment.', function() {
 		openAlignmentPaneForFirstCell();
 
-		helper.clickOnIdle('#AlignBlock');
+		helper.clickOnIdle('.unoAlignBlock');
 
 		calcHelper.selectEntireSheet();
 
@@ -112,7 +112,7 @@ describe('Change alignment settings.', function() {
 	it('Align to the top and to bottom.', function() {
 		openAlignmentPaneForFirstCell();
 
-		helper.clickOnIdle('#AlignTop');
+		helper.clickOnIdle('.unoAlignTop');
 
 		calcHelper.selectEntireSheet();
 
@@ -126,7 +126,7 @@ describe('Change alignment settings.', function() {
 
 		helper.clickOnIdle('#ScAlignmentPropertyPanel');
 
-		helper.clickOnIdle('#AlignBottom');
+		helper.clickOnIdle('.unoAlignBottom');
 
 		calcHelper.selectEntireSheet();
 
@@ -137,7 +137,7 @@ describe('Change alignment settings.', function() {
 	it('Align to center vertically.', function() {
 		openAlignmentPaneForFirstCell();
 
-		helper.clickOnIdle('#AlignVCenter');
+		helper.clickOnIdle('.unoAlignVCenter');
 
 		calcHelper.selectEntireSheet();
 
@@ -265,7 +265,7 @@ describe('Change alignment settings.', function() {
 
 		helper.clickOnIdle('#ScAlignmentPropertyPanel');
 
-		cy.get('#AlignLeft')
+		cy.get('.unoAlignLeft')
 			.should('be.visible');
 
 		cy.get('input#mergecells')

--- a/cypress_test/integration_tests/mobile/impress/apply_font_text_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/apply_font_text_spec.js
@@ -30,7 +30,7 @@ describe('Apply font on selected text.', function() {
 
 		mobileHelper.openTextPropertiesPanel();
 
-		helper.clickOnIdle('#Bold');
+		helper.clickOnIdle('.unoBold');
 
 		triggerNewSVG();
 
@@ -43,7 +43,7 @@ describe('Apply font on selected text.', function() {
 
 		mobileHelper.openTextPropertiesPanel();
 
-		helper.clickOnIdle('#Italic');
+		helper.clickOnIdle('.unoItalic');
 
 		triggerNewSVG();
 
@@ -56,7 +56,7 @@ describe('Apply font on selected text.', function() {
 
 		mobileHelper.openTextPropertiesPanel();
 
-		helper.clickOnIdle('#Underline');
+		helper.clickOnIdle('.unoUnderline');
 
 		triggerNewSVG();
 
@@ -69,7 +69,7 @@ describe('Apply font on selected text.', function() {
 
 		mobileHelper.openTextPropertiesPanel();
 
-		helper.clickOnIdle('#Strikeout');
+		helper.clickOnIdle('.unoStrikeout');
 
 		triggerNewSVG();
 
@@ -82,7 +82,7 @@ describe('Apply font on selected text.', function() {
 
 		mobileHelper.openTextPropertiesPanel();
 
-		helper.clickOnIdle('#Shadowed');
+		helper.clickOnIdle('.unoShadowed');
 
 		triggerNewSVG();
 
@@ -129,7 +129,7 @@ describe('Apply font on selected text.', function() {
 
 		helper.clickOnIdle('#Color .ui-header');
 
-		mobileHelper.selectFromColorPalette(2, 5, 13, 2);
+		mobileHelper.selectFromColorPicker('#Color', 5, 2);
 
 		triggerNewSVG();
 
@@ -144,7 +144,7 @@ describe('Apply font on selected text.', function() {
 
 		helper.clickOnIdle('#CharBackColor .ui-header');
 
-		mobileHelper.selectFromColorPalette(3, 2, 13, 2);
+		mobileHelper.selectFromColorPicker('#CharBackColor', 2, 2);
 
 		cy.get('#CharBackColor .color-sample-selected')
 			.should('have.attr', 'style', 'background-color: rgb(204, 0, 0);');
@@ -172,7 +172,7 @@ describe('Apply font on selected text.', function() {
 		cy.get('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph')
 			.should('have.attr', 'font-size', '635px');
 
-		helper.clickOnIdle('#SuperScript');
+		helper.clickOnIdle('.unoSuperScript');
 
 		triggerNewSVG();
 
@@ -192,7 +192,7 @@ describe('Apply font on selected text.', function() {
 		cy.get('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph')
 			.should('have.attr', 'font-size', '635px');
 
-		helper.clickOnIdle('#SubScript');
+		helper.clickOnIdle('.unoSubScript');
 
 		triggerNewSVG();
 


### PR DESCRIPTION
works with core fix: https://gerrit.libreoffice.org/c/core/+/140035
sidebar: show on demand

Previously sidebar was always active on launch.
This patch together with core fix changes that so
initially it is off and we don't waste resources
for rendering sidebar which is hidden just after short
time.

We don't know the state of sidebar (which deck is activated)
on the core side so in some cases we need to switch decks
in 2 steps: send SidebarShow, and when we received result
we change deck to other one or we do nothing. This allows us
to switch correctly the decks.