### PR TITLE
zotero: added warning for unreachable citation items

### DIFF
--- a/browser/src/control/Control.Zotero.js
+++ b/browser/src/control/Control.Zotero.js
@@ -56,6 +56,7 @@ L.Control.Zotero = L.Control.extend({
 			this.citationCluster[values.citationID] = [];
 			var citationString = L.Util.trim(values.properties.plainCitation, this.settings.layout.prefix, this.settings.layout.suffix);
 			var citations = citationString.split(this.settings.layout.delimiter);
+			var itemUriList = [];
 			values.citationItems.forEach(function(item, i) {
 				//zotero desktop versions do not store keys in cslJSON
 				//extract key from the item url
@@ -64,7 +65,9 @@ L.Control.Zotero = L.Control.extend({
 				that.citationCluster[values.citationID].push(citationId);
 				that.citations[citationId] = L.Util.trim(citations[i], that.settings.group.prefix, that.settings.group.suffix);
 				that.setCitationNumber(that.citations[citationId]);
+				itemUriList.push(itemUri);
 			});
+			this.showUnsupportedItemWarning(itemUriList);
 		}
 
 		if (this.pendingCitationUpdate || (this.previousNumberOfFields && this.previousNumberOfFields !== fields.length)) {
@@ -110,7 +113,40 @@ L.Control.Zotero = L.Control.extend({
 					that.map.uiManager.refreshNotebookbar();
 				else
 					that.map.uiManager.refreshMenubar();
+				that.updateGroupIdList();
 			}, function () { that.map.uiManager.showSnackbar(_('Zotero API key is incorrect')); });
+	},
+
+	updateGroupIdList: function() {
+		this.groupIdList = new Set();
+		var that = this;
+		this.getCachedOrFetch('https://api.zotero.org/users/' + this.userID + '/groups?v=3&key=' + this.apiKey)
+			.then(function (data) {
+				for (var i = 0; i < data.length; i++) {
+					that.groupIdList.add(data[i].data.id.toString());
+				}
+			}, function () {});
+	},
+
+	showUnsupportedItemWarning: function(uriList) {
+		if (this.showUnsupportedWarning === false || !this.userID)
+			return;
+
+		for (var i in uriList) {
+			var uriObject = new URL(uriList[i]);
+
+			var catagory = uriObject.pathname.startsWith('/groups/') ? '/groups/' : '/users/';
+
+			var id = uriObject.pathname.substring(catagory.length);
+			id = id.substring(0, id.indexOf('/'));
+			if (!this.groupIdList.has(id) && id !== this.userID.toString()) {
+				this.showUnsupportedWarning = false;
+				this.map.uiManager.showInfoModal('zoterounreachablewarn', _('Zotero Warning'),
+					_('The document contains some citations which may be unreachable through web API. It may cause some problems while editing citations or bibliography.'),
+					null, _('Close'), function() {});
+				return;
+			}
+		}
 	},
 
 	getTopBarJSON: function () {


### PR DESCRIPTION
In cases where zotero item is added by a user and another user opens the doc, if the new user does not have that item in the database, he may fail to do activity related to that item, so we warn the user when we are setting up the zotero

Signed-off-by: Pranam Lashkari <lpranam@collabora.com>
Change-Id: I9056f38334cb8d9b127ddb594adb083d25bd4472


* Target version: master 



### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

