### PR TITLE
Add new "download as" PDF option

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2384,6 +2384,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			// The fix for issues #6103 and #6104 changes the name of these
 			// icons so map the new names to the old names.
 			'downloadas-pdf': 'exportpdf',
+			'downloadas-direct-pdf': 'exportdirectpdf',
 			'downloadas-epub': 'exportepub',
 		};
 		if (iconURLAliases[cleanName]) {

--- a/browser/src/control/Control.NotebookbarBuilder.js
+++ b/browser/src/control/Control.NotebookbarBuilder.js
@@ -568,8 +568,13 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 					'command': !window.ThisIsAMobileApp ? 'exportepub' : 'downloadas-epub'
 				},
 				{
-					'id': !window.ThisIsAMobileApp ? 'exportpdf' : 'downloadas-pdf',
+					'id': !window.ThisIsAMobileApp ? 'exportdirectpdf' : 'downloadas-direct-pdf',
 					'text': _('PDF Document (.pdf)'),
+					'command': !window.ThisIsAMobileApp ? 'exportdirectpdf' : 'downloadas-direct-pdf'
+				},
+				{
+					'id': !window.ThisIsAMobileApp ? 'exportpdf' : 'downloadas-pdf',
+					'text': _('PDF Document (.pdf) as...'),
 					'command': !window.ThisIsAMobileApp ? 'exportpdf' : 'downloadas-pdf'
 				}
 			];

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -370,7 +370,8 @@ L.Map.include({
 		if (this.isPermissionEditForComments()) {
 			allowedCommands.push('.uno:InsertAnnotation','.uno:DeleteCommentThread', '.uno:DeleteAnnotation', '.uno:DeleteNote',
 				'.uno:DeleteComment', '.uno:ReplyComment', '.uno:ReplyToAnnotation', '.uno:ResolveComment',
-				'.uno:ResolveCommentThread', '.uno:ResolveComment', '.uno:EditAnnotation', '.uno:ExportToEPUB', '.uno:ExportToPDF');
+				'.uno:ResolveCommentThread', '.uno:ResolveComment', '.uno:EditAnnotation', '.uno:ExportToEPUB', '.uno:ExportToPDF',
+				'.uno:ExportDirectToPDF');
 		}
 
 		for (var i in allowedCommands) {
@@ -950,6 +951,16 @@ L.Map.include({
 		case 'exportpdf':
 			{
 				this.sendUnoCommand('.uno:ExportToPDF', {
+					'SynchronMode': {
+						'type': 'boolean',
+						'value': false
+					}
+				});
+			}
+			break;
+		case 'exportdirectpdf':
+			{
+				this.sendUnoCommand('.uno:ExportDirectToPDF', {
 					'SynchronMode': {
 						'type': 'boolean',
 						'value': false


### PR DESCRIPTION
PDF export was avaliable only with a modal "pdf options" window.
It seems a little complicated for some users who'd like to
simply press the button and receive pdf.
Added a new menu item to download pdf directly.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Signed-off-by: luigiiucci <luigi.iucci@collabora.com>
Change-Id: Id824179adeac3b516e58c85a9e2d01838f81c892
