### PR TITLE
calcRTL: switch between RTL/LTR layout in a sheet

### DIFF
--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -375,6 +375,19 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 		}
 	},
 
+	_handleRTLFlags: function (command) {
+		var rtlChanged = command.rtlParts === undefined;
+		rtlChanged = rtlChanged || this._rtlParts !== undefined && (
+			command.rtlParts.length !== this._rtlParts.length
+			|| this._rtlParts.some(function (part, index) {
+				return part !== command.rtlParts[index];
+			}));
+		this._rtlParts = command.rtlParts || [];
+		if (rtlChanged) {
+			this._adjustCanvasSectionsForLayoutChange();
+		}
+	},
+
 	_onStatusMsg: function (textMsg) {
 		console.log('DEBUG: onStatusMsg: ' + textMsg);
 		var command = app.socket.parseServerCmd(textMsg);
@@ -413,8 +426,7 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 				this._updateMaxBounds(true);
 			}
 			this._hiddenParts = command.hiddenparts || [];
-			this._rtlParts = command.rtlParts || [];
-			console.log('DEBUG: rtlParts = ' + this._rtlParts);
+			this._handleRTLFlags(command);
 			this._documentInfo = textMsg;
 			var partNames = textMsg.match(/[^\r\n]+/g);
 			// only get the last matches
@@ -432,6 +444,8 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 			if (firstSelectedPart) {
 				this._switchSplitPanesContext();
 			}
+		} else {
+			this._handleRTLFlags(command);
 		}
 
 		var scrollSection = app.sectionContainer.getSectionWithName(L.CSections.Scroll.name);

--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -621,8 +621,7 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 	},
 
 	_adjustCanvasSectionsForLayoutChange: function () {
-
-		var sheetIsRTL = this._selectedPart in this._rtlParts;
+		var sheetIsRTL = this._rtlParts.indexOf(this._selectedPart) >= 0;
 		if (sheetIsRTL && this._layoutIsRTL !== true) {
 			console.log('debug: in LTR -> RTL canvas section adjustments');
 			var sectionContainer = this._painter._sectionContainer;


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
Ability to switch between RTL/LTR layout in a sheet based on status provided by the core. A patch to add menu UI element for this switch is in the PR https://github.com/CollaboraOnline/online/pull/5570

### TODO
- Fix offset in mouse events just after layout switch.

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

