### PR TITLE
calc cell cursor: get the layout and sizing right.

### DIFF
--- a/browser/src/layer/tile/AutoFillMarkerSection.ts
+++ b/browser/src/layer/tile/AutoFillMarkerSection.ts
@@ -57,7 +57,7 @@ class AutoFillMarkerSection {
 
 	public onInitialize () {
 		if ((<any>window).mode.isDesktop()) {
-			this.size = [Math.round(8 * app.dpiScale), Math.round(8 * app.dpiScale)];
+			this.size = [Math.round(6 * app.dpiScale), Math.round(6 * app.dpiScale)];
 		}
 		else {
 			this.size = [Math.round(16 * app.dpiScale), Math.round(16 * app.dpiScale)];
@@ -105,32 +105,28 @@ class AutoFillMarkerSection {
 		this.setPosition(position[0], position[1]);
 	}
 
-	// Give bottom right position of selected area, in core pixels. Call with null parameter when auto fill marker is not visible.
-	public calculatePositionViaCellSelection (point: Array<number>) {
+	private calculatePositionFromPoint (point: Array<number>) {
+		var calcPoint: Array<number>;
 		if (point === null) {
-			this.sectionProperties.selectedAreaPoint = null;
+			calcPoint = null;
 		}
 		else {
-			var translation = (<any>window).mode.isDesktop() ?
-				[this.size[0], this.size[1]] :
-				[Math.floor(this.size[0] * 0.5), Math.floor(this.size[1] * 0.5)];
-			this.sectionProperties.selectedAreaPoint = [point[0] - translation[0], point[1] - translation[1]];
+			var translation = [Math.floor(this.size[0] * 0.5), Math.floor(this.size[1] * 0.5)];
+			calcPoint = [point[0] - translation[0], point[1] - translation[1]];
 		}
-		this.setMarkerPosition();
+		return calcPoint;
+	}
+
+	// Give bottom right position of selected area, in core pixels. Call with null parameter when auto fill marker is not visible.
+	public calculatePositionViaCellSelection (point: Array<number>) {
+	       this.sectionProperties.selectedAreaPoint = this.calculatePositionFromPoint(point);
+	       this.setMarkerPosition();
 	}
 
 	// Give bottom right position of cell cursor, in core pixels. Call with null parameter when auto fill marker is not visible.
 	public calculatePositionViaCellCursor (point: Array<number>) {
-		if (point === null) {
-			this.sectionProperties.cellCursorPoint = null;
-		}
-		else {
-			var translation = (<any>window).mode.isDesktop() ?
-				[this.size[0], this.size[1]] :
-				[Math.floor(this.size[0] * 0.5), Math.floor(this.size[1] * 0.5)];
-			this.sectionProperties.cellCursorPoint = [point[0] - translation[0], point[1] - translation[1]];
-		}
-		this.setMarkerPosition();
+	       this.sectionProperties.cellCursorPoint = this.calculatePositionFromPoint(point);
+	       this.setMarkerPosition();
 	}
 
 	// This is for enhancing contrast of the marker with the background
@@ -149,10 +145,11 @@ class AutoFillMarkerSection {
 			return adjustForRTL ? this.size[0] - xcoord : xcoord;
 		};
 
+		// top white line
 		this.context.beginPath();
 		this.context.moveTo(transformX(-0.5), -0.5);
 		var borderWidth = this.sectionProperties.selectedAreaPoint ? this.selectionBorderWidth : this.cursorBorderWidth;
-		this.context.lineTo(transformX(this.size[0] - 0.5 - (desktop ? borderWidth : 0)), -0.5);
+		this.context.lineTo(transformX(this.size[0] + 0.5 - (desktop ? borderWidth : 0)), - 0.5);
 		this.context.stroke();
 
 		if (!desktop) {
@@ -162,9 +159,10 @@ class AutoFillMarkerSection {
 			this.context.stroke();
 		}
 
+		// bottom white line
 		this.context.beginPath();
 		this.context.moveTo(transformX(-0.5), -0.5);
-		this.context.lineTo(transformX(-0.5), translation[1] - 0.5 - borderWidth);
+		this.context.lineTo(transformX(-0.5), translation[1] + 0.5 - borderWidth);
 		this.context.stroke();
 	}
 

--- a/browser/src/layer/vector/CRectangle.ts
+++ b/browser/src/layer/vector/CRectangle.ts
@@ -66,14 +66,14 @@ class CCellCursor extends CPathGroup {
 		for (let idx = 0; idx < this.cursorWeight; ++idx) {
 			const pixels = idx; // device pixels from real cell-border.
 			boundsForBorder.push(new cool.Bounds(
-				cellBounds.min.add(new cool.Point(pixels, pixels)),
-				cellBounds.max.subtract(new cool.Point(pixels, pixels))
+				cellBounds.min.subtract(new cool.Point(pixels, pixels)),
+				cellBounds.max.add(new cool.Point(pixels, pixels))
 			));
 		}
 
 		const boundsForContrastBorder = new cool.Bounds(
-			cellBounds.min.add(new cool.Point(this.cursorWeight, this.cursorWeight)),
-			cellBounds.max.subtract(new cool.Point(this.cursorWeight, this.cursorWeight)));
+			cellBounds.min.add(new cool.Point(1.0, 1.0)),
+			cellBounds.max.subtract(new cool.Point(1.0, 1.0)));
 
 		if (this.borderPaths && this.innerContrastBorder) {
 			console.assert(this.borderPaths.length === this.cursorWeight);


### PR DESCRIPTION
The cursor should minimally obscure the cell content - so the border should go outside and over the cell border, and the white contrast line inside it.

Similarly the autofill handle should not obscure the number in the cell you're trying to read - so move it out and down to a more familiar position, shrink the size somewhat, and correct the white boarders around it too.

Change-Id: Ib107adc2927172d69b8cd9a6523b50327d4f81cb
Signed-off-by: Michael Meeks <michael.meeks@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

