### PR TITLE
Better Modified Tracking and Upload Headers

### DIFF
--- a/test/httpwstest.cpp
+++ b/test/httpwstest.cpp
@@ -373,6 +373,7 @@ void HTTPWSTest::testInactiveClient()
                                             token == "editor:" ||
                                             token == "context:" ||
                                             token == "window:" ||
+                                            token == "rulerupdate:" ||
                                             token == "tableselected:");
 
                     // End when we get state changed.

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -683,9 +683,8 @@ bool ClientSession::_handleInput(const char *buffer, int length)
                 }
             }
 
-            constexpr bool isAutosave = false;
-            docBroker->sendUnoSave(client_from_this(), dontTerminateEdit != 0,
-                                   dontSaveIfUnmodified != 0, isAutosave, extendedData);
+            docBroker->manualSave(client_from_this(), dontTerminateEdit != 0,
+                                  dontSaveIfUnmodified != 0, extendedData);
         }
     }
     else if (tokens.equals(0, "savetostorage"))

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1550,18 +1550,8 @@ bool ClientSession::handleKitToClientMessage(const std::shared_ptr<Message>& pay
                 const auto& object = parsedJSON.extract<Poco::JSON::Object::Ptr>();
                 if (object->get("commandName").toString() == ".uno:Save")
                 {
-                    const bool success = object->get("success").toString() == "true";
-                    std::string result;
-                    if (object->has("result"))
-                    {
-                        const Poco::Dynamic::Var parsedResultJSON = object->get("result");
-                        const auto& resultObj = parsedResultJSON.extract<Poco::JSON::Object::Ptr>();
-                        if (resultObj->get("type").toString() == "string")
-                            result = resultObj->get("value").toString();
-                    }
-
                     // Save to Storage and log result.
-                    docBroker->handleSaveResponse(client_from_this(), success, result);
+                    docBroker->handleSaveResponse(client_from_this(), object);
 
                     if (!isCloseFrame())
                         forwardToClient(payload);

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -1397,13 +1397,15 @@ private:
 
     std::unique_ptr<StorageBase> _storage;
 
-    /// The current upload request's attributes. Re-used to retry after failure.
-    /// Updated right before uploading.
-    StorageBase::Attributes _currentStorageAttrs;
-    /// The next upload request's attributes. Avoids clobbering
-    /// _currentStorageAttrs until the current request succeeds.
-    /// Updated right before saving.
+    /// The next upload request's attributes, used during uno:Save only.
+    /// Updated right before saving and when saving is completed.
     StorageBase::Attributes _nextStorageAttrs;
+    /// The current upload request's attributes.
+    /// Updated after saving and merged with 'last' when upload fails.
+    StorageBase::Attributes _currentStorageAttrs;
+    /// The last upload request's attributes. Re-used to retry after failure.
+    /// Updated right before uploading.
+    StorageBase::Attributes _lastStorageAttrs;
 
     std::unique_ptr<TileCache> _tileCache;
     std::atomic<bool> _isModified;

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -452,10 +452,9 @@ public:
             _lastEditingSessionId = viewId;
     }
 
-    /// Sends the .uno:Save command to LoKit.
-    bool sendUnoSave(const std::shared_ptr<ClientSession>& session, bool dontTerminateEdit = true,
-                     bool dontSaveIfUnmodified = true, bool isAutosave = false,
-                     const std::string& extendedData = std::string());
+    /// User wants to issue a save on the document.
+    bool manualSave(const std::shared_ptr<ClientSession>& session, bool dontTerminateEdit,
+                    bool dontSaveIfUnmodified, const std::string& extendedData);
 
     /// Sends a message to all sessions.
     /// Returns the number of sessions sent the message to.
@@ -607,6 +606,11 @@ private:
 
     /// Handles the completion of uploading to storage, both success and failure cases.
     void handleUploadToStorageResponse(const StorageBase::UploadResult& uploadResult);
+
+    /// Sends the .uno:Save command to LoKit.
+    bool sendUnoSave(const std::shared_ptr<ClientSession>& session, bool dontTerminateEdit = true,
+                     bool dontSaveIfUnmodified = true, bool isAutosave = false,
+                     const std::string& extendedData = std::string());
 
     /**
      * Report back the save result to PostMessage users (Action_Save_Resp)

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -290,8 +290,8 @@ public:
 
     /// Handle the save response from Core and upload to storage as necessary.
     /// Also notifies clients of the result.
-    void handleSaveResponse(const std::shared_ptr<ClientSession>& session, bool success,
-                            const std::string& result);
+    void handleSaveResponse(const std::shared_ptr<ClientSession>& session,
+                            const Poco::JSON::Object::Ptr& json);
 
     /// Check if uploading is needed, and start uploading.
     /// The current state of uploading must be introspected separately.


### PR DESCRIPTION
The primary purpose of this PR is to make sure the IsModifiedByUser header passed to storage is accurate. We now get this flag from Core in the uno:Save response, so there are no race conditions.

- wsd: do not allow multiple saves in flight
- wsd: process the modified state from uno:Save
- wsd: track the storage attributes more accurately
- wsd: test: new test for superfluous save commands
- wsd: test: rulerupdate is an expected message
