### PR TITLE
Spelling dialog icon not found

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2218,6 +2218,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		}
 
 		var iconURLAliases = {
+			'addmb-menu': 'ok',
 			'closetablet': 'view',
 			'defineprintarea': 'menuprintranges',
 			'deleteprintarea': 'delete',


### PR DESCRIPTION
addmb-menu corresponding to add to dictionary seems to be a dropdown
that is not enabled in online. And we do hide the main component by
making use of hidden class. Nevertheless, and even though that is
never visible, we keep getting the file not found in the console.
  - better to add an generic alias for that file so to avoid that error

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ic9ad2d9cb07fa1f496166d3653bbf81de3f310d0
