### PR TITLE
Sidebar Paragraph and Table Section has 1fr 1fr (50/50) width

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -262,6 +262,16 @@ button#button2.ui-pushbutton.jsdialog.sidebar {
 	width: 118px;
 }
 
+#TableEditPanel.sidebar.ui-grid #grid1,
+#ParaPropertyPanel.sidebar.ui-grid #grid1 {
+	grid-template-columns: 1fr 1fr !important; /* all columns use same width */
+	column-gap: 16px;
+}
+
+#numberbullet {
+	width: 121px; /* to much conent break grid columns width */
+}
+
 /* calc */
 
 /* cell appearance use one row */


### PR DESCRIPTION
see #6392 
This is needed to have the colums same width and
make everything nicely align

| before | after |
| --------- | -------- |
| ![Screenshot_20230527_010109](https://github.com/CollaboraOnline/online/assets/8517736/4ffac825-b9da-4436-a36e-2d14f7f621f3) | ![Screenshot_20230527_010927](https://github.com/CollaboraOnline/online/assets/8517736/cea385b4-5981-4ba7-a7da-c5465dcf4cdb) |

The Background Color command will be correct aligned with #6454 

Change-Id: I21887ba06606d6ea4bc10eaafb3964f2659c90e2