### PR TITLE
Hide insert menu item when in readonly mode

### DIFF
--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -2019,6 +2019,13 @@ L.Control.Menubar = L.Control.extend({
 	_createMenu: function(menu) {
 		var itemList = [];
 		var docType = this._map.getDocType();
+		var isReadOnly = this._map.isPermissionReadOnly();
+		var isAllowChangeComments = this._map.isAllowChangeComments();
+
+		if (!isAllowChangeComments && isReadOnly) { // Checks if PDF or not indirectly. If It is not a PDF(view_comments)
+			//this._hiddenItems.push('insert');     // and a readonly doc, all subitems of insert menu are disabled so not
+		}                                           // have a reason to show insert menu anymore.
+
 		for (var i in menu) {
 			if (this._checkItemVisibility(menu[i]) === false)
 				continue;

--- a/browser/src/control/Permission.js
+++ b/browser/src/control/Permission.js
@@ -258,5 +258,9 @@ L.Map.include({
 
 	isPermissionEdit: function() {
 		return this._permission === 'edit';
+	},
+
+	isAllowChangeComments: function() {
+		return this.options.allowChangeComments;
 	}
 });

--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -620,6 +620,11 @@ app.definitions.Socket = L.Class.extend({
 				this._map.options.permission = 'readonly';
 			}
 
+			if (json.allowComments) {
+				console.debug('xxx: we allowed comments');
+				this._map.options.allowChangeComments = true;
+			}
+
 			if (this._map._docLayer) {
 				this._map.setPermission(this._map.options.permission);
 			}

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1360,6 +1360,8 @@ void ClientSession::sendFileMode(const bool readOnly, const bool editComments)
     result += readOnly ? "true": "false";
     result += ", \"editComment\": ";
     result += editComments ? "true": "false";
+    result += ", \"allowComments\": ";
+    result += isAllowChangeComments() ? "true": "false";
     result += "}";
     sendTextFrame(result);
 }


### PR DESCRIPTION
To do some PDF specific operations we need to sure document is really PDF instead of relying only extension.

Signed-off-by: Gülşah Köse <gulsah.kose@collabora.com>
Change-Id: I02d710293c174e642e66e27f8ca545859521434c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

