### PR TITLE
Partial fix #5885 Close the font picker when a font is tapped

### DIFF
--- a/ios/Mobile/DocumentViewController.mm
+++ b/ios/Mobile/DocumentViewController.mm
@@ -566,6 +566,10 @@ static IMP standardImpOfInputAccessoryView = nil;
 }
 
 - (void)fontPickerViewControllerDidPickFont:(UIFontPickerViewController *)viewController {
+    // Partial fix #5885 Close the font picker when a font is tapped
+    // This matches the behavior of Apple apps such as Pages and Mail.
+    [viewController dismissViewControllerAnimated:YES completion:nil];
+
     // NSLog(@"Picked font: %@", [viewController selectedFontDescriptor]);
     NSDictionary<UIFontDescriptorAttributeName, id> *attribs = [[viewController selectedFontDescriptor] fontAttributes];
     NSString *family = attribs[UIFontDescriptorFamilyAttribute];

--- a/ios/README
+++ b/ios/README
@@ -4,12 +4,4 @@ See https://collaboraonline.github.io/post/build-code-ios/
 App Store "Test Details" text for the last TestFlight build
 -----------------------------------------------------------
 
-This version includes the latest 22.05.10 code and fixes the following bugs:
-
-• A crash would occur when opening certain presentation or draw documents
-• Some dialogs would only display an empty gray window
-• The font selection button would not display a list of fonts when tapped
-
-Important note (le texte en français est ci-dessous): this version is not available for the users of the App Store in France because we are waiting for approval to distribute in France from the Agence nationale de la sécurité des systèmes d’information (ANSSI).
-
-Note importante : cette version n'est pas disponible pour les utilisateurs de l'App Store dans France à cause de nous attendons l'autorisation de diffusion dans France de l'Agence nationale de la sécurité des systèmes d'information (ANSSI).
+This version includes the latest 23.05 code.


### PR DESCRIPTION
This is a near duplicate of pull request #5898.