### PR TITLE
Re-Enable TileTests and Minor Misc Improvements

### DIFF
--- a/common/Unit.cpp
+++ b/common/Unit.cpp
@@ -346,6 +346,10 @@ void UnitBase::exitTest(TestResult result)
 {
     if (isFinished())
     {
+        if ((result == TestResult::Ok && _retValue != EX_OK) ||
+            (result != TestResult::Ok && _retValue == EX_OK))
+            LOG_TST(getTestname() << ": exitTest " << testResultAsString(result)
+                                  << " but is already finished with a different result.");
         return;
     }
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -23,6 +23,7 @@ AM_CXXFLAGS = $(CPPUNIT_CFLAGS) -DTDOC=\"$(abs_top_srcdir)/test/data\" \
 # 'Finished in' in the `make check` output.
 # When adding new tests, please maintain order.
 all_la_unit_tests = \
+	unit-wopi-stuck-save.la \
 	unit-insert-delete.la \
 	unit-tiletest.la \
 	unit-httpws.la \
@@ -32,7 +33,6 @@ all_la_unit_tests = \
 	unit-crash.la \
 	unit-wopi-save-on-exit.la \
 	unit-wopi-documentconflict.la \
-	unit-wopi-stuck-save.la \
 	unit-wopi-fileurl.la \
 	unit-each-view.la \
 	unit-close.la \

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -24,6 +24,7 @@ AM_CXXFLAGS = $(CPPUNIT_CFLAGS) -DTDOC=\"$(abs_top_srcdir)/test/data\" \
 # When adding new tests, please maintain order.
 all_la_unit_tests = \
 	unit-insert-delete.la \
+	unit-tiletest.la \
 	unit-httpws.la \
 	unit-password-protected.la \
 	unit-wopi-fail-upload.la \

--- a/test/TileCacheTests.cpp
+++ b/test/TileCacheTests.cpp
@@ -1579,7 +1579,9 @@ void TileCacheTests::testTileProcessed()
 
     } while(gotTile);
 
-    LOK_ASSERT_EQUAL_MESSAGE("Expected exactly the requested number of tiles", 25, arrivedTile);
+    // Now that we force flushing invalidated tiles (Core 2cc955f9109c0fc8443c9f93c1bf6bd317043cb5),
+    // we get 28 tiles instead of the 25 we got previously.
+    LOK_ASSERT_EQUAL_MESSAGE("Expected exactly the requested number of tiles", 28, arrivedTile);
 
     for(std::string& tileID : tileIDs)
     {

--- a/test/UnitWOPIStuckSave.cpp
+++ b/test/UnitWOPIStuckSave.cpp
@@ -36,7 +36,7 @@ public:
         , _phase(Phase::Load)
     {
         // We need more time to retry saving.
-        setTimeout(std::chrono::seconds(90));
+        setTimeout(std::chrono::seconds(200));
     }
 
     void configure(Poco::Util::LayeredConfiguration& config) override
@@ -44,7 +44,7 @@ public:
         WopiTestServer::configure(config);
 
         // Small value to shorten the test run time.
-        config.setUInt("per_document.limit_store_failures", 3);
+        config.setUInt("per_document.limit_store_failures", 2);
         config.setBool("per_document.always_save_on_exit", true);
     }
 

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -5162,7 +5162,7 @@ private:
         ClientPortNumber = port;
 
 #if !MOBILEAPP
-        LOG_INF("Listening to client connections on port " << port);
+        LOG_INF('#' << socket->getFD() << "Listening to client connections on port " << port);
 #else
         LOG_INF("Listening to client connections on #" << socket->getFD());
 #endif


### PR DESCRIPTION
- wsd: test: reduce the duration of UnitWOPIStuckSave
- wsd: log the socket FD used to listen to client connections
- wsd: test: log multiple exitTest cases with different results
- wsd: test: enable tile-tests
- wsd: test: re-order tests to minimize execution time
