### PR TITLE
private/pedro/fix busypopup css

### DIFF
--- a/browser/css/device-mobile.css
+++ b/browser/css/device-mobile.css
@@ -699,7 +699,6 @@ td[id^='tb_spreadsheet-toolbar_item']:focus table.w2ui-button div.w2ui-icon, td[
 	border-radius: 16px 16px 0 0;
 }
 #mobile-wizard.popup #mobile-wizard-content {
-	height: 100%;
 	display: flex;
 	align-items: center;
 	justify-content: center;

--- a/browser/css/device-mobile.css
+++ b/browser/css/device-mobile.css
@@ -716,8 +716,8 @@ td[id^='tb_spreadsheet-toolbar_item']:focus table.w2ui-button div.w2ui-icon, td[
 #mobile-wizard.popup #busylabel {
 	border-bottom: none !important;
 	font-size: 100% !important;
-	margin: 20px !important;
-	width: 100%;
+	/* inherits margin top and bototm from jsdialogs.css */
+	margin-inline: 2px !important;
 }
 
 /* snackbar */

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -105,7 +105,7 @@
 	text-transform: none;
 }
 
-*:not(#modal-dialog-about-dialog-box) > .lokdialog_container.ui-dialog.ui-widget-content, .autofilter-container {
+*:not(#modal-dialog-about-dialog-box, #busypopup) > .lokdialog_container.ui-dialog.ui-widget-content, .autofilter-container {
 	border: 1px solid var(--color-border-darker);
 	-webkit-box-shadow: 0 0 3px var(--color-border-darker);
 	box-shadow: 0 0 3px var(--color-border-darker);
@@ -1055,6 +1055,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	text-align: center;
 	font-size: 100%;
 	text-transform: initial;
+	display: block;
 }
 
 #busypopup #spinner-paper-g,


### PR DESCRIPTION
- Mobile: popups should not have height: 100%;
- Mobile: Fix busypopup label alignment
- Busypopup: don't inherit duplicated styles and fix label
