### PR TITLE
Fix isLocal failing check with IPv4

### DIFF
--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -900,7 +900,8 @@ bool Socket::isLocal() const
         return true;
     if (_clientAddress == "::1")
         return true;
-    return  _clientAddress.rfind("127.0.0.", 0);
+    return  _clientAddress.rfind("::ffff:127.0.0.", 0) != std::string::npos ||
+                _clientAddress.rfind("127.0.0.", 0) != std::string::npos;
 }
 
 std::shared_ptr<Socket> LocalServerSocket::accept()


### PR DESCRIPTION
If the server bind type is `IPV4` the client address will be `127.0.0.1`.  
If the bind type is `All` and a client connects to 127.0.0.1 the client address will be `::ffff:127.0.0.1`.  

Actually the `isLocal()` will return false if you set `net.proto=IPV4` and try to connect to 127.0.0.1, which will always cause a 400 BadRequest.

This happens because `rfind` returns the position of the match which means that if the client address is `127.0.0.1` it will return 0 (interpreted as false).  

When rfind fails it returns std::npos (-1, which is true), so this condition is wrong because it always returns true except for `127.0.0.1`.

It's currently working because the function (with `All` proto) always returns `-1`.  

I don't know if this is a security issue as I have no idea how this software works.

~~Anyway, I'm sorry, but I can't test it because I only have a smartphone at the moment, so I'm passing it on to you.~~

~~Sure, this pull request is against the standards, but it's only one line of code, so you can commit it yourself if you don't like it.~~

PS: I don't know if my condition is too restrictive, so feel free to use another one.


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

