### PR TITLE
Duplicate and place Accessibility Check in the Help tab

### DIFF
--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -320,6 +320,11 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 						]
 					},
 					{
+						'type': 'bigtoolitem',
+						'text': _UNO('.uno:AccessibilityCheck', 'text'),
+						'command': '.uno:AccessibilityCheck'
+					},
+					{
 						'type': 'toolbox',
 						'children': [
 							{


### PR DESCRIPTION
Accessibility checker seems hard to discover. Users tend
to look for such feature in the Help tab (near to Keyboard shortcuts)
and after all we have plenty of space to place it in the help tab.

Better to duplicate instead of moving the icon altogether since it has
been there and we might already have a user base that expects to see
it there. On top of that it makes sense to be together with other
review related action.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ibb5fa8b681faa5a16267f8a23cdbff0ee0d42ec2
