### PR TITLE
Remove notebookbar seperation from Cypress tests.

### DIFF
--- a/cypress_test/Makefile.am
+++ b/cypress_test/Makefile.am
@@ -25,7 +25,6 @@ DESKTOP_TEST_FOLDER = $(abs_srcdir)/integration_tests/desktop
 DESKTOP_DATA_FOLDER = $(abs_srcdir)/data/desktop/
 DESKTOP_DATA_WORKDIR = $(abs_builddir)/workdir/data/desktop/
 DESKTOP_TRACK_FOLDER=$(abs_builddir)/workdir/track/desktop
-DESKTOP_NB_TRACK_FOLDER=$(abs_builddir)/workdir/track/notebookbar
 
 MOBILE_USER_AGENT = "cypress-mobile"
 MOBILE_TEST_FOLDER = $(abs_srcdir)/integration_tests/mobile
@@ -80,9 +79,6 @@ MOBILE_TEST_FILES_DONE= \
 DESKTOP_TEST_FILES_DONE= \
 	$(foreach test_file,$(DESKTOP_TEST_FILES),$(DESKTOP_TRACK_FOLDER)/$(test_file).done)
 
-DESKTOP_NB_TEST_FILES_DONE= \
-	$(foreach test_file,$(DESKTOP_TEST_FILES),$(DESKTOP_NB_TRACK_FOLDER)/$(test_file).done)
-
 MULTIUSER_TESTS_DONE= \
 	$(MULTIUSER_TRACK_FOLDER)/multiuser_tests.done
 
@@ -90,11 +86,6 @@ check-local: do-check
 	$(if $(wildcard $(ERROR_LOG)),$(error CypressError: some tests failed!))
 
 do-check: $(DESKTOP_TEST_FILES_DONE) $(MOBILE_TEST_FILES_DONE) $(MULTIUSER_TESTS_DONE)
-	@$(KILL_COMMAND) || true
-	$(if $(HEADLESS_BUILD),@pkill Xvfb,)
-	$(if $(wildcard $(ERROR_LOG)),@cat $(ERROR_LOG))
-
-check-notebookbar: $(DESKTOP_NB_TEST_FILES_DONE)
 	@$(KILL_COMMAND) || true
 	$(if $(HEADLESS_BUILD),@pkill Xvfb,)
 	$(if $(wildcard $(ERROR_LOG)),@cat $(ERROR_LOG))
@@ -123,17 +114,6 @@ $(DESKTOP_TEST_FILES_DONE): $(PID_FILE)
 		@mkdir -p $(dir $@) && touch $@\
 		,\
 		@$(foreach done_file,$(DESKTOP_TEST_FILES_DONE),mkdir -p $(dir $(done_file)) && touch $(done_file) &&) true\
-	)
-
-$(DESKTOP_NB_TEST_FILES_DONE): export USER_INTERFACE = notebookbar
-$(DESKTOP_NB_TEST_FILES_DONE): $(PID_FILE)
-	$(if $(PARALLEL_BUILD),\
-		$(call run_desktop_tests,$(subst $(DESKTOP_NB_TRACK_FOLDER)/,,$(basename $@)),$(basename $@).log),\
-		$(call run_desktop_tests))
-	$(if $(PARALLEL_BUILD),\
-		@mkdir -p $(dir $@) && touch $@\
-		,\
-		@$(foreach done_file,$(DESKTOP_NB_TEST_FILES_DONE),mkdir -p $(dir $(done_file)) && touch $(done_file) &&) true\
 	)
 
 $(MULTIUSER_TESTS_DONE): $(PID_FILE) $(MOBILE_TEST_FILES_DONE)
@@ -328,7 +308,7 @@ endef
 # 2 - log (optional):	log file for cypress run, needed for parallel build only.
 # 3 - +env (optional):	additional env variables (will be appended to $(DESKTOP_ENV).
 define run_desktop_tests
-	@echo $(if $(1),"Running cypress desktop $(USER_INTERFACE) mode test: $(1)","Running cypress desktop $(USER_INTERFACE) mode tests...")
+	@echo $(if $(1),"Running cypress desktop mode test: $(1)","Running cypress desktop mode tests...")
 	@echo
 	$(eval ENV_EXTENDED=$(DESKTOP_ENV)$(if $(3),$(COMMA)$(3)))
 	$(if $(and $(PARALLEL_BUILD), $(1)),\

--- a/cypress_test/README
+++ b/cypress_test/README
@@ -35,20 +35,13 @@ To run cypress test cases selectively, you need to
 go in to the cypress_test folder first and run one of
 the following commands.
 
-To run all desktop tests:
+To run all desktop tests (this includes notebookbar UI related tests):
 
     make check-desktop
 
 To run all mobile tests:
 
     make check-mobile
-
-To run all notebookbar tests:
-
-    make USER_INTERFACE="notebookbar" check-desktop
-
-    Note: Currently all the test spec listed in cypress_test/plugins/whitelists.js
-          are supported for notebookbar
 
 To run one specific test suite of desktop tests,
 use spec argument with a relative path to
@@ -61,15 +54,6 @@ use spec argument with a relative path to
 cypress_test/integration_tests/mobile/:
 
     make check-mobile spec=writer/toolbar_spec.js
-
-To run one specific test suite of desktop notebookbar tests,
-use spec argument with a relative path to
-cypress_test/integration_tests/desktop/:
-
-    make USER_INTERFACE="notebookbar" check-desktop spec=writer/top_toolbar_spec.js
-
-    Note: Currently all the test spec listed in cypress_test/plugins/whitelists.js
-          are supported for notebookbar
 
 Running one specific test
 -------------------------
@@ -111,13 +95,6 @@ To open mobile tests in the test runner:
 
     make run-mobile
 
-To open desktop notebookbar tests in the test runner:
-
-    make USER_INTERFACE="notebookbar" run-desktop
-
-    Note: Currently all the test spec listed in cypress_test/plugins/whitelists.js
-          are supported for notebookbar
-
 To open one specific test suite of desktop tests,
 use spec argument with a relative path to
 cypress_test/integration_tests/desktop/:
@@ -129,15 +106,6 @@ use spec argument with a relative path to
 cypress_test/integration_tests/mobile/:
 
     make run-mobile spec=writer/toolbar_spec.js
-
-To open one specific test suite of desktop notebookbar tests,
-use spec argument with a relative path to
-cypress_test/integration_tests/desktop/:
-
-    make USER_INTERFACE="notebookbar" run-desktop spec=writer/top_toolbar_spec.js
-
-    Note: Currently all the test spec listed in cypress_test/plugins/whitelists.js
-          are supported for notebookbar
 
 During the build we run the tests with Chrome browser, so make sure
 you select Chrome browser on the GUI while checking tests.

--- a/cypress_test/plugins/index.js
+++ b/cypress_test/plugins/index.js
@@ -44,11 +44,6 @@ function plugin(on, config) {
 		config.defaultCommandTimeout = 10000;
 	}
 
-	if (process.env.USER_INTERFACE === 'notebookbar') {
-		config.env.USER_INTERFACE = 'notebookbar';
-		config.env.CYPRESS_INCLUDE_TAGS = 'tagnotebookbar';
-	}
-
 	on('file:preprocessor', tagify.tagify(config));
 
 	return config;


### PR DESCRIPTION
Change-Id: If07b5f54b60cd0d7a934f97973a487f103702581


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

