### PR TITLE
Improve cypress tests

### DIFF
--- a/cypress_test/integration_tests/desktop/writer/image_operation_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/image_operation_spec.js
@@ -40,8 +40,6 @@ describe('Image Operation Tests', function() {
 		cy.get('#selectheight input').clear({force:true})
 			.type('2{enter}', {force:true});
 
-		cy.wait(1000);
-
 		assertImageSize(139, 93);
 
 		//Keep ratio checked
@@ -51,8 +49,6 @@ describe('Image Operation Tests', function() {
 
 		cy.get('#selectheight input').clear({force:true})
 			.type('5{enter}', {force:true});
-
-		cy.wait(1000);
 
 		assertImageSize(347, 232);
 	});

--- a/cypress_test/integration_tests/desktop/writer/scrolling_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/scrolling_spec.js
@@ -62,8 +62,6 @@ describe('Scroll through document', function() {
 		cy.get('.leaflet-layer')
 			.click('bottom');
 
-		cy.wait(500);
-
 		helper.typeIntoDocument('{home}{end}{home}');
 
 		cy.get('#test-div-horizontal-scrollbar')

--- a/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
@@ -279,15 +279,17 @@ describe('Top toolbar tests.', function() {
 		cy.get('#annotation-content-area-1').should('contain','some text0');
 	});
 
-	it('Insert/delete table.', function() {
+	it.only('Insert/delete table.', function() {
 		cy.get('#toolbar-up .w2ui-scroll-right')
 			.click();
 
 		mode === 'notebookbar' ? cy.get('#toolbar-up .w2ui-scroll-right').click() : '';
 
-		cy.wait(500);
+		//cy.wait(500);
 
-		desktopHelper.actionOnSelector('insertTable', (selector) => { cy.get(selector).click(); });
+		desktopHelper.actionOnSelector('insertTable', (selector) => { 
+			cy.get(selector).should('be.visible').click(); 
+		});
 
 		cy.get('.inserttable-grid > .row > .col').eq(3)
 		   .click();
@@ -486,16 +488,18 @@ describe('Top toolbar tests.', function() {
 
 	});
 
-	it('Insert Special Character.', function() {
+	it.only('Insert Special Character.', function() {
 
 		cy.get('#toolbar-up .w2ui-scroll-right')
 			.click();
 
 		mode === 'notebookbar' ? cy.get('#toolbar-up .w2ui-scroll-right').click() : '';
 
-		cy.wait(500);
+		//cy.wait(500);
 
-		desktopHelper.actionOnSelector('insertSymbol', (selector) => { cy.get(selector).click(); });
+		desktopHelper.actionOnSelector('insertSymbol', (selector) => { 
+			cy.get(selector).should('be.visible').click();
+		});
 
 		desktopHelper.checkDialogAndClose('Special Characters');
 	});

--- a/cypress_test/integration_tests/desktop/writer/track_changes_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/track_changes_spec.js
@@ -47,7 +47,7 @@ describe('Track Changes', function () {
 			.click();
 	}
 
-	it('Accept All', function () {
+	it.only('Accept All', function () {
 
 		helper.typeIntoDocument('Hello World');
 
@@ -55,13 +55,13 @@ describe('Track Changes', function () {
 
 		helper.clearAllText();
 		//if we don't wait , the test will fail in CLI
-		cy.wait(200);
+		//cy.wait(200);
 
 		helper.selectAllText();
 
 		confirmChange('Accept All');
 
-		cy.wait(200);
+		//cy.wait(200);
 
 		helper.typeIntoDocument('{ctrl}a');
 


### PR DESCRIPTION
Signed-off-by: NickWingate <nick.wingate@collabora.com>
Change-Id: I99c06fdde0bcf442952d5bbfc12002e56e520f47


* Resolves: # <!-- related github issue -->
* Target version: master 
* Phab ticket: https://phabricator.collabora.com/T39833

### Summary
Improve cypress test efficiency with two main optimisations:
- Remove `cy.wait()` calls where possible and use HTML checks instead
- See if possible to run multiple tests on a document inbetween setup and teardown. e.g. Test if **bold** and _italic_ work in the same document to avoid the exact same calls before and after.

### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

