### PR TITLE
jsdialog: Pasting externally copied data in Calc can fail #6597

### DIFF
--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -272,8 +272,8 @@ L.Clipboard = L.Class.extend({
 				that._doAsyncDownload(
 					'POST', dest, formData, false,
 					function() {
-						if (this.isPasteSpecialDialogOpen()) {
-							this._map.jsdialog.closeDialog(this.pasteSpecialDialogId, false);
+						if (that.isPasteSpecialDialogOpen()) {
+							that._map.jsdialog.closeDialog(that.pasteSpecialDialogId, false);
 							window.app.console.log('up-load done, now paste special');
 							app.socket.sendMessage('uno .uno:PasteSpecial');
 						} else {
@@ -302,8 +302,8 @@ L.Clipboard = L.Class.extend({
 				that._doAsyncDownload(
 					'POST', dest, formData, false,
 					function() {
-						if (this.isPasteSpecialDialogOpen()) {
-							this._map.jsdialog.closeDialog(this.pasteSpecialDialogId, false);
+						if (that.isPasteSpecialDialogOpen()) {
+							that._map.jsdialog.closeDialog(that.pasteSpecialDialogId, false);
 							window.app.console.log('up-load of fallback done, now paste special');
 							app.socket.sendMessage('uno .uno:PasteSpecial');
 						} else {


### PR DESCRIPTION
Fixes #6597

error:
Clipboard.js:305 Uncaught TypeError: this.isPasteSpecialDialogOpen is not a function
    at Clipboard.js:305:16
    at request.onload (Clipboard.js:225:6)


Change-Id: I8c2717b627fead7a3ad3bdd870845c86c586eed4


* Resolves: #6597
* Target version: master 

### Checklist

- [X] Code is properly formatted
- [X] All commits have Change-Id
- [ ] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

