### PR TITLE
Sidebar: Align everything to start and remove unnecessary css

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -94,10 +94,8 @@ img.sidebar.ui-image {
 	line-height: var(--default-height);
 }
 
-#fontheight,
-#AlignmentPropertyPanel #textorientbox,
 .sidebar.ui-grid.ui-grid-cell > div {
-	justify-content: end;
+	justify-content: start;
 	display: flex;
 }
 
@@ -289,10 +287,13 @@ button#button2.ui-pushbutton.jsdialog.sidebar {
 }
 
 /* fixes sidebar width in calc (textorientbox) */
+#textorientbox {
+	grid-template-columns: repeat(auto-fill, minmax(32px, 1fr));
+	grid-gap: inherit;
+}
 #textorientbox button {
-	min-width: 32px;
-	width: 32px;
-	margin: 0 2px;
+	min-width: auto;
+	width: auto;
 }
 
 


### PR DESCRIPTION
Better to align everything to start so if the components differ in
width they will still be aligned (as opposed to be laid out in a staircase)

This is a follow up from 1bfbdf807208b98be56aa558f749e32c7a67acdf coming with
the following PR https://github.com/CollaboraOnline/online/pull/6389

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ic607567d30656cc122f9cbfd71bd3d910ebfe9bf
