### PR TITLE
Add a dummy handler (for now) for LOK_CALLBACK_FONTS_MISSING

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -3110,6 +3110,9 @@ void ChildSession::loKitCallback(const int type, const std::string& payload)
     case LOK_CALLBACK_PRINT_RANGES:
         sendTextFrame("printranges: " + payload);
         break;
+    case LOK_CALLBACK_FONTS_MISSING:
+        // TODO
+        break;
     default:
         LOG_ERR("Unknown callback event (" << lokCallbackTypeToString(type) << "): " << payload);
     }


### PR DESCRIPTION
Avoids logging an ERR.

Proper handling of that functionality is still a work in progress.

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: Id6bd985ee62e6cb76641d6f866f6318868b9b2b3


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

