### PR TITLE
cypress: fix: notebookbar test failing

### DIFF
--- a/cypress_test/integration_tests/desktop/impress/table_operation_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/table_operation_spec.js
@@ -304,14 +304,10 @@ describe('Table operations', function() {
 
 		selectOptionNotebookbar('.unospan-Table.unoSplitCell');
 
-		cy.get('.lokdialog_canvas').should('exist');
+		cy.get('#SplitCellsDialog').should('be.visible');
 
-		helper.waitUntilIdle('.lokdialog_canvas');
-
-		cy.get('.lokdialog_canvas').click();
-
-		//to close the lokdialog
-		helper.typeIntoDocument('{shift}{enter}');
+		cy.get('#SplitCellsDialog .ui-pushbutton.jsdialog.button-primary')
+			.click();
 
 		cy.get('.leaflet-marker-icon.table-row-resize-marker')
 			.should('have.length', 4);

--- a/cypress_test/plugins/selectorList.js
+++ b/cypress_test/plugins/selectorList.js
@@ -18,7 +18,7 @@ module.exports.list = {
 	insertAnnotation: ['#Insert .unoInsertAnnotation', '#tb_editbar_item_insertannotation'],
 	insertTable: ['#InsertTable', '#tb_editbar_item_inserttable'],
 	insertGraphic: ['#InsertGraphic', '#tb_editbar_item_insertgraphic'],
-	clearFormat: ['#clearFormatting', '#tb_editbar_item_reset'],
+	clearFormat: ['#Home .unoResetAttributes', '#tb_editbar_item_reset'],
 	hyperLink: ['#HyperlinkDialog', '#tb_editbar_item_link'],
 	insertShape: ['#BasicShapes', '#tb_editbar_item_insertshapes'],
 	save: ['#Save', '#tb_editbar_item_save'],


### PR DESCRIPTION
impress/table_operation_spec.js was failing due to split dialog converting to jsdialog writer/top_toolbar_spec.js failing due to change in name of clear formatting button

Signed-off-by: Rash419 <rashesh.padia@collabora.com>
Change-Id: Ia70b80540ebfee66b1499b931c1fc32ab6f9df95

* Target version: master 

