### PR TITLE
Fix jsdialog spinfield jumping on hover

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -430,6 +430,11 @@ input[type='checkbox']:checked.autofilter, .jsdialog input[type='checkbox']:chec
 }
 /* spinfield */
 
+.spinfieldcontainer input {
+	border: 1px solid var(--color-border-dark);
+	border-radius: var(--border-radius);
+}
+
 .spinfieldcontainer input:hover {
 	border: 1px solid var(--color-border-darker);
 	color: var(--color-text-darker);

--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -24,8 +24,6 @@
 
 .sidebar .spinfieldcontainer input {
 	width: 121px;
-	border: 1px solid var(--color-border-dark);
-	border-radius: var(--border-radius);
 	height: 28px;
 	padding-inline-start: 4px;
 	position: relative;


### PR DESCRIPTION
Visible when using the following core change:
https://gerrit.libreoffice.org/c/core/+/142974

Note: no need to have generic CSS rules for spinfields
only for the sidebar

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Id2c9df00d1067537adb9ec5e3db0eab8bd1b2290
