### PR TITLE
impress: arrange slide/hide show menu entries better

### DIFF
--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -932,6 +932,8 @@ button.leaflet-control-search-next
 .w2ui-icon.color{ background: url('images/lc_color.svg') no-repeat center; }
 .w2ui-icon.deletepage{ background: url('images/lc_deletepage.svg') no-repeat center; }
 .w2ui-icon.duplicatepage{ background: url('images/lc_duplicatepage.svg') no-repeat center; }
+.w2ui-icon.showslide{ background: url('images/lc_showslide.svg') no-repeat center; }
+.w2ui-icon.hideslide{ background: url('images/lc_hideslide.svg') no-repeat center; }
 .w2ui-icon.equal{ background: url('images/lc26049.svg') no-repeat center; }
 .w2ui-icon.help{ background: url('images/lc_helpindex.svg') no-repeat center; }
 .w2ui-icon.insertpage{ background: url('images/lc_insertpage.svg') no-repeat center; }

--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -486,12 +486,11 @@ L.Control.Menubar = L.Control.extend({
 				{name: _UNO('.uno:InsertSlide', 'presentation'), id: 'insertpage', type: 'action'},
 				{name: _UNO('.uno:DuplicateSlide', 'presentation'), id: 'duplicatepage', type: 'action'},
 				{name: _UNO('.uno:DeleteSlide', 'presentation'), id: 'deletepage', type: 'action'},
+				{name: _UNO('.uno:ShowSlide', 'presentation'), id: 'showslide', type: 'action'},
+				{name: _UNO('.uno:HideSlide', 'presentation'), id: 'hideslide', type: 'action'},
 				{type: 'separator', id: 'fullscreen-presentation-separator'},
 				{name: _('Fullscreen presentation'), id: 'fullscreen-presentation', type: 'action'},
-				{name: _('Present current slide'), id: 'presentation-currentslide', type: 'action'},
-				{type: 'separator', id: 'slide-show-hide-separator'},
-				{name: _UNO('.uno:ShowSlide', 'presentation'), id: 'showslide', type: 'action'},
-				{name: _UNO('.uno:HideSlide', 'presentation'), id: 'hideslide', type: 'action'}]
+				{name: _('Present current slide'), id: 'presentation-currentslide', type: 'action'}]
 			},
 			{name: _UNO('.uno:ToolsMenu', 'presentation'), id: 'tools', type: 'menu', menu: [
 				{uno: '.uno:SpellDialog'},

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -427,18 +427,6 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'type': 'bigtoolitem',
 				'text': _UNO('.uno:Sidebar'),
 				'command': '.uno:SidebarDeck.PropertyDeck'
-			},
-			{
-				'id': 'showslide',
-				'type': 'bigmenubartoolitem',
-				'text': _UNO('.uno:ShowSlide', 'presentation'),
-				'command': '.uno:ShowSlide'
-			},
-			{
-				'id': 'hideslide',
-				'type': 'bigmenubartoolitem',
-				'text': _UNO('.uno:HideSlide', 'presentation'),
-				'command': '.uno:HideSlide'
 			}
 		];
 
@@ -1142,6 +1130,18 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'type': 'bigtoolitem',
 				'text': _UNO('.uno:InsertSlide', 'presentation'),
 				'command': '.uno:InsertPage'
+			},
+			{
+				'id': 'showslide',
+				'type': 'bigmenubartoolitem',
+				'text': _UNO('.uno:ShowSlide', 'presentation'),
+				'command': '.uno:ShowSlide'
+			},
+			{
+				'id': 'hideslide',
+				'type': 'bigmenubartoolitem',
+				'text': _UNO('.uno:HideSlide', 'presentation'),
+				'command': '.uno:HideSlide'
 			},
 			{
 				'type': 'container',

--- a/browser/src/control/Control.PresentationBar.js
+++ b/browser/src/control/Control.PresentationBar.js
@@ -17,6 +17,11 @@ L.Control.PresentationBar = L.Control.extend({
 		map.on('doclayerinit', this.onDocLayerInit, this);
 		map.on('updatepermission', this.onUpdatePermission, this);
 		map.on('commandstatechanged', this.onCommandStateChanged, this);
+
+		if (this.map.getDocType() === 'presentation') {
+			this.map.on('updateparts', this.onSlideHideToggle, this);
+			this.map.on('toggleslidehide', this.onSlideHideToggle, this);
+		}
 	},
 
 	create: function() {
@@ -32,6 +37,8 @@ L.Control.PresentationBar = L.Control.extend({
 				{type: 'button',  id: 'insertpage', img: 'insertpage', hint: this._getItemUnoName('insertpage')},
 				{type: 'button',  id: 'duplicatepage', img: 'duplicatepage', hint: this._getItemUnoName('duplicatepage')},
 				{type: 'button',  id: 'deletepage', img: 'deletepage', hint: this._getItemUnoName('deletepage')},
+				{type: 'button', id: 'showslide', img: 'showslide', hidden: that.map.getDocType() !== 'presentation', hint: _UNO('.uno:ShowSlide', 'presentation')},
+				{type: 'button', id: 'hideslide', img: 'hideslide', hidden: that.map.getDocType() !== 'presentation', hint: _UNO('.uno:HideSlide', 'presentation')},
 				{type: 'html',  id: 'right'}
 			],
 			onClick: function (e) {
@@ -97,6 +104,12 @@ L.Control.PresentationBar = L.Control.extend({
 		}
 		else if (id === 'deletepage') {
 			this.map.dispatch('deletepage');
+		}
+		else if (id === 'showslide') {
+			this.map.showSlide();
+		}
+		else if (id === 'hideslide') {
+			this.map.hideSlide();
 		}
 	},
 
@@ -176,6 +189,23 @@ L.Control.PresentationBar = L.Control.extend({
 				}
 			}
 		}
+	},
+
+	onSlideHideToggle: function() {
+		if (this.map.getDocType() !== 'presentation')
+			return;
+
+
+		if (!this.map._docLayer.isHiddenSlide(this.map.getCurrentPartNumber()))
+			w2ui['presentation-toolbar'].hide('showslide');
+
+		else
+		w2ui['presentation-toolbar'].show('showslide');
+
+		if (this.map._docLayer.isHiddenSlide(this.map.getCurrentPartNumber()))
+			w2ui['presentation-toolbar'].hide('hideslide');
+		else
+		w2ui['presentation-toolbar'].show('hideslide');
 	},
 });
 


### PR DESCRIPTION
added slide hide/show option in presentation bar
rearranged icons to align them with core UI


Change-Id: Ic4b121ab5d9ab21d8f48e68bb07e51a31442586e

* Target version: master 


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

