### PR TITLE
fix: Avoid important property on all classic toolbar w2ui icons

### DIFF
--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -602,703 +602,703 @@ button.leaflet-control-search-next
 	color: var(--color-text-dark);
 }
 
-.w2ui-icon.basicshapes_rectangle { background: url('images/lc_rect.svg') no-repeat center !important; }
-.w2ui-icon.basicshapes_round-rectangle { background: url('images/lc_rect_rounded.svg') no-repeat center !important; }
-.w2ui-icon.basicshapes_quadrat { background: url('images/lc_square.svg') no-repeat center !important; }
-.w2ui-icon.basicshapes_round-quadrat { background: url('images/lc_basicshapes.round-quadrat.svg') no-repeat center !important; }
-.w2ui-icon.basicshapes_circle { background: url('images/lc_circle.svg') no-repeat center !important; }
-.w2ui-icon.basicshapes_ellipse { background: url('images/lc_ellipse.svg') no-repeat center !important; }
-.w2ui-icon.basicshapes_circle-pie { background: url('images/lc_pie.svg') no-repeat center !important; }
-.w2ui-icon.basicshapes_isosceles-triangle { background: url('images/lc_basicshapes.isosceles-triangle.svg') no-repeat center !important; }
-.w2ui-icon.basicshapes_right-triangle { background: url('images/lc_basicshapes.right-triangle.svg') no-repeat center !important; }
-.w2ui-icon.basicshapes_trapezoid { background: url('images/lc_basicshapes.trapezoid.svg') no-repeat center !important; }
-.w2ui-icon.basicshapes_diamond { background: url('images/lc_basicshapes.diamond.svg') no-repeat center !important; }
-.w2ui-icon.basicshapes_parallelogram { background: url('images/lc_flowchartshapes.flowchart-data.svg') no-repeat center !important; }
-.w2ui-icon.basicshapes_pentagon { background: url('images/lc_basicshapes.pentagon.svg') no-repeat center !important; }
-.w2ui-icon.basicshapes_hexagon { background: url('images/lc_basicshapes.hexagon.svg') no-repeat center !important; }
-.w2ui-icon.basicshapes_octagon { background: url('images/lc_basicshapes.octagon.svg') no-repeat center !important; }
-.w2ui-icon.basicshapes_cross { background: url('images/lc_basicshapes.cross.svg') no-repeat center !important; }
-.w2ui-icon.basicshapes_ring { background: url('images/lc_basicshapes.ring.svg') no-repeat center !important; }
-.w2ui-icon.basicshapes_block-arc { background: url('images/lc_basicshapes.block-arc.svg') no-repeat center !important; }
-.w2ui-icon.basicshapes_can { background: url('images/lc_basicshapes.can.svg') no-repeat center !important; }
-.w2ui-icon.basicshapes_cube { background: url('images/lc_basicshapes.cube.svg') no-repeat center !important; }
-.w2ui-icon.basicshapes_paper { background: url('images/lc_basicshapes.paper.svg') no-repeat center !important; }
-.w2ui-icon.basicshapes_frame { background: url('images/lc_rect_unfilled.svg') no-repeat center !important; }
+.w2ui-icon.basicshapes_rectangle { background: url('images/lc_rect.svg') no-repeat center; }
+.w2ui-icon.basicshapes_round-rectangle { background: url('images/lc_rect_rounded.svg') no-repeat center; }
+.w2ui-icon.basicshapes_quadrat { background: url('images/lc_square.svg') no-repeat center; }
+.w2ui-icon.basicshapes_round-quadrat { background: url('images/lc_basicshapes.round-quadrat.svg') no-repeat center; }
+.w2ui-icon.basicshapes_circle { background: url('images/lc_circle.svg') no-repeat center; }
+.w2ui-icon.basicshapes_ellipse { background: url('images/lc_ellipse.svg') no-repeat center; }
+.w2ui-icon.basicshapes_circle-pie { background: url('images/lc_pie.svg') no-repeat center; }
+.w2ui-icon.basicshapes_isosceles-triangle { background: url('images/lc_basicshapes.isosceles-triangle.svg') no-repeat center; }
+.w2ui-icon.basicshapes_right-triangle { background: url('images/lc_basicshapes.right-triangle.svg') no-repeat center; }
+.w2ui-icon.basicshapes_trapezoid { background: url('images/lc_basicshapes.trapezoid.svg') no-repeat center; }
+.w2ui-icon.basicshapes_diamond { background: url('images/lc_basicshapes.diamond.svg') no-repeat center; }
+.w2ui-icon.basicshapes_parallelogram { background: url('images/lc_flowchartshapes.flowchart-data.svg') no-repeat center; }
+.w2ui-icon.basicshapes_pentagon { background: url('images/lc_basicshapes.pentagon.svg') no-repeat center; }
+.w2ui-icon.basicshapes_hexagon { background: url('images/lc_basicshapes.hexagon.svg') no-repeat center; }
+.w2ui-icon.basicshapes_octagon { background: url('images/lc_basicshapes.octagon.svg') no-repeat center; }
+.w2ui-icon.basicshapes_cross { background: url('images/lc_basicshapes.cross.svg') no-repeat center; }
+.w2ui-icon.basicshapes_ring { background: url('images/lc_basicshapes.ring.svg') no-repeat center; }
+.w2ui-icon.basicshapes_block-arc { background: url('images/lc_basicshapes.block-arc.svg') no-repeat center; }
+.w2ui-icon.basicshapes_can { background: url('images/lc_basicshapes.can.svg') no-repeat center; }
+.w2ui-icon.basicshapes_cube { background: url('images/lc_basicshapes.cube.svg') no-repeat center; }
+.w2ui-icon.basicshapes_paper { background: url('images/lc_basicshapes.paper.svg') no-repeat center; }
+.w2ui-icon.basicshapes_frame { background: url('images/lc_rect_unfilled.svg') no-repeat center; }
 
-.w2ui-icon.line { background: url('images/lc_line.svg') no-repeat center !important; }
+.w2ui-icon.line { background: url('images/lc_line.svg') no-repeat center; }
 
-.w2ui-icon.symbolshapes { background: url('images/lc_symbolshapes.svg') no-repeat center !important; }
-.w2ui-icon.symbolshapes_sun { background: url('images/lc_symbolshapes.sun.svg') no-repeat center !important; }
-.w2ui-icon.symbolshapes_moon { background: url('images/lc_symbolshapes.moon.svg') no-repeat center !important; }
-.w2ui-icon.symbolshapes_lightning { background: url('images/lc_symbolshapes.lightning.svg') no-repeat center !important; }
-.w2ui-icon.symbolshapes_heart { background: url('images/lc_symbolshapes.heart.svg') no-repeat center !important; }
-.w2ui-icon.symbolshapes_flower { background: url('images/lc_symbolshapes.flower.svg') no-repeat center !important; }
-.w2ui-icon.symbolshapes_cloud { background: url('images/lc_symbolshapes.cloud.svg') no-repeat center !important; }
-.w2ui-icon.symbolshapes_forbidden { background: url('images/lc_symbolshapes.forbidden.svg') no-repeat center !important; }
-.w2ui-icon.symbolshapes_puzzle { background: url('images/lc_symbolshapes.puzzle.svg') no-repeat center !important; }
-.w2ui-icon.symbolshapes_bracket-pair { background: url('images/lc_symbolshapes.bracket-pair.svg') no-repeat center !important; }
-.w2ui-icon.symbolshapes_left-bracket { background: url('images/lc_symbolshapes.left-bracket.svg') no-repeat center !important; }
-.w2ui-icon.symbolshapes_right-bracket { background: url('images/lc_symbolshapes.right-bracket.svg') no-repeat center !important; }
-.w2ui-icon.symbolshapes_brace-pair { background: url('images/lc_symbolshapes.brace-pair.svg') no-repeat center !important; }
-.w2ui-icon.symbolshapes_left-brace { background: url('images/lc_symbolshapes.left-brace.svg') no-repeat center !important; }
-.w2ui-icon.symbolshapes_right-brace { background: url('images/lc_symbolshapes.right-brace.svg') no-repeat center !important; }
-.w2ui-icon.symbolshapes_quad-bevel { background: url('images/lc_symbolshapes.right-brace.svg') no-repeat center !important; }
-.w2ui-icon.symbolshapes_octagon-bevel { background: url('images/lc_symbolshapes.octagon-bevel.svg') no-repeat center !important; }
-.w2ui-icon.symbolshapes_diamond-bevel { background: url('images/lc_symbolshapes.diamond-bevel.svg') no-repeat center !important; }
+.w2ui-icon.symbolshapes { background: url('images/lc_symbolshapes.svg') no-repeat center; }
+.w2ui-icon.symbolshapes_sun { background: url('images/lc_symbolshapes.sun.svg') no-repeat center; }
+.w2ui-icon.symbolshapes_moon { background: url('images/lc_symbolshapes.moon.svg') no-repeat center; }
+.w2ui-icon.symbolshapes_lightning { background: url('images/lc_symbolshapes.lightning.svg') no-repeat center; }
+.w2ui-icon.symbolshapes_heart { background: url('images/lc_symbolshapes.heart.svg') no-repeat center; }
+.w2ui-icon.symbolshapes_flower { background: url('images/lc_symbolshapes.flower.svg') no-repeat center; }
+.w2ui-icon.symbolshapes_cloud { background: url('images/lc_symbolshapes.cloud.svg') no-repeat center; }
+.w2ui-icon.symbolshapes_forbidden { background: url('images/lc_symbolshapes.forbidden.svg') no-repeat center; }
+.w2ui-icon.symbolshapes_puzzle { background: url('images/lc_symbolshapes.puzzle.svg') no-repeat center; }
+.w2ui-icon.symbolshapes_bracket-pair { background: url('images/lc_symbolshapes.bracket-pair.svg') no-repeat center; }
+.w2ui-icon.symbolshapes_left-bracket { background: url('images/lc_symbolshapes.left-bracket.svg') no-repeat center; }
+.w2ui-icon.symbolshapes_right-bracket { background: url('images/lc_symbolshapes.right-bracket.svg') no-repeat center; }
+.w2ui-icon.symbolshapes_brace-pair { background: url('images/lc_symbolshapes.brace-pair.svg') no-repeat center; }
+.w2ui-icon.symbolshapes_left-brace { background: url('images/lc_symbolshapes.left-brace.svg') no-repeat center; }
+.w2ui-icon.symbolshapes_right-brace { background: url('images/lc_symbolshapes.right-brace.svg') no-repeat center; }
+.w2ui-icon.symbolshapes_quad-bevel { background: url('images/lc_symbolshapes.right-brace.svg') no-repeat center; }
+.w2ui-icon.symbolshapes_octagon-bevel { background: url('images/lc_symbolshapes.octagon-bevel.svg') no-repeat center; }
+.w2ui-icon.symbolshapes_diamond-bevel { background: url('images/lc_symbolshapes.diamond-bevel.svg') no-repeat center; }
 
-.w2ui-icon.arrowshapes_left-arrow { background: url('images/lc_arrowshapes.left-arrow.svg') no-repeat center !important; }
-.w2ui-icon.arrowshapes_right-arrow { background: url('images/lc_arrowshapes.right-arrow.svg') no-repeat center !important; }
-.w2ui-icon.arrowshapes_up-arrow { background: url('images/lc_arrowshapes.up-arrow.svg') no-repeat center !important; }
-.w2ui-icon.arrowshapes_down-arrow { background: url('images/lc_arrowshapes.down-arrow.svg') no-repeat center !important; }
-.w2ui-icon.arrowshapes_left-right-arrow { background: url('images/lc_arrowshapes.svg') no-repeat center !important; }
-.w2ui-icon.arrowshapes_up-down-arrow { background: url('images/lc_arrowshapes.up-down-arrow.svg') no-repeat center !important; }
+.w2ui-icon.arrowshapes_left-arrow { background: url('images/lc_arrowshapes.left-arrow.svg') no-repeat center; }
+.w2ui-icon.arrowshapes_right-arrow { background: url('images/lc_arrowshapes.right-arrow.svg') no-repeat center; }
+.w2ui-icon.arrowshapes_up-arrow { background: url('images/lc_arrowshapes.up-arrow.svg') no-repeat center; }
+.w2ui-icon.arrowshapes_down-arrow { background: url('images/lc_arrowshapes.down-arrow.svg') no-repeat center; }
+.w2ui-icon.arrowshapes_left-right-arrow { background: url('images/lc_arrowshapes.svg') no-repeat center; }
+.w2ui-icon.arrowshapes_up-down-arrow { background: url('images/lc_arrowshapes.up-down-arrow.svg') no-repeat center; }
 
-.w2ui-icon.arrowshapes_up-right-arrow { background: url('images/lc_arrowshapes.up-right-arrow.svg') no-repeat center !important; }
-.w2ui-icon.arrowshapes_up-right-down-arrow { background: url('images/lc_arrowshapes.up-right-down-arrow.svg') no-repeat center !important; }
-.w2ui-icon.arrowshapes_quad-arrow { background: url('images/lc_arrowshapes.quad-arrow.svg') no-repeat center !important; }
-.w2ui-icon.arrowshapes_corner-right-arrow { background: url('images/lc_arrowshapes.corner-right-arrow.svg') no-repeat center !important; }
-.w2ui-icon.arrowshapes_split-arrow { background: url('images/lc_arrowshapes.split-arrow.svg') no-repeat center !important; }
-.w2ui-icon.arrowshapes_striped-right-arrow { background: url('images/lc_arrowshapes.striped-right-arrow.svg') no-repeat center !important; }
+.w2ui-icon.arrowshapes_up-right-arrow { background: url('images/lc_arrowshapes.up-right-arrow.svg') no-repeat center; }
+.w2ui-icon.arrowshapes_up-right-down-arrow { background: url('images/lc_arrowshapes.up-right-down-arrow.svg') no-repeat center; }
+.w2ui-icon.arrowshapes_quad-arrow { background: url('images/lc_arrowshapes.quad-arrow.svg') no-repeat center; }
+.w2ui-icon.arrowshapes_corner-right-arrow { background: url('images/lc_arrowshapes.corner-right-arrow.svg') no-repeat center; }
+.w2ui-icon.arrowshapes_split-arrow { background: url('images/lc_arrowshapes.split-arrow.svg') no-repeat center; }
+.w2ui-icon.arrowshapes_striped-right-arrow { background: url('images/lc_arrowshapes.striped-right-arrow.svg') no-repeat center; }
 
-.w2ui-icon.arrowshapes_notched-right-arrow { background: url('images/lc_arrowshapes.notched-right-arrow.svg') no-repeat center !important; }
-.w2ui-icon.arrowshapes_pentagon-right { background: url('images/lc_arrowshapes.pentagon-right.svg') no-repeat center !important; }
-.w2ui-icon.arrowshapes_chevron { background: url('images/lc_arrowshapes.chevron.svg') no-repeat center !important; }
-.w2ui-icon.arrowshapes_right-arrow-callout { background: url('images/lc_arrowshapes.right-arrow-callout.svg') no-repeat center !important; }
-.w2ui-icon.arrowshapes_left-arrow-callout { background: url('images/lc_arrowshapes.left-arrow-callout.svg') no-repeat center !important; }
-.w2ui-icon.arrowshapes_up-arrow-callout { background: url('images/lc_arrowshapes.up-arrow-callout.svg') no-repeat center !important; }
+.w2ui-icon.arrowshapes_notched-right-arrow { background: url('images/lc_arrowshapes.notched-right-arrow.svg') no-repeat center; }
+.w2ui-icon.arrowshapes_pentagon-right { background: url('images/lc_arrowshapes.pentagon-right.svg') no-repeat center; }
+.w2ui-icon.arrowshapes_chevron { background: url('images/lc_arrowshapes.chevron.svg') no-repeat center; }
+.w2ui-icon.arrowshapes_right-arrow-callout { background: url('images/lc_arrowshapes.right-arrow-callout.svg') no-repeat center; }
+.w2ui-icon.arrowshapes_left-arrow-callout { background: url('images/lc_arrowshapes.left-arrow-callout.svg') no-repeat center; }
+.w2ui-icon.arrowshapes_up-arrow-callout { background: url('images/lc_arrowshapes.up-arrow-callout.svg') no-repeat center; }
 
-.w2ui-icon.arrowshapes_down-arrow-callout { background: url('images/lc_arrowshapes.down-arrow-callout.svg') no-repeat center !important; }
-.w2ui-icon.arrowshapes_left-right-arrow-callout { background: url('images/lc_arrowshapes.left-right-arrow-callout.svg') no-repeat center !important; }
-.w2ui-icon.arrowshapes_up-down-arrow-callout { background: url('images/lc_arrowshapes.up-down-arrow-callout.svg') no-repeat center !important; }
-.w2ui-icon.arrowshapes_up-right-arrow-callout { background: url('images/lc_arrowshapes.up-right-arrow-callout.svg') no-repeat center !important; }
-.w2ui-icon.arrowshapes_quad-arrow-callout { background: url('images/lc_arrowshapes.quad-arrow-callout.svg') no-repeat center !important; }
-.w2ui-icon.arrowshapes_circular-arrow { background: url('images/lc_arrowshapes.circular-arrow.svg') no-repeat center !important; }
+.w2ui-icon.arrowshapes_down-arrow-callout { background: url('images/lc_arrowshapes.down-arrow-callout.svg') no-repeat center; }
+.w2ui-icon.arrowshapes_left-right-arrow-callout { background: url('images/lc_arrowshapes.left-right-arrow-callout.svg') no-repeat center; }
+.w2ui-icon.arrowshapes_up-down-arrow-callout { background: url('images/lc_arrowshapes.up-down-arrow-callout.svg') no-repeat center; }
+.w2ui-icon.arrowshapes_up-right-arrow-callout { background: url('images/lc_arrowshapes.up-right-arrow-callout.svg') no-repeat center; }
+.w2ui-icon.arrowshapes_quad-arrow-callout { background: url('images/lc_arrowshapes.quad-arrow-callout.svg') no-repeat center; }
+.w2ui-icon.arrowshapes_circular-arrow { background: url('images/lc_arrowshapes.circular-arrow.svg') no-repeat center; }
 
-.w2ui-icon.arrowshapes_split-round-arrow { background: url('images/lc_arrowshapes.split-round-arrow.svg') no-repeat center !important; }
-.w2ui-icon.arrowshapes_s-sharped-arrow { background: url('images/lc_arrowshapes.s-sharped-arrow.svg') no-repeat center !important; }
+.w2ui-icon.arrowshapes_split-round-arrow { background: url('images/lc_arrowshapes.split-round-arrow.svg') no-repeat center; }
+.w2ui-icon.arrowshapes_s-sharped-arrow { background: url('images/lc_arrowshapes.s-sharped-arrow.svg') no-repeat center; }
 
-.w2ui-icon.starshapes_bang { background: url('images/lc_starshapes.bang.svg') no-repeat center !important; }
-.w2ui-icon.starshapes_star4 { background: url('images/lc_starshapes.star4.svg') no-repeat center !important; }
-.w2ui-icon.starshapes_star5 { background: url('images/lc_starshapes.star5.svg') no-repeat center !important; }
-.w2ui-icon.starshapes_star6 { background: url('images/lc_starshapes.star6.svg') no-repeat center !important; }
-.w2ui-icon.starshapes_star8 { background: url('images/lc_starshapes.star8.svg') no-repeat center !important; }
-.w2ui-icon.starshapes_star12 { background: url('images/lc_starshapes.star12.svg') no-repeat center !important; }
+.w2ui-icon.starshapes_bang { background: url('images/lc_starshapes.bang.svg') no-repeat center; }
+.w2ui-icon.starshapes_star4 { background: url('images/lc_starshapes.star4.svg') no-repeat center; }
+.w2ui-icon.starshapes_star5 { background: url('images/lc_starshapes.star5.svg') no-repeat center; }
+.w2ui-icon.starshapes_star6 { background: url('images/lc_starshapes.star6.svg') no-repeat center; }
+.w2ui-icon.starshapes_star8 { background: url('images/lc_starshapes.star8.svg') no-repeat center; }
+.w2ui-icon.starshapes_star12 { background: url('images/lc_starshapes.star12.svg') no-repeat center; }
 
-.w2ui-icon.starshapes_star24 { background: url('images/lc_starshapes.star24.svg') no-repeat center !important; }
-.w2ui-icon.starshapes_concave-star6 { background: url('images/lc_starshapes.concave-star6.svg') no-repeat center !important; }
-.w2ui-icon.starshapes_vertical-scroll { background: url('images/lc_starshapes.vertical-scroll.svg') no-repeat center !important; }
-.w2ui-icon.starshapes_horizontal-scroll { background: url('images/lc_starshapes.horizontal-scroll.svg') no-repeat center !important; }
-.w2ui-icon.starshapes_signet { background: url('images/lc_starshapes.signet.svg' ) no-repeat center !important; }
-.w2ui-icon.starshapes_doorplate { background: url('images/lc_starshapes.doorplate.svg') no-repeat center !important; }
+.w2ui-icon.starshapes_star24 { background: url('images/lc_starshapes.star24.svg') no-repeat center; }
+.w2ui-icon.starshapes_concave-star6 { background: url('images/lc_starshapes.concave-star6.svg') no-repeat center; }
+.w2ui-icon.starshapes_vertical-scroll { background: url('images/lc_starshapes.vertical-scroll.svg') no-repeat center; }
+.w2ui-icon.starshapes_horizontal-scroll { background: url('images/lc_starshapes.horizontal-scroll.svg') no-repeat center; }
+.w2ui-icon.starshapes_signet { background: url('images/lc_starshapes.signet.svg' ) no-repeat center; }
+.w2ui-icon.starshapes_doorplate { background: url('images/lc_starshapes.doorplate.svg') no-repeat center; }
 
-.w2ui-icon.calloutshapes_rectangular-callout { background: url('images/lc_calloutshapes.rectangular-callout.svg') no-repeat center !important; }
-.w2ui-icon.calloutshapes_round-rectangular-callout { background: url('images/lc_calloutshapes.svg') no-repeat center !important; }
-.w2ui-icon.calloutshapes_round-callout { background: url('images/lc_calloutshapes.round-callout.svg') no-repeat center !important; }
-.w2ui-icon.calloutshapes_cloud-callout { background: url('images/lc_calloutshapes.cloud-callout.svg') no-repeat center !important; }
-.w2ui-icon.calloutshapes_line-callout-1 { background: url('images/lc_calloutshapes.line-callout-1.svg') no-repeat center !important; }
-.w2ui-icon.calloutshapes_line-callout-2 { background: url('images/lc_calloutshapes.line-callout-2.svg') no-repeat center !important; }
-.w2ui-icon.calloutshapes_line-callout-3 { background: url('images/lc_calloutshapes.line-callout-3.svg') no-repeat center !important; }
+.w2ui-icon.calloutshapes_rectangular-callout { background: url('images/lc_calloutshapes.rectangular-callout.svg') no-repeat center; }
+.w2ui-icon.calloutshapes_round-rectangular-callout { background: url('images/lc_calloutshapes.svg') no-repeat center; }
+.w2ui-icon.calloutshapes_round-callout { background: url('images/lc_calloutshapes.round-callout.svg') no-repeat center; }
+.w2ui-icon.calloutshapes_cloud-callout { background: url('images/lc_calloutshapes.cloud-callout.svg') no-repeat center; }
+.w2ui-icon.calloutshapes_line-callout-1 { background: url('images/lc_calloutshapes.line-callout-1.svg') no-repeat center; }
+.w2ui-icon.calloutshapes_line-callout-2 { background: url('images/lc_calloutshapes.line-callout-2.svg') no-repeat center; }
+.w2ui-icon.calloutshapes_line-callout-3 { background: url('images/lc_calloutshapes.line-callout-3.svg') no-repeat center; }
 
-.w2ui-icon.flowchartshapes_flowchart-process { background: url('images/lc_square.svg') no-repeat center !important; }
-.w2ui-icon.flowchartshapes_flowchart-alternate-process { background: url('images/lc_basicshapes.round-quadrat.svg') no-repeat center !important; }
-.w2ui-icon.flowchartshapes_flowchart-decision { background: url('images/lc_flowchartshapes.flowchart-decision.svg') no-repeat center !important; }
-.w2ui-icon.flowchartshapes_flowchart-data { background: url('images/lc_flowchartshapes.flowchart-data.svg') no-repeat center !important; }
-.w2ui-icon.flowchartshapes_flowchart-predefined-process { background: url('images/lc_flowchartshapes.flowchart-predefined-process.svg') no-repeat center !important; }
-.w2ui-icon.flowchartshapes_flowchart-internal-storage { background: url('images/lc_flowchartshapes.flowchart-internal-storage.svg') no-repeat center !important; }
+.w2ui-icon.flowchartshapes_flowchart-process { background: url('images/lc_square.svg') no-repeat center; }
+.w2ui-icon.flowchartshapes_flowchart-alternate-process { background: url('images/lc_basicshapes.round-quadrat.svg') no-repeat center; }
+.w2ui-icon.flowchartshapes_flowchart-decision { background: url('images/lc_flowchartshapes.flowchart-decision.svg') no-repeat center; }
+.w2ui-icon.flowchartshapes_flowchart-data { background: url('images/lc_flowchartshapes.flowchart-data.svg') no-repeat center; }
+.w2ui-icon.flowchartshapes_flowchart-predefined-process { background: url('images/lc_flowchartshapes.flowchart-predefined-process.svg') no-repeat center; }
+.w2ui-icon.flowchartshapes_flowchart-internal-storage { background: url('images/lc_flowchartshapes.flowchart-internal-storage.svg') no-repeat center; }
 
-.w2ui-icon.flowchartshapes_flowchart-document { background: url('images/lc_flowchartshapes.flowchart-document.svg') no-repeat center !important; }
-.w2ui-icon.flowchartshapes_flowchart-multidocument { background: url('images/lc_flowchartshapes.flowchart-multidocument.svg') no-repeat center !important; }
-.w2ui-icon.flowchartshapes_flowchart-terminator { background: url('images/lc_flowchartshapes.flowchart-terminator.svg') no-repeat center !important; }
-.w2ui-icon.flowchartshapes_flowchart-preparation { background: url('images/lc_flowchartshapes.flowchart-preparation.svg') no-repeat center !important; }
-.w2ui-icon.flowchartshapes_flowchart-manual-input { background: url('images/lc_flowchartshapes.flowchart-manual-input.svg') no-repeat center !important; }
-.w2ui-icon.flowchartshapes_flowchart-manual-operation { background: url('images/lc_basicshapes.trapezoid.svg') no-repeat center !important; }
+.w2ui-icon.flowchartshapes_flowchart-document { background: url('images/lc_flowchartshapes.flowchart-document.svg') no-repeat center; }
+.w2ui-icon.flowchartshapes_flowchart-multidocument { background: url('images/lc_flowchartshapes.flowchart-multidocument.svg') no-repeat center; }
+.w2ui-icon.flowchartshapes_flowchart-terminator { background: url('images/lc_flowchartshapes.flowchart-terminator.svg') no-repeat center; }
+.w2ui-icon.flowchartshapes_flowchart-preparation { background: url('images/lc_flowchartshapes.flowchart-preparation.svg') no-repeat center; }
+.w2ui-icon.flowchartshapes_flowchart-manual-input { background: url('images/lc_flowchartshapes.flowchart-manual-input.svg') no-repeat center; }
+.w2ui-icon.flowchartshapes_flowchart-manual-operation { background: url('images/lc_basicshapes.trapezoid.svg') no-repeat center; }
 
-.w2ui-icon.flowchartshapes_flowchart-connector { background: url('images/lc_circle.svg') no-repeat center !important; }
-.w2ui-icon.flowchartshapes_flowchart-off-page-connector { background: url('images/lc_flowchartshapes.flowchart-off-page-connector.svg') no-repeat center !important; }
-.w2ui-icon.flowchartshapes_flowchart-card { background: url('images/lc_flowchartshapes.flowchart-card.svg') no-repeat center !important; }
-.w2ui-icon.flowchartshapes_flowchart-punched-tape { background: url('images/lc_fontworkshapetype.fontwork-wave.svg') no-repeat center !important; }
-.w2ui-icon.flowchartshapes_flowchart-summing-junction { background: url('images/lc_flowchartshapes.flowchart-summing-junction.svg') no-repeat center !important; }
-.w2ui-icon.flowchartshapes_flowchart-or { background: url('images/lc_flowchartshapes.flowchart-or.svg') no-repeat center !important; }
+.w2ui-icon.flowchartshapes_flowchart-connector { background: url('images/lc_circle.svg') no-repeat center; }
+.w2ui-icon.flowchartshapes_flowchart-off-page-connector { background: url('images/lc_flowchartshapes.flowchart-off-page-connector.svg') no-repeat center; }
+.w2ui-icon.flowchartshapes_flowchart-card { background: url('images/lc_flowchartshapes.flowchart-card.svg') no-repeat center; }
+.w2ui-icon.flowchartshapes_flowchart-punched-tape { background: url('images/lc_fontworkshapetype.fontwork-wave.svg') no-repeat center; }
+.w2ui-icon.flowchartshapes_flowchart-summing-junction { background: url('images/lc_flowchartshapes.flowchart-summing-junction.svg') no-repeat center; }
+.w2ui-icon.flowchartshapes_flowchart-or { background: url('images/lc_flowchartshapes.flowchart-or.svg') no-repeat center; }
 
-.w2ui-icon.flowchartshapes_flowchart-collate { background: url('images/lc_flowchartshapes.flowchart-collate.svg') no-repeat center !important; }
-.w2ui-icon.flowchartshapes_flowchart-sort { background: url('images/lc_flowchartshapes.flowchart-sort.svg') no-repeat center !important; }
-.w2ui-icon.flowchartshapes_flowchart-extract { background: url('images/lc_basicshapes.isosceles-triangle.svg') no-repeat center !important; }
-.w2ui-icon.flowchartshapes_flowchart-merge { background: url('images/lc_fontworkshapetype.fontwork-triangle-down.svg') no-repeat center !important; }
-.w2ui-icon.flowchartshapes_flowchart-stored-data { background: url('images/lc_flowchartshapes.flowchart-stored-data.svg') no-repeat center !important; }
-.w2ui-icon.flowchartshapes_flowchart-delay { background: url('images/lc_flowchartshapes.flowchart-delay.svg') no-repeat center !important; }
+.w2ui-icon.flowchartshapes_flowchart-collate { background: url('images/lc_flowchartshapes.flowchart-collate.svg') no-repeat center; }
+.w2ui-icon.flowchartshapes_flowchart-sort { background: url('images/lc_flowchartshapes.flowchart-sort.svg') no-repeat center; }
+.w2ui-icon.flowchartshapes_flowchart-extract { background: url('images/lc_basicshapes.isosceles-triangle.svg') no-repeat center; }
+.w2ui-icon.flowchartshapes_flowchart-merge { background: url('images/lc_fontworkshapetype.fontwork-triangle-down.svg') no-repeat center; }
+.w2ui-icon.flowchartshapes_flowchart-stored-data { background: url('images/lc_flowchartshapes.flowchart-stored-data.svg') no-repeat center; }
+.w2ui-icon.flowchartshapes_flowchart-delay { background: url('images/lc_flowchartshapes.flowchart-delay.svg') no-repeat center; }
 
-.w2ui-icon.flowchartshapes_flowchart-sequential-access { background: url('images/lc_flowchartshapes.flowchart-sequential-access.svg') no-repeat center !important; }
-.w2ui-icon.flowchartshapes_flowchart-magnetic-disk { background: url('images/lc_basicshapes.can.svg') no-repeat center !important; }
-.w2ui-icon.flowchartshapes_flowchart-direct-access-storage { background: url('images/lc_flowchartshapes.flowchart-direct-access-storage.svg') no-repeat center !important; }
-.w2ui-icon.flowchartshapes_flowchart-display { background: url('images/lc_flowchartshapes.flowchart-display.svg') no-repeat center !important; }
+.w2ui-icon.flowchartshapes_flowchart-sequential-access { background: url('images/lc_flowchartshapes.flowchart-sequential-access.svg') no-repeat center; }
+.w2ui-icon.flowchartshapes_flowchart-magnetic-disk { background: url('images/lc_basicshapes.can.svg') no-repeat center; }
+.w2ui-icon.flowchartshapes_flowchart-direct-access-storage { background: url('images/lc_flowchartshapes.flowchart-direct-access-storage.svg') no-repeat center; }
+.w2ui-icon.flowchartshapes_flowchart-display { background: url('images/lc_flowchartshapes.flowchart-display.svg') no-repeat center; }
 
-.w2ui-icon.connectors_connector { background: url('images/lc_connector.svg') no-repeat center !important; }
-.w2ui-icon.connectors_connectorarrows { background: url('images/lc_connectorarrows.svg') no-repeat center !important; }
-.w2ui-icon.connectors_connectorarrowend { background: url('images/lc_connectorarrowend.svg') no-repeat center !important; }
-.w2ui-icon.connectors_connectorlinearrowend { background: url('images/lc_connectorlinearrowend.svg') no-repeat center !important; }
-.w2ui-icon.connectors_connectorcurvearrowend { background: url('images/lc_connectorcurvearrowend.svg') no-repeat center !important; }
-.w2ui-icon.connectors_connectorlinesarrowend { background: url('images/lc_connectorlinesarrowend.svg') no-repeat center !important; }
-.w2ui-icon.connectors_connectorline { background: url('images/lc_connectorline.svg') no-repeat center !important; }
-.w2ui-icon.connectors_connectorcurve { background: url('images/lc_connectorcurve.svg') no-repeat center !important; }
-.w2ui-icon.connectors_connectorlines { background: url('images/lc_connectorlines.svg') no-repeat center !important; }
-.w2ui-icon.connectors_connectorlinearrows { background: url('images/lc_connectorlinearrows.svg') no-repeat center !important; }
-.w2ui-icon.connectors_connectorcurvearrows { background: url('images/lc_connectorcurvearrows.svg') no-repeat center !important; }
+.w2ui-icon.connectors_connector { background: url('images/lc_connector.svg') no-repeat center; }
+.w2ui-icon.connectors_connectorarrows { background: url('images/lc_connectorarrows.svg') no-repeat center; }
+.w2ui-icon.connectors_connectorarrowend { background: url('images/lc_connectorarrowend.svg') no-repeat center; }
+.w2ui-icon.connectors_connectorlinearrowend { background: url('images/lc_connectorlinearrowend.svg') no-repeat center; }
+.w2ui-icon.connectors_connectorcurvearrowend { background: url('images/lc_connectorcurvearrowend.svg') no-repeat center; }
+.w2ui-icon.connectors_connectorlinesarrowend { background: url('images/lc_connectorlinesarrowend.svg') no-repeat center; }
+.w2ui-icon.connectors_connectorline { background: url('images/lc_connectorline.svg') no-repeat center; }
+.w2ui-icon.connectors_connectorcurve { background: url('images/lc_connectorcurve.svg') no-repeat center; }
+.w2ui-icon.connectors_connectorlines { background: url('images/lc_connectorlines.svg') no-repeat center; }
+.w2ui-icon.connectors_connectorlinearrows { background: url('images/lc_connectorlinearrows.svg') no-repeat center; }
+.w2ui-icon.connectors_connectorcurvearrows { background: url('images/lc_connectorcurvearrows.svg') no-repeat center; }
 
-.w2ui-icon.frame01 { background: url('images/fr01.svg') no-repeat center !important; }
-.w2ui-icon.frame02 { background: url('images/fr02.svg') no-repeat center !important; }
-.w2ui-icon.frame03 { background: url('images/fr03.svg') no-repeat center !important; }
-.w2ui-icon.frame04 { background: url('images/fr04.svg') no-repeat center !important; }
-.w2ui-icon.frame05 { background: url('images/fr05.svg') no-repeat center !important; }
-.w2ui-icon.frame06 { background: url('images/fr06.svg') no-repeat center !important; }
-.w2ui-icon.frame07 { background: url('images/fr07.svg') no-repeat center !important; }
-.w2ui-icon.frame08 { background: url('images/fr08.svg') no-repeat center !important; }
-.w2ui-icon.frame09 { background: url('images/fr09.svg') no-repeat center !important; }
-.w2ui-icon.frame10 { background: url('images/fr010.svg') no-repeat center !important; }
-.w2ui-icon.frame11 { background: url('images/fr011.svg') no-repeat center !important; }
-.w2ui-icon.frame12 { background: url('images/fr012.svg') no-repeat center !important; }
-.w2ui-icon.frame13 { width: 108px !important; }
+.w2ui-icon.frame01 { background: url('images/fr01.svg') no-repeat center; }
+.w2ui-icon.frame02 { background: url('images/fr02.svg') no-repeat center; }
+.w2ui-icon.frame03 { background: url('images/fr03.svg') no-repeat center; }
+.w2ui-icon.frame04 { background: url('images/fr04.svg') no-repeat center; }
+.w2ui-icon.frame05 { background: url('images/fr05.svg') no-repeat center; }
+.w2ui-icon.frame06 { background: url('images/fr06.svg') no-repeat center; }
+.w2ui-icon.frame07 { background: url('images/fr07.svg') no-repeat center; }
+.w2ui-icon.frame08 { background: url('images/fr08.svg') no-repeat center; }
+.w2ui-icon.frame09 { background: url('images/fr09.svg') no-repeat center; }
+.w2ui-icon.frame10 { background: url('images/fr010.svg') no-repeat center; }
+.w2ui-icon.frame11 { background: url('images/fr011.svg') no-repeat center; }
+.w2ui-icon.frame12 { background: url('images/fr012.svg') no-repeat center; }
+.w2ui-icon.frame13 { width: 108px; }
 #div-frame13 { width: 102px; height: 18px; text-align: center; display: table-cell; vertical-align: middle; cursor: default; }
 
-.w2ui-icon.iconset00 { background: url('images/icon-set-colorarrows-down.svg') no-repeat, url('images/icon-set-colorarrows-same.svg') no-repeat, url('images/icon-set-colorarrows-up.svg') no-repeat !important;
+.w2ui-icon.iconset00 { background: url('images/icon-set-colorarrows-down.svg') no-repeat, url('images/icon-set-colorarrows-same.svg') no-repeat, url('images/icon-set-colorarrows-up.svg') no-repeat;
 	background-size: 16px 16px, 16px 16px, 16px 16px !important;
 	background-position: 2px center, 20px center, 38px center !important;
 	width: 94px !important; }
-.w2ui-icon.iconset01 { background: url('images/icon-set-grayarrows-down.svg') no-repeat, url('images/icon-set-grayarrows-same.svg') no-repeat, url('images/icon-set-grayarrows-up.svg') no-repeat !important;
+.w2ui-icon.iconset01 { background: url('images/icon-set-grayarrows-down.svg') no-repeat, url('images/icon-set-grayarrows-same.svg') no-repeat, url('images/icon-set-grayarrows-up.svg') no-repeat;
 	background-size: 16px 16px, 16px 16px, 16px 16px !important;
 	background-position: 2px center, 20px center, 38px center !important;
 	width: 94px !important; }
-.w2ui-icon.iconset02 { background: url('images/icon-set-flags-red.svg') no-repeat, url('images/icon-set-flags-yellow.svg') no-repeat, url('images/icon-set-flags-green.svg') no-repeat !important;
+.w2ui-icon.iconset02 { background: url('images/icon-set-flags-red.svg') no-repeat, url('images/icon-set-flags-yellow.svg') no-repeat, url('images/icon-set-flags-green.svg') no-repeat;
 	background-size: 16px 16px, 16px 16px, 16px 16px !important;
 	background-position: 2px center, 20px center, 38px center !important;
 	width: 94px !important; }
-.w2ui-icon.iconset03 { background: url('images/icon-set-circles1-red.svg') no-repeat, url('images/icon-set-circles1-yellow.svg') no-repeat, url('images/icon-set-circles1-green.svg') no-repeat !important;
+.w2ui-icon.iconset03 { background: url('images/icon-set-circles1-red.svg') no-repeat, url('images/icon-set-circles1-yellow.svg') no-repeat, url('images/icon-set-circles1-green.svg') no-repeat;
 	background-size: 16px 16px, 16px 16px, 16px 16px !important;
 	background-position: 2px center, 20px center, 38px center !important;
 	width: 94px !important; }
-.w2ui-icon.iconset04 { background: url('images/icon-set-trafficlights-red.svg') no-repeat, url('images/icon-set-trafficlights-yellow.svg') no-repeat, url('images/icon-set-trafficlights-green.svg') no-repeat !important;
+.w2ui-icon.iconset04 { background: url('images/icon-set-trafficlights-red.svg') no-repeat, url('images/icon-set-trafficlights-yellow.svg') no-repeat, url('images/icon-set-trafficlights-green.svg') no-repeat;
 	background-size: 16px 16px, 16px 16px, 16px 16px !important;
 	background-position: 2px center, 20px center, 38px center !important;
 	width: 94px !important; }
-.w2ui-icon.iconset05 { background: url('images/icon-set-shapes-diamond.svg') no-repeat, url('images/icon-set-shapes-triangle.svg') no-repeat, url('images/icon-set-shapes-circle.svg') no-repeat !important;
+.w2ui-icon.iconset05 { background: url('images/icon-set-shapes-diamond.svg') no-repeat, url('images/icon-set-shapes-triangle.svg') no-repeat, url('images/icon-set-shapes-circle.svg') no-repeat;
 	background-size: 16px 16px, 16px 16px, 16px 16px !important;
 	background-position: 2px center, 20px center, 38px center !important;
 	width: 94px !important; }
-.w2ui-icon.iconset06 { background: url('images/icon-set-symbols1-cross.svg') no-repeat, url('images/icon-set-symbols1-exclamation-mark.svg') no-repeat, url('images/icon-set-symbols1-check.svg') no-repeat !important;
+.w2ui-icon.iconset06 { background: url('images/icon-set-symbols1-cross.svg') no-repeat, url('images/icon-set-symbols1-exclamation-mark.svg') no-repeat, url('images/icon-set-symbols1-check.svg') no-repeat;
 	background-size: 16px 16px, 16px 16px, 16px 16px !important;
 	background-position: 2px center, 20px center, 38px center !important;
 	width: 94px !important; }
 /* Avoid the iconset07, the core renders it the same as iconset06, no need to support it in the online.
-.w2ui-icon.iconset07 { background: url('images/icon-set-symbols1-cross.svg') no-repeat, url('images/icon-set-symbols1-exclamation-mark.svg') no-repeat, url('images/icon-set-symbols1-check.svg') no-repeat !important;
+.w2ui-icon.iconset07 { background: url('images/icon-set-symbols1-cross.svg') no-repeat, url('images/icon-set-symbols1-exclamation-mark.svg') no-repeat, url('images/icon-set-symbols1-check.svg') no-repeat;
 											 background-size: 16px 16px, 16px 16px, 16px 16px !important;
 											 background-position: 2px center, 20px center, 38px center !important;
 																			width: 94px !important; }*/
-.w2ui-icon.iconset08 { background: url('images/icon-set-positive-yellow-smilie.svg') no-repeat, url('images/icon-set-neutral-yellow-smilie.svg') no-repeat, url('images/icon-set-negative-yellow-smilie.svg') no-repeat !important;
+.w2ui-icon.iconset08 { background: url('images/icon-set-positive-yellow-smilie.svg') no-repeat, url('images/icon-set-neutral-yellow-smilie.svg') no-repeat, url('images/icon-set-negative-yellow-smilie.svg') no-repeat;
 	background-size: 16px 16px, 16px 16px, 16px 16px !important;
 	background-position: 2px center, 20px center, 38px center !important;
 	width: 94px !important; }
-.w2ui-icon.iconset09 { background: url('images/icon-set-stars-empty.svg') no-repeat, url('images/icon-set-stars-half.svg') no-repeat, url('images/icon-set-stars-full.svg') no-repeat !important;
+.w2ui-icon.iconset09 { background: url('images/icon-set-stars-empty.svg') no-repeat, url('images/icon-set-stars-half.svg') no-repeat, url('images/icon-set-stars-full.svg') no-repeat;
 	background-size: 16px 16px, 16px 16px, 16px 16px !important;
 	background-position: 2px center, 20px center, 38px center !important;
 	width: 94px !important; }
-.w2ui-icon.iconset10 { background: url('images/icon-set-triangles-down.svg') no-repeat, url('images/icon-set-triangles-same.svg') no-repeat, url('images/icon-set-triangles-up.svg') no-repeat !important;
+.w2ui-icon.iconset10 { background: url('images/icon-set-triangles-down.svg') no-repeat, url('images/icon-set-triangles-same.svg') no-repeat, url('images/icon-set-triangles-up.svg') no-repeat;
 	background-size: 16px 16px, 16px 16px, 16px 16px !important;
 	background-position: 2px center, 20px center, 38px center !important;
 	width: 94px !important; }
-.w2ui-icon.iconset11 { background: url('images/icon-set-positive-green-smilie.svg') no-repeat, url('images/icon-set-neutral-yellow-smilie.svg') no-repeat, url('images/icon-set-negative-red-smilie.svg') no-repeat !important;
+.w2ui-icon.iconset11 { background: url('images/icon-set-positive-green-smilie.svg') no-repeat, url('images/icon-set-neutral-yellow-smilie.svg') no-repeat, url('images/icon-set-negative-red-smilie.svg') no-repeat;
 	background-size: 16px 16px, 16px 16px, 16px 16px !important;
 	background-position: 2px center, 20px center, 38px center !important;
 	width: 94px !important; }
-.w2ui-icon.iconset12 { background: url('images/icon-set-colorarrows-down.svg') no-repeat, url('images/icon-set-colorarrows-slightly-down.svg') no-repeat, url('images/icon-set-colorarrows-slightly-up.svg') no-repeat, url('images/icon-set-colorarrows-up.svg') no-repeat !important;
+.w2ui-icon.iconset12 { background: url('images/icon-set-colorarrows-down.svg') no-repeat, url('images/icon-set-colorarrows-slightly-down.svg') no-repeat, url('images/icon-set-colorarrows-slightly-up.svg') no-repeat, url('images/icon-set-colorarrows-up.svg') no-repeat;
 	background-size: 16px 16px, 16px 16px, 16px 16px, 16px 16px !important;
 	background-position: 2px center, 20px center, 38px center, 56px center !important;
 	width: 94px !important; }
-.w2ui-icon.iconset13 { background: url('images/icon-set-grayarrows-down.svg') no-repeat, url('images/icon-set-grayarrows-slightly-down.svg') no-repeat, url('images/icon-set-grayarrows-slightly-up.svg') no-repeat, url('images/icon-set-grayarrows-up.svg') no-repeat !important;
+.w2ui-icon.iconset13 { background: url('images/icon-set-grayarrows-down.svg') no-repeat, url('images/icon-set-grayarrows-slightly-down.svg') no-repeat, url('images/icon-set-grayarrows-slightly-up.svg') no-repeat, url('images/icon-set-grayarrows-up.svg') no-repeat;
 	background-size: 16px 16px, 16px 16px, 16px 16px, 16px 16px !important;
 	background-position: 2px center, 20px center, 38px center, 56px center !important;
 	width: 94px !important; }
-.w2ui-icon.iconset14 { background: url('images/icon-set-circles2-dark-gray.svg') no-repeat, url('images/icon-set-circles2-light-gray.svg') no-repeat, url('images/icon-set-circles2-light-red.svg') no-repeat, url('images/icon-set-circles2-dark-red.svg') no-repeat !important;
+.w2ui-icon.iconset14 { background: url('images/icon-set-circles2-dark-gray.svg') no-repeat, url('images/icon-set-circles2-light-gray.svg') no-repeat, url('images/icon-set-circles2-light-red.svg') no-repeat, url('images/icon-set-circles2-dark-red.svg') no-repeat;
 	background-size: 16px 16px, 16px 16px, 16px 16px, 16px 16px !important;
 	background-position: 2px center, 20px center, 38px center, 56px center !important;
 	width: 94px !important; }
-.w2ui-icon.iconset15 { background: url('images/icon-set-bars-one-quarter.svg') no-repeat, url('images/icon-set-bars-half.svg') no-repeat, url('images/icon-set-bars-three-quarters.svg') no-repeat, url('images/icon-set-bars-full.svg') no-repeat !important;
+.w2ui-icon.iconset15 { background: url('images/icon-set-bars-one-quarter.svg') no-repeat, url('images/icon-set-bars-half.svg') no-repeat, url('images/icon-set-bars-three-quarters.svg') no-repeat, url('images/icon-set-bars-full.svg') no-repeat;
 	background-size: 16px 16px, 16px 16px, 16px 16px, 16px 16px !important;
 	background-position: 2px center, 20px center, 38px center, 56px center !important;
 	width: 94px !important; }
-.w2ui-icon.iconset16 { background: url('images/icon-set-circles1-gray.svg') no-repeat, url('images/icon-set-circles1-red.svg') no-repeat, url('images/icon-set-circles1-yellow.svg') no-repeat, url('images/icon-set-circles1-green.svg') no-repeat !important;
+.w2ui-icon.iconset16 { background: url('images/icon-set-circles1-gray.svg') no-repeat, url('images/icon-set-circles1-red.svg') no-repeat, url('images/icon-set-circles1-yellow.svg') no-repeat, url('images/icon-set-circles1-green.svg') no-repeat;
 	background-size: 16px 16px, 16px 16px, 16px 16px, 16px 16px !important;
 	background-position: 2px center, 20px center, 38px center, 56px center !important;
 	width: 94px !important; }
-.w2ui-icon.iconset17 { background: url('images/icon-set-colorarrows-down.svg') no-repeat, url('images/icon-set-colorarrows-slightly-down.svg') no-repeat, url('images/icon-set-colorarrows-same.svg') no-repeat, url('images/icon-set-colorarrows-slightly-up.svg') no-repeat, url('images/icon-set-colorarrows-up.svg') no-repeat !important;
+.w2ui-icon.iconset17 { background: url('images/icon-set-colorarrows-down.svg') no-repeat, url('images/icon-set-colorarrows-slightly-down.svg') no-repeat, url('images/icon-set-colorarrows-same.svg') no-repeat, url('images/icon-set-colorarrows-slightly-up.svg') no-repeat, url('images/icon-set-colorarrows-up.svg') no-repeat;
 	background-size: 16px 16px, 16px 16px, 16px 16px, 16px 16px, 16px 16px !important;
 	background-position: 2px center, 20px center, 38px center, 56px center, 74px center !important;
 	width: 94px !important; }
-.w2ui-icon.iconset18 { background: url('images/icon-set-grayarrows-down.svg') no-repeat, url('images/icon-set-grayarrows-slightly-down.svg') no-repeat, url('images/icon-set-grayarrows-same.svg') no-repeat, url('images/icon-set-grayarrows-slightly-up.svg') no-repeat, url('images/icon-set-grayarrows-up.svg') no-repeat !important;
+.w2ui-icon.iconset18 { background: url('images/icon-set-grayarrows-down.svg') no-repeat, url('images/icon-set-grayarrows-slightly-down.svg') no-repeat, url('images/icon-set-grayarrows-same.svg') no-repeat, url('images/icon-set-grayarrows-slightly-up.svg') no-repeat, url('images/icon-set-grayarrows-up.svg') no-repeat;
 	background-size: 16px 16px, 16px 16px, 16px 16px, 16px 16px, 16px 16px !important;
 	background-position: 2px center, 20px center, 38px center, 56px center, 74px center !important;
 	width: 94px !important; }
-.w2ui-icon.iconset19 { background: url('images/icon-set-bars-empty.svg') no-repeat, url('images/icon-set-bars-one-quarter.svg') no-repeat, url('images/icon-set-bars-half.svg') no-repeat, url('images/icon-set-bars-three-quarters.svg') no-repeat, url('images/icon-set-bars-full.svg') no-repeat !important;
+.w2ui-icon.iconset19 { background: url('images/icon-set-bars-empty.svg') no-repeat, url('images/icon-set-bars-one-quarter.svg') no-repeat, url('images/icon-set-bars-half.svg') no-repeat, url('images/icon-set-bars-three-quarters.svg') no-repeat, url('images/icon-set-bars-full.svg') no-repeat;
 	background-size: 16px 16px, 16px 16px, 16px 16px, 16px 16px, 16px 16px !important;
 	background-position: 2px center, 20px center, 38px center, 56px center, 74px center !important;
 	width: 94px !important; }
-.w2ui-icon.iconset20 { background: url('images/icon-set-pies-empty.svg') no-repeat, url('images/icon-set-pies-one-quarter.svg') no-repeat, url('images/icon-set-pies-half.svg') no-repeat, url('images/icon-set-pies-three-quarters.svg') no-repeat, url('images/icon-set-pies-full.svg') no-repeat !important;
+.w2ui-icon.iconset20 { background: url('images/icon-set-pies-empty.svg') no-repeat, url('images/icon-set-pies-one-quarter.svg') no-repeat, url('images/icon-set-pies-half.svg') no-repeat, url('images/icon-set-pies-three-quarters.svg') no-repeat, url('images/icon-set-pies-full.svg') no-repeat;
 	background-size: 16px 16px, 16px 16px, 16px 16px, 16px 16px, 16px 16px !important;
 	background-position: 2px center, 20px center, 38px center, 56px center, 74px center !important;
 	width: 94px !important; }
-.w2ui-icon.iconset21 { background: url('images/icon-set-squares-empty.svg') no-repeat, url('images/icon-set-squares-one-quarter.svg') no-repeat, url('images/icon-set-squares-half.svg') no-repeat, url('images/icon-set-squares-three-quarters.svg') no-repeat, url('images/icon-set-squares-full.svg') no-repeat !important;
+.w2ui-icon.iconset21 { background: url('images/icon-set-squares-empty.svg') no-repeat, url('images/icon-set-squares-one-quarter.svg') no-repeat, url('images/icon-set-squares-half.svg') no-repeat, url('images/icon-set-squares-three-quarters.svg') no-repeat, url('images/icon-set-squares-full.svg') no-repeat;
 	background-size: 16px 16px, 16px 16px, 16px 16px, 16px 16px, 16px 16px !important;
 	background-position: 2px center, 20px center, 38px center, 56px center, 74px center !important;
 	width: 94px !important; }
 
-.w2ui-icon.print{ background: url('images/lc_print.svg') no-repeat center !important; }
-.w2ui-icon.undo{ background: url('images/lc_undo.svg') no-repeat center !important; }
-.w2ui-icon.redo{ background: url('images/lc_redo.svg') no-repeat center !important; }
-.w2ui-icon.copyformat{ background: url('images/lc_formatpaintbrush.svg') no-repeat center !important; }
-.w2ui-icon.deleteformat{ background: url('images/lc_setdefault.svg') no-repeat center !important; }
-.w2ui-icon.bold{ background: url('images/lc_bold.svg') no-repeat center !important; }
-.w2ui-icon.italic{ background: url('images/lc_italic.svg') no-repeat center !important; }
-.w2ui-icon.underline{ background: url('images/lc_underline.svg') no-repeat center !important; }
-.w2ui-icon.strikeout{ background: url('images/lc_strikeout.svg') no-repeat center !important; }
-.w2ui-icon.textcolor{ background: url('images/lc_fontcolor.svg') no-repeat center !important; }
-.w2ui-icon.backcolor{ background: url('images/lc_backcolor.svg') no-repeat center !important; }
-.w2ui-icon.backgroundcolor{ background: url('images/lc_fillcolor.svg') no-repeat center !important; }
-.w2ui-icon.alignleft{ background: url('images/lc_leftpara.svg') no-repeat center !important; }
-.w2ui-icon.alignhorizontal{ background: url('images/lc_centerpara.svg') no-repeat center !important; }
-.w2ui-icon.alignright{ background: url('images/lc_rightpara.svg') no-repeat center !important; }
-.w2ui-icon.alignblock{ background: url('images/lc_justifypara.svg') no-repeat center !important; }
-.w2ui-icon.aligntop{ background: url('images/lc_aligntop.svg') no-repeat center !important; }
-.w2ui-icon.alignvcenter{ background: url('images/lc_alignvcenter.svg') no-repeat center !important; }
-.w2ui-icon.alignbottom{ background: url('images/lc_alignbottom.svg') no-repeat center !important; }
-.w2ui-icon.cellverttop{ background: url('images/lc_cellverttop.svg') no-repeat center !important; }
-.w2ui-icon.cellvertcenter{ background: url('images/lc_cellvertcenter.svg') no-repeat center !important; }
-.w2ui-icon.cellvertbottom{ background: url('images/lc_cellvertbottom.svg') no-repeat center !important; }
-.w2ui-icon.linespacing, .w2ui-icon.spacepara1, .w2ui-icon.spacepara15{ background: url('images/lc_linespacing.svg') no-repeat center !important; }
-.w2ui-icon.spacepara2{ background: url('images/lc_spacepara2.svg') no-repeat center !important; }
-.w2ui-icon.paraspaceincrease{ background: url('images/lc_paraspaceincrease.svg') no-repeat center !important; }
-.w2ui-icon.paraspacedecrease{ background: url('images/lc_paraspacedecrease.svg') no-repeat center !important; }
-.w2ui-icon.numbering{ background: url('images/lc_defaultnumbering.svg') no-repeat center !important; }
-.w2ui-icon.bullet{ background: url('images/lc_defaultbullet.svg') no-repeat center !important; }
-.w2ui-icon.incrementindent{ background: url('images/lc_leftindent.svg') no-repeat center !important; }
-.w2ui-icon.decrementindent{ background: url('images/lc_decrementindent.svg') no-repeat center !important; }
-.w2ui-icon.outlineleft{ background: url('images/lc_outlineleft.svg') no-repeat center !important; }
-.w2ui-icon.outlineright{ background: url('images/lc_outlineright.svg') no-repeat center !important; }
-.w2ui-icon.text{ background: url('images/lc_text.svg') no-repeat center !important; }
-.w2ui-icon.annotation{ background: url('images/lc_shownote.svg') no-repeat center !important; }
-.w2ui-icon.inserttable{ background: url('images/lc_inserttable.svg') no-repeat center !important; }
-.w2ui-icon.insertgraphic{ background: url('images/lc_gallery.svg') no-repeat center !important; }
-.w2ui-icon.link{ background: url('images/lc_inserthyperlink.svg') no-repeat center !important; }
-.w2ui-icon.insertsymbol{ background: url('images/lc_insertsymbol.svg') no-repeat center !important; }
-.w2ui-icon.edit{ background: url('images/lc_editdoc.svg') no-repeat center !important; }
-.w2ui-icon.fold{ background: url('images/fold.svg') no-repeat center center / 19px !important; opacity: 0.8; filter: alpha(opacity=80);}
-.w2ui-icon.unfold{ background: url('images/unfold.svg') no-repeat center center/ 19px !important; opacity: 0.8; filter: alpha(opacity=80);}
-.w2ui-icon.hamburger{ background: url('images/hamburger.svg') no-repeat center !important; }
-.w2ui-icon.setborderstyle{ background: url('images/lc_setborderstyle.svg') no-repeat center !important; }
-.w2ui-icon.togglemergecells{ background: url('images/lc_togglemergecells.svg') no-repeat center !important; }
-.w2ui-icon.wraptext{ background: url('images/lc_wraptext.svg') no-repeat center !important; }
-.w2ui-icon.numberformatstandard{ background: url('images/lc_numberformatstandard.svg') no-repeat center !important; }
-.w2ui-icon.numberformatcurrency{ background: url('images/lc_numberformatcurrency.svg') no-repeat center !important; }
-.w2ui-icon.numberformatpercent{ background: url('images/lc_numberformatpercent.svg') no-repeat center !important; }
-.w2ui-icon.numberformatdecimal{ background: url('images/lc_numberformatdecimal.svg') no-repeat center !important; }
-.w2ui-icon.numberformatdate{ background: url('images/lc_numberformatdate.svg') no-repeat center !important; }
-.w2ui-icon.numberformattime{ background: url('images/lc_numberformattime.svg') no-repeat center !important; }
-.w2ui-icon.numberformatscientific{ background: url('images/lc_numberformatscientific.svg') no-repeat center !important; }
-.w2ui-icon.numberformatthousands{ background: url('images/lc_numberformatthousands.svg') no-repeat center !important; }
-.w2ui-icon.numberformatincdecimals{ background: url('images/lc_numberformatincdecimals.svg') no-repeat center !important; }
-.w2ui-icon.numberformatdecdecimals{ background: url('images/lc_numberformatdecdecimals.svg') no-repeat center !important; }
-.w2ui-icon.insertobjectchart{ background: url('images/lc_drawchart.svg') no-repeat center !important; }
-.w2ui-icon.insertrowsafter{ background: url('images/lc_insertrowsafter.svg') no-repeat center !important; }
-.w2ui-icon.insertcolumnsafter{ background: url('images/lc_insertcolumnsafter.svg') no-repeat center !important; }
-.w2ui-icon.insertcolumnsbefore{ background: url('images/lc_insertcolumnsbefore.svg') no-repeat center !important; }
-.w2ui-icon.insertrowsbefore{ background: url('images/lc_insertrowsbefore.svg') no-repeat center !important; }
-.w2ui-icon.autosum{ background: url('images/lc_autosum.svg') no-repeat center !important; }
-.w2ui-icon.orientation{ background: url('images/lc_orientation.svg') no-repeat center !important; }
-.w2ui-icon.deleterows{ background: url('images/lc_deleterows.svg') no-repeat center !important; }
-.w2ui-icon.hiderow{ background: url('images/lc_hiderow.svg') no-repeat center !important; }
-.w2ui-icon.showrow{ background: url('images/lc_showrow.svg') no-repeat center !important; }
-.w2ui-icon.deletecolumns{ background: url('images/lc_deletecolumns.svg') no-repeat center !important; }
-.w2ui-icon.hidecolumn{ background: url('images/lc_hidecolumn.svg') no-repeat center !important; }
-.w2ui-icon.showcolumn{ background: url('images/lc_showcolumn.svg') no-repeat center !important; }
-.w2ui-icon.entirerow{ background: url('images/lc_entirerow.svg') no-repeat center !important; }
-.w2ui-icon.setoptimalrowheight{ background: url('images/lc_setoptimalrowheight.svg') no-repeat center !important; }
-.w2ui-icon.setoptimalcolumnwidth{ background: url('images/lc_setoptimalcolumnwidth.svg') no-repeat center !important; }
-.w2ui-icon.entirecell{ background: url('images/lc_entirecell.svg') no-repeat center !important; }
-.w2ui-icon.entirecolumn{ background: url('images/lc_entirecolumn.svg') no-repeat center !important; }
-.w2ui-icon.selecttable{ background: url('images/lc_selecttable.svg') no-repeat center !important; }
+.w2ui-icon.print{ background: url('images/lc_print.svg') no-repeat center; }
+.w2ui-icon.undo{ background: url('images/lc_undo.svg') no-repeat center; }
+.w2ui-icon.redo{ background: url('images/lc_redo.svg') no-repeat center; }
+.w2ui-icon.copyformat{ background: url('images/lc_formatpaintbrush.svg') no-repeat center; }
+.w2ui-icon.deleteformat{ background: url('images/lc_setdefault.svg') no-repeat center; }
+.w2ui-icon.bold{ background: url('images/lc_bold.svg') no-repeat center; }
+.w2ui-icon.italic{ background: url('images/lc_italic.svg') no-repeat center; }
+.w2ui-icon.underline{ background: url('images/lc_underline.svg') no-repeat center; }
+.w2ui-icon.strikeout{ background: url('images/lc_strikeout.svg') no-repeat center; }
+.w2ui-icon.textcolor{ background: url('images/lc_fontcolor.svg') no-repeat center; }
+.w2ui-icon.backcolor{ background: url('images/lc_backcolor.svg') no-repeat center; }
+.w2ui-icon.backgroundcolor{ background: url('images/lc_fillcolor.svg') no-repeat center; }
+.w2ui-icon.alignleft{ background: url('images/lc_leftpara.svg') no-repeat center; }
+.w2ui-icon.alignhorizontal{ background: url('images/lc_centerpara.svg') no-repeat center; }
+.w2ui-icon.alignright{ background: url('images/lc_rightpara.svg') no-repeat center; }
+.w2ui-icon.alignblock{ background: url('images/lc_justifypara.svg') no-repeat center; }
+.w2ui-icon.aligntop{ background: url('images/lc_aligntop.svg') no-repeat center; }
+.w2ui-icon.alignvcenter{ background: url('images/lc_alignvcenter.svg') no-repeat center; }
+.w2ui-icon.alignbottom{ background: url('images/lc_alignbottom.svg') no-repeat center; }
+.w2ui-icon.cellverttop{ background: url('images/lc_cellverttop.svg') no-repeat center; }
+.w2ui-icon.cellvertcenter{ background: url('images/lc_cellvertcenter.svg') no-repeat center; }
+.w2ui-icon.cellvertbottom{ background: url('images/lc_cellvertbottom.svg') no-repeat center; }
+.w2ui-icon.linespacing, .w2ui-icon.spacepara1, .w2ui-icon.spacepara15{ background: url('images/lc_linespacing.svg') no-repeat center; }
+.w2ui-icon.spacepara2{ background: url('images/lc_spacepara2.svg') no-repeat center; }
+.w2ui-icon.paraspaceincrease{ background: url('images/lc_paraspaceincrease.svg') no-repeat center; }
+.w2ui-icon.paraspacedecrease{ background: url('images/lc_paraspacedecrease.svg') no-repeat center; }
+.w2ui-icon.numbering{ background: url('images/lc_defaultnumbering.svg') no-repeat center; }
+.w2ui-icon.bullet{ background: url('images/lc_defaultbullet.svg') no-repeat center; }
+.w2ui-icon.incrementindent{ background: url('images/lc_leftindent.svg') no-repeat center; }
+.w2ui-icon.decrementindent{ background: url('images/lc_decrementindent.svg') no-repeat center; }
+.w2ui-icon.outlineleft{ background: url('images/lc_outlineleft.svg') no-repeat center; }
+.w2ui-icon.outlineright{ background: url('images/lc_outlineright.svg') no-repeat center; }
+.w2ui-icon.text{ background: url('images/lc_text.svg') no-repeat center; }
+.w2ui-icon.annotation{ background: url('images/lc_shownote.svg') no-repeat center; }
+.w2ui-icon.inserttable{ background: url('images/lc_inserttable.svg') no-repeat center; }
+.w2ui-icon.insertgraphic{ background: url('images/lc_gallery.svg') no-repeat center; }
+.w2ui-icon.link{ background: url('images/lc_inserthyperlink.svg') no-repeat center; }
+.w2ui-icon.insertsymbol{ background: url('images/lc_insertsymbol.svg') no-repeat center; }
+.w2ui-icon.edit{ background: url('images/lc_editdoc.svg') no-repeat center; }
+.w2ui-icon.fold{ background: url('images/fold.svg') no-repeat center center / 19px; opacity: 0.8; filter: alpha(opacity=80);}
+.w2ui-icon.unfold{ background: url('images/unfold.svg') no-repeat center center/ 19px; opacity: 0.8; filter: alpha(opacity=80);}
+.w2ui-icon.hamburger{ background: url('images/hamburger.svg') no-repeat center; }
+.w2ui-icon.setborderstyle{ background: url('images/lc_setborderstyle.svg') no-repeat center; }
+.w2ui-icon.togglemergecells{ background: url('images/lc_togglemergecells.svg') no-repeat center; }
+.w2ui-icon.wraptext{ background: url('images/lc_wraptext.svg') no-repeat center; }
+.w2ui-icon.numberformatstandard{ background: url('images/lc_numberformatstandard.svg') no-repeat center; }
+.w2ui-icon.numberformatcurrency{ background: url('images/lc_numberformatcurrency.svg') no-repeat center; }
+.w2ui-icon.numberformatpercent{ background: url('images/lc_numberformatpercent.svg') no-repeat center; }
+.w2ui-icon.numberformatdecimal{ background: url('images/lc_numberformatdecimal.svg') no-repeat center; }
+.w2ui-icon.numberformatdate{ background: url('images/lc_numberformatdate.svg') no-repeat center; }
+.w2ui-icon.numberformattime{ background: url('images/lc_numberformattime.svg') no-repeat center; }
+.w2ui-icon.numberformatscientific{ background: url('images/lc_numberformatscientific.svg') no-repeat center; }
+.w2ui-icon.numberformatthousands{ background: url('images/lc_numberformatthousands.svg') no-repeat center; }
+.w2ui-icon.numberformatincdecimals{ background: url('images/lc_numberformatincdecimals.svg') no-repeat center; }
+.w2ui-icon.numberformatdecdecimals{ background: url('images/lc_numberformatdecdecimals.svg') no-repeat center; }
+.w2ui-icon.insertobjectchart{ background: url('images/lc_drawchart.svg') no-repeat center; }
+.w2ui-icon.insertrowsafter{ background: url('images/lc_insertrowsafter.svg') no-repeat center; }
+.w2ui-icon.insertcolumnsafter{ background: url('images/lc_insertcolumnsafter.svg') no-repeat center; }
+.w2ui-icon.insertcolumnsbefore{ background: url('images/lc_insertcolumnsbefore.svg') no-repeat center; }
+.w2ui-icon.insertrowsbefore{ background: url('images/lc_insertrowsbefore.svg') no-repeat center; }
+.w2ui-icon.autosum{ background: url('images/lc_autosum.svg') no-repeat center; }
+.w2ui-icon.orientation{ background: url('images/lc_orientation.svg') no-repeat center; }
+.w2ui-icon.deleterows{ background: url('images/lc_deleterows.svg') no-repeat center; }
+.w2ui-icon.hiderow{ background: url('images/lc_hiderow.svg') no-repeat center; }
+.w2ui-icon.showrow{ background: url('images/lc_showrow.svg') no-repeat center; }
+.w2ui-icon.deletecolumns{ background: url('images/lc_deletecolumns.svg') no-repeat center; }
+.w2ui-icon.hidecolumn{ background: url('images/lc_hidecolumn.svg') no-repeat center; }
+.w2ui-icon.showcolumn{ background: url('images/lc_showcolumn.svg') no-repeat center; }
+.w2ui-icon.entirerow{ background: url('images/lc_entirerow.svg') no-repeat center; }
+.w2ui-icon.setoptimalrowheight{ background: url('images/lc_setoptimalrowheight.svg') no-repeat center; }
+.w2ui-icon.setoptimalcolumnwidth{ background: url('images/lc_setoptimalcolumnwidth.svg') no-repeat center; }
+.w2ui-icon.entirecell{ background: url('images/lc_entirecell.svg') no-repeat center; }
+.w2ui-icon.entirecolumn{ background: url('images/lc_entirecolumn.svg') no-repeat center; }
+.w2ui-icon.selecttable{ background: url('images/lc_selecttable.svg') no-repeat center; }
 
-.w2ui-icon.accepttrackedchanges{ background: url('images/lc_acceptchanges.svg') no-repeat center !important; }
-.w2ui-icon.ok{ background: url('images/lc_ok.svg') no-repeat center !important; }
-.w2ui-icon.cancel{ background: url('images/lc_cancel.svg') no-repeat center !important; }
-.w2ui-icon.color{ background: url('images/lc_color.svg') no-repeat center !important; }
-.w2ui-icon.deletepage{ background: url('images/lc_deletepage.svg') no-repeat center !important; }
-.w2ui-icon.duplicatepage{ background: url('images/lc_duplicatepage.svg') no-repeat center !important; }
-.w2ui-icon.equal{ background: url('images/lc26049.svg') no-repeat center !important; }
-.w2ui-icon.help{ background: url('images/lc_helpindex.svg') no-repeat center !important; }
-.w2ui-icon.insertpage{ background: url('images/lc_insertpage.svg') no-repeat center !important; }
-.w2ui-icon.insertsheet{ background: url('images/plus.svg') no-repeat center !important; }
-.w2ui-icon.conditionalformatdialog{ background: url('images/lc_conditionalformatmenu.svg') no-repeat center !important; }
-.w2ui-icon.search{ background: url('images/sc_recsearch.svg') no-repeat center !important; }
-.w2ui-icon.next{ background: url('images/lc_downsearch.svg') no-repeat center !important; }
-.w2ui-icon.presentation{ background: url('images/lc_dia.svg') no-repeat center !important; }
-.w2ui-icon.sign_ok{ background: url('images/sign_ok.svg') no-repeat center !important; }
-.w2ui-icon.sign_not_ok{ background: url('images/sign_not_ok.svg') no-repeat center !important; }
-.w2ui-icon.prev{ background: url('images/lc_upsearch.svg') no-repeat center !important; }
-.w2ui-icon.save{ background: url('images/lc_save.svg') no-repeat center !important; }
-.w2ui-icon.saveas{ background: url('images/lc_saveas.svg') no-repeat center !important; }
-.w2ui-icon.savemodified{ background: url('images/savemodified_large.svg') no-repeat center !important; }
-.w2ui-icon.zoomin{ background: url('images/plus.svg') no-repeat center !important; }
-.w2ui-icon.zoomout{ background: url('images/minus.svg') no-repeat center !important; }
-.w2ui-icon.zoomreset{ background: url('images/lc_view100.svg') no-repeat center !important; }
-.w2ui-icon.more{ background: url('images/lc_downsearch.svg') no-repeat center !important; }
-.w2ui-icon.firstrecord{ background: url('images/lc_firstrecord.svg') no-repeat center !important; }
-.w2ui-icon.nextrecord{ background: url('images/lc_nextrecord.svg') no-repeat center !important; }
-.w2ui-icon.prevrecord{ background: url('images/lc_prevrecord.svg') no-repeat center !important; }
-.w2ui-icon.lastrecord{ background: url('images/lc_lastrecord.svg') no-repeat center !important; }
-.w2ui-icon.sortascending{ background: url('images/lc_sortascending.svg') no-repeat center !important; }
-.w2ui-icon.sortdescending{ background: url('images/lc_sortdescending.svg') no-repeat center !important; }
-.w2ui-icon.selected{ background: url('images/lc_ok.svg') no-repeat center !important; }
+.w2ui-icon.accepttrackedchanges{ background: url('images/lc_acceptchanges.svg') no-repeat center; }
+.w2ui-icon.ok{ background: url('images/lc_ok.svg') no-repeat center; }
+.w2ui-icon.cancel{ background: url('images/lc_cancel.svg') no-repeat center; }
+.w2ui-icon.color{ background: url('images/lc_color.svg') no-repeat center; }
+.w2ui-icon.deletepage{ background: url('images/lc_deletepage.svg') no-repeat center; }
+.w2ui-icon.duplicatepage{ background: url('images/lc_duplicatepage.svg') no-repeat center; }
+.w2ui-icon.equal{ background: url('images/lc26049.svg') no-repeat center; }
+.w2ui-icon.help{ background: url('images/lc_helpindex.svg') no-repeat center; }
+.w2ui-icon.insertpage{ background: url('images/lc_insertpage.svg') no-repeat center; }
+.w2ui-icon.insertsheet{ background: url('images/plus.svg') no-repeat center; }
+.w2ui-icon.conditionalformatdialog{ background: url('images/lc_conditionalformatmenu.svg') no-repeat center; }
+.w2ui-icon.search{ background: url('images/sc_recsearch.svg') no-repeat center; }
+.w2ui-icon.next{ background: url('images/lc_downsearch.svg') no-repeat center; }
+.w2ui-icon.presentation{ background: url('images/lc_dia.svg') no-repeat center; }
+.w2ui-icon.sign_ok{ background: url('images/sign_ok.svg') no-repeat center; }
+.w2ui-icon.sign_not_ok{ background: url('images/sign_not_ok.svg') no-repeat center; }
+.w2ui-icon.prev{ background: url('images/lc_upsearch.svg') no-repeat center; }
+.w2ui-icon.save{ background: url('images/lc_save.svg') no-repeat center; }
+.w2ui-icon.saveas{ background: url('images/lc_saveas.svg') no-repeat center; }
+.w2ui-icon.savemodified{ background: url('images/savemodified_large.svg') no-repeat center; }
+.w2ui-icon.zoomin{ background: url('images/plus.svg') no-repeat center; }
+.w2ui-icon.zoomout{ background: url('images/minus.svg') no-repeat center; }
+.w2ui-icon.zoomreset{ background: url('images/lc_view100.svg') no-repeat center; }
+.w2ui-icon.more{ background: url('images/lc_downsearch.svg') no-repeat center; }
+.w2ui-icon.firstrecord{ background: url('images/lc_firstrecord.svg') no-repeat center; }
+.w2ui-icon.nextrecord{ background: url('images/lc_nextrecord.svg') no-repeat center; }
+.w2ui-icon.prevrecord{ background: url('images/lc_prevrecord.svg') no-repeat center; }
+.w2ui-icon.lastrecord{ background: url('images/lc_lastrecord.svg') no-repeat center; }
+.w2ui-icon.sortascending{ background: url('images/lc_sortascending.svg') no-repeat center; }
+.w2ui-icon.sortdescending{ background: url('images/lc_sortdescending.svg') no-repeat center; }
+.w2ui-icon.selected{ background: url('images/lc_ok.svg') no-repeat center; }
 .w2ui-icon.users{ background: url('images/contacts-dark.svg') no-repeat center; }
-.w2ui-icon.fullscreen{ background: url('images/lc_fullscreen.svg') no-repeat center !important; }
-.w2ui-icon.closemobile{ background: url('images/lc_closedocmobile.svg') no-repeat center !important; }
-.w2ui-icon.editmode { background: url('images/lc_listitem-selected.svg') no-repeat center / 28px !important; }
-.w2ui-icon.closetoolbar{ background: url('images/close_toolbar.svg') no-repeat center !important; }
-.w2ui-icon.sidebar_modify_page{ background: url('images/lc_sidebar.svg') no-repeat center !important; }
-.w2ui-icon.sidebar_slide_change{ background: url('images/lc_slidechangewindow.svg') no-repeat center !important; }
-.w2ui-icon.sidebar_custom_animation{ background: url('images/lc_customanimation.svg') no-repeat center !important; }
-.w2ui-icon.sidebar_master_slides{ background: url('images/lc_masterslide.svg') no-repeat center !important; }
-.w2ui-icon.mobile_wizard{ background: url('images/lc_mobile_wizard.svg') no-repeat center !important; }
-.w2ui-icon.fullscreen-presentation{ background: url('images/lc_fullscreen-presentation-toolbar-mobile.svg') no-repeat center !important;}
-.w2ui-icon.mobile_comment_wizard{ background: url('images/lc_mobile_comment_wizard.svg') no-repeat center !important; }
-.w2ui-icon.insertion_mobile_wizard{ background: url('images/lc_insertion_mobile_wizard.svg') no-repeat center !important; }
-.w2ui-icon.viewcomments{ background: url('images/lc_mobile_comment_wizard.svg') no-repeat center !important; }
-.w2ui-icon.insertcomment{ background: url('images/lc_insertcomment.svg') no-repeat center !important; }
-.w2ui-icon.freezepanes{ background: url('images/lc_freezepanes.svg') no-repeat center !important; }
-.w2ui-icon.freezepanescolumn{ background: url('images/lc_freezepanescolumn.svg') no-repeat center !important; }
-.w2ui-icon.freezepanesrow{ background: url('images/lc_freezepanesrow.svg') no-repeat center !important; }
-.w2ui-icon.navigator{ background: url('images/lc_navigator.svg') no-repeat center !important; }
+.w2ui-icon.fullscreen{ background: url('images/lc_fullscreen.svg') no-repeat center; }
+.w2ui-icon.closemobile{ background: url('images/lc_closedocmobile.svg') no-repeat center; }
+.w2ui-icon.editmode { background: url('images/lc_listitem-selected.svg') no-repeat center / 28px; }
+.w2ui-icon.closetoolbar{ background: url('images/close_toolbar.svg') no-repeat center; }
+.w2ui-icon.sidebar_modify_page{ background: url('images/lc_sidebar.svg') no-repeat center; }
+.w2ui-icon.sidebar_slide_change{ background: url('images/lc_slidechangewindow.svg') no-repeat center; }
+.w2ui-icon.sidebar_custom_animation{ background: url('images/lc_customanimation.svg') no-repeat center; }
+.w2ui-icon.sidebar_master_slides{ background: url('images/lc_masterslide.svg') no-repeat center; }
+.w2ui-icon.mobile_wizard{ background: url('images/lc_mobile_wizard.svg') no-repeat center; }
+.w2ui-icon.fullscreen-presentation{ background: url('images/lc_fullscreen-presentation-toolbar-mobile.svg') no-repeat center;}
+.w2ui-icon.mobile_comment_wizard{ background: url('images/lc_mobile_comment_wizard.svg') no-repeat center; }
+.w2ui-icon.insertion_mobile_wizard{ background: url('images/lc_insertion_mobile_wizard.svg') no-repeat center; }
+.w2ui-icon.viewcomments{ background: url('images/lc_mobile_comment_wizard.svg') no-repeat center; }
+.w2ui-icon.insertcomment{ background: url('images/lc_insertcomment.svg') no-repeat center; }
+.w2ui-icon.freezepanes{ background: url('images/lc_freezepanes.svg') no-repeat center; }
+.w2ui-icon.freezepanescolumn{ background: url('images/lc_freezepanescolumn.svg') no-repeat center; }
+.w2ui-icon.freezepanesrow{ background: url('images/lc_freezepanesrow.svg') no-repeat center; }
+.w2ui-icon.navigator{ background: url('images/lc_navigator.svg') no-repeat center; }
 
-.w2ui-icon.flipvertical { background: url('images/lc_flipvertical.svg') no-repeat center !important; }
-.w2ui-icon.fliphorizontal { background: url('images/lc_fliphorizontal.svg') no-repeat center !important; }
+.w2ui-icon.flipvertical { background: url('images/lc_flipvertical.svg') no-repeat center; }
+.w2ui-icon.fliphorizontal { background: url('images/lc_fliphorizontal.svg') no-repeat center; }
 
-.w2ui-icon.wrapmenu { background: url('images/lc_wrapmenu.svg') no-repeat center !important; }
-.w2ui-icon.wrapoff { background: url('images/lc_wrapoff.svg') no-repeat center !important; }
-.w2ui-icon.wrapon { background: url('images/lc_wrapon.svg') no-repeat center !important; }
-.w2ui-icon.wrapideal { background: url('images/lc_wrapideal.svg') no-repeat center !important; }
-.w2ui-icon.wrapleft { background: url('images/lc_wrapleft.svg') no-repeat center !important; }
-.w2ui-icon.wrapright { background: url('images/lc_wrapright.svg') no-repeat center !important; }
-.w2ui-icon.wrapthrough { background: url('images/lc_wrapthrough.svg') no-repeat center !important; }
-.w2ui-icon.wrapthroughtransparencytoggle { background: url('images/lc_wrapthroughtransparencytoggle.svg') no-repeat center !important; }
-.w2ui-icon.wrapcontour { background: url('images/lc_wrapcontour.svg') no-repeat center !important; }
-.w2ui-icon.wrapanchoronly { background: url('images/lc_wrapanchoronly.svg') no-repeat center !important; }
+.w2ui-icon.wrapmenu { background: url('images/lc_wrapmenu.svg') no-repeat center; }
+.w2ui-icon.wrapoff { background: url('images/lc_wrapoff.svg') no-repeat center; }
+.w2ui-icon.wrapon { background: url('images/lc_wrapon.svg') no-repeat center; }
+.w2ui-icon.wrapideal { background: url('images/lc_wrapideal.svg') no-repeat center; }
+.w2ui-icon.wrapleft { background: url('images/lc_wrapleft.svg') no-repeat center; }
+.w2ui-icon.wrapright { background: url('images/lc_wrapright.svg') no-repeat center; }
+.w2ui-icon.wrapthrough { background: url('images/lc_wrapthrough.svg') no-repeat center; }
+.w2ui-icon.wrapthroughtransparencytoggle { background: url('images/lc_wrapthroughtransparencytoggle.svg') no-repeat center; }
+.w2ui-icon.wrapcontour { background: url('images/lc_wrapcontour.svg') no-repeat center; }
+.w2ui-icon.wrapanchoronly { background: url('images/lc_wrapanchoronly.svg') no-repeat center; }
 
-.w2ui-icon.objectalignleft { background: url('images/lc_objectalignleft.svg') no-repeat center !important; }
-.w2ui-icon.aligncenter { background: url('images/lc_aligncenter.svg') no-repeat center !important; }
-.w2ui-icon.objectalignright { background: url('images/lc_objectalignright.svg') no-repeat center !important; }
-.w2ui-icon.alignup { background: url('images/lc_alignup.svg') no-repeat center !important; }
-.w2ui-icon.alignmiddle { background: url('images/lc_alignmiddle.svg') no-repeat center !important; }
-.w2ui-icon.aligndown { background: url('images/lc_aligndown.svg') no-repeat center !important; }
+.w2ui-icon.objectalignleft { background: url('images/lc_objectalignleft.svg') no-repeat center; }
+.w2ui-icon.aligncenter { background: url('images/lc_aligncenter.svg') no-repeat center; }
+.w2ui-icon.objectalignright { background: url('images/lc_objectalignright.svg') no-repeat center; }
+.w2ui-icon.alignup { background: url('images/lc_alignup.svg') no-repeat center; }
+.w2ui-icon.alignmiddle { background: url('images/lc_alignmiddle.svg') no-repeat center; }
+.w2ui-icon.aligndown { background: url('images/lc_aligndown.svg') no-repeat center; }
 
-.w2ui-icon.arrangemenu { background: url('images/lc_arrangemenu.svg') no-repeat center !important; }
-.w2ui-icon.bringtofront { background: url('images/lc_bringtofront.svg') no-repeat center !important; }
-.w2ui-icon.objectforwardone { background: url('images/lc_objectforwardone.svg') no-repeat center !important; }
-.w2ui-icon.objectbackone { background: url('images/lc_objectbackone.svg') no-repeat center !important; }
-.w2ui-icon.sendtoback { background: url('images/lc_sendtoback.svg') no-repeat center !important; }
+.w2ui-icon.arrangemenu { background: url('images/lc_arrangemenu.svg') no-repeat center; }
+.w2ui-icon.bringtofront { background: url('images/lc_bringtofront.svg') no-repeat center; }
+.w2ui-icon.objectforwardone { background: url('images/lc_objectforwardone.svg') no-repeat center; }
+.w2ui-icon.objectbackone { background: url('images/lc_objectbackone.svg') no-repeat center; }
+.w2ui-icon.sendtoback { background: url('images/lc_sendtoback.svg') no-repeat center; }
 
-.w2ui-icon.vereign{ background: url('images/vereign.png') no-repeat center !important; }
+.w2ui-icon.vereign{ background: url('images/vereign.png') no-repeat center; }
 
 /* dark theme icon css */
-[data-theme='dark'] .w2ui-icon.basicshapes_round-rectangle { background: url('images/dark/lc_rect_rounded.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.basicshapes_rectangle { background: url('images/dark/lc_rect.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.basicshapes_quadrat { background: url('images/dark/lc_square.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.basicshapes_round-quadrat { background: url('images/dark/lc_basicshapes.round-quadrat.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.basicshapes_circle { background: url('images/dark/lc_circle.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.basicshapes_ellipse { background: url('images/dark/lc_ellipse.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.basicshapes_circle-pie { background: url('images/dark/lc_pie.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.basicshapes_isosceles-triangle { background: url('images/dark/lc_basicshapes.isosceles-triangle.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.basicshapes_right-triangle { background: url('images/dark/lc_basicshapes.right-triangle.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.basicshapes_trapezoid { background: url('images/dark/lc_basicshapes.trapezoid.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.basicshapes_diamond { background: url('images/dark/lc_basicshapes.diamond.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.basicshapes_parallelogram { background: url('images/dark/lc_flowchartshapes.flowchart-data.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.basicshapes_pentagon { background: url('images/dark/lc_basicshapes.pentagon.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.basicshapes_hexagon { background: url('images/dark/lc_basicshapes.hexagon.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.basicshapes_octagon { background: url('images/dark/lc_basicshapes.octagon.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.basicshapes_cross { background: url('images/dark/lc_basicshapes.cross.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.basicshapes_ring { background: url('images/dark/lc_basicshapes.ring.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.basicshapes_block-arc { background: url('images/dark/lc_basicshapes.block-arc.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.basicshapes_can { background: url('images/dark/lc_basicshapes.can.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.basicshapes_cube { background: url('images/dark/lc_basicshapes.cube.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.basicshapes_paper { background: url('images/dark/lc_basicshapes.paper.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.basicshapes_frame { background: url('images/dark/lc_rect_unfilled.svg') no-repeat center !important; }
+[data-theme='dark'] .w2ui-icon.basicshapes_round-rectangle { background: url('images/dark/lc_rect_rounded.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.basicshapes_rectangle { background: url('images/dark/lc_rect.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.basicshapes_quadrat { background: url('images/dark/lc_square.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.basicshapes_round-quadrat { background: url('images/dark/lc_basicshapes.round-quadrat.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.basicshapes_circle { background: url('images/dark/lc_circle.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.basicshapes_ellipse { background: url('images/dark/lc_ellipse.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.basicshapes_circle-pie { background: url('images/dark/lc_pie.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.basicshapes_isosceles-triangle { background: url('images/dark/lc_basicshapes.isosceles-triangle.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.basicshapes_right-triangle { background: url('images/dark/lc_basicshapes.right-triangle.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.basicshapes_trapezoid { background: url('images/dark/lc_basicshapes.trapezoid.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.basicshapes_diamond { background: url('images/dark/lc_basicshapes.diamond.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.basicshapes_parallelogram { background: url('images/dark/lc_flowchartshapes.flowchart-data.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.basicshapes_pentagon { background: url('images/dark/lc_basicshapes.pentagon.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.basicshapes_hexagon { background: url('images/dark/lc_basicshapes.hexagon.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.basicshapes_octagon { background: url('images/dark/lc_basicshapes.octagon.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.basicshapes_cross { background: url('images/dark/lc_basicshapes.cross.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.basicshapes_ring { background: url('images/dark/lc_basicshapes.ring.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.basicshapes_block-arc { background: url('images/dark/lc_basicshapes.block-arc.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.basicshapes_can { background: url('images/dark/lc_basicshapes.can.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.basicshapes_cube { background: url('images/dark/lc_basicshapes.cube.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.basicshapes_paper { background: url('images/dark/lc_basicshapes.paper.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.basicshapes_frame { background: url('images/dark/lc_rect_unfilled.svg') no-repeat center; }
 
-[data-theme='dark'] .w2ui-icon.line { background: url('images/dark/lc_line.svg') no-repeat center !important; }
+[data-theme='dark'] .w2ui-icon.line { background: url('images/dark/lc_line.svg') no-repeat center; }
 
-[data-theme='dark'] .w2ui-icon.symbolshapes { background: url('images/dark/lc_symbolshapes.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.symbolshapes_sun { background: url('images/dark/lc_symbolshapes.sun.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.symbolshapes_moon { background: url('images/dark/lc_symbolshapes.moon.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.symbolshapes_lightning { background: url('images/dark/lc_symbolshapes.lightning.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.symbolshapes_heart { background: url('images/dark/lc_symbolshapes.heart.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.symbolshapes_flower { background: url('images/dark/lc_symbolshapes.flower.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.symbolshapes_cloud { background: url('images/dark/lc_symbolshapes.cloud.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.symbolshapes_forbidden { background: url('images/dark/lc_symbolshapes.forbidden.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.symbolshapes_puzzle { background: url('images/dark/lc_symbolshapes.puzzle.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.symbolshapes_bracket-pair { background: url('images/dark/lc_symbolshapes.bracket-pair.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.symbolshapes_left-bracket { background: url('images/dark/lc_symbolshapes.left-bracket.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.symbolshapes_right-bracket { background: url('images/dark/lc_symbolshapes.right-bracket.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.symbolshapes_brace-pair { background: url('images/dark/lc_symbolshapes.brace-pair.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.symbolshapes_left-brace { background: url('images/dark/lc_symbolshapes.left-brace.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.symbolshapes_right-brace { background: url('images/dark/lc_symbolshapes.right-brace.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.symbolshapes_quad-bevel { background: url('images/dark/lc_symbolshapes.right-brace.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.symbolshapes_octagon-bevel { background: url('images/dark/lc_symbolshapes.octagon-bevel.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.symbolshapes_diamond-bevel { background: url('images/dark/lc_symbolshapes.diamond-bevel.svg') no-repeat center !important; }
+[data-theme='dark'] .w2ui-icon.symbolshapes { background: url('images/dark/lc_symbolshapes.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.symbolshapes_sun { background: url('images/dark/lc_symbolshapes.sun.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.symbolshapes_moon { background: url('images/dark/lc_symbolshapes.moon.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.symbolshapes_lightning { background: url('images/dark/lc_symbolshapes.lightning.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.symbolshapes_heart { background: url('images/dark/lc_symbolshapes.heart.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.symbolshapes_flower { background: url('images/dark/lc_symbolshapes.flower.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.symbolshapes_cloud { background: url('images/dark/lc_symbolshapes.cloud.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.symbolshapes_forbidden { background: url('images/dark/lc_symbolshapes.forbidden.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.symbolshapes_puzzle { background: url('images/dark/lc_symbolshapes.puzzle.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.symbolshapes_bracket-pair { background: url('images/dark/lc_symbolshapes.bracket-pair.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.symbolshapes_left-bracket { background: url('images/dark/lc_symbolshapes.left-bracket.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.symbolshapes_right-bracket { background: url('images/dark/lc_symbolshapes.right-bracket.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.symbolshapes_brace-pair { background: url('images/dark/lc_symbolshapes.brace-pair.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.symbolshapes_left-brace { background: url('images/dark/lc_symbolshapes.left-brace.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.symbolshapes_right-brace { background: url('images/dark/lc_symbolshapes.right-brace.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.symbolshapes_quad-bevel { background: url('images/dark/lc_symbolshapes.right-brace.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.symbolshapes_octagon-bevel { background: url('images/dark/lc_symbolshapes.octagon-bevel.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.symbolshapes_diamond-bevel { background: url('images/dark/lc_symbolshapes.diamond-bevel.svg') no-repeat center; }
 
-[data-theme='dark'] .w2ui-icon.arrowshapes_left-arrow { background: url('images/dark/lc_arrowshapes.left-arrow.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.arrowshapes_right-arrow { background: url('images/dark/lc_arrowshapes.right-arrow.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.arrowshapes_up-arrow { background: url('images/dark/lc_arrowshapes.up-arrow.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.arrowshapes_down-arrow { background: url('images/dark/lc_arrowshapes.down-arrow.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.arrowshapes_left-right-arrow { background: url('images/dark/lc_arrowshapes.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.arrowshapes_up-down-arrow { background: url('images/dark/lc_arrowshapes.up-down-arrow.svg') no-repeat center !important; }
+[data-theme='dark'] .w2ui-icon.arrowshapes_left-arrow { background: url('images/dark/lc_arrowshapes.left-arrow.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.arrowshapes_right-arrow { background: url('images/dark/lc_arrowshapes.right-arrow.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.arrowshapes_up-arrow { background: url('images/dark/lc_arrowshapes.up-arrow.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.arrowshapes_down-arrow { background: url('images/dark/lc_arrowshapes.down-arrow.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.arrowshapes_left-right-arrow { background: url('images/dark/lc_arrowshapes.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.arrowshapes_up-down-arrow { background: url('images/dark/lc_arrowshapes.up-down-arrow.svg') no-repeat center; }
 
-[data-theme='dark'] .w2ui-icon.arrowshapes_up-right-arrow { background: url('images/dark/lc_arrowshapes.up-right-arrow.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.arrowshapes_up-right-down-arrow { background: url('images/dark/lc_arrowshapes.up-right-down-arrow.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.arrowshapes_quad-arrow { background: url('images/dark/lc_arrowshapes.quad-arrow.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.arrowshapes_corner-right-arrow { background: url('images/dark/lc_arrowshapes.corner-right-arrow.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.arrowshapes_split-arrow { background: url('images/dark/lc_arrowshapes.split-arrow.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.arrowshapes_striped-right-arrow { background: url('images/dark/lc_arrowshapes.striped-right-arrow.svg') no-repeat center !important; }
+[data-theme='dark'] .w2ui-icon.arrowshapes_up-right-arrow { background: url('images/dark/lc_arrowshapes.up-right-arrow.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.arrowshapes_up-right-down-arrow { background: url('images/dark/lc_arrowshapes.up-right-down-arrow.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.arrowshapes_quad-arrow { background: url('images/dark/lc_arrowshapes.quad-arrow.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.arrowshapes_corner-right-arrow { background: url('images/dark/lc_arrowshapes.corner-right-arrow.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.arrowshapes_split-arrow { background: url('images/dark/lc_arrowshapes.split-arrow.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.arrowshapes_striped-right-arrow { background: url('images/dark/lc_arrowshapes.striped-right-arrow.svg') no-repeat center; }
 
-[data-theme='dark'] .w2ui-icon.arrowshapes_notched-right-arrow { background: url('images/dark/lc_arrowshapes.notched-right-arrow.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.arrowshapes_pentagon-right { background: url('images/dark/lc_arrowshapes.pentagon-right.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.arrowshapes_chevron { background: url('images/dark/lc_arrowshapes.chevron.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.arrowshapes_right-arrow-callout { background: url('images/dark/lc_arrowshapes.right-arrow-callout.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.arrowshapes_left-arrow-callout { background: url('images/dark/lc_arrowshapes.left-arrow-callout.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.arrowshapes_up-arrow-callout { background: url('images/dark/lc_arrowshapes.up-arrow-callout.svg') no-repeat center !important; }
+[data-theme='dark'] .w2ui-icon.arrowshapes_notched-right-arrow { background: url('images/dark/lc_arrowshapes.notched-right-arrow.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.arrowshapes_pentagon-right { background: url('images/dark/lc_arrowshapes.pentagon-right.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.arrowshapes_chevron { background: url('images/dark/lc_arrowshapes.chevron.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.arrowshapes_right-arrow-callout { background: url('images/dark/lc_arrowshapes.right-arrow-callout.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.arrowshapes_left-arrow-callout { background: url('images/dark/lc_arrowshapes.left-arrow-callout.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.arrowshapes_up-arrow-callout { background: url('images/dark/lc_arrowshapes.up-arrow-callout.svg') no-repeat center; }
 
-[data-theme='dark'] .w2ui-icon.arrowshapes_down-arrow-callout { background: url('images/dark/lc_arrowshapes.down-arrow-callout.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.arrowshapes_left-right-arrow-callout { background: url('images/dark/lc_arrowshapes.left-right-arrow-callout.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.arrowshapes_up-down-arrow-callout { background: url('images/dark/lc_arrowshapes.up-down-arrow-callout.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.arrowshapes_up-right-arrow-callout { background: url('images/dark/lc_arrowshapes.up-right-arrow-callout.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.arrowshapes_quad-arrow-callout { background: url('images/dark/lc_arrowshapes.quad-arrow-callout.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.arrowshapes_circular-arrow { background: url('images/dark/lc_arrowshapes.circular-arrow.svg') no-repeat center !important; }
+[data-theme='dark'] .w2ui-icon.arrowshapes_down-arrow-callout { background: url('images/dark/lc_arrowshapes.down-arrow-callout.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.arrowshapes_left-right-arrow-callout { background: url('images/dark/lc_arrowshapes.left-right-arrow-callout.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.arrowshapes_up-down-arrow-callout { background: url('images/dark/lc_arrowshapes.up-down-arrow-callout.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.arrowshapes_up-right-arrow-callout { background: url('images/dark/lc_arrowshapes.up-right-arrow-callout.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.arrowshapes_quad-arrow-callout { background: url('images/dark/lc_arrowshapes.quad-arrow-callout.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.arrowshapes_circular-arrow { background: url('images/dark/lc_arrowshapes.circular-arrow.svg') no-repeat center; }
 
-[data-theme='dark'] .w2ui-icon.arrowshapes_split-round-arrow { background: url('images/dark/lc_arrowshapes.split-round-arrow.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.arrowshapes_s-sharped-arrow { background: url('images/dark/lc_arrowshapes.s-sharped-arrow.svg') no-repeat center !important; }
+[data-theme='dark'] .w2ui-icon.arrowshapes_split-round-arrow { background: url('images/dark/lc_arrowshapes.split-round-arrow.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.arrowshapes_s-sharped-arrow { background: url('images/dark/lc_arrowshapes.s-sharped-arrow.svg') no-repeat center; }
 
-[data-theme='dark'] .w2ui-icon.starshapes_bang { background: url('images/dark/lc_starshapes.bang.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.starshapes_star4 { background: url('images/dark/lc_starshapes.star4.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.starshapes_star5 { background: url('images/dark/lc_starshapes.star5.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.starshapes_star6 { background: url('images/dark/lc_starshapes.star6.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.starshapes_star8 { background: url('images/dark/lc_starshapes.star8.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.starshapes_star12 { background: url('images/dark/lc_starshapes.star12.svg') no-repeat center !important; }
+[data-theme='dark'] .w2ui-icon.starshapes_bang { background: url('images/dark/lc_starshapes.bang.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.starshapes_star4 { background: url('images/dark/lc_starshapes.star4.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.starshapes_star5 { background: url('images/dark/lc_starshapes.star5.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.starshapes_star6 { background: url('images/dark/lc_starshapes.star6.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.starshapes_star8 { background: url('images/dark/lc_starshapes.star8.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.starshapes_star12 { background: url('images/dark/lc_starshapes.star12.svg') no-repeat center; }
 
-[data-theme='dark'] .w2ui-icon.starshapes_star24 { background: url('images/dark/lc_starshapes.star24.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.starshapes_concave-star6 { background: url('images/dark/lc_starshapes.concave-star6.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.starshapes_vertical-scroll { background: url('images/dark/lc_starshapes.vertical-scroll.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.starshapes_horizontal-scroll { background: url('images/dark/lc_starshapes.horizontal-scroll.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.starshapes_signet { background: url('images/dark/lc_starshapes.signet.svg' ) no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.starshapes_doorplate { background: url('images/dark/lc_starshapes.doorplate.svg') no-repeat center !important; }
+[data-theme='dark'] .w2ui-icon.starshapes_star24 { background: url('images/dark/lc_starshapes.star24.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.starshapes_concave-star6 { background: url('images/dark/lc_starshapes.concave-star6.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.starshapes_vertical-scroll { background: url('images/dark/lc_starshapes.vertical-scroll.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.starshapes_horizontal-scroll { background: url('images/dark/lc_starshapes.horizontal-scroll.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.starshapes_signet { background: url('images/dark/lc_starshapes.signet.svg' ) no-repeat center; }
+[data-theme='dark'] .w2ui-icon.starshapes_doorplate { background: url('images/dark/lc_starshapes.doorplate.svg') no-repeat center; }
 
-[data-theme='dark'] .w2ui-icon.calloutshapes_rectangular-callout { background: url('images/dark/lc_calloutshapes.rectangular-callout.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.calloutshapes_round-rectangular-callout { background: url('images/dark/lc_calloutshapes.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.calloutshapes_round-callout { background: url('images/dark/lc_calloutshapes.round-callout.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.calloutshapes_cloud-callout { background: url('images/dark/lc_calloutshapes.cloud-callout.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.calloutshapes_line-callout-1 { background: url('images/dark/lc_calloutshapes.line-callout-1.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.calloutshapes_line-callout-2 { background: url('images/dark/lc_calloutshapes.line-callout-2.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.calloutshapes_line-callout-3 { background: url('images/dark/lc_calloutshapes.line-callout-3.svg') no-repeat center !important; }
+[data-theme='dark'] .w2ui-icon.calloutshapes_rectangular-callout { background: url('images/dark/lc_calloutshapes.rectangular-callout.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.calloutshapes_round-rectangular-callout { background: url('images/dark/lc_calloutshapes.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.calloutshapes_round-callout { background: url('images/dark/lc_calloutshapes.round-callout.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.calloutshapes_cloud-callout { background: url('images/dark/lc_calloutshapes.cloud-callout.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.calloutshapes_line-callout-1 { background: url('images/dark/lc_calloutshapes.line-callout-1.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.calloutshapes_line-callout-2 { background: url('images/dark/lc_calloutshapes.line-callout-2.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.calloutshapes_line-callout-3 { background: url('images/dark/lc_calloutshapes.line-callout-3.svg') no-repeat center; }
 
-[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-process { background: url('images/dark/lc_square.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-alternate-process { background: url('images/dark/lc_basicshapes.round-quadrat.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-decision { background: url('images/dark/lc_flowchartshapes.flowchart-decision.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-data { background: url('images/dark/lc_flowchartshapes.flowchart-data.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-predefined-process { background: url('images/dark/lc_flowchartshapes.flowchart-predefined-process.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-internal-storage { background: url('images/dark/lc_flowchartshapes.flowchart-internal-storage.svg') no-repeat center !important; }
+[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-process { background: url('images/dark/lc_square.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-alternate-process { background: url('images/dark/lc_basicshapes.round-quadrat.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-decision { background: url('images/dark/lc_flowchartshapes.flowchart-decision.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-data { background: url('images/dark/lc_flowchartshapes.flowchart-data.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-predefined-process { background: url('images/dark/lc_flowchartshapes.flowchart-predefined-process.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-internal-storage { background: url('images/dark/lc_flowchartshapes.flowchart-internal-storage.svg') no-repeat center; }
 
-[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-document { background: url('images/dark/lc_flowchartshapes.flowchart-document.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-multidocument { background: url('images/dark/lc_flowchartshapes.flowchart-multidocument.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-terminator { background: url('images/dark/lc_flowchartshapes.flowchart-terminator.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-preparation { background: url('images/dark/lc_flowchartshapes.flowchart-preparation.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-manual-input { background: url('images/dark/lc_flowchartshapes.flowchart-manual-input.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-manual-operation { background: url('images/dark/lc_basicshapes.trapezoid.svg') no-repeat center !important; }
+[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-document { background: url('images/dark/lc_flowchartshapes.flowchart-document.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-multidocument { background: url('images/dark/lc_flowchartshapes.flowchart-multidocument.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-terminator { background: url('images/dark/lc_flowchartshapes.flowchart-terminator.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-preparation { background: url('images/dark/lc_flowchartshapes.flowchart-preparation.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-manual-input { background: url('images/dark/lc_flowchartshapes.flowchart-manual-input.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-manual-operation { background: url('images/dark/lc_basicshapes.trapezoid.svg') no-repeat center; }
 
-[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-connector { background: url('images/dark/lc_circle.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-off-page-connector { background: url('images/dark/lc_flowchartshapes.flowchart-off-page-connector.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-card { background: url('images/dark/lc_flowchartshapes.flowchart-card.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-punched-tape { background: url('images/dark/lc_fontworkshapetype.fontwork-wave.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-summing-junction { background: url('images/dark/lc_flowchartshapes.flowchart-summing-junction.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-or { background: url('images/dark/lc_flowchartshapes.flowchart-or.svg') no-repeat center !important; }
+[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-connector { background: url('images/dark/lc_circle.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-off-page-connector { background: url('images/dark/lc_flowchartshapes.flowchart-off-page-connector.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-card { background: url('images/dark/lc_flowchartshapes.flowchart-card.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-punched-tape { background: url('images/dark/lc_fontworkshapetype.fontwork-wave.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-summing-junction { background: url('images/dark/lc_flowchartshapes.flowchart-summing-junction.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-or { background: url('images/dark/lc_flowchartshapes.flowchart-or.svg') no-repeat center; }
 
-[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-collate { background: url('images/dark/lc_flowchartshapes.flowchart-collate.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-sort { background: url('images/dark/lc_flowchartshapes.flowchart-sort.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-extract { background: url('images/dark/lc_basicshapes.isosceles-triangle.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-merge { background: url('images/dark/lc_fontworkshapetype.fontwork-triangle-down.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-stored-data { background: url('images/dark/lc_flowchartshapes.flowchart-stored-data.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-delay { background: url('images/dark/lc_flowchartshapes.flowchart-delay.svg') no-repeat center !important; }
+[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-collate { background: url('images/dark/lc_flowchartshapes.flowchart-collate.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-sort { background: url('images/dark/lc_flowchartshapes.flowchart-sort.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-extract { background: url('images/dark/lc_basicshapes.isosceles-triangle.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-merge { background: url('images/dark/lc_fontworkshapetype.fontwork-triangle-down.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-stored-data { background: url('images/dark/lc_flowchartshapes.flowchart-stored-data.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-delay { background: url('images/dark/lc_flowchartshapes.flowchart-delay.svg') no-repeat center; }
 
-[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-sequential-access { background: url('images/dark/lc_flowchartshapes.flowchart-sequential-access.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-magnetic-disk { background: url('images/dark/lc_basicshapes.can.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-direct-access-storage { background: url('images/dark/lc_flowchartshapes.flowchart-direct-access-storage.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-display { background: url('images/dark/lc_flowchartshapes.flowchart-display.svg') no-repeat center !important; }
+[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-sequential-access { background: url('images/dark/lc_flowchartshapes.flowchart-sequential-access.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-magnetic-disk { background: url('images/dark/lc_basicshapes.can.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-direct-access-storage { background: url('images/dark/lc_flowchartshapes.flowchart-direct-access-storage.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.flowchartshapes_flowchart-display { background: url('images/dark/lc_flowchartshapes.flowchart-display.svg') no-repeat center; }
 
-[data-theme='dark'] .w2ui-icon.connectors_connector { background: url('images/dark/lc_connector.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.connectors_connectorarrows { background: url('images/dark/lc_connectorarrows.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.connectors_connectorarrowend { background: url('images/dark/lc_connectorarrowend.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.connectors_connectorlinearrowend { background: url('images/dark/lc_connectorlinearrowend.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.connectors_connectorcurvearrowend { background: url('images/dark/lc_connectorcurvearrowend.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.connectors_connectorlinesarrowend { background: url('images/dark/lc_connectorlinesarrowend.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.connectors_connectorline { background: url('images/dark/lc_connectorline.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.connectors_connectorcurve { background: url('images/dark/lc_connectorcurve.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.connectors_connectorlines { background: url('images/dark/lc_connectorlines.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.connectors_connectorlinearrows { background: url('images/dark/lc_connectorlinearrows.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.connectors_connectorcurvearrows { background: url('images/dark/lc_connectorcurvearrows.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.print{ background: url('images/dark/lc_print.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.undo{ background: url('images/dark/lc_undo.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.redo{ background: url('images/dark/lc_redo.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.copyformat{ background: url('images/dark/lc_formatpaintbrush.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.deleteformat{ background: url('images/dark/lc_setdefault.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.bold{ background: url('images/dark/lc_bold.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.italic{ background: url('images/dark/lc_italic.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.underline{ background: url('images/dark/lc_underline.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.strikeout{ background: url('images/dark/lc_strikeout.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.textcolor{ background: url('images/dark/lc_fontcolor.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.backcolor{ background: url('images/dark/lc_backcolor.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.backgroundcolor{ background: url('images/dark/lc_fillcolor.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.alignleft{ background: url('images/dark/lc_leftpara.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.alignhorizontal{ background: url('images/dark/lc_centerpara.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.alignright{ background: url('images/dark/lc_rightpara.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.alignblock{ background: url('images/dark/lc_justifypara.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.aligntop{ background: url('images/dark/lc_aligntop.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.alignvcenter{ background: url('images/dark/lc_alignvcenter.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.alignbottom{ background: url('images/dark/lc_alignbottom.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.cellverttop{ background: url('images/dark/lc_cellverttop.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.cellvertcenter{ background: url('images/dark/lc_cellvertcenter.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.cellvertbottom{ background: url('images/dark/lc_cellvertbottom.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.linespacing, .w2ui-icon.spacepara1, .w2ui-icon.spacepara15{ background: url('images/dark/lc_linespacing.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.spacepara2{ background: url('images/dark/lc_spacepara2.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.paraspaceincrease{ background: url('images/dark/lc_paraspaceincrease.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.paraspacedecrease{ background: url('images/dark/lc_paraspacedecrease.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.numbering{ background: url('images/dark/lc_defaultnumbering.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.bullet{ background: url('images/dark/lc_defaultbullet.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.incrementindent{ background: url('images/dark/lc_leftindent.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.decrementindent{ background: url('images/dark/lc_decrementindent.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.outlineleft{ background: url('images/dark/lc_outlineleft.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.outlineright{ background: url('images/dark/lc_outlineright.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.text{ background: url('images/dark/lc_text.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.annotation{ background: url('images/dark/lc_shownote.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.inserttable{ background: url('images/dark/lc_inserttable.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.insertgraphic{ background: url('images/dark/lc_gallery.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.link{ background: url('images/dark/lc_inserthyperlink.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.insertsymbol{ background: url('images/dark/lc_insertsymbol.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.edit{ background: url('images/dark/lc_editdoc.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.fold{ background: url('images/dark/fold.svg') no-repeat center center / 19px !important; opacity: 0.8; filter: alpha(opacity=80);}
-[data-theme='dark'] .w2ui-icon.unfold{ background: url('images/dark/unfold.svg') no-repeat center center/ 19px !important; opacity: 0.8; filter: alpha(opacity=80);}
-[data-theme='dark'] .w2ui-icon.hamburger{ background: url('images/dark/hamburger.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.setborderstyle{ background: url('images/dark/lc_setborderstyle.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.togglemergecells{ background: url('images/dark/lc_togglemergecells.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.wraptext{ background: url('images/dark/lc_wraptext.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.numberformatstandard{ background: url('images/dark/lc_numberformatstandard.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.numberformatcurrency{ background: url('images/dark/lc_numberformatcurrency.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.numberformatpercent{ background: url('images/dark/lc_numberformatpercent.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.numberformatdecimal{ background: url('images/dark/lc_numberformatdecimal.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.numberformatdate{ background: url('images/dark/lc_numberformatdate.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.numberformattime{ background: url('images/dark/lc_numberformattime.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.numberformatscientific{ background: url('images/dark/lc_numberformatscientific.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.numberformatthousands{ background: url('images/dark/lc_numberformatthousands.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.numberformatincdecimals{ background: url('images/dark/lc_numberformatincdecimals.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.numberformatdecdecimals{ background: url('images/dark/lc_numberformatdecdecimals.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.insertobjectchart{ background: url('images/dark/lc_drawchart.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.insertrowsafter{ background: url('images/dark/lc_insertrowsafter.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.insertcolumnsafter{ background: url('images/dark/lc_insertcolumnsafter.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.insertcolumnsbefore{ background: url('images/dark/lc_insertcolumnsbefore.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.insertrowsbefore{ background: url('images/dark/lc_insertrowsbefore.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.autosum{ background: url('images/dark/lc_autosum.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.orientation{ background: url('images/dark/lc_orientation.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.deleterows{ background: url('images/dark/lc_deleterows.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.hiderow{ background: url('images/dark/lc_hiderow.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.showrow{ background: url('images/dark/lc_showrow.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.deletecolumns{ background: url('images/dark/lc_deletecolumns.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.hidecolumn{ background: url('images/dark/lc_hidecolumn.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.showcolumn{ background: url('images/dark/lc_showcolumn.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.entirerow{ background: url('images/dark/lc_entirerow.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.setoptimalrowheight{ background: url('images/dark/lc_setoptimalrowheight.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.setoptimalcolumnwidth{ background: url('images/dark/lc_setoptimalcolumnwidth.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.entirecell{ background: url('images/dark/lc_entirecell.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.entirecolumn{ background: url('images/dark/lc_entirecolumn.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.selecttable{ background: url('images/dark/lc_selecttable.svg') no-repeat center !important; }
+[data-theme='dark'] .w2ui-icon.connectors_connector { background: url('images/dark/lc_connector.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.connectors_connectorarrows { background: url('images/dark/lc_connectorarrows.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.connectors_connectorarrowend { background: url('images/dark/lc_connectorarrowend.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.connectors_connectorlinearrowend { background: url('images/dark/lc_connectorlinearrowend.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.connectors_connectorcurvearrowend { background: url('images/dark/lc_connectorcurvearrowend.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.connectors_connectorlinesarrowend { background: url('images/dark/lc_connectorlinesarrowend.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.connectors_connectorline { background: url('images/dark/lc_connectorline.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.connectors_connectorcurve { background: url('images/dark/lc_connectorcurve.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.connectors_connectorlines { background: url('images/dark/lc_connectorlines.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.connectors_connectorlinearrows { background: url('images/dark/lc_connectorlinearrows.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.connectors_connectorcurvearrows { background: url('images/dark/lc_connectorcurvearrows.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.print{ background: url('images/dark/lc_print.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.undo{ background: url('images/dark/lc_undo.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.redo{ background: url('images/dark/lc_redo.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.copyformat{ background: url('images/dark/lc_formatpaintbrush.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.deleteformat{ background: url('images/dark/lc_setdefault.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.bold{ background: url('images/dark/lc_bold.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.italic{ background: url('images/dark/lc_italic.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.underline{ background: url('images/dark/lc_underline.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.strikeout{ background: url('images/dark/lc_strikeout.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.textcolor{ background: url('images/dark/lc_fontcolor.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.backcolor{ background: url('images/dark/lc_backcolor.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.backgroundcolor{ background: url('images/dark/lc_fillcolor.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.alignleft{ background: url('images/dark/lc_leftpara.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.alignhorizontal{ background: url('images/dark/lc_centerpara.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.alignright{ background: url('images/dark/lc_rightpara.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.alignblock{ background: url('images/dark/lc_justifypara.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.aligntop{ background: url('images/dark/lc_aligntop.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.alignvcenter{ background: url('images/dark/lc_alignvcenter.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.alignbottom{ background: url('images/dark/lc_alignbottom.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.cellverttop{ background: url('images/dark/lc_cellverttop.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.cellvertcenter{ background: url('images/dark/lc_cellvertcenter.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.cellvertbottom{ background: url('images/dark/lc_cellvertbottom.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.linespacing, .w2ui-icon.spacepara1, .w2ui-icon.spacepara15{ background: url('images/dark/lc_linespacing.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.spacepara2{ background: url('images/dark/lc_spacepara2.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.paraspaceincrease{ background: url('images/dark/lc_paraspaceincrease.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.paraspacedecrease{ background: url('images/dark/lc_paraspacedecrease.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.numbering{ background: url('images/dark/lc_defaultnumbering.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.bullet{ background: url('images/dark/lc_defaultbullet.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.incrementindent{ background: url('images/dark/lc_leftindent.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.decrementindent{ background: url('images/dark/lc_decrementindent.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.outlineleft{ background: url('images/dark/lc_outlineleft.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.outlineright{ background: url('images/dark/lc_outlineright.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.text{ background: url('images/dark/lc_text.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.annotation{ background: url('images/dark/lc_shownote.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.inserttable{ background: url('images/dark/lc_inserttable.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.insertgraphic{ background: url('images/dark/lc_gallery.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.link{ background: url('images/dark/lc_inserthyperlink.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.insertsymbol{ background: url('images/dark/lc_insertsymbol.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.edit{ background: url('images/dark/lc_editdoc.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.fold{ background: url('images/dark/fold.svg') no-repeat center center / 19px; opacity: 0.8; filter: alpha(opacity=80);}
+[data-theme='dark'] .w2ui-icon.unfold{ background: url('images/dark/unfold.svg') no-repeat center center/ 19px; opacity: 0.8; filter: alpha(opacity=80);}
+[data-theme='dark'] .w2ui-icon.hamburger{ background: url('images/dark/hamburger.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.setborderstyle{ background: url('images/dark/lc_setborderstyle.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.togglemergecells{ background: url('images/dark/lc_togglemergecells.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.wraptext{ background: url('images/dark/lc_wraptext.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.numberformatstandard{ background: url('images/dark/lc_numberformatstandard.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.numberformatcurrency{ background: url('images/dark/lc_numberformatcurrency.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.numberformatpercent{ background: url('images/dark/lc_numberformatpercent.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.numberformatdecimal{ background: url('images/dark/lc_numberformatdecimal.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.numberformatdate{ background: url('images/dark/lc_numberformatdate.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.numberformattime{ background: url('images/dark/lc_numberformattime.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.numberformatscientific{ background: url('images/dark/lc_numberformatscientific.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.numberformatthousands{ background: url('images/dark/lc_numberformatthousands.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.numberformatincdecimals{ background: url('images/dark/lc_numberformatincdecimals.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.numberformatdecdecimals{ background: url('images/dark/lc_numberformatdecdecimals.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.insertobjectchart{ background: url('images/dark/lc_drawchart.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.insertrowsafter{ background: url('images/dark/lc_insertrowsafter.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.insertcolumnsafter{ background: url('images/dark/lc_insertcolumnsafter.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.insertcolumnsbefore{ background: url('images/dark/lc_insertcolumnsbefore.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.insertrowsbefore{ background: url('images/dark/lc_insertrowsbefore.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.autosum{ background: url('images/dark/lc_autosum.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.orientation{ background: url('images/dark/lc_orientation.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.deleterows{ background: url('images/dark/lc_deleterows.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.hiderow{ background: url('images/dark/lc_hiderow.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.showrow{ background: url('images/dark/lc_showrow.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.deletecolumns{ background: url('images/dark/lc_deletecolumns.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.hidecolumn{ background: url('images/dark/lc_hidecolumn.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.showcolumn{ background: url('images/dark/lc_showcolumn.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.entirerow{ background: url('images/dark/lc_entirerow.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.setoptimalrowheight{ background: url('images/dark/lc_setoptimalrowheight.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.setoptimalcolumnwidth{ background: url('images/dark/lc_setoptimalcolumnwidth.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.entirecell{ background: url('images/dark/lc_entirecell.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.entirecolumn{ background: url('images/dark/lc_entirecolumn.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.selecttable{ background: url('images/dark/lc_selecttable.svg') no-repeat center; }
 
-[data-theme='dark'] .w2ui-icon.accepttrackedchanges{ background: url('images/dark/lc_acceptchanges.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.ok{ background: url('images/dark/lc_ok.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.cancel{ background: url('images/dark/lc_cancel.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.color{ background: url('images/dark/lc_color.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.deletepage{ background: url('images/dark/lc_deletepage.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.duplicatepage{ background: url('images/dark/lc_duplicatepage.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.equal{ background: url('images/dark/lc26049.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.help{ background: url('images/dark/lc_helpindex.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.insertpage{ background: url('images/dark/lc_insertpage.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.insertsheet{ background: url('images/dark/plus.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.conditionalformatdialog{ background: url('images/dark/lc_conditionalformatmenu.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.search{ background: url('images/dark/sc_recsearch.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.next{ background: url('images/dark/lc_downsearch.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.presentation{ background: url('images/dark/lc_dia.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.sign_ok{ background: url('images/dark/sign_ok.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.sign_not_ok{ background: url('images/dark/sign_not_ok.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.prev{ background: url('images/dark/lc_upsearch.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.save{ background: url('images/dark/lc_save.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.saveas{ background: url('images/dark/lc_saveas.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.savemodified{ background: url('images/dark/savemodified_large.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.zoomin{ background: url('images/dark/plus.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.zoomout{ background: url('images/dark/minus.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.zoomreset{ background: url('images/dark/lc_view100.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.more{ background: url('images/dark/lc_downsearch.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.firstrecord{ background: url('images/dark/lc_firstrecord.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.nextrecord{ background: url('images/dark/lc_nextrecord.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.prevrecord{ background: url('images/dark/lc_prevrecord.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.lastrecord{ background: url('images/dark/lc_lastrecord.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.sortascending{ background: url('images/dark/lc_sortascending.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.sortdescending{ background: url('images/dark/lc_sortdescending.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.selected{ background: url('images/dark/lc_ok.svg') no-repeat center !important; }
+[data-theme='dark'] .w2ui-icon.accepttrackedchanges{ background: url('images/dark/lc_acceptchanges.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.ok{ background: url('images/dark/lc_ok.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.cancel{ background: url('images/dark/lc_cancel.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.color{ background: url('images/dark/lc_color.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.deletepage{ background: url('images/dark/lc_deletepage.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.duplicatepage{ background: url('images/dark/lc_duplicatepage.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.equal{ background: url('images/dark/lc26049.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.help{ background: url('images/dark/lc_helpindex.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.insertpage{ background: url('images/dark/lc_insertpage.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.insertsheet{ background: url('images/dark/plus.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.conditionalformatdialog{ background: url('images/dark/lc_conditionalformatmenu.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.search{ background: url('images/dark/sc_recsearch.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.next{ background: url('images/dark/lc_downsearch.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.presentation{ background: url('images/dark/lc_dia.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.sign_ok{ background: url('images/dark/sign_ok.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.sign_not_ok{ background: url('images/dark/sign_not_ok.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.prev{ background: url('images/dark/lc_upsearch.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.save{ background: url('images/dark/lc_save.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.saveas{ background: url('images/dark/lc_saveas.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.savemodified{ background: url('images/dark/savemodified_large.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.zoomin{ background: url('images/dark/plus.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.zoomout{ background: url('images/dark/minus.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.zoomreset{ background: url('images/dark/lc_view100.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.more{ background: url('images/dark/lc_downsearch.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.firstrecord{ background: url('images/dark/lc_firstrecord.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.nextrecord{ background: url('images/dark/lc_nextrecord.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.prevrecord{ background: url('images/dark/lc_prevrecord.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.lastrecord{ background: url('images/dark/lc_lastrecord.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.sortascending{ background: url('images/dark/lc_sortascending.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.sortdescending{ background: url('images/dark/lc_sortdescending.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.selected{ background: url('images/dark/lc_ok.svg') no-repeat center; }
 [data-theme='dark'] .w2ui-icon.users{ background: url('images/dark/contacts-dark.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.fullscreen{ background: url('images/dark/lc_fullscreen.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.closemobile{ background: url('images/dark/lc_closedocmobile.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.editmode { background: url('images/dark/lc_listitem-selected.svg') no-repeat center / 28px !important; }
-[data-theme='dark'] .w2ui-icon.closetoolbar{ background: url('images/dark/close_toolbar.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.sidebar_modify_page{ background: url('images/dark/lc_sidebar.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.sidebar_slide_change{ background: url('images/dark/lc_slidechangewindow.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.sidebar_custom_animation{ background: url('images/dark/lc_customanimation.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.sidebar_master_slides{ background: url('images/dark/lc_masterslide.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.mobile_wizard{ background: url('images/dark/lc_mobile_wizard.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.fullscreen-presentation{ background: url('images/dark/lc_fullscreen-presentation-toolbar-mobile.svg') no-repeat center !important;}
-[data-theme='dark'] .w2ui-icon.mobile_comment_wizard{ background: url('images/dark/lc_mobile_comment_wizard.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.insertion_mobile_wizard{ background: url('images/dark/lc_insertion_mobile_wizard.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.viewcomments{ background: url('images/dark/lc_mobile_comment_wizard.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.insertcomment{ background: url('images/dark/lc_insertcomment.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.freezepanes{ background: url('images/dark/lc_freezepanes.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.freezepanescolumn{ background: url('images/dark/lc_freezepanescolumn.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.freezepanesrow{ background: url('images/dark/lc_freezepanesrow.svg') no-repeat center !important; }
+[data-theme='dark'] .w2ui-icon.fullscreen{ background: url('images/dark/lc_fullscreen.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.closemobile{ background: url('images/dark/lc_closedocmobile.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.editmode { background: url('images/dark/lc_listitem-selected.svg') no-repeat center / 28px; }
+[data-theme='dark'] .w2ui-icon.closetoolbar{ background: url('images/dark/close_toolbar.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.sidebar_modify_page{ background: url('images/dark/lc_sidebar.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.sidebar_slide_change{ background: url('images/dark/lc_slidechangewindow.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.sidebar_custom_animation{ background: url('images/dark/lc_customanimation.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.sidebar_master_slides{ background: url('images/dark/lc_masterslide.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.mobile_wizard{ background: url('images/dark/lc_mobile_wizard.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.fullscreen-presentation{ background: url('images/dark/lc_fullscreen-presentation-toolbar-mobile.svg') no-repeat center;}
+[data-theme='dark'] .w2ui-icon.mobile_comment_wizard{ background: url('images/dark/lc_mobile_comment_wizard.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.insertion_mobile_wizard{ background: url('images/dark/lc_insertion_mobile_wizard.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.viewcomments{ background: url('images/dark/lc_mobile_comment_wizard.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.insertcomment{ background: url('images/dark/lc_insertcomment.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.freezepanes{ background: url('images/dark/lc_freezepanes.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.freezepanescolumn{ background: url('images/dark/lc_freezepanescolumn.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.freezepanesrow{ background: url('images/dark/lc_freezepanesrow.svg') no-repeat center; }
 
-[data-theme='dark'] .w2ui-icon.flipvertical { background: url('images/dark/lc_flipvertical.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.fliphorizontal { background: url('images/dark/lc_fliphorizontal.svg') no-repeat center !important; }
+[data-theme='dark'] .w2ui-icon.flipvertical { background: url('images/dark/lc_flipvertical.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.fliphorizontal { background: url('images/dark/lc_fliphorizontal.svg') no-repeat center; }
 
-[data-theme='dark'] .w2ui-icon.wrapmenu { background: url('images/dark/lc_wrapmenu.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.wrapoff { background: url('images/dark/lc_wrapoff.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.wrapon { background: url('images/dark/lc_wrapon.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.wrapideal { background: url('images/dark/lc_wrapideal.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.wrapleft { background: url('images/dark/lc_wrapleft.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.wrapright { background: url('images/dark/lc_wrapright.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.wrapthrough { background: url('images/dark/lc_wrapthrough.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.wrapthroughtransparencytoggle { background: url('images/dark/lc_wrapthroughtransparencytoggle.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.wrapcontour { background: url('images/dark/lc_wrapcontour.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.wrapanchoronly { background: url('images/dark/lc_wrapanchoronly.svg') no-repeat center !important; }
+[data-theme='dark'] .w2ui-icon.wrapmenu { background: url('images/dark/lc_wrapmenu.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.wrapoff { background: url('images/dark/lc_wrapoff.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.wrapon { background: url('images/dark/lc_wrapon.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.wrapideal { background: url('images/dark/lc_wrapideal.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.wrapleft { background: url('images/dark/lc_wrapleft.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.wrapright { background: url('images/dark/lc_wrapright.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.wrapthrough { background: url('images/dark/lc_wrapthrough.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.wrapthroughtransparencytoggle { background: url('images/dark/lc_wrapthroughtransparencytoggle.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.wrapcontour { background: url('images/dark/lc_wrapcontour.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.wrapanchoronly { background: url('images/dark/lc_wrapanchoronly.svg') no-repeat center; }
 
-[data-theme='dark'] .w2ui-icon.objectalignleft { background: url('images/dark/lc_objectalignleft.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.aligncenter { background: url('images/dark/lc_aligncenter.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.objectalignright { background: url('images/dark/lc_objectalignright.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.alignup { background: url('images/dark/lc_alignup.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.alignmiddle { background: url('images/dark/lc_alignmiddle.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.aligndown { background: url('images/dark/lc_aligndown.svg') no-repeat center !important; }
+[data-theme='dark'] .w2ui-icon.objectalignleft { background: url('images/dark/lc_objectalignleft.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.aligncenter { background: url('images/dark/lc_aligncenter.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.objectalignright { background: url('images/dark/lc_objectalignright.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.alignup { background: url('images/dark/lc_alignup.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.alignmiddle { background: url('images/dark/lc_alignmiddle.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.aligndown { background: url('images/dark/lc_aligndown.svg') no-repeat center; }
 
-[data-theme='dark'] .w2ui-icon.arrangemenu { background: url('images/dark/lc_arrangemenu.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.bringtofront { background: url('images/dark/lc_bringtofront.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.objectforwardone { background: url('images/dark/lc_objectforwardone.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.objectbackone { background: url('images/dark/lc_objectbackone.svg') no-repeat center !important; }
-[data-theme='dark'] .w2ui-icon.sendtoback { background: url('images/dark/lc_sendtoback.svg') no-repeat center !important; }
+[data-theme='dark'] .w2ui-icon.arrangemenu { background: url('images/dark/lc_arrangemenu.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.bringtofront { background: url('images/dark/lc_bringtofront.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.objectforwardone { background: url('images/dark/lc_objectforwardone.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.objectbackone { background: url('images/dark/lc_objectbackone.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.sendtoback { background: url('images/dark/lc_sendtoback.svg') no-repeat center; }
 
-[data-theme='dark'] .w2ui-icon.vereign{ background: url('images/dark/vereign.png') no-repeat center !important; }
+[data-theme='dark'] .w2ui-icon.vereign{ background: url('images/dark/vereign.png') no-repeat center; }
 
 .inserttable-pop {
 	z-index: 1000;


### PR DESCRIPTION
Signed-off-by: Julius Härtl <jus@bitgrid.net>
Change-Id: I2a2ace9ffc2a31d500b6819f790a07e5762a5f6a

* Target version: master 

### Summary

This is basically a regex replace for any usage where the background image was enforced with `!important` in toolbar.css for the classic toolbar. From my perspective those were not needed at all and also make life harder during icon adjustments in other css parts like branding. 

I went through the classic toolbar on all apps and couldn't find a problem, but probably needs some careful checking from @pedropintosilva 

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

