### PR TITLE
Dark mode toggle: fix flimsy selected state

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -185,6 +185,7 @@ div.sidebar.ui-grid .checkbutton.sidebar,
 }
 /* selected */
 .hasnotebookbar .ui-content.unotoolbutton.selected.has-label,
+[data-theme='dark'] #toggledarktheme,
 .hasnotebookbar .ui-content.unotoolbutton.selected.inline,
 .hasnotebookbar .ui-content.unotoolbutton.selected:not(.has-label):not(.inline),
 .sidebar.unotoolbutton.selected {


### PR DESCRIPTION
I have noticed that sometimes the toggle doesn't get assigned with
selected css class. We could just rely on this line and avoid add and
removing css class to the DOM every time the mode changes

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I7c19f626d60c761a1ebe2509e7ab7aa8031403ad
