### PR TITLE
Add additional column gap to all page widgets within dialogs

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -830,6 +830,10 @@ nav.spreadsheet-color-indicator ~ #sidebar-dock-wrapper {
 	border-radius: calc(var(--border-radius)/2);
 }
 
+.lokdialog.ui-dialog-content [Id$='Page'] {
+	grid-column-gap: 24px;
+}
+
 .lokdialog_container:not(.jsdialog-container) .lokdialog.ui-dialog-content.ui-widget-content {
 	padding: 0px;
 }


### PR DESCRIPTION
If the page widget (elements that end their id with Page) have just
one column this will not take effect.

Why: the grip-grap (for both columns and rows) of 4 px set in the
jsdialogs.css is enough for many cases but when we have a Page with
more than 1 column the 4 pixels is too small to distinguish the
different sections.

Dialogs affected by this commit: All with child content id ending in
Page. Examples of improved dialogs:
- File properties
- Char format
- Settings of Footnotes and Endnotes
- Paragraph (format)
- Bullets and Numbering (position tab)
- Page Style (border, Header)

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Iebe9f01b758f1af8b43317cdf01a44f74c70cc42
