### PR TITLE
Fix Draw - Page Layout cannot be open from top tool sidebar icon

### DIFF
--- a/browser/src/control/Control.NotebookbarDraw.js
+++ b/browser/src/control/Control.NotebookbarDraw.js
@@ -778,7 +778,7 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 			{
 				'type': 'bigtoolitem',
 				'text': _UNO('.uno:ModifyPage', 'drawing', true),
-				'command': '.uno:ModifyPage'
+				'command': '.uno:SidebarDeck.PropertyDeck'
 			},
 			{
 				'type': 'bigtoolitem',


### PR DESCRIPTION
Change-Id: If9a57484a8335034e3007f47513cd4827c8decbc


* Resolves: #6405 
* Target version: master 

- Fixed sidebar toogle functionality in odg (draw) file

