### PR TITLE
systemplate: include /lib/*/nss

### DIFF
--- a/coolwsd-systemplate-setup
+++ b/coolwsd-systemplate-setup
@@ -44,6 +44,7 @@ cd / || exit 1
 find etc/ld.so.* \
      lib/ld-* lib64/ld-* \
      lib/libnss_* lib64/libnss_* lib/*/libnss_* \
+     lib/*/nss/*.so \
      lib/libresolv* lib64/libresolv* lib/*/libresolv* \
      var/cache/fontconfig \
      etc/fonts \


### PR DESCRIPTION
It seems the location of the NSS dynamic
libraries have changed recently. This is
true on Ubuntu 22.04 and it seems on
Clear Linux.

We expected to find them in /usr/lib but
they are now in /lib. We support both
now, so the systemplate should work on
both new and old systems.

The symptom of not having the NSS libs
is failure to open password-protected
documents. The tests failed, which
helped to reproduce and debug.

Change-Id: Ifb4cbc4e2c852464ffcdcc19801689ea60355042
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
