### PR TITLE
wsd: re-create the jail directory when mounting fails

### DIFF
--- a/common/JailUtil.cpp
+++ b/common/JailUtil.cpp
@@ -206,11 +206,18 @@ void cleanupJails(const std::string& root)
         LOG_WRN("Jails root directory [" << root << "] is not empty. Will not remove it.");
 }
 
+void createJailPath(const std::string& path)
+{
+    LOG_INF("Creating jail path (if missing): " << path);
+    Poco::File(path).createDirectories();
+    chmod(path.c_str(), S_IXUSR | S_IWUSR | S_IRUSR);
+}
+
 void setupChildRoot(bool bindMount, const std::string& childRoot, const std::string& sysTemplate)
 {
     // Start with a clean slate.
     cleanupJails(childRoot);
-    Poco::File(childRoot + CHILDROOT_TMP_INCOMING_PATH).createDirectories();
+    createJailPath(childRoot + CHILDROOT_TMP_INCOMING_PATH);
 
     disableBindMounting(); // Clear to avoid surprises.
 

--- a/common/JailUtil.hpp
+++ b/common/JailUtil.hpp
@@ -42,6 +42,9 @@ void removeJail(const std::string& root);
 /// Remove all jails.
 void cleanupJails(const std::string& jailRoot);
 
+/// Creates the jail directory path recursively.
+void createJailPath(const std::string& path);
+
 /// Setup the Child-Root directory.
 void setupChildRoot(bool bindMount, const std::string& jailRoot, const std::string& sysTemplate);
 

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -2627,9 +2627,7 @@ void lokit_main(
 #if !MOBILEAPP
         const Path jailPath = Path::forDirectory(childRoot + '/' + jailId);
         const std::string jailPathStr = jailPath.toString();
-        LOG_INF("Jail path: " << jailPathStr);
-        File(jailPath).createDirectories();
-        chmod(jailPathStr.c_str(), S_IXUSR | S_IWUSR | S_IRUSR);
+        JailUtil::createJailPath(jailPathStr);
 
         if (!ChildSession::NoCapsForKit)
         {
@@ -2658,7 +2656,7 @@ void lokit_main(
 
                 // Mount loTemplate inside it.
                 LOG_INF("Mounting " << loTemplate << " -> " << loJailDestPath);
-                Poco::File(loJailDestPath).createDirectories();
+                JailUtil::createJailPath(loJailDestPath);
                 if (!JailUtil::bind(loTemplate, loJailDestPath)
                     || !JailUtil::remountReadonly(loTemplate, loJailDestPath))
                 {
@@ -2706,6 +2704,9 @@ void lokit_main(
             {
                 LOG_INF("Mounting is disabled, will link/copy " << sysTemplate << " -> "
                                                                 << jailPathStr);
+
+                // Make sure we have the jail directory.
+                JailUtil::createJailPath(jailPathStr);
 
                 // Create a file to mark this a copied jail.
                 JailUtil::markJailCopied(jailPathStr);


### PR DESCRIPTION
    This guarantees that the jail directory is always
    created, especially in case mounting fails and
    we cleanup and fallback.
    
    Also, move the directory creation and setting
    the perms into a helper, and reuse.
