### PR TITLE
Set inital focus widget for repair dialog

### DIFF
--- a/browser/src/control/Control.DocumentRepair.js
+++ b/browser/src/control/Control.DocumentRepair.js
@@ -28,6 +28,7 @@ L.Control.DocumentRepair = L.Control.extend({
 					response: 0
 				},
 			],
+			'init_focus_id': 'ok',
 			enabled: true,
 			children: [
 				{


### PR DESCRIPTION
Without this change focus is on sheet and ESC does not close the dialog

Signed-off-by: Gülşah Köse <gulsah.kose@collabora.com>
Change-Id: Ib60e681726393c67b38101d6eb48e3693ba156e3


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

