### PR TITLE
Private/pedro/hyperlink improvements add buttons

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -869,6 +869,8 @@ nav.spreadsheet-color-indicator ~ #sidebar-dock-wrapper {
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
+	margin: 6px 8px;
+	font-size: 14px;
 }
 
 .leaflet-canvas-container .cell-cursor-data {

--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -871,6 +871,26 @@ nav.spreadsheet-color-indicator ~ #sidebar-dock-wrapper {
 	text-overflow: ellipsis;
 	margin: 6px 8px;
 	font-size: 14px;
+	line-height: 1;
+}
+
+#hyperlink-pop-up {
+	padding: 6px 0;
+	display: inline-block;
+	line-height: 1;
+}
+
+.hyperlink-popup-btn {
+	display: inline-block;
+	margin-left: 12px;
+	vertical-align: baseline;
+	width: 26px;
+	height: 26px;
+}
+
+.hyperlink-popup-btn:hover {
+	background-color: var(--color-background-darker);
+	border-radius: 50%;
 }
 
 .leaflet-canvas-container .cell-cursor-data {

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -2425,6 +2425,7 @@ L.CanvasTileLayer = L.Layer.extend({
 			link.innerText = url;
 			var copyBtn = L.DomUtil.createWithId('div', 'hyperlink-pop-up-copy');
 			L.DomUtil.addClass(copyBtn, 'hyperlink-popup-btn');
+			copyBtn.setAttribute('title', _('Copy link location'));
 			var imgCopyBtn = L.DomUtil.create('img', 'hyperlink-pop-up-copyimg', copyBtn);
 			imgCopyBtn.setAttribute('src', L.LOUtil.getImageURL('lc_copyhyperlinklocation.svg'));
 			imgCopyBtn.setAttribute('width', 18);
@@ -2432,6 +2433,7 @@ L.CanvasTileLayer = L.Layer.extend({
 			imgCopyBtn.setAttribute('style', 'padding: 4px');
 			var editBtn = L.DomUtil.createWithId('div', 'hyperlink-pop-up-edit');
 			L.DomUtil.addClass(editBtn, 'hyperlink-popup-btn');
+			editBtn.setAttribute('title', _('Edit link'));
 			var imgEditBtn = L.DomUtil.create('img', 'hyperlink-pop-up-editimg', editBtn);
 			imgEditBtn.setAttribute('src', L.LOUtil.getImageURL('lc_edithyperlink.svg'));
 			imgEditBtn.setAttribute('width', 18);
@@ -2439,6 +2441,7 @@ L.CanvasTileLayer = L.Layer.extend({
 			imgEditBtn.setAttribute('style', 'padding: 4px');
 			var removeBtn = L.DomUtil.createWithId('div', 'hyperlink-pop-up-remove');
 			L.DomUtil.addClass(removeBtn, 'hyperlink-popup-btn');
+			removeBtn.setAttribute('title', _('Remove link'));
 			var imgRemoveBtn = L.DomUtil.create('img', 'hyperlink-pop-up-removeimg', removeBtn);
 			imgRemoveBtn.setAttribute('src', L.LOUtil.getImageURL('lc_removehyperlink.svg'));
 			imgRemoveBtn.setAttribute('width', 18);

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -2423,6 +2423,13 @@ L.CanvasTileLayer = L.Layer.extend({
 		if (!url.startsWith('#')) {
 			var link = L.DomUtil.createWithId('a', 'hyperlink-pop-up');
 			link.innerText = url;
+			var copyBtn = L.DomUtil.createWithId('div', 'hyperlink-pop-up-copy');
+			L.DomUtil.addClass(copyBtn, 'hyperlink-popup-btn');
+			var imgCopyBtn = L.DomUtil.create('img', 'hyperlink-pop-up-copyimg', copyBtn);
+			imgCopyBtn.setAttribute('src', L.LOUtil.getImageURL('lc_copyhyperlinklocation.svg'));
+			imgCopyBtn.setAttribute('width', 18);
+			imgCopyBtn.setAttribute('height', 18);
+			imgCopyBtn.setAttribute('style', 'padding: 4px');
 			var editBtn = L.DomUtil.createWithId('div', 'hyperlink-pop-up-edit');
 			L.DomUtil.addClass(editBtn, 'hyperlink-popup-btn');
 			var imgEditBtn = L.DomUtil.create('img', 'hyperlink-pop-up-editimg', editBtn);
@@ -2437,7 +2444,7 @@ L.CanvasTileLayer = L.Layer.extend({
 			imgRemoveBtn.setAttribute('width', 18);
 			imgRemoveBtn.setAttribute('height', 18);
 			imgRemoveBtn.setAttribute('style', 'padding: 4px');
-			var linkOuterHtml = link.outerHTML + editBtn.outerHTML + removeBtn.outerHTML;
+			var linkOuterHtml = link.outerHTML + copyBtn.outerHTML + editBtn.outerHTML + removeBtn.outerHTML;
 			this._map.hyperlinkPopup = new L.Popup({className: 'hyperlink-popup', closeButton: false, closeOnClick: false, autoPan: false})
 				.setContent(linkOuterHtml)
 				.setLatLng(position)
@@ -2450,11 +2457,14 @@ L.CanvasTileLayer = L.Layer.extend({
 			this._setupClickFuncForId('hyperlink-pop-up', function() {
 				map_.fire('warn', {url: url, map: map_, cmd: 'openlink'});
 			});
+			this._setupClickFuncForId('hyperlink-pop-up-copy', function () {
+				map_.sendUnoCommand('.uno:CopyHyperlinkLocation');
+			});
 			this._setupClickFuncForId('hyperlink-pop-up-edit', function () {
 				map_.sendUnoCommand('.uno:EditHyperlink');
 			});
 			this._setupClickFuncForId('hyperlink-pop-up-remove', function () {
-				// delete
+				map_.sendUnoCommand('.uno:RemoveHyperlink');
 			});
 		}
 	},

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -2417,8 +2417,23 @@ L.CanvasTileLayer = L.Layer.extend({
 		if (!url.startsWith('#')) {
 			var link = L.DomUtil.createWithId('a', 'hyperlink-pop-up');
 			link.innerText = url;
+			var editBtn = L.DomUtil.createWithId('div', 'hyperlink-pop-up-edit');
+			L.DomUtil.addClass(editBtn, 'hyperlink-popup-btn');
+			var imgEditBtn = L.DomUtil.create('img', 'hyperlink-pop-up-editimg', editBtn);
+			imgEditBtn.setAttribute('src', L.LOUtil.getImageURL('lc_edithyperlink.svg'));
+			imgEditBtn.setAttribute('width', 18);
+			imgEditBtn.setAttribute('height', 18);
+			imgEditBtn.setAttribute('style', 'padding: 4px');
+			var removeBtn = L.DomUtil.createWithId('div', 'hyperlink-pop-up-remove');
+			L.DomUtil.addClass(removeBtn, 'hyperlink-popup-btn');
+			var imgRemoveBtn = L.DomUtil.create('img', 'hyperlink-pop-up-removeimg', removeBtn);
+			imgRemoveBtn.setAttribute('src', L.LOUtil.getImageURL('lc_removehyperlink.svg'));
+			imgRemoveBtn.setAttribute('width', 18);
+			imgRemoveBtn.setAttribute('height', 18);
+			imgRemoveBtn.setAttribute('style', 'padding: 4px');
+			var linkOuterHtml = link.outerHTML + editBtn.outerHTML + removeBtn.outerHTML;
 			this._map.hyperlinkPopup = new L.Popup({className: 'hyperlink-popup', closeButton: false, closeOnClick: false, autoPan: false})
-				.setContent(link.outerHTML)
+				.setContent(linkOuterHtml)
 				.setLatLng(position)
 				.openOn(this._map);
 			var offsetDiffTop = $('.hyperlink-popup').offset().top - $('#map').offset().top;

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -2452,6 +2452,8 @@ L.CanvasTileLayer = L.Layer.extend({
 				.setContent(linkOuterHtml)
 				.setLatLng(position)
 				.openOn(this._map);
+			document.getElementById('hyperlink-pop-up').style.maxWidth = '150px';
+			document.getElementById('hyperlink-pop-up').style.overflow = 'hidden';
 			var offsetDiffTop = $('.hyperlink-popup').offset().top - $('#map').offset().top;
 			var offsetDiffLeft = $('.hyperlink-popup').offset().left - $('#map').offset().left;
 			if (offsetDiffTop < 10) this._movePopUpBelow();

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -2412,6 +2412,12 @@ L.CanvasTileLayer = L.Layer.extend({
 		}
 	},
 
+	_setupClickFuncForId: function(targetId, func) {
+		var target = document.getElementById(targetId);
+		target.style.cursor = 'pointer';
+		target.onclick = target.ontouchend = func;
+	},
+
 	_showURLPopUp: function(position, url) {
 		// # for internal links
 		if (!url.startsWith('#')) {
@@ -2441,11 +2447,15 @@ L.CanvasTileLayer = L.Layer.extend({
 			if (offsetDiffTop < 10) this._movePopUpBelow();
 			if (offsetDiffLeft < 10) this._movePopUpRight();
 			var map_ = this._map;
-			var element = document.getElementById('hyperlink-pop-up');
-			element.style.cursor = 'pointer';
-			element.onclick = element.ontouchend = function() {
+			this._setupClickFuncForId('hyperlink-pop-up', function() {
 				map_.fire('warn', {url: url, map: map_, cmd: 'openlink'});
-			};
+			});
+			this._setupClickFuncForId('hyperlink-pop-up-edit', function () {
+				map_.sendUnoCommand('.uno:EditHyperlink');
+			});
+			this._setupClickFuncForId('hyperlink-pop-up-remove', function () {
+				// delete
+			});
 		}
 	},
 


### PR DESCRIPTION
It would be cool to have a hyperlink popup that is not so big in size but has bigger font size plus a couple of actions so the user can edit, remove hyperlink without exiting the popup and trigger the context menu


This PR does that (without sending the uno command yet):
![image](https://user-images.githubusercontent.com/65948705/201128384-4de3fa08-37d9-41a1-b2d2-e6703417fb1a.png)
^ we will then need to add new less complex icon for remove hyperlink icon to be used here


I need help here, my initial feeling was to do something like this (and obviously it is wrong):
```javascript
editBtn.onclick = this._map.sendUnoCommand('.uno:EditHyperlink');
```