### PR TITLE
Fix missing icon for Line Spacing: 1.5

### DIFF
--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -870,8 +870,7 @@ button.leaflet-control-search-next
 .w2ui-icon.cellverttop{ background: url('images/lc_cellverttop.svg') no-repeat center !important; }
 .w2ui-icon.cellvertcenter{ background: url('images/lc_cellvertcenter.svg') no-repeat center !important; }
 .w2ui-icon.cellvertbottom{ background: url('images/lc_cellvertbottom.svg') no-repeat center !important; }
-.w2ui-icon.linespacing, .w2ui-icon.spacepara1{ background: url('images/lc_linespacing.svg') no-repeat center !important; }
-.w2ui-icon.spacepara15{ background: url('images/lc_spacepara15.svg') no-repeat center !important; }
+.w2ui-icon.linespacing, .w2ui-icon.spacepara1, .w2ui-icon.spacepara15{ background: url('images/lc_linespacing.svg') no-repeat center !important; }
 .w2ui-icon.spacepara2{ background: url('images/lc_spacepara2.svg') no-repeat center !important; }
 .w2ui-icon.paraspaceincrease{ background: url('images/lc_paraspaceincrease.svg') no-repeat center !important; }
 .w2ui-icon.paraspacedecrease{ background: url('images/lc_paraspacedecrease.svg') no-repeat center !important; }


### PR DESCRIPTION
With the following commit
4e075146b91c6ca3197fdf96d7bb5d75a73b350e
we need to update css to use the same lc_linespacing.svg

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ibd7131a69765b29d69de6d2bb53d1407df363345
