### PR TITLE
private/pedro/references zotero ui jsdialogs fixes

### DIFF
--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -79,8 +79,10 @@ button:not(.ui-corner-all):not(.button-primary) {
 .jsdialog.ui-button-box-right {
 	display: flex;
 	float: inline-end;
+	margin-inline-end: -5px;
 }
 
 .jsdialog.ui-button-box-left {
 	float: inline-start;
+	margin-inline-start: -5px;
 }

--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -790,9 +790,12 @@ nav.spreadsheet-color-indicator ~ #sidebar-dock-wrapper {
 }
 
 .lokdialog.ui-dialog-content.ui-widget-content {
-	padding: 0px;
 	overflow: auto;
 	border-radius: calc(var(--border-radius)/2);
+}
+
+.lokdialog_container:not(.jsdialog-container) .lokdialog.ui-dialog-content.ui-widget-content {
+	padding: 0px;
 }
 
 .lokdialog_canvas {

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -21,10 +21,6 @@
 	z-index: 2001;
 }
 
-.lokdialog > .jsdialog.root-container:not(.autofilter) {
-	margin: .5em 1em; /*same as in .ui-dialog */
-}
-
 .jsdialog-container {
 	position: absolute;
 	z-index: 1105;

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -403,7 +403,7 @@ input[type='checkbox']:checked.autofilter, .jsdialog input[type='checkbox']:chec
 	background-color: var(--color-background-dark);
 	line-height: 28px;
 	max-height: 32px;
-	width: 100%;
+	width: auto;
 	border: 1px solid var(--color-border-dark);
 	border-radius: var(--border-radius);
 }

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1250,7 +1250,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 }
 
 #ZoteroDialog-search-container.jsdialog, #ZoteroDialog-locale-container.jsdialog {
-	margin: 7px;
+	margin-block: 7px;
 }
 
 #ZoteroDialog-locale-container.jsdialog {
@@ -1264,11 +1264,14 @@ input[type='number']:hover::-webkit-outer-spin-button {
 }
 
 #zoterolist.jsdialog {
-	margin-inline-end: 7px;
 	width: 800px;
 }
 
-#zoterosearch-label.jsdialog, #zoterolocale-label.jsdialog {
+#zoterosearch-label.jsdialog {
 	text-align: end;
 	margin: auto 7px;
+}
+
+#zoterolocale-label.jsdialog {
+	margin-inline-end: 7px;
 }

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -610,12 +610,13 @@ L.Control.JSDialogBuilder = L.Control.extend({
 												+ (data.layoutstyle ? data.layoutstyle : ''), parentContainer);
 		container.id = data.id;
 
+		var isButtonBoxLeft = data.leftaligned === 'true';
 		var leftAlignButtons = [];
 		var rightAlignButton = [];
 
 		for (var i in data.children) {
 			var child = data.children[i];
-			if (child.id === 'help')
+			if (child.id === 'help' || isButtonBoxLeft === true)
 				leftAlignButtons.push(child);
 			else
 				rightAlignButton.push(child);

--- a/browser/src/control/Control.Zotero.js
+++ b/browser/src/control/Control.Zotero.js
@@ -128,9 +128,18 @@ L.Control.Zotero = L.Control.extend({
 							layoutstyle: 'end',
 							children: [
 								{
-									type: 'pushbutton',
-									id: 'zoterorefresh',
-									text: _('Refresh')
+									id: 'zoterorefresh-buttonbox',
+									type: 'buttonbox',
+									leftaligned: 'true',
+									children: [
+										{
+											type: 'pushbutton',
+											id: 'zoterorefresh',
+											text: _('Refresh')
+										}
+									],
+									vertical: false,
+									layoutstyle: 'end'
 								},
 								{
 									type: 'fixedtext',


### PR DESCRIPTION
- JSDialog: add margin offsets to buttonbox L and R
- JSdialog: Fix container's padding
- JSDialog: edit controls (input fields): do not force their width
- Citations: Fix extra h margins affecting search and locale controls
- **Updated:** `So it uses new json property instead of checking for the specific id` Citations: Fix refresh button alignment
- **Removed:** `It seems it is better to do in Zotero dialog implementation in the callback as` @eszkadev `mentioned bellow` ~~Allow edit control to have placeholder + remove zotero search label~~
