### PR TITLE
browser: fix encode hyperlink parameter

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -2515,7 +2515,7 @@ L.CanvasTileLayer = L.Layer.extend({
 			if (!url.startsWith('#'))
 				map_.fire('warn', {url: url, map: map_, cmd: 'openlink'});
 			else
-				map_.sendUnoCommand('.uno:JumpToMark?Bookmark:string=' + url.substring(1));
+				map_.sendUnoCommand('.uno:JumpToMark?Bookmark:string=' + encodeURIComponent(url.substring(1)));
 		});
 		this._setupClickFuncForId('hyperlink-pop-up-copy', function () {
 			map_.sendUnoCommand('.uno:CopyHyperlinkLocation');


### PR DESCRIPTION
Encode the "JumpToMark" bookmark parameter to jump
sheet name with white spaces.

Change-Id: I3943751379bd00bbd4036e137256df1338d26f0d
Signed-off-by: Henry Castro <hcastro@collabora.com>
