### PR TITLE
Show correct launch URI

### DIFF
--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -190,7 +190,7 @@ using Poco::XML::InputSource;
 using Poco::XML::NodeList;
 
 /// Port for external clients to connect to
-int ClientPortNumber = 0;
+int ClientPortNumber = DEFAULT_CLIENT_PORT_NUMBER;
 /// Protocols to listen on
 Socket::Type ClientPortProto = Socket::Type::All;
 
@@ -5402,7 +5402,7 @@ private:
     {
         std::shared_ptr<SocketFactory> factory;
 
-        if (ClientPortNumber <= 0)
+        if (ClientPortNumber == DEFAULT_CLIENT_PORT_NUMBER)
         {
             // Avoid using the default port for unit-tests altogether.
             // This avoids interfering with a running test instance.


### PR DESCRIPTION
this fixes regression from:
commit 158e1a125f9a839893f5289329ba37584077cf5b
wsd: avoid using the default port for unit-tests

where 0 was shown as port in example launch URI on make run