### PR TITLE
fix(darkmode): Fix toggling darkmode in notebookbar

### DIFF
--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -106,14 +106,14 @@ L.Control.UIManager = L.Control.extend({
 			};
 			app.socket.sendMessage('uno .uno:ChangeTheme ' + JSON.stringify(cmd));
 		}
-		if (this.getSavedStateOrDefault('CompactMode', null)) {
+		if (this.getCurrentMode() === 'classic') {
 			this.refreshMenubar();
+			this.refreshToolbar();
 		}
 		else { 
 			this.refreshNotebookbar();
 		}
 		this.refreshSidebar();
-		this.refreshToolbar();
 	},
 	initDarkModeFromSettings: function() {
 		var selectedMode = this.getDarkModeState();


### PR DESCRIPTION
Signed-off-by: Julius Härtl <jus@bitgrid.net>
Change-Id: Ia8b490de6144df771e5ee115c068b87e997e3ccb


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

Fix error when toggling the darkmode wrongly tried to refresh the toolbar from compact mode.

```
Control.UIManager.js:425 Uncaught TypeError: Cannot read properties of undefined (reading 'refresh')
    at NewClass.refreshToolbar (Control.UIManager.js:425:19)
    at NewClass.toggleDarkMode (Control.UIManager.js:116:8)
    at NewClass.dispatch (Toolbar.js:971:19)
    at HTMLDivElement.<anonymous> (Control.JSDialogBuilder.js:2609:17)
    at HTMLDivElement.dispatch (jquery.js:5429:27)
    at elemData.handle (jquery.js:5233:28)
```

Steps to reproduce:
- Start cool with compact mode
- Switch to notebook bar
- Toggle dark mode back and forth

### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

