### PR TITLE
cool#7164 use existing delay queue for 'canonicalidchange'

### DIFF
--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -1187,20 +1187,6 @@ app.definitions.Socket = L.Class.extend({
 		if (this._map._docLayer && !msgDelayed) {
 			this._map._docLayer._onMessage(textMsg, e.image);
 		}
-		else if (!this._map._docLayer && !msgDelayed) {
-			// If message is delayed and document layer is not ready at the time, message gets lost.
-			// To prevent this, we wait a little for document layer.
-			var waitForDocLayer = function(message, image) {
-				setTimeout(function() {
-					if (this._map._docLayer)
-						this._map._docLayer._onMessage(message, image);
-					else
-						waitForDocLayer(message, image);
-				}.bind(this), 300);
-			}.bind(this);
-
-			waitForDocLayer(textMsg, e.image);
-		}
 	},
 
 	_exportAsCallback: function(command) {
@@ -1316,6 +1302,7 @@ app.definitions.Socket = L.Class.extend({
 	_tryToDelayMessage: function(textMsg) {
 		var delayed = false;
 		if (textMsg.startsWith('window:') ||
+			textMsg.startsWith('canonicalidchange:') ||
 			textMsg.startsWith('celladdress:') ||
 			textMsg.startsWith('cellviewcursor:') ||
 			textMsg.startsWith('statechanged:') ||


### PR DESCRIPTION
https://github.com/CollaboraOnline/online/issues/7164

might be best to add everything to this queue, and not drop any incoming message, and then process the queue when both this._map._docLayer and _isReady become available/true.

But perhaps this serves as a reasonable safe checkpoint to return to if it becomes necessary.


Change-Id: Ib77a4126437689709e2ca0915667b5b9b2f2f207


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

