### PR TITLE
browser: add author data to calc comment

### DIFF
--- a/browser/src/layer/tile/CommentListSection.ts
+++ b/browser/src/layer/tile/CommentListSection.ts
@@ -529,6 +529,10 @@ export class CommentSection extends CanvasSectionObject {
 					type: 'string',
 					value: annotation.sectionProperties.data.id
 				},
+			        Author: {
+					type: 'string',
+					value: annotation.sectionProperties.data.author
+				},
 				Text: {
 					type: 'string',
 					value: annotation.sectionProperties.data.text


### PR DESCRIPTION
The recent changes in LO Core, when edit a comment
in Calc the author data is not preserved.

Change-Id: I4f26ef2044d28bf55ff6a00a2e585ece79c6eb9b
Signed-off-by: Henry Castro <hcastro@collabora.com>
