### PR TITLE
wsd: disable mounting when unmount fails

### DIFF
--- a/common/JailUtil.cpp
+++ b/common/JailUtil.cpp
@@ -220,7 +220,9 @@ void setupChildRoot(bool bindMount, const std::string& childRoot, const std::str
         // Test mounting to verify it actually works,
         // as it might not function in some systems.
         const std::string target = Poco::Path(childRoot, "cool_test_mount").toString();
-        if (bind(sysTemplate, target))
+
+        // Make sure that we can both mount and unmount before enabling bind-mounting.
+        if (bind(sysTemplate, target) && unmount(target))
         {
             enableBindMounting();
             safeRemoveDir(target);


### PR DESCRIPTION
It seems that on some systems it is possible
to succeed in mounting, but fail to unmount.

This is proving very problematic and it is
best to detect unmount failures and disable
mount-binding altogether.

Should avoid the issues seen in #5155 and #5164. 