### PR TITLE
Remove insert shape dropdown extra bottom padding

### DIFF
--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -1077,10 +1077,6 @@ button.leaflet-control-search-next
 	text-align: left;
 }
 
-.insertshape-grid .row:last-child {
-	margin-bottom: 70px;
-}
-
 .insertshape-grid .col {
 	height: 30px;
 	padding: 2px;


### PR DESCRIPTION
Before this commit the extra space was not used plus
it was making the popup bigger without necessity.

Referenced in https://github.com/CollaboraOnline/online/issues/2015

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I6b2ba82b3d522f9673e555fb4f762b563c3a9c99
