### PR TITLE
jsdialog: don't show error on closing busypopup

### DIFF
--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -137,9 +137,9 @@ L.Control.JSDialog = L.Control.extend({
 		if (instance.id && this.dialogs[instance.id]) {
 			var container = this.dialogs[instance.id].container;
 			L.DomUtil.addClass(container, 'fadeout');
-			container.onanimationend = function() { instance.that.close(instance.id); };
+			container.onanimationend = function() { instance.that.close(instance.id, false); };
 			// be sure it will be removed
-			setTimeout(function() { instance.that.close(instance.id); }, 700);
+			setTimeout(function() { instance.that.close(instance.id, false); }, 700);
 		}
 	},
 


### PR DESCRIPTION
This is regression from:
a2d666d53adcb23e60ed61328e8e3fe44fdc1af5
JSDialog overlay: Use CSS rules for positioning.

When auto-save or save is performed we show busypopup. We shoudn't send any messages to the server as it is pure JS dialog.

Parsing error was caused by sending close message: 1677832085616 OUTGOING: control: 'dialog' id:'__DIALOG__' event: 'close' state: 'null' 1677832085617 OUTGOING: dialogevent busypopup {"id":"__DIALOG__", "cmd": "close", "data": "null", "type": "dialog"} 1677832085620 INCOMING: error: cmd=dialogevent kind=syntax 1677832085621 INCOMING: jsdialog: {"id":"busypopup","jsontype":"dialog","type":"modalpopup","action":"fadeout"} 1677832094401 OUTGOING: userinactive

Let's don't send that message for fade out effect we use to close it.
