### PR TITLE
ios: fix doubleclick in navi, with single clicks

### DIFF
--- a/browser/src/control/jsdialog/Widget.TreeView.js
+++ b/browser/src/control/jsdialog/Widget.TreeView.js
@@ -123,6 +123,8 @@ function _getCellIconId(cellData) {
 	return iconId;
 }
 
+var lastClickHelperRow = -1;
+var lastClickHelperId = '';
 function _treelistboxEntry(parentContainer, treeViewData, entry, builder, isTreeView, treeRoot) {
 	if (entry.text == '<dummy>')
 		return;
@@ -257,7 +259,21 @@ function _treelistboxEntry(parentContainer, treeViewData, entry, builder, isTree
 		});
 
 		if (!singleClick) {
-			$(text).dblclick(doubleClickFunction);
+			if (window.ThisIsTheiOSApp) {
+				text.addEventListener('click', function() {
+					if (entry.row == lastClickHelperRow && treeViewData.id == lastClickHelperId)
+						doubleClickFunction();
+					else {
+						lastClickHelperRow = entry.row;
+						lastClickHelperId = treeViewData.id;
+						setTimeout(function() {
+							lastClickHelperRow = -1;
+						}, 300);
+					}
+				});
+			} else {
+				$(text).dblclick(doubleClickFunction);
+			}
 		}
 	}
 }


### PR DESCRIPTION
dblclick seems not to work on ios, but click does. We can simulate dblclick with single clicks.


Change-Id: Ic9ae58a39122025c9947294ebfd2292ffe04ae5c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

