### PR TITLE
Fix issue #6145 by adding aliases for the PDF and EPUB icons

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2299,6 +2299,11 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			'zoterounlink': 'unlinkcitation',
 			'zoteroaddeditbibliography': 'addeditbibliography',
 			'zoterosetdocprefs': 'formproperties',
+			// Fix issue #6145 by adding aliases for the PDF and EPUB icons
+			// The fix for issues #6103 and #6104 changes the name of these
+			// icons so map the new names to the old names.
+			'downloadas-pdf': 'exportpdf',
+			'downloadas-epub': 'exportepub',
 		};
 		if (iconURLAliases[cleanName]) {
 			cleanName = iconURLAliases[cleanName];

--- a/ios/README
+++ b/ios/README
@@ -6,5 +6,4 @@ App Store "Test Details" text for the last TestFlight build
 
 This version includes the latest 22.05.12 code and fixes the following bugs:
 
-• Closing certain dialogs when they are displayed underneath another dialog would cause a crash
 • Icons would fail to load for any menu items and toolbar buttons that export a document to PDF or EPUB

--- a/ios/README
+++ b/ios/README
@@ -6,7 +6,5 @@ App Store "Test Details" text for the last TestFlight build
 
 This version includes the latest 22.05.12 code and fixes the following bugs:
 
-• The bold, underline, and italics toolbar buttons used the wrong localization
-• Some buttons in the Sidebar in Writer were misaligned or drawn outside of the visable area
-• Tapping an Export as PDF menu item or toolbar button would cause the app to hang
-• Tapping an Export as EPUB menu item or toolbar button would silently fail
+• Closing certain dialogs when they are displayed underneath another dialog would cause a crash
+• Icons would fail to load for any menu items and toolbar buttons that export a document to PDF or EPUB


### PR DESCRIPTION
The fix for issues #6103 and #6104 changes the name of these
icons so map the new names to the old names.