### PR TITLE
Fix : Wrong label 'BackColor' on mobile UI

### DIFF
--- a/browser/src/control/Control.MobileBottomBar.js
+++ b/browser/src/control/Control.MobileBottomBar.js
@@ -33,7 +33,7 @@ L.Control.MobileBottomBar = L.Control.extend({
 				{type: 'button',  id: 'underline',  img: 'underline', hint: _UNO('.uno:Underline'), uno: '.uno:Underline', context: ['default', 'Text', 'DrawText', 'Table']},
 				{type: 'break', id: 'breakcolor', context: ['default', 'Text', 'DrawText', 'Table']},
 				{type: 'button',  id: 'fontcolor', img: 'textcolor', hint: _UNO('.uno:FontColor'), lockUno: '.uno:FontColor', context: ['default', 'Text', 'DrawText', 'Table']},
-				{type: 'button',  id: 'backcolor', img: 'backcolor', hint: _UNO('.uno:BackColor'), lockUno: '.uno:BackColor', context: ['default', 'Text', 'DrawText', 'Table']},
+				{type: 'button',  id: 'backcolor', img: 'backcolor', hint: _UNO('.uno:BackColor', 'text'), lockUno: '.uno:BackColor', context: ['default', 'Text', 'DrawText', 'Table']},
 				{type: 'drop',  id: 'setborderstyle',  img: 'setborderstyle', hint: _('Borders'), hidden: true, html: window.getBorderStyleMenuHtml(), context: ['Table']},
 				{type: 'break', id: 'breakalign-text', context: ['default', 'Text', 'DrawText']},
 				{type: 'menu', id: 'align-text', img: 'alignblock', hint: _UNO('.uno:TextAlign'), lockUno: '.uno:TextAlign', context: ['default', 'Text'],


### PR DESCRIPTION
Change-Id: I264d02b57a5e2c969ac9245cee2fa4be028e1c04


* Resolves: #6755
* Target version: master 

### Summary

Fix wrong backcolor tooltip for mobile UI
![image](https://github.com/CollaboraOnline/online/assets/61383886/c235ab63-df86-4399-9a23-73b131c73c21)


