### PR TITLE
configure option to disable building unit tests

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -373,6 +373,10 @@ AC_ARG_ENABLE([cypress],
             AS_HELP_STRING([--enable-cypress],
                            [Enable cypress tests.]))
 
+AC_ARG_ENABLE([tests],
+            AS_HELP_STRING([--disable-tests],
+                           [Do not build and run unit tests.]))
+
 AC_ARG_WITH([help-url],
             AS_HELP_STRING([--with-help-url=<url>],
                 [Set the base URL of the online help. Default is https://help.collaboraoffice.com/help.html?])
@@ -1482,6 +1486,15 @@ else
    ENABLE_CYPRESS=false
 fi
 AM_CONDITIONAL([ENABLE_CYPRESS], [$ENABLE_CYPRESS])
+
+ENABLE_TESTS=true
+if test "$enable_tests" = "no"; then
+    ENABLE_TESTS=false
+else
+    ENABLE_TESTS=true
+fi
+AM_CONDITIONAL([ENABLE_TESTS], [$ENABLE_TESTS])
+
 
 AC_MSG_CHECKING([for URL of online help])
 if test -n "$with_help_url" -a "$with_help_url" != "no"; then

--- a/coolwsd.spec.in
+++ b/coolwsd.spec.in
@@ -30,6 +30,7 @@ Obsoletes: loolwsd collaboraoffice-dict-br collaboraoffice-dict-et collaboraoffi
 	--with-lokit-path=bundled/include \
 	--with-lo-path=/opt/collaboraoffice \
 	--disable-setcap \
+	--disable-tests \
 %if 0%{?config_options:1}
 	%{config_options}
 %endif

--- a/debian/rules
+++ b/debian/rules
@@ -5,7 +5,7 @@ DPKG_EXPORT_BUILDFLAGS = 1
 
 include /usr/share/dpkg/default.mk
 
-CONFFLAGS = --enable-silent-rules --prefix=/usr --localstatedir=/var --sysconfdir=/etc --with-lokit-path=`pwd`/bundled/include --disable-setcap $(CONFIG_OPTIONS)
+CONFFLAGS = --enable-silent-rules --prefix=/usr --localstatedir=/var --sysconfdir=/etc --with-lokit-path=`pwd`/bundled/include --disable-setcap --disable-tests $(CONFIG_OPTIONS)
 
 # main packaging script based on dh7 syntax
 %:

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,3 +1,5 @@
+if ENABLE_TESTS
+
 # Cap threadpools to 4 threads.
 export MAX_CONCURRENCY=4
 AUTOMAKE_OPTION = serial-tests
@@ -335,3 +337,4 @@ all-local: unittest
 	@$(CLEANUP_COMMAND)
 
 .PRECIOUS: $(TEST_LOGS)
+endif


### PR DESCRIPTION
rational: building for release takes a lot of time and we neither package, nor run (most of) these unit tests when we make packages.
CI runs all of these tests before merging PRs, so risk is low, if we do not run the few build-time unit tests when we package.

make -j12
--enable-tests (default): 3m 18s
--disable-test: 1m 9s
3x faster...


Change-Id: I4edd98af55748432e30c65c4c910e72c0221272a
