### PR TITLE
Mobile: Add "Read-only" label ONLY when it's not possible to edit

### DIFF
--- a/browser/src/control/Control.MobileTopBar.js
+++ b/browser/src/control/Control.MobileTopBar.js
@@ -216,10 +216,12 @@ L.Control.MobileTopBar = L.Control.extend({
 					toolbar.disable(id);
 				});
 				toolbar.enable('comment_wizard');
-				toolbar.show('PermissionMode');
-				toolbar.show('after-PermissionMode');
-				$('#tb_actionbar_item_before-PermissionMode').width('50%');
-				$('#tb_actionbar_item_after-PermissionMode').width('50%');
+				if ($('#mobile-edit-button').is(':hidden')) {
+					toolbar.show('PermissionMode');
+					toolbar.show('after-PermissionMode');
+					$('#tb_actionbar_item_before-PermissionMode').width('50%');
+					$('#tb_actionbar_item_after-PermissionMode').width('50%');
+				}
 			}
 		}
 	},


### PR DESCRIPTION
The new label added in a13f33b777b0ecc85752f832cd475736206f241e might
be a bit confusing and not necessary if the edit button (pencil) is
already present.

Better to:
* Have only the edit button (that should already be enough to signify
that the user is currently in a read-only transient mode)
* Add Read-only label for the cases were the user is opening a
read-only file (without permission to edit and thus the edit button is
absent)

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I1fc5ca821bfd9feb75f411d2c3260a43d54e16cd
