### PR TITLE
Enter shouldn't be a requirement to trigger a tab or a button

### DIFF
--- a/browser/src/dom/NotebookbarAccessibility.js
+++ b/browser/src/dom/NotebookbarAccessibility.js
@@ -225,12 +225,6 @@ var NotebookbarAccessibility = function() {
 				this.resetState();
 			}
 		}
-		else if (key === 'ENTER' || key === ' ') {
-			if (this.filteredItem !== null)
-				this.clickOnFilteredItem();
-			else
-				app.map.focus();
-		}
 		else if (event.keyCode === 16) // ShiftLeft.
 			return; // Ignore shift key.
 		else if (key === 'ARROWUP') {
@@ -261,7 +255,8 @@ var NotebookbarAccessibility = function() {
 				this.checkCombinationAgainstAcccelerators();
 				this.filterOutNonMatchingInfoBoxes();
 			}
-
+			if (this.filteredItem !== null)
+				this.clickOnFilteredItem();
 			// So we checked the pressed key against available combinations. If there is no match, focus back to map.
 			if (this.isAllFilteredOut() === true)
 				app.map.focus();


### PR DESCRIPTION

Change-Id: I9ab9e004e9dc883d18b8f750a9a400e1f318240e

* Resolves: 
* Target version: master 

### Summary

Enter key will not be necessary to change tab by accessibility key
