### PR TITLE
kit: default timeout to ~5 seconds when we get a negative wait.

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -2479,6 +2479,8 @@ void documentViewCallback(const int type, const char* payload, void* data)
 /// Called by LOK main-loop the central location for data processing.
 int pollCallback(void* pData, int timeoutUs)
 {
+    if (timeoutUs < 0)
+        timeoutUs = SocketPoll::DefaultPollTimeoutMicroS.count();
 #ifndef IOS
     if (!pData)
         return 0;


### PR DESCRIPTION
I can only assume that recent LOK's often don't have any lingering timeouts for cursor blinking or whatever, such that we get an infinite wait passed as a negative microseconds-count.

Best not to interpret that as a zero wait to avoid a busy loop.

Change-Id: If79228af969f4598f07681deb355c72f72602d19
Signed-off-by: Michael Meeks <michael.meeks@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

