### PR TITLE
hide Formatting Marks when on read-only mode

### DIFF
--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -914,7 +914,7 @@ L.Control.Menubar = L.Control.extend({
 			]},
 			{name: _UNO('.uno:ViewMenu', 'text'), id: 'view', type: 'menu', menu: [
 				{name: _UNO('.uno:FullScreen', 'text'), id: 'fullscreen', type: 'action', mobileapp: false},
-				{uno: '.uno:ControlCodes'},
+				{uno: '.uno:ControlCodes', id: 'formattingmarks'},
 				{uno: '.uno:SpellOnline'},
 				{name: _UNO('.uno:ShowResolvedAnnotations', 'text'), id: 'showresolved', type: 'action', uno: '.uno:ShowResolvedAnnotations'},
 			]
@@ -1971,6 +1971,7 @@ L.Control.Menubar = L.Control.extend({
 			case 'pagesetup':
 			case 'watermark':
 			case 'properties':
+			case 'formattingmarks':
 				return false;
 			case 'insertcomment':
 			case 'savecomments':


### PR DESCRIPTION
On mobile, the Formatting marks should not be visible in the hamburger menu when on read-only mode.

- new menuItem.id added for Formatting Marks as "formattingmarks"
- the id is added to the switch case so that it can be hidden on read-only mode


Change-Id: I17098e0cd0b59556ab85d93b51745ff376f6156e


* Resolves: #5868
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

