### PR TITLE
zotero: fix locale drop down showing incorrect language

### DIFF
--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -533,6 +533,9 @@ L.Control.JSDialog = L.Control.extend({
 			newControl.style.gridColumn = backupGridSpan;
 		}
 
+		if (data.control.has_default === true && (data.control.type === 'pushbutton' || data.control.type === 'okbutton'))
+			L.DomUtil.addClass(newControl, 'button-primary');
+
 		if (focusedId)
 			dialog.querySelector('[id=\'' + focusedId + '\']').focus();
 

--- a/browser/src/control/Control.Zotero.js
+++ b/browser/src/control/Control.Zotero.js
@@ -194,7 +194,7 @@ L.Control.Zotero = L.Control.extend({
 									id: 'ok',
 									type: 'pushbutton',
 									text: _('OK'),
-									'has_default': true,
+									enabled: false,
 								}
 							],
 							vertical: false,
@@ -220,6 +220,23 @@ L.Control.Zotero = L.Control.extend({
 		this.map.fire(window.mode.isMobile() ? 'mobilewizard' : 'jsdialog', dialogBuildEvent);
 
 		return this;
+	},
+
+	enableDialogOKButton: function() {
+		this.map.fire('jsdialogupdate', {
+			data: {
+				jsontype: 'dialog',
+				action: 'update',
+				id: 'ZoteroDialog',
+				control: {
+					id: 'ok',
+					type: 'pushbutton',
+					text: _('OK'),
+					'has_default': true
+				},
+			},
+			callback: this._onAction.bind(this)
+		});
 	},
 
 	updateList: function(headerArray, failText) {
@@ -479,6 +496,8 @@ L.Control.Zotero = L.Control.extend({
 
 		var styleNode = document.createElement('style');
 		styleNode.setAttribute('id', 'http://www.zotero.org/styles/' + style.name);
+		if (this.selectedCitationLangCode)
+			this.settings.locale = this.selectedCitationLangCode;
 		styleNode.setAttribute('locale', this.settings.locale);
 		styleNode.setAttribute('hasBibliography', this.settings.hasBibliography);
 		styleNode.setAttribute('bibliographyStyleHasBeenSet', this.settings.bibliographyStyleHasBeenSet);
@@ -619,6 +638,7 @@ L.Control.Zotero = L.Control.extend({
 				return;
 			} else {
 				this.selected = data.entries[parseInt(index)];
+				this.enableDialogOKButton();
 				return;
 			}
 		}
@@ -626,11 +646,12 @@ L.Control.Zotero = L.Control.extend({
 			document.getElementById('zoterolist').filterEntries(data.value);
 			return;
 		}
-		if (element === 'responsebutton' && data.id == 'ok') {
-			if (this.selected)
+		if (data.id == 'ok') {
+			// style already specified just changing the language
+			if (!this.selected && this.selectedCitationLangCode)
+				this._onOk({name: this.settings.style, type: 'style'});
+			else
 				this._onOk(this.selected);
-			if (this.selectedCitationLangCode)
-				this.settings.locale = this.selectedCitationLangCode;
 		}
 		if (element === 'pushbutton' && data.id === 'zoterorefresh') {
 			this._cachedURL = [];
@@ -642,6 +663,8 @@ L.Control.Zotero = L.Control.extend({
 		}
 		if (element === 'combobox') {
 			this.selectedCitationLangCode = Object.keys(this.languageNames)[parseInt(index)];
+			if (this.settings.style)
+				this.enableDialogOKButton();
 			return;
 		}
 


### PR DESCRIPTION
user was allowed to select language without selecting the style, if style is not selected language data will also be not written in the doc.

force user to select style too if want to set the language.

Signed-off-by: Pranam Lashkari <lpranam@collabora.com>
Change-Id: Ie323b19189858e601f3fa979d747d7c688e4baf1


* Target version: master 



### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

