### PR TITLE
jsdialog: improve initial focus in dialog #6271

### DIFF
--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -243,6 +243,10 @@ L.Control.JSDialog = L.Control.extend({
 			L.DomUtil.addClass(primaryBtn, 'button-primary');
 	},
 
+	getFirstFocusableElement: function(widget) {
+		return widget.querySelector('[tabIndex="0"]:not(.jsdialog-begin-marker):not([disabled]):not(.hidden)');
+	},
+
 	addFocusHandler: function(instance) {
 		// loop using tab key
 		var beginMarker = L.DomUtil.create('div', 'jsdialog autofilter jsdialog-begin-marker');
@@ -256,7 +260,7 @@ L.Control.JSDialog = L.Control.extend({
 
 		instance.container.addEventListener('focusin', function(event) {
 			if (event.target == beginMarker || event.target == endMarker) {
-				var firstFocusElement = instance.container.querySelector('[tabIndex="0"]:not(.jsdialog-begin-marker, .jsdialog-end-marker)');
+				var firstFocusElement = instance.container.querySelector('[tabIndex="0"]:not(.jsdialog-begin-marker, .jsdialog-end-marker):not([disabled]):not(.hidden)');
 				if (firstFocusElement)
 					firstFocusElement.focus();
 				else if (document.getElementById(instance.init_focus_id)) {
@@ -327,7 +331,7 @@ L.Control.JSDialog = L.Control.extend({
 		instance.clickToClose = clickToCloseElement;
 
 		// setup initial focus and helper elements for closing popup
-		var initialFocusElement = instance.container.querySelector('[tabIndex="0"]:not(.jsdialog-begin-marker)');
+		var initialFocusElement = this.getFirstFocusableElement(instance.container);
 
 		if (instance.canHaveFocus && initialFocusElement)
 			initialFocusElement.focus();
@@ -335,8 +339,13 @@ L.Control.JSDialog = L.Control.extend({
 		var focusWidget = instance.init_focus_id ? instance.container.querySelector('[id=\'' + instance.init_focus_id + '\']') : null;
 		if (focusWidget)
 			focusWidget.focus();
-		if (focusWidget && document.activeElement !== focusWidget)
-			console.error('cannot get focus for widget: "' + instance.init_focus_id + '"');
+		if (focusWidget && document.activeElement !== focusWidget) {
+			var firstFocusable = this.getFirstFocusableElement(focusWidget);
+			if (firstFocusable)
+				firstFocusable.focus();
+			else
+				console.error('cannot get focus for widget: "' + instance.init_focus_id + '"');
+		}
 	},
 
 	setPosition: function(instance, updatedPos) {
@@ -503,8 +512,7 @@ L.Control.JSDialog = L.Control.extend({
 				var lastKey = dialogs[dialogs.length - 1];
 				var container = this.dialogs[lastKey].container;
 				container.focus();
-				var initialFocusElement =
-					container.querySelector('[tabIndex="0"]:not(.jsdialog-begin-marker)');
+				var initialFocusElement = this.getFirstFocusableElement(container);
 				initialFocusElement.focus();
 			}
 		}

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -1055,7 +1055,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 	{
 		return function() {
 			$(tabs[t]).addClass('selected');
-			tabs[t].removeAttribute('tabindex');
+			tabs[t].tabIndex = '0';
 			tabs[t].setAttribute('aria-selected', 'true');
 
 			for (var i = 0; i < tabs.length; i++) {
@@ -1113,7 +1113,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 				if (isSelectedTab) {
 					$(tab).addClass('selected');
 					tab.setAttribute('aria-selected', 'true');
-					tab.removeAttribute('tabindex');
+					tab.tabIndex = '0';
 					tab.title = tabTooltip;
 					singleTabId = tabIdx;
 				} else {

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -3179,6 +3179,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			&& data.type !== 'tabcontrol'
 			&& data.type !== 'drawingarea'
 			&& data.type !== 'grid'
+			&& data.type !== 'image'
 			&& data.type !== 'toolbox'
 			&& data.type !== 'listbox'
 			&& data.type !== 'combobox'


### PR DESCRIPTION
can be tested with File -> Properties,
no error is shown with this patch and initially focused element is something we can use not an image