### PR TITLE
browser: Make navigation shortcuts work in read-only mode

### DIFF
--- a/browser/src/map/handler/Map.Keyboard.js
+++ b/browser/src/map/handler/Map.Keyboard.js
@@ -772,6 +772,16 @@ L.Map.Keyboard = L.Handler.extend({
 		// comment insert
 		else if (e.key === 'c' && e.altKey && e.altKey && e.ctrlKey && this._map.isPermissionEditForComments())
 			return true;
+		// full-screen presentation
+		else if (e.type === 'keydown' && e.keyCode === this.keyCodes.F5 && this._map._docLayer._docType === 'presentation')
+			return true;
+		// moving around
+		else if (!this.modifier && (e.keyCode === this.keyCodes.pageUp || e.keyCode === this.keyCodes.pageDown) && e.type === 'keydown')
+			return true;
+		else if (!this.modifier && (e.keyCode === this.keyCodes.END || e.keyCode === this.keyCodes.HOME) && e.type === 'keydown')
+			return true;
+		else if (e.type === 'keydown' && e.keyCode in this._panKeys)
+			return true;
 
 		return false;
 	}


### PR DESCRIPTION
F5 for slideshow, too.
Regression from 47c52b90f3a295e29106a61596645e774949a0aa

Signed-off-by: Aron Budea <aron.budea@collabora.com>
Change-Id: I056703f575460076693b245f790c7284854162be

* Target version: master 

- [X] Code is properly formatted
- [X] All commits have Change-Id
- [ ] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

