### PR TITLE
Mobile: add extra space to color-control-label(s)

### DIFF
--- a/browser/css/mobilewizard.css
+++ b/browser/css/mobilewizard.css
@@ -129,7 +129,7 @@ span#main-menu-btn-icon {
 
 .no-color-control-label, .auto-color-control-label {
 	display: table-cell;
-	padding-left: 4px;
+	padding-left: 8px;
 	vertical-align: middle;
 }
 

--- a/browser/css/mobilewizard.css
+++ b/browser/css/mobilewizard.css
@@ -115,7 +115,8 @@ span#main-menu-btn-icon {
 
 .colors-container-no-color-row, .colors-container-auto-color-row{
 	display: flex;
-	justify-content: space-between;
+	justify-content: flex-start;
+	align-items: center;
 	height: 50px;
 }
 


### PR DESCRIPTION
Change-Id: Ide0b810cab18d63748678e3007b8ee8c7234114e

* Resolves: #2813
* Target version: master 

### Summary

in labels(classes):
- .no-color-control-label
- .auto-color-control-label

the value of padding-left property is
increased from 4px to 8px.

### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

