### PR TITLE
Introducing Zotero tab

### DIFF
--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -7,7 +7,7 @@
 L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 
 	getTabs: function() {
-		return [
+		var tabs = [
 			{
 				'text': _('~File'),
 				'id': '-1',
@@ -34,6 +34,17 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				'id': '-6',
 				'name': 'References'
 			},
+		];
+		if (this._map.zotero && this._map.zotero.enable) {
+			tabs.push(
+				{
+					'text': _('Zotero'),
+					'id': 'zotero',
+					'name': 'Zotero',
+				}
+			);
+		}
+		tabs.push(
 			{
 				'text': _('~Review'),
 				'id': '-7',
@@ -71,25 +82,31 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				'id': '-2',
 				'name': 'Help',
 			}
-		];
+		);
+		return tabs;
 	},
 
 	getFullJSON: function(selectedId) {
-		return this.getNotebookbar(
-			[
-				this.getFileTab(),
-				this.getHomeTab(),
-				this.getInsertTab(),
-				this.getLayoutTab(),
-				this.getReferencesTab(),
-				this.getReviewTab(),
-				this.getFormatTab(),
-				this.getFormTab(),
-				this.getTableTab(),
-				this.getDrawTab(),
-				this.getViewTab(),
-				this.getHelpTab()
-			], selectedId);
+		var tabPages = [
+			this.getFileTab(),
+			this.getHomeTab(),
+			this.getInsertTab(),
+			this.getLayoutTab(),
+			this.getReferencesTab()
+		];
+		if (this._map.zotero && this._map.zotero.enable) {
+			tabPages.push(this.getZoteroTab());
+		}
+		tabPages.push(
+			this.getReviewTab(),
+			this.getFormatTab(),
+			this.getFormTab(),
+			this.getTableTab(),
+			this.getDrawTab(),
+			this.getViewTab(),
+			this.getHelpTab()
+		);
+		return this.getNotebookbar(tabPages, selectedId);
 	},
 
 	getFileTab: function() {
@@ -1501,27 +1518,29 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 			}
 		];
 
-		if (this._map.zotero && this._map.zotero.enable) {
-			content.push(
-				{
-					'id': 'zoteroedit',
-					'type': 'bigmenubartoolitem',
-					'text': _('Add/Edit Citation'),
-					'command': 'zoteroEdit'
-				},
-				{
-					'id': 'zoterostyle',
-					'type': 'bigmenubartoolitem',
-					'text': _('Citation Style'),
-					'command': 'zoteroStyle'
-				}
-			);
-		}
-
 		return this.getTabPage('References', content);
 	},
 
-	getReviewTab: function() {
+	getZoteroTab: function() {
+		var content = [
+			{
+				'id': 'zoteroedit',
+				'type': 'bigmenubartoolitem',
+				'text': _('Add/Edit Citation'),
+				'command': 'zoteroEdit'
+			},
+			{
+				'id': 'zoterostyle',
+				'type': 'bigmenubartoolitem',
+				'text': _('Citation Style'),
+				'command': 'zoteroStyle'
+			}
+		 ];
+
+		return this.getTabPage('Zotero', content);
+	 },
+
+	 getReviewTab: function() {
 		var content = [
 			{
 				'type': 'bigtoolitem',


### PR DESCRIPTION
- Prefer to show zotero related actions within a dedicated tab (instead
of adding those within references tab as it was previously). This,
hopefully is more familiar to user using similar interface elsewhere
- Show this new tab conditionally (if zotero is enabled)

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I1690295724d54693aca68ade567e9d1076f26876
