### PR TITLE
Show the context menu on click empty parts of slides pane

### DIFF
--- a/browser/src/control/Control.PartsPreview.js
+++ b/browser/src/control/Control.PartsPreview.js
@@ -221,6 +221,35 @@ L.Control.PartsPreview = L.Control.extend({
 		}, this);
 
 		var that = this;
+		var pcw = document.getElementById('presentation-controls-wrapper');
+
+		L.DomEvent.on(pcw, 'contextmenu', function(e) {
+			that._setPart(e);
+			$.contextMenu({
+				selector: '#presentation-controls-wrapper',
+				className: 'cool-font',
+				items: {
+					paste: {
+						name: _('Paste Slide'),
+						callback: function(key, options) {
+							var part = that._findClickedPart(options.$trigger[0].parentNode);
+							if (part !== null) {
+								that._setPart(that.copiedSlide);
+								that._map.duplicatePage(parseInt(part));
+							}
+						},
+						visible: function() {
+							return that.copiedSlide;
+						}
+					},
+					newslide: {
+						name: _UNO(that._map._docLayer._docType == 'presentation' ? '.uno:InsertSlide' : '.uno:InsertPage', 'presentation'),
+						callback: function() { that._map.insertPage(); }
+					}
+				}
+			});
+		}, this);
+
 		L.DomEvent.on(img, 'contextmenu', function(e) {
 			that._setPart(e);
 			$.contextMenu({


### PR DESCRIPTION
Show New Slide and Paste (if clipboard is not empty) on context menu when the user cliked on the empty parts of the slides pane.


Change-Id: I3d009499cc4400612f1246c28ce5478b80469428


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

