### PR TITLE
Configurable CSP Header

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -262,6 +262,7 @@ wsd_headers = wsd/Admin.hpp \
               wsd/AdminModel.hpp \
               wsd/Auth.hpp \
               wsd/ClientSession.hpp \
+              wsd/ContentSecurityPolicy.hpp \
               wsd/DocumentBroker.hpp \
               wsd/ProxyProtocol.hpp \
               wsd/Exceptions.hpp \

--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -157,7 +157,8 @@
         <host desc="The IPv4 private 10.0.0.0/8 subnet (Podman).">10\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}</host>
         <host desc="Ditto, but as IPv4-mapped IPv6 addresses">::ffff:10\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}</host>
       </post_allow>
-      <frame_ancestors desc="Specify who is allowed to embed the Collabora Online iframe (coolwsd and WOPI host are always allowed). Separate multiple hosts by space."></frame_ancestors>
+      <content_security_policy desc="Customize the CSP header by specifying one or more policy-directive, separated by semicolons. See w3.org/TR/CSP2"></content_security_policy>
+      <frame_ancestors desc="OBSOLETE: Use content_security_policy. Specify who is allowed to embed the Collabora Online iframe (coolwsd and WOPI host are always allowed). Separate multiple hosts by space."></frame_ancestors>
       <connection_timeout_secs desc="Specifies the connection, send, recv timeout in seconds for connections initiated by coolwsd (such as WOPI connections)." type="int" default="30"></connection_timeout_secs>
 
       <!-- this setting radically changes how online works, it should not be used in a production environment -->

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -1991,6 +1991,8 @@ void COOLWSD::innerInitialize(Application& self)
         { "net.proto", "all" },
         { "net.service_root", "" },
         { "net.proxy_prefix", "false" },
+        { "net.content_security_policy", "" },
+        { "net.frame_ancestors", "" },
         { "num_prespawn_children", "1" },
         { "per_document.always_save_on_exit", "false" },
         { "per_document.autosave_duration_secs", "300" },
@@ -2093,7 +2095,7 @@ void COOLWSD::innerInitialize(Application& self)
 #if !MOBILEAPP
         { "help_url", HELP_URL },
 #endif
-        { "product_name", APP_NAME}
+        { "product_name", APP_NAME }
     };
 
     // Set default values, in case they are missing from the config file.

--- a/wsd/ContentSecurityPolicy.hpp
+++ b/wsd/ContentSecurityPolicy.hpp
@@ -1,0 +1,79 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include "Log.hpp"
+#include "StringVector.hpp"
+#include "Util.hpp"
+#include <sstream>
+#include <string>
+#include <unordered_map>
+
+/// Manages the HTTP Content-Security-Policy Header.
+/// See https://www.w3.org/TR/CSP2/
+class ContentSecurityPolicy
+{
+public:
+    ContentSecurityPolicy() = default;
+
+    ContentSecurityPolicy(const ContentSecurityPolicy& other)
+        : _directives(other._directives)
+    {
+    }
+
+    /// Given a CSP string, merge it with the existing values.
+    void merge(const std::string& csp)
+    {
+        LOG_TRC("Merging CSP directives [" << csp << ']');
+        StringVector tokens = StringVector::tokenize(csp, ';');
+        for (std::size_t i = 0; i < tokens.size(); ++i)
+        {
+            const std::string token = Util::trimmed(tokens[i]);
+            if (!token.empty())
+            {
+                LOG_TRC("Merging CSP directive [" << token << ']');
+                const auto parts = Util::split(token);
+                appendDirective(parts.first, parts.second);
+            }
+        }
+    }
+
+    /// Append the given value to a directive.
+    /// @value must be space-delimited and cannot have semicolon.
+    void appendDirective(std::string directive, std::string value)
+    {
+        LOG_ASSERT_MSG(value.find_first_of(';') == std::string::npos,
+                       "Unexpected semicolon in CSP policy directive");
+
+        Util::trim(directive);
+        Util::trim(value);
+        if (!directive.empty() && !value.empty())
+        {
+            LOG_TRC("Appending CSP directive [" << directive << "] = [" << value << ']');
+            _directives[directive].append(' ' + value);
+        }
+    }
+
+    /// Returns the value of the CSP header.
+    std::string generate() const
+    {
+        std::ostringstream oss;
+        for (const auto& pair : _directives)
+        {
+            oss << pair.first << ' ' << pair.second << "; ";
+        }
+
+        return oss.str();
+    }
+
+private:
+    /// The policy directives.
+    std::unordered_map<std::string, std::string> _directives;
+};
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -54,6 +54,8 @@
 #if !MOBILEAPP
 #include <net/HttpHelper.hpp>
 #endif
+#include <ContentSecurityPolicy.hpp>
+
 using Poco::Net::HTMLForm;
 using Poco::Net::HTTPBasicCredentials;
 using Poco::Net::HTTPRequest;
@@ -1063,20 +1065,34 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
 
     const std::string mimeType = "text/html";
 
+    ContentSecurityPolicy csp;
+    csp.appendDirective("default-src", "'none'");
+    csp.appendDirective("frame-src", "'self'");
+    csp.appendDirective("frame-src", WELCOME_URL);
+    csp.appendDirective("frame-src", FEEDBACK_URL);
+    csp.appendDirective("frame-src", buyProduct);
+    csp.appendDirective("frame-src", "blob:"); // Equivalent to unsafe-eval!
+    csp.appendDirective("frame-src", documentSigningURL);
+    csp.appendDirective("connect-src", "'self'");
+    csp.appendDirective("connect-src", "https://www.zotero.org");
+    csp.appendDirective("connect-src", "https://api.zotero.org");
+    csp.appendDirective("connect-src", cnxDetails.getWebSocketUrl());
+    csp.appendDirective("connect-src", cnxDetails.getWebServerUrl());
+    csp.appendDirective("connect-src", indirectionURI.getAuthority());
+    csp.appendDirective("script-src", "'self'");
+    csp.appendDirective("script-src", "'unsafe-inline'");
+    csp.appendDirective("style-src", "'self'");
+    csp.appendDirective("style-src", "'unsafe-inline'");
+    csp.appendDirective("font-src", "'self'");
+    csp.appendDirective("font-src", "data:"); // Equivalent to unsafe-inline!
+    csp.appendDirective("object-src", "'self'");
+    csp.appendDirective("object-src", "blob:"); // Equivalent to unsafe-eval!
+    csp.appendDirective("media-src", "'self'");
+
     // Document signing: if endpoint URL is configured, whitelist that for
     // iframe purposes.
     std::ostringstream cspOss;
-    cspOss << "Content-Security-Policy: default-src 'none'; "
-        "frame-src 'self' " << WELCOME_URL << " " << FEEDBACK_URL << " " << buyProduct <<
-        " blob: " << documentSigningURL << "; "
-           "connect-src 'self' https://www.zotero.org https://api.zotero.org "
-           << cnxDetails.getWebSocketUrl() << " " << cnxDetails.getWebServerUrl() << " "
-           << indirectionURI.getAuthority() << "; "
-           "script-src 'unsafe-inline' 'self'; "
-           "style-src 'self' 'unsafe-inline'; "
-           "font-src 'self' data:; "
-           "object-src 'self' blob:; "
-           "media-src 'self'; ";
+    cspOss << "Content-Security-Policy: " << csp.generate();
 
     // Frame ancestors: Allow coolwsd host, wopi host and anything configured.
     std::string configFrameAncestor = config.getString("net.frame_ancestors", "");

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -1092,11 +1092,9 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     {
         if (param.first == "WOPISrc")
         {
-            std::string wopiFrameAncestor;
-            Poco::URI::decode(param.second, wopiFrameAncestor);
-            Poco::URI uriWopiFrameAncestor(wopiFrameAncestor);
+            const Poco::URI uriWopiFrameAncestor(Util::decodeURIComponent(param.second));
             // Remove parameters from URL
-            wopiFrameAncestor = uriWopiFrameAncestor.getHost();
+            const std::string& wopiFrameAncestor = uriWopiFrameAncestor.getHost();
             if (wopiFrameAncestor != uriHost.getHost() && wopiFrameAncestor != configFrameAncestor)
             {
                 frameAncestors += ' ' + wopiFrameAncestor + ":*";

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -713,9 +713,9 @@ void FileServerRequestHandler::sendError(int errorCode, const Poco::Net::HTTPReq
     std::string headers = extraHeader;
     if (!shortMessage.empty())
     {
-        Poco::URI requestUri(request.getURI());
-        std::string pathSanitized;
-        Poco::URI::encode(requestUri.getPath(), "", pathSanitized);
+        const Poco::URI requestUri(request.getURI());
+        const std::string pathSanitized =
+            Util::encodeURIComponent(requestUri.getPath(), std::string());
         // Let's keep message as plain text to avoid complications.
         headers += "Content-Type: text/plain charset=UTF-8\r\n";
         body = "Error: " + shortMessage + '\n' +
@@ -896,10 +896,9 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     // Escape bad characters in access token.
     // This is placed directly in javascript in cool.html, we need to make sure
     // that no one can do anything nasty with their clever inputs.
-    std::string escapedAccessToken, escapedAccessHeader, escapedPostmessageOrigin;
-    Poco::URI::encode(accessToken, "'", escapedAccessToken);
-    Poco::URI::encode(accessHeader, "'", escapedAccessHeader);
-    Poco::URI::encode(postMessageOrigin, "'", escapedPostmessageOrigin);
+    const std::string escapedAccessToken = Util::encodeURIComponent(accessToken, "'");
+    const std::string escapedAccessHeader = Util::encodeURIComponent(accessHeader, "'");
+    const std::string escapedPostmessageOrigin = Util::encodeURIComponent(postMessageOrigin, "'");
 
     unsigned long tokenTtl = 0;
     if (!accessToken.empty())
@@ -953,8 +952,7 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
 
     bool useIntegrationTheme = config.getBool("user_interface.use_integration_theme", true);
     bool hasIntegrationTheme = (theme != "") && FileUtil::Stat(COOLWSD::FileServerRoot + "/browser/dist/" + theme).exists();
-    std::string escapedTheme;
-    Poco::URI::encode(theme, "'", escapedTheme);
+    const std::string escapedTheme = Util::encodeURIComponent(theme, "'");
     const std::string themePreFix = hasIntegrationTheme && useIntegrationTheme ? escapedTheme + "/" : "";
     const std::string linkCSS("<link rel=\"stylesheet\" href=\"%s/browser/" COOLWSD_VERSION_HASH "/" + themePreFix + "%s.css\">");
     const std::string scriptJS("<script src=\"%s/browser/" COOLWSD_VERSION_HASH "/" + themePreFix + "%s.js\"></script>");
@@ -983,7 +981,7 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     if (!documentSigningURL.empty())
     {
         documentSigningDiv = "<div id=\"document-signing-bar\"></div>";
-        Poco::URI::encode(documentSigningURL, "'", escapedDocumentSigningURL);
+        escapedDocumentSigningURL = Util::encodeURIComponent(documentSigningURL, "'");
     }
     Poco::replaceInPlace(preprocess, std::string("<!--%DOCUMENT_SIGNING_DIV%-->"), documentSigningDiv);
     Poco::replaceInPlace(preprocess, std::string("%DOCUMENT_SIGNING_URL%"), escapedDocumentSigningURL);
@@ -1055,8 +1053,7 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     Poco::replaceInPlace(preprocess, std::string("%FEEDBACK_URL%"), std::string(FEEDBACK_URL));
     Poco::replaceInPlace(preprocess, std::string("%WELCOME_URL%"), std::string(WELCOME_URL));
 
-    std::string escapedBuyProduct;
-    Poco::URI::encode(buyProduct, "'", escapedBuyProduct);
+    const std::string escapedBuyProduct = Util::encodeURIComponent(buyProduct, "'");
     Poco::replaceInPlace(preprocess, std::string("%BUYPRODUCT_URL%"), escapedBuyProduct);
 
     Poco::replaceInPlace(preprocess, std::string("%DEEPL_ENABLED%"), (config.getBool("deepl.enabled", false) ? std::string("true"): std::string("false")));
@@ -1113,8 +1110,7 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
         // frame anchestors are also allowed for img-src in order to load the views avatars
         cspOss << imgSrc << " " << frameAncestors << "; "
                 << "frame-ancestors " << frameAncestors;
-        std::string escapedFrameAncestors;
-        Poco::URI::encode(frameAncestors, "'", escapedFrameAncestors);
+        const std::string escapedFrameAncestors = Util::encodeURIComponent(frameAncestors, "'");
         Poco::replaceInPlace(preprocess, std::string("%FRAME_ANCESTORS%"), escapedFrameAncestors);
     }
     else

--- a/wsd/QuarantineUtil.cpp
+++ b/wsd/QuarantineUtil.cpp
@@ -12,6 +12,7 @@
 #include "ClientSession.hpp"
 #include "COOLWSD.hpp"
 #include "DocumentBroker.hpp"
+#include "Util.hpp"
 
 #include <common/Common.hpp>
 #include <common/StringVector.hpp>
@@ -41,18 +42,16 @@ namespace Quarantine
         QuarantineMap.clear();
 
         std::vector<StringToken> tokens;
-        std::string decoded;
 
         std::sort(files.begin(), files.end());
         for (const auto& file : files)
         {
-
             StringVector::tokenize(file.c_str(), file.size(), '_', tokens);
-            Poco::URI::decode(file.substr(tokens[2]._index), decoded);
+            const std::string decoded =
+                Util::decodeURIComponent(tokens.size() > 2 ? file.substr(tokens[2]._index) : file);
             QuarantineMap[decoded].emplace_back(COOLWSD::QuarantinePath + file);
 
             tokens.clear();
-            decoded.clear();
         }
     }
 


### PR DESCRIPTION
- wsd: allow for legacy quarantine directories
- wsd: simplify frame-ancestor handling
- killpoco: replace URI::encode with our wrapper
- wsd: add ContentSecurityPolicy manager
- wsd: more CSP refactoring
- wsd: support providing CSP header in the config
