### PR TITLE
Fix disabled buttons inconsistencies

### DIFF
--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -74,6 +74,16 @@ button:not(.ui-corner-all):not(.button-primary) {
 	display: initial !important;
 }
 
+.ui-pushbutton[disabled] {
+	color: var(--color-text-lighter) !important;
+	background-color: white !important;
+}
+
+.ui-pushbutton[disabled]:hover {
+	cursor: not-allowed !important;
+	background: white !important;
+}
+
 /* button box */
 
 /* - Add fallback for browsers without support


### PR DESCRIPTION
Primary buttons, secondary buttons and others are getting styled
differently for the same 'disabled' status. Plus, they are react
on hover which can lead the user to wrongly think they are active.
 - Fix inconsistencies and make it clear that they are all disabled

Example dialog: Find and replace

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I45be52ecda264d0af9a53a70c222d1047a3cdf73
