### PR TITLE
MentionPopup: fix double border and parent padding

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -1013,12 +1013,25 @@ nav.spreadsheet-color-indicator ~ #sidebar-dock-wrapper {
 	background-position: 0;
 }
 
+#mentionPopup {
+	border: none !important;
+}
+
 #mentionPopup .lokdialog.ui-dialog-content.ui-widget-content {
 	display: flex;
 	justify-content: center;
 	align-items: center;
 	min-height: 100px;
 	min-width: 100px;
+	padding: 0;
+}
+
+#mentionPopup .ui-treeview-entry:not(.autofilter) {
+	padding: 0 1em;
+}
+
+#mentionPopup .lokdialog.ui-dialog-content.ui-widget-content .root-container {
+	flex-grow: 1;
 }
 
 #hyperlink-pop-up-preview {


### PR DESCRIPTION
Before this commit:
- the popup was appearing with 2 border
- the content (list) was quite small and the parent element
bigger

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I539c9cad0f94bfd65eb06b9d704fa9f89e1e949b
