### PR TITLE
Drop POCO_HAVE_FD_EPOLL for Emscripten

### DIFF
--- a/wasm/poco-1.12.4-emscripten.patch
+++ b/wasm/poco-1.12.4-emscripten.patch
@@ -29,3 +29,14 @@
  	#define POCO_HAVE_FD_EPOLL 1
  #endif
  
+--- poco-1.12.4-all/build/config/Linux
++++ poco-1.12.4-all/build/config/Linux
+@@ -63,7 +63,7 @@
+ #
+ # System Specific Flags
+ #
+-SYSFLAGS = -D_XOPEN_SOURCE=600 -D_REENTRANT -D_THREAD_SAFE -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -DPOCO_HAVE_FD_EPOLL
++SYSFLAGS = -D_XOPEN_SOURCE=600 -D_REENTRANT -D_THREAD_SAFE -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE
+ 
+ #
+ # System Specific Libraries


### PR DESCRIPTION
Not sure why I now suddenly needed this, too, when I recompiled Poco for WASM (with different options than before).


Change-Id: I7221947e0cd2264535b6d34e0640b95d7cfc7cf4


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

