### PR TITLE
Made bigtoolitem bigger than icon with inline labels.

### DIFF
--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -298,7 +298,8 @@
 }
 
 .unotoolbutton.notebookbar.has-label:not(.inline) img {
-	width: 24px !important;
+	width: 32px !important;
+	height: 32px !important;
 	margin: auto !important;
 	display: block;
 }


### PR DESCRIPTION
Change-Id: If3c7cace825c86e00426c636ed52361b95c2aba2


* Resolves: https://github.com/CollaboraOnline/online/issues/5395
* Target version: master 

### Summary


### TODO

- Made bigtoolitem size from 24 to 32 px to make it looks bigger than icon with inline labels.

### Checklist

- [X] Code is properly formatted
- [X] All commits have Change-Id
- [ ] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

@mmeeks, @vmiklos, @eszkadev, @Andreas-Kainz 