### PR TITLE
Prevent double feature unlock dialog

### DIFF
--- a/browser/src/control/Control.Command.js
+++ b/browser/src/control/Control.Command.js
@@ -3,7 +3,8 @@
  * Feature blocking handler
  */
 
-/* global $ vex _ */
+/* global $ vex _ isAnyVexDialogActive*/
+
 L.Map.include({
 
 	Locking: {
@@ -57,7 +58,7 @@ L.Map.include({
 	},
 
 	openUnlockPopup: function(cmd) {
-		if (this.isRestrictedUser() && this.isRestrictedItem(cmd))
+		if ((this.isRestrictedUser() && this.isRestrictedItem(cmd)) || isAnyVexDialogActive())
 			return;
 		var lockingOnMobile = '';
 


### PR DESCRIPTION
If we have already a feature unlock dialog open, don't let open the second one.

Signed-off-by: Gülşah Köse <gulsah.kose@collabora.com>
Change-Id: I7c7235bc1a64c48ba69f11d0599bbb9839b7fe71


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

