### PR TITLE
private/pedro/statusbar never goes readonly

### DIFF
--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -35,10 +35,6 @@
 #tb_actionbar_item_LanguageStatus .w2ui-tb-caption{
 	float: none;
 }
-#toolbar-down.readonly #tb_actionbar_item_InsertMode,
-#toolbar-down.readonly #tb_actionbar_item_InsertMode + td[id^='tb_actionbar_item_break'],
-#toolbar-down.readonly #tb_actionbar_item_StatusSelectionMode,
-#toolbar-down.readonly #tb_actionbar_item_StatusSelectionMode + td[id^='tb_actionbar_item_break'],
 #toolbar-down.readonly #tb_actionbar_item_LanguageStatus .w2ui-button .w2ui-tb-down {
 	display: none;
 }

--- a/browser/src/control/Control.StatusBar.js
+++ b/browser/src/control/Control.StatusBar.js
@@ -456,6 +456,11 @@ L.Control.StatusBar = L.Control.extend({
 
 	onPermissionChanged: function(event) {
 		var isReadOnly = event.perm === 'readonly';
+		if (isReadOnly) {
+			$('#toolbar-down').addClass('readonly');
+		} else {
+			$('#toolbar-down').removeClass('readonly');
+		}
 		$('#PermissionMode').parent().html(this._getPermissionModeHtml(isReadOnly));
 	},
 

--- a/browser/src/control/Control.StatusBar.js
+++ b/browser/src/control/Control.StatusBar.js
@@ -65,7 +65,22 @@ L.Control.StatusBar = L.Control.extend({
 	},
 
 	_updateToolbarsVisibility: function(context) {
-		window.updateVisibilityForToolbar(w2ui['actionbar'], context);
+		var isReadOnly = this.map.isPermissionReadOnly();
+		var statusbar = w2ui['actionbar'];
+		if (isReadOnly) {
+			statusbar.disable('LanguageStatus');
+			statusbar.hide('InsertMode');
+			statusbar.hide('break6');
+			statusbar.hide('StatusSelectionMode');
+			statusbar.hide('break7');
+		} else {
+			statusbar.enable('LanguageStatus');
+			statusbar.show('InsertMode');
+			statusbar.show('break6');
+			statusbar.show('StatusSelectionMode');
+			statusbar.show('break7');
+		}
+		window.updateVisibilityForToolbar(statusbar, context);
 	},
 
 	onContextChange: function(event) {
@@ -404,9 +419,6 @@ L.Control.StatusBar = L.Control.extend({
 		this.map.fire('updateuserlistcount');
 
 		this._updateToolbarsVisibility();
-
-		if (isReadOnly)
-			statusbar.disable('LanguageStatus');
 
 		if (statusbar)
 			statusbar.refresh();


### PR DESCRIPTION
- Code refactoring: avoid long statusbar css rules
- Fix statusbar display discrepancies when in readonly mode
