### PR TITLE
Tablet: Non-functional sidebar button shown in read-only mode

### DIFF
--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -328,10 +328,12 @@ L.Control.UIManager = L.Control.extend({
 	refreshNotebookbar: function() {
 		this.removeNotebookbarUI();
 		this.createNotebookbarControl(this.map.getDocType());
+		if (this._map._permission === 'edit') {
+			$('.main-nav').removeClass('readonly');
+		}
 		this.makeSpaceForNotebookbar();
 		this.notebookbar._showNotebookbar = true;
 		this.notebookbar.showTabs();
-		$('.main-nav').removeClass('readonly');
 		$('#map').addClass('notebookbar-opened');
 		this.insertCustomButtons();
 		this.map.sendInitUNOCommands();


### PR DESCRIPTION
Do not wrongly switch part of the UI to edit mode when on read-only mode. Best to be only remove readonly css class when it's not needed as opposed to removed it whenever refreshNotebookbar() is called.

Before this commit:
- We were showing tabs in wrong mode (readonly mode) -> every-time refreshNotebookbar() was called. Thus, initial tablet mode was appearing with icons and actions from edit mode.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I6ad9c8c14e60d4c3513f63b75717db0a124b73ea (cherry picked from commit ec67c92264775b2fd52de32d2abe2f053c53be15)

* Target version: 22.05 

### TODO

- [ ] ...

### Checklist

- [X] Code is properly formatted
- [X] All commits have Change-Id
- [ ] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

