### PR TITLE
Don't let the open dialog if it is open already

### DIFF
--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -547,6 +547,13 @@ L.Control.JSDialog = L.Control.extend({
 			}
 		}
 		else {
+			// Is the target dialog already open. So don't let the open same dialog again
+			var dialogs = Object.keys(this.dialogs);
+			for (var i = 0; i < dialogs.length; i++) {
+				if (this.dialogs[dialogs[i]].dialogid === instance.dialogid)
+					return;
+			}
+
 			// There is no action, so we create a new dialogue.
 			if (instance.isModalPopUp || instance.isDocumentAreaPopup)
 				this.getOrCreateOverlay(instance);


### PR DESCRIPTION
Eg: Writer -> Format -> Theme dialog's "Add" button lets the open multiple same dialogs. We should prevent that case.


Change-Id: I4297c133eee52d04f0aa67f62efece87af6b023c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

