### PR TITLE
add hasZoteroSupport to /hosting/capabilities

### DIFF
--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -149,6 +149,7 @@ using Poco::Net::PartHandler;
 #include <common/SigUtil.hpp>
 
 #include <ServerSocket.hpp>
+#include <Zotero.hpp>
 
 #if MOBILEAPP
 #ifdef IOS
@@ -4914,6 +4915,9 @@ private:
 
         // Set that this is a proxy.php-enabled instance
         capabilities->set("hasProxyPrefix", COOLWSD::IsProxyPrefixEnabled);
+
+        // Set if this instance supports Zotero
+        capabilities->set("hasZoteroSupport", Zotero::ZoteroConfig::isEnabled());
 
         std::ostringstream ostrJSON;
         capabilities->stringify(ostrJSON);


### PR DESCRIPTION
The idea is that the integration should look for hasZoteroSupport capability, and if it's missing or false, then it should not enable setting of the Zotero API key. Instead, it could write "This instance does not support Zotero, because the feature is missing." or " ... because the feature is disabled in configuration."

Signed-off-by: Andras Timar <andras.timar@collabora.com>
Change-Id: Ibff9cb61ada062f59e8b2b63ddcdb7a9cf899b82


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

