### PR TITLE
Private/andreas kainz/dark styles preview

### DIFF
--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -452,8 +452,9 @@ button.ui-tab.notebookbar {
 	height: 30px;
 }
 
-[data-theme=dark] #stylesview {
-  filter: invert(0.85) !important;
+[data-theme='dark'] #stylesview {
+	filter: invert(0.85) hue-rotate(180deg) !important;
+	background-color: var(--color-primary-text);
 }
 
 /* Insert Tab */

--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -452,6 +452,10 @@ button.ui-tab.notebookbar {
 	height: 30px;
 }
 
+[data-theme=dark] #stylesview {
+  filter: invert(0.85) !important;
+}
+
 /* Insert Tab */
 
 /* Layout Tab */


### PR DESCRIPTION
* Resolves: #4727 
* Target version: master 

### Summary

Styles preview background was themed depend on light/dark mode.

| light | dark |
| ------- | ------ |
| ![Screenshot_20230711_005426](https://github.com/CollaboraOnline/online/assets/8517736/a291133e-5741-4a2c-a97d-c998b73e61ff) | ![Screenshot_20230711_005450](https://github.com/CollaboraOnline/online/assets/8517736/3e789e19-bea7-44d0-980a-33006f9fb2ed)  |

Same behavior than at NC office (branding part).