### PR TITLE
Tabbed view: Writer: layout tab: Reorder elements

### DIFF
--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -1164,6 +1164,11 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				'command': '.uno:PageDialog'
 			},
 			{
+				'type': 'bigtoolitem',
+				'text': _UNO('.uno:FormatColumns', 'text'),
+				'command': '.uno:FormatColumns'
+			},
+			{
 				'type': 'container',
 				'children': [
 					{
@@ -1190,37 +1195,6 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				'vertical': 'true'
 			},
 			{
-				'type': 'bigtoolitem',
-				'text': _UNO('.uno:TitlePageDialog', 'text'),
-				'command': '.uno:TitlePageDialog'
-			},
-			{
-				'type': 'container',
-				'children': [
-					{
-						'type': 'toolbox',
-						'children': [
-							{
-								'type': 'toolitem',
-								'text': _UNO('.uno:FormatColumns', 'text'),
-								'command': '.uno:FormatColumns'
-							}
-						]
-					},
-					{
-						'type': 'toolbox',
-						'children': [
-							{
-								'type': 'toolitem',
-								'text': _UNO('.uno:Watermark', 'text'),
-								'command': '.uno:Watermark'
-							}
-						]
-					}
-				],
-				'vertical': 'true'
-			},
-			{
 				'type': 'container',
 				'children': [
 					{
@@ -1240,6 +1214,32 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 								'type': 'toolitem',
 								'text': _UNO('.uno:LineNumberingDialog', 'text'),
 								'command': '.uno:LineNumberingDialog'
+							}
+						]
+					}
+				],
+				'vertical': 'true'
+			},
+			{
+				'type': 'container',
+				'children': [
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:TitlePageDialog', 'text'),
+								'command': '.uno:TitlePageDialog'
+							}
+						]
+					},
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:Watermark', 'text'),
+								'command': '.uno:Watermark'
 							}
 						]
 					}


### PR DESCRIPTION
Better to reorder these so we have higher probably to meet user's
expectations and fix the priority in which the elements are placed
- Move "Columns" (.uno:FormatColumns) to a higher priority place
- Demote "Title page" (.uno:TitlePageDialog) to a toolitem: This
Button is already present in the insert tab and so we don't need to
have it as a bigtoolitem here
- Move Hyphenate and LineNumbering to be right after breaks

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I6cba0ad920e9ee9ec836f9e06e201f0ff9264f84
