### PR TITLE
Hyperlink dialog: Use input field instead of textarea for text field

### DIFF
--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -741,7 +741,7 @@ L.Map.include({
 			message: _('Insert hyperlink'),
 			overlayClosesOnClick: false,
 			input: [
-				_('Text') + '<textarea name="text" id="hyperlink-text-box" style="resize: none" type="text"></textarea>',
+				_('Text') + '<input name="text" id="hyperlink-text-box" type="text" value="' + text  + '">',
 				_('Link') + '<input name="link" id="hyperlink-link-box" type="text" value="' + link + '" required/>'
 			].join(''),
 			buttons: [


### PR DESCRIPTION
This change also fixes the weird cursor (since the textarea looked
like a input field with bad heigh and alignment). On top of that
there is no great reason to use a short textarea for text field
instead of a input field

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I44ac38bce565b67ed9e0c4d16f4bd78cd50765d4
