### PR TITLE
FIX: JSDialog: label vs textarea vs input field inconsistent paddings

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -521,6 +521,7 @@ input[type='checkbox']:checked.autofilter, .jsdialog input[type='checkbox']:chec
 	border-radius: var(--border-radius);
 	overflow: hidden;
 	align-self: center;
+	padding-inline: 4px;
 }
 
 #search_edit.ui-edit.autofilter {
@@ -576,6 +577,10 @@ input[type='checkbox']:checked.autofilter, .jsdialog input[type='checkbox']:chec
 /* text label */
 
 .ui-dialog-content .jsdialog.ui-text {
+	padding-inline-start: 0;
+}
+
+.jsdialog.ui-text {
 	padding-inline-start: 8px;
 }
 


### PR DESCRIPTION
These changes provide a decent padding to both the label and text area, with having no changes caused in the sidebar. 

Change-Id: I53494733c47b35d59133979c456665b4174e393c


* Resolves: #7037
* Target version: master 

### Summary


### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

