### PR TITLE
Fix debug build breakage due to undefined DEBUG_ABSSRCDIR macro on iOS

### DIFF
--- a/ios/Mobile/AppDelegate.mm
+++ b/ios/Mobile/AppDelegate.mm
@@ -231,8 +231,11 @@ static void updateTemplates(NSData *data, NSURLResponse *response)
     // language, as it might be hard to find the way to set it back to a known language.
 
     char *lang = std::getenv("LANG");
+    // Fix assert failure when running "My Mac (Designed for iPad)" in Xcode
+    // LANG values such as en_US.UTF-8 trigger an assert in the LibreOffice
+    // code so replace all "_" characters with "-" characters.
     if (lang != nullptr)
-        app_locale = [NSString stringWithUTF8String:lang];
+        app_locale = [[NSString stringWithUTF8String:lang] stringByReplacingOccurrencesOfString:@"_" withString:@"-"];
     else
         app_locale = [[NSLocale preferredLanguages] firstObject];
 

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -5667,7 +5667,7 @@ int COOLWSD::innerMain()
     }
 #endif
 
-#if ENABLE_DEBUG
+#if ENABLE_DEBUG && !MOBILEAPP
     const std::string postMessageURI =
         getServiceURI("/browser/dist/framed.doc.html?file_path=" DEBUG_ABSSRCDIR
                       "/" COOLWSD_TEST_DOCUMENT_RELATIVE_PATH_WRITER);


### PR DESCRIPTION
On iOS and Android, a custom build process and the Online server code runs locally in the same process as the app so defer modifying those separate build processes until they are needed on mobile platforms.