### PR TITLE
Fix regression in tab cycle in dialogs

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -1177,7 +1177,8 @@ L.Control.JSDialogBuilder = L.Control.extend({
 				var title = builder._cleanText(item.text);
 
 				var tab = L.DomUtil.create('button', 'ui-tab ' + builder.options.cssClass, tabsContainer);
-				tab.id = item.id;
+				// avoid duplicated ids: we receive plain number from core, append prefix
+				tab.id = Number.isInteger(parseInt(item.id)) ? data.id + '-' + item.id : item.id;
 				tab.textContent = title;
 				tab.setAttribute('role', 'tab');
 				tab.setAttribute('aria-label', title);

--- a/cypress_test/integration_tests/desktop/writer/file_properties_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/file_properties_spec.js
@@ -19,7 +19,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'File Property Tests', func
 
 	it('Add File Description.', function() {
 		writerHelper.openFileProperties();
-		cy.cGet('#tabcontrol #2').click();
+		cy.cGet('#tabcontrol-2').click();
 		helper.waitUntilIdle('#title.ui-edit');
 		cy.cGet('#title.ui-edit').type('New Title');
 		// sometimes it doesn't finish typing
@@ -38,7 +38,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'File Property Tests', func
 		cy.cGet('#ok.ui-pushbutton').click();
 		writerHelper.openFileProperties();
 
-		cy.cGet('#tabcontrol #2').click();
+		cy.cGet('#tabcontrol-2').click();
 		cy.cGet('#title.ui-edit').should('have.value', 'New Title');
 		cy.cGet('#comments.ui-textarea').should('have.value', 'New');
 


### PR DESCRIPTION
this is regression from commit:
f8e53bd851a267fd50f369a1beb3c398d46f620a
Assign tab ids while defining tabs.

When opened Format -> Page Style dialog in Writer. There was "123" label next to the tabs.
Also when switching between widgets using tab key
it was moving focus outside window.

Core is sending id as plain number what is easy to duplicate. Let's add some unique name.
