### PR TITLE
Switch tab using keyboard shortcut

### DIFF
--- a/browser/src/map/handler/Map.Keyboard.js
+++ b/browser/src/map/handler/Map.Keyboard.js
@@ -717,6 +717,24 @@ L.Map.Keyboard = L.Handler.extend({
 				case this.keyCodes.D: // d
 					app.socket.sendMessage('uno .uno:InsertEndnote');
 					return true;
+				case this.keyCodes.pageUp:
+				case this.keyCodes.pageDown :
+					if (this._map.getDocType() === 'spreadsheet') {
+						var currentSelectedPart = this._map._docLayer._selectedPart;
+						var parts = this._map._docLayer._parts;
+						var partToSelect = 0;
+						this._map._docLayer._clearReferences();
+			
+						if (e.keyCode === this.keyCodes.pageUp) {
+							partToSelect = currentSelectedPart != parts - 1 ? currentSelectedPart + 1 : 0;
+						}
+						else {
+							partToSelect = currentSelectedPart != 0 ? currentSelectedPart - 1 : parts - 1;
+						}
+						this._map.setPart(parseInt(partToSelect), /*external:*/ false, /*calledFromSetPartHandler:*/ true);
+						return;
+					}
+
 				}
 			} else if (e.altKey) {
 				switch (e.keyCode) {


### PR DESCRIPTION
Signed-off-by: Darshan-upadhyay1110 <darshan.upadhyay@collabora.com>
Change-Id: I4e76a0cc382fbe97f16037c8f9d78174e8663491


* Target version: master 

### Summary

LO is offering this using `CTRL`+`PageUp` or 'PageDown`.
- but there are some browser restriction related to security purpose some of the event we can not prevent.
- for an example CTRL + PageUp will not be prevented using JS in browser ( as per browser security rules )
- so i have tried to add this shortcut using Ctrl + Alt
- we can cycle through all sheets.

Adding this small enhancement  as part of this `HackWeek` :)




