### PR TITLE
wsd: test: fix UnitWOPILock once and for all

### DIFF
--- a/test/UnitWOPILock.cpp
+++ b/test/UnitWOPILock.cpp
@@ -15,31 +15,41 @@
 
 #include <Poco/Net/HTTPRequest.h>
 
+/// This is to test that we unlock before unloading the last editor.
 class UnitWopiLock : public WopiTestServer
 {
     STATE_ENUM(Phase, Load, LockDocument, UnlockDocument, Done) _phase;
 
     std::string _lockState;
-    std::string _lockString;
-    std::size_t _sessionCount;
+    std::string _lockToken;
+    std::size_t _checkFileInfoCount;
+    std::size_t _viewCount;
 
 public:
     UnitWopiLock()
         : WopiTestServer("UnitWopiLock")
         , _phase(Phase::Load)
         , _lockState("UNLOCK")
-        , _sessionCount(0)
+        , _checkFileInfoCount(0)
+        , _viewCount(0)
     {
     }
 
     void configCheckFileInfo(Poco::JSON::Object::Ptr fileInfo) override
     {
-        LOG_TST("CheckFileInfo: Have " << _sessionCount << " sessions");
+        // Make the first session the editor, subsequent ones read-only.
+        const bool firstView = _checkFileInfoCount == 0;
+        ++_checkFileInfoCount;
+
+        LOG_TST("CheckFileInfo: " << (firstView ? "editor" : "viewer"));
 
         fileInfo->set("SupportsLocks", "true");
+        fileInfo->set("UserCanWrite", firstView ? "true" : "false");
 
-        // Make the first session the editor, the second one read-only.
-        fileInfo->set("UserCanWrite", _sessionCount ? "false" : "true");
+        // An extension that doesn't allow commenting. By omitting this,
+        // the test fails because we allow commenting and consider the
+        // document editable, and don't unlock when the editor disconnects.
+        fileInfo->set("BaseFileName", "doc.odt");
     }
 
     void assertLockRequest(const Poco::Net::HTTPRequest& request) override
@@ -53,16 +63,17 @@ public:
         {
             LOK_ASSERT_EQUAL_MESSAGE("Expected X-WOPI-Override:LOCK", std::string("LOCK"),
                                      newLockState);
-            LOK_ASSERT_MESSAGE("Lock String cannot be empty", !lock.empty());
+            LOK_ASSERT_MESSAGE("Lock token cannot be empty", !lock.empty());
             _lockState = newLockState;
-            _lockString = lock;
+            _lockToken = lock;
         }
         else if (_phase == Phase::UnlockDocument)
         {
             LOK_ASSERT_EQUAL_MESSAGE("Expected X-WOPI-Override:UNLOCK", std::string("UNLOCK"),
                                      newLockState);
-            LOK_ASSERT_MESSAGE("Document is not unlocked", _lockState != "UNLOCK");
-            LOK_ASSERT_EQUAL(_lockString, lock);
+            LOK_ASSERT_EQUAL_MESSAGE("Document is not unlocked", std::string("LOCK"), _lockState);
+            LOK_ASSERT_EQUAL_MESSAGE("The lock token has changed", _lockToken, lock);
+
             TRANSITION_STATE(_phase, Phase::Done);
             exitTest(TestResult::Ok);
         }
@@ -72,21 +83,13 @@ public:
         }
     }
 
-    /// Called when a new client session is added to a DocumentBroker.
-    void onDocBrokerAddSession(const std::string&,
-                               const std::shared_ptr<ClientSession>& session) override
-    {
-        ++_sessionCount;
-        LOG_TST("New Session [" << session->getName() << "] added. Have " << _sessionCount
-                                << " sessions.");
-    }
-
     void onDocBrokerViewLoaded(const std::string&,
                                const std::shared_ptr<ClientSession>& session) override
     {
-        LOG_TST("View for session [" << session->getName() << "] loaded.");
+        LOG_TST("View #" << _viewCount + 1 << " [" << session->getName() << "] loaded");
 
-        if (_sessionCount == 2)
+        ++_viewCount;
+        if (_viewCount == 2)
         {
             // Transition before disconnecting.
             TRANSITION_STATE(_phase, Phase::UnlockDocument);
@@ -95,15 +98,6 @@ public:
             LOG_TST("Disconnecting first connection with edit permission");
             deleteSocketAt(0);
         }
-    }
-
-    /// Called when a client session is removed to a DocumentBroker.
-    void onDocBrokerRemoveSession(const std::string&,
-                                  const std::shared_ptr<ClientSession>& session) override
-    {
-        --_sessionCount;
-        LOG_TST("Session [" << session->getName() << "] removed. Have " << _sessionCount
-                            << " sessions.");
     }
 
     void invokeWSDTest() override
@@ -139,9 +133,6 @@ public:
     }
 };
 
-UnitBase *unit_create_wsd(void)
-{
-    return new UnitWopiLock();
-}
+UnitBase* unit_create_wsd(void) { return new UnitWopiLock(); }
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/test/UnitWOPIUnlock.cpp
+++ b/test/UnitWOPIUnlock.cpp
@@ -22,7 +22,7 @@ class UnitWopiUnlock : public WopiTestServer
     STATE_ENUM(Phase, Load, Lock, Modify, Upload, Unlock, Done) _phase;
 
     std::string _lockState;
-    std::string _lockString;
+    std::string _lockToken;
     std::size_t _sessionCount;
 
 public:
@@ -60,17 +60,19 @@ public:
         {
             LOK_ASSERT_EQUAL_MESSAGE("Expected X-WOPI-Override:LOCK", std::string("LOCK"),
                                      newLockState);
-            LOK_ASSERT_MESSAGE("Lock String cannot be empty", !lock.empty());
+            LOK_ASSERT_MESSAGE("Lock token cannot be empty", !lock.empty());
             _lockState = newLockState;
-            _lockString = lock;
+            _lockToken = lock;
             TRANSITION_STATE(_phase, Phase::Modify);
         }
         else if (_phase == Phase::Unlock)
         {
             LOK_ASSERT_EQUAL_MESSAGE("Expected X-WOPI-Override:UNLOCK", std::string("UNLOCK"),
                                      newLockState);
-            LOK_ASSERT_MESSAGE("Document is not unlocked", _lockState != "UNLOCK");
-            LOK_ASSERT_EQUAL(_lockString, lock);
+            LOK_ASSERT_EQUAL_MESSAGE("Document is not unlocked", std::string("LOCK"), _lockState);
+            LOK_ASSERT_EQUAL_MESSAGE("The lock token has changed", _lockToken, lock);
+
+            TRANSITION_STATE(_phase, Phase::Done);
             exitTest(TestResult::Ok);
         }
         else


### PR DESCRIPTION
This fixes a race in UnitWOPILock and the
fact that the second view wasn't really
read-only due to empty extensions being
commentable, by default.

Also, improve UnitWOPIUnlock.
