### PR TITLE
ColorScheme Adjustments of UI elements

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -237,7 +237,7 @@ body {
 
 #sidebar-dock-wrapper {
 	display: none;
-	background: var(--color-main-background);
+	background: var(--color-background-lighter);
 	position: relative;
 	border-inline-start: 1px solid var(--color-border);
 	overflow: hidden;


### PR DESCRIPTION
Sidebar use toolbar color

| before | after |
| ---------- | ------- |
| ![image](https://github.com/CollaboraOnline/online/assets/8517736/dc040d05-fbc7-4849-aad9-747cbd60c59c) | ![image](https://github.com/CollaboraOnline/online/assets/8517736/ac7b3ab6-9702-418e-b149-f83846ff3585) |
| dark | mode |
| ![image](https://github.com/CollaboraOnline/online/assets/8517736/d574088e-895f-4e02-b580-fef172929ce9) | ![image](https://github.com/CollaboraOnline/online/assets/8517736/19095a3c-e866-4556-acdf-a6d0ef665af0) |
| light | mode |

No big difference at light mode but in dark mode you see that the sidebar background is to dark. Better sync the color of the sidebar and the toolbar to have them similar.

Change-Id: I3dc401e30e0b43664847f25d21ab0b6f027df372