### PR TITLE
private/pedro/navigator fixalignment

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -358,6 +358,8 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 	color: var(--color-text-lighter) !important;
 }
 
+/*.ui-treeview-body needs this max-height both in dialogs
+ and within sidebar e.g.: animation > effect*/
 .ui-treeview-body,
 #custom_animation_label_parent {
 	color: var(--color-main-text);

--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -328,14 +328,7 @@ button#button2.ui-pushbutton.jsdialog.sidebar {
 
 /* Navigator */
 
-#NavigatorDeck #contentbox,
-#NavigatorDeck #contenttree,
-#NavigatorDeck #tree {
-	position: absolute;
-	top: 30px;
-	bottom: 10px;
-	left: 10px;
-	right: 10px;
+#NavigatorDeck * {
 	border: none;
 }
 #NavigatorDeck .ui-treeview-entry {
@@ -349,6 +342,9 @@ button#button2.ui-pushbutton.jsdialog.sidebar {
 #NavigatorDeck .ui-treeview-cell-text {
 	/* good to move this into css var*/
 	font-size: 14px;
+}
+#NavigatorDeck #contenttree > .ui-treeview-body {
+	max-height: initial;
 }
 #NavigatorDeck .ui-treeview-cell {
 	/* Move this whole block away and fix in the main control */

--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -331,7 +331,11 @@ button#button2.ui-pushbutton.jsdialog.sidebar {
 #NavigatorDeck * {
 	border: none;
 }
+#NavigatorDeck .ui-expander-content > .root-container.jsdialog {
+	margin: 0;
+}
 #NavigatorDeck .ui-treeview-entry {
+	padding-inline-start: 0;
 	background-color: transparent;
 	margin-block-end: 8px;
 }


### PR DESCRIPTION
- Navigator: do not resort to absolute position to set deck
- Navigator: Fix alignment to coincide w/sidebar properties expanders
