### PR TITLE
writer: vex-desktop: clicking away drops comment

### DIFF
--- a/browser/src/layer/tile/CommentListSection.ts
+++ b/browser/src/layer/tile/CommentListSection.ts
@@ -412,7 +412,11 @@ class CommentSection {
 				else {
 					this.cancel(comment);
 				}
-			}.bind(this)
+			}.bind(this),
+
+			// Allow close on click away only in desktop (in case of reduced window size otherwise we wont use vex).
+			// Refer: vex.defaultOptions in vex.combined.js
+			overlayClosesOnClick: (<any>window).mode.isMobile() || (<any>window).mode.isTablet(),
 		});
 
 		var tagTd = 'td',


### PR DESCRIPTION
In case of desktop browser window whose size is only a little bigger than the page, our native comments get collapsed and we use vex. In this case don't close the comment dialog on clicking outside the dialog or when switching browser tabs.

Signed-off-by: Dennis Francis <dennis.francis@collabora.com>
Change-Id: I92c9d800d58a6910d6df01371e6748c864641cff


* Resolves: # <!-- related github issue -->
* Target version: master 


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

