### PR TITLE
Hyperlink: Fix thumbnail overflow

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -876,6 +876,7 @@ nav.spreadsheet-color-indicator ~ #sidebar-dock-wrapper {
 	margin: 6px 8px;
 	font-size: 14px;
 	line-height: 1;
+	overflow: hidden;
 }
 
 #hyperlink-pop-up {
@@ -1038,4 +1039,9 @@ nav.spreadsheet-color-indicator ~ #sidebar-dock-wrapper {
 #hyperlink-pop-up-preview img {
 	max-height: 150px;
 	max-width: 250px;
+}
+
+#hyperlink-pop-up-preview p {
+	text-overflow: ellipsis;
+	overflow: hidden;
 }


### PR DESCRIPTION
Before this commit:
 - Images (coming from link preview) could brake html parent element
 - Metadata (p element) could brake html parent element

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I362afe9eadd86b88dc6afc584f635d50fac0ad03
