### PR TITLE
Leave ThreadPool max concurrency at 2 for Emscripten

### DIFF
--- a/common/RenderTiles.hpp
+++ b/common/RenderTiles.hpp
@@ -35,7 +35,9 @@ public:
           _shutdown(false)
     {
         int maxConcurrency = 2;
-#if MOBILEAPP && !defined(GTKAPP)
+#ifdef __EMSCRIPTEN__
+        // Leave it at that.
+#elif MOBILEAPP && !defined(GTKAPP)
         maxConcurrency = std::max<int>(std::thread::hardware_concurrency(), 2);
 #else
         const char *max = getenv("MAX_CONCURRENCY");


### PR DESCRIPTION
The default would be `std::thread::hardware_concurrency()` which can be ridiculously high for the WASM case.

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: I77902a58b96248d7afe638a039886712516fe905


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

