### PR TITLE
Configurable CSP Header

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -264,6 +264,7 @@ wsd_headers = wsd/Admin.hpp \
               wsd/AdminModel.hpp \
               wsd/Auth.hpp \
               wsd/ClientSession.hpp \
+              wsd/ContentSecurityPolicy.hpp \
               wsd/DocumentBroker.hpp \
               wsd/ProxyProtocol.hpp \
               wsd/Exceptions.hpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -436,8 +436,8 @@ clean-am: cleanup clean-binPROGRAMS clean-generic clean-libtool clean-local clea
 
 clean-local:
 	$(CLEANUP_COMMAND)
-	if test "z@JAILS_PATH@" != "z"; then rm -rf "@JAILS_PATH@"; fi
-	if test "z@SYSTEMPLATE_PATH@" != "z"; then rm -rf "@SYSTEMPLATE_PATH@"; fi
+	if test "z@SYSTEMPLATE_PATH@" != "z"; then rm -rf "@SYSTEMPLATE_PATH@" || echo "WARNING: failed to remove the systemplate"; fi
+	if test "z@JAILS_PATH@" != "z"; then rm -rf "@JAILS_PATH@" || echo "WARNING: failed to remove all jails cleanly"; fi
 	rm -rf "${top_srcdir}/loleaflet"
 	rm -rf loolconfig loolconvert loolforkit loolmap loolmount # kill old binaries
 	rm -rf loolwsd loolwsd_fuzzer coolwsd_fuzzer loolstress loolsocketdump

--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -160,7 +160,8 @@
         <host desc="The IPv4 private 10.0.0.0/8 subnet (Podman).">10\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}</host>
         <host desc="Ditto, but as IPv4-mapped IPv6 addresses">::ffff:10\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}</host>
       </post_allow>
-      <frame_ancestors desc="Specify who is allowed to embed the Collabora Online iframe (coolwsd and WOPI host are always allowed). Separate multiple hosts by space."></frame_ancestors>
+      <content_security_policy desc="Customize the CSP header by specifying one or more policy-directive, separated by semicolons. See w3.org/TR/CSP2"></content_security_policy>
+      <frame_ancestors desc="OBSOLETE: Use content_security_policy. Specify who is allowed to embed the Collabora Online iframe (coolwsd and WOPI host are always allowed). Separate multiple hosts by space."></frame_ancestors>
       <connection_timeout_secs desc="Specifies the connection, send, recv timeout in seconds for connections initiated by coolwsd (such as WOPI connections)." type="int" default="30"></connection_timeout_secs>
 
       <!-- this setting radically changes how online works, it should not be used in a production environment -->

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -1979,6 +1979,8 @@ void COOLWSD::innerInitialize(Application& self)
         { "net.proto", "all" },
         { "net.service_root", "" },
         { "net.proxy_prefix", "false" },
+        { "net.content_security_policy", "" },
+        { "net.frame_ancestors", "" },
         { "num_prespawn_children", "1" },
         { "per_document.always_save_on_exit", "false" },
         { "per_document.autosave_duration_secs", "300" },
@@ -2080,7 +2082,7 @@ void COOLWSD::innerInitialize(Application& self)
 #if !MOBILEAPP
         { "help_url", HELP_URL },
 #endif
-        { "product_name", APP_NAME}
+        { "product_name", APP_NAME }
     };
 
     // Set default values, in case they are missing from the config file.

--- a/wsd/ContentSecurityPolicy.hpp
+++ b/wsd/ContentSecurityPolicy.hpp
@@ -1,0 +1,79 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include "Log.hpp"
+#include "StringVector.hpp"
+#include "Util.hpp"
+#include <sstream>
+#include <string>
+#include <unordered_map>
+
+/// Manages the HTTP Content-Security-Policy Header.
+/// See https://www.w3.org/TR/CSP2/
+class ContentSecurityPolicy
+{
+public:
+    ContentSecurityPolicy() = default;
+
+    ContentSecurityPolicy(const ContentSecurityPolicy& other)
+        : _directives(other._directives)
+    {
+    }
+
+    /// Given a CSP string, merge it with the existing values.
+    void merge(const std::string& csp)
+    {
+        LOG_TRC("Merging CSP directives [" << csp << ']');
+        StringVector tokens = StringVector::tokenize(csp, ';');
+        for (std::size_t i = 0; i < tokens.size(); ++i)
+        {
+            const std::string token = Util::trimmed(tokens[i]);
+            if (!token.empty())
+            {
+                LOG_TRC("Merging CSP directive [" << token << ']');
+                const auto parts = Util::split(token);
+                appendDirective(parts.first, parts.second);
+            }
+        }
+    }
+
+    /// Append the given value to a directive.
+    /// @value must be space-delimited and cannot have semicolon.
+    void appendDirective(std::string directive, std::string value)
+    {
+        LOG_ASSERT_MSG(value.find_first_of(';') == std::string::npos,
+                       "Unexpected semicolon in CSP policy directive");
+
+        Util::trim(directive);
+        Util::trim(value);
+        if (!directive.empty() && !value.empty())
+        {
+            LOG_TRC("Appending CSP directive [" << directive << "] = [" << value << ']');
+            _directives[directive].append(' ' + value);
+        }
+    }
+
+    /// Returns the value of the CSP header.
+    std::string generate() const
+    {
+        std::ostringstream oss;
+        for (const auto& pair : _directives)
+        {
+            oss << pair.first << ' ' << pair.second << "; ";
+        }
+
+        return oss.str();
+    }
+
+private:
+    /// The policy directives.
+    std::unordered_map<std::string, std::string> _directives;
+};
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -1061,6 +1061,8 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
 
     const std::string mimeType = "text/html";
 
+    // Document signing: if endpoint URL is configured, whitelist that for
+    // iframe purposes.
     ContentSecurityPolicy csp;
     csp.appendDirective("default-src", "'none'");
     csp.appendDirective("frame-src", "'self'");
@@ -1087,11 +1089,20 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     csp.appendDirective("img-src", "data:"); // Equivalent to unsafe-inline!
     csp.appendDirective("img-src", "https://www.collaboraoffice.com/");
 
-    std::ostringstream cspOss;
-    cspOss << "Content-Security-Policy: ";
-
     // Frame ancestors: Allow coolwsd host, wopi host and anything configured.
-    std::string configFrameAncestor = config.getString("net.frame_ancestors", "");
+    const std::string configFrameAncestor = config.getString("net.frame_ancestors", "");
+    if (!configFrameAncestor.empty())
+    {
+        static bool warned = false;
+        if (!warned)
+        {
+            warned = true;
+            LOG_WRN("The config entry net.frame_ancestors is obsolete and will be removed in the "
+                    "future. Please add 'frame-ancestors "
+                    << configFrameAncestor << "' in the net.content_security_policy config");
+        }
+    }
+
     std::string frameAncestors = configFrameAncestor;
     Poco::URI uriHost(cnxDetails.getWebSocketUrl());
     if (uriHost.getHost() != configFrameAncestor)
@@ -1129,7 +1140,7 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
         LOG_TRC("Denied all frame ancestors");
     }
 
-    cspOss << csp.generate() << "\r\n";
+    csp.merge(config.getString("net.content_security_policy", ""));
 
     std::ostringstream oss;
     oss << "HTTP/1.1 200 OK\r\n"
@@ -1145,7 +1156,7 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
         "Referrer-Policy: no-referrer\r\n";
 
     // Append CSP to response headers too
-    oss << cspOss.str();
+    oss << "Content-Security-Policy: " << csp.generate() << "\r\n";
 
     // Setup HTTP Public key pinning
     if ((COOLWSD::isSSLEnabled() || COOLWSD::isSSLTermination()) && config.getBool("ssl.hpkp[@enable]", false))

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -714,9 +714,9 @@ void FileServerRequestHandler::sendError(int errorCode, const Poco::Net::HTTPReq
     std::string headers = extraHeader;
     if (!shortMessage.empty())
     {
-        Poco::URI requestUri(request.getURI());
-        std::string pathSanitized;
-        Poco::URI::encode(requestUri.getPath(), "", pathSanitized);
+        const Poco::URI requestUri(request.getURI());
+        const std::string pathSanitized =
+            Util::encodeURIComponent(requestUri.getPath(), std::string());
         // Let's keep message as plain text to avoid complications.
         headers += "Content-Type: text/plain charset=UTF-8\r\n";
         body = "Error: " + shortMessage + '\n' +
@@ -898,10 +898,9 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     // Escape bad characters in access token.
     // This is placed directly in javascript in cool.html, we need to make sure
     // that no one can do anything nasty with their clever inputs.
-    std::string escapedAccessToken, escapedAccessHeader, escapedPostmessageOrigin;
-    Poco::URI::encode(accessToken, "'", escapedAccessToken);
-    Poco::URI::encode(accessHeader, "'", escapedAccessHeader);
-    Poco::URI::encode(postMessageOrigin, "'", escapedPostmessageOrigin);
+    const std::string escapedAccessToken = Util::encodeURIComponent(accessToken, "'");
+    const std::string escapedAccessHeader = Util::encodeURIComponent(accessHeader, "'");
+    const std::string escapedPostmessageOrigin = Util::encodeURIComponent(postMessageOrigin, "'");
 
     unsigned long tokenTtl = 0;
     if (!accessToken.empty())
@@ -958,8 +957,7 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
 
     bool useIntegrationTheme = config.getBool("user_interface.use_integration_theme", true);
     bool hasIntegrationTheme = (theme != "") && FileUtil::Stat(COOLWSD::FileServerRoot + "/browser/dist/" + theme).exists();
-    std::string escapedTheme;
-    Poco::URI::encode(theme, "'", escapedTheme);
+    const std::string escapedTheme = Util::encodeURIComponent(theme, "'");
     const std::string themePreFix = hasIntegrationTheme && useIntegrationTheme ? escapedTheme + "/" : "";
     const std::string linkCSS("<link rel=\"stylesheet\" href=\"%s/browser/" COOLWSD_VERSION_HASH "/" + themePreFix + "%s.css\">");
     const std::string scriptJS("<script src=\"%s/browser/" COOLWSD_VERSION_HASH "/" + themePreFix + "%s.js\"></script>");
@@ -1051,8 +1049,7 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     Poco::replaceInPlace(preprocess, std::string("%FEEDBACK_URL%"), std::string(FEEDBACK_URL));
     Poco::replaceInPlace(preprocess, std::string("%WELCOME_URL%"), std::string(WELCOME_URL));
 
-    std::string escapedBuyProduct;
-    Poco::URI::encode(buyProduct, "'", escapedBuyProduct);
+    const std::string escapedBuyProduct = Util::encodeURIComponent(buyProduct, "'");
     Poco::replaceInPlace(preprocess, std::string("%BUYPRODUCT_URL%"), escapedBuyProduct);
 
     Poco::replaceInPlace(preprocess, std::string("%DEEPL_ENABLED%"), (config.getBool("deepl.enabled", false) ? std::string("true"): std::string("false")));
@@ -1106,8 +1103,7 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
         // frame anchestors are also allowed for img-src in order to load the views avatars
         cspOss << imgSrc << " " << frameAncestors << "; "
                 << "frame-ancestors " << frameAncestors;
-        std::string escapedFrameAncestors;
-        Poco::URI::encode(frameAncestors, "'", escapedFrameAncestors);
+        const std::string escapedFrameAncestors = Util::encodeURIComponent(frameAncestors, "'");
         Poco::replaceInPlace(preprocess, std::string("%FRAME_ANCESTORS%"), escapedFrameAncestors);
     }
     else

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -1085,11 +1085,9 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     {
         if (param.first == "WOPISrc")
         {
-            std::string wopiFrameAncestor;
-            Poco::URI::decode(param.second, wopiFrameAncestor);
-            Poco::URI uriWopiFrameAncestor(wopiFrameAncestor);
+            const Poco::URI uriWopiFrameAncestor(Util::decodeURIComponent(param.second));
             // Remove parameters from URL
-            wopiFrameAncestor = uriWopiFrameAncestor.getHost();
+            const std::string& wopiFrameAncestor = uriWopiFrameAncestor.getHost();
             if (wopiFrameAncestor != uriHost.getHost() && wopiFrameAncestor != configFrameAncestor)
             {
                 frameAncestors += ' ' + wopiFrameAncestor + ":*";

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -1083,9 +1083,12 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     csp.appendDirective("object-src", "'self'");
     csp.appendDirective("object-src", "blob:"); // Equivalent to unsafe-eval!
     csp.appendDirective("media-src", "'self'");
+    csp.appendDirective("img-src", "'self'");
+    csp.appendDirective("img-src", "data:"); // Equivalent to unsafe-inline!
+    csp.appendDirective("img-src", "https://www.collaboraoffice.com/");
 
     std::ostringstream cspOss;
-    cspOss << "Content-Security-Policy: " << csp.generate();
+    cspOss << "Content-Security-Policy: ";
 
     // Frame ancestors: Allow coolwsd host, wopi host and anything configured.
     std::string configFrameAncestor = config.getString("net.frame_ancestors", "");
@@ -1110,25 +1113,23 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
         }
     }
 
-    std::string imgSrc = "img-src 'self' data: https://www.collaboraoffice.com/";
     if (!frameAncestors.empty())
     {
         LOG_TRC("Allowed frame ancestors: " << frameAncestors);
         // X-Frame-Options supports only one ancestor, ignore that
         //(it's deprecated anyway and CSP works in all major browsers)
-        // frame anchestors are also allowed for img-src in order to load the views avatars
-        cspOss << imgSrc << " " << frameAncestors << "; "
-                << "frame-ancestors " << frameAncestors;
+        // frame ancestors are also allowed for img-src in order to load the views avatars
+        csp.appendDirective("img-src", frameAncestors);
+        csp.appendDirective("frame-ancestors", frameAncestors);
         const std::string escapedFrameAncestors = Util::encodeURIComponent(frameAncestors, "'");
         Poco::replaceInPlace(preprocess, std::string("%FRAME_ANCESTORS%"), escapedFrameAncestors);
     }
     else
     {
         LOG_TRC("Denied all frame ancestors");
-        cspOss << imgSrc << "; ";
     }
 
-    cspOss << "\r\n";
+    cspOss << csp.generate() << "\r\n";
 
     std::ostringstream oss;
     oss << "HTTP/1.1 200 OK\r\n"


### PR DESCRIPTION
- make: failing jail cleanup is not fatal
- wsd: simplify frame-ancestor handling
- killpoco: replace URI::encode with our wrapper
- wsd: add ContentSecurityPolicy manager
- wsd: more CSP refactoring
- wsd: support providing CSP header in the config
