### PR TITLE
Calc: fix formulabar expander being cropped on mobile

### DIFF
--- a/browser/css/device-mobile.css
+++ b/browser/css/device-mobile.css
@@ -425,6 +425,20 @@ button.button-secondary.vex-dialog-button.vex-last {
 nav:not(.spreadsheet-color-indicator) ~ #toolbar-wrapper #toolbar-up.w2ui-toolbar {
 	border-color: transparent;
 }
+.formulabar.unotoolbutton {
+	margin: 0 !important;
+}
+#expand.formulabar {
+	margin-inline-start: -8px !important
+}
+.formulabar.toolbox {
+	grid-column-gap: 8px;
+	/* fx = inputfield expander */
+	grid-template-columns: 24px auto 16px 0;
+	display: grid;
+	grid-auto-flow: column;
+	align-items: center;
+}
 #formulabar {
 	padding: 0px !important;
 	border-top: 1px solid #bbbbbb !important;

--- a/browser/css/device-mobile.css
+++ b/browser/css/device-mobile.css
@@ -438,6 +438,9 @@ nav:not(.spreadsheet-color-indicator) ~ #toolbar-wrapper #toolbar-up.w2ui-toolba
 	grid-auto-flow: column;
 	align-items: center;
 }
+.expanded .formulabar.toolbox {
+	align-items: center;
+}
 #formulabar {
 	padding: 0px !important;
 	border-top: 1px solid #bbbbbb !important;

--- a/browser/css/device-mobile.css
+++ b/browser/css/device-mobile.css
@@ -391,7 +391,6 @@ button.button-secondary.vex-dialog-button.vex-last {
 /* Related to toolbar.css */
 @-moz-document url-prefix() {
 	#formulabar #formulaInput, #formulabar #addressInput{
-		margin-left: 5px;
 		color: var(--color-main-text);
 		border: 1px solid var(--color-border) !important;
 		border-radius: 0px;
@@ -476,6 +475,7 @@ nav:not(.spreadsheet-color-indicator) ~ #toolbar-wrapper #toolbar-up.w2ui-toolba
 	transform: rotate(180deg);
 }
 #addressInput{
+	margin-inline-start: 8px;
 	width: 50px;
 	height: 23px;
 	text-align: center;

--- a/browser/src/control/Control.FormulaBar.js
+++ b/browser/src/control/Control.FormulaBar.js
@@ -141,16 +141,18 @@ L.Map.include({
 	onFormulaBarFocus: function() {
 		var mobileTopBar = w2ui['actionbar'];
 		var jsdialogFormulabar = this.formulabar;
+		var target = jsdialogFormulabar;
 
-		var target = window.mode.isMobile() ? mobileTopBar : jsdialogFormulabar;
+		if (window.mode.isMobile() === true) {
+			mobileTopBar.hide('undo');
+			mobileTopBar.hide('redo');
+			target = mobileTopBar;
+		} else {
+			jsdialogFormulabar.hide('startformula');
+			jsdialogFormulabar.hide('AutoSumMenu');
+		}
 		target.show('cancelformula');
 		target.show('acceptformula');
-
-		mobileTopBar.hide('undo');
-		mobileTopBar.hide('redo');
-
-		jsdialogFormulabar.hide('startformula');
-		jsdialogFormulabar.hide('AutoSumMenu');
 	},
 
 	onFormulaBarBlur: function() {

--- a/browser/src/control/Control.FormulaBarJSDialog.js
+++ b/browser/src/control/Control.FormulaBarJSDialog.js
@@ -32,61 +32,79 @@ L.Control.FormulaBarJSDialog = L.Control.extend({
 	},
 
 	createFormulabar: function(text) {
-		var data = [
-			{
-				type: 'toolbox',
-				children: [
-					{
-						id: 'functiondialog',
-						type: 'toolitem',
-						text: _('Function Wizard'),
-						command: '.uno:FunctionDialog'
-					},
-					(!window.mode.isMobile()) ? (
+		if (!window.mode.isMobile()) {
+			var data = [
+				{
+					type: 'toolbox',
+					children: [
+						{
+							id: 'functiondialog',
+							type: 'toolitem',
+							text: _('Function Wizard'),
+							command: '.uno:FunctionDialog'
+						},
 						{
 							id: 'autosummenu:AutoSumMenu',
 							type: 'menubutton',
 							command: '.uno:AutoSumMenu'
-						}
-					) : {},
-					{
-						id: 'startformula',
-						type: 'customtoolitem',
-						text: _('Formula'),
-					},
-					// on mobile we show other buttons on the top bar
-					(!window.mode.isMobile()) ? (
+						},
 						{
+							id: 'startformula',
+							type: 'customtoolitem',
+							text: _('Formula'),
+						},
+						{
+							// on mobile we show other buttons on the top bar
 							id: 'acceptformula',
 							type: 'customtoolitem',
 							text: _('Accept'),
 							visible: false
-						}
-					) : {},
-					(!window.mode.isMobile()) ? (
+						},
 						{
 							id: 'cancelformula',
 							type: 'customtoolitem',
 							text: _UNO('.uno:Cancel', 'spreadsheet'),
 							visible: false
-						}
-					) : {},
-					{
-						id: 'sc_input_window',
-						type: 'multilineedit',
-						text: text ? text : '',
-						rawKeyEvents: window.mode.isDesktop() ? true : undefined,
-						useTextInput: window.mode.isDesktop() ? undefined : true
-					},
-					{
-						id: 'expand',
-						type: 'pushbutton',
-						text: '',
-						symbol: 'SPIN_DOWN',
-					}
-				]
-			}
-		];
+						},
+						{
+							id: 'sc_input_window',
+							type: 'multilineedit',
+							text: text ? text : '',
+							rawKeyEvents: window.mode.isDesktop() ? true : undefined,
+							useTextInput: window.mode.isDesktop() ? undefined : true
+						},
+						{
+							id: 'expand',
+							type: 'pushbutton',
+							text: '',
+							symbol: 'SPIN_DOWN',
+						}]
+				}];
+		} else {
+			var data = [
+				{
+					type: 'toolbox',
+					children: [
+						{
+							id: 'functiondialog',
+							type: 'toolitem',
+							text: _('Function Wizard'),
+							command: '.uno:FunctionDialog'
+						}, {
+							id: 'sc_input_window',
+							type: 'multilineedit',
+							text: text ? text : '',
+							rawKeyEvents: undefined,
+							useTextInput: true
+						},
+						{
+							id: 'expand',
+							type: 'pushbutton',
+							text: '',
+							symbol: 'SPIN_DOWN',
+						}]
+				}];
+		}
 
 		var wrapper = document.getElementById('calc-inputbar-wrapper');
 		wrapper.style.display = 'block';


### PR DESCRIPTION
commit db6581582a46fa0ffb1f671babbbec41d7c62e04 (HEAD -> private/pedro/fix-mobile-calc-expander-hide-startformula, origin/private/pedro/fix-mobile-calc-expander-hide-startformula)
Author: Pedro Pinto Silva <pedro.silva@collabora.com>
Date:   Tue Mar 7 09:46:42 2023 +0100

    Mobile: calc: formulabar element: align to top on expanded
    
    Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
    Change-Id: I1579f526daa18c45af0e7106eff43d5491aaf89b

commit 164772259e1800afde50d26fbf5f1817b7433e3c
Author: Pedro Pinto Silva <pedro.silva@collabora.com>
Date:   Mon Mar 6 12:26:37 2023 +0100

    Mobile: calc: Fix addressinput  misalignment
    
    In some browsers addressinput was misaligned (no initial margin)
      - Remove FF specific margin-left
      - Add non LTR specific margin to every browser
      - Use the same dimension (8px) as used in the .formulabar.toolbox's
      grid-column-gap
    
    Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
    Change-Id: I6a2e86a9a56f05bbf514d12a080fbcb2408cb816

commit 8e0b45fc36cad59e528b20ec4277c806fb175955
Author: Pedro Pinto Silva <pedro.silva@collabora.com>
Date:   Fri Mar 3 18:34:19 2023 +0100

    Calc: fix formulabar expander being cropped on mobile
    
    - Make sure all elements within formulabar toolbox fit even
    on smaller devices
        - Do not user margins to position, use instead grid
    - Remove Equal sign (startformula). Before this commit the
    startformula icon was visible and then invisible once the user
    enter the cell to type -> it seems this was initially intended to save
    space but the truth of the matter is that it causes a flicker and
    where the position of the elements shift making even harder to write
    on mobile.
        - Solution: do not create that element in the first place on
    mobile. Plus when the user enter the cell can always press the "="
    right via the native keyboard anyhow.
    
    note: avoid multiple instances of the same condition in FormulaBarJSDialog
    
    Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
    Change-Id: Ic4f3b7fddb9d862170a0e95243f4b19a89340575
