### PR TITLE
masterpage: followup

### DIFF
--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -323,9 +323,8 @@ L.Map.include({
 
 	sendUnoCommand: function (command, json) {
 		if ((command.startsWith('.uno:Sidebar') && !command.startsWith('.uno:SidebarShow')) ||
-			command.startsWith('.uno:SlideMasterPage') || command.startsWith('.uno:SlideChangeWindow') ||
-			command.startsWith('.uno:CustomAnimation') || command.startsWith('.uno:MasterSlidesPanel') ||
-			command.startsWith('.uno:ModifyPage')) {
+			command.startsWith('.uno:SlideChangeWindow') || command.startsWith('.uno:CustomAnimation') ||
+			command.startsWith('.uno:MasterSlidesPanel') || command.startsWith('.uno:ModifyPage')) {
 
 			// sidebar control is present only in desktop/tablet case
 			if (this.sidebar) {

--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -170,7 +170,7 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 			command.part = this._selectedPart;
 		}
 
-		if (command.mode === undefined)
+		if (isNaN(command.mode))
 			command.mode = this._selectedMode;
 
 		var topLeftTwips = new L.Point(command.x, command.y);

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1586,12 +1586,12 @@ L.CanvasTileLayer = L.Layer.extend({
 					msg += 'part=0 ';
 				} else {
 					var tokens = payload.substring('EMPTY'.length + 1);
-					tokens = tokens.split(' ');
+					tokens = tokens.split(',');
 					var part = parseInt(tokens[0] ? tokens[0] : '');
-					var mode = parseInt(tokens[1] ? tokens[1] : '');
+					var mode = parseInt((tokens.length > 1 && tokens[1]) ? tokens[1] : '');
 					mode = (isNaN(mode) ? this._selectedMode : mode);
 					msg += 'part=' + (isNaN(part) ? this._selectedPart : part)
-						+ ((mode !== 0) ? (' mode=' + mode) : '')
+						+ ((mode && mode !== 0) ? (' mode=' + mode) : '')
 						+ ' ';
 				}
 				msg += 'x=0 y=0 ';

--- a/browser/src/layer/tile/ImpressTileLayer.js
+++ b/browser/src/layer/tile/ImpressTileLayer.js
@@ -180,7 +180,7 @@ L.ImpressTileLayer = L.CanvasTileLayer.extend({
 			command.part = this._selectedPart;
 		}
 
-		if (command.mode === undefined)
+		if (isNaN(command.mode))
 			command.mode = this._selectedMode;
 
 		var topLeftTwips = new L.Point(command.x, command.y);

--- a/browser/src/layer/tile/WriterTileLayer.js
+++ b/browser/src/layer/tile/WriterTileLayer.js
@@ -61,7 +61,7 @@ L.WriterTileLayer = L.CanvasTileLayer.extend({
 			command.part = this._selectedPart;
 		}
 
-		if (command.mode === undefined)
+		if (isNaN(command.mode))
 			command.mode = this._selectedMode;
 
 		command.part = 0;

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -2847,21 +2847,16 @@ void ChildSession::loKitCallback(const int type, const std::string& payload)
             }
             else if (tokens.size() == 2 && tokens.equals(0, "EMPTY"))
             {
+                // without mode: "EMPTY, <part>"
                 const std::string part = (_docType != "text" ? tokens[1].c_str() : "0"); // Writer renders everything as part 0.
-
-                // without mode: "EMPTY, <parts>"
-                // with mode:    "EMPTY, <parts> <mode>"
-                StringVector spaceTokens(StringVector::tokenize(payload, ' '));
-                if (spaceTokens.size() == 3)
-                {
-                    const std::string newPart = spaceTokens[1].c_str();
-                    const std::string mode = spaceTokens[2].c_str();
-                    sendTextFrame("invalidatetiles: EMPTY, " + part + ", " + mode);
-                }
-                else
-                {
-                    sendTextFrame("invalidatetiles: EMPTY, " + part);
-                }
+                sendTextFrame("invalidatetiles: EMPTY, " + part);
+            }
+            else if (tokens.size() == 3 && tokens.equals(0, "EMPTY"))
+            {
+                // with mode:    "EMPTY, <part>, <mode>"
+                const std::string part = (_docType != "text" ? tokens[1].c_str() : "0"); // Writer renders everything as part 0.
+                const std::string mode = (_docType != "text" ? tokens[2].c_str() : "0"); // Writer is not using mode.
+                sendTextFrame("invalidatetiles: EMPTY, " + part + ", " + mode);
             }
             else
             {
@@ -2909,7 +2904,9 @@ void ChildSession::loKitCallback(const int type, const std::string& payload)
             for (int i = 0; i < getLOKitDocument()->getParts(); i++)
             {
                 const std::string parts = std::to_string(i);
-                sendTextFrame("invalidatetiles: EMPTY, " + parts);
+                const int mode = 0; // TODO: next step: getLOKitDocument()->getEditMode();
+                const std::string optionalMode = (mode > 0) ? (", " + std::to_string(mode)) : "";
+                sendTextFrame("invalidatetiles: EMPTY, " + parts + optionalMode);
             }
         }
         break;


### PR DESCRIPTION
helps with:
- activation of a closed sidebar on master page activation
- parses correctly message with `mode` param, should be separated with `,` not a space

this is required for next set of patches which will activate the `mode` param