### PR TITLE
WASM: Copy all the necessary files from builddir\wasm

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -459,6 +459,25 @@ if !ENABLE_MOBILEAPP
 ADMIN_BUNDLE = $(DIST_FOLDER)/admin-bundle.js
 endif
 
+if ENABLE_WASM
+$(DIST_FOLDER)/online%: $(abs_top_builddir)/wasm/online%
+	@mkdir -p $(dir $@)
+	@cp $< $@
+
+$(DIST_FOLDER)/soffice%: $(abs_top_builddir)/wasm/soffice%
+	@mkdir -p $(dir $@)
+	@cp $< $@
+
+WASM_FILES= \
+	$(DIST_FOLDER)/online.data \
+	$(DIST_FOLDER)/online.js \
+	$(DIST_FOLDER)/online.wasm \
+	$(DIST_FOLDER)/online.wasm.debug.wasm \
+	$(DIST_FOLDER)/online.worker.js \
+	$(DIST_FOLDER)/soffice.data \
+	$(DIST_FOLDER)/soffice.data.js.metadata
+endif
+
 $(TYPESCRIPT_JS_DIR)/%.js: $(srcdir)/%.ts
 	@mkdir -p $(dir $@)
 	$(builddir)/node_modules/typescript/bin/tsc --outFile $@ $<
@@ -477,7 +496,8 @@ build-cool: \
 	$(DIST_FOLDER)/device-tablet.css \
 	$(DIST_FOLDER)/device-desktop.css \
 	$(DIST_FOLDER)/bundle.js \
-	$(DIST_FOLDER)/cool.html
+	$(DIST_FOLDER)/cool.html \
+	$(WASM_FILES)
 	@echo "build cool completed"
 if ENABLE_ANDROIDAPP
 	@if test -d "$(APP_BRANDING_DIR)" ; then cp -a "$(APP_BRANDING_DIR)/branding.css" "$(APP_BRANDING_DIR)/branding.js" $(DIST_FOLDER)/ ; else touch $(DIST_FOLDER)/branding.css ; fi


### PR DESCRIPTION
to browser\dist, otherwise it has to be done by hand after every wasm build.

Signed-off-by: Balázs Varga (allotropia) <balazs.varga.extern@allotropia.de>
Change-Id: I46c432116d0d42016dfc1573009d284f82c52114


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

