### PR TITLE
There is no need to call lok_cpp_init() here

### DIFF
--- a/wasm/wasmapp.cpp
+++ b/wasm/wasmapp.cpp
@@ -18,7 +18,6 @@ static std::string fileURL = "file:///sample.docx";
 static COOLWSD *coolwsd = nullptr;
 static int fakeClientFd;
 static int closeNotificationPipeForForwardingThread[2] = {-1, -1};
-static lok::Office * llo = NULL;
 
 static void send2JS(const std::vector<char>& buffer)
 {
@@ -225,28 +224,9 @@ void closeDocument()
     LOG_DBG("COOLWSD has finished.");
 }
 
-void * lok_init()
-{
-    try {
-        std::string lo_path = "/instdir/program";
-        llo = lok::lok_cpp_init(lo_path.c_str());
-        if (!llo) {
-            std::cerr << ": Failed to initialise LibreOfficeKit" << std::endl;
-            return NULL;
-        }
-        return static_cast<void*>(llo);
-    } catch (const std::exception & e) {
-        delete llo;
-        std::cerr << ": LibreOfficeKit threw exception (" << e.what() << ")" << std::endl;
-        return NULL;
-    }
-}
-
 int main(int, char*[])
 {
     std::cout << "================ Here is main()" << std::endl;
-
-    lok_init();
 
     Log::initialize("WASM", "error", false, false, {});
     Util::setThreadName("main");


### PR DESCRIPTION
LOKit will be initialised in the lok_init_2() call in lokit_main() in Kit.cpp. This change also puts setting and getting the LOK_OPTIONS environment variable in the right order.

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: Iee6f5adcb60bb887083c67666c2d597a15686bf9
Signed-off-by: Tor Lillqvist <tml@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

