### PR TITLE
browser: fix freeze row/column panes

### DIFF
--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -839,7 +839,8 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 			return;
 		}
 
-		var newSplitIndex = Math.floor(parseInt(e.state));
+		var values = e.state.split('/');
+		var newSplitIndex = Math.floor(parseInt(values[0]));
 		window.app.console.assert(!isNaN(newSplitIndex) && newSplitIndex >= 0, 'invalid argument for ' + e.commandName);
 
 		// This stores the current split-cell state of core, so this should not be modified.


### PR DESCRIPTION
The UNO command  state has changed to Point (row, tab)
and Point (col, tab), Otherwise, if the row or column
has the same value for all sheets, the state cache will
not report any changes to the client side.

Change-Id: I0ad4a058d9328ff3b7b2455197a87880d8e43125
Signed-off-by: Henry Castro <hcastro@collabora.com>
