### PR TITLE
wsd: trim memory on idling

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -13,6 +13,7 @@
 #include <config_version.h>
 
 #include <dlfcn.h>
+#include <limits>
 #ifdef __linux__
 #include <ftw.h>
 #include <sys/vfs.h>
@@ -708,6 +709,7 @@ public:
         _stop(false),
         _editorId(-1),
         _editorChangeWarning(false),
+        _lastMemTrimTime(std::chrono::steady_clock::now()),
         _mobileAppDocId(mobileAppDocId),
         _inputProcessingEnabled(true)
     {
@@ -980,6 +982,34 @@ public:
         LOG_WRN("Sessions are all inactive - trim memory");
         _loKit->trimMemory(4096);
         _deltaGen.dropCache();
+    }
+
+    void trimIfExcessive()
+    {
+        LOG_TRC("Should we trim our caches ?");
+        if (std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() -
+                                                             _lastMemTrimTime) < std::chrono::seconds(30))
+        {
+            LOG_TRC("Too soon to trim again");
+            return;
+        }
+
+        double minInactivityMs = std::numeric_limits<double>::max();
+        for (const auto& it : _sessions)
+        {
+            minInactivityMs = std::min(it.second->getInactivityMS(), minInactivityMs);
+        }
+
+        if (minInactivityMs >= 9999)
+        {
+            LOG_DBG("Trimming Core caches");
+            _loKit->trimMemory(4096);
+
+            LOG_DBG("Dropping delta caches");
+            _deltaGen.dropCache();
+
+            _lastMemTrimTime = std::chrono::steady_clock::now();
+        }
     }
 
     static void GlobalCallback(const int type, const char* p, void* data)
@@ -2108,6 +2138,9 @@ private:
     std::map<int, std::unique_ptr<CallbackDescriptor>> _viewIdToCallbackDescr;
     SessionMap<ChildSession> _sessions;
 
+    /// The timestamp of the last memory trimming.
+    std::chrono::steady_clock::time_point _lastMemTrimTime;
+
     std::map<int, std::chrono::steady_clock::time_point> _lastUpdatedAt;
     std::map<int, int> _speedCount;
     /// For showing disconnected user info in the doc repair dialog.
@@ -2343,10 +2376,15 @@ public:
             if (remainingTime < std::chrono::microseconds(timeoutMicroS))
                 _document->checkIdle();
             else
-                LOG_TRC("Poll of woudl not close gap - continuing");
+                LOG_TRC("Poll of would not close gap - continuing");
         }
 
         drainQueue();
+
+        if (_document)
+        {
+            _document->trimIfExcessive();
+        }
 
 #if !MOBILEAPP
         flushTraceEventRecordings();


### PR DESCRIPTION
When all users idle their activities
for at least 10 seconds, we take the
opportunity to trim the memory footprint.

We are careful not to issue a subsequent
trimming too soon. A minimum of 30 seconds
needs to pass to trim again. This should
give a decent balance between performance
and reduced memory footprint.

Change-Id: I1c8b2c4a265c9aa0ac5033762695706ad970f11e
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
