### PR TITLE
jsdialog: add minimal size for treeview

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -366,6 +366,7 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 	overflow-y: auto;
 	overflow-x: hidden;
 	max-width: 1000px;
+	min-width: 150px;
 	padding: 1px;
 	padding-inline-end: 3px;
 }


### PR DESCRIPTION
Without it in calc -> insert -> chart treeview
for chart type selection was invisible / 0px width