### PR TITLE
jsdialog: avoid closing parent dialog if child dialog is open

### DIFF
--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -68,6 +68,10 @@ L.Control.JSDialog = L.Control.extend({
 			return;
 		}
 
+		var newestDialog = Math.max.apply(null, Object.keys(this.dialogs).map(function(i) { return parseInt(i);}));
+		if (newestDialog > parseInt(id))
+			return;
+
 		this.focusToLastElement(id);
 
 		var builder = this.clearDialog(id);


### PR DESCRIPTION
this patch assumes that dialog ids are incremental, and no two dialogs are open at the same time unless one dialog(parent dialog) has triggered another dialog

i.e: calc advance filter dialog triggers warning dialogs, if entered an invalid range and closing the advance filter dialog before the warning dialog causes a crash of LOK


Change-Id: Ic4ba3b4553fb0ee089b1ab9b50b1c023801b674a


* Target version: master 


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

