### PR TITLE
Implement HideRepairOption in CheckFileInfo

### DIFF
--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -1976,6 +1976,9 @@ L.Control.Menubar = L.Control.extend({
 		if (menuItem.id && menuItem.id.startsWith('fullscreen-presentation') && this._map['wopi'].HideExportOption)
 			return false;
 
+		if (menuItem.id === 'repair' && this._map['wopi'].HideRepairOption)
+			return false;
+
 		if (menuItem.id === 'changesmenu' && this._map['wopi'].HideChangeTrackingControls)
 			return false;
 

--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -82,6 +82,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 	getFileTab: function() {
 		var hasRevisionHistory = L.Params.revHistoryEnabled;
 		var hasPrint = !this._map['wopi'].HidePrintOption;
+		var hasRepair = !this._map['wopi'].HideRepairOption;
 		var hasSaveAs = !this._map['wopi'].UserCanNotWriteRelative;
 		var hasShare = this._map['wopi'].EnableShare;
 		var hasGroupedDownloadAs = !!window.groupDownloadAsForNb;
@@ -171,18 +172,20 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				'text': _('Download')
 			});
 
-			content.push({
-				'type': 'container',
-				'children': [
-					{
-						'id': 'repair',
-						'type': 'menubartoolitem',
-						'text': _('Repair'),
-						'command': _('Repair')
-					}
-				],
-				'vertical': 'true'
-			});
+			if (hasRepair) {
+				content.push({
+					'type': 'container',
+					'children': [
+						{
+							'id': 'repair',
+							'type': 'menubartoolitem',
+							'text': _('Repair'),
+							'command': _('Repair')
+						}
+					],
+					'vertical': 'true'
+				});
+			}
 		} else {
 			content = content.concat([
 				{
@@ -233,12 +236,12 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 							'text': _('PDF Document (.pdf)'),
 							'command': ''
 						},
-						{
+						hasRepair? {
 							'id': 'repair',
 							'type': 'menubartoolitem',
 							'text': _('Repair'),
 							'command': _('Repair')
-						}
+						} : {}
 					],
 					'vertical': 'true'
 				}

--- a/browser/src/control/Control.NotebookbarDraw.js
+++ b/browser/src/control/Control.NotebookbarDraw.js
@@ -115,6 +115,7 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 	getFileTab: function() {
 		var hasRevisionHistory = L.Params.revHistoryEnabled;
 		var hasPrint = !this._map['wopi'].HidePrintOption;
+		var hasRepair = !this._map['wopi'].HideRepairOption;
 		var hasSaveAs = !this._map['wopi'].UserCanNotWriteRelative;
 		var hasShare = this._map['wopi'].EnableShare;
 		var hasSave = !this._map['wopi'].HideSaveOption;
@@ -196,12 +197,12 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 						'text': _('PDF Document (.pdf)'),
 						'command': ''
 					},
-					{
+					hasRepair? {
 						'id': 'repair',
 						'type': 'menubartoolitem',
 						'text': _('Repair'),
 						'command': _('Repair')
-					}
+					} : {}
 				],
 				'vertical': 'true'
 			}

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -134,6 +134,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 	getFileTab: function() {
 		var hasRevisionHistory = L.Params.revHistoryEnabled;
 		var hasPrint = !this._map['wopi'].HidePrintOption;
+		var hasRepair = !this._map['wopi'].HideRepairOption;
 		var hasSaveAs = !this._map['wopi'].UserCanNotWriteRelative;
 		var hasShare = this._map['wopi'].EnableShare;
 		var hasGroupedDownloadAs = !!window.groupDownloadAsForNb;
@@ -223,18 +224,20 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'text': _('Download')
 			});
 
-			content.push({
-				'type': 'container',
-				'children': [
-					{
-						'id': 'repair',
-						'type': 'menubartoolitem',
-						'text': _('Repair'),
-						'command': _('Repair')
-					}
-				],
-				'vertical': 'true'
-			});
+			if (hasRepair) {
+				content.push({
+					'type': 'container',
+					'children': [
+						{
+							'id': 'repair',
+							'type': 'menubartoolitem',
+							'text': _('Repair'),
+							'command': _('Repair')
+						}
+					],
+					'vertical': 'true'
+				});
+			}
 		} else {
 			content = content.concat([
 				{
@@ -285,12 +288,12 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 							'text': _('PDF Document (.pdf)'),
 							'command': ''
 						},
-						{
+						hasRepair? {
 							'id': 'repair',
 							'type': 'menubartoolitem',
 							'text': _('Repair'),
 							'command': _('Repair')
-						}
+						} : {}
 					],
 					'vertical': 'true'
 				}

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -96,6 +96,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 		var hasSigning = L.DomUtil.get('document-signing-bar') !== null;
 		var hasRevisionHistory = L.Params.revHistoryEnabled;
 		var hasPrint = !this._map['wopi'].HidePrintOption;
+		var hasRepair = !this._map['wopi'].HideRepairOption;
 		var hasSaveAs = !this._map['wopi'].UserCanNotWriteRelative;
 		var hasShare = this._map['wopi'].EnableShare;
 		var hasGroupedDownloadAs = !!window.groupDownloadAsForNb;
@@ -242,38 +243,24 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 			]);
 		}
 
-		if (hasSigning === false) {
-			content.push({
-				'type': 'container',
-				'children': [
-					{
-						'id': 'repair',
-						'type': 'bigmenubartoolitem',
-						'text': _('Repair'),
-						'command': _('Repair')
-					}
-				]
-			});
-		} else {
-			content.push({
-				'type': 'container',
-				'children': [
-					{
-						'id': 'repair',
-						'type': 'menubartoolitem',
-						'text': _('Repair'),
-						'command': _('Repair')
-					},
-					{
-						'id': 'signdocument',
-						'type': 'menubartoolitem',
-						'text': _('Sign document'),
-						'command': ''
-					}
-				],
-				'vertical': 'true'
-			});
-		}
+		content.push({
+			'type': 'container',
+			'children': [
+				hasRepair? {
+					'id': 'repair',
+					'type': 'menubartoolitem',
+					'text': _('Repair'),
+					'command': _('Repair')
+				} : {},
+				hasSigning? {
+					'id': 'signdocument',
+					'type': 'menubartoolitem',
+					'text': _('Sign document'),
+					'command': ''
+				} : {}
+			],
+			'vertical': 'true'
+		});
 
 		content.push({
 			'type': 'container',

--- a/browser/src/map/handler/Map.WOPI.js
+++ b/browser/src/map/handler/Map.WOPI.js
@@ -15,6 +15,7 @@ L.Map.WOPI = L.Handler.extend({
 	HidePrintOption: false,
 	HideSaveOption: false,
 	HideExportOption: false,
+	HideRepairOption: false,
 	HideChangeTrackingControls: false,
 	DisablePrint: false,
 	DisableExport: false,
@@ -106,6 +107,7 @@ L.Map.WOPI = L.Handler.extend({
 		this.HidePrintOption = !!wopiInfo['HidePrintOption'];
 		this.HideSaveOption = !!wopiInfo['HideSaveOption'];
 		this.HideExportOption = !!wopiInfo['HideExportOption'];
+		this.HideRepairOption = !!wopiInfo['HideRepairOption'];
 		this.HideChangeTrackingControls = !!wopiInfo['HideChangeTrackingControls'];
 		this.DisablePrint = !!wopiInfo['DisablePrint'];
 		this.DisableExport = !!wopiInfo['DisableExport'];

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -776,6 +776,7 @@ bool DocumentBroker::download(const std::shared_ptr<ClientSession>& session, con
         wopiInfo->set("HidePrintOption", wopifileinfo->getHidePrintOption());
         wopiInfo->set("HideSaveOption", wopifileinfo->getHideSaveOption());
         wopiInfo->set("HideExportOption", wopifileinfo->getHideExportOption());
+        wopiInfo->set("HideRepairOption", wopifileinfo->getHideRepairOption());
         wopiInfo->set("DisablePrint", wopifileinfo->getDisablePrint());
         wopiInfo->set("DisableExport", wopifileinfo->getDisableExport());
         wopiInfo->set("DisableCopy", wopifileinfo->getDisableCopy());

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -764,6 +764,7 @@ void WopiStorage::WOPIFileInfo::init()
     _hidePrintOption = false;
     _hideSaveOption = false;
     _hideExportOption = false;
+    _hideRepairOption = false;
     _disablePrint = false;
     _disableExport = false;
     _disableCopy = false;
@@ -850,6 +851,7 @@ WopiStorage::WOPIFileInfo::WOPIFileInfo(const FileInfo &fileInfo,
     JsonUtil::findJSONValue(object, "HidePrintOption", _hidePrintOption);
     JsonUtil::findJSONValue(object, "HideSaveOption", _hideSaveOption);
     JsonUtil::findJSONValue(object, "HideExportOption", _hideExportOption);
+    JsonUtil::findJSONValue(object, "HideRepairOption", _hideRepairOption);
     JsonUtil::findJSONValue(object, "EnableOwnerTermination", _enableOwnerTermination);
     JsonUtil::findJSONValue(object, "DisablePrint", _disablePrint);
     JsonUtil::findJSONValue(object, "DisableExport", _disableExport);

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -529,6 +529,8 @@ public:
         bool getHideSaveOption() const { return _hideSaveOption; }
         void setHideExportOption(bool hideExportOption) { _hideExportOption = hideExportOption; }
         bool getHideExportOption() const { return _hideExportOption; }
+        void setHideRepairOption(bool hideRepairOption) { _hideRepairOption = hideRepairOption; }
+        bool getHideRepairOption() const { return _hideRepairOption; }
         bool getEnableOwnerTermination() const { return _enableOwnerTermination; }
         bool getDisablePrint() const { return _disablePrint; }
         bool getDisableExport() const { return _disableExport; }
@@ -574,6 +576,8 @@ public:
         bool _hideSaveOption;
         /// Hide 'Download as' button/menubar item from UI
         bool _hideExportOption;
+        /// Hide the 'Repair' button/item from the UI
+        bool _hideRepairOption;
         /// If WOPI host has enabled owner termination feature on
         bool _enableOwnerTermination;
         /// If WOPI host has allowed the user to print the document

--- a/wsd/protocol.txt
+++ b/wsd/protocol.txt
@@ -630,6 +630,8 @@ wopi: <JSON>
      + HidePrintOption: (boolean): If Collabora Online should hide print options
      + HideExportOption: (boolean): If Collabora Online should hide the export options
        this implies 'Download as' options in file menu
+     + HideRepairOption: (boolean): If Collabora Online should hide the Repair
+       undo functionality
 
 versionrestore: <action>
 


### PR DESCRIPTION
When present and equal to 'true', the 'Repair' button and/or menu entry
is hidden in the UI.

Signed-off-by: Jan Holesovsky <kendy@collabora.com>
Change-Id: If8075be479551e0d1a5fa03014aa5e4412578c31
