### PR TITLE
Misc Improvements

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -396,6 +396,8 @@ else
 CLEANUP_COMMAND=if test -s ./coolwsd; then echo "Cleaning up..." && ./coolwsd --disable-cool-user-checking --cleanup --o:logging.level=trace || rm ./coolwsd; fi
 endif
 
+CLEANUP_COVERAGE=rm -rf ${abs_top_srcdir}/gcov; find . -iname "*.gc??" -delete
+
 if HAVE_LO_PATH
 
 SYSTEM_STAMP = @SYSTEMPLATE_PATH@/system_stamp
@@ -440,8 +442,7 @@ clean-local:
 	rm -rf "${top_srcdir}/loleaflet"
 	rm -rf loolconfig loolconvert loolforkit loolmap loolmount # kill old binaries
 	rm -rf loolwsd loolwsd_fuzzer coolwsd_fuzzer loolstress loolsocketdump
-	rm -rf ${abs_top_srcdir}/gcov
-	find . -iname "*.gc??" -delete
+	$(CLEANUP_COVERAGE)
 
 if ENABLE_DEBUG
 # can write to /tmp/coolwsd.log
@@ -635,6 +636,9 @@ check: check-for-system-nss check-recursive
 
 coverage-report:
 	$(GEN_COVERAGE_COMMAND)
+
+coverage-clean:
+	$(CLEANUP_COVERAGE)
 
 czech: check
 	@echo "This should do something much cooler"

--- a/android/lib/src/main/cpp/androidapp.cpp
+++ b/android/lib/src/main/cpp/androidapp.cpp
@@ -347,7 +347,7 @@ Java_org_libreoffice_androidlib_LOActivity_createCOOLWSD(JNIEnv *env, jobject in
                         {
                             fakeClientFd = fakeSocketSocket();
                             LOG_DBG("createCOOLWSD created fakeClientFd: " << fakeClientFd);
-                            std::unique_ptr<COOLWSD> coolwsd(new COOLWSD());
+                            std::unique_ptr<COOLWSD> coolwsd = std::make_unique<COOLWSD>();
                             coolwsd->run(1, argv);
                         }
                         LOG_DBG("One run of COOLWSD completed");

--- a/common/Crypto.cpp
+++ b/common/Crypto.cpp
@@ -65,8 +65,8 @@ struct SupportKeyImpl
     }
 };
 
-SupportKey::SupportKey(const std::string &key) :
-    _impl(new SupportKeyImpl(key))
+SupportKey::SupportKey(const std::string& key)
+    : _impl(std::make_unique<SupportKeyImpl>(key))
 {
 }
 

--- a/common/Protocol.hpp
+++ b/common/Protocol.hpp
@@ -15,6 +15,7 @@
 #include <regex>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include <StringVector.hpp>

--- a/common/RenderTiles.hpp
+++ b/common/RenderTiles.hpp
@@ -366,9 +366,8 @@ namespace RenderTiles
 
             LOG_TRC("Sending back painted tiles for " << tileMsg << " of size " << output.size() << " bytes) for: " << tileMsg);
 
-            std::unique_ptr<char[]> response;
             const size_t responseSize = tileMsg.size() + output.size();
-            response.reset(new char[responseSize]);
+            std::unique_ptr<char[]> response(std::make_unique<char[]>(responseSize));
             std::copy(tileMsg.begin(), tileMsg.end(), response.get());
             std::copy(output.begin(), output.end(), response.get() + tileMsg.size());
             outputMessage(response.get(), responseSize);
@@ -380,8 +379,7 @@ namespace RenderTiles
             {
                 tileMsg = i.serialize("tile:", "\n");
                 const size_t responseSize = tileMsg.size() + i.getImgSize();
-                std::unique_ptr<char[]> response;
-                response.reset(new char[responseSize]);
+                std::unique_ptr<char[]> response(std::make_unique<char[]>(responseSize));
                 std::copy(tileMsg.begin(), tileMsg.end(), response.get());
                 std::copy(output.begin() + outputOffset, output.begin() + outputOffset + i.getImgSize(), response.get() + tileMsg.size());
                 outputMessage(response.get(), responseSize);

--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -1428,17 +1428,6 @@ int main(int argc, char**argv)
         return std::string(s);
     }
 
-    /**
-     * Constructs an object of type T and wraps it in a std::unique_ptr.
-     *
-     * Can be replaced by std::make_unique when we allow C++14.
-     */
-    template<typename T, typename... Args>
-    typename std::unique_ptr<T> make_unique(Args&& ... args)
-    {
-        return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
-    }
-
     /// Dump an object that supports .dumpState into a string.
     /// Helpful for logging.
     template <typename T> std::string dump(const T& object, const std::string& indent = ", ")

--- a/configure.ac
+++ b/configure.ac
@@ -1030,6 +1030,7 @@ fi
 
 # Check if we have clang, rather than gcc, which
 # doesn't like -pthread on the linker command-line.
+HAVE_CLANG=false
 AC_MSG_CHECKING([whether the compiler is clang])
 AC_COMPILE_IFELSE([AC_LANG_SOURCE([
     #if !defined(__clang__)
@@ -1037,10 +1038,11 @@ AC_COMPILE_IFELSE([AC_LANG_SOURCE([
     #endif
 ])],
                     [AC_MSG_RESULT([yes])
-                    AC_DEFINE([HAVE_CLANG],1,[whether the C++ compiler is clang])],
+                    AC_DEFINE([HAVE_CLANG],true,[whether the C++ compiler is clang])],
                     [AC_MSG_RESULT([no])
-                    AC_DEFINE([HAVE_CLANG],0,[whether the C++ compiler is clang])])
-AM_CONDITIONAL([HAVE_CLANG], [test "$HAVE_CLANG" = "1"])
+                    AC_DEFINE([HAVE_CLANG],false,[whether the C++ compiler is clang])])
+AM_CONDITIONAL([HAVE_CLANG], [test "$HAVE_CLANG" = "true"])
+AC_SUBST(HAVE_CLANG)
 
 AS_IF([test "$ENABLE_GTKAPP" != true],
 [CXXFLAGS="$CXXFLAGS $CXXFLAGS_CXXSTD"])

--- a/configure.ac
+++ b/configure.ac
@@ -346,7 +346,8 @@ AC_ARG_WITH([infobar-url],
 AC_ARG_WITH([coverage],
              AS_HELP_STRING([--with-coverage=<gcov>],
                             [Enable a code-coverage method. Currently only gcov is supported (works with both gcc and clang).
-                            Output HTML in gcov/ directory.]))
+                            Output HTML in gcov/ directory.
+                            Generate report with 'make coverage-report'. Clean coverage files with 'make coverage-clean']))
 
 AC_ARG_WITH([sanitizer],
              AS_HELP_STRING([--with-sanitizer],

--- a/kit/ChildSession.hpp
+++ b/kit/ChildSession.hpp
@@ -224,8 +224,8 @@ public:
     {
         if (hasWatermark())
         {
-            _docWatermark.reset(
-                new Watermark(getLOKitDocument(), getWatermarkText(), getWatermarkOpacity()));
+            _docWatermark = std::make_shared<Watermark>(getLOKitDocument(), getWatermarkText(),
+                                                        getWatermarkOpacity());
         }
 
         return _docWatermark != nullptr;

--- a/kit/Delta.hpp
+++ b/kit/Delta.hpp
@@ -354,7 +354,7 @@ class DeltaGenerator {
             assert (_loc == repl->_loc);
             if (repl.get() == this)
             {
-                assert("replacing with yourself should never happen");
+                assert(!"replacing with yourself should never happen");
                 return;
             }
             _wid = repl->_wid;

--- a/kit/DummyLibreOfficeKit.cpp
+++ b/kit/DummyLibreOfficeKit.cpp
@@ -140,7 +140,7 @@ LibLODocument_Impl::LibLODocument_Impl()
 {
     if (!(m_pDocumentClass = gDocumentClass.lock()))
     {
-        m_pDocumentClass.reset(new LibreOfficeKitDocumentClass);
+        m_pDocumentClass = std::make_shared<LibreOfficeKitDocumentClass>();
 
         m_pDocumentClass->nSize = sizeof(LibreOfficeKitDocument);
 

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -2284,8 +2284,7 @@ public:
 
     static std::shared_ptr<KitSocketPoll> create()
     {
-        KitSocketPoll *p = new KitSocketPoll();
-        auto result = std::shared_ptr<KitSocketPoll>(p);
+        std::shared_ptr<KitSocketPoll> result(new KitSocketPoll());
 
 #ifdef IOS
         std::unique_lock<std::mutex> lock(KSPollsMutex);

--- a/net/HttpHelper.cpp
+++ b/net/HttpHelper.cpp
@@ -48,7 +48,7 @@ void sendUncompressedFileContent(const std::shared_ptr<StreamSocket>& socket,
                                  const std::string& path, const int bufferSize)
 {
     std::ifstream file(path, std::ios::binary);
-    std::unique_ptr<char[]> buf(new char[bufferSize]);
+    std::unique_ptr<char[]> buf = std::make_unique<char[]>(bufferSize);
     do
     {
         file.read(&buf[0], bufferSize);
@@ -70,13 +70,13 @@ void sendDeflatedFileContent(const std::shared_ptr<StreamSocket>& socket, const 
     if (fileSize > 0)
     {
         std::ifstream file(path, std::ios::binary);
-        std::unique_ptr<char[]> buf(new char[fileSize]);
+        std::unique_ptr<char[]> buf = std::make_unique<char[]>(fileSize);
         file.read(&buf[0], fileSize);
 
         static const unsigned int Level = 1;
         const long unsigned int size = file.gcount();
         long unsigned int compSize = compressBound(size);
-        std::unique_ptr<char[]> cbuf(new char[compSize]);
+        std::unique_ptr<char[]> cbuf = std::make_unique<char[]>(compSize);
         compress2((Bytef*)&cbuf[0], &compSize, (Bytef*)&buf[0], size, Level);
 
         if (size > 0)

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -595,6 +595,23 @@ public:
             size);
     }
 
+    void setBody(std::string body, std::string contentType = "text/html charset=UTF-8")
+    {
+        if (!body.empty()) // Type is only meaningful if there is a body.
+            _header.setContentType(std::move(contentType));
+
+        //FIXME: use generalized lambda capture to move the istringstream, available in C++14.
+        auto iss = std::make_shared<std::istringstream>(body, std::ios::binary);
+
+        setBodySource(
+            [=](char* buf, int64_t len) -> int64_t
+            {
+                iss->read(buf, len);
+                return iss->gcount();
+            },
+            body.size());
+    }
+
     Stage stage() const { return _stage; }
 
     bool writeData(Buffer& out, std::size_t capacity)

--- a/net/Ssl.hpp
+++ b/net/Ssl.hpp
@@ -81,8 +81,8 @@ public:
     {
         assert(!isServerContextInitialized() &&
                "Cannot initialize the server context more than once");
-        ServerInstance.reset(
-            new SslContext(certFilePath, keyFilePath, caFilePath, cipherList, verification));
+        ServerInstance = std::make_unique<SslContext>(certFilePath, keyFilePath, caFilePath,
+                                                      cipherList, verification);
     }
 
     static void uninitializeServerContext() { ServerInstance.reset(); }
@@ -105,8 +105,8 @@ public:
     {
         assert(!isClientContextInitialized() &&
                "Cannot initialize the client context more than once");
-        ClientInstance.reset(
-            new SslContext(certFilePath, keyFilePath, caFilePath, cipherList, verification));
+        ClientInstance = std::make_unique<SslContext>(certFilePath, keyFilePath, caFilePath,
+                                                      cipherList, verification);
     }
 
     static void uninitializeClientContext() { ClientInstance.reset(); }

--- a/net/clientnb.cpp
+++ b/net/clientnb.cpp
@@ -119,8 +119,7 @@ public:
         _session->setTimeout(Poco::Timespan(10, 0));
         HTTPRequest request(HTTPRequest::HTTP_GET, "/ws");
         HTTPResponse response;
-        return std::shared_ptr<WebSocket>(
-            new WebSocket(*_session, request, response));
+        return std::make_shared<WebSocket>(*_session, request, response);
     }
 };
 

--- a/test/UnitQuarantine.cpp
+++ b/test/UnitQuarantine.cpp
@@ -106,7 +106,7 @@ public:
         LOK_ASSERT_EQUAL_MESSAGE("Unexpected overwritting the document in storage", false, force);
 
         // Internal Server Error.
-        return Util::make_unique<http::Response>(http::StatusCode::InternalServerError);
+        return std::make_unique<http::Response>(http::StatusCode::InternalServerError);
     }
 
     bool onDocumentModified(const std::string& message) override

--- a/test/UnitWOPIAsyncUpload_ModifyClose.cpp
+++ b/test/UnitWOPIAsyncUpload_ModifyClose.cpp
@@ -49,7 +49,7 @@ public:
 
             TRANSITION_STATE(_phase, Phase::WaitDestroy);
 
-            return Util::make_unique<http::Response>(http::StatusCode::OK);
+            return std::make_unique<http::Response>(http::StatusCode::OK);
         }
 
         // This during closing the document.

--- a/test/UnitWOPIFailUpload.cpp
+++ b/test/UnitWOPIFailUpload.cpp
@@ -100,7 +100,7 @@ public:
         LOK_ASSERT_EQUAL_MESSAGE("Unexpected overwritting the document in storage", false, force);
 
         // Internal Server Error.
-        return Util::make_unique<http::Response>(http::StatusCode::InternalServerError);
+        return std::make_unique<http::Response>(http::StatusCode::InternalServerError);
     }
 
     bool onDocumentModified(const std::string& message) override
@@ -209,7 +209,7 @@ public:
             LOK_ASSERT_EQUAL(std::string("true"), request.get("X-COOL-WOPI-IsModifiedByUser"));
 
             // File unknown/User unauthorized.
-            return Util::make_unique<http::Response>(http::StatusCode::NotFound);
+            return std::make_unique<http::Response>(http::StatusCode::NotFound);
         }
 
         // This during closing the document.
@@ -502,7 +502,7 @@ public:
 
             // Fail with error.
             LOG_TST("Simulate PutFile failure");
-            return Util::make_unique<http::Response>(http::StatusCode::InternalServerError);
+            return std::make_unique<http::Response>(http::StatusCode::InternalServerError);
         }
 
         if (getCountPutFile() == 2)
@@ -510,7 +510,7 @@ public:
             LOG_TST("Second PutFile, which will also fail");
 
             LOG_TST("Simulate PutFile failure (again)");
-            return Util::make_unique<http::Response>(http::StatusCode::InternalServerError);
+            return std::make_unique<http::Response>(http::StatusCode::InternalServerError);
         }
 
         if (getCountPutFile() == 3)
@@ -650,7 +650,7 @@ public:
 
             // Fail with error.
             LOG_TST("Returning 500 to simulate PutFile failure");
-            return Util::make_unique<http::Response>(http::StatusCode::InternalServerError);
+            return std::make_unique<http::Response>(http::StatusCode::InternalServerError);
         }
 
         // This during closing the document.

--- a/test/UnitWOPILock.cpp
+++ b/test/UnitWOPILock.cpp
@@ -396,7 +396,7 @@ public:
             LOK_ASSERT_EQUAL_MESSAGE("Lock refresh with expired token", 1UL, _lockRefreshCount);
 
             // Internal Server Error.
-            return Util::make_unique<http::Response>(http::StatusCode::Unauthorized);
+            return std::make_unique<http::Response>(http::StatusCode::Unauthorized);
         }
         else
         {

--- a/test/UnitWSDClient.hpp
+++ b/test/UnitWSDClient.hpp
@@ -91,7 +91,7 @@ protected:
 
         // Insert at the front.
         const auto& _ws = _wsList.emplace(
-            _wsList.begin(), Util::make_unique<UnitWebSocket>(
+            _wsList.begin(), std::make_unique<UnitWebSocket>(
                                  socketPoll(), "/cool/" + _wopiSrc + "/ws", getTestname()));
 
         assert((*_ws).get());
@@ -112,8 +112,8 @@ protected:
 
         // Insert at the back.
         const auto& _ws = _wsList.emplace(
-            _wsList.end(), Util::make_unique<UnitWebSocket>(
-                               socketPoll(), "/cool/" + wopiSrc + "/ws", getTestname()));
+            _wsList.end(), std::make_unique<UnitWebSocket>(socketPoll(), "/cool/" + wopiSrc + "/ws",
+                                                           getTestname()));
         assert((*_ws).get());
 
         return wopiSrc;
@@ -127,7 +127,7 @@ protected:
 
         // Insert at the back.
         const auto& _ws = _wsList.emplace(
-            _wsList.end(), Util::make_unique<UnitWebSocket>(
+            _wsList.end(), std::make_unique<UnitWebSocket>(
                                socketPoll(), "/cool/" + _wopiSrc + "/ws", getTestname()));
 
         assert((*_ws).get());
@@ -157,7 +157,7 @@ protected:
 
         LOG_TST("Connecting to local document [" << docFilename << "] with URL: " << documentURL);
         _wsList.emplace_back(
-            Util::make_unique<UnitWebSocket>(socketPoll(), documentURL, getTestname()));
+            std::make_unique<UnitWebSocket>(socketPoll(), documentURL, getTestname()));
 
         return documentURL;
     }

--- a/test/UnitWSDClient.hpp
+++ b/test/UnitWSDClient.hpp
@@ -78,12 +78,12 @@ protected:
         socket.reset();
     }
 
-    void initWebsocket(const std::string& wopiName)
+    std::string initWebsocket(const std::string& wopiName)
     {
-        Poco::URI wopiURL(helpers::getTestServerURI() + wopiName + "&testname=" + getTestname());
+        const Poco::URI wopiURL(helpers::getTestServerURI() + wopiName +
+                                "&testname=" + getTestname());
 
-        _wopiSrc.clear();
-        Poco::URI::encode(wopiURL.toString(), ":/?", _wopiSrc);
+        _wopiSrc = Util::encodeURIComponent(wopiURL.toString());
 
         // This is just a client connection that is used from the tests.
         LOG_TST("Connecting test client to COOL (#" << (_wsList.size() + 1)
@@ -95,6 +95,28 @@ protected:
                                  socketPoll(), "/cool/" + _wopiSrc + "/ws", getTestname()));
 
         assert((*_ws).get());
+
+        return _wopiSrc;
+    }
+
+    std::string addWebSocket(const std::string& wopiName)
+    {
+        const Poco::URI wopiURL(helpers::getTestServerURI() + wopiName +
+                                "&testname=" + getTestname());
+
+        std::string wopiSrc = Util::encodeURIComponent(wopiURL.toString());
+
+        // This is just a client connection that is used from the tests.
+        LOG_TST("Connecting test client to COOL (#" << (_wsList.size() + 1)
+                                                    << " connection): /cool/" << wopiSrc << "/ws");
+
+        // Insert at the back.
+        const auto& _ws = _wsList.emplace(
+            _wsList.end(), Util::make_unique<UnitWebSocket>(
+                               socketPoll(), "/cool/" + wopiSrc + "/ws", getTestname()));
+        assert((*_ws).get());
+
+        return wopiSrc;
     }
 
     void addWebSocket()

--- a/test/WopiTestServer.hpp
+++ b/test/WopiTestServer.hpp
@@ -278,7 +278,7 @@ protected:
     {
         std::unique_ptr<http::Response> httpResponse = assertCheckFileInfoRequest(request);
         if (!httpResponse)
-            httpResponse = Util::make_unique<http::Response>(http::StatusCode::OK);
+            httpResponse = std::make_unique<http::Response>(http::StatusCode::OK);
 
         if (httpResponse->statusLine().statusCategory() ==
             http::StatusLine::StatusCodeClass::Successful)
@@ -318,7 +318,7 @@ protected:
     {
         std::unique_ptr<http::Response> httpResponse = assertGetFileRequest(request);
         if (!httpResponse)
-            httpResponse = Util::make_unique<http::Response>(http::StatusCode::OK);
+            httpResponse = std::make_unique<http::Response>(http::StatusCode::OK);
 
         if (httpResponse->statusLine().statusCategory() ==
             http::StatusLine::StatusCodeClass::Successful)

--- a/test/helpers.hpp
+++ b/test/helpers.hpp
@@ -152,10 +152,10 @@ inline std::unique_ptr<Poco::Net::HTTPClientSession> createSession(const Poco::U
 {
 #if ENABLE_SSL
     if (uri.getScheme() == "https" || uri.getScheme() == "wss")
-        return Util::make_unique<Poco::Net::HTTPSClientSession>(uri.getHost(), uri.getPort());
+        return std::make_unique<Poco::Net::HTTPSClientSession>(uri.getHost(), uri.getPort());
 #endif
 
-    return Util::make_unique<Poco::Net::HTTPClientSession>(uri.getHost(), uri.getPort());
+    return std::make_unique<Poco::Net::HTTPClientSession>(uri.getHost(), uri.getPort());
 }
 
 /// Uses Poco to make an HTTP GET from the given URI.

--- a/test/integration-http-server.cpp
+++ b/test/integration-http-server.cpp
@@ -7,7 +7,13 @@
 
 #include <config.h>
 
+#include <helpers.hpp>
+#include <lokassert.hpp>
 #include <net/HttpRequest.hpp>
+#include <Session.hpp>
+#include <Common.hpp>
+#include <common/FileUtil.hpp>
+#include <countcoolkits.hpp>
 
 #include <Poco/Net/AcceptCertificateHandler.h>
 #include <Poco/Net/FilePartSource.h>
@@ -23,11 +29,6 @@
 
 #include <cppunit/extensions/HelperMacros.h>
 
-#include <Common.hpp>
-#include <common/FileUtil.hpp>
-
-#include <countcoolkits.hpp>
-#include <helpers.hpp>
 #include <memory>
 
 /// Tests the HTTP GET API of coolwsd.
@@ -38,6 +39,7 @@ class HTTPServerTest : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST_SUITE(HTTPServerTest);
 
     CPPUNIT_TEST(testCoolGet);
+    CPPUNIT_TEST(testCoolPostPoco);
     CPPUNIT_TEST(testCoolPost);
     CPPUNIT_TEST(testScriptsAndLinksGet);
     CPPUNIT_TEST(testScriptsAndLinksPost);
@@ -51,6 +53,7 @@ class HTTPServerTest : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST_SUITE_END();
 
     void testCoolGet();
+    void testCoolPostPoco();
     void testCoolPost();
     void testScriptsAndLinksGet();
     void testScriptsAndLinksPost();
@@ -139,7 +142,7 @@ void HTTPServerTest::testCoolGet()
     LOK_ASSERT(html.find(std::string(COOLWSD_VERSION_HASH)) != std::string::npos);
 }
 
-void HTTPServerTest::testCoolPost()
+void HTTPServerTest::testCoolPostPoco()
 {
     constexpr auto testname = __func__;
 
@@ -161,6 +164,80 @@ void HTTPServerTest::testCoolPost()
 
     LOK_ASSERT(html.find(form["access_token"]) != std::string::npos);
     LOK_ASSERT(html.find(_uri.getHost()) != std::string::npos);
+}
+
+void HTTPServerTest::testCoolPost()
+{
+    constexpr auto testname = __func__;
+
+    const auto pathAndQuery = "/browser/dist/"
+                              "cool.html?WOPISrc=https%3A%2F%2Flocalhost%2Fnextcloud%2Findex.php%"
+                              "2Fapps%2Frichdocuments%2Fwopi%2Ffiles%2F8725_ocqiesh0cngs&title="
+                              "Test.Weekly.odt&lang=en&closebutton=1&revisionhistory=1";
+
+    http::Request httpRequest(pathAndQuery, http::Request::VERB_POST);
+
+    http::Header& httpHeader = httpRequest.header();
+    httpHeader.set("Cache-Control", "max-age=0");
+    httpHeader.set("sec-ch-ua",
+                   "\"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"114\", \"Google Chrome\";v=\"114\"");
+    httpHeader.set("sec-ch-ua-mobile", "?0");
+    httpHeader.set("sec-ch-ua-platform", "\"Linux\"");
+    httpHeader.set("Upgrade-Insecure-Requests", "1");
+    httpHeader.set("Origin", "null");
+    httpHeader.set("User-Agent", "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like "
+                                 "Gecko) Chrome/114.0.0.0 Safari/537.36");
+    httpHeader.set("Accept",
+                   "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/"
+                   "webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7");
+    httpHeader.set("Sec-Fetch-Site", "same-site");
+    httpHeader.set("Sec-Fetch-Mode", "navigate");
+    httpHeader.set("Sec-Fetch-Dest", "iframe");
+    httpHeader.set("Accept-Encoding", "gzip, deflate, br");
+    httpHeader.set("Accept-Language", "en-US,en;q=0.9");
+
+    httpRequest.setBody(
+        "access_token=choMXq0rSMcsm0RoZZWDWsrgAcE5AHwc&ui_defaults=TextRuler%3Dfalse%3BTextSidebar%"
+        "3Dfalse%3BTextStatusbar%3Dfalse%3BPresentationSidebar%3Dfalse%3BPresentationStatusbar%"
+        "3Dfalse%3BSpreadsheetSidebar%3Dfalse%3BSpreadsheetStatusbar%3Dfalse%3BUIMode%3Dclassic%3B&"
+        "css_variables=--co-primary-text%3D%23ffffff%3B--co-primary-element%3D%230082c9%3B--co-"
+        "text-accent%3D%230082c9%3B--co-primary-light%3D%23e6f3fa%3B--co-primary-element-light%3D%"
+        "2317adff%3B--co-color-error%3D%23e9322d%3B--co-color-warning%3D%23eca700%3B--co-color-"
+        "success%3D%2346ba61%3B--co-border-radius%3D3px%3B--co-border-radius-large%3D10px%3B--co-"
+        "loading-light%3D%23ccc%3B--co-loading-dark%3D%23444%3B--co-box-shadow%3Drgba%2877%2C+77%"
+        "2C+77%2C+0.5%29%3B--co-border%3D%23ededed%3B--co-border-dark%3D%23dbdbdb%3B--co-border-"
+        "radius-pill%3D100px%3B&theme=nextcloud",
+        "application/x-www-form-urlencoded");
+
+    std::shared_ptr<http::Session> httpSession = http::Session::create(_uri.toString());
+    const std::shared_ptr<const http::Response> httpResponse =
+        httpSession->syncRequest(httpRequest, http::Session::getDefaultTimeout());
+
+    LOK_ASSERT_EQUAL(http::StatusCode::OK, httpResponse->statusLine().statusCode());
+    LOK_ASSERT_EQUAL(std::string("text/html"), httpResponse->header().getContentType());
+
+    const std::string html = httpResponse->getBody();
+    fprintf(stderr, "%s\n", html.c_str());
+    LOK_ASSERT(html.find(_uri.getHost()) != std::string::npos);
+    LOK_ASSERT(html.find("window.versionPath = '" COOLWSD_VERSION_HASH "';") != std::string::npos);
+    LOK_ASSERT(html.find("window.coolwsdVersion = '" COOLWSD_VERSION "';") != std::string::npos);
+    LOK_ASSERT(html.find("window.accessToken = 'choMXq0rSMcsm0RoZZWDWsrgAcE5AHwc';") !=
+               std::string::npos);
+    LOK_ASSERT(html.find("window.accessTokenTTL = '0';") != std::string::npos);
+    LOK_ASSERT(html.find("window.accessHeader = '';") != std::string::npos);
+    LOK_ASSERT(html.find("window.postMessageOriginExt = '';") != std::string::npos);
+    LOK_ASSERT(
+        html.find(
+            "window.frameAncestors = decodeURIComponent('%20127.0.0.1:%2A%20localhost:%2A');") !=
+        std::string::npos);
+    LOK_ASSERT(
+        html.find(
+            R"xx(window.uiDefaults = {"presentation":{"ShowSidebar":false,"ShowStatusbar":false},"spreadsheet":{"ShowSidebar":false,"ShowStatusbar":false},"text":{"ShowRuler":false,"ShowSidebar":false,"ShowStatusbar":false},"uiMode":"classic"};)xx") !=
+        std::string::npos);
+    LOK_ASSERT(
+        html.find(
+            R"xx(<style>:root {--co-primary-text:#ffffff;--co-primary-element:#0082c9;--co-text-accent:#0082c9;--co-primary-light:#e6f3fa;--co-primary-element-light:#17adff;--co-color-error:#e9322d;--co-color-warning:#eca700;--co-color-success:#46ba61;--co-border-radius:3px;--co-border-radius-large:10px;--co-loading-light:#ccc;--co-loading-dark:#444;--co-box-shadow:rgba(77, 77, 77, 0.5);--co-border:#ededed;--co-border-dark:#dbdbdb;--co-border-radius-pill:100px;}</style>)xx") !=
+        std::string::npos);
 }
 
 void HTTPServerTest::assertHTTPFilesExist(const Poco::URI& uri, Poco::RegularExpression& expr,

--- a/wsd/AdminModel.cpp
+++ b/wsd/AdminModel.cpp
@@ -509,7 +509,8 @@ void AdminModel::addDocument(const std::string& docKey, pid_t pid,
                              const int smapsFD, const Poco::URI& wopiSrc, bool isViewReadOnly)
 {
     ASSERT_CORRECT_THREAD_OWNER(_owner);
-    const auto ret = _documents.emplace(docKey, std::unique_ptr<Document>(new Document(docKey, pid, filename, wopiSrc)));
+    const auto ret =
+        _documents.emplace(docKey, std::make_unique<Document>(docKey, pid, filename, wopiSrc));
     ret.first->second->setProcSMapsFD(smapsFD);
     ret.first->second->takeSnapshot();
     ret.first->second->addView(sessionId, userName, userId, isViewReadOnly);

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -2700,21 +2700,22 @@ void COOLWSD::innerInitialize(Application& self)
 
         const auto compress = getConfigValue<bool>(conf, "trace.path[@compress]", false);
         const auto takeSnapshot = getConfigValue<bool>(conf, "trace.path[@snapshot]", false);
-        TraceDumper = Util::make_unique<TraceFileWriter>(path, recordOutgoing, compress, takeSnapshot, filters);
+        TraceDumper = std::make_unique<TraceFileWriter>(path, recordOutgoing, compress,
+                                                        takeSnapshot, filters);
     }
 
 #if !MOBILEAPP
-    SavedClipboards = Util::make_unique<ClipboardCache>();
+    SavedClipboards = std::make_unique<ClipboardCache>();
 
     LOG_TRC("Initialize FileServerRequestHandler");
     FileServerRequestHandler::initialize(COOLWSD::FileServerRoot);
 #endif
 
-    WebServerPoll = Util::make_unique<TerminatingPoll>("websrv_poll");
+    WebServerPoll = std::make_unique<TerminatingPoll>("websrv_poll");
 
-    PrisonerPoll = Util::make_unique<PrisonPoll>();
+    PrisonerPoll = std::make_unique<PrisonPoll>();
 
-    Server = Util::make_unique<COOLWSDServer>();
+    Server = std::make_unique<COOLWSDServer>();
 
     LOG_TRC("Initialize StorageBase");
     StorageBase::initialize();
@@ -5749,7 +5750,7 @@ int COOLWSD::innerMain()
     try
     {
         // Fetch font settings from server if configured
-        remoteFontConfigThread = Util::make_unique<RemoteFontConfigPoll>(config());
+        remoteFontConfigThread = std::make_unique<RemoteFontConfigPoll>(config());
         remoteFontConfigThread->start();
     }
     catch (const Poco::Exception&)

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -3967,7 +3967,8 @@ private:
                      requestDetails.equals(1, "getMetrics"))
             {
                 // See metrics.txt
-                std::shared_ptr<Poco::Net::HTTPResponse> response(new Poco::Net::HTTPResponse());
+                std::shared_ptr<Poco::Net::HTTPResponse> response =
+                    std::make_shared<Poco::Net::HTTPResponse>();
 
                 if (!COOLWSD::AdminEnabled)
                     throw Poco::FileAccessDeniedException("Admin console disabled");

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -2707,7 +2707,7 @@ void COOLWSD::innerInitialize(Application& self)
     SavedClipboards = Util::make_unique<ClipboardCache>();
 
     LOG_TRC("Initialize FileServerRequestHandler");
-    FileServerRequestHandler::initialize();
+    FileServerRequestHandler::initialize(COOLWSD::FileServerRoot);
 #endif
 
     WebServerPoll = Util::make_unique<TerminatingPoll>("websrv_poll");

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -2239,7 +2239,7 @@ void ClientSession::enqueueSendMessage(const std::shared_ptr<Message>& data)
     if (data->firstTokenMatches("tile:"))
     {
         // Avoid sending tile if it has the same wireID as the previously sent tile
-        tile = Util::make_unique<TileDesc>(TileDesc::parse(data->firstLine()));
+        tile = std::make_unique<TileDesc>(TileDesc::parse(data->firstLine()));
         auto iter = _oldWireIds.find(tile->generateID());
         if(iter != _oldWireIds.end() && tile->getWireId() != 0 && tile->getWireId() == iter->second)
         {

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -141,9 +141,9 @@ DocumentBroker::DocumentBroker(ChildType type, const std::string& uri, const Poc
     , _cursorWidth(0)
     , _cursorHeight(0)
     , _poll(
-          Util::make_unique<DocumentBrokerPoll>("doc" SHARED_DOC_THREADNAME_SUFFIX + _docId, *this))
+          std::make_unique<DocumentBrokerPoll>("doc" SHARED_DOC_THREADNAME_SUFFIX + _docId, *this))
     , _stop(false)
-    , _lockCtx(Util::make_unique<LockContext>())
+    , _lockCtx(std::make_unique<LockContext>())
     , _tileVersion(0)
     , _debugRenderedTileCount(0)
     , _loadDuration(0)
@@ -1162,7 +1162,7 @@ bool DocumentBroker::download(const std::shared_ptr<ClientSession>& session, con
 
         _filename = fileInfo.getFilename();
 #if !MOBILEAPP
-        _quarantine = Util::make_unique<Quarantine>(*this, _filename);
+        _quarantine = std::make_unique<Quarantine>(*this, _filename);
 #endif
 
         if (!templateSource.empty())
@@ -1187,8 +1187,8 @@ bool DocumentBroker::download(const std::shared_ptr<ClientSession>& session, con
         dontUseCache = true;
 #endif
 
-        _tileCache = Util::make_unique<TileCache>(_storage->getUri().toString(),
-                                                  _saveManager.getLastModifiedTime(), dontUseCache);
+        _tileCache = std::make_unique<TileCache>(_storage->getUri().toString(),
+                                                 _saveManager.getLastModifiedTime(), dontUseCache);
         _tileCache->setThreadOwner(std::this_thread::get_id());
     }
 
@@ -1715,8 +1715,8 @@ void DocumentBroker::uploadToStorageInternal(const std::shared_ptr<ClientSession
 
     LOG_DBG("Uploading [" << _docKey << "] after saving to URI [" << uriAnonym << "].");
 
-    _uploadRequest = Util::make_unique<UploadRequest>(uriAnonym, newFileModifiedTime, session,
-                                                      isSaveAs, isExport, isRename);
+    _uploadRequest = std::make_unique<UploadRequest>(uriAnonym, newFileModifiedTime, session,
+                                                     isSaveAs, isExport, isRename);
 
     StorageBase::AsyncUploadCallback asyncUploadCallback =
         [this](const StorageBase::AsyncUpload& asyncUp)

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -4082,8 +4082,10 @@ void DocumentBroker::dumpState(std::ostream& os)
     os << "\n  lastModifyActivityTime: " << Util::getTimeForLog(now, _lastModifyActivityTime);
     os << "\n  haveModifyActivityAfterSaveRequest: " << haveModifyActivityAfterSaveRequest();
     os << "\n  isViewFileExtension: " << _isViewFileExtension;
+#if !MOBILEAPP
     os << "\n  last quarantined version: "
        << (_quarantine ? _quarantine->lastQuarantinedFilePath() : "<unavailable>");
+#endif
 
     if (_limitLifeSeconds > std::chrono::seconds::zero())
         os << "\n  life limit in seconds: " << _limitLifeSeconds.count();

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -4082,6 +4082,8 @@ void DocumentBroker::dumpState(std::ostream& os)
     os << "\n  lastModifyActivityTime: " << Util::getTimeForLog(now, _lastModifyActivityTime);
     os << "\n  haveModifyActivityAfterSaveRequest: " << haveModifyActivityAfterSaveRequest();
     os << "\n  isViewFileExtension: " << _isViewFileExtension;
+    os << "\n  last quarantined version: "
+       << (_quarantine ? _quarantine->lastQuarantinedFilePath() : "<unavailable>");
 
     if (_limitLifeSeconds > std::chrono::seconds::zero())
         os << "\n  life limit in seconds: " << _limitLifeSeconds.count();

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -777,13 +777,13 @@ void FileServerRequestHandler::readDirToHash(const std::string &basePath, const 
         LOG_TRC("Pre-read " << fileCount << " file(s) from directory: " << basePath << path << ": " << filesRead);
 }
 
-void FileServerRequestHandler::initialize()
+void FileServerRequestHandler::initialize(const std::string& root)
 {
     // cool files
     try {
-        readDirToHash(COOLWSD::FileServerRoot, "/browser/dist");
+        readDirToHash(root, "/browser/dist");
     } catch (...) {
-        LOG_ERR("Failed to read from directory " << COOLWSD::FileServerRoot);
+        LOG_ERR("Failed to read from directory " << root);
     }
 }
 

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -735,7 +735,7 @@ void FileServerRequestHandler::readDirToHash(const std::string &basePath, const 
             strm.opaque = Z_NULL;
             deflateInit2(&strm, Z_DEFAULT_COMPRESSION, Z_DEFLATED, 31, 8, Z_DEFAULT_STRATEGY);
 
-            std::unique_ptr<char[]> buf(new char[fileStat.st_size]);
+            std::unique_ptr<char[]> buf = std::make_unique<char[]>(fileStat.st_size);
             std::string compressedFile;
             compressedFile.reserve(fileStat.st_size);
             std::string uncompressedFile;

--- a/wsd/FileServer.hpp
+++ b/wsd/FileServer.hpp
@@ -57,7 +57,7 @@ public:
                               const std::shared_ptr<StreamSocket>& socket);
 
     /// Read all files that we can serve into memory and compress them.
-    static void initialize();
+    static void initialize(const std::string& root);
 
     /// Clean cached files.
     static void uninitialize() { FileHash.clear(); }

--- a/wsd/QuarantineUtil.cpp
+++ b/wsd/QuarantineUtil.cpp
@@ -243,6 +243,17 @@ bool Quarantine::quarantineFile(const std::string& docPath)
     return false;
 }
 
+std::string Quarantine::lastQuarantinedFilePath() const
+{
+    if (!isQuarantineEnabled())
+        return std::string();
+
+    std::lock_guard<std::mutex> lock(Mutex);
+
+    const auto& fileList = QuarantineMap[_docKey];
+    return fileList.empty() ? std::string() : fileList[fileList.size() - 1];
+}
+
 void Quarantine::removeQuarantinedFiles()
 {
     std::lock_guard<std::mutex> lock(Mutex);

--- a/wsd/QuarantineUtil.hpp
+++ b/wsd/QuarantineUtil.hpp
@@ -21,7 +21,11 @@ public:
 
     static void initialize(const std::string& path);
 
+    /// Quarantines a new version of the document.
     bool quarantineFile(const std::string& docName);
+
+    /// Returns the last quarantined file's path.
+    std::string lastQuarantinedFilePath() const;
 
     /// Removes the quarantined files for the given DocKey when we unload gracefully.
     void removeQuarantinedFiles();

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -294,12 +294,11 @@ std::unique_ptr<StorageBase> StorageBase::create(const Poco::URI& uri, const std
                 "] in config");
             break;
         case StorageBase::StorageType::FileSystem:
-            return std::unique_ptr<StorageBase>(
-                new LocalStorage(uri, jailRoot, jailPath, takeOwnership));
+            return std::make_unique<LocalStorage>(uri, jailRoot, jailPath, takeOwnership);
             break;
         case StorageBase::StorageType::Wopi:
 #if !MOBILEAPP
-            return std::unique_ptr<StorageBase>(new WopiStorage(uri, jailRoot, jailPath));
+            return std::make_unique<WopiStorage>(uri, jailRoot, jailPath);
 #endif
             break;
     }
@@ -332,8 +331,7 @@ std::unique_ptr<LocalStorage::LocalFileInfo> LocalStorage::getLocalFileInfo()
     if (userNameString.empty())
         userNameString = "LocalUser#" + userId;
 
-    return std::unique_ptr<LocalStorage::LocalFileInfo>(
-        new LocalFileInfo({"LocalUser" + userId, userNameString}));
+    return std::make_unique<LocalStorage::LocalFileInfo>("LocalUser" + userId, userNameString);
 }
 
 std::string LocalStorage::downloadStorageFileToLocal(const Authorization& /*auth*/,

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -750,7 +750,7 @@ WopiStorage::getWOPIFileInfoForUri(Poco::URI uriObject, const Authorization& aut
         if (COOLWSD::AnonymizeUserData)
             Util::mapAnonymized(Util::getFilenameFromURL(filename), Util::getFilenameFromURL(getUri().toString()));
 
-        auto wopiInfo = Util::make_unique<WopiStorage::WOPIFileInfo>(fileInfo, object, uriObject);
+        auto wopiInfo = std::make_unique<WopiStorage::WOPIFileInfo>(fileInfo, object, uriObject);
         if (wopiInfo->getSupportsLocks())
             lockCtx.initSupportsLocks();
 


### PR DESCRIPTION
- gcov: support cleaning coverage data and document
- wsd: dump the last quarantined version with the status
- wsd: test: better UnitWSDClient interface
- make: better clang detection
- wsd: reduce manual http header creation
- wsd: decouple FileServerRequestHandler from COOLWSD
- wsd: include string_view
- wsd: test: new cool.html post request test
- wsd: smart pointer cleanup
- wsd: correct assertion
- wsd: Util::make_unique -> std::make_unique
