### PR TITLE
Set missing dimensions to sidebar button images

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1240,10 +1240,6 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	border: none;
 }
 
-.jsdialog .ui-content.unobutton > img{
-	height: 100%;
-}
-
 .unotoolbutton.jsdialog.sidebar.ui-content > .arrowbackground {
 	width: auto;
 }

--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -20,6 +20,11 @@ img.sidebar.ui-image {
 	margin: 0;
 }
 
+.sidebar .unobutton > img {
+	width: var(--btn-size);
+	height: var(--btn-size);
+}
+
 #document-container:not(.mobile) + #sidebar-dock-wrapper {
 	padding: 0;
 	box-sizing: border-box;


### PR DESCRIPTION
- re-use btn-size variable
- make it clear that this set of rules is intended to sidebar elements
  - Improve selector (more clear and so it doesn't target other
    elements outside of the sidebar)
  - Move it to jssidebar.css file

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ib03c412a1e05fd6ed315f58a70486f14eaf5b9ea
