### PR TITLE
Use thin instead of auto for scrollbar width

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -224,7 +224,7 @@ nav.spreadsheet-color-indicator ~ #sidebar-dock-wrapper {
 	overflow-x: hidden;
 	overflow-y: auto;
 	z-index: 1200;
-	scrollbar-width: auto;
+	scrollbar-width: thin;
 	scrollbar-color: var(--color-border) transparent;
 }
 


### PR DESCRIPTION
On Windows firefox auto setting is not handled properly. Scrollbar flows on the sidebar elements. We use thin instead.

Signed-off-by: Gülşah Köse <gulsah.kose@collabora.com>
Change-Id: Ife27f461639e6b034ac9071624d628cd35709191


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

