### PR TITLE
wsd: random device mounting

### DIFF
--- a/common/JailUtil.cpp
+++ b/common/JailUtil.cpp
@@ -328,9 +328,13 @@ bool createRandomDeviceInJail(const std::string& root, const std::string& device
 
     if (isBindMountingEnabled())
     {
-        LOG_DBG("Failed to create random device via mknod("
-                << absPath << "). Mount must not use nodev flag. Will try bind-mounting instead: "
-                << strerror(mknodErrno));
+        static bool warned = false;
+        if (!warned)
+        {
+            warned = true;
+            LOG_WRN("Performance issue: nodev mount permission or mknod fails. Have to bind mount "
+                    "random devices");
+        }
 
         Poco::File(absPath).createFile();
         if (coolmount("-b", devicePath, absPath))


### PR DESCRIPTION
We now warn when we fail to use mknod
to create the random devices and have
stricter requirements to mounting
character-devices. Specifically,
we explicitly only allow mounting
the random devices.

Change-Id: Ib0dc300dedc40942ea52426af2b267f6a81fbeb8
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
