### PR TITLE
Enable Show Status Bar menu entry in readonly mode

### DIFF
--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -1189,7 +1189,7 @@ L.Control.Menubar = L.Control.extend({
 			'downloadas-pdf', 'downloadas-odt', 'downloadas-doc', 'downloadas-docx', 'downloadas-rtf', 'downloadas-epub', // file menu
 			'downloadas-odp', 'downloadas-ppt', 'downloadas-pptx', 'downloadas-odg', 'print', // file menu
 			'downloadas-ods', 'downloadas-xls', 'downloadas-xlsx', 'downloadas-csv', 'closedocument', // file menu
-			'fullscreen', 'zoomin', 'zoomout', 'zoomreset', 'showresolved', // view menu
+			'fullscreen', 'zoomin', 'zoomout', 'zoomreset', 'showstatusbar', 'showresolved', // view menu
 			'about', 'keyboard-shortcuts', 'latestupdates', 'feedback', 'online-help', 'report-an-issue', // help menu
 			'insertcomment'
 		]


### PR DESCRIPTION
Without this commit if the status bar is hidden, it's impossible
to bring it back and so the user is unable to:
- Search within readonly mode
- View the number of pages
- Zoom in our out via selecting the specific values

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: If30a0729862788f7475ce800b643db2b386722f3
