### PR TITLE
Handle CTRL+A selection event of formulabar

### DIFF
--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -48,6 +48,7 @@ L.Clipboard = L.Class.extend({
 		document.onbeforecut = beforeSelect;
 		document.onbeforecopy = beforeSelect;
 		document.onbeforepaste = beforeSelect;
+		document.onselectionchange = function() { return that.selectionchange(); };
 	},
 
 	// We can do a much better job when we fetch text/plain too.
@@ -755,6 +756,11 @@ L.Clipboard = L.Class.extend({
 				this._stopHideDownload();
 		}
 		return false;
+	},
+
+	// Listens all type selection changes from out of the map eg:formulabar
+	selectionchange: function() {
+		this.setTextSelectionText(document.getSelection());
 	},
 
 	clearSelection: function() {


### PR DESCRIPTION
Current event listeners can listen CTRL+A event on sheet but we don't have a listener for CTRL+A to update clipboard on selection changed on formula bar. As a result copy paste was not working normally.

With that patch we can update selection of clipboard object even in we are on formula bar's text input areas. And copy paste works.

Signed-off-by: Gülşah Köse <gulsah.kose@collabora.com>
Change-Id: I07221197dc9ecacc47abb5324be0f8c09505b5cb


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

