### PR TITLE
comments: fix hidden comment after lost focus in modification

### DIFF
--- a/browser/src/layer/tile/CommentSection.ts
+++ b/browser/src/layer/tile/CommentSection.ts
@@ -1108,6 +1108,8 @@ export class Comment extends CanvasSectionObject {
 	public setCollapsed(): void {
 		this.isCollapsed = true;
 
+		this.show();
+
 		if (this.isRootComment() || this.sectionProperties.docLayer._docType === 'presentation' || this.sectionProperties.docLayer._docType === 'drawing') {
 			this.sectionProperties.container.style.visibility = 'hidden';
 


### PR DESCRIPTION
after commit 51d19dd60e268ddf0a087c38dc3ad8290f4ac4c2 annotation: avoid saving comments on losing focus

We had regression causing collapsed comment to be completly hidden if user first opened 'modify mode' and clicked outside comment area. Then comment was collapsed but when selected again - content wasn't shown.

This commits makes us sure that when we select comment it has visible content.