### PR TITLE
wsd: better detection of modification during a conflict

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -992,8 +992,13 @@ bool DocumentBroker::download(const std::shared_ptr<ClientSession>& session, con
                                  << ", Actual: " << fileInfo.getLastModifiedTime());
 
             _documentChangedInStorage = true;
-            const std::string message = isModified() ? "error: cmd=storage kind=documentconflict"
-                                                     : "close: documentconflict";
+            // Do not reload the document ("close: documentconflict") if there are
+            // any changes in the loaded document, either saved or unsaved.
+            const std::string message =
+                (_lastStorageAttrs.isUserModified() || _currentStorageAttrs.isUserModified() ||
+                 isPossiblyModified())
+                    ? "error: cmd=storage kind=documentconflict"
+                    : "close: documentconflict";
 
             session->sendTextFrame(message);
             broadcastMessage(message);
@@ -1991,8 +1996,12 @@ void DocumentBroker::handleUploadToStorageResponse(const StorageBase::UploadResu
     {
         LOG_ERR("PutFile says that Document [" << _docKey << "] changed in storage");
         _documentChangedInStorage = true;
-        const std::string message
-            = isPossiblyModified() ? "error: cmd=storage kind=documentconflict" : "close: documentconflict";
+        // Do not reload the document ("close: documentconflict") if there are
+        // any changes in the loaded document, either saved or unsaved.
+        const std::string message = (_lastStorageAttrs.isUserModified() ||
+                                     _currentStorageAttrs.isUserModified() || isPossiblyModified())
+                                        ? "error: cmd=storage kind=documentconflict"
+                                        : "close: documentconflict";
 
         const std::size_t activeClients = broadcastMessage(message);
         broadcastSaveResult(false, "Conflict: Document changed in storage",


### PR DESCRIPTION
When we detect document change in storage, we have to
either prompt the user(s) to either reload from storage,
discarding their own changes, or force saving their
changes and clobber the version in storage.

However this implies that the loaded document was
modified. Because otherwise, we do reload the
document from storage, automatically.
This change improves the detection logic to take
into account not just the saved state of the
document, but also the upload state. That is,
if a previous modification was not uploaded yet,
then the user does have changes that they need to
consider to discard or save.

Change-Id: I5f03593bebc5b565fc19e78562896bcdcb6112e2
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
