### PR TITLE
impress slide previews are not 256x256 to triggers assert

### DIFF
--- a/common/RenderTiles.hpp
+++ b/common/RenderTiles.hpp
@@ -228,7 +228,6 @@ namespace RenderTiles
         const int pixelWidth = tileCombined.getWidth();
         const int pixelHeight = tileCombined.getHeight();
         assert (pixelWidth > 0 && pixelHeight > 0);
-        assert (pixelWidth <= 256 && pixelHeight <= 256);
         const size_t pixmapWidth = tilesByX * pixelWidth;
         const size_t pixmapHeight = tilesByY * pixelHeight;
 
@@ -311,6 +310,7 @@ namespace RenderTiles
                         {
                             // Can we create a delta ?
                             LOG_TRC("Compress new tile #" << tileIndex);
+                            assert(pixelWidth <= 256 && pixelHeight <= 256);
                             deltaGen.compressOrDelta(pixmap.data(), offsetX, offsetY,
                                                      pixelWidth, pixelHeight,
                                                      pixmapWidth, pixmapHeight,


### PR DESCRIPTION
but they don't go through the delta mechanism, so move the assert to the delta path, the other path is ok wrt gt 256x256


Change-Id: I2ba4d8affb7645349540f3a5de31d1802f04c53d


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

