### PR TITLE
 Speed-up callbacks, issue #4837 

### DIFF
--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -367,11 +367,11 @@ int SocketPoll::poll(int64_t timeoutMaxMicroS)
         // Clear the data.
 #if !MOBILEAPP
         int dump[32];
-        dump[0] = ::read(_wakeup[0], &dump, sizeof(dump));
+        dump[0] = ::read(_wakeup[i], &dump, sizeof(dump));
         LOG_TRC("Wakup pipe read " << dump[0] << " bytes");
 #else
         LOG_TRC("Wakeup pipe read");
-        int dump = fakeSocketRead(_wakeup[0], &dump, sizeof(dump));
+        int dump = fakeSocketRead(_wakeup[i], &dump, sizeof(dump));
 #endif
 
         std::vector<CallbackFn> invoke;

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -614,6 +614,7 @@ public:
             }
         }
 #endif
+    if (!_newSockets.empty() || !_newCallbacks.empty())
         wakeup();
     }
 
@@ -697,7 +698,6 @@ public:
             LOG_WRN("Waking up dead poll thread ["
                     << _name << "], started: " << (_threadStarted ? "true" : "false")
                     << ", finished: " << _threadFinished);
-
         wakeup(_wakeup[1]);
     }
 
@@ -719,7 +719,8 @@ public:
 
             std::lock_guard<std::mutex> lock(_mutex);
             _newSockets.emplace_back(std::move(newSocket));
-            wakeup();
+            if (!_newSockets.empty() || !_newCallbacks.empty())
+                wakeup();
         }
     }
 
@@ -746,9 +747,8 @@ public:
     void addCallback(const CallbackFn& fn)
     {
         std::lock_guard<std::mutex> lock(_mutex);
-        bool wasEmpty = _newCallbacks.empty();
         _newCallbacks.emplace_back(fn);
-        if (wasEmpty)
+        if (!_newSockets.empty() || !_newCallbacks.empty())
             wakeup();
     }
 


### PR DESCRIPTION
* Resolves: #4837
* Target version: master 

### Summary
Changes:

    condition on _newsockets and _newcallbacks --> Inside wakeup function
    Use loop to read Wakeup pipe inside poll function --> in socket.cpp 

### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

