### PR TITLE
autofill onMouseDown doesn't generate working event position for hidpi

### DIFF
--- a/browser/src/layer/tile/AutoFillMarkerSection.ts
+++ b/browser/src/layer/tile/AutoFillMarkerSection.ts
@@ -213,9 +213,10 @@ class AutoFillMarkerSection extends CanvasSectionObject {
 			this.sectionProperties.inMouseDown = true;
 
 			// revert coordinates to global and fire event again with position in the center
+			// inverse of convertPositionToCanvasLocale
 			var canvasClientRect = this.containerObject.getCanvasBoundingClientRect();
-			point[0] = this.myTopLeft[0] / app.dpiScale + this.size[0] * 0.5 + 1 + canvasClientRect.left;
-			point[1] = this.myTopLeft[1] / app.dpiScale + this.size[1] * 0.5 + 1 + canvasClientRect.top;
+			point[0] = (this.myTopLeft[0] + this.size[0] * 0.5 + 1) / app.dpiScale + canvasClientRect.left;
+			point[1] = (this.myTopLeft[1] + this.size[1] * 0.5 + 1) / app.dpiScale + canvasClientRect.top;
 
 			var newPoint = {
 				clientX: point[0],


### PR DESCRIPTION
so the autofill handle in hidpi didn't work

Signed-off-by: Caolán McNamara <caolan.mcnamara@collabora.com>
Change-Id: I718d9a8d3954a441705849eba174fe6b5b2983c4 (cherry picked from commit 912dfcd08ef2dc20b1f04fdce6dbb84bb970d770)


* Resolves: #6738
* Target version: 22.05 


### Checklist

- [X] Code is properly formatted
- [X] All commits have Change-Id
- [ ] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

