### PR TITLE
Temporarily hardcode the document URL and UI lang for WASM in more pl…

### DIFF
--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -733,6 +733,9 @@ window.app = {
 				return encodeURIComponent(key) + '=' + encodeURIComponent(wopiParams[key]);
 			}).join('&');
 		}
+	} else if (window.ThisIsTheEmscriptenApp) {
+		// This is of course just a horrible temporary hack
+		global.docURL = 'file:///android/default-document/example.odt';
 	} else {
 		global.docURL = filePath;
 	}
@@ -820,7 +823,10 @@ window.app = {
 
 	var lang = encodeURIComponent(global.getParameterByName('lang'));
 	global.queueMsg = [];
-	if (window.ThisIsAMobileApp)
+	if (window.ThisIsTheEmscriptenApp)
+		// Temporary hack
+		window.LANG = 'en-US';
+	else if (window.ThisIsAMobileApp)
 		window.LANG = lang;
 	if (global.socket && global.socket.readyState !== 3) {
 		global.socket.onopen = function () {

--- a/browser/src/main.js
+++ b/browser/src/main.js
@@ -15,7 +15,11 @@ else if (wopiSrc !== '' && accessHeader !== '') {
 	wopiParams = { 'access_header': accessHeader };
 }
 
-var filePath = getParameterByName('file_path');
+if (window.ThisIsTheEmscriptenApp)
+	// Temporary hack
+	var filePath = 'file:///android/default-document/example.odt';
+else
+	var filePath = getParameterByName('file_path');
 
 app.file.permission = getParameterByName('permission') || 'edit';
 


### PR DESCRIPTION
…aces

(Note that the existence of a window.ThisIsTheEmscriptenApp property is also a temporary hack; the eventual goal is for a one same Online webpage to be able to switch automatically from server-based to WASM-based and back based on connectivity to the server.)

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: Ia5e3f4008eaaf1543c08482418635dca0d3983e5
Signed-off-by: Tor Lillqvist <tml@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

