### PR TITLE
Test Improvements

### DIFF
--- a/common/Unit.cpp
+++ b/common/Unit.cpp
@@ -506,6 +506,9 @@ void UnitBase::exitTest(TestResult result, const std::string& reason)
             if (GlobalWSD)
                 GlobalWSD->configure(Poco::Util::Application::instance().config());
             GlobalArray[GlobalIndex]->initialize();
+
+            // Wake-up so the previous test stops.
+            SocketPoll::wakeupWorld();
             return;
         }
     }

--- a/common/Unit.cpp
+++ b/common/Unit.cpp
@@ -484,6 +484,7 @@ void UnitBase::exitTest(TestResult result, const std::string& reason)
             GlobalResult = result;
     }
 
+    endTest(reason);
     _setRetValue = true;
 
     // Check if we have more tests, but keep the current index if it's the last.

--- a/common/Unit.cpp
+++ b/common/Unit.cpp
@@ -464,19 +464,19 @@ void UnitBase::exitTest(TestResult result, const std::string& reason)
     {
         if ((result == TestResult::Ok && _retValue != EX_OK) ||
             (result != TestResult::Ok && _retValue == EX_OK))
-            LOG_TST(getTestname() << ": exitTest " << testResultAsString(result)
+            LOG_TST(getTestname() << ": exitTest " << name(result)
                                   << " but is already finished with a different result.");
         return;
     }
 
     if (result == TestResult::Ok)
     {
-        LOG_TST(getTestname() << ": SUCCESS: exitTest: " << testResultAsString(result)
+        LOG_TST(getTestname() << ": SUCCESS: exitTest: " << name(result)
                               << (reason.empty() ? "" : ": " + reason));
     }
     else
     {
-        LOG_TST("ERROR " << getTestname() << ": FAILURE: exitTest: " << testResultAsString(result)
+        LOG_TST("ERROR " << getTestname() << ": FAILURE: exitTest: " << name(result)
                          << (reason.empty() ? "" : ": " + reason));
 
         _retValue = EX_SOFTWARE;

--- a/common/Unit.cpp
+++ b/common/Unit.cpp
@@ -551,18 +551,4 @@ void UnitBase::returnValue(int &retValue)
     LOG_TST("==================== Finished [" << getTestname() << "] ====================");
 }
 
-void UnitKit::returnValue(int &retValue)
-{
-    UnitBase::returnValue(retValue);
-
-    GlobalKit = nullptr;
-}
-
-void UnitWSD::returnValue(int &retValue)
-{
-    UnitBase::returnValue(retValue);
-
-    GlobalWSD = nullptr;
-}
-
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/common/Unit.cpp
+++ b/common/Unit.cpp
@@ -520,7 +520,7 @@ void UnitBase::exitTest(TestResult result, const std::string& reason)
                                  << (GlobalResult == TestResult::Ok ? "SUCCESS" : "FAILED"));
 
 #if !MOBILEAPP
-    LOG_INF("Setting ShutdownRequestFlag as there are no more tests");
+    LOG_TST("Setting TerminationFlag as there are no more tests");
     SigUtil::setTerminationFlag(); // And wakupWorld.
 #else
     SocketPoll::wakeupWorld();

--- a/common/Unit.cpp
+++ b/common/Unit.cpp
@@ -13,6 +13,7 @@
 #include <cassert>
 #include <dlfcn.h>
 #include <fstream>
+#include <mutex>
 #include <sstream>
 #include <sysexits.h>
 #include <thread>
@@ -460,6 +461,10 @@ UnitKit& UnitKit::get()
 
 void UnitBase::exitTest(TestResult result, const std::string& reason)
 {
+    // We could be called from either a SocketPoll (websrv_poll)
+    // or from invokeTest (coolwsd main).
+    std::lock_guard<std::mutex> guard(_lock);
+
     if (isFinished())
     {
         if (result != _result)

--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -93,16 +93,13 @@ protected:
         exitTest(TestResult::Ok, reason);
     }
 
-    virtual void endTest(const std::string& reason)
-    {
-        LOG_TST("Ending test by stopping SocketPoll [" << _socketPoll->name() << "]: " << reason);
-        _socketPoll->joinThread();
-    }
+    /// Called when a test has eneded, to clean up.
+    virtual void endTest(const std::string& reason);
 
     /// Construct a UnitBase instance with a default name.
     explicit UnitBase(const std::string& name, UnitType type)
         : _setRetValue(false)
-        , _retValue(0)
+        , _result(TestResult::Ok)
         , _timeoutMilliSeconds(std::chrono::seconds(30))
         , _type(type)
         , _socketPoll(std::make_shared<SocketPoll>(name))
@@ -204,7 +201,7 @@ public:
 
     /// True iff exitTest was called with anything but TestResult::Ok.
     /// Meaningful only when isFinished() is true.
-    bool failed() const { return _retValue; }
+    bool failed() const { return _result != TestResult::Ok; }
 
     std::chrono::milliseconds getTimeoutMilliSeconds() const
     {
@@ -267,7 +264,7 @@ private:
     static TestResult GlobalResult; //< The result of all tests. Latches at first failure.
 
     bool _setRetValue;
-    int _retValue;
+    TestResult _result;
     std::chrono::milliseconds _timeoutMilliSeconds;
     UnitType _type;
 

--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -76,28 +76,7 @@ protected:
     /// After this time we invoke 'timeout' default 30 seconds
     void setTimeout(std::chrono::milliseconds timeoutMilliSeconds);
 
-    enum class TestResult
-    {
-        Failed,
-        Ok,
-        TimedOut
-    };
-
-    static const std::string testResultAsString(TestResult res)
-    {
-        switch (res)
-        {
-            case TestResult::Failed:
-                return "Failed";
-            case TestResult::Ok:
-                return "Ok";
-            case TestResult::TimedOut:
-                return "TimedOut";
-        }
-
-        assert(!"Unknown TestResult entry.");
-        return std::to_string(static_cast<int>(res));
-    }
+    STATE_ENUM(TestResult, Failed, Ok, TimedOut);
 
     /// Encourages the process to exit with this value (unless hooked)
     void exitTest(TestResult result, const std::string& reason = std::string());

--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -127,6 +127,7 @@ public:
     /// Returns true if we failed, false otherwise.
     virtual bool onDataLoss(const std::string& reason)
     {
+        LOG_TST("onDataLoss: " << reason);
         failTest(reason);
         return failed();
     }

--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -268,6 +268,7 @@ private:
     std::chrono::milliseconds _timeoutMilliSeconds;
     UnitType _type;
 
+    std::mutex _lock; //< Used to protect cleanup functions.
     std::shared_ptr<SocketPoll> _socketPoll; //< Poll thread for async http comm.
 
 protected:

--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -314,8 +314,6 @@ public:
 
     static UnitWSD& get();
 
-    virtual void returnValue(int& /* retValue */);
-
     enum class TestRequest
     {
         Client,
@@ -461,8 +459,6 @@ public:
     explicit UnitKit(const std::string& testname);
     virtual ~UnitKit();
     static UnitKit& get();
-
-    virtual void returnValue(int& /* retValue */);
 
     // ---------------- ForKit hooks ----------------
 

--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -114,6 +114,12 @@ protected:
         exitTest(TestResult::Ok, reason);
     }
 
+    virtual void endTest(const std::string& reason)
+    {
+        LOG_TST("Ending test by stopping SocketPoll [" << _socketPoll->name() << "]: " << reason);
+        _socketPoll->joinThread();
+    }
+
     /// Construct a UnitBase instance with a default name.
     explicit UnitBase(const std::string& name, UnitType type)
         : _setRetValue(false)

--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -44,6 +44,14 @@ private:
     unsigned char _lastFlags; //< The flags in the last frame.
     const bool _isClient;
 
+    // Last member.
+#ifdef ENABLE_DEBUG
+    /// The UnitBase instance. We capture it here since
+    /// this is our instance, but the test framework
+    /// has a single global instance via UnitWSD::get().
+    UnitBase& _unit;
+#endif
+
 protected:
     struct WSFrameMask
     {
@@ -75,6 +83,9 @@ public:
         _shuttingDown(false)
         , _lastFlags(0)
         , _isClient(isClient)
+#ifdef ENABLE_DEBUG
+        , _unit(UnitBase::get())
+#endif
     {
     }
 
@@ -644,8 +655,7 @@ public:
         if (!Util::isFuzzing())
         {
             int unitReturn = -1;
-            static auto& unit = UnitBase::get();
-            if (unit.filterSendWebSocketMessage(data, len, code, flush, unitReturn))
+            if (_unit.filterSendWebSocketMessage(data, len, code, flush, unitReturn))
                 return unitReturn;
         }
 

--- a/test/UnitWSDClient.hpp
+++ b/test/UnitWSDClient.hpp
@@ -111,6 +111,13 @@ protected:
         assert((*_ws).get());
     }
 
+    void endTest(const std::string& reason) override
+    {
+        LOG_TST("Ending test by disconnecting " << _wsList.size() << " connection(s): " << reason);
+        _wsList.clear();
+        UnitWSD::endTest(reason);
+    }
+
     /// Send a command to WSD.
     void sendCommand(int index, const std::string& msg)
     {


### PR DESCRIPTION
- wsd: test: wakeup world when starting a new test
- wsd: test: correctly capture UnitBase in WebSocketHandler
- wsd: test: add endTest to clean-up tests
- wsd: test: remove returnValue overrides
- wsd: test: convert TestResult to STATE_ENUM
- wsd: test: capture the original test result
- wsd: test: fix rare deadlock on stopping
- wsd: test: logging
