### PR TITLE
cypress:fix: insert_content_control_spec.js

### DIFF
--- a/cypress_test/integration_tests/mobile/writer/insert_content_control_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/insert_content_control_spec.js
@@ -68,9 +68,9 @@ describe('Insert objects via insertion wizard.', function() {
 		cy.get('#listitems .mobile-wizard.ui-treeview-body .ui-listview-entry')
 			.each((item, index) => {
 				if (index == 0)
-					expect(item.get(0).innerText).to.eq('\tChoose an item');
+					expect(item.get(0).innerText).to.eq('\t\tChoose an item');
 				else if (index == 1)
-					expect(item.get(0).innerText).to.eq('some text\tsomething');
+					expect(item.get(0).innerText).to.eq('\tsome text\tsomething');
 			});
 	});
 });


### PR DESCRIPTION
AssertionError: expected '\t\tChoose an item' to equal '\tChoose an item'

Signed-off-by: Rash419 <rashesh.padia@collabora.com>
Change-Id: Iad286caf45d169176d6f5bb03771bfa1ecc8808a


* Resolves: # <!-- related github issue -->
* Target version: master 
