### PR TITLE
More WASM hacking

### DIFF
--- a/wasm/wasmapp.cpp
+++ b/wasm/wasmapp.cpp
@@ -12,7 +12,7 @@ int coolwsd_server_socket_fd = -1;
 const char* user_name;
 const int SHOW_JS_MAXLEN = 70;
 
-static std::string fileURL;
+static std::string fileURL = "file:///android/default-document/example.odt";
 static COOLWSD *coolwsd = nullptr;
 static int fakeClientFd;
 static int closeNotificationPipeForForwardingThread[2] = {-1, -1};
@@ -69,12 +69,14 @@ static void send2JS(const std::vector<char>& buffer)
 
     LOG_TRC_NOFILE( "Evaluating JavaScript: " << subjs);
 
-    emscripten_run_script(js.c_str());
+    MAIN_THREAD_EM_ASM(eval(UTF8ToString($0)), js.c_str());
 }
 
 extern "C"
 void handle_cool_message(const char *string_value)
 {
+    std::cout << "================ handle_cool_message(): '" << string_value << "'" << std::endl;
+
     if (strcmp(string_value, "HULLO") == 0)
     {
         // Now we know that the JS has started completely
@@ -238,6 +240,7 @@ void * lok_init()
 
 int loadDoc(bool url, const char * input, const char * options)
 {
+    std::cout << "================ loadDoc('" << input << "'" << std::endl;
     try {
         std::string input_url;
         if (url) {

--- a/wasm/wasmapp.hpp
+++ b/wasm/wasmapp.hpp
@@ -32,4 +32,6 @@ extern int coolwsd_server_socket_fd;
 
 extern const char* user_name;
 
+extern "C" void handle_cool_message(const char *string_value);
+
 /* vim:set shiftwidth=4 softtabstop=4 expandtab cinoptions=b1,g0,N-s cinkeys+=0=break: */

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -5462,6 +5462,10 @@ int COOLWSD::innerMain()
     // Start the server.
     Server->start();
 
+#if defined(__EMSCRIPTEN__)
+    handle_cool_message("HULLO");
+#endif
+
     /// The main-poll does next to nothing:
     SocketPoll mainWait("main");
 


### PR DESCRIPTION
Apparently handle_cool_message() gets called from a web worker thread and then using emscripten_run_script() in wasmapp.cpp to run a JS snippet that refers to the 'window' variable will not work. That variable exists only in the main thread. So use MAIN_THREAD_EM_ASM() instead.

Hardcode the document URL for now also in wasmapp.cpp.

Try to send the HULLO message from COOLWSD::innerMain().

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: Ic48042c6d0c6239a3b82e74f0565056a15f3d98d


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

