### PR TITLE
refactor: Toolbar down icons: remove unnecessary !important rule

### DIFF
--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -76,11 +76,11 @@
 }
 
 #tb_actionbar_item_prev .w2ui-icon.prev {
-	background: url('images/lc_prevrecord.svg') no-repeat center/24px !important;
+	background: url('images/lc_prevrecord.svg') no-repeat center/24px;
 }
 
 #tb_actionbar_item_next .w2ui-icon.next {
-	background: url('images/lc_nextrecord.svg') no-repeat center/24px !important;
+	background: url('images/lc_nextrecord.svg') no-repeat center/24px;
 }
 
 .w2ui-icon-check:before {
@@ -1318,11 +1318,11 @@ button.leaflet-control-search-next
 [data-theme='dark'] .w2ui-icon.frame12 { background: url('images/dark/fr012.svg') no-repeat center; }
 
 [data-theme='dark'] #tb_actionbar_item_prev .w2ui-icon.prev {
-	background: url('images/dark/lc_prevrecord.svg') no-repeat center/24px !important;
+	background: url('images/dark/lc_prevrecord.svg') no-repeat center/24px;
 }
 
 [data-theme='dark'] #tb_actionbar_item_next .w2ui-icon.next {
-	background: url('images/dark/lc_nextrecord.svg') no-repeat center/24px !important;
+	background: url('images/dark/lc_nextrecord.svg') no-repeat center/24px;
 }
 
 .inserttable-pop {


### PR DESCRIPTION
If we set the initial backgrounds without `!important` then there is
no need to use `!important` for dark-mode (since we are already using
a more specific targe via data-them attribute)

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I600629dfc0485edac6ff725f6278de1501e1c9a7
