### PR TITLE
Tabbed view: Fix save modified icon being cropped

### DIFF
--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -78,7 +78,7 @@ button.ui-tab.notebookbar {
 	height: 31px;
 }
 
-.notebookbar-shortcuts-bar .unotoolbutton.notebookbar .unobutton img {
+.notebookbar-shortcuts-bar .unotoolbutton.notebookbar .unobutton:not(#Saveimg) img {
 	width: 16px !important;
 	height: 16px !important;
 	margin: 0 !important;


### PR DESCRIPTION
Before this, save icon's dot was being cropped due to height rule

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Id7b16b3fcd05d169c1206b9b7c3dbe615f0e8141
