### PR TITLE
remove lonely "close all" calls for vex.

### DIFF
--- a/browser/src/control/Control.AlertDialog.js
+++ b/browser/src/control/Control.AlertDialog.js
@@ -3,7 +3,7 @@
  * L.Control.Dialog used for displaying alerts
  */
 
-/* global _ vex sanitizeUrl */
+/* global _ sanitizeUrl */
 L.Control.AlertDialog = L.Control.extend({
 	onAdd: function (map) {
 		// TODO: Better distinction between warnings and errors
@@ -13,20 +13,14 @@ L.Control.AlertDialog = L.Control.extend({
 
 	_onError: function(e) {
 		if (!this._map._fatal) {
-			// TODO. queue message errors and pop-up dialogs
-			// Close other dialogs before presenting a new one.
-			vex.closeAll();
-			if (this._map.jsdialog)
-				this._map.jsdialog.closeAll();
+			this._map.uiManager.closeAll();
 		}
 
 		if (e.msg) {
 			if (window.ThisIsAMobileApp && this._map._fatal) {
 				this._map.uiManager.showConfirmModal('cool_alert', '', e.msg, _('Close'), function() {
 					window.postMobileMessage('BYE');
-					vex.closeAll();
-					if (this._map.jsdialog)
-						this._map.jsdialog.closeAll();
+					this._map.uiManager.closeAll();
 				}.bind(this), true /* Hide cancel button */);
 			}
 			else

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -824,6 +824,13 @@ L.Control.UIManager = L.Control.extend({
 		app.socket._onMessage({ textMsg: 'jsdialog: ' + JSON.stringify(closeMessage) });
 	},
 
+	closeAll: function() {
+		if (this.map.jsdialog)
+			this.map.jsdialog.closeAll();
+		else
+			this.mobileWizard._closeWizard();
+	},
+
 	/// Returns generated (or to be generated) id for the modal container.
 	generateModalId: function(givenId) {
 		return this.modalIdPretext + givenId;

--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -3,7 +3,7 @@
  * L.Socket contains methods for the communication with the server
  */
 
-/* global app _ vex $ errorMessages Uint8Array brandProductName */
+/* global app _ $ errorMessages Uint8Array brandProductName */
 
 app.definitions.Socket = L.Class.extend({
 	ProtocolVersionNumber: '0.1',
@@ -679,11 +679,6 @@ app.definitions.Socket = L.Class.extend({
 		else if (textMsg.startsWith('commandresult: ')) {
 			var commandresult = JSON.parse(textMsg.substring(textMsg.indexOf('{')));
 			if (commandresult['command'] === 'savetostorage' || commandresult['command'] === 'save') {
-				if (commandresult['success']) {
-					// Close any open confirmation dialogs
-					vex.closeAll();
-				}
-
 				var postMessageObj = {
 					success: commandresult['success'],
 					result: commandresult['result'],
@@ -747,7 +742,6 @@ app.definitions.Socket = L.Class.extend({
 					if (socket.connected()) {
 						// We're connected: cancel timer and dialog.
 						clearTimeout(this.timer);
-						vex.closeAll();
 						return;
 					}
 
@@ -798,8 +792,7 @@ app.definitions.Socket = L.Class.extend({
 			}
 
 			// Close any open dialogs first.
-			vex.closeAll();
-			this._map.jsdialog.closeAll();
+			this._map.uiManager.closeAll();
 
 			var message = '';
 			if (!this._map['wopi'].DisableInactiveMessages) {
@@ -1042,7 +1035,6 @@ app.definitions.Socket = L.Class.extend({
 				// We're connected: cancel timer and dialog.
 				this.ReconnectCount = 0;
 				clearTimeout(this.timer);
-				vex.closeAll();
 			}
 		}
 		else if (window.ThisIsAMobileApp && textMsg.startsWith('mobile:')) {


### PR DESCRIPTION
Replace closeAll calls with uimanager.closeAll. It works for also mobile view.


Change-Id: Ieaf11fc8f68390f789c18a29813a171d51c13a88


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

