### PR TITLE
Update Dockerfile

### DIFF
--- a/docker/from-packages/Dockerfile
+++ b/docker/from-packages/Dockerfile
@@ -4,7 +4,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-FROM debian:stable-bullseye
+FROM debian:bullseye-slim
 MAINTAINER Andras Timar <andras.timar@collabora.com>
 
 # repo: can be 'repos', 'repos-staging', 'repos-snapshot'

--- a/docker/from-packages/Dockerfile
+++ b/docker/from-packages/Dockerfile
@@ -4,7 +4,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-FROM debian:stable-slim
+FROM debian:stable-bullseye
 MAINTAINER Andras Timar <andras.timar@collabora.com>
 
 # repo: can be 'repos', 'repos-staging', 'repos-snapshot'


### PR DESCRIPTION
The sim-stable image do not found curl and broke the build


* Resolves: build image from-package 
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

