### PR TITLE
use getentropy() for BSD systems

### DIFF
--- a/common/Util.cpp
+++ b/common/Util.cpp
@@ -20,6 +20,10 @@
 
 #include <poll.h>
 
+#ifdef HAVE_GETENTROPY
+#  include <unistd.h>
+#endif
+
 #ifdef HAVE_SYS_RANDOM_H
 #  include <sys/random.h>
 #endif
@@ -114,12 +118,24 @@ namespace Util
             std::vector<char> v(length);
 
             int len = 0;
-#ifdef HAVE_SYS_RANDOM_H
+            /* use "/dev/[u]random" by default in case of
+            getentropy() or getrandom() fails,
+            or they don't available */
+            bool useDevRandom = true;
+#ifdef HAVE_GETENTROPY
+            len = getentropy(v.data(), length);
+
+            // getentropy() works, no need to use "/dev/[u]random"
+            if (len != -1)
+                useDevRandom = false;
+#elif defined HAVE_SYS_RANDOM_H
             len = getrandom(v.data(), length, GRND_NONBLOCK);
 
-            // if getrandom() fails, we fall back to "/dev/[u]random" approach.
-            if (len != length)
+            // getrandom() works, no need to use "/dev/[u]random"
+            if (len != -1)
+                useDevRandom = false;
 #endif
+            if (useDevRandom)
             {
                 const int fd = open("/dev/urandom", O_RDONLY);
                 if (fd < 0 ||

--- a/configure.ac
+++ b/configure.ac
@@ -1070,6 +1070,18 @@ else
     AC_DEFINE([HAVE_SYS_RANDOM_H],0,[Define to 1 if you have the <sys/random.h> header file.])
 fi
 
+AC_LINK_IFELSE(
+    [AC_LANG_SOURCE([[
+    #include <unistd.h>
+    int main()
+    {
+        char buffer[8];
+        getentropy(buffer, sizeof(buffer));
+    }
+    ]])],
+    [AC_DEFINE([HAVE_GETENTROPY],1,[Define to 1 if you have getentropy() function in <unistd.h> header file.])],
+    [AC_DEFINE([HAVE_GETENTROPY],0,[Define to 1 if you have getentropy() function in <unistd.h> header file.])])
+
 AS_IF([test -n "$LOKIT_PATH"],
       [CPPFLAGS="$CPPFLAGS -I${LOKIT_PATH}"])
 lokit_msg="$LOKIT_PATH"


### PR DESCRIPTION
Change-Id: Id6a2629c06d641eb4e7cf3991de4036d2f7b346e

* Resolves: #5851 
* Target version: master 

### Summary

- instead of using /dev/[u]random devices, 
use getentropy() to make direct system calls if the system is a BSD.

- if getentropy() fails, we need to fall back to "/dev/[u]random" approach.

### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

