### PR TITLE
restore tile debug popover content.

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -6921,7 +6921,9 @@ L.CanvasTileLayer = L.Layer.extend({
 			if (tile._debugTime.date !== 0)
 				msg += '<br>' + this._debugSetTimes(tile._debugTime, +new Date() - tile._debugTime.date).replace(/, /g, '<br>');
 			msg += '<br>nviewid: ' + tileMsgObj.nviewid;
-			tile._debugPopup.setContent(msg);
+			var node = document.createElement('p');
+			node.innerHTML = msg;
+			tile._debugPopup.setHTMLContent(node);
 
 			if (tile._debugTile) // deltas in yellow
 				tile._debugTile.setStyle({ fillOpacity: tile.lastKeyframe ? 0 : 0.1, fillColor: 'yellow' });


### PR DESCRIPTION
Somehow escaping was disabled for this safe text we generate.

Change-Id: I47fbf72b9d47a80975ca1b926ff2d27c248fac12


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

