### PR TITLE
asan error seen in testRleComplex

### DIFF
--- a/kit/Delta.hpp
+++ b/kit/Delta.hpp
@@ -95,7 +95,8 @@ class DeltaGenerator {
             void next()
             {
                 _x++;
-                if (!(_row._rleMask[_x >> 6] & (uint64_t(1) << (_x & 63))))
+                size_t rleMaskIndex = _x >> 6;
+                if (rleMaskIndex >= _rleMaskUnits || !(_row._rleMask[rleMaskIndex] & (uint64_t(1) << (_x & 63))))
                     _rlePtr++;
             }
         };


### PR DESCRIPTION
=============== START DeltaTests::testRleComplex
../kit/Delta.hpp:98:23: runtime error: index 4 out of bounds for type 'const uint64_t[4]' (aka 'const unsigned long[4]')
    #0 0x55d29dacd21b in DeltaGenerator::DeltaBitmapRow::PixIterator::next() libreoffice/online-san/test/../kit/Delta.hpp:98:23
    #1 0x55d29da8d514 in DeltaTests::testRleComplex() libreoffice/online-san/test/DeltaTests.cpp:316:16
    #2 0x55d29daf7a87 in void std::__invoke_impl<void, void (DeltaTests::*&)(), DeltaTests*&>(std::__invoke_memfun_deref, void (DeltaTests::*&)(), DeltaTests*&) /usr/bin/../lib64/gcc/x86_64-suse-linux/9/../../../../include/c++/9/bits/invoke.h:73:14


Change-Id: Ib6e13eaf0fb89ad086a99251d5b8edcdcedd6800


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

