### PR TITLE
zotero: fix library dialog empty when collection has notes

### DIFF
--- a/browser/src/control/Control.Zotero.js
+++ b/browser/src/control/Control.Zotero.js
@@ -145,7 +145,7 @@ L.Control.Zotero = L.Control.extend({
 	fillItems: function (items) {
 		for (var iterator = 0; iterator < items.length; ++iterator) {
 			var creatorArray = [];
-			for (var creator = 0; creator < items[iterator].data.creators.length; ++creator) {
+			for (var creator = 0; items[iterator].data.creators && creator < items[iterator].data.creators.length; ++creator) {
 				creatorArray.push(items[iterator].data.creators[creator].firstName + ' ' + items[iterator].data.creators[creator].lastName);
 			}
 			var creatorString = creatorArray.join(', ');


### PR DESCRIPTION
Signed-off-by: Pranam Lashkari <lpranam@collabora.com>
Change-Id: Ie96550faaf3dc23e0aff0c289a38f717c6624e6f


* Target version: master 



### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

