### PR TITLE
impress: remove unused mobile-slide-sorter

### DIFF
--- a/browser/css/device-mobile.css
+++ b/browser/css/device-mobile.css
@@ -578,14 +578,6 @@ td[id^='tb_spreadsheet-toolbar_item']:focus table.w2ui-button div.w2ui-icon, td[
 	right: 0;
 }
 
-/* Related to mobilewizard.cxx */
-#mobile-wizard-header.landscape {
-	display: none;
-}
-#mobile-wizard-header.portrait {
-	display: block;
-}
-
 /* Related to mobile-wizard based menubar */
 #mobile-wizard.menuwizard.landscape #mobile-wizard-content.landscape {
 	overflow-y: auto !important;

--- a/browser/css/mobilewizard.css
+++ b/browser/css/mobilewizard.css
@@ -487,13 +487,6 @@ p.mobile-wizard.ui-combobox-text.selected {
 	background-color: var(--color-background-lighter);
 }
 
-#mobile-wizard-header {
-	position: sticky;
-	top: 0;
-	background-color: var(--color-background-lighter);
-	z-index: 2;
-}
-
 .ui-tab.mobile-wizard {
 	display: table-cell;
 	width: 49%;
@@ -658,7 +651,7 @@ a.leaflet-control-zoom-in {
 #slide-sorter .preview-img:hover{
 	border-color: var(--color-primary-darker);
 }
-#slide-sorter .preview-img-currentpart, #mobile-wizard-header .preview-img-currentpart{
+#slide-sorter .preview-img-currentpart{
 	border-color: var(--color-primary-dark);
 	border-style: solid;
 	border-radius: var(--border-radius);

--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -1534,13 +1534,11 @@ L.Control.Menubar = L.Control.extend({
 							window.app.console.log('======> Assertion failed!? Not window.mode.isMobile()? Control.Menubar.js #1');
 							$nav.css({height: 'initial', bottom: '38px'});
 							$menu.hide().slideDown(250, function() { $menu.css('display', ''); });
-							$('#mobile-wizard-header').show();
 						} else {
 							window.mobileMenuWizard = true;
 							var menuData = self._map.menubar.generateFullMenuStructure();
 							self._map.fire('mobilewizard', {data: menuData});
 							$('#toolbar-hamburger').removeClass('menuwizard-closed').addClass('menuwizard-opened');
-							$('#mobile-wizard-header').hide();
 							$('#toolbar-mobile-back').css('visibility', 'hidden');
 							$('#formulabar').hide();
 						}

--- a/browser/src/control/Control.MobileWizard.js
+++ b/browser/src/control/Control.MobileWizard.js
@@ -104,9 +104,6 @@ L.Control.MobileWizard = L.Control.extend({
 		if (window.pageMobileWizard === true)
 			window.pageMobilewizard = false;
 
-		if (this.map.getDocType() === 'presentation' || this.map.getDocType() === 'drawing')
-			this._hideSlideSorter();
-
 		if (window.commentWizard === true)
 			window.commentWizard = false;
 
@@ -215,10 +212,6 @@ L.Control.MobileWizard = L.Control.extend({
 			}
 			this._hideWizard();
 		}
-	},
-
-	_hideSlideSorter: function() {
-		document.getElementById('mobile-wizard-header').style.display = 'none';
 	},
 
 	onJSUpdate: function (e) {

--- a/browser/src/control/Control.PartsPreview.js
+++ b/browser/src/control/Control.PartsPreview.js
@@ -151,14 +151,6 @@ L.Control.PartsPreview = L.Control.extend({
 
 			// re-create scrollbar with new direction
 			this._direction = !window.mode.isDesktop() && !window.mode.isTablet() && L.DomUtil.isPortrait() ? 'x' : 'y';
-
-			// Hide portrait view's previews when layout view is used.
-			if (this._direction === 'x' && window.mode.isMobile()) {
-				document.getElementById('mobile-slide-sorter').style.display = 'block';
-			}
-			else if (this._direction === 'y' && window.mode.isMobile()) {
-				document.getElementById('mobile-slide-sorter').style.display = 'none';
-			}
 		}
 	},
 

--- a/browser/src/layer/tile/ImpressTileLayer.js
+++ b/browser/src/layer/tile/ImpressTileLayer.js
@@ -89,20 +89,6 @@ L.ImpressTileLayer = L.CanvasTileLayer.extend({
 			map._docPreviews = {};
 
 		map.uiManager.initializeSpecializedUI(this._docType);
-		if (window.mode.isMobile()) {
-			L.Control.MobileWizard.mergeOptions({maxHeight: '55vh'});
-			var mobileWizard = L.DomUtil.get('mobile-wizard');
-			var container = L.DomUtil.createWithId('div', 'mobile-wizard-header', mobileWizard);
-			var preview = L.DomUtil.createWithId('div', 'mobile-slide-sorter', container);
-			L.DomUtil.toBack(container);
-			map.addControl(L.control.partsPreview(container, preview, {
-				fetchThumbnail: false,
-				allowOrientation: false,
-				axis: 'x',
-				imageClass: 'preview-img-portrait',
-				frameClass: 'preview-frame-portrait'
-			}));
-		}
 	},
 
 	onResizeImpress: function () {


### PR DESCRIPTION
- to show previews we use slide-sorter element and presentation-controls-wrapper as container


Change-Id: Iaed0892779d5016a565d556955305317129edea4

* Target version: master 

