### PR TITLE
private/ash/tests

### DIFF
--- a/test/UnitLoad.cpp
+++ b/test/UnitLoad.cpp
@@ -179,7 +179,7 @@ UnitBase::TestResult UnitLoad::testExcelLoad()
         helpers::sendTextFrame(socket, "status", testname);
         const auto status = helpers::assertResponseString(socket, "status:", testname);
 
-        // Expected format is something like 'status: type=text parts=2 current=0 width=12808 height=1142 viewid=0\n...'.
+        // Expected format is something like 'status: type=spreadsheet parts=1 current=0 width=20685 height=24885 viewid=0 lastcolumn=31 lastrow=12'
         StringVector tokens(StringVector::tokenize(status, ' '));
         LOK_ASSERT_EQUAL(static_cast<size_t>(9), tokens.size());
     }

--- a/test/UnitOAuth.cpp
+++ b/test/UnitOAuth.cpp
@@ -7,11 +7,14 @@
 
 #include <config.h>
 
+#include <HttpRequest.hpp>
 #include <WopiTestServer.hpp>
 #include <Log.hpp>
 #include <Unit.hpp>
 #include <UnitHTTP.hpp>
 #include <helpers.hpp>
+#include <Util.hpp>
+
 #include <Poco/Net/HTTPRequest.h>
 #include <Poco/Net/OAuth20Credentials.h>
 #include <Poco/Util/LayeredConfiguration.h>
@@ -77,10 +80,13 @@ public:
         assertRequest(request);
     }
 
-    void assertGetFileRequest(const Poco::Net::HTTPRequest& request) override
+    std::unique_ptr<http::Response>
+    assertGetFileRequest(const Poco::Net::HTTPRequest& request) override
     {
         _getFileCalled = true;
         assertRequest(request);
+
+        return nullptr; // Success.
     }
 
     std::unique_ptr<http::Response>

--- a/test/UnitOAuth.cpp
+++ b/test/UnitOAuth.cpp
@@ -74,10 +74,13 @@ public:
         }
     }
 
-    void assertCheckFileInfoRequest(const Poco::Net::HTTPRequest& request) override
+    virtual std::unique_ptr<http::Response>
+    assertCheckFileInfoRequest(const Poco::Net::HTTPRequest& request)
     {
         _checkFileInfoCalled = true;
         assertRequest(request);
+
+        return nullptr; // Success.
     }
 
     std::unique_ptr<http::Response>

--- a/test/UnitQuarantine.cpp
+++ b/test/UnitQuarantine.cpp
@@ -75,7 +75,8 @@ public:
         }
     }
 
-    void assertGetFileRequest(const Poco::Net::HTTPRequest& /*request*/) override
+    std::unique_ptr<http::Response>
+    assertGetFileRequest(const Poco::Net::HTTPRequest& /*request*/) override
     {
         LOG_TST("Testing " << toString(_scenario));
         LOK_ASSERT_STATE(_phase, Phase::WaitLoadStatus);
@@ -86,6 +87,8 @@ public:
         // LOK_ASSERT_EQUAL_MESSAGE("Expected modified document detection to have triggered", true,
         //                          _unloadingModifiedDocDetected);
         _unloadingModifiedDocDetected = false; // Reset.
+
+        return nullptr; // Success.
     }
 
     std::unique_ptr<http::Response>

--- a/test/UnitWOPIDocumentConflict.cpp
+++ b/test/UnitWOPIDocumentConflict.cpp
@@ -37,12 +37,15 @@ public:
     {
     }
 
-    void assertGetFileRequest(const Poco::Net::HTTPRequest& /*request*/) override
+    std::unique_ptr<http::Response>
+    assertGetFileRequest(const Poco::Net::HTTPRequest& /*request*/) override
     {
         LOG_TST("Testing " << toString(_scenario));
         LOK_ASSERT_STATE(_phase, Phase::WaitLoadStatus);
 
         assertGetFileCount();
+
+        return nullptr; // Success.
     }
 
     std::unique_ptr<http::Response>

--- a/test/UnitWOPIFailUpload.cpp
+++ b/test/UnitWOPIFailUpload.cpp
@@ -69,7 +69,8 @@ public:
         }
     }
 
-    void assertGetFileRequest(const Poco::Net::HTTPRequest& /*request*/) override
+    std::unique_ptr<http::Response>
+    assertGetFileRequest(const Poco::Net::HTTPRequest& /*request*/) override
     {
         LOG_TST("Testing " << toString(_scenario));
         LOK_ASSERT_STATE(_phase, Phase::WaitLoadStatus);
@@ -80,6 +81,8 @@ public:
         // LOK_ASSERT_EQUAL_MESSAGE("Expected modified document detection to have triggered", true,
         //                          _unloadingModifiedDocDetected);
         _unloadingModifiedDocDetected = false; // Reset.
+
+        return nullptr; // Success.
     }
 
     std::unique_ptr<http::Response>

--- a/test/UnitWOPIFailUpload.cpp
+++ b/test/UnitWOPIFailUpload.cpp
@@ -306,7 +306,8 @@ public:
         config.setBool("per_document.always_save_on_exit", true);
     }
 
-    void configCheckFileInfo(Poco::JSON::Object::Ptr fileInfo) override
+    void configCheckFileInfo(const Poco::Net::HTTPRequest& /*request*/,
+                             Poco::JSON::Object::Ptr fileInfo) override
     {
         LOG_TST("CheckFileInfo: making read-only");
 

--- a/test/UnitWOPIFileUrl.cpp
+++ b/test/UnitWOPIFileUrl.cpp
@@ -123,8 +123,8 @@ public:
                 const std::string filename = std::string(TDOC) + InvalidFilename;
                 LOG_TST("FakeWOPIHost: Request, WOPI::GetFile returning 404 for: " << filename);
 
-                socket->send(http::Response(http::StatusCode::NotFound));
-                socket->shutdown();
+                http::Response httpResponse(http::StatusCode::NotFound);
+                socket->sendAndShutdown(httpResponse);
 
                 return true;
             }
@@ -162,8 +162,7 @@ public:
             httpResponse.setBody("{\"LastModifiedTime\": \"" +
                                      Util::getHttpTime(getFileLastModifiedTime()) + "\" }",
                                  "application/json; charset=utf-8");
-            socket->send(httpResponse);
-            socket->shutdown();
+            socket->sendAndShutdown(httpResponse);
 
             LOG_TST("Closing document after PutFile");
             WSD_CMD("closedocument");

--- a/test/UnitWOPIFileUrl.cpp
+++ b/test/UnitWOPIFileUrl.cpp
@@ -95,19 +95,9 @@ public:
             {
                 LOG_TST("FakeWOPIHost: Handling WOPI::CheckFileInfo: " << uriReq.getPath());
 
-                Poco::JSON::Object::Ptr fileInfo = new Poco::JSON::Object();
+                Poco::JSON::Object::Ptr fileInfo = getDefaultCheckFileInfoPayload(uriReq);
                 fileInfo->set("BaseFileName", DefaultUrlFilename);
                 fileInfo->set("FileUrl", getFileUrl());
-                fileInfo->set("Size", getFileContent().size());
-                fileInfo->set("Version", "1.0");
-                fileInfo->set("OwnerId", "test");
-                fileInfo->set("UserId", "test");
-                fileInfo->set("UserFriendlyName", "test");
-                fileInfo->set("UserCanWrite", "true");
-                fileInfo->set("PostMessageOrigin", "localhost");
-                fileInfo->set("LastModifiedTime",
-                              Util::getIso8601FracformatTime(getFileLastModifiedTime()));
-                fileInfo->set("EnableOwnerTermination", "true");
 
                 std::ostringstream jsonStream;
                 fileInfo->stringify(jsonStream);

--- a/test/UnitWOPIFileUrl.cpp
+++ b/test/UnitWOPIFileUrl.cpp
@@ -123,9 +123,7 @@ public:
                 const std::string filename = std::string(TDOC) + InvalidFilename;
                 LOG_TST("FakeWOPIHost: Request, WOPI::GetFile returning 404 for: " << filename);
 
-                socket->send("HTTP/1.1 404 Not Found\r\n"
-                             "User-Agent: " WOPI_AGENT_STRING "\r\n"
-                             "\r\n");
+                socket->send(http::Response(http::StatusCode::NotFound));
                 socket->shutdown();
 
                 return true;
@@ -160,14 +158,11 @@ public:
             std::streamsize size = request.getContentLength();
             LOK_ASSERT(size > 0);
 
-            std::ostringstream oss;
-            oss << "HTTP/1.1 200 OK\r\n"
-                << "User-Agent: " << WOPI_AGENT_STRING << "\r\n"
-                << "\r\n"
-                << "{\"LastModifiedTime\": \"" << Util::getHttpTime(getFileLastModifiedTime())
-                << "\" }";
-
-            socket->send(oss.str());
+            http::Response httpResponse(http::StatusCode::OK);
+            httpResponse.setBody("{\"LastModifiedTime\": \"" +
+                                     Util::getHttpTime(getFileLastModifiedTime()) + "\" }",
+                                 "application/json; charset=utf-8");
+            socket->send(httpResponse);
             socket->shutdown();
 
             LOG_TST("Closing document after PutFile");

--- a/test/UnitWOPIHttpHeaders.cpp
+++ b/test/UnitWOPIHttpHeaders.cpp
@@ -26,10 +26,13 @@ protected:
         assertHeaders(request);
     }
 
-    void assertGetFileRequest(const Poco::Net::HTTPRequest& request) override
+    std::unique_ptr<http::Response>
+    assertGetFileRequest(const Poco::Net::HTTPRequest& request) override
     {
         assertHeaders(request);
         exitTest(TestResult::Ok); //TODO: Remove when we add put/rename cases.
+
+        return nullptr; // Success.
     }
 
     std::unique_ptr<http::Response>

--- a/test/UnitWOPIHttpHeaders.cpp
+++ b/test/UnitWOPIHttpHeaders.cpp
@@ -21,9 +21,12 @@ class UnitWopiHttpHeaders : public WopiTestServer
     _phase;
 
 protected:
-    void assertCheckFileInfoRequest(const Poco::Net::HTTPRequest& request) override
+    virtual std::unique_ptr<http::Response>
+    assertCheckFileInfoRequest(const Poco::Net::HTTPRequest& request)
     {
         assertHeaders(request);
+
+        return nullptr; // Success.
     }
 
     std::unique_ptr<http::Response>

--- a/test/UnitWOPIHttpRedirect.cpp
+++ b/test/UnitWOPIHttpRedirect.cpp
@@ -73,19 +73,10 @@ public:
             if (_phase == Phase::Redirected)
                 TRANSITION_STATE(_phase, Phase::GetFile);
 
-            Poco::LocalDateTime now;
-            const std::string fileName(uriReq.getPath() == "/wopi/files/3" ? "he%llo.txt" : "hello.txt");
-            Poco::JSON::Object::Ptr fileInfo = new Poco::JSON::Object();
+            Poco::JSON::Object::Ptr fileInfo = getDefaultCheckFileInfoPayload(uriReq);
+            const std::string fileName(uriReq.getPath() == "/wopi/files/3" ? "he%llo.txt"
+                                                                           : "hello.txt");
             fileInfo->set("BaseFileName", fileName);
-            fileInfo->set("Size", getFileContent().size());
-            fileInfo->set("Version", "1.0");
-            fileInfo->set("OwnerId", "test");
-            fileInfo->set("UserId", "test");
-            fileInfo->set("UserFriendlyName", "test");
-            fileInfo->set("UserCanWrite", "true");
-            fileInfo->set("PostMessageOrigin", "localhost");
-            fileInfo->set("LastModifiedTime", Util::getIso8601FracformatTime(getFileLastModifiedTime()));
-            fileInfo->set("EnableOwnerTermination", "true");
 
             std::ostringstream jsonStream;
             fileInfo->stringify(jsonStream);

--- a/test/UnitWOPILock.cpp
+++ b/test/UnitWOPILock.cpp
@@ -38,7 +38,8 @@ public:
     {
     }
 
-    void configCheckFileInfo(Poco::JSON::Object::Ptr fileInfo) override
+    void configCheckFileInfo(const Poco::Net::HTTPRequest& /*request*/,
+                             Poco::JSON::Object::Ptr fileInfo) override
     {
         // Make the first session the editor, subsequent ones read-only.
         const bool firstView = _checkFileInfoCount == 0;
@@ -168,7 +169,8 @@ public:
         config.setUInt("storage.wopi.locking.refresh", RefreshPeriodSeconds);
     }
 
-    void configCheckFileInfo(Poco::JSON::Object::Ptr fileInfo) override
+    void configCheckFileInfo(const Poco::Net::HTTPRequest& /*request*/,
+                             Poco::JSON::Object::Ptr fileInfo) override
     {
         fileInfo->set("SupportsLocks", "true");
     }

--- a/test/UnitWOPISaveOnExit.cpp
+++ b/test/UnitWOPISaveOnExit.cpp
@@ -47,12 +47,15 @@ public:
         config.setBool("per_document.always_save_on_exit", true);
     }
 
-    void assertGetFileRequest(const Poco::Net::HTTPRequest& /*request*/) override
+    std::unique_ptr<http::Response>
+    assertGetFileRequest(const Poco::Net::HTTPRequest& /*request*/) override
     {
         LOG_TST("Testing " << toString(_scenario));
         LOK_ASSERT_STATE(_phase, Phase::WaitLoadStatus);
 
         assertGetFileCount();
+
+        return nullptr; // Success.
     }
 
     std::unique_ptr<http::Response>

--- a/test/UnitWOPITemplate.cpp
+++ b/test/UnitWOPITemplate.cpp
@@ -70,8 +70,7 @@ public:
 
             http::Response httpResponse(http::StatusCode::OK);
             httpResponse.set("Allow", "GET");
-            socket->send(httpResponse);
-            socket->shutdown();
+            socket->sendAndShutdown(httpResponse);
 
             return true;
         }

--- a/test/UnitWOPITemplate.cpp
+++ b/test/UnitWOPITemplate.cpp
@@ -68,13 +68,9 @@ public:
         {
             LOG_TST("FakeWOPIHost: Handling " << request.getMethod() << " on " << uriReq.getPath());
 
-            std::ostringstream oss;
-            oss << "HTTP/1.1 200 OK\r\n"
-                << "Allow: GET\r\n"
-                << "User-Agent: " << WOPI_AGENT_STRING << "\r\n"
-                << "\r\n";
-
-            socket->send(oss.str());
+            http::Response httpResponse(http::StatusCode::OK);
+            httpResponse.set("Allow", "GET");
+            socket->send(httpResponse);
             socket->shutdown();
 
             return true;

--- a/test/UnitWOPITemplate.cpp
+++ b/test/UnitWOPITemplate.cpp
@@ -48,18 +48,9 @@ public:
         {
             LOG_TST("FakeWOPIHost: Handling CheckFileInfo: " << uriReq.getPath());
 
-            Poco::JSON::Object::Ptr fileInfo = new Poco::JSON::Object();
+            Poco::JSON::Object::Ptr fileInfo = getDefaultCheckFileInfoPayload(uriReq);
             fileInfo->set("BaseFileName", "test.odt");
             fileInfo->set("TemplateSource", helpers::getTestServerURI() + "/test.ott");
-            fileInfo->set("Size", getFileContent().size());
-            fileInfo->set("Version", "1.0");
-            fileInfo->set("OwnerId", "test");
-            fileInfo->set("UserId", "test");
-            fileInfo->set("UserFriendlyName", "test");
-            fileInfo->set("UserCanWrite", "true");
-            fileInfo->set("PostMessageOrigin", "localhost");
-            fileInfo->set("LastModifiedTime", Util::getIso8601FracformatTime(getFileLastModifiedTime()));
-            fileInfo->set("EnableOwnerTermination", "true");
 
             std::ostringstream jsonStream;
             fileInfo->stringify(jsonStream);

--- a/test/UnitWOPIUnlock.cpp
+++ b/test/UnitWOPIUnlock.cpp
@@ -34,7 +34,8 @@ public:
     {
     }
 
-    void configCheckFileInfo(Poco::JSON::Object::Ptr fileInfo) override
+    void configCheckFileInfo(const Poco::Net::HTTPRequest& /*request*/,
+                             Poco::JSON::Object::Ptr fileInfo) override
     {
         fileInfo->set("SupportsLocks", "true");
     }

--- a/test/UnitWOPIWatermark.cpp
+++ b/test/UnitWOPIWatermark.cpp
@@ -13,7 +13,6 @@
 #include <UnitHTTP.hpp>
 #include <helpers.hpp>
 #include <Poco/Net/HTTPRequest.h>
-#include <Poco/Util/LayeredConfiguration.h>
 
 class UnitWOPIWatermark : public WopiTestServer
 {
@@ -61,16 +60,17 @@ public:
             {
                 WSD_CMD("tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0,3840 "
                         "tileposy=0,0 tilewidth=3840 tileheight=3840");
-                std::string tile =
+                const std::string tile =
                     helpers::getResponseString(getWs()->getWebSocket(), "tile:", testName);
 
-                if(!tile.empty())
+                if (!tile.empty())
                 {
                     StringVector tokens(StringVector::tokenize(tile, ' '));
                     std::string nviewid = tokens[1].substr(std::string("nviewid=").size());
                     if (!nviewid.empty() && nviewid != "0")
                     {
-                        LOG_INF("Watermark is hashed into integer successfully nviewid=" << nviewid);
+                        LOG_INF(
+                            "Watermark is hashed into integer successfully nviewid=" << nviewid);
                         TRANSITION_STATE(_phase, Phase::Done);
                     }
                 }
@@ -80,9 +80,6 @@ public:
     }
 };
 
-UnitBase *unit_create_wsd(void)
-{
-    return new UnitWOPIWatermark();
-}
+UnitBase* unit_create_wsd(void) { return new UnitWOPIWatermark(); }
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/test/UnitWOPIWatermark.cpp
+++ b/test/UnitWOPIWatermark.cpp
@@ -41,18 +41,10 @@ public:
 
             assertCheckFileInfoRequest(request);
 
-            const std::string fileName(uriReq.getPath() == "/wopi/files/3" ? "he%llo.txt" : "hello.txt");
-            Poco::JSON::Object::Ptr fileInfo = new Poco::JSON::Object();
+            Poco::JSON::Object::Ptr fileInfo = getDefaultCheckFileInfoPayload(uriReq);
+            const std::string fileName(uriReq.getPath() == "/wopi/files/3" ? "he%llo.txt"
+                                                                           : "hello.txt");
             fileInfo->set("BaseFileName", fileName);
-            fileInfo->set("Size", getFileContent().size());
-            fileInfo->set("Version", "1.0");
-            fileInfo->set("OwnerId", "test");
-            fileInfo->set("UserId", "test");
-            fileInfo->set("UserFriendlyName", "test");
-            fileInfo->set("UserCanWrite", "true");
-            fileInfo->set("PostMessageOrigin", "localhost");
-            fileInfo->set("LastModifiedTime", Util::getIso8601FracformatTime(getFileLastModifiedTime()));
-            fileInfo->set("EnableOwnerTermination", "true");
             fileInfo->set("WatermarkText", "WatermarkTest");
 
             std::ostringstream jsonStream;

--- a/test/WopiTestServer.hpp
+++ b/test/WopiTestServer.hpp
@@ -284,7 +284,7 @@ protected:
             http::StatusLine::StatusCodeClass::Successful)
         {
             Poco::JSON::Object::Ptr fileInfo = getDefaultCheckFileInfoPayload(request.getURI());
-            configCheckFileInfo(fileInfo);
+            configCheckFileInfo(request, fileInfo);
 
             std::ostringstream jsonStream;
             fileInfo->stringify(jsonStream);
@@ -308,7 +308,10 @@ protected:
     }
 
     /// Override to set the CheckFileInfo attributes.
-    virtual void configCheckFileInfo(Poco::JSON::Object::Ptr /*fileInfo*/) {}
+    virtual void configCheckFileInfo(const Poco::Net::HTTPRequest& /*request*/,
+                                     Poco::JSON::Object::Ptr /*fileInfo*/)
+    {
+    }
 
     virtual bool handleGetFileRequest(const Poco::Net::HTTPRequest& request,
                                       std::shared_ptr<StreamSocket>& socket)

--- a/test/WopiTestServer.hpp
+++ b/test/WopiTestServer.hpp
@@ -242,25 +242,37 @@ protected:
         config.setBool("storage.ssl.as_scheme", false);
     }
 
-    /// Handles WOPI CheckFileInfo requests.
-    virtual bool handleCheckFileInfoRequest(const Poco::Net::HTTPRequest& request,
-                                            std::shared_ptr<StreamSocket>& socket)
+    /// Returns the default CheckFileInfo json.
+    Poco::JSON::Object::Ptr getDefaultCheckFileInfoPayload(const Poco::URI& uri)
     {
-        const Poco::URI uriReq(request.getURI());
-
         Poco::JSON::Object::Ptr fileInfo = new Poco::JSON::Object();
-        fileInfo->set("BaseFileName", getFilename(uriReq));
+        fileInfo->set("BaseFileName", getFilename(uri));
         fileInfo->set("Size", getFileContent().size());
         fileInfo->set("Version", "1.0");
-        fileInfo->set("OwnerId", "test");
-        fileInfo->set("UserId", "test");
-        fileInfo->set("UserFriendlyName", "test");
+        fileInfo->set("OwnerId", "tuser");
+        fileInfo->set("UserId", "tuser");
+        fileInfo->set("UserFriendlyName", "Test User");
         fileInfo->set("UserCanWrite", "true");
         fileInfo->set("PostMessageOrigin", "localhost");
         fileInfo->set("LastModifiedTime",
                       Util::getIso8601FracformatTime(getFileLastModifiedTime()));
         fileInfo->set("EnableOwnerTermination", "true");
         fileInfo->set("SupportsLocks", "false");
+
+        return fileInfo;
+    }
+
+    /// Returns the default CheckFileInfo json.
+    Poco::JSON::Object::Ptr getDefaultCheckFileInfoPayload(const std::string& uri)
+    {
+        return getDefaultCheckFileInfoPayload(Poco::URI(uri));
+    }
+
+    /// Handles WOPI CheckFileInfo requests.
+    virtual bool handleCheckFileInfoRequest(const Poco::Net::HTTPRequest& request,
+                                            std::shared_ptr<StreamSocket>& socket)
+    {
+        Poco::JSON::Object::Ptr fileInfo = getDefaultCheckFileInfoPayload(request.getURI());
         configCheckFileInfo(fileInfo);
 
         std::ostringstream jsonStream;


### PR DESCRIPTION
- wsd: test: refactor the default CheckFileInfo payload
- wsd: test: reuse getDefaultCheckFileInfoPayload
- wsd: test: reduce manual http header creation
- wsd: test: use sendAndShutdown
- wsd: test: refactor assertGetFileRequest into the handler
- wsd: test: refactor assertCheckFileInfoRequest into the handler
- wsd: test: use configCheckFileInfo instead of handleHttpRequest
- wsd: test: minor cleanup of UnitWOPIWatermark
- wsd: test: correct message example in comment
