### PR TITLE
Revert "Fix wrong device detection logic."

### DIFF
--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -253,7 +253,7 @@ window.app = {
 				return true;
 			}
 
-			return L.Browser.mobile && (window.innerWidth < 768 || window.innerHeight < 768);
+			return L.Browser.mobile && (screen.width < 768 || screen.height < 768);
 		},
 		// Mobile device with big screen size.
 		isTablet: function() {


### PR DESCRIPTION
On actual iPad (2048x1536 native, 1024x768 browser), in landscape view in Safari, mobile phone view is shown in online instead of tablet.

This reverts commit f1e9ee72fe48d21ac7a78b7702055b91ba8f3ba9.


Change-Id: I2cd4ba6cdcd616760c06c7db479e6d13be3d83b4


* Resolves: # <!-- related github issue -->
* Target version: master 

### Checklist

- [X] Code is properly formatted
- [X] All commits have Change-Id
- [ ] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

