### PR TITLE
jsdialog: don't create empty tabs container #6260

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -184,16 +184,6 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 }
 
 /* Tabs */
-.jsdialog-tabs {
-	display: flex;
-	width: 100%;
-	background: var(--color-background-lighter);
-}
-
-.jsdialog-tabs:empty {
-	display: none;
-}
-
 .ui-tab.jsdialog {
 	float: left !important;
 	font-size: var(--default-font-size) !important;

--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -113,16 +113,8 @@ L.Control.JSDialog = L.Control.extend({
 		}
 	},
 
-	setTabs: function(tabs, builder) {
-		var dialog = this.dialogs[builder.windowId.toString()];
-		if (dialog) {
-			var tabsContainer = dialog.tabs;
-
-			while (tabsContainer.firstChild)
-				tabsContainer.removeChild(tabsContainer.firstChild);
-
-			tabsContainer.appendChild(tabs);
-		}
+	setTabs: function() {
+		console.error('setTabs: not implemented in dialogs.');
 	},
 
 	selectedTab: function() {
@@ -218,13 +210,9 @@ L.Control.JSDialog = L.Control.extend({
 		if (instance.isSnackbar)
 			L.DomUtil.addClass(instance.container, 'snackbar');
 
-		instance.tabs = L.DomUtil.create('div', 'jsdialog-tabs', instance.container);
 		instance.content = L.DomUtil.create('div', 'lokdialog ui-dialog-content ui-widget-content', instance.container);
 
-		// required to exist before builder was launched (for setTabs)
-		this.dialogs[instance.id] = {
-			tabs: instance.tabs
-		};
+		this.dialogs[instance.id] = {};
 	},
 
 	createDialog: function(instance) {


### PR DESCRIPTION
In dialogs we put tab list directly where tab control is placed. We don't need special container anymore (setTabs is not used).