### PR TITLE
reduce cost of TileDesc::parse

### DIFF
--- a/common/Log.hpp
+++ b/common/Log.hpp
@@ -255,7 +255,6 @@ static constexpr std::size_t skipPathPrefix(const char (&s)[N], std::size_t n = 
 #define LOG_FILE_NAME(f) (&f[skipPathPrefix(f)])
 #endif
 
-#define STRINGIFY(X) #X
 #define STRING(X) STRINGIFY(X)
 
 #ifdef __ANDROID__

--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -42,6 +42,8 @@
 
 #include <StringVector.hpp>
 
+#define STRINGIFY(X) #X
+
 #if CODE_COVERAGE
 extern "C"
 {


### PR DESCRIPTION
perf reported 6.58% of time in collaborative multi user test on 2023-08-24 was spent in TileDesc::parse and much of that in std::unordered_map.

There are only 12 arguments in the map we care about here so we can just used a sorted array, look by name on write, and read by index.


Change-Id: Iadfc2001e298d8f4d46200c8488f0eb4cd8734c2


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

