### PR TITLE
Add min and max width to jsdialog modalPopup

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -32,6 +32,8 @@
 }
 
 .jsdialog-container.modalpopup {
+	min-width: 198px;
+	max-width: 498px;
 	border: 1px solid #a4a4a4 !important;
 	border-radius: var(--border-radius);
 	box-shadow: 0 -1px 2px 0 rgba(0, 0, 0, 0.15), 0 2px 2px 0 rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
with the introduction of showModal:
https://github.com/CollaboraOnline/online/pull/5518 we now have
a type of a dialog that, without this commit, can grow without
limits and can be as small as its content which is not ideal.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I8768925377606924fd70fab8be40b0b755d802ac
