### PR TITLE
Notebookbar: introduce simple search button

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2250,6 +2250,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		}
 
 		var iconURLAliases = {
+			'home-search': 'recsearch',
 			'addmb-menu': 'ok',
 			'closetablet': 'view',
 			'defineprintarea': 'menuprintranges',

--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -1849,7 +1849,8 @@ L.Control.Menubar = L.Control.extend({
 			|| id.startsWith('zotero')
 			|| id === 'deletepage'
 			|| id === 'remotelink'
-			|| id === 'toggledarktheme') {
+			|| id === 'toggledarktheme'
+			|| id === 'home-search') {
 			this._map.dispatch(id);
 		} else if (id === 'insertcomment') {
 			this._map.insertComment();

--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -827,11 +827,34 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				'vertical': 'true'
 			},
 			{
-				'id': 'home-search-dialog',
-				'type': 'bigtoolitem',
-				'text': _UNO('.uno:SearchDialog'),
-				'command': '.uno:SearchDialog',
-				'accessibility': { focusBack: true,	combination: 'FD', de: null }
+				'type': 'container',
+				'children': [
+					{
+						'type': 'toolbox',
+						'children': [
+								{
+									'id': 'home-search',
+									'type': 'menubartoolitem',
+									'text': _('Search'),
+									'command': _('Show Status Bar'),
+									'accessibility': { focusBack: false,	combination: 'SS',	de: 'SS' }
+								}
+							]
+						},
+						{
+							'type': 'toolbox',
+							'children': [
+								{
+									'id': 'home-search-dialog',
+									'type': 'toolitem',
+									'text': _UNO('.uno:SearchDialog'),
+									'command': '.uno:SearchDialog',
+									'accessibility': { focusBack: false, 	combination: 'FD',	de: null }
+								}
+							]
+						}
+					],
+				'vertical': 'true'
 			},
 			{
 				'id': 'Home-Section-Find',

--- a/browser/src/control/Control.NotebookbarDraw.js
+++ b/browser/src/control/Control.NotebookbarDraw.js
@@ -886,12 +886,35 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 				'vertical': 'true'
 			},
 			{
-				'id': 'home-search-dialog',
-				'type': 'bigtoolitem',
-				'text': _UNO('.uno:SearchDialog'),
-				'command': '.uno:SearchDialog',
-				'accessibility': { focusBack: true, combination: 'FD', de: null }
-			}
+				'type': 'container',
+				'children': [
+					{
+						'type': 'toolbox',
+						'children': [
+								{
+									'id': 'home-search',
+									'type': 'menubartoolitem',
+									'text': _('Search'),
+									'command': _('Show Status Bar'),
+									'accessibility': { focusBack: false,	combination: 'SS',	de: 'SS' }
+								}
+							]
+						},
+						{
+							'type': 'toolbox',
+							'children': [
+								{
+									'id': 'home-search-dialog',
+									'type': 'toolitem',
+									'text': _UNO('.uno:SearchDialog'),
+									'command': '.uno:SearchDialog',
+									'accessibility': { focusBack: false, 	combination: 'FD',	de: null }
+								}
+							]
+						}
+					],
+				'vertical': 'true'
+			},
 		];
 
 		return this.getTabPage('Home', content);

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -877,10 +877,35 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'command': 'presentation'
 			},
 			{
-				'type': 'bigtoolitem',
-				'text': _UNO('.uno:SearchDialog'),
-				'command': '.uno:SearchDialog'
-			}
+				'type': 'container',
+				'children': [
+					{
+						'type': 'toolbox',
+						'children': [
+								{
+									'id': 'home-search',
+									'type': 'menubartoolitem',
+									'text': _('Search'),
+									'command': _('Show Status Bar'),
+									'accessibility': { focusBack: false,	combination: 'SS',	de: 'SS' }
+								}
+							]
+						},
+						{
+							'type': 'toolbox',
+							'children': [
+								{
+									'id': 'home-search-dialog',
+									'type': 'toolitem',
+									'text': _UNO('.uno:SearchDialog'),
+									'command': '.uno:SearchDialog',
+									'accessibility': { focusBack: false, 	combination: 'FD',	de: null }
+								}
+							]
+						}
+					],
+				'vertical': 'true'
+			},
 		];
 
 		return this.getTabPage('Home', content);

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -837,12 +837,35 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				'vertical': 'true'
 			},
 			{
-				'id': 'home-search-dialog',
-				'type': 'bigtoolitem',
-				'text': _UNO('.uno:SearchDialog'),
-				'command': '.uno:SearchDialog',
-				'accessibility': { focusBack: false, 	combination: 'FD',	de: 'US' }
-			}
+				'type': 'container',
+				'children': [
+					{
+						'type': 'toolbox',
+						'children': [
+								{
+									'id': 'home-search',
+									'type': 'menubartoolitem',
+									'text': _('Search'),
+									'command': _('Show Status Bar'),
+									'accessibility': { focusBack: false,	combination: 'SS',	de: 'SS' }
+								}
+							]
+						},
+						{
+							'type': 'toolbox',
+							'children': [
+								{
+									'id': 'home-search-dialog',
+									'type': 'toolitem',
+									'text': _UNO('.uno:SearchDialog'),
+									'command': '.uno:SearchDialog',
+									'accessibility': { focusBack: false, 	combination: 'FD',	de: 'US' }
+								}
+							]
+						}
+					],
+				'vertical': 'true'
+			},
 		];
 
 		return this.getTabPage(homeTabName, content);

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -801,6 +801,11 @@ L.Control.UIManager = L.Control.extend({
 			this.showStatusBar();
 	},
 
+	focusSearch: function() {
+		this.showStatusBar();
+		document.getElementById('search-input').focus();
+	},
+
 	isStatusBarVisible: function() {
 		return $('#toolbar-down').is(':visible');
 	},

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -1067,6 +1067,9 @@ L.Map.include({
 		case 'toggledarktheme':
 			this.uiManager.toggleDarkMode();
 			break;
+		case 'home-search':
+			this.uiManager.focusSearch();
+			break;
 		case 'renamedocument':
 			this.uiManager.renameDocument();
 			break;


### PR DESCRIPTION
This way we increase status bar discoverability ( fixes #7098 ) and
group both search functionality in one place in the home tab

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ia1fa8fe58903088aad37a560edd033a184d35e0e
