### PR TITLE
Fix pasting image assertion

### DIFF
--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -778,16 +778,11 @@ protected:
             size_t offset = Util::isValidUtf8((unsigned char*)data, len);
             if (offset < len)
             {
-                static const char *imgModel = "child-000 paste mimetype=image/";
-                static std::regex imgRegex("^child-[0-9a-f]{3} paste mimetype=image/$");
-                bool isImagePaste = std::regex_match(data, data + strlen(imgModel), imgRegex);
-                if (!isImagePaste) {
-                    std::string raw(data, len);
-                    std::cerr << "attempting to send invalid UTF-8 message '" << raw << "' "
-                            << " error at offset " << std::hex << "0x" << offset << std::dec
-                            << " bytes, string: " << Util::dumpHex(raw) << "\n";
-                    assert("invalid utf-8 - check Message::detectType()" && false);
-                }
+                std::string raw(data, len);
+                std::cerr << "attempting to send invalid UTF-8 message '" << raw << "' "
+                          << " error at offset " << std::hex << "0x" << offset << std::dec
+                          << " bytes, string: " << Util::dumpHex(raw) << "\n";
+                assert("invalid utf-8 - check Message::detectType()" && false);
             }
         }
 #endif

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1343,7 +1343,8 @@ bool ClientSession::sendCombinedTiles(const char* /*buffer*/, int /*length*/, co
 bool ClientSession::forwardToChild(const std::string& message,
                                    const std::shared_ptr<DocumentBroker>& docBroker)
 {
-    return docBroker->forwardToChild(client_from_this(), message);
+    const bool binary = Util::startsWith(message, "paste") ? true : false;
+    return docBroker->forwardToChild(client_from_this(), message, binary);
 }
 
 bool ClientSession::filterMessage(const std::string& message) const


### PR DESCRIPTION
Revert "Avoid crash when pasting image in debug mode" This reverts commit 78558fe9af361dd0238bd3021c67e9d431dcf981.

Instead of detecting paste command and not trigerring assertion: fix frame type so it will be binary in case of paste.

