### PR TITLE
Expose Translate option to mobile if feature is enabled

### DIFF
--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -934,6 +934,10 @@ L.Control.Menubar = L.Control.extend({
 			{id: 'watermark', uno: '.uno:Watermark'},
 			{name: _('Page Setup'), id: 'pagesetup', type: 'action'},
 			{uno: '.uno:WordCountDialog'},
+			window.deeplEnabled ?
+				{
+					uno: '.uno:Translate'
+				} : {},
 			{name: _UNO('.uno:RunMacro'), id: 'runmacro', uno: '.uno:RunMacro'},
 			{name: _('Latest Updates'), id: 'latestupdates', type: 'action', iosapp: false},
 			{name: _('Send Feedback'), id: 'feedback', type: 'action', mobileapp: false},


### PR DESCRIPTION
Before this commit was impossible to use the translate button
on mobile phone

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ia93e1bf009723f3f7791b63f0b15a74467595ab7
