### PR TITLE
calc insert comment checks undefined tab field

### DIFF
--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -23,7 +23,7 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 
 		for (var i = 0; i < commentList.length; i++) {
 			if (this._cellCursorTwips.contains(commentList[i].sectionProperties.data.cellPos)) {
-				if (commentList[i].tab == this._selectedPart) {
+				if (commentList[i].sectionProperties.data.tab == this._selectedPart) {
 					comment = commentList[i];
 					break;
 				}


### PR DESCRIPTION
and so this loop never finds anything, the intent is clearly to find an existing comment in this cell so use the right field for that.

possibly a problem since:

commit 922ae4924ad36b501eff187b57aa940bb1a02d9a
Date:   Wed Jan 26 15:08:31 2022 +0300

    calc: Fix new comments do not check tabid on insert


Change-Id: I11208493ef7eae6a01576d90129b25ed9f792d62


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

