### PR TITLE
fix: language selection in More... dialog is not applied

### DIFF
--- a/browser/src/control/Control.LanguageDialog.js
+++ b/browser/src/control/Control.LanguageDialog.js
@@ -17,7 +17,7 @@ L.Control.LanguageDialog = L.Control.extend({
 
 	_onItemSelected: function(language) {
 		var unoCommand = '.uno:LanguageStatus?Language:string=' + this.applyTo + '_' + language;
-		this.map.sendUnoCommand(unoCommand);
+		this.map.sendUnoCommand(unoCommand, null, true);
 	},
 
 	_getSelectedLanguage: function() {

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -395,6 +395,16 @@ L.Map.include({
 
 		if (this.uiManager.isUIBlocked())
 			return;
+
+		// This check is necessary to allow the user to change a language in the More... modal
+		if (this.jsdialog
+			&& this.jsdialog.hasDialogOpened()
+			&& command.startsWith('.uno:LanguageStatus?Language')
+		) {
+			app.socket.sendMessage('uno ' + command);
+			return;
+		}
+
 		if ((this.dialog.hasOpenedDialog() || (this.jsdialog && this.jsdialog.hasDialogOpened()))
 			&& !command.startsWith('.uno:ToolbarMode') && !force) {
 			console.debug('Cannot execute: ' + command + ' when dialog is opened.');

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -395,16 +395,6 @@ L.Map.include({
 
 		if (this.uiManager.isUIBlocked())
 			return;
-
-		// This check is necessary to allow the user to change a language in the More... modal
-		if (this.jsdialog
-			&& this.jsdialog.hasDialogOpened()
-			&& command.startsWith('.uno:LanguageStatus?Language')
-		) {
-			app.socket.sendMessage('uno ' + command);
-			return;
-		}
-
 		if ((this.dialog.hasOpenedDialog() || (this.jsdialog && this.jsdialog.hasDialogOpened()))
 			&& !command.startsWith('.uno:ToolbarMode') && !force) {
 			console.debug('Cannot execute: ' + command + ' when dialog is opened.');


### PR DESCRIPTION
### Info
* Resolves: #6808
* Target version: master 

### Summary
When a user selects a different language for the document using the More... dialog, the system does not apply the selection. This patch allows the system to send the LanguageStatus command even when the jsdialog is opened.

Change-Id: I7a1a39b31db59f1bc5f980d63f3040ffa9b311e5

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

