### PR TITLE
Calc: fix document background. It should be white.

### DIFF
--- a/browser/css/color-palette-dark.css
+++ b/browser/css/color-palette-dark.css
@@ -12,6 +12,7 @@
 	--color-text-lighter: #fff; /* secondard text, disabled */
 
 	--color-canvas: #121212;
+	--color-background-document: #121212;
 	--color-main-background: #121212;
 	--color-background-dark: #1E1E1E;  /* select */
 	--color-background-darker: #000;  /* todo: apply to pressed (active), li:hover(top menu on classic mode)*/

--- a/browser/css/color-palette.css
+++ b/browser/css/color-palette.css
@@ -13,6 +13,7 @@
 	--color-text-lighter: #696969; /* secondard text, disabled */
 
 	--color-canvas: #F8F9FA;
+	--color-background-document: #FFFFFF;
 	--color-main-background: #F8F9FA;
 	--color-background-dark: #e8e8e8;  /* select */
 	--color-background-darker: #c0bfbc;  /* todo: apply to pressed (active), li:hover(top menu on classic mode)*/

--- a/browser/src/layer/tile/CanvasSectionContainer.ts
+++ b/browser/src/layer/tile/CanvasSectionContainer.ts
@@ -559,10 +559,15 @@ class CanvasSectionContainer {
 		this.clearColor = window.getComputedStyle(document.documentElement).getPropertyValue('--color-canvas');
 		// Set document background color to the app background color for now until we get the real color from the kit
 		// through a LOK_CALLBACK_DOCUMENT_BACKGROUND_COLOR
-		this.documentBackgroundColor = window.getComputedStyle(document.documentElement).getPropertyValue('--color-canvas');
+		this.documentBackgroundColor = window.getComputedStyle(document.documentElement).getPropertyValue('--color-background-document');
 
-		if (disableDrawing)
+		// If CanvasTileLayer.js:this._layer.isCalc()
+		if (disableDrawing) {
+			// On Calc cells have no color, so let's set canvas color with document bg
+			this.clearColor = this.documentBackgroundColor;
+
 			this.disableDrawing();
+		}
 	}
 
 	private clearCanvas() {


### PR DESCRIPTION
With c04c065edcfe9e00e4f7e50834e6317caaceb9ea we start to dynamically
set the canvas background. The problem is that for Calc cells do not
have intrinsically a background and thus what we end up to see as the
document background color is actually the canvas color.
	 - Make sure that when we are in presence of calc we set the
	 canvas color (clearColor) with the value coming from
	 documentBackgroundColor
	 - To make it clear: create a new CSS variable to be used as
	 background-document

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I4c456e4aeea233609ee58684d967984dd8afd63a
