### PR TITLE
wsd: avoid cursor invalidation if cursor becomes not visible

### DIFF
--- a/common/MessageQueue.cpp
+++ b/common/MessageQueue.cpp
@@ -448,6 +448,17 @@ std::string TileQueue::removeCallbackDuplicate(const std::string& callbackMsg)
                         break;
                     }
                 }
+
+                // if cursor is not visible we can ignore cursor invalidate msgs too
+                if (callbackType ==  LOK_CALLBACK_CURSOR_VISIBLE
+                    && tokens.equals(3, "false")
+                    && static_cast<LibreOfficeKitCallbackType>(Util::i32FromString(queuedTokens[2]).first) == LOK_CALLBACK_INVALIDATE_VISIBLE_CURSOR)
+                    {
+                        LOG_TRC("Remove obsolete cursor invalidate callback: "
+                                << std::string(it.data(), it.size()) << " -> "
+                                << COOLProtocol::getAbbreviatedMessage(callbackMsg));
+                        getQueue().erase(getQueue().begin() + i);
+                    }
             }
         }
         break;


### PR DESCRIPTION
this also helps in avoiding flickering of keyboard in mobile in some cases

Change-Id: I59312ca93136cd6bd13ad958dab0e72242f839e1

* Target version: master 


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

