### PR TITLE
jsdialog: get precision for validation also from value

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -406,10 +406,11 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			// we don't want to show error popups due to browser step validation
 			// so be sure all the values will be acceptted, check only precision
 			var step = getPrecision(data.step);
+			var value = data.value ? getPrecision(data.value) : 1;
 			var minStep = getPrecision(data.min);
 			var maxStep = getPrecision(data.max);
 
-			step = Math.min(step, minStep, maxStep);
+			step = Math.min(step, value, minStep, maxStep);
 
 			$(spinfield).attr('step', step);
 		}


### PR DESCRIPTION
when we open Writer -> Format -> Footnote field: Thickness shows an alert about incorrect value. It's caused because step is set to 1 but value is 0.5 as core uses step only for increase/decrease but not for valudation. Fix this annoying error by allowing to use 0.1 step.