### PR TITLE
slidesorter: use correct styles for desktop & selection more visible

### DIFF
--- a/browser/css/partsPreviewControl.css
+++ b/browser/css/partsPreviewControl.css
@@ -31,19 +31,19 @@
 	vertical-align: middle;
 	max-width: 164px;
 	cursor: pointer;
-	border: 1px solid var(--color-border);
+	border: 1px solid var(--color-border) !important;
 	margin-left: 10px;
 	margin-right: 10px;
 }
 
 /* The current part the user is on. */
 .preview-img-currentpart {
-	border: 1px solid var(--color-border-dark);
+	border: 1px solid var(--color-primary-dark) !important;
 }
 
 /* One of (potentially many) selected parts, but not the current. */
 .preview-img-selectedpart {
-	border: 1px solid var(--color-border-dark) !important;
+	border: 1px solid var(--color-primary) !important;
 }
 
 /* Highlight where a slide can be dropped when reordering by drag-and-drop. */


### PR DESCRIPTION
Mark as important so will not be overriden by the mobile-wizard rules.

Use primary color for selection so it will be visible...

Previously we had primary color for current slide (from mobile-wizard) and grey for other selected slides.

![slidesorter](https://user-images.githubusercontent.com/5307369/192769376-331021a9-04e2-4684-b73b-37c353fca4e0.png)
