### PR TITLE
cypress: add flag to delay update popup in Chrome indefinitely.

### DIFF
--- a/cypress_test/plugins/index.js
+++ b/cypress_test/plugins/index.js
@@ -30,15 +30,17 @@ function plugin(on, config) {
 		});
 	}
 
-	if (process.env.ENABLE_LOGGING) {
-		on('before:browser:launch', function(browser, launchOptions) {
-			if (browser.family === 'chromium') {
+	on('before:browser:launch', function(browser, launchOptions) {
+		if (browser.family === 'chromium') {
+			if (process.env.ENABLE_LOGGING) {
 				launchOptions.args.push('--enable-logging=stderr');
 				launchOptions.args.push('--v=2');
-				return launchOptions;
 			}
-		});
-	}
+			launchOptions.args.push('--simulate-outdated-no-au=\'2099-12-31T23:59:59.000000+00:00\'');
+		}
+
+		return launchOptions;
+	});
 
 	if (process.env.CYPRESS_INTEGRATION === 'php-proxy') {
 		config.defaultCommandTimeout = 10000;


### PR DESCRIPTION
The suspicion is that the update popup messes with focus, and can break tests after they start intermittently - at least in interactive mode.

cf. also https://github.com/cypress-io/cypress/pull/16694

Date syntax is altered to avoid another bug with cypress parameter parsing.

Change-Id: I92b9911eb7b3673a64a9d123b2c110111b7c3549


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

