### PR TITLE
use getrandom() instead of /dev/[u]random

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1080,6 +1080,26 @@ else
     AC_DEFINE([HAVE_STD_FILESYSTEM_EXPERIMENTAL],0,[Whether the std::filesystem is in the experimental header.])
 fi
 
+SYS_RANDOM=
+AC_LANG_PUSH([C++])
+AC_LINK_IFELSE(
+    [AC_LANG_SOURCE([[
+    #include <sys/random.h>
+    int main()
+    {
+        char buffer[8];
+        getrandom(buffer, sizeof(buffer), GRND_NONBLOCK);
+    }
+    ]])],
+    [SYS_RANDOM=TRUE])
+AC_LANG_POP([C++])
+
+if test "$SYS_RANDOM" == "TRUE" ; then
+    AC_DEFINE([HAVE_SYS_RANDOM_H],1,[Define to 1 if you have the <sys/random.h> header file.])
+else
+    AC_DEFINE([HAVE_SYS_RANDOM_H],0,[Define to 1 if you have the <sys/random.h> header file.])
+fi
+
 AS_IF([test -n "$LOKIT_PATH"],
       [CPPFLAGS="$CPPFLAGS -I${LOKIT_PATH}"])
 lokit_msg="$LOKIT_PATH"


### PR DESCRIPTION
Change-Id: Id64b35a02718f59014b18f5c667a7465bcf8cb43

* Resolves: #5851
* Target version: master 

### Summary
- instead of using /dev/[u]random devices, use
getrandom() and/or getentropy() to make direct
system calls if sys/random.h available.

- if getrandom() fails, we need to fall back to 
"/dev/[u]random" approach.

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

