### PR TITLE
Fix helm Lint error on Servicemonitor when Labes are empty

### DIFF
--- a/kubernetes/helm/collabora-online/templates/servicemonitor.yaml
+++ b/kubernetes/helm/collabora-online/templates/servicemonitor.yaml
@@ -5,7 +5,9 @@ metadata:
   name: {{ include "collabora-online.fullname" . }}
   labels:
     {{- include "collabora-online.labels" . | nindent 4 }}
+    {{- if .Values.prometheus.servicemonitor.labels }}
     {{- toYaml .Values.prometheus.servicemonitor.labels | nindent 4 }}
+    {{- end }}
 spec:
   endpoints:
     - port: http


### PR DESCRIPTION
* Resolves: Helm linting error when .Values.prometheus.servicemonitor.labels is empty
### Summary
When .Values.prometheus.servicemonitor.labels is empty but .Values.prometheus.servicemonitor.enabled is true, then the generated YAML could not be converted to JSON so linting failed. 
