### PR TITLE
jsdialog: always execute close message from server

### DIFF
--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -70,10 +70,6 @@ L.Control.JSDialog = L.Control.extend({
 			return;
 		}
 
-		var newestDialog = Math.max.apply(null, Object.keys(this.dialogs).map(function(i) { return parseInt(i);}));
-		if (newestDialog > parseInt(id))
-			return;
-
 		this.focusToLastElement(id);
 
 		var builder = this.clearDialog(id);
@@ -287,6 +283,11 @@ L.Control.JSDialog = L.Control.extend({
 
 		if (instance.nonModal) {
 			instance.titleCloseButton.onclick = function() {
+				var newestDialog = Math.max.apply(null,
+					Object.keys(instance.that.dialogs).map(function(i) { return parseInt(i);}));
+				if (newestDialog > parseInt(instance.id))
+					return;
+
 				instance.that.closeDialog(instance.id, true);
 			};
 


### PR DESCRIPTION
Block only close requests from the user clicking on 'X' button. We need to always process close messages from the server.

Eg. Format -> Theme, click Add:
then close parent dialog using 'x' -> should not work then close parent using 'cancel' button -> should exit dialog

test together with: https://gerrit.libreoffice.org/c/core/+/155715