### PR TITLE
Fix down arrow/triangle position in sidebar dropdown icons

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -213,6 +213,9 @@ div.sidebar.ui-grid .checkbutton.sidebar,
 	border: 1px solid transparent;
 	margin-right: 5px;
 }
+.sidebar.unotoolbutton.has-dropdown {
+	display: flex;
+}
 .sidebar.jsdialog.checkbutton {
 	font-size: var(--default-font-size);
 }


### PR DESCRIPTION
before this commit the triangle was misplaced, under the icon instead
of side by side

(might be related to https://github.com/CollaboraOnline/online/issues/6236)

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Id8d118471dcb02b5bc79399a4319ee514af03c5b
