### PR TITLE
Fix listview icon sizes

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -287,7 +287,8 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 }
 
 .ui-listview-icon {
-	height: 24px;
+	height: var(--btn-size);
+	width: var(--btn-size);
 	margin-inline-end: 8px;
 }
 


### PR DESCRIPTION
icons or being set with a non 1:1 ratio, missing width in the css.
Also better to reuse the btn-size

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I55b005d83718da81d9a7a44193b6f9de7192d41e
