### PR TITLE
feat: Add UITheme option for light/dark to ui_defaults

### DIFF
--- a/browser/html/cool.html.m4
+++ b/browser/html/cool.html.m4
@@ -9,7 +9,7 @@ m4_define(_YEAR_,m4_esyscmd(date +%Y|tr -d '\n'))
 <!-- saved from url=(0054)http://leafletjs.com/examples/quick-start-example.html -->
 m4_ifelse(IOSAPP,[true],
 <!-- Related to issue #5841: the iOS app sets the base text direction via the "dir" parameter -->
-<html dir="" style="height:100%"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<html dir="" style="height:100%"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8" data-theme="%UI_THEME%">
 ,
 <html %UI_RTL_SETTINGS% style="height:100%"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 )m4_dnl

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -83,7 +83,7 @@ L.Control.UIManager = L.Control.extend({
 	},
 
 	getDarkModeState: function() {
-		return this.getSavedStateOrDefault('darkTheme', false);
+		return this.getSavedStateOrDefault('darkTheme', window.uiDefaults['darkTheme'] ?  window.uiDefaults['darkTheme'] : false);
 	},
 
 	toggleDarkMode: function() {

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -1306,6 +1306,10 @@ L.Control.UIManager = L.Control.extend({
 			if (window.uiDefaults && window.uiDefaults[docType])
 				retval = window.uiDefaults[docType][name];
 
+			// check UIDefaults root without limiting to the doctype
+			if (retval === undefined || retval === null)
+				retval = window.uiDefaults[name];
+
 			if (retval === undefined || retval === null) {
 				if (forcedDefault !== undefined)
 					return forcedDefault;

--- a/browser/src/core/LOUtil.js
+++ b/browser/src/core/LOUtil.js
@@ -116,7 +116,7 @@ L.LOUtil = {
 		var defaultImageURL = this.getURL('images/' + imgName);
 		if (window.isLocalStorageAllowed) {
 			var state = localStorage.getItem('UIDefaults_' + docType + '_darkTheme');
-			if (state && (/true/).test(state.toLowerCase())) {
+			if ((state && (/true/).test(state.toLowerCase())) || (state === null &&  window.uiDefaults['darkTheme'])) {
 				return this.getURL('images/dark/' + imgName);
 			}
 		}

--- a/test/WhiteBoxTests.cpp
+++ b/test/WhiteBoxTests.cpp
@@ -1028,20 +1028,21 @@ void WhiteBoxTests::testUIDefaults()
     constexpr auto testname = __func__;
 
     std::string uiMode;
+    std::string uiTheme;
 
     LOK_ASSERT_EQUAL(std::string("{\"uiMode\":\"classic\"}"),
-                     FileServerRequestHandler::uiDefaultsToJSON("UIMode=classic;huh=bleh;", uiMode));
+                     FileServerRequestHandler::uiDefaultsToJSON("UIMode=classic;huh=bleh;", uiMode, uiTheme));
     LOK_ASSERT_EQUAL(std::string("classic"), uiMode);
 
     LOK_ASSERT_EQUAL(std::string("{\"spreadsheet\":{\"ShowSidebar\":false},\"text\":{\"ShowRuler\":true}}"),
-                     FileServerRequestHandler::uiDefaultsToJSON("TextRuler=true;SpreadsheetSidebar=false", uiMode));
+                     FileServerRequestHandler::uiDefaultsToJSON("TextRuler=true;SpreadsheetSidebar=false", uiMode, uiTheme));
     LOK_ASSERT_EQUAL(std::string(""), uiMode);
 
     LOK_ASSERT_EQUAL(std::string("{\"presentation\":{\"ShowStatusbar\":false},\"spreadsheet\":{\"ShowSidebar\":false},\"text\":{\"ShowRuler\":true},\"uiMode\":\"notebookbar\"}"),
-                     FileServerRequestHandler::uiDefaultsToJSON(";;UIMode=notebookbar;;PresentationStatusbar=false;;TextRuler=true;;bah=ugh;;SpreadsheetSidebar=false", uiMode));
+                     FileServerRequestHandler::uiDefaultsToJSON(";;UIMode=notebookbar;;PresentationStatusbar=false;;TextRuler=true;;bah=ugh;;SpreadsheetSidebar=false", uiMode, uiTheme));
 
     LOK_ASSERT_EQUAL(std::string("{\"drawing\":{\"ShowStatusbar\":true},\"presentation\":{\"ShowStatusbar\":false},\"spreadsheet\":{\"ShowSidebar\":false},\"text\":{\"ShowRuler\":true},\"uiMode\":\"notebookbar\"}"),
-                     FileServerRequestHandler::uiDefaultsToJSON(";;UIMode=notebookbar;;PresentationStatusbar=false;;TextRuler=true;;bah=ugh;;SpreadsheetSidebar=false;;DrawingStatusbar=true", uiMode));
+                     FileServerRequestHandler::uiDefaultsToJSON(";;UIMode=notebookbar;;PresentationStatusbar=false;;TextRuler=true;;bah=ugh;;SpreadsheetSidebar=false;;DrawingStatusbar=true", uiMode, uiTheme));
 
     LOK_ASSERT_EQUAL(std::string("notebookbar"), uiMode);
 }

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -929,6 +929,8 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
 
     std::string responseRoot = cnxDetails.getResponseRoot();
     std::string userInterfaceMode;
+    std::string userInterfaceTheme;
+
 
     Poco::replaceInPlace(preprocess, std::string("%ACCESS_TOKEN%"), escapedAccessToken);
     Poco::replaceInPlace(preprocess, std::string("%ACCESS_TOKEN_TTL%"), std::to_string(tokenTtl));
@@ -937,7 +939,8 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     Poco::replaceInPlace(preprocess, std::string("%VERSION%"), std::string(COOLWSD_VERSION_HASH));
     Poco::replaceInPlace(preprocess, std::string("%COOLWSD_VERSION%"), std::string(COOLWSD_VERSION));
     Poco::replaceInPlace(preprocess, std::string("%SERVICE_ROOT%"), responseRoot);
-    Poco::replaceInPlace(preprocess, std::string("%UI_DEFAULTS%"), uiDefaultsToJSON(uiDefaults, userInterfaceMode));
+    Poco::replaceInPlace(preprocess, std::string("%UI_DEFAULTS%"), uiDefaultsToJSON(uiDefaults, userInterfaceMode, userInterfaceTheme));
+    Poco::replaceInPlace(preprocess, std::string("%UI_THEME%"), userInterfaceTheme);
     Poco::replaceInPlace(preprocess, std::string("%POSTMESSAGE_ORIGIN%"), escapedPostmessageOrigin);
     Poco::replaceInPlace(preprocess, std::string("%CHECK_FILE_INFO_OVERRIDE%"),
                          checkFileInfoToJSON(checkfileinfo_override));

--- a/wsd/FileServer.hpp
+++ b/wsd/FileServer.hpp
@@ -37,7 +37,7 @@ class FileServerRequestHandler
     /// UIMode=classic;TextRuler=true;PresentationStatusbar=false
     /// that is passed as "ui_defaults" hidden input during the iframe setup.
     /// Also returns the UIMode from uiDefaults in uiMode output param
-    static std::string uiDefaultsToJSON(const std::string& uiDefaults, std::string& uiMode);
+    static std::string uiDefaultsToJSON(const std::string& uiDefaults, std::string& uiMode, std::string& uiTheme);
 
     static std::string checkFileInfoToJSON(const std::string& checkfileFileInfo);
 

--- a/wsd/FileServerUtil.cpp
+++ b/wsd/FileServerUtil.cpp
@@ -13,7 +13,7 @@
 
 #include <Poco/JSON/Object.h>
 
-std::string FileServerRequestHandler::uiDefaultsToJSON(const std::string& uiDefaults, std::string& uiMode)
+std::string FileServerRequestHandler::uiDefaultsToJSON(const std::string& uiDefaults, std::string& uiMode, std::string& uiTheme)
 {
     static std::string previousUIDefaults;
     static std::string previousJSON("{}");
@@ -33,6 +33,7 @@ std::string FileServerRequestHandler::uiDefaultsToJSON(const std::string& uiDefa
     Poco::JSON::Object drawingDefs;
 
     uiMode = "";
+    uiTheme = "light";
     StringVector tokens(StringVector::tokenize(uiDefaults, ';'));
     for (const auto& token : tokens)
     {
@@ -57,6 +58,13 @@ std::string FileServerRequestHandler::uiDefaultsToJSON(const std::string& uiDefa
                 LOG_ERR("unknown UIMode value " << keyValue[1]);
 
             continue;
+        }
+
+        // detect the UITheme default, light or dark
+        if (keyValue.equals(0, "UITheme"))
+        {
+                json.set("darkTheme", keyValue.equals(1, "dark"));
+                uiTheme = keyValue[1];
         }
         if (keyValue.equals(0, "SaveAsMode"))
         {


### PR DESCRIPTION
Signed-off-by: Julius Härtl <jus@bitgrid.net>
Change-Id: Ief028dcec0daa2ae448f83df993e0e5ade594a7c


* Resolves: #6432
* Target version: master 

### Summary

This adds the option to provide a default theme through the form parameters ui_defaults. As the frontend code currently only uses a boolean flag I mapped just UITheme=dark to enable the dark mode, all other values will use light by default.

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

