### PR TITLE
Disable start/stop updates for Calc.

### DIFF
--- a/browser/src/control/Control.Header.js
+++ b/browser/src/control/Control.Header.js
@@ -521,9 +521,7 @@ L.Control.Header = L.Class.extend({
 		}
 	},
 
-	onNewDocumentTopLeft: function () {
-		this._updateCanvas();
-	},
+	onNewDocumentTopLeft: function () { },
 
 	onMouseWheel: function() {},
 });

--- a/browser/src/control/Control.RowHeader.js
+++ b/browser/src/control/Control.RowHeader.js
@@ -220,7 +220,6 @@ L.Control.RowHeader = L.Control.Header.extend({
 			};
 
 			this._map.sendUnoCommand('.uno:RowHeight', command);
-			//this.containerObject.requestReDraw();
 			this._mouseOverEntry = null;
 		}
 	},

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1060,7 +1060,7 @@ L.CanvasTileLayer = L.Layer.extend({
 				setTimeout(this.update.bind(this), 200);
 			}, this._painter);
 		}
-		else {
+		else if (this._docType !== 'spreadsheet') { // See scroll section. panBy is used for spreadsheets while scrolling.
 			this._map.on('movestart', this._painter.startUpdates, this._painter);
 			this._map.on('moveend', this._painter.stopUpdates, this._painter);
 		}

--- a/browser/src/layer/tile/ScrollSection.ts
+++ b/browser/src/layer/tile/ScrollSection.ts
@@ -579,7 +579,8 @@ class ScrollSection {
 			this.sectionProperties.drawVerticalScrollBar = true;
 			this.sectionProperties.mouseIsOnVerticalScrollBar = true;
 			this.sectionProperties.mapPane.style.cursor = 'pointer';
-			this.containerObject.requestReDraw();
+			if (!this.containerObject.draggingSomething && !(<any>window).mode.isDesktop())
+				this.containerObject.requestReDraw();
 		}
 	}
 
@@ -608,7 +609,8 @@ class ScrollSection {
 			this.sectionProperties.drawHorizontalScrollBar = true;
 			this.sectionProperties.mouseIsOnHorizontalScrollBar = true;
 			this.sectionProperties.mapPane.style.cursor = 'pointer';
-			this.containerObject.requestReDraw();
+			if (!this.containerObject.draggingSomething && !(<any>window).mode.isDesktop())
+				this.containerObject.requestReDraw();
 		}
 	}
 


### PR DESCRIPTION
Another method is used for Calc while scrolling.
Remove unnecessary call to draw in control.header.js Add condition for draw calls while scrolling on desktop view. Scroll bar is visible by default on desktop.

Remove commented-out code.

Signed-off-by: Gökay Şatır <gokaysatir@collabora.com>
Change-Id: Iaaa0267c63a9a92aa67786231baf53a625541440
Signed-off-by: Gökay Şatır <gokaysatir@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

