### PR TITLE
Fixes: Sidebar icons are cut off

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -261,10 +261,6 @@ button#button2.ui-pushbutton.jsdialog.sidebar {
 	left: -10px;
 }
 
-#ParaPropertyPanel.sidebar.ui-grid #indentfieldbox {
-	width: 158px;
-}
-
 #TableEditPanel.sidebar.ui-grid #delete_label {
 	width: 118px;
 }


### PR DESCRIPTION
This hard coded width is not needed and was imposing that width value
to #indentfieldbox even if there is other elements present resulting
in the whole container being bigger than the sidebar itself

This issue became more evident with
https://github.com/CollaboraOnline/online/commit/27fddae9c6b3fe0dc0c948bb132034f9ffa38012 (even
though it's not related to the bug but rather exposed it even more)

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I90e684b395b950e4cc25a96a9875d4702016411d
