### PR TITLE
Show citation snackbar also when loading up document

### DIFF
--- a/browser/src/control/Control.Zotero.js
+++ b/browser/src/control/Control.Zotero.js
@@ -72,7 +72,7 @@ L.Control.Zotero = L.Control.extend({
 
 		if (this.pendingCitationUpdate || this.previousNumberOfFields !== fields.length) {
 			delete this.pendingCitationUpdate;
-			this.updateCitations();
+			this.updateCitations(true);
 		}
 		this.previousNumberOfFields = fields.length;
 	},


### PR DESCRIPTION
Before this commit, when opening a document with citations,
citations would be updated and the document refreshed but without
any information of what is happening

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I474e8cdf9c31e18027501ebfc9bd6dd2f55a58a5
