### PR TITLE
Do Not Upload to Read-Only Storage

### DIFF
--- a/common/Session.cpp
+++ b/common/Session.cpp
@@ -281,6 +281,8 @@ void Session::dumpState(std::ostream& os)
        << "\n\t\tisActive: " << _isActive
        << "\n\t\tisCloseFrame: " << _isCloseFrame
        << "\n\t\tisReadOnly: " << _isReadOnly
+       << "\n\t\tisAllowChangeComments: " << _isAllowChangeComments
+       << "\n\t\tisEditable: " << isEditable()
        << "\n\t\tdocURL: " << _docURL
        << "\n\t\tjailedFilePath: " << _jailedFilePath
        << "\n\t\tdocPwd: " << _docPassword

--- a/common/Session.cpp
+++ b/common/Session.cpp
@@ -32,6 +32,7 @@ Session::Session(const std::shared_ptr<ProtocolHandlerInterface> &protocol,
     _isActive(true),
     _lastActivityTime(std::chrono::steady_clock::now()),
     _isCloseFrame(false),
+    _isWritable(readOnly),
     _isReadOnly(readOnly),
     _isAllowChangeComments(false),
     _haveDocPassword(false),
@@ -280,6 +281,7 @@ void Session::dumpState(std::ostream& os)
        << "\n\t\tdisconnected: " << _disconnected
        << "\n\t\tisActive: " << _isActive
        << "\n\t\tisCloseFrame: " << _isCloseFrame
+       << "\n\t\tisWritable: " << _isWritable
        << "\n\t\tisReadOnly: " << _isReadOnly
        << "\n\t\tisAllowChangeComments: " << _isAllowChangeComments
        << "\n\t\tisEditable: " << isEditable()

--- a/common/Session.hpp
+++ b/common/Session.hpp
@@ -83,6 +83,9 @@ public:
     void setAllowChangeComments(bool allow) { _isAllowChangeComments = allow; }
     bool isAllowChangeComments() const { return _isAllowChangeComments; }
 
+    /// Returns true iff the view is either non-readonly or can change comments.
+    bool isEditable() const { return !isReadOnly() || isAllowChangeComments(); }
+
     /// overridden to prepend client ids on messages by the Kit
     virtual bool sendBinaryFrame(const char* buffer, int length);
     virtual bool sendTextFrame(const char* buffer, const int length);

--- a/common/Session.hpp
+++ b/common/Session.hpp
@@ -77,9 +77,26 @@ public:
     const std::string& getName() const { return _name; }
     bool isDisconnected() const { return _disconnected; }
 
+    /// Controls whether writing in the Storage is enabled in this session.
+    /// If set to false, will setReadOnly(true) and setAllowChangeComments(false).
+    void setWritable(bool writable)
+    {
+        _isWritable = writable;
+        if (!writable)
+        {
+            setReadOnly(true);
+            setAllowChangeComments(false);
+        }
+    }
+
+    /// True iff the session can write in the Storage.
+    bool isWritable() const { return _isWritable; }
+
+    /// Controls whether editing is enabled in this session.
     virtual void setReadOnly(bool readonly) { _isReadOnly = readonly; }
     bool isReadOnly() const { return _isReadOnly; }
 
+    /// Controls whether commenting is enabled in this session
     void setAllowChangeComments(bool allow) { _isAllowChangeComments = allow; }
     bool isAllowChangeComments() const { return _isAllowChangeComments; }
 
@@ -283,10 +300,14 @@ private:
     // Whether websocket received close frame.  Closing Handshake
     std::atomic<bool> _isCloseFrame;
 
-    /// Whether the session is opened as readonly
+    /// Whether the session can write in storage.
+    bool _isWritable;
+
+    /// Whether the session can edit the document.
     bool _isReadOnly;
 
-    /// If the session is read-only, are comments allowed
+    /// Whether the session can add/change comments.
+    /// Must have _isWritable=true, regardless of _isReadOnly.
     bool _isAllowChangeComments;
 
     /// The actual URL, also in the child, even if the child never accesses that.

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -462,7 +462,7 @@ bool ClientSession::_handleInput(const char *buffer, int length)
             docBroker->updateLastModifyingActivityTime();
         }
 
-        if (isWritable() && isViewLoaded())
+        if (isEditable() && isViewLoaded())
         {
             assert(!inWaitDisconnected() && "A writable view can't be waiting disconnection.");
             docBroker->updateEditingSessionId(getId());
@@ -2187,9 +2187,6 @@ void ClientSession::dumpState(std::ostream& os)
 
     os << "\t\tisLive: " << isLive()
        << "\n\t\tisViewLoaded: " << isViewLoaded()
-       << "\n\t\tisReadOnly: " << isReadOnly()
-       << "\n\t\tisAllowChangeComments: " << isAllowChangeComments()
-       << "\n\t\tisWritable: " << isWritable()
        << "\n\t\tisDocumentOwner: " << isDocumentOwner()
        << "\n\t\tstate: " << name(_state)
        << "\n\t\tkeyEvents: " << _keyEvents

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -646,9 +646,12 @@ bool ClientSession::_handleInput(const char *buffer, int length)
     }
     else if (tokens.equals(0, "save"))
     {
-        if (isReadOnly() && !isAllowChangeComments())
+        // If we can't write to Storage, there is no point in saving.
+        if (!isWritable())
         {
-            LOG_WRN("The document is read-only, cannot save.");
+            LOG_WRN("Session [" << getId() << "] on document [" << docBroker->getDocKey()
+                                << "] has no write permissions in Storage and cannot save.");
+            sendTextFrameAndLogError("error: cmd=save kind=savefailed");
         }
         else
         {

--- a/wsd/ClientSession.hpp
+++ b/wsd/ClientSession.hpp
@@ -65,9 +65,6 @@ public:
     /// from either the client or the Kit.
     bool isLive() const { return _state == SessionState::LIVE && !isCloseFrame(); }
 
-    /// Returns true iff the view is either not readonly or can change comments.
-    bool isWritable() const { return !isReadOnly() || isAllowChangeComments(); }
-
     /// Handle kit-to-client message.
     bool handleKitToClientMessage(const std::shared_ptr<Message>& payload);
 

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -741,26 +741,26 @@ bool DocumentBroker::download(const std::shared_ptr<ClientSession>& session, con
         if (!wopifileinfo->getUserCanWrite()) // Readonly.
         {
             LOG_DBG("Setting session [" << sessionId << "] to readonly for UserCanWrite=false");
-            session->setReadOnly(true);
-            session->setAllowChangeComments(false);
+            session->setWritable(false);
         }
         else if (CommandControl::LockManager::isLockedReadOnlyUser()) // Readonly.
         {
             LOG_DBG("Setting session [" << sessionId << "] to readonly for LockedReadOnlyUser");
-            session->setReadOnly(true);
-            session->setAllowChangeComments(false);
+            session->setWritable(false);
         }
         else if (_isViewFileExtension) // PDF and the like: only commenting, no editing.
         {
             LOG_DBG("Setting session [" << sessionId << "] to readonly for ViewFileExtension ["
                                         << wopiStorage->getFileExtension()
                                         << "] and allowing comments");
+            session->setWritable(true);
             session->setReadOnly(true);
             session->setAllowChangeComments(true);
         }
         else // Fully writable document, with comments.
         {
             LOG_DBG("Setting session [" << sessionId << "] to writable and allowing comments");
+            session->setWritable(true);
             session->setReadOnly(false);
             session->setAllowChangeComments(true);
         }

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -743,7 +743,7 @@ bool DocumentBroker::download(const std::shared_ptr<ClientSession>& session, con
         {
             LOG_DBG("Setting session [" << sessionId << "] as readonly");
             session->setReadOnly(true);
-            if (COOLWSD::IsViewWithCommentsFileExtension(wopiStorage->getFileExtension()))
+            if (_isViewFileExtension)
             {
                 LOG_DBG("Allow session [" << sessionId
                                           << "] to change comments on document with extension ["
@@ -860,11 +860,12 @@ bool DocumentBroker::download(const std::shared_ptr<ClientSession>& session, con
             userId = localfileinfo->getUserId();
             username = localfileinfo->getUsername();
 
-            if (COOLWSD::IsViewFileExtension(localStorage->getFileExtension()))
+            _isViewFileExtension = COOLWSD::IsViewFileExtension(localStorage->getFileExtension());
+            if (_isViewFileExtension)
             {
                 LOG_DBG("Setting session [" << sessionId << "] as readonly");
                 session->setReadOnly(true);
-                if (COOLWSD::IsViewWithCommentsFileExtension(localStorage->getFileExtension()))
+                if (_isViewFileExtension)
                 {
                     LOG_DBG("Allow session [" << sessionId
                                               << "] to change comments on document with extension ["

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1927,7 +1927,7 @@ std::shared_ptr<ClientSession> DocumentBroker::getWriteableSession() const
         // Save the document using a session that is loaded, editable, and
         // with a valid authorization token, or the first.
         // Note that isViewLoaded() precludes inWaitDisconnected().
-        if (!savingSession || (session->isViewLoaded() && session->isWritable() &&
+        if (!savingSession || (session->isViewLoaded() && session->isEditable() &&
                                !session->getAuthorization().isExpired()))
         {
             savingSession = session;
@@ -2033,7 +2033,7 @@ bool DocumentBroker::autoSave(const bool force, const bool dontSaveIfUnmodified)
     // Note: a loaded view cannot be disconnecting.
     const auto itLastEditingSession = _sessions.find(_lastEditingSessionId);
     const std::shared_ptr<ClientSession> savingSession =
-        (itLastEditingSession != _sessions.end() && itLastEditingSession->second->isWritable() &&
+        (itLastEditingSession != _sessions.end() && itLastEditingSession->second->isEditable() &&
          itLastEditingSession->second->isViewLoaded())
             ? itLastEditingSession->second
             : getWriteableSession();
@@ -2382,7 +2382,7 @@ std::size_t DocumentBroker::removeSession(const std::shared_ptr<ClientSession>& 
     {
         const std::size_t activeSessionCount = countActiveSessions();
 
-        const bool lastEditableSession = session->isWritable() && !haveAnotherEditableSession(id);
+        const bool lastEditableSession = session->isEditable() && !haveAnotherEditableSession(id);
         static const bool dontSaveIfUnmodified = !COOLWSD::getConfigValue<bool>("per_document.always_save_on_exit", false);
 
         LOG_INF("Removing session [" << id << "] on docKey [" << _docKey << "]. Have "
@@ -2390,7 +2390,7 @@ std::size_t DocumentBroker::removeSession(const std::shared_ptr<ClientSession>& 
                                      << " active). IsLive: " << session->isLive()
                                      << ", IsReadOnly: " << session->isReadOnly()
                                      << ", IsAllowChangeComments: " << session->isAllowChangeComments()
-                                     << ", IsWritable: " << session->isWritable()
+                                     << ", IsEditable: " << session->isEditable()
                                      << ", Unloading: " << _docState.isUnloadRequested()
                                      << ", MarkToDestroy: " << _docState.isMarkedToDestroy()
                                      << ", LastEditableSession: " << lastEditableSession
@@ -2476,7 +2476,7 @@ void DocumentBroker::disconnectSessionInternal(const std::shared_ptr<ClientSessi
             _docState.markToDestroy();
         }
 
-        const bool lastEditableSession = session->isWritable() && !haveAnotherEditableSession(id);
+        const bool lastEditableSession = session->isEditable() && !haveAnotherEditableSession(id);
 
         LOG_TRC("Disconnect session internal "
                 << id << ", LastEditableSession: " << lastEditableSession << " destroy? "
@@ -3217,7 +3217,7 @@ bool DocumentBroker::haveAnotherEditableSession(const std::string& id) const
 
     for (const auto& it : _sessions)
     {
-        if (it.second->getId() != id && it.second->isViewLoaded() && it.second->isWritable())
+        if (it.second->getId() != id && it.second->isViewLoaded() && it.second->isEditable())
         {
             // This is a loaded session that is non-readonly.
             return true;


### PR DESCRIPTION
This fixes a corner-case where if we had a document that was not editable, but commenting were allowed (e.g. a PDF), we uploaded even when the Storage had UserCanWrite=false. Includes tests.

- wsd: set _isViewFileExtension for LocalStorage
- wsd: correct setting read-only and allow-comments
- wsd: move isWritable to Session and rename
- wsd: support isWritable flag in Session
- wsd: disable editing when Storage UserCanWrite=false
- wsd: test: add read-only storage tests
