### PR TITLE
Storage Attribute Fixes and Improvements

### DIFF
--- a/test/UnitWOPIFailUpload.cpp
+++ b/test/UnitWOPIFailUpload.cpp
@@ -481,9 +481,18 @@ public:
         LOK_ASSERT_EQUAL(std::string("false"), request.get("X-COOL-WOPI-IsAutosave"));
         LOK_ASSERT_EQUAL(std::string("false"), request.get("X-LOOL-WOPI-IsAutosave"));
 
-        // Certainly not exiting yet.
-        LOK_ASSERT_EQUAL(std::string("false"), request.get("X-COOL-WOPI-IsExitSave"));
-        LOK_ASSERT_EQUAL(std::string("false"), request.get("X-LOOL-WOPI-IsExitSave"));
+        if (getCountPutFile() < 3)
+        {
+            // Certainly not exiting yet.
+            LOK_ASSERT_EQUAL(std::string("false"), request.get("X-COOL-WOPI-IsExitSave"));
+            LOK_ASSERT_EQUAL(std::string("false"), request.get("X-LOOL-WOPI-IsExitSave"));
+        }
+        else
+        {
+            // Only on the last (third) attempt we exit.
+            LOK_ASSERT_EQUAL(std::string("true"), request.get("X-COOL-WOPI-IsExitSave"));
+            LOK_ASSERT_EQUAL(std::string("true"), request.get("X-LOOL-WOPI-IsExitSave"));
+        }
 
         LOK_ASSERT_MESSAGE("Unexpected phase", _phase == Phase::WaitModifiedStatus ||
                                                    _phase == Phase::WaitUnmodifiedStatus);

--- a/test/UnitWOPIFailUpload.cpp
+++ b/test/UnitWOPIFailUpload.cpp
@@ -660,8 +660,8 @@ public:
         LOK_ASSERT_STATE(_phase, Phase::WaitSecondPutFile);
 
         // Triggered while closing.
-        // LOK_ASSERT_EQUAL(std::string("true"), request.get("X-COOL-WOPI-IsExitSave"));
-        // LOK_ASSERT_EQUAL(std::string("true"), request.get("X-LOOL-WOPI-IsExitSave"));
+        LOK_ASSERT_EQUAL(std::string("true"), request.get("X-COOL-WOPI-IsExitSave"));
+        LOK_ASSERT_EQUAL(std::string("true"), request.get("X-LOOL-WOPI-IsExitSave"));
 
         return nullptr;
     }

--- a/test/UnitWOPISaveOnExit.cpp
+++ b/test/UnitWOPISaveOnExit.cpp
@@ -160,6 +160,111 @@ public:
     }
 };
 
-UnitBase* unit_create_wsd(void) { return new UnitWOPISaveOnExit(); }
+/// Test Async uploading with always_save_on_exit.
+/// The test verifies the headers only.
+/// Load, Save, Upload -> verify IsModifiedByUser=false.
+class UnitSaveOnExitUnmodified : public WopiTestServer
+{
+    using Base = WopiTestServer;
+
+    STATE_ENUM(Phase, Load, WaitLoadStatus, WaitPutFile, WaitDestroy, Done)
+    _phase;
+
+public:
+    UnitSaveOnExitUnmodified()
+        : WopiTestServer("UnitSaveOnExitUnmodified")
+        , _phase(Phase::Load)
+    {
+    }
+
+    void configure(Poco::Util::LayeredConfiguration& config) override
+    {
+        WopiTestServer::configure(config);
+
+        // Make it more likely to force uploading.
+        config.setBool("per_document.always_save_on_exit", true);
+    }
+
+    std::unique_ptr<http::Response>
+    assertPutFileRequest(const Poco::Net::HTTPRequest& request) override
+    {
+        LOG_TST("Checking X-COOL-WOPI headers");
+
+        // No modifications.
+        LOK_ASSERT_EQUAL(std::string("false"), request.get("X-COOL-WOPI-IsModifiedByUser"));
+        LOK_ASSERT_EQUAL(std::string("false"), request.get("X-LOOL-WOPI-IsModifiedByUser"));
+
+        // Closing, no auto-save expected.
+        LOK_ASSERT_EQUAL(std::string("false"), request.get("X-COOL-WOPI-IsAutosave"));
+        LOK_ASSERT_EQUAL(std::string("false"), request.get("X-LOOL-WOPI-IsAutosave"));
+
+        // Exiting, certainly.
+        LOK_ASSERT_EQUAL(std::string("true"), request.get("X-COOL-WOPI-IsExitSave"));
+        LOK_ASSERT_EQUAL(std::string("true"), request.get("X-LOOL-WOPI-IsExitSave"));
+
+        TRANSITION_STATE(_phase, Phase::WaitDestroy);
+        return nullptr;
+    }
+
+    /// The document is loaded.
+    bool onDocumentLoaded(const std::string& message) override
+    {
+        LOG_TST("onDocumentLoaded: [" << message << ']');
+        LOK_ASSERT_STATE(_phase, Phase::WaitLoadStatus);
+
+        TRANSITION_STATE(_phase, Phase::WaitPutFile);
+        WSD_CMD("closedocument");
+
+        return true;
+    }
+
+    void onDocumentUploaded(bool success) override
+    {
+        LOK_ASSERT_MESSAGE("Upload failed unexpectedly", success);
+        LOK_ASSERT_STATE(_phase, Phase::WaitDestroy);
+    }
+
+    // Wait for clean unloading.
+    void onDocBrokerDestroy(const std::string& docKey) override
+    {
+        LOG_TST("Destroyed dockey [" << docKey << "] closed");
+        LOK_ASSERT_STATE(_phase, Phase::WaitDestroy);
+
+        TRANSITION_STATE(_phase, Phase::Done);
+        passTest("Document uploaded on closing as expected");
+
+        Base::onDocBrokerDestroy(docKey);
+    }
+
+    void invokeWSDTest() override
+    {
+        switch (_phase)
+        {
+            case Phase::Load:
+            {
+                TRANSITION_STATE(_phase, Phase::WaitLoadStatus);
+
+                LOG_TST("Load: initWebsocket.");
+                initWebsocket("/wopi/files/0?access_token=anything");
+
+                WSD_CMD("load url=" + getWopiSrc());
+                break;
+            }
+            case Phase::WaitLoadStatus:
+            case Phase::WaitPutFile:
+            case Phase::WaitDestroy:
+            case Phase::Done:
+            {
+                // just wait for the results
+                break;
+            }
+        }
+    }
+};
+
+UnitBase** unit_create_wsd_multi(void)
+{
+    return new UnitBase* [3] { new UnitWOPISaveOnExit(), new UnitSaveOnExitUnmodified(), nullptr };
+}
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/test/UnitWOPISaveOnExit.cpp
+++ b/test/UnitWOPISaveOnExit.cpp
@@ -74,8 +74,19 @@ public:
             case Scenario::VerifyOverwrite:
                 break;
             case Scenario::SaveOverwrite:
-                LOK_ASSERT_EQUAL_MESSAGE("Unexpected contents in storage",
-                                         std::string(ConflictingDocContent), getFileContent());
+                if (getCountPutFile() < 3)
+                {
+                    // The first two times the content should be the conflicting one.
+                    LOK_ASSERT_EQUAL_MESSAGE("Unexpected contents in storage",
+                                             std::string(ConflictingDocContent), getFileContent());
+                }
+                else
+                {
+                    // The second time will overwrite with the modified content.
+                    LOK_ASSERT_EQUAL_MESSAGE("Unexpected contents in storage",
+                                             std::string(ModifiedOriginalDocContent),
+                                             getFileContent());
+                }
                 break;
         }
 
@@ -86,11 +97,12 @@ public:
     {
         Base::onDocBrokerCreate(docKey);
 
-        // When overwriting, we will do so twice.
-        // Once to find out that we have a conflict and another time to force it.
         if (_scenario == Scenario::SaveOverwrite)
         {
-            setExpectedPutFile(2);
+            // When overwriting, we will do so thrice.
+            // Once to find out that we have a conflict and another
+            // to force overwriting it. Finally, always_save_on_exit.
+            setExpectedPutFile(3);
         }
         else
         {

--- a/test/UnitWOPISaveOnExit.cpp
+++ b/test/UnitWOPISaveOnExit.cpp
@@ -76,8 +76,6 @@ public:
             case Scenario::SaveOverwrite:
                 LOK_ASSERT_EQUAL_MESSAGE("Unexpected contents in storage",
                                          std::string(ConflictingDocContent), getFileContent());
-                LOG_TST("Closing the document to verify its contents after reloading");
-                WSD_CMD("closedocument");
                 break;
         }
 
@@ -98,6 +96,27 @@ public:
         {
             // With always_save_on_exit, we expect exactly one PutFile per document.
             setExpectedPutFile(1);
+        }
+    }
+
+    void onDocumentUploaded(bool success) override
+    {
+        LOG_TST("Uploaded: " << (success ? "success" : "failure"));
+
+        switch (_scenario)
+        {
+            case Scenario::Disconnect:
+            case Scenario::SaveDiscard:
+            case Scenario::CloseDiscard:
+            case Scenario::VerifyOverwrite:
+                break;
+            case Scenario::SaveOverwrite:
+                if (getCountPutFile() == 2)
+                {
+                    LOG_TST("Closing the document to verify its contents after reloading");
+                    WSD_CMD("closedocument");
+                }
+                break;
         }
     }
 

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -681,9 +681,8 @@ bool ClientSession::_handleInput(const char *buffer, int length)
             }
 
             constexpr bool isAutosave = false;
-            constexpr bool isExitSave = false;
             docBroker->sendUnoSave(client_from_this(), dontTerminateEdit != 0,
-                                   dontSaveIfUnmodified != 0, isAutosave, isExitSave, extendedData);
+                                   dontSaveIfUnmodified != 0, isAutosave, extendedData);
         }
     }
     else if (tokens.equals(0, "savetostorage"))

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1686,6 +1686,9 @@ void DocumentBroker::handleUploadToStorageResponse(const StorageBase::UploadResu
 
             // Reset the storage attributes; They've been used and we can discard them.
             _currentStorageAttrs.reset();
+            // In case there was an update while we were uploading, merge it.
+            _currentStorageAttrs.merge(_nextStorageAttrs);
+            _nextStorageAttrs.reset();
 
             LOG_DBG("Uploaded docKey ["
                     << _docKey << "] to URI [" << _uploadRequest->uriAnonym()

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1459,12 +1459,6 @@ void DocumentBroker::uploadToStorage(const std::shared_ptr<ClientSession>& sessi
     assertCorrectThread();
 
     LOG_TRC("uploadToStorage [" << session->getId() << "]: " << (force ? "" : "not") << " forced");
-    if (force)
-    {
-        // Don't reset the force flag if it was set
-        // (which would imply we failed to upload).
-        _currentStorageAttrs.setForced(force);
-    }
 
     // Upload immediately if forced or had no failures. Otherwise, throttle (on failure).
     if (force || _storageManager.lastUploadSuccessful() || _storageManager.canUploadNow())
@@ -1624,6 +1618,13 @@ void DocumentBroker::uploadToStorageInternal(const std::shared_ptr<ClientSession
                 break;
         }
     };
+
+    if (force)
+    {
+        // Don't reset the force flag if it was set
+        // (which would imply we failed to upload).
+        _currentStorageAttrs.setForced(true);
+    }
 
     _storage->uploadLocalFileToStorageAsync(session->getAuthorization(), *_lockCtx, saveAsPath,
                                             saveAsFilename, isRename, _currentStorageAttrs, *_poll,

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1199,8 +1199,7 @@ void DocumentBroker::startRenameFileCommand()
     constexpr bool dontTerminateEdit = false; // We will save, rename, and reload: terminate.
     constexpr bool dontSaveIfUnmodified = true;
     constexpr bool isAutosave = false;
-    constexpr bool isExitSave = false;
-    sendUnoSave(it->second, dontTerminateEdit, dontSaveIfUnmodified, isAutosave, isExitSave);
+    sendUnoSave(it->second, dontTerminateEdit, dontSaveIfUnmodified, isAutosave);
 }
 
 void DocumentBroker::endRenameFileCommand()
@@ -2086,9 +2085,8 @@ bool DocumentBroker::autoSave(const bool force, const bool dontSaveIfUnmodified)
         // potentially optimize it away. This is as good as user-issued save, since this is
         // triggered when the document is closed. In the case of network disconnection or browser crash
         // most users would want to have had the chance to hit save before the document unloaded.
-        sent = sendUnoSave(savingSession, /*dontTerminateEdit=*/true,
-                           dontSaveIfUnmodified, /*isAutosave=*/false,
-                           /*isExitSave=*/true);
+        sent = sendUnoSave(savingSession, /*dontTerminateEdit=*/true, dontSaveIfUnmodified,
+                           /*isAutosave=*/false);
     }
     else if (isModified())
     {
@@ -2117,8 +2115,7 @@ bool DocumentBroker::autoSave(const bool force, const bool dontSaveIfUnmodified)
         {
             LOG_TRC("Sending timed save command for [" << _docKey << ']');
             sent = sendUnoSave(savingSession, /*dontTerminateEdit=*/true,
-                               /*dontSaveIfUnmodified=*/true, /*isAutosave=*/true,
-                               /*isExitSave=*/false);
+                               /*dontSaveIfUnmodified=*/true, /*isAutosave=*/true);
         }
     }
 
@@ -2244,7 +2241,7 @@ void DocumentBroker::autoSaveAndStop(const std::string& reason)
 
 bool DocumentBroker::sendUnoSave(const std::shared_ptr<ClientSession>& session,
                                  bool dontTerminateEdit, bool dontSaveIfUnmodified, bool isAutosave,
-                                 bool isExitSave, const std::string& extendedData)
+                                 const std::string& extendedData)
 {
     assertCorrectThread();
 
@@ -2292,7 +2289,7 @@ bool DocumentBroker::sendUnoSave(const std::shared_ptr<ClientSession>& session,
 
     // Note: It's odd to capture these here, but this function is used from ClientSession too.
     _nextStorageAttrs.setIsAutosave(isAutosave || _unitWsd.isAutosave());
-    _nextStorageAttrs.setIsExitSave(isExitSave);
+    _nextStorageAttrs.setIsExitSave(isUnloading());
     _nextStorageAttrs.setExtendedData(extendedData);
 
     const std::string saveArgs = oss.str();

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1619,6 +1619,9 @@ void DocumentBroker::uploadToStorageInternal(const std::shared_ptr<ClientSession
         }
     };
 
+    // Once set, isUnloading shouldn't be unset.
+    _currentStorageAttrs.setIsExitSave(isUnloading());
+
     if (force)
     {
         // Don't reset the force flag if it was set
@@ -2290,7 +2293,6 @@ bool DocumentBroker::sendUnoSave(const std::shared_ptr<ClientSession>& session,
 
     // Note: It's odd to capture these here, but this function is used from ClientSession too.
     _nextStorageAttrs.setIsAutosave(isAutosave || _unitWsd.isAutosave());
-    _nextStorageAttrs.setIsExitSave(isUnloading());
     _nextStorageAttrs.setExtendedData(extendedData);
 
     const std::string saveArgs = oss.str();

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1235,23 +1235,20 @@ DocumentBroker::NeedToUpload DocumentBroker::needToUploadToStorage() const
 
     // When destroying, we might have to force uploading if always_save_on_exit=true.
     // If unloadRequested is set, assume we will unload after uploading and exit.
-    if (isMarkedToDestroy() || _docState.isUnloadRequested())
+    if (isUnloading() && _alwaysSaveOnExit)
     {
-        if (_alwaysSaveOnExit)
+        if (_documentChangedInStorage)
         {
-            if (_documentChangedInStorage)
-            {
-                LOG_INF("Need to upload per always_save_on_exit config while the document has a "
-                        "conflict");
-            }
-            else
-            {
-                LOG_INF("Need to upload per always_save_on_exit config "
-                        << (isMarkedToDestroy() ? "MarkedToDestroy" : "Unloading"));
-            }
-
-            return NeedToUpload::Yes;
+            LOG_INF("Need to upload per always_save_on_exit config while the document has a "
+                    "conflict");
         }
+        else
+        {
+            LOG_INF("Need to upload per always_save_on_exit config "
+                    << (isMarkedToDestroy() ? "MarkedToDestroy" : "Unloading"));
+        }
+
+        return NeedToUpload::Yes;
     }
 
     // Force uploading only for retryable failures, not conflicts. See FIXME below.

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -455,7 +455,7 @@ public:
     /// Sends the .uno:Save command to LoKit.
     bool sendUnoSave(const std::shared_ptr<ClientSession>& session, bool dontTerminateEdit = true,
                      bool dontSaveIfUnmodified = true, bool isAutosave = false,
-                     bool isExitSave = false, const std::string& extendedData = std::string());
+                     const std::string& extendedData = std::string());
 
     /// Sends a message to all sessions.
     /// Returns the number of sessions sent the message to.


### PR DESCRIPTION
- wsd: set IsExitSave header only when unloading
- wsd: move setForced attribute closer to usage
- wsd: set IsExitSave attribute before uploading
- wsd: test: add IsExitSave check in UnitWOPIAsyncUpload_Close
- wsd: merge the storage attributes after uploading
- wsd: test: better UnitWOPISaveOnExit
- wsd: fix always_save_on_exit
- wsd: test: add UnitSaveOnExitUnmodified
- wsd: better storage attribute handling
