### PR TITLE
Don't pointlessly assign global.socket = app.socket

### DIFF
--- a/browser/src/main.js
+++ b/browser/src/main.js
@@ -70,7 +70,6 @@ L.Map.THIS = map;
 
 map.loadDocument(global.socket);
 
-global.socket = app.socket;
 window.addEventListener('beforeunload', function () {
 	if (map && app.socket) {
 		if (app.socket.setUnloading)


### PR DESCRIPTION
Note that the code changed is inside an anonymous function that is called with one argument: window, for the function parameter called global. Thus the assignment that this change removes sets window.socket.

The window.socket variable is not used by code later, so this change can be this minimal.

The window.socket variable has earlier been set to the WebSocket object used to communicate with the COOL server. Let's keep it for that purpose. app.socket is the app.definitions.Socket object. Even though JavaScript is not type-safe, it is very confusing to use the same variable for completely different object types at different stages in the code execution. I am working on some new code that will want to access the WebSocket object also later.

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: I6273a6d6acee3fa46ab9fedc5742ae44c8bfa567


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

