### PR TITLE
jsdialog: handle multiple tab controls inside dialog

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -17,6 +17,8 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		mobileWizard: null,
 		// css class name added to the html nodes
 		cssClass: 'mobile-wizard',
+		// custom tabs placement handled by the parent container
+		useSetTabs: false,
 
 		// create only icon without label
 		noLabelsForUnoButtons: false,
@@ -1027,9 +1029,11 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			}
 			var isMultiTabJSON = tabs > 1;
 
-			var tabsContainer = L.DomUtil.create('div', 'ui-tabs ' + builder.options.cssClass + ' ui-widget');
-			tabsContainer.id = data.id;
-			var contentsContainer = L.DomUtil.create('div', 'ui-tabs-content ' + builder.options.cssClass + ' ui-widget', parentContainer);
+			var tabWidgetRootContainer = L.DomUtil.create('div', 'ui-tabs-root ' + builder.options.cssClass + ' ui-widget', parentContainer);
+			tabWidgetRootContainer.id = data.id;
+
+			var tabsContainer = L.DomUtil.create('div', 'ui-tabs ' + builder.options.cssClass + ' ui-widget', builder.options.useSetTabs ? undefined : tabWidgetRootContainer);
+			var contentsContainer = L.DomUtil.create('div', 'ui-tabs-content ' + builder.options.cssClass + ' ui-widget', tabWidgetRootContainer);
 
 			var tabs = [];
 			var contentDivs = [];
@@ -1077,7 +1081,8 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			}
 
 			if (builder.wizard) {
-				builder.wizard.setTabs(tabsContainer, builder);
+				if (builder.options.useSetTabs)
+					builder.wizard.setTabs(tabsContainer, builder);
 
 				for (var t = 0; t < tabs.length; t++) {
 					// to get capture of 't' right has to be a sub fn.
@@ -1124,6 +1129,9 @@ L.Control.JSDialogBuilder = L.Control.extend({
 	},
 
 	_panelTabsHandler: function(parentContainer, data, builder) {
+		if (!builder.options.useSetTabs)
+			console.warn('mobile panelTabsHandler: setTabs will be used ignoring useSetTabs property');
+
 		var tabsContainer = L.DomUtil.create('div', 'ui-tabs ' + builder.options.cssClass + ' ui-widget');
 		var contentsContainer = L.DomUtil.create('div', 'ui-tabs-content ' + builder.options.cssClass + ' ui-widget', parentContainer);
 

--- a/browser/src/control/Control.MobileWizardWindow.js
+++ b/browser/src/control/Control.MobileWizardWindow.js
@@ -447,8 +447,16 @@ L.Control.MobileWizardWindow = L.Control.extend({
 					} else {
 						this.backButton.hide();
 						popupContainer.empty();
-						if (!this._builder)
-							this._builder = L.control.mobileWizardBuilder({windowId: data.id, mobileWizard: this, map: this.map, cssClass: 'mobile-wizard'});
+						if (!this._builder) {
+							this._builder = L.control.mobileWizardBuilder(
+								{
+									windowId: data.id,
+									mobileWizard: this,
+									map: this.map,
+									cssClass: 'mobile-wizard',
+									useSetTabs: true
+								});
+						}
 						this._builder.build(popupContainer.get(0), [data]);
 					}
 
@@ -486,8 +494,17 @@ L.Control.MobileWizardWindow = L.Control.extend({
 				history.pushState({context: 'mobile-wizard', level: 0}, 'mobile-wizard-level-0');
 			}
 
-			if (!this._builder)
-				this._builder = L.control.mobileWizardBuilder({windowId: data.id, mobileWizard: this, map: this.map, cssClass: 'mobile-wizard', callback: callback});
+			if (!this._builder) {
+				this._builder = L.control.mobileWizardBuilder(
+					{
+						windowId: data.id,
+						mobileWizard: this,
+						map: this.map,
+						cssClass: 'mobile-wizard',
+						callback: callback,
+						useSetTabs: true
+					});
+			}
 			this._builder.build(this.content, [data]);
 			if (window.ThisIsTheAndroidApp)
 				window.postMobileMessage('hideProgressbar');

--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -28,7 +28,7 @@ L.Control.Notebookbar = L.Control.extend({
 		if (document.documentElement.dir === 'rtl')
 			this._RTL = true;
 
-		this.builder = new L.control.notebookbarBuilder({mobileWizard: this, map: map, cssClass: 'notebookbar'});
+		this.builder = new L.control.notebookbarBuilder({mobileWizard: this, map: map, cssClass: 'notebookbar', useSetTabs: true});
 		var toolbar = L.DomUtil.get('toolbar-up');
 		// In case it contains garbage
 		if (toolbar)


### PR DESCRIPTION
It was possible to use only one tab control.
Now useSetTabs parameter for builder is introduced which defines if we want to use custom placement
of tabs handled by the parent container or put
tabs in the place where they are defined in JSON.

Custom placement is needed in mobile-wizard and notebookbar as for them tabs needs to be placed at the top bar.
