### PR TITLE
formulabar: fixed scrollIntoView caused problems

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -1916,18 +1916,6 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		}
 	},
 
-	_scrollIntoViewBlockOption: function(option) {
-		if (option === 'nearest' || option === 'center') {
-			// compatibility with older firefox
-			var match = window.navigator.userAgent.match(/Firefox\/([0-9]+)\./);
-			var firefoxVer = match ? parseInt(match[1]) : 58;
-			var blockOption = firefoxVer >= 58 ? option : 'start';
-			return blockOption;
-		}
-
-		return option;
-	},
-
 	_iconViewControl: function (parentContainer, data, builder) {
 		var container = L.DomUtil.create('div', builder.options.cssClass + ' ui-iconview', parentContainer);
 		container.id = data.id;
@@ -1941,7 +1929,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		}
 
 		var firstSelected = $(container).children('.selected').get(0);
-		var blockOption = builder._scrollIntoViewBlockOption('nearest');
+		var blockOption = JSDialog._scrollIntoViewBlockOption('nearest');
 		if (firstSelected)
 			firstSelected.scrollIntoView({behavior: 'smooth', block: blockOption, inline: 'nearest'});
 
@@ -3245,7 +3233,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 
 			if (entry) {
 				L.DomUtil.addClass(entry, 'selected');
-				var blockOption = this._scrollIntoViewBlockOption('nearest');
+				var blockOption = JSDialog._scrollIntoViewBlockOption('nearest');
 				entry.scrollIntoView({behavior: 'smooth', block: blockOption, inline: 'nearest'});
 			} else if (pos != -1)
 				console.warn('not found entry: "' + pos + '" in: "' + data.control_id + '"');
@@ -3560,6 +3548,18 @@ L.Control.JSDialogBuilder.getMenuStructureForMobileWizard = function(menu, mainM
 	}
 
 	return menuStructure;
+};
+
+JSDialog._scrollIntoViewBlockOption = function(option) {
+	if (option === 'nearest' || option === 'center') {
+		// compatibility with older firefox
+		var match = window.navigator.userAgent.match(/Firefox\/([0-9]+)\./);
+		var firefoxVer = match ? parseInt(match[1]) : 58;
+		var blockOption = firefoxVer >= 58 ? option : 'start';
+		return blockOption;
+	}
+
+	return option;
 };
 
 L.control.jsDialogBuilder = function (options) {

--- a/browser/src/control/jsdialog/Widget.FormulabarEdit.js
+++ b/browser/src/control/jsdialog/Widget.FormulabarEdit.js
@@ -99,7 +99,8 @@ function _appendNewLine(cursorLayer) {
 function _appendCursor(cursorLayer) {
 	var cursor = L.DomUtil.create('span', 'cursor');
 	cursorLayer.appendChild(cursor);
-	cursor.scrollIntoView();
+	var blockOption = JSDialog._scrollIntoViewBlockOption('nearest');
+	cursor.scrollIntoView({behavior: 'smooth', block: blockOption, inline: 'nearest'});
 }
 
 function _setSelection(cursorLayer, text, startX, endX, startY, endY) {


### PR DESCRIPTION
in some browser scrollIntoView causes problem without parameters in this particular case problem was entire view being pushed upwords out of view reproducing steps:
Open a spreadsheet in two views,
With 1st view, navigate to bottom right corner via Ctrl+⬇ and Ctrl+➡, With 1st view, type something in that cell, and then the cell above (stay editing the cell, don't press Enter), With 2nd view, start typing in A1.

2nd view's editing view is pushed upwards


Change-Id: I4bc551de321483608eb210718c1d81a622de5a6d


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

