### PR TITLE
Fix PDF detection when deciding if edit button should be visible

### DIFF
--- a/browser/src/control/Permission.js
+++ b/browser/src/control/Permission.js
@@ -21,7 +21,8 @@ L.Map.include({
 		//
 		// For mobile we need to display the edit button for all the cases except for PDF
 		// we offer save-as to another place where the user can edit the document
-		if (!app.file.fileBasedView && (this._shouldStartReadOnly() || window.mode.isMobile() || window.mode.isTablet())) {
+		var isPDF = app.file.fileBasedView && app.file.editComment;
+		if (!isPDF && (this._shouldStartReadOnly() || window.mode.isMobile() || window.mode.isTablet())) {
 			button.show();
 		} else {
 			button.hide();


### PR DESCRIPTION
Before this commit both mobile and is_lock_readonly (upsell)
were being affected. Namely, the edit buttons was not being
shown for presentations and drawings

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I903ea43ca5ea1c94eec6b8f63b8b5626b8ee2203
