### PR TITLE
Fit the images into the sidebar.

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -11,6 +11,11 @@ img.sidebar.ui-image {
 	padding: 6px;
 }
 
+/* Impress -> Master Slides images should fit in the visible width */
+img.sidebar.ui-drawing-area {
+	width: 300px;
+}
+
 .sidebar.ui-grid {
 	row-gap: 8px;
 }


### PR DESCRIPTION
Without patch image sizes are 336px and seems cropped in sidebar. We should use same width with sidebar width.


Change-Id: I617a4e79e15d1d49ca95aec8f5a20f95734160a2


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

