### PR TITLE
impress: mark multiple slides as hidden or show

### DIFF
--- a/browser/src/control/Control.PartsPreview.js
+++ b/browser/src/control/Control.PartsPreview.js
@@ -279,7 +279,7 @@ L.Control.PartsPreview = L.Control.extend({
 						callback: function(key, options) {
 							var part = that._findClickedPart(options.$trigger[0].parentNode);
 							if (part !== null) {
-								that._map.showSlide(parseInt(part) - 1);
+								that._map.showSlide();
 							}
 						},
 						visible: function(key, options) {
@@ -292,7 +292,7 @@ L.Control.PartsPreview = L.Control.extend({
 						callback: function(key, options) {
 							var part = that._findClickedPart(options.$trigger[0].parentNode);
 							if (part !== null) {
-								that._map.hideSlide(parseInt(part) - 1);
+								that._map.hideSlide();
 							}
 						},
 						visible: function(key, options) {

--- a/browser/src/control/Parts.js
+++ b/browser/src/control/Parts.js
@@ -445,20 +445,24 @@ L.Map.include({
 		}
 	},
 
-	hideSlide: function(slideNum) {
-		if (slideNum === undefined)
-			slideNum = this.getCurrentPartNumber();
-		L.DomUtil.addClass(this._docLayer._preview._previewTiles[slideNum], 'hidden-slide');
-		this._docLayer._hiddenSlides.add(slideNum);
+	hideSlide: function() {
+		for (var index = 0; index < this._docLayer._selectedParts.length; index++) {
+			var id = this._docLayer._selectedParts[index];
+			L.DomUtil.addClass(this._docLayer._preview._previewTiles[id], 'hidden-slide');
+			this._docLayer._hiddenSlides.add(id);
+		}
+
 		app.socket.sendMessage('uno .uno:HideSlide');
 		this.fire('toggleslidehide');
 	},
 
-	showSlide: function(slideNum) {
-		if (slideNum === undefined)
-			slideNum = this.getCurrentPartNumber();
-		L.DomUtil.removeClass(this._docLayer._preview._previewTiles[slideNum], 'hidden-slide');
-		this._docLayer._hiddenSlides.delete(slideNum);
+	showSlide: function() {
+		for (var index = 0; index < this._docLayer._selectedParts.length; index++) {
+			var id = this._docLayer._selectedParts[index];
+			L.DomUtil.removeClass(this._docLayer._preview._previewTiles[id], 'hidden-slide');
+			this._docLayer._hiddenSlides.delete(id);
+		}
+
 		app.socket.sendMessage('uno .uno:ShowSlide');
 		this.fire('toggleslidehide');
 	},


### PR DESCRIPTION
when user hide or show multiple selected slide,
slides were actually hidden or shown but previews did not reflect that, only first selected preview was marked as performed action

Change-Id: Ie0c2eea8442feb0a4340551a63d8d39932adad3c

* Target version: master 

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

