### PR TITLE
Fix remotelink id

### DIFF
--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -841,7 +841,8 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 			(this._map['wopi'].EnableRemoteLinkPicker) ? {
 				'type': 'bigcustomtoolitem',
 				'text': _('Pick Link'),
-				'command': 'remotelink'
+				'command': 'remotelink',
+				'id': 'remotelink'
 			} : {},
 			{
 				'type': 'container',


### PR DESCRIPTION
Before this commit remotelink HTML elements were being generated with
the following HTML ID (including spaces): "Pick Link"

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I81b85c8bba9144e11b6579b777eb3df86e6e237d
