### PR TITLE
export as pdf: we need to decode path

### DIFF
--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1660,7 +1660,7 @@ bool ClientSession::handleKitToClientMessage(const std::shared_ptr<Message>& pay
         if (resultURL.getScheme() == "file" && !COOLWSD::NoCapsForKit)
         {
             std::string relative;
-            if (isConvertTo)
+            if (isConvertTo || isExportAs)
                 Poco::URI::decode(resultURL.getPath(), relative);
             else
                 relative = resultURL.getPath();


### PR DESCRIPTION
When using Nextcloud with source file with spaces in the name eg. "file name.docx" and we tried to export as PDF then error appeared.

In the logs we had "SaveAs produced no output in '<...>file%20name.docx', producing blank url.

We need to decode file name similar to convert-to case.