### PR TITLE
Remove vex dialog from saved-as warning.

### DIFF
--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -1115,12 +1115,11 @@ app.definitions.Socket = L.Class.extend({
 			textMsg = textMsg.substring(len);
 			if (textMsg.startsWith('saveas:')) {
 				var userName = command.username ? command.username : _('Someone');
-				vex.dialog.confirm({
-					message: _('%userName saved this document as %fileName. Do you want to join?').replace('%userName', userName).replace('%fileName', command.filename),
-					callback: L.bind(function (val) {
-						if (val) this._renameOrSaveAsCallback(textMsg, command);
-					}, this)
-				});
+				var message = _('%userName saved this document as %fileName. Do you want to join?').replace('%userName', userName).replace('%fileName', command.filename);
+
+				this._map.uiManager.showConfirmModal('save-as-warning', '', message, _('OK'), function() {
+					this._renameOrSaveAsCallback(textMsg, command);
+				}.bind(this));
 			}
 		}
 		else if (textMsg.startsWith('statusindicator:')) {


### PR DESCRIPTION
Change-Id: Id41c98806bc4763797c9986a60ef39301581da06


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

