### PR TITLE
icon size use css variables #5420

### DIFF
--- a/browser/css/color-palette.css
+++ b/browser/css/color-palette.css
@@ -45,6 +45,9 @@
 	--default-height: 24px;
 	--header-height: 38px;
 
+	--icon-size: 24px;
+	--icon-size-big: 32px;
+
 	/* Annotations */
 	--annotation-input-size: 240px;
 }

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -785,7 +785,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 /* color selector */
 .unotoolbutton .selected-color {
 	height: 5px;
-	width: 24px;
+	width: var(--icon-size);
 	position: relative;
 	top: -6px;
 	border: 1px solid var(--color-border-dark);
@@ -854,6 +854,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 }
 
 /* toolbox */
+.no-label.has-dropdown,
 .jsdialog.toolbox {
 	display: flex;
 	align-items: center;
@@ -1137,8 +1138,8 @@ input[type='number']:hover::-webkit-outer-spin-button {
 /* toolbuttons */
 
 .jsdialog .ui-content.unobutton {
-	width: 24px;
-	height: 24px;
+	width: var(--icon-size);
+	height: var(--icon-size);
 	margin-inline-end: 5px;
 	vertical-align: middle;
 }
@@ -1208,8 +1209,8 @@ input[type='number']:hover::-webkit-outer-spin-button {
 }
 
 .formulabar.unotoolbutton img, .formulabar.ui-pushbutton {
-	height: 24px !important;
-	width: 24px !important;
+	height: var(--icon-size) !important;
+	width: var(--icon-size) !important;
 	min-width: unset !important;
 }
 

--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -81,8 +81,8 @@
 }
 
 .notebookbar-shortcuts-bar .notebookbar.unotoolbutton {
-	height: 27px;
-	width: 24px;
+	height: var(--icon-size);
+	width: var(--icon-size);
 	display: flex;
 	margin: 0px !important;
 	align-items: center;
@@ -202,9 +202,6 @@
 /* unobuttons */
 
 .hasnotebookbar .ui-content .unobutton {
-	width: 32px;
-	height: 32px;
-	margin-inline-end: 5px;
 	vertical-align: middle;
 }
 
@@ -223,13 +220,13 @@
 }
 
 .unotoolbutton.notebookbar .unobutton {
-	width: 24px !important;
-	height: 24px !important;
+	width: var(--icon-size);
+	height: var(--icon-size);
 	margin-inline-end: 0px !important;
 }
 
 .has-dropdown--color.notebookbar {
-	height: 24px !important;
+	height: var(--icon-size);
 }
 
 .unotoolbutton.notebookbar .unolabel {
@@ -298,7 +295,8 @@
 }
 
 .unotoolbutton.notebookbar.has-label:not(.inline) img {
-	width: 24px !important;
+	width: var(--icon-size-big);
+	height: var(--icon-size-big);
 	margin: auto !important;
 	display: block;
 }
@@ -335,15 +333,6 @@
 #table-HomeTab {
 	margin-left: -16px;/*force alignment: clipboard elements*/
 	margin-top: -5px;
-}
-
-#clearFormatting.notebookbar div img, #FormatPaintbrush.notebookbar div img {
-	width: 24px !important;
-	height: 24px !important;
-}
-
-#clearFormatting.notebookbar, #FormatPaintbrush.notebookbar{
-	height: 24px !important;
 }
 
 #fontsize.notebookbar .select2.select2-container {

--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -380,9 +380,9 @@ td[id^='tb_editbar_item_sidebar']{
 	margin: 0 !important;
 }
 
-.w2ui-tb-image {
-	width: 24px !important;
-	height: 24px !important;
+.w2ui-toolbar table.w2ui-button .w2ui-icon {
+	width: var(--icon-size);
+	height: var(--icon-size);
 }
 
 .w2ui-break {
@@ -1162,8 +1162,8 @@ menu-entry-with-icon.padding-left + menu-entry-icon.width */
 
 #userListHeader .user-info,
 #userListHeader .avatar-img {
-	width: 24px;
-	height: 24px;
+	width: var(--icon-size);
+	height: var(--icon-size);
 	background-color: var(--color-background-lighter);
 	background-position: center;
 	background-size: cover;


### PR DESCRIPTION
add variables to color-scheme.css file
replace hardcoded sizes with var's at
- notebookbar
- toolbar
- sidebar

Signed-off-by: andreas kainz <kainz.a@gmail.com>
Change-Id: I8e6a0e76ea7f32bda3a8bcd781e75b06d800ec88

* Resolves: #5420 and #5395 
* Target version: master 