### PR TITLE
Support for Theme dialog in Calc, Draw, Impress

### DIFF
--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -469,7 +469,8 @@ L.Control.Menubar = L.Control.extend({
 				{uno: '.uno:FormatLine'},
 				{uno: '.uno:FormatArea'},
 				{type: 'separator'},
-				{uno: '.uno:OutlineBullet'}]
+				{uno: '.uno:OutlineBullet'},
+				{uno: '.uno:ThemeDialog'}]
 			},
 			{name: _UNO('.uno:TableMenu', 'text'/*HACK should be 'presentation', but not in xcu*/), id:'table', type: 'menu', menu: [
 				{name: _UNO('.uno:InsertTable', 'text'), uno: '.uno:InsertTable'},
@@ -603,7 +604,8 @@ L.Control.Menubar = L.Control.extend({
 				{uno: '.uno:FormatLine'},
 				{uno: '.uno:FormatArea'},
 				{type: 'separator'},
-				{uno: '.uno:OutlineBullet'}]
+				{uno: '.uno:OutlineBullet'},
+				{uno: '.uno:ThemeDialog'}]
 			},
 			{name: _UNO('.uno:TableMenu', 'text'/*HACK should be 'presentation', but not in xcu*/), id: 'table', type: 'menu', menu: [
 				{name: _UNO('.uno:InsertTable', 'text'), uno: '.uno:InsertTable'},

--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -814,7 +814,8 @@ L.Control.Menubar = L.Control.extend({
 				{type: 'separator'},
 				{uno: '.uno:TransformDialog'},
 				{uno: '.uno:FormatLine'},
-				{uno: '.uno:FormatArea'}
+				{uno: '.uno:FormatArea'},
+				{uno: '.uno:ThemeDialog'}
 			]},
 			{name: _UNO('.uno:SheetMenu', 'spreadsheet'), id: 'sheet', type: 'menu', menu: [
 				{uno: '.uno:InsertCell'},

--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -1956,6 +1956,13 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				'enabled': 'true',
 				'accessibility': { focusBack: true,	combination: 'SM', de: null }
 			},
+			{
+				'id': 'format-theme-dialog',
+				'type': 'bigtoolitem',
+				'text': _UNO('.uno:ThemeDialog'),
+				'command': '.uno:ThemeDialog',
+				'accessibility': { focusBack: false, combination: 'J', de: null }
+			}
 		];
 
 		return this.getTabPage('Format', content);

--- a/browser/src/control/Control.NotebookbarDraw.js
+++ b/browser/src/control/Control.NotebookbarDraw.js
@@ -1417,6 +1417,13 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 				'text': _UNO('.uno:TransformDialog'),
 				'command': '.uno:TransformDialog',
 				'accessibility': { focusBack: true, combination: 'TD', de: null }
+			},
+			{
+				'id': 'format-theme-dialog',
+				'type': 'bigtoolitem',
+				'text': _UNO('.uno:ThemeDialog'),
+				'command': '.uno:ThemeDialog',
+				'accessibility': { focusBack: false, combination: 'J', de: null }
 			}
 		];
 

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -960,6 +960,13 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'type': 'bigtoolitem',
 				'text': _UNO('.uno:TransformDialog'),
 				'command': '.uno:TransformDialog'
+			},
+			{
+				'id': 'format-theme-dialog',
+				'type': 'bigtoolitem',
+				'text': _UNO('.uno:ThemeDialog'),
+				'command': '.uno:ThemeDialog',
+				'accessibility': { focusBack: false, combination: 'J', de: null }
 			}
 		];
 


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
Adds support to trigger the Theme dialog in menu bar and notbeook bar in Calc, then also Impress and Draw.

### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

