### PR TITLE
Tag polls correctly as running synchronously in the client thread.

### DIFF
--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -1014,6 +1014,7 @@ public:
                                                        const std::string& saveToFilePath)
     {
         TerminatingPoll poller("HttpSynReqPoll");
+        poller.runOnClientThread();
         return syncDownload(req, saveToFilePath, poller);
     }
 
@@ -1034,6 +1035,7 @@ public:
     const std::shared_ptr<const Response> syncRequest(const Request& req)
     {
         TerminatingPoll poller("HttpSynReqPoll");
+        poller.runOnClientThread();
         return syncRequest(req, poller);
     }
 

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -806,6 +806,7 @@ public:
 
         if (!_threadStarted)
         {
+            // TODO: should avoid wakeup resource creation too.
             _runOnClientThread = true;
             return true;
         }


### PR DESCRIPTION
This avoids wakeup warning us that the thread is not started to wakeup.

Change-Id: Ifd5c483717024cb1c30521433d0d10acead01e2f
Signed-off-by: Michael Meeks <michael.meeks@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

