### PR TITLE
jsdialog: make tabs accessible using keybaord

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -193,39 +193,40 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 }
 
 .ui-tab.jsdialog {
-	float: left;
-	font-size: var(--default-font-size);
-	font-family: var(--cool-font);
-	line-height: normal;
-	color: dimgray;
-	color: var(--color-text-dark);
-	height: 24px;
-	display: flex;
-	align-items: center;
-	padding: 0px 1em;
-	border-radius: var(--border-radius);
-	background-color: var(--color-main-background);
-	margin-inline-end: 12px;
+	float: left !important;
+	font-size: var(--default-font-size) !important;
+	font-family: var(--cool-font) !important;
+	line-height: normal !important;
+	color: dimgray !important;
+	color: var(--color-text-dark) !important;
+	height: 24px !important;
+	display: flex !important;
+	align-items: center !important;
+	padding: 0px 1em !important;
+	border: solid 1px transparent !important;
+	border-radius: var(--border-radius) !important;
+	background-color: var(--color-main-background) !important;
+	margin-inline-end: 12px !important;
 }
 
 .ui-tab.jsdialog:first-child {
-	margin-inline-start: 12px;
+	margin-inline-start: 12px !important;
 }
 
 .ui-tab.hidden.jsdialog {
-	visibility: hidden;
+	visibility: hidden !important;
 }
 
 .ui-tab.selected.jsdialog {
-	background-color: var(--color-background-lighter);
-	color: var(--color-text-darker);
-	box-shadow: 0 0 2px 1px #cfcfcf;
+	background-color: var(--color-background-lighter) !important;
+	color: var(--color-text-darker) !important;
+	box-shadow: 0 0 2px 1px #cfcfcf !important;
 }
 
 .ui-tab.jsdialog:not(.selected):hover {
-	cursor: pointer;
-	background-color: var(--color-background-darker);
-	color: var(--color-text-darker);
+	cursor: pointer !important;
+	background-color: var(--color-background-darker) !important;
+	color: var(--color-text-darker) !important;
 }
 
 /* Expander */

--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -15,12 +15,13 @@
 }
 
 .ui-tab.notebookbar {
-	height: 24px;
-	display: flex;
-	align-items: center;
-	padding: 0px 1em;
-	border: 1px solid transparent;
-	border-radius: var(--border-radius);
+	height: 24px !important;
+	display: flex !important;
+	align-items: center !important;
+	padding: 0px 1em !important;
+	border: 1px solid transparent !important;
+	border-radius: var(--border-radius) !important;
+	background-color: transparent !important;
 }
 
 .ui-tab.notebookbar[style*='block'] {
@@ -28,7 +29,7 @@
 }
 
 .ui-tab.hidden.notebookbar {
-	display: none;
+	display: none !important;
 }
 
 .ui-tab.notebookbar > button {
@@ -42,19 +43,19 @@
 }
 
 .ui-tab.selected.notebookbar {
-	background: var(--color-background-dark);
-	border: 1px solid var(--color-border-dark);
+	background: var(--color-background-dark) !important;
+	border: 1px solid var(--color-border-dark) !important;
 }
 .ui-tab.selected.notebookbar > button {
-	color: var(--color-text-darker);
+	color: var(--color-text-darker) !important;
 }
 .ui-tab.notebookbar:hover {
-	background: var(--color-background-darker);
-	border: 1px solid var(--color-border-darker);
-	cursor: pointer;
+	background: var(--color-background-darker) !important;
+	border: 1px solid var(--color-border-darker) !important;
+	cursor: pointer !important;
 }
 .ui-tab.notebookbar:hover > button {
-	color: var(--color-text-darker);
+	color: var(--color-text-darker) !important;
 }
 /* Document Logo */
 .main-nav.hasnotebookbar #document-header {

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -1059,9 +1059,10 @@ L.Control.JSDialogBuilder = L.Control.extend({
 
 				var title = builder._cleanText(item.text);
 
-				var tab = L.DomUtil.create('div', 'ui-tab ' + builder.options.cssClass, tabsContainer);
+				var tab = L.DomUtil.create('button', 'ui-tab ' + builder.options.cssClass, tabsContainer);
 				tab.id = item.name + '-tab-label';
 				tab.number = item.id - 1;
+				tab.setAttribute('tabIndex', '0');
 
 				var isSelectedTab = data.selected == item.id;
 				if (isSelectedTab) {
@@ -3035,6 +3036,8 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		// natural tab-order when using keyboard navigation
 		if (control && !control.hasAttribute('tabIndex')
 			&& data.type !== 'container'
+			&& data.type !== 'tabpage'
+			&& data.type !== 'tabcontrol'
 			&& data.type !== 'grid'
 			&& data.type !== 'toolbox'
 			&& data.type !== 'listbox'

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -3038,6 +3038,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			&& data.type !== 'container'
 			&& data.type !== 'tabpage'
 			&& data.type !== 'tabcontrol'
+			&& data.type !== 'drawingarea'
 			&& data.type !== 'grid'
 			&& data.type !== 'toolbox'
 			&& data.type !== 'listbox'

--- a/browser/src/control/jsdialog/Widget.DrawingArea.js
+++ b/browser/src/control/jsdialog/Widget.DrawingArea.js
@@ -117,7 +117,6 @@ function _drawingAreaControl (parentContainer, data, builder) {
 			event.preventDefault();
 		} else if (event.key === 'Tab') {
 			builder.callback('drawingarea', 'keypress', container, UNOKey.TAB | modifier, builder);
-			event.preventDefault();
 		} else if (event.key === 'Shift') {
 			modifier = modifier | UNOModifier.SHIFT;
 			event.preventDefault();


### PR DESCRIPTION
This changes tabs into button elements so they can be switched using keyboard Enter key. It's also better from a11y point of view

Styles has to be !important to override button styling