### PR TITLE
Add rename document to notebookbar and menubar

### DIFF
--- a/browser/src/control/Control.DocumentNameInput.js
+++ b/browser/src/control/Control.DocumentNameInput.js
@@ -29,6 +29,10 @@ L.Control.DocumentNameInput = L.Control.extend({
 						this.map.renameFile(value);
 					}
 				}
+				else {
+					// when user doesn't specify any extension
+					this.map.renameFile(value);
+				}
 			} else {
 				// saveAs for rename
 				this.map.saveAs(value);

--- a/browser/src/control/Control.DocumentNameInput.js
+++ b/browser/src/control/Control.DocumentNameInput.js
@@ -13,8 +13,7 @@ L.Control.DocumentNameInput = L.Control.extend({
 		map.on('wopiprops', this.onWopiProps, this);
 	},
 
-	documentNameConfirm: function() {
-		var value = $('#document-name-input').val();
+	documentNameConfirm: function(value) {
 		if (value !== null && value != '' && value != this.map['wopi'].BaseFileName) {
 			if (this.map['wopi'].UserCanRename && this.map['wopi'].SupportsRename) {
 				if (value.lastIndexOf('.') > 0) {
@@ -45,7 +44,8 @@ L.Control.DocumentNameInput = L.Control.extend({
 
 	onDocumentNameKeyPress: function(e) {
 		if (e.keyCode === 13) { // Enter key
-			this.documentNameConfirm();
+			var value = $('#document-name-input').val();
+			this.documentNameConfirm(value);
 		} else if (e.keyCode === 27) { // Escape key
 			this.documentNameCancel();
 		}

--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -73,6 +73,7 @@ L.Control.Menubar = L.Control.extend({
 					{name: _('PDF Document (.pdf)'), id: 'exportas-pdf', type: 'action'},
 					{name: _('EPUB (.epub)'), id: 'exportas-epub', type: 'action'}
 				]},
+				{name: _('Rename Document'), id: 'renamedocument', type: 'action'},
 				{name: _('Share...'), id:'shareas', type: 'action'},
 				{name: _('See revision history'), id: 'rev-history', type: 'action'},
 				{name: !window.ThisIsAMobileApp ? _('Download as') : _('Export as'), id: 'downloadas', type: 'menu', menu: [

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -317,6 +317,17 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 			}
 		];
 
+		content.push({
+			'type': 'container',
+			'children': [
+				{
+					'id': 'renamedocument',
+					'type': 'bigcustomtoolitem',
+					'text': _('Rename'),
+				}
+			]
+		});
+
 		return this.getTabPage(fileTabName, content);
 	},
 

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -7,6 +7,7 @@
 /* global app $ setupToolbar w2ui toolbarUpMobileItems _ Hammer */
 L.Control.UIManager = L.Control.extend({
 	mobileWizard: null,
+	documentNameInput: null,
 	blockedUI: false,
 	busyPopupTimer: null,
 	customButtons: [], // added by WOPI InsertButton
@@ -126,6 +127,7 @@ L.Control.UIManager = L.Control.extend({
 		}
 		this.refreshSidebar();
 	},
+
 	initDarkModeFromSettings: function() {
 		var selectedMode = this.getDarkModeState();
 		if (selectedMode) {
@@ -142,6 +144,15 @@ L.Control.UIManager = L.Control.extend({
 			};
 			app.socket.sendMessage('uno .uno:ChangeTheme ' + JSON.stringify(cmd));
 		}
+	},
+
+	renameDocument: function() {
+		// todo: does this need _('rename document)
+		var docNameInput = this.documentNameInput;
+		this.showInputModal('rename-modal', _('Rename Document'), _('Enter new name'), '', _('Rename'), 
+			function(newName) {
+				docNameInput.documentNameConfirm(newName);
+		});
 	},
 
 	getAccessibilityState: function() {
@@ -195,7 +206,8 @@ L.Control.UIManager = L.Control.extend({
 
 		setupToolbar(this.map);
 
-		this.map.addControl(L.control.documentNameInput());
+		this.documentNameInput = L.control.documentNameInput();
+		this.map.addControl(this.documentNameInput);
 		this.map.addControl(L.control.alertDialog());
 		this.mobileWizard = L.control.mobileWizard();
 		this.map.addControl(this.mobileWizard);

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -1067,6 +1067,9 @@ L.Map.include({
 		case 'toggledarktheme':
 			this.uiManager.toggleDarkMode();
 			break;
+		case 'renamedocument':
+			this.uiManager.renameDocument();
+			break;
 		default:
 			console.error('unknown dispatch: "' + action + '"');
 		}


### PR DESCRIPTION
Change-Id: Iec25de88aa3e7089af102dd9f4bda6507308c215

Related: [#6989](https://github.com/CollaboraOnline/online/pull/6989)

Add button to notebookbar and menubar to rename document.

* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [x] Test with integrator (nextcloud)
- [ ] Get icon
- [x] Test menubar

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

