### PR TITLE
Fix button ration

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1232,8 +1232,8 @@ input[type='number']:hover::-webkit-outer-spin-button {
 /* toolbuttons */
 
 .jsdialog .ui-content.unobutton {
-	width: 30px;
-	height: 24px;
+	width: var(--btn-size);
+	height: var(--btn-size);
 	margin-inline-end: 5px;
 	vertical-align: middle;
 	background-color: transparent;

--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -18,6 +18,7 @@ img.sidebar.ui-image {
 .sidebar .ui-content .unobutton {
 	box-sizing: border-box;
 	margin: 0;
+	padding: 0;
 }
 
 .sidebar .unobutton > img {


### PR DESCRIPTION
Before this commit we were setting buttons in places such as
the sidebar with weird ratio (not 1:1) this might lead to problems
when aligning, adjusting gaps. Better to adjust gap or margin if we
need bigger spaces in between

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Id60cd6353de2ace2a066c0d1624000a09f0ca98e
