### PR TITLE
jsdialog: fix error on insert_button

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2490,7 +2490,8 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			else
 				console.warn('_unoToolButton: no id provided');
 
-			L.DomUtil.addClass(div, data.command.replace(':', '').replace('.', ''));
+			if (data.command)
+				L.DomUtil.addClass(div, data.command.replace(':', '').replace('.', ''));
 
 			if (isRealUnoCommand)
 				id = builder._makeIdUnique(id);


### PR DESCRIPTION
When button is inserted using postmessage API
it can have no command property. Prevent us from
TypeError here.
