### PR TITLE
android: fix app crashes after closing the document

### DIFF
--- a/android/lib/src/main/cpp/androidapp.cpp
+++ b/android/lib/src/main/cpp/androidapp.cpp
@@ -35,6 +35,7 @@ static int fakeClientFd;
 static int closeNotificationPipeForForwardingThread[2] = {-1, -1};
 static JavaVM* javaVM = nullptr;
 static bool lokInitialized = false;
+static std::mutex coolwsdRunningMutex;
 
 // Remember the reference to the LOActivity
 jclass g_loActivityClz = nullptr;
@@ -182,9 +183,11 @@ void closeDocument()
 {
     // Close one end of the socket pair, that will wake up the forwarding thread that was constructed in HULLO
     fakeSocketClose(closeNotificationPipeForForwardingThread[0]);
-
+    LOG_DBG("Waiting for Lokit to finish...");
+    std::unique_lock<std::mutex> lokitLock(COOLWSD::lokit_main_mutex);
+    LOG_DBG("Lokit has finished.");
     LOG_DBG("Waiting for COOLWSD to finish...");
-    std::unique_lock<std::mutex> lock(COOLWSD::lokit_main_mutex);
+    std::unique_lock<std::mutex> coolwsdLock(coolwsdRunningMutex);
     LOG_DBG("COOLWSD has finished.");
 }
 
@@ -345,6 +348,7 @@ Java_org_libreoffice_androidlib_LOActivity_createCOOLWSD(JNIEnv *env, jobject in
                     {
                         LOG_DBG("Creating COOLWSD");
                         {
+                            std::unique_lock<std::mutex> lock(coolwsdRunningMutex);
                             fakeClientFd = fakeSocketSocket();
                             LOG_DBG("createCOOLWSD created fakeClientFd: " << fakeClientFd);
                             std::unique_ptr<COOLWSD> coolwsd = std::make_unique<COOLWSD>();


### PR DESCRIPTION
- It exits LOActivity when lokit thread finishes using lokit_main_mutex. But if we edit document and exit without saving lokit thread gets finished but COOLWSD is still running to clean up the docBrokers. It takes some time to clean up this docBrokers. We need to exit the LOActivity only after COOLWSD is finished
- for that I have added coolwsdRunningMutex again - it was removed in ad32888d7c2ec960255d826c245f7df2e93c3f1b


Change-Id: Ic9785f5aa55deafbac98efc4013bd3376d0ba62d

