### PR TITLE
Switch focus to editor after JSDialog close event

### DIFF
--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -93,7 +93,6 @@ L.Control.JSDialog = L.Control.extend({
 		}
 		else {
 			this.clearDialog(id);
-			this.map.focus();
 		}
 	},
 
@@ -156,6 +155,21 @@ L.Control.JSDialog = L.Control.extend({
 		else if (data.action === 'close')
 		{
 			this.close(data.id, false);
+
+			// Manage focus
+			var dialogs = Object.keys(this.dialogs);
+			if (dialogs.length) {
+				var lastKey = dialogs[dialogs.length - 1];
+				var container = this.dialogs[lastKey].container;
+				container.focus();
+				var initialFocusElement =
+					container.querySelector('[tabIndex="0"]:not(.jsdialog-begin-marker)');
+				initialFocusElement.focus();
+			}
+			else if (!this.hasDialogOpened()) {
+				this._map.fire('editorgotfocus');
+			}
+
 			return;
 		}
 


### PR DESCRIPTION
Similar to  LokDialog _onDialogClose, after the closing a JSDialog we should change the focus editor again.

Signed-off-by: Gülşah Köse <gulsah.kose@collabora.com>
Change-Id: I348ead91838703590d5b9753d6028ff7f70f6111


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

