### PR TITLE
Set box-sizing for sidebar and notebookbar icons

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -16,6 +16,7 @@ img.sidebar.ui-image {
 }
 
 .sidebar .ui-content .unobutton {
+	box-sizing: border-box;
 	margin: 0;
 }
 

--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -223,6 +223,7 @@
 }
 
 .unotoolbutton.notebookbar .unobutton {
+	box-sizing: border-box;
 	width: 24px !important;
 	height: 24px !important;
 	margin-inline-end: 0px !important;


### PR DESCRIPTION
This makes any resizing or position easier
and it's what is expected from "buttons" (it's the default value)

and those icons are buttons even if the html elment is somehting else

Bottom line: better to account for any border and padding in the values
we specify for width, height, border and padding. This makes sure that
the content box shrinks to adapt to those values.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I39af02f983611bc751e764c26d13d955b7774928
