### PR TITLE
formulabar: use IME also on desktop #6737

### DIFF
--- a/browser/src/control/Control.FormulaBarJSDialog.js
+++ b/browser/src/control/Control.FormulaBarJSDialog.js
@@ -70,8 +70,8 @@ L.Control.FormulaBarJSDialog = L.Control.extend({
 							id: 'sc_input_window',
 							type: 'multilineedit',
 							text: text ? text : '',
-							rawKeyEvents: window.mode.isDesktop() ? true : undefined,
-							useTextInput: window.mode.isDesktop() ? undefined : true
+							rawKeyEvents: undefined,
+							useTextInput: true
 						},
 						{
 							id: 'expand',
@@ -191,11 +191,9 @@ L.Control.FormulaBarJSDialog = L.Control.extend({
 	},
 
 	blur: function() {
-		if (!window.mode.isDesktop()) {
-			var textInput = this.map && this.map._textInput;
-			if (textInput && textInput._isComposing)
-				textInput._abortComposition();
-		}
+		var textInput = this.map && this.map._textInput;
+		if (textInput && textInput._isComposing)
+			textInput._abortComposition();
 
 		var input = this.getInputField();
 		if (input)
@@ -308,10 +306,8 @@ L.Control.FormulaBarJSDialog = L.Control.extend({
 			var keepInputFocus = messageForInputField && this.hasFocus();
 			var textInput = this.map._textInput;
 
-			// on desktop we display what we get from the server
-			// on touch devices we allow to type into the field directly, so we cannot update always
-			var allowUpdate = window.mode.isDesktop()
-				|| !this.hasFocus() || (this.hasFocus() && this.dirty);
+			// we allow user to type into the field directly, so we cannot update always
+			var allowUpdate = !this.hasFocus() || (this.hasFocus() && this.dirty);
 
 			if (!allowUpdate && messageForInputField && isSetTextMessage)
 				return;
@@ -320,7 +316,7 @@ L.Control.FormulaBarJSDialog = L.Control.extend({
 
 			this.builder.executeAction(this.container, innerData);
 
-			if (!window.mode.isDesktop() && messageForInputField && this.hasFocus()) {
+			if (messageForInputField && this.hasFocus()) {
 				var newContent = textInput.getValueAsCodePoints().slice(1, -1);
 				textInput.setupLastContent(newContent);
 			}

--- a/browser/src/control/jsdialog/Widget.MultilineEdit.js
+++ b/browser/src/control/jsdialog/Widget.MultilineEdit.js
@@ -92,6 +92,13 @@ function _multiLineEditControl(parentContainer, data, builder, callback) {
 		// uses TextInput.js logic and events handling (IME for mobile/touch devices)
 		edit.addEventListener('input', builder.map._textInput._onInput.bind(builder.map._textInput));
 		edit.addEventListener('beforeinput', builder.map._textInput._onBeforeInput.bind(builder.map._textInput));
+		edit.addEventListener('keydown', builder.map._textInput._onKeyDown.bind(builder.map._textInput));
+		edit.addEventListener('keydown', function(event) {
+			if (event.key === 'Enter' && !event.shiftKey) {
+				builder.callback('edit', 'keypress', edit, UNOKey.RETURN | modifier, builder);
+				event.preventDefault();
+			}
+		});
 	} else if (data.rawKeyEvents) {
 		// sends key events over jsdialog
 		var modifier = 0;


### PR DESCRIPTION
it was already used on mobile so
disable "raw key events" and enable "text input".

this also requires core change:
https://gerrit.libreoffice.org/c/core/+/153718

fixes #6737