### PR TITLE
annotation: avoid saving comments on losing focus

### DIFF
--- a/browser/src/control/Control.IdleHandler.ts
+++ b/browser/src/control/Control.IdleHandler.ts
@@ -46,7 +46,8 @@ class IdleHandler {
 			}
 		}
 
-		if (window.mode.isDesktop() && !this.map.uiManager.isAnyDialogOpen()) {
+		var section = app.sectionContainer.getSectionWithName(L.CSections.CommentList.name);
+		if (window.mode.isDesktop() && !this.map.uiManager.isAnyDialogOpen() && !section.sectionProperties.selectedComment) {
 			this.map.focus();
 		}
 

--- a/browser/src/layer/tile/CommentListSection.ts
+++ b/browser/src/layer/tile/CommentListSection.ts
@@ -1748,7 +1748,7 @@ export class CommentSection extends CanvasSectionObject {
 	public onCommentsDataUpdate(): void {
 		for (var i: number = this.sectionProperties.commentList.length -1; i > -1; i--) {
 			var comment = this.sectionProperties.commentList[i];
-			if (!comment.valid) {
+			if (!comment.valid &&  (!$(comment.sectionProperties.container).hasClass('reply-annotation-container') && !$(comment.sectionProperties.container).hasClass('modify-annotation-container'))) {
 				comment.sectionProperties.commentListSection.removeItem(comment.sectionProperties.data.id);
 			}
 			comment.onCommentDataUpdate();

--- a/browser/src/layer/tile/CommentListSection.ts
+++ b/browser/src/layer/tile/CommentListSection.ts
@@ -671,7 +671,7 @@ export class CommentSection extends CanvasSectionObject {
 	}
 
 	public unselect (): void {
-		if (this.sectionProperties.selectedComment) {
+		if (this.sectionProperties.selectedComment && this.sectionProperties.selectedComment.sectionProperties.data.id != 'new') {
 			if (this.sectionProperties.selectedComment && $(this.sectionProperties.selectedComment.sectionProperties.container).hasClass('annotation-active'))
 				$(this.sectionProperties.selectedComment.sectionProperties.container).removeClass('annotation-active');
 

--- a/browser/src/layer/tile/CommentSection.ts
+++ b/browser/src/layer/tile/CommentSection.ts
@@ -807,24 +807,6 @@ export class Comment extends CanvasSectionObject {
 
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 	public onLostFocus (e: any): void {
-		if (!this.sectionProperties.isRemoved) {
-			$(this.sectionProperties.container).removeClass('annotation-active reply-annotation-container modify-annotation-container');
-			if (this.sectionProperties.contentText.origText !== this.sectionProperties.nodeModifyText.value) {
-				this.onSaveComment(e);
-			}
-			else {
-				if (!this.containerObject.testing) // eslint-disable-line no-lonely-if
-					this.onCancelClick(e);
-				else {
-					var insertButton = document.getElementById('menu-insertcomment');
-					if (insertButton) {
-						if (window.getComputedStyle(insertButton).display === 'none') {
-							this.onCancelClick(e);
-						}
-					}
-				}
-			}
-		}
 		app.view.commentHasFocus = false;
 	}
 


### PR DESCRIPTION
problem:
resolves: #5995
it was just annoying for user when he goes to some other tab or clicks somewhere, and the comment is saved automatically while they may want to still edit

also this solved another problem where in multiple users case, if another user switches tab comments were saved even if user was editing it


Change-Id: Iee32f21803d6a0dbc164bbf9a9bee803228aad7a


* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

