### PR TITLE
Improve Dialow Window border and box-shadow

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -83,9 +83,9 @@
 }
 
 .lokdialog_container.ui-dialog.ui-widget-content, .autofilter-container {
-	border: 1px solid var(--color-border-dark);
-	-webkit-box-shadow: 0 0 3px var(--color-border);
-	box-shadow: 0 0 3px var(--color-box-shadow);
+	border: 1px solid var(--color-border-darker);
+	-webkit-box-shadow: 0 0 3px var(--color-border-darker);
+	box-shadow: 0 0 3px var(--color-border-darker);
 	border-radius: var(--border-radius);
 	background: var(--color-background-darker);
 }


### PR DESCRIPTION
There is no visual difference at light mode, but in dark mode you can see the difference and improvement.

| before | after |
| --------- | ------- |
| ![Screenshot_20230512_005053](https://github.com/CollaboraOnline/online/assets/8517736/ed44df7f-4fd3-4c85-860c-239d044e7cbe) | ![Screenshot_20230512_005019](https://github.com/CollaboraOnline/online/assets/8517736/ea98ab95-ea49-42fd-98cf-db0ed79fd160) |
| ![Screenshot_20230512_004954](https://github.com/CollaboraOnline/online/assets/8517736/9730cd64-1fc6-4c52-80fc-77669285d1d5) | ![Screenshot_20230512_005106](https://github.com/CollaboraOnline/online/assets/8517736/cad5d3d9-5e43-4ba3-a7a8-62336b060057) |

Change-Id: Ib9c9d83424791d2e3961fb49c276c7a2c014f208
