### PR TITLE
Revert "Dark Mode add color-scheme: dark setting"

### DIFF
--- a/browser/css/color-palette-dark.css
+++ b/browser/css/color-palette-dark.css
@@ -1,5 +1,4 @@
 [data-theme='dark'] {
-	color-scheme: dark;
 	/*LibreOffice Colors: https://wiki.documentfoundation.org/Marketing/Branding#Colors
 	----------------------------------[to do]*/
 	--blue1-txt-primary-color: 3, 105, 163;


### PR DESCRIPTION
Reverts CollaboraOnline/online#6258

See #6302, this change (#6258) breaks dark mode on firefox.

This is how it would look on firefox (white screen):

![image](https://user-images.githubusercontent.com/21157395/236836220-9c96b203-1366-44d6-b6e8-e3971ec35871.png)