### PR TITLE
fix(SaveAs): Fix format extraction on SaveAs with filenames that contain multiple dots

### DIFF
--- a/browser/src/map/handler/Map.WOPI.js
+++ b/browser/src/map/handler/Map.WOPI.js
@@ -473,10 +473,10 @@ L.Map.WOPI = L.Handler.extend({
 			if (msg.Values) {
 				if (msg.Values.Filename !== null && msg.Values.Filename !== undefined) {
 					this._notifySave = msg.Values['Notify'];
-					var dotPos = msg.Values.Filename.indexOf('.');
+					var nameParts = msg.Values.Filename.split('.');
 					var format = undefined;
-					if (dotPos > 0)
-						format = msg.Values.Filename.substr(dotPos + 1);
+					if (nameParts.length > 1)
+						format = nameParts.pop();
 					else {
 						this._map.uiManager.showInfoModal('error', _('Error'), _('File name should contain an extension.'), '', _('OK'));
 						return;


### PR DESCRIPTION
* Target version: master 

### Summary

This fixes an issue where using save as to store a file with a name containing multiple dots like "example.1.odt" by adapting the logic to extract the file extension from the provided path.


### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

