### PR TITLE
Change hardcoded sample document name and verify that we get it

### DIFF
--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -735,7 +735,7 @@ window.app = {
 		}
 	} else if (window.ThisIsTheEmscriptenApp) {
 		// This is of course just a horrible temporary hack
-		global.docURL = 'file:///android/default-document/example.odt';
+		global.docURL = 'file:///sample.docx';
 	} else {
 		global.docURL = filePath;
 	}

--- a/browser/src/main.js
+++ b/browser/src/main.js
@@ -17,7 +17,7 @@ else if (wopiSrc !== '' && accessHeader !== '') {
 
 if (window.ThisIsTheEmscriptenApp)
 	// Temporary hack
-	var filePath = 'file:///android/default-document/example.odt';
+	var filePath = 'file:///sample.docx';
 else
 	var filePath = getParameterByName('file_path');
 

--- a/configure.ac
+++ b/configure.ac
@@ -154,7 +154,9 @@ AC_ARG_WITH([wasm-additional-files],
                               build of Collabora Office. The files will be available in the WASM in-memory file system as pathnames
                               stripping the initial prefix <path> where they are on the build system. For instance, if you give
                               --with-wasm-additional-files=$HOME/our-sample-docs, and there is a file $HOME/our-sample-docs/temp/test.docx,
-                              that will be available in the online.wasm as /temp/test.docx.]))
+                              that will be available in the online.wasm as /temp/test.docx.
+                              NOTE: Temporarily for now, this option is mandatory and the additional files should contain a document
+                              in the root called "sample.docx"]))
 
 AC_ARG_WITH([iosapp-appicon],
               AS_HELP_STRING([--with-iosapp-appicon=<path>],
@@ -842,6 +844,15 @@ dnl capability. Compare to ENABLE_WASM.
 AM_CONDITIONAL([ENABLE_WASM_FALLBACK], [test -n "$with_wasm_fallback"])
 WASM_BUILDDIR="$with_wasm_fallback"
 AC_SUBST(WASM_BUILDDIR)
+
+dnl Temporary hack: We hardcode /sample.docx in a few places, so make sure that file is there
+AS_IF(["$host_os" = "emscripten"],
+      [AC_MSG_CHECKING([that temporarily there is a sample document with a fixed name])
+      AS_IF([test -z "$with_wasm_additional_files"],
+            [AC_MSG_ERROR([You must use the --with-wasm-additional-files option for now])])
+      AS_IF([test ! -f "$with_wasm_additional_files/sample.docx"],
+            [AC_MSG_ERROR([There must be a file called sample.docx in $with_wasm_additional_files for now])])
+      AC_MSG_RESULT([yes])])
 
 AM_CONDITIONAL([ENABLE_WASM_ADDITIONAL_FILES], [test -n "$with_wasm_additional_files"])
 WASM_ADDITIONAL_FILES="$with_wasm_additional_files"

--- a/wasm/wasmapp.cpp
+++ b/wasm/wasmapp.cpp
@@ -14,7 +14,7 @@ int coolwsd_server_socket_fd = -1;
 const char* user_name;
 const int SHOW_JS_MAXLEN = 200;
 
-static std::string fileURL = "file:///android/default-document/example.odt";
+static std::string fileURL = "file:///sample.docx";
 static COOLWSD *coolwsd = nullptr;
 static int fakeClientFd;
 static int closeNotificationPipeForForwardingThread[2] = {-1, -1};


### PR DESCRIPTION
You now must pass --with-wasm-additional-files=<path> where path contains a file called sample.docx.

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: I21e62feb6282833a5d60b31db26328eda63cdaea


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

