### PR TITLE
jsdialog: simplify css for button box

### DIFF
--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -77,25 +77,18 @@ button:not(.ui-tab):not(.ui-corner-all):not(.button-primary):not(.unobutton):not
 
 /* button box */
 
-/* - Add fallback for browsers without support
-for float logical values */
-html:not([dir='rtl']) .jsdialog.ui-button-box-right,
-html[dir='rtl'] .jsdialog.ui-button-box-left {
-	float: right;
+.jsdialog.ui-button-box {
+	display: grid;
 }
-html[dir='rtl'] .jsdialog.ui-button-box-right,
-html:not([dir='rtl']) .jsdialog.ui-button-box-left {
-	float: left;
-}
-/* - */
 
 .jsdialog.ui-button-box-right {
 	display: flex;
-	float: inline-end;
+	justify-self: end;
 	margin-inline-end: -5px;
 }
 
 .jsdialog.ui-button-box-left {
-	float: inline-start;
+	display: flex;
+	justify-self: start;
 	margin-inline-start: -5px;
 }


### PR DESCRIPTION
this fixes layout of 2 rows of button boxes,
example: manage names in Calc

![buttonbox](https://github.com/CollaboraOnline/online/assets/5307369/9ba0c852-9ebb-472d-a3c1-7a150c973230)
