### PR TITLE
jsdialog: fix alignment in dialogs

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -140,6 +140,7 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 	border-spacing: 0px;
 	width: 100%;
 	display: grid;
+	grid-gap: 4px;
 }
 
 /* Find and replace dialog */

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -527,13 +527,13 @@ input[type='checkbox']:checked.autofilter, .jsdialog input[type='checkbox']:chec
 	box-sizing: border-box;
 	margin-right: 1px;
 	min-width: 70px;
+	width: 100%;
 }
 
 .spinfieldunit {
 	font-size: var(--default-font-size);
 	color: var(--color-text-dark);
 	margin: 5px;
-	position: absolute;
 	margin-inline-start: calc(-40px);
 }
 /* spinfield (number) */
@@ -566,6 +566,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	-moz-appearance: none;
 	appearance: none;
 	min-width: 100px;
+	width: 100%;
 	height: 28px;
 	line-height: normal;
 	font-size: var(--default-font-size);

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1263,6 +1263,16 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	to { opacity: 0 }
 }
 
+/* images */
+
+.ui-image {
+	margin: auto;
+}
+
+.ui-drawing-area-container {
+	margin: auto;
+}
+
 /* formulabar */
 #sc_input_window.formulabar {
 	height: 28px;

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -493,11 +493,12 @@ input[type='checkbox']:checked.autofilter, .jsdialog input[type='checkbox']:chec
 
 .radiobutton.jsdialog {
 	display: flex;
+	align-items: center;
+	justify-content: flex-start;
 }
 
 .jsdialog input[type='radio'] {
-	vertical-align: middle;
-	margin: auto 3px auto 2px;
+	margin: 0;
 	border: none;
 }
 


### PR DESCRIPTION
- added space between elements in grid
- spinfileds, listboxes have equal width, 100% of a grid cell