### PR TITLE
Related: #6514 removeCallbackDuplicate only needs up to 4 tokens

### DIFF
--- a/common/StringVector.hpp
+++ b/common/StringVector.hpp
@@ -77,6 +77,37 @@ public:
             tokens.emplace_back(start - data, end - start);
     }
 
+    // call func on each token until func returns true or we run out of tokens
+    template <class UnaryFunction>
+    static void tokenize_foreach(UnaryFunction& func, const char* data, const std::size_t size, const char delimiter = ' ')
+    {
+        if (size == 0 || data == nullptr || *data == '\0')
+            return;
+
+        size_t index = 0;
+
+        const char* start = data;
+        const char* end = data;
+        for (std::size_t i = 0; i < size && data[i] != '\n'; ++i, ++end)
+        {
+            if (data[i] == delimiter)
+            {
+                if (start != end && *start != delimiter)
+                {
+                    if (func(index++, std::string_view(start, end - start)))
+                        return;
+                }
+
+                start = end;
+            }
+            else if (*start == delimiter)
+                ++start;
+        }
+
+        if (start != end && *start != delimiter && *start != '\n')
+            func(index, std::string_view(start, end - start));
+    }
+
     /// Tokenize single-char delimited values until we hit new-line or the end.
     static StringVector tokenize(const char* data, const std::size_t size,
                                  const char delimiter = ' ')


### PR DESCRIPTION
rearrange so we can use the tokens as they are generated and can end tokenization early as we find we don't need any more

from:

|--74.39%--SvpSalInstance::CheckTimeout
|          SalTimer::CallCallback (inlined)
|          Scheduler::CallbackTaskScheduling
|          |
|          |--63.01%--desktop::CallbackFlushHandler::Invoke
|          |          |
|          |           --62.92%--Document::ViewCallback
|          |                     |
|          |                     |--62.11%--MessageQueue::put
|          |                     |          |
|          |                     |          |--61.95%--MessageQueue::put
|          |                     |          |          TileQueue::put_impl
|          |                     |          |          |
|          |                     |          |          |--61.51%--TileQueue::removeCallbackDuplicate

to:

|--44.61%--SvpSalInstance::CheckTimeout
|          SalTimer::CallCallback (inlined)
|          Scheduler::CallbackTaskScheduling
|          |
|          |--21.23%--desktop::CallbackFlushHandler::Invoke
|          |          |
|          |          |--20.75%--Document::ViewCallback
|          |          |          |
|          |          |          |--19.33%--MessageQueue::put
|          |          |          |          |
|          |          |          |          |--19.17%--MessageQueue::put
|          |          |          |          |          TileQueue::put_impl
|          |          |          |          |          |
|          |          |          |          |          |--18.69%--TileQueue::removeCallbackDuplicate

seen with 25 simultaneous joins to a local instance


Change-Id: Iea4de188521f7cd8039d6ab60e9c52209fc3154d


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

