### PR TITLE
Fix not working inotify / restart on coolwsd.xml changes

### DIFF
--- a/docker/from-packages/scripts/start-collabora-online.sh
+++ b/docker/from-packages/scripts/start-collabora-online.sh
@@ -52,7 +52,7 @@ if test -n "${dictionaries}"; then
 fi
 
 # Restart when /etc/coolwsd/coolwsd.xml changes
-[ -x /usr/bin/inotifywait -a /usr/bin/killall ] && (
+[ -x /usr/bin/inotifywait -a -x /usr/bin/killall ] && (
   /usr/bin/inotifywait -e modify /etc/coolwsd/coolwsd.xml
   echo "$(ls -l /etc/coolwsd/coolwsd.xml) modified --> restarting"
   /usr/bin/killall -1 coolwsd


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
Recently noticed that the inotify I originally added to cause an automatic restart of Collabora, if the coolwsd.xml was changed, no longer works.
Looking at the shell script the problem is obvious.
So, please merge ASAP.

Ralf

### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

