### PR TITLE
wsd: check for editable session not readonly

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1577,7 +1577,7 @@ void DocumentBroker::uploadToStorageInternal(const std::shared_ptr<ClientSession
     LOG_ASSERT_MSG(session, "Must have a valid ClientSession");
 
     const std::string sessionId = session->getId();
-    if (session->isReadOnly())
+    if (!session->isEditable())
     {
         LOG_WRN("Session [" << sessionId << "] is read-only and cannot upload docKey [" << _docKey
                             << ']');


### PR DESCRIPTION
The following commit caused a regression with
PDFs which are read-only, but may allow comments.

commit cca0a561ed5d7750404d39191918320d71726d5b
Author: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
Date:   Sun Jan 15 18:29:18 2023 -0500

    wsd: never upload using a session that is read-only

Change-Id: I9bf1fde21b47a4f119b99cc58f76cd683c2152a9

* Target version: 22.05