### PR TITLE
fix js/useless-assignment-to-local warning

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -6315,9 +6315,8 @@ L.CanvasTileLayer = L.Layer.extend({
 			for (i = 0; i < queue.length; i++) {
 				coords = queue[i];
 				key = this._tileCoordsToKey(coords);
-				tile = this._tiles[key];
-				if (!tile)
-					tile = this.createTile(coords, key);
+				if (!this._tiles[key])
+					this.createTile(coords, key);
 
 				if (!this._tileHasContent(key)) {
 					// request each tile just once in these tilecombines


### PR DESCRIPTION
 tile = this._tiles[key];
 if (!tile)
   tile = this.createTile(coords, key);
   ^^^^
The value assigned to tile here is unused.


Change-Id: Iaabaa6417bcbf385ff2bde139663f8bd2e90db49


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

