### PR TITLE
Remove open_local_editor button in tablet view

### DIFF
--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -583,14 +583,14 @@ L.Control.UIManager = L.Control.extend({
 		}
 
 		this.customButtons.push(button);
-		if (button.tablet === false && window.mode.isTablet()) {
-			return;
-		}
 		this.insertCustomButton(button);
 	},
 
 	// insert custom button to the current UI
 	insertCustomButton: function(button) {
+		if (button.tablet === false && window.mode.isTablet()) {
+			return;
+		}
 		if (!this.notebookbar)
 			this.insertButtonToClassicToolbar(button);
 		else


### PR DESCRIPTION
Change-Id: I18908150ee537bfe7dd36b0b94f8baa11d2739ea


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
Before it was showing custome buttons even if tablet flag is false. but now we will only insert button if conditon matches 
Patch for this PR : https://github.com/CollaboraOnline/online/pull/7005

### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

