### PR TITLE
Made bigtoolitem appearance bigger than icon with inline labels.

### DIFF
--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -298,7 +298,8 @@
 }
 
 .unotoolbutton.notebookbar.has-label:not(.inline) img {
-	width: 24px !important;
+	width: 32px !important;
+	height: 32px !important;
 	margin: auto !important;
 	display: block;
 }


### PR DESCRIPTION
Change-Id: Ie4eead1f20fb183b2f5c48aee4fe1f72fa7b12f1


* Resolves: #5395 
* Target version: master 

### Summary


### TODO

- Made bigtoolitem size from 24 to 32 px to make it's looks bigger than icon with inline labels.

### Checklist

- [X] Code is properly formatted
- [X] All commits have Change-Id
- [ ] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

@mmeeks, @vmiklos, @eszkadev, @Andreas-Kainz 