### PR TITLE
autofill onMouseDown doesn't generate working event position for hidpi

### DIFF
--- a/browser/src/layer/tile/AutoFillMarkerSection.ts
+++ b/browser/src/layer/tile/AutoFillMarkerSection.ts
@@ -213,9 +213,10 @@ class AutoFillMarkerSection extends CanvasSectionObject {
 			this.sectionProperties.inMouseDown = true;
 
 			// revert coordinates to global and fire event again with position in the center
+			// inverse of convertPositionToCanvasLocale
 			var canvasClientRect = this.containerObject.getCanvasBoundingClientRect();
-			point[0] = this.myTopLeft[0] / app.dpiScale + this.size[0] * 0.5 + 1 + canvasClientRect.left;
-			point[1] = this.myTopLeft[1] / app.dpiScale + this.size[1] * 0.5 + 1 + canvasClientRect.top;
+			point[0] = (this.myTopLeft[0] + this.size[0] * 0.5 + 1) / app.dpiScale + canvasClientRect.left;
+			point[1] = (this.myTopLeft[1] + this.size[1] * 0.5 + 1) / app.dpiScale + canvasClientRect.top;
 
 			var newPoint = {
 				clientX: point[0],


### PR DESCRIPTION
so the autofill handle in hidpi didn't work


Change-Id: I718d9a8d3954a441705849eba174fe6b5b2983c4


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

