### PR TITLE
Fix Direct change by accesskey from Home to Insert tab triggers bullet command

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -512,6 +512,11 @@ L.Control.JSDialogBuilder = L.Control.extend({
 				element.accessKey = key;
 	},
 
+	_resetAccessKeyForCurrentTab: function() {
+		if (app.UI.notebookbarAccessibility)
+			app.UI.notebookbarAccessibility.resetAccessKeyForCurrentTab();
+	},
+
 	_getAccessKeyFromText: function(text) {
 		var nextChar = null;
 		if (text && text.includes('~')) {
@@ -1255,6 +1260,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 				};
 
 				var moveFocusToPreviousTab = function(tab) {
+					builder._resetAccessKeyForCurrentTab();
 					if (tab === tabs[0]) {
 						tabs[tabs.length - 1].click();
 						tabs[tabs.length - 1].focus();
@@ -1267,6 +1273,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 				};
 
 				var moveFocusToNextTab = function(tab) {
+					builder._resetAccessKeyForCurrentTab();
 					if (tab === tabs[tabs.length - 1]) {
 						tabs[0].click();
 						tabs[0].focus();

--- a/browser/src/dom/NotebookbarAccessibility.js
+++ b/browser/src/dom/NotebookbarAccessibility.js
@@ -95,6 +95,7 @@ var NotebookbarAccessibility = function() {
 			}
 			else if (event.keyCode === 18 || (event.keyCode === 18 && event.shiftKey)) {
 				this.mayShowAcceleratorInfoBoxes = true;
+				this.resetAccessKeyForCurrentTab();
 			}
 		}
 	};
@@ -219,6 +220,7 @@ var NotebookbarAccessibility = function() {
 		if (element) {
 			element.classList.remove('add-focus-to-tab');
 		}
+		this.resetAccessKeyForCurrentTab();
 	};
 
 	this.focusToMap = function () {
@@ -238,6 +240,16 @@ var NotebookbarAccessibility = function() {
 		this.combination = null;
 		this.mayShowAcceleratorInfoBoxes = false;
 		this.filteredItem = null;
+	};
+
+	this.onInputKeyDown = function(event) {
+		var key = event.key.toUpperCase();
+		event.preventDefault();
+		event.stopPropagation();
+
+		if (key === 'ESCAPE' || key === 'ALT') {
+			this.resetAccessKeyForCurrentTab();
+		}
 	};
 
 	this.onInputKeyUp = function(event) {
@@ -326,6 +338,16 @@ var NotebookbarAccessibility = function() {
 		}
 	};
 
+	this.resetAccessKeyForCurrentTab = function() {
+		for (var i = 0; i < this.activeTabPointers.contentList.length; i++) {
+			var element = this.getElementOfWhichIdStartsWith(this.activeTabPointers.contentList[i].id);
+			if (element) {
+			  // Remove the accesskey attribute from the element
+			  element.removeAttribute('accesskey');
+			}
+		  }
+	};
+
 	this.addTabAccelerators = function() {
 		// Remove all info boxes first.
 		this.removeAllInfoBoxes();
@@ -368,6 +390,7 @@ var NotebookbarAccessibility = function() {
 		this.accessibilityInputElement.onfocus = this.onInputFocus.bind(this);
 		this.accessibilityInputElement.onblur = this.onInputBlur.bind(this);
 		this.accessibilityInputElement.onkeyup = this.onInputKeyUp.bind(this);
+		this.accessibilityInputElement.onkeydown = this.onInputKeyDown.bind(this);
 
 		var container = document.createElement('div');
 		container.style.width = container.style.height = '0';


### PR DESCRIPTION
Change-Id: Iaace6bfc446e91b638494a4dc69dce611b1e3bf8
Signed-off-by: Darshan-upadhyay1110 [darshan.upadhyay@collabora.com](mailto:darshan.upadhyay@collabora.com)

* Resolves: #
* Target version: master 

### Summary
 press alt (shift + alt) at all the tab's content shortcuts shouldn't be accessible and their hints shouldn't be visible.
