### PR TITLE
jsdialog: fix jumping Page Style dialog

### DIFF
--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -32,6 +32,7 @@ button:not(.ui-tab):not(.ui-corner-all):not(.button-primary):not(.unobutton) {
 	border-radius: var(--border-radius);
 	margin: 5px;
 	vertical-align: middle;
+	width: max-content;
 }
 
 .button-primary {
@@ -44,6 +45,7 @@ button:not(.ui-tab):not(.ui-corner-all):not(.button-primary):not(.unobutton) {
 	border-radius: var(--border-radius);
 	margin: 5px;
 	vertical-align: middle;
+	width: max-content;
 }
 
 .jsdialog.ui-button-box.end {

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -184,6 +184,29 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 }
 
 /* Tabs */
+
+.ui-tabs-content.jsdialog {
+	display: grid;
+}
+
+.ui-tabs-content.jsdialog > .ui-content {
+	grid-row: 1;
+	grid-column: 1;
+	display: flex;
+	justify-items: stretch;
+	align-items: stretch;
+}
+
+.ui-tabs-content.jsdialog > .ui-content.hidden {
+	display: inherit !important;
+	visibility: hidden;
+}
+
+.ui-tabpage.jsdialog {
+	width: 100%;
+	height: 100%;
+}
+
 .ui-tab.jsdialog {
 	float: left !important;
 	font-size: var(--default-font-size) !important;

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1206,7 +1206,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 }
 
 /* snackbar */
-#snackbar {
+.snackbar {
 	border: none !important;
 }
 .snackbar.jsdialog-window {
@@ -1260,13 +1260,13 @@ input[type='number']:hover::-webkit-outer-spin-button {
 }
 
 #mobile-wizard.popup.snackbar #button,
-#snackbar.jsdialog-container #button {
+.snackbar.jsdialog-container #button {
 	color: #469cff !important;
 	font-weight: 600;
 	font-size: var(--header-font-size) !important;
 	padding: 8px;
 }
-#snackbar.jsdialog-container #button:hover {
+.snackbar.jsdialog-container #button:hover {
 	background-color: #ffffff15 !important;
 }
 

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -23,13 +23,22 @@
 	background: #1c5fa814;
 }
 
-.lokdialog_container.ui-dialog.ui-widget-content.modalpopup {
+.lokdialog_container.ui-dialog.ui-widget-content.modalpopup,
+.jsdialog-window.modalpopup {
 	z-index: 2001;
+}
+
+.jsdialog-window {
+	position: absolute;
+	z-index: 1105;
 }
 
 .jsdialog-container {
 	position: absolute;
-	z-index: 1105;
+}
+
+.jsdialog-window:not(.modalpopup) .jsdialog-container:not(.snackbar) {
+	min-width: 400px;
 }
 
 .jsdialog.one-child-popup {
@@ -37,7 +46,7 @@
 	margin: 0 !important;
 }
 
-.jsdialog-container.modalpopup {
+.jsdialog-window.modalpopup {
 	min-width: 198px;
 	max-width: 498px;
 	border: 1px solid #a4a4a4 !important;
@@ -49,6 +58,10 @@
 	max-height: calc(100% - 30px);
 }
 
+.jsdialog-window.modalpopup .jsdialog-container {
+	position: relative;
+}
+
 .jsdialog-container .ui-dialog-titlebar {
 	background-color: var(--color-background-lighter);
 }
@@ -57,6 +70,10 @@
 	background-color: var(--color-background-lighter) !important;
 	font-family: var(--jquery-ui-font);
 	line-height: 1.5;
+}
+
+.jsdialog-container .lokdialog.ui-dialog-content.ui-widget-content {
+	overflow: hidden;
 }
 
 .jsdialog.vertical label, .ui-frame-label {
@@ -153,10 +170,6 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 }
 
 /* keep structure with hidden elements correct */
-.ui-grid {
-	/* don't show scroll for hidden objects */
-	overflow: hidden;
-}
 
 .ui-grid > .hidden {
 	visibility: hidden;
@@ -222,10 +235,7 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 	border-radius: var(--border-radius) !important;
 	background-color: var(--color-main-background) !important;
 	margin-inline-end: 12px !important;
-}
-
-.ui-tab.jsdialog:first-child {
-	margin-inline-start: 12px !important;
+	margin-bottom: 6px;
 }
 
 .ui-tab.hidden.jsdialog {
@@ -1199,12 +1209,17 @@ input[type='number']:hover::-webkit-outer-spin-button {
 #snackbar {
 	border: none !important;
 }
+.snackbar.jsdialog-window {
+	overflow: visible;
+}
 #mobile-wizard.popup.snackbar,
 .snackbar.jsdialog-container .ui-dialog-content {
 	min-width: 200px;
 	background-color: #323232 !important;
 }
-
+.snackbar.jsdialog-container .ui-dialog-content {
+	width: max-content !important;
+}
 #mobile-wizard.popup.snackbar #label,
 .snackbar.jsdialog-container #label,
 #mobile-wizard.popup.snackbar #label-no-action,

--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -162,9 +162,11 @@ L.Control.JSDialog = L.Control.extend({
 
 	createContainer: function(instance, parentContainer) {
 		// it has to be form to handle default button
-		instance.container = L.DomUtil.create('form', 'jsdialog-container ui-dialog ui-widget-content lokdialog_container', parentContainer);
+		instance.container = L.DomUtil.create('div', 'jsdialog-container ui-dialog ui-widget-content lokdialog_container', parentContainer);
 		instance.container.setAttribute('role', 'dialog');
 		instance.container.id = instance.id;
+
+		instance.form = L.DomUtil.create('form', '', instance.container);
 
 		// Prevent overlay from getting the click.
 		instance.container.onclick = function(e) { e.stopPropagation(); };
@@ -173,7 +175,7 @@ L.Control.JSDialog = L.Control.extend({
 			L.DomUtil.addClass(instance.container, 'collapsed');
 
 		// prevent from reloading
-		instance.container.addEventListener('submit', function (event) { event.preventDefault(); });
+		instance.form.addEventListener('submit', function (event) { event.preventDefault(); });
 
 		instance.defaultButtonId = this._getDefaultButtonId(instance.children);
 
@@ -193,7 +195,7 @@ L.Control.JSDialog = L.Control.extend({
 		};
 
 		if (instance.haveTitlebar) {
-			instance.titlebar = L.DomUtil.create('div', 'ui-dialog-titlebar ui-corner-all ui-widget-header ui-helper-clearfix', instance.container);
+			instance.titlebar = L.DomUtil.create('div', 'ui-dialog-titlebar ui-corner-all ui-widget-header ui-helper-clearfix', instance.form);
 			var title = L.DomUtil.create('span', 'ui-dialog-title', instance.titlebar);
 			title.innerText = instance.title;
 			instance.titleCloseButton = L.DomUtil.create('button', 'ui-button ui-corner-all ui-widget ui-button-icon-only ui-dialog-titlebar-close', instance.titlebar);
@@ -210,7 +212,7 @@ L.Control.JSDialog = L.Control.extend({
 		if (instance.isSnackbar)
 			L.DomUtil.addClass(instance.container, 'snackbar');
 
-		instance.content = L.DomUtil.create('div', 'lokdialog ui-dialog-content ui-widget-content', instance.container);
+		instance.content = L.DomUtil.create('div', 'lokdialog ui-dialog-content ui-widget-content', instance.form);
 
 		this.dialogs[instance.id] = {};
 	},

--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -162,11 +162,11 @@ L.Control.JSDialog = L.Control.extend({
 
 	createContainer: function(instance, parentContainer) {
 		// it has to be form to handle default button
-		instance.container = L.DomUtil.create('div', 'jsdialog-container ui-dialog ui-widget-content lokdialog_container', parentContainer);
+		instance.container = L.DomUtil.create('div', 'jsdialog-window', parentContainer);
 		instance.container.setAttribute('role', 'dialog');
 		instance.container.id = instance.id;
 
-		instance.form = L.DomUtil.create('form', '', instance.container);
+		instance.form = L.DomUtil.create('form', 'jsdialog-container ui-dialog ui-widget-content lokdialog_container', instance.container);
 
 		// Prevent overlay from getting the click.
 		instance.container.onclick = function(e) { e.stopPropagation(); };
@@ -209,8 +209,10 @@ L.Control.JSDialog = L.Control.extend({
 		if (instance.isModalPopUp && !instance.popupParent) // Special case for menu popups (they are also modal dialogues).
 			instance.overlay.classList.add('dimmed');
 
-		if (instance.isSnackbar)
+		if (instance.isSnackbar) {
 			L.DomUtil.addClass(instance.container, 'snackbar');
+			L.DomUtil.addClass(instance.form, 'snackbar');
+		}
 
 		instance.content = L.DomUtil.create('div', 'lokdialog ui-dialog-content ui-widget-content', instance.form);
 
@@ -377,7 +379,7 @@ L.Control.JSDialog = L.Control.extend({
 					instance.posy -= instance.posy + instance.content.clientHeight + 10 - window.innerHeight;
 			}
 			else {
-				var height = instance.container.getBoundingClientRect().height;
+				var height = instance.form.getBoundingClientRect().height;
 				if (instance.posy + height > instance.containerParent.getBoundingClientRect().height) {
 					calculated = true;
 					var newTopPosition = instance.posy - height;
@@ -386,7 +388,7 @@ L.Control.JSDialog = L.Control.extend({
 					instance.posy = newTopPosition;
 				}
 
-				var width = instance.container.getBoundingClientRect().width;
+				var width = instance.form.getBoundingClientRect().width;
 				if (instance.posx + width > instance.containerParent.getBoundingClientRect().width) {
 					calculated = true;
 					var newLeftPosition = instance.posx - width;
@@ -397,8 +399,8 @@ L.Control.JSDialog = L.Control.extend({
 			}
 		} else if (instance.isSnackbar) {
 			calculated = true;
-			instance.posx = window.innerWidth/2 - instance.container.offsetWidth/2;
-			instance.posy = window.innerHeight - instance.container.offsetHeight - 40;
+			instance.posx = window.innerWidth/2 - instance.form.offsetWidth/2;
+			instance.posy = window.innerHeight - instance.form.offsetHeight - 40;
 		}
 
 		var positionNotSet = !instance.container.style || !instance.container.style.marginLeft;
@@ -530,8 +532,8 @@ L.Control.JSDialog = L.Control.extend({
 
 			// Special case for nonModal dialogues. Core side doesn't send their initial coordinates. We need to center them.
 			if (instance.nonModal) {
-				var height = instance.container.getBoundingClientRect().height;
-				var width = instance.container.getBoundingClientRect().width;
+				var height = instance.form.getBoundingClientRect().height;
+				var width = instance.form.getBoundingClientRect().width;
 				instance.startX = instance.posx = (window.innerWidth - width) / 2;
 				instance.startY = instance.posy = (window.innerHeight - height) / 2;
 			}

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -1063,12 +1063,12 @@ L.Control.JSDialogBuilder = L.Control.extend({
 				if (i !== t)
 				{
 					$(tabs[i]).removeClass('selected');
-					$(contentDivs[i]).hide();
+					$(contentDivs[i]).addClass('hidden');
 					tabs[i].setAttribute('aria-selected', 'false');
 					tabs[i].tabIndex = -1;
 				}
 			}
-			$(contentDivs[t]).show();
+			$(contentDivs[t]).removeClass('hidden');
 			builder.wizard.selectedTab(tabIds[t]);
 		};
 	},
@@ -1141,7 +1141,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 				contentDiv.setAttribute('role', 'tabpanel');
 
 				if (!isSelectedTab)
-					$(contentDiv).hide();
+					$(contentDiv).addClass('hidden');
 				contentDivs[tabIdx] = contentDiv;
 			}
 

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -841,6 +841,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			var container = L.DomUtil.create('div', 'ui-expander-container ' + builder.options.cssClass, parentContainer);
 			container.id = data.id;
 
+			var expanded = data.expanded === true || (data.children[0] && data.children[0].checked === true);
 			if (data.children[0].text && data.children[0].text !== '') {
 				var expander = L.DomUtil.create('div', 'ui-expander ' + builder.options.cssClass, container);
 				expander.tabIndex = '0';
@@ -851,7 +852,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 					L.DomUtil.addClass(label, 'hidden');
 				builder.postProcess(expander, data.children[0]);
 
-				if (data.children.length > 1 && data.expanded === true)
+				if (data.children.length > 1 && expanded)
 					$(label).addClass('expanded');
 
 				var toggleFunction = function () {
@@ -874,7 +875,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 
 			var expanderChildren = L.DomUtil.create('div', 'ui-expander-content ' + builder.options.cssClass, container);
 
-			if (data.expanded === true)
+			if (expanded)
 				$(expanderChildren).addClass('expanded');
 
 			var children = [];

--- a/browser/src/control/Control.NotebookbarBuilder.js
+++ b/browser/src/control/Control.NotebookbarBuilder.js
@@ -365,10 +365,10 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 					tabs[i].setAttribute('aria-selected', 'false');
 					tabs[i].tabIndex = -1;
 					$(tabs[i]).prop('title', '');
-					$(contentDivs[i]).hide();
+					$(contentDivs[i]).addClass('hidden');
 				}
 			}
-			$(contentDivs[t]).show();
+			$(contentDivs[t]).removeClass('hidden');
 			$(window).resize();
 			builder.wizard.selectedTab(tabIds[t]);
 

--- a/browser/src/control/jsdialog/Widget.MobileTabControl.js
+++ b/browser/src/control/jsdialog/Widget.MobileTabControl.js
@@ -65,7 +65,7 @@ function _panelTabsHandler(parentContainer, data, builder, tabTooltip, isTabCont
 		}
 		builder._currentDepth--;
 
-		$(contentDiv).hide();
+		$(contentDiv).addClass('hidden');
 		contentDivs[tabIdx] = contentDiv;
 	}
 

--- a/cypress_test/integration_tests/desktop/impress/sidebar_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/sidebar_spec.js
@@ -32,7 +32,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Sidebar Tests', function()
 		cy.cGet('#fillattr3').should('be.visible');
 		helper.waitUntilIdle('#fillattr2');
 		cy.cGet('#fillattr2').click();
-		cy.cGet('.modalpopup').should('be.visible');
+		cy.cGet('.modalpopup .jsdialog-container').should('be.visible');
 		cy.cGet('#colorset').should('be.visible');
 	});
 
@@ -42,7 +42,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Sidebar Tests', function()
 		impressHelper.selectTextOfShape();
 		cy.cGet('#layoutvalueset').should('not.be.visible');
 		cy.cGet('#Underline .arrowbackground').click();
-		cy.cGet('.modalpopup').should('be.visible');
+		cy.cGet('.modalpopup .jsdialog-container').should('be.visible');
 		cy.cGet('#single').click();
 		impressHelper.triggerNewSVGForShapeInTheCenter();
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph')


### PR DESCRIPTION
Fixes position and dragging in Writer -> Format -> Page Style dialog

It was caused by `<button>` with id = style inside dialog's `<form>`. In that case style property was a reference to the dialog, not CSS properties map. It cannot be changed... so Introduced new parent container which is div for setting position.

This PR also makes dialogs more compact, using minimal width thanks to using 'position: absolute' inside parent container. What helps to not cover whole screen with dialog.