### PR TITLE
Hide insert menu item when in readonly mode

### DIFF
--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -2019,6 +2019,11 @@ L.Control.Menubar = L.Control.extend({
 	_createMenu: function(menu) {
 		var itemList = [];
 		var docType = this._map.getDocType();
+		var isReadOnly = this._map.isReadOnlyMode();
+
+		if (isReadOnly && !app.file.editComment) {
+			this._hiddenItems.push('insert');
+		}
 		for (var i in menu) {
 			if (this._checkItemVisibility(menu[i]) === false)
 				continue;


### PR DESCRIPTION
except if we are in presence of PDF
- Insert is needed there (insert > comment)

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I20276e5690fa515a6fb497d1bb3447d0808f02d0
