### PR TITLE
Check the integrator has smart link funcitonality #6489

### DIFF
--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -1739,6 +1739,13 @@ L.Control.Menubar = L.Control.extend({
 					}
 				}
 			}
+
+			if (id === 'remotelink') {
+				if (self._map['wopi'].EnableRemoteLinkPicker)
+					$(aItem).show();
+				else
+					$(aItem).hide();
+			}
 		});
 	},
 


### PR DESCRIPTION
Insert -> Smart Link option works if only the integrator supports the funcitonality. If not supported not need to show to user.


Change-Id: Iad6609ad6a90a57126b30288a9c089f9185d97f2


* Resolves: #6489
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

