### PR TITLE
wsd: .uno:Copy is allowed for internal use

### DIFF
--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1339,8 +1339,10 @@ bool ClientSession::filterMessage(const std::string& message) const
             LOG_WRN("No value of id in downloadas message");
         }
     }
-    else if (tokens.equals(0, "gettextselection") || tokens.equals(0, ".uno:Copy"))
+    else if (tokens.equals(0, "gettextselection"))
     {
+        // Copying/pasting *within* the document is fine,
+        // so keep .uno:Copy and .uno:Paste, but exporting is not.
         if (_wopiFileInfo && _wopiFileInfo->getDisableCopy())
         {
             allowed = false;


### PR DESCRIPTION
When copying is disabled, we still allow
copy/pasting *within* the document. What
is disabled is exporting the copied data
to the browser.

Luckily, this code was broken, and it
wasn't really blocking .uno:Copy at all.

Change-Id: I50a01eefbe1de3758b4451385bbc51fbde5878a8
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
