### PR TITLE
Make writer page background match document color

### DIFF
--- a/browser/src/layer/tile/CanvasSectionContainer.ts
+++ b/browser/src/layer/tile/CanvasSectionContainer.ts
@@ -492,6 +492,7 @@ class CanvasSectionContainer {
 	private touchCenter: Array<number> = null;
 	private potentialLongPress: boolean = false;
 	private clearColor: string = '#f8f9fa';
+	private documentBackgroundColor = '#ffffff'; // This is the background color of the document
 	private useCSSForBackgroundColor = true;
 	private touchEventInProgress: boolean = false; // This prevents multiple calling of mouse down and up events.
 	public testing: boolean = false; // If this set to true, container will create a div element for every section. So, cypress tests can find where to click etc.
@@ -556,6 +557,9 @@ class CanvasSectionContainer {
 		document.body.removeChild(tempElement); // Remove the temporary element.
 
 		this.clearColor = window.getComputedStyle(document.documentElement).getPropertyValue('--color-canvas');
+		// Set document background color to the app background color for now until we get the real color from the kit
+		// through a LOK_CALLBACK_DOCUMENT_BACKGROUND_COLOR
+		this.documentBackgroundColor = window.getComputedStyle(document.documentElement).getPropertyValue('--color-canvas');
 
 		if (disableDrawing)
 			this.disableDrawing();
@@ -601,6 +605,14 @@ class CanvasSectionContainer {
 
 	getClearColor () {
 		return this.clearColor;
+	}
+
+	setDocumentBackgroundColor (color: string) {
+		this.documentBackgroundColor = color;
+	}
+
+	getDocumentBackgroundColor () {
+		return this.documentBackgroundColor;
 	}
 
 	public getCanvasStyle(): CSSStyleDeclaration {

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1796,6 +1796,9 @@ L.CanvasTileLayer = L.Layer.extend({
 			app.sectionContainer.setClearColor('#' + textMsg.substring('applicationbackgroundcolor:'.length + 1).trim());
 			app.sectionContainer.requestReDraw();
 		}
+		else if (textMsg.startsWith('documentbackgroundcolor:')) {
+			app.sectionContainer.setDocumentBackgroundColor('#' + textMsg.substring('documentbackgroundcolor:'.length + 1).trim());
+		}
 		else if (textMsg.startsWith('contentcontrol:')) {
 			textMsg = textMsg.substring('contentcontrol:'.length + 1);
 			if (!app.sectionContainer.doesSectionExist(L.CSections.ContentControl.name)) {

--- a/browser/src/layer/tile/TilesSection.ts
+++ b/browser/src/layer/tile/TilesSection.ts
@@ -33,7 +33,6 @@ class TilesSection extends CanvasSectionObject {
 		this.sectionProperties.tsManager = this.sectionProperties.docLayer._painter;
 		this.sectionProperties.pageBackgroundInnerMargin = 0; // In core pixels. We don't want backgrounds to have exact same borders with tiles for not making them visible when tiles are rendered.
 		this.sectionProperties.pageBackgroundBorderColor = 'lightgrey';
-		this.sectionProperties.pageBackgroundFillColorWriter = 'white';
 		this.sectionProperties.pageBackgroundTextColor = 'grey';
 		this.sectionProperties.pageBackgroundFont = String(40 * app.roundedDpiScale) + 'px Arial';
 
@@ -295,7 +294,7 @@ class TilesSection extends CanvasSectionObject {
 	private drawPageBackgroundWriter (ctx: any, rectangle: any, pageNumber: number) {
 		rectangle = [Math.round(rectangle[0] * app.twipsToPixels), Math.round(rectangle[1] * app.twipsToPixels), Math.round(rectangle[2] * app.twipsToPixels), Math.round(rectangle[3] * app.twipsToPixels)];
 
-		this.context.fillStyle = this.sectionProperties.pageBackgroundFillColorWriter;
+		this.context.fillStyle = this.containerObject.getDocumentBackgroundColor(); // used to be pageBackgroundFillColorWriter (see below)
 		this.context.fillRect(rectangle[0] - ctx.viewBounds.min.x + this.sectionProperties.pageBackgroundInnerMargin,
 			rectangle[1] - ctx.viewBounds.min.y + this.sectionProperties.pageBackgroundInnerMargin,
 			rectangle[2] - this.sectionProperties.pageBackgroundInnerMargin,

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -2965,6 +2965,9 @@ void ChildSession::loKitCallback(const int type, const std::string& payload)
     case LOK_CALLBACK_INVALIDATE_SHEET_GEOMETRY:
         sendTextFrame("invalidatesheetgeometry: " + payload);
         break;
+    case LOK_CALLBACK_DOCUMENT_BACKGROUND_COLOR:
+        sendTextFrame("documentbackgroundcolor: " + payload);
+        break;
     case LOK_CALLBACK_APPLICATION_BACKGROUND_COLOR:
         sendTextFrame("applicationbackgroundcolor: " + payload);
         break;


### PR DESCRIPTION
It used to be that scrolling in dark mode would show a white color while the tiles were loading - now shows the document background color.


Change-Id: Id4c3881e728ae18496bf276e8c565a7abc1de7b5

