### PR TITLE
Add check for Insert_buttons to display in tablet view

### DIFF
--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -459,6 +459,9 @@ L.Control.UIManager = L.Control.extend({
 		}
 
 		this.customButtons.push(button);
+		if (button.tablet === false && window.mode.isTablet()) {
+			return;
+		}
 		this.insertCustomButton(button);
 	},
 


### PR DESCRIPTION
Added tablet check for Insert buttons to display on dom or not based on passed condition .
 - By default custom buttons will show up in tablet.
Signed-off-by: Darshan-upadhyay1110 <darshan.upadhyay@collabora.com>
Change-Id: I103461b02405bc03d63671b885a31735668d4111
