### PR TITLE
Dont show error for wrong shape content

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -2061,7 +2061,9 @@ L.CanvasTileLayer = L.Layer.extend({
 
 			// video is handled in _onMediaShapeMsg
 			var isVideoSVG = textMsg.indexOf('<video') !== -1;
-			if (!isVideoSVG) {
+			if (isVideoSVG) {
+				this._map._cacheSVG[extraInfo.id] = undefined;
+			} else {
 				this._graphicMarker.addEmbeddedSVG(textMsg);
 				if (wasVisibleSVG)
 					this._graphicMarker._showEmbeddedSVG();


### PR DESCRIPTION
This happens when second time embedded video was selected.

(Error in the browser console about wrong URL)