### PR TITLE
fix: info level log for exceptions

### DIFF
--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -345,7 +345,7 @@ app.definitions.Socket = L.Class.extend({
 					{
 						// unpleasant - but stops this one problem
 						// event stopping an unknown number of others.
-						window.app.console.log('Exception ' + e + ' emitting event ' + evt.data);
+						window.app.console.error('Exception ' + e + ' emitting event ' + evt.data);
 					}
 					finally {
 						if (completeEventOneMessage)


### PR DESCRIPTION
-  hard to find exception if browser logs error at info level


Change-Id: I9f354480e1ee1d2da8a85973acd7b6563df83291


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

