### PR TITLE
JSDialog: Add padding in between columns and fix th alignment

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -105,6 +105,14 @@
 	width: 100%;
 }
 
+th.jsdialog:not(:first-child) {
+	padding-inline-end: 24px;
+}
+
+th.jsdialog {
+	text-align: start;
+}
+
 .jsdialog.vertical:not([id^='table-dialog-action_area']) > .jsdialog.row,
 td.jsdialog > [id^='table-box']:not(.sidebar) {
 	display: table;


### PR DESCRIPTION
Before this table columns were getting "glued" (content of one
col would end and immediately would start content of another col).
Plus, we were having table content normally aligned to th start
while headers were being centered aligned

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ie0908c26d1e7bedc37b3c5d768d941b091946524
