### PR TITLE
Fix Missing icon "Open in local editor" #6507

### DIFF
--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -121,7 +121,7 @@ L.Control.UIManager = L.Control.extend({
 			this.refreshMenubar();
 			this.refreshToolbar();
 		}
-		else { 
+		else {
 			this.refreshNotebookbar();
 		}
 		this.refreshSidebar();
@@ -518,7 +518,7 @@ L.Control.UIManager = L.Control.extend({
 				if (style.length == 0)
 					$('html > head').append('<style/>');
 				$('html > head > style').append('.w2ui-icon.' + encodeURIComponent(button.id) +
-					'{background: url("' + encodeURIComponent(button.imgurl) + '") no-repeat center !important; }');
+					'{background: url("' + encodeURI(button.imgurl) + '") no-repeat center !important; }');
 
 				// Position: Either specified by the caller, or defaulting to first position (before save)
 				var insertBefore = button.insertBefore || 'save';
@@ -617,7 +617,7 @@ L.Control.UIManager = L.Control.extend({
 		var obj = $('.unfold');
 		obj.removeClass('w2ui-icon unfold');
 		obj.addClass('w2ui-icon fold');
-		
+
 	},
 
 	hideMenubar: function() {


### PR DESCRIPTION
It seems we were encoding even when setting the url via CSS.

Tested using richdocuments
Tested using browser/html/framed.doc.html

Context:
Open in local editor is insert via
https://github.com/nextcloud/richdocuments/blob/b77f855ded8ad94990d116e9a84229e9c999a8bf/src/document.js#L330
using https://sdk.collaboraonline.com/docs/postmessage_api.html?highlight=insert_button#id5

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I526a5f476e90dbbc52640bd6d76f416a654a20a5
