### PR TITLE
scroll: override any pending scroll for cursor following

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -3745,6 +3745,9 @@ L.CanvasTileLayer = L.Layer.extend({
 		&& (!this.isCalc() || this._lastVisibleCursorRef !== this._visibleCursor)
 		&& this._allowViewJump()) {
 
+			// Cursor invalidation should take most precedence among all the scrolling to follow the cursor
+			// so here we disregard all the pending scrolling
+			this._map._docLayer._painter._sectionContainer.getSectionWithName(L.CSections.Scroll.name).pendingScrollEvent = null;
 			var paneRectsInLatLng = this.getPaneLatLngRectangles();
 			if (!this._visibleCursor.isInAny(paneRectsInLatLng)) {
 				if (!(this._selectionHandles.start && this._selectionHandles.start.isDragged) &&


### PR DESCRIPTION
problem:
unselecting shape would make document jump to position where cursor was before selecting the shape


Change-Id: I4aa75932631de51e84e3aca9b439f1a9a945e2d3


* Target version: master 


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

