### PR TITLE
wsd: add lang param to conversion

### DIFF
--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -4226,12 +4226,14 @@ private:
                    options += ",PDFVer=" + pdfVer + "PDFVEREND";
                 }
 
+                std::string lang = (form.has("lang") ? form.get("lang") : "");
+
                 // This lock could become a bottleneck.
                 // In that case, we can use a pool and index by publicPath.
                 std::unique_lock<std::mutex> docBrokersLock(DocBrokersMutex);
 
                 LOG_DBG("New DocumentBroker for docKey [" << docKey << "].");
-                auto docBroker = std::make_shared<ConvertToBroker>(fromPath, uriPublic, docKey, format, options);
+                auto docBroker = std::make_shared<ConvertToBroker>(fromPath, uriPublic, docKey, format, options, lang);
                 handler.takeFile();
 
                 cleanupDocBrokers();

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -3410,14 +3410,17 @@ ConvertToBroker::ConvertToBroker(const std::string& uri,
                                  const Poco::URI& uriPublic,
                                  const std::string& docKey,
                                  const std::string& format,
-                                 const std::string& sOptions)
+                                 const std::string& sOptions,
+                                 const std::string& lang)
     : StatelessBatchBroker(uri, uriPublic, docKey)
     , _format(format)
     , _sOptions(sOptions)
+    , _lang(lang)
 {
     LOG_TRC("Created ConvertToBroker: uri: [" << uri << "], uriPublic: [" << uriPublic.toString()
                                               << "], docKey: [" << docKey << "], format: ["
-                                              << format << "], options: [" << sOptions << "].");
+                                              << format << "], options: [" << sOptions << "], lang: ["
+                                              << lang << "].");
 
     static const std::chrono::seconds limit_convert_secs(
         COOLWSD::getConfigValue<int>("per_document.limit_convert_secs", 100));
@@ -3455,7 +3458,9 @@ bool ConvertToBroker::startConversion(SocketDisposition &disposition, const std:
             std::string encodedFrom;
             Poco::URI::encode(docBroker->getPublicUri().getPath(), "", encodedFrom);
             // add batch mode, no interactive dialogs
-            const std::string _load = "load url=" + encodedFrom + " batch=true";
+            std::string _load = "load url=" + encodedFrom + " batch=true";
+            if (!docBroker->getLang().empty())
+                _load += " lang=" + docBroker->getLang();
             std::vector<char> loadRequest(_load.begin(), _load.end());
             docBroker->_clientSession->handleMessage(loadRequest);
 

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -1427,6 +1427,7 @@ class ConvertToBroker final : public StatelessBatchBroker
 {
     const std::string _format;
     const std::string _sOptions;
+    const std::string _lang;
 
 public:
     /// Construct DocumentBroker with URI and docKey
@@ -1434,8 +1435,12 @@ public:
                     const Poco::URI& uriPublic,
                     const std::string& docKey,
                     const std::string& format,
-                    const std::string& sOptions);
+                    const std::string& sOptions,
+                    const std::string& lang);
     virtual ~ConvertToBroker();
+
+    /// _lang accessors
+    const std::string& getLang() { return _lang; }
 
     /// Move socket to this broker for response & do conversion
     bool startConversion(SocketDisposition &disposition, const std::string &id);


### PR DESCRIPTION
This is needed, for example, for date type cells
for which the format language is set to default.
In this case the load language is used and it
determines the display/output format.

Signed-off-by: Gabriel Masei <gabriel.masei@1and1.ro>
Change-Id: I49ec4940377b261971224d37ea5fbe8ed7006157


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

