### PR TITLE
Fix iOS build breakage due to Poco replacement changes

### DIFF
--- a/browser/src/layer/tile/CanvasSectionContainer.ts
+++ b/browser/src/layer/tile/CanvasSectionContainer.ts
@@ -1595,6 +1595,22 @@ class CanvasSectionContainer {
 		this.canvas.width = newWidth;
 		this.canvas.height = newHeight;
 
+		// Partial fix for #5876 reduce size if canvas context is null
+		// WKWebView has a hard limit on the number of bytes of canvas
+		// context memory that can be allocated. Canvas with sizes that
+		// are too large will return a null context so reduce the size
+		// of the canvas until a non-null context is obtained.
+		if ((window as any).ThisIsTheiOSApp) {
+			this.context = this.canvas.getContext('2d', { alpha: false });
+			while (!this.context && this.canvas.width >= 2 && this.canvas.height >= 2) {
+				this.canvas.width /= 2;
+				this.canvas.height /= 2;
+				this.context = this.canvas.getContext('2d', { alpha: false });
+			}
+			for (var i: number = 0; i < this.sections.length; i++)
+				this.sections[i].context = this.context;
+		}
+
 		// CSS pixels can be fractional, but need to round to the same real pixels
 		var cssWidth: number = newWidth / app.dpiScale; // NB. beware
 		var cssHeight: number = newHeight / app.dpiScale;

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -6651,6 +6651,19 @@ L.CanvasTileLayer = L.Layer.extend({
 		return new L.LatLngBounds(nw, se);
 	},
 
+	_reclaimTileCanvasMemory: function (tile) {
+		// Partial fix for #5876 allow immediate reuse of canvas context memory
+		// WKWebView has a hard limit on the number of bytes of canvas
+		// context memory that can be allocated. Reducing the canvas
+		// size to zero is a way to reduce the number of bytes counted
+		// against this limit.
+		if (window.ThisIsTheiOSApp && tile && tile.el && tile.el instanceof HTMLCanvasElement) {
+			tile.el.width = 0;
+			tile.el.height = 0;
+			delete tile.el;
+		}
+	},
+
 	_removeTile: function (key) {
 		var tile = this._tiles[key];
 		if (!tile) { return; }
@@ -6743,6 +6756,32 @@ L.CanvasTileLayer = L.Layer.extend({
 
 		var imgData;
 		var ctx = canvas.getContext('2d');
+
+		// Partial fix for issue #5876 discard excess canvas contexts
+		// WKWebView has a hardcoded memory limit for all canvas contexts
+		// so if canvas.getContext('2d') returns null, convert the canvas
+		// of other tiles to an image until canvas.getContext('2d') succeeds.
+		if (!ctx && window.ThisIsTheiOSApp) {
+			for (var key in this._tiles) {
+				var value = this._tiles[key];
+				if (value && value !== tile && value.el && value.el instanceof HTMLCanvasElement) {
+					var imageSrc = value.el.toDataURL();
+					this._reclaimTileCanvasMemory(value);
+					value.el = document.createElement('img');
+					value.el.src = imageSrc;
+					if (!(value._invalidCount > 0) && this._tileCache[key])
+						this._tileCache[key] = value.el;
+					ctx = canvas.getContext('2d');
+					if (ctx)
+						break;
+				}
+			}
+
+			// If we can't free up enough canvas context, there is nothing
+			// more we can do. Is there a better way to handle this?
+			if (!ctx)
+				return;
+		}
 
 		while (offset < allDeltas.length)
 		{

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -3463,6 +3463,7 @@ private:
                 << Util::dumpHex(std::string(data.data(), std::min(data.size(), 256UL))));
 #endif
 
+#if !MOBILEAPP
         // Consume the incoming data by parsing and processing the body.
         http::Request request;
         const int64_t read = request.readData(data.data(), data.size());
@@ -3482,6 +3483,9 @@ private:
 
         // Remove consumed data.
         data.eraseFirst(read);
+#else
+        Poco::Net::HTTPRequest request;
+#endif
 
         try
         {
@@ -3551,7 +3555,6 @@ private:
 #else
             pid_t pid = 100;
             std::string jailId = "jail";
-            LOG_ASSERT_MSG(socket->getInBuffer().empty(), "Unexpected data in prisoner socket");
             socket->getInBuffer().clear();
 #endif
             LOG_TRC("Calling make_shared<ChildProcess>, for NewChildren?");


### PR DESCRIPTION
iOS (and maybe Android) do not compile or use the HttpRequest class. The socket in these apps is between two threads in the same process, not a web browser and a web server so no HTTP headers are passed over the socket.

From what I can see, on iOS this call only gets called once when a document is opened and the socket is empty. Which makes sense to me since on iOS we use WKWebView's special JavaScript streams to send messages to the server code.