### PR TITLE
test: fix -Werror,-Winconsistent-missing-override

### DIFF
--- a/test/WhiteBoxTests.cpp
+++ b/test/WhiteBoxTests.cpp
@@ -609,7 +609,7 @@ public:
         return 0;
     }
 
-    void trimIfInactive()
+    void trimIfInactive() override
     {
     }
 };


### PR DESCRIPTION
'trimIfInactive' overrides a member function but was not marked 'override'.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I25b0033652a3362118a77b7ef5ef7a511ce492ea
