### PR TITLE
admin: added a seprate state for the uploaded document

### DIFF
--- a/browser/admin/admin.html
+++ b/browser/admin/admin.html
@@ -63,6 +63,7 @@
             <th class="has-text-centered"><script>document.write(l10nstrings.strElapsedTime)</script></th>
             <th class="has-text-centered"><script>document.write(l10nstrings.strIdleTime)</script></th>
             <th class="has-text-centered"><script>document.write(l10nstrings.strModified)</script></th>
+            <th class="has-text-centered"><script>document.write(l10nstrings.strUploaded)</script></th>
           </tr>
         </thead>
         <tbody id="doclist"></tbody>

--- a/browser/admin/admin.strings.js
+++ b/browser/admin/admin.strings.js
@@ -26,6 +26,7 @@ l10nstrings.strViewers = _('Views');
 l10nstrings.strElapsedTime = _('Elapsed time');
 l10nstrings.strIdleTime = _('Idle time');
 l10nstrings.strModified = _('Modified');
+l10nstrings.strUploaded = _('Uploaded');
 l10nstrings.strWopihost = _('WOPI host');
 l10nstrings.strKill = _('Kill');
 l10nstrings.strGraphs = _('Graphs');

--- a/browser/admin/src/AdminSocketOverview.js
+++ b/browser/admin/src/AdminSocketOverview.js
@@ -155,6 +155,16 @@ function upsertDocsTable(doc, sName, socket, wopiHost) {
 	if (add === true) { row.appendChild(isModifiedCell); } else { row.cells[0] = isModifiedCell; }
 	isModifiedCell.className = 'has-text-centered';
 
+	var isUploadedCell = document.createElement('td');
+	isUploadedCell.id = 'up' + doc['pid'];
+	isUploadedCell.innerText = doc['uploaded'];
+	if (add === true) {
+		row.appendChild(isUploadedCell);
+	} else {
+		row.cells[0] = isUploadedCell;
+	}
+	isUploadedCell.className = 'has-text-centered';
+
 	// TODO: Is activeViews always the same with viewer count? We will hide this for now. If they are not same, this will be added to Users column like: 1/2 active/user(s).
 	if (add === true) {
 		var viewsCell = document.createElement('td');
@@ -221,7 +231,7 @@ var AdminSocketOverview = AdminSocketBase.extend({
 		this.base.call(this);
 
 		this.socket.send('documents');
-		this.socket.send('subscribe adddoc rmdoc resetidle propchange modifications');
+		this.socket.send('subscribe adddoc rmdoc resetidle propchange modifications uploaded');
 
 		this._getBasicStats();
 		var socketOverview = this;
@@ -287,6 +297,7 @@ var AdminSocketOverview = AdminSocketBase.extend({
 				'elapsedTime': '0',
 				'idleTime': '0',
 				'modified': 'No',
+				'uploaded': 'Yes',
 				'views': [{ 'sessionid': docProps[2], 'userName': decodeURI(docProps[3]) }]
 			};
 
@@ -378,6 +389,19 @@ var AdminSocketOverview = AdminSocketBase.extend({
 
 			var $mod = $(document.getElementById('mod' + sPid));
 			$mod.text(value);
+		}
+		else if (textMsg.startsWith('uploaded')) {
+			textMsg = textMsg.substring('uploaded'.length);
+			docProps = textMsg.trim().split(' ');
+			if (docProps.length === 2) {
+				sPid = docProps[0];
+				var value = docProps[1];
+
+				var up = $(document.getElementById('up' + sPid));
+				if (up !== undefined) {
+					up.text(value);
+				}
+			}
 		}
 		else if (e.data == 'InvalidAuthToken' || e.data == 'NotAuthenticated') {
 			var msg;

--- a/wsd/Admin.cpp
+++ b/wsd/Admin.cpp
@@ -552,6 +552,11 @@ void Admin::modificationAlert(const std::string& dockey, pid_t pid, bool value){
     addCallback([=] { _model.modificationAlert(dockey, pid, value); });
 }
 
+void Admin::uploadedAlert(const std::string& dockey, pid_t pid, bool value)
+{
+    addCallback([=] { _model.uploadedAlert(dockey, pid, value); });
+}
+
 void Admin::addDoc(const std::string& docKey, pid_t pid, const std::string& filename,
                    const std::string& sessionId, const std::string& userName, const std::string& userId,
                    const int smapsFD, const Poco::URI& wopiSrc)

--- a/wsd/Admin.hpp
+++ b/wsd/Admin.hpp
@@ -100,6 +100,9 @@ public:
     size_t getTotalCpuUsage();
 
     void modificationAlert(const std::string& dockey, pid_t pid, bool value);
+
+    void uploadedAlert(const std::string& dockey, pid_t pid, bool value);
+
     /// Update the Admin Model.
     void update(const std::string& message);
 

--- a/wsd/AdminModel.cpp
+++ b/wsd/AdminModel.cpp
@@ -501,6 +501,19 @@ void AdminModel::modificationAlert(const std::string& docKey, pid_t pid, bool va
     notify(oss.str());
 }
 
+void AdminModel::uploadedAlert(const std::string& docKey, pid_t pid, bool value)
+{
+    assertCorrectThread();
+
+    auto doc = _documents.find(docKey);
+    if (doc != _documents.end())
+        doc->second->setUploaded(value);
+
+    std::ostringstream oss;
+    oss << "uploaded " << pid << ' ' << (value ? "Yes" : "No");
+    notify(oss.str());
+}
+
 void AdminModel::addDocument(const std::string& docKey, pid_t pid,
                              const std::string& filename, const std::string& sessionId,
                              const std::string& userName, const std::string& userId,
@@ -789,6 +802,7 @@ std::string AdminModel::getDocuments() const
                 << "\"elapsedTime\"" << ':' << it.second->getElapsedTime() << ','
                 << "\"idleTime\"" << ':' << it.second->getIdleTime() << ','
                 << "\"modified\"" << ':' << '"' << (it.second->getModifiedStatus() ? "Yes" : "No") << '"' << ','
+                << "\"uploaded\"" << ':' << '"' << (it.second->getUploadedStatus() ? "Yes" : "No") << '"' << ','
                 << "\"views\"" << ':' << '[';
             std::map<std::string, View> viewers = it.second->getViews();
             std::string separator;

--- a/wsd/AdminModel.hpp
+++ b/wsd/AdminModel.hpp
@@ -158,6 +158,7 @@ public:
         , _hasMemDirtyChanged(true)
         , _badBehaviorDetectionTime(0)
         , _abortTime(0)
+        , _isUploaded(0)
     {
     }
 
@@ -205,6 +206,9 @@ public:
 
     void setModified(bool value) { _isModified = value; }
     bool getModifiedStatus() const { return _isModified; }
+
+    void setUploaded(bool value) { _isUploaded = value; }
+    bool getUploadedStatus() const { return _isUploaded; }
 
     void addBytes(uint64_t sent, uint64_t recv)
     {
@@ -268,6 +272,8 @@ private:
 
     std::time_t _badBehaviorDetectionTime;
     std::time_t _abortTime;
+
+    bool _isUploaded;
 };
 
 /// An Admin session subscriber.
@@ -341,6 +347,8 @@ public:
     void unsubscribe(int sessionId, const std::string& command);
 
     void modificationAlert(const std::string& docKey, pid_t pid, bool value);
+
+    void uploadedAlert(const std::string& docKey, pid_t pid, bool value);
 
     void clearMemStats() { _memStats.clear(); }
 

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1752,10 +1752,11 @@ void DocumentBroker::handleUploadToStorageResponse(const StorageBase::UploadResu
 #if !MOBILEAPP
     if (lastUploadSuccessful && !isModified())
     {
-        // Flag the document as un-modified in the admin console.
-        // But only when we have uploaded successfully and the document
-        // is current not flagged as modified by Core.
-        Admin::instance().modificationAlert(_docKey, getPid(), false);
+        // Flag the document as uploaded in the admin console.
+        // But only when isModified() == false because it might happen
+        // by the time we finish uploading there is further modification
+        // to the document.
+        Admin::instance().uploadedAlert(_docKey, getPid(), lastUploadSuccessful);
     }
 #endif
 
@@ -3424,12 +3425,12 @@ std::size_t DocumentBroker::countActiveSessions() const
 void DocumentBroker::setModified(const bool value)
 {
 #if !MOBILEAPP
-    if (value)
-    {
-        // Flag the document as modified in the admin console.
-        // But only flag it as unmodified when we do upload it.
-        Admin::instance().modificationAlert(_docKey, getPid(), value);
-    }
+    // Flag the document as modified in the admin console.
+    Admin::instance().modificationAlert(_docKey, getPid(), value);
+
+    // Flag the document as uploaded in the admin console.
+    Admin::instance().uploadedAlert(
+        _docKey, getPid(), !isAsyncUploading() && needToUploadToStorage() == NeedToUpload::No);
 #endif
 
     LOG_DBG("Modified state set to " << value << " for Doc [" << _docId << ']');


### PR DESCRIPTION
- previously we set the Modified state in admin panel only when wsd successfully upload the document to storage
- modified state updation depends on core, it might happen that uploading is already done and successfull but we didnot get the modified state from the core which will show wrong modified status in admin panel

Change-Id: I014a8f92753fc6a93b37921d0f3cdce390bef35e


* Resolves: # <!-- related github issue -->
* Target version: master 
