### PR TITLE
cool#7102 fix 2nd presentation under chrome not appearing

### DIFF
--- a/browser/src/map/handler/Map.SlideShow.js
+++ b/browser/src/map/handler/Map.SlideShow.js
@@ -85,6 +85,10 @@ L.Map.SlideShow = L.Handler.extend({
 			document.msFullscreenElement;
 		if (!this.fullscreen) {
 			L.DomUtil.remove(this._slideShow);
+			// #7102 on exit from fullscreen we don't get a 'focus' event
+			// in chome so a later second attempt at launching a presentation
+			// fails
+			this._map.focus();
 		}
 	},
 


### PR DESCRIPTION
On entering full screen the normal browser window goes "idle" on losing focus. When the full screen presentation exits no "focus" events gets sent to the normal window so clicking "presentation" again doesn't do anything as idle inhibits anything getting actually sent to the server.

in:
commit 5f655a7555cd836933dc14395495561f5f8cd04e
Date:   Tue Oct 13 19:26:16 2015 +0300

    loleaflet: print handler tdf#94607

a similar _map.focus() is done after a similar L.DomUtil.remove()

and doing there same here gets this case to work.


Change-Id: Iae44ba949af2a64bf669b9d5f1113c647a354af1


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

