### PR TITLE
Use window.ThisIsAMobileApp instead of checking for iOS or Android

### DIFF
--- a/browser/src/map/Map.js
+++ b/browser/src/map/Map.js
@@ -79,7 +79,7 @@ L.Map = L.Evented.extend({
 			this.options.documentContainer = L.DomUtil.get(this.options.documentContainer);
 		}
 
-		if (!window.ThisIsTheiOSApp && !window.ThisIsTheAndroidApp)
+		if (!window.ThisIsAMobileApp)
 			this._clip = L.clipboard(this);
 		this._initContainer(id);
 		this._initLayout();


### PR DESCRIPTION
The code that is conditionally called based on that check verifies using ThisIsAMobileApp anyway.

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: Ic86cf102e061d90bedecb6efcb4ef171dc494004


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

