### PR TITLE
browser: Paste progress bar has double precision

### DIFF
--- a/browser/src/control/Control.DownloadProgress.js
+++ b/browser/src/control/Control.DownloadProgress.js
@@ -102,8 +102,8 @@ L.Control.DownloadProgress = L.Control.extend({
 	},
 
 	setValue: function (value) {
-		this._bar.style.width = value + '%';
-		this._value.innerHTML = value + '%';
+		this._bar.style.width = Math.round(value) + '%';
+		this._value.innerHTML = Math.round(value) + '%';
 	},
 
 	_setProgressCursor: function() {


### PR DESCRIPTION
So round the value in the progress bar to integer.

Signed-off-by: Aron Budea <aron.budea@collabora.com>
Change-Id: I34058b2b8e04714eb7da60d8274660b06e583702

* Target version: master 

### Checklist

- [X] Code is properly formatted
- [X] All commits have Change-Id
- [ ] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

