### PR TITLE
browser: menu: ignore menu item with empty text

### DIFF
--- a/browser/src/control/Control.ContextMenu.js
+++ b/browser/src/control/Control.ContextMenu.js
@@ -244,6 +244,9 @@ L.Control.ContextMenu = L.Control.extend({
 				if (window.mode.isMobile() && this.options.mobileBlackList.indexOf(commandName) !== -1)
 					continue;
 
+				if (commandName == 'None' && !item.text)
+					continue;
+
 				if (hasParam || commandName === 'None' || commandName === 'FontDialogForParagraph' || commandName === 'Delete') {
 					itemName = window.removeAccessKey(item.text);
 					itemName = itemName.replace(' ', '\u00a0');


### PR DESCRIPTION
if command "None" and empty item text, there is
an unhandled exception, and no grammar suggestions are shown.

Change-Id: Ie2c832a2a3ff7fe9944024fa003370819b16a432
Signed-off-by: Henry Castro <hcastro@collabora.com>
