### PR TITLE
zotero: initialize only one time

### DIFF
--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -764,7 +764,7 @@ L.Control.UIManager = L.Control.extend({
 		var userPrivateInfo = this.map._docLayer ? this.map._viewInfo[this.map._docLayer._viewId].userprivateinfo : null;
 		if (userPrivateInfo) {
 			var apiKey = userPrivateInfo.ZoteroAPIKey;
-			if (apiKey !== undefined) {
+			if (apiKey !== undefined && !this.map.zotero) {
 				this.map.zotero = L.control.zotero(this.map);
 				this.map.zotero.apiKey = apiKey;
 				this.map.addControl(this.map.zotero);


### PR DESCRIPTION
we didn't check if zotero was already initialized what caused reload of the notebookbar when any new user joined to collaborative editing