### PR TITLE
feature_lock: fix unlock_image option not working

### DIFF
--- a/browser/src/control/Control.Command.js
+++ b/browser/src/control/Control.Command.js
@@ -62,7 +62,7 @@ L.Map.include({
 			return;
 		var message = [
 			'<div class="container">',
-			'<img id="unlock-image" class="item illustration">',
+			'<img id="unlock-image">',
 			'<div class="item">',
 			'<h1>' + this.Locking.unlockTitle + '</h1>',
 			'<p>' + this.Locking.unlockDescription + '<p>',
@@ -93,8 +93,10 @@ L.Map.include({
 		}
 
 		var unlockImage = L.DomUtil.get('unlock-image');
+		L.DomUtil.setStyle(unlockImage, 'width', '100%');
+		L.DomUtil.setStyle(unlockImage, 'height', 'auto');
 		if (this.Locking.unlockImageUrlPath) {
-			unlockImage.src = this.Locking.unlockImageUrlPath;
+			unlockImage.src = 'remote/static' + this.Locking.unlockImageUrlPath;
 		} else {
 			unlockImage.src = 'images/lock-illustration.svg';
 		}

--- a/configure.ac
+++ b/configure.ac
@@ -1602,7 +1602,7 @@ if test "$enable_feature_lock" = "yes"; then
         <unlock_title desc=\"Title to show user when prompting the unlock popup\" default=\"$UNLOCK_TITLE\">$UNLOCK_TITLE</unlock_title>
         <unlock_link desc=\"Link from where user can unlock the features\" default=\"$UNLOCK_LINK\">$UNLOCK_LINK</unlock_link>
         <unlock_description desc=\"Description about unlocking features\" default=\"$UNLOCK_DESCRIPTION\">$UNLOCK_DESCRIPTION</unlock_description>
-        <unlock_image desc=\"URL of image shown when unlock dialog get displayed\" default=\"\"></unlock_image><!-- URL structure - https://<hostname>/static/<image_endpoint> -->
+        <unlock_image desc=\"URL of image shown when unlock dialog get displayed\" default=\"\"></unlock_image>
         <writer_unlock_highlights desc=\"Short note about Writer benefits of unlocking\" default=\"$WRITER_UNLOCK_HIGHLIGHTS\">$WRITER_UNLOCK_HIGHLIGHTS</writer_unlock_highlights>
         <calc_unlock_highlights desc=\"Short note about Calc benefits of unlocking\" default=\"$CALC_UNLOCK_HIGHLIGHTS\">$CALC_UNLOCK_HIGHLIGHTS</calc_unlock_highlights>
         <impress_unlock_highlights desc=\"Short note about Impress benefits of unlocking\" default=\"$IMPRESS_UNLOCK_HIGHLIGHTS\">$IMPRESS_UNLOCK_HIGHLIGHTS</impress_unlock_highlights>

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -3932,7 +3932,7 @@ private:
                         {
                             const std::string& serverUri =
                                 unlockImageUri.getScheme() + "://" + unlockImageUri.getAuthority();
-                            ProxyRequestHandler::handleRequest(uri.substr(pos + ProxyRemoteLen),
+                            ProxyRequestHandler::handleRequest(uri.substr(pos + sizeof("/remote/static") - 1),
                                                                socket, serverUri);
                         }
                     }


### PR DESCRIPTION
- regression from ec17f72fb516e8b68fac669f9bd0a28c1264f9a3
- also removed the restriction to have "static" in unlock_image url


Change-Id: Ie4f1170fb6a12db5218fb28f21d78f88ebc61d56

