### PR TITLE
configure.ac: Fix missing space in test command

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -96,7 +96,7 @@ for MODULE in lxml polib; do
         AC_MSG_RESULT([yes])
     else
         AC_MSG_RESULT([no])
-        AS_IF([test `uname -s` = Linux -o `uname -s` = FreeBSD -o `uname -s`= Darwin],
+        AS_IF([test `uname -s` = Linux -o `uname -s` = FreeBSD -o `uname -s` = Darwin],
               [AC_MSG_ERROR([${MODULE} for python3 is needed. It might be in a package called python3-${MODULE}.])],
               [AC_MSG_WARN([${MODULE} for python3 is needed. It might be in a package called python3-${MODULE}. But
                if you are building the JS bits on another (Linux) machine, that doesn't matter])])


### PR DESCRIPTION
Omitting this space leads to the error "test: too many arguments"


Change-Id: Id8a83d77adfb484dcc949a10b4b25f6ad81130f8

* Target version: master 

### Summary
When building Collabora online I noticed this error:
```
./configure: line 18286: test: too many arguments
configure: WARNING: lxml for python3 is needed. It might be in a package called python3-lxml. But
               if you are building the JS bits on another (Linux) machine, that doesn't matter
checking for polib for python3... no
./configure: line 18286: test: too many arguments
configure: WARNING: polib for python3 is needed. It might be in a package called python3-polib. But
               if you are building the JS bits on another (Linux) machine, that doesn't matter
```
It appears that a typo was made in this test command as a space was missing between a uname invocation and the = sign

### Checklist

- [ ] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

