### PR TITLE
Add date time fields under the insert menu

### DIFF
--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -1146,6 +1146,32 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				'text': _('Smart Picker'),
 				'command': 'remotelink'
 			} : {},
+            {
+                'type': 'container',
+                'children': [
+                    {
+                        'type': 'toolbox',
+                        'children': [
+                            {
+                                'type': 'toolitem',
+                                'text': _UNO('.uno:InsertCurrentDate', 'spreadsheet'),
+                                'command': '.uno:InsertCurrentDate'
+                            }
+                        ]
+                    },
+                    {
+                        'type': 'toolbox',
+                        'children': [
+                            {
+                                'type': 'toolitem',
+                                'text': _UNO('.uno:InsertCurrentTime', 'spreadsheet'),
+                                'command': '.uno:InsertCurrentTime'
+                            }
+                        ]
+                    }
+                ],
+                'vertical': 'true'
+            },
 			{
 				'id': 'Insert-Section-NameRangesTable-Ext',
 				'type': 'container',


### PR DESCRIPTION
In Calc compact view we have insert current date and time actions but in tabbed view we don't have them. For equality we need to add in tabbed view too.


Change-Id: I5498f47a8dc96a5403cdf17be52ef3a7ad66862c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

