### PR TITLE
zotero: fetch citation style when zotero is initialized

### DIFF
--- a/browser/src/control/Control.Zotero.js
+++ b/browser/src/control/Control.Zotero.js
@@ -38,6 +38,7 @@ L.Control.Zotero = L.Control.extend({
 	onAdd: function (map) {
 		this.map = map;
 		this.enable = false;
+		this.fetchStyle();
 	},
 
 	extractItemKeyFromLink: function(link) {

--- a/browser/src/map/Map.js
+++ b/browser/src/map/Map.js
@@ -292,8 +292,6 @@ L.Map = L.Evented.extend({
 			this._docLoaded = e.status;
 			if (this._docLoaded) {
 				app.socket.sendMessage('blockingcommandstatus isRestrictedUser=' + this.Restriction.isRestrictedUser + ' isLockedUser=' + this.Locking.isLockedUser);
-				if (this.zotero)
-					this.zotero.fetchStyle();
 				this.notifyActive();
 				if (!document.hasFocus()) {
 					this.fire('editorgotfocus');


### PR DESCRIPTION
when document is loaded zotero may not be initialized, this caused problem and citation style was never fetched


Change-Id: I827bf4edf03dc81bbf8e246280ed14370e438494


* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

