### PR TITLE
Allow top bar to be scroll-able when in tabbed view

### DIFF
--- a/browser/css/menubar.css
+++ b/browser/css/menubar.css
@@ -87,6 +87,7 @@
 .main-nav.hasnotebookbar:not(.readonly) {
 	background: var(--color-main-background);
 	padding: 0px;
+	overflow-x: auto;
 }
 
 /* Customizations to sm-simple theme to make it look like LO menu, lo-menu class */


### PR DESCRIPTION
Before this commit, some actions were unreachable on tablets,
small screen factor laptops. Basically  when the web browser window
is smaller then the top bar's content.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I2e93540fa7b7d7bcf1a9f7e9f6697322528562f7
