### PR TITLE
Prevent view from jumping on pressing alt key

### DIFF
--- a/browser/src/dom/NotebookbarAccessibility.js
+++ b/browser/src/dom/NotebookbarAccessibility.js
@@ -312,7 +312,7 @@ var NotebookbarAccessibility = function() {
 		container.style.overflow = 'hidden';
 		container.appendChild(this.accessibilityInputElement);
 
-		document.body.appendChild(container);
+		document.body.insertBefore(container, document.body.firstChild);
 	};
 
 	this.initialize = function() {


### PR DESCRIPTION
this.accessibilityInputElement.focus();

line in onDocumentKeyUp in browser/src/dom/NotebookbarAccessibility.js caused view to jump, in result half of the screen was white when document was very long and had comment inside

To fix this insert accessibility input at the beginning of the DOM so browser will not try to scroll anything when it is focused.

this is regression introduced in:
commit 3e40f3fbe4a853f36fa540120a21acafeb234b08
Add functionality for notebookbar accessibility keys.
