### PR TITLE
When Calc starts with the notebook ui, sheet tabs are missing

### DIFF
--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -49,8 +49,10 @@ L.Control.Notebookbar = L.Control.extend({
 		this.map.on('statusbarchanged', this.onStatusbarChange, this);
 		this.map.on('rulerchanged', this.onRulerChange, this);
 		this.map.on('darkmodechanged', this.onDarkModeToggleChange, this);
-		this.map.on('updateparts', this.onSlideHideToggle, this);
-		this.map.on('toggleslidehide', this.onSlideHideToggle, this);
+		if (docType === 'presentation') {
+			this.map.on('updateparts', this.onSlideHideToggle, this);
+			this.map.on('toggleslidehide', this.onSlideHideToggle, this);
+		}
 
 		this.map.sendUnoCommand('.uno:ToolbarMode?Mode:string=notebookbar_online.ui');
 


### PR DESCRIPTION
This patch fix a regression started from
17b50868ea379b3271c4cb8e678b14f1a2725870
"impress: introduce slide hiding/showing in presentation"

Signed-off-by: Marco Cecchetti <marco.cecchetti@collabora.com>
Change-Id: I55263b07088d16fe07171e004b5d505eb3b70500
