### PR TITLE
Add cli option to use settings from env variables

### DIFF
--- a/man/coolwsd.1
+++ b/man/coolwsd.1
@@ -30,5 +30,7 @@ coolwsd OPTIONS
 .PP
 \fB\-\-nocaps\fR                       Use a non\-privileged forkit, with increase in security problems.
 .PP
+\fB\-\-use\-env\-vars\fR                Override coolwsd.xml config with options from the environment variables described in https://col.la/dockercodeconfigviaenv
+.PP
 .SH "SEE ALSO"
 coolforkit(1), coolconvert(1), coolconfig(1), coolwsd-systemplate-setup(1), coolmount(1)

--- a/wsd/COOLWSD.hpp
+++ b/wsd/COOLWSD.hpp
@@ -249,6 +249,7 @@ public:
     static bool AdminEnabled;
     static bool UnattendedRun; //< True when run from an unattended test, not interactive.
     static bool SignalParent;
+    static bool UseEnvVarOptions;
     static std::string RouteToken;
 #if ENABLE_DEBUG
     static bool SingleKit;
@@ -518,6 +519,7 @@ protected:
 
     void defineOptions(Poco::Util::OptionSet& options) override;
     void handleOption(const std::string& name, const std::string& value) override;
+    void initializeEnvOptions();
     int main(const std::vector<std::string>& args) override;
 
     /// Handle various global static destructors.


### PR DESCRIPTION
Change-Id: I75762ad620132037523fa82167a3ff17075c7027


* Target version: master 

### Summary
Currently [in docker it is possible to do configuration through
environment variables](https://col.la/dockercodeconfigviaenv), which
works using the start-collabora-online.sh start-collabora-online.pl
scripts. This PR lets COOLWSD listen to the same environment
variables directly

### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

