### PR TITLE
Navigator: fix scroll position change

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -45,6 +45,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 	_colorLastSelection: {},
 	_decimal: '.',
 	_minusSign: '-',
+	_naviLastScrollPos: 0,
 
 	// Responses are included in a parent container. While buttons are created, responses need to be checked.
 	// So we save the button ids and responses to check them later.

--- a/browser/src/control/jsdialog/Widget.TreeView.js
+++ b/browser/src/control/jsdialog/Widget.TreeView.js
@@ -475,6 +475,7 @@ function _treelistboxControl(parentContainer, data, builder) {
 	}
 
 	if (!data.entries || data.entries.length === 0) {
+		// contentbox and tree can never be empty, 1 page or 1 sheet always exists
 		if (data.id === 'contenttree') {
 			var tr = L.DomUtil.create('tr', builder.options.cssClass + ' ui-listview-entry', tbody);
 			tr.setAttribute('role', 'row');
@@ -526,8 +527,17 @@ function _treelistboxControl(parentContainer, data, builder) {
 		firstSelected = tbody.querySelector('.ui-treeview-entry.selected');
 	}
 
+    if (data.id === 'contenttree' || data.id === 'contentbox' || data.id === 'tree') {
+        table.addEventListener('scroll', function onEvent() {
+            builder._naviLastScrollPos = table.scrollTop;
+        });
+	}
+
 	if (firstSelected) {
 		var observer = new IntersectionObserver(function (entries, observer) {
+			if (data.id === 'contenttree' || data.id === 'contentbox' || data.id === 'tree') {
+				table.scrollTop = builder._naviLastScrollPos;
+			}
 			var offsetTop;
 			if (isHeaderListBox)
 				offsetTop = firstSelected.offsetTop;


### PR DESCRIPTION
Save the scroll position of contenttree (whenever its scroll changed), and use its last value as an initial scroll position when the tree is reconstructed.

There is still a glitch, for a moment the tree displayed with a default scroll position (0 = scrolled to top) when the tree reconstructed before its scroll resetted, but after that, the scroll position will be good.


Change-Id: Ib790d50ee13f6fc697ae1481dcb695416c2a2c3f


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

