### PR TITLE
Fix error in conversion from microseconds to whole milliseconds

### DIFF
--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -342,13 +342,13 @@ int SocketPoll::poll(int64_t timeoutMaxMicroS)
         timeout.tv_nsec = (timeoutMaxMicroS % (1000 * 1000)) * 1000;
         rc = ::ppoll(&_pollFds[0], size + 1, &timeout, nullptr);
 #  else
-        int timeoutMaxMs = (timeoutMaxMicroS + 9999) / 1000;
+        int timeoutMaxMs = (timeoutMaxMicroS + 999) / 1000;
         LOG_TRC("Legacy Poll start, timeoutMs: " << timeoutMaxMs);
         rc = ::poll(&_pollFds[0], size + 1, std::max(timeoutMaxMs,0));
 #  endif
 #else
         LOG_TRC("SocketPoll Poll");
-        int timeoutMaxMs = (timeoutMaxMicroS + 9999) / 1000;
+        int timeoutMaxMs = (timeoutMaxMicroS + 999) / 1000;
         rc = fakeSocketPoll(&_pollFds[0], size + 1, std::max(timeoutMaxMs,0));
 #endif
     }


### PR DESCRIPTION
I had added some extra debugging output to the !MOBILEAPP branch to log values of timeoutMaxMicroS and timeoutMaxMS and was wondering why I saw things like:

    timeoutMaxMicroS=5000000 timeoutMaxMS=5009

and

    timeoutMaxMicroS=0 timeoutMaxMS=9

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: Iac8599ce5b00ef90d62eabc29c5d92858e276bb6


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

