### PR TITLE
NC is sending custom buttons information before the UI is switched.

### DIFF
--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -535,6 +535,9 @@ L.Control.UIManager = L.Control.extend({
 	// UI modification
 
 	insertButtonToClassicToolbar: function(button) {
+		if (!w2ui['editbar'])
+			return; // Early exit.
+
 		if (!w2ui['editbar'].get(button.id)) {
 			if (this.map.isEditMode()) {
 				// add the css rule for the image


### PR DESCRIPTION
This is causing JS errors if the UI will be forced into compact mode.

Error occurs on PDF files.


Change-Id: I767882640641dd5f46351d2d50e8639d3efee778


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

