### PR TITLE
Fix the iOS app: Can't use %THINGIES% in cool.html.m4

### DIFF
--- a/browser/html/cool.html.m4
+++ b/browser/html/cool.html.m4
@@ -316,7 +316,7 @@ m4_ifelse(MOBILEAPP,[true],
       window.uiDefaults = {};
       window.useIntegrationTheme = 'false';
       window.checkFileInfoOverride = {};
-	  window.deeplEnabled = %DEEPL_ENABLED%;],
+      window.deeplEnabled = false;],
      [window.host = '%HOST%';
       window.serviceRoot = '%SERVICE_ROOT%';
       window.hexifyUrl = %HEXIFY_URL%;


### PR DESCRIPTION
There is no "file server" in the mobile apps that would expand such percent sequences. The generated cool.html file is used as is.

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: I046c23c13ade6195f3f4a8b395ede7c42fc46bd2


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

