### PR TITLE
Tabbed view: fix buttons occupying extra space

### DIFF
--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -199,13 +199,6 @@ button.ui-tab.notebookbar {
 
 /* unobuttons */
 
-.hasnotebookbar .ui-content .unobutton {
-	width: 32px;
-	height: 32px;
-	margin-inline-end: 5px;
-	vertical-align: middle;
-}
-
 /* avoid bug with arrow in new line when window is small */
 #table-Home-Section-Insert #table-LineB9 #InsertGraphic.notebookbar,
 #table-Home-Section-Insert #table-GroupB20 #InsertTable.notebookbar {
@@ -223,10 +216,11 @@ button.ui-tab.notebookbar {
 .unotoolbutton.notebookbar .unobutton {
 	box-sizing: border-box;
 	padding: 0;
-	width: auto;
-	height: 24px;
+	width: var(--btn-size);
+	height: var(--btn-size);
 	background-color: transparent;
 	margin: 0;
+	vertical-align: middle;
 	border: none;
 	line-height: 0em;
 	color: var(--color-main-text);


### PR DESCRIPTION
similar to d1991e177c8bcb6e484ee62afd90a8c399edef40
but his time addressing:
- outdated css rules (remove them). They are outdated because we
already have `.unotoolbutton.notebookbar .unobutton`. Plus all of the
with exception of `vertical-align: middle;` were being ignored
- Do not allow browser to calculate width and instead set the same
value as in height
- Move `vertical-align: middle;` to a better place

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Idb2de12365727d0ed2886729d9effbf36ede31ab
