### PR TITLE
allow tileprocessed to accept multiple comma-seperated tileids 

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -7125,9 +7125,11 @@ L.CanvasTileLayer = L.Layer.extend({
 	_sendProcessedResponse: function() {
 		var toSend = this._queuedProcessed;
 		this._queuedProcessed = [];
-		// FIXME: new multi-tile-processed message.
-		for (var i = 0; i < toSend.length; i++) {
-			app.socket.sendMessage('tileprocessed tile=' + toSend[i]);
+		if (toSend.length > 0) {
+			var msg = 'tileprocessed tile=' + toSend[0];
+			for (var i = 1; i < toSend.length; ++i)
+				msg += ',' + toSend[i];
+			app.socket.sendMessage(msg);
 		}
 		if (this._fetchKeyframeQueue.length > 0)
 		{

--- a/wsd/ClientSession.hpp
+++ b/wsd/ClientSession.hpp
@@ -322,7 +322,7 @@ private:
     /// ClientSession::postProcessCopyPayload().
     void preProcessSetClipboardPayload(std::string& payload);
 
-    void onTileProcessed(const std::string& tileID);
+    void onTileProcessed(const std::string_view tileID);
 
 private:
     std::weak_ptr<DocumentBroker> _docBroker;

--- a/wsd/ClientSession.hpp
+++ b/wsd/ClientSession.hpp
@@ -322,6 +322,8 @@ private:
     /// ClientSession::postProcessCopyPayload().
     void preProcessSetClipboardPayload(std::string& payload);
 
+    void onTileProcessed(const std::string& tileID);
+
 private:
     std::weak_ptr<DocumentBroker> _docBroker;
 

--- a/wsd/protocol.txt
+++ b/wsd/protocol.txt
@@ -78,10 +78,10 @@ TRACEEVENT name=<name> ph=<letter> ts=<timestamp> <more parameters>... [ args=<J
     between the beginning of the thing being timed and the time when
     the 'X' message was emitted, also in microseconds.
 
-tileprocessed tile=<tileid>
+tileprocessed tile=<tileid1,tileid2,...>
 
     Previously sent tile (server -> client) arrived and processed by the client.
-    Tileid has the next structure : <selected part>:<tile x coord>:<tile y coord>:<tile width in twips>:<tile height in twips>
+    Each tileid has the next structure : <selected part>:<tile x coord>:<tile y coord>:<tile width in twips>:<tile height in twips>
 
 downloadas name=<fileName> id=<id> format=<document format> options=<SkipImages, etc>
 


### PR DESCRIPTION
Change-Id: I383542b6c9c3a888937e2f7e330ec7e77efaaa82


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

