### PR TITLE
Tablet: Add "Read-only" label only for users with no writing access

### DIFF
--- a/browser/src/control/Control.StatusBar.js
+++ b/browser/src/control/Control.StatusBar.js
@@ -283,6 +283,7 @@ L.Control.StatusBar = L.Control.extend({
 		var statusbar = w2ui['actionbar'];
 		var docType = this.map.getDocType();
 		var isReadOnly = this.map.isReadOnlyMode();
+		var canUserWrite = this.map.canUserWrite();
 
 		switch (docType) {
 		case 'spreadsheet':
@@ -335,7 +336,7 @@ L.Control.StatusBar = L.Control.extend({
 					{type: 'break', id: 'break9', mobile: false},
 					{
 						type: 'html', id: 'PermissionMode', mobile: false, tablet: true,
-						html: this._getPermissionModeHtml(isReadOnly)
+						html: this._getPermissionModeHtml(isReadOnly, canUserWrite)
 					}
 				]);
 			}
@@ -371,7 +372,7 @@ L.Control.StatusBar = L.Control.extend({
 					{type: 'break', id: 'break8', mobile: false},
 					{
 						type: 'html', id: 'PermissionMode', mobile: false, tablet: true,
-						html: this._getPermissionModeHtml(isReadOnly)
+						html: this._getPermissionModeHtml(isReadOnly, canUserWrite)
 					}
 				]);
 			}
@@ -392,7 +393,7 @@ L.Control.StatusBar = L.Control.extend({
 					{type: 'break', id: 'break8', mobile: false},
 					{
 						type: 'html', id: 'PermissionMode', mobile: false, tablet: true,
-						html: this._getPermissionModeHtml(isReadOnly)
+						html: this._getPermissionModeHtml(isReadOnly, canUserWrite)
 					}
 				]);
 			}
@@ -412,7 +413,7 @@ L.Control.StatusBar = L.Control.extend({
 					{type: 'break', id: 'break8', mobile: false},
 					{
 						type: 'html', id: 'PermissionMode', mobile: false, tablet: true,
-						html: this._getPermissionModeHtml(isReadOnly)
+						html: this._getPermissionModeHtml(isReadOnly, canUserWrite)
 					}
 				]);
 			}
@@ -450,11 +451,16 @@ L.Control.StatusBar = L.Control.extend({
 		this.map._onGotFocus();
 	},
 
-	_getPermissionModeHtml: function(isReadOnly) {
-		return '<div id="PermissionMode" class="cool-font ' +
-			(isReadOnly
-				? ' status-readonly-mode" title="' + _('Permission Mode') + '" style="padding: 5px 5px;"> ' + _('Read-only') + ' </div>'
-				: ' status-edit-mode" title="' + _('Permission Mode') + '" style="padding: 5px 5px;"> ' + _('Edit') + ' </div>');
+	_getPermissionModeHtml: function(isReadOnly, canUserWrite) {
+		var permissionModeDiv = '<div id="PermissionMode" class="cool-font ';
+		if (isReadOnly && !canUserWrite) {
+			permissionModeDiv += ' status-readonly-mode" title="' + _('Permission Mode') + '" style="padding: 5px 5px;"> ' + _('Read-only') + ' </div>';
+		} else if (isReadOnly && canUserWrite) {
+			permissionModeDiv += ' status-readonly-transient-mode" style="display: none;"></div>';
+		} else {
+			permissionModeDiv += ' status-edit-mode" title="' + _('Permission Mode') + '" style="padding: 5px 5px;"> ' + _('Edit') + ' </div>';
+		}
+		return permissionModeDiv;
 	},
 
 	onPermissionChanged: function(event) {
@@ -464,7 +470,7 @@ L.Control.StatusBar = L.Control.extend({
 		} else {
 			$('#toolbar-down').removeClass('readonly');
 		}
-		$('#PermissionMode').parent().html(this._getPermissionModeHtml(isReadOnly));
+		$('#PermissionMode').parent().html(this._getPermissionModeHtml(isReadOnly, this.map.canUserWrite()));
 	},
 
 	onCommandStateChanged: function(e) {


### PR DESCRIPTION
Before this the read-only label was being added to the status bar even
if the user has writing access but is currently in that transient
read-only mode state (pencil icon is visible)

Don't show read-only label for those cases. We already have the pencil
icon/btn that signifies that.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I5295564244977388034c7a7930840cb45dfdd629
