### PR TITLE
Dialog: don't ignore label's padding (ui-text)

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -557,7 +557,7 @@ input[type='checkbox']:checked.autofilter, .jsdialog input[type='checkbox']:chec
 
 /* text label */
 
-.jsdialog.ui-text {
+.ui-dialog-content .jsdialog.ui-text {
 	padding-inline-start: 8px;
 }
 


### PR DESCRIPTION
Before this 8a0c8c44a710b1043b678f2049e480becd18f0a5 was not being
applied furthermore better to specifically set this to only affect
labels within dialog content (since jsdialog class is also in many
other places such as sidebar and widgets)

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ic1cb825d6c70858a4c49123243866eaf0a6a8e50
