### PR TITLE
Disable CalcHiddenColRow by default

### DIFF
--- a/coolkitconfig.xcu.in
+++ b/coolkitconfig.xcu.in
@@ -241,7 +241,7 @@
                 <value>2293980</value>
             </prop>
             <prop oor:name="IsVisible" oor:op="fuse">
-                <value>true</value>
+                <value>false</value>
             </prop>
         </node>
         <node oor:name="CalcTextOverflow">


### PR DESCRIPTION
Change-Id: I717ef1080fe3b9af39ed081eb79355d0e5bd6e4e


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

