### PR TITLE
Test Improvements

### DIFF
--- a/common/Unit.cpp
+++ b/common/Unit.cpp
@@ -102,6 +102,24 @@ UnitBase** UnitBase::linkAndCreateUnit(UnitType type, const std::string& unitLib
     return nullptr;
 }
 
+void UnitBase::filter()
+{
+    // For now, support only filtering.
+    static const char* TestOptions = getenv("COOL_TEST_OPTIONS");
+    if (TestOptions == nullptr)
+        return;
+
+    const std::string filter = Util::toLower(TestOptions);
+    for (GlobalIndex = 0; GlobalArray[GlobalIndex] != nullptr; ++GlobalIndex)
+    {
+        const std::string& name = GlobalArray[GlobalIndex]->getTestname();
+        if (strstr(Util::toLower(name).c_str(), filter.c_str()))
+            break;
+
+        LOG_INF("Skipping test [" << name << "] per filter [" << TestOptions << "]");
+    }
+}
+
 bool UnitBase::init(UnitType type, const std::string &unitLibPath)
 {
 #if !MOBILEAPP
@@ -119,7 +137,10 @@ bool UnitBase::init(UnitType type, const std::string &unitLibPath)
         GlobalArray = linkAndCreateUnit(type, unitLibPath);
         if (GlobalArray)
         {
+            // Filter tests.
             GlobalIndex = 0;
+            filter();
+
             UnitBase* instance = GlobalArray[GlobalIndex];
             if (instance)
             {

--- a/common/Unit.cpp
+++ b/common/Unit.cpp
@@ -20,6 +20,7 @@
 #include <Poco/JSON/Object.h>
 #include <Poco/JSON/Parser.h>
 #include <Poco/Util/LayeredConfiguration.h>
+#include <Poco/Util/Application.h>
 
 #include "Log.hpp"
 #include "Util.hpp"
@@ -497,6 +498,8 @@ void UnitBase::exitTest(TestResult result, const std::string& reason)
 
         LOG_TST("Starting test #" << GlobalIndex + 1 << ": "
                                   << GlobalArray[GlobalIndex]->getTestname());
+        if (GlobalWSD)
+            GlobalWSD->configure(Poco::Util::Application::instance().config());
         GlobalArray[GlobalIndex]->initialize();
         return;
     }

--- a/common/Unit.cpp
+++ b/common/Unit.cpp
@@ -456,7 +456,7 @@ UnitKit& UnitKit::get()
     return *GlobalKit;
 }
 
-void UnitBase::exitTest(TestResult result)
+void UnitBase::exitTest(TestResult result, const std::string& reason)
 {
     if (isFinished())
     {
@@ -469,11 +469,14 @@ void UnitBase::exitTest(TestResult result)
 
     if (result == TestResult::Ok)
     {
-        LOG_TST(getTestname() << ": SUCCESS: exitTest: " << testResultAsString(result));
+        LOG_TST(getTestname() << ": SUCCESS: exitTest: " << testResultAsString(result)
+                              << (reason.empty() ? "" : ": " + reason));
     }
     else
     {
-        LOG_TST("ERROR " << getTestname() << ": FAILURE: exitTest: " << testResultAsString(result));
+        LOG_TST("ERROR " << getTestname() << ": FAILURE: exitTest: " << testResultAsString(result)
+                         << (reason.empty() ? "" : ": " + reason));
+
         _retValue = EX_SOFTWARE;
         if (GlobalResult == TestResult::Ok)
             GlobalResult = result;

--- a/common/Unit.cpp
+++ b/common/Unit.cpp
@@ -68,7 +68,19 @@ UnitBase** UnitBase::linkAndCreateUnit(UnitType type, const std::string& unitLib
             {
                 UnitBase** hooks = createHooksMulti();
                 if (hooks)
+                {
+                    std::ostringstream oss;
+                    oss << "Loaded UnitTest [" << unitLibPath << "] with: ";
+                    for (int i = 0; hooks[i] != nullptr; ++i)
+                    {
+                        if (i)
+                            oss << ", ";
+                        oss << hooks[i]->getTestname();
+                    }
+
+                    LOG_INF(oss.str());
                     return hooks;
+                }
             }
 
             // Fallback.

--- a/common/Unit.cpp
+++ b/common/Unit.cpp
@@ -268,8 +268,7 @@ int UnitBase::uninit()
 void UnitBase::initialize()
 {
     assert(DlHandle != nullptr && "Invalid handle to set");
-    LOG_TST(getTestname() << ">>> initialize: " << this
-                          << " starting thread: " << _socketPoll.get());
+    LOG_TST("==================== Starting [" << getTestname() << "] ====================");
     _socketPoll->startThread();
 }
 
@@ -499,6 +498,8 @@ void UnitBase::returnValue(int &retValue)
     TimeoutThreadMutex.unlock();
     if (TimeoutThread.joinable())
         TimeoutThread.join();
+
+    LOG_TST("==================== Finished [" << getTestname() << "] ====================");
 }
 
 void UnitKit::returnValue(int &retValue)

--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -143,10 +143,12 @@ public:
     /// Tweak the return value from the process.
     virtual void returnValue(int& /* retValue */);
 
-    /// Trigger a failure due to any reason.
-    virtual void fail(const std::string& reason)
+    /// Data-loss detection. Override if expected/intentional.
+    /// Returns true if we failed, false otherwise.
+    virtual bool onDataLoss(const std::string& reason)
     {
         failTest(reason);
+        return failed();
     }
 
     /// Input message either for WSD or Kit

--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -100,20 +100,18 @@ protected:
     }
 
     /// Encourages the process to exit with this value (unless hooked)
-    void exitTest(TestResult result);
+    void exitTest(TestResult result, const std::string& reason = std::string());
 
     /// Fail the test with the given reason.
     void failTest(const std::string& reason)
     {
-        LOG_TST("FAILURE: " << getTestname() << " finished: " << reason);
-        exitTest(TestResult::Failed);
+        exitTest(TestResult::Failed, reason);
     }
 
     /// Pass the test with the given optional reason.
     void passTest(const std::string& reason = std::string())
     {
-        LOG_TST("SUCCESS: " << getTestname() << " finished: " << reason);
-        exitTest(TestResult::Ok);
+        exitTest(TestResult::Ok, reason);
     }
 
     /// Construct a UnitBase instance with a default name.

--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -50,8 +50,9 @@ class Session;
 class StorageBase;
 
 typedef UnitBase *(CreateUnitHooksFunction)();
+typedef UnitBase**(CreateUnitHooksFunctionMulti)();
 extern "C" { UnitBase *unit_create_wsd(void); }
-extern "C" { UnitBase *unit_create_wsd_multi(void); }
+extern "C" { UnitBase** unit_create_wsd_multi(void); }
 extern "C" { UnitBase *unit_create_kit(void); }
 extern "C" { typedef struct _LibreOfficeKit LibreOfficeKit; }
 

--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -258,6 +258,9 @@ private:
     /// Dynamically load the unit-test .so.
     static UnitBase** linkAndCreateUnit(UnitType type, const std::string& unitLibPath);
 
+    /// Based on COOL_TEST_OPTIONS envar, filter the tests.
+    static void filter();
+
     /// Handles messages from LOKit.
     virtual bool onFilterLOKitMessage(const std::shared_ptr<Message>& /*message*/) { return false; }
 

--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -333,7 +333,10 @@ public:
         try
         {
             // Invoke the test, expect no exceptions.
-            invokeWSDTest();
+            if (!isFinished())
+            {
+                invokeWSDTest();
+            }
         }
         catch (const Poco::Exception& ex)
         {

--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -647,10 +647,13 @@ public:
     /// 0 for closed socket, and -1 for other errors.
     int sendMessage(const char* data, const size_t len, const WSOpCode code, const bool flush) const
     {
-        int unitReturn = -1;
-        if (!Util::isFuzzing() &&
-            UnitBase::get().filterSendWebSocketMessage(data, len, code, flush, unitReturn))
-            return unitReturn;
+        if (!Util::isFuzzing())
+        {
+            int unitReturn = -1;
+            static auto& unit = UnitBase::get();
+            if (unit.filterSendWebSocketMessage(data, len, code, flush, unitReturn))
+                return unitReturn;
+        }
 
         //TODO: Support fragmented messages.
 

--- a/test/UnitWOPICrashModified.cpp
+++ b/test/UnitWOPICrashModified.cpp
@@ -74,10 +74,11 @@ public:
         return true;
     }
 
-    void fail(const std::string& reason) override
+    bool onDataLoss(const std::string& reason) override
     {
         LOK_ASSERT_STATE(_phase, Phase::WaitDocClose);
         passTest("Finished with the data-loss check: " + reason);
+        return failed();
     }
 
     void invokeWSDTest() override

--- a/test/UnitWOPIFailUpload.cpp
+++ b/test/UnitWOPIFailUpload.cpp
@@ -173,7 +173,7 @@ public:
     }
 
     // Called when we have modified document data at exit.
-    void fail(const std::string& reason) override
+    bool onDataLoss(const std::string& reason) override
     {
         LOG_TST("Modified document being unloaded: " << reason);
 
@@ -184,6 +184,8 @@ public:
         LOK_ASSERT_MESSAGE("Expected to be in Phase::WaitDocClose but was " + toString(_phase),
                            _phase == Phase::WaitDocClose);
         _unloadingModifiedDocDetected = true;
+
+        return failed();
     }
 
     // Wait for clean unloading.

--- a/test/UnitWOPIStuckSave.cpp
+++ b/test/UnitWOPIStuckSave.cpp
@@ -112,10 +112,11 @@ public:
         return false;
     }
 
-    void fail(const std::string& reason) override
+    bool onDataLoss(const std::string& reason) override
     {
         LOK_ASSERT_STATE(_phase, Phase::WaitClose);
         passTest("Finished with the data-loss check: " + reason);
+        return failed();
     }
 
     void invokeWSDTest() override

--- a/test/UnitWSDClient.hpp
+++ b/test/UnitWSDClient.hpp
@@ -6,6 +6,7 @@
  */
 
 #include "helpers.hpp"
+#include "lokassert.hpp"
 #include "testlog.hpp"
 #include "Unit.hpp"
 #include "Util.hpp"
@@ -21,8 +22,7 @@
     do                                                                                             \
     {                                                                                              \
         LOG_TST("Sending from #" << INDEX << ": " << MSG);                                         \
-        helpers::sendTextFrame(getWsAt(INDEX)->getWebSocket(), MSG, getTestname());                \
-        SocketPoll::wakeupWorld();                                                                 \
+        sendCommand(INDEX, MSG);                                                                   \
     } while (false)
 
 /// Send a command message to WSD from a UnitWSDClient instance on the primary connection.
@@ -109,6 +109,14 @@ protected:
                                socketPoll(), "/cool/" + _wopiSrc + "/ws", getTestname()));
 
         assert((*_ws).get());
+    }
+
+    /// Send a command to WSD.
+    void sendCommand(int index, const std::string& msg)
+    {
+        LOK_ASSERT(index >= 0 && static_cast<std::size_t>(index) < _wsList.size());
+        helpers::sendTextFrame(getWsAt(index)->getWebSocket(), msg, getTestname());
+        SocketPoll::wakeupWorld();
     }
 
 private:

--- a/test/WOPIUploadConflictCommon.hpp
+++ b/test/WOPIUploadConflictCommon.hpp
@@ -260,7 +260,7 @@ public:
     }
 
     // Called when we have modified document data at exit.
-    void fail(const std::string& reason) override
+    bool onDataLoss(const std::string& reason) override
     {
         // We expect this to happen only with the disonnection test,
         // because only in that case there is no user input.
@@ -275,6 +275,8 @@ public:
             "Expected to be in Scenario::Disconnect OR Scenario::SaveOverwrite but was " +
                 toString(_scenario),
             (_scenario == Scenario::Disconnect) || (_scenario == Scenario::SaveOverwrite));
+
+        return failed();
     }
 
     // Wait for clean unloading.

--- a/test/WopiTestServer.hpp
+++ b/test/WopiTestServer.hpp
@@ -18,6 +18,7 @@
 #include <Poco/URI.h>
 #include <Poco/Util/LayeredConfiguration.h>
 
+#include <cctype>
 #include <sstream>
 #include <vector>
 
@@ -160,11 +161,14 @@ protected:
             return "he%llo.txt";
         }
 
-        const auto number = std::stoi(filename);
-        if (number >=1 && number <= 9)
+        if (filename.size() == 1 && std::isdigit(filename[0]))
         {
-            // Fake filename, depends on implicit filename.
-            return DefaultFilename;
+            const auto number = std::stoi(filename);
+            if (number >= 1 && number <= 9)
+            {
+                // Fake filename, depends on implicit filename.
+                return DefaultFilename;
+            }
         }
 
         // Return the filename given in the URI.

--- a/test/lokassert.hpp
+++ b/test/lokassert.hpp
@@ -26,22 +26,23 @@ inline std::ostream& operator<<(std::ostream& os, const std::vector<char>& v)
 }
 
 template <typename T, typename U>
-inline std::string lokFormatAssertEq(const T& expected, const char* expectedName, const U& actual)
+inline std::string lokFormatAssertEq(const char* expectedName, const T& expected,
+                                     const char* actualName, const U& actual)
 {
     std::ostringstream oss;
-    oss << "Expected " << expectedName << " == [" << std::boolalpha << (expected) << "] but got ["
-        << (actual) << ']';
+    oss << "Expected " << actualName << " [" << std::boolalpha << (actual)
+        << "] == " << expectedName << " [" << (expected) << ']';
     return oss.str();
 }
 
 template <>
-std::string inline lokFormatAssertEq(const std::string& expected, const char*,
-                                     const std::string& actual)
+std::string inline lokFormatAssertEq(const char* expected_name, const std::string& expected,
+                                     const char* actual_name, const std::string& actual)
 {
     std::ostringstream oss;
     oss << '\n';
-    oss << "Expected: [" << expected << "]\n";
-    oss << "Actual:   [" << actual << "]\n";
+    oss << "Expected (" << expected_name << "): [" << expected << "]\n";
+    oss << "Actual (" << actual_name << "):   [" << actual << "]\n";
     oss << "          [";
 
     const auto minSize = std::min(expected.size(), actual.size());
@@ -110,11 +111,11 @@ std::string inline lokFormatAssertEq(const std::string& expected, const char*,
 /// Assert the equality of two expressions. WARNING: Multiple evaluations!
 /// Captures full expressions, but only meaningful when they have no side-effects when evaluated.
 #define LOK_ASSERT_EQUAL_UNSAFE(expected, actual)                                                  \
-    LOK_ASSERT_EQUAL_MESSAGE_UNSAFE("", expected, #actual, actual)
+    LOK_ASSERT_EQUAL_MESSAGE_UNSAFE("", #expected, expected, #actual, actual)
 
 /// Assert the equality of two expressions with a custom message. WARNING: Multiple evaluations!
 /// Captures full expressions, but only meaningful when they have no side-effects when evaluated.
-#define LOK_ASSERT_EQUAL_MESSAGE_UNSAFE(message, expected, actual_name, actual)                    \
+#define LOK_ASSERT_EQUAL_MESSAGE_UNSAFE(message, expected_name, expected, actual_name, actual)     \
     do                                                                                             \
     {                                                                                              \
         if (!((expected) == (actual)))                                                             \
@@ -124,7 +125,7 @@ std::string inline lokFormatAssertEq(const std::string& expected, const char*,
             const auto msg##__LINE__ = oss##__LINE__.str();                                        \
             TST_LOG("ERROR: Assertion failure: "                                                   \
                     << (msg##__LINE__.empty() ? "" : msg##__LINE__ + ' ')                          \
-                    << lokFormatAssertEq(expected, actual_name, actual));                          \
+                    << lokFormatAssertEq(expected_name, expected, actual_name, actual));           \
             LOK_ASSERT_IMPL((expected) == (actual));                                               \
             CPPUNIT_ASSERT_EQUAL_MESSAGE(msg##__LINE__, (expected), (actual));                     \
         }                                                                                          \
@@ -138,7 +139,7 @@ std::string inline lokFormatAssertEq(const std::string& expected, const char*,
         auto&& act##__LINE__ = ACT;                                                                \
         if (!(exp##__LINE__ == act##__LINE__))                                                     \
         {                                                                                          \
-            LOK_ASSERT_EQUAL_MESSAGE_UNSAFE(MSG, exp##__LINE__, #ACT, act##__LINE__);              \
+            LOK_ASSERT_EQUAL_MESSAGE_UNSAFE(MSG, #EXP, exp##__LINE__, #ACT, act##__LINE__);        \
         }                                                                                          \
         else                                                                                       \
         {                                                                                          \

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -521,7 +521,8 @@ void DocumentBroker::pollThread()
             LOG_WRN("DocumentBroker stopping although " << reason << ". State: " << state.str());
             if (UnitWSD::isUnitTesting())
             {
-                UnitWSD::get().fail("Data-loss detected while exiting DocBroker [" + _docKey + ']');
+                UnitWSD::get().onDataLoss("Data-loss detected while exiting DocBroker [" +
+                                            _docKey + ']');
             }
         }
     }

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -284,6 +284,12 @@ void DocumentBroker::pollThread()
             break;
         }
 
+        if (UnitWSD::isUnitTesting() && UnitWSD::get().isFinished())
+        {
+            stop("UnitTestFinished");
+            break;
+        }
+
 #if !MOBILEAPP
         const auto now = std::chrono::steady_clock::now();
 

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -1410,6 +1410,14 @@ private:
 
     /// Embedded media map [id, json].
     std::map<std::string, std::string> _embeddedMedia;
+
+    // Last member.
+#ifdef ENABLE_DEBUG
+    /// The UnitWSD instance. We capture it here since
+    /// this is our instance, but the test framework
+    /// has a single global instance via UnitWSD::get().
+    UnitWSD& _unitWsd;
+#endif
 };
 
 #if !MOBILEAPP


### PR DESCRIPTION
- wsd: test: return the correct type from hooks multi
- wsd: test: simplify WSD_CMD_BY_CONNECTION_INDEX
- wsd: test: log test start and finish visibly
- wsd: test: non-numeric filenames in WopiTestServer
- wsd: test: stop DocBroker when unit-test finishes
- wsd: test: fail -> onDataLoss
- wsd: test: capture the UnitWSD instance per DocBroker
- wsd: test: filter tests using COOL_TEST_OPTIONS
- wsd: test: log all test names before running
- wsd: test: capture the reason in exitTest
- wsd: test: improved assert logging on failure
- wsd: test: invoke configure for each test
- wsd: test: capture the UnitBase instance in WebSocketHandler
- wsd: test: filter subsequent tests
- wsd: test: do not invoke WSD test when finished
