### PR TITLE
Add missing dark mode toggle in mobile view

### DIFF
--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -947,6 +947,7 @@ L.Control.Menubar = L.Control.extend({
 				{uno: '.uno:ControlCodes', id: 'formattingmarks'},
 				{uno: '.uno:SpellOnline'},
 				{name: _UNO('.uno:ShowResolvedAnnotations', 'text'), id: 'showresolved', type: 'action', uno: '.uno:ShowResolvedAnnotations'},
+				{name: _('Dark Mode'), id: 'toggledarktheme', type: 'action'},
 			]
 			},
 			window.enableAccessibility ?
@@ -2341,6 +2342,8 @@ L.Control.Menubar = L.Control.extend({
 		} else if (item.id === 'togglea11ystate') {
 			if (this._map.uiManager.getAccessibilityState())
 				menuStructure['checked'] = true;
+		} else if (item.id === 'toggledarktheme' && this._map.uiManager.getDarkModeState()) {
+			menuStructure['checked'] = true;
 		}
 
 		if (item.menu)

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -118,14 +118,8 @@ L.Control.UIManager = L.Control.extend({
 			};
 			app.socket.sendMessage('uno .uno:ChangeTheme ' + JSON.stringify(cmd));
 		}
-		if (this.getCurrentMode() === 'classic' || this.map.isReadOnlyMode()) {
-			this.refreshMenubar();
-			this.refreshToolbar();
-		}
-		else {
-			this.refreshNotebookbar();
-		}
-		this.refreshSidebar();
+		if (!window.mode.isMobile())
+			this.refreshAfterThemeChange();
 	},
 
 	initDarkModeFromSettings: function() {
@@ -440,22 +434,33 @@ L.Control.UIManager = L.Control.extend({
 		app.UI.notebookbarAccessibility.initialize();
 	},
 
-	refreshNotebookbar: function() {
-		var selectedTab = $('.ui-tab.notebookbar[aria-selected="true"]').attr('id') || 'Home-tab-label';
-		this.removeNotebookbarUI();
-		this.createNotebookbarControl(this.map.getDocType());
-		if (this._map._permission === 'edit') {
-			$('.main-nav').removeClass('readonly');
+	refreshAfterThemeChange: function() {
+		if (this.getCurrentMode() === 'classic' || this.map.isReadOnlyMode()) {
+			this.refreshMenubar();
+			this.refreshToolbar();
 		}
-		$('#' + selectedTab).click();
-		this.makeSpaceForNotebookbar();
-		this.notebookbar._showNotebookbar = true;
-		this.notebookbar.showTabs();
-		$('#map').addClass('notebookbar-opened');
-		this.insertCustomButtons();
-		this.map.sendInitUNOCommands();
-		if (this.map.getDocType() === 'presentation')
-			this.map.fire('toggleslidehide');
+		else {
+			this.refreshNotebookbar();
+		}
+		this.refreshSidebar();
+	},
+
+	refreshNotebookbar: function() {
+			var selectedTab = $('.ui-tab.notebookbar[aria-selected="true"]').attr('id') || 'Home-tab-label';
+			this.removeNotebookbarUI();
+			this.createNotebookbarControl(this.map.getDocType());
+			if (this._map._permission === 'edit') {
+				$('.main-nav').removeClass('readonly');
+			}
+			$('#' + selectedTab).click();
+			this.makeSpaceForNotebookbar();
+			this.notebookbar._showNotebookbar = true;
+			this.notebookbar.showTabs();
+			$('#map').addClass('notebookbar-opened');
+			this.insertCustomButtons();
+			this.map.sendInitUNOCommands();
+			if (this.map.getDocType() === 'presentation')
+				this.map.fire('toggleslidehide');
 	},
 
 	refreshMenubar: function() {


### PR DESCRIPTION
Change-Id: I89100d703444e8bfe2a8960d00c62a1e1ea88a84


* Resolves: #7094 
* Target version: master 

### Summary
- Added missing dark mode icon  with checkmark.

### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

