### PR TITLE
fix worng image path name passing to setImage url

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -731,7 +731,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		}
 		if (iconURL) {
 			var icon = L.DomUtil.create('img', 'menu-entry-icon', leftDiv);
-			L.LOUtil.setImage(icon, 'lc_'+ sectionTitle.id.toLowerCase() +'.svg', builder.map.getDocType());
+			L.LOUtil.setImage(icon, iconURL.split('/').pop(), builder.map.getDocType());
 			icon.alt = '';
 			titleClass = 'menu-entry-with-icon';
 


### PR DESCRIPTION
Change-Id: I58dab34e1dbe0811844a01aaa54bd889a2e6d033


* Resolves: # 
* Target version: master 

### Summary
In Mobile view we are getting error related to image icon path not found. this is because section id is empty and we are tring to set value of based on that.
![image](https://github.com/CollaboraOnline/online/assets/61383886/80df443e-62e8-4fb8-b78e-a8c668802484)


here i am posting  the fix for that :)

