### PR TITLE
Remove unnecessary `.wait`s from image tests

### DIFF
--- a/cypress_test/integration_tests/desktop/writer/image_operation_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/image_operation_spec.js
@@ -29,7 +29,8 @@ describe('Image Operation Tests', function() {
 		insertImage();
 		//when Keep ratio is unchecked
 		assertImageSize(248, 63);
-		// TODO: if window is too small sidebar won't popup
+		// if window is too small sidebar won't popup
+		cy.viewport(1000, 660);
 
 		cy.get('#selectwidth input').clear({force:true})
 			.type('3{enter}', {force:true});

--- a/cypress_test/integration_tests/desktop/writer/image_operation_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/image_operation_spec.js
@@ -29,30 +29,21 @@ describe('Image Operation Tests', function() {
 		insertImage();
 		//when Keep ratio is unchecked
 		assertImageSize(248, 63);
-
-		helper.waitUntilIdle('#selectwidth input');
+		// TODO: if window is too small sidebar won't popup
 
 		cy.get('#selectwidth input').clear({force:true})
 			.type('3{enter}', {force:true});
 
-		helper.waitUntilIdle('#selectheight input');
-
 		cy.get('#selectheight input').clear({force:true})
 			.type('2{enter}', {force:true});
-
-		cy.wait(1000);
 
 		assertImageSize(139, 93);
 
 		//Keep ratio checked
 		cy.get('#ratio input').check();
 
-		helper.waitUntilIdle('#selectheight input');
-
 		cy.get('#selectheight input').clear({force:true})
 			.type('5{enter}', {force:true});
-
-		cy.wait(1000);
 
 		assertImageSize(347, 232);
 	});


### PR DESCRIPTION
Tests consistently pass without these waits.


* Resolves: # <!-- related github issue -->
* Target version: master 
* https://phabricator.collabora.com/T39833

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

