### PR TITLE
Mobile: spreadsheet: Allow user to define and remove print area

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2141,6 +2141,8 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		}
 
 		var iconURLAliases = {
+			'defineprintarea': 'menuprintranges',
+			'deleteprintarea': 'delete',
 			'sheetrighttoleft' : 'pararighttoleft',
 			'alignleft': 'leftpara',
 			'alignright': 'rightpara',

--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -1051,6 +1051,8 @@ L.Control.Menubar = L.Control.extend({
 				{name: _('See revision history'), id: 'rev-history', type: 'action'},
 				{type: 'separator'},
 				{name: _UNO('.uno:Print', 'spreadsheet'), id: 'print', type: 'action'},
+				{name: _('Define print area', 'spreadsheet'), uno: '.uno:DefinePrintArea' },
+				{name: _('Remove print area', 'spreadsheet'), uno: '.uno:DeletePrintArea' },
 				{name: _UNO('.uno:SetDocumentProperties', 'spreadsheet'), uno: '.uno:SetDocumentProperties', id: 'properties'}
 			]},
 			{name: !window.ThisIsAMobileApp ? _('Download as') : _('Export as'), id:'downloadas', type: 'menu', menu: [


### PR DESCRIPTION
This fixes #353

For now add only the .uno:DefinePrintArea and DeletePrintArea
- Edit triggers a tunneled dialog and thus is not ready for mobile
- Add (allows to add multiple) is should not be added to mobile until
Edit is available

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I27b5377d00080e745aab465da4dd65fffeaa3217
