### PR TITLE
Remove the 'Insert Bibliography Entry' feature

### DIFF
--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -164,6 +164,8 @@ L.Control.Menubar = L.Control.extend({
 				{name: _UNO('.uno:HyperlinkDialog'), id: 'inserthyperlink', type: 'action'},
 				{uno: '.uno:InsertBookmark'},
 				{uno: '.uno:InsertReferenceField'},
+				{uno: '.uno:InsertIndexesEntry'},
+				{name: _UNO('.uno:IndexesMenu', 'text'), uno: '.uno:InsertMultiIndex'},
 				{type: 'separator'},
 				{uno: '.uno:InsertSymbol'},
 				{name: _UNO('.uno:FormattingMarkMenu', 'text'), type: 'menu', menu: [
@@ -174,10 +176,6 @@ L.Control.Menubar = L.Control.extend({
 					{uno: '.uno:InsertWJ'},
 					{uno: '.uno:InsertLRM'},
 					{uno: '.uno:InsertRLM'}]},
-				{name: _UNO('.uno:IndexesMenu', 'text'), type: 'menu', menu: [
-					{uno: '.uno:InsertIndexesEntry'},
-					{uno: '.uno:InsertAuthoritiesEntry'},
-					{uno: '.uno:InsertMultiIndex'}]},
 			]},
 			{name: _UNO('.uno:FormatMenu', 'text'), id: 'format', type: 'menu', menu: [
 				{name: _UNO('.uno:FormatTextMenu', 'text'), type: 'menu', menu: [

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -1367,7 +1367,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 		var content = [
 			{
 				'type': 'bigtoolitem',
-				'text': _UNO('.uno:InsertMultiIndex', 'text'),
+				'text': _UNO('.uno:IndexesMenu', 'text'),
 				'command': '.uno:InsertMultiIndex'
 			},
 			{
@@ -1428,11 +1428,6 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				'vertical': 'true'
 			},
 			{
-				'type': 'bigtoolitem',
-				'text': _UNO('.uno:InsertReferenceField', 'text'),
-				'command': '.uno:InsertReferenceField'
-			},
-			{
 				'type': 'container',
 				'children': [
 					{
@@ -1450,8 +1445,8 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 						'children': [
 							{
 								'type': 'toolitem',
-								'text': _UNO('.uno:InsertAuthoritiesEntry', 'text'),
-								'command': '.uno:InsertAuthoritiesEntry'
+								'text': _UNO('.uno:InsertReferenceField', 'text'),
+								'command': '.uno:InsertReferenceField'
 							}
 						]
 					}

--- a/configure.ac
+++ b/configure.ac
@@ -1438,7 +1438,7 @@ if test "$enable_feature_lock" = "yes"; then
 .uno:TTestDialog .uno:FTestDialog .uno:ZTestDialog .uno:ChiSquareTestDialog \
 .uno:FourierAnalysisDialog .uno:Validation .uno:DataFilterSpecialFilter \
 .uno:TrackChanges .uno:AcceptTrackedChanges .uno:InsertReferenceField \
-.uno:Watermark .uno:InsertIndexesEntry .uno:InsertAuthoritiesEntry \
+.uno:Watermark .uno:InsertIndexesEntry \
 .uno:InsertMultiIndex .uno:SlideMasterPage downloadas-epub downloadas-rtf masterslidebutton"
 fi
 AC_DEFINE_UNQUOTED([LOCKED_COMMANDS],["$LOCKED_COMMANDS"],[Default value of feature_lock.locked_commands])


### PR DESCRIPTION
LibreOffice has its own solution to handle bibliography. It is outdated, and reportedly everyone prefers Zotero or similar solutions. Moreover in Online this feature does not work, because the bibliography database is a file in the jail that is not retained, and because tunneled dialogs have serious UX problems.

Signed-off-by: Andras Timar <andras.timar@collabora.com>
Change-Id: Ibf6195c0265c767b3acf94012ee3f82339cf34d3


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

