### PR TITLE
zotero: show buttons when integrator supports it

### DIFF
--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -756,7 +756,7 @@ L.Control.UIManager = L.Control.extend({
 		var userPrivateInfo = this.map._docLayer ? this.map._viewInfo[this.map._docLayer._viewId].userprivateinfo : null;
 		if (userPrivateInfo) {
 			var apiKey = userPrivateInfo.ZoteroAPIKey;
-			if (apiKey) {
+			if (apiKey !== undefined) {
 				this.map.zotero = L.control.zotero(this.map);
 				this.map.zotero.apiKey = apiKey;
 				this.map.addControl(this.map.zotero);

--- a/browser/src/control/Control.Zotero.js
+++ b/browser/src/control/Control.Zotero.js
@@ -129,17 +129,26 @@ L.Control.Zotero = L.Control.extend({
 			this.map.uiManager.showSnackbar(_('Zotero API key is not configured'));
 	},
 
+	refreshUI: function () {
+		if (this.map.uiManager.notebookbar)
+			this.map.uiManager.refreshNotebookbar();
+		else
+			this.map.uiManager.refreshMenubar();
+	},
+
 	updateUserID: function () {
+		if (this.apiKey === '') {
+			this.refreshUI();
+			return;
+		}
+
 		var that = this;
 		fetch('https://api.zotero.org/keys/' + this.apiKey)
 			.then(function (response) { return response.json(); })
 			.then(function (data) {
 				that.userID = data.userID;
 				that.enable = !!that.userID;
-				if (that.map.uiManager.notebookbar)
-					that.map.uiManager.refreshNotebookbar();
-				else
-					that.map.uiManager.refreshMenubar();
+				that.refreshUI();
 				that.updateGroupIdList();
 			}, function () { that.map.uiManager.showSnackbar(_('Zotero API key is incorrect')); });
 	},


### PR DESCRIPTION
Empty api key string indicates that integrator supports Zotero. When any functionality is accessed by the user we show notification to integration so it will show a popup for user with instructions.
