### PR TITLE
Screen reader doesn't properly report tab names in Tab View UI

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -1184,6 +1184,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 				tab.number = item.id - 1;
 				tab.textContent = title;
 				tab.setAttribute('role', 'tab');
+				tab.setAttribute('aria-label', title);
 				builder._setAccessKey(tab, builder._getAccessKeyFromText(item.text));
 				builder._stressAccessKey(tab, tab.accessKey);
 


### PR DESCRIPTION
Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I0ebe938080fa0e6865d4bf18e5dd33b0eb6a1567
