### PR TITLE
Admin settings: Fix hidden shutdown btn, adjust version info

### DIFF
--- a/browser/admin/adminSettings.html
+++ b/browser/admin/adminSettings.html
@@ -119,21 +119,17 @@
         </div>
       </div>
     </form>
-
-    <div class="section">
-      <h4><script>document.write(l10nstrings.strVersionInfo)</script></h4>
-      <p>
-        <h5><b>COOLWSD</b></h5>
-        <div id="coolwsd-version"></div>
-      </p>
-      <p>
-        <h5><b>LOKit</b></h5>
-        <div id="lokit-version"></div>
-      </p>
-    </div>
-
     <div class="section is-fullwidth has-text-right">
       <button id="btnShutdown" type="submit" class="button is-danger" style="min-width:140px;"><script>document.write(l10nstrings.strShutdown)</script></button>
+    </div>
+    <div class="section" style="margin: 38px 0;">
+      <h4><script>document.write(l10nstrings.strVersionInfo)</script></h4>
+      <p>
+        <b>COOLWSD: </b><span id="coolwsd-version"></span>
+      </p>
+      <p>
+        <b>LOKit: </b><span id="lokit-version"></span>
+      </p>
     </div>
 
   </div>


### PR DESCRIPTION
Shutdown btn is now position right after the list of settings
(before the user needed to scroll all the way down past
version information).

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I2be401f2205122510ab8e73da90d244acf130364
