### PR TITLE
Set the checked state of the FreezePanes item

### DIFF
--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -2230,7 +2230,8 @@ L.Control.Menubar = L.Control.extend({
 			item.uno === '.uno:ShowTrackedChanges' ||
 			item.uno === '.uno:ControlCodes' ||
 			item.uno === '.uno:SpellOnline' ||
-			item.uno === '.uno:ShowResolvedAnnotations') {
+			item.uno === '.uno:ShowResolvedAnnotations' ||
+			item.uno === '.uno:FreezePanes') {
 			if (this._map['stateChangeHandler'].getItemValue(item.uno) === 'true') {
 				menuStructure['checked'] = true;
 			}


### PR DESCRIPTION
To show a checkmark for "Freeze Rows and Columns" item on hamburger menu, we have to set "checked" propery of the item according to uno command's status.

Signed-off-by: Gülşah Köse <gulsah.kose@collabora.com>
Change-Id: Icfc2ac07a84ed8a843b3bb8b2fe4c75de8ad9233


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

