### PR TITLE
return failure early in case of oversized tiles

### DIFF
--- a/kit/Delta.hpp
+++ b/kit/Delta.hpp
@@ -542,6 +542,13 @@ class DeltaGenerator {
             return false;
         }
 
+        if (width > 256 || height > 256)
+        {
+            LOG_TRC("Bad size << " << width << " x " << height << " to create deltas ");
+            assert(false && "shouldn't be possible to get tiles > 256x256");
+            return false;
+        }
+
         // FIXME: why duplicate this ? we could overwrite
         // as we make the delta into an existing cache entry,
         // and just do this as/when there is no entry.


### PR DESCRIPTION
it shouldn't happen, but return early if it does


Change-Id: I1733d346ff370827fd882caacebca111f790bbe1


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

