### PR TITLE
paste: cleanup excessive debugging.

### DIFF
--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -778,10 +778,29 @@ protected:
             size_t offset = Util::isValidUtf8((unsigned char*)data, len);
             if (offset < len)
             {
-                std::string raw(data, len);
+                std::string hex, raw;
+                if (len < 256)
+                {
+                    raw = std::string(data, len);
+                    hex = "whole string:" + Util::dumpHex(raw);
+                }
+                else
+                {
+                    // 64 bytes before & after ...
+                    size_t cropstart, croplen;
+                    if (offset < 64)
+                        cropstart = 0;
+                    else
+                        cropstart = offset - 64;
+                    croplen = std::min<size_t>(len - cropstart, 128);
+                    assert (cropstart + croplen <= len);
+                    raw = std::string(data + cropstart, croplen);
+                    hex = "msg: "+ COOLProtocol::getAbbreviatedMessage(data, len) +
+                        " string region error at byte " + std::to_string(offset - cropstart) + ": " + Util::dumpHex(raw);
+                };
                 std::cerr << "attempting to send invalid UTF-8 message '" << raw << "' "
                           << " error at offset " << std::hex << "0x" << offset << std::dec
-                          << " bytes, string: " << Util::dumpHex(raw) << "\n";
+                          << " bytes, " << hex << "\n";
                 assert("invalid utf-8 - check Message::detectType()" && false);
             }
         }

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -3553,8 +3553,10 @@ bool DocumentBroker::forwardToChild(const std::shared_ptr<ClientSession>& sessio
 
     LOG_TRC("Forwarding payload to child [" << viewId << "]: " << getAbbreviatedMessage(message));
 
+#if 0 // extreme paste debugging - message can be giant and binary
     if (Log::traceEnabled() && Util::startsWith(message, "paste "))
         LOG_TRC("Logging paste payload (" << message.size() << " bytes) '" << message << "' end paste");
+#endif
 
     std::string msg = "child-" + viewId + ' ';
     if (Util::startsWith(message, "load "))


### PR DESCRIPTION
We don't want to dump the whole paste buffer as hex, or indeed any large mis-encoded string - instead crop to the problematic section for easier debugging, and no performance hit.

Change-Id: I30518beea436895a42b3429c3cb6e16e2093cca9


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

