### PR TITLE
config: Fix 'warn_unused_result' during build

### DIFF
--- a/tools/Config.cpp
+++ b/tools/Config.cpp
@@ -477,7 +477,9 @@ int Config::main(const std::vector<std::string>& args)
             proofKey.save(proofKeyPath + ".pub", proofKeyPath, "" /*no password*/);
 #if !ENABLE_DEBUG
             chmod(proofKeyPath.c_str(), S_IRUSR | S_IWUSR);
-            chown(proofKeyPath.c_str(), pwd->pw_uid, -1);
+            const int ChResult = chown(proofKeyPath.c_str(), pwd->pw_uid, -1);
+            if (ChResult != 0)
+                std::cerr << "Changing owner of " + proofKeyPath + " failed." << std::endl;
 #endif
         }
         else


### PR DESCRIPTION
tools/Config.cpp: In member function 'virtual int Config::main(const std::vector<std::basic_string<char> >&)': tools/Config.cpp:480:18: error: ignoring return value of 'int chown(const char*, __uid_t, __gid_t)' declared with attribute 'warn_unused_result' [-Werror=unused-result]
  480 |             chown(proofKeyPath.c_str(), pwd->pw_uid, -1);
      |             ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

From fc946198d39da83e829eed4c852f904631f45e0f


Change-Id: Iaa4db6fb4dc6f742779754d4e05708aa8f41ebd6

* Target version: master 

### Checklist

- [X] Code is properly formatted
- [X] All commits have Change-Id
- [ ] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

