### PR TITLE
Add remotefontconfigurl as env for Docker entrypoint

### DIFF
--- a/docker/from-packages/scripts/start-collabora-online.pl
+++ b/docker/from-packages/scripts/start-collabora-online.pl
@@ -97,6 +97,7 @@ sub rewrite_config($) {
     open(CONFIG, '<', $config) or die $!;
 
     my $in_aliases = 0;
+    my $in_remote_font_config = 0;
     while (<CONFIG>) {
         if (/<remote_url (.*)>.*<\/remote_url>/) {
             my $remoteurl = $ENV{'remoteconfigurl'};
@@ -107,6 +108,21 @@ sub rewrite_config($) {
             else {
                 $output .= $_;
             }
+        }
+        elsif (/<remote_font_config/) {
+            $in_remote_font_config = 1;
+            $output .= $_;
+        }
+        elsif ($in_remote_font_config && /<url /) {
+            my $remoteurl = $ENV{'remotefontconfigurl'};
+            if ($remoteurl) {
+                s/<url (.*)>.*<\/url>/<url $1>$remoteurl<\/url>/;
+                $output .= $_;
+            }
+            else {
+                $output .= $_;
+            }
+            $in_remote_font_config = 0;
         }
         elsif (/<alias_groups/) {
             $in_aliases = 1;
@@ -128,7 +144,7 @@ sub rewrite_config($) {
             $in_aliases = 0;
             $output .= $_;
         }
-        elsif (!$in_aliases) {
+        elsif (!$in_aliases && !$in_remote_font_config) {
             $output .= $_;
         }
     }

--- a/docker/from-packages/scripts/start-collabora-online.sh
+++ b/docker/from-packages/scripts/start-collabora-online.sh
@@ -35,7 +35,7 @@ SAL_LOG="-INFO-WARN"
 fi
 
 # Replace trusted host and set admin username and password - only if they are set
-if test -n "${aliasgroup1}" -o -n "${domain}" -o -n "${remoteconfigurl}"; then
+if test -n "${aliasgroup1}" -o -n "${domain}" -o -n "${remoteconfigurl}" -o -n "${remotefontconfigurl}"; then
     perl -w /start-collabora-online.pl || { exit 1; }
 fi
 if test -n "${username}"; then


### PR DESCRIPTION
* Target version: master 

### Summary

This commit adds the environment variable `remotefontconfigurl` to docker images and templates it's value into the coolwsd.xml in the same way as the other environment variables currently handled this way like `remoteconfigurl`.

This allows the `remote_font_config` URL to be set in the config via ENV.

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have successfully build the container
- [x] I have successfully build the container and tested that with a remotefontconfigurl as ENV I can successfully use the remote_font_config feature
- [x] Documentation (manuals or wiki) is not required, as the other env options (`remoteconfigurl`) is also undocumented afaik...

