### PR TITLE
don't append wid=X to payload

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1174,8 +1174,7 @@ public:
         {
             // no point in handling invalidations or page resizes per-view,
             // all views have to be in sync
-            tileQueue->put("callback all " + std::to_string(type) + ' ' + payload +
-                           " wid=" + std::to_string(RenderTiles::getCurrentWireId()));
+            tileQueue->put("callback all " + std::to_string(type) + ' ' + payload);
         }
         else
             tileQueue->put("callback " + std::to_string(descriptor->getViewId()) + ' ' + std::to_string(type) + ' ' + payload);


### PR DESCRIPTION
commit 36818e915316f12ed9988adf04bb03888f5003ac
Date:   Thu Jun 22 22:26:59 2023 +0100

    tiles: track invalidation by monotonic timestamp.

added wid=X to invalidatetiles (etc?)

but TileCache::parseInvalidateMsg is unaware of the extra arg and ends up doing nothing.


Change-Id: I6da20253807daa60064683d13e7e9471ccab4b99


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

