### PR TITLE
Fix regression from commit 51bb1d3

### DIFF
--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -1,7 +1,5 @@
 /* For btns hover status see device-desktop.css */
 
-.jsdialog-container .ui-button-box button,
-
 .jsdialog *[disabled] {
 	color: var(--color-text-lighter);
 	border: 1px solid var(--color-btn-border-dis);


### PR DESCRIPTION
the commit 51bb1d3 with the following change-id
I16a5df46bced608952c22bf979808bc735645366 introduced incomplete
CSS rule, rendering the whole css file invalid

So we should add back the rules and just remove the vex classes
but and upon further investigation button are already inheriting
font-family from jsdialogs.css: .jsdialog-container .ui-dialog-content
so we can just remove it altogether.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Iab42230efc7341e8967ce776f0d3decf41655ba6
