### PR TITLE
jsdialog: don't block uno commands when snackbar is shown

### DIFF
--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -28,7 +28,9 @@ L.Control.JSDialog = L.Control.extend({
 	},
 
 	hasDialogOpened: function() {
-		return Object.keys(this.dialogs).length > 0;
+		return Object.keys(this.dialogs)
+			.filter(function (key) { return key != 'snackbar'; })
+			.length > 0;
 	},
 
 	clearDialog: function(id) {


### PR DESCRIPTION
when any dialog is shown we block executing uno commands don't count snackbar as a dialog and allow full interaction of the user when snackbar is shown
