### PR TITLE
Fix white screen over document on dark mode

### DIFF
--- a/browser/css/color-palette-dark.css
+++ b/browser/css/color-palette-dark.css
@@ -1,5 +1,5 @@
 [data-theme='dark'] {
-	color-scheme: dark;
+	--color-scheme: dark;
 	/*LibreOffice Colors: https://wiki.documentfoundation.org/Marketing/Branding#Colors
 	----------------------------------[to do]*/
 	--blue1-txt-primary-color: 3, 105, 163;


### PR DESCRIPTION
Upon switching to dark mode the document would disappear and replaced with a white screen. The above change fixes that. My assumption is that for some reason it would silently crash and display nothing.


Change-Id: Ia59f1a4c10b4198243a017ba9cc1cbeff50619d0


