### PR TITLE
handle incoming mouse pointer style msg

### DIFF
--- a/browser/src/layer/marker/Cursor.ts
+++ b/browser/src/layer/marker/Cursor.ts
@@ -80,6 +80,11 @@ class Cursor {
 			}
 		}
 	}
+	setMouseCursorForTextBox() {
+		if (this.domAttached && this.container && this.container.querySelector('.blinking-cursor') !== null) {
+			$('.leaflet-interactive').css('cursor', 'text');
+		}
+	}
 
 	remove() {
 		this.map.off('splitposchanged', this.update, this);

--- a/browser/src/layer/marker/TextInput.js
+++ b/browser/src/layer/marker/TextInput.js
@@ -433,7 +433,7 @@ L.TextInput = L.Layer.extend({
 			// Display caret
 			this._map._docLayer._cursorMarker.add();
 		}
-		this._map._docLayer._cursorMarker.setMouseCursor();
+		this._map._docLayer._cursorMarker.setMouseCursorForTextBox();
 
 		// Move and display under-caret marker
 		if (L.Browser.touch) {

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -2382,8 +2382,9 @@ L.CanvasTileLayer = L.Layer.extend({
 	_onMousePointerMsg: function (textMsg) {
 		textMsg = textMsg.substring(14); // "mousepointer: "
 		textMsg = Cursor.getCustomCursor(textMsg) || textMsg;
-		if (this._map._container.style.cursor !== textMsg) {
-			this._map._container.style.cursor = textMsg;
+		var mapPane = $('.leaflet-pane.leaflet-map-pane');
+		if (mapPane.css('cursor') !== textMsg) {
+			mapPane.css('cursor', textMsg);
 		}
 	},
 


### PR DESCRIPTION
Problem: pointer style was set up for a <div> element wrapping the map
pane, anyway a further <div> element in the middle had the pointer
style always set up to 'text', so any incoming mouse pointer msg had
no effect.
Now the pointer style is set up on the same <div> element.

Moreover I noticed that in writer mouse pointer hovering over an
edited text box had a wrong style. This commit fix this issue, too.

Signed-off-by: Marco Cecchetti <marco.cecchetti@collabora.com>
Change-Id: I3f62908b00ab748d19a3651270babb926252fe21
