### PR TITLE
Draw dark mode fixes

### DIFF
--- a/browser/src/control/Control.PartsPreview.js
+++ b/browser/src/control/Control.PartsPreview.js
@@ -374,6 +374,9 @@ L.Control.PartsPreview = L.Control.extend({
 	},
 
 	_layoutPreview: function (i, img, bottomBound) {
+		if (this._map._docLayer._canonicalViewId == -1) {
+			return;
+		}
 		var topBound = this._previewContTop;
 		var previewFrameTop = 0;
 		var previewFrameBottom = 0;

--- a/browser/src/control/Parts.js
+++ b/browser/src/control/Parts.js
@@ -170,9 +170,14 @@ L.Map.include({
 		if (!this._docPreviews) {
 			this._docPreviews = {};
 		}
+
 		var autoUpdate = options ? !!options.autoUpdate : false;
 		var fetchThumbnail = options && options.fetchThumbnail ? options.fetchThumbnail : true;
 		this._docPreviews[id] = {id: id, index: index, maxWidth: maxWidth, maxHeight: maxHeight, autoUpdate: autoUpdate, invalid: false};
+
+		if (this._docLayer._canonicalViewId == -1) {
+			return;
+		}
 
 		var docLayer = this._docLayer;
 		if (docLayer._docType === 'text') {
@@ -198,7 +203,7 @@ L.Map.include({
 		if (fetchThumbnail) {
 			var mode = docLayer._selectedMode;
 			this._addPreviewToQueue(part, 'tile ' +
-							'nviewid=0' + ' ' +
+							'nviewid=' + this._docLayer._canonicalViewId + ' ' +
 							'part=' + part + ' ' +
 							((mode !== 0) ? ('mode=' + mode + ' ') : '') +
 							'width=' + maxWidth * app.roundedDpiScale + ' ' +
@@ -222,13 +227,18 @@ L.Map.include({
 		if (!this._docPreviews) {
 			this._docPreviews = {};
 		}
+
 		var autoUpdate = options ? options.autoUpdate : false;
 		this._docPreviews[id] = {id: id, part: part, width: width, height: height, tilePosX: tilePosX,
 			tilePosY: tilePosY, tileWidth: tileWidth, tileHeight: tileHeight, autoUpdate: autoUpdate, invalid: false};
 
+		if (this._docLayer._canonicalViewId == -1) {
+			return;
+		}
+
 		var mode = this._docLayer._selectedMode;
 		this._addPreviewToQueue(part, 'tile ' +
-							'nviewid=0' + ' ' +
+							'nviewid=' + this._docLayer._canonicalViewId + ' ' +
 							'part=' + part + ' ' +
 							((mode !== 0) ? ('mode=' + mode + ' ') : '') +
 							'width=' + width * app.roundedDpiScale + ' ' +

--- a/common/Session.hpp
+++ b/common/Session.hpp
@@ -39,14 +39,18 @@ public:
     int createCanonicalId(const std::string &viewProps)
     {
         if (viewProps.empty())
+        {
+            LOG_ERR("Cannot create canonical id for empty viewProps");
             return 0;
+        }
+
         for (const auto& it : _canonicalIds)
         {
             if (it.first == viewProps)
                 return it.second;
         }
 
-        const std::size_t id = _canonicalIds.size() + 1000;
+        const std::size_t id = (_canonicalIds.size() + 1) + 1000;
         _canonicalIds[viewProps] = id;
         return id;
     }

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1716,7 +1716,6 @@ private:
 
         session->initWatermark();
 
-        invalidateCanonicalId(sessionId);
         return _loKitDocument;
     }
 

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1716,6 +1716,7 @@ private:
 
         session->initWatermark();
 
+        invalidateCanonicalId(sessionId);
         return _loKitDocument;
     }
 

--- a/test/TileCacheTests.cpp
+++ b/test/TileCacheTests.cpp
@@ -267,14 +267,14 @@ void TileCacheTests::testSimpleCombine()
     std::shared_ptr<http::WebSocketSession> socket1
         = loadDocAndGetSession(_socketPoll, _uri, documentURL, testname + "1 ");
 
-    sendTextFrame(socket1, "tilecombine nviewid=0  part=0 width=256 height=256 tileposx=0,3840 tileposy=0,0 tilewidth=3840 tileheight=3840");
+    sendTextFrame(socket1, "tilecombine nviewid=1001 part=0 width=256 height=256 tileposx=0,3840 tileposy=0,0 tilewidth=3840 tileheight=3840");
 
     std::vector<char> tile1a = getResponseMessage(socket1, "tile:", testname + "1 ");
     LOK_ASSERT_MESSAGE("did not receive a tile: message as expected", !tile1a.empty());
     std::vector<char> tile1b = getResponseMessage(socket1, "tile:", testname + "1 ");
     LOK_ASSERT_MESSAGE("did not receive a tile: message as expected", !tile1b.empty());
 
-    sendTextFrame(socket1, "tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0,3840 tileposy=0,0 oldwid=42,42 tilewidth=3840 tileheight=3840");
+    sendTextFrame(socket1, "tilecombine nviewid=1001 part=0 width=256 height=256 tileposx=0,3840 tileposy=0,0 oldwid=42,42 tilewidth=3840 tileheight=3840");
     tile1a = getResponseMessage(socket1, "delta:", testname + "1 ", std::chrono::seconds(10));
 //  TST_LOG("Response is: " + Util::dumpHex(tile1a) << "\n");
     // no content in an update delta: - so ends with a '\n'
@@ -287,7 +287,7 @@ void TileCacheTests::testSimpleCombine()
     std::shared_ptr<http::WebSocketSession> socket2
         = loadDocAndGetSession(_socketPoll, _uri, documentURL, testname + "2 ");
 
-    sendTextFrame(socket2, "tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0,3840 tileposy=0,0 tilewidth=3840 tileheight=3840");
+    sendTextFrame(socket2, "tilecombine nviewid=1001 part=0 width=256 height=256 tileposx=0,3840 tileposy=0,0 tilewidth=3840 tileheight=3840");
 
     std::vector<char> tile2a = getResponseMessage(socket2, "tile:", testname + "2 ");
     LOK_ASSERT_MESSAGE("did not receive a tile: message as expected", !tile2a.empty());
@@ -295,7 +295,7 @@ void TileCacheTests::testSimpleCombine()
     LOK_ASSERT_MESSAGE("did not receive a tile: message as expected", !tile2b.empty());
 
     // First - check force keyframe
-    sendTextFrame(socket1, "tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0,3840 tileposy=0,0 oldwid=0,0 tilewidth=3840 tileheight=3840");
+    sendTextFrame(socket1, "tilecombine nviewid=1001 part=0 width=256 height=256 tileposx=0,3840 tileposy=0,0 oldwid=0,0 tilewidth=3840 tileheight=3840");
     tile1a = getResponseMessage(socket1, "tile:", testname + "1 ");
     LOK_ASSERT_MESSAGE("did not receive a tile: message as expected", !tile1a.empty());
     tile1b = getResponseMessage(socket1, "tile:", testname + "1 ");
@@ -320,7 +320,7 @@ void TileCacheTests::testTileSubscription()
     std::shared_ptr<http::WebSocketSession> socket1
         = loadDocAndGetSession(_socketPoll, _uri, documentURL, testname + "1 ");
 
-    sendTextFrame(socket1, "tilecombine nviewid=0  part=0 width=256 height=256 tileposx=0,3840 tileposy=0,0 tilewidth=3840 tileheight=3840");
+    sendTextFrame(socket1, "tilecombine nviewid=1001  part=0 width=256 height=256 tileposx=0,3840 tileposy=0,0 tilewidth=3840 tileheight=3840");
 
     // std::shared_ptr<TileDesc>
     auto tile1a = getResponseDesc(socket1, "tile:", testname + "1 ");
@@ -332,7 +332,7 @@ void TileCacheTests::testTileSubscription()
     sendChar(socket1, '.', skNone, testname);
 
     // no viewport set so we have to re-request:
-    sendTextFrame(socket1, "tilecombine nviewid=0  part=0 width=256 height=256 tileposx=0,3840 tileposy=0,0 oldwid=42,42 tilewidth=3840 tileheight=3840");
+    sendTextFrame(socket1, "tilecombine nviewid=1001  part=0 width=256 height=256 tileposx=0,3840 tileposy=0,0 oldwid=42,42 tilewidth=3840 tileheight=3840");
 
     auto delta1a = getResponseDesc(socket1, "delta:", testname + "1 ");
     LOK_ASSERT_MESSAGE("did not receive a delta: message as expected", !!delta1a);
@@ -365,9 +365,9 @@ void TileCacheTests::testTileSubscription()
     assertResponseString(socket1, "invalidatetiles:", testname);
 
     // two subscriptions on a tile we hope from three requests
-    sendTextFrame(socket1, "tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0,3840 oldwid=42,42 tileposy=0,0 tilewidth=3840 tileheight=3840");
-    sendTextFrame(socket1, "tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0,3840 oldwid=42,42 tileposy=0,0 tilewidth=3840 tileheight=3840");
-    sendTextFrame(socket2, "tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0,3840 tileposy=0,0 tilewidth=3840 tileheight=3840");
+    sendTextFrame(socket1, "tilecombine nviewid=1001 part=0 width=256 height=256 tileposx=0,3840 oldwid=42,42 tileposy=0,0 tilewidth=3840 tileheight=3840");
+    sendTextFrame(socket1, "tilecombine nviewid=1001 part=0 width=256 height=256 tileposx=0,3840 oldwid=42,42 tileposy=0,0 tilewidth=3840 tileheight=3840");
+    sendTextFrame(socket2, "tilecombine nviewid=1001 part=0 width=256 height=256 tileposx=0,3840 tileposy=0,0 tilewidth=3840 tileheight=3840");
 
     // User 2 should get tiles
     auto tile2a = getResponseDesc(socket2, "tile:", testname + "1 ");
@@ -461,12 +461,12 @@ void TileCacheTests::testDisconnectMultiView()
             = loadDocAndGetSession(_socketPoll, _uri, documentURL, "disconnectMultiView-2 ", true);
 
         sendTextFrame(socket1,
-                      "tilecombine nviewid=0 part=0 width=256 height=256 "
+                      "tilecombine nviewid=1001 part=0 width=256 height=256 "
                       "tileposx=0,3840,7680,11520,0,3840,7680,11520 "
                       "tileposy=0,0,0,0,3840,3840,3840,3840 tilewidth=3840 tileheight=3840",
                       "cancelTilesMultiView-1 ");
         sendTextFrame(socket2,
-                      "tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0,3840,7680,0 "
+                      "tilecombine nviewid=1001 part=0 width=256 height=256 tileposx=0,3840,7680,0 "
                       "tileposy=0,0,0,22520 tilewidth=3840 tileheight=3840",
                       "cancelTilesMultiView-2 ");
 
@@ -527,14 +527,14 @@ void TileCacheTests::testUnresponsiveClient()
         assertResponseString(socket2, "invalidatetiles:", testname + "2 ");
 
         // Ask for tiles and don't read!
-        sendTextFrame(socket1, "tilecombine nviewid=0 part=0 width=256 height=256 "
+        sendTextFrame(socket1, "tilecombine nviewid=1001 part=0 width=256 height=256 "
                                "tileposx=0,3840,7680,11520,0,3840,7680,11520 "
                                "tileposy=0,0,0,0,3840,3840,3840,3840 tilewidth=3840 "
                                "tileheight=3840",
                       testname + "1 ");
 
         // Verify that we get all 8 tiles.
-        sendTextFrame(socket2, "tilecombine nviewid=0 part=0 width=256 height=256 "
+        sendTextFrame(socket2, "tilecombine nviewid=1001 part=0 width=256 height=256 "
                                "tileposx=0,3840,7680,11520,0,3840,7680,11520 "
                                "tileposy=0,0,0,0,3840,3840,3840,3840 tilewidth=3840 "
                                "tileheight=3840",
@@ -566,7 +566,7 @@ void TileCacheTests::testImpressTiles()
             = loadDocAndGetSession(_socketPoll, "setclientpart.odp", _uri, testname);
 
         sendTextFrame(socket,
-                      "tile nviewid=0 part=0 width=180 height=135 tileposx=0 tileposy=0 "
+                      "tile nviewid=1001 part=0 width=180 height=135 tileposx=0 tileposy=0 "
                       "tilewidth=15875 tileheight=11906 id=0",
                       testname);
         getTileMessage(socket, testname);
@@ -644,7 +644,7 @@ void TileCacheTests::testTilesRenderedJustOnce()
         assertResponseString(socket, "invalidatetiles:", testname);
 
         // Get 3 tiles.
-        sendTextFrame(socket, "tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0,3840,7680 tileposy=0,0,0 tilewidth=3840 tileheight=3840", testname);
+        sendTextFrame(socket, "tilecombine nviewid=1001 part=0 width=256 height=256 tileposx=0,3840,7680 tileposy=0,0,0 tilewidth=3840 tileheight=3840", testname);
         assertResponseString(socket, "tile:", testname);
         assertResponseString(socket, "tile:", testname);
         assertResponseString(socket, "tile:", testname);
@@ -657,7 +657,7 @@ void TileCacheTests::testTilesRenderedJustOnce()
         LOK_ASSERT_EQUAL((i+1) * 3, renderCount2);
 
         // Get same 3 tiles.
-        sendTextFrame(socket, "tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0,3840,7680 tileposy=0,0,0 tilewidth=3840 tileheight=3840", testname);
+        sendTextFrame(socket, "tilecombine nviewid=1001 part=0 width=256 height=256 tileposx=0,3840,7680 tileposy=0,0,0 tilewidth=3840 tileheight=3840", testname);
         const auto tile1 = assertResponseString(socket, "tile:", testname);
 
         // monotonically increasing id.
@@ -732,25 +732,25 @@ void TileCacheTests::testTilesRenderedJustOnceMultiClient()
         assertResponseString(socket1, "invalidatetiles:", testname1);
 
         // Get 3 tiles.
-        sendTextFrame(socket1, "tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0,3840,7680 tileposy=0,0,0 tilewidth=3840 tileheight=3840", testname1);
+        sendTextFrame(socket1, "tilecombine nviewid=1001 part=0 width=256 height=256 tileposx=0,3840,7680 tileposy=0,0,0 tilewidth=3840 tileheight=3840", testname1);
         assertResponseString(socket1, "tile:", testname1);
         assertResponseString(socket1, "tile:", testname1);
         assertResponseString(socket1, "tile:", testname1);
 
         assertResponseString(socket2, "invalidatetiles:", testname2);
-        sendTextFrame(socket2, "tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0,3840,7680 tileposy=0,0,0 tilewidth=3840 tileheight=3840", testname2);
+        sendTextFrame(socket2, "tilecombine nviewid=1001 part=0 width=256 height=256 tileposx=0,3840,7680 tileposy=0,0,0 tilewidth=3840 tileheight=3840", testname2);
         assertResponseString(socket2, "tile:", testname2);
         assertResponseString(socket2, "tile:", testname2);
         assertResponseString(socket2, "tile:", testname2);
 
         assertResponseString(socket3, "invalidatetiles:", testname3);
-        sendTextFrame(socket3, "tilecombine nviewid=0 part=0 nviewid=0 width=256 height=256 tileposx=0,3840,7680 tileposy=0,0,0 tilewidth=3840 tileheight=3840", testname3);
+        sendTextFrame(socket3, "tilecombine nviewid=1001 part=0 width=256 height=256 tileposx=0,3840,7680 tileposy=0,0,0 tilewidth=3840 tileheight=3840", testname3);
         assertResponseString(socket3, "tile:", testname3);
         assertResponseString(socket3, "tile:", testname3);
         assertResponseString(socket3, "tile:", testname3);
 
         assertResponseString(socket4, "invalidatetiles:", testname4);
-        sendTextFrame(socket4, "tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0,3840,7680 tileposy=0,0,0 tilewidth=3840 tileheight=3840", testname4);
+        sendTextFrame(socket4, "tilecombine nviewid=1001 part=0 width=256 height=256 tileposx=0,3840,7680 tileposy=0,0,0 tilewidth=3840 tileheight=3840", testname4);
         assertResponseString(socket4, "tile:", testname4);
         assertResponseString(socket4, "tile:", testname4);
         assertResponseString(socket4, "tile:", testname4);
@@ -763,7 +763,7 @@ void TileCacheTests::testTilesRenderedJustOnceMultiClient()
         LOK_ASSERT_EQUAL((i+1) * 3, renderCount2);
 
         // Get same 3 tiles.
-        sendTextFrame(socket1, "tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0,3840,7680 tileposy=0,0,0 tilewidth=3840 tileheight=3840", testname1);
+        sendTextFrame(socket1, "tilecombine nviewid=1001 part=0 width=256 height=256 tileposx=0,3840,7680 tileposy=0,0,0 tilewidth=3840 tileheight=3840", testname1);
         const auto tile1 = assertResponseString(socket1, "tile:", testname1);
         std::string renderId1;
         COOLProtocol::getTokenStringFromMessage(tile1, "renderid", renderId1);
@@ -820,8 +820,8 @@ void TileCacheTests::testSimultaneousTilesRenderedJustOnce()
     assertResponseString(socket1, "statechanged:", "client1 ");
     assertResponseString(socket2, "statechanged:", "client2 ");
 
-    sendTextFrame(socket1, "tile nviewid=0 part=42 width=256 height=256 tileposx=1000 tileposy=2000 tilewidth=3000 tileheight=3000");
-    sendTextFrame(socket2, "tile nviewid=0 part=42 width=256 height=256 tileposx=1000 tileposy=2000 tilewidth=3000 tileheight=3000");
+    sendTextFrame(socket1, "tile nviewid=1001 part=42 width=256 height=256 tileposx=1000 tileposy=2000 tilewidth=3000 tileheight=3000");
+    sendTextFrame(socket2, "tile nviewid=1001 part=42 width=256 height=256 tileposx=1000 tileposy=2000 tilewidth=3000 tileheight=3000");
 
     const auto response1 = assertResponseString(socket1, "tile:", "client1 ");
     const auto response2 = assertResponseString(socket2, "tile:", "client2 ");
@@ -918,7 +918,7 @@ void TileCacheTests::checkBlackTiles(std::shared_ptr<http::WebSocketSession>& so
     // render correctly and there are no black tiles.
     // Current cap of table size ends at 257280 twips (for load12.ods),
     // otherwise 2035200 should be rendered successfully.
-    const char* req = "tile nviewid=0 part=0 width=256 height=256 tileposx=0 tileposy=253440 "
+    const char* req = "tile nviewid=1001 part=0 width=256 height=256 tileposx=0 tileposy=253440 "
                       "tilewidth=3840 tileheight=3840";
     sendTextFrame(socket, req);
 
@@ -1357,7 +1357,7 @@ void TileCacheTests::requestTiles(std::shared_ptr<http::WebSocketSession>& socke
             tileX = tileSize * itCol;
             tileY = tileSize * itRow;
             text
-                = Poco::format("tile nviewid=0 part=%d width=%d height=%d tileposx=%d tileposy=%d "
+                = Poco::format("tile nviewid=1001 part=%d width=%d height=%d tileposx=%d tileposy=%d "
                                "tilewidth=%d tileheight=%d",
                                part, pixTileSize, pixTileSize, tileX, tileY, tileWidth, tileHeight);
 
@@ -1366,7 +1366,7 @@ void TileCacheTests::requestTiles(std::shared_ptr<http::WebSocketSession>& socke
             // expected tile: part= width= height= tileposx= tileposy= tilewidth= tileheight=
             StringVector tokens(StringVector::tokenize(tile, ' '));
             LOK_ASSERT_EQUAL(std::string("tile:"), tokens[0]);
-            LOK_ASSERT_EQUAL(1000, std::stoi(tokens[1].substr(std::string("nviewid=").size())));
+            LOK_ASSERT_EQUAL(1001, std::stoi(tokens[1].substr(std::string("nviewid=").size())));
             LOK_ASSERT_EQUAL(part, std::stoi(tokens[2].substr(std::string("part=").size())));
             LOK_ASSERT_EQUAL(pixTileSize,
                              std::stoi(tokens[3].substr(std::string("width=").size())));
@@ -1440,7 +1440,7 @@ void TileCacheTests::testTileRequestByZoom()
     sendTextFrame(socket, "clientzoom tilepixelwidth=256 tilepixelheight=256 tiletwipwidth=3200 tiletwipheight=3200");
 
     // Request all tile of the visible area (it happens by zoom)
-    sendTextFrame(socket, "tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0,3200,6400,9600,12800,0,3200,6400,9600,12800,0,3200,6400,9600,12800,0,3200,6400,9600,12800 tileposy=0,0,0,0,0,3200,3200,3200,3200,3200,6400,6400,6400,6400,6400,9600,9600,9600,9600,9600 tilewidth=3200 tileheight=3200");
+    sendTextFrame(socket, "tilecombine nviewid=1001 part=0 width=256 height=256 tileposx=0,3200,6400,9600,12800,0,3200,6400,9600,12800,0,3200,6400,9600,12800,0,3200,6400,9600,12800 tileposy=0,0,0,0,0,3200,3200,3200,3200,3200,6400,6400,6400,6400,6400,9600,9600,9600,9600,9600 tilewidth=3200 tileheight=3200");
 
     // Check that we get all the tiles without we send back the tileprocessed message
     for (int i = 0; i < 20; ++i)
@@ -1536,7 +1536,7 @@ void TileCacheTests::testTileProcessed()
         getResponseMessage(socket, "spinandwait:", testname, std::chrono::milliseconds(10));
 
     // Request a lots of tiles ~25 ie. more than wsd can send back at once.
-    sendTextFrame(socket, "tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0,3200,6400,9600,12800,0,3200,6400,9600,12800,0,3200,6400,9600,12800,0,3200,6400,9600,12800,0,3200,6400,9600,12800 tileposy=0,0,0,0,0,3200,3200,3200,3200,3200,6400,6400,6400,6400,6400,9600,9600,9600,9600,9600,12800,12800,12800,12800,12800 tilewidth=3200 tileheight=3200");
+    sendTextFrame(socket, "tilecombine nviewid=1001 part=0 width=256 height=256 tileposx=0,3200,6400,9600,12800,0,3200,6400,9600,12800,0,3200,6400,9600,12800,0,3200,6400,9600,12800,0,3200,6400,9600,12800 tileposy=0,0,0,0,0,3200,3200,3200,3200,3200,6400,6400,6400,6400,6400,9600,9600,9600,9600,9600,12800,12800,12800,12800,12800 tilewidth=3200 tileheight=3200");
 
     std::vector<std::string> tileIDs;
     int arrivedTile = 0;
@@ -1756,7 +1756,7 @@ void TileCacheTests::testWireIDFilteringOnWSDSide()
 
     //2. Now request the same tiles by the other client (e.g. scroll to the same view)
 
-    sendTextFrame(socket2, "tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0,3840,7680 tileposy=0,0,0 tilewidth=3840 tileheight=3840");
+    sendTextFrame(socket2, "tilecombine nviewid=1001 part=0 width=256 height=256 tileposx=0,3840,7680 tileposy=0,0,0 tilewidth=3840 tileheight=3840");
 
     // We expect three tiles sent to the second client
     LOK_ASSERT_EQUAL(3, countMessages(socket2, "tile:", testname, std::chrono::seconds(1)));

--- a/test/UnitWOPIWatermark.cpp
+++ b/test/UnitWOPIWatermark.cpp
@@ -58,7 +58,7 @@ public:
             }
             case Phase::TileRequest:
             {
-                WSD_CMD("tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0,3840 "
+                WSD_CMD("tilecombine nviewid=1001 part=0 width=256 height=256 tileposx=0,3840 "
                         "tileposy=0,0 tilewidth=3840 tileheight=3840");
                 const std::string tile =
                     helpers::getResponseString(getWs()->getWebSocket(), "tile:", testName);
@@ -67,7 +67,7 @@ public:
                 {
                     StringVector tokens(StringVector::tokenize(tile, ' '));
                     std::string nviewid = tokens[1].substr(std::string("nviewid=").size());
-                    if (!nviewid.empty() && nviewid != "0")
+                    if (!nviewid.empty() && nviewid == "1001")
                     {
                         LOG_INF(
                             "Watermark is hashed into integer successfully nviewid=" << nviewid);

--- a/test/httpwstest.cpp
+++ b/test/httpwstest.cpp
@@ -268,7 +268,10 @@ void HTTPWSTest::testInactiveClient()
                     // expected.
                     LOK_ASSERT_MESSAGE("unexpected message: " + msg,
                                             token == "a11yfocuschanged:" ||
+                                            token == "applicationbackgroundcolor:" ||
+                                            token == "canonicalidchange:" ||
                                             token == "cursorvisible:" ||
+                                            token == "documentbackgroundcolor:" ||
                                             token == "graphicselection:" ||
                                             token == "graphicviewselection:" ||
                                             token == "invalidatecursor:" ||


### PR DESCRIPTION
Resolves issue where presentations would not load all at once. Along with https://gerrit.libreoffice.org/c/core/+/154940, the dark mode related Draw bugs should be fixed.