### PR TITLE
LOK_CALLBACK_DOCUMENT_SIZE_CHANGED is different per view

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1198,10 +1198,8 @@ public:
         }
 
         // merge various callback types together if possible
-        if (type == LOK_CALLBACK_INVALIDATE_TILES ||
-            type == LOK_CALLBACK_DOCUMENT_SIZE_CHANGED)
+        if (type == LOK_CALLBACK_INVALIDATE_TILES)
         {
-            // no point in handling invalidations or page resizes per-view,
             // all views have to be in sync
             tileQueue->put("callback all " + std::to_string(type) + ' ' + payload);
         }


### PR DESCRIPTION
In calc and impress we send different data depending on the view in status: message which is triggered by LOK_CALLBACK_DOCUMENT_SIZE_CHANGED. Every view can be on a different part / sheet / slide where document size can be also independent.

This helps to reduce status: messages sent to other view when switching sheets in other view.