### PR TITLE
private/pedro/porting tabs improvements

### DIFF
--- a/browser/css/device-tablet.css
+++ b/browser/css/device-tablet.css
@@ -104,22 +104,6 @@
 	display: none;
 }
 
-.notebookbar-tabs-container:after,
-.notebookbar-tabs-container:before {
-	content: '';
-	position: relative;
-	z-index: -1;
-	display: block;
-	min-width: 2rem;
-	margin: 0;
-	-webkit-box-flex: 1;
-	-webkit-flex: 1 0 auto;
-	-ms-flex: 1 0 auto;
-	flex: 1 0 auto;
-	max-width: 2rem;
-	box-shadow: 0px 0 13px 2px var(--color-primary), 0px 0px 26px 6px var(--color-primary-lighter);
-}
-
 .hasnotebookbar #document-titlebar {
 	position: static;
 	display: inline-flex;

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -155,6 +155,8 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 	align-items: center;
 	padding: 0px 1em;
 	border-radius: var(--border-radius);
+	background-color: var(--color-main-background);
+	margin-inline-end: 12px;
 }
 
 .ui-tab.jsdialog:first-child {

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -150,7 +150,7 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 	line-height: normal;
 	color: dimgray;
 	color: var(--color-text-dark);
-	height: 32px;
+	height: 24px;
 	display: flex;
 	align-items: center;
 	padding: 0px 1em;

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -157,7 +157,7 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 	border-radius: var(--border-radius);
 }
 
-.ui-tab.jsdialog:first-child.selected {
+.ui-tab.jsdialog:first-child {
 	margin-inline-start: 12px;
 }
 

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -171,7 +171,7 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 	box-shadow: 0 0 2px 1px #cfcfcf;
 }
 
-.ui-tab.jsdialog:hover {
+.ui-tab.jsdialog:not(.selected):hover {
 	cursor: pointer;
 	background-color: var(--color-background-darker);
 	color: var(--color-text-darker);

--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -3,6 +3,7 @@
 
 .notebookbar-tabs-container {
 	display: inline-flex;
+	flex: 1 1 auto;
 	margin-inline-start: 5px;
 }
 

--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -3,6 +3,7 @@
 
 .notebookbar-tabs-container {
 	display: inline-flex;
+	margin-inline-start: 5px;
 }
 
 .ui-tabs.notebookbar {

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -3164,7 +3164,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		if (commandName && commandName.length && L.LOUtil.existsIconForCommand(commandName, builder.map.getDocType())) {
 			var iconName = builder._generateMenuIconName(commandName);
 			var iconSpan = L.DomUtil.create('span', 'menu-entry-icon ' + iconName, menuEntry);
-			var iconURL = L.LOUtil.getImageURL('lc_' + iconName + '.svg');
+			var iconURL = builder._createIconURL(iconName, true);
 			icon = L.DomUtil.create('img', '', iconSpan);
 			icon.src = iconURL;
 			icon.alt = '';

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -974,7 +974,10 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		};
 	},
 
-	_tabsControlHandler: function(parentContainer, data, builder) {
+	_tabsControlHandler: function(parentContainer, data, builder, tabTooltip) {
+		if (tabTooltip === undefined) {
+			tabTooltip = '';
+		}
 		if (data.tabs) {
 			var tabs = 0;
 			for (var tabIdx = 0; data.children && tabIdx < data.children.length; tabIdx++) {
@@ -1003,6 +1006,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 				var isSelectedTab = data.selected == item.id;
 				if (isSelectedTab) {
 					$(tab).addClass('selected');
+					tab.title = tabTooltip;
 					singleTabId = tabIdx;
 				}
 

--- a/browser/src/control/Control.NotebookbarBuilder.js
+++ b/browser/src/control/Control.NotebookbarBuilder.js
@@ -347,20 +347,26 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 	// overriden
 	_createTabClick: function(builder, t, tabs, contentDivs, tabIds)
 	{
+		var tooltipCollapsed = _('Tap to expand');
+		var tooltipExpanded = _('Tap to collapse');
+		$(tabs[t]).prop('title', tooltipExpanded);
 		return function(event) {
 			var tabIsSelected = $(tabs[t]).hasClass('selected');
 			var notebookbarIsCollapsed = builder.wizard.isCollapsed();
 
 			if (tabIsSelected && !notebookbarIsCollapsed) {
 				builder.wizard.collapse();
+				$(tabs[t]).prop('title', tooltipCollapsed);
 			} else if (notebookbarIsCollapsed) {
 				builder.wizard.extend();
+				$(tabs[t]).prop('title', tooltipExpanded);
 			}
 
 			$(tabs[t]).addClass('selected');
 			for (var i = 0; i < tabs.length; i++) {
 				if (i !== t) {
 					$(tabs[i]).removeClass('selected');
+					$(tabs[i]).prop('title', '');
 					$(contentDivs[i]).hide();
 				}
 			}
@@ -376,7 +382,7 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 
 	_overriddenTabsControlHandler: function(parentContainer, data, builder) {
 		data.tabs = builder.wizard.getTabs();
-		return builder._tabsControlHandler(parentContainer, data, builder);
+		return builder._tabsControlHandler(parentContainer, data, builder, _('Tap to collapse'));
 	},
 
 	_toolboxHandler: function(parentContainer, data) {


### PR DESCRIPTION
- Remove hover effect on selected tabs
- Mobile: Fix missing icon on lists within mobilewizard panels
- Make tabs shorter
- Add background to all tabs and add space in between them
- Remove notebookbar tab indicators on tablet
- Add margin to tabbed view: tabs
- Tabbed view: center document name in the toolbar
- Tabbed view: Add "Tap to collapse/expand" tooltip
