### PR TITLE
navigator: explaining text in case of empty contenttree

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -736,6 +736,7 @@ pot:
 		src/control/Ruler.js \
 		src/control/Signing.js \
 		src/control/Toolbar.js \
+		src/control/jsdialog/Widget.TreeView.js \
 		src/core/Socket.js \
 		src/errormessages.js \
 		src/layer/tile/CanvasTileLayer.js \

--- a/browser/src/control/jsdialog/Widget.TreeView.js
+++ b/browser/src/control/jsdialog/Widget.TreeView.js
@@ -33,7 +33,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-/* global $ JSDialog */
+/* global $ _ JSDialog */
 
 function _createCheckbox(parentContainer, treeViewData, builder, entry) {
 	var checkbox = L.DomUtil.create('input', builder.options.cssClass + ' ui-treeview-checkbox', parentContainer);
@@ -469,7 +469,13 @@ function _treelistboxControl(parentContainer, data, builder) {
 	}
 
 	if (!data.entries || data.entries.length === 0) {
-		L.DomUtil.addClass(table, 'empty');
+		if (data.id === 'contenttree') {
+			var tr = L.DomUtil.create('tr', builder.options.cssClass + ' ui-listview-entry', tbody);
+			tr.setAttribute('role', 'row');
+			tr.innerText = _('Headings and objects that you add to the document will appear here');
+		} else {
+			L.DomUtil.addClass(table, 'empty');
+		}
 		return false;
 	}
 


### PR DESCRIPTION
Add a TR with the text:
"Headings and objects that you add to the document will appear here." if the navigator is empty.


Change-Id: Iff944df90b921e6f6415d2a3bee462b86e5a5eb4


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

