### PR TITLE
fix: memory leak with remote config

### DIFF
--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -1199,6 +1199,7 @@ public:
 
         AutoPtr<AppConfigMap> newConfig(new AppConfigMap(newAppConfig));
         _conf.addWriteable(newConfig, PRIO_JSON);
+        newConfig->clear();
 
 #if ENABLE_FEATURE_LOCK
         CommandControl::LockManager::parseLockedHost(_conf);

--- a/wsd/HostUtil.cpp
+++ b/wsd/HostUtil.cpp
@@ -80,6 +80,8 @@ void HostUtil::parseAliases(Poco::Util::LayeredConfiguration& conf)
     }
 
     AliasHosts.clear();
+    WopiHosts.clear();
+    hostList.clear();
 #if ENABLE_FEATURE_LOCK
     CommandControl::LockManager::unlockLinkMap.clear();
 #endif


### PR DESCRIPTION
when eTag header is not passed from remote server it keeps on parsing the new settings without clearing old ones

Signed-off-by: Rash419 <rashesh.padia@collabora.com>
Change-Id: Iaad9fb6c0e7fd45be3e121b0c0bebaba17d90aab


* Resolves: #5436 
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

