### PR TITLE
Don't add outline to ShowInfoModal that have no buttons

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -27,6 +27,9 @@
 	/* Annotations */
 	--annotation-input-size: 100px;
 }
+.focus-hidden:focus {
+	outline: none;
+}
 
 .access-key {
 	text-decoration: none;

--- a/browser/src/control/Control.IdleHandler.ts
+++ b/browser/src/control/Control.IdleHandler.ts
@@ -74,8 +74,6 @@ class IdleHandler {
 
 		this.map.uiManager.showInfoModal('inactive_user_message');
 		document.getElementById('inactive_user_message').textContent = message;
-		document.getElementById('inactive_user_message').tabIndex = 0;
-		document.getElementById('inactive_user_message').focus(); // We hid the OK button, we need to set focus manually on the popup.
 
 		if (message === '') {
 			document.getElementById(this.map.uiManager.generateModalId('inactive_user_message')).style.display = 'none';

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -1057,6 +1057,13 @@ L.Control.UIManager = L.Control.extend({
 				that.closeModal(dialogId);
 			}}
 		], cancelButtonId);
+		if (!buttonText && !withCancel) {
+			// if no buttons better to set tabIndex to negative so the element is not reachable via sequential keyboard navigation but can be focused programatically
+			document.getElementById(dialogId).tabIndex = -1;
+			// We hid the OK button, we need to set focus manually on the popup.
+			document.getElementById(dialogId).focus();
+			document.getElementById(dialogId).className += ' focus-hidden';
+		}
 	},
 
 	/// buttonObjectList: [{id: button's id, text: button's text, ..other properties if needed}, ...]

--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -895,8 +895,6 @@ L.Clipboard = L.Class.extend({
 
 		this._map.uiManager.showInfoModal('large_copy_paste_warning');
 		document.getElementById('large_copy_paste_warning').innerHTML = this._substProductName(msg);
-		document.getElementById('large_copy_paste_warning').tabIndex = 0;
-		document.getElementById('large_copy_paste_warning').focus(); // We hid the OK button, we need to set focus manually on the popup.
 	},
 
 	_warnLargeCopyPasteAlreadyStarted: function () {


### PR DESCRIPTION
Large Clipboard  and document idle modals were being set with tabindex
0 allowing for manual user focus plus were being focused dynamically
for each instance:
    - Transfer all that (just once) to showinfomodal instead for the
    cases where we have buttons
        - This in turn sets the things to the parent (dialog itself)
	and not the subcontianer
        - Set tabIndex with negative value so, it only allows focus via
    code
    - This fixes the weird outline (focus) that sometimes would appear
    on sub containers of that dialog instances

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: If40192e05c4b0e25e2ce71bc612ab64fc54a29ec
