### PR TITLE
JSSidebar: remove non-effective rules for expanders

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -80,11 +80,7 @@ img.sidebar.ui-image {
 .sidebar.ui-expander-content {
 	padding-inline: 10px;
 	width: 300px;
-	row-gap: 4px;
-	column-gap: 4px;
-	align-items: center;
 	line-height: var(--default-height);
-	justify-content: space-between;
 }
 
 #fontheight,


### PR DESCRIPTION
These have no effect on the ui-expander-content since they are set to display: block somewhere else (jsdialogs.css) plus, (and even testing with flex) this does not seem to improve or fix anything

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I0260f44413ff46f79b9ea6a15e154ee62fb1e53f
