### PR TITLE
Feature add Send_UNO_Command postMessage

### DIFF
--- a/browser/html/framed.doc.html
+++ b/browser/html/framed.doc.html
@@ -30,6 +30,30 @@
         window.frames[0].postMessage(JSON.stringify(msg), '*');
       }
 
+      function sendBoldUNOCommand() {
+        post({'MessageId': 'Send_UNO_Command',
+              'Values': { 'Command': '.uno:Bold' }
+            });
+      }
+
+      function sendInsertBookMarkUNOCommand() {
+        post({'MessageId': 'Send_UNO_Command',
+              'Values': {
+                'Command': '.uno:InsertBookmark',
+                'Args': {
+                  Bookmark: {
+                    type: 'string',
+                    value: 'Test Insert BookMark'
+                  },
+                  BookmarkText: {
+                    type: 'string',
+                    value: 'Text of the Test Insert BookMark'
+                  }
+                }
+              }
+            });
+      }
+
       function insertText(text) {
         post({'MessageId': 'CallPythonScript',
               'SendTime': Date.now(),
@@ -308,6 +332,12 @@
       <p>
       <button onclick="ShowNotebookbar(false); return false;">Compact Toolbar</button>
       <button onclick="ShowNotebookbar(true); return false;">Tabbed Toolbar</button>
+    </form>
+
+    <h3>Send UNO Commands</h3>
+    <form id="menubar-toggle">
+      <button onclick="sendBoldUNOCommand(); return false;">Send Bold UNO Command (and example without args)</button>
+      <button onclick="sendInsertBookMarkUNOCommand(); return false;">Send InsertBookmark UNO Command (an example with args)</button>
     </form>
 
     <h3>Document frame</h3>

--- a/browser/src/map/handler/Map.WOPI.js
+++ b/browser/src/map/handler/Map.WOPI.js
@@ -319,6 +319,8 @@ L.Map.WOPI = L.Handler.extend({
 		else if (msg.MessageId === 'Insert_Button' &&
 			msg.Values && msg.Values.id && msg.Values.imgurl) {
 			this._map.uiManager.insertButton(msg.Values);
+		} else if (msg.MessageId === 'Send_UNO_Command' && msg.Values && msg.Values.Command) {
+			this._map.sendUnoCommand(msg.Values.Command, msg.Values.Args || '');
 		}
 		else if (msg.MessageId === 'Disable_Default_UIAction') {
 			// Disable the default handler and action for a UI command.


### PR DESCRIPTION
* Target version: master 

### Summary

We needed to execute UNO commands using `postMessage` from outside of the iframe, in order to add some custom UI and custom functionality. So, because executing UNO commands (especially with arguments like InsertBookMark) was not supported, we decided to add it as a general feature.

I have updated the `framed.doc.html` file, I don't know if there is any file or documentation I should update for this PR. If any, please mention it and I will update it. `framed.doc.html` preview:

<img width="924" alt="Screen Shot 2023-03-26 at 9 01 21 AM" src="https://user-images.githubusercontent.com/11475858/227757263-5837c17a-0ea4-47a4-af0a-d240d3f21905.png">

This is also our use case that uses `.uno:InsertBookMark` UNO command:

<img width="1657" alt="Screen Shot 2023-03-26 at 8 14 55 AM" src="https://user-images.githubusercontent.com/11475858/227757290-ca6e6a34-f4a4-4526-af11-99ae72c30aeb.png">

Our code is to add a sharing feature inside Collabora using custom-added buttons (using `Insert_Button` postMessage). We listen to the buttons' clicks and then we want to add a custom bookmark on the text (using UNO commands). (PR: https://github.com/BurnaSmartLab/osjs-office-collabora/pull/4)

**I have also run the code and tested it using Gitpod.**


### Checklist

- [X] Code is properly formatted
- [X] All commits have Change-Id
- [X] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

