### PR TITLE
Set the width of the effects buttons #6378

### DIFF
--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -92,3 +92,8 @@ button:not(.ui-tab):not(.ui-corner-all):not(.button-primary):not(.unobutton):not
 	justify-self: start;
 	margin-inline-start: -5px;
 }
+
+/* Eg: Sidebar -> Animation -> Effects buttons shouldn't overflow the content */
+button.has-img {
+	min-width: auto !important;
+}


### PR DESCRIPTION
Impress -> Sidebar -> Animation tab -> Effects
Unset the hardcoded  min-width and use fit-content instead.


Change-Id: If524533997e33037d669055fd5479ddcbba80d71


* Resolves: #6378
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

