### PR TITLE
android: don't link against PocoRedis

### DIFF
--- a/android/lib/src/main/cpp/CMakeLists.txt.in
+++ b/android/lib/src/main/cpp/CMakeLists.txt.in
@@ -129,7 +129,6 @@ target_link_libraries(androidapp
                       ${LOBUILDDIR_ABI}/workdir/LinkTarget/StaticLibrary/liblibpng.a
                       ${POCOLIB_ABI}/libPocoEncodings@POCODEBUG@.a
                       ${POCOLIB_ABI}/libPocoNet@POCODEBUG@.a
-                      ${POCOLIB_ABI}/libPocoRedis@POCODEBUG@.a
                       ${POCOLIB_ABI}/libPocoUtil@POCODEBUG@.a
                       ${POCOLIB_ABI}/libPocoXML@POCODEBUG@.a
                       ${POCOLIB_ABI}/libPocoJSON@POCODEBUG@.a


### PR DESCRIPTION
This was added in commit 4f03f09c534d4b7ac7d397ed697cfebfacaf1895
(android: Gradle project and other stuff to build., 2019-02-12), but
Online doesn't need it, probably was a copy&paste mistake that went
unnoticed till today Michael S mentioned it on IRC.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Icb60cacfb9469a674db3f0f7a359ccdf01132558
