### PR TITLE
I don't see the reason to use the intermediate libonline.a for WASM

### DIFF
--- a/wasm/Makefile.am
+++ b/wasm/Makefile.am
@@ -1,35 +1,6 @@
 
 EXEEXT = .js
 
-noinst_LIBRARIES = libonline.a
-
-libonline_a_SOURCES = \
-	../common/Authorization.cpp \
-	../common/ConfigUtil.cpp \
-	../common/FileUtil.cpp \
-	../common/CommandControl.cpp \
-	../common/Log.cpp \
-	../common/MessageQueue.cpp \
-	../common/TraceEvent.cpp \
-	../common/Protocol.cpp \
-	../common/StringVector.cpp \
-	../common/Session.cpp \
-	../common/SigUtil.cpp \
-	../common/SpookyV2.cpp \
-	../common/Unit.cpp \
-	../common/Util.cpp \
-	../common/CommandControl.cpp \
-	../kit/ChildSession.cpp \
-	../kit/Kit.cpp \
-	../net/FakeSocket.cpp \
-	../net/Socket.cpp \
-	../wsd/ClientSession.cpp \
-	../wsd/DocumentBroker.cpp \
-	../wsd/COOLWSD.cpp \
-	../wsd/RequestDetails.cpp \
-	../wsd/Storage.cpp \
-	../wsd/TileCache.cpp
-
 AM_CXXFLAGS = \
 	-pthread -s USE_PTHREADS=1 \
 	-s DISABLE_EXCEPTION_CATCHING=0
@@ -48,17 +19,40 @@ AM_CPPFLAGS = \
 
 bin_PROGRAMS = online
 
-online_SOURCES = wasmapp.cpp
+online_SOURCES = \
+	wasmapp.cpp \
+	../common/Authorization.cpp \
+	../common/ConfigUtil.cpp \
+	../common/FileUtil.cpp \
+	../common/CommandControl.cpp \
+	../common/Log.cpp \
+	../common/MessageQueue.cpp \
+	../common/TraceEvent.cpp \
+	../common/Protocol.cpp \
+	../common/StringVector.cpp \
+	../common/Session.cpp \
+	../common/SigUtil.cpp \
+	../common/SpookyV2.cpp \
+	../common/Unit.cpp \
+	../common/Util.cpp \
+	../kit/ChildSession.cpp \
+	../kit/Kit.cpp \
+	../net/FakeSocket.cpp \
+	../net/Socket.cpp \
+	../wsd/ClientSession.cpp \
+	../wsd/DocumentBroker.cpp \
+	../wsd/COOLWSD.cpp \
+	../wsd/RequestDetails.cpp \
+	../wsd/Storage.cpp \
+	../wsd/TileCache.cpp
 
 online_DEPENDENCIES = \
 	@LOBUILDDIR@/instdir/program/soffice.html.linkdeps \
 	soffice.data \
-	soffice.data.js.metadata \
-	libonline.a
+	soffice.data.js.metadata
 
 # note cannot add content of .linkdeps to DEPENDENCIES because it contains -lFoo
 online_LDADD = \
-	libonline.a \
 	${POCOLIB}/libPocoEncodings@POCODEBUG@.a \
 	${POCOLIB}/libPocoNet@POCODEBUG@.a \
 	${POCOLIB}/libPocoUtil@POCODEBUG@.a \


### PR DESCRIPTION
Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: I520aa232f6ac51a6a57f36d8ac775150aa095a4d


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

