### PR TITLE
Related: #6423 _removeTile nearly never populates the tileCache

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -6657,8 +6657,10 @@ L.CanvasTileLayer = L.Layer.extend({
 
 		// FIXME: this _tileCache is used for prev/next slide; but it is
 		// dangerous in connection with typing / invalidation
-		if (!(this._tiles[key]._invalidCount > 0) && tile.el.src) {
-			this._tileCache[key] = tile.el;
+		if (!(this._tiles[key]._invalidCount > 0)) {
+			if (tile.el.src || tile.el instanceof HTMLCanvasElement) {
+				this._tileCache[key] = tile.el;
+			}
 		}
 
 		if (!tile.loaded && this._emptyTilesCount > 0) {


### PR DESCRIPTION
if the tile has a Canvas as tile element then it never gets cached.

All was apparently well at:

commit c812edc7d35782dfdccd10e4d7765df9f3b3da82
Date:   Mon Jun 7 12:31:26 2021 +0530

fix avoid putting empty tiles to cache

where the change to cache only if tile.el.src is non-null was added.

But by now tile.el can be (usually is) a canvas and generally doesn't get cached here.

It seems to work fine to just cache the Canvas directly.

note: This cache guard itself flip-flopped a bit in:

commit 6db97718967fd1434c0462dbe55a4d37eed04f88
Date:   Wed Jun 9 15:45:07 2021 +0300

CanvasTileLayer: Use el instead of el.src.

where changed as:

- if (!(this._tiles[key]._invalidCount > 0) && tile.el.src) {
+ if (!(this._tiles[key]._invalidCount > 0) && tile.el) {

but reverted in:

commit 115d20082d5398f8fed0ec16d5e4929df90f1f95
Date:   Tue Jul 6 15:59:08 2021 +0300

CanvasTileLayer: Correct the check for the tile source.

back to:

+ if (!(this._tiles[key]._invalidCount > 0) && tile.el.src) {


Change-Id: I1760f94c0aebd10b75f936f23460f96159c736af


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

