### PR TITLE
snackbar: do not block users

### DIFF
--- a/browser/css/iframedialog.css
+++ b/browser/css/iframedialog.css
@@ -1,8 +1,13 @@
 .iframe-dialog-wrap {
 	position: absolute;
 	z-index: 1106;
-	left: calc(50% - 225px);
-	top: calc(50% - 315px);
+	left: 50%;
+	top: 50%;
+}
+
+.iframe-dialog-content {
+	margin-left: -50%;
+	margin-top: -50%;
 }
 
 .iframe-dialog-modal {

--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -210,7 +210,7 @@ L.Control.JSDialog = L.Control.extend({
 			L.DomUtil.create('span', 'ui-button-icon ui-icon ui-icon-closethick', instance.titleCloseButton);
 		}
 
-		if (instance.isModalPopUp || instance.isDocumentAreaPopup)
+		if (instance.isModalPopUp || instance.isDocumentAreaPopup || instance.isSnackbar)
 			L.DomUtil.addClass(instance.container, 'modalpopup');
 
 		if (instance.isModalPopUp && !instance.popupParent) // Special case for menu popups (they are also modal dialogues).
@@ -372,7 +372,11 @@ L.Control.JSDialog = L.Control.extend({
 		var calculated = false;
 		var isRTL = document.documentElement.dir === 'rtl';
 
-		if (instance.nonModal || instance.popupParent) {
+		if (instance.isSnackbar) {
+			calculated = true;
+			instance.posx = window.innerWidth/2 - instance.form.offsetWidth/2;
+			instance.posy = window.innerHeight - instance.form.offsetHeight - 40;
+		} else if (instance.nonModal || instance.popupParent) {
 			// in case of toolbox we want to create popup positioned by toolitem not toolbox
 			if (updatedPos) {
 				calculated = true;
@@ -433,10 +437,6 @@ L.Control.JSDialog = L.Control.extend({
 					instance.posx = newLeftPosition;
 				}
 			}
-		} else if (instance.isSnackbar) {
-			calculated = true;
-			instance.posx = window.innerWidth/2 - instance.form.offsetWidth/2;
-			instance.posy = window.innerHeight - instance.form.offsetHeight - 40;
 		}
 
 		var positionNotSet = !instance.container.style || !instance.container.style.marginInlineStart;
@@ -506,7 +506,7 @@ L.Control.JSDialog = L.Control.extend({
 
 		instance.callback = e.callback;
 		instance.isSnackbar = e.data.type === 'snackbar';
-		instance.isModalPopUp = e.data.type === 'modalpopup' || instance.isSnackbar;
+		instance.isModalPopUp = e.data.type === 'modalpopup';
 		instance.isOnlyChild = false;
 		instance.that = this;
 		instance.startX = e.data.posx;
@@ -514,11 +514,11 @@ L.Control.JSDialog = L.Control.extend({
 		instance.updatePos = null;
 		instance.canHaveFocus = !instance.isSnackbar && instance.id !== 'busypopup' && !instance.isMention;
 		instance.isDocumentAreaPopup = instance.popupParent === '_POPOVER_' && instance.posx !== undefined && instance.posy !== undefined;
-		instance.isPopUp = instance.isModalPopUp || instance.isDocumentAreaPopup;
+		instance.isPopUp = instance.isModalPopUp || instance.isDocumentAreaPopup || instance.isSnackbar;
 		instance.containerParent = instance.isDocumentAreaPopup ? document.getElementById('document-container'): document.body;
 		instance.isAutofilter = instance.isDocumentAreaPopup && this.map._docLayer.isCalc();
-		instance.haveTitlebar = !instance.isModalPopUp || (instance.hasClose && instance.title && instance.title !== '');
-		instance.nonModal = !instance.isModalPopUp && !instance.isDocumentAreaPopup;
+		instance.haveTitlebar = (!instance.isModalPopUp && !instance.isSnackbar) || (instance.hasClose && instance.title && instance.title !== '');
+		instance.nonModal = !instance.isModalPopUp && !instance.isDocumentAreaPopup && !instance.isSnackbar;
 
 		// Make a better seperation between popups and modals.
 		if (instance.isDocumentAreaPopup)


### PR DESCRIPTION
Make snackbar non-modal
    
    Snackbar shoudn't block user interactions with other
    UI components. This fixes regression introduced with
    vex rework to JSDialogs where snackbar become modal.
    
    This fixes problem with "send feedback" and "Zotero"
    snackbars which block users for ~10s from editing.

------------

Center IFrameDialog using CSS
    
    instead of using hardcoded pixel distance...