### PR TITLE
Make dialog button style to specific that dialog #6275

### DIFF
--- a/browser/html/cool-help.html
+++ b/browser/html/cool-help.html
@@ -11,7 +11,7 @@
     .screenshot { text-align:center; margin: 0.1in; }
     .screenshot > img { max-width: 100%; height: auto; }
     .blue { color:#63bbee; }
-    button { font-family: "Helvetica Neue", sans-serif; background: none!important; border: none; padding: 0!important; color: -webkit-link; cursor: pointer; text-decoration: underline; font-size: 1em; line-height: 1.5em; }
+    button.border-0 { font-family: "Helvetica Neue", sans-serif; background: none!important; border: none; padding: 0!important; color: -webkit-link; cursor: pointer; text-decoration: underline; font-size: 1em; line-height: 1.5em; }
     button:active { color: -webkit-activelink; }
     button:focus { outline: -webkit-focus-ring-color auto 1px; }
 </style>


### PR DESCRIPTION
In tabbed view when we open help or keyboard shortcuts dialog "button" style of cool-help.html overrides the button.ui-tab.notebookbar. So all buttons (even in notebook bar) uses dialog buttons' text-decoration: underline and padding:0

Here we make the dialog's button style specific to related dialogs.


Change-Id: Iacaab42efa527fc5c6ada21fd007e4a352912b60


* Resolves: #6275 
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

