### PR TITLE
Private/pedro/t42445 dialogs

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -46,7 +46,7 @@
 	margin: 0 !important;
 }
 
-.jsdialog-window.modalpopup {
+.jsdialog-window.modalpopup:not(.snackbar) {
 	min-width: 198px;
 	max-width: 498px;
 	border: 1px solid var(--color-border-darker) !important;

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -105,7 +105,7 @@
 	text-transform: none;
 }
 
-*:not(#modal-dialog-about-dialog-box, #busypopup) > .lokdialog_container.ui-dialog.ui-widget-content, .autofilter-container {
+*:not(.modalpopup) > .lokdialog_container.ui-dialog.ui-widget-content, .autofilter-container {
 	border: 1px solid var(--color-border-darker);
 	-webkit-box-shadow: 0 0 3px var(--color-border-darker);
 	box-shadow: 0 0 3px var(--color-border-darker);


### PR DESCRIPTION
note: To trigger snackbar and busypopup

```diff
diff --git a/browser/src/control/Control.UIManager.js b/browser/src/control/Control.UIManager.js
index d0b88a8656..9bbefdcb38 100644
--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -730,6 +730,7 @@ L.Control.UIManager = L.Control.extend({
 		$('#toolbar-down').show();
 		this.setSavedState('ShowStatusbar', true);
 		this.map.fire('statusbarchanged');
+		// this.showSnackbar(_('Server is now reachable. We have to refresh the page now.'), _('RELOAD'), function () { console.debug('snackbar'); });
 	},
 
 	hideStatusBar: function(firstStart) {
diff --git a/browser/src/control/Toolbar.js b/browser/src/control/Toolbar.js
index 665e834906..d392f1b779 100644
--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -769,6 +769,7 @@ L.Map.include({
 	},
 
 	showHyperlinkDialog: function() {
+		// this.fire('blockUI', {message: 'Saving document, please wait...'});
 		var text = this.getTextForLink();
 		var link = '';
 		if (this.hyperlinkUnderCursor && this.hyperlinkUnderCursor.link)
```