### PR TITLE
admin: imprv ui sizes of adminClusterOverview.html

### DIFF
--- a/browser/admin/adminClusterOverview.html
+++ b/browser/admin/adminClusterOverview.html
@@ -5,6 +5,29 @@
     Admin.ClusterOverview(host);
 </script>
 
+<style>
+  /* Set graph text size  */
+  svg g, svg text {
+      font-size: 1em; /* based on parent div */
+  }
+  /* Set to scroll otherwise tablets can spill over into other cards*/
+  .card {
+      overflow: auto;
+  }
+  /* Decrease left panel when on laptop  */
+  @media screen and (max-width: 1024px) {
+      #column-admin-panel {
+          width: 20% !important;
+      }
+  }
+  /* Hide left panel before reaching mobile (there is no space)  */
+  @media screen and (max-width: 960px) {
+      #column-admin-panel {
+          display: none !important;
+      }
+  }
+</style>
+
 <div class="is-fullwidth has-text-white" style="height:62px;background-color:#17191E;line-height:50px;">
     <a style="margin-left:12px;color:#9D998D;"><script>document.write(l10nstrings.strProductName + ' - ' + l10nstrings.strAdminConsole)</script></a>
 </div>

--- a/browser/admin/adminClusterOverview.html
+++ b/browser/admin/adminClusterOverview.html
@@ -6,10 +6,6 @@
 </script>
 
 <style>
-  /* Set graph text size  */
-  svg g, svg text {
-      font-size: 1em; /* based on parent div */
-  }
   /* Set to scroll otherwise tablets can spill over into other cards*/
   .card {
       overflow: auto;

--- a/browser/admin/src/AdminClusterOverview.js
+++ b/browser/admin/src/AdminClusterOverview.js
@@ -21,7 +21,7 @@ var AdminClusterOverview = AdminSocketBase.extend({
         top: 5,
         right: 0,
         bottom: 5,
-        left: 25
+        left: 30
     },
 
     _interval: 5000,
@@ -226,6 +226,7 @@ var AdminClusterOverview = AdminSocketBase.extend({
 
         var yAxis = svg.append('g')
             .attr('class', 'y-axis axis')
+            .style('font-size', '1em')
             .call(yAxisGenerator);
 
         yAxis.select('.domain').attr('stroke-width', 0);


### PR DESCRIPTION
- Graph axis text is too small (10px) better to set it to 1em based on
parent div (16px). Good to also set any group within svg to 1em to
avoid any surprises
- Currently tablets from one card is spilling over to the next card
when there is not enough space. Better to allow scrolling.
- The left pane should be hidden even before reaching the mobile
size. This will fix the lack of space for cards and avoid everything
being so small

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I58c88385875469b56542703663e570ab4d63fbdc
