### PR TITLE
Don't scroll when cursor still visible on the screen

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -3681,9 +3681,19 @@ L.CanvasTileLayer = L.Layer.extend({
 				That edit changed our cursor position.
 			Now we already set the cursor position to another point.
 			We want to keep the cursor position at the same point relative to screen.
+			Do that only when we are reaching the end of screen so we don't flicker.
 			*/
-			var y = this._cursorCorePixels.min.y - this._cursorPreviousPositionCorePixels.min.y;
-			this._painter._sectionContainer.getSectionWithName(L.CSections.Scroll.name).scrollVerticalWithOffset(y);
+			var that = this;
+			var paneRectsInLatLng = this.getPaneLatLngRectangles();
+			var isCursorVisible = this._visibleCursor.isInAny(paneRectsInLatLng);
+			if (!isCursorVisible) {
+				setTimeout(function () {
+					var y = that._cursorCorePixels.min.y - that._cursorPreviousPositionCorePixels.min.y;
+					if (y) {
+						that._painter._sectionContainer.getSectionWithName(L.CSections.Scroll.name).scrollVerticalWithOffset(y);
+					}
+				}, 0);
+			}
 		}
 
 		this._updateCursorAndOverlay();


### PR DESCRIPTION
When we have 2 users:
A is typing on the page 0
B is at the bottom of the document

We scrolled view B when page overflow happened what caused "flickering". This patch prevents us from scrolling when cursor is still on the screen and visible.