### PR TITLE
Remove obsolete css rules for shadow-transparency items.

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -116,17 +116,6 @@
 	width: 294px;
 }
 
-.sidebar #FIELD_TRANSPARENCY {
-	height: 0;
-	position: relative;
-	bottom: 18px;
-}
-
-.sidebar #transparency_label {
-	position: relative;
-	top: 12px;
-}
-
 .sidebar #table-indentfieldbox {
 	text-align: left;
 }


### PR DESCRIPTION
Signed-off-by: Gökay Şatır <gokaysatir@collabora.com>
Change-Id: Idd1b71e1b32a1367902a230eb9f43fe18321f856


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

