### PR TITLE
jsdialog: listbox doesnt need tabindex

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -1822,7 +1822,6 @@ L.Control.JSDialogBuilder = L.Control.extend({
 
 		var listbox = L.DomUtil.create('select', builder.options.cssClass + ' ui-listbox ', container);
 		listbox.id = data.id + '-input';
-		listbox.tabIndex = '0';
 		var listboxArrow = L.DomUtil.create('span', builder.options.cssClass + ' ui-listbox-arrow', container);
 		listboxArrow.id = 'listbox-arrow-' + data.id;
 


### PR DESCRIPTION
it confuses our selectors for focus widgets when
widget is hidden. unfortunately this property was
added to the inner node not top one so we don't see .hidden class. listbox doesn't need tabindex at all so just remove it
