### PR TITLE
Limit memory usage of internal log storage.

### DIFF
--- a/browser/src/core/Log.js
+++ b/browser/src/core/Log.js
@@ -11,6 +11,14 @@ L.Log = {
 		if (!this._logs) {
 			this._logs = [];
 		}
+		// Limit memory usage of log by only keeping the latest entries
+		var maxEntries = 100;
+		while (this._logs.length > maxEntries)
+			this._logs.shift();
+		// Limit memory usage of log by limiting length of message
+		var maxMsgLen = 128;
+		if (msg.length > maxMsgLen)
+			msg = msg.substring(0, maxMsgLen);
 		msg = msg.replace(/(\r\n|\n|\r)/gm, ' ');
 		this._logs.push({msg : msg, direction : direction,
 			coords : tileCoords, time : time});


### PR DESCRIPTION
Otherwise it could grow without bound; now limited to 100 entries, each of <128 characters.

Change-Id: I6a1b96a8cb6a67f991c3870f5b724989f65e0e74


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

