### PR TITLE
feat: add helm-repo release ci (with usage of github-pages as helm repo)

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -1,0 +1,38 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - main
+      # legacy support
+      - master
+
+jobs:
+  release:
+    # depending on default permission settings for your org (contents being read-only or read-write for workloads), you will have to add permissions
+    # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.12.1
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.5.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        with:
+          charts_dir: "kubernetes/helm"

--- a/kubernetes/helm/README.md
+++ b/kubernetes/helm/README.md
@@ -34,9 +34,10 @@ How to test this specific setup:
 
         image:
           tag: "latest"
+          pullPolicy: Always
       ```
 
-      Important notes: 
+      Important notes:
       1. If you have multiple host and aliases setup set aliasgroups in my_values.yaml
           ```yaml
           collabora:
@@ -53,7 +54,8 @@ How to test this specific setup:
   5. Install helm-chart using below command (with a new namespace collabora)
 
       ```bash
-      helm install --create-namespace --namespace collabora collabora-online ./kubernetes/helm/collabora-online/ -f my_values.yaml
+      helm repo add collabora https://genofire.github.io/collaboraonline-helm/
+      helm install --create-namespace --namespace collabora collabora-online collabora/collabora-online -f my_values.yaml
       ```
 
   6. Finally spin the collabora-online in kubernetes
@@ -136,7 +138,7 @@ How to test this specific setup:
 
 * To uninstall the helm chart
   ```bash
-  helm uninstall collabora-online -n collabora
+  helm uninstall --namespace collabora collabora-online
   ```
 
 ## Notes:


### PR DESCRIPTION
* Resolves: #5371
* Target version: master 

### Summary
This PR adds an Github-Actions, on every change of the `version:` in `Chart.yaml` it will:
 1. bundle the helmchart to a `.tgz`
 2. add an git-tag / github-release with `<helmchartname>-<version>`:
 3. upload the bundle `.tgz` to the github-release
 4. update the `index.yaml` in branch `gh-pages`:
    - add the new helmchart release with url to the `tgz` on github-release
    - so this index.yaml should be accessible under: https://collaboraonline.github.io/online/index.yaml
 
---
so everybody could use it as an helm-repository like:
```bash
helm repo add collabora https://collaboraonline.github.io/online/
helm install --create-namespace --namespace collabora collabora-online collabora/collabora-online -f my_values.yaml
```

TODO:
 - [ ] create the branch `gh-pages` (an manuelle step on this repo)

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

