### PR TITLE
After one the previews is clicked, allow using the arrow keys for nav…

### DIFF
--- a/browser/src/map/handler/Map.Keyboard.js
+++ b/browser/src/map/handler/Map.Keyboard.js
@@ -362,14 +362,20 @@ L.Map.Keyboard = L.Handler.extend({
 			return;
 		}
 		else if (this._map._docLayer._docType === 'presentation' || this._map._docLayer._docType === 'drawing' && this._map._docLayer._preview.partsFocused === true) {
-			if (!this.modifier && (ev.keyCode === this.keyCodes.DOWN || ev.keyCode === this.keyCodes.UP || ev.keyCode === this.keyCodes.RIGHT || ev.keyCode === this.keyCodes.LEFT) && ev.type === 'keydown') {
+			if (!this.modifier && (ev.keyCode === this.keyCodes.DOWN || ev.keyCode === this.keyCodes.UP || ev.keyCode === this.keyCodes.RIGHT || ev.keyCode === this.keyCodes.LEFT
+				|| ev.keyCode === this.keyCodes.DELETE || ev.keyCode === this.keyCodes.BACKSPACE) && ev.type === 'keydown') {
 				var partToSelect = (ev.keyCode === this.keyCodes.UP || ev.keyCode === this.keyCodes.LEFT) ? 'prev' : 'next';
-				this._map.setPart(partToSelect);
-				if (app.file.fileBasedView)
-					this._map._docLayer._checkSelectedPart();
+				var deletePart = (ev.keyCode === this.keyCodes.DELETE || ev.keyCode === this.keyCodes.BACKSPACE) ? true: false;
 
+				if (!deletePart) {
+					this._map.setPart(partToSelect);
+					if (app.file.fileBasedView)
+						this._map._docLayer._checkSelectedPart();
+				}
+				else if (this._map.isEditMode() && !app.file.fileBasedView) {
+					this._map.deletePage(this._map._docLayer._selectedPart);
+				}
 				ev.preventDefault();
-				console.log('parts focused is working');
 				return;
 			}
 			else {


### PR DESCRIPTION
…igating between previews.

Left and Right arrow keys are also allowed.

If user presses one of the other keys, focus will be set to map again.

Signed-off-by: Gökay Şatır <gokaysatir@collabora.com>
Change-Id: I3786ed4b9ef04deb7e3e05f157843fc30f3dc76e


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

