### PR TITLE
Allow 'download as' uno commands to be sent when file is readonly

### DIFF
--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -366,12 +366,12 @@ L.Map.include({
 		var isAllowedInReadOnly = false;
 		var allowedCommands = ['.uno:Save', '.uno:WordCountDialog',
 			'.uno:Signature', '.uno:ShowResolvedAnnotations',
-			'.uno:ToolbarMode?Mode:string=notebookbar_online.ui', '.uno:ToolbarMode?Mode:string=Default'];
+			'.uno:ToolbarMode?Mode:string=notebookbar_online.ui', '.uno:ToolbarMode?Mode:string=Default', 
+			'.uno:ExportToEPUB', '.uno:ExportToPDF', '.uno:ExportDirectToPDF'];
 		if (this.isPermissionEditForComments()) {
 			allowedCommands.push('.uno:InsertAnnotation','.uno:DeleteCommentThread', '.uno:DeleteAnnotation', '.uno:DeleteNote',
 				'.uno:DeleteComment', '.uno:ReplyComment', '.uno:ReplyToAnnotation', '.uno:ResolveComment',
-				'.uno:ResolveCommentThread', '.uno:ResolveComment', '.uno:EditAnnotation', '.uno:ExportToEPUB', '.uno:ExportToPDF',
-				'.uno:ExportDirectToPDF');
+				'.uno:ResolveCommentThread', '.uno:ResolveComment', '.uno:EditAnnotation');
 		}
 
 		for (var i in allowedCommands) {


### PR DESCRIPTION
Change-Id: I725182cb8bcf2c4244367538d244117a0b9147f8


* Resolves: #6653 
* Target version: master 

### Summary
When a document is read-only user cannot export as pdf or epub (rtf, doc, and docx work correctly)

- First problem is with `Toolbar.js:sendUnoCommand` where the allowed commands don't include export uno commands unless comment editing is allowed
- After fixing that `Download as > PDF Document as` works but PDF and EPUB direct download don't work
- Can see outgoing `ExportDirectToPDF` and `ExportToEPUB` logged in console but dont seem to make it to core side: `ChildSession::_handleInput` isn't called nor is `Socket.js:_onMessage`


### TODO

- [ ] Fix direct downloads for EPUB and PDF

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

