### PR TITLE
Impress: Fix imperceptible active (current) slide border

### DIFF
--- a/browser/css/partsPreviewControl.css
+++ b/browser/css/partsPreviewControl.css
@@ -31,19 +31,22 @@
 	vertical-align: middle;
 	max-width: 164px;
 	cursor: pointer;
-	border: 1px solid var(--color-border) !important;
+	border: 3px solid transparent !important;
+	outline: 3px solid var(--color-border);
+	box-sizing: border-box;
 	margin-left: 10px;
 	margin-right: 10px;
 }
 
 /* The current part the user is on. */
 .preview-img-currentpart {
-	border: 1px solid var(--color-primary-dark) !important;
+	border-color: var(--color-background-lighter) !important;
+	outline-color: var(--color-primary-dark);
 }
 
 /* One of (potentially many) selected parts, but not the current. */
 .preview-img-selectedpart {
-	border: 1px solid var(--color-primary) !important;
+	border-color: var(--color-primary) !important;
 }
 
 /* Highlight where a slide can be dropped when reordering by drag-and-drop. */


### PR DESCRIPTION
- Make it bigger
- Also size is not enough, specially for slides that have backgrounds
  - Add white inner margin so there is a clear distinction between
- what is the slide preview (image) and its contour

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ifee386b98d74c937efa35c19551334482ec18632
