### PR TITLE
Revert "share css-url renamer with branding"

### DIFF
--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -625,9 +625,8 @@ window.app = {
 
 	if (global.socketProxy)
 	{
-		// [start:cssRenamerSocketProxy]
 		// re-write relative URLs in CSS - somewhat grim.
-		var cssRenamerSocketProxy = function() {
+		window.addEventListener('load', function() {
 			var replaceUrls = function(rules, replaceBase) {
 				if (!rules)
 					return;
@@ -670,10 +669,7 @@ window.app = {
 				}
 				replaceUrls(rules, replaceBase);
 			}
-		};
-		// [end:cssRenamerSocketProxy]
-
-		window.addEventListener('load', cssRenamerSocketProxy, false);
+		}, false);
 	}
 
 	global.createWebSocket = function(uri) {


### PR DESCRIPTION
This reverts commit 089b6d235a0e38d5b1d021fab024becc2def0ada.

Reason for revert: For packaging builds the global.js is in minified form hence marker comments are not present and it is difficult to extract the css url renamer function without js-language analysis tools or packages - this needs more thought.


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

