### PR TITLE
calcRTL: sync map area after RTL mode switch

### DIFF
--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -646,6 +646,7 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 			this._layoutIsRTL = true;
 
 			sectionContainer.reNewAllSections(true);
+			this._syncTileContainerSize();
 
 		} else if (!sheetIsRTL && this._layoutIsRTL === true) {
 
@@ -683,7 +684,7 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 			tilesSection.anchor = [[L.CSections.ColumnHeader.name, 'bottom', 'top'], [L.CSections.RowHeader.name, 'right', 'left']];
 
 			sectionContainer.reNewAllSections(true);
-
+			this._syncTileContainerSize();
 		}
 	},
 


### PR DESCRIPTION
Signed-off-by: Dennis Francis <dennis.francis@collabora.com>
Change-Id: Ie5ff495d5ea6a75963f0379bbb670b3d04f6c656


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
calcRTL: sync map area after RTL mode switch using uno command else there will be an offset in x direction due to the changed position of row headers.

### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

