### PR TITLE
Actually use the safer (escaped) string we construct

### DIFF
--- a/gtk/mobile.cpp
+++ b/gtk/mobile.cpp
@@ -30,7 +30,7 @@
 
 const char *user_name = "Dummy";
 
-const int SHOW_JS_MAXLEN = 70;
+const int SHOW_JS_MAXLEN = 300;
 
 int coolwsd_server_socket_fd = -1;
 
@@ -87,10 +87,9 @@ static void send2JS(const std::vector<char>& buffer)
                 data.push_back(ubufp[i]);
             }
         }
-        data.push_back(0);
 
         js = "window.TheFakeWebSocket.onmessage({'data': '";
-        js = js + std::string(buffer.data(), buffer.size());
+        js = js + std::string(data.data(), data.size());
         js = js + "'});";
     }
 


### PR DESCRIPTION
Also, no reason to append a null byte to it.

Don't know why this worked even when not escaping "dangerous" characters. Does Webkit have a more relaxed lexical analyser?

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: Idfedcbf11a9ee565b954ba972e7e3bc9b804a122


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

