### PR TITLE
Avoid crash when pasting image in debug mode

### DIFF
--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -778,11 +778,16 @@ protected:
             size_t offset = Util::isValidUtf8((unsigned char*)data, len);
             if (offset < len)
             {
-                std::string raw(data, len);
-                std::cerr << "attempting to send invalid UTF-8 message '" << raw << "' "
-                          << " error at offset " << std::hex << "0x" << offset << std::dec
-                          << " bytes, string: " << Util::dumpHex(raw) << "\n";
-                assert("invalid utf-8 - check Message::detectType()" && false);
+                static const char *imgModel = "child-000 paste mimetype=image/";
+                static std::regex imgRegex("^child-[0-9a-f]{3} paste mimetype=image/$");
+                bool isImagePaste = std::regex_match(data, data + strlen(imgModel), imgRegex);
+                if (!isImagePaste) {
+                    std::string raw(data, len);
+                    std::cerr << "attempting to send invalid UTF-8 message '" << raw << "' "
+                            << " error at offset " << std::hex << "0x" << offset << std::dec
+                            << " bytes, string: " << Util::dumpHex(raw) << "\n";
+                    assert("invalid utf-8 - check Message::detectType()" && false);
+                }
             }
         }
 #endif


### PR DESCRIPTION
If COOL is running in debug mode ther is a
check that incoming messages are UTF-8.
We skip this tests if the message refers
to an image pasted.


Change-Id: I4f7e4a647deb22ec2a032d4d6347d910184c0701


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

