### PR TITLE
wsd: do not disconnect the last session if saving

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -2510,9 +2510,13 @@ std::size_t DocumentBroker::removeSession(const std::shared_ptr<ClientSession>& 
 
         // So just go down the same code path as for normal Online:
 
-        // If last editable, save and don't remove until after uploading to storage.
-        if (!lastEditableSession || !autoSave(isPossiblyModified(), dontSaveIfUnmodified))
+        // If last editable, save (if not saving already) and
+        // don't remove until after uploading to storage.
+        if (!lastEditableSession ||
+            (!_saveManager.isSaving() && !autoSave(isPossiblyModified(), dontSaveIfUnmodified)))
+        {
             disconnectSessionInternal(session);
+        }
 
         // Last view going away; can destroy?
         if (activeSessionCount <= 1)


### PR DESCRIPTION
Previously we only waited if a new auto-save has
been issued at the point of disconnecting the
last session. However, we could have a save in
progress, particularly when it's a slow one,
and we should equally wait for it before
disconnecting the last session.

Failing to do so will exit the kit right after
finishing the save and will rob us of the
ability to upload the just-saved version.

Change-Id: I678689a95211fa8b80bcd3e8d4537de7de5d6632
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
