### PR TITLE
Fix wrong device detection logic.

### DIFF
--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -244,7 +244,7 @@ window.app = {
 				return true;
 			}
 
-			return L.Browser.mobile && (screen.width < 768 || screen.height < 768);
+			return L.Browser.mobile && (window.innerWidth < 768 || window.innerHeight < 768);
 		},
 		// Mobile device with big screen size.
 		isTablet: function() {


### PR DESCRIPTION
window.screen.width/height returns the width/height of the screen in CSS pixels. window.innerWidth/innerHeight returns the interior width/height of the window in pixels. This includes the width of the vertical scroll bar, if one is present.

That gives better result. eg: responsive mode


Change-Id: Ibecb9614224cb3bfd6d5d8dc9ad5febe6aa7673b


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

