### PR TITLE
wsd: fix malformed img-src field

### DIFF
--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -1118,7 +1118,7 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
         // X-Frame-Options supports only one ancestor, ignore that
         //(it's deprecated anyway and CSP works in all major browsers)
         // frame anchestors are also allowed for img-src in order to load the views avatars
-        cspOss << imgSrc << frameAncestors << "; "
+        cspOss << imgSrc << " " << frameAncestors << "; "
                 << "frame-ancestors " << frameAncestors;
         std::string escapedFrameAncestors;
         Poco::URI::encode(frameAncestors, "'", escapedFrameAncestors);


### PR DESCRIPTION
The generated field is

   img-src 'self' data: https://www.collaboraoffice.com/https://*:* ...;

while a space was expected before the "https://*:*"

This was introduced with

   7e94149ec476445a445ffcd0922d83b1c60c5c64

   wsd: Only add one img-src rule to the CSP header

Signed-off-by: Thomas Lehmann <t.lehmann@strato-rz.de>
Change-Id: Ia900bb2508e7f04b111160001c6602e87eae2023

* Target version: master 

### Summary
Forward-ported from co-6-4.