### PR TITLE
Partial fix #5885 Close the font picker when a font is tapped

### DIFF
--- a/ios/Mobile/DocumentViewController.mm
+++ b/ios/Mobile/DocumentViewController.mm
@@ -566,6 +566,10 @@ static IMP standardImpOfInputAccessoryView = nil;
 }
 
 - (void)fontPickerViewControllerDidPickFont:(UIFontPickerViewController *)viewController {
+    // Close the font picker when a font is tapped
+    // This matches the behavior of Apple apps such as Pages and Mail.
+    [viewController dismissViewControllerAnimated:YES completion:nil];
+
     // NSLog(@"Picked font: %@", [viewController selectedFontDescriptor]);
     NSDictionary<UIFontDescriptorAttributeName, id> *attribs = [[viewController selectedFontDescriptor] fontAttributes];
     NSString *family = attribs[UIFontDescriptorFamilyAttribute];

--- a/ios/Mobile/DocumentViewController.mm
+++ b/ios/Mobile/DocumentViewController.mm
@@ -566,7 +566,7 @@ static IMP standardImpOfInputAccessoryView = nil;
 }
 
 - (void)fontPickerViewControllerDidPickFont:(UIFontPickerViewController *)viewController {
-    // Close the font picker when a font is tapped
+    // Partial fix #5885 Close the font picker when a font is tapped
     // This matches the behavior of Apple apps such as Pages and Mail.
     [viewController dismissViewControllerAnimated:YES completion:nil];
 

--- a/ios/README
+++ b/ios/README
@@ -9,5 +9,6 @@ This version includes the latest 22.05.10 code and fixes the following bugs:
 • Presentation documents saved in outline view would display as an empty document
 • The font selection button would display as non-tappable text
 • Tapping on a font in the native font picker popup would not close the popup
+• Non-ASCII characters would be misencoded in the sidebar panel
 
 Also, the obsolete Template List URL setting  was removed from the Collabora Office panel in the Settings app.

--- a/ios/README
+++ b/ios/README
@@ -6,10 +6,8 @@ App Store "Test Details" text for the last TestFlight build
 
 This version includes the latest 22.05.10 code and fixes the following bugs:
 
-• A crash would occur when opening certain presentation or draw documents
-• Some dialogs would only display an empty gray window
-• The font selection button would not display a list of fonts when tapped
+• Presentation documents saved in outline view would display as an empty document
+• The font selection button would display as non-tappable text
+• Tapping on a font in the native font picker popup would not close the popup
 
-Important note (le texte en français est ci-dessous): this version is not available for the users of the App Store in France because we are waiting for approval to distribute in France from the Agence nationale de la sécurité des systèmes d’information (ANSSI).
-
-Note importante : cette version n'est pas disponible pour les utilisateurs de l'App Store dans France à cause de nous attendons l'autorisation de diffusion dans France de l'Agence nationale de la sécurité des systèmes d'information (ANSSI).
+Also, the obsolete Template List URL setting  was removed from the Collabora Office panel in the Settings app.


### PR DESCRIPTION
This matches the behavior of Apple apps such as Pages and Mail.