### PR TITLE
feat: Add tooltip to hide menu button (compact view)

### DIFF
--- a/browser/src/control/Control.TopToolbar.js
+++ b/browser/src/control/Control.TopToolbar.js
@@ -245,7 +245,7 @@ L.Control.TopToolbar = L.Control.extend({
 			{type: 'button',  id: 'customanimation', img: 'sidebar_custom_animation', hint: _UNO('.uno:CustomAnimation', 'presentation', true), uno: '.uno:CustomAnimation', hidden: true},
 			{type: 'button',  id: 'masterslidespanel', img: 'sidebar_master_slides', hint: _UNO('.uno:MasterSlidesPanel', 'presentation', true), uno: '.uno:MasterSlidesPanel', hidden: true},
 			{type: 'button',  id: 'navigator', img: 'navigator', hint: _UNO('.uno:Navigator'), uno: '.uno:Navigator', hidden: true},
-			{type: 'button',  id: 'fold',  img: 'fold', desktop: true, mobile: false, hidden: true},
+			{type: 'button',  id: 'fold',  img: 'fold', hint: _('Hide Menu'), desktop: true, mobile: false, hidden: true},
 			{type: 'button',  id: 'hamburger-tablet',  img: 'fold', desktop: false, mobile: false, tablet: true, iosapptablet: false, hidden: true},
 		];
 	},

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -656,7 +656,7 @@ L.Control.UIManager = L.Control.extend({
 		var obj = $('.unfold');
 		obj.removeClass('w2ui-icon unfold');
 		obj.addClass('w2ui-icon fold');
-
+		$('#tb_editbar_item_fold').prop('title', _('Hide Menu'));
 	},
 
 	hideMenubar: function() {
@@ -670,7 +670,7 @@ L.Control.UIManager = L.Control.extend({
 		var obj = $('.fold');
 		obj.removeClass('w2ui-icon fold');
 		obj.addClass('w2ui-icon unfold');
-
+		$('#tb_editbar_item_fold').prop('title', _('Show Menu'));
 	},
 
 	isMenubarHidden: function() {


### PR DESCRIPTION
Change-Id: I05011bf9ffec99af8558c7af06dce5e350511f7c


* Resolves: #3751 
* Target version: master 

### Summary
Add tooltip (Show Menu / Hide Menu) to the up/down chevron button (compact view)

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

