### PR TITLE
Partial Fix: Speed-up variable substitution

### DIFF
--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -11,8 +11,6 @@
 #include <iomanip>
 #include <string>
 #include <vector>
-#include <unordered_map>
-#include <string_view>
 
 #include <dirent.h>
 #include <sys/stat.h>

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -11,6 +11,8 @@
 #include <iomanip>
 #include <string>
 #include <vector>
+#include <unordered_map>
+#include <string_view>
 
 #include <dirent.h>
 #include <sys/stat.h>

--- a/wsd/FileServer.hpp
+++ b/wsd/FileServer.hpp
@@ -8,6 +8,8 @@
 #pragma once
 
 #include <string>
+#include <unordered_map>
+
 #include "Socket.hpp"
 
 #include <Poco/MemoryStream.h>

--- a/wsd/FileServer.hpp
+++ b/wsd/FileServer.hpp
@@ -73,6 +73,7 @@ private:
     static void sendError(int errorCode, const Poco::Net::HTTPRequest& request,
                           const std::shared_ptr<StreamSocket>& socket, const std::string& shortMessage,
                           const std::string& longMessage, const std::string& extraHeader = "");
+    static void substituteVariables(std::string& file, const std::unordered_map<std::string, std::string>& varMap);
 };
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */


### PR DESCRIPTION
This speeds up variable substitution using the method suggested in #4454 (only for variables in the format `%VAR_NAME%`) in file server.


Change-Id: Ia2d0301c2033fdb5ffcd364a40f5836475af646e


* Resolves: #4454 
* Target version: master 

### Summary


### TODO

- [ ] Improve the algorithm to substitute variables in the format `<!--%VAR_NAME%-->` (note to self, check requirements more carefully next time).
- [ ] Replace string_view (fails GCC 6.3.0 check)

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

