### PR TITLE
Export PDF to storage

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2703,6 +2703,14 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		if (!data.command)
 			data.command = data.id;
 
+		if (data.id && data.id !== 'exportas' && data.id.startsWith('export')) {
+			var format = data.id.substring('export'.length);
+			builder.map._docLayer.registerExportFormat(data.text, format);
+
+			if (builder.map['wopi'].HideExportOption)
+				return false;
+		}
+
 		if (data.inlineLabel !== undefined) {
 			var backupInlineText = builder.options.useInLineLabelsForUnoButtons;
 			builder.options.useInLineLabelsForUnoButtons = data.inlineLabel;

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2348,6 +2348,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			'formatsparklinemenu': 'insertsparkline',
 			'insertdatecontentcontrol': 'datefield',
 			'editheaderandfooter': 'headerandfooter',
+			'exportas': 'saveas',
 			'insertheaderfooter': 'headerandfooter',
 			'previoustrackedchange': 'prevrecord',
 			'fieldtransparency': 'linetransparency',

--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -69,6 +69,9 @@ L.Control.Menubar = L.Control.extend({
 					{name: _('Word Document (.docx)'), id: 'saveas-docx', type: 'action'},
 					{name: _('Rich Text (.rtf)'), id: 'saveas-rtf', type: 'action'},
 				]},
+				{name: _('Export as'), id: 'exportas', type: 'menu', menu: [
+					{name: _('PDF Document (.pdf)'), id: 'exportas-pdf', type: 'action'}
+				]},
 				{name: _('Share...'), id:'shareas', type: 'action'},
 				{name: _('See revision history'), id: 'rev-history', type: 'action'},
 				{name: !window.ThisIsAMobileApp ? _('Download as') : _('Export as'), id: 'downloadas', type: 'menu', menu: [
@@ -359,6 +362,9 @@ L.Control.Menubar = L.Control.extend({
 					{name: _('PowerPoint 2003 Presentation (.ppt)'), id: 'saveas-ppt', type: 'action'},
 					{name: _('PowerPoint Presentation (.pptx)'), id: 'saveas-pptx', type: 'action'},
 				]},
+				{name: _('Export as'), id: 'exportas', type: 'menu', menu: [
+					{name: _('PDF Document (.pdf)'), id: 'exportas-pdf', type: 'action'}
+				]},
 				{name: _('Save Comments'), id: 'savecomments', type: 'action'},
 				{name: _('Share...'), id:'shareas', type: 'action'},
 				{name: _('See revision history'), id: 'rev-history', type: 'action'},
@@ -497,6 +503,9 @@ L.Control.Menubar = L.Control.extend({
 			{name: _UNO('.uno:PickList', 'presentation'), id: 'file', type: 'menu', menu: [
 				{name: L.Control.MenubarShortcuts.addShortcut(_UNO('.uno:Save', 'presentation'), L.Control.MenubarShortcuts.shortcuts.SAVE), id: 'save', type: 'action'},
 				{name: _UNO('.uno:SaveAs', 'presentation'), id: 'saveas', type: 'action'},
+				{name: _('Export as'), id: 'exportas', type: 'menu', menu: [
+					{name: _('PDF Document (.pdf)'), id: 'exportas-pdf', type: 'action'}
+				]},
 				{name: _('Save Comments'), id: 'savecomments', type: 'action'},
 				{name: _('Share...'), id:'shareas', type: 'action'},
 				{name: _UNO('.uno:Print', 'presentation'), id: 'print', type: 'action'},
@@ -618,6 +627,9 @@ L.Control.Menubar = L.Control.extend({
 					{name: _('ODF spreadsheet (.ods)'), id: 'saveas-ods', type: 'action'},
 					{name: _('Excel 2003 Spreadsheet (.xls)'), id: 'saveas-xls', type: 'action'},
 					{name: _('Excel Spreadsheet (.xlsx)'), id: 'saveas-xlsx', type: 'action'},
+				]},
+				{name: _('Export as'), id: 'exportas', type: 'menu', menu: [
+					{name: _('PDF Document (.pdf)'), id: 'exportas-pdf', type: 'action'}
 				]},
 				{name: _('Share...'), id:'shareas', type: 'action'},
 				{name: _('See revision history'), id: 'rev-history', type: 'action'},
@@ -1988,6 +2000,9 @@ L.Control.Menubar = L.Control.extend({
 			return false;
 
 		if (menuItem.id && (menuItem.id === 'saveas' || menuItem.id.startsWith('saveas-')) && this._map['wopi'].UserCanNotWriteRelative)
+			return false;
+
+		if (menuItem.id && (menuItem.id.startsWith('exportas')) && this._map['wopi'].UserCanNotWriteRelative)
 			return false;
 
 		if ((menuItem.id === 'shareas' || menuItem.id === 'ShareAs') && !this._map['wopi'].EnableShare)

--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -2033,6 +2033,11 @@ L.Control.Menubar = L.Control.extend({
 				return false;
 		}
 
+		if (menuItem.id && this._map['wopi'].HideExportOption
+			&& (menuItem.id.startsWith('export'))) {
+			return false;
+		}
+
 		if (this._hiddenItems &&
 		    $.inArray(menuItem.id, this._hiddenItems) !== -1)
 			return false;

--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -1739,17 +1739,9 @@ L.Control.Menubar = L.Control.extend({
 		} else if (id === 'print') {
 			this._map.print();
 		} else if (id.startsWith('downloadas-')) {
-			var format = id.substring('downloadas-'.length);
-			var fileName = this._map['wopi'].BaseFileName;
-			fileName = fileName.substr(0, fileName.lastIndexOf('.'));
-			fileName = fileName === '' ? 'document' : fileName;
-			this._map.downloadAs(fileName + '.' + format, format);
+			this._map.dispatch(id);
 		} else if (id.startsWith('saveas-')) {
-			var format = id.substring('saveas-'.length);
-			var fileName = this._map['wopi'].BaseFileName;
-			fileName = fileName.substr(0, fileName.lastIndexOf('.'));
-			fileName = fileName === '' ? 'document' : fileName;
-			this._map.openSaveAs(format);
+			this._map.dispatch(id);
 		} else if (id === 'signdocument') {
 			this._map.showSignDocument();
 		} else if (id === 'insertcomment') {

--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -2033,9 +2033,14 @@ L.Control.Menubar = L.Control.extend({
 				return false;
 		}
 
-		if (menuItem.id && this._map['wopi'].HideExportOption
-			&& (menuItem.id.startsWith('export'))) {
-			return false;
+		if (menuItem.id && menuItem.id.startsWith('export')) {
+			if (!menuItem.id.startsWith('exportas-')) {
+				var format = menuItem.id.substring('export'.length);
+				this._map._docLayer.registerExportFormat(menuItem.name, format);
+			}
+
+			if (this._map['wopi'].HideExportOption)
+				return false;
 		}
 
 		if (this._hiddenItems &&

--- a/browser/src/control/Control.NotebookbarBuilder.js
+++ b/browser/src/control/Control.NotebookbarBuilder.js
@@ -407,8 +407,10 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 
 		var isDownloadAsGroup = data.id === 'downloadas';
 		var isSaveAsGroup = data.id === 'saveas';
+		var isExportAsGroup = data.id === 'exportas';
 		var options = {};
-		if (isDownloadAsGroup || isSaveAsGroup) {
+		var hasCustomMenu = isDownloadAsGroup || isSaveAsGroup || isExportAsGroup;
+		if (hasCustomMenu) {
 			options.hasDropdownArrow = true;
 		}
 
@@ -417,7 +419,7 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 		$(control.container).unbind('click.toolbutton');
 		if (!builder.map.isLockedItem(data)) {
 			$(control.container).click(function () {
-				if (!isDownloadAsGroup && !isSaveAsGroup) {
+				if (!hasCustomMenu) {
 					L.control.menubar()._executeAction.bind({_map: builder.options.map})(undefined, {id: data.id});
 					return;
 				}
@@ -462,6 +464,8 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 			return builder._getDownloadAsSubmenuOpts(docType);
 		case 'saveas':
 			return builder._getSaveAsSubmenuOpts(docType);
+		case 'exportas':
+			return builder._getExportAsSubmenuOpts(docType);
 		}
 	},
 
@@ -604,6 +608,46 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 				{
 					'id': 'saveas-ppt',
 					'text': _('PowerPoint 2003 Presentation (.ppt)')
+				}
+			];
+		}
+
+		submenuOpts.forEach(function mapIconToItem(menuItem) {
+			menuItem.icon = menuItem.id + '-submenu-icon';
+		});
+
+		return submenuOpts;
+	},
+
+	_getExportAsSubmenuOpts: function(docType) {
+		var submenuOpts = [];
+
+		if (docType === 'text') {
+			submenuOpts = [
+				{
+					'id': 'exportas-pdf',
+					'text': _('PDF Document (.pdf)')
+				}
+			];
+		} else if (docType === 'spreadsheet') {
+			submenuOpts = [
+				{
+					'id': 'exportas-pdf',
+					'text': _('PDF Document (.pdf)')
+				}
+			];
+		} else if (docType === 'presentation') {
+			submenuOpts = [
+				{
+					'id': 'exportas-pdf',
+					'text': _('PDF Document (.pdf)')
+				}
+			];
+		} else if (docType === 'drawing') {
+			submenuOpts = [
+				{
+					'id': 'exportas-pdf',
+					'text': _('PDF Document (.pdf)')
 				}
 			];
 		}

--- a/browser/src/control/Control.NotebookbarBuilder.js
+++ b/browser/src/control/Control.NotebookbarBuilder.js
@@ -627,6 +627,10 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 				{
 					'id': 'exportas-pdf',
 					'text': _('PDF Document (.pdf)')
+				},
+				{
+					'id': 'exportas-epub',
+					'text': _('EPUB (.epub)')
 				}
 			];
 		} else if (docType === 'spreadsheet') {

--- a/browser/src/control/Control.NotebookbarBuilder.js
+++ b/browser/src/control/Control.NotebookbarBuilder.js
@@ -415,6 +415,7 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 		}
 
 		var control = builder._unoToolButton(parentContainer, data, builder, options);
+		var submenuOpts = builder._getSubmenuOpts(builder.options.map._docLayer._docType, data.id, builder);
 
 		$(control.container).unbind('click.toolbutton');
 		if (!builder.map.isLockedItem(data)) {
@@ -424,8 +425,6 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 					return;
 				}
 
-				var submenuOpts = builder._getSubmenuOpts(builder.options.map._docLayer._docType, data.id, builder);
-
 				$(control.container).w2menu({
 					items: submenuOpts,
 					onSelect: function (event) {
@@ -433,6 +432,19 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 					}
 				});
 			});
+		}
+
+		for (var i in submenuOpts) {
+			var item = submenuOpts[i];
+
+			if (item.id.startsWith('export')) {
+				var format = item.id.substring('export'.length);
+				builder.map._docLayer.registerExportFormat(item.text, format);
+			}
+			else if (item.id.startsWith('downloadas-')) {
+				var format = item.id.substring('downloadas-'.length);
+				builder.map._docLayer.registerExportFormat(item.text, format);
+			}
 		}
 	},
 
@@ -467,6 +479,7 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 		case 'exportas':
 			return builder._getExportAsSubmenuOpts(docType);
 		}
+		return [];
 	},
 
 	_getDownloadAsSubmenuOpts: function(docType) {

--- a/browser/src/control/Control.NotebookbarBuilder.js
+++ b/browser/src/control/Control.NotebookbarBuilder.js
@@ -427,7 +427,7 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 				$(control.container).w2menu({
 					items: submenuOpts,
 					onSelect: function (event) {
-						L.control.menubar()._executeAction.bind({_map: builder.options.map})(undefined, {id: event.item.id});
+						builder.map.dispatch(event.item.id);
 					}
 				});
 			});

--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -122,6 +122,14 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 			}
 		}
 
+		if (hasSaveAs) {
+			content.push({
+				'id': 'exportas',
+				'type': 'bigmenubartoolitem',
+				'text': _('Export As'),
+			});
+		}
+
 		content = content.concat([
 			{
 				'id': 'file-shareas-rev-history',

--- a/browser/src/control/Control.NotebookbarDraw.js
+++ b/browser/src/control/Control.NotebookbarDraw.js
@@ -140,6 +140,12 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 					'text': _UNO('.uno:SaveAs', 'presentation'),
 					'command': '.uno:SaveAs'
 				} : {},
+			hasSaveAs ?
+				{
+					'id': 'exportas',
+					'type': 'bigmenubartoolitem',
+					'text': _('Export As'),
+				} : {},
 			{
 				'id': 'file-shareas-rev-history',
 				'type': 'container',

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -174,6 +174,14 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 			}
 		}
 
+		if (hasSaveAs) {
+			content.push({
+				'id': 'exportas',
+				'type': 'bigmenubartoolitem',
+				'text': _('Export As'),
+			});
+		}
+
 		var content = content.concat([
 			{
 				'id': 'file-shareas-rev-history',

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -136,6 +136,14 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 			}
 		}
 
+		if (hasSaveAs) {
+			content.push({
+				'id': 'exportas',
+				'type': 'bigmenubartoolitem',
+				'text': _('Export As'),
+			});
+		}
+
 		content = content.concat([
 			{
 				'type': 'container',

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -273,6 +273,14 @@ L.Map.include({
 			'options=' + options);
 	},
 
+	exportAs: function (url) {
+		if (url === undefined || url == null) {
+			return;
+		}
+
+		app.socket.sendMessage('exportas url=wopi:' + encodeURIComponent(url));
+	},
+
 	renameFile: function (filename) {
 		if (!filename) {
 			return;
@@ -818,6 +826,10 @@ L.Map.include({
 			fileName = fileName.substr(0, fileName.lastIndexOf('.'));
 			fileName = fileName === '' ? 'document' : fileName;
 			this.downloadAs(fileName + '.' + format, format);
+			return;
+		} if (action.indexOf('exportas-') === 0) {
+			var format = action.substring('exportas-'.length);
+			this.openSaveAs(format);
 			return;
 		}
 

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -808,6 +808,19 @@ L.Map.include({
 
 	// map.dispatch() will be used to call some actions so we can share the code
 	dispatch: function(action) {
+		if (action.indexOf('saveas-') === 0) {
+			var format = action.substring('saveas-'.length);
+			this.openSaveAs(format);
+			return;
+		} else if (action.indexOf('downloadas-') === 0) {
+			var format = action.substring('downloadas-'.length);
+			var fileName = this['wopi'].BaseFileName;
+			fileName = fileName.substr(0, fileName.lastIndexOf('.'));
+			fileName = fileName === '' ? 'document' : fileName;
+			this.downloadAs(fileName + '.' + format, format);
+			return;
+		}
+
 		switch (action) {
 		case 'acceptformula':
 			{
@@ -902,6 +915,8 @@ L.Map.include({
 				});
 			}
 			break;
+		default:
+			console.error('unknown dispatch: "' + action + '"');
 		}
 	},
 });

--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -1122,6 +1122,9 @@ app.definitions.Socket = L.Class.extend({
 		else if (textMsg.startsWith('saveas:') || textMsg.startsWith('renamefile:')) {
 			this._renameOrSaveAsCallback(textMsg, command);
 		}
+		else if (textMsg.startsWith('exportas:')) {
+			this._exportAsCallback(command);
+		}
 		else if (textMsg.startsWith('warn:')) {
 			var len = 'warn: '.length;
 			textMsg = textMsg.substring(len);
@@ -1250,6 +1253,11 @@ app.definitions.Socket = L.Class.extend({
 		if (this._map._docLayer && !msgDelayed) {
 			this._map._docLayer._onMessage(textMsg, e.image);
 		}
+	},
+
+	_exportAsCallback: function(command) {
+		this._map.hideBusy();
+		this._map.uiManager.showInfoModal('exported-success', _('Exported to storage'), _('Successfully exported: ') + decodeURIComponent(command.filename), '', _('OK'));
 	},
 
 	_renameOrSaveAsCallback: function(textMsg, command) {

--- a/browser/src/map/handler/Map.WOPI.js
+++ b/browser/src/map/handler/Map.WOPI.js
@@ -432,8 +432,20 @@ L.Map.WOPI = L.Handler.extend({
 			if (msg.Values) {
 				if (msg.Values.Filename !== null && msg.Values.Filename !== undefined) {
 					this._notifySave = msg.Values['Notify'];
-					this._map.showBusy(_('Creating copy...'), false);
-					this._map.saveAs(msg.Values.Filename);
+					var dotPos = msg.Values.Filename.indexOf('.');
+					var format = undefined;
+					if (dotPos > 0)
+						format = msg.Values.Filename.substr(dotPos + 1);
+					else
+						console.warn('Action_SaveAs: no format specified');
+
+					var isExport = format === 'pdf' || format === 'epub';
+					if (isExport) {
+						this._map.exportAs(msg.Values.Filename);
+					} else {
+						this._map.showBusy(_('Creating copy...'), false);
+						this._map.saveAs(msg.Values.Filename, format);
+					}
 				}
 			}
 		}

--- a/common/FileUtil.cpp
+++ b/common/FileUtil.cpp
@@ -568,6 +568,11 @@ namespace FileUtil
         return AnonymizeUserData ? Util::anonymize(username, AnonymizationSalt) : username;
     }
 
+    std::string extractFileExtension(const std::string& path)
+    {
+        return Util::splitLast(path, '.', true).second;
+    }
+
 } // namespace FileUtil
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/common/FileUtil.hpp
+++ b/common/FileUtil.hpp
@@ -124,6 +124,9 @@ namespace FileUtil
         return realpath(path.c_str());
     }
 
+    /// Returns file extension from the path
+    std::string extractFileExtension(const std::string& path);
+
     /// Returns true iff the two files both exist, can be read,
     /// have equal size and every byte of their contents match.
     bool compareFileContents(const std::string& rhsPath, const std::string& lhsPath);

--- a/kit/ChildSession.hpp
+++ b/kit/ChildSession.hpp
@@ -292,6 +292,7 @@ private:
     bool resizeWindow(const StringVector& tokens);
     bool resetSelection(const StringVector& tokens);
     bool saveAs(const StringVector& tokens);
+    bool exportAs(const StringVector& tokens);
     bool setClientPart(const StringVector& tokens);
     bool selectClientPart(const StringVector& tokens);
     bool moveSelectedClientParts(const StringVector& tokens);
@@ -375,6 +376,9 @@ private:
 
     /// How many sessions / clients we have
     static size_t NumSessions;
+
+    /// stores wopi url for export as operation
+    std::string _exportAsWopiUrl;
 };
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1001,6 +1001,7 @@ bool ClientSession::_handleInput(const char *buffer, int length)
              tokens.equals(0, "requestloksession") ||
              tokens.equals(0, "resetselection") ||
              tokens.equals(0, "saveas") ||
+             tokens.equals(0, "exportas") ||
              tokens.equals(0, "selectgraphic") ||
              tokens.equals(0, "selecttext") ||
              tokens.equals(0, "windowselecttext") ||
@@ -1338,7 +1339,8 @@ bool ClientSession::filterMessage(const std::string& message) const
     {
         // By default, don't allow anything
         allowed = false;
-        if (tokens.equals(0, "userinactive") || tokens.equals(0, "useractive") || tokens.equals(0, "saveas") || tokens.equals(0, "rendersearchresult"))
+        if (tokens.equals(0, "userinactive") || tokens.equals(0, "useractive") || tokens.equals(0, "saveas")
+            || tokens.equals(0, "rendersearchresult") || tokens.equals(0, "exportas"))
         {
             allowed = true;
         }
@@ -1605,8 +1607,9 @@ bool ClientSession::handleKitToClientMessage(const std::shared_ptr<Message>& pay
          }
     }
 #if !MOBILEAPP
-    else if (tokens.size() == 3 && tokens.equals(0, "saveas:"))
+    else if (tokens.size() == 3 && (tokens.equals(0, "saveas:") || tokens.equals(0, "exportas:")))
     {
+        bool isExportAs = tokens.equals(0, "exportas:");
 
         std::string encodedURL;
         if (!getTokenString(tokens[1], "url", encodedURL))
@@ -1683,7 +1686,7 @@ bool ClientSession::handleKitToClientMessage(const std::shared_ptr<Message>& pay
                 // this also sends the saveas: result
                 LOG_TRC("Save-as path: " << resultURL.getPath());
                 docBroker->uploadAsToStorage(client_from_this(), resultURL.getPath(), wopiFilename,
-                                             false);
+                                             false, isExportAs);
             }
             else
                 sendTextFrameAndLogError("error: cmd=storage kind=savefailed");

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -305,7 +305,7 @@ public:
     /// @param uploadAsPath Absolute path to the jailed file.
     void uploadAsToStorage(const std::shared_ptr<ClientSession>& session,
                            const std::string& uploadAsPath, const std::string& uploadAsFilename,
-                           const bool isRename);
+                           const bool isRename, const bool isExport);
 
     /// Uploads the document right after loading from a template.
     /// Template-loading requires special handling because the
@@ -611,7 +611,7 @@ private:
     /// Upload the doc to the storage.
     void uploadToStorageInternal(const std::shared_ptr<ClientSession>& session,
                                  const std::string& saveAsPath, const std::string& saveAsFilename,
-                                 const bool isRename, const bool force);
+                                 const bool isRename, const bool isExport, const bool force);
 
     /// Handles the completion of uploading to storage, both success and failure cases.
     void handleUploadToStorageResponse(const StorageBase::UploadResult& uploadResult);
@@ -1061,12 +1061,13 @@ private:
         UploadRequest(std::string uriAnonym,
                       std::chrono::system_clock::time_point newFileModifiedTime,
                       const std::shared_ptr<class ClientSession>& session, bool isSaveAs,
-                      bool isRename)
+                      bool isExport, bool isRename)
             : _startTime(std::chrono::steady_clock::now())
             , _uriAnonym(std::move(uriAnonym))
             , _newFileModifiedTime(newFileModifiedTime)
             , _session(session)
             , _isSaveAs(isSaveAs)
+            , _isExport(isExport)
             , _isRename(isRename)
         {
         }
@@ -1085,6 +1086,7 @@ private:
 
         std::shared_ptr<class ClientSession> session() const { return _session.lock(); }
         bool isSaveAs() const { return _isSaveAs; }
+        bool isExport() const { return _isExport; }
         bool isRename() const { return _isRename; }
 
     private:
@@ -1093,6 +1095,7 @@ private:
         const std::chrono::system_clock::time_point _newFileModifiedTime;
         const std::weak_ptr<class ClientSession> _session;
         const bool _isSaveAs;
+        const bool _isExport;
         const bool _isRename;
     };
 


### PR DESCRIPTION
It allows to export PDF directly to the storage, without need to download it.

This is copy of the save as functionality flow (reuses interaction with integrator)

`Save as` scenario looks like:
1. we sent UI_SaveAs to integrator
2. Integrator opens dialog, user selects target file name, integrator sends response to us
3. client sends to server `saveas` with target file name and format
4. we export file locally on the server
5. server uploads local file to the integrator's storage
6. server sends message to the client
7. client reloads app, by opening new file

Differences in export:
* In point 4. we use uno command to open additional dialog with options. After that we receive callback: LOK_CALLBACK_EXPORT_FILE with: PENDING or ABORT status. Then again after file was exported we got LOK_CALLBACK_EXPORT_FILE with exported local file path.
* In point 7. we don't reopen newly exported file. We only show the message to the user about successful operation with file name.