### PR TITLE
23.05 - Android : tapping on cells flickers the keyboard

### DIFF
--- a/browser/src/layer/marker/TextInput.js
+++ b/browser/src/layer/marker/TextInput.js
@@ -238,7 +238,7 @@ L.TextInput = L.Layer.extend({
 				this._textArea.setAttribute('readonly', true);
 		}
 
-		if (!window.ThisIsTheiOSApp && navigator.platform !== 'iPhone') {
+		if (!window.ThisIsTheiOSApp && navigator.platform !== 'iPhone' && this.canAcceptKeyboardInput()) {
 			this._textArea.focus();
 		} else if (acceptInput === true) {
 			// On the iPhone, only call the textarea's focus() when we get an explicit


### PR DESCRIPTION
Signed-off-by: Darshan-upadhyay1110 <darshan.upadhyay@collabora.com>
Change-Id: I8cb6211a3605503f4144a3c48e059960cf461617

Added condition for focus on textarea so ot will handle the keyboard in mobile view to stop flicker.


* Resolves: 
* Target version: master 
