### PR TITLE
feature-locking: send lock/restriction status from client session

### DIFF
--- a/browser/src/map/Map.js
+++ b/browser/src/map/Map.js
@@ -280,7 +280,6 @@ L.Map = L.Evented.extend({
 		this.on('docloaded', function(e) {
 			this._docLoaded = e.status;
 			if (this._docLoaded) {
-				app.socket.sendMessage('blockingcommandstatus isRestrictedUser=' + this.Restriction.isRestrictedUser + ' isLockedUser=' + this.Locking.isLockedUser);
 				app.idleHandler.notifyActive();
 				if (!document.hasFocus()) {
 					this.fire('editorgotfocus');

--- a/wsd/ClientSession.hpp
+++ b/wsd/ClientSession.hpp
@@ -262,6 +262,10 @@ public:
     void sendLockedInfo();
 #endif
 
+#if ENABLE_FEATURE_RESTRICTION
+    void sendRestrictionInfo();
+#endif
+
     /// Process an SVG to replace embedded file:/// media URIs with public http URLs.
     std::string processSVGContent(const std::string& svg);
 

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1002,22 +1002,6 @@ bool DocumentBroker::download(const std::shared_ptr<ClientSession>& session, con
         }
     }
 
-#if ENABLE_FEATURE_RESTRICTION
-    Object::Ptr restrictionInfo = new Object();
-    restrictionInfo->set("IsRestrictedUser", CommandControl::RestrictionManager::isRestrictedUser());
-
-    // Poco:Dynamic:Var does not support std::unordred_set so converted to std::vector
-    std::vector<std::string> restrictedCommandList(CommandControl::RestrictionManager::getRestrictedCommandList().begin(),
-                                                CommandControl::RestrictionManager::getRestrictedCommandList().end());
-    restrictionInfo->set("RestrictedCommandList", restrictedCommandList);
-
-    std::ostringstream ossRestrictionInfo;
-    restrictionInfo->stringify(ossRestrictionInfo);
-    const std::string restrictionInfoString = ossRestrictionInfo.str();
-    LOG_TRC("Sending command restriction info to client: " << restrictionInfoString);
-    session->sendMessage("restrictedCommands: " + restrictionInfoString);
-#endif
-
 #if ENABLE_SUPPORT_KEY
     if (!COOLWSD::OverrideWatermark.empty())
         watermarkText = COOLWSD::OverrideWatermark;


### PR DESCRIPTION
problem:
earlier restriction/lock status was sent to kit via browser, now client session send this status directily to the kit. this design will require less communication between server and browser


Change-Id: I6b830f30fb326a5e6637e345250893cbba101de6


* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

