### PR TITLE
browser: Add PageNumberWizard button in notebook bar

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2398,6 +2398,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			'styleapply3fstyle3astring3ddefault26familyname3astring3dcellstyles': 'fontcolor',
 			'fontworkgalleryfloater': 'fontworkpropertypanel',
 			'insertfieldctrl': 'insertfield',
+			'pagenumberwizard': 'insertpagenumberfield',
 			'entirerow': 'fromrow',
 			'insertcheckboxcontentcontrol': 'checkbox',
 			'cellvertbottom': 'alignbottom',

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -856,6 +856,11 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 			},
 			{
 				'type': 'bigtoolitem',
+				'text': _UNO('.uno:PageNumberWizard', 'text'),
+				'command': '.uno:PageNumberWizard'
+			},
+			{
+				'type': 'bigtoolitem',
 				'text': _UNO('.uno:InsertFieldCtrl', 'text'),
 				'command': '.uno:InsertFieldCtrl'
 			},

--- a/browser/src/unocommands.js
+++ b/browser/src/unocommands.js
@@ -256,6 +256,7 @@ var unoCommandsArray = {
 	'InsertEndnote':{text:{context:_('Insert Endnote'),menu:_('~Endnote'),},},
 	'InsertField':{text:{menu:_('~More Fields...'),},},
 	'InsertFieldCtrl':{text:{context:_('Insert Field'),menu:_('Fiel~d'),},},
+	'PageNumberWizard':{text:{context:_('Page Number'),menu:_('~Page Number...'),},},
 	'InsertFootnote':{text:{context:_('Insert Footnote'),menu:_('~Footnote'),},},
 	'InsertGraphic':{global:{context:_('Insert Image...'),menu:_('~Image...'),},},
 	'InsertHardHyphen':{global:{menu:_('Insert non-br~eaking hyphen'),},},


### PR DESCRIPTION
Add button that opens the page number wizard in the Writer notebook bar

Signed-off-by: Paris Oplopoios <paris.oplopoios@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

Adds a button in the insert tab in the notebook bar that opens the one step page number wizard dialog.

co-22.05 patch: https://gerrit.libreoffice.org/c/core/+/144998 (not yet merged, should be merged before this PR is)

### Checklist

- [X] Code is properly formatted
- [X] All commits have Change-Id
- [X] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

