### PR TITLE
jsdialog: don't allow opening multiple dialogs

### DIFF
--- a/browser/src/control/Control.DocumentRepair.js
+++ b/browser/src/control/Control.DocumentRepair.js
@@ -196,7 +196,7 @@ L.Control.DocumentRepair = L.Control.extend({
 			type: 'unsigned short',
 			value: index + 1
 		};
-		this._map.sendUnoCommand('.uno:' + action, command);
+		this._map.sendUnoCommand('.uno:' + action, command, true);
 	}
 });
 

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -340,7 +340,7 @@ L.Map.include({
 		}
 	},
 
-	sendUnoCommand: function (command, json) {
+	sendUnoCommand: function (command, json, force) {
 		if ((command.startsWith('.uno:Sidebar') && !command.startsWith('.uno:SidebarShow')) ||
 			command.startsWith('.uno:SlideChangeWindow') || command.startsWith('.uno:CustomAnimation') ||
 			command.startsWith('.uno:MasterSlidesPanel') || command.startsWith('.uno:ModifyPage')) {
@@ -394,7 +394,8 @@ L.Map.include({
 		if (this.uiManager.isUIBlocked())
 			return;
 		if ((this.dialog.hasOpenedDialog() || (this.jsdialog && this.jsdialog.hasDialogOpened()))
-			&& !command.startsWith('.uno:ToolbarMode')) {
+			&& !command.startsWith('.uno:ToolbarMode') && !force) {
+			console.debug('Cannot execute: ' + command + ' when dialog is opened.');
 			this.dialog.blinkOpenDialog();
 		} else if (this.isEditMode() || isAllowedInReadOnly) {
 			if (!this.messageNeedsToBeRedirected(command))
@@ -801,6 +802,7 @@ L.Map.include({
 		// It prevents launching multiple instances of the same dialog.
 		if (this.dialog.hasOpenedDialog() || (this.jsdialog && this.jsdialog.hasDialogOpened())) {
 			this.dialog.blinkOpenDialog();
+			console.debug('Cannot dispatch: ' + action + ' when dialog is opened.');
 			return;
 		}
 

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -797,6 +797,13 @@ L.Map.include({
 
 	// map.dispatch() will be used to call some actions so we can share the code
 	dispatch: function(action) {
+		// Don't allow to execute new actions while any dialog is visible.
+		// It prevents launching multiple instances of the same dialog.
+		if (this.dialog.hasOpenedDialog() || (this.jsdialog && this.jsdialog.hasDialogOpened())) {
+			this.dialog.blinkOpenDialog();
+			return;
+		}
+
 		if (action.indexOf('saveas-') === 0) {
 			var format = action.substring('saveas-'.length);
 			this.openSaveAs(format);

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -393,9 +393,10 @@ L.Map.include({
 
 		if (this.uiManager.isUIBlocked())
 			return;
-		if (this.dialog.hasOpenedDialog() && !command.startsWith('.uno:ToolbarMode'))
+		if ((this.dialog.hasOpenedDialog() || (this.jsdialog && this.jsdialog.hasDialogOpened()))
+			&& !command.startsWith('.uno:ToolbarMode')) {
 			this.dialog.blinkOpenDialog();
-		else if (this.isEditMode() || isAllowedInReadOnly) {
+		} else if (this.isEditMode() || isAllowedInReadOnly) {
 			if (!this.messageNeedsToBeRedirected(command))
 				app.socket.sendMessage('uno ' + command + (json ? ' ' + JSON.stringify(json) : ''));
 		}

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -732,7 +732,7 @@ L.Map.include({
 							value: map.makeURLFromStr(link.value)
 						}
 					};
-					map.sendUnoCommand('.uno:SetHyperlink', command);
+					map.sendUnoCommand('.uno:SetHyperlink', command, true);
 				}
 
 				map.uiManager.closeModal(dialogId);


### PR DESCRIPTION
We had this for tunneled dialogs but also for jsdialog it should be done. When trying to execute uno command when any dialog is opened - blink dialog to indicate that user has to close it to open next one. This blocks possibility to open multiple instances of the same dialog.