### PR TITLE
zotero: restric user from changing field type

### DIFF
--- a/browser/src/control/Control.Zotero.js
+++ b/browser/src/control/Control.Zotero.js
@@ -207,7 +207,8 @@ L.Control.Zotero = L.Control.extend({
 					selectedCount: '1',
 					selectedEntries: [
 						this.getFieldType() === 'Bookmark' ? 1 : 0
-					]
+					],
+					enabled: !(this.citations && Object.keys(this.citations).length)
 				}
 			]
 		};


### PR DESCRIPTION
if document contains existing zotero citation,
restrict user from changing the field storage type.

currently online does not have any ways to change the field type maybe in future we can add some core APIs to support this

Signed-off-by: Pranam Lashkari <lpranam@collabora.com>
Change-Id: I58caf403744431d34344f5a1cb635781409d7e68


* Target version: master 



### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

