### PR TITLE
Thread Sanitization

### DIFF
--- a/common/SigUtil.cpp
+++ b/common/SigUtil.cpp
@@ -431,17 +431,14 @@ namespace SigUtil
                 static constexpr auto msg =
                     "Crashed in unattended run and won't wait for debugger. Re-run without "
                     "--unattended to attach a debugger.";
-                LOG_ERR(msg);
-                std::cerr << msg << '\n';
+                std::cerr << msg << std::endl;
             }
             else
             {
                 signalLog(FatalGdbString);
-                LOG_ERR("Sleeping 60s to allow debugging: attach " << getpid());
-                std::cerr << "Sleeping 60s to allow debugging: attach " << getpid() << '\n';
+                std::cerr << "Sleeping 60s to allow debugging: attach " << getpid() << std::endl;
                 sleep(60);
-                LOG_ERR("Finished sleeping to allow debugging of: " << getpid());
-                std::cerr << "Finished sleeping to allow debugging of: " << getpid() << '\n';
+                std::cerr << "Finished sleeping to allow debugging of: " << getpid() << std::endl;
             }
         }
     }

--- a/common/SigUtil.cpp
+++ b/common/SigUtil.cpp
@@ -295,6 +295,8 @@ namespace SigUtil
     static
     void handleTerminationSignal(const int signal)
     {
+        const auto onrre = errno; // Save.
+
         bool hardExit = false;
         const char *domain;
         if (!ShutdownRequestFlag && (signal == SIGINT || signal == SIGTERM))
@@ -329,8 +331,11 @@ namespace SigUtil
 #endif
 
             ::signal (signal, SIG_DFL);
+            errno = onrre; // Restore.
             ::raise (signal);
         }
+
+        errno = onrre; // Restore.
     }
 
     void requestShutdown()

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -1582,7 +1582,8 @@ private:
     bool _sentHTTPContinue;
 
     /// True when shutdown was requested via shutdown().
-    bool _shutdownSignalled;
+    /// It's accessed from different threads.
+    std::atomic_bool _shutdownSignalled;
     int _incomingFD;
     ReadType _readType;
     std::atomic_bool _inputProcessingEnabled;

--- a/wsd/COOLWSD.hpp
+++ b/wsd/COOLWSD.hpp
@@ -199,7 +199,7 @@ protected:
 
 private:
     std::string _name;
-    pid_t _pid;
+    std::atomic<pid_t> _pid; //< The process-id, which can be access from different threads.
     std::shared_ptr<WebSocketHandler> _ws;
     std::shared_ptr<Socket> _socket;
 };


### PR DESCRIPTION
Some thread-safety fixes with the help of the thread sanitizer.

- wsd: signal handler cannot log
- wsd: test: better test timeout thread management
- wsd: thread-safe socket shutdown flag
- wsd: thread-safe kit pid
- wsd: signal handlers must preserve errno
