### PR TITLE
Fix crash for LOK_CALLBACK_FONTS_MISSING in the mobile apps

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -3128,7 +3128,9 @@ void ChildSession::loKitCallback(const int type, const std::string& payload)
         sendTextFrame("printranges: " + payload);
         break;
     case LOK_CALLBACK_FONTS_MISSING:
+#if !MOBILEAPP
         {
+            // This environment variable is always set in COOLWSD::innerInitialize().
             static std::string fontsMissingHandling = std::string(std::getenv("FONTS_MISSING_HANDLING"));
             if (fontsMissingHandling == "report" || fontsMissingHandling == "both")
                 sendTextFrame("fontsmissing: " + payload);
@@ -3147,6 +3149,7 @@ void ChildSession::loKitCallback(const int type, const std::string& payload)
 #endif
             }
         }
+#endif
         break;
     default:
         LOG_ERR("Unknown callback event (" << lokCallbackTypeToString(type) << "): " << payload);


### PR DESCRIPTION
We should just ignore that callback in the mobile apps for now.

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: Ic1e2f79b23d75433a1f4c491bc31e43d4ebbe3c2


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

