### PR TITLE
No need to cd back before exiting a shell script that is run as a com…

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -3,7 +3,6 @@
 srcdir=`dirname $0`
 test -n "$srcdir" || srcdir=.
 
-olddir=`pwd`
 cd "$srcdir"
 
 function failed {
@@ -37,5 +36,3 @@ cat << EOF
 Result: All went OK, please run $srcdir/configure (with the appropriate parameters) now.
 
 EOF
-
-cd "$olddir"


### PR DESCRIPTION
…mand

The autogen.sh script is not supposed to be sourced ("source autogen.sh"), but run as a command ("./autogen.sh"). After all, it has the executable bit set. Also, the function called "failed" in it does an "exit" at the end. That would be a rather rude thing to do as soon as something goes wrong if the script is sourced.

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: Ia0e4bbb2b9bed93fb4dba5c0f46a1760ec6e50d7


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

