### PR TITLE
calc: canvas: use original mouse event cordinates for auto fill marker

### DIFF
--- a/browser/src/layer/tile/AutoFillMarkerSection.ts
+++ b/browser/src/layer/tile/AutoFillMarkerSection.ts
@@ -212,14 +212,9 @@ class AutoFillMarkerSection extends CanvasSectionObject {
 
 			this.sectionProperties.inMouseDown = true;
 
-			// revert coordinates to global and fire event again with position in the center
-			var canvasClientRect = this.containerObject.getCanvasBoundingClientRect();
-			point[0] = this.myTopLeft[0] / app.dpiScale + this.size[0] * 0.5 + 1 + canvasClientRect.left;
-			point[1] = this.myTopLeft[1] / app.dpiScale + this.size[1] * 0.5 + 1 + canvasClientRect.top;
-
 			var newPoint = {
-				clientX: point[0],
-				clientY: point[1],
+				clientX: e.pageX,
+				clientY: e.pageY,
 			};
 
 			var newEvent = this.sectionProperties.docLayer._createNewMouseEvent('mousedown', newPoint);


### PR DESCRIPTION
problem:
with extreme zoom or on high DPI monitors,
calculated coordinates caused problems,
i.e trying to use the auto fill marker will select the adjacent cell


Change-Id: Ib5943d5263c73624c51d28bd8e3826493c9268ef

* Target version: master 


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

