### PR TITLE
fail make check early in typical dev setup if core not built using --…

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -622,7 +622,17 @@ else
 GEN_COVERAGE_COMMAND=true
 endif
 
-check: check-recursive
+# typically the system nss won't work in a jail and fail to init which is fatal for
+# exporting to pdf, which is something that gets tested
+check-for-system-nss:
+	@if test -e "@LO_PATH@/../config_host.mk"; then \
+		if grep -q SYSTEM_NSS=TRUE "@LO_PATH@/../config_host.mk"; then \
+			echo make check will fail unless core is configured using --without-system-nss; \
+			exit 1; \
+		fi \
+	fi
+
+check: check-for-system-nss check-recursive
 	$(GEN_COVERAGE_COMMAND)
 
 coverage-report:


### PR DESCRIPTION
…without-system-nss

Change-Id: Idcf86a7b488e08d59a944a96f17072a7a7a72b3f


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

