### PR TITLE
Keep focus on sheet if empty part of the notebookbar clicked

### DIFF
--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -13,6 +13,7 @@ L.Control.UIManager = L.Control.extend({
 
 	onAdd: function (map) {
 		this.map = map;
+		var that = this;
 		this.notebookbar = null;
 		// Every time the UI mode changes from 'classic' to 'notebookbar'
 		// the two below elements will be destroyed.
@@ -37,6 +38,19 @@ L.Control.UIManager = L.Control.extend({
 
 		map.on('blockUI', this.blockUI, this);
 		map.on('unblockUI', this.unblockUI, this);
+
+		$('#toolbar-wrapper').on('click', function (event) {
+			if (event.target.parentElement.id === 'toolbar-up' || // checks if clicked on empty part of the toolbar on tabbed view
+				event.target.id === 'tb_editbar_item_item_64') // checks if clicked on empty part of the toolbar on compact view
+				that.map.fire('editorgotfocus');
+		});
+
+		$('.main-nav').on('click', function (event) {
+			if (event.target.parentElement.nodeName === 'NAV' || // checks if clicked on an container of an element
+				event.target.nodeName === 'NAV' || // checks if clicked on navigation bar itself
+				event.target.parentElement.id === 'document-titlebar') { // checks if clicked on the document titlebar container
+				that.map.fire('editorgotfocus');}
+		});
 	},
 
 	// UI initialization


### PR DESCRIPTION
When we click empty part of notebook bar, focus should be on sheet. Without this patch, focus is on browser itself and CTRL+S saves the HTML instead of current document.

Signed-off-by: Gülşah Köse <gulsah.kose@collabora.com>
Change-Id: Ia0a89ae761eeeb3bb21a655c5181425df19e1c94


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

