### PR TITLE
linking api: improvements

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -309,7 +309,7 @@ bool ChildSession::_handleInput(const char *buffer, int length)
         constexpr int height = 630;
 
         // Unclear what this "zoom" level means
-        constexpr float zoom = 1;
+        constexpr float zoom = 2;
 
         // The magic number 15 is the number of twips per pixel for a resolution of 96 pixels per
         // inch, which apparently is some "standard".

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -2055,6 +2055,22 @@ bool ClientSession::handleKitToClientMessage(const std::shared_ptr<Message>& pay
             handleTileInvalidation(firstLine, docBroker);
             return ret;
         }
+        else if (tokens.equals(0, "statechanged:"))
+        {
+            if (_thumbnailSession)
+            {
+                bool cursorAlreadyAtTargetPosition = getThumbnailTarget().empty();
+                if (cursorAlreadyAtTargetPosition)
+                {
+                    // fallback in case we setup target at first character in the text document,
+                    // or not existing target and we will not enter invalidatecursor second time
+                    std::ostringstream renderThumbnailCmd;
+                    auto position = getThumbnailPosition();
+                    renderThumbnailCmd << "getthumbnail x=" << position.first << " y=" << position.second;
+                    docBroker->forwardToChild(client_from_this(), renderThumbnailCmd.str());
+                }
+            }
+        }
         else if (tokens.equals(0, "invalidatecursor:"))
         {
             assert(firstLine.size() == payload->size() &&
@@ -2084,6 +2100,8 @@ bool ClientSession::handleKitToClientMessage(const std::shared_ptr<Message>& pay
                     // session used for thumbnailing and target already was set
                     if (_thumbnailSession)
                     {
+                        setThumbnailPosition(std::make_pair(x, y));
+
                         bool cursorAlreadyAtTargetPosition = getThumbnailTarget().empty();
                         if (cursorAlreadyAtTargetPosition)
                         {

--- a/wsd/ClientSession.hpp
+++ b/wsd/ClientSession.hpp
@@ -218,6 +218,10 @@ public:
 
     const std::string& getThumbnailTarget() const { return _thumbnailTarget; }
 
+    void setThumbnailPosition(const std::pair<int, int>& pos) { _thumbnailPosition = pos; }
+
+    const std::pair<int, int>& getThumbnailPosition() const { return _thumbnailPosition; }
+
     bool thumbnailSession() { return _thumbnailSession; }
 
     /// Do we recognize this clipboard ?
@@ -377,6 +381,9 @@ private:
 
     /// Target used for thumbnail rendering
     std::string _thumbnailTarget;
+
+    // Position used for thumbnail rendering
+    std::pair<int, int> _thumbnailPosition;
 
     /// Rotating clipboard remote access identifiers - protected by GlobalSessionMapMutex
     std::string _clipboardKeys[2];


### PR DESCRIPTION
Fixes  https://github.com/CollaboraOnline/online/issues/6229

- renders preview with zoom so we don't produce thumbnail with only half width content in case of writer documents
- avoids infinite response time for rendering requests in case of not-existing targets, or first character in document