### PR TITLE
wsd: simplify passing mobileAppDocId to getNewChild

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -2510,9 +2510,13 @@ std::size_t DocumentBroker::removeSession(const std::shared_ptr<ClientSession>& 
 
         // So just go down the same code path as for normal Online:
 
-        // If last editable, save and don't remove until after uploading to storage.
-        if (!lastEditableSession || !autoSave(isPossiblyModified(), dontSaveIfUnmodified))
+        // If last editable, save (if not saving already) and
+        // don't remove until after uploading to storage.
+        if (!lastEditableSession ||
+            (!_saveManager.isSaving() && !autoSave(isPossiblyModified(), dontSaveIfUnmodified)))
+        {
             disconnectSessionInternal(session);
+        }
 
         // Last view going away; can destroy?
         if (activeSessionCount <= 1)


### PR DESCRIPTION
It seems more complex to have #ifdef guarded logic
around a function call to pass or not pass an argument
when we that same argument is already defaulted in
that function.

If the difference between the two paths is primarily
the argument, then we can always pass it, making sure
that in the case that defaulting would have been used
that we pass the same default value. This is now done
with assertions.

Change-Id: I333eb3f42cb51dfab8584ae8c5aa52ee45c5a9a1
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
