### PR TITLE
revert naming changes of aliasgroups in helmchart

### DIFF
--- a/kubernetes/helm/README.md
+++ b/kubernetes/helm/README.md
@@ -40,7 +40,7 @@ How to test this specific setup:
       1. If you have multiple host and aliases setup set aliasgroups in my_values.yaml
           ```yaml
           collabora:
-            - host: "<protocol>://<host-name>:<port>"
+            - domain: "<protocol>://<host-name>:<port>"
               aliases: ["<protocol>://<its-first-alias>:<port>, <protocol>://<its-second-alias>:<port>"]
           ```
 

--- a/kubernetes/helm/collabora-online/templates/configmap.yaml
+++ b/kubernetes/helm/collabora-online/templates/configmap.yaml
@@ -12,7 +12,7 @@ data:
   {{- end }}
   server_name: {{ .Values.collabora.server_name }}
   {{- range $k,$v := .Values.collabora.aliasgroups }}
-  {{- $alias := $v.host }}
+  {{- $alias := $v.domain }}
   {{- if $v.aliases }}
   {{- $alias := printf "%s,%s" $alias (join "," $v.aliases) }}
   aliasgroup{{ add $k 1 }}: {{ $alias }}

--- a/kubernetes/helm/collabora-online/values.yaml
+++ b/kubernetes/helm/collabora-online/values.yaml
@@ -24,7 +24,7 @@ serviceAccount:
 
 collabora:
   # example to add aliasgroups
-  # - host: "<protocol>://<host-name>:<port>"
+  # - domain: "<protocol>://<host-name>:<port>"
   #   aliases: ["<protocol>://<its-first-alias>:<port>, <protocol>://<its-second-alias>:<port>"]
   aliasgroups: []
 


### PR DESCRIPTION
introduced in commit e75bdca77601f8109ea8cf07a684399294945541

Signed-off-by: Rash419 <rashesh.padia@collabora.com>
Change-Id: Idb1c6b3de4ba2f3e1ea23ccf3357e0969d30ad92


* Resolves: # <!-- related github issue -->
* Target version: master 


