### PR TITLE
updated helm chart

### DIFF
--- a/kubernetes/helm/collabora-online/templates/configmap.yaml
+++ b/kubernetes/helm/collabora-online/templates/configmap.yaml
@@ -12,9 +12,9 @@ data:
   {{- end }}
   server_name: {{ .Values.collabora.server_name }}
   {{- range $k,$v := .Values.collabora.aliasgroups }}
-  {{- $alias := $v.domain }}
+  {{- $alias := $v.host }}
   {{- if $v.aliases }}
-  {{- $alias := printf "%s|https://%s:443" $alias (join ":443|https://" $v.aliases ) }}
+  {{- $alias := printf "%s,%s" $alias (join "," $v.aliases) }}
   aliasgroup{{ add $k 1 }}: {{ $alias }}
   {{- else }}
   aliasgroup{{ add $k 1 }}: {{ $alias }}

--- a/kubernetes/helm/collabora-online/templates/deployment.yaml
+++ b/kubernetes/helm/collabora-online/templates/deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     {{- include "collabora-online.labels" . | nindent 4 }}
 spec:
-  terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
   minReadySeconds: {{ .Values.deployment.minReadySeconds }}
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
@@ -34,6 +33,17 @@ spec:
         {{- include "collabora-online.selectorLabels" . | nindent 8 }}
         type: main
     spec:
+      {{- if .Values.deployment.hostAliases }}
+      hostAliases:
+        {{- range .Values.deployment.hostAliases }}
+        - ip: {{ .ip | quote }}
+          hostnames:
+          {{- range .hostnames }}
+          - {{ . | quote }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/kubernetes/helm/collabora-online/values.yaml
+++ b/kubernetes/helm/collabora-online/values.yaml
@@ -23,9 +23,18 @@ serviceAccount:
   name: ""
 
 collabora:
+  # example to add aliasgroups
+  # - host: "<protocol>://<host-name>:<port>"
+  #   aliases: ["<protocol>://<its-first-alias>:<port>, <protocol>://<its-second-alias>:<port>"]
   aliasgroups: []
-  extra_params: --o:ssl.termination=true --o:ssl.enable=false
-  server_name: "localhost"
+
+  extra_params: --o:ssl.enable=false
+  
+  # External hostname:port of the server running coolwsd. 
+  # If empty, it's derived from the request (please set it if this doesn't work). 
+  # May be specified when behind a reverse-proxy or when the hostname is not reachable directly.
+  server_name: null
+  
   existingSecret:
     enabled: false
     secretName: ""
@@ -98,12 +107,15 @@ service:
 
 deployment:
   # Use StatefulSet or Deployment
-  kind: StatefulSet
+  kind: Deployment
   containerPort: 9980
   type: RollingUpdate
   minReadySeconds: 0
   maxUnavailable: 0
   maxSurge: 1
+  # info on how to use hostAliases: https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/
+  # note: different from aliasgroups
+  hostAliases: null
 
 probes:
   startup:


### PR DESCRIPTION
- now works with default configuration
- updated readme
- fixed unknown field "spec.terminationGracePeriodSeconds" in deployment.yaml
  error. This field should be defined in pod spec not in deployment spec
- improved how aliasgroups are defined in helm chart
- change default to kubernetes "Deployment" instead of "StatefulSet"
- added support for kubernetes hostAliases

Signed-off-by: Rash419 <rashesh.padia@collabora.com>
Change-Id: Ief1e2b3f0ea130425853babbd28462d48e50280f


* Resolves: # <!-- related github issue -->
* Target version: master 


