### PR TITLE
Modified Flag Handling

### DIFF
--- a/common/Protocol.hpp
+++ b/common/Protocol.hpp
@@ -237,20 +237,28 @@ namespace COOLProtocol
     /// can only potentially be modifying, e.g. 'mouse' while dragging.
     /// Note: this is only used when we don't have the modified flag from
     /// Core so we flag the document as user-modified more accurately.
-    inline bool tokenIndicatesDocumentModification(const std::string& token)
+    inline bool tokenIndicatesDocumentModification(const StringVector& tokens)
     {
         // These keywords are chosen to cover the largest set of
         // commands that may potentially modify the document.
         // We need to assume modification rather than not.
-        return (
-            token.find("mouse") != std::string::npos || token.find("key") != std::string::npos ||
-            token.find("command") != std::string::npos ||
-            token.find("select") != std::string::npos || token.find("set") != std::string::npos ||
-            token.find("uno") != std::string::npos || token.find("input") != std::string::npos ||
-            token.find("move") != std::string::npos || token.find("paste") != std::string::npos ||
-            token.find("insert") != std::string::npos ||
-            token.find("resize") != std::string::npos ||
-            token.find("remove") != std::string::npos || token.find("sign") != std::string::npos);
+        if (tokens.equals(0, "key") || tokens.equals(0, "outlinestate") ||
+            tokens.equals(0, "paste") || tokens.equals(0, "insertfile") ||
+            tokens.equals(0, "textinput") || tokens.equals(0, "windowkey") ||
+            tokens.equals(0, "windowmouse") || tokens.equals(0, "windowgesture") ||
+            tokens.equals(0, "signdocument"))
+        {
+            return true;
+        }
+
+        if (tokens.size() > 1 && tokens.equals(0, "uno"))
+        {
+            // By default, all uno commands are modifying, unless we are certain they don't.
+            return !tokens.equals(1, ".uno:SidebarHide") && !tokens.equals(1, ".uno:SidebarShow") &&
+                   !tokens.equals(1, ".uno:Copy") && !tokens.equals(1, ".uno:Save");
+        }
+
+        return false;
     }
 
     /// Returns the first line of a message.

--- a/test/UnitWOPIFailUpload.cpp
+++ b/test/UnitWOPIFailUpload.cpp
@@ -181,7 +181,7 @@ public:
 /// This test simulates an expired token when uploading.
 class UnitWOPIExpiredToken : public WopiTestServer
 {
-    STATE_ENUM(Phase, Load, WaitLoadStatus, ModifyAndClose, WaitPutFile, Done) _phase;
+    STATE_ENUM(Phase, Load, WaitLoadStatus, WaitPutFile, Done) _phase;
 
 public:
     UnitWOPIExpiredToken()
@@ -224,7 +224,11 @@ public:
         LOG_TST("onDocumentLoaded: [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitLoadStatus);
 
-        TRANSITION_STATE(_phase, Phase::ModifyAndClose);
+        TRANSITION_STATE(_phase, Phase::WaitPutFile);
+
+        WSD_CMD("key type=input char=97 key=0");
+        WSD_CMD("key type=up char=0 key=512");
+        WSD_CMD("closedocument");
 
         return true;
     }
@@ -260,16 +264,6 @@ public:
                 break;
             }
             case Phase::WaitLoadStatus:
-                break;
-            case Phase::ModifyAndClose:
-            {
-                TRANSITION_STATE(_phase, Phase::WaitPutFile);
-
-                WSD_CMD("key type=input char=97 key=0");
-                WSD_CMD("key type=up char=0 key=512");
-                WSD_CMD("closedocument");
-                break;
-            }
             case Phase::WaitPutFile:
             case Phase::Done:
             {

--- a/test/UnitWOPISaveOnExit.cpp
+++ b/test/UnitWOPISaveOnExit.cpp
@@ -55,7 +55,6 @@ public:
         assertGetFileCount();
     }
 
-
     std::unique_ptr<http::Response>
     assertPutFileRequest(const Poco::Net::HTTPRequest& /*request*/) override
     {

--- a/wsd/AdminModel.cpp
+++ b/wsd/AdminModel.cpp
@@ -485,13 +485,9 @@ void AdminModel::addBytes(const std::string& docKey, uint64_t sent, uint64_t rec
     _recvBytesTotal += recv;
 }
 
-void AdminModel::modificationAlert(const std::string& docKey, pid_t pid, bool value)
+void AdminModel::modificationAlert(const std::string& /*docKey*/, pid_t pid, bool value)
 {
     assertCorrectThread();
-
-    auto doc = _documents.find(docKey);
-    if (doc != _documents.end())
-        doc->second->setModified(value);
 
     std::ostringstream oss;
     oss << "modifications "

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -473,6 +473,7 @@ bool ClientSession::_handleInput(const char *buffer, int length)
             docBroker->updateEditingSessionId(getId());
         }
     }
+
     if (tokens.equals(0, "coolclient"))
     {
         if (tokens.size() < 2)
@@ -492,13 +493,13 @@ bool ClientSession::_handleInput(const char *buffer, int length)
         _performanceCounterEpoch = 0;
         if (tokens.size() >= 4)
         {
-            std::string timestamp = tokens[2];
+            const std::string timestamp = tokens[2];
             const char* str = timestamp.c_str();
             char* endptr = nullptr;
             uint64_t ts = strtoull(str, &endptr, 10);
             if (*endptr == '\0')
             {
-                std::string perfcounter = tokens[3].data();
+                const std::string perfcounter = tokens[3];
                 str = perfcounter.data();
                 endptr = nullptr;
                 double counter = strtod(str, &endptr);

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -462,10 +462,6 @@ bool ClientSession::_handleInput(const char *buffer, int length)
         // Keep track of timestamps of incoming client messages that indicate user activity.
         updateLastActivityTime();
         docBroker->updateLastActivityTime();
-        if (COOLProtocol::tokenIndicatesDocumentModification(tokens[0]))
-        {
-            docBroker->updateLastModifyingActivityTime();
-        }
 
         if (isEditable() && isViewLoaded())
         {
@@ -792,6 +788,7 @@ bool ClientSession::_handleInput(const char *buffer, int length)
             }
             else
             {
+                docBroker->updateLastModifyingActivityTime();
                 return forwardToChild(std::string(buffer, length), docBroker);
             }
         }
@@ -1027,6 +1024,11 @@ bool ClientSession::_handleInput(const char *buffer, int length)
     {
         if (tokens.equals(0, "key"))
             _keyEvents++;
+
+        if (COOLProtocol::tokenIndicatesDocumentModification(tokens))
+        {
+            docBroker->updateLastModifyingActivityTime();
+        }
 
         if (!filterMessage(firstLine))
         {


### PR DESCRIPTION
Resolves #5450

- wsd: break cyclic setModified call
- wsd: const and minor cleanup
- wsd: more accurate possible-modification flagging
- wsd: test: simplify UnitWOPIExpiredToken
