### PR TITLE
jsdialog: improvements

### DIFF
--- a/browser/src/control/jsdialog/Widget.DrawingArea.js
+++ b/browser/src/control/jsdialog/Widget.DrawingArea.js
@@ -27,6 +27,7 @@ function _drawingAreaControl (parentContainer, data, builder) {
 		return;
 
 	var image = L.DomUtil.create('img', builder.options.cssClass + ' ui-drawing-area', container);
+	image.id = data.id + '-img';
 	image.src = data.image.replace(/\\/g, '');
 	image.alt = data.text;
 	image.title = data.text;


### PR DESCRIPTION
jsdialog: keep focus in drawingarea when typing

When drawingarea is used as edit filed it is updated on every kep press or mouse click. We need to setup unique id for img also so focus later will be set for the same element after we get update message. (focus is set based on previously focused id)
--------------------------------------------------------------------------