### PR TITLE
Remove view selection on user disconnection

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -2877,9 +2877,12 @@ L.CanvasTileLayer = L.Layer.extend({
 
 	_removeView: function(viewId) {
 		// Remove selection, if any.
-		if (this._viewSelections[viewId] && this._viewSelections[viewId].selection) {
-			this._viewSelections[viewId].selection.remove();
-			this._viewSelections[viewId].selection = undefined;
+		if (this._viewSelections[viewId]) {
+			if (this._viewSelections[viewId].selection) {
+				this._viewSelections[viewId].selection.remove();
+				this._viewSelections[viewId].selection = undefined;
+			}
+			delete this._viewSelections[viewId];
 		}
 
 		// Remove the view and update (to refresh as needed).


### PR DESCRIPTION
Fixes type error on switching sheets in Calc:

Steps to reproduce:
1. Open Calc spreadsheet with 2 sheets and 2 user sessions
2. Switch user A to sheet 1
3. Switch with user B to sheet 2 and select few cells
4. close user B browser / tab
5. switch user A to sheet 2