### PR TITLE
mobile: use attribute 'visibility' to hide toolbar back button

### DIFF
--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -1510,7 +1510,7 @@ L.Control.Menubar = L.Control.extend({
 							self._map.fire('mobilewizard', {data: menuData});
 							$('#toolbar-hamburger').removeClass('menuwizard-closed').addClass('menuwizard-opened');
 							$('#mobile-wizard-header').hide();
-							$('#toolbar-mobile-back').hide();
+							$('#toolbar-mobile-back').css('visibility', 'hidden');
 							$('#formulabar').hide();
 						}
 					} else if (!window.mode.isMobile()) {
@@ -1522,7 +1522,7 @@ L.Control.Menubar = L.Control.extend({
 						window.mobileMenuWizard = false;
 						self._map.fire('closemobilewizard');
 						$('#toolbar-hamburger').removeClass('menuwizard-opened').addClass('menuwizard-closed');
-						$('#toolbar-mobile-back').show();
+						$('#toolbar-mobile-back').css('visibility', '');
 						if (self._map.getDocType() === 'spreadsheet')
 							$('#formulabar').show();
 					}


### PR DESCRIPTION
Otherwise, the toolbar re-layout half the size.

Change-Id: I492a98f822a829d814b4c6e6b4765ec14a65cc98
Signed-off-by: Henry Castro <hcastro@collabora.com>
