### PR TITLE
Github "New Issue" Template Fixes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,35 +7,44 @@ assignees: ''
 
 ---
 
-**Describe the bug**
+### Describe the Bug
+
 A clear and concise description of what the bug is.
 
-**To Reproduce**
-Steps to reproduce the behavior:
+### Steps to Reproduce
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-**Expected behavior**
+### Expected Behavior
+
 A clear and concise description of what you expected to happen.
 
-**Actual behavior**
+### Actual Behavior
+
 A clear and concise description of what actually happens.
 
-**Screenshots**
+### Screenshots
+
 If applicable, add screenshots to help explain your problem.
 
-**Desktop (please complete the following information)**
- - OS: [e.g. iOS]
- - Browser: [e.g. chrome, safari]
- - Version: [e.g. 22]
+### Desktop
 
-**Smartphone (please complete the following information)**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser: [e.g. stock browser, safari]
- - Version: [e.g. 22]
+(Please complete the following information)
+ - **OS:** [e.g. Windows 11]
+ - **Browser:** [e.g. Chrome]
+ - **Version:** [e.g. 114.0]
 
-**Additional context**
+### Smartphone
+
+(Please complete the following information)
+ - **Device:** [e.g. iPhone14]
+ - **OS:** [e.g. iOS16.5]
+ - **Browser:** [e.g. Safari]
+ - **Version:** [e.g. 16.4]
+
+### Additional Context
+
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report_smoke-test.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_smoke-test.md
@@ -7,36 +7,42 @@ assignees: ''
 
 ---
 
-**Describe the bug**
+### Describe the Bug
+
 A clear and concise description of what the bug is.
 
-**To Reproduce**
-Steps to reproduce the behavior:
+### Steps to Reproduce
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-**Expected behavior**
+### Expected Behavior
 A clear and concise description of what you expected to happen.
 
-**Actual behavior**
+### Actual Behavior
+
 A clear and concise description of what actually happens.
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+### Screenshots
 
-**Desktop (please complete the following information)**
- - OS: [e.g. iOS]
- - Browser: [e.g. chrome, safari]
- - Version: [e.g. 22]
+### Desktop
 
-**Smartphone (please complete the following information)**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser: [e.g. stock browser, safari]
- - Version: [e.g. 22]
+(Please complete the following information)
+ - **OS:** [e.g. Windows 11]
+ - **Browser:** [e.g. Chrome]
+ - **Version:** [e.g. 114.0]
 
-**Additional context**
+### Smartphone
+
+(Please complete the following information)
+ - **Device:** [e.g. iPhone14]
+ - **OS:** [e.g. iOS16.5]
+ - **Browser:** [e.g. Safari]
+ - **Version:** [e.g. 16.4]
+
+### Additional Context
+
 https://github.com/CollaboraOnline/online/discussions/3461
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,14 +7,22 @@ assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+### Is your feature request related to a problem?
 
-**Describe the solution you'd like**
+A clear and concise description of what the problem is.
+
+[Example: I want to do X, but because of PROBLEM, it takes 5 extra steps instead of 1.]
+
+### Describe the solution you'd like
+
 A clear and concise description of what you want to happen.
 
-**Describe alternatives you've considered**
+[Example: When I press on X, I think Y should happen. In other software, this exists under the "Help" tab.]
+
+### Describe alternatives you've considered
+
 A clear and concise description of any alternative solutions or features you've considered.
 
-**Additional context**
+### Additional context
+
 Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
### Summary

I added Headings + updated some wording/examples in:

- Bug Report
- Bug Report (Smoke Test)
- Feature Request

so when users submit a "New Issue" to Github, it will look nicer.

- - -

**Note:** This is a redo of PR #6944, this time with the required "signed-off-by" lines.

- - -

### TODO

I think some of these, especially Bug Reports, could use an overhaul to:

- Use Text Boxes
   - Instead of having users manually deleting strings.

and add a new section for:

- **Help > About** info.
   - Getting exact versions from users would help QA with testing/debugging.

### Checklist

- [x] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required