### PR TITLE
zotero: added unlink citation support for section

### DIFF
--- a/browser/src/control/Control.Zotero.js
+++ b/browser/src/control/Control.Zotero.js
@@ -1252,6 +1252,14 @@ L.Control.Zotero = L.Control.extend({
 				}
 			};
 			command = '.uno:DeleteFields';
+
+			var sectionUnlinkParameter = {
+				'SectionNamePrefix': {
+					'type': 'string',
+					'value': 'ZOTERO_BIBL'
+				}
+			};
+			this.map.sendUnoCommand('.uno:DeleteSections', sectionUnlinkParameter);
 		}
 		this.map.sendUnoCommand(command, parametes);
 		this.resetCitation();


### PR DESCRIPTION
sections are used to represent bibliography when citations are used as refmark

Signed-off-by: Pranam Lashkari <lpranam@collabora.com>
Change-Id: I4094cf053cb3fe1c86eb7f7f0a95816fb51fa8c7


* Resolves: # <!-- related github issue -->
* Target version: master 



### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

