### PR TITLE
We aparently want thumbnails to be of size 1200x630 pixels

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -302,11 +302,11 @@ bool ChildSession::_handleInput(const char *buffer, int length)
             y = 0;
 
         bool success = false;
-        const int width = 120;
-        const int height = 120;
 
-        // These arbitrary magic numbers are from the original interrupted WIP, surely this will need more work.
-        constexpr float zoom = 0.5f;
+        constexpr int width = 1200;
+        constexpr int height = 630;
+
+        constexpr float zoom = 1;
         constexpr int pixelWidthTwips = width * 15 / zoom;
         constexpr int pixelHeightTwips = height * 15 / zoom;
         constexpr int offsetXTwips = 15 * 15; // start 15 px/twips before the target to get a clearer thumbnail

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -303,19 +303,24 @@ bool ChildSession::_handleInput(const char *buffer, int length)
 
         bool success = false;
 
+        // Size of thumbnail in pixels
         constexpr int width = 1200;
         constexpr int height = 630;
 
+        // Unclear what this "zoom" level means
         constexpr float zoom = 1;
-        constexpr int pixelWidthTwips = width * 15 / zoom;
-        constexpr int pixelHeightTwips = height * 15 / zoom;
-        constexpr int offsetXTwips = 15 * 15; // start 15 px/twips before the target to get a clearer thumbnail
+
+        // The magic number 15 is the number of twips per pixel for a resolution of 96 pixels per
+        // inch, which apparently is some "standard".
+        constexpr int widthTwips = width * 15 / zoom;
+        constexpr int heightTwips = height * 15 / zoom;
+        constexpr int offsetXTwips = 15 * 15; // start 15 pixels before the target to get a clearer thumbnail
         constexpr int offsetYTwips = 15 * 15;
 
         const auto mode = static_cast<LibreOfficeKitTileMode>(getLOKitDocument()->getTileMode());
 
         std::vector<unsigned char> thumbnail(width * height * 4);
-        getLOKitDocument()->paintTile(thumbnail.data(), width, height, x - offsetXTwips, y - offsetYTwips, pixelWidthTwips, pixelHeightTwips);
+        getLOKitDocument()->paintTile(thumbnail.data(), width, height, x - offsetXTwips, y - offsetYTwips, widthTwips, heightTwips);
 
         std::vector<char> pngThumbnail;
         if (Png::encodeBufferToPNG(thumbnail.data(), width, height, pngThumbnail, mode))


### PR DESCRIPTION
Tweak the "zoom" variabe to be 1 so that with this thumbnail size, for a typical document we get more of it into the thumbnail.


Change-Id: I419afccbf57eae23062ab4c849dd41293f068f00


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

