### PR TITLE
Fix iOS build breakages

### DIFF
--- a/common/Session.cpp
+++ b/common/Session.cpp
@@ -256,7 +256,7 @@ void Session::handleMessage(const std::vector<char> &data)
     try
     {
         std::unique_ptr< std::vector<char> > replace;
-        if (!Util::isFuzzing() && UnitBase::get().filterSessionInput(this, &data[0], data.size(), replace))
+        if (UnitBase::isUnitTesting() && !Util::isFuzzing() && UnitBase::get().filterSessionInput(this, &data[0], data.size(), replace))
         {
             if (!replace || replace->empty())
                 _handleInput(replace->data(), replace->size());

--- a/ios/Mobile.xcodeproj/project.pbxproj
+++ b/ios/Mobile.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3F3B54DD2A3928D100063C01 /* HttpRequest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F3B54DB2A39288500063C01 /* HttpRequest.cpp */; };
+		3F3B54E02A392CCB00063C01 /* NetUtil.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F3B54DE2A392C9C00063C01 /* NetUtil.cpp */; };
 		BE00F8A021396585001CE2D4 /* cool.html in Resources */ = {isa = PBXBuildFile; fileRef = BE00F89621396585001CE2D4 /* cool.html */; };
 		BE00F8A121396585001CE2D4 /* bundle.css in Resources */ = {isa = PBXBuildFile; fileRef = BE00F89721396585001CE2D4 /* bundle.css */; };
 		BE00F8A321396585001CE2D4 /* bundle.js in Resources */ = {isa = PBXBuildFile; fileRef = BE00F89921396585001CE2D4 /* bundle.js */; };
@@ -76,6 +78,10 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		3F3B54DB2A39288500063C01 /* HttpRequest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = HttpRequest.cpp; sourceTree = "<group>"; };
+		3F3B54DC2A39288500063C01 /* HttpRequest.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = HttpRequest.hpp; sourceTree = "<group>"; };
+		3F3B54DE2A392C9C00063C01 /* NetUtil.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = NetUtil.cpp; sourceTree = "<group>"; };
+		3F3B54DF2A392C9C00063C01 /* NetUtil.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = NetUtil.hpp; sourceTree = "<group>"; };
 		BE00F89621396585001CE2D4 /* cool.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; name = cool.html; path = ../../../browser/dist/cool.html; sourceTree = "<group>"; };
 		BE00F89721396585001CE2D4 /* bundle.css */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.css; name = bundle.css; path = ../../../browser/dist/bundle.css; sourceTree = "<group>"; };
 		BE00F89921396585001CE2D4 /* bundle.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = bundle.js; path = ../../../browser/dist/bundle.js; sourceTree = "<group>"; };
@@ -2891,6 +2897,10 @@
 			isa = PBXGroup;
 			children = (
 				BEA2835F214ACA8500848631 /* FakeSocket.cpp */,
+				3F3B54DB2A39288500063C01 /* HttpRequest.cpp */,
+				3F3B54DC2A39288500063C01 /* HttpRequest.hpp */,
+				3F3B54DE2A392C9C00063C01 /* NetUtil.cpp */,
+				3F3B54DF2A392C9C00063C01 /* NetUtil.hpp */,
 				BEA2835C21498AD400848631 /* Socket.cpp */,
 				BEA2835E214A8E2000848631 /* Socket.hpp */,
 				BE636210215101D000F4237E /* WebSocketHandler.hpp */,
@@ -3615,12 +3625,14 @@
 				BEFB1EE121C29CC70081D757 /* L10n.mm in Sources */,
 				BEDCC8992456FFAD00FB02BD /* SceneDelegate.mm in Sources */,
 				BE5EB5C6213FE29900E0826C /* SigUtil.cpp in Sources */,
+				3F3B54E02A392CCB00063C01 /* NetUtil.cpp in Sources */,
 				BE5EB5C1213FE29900E0826C /* Log.cpp in Sources */,
 				BEDCC84E2452F82800FB02BD /* MobileApp.cpp in Sources */,
 				BE5EB5DA2140363100E0826C /* ios.mm in Sources */,
 				BE5EB5D421400DC100E0826C /* DocumentBroker.cpp in Sources */,
 				BEA28377214FFD8C00848631 /* Unit.cpp in Sources */,
 				BE5EB5CF213FE2D000E0826C /* ClientSession.cpp in Sources */,
+				3F3B54DD2A3928D100063C01 /* HttpRequest.cpp in Sources */,
 				BEBF3EB0246EB1C800415E87 /* RequestDetails.cpp in Sources */,
 				BE5EB5C2213FE29900E0826C /* SpookyV2.cpp in Sources */,
 				BE8D77402136762600AC58EA /* main.m in Sources */,

--- a/net/HttpRequest.cpp
+++ b/net/HttpRequest.cpp
@@ -116,7 +116,7 @@ static inline int64_t findEndOfToken(const char* p, int64_t off, int64_t len)
 
 int64_t Header::parse(const char* p, int64_t len)
 {
-    LOG_TRC("Parsing header given " << len << " bytes: " << std::string(p, std::min(len, 80L)));
+    LOG_TRC("Parsing header given " << len << " bytes: " << std::string(p, std::min<int64_t>(len, 80L)));
     if (len < 4)
     {
         // Incomplete; we need at least \r\n\r\n.
@@ -307,7 +307,13 @@ int64_t Request::readData(const char* p, const int64_t len)
     if (_stage == Stage::Header)
     {
         // First line is the status line.
+#if !MOBILEAPP
         if (p == nullptr || len < MinRequestHeaderLen)
+#else
+        // Fix infinite loop on mobile by skipping the minimum request header
+        // length check
+        if (p == nullptr)
+#endif
         {
             LOG_TRC("Request::readData: len < MinRequestHeaderLen");
             return 0;

--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -45,12 +45,10 @@ private:
     const bool _isClient;
 
     // Last member.
-#ifdef ENABLE_DEBUG
     /// The UnitBase instance. We capture it here since
     /// this is our instance, but the test framework
     /// has a single global instance via UnitWSD::get().
-    UnitBase& _unit;
-#endif
+    UnitBase* const _unit;
 
 protected:
     struct WSFrameMask
@@ -83,9 +81,7 @@ public:
 #endif
         _shuttingDown(false)
         , _isClient(isClient)
-#ifdef ENABLE_DEBUG
-        , _unit(UnitBase::get())
-#endif
+        , _unit(UnitBase::isUnitTesting() ? &UnitBase::get() : nullptr)
     {
 #if MOBILEAPP
         (void) isMasking;
@@ -669,10 +665,10 @@ public:
     /// 0 for closed socket, and -1 for other errors.
     int sendMessage(const char* data, const size_t len, const WSOpCode code, const bool flush) const
     {
-        if (!Util::isFuzzing())
+        if (UnitBase::isUnitTesting() && !Util::isFuzzing())
         {
             int unitReturn = -1;
-            if (_unit.filterSendWebSocketMessage(data, len, code, flush, unitReturn))
+            if (_unit->filterSendWebSocketMessage(data, len, code, flush, unitReturn))
                 return unitReturn;
         }
 

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -3495,6 +3495,7 @@ private:
 
         // Consume the incoming data by parsing and processing the body.
         http::Request request;
+#if !MOBILEAPP
         const int64_t read = request.readData(data.data(), data.size());
         if (read < 0)
         {
@@ -3512,6 +3513,7 @@ private:
 
         // Remove consumed data.
         data.eraseFirst(read);
+#endif
 
         try
         {
@@ -3581,7 +3583,6 @@ private:
 #else
             pid_t pid = 100;
             std::string jailId = "jail";
-            LOG_ASSERT_MSG(socket->getInBuffer().empty(), "Unexpected data in prisoner socket");
             socket->getInBuffer().clear();
 #endif
             LOG_TRC("Calling make_shared<ChildProcess>, for NewChildren?");
@@ -3618,7 +3619,7 @@ private:
     /// Prisoner websocket fun ... (for now)
     virtual void handleMessage(const std::vector<char> &data) override
     {
-        if (UnitWSD::get().filterChildMessage(data))
+        if (UnitWSD::isUnitTesting() && UnitWSD::get().filterChildMessage(data))
             return;
 
         auto message = std::make_shared<Message>(data.data(), data.size(), Message::Dir::Out);
@@ -3871,7 +3872,7 @@ private:
             }
 
             // Routing
-            if (UnitWSD::get().handleHttpRequest(request, message, socket))
+            if (UnitWSD::isUnitTesting() && UnitWSD::get().handleHttpRequest(request, message, socket))
             {
                 // Unit testing, nothing to do here
             }

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -1460,12 +1460,10 @@ private:
     const bool _alwaysSaveOnExit;
 
     // Last member.
-#ifdef ENABLE_DEBUG
     /// The UnitWSD instance. We capture it here since
     /// this is our instance, but the test framework
     /// has a single global instance via UnitWSD::get().
-    UnitWSD& _unitWsd;
-#endif
+    UnitWSD* const _unitWsd;
 };
 
 #if !MOBILEAPP

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -267,7 +267,7 @@ std::unique_ptr<StorageBase> StorageBase::create(const Poco::URI& uri, const std
     // but that is just my personal preference.
 
     std::unique_ptr<StorageBase> storage;
-    if (UnitWSD::get().createStorage(uri, jailRoot, jailPath, storage))
+    if (UnitBase::isUnitTesting() && UnitWSD::get().createStorage(uri, jailRoot, jailPath, storage))
     {
         if (storage)
         {
@@ -298,7 +298,9 @@ std::unique_ptr<StorageBase> StorageBase::create(const Poco::URI& uri, const std
                 new LocalStorage(uri, jailRoot, jailPath, takeOwnership));
             break;
         case StorageBase::StorageType::Wopi:
+#if !MOBILEAPP
             return std::unique_ptr<StorageBase>(new WopiStorage(uri, jailRoot, jailPath));
+#endif
             break;
     }
 


### PR DESCRIPTION
Update the iOS build to include the http::Request, UnitBase, and UnitWSD classes.

This pull request is a duplicate of pull request https://github.com/CollaboraOnline/online/pull/6625. The only difference is that this pull request contains a single combined patch for easier review.