### PR TITLE
Dont set readonly on non-critical error

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -3396,7 +3396,7 @@ L.CanvasTileLayer = L.Layer.extend({
 	},
 
 	_mapOnError: function (e) {
-		if (e.msg && this._map.isPermissionEdit()) {
+		if (e.msg && this._map.isPermissionEdit() && e.critical !== false) {
 			this._map.setPermission('view');
 		}
 	},

--- a/browser/src/map/handler/Map.FileInserter.js
+++ b/browser/src/map/handler/Map.FileInserter.js
@@ -106,7 +106,7 @@ L.Map.FileInserter = L.Handler.extend({
 			if (file.size === 0)
 				errMsg = _('The file of type: %0 cannot be uploaded to server since the file is empty');
 			errMsg = errMsg.replace('%0', file.type);
-			map.fire('error', {msg: errMsg});
+			map.fire('error', {msg: errMsg, critical: false});
 			return;
 		}
 


### PR DESCRIPTION
When we insert empty/not esiting image - we can continue...
