### PR TITLE
jsdialog: Improve cosmetics of Find and replace

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -142,6 +142,14 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 	display: grid;
 }
 
+/* Find and replace dialog */
+#search_grid, #replace_grid {
+	grid-template-columns: minmax(100px, min-content) auto !important;
+}
+#searchframe input[type='checkbox'] {
+	margin-inline-start: 0;
+}
+
 /* keep structure with hidden elements correct */
 .ui-grid {
 	/* don't show scroll for hidden objects */


### PR DESCRIPTION
- Make sure the grid columns of 'Find' and 'Replace'
share the same minimum
  - the maximum parameter in minmax function (so min-content) is
    ignored when that value is lower than the min value but it is
    there for when the language has quite long 'Find' or 'Replace'
    making that max width increase according to its contents
- Remove extra margin from checkbox so it gets aligned

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ica38b407f2a5936e3657dc067ac0658ef5b8aeed
