### PR TITLE
Avoid Repeated ClientSession Lookup

### DIFF
--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1816,7 +1816,7 @@ bool ClientSession::handleKitToClientMessage(const std::shared_ptr<Message>& pay
     } else if (tokens.equals(0, "disconnected:")) {
 
         LOG_INF("End of disconnection handshake for " << getId());
-        docBroker->finalRemoveSession(getId());
+        docBroker->finalRemoveSession(client_from_this());
         return true;
     }
     else if (tokens.equals(0, "mediashape:"))

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1511,7 +1511,7 @@ bool ClientSession::handleKitToClientMessage(const std::shared_ptr<Message>& pay
                     }
 
                     // Save to Storage and log result.
-                    docBroker->handleSaveResponse(getId(), success, result);
+                    docBroker->handleSaveResponse(client_from_this(), success, result);
 
                     if (!isCloseFrame())
                         forwardToClient(payload);

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -251,8 +251,8 @@ public:
     /// Flag for termination. Note that this doesn't save any unsaved changes in the document
     void stop(const std::string& reason);
 
-    /// Hard removes a session by ID, only for ClientSession.
-    void finalRemoveSession(const std::string& id);
+    /// Hard removes a session, only for ClientSession.
+    void finalRemoveSession(const std::shared_ptr<ClientSession>& session);
 
     /// Create new client session
     std::shared_ptr<ClientSession> createNewClientSession(

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -688,7 +688,7 @@ private:
     std::size_t addSessionInternal(const std::shared_ptr<ClientSession>& session);
 
     /// Starts the Kit <-> DocumentBroker shutdown handshake
-    void disconnectSessionInternal(const std::string& id);
+    void disconnectSessionInternal(const std::shared_ptr<ClientSession>& session);
 
     /// Forward a message from child session to its respective client session.
     bool forwardToClient(const std::shared_ptr<Message>& payload);

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -290,11 +290,12 @@ public:
 
     /// Handle the save response from Core and upload to storage as necessary.
     /// Also notifies clients of the result.
-    void handleSaveResponse(const std::string& sessionId, bool success, const std::string& result);
+    void handleSaveResponse(const std::shared_ptr<ClientSession>& session, bool success,
+                            const std::string& result);
 
     /// Check if uploading is needed, and start uploading.
     /// The current state of uploading must be introspected separately.
-    void checkAndUploadToStorage(const std::string& sessionId);
+    void checkAndUploadToStorage(const std::shared_ptr<ClientSession>& session);
 
     /// Upload the document to Storage if it needs persisting.
     /// Results are logged and broadcast to users.


### PR DESCRIPTION
Reduce the number of lookups in `_sessions` when we already have the ClientSession instance.

- wsd: pass ClientSession to finalRemoveSession
- wsd: pass ClientSession to disconnectSessionInternal
- wsd: pass ClientSession to checkAndUploadToStorage
