### PR TITLE
browser: Add page number wizard to compact insert menu

### DIFF
--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -138,6 +138,7 @@ L.Control.Menubar = L.Control.extend({
 				{name: _UNO('.uno:VerticalText'), uno: '.uno:VerticalText'},
 				{type: 'separator'},
 				{uno: '.uno:InsertSection', id: 'insertsection'},
+				{uno: '.uno:PageNumberWizard', id: 'pagenumberwizard'},
 				{name: _UNO('.uno:InsertFieldCtrl', 'text'), type: 'menu', menu: [
 					{uno: '.uno:InsertPageNumberField'},
 					{uno: '.uno:InsertPageCountField'},


### PR DESCRIPTION
Signed-off-by: Paris Oplopoios <paris.oplopoios@collabora.com>
Change-Id: Ibb92c17894166276c0e0ef33736522b282fea993


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
Adds the page number wizard as a button in the compact view Insert menu

### Checklist

- [X] Code is properly formatted
- [X] All commits have Change-Id
- [X] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

