### PR TITLE
Update jquery-ui.css to make the container's height reflect its content.

### DIFF
--- a/browser/css/jquery-ui-lightness.css
+++ b/browser/css/jquery-ui-lightness.css
@@ -837,6 +837,9 @@ button.ui-button::-moz-focus-inner {
 .ui-tabs {
 	position: relative;/* position: relative prevents IE scroll bug (element with position: relative inside container with overflow: auto appear as "fixed") */
 	padding: .2em;
+	box-sizing: border-box;
+	height: fit-content;
+	overflow: hidden;
 }
 .ui-tabs .ui-tabs-nav {
 	margin: 0;

--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -234,6 +234,10 @@ button.ui-tab.notebookbar {
 	border-radius: var(--border-radius);
 }
 
+.jsdialog .ui-tabs-content {
+	margin-top: 10px;
+}
+
 .ui-tabs-content .unobutton > img {
 	width: var(--btn-size);
 	height: var(--btn-size);


### PR DESCRIPTION
Create a new CSS rule to make tabs' content lower enough from the tabs' buttons.


Change-Id: I3354b93711f1e93aa9c97c31b3717cad7b917351


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

