### PR TITLE
Bin superfluous logging of what we are about to send to the JS bits

### DIFF
--- a/wasm/wasmapp.cpp
+++ b/wasm/wasmapp.cpp
@@ -21,11 +21,6 @@ static int closeNotificationPipeForForwardingThread[2] = {-1, -1};
 
 static void send2JS(const std::vector<char>& buffer)
 {
-    if (buffer.size() < SHOW_JS_MAXLEN)
-        LOG_TRC_NOFILE("Send to JS: " << std::string(buffer.data(), buffer.size()));
-    else
-        LOG_TRC_NOFILE("Send to JS: " << std::string(buffer.data(), SHOW_JS_MAXLEN) << "...");
-
     std::string js;
 
     // Check if the message is binary. We say that any message that isn't just a single line is


### PR DESCRIPTION
We are logging what we are evaluating as JavaScript later in the function anyway.

Signed-off-by: Tor Lillqvist <tml@collabora.com>
Change-Id: I79972ec585dee128bbcca910def1d46e8134cdc5


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

