### PR TITLE
Remove scrollbar button in mobile view

### DIFF
--- a/browser/js/w2ui-1.5.rc1.js
+++ b/browser/js/w2ui-1.5.rc1.js
@@ -6197,6 +6197,10 @@ w2utils.event = {
                 }
             }
 
+            if (window.mode.isMobile()) {
+                $('#toolbar-wrapper.mobile .w2ui-scroll-right, #toolbar-wrapper.mobile .w2ui-scroll-left').hide();
+            }
+
             // event after
             this.trigger($.extend(edata, { phase: 'after' }));
             return (new Date()).getTime() - time;


### PR DESCRIPTION
Change-Id: Icec596bc4691b5bdd04ab2c687cc8c0c54608412

* Resolves: # 
* Target version: master 

### Summary

Issue: 

- Occasionally a button appears on top right, which does not belong to the default control elements. It looks like a rewind button in a player.On tap nothing will happen and the button disappears.

Fixed this issue which now not showing any scroll button when document loads in android app. I have tested.

@pedropintosilva  can you  please review the changes. 

