### PR TITLE
scroll: avoid selecting elements while dragging scroll bar

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -1132,3 +1132,9 @@ nav.spreadsheet-color-indicator ~ #sidebar-dock-wrapper {
 	text-overflow: ellipsis;
 	overflow: hidden;
 }
+
+.prevent-select {
+	-webkit-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
+}

--- a/browser/src/layer/tile/ScrollSection.ts
+++ b/browser/src/layer/tile/ScrollSection.ts
@@ -813,6 +813,7 @@ export class ScrollSection extends CanvasSectionObject {
 		if (!(<any>window).mode.isDesktop())
 			return;
 
+		L.DomUtil.addClass(document.documentElement, 'prevent-select');
 		var props = this.getVerticalScrollProperties();
 		var midY = (props.startY + props.startY + props.scrollSize - this.sectionProperties.scrollBarThickness) * 0.5;
 
@@ -845,6 +846,7 @@ export class ScrollSection extends CanvasSectionObject {
 		if (!(<any>window).mode.isDesktop())
 			return;
 
+		L.DomUtil.addClass(document.documentElement, 'prevent-select');
 		var props = this.getHorizontalScrollProperties();
 		const sizeX = props.scrollSize - this.sectionProperties.scrollBarThickness;
 		const docWidth: number = this.map.getPixelBoundsCore().getSize().x;
@@ -941,6 +943,7 @@ export class ScrollSection extends CanvasSectionObject {
 	}
 
 	public onMouseUp (point: Array<number>, e: MouseEvent): void {
+		L.DomUtil.removeClass(document.documentElement, 'prevent-select');
 		this.map.scrollingIsHandled = false;
 		this.clearQuickScrollTimeout();
 


### PR DESCRIPTION
Change-Id: I222d246148d5d84a5c0b3cfdb1890350f428e696

problem:
In safari and gnome web when you scroll using scroll bar,
DOM elements on the slidebar and documents would get selected

* Target version: master 


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

