### PR TITLE
wsd: add option to restrict the URL ...

### DIFF
--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -1073,7 +1073,9 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     cspOss << "Content-Security-Policy: default-src 'none'; "
         "frame-src 'self' " << WELCOME_URL << " " << FEEDBACK_URL << " " << buyProduct <<
         " blob: " << documentSigningURL << "; "
-           "connect-src 'self' https://www.zotero.org https://api.zotero.org " << cnxDetails.getWebSocketUrl() << " " << indirectionURI.getAuthority() << "; "
+           "connect-src 'self' https://www.zotero.org https://api.zotero.org "
+           << cnxDetails.getWebSocketUrl() << " " << cnxDetails.getWebServerUrl() << " "
+           << indirectionURI.getAuthority() << "; "
            "script-src 'unsafe-inline' 'self'; "
            "style-src 'self' 'unsafe-inline'; "
            "font-src 'self' data:; "

--- a/wsd/ServerURL.hpp
+++ b/wsd/ServerURL.hpp
@@ -80,6 +80,14 @@ public:
         return schemeProtocol + "://" + _schemeAuthority;
     }
 
+    std::string getWebServerUrl() const
+    {
+        std::string schemeProtocol = "http";
+        if (_ssl)
+            schemeProtocol += 's';
+        return schemeProtocol + "://" + _schemeAuthority;
+    }
+
     std::string getSubURLForEndpoint(const std::string &path) const
     {
         return std::string("http") + (_ssl ? "s" : "") + "://" + _schemeAuthority + _pathPlus + path;


### PR DESCRIPTION
which can be loaded using script interfaces.

There is use case such reverse proxy uses another domain
to request the l10n json resources, but the CSP Chrome triggers:

l10n.js:62 Refused to connect to 'http://192.168.0.2/localizations.json' because it violates the following Content Security Policy directive: "connect-src 'self' ws://192.168.0.1:9980".

request_JSON @ l10n.js:62
String_ctr.<computed> @ l10n.js:85
(anonymous) @ l10n.js:263
(anonymous) @ l10n.js:286
l10n.js:62 Uncaught DOMException: Failed to execute 'send' on 'XMLHttpRequest': Failed to load 'http://192.168.0.2/localizations.json'.

Change-Id: I57fff24c00adebdf7dd06929d6341ea14554a6d2
Signed-off-by: Henry Castro <hcastro@collabora.com>
