### PR TITLE
_userCanWrite variable is set to false when the host is read-only.

### DIFF
--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -896,6 +896,8 @@ WopiStorage::WOPIFileInfo::WOPIFileInfo(const FileInfo &fileInfo,
         if (isReadOnly)
         {
             isUserLocked = true;
+            _userCanWrite = false;
+            LOG_DBG("Feature lock is enabled and " << host << " is in the list of read-only members. Therefore, document is set to read-only.");
         }
         CommandControl::LockManager::setHostReadOnly(isReadOnly);
     }


### PR DESCRIPTION
Signed-off-by: Gökay Şatır <gokaysatir@collabora.com>
Change-Id: I485c5254a534365cd9defb726ed0eb705977361e


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

