### PR TITLE
zotero: avoid updating bibliography if no citations

### DIFF
--- a/browser/src/control/Control.Zotero.js
+++ b/browser/src/control/Control.Zotero.js
@@ -1275,6 +1275,9 @@ L.Control.Zotero = L.Control.extend({
 		if (!(this.citations && Object.keys(this.citations)))
 			return;
 
+		if (this.getCitationKeys().length === 0)
+			return;
+
 		var that = this;
 
 		if (this.settings.citationFormat === 'numeric') {


### PR DESCRIPTION
sending requests without citation keys returns bibliography for all the items in library this causes problem is the document already has some kind of bibliography which is updated unintentionally


Change-Id: I34976f94bf3cbb6d07fe06e8b1ca974b2ee59ebb


* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

