### PR TITLE
Remove open_local_editor button in tablet view

### DIFF
--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -459,14 +459,14 @@ L.Control.UIManager = L.Control.extend({
 		}
 
 		this.customButtons.push(button);
-		if (button.tablet === false && window.mode.isTablet()) {
-			return;
-		}
 		this.insertCustomButton(button);
 	},
 
 	// insert custom button to the current UI
 	insertCustomButton: function(button) {
+		if (button.tablet === false && window.mode.isTablet()) {
+			return;
+		}
 		if (!this.notebookbar)
 			this.insertButtonToClassicToolbar(button);
 		else


### PR DESCRIPTION
Change-Id: I18908150ee537bfe7dd36b0b94f8baa11d2739ea


Before it would insert the button on tablet when switching the UI view

By default custom buttons will show up in tablet.
Signed-off-by: Darshan-upadhyay1110 darshan.upadhyay@collabora.com
Change-Id: I18908150ee537bfe7dd36b0b94f8baa11d2739ea

