### PR TITLE
When document layer is not ready and socket message is not delayed, m…

### DIFF
--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -1187,6 +1187,20 @@ app.definitions.Socket = L.Class.extend({
 		if (this._map._docLayer && !msgDelayed) {
 			this._map._docLayer._onMessage(textMsg, e.image);
 		}
+		else if (!this._map._docLayer && !msgDelayed) {
+			// If message is delayed and document layer is not ready at the time, message gets lost.
+			// To prevent this, we wait a little for document layer.
+			var waitForDocLayer = function(message, image) {
+				setTimeout(function() {
+					if (this._map._docLayer)
+						this._map._docLayer._onMessage(message, image);
+					else
+						waitForDocLayer(message, image);
+				}.bind(this), 300);
+			}.bind(this);
+
+			waitForDocLayer(textMsg, e.image);
+		}
 	},
 
 	_exportAsCallback: function(command) {


### PR DESCRIPTION
…essage is lost.

Wait for doclayer to be ready in this case.


Change-Id: Ib3e9427a89e8be7d97f7baf92bdcb6295c695ca2


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

