### PR TITLE
docker: remove obsolete fix

### DIFF
--- a/docker/from-packages/Dockerfile
+++ b/docker/from-packages/Dockerfile
@@ -113,8 +113,7 @@ RUN --mount=type=secret,id=secret_key \
     if [ -z "$noinotifywait" ]; then \
         apt-get -y install inotify-tools psmisc; \
     fi && \
-# Fix permissions of files that will be modified on start of the container by cool user
-    chown cool:cool /opt/cool/systemplate/etc/hosts /opt/cool/systemplate/etc/resolv.conf && \
+# Fix ownership of config directory that will be modified on start of the container by cool user
     chown cool:cool /etc/coolwsd && \
 # Remove packages that are not needed
 # FIXME: long way to go, the commands below remove coolwsd, too.

--- a/docker/from-packages/scripts/start-collabora-online.sh
+++ b/docker/from-packages/scripts/start-collabora-online.sh
@@ -3,9 +3,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-# Fix domain name resolution from jails
-cp /etc/resolv.conf /etc/hosts /opt/cool/systemplate/etc/
-
 if test "${DONT_GEN_SSL_CERT-set}" = set; then
 # Generate new SSL certificate instead of using the default
 mkdir -p /tmp/ssl/


### PR DESCRIPTION
The domain resolution problem from jails was properly solved by https://github.com/CollaboraOnline/online/commit/bc8da0cb339cc685f9a24c78e8a92aadcd690479 This hack is not necessary in docker.


Change-Id: I59664b895d187b2a8930a34b096305e0b7c384e3

