### PR TITLE
Downloaded fonts don't need to be visible to Kit processes any longer

### DIFF
--- a/coolwsd-systemplate-setup
+++ b/coolwsd-systemplate-setup
@@ -15,12 +15,6 @@ test -d "$INSTDIR" || { echo "$0: No such directory: $INSTDIR"; exit 1; }
 
 mkdir -p $CHROOT || exit 1
 
-# For the tmpfonts we need to use the pathnames as used by the
-# configure script, which does *not* look up realpaths, because the
-# Makefile.am uses @SYSTEMPLATE_PATH@ which uses abs_top_builddir
-# which uses ac_pwd which is not based on use of realpath.
-CHROOT_AS_GIVEN=$CHROOT
-
 # Resolve the real paths, in case they are relative and/or symlinked.
 # INSTDIR_LOGICAL will contain the logical path, if there are symlinks,
 # while INSTDIR is the physical one. Both will most likely be the same,
@@ -118,23 +112,6 @@ do
     mkdir -p $INSTDIR_PARENT
     ln -f -s `${REALPATH} --relative-to=$INSTDIR_PARENT $CHROOT/lo` $CHROOT/$path
 done
-
-# A similar dance also for the directory where "temporary" fonts are
-# stored. Such are downloaded from other servers based on a separate
-# configuration file. They need to be accessible using the same
-# pathname both in the ForKit process and in the Kit processes.
-
-mkdir -p $CHROOT/tmpfonts
-mkdir -p $CHROOT$CHROOT
-ln -f -s `${REALPATH} --relative-to=$CHROOT$CHROOT $CHROOT/tmpfonts` $CHROOT$CHROOT
-
-# To be safe we do this both for $CHROOT and $CHROOT_AS_GIVEN, in case they differ.
-
-if [ "$CHROOT_AS_GIVEN" != "$CHROOT" ]; then
-    mkdir -p $CHROOT_AS_GIVEN/tmpfonts
-    mkdir -p $CHROOT_AS_GIVEN$CHROOT_AS_GIVEN
-    ln -f -s `${REALPATH} --relative-to=$CHROOT_AS_GIVEN$CHROOT_AS_GIVEN $CHROOT_AS_GIVEN/tmpfonts` $CHROOT_AS_GIVEN$CHROOT_AS_GIVEN
-fi
 
 # /usr/share/fonts needs to be taken care of separately because the
 # directory time stamps must be preserved for fontconfig to trust

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -5231,7 +5231,7 @@ int COOLWSD::innerMain()
     assert(Server && "The COOLWSDServer instance does not exist.");
     Server->findClientPort();
 
-    TmpFontDir = SysTemplate + "/tmpfonts";
+    TmpFontDir = ChildRoot + JailUtil::CHILDROOT_TMP_INCOMING_PATH;
 
     // Start the internal prisoner server and spawn forkit,
     // which in turn forks first child.


### PR DESCRIPTION
After recent changes in core, it is only the ForKit process that opens such files.

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: I69ce1c4caf229b34e42799c525a1f1461a1841e0


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

