### PR TITLE
the tile is assumed to be 256 in width

### DIFF
--- a/kit/Delta.hpp
+++ b/kit/Delta.hpp
@@ -95,8 +95,8 @@ class DeltaGenerator {
             void next()
             {
                 _x++;
-                size_t index = _x >> 6;
-                if (index < _rleMaskUnits && !(_row._rleMask[index] & (uint64_t(1) << (_x & 63))))
+                size_t rleMaskIndex = _x >> 6;
+                if (rleMaskIndex >= _rleMaskUnits || !(_row._rleMask[rleMaskIndex] & (uint64_t(1) << (_x & 63))))
                     _rlePtr++;
             }
         };
@@ -125,8 +125,9 @@ class DeltaGenerator {
             _rleMask[0] = 1;
             for (unsigned int x = 1; x < width; ++x)
             {
-                if (from[x] == scratch[outp]) // set for run
-                    _rleMask[x>>6] |= uint64_t(1) << (x & 63);
+                size_t rleMaskIndex = x >> 6;
+                if (rleMaskIndex < _rleMaskUnits && from[x] == scratch[outp]) // set for run
+                    _rleMask[rleMaskIndex] |= uint64_t(1) << (x & 63);
                 else
                     scratch[++outp] = from[x];
             }


### PR DESCRIPTION
but as seen with unit-tiletest that is not always the case

==24170==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x63400001e808 at pc 0x558a6f505973 bp 0x7ffc0670e7d0 sp 0x7ffc0670e7c8 READ of size 8 at 0x63400001e808 thread T0 (kitbroker_002)
    #0 0x558a6f505972 in DeltaGenerator::DeltaBitmapRow::initRow(unsigned int const*, unsigned int) Delta.hpp:129:36
    #1 0x558a6f4fc318 in DeltaGenerator::DeltaData::DeltaData(unsigned int, unsigned char*, unsigned long, unsigned long, int, int, TileLocation const&, int, int) Delta.hpp:233:21
    #2 0x558a6f4f8a22 in DeltaGenerator::createDelta(unsigned char*, unsigned long, unsigned long, int, int, int, int, TileLocation const&, std::vector<char, std::allocator<char> >&, unsigned int, bool) Delta.hpp:574:17
    #3 0x558a6f4f2a35 in DeltaGenerator::compressOrDelta(unsigned char*, unsigned long, unsigned long, int, int, int, int, TileLocation const&, std::vector<char, std::allocator<char> >&, unsigned int, bool, bool, LibreOfficeKitTileMode) Delta.hpp:669:14
    #4 0x558a6f41f300 in RenderTiles::doRender(std::shared_ptr<lok::Document>, DeltaGenerator&, TileCombined&, ThreadPool&, bool, std::function<void (unsigned char*, int, int, unsigned long, unsigned long, int, int, LibreOfficeKitTileMode)> const&, std::function<void (char const*, unsigned long)> const&, unsigned int, int, bool)::$_0::operator()() const /home/vmiklos/git/libreoffice/online-san/./common/RenderTiles.hpp:304:38

so just use the rle cache for the first 256 pixels


Change-Id: I8d34ea53bd20b69184e100b56017dfc0a904eaab


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

