### PR TITLE
Sidebar calc Alignment fix button size of align icons

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -289,8 +289,8 @@ button#button2.ui-pushbutton.jsdialog.sidebar {
 	height: auto;
 }
 
-/* fixes sidebar width in calc (textorientbox, alignment buttons were too big) */
-#AlignmentPropertyPanel button {
+/* fixes sidebar width in calc (textorientbox) */
+#textorientbox button {
 	min-width: 32px;
 	width: 32px;
 	margin: 0 2px;


### PR DESCRIPTION
#### Sidebar calc

| before | after |
| ---------- | ------- |
| ![Screenshot_20230519_113538](https://github.com/CollaboraOnline/online/assets/8517736/c22025a2-72fa-41fe-8f1b-50c40fe0ec45) | ![Screenshot_20230519_113503](https://github.com/CollaboraOnline/online/assets/8517736/86674bbf-78ba-4327-a1ee-f72362739ac1) |

The Alignment icons (Align left, right, center, top, bottom, ... ) in every other cool app use `--btn-size` icon width/height, only at calc the size increase to 32px which cause the issue, that the 9 buttons are to large for the sidebar.

Change request is to use the correct size for the Alignment icons and ONLY `textorientbox` buttons use the 32px size.

Change-Id: I954c7885946dfd4e13261622673d1b97ef59001c