### PR TITLE
Improve Lock Refreshing

### DIFF
--- a/test/UnitWOPILock.cpp
+++ b/test/UnitWOPILock.cpp
@@ -52,7 +52,8 @@ public:
         fileInfo->set("BaseFileName", "doc.odt");
     }
 
-    void assertLockRequest(const Poco::Net::HTTPRequest& request) override
+    std::unique_ptr<http::Response>
+    assertLockRequest(const Poco::Net::HTTPRequest& request) override
     {
         const std::string lock = request.get("X-WOPI-Lock", std::string());
         const std::string newLockState = request.get("X-WOPI-Override", std::string());
@@ -81,6 +82,8 @@ public:
         {
             LOK_ASSERT_FAIL("Unexpected lock-state change while in " + toString(_phase));
         }
+
+        return nullptr; // Success.
     }
 
     void onDocBrokerViewLoaded(const std::string&,

--- a/test/UnitWOPIUnlock.cpp
+++ b/test/UnitWOPIUnlock.cpp
@@ -49,7 +49,8 @@ public:
         return nullptr;
     }
 
-    void assertLockRequest(const Poco::Net::HTTPRequest& request) override
+    std::unique_ptr<http::Response>
+    assertLockRequest(const Poco::Net::HTTPRequest& request) override
     {
         const std::string lock = request.get("X-WOPI-Lock", std::string());
         const std::string newLockState = request.get("X-WOPI-Override", std::string());
@@ -79,6 +80,8 @@ public:
         {
             LOK_ASSERT_FAIL("Unexpected lock-state change while in " + toString(_phase));
         }
+
+        return nullptr; // Success.
     }
 
     /// Called when a new client session is added to a DocumentBroker.

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1399,6 +1399,8 @@ void ClientSession::sendFileMode(const bool readOnly, const bool editComments)
 
 void ClientSession::setLockFailed(const std::string& sReason)
 {
+    // TODO: make this "read-only" a special one with a notification (infobar? balloon tip?)
+    //       and a button to unlock
     _isLockFailed = true;
     setReadOnly(true);
     sendTextFrame("lockfailed:" + sReason);

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -963,10 +963,10 @@ bool DocumentBroker::download(const std::shared_ptr<ClientSession>& session, con
             !fileInfo.getLastModifiedTime().empty() &&
             _storageManager.getLastModifiedTime() != fileInfo.getLastModifiedTime())
         {
-            LOG_DBG("Document " << _docKey << "] has been modified behind our back. "
-                                << "Informing all clients. Expected: "
-                                << _storageManager.getLastModifiedTime()
-                                << ", Actual: " << fileInfo.getLastModifiedTime());
+            LOG_DBG("Document [" << _docKey << "] has been modified behind our back. "
+                                 << "Informing all clients. Expected: "
+                                 << _storageManager.getLastModifiedTime()
+                                 << ", Actual: " << fileInfo.getLastModifiedTime());
 
             _documentChangedInStorage = true;
             const std::string message = isModified() ? "error: cmd=storage kind=documentconflict"

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -280,7 +280,7 @@ public:
     virtual void setInteractive(bool value);
 
     /// If not yet locked, try to lock
-    bool attemptLock(const ClientSession& session, std::string& failReason);
+    bool attemptLock(ClientSession& session, std::string& failReason);
 
     bool isDocumentChangedInStorage() { return _documentChangedInStorage; }
 
@@ -513,6 +513,10 @@ private:
     bool download(const std::shared_ptr<ClientSession>& session, const std::string& jailId);
     bool isLoaded() const { return _docState.hadLoaded(); }
     bool isInteractive() const { return _docState.isInteractive(); }
+
+    /// Updates the document's lock in storage to either locked or unlocked.
+    /// Returns true iff the operation was successful.
+    bool updateStorageLockState(ClientSession& session, bool lock, std::string& error);
 
     std::size_t getIdleTimeSecs() const
     {

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -553,10 +553,8 @@ void LockContext::initSupportsLocks()
 
 bool LockContext::needsRefresh(const std::chrono::steady_clock::time_point &now) const
 {
-    static int refreshSeconds = COOLWSD::getConfigValue<int>("storage.wopi.locking.refresh", 900);
-    return _supportsLocks && _isLocked && refreshSeconds > 0 &&
-        std::chrono::duration_cast<std::chrono::seconds>
-        (now - _lastLockTime).count() >= refreshSeconds;
+    return _supportsLocks && _isLocked && _refreshSeconds > std::chrono::seconds::zero() &&
+           (now - _lastLockTime) >= _refreshSeconds;
 }
 
 void LockContext::dumpState(std::ostream& os) const

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -52,7 +52,12 @@ struct LockContext
     /// Reason for unsuccessful locking request
     std::string _lockFailureReason;
 
-    LockContext() : _supportsLocks(false), _isLocked(false) { }
+    LockContext()
+        : _supportsLocks(false)
+        , _isLocked(false)
+        , _refreshSeconds(COOLWSD::getConfigValue<int>("storage.wopi.locking.refresh", 900))
+    {
+    }
 
     /// one-time setup for supporting locks & create token
     void initSupportsLocks();
@@ -61,6 +66,9 @@ struct LockContext
     bool needsRefresh(const std::chrono::steady_clock::time_point &now) const;
 
     void dumpState(std::ostream& os) const;
+
+private:
+    const std::chrono::seconds _refreshSeconds;
 };
 
 /// Base class of all Storage abstractions.

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -341,9 +341,16 @@ public:
 
     std::string getFileExtension() const { return Poco::Path(_fileInfo.getFilename()).getExtension(); }
 
+    STATE_ENUM(LockUpdateResult,
+               UNSUPPORTED, //< Locking is not supported on this host.
+               OK, //< Succeeded to either lock or unlock (see LockContext).
+               UNAUTHORIZED, //< 401, 403, 404.
+               FAILED //< Other failures.
+    );
+
     /// Update the locking state (check-in/out) of the associated file
-    virtual bool updateLockState(const Authorization& auth, LockContext& lockCtx, bool lock,
-                                 const Attributes& attribs) = 0;
+    virtual LockUpdateResult updateLockState(const Authorization& auth, LockContext& lockCtx,
+                                             bool lock, const Attributes& attribs) = 0;
 
     /// Returns a local file path for the given URI.
     /// If necessary copies the file locally first.
@@ -474,9 +481,10 @@ public:
     /// obtained using getFileInfo method
     std::unique_ptr<LocalFileInfo> getLocalFileInfo();
 
-    bool updateLockState(const Authorization&, LockContext&, bool, const Attributes&) override
+    LockUpdateResult updateLockState(const Authorization&, LockContext&, bool,
+                                     const Attributes&) override
     {
-        return true;
+        return LockUpdateResult::OK;
     }
 
     std::string downloadStorageFileToLocal(const Authorization& auth, LockContext& lockCtx,
@@ -645,8 +653,8 @@ public:
                                                         unsigned redirectLimit);
 
     /// Update the locking state (check-in/out) of the associated file
-    bool updateLockState(const Authorization& auth, LockContext& lockCtx, bool lock,
-                         const Attributes& attribs) override;
+    LockUpdateResult updateLockState(const Authorization& auth, LockContext& lockCtx, bool lock,
+                                     const Attributes& attribs) override;
 
     /// uri format: http://server/<...>/wopi*/files/<id>/content
     std::string downloadStorageFileToLocal(const Authorization& auth, LockContext& lockCtx,


### PR DESCRIPTION
Resolves #5870.

- wsd: minor log improvement
- wsd: test: support controlling the response to LOCK/UNLOCK
- wsd: avoid function-local static configs in LockContext
- wsd: detect unuathorized locking/unlocking response
- wsd: handle errors from locking/unlocking a document
- wsd: test: new test to verify refresh lock behavior
- wsd: test: minor cleanup of UnitWopiLock
