### PR TITLE
Dark mode: Canvas, get directly the css var property value

### DIFF
--- a/browser/css/color-palette-dark.css
+++ b/browser/css/color-palette-dark.css
@@ -11,6 +11,7 @@
 	--color-text-darker: #c0bfbc;  /* hover */
 	--color-text-lighter: #fff; /* secondard text, disabled */
 
+	--color-canvas: #121212;
 	--color-main-background: #121212;
 	--color-background-dark: #1E1E1E;  /* select */
 	--color-background-darker: #000;  /* todo: apply to pressed (active), li:hover(top menu on classic mode)*/

--- a/browser/css/color-palette.css
+++ b/browser/css/color-palette.css
@@ -12,6 +12,7 @@
 	--color-text-darker: #000;  /* hover */
 	--color-text-lighter: #696969; /* secondard text, disabled */
 
+	--color-canvas: #F8F9FA;
 	--color-main-background: #F8F9FA;
 	--color-background-dark: #e8e8e8;  /* select */
 	--color-background-darker: #c0bfbc;  /* todo: apply to pressed (active), li:hover(top menu on classic mode)*/

--- a/browser/src/layer/tile/CanvasSectionContainer.ts
+++ b/browser/src/layer/tile/CanvasSectionContainer.ts
@@ -555,7 +555,7 @@ class CanvasSectionContainer {
 		this.scrollLineHeight = parseInt(window.getComputedStyle(tempElement).fontSize);
 		document.body.removeChild(tempElement); // Remove the temporary element.
 
-		this.clearColor = window.getComputedStyle(document.getElementById('document-container')).backgroundColor;
+		this.clearColor = window.getComputedStyle(document.documentElement).getPropertyValue('--color-canvas');
 
 		if (disableDrawing)
 			this.disableDrawing();


### PR DESCRIPTION
- Get directly the particular css var that we want instead of on relying on a container
  - This makes things easier to maintain in the future
- Use a new --color-canvas instead of relying on --color-main-background
  - color-main-background is used in many other places which means
  that if we want to have some particular UI brighter or darker it
  would affect the canvas. Better to use a different/new css var for that

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I3d7d3ba188e96080d9f6f814a5c46f85ea378142
