### PR TITLE
Fix failed starts when core is at a relative path

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1118,7 +1118,7 @@ AS_IF([test "$ENABLE_IOSAPP" != "true" -a "$ENABLE_ANDROIDAPP" != "true"],
       [AC_MSG_CHECKING([for LibreOffice path])
       if test -n "$with_lo_path"; then
           # strip trailing '/' from LO_PATH, 'ln -s' with such path will otherwise fail
-          LO_PATH="${with_lo_path%/}"
+          LO_PATH=`readlink -f ${with_lo_path%/}`
           AC_MSG_RESULT([found])
       else
           AC_MSG_RESULT([not found])


### PR DESCRIPTION
- Previously giving --with-lo-path as a relative path caused collabora online to crash with "component context fails to supply singleton" errors
- This patch uses readlink on the with-lo-path option, expanding it into its full canonical path
- I could probably have gotten away with realpath, but for consistency with --with-lokit-path I decided to use readlink -f

Change-Id: I16aacddbda9749451578fb7aded6c3c4e145ee26

Fixes #7041 
* Target version: master 

### Summary

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

