### PR TITLE
Updated copyVersionInfoToClipboard to work when navigator.clipboard is undefined or the origin is not secure

### DIFF
--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -693,13 +693,30 @@ L.Map.include({
 		text += 'Served by: ' + document.getElementById('os-info').innerText + '\n';
 		text += 'Server ID: ' + document.getElementById('coolwsd-id').innerText + '\n';
 
-		navigator.clipboard.writeText(text)
-		.then(function() {
-		  window.console.log('Text copied to clipboard');
-		})
-		.catch(function(error) {
-		  window.console.error('Error copying text to clipboard:', error);
-		});
+		if (navigator.clipboard && window.isSecureContext) {
+			navigator.clipboard.writeText(text)
+			.then(function() {
+				window.console.log('Text copied to clipboard');
+			})
+			.catch(function(error) {
+				window.console.error('Error copying text to clipboard:', error);
+			});
+		} else {
+			var textArea = document.createElement('textarea');
+			textArea.style.position = 'absolute';
+			textArea.style.opacity = 0;
+			textArea.value = text;
+			document.body.appendChild(textArea);
+			textArea.select();
+			try {
+				document.execCommand('copy');
+				window.console.log('Text copied to clipboard');
+			} catch (error) {
+				window.console.error('Error copying text to clipboard:', error);
+			} finally {
+				document.body.removeChild(textArea);
+			}
+		}
 	},
 
 	extractContent: function(html) {


### PR DESCRIPTION
Change-Id: I3ed071f49c1008f15f6eb1e5b97dfd6c2c78c1d4


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
This is regarding #6549. These changes ensure that the copy to clipboard functionality works correctly even when `navigator.clipboard` is null or the origin is insecure. 

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

