### PR TITLE
Added functionality to switch spreadsheet tabs using key board shortcut

### DIFF
--- a/browser/src/map/handler/Map.Keyboard.js
+++ b/browser/src/map/handler/Map.Keyboard.js
@@ -497,6 +497,21 @@ L.Map.Keyboard = L.Handler.extend({
 			return;
 		}
 
+		if (!this.modifier && this._map.getDocType() === 'spreadsheet' && (keyCode === this.keyCodes.pageUp || keyCode === this.keyCodes.pageDown) && ev.type === 'keydown') {
+			ev.preventDefault();
+			var currentSelectedPart = this._map._docLayer._selectedPart;
+			var parts = this._map._docLayer._parts;
+			var partToSelect = 0;
+			this._map._docLayer._clearReferences();
+
+			if (keyCode === this.keyCodes.pageUp) {
+				partToSelect = currentSelectedPart != parts - 1 ? currentSelectedPart + 1 : 0;
+			}
+			else {
+				partToSelect = currentSelectedPart != 0 ? currentSelectedPart - 1 : parts - 1;
+			}
+			this._map.setPart(parseInt(partToSelect), /*external:*/ false, /*calledFromSetPartHandler:*/ true);
+		}
 		if (this._map.isEditMode()) {
 			docLayer._resetPreFetching();
 
@@ -783,7 +798,6 @@ L.Map.Keyboard = L.Handler.extend({
 		}
 		return false;
 	},
-
 	readOnlyAllowedShortcuts: function(e) {
 		// Open keyboard shortcuts help page
 		if (this._isCtrlKey(e) && e.shiftKey && e.key === '?')


### PR DESCRIPTION
- Added tab switch functionality in spreadsheet using keyboard shortcut ( Pageup and pagedown )
- There are some restrictions of chrome browser when we want to use CTRL + PAGEUP as keyboard shortcut so as of now i have only used PAGEUP and PAGEDOWN to switch tabs.
-  To test add as many tabs you want and use PAGEUP and PAGEDOWN to move back and forth between spreadsheet tabs 
- By only using PAGEUP and PAGEDOWN as shortcut it will create some user level problem like if user Presses PAGEDOWN then it will switch the tab and scroll down to bottom of the page 
- i am still figuring out how can i add CTRL support so this intervention will not be problem

@mmeeks , @vmiklos ,  @eszkadev 