### PR TITLE
jsdialog: dialog adjusted to size of biggest tab

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -184,6 +184,29 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 }
 
 /* Tabs */
+
+.ui-tabs-content.jsdialog {
+	display: grid;
+}
+
+.ui-tabs-content.jsdialog > .ui-content {
+	grid-row: 1;
+	grid-column: 1;
+	display: flex;
+	justify-items: stretch;
+	align-items: stretch;
+}
+
+.ui-tabs-content.jsdialog > .ui-content.hidden {
+	display: inherit !important;
+	visibility: hidden;
+}
+
+.ui-tabpage.jsdialog {
+	width: 100%;
+	height: 100%;
+}
+
 .ui-tab.jsdialog {
 	float: left !important;
 	font-size: var(--default-font-size) !important;

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -1062,12 +1062,12 @@ L.Control.JSDialogBuilder = L.Control.extend({
 				if (i !== t)
 				{
 					$(tabs[i]).removeClass('selected');
-					$(contentDivs[i]).hide();
+					$(contentDivs[i]).addClass('hidden');
 					tabs[i].setAttribute('aria-selected', 'false');
 					tabs[i].tabIndex = -1;
 				}
 			}
-			$(contentDivs[t]).show();
+			$(contentDivs[t]).removeClass('hidden');
 			builder.wizard.selectedTab(tabIds[t]);
 		};
 	},
@@ -1140,7 +1140,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 				contentDiv.setAttribute('role', 'tabpanel');
 
 				if (!isSelectedTab)
-					$(contentDiv).hide();
+					$(contentDiv).addClass('hidden');
 				contentDivs[tabIdx] = contentDiv;
 			}
 

--- a/browser/src/control/Control.NotebookbarBuilder.js
+++ b/browser/src/control/Control.NotebookbarBuilder.js
@@ -365,10 +365,10 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 					tabs[i].setAttribute('aria-selected', 'false');
 					tabs[i].tabIndex = -1;
 					$(tabs[i]).prop('title', '');
-					$(contentDivs[i]).hide();
+					$(contentDivs[i]).addClass('hidden');
 				}
 			}
-			$(contentDivs[t]).show();
+			$(contentDivs[t]).removeClass('hidden');
 			$(window).resize();
 			builder.wizard.selectedTab(tabIds[t]);
 


### PR DESCRIPTION
this uses css grid to position all the tabs stacked on each other at row 1 col 1. then when tab is hidden we use 'visibility: hidden' instead of 'display: none' so we hide content but leave white space needed for it. this way we don't change dialog's size on tab switch when tab has different size requirement, but we match dialog to the size of biggest content
