### PR TITLE
fix: empty mobile wizard when opened for the first time

### DIFF
--- a/browser/src/control/Control.MobileWizardWindow.js
+++ b/browser/src/control/Control.MobileWizardWindow.js
@@ -678,7 +678,7 @@ L.Control.MobileWizardWindow = L.Control.extend({
 		}
 
 		if (currentLevel) {
-			currentLevel = currentLevel.substring('level-'.length);
+			currentLevel = parseInt(currentLevel.substring('level-'.length));
 			this._builder._currentDepth = currentLevel;
 		}
 
@@ -687,6 +687,9 @@ L.Control.MobileWizardWindow = L.Control.extend({
 		parent.insertBefore(temporaryParent.firstChild, control.nextSibling);
 		var backupGridSpan = control.style.gridColumn;
 		L.DomUtil.remove(control);
+
+		// reset _builder._currentDepth
+		this._builder._currentDepth = 0;
 
 		// when we updated toolbox or menubutton with color picker we need to leave
 		// mobile wizard at the same level (opened color picker) on update


### PR DESCRIPTION
- it was only affecting wizard with tabs


Change-Id: I6172a3a1a498982927e63676c4743be8f2ff9d80

* Target version: master 

