### PR TITLE
Hide MediaPlaybackPanel on sidebar

### DIFF
--- a/coolkitconfig.xcu.in
+++ b/coolkitconfig.xcu.in
@@ -62,4 +62,7 @@
 <item oor:path="/org.openoffice.Office.Linguistic/ServiceManager/GrammarCheckerList"><prop oor:name="zh-CN" oor:op="fuse" oor:type="oor:string-list"><value><it>org.openoffice.lingu.LanguageToolGrammarChecker</it></value></prop></item>
 <item oor:path="/org.openoffice.Office.Linguistic/ServiceManager/GrammarCheckerList"><prop oor:name="ro-RO" oor:op="fuse" oor:type="oor:string-list"><value><it>org.openoffice.lingu.LanguageToolGrammarChecker</it></value></prop></item>
 
+<!-- Hide MediaPlaybackPanel on sidebar. It does not work in Online. Video playback controls are implemented by the browser.  -->
+<item oor:path="/org.openoffice.Office.UI.Sidebar/Content/PanelList/org.openoffice.Office.UI.Sidebar:Panel['MediaPlaybackPanel']"><prop oor:name="ContextList" oor:op="fuse"><value><it>any</it><it>default</it><it>hidden</it></value></prop></item>
+
 </oor:items>


### PR DESCRIPTION
It does not work in Online.
Video playback controls are implemented by the browser.

Signed-off-by: Andras Timar <andras.timar@collabora.com>
Change-Id: Ib1aa2bb3d8820afb375a6a2c1a71d022a4dc119e


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

