### PR TITLE
Fix writer/help_dialog_update_spec.js spec issues

### DIFF
--- a/cypress_test/integration_tests/desktop/writer/help_dialog_update_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/help_dialog_update_spec.js
@@ -68,7 +68,7 @@ describe('Help dialog screenshot updation', function() {
 		cy.get('#menu-editmenu').click()
 			.get('#menu-repair').click();
 
-		cy.get('.jsdialog-container.lokdialog_container')
+		cy.get('.jsdialog-container.lokdialog_container') 
 			.should('exist');
 
 		helper.waitUntilIdle('.jsdialog-container.lokdialog_container');
@@ -153,7 +153,7 @@ describe('Help dialog screenshot updation', function() {
 		copyScreenshot('insert-table.png');
 	});
 
-	it('word count', function() {
+	it('Word count', function() {
 		cy.get('#menu-tools')
 			.click();
 
@@ -168,7 +168,7 @@ describe('Help dialog screenshot updation', function() {
 		copyScreenshot('word-count.png');
 	});
 
-	it('insert special', function() {
+	it('Insert special', function() {
 		cy.get('#toolbar-up > .w2ui-scroll-right')
 			.click();
 
@@ -188,7 +188,7 @@ describe('Help dialog screenshot updation', function() {
 		copyScreenshot('special-character.png');
 	});
 
-	it('manage changes', function() {
+	it('Manage changes', function() {
 		cy.get('#menu-editmenu')
 			.click()
 			.get('#menu-changesmenu')

--- a/cypress_test/integration_tests/desktop/writer/help_dialog_update_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/help_dialog_update_spec.js
@@ -68,12 +68,12 @@ describe('Help dialog screenshot updation', function() {
 		cy.get('#menu-editmenu').click()
 			.get('#menu-repair').click();
 
-		cy.get('.leaflet-popup-content-wrapper')
+		cy.get('.jsdialog-container.lokdialog_container')
 			.should('exist');
 
-		helper.waitUntilIdle('.leaflet-popup-content-wrapper');
+		helper.waitUntilIdle('.jsdialog-container.lokdialog_container');
 
-		cy.get('.leaflet-popup-content-wrapper')
+		cy.get('.jsdialog-container.lokdialog_container')
 			.screenshot('repair-document');
 
 		copyScreenshot('repair-document.png');

--- a/cypress_test/integration_tests/desktop/writer/help_dialog_update_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/help_dialog_update_spec.js
@@ -89,11 +89,11 @@ describe('Help dialog screenshot updation', function() {
 
 		cy.get('#new-mobile-comment-input-area').type('comment added');
 
-		cy.get('.vex-dialog-buttons .button-primary').click();
+		cy.get('.vex-dialog-buttons .button-primary').click(); // save button
 
 		cy.wait(1000);
 
-		cy.get('.cool-annotation-collapsed').click();
+		cy.get('.jsdialog-container.cool-annotation-collapsed').click();
 
 		cy.wait(1000);
 


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

Has several problems stopping tests from passing:
~~- [ ] Running entire spec causes all 11 tests to hang on 'pending' with no progress (may just be an issue on my end)~~
    - Just needed the `UPDATE_SCREENSHOT=true` tag
- [x] `Document Repair` test asserts for a tunneled dialog which is now a jsdialog
- [x] `Comment` test tries to click based on a selector which could be three different elements
- [ ] 


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

