### PR TITLE
Log Improvements

### DIFF
--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -846,7 +846,7 @@ public:
         _bodyFile.open(path, std::ios_base::out | std::ios_base::binary);
         _onBodyWriteCb = [this](const char* p, int64_t len)
         {
-            LOG_TRC("Writing " << len << " bytes.");
+            LOG_TRC("Writing " << len << " bytes");
             if (_bodyFile.good())
                 _bodyFile.write(p, len);
             return _bodyFile.good() ? len : -1;
@@ -1324,6 +1324,7 @@ private:
         if (socket)
         {
             _fd = socket->getFD();
+            _response->setLogContext(_fd);
             LOG_TRC("Connected");
             _connected = true;
         }

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -165,6 +165,7 @@ bool ClientSession::disconnectFromKit()
         docBroker->forwardToChild(client_from_this(), "getclipboard");
 #endif
         // handshake nicely; so wait for 'disconnected'
+        LOG_TRC("Sending 'disconnect' command to session " << getId());
         docBroker->forwardToChild(client_from_this(), "disconnect");
 
         return false;

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -2112,7 +2112,7 @@ bool DocumentBroker::autoSave(const bool force, const bool dontSaveIfUnmodified)
     if (!isModified() && !force)
     {
         // Nothing to do.
-        LOG_TRC("Nothing to autosave [" << _docKey << "].");
+        LOG_TRC("Nothing to autosave [" << _docKey << ']');
         return false;
     }
 
@@ -2156,9 +2156,13 @@ bool DocumentBroker::autoSave(const bool force, const bool dontSaveIfUnmodified)
             = std::chrono::duration_cast<std::chrono::milliseconds>(now - _lastActivityTime);
         const auto timeSinceLastSave = std::min(_saveManager.timeSinceLastSaveRequest(),
                                                 _storageManager.timeSinceLastUploadResponse());
-        LOG_TRC("Time since last save of docKey [" << _docKey << "] is " << timeSinceLastSave
-                                                     << " and most recent activity was "
-                                                     << inactivityTime << " ago.");
+        LOG_TRC("DocKey [" << _docKey << "] is modified. It has been " << timeSinceLastSave
+                           << " since last save and the most recent activity was " << inactivityTime
+                           << " ago. Idle save is "
+                           << (_saveManager.isIdleSaveEnabled() ? "" : "not ")
+                           << "enabled, auto save is "
+                           << (_saveManager.isAutoSaveEnabled() ? "" : "not ")
+                           << "enabled with interval of " << _saveManager.autoSaveInterval());
 
         // Either we've been idle long enough, or it's auto-save time.
         bool save = _saveManager.isIdleSaveEnabled() &&
@@ -2564,7 +2568,7 @@ void DocumentBroker::disconnectSessionInternal(const std::shared_ptr<ClientSessi
             // We must be the last session, flag to destroy if unload is requested.
             LOG_ASSERT_MSG(countActiveSessions() <= 1, "Unload-requested with multiple sessions");
             LOG_TRC("Unload requested while disconnecting session ["
-                    << id << "], having " << _sessions.size() << " sessions, marking to destroy.");
+                    << id << "], having " << _sessions.size() << " sessions, marking to destroy");
             _docState.markToDestroy();
         }
 
@@ -2581,17 +2585,18 @@ void DocumentBroker::disconnectSessionInternal(const std::shared_ptr<ClientSessi
         {
             LOG_ERR("Failed to unlock docKey [" << _docKey
                                                 << "] before disconnecting last editable session ["
-                                                << session->getId() << "]: " << error);
+                                                << session->getName() << "]: " << error);
         }
 
         bool hardDisconnect;
         if (session->inWaitDisconnected())
         {
-            LOG_TRC("hard disconnecting while waiting for disconnected handshake.");
+            LOG_TRC("Removing session [" << id << "] while waiting for disconnected handshake");
             hardDisconnect = true;
         }
         else
         {
+            LOG_DBG("Disconnecting session [" << id << "] from Kit");
             hardDisconnect = session->disconnectFromKit();
 
 #if !MOBILEAPP
@@ -2603,8 +2608,9 @@ void DocumentBroker::disconnectSessionInternal(const std::shared_ptr<ClientSessi
                 // If at the end of loading it shows a dialog (such as the macro or
                 // csv import dialogs), it will wait for their dismissal indefinetely.
                 // Neither would our load-timeout kick in, since we would be gone.
-                LOG_INF("Session [" << id << "] disconnected but DocKey [" << _docKey
-                                    << "] isn't loaded yet. Terminating the child roughly.");
+                LOG_INF("Session [" << session->getName() << "] disconnected but DocKey ["
+                                    << _docKey
+                                    << "] isn't loaded yet. Terminating the child roughly");
                 _childProcess->terminate();
             }
 #endif

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -2297,7 +2297,7 @@ void DocumentBroker::autoSaveAndStop(const std::string& reason)
     {
         LOG_TRC("Too soon to issue another save on ["
                 << getDocKey() << "]: " << _saveManager.timeSinceLastSaveRequest()
-                << " since last save request and " << _saveManager.timeSinceLastSaveRequest()
+                << " since last save request and " << _saveManager.timeSinceLastSaveResponse()
                 << " since last save response. Min time between saves: "
                 << _saveManager.minTimeBetweenSaves());
     }

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -2207,9 +2207,8 @@ void DocumentBroker::autoSaveAndStop(const std::string& reason)
     const NeedToSave needToSave = needToSaveToDisk();
     const NeedToUpload needToUpload = needToUploadToStorage();
     bool canStop = (needToSave == NeedToSave::No && needToUpload == NeedToUpload::No);
-    LOG_TRC("autoSaveAndStop for docKey [" << getDocKey() << "] needToSave: " << name(needToSave)
-                                           << ", needToUpload: " << name(needToUpload)
-                                           << ", canStop: " << canStop);
+    LOG_TRC("autoSaveAndStop for docKey [" << getDocKey() << "]: " << name(needToSave) << ", "
+                                           << name(needToUpload) << ", canStop: " << canStop);
 
     if (!canStop && needToSave == NeedToSave::No && !isStorageOutdated())
     {
@@ -2297,9 +2296,10 @@ void DocumentBroker::autoSaveAndStop(const std::string& reason)
     {
         LOG_TRC("Too soon to issue another save on ["
                 << getDocKey() << "]: " << _saveManager.timeSinceLastSaveRequest()
-                << " since last save request and " << _saveManager.timeSinceLastSaveResponse()
-                << " since last save response. Min time between saves: "
-                << _saveManager.minTimeBetweenSaves());
+                << " since last save request, " << _saveManager.timeSinceLastSaveResponse()
+                << " since last save response, and last save took "
+                << _saveManager.lastSaveDuration()
+                << ". Min time between saves: " << _saveManager.minTimeBetweenSaves());
     }
 
     if (canStop)


### PR DESCRIPTION
- wsd: http: set http::Request log context
- wsd: logging improvements
- wsd: better logging of WOPI::PutFile
- wsd: do not warn of unassociated Kit after unloading
- wsd: only warn of live sessions on unload
- wsd: correct log of time since last save response
- wsd: better logging in autoSaveAndStop
