### PR TITLE
Fix dropdown's arrow position

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -519,7 +519,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	font-family: var(--jquery-ui-font);
 	border: 1px solid #CCC;
 	border-radius: var(--border-radius);
-	padding: 0 4px;
+	padding: 0 14px 0 4px;
 	background-color: #F1F1F1;
 }
 


### PR DESCRIPTION
Before this commit, the text in a dropdown could be overlapped by the
triangle (arrow). Example: Insert > Page number dialog

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I770acb10b89239bce280cf44ad56b9ec2c3a8264
