### PR TITLE
unocommands.py: Treat JS/TS files as UTF-8

### DIFF
--- a/scripts/unocommands.py
+++ b/scripts/unocommands.py
@@ -75,7 +75,7 @@ def extractMenuCommands(path):
     commands = []
 
     # extract from the menu specifications
-    f = open(path + '/browser/src/control/Control.Menubar.js', 'r')
+    f = open(path + '/browser/src/control/Control.Menubar.js', 'r', encoding='utf-8')
     for line in f:
         if line.find("uno:") >= 0 and line.find("name:") < 0:
             commands += commandFromMenuLine(line)
@@ -92,7 +92,7 @@ def extractContextCommands(path):
     commands = []
 
     # extract from the comments whitelist
-    f = open(path + '/browser/src/control/Control.ContextMenu.js', 'r')
+    f = open(path + '/browser/src/control/Control.ContextMenu.js', 'r', encoding='utf-8')
     readingCommands = False
     for line in f:
         if line.find('UNOCOMMANDS_EXTRACT_START') >= 0:
@@ -102,17 +102,17 @@ def extractContextCommands(path):
         elif readingCommands:
             commands += commandsFromLine(line)
 
-    f = open(path + '/browser/src/control/Control.ColumnHeader.ts', 'r')
+    f = open(path + '/browser/src/control/Control.ColumnHeader.ts', 'r', encoding='utf-8')
     for line in f:
         if line.find("_UNO(") >= 0:
             commands += commandFromMenuLine(line)
 
-    f = open(path + '/browser/src/control/Control.RowHeader.ts', 'r')
+    f = open(path + '/browser/src/control/Control.RowHeader.ts', 'r', encoding='utf-8')
     for line in f:
         if line.find("_UNO(") >= 0:
             commands += commandFromMenuLine(line)
 
-    f = open(path + '/browser/src/control/Control.Tabs.js', 'r')
+    f = open(path + '/browser/src/control/Control.Tabs.js', 'r', encoding='utf-8')
     for line in f:
         if line.find("_UNO(") >= 0:
             commands += commandFromMenuLine(line)
@@ -128,74 +128,74 @@ def extractToolbarCommands(path):
     commands = []
 
     # extract from the toolbars
-    f = open(path + '/browser/src/control/Control.Toolbar.js', 'r')
+    f = open(path + '/browser/src/control/Control.Toolbar.js', 'r', encoding='utf-8')
     for line in f:
         if line.find("_UNO(") >= 0:
             commands += commandFromMenuLine(line)
 
-    f = open(path + '/browser/src/control/Control.MobileBottomBar.js', 'r')
+    f = open(path + '/browser/src/control/Control.MobileBottomBar.js', 'r', encoding='utf-8')
     for line in f:
         if line.find("_UNO(") >= 0:
             commands += commandFromMenuLine(line)
 
-    f = open(path + '/browser/src/control/Control.MobileTopBar.js', 'r')
+    f = open(path + '/browser/src/control/Control.MobileTopBar.js', 'r', encoding='utf-8')
     for line in f:
         if line.find("_UNO(") >= 0:
             commands += commandFromMenuLine(line)
 
-    f = open(path + '/browser/src/control/Control.MobileWizardBuilder.js', 'r')
-    for line in f:
-        if line.find("_UNO(") >= 0:
-            commands += commandFromMenuLine(line)
-
-    f = open(path +
-             '/browser/src/control/Control.NotebookbarBuilder.js', 'r')
-    for line in f:
-        if line.find("_UNO(") >= 0:
-            commands += commandFromMenuLine(line)
-
-    f = open(path + '/browser/src/control/Control.Notebookbar.js', 'r')
-    for line in f:
-        if line.find("_UNO(") >= 0:
-            commands += commandFromMenuLine(line)
-
-    f = open(path + '/browser/src/control/Control.NotebookbarWriter.js', 'r')
-    for line in f:
-        if line.find("_UNO(") >= 0:
-            commands += commandFromMenuLine(line)
-
-    f = open(path + '/browser/src/control/Control.NotebookbarCalc.js', 'r')
+    f = open(path + '/browser/src/control/Control.MobileWizardBuilder.js', 'r', encoding='utf-8')
     for line in f:
         if line.find("_UNO(") >= 0:
             commands += commandFromMenuLine(line)
 
     f = open(path +
-             '/browser/src/control/Control.NotebookbarImpress.js', 'r')
+             '/browser/src/control/Control.NotebookbarBuilder.js', 'r', encoding='utf-8')
     for line in f:
         if line.find("_UNO(") >= 0:
             commands += commandFromMenuLine(line)
 
-    f = open(path + '/browser/src/control/Control.NotebookbarDraw.js', 'r')
+    f = open(path + '/browser/src/control/Control.Notebookbar.js', 'r', encoding='utf-8')
     for line in f:
         if line.find("_UNO(") >= 0:
             commands += commandFromMenuLine(line)
 
-    f = open(path + '/browser/src/control/Control.PresentationBar.js', 'r')
+    f = open(path + '/browser/src/control/Control.NotebookbarWriter.js', 'r', encoding='utf-8')
     for line in f:
         if line.find("_UNO(") >= 0:
             commands += commandFromMenuLine(line)
 
-    f = open(path + '/browser/src/control/Control.SearchBar.js', 'r')
+    f = open(path + '/browser/src/control/Control.NotebookbarCalc.js', 'r', encoding='utf-8')
     for line in f:
         if line.find("_UNO(") >= 0:
             commands += commandFromMenuLine(line)
 
-    f = open(path + '/browser/src/control/Control.StatusBar.js', 'r')
+    f = open(path +
+             '/browser/src/control/Control.NotebookbarImpress.js', 'r', encoding='utf-8')
     for line in f:
         if line.find("_UNO(") >= 0:
             commands += commandFromMenuLine(line)
 
-    f = open(path + '/browser/src/control/Control.TopToolbar.js', 'r')
+    f = open(path + '/browser/src/control/Control.NotebookbarDraw.js', 'r', encoding='utf-8')
+    for line in f:
+        if line.find("_UNO(") >= 0:
+            commands += commandFromMenuLine(line)
+
+    f = open(path + '/browser/src/control/Control.PresentationBar.js', 'r', encoding='utf-8')
+    for line in f:
+        if line.find("_UNO(") >= 0:
+            commands += commandFromMenuLine(line)
+
+    f = open(path + '/browser/src/control/Control.SearchBar.js', 'r', encoding='utf-8')
+    for line in f:
+        if line.find("_UNO(") >= 0:
+            commands += commandFromMenuLine(line)
+
+    f = open(path + '/browser/src/control/Control.StatusBar.js', 'r', encoding='utf-8')
+    for line in f:
+        if line.find("_UNO(") >= 0:
+            commands += commandFromMenuLine(line)
+
+    f = open(path + '/browser/src/control/Control.TopToolbar.js', 'r', encoding='utf-8')
     for line in f:
         if line.find("_UNO(") >= 0:
             commands += commandFromMenuLine(line)


### PR DESCRIPTION
Otherwise eg. non-ASCII shortcuts appearing in files can cause failures like this.

Traceback (most recent call last):
  File ".../rpmbuild/BUILD/coolwsd-23.05.2.2snapshot/scripts/unocommands.py", line 454, in <module>
    toolbarCommands = extractToolbarCommands(onlineDir)
  File ".../rpmbuild/BUILD/coolwsd-23.05.2.2snapshot/scripts/unocommands.py", line 163, in extractToolbarCommands
    for line in f:
  File "/usr/lib64/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]

Encountered after 1a2500c8d31f12a8e23c648a0afb208e3d09bb05.

This is not ASCII in browser/src/control/Control.NotebookbarWriter.js:
`'accessibility': { focusBack: true,     combination: 'AI',      de: 'ÖI' }


Change-Id: I72aac2809530c14b9440f73e5072db17770f438a

* Target version: master 


### Checklist

- [X] Code is properly formatted
- [X] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required