### PR TITLE
Fix issues #5887 and #5841 on iOS

### DIFF
--- a/browser/html/cool.html.m4
+++ b/browser/html/cool.html.m4
@@ -7,16 +7,18 @@ m4_define([_m4_foreachq],[m4_ifelse([$#],[3],[],[m4_define([$1],[$4])$2[]$0([$1]
 m4_define(_YEAR_,m4_esyscmd(date +%Y|tr -d '\n'))
 <!DOCTYPE html>
 <!-- saved from url=(0054)http://leafletjs.com/examples/quick-start-example.html -->
+m4_ifelse(IOSAPP,[true],
+<!-- Related to issue #5841: the iOS app sets the base text direction via the "dir" parameter -->
+<html dir="" style="height:100%"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+,
 <html %UI_RTL_SETTINGS% style="height:100%"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+)m4_dnl
 <title>Online Editor</title>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0 minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
 
 <script>
 m4_dnl# Define MOBILEAPP as true if this is either for the iOS app or for the gtk+ "app" testbed
-   window.welcomeUrl = '%WELCOME_URL%';
-   window.feedbackUrl = '%FEEDBACK_URL%';
-   window.buyProductUrl = '%BUYPRODUCT_URL%';
 m4_define([MOBILEAPP],[])
 m4_ifelse(IOSAPP,[true],[m4_define([MOBILEAPP],[true])])
 m4_ifelse(GTKAPP,[true],[m4_define([MOBILEAPP],[true])])
@@ -32,10 +34,14 @@ m4_ifelse(ANDROIDAPP,[true],[m4_define([MOBILEAPP],[true])])
 m4_ifelse(EMSCRIPTENAPP,[true],[m4_define([MOBILEAPP],[true])])
 
 m4_ifelse(MOBILEAPP,[],
+  window.welcomeUrl = '%WELCOME_URL%';
+  window.feedbackUrl = '%FEEDBACK_URL%';
+  window.buyProductUrl = '%BUYPRODUCT_URL%';
+
   // Start listening for Host_PostmessageReady message and save the
   // result for future
-    window.WOPIpostMessageReady = false;
-    var PostMessageReadyListener = function(e) {
+  window.WOPIpostMessageReady = false;
+  var PostMessageReadyListener = function(e) {
     if (!(e && e.data))
         return;
 
@@ -58,6 +64,11 @@ m4_dnl# and window.ThisIsTheGtkApp
 
 m4_ifelse(MOBILEAPP,[true],
   [   window.ThisIsAMobileApp = true;
+   // Fix issue #5841 by setting the welcome, feedback, and buy product URLs
+   // to empty for mobile
+   window.welcomeUrl = '';
+   window.feedbackUrl = '';
+   window.buyProductUrl = '';
    window.HelpFile = String.raw`m4_syscmd([cat html/cool-help.html])`;
    window.open = function (url, windowName, windowFeatures) {
      window.postMobileMessage('HYPERLINK ' + url); /* don't call the 'normal' window.open on mobile at all */
@@ -379,6 +390,11 @@ m4_ifelse(MOBILEAPP,[true],
 
 // This is GLOBAL_JS:
 m4_syscmd([cat ]GLOBAL_JS)m4_dnl
+
+// Related to issue #5841: the iOS app sets the base text direction via the
+// "dir" parameter
+m4_ifelse(IOSAPP,[true],
+     [document.dir = window.getParameterByName('dir');])
 
 m4_ifelse(IOSAPP,[true],
      [window.userInterfaceMode = window.getParameterByName('userinterfacemode');])

--- a/common/LangUtil.hpp
+++ b/common/LangUtil.hpp
@@ -1,0 +1,34 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace LangUtil
+{
+    bool isRtlLanguage(const std::string& language)
+    {
+        if (language.rfind("ar", 0) == 0 ||
+            language.rfind("arc", 0) == 0 ||
+            language.rfind("dv", 0) == 0 ||
+            language.rfind("fa", 0) == 0 ||
+            language.rfind("ha", 0) == 0 ||
+            language.rfind("he", 0) == 0 ||
+            language.rfind("khw", 0) == 0 ||
+            language.rfind("ks", 0) == 0 ||
+            language.rfind("ku", 0) == 0 ||
+            language.rfind("ps", 0) == 0 ||
+            language.rfind("ur", 0) == 0 ||
+            language.rfind("yi", 0) == 0)
+            return true;
+
+        return false;
+    }
+}
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/ios/Mobile/AppDelegate.h
+++ b/ios/Mobile/AppDelegate.h
@@ -15,6 +15,7 @@
 @end
 
 extern NSString *app_locale;
+extern NSString *app_text_direction;
 
 // vim:set shiftwidth=4 softtabstop=4 expandtab:
 

--- a/ios/Mobile/AppDelegate.mm
+++ b/ios/Mobile/AppDelegate.mm
@@ -29,7 +29,10 @@
 #import "SetupKitEnvironment.hpp"
 #import "Util.hpp"
 
+#import <common/LangUtil.hpp>
+
 NSString *app_locale;
+NSString *app_text_direction;
 
 static void download(NSURL *source, NSURL *destination) {
     [[[NSURLSession sharedSession] downloadTaskWithURL:source
@@ -232,6 +235,11 @@ static void updateTemplates(NSData *data, NSURLResponse *response)
         app_locale = [NSString stringWithUTF8String:lang];
     else
         app_locale = [[NSLocale preferredLanguages] firstObject];
+
+    if (LangUtil::isRtlLanguage(std::string([app_locale UTF8String])))
+        app_text_direction = @"rtl";
+    else
+        app_text_direction = @"";
 
     lo_kit = lok_init_2(nullptr, nullptr);
 

--- a/ios/Mobile/CODocument.mm
+++ b/ios/Mobile/CODocument.mm
@@ -84,6 +84,9 @@ static std::atomic<unsigned> appDocIdCounter(1);
                                [NSURLQueryItem queryItemWithName:@"lang" value:app_locale],
                                [NSURLQueryItem queryItemWithName:@"appdocid" value:[NSString stringWithFormat:@"%u", appDocId]],
                                [NSURLQueryItem queryItemWithName:@"userinterfacemode" value:([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad ? @"notebookbar" : @"classic")],
+                               // Related to issue #5841: the iOS app sets the
+                               // base text direction via the "dir" parameter
+                               [NSURLQueryItem queryItemWithName:@"dir" value:app_text_direction],
                              ];
 
     NSURLRequest *request = [[NSURLRequest alloc]initWithURL:components.URL];

--- a/ios/README
+++ b/ios/README
@@ -6,9 +6,6 @@ App Store "Test Details" text for the last TestFlight build
 
 This version includes the latest 22.05.10 code and fixes the following bugs:
 
-• Presentation documents saved in outline view would display as an empty document
-• The font selection button would display as non-tappable text
-• Tapping on a font in the native font picker popup would not close the popup
-• Non-ASCII characters would be misencoded in the sidebar panel
-
-Also, the obsolete Template List URL setting  was removed from the Collabora Office panel in the Settings app.
+• Pressing the Save, Paste, or certain other buttons would display an error or silently fail
+• Localizations for several languages were missing
+• When running the app with the user interface set to Hebrew, Arabic, or one of the other right to left (RTL) languages, the user interface would still be arranged left to right

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -906,8 +906,24 @@ bool DocumentBroker::download(const std::shared_ptr<ClientSession>& session, con
                                               << localStorage->getFileExtension() << ']');
                     session->setAllowChangeComments(true);
                 }
+                // Related to fix for issue #5887: only send a read-only
+                // message for "view file extension" document types
+                session->sendFileMode(session->isReadOnly(), session->isAllowChangeComments());
             }
-            session->sendFileMode(session->isReadOnly(), session->isAllowChangeComments());
+#ifdef IOS
+            else
+            {
+                // Fix issue #5887 by assuming that documents are writable on iOS
+                // The iOS app saves directly to local disk so, other than for
+                // "view file extension" document types or other cases that
+                // I am missing, we can assume the document is writable until
+                // a write failure occurs.
+                LOG_DBG("Setting session [" << sessionId << "] to writable and allowing comments");
+                session->setWritable(true);
+                session->setReadOnly(false);
+                session->setAllowChangeComments(true);
+            }
+#endif
         }
     }
 

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -50,6 +50,7 @@
 #include <Protocol.hpp>
 #include <Util.hpp>
 #include <common/ConfigUtil.hpp>
+#include <common/LangUtil.hpp>
 #if !MOBILEAPP
 #include <net/HttpHelper.hpp>
 #endif
@@ -850,28 +851,6 @@ constexpr char BRANDING[] = "branding";
 constexpr char BRANDING_UNSUPPORTED[] = "branding-unsupported";
 #endif
 
-namespace
-{
-    bool isRtlLanguage(const std::string& language)
-    {
-        if (language.rfind("ar", 0) == 0 ||
-            language.rfind("arc", 0) == 0 ||
-            language.rfind("dv", 0) == 0 ||
-            language.rfind("fa", 0) == 0 ||
-            language.rfind("ha", 0) == 0 ||
-            language.rfind("he", 0) == 0 ||
-            language.rfind("khw", 0) == 0 ||
-            language.rfind("ks", 0) == 0 ||
-            language.rfind("ku", 0) == 0 ||
-            language.rfind("ps", 0) == 0 ||
-            language.rfind("ur", 0) == 0 ||
-            language.rfind("yi", 0) == 0)
-            return true;
-
-        return false;
-    }
-}
-
 void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
                                               const RequestDetails &requestDetails,
                                               Poco::MemoryInputStream& message,
@@ -1051,7 +1030,7 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     Poco::replaceInPlace(preprocess, std::string("%USER_INTERFACE_MODE%"), userInterfaceMode);
 
     std::string uiRtlSettings;
-    if (isRtlLanguage(requestDetails.getParam("lang")))
+    if (LangUtil::isRtlLanguage(requestDetails.getParam("lang")))
         uiRtlSettings = " dir=\"rtl\" ";
     Poco::replaceInPlace(preprocess, std::string("%UI_RTL_SETTINGS%"), uiRtlSettings);
 


### PR DESCRIPTION
The iOS app saves directly to local disk so, other than for "view file extension" document types or other cases that I am missing, we can assume the document is writable until a write failure occurs.


Change-Id: I72e80e74f1132d41c11015a80bcc0d79c77acb26