### PR TITLE
occasionally testTileSubscription fails

### DIFF
--- a/test/TileCacheTests.cpp
+++ b/test/TileCacheTests.cpp
@@ -339,6 +339,13 @@ void TileCacheTests::testTileSubscription()
     auto delta1b = getResponseDesc(socket1, "delta:", testname + "1 ");
     LOK_ASSERT_MESSAGE("did not receive a delta: message as expected", !!delta1b);
 
+    // ordering is undefined tiles arrive in so swap if needed:
+    if (tile1a->getTilePosX() != delta1a->getTilePosX())
+    {
+        std::swap(delta1a, delta1b);
+        TST_LOG("tiles re-ordered for once");
+    }
+
     // check WIDs variously
     LOK_ASSERT_EQUAL(tile1a->getWireId(), delta1a->getWireId());
     LOK_ASSERT_EQUAL(tile1b->getWireId(), delta1b->getWireId());


### PR DESCRIPTION
sometimes the deltas arrive in a different order, later in the same test we have "ordering is undefined tiles arrive in so swap if needed" for a pair of later deltas, so do the same reordering for this intermittently failing earlier test


Change-Id: If51edb9a4e22d469d9e029c38da7348c34b17832


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

