### PR TITLE
fuuzer, httpresponse: clear state before each run

### DIFF
--- a/fuzzer/HttpResponse.cpp
+++ b/fuzzer/HttpResponse.cpp
@@ -6,9 +6,11 @@
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
-    http::Response response;
     for (size_t i = 0; i < size; ++i)
+    {
+        http::Response response;
         response.readData(reinterpret_cast<const char*>(data), i);
+    }
     return 0;
 }
 


### PR DESCRIPTION
The max input size is 16384, so in case the input is saved after each
run, then this can allocate ~300MB of memory. This is considerable
amount, given that the upper limit of the fuzzer process is 2GB.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Ieedb6a537d5b539255ed8bacd79ff23db3c15e9f
