### PR TITLE
Sidebar: Fix to allow ratio to span across columns

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -220,9 +220,16 @@ div.sidebar.ui-grid .checkbutton.sidebar,
 
 /* writer */
 
-#PosSizePropertyPanel.sidebar #selectrotationtype,
-#PosSizePropertyPanel.sidebar #ratio {
+#PosSizePropertyPanel.sidebar #selectrotationtype {
 	justify-content: end;
+}
+/* Fix to allow ratio to span across columns
+ so Seitenverhältnis beibehalten doesn't get cropped*/
+#PosSizePropertyPanel.sidebar #ratio {
+	grid-column: 1 / 3;
+}
+#PosSizePropertyPanel.sidebar #ratio input[type='checkbox'] {
+	margin-inline-start: 0;
 }
 #ParaPropertyPanel.sidebar #box3 {
 	display: grid;


### PR DESCRIPTION
There is an element displayed as a column before ratio
and we then hide it which is fine but, when ratio label
becomes to lengthly (Seitenverhältnis beibehalten) it then
gets cropped due to lack of space.
- Make it span across columns
- Do not align to the end
- Remove left margin from checkbox

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I02ec7a608c0b330a52fa70db3b453fe04fefa805
