### PR TITLE
Fix: Speed-up callbacks

### DIFF
--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -614,6 +614,7 @@ public:
             }
         }
 #endif
+    if (!_newSockets.empty() || !_newCallbacks.empty())
         wakeup();
     }
 
@@ -718,8 +719,10 @@ public:
             newSocket->resetThreadOwner();
 
             std::lock_guard<std::mutex> lock(_mutex);
+            const bool wasEmpty = _newSockets.empty() && _newCallbacks.empty();
             _newSockets.emplace_back(std::move(newSocket));
-            wakeup();
+            if (wasEmpty)
+                wakeup();
         }
     }
 
@@ -746,7 +749,7 @@ public:
     void addCallback(const CallbackFn& fn)
     {
         std::lock_guard<std::mutex> lock(_mutex);
-        bool wasEmpty = _newCallbacks.empty();
+        const bool wasEmpty = _newSockets.empty() && _newCallbacks.empty();
         _newCallbacks.emplace_back(fn);
         if (wasEmpty)
             wakeup();


### PR DESCRIPTION
Change-Id: I796d71e48ae7110fb8d88eda781e362faba75aa2


* Resolves: #4837
* Target version: master 

### Summary

- Lock in callback function was already placed. 
- Poll already reads the whole value of wakeup[0] and it does not need to read wakeup[1].
- Check the condition to look for new sockets and call-backs before calling wakeup() is placed here. 

The third one was to check for callbacks and sockets before calling wakeup, which I implemented, and also studied more ways but checked that most of it was implemented.

### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

