### PR TITLE
fix asan build test

### DIFF
--- a/kit/Delta.hpp
+++ b/kit/Delta.hpp
@@ -65,10 +65,12 @@ class DeltaGenerator {
     // fast - and deltas take lots of size off.
     static const int compressionLevel = -3;
 
+    static constexpr size_t _rleMaskUnits = 256 / 64;
+
     /// Bitmap row with a CRC for quick vertical shift detection
     class DeltaBitmapRow final {
         size_t _rleSize;
-        uint64_t _rleMask[256/64];
+        uint64_t _rleMask[_rleMaskUnits];
         uint32_t *_rleData;
     public:
         class PixIterator final
@@ -93,7 +95,8 @@ class DeltaGenerator {
             void next()
             {
                 _x++;
-                if (!(_row._rleMask[_x>>6] & (uint64_t(1) << (_x & 63))))
+                size_t index = _x >> 6;
+                if (index < _rleMaskUnits && !(_row._rleMask[index] & (uint64_t(1) << (_x & 63))))
                     _rlePtr++;
             }
         };


### PR DESCRIPTION
../kit/Delta.hpp:96:23: runtime error: index 4 out of bounds for type 'const uint64_t[4]' (aka 'const unsigned long[4]')
    #0 0x558e8e0f800b in DeltaGenerator::DeltaBitmapRow::PixIterator::next() libreoffice/online-san/test/../kit/Delta.hpp:96:23
    #1 0x558e8e0b8304 in DeltaTests::testRleComplex() libreoffice/online-san/test/DeltaTests.cpp:317:16


Change-Id: I01da1e99b5d224411344659dce8bd2f29e7d74b0


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

