### PR TITLE
Fix 'manage changes' dialog expanding infinitely

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -14,11 +14,6 @@
 	display: flex;
 }
 
-.jsdialog #writerchanges .ui-treeview-body {
-	min-height: 300px;
-	max-height: none;
-}
-
 .jsdialog-overlay.cancellable {
 	-webkit-animation: none;
 	animation: none;
@@ -1570,4 +1565,10 @@ kbd,
 
 .warn-copy-paste {
 	width: 100%;
+}
+
+/* manage changes dialog */
+
+.jsdialog #writerchanges .ui-treeview-body {
+	min-height: 300px;
 }


### PR DESCRIPTION
A regression in #7011 caused the manage changes dialog to continue expanding when new elements were added, no matter how big it got. This would cause you to be unable to see all the changes when there were a lot of them because you could not scroll through the list. This patch fixes the scrolling, without making the list area very small again.

Change-Id: Ib29fb161522773ea9893b7bc21d06aab19b74c52

* Target version: master 

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

