### PR TITLE
TileCacheTests: re-copy documents when repeating tests.

### DIFF
--- a/test/TileCacheTests.cpp
+++ b/test/TileCacheTests.cpp
@@ -389,14 +389,15 @@ void TileCacheTests::testCancelTiles()
 void TileCacheTests::testCancelTilesMultiView()
 {
     const std::string testname = "testCancelTilesMultiView-";
-    std::string documentPath, documentURL;
-    getDocumentPathAndURL("setclientpart.ods", documentPath, documentURL, testname);
 
     // The tile response can race past the canceltiles,
     // so be forgiving to avoid spurious failures.
     constexpr size_t repeat = 2;
     for (size_t j = 1; j <= repeat; ++j)
     {
+        std::string documentPath, documentURL;
+        getDocumentPathAndURL("setclientpart.ods", documentPath, documentURL, testname);
+
         TST_LOG("cancelTilesMultiView try #" << j);
 
         // Wait to clear previous sessions.
@@ -473,12 +474,13 @@ void TileCacheTests::testCancelTilesMultiView()
 void TileCacheTests::testDisconnectMultiView()
 {
     const char* testname = "testDisconnectMultiView";
-    std::string documentPath, documentURL;
-    getDocumentPathAndURL("setclientpart.ods", documentPath, documentURL, "disconnectMultiView ");
 
     constexpr size_t repeat = 2;
     for (size_t j = 1; j <= repeat; ++j)
     {
+        std::string documentPath, documentURL;
+        getDocumentPathAndURL("setclientpart.ods", documentPath, documentURL, "disconnectMultiView ");
+
         TST_LOG("disconnectMultiView try #" << j);
 
         // Wait to clear previous sessions.


### PR DESCRIPTION
Attempted blind fix for intermittent failure:

[ kitbroker_004 ] TRC  Document::GlobalCallback LOK_CALLBACK_ERROR [{ "classification": "error", "cmd": "load", "kind": "io", "code": 770, "message": ""}]. filter/source/config/cache/typedetection.cxx:452: caught exception while querying type of ... "Could not open stream for <file:///tmp/.../disconnectMultiView_5f47c785_setclientpart.ods> at filter/source/config/cache/typedetection.cxx:1123"

[ coolwsd ] TST  disconnectMultiView-1  [loadDocAndGetSession] (+22012ms): ERROR: Assertion failure: Failed to load the document cool/file%3A%2F%2F%2Ftmp%2FdisconnectMultiView_5f47c785_setclientpart.ods/ws. Condition: isLoaded| helpers.hpp:531

Change-Id: I91062bf4c136dbd6a4cf6def842ff2ae7687c758


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

