### PR TITLE
Disconnecting with Read-Only Session

### DIFF
--- a/test/UnitQuarantine.cpp
+++ b/test/UnitQuarantine.cpp
@@ -65,7 +65,7 @@ public:
         if (_scenario == Scenario::VerifyOverwrite)
         {
             // By default, we don't upload when verifying (unless always_save_on_exit is set).
-            setExpectedPutFile(SaveOnExit);
+            setExpectedPutFile(SaveOnExit ? 2 : 0);
         }
         else
         {

--- a/test/UnitWOPIFailUpload.cpp
+++ b/test/UnitWOPIFailUpload.cpp
@@ -59,7 +59,7 @@ public:
         if (_scenario == Scenario::VerifyOverwrite)
         {
             // By default, we don't upload when verifying (unless always_save_on_exit is set).
-            setExpectedPutFile(SaveOnExit);
+            setExpectedPutFile(SaveOnExit ? 2 : 0);
         }
         else
         {

--- a/test/UnitWOPILock.cpp
+++ b/test/UnitWOPILock.cpp
@@ -140,6 +140,197 @@ public:
     }
 };
 
+/// This is to test that we unlock before unloading the last editor
+/// when the first view is read-only.
+class UnitWopiLockReadOnly : public WopiTestServer
+{
+    STATE_ENUM(Phase, LoadViewer, LoadEditor, Lock, WaitModify, Unlock, WaitUnload, Done) _phase;
+
+    std::string _lockState;
+    std::string _lockToken;
+    std::size_t _checkFileInfoCount;
+    std::size_t _viewCount;
+
+public:
+    UnitWopiLockReadOnly()
+        : WopiTestServer("UnitWopiLockReadOnly")
+        , _phase(Phase::LoadViewer)
+        , _lockState("UNLOCK")
+        , _checkFileInfoCount(0)
+        , _viewCount(0)
+    {
+    }
+
+    void configCheckFileInfo(const Poco::Net::HTTPRequest& /*request*/,
+                             Poco::JSON::Object::Ptr fileInfo) override
+    {
+        // Make the first session the editor, subsequent ones read-only.
+        const bool firstView = _checkFileInfoCount == 0;
+        ++_checkFileInfoCount;
+
+        LOG_TST("CheckFileInfo: " << (firstView ? "viewer" : "editor"));
+
+        fileInfo->set("SupportsLocks", "true");
+        fileInfo->set("UserCanWrite", firstView ? "false" : "true");
+
+        // An extension that doesn't allow commenting. By omitting this,
+        // the test fails because we allow commenting and consider the
+        // document editable, and don't unlock when the editor disconnects.
+        fileInfo->set("BaseFileName", "doc.odt");
+    }
+
+    std::unique_ptr<http::Response>
+    assertLockRequest(const Poco::Net::HTTPRequest& request) override
+    {
+        const std::string lockToken = request.get("X-WOPI-Lock", std::string());
+        const std::string newLockState = request.get("X-WOPI-Override", std::string());
+        LOG_TST("In " << toString(_phase) << ", X-WOPI-Lock: " << lockToken << ", X-WOPI-Override: "
+                      << newLockState << ", for URI: " << request.getURI());
+
+        if (_phase == Phase::Lock)
+        {
+            LOK_ASSERT_EQUAL_MESSAGE("Expected X-WOPI-Override:LOCK", std::string("LOCK"),
+                                     newLockState);
+            LOK_ASSERT_MESSAGE("Lock token cannot be empty", !lockToken.empty());
+            _lockState = newLockState;
+            _lockToken = lockToken;
+        }
+        else if (_phase == Phase::Unlock)
+        {
+            LOK_ASSERT_EQUAL_MESSAGE("Expected X-WOPI-Override:UNLOCK", std::string("UNLOCK"),
+                                     newLockState);
+            LOK_ASSERT_EQUAL_MESSAGE("Document is not locked", std::string("LOCK"), _lockState);
+            LOK_ASSERT_EQUAL_MESSAGE("The lock token has changed", _lockToken, lockToken);
+
+            // TRANSITION_STATE(_phase, Phase::Done);
+            // exitTest(TestResult::Ok);
+        }
+        else
+        {
+            LOK_ASSERT_FAIL("Unexpected lock-state change while in " + toString(_phase));
+        }
+
+        return nullptr; // Success.
+    }
+
+    std::unique_ptr<http::Response>
+    assertPutFileRequest(const Poco::Net::HTTPRequest& request) override
+    {
+        LOK_ASSERT_STATE(_phase, Phase::Unlock);
+        TRANSITION_STATE(_phase, Phase::WaitUnload);
+
+        // The document is modified.
+        LOK_ASSERT_EQUAL(std::string("true"), request.get("X-COOL-WOPI-IsModifiedByUser"));
+        LOK_ASSERT_EQUAL(std::string("true"), request.get("X-LOOL-WOPI-IsModifiedByUser"));
+
+        // Triggered manually or during closing, not auto-save.
+        LOK_ASSERT_EQUAL(std::string("false"), request.get("X-COOL-WOPI-IsAutosave"));
+        LOK_ASSERT_EQUAL(std::string("false"), request.get("X-LOOL-WOPI-IsAutosave"));
+
+        // The only editor goes away.
+        // LOK_ASSERT_EQUAL(std::string("true"), request.get("X-COOL-WOPI-IsExitSave"));
+        // LOK_ASSERT_EQUAL(std::string("true"), request.get("X-LOOL-WOPI-IsExitSave"));
+
+        // Simulate the viewer closing browser.
+        LOG_TST("Disconnecting Viewer");
+        deleteSocketAt(0);
+
+        return nullptr; // Success.
+    }
+
+    void onDocBrokerViewLoaded(const std::string&,
+                               const std::shared_ptr<ClientSession>& session) override
+    {
+        LOG_TST("View #" << _viewCount + 1 << " [" << session->getName() << "] loaded");
+
+        ++_viewCount;
+        if (_viewCount == 1)
+        {
+            LOK_ASSERT_STATE(_phase, Phase::LoadEditor);
+            TRANSITION_STATE(_phase, Phase::Lock);
+
+            LOG_TST("Loading second view (editor)");
+            WSD_CMD_BY_CONNECTION_INDEX(1, "load url=" + getWopiSrc());
+        }
+        else if (_viewCount == 2)
+        {
+            // Transition before modifying.
+            TRANSITION_STATE(_phase, Phase::WaitModify);
+
+            // Modify the doc.
+            LOG_TST("Modifying (editor)");
+            WSD_CMD_BY_CONNECTION_INDEX(1, "key type=input char=97 key=0");
+            WSD_CMD_BY_CONNECTION_INDEX(1, "key type=up char=0 key=512");
+        }
+    }
+
+    /// The document is modified. Disconnect editor.
+    bool onDocumentModified(const std::string& message) override
+    {
+        LOG_TST("onDocumentModified: [" << message << ']');
+        LOK_ASSERT_STATE(_phase, Phase::WaitModify);
+
+        TRANSITION_STATE(_phase, Phase::Unlock);
+
+        // Simulate the editor closing browser.
+        LOG_TST("Disconnecting Editor");
+        deleteSocketAt(1);
+
+        return true;
+    }
+
+    void onDocBrokerRemoveSession(const std::string&,
+                                  const std::shared_ptr<ClientSession>& session) override
+    {
+        LOG_TST("Removing session [" << session->getName() << ']');
+        if (_phase == Phase::Unlock)
+        {
+            // LOK_ASSERT_STATE(_phase, Phase::WaitUnload);
+        }
+    }
+
+    void onDocBrokerDestroy(const std::string& docKey) override
+    {
+        LOG_TST("Destroyed dockey [" << docKey << ']');
+        LOK_ASSERT_STATE(_phase, Phase::WaitUnload);
+
+        TRANSITION_STATE(_phase, Phase::Done);
+        passTest("No modification or unexpected PutFile on read-only doc");
+    }
+
+    void invokeWSDTest() override
+    {
+        switch (_phase)
+        {
+            case Phase::LoadViewer:
+            {
+                // Always transition before issuing commands.
+                TRANSITION_STATE(_phase, Phase::LoadEditor);
+
+                LOG_TST("Creating first connection");
+                initWebsocket("/wopi/files/0?access_token=anything");
+
+                LOG_TST("Creating second connection");
+                addWebSocket();
+
+                LOG_TST("Loading first view (viewer)");
+                WSD_CMD_BY_CONNECTION_INDEX(0, "load url=" + getWopiSrc());
+                break;
+            }
+            case Phase::LoadEditor:
+            case Phase::Lock:
+            case Phase::WaitModify:
+            case Phase::Unlock:
+            case Phase::WaitUnload:
+            case Phase::Done:
+            {
+                // just wait for the results
+                break;
+            }
+        }
+    }
+};
+
 /// This is to test the behavior when locking fails.
 class UnitWopiLockFail : public WopiTestServer
 {
@@ -419,8 +610,11 @@ public:
 
 UnitBase** unit_create_wsd_multi(void)
 {
-    return new UnitBase* [4]
-    { new UnitWopiLock(), new UnitWopiLockFail(), new UnitWopiUnlock(), nullptr };
+    return new UnitBase* [5]
+    {
+        new UnitWopiLock(), new UnitWopiLockReadOnly(), new UnitWopiLockFail(),
+            new UnitWopiUnlock(), nullptr
+    };
 }
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/test/httpcrashtest.cpp
+++ b/test/httpcrashtest.cpp
@@ -51,7 +51,11 @@ class HTTPCrashTest : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST(testBarren);
     CPPUNIT_TEST(testCrashKit);
     CPPUNIT_TEST(testRecoverAfterKitCrash);
-    CPPUNIT_TEST(testCrashForkit);
+
+    // Disabled because we think we have modifications when we disconnect
+    // when in fact we have none. The reason is because isPossiblyModified
+    // checks for any user activity, and not just modifying activity.
+    // CPPUNIT_TEST(testCrashForkit);
 
     CPPUNIT_TEST_SUITE_END();
 

--- a/test/httpcrashtest.cpp
+++ b/test/httpcrashtest.cpp
@@ -52,10 +52,7 @@ class HTTPCrashTest : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST(testCrashKit);
     CPPUNIT_TEST(testRecoverAfterKitCrash);
 
-    // Disabled because we think we have modifications when we disconnect
-    // when in fact we have none. The reason is because isPossiblyModified
-    // checks for any user activity, and not just modifying activity.
-    // CPPUNIT_TEST(testCrashForkit);
+    CPPUNIT_TEST(testCrashForkit);
 
     CPPUNIT_TEST_SUITE_END();
 

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -470,14 +470,14 @@ void DocumentBroker::pollThread()
                 {
                     // We will never save. No need to wait for timeout.
                     LOG_DBG("Doc disconnected while saving. Ending save activity.");
-                    _saveManager.setLastSaveResult(/*success=*/false);
+                    _saveManager.setLastSaveResult(/*success=*/false, /*newVersion=*/false);
                     endActivity();
                 }
                 else
                 if (_saveManager.hasSavingTimedOut())
                 {
                     LOG_DBG("Saving timedout. Ending save activity.");
-                    _saveManager.setLastSaveResult(/*success=*/false);
+                    _saveManager.setLastSaveResult(/*success=*/false, /*newVersion=*/false);
                     endActivity();
                 }
             }
@@ -1352,7 +1352,7 @@ DocumentBroker::NeedToUpload DocumentBroker::needToUploadToStorage() const
 
     // When destroying, we might have to force uploading if always_save_on_exit=true.
     // If unloadRequested is set, assume we will unload after uploading and exit.
-    if (isUnloading() && _alwaysSaveOnExit)
+    if (isUnloading() && _alwaysSaveOnExit && _saveManager.version() > 0)
     {
         if (_documentChangedInStorage)
         {
@@ -1444,7 +1444,7 @@ void DocumentBroker::handleSaveResponse(const std::shared_ptr<ClientSession>& se
     _nextStorageAttrs.reset();
 
     // Record that we got a response to avoid timing out on saving.
-    _saveManager.setLastSaveResult(success || result == "unmodified");
+    _saveManager.setLastSaveResult(success || result == "unmodified", /*newVersion=*/success);
 
     if (success)
         LOG_DBG("Save result from Core: saved (during " << DocumentState::name(_docState.activity())

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1608,7 +1608,8 @@ void DocumentBroker::uploadToStorage(const std::shared_ptr<ClientSession>& sessi
     LOG_TRC("uploadToStorage [" << session->getId() << "]: " << (force ? "" : "not") << " forced");
 
     // Upload immediately if forced or had no failures. Otherwise, throttle (on failure).
-    if (force || _storageManager.lastUploadSuccessful() || _storageManager.canUploadNow())
+    if (force || _storageManager.lastUploadSuccessful() ||
+        _storageManager.canUploadNow(isUnloading()))
     {
         constexpr bool isRename = false;
         constexpr bool isExport = false;
@@ -2424,7 +2425,7 @@ void DocumentBroker::autoSaveAndStop(const std::string& reason)
     }
 
     // Don't hammer on saving.
-    if (!canStop && _saveManager.canSaveNow())
+    if (!canStop && _saveManager.canSaveNow(isUnloading()))
     {
         // Stop if there is nothing to save.
         const bool possiblyModified = isPossiblyModified();

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -2194,7 +2194,7 @@ DocumentBroker::NeedToSave DocumentBroker::needToSaveToDisk() const
 
     assert(_saveManager.lastSaveSuccessful() && "Last save failed");
 
-    if (haveActivityAfterSaveRequest())
+    if (haveModifyActivityAfterSaveRequest())
     {
         return NeedToSave::Maybe;
     }
@@ -2361,7 +2361,7 @@ void DocumentBroker::autoSaveAndStop(const std::string& reason)
         // very late, or not at all. We care that there is nothing to upload
         // and the last save succeeded, possibly because there was no
         // modifications, and there has been no activity since.
-        if (!haveActivityAfterSaveRequest() && !_saveManager.isSaving() &&
+        if (!haveModifyActivityAfterSaveRequest() && !_saveManager.isSaving() &&
             _saveManager.lastSaveSuccessful())
         {
             // We can stop, but the modified flag is set. Delayed ModifiedStatus?

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -297,7 +297,7 @@ public:
 
     /// Check if uploading is needed, and start uploading.
     /// The current state of uploading must be introspected separately.
-    void checkAndUploadToStorage(const std::shared_ptr<ClientSession>& session);
+    void checkAndUploadToStorage(const std::shared_ptr<ClientSession>& session, bool justSaved);
 
     /// Upload the document to Storage if it needs persisting.
     /// Results are logged and broadcast to users.

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -655,7 +655,7 @@ private:
     /// since there are race conditions vis-a-vis user activity while saving.
     bool isPossiblyModified() const
     {
-        if (haveActivityAfterSaveRequest())
+        if (haveModifyActivityAfterSaveRequest())
         {
             // Always assume possible modification when we have
             // user input after sending a .uno:Save, due to racing.


### PR DESCRIPTION
This PR resolves a number of corner-cases related to disconnecting and unloading sessions.
Details in the commit logs.

- wsd: better session disconnection logic
- wsd: always-save-on-exit skips uploading as-loaded docs
- wsd: better modification detection after saving
- wsd: better data-loss detection
- wsd: test: new UnitWopiLockReadOnly test
- wsd: better detection of upload skipping for save-on-exit
- wsd: better always-save-on-exit handling
- wsd: test: enable testCrashForkit
- wsd: save and upload rapidly when unloading
