### PR TITLE
jsdialog: fix switching the tabs

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -1107,7 +1107,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 				tabs.forEach(function (tab, index) {
 					tab.addEventListener('click', function(event) {
 						builder._createTabClick(builder, index, tabs, contentDivs, tabIds)(event);
-						if (data.tabs[index].index - 1 >= 0)
+						if (data.tabs[index].id - 1 >= 0)
 							builder.callback('tabcontrol', 'selecttab', tabWidgetRootContainer, index, builder);
 					});
 				});


### PR DESCRIPTION
This fixes regression from:
commit e5d86f0b3c4114fa8374fdc83373f0cc9a6f1a20
We can use foreach when there is indexed assinments.

there is no index field but id

it was not sending commang to the backend to switch the tab because of that