### PR TITLE
A11yTextInput: improve screen reader on unselecting text

### DIFF
--- a/browser/src/layer/marker/A11yTextInput.js
+++ b/browser/src/layer/marker/A11yTextInput.js
@@ -1196,8 +1196,6 @@ L.A11yTextInput = L.Layer.extend({
 		this._fancyLog('abort-composition', ev.type);
 		if (this._isComposing)
 			this._isComposing = false;
-		this._emptyArea((document.activeElement !== this._textArea)
-			&& !this._hasFormulaBarFocus());
 		this._requestFocusedParagraph();
 	},
 


### PR DESCRIPTION
When text is unselected by clicking somewhere, selected text innside
the editable area was unselected, selected again, unselected again.
That was causing the screen reader to report such a nonsense sequence.

Signed-off-by: Marco Cecchetti <marco.cecchetti@collabora.com>
Change-Id: Ib9d6628f7ac30fe2cd40ee7823ac67eb6471d1f2
