### PR TITLE
Add float logical values fallback for buttonboxes

### DIFF
--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -76,6 +76,18 @@ button:not(.ui-corner-all):not(.button-primary) {
 
 /* button box */
 
+/* - Add fallback for browsers without support
+for float logical values */
+html:not([dir='rtl']) .jsdialog.ui-button-box-right,
+html[dir='rtl'] .jsdialog.ui-button-box-left {
+	float: right;
+}
+html[dir='rtl'] .jsdialog.ui-button-box-right,
+html:not([dir='rtl']) .jsdialog.ui-button-box-left {
+	float: left;
+}
+/* - */
+
 .jsdialog.ui-button-box-right {
 	display: flex;
 	float: inline-end;


### PR DESCRIPTION
Before this commit, browsers such as chrome (without enabling
experimental features) were not supporting those float values

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I2530e7bf46d161ac980559c181a4e03947edbeee
