### PR TITLE
Stop coolwsd when /etc/coolwsd/coolwsd.xml changes

### DIFF
--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -269,6 +269,8 @@
         <remote_url desc="remote server to which you will send resquest to get remote config in response" type="string" default=""></remote_url>
     </remote_config>
 
+    <stop_on_config_change desc="Stop coolwsd whenever config files change." type="bool" default="false">false</stop_on_config_change>
+
     <remote_font_config>
         <url desc="URL of optional JSON file that lists fonts to be included in Online" type="string" default=""></url>
     </remote_font_config>


### PR DESCRIPTION
- This allows you to, say, have a docker container and --restart=always
  to restart when you update the config
- This patch only listens for "/etc/coolwsd/coolwsd.xml", so if you
  specify a config file that isn't there then you're out of luck... An
  improvement for a followup patch will be make it listen to wherever
  your config files actually are
- This patch doesn't work when editing /etc/coolwsd/coolwsd.xml with vim
  as vim moves the file before writing a new file in the right place.
  Again, this may be a fix for a followup patch. The current docker
  scripts only listen for modifications, so this matches that behavior

- This patch adds an option to enable this feature, it is off by default