### PR TITLE
Misc Non-Functional Improvements

### DIFF
--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -1081,7 +1081,7 @@ public:
             LOG_ASSERT_MSG(_socket.lock(), "Connect must set the _socket member.");
             LOG_ASSERT_MSG(_socket.lock()->getFD() == socket->getFD(),
                            "Socket FD's mismatch after connect().");
-            LOG_TRC('#' << socket->getFD() << ": Connected");
+            LOG_TRC('#' << socket->getFD() << ": inserting in poller after connecting");
             poll.insertNewSocket(socket);
         }
         else
@@ -1206,7 +1206,7 @@ private:
     {
         if (socket)
         {
-            LOG_TRC('#' << socket->getFD() << " Connected.");
+            LOG_TRC('#' << socket->getFD() << ": Connected");
             _connected = true;
         }
         else

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -1132,11 +1132,13 @@ public:
                 if (len < 0 && last_errno != EAGAIN && last_errno != EWOULDBLOCK)
                     LOG_SYS_ERRNO(last_errno,
                                   "Read failed, have " << _inBuffer.size() << " buffered bytes");
-                else if (len <= 0)
+                else if (len < 0)
                     LOG_TRC("Read failed ("
                             << len << "), have " << _inBuffer.size() << " buffered bytes ("
                             << Util::symbolicErrno(last_errno) << ": " << std::strerror(last_errno)
                             << ')');
+                else if (len == 0)
+                    LOG_TRC("Read closed (0), have " << _inBuffer.size() << " buffered bytes");
                 else // Success.
                     LOG_TRC("Read " << len << " bytes in addition to " << _inBuffer.size()
                                     << " buffered bytes"

--- a/test/HttpTestServer.hpp
+++ b/test/HttpTestServer.hpp
@@ -30,7 +30,7 @@ private:
     void onConnect(const std::shared_ptr<StreamSocket>& socket) override
     {
         _socket = socket;
-        LOG_TRC('#' << socket->getFD() << " Connected to ServerRequestHandler.");
+        LOG_TRC('#' << socket->getFD() << ": Connected to ServerRequestHandler");
     }
 
     /// Called after successful socket reads.

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -832,12 +832,13 @@ bool ClientSession::_handleInput(const char *buffer, int length)
         docBroker->sendRequestedTiles(client_from_this());
         return true;
     }
-    else if (tokens.equals(0, "removesession")) {
+    else if (tokens.equals(0, "removesession"))
+    {
         if (tokens.size() > 1 && (_isDocumentOwner || !isReadOnly()))
         {
             std::string sessionId = Util::encodeId(std::stoi(tokens[1]), 4);
             docBroker->broadcastMessage(firstLine);
-            docBroker->removeSession(sessionId);
+            docBroker->removeSession(client_from_this());
         }
         else
             LOG_WRN("Readonly session '" << getId() << "' trying to kill another view");
@@ -1545,7 +1546,7 @@ bool ClientSession::handleKitToClientMessage(const std::shared_ptr<Message>& pay
                         // Conversion failed, cleanup fake session.
                         LOG_TRC("Removing save-as ClientSession after conversion error.");
                         // Remove us.
-                        docBroker->removeSession(getId());
+                        docBroker->removeSession(client_from_this());
                         // Now terminate.
                         docBroker->stop("Aborting saveas handler.");
                     }
@@ -1691,7 +1692,7 @@ bool ClientSession::handleKitToClientMessage(const std::shared_ptr<Message>& pay
             LOG_TRC("Removing save-as ClientSession after conversion.");
 
             // Remove us.
-            docBroker->removeSession(getId());
+            docBroker->removeSession(client_from_this());
 
             // Now terminate.
             docBroker->stop("Finished saveas handler.");
@@ -2129,7 +2130,7 @@ void ClientSession::onDisconnect()
         // Connection terminated. Destroy session.
         LOG_DBG("on docKey [" << docKey << "] terminated. Cleaning up");
 
-        docBroker->removeSession(getId());
+        docBroker->removeSession(session);
     }
     catch (const UnauthorizedRequestException& exc)
     {

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -687,7 +687,7 @@ bool ClientSession::_handleInput(const char *buffer, int length)
         // The savetostorage command is really only used to resolve save conflicts
         // and it seems to always have force=1. However, we should still honor the
         // contract and do as told, not as we expect the API to be used. Use force if provided.
-        docBroker->uploadToStorage(getId(), force);
+        docBroker->uploadToStorage(client_from_this(), force);
     }
     else if (tokens.equals(0, "clientvisiblearea"))
     {

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1878,7 +1878,7 @@ bool ClientSession::handleKitToClientMessage(const std::shared_ptr<Message>& pay
             {
                 LOG_DBG("Uploading template [" << _wopiFileInfo->getTemplateSource()
                                                << "] to storage after loading.");
-                docBroker->uploadAfterLoadingTemplate(getId());
+                docBroker->uploadAfterLoadingTemplate(client_from_this());
             }
 
             for(auto &token : tokens)

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1865,9 +1865,7 @@ bool ClientSession::handleKitToClientMessage(const std::shared_ptr<Message>& pay
 
             if (UnitWSD::isUnitTesting())
             {
-                UnitWSD::get().onDocBrokerViewLoaded(
-                    docBroker->getDocKey(),
-                    std::dynamic_pointer_cast<ClientSession>(shared_from_this()));
+                UnitWSD::get().onDocBrokerViewLoaded(docBroker->getDocKey(), client_from_this());
             }
 
 #if !MOBILEAPP

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1463,8 +1463,10 @@ void DocumentBroker::uploadAsToStorage(const std::string& sessionId,
     uploadToStorageInternal(it->second, uploadAsPath, uploadAsFilename, isRename, /*force=*/false);
 }
 
-void DocumentBroker::uploadAfterLoadingTemplate(const std::string& sessionId)
+void DocumentBroker::uploadAfterLoadingTemplate(const std::shared_ptr<ClientSession>& session)
 {
+    LOG_ASSERT_MSG(session, "Must have a valid ClientSession");
+
 #if !MOBILEAPP
     // Create the 'upload' file as it gets created only when
     // handling .uno:Save, which isn't issued for templates
@@ -1483,17 +1485,7 @@ void DocumentBroker::uploadAfterLoadingTemplate(const std::string& sessionId)
     }
 #endif //!MOBILEAPP
 
-    const auto it = _sessions.find(sessionId);
-    if (it == _sessions.end())
-    {
-        LOG_ERR("Session with sessionId ["
-                << sessionId << "] not found to upload after loading docKey [" << _docKey
-                << "] from template. The document will not be uploaded to storage at this time.");
-        broadcastSaveResult(false, "Session not found");
-        return;
-    }
-
-    uploadToStorage(it->second, /*force=*/false);
+    uploadToStorage(session, /*force=*/false);
 }
 
 void DocumentBroker::uploadToStorageInternal(const std::shared_ptr<ClientSession>& session,

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -2328,20 +2328,14 @@ std::size_t DocumentBroker::addSessionInternal(const std::shared_ptr<ClientSessi
     return count;
 }
 
-std::size_t DocumentBroker::removeSession(const std::string& id)
+std::size_t DocumentBroker::removeSession(const std::shared_ptr<ClientSession>& session)
 {
     assertCorrectThread();
 
+    LOG_ASSERT_MSG(session, "Got null ClientSession");
+    const std::string id = session->getId();
     try
     {
-        const auto it = _sessions.find(id);
-        if (it == _sessions.end())
-        {
-            LOG_ERR("Invalid or unknown session [" << id << "] to remove.");
-            return _sessions.size();
-        }
-        std::shared_ptr<ClientSession> session = it->second;
-
         const std::size_t activeSessionCount = countActiveSessions();
 
         const bool lastEditableSession = session->isWritable() && !haveAnotherEditableSession(id);
@@ -3363,7 +3357,7 @@ void DocumentBroker::shutdownClients(const std::string& closeReason)
                 session->shutdownGoingAway(closeReason);
 
                 // Remove session, save, and mark to destroy.
-                removeSession(session->getId());
+                removeSession(session);
             }
         }
         catch (const std::exception& exc)
@@ -3700,7 +3694,7 @@ bool RenderSearchResultBroker::handleInput(const std::shared_ptr<Message>& messa
                 httpResponse.set("Connection", "close");
                 _socket->sendAndShutdown(httpResponse);
 
-                removeSession(_clientSession->getId());
+                removeSession(_clientSession);
                 stop("Finished RenderSearchResult handler.");
             }
         }

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -298,7 +298,7 @@ public:
 
     /// Upload the document to Storage if it needs persisting.
     /// Results are logged and broadcast to users.
-    void uploadToStorage(const std::string& sesionId, bool force);
+    void uploadToStorage(const std::shared_ptr<ClientSession>& session, bool force);
 
     /// UploadAs the document to Storage, with a new name.
     /// @param uploadAsPath Absolute path to the jailed file.
@@ -606,9 +606,9 @@ private:
     bool isStorageOutdated() const;
 
     /// Upload the doc to the storage.
-    void uploadToStorageInternal(const std::string& sesionId, const std::string& saveAsPath,
-                                 const std::string& saveAsFilename, const bool isRename,
-                                 const bool force);
+    void uploadToStorageInternal(const std::shared_ptr<ClientSession>& session,
+                                 const std::string& saveAsPath, const std::string& saveAsFilename,
+                                 const bool isRename, const bool force);
 
     /// Handles the completion of uploading to storage, both success and failure cases.
     void handleUploadToStorageResponse(const StorageBase::UploadResult& uploadResult);

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -308,7 +308,7 @@ public:
     /// Uploads the document right after loading from a template.
     /// Template-loading requires special handling because the
     /// document changes once loaded into a non-template format.
-    void uploadAfterLoadingTemplate(const std::string& sessionId);
+    void uploadAfterLoadingTemplate(const std::shared_ptr<ClientSession>& session);
 
     bool isModified() const { return _isModified; }
     void setModified(const bool value);

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -497,8 +497,11 @@ public:
     void removeEmbeddedMedia(const std::string& json);
 
 private:
-    /// get the session id of a session that can write the document for save / locking.
+    /// Get the session that can write the document for save / locking / uploading.
     /// Note that if there is no loaded and writable session, the first will be returned.
+    std::shared_ptr<ClientSession> getWriteableSession() const;
+
+    /// Return the SessionId of the first writable session.
     std::string getWriteableSessionId() const;
 
     void refreshLock();

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -347,7 +347,7 @@ public:
     std::size_t addSession(const std::shared_ptr<ClientSession>& session);
 
     /// Removes a session by ID. Returns the new number of sessions.
-    std::size_t removeSession(const std::string& id);
+    std::size_t removeSession(const std::shared_ptr<ClientSession>& session);
 
     /// Add a callback to be invoked in our polling thread.
     void addCallback(const SocketPoll::CallbackFn& fn);


### PR DESCRIPTION
Non-functional improvements and cleanups. Some performance wins, eventually, when we remove unnecessary sessionId look-ups.

- wsd: breakup getWritableSessionId and getWritableSession
- wsd: log closed-socket state on read explicitly
- wsd: http: improved logs
- wsd: use client_from_this
- wsd: pass ClientSession to removeSession
- wsd: pass ClientSession to uploadToStorage
- wsd: pass ClientSession to uploadAfterLoadingTemplate