### PR TITLE
Reduce Warning Logs

### DIFF
--- a/common/Util.cpp
+++ b/common/Util.cpp
@@ -1114,7 +1114,10 @@ namespace Util
 
     void forcedExit(int code)
     {
-        LOG_FTL("Forced Exit with code: " << code);
+        if (code)
+            LOG_FTL("Forced Exit with code: " << code);
+        else
+            LOG_INF("Forced Exit with code: " << code);
         Log::shutdown();
 
 #if CODE_COVERAGE

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -1089,7 +1089,7 @@ public:
             // Technically, there is a race here. The socket can
             // get disconnected and removed right after isConnected.
             // In that case, we will timeout and no request will be sent.
-            poll.wakeupWorld();
+            poll.wakeup();
         }
 
         return true;

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -255,8 +255,9 @@ bool SocketPoll::startThread()
         // because the owner is unlikely to recover.
         // If there is a valid use-case for restarting
         // an expired thread, we should add a way to reset it.
-        LOG_ERR("SocketPoll [" << _name
-                               << "] thread has ran and finished. Will not start it again.");
+        LOG_ASSERT_MSG(!"Expired thread",
+                       "SocketPoll [" << _name
+                                      << "] thread has ran and finished. Will not start it again");
     }
 
     return false;

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -721,7 +721,9 @@ public:
     /// Wakeup the main polling loop in another thread
     void wakeup()
     {
-        if (!isAlive())
+        // There is a race when shutting down because
+        // SocketPoll threads exit when shutting down.
+        if (!isAlive() && !SigUtil::getShutdownRequestFlag())
             LOG_WRN("Waking up dead poll thread ["
                     << _name << "], started: " << (_threadStarted ? "true" : "false")
                     << ", finished: " << _threadFinished);

--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -238,16 +238,17 @@ public:
     void shutdown(const StatusCodes statusCode = StatusCodes::NORMAL_CLOSE,
                   const std::string& statusMessage = std::string())
     {
-        if (!_shuttingDown)
-            sendCloseFrame(statusCode, statusMessage);
         std::shared_ptr<StreamSocket> socket = _socket.lock();
         if (socket)
         {
             LOG_TRC('#' << socket->getFD() << ": Shutdown. Close Connection.");
+            if (!_shuttingDown)
+                sendCloseFrame(statusCode, statusMessage);
             socket->closeConnection();
             socket->getInBuffer().clear();
             socket->ignoreInput();
         }
+
         _wsPayload.clear();
 #if !MOBILEAPP
         _inFragmentBlock = false;

--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -72,7 +72,7 @@ public:
         :
 #if !MOBILEAPP
         _lastPingSentTime(std::chrono::steady_clock::now() -
-                          std::chrono::microseconds(PingFrequencyMicroS) -
+                          std::chrono::microseconds(PingFrequencyMicroS) +
                           std::chrono::microseconds(InitialPingDelayMicroS))
         , _pingTimeUs(0)
         , _isMasking(isClient && isMasking)

--- a/test/UnitCopyPaste.cpp
+++ b/test/UnitCopyPaste.cpp
@@ -33,6 +33,11 @@ using namespace Poco::Net;
 // Inside the WSD process
 class UnitCopyPaste : public UnitWSD
 {
+    STATE_ENUM(Phase, RunTest, WaitDocClose, PostCloseTest, Done) _phase;
+
+    std::string _clipURI;
+    std::string _clipURI2;
+
 public:
     UnitCopyPaste()
         : UnitWSD("UnitCopyPaste")
@@ -222,7 +227,15 @@ public:
         return clipData.str();
     }
 
-    void invokeWSDTest() override
+    void onDocBrokerDestroy(const std::string& docKey) override
+    {
+        LOG_TST("Destroyed dockey [" << docKey << ']');
+        LOK_ASSERT_STATE(_phase, Phase::WaitDocClose);
+
+        TRANSITION_STATE(_phase, Phase::PostCloseTest);
+    }
+
+    void runTest()
     {
         // NOTE: This code has multiple race-conditions!
         // The main one is that the fetching of clipboard
@@ -271,70 +284,73 @@ public:
         std::shared_ptr<http::WebSocketSession> socket = helpers::loadDocAndGetSession(
             socketPoll(), Poco::URI(helpers::getTestServerURI()), documentURL, testname);
 
-        std::string clipURI = getSessionClipboardURI(0);
+        _clipURI = getSessionClipboardURI(0);
 
         LOG_TST("Fetch empty clipboard content after loading");
-        if (!fetchClipboardAssert(clipURI, "", ""))
+        if (!fetchClipboardAssert(_clipURI, "", ""))
             return;
 
         // Check existing content
         LOG_TST("Fetch pristine content from the document");
         helpers::sendTextFrame(socket, "uno .uno:SelectAll", testname);
         helpers::sendAndDrain(socket, testname, "uno .uno:Copy", "statechanged:");
-        std::string oneColumn = "2\n3\n5\n";
-        if (!fetchClipboardAssert(clipURI, "text/plain;charset=utf-8", oneColumn))
+        const std::string oneColumn = "2\n3\n5\n";
+        if (!fetchClipboardAssert(_clipURI, "text/plain;charset=utf-8", oneColumn))
             return;
 
         LOG_TST("Open second connection");
         std::shared_ptr<http::WebSocketSession> socket2 = helpers::loadDocAndGetSession(
             socketPoll(), Poco::URI(helpers::getTestServerURI()), documentURL, testname);
-        std::string clipURI2 = getSessionClipboardURI(1);
+        _clipURI2 = getSessionClipboardURI(1);
 
         LOG_TST("Check no clipboard content on second view");
-        if (!fetchClipboardAssert(clipURI2, "", ""))
+        if (!fetchClipboardAssert(_clipURI2, "", ""))
             return;
 
         LOG_TST("Inject content through first view");
         helpers::sendTextFrame(socket, "uno .uno:Deselect", testname);
-        std::string text = "This is some content?&*/\\!!";
+        const std::string text = "This is some content?&*/\\!!";
         helpers::sendTextFrame(socket, "paste mimetype=text/plain;charset=utf-8\n" + text, testname);
         helpers::sendTextFrame(socket, "uno .uno:SelectAll", testname);
         helpers::sendAndDrain(socket, testname, "uno .uno:Copy", "statechanged:");
 
-        std::string existing = "2\t\n3\t\n5\t";
-        if (!fetchClipboardAssert(clipURI, "text/plain;charset=utf-8", existing + text + '\n'))
+        const std::string existing = "2\t\n3\t\n5\t";
+        if (!fetchClipboardAssert(_clipURI, "text/plain;charset=utf-8", existing + text + '\n'))
             return;
 
         LOG_TST("re-check no clipboard content");
-        if (!fetchClipboardAssert(clipURI2, "", ""))
+        if (!fetchClipboardAssert(_clipURI2, "", ""))
             return;
 
         LOG_TST("Push new clipboard content");
-        std::string newcontent = "1234567890";
+        const std::string newcontent = "1234567890";
         helpers::sendAndWait(socket, testname, "uno .uno:Deselect", "statechanged:");
-        if (!setClipboard(clipURI, buildClipboardText(newcontent), HTTPResponse::HTTP_OK))
+        if (!setClipboard(_clipURI, buildClipboardText(newcontent), HTTPResponse::HTTP_OK))
             return;
         helpers::sendAndWait(socket, testname, "uno .uno:Paste", "statechanged:");
 
-        if (!fetchClipboardAssert(clipURI, "text/plain;charset=utf-8", newcontent))
+        if (!fetchClipboardAssert(_clipURI, "text/plain;charset=utf-8", newcontent))
             return;
 
         LOG_TST("Check the result.");
         helpers::sendTextFrame(socket, "uno .uno:SelectAll", testname);
         helpers::sendAndDrain(socket, testname, "uno .uno:Copy", "statechanged:");
-        if (!fetchClipboardAssert(clipURI, "text/plain;charset=utf-8", existing + newcontent + '\n'))
+        if (!fetchClipboardAssert(_clipURI, "text/plain;charset=utf-8",
+                                  existing + newcontent + '\n'))
             return;
 
         LOG_TST("Setup clipboards:");
-        if (!setClipboard(clipURI2, buildClipboardText("kippers"), HTTPResponse::HTTP_OK))
+        if (!setClipboard(_clipURI2, buildClipboardText("kippers"), HTTPResponse::HTTP_OK))
             return;
-        if (!setClipboard(clipURI, buildClipboardText("herring"), HTTPResponse::HTTP_OK))
+        if (!setClipboard(_clipURI, buildClipboardText("herring"), HTTPResponse::HTTP_OK))
             return;
         LOG_TST("Fetch clipboards:");
-        if (!fetchClipboardAssert(clipURI2, "text/plain;charset=utf-8", "kippers"))
+        if (!fetchClipboardAssert(_clipURI2, "text/plain;charset=utf-8", "kippers"))
             return;
-        if (!fetchClipboardAssert(clipURI, "text/plain;charset=utf-8", "herring"))
+        if (!fetchClipboardAssert(_clipURI, "text/plain;charset=utf-8", "herring"))
             return;
+
+        TRANSITION_STATE(_phase, Phase::WaitDocClose);
 
         LOG_TST("Close sockets:");
         socket2->asyncShutdown();
@@ -344,17 +360,41 @@ public:
                            socket2->waitForDisconnection(std::chrono::seconds(5)));
         LOK_ASSERT_MESSAGE("Expected successful disconnection of the WebSocket 0",
                            socket->waitForDisconnection(std::chrono::seconds(5)));
+    }
 
+    void postCloseTest()
+    {
         sleep(1); // paranoia.
 
         LOG_TST("Fetch clipboards after shutdown:");
-        if (!fetchClipboardAssert(clipURI2, "text/plain;charset=utf-8", "kippers"))
-            return;
-        if (!fetchClipboardAssert(clipURI, "text/plain;charset=utf-8", "herring"))
-            return;
+        LOK_ASSERT_MESSAGE("Failed to get Session #2 clipboard content 'kippers'",
+                           fetchClipboardAssert(_clipURI2, "text/plain;charset=utf-8", "kippers"));
+        LOK_ASSERT_MESSAGE("Failed to get Session #1 clipboard content 'herring'",
+                           fetchClipboardAssert(_clipURI, "text/plain;charset=utf-8", "herring"));
+
+        TRANSITION_STATE(_phase, Phase::Done);
 
         LOG_TST("Clipboard tests succeeded");
-        exitTest(TestResult::Ok);
+        passTest("Got clipboard contents after shutdown");
+    }
+
+    void invokeWSDTest() override
+    {
+        switch (_phase)
+        {
+            case Phase::RunTest:
+            {
+                runTest();
+                break;
+            }
+            case Phase::WaitDocClose:
+                break;
+            case Phase::PostCloseTest:
+                postCloseTest();
+                break;
+            case Phase::Done:
+                break;
+        }
     }
 };
 

--- a/test/UnitWOPIFileUrl.cpp
+++ b/test/UnitWOPIFileUrl.cpp
@@ -223,7 +223,6 @@ public:
         WSD_CMD("key type=input char=97 key=0");
         WSD_CMD("key type=up char=0 key=512");
 
-        SocketPoll::wakeupWorld();
         return true;
     }
 
@@ -238,8 +237,6 @@ public:
 
         WSD_CMD("save dontTerminateEdit=0 dontSaveIfUnmodified=0 "
                 "extendedData=CustomFlag%3DCustom%20Value%3BAnotherFlag%3DAnotherValue");
-
-        SocketPoll::wakeupWorld();
 
         return true;
     }

--- a/test/UnitWOPIHttpRedirect.cpp
+++ b/test/UnitWOPIHttpRedirect.cpp
@@ -157,7 +157,6 @@ public:
                 initWebsocket("/wopi/files/1?" + params);
 
                 WSD_CMD("load url=" + getWopiSrc());
-                SocketPoll::wakeupWorld();
 
                 break;
             }

--- a/test/UnitWOPIHttpRedirectLoop.cpp
+++ b/test/UnitWOPIHttpRedirectLoop.cpp
@@ -87,7 +87,6 @@ public:
                 initWebsocket("/wopi/files/0?" + params);
 
                 WSD_CMD("load url=" + getWopiSrc());
-                SocketPoll::wakeupWorld();
 
                 break;
             }

--- a/test/UnitWOPITemplate.cpp
+++ b/test/UnitWOPITemplate.cpp
@@ -148,7 +148,6 @@ public:
                 initWebsocket("/wopi/files/10?access_token=anything");
                 WSD_CMD("load url=" + getWopiSrc());
 
-                SocketPoll::wakeupWorld();
                 break;
             }
             case Phase::CloseDoc:

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -3419,9 +3419,11 @@ private:
         std::shared_ptr<DocumentBroker> docBroker = child ? child->getDocumentBroker() : nullptr;
         if (docBroker)
             docBroker->handleInput(message);
+        else if (child)
+            LOG_WRN("Child " << child->getPid() << " has no DocBroker to handle message: ["
+                             << message->abbr() << ']');
         else
-            LOG_WRN("Child " << child->getPid() <<
-                    " has no DocumentBroker to handle message: [" << message->abbr() << ']');
+            LOG_WRN("Cannot handle message with unassociated Kit: [" << message->abbr() << ']');
     }
 
     int getPollEvents(std::chrono::steady_clock::time_point /* now */,

--- a/wsd/COOLWSD.hpp
+++ b/wsd/COOLWSD.hpp
@@ -137,20 +137,22 @@ public:
     pid_t getPid() const { return _pid; }
 
     /// Send a text payload to the child-process WS.
-    bool sendTextFrame(const std::string& data)
+    bool sendTextFrame(const std::string& data, bool flush = false)
     {
-        return sendFrame(data, false);
+        return sendFrame(data, false, flush);
     }
 
     /// Send a payload to the child-process WS.
-    bool sendFrame(const std::string& data, bool binary = false)
+    bool sendFrame(const std::string& data, bool binary = false, bool flush = false)
     {
         try
         {
             if (_ws)
             {
-                LOG_TRC("Send to " << _name << " message: [" << COOLProtocol::getAbbreviatedMessage(data) << "].");
-                _ws->sendMessage(data.c_str(), data.size(), (binary ? WSOpCode::Binary : WSOpCode::Text), false);
+                LOG_TRC("Send to " << _name << " message: ["
+                                   << COOLProtocol::getAbbreviatedMessage(data) << ']');
+                _ws->sendMessage(data.c_str(), data.size(),
+                                 (binary ? WSOpCode::Binary : WSOpCode::Text), flush);
                 return true;
             }
         }

--- a/wsd/COOLWSD.hpp
+++ b/wsd/COOLWSD.hpp
@@ -88,12 +88,7 @@ public:
         {
             LOG_DBG("Closing ChildProcess [" << _pid << "].");
 
-            // Request the child to exit
-            if (isAlive())
-            {
-                LOG_DBG("Stopping ChildProcess [" << _pid << "] by sending 'exit' command.");
-                sendTextFrame("exit");
-            }
+            requestTermination();
 
             // Shutdown the socket.
             if (_ws)
@@ -105,6 +100,17 @@ public:
         }
 
         _pid = -1; // Detach from child.
+    }
+
+    /// Request graceful termination.
+    void requestTermination()
+    {
+        // Request the child to exit
+        if (isAlive())
+        {
+            LOG_DBG("Stopping ChildProcess [" << _pid << "] by sending 'exit' command");
+            sendTextFrame("exit", /*flush=*/true);
+        }
     }
 
     /// Kill or abandon the child.

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -2508,12 +2508,8 @@ void DocumentBroker::disconnectSessionInternal(const std::shared_ptr<ClientSessi
         {
             hardDisconnect = session->disconnectFromKit();
 
-            if (isLoaded() || _sessions.size() > 1)
-            {
-                // Let the child know the client has disconnected.
-                _childProcess->sendTextFrame("child-" + id + " disconnect");
-            }
-            else
+#if !MOBILEAPP
+            if (!isLoaded() && _sessions.empty())
             {
                 // We aren't even loaded and no other views--kill.
                 // If we send disconnect, we risk hanging because we flag Core for
@@ -2521,12 +2517,11 @@ void DocumentBroker::disconnectSessionInternal(const std::shared_ptr<ClientSessi
                 // If at the end of loading it shows a dialog (such as the macro or
                 // csv import dialogs), it will wait for their dismissal indefinetely.
                 // Neither would our load-timeout kick in, since we would be gone.
-#if !MOBILEAPP
                 LOG_INF("Session [" << id << "] disconnected but DocKey [" << _docKey
                                     << "] isn't loaded yet. Terminating the child roughly.");
                 _childProcess->terminate();
-#endif
             }
+#endif
         }
 
         if (hardDisconnect)

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -517,6 +517,13 @@ void DocumentBroker::pollThread()
             << ", ShutdownRequestFlag: " << SigUtil::getShutdownRequestFlag()
             << ", TerminationFlag: " << SigUtil::getTerminationFlag());
 
+    if (_childProcess && _sessions.empty())
+    {
+        LOG_INF("Requesting termination of child [" << getPid() << "] for doc [" << _docKey
+                                                    << "] as there are no sessions");
+        _childProcess->requestTermination();
+    }
+
     // Check for data-loss.
     std::string reason;
     if (isModified() || isStorageOutdated())

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -3437,9 +3437,18 @@ void DocumentBroker::closeDocument(const std::string& reason)
 
 void DocumentBroker::disconnectedFromKit()
 {
-    LOG_INF("DocBroker " << _docKey << " Disconnected from Kit. Flagging to close.");
-    _docState.setDisconnected();
-    closeDocument("docdisconnected");
+    _docState.setDisconnected(); // Always set the disconnected flag.
+    if (_closeReason.empty())
+    {
+        // If we have a reason to close, no advantage in clobbering it.
+        LOG_INF("DocBroker [" << _docKey << "] Disconnected from Kit. Flagging to close");
+        closeDocument("docdisconnected");
+    }
+    else
+    {
+        LOG_INF("DocBroker [" << _docKey << "] Disconnected from Kit while closing with reason ["
+                              << _closeReason << ']');
+    }
 }
 
 std::size_t DocumentBroker::broadcastMessage(const std::string& message) const

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -513,9 +513,9 @@ void DocumentBroker::pollThread()
 
     LOG_INF("Finished polling doc ["
             << _docKey << "]. stop: " << _stop << ", continuePolling: " << _poll->continuePolling()
+            << ", CloseReason: [" << _closeReason << ']'
             << ", ShutdownRequestFlag: " << SigUtil::getShutdownRequestFlag()
-            << ", TerminationFlag: " << SigUtil::getTerminationFlag()
-            << ". Terminating child with reason: [" << _closeReason << ']');
+            << ", TerminationFlag: " << SigUtil::getTerminationFlag());
 
     // Check for data-loss.
     std::string reason;
@@ -571,6 +571,7 @@ void DocumentBroker::pollThread()
     }
 
     // Terminate properly while we can.
+    LOG_DBG("Terminating child with reason: [" << _closeReason << ']');
     terminateChild(_closeReason);
 
     // Stop to mark it done and cleanup.


### PR DESCRIPTION
These patches reduce the number of superfluous WRN log entries significantly. Using the unit-tests as one reference, the number of warning log entries go down from around 2800 to around 170. The goal is to remove noisy logs without sacrificing the usefulness of the warnings, as they were designed. The commit logs may have more information.

- wsd: test: better post-close check in UnitCopyPaste
- wsd: preserve close reason when disconnected from Kit
- wsd: better log levels
- wsd: wait InitialPingDelayMicroS before first ping
- wsd: send WS close frame only when we have a socket
- wsd: do not warn of expected DocBroker disconnection
- wsd: support flushing control in WSProcess::sendFrame
- wsd: request Kit termination early when unloading
- wsd: do not send duplicate 'disconnect' to the Kit
- wsd: smarter warnings and errors on kit disconnection
- wsd: do not warn when waking up dead poll-thread at shutdown
- wsd: asyncRequest needs only wakeup its own poll thread
- wsd: test: cleanup redundant wakupWorld after sending a command
