### PR TITLE
JSDialog: Add missing padding for ui-text labels

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -555,6 +555,12 @@ input[type='checkbox']:checked.autofilter, .jsdialog input[type='checkbox']:chec
 	color: var(--color-text-lighter);
 }
 
+/* text label */
+
+.jsdialog.ui-text {
+	padding-inline-start: 8px;
+}
+
 /* spinfield */
 
 .spinfieldcontainer input {


### PR DESCRIPTION
This way they:
- Align to checkbox
- And have additional padding in places such as Format > Paragraph
Line spacing 's dropdown is glued to "of" label

This also fixes one task from https://github.com/CollaboraOnline/online/issues/6647

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I53e66602dffbc96db39449cbda53d433a9dd12d8
