### PR TITLE
Limit the automatic addition of percentage sign.

### DIFF
--- a/browser/src/layer/marker/TextInput.js
+++ b/browser/src/layer/marker/TextInput.js
@@ -705,7 +705,7 @@ L.TextInput = L.Layer.extend({
 			// automatically we send the first digit character as KeyEvent.
 			if (this._map.getDocType() === 'spreadsheet' &&
 			    content.length === 1 && ev.inputType === 'insertText' &&
-				this._isDigit(newText)) {
+				this._isDigit(newText) && window.mode.isDesktop()) {
 				this._sendKeyEvent(newText, this._unoKeyMap[newText], 'input');
 			}
 			else


### PR DESCRIPTION
In mobile view there is no way to select a cell and type something into. We had to switch edit mode or use formula bar. So automatic percentage sign addition is useless on mobile view.

Signed-off-by: Gülşah Köse <gulsah.kose@collabora.com>
Change-Id: Ie0fca8121534a53304414d98e6fbdef82a349d89


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

