### PR TITLE
calc: blur address bar when tapped on sheet

### DIFF
--- a/browser/src/control/Control.FormulaBar.js
+++ b/browser/src/control/Control.FormulaBar.js
@@ -120,7 +120,6 @@ L.Control.FormulaBar = L.Control.extend({
 	onAddressInput: function(e) {
 		if (e.keyCode === 13) {
 			// address control should not have focus anymore
-			$('#addressInput').blur();
 			this.map.focus();
 			var value = L.DomUtil.get('addressInput').value;
 			var command = {
@@ -133,7 +132,6 @@ L.Control.FormulaBar = L.Control.extend({
 			this.map.sendUnoCommand('.uno:GoToCell', command);
 		} else if (e.keyCode === 27) { // 27 = esc key
 			this.map.sendUnoCommand('.uno:Cancel');
-			$('#addressInput').blur();
 			this.map.focus();
 		}
 	}
@@ -188,6 +186,7 @@ L.Map.include({
 		}, 250);
 
 		map.formulabar.blurField();
+		$('#addressInput').blur();
 	}
 });
 


### PR DESCRIPTION
problem:
regression from 919db16
when address input has focus and keyboard is open, tapping on sheet would not close keyboard and bring focus back to map only way to close keyboard and focus map was to accept the input


Change-Id: I2c6f23be9efcbbe8e4d47d11505074a75abc000f


* Target version: master 


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

