### PR TITLE
Add read-only mode tooltip when hovering disabled menu items

### DIFF
--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -1639,6 +1639,7 @@ L.Control.Menubar = L.Control.extend({
 			} else { // eslint-disable-next-line no-lonely-if
 				if (type === 'unocommand') { // disable all uno commands
 					$(aItem).addClass('disabled');
+					aItem.title = _('Read-only mode');
 				} else if (type === 'action') { // disable all except allowedViewModeActions
 					var found = false;
 					for (var i in self.options.allowedViewModeActions) {
@@ -1651,6 +1652,7 @@ L.Control.Menubar = L.Control.extend({
 						found = false;
 					if (!found) {
 						$(aItem).addClass('disabled');
+						aItem.title = _('Read-only mode');
 					} else {
 						$(aItem).removeClass('disabled');
 					}


### PR DESCRIPTION
So user can have yet another visual cue that the current mode
is read-only

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ie7862e963603541c04d1b6662fbc7350f6e675a0
