### PR TITLE
Accessiblity checker tabbed item should only exist for text doctype

### DIFF
--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -292,6 +292,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 	getHelpTab: function() {
 		var hasLatestUpdates = window.enableWelcomeMessage;
 		var hasFeedback = this._map.feedback;
+		var hasAccessibilityCheck = this._map.getDocType() === 'text';
 		var hasAbout = L.DomUtil.get('about-dialog') !== null;
 
 		var content = [
@@ -331,11 +332,12 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 							}
 						]
 					},
-					{
-						'type': 'bigtoolitem',
-						'text': _UNO('.uno:AccessibilityCheck', 'text'),
-						'command': '.uno:AccessibilityCheck'
-					},
+					hasAccessibilityCheck ?
+						{
+							'type': 'bigtoolitem',
+							'text': _UNO('.uno:AccessibilityCheck', 'text'),
+							'command': '.uno:AccessibilityCheck'
+						} : {},
 					{
 						'type': 'toolbox',
 						'children': [


### PR DESCRIPTION
Since the helptab is shared between different doctypes we need to
make sure that writer's accessibility check doesn't bleed out to
other doctypes

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ic4d35fe080cbefc2564db1a250dbf6d62274de69
