### PR TITLE
jsdialog: don't setup additional margin for unmanaged scrollwindow

### DIFF
--- a/browser/src/control/jsdialog/Widget.ScrolledWindow.js
+++ b/browser/src/control/jsdialog/Widget.ScrolledWindow.js
@@ -75,18 +75,23 @@ function _scrolledWindowControl(parentContainer, data, builder) {
 			return;
 		}
 
-		content.style.height = (realContentHeight + verticalSteps) + 'px';
-		content.style.width = (realContentWidth + horizontalSteps) + 'px';
-		if (!noVertical)
+		if (!noVertical) {
+			content.style.height = (realContentHeight + verticalSteps) + 'px';
 			scrollwindow.style.height = (realContentHeight + margin) + 'px';
-		if (!noHorizontal)
+		}
+		if (!noHorizontal) {
+			content.style.width = (realContentWidth + horizontalSteps) + 'px';
 			scrollwindow.style.width = (realContentWidth + margin) + 'px';
+		}
+
 		content.scrollTop = data.vertical.value * 10;
 		content.scrollLeft = data.horizontal.value * 10;
+
 		content.style.margin = content.scrollTop + 'px ' + margin + 'px ' + margin + 'px ' + content.scrollLeft + 'px';
 	};
 
-	setTimeout(updateSize, 0);
+	if (data.user_managed_scrolling !== false)
+		setTimeout(updateSize, 0);
 
 	var sendTimer = null;
 


### PR DESCRIPTION
Can be tested with Calc's Data -> Sort dialog:
When we have multiple entries we still should scroll only to the end of last entry. Previously we added lot of extra space when scrollbar was present. 

Can be tested with Conditional Formatting dialog:
Also this change prevents from adding unnecessary margin to drawing areas.