### PR TITLE
Focus back to document when Escape key pressed

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2637,6 +2637,14 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			e.stopPropagation();
 		});
 
+		div.addEventListener('keydown', function(e) {
+			switch (e.key) {
+			case 'Escape':
+				builder.map.focus();
+				break;
+			}
+		});
+
 		builder._preventDocumentLosingFocusOnClick(div);
 
 		if (data.enabled === 'false' || data.enabled === false)

--- a/browser/src/control/Control.NotebookbarBuilder.js
+++ b/browser/src/control/Control.NotebookbarBuilder.js
@@ -441,7 +441,8 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 					else if (e.code === 'Escape') {
 						if (elementToHide)
 							elementToHide.style.display = 'none';
-						document.getElementById(parentId).focus();
+						var parentUNOButton = document.getElementById(parentId).querySelector('button');
+						parentUNOButton ? document.getElementById(parentId).querySelector('button').focus() : document.getElementById(parentId).focus();
 					}
 				};
 			});


### PR DESCRIPTION

Signed-off-by: Darshan-upadhyay1110 <darshan.upadhyay@collabora.com>
Change-Id: I4b34ae795465ecc402c5228478b7797298acc5a7


* Resolves: 
* Target version: master 

### Summary
 * Focus back to document when escape key pressed on any element in Notebookbar
 * Exception: When drop down is already open then focus back to element.


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

