### PR TITLE
Fixes Menu items hover color are inconsistent #6254

### DIFF
--- a/browser/css/device-desktop.css
+++ b/browser/css/device-desktop.css
@@ -27,7 +27,7 @@
    Rules not intended for touch devices */
 
 .button-secondary:hover,
-button:not(.ui-corner-all):not(.button-primary):hover {
+button:not(.ui-corner-all):not(.button-primary):not(.unobutton):hover {
 	cursor: pointer;
 	color: var(--color-text-darker) !important;
 	background-color: var(--color-background-lighter) !important;


### PR DESCRIPTION
Fixes https://github.com/CollaboraOnline/online/issues/6254

Before this commit and with recent a11y changes generic btn hover
styles were bleeding out to multiple places where icon btns are present

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I3855d081595a2d3aa56e58137e21aba5d7bf8532
