### PR TITLE
Multitest Support

### DIFF
--- a/common/Unit.cpp
+++ b/common/Unit.cpp
@@ -123,7 +123,7 @@ bool UnitBase::init(UnitType type, const std::string &unitLibPath)
                 rememberInstance(type, instance);
                 TST_LOG_NAME("UnitBase",
                              "Starting test #1: " << GlobalArray[GlobalIndex]->getTestname());
-                instance->setHandle();
+                instance->initialize();
 
                 if (instance && type == UnitType::Kit)
                 {
@@ -249,6 +249,14 @@ void UnitBase::uninit()
         dlclose(DlHandle);
     DlHandle = nullptr;
 
+}
+
+void UnitBase::initialize()
+{
+    assert(DlHandle != nullptr && "Invalid handle to set");
+    LOG_TST(getTestname() << ">>> initialize: " << this
+                          << " starting thread: " << _socketPoll.get());
+    _socketPoll->startThread();
 }
 
 bool UnitBase::isUnitTesting()
@@ -432,7 +440,7 @@ void UnitBase::exitTest(TestResult result)
 
         LOG_TST("Starting test #" << GlobalIndex + 1 << ": "
                                   << GlobalArray[GlobalIndex]->getTestname());
-        GlobalArray[GlobalIndex]->setHandle();
+        GlobalArray[GlobalIndex]->initialize();
         return;
     }
 

--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -247,11 +247,8 @@ public:
     std::shared_ptr<SocketPoll> socketPoll() { return _socketPoll; }
 
 private:
-    void setHandle()
-    {
-        assert(DlHandle != nullptr && "Invalid handle to set");
-        _socketPoll->startThread();
-    }
+    /// Initialize the test.
+    virtual void initialize();
 
     /// Dynamically load the unit-test .so.
     static UnitBase** linkAndCreateUnit(UnitType type, const std::string& unitLibPath);

--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -51,6 +51,7 @@ class StorageBase;
 
 typedef UnitBase *(CreateUnitHooksFunction)();
 extern "C" { UnitBase *unit_create_wsd(void); }
+extern "C" { UnitBase *unit_create_wsd_multi(void); }
 extern "C" { UnitBase *unit_create_kit(void); }
 extern "C" { typedef struct _LibreOfficeKit LibreOfficeKit; }
 

--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -233,8 +233,8 @@ public:
 
     static UnitBase& get()
     {
-        assert(Global);
-        return *Global;
+        assert(GlobalArray && GlobalIndex >= 0 && GlobalArray[GlobalIndex]);
+        return *GlobalArray[GlobalIndex];
     }
 
     static std::string getUnitLibPath() { return std::string(UnitLibPath); }
@@ -252,7 +252,9 @@ private:
         _dlHandle = dlHandle;
         _socketPoll->startThread();
     }
-    static UnitBase *linkAndCreateUnit(UnitType type, const std::string& unitLibPath);
+
+    /// Dynamically load the unit-test .so.
+    static UnitBase** linkAndCreateUnit(UnitType type, const std::string& unitLibPath);
 
     /// Handles messages from LOKit.
     virtual bool onFilterLOKitMessage(const std::shared_ptr<Message>& /*message*/) { return false; }
@@ -272,10 +274,12 @@ private:
 
     void *_dlHandle;
     static char *UnitLibPath;
+    static UnitBase** GlobalArray; //< All the tests.
+    static int GlobalIndex; //< The index of the current test.
+
     bool _setRetValue;
     int _retValue;
     std::chrono::milliseconds _timeoutMilliSeconds;
-    static UnitBase *Global;
     UnitType _type;
 
     std::shared_ptr<SocketPoll> _socketPoll; //< Poll thread for async http comm.

--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -132,7 +132,9 @@ public:
     /// Load unit test hook shared library from this path
     static bool init(UnitType type, const std::string& unitLibPath);
 
-    static void uninit();
+    /// Uninitialize the unit-test and return the global exit code.
+    /// Returns 0 on success.
+    static int uninit();
 
     /// Do we have a unit test library hooking things & loaded
     static bool isUnitTesting();
@@ -273,6 +275,7 @@ private:
     static char *UnitLibPath;
     static UnitBase** GlobalArray; //< All the tests.
     static int GlobalIndex; //< The index of the current test.
+    static TestResult GlobalResult; //< The result of all tests. Latches at first failure.
 
     bool _setRetValue;
     int _retValue;

--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -116,8 +116,7 @@ protected:
 
     /// Construct a UnitBase instance with a default name.
     explicit UnitBase(const std::string& name, UnitType type)
-        : _dlHandle(nullptr)
-        , _setRetValue(false)
+        : _setRetValue(false)
         , _retValue(0)
         , _timeoutMilliSeconds(std::chrono::seconds(30))
         , _type(type)
@@ -131,6 +130,8 @@ protected:
 public:
     /// Load unit test hook shared library from this path
     static bool init(UnitType type, const std::string& unitLibPath);
+
+    static void uninit();
 
     /// Do we have a unit test library hooking things & loaded
     static bool isUnitTesting();
@@ -245,11 +246,9 @@ public:
     std::shared_ptr<SocketPoll> socketPoll() { return _socketPoll; }
 
 private:
-    void setHandle(void *dlHandle)
+    void setHandle()
     {
-        assert(_dlHandle == nullptr && "setHandle must only be called once");
-        assert(dlHandle != nullptr && "Invalid handle to set");
-        _dlHandle = dlHandle;
+        assert(DlHandle != nullptr && "Invalid handle to set");
         _socketPoll->startThread();
     }
 
@@ -272,7 +271,7 @@ private:
     /// setup global instance for get() method
     static void rememberInstance(UnitType type, UnitBase* instance);
 
-    void *_dlHandle;
+    static void* DlHandle; //< The handle to the unit-test .so.
     static char *UnitLibPath;
     static UnitBase** GlobalArray; //< All the tests.
     static int GlobalIndex; //< The index of the current test.

--- a/kit/ForKit.cpp
+++ b/kit/ForKit.cpp
@@ -773,6 +773,8 @@ int main(int argc, char** argv)
     int returnValue = EX_OK;
     UnitKit::get().returnValue(returnValue);
 
+    UnitBase::uninit();
+
     LOG_INF("ForKit process finished.");
     Util::forcedExit(returnValue);
 }

--- a/kit/ForKit.cpp
+++ b/kit/ForKit.cpp
@@ -770,10 +770,7 @@ int main(int argc, char** argv)
             forkLibreOfficeKit(childRoot, sysTemplate, loTemplate);
     }
 
-    int returnValue = EX_OK;
-    UnitKit::get().returnValue(returnValue);
-
-    UnitBase::uninit();
+    const int returnValue = UnitBase::uninit();
 
     LOG_INF("ForKit process finished.");
     Util::forcedExit(returnValue);

--- a/test/UnitTimeout.cpp
+++ b/test/UnitTimeout.cpp
@@ -35,12 +35,12 @@ public:
     {
         bool madeWSD = init(UnitType::Wsd, std::string());
         assert(madeWSD);
-        delete UnitBase::Global;
-        UnitBase::Global = nullptr;
+        delete [] UnitBase::GlobalArray;
+        UnitBase::GlobalArray = nullptr;
         bool madeKit = init(UnitType::Kit, std::string());
         assert(madeKit);
-        delete UnitBase::Global;
-        UnitBase::Global = nullptr;
+        delete [] UnitBase::GlobalArray;
+        UnitBase::GlobalArray = nullptr;
     }
 };
 

--- a/test/UnitWSDClient.hpp
+++ b/test/UnitWSDClient.hpp
@@ -16,16 +16,30 @@
 #include <string>
 #include <vector>
 
+/// Send a command message to WSD from a UnitWSDClient instance on the given connection.
+#define WSD_CMD_BY_CONNECTION_INDEX(INDEX, MSG)                                                    \
+    do                                                                                             \
+    {                                                                                              \
+        LOG_TST("Sending from #" << INDEX << ": " << MSG);                                         \
+        helpers::sendTextFrame(getWsAt(INDEX)->getWebSocket(), MSG, getTestname());                \
+        SocketPoll::wakeupWorld();                                                                 \
+    } while (false)
+
+/// Send a command message to WSD from a UnitWSDClient instance on the primary connection.
+#define WSD_CMD(MSG) WSD_CMD_BY_CONNECTION_INDEX(0, MSG)
+
+/// A WebSocketSession wrapper to help with testing.
 class UnitWebSocket final
 {
     std::shared_ptr<http::WebSocketSession> _httpSocket;
 
 public:
-    /// Get a websocket connected for a given URL
-    UnitWebSocket(const std::shared_ptr<SocketPoll>& socketPoll, const std::string& documentURL)
+    /// Get a websocket connected for a given URL.
+    UnitWebSocket(const std::shared_ptr<SocketPoll>& socketPoll, const std::string& documentURL,
+                  const std::string& testname = "UnitWebSocket ")
     {
         Poco::URI uri(helpers::getTestServerURI());
-        _httpSocket = helpers::connectLOKit(socketPoll, uri, documentURL, "UnitWebSocket ");
+        _httpSocket = helpers::connectLOKit(socketPoll, uri, documentURL, testname);
     }
 
     /// Destroy the WS.
@@ -39,6 +53,8 @@ public:
 
 /// A WSD unit-test base class with support
 /// to manage client connections.
+/// This cannot be in UnitWSD or UnitBase because
+/// we use test code that isn't availabe in COOLWSD.
 class UnitWSDClient : public UnitWSD
 {
 public:
@@ -75,8 +91,8 @@ protected:
 
         // Insert at the front.
         const auto& _ws = _wsList.emplace(
-            _wsList.begin(),
-            Util::make_unique<UnitWebSocket>(socketPoll(), "/cool/" + _wopiSrc + "/ws"));
+            _wsList.begin(), Util::make_unique<UnitWebSocket>(
+                                 socketPoll(), "/cool/" + _wopiSrc + "/ws", getTestname()));
 
         assert((*_ws).get());
     }
@@ -89,8 +105,8 @@ protected:
 
         // Insert at the back.
         const auto& _ws = _wsList.emplace(
-            _wsList.end(),
-            Util::make_unique<UnitWebSocket>(socketPoll(), "/cool/" + _wopiSrc + "/ws"));
+            _wsList.end(), Util::make_unique<UnitWebSocket>(
+                               socketPoll(), "/cool/" + _wopiSrc + "/ws", getTestname()));
 
         assert((*_ws).get());
     }
@@ -102,17 +118,5 @@ private:
     /// Websockets to communicate.
     std::vector<std::unique_ptr<UnitWebSocket>> _wsList;
 };
-
-/// Send a command message to WSD from a WopiTestServer on the given connection.
-#define WSD_CMD_BY_CONNECTION_INDEX(INDEX, MSG)                                                    \
-    do                                                                                             \
-    {                                                                                              \
-        LOG_TST("Sending from #" << INDEX << ": " << MSG);                                         \
-        helpers::sendTextFrame(getWsAt(INDEX)->getWebSocket(), MSG, getTestname());                \
-        SocketPoll::wakeupWorld();                                                                 \
-    } while (false)
-
-/// Send a command message to WSD from a WopiTestServer on the primary connection.
-#define WSD_CMD(MSG) WSD_CMD_BY_CONNECTION_INDEX(0, MSG)
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -5596,6 +5596,7 @@ int COOLWSD::innerMain()
     int returnValue = EX_OK;
     UnitWSD::get().returnValue(returnValue);
 
+    UnitBase::uninit();
     LOG_INF("Process [coolwsd] finished with exit status: " << returnValue);
 
     // At least on centos7, Poco deadlocks while
@@ -5677,6 +5678,8 @@ int COOLWSD::main(const std::vector<std::string>& /*args*/)
     cleanup();
 
     UnitWSD::get().returnValue(returnValue);
+
+    UnitBase::uninit();
 
     LOG_INF("Process [coolwsd] finished with exit status: " << returnValue);
 

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -5593,8 +5593,7 @@ int COOLWSD::innerMain()
     JailUtil::cleanupJails(ChildRoot);
 #endif // !MOBILEAPP
 
-    int returnValue = EX_OK;
-    UnitWSD::get().returnValue(returnValue);
+    const int returnValue = UnitBase::uninit();
 
     UnitBase::uninit();
     LOG_INF("Process [coolwsd] finished with exit status: " << returnValue);
@@ -5677,9 +5676,7 @@ int COOLWSD::main(const std::vector<std::string>& /*args*/)
 
     cleanup();
 
-    UnitWSD::get().returnValue(returnValue);
-
-    UnitBase::uninit();
+    returnValue = UnitBase::uninit();
 
     LOG_INF("Process [coolwsd] finished with exit status: " << returnValue);
 


### PR DESCRIPTION
This adds support for multiple tests
within a single unit-test .so.

We did have many, many tests within
the converted "old style" tests already.
Except, they couldn't support the proper
event-driven tests, nor were they running
as fast as possible. They also blocked the
main thread in COOLWSD.

With this support, we can now avoid
creating a new .so for each test case.
This will reduce the effort to add new
tests and the build time. In addition,
the execution of each unit-test is
dominated by the initialization, which
takes in the order of 5 seconds. Running
multiple tests after this high load time
reduces the per-test average time.

Later we will support listing tests,
running particular tests (i.e. filtering)
and other debugging and troubleshooting
facilities.

Each commit is self-contained, builds and passes tests. Best reviewed by commit.

- wsd: test: improvements to UnitWSDClient
- wsd: test: use a global array to support multiple tests
- wsd: test: make dlhandle static and properly cleanup
- wsd: test: support multitests
- wsd: test: rename setHandle to initialize
- wsd: test: merge the results of all tests

