### PR TITLE
a11y: don't focus map if focusBack is false

### DIFF
--- a/browser/src/dom/NotebookbarAccessibility.js
+++ b/browser/src/dom/NotebookbarAccessibility.js
@@ -173,6 +173,8 @@ var NotebookbarAccessibility = function() {
 	};
 
 	this.clickOnFilteredItem = function() {
+		var itemWasClicked = false;
+
 		if (this.filteredItem !== null) {
 			var element = document.getElementById(this.filteredItem.id);
 			if (element) {
@@ -188,6 +190,7 @@ var NotebookbarAccessibility = function() {
 					this.state = 1;
 				}
 				else if (this.state === 1) {
+					itemWasClicked = true;
 					this.setTabItemDescription(element);
 					element.click();
 					if (this.filteredItem && this.filteredItem.focusBack === true) {
@@ -199,6 +202,8 @@ var NotebookbarAccessibility = function() {
 		}
 		else
 			this.focusToMap();
+
+		return itemWasClicked;
 	};
 
 	this.addTabFocus = function() {
@@ -304,8 +309,9 @@ var NotebookbarAccessibility = function() {
 				this.checkCombinationAgainstAcccelerators();
 				this.filterOutNonMatchingInfoBoxes();
 			}
-			if (this.filteredItem !== null)
-				this.clickOnFilteredItem();
+			// If item was clicked - don't focus the map to keep focus on dropdowns
+			if (this.filteredItem !== null && this.clickOnFilteredItem())
+				return;
 			// So we checked the pressed key against available combinations. If there is no match, focus back to map.
 			if (this.isAllFilteredOut() === true)
 				this.focusToMap();


### PR DESCRIPTION
This fixes regression introduced in commit 2ac7183e44e16a2a6956665d2d461c0873d62d95
Add Left or right arrow on a tab label should switch tabs

When we are in writer: Alt + H, K - opens spacing dropdown
Before this patch focus was stolen by the map even if the spacing item has focusBack property set to false
