### PR TITLE
Compact view: Add missing InsertObjectStarMath (formula object)

### DIFF
--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -172,6 +172,7 @@ L.Control.Menubar = L.Control.extend({
 				{name: _('Smart Picker'), id: 'remotelink', type: 'action'},
 				{type: 'separator'},
 				{uno: '.uno:InsertSymbol'},
+				{uno: '.uno:InsertObjectStarMath'},
 				{name: _UNO('.uno:FormattingMarkMenu', 'text'), type: 'menu', menu: [
 					{uno: '.uno:InsertNonBreakingSpace'},
 					{uno: '.uno:InsertHardHyphen'},


### PR DESCRIPTION
Before this commit this option was only available on tabbed view

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I6e027f1b84d09e802f7ea6c6fd9e5144cae2eb91
