### PR TITLE
rle: optimize inner loop bit-bashing.

### DIFF
--- a/test/DeltaTests.cpp
+++ b/test/DeltaTests.cpp
@@ -280,6 +280,18 @@ void DeltaTests::testRle()
         LOK_ASSERT_EQUAL(data[i], it.getPixel());
         it.next();
     }
+
+    const uint32_t empty[256] = { 0, };
+    DeltaGenerator::DeltaBitmapRow rowc;
+    rowc.initRow(empty, 256);
+    LOK_ASSERT(!rowa.identical(rowc));
+    LOK_ASSERT(!rowb.identical(rowc));
+    DeltaGenerator::DeltaBitmapRow::PixIterator it2(rowc);
+    for (uint32_t i = 0; i < 256; ++i)
+    {
+        LOK_ASSERT_EQUAL(empty[i], it2.getPixel());
+        it2.next();
+    }
 }
 
 void DeltaTests::testRleComplex()


### PR DESCRIPTION
Simplified code:

+ re-use the bit mask as an inner loop counter.
+ turn alpha only rows into zero length with agreed lastPix.
+ keep lastPix around on the stack.
+ handle odd widths in a duplicate slow-path

Change-Id: Ibc7630f7187ea5f4904c6fed14dda28cdfbf7523

rle: further optimize the pixel reading & de-compression.


Change-Id: Ifcaaa45d1de6532b3fd43015c47a37daf56c2ea5


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

