### PR TITLE
Tabbed view: Fix .main-nav's horizontal scrolling

### DIFF
--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -53,6 +53,7 @@ L.Control.Notebookbar = L.Control.extend({
 		this.map.sendUnoCommand('.uno:ToolbarMode?Mode:string=notebookbar_online.ui');
 
 		$('#toolbar-wrapper').addClass('hasnotebookbar');
+		$('.main-nav').removeProp('overflow');
 		$('.main-nav').addClass('hasnotebookbar');
 		$('.main-nav').addClass(docType + '-color-indicator');
 		document.getElementById('document-container').classList.add('notebookbar-active');


### PR DESCRIPTION
Remove inline overflow style.

Before this commit:
It seems we are adding inline style overflow visible onRemove()
- important for when we switch compact <-> tabbed view - but we never
remove that property. Thus we end up losing the ability to access any
element that doesn't fit the screen via horizontal scroll

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Id1ed8cde27af037f6b28b1966dfe4c563b0120cf
