### PR TITLE
Revert "Remove unnecessary `.wait`s from image tests"

### DIFF
--- a/cypress_test/integration_tests/desktop/writer/image_operation_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/image_operation_spec.js
@@ -32,19 +32,29 @@ describe('Image Operation Tests', function() {
 		// if window is too small sidebar won't popup
 		cy.viewport(1000, 660);
 
+		helper.waitUntilIdle('#selectwidth input');
+
 		cy.get('#selectwidth input').clear({force:true})
 			.type('3{enter}', {force:true});
 
+		helper.waitUntilIdle('#selectheight input');
+
 		cy.get('#selectheight input').clear({force:true})
 			.type('2{enter}', {force:true});
+
+		cy.wait(1000);
 
 		assertImageSize(139, 93);
 
 		//Keep ratio checked
 		cy.get('#ratio input').check();
 
+		helper.waitUntilIdle('#selectheight input');
+
 		cy.get('#selectheight input').clear({force:true})
 			.type('5{enter}', {force:true});
+
+		cy.wait(1000);
 
 		assertImageSize(347, 232);
 	});


### PR DESCRIPTION
- image test consistently fails without waits in CI

This reverts commit b529c96a488eb23716d99599cb9280360b4c53e7.
Change-Id: I66bd85c8fe1ce28ccab8d644a98265145d3de64b

* Target version: master 
CI gives this 
```
`<input class="jsdialog sidebar spinfield" id="selectwidth-input" type="number" dir="" tabindex="0" min="0" max="336" step="0.02">`

Cypress requires elements be attached in the DOM to interact with them.

The previous command that ran was:

  > `cy.clear()`

This DOM element likely became detached somewhere between the previous and current command.

```
https://cpci.cbg.collabora.co.uk:8080/job/tinderbox_online_master_debug_vs_co-22.05/
