### PR TITLE
Revert "wsd: break cyclic setModified call"

### DIFF
--- a/wsd/AdminModel.cpp
+++ b/wsd/AdminModel.cpp
@@ -485,9 +485,13 @@ void AdminModel::addBytes(const std::string& docKey, uint64_t sent, uint64_t rec
     _recvBytesTotal += recv;
 }
 
-void AdminModel::modificationAlert(const std::string& /*docKey*/, pid_t pid, bool value)
+void AdminModel::modificationAlert(const std::string& docKey, pid_t pid, bool value)
 {
     assertCorrectThread();
+
+    auto doc = _documents.find(docKey);
+    if (doc != _documents.end())
+        doc->second->setModified(value);
 
     std::ostringstream oss;
     oss << "modifications "


### PR DESCRIPTION
The setModified is on an internal, AdminModel
specific, Document object. It is not the
DocumentBroker.

This reverts commit e33d6aa2ca3231befd6634ddf2316712d681ded1.

Change-Id: Ib706927051678cfc19dc1246d679ef530eb8d586
