### PR TITLE
formulabar: handle Japanese input and fix mobile

### DIFF
--- a/browser/css/device-mobile.css
+++ b/browser/css/device-mobile.css
@@ -250,7 +250,7 @@ textarea.cool-annotation-textarea {
 
 /* Related to toolbar.css */
 @-moz-document url-prefix() {
-	#formulabar #formulaInput, #formulabar #addressInput{
+	#formulabar #addressInput{
 		color: var(--color-main-text);
 		border: 1px solid var(--color-border) !important;
 		border-radius: 0px;
@@ -345,13 +345,6 @@ nav:not(.spreadsheet-color-indicator) ~ #toolbar-wrapper #toolbar-up.w2ui-toolba
 	border-color: 1px solid #808080 !important;
 }
 .w2ui-icon.equal, .w2ui-icon.autosum{width: 38px !important;}
-#formulaInput{
-	border: 1px solid #bbbbbb;
-	border-bottom: none;
-	border-top: none;
-	border-right: none;
-	height: 35px !important;
-}
 
 #calc-inputbar-wrapper {
 	display: block;

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1359,13 +1359,51 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	height: 28px;
 	border: 1px solid var(--color-border);
 	flex-grow: 1;
-	resize: none !important;
-	max-width: unset !important;
-	font-size: calc(var(--default-font-size)*1.2) !important;
-	line-height: 1.2;
-	color: var(--color-main-text);
 	background-color: var(--color-background-lighter);
 	border-radius: var(--border-radius) 0 0 var(--border-radius);
+}
+
+.ui-custom-textarea {
+	overflow: auto;
+	display: grid;
+}
+
+.ui-custom-textarea.focused {
+	border: 1px solid var(--color-primary) !important;
+}
+
+.ui-custom-textarea,
+.ui-custom-textarea-cursor-layer,
+.ui-custom-textarea-text-layer {
+	font-family: monospace;
+	line-height: 1.2;
+	font-size: calc(var(--default-font-size)*1.2) !important;
+	color: var(--color-main-text);
+	overflow-wrap: anywhere;
+}
+
+.ui-custom-textarea-cursor-layer,
+.ui-custom-textarea-text-layer {
+	padding: 4px;
+	grid-column: 1;
+	grid-row: 1;
+	white-space: pre-wrap;
+	text-wrap: wrap;
+}
+
+.ui-custom-textarea-cursor-layer {
+	color: transparent;
+	pointer-events: none;
+}
+
+.ui-custom-textarea.focused .ui-custom-textarea-cursor-layer span.cursor:not(.hidden) {
+	border-left: 1px solid black;
+	margin-left: -1px;
+}
+
+.ui-custom-textarea-cursor-layer span.selection:not(.hidden) {
+	background-color: var(--color-primary-darker);
+	color: var(--color-primary-text);
 }
 
 #sc_input_window.formulabar:focus {

--- a/browser/src/control/Control.FormulaBar.js
+++ b/browser/src/control/Control.FormulaBar.js
@@ -97,7 +97,7 @@ L.Control.FormulaBar = L.Control.extend({
 		if (e.perm === 'edit') {
 			// Enable formula bar
 			$('#addressInput').prop('disabled', false);
-			$('#formulaInput').prop('disabled', false);
+			this.map.formulabar.enable();
 
 			if (toolbar) {
 				formulaBarButtons.forEach(function(id) {
@@ -107,7 +107,7 @@ L.Control.FormulaBar = L.Control.extend({
 		} else {
 			// Disable formula bar
 			$('#addressInput').prop('disabled', true);
-			$('#formulaInput').prop('disabled', true);
+			this.map.formulabar.disable();
 
 			if (toolbar) {
 				formulaBarButtons.forEach(function(id) {
@@ -184,6 +184,8 @@ L.Map.include({
 			// clear reference marks
 			map._docLayer._clearReferences();
 		}, 250);
+
+		map.formulabar.blurField();
 	}
 });
 

--- a/browser/src/control/Control.Toolbar.js
+++ b/browser/src/control/Control.Toolbar.js
@@ -829,9 +829,6 @@ function onInsertBackground() {
 
 function onWopiProps(e) {
 	if (e.DisableCopy) {
-		$('input#formulaInput').bind('copy', function(evt) {
-			evt.preventDefault();
-		});
 		$('input#addressInput').bind('copy', function(evt) {
 			evt.preventDefault();
 		});

--- a/browser/src/layer/marker/A11yTextInput.js
+++ b/browser/src/layer/marker/A11yTextInput.js
@@ -229,6 +229,9 @@ L.A11yTextInput = L.Layer.extend({
 		if (ev.type === 'blur' && this._isComposing) {
 			this._abortComposition(ev);
 		}
+
+		if (ev.type === 'blur' && this._hasFormulaBarFocus())
+			this._map.formulabar.blurField();
 	},
 
 	hasFocus: function() {
@@ -317,10 +320,7 @@ L.A11yTextInput = L.Layer.extend({
 	},
 
 	getValue: function() {
-		var value = this.getPlainTextContent();
-		if (this._hasFormulaBarFocus())
-			value =  this._map.formulabar.getValue();
-		return value;
+		return this.getPlainTextContent();
 	},
 
 	getPlainTextContent: function() {
@@ -807,7 +807,6 @@ L.A11yTextInput = L.Layer.extend({
 		this._dbg('_onBeforeInput ]');
 	},
 
-	// Used by FormulaBarJSDialog
 	updateLastContent: function() {
 		var value = this.getValue();
 		this._lastContent = this.getValueAsCodePoints(value);
@@ -1069,10 +1068,6 @@ L.A11yTextInput = L.Layer.extend({
 	},
 
 	_finishFormulabarEditing: function() {
-		// now we use that only on touch devices
-		if (window.mode.isDesktop())
-			return;
-
 		if (this._hasFormulaBarFocus())
 			this._map.dispatch('acceptformula');
 	},
@@ -1138,9 +1133,6 @@ L.A11yTextInput = L.Layer.extend({
 		this._setLastCursorPosition(0);
 
 		this.resetContent();
-
-		if (this._hasFormulaBarFocus())
-			this._map.formulabar.setValue('');
 
 		// avoid setting the focus keyboard
 		if (!noSelect && document.getElementById(this._textArea.id)) {

--- a/cypress_test/integration_tests/common/calc_helper.js
+++ b/cypress_test/integration_tests/common/calc_helper.js
@@ -86,7 +86,7 @@ function typeIntoFormulabar(text) {
 		});
 
 	cy.cGet('#sc_input_window.formulabar').click(); // This probably shouldn't be here, but acceptformula doesn't get visible without a click.
-	cy.cGet('#sc_input_window.formulabar').should('have.focus');
+	cy.cGet('#sc_input_window.formulabar').should('have.class', 'focused');
 	cy.cGet('body').type(text);
 
 	helper.doIfOnMobile(function() {


### PR DESCRIPTION
It converts formulabar's textarea into contenteditable div.
Input is handled by TextInput.js used for document
and already in the past for formulabar. Replaces
usage of keyevents which are not triggered with
eg. Japanese.
    
Fixes also #6737
Fixes on mobile #6767 requires: https://gerrit.libreoffice.org/c/core/+/153717
    
New widget consists of text layer with visible content
and cursor layer with selections and cursor. When clicked
it focuses TextInput.js field for typing.