### PR TITLE
browser: fix first character IME input

### DIFF
--- a/browser/src/layer/marker/TextInput.js
+++ b/browser/src/layer/marker/TextInput.js
@@ -655,7 +655,7 @@ L.TextInput = L.Layer.extend({
 		// And that is caused because after entering the first character
 		// cursor position is never updated by keyboard (I know it is strange)
 		// so here we manually correct the position
-		if (content.length === 1 && this._lastContent.length === 0)
+		if (window.mode.isMobile() && content.length === 1 && this._lastContent.length === 0)
 			this._setCursorPosition(2);
 
 		var matchTo = 0;


### PR DESCRIPTION
The FireFox browser corrupts the first IME input character
while it is IME composing and changing cursor position.

Change-Id: I96a6ddd9f5c74b83566051b447b46e45745fa2be
Signed-off-by: Henry Castro <hcastro@collabora.com>
