### PR TITLE
Jail cleanup - include coolwsd pid + hash into a jails sub-directory.

### DIFF
--- a/common/JailUtil.hpp
+++ b/common/JailUtil.hpp
@@ -37,7 +37,7 @@ void markJailCopied(const std::string& root);
 bool isJailCopied(const std::string& root);
 
 /// Remove the jail directory and all its contents.
-void removeJail(const std::string& root);
+bool tryRemoveJail(const std::string& root);
 
 /// Remove all jails.
 void cleanupJails(const std::string& jailRoot);

--- a/kit/ForKit.cpp
+++ b/kit/ForKit.cpp
@@ -357,7 +357,7 @@ static void cleanupChildren()
     while (i-- > 0)
     {
         const std::string path = cleanupJailPaths[i];
-        JailUtil::removeJail(path);
+        JailUtil::tryRemoveJail(path);
         const FileUtil::Stat st(path);
         if (st.good() && st.isDirectory())
             LOG_DBG("Could not remove jail path [" << path << "]. Will retry later.");

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -2839,7 +2839,7 @@ void lokit_main(
                 if (!mountJail())
                 {
                     LOG_INF("Cleaning up jail before linking/copying.");
-                    JailUtil::removeJail(jailPathStr);
+                    JailUtil::tryRemoveJail(jailPathStr);
                     bindMount = false;
                     JailUtil::disableBindMounting();
                 }
@@ -3188,6 +3188,7 @@ void consistencyCheckJail()
                     "potentially indicative of an operator damaging the system, and will "
                     "inevitably cause document data-loss and/or malfunction.");
             warned = true;
+            assert(!"Fatal system error with jail setup.");
         }
         else
             LOG_TRC("Passed system consistency check");

--- a/wsd/COOLWSD.hpp
+++ b/wsd/COOLWSD.hpp
@@ -261,6 +261,7 @@ public:
     static std::string ConfigDir;
     static std::string SysTemplate;
     static std::string LoTemplate;
+    static std::string CleanupChildRoot;
     static std::string ChildRoot;
     static std::string ServerName;
     static std::string FileServerRoot;


### PR DESCRIPTION
This avoids removing the jails of other running coolwsd that share the same jails/ directory, such as unit-tests, cypress tests etc.

Assert on fatal system error to help catch this during test builds.

Remove old unit-test specific approach, and generalize it, since apparently we did a recursive cleanup of other people's jails anyway.

Remove over-complicated recursive approach, for a rather simpler one-level scheme. Avoid following symlinks too for safety.

Remove obsolete lo_jail_subpath setting.


Change-Id: I371f8c0e22f64fb2befb4b58f72cefa39567f3b5


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

