### PR TITLE
On a cache hit for a tile the result typically had a wireId of 0

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -3317,6 +3317,16 @@ void DocumentBroker::sendRequestedTiles(const std::shared_ptr<ClientSession>& se
             Tile cachedTile = _tileCache->lookupTile(tile);
             if (cachedTile && cachedTile->isValid())
             {
+                // It is typical for a request not to have a wireId. If the result is generated
+                // without using the cache then doRender will send a timecombine result with wireIds
+                // set. But if we use the cache here we send a response using the wireId of the request.
+
+                // With no wireId in the request the result will have wireId of 0 and
+                // in CanvasTileLayer.js tile::needsFetch such a tile will always return true
+                // for needsFetch and is wasted.
+                if (tile.getWireId() == 0)
+                    tile.setWireId(cachedTile->_wids.back());
+
                 // TODO: Combine the response to reduce latency.
                 session->sendTileNow(tile, cachedTile);
             }


### PR DESCRIPTION
And tile::needsFetch on that result will always return true given the default of invalidFrom of 0 and the comparison of
  return this.invalidFrom >= this.wireId || ...
so the tile return from the cache is unusable.

It is typical for a request not to have a wireId, if we don't use the cache then doRender will send a timecombine result with wireIds set. But if we use the cache here we send a response using the wireId of the request.


Change-Id: I586406af86b0f503dfc204e20120cc8acebf5b8e


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

