### PR TITLE
DeltaTests::testDeltaCopyOutOfBounds fails in a build from make dist …

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -317,7 +317,7 @@ TEST_EXTENSIONS = .la
 LA_LOG_DRIVER = ${top_builddir}/test/run_unit.sh
 LOG_DRIVER = ${top_builddir}/test/run_unit_standalone.sh
 
-EXTRA_DIST = data/delta-text.png data/delta-text2.png data/hello.odt data/hello.txt $(test_SOURCES) $(unittest_SOURCES) run_unit.sh run_unit_standalone.sh
+EXTRA_DIST = data/delta-text.png data/delta-text2.png data/delta-graphic.png data/delta-graphic2.png data/hello.odt data/hello.txt $(test_SOURCES) $(unittest_SOURCES) run_unit.sh run_unit_standalone.sh
 
 check_valgrind: all
 	@fc-cache "@LO_PATH@"/share/fonts/truetype


### PR DESCRIPTION
…tarball

because data/delta-graphic.png and data/delta-graphic2.png are missing


Change-Id: Ie850d9ae76946e891d2928de80c5ded4e970f4cf


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

