### PR TITLE
Quarantine Improvements

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -83,7 +83,12 @@ if !ENABLE_DEBUG
 AM_CPPFLAGS += -DNDEBUG
 endif
 
-AM_LDFLAGS = -pthread -Wl,-E -lpam $(ZLIB_LIBS) $(ZSTD_LIBS) ${PNG_LIBS}
+AM_LDFLAGS = -Wl,-E -lpam $(ZLIB_LIBS) $(ZSTD_LIBS) ${PNG_LIBS}
+
+# Clang's linker doesn't like -pthread.
+if !HAVE_CLANG
+AM_LDFLAGS += -pthread
+endif
 
 if ENABLE_SSL
 AM_LDFLAGS += ${OPENSSL_LIBS}

--- a/common/FileUtil.hpp
+++ b/common/FileUtil.hpp
@@ -95,6 +95,22 @@ namespace FileUtil
         copy(fromPath, toPath, /*log=*/true, /*throw_on_error=*/true);
     }
 
+    /// Try to hard-link, and fallback to copying it linking fails.
+    /// Returns true iff either linking or copying succeeds.
+    inline bool linkOrCopyFile(const std::string& source, const std::string& newPath)
+    {
+        // first try a simple hard-link
+        if (link(source.c_str(), newPath.c_str()) == 0)
+            return true;
+
+        const auto onrre = errno;
+        LOG_DBG("Failed to link [" << source << "] to [" << newPath << "] ("
+                                   << Util::symbolicErrno(onrre) << ": " << std::strerror(onrre)
+                                   << "), will try to copy");
+
+        return FileUtil::copy(source, newPath, /*log=*/true, /*throw_on_error=*/false);
+    }
+
     /// Returns the system temporary directory.
     std::string getSysTempDirectoryPath();
 

--- a/common/FileUtil.hpp
+++ b/common/FileUtil.hpp
@@ -218,6 +218,18 @@ namespace FileUtil
         bool exists() const { return good() || (_errno != ENOENT && _errno != ENOTDIR); }
 
         /// Returns true if both files exist and have
+        /// the same size and same contents.
+        bool isIdenticalTo(const Stat& other) const
+        {
+            // No need to check whether they are linked or not,
+            // since if they are, the following check will match,
+            // and if they aren't, we still need to rely on the following.
+            // Finally, compare the contents, to avoid costly copying if we fail to update.
+            return (exists() && other.exists() && !isDirectory() && !other.isDirectory() &&
+                    size() == other.size() && compareFileContents(_path, other._path));
+        }
+
+        /// Returns true if both files exist and have
         /// the same size and modified timestamp.
         bool isUpToDate(const Stat& other) const
         {
@@ -225,8 +237,7 @@ namespace FileUtil
             // since if they are, the following check will match,
             // and if they aren't, we still need to rely on the following.
             // Finally, compare the contents, to avoid costly copying if we fail to update.
-            if (exists() && other.exists() && !isDirectory() && !other.isDirectory()
-                && size() == other.size() && compareFileContents(_path, other._path))
+            if (isIdenticalTo(other))
             {
                 return true;
             }

--- a/common/JailUtil.cpp
+++ b/common/JailUtil.cpp
@@ -145,6 +145,7 @@ static bool safeRemoveDir(const std::string& path)
 
     // Recursively remove if link/copied.
     const bool recursive = copied;
+    //FIXME: do not delete the 'copied' marker until the very end.
     FileUtil::removeFile(path, recursive);
     return true;
 }

--- a/common/Util.cpp
+++ b/common/Util.cpp
@@ -528,7 +528,7 @@ namespace Util
             std::string::size_type pos = 0;
             while ((pos = result.find(a, pos)) != std::string::npos)
             {
-                result = result.replace(pos, aSize, b);
+                result.replace(pos, aSize, b);
                 pos += bSize; // Skip the replacee to avoid endless recursion.
             }
         }

--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -263,6 +263,7 @@ namespace Util
     void setProcessAndThreadPriorities(const pid_t pid, int prio);
 #endif
 
+    /// Replace substring @a in string @s with string @b.
     std::string replace(std::string s, const std::string& a, const std::string& b);
 
     std::string formatLinesForLog(const std::string& s);

--- a/configure.ac
+++ b/configure.ac
@@ -1023,6 +1023,20 @@ else
     AC_MSG_ERROR(Compiler doesn't support C++17)
 fi
 
+# Check if we have clang, rather than gcc, which
+# doesn't like -pthread on the linker command-line.
+AC_MSG_CHECKING([whether the compiler is clang])
+AC_COMPILE_IFELSE([AC_LANG_SOURCE([
+    #if !defined(__clang__)
+    #error not clang
+    #endif
+])],
+                    [AC_MSG_RESULT([yes])
+                    AC_DEFINE([HAVE_CLANG],1,[whether the C++ compiler is clang])],
+                    [AC_MSG_RESULT([no])
+                    AC_DEFINE([HAVE_CLANG],0,[whether the C++ compiler is clang])])
+AM_CONDITIONAL([HAVE_CLANG], [test "$HAVE_CLANG" = "1"])
+
 AS_IF([test "$ENABLE_GTKAPP" != true],
 [CXXFLAGS="$CXXFLAGS $CXXFLAGS_CXXSTD"])
 

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -352,7 +352,7 @@ namespace
             if (errno == ENOENT)
             {
                 File(Path(linkableCopy).parent()).createDirectories();
-                if (!FileUtil::copy(fpath, linkableCopy.c_str(), /*log=*/false, /*throw_on_error=*/false))
+                if (!FileUtil::copy(fpath, linkableCopy, /*log=*/false, /*throw_on_error=*/false))
                     LOG_TRC("Failed to create linkable copy [" << fpath << "] to [" << linkableCopy.c_str() << "]");
                 else {
                     // Match system permissions, so a file we can write is not shared across jails.
@@ -487,9 +487,7 @@ namespace
         return FTW_CONTINUE;
     }
 
-    void linkOrCopy(std::string source,
-                    const Poco::Path& destination,
-                    std::string linkable,
+    void linkOrCopy(std::string source, const Poco::Path& destination, const std::string& linkable,
                     LinkOrCopyType type)
     {
         std::string resolved = FileUtil::realpath(source);

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -61,6 +61,7 @@ all_la_unit_tests = \
 	unit-rendering-options.la \
 	unit-paste.la \
 	unit-large-paste.la \
+	unit-quarantine.la \
 	unit-typing.la \
 	unit-wopi-httpredirectloop.la \
 	unit-render-shape.la \
@@ -286,6 +287,8 @@ unit_bad_doc_load_la_SOURCES = UnitBadDocLoad.cpp
 unit_bad_doc_load_la_LIBADD = $(CPPUNIT_LIBS)
 unit_hosting_la_SOURCES = UnitHosting.cpp
 unit_hosting_la_LIBADD = $(CPPUNIT_LIBS)
+unit_quarantine_la_SOURCES = UnitQuarantine.cpp
+unit_quarantine_la_LIBADD = $(CPPUNIT_LIBS)
 
 if HAVE_LO_PATH
 SYSTEM_STAMP = @SYSTEMPLATE_PATH@/system_stamp

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -93,7 +93,12 @@ endif
 noinst_LTLIBRARIES = ${all_la_unit_tests}
 
 MAGIC_TO_FORCE_SHLIB_CREATION = -rpath /dummy
-AM_LDFLAGS = -pthread -module $(MAGIC_TO_FORCE_SHLIB_CREATION) $(ZLIB_LIBS) $(ZSTD_LIBS) ${PNG_LIBS}
+AM_LDFLAGS = -module $(MAGIC_TO_FORCE_SHLIB_CREATION) $(ZLIB_LIBS) $(ZSTD_LIBS) ${PNG_LIBS}
+
+# Clang's linker doesn't like -pthread.
+if !HAVE_CLANG
+AM_LDFLAGS += -pthread
+endif
 
 if ENABLE_SSL
 AM_LDFLAGS += ${OPENSSL_LIBS}

--- a/test/UnitQuarantine.cpp
+++ b/test/UnitQuarantine.cpp
@@ -1,0 +1,178 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include "config.h"
+
+#include "WopiTestServer.hpp"
+#include "WOPIUploadConflictCommon.hpp"
+#include "Log.hpp"
+#include "Unit.hpp"
+#include "UnitHTTP.hpp"
+#include "helpers.hpp"
+
+#include <Poco/Net/HTTPRequest.h>
+
+/// This test simulates a permanently-failing upload.
+class UnitQuarantineConflict : public WOPIUploadConflictCommon
+{
+    using Base = WOPIUploadConflictCommon;
+
+    using Base::Phase;
+    using Base::Scenario;
+
+    using Base::OriginalDocContent;
+
+    bool _unloadingModifiedDocDetected;
+
+    static constexpr std::size_t LimitStoreFailures = 2;
+    static constexpr bool SaveOnExit = true;
+
+public:
+    UnitQuarantineConflict()
+        : Base("UnitQuarantineConflict", OriginalDocContent)
+        , _unloadingModifiedDocDetected(true)
+    {
+    }
+
+    void configure(Poco::Util::LayeredConfiguration& config) override
+    {
+        Base::configure(config);
+
+        // Small value to shorten the test run time.
+        config.setUInt("per_document.limit_store_failures", LimitStoreFailures);
+        config.setBool("per_document.always_save_on_exit", SaveOnExit);
+    }
+
+    void onDocBrokerCreate(const std::string& docKey) override
+    {
+        Base::onDocBrokerCreate(docKey);
+
+        if (_scenario == Scenario::VerifyOverwrite)
+        {
+            // By default, we don't upload when verifying (unless always_save_on_exit is set).
+            setExpectedPutFile(SaveOnExit);
+        }
+        else
+        {
+            // With always_save_on_exit=true and limit_store_failures=LimitStoreFailures,
+            // we expect exactly two PutFile requests per document.
+            setExpectedPutFile(LimitStoreFailures);
+        }
+    }
+
+    void assertGetFileRequest(const Poco::Net::HTTPRequest& /*request*/) override
+    {
+        LOG_TST("Testing " << toString(_scenario));
+        LOK_ASSERT_STATE(_phase, Phase::WaitLoadStatus);
+
+        assertGetFileCount();
+
+        //FIXME: check that unloading modified documents trigger test failure.
+        // LOK_ASSERT_EQUAL_MESSAGE("Expected modified document detection to have triggered", true,
+        //                          _unloadingModifiedDocDetected);
+        _unloadingModifiedDocDetected = false; // Reset.
+    }
+
+    std::unique_ptr<http::Response>
+    assertPutFileRequest(const Poco::Net::HTTPRequest& request) override
+    {
+        LOG_TST("Testing " << toString(_scenario));
+        LOK_ASSERT_STATE(_phase, Phase::WaitDocClose);
+
+        assertPutFileCount();
+
+        const std::string wopiTimestamp = request.get("X-COOL-WOPI-Timestamp", std::string());
+        const bool force = wopiTimestamp.empty(); // Without a timestamp we force to always store.
+
+        // We don't expect overwriting by forced uploading.
+        LOK_ASSERT_EQUAL_MESSAGE("Unexpected overwritting the document in storage", false, force);
+
+        // Internal Server Error.
+        return Util::make_unique<http::Response>(http::StatusCode::InternalServerError);
+    }
+
+    bool onDocumentModified(const std::string& message) override
+    {
+        LOG_TST("Testing " << toString(_scenario) << ": [" << message << ']');
+        LOK_ASSERT_STATE(_phase, Phase::WaitModifiedStatus);
+
+        TRANSITION_STATE(_phase, Phase::WaitDocClose);
+
+        switch (_scenario)
+        {
+            case Scenario::Disconnect:
+                // Just disconnect.
+                LOG_TST("Disconnecting");
+                deleteSocketAt(0);
+                break;
+            case Scenario::SaveDiscard:
+            case Scenario::SaveOverwrite:
+                // Save the document.
+                LOG_TST("Saving the document");
+                WSD_CMD("save dontTerminateEdit=0 dontSaveIfUnmodified=0");
+                break;
+            case Scenario::CloseDiscard:
+                // Close the document.
+                LOG_TST("Closing the document");
+                WSD_CMD("closedocument");
+                break;
+            case Scenario::VerifyOverwrite:
+                LOK_ASSERT_FAIL("Unexpected modification in " + toString(_scenario));
+                break;
+        }
+
+        return true;
+    }
+
+    bool onDocumentError(const std::string& message) override
+    {
+        LOG_TST("Testing " << toString(_scenario) << ": [" << message << ']');
+        LOK_ASSERT_STATE(_phase, Phase::WaitDocClose);
+
+        LOK_ASSERT_EQUAL_MESSAGE("Expect only documentconflict errors",
+                                 std::string("error: cmd=storage kind=savefailed"), message);
+
+        // Close the document.
+        LOG_TST("Closing the document");
+        WSD_CMD("closedocument");
+
+        return true;
+    }
+
+    // Called when we have modified document data at exit.
+    bool onDataLoss(const std::string& reason) override
+    {
+        LOG_TST("Modified document being unloaded: " << reason);
+
+        // We expect this to happen only with the disonnection test,
+        // because only in that case there is no user input.
+        LOK_ASSERT_MESSAGE("Expected reason to be 'Data-loss detected'",
+                           Util::startsWith(reason, "Data-loss detected"));
+        LOK_ASSERT_MESSAGE("Expected to be in Phase::WaitDocClose but was " + toString(_phase),
+                           _phase == Phase::WaitDocClose);
+        _unloadingModifiedDocDetected = true;
+
+        return failed();
+    }
+
+    // Wait for clean unloading.
+    void onDocBrokerDestroy(const std::string& docKey) override
+    {
+        LOG_TST("Testing " << toString(_scenario) << " with dockey [" << docKey << "] closed.");
+        LOK_ASSERT_STATE(_phase, Phase::WaitDocClose);
+
+        // Uploading fails and we can't have anything but the original.
+        LOK_ASSERT_EQUAL_MESSAGE("Unexpected contents in storage", std::string(OriginalDocContent),
+                                 getFileContent());
+
+        Base::onDocBrokerDestroy(docKey);
+    }
+};
+
+UnitBase* unit_create_wsd(void) { return new UnitQuarantineConflict(); }
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -926,7 +926,6 @@ static std::string UnitTestLibrary;
 
 unsigned int COOLWSD::NumPreSpawnedChildren = 0;
 std::unique_ptr<TraceFileWriter> COOLWSD::TraceDumper;
-std::unordered_map<std::string, std::vector<std::string>> COOLWSD::QuarantineMap;
 #if !MOBILEAPP
 std::unique_ptr<ClipboardCache> COOLWSD::SavedClipboards;
 #endif

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -2473,7 +2473,7 @@ void COOLWSD::innerInitialize(Application& self)
             if (FileUtil::Stat(path).exists())
             {
                 LOG_INF("Initializing quarantine at [" + path << ']');
-                Quarantine::createQuarantineMap(path);
+                Quarantine::initialize(path);
             }
         }
     }

--- a/wsd/COOLWSD.hpp
+++ b/wsd/COOLWSD.hpp
@@ -283,7 +283,6 @@ public:
     static std::atomic<unsigned> NumConnections;
     static std::unique_ptr<TraceFileWriter> TraceDumper;
     static std::unordered_map<std::string, std::vector<std::string>> QuarantineMap;
-    static std::string QuarantinePath;
 #if !MOBILEAPP
     static std::unique_ptr<ClipboardCache> SavedClipboards;
 #endif

--- a/wsd/COOLWSD.hpp
+++ b/wsd/COOLWSD.hpp
@@ -282,7 +282,6 @@ public:
     static bool IsProxyPrefixEnabled;
     static std::atomic<unsigned> NumConnections;
     static std::unique_ptr<TraceFileWriter> TraceDumper;
-    static std::unordered_map<std::string, std::vector<std::string>> QuarantineMap;
 #if !MOBILEAPP
     static std::unique_ptr<ClipboardCache> SavedClipboards;
 #endif

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1917,7 +1917,7 @@ void DocumentBroker::handleUploadToStorageResponse(const StorageBase::UploadResu
                    "WOPI host might be low on disk or hitting a quota limit. Making all sessions "
                    "on doc read-only and notifying clients.");
 
-        // Make everyone readonly and tell everyone that storage is low on diskspace.
+        // Make everyone readonly and tell everyone that the file is too large for the storage.
         for (const auto& sessionIt : _sessions)
         {
             sessionIt.second->sendTextFrameAndLogError("error: cmd=storage kind=savetoolarge");

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1157,7 +1157,7 @@ bool DocumentBroker::download(const std::shared_ptr<ClientSession>& session, con
 
         _filename = fileInfo.getFilename();
 #if !MOBILEAPP
-        _quarantine.quarantineFile(_filename);
+        _quarantine.setDocumentName(_filename);
 #endif
         if (!templateSource.empty())
         {

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -135,7 +135,6 @@ DocumentBroker::DocumentBroker(ChildType type, const std::string& uri, const Poc
                        "per_document.min_time_between_saves_ms", 500)))
     , _storageManager(std::chrono::milliseconds(
           COOLWSD::getConfigValueNonZero<int>("per_document.min_time_between_uploads_ms", 5000)))
-    , _quarantine(*this)
     , _isModified(false)
     , _cursorPosX(0)
     , _cursorPosY(0)
@@ -605,13 +604,13 @@ void DocumentBroker::pollThread()
         // Quarantine the last copy, if different.
         LOG_DBG("Data loss detected, will quarantine last version of [" << getDocKey()
                                                                         << "] if necessary");
-        if (_storage)
+        if (_storage && _quarantine)
         {
             const std::string uploading = _storage->getRootFilePathUploading();
             if (FileUtil::Stat(uploading).exists())
             {
                 LOG_DBG("Quarantining the .uploading file: " << uploading);
-                _quarantine.quarantineFile(uploading);
+                _quarantine->quarantineFile(uploading);
             }
             else
             {
@@ -619,22 +618,22 @@ void DocumentBroker::pollThread()
                 if (FileUtil::Stat(upload).exists())
                 {
                     LOG_DBG("Quarantining the .upload file: " << upload);
-                    _quarantine.quarantineFile(upload);
+                    _quarantine->quarantineFile(upload);
                 }
                 else
                 {
                     // Fallback to quarantining to the original document.
                     LOG_DBG("Quarantining the original document file: " << _filename);
-                    _quarantine.quarantineFile(_filename);
+                    _quarantine->quarantineFile(_filename);
                 }
             }
         }
     }
-    else
+    else if (_quarantine)
     {
         // Gracefully unloaded.
         LOG_DBG("Cleaning up quarantined files for [" << getDocKey() << ']');
-        _quarantine.removeQuarantinedFiles();
+        _quarantine->removeQuarantinedFiles();
     }
 
     // Async cleanup.
@@ -1157,8 +1156,9 @@ bool DocumentBroker::download(const std::shared_ptr<ClientSession>& session, con
 
         _filename = fileInfo.getFilename();
 #if !MOBILEAPP
-        _quarantine.setDocumentName(_filename);
+        _quarantine = Util::make_unique<Quarantine>(*this, _filename);
 #endif
+
         if (!templateSource.empty())
         {
             // Invalid timestamp for templates, to force uploading once we save-after-loading.
@@ -1486,7 +1486,8 @@ void DocumentBroker::handleSaveResponse(const std::shared_ptr<ClientSession>& se
         LOG_TRC("Renamed [" << oldName << "] to [" << newName << ']');
     }
 
-    _quarantine.quarantineFile(newName);
+    if (_quarantine)
+        _quarantine->quarantineFile(newName);
 #endif //!MOBILEAPP
 
     // Let the clients know of any save failures.

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -24,6 +24,7 @@
 #include <Poco/URI.h>
 
 #include "Log.hpp"
+#include "QuarantineUtil.hpp"
 #include "TileDesc.hpp"
 #include "Util.hpp"
 #include "net/Socket.hpp"
@@ -1406,6 +1407,9 @@ private:
     /// The last upload request's attributes. Re-used to retry after failure.
     /// Updated right before uploading.
     StorageBase::Attributes _lastStorageAttrs;
+
+    /// The Quarantine manager.
+    Quarantine _quarantine;
 
     std::unique_ptr<TileCache> _tileCache;
     std::atomic<bool> _isModified;

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -1409,7 +1409,7 @@ private:
     StorageBase::Attributes _lastStorageAttrs;
 
     /// The Quarantine manager.
-    Quarantine _quarantine;
+    std::unique_ptr<Quarantine> _quarantine;
 
     std::unique_ptr<TileCache> _tileCache;
     std::atomic<bool> _isModified;

--- a/wsd/QuarantineUtil.cpp
+++ b/wsd/QuarantineUtil.cpp
@@ -56,8 +56,13 @@ void Quarantine::initialize(const std::string& path)
     std::vector<std::string> files;
     Poco::File(path).list(files);
 
-    //FIXME: This is lexicographical and won't sort timestamps correctly.
-    std::sort(files.begin(), files.end());
+    std::sort(files.begin(), files.end(),
+              [](const auto& lhs, const auto& rhs)
+              {
+                  const auto lhsPair = Util::u64FromString(Util::split(lhs, Delimiter).first);
+                  const auto rhsPair = Util::u64FromString(Util::split(rhs, Delimiter).first);
+                  return lhsPair.first && rhsPair.first && lhsPair.second < rhsPair.second;
+              });
 
     std::vector<StringToken> tokens;
     for (const auto& file : files)
@@ -113,8 +118,16 @@ void Quarantine::makeQuarantineSpace()
 
     std::vector<std::string> files;
     Poco::File(QuarantinePath).list(files);
+    if (files.empty())
+        return;
 
-    std::sort(files.begin(), files.end());
+    std::sort(files.begin(), files.end(),
+              [](const auto& lhs, const auto& rhs)
+              {
+                  const auto lhsPair = Util::u64FromString(Util::split(lhs, Delimiter).first);
+                  const auto rhsPair = Util::u64FromString(Util::split(rhs, Delimiter).first);
+                  return lhsPair.first && rhsPair.first && lhsPair.second < rhsPair.second;
+              });
 
     const auto timeNow = std::chrono::system_clock::now();
     const auto ts =

--- a/wsd/QuarantineUtil.cpp
+++ b/wsd/QuarantineUtil.cpp
@@ -28,8 +28,8 @@ std::unordered_map<std::string, std::vector<std::string>> Quarantine::Quarantine
 Quarantine::Quarantine(DocumentBroker& docBroker, const std::string& docName)
     : _docKey(docBroker.getDocKey())
     , _docName(docName)
-    , _quarantinedFilenamePrefix('_' + std::to_string(docBroker.getPid()) + '_' +
-                                 docBroker.getDocKey() + '_')
+    , _quarantinedFilename('_' + std::to_string(docBroker.getPid()) + '_' + docBroker.getDocKey() +
+                           '_' + _docName)
     , _maxSizeBytes(COOLWSD::getConfigValue<std::size_t>("quarantine_files.limit_dir_size_mb", 0) *
                     1024 * 1024)
     , _maxAgeSecs(COOLWSD::getConfigValue<std::size_t>("quarantine_files.expiry_min", 30) * 60)
@@ -179,8 +179,7 @@ bool Quarantine::quarantineFile(const std::string& docPath)
     const auto ts =
         std::chrono::duration_cast<std::chrono::seconds>(timeNow.time_since_epoch()).count();
 
-    const std::string linkedFilePath =
-        QuarantinePath + std::to_string(ts) + _quarantinedFilenamePrefix + _docName;
+    const std::string linkedFilePath = QuarantinePath + std::to_string(ts) + _quarantinedFilename;
 
     auto& fileList = QuarantineMap[_docKey];
     if (!fileList.empty())

--- a/wsd/QuarantineUtil.cpp
+++ b/wsd/QuarantineUtil.cpp
@@ -194,4 +194,14 @@ namespace Quarantine
 
         return false;
     }
+
+    void removeQuarantinedFiles(const std::string& docKey)
+    {
+        for (const auto& file : COOLWSD::QuarantineMap[docKey])
+        {
+            FileUtil::removeFile(file);
+        }
+
+        COOLWSD::QuarantineMap.erase(docKey);
+    }
 }

--- a/wsd/QuarantineUtil.cpp
+++ b/wsd/QuarantineUtil.cpp
@@ -14,11 +14,30 @@
 #include "DocumentBroker.hpp"
 #include "FileUtil.hpp"
 
+#include <chrono>
 #include <common/Common.hpp>
 #include <common/StringVector.hpp>
 #include <common/Log.hpp>
 
 std::string Quarantine::QuarantinePath;
+
+namespace
+{
+
+std::string createQuarantinedFilename(DocumentBroker& docBroker)
+{
+    std::string docKey;
+    Poco::URI::encode(docBroker.getDocKey(), "?#/", docKey);
+    return '_' + std::to_string(docBroker.getPid()) + '_' + docKey + '_';
+}
+
+} // namespace
+
+Quarantine::Quarantine(DocumentBroker& docBroker)
+    : _docBroker(docBroker)
+    , _quarantinedFilenamePrefix(createQuarantinedFilename(docBroker))
+{
+}
 
 void Quarantine::initialize(const std::string& path)
 {

--- a/wsd/QuarantineUtil.cpp
+++ b/wsd/QuarantineUtil.cpp
@@ -5,6 +5,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include <config.h>
+
 #include "QuarantineUtil.hpp"
 
 #include <Poco/Path.h>

--- a/wsd/QuarantineUtil.cpp
+++ b/wsd/QuarantineUtil.cpp
@@ -82,9 +82,6 @@ void Quarantine::removeQuarantine()
     FileUtil::removeFile(QuarantinePath, true);
 }
 
-// returns quarantine directory size in bytes
-// files with hardlink count of more than 1 is not counted
-// because they are originally stored in jails
 std::size_t Quarantine::quarantineSize()
 {
     if (!isQuarantineEnabled())
@@ -96,10 +93,9 @@ std::size_t Quarantine::quarantineSize()
     for (const auto& file : files)
     {
         FileUtil::Stat f(QuarantinePath + file);
-
-        if (f.hardLinkCount() == 1)
-            size += f.size();
+        size += f.size();
     }
+
     return size;
 }
 

--- a/wsd/QuarantineUtil.cpp
+++ b/wsd/QuarantineUtil.cpp
@@ -18,195 +18,192 @@
 #include <common/Log.hpp>
 #include <common/JailUtil.hpp>
 
-namespace Quarantine
+std::string Quarantine::QuarantinePath;
+
+void Quarantine::initialize(const std::string& path)
 {
-    static std::string QuarantinePath;
+    if (!COOLWSD::getConfigValue<bool>("quarantine_files[@enable]", false) || isQuarantineEnabled())
+        return;
 
-    bool isQuarantineEnabled()
+    std::vector<std::string> files;
+    Poco::File(path).list(files);
+    COOLWSD::QuarantineMap.clear();
+
+    std::vector<StringToken> tokens;
+    std::string decoded;
+
+    std::sort(files.begin(), files.end());
+    for (const auto& file : files)
     {
-        return !QuarantinePath.empty();
+        StringVector::tokenize(file.c_str(), file.size(), '_', tokens);
+        Poco::URI::decode(file.substr(tokens[2]._index), decoded);
+        COOLWSD::QuarantineMap[decoded].emplace_back(path + file);
+
+        tokens.clear();
+        decoded.clear();
     }
 
-    void createQuarantineMap(const std::string& path)
+    QuarantinePath = path;
+}
+
+void Quarantine::removeQuarantine()
+{
+    if (!isQuarantineEnabled())
+        return;
+
+    FileUtil::removeFile(QuarantinePath, true);
+}
+
+// returns quarantine directory size in bytes
+// files with hardlink count of more than 1 is not counted
+// because they are originally stored in jails
+std::size_t Quarantine::quarantineSize()
+{
+    if (!isQuarantineEnabled())
+        return 0;
+
+    std::vector<std::string> files;
+    Poco::File(QuarantinePath).list(files);
+    std::size_t size = 0;
+    for (const auto& file : files)
     {
-        if (!COOLWSD::getConfigValue<bool>("quarantine_files[@enable]", false) ||
-            isQuarantineEnabled())
-            return;
+        FileUtil::Stat f(QuarantinePath + file);
 
-        std::vector<std::string> files;
-        Poco::File(path).list(files);
-        COOLWSD::QuarantineMap.clear();
+        if (f.hardLinkCount() == 1)
+            size += f.size();
+    }
+    return size;
+}
 
-        std::vector<StringToken> tokens;
-        std::string decoded;
+void Quarantine::makeQuarantineSpace()
+{
+    if (!isQuarantineEnabled())
+        return;
 
-        std::sort(files.begin(), files.end());
-        for (const auto& file : files)
+    std::size_t sizeLimit =
+        COOLWSD::getConfigValue<std::size_t>("quarantine_files.limit_dir_size_mb", 0) * 1024 * 1024;
+
+    std::vector<std::string> files;
+    Poco::File(QuarantinePath).list(files);
+
+    std::sort(files.begin(), files.end());
+
+    std::size_t timeLimit = COOLWSD::getConfigValue<std::size_t>("quarantine_files.expiry_min", 30);
+    const auto timeNow = std::chrono::system_clock::now();
+    const auto ts =
+        std::chrono::duration_cast<std::chrono::seconds>(timeNow.time_since_epoch()).count();
+
+    std::size_t currentSize = quarantineSize();
+    auto index = files.begin();
+    while (index != files.end() && !files.empty())
+    {
+        FileUtil::Stat file(QuarantinePath + *index);
+        const auto modifyTime = std::chrono::duration_cast<std::chrono::seconds>(
+                                    file.modifiedTimepoint().time_since_epoch())
+                                    .count();
+        bool isExpired = static_cast<std::size_t>(ts - modifyTime) > timeLimit * 60;
+
+        if ((file.hardLinkCount() == 1) && (isExpired || (currentSize >= sizeLimit)))
         {
-
-            StringVector::tokenize(file.c_str(), file.size(), '_', tokens);
-            Poco::URI::decode(file.substr(tokens[2]._index), decoded);
-            COOLWSD::QuarantineMap[decoded].emplace_back(path + file);
-
-            tokens.clear();
-            decoded.clear();
-        }
-
-        QuarantinePath = path;
-    }
-
-    void removeQuarantine()
-    {
-        if (!isQuarantineEnabled())
-            return;
-
-        FileUtil::removeFile(QuarantinePath, true);
-    }
-
-    // returns quarantine directory size in bytes
-    // files with hardlink count of more than 1 is not counted
-    // because they are originally stored in jails
-    std::size_t quarantineSize()
-    {
-        if (!isQuarantineEnabled())
-            return 0;
-
-        std::vector<std::string> files;
-        Poco::File(QuarantinePath).list(files);
-        std::size_t size = 0;
-        for (const auto& file : files)
-        {
-            FileUtil::Stat f(QuarantinePath + file);
-
-            if (f.hardLinkCount() == 1)
-                size += f.size();
-        }
-        return size;
-    }
-
-    void makeQuarantineSpace()
-    {
-        if (!isQuarantineEnabled())
-            return;
-
-        std::size_t sizeLimit = COOLWSD::getConfigValue<std::size_t>("quarantine_files.limit_dir_size_mb", 0)*1024*1024;
-
-        std::vector<std::string> files;
-        Poco::File(QuarantinePath).list(files);
-
-        std::sort(files.begin(), files.end());
-
-        std::size_t timeLimit = COOLWSD::getConfigValue<std::size_t>("quarantine_files.expiry_min", 30);
-        const auto timeNow = std::chrono::system_clock::now();
-        const auto ts = std::chrono::duration_cast<std::chrono::seconds>(timeNow.time_since_epoch()).count();
-
-        std::size_t currentSize = quarantineSize();
-        auto index = files.begin();
-        while (index != files.end() && !files.empty())
-        {
-            FileUtil::Stat file(QuarantinePath + *index);
-            const auto modifyTime = std::chrono::duration_cast<std::chrono::seconds>(file.modifiedTimepoint().time_since_epoch()).count();
-            bool isExpired = static_cast<std::size_t>(ts - modifyTime) > timeLimit * 60;
-
-            if ( (file.hardLinkCount() == 1) && (isExpired || (currentSize >= sizeLimit)) )
-            {
-                currentSize -= file.size();
-                FileUtil::removeFile(QuarantinePath + *index, true);
-                files.erase(index);
-            }
-            else
-                index++;
-        }
-    }
-
-    void clearOldQuarantineVersions(const std::string& docKey)
-    {
-        if (!isQuarantineEnabled())
-            return;
-
-        std::size_t maxVersionCount =
-            std::max<size_t>(COOLWSD::getConfigValue<std::size_t>("quarantine_files.max_versions_to_maintain", 2), 1);
-        std::string decoded;
-        Poco::URI::decode(docKey, decoded);
-        while (COOLWSD::QuarantineMap[decoded].size() > maxVersionCount)
-        {
-            FileUtil::removeFile(COOLWSD::QuarantineMap[decoded][0]);
-            COOLWSD::QuarantineMap[decoded].erase(COOLWSD::QuarantineMap[decoded].begin());
-        }
-    }
-
-    bool quarantineFile(DocumentBroker* docBroker, const std::string& docName)
-    {
-        if (!isQuarantineEnabled())
-            return false;
-
-        std::string docKey;
-        Poco::URI::encode(docBroker->getDocKey(), "?#/", docKey);
-
-        const auto timeNow = std::chrono::system_clock::now();
-        const std::string ts = std::to_string(std::chrono::duration_cast<std::chrono::seconds>(timeNow.time_since_epoch()).count());
-
-        std::string sourcefilePath;
-        if(JailUtil::isBindMountingEnabled())
-        {
-            sourcefilePath = COOLWSD::ChildRoot + "tmp/cool-" + docBroker->getJailId() +
-                             "/user/docs/" + docBroker->getJailId() + '/' + docName;
+            currentSize -= file.size();
+            FileUtil::removeFile(QuarantinePath + *index, true);
+            files.erase(index);
         }
         else
+            index++;
+    }
+}
+
+void Quarantine::clearOldQuarantineVersions(const std::string& docKey)
+{
+    if (!isQuarantineEnabled())
+        return;
+
+    std::size_t maxVersionCount = std::max<size_t>(
+        COOLWSD::getConfigValue<std::size_t>("quarantine_files.max_versions_to_maintain", 2), 1);
+    std::string decoded;
+    Poco::URI::decode(docKey, decoded);
+    while (COOLWSD::QuarantineMap[decoded].size() > maxVersionCount)
+    {
+        FileUtil::removeFile(COOLWSD::QuarantineMap[decoded][0]);
+        COOLWSD::QuarantineMap[decoded].erase(COOLWSD::QuarantineMap[decoded].begin());
+    }
+}
+
+bool Quarantine::quarantineFile(DocumentBroker* docBroker, const std::string& docName)
+{
+    if (!isQuarantineEnabled())
+        return false;
+
+    std::string docKey;
+    Poco::URI::encode(docBroker->getDocKey(), "?#/", docKey);
+
+    const auto timeNow = std::chrono::system_clock::now();
+    const std::string ts = std::to_string(
+        std::chrono::duration_cast<std::chrono::seconds>(timeNow.time_since_epoch()).count());
+
+    std::string sourcefilePath;
+    if (JailUtil::isBindMountingEnabled())
+    {
+        sourcefilePath = COOLWSD::ChildRoot + "tmp/cool-" + docBroker->getJailId() + "/user/docs/" +
+                         docBroker->getJailId() + '/' + docName;
+    }
+    else
+    {
+        sourcefilePath = COOLWSD::ChildRoot + docBroker->getJailId() + "/tmp/user/docs/" +
+                         docBroker->getJailId() + '/' + docName;
+    }
+
+    std::string linkedFileName =
+        ts + '_' + std::to_string(docBroker->getPid()) + '_' + docKey + '_' + docName;
+    std::string linkedFilePath = QuarantinePath + linkedFileName;
+
+    auto& fileList = COOLWSD::QuarantineMap[docBroker->getDocKey()];
+    if (!fileList.empty())
+    {
+        FileUtil::Stat sourceStat(sourcefilePath);
+        FileUtil::Stat lastFileStat(fileList[fileList.size() - 1]);
+
+        if (lastFileStat.inodeNumber() == sourceStat.inodeNumber())
         {
-            sourcefilePath = COOLWSD::ChildRoot + docBroker->getJailId() + "/tmp/user/docs/" +
-                             docBroker->getJailId() + '/' + docName;
-        }
-
-        std::string linkedFileName = ts + '_' + std::to_string(docBroker->getPid()) + '_' + docKey + '_' + docName;
-        std::string linkedFilePath = QuarantinePath + linkedFileName;
-
-        auto& fileList = COOLWSD::QuarantineMap[docBroker->getDocKey()];
-        if(!fileList.empty())
-        {
-            FileUtil::Stat sourceStat(sourcefilePath);
-            FileUtil::Stat lastFileStat(fileList[fileList.size()-1]);
-
-            if(lastFileStat.inodeNumber() == sourceStat.inodeNumber())
-            {
-                LOG_INF("Quarantining of file " << sourcefilePath << " to " << linkedFilePath
+            LOG_INF("Quarantining of file "
+                    << sourcefilePath << " to " << linkedFilePath
                     << " is skipped because this file version is already quarantined.");
-                return false;
-            }
+            return false;
         }
+    }
 
+    makeQuarantineSpace();
 
+    int result_link = link(sourcefilePath.c_str(), linkedFilePath.c_str());
+
+    if (result_link == 0)
+    {
+        fileList.emplace_back(linkedFilePath);
+        clearOldQuarantineVersions(docKey);
         makeQuarantineSpace();
 
-        int result_link = link(sourcefilePath.c_str(),linkedFilePath.c_str());
-
-        if (result_link == 0)
-        {
-            fileList.emplace_back(linkedFilePath);
-            clearOldQuarantineVersions(docKey);
-            makeQuarantineSpace();
-
-            LOG_INF("Quarantined " << sourcefilePath << " to " << linkedFilePath);
-            return true;
-        }
-        else
-        {
-            int saved_errno = errno;
-            LOG_ERR("Quarantining of file " << sourcefilePath << " to " << linkedFilePath << " failed: "
-                    << Util::symbolicErrno(saved_errno) << ": " << std::strerror(saved_errno));
-            return false;
-        }
-
+        LOG_INF("Quarantined " << sourcefilePath << " to " << linkedFilePath);
+        return true;
+    }
+    else
+    {
+        int saved_errno = errno;
+        LOG_ERR("Quarantining of file " << sourcefilePath << " to " << linkedFilePath
+                                        << " failed: " << Util::symbolicErrno(saved_errno) << ": "
+                                        << std::strerror(saved_errno));
         return false;
     }
 
-    void removeQuarantinedFiles(const std::string& docKey)
-    {
-        for (const auto& file : COOLWSD::QuarantineMap[docKey])
-        {
-            FileUtil::removeFile(file);
-        }
+    return false;
+}
 
-        COOLWSD::QuarantineMap.erase(docKey);
+void Quarantine::removeQuarantinedFiles(const std::string& docKey)
+{
+    for (const auto& file : COOLWSD::QuarantineMap[docKey])
+    {
+        FileUtil::removeFile(file);
     }
+
+    COOLWSD::QuarantineMap.erase(docKey);
 }

--- a/wsd/QuarantineUtil.cpp
+++ b/wsd/QuarantineUtil.cpp
@@ -156,18 +156,12 @@ bool Quarantine::quarantineFile(const std::string& docPath)
     if (!isQuarantineEnabled())
         return false;
 
-    std::string docKey;
-    Poco::URI::encode(_docBroker.getDocKey(), "?#/", docKey);
-
     const auto timeNow = std::chrono::system_clock::now();
-    const std::string ts = std::to_string(
-        std::chrono::duration_cast<std::chrono::seconds>(timeNow.time_since_epoch()).count());
+    const auto ts =
+        std::chrono::duration_cast<std::chrono::seconds>(timeNow.time_since_epoch()).count();
 
-    const std::string docName = Poco::Path(docPath).getFileName();
-
-    std::string linkedFileName =
-        ts + '_' + std::to_string(_docBroker.getPid()) + '_' + docKey + '_' + docName;
-    std::string linkedFilePath = QuarantinePath + linkedFileName;
+    const std::string linkedFilePath =
+        QuarantinePath + std::to_string(ts) + _quarantinedFilename + _docName;
 
     auto& fileList = COOLWSD::QuarantineMap[_docBroker.getDocKey()];
     if (!fileList.empty())

--- a/wsd/QuarantineUtil.cpp
+++ b/wsd/QuarantineUtil.cpp
@@ -213,8 +213,10 @@ bool Quarantine::quarantineFile(const std::string& docPath)
 
 void Quarantine::removeQuarantinedFiles()
 {
+    LOG_DBG("Removing all quarantined files for [" << _docKey << ']');
     for (const auto& file : QuarantineMap[_docKey])
     {
+        LOG_TRC("Removing quarantined file [" << file << "] for [" << _docKey << ']');
         FileUtil::removeFile(file);
     }
 

--- a/wsd/QuarantineUtil.cpp
+++ b/wsd/QuarantineUtil.cpp
@@ -25,8 +25,9 @@
 std::string Quarantine::QuarantinePath;
 std::unordered_map<std::string, std::vector<std::string>> Quarantine::QuarantineMap;
 
-Quarantine::Quarantine(DocumentBroker& docBroker)
+Quarantine::Quarantine(DocumentBroker& docBroker, const std::string& docName)
     : _docKey(docBroker.getDocKey())
+    , _docName(docName)
     , _quarantinedFilenamePrefix('_' + std::to_string(docBroker.getPid()) + '_' +
                                  docBroker.getDocKey() + '_')
     , _maxSizeBytes(COOLWSD::getConfigValue<std::size_t>("quarantine_files.limit_dir_size_mb", 0) *
@@ -36,6 +37,7 @@ Quarantine::Quarantine(DocumentBroker& docBroker)
           COOLWSD::getConfigValue<std::size_t>("quarantine_files.max_versions_to_maintain", 2),
           1UL))
 {
+    LOG_DBG("Quarantine ctor for [" << _docKey << ']');
 }
 
 void Quarantine::initialize(const std::string& path)

--- a/wsd/QuarantineUtil.cpp
+++ b/wsd/QuarantineUtil.cpp
@@ -24,12 +24,13 @@ namespace Quarantine
 
     bool isQuarantineEnabled()
     {
-        return COOLWSD::getConfigValue<bool>("quarantine_files[@enable]", false);
+        return !QuarantinePath.empty();
     }
 
     void createQuarantineMap(const std::string& path)
     {
-        if (!isQuarantineEnabled())
+        if (!COOLWSD::getConfigValue<bool>("quarantine_files[@enable]", false) ||
+            isQuarantineEnabled())
             return;
 
         std::vector<std::string> files;

--- a/wsd/QuarantineUtil.cpp
+++ b/wsd/QuarantineUtil.cpp
@@ -115,13 +115,14 @@ void Quarantine::makeQuarantineSpace()
     }
 }
 
-void Quarantine::clearOldQuarantineVersions(const std::string& docKey)
+void Quarantine::clearOldQuarantineVersions()
 {
     if (!isQuarantineEnabled())
         return;
 
     std::size_t maxVersionCount = std::max<size_t>(
         COOLWSD::getConfigValue<std::size_t>("quarantine_files.max_versions_to_maintain", 2), 1);
+    const std::string& docKey = _docBroker.getDocKey();
     std::string decoded;
     Poco::URI::decode(docKey, decoded);
     while (COOLWSD::QuarantineMap[decoded].size() > maxVersionCount)
@@ -169,7 +170,7 @@ bool Quarantine::quarantineFile(const std::string& docPath)
     if (FileUtil::linkOrCopyFile(docPath, linkedFilePath))
     {
         fileList.emplace_back(linkedFilePath);
-        clearOldQuarantineVersions(docKey);
+        clearOldQuarantineVersions();
         makeQuarantineSpace();
 
         LOG_INF("Quarantined [" << docPath << "] to [" << linkedFilePath << ']');

--- a/wsd/QuarantineUtil.cpp
+++ b/wsd/QuarantineUtil.cpp
@@ -39,6 +39,9 @@ Quarantine::Quarantine(DocumentBroker& docBroker)
     , _maxSizeBytes(COOLWSD::getConfigValue<std::size_t>("quarantine_files.limit_dir_size_mb", 0) *
                     1024 * 1024)
     , _maxAgeSecs(COOLWSD::getConfigValue<std::size_t>("quarantine_files.expiry_min", 30) * 60)
+    , _maxVersions(std::max(
+          COOLWSD::getConfigValue<std::size_t>("quarantine_files.max_versions_to_maintain", 2),
+          1UL))
 {
 }
 
@@ -138,11 +141,9 @@ void Quarantine::clearOldQuarantineVersions()
     if (!isQuarantineEnabled())
         return;
 
-    std::size_t maxVersionCount = std::max<size_t>(
-        COOLWSD::getConfigValue<std::size_t>("quarantine_files.max_versions_to_maintain", 2), 1);
     std::string decoded;
     Poco::URI::decode(_docKey, decoded);
-    while (COOLWSD::QuarantineMap[decoded].size() > maxVersionCount)
+    while (COOLWSD::QuarantineMap[decoded].size() > _maxVersions)
     {
         FileUtil::removeFile(COOLWSD::QuarantineMap[decoded][0]);
         COOLWSD::QuarantineMap[decoded].erase(COOLWSD::QuarantineMap[decoded].begin());

--- a/wsd/QuarantineUtil.cpp
+++ b/wsd/QuarantineUtil.cpp
@@ -148,10 +148,23 @@ void Quarantine::clearOldQuarantineVersions()
     if (!isQuarantineEnabled())
         return;
 
-    while (QuarantineMap[_docKey].size() > _maxVersions)
+    auto& container = QuarantineMap[_docKey];
+    if (container.size() > _maxVersions)
     {
-        FileUtil::removeFile(QuarantineMap[_docKey][0]);
-        QuarantineMap[_docKey].erase(QuarantineMap[_docKey].begin());
+        const std::size_t excess = container.size() - _maxVersions;
+        LOG_TRC("Removing " << excess << " excess quarantined file versions for [" << _docKey
+                            << ']');
+        for (std::size_t i = 0; i < excess; ++i)
+        {
+            const std::string& path = container[i];
+            LOG_TRC("Removing excess quarantined file version #" << (i + 1) << " [" << path
+                                                                 << "] for [" << _docKey << ']');
+
+            FileUtil::removeFile(path);
+        }
+
+        // And remove them from the container.
+        container.erase(container.begin(), container.begin() + excess);
     }
 }
 

--- a/wsd/QuarantineUtil.hpp
+++ b/wsd/QuarantineUtil.hpp
@@ -34,7 +34,7 @@ private:
 
     void makeQuarantineSpace();
 
-    void clearOldQuarantineVersions(const std::string& docKey);
+    void clearOldQuarantineVersions();
 
     void removeQuarantine();
 

--- a/wsd/QuarantineUtil.hpp
+++ b/wsd/QuarantineUtil.hpp
@@ -16,4 +16,7 @@ namespace Quarantine
     void createQuarantineMap();
 
     bool quarantineFile(DocumentBroker* docBroker, const std::string& docName);
+
+    /// Removes the quarantined files for the given DocKey when we unload gracefully.
+    void removeQuarantinedFiles(const std::string& docKey);
 }

--- a/wsd/QuarantineUtil.hpp
+++ b/wsd/QuarantineUtil.hpp
@@ -42,5 +42,6 @@ private:
 
     const std::string _docKey;
     const std::string _quarantinedFilenamePrefix;
+    const std::size_t _maxSizeBytes;
     std::string _docName;
 };

--- a/wsd/QuarantineUtil.hpp
+++ b/wsd/QuarantineUtil.hpp
@@ -15,10 +15,7 @@ class DocumentBroker;
 class Quarantine
 {
 public:
-    Quarantine(DocumentBroker& docBroker)
-        : _docBroker(docBroker)
-    {
-    }
+    Quarantine(DocumentBroker& docBroker);
 
     static void initialize(const std::string& path);
 
@@ -42,4 +39,6 @@ private:
     static std::string QuarantinePath;
 
     DocumentBroker& _docBroker;
+    const std::string _quarantinedFilenamePrefix;
+    std::string _docName;
 };

--- a/wsd/QuarantineUtil.hpp
+++ b/wsd/QuarantineUtil.hpp
@@ -19,6 +19,8 @@ public:
 
     static void initialize(const std::string& path);
 
+    void setDocumentName(const std::string& docName) { _docName = docName; }
+
     bool quarantineFile(const std::string& docName);
 
     /// Removes the quarantined files for the given DocKey when we unload gracefully.

--- a/wsd/QuarantineUtil.hpp
+++ b/wsd/QuarantineUtil.hpp
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -39,6 +40,8 @@ private:
 
 private:
     static std::unordered_map<std::string, std::vector<std::string>> QuarantineMap;
+    /// Protects the shared QuarantineMap from concurrent modification.
+    static std::mutex Mutex;
     static std::string QuarantinePath;
 
     /// The delimiter used in the quarantine filename.

--- a/wsd/QuarantineUtil.hpp
+++ b/wsd/QuarantineUtil.hpp
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <config.h>
 #include <string>
 
 class DocumentBroker;

--- a/wsd/QuarantineUtil.hpp
+++ b/wsd/QuarantineUtil.hpp
@@ -44,5 +44,6 @@ private:
     const std::string _quarantinedFilenamePrefix;
     const std::size_t _maxSizeBytes;
     const std::size_t _maxAgeSecs;
+    const std::size_t _maxVersions;
     std::string _docName;
 };

--- a/wsd/QuarantineUtil.hpp
+++ b/wsd/QuarantineUtil.hpp
@@ -40,7 +40,7 @@ private:
 private:
     static std::string QuarantinePath;
 
-    DocumentBroker& _docBroker;
+    const std::string _docKey;
     const std::string _quarantinedFilenamePrefix;
     std::string _docName;
 };

--- a/wsd/QuarantineUtil.hpp
+++ b/wsd/QuarantineUtil.hpp
@@ -15,24 +15,31 @@ class DocumentBroker;
 class Quarantine
 {
 public:
+    Quarantine(DocumentBroker& docBroker)
+        : _docBroker(docBroker)
+    {
+    }
+
     static void initialize(const std::string& path);
 
-    static bool quarantineFile(DocumentBroker* docBroker, const std::string& docName);
+    bool quarantineFile(const std::string& docName);
 
     /// Removes the quarantined files for the given DocKey when we unload gracefully.
-    static void removeQuarantinedFiles(const std::string& docKey);
+    void removeQuarantinedFiles();
 
 private:
-    static bool isQuarantineEnabled() { return !QuarantinePath.empty(); }
+    bool isQuarantineEnabled() const { return !QuarantinePath.empty(); }
 
-    static std::size_t quarantineSize();
+    std::size_t quarantineSize();
 
-    static void makeQuarantineSpace();
+    void makeQuarantineSpace();
 
-    static void clearOldQuarantineVersions(const std::string& docKey);
+    void clearOldQuarantineVersions(const std::string& docKey);
 
-    static void removeQuarantine();
+    void removeQuarantine();
 
 private:
     static std::string QuarantinePath;
+
+    DocumentBroker& _docBroker;
 };

--- a/wsd/QuarantineUtil.hpp
+++ b/wsd/QuarantineUtil.hpp
@@ -8,6 +8,8 @@
 #pragma once
 
 #include <string>
+#include <unordered_map>
+#include <vector>
 
 class DocumentBroker;
 
@@ -37,6 +39,7 @@ private:
     void removeQuarantine();
 
 private:
+    static std::unordered_map<std::string, std::vector<std::string>> QuarantineMap;
     static std::string QuarantinePath;
 
     const std::string _docKey;

--- a/wsd/QuarantineUtil.hpp
+++ b/wsd/QuarantineUtil.hpp
@@ -11,12 +11,28 @@
 #include <string>
 
 class DocumentBroker;
-namespace Quarantine
-{
-    void createQuarantineMap(const std::string& path);
 
-    bool quarantineFile(DocumentBroker* docBroker, const std::string& docName);
+class Quarantine
+{
+public:
+    static void initialize(const std::string& path);
+
+    static bool quarantineFile(DocumentBroker* docBroker, const std::string& docName);
 
     /// Removes the quarantined files for the given DocKey when we unload gracefully.
-    void removeQuarantinedFiles(const std::string& docKey);
-}
+    static void removeQuarantinedFiles(const std::string& docKey);
+
+private:
+    static bool isQuarantineEnabled() { return !QuarantinePath.empty(); }
+
+    static std::size_t quarantineSize();
+
+    static void makeQuarantineSpace();
+
+    static void clearOldQuarantineVersions(const std::string& docKey);
+
+    static void removeQuarantine();
+
+private:
+    static std::string QuarantinePath;
+};

--- a/wsd/QuarantineUtil.hpp
+++ b/wsd/QuarantineUtil.hpp
@@ -28,6 +28,7 @@ public:
 private:
     bool isQuarantineEnabled() const { return !QuarantinePath.empty(); }
 
+    /// Returns quarantine directory size in bytes.
     std::size_t quarantineSize();
 
     void makeQuarantineSpace();

--- a/wsd/QuarantineUtil.hpp
+++ b/wsd/QuarantineUtil.hpp
@@ -43,5 +43,6 @@ private:
     const std::string _docKey;
     const std::string _quarantinedFilenamePrefix;
     const std::size_t _maxSizeBytes;
+    const std::size_t _maxAgeSecs;
     std::string _docName;
 };

--- a/wsd/QuarantineUtil.hpp
+++ b/wsd/QuarantineUtil.hpp
@@ -13,7 +13,7 @@
 class DocumentBroker;
 namespace Quarantine
 {
-    void createQuarantineMap();
+    void createQuarantineMap(const std::string& path);
 
     bool quarantineFile(DocumentBroker* docBroker, const std::string& docName);
 

--- a/wsd/QuarantineUtil.hpp
+++ b/wsd/QuarantineUtil.hpp
@@ -16,11 +16,9 @@ class DocumentBroker;
 class Quarantine
 {
 public:
-    Quarantine(DocumentBroker& docBroker);
+    Quarantine(DocumentBroker& docBroker, const std::string& docName);
 
     static void initialize(const std::string& path);
-
-    void setDocumentName(const std::string& docName) { _docName = docName; }
 
     bool quarantineFile(const std::string& docName);
 
@@ -43,9 +41,9 @@ private:
     static std::string QuarantinePath;
 
     const std::string _docKey;
+    const std::string _docName;
     const std::string _quarantinedFilenamePrefix;
     const std::size_t _maxSizeBytes;
     const std::size_t _maxAgeSecs;
     const std::size_t _maxVersions;
-    std::string _docName;
 };

--- a/wsd/QuarantineUtil.hpp
+++ b/wsd/QuarantineUtil.hpp
@@ -42,7 +42,7 @@ private:
 
     const std::string _docKey;
     const std::string _docName;
-    const std::string _quarantinedFilenamePrefix;
+    const std::string _quarantinedFilename;
     const std::size_t _maxSizeBytes;
     const std::size_t _maxAgeSecs;
     const std::size_t _maxVersions;

--- a/wsd/QuarantineUtil.hpp
+++ b/wsd/QuarantineUtil.hpp
@@ -40,8 +40,15 @@ private:
     static std::unordered_map<std::string, std::vector<std::string>> QuarantineMap;
     static std::string QuarantinePath;
 
+    /// The delimiter used in the quarantine filename.
+    static constexpr char Delimiter = '_';
+
     const std::string _docKey;
     const std::string _docName;
+    /// The quarantined filename is a multi-part string, formed
+    /// from the timestamp, pid, docKey, and document filename.
+    /// The Delimiter is used to join and later tokenize it.
+    /// The document filename is encoded to ensure tokenization.
     const std::string _quarantinedFilename;
     const std::size_t _maxSizeBytes;
     const std::size_t _maxAgeSecs;

--- a/wsd/RequestDetails.cpp
+++ b/wsd/RequestDetails.cpp
@@ -34,34 +34,6 @@ std::map<std::string, std::string> getParams(const std::string& uri)
 
     return result;
 }
-
-/// Returns true iff the two containers are equal.
-template <typename T> bool equal(const T& lhs, const T& rhs)
-{
-    if (lhs.size() != rhs.size())
-    {
-        LOG_ERR("!!! Size mismatch: [" << lhs.size() << "] != [" << rhs.size() << "].");
-        return false;
-    }
-
-    const auto endLeft = std::end(lhs);
-
-    auto itRight = std::begin(rhs);
-
-    for (auto itLeft = std::begin(lhs); itLeft != endLeft; ++itLeft, ++itRight)
-    {
-        const auto subLeft = lhs.getParam(*itLeft);
-        const auto subRight = rhs.getParam(*itRight);
-
-        if (subLeft != subRight)
-        {
-            LOG_ERR("!!! Data mismatch: [" << subLeft << "] != [" << subRight << ']');
-            return false;
-        }
-    }
-
-    return true;
-}
 }
 
 RequestDetails::RequestDetails(Poco::Net::HTTPRequest &request, const std::string& serviceRoot)


### PR DESCRIPTION
This PR fixes known/reported issues, leaving the original logic/design mostly intact.

Key changes:
1. Support for copying when hard-linking fails.
2. Thread-safety.
3. Adding unit-test.
4. Correct timestamp comparison, sorting, and clean-up.
5. Correct loading of quarantined files at initialization.
6. Support for failed initialization and disabling of Quarantine.
7. Avoid reconstructing the path to the document manually.
8. Avoid reading the configuration repeatedly, which is slow.
9. Encapsulation of Quarantine members/data.
10. Minimize hard-coded values and code duplication.

Patches:
- wsd: more accurate comment
- wsd: test: add quarantine test
- wsd: clang tidy fixes
- make: silence clang complaining of -pthread
- wsd: FileUtil to link or copy files
- wsd: add fixme for safer jail removal
- wsd: quarantine: cleanup quarantined files when unloading cleanly
- wsd: quarantine: encapsulate the quarantine path
- wsd: quarantine: smarter quarantine enabling
- wsd: quarantine: convert Quarantine to a class
- wsd: quarantine: more encapsulation
- wsd: refactor FileUtil::Stat::isUpToDate
- wsd: quarantine: provide the filename to quarantine
- wsd: quarantine: minimize explicit arg passing
- wsd: quarantine: capture const values
- wsd: quarantine: capture the document name
- wsd: quarantine: capture DocKey
- wsd: quarantine: capture the maximum quarantine size
- wsd: quarantine: capture the maximum age of quarantined files
- wsd: quarantine: capture the maximum quarantined file versions
- wsd: quarantine: include correction
- wsd: quarantine: encapsulate QuarantineMap
- killpoco: remove direct URI encode/decode usage in RequestDetails
- wsd: remove unused helper
- wsd: quarantine: docKey is already encoded
- wsd: quarantine: improved cleanup
- wsd: quarantine: better quarantined version cleanup
- wsd: quarantine: cleanup and logging of quarantine file removal
- wsd: quarantine: delayed construction of the quarantine instance
- wsd: quarantine: simplify the filename
- wsd: minor improvement to Util::replace
- wsd: quarantine: better filename tokenization
- wsd: quarantine: size calculation
- wsd: quarantine: thread-safe quarantining
- wsd: quarantine: correctly sort files based on timestamp
- wsd: quarantine: refactor the timestamp
