### PR TITLE
kit: fix missing init of _isDumpingTiles in ChildSession

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -108,7 +108,8 @@ ChildSession::ChildSession(
     _viewId(-1),
     _isDocLoaded(false),
     _copyToClipboard(false),
-    _canonicalViewId(-1)
+    _canonicalViewId(-1),
+    _isDumpingTiles(false)
 {
     LOG_INF("ChildSession ctor [" << getName() << "]. JailRoot: [" << _jailRoot << ']');
 }


### PR DESCRIPTION
This was forgotten in commit 21966e1a9c2379214d3bef2dfb93c7e7ee32ae82
(Fix copy command going out of bounds during delta creation,
2023-05-31).

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I91ce26f46cc6cb7a2dc3ab0665dc9aeea8a5c00f
