### PR TITLE
Fix w2ui menus appearing with unnecessary scrollbars

### DIFF
--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -112,6 +112,7 @@ w2ui-toolbar {
 .w2ui-overlay .menu {
 	overflow: hidden auto;
 	border-radius: var(--border-radius);
+	position: static !important;
 }
 .w2ui-overlay > div {
 	border: 1px solid var(--color-border-dark);


### PR DESCRIPTION
Before this commit, on chrome/mium, menus such as
image or save as in the tabbed view (and with the browser zoom
set to bellow 80%) were being displayed with scrollbars.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Id32e86229fe5d7aad293d24a20c9bfa555fbe78b
