### PR TITLE
Remove obsolete css rules for shadow-transparency items.

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -116,17 +116,6 @@
 	width: 294px;
 }
 
-.sidebar #FIELD_TRANSPARENCY {
-	height: 0;
-	position: relative;
-	bottom: 18px;
-}
-
-.sidebar #transparency_label {
-	position: relative;
-	top: 12px;
-}
-
 .sidebar #table-indentfieldbox {
 	text-align: left;
 }


### PR DESCRIPTION
Signed-off-by: Gökay Şatır <gokaysatir@collabora.com>
Change-Id: Idd1b71e1b32a1367902a230eb9f43fe18321f856
