### PR TITLE
jsdialogs radio button use same margin than checkboxes

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -532,8 +532,10 @@ input[type='checkbox']:checked.autofilter, .jsdialog input[type='checkbox']:chec
 }
 
 .jsdialog input[type='radio'] {
-	margin: 0;
+	margin: 1px 8px;
 	border: none;
+	height: 18px;
+	width: 20px;
 }
 
 .jsdialog .radiobutton > label {


### PR DESCRIPTION
![Screenshot_20230528_231250-1](https://github.com/CollaboraOnline/online/assets/8517736/d4d44918-dd32-41c9-a9ef-178212d01158)

Change-Id: I3d9611595819d505632fc58686f1ee9355228524