### PR TITLE
Fix GitHub issue #5839 and never disable Paste toolbar button

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2425,10 +2425,26 @@ L.Control.JSDialogBuilder = L.Control.extend({
 						$(div).removeClass('selected');
 					}
 
-					if (state && state === 'disabled')
-						$(div).addClass('disabled');
-					else
+					if (state && state === 'disabled') {
+						if (data.command === '.uno:Paste') {
+							// Fix GitHub issue #5839 and never disable Paste toolbar button
+							// Behave the same as Contol.Menubar and never
+							// disable Paste toolbar button. Native clients
+							// that run LibreOffice locally may send a
+							// "statechanged: .uno:Paste=disabled" message when
+							// opening a document if the system clipboard is
+							// empty, So, we ignore such messages or else the
+							// current document's Paste toolbar button will
+							// never be enabled.
+							$(div).removeClass('disabled');
+							window.app.console.log('do not disable paste based on server side data');
+						} else {
+							$(div).addClass('disabled');
+						}
+					}
+					else {
 						$(div).removeClass('disabled');
+					}
 				};
 
 				updateFunction();

--- a/ios/README
+++ b/ios/README
@@ -4,8 +4,6 @@ See https://collaboraonline.github.io/post/build-code-ios/
 App Store "Test Details" text for the last TestFlight build
 -----------------------------------------------------------
 
-This version includes the latest 22.05.10 code and fixes the following bugs:
+This version includes the latest 22.05.11 code and fixes the following bugs:
 
-• Pressing the Save, Paste, or certain other buttons would display an error or silently fail
-• Localizations for several languages were missing
-• When running the app with the user interface set to Hebrew, Arabic, or one of the other right to left (RTL) languages, the user interface would still be arranged left to right
+• The Paste button in the toolbar would sometimes be disabled even when there was content in the system pasteboard


### PR DESCRIPTION
Behave the same as Contol.Menubar and never disable Paste toolbar
button. Native clients that run LibreOffice locally may send a
"statechanged: .uno:Paste=disabled" message when opening a document
if the system clipboard is empty, So, we ignore such messages or else
the current document's Paste toolbar button will never be enabled.