### PR TITLE
mobile-wizard: fix textarea remains white in darkmode

### DIFF
--- a/browser/css/mobilewizard.css
+++ b/browser/css/mobilewizard.css
@@ -1009,7 +1009,7 @@ label.disabled {
 
 .ui-edit.mobile-wizard,
 .ui-textarea.mobile-wizard,
-#hyperlink-link-box-label.mobile-wizard {
+.cool-annotation-table {
 	/*
 	, textarea was also here assign but it was messing up with all textareas (annotations on desktop and mobile):
 	- added 93038: jsdialog: style dialogs; a5016d547c6242f6f9b28748b5724b0bc10cdb67
@@ -1017,6 +1017,11 @@ label.disabled {
 	width: -moz-available;
 	width: -webkit-fill-available;
 	margin: 10px 5% !important;
+}
+
+.ui-textarea.mobile-wizard {
+	background-color: var(--color-background-dark);
+	border: 1px solid var(--color-border);
 }
 
 #mobile-wizard #label9, #documentlabel-mobile {


### PR DESCRIPTION
- also fixes the misalignment in cool-annotation-table


Change-Id: I58db4c6918c3a36a230c6f9317ddf39c3361bb24

* Target version: master 

Before:
![image](https://github.com/CollaboraOnline/online/assets/26241069/ebb74140-d08d-4116-85db-57fc6ea847b4)


After:
![image](https://github.com/CollaboraOnline/online/assets/26241069/6c2eeed5-334f-4475-b8e3-1c18aa5cca4b)

