### PR TITLE
fix missing icon 'Open in local editor' in compact mode

### DIFF
--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -68,6 +68,7 @@ L.Control.UIManager = L.Control.extend({
 			|| forceCompact === false;
 	},
 
+
 	initializeBasicUI: function() {
 		var enableNotebookbar = this.shouldUseNotebookbarMode();
 		var that = this;
@@ -417,7 +418,7 @@ L.Control.UIManager = L.Control.extend({
 				if (style.length == 0)
 					$('html > head').append('<style/>');
 				$('html > head > style').append('.w2ui-icon.' + encodeURIComponent(button.id) +
-					'{background: url("' + encodeURIComponent(button.imgurl) + '") no-repeat center !important; }');
+					'{background: url("' + encodeURI(button.imgurl) + '") no-repeat center !important; }');
 
 				// Position: Either specified by the caller, or defaulting to first position (before save)
 				var insertBefore = button.insertBefore || 'save';


### PR DESCRIPTION
- use encodeUri instead of encodeURIComponent because
 it preserves those characters that are part of the URI
 syntax

Signed-off-by: Rash419 <rashesh.padia@collabora.com>
Change-Id: Ibde1b9ad40424b9bd2ce065cddfe2e83b23271c5
