### PR TITLE
Tabbed view: Fix context tabs visibility

### DIFF
--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -441,6 +441,7 @@ L.Control.Notebookbar = L.Control.extend({
 				for (var context in contexts) {
 					if (contexts[context] === event.context) {
 						tabElement.show();
+						tabElement.removeClass('hidden');
 						if (!tabElement.hasClass('selected'))
 							contextTab = tabElement;
 					} else if (contexts[context] === 'default') {


### PR DESCRIPTION
With the a11y improvements from
9d3d0cdee73e84b8446324cf55fb1feefe720cd8
we now add !important to visibility: hidden that in turn makes the
browser ignore the inline display block. The result: we get a new tab
content without the tab itself (it's hidden)
- Fix this by removing the 'hidden' class when the tab button needs to
be shown

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I276d3fa62d89b32935de0357d0b24f558fcf3fd6
