### PR TITLE
overriding checkfileinfo using hidden input field

### DIFF
--- a/browser/html/cool.html.m4
+++ b/browser/html/cool.html.m4
@@ -312,7 +312,8 @@ m4_ifelse(MOBILEAPP,[true],
       window.socketProxy = false;
       window.tileSize = 256;
       window.uiDefaults = {};
-      window.useIntegrationTheme = 'false';],
+      window.useIntegrationTheme = 'false';
+      window.checkFileInfoOverride = {};],
      [window.host = '%HOST%';
       window.serviceRoot = '%SERVICE_ROOT%';
       window.hexifyUrl = %HEXIFY_URL%;
@@ -336,7 +337,8 @@ m4_ifelse(MOBILEAPP,[true],
       window.socketProxy = %SOCKET_PROXY%;
       window.tileSize = 256;
       window.groupDownloadAsForNb = %GROUP_DOWNLOAD_AS%;
-      window.uiDefaults = %UI_DEFAULTS%;])
+      window.uiDefaults = %UI_DEFAULTS%;
+      window.checkFileInfoOverride = %CHECK_FILE_INFO_OVERRIDE%;])
 
 // This is GLOBAL_JS:
 m4_syscmd([cat ]GLOBAL_JS)m4_dnl

--- a/browser/src/map/handler/Map.WOPI.js
+++ b/browser/src/map/handler/Map.WOPI.js
@@ -93,6 +93,7 @@ L.Map.WOPI = L.Handler.extend({
 	},
 
 	_setWopiProps: function(wopiInfo) {
+		var overridenFileInfo = window.checkFileInfoOverride;
 		// Store postmessageorigin property, if it exists
 		if (wopiInfo['PostMessageOrigin']) {
 			this.PostMessageOrigin = wopiInfo['PostMessageOrigin'];
@@ -110,7 +111,8 @@ L.Map.WOPI = L.Handler.extend({
 		this.DisableExport = !!wopiInfo['DisableExport'];
 		this.DisableCopy = !!wopiInfo['DisableCopy'];
 		this.DisableInactiveMessages = !!wopiInfo['DisableInactiveMessages'];
-		this.DownloadAsPostMessage = !!wopiInfo['DownloadAsPostMessage'];
+		this.DownloadAsPostMessage = Object.prototype.hasOwnProperty.call(overridenFileInfo, 'DownloadAsPostMessage') ?
+			overridenFileInfo.DownloadAsPostMessage : !!wopiInfo['DownloadAsPostMessage'];
 		this.UserCanNotWriteRelative = !!wopiInfo['UserCanNotWriteRelative'];
 		this.EnableInsertRemoteImage = !!wopiInfo['EnableInsertRemoteImage'];
 		this.SupportsRename = !!wopiInfo['SupportsRename'];

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -897,6 +897,8 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     LOG_TRC("postmessage_origin" << postMessageOrigin);
     const std::string theme = form.get("theme", "");
     LOG_TRC("theme=" << theme);
+    const std::string checkfileinfo_override = form.get("checkfileinfo_override", "");
+    LOG_TRC("checkfileinfo_override=" << checkfileinfo_override);
 
     // Escape bad characters in access token.
     // This is placed directly in javascript in cool.html, we need to make sure
@@ -943,6 +945,8 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     Poco::replaceInPlace(preprocess, std::string("%SERVICE_ROOT%"), responseRoot);
     Poco::replaceInPlace(preprocess, std::string("%UI_DEFAULTS%"), uiDefaultsToJSON(uiDefaults, userInterfaceMode));
     Poco::replaceInPlace(preprocess, std::string("%POSTMESSAGE_ORIGIN%"), escapedPostmessageOrigin);
+    Poco::replaceInPlace(preprocess, std::string("%CHECK_FILE_INFO_OVERRIDE%"),
+                         checkFileInfoToJSON(checkfileinfo_override));
 
     const auto& config = Application::instance().config();
 

--- a/wsd/FileServer.hpp
+++ b/wsd/FileServer.hpp
@@ -39,6 +39,8 @@ class FileServerRequestHandler
     /// Also returns the UIMode from uiDefaults in uiMode output param
     static std::string uiDefaultsToJSON(const std::string& uiDefaults, std::string& uiMode);
 
+    static std::string checkFileInfoToJSON(const std::string& checkfileFileInfo);
+
     static std::string cssVarsToStyle(const std::string& cssVars);
 
     static std::string stringifyBoolFromConfig(const Poco::Util::LayeredConfiguration& config,

--- a/wsd/FileServerUtil.cpp
+++ b/wsd/FileServerUtil.cpp
@@ -124,6 +124,35 @@ std::string FileServerRequestHandler::uiDefaultsToJSON(const std::string& uiDefa
     return previousJSON;
 }
 
+std::string FileServerRequestHandler::checkFileInfoToJSON(const std::string& checkfileInfo)
+{
+    static std::string previousCheckFileInfo;
+    static std::string previousCheckFileInfoJSON("{}");
+
+    // early exit if we are serving the same thing
+    if (checkfileInfo == previousCheckFileInfo)
+        return previousCheckFileInfoJSON;
+
+    Poco::JSON::Object json;
+    StringVector tokens(StringVector::tokenize(checkfileInfo, ';'));
+    for (const auto& token : tokens)
+    {
+        StringVector keyValue(StringVector::tokenize(tokens.getParam(token), '='));
+        if (keyValue.equals(0, "DownloadAsPostMessage"))
+        {
+            bool value(false);
+            if (keyValue.equals(1, "true") || keyValue.equals(1, "True") || keyValue.equals(1, "1"))
+                value = true;
+            json.set(keyValue[0], value);
+        }
+    }
+    std::ostringstream oss;
+    Poco::JSON::Stringifier::stringify(json, oss);
+    previousCheckFileInfo = checkfileInfo;
+    previousCheckFileInfoJSON = oss.str();
+    return previousCheckFileInfoJSON;
+}
+
 namespace
 {
 bool isValidCss(const std::string& token)


### PR DESCRIPTION
wopi host can add following input field to their html to override checkfileinfo, right now only DownloadAsPostMessage is supported
<input name="checkfileinfo_override" value="DownloadAsPostMessage=true" type="hidden"/> This can be usefull when same html is used to load collabora online in both desktop browser and mobile webview

Signed-off-by: Rash419 <rashesh.padia@collabora.com>
Change-Id: I8ff122f2824694d451724a832d992e08161fb448


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

