### PR TITLE
Unlock only after uploading

### DIFF
--- a/common/Unit.cpp
+++ b/common/Unit.cpp
@@ -346,6 +346,10 @@ void UnitBase::exitTest(TestResult result)
 {
     if (isFinished())
     {
+        if ((result == TestResult::Ok && _retValue != EX_OK) ||
+            (result != TestResult::Ok && _retValue == EX_OK))
+            LOG_TST(getTestname() << ": exitTest " << testResultAsString(result)
+                                  << " but is already finished with a different result.");
         return;
     }
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -67,6 +67,7 @@ all_la_unit_tests = \
 	unit-wopi-httpheaders.la \
 	unit-load.la \
 	unit-wopi-lock.la \
+	unit-wopi-unlock.la \
 	unit-wopi-httpredirect.la \
 	unit-wopi-loadencoded.la \
 	unit-prefork.la \
@@ -231,6 +232,8 @@ unit_wopi_languages_la_SOURCES = UnitWOPILanguages.cpp
 unit_wopi_languages_la_LIBADD = $(CPPUNIT_LIBS)
 unit_wopi_lock_la_SOURCES = UnitWOPILock.cpp
 unit_wopi_lock_la_LIBADD = $(CPPUNIT_LIBS)
+unit_wopi_unlock_la_SOURCES = UnitWOPIUnlock.cpp
+unit_wopi_unlock_la_LIBADD = $(CPPUNIT_LIBS)
 unit_wopi_watermark_la_SOURCES = UnitWOPIWatermark.cpp
 unit_wopi_watermark_la_LIBADD = $(CPPUNIT_LIBS)
 unit_wopi_loadencoded_la_SOURCES = UnitWOPILoadEncoded.cpp

--- a/test/UnitWOPIStuckSave.cpp
+++ b/test/UnitWOPIStuckSave.cpp
@@ -36,7 +36,7 @@ public:
         , _phase(Phase::Load)
     {
         // We need more time to retry saving.
-        setTimeout(std::chrono::seconds(90));
+        setTimeout(std::chrono::seconds(200));
     }
 
     void configure(Poco::Util::LayeredConfiguration& config) override
@@ -44,7 +44,7 @@ public:
         WopiTestServer::configure(config);
 
         // Small value to shorten the test run time.
-        config.setUInt("per_document.limit_store_failures", 3);
+        config.setUInt("per_document.limit_store_failures", 2);
         config.setBool("per_document.always_save_on_exit", true);
     }
 

--- a/test/UnitWOPIUnlock.cpp
+++ b/test/UnitWOPIUnlock.cpp
@@ -1,0 +1,167 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <config.h>
+
+#include "lokassert.hpp"
+#include <WopiTestServer.hpp>
+#include <Log.hpp>
+#include <helpers.hpp>
+#include <wsd/ClientSession.hpp>
+
+#include <Poco/Net/HTTPRequest.h>
+
+/// This is to test that we do not unlock before uploading
+/// the document, right before unloading the last view.
+class UnitWopiUnlock : public WopiTestServer
+{
+    STATE_ENUM(Phase, Load, Lock, Modify, Upload, Unlock, Done) _phase;
+
+    std::string _lockState;
+    std::string _lockString;
+    std::size_t _sessionCount;
+
+public:
+    UnitWopiUnlock()
+        : WopiTestServer("UnitWopiUnlock")
+        , _phase(Phase::Load)
+        , _lockState("UNLOCK")
+        , _sessionCount(0)
+    {
+    }
+
+    void configCheckFileInfo(Poco::JSON::Object::Ptr fileInfo) override
+    {
+        fileInfo->set("SupportsLocks", "true");
+    }
+
+    std::unique_ptr<http::Response>
+    assertPutFileRequest(const Poco::Net::HTTPRequest& /*request*/) override
+    {
+        LOG_TST("assertPutFileRequest");
+        LOK_ASSERT_STATE(_phase, Phase::Upload);
+
+        TRANSITION_STATE(_phase, Phase::Unlock);
+        return nullptr;
+    }
+
+    void assertLockRequest(const Poco::Net::HTTPRequest& request) override
+    {
+        const std::string lock = request.get("X-WOPI-Lock", std::string());
+        const std::string newLockState = request.get("X-WOPI-Override", std::string());
+        LOG_TST("In " << toString(_phase) << ", X-WOPI-Lock: " << lock << ", X-WOPI-Override: "
+                      << newLockState << ", for URI: " << request.getURI());
+
+        if (_phase == Phase::Lock)
+        {
+            LOK_ASSERT_EQUAL_MESSAGE("Expected X-WOPI-Override:LOCK", std::string("LOCK"),
+                                     newLockState);
+            LOK_ASSERT_MESSAGE("Lock String cannot be empty", !lock.empty());
+            _lockState = newLockState;
+            _lockString = lock;
+            TRANSITION_STATE(_phase, Phase::Modify);
+        }
+        else if (_phase == Phase::Unlock)
+        {
+            LOK_ASSERT_EQUAL_MESSAGE("Expected X-WOPI-Override:UNLOCK", std::string("UNLOCK"),
+                                     newLockState);
+            LOK_ASSERT_MESSAGE("Document is not unlocked", _lockState != "UNLOCK");
+            LOK_ASSERT_EQUAL(_lockString, lock);
+            exitTest(TestResult::Ok);
+        }
+        else
+        {
+            LOK_ASSERT_FAIL("Unexpected lock-state change while in " + toString(_phase));
+        }
+    }
+
+    /// Called when a new client session is added to a DocumentBroker.
+    void onDocBrokerAddSession(const std::string&,
+                               const std::shared_ptr<ClientSession>& session) override
+    {
+        ++_sessionCount;
+        LOG_TST("New Session [" << session->getName() << "] added. Have " << _sessionCount
+                                << " sessions.");
+    }
+
+    void onDocBrokerViewLoaded(const std::string&,
+                               const std::shared_ptr<ClientSession>& session) override
+    {
+        LOG_TST("View for session [" << session->getName() << "] loaded. Have " << _sessionCount
+                                     << " sessions.");
+    }
+
+    /// The document is loaded.
+    bool onDocumentLoaded(const std::string& message) override
+    {
+        LOG_TST("onDocumentLoaded: [" << message << ']');
+        LOK_ASSERT_STATE(_phase, Phase::Modify);
+
+        // Modify the doc.
+        LOG_TST("Modifying");
+        WSD_CMD("key type=input char=97 key=0");
+        WSD_CMD("key type=up char=0 key=512");
+
+        return true;
+    }
+
+    /// The document is modified. Load the viewer session.
+    bool onDocumentModified(const std::string& message) override
+    {
+        LOG_TST("onDocumentModified: [" << message << ']');
+        LOK_ASSERT_STATE(_phase, Phase::Modify);
+
+        TRANSITION_STATE(_phase, Phase::Upload);
+
+        LOG_TST("Disconnecting");
+        deleteSocketAt(0);
+
+        return true;
+    }
+
+    /// Called when a client session is removed to a DocumentBroker.
+    void onDocBrokerRemoveSession(const std::string&,
+                                  const std::shared_ptr<ClientSession>& session) override
+    {
+        --_sessionCount;
+        LOG_TST("Session [" << session->getName() << "] removed. Have " << _sessionCount
+                            << " sessions.");
+    }
+
+    void invokeWSDTest() override
+    {
+        switch (_phase)
+        {
+            case Phase::Load:
+            {
+                // Always transition before issuing commands.
+                TRANSITION_STATE(_phase, Phase::Lock);
+
+                LOG_TST("Creating first connection");
+                initWebsocket("/wopi/files/0?access_token=anything");
+
+                LOG_TST("Loading view");
+                WSD_CMD_BY_CONNECTION_INDEX(0, "load url=" + getWopiSrc());
+                break;
+            }
+            case Phase::Lock:
+            case Phase::Modify:
+            case Phase::Upload:
+            case Phase::Unlock:
+                break;
+            case Phase::Done:
+            {
+                // just wait for the results
+                break;
+            }
+        }
+    }
+};
+
+UnitBase* unit_create_wsd(void) { return new UnitWopiUnlock(); }
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -5162,7 +5162,7 @@ private:
         ClientPortNumber = port;
 
 #if !MOBILEAPP
-        LOG_INF("Listening to client connections on port " << port);
+        LOG_INF('#' << socket->getFD() << "Listening to client connections on port " << port);
 #else
         LOG_INF("Listening to client connections on #" << socket->getFD());
 #endif

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1359,11 +1359,12 @@ void DocumentBroker::checkAndUploadToStorage(const std::string& sessionId)
     {
         uploadToStorage(sessionId, /*force=*/needToUploadState == NeedToUpload::Force);
     }
-    else
+
+    if (!isAsyncUploading())
     {
-        // If the session is disconnected, remove.
+        // If marked to destroy, or session is disconnected, remove.
         const auto it = _sessions.find(sessionId);
-        if (it != _sessions.end() && it->second->isCloseFrame())
+        if (_docState.isMarkedToDestroy() || (it != _sessions.end() && it->second->isCloseFrame()))
             disconnectSessionInternal(sessionId);
 
         // If marked to destroy, then this was the last session.
@@ -1394,11 +1395,6 @@ void DocumentBroker::uploadToStorage(const std::string& sessionId, bool force)
         constexpr bool isRename = false;
         uploadToStorageInternal(sessionId, /*saveAsPath*/ std::string(),
                                 /*saveAsFilename*/ std::string(), isRename, force);
-
-        // If marked to destroy, or session is disconnected, remove.
-        const auto it = _sessions.find(sessionId);
-        if (_docState.isMarkedToDestroy() || (it != _sessions.end() && it->second->isCloseFrame()))
-            disconnectSessionInternal(sessionId);
     }
     else
     {


### PR DESCRIPTION
- wsd: test: log multiple exitTest cases with different results
- wsd: log the socket FD used to listen to client connections
- wsd: test: reduce the duration of UnitWOPIStuckSave
- wsd: test: move assertLockRequest to WopiTestServer
- wsd: unlock the document only after uploading
