### PR TITLE
Show document loading error popup

### DIFF
--- a/browser/src/control/Control.LokDialog.js
+++ b/browser/src/control/Control.LokDialog.js
@@ -153,7 +153,7 @@ L.Control.LokDialog = L.Control.extend({
 
 	_docLoaded: function(e) {
 		if (!e.status) {
-			$('.lokdialog_container').remove();
+			$('.lokdialog_container:not(.jsdialog-container)').remove();
 			$('.lokdialogchild-canvas').remove();
 		}
 	},


### PR DESCRIPTION
This fixes regression from popups rework.
Run collabora online, try to open not existing document. You should see error: "Well, this is embarrassing..."