### PR TITLE
keyboard: show keyboard only when explicitly requested

### DIFF
--- a/browser/src/layer/marker/TextInput.js
+++ b/browser/src/layer/marker/TextInput.js
@@ -241,9 +241,7 @@ L.TextInput = L.Layer.extend({
 				this._textArea.setAttribute('readonly', true);
 		}
 
-		if (!window.ThisIsTheiOSApp && navigator.platform !== 'iPhone') {
-			this._textArea.focus();
-		} else if (acceptInput === true) {
+		if (acceptInput === true) {
 			// On the iPhone, only call the textarea's focus() when we get an explicit
 			// true parameter. On the other hand, never call the textarea's blur().
 
@@ -259,6 +257,9 @@ L.TextInput = L.Layer.extend({
 			// this function, and check when the topmost slot in the stack trace is
 			// "(anonymous function)" in hammer.js (an event handler), and when it is
 			// _onMessage (the WebSocket message handler in Socket.js).
+
+			// Even on android it is causing keyboard flicker so only foucs it on
+			// explicit true parameter
 
 			this._textArea.focus();
 		}


### PR DESCRIPTION
problem:
on mobile phone keyboard used to flicker when you tap on cell, even if you were not editing inside cell


Change-Id: I966267817e054694dabd30c2aa8db09a1f189ce5


* Target version: master 

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

