### PR TITLE
browser: set the document view only if it is offline

### DIFF
--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -1549,6 +1549,10 @@ app.definitions.Socket = L.Class.extend({
 			}
 		}, 1 /* ms */);
 
+		if (this._map.isPermissionEdit()) {
+			this._map.setPermission('view');
+		}
+
 		if (!this._map['wopi'].DisableInactiveMessages)
 			this._map.uiManager.showSnackbar(_('The server has been disconnected.'));
 	},


### PR DESCRIPTION
The cursor will hide and the permission will be updated
after the document is re-connected.

Change-Id: Ib0a584371317adabe9898dad8bb0cd96717cefff
Signed-off-by: Henry Castro <hcastro@collabora.com>
