### PR TITLE
zotero: extract item key from item URL

### DIFF
--- a/browser/src/control/Control.Zotero.js
+++ b/browser/src/control/Control.Zotero.js
@@ -63,14 +63,17 @@ L.Control.Zotero = L.Control.extend({
 			var citationString = L.Util.trim(values.properties.plainCitation, this.settings.layout.prefix, this.settings.layout.suffix);
 			var citations = citationString.split(this.settings.layout.delimiter);
 			values.citationItems.forEach(function(item, i) {
-				var citationId = item.id.toString().substr(item.id.toString().indexOf('/')+1);
+				//zotero desktop versions do not store keys in cslJSON
+				//extract key from the item url
+				var itemUri = item.uris[0];
+				var citationId = itemUri.substr(itemUri.lastIndexOf('/')+1);
 				that.citationCluster[values.citationID].push(citationId);
 				that.citations[citationId] = L.Util.trim(citations[i], that.settings.group.prefix, that.settings.group.suffix);
 				that.setCitationNumber(that.citations[citationId]);
 			});
 		}
 
-		if (this.pendingCitationUpdate || this.previousNumberOfFields !== fields.length) {
+		if (this.pendingCitationUpdate || (this.previousNumberOfFields && this.previousNumberOfFields !== fields.length)) {
 			delete this.pendingCitationUpdate;
 			this.updateCitations(true);
 		}


### PR DESCRIPTION
online stores keys as item id,
but other softewares use numbers for id and no other fields store keys. keys are required in order to fetch the data from API. So extract the item key from item URL

Signed-off-by: Pranam Lashkari <lpranam@collabora.com>
Change-Id: Ib2d25df81f975d0e926627408047b79c624394fb


* Target version: master 


- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

