### PR TITLE
wsd: http: define named HTTP status codes

### DIFF
--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -928,7 +928,7 @@ protected:
             socket->setSocketBufferSize(0);
 #endif
 
-        http::Response httpResponse(http::StatusLine(101));
+        http::Response httpResponse(http::StatusCode::SwitchingProtocols);
         httpResponse.set("Upgrade", "websocket");
         httpResponse.set("Connection", "Upgrade");
         httpResponse.set("Sec-WebSocket-Accept", PublicComputeAccept::doComputeAccept(wsKey));

--- a/test/HttpTestServer.hpp
+++ b/test/HttpTestServer.hpp
@@ -123,7 +123,7 @@ private:
             }
             else
             {
-                http::Response response(http::StatusLine(200));
+                http::Response response(http::StatusCode::OK);
                 if (Util::startsWith(request.getUrl(), "/echo/"))
                 {
                     if (Util::startsWith(request.getUrl(), "/echo/chunked/"))
@@ -158,7 +158,7 @@ private:
         }
         else
         {
-            http::Response response(http::StatusLine(501));
+            http::Response response(http::StatusCode::NotImplemented);
             response.set("Content-Length", "0");
             socket->send(response);
         }

--- a/test/UnitWOPIAsyncUpload_Close.cpp
+++ b/test/UnitWOPIAsyncUpload_Close.cpp
@@ -59,8 +59,8 @@ public:
             LOK_ASSERT_EQUAL(std::string("false"), request.get("X-LOOL-WOPI-IsExitSave"));
 
             // Fail with error.
-            LOG_TST("assertPutFileRequest: returning 404 to simulate PutFile failure");
-            return Util::make_unique<http::Response>(http::StatusLine(404));
+            LOG_TST("Returning 500 to simulate PutFile failure");
+            return Util::make_unique<http::Response>(http::StatusCode::InternalServerError);
         }
 
         // This during closing the document.

--- a/test/UnitWOPIAsyncUpload_ModifyClose.cpp
+++ b/test/UnitWOPIAsyncUpload_ModifyClose.cpp
@@ -49,7 +49,7 @@ public:
 
             TRANSITION_STATE(_phase, Phase::WaitDestroy);
 
-            return Util::make_unique<http::Response>(http::StatusLine(200));
+            return Util::make_unique<http::Response>(http::StatusCode::OK);
         }
 
         // This during closing the document.

--- a/test/UnitWOPIFailUpload.cpp
+++ b/test/UnitWOPIFailUpload.cpp
@@ -122,7 +122,7 @@ public:
         }
 
         // Internal Server Error.
-        return Util::make_unique<http::Response>(http::StatusLine(500));
+        return Util::make_unique<http::Response>(http::StatusCode::InternalServerError);
     }
 
     bool onDocumentModified(const std::string& message) override
@@ -231,7 +231,7 @@ public:
             LOK_ASSERT_EQUAL(std::string("true"), request.get("X-COOL-WOPI-IsModifiedByUser"));
 
             // File unknown/User unauthorized.
-            return Util::make_unique<http::Response>(http::StatusLine(404));
+            return Util::make_unique<http::Response>(http::StatusCode::NotFound);
         }
 
         // This during closing the document.
@@ -520,7 +520,7 @@ public:
 
             // Fail with error.
             LOG_TST("Simulate PutFile failure");
-            return Util::make_unique<http::Response>(http::StatusLine(500));
+            return Util::make_unique<http::Response>(http::StatusCode::InternalServerError);
         }
 
         if (getCountPutFile() == 2)
@@ -528,7 +528,7 @@ public:
             LOG_TST("Second PutFile, which will also fail");
 
             LOG_TST("Simulate PutFile failure (again)");
-            return Util::make_unique<http::Response>(http::StatusLine(500));
+            return Util::make_unique<http::Response>(http::StatusCode::InternalServerError);
         }
 
         if (getCountPutFile() == 3)

--- a/test/UnitWOPIFileUrl.cpp
+++ b/test/UnitWOPIFileUrl.cpp
@@ -113,7 +113,7 @@ public:
                 std::ostringstream jsonStream;
                 fileInfo->stringify(jsonStream);
 
-                http::Response httpResponse(http::StatusLine(200));
+                http::Response httpResponse(http::StatusCode::OK);
                 httpResponse.set("Last-Modified", Util::getHttpTime(getFileLastModifiedTime()));
                 httpResponse.setBody(jsonStream.str(), "application/json; charset=utf-8");
                 socket->sendAndShutdown(httpResponse);

--- a/test/UnitWOPIHttpRedirect.cpp
+++ b/test/UnitWOPIHttpRedirect.cpp
@@ -98,7 +98,7 @@ public:
             std::ostringstream jsonStream;
             fileInfo->stringify(jsonStream);
 
-            http::Response httpResponse(http::StatusLine(200));
+            http::Response httpResponse(http::StatusCode::OK);
             httpResponse.set("Last-Modified", Util::getHttpTime(getFileLastModifiedTime()));
             httpResponse.setBody(jsonStream.str(), "application/json; charset=utf-8");
             socket->sendAndShutdown(httpResponse);
@@ -135,7 +135,7 @@ public:
             LOK_ASSERT_MESSAGE("Expected to be in Phase::Redirected2", _phase == Phase::Redirected2);
             _phase = Phase::Loaded;
 
-            http::Response httpResponse(http::StatusLine(200));
+            http::Response httpResponse(http::StatusCode::OK);
             httpResponse.set("Last-Modified", Util::getHttpTime(getFileLastModifiedTime()));
             httpResponse.setBody(getFileContent(), "text/plain; charset=utf-8");
             socket->sendAndShutdown(httpResponse);

--- a/test/UnitWOPITemplate.cpp
+++ b/test/UnitWOPITemplate.cpp
@@ -64,7 +64,7 @@ public:
             std::ostringstream jsonStream;
             fileInfo->stringify(jsonStream);
 
-            http::Response httpResponse(http::StatusLine(200));
+            http::Response httpResponse(http::StatusCode::OK);
             httpResponse.set("Last-Modified", Util::getHttpTime(getFileLastModifiedTime()));
             httpResponse.setBody(jsonStream.str(), "application/json; charset=utf-8");
             socket->sendAndShutdown(httpResponse);
@@ -123,7 +123,7 @@ public:
 
             const std::string body = "{\"LastModifiedTime\": \"" +
                                      Util::getIso8601FracformatTime(getFileLastModifiedTime()) + "\" }";
-            http::Response httpResponse(http::StatusLine(200));
+            http::Response httpResponse(http::StatusCode::OK);
             httpResponse.setBody(body, "application/json; charset=utf-8");
             socket->sendAndShutdown(httpResponse);
 

--- a/test/UnitWOPIWatermark.cpp
+++ b/test/UnitWOPIWatermark.cpp
@@ -58,7 +58,7 @@ public:
             std::ostringstream jsonStream;
             fileInfo->stringify(jsonStream);
 
-            http::Response httpResponse(http::StatusLine(200));
+            http::Response httpResponse(http::StatusCode::OK);
             httpResponse.set("Last-Modified", Util::getHttpTime(getFileLastModifiedTime()));
             httpResponse.setBody(jsonStream.str(), "application/json; charset=utf-8");
             socket->sendAndShutdown(httpResponse);
@@ -72,7 +72,7 @@ public:
 
             assertGetFileRequest(request);
 
-            http::Response httpResponse(http::StatusLine(200));
+            http::Response httpResponse(http::StatusCode::OK);
             httpResponse.set("Last-Modified", Util::getHttpTime(getFileLastModifiedTime()));
             httpResponse.setBody(getFileContent(), "text/plain; charset=utf-8");
             socket->sendAndShutdown(httpResponse);

--- a/test/WopiTestServer.hpp
+++ b/test/WopiTestServer.hpp
@@ -240,7 +240,7 @@ protected:
         std::ostringstream jsonStream;
         fileInfo->stringify(jsonStream);
 
-        http::Response httpResponse(http::StatusLine(200));
+        http::Response httpResponse(http::StatusCode::OK);
         httpResponse.set("Last-Modified", Util::getHttpTime(getFileLastModifiedTime()));
         httpResponse.setBody(jsonStream.str(), "application/json; charset=utf-8");
         socket->sendAndShutdown(httpResponse);
@@ -254,7 +254,7 @@ protected:
     virtual bool handleGetFileRequest(const Poco::Net::HTTPRequest&,
                                       std::shared_ptr<StreamSocket>& socket)
     {
-        http::Response httpResponse(http::StatusLine(200));
+        http::Response httpResponse(http::StatusCode::OK);
         httpResponse.set("Last-Modified", Util::getHttpTime(getFileLastModifiedTime()));
         httpResponse.setBody(getFileContent(), "application/octet-stream");
         socket->sendAndShutdown(httpResponse);
@@ -308,12 +308,12 @@ protected:
                 if (op == "LOCK" || op == "UNLOCK")
                 {
                     assertLockRequest(request);
-                    http::Response httpResponse(http::StatusLine(200));
+                    http::Response httpResponse(http::StatusCode::OK);
                     socket->sendAndShutdown(httpResponse);
                 }
                 else
                 {
-                    http::Response httpResponse(http::StatusLine(409));
+                    http::Response httpResponse(http::StatusCode::Conflict);
                     httpResponse.set("X-WOPI-LockFailureReason", "Invalid lock operation");
                     socket->sendAndShutdown(httpResponse);
                 }
@@ -343,7 +343,7 @@ protected:
                     content = "{ \"Name\":\"hello\", \"Url\":\"" + wopiURL + "\" }";
                 }
 
-                http::Response httpResponse(http::StatusLine(200));
+                http::Response httpResponse(http::StatusCode::OK);
                 httpResponse.set("Last-Modified", Util::getHttpTime(getFileLastModifiedTime()));
                 httpResponse.setBody(content, "application/json; charset=utf-8");
                 socket->sendAndShutdown(httpResponse);
@@ -364,7 +364,7 @@ protected:
                     Util::getIso8601FracformatTime(getFileLastModifiedTime());
                 if (wopiTimestamp != fileModifiedTime)
                 {
-                    http::Response httpResponse(http::StatusLine(409));
+                    http::Response httpResponse(http::StatusCode::Conflict);
                     httpResponse.setBody(
                         "{\"COOLStatusCode\":" +
                         std::to_string(static_cast<int>(COOLStatusCode::DocChanged)) + '}');
@@ -400,7 +400,7 @@ protected:
                                          "\" }";
                 LOG_TST("Fake wopi host (default) response to POST " << uriReq.getPath()
                                                                      << ": 200 OK " << body);
-                http::Response httpResponse(http::StatusLine(200));
+                http::Response httpResponse(http::StatusCode::OK);
                 httpResponse.setBody(body, "application/json; charset=utf-8");
                 socket->sendAndShutdown(httpResponse);
             }

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -3736,7 +3736,7 @@ private:
                 catch (const Poco::Net::NotAuthenticatedException& exc)
                 {
                     //LOG_ERR("FileServerRequestHandler::NotAuthenticated: " << exc.displayText());
-                    http::Response httpResponse(http::StatusLine(401));
+                    http::Response httpResponse(http::StatusCode::Unauthorized);
                     httpResponse.set("Content-Type", "text/html charset=UTF-8");
                     httpResponse.set("WWW-authenticate", "Basic realm=\"online\"");
                     socket->sendAndShutdown(httpResponse);
@@ -3829,7 +3829,7 @@ private:
 
             // Bad request.
             // NOTE: Check _wsState to choose between HTTP response or WebSocket (app-level) error.
-            http::Response httpResponse(http::StatusLine(400));
+            http::Response httpResponse(http::StatusCode::BadRequest);
             httpResponse.set("Content-Length", "0");
             socket->sendAndShutdown(httpResponse);
             socket->ignoreInput();
@@ -3893,7 +3893,7 @@ private:
         const std::string mimeType = "text/plain";
         const std::string responseString = "OK";
 
-        http::Response httpResponse(http::StatusLine(200));
+        http::Response httpResponse(http::StatusCode::OK);
         httpResponse.set("Content-Length", std::to_string(responseString.size()));
         httpResponse.set("Content-Type", mimeType);
         httpResponse.set("Last-Modified", Util::getHttpTimeNow());
@@ -3940,7 +3940,7 @@ private:
             srvUrl = requestDetails.getProxyPrefix();
         Poco::replaceInPlace(xml, std::string("%SRV_URI%"), srvUrl);
 
-        http::Response httpResponse(http::StatusLine(200));
+        http::Response httpResponse(http::StatusCode::OK);
         httpResponse.setBody(xml, "text/xml");
         httpResponse.set("Last-Modified", Util::getHttpTimeNow());
         httpResponse.set("X-Content-Type-Options", "nosniff");
@@ -3958,7 +3958,7 @@ private:
 
         const std::string capabilities = getCapabilitiesJson(request, socket);
 
-        http::Response httpResponse(http::StatusLine(200));
+        http::Response httpResponse(http::StatusCode::OK);
         httpResponse.set("Last-Modified", Util::getHttpTimeNow());
         httpResponse.setBody(capabilities, "application/json");
         httpResponse.set("X-Content-Type-Options", "nosniff");
@@ -4003,7 +4003,7 @@ private:
             LOG_ERR(errMsg);
 
             // we got the wrong request.
-            http::Response httpResponse(http::StatusLine(400));
+            http::Response httpResponse(http::StatusCode::BadRequest);
             httpResponse.set("Content-Length", "0");
             socket->sendAndShutdown(httpResponse);
             socket->ignoreInput();
@@ -4077,7 +4077,7 @@ private:
         LOG_DBG("HTTP request: " << request.getURI());
         const std::string responseString = "User-agent: *\nDisallow: /\n";
 
-        http::Response httpResponse(http::StatusLine(200));
+        http::Response httpResponse(http::StatusCode::OK);
         httpResponse.set("Last-Modified", Util::getHttpTimeNow());
         httpResponse.set("Content-Length", std::to_string(responseString.size()));
         httpResponse.set("Content-Type", "text/plain");
@@ -4130,7 +4130,7 @@ private:
             LOG_ERR(errMsg);
 
             // we got the wrong request.
-            http::Response httpResponse(http::StatusLine(400));
+            http::Response httpResponse(http::StatusCode::BadRequest);
             httpResponse.set("Content-Length", "0");
             socket->sendAndShutdown(httpResponse);
             socket->ignoreInput();
@@ -4149,7 +4149,7 @@ private:
                     "Unknown DocBroker reference in media URL: " + request.getURI();
                 LOG_ERR(errMsg);
 
-                http::Response httpResponse(http::StatusLine(400));
+                http::Response httpResponse(http::StatusCode::BadRequest);
                 httpResponse.set("Content-Length", "0");
                 socket->sendAndShutdown(httpResponse);
                 socket->ignoreInput();
@@ -4342,7 +4342,7 @@ private:
             if (!allowConvertTo(socket->clientAddress(), request))
             {
                 LOG_WRN("Conversion requests not allowed from this address: " << socket->clientAddress());
-                http::Response httpResponse(http::StatusLine(403));
+                http::Response httpResponse(http::StatusCode::Forbidden);
                 httpResponse.set("Content-Length", "0");
                 socket->sendAndShutdown(httpResponse);
                 socket->ignoreInput();
@@ -4386,7 +4386,7 @@ private:
                         && strcasecmp(pdfVer.c_str(), "PDF-1.5") && strcasecmp(pdfVer.c_str(), "PDF-1.6"))
                     {
                         LOG_ERR("Wrong PDF type: " << pdfVer << ". Conversion aborted.");
-                        http::Response httpResponse(http::StatusLine(400));
+                        http::Response httpResponse(http::StatusCode::BadRequest);
                         httpResponse.set("Content-Length", "0");
                         socket->sendAndShutdown(httpResponse);
                         socket->ignoreInput();
@@ -4461,7 +4461,7 @@ private:
 
                     handler.takeFile();
 
-                    http::Response httpResponse(http::StatusLine(200));
+                    http::Response httpResponse(http::StatusCode::OK);
                     httpResponse.set("Content-Length", "0");
                     socket->sendAndShutdown(httpResponse);
                     socket->ignoreInput();
@@ -4545,7 +4545,7 @@ private:
                 else
                     LOG_ERR("Download with id [" << downloadId << "] not found.");
 
-                http::Response httpResponse(http::StatusLine(404));
+                http::Response httpResponse(http::StatusCode::NotFound);
                 httpResponse.set("Content-Length", "0");
                 socket->sendAndShutdown(httpResponse);
             }

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -3736,7 +3736,7 @@ bool RenderSearchResultBroker::handleInput(const std::shared_ptr<Message>& messa
 
                 std::string aDataString(_aResposeData.data(), _aResposeData.size());
                 // really not ideal that the response works only with std::string
-                http::Response httpResponse(http::StatusLine(200));
+                http::Response httpResponse(http::StatusCode::OK);
                 httpResponse.setBody(aDataString, "image/png");
                 httpResponse.set("Connection", "close");
                 _socket->sendAndShutdown(httpResponse);

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -445,7 +445,7 @@ bool FileServerRequestHandler::isAdminLoggedIn(const HTTPRequest& request,
                 const std::string fileModifiedTime = Util::getIso8601FracformatTime(LocalFileInfo::fileInfoVec[i].fileLastModifiedTime);
                 if (wopiTimestamp != fileModifiedTime)
                 {
-                    http::Response httpResponse(http::StatusLine(409));
+                    http::Response httpResponse(http::StatusCode::Conflict);
                     httpResponse.setBody(
                         "{\"COOLStatusCode\":" +
                         std::to_string(static_cast<int>(LocalFileInfo::COOLStatusCode::DocChanged)) + ',' +
@@ -469,7 +469,7 @@ bool FileServerRequestHandler::isAdminLoggedIn(const HTTPRequest& request,
             const std::string body = "{\"LastModifiedTime\": \"" +
                                         Util::getIso8601FracformatTime(LocalFileInfo::fileInfoVec[i].fileLastModifiedTime) +
                                         "\" }";
-            http::Response httpResponse(http::StatusLine(200));
+            http::Response httpResponse(http::StatusCode::OK);
             httpResponse.setBody(body);
             socket->send(httpResponse);
             return;


### PR DESCRIPTION
This replaces the hard-coded status-code
numbers with named compile-time constants.

Change-Id: Ibe678fb2c533b29efd696e4430f5377523eeb298
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
