### PR TITLE
Fix to issue #6977

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -14,6 +14,11 @@
 	display: flex;
 }
 
+.jsdialog #writerchanges .ui-treeview-body {
+	min-height: 300px;
+	max-height: none;
+}
+
 .jsdialog-overlay.cancellable {
 	-webkit-animation: none;
 	animation: none;


### PR DESCRIPTION
Fixes the ui-treeview's limited occupied vertical space in writer. 
Change-Id: I8551242fc2b987f00c67088caa0ed07ee8526a72


* Resolves: #6977 
* Target version: master 

### Summary

As there are 3 hidden grids, changing their individual heights did not change anything so I forced change the height of ui-treeview.

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

