### PR TITLE
zotero: fixed style attribute storage in xml

### DIFF
--- a/browser/src/control/Control.Zotero.js
+++ b/browser/src/control/Control.Zotero.js
@@ -701,15 +701,16 @@ L.Control.Zotero = L.Control.extend({
 		this.settings.style = style.name;
 		this.settings.hasBibliography = '1';
 
-		var dataNode = document.createElement('data');
+		var xmlDoc = new DOMParser().parseFromString('<data></data>', 'text/xml');
+		var dataNode = xmlDoc.getElementsByTagName('data')[0];
 		dataNode.setAttribute('data-version', '3');
 
-		var sessionNode = document.createElement('session');
+		var sessionNode = xmlDoc.createElement('session');
 		sessionNode.setAttribute('id', L.Util.randomString(8));
 
 		dataNode.appendChild(sessionNode);
 
-		var styleNode = document.createElement('style');
+		var styleNode = xmlDoc.createElement('style');
 		styleNode.setAttribute('id', 'http://www.zotero.org/styles/' + style.name);
 		if (this.selectedCitationLangCode)
 			this.settings.locale = this.selectedCitationLangCode;
@@ -719,9 +720,9 @@ L.Control.Zotero = L.Control.extend({
 
 		dataNode.appendChild(styleNode);
 
-		var prefsNode = document.createElement('prefs');
+		var prefsNode = xmlDoc.createElement('prefs');
 
-		var prefNode = document.createElement('pref');
+		var prefNode = xmlDoc.createElement('pref');
 		prefNode.setAttribute('name', 'fieldType');
 		prefNode.setAttribute('value', this.getFieldType());
 


### PR DESCRIPTION
style settings were treated as html instead of xml, which caused attributes to lose its camelCase naming, due to which some attributes were unrecognised and caused regression

Signed-off-by: Pranam Lashkari <lpranam@collabora.com>
Change-Id: I34f211c54f9692ec67e08a872a68f516b1f82944


* Target version: master 


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

