### PR TITLE
Zotero refmark

### DIFF
--- a/browser/src/control/Control.Zotero.js
+++ b/browser/src/control/Control.Zotero.js
@@ -378,7 +378,7 @@ L.Control.Zotero = L.Control.extend({
 
 	getCitationJSONString: function(items) {
 		var resultJSON = {};
-		resultJSON['citationID'] = Math.random().toString(36).substring(2,12);
+		resultJSON['citationID'] = L.Util.randomString(10);
 
 		var citationNode = this.handleCitationText(items);
 
@@ -620,7 +620,7 @@ L.Control.Zotero = L.Control.extend({
 		dataNode.setAttribute('data-version', '3');
 
 		var sessionNode = document.createElement('session');
-		sessionNode.setAttribute('id', Math.random().toString(36).substring(2,10));
+		sessionNode.setAttribute('id', L.Util.randomString(8));
 
 		dataNode.appendChild(sessionNode);
 
@@ -1029,7 +1029,7 @@ L.Control.Zotero = L.Control.extend({
 			field['FieldResult'] = {type: 'string', value: citationString};
 		} else if (this.getFieldType() === 'ReferenceMark') {
 			field['TypeName'] = {type: 'string', value: 'SetRef'};
-			field['Name'] = {type: 'string', value: 'ZOTERO_ITEM CSL_CITATION ' + cslJSON + ' RNDpyJknp173F'};
+			field['Name'] = {type: 'string', value: 'ZOTERO_ITEM CSL_CITATION ' + cslJSON + ' RND' + L.Util.randomString(10)};
 			field['Content'] = {type: 'string', value: citationString};
 		}
 

--- a/browser/src/control/Signing.js
+++ b/browser/src/control/Signing.js
@@ -41,7 +41,7 @@ function getVereignIFrameURL() {
 }
 
 function randomName() {
-	return Math.random().toString(36).substring(2) + (new Date()).getTime().toString(36);
+	return L.Util.randomString(12) + (new Date()).getTime().toString(36);
 }
 
 function getCurrentDocumentFilename(documentType) {

--- a/browser/src/core/Util.js
+++ b/browser/src/core/Util.js
@@ -243,6 +243,15 @@ L.Util = {
 			return msg.replace(ctrl, '⌘').replace(alt, '⌥');
 		}
 		return msg;
+	},
+
+	randomString: function(len) {
+		var result = '';
+		var ValidCharacters = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+		for (var i = 0; i < len; i++) {
+			result += ValidCharacters.charAt(Math.floor(Math.random() * ValidCharacters.length));
+		}
+		return result;
 	}
 };
 

--- a/browser/src/layer/tile/WriterTileLayer.js
+++ b/browser/src/layer/tile/WriterTileLayer.js
@@ -50,6 +50,8 @@ L.WriterTileLayer = L.CanvasTileLayer.extend({
 		}
 		else if (values.fields) {
 			this._map.zotero.onFieldValue(values.fields);
+		} else if (values.setRefs) {
+			this._map.zotero.onFieldValue(values.setRefs);
 		}
 		else {
 			L.CanvasTileLayer.prototype._onCommandValuesMsg.call(this, textMsg);


### PR DESCRIPTION
now odf documents will by default use refmarks,
MS docs will use field marks by default

Signed-off-by: Pranam Lashkari <lpranam@collabora.com>
Change-Id: I57ef5de9bef8d1e5f6b5029e478d9a43e38dbc4d

* Target version: master 


### TODO
With reference marks, citation renumbering will not work as of now due to the core not sending remarks in sequence of them appearing in doc. All else should work fine. core patch work is in queue. MS doc formats will work as expected



### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

