### PR TITLE
Limit line length in uglified bundle.js file

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -433,6 +433,7 @@ define bundle_all
 			-DCOOL_JS=$(INTERMEDIATE_DIR)/cool-src.js \
 			$(srcdir)/bundle.js.m4 > $(INTERMEDIATE_DIR)/bundle.js
 		@$(NODE) node_modules/uglify-js/bin/uglifyjs \
+			-O max_line_len=100 \
 			$(INTERMEDIATE_DIR)/bundle.js \
 			--output $@)
 endef


### PR DESCRIPTION
Helps in the hopefully rare cases where you need to see what code some error message points to. Otherwise bundle.js will have extremely long lines, and many editors have a hard time with such. (For example: Line 1, column 2949562.)

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: I229814e985348e94c8cda2d88b77ad1ea4b74ae7


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

