### PR TITLE
Enable read-only status label for tablets

### DIFF
--- a/browser/src/control/Control.StatusBar.js
+++ b/browser/src/control/Control.StatusBar.js
@@ -331,7 +331,7 @@ L.Control.StatusBar = L.Control.extend({
 					},
 					{type: 'break', id: 'break9', mobile: false},
 					{
-						type: 'html', id: 'PermissionMode', mobile: false, tablet: false,
+						type: 'html', id: 'PermissionMode', mobile: false, tablet: true,
 						html: this._getPermissionModeHtml(isReadOnly)
 					}
 				]);
@@ -367,7 +367,7 @@ L.Control.StatusBar = L.Control.extend({
 					},
 					{type: 'break', id: 'break8', mobile: false},
 					{
-						type: 'html', id: 'PermissionMode', mobile: false, tablet: false,
+						type: 'html', id: 'PermissionMode', mobile: false, tablet: true,
 						html: this._getPermissionModeHtml(isReadOnly)
 					}
 				]);
@@ -388,7 +388,7 @@ L.Control.StatusBar = L.Control.extend({
 					},
 					{type: 'break', id: 'break8', mobile: false},
 					{
-						type: 'html', id: 'PermissionMode', mobile: false, tablet: false,
+						type: 'html', id: 'PermissionMode', mobile: false, tablet: true,
 						html: this._getPermissionModeHtml(isReadOnly)
 					}
 				]);
@@ -408,7 +408,7 @@ L.Control.StatusBar = L.Control.extend({
 					},
 					{type: 'break', id: 'break8', mobile: false},
 					{
-						type: 'html', id: 'PermissionMode', mobile: false, tablet: false,
+						type: 'html', id: 'PermissionMode', mobile: false, tablet: true,
 						html: this._getPermissionModeHtml(isReadOnly)
 					}
 				]);


### PR DESCRIPTION
So tablet user is able to check what is the current edit mode
by looking at the status bar

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I4990ca748762eb100b0ca9e791b4ae2a0843f2f6
