### PR TITLE
Fix Canvas tiles color do no change when clicking the dark mode toggle

### DIFF
--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -74,16 +74,27 @@ L.Control.UIManager = L.Control.extend({
 
 	loadLightMode: function() {
 		document.documentElement.setAttribute('data-theme','light');
+		this.setCanvasColorAfterModeChange();
 		this.map.fire('darkmodechanged');
 	},
 
 	loadDarkMode: function() {
 		document.documentElement.setAttribute('data-theme','dark');
+		this.setCanvasColorAfterModeChange();
 		this.map.fire('darkmodechanged');
 	},
 
 	getDarkModeState: function() {
 		return this.getSavedStateOrDefault('darkTheme', window.uiDefaults['darkTheme'] ?  window.uiDefaults['darkTheme'] : false);
+	},
+
+	setCanvasColorAfterModeChange: function() {
+		if (app.sectionContainer) {
+			app.sectionContainer.setBackgroundColorMode(false);
+			app.sectionContainer.setClearColor(window.getComputedStyle(document.documentElement).getPropertyValue('--color-canvas'));
+			//change back to it's default value after setting canvas color
+			app.sectionContainer.setBackgroundColorMode(true);
+		}
 	},
 
 	toggleDarkMode: function() {


### PR DESCRIPTION
Change-Id: Ifdb5bbf06cb2ed5b8aa1e03ddb6796a0bc80b1c8


* Resolves: #6527 
* Target version: master 

### Summary

Added css variable condition in setBackgroundColorMode which was not used in any part of online code. this will work for both the case the normal one and for css variables if we pass as url parms 