### PR TITLE
wsd:fix: memory leak properly

### DIFF
--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -1243,13 +1243,23 @@ public:
                 return;
             }
 
-            Poco::Dynamic::Var allow = lockedHost->get("allow");
+            //use feature_lock.locked_hosts[@allow] entry from coolwsd.xml if feature_lock.locked_hosts.allow key doesnot exist in json
+            Poco::Dynamic::Var allow = false;
+            if (!lockedHost->has("allow"))
+            {
+                allow = _conf.getBool("feature_lock.locked_hosts[@allow]");
+            }
+            else
+            {
+                allow = lockedHost->get("allow");
+            }
+            newAppConfig.insert(std::make_pair("feature_lock.locked_hosts[@allow]", booleanToString(allow)));
+
             if (booleanToString(allow) == "false")
             {
                 LOG_INF("locked_hosts feature is disabled, set feature_lock->locked_hosts->allow to true to enable");
                 return;
             }
-            newAppConfig.insert(std::make_pair("feature_lock.locked_hosts[@allow]", booleanToString(allow)));
 
             std::size_t i;
             for (i = 0; i < lockedHostPatterns->size(); i++)


### PR DESCRIPTION
introduced in e0752419575f09fef3d770f8cccf78c92a2d8612 commit. clearing new remote config  after addWriteable resulted into removing data top of top layer from Poco::LayeredConfiguration. This patch makes sure to remove old layer of remote config before applying the new layer

Signed-off-by: Rash419 <rashesh.padia@collabora.com>
Change-Id: If11bd6e4b3a0a9f4ee32ae9bb43b076479e9bd84


* Resolves: # <!-- related github issue -->
* Target version: master 




