### PR TITLE
Remove 'Current Index' button from References tab

### DIFF
--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -1371,30 +1371,9 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				'command': '.uno:InsertMultiIndex'
 			},
 			{
-				'type': 'container',
-				'children': [
-					{
-						'type': 'toolbox',
-						'children': [
-							{
-								'type': 'toolitem',
-								'text': _UNO('.uno:InsertIndexesEntry', 'text'),
-								'command': '.uno:InsertIndexesEntry'
-							}
-						]
-					},
-					{
-						'type': 'toolbox',
-						'children': [
-							{
-								'type': 'toolitem',
-								'text': _UNO('.uno:UpdateCurIndex', 'text'),
-								'command': '.uno:UpdateCurIndex'
-							}
-						]
-					}
-				],
-				'vertical': 'true'
+				'type': 'bigtoolitem',
+				'text': _UNO('.uno:InsertIndexesEntry', 'text'),
+				'command': '.uno:InsertIndexesEntry'
 			},
 			{
 				'type': 'bigtoolitem',


### PR DESCRIPTION
The label is misleading, it should read 'Update Index'. On the other hand this is a context sensitive command, it is active only when the cursor is in the Index field. So probably we do not need it on the tab bar. We have the context sensitive local menu entry 'Update Index'.

Signed-off-by: Andras Timar <andras.timar@collabora.com>
Change-Id: I9d77ed5079cb9dbbcd04f780620a7dbcae9804f7

![image](https://user-images.githubusercontent.com/290614/206184990-4687ec36-eac0-4bdc-aa2d-b7463036355a.png)
