### PR TITLE
Fix unit-httpws by allowing jsdialog message

### DIFF
--- a/test/httpwstest.cpp
+++ b/test/httpwstest.cpp
@@ -287,7 +287,8 @@ void HTTPWSTest::testInactiveClient()
                                             token == "window:" ||
                                             token == "rulerupdate:" ||
                                             token == "tableselected:" ||
-                                            token == "colorpalettes:");
+                                            token == "colorpalettes:" ||
+                                            token == "jsdialog:");
 
                     // End when we get state changed.
                     return (token != "statechanged:");


### PR DESCRIPTION
test was failing because we received some initial sidebar content
