### PR TITLE
Insert new slide to specific position

### DIFF
--- a/browser/css/partsPreviewControl.css
+++ b/browser/css/partsPreviewControl.css
@@ -16,7 +16,7 @@
 	max-width: 190px;
 	white-space: nowrap;
 	text-align: center;
-	margin: 1em 0;
+	padding: 1em 0;
 }
 
 .preview-helper {

--- a/browser/src/control/Parts.js
+++ b/browser/src/control/Parts.js
@@ -336,7 +336,13 @@ L.Map.include({
 		}
 
 		if (this.isPresentationOrDrawing()) {
-			app.socket.sendMessage('uno .uno:InsertPage');
+			if (nPos === undefined) {
+				app.socket.sendMessage('uno .uno:InsertPage');
+			}
+			else {
+				var argument = {InsertPos: {type: 'int16', value: nPos}};
+				app.socket.sendMessage('uno .uno:InsertPage ' + JSON.stringify(argument));
+			}
 		}
 		else if (this.getDocType() === 'spreadsheet') {
 			this._docLayer._sheetSwitch.updateOnSheetInsertion(nPos);


### PR DESCRIPTION
When we insert a new slide via context menu of the slidesorter, new slide should be inserted on pointer position instead of end of the last selected slide.


Change-Id: Ie5efb78d6b6ee468cda150cc416cbd2ab536d6dd


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

