### PR TITLE
wsd: add the web-server URL to the media-src list

### DIFF
--- a/wsd/ContentSecurityPolicy.hpp
+++ b/wsd/ContentSecurityPolicy.hpp
@@ -48,7 +48,8 @@ public:
     void appendDirective(std::string directive, std::string value)
     {
         LOG_ASSERT_MSG(value.find_first_of(';') == std::string::npos,
-                       "Unexpected semicolon in CSP policy directive");
+                       "Unexpected semicolon in CSP source [" << value << "] for policy directive ["
+                                                              << directive << ']');
 
         Util::trim(directive);
         Util::trim(value);

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -1090,6 +1090,7 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     csp.appendDirective("object-src", "'self'");
     csp.appendDirective("object-src", "blob:"); // Equivalent to unsafe-eval!
     csp.appendDirective("media-src", "'self'");
+    csp.appendDirective("media-src", cnxDetails.getWebServerUrl());
     csp.appendDirective("img-src", "'self'");
     csp.appendDirective("img-src", "data:"); // Equivalent to unsafe-inline!
     csp.appendDirective("img-src", "https://www.collaboraoffice.com/");
@@ -1104,7 +1105,7 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
             warned = true;
             LOG_WRN("The config entry net.frame_ancestors is obsolete and will be removed in the "
                     "future. Please add 'frame-ancestors "
-                    << configFrameAncestor << "' in the net.content_security_policy config");
+                    << configFrameAncestor << ";' in the net.content_security_policy config");
         }
     }
 


### PR DESCRIPTION
We need to allow loading media sources from
the web-server URL. This seems to be necessary
at least on iOS.

Change-Id: Ic7b23c4f80b975460de9311a67f3c5cb51758d14
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
