### PR TITLE
Fix iOS build breakages by adding http::Request to iOS build

### DIFF
--- a/common/Session.cpp
+++ b/common/Session.cpp
@@ -254,6 +254,7 @@ void Session::handleMessage(const std::vector<char> &data)
 {
     try
     {
+#if !MOBILEAPP
         std::unique_ptr< std::vector<char> > replace;
         if (!Util::isFuzzing() && UnitBase::get().filterSessionInput(this, &data[0], data.size(), replace))
         {
@@ -261,6 +262,7 @@ void Session::handleMessage(const std::vector<char> &data)
                 _handleInput(replace->data(), replace->size());
             return;
         }
+#endif
 
         if (!data.empty())
             _handleInput(&data[0], data.size());

--- a/common/Session.cpp
+++ b/common/Session.cpp
@@ -254,15 +254,13 @@ void Session::handleMessage(const std::vector<char> &data)
 {
     try
     {
-#if !MOBILEAPP
         std::unique_ptr< std::vector<char> > replace;
-        if (!Util::isFuzzing() && UnitBase::get().filterSessionInput(this, &data[0], data.size(), replace))
+        if (UnitBase::isUnitTesting() && !Util::isFuzzing() && UnitBase::get().filterSessionInput(this, &data[0], data.size(), replace))
         {
             if (!replace || replace->empty())
                 _handleInput(replace->data(), replace->size());
             return;
         }
-#endif
 
         if (!data.empty())
             _handleInput(&data[0], data.size());

--- a/ios/Mobile.xcodeproj/project.pbxproj
+++ b/ios/Mobile.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3F3B54DD2A3928D100063C01 /* HttpRequest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F3B54DB2A39288500063C01 /* HttpRequest.cpp */; };
+		3F3B54E02A392CCB00063C01 /* NetUtil.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F3B54DE2A392C9C00063C01 /* NetUtil.cpp */; };
 		BE00F8A021396585001CE2D4 /* cool.html in Resources */ = {isa = PBXBuildFile; fileRef = BE00F89621396585001CE2D4 /* cool.html */; };
 		BE00F8A121396585001CE2D4 /* bundle.css in Resources */ = {isa = PBXBuildFile; fileRef = BE00F89721396585001CE2D4 /* bundle.css */; };
 		BE00F8A321396585001CE2D4 /* bundle.js in Resources */ = {isa = PBXBuildFile; fileRef = BE00F89921396585001CE2D4 /* bundle.js */; };
@@ -76,6 +78,10 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		3F3B54DB2A39288500063C01 /* HttpRequest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = HttpRequest.cpp; sourceTree = "<group>"; };
+		3F3B54DC2A39288500063C01 /* HttpRequest.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = HttpRequest.hpp; sourceTree = "<group>"; };
+		3F3B54DE2A392C9C00063C01 /* NetUtil.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = NetUtil.cpp; sourceTree = "<group>"; };
+		3F3B54DF2A392C9C00063C01 /* NetUtil.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = NetUtil.hpp; sourceTree = "<group>"; };
 		BE00F89621396585001CE2D4 /* cool.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; name = cool.html; path = ../../../browser/dist/cool.html; sourceTree = "<group>"; };
 		BE00F89721396585001CE2D4 /* bundle.css */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.css; name = bundle.css; path = ../../../browser/dist/bundle.css; sourceTree = "<group>"; };
 		BE00F89921396585001CE2D4 /* bundle.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = bundle.js; path = ../../../browser/dist/bundle.js; sourceTree = "<group>"; };
@@ -2891,6 +2897,10 @@
 			isa = PBXGroup;
 			children = (
 				BEA2835F214ACA8500848631 /* FakeSocket.cpp */,
+				3F3B54DB2A39288500063C01 /* HttpRequest.cpp */,
+				3F3B54DC2A39288500063C01 /* HttpRequest.hpp */,
+				3F3B54DE2A392C9C00063C01 /* NetUtil.cpp */,
+				3F3B54DF2A392C9C00063C01 /* NetUtil.hpp */,
 				BEA2835C21498AD400848631 /* Socket.cpp */,
 				BEA2835E214A8E2000848631 /* Socket.hpp */,
 				BE636210215101D000F4237E /* WebSocketHandler.hpp */,
@@ -3615,12 +3625,14 @@
 				BEFB1EE121C29CC70081D757 /* L10n.mm in Sources */,
 				BEDCC8992456FFAD00FB02BD /* SceneDelegate.mm in Sources */,
 				BE5EB5C6213FE29900E0826C /* SigUtil.cpp in Sources */,
+				3F3B54E02A392CCB00063C01 /* NetUtil.cpp in Sources */,
 				BE5EB5C1213FE29900E0826C /* Log.cpp in Sources */,
 				BEDCC84E2452F82800FB02BD /* MobileApp.cpp in Sources */,
 				BE5EB5DA2140363100E0826C /* ios.mm in Sources */,
 				BE5EB5D421400DC100E0826C /* DocumentBroker.cpp in Sources */,
 				BEA28377214FFD8C00848631 /* Unit.cpp in Sources */,
 				BE5EB5CF213FE2D000E0826C /* ClientSession.cpp in Sources */,
+				3F3B54DD2A3928D100063C01 /* HttpRequest.cpp in Sources */,
 				BEBF3EB0246EB1C800415E87 /* RequestDetails.cpp in Sources */,
 				BE5EB5C2213FE29900E0826C /* SpookyV2.cpp in Sources */,
 				BE8D77402136762600AC58EA /* main.m in Sources */,

--- a/net/HttpRequest.cpp
+++ b/net/HttpRequest.cpp
@@ -116,7 +116,7 @@ static inline int64_t findEndOfToken(const char* p, int64_t off, int64_t len)
 
 int64_t Header::parse(const char* p, int64_t len)
 {
-    LOG_TRC("Parsing header given " << len << " bytes: " << std::string(p, std::min(len, 80L)));
+    LOG_TRC("Parsing header given " << len << " bytes: " << std::string(p, std::min(len, (int64_t)80L)));
     if (len < 4)
     {
         // Incomplete; we need at least \r\n\r\n.
@@ -307,7 +307,13 @@ int64_t Request::readData(const char* p, const int64_t len)
     if (_stage == Stage::Header)
     {
         // First line is the status line.
+#if !MOBILEAPP
         if (p == nullptr || len < MinRequestHeaderLen)
+#else
+        // Fix infinite loop on mobile by skipping the minimum request header
+        // length check
+        if (p == nullptr)
+#endif
         {
             LOG_TRC("Request::readData: len < MinRequestHeaderLen");
             return 0;

--- a/net/HttpRequest.cpp
+++ b/net/HttpRequest.cpp
@@ -116,7 +116,7 @@ static inline int64_t findEndOfToken(const char* p, int64_t off, int64_t len)
 
 int64_t Header::parse(const char* p, int64_t len)
 {
-    LOG_TRC("Parsing header given " << len << " bytes: " << std::string(p, std::min(len, (int64_t)80L)));
+    LOG_TRC("Parsing header given " << len << " bytes: " << std::string(p, std::min<int64_t>(len, 80L)));
     if (len < 4)
     {
         // Incomplete; we need at least \r\n\r\n.

--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -48,7 +48,7 @@ private:
     /// The UnitBase instance. We capture it here since
     /// this is our instance, but the test framework
     /// has a single global instance via UnitWSD::get().
-    UnitBase* _unit;
+    UnitBase* const _unit;
 
 protected:
     struct WSFrameMask
@@ -81,14 +81,11 @@ public:
 #endif
         _shuttingDown(false)
         , _isClient(isClient)
-        , _unit(nullptr)
+        , _unit(UnitBase::isUnitTesting() ? &UnitBase::get() : nullptr)
     {
 #if MOBILEAPP
         (void) isMasking;
 #endif
-
-        if (UnitBase::isUnitTesting())
-            _unit = &UnitBase::get();
     }
 
     /// Upgrades itself to a websocket directly.

--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -45,7 +45,7 @@ private:
     const bool _isClient;
 
     // Last member.
-#ifdef ENABLE_DEBUG
+#if !MOBILEAPP
     /// The UnitBase instance. We capture it here since
     /// this is our instance, but the test framework
     /// has a single global instance via UnitWSD::get().
@@ -83,7 +83,7 @@ public:
 #endif
         _shuttingDown(false)
         , _isClient(isClient)
-#ifdef ENABLE_DEBUG
+#if !MOBILEAPP
         , _unit(UnitBase::get())
 #endif
     {
@@ -669,12 +669,14 @@ public:
     /// 0 for closed socket, and -1 for other errors.
     int sendMessage(const char* data, const size_t len, const WSOpCode code, const bool flush) const
     {
+#if !MOBILEAPP
         if (!Util::isFuzzing())
         {
             int unitReturn = -1;
             if (_unit.filterSendWebSocketMessage(data, len, code, flush, unitReturn))
                 return unitReturn;
         }
+#endif
 
         //TODO: Support fragmented messages.
 

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -3613,10 +3613,8 @@ private:
     /// Prisoner websocket fun ... (for now)
     virtual void handleMessage(const std::vector<char> &data) override
     {
-#if !MOBILEAPP
-        if (UnitWSD::get().filterChildMessage(data))
+        if (UnitWSD::isUnitTesting() && UnitWSD::get().filterChildMessage(data))
             return;
-#endif
 
         auto message = std::make_shared<Message>(data.data(), data.size(), Message::Dir::Out);
         std::shared_ptr<StreamSocket> socket = getSocket().lock();
@@ -3868,7 +3866,7 @@ private:
             }
 
             // Routing
-            if (UnitWSD::get().handleHttpRequest(request, message, socket))
+            if (UnitWSD::isUnitTesting() && UnitWSD::get().handleHttpRequest(request, message, socket))
             {
                 // Unit testing, nothing to do here
             }

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -3489,6 +3489,7 @@ private:
 
         // Consume the incoming data by parsing and processing the body.
         http::Request request;
+#if !MOBILEAPP
         const int64_t read = request.readData(data.data(), data.size());
         if (read < 0)
         {
@@ -3506,6 +3507,7 @@ private:
 
         // Remove consumed data.
         data.eraseFirst(read);
+#endif
 
         try
         {
@@ -3575,7 +3577,6 @@ private:
 #else
             pid_t pid = 100;
             std::string jailId = "jail";
-            LOG_ASSERT_MSG(socket->getInBuffer().empty(), "Unexpected data in prisoner socket");
             socket->getInBuffer().clear();
 #endif
             LOG_TRC("Calling make_shared<ChildProcess>, for NewChildren?");
@@ -3612,8 +3613,10 @@ private:
     /// Prisoner websocket fun ... (for now)
     virtual void handleMessage(const std::vector<char> &data) override
     {
+#if !MOBILEAPP
         if (UnitWSD::get().filterChildMessage(data))
             return;
+#endif
 
         auto message = std::make_shared<Message>(data.data(), data.size(), Message::Dir::Out);
         std::shared_ptr<StreamSocket> socket = getSocket().lock();

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -149,13 +149,10 @@ DocumentBroker::DocumentBroker(ChildType type, const std::string& uri, const Poc
     , _wopiDownloadDuration(0)
     , _mobileAppDocId(mobileAppDocId)
     , _alwaysSaveOnExit(COOLWSD::getConfigValue<bool>("per_document.always_save_on_exit", false))
-    , _unitWsd(nullptr)
+    , _unitWsd(UnitWSD::isUnitTesting() ? &UnitWSD::get() : nullptr)
 {
     assert(!_docKey.empty());
     assert(!COOLWSD::ChildRoot.empty());
-
-    if (UnitWSD::isUnitTesting())
-        _unitWsd = &UnitWSD::get();
 
 #if !MOBILEAPP
     assert(_mobileAppDocId == 0 && "Unexpected to have mobileAppDocId in the non-mobile build");

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -149,7 +149,7 @@ DocumentBroker::DocumentBroker(ChildType type, const std::string& uri, const Poc
     , _wopiDownloadDuration(0)
     , _mobileAppDocId(mobileAppDocId)
     , _alwaysSaveOnExit(COOLWSD::getConfigValue<bool>("per_document.always_save_on_exit", false))
-#ifdef ENABLE_DEBUG
+#if !MOBILEAPP
     , _unitWsd(UnitWSD::get())
 #endif
 {
@@ -167,10 +167,12 @@ DocumentBroker::DocumentBroker(ChildType type, const std::string& uri, const Poc
                                << "] created with docKey [" << _docKey
                                << "], always_save_on_exit: " << _alwaysSaveOnExit);
 
+#if !MOBILEAPP
     if (UnitWSD::isUnitTesting())
     {
         _unitWsd.onDocBrokerCreate(_docKey);
     }
+#endif
 }
 
 void DocumentBroker::setupPriorities()
@@ -290,13 +292,13 @@ void DocumentBroker::pollThread()
             break;
         }
 
+#if !MOBILEAPP
         if (UnitWSD::isUnitTesting() && _unitWsd.isFinished())
         {
             stop("UnitTestFinished");
             break;
         }
 
-#if !MOBILEAPP
         const auto now = std::chrono::steady_clock::now();
 
         // a tile's data is ~8k, a 4k screen is ~256 256x256 tiles
@@ -543,14 +545,20 @@ void DocumentBroker::pollThread()
             dataLoss = true;
             reason = isModified() ? "flagged as modified" : "not uploaded to storage";
 
+#if !MOBILEAPP
             // The test may override (if it was expected).
             if (UnitWSD::isUnitTesting() &&
                 !_unitWsd.onDataLoss("Data-loss detected while exiting [" + _docKey + ']'))
                 reason.clear();
+#endif
         }
     }
 
+#if !MOBILEAPP
     if (!reason.empty() || (UnitWSD::isUnitTesting() && _unitWsd.isFinished() && _unitWsd.failed()))
+#else
+    if (!reason.empty())
+#endif
     {
         std::stringstream state;
         state << "DocBroker [" << _docKey << " stopped "
@@ -683,12 +691,12 @@ DocumentBroker::~DocumentBroker()
 #if !MOBILEAPP
     // Remove from the admin last, to avoid racing the next test.
     Admin::instance().rmDoc(_docKey);
-#endif
 
     if (UnitWSD::isUnitTesting())
     {
         _unitWsd.DocBrokerDestroy(_docKey);
     }
+#endif
 }
 
 void DocumentBroker::joinThread()
@@ -723,11 +731,13 @@ bool DocumentBroker::download(const std::shared_ptr<ClientSession>& session, con
     LOG_INF("Loading [" << _docKey << "] for session [" << sessionId << "] in jail [" << jailId
                         << ']');
 
+#if !MOBILEAPP
     {
         bool result;
         if (_unitWsd.filterLoad(sessionId, jailId, result))
             return result;
     }
+#endif
 
     if (_docState.isMarkedToDestroy())
     {
@@ -1789,9 +1799,9 @@ void DocumentBroker::handleUploadToStorageResponse(const StorageBase::UploadResu
     LOG_TRC("lastUploadSuccessful: " << lastUploadSuccessful);
     _storageManager.setLastUploadResult(lastUploadSuccessful);
 
+#if !MOBILEAPP
     _unitWsd.onDocumentUploaded(lastUploadSuccessful);
 
-#if !MOBILEAPP
     if (lastUploadSuccessful && !isModified())
     {
         // Flag the document as uploaded in the admin console.
@@ -2477,7 +2487,11 @@ bool DocumentBroker::sendUnoSave(const std::shared_ptr<ClientSession>& session,
     _nextStorageAttrs.setUserModified(isModified() || haveModifyActivityAfterSaveRequest());
 
     // Note: It's odd to capture these here, but this function is used from ClientSession too.
+#if !MOBILEAPP
     _nextStorageAttrs.setIsAutosave(isAutosave || _unitWsd.isAutosave());
+#else
+    _nextStorageAttrs.setIsAutosave(isAutosave);
+#endif
     _nextStorageAttrs.setExtendedData(extendedData);
 
     const std::string saveArgs = oss.str();
@@ -2583,10 +2597,12 @@ std::size_t DocumentBroker::addSessionInternal(const std::shared_ptr<ClientSessi
             " session [" << id << "] to docKey [" <<
             _docKey << "] to have " << count << " sessions.");
 
+#if !MOBILEAPP
     if (UnitWSD::isUnitTesting())
     {
         _unitWsd.onDocBrokerAddSession(_docKey, session);
     }
+#endif
 
     return count;
 }
@@ -2761,11 +2777,13 @@ void DocumentBroker::finalRemoveSession(const std::shared_ptr<ClientSession>& se
     const std::string sessionId = session->getId();
     try
     {
+#if !MOBILEAPP
         if (UnitWSD::isUnitTesting())
         {
             // Notify test code before removal.
             _unitWsd.onDocBrokerRemoveSession(_docKey, session);
         }
+#endif
 
         const bool readonly = session->isReadOnly();
         session->dispose();
@@ -2845,8 +2863,10 @@ void DocumentBroker::alertAllUsers(const std::string& msg)
 {
     ASSERT_CORRECT_THREAD();
 
+#if !MOBILEAPP
     if (_unitWsd.filterAlertAllusers(msg))
         return;
+#endif
 
     auto payload = std::make_shared<Message>(msg, Message::Dir::Out);
 
@@ -2888,10 +2908,10 @@ bool DocumentBroker::handleInput(const std::shared_ptr<Message>& message)
 #if !MOBILEAPP
     if (COOLWSD::TraceDumper)
         COOLWSD::dumpOutgoingTrace(getJailId(), "0", message->abbr());
-#endif
 
     if (_unitWsd.filterLOKitMessage(message))
         return true;
+#endif
 
     if (COOLProtocol::getFirstToken(message->forwardToken(), '-') == "client")
     {

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -149,12 +149,13 @@ DocumentBroker::DocumentBroker(ChildType type, const std::string& uri, const Poc
     , _wopiDownloadDuration(0)
     , _mobileAppDocId(mobileAppDocId)
     , _alwaysSaveOnExit(COOLWSD::getConfigValue<bool>("per_document.always_save_on_exit", false))
-#if !MOBILEAPP
-    , _unitWsd(UnitWSD::get())
-#endif
+    , _unitWsd(nullptr)
 {
     assert(!_docKey.empty());
     assert(!COOLWSD::ChildRoot.empty());
+
+    if (UnitWSD::isUnitTesting())
+        _unitWsd = &UnitWSD::get();
 
 #if !MOBILEAPP
     assert(_mobileAppDocId == 0 && "Unexpected to have mobileAppDocId in the non-mobile build");
@@ -167,12 +168,10 @@ DocumentBroker::DocumentBroker(ChildType type, const std::string& uri, const Poc
                                << "] created with docKey [" << _docKey
                                << "], always_save_on_exit: " << _alwaysSaveOnExit);
 
-#if !MOBILEAPP
-    if (UnitWSD::isUnitTesting())
+    if (_unitWsd)
     {
-        _unitWsd.onDocBrokerCreate(_docKey);
+        _unitWsd->onDocBrokerCreate(_docKey);
     }
-#endif
 }
 
 void DocumentBroker::setupPriorities()
@@ -292,13 +291,13 @@ void DocumentBroker::pollThread()
             break;
         }
 
-#if !MOBILEAPP
-        if (UnitWSD::isUnitTesting() && _unitWsd.isFinished())
+        if (_unitWsd && _unitWsd->isFinished())
         {
             stop("UnitTestFinished");
             break;
         }
 
+#if !MOBILEAPP
         const auto now = std::chrono::steady_clock::now();
 
         // a tile's data is ~8k, a 4k screen is ~256 256x256 tiles
@@ -545,20 +544,14 @@ void DocumentBroker::pollThread()
             dataLoss = true;
             reason = isModified() ? "flagged as modified" : "not uploaded to storage";
 
-#if !MOBILEAPP
             // The test may override (if it was expected).
-            if (UnitWSD::isUnitTesting() &&
-                !_unitWsd.onDataLoss("Data-loss detected while exiting [" + _docKey + ']'))
+            if (_unitWsd &&
+                !_unitWsd->onDataLoss("Data-loss detected while exiting [" + _docKey + ']'))
                 reason.clear();
-#endif
         }
     }
 
-#if !MOBILEAPP
-    if (!reason.empty() || (UnitWSD::isUnitTesting() && _unitWsd.isFinished() && _unitWsd.failed()))
-#else
-    if (!reason.empty())
-#endif
+    if (!reason.empty() || (_unitWsd && _unitWsd->isFinished() && _unitWsd->failed()))
     {
         std::stringstream state;
         state << "DocBroker [" << _docKey << " stopped "
@@ -691,12 +684,12 @@ DocumentBroker::~DocumentBroker()
 #if !MOBILEAPP
     // Remove from the admin last, to avoid racing the next test.
     Admin::instance().rmDoc(_docKey);
-
-    if (UnitWSD::isUnitTesting())
-    {
-        _unitWsd.DocBrokerDestroy(_docKey);
-    }
 #endif
+
+    if (_unitWsd)
+    {
+        _unitWsd->DocBrokerDestroy(_docKey);
+    }
 }
 
 void DocumentBroker::joinThread()
@@ -731,13 +724,12 @@ bool DocumentBroker::download(const std::shared_ptr<ClientSession>& session, con
     LOG_INF("Loading [" << _docKey << "] for session [" << sessionId << "] in jail [" << jailId
                         << ']');
 
-#if !MOBILEAPP
+    if (_unitWsd)
     {
         bool result;
-        if (_unitWsd.filterLoad(sessionId, jailId, result))
+        if (_unitWsd->filterLoad(sessionId, jailId, result))
             return result;
     }
-#endif
 
     if (_docState.isMarkedToDestroy())
     {
@@ -1799,9 +1791,10 @@ void DocumentBroker::handleUploadToStorageResponse(const StorageBase::UploadResu
     LOG_TRC("lastUploadSuccessful: " << lastUploadSuccessful);
     _storageManager.setLastUploadResult(lastUploadSuccessful);
 
-#if !MOBILEAPP
-    _unitWsd.onDocumentUploaded(lastUploadSuccessful);
+    if (_unitWsd)
+        _unitWsd->onDocumentUploaded(lastUploadSuccessful);
 
+#if !MOBILEAPP
     if (lastUploadSuccessful && !isModified())
     {
         // Flag the document as uploaded in the admin console.
@@ -2487,11 +2480,7 @@ bool DocumentBroker::sendUnoSave(const std::shared_ptr<ClientSession>& session,
     _nextStorageAttrs.setUserModified(isModified() || haveModifyActivityAfterSaveRequest());
 
     // Note: It's odd to capture these here, but this function is used from ClientSession too.
-#if !MOBILEAPP
-    _nextStorageAttrs.setIsAutosave(isAutosave || _unitWsd.isAutosave());
-#else
-    _nextStorageAttrs.setIsAutosave(isAutosave);
-#endif
+    _nextStorageAttrs.setIsAutosave(isAutosave || (_unitWsd && _unitWsd->isAutosave()));
     _nextStorageAttrs.setExtendedData(extendedData);
 
     const std::string saveArgs = oss.str();
@@ -2597,12 +2586,10 @@ std::size_t DocumentBroker::addSessionInternal(const std::shared_ptr<ClientSessi
             " session [" << id << "] to docKey [" <<
             _docKey << "] to have " << count << " sessions.");
 
-#if !MOBILEAPP
-    if (UnitWSD::isUnitTesting())
+    if (_unitWsd)
     {
-        _unitWsd.onDocBrokerAddSession(_docKey, session);
+        _unitWsd->onDocBrokerAddSession(_docKey, session);
     }
-#endif
 
     return count;
 }
@@ -2777,13 +2764,11 @@ void DocumentBroker::finalRemoveSession(const std::shared_ptr<ClientSession>& se
     const std::string sessionId = session->getId();
     try
     {
-#if !MOBILEAPP
-        if (UnitWSD::isUnitTesting())
+        if (_unitWsd)
         {
             // Notify test code before removal.
-            _unitWsd.onDocBrokerRemoveSession(_docKey, session);
+            _unitWsd->onDocBrokerRemoveSession(_docKey, session);
         }
-#endif
 
         const bool readonly = session->isReadOnly();
         session->dispose();
@@ -2863,10 +2848,8 @@ void DocumentBroker::alertAllUsers(const std::string& msg)
 {
     ASSERT_CORRECT_THREAD();
 
-#if !MOBILEAPP
-    if (_unitWsd.filterAlertAllusers(msg))
+    if (_unitWsd && _unitWsd->filterAlertAllusers(msg))
         return;
-#endif
 
     auto payload = std::make_shared<Message>(msg, Message::Dir::Out);
 
@@ -2908,10 +2891,10 @@ bool DocumentBroker::handleInput(const std::shared_ptr<Message>& message)
 #if !MOBILEAPP
     if (COOLWSD::TraceDumper)
         COOLWSD::dumpOutgoingTrace(getJailId(), "0", message->abbr());
-
-    if (_unitWsd.filterLOKitMessage(message))
-        return true;
 #endif
+
+    if (_unitWsd && _unitWsd->filterLOKitMessage(message))
+        return true;
 
     if (COOLProtocol::getFirstToken(message->forwardToken(), '-') == "client")
     {

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -1460,7 +1460,7 @@ private:
     const bool _alwaysSaveOnExit;
 
     // Last member.
-#ifdef ENABLE_DEBUG
+#if !MOBILEAPP
     /// The UnitWSD instance. We capture it here since
     /// this is our instance, but the test framework
     /// has a single global instance via UnitWSD::get().

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -1463,7 +1463,7 @@ private:
     /// The UnitWSD instance. We capture it here since
     /// this is our instance, but the test framework
     /// has a single global instance via UnitWSD::get().
-    UnitWSD* _unitWsd;
+    UnitWSD* const _unitWsd;
 };
 
 #if !MOBILEAPP

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -1460,12 +1460,10 @@ private:
     const bool _alwaysSaveOnExit;
 
     // Last member.
-#if !MOBILEAPP
     /// The UnitWSD instance. We capture it here since
     /// this is our instance, but the test framework
     /// has a single global instance via UnitWSD::get().
-    UnitWSD& _unitWsd;
-#endif
+    UnitWSD* _unitWsd;
 };
 
 #if !MOBILEAPP

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -266,6 +266,7 @@ std::unique_ptr<StorageBase> StorageBase::create(const Poco::URI& uri, const std
     // here much earlier. Also, using exceptions is lame and makes understanding the code harder,
     // but that is just my personal preference.
 
+#if !MOBILEAPP
     std::unique_ptr<StorageBase> storage;
     if (UnitWSD::get().createStorage(uri, jailRoot, jailPath, storage))
     {
@@ -275,6 +276,7 @@ std::unique_ptr<StorageBase> StorageBase::create(const Poco::URI& uri, const std
             return storage;
         }
     }
+#endif
 
     const StorageBase::StorageType type = validate(uri, takeOwnership);
     switch (type)
@@ -298,7 +300,9 @@ std::unique_ptr<StorageBase> StorageBase::create(const Poco::URI& uri, const std
                 new LocalStorage(uri, jailRoot, jailPath, takeOwnership));
             break;
         case StorageBase::StorageType::Wopi:
+#if !MOBILEAPP
             return std::unique_ptr<StorageBase>(new WopiStorage(uri, jailRoot, jailPath));
+#endif
             break;
     }
 

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -266,9 +266,8 @@ std::unique_ptr<StorageBase> StorageBase::create(const Poco::URI& uri, const std
     // here much earlier. Also, using exceptions is lame and makes understanding the code harder,
     // but that is just my personal preference.
 
-#if !MOBILEAPP
     std::unique_ptr<StorageBase> storage;
-    if (UnitWSD::get().createStorage(uri, jailRoot, jailPath, storage))
+    if (UnitBase::isUnitTesting() && UnitWSD::get().createStorage(uri, jailRoot, jailPath, storage))
     {
         if (storage)
         {
@@ -276,7 +275,6 @@ std::unique_ptr<StorageBase> StorageBase::create(const Poco::URI& uri, const std
             return storage;
         }
     }
-#endif
 
     const StorageBase::StorageType type = validate(uri, takeOwnership);
     switch (type)


### PR DESCRIPTION
Still needed to add a bunch of #if !MOBILAPP to disable all of the Online server's unit testing classes so that the iOS app won't crash when opening a document.

TODO: the iOS app will get stuck in an infinite loop when opening a document on iOS in http::Request::readData().