### PR TITLE
Revert "fix: memory leak with remote config"

### DIFF
--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -1199,7 +1199,6 @@ public:
 
         AutoPtr<AppConfigMap> newConfig(new AppConfigMap(newAppConfig));
         _conf.addWriteable(newConfig, PRIO_JSON);
-        newConfig->clear();
 
 #if ENABLE_FEATURE_LOCK
         CommandControl::LockManager::parseLockedHost(_conf);

--- a/wsd/HostUtil.cpp
+++ b/wsd/HostUtil.cpp
@@ -80,8 +80,6 @@ void HostUtil::parseAliases(Poco::Util::LayeredConfiguration& conf)
     }
 
     AliasHosts.clear();
-    WopiHosts.clear();
-    hostList.clear();
 #if ENABLE_FEATURE_LOCK
     CommandControl::LockManager::unlockLinkMap.clear();
 #endif


### PR DESCRIPTION
Backwards compatible storage.wopi.host entries stopped working.

This reverts commit 3aa3334a7b2b0abad7a07beefa881be62a83020b.

Signed-off-by: Aron Budea <aron.budea@collabora.com>
Change-Id: I5bb0c53a874a52db88125cb3aa59dc08b62b75a7


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

