### PR TITLE
wsd: http: killpoco in prisoner http handler

### DIFF
--- a/net/HttpRequest.cpp
+++ b/net/HttpRequest.cpp
@@ -473,9 +473,9 @@ int64_t Response::readData(const char* p, int64_t len)
             // Assume we have a body unless we have reason to expect otherwise.
             _parserStage = ParserStage::Body;
 
-            if (_statusLine.statusCategory() == StatusLine::StatusCodeClass::Informational
-                || _statusLine.statusCode() == 204 /*No Content*/
-                || _statusLine.statusCode() == 304 /*Not Modified*/) // || HEAD request
+            if (_statusLine.statusCategory() == StatusLine::StatusCodeClass::Informational ||
+                _statusLine.statusCode() == http::StatusCode::NoContent ||
+                _statusLine.statusCode() == http::StatusCode::NotModified) // || HEAD request
             // || 2xx on CONNECT request
             {
                 // No body, we are done.

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -178,7 +178,9 @@ enum class StatusCode : unsigned
     SeeOther = 303,
     NotModified = 304,
     UseProxy = 305,
+    // Unused: 306
     TemporaryRedirect = 307,
+    PermanentRedirect = 308,
 
     // Client Error
     BadRequest = 400,
@@ -313,6 +315,11 @@ static inline const char* getReasonPhraseForCode(int code)
 #undef CASE
 
     return "Unknown";
+}
+
+static inline const char* getReasonPhraseForCode(StatusCode statusCode)
+{
+    return getReasonPhraseForCode(static_cast<unsigned>(statusCode));
 }
 
 /// The callback signature for handling IO writes.
@@ -749,7 +756,7 @@ public:
     const std::string& httpVersion() const { return _httpVersion; }
     unsigned versionMajor() const { return _versionMajor; }
     unsigned versionMinor() const { return _versionMinor; }
-    unsigned statusCode() const { return _statusCode; }
+    StatusCode statusCode() const { return static_cast<StatusCode>(_statusCode); }
     const std::string& reasonPhrase() const { return _reasonPhrase; }
 
 private:
@@ -1758,6 +1765,18 @@ inline std::ostream& operator<<(std::ostream& os, const http::Header& header)
         os << '\t' << pair.first << ": " << pair.second << " / ";
     }
 
+    return os;
+}
+
+inline std::ostream& operator<<(std::ostream& os, const http::StatusCode& statusCode)
+{
+    os << getReasonPhraseForCode(statusCode);
+    return os;
+}
+
+inline std::ostringstream& operator<<(std::ostringstream& os, const http::StatusCode& statusCode)
+{
+    os << getReasonPhraseForCode(statusCode);
     return os;
 }
 

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -1751,7 +1751,15 @@ private:
 };
 }
 
-} // namespace http
+inline std::ostream& operator<<(std::ostream& os, const http::Header& header)
+{
+    for (const auto& pair : header)
+    {
+        os << '\t' << pair.first << ": " << pair.second << " / ";
+    }
+
+    return os;
+}
 
 inline std::ostream& operator<<(std::ostream& os, const http::FieldParseState& fieldParseState)
 {
@@ -1770,5 +1778,28 @@ inline std::ostream& operator<<(std::ostream& os, const http::Response::State& s
     os << http::Response::name(state);
     return os;
 }
+
+/// Format seconds with the units suffix until we migrate to C++20.
+inline std::ostream& operator<<(std::ostream& os, const std::chrono::seconds& s)
+{
+    os << s.count() << 's';
+    return os;
+}
+
+/// Format milliseconds with the units suffix until we migrate to C++20.
+inline std::ostream& operator<<(std::ostream& os, const std::chrono::milliseconds& ms)
+{
+    os << ms.count() << "ms";
+    return os;
+}
+
+/// Format microseconds with the units suffix until we migrate to C++20.
+inline std::ostream& operator<<(std::ostream& os, const std::chrono::microseconds& ms)
+{
+    os << ms.count() << "us";
+    return os;
+}
+
+} // namespace http
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -969,8 +969,7 @@ protected:
         http::Response response(
             [&]()
             {
-                if (response.statusLine().statusCode() ==
-                        Poco::Net::HTTPResponse::HTTP_SWITCHING_PROTOCOLS &&
+                if (response.statusLine().statusCode() == http::StatusCode::SwitchingProtocols &&
                     Util::iequal(response.get("Upgrade"), "websocket") &&
                     Util::iequal(response.get("Connection", ""), "Upgrade") &&
                     response.get("Sec-WebSocket-Accept", "") ==

--- a/test/HttpRequestTests.cpp
+++ b/test/HttpRequestTests.cpp
@@ -249,7 +249,7 @@ void HttpRequestTests::testGoodResponse()
         LOK_ASSERT(httpResponse->state() == http::Response::State::Complete);
         LOK_ASSERT(!httpResponse->statusLine().httpVersion().empty());
         LOK_ASSERT(!httpResponse->statusLine().reasonPhrase().empty());
-        LOK_ASSERT_EQUAL(200U, httpResponse->statusLine().statusCode());
+        LOK_ASSERT_EQUAL(http::StatusCode::OK, httpResponse->statusLine().statusCode());
         LOK_ASSERT(httpResponse->statusLine().statusCategory() ==
                    http::StatusLine::StatusCodeClass::Successful);
         LOK_ASSERT_EQUAL(std::string("HTTP/1.1"), httpResponse->statusLine().httpVersion());
@@ -316,7 +316,7 @@ void HttpRequestTests::testSimpleGet()
         LOK_ASSERT(httpResponse->state() == http::Response::State::Complete);
         LOK_ASSERT(!httpResponse->statusLine().httpVersion().empty());
         LOK_ASSERT(!httpResponse->statusLine().reasonPhrase().empty());
-        LOK_ASSERT_EQUAL(200U, httpResponse->statusLine().statusCode());
+        LOK_ASSERT_EQUAL(http::StatusCode::OK, httpResponse->statusLine().statusCode());
         LOK_ASSERT(httpResponse->statusLine().statusCategory()
                    == http::StatusLine::StatusCodeClass::Successful);
 
@@ -352,7 +352,7 @@ void HttpRequestTests::testSimpleGetSync()
 
         LOK_ASSERT(!httpResponse->statusLine().httpVersion().empty());
         LOK_ASSERT(!httpResponse->statusLine().reasonPhrase().empty());
-        LOK_ASSERT_EQUAL(200U, httpResponse->statusLine().statusCode());
+        LOK_ASSERT_EQUAL(http::StatusCode::OK, httpResponse->statusLine().statusCode());
         LOK_ASSERT(httpResponse->statusLine().statusCategory()
                    == http::StatusLine::StatusCodeClass::Successful);
         LOK_ASSERT_EQUAL(std::string("HTTP/1.1"), httpResponse->statusLine().httpVersion());
@@ -389,7 +389,7 @@ void HttpRequestTests::testChunkedGetSync()
 
         LOK_ASSERT(!httpResponse->statusLine().httpVersion().empty());
         LOK_ASSERT(!httpResponse->statusLine().reasonPhrase().empty());
-        LOK_ASSERT_EQUAL(200U, httpResponse->statusLine().statusCode());
+        LOK_ASSERT_EQUAL(http::StatusCode::OK, httpResponse->statusLine().statusCode());
         LOK_ASSERT(httpResponse->statusLine().statusCategory()
                    == http::StatusLine::StatusCodeClass::Successful);
         LOK_ASSERT_EQUAL(std::string("HTTP/1.1"), httpResponse->statusLine().httpVersion());
@@ -425,7 +425,7 @@ void HttpRequestTests::testChunkedGetSync_External()
 
         LOK_ASSERT(!httpResponse->statusLine().httpVersion().empty());
         LOK_ASSERT(!httpResponse->statusLine().reasonPhrase().empty());
-        LOK_ASSERT_EQUAL(200U, httpResponse->statusLine().statusCode());
+        LOK_ASSERT_EQUAL(http::StatusCode::OK, httpResponse->statusLine().statusCode());
         LOK_ASSERT(httpResponse->statusLine().statusCategory()
                    == http::StatusLine::StatusCodeClass::Successful);
         LOK_ASSERT_EQUAL(std::string("HTTP/1.1"), httpResponse->statusLine().httpVersion());
@@ -457,7 +457,7 @@ static void compare(const Poco::Net::HTTPResponse& pocoResponse, const std::stri
         LOK_ASSERT_EQUAL_MESSAGE("Body empty?", pocoBody.empty(), httpResponse.getBody().empty());
 
     LOK_ASSERT_EQUAL_MESSAGE("Status Code", static_cast<unsigned>(pocoResponse.getStatus()),
-                             httpResponse.statusLine().statusCode());
+                             static_cast<unsigned>(httpResponse.statusLine().statusCode()));
     if (checkReasonPhrase)
         LOK_ASSERT_EQUAL_MESSAGE("Reason Phrase", Util::toLower(pocoResponse.getReason()),
                                  Util::toLower(httpResponse.statusLine().reasonPhrase()));
@@ -551,7 +551,8 @@ void HttpRequestTests::test500GetStatuses()
         LOK_ASSERT(httpResponse->statusLine().statusCategory()
                    == statusCodeClasses[curStatusCodeClass]);
 
-        LOK_ASSERT_EQUAL(statusCode, httpResponse->statusLine().statusCode());
+        LOK_ASSERT_EQUAL(statusCode,
+                         static_cast<unsigned>(httpResponse->statusLine().statusCode()));
 
         // Poco throws exception "No message received" for 1xx Status Codes.
         if (statusCode > 100)
@@ -619,7 +620,7 @@ void HttpRequestTests::testSimplePost_External()
     LOK_ASSERT(httpResponse->state() == http::Response::State::Complete);
     LOK_ASSERT(!httpResponse->statusLine().httpVersion().empty());
     LOK_ASSERT(!httpResponse->statusLine().reasonPhrase().empty());
-    LOK_ASSERT_EQUAL(200U, httpResponse->statusLine().statusCode());
+    LOK_ASSERT_EQUAL(http::StatusCode::OK, httpResponse->statusLine().statusCode());
     LOK_ASSERT(httpResponse->statusLine().statusCategory()
                == http::StatusLine::StatusCodeClass::Successful);
 

--- a/test/HttpWhiteBoxTests.cpp
+++ b/test/HttpWhiteBoxTests.cpp
@@ -52,10 +52,13 @@ void HttpWhiteBoxTests::testStatusLineParserValidComplete()
     const unsigned expVersionMinor = 1;
     const std::string expVersion
         = "HTTP/" + std::to_string(expVersionMajor) + '.' + std::to_string(expVersionMinor);
-    const unsigned expStatusCode = 101;
+    const http::StatusCode expStatusCode = http::StatusCode::SwitchingProtocols;
     const std::string expReasonPhrase = "Something Something";
-    const std::string data
-        = expVersion + ' ' + std::to_string(expStatusCode) + ' ' + expReasonPhrase + "\r\n";
+
+    std::ostringstream oss;
+    oss << expVersion << ' ' << static_cast<unsigned>(expStatusCode) << ' ' << expReasonPhrase
+        << "\r\n";
+    const std::string data = oss.str();
 
     http::StatusLine statusLine;
 
@@ -76,10 +79,13 @@ void HttpWhiteBoxTests::testStatusLineParserValidComplete_NoReason()
     const unsigned expVersionMinor = 1;
     const std::string expVersion
         = "HTTP/" + std::to_string(expVersionMajor) + '.' + std::to_string(expVersionMinor);
-    const unsigned expStatusCode = 101;
+    const http::StatusCode expStatusCode = http::StatusCode::SwitchingProtocols;
     const std::string expReasonPhrase;
-    const std::string data
-        = expVersion + ' ' + std::to_string(expStatusCode) + ' ' + expReasonPhrase + "\r\n";
+
+    std::ostringstream oss;
+    oss << expVersion << ' ' << static_cast<unsigned>(expStatusCode) << ' ' << expReasonPhrase
+        << "\r\n";
+    const std::string data = oss.str();
 
     http::StatusLine statusLine;
 
@@ -100,10 +106,13 @@ void HttpWhiteBoxTests::testStatusLineParserValidIncomplete()
     const unsigned expVersionMinor = 1;
     const std::string expVersion
         = "HTTP/" + std::to_string(expVersionMajor) + '.' + std::to_string(expVersionMinor);
-    const unsigned expStatusCode = 101;
+    const http::StatusCode expStatusCode = http::StatusCode::SwitchingProtocols;
     const std::string expReasonPhrase = "Something Something";
-    const std::string data
-        = expVersion + ' ' + std::to_string(expStatusCode) + "    " + expReasonPhrase + "\r\n";
+
+    std::ostringstream oss;
+    oss << expVersion << ' ' << static_cast<unsigned>(expStatusCode) << ' ' << expReasonPhrase
+        << "\r\n";
+    const std::string data = oss.str();
 
     http::StatusLine statusLine;
 

--- a/test/UnitCopyPaste.cpp
+++ b/test/UnitCopyPaste.cpp
@@ -9,6 +9,7 @@
 
 #include <config.h>
 
+#include "HttpRequest.hpp"
 #include "lokassert.hpp"
 
 #include <Unit.hpp>
@@ -59,8 +60,8 @@ public:
         return httpResponse->getBody();
     }
 
-    std::shared_ptr<ClipboardData> getClipboard(const std::string &clipURIstr,
-                                                HTTPResponse::HTTPStatus expected)
+    std::shared_ptr<ClipboardData> getClipboard(const std::string& clipURIstr,
+                                                http::StatusCode expected)
     {
         LOG_TST("getClipboard: connect to " << clipURIstr);
         Poco::URI clipURI(clipURIstr);
@@ -77,8 +78,7 @@ public:
 
             if (httpResponse->statusLine().statusCode() != expected)
             {
-                LOK_ASSERT_EQUAL_MESSAGE("clipboard status mismatches expected",
-                                         static_cast<unsigned int>(expected),
+                LOK_ASSERT_EQUAL_MESSAGE("clipboard status mismatches expected", expected,
                                          httpResponse->statusLine().statusCode());
                 exitTest(TestResult::Failed);
                 return std::shared_ptr<ClipboardData>();
@@ -133,10 +133,9 @@ public:
         return true;
     }
 
-    bool fetchClipboardAssert(const std::string &clipURI,
-                              const std::string &mimeType,
-                              const std::string &content,
-                              HTTPResponse::HTTPStatus expected = HTTPResponse::HTTP_OK)
+    bool fetchClipboardAssert(const std::string& clipURI, const std::string& mimeType,
+                              const std::string& content,
+                              http::StatusCode expected = http::StatusCode::OK)
     {
         try
         {

--- a/test/UnitHosting.cpp
+++ b/test/UnitHosting.cpp
@@ -50,7 +50,7 @@ UnitBase::TestResult UnitHosting::testDiscovery()
 
     LOK_ASSERT(!httpResponse->statusLine().httpVersion().empty());
     LOK_ASSERT(!httpResponse->statusLine().reasonPhrase().empty());
-    LOK_ASSERT_EQUAL(200U, httpResponse->statusLine().statusCode());
+    LOK_ASSERT_EQUAL(http::StatusCode::OK, httpResponse->statusLine().statusCode());
     LOK_ASSERT(httpResponse->statusLine().statusCategory()
                == http::StatusLine::StatusCodeClass::Successful);
     LOK_ASSERT_EQUAL(std::string("HTTP/1.1"), httpResponse->statusLine().httpVersion());
@@ -67,7 +67,7 @@ UnitBase::TestResult UnitHosting::testDiscovery()
 
     LOK_ASSERT(!httpResponse2->statusLine().httpVersion().empty());
     LOK_ASSERT(!httpResponse2->statusLine().reasonPhrase().empty());
-    LOK_ASSERT_EQUAL(200U, httpResponse2->statusLine().statusCode());
+    LOK_ASSERT_EQUAL(http::StatusCode::OK, httpResponse2->statusLine().statusCode());
     LOK_ASSERT(httpResponse2->statusLine().statusCategory()
                == http::StatusLine::StatusCodeClass::Successful);
     LOK_ASSERT_EQUAL(std::string("HTTP/1.1"), httpResponse2->statusLine().httpVersion());
@@ -92,7 +92,7 @@ UnitBase::TestResult UnitHosting::testCapabilities()
     // Get discovery first and extract the urlsrc of the capabilities end point
     std::string capabilitiesURI;
     {
-        LOK_ASSERT_EQUAL(200U, httpResponse->statusLine().statusCode());
+        LOK_ASSERT_EQUAL(http::StatusCode::OK, httpResponse->statusLine().statusCode());
         LOK_ASSERT_EQUAL(std::string("text/xml"), httpResponse->header().getContentType());
 
         const std::string discoveryXML = httpResponse->getBody();
@@ -126,7 +126,7 @@ UnitBase::TestResult UnitHosting::testCapabilities()
         LOK_ASSERT(httpResponse->done());
         LOK_ASSERT(httpResponse->state() == http::Response::State::Complete);
 
-        LOK_ASSERT_EQUAL(200U, httpResponse->statusLine().statusCode());
+        LOK_ASSERT_EQUAL(http::StatusCode::OK, httpResponse->statusLine().statusCode());
         LOK_ASSERT_EQUAL(std::string("application/json"), httpResponse->header().getContentType());
 
         const std::string responseString = httpResponse->getBody();

--- a/test/integration-http-server.cpp
+++ b/test/integration-http-server.cpp
@@ -126,8 +126,7 @@ void HTTPServerTest::testCoolGet()
     const std::shared_ptr<const http::Response> httpResponse
         = http::get(_uri.toString(), pathAndQuery);
 
-    LOK_ASSERT_EQUAL(static_cast<unsigned>(Poco::Net::HTTPResponse::HTTP_OK),
-                     httpResponse->statusLine().statusCode());
+    LOK_ASSERT_EQUAL(http::StatusCode::OK, httpResponse->statusLine().statusCode());
     LOK_ASSERT_EQUAL(std::string("text/html"), httpResponse->header().getContentType());
 
     //FIXME: Replace with own URI parser.

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -1137,9 +1137,9 @@ public:
                     const std::shared_ptr<const http::Response> httpResponse =
                         httpSession->syncRequest(request);
 
-                    unsigned int statusCode = httpResponse->statusLine().statusCode();
+                    const http::StatusCode statusCode = httpResponse->statusLine().statusCode();
 
-                    if (statusCode == Poco::Net::HTTPResponse::HTTP_OK)
+                    if (statusCode == http::StatusCode::OK)
                     {
                         _eTagValue = httpResponse->get("ETag");
 
@@ -1167,15 +1167,14 @@ public:
                             LOG_ERR("Could not parse the remote config JSON");
                         }
                     }
-                    else if (statusCode == Poco::Net::HTTPResponse::HTTP_NOT_MODIFIED)
+                    else if (statusCode == http::StatusCode::NotModified)
                     {
                         LOG_DBG("Not modified since last time: " << remoteServerURI.toString());
                         handleUnchangedJSON();
                     }
                     else
                     {
-                        LOG_ERR("Remote config server has response status code: " +
-                                std::to_string(statusCode));
+                        LOG_ERR("Remote config server has response status code: " << statusCode);
                     }
                 }
                 catch (...)
@@ -1807,9 +1806,7 @@ private:
         const std::shared_ptr<const http::Response> httpResponse
             = httpSession->syncRequest(request);
 
-        const unsigned int statusCode = httpResponse->statusLine().statusCode();
-
-        if (statusCode == Poco::Net::HTTPResponse::HTTP_NOT_MODIFIED)
+        if (httpResponse->statusLine().statusCode() == http::StatusCode::NotModified)
         {
             LOG_DBG("Not modified since last time: " << uri);
             return true;
@@ -1834,9 +1831,7 @@ private:
         const std::shared_ptr<const http::Response> httpResponse
             = httpSession->syncRequest(request);
 
-        const unsigned int statusCode = httpResponse->statusLine().statusCode();
-
-        if (statusCode == Poco::Net::HTTPResponse::HTTP_NOT_MODIFIED)
+        if (httpResponse->statusLine().statusCode() == http::StatusCode::NotModified)
         {
             LOG_DBG("Not modified since last time: " << uri);
             return true;
@@ -1851,9 +1846,7 @@ private:
 
     bool finishDownload(const std::string& uri, const std::shared_ptr<const http::Response> httpResponse)
     {
-        const unsigned int statusCode = httpResponse->statusLine().statusCode();
-
-        if (statusCode != Poco::Net::HTTPResponse::HTTP_OK)
+        if (httpResponse->statusLine().statusCode() != http::StatusCode::OK)
         {
             LOG_WRN("Could not fetch " << uri);
             return false;
@@ -5459,7 +5452,7 @@ void COOLWSD::processFetchUpdate()
 
         const std::shared_ptr<const http::Response> httpResponse =
             sessionFetch->syncRequest(request);
-        if (httpResponse->statusLine().statusCode() == Poco::Net::HTTPResponse::HTTP_OK)
+        if (httpResponse->statusLine().statusCode() == http::StatusCode::OK)
         {
             LOG_DBG("Infobar update returned: " << httpResponse->getBody());
 

--- a/wsd/ProxyRequestHandler.cpp
+++ b/wsd/ProxyRequestHandler.cpp
@@ -52,7 +52,7 @@ void ProxyRequestHandler::handleRequest(const std::string& relPath,
                 {
                     const auto callbackNow = std::chrono::system_clock::now();
                     std::shared_ptr<http::Response> httpResponse = httpSession->response();
-                    if (httpResponse->statusLine().statusCode() == 200)
+                    if (httpResponse->statusLine().statusCode() == http::StatusCode::OK)
                     {
                         if (MaxAge == zero)
                         {

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -653,10 +653,11 @@ WopiStorage::getWOPIFileInfoForUri(Poco::URI uriObject, const Authorization& aut
         callDurationMs = std::chrono::duration_cast<std::chrono::milliseconds>(
             std::chrono::steady_clock::now() - startTime);
 
-        if (httpResponse->statusLine().statusCode() == Poco::Net::HTTPResponse::HTTP_FOUND ||
-            httpResponse->statusLine().statusCode() == Poco::Net::HTTPResponse::HTTP_MOVED_PERMANENTLY ||
-            httpResponse->statusLine().statusCode() == Poco::Net::HTTPResponse::HTTP_TEMPORARY_REDIRECT ||
-            httpResponse->statusLine().statusCode() == Poco::Net::HTTPResponse::HTTP_PERMANENT_REDIRECT)
+        const http::StatusCode statusCode = httpResponse->statusLine().statusCode();
+        if (statusCode == http::StatusCode::MovedPermanently ||
+            statusCode == http::StatusCode::Found ||
+            statusCode == http::StatusCode::TemporaryRedirect ||
+            statusCode == http::StatusCode::PermanentRedirect)
         {
             if (redirectLimit)
             {
@@ -675,8 +676,7 @@ WopiStorage::getWOPIFileInfoForUri(Poco::URI uriObject, const Authorization& aut
 
         // Note: we don't log the response if obfuscation is enabled, except for failures.
         wopiResponse = httpResponse->getBody();
-        const bool failed
-            = (httpResponse->statusLine().statusCode() != Poco::Net::HTTPResponse::HTTP_OK);
+        const bool failed = (httpResponse->statusLine().statusCode() != http::StatusCode::OK);
 
         Log::StreamLogger logRes = failed ? Log::error() : Log::trace();
         if (logRes.enabled())
@@ -697,7 +697,7 @@ WopiStorage::getWOPIFileInfoForUri(Poco::URI uriObject, const Authorization& aut
 
         if (failed)
         {
-            if (httpResponse->statusLine().statusCode() == Poco::Net::HTTPResponse::HTTP_FORBIDDEN)
+            if (httpResponse->statusLine().statusCode() == http::StatusCode::Forbidden)
                 throw UnauthorizedRequestException(
                     "Access denied, 403. WOPI::CheckFileInfo failed on: " + uriAnonym);
 
@@ -1131,7 +1131,8 @@ std::string WopiStorage::downloadDocument(const Poco::URI& uriObject, const std:
     const std::chrono::milliseconds diff = std::chrono::duration_cast<std::chrono::milliseconds>(
         std::chrono::steady_clock::now() - startTime);
 
-    if (httpResponse->statusLine().statusCode() == Poco::Net::HTTPResponse::HTTP_OK)
+    const http::StatusCode statusCode = httpResponse->statusLine().statusCode();
+    if (statusCode == http::StatusCode::OK)
     {
         // Log the response header.
         Log::StreamLogger logger = Log::trace();
@@ -1146,10 +1147,10 @@ std::string WopiStorage::downloadDocument(const Poco::URI& uriObject, const std:
             LOG_END_FLUSH(logger);
         }
     }
-    else if (httpResponse->statusLine().statusCode() == Poco::Net::HTTPResponse::HTTP_FOUND ||
-            httpResponse->statusLine().statusCode() == Poco::Net::HTTPResponse::HTTP_MOVED_PERMANENTLY ||
-            httpResponse->statusLine().statusCode() == Poco::Net::HTTPResponse::HTTP_TEMPORARY_REDIRECT ||
-            httpResponse->statusLine().statusCode() == Poco::Net::HTTPResponse::HTTP_PERMANENT_REDIRECT)
+    else if (statusCode == http::StatusCode::MovedPermanently ||
+             statusCode == http::StatusCode::Found ||
+             statusCode == http::StatusCode::TemporaryRedirect ||
+             statusCode == http::StatusCode::PermanentRedirect)
     {
         if (redirectLimit)
         {
@@ -1470,7 +1471,7 @@ WopiStorage::handleUploadToStorageResponse(const WopiUploadDetails& details,
                             << details.httpResponseReason << ": " << responseString);
         }
 
-        if (details.httpResponseCode == Poco::Net::HTTPResponse::HTTP_OK)
+        if (details.httpResponseCode == http::StatusCode::OK)
         {
             result.setResult(StorageBase::UploadResult::Result::OK);
             Poco::JSON::Object::Ptr object;
@@ -1497,20 +1498,20 @@ WopiStorage::handleUploadToStorageResponse(const WopiUploadDetails& details,
                 LOG_ERR("Invalid or missing JSON in " << wopiLog << " HTTP_OK response.");
             }
         }
-        else if (details.httpResponseCode == Poco::Net::HTTPResponse::HTTP_REQUEST_ENTITY_TOO_LARGE)
+        else if (details.httpResponseCode == http::StatusCode::PayloadTooLarge)
         {
             result.setResult(StorageBase::UploadResult::Result::TOO_LARGE);
         }
-        else if (details.httpResponseCode == Poco::Net::HTTPResponse::HTTP_UNAUTHORIZED ||
-                 details.httpResponseCode == Poco::Net::HTTPResponse::HTTP_FORBIDDEN ||
-                 details.httpResponseCode == Poco::Net::HTTPResponse::HTTP_NOT_FOUND)
+        else if (details.httpResponseCode == http::StatusCode::Unauthorized ||
+                 details.httpResponseCode == http::StatusCode::Forbidden ||
+                 details.httpResponseCode == http::StatusCode::NotFound)
         {
             // The ms-wopi specs recognizes 401 and 404 for invalid token
             // and file unknown/user unauthorized, respectively.
             // We also handle 403 that some implementation use.
             result.setResult(StorageBase::UploadResult::Result::UNAUTHORIZED);
         }
-        else if (details.httpResponseCode == Poco::Net::HTTPResponse::HTTP_CONFLICT)
+        else if (details.httpResponseCode == http::StatusCode::Conflict)
         {
             result.setResult(StorageBase::UploadResult::Result::CONFLICT);
             Poco::JSON::Object::Ptr object;

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -692,7 +692,7 @@ protected:
         const std::string filePathAnonym;
         const std::string uriAnonym;
         const std::string httpResponseReason;
-        const long httpResponseCode;
+        const http::StatusCode httpResponseCode;
         const std::size_t size;
         const bool isSaveAs;
         const bool isRename;


### PR DESCRIPTION
We use our own status codes, which
are type-safe and use streaming
operators to serialize and log.