### PR TITLE
Don't mix mouse move and auto-scroll-to-point handling

### DIFF
--- a/browser/src/layer/tile/ScrollSection.ts
+++ b/browser/src/layer/tile/ScrollSection.ts
@@ -763,6 +763,8 @@ class ScrollSection {
 	}
 
 	public onMouseMove (position: Array<number>, dragDistance: Array<number>, e: MouseEvent) {
+		this.clearQuickScrollTimeout();
+
 		if (this.sectionProperties.clickScrollVertical && this.containerObject.draggingSomething) {
 			if (!this.sectionProperties.previousDragDistance) {
 				this.sectionProperties.previousDragDistance = [0, 0];


### PR DESCRIPTION
If user moves mouse - reset current auto scroll settings. So we don't get scheduled events changing current state and causing movement in the other direction.