### PR TITLE
Add possibility to define help root URL from brand package

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -61,6 +61,9 @@
 /* Whether the std::filesystem is in the experimental header. */
 #undef HAVE_STD_FILESYSTEM_EXPERIMENTAL
 
+/* Default value of help root URL */
+#undef HELP_URL
+
 /* Default value of feature_lock.impress_unlock_highlights */
 #undef IMPRESS_UNLOCK_HIGHLIGHTS
 

--- a/configure.ac
+++ b/configure.ac
@@ -1481,6 +1481,7 @@ else
     AC_MSG_RESULT([default: $HELP_URL])
 fi
 AC_SUBST(HELP_URL)
+AC_DEFINE_UNQUOTED([HELP_URL],["$HELP_URL"],[Default value of help root URL])
 
 AC_MSG_CHECKING([for allowed languages for Writing Aids])
 if test -n "$with_dictionaries" -a "$with_dictionaries" != "no"; then

--- a/coolkitconfig-mobile.xcu
+++ b/coolkitconfig-mobile.xcu
@@ -10,10 +10,6 @@
 <!-- Disable two capitals at start autocorrect -->
 <item oor:path="/org.openoffice.Office.Common/AutoCorrect"><prop oor:name="TwoCapitalsAtStart" oor:op="fuse"><value>false</value></prop></item>
 
-<!-- The Help root URL, or empty for no help (hides the help buttons) -->
-<!-- On mobile UI there should be no tunnelled dialogs. But if there are some, by mistake, at least they should not have a non-working Help button -->
-<item oor:path="/org.openoffice.Office.Common/Help"><prop oor:name="HelpRootURL" oor:op="fuse"><value></value></prop></item>
-
 <!-- Enable spell-checking by default -->
 <item oor:path="/org.openoffice.Office.Linguistic/SpellChecking"><prop oor:name="IsSpellAuto" oor:op="fuse"><value>true</value></prop></item>
 

--- a/coolkitconfig.xcu.in
+++ b/coolkitconfig.xcu.in
@@ -10,9 +10,6 @@
 <!-- Disable two capitals at start autocorrect -->
 <item oor:path="/org.openoffice.Office.Common/AutoCorrect"><prop oor:name="TwoCapitalsAtStart" oor:op="fuse"><value>false</value></prop></item>
 
-<!-- The Help root URL, or empty for no help (hides the help buttons) -->
-<item oor:path="/org.openoffice.Office.Common/Help"><prop oor:name="HelpRootURL" oor:op="fuse"><value>@HELP_URL@</value></prop></item>
-
 <!-- Enable spell-checking by default -->
 <item oor:path="/org.openoffice.Office.Linguistic/SpellChecking"><prop oor:name="IsSpellAuto" oor:op="fuse"><value>true</value></prop></item>
 

--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -289,4 +289,6 @@
         <enable desc="Enable Zotero plugin." type="bool" default="true">true</enable>
     </zotero>
 
+    <help_url desc="The Help root URL, or empty for no help (hides the Help buttons)" type="string" default="@HELP_URL@">@HELP_URL@</help_url>
+
 </config>

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -2081,7 +2081,8 @@ void COOLWSD::innerInitialize(Application& self)
         { "deepl.auth_key", "" },
         { "deepl.enabled", "false" },
         { "zotero.enable", "true" },
-        { "indirection_endpoint.url", "" }
+        { "indirection_endpoint.url", "" },
+        { "help_url", HELP_URL }
     };
 
     // Set default values, in case they are missing from the config file.
@@ -2546,6 +2547,15 @@ void COOLWSD::innerInitialize(Application& self)
     const std::string authKey = getConfigValue<std::string>(conf, "deepl.auth_key", "");
     setenv("DEEPL_API_URL", apiURL.c_str(), 1);
     setenv("DEEPL_AUTH_KEY", authKey.c_str(), 1);
+
+#if !MOBILEAPP
+    const std::string helpUrl = getConfigValue<std::string>(conf, "help_url", HELP_URL);
+    setenv("LOK_HELP_URL", helpUrl.c_str(), 1);
+#else
+    // On mobile UI there should be no tunnelled dialogs. But if there are some, by mistake,
+    // at least they should not have a non-working Help button.
+    setenv("LOK_HELP_URL", "", 1);
+#endif
 
 #if ENABLE_SUPPORT_KEY
     const std::string supportKeyString = getConfigValue<std::string>(conf, "support_key", "");


### PR DESCRIPTION
Previously the help root URL was defined in coolkitconfig.xcu, but it was inconvenient to change. Now we have this setting in coolwsd.xml, therefore it can be changed more easily. For example a brand package can disable the Help buttons on dialogs by executing the following command in postinstall script:
  coolconfig set help_url ""


Change-Id: I6d0bdd71ca908df3d2dd20bd321aff9e93896f52

