### PR TITLE
Add possibility to define product name from brand package

### DIFF
--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -2080,7 +2080,8 @@ void COOLWSD::innerInitialize(Application& self)
         { "deepl.enabled", "false" },
         { "zotero.enable", "true" },
         { "indirection_endpoint.url", "" },
-        { "help_url", HELP_URL }
+        { "help_url", HELP_URL },
+        { "product_name", APP_NAME}
     };
 
     // Set default values, in case they are missing from the config file.
@@ -5156,7 +5157,7 @@ private:
         capabilities->set("hasMobileSupport", true);
 
         // Set the product name
-        capabilities->set("productName", APP_NAME);
+        capabilities->set("productName", config::getString("product_name", APP_NAME));
 
         // Set the Server ID
         capabilities->set("serverId", Util::getProcessIdentifier());
@@ -5500,7 +5501,7 @@ void COOLWSD::processFetchUpdate()
             return; // No url, nothing to do.
 
         Poco::URI uriFetch(url);
-        uriFetch.addQueryParameter("product", APP_NAME);
+        uriFetch.addQueryParameter("product", config::getString("product_name", APP_NAME));
         uriFetch.addQueryParameter("version", COOLWSD_VERSION);
         LOG_TRC("Infobar update request from " << uriFetch.toString());
         std::shared_ptr<http::Session> sessionFetch = StorageBase::getHttpSession(uriFetch);


### PR DESCRIPTION
This is the product name served by hosting/capabilities endpoint. Also, it is used by update checker.
It can be defined --with-app-name build time, but if we would like to configure it run-time (e.g. with the brand package), then we need a config setting for it. E.g. brand package could execute
  coolconfig set product_name "foo bar"
in postinstall script, if necessary.


Change-Id: I8e72d3a3735e3a77c7aaac9a88b2c0fc6a957c0e

