### PR TITLE
Force notebookbar ui when a11y is enabled

### DIFF
--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -899,6 +899,7 @@ std::string COOLWSD::LOKitVersion;
 std::string COOLWSD::ConfigFile = COOLWSD_CONFIGDIR "/coolwsd.xml";
 std::string COOLWSD::ConfigDir = COOLWSD_CONFIGDIR "/conf.d";
 bool COOLWSD::EnableTraceEventLogging = false;
+bool COOLWSD::EnableAccessibility = false;
 FILE *COOLWSD::TraceEventFile = NULL;
 std::string COOLWSD::LogLevel = "trace";
 std::string COOLWSD::LogLevelStartup = "trace";
@@ -2124,6 +2125,8 @@ void COOLWSD::innerInitialize(Application& self)
     // Experimental features.
     EnableExperimental = getConfigValue<bool>(conf, "experimental_features", false);
 
+    EnableAccessibility = getConfigValue<bool>(conf, "accessibility.enable", false);
+
     // Setup user interface mode
     UserInterface = getConfigValue<std::string>(conf, "user_interface.mode", "default");
 
@@ -2131,6 +2134,9 @@ void COOLWSD::innerInitialize(Application& self)
         UserInterface = "classic";
 
     if (UserInterface == "tabbed")
+        UserInterface = "notebookbar";
+
+    if (EnableAccessibility)
         UserInterface = "notebookbar";
 
     // Set the log-level after complete initialization to force maximum details at startup.

--- a/wsd/COOLWSD.hpp
+++ b/wsd/COOLWSD.hpp
@@ -270,6 +270,7 @@ public:
     static std::string TmpFontDir;
     static std::string LOKitVersion;
     static bool EnableTraceEventLogging;
+    static bool EnableAccessibility;
     static FILE *TraceEventFile;
     static void writeTraceEventRecording(const char *data, std::size_t nbytes);
     static void writeTraceEventRecording(const std::string &recording);

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -1004,6 +1004,9 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     Poco::replaceInPlace(preprocess, std::string("%ENABLE_WELCOME_MSG%"), enableWelcomeMessage);
     Poco::replaceInPlace(preprocess, std::string("%AUTO_SHOW_WELCOME%"), autoShowWelcome);
 
+    std::string enableAccessibility = stringifyBoolFromConfig(config, "accessibility.enable", false);
+    Poco::replaceInPlace(preprocess, std::string("%ENABLE_ACCESSIBILITY%"), enableAccessibility);
+
     // the config value of 'notebookbar/tabbed' or 'classic/compact' overrides the UIMode
     // from the WOPI
     std::string userInterfaceModeConfig = config.getString("user_interface.mode", "default");
@@ -1018,7 +1021,7 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
 
     // default to the notebookbar if the value is "default" or whatever
     // nonsensical
-    if (userInterfaceMode != "classic" && userInterfaceMode != "notebookbar")
+    if (enableAccessibility == "true" || (userInterfaceMode != "classic" && userInterfaceMode != "notebookbar"))
         userInterfaceMode = "notebookbar";
 
     Poco::replaceInPlace(preprocess, std::string("%USER_INTERFACE_MODE%"), userInterfaceMode);
@@ -1034,8 +1037,6 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     std::string enableMacrosExecution = stringifyBoolFromConfig(config, "security.enable_macros_execution", false);
     Poco::replaceInPlace(preprocess, std::string("%ENABLE_MACROS_EXECUTION%"), enableMacrosExecution);
 
-    std::string enableAccessibility = stringifyBoolFromConfig(config, "accessibility.enable", false);
-    Poco::replaceInPlace(preprocess, std::string("%ENABLE_ACCESSIBILITY%"), enableAccessibility);
 
     if (!config.getBool("feedback.show", true) && config.getBool("home_mode.enable", false))
     {


### PR DESCRIPTION
When accessibility is enabled in coolwsd.xml, overrides setting in
<user-interface> section by force to use the notebookbar UI.

Signed-off-by: Marco Cecchetti <marco.cecchetti@collabora.com>
Change-Id: I98f4b288439b21110214ca2a67df639b397184c9
