### PR TITLE
Avoid misleading wording in log

### DIFF
--- a/wsd/TileCache.cpp
+++ b/wsd/TileCache.cpp
@@ -203,7 +203,10 @@ void TileCache::saveTileAndNotify(const TileDesc& desc, const char *data, const 
     // Ignore if we can't save the tile, things will work anyway, but slower.
     // An error indication is supposed to be sent to all users in that case.
     Tile tile = saveDataToCache(desc, data, size);
-    LOG_TRC("Saved cache tile: " << cacheFileName(desc) << " of size " << size << " bytes");
+    if (!_dontCache)
+        LOG_TRC("Saved cache tile: " << cacheFileName(desc) << " of size " << size << " bytes");
+    else
+        LOG_TRC("Got (non-cached) tile: " << cacheFileName(desc));
 
     // Notify subscribers, if any.
     if (tileBeingRendered)


### PR DESCRIPTION
If we are not caching tiles, it is misleading to log "Saved cache tile".

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: I0e0ec446d5edf266ea4acb42883c49d5f7063763


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

