### PR TITLE
dark-mode use correct jquery-ui icons with data-theme value

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -593,11 +593,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 .ui-listbox::-ms-expand {
 	display: none;
 }
-@media (prefers-color-scheme: dark) {
-	.ui-listbox-arrow {
-		background: url('images/jquery-ui-lightness/ui-icons_ffffff_256x240.png') no-repeat transparent !important;
-	}
-}
+
 .ui-listbox-arrow {
 	content: '';
 	background: url('images/jquery-ui-lightness/ui-icons_222222_256x240.png') no-repeat transparent;
@@ -611,6 +607,10 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	margin-block-start: 8px;
 	margin-inline-start: -16px;
 	margin-inline-end: 4px;
+}
+
+[data-theme='dark'] .ui-listbox-arrow {
+	background: url('images/jquery-ui-lightness/ui-icons_ffffff_256x240.png') no-repeat transparent;
 }
 
 .ui-listbox[disabled='disabled'] ~ .ui-listbox-arrow {


### PR DESCRIPTION
dark theme was switched with [data-theme='dark'] instead of prefer-color-scheme so the new setting respect [data-theme='dark'].

#### dropdown icon color is fixed

![Screenshot_20230427_230607](https://user-images.githubusercontent.com/8517736/234993621-546f2849-bb7c-4de3-a5b5-51c55f267315.png)

![Screenshot_20230427_230549](https://user-images.githubusercontent.com/8517736/234993640-ca9f8db6-cf9a-476e-80e3-49e3bfd4003e.png)

Change-Id: I9214fda63f6caea0a36ab8be7c26baf4e1c0f46e