### PR TITLE
Fix "Dark Mode" Button Jumps to "Home" Tab

### DIFF
--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -429,8 +429,10 @@ L.Control.UIManager = L.Control.extend({
 	},
 
 	refreshNotebookbar: function() {
+		var selectedTab = $('.ui-tab.notebookbar[aria-selected="true"]').attr('id') || 'Home-tab-label';
 		this.removeNotebookbarUI();
 		this.createNotebookbarControl(this.map.getDocType());
+		$('#' + selectedTab).click();
 		this.makeSpaceForNotebookbar();
 		this.notebookbar._showNotebookbar = true;
 		this.notebookbar.showTabs();


### PR DESCRIPTION
Signed-off-by: Darshan-upadhyay1110 <darshan.upadhyay@collabora.com>
Change-Id: Id0df0ded18a5858efa15eb0942b1ec69b6a716c2


* Resolves: #6835
* Target version: master 

### Summary
After change to dark mode in notebookbar focus will stays to `view` tab.


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

