### PR TITLE
23.05: Dark Mode - Texts on Comments dialog on Dark mode is not visible during edit

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -620,6 +620,7 @@ nav.spreadsheet-color-indicator ~ #sidebar-dock-wrapper {
 	font-size: var(--default-font-size);
 	border: 1px solid var(--color-border);
 	background-color: var(--color-background-dark);
+	color: var(--color-main-text);
 	overflow-x: hidden;
 	height: 50px;
 	width: 100%;


### PR DESCRIPTION
Signed-off-by: Darshan-upadhyay1110 <darshan.upadhyay@collabora.com>
Change-Id: I74d5e83641982acc1b0b328c707c09d06d68c56d


Add color property for annotation-textarea to get correct font color in comment box.
