### PR TITLE
Don't steal focus from outside iframe on load Calc

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -4422,7 +4422,8 @@ L.CanvasTileLayer = L.Layer.extend({
 
 			this._addDropDownMarker();
 
-			var dontFocusDocument = this._isAnyInputFocused();
+			var focusOutOfDocument = document.activeElement === document.body;
+			var dontFocusDocument = this._isAnyInputFocused() || focusOutOfDocument;
 
 			// when the cell cursor is moving, the user is in the document,
 			// and the focus should leave the cell input bar


### PR DESCRIPTION
When Collabora Online is inside iframe and we load Calc spreadsheet, after few seconds we receive CellCursor message. In case when user was typing outside iframe in some textbox - we were stealing focus, what caused that user started to type inside spreadsheet.