### PR TITLE
Fix UpdateCurIndex string

### DIFF
--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -1388,7 +1388,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 						'children': [
 							{
 								'type': 'toolitem',
-								'text': _UNO('.uno:UpdateCurIndex', 'text'),
+								'text': _('Update Index'),
 								'command': '.uno:UpdateCurIndex'
 							}
 						]


### PR DESCRIPTION
Avoid using `Current Index` (uno text) and instead set custom
string that is easier to understand

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I5057b7c974a5bd33f8af5b93f5bf6a85af916f98
