### PR TITLE
jsdialog: fixed dialog content being cut off

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -41,6 +41,11 @@
 	min-width: 400px;
 }
 
+img.ui-drawing-area {
+	width: -webkit-fill-available;
+	width: -moz-available;
+}
+
 .jsdialog.one-child-popup {
 	border: 0;
 	margin: 0 !important;


### PR DESCRIPTION
i.e: theme dialog(format->theme)


Change-Id: I9a09d52cd2c0d95cfae18ae12995761985d8111d


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

