### PR TITLE
deltas: don't drop delta cache on 10 seconds idleness.

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1005,9 +1005,6 @@ public:
             LOG_DBG("Trimming Core caches");
             _loKit->trimMemory(4096);
 
-            LOG_DBG("Dropping delta caches");
-            _deltaGen.dropCache();
-
             _lastMemTrimTime = std::chrono::steady_clock::now();
         }
     }


### PR DESCRIPTION
This would have only a small impact on memory use, and a large impact on interactivity, performance and bandwidth use. So lets not do that.


Change-Id: I07b2538cd4f5cd2c91926cfabeaa159dd992b068


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

