### PR TITLE
browser: remove hyperlink pop-up

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -4561,29 +4561,7 @@ L.CanvasTileLayer = L.Layer.extend({
 			this._cellCursorMarker = undefined;
 		}
 		this._removeDropDownMarker();
-
-		//hyperlink pop-up from here
-		if (this._lastFormula && this._cellCursorMarker && this._lastFormula.substring(1, 10) == 'HYPERLINK')
-		{
-			var formula = this._lastFormula;
-			var targetURL = formula.substring(11, formula.length - 1).split(',')[0];
-			targetURL = targetURL.split('"').join('');
-			if (targetURL.startsWith('#')) {
-				targetURL = targetURL.split(';')[0];
-			} else {
-				targetURL = this._map.makeURLFromStr(targetURL);
-			}
-
-			this._closeURLPopUp();
-			if (targetURL) {
-				this._showURLPopUp(this._cellCursor.getNorthEast(), targetURL);
-			}
-
-		}
-		else if (this._map.hyperlinkPopup)
-		{
-			this._closeURLPopUp();
-		}
+		this._closeURLPopUp();
 	},
 
 	_onValidityListButtonMsg: function(textMsg) {


### PR DESCRIPTION
Unfortunately, we cannot show the hyperlink pop-up,
in client side based on cell formula, because the formula
had not been evaluated.

=HYPERLINK(A1,A1);

The server should fire event "hyperlinkclicked".

Change-Id: Ie2b743812493e1790b9e54f0050974c585e61e00
Signed-off-by: Henry Castro <hcastro@collabora.com>
