### PR TITLE
jsdialog spinfield validation (22.05)

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -402,12 +402,9 @@ L.Control.JSDialogBuilder = L.Control.extend({
 
 		var getPrecision = function (data) {
 			data = Math.abs(data);
-			var counter = 1;
-
-			while (Math.floor(data * counter) < (data * counter))
-				counter *= 10;
-
-			return 1/counter;
+			var str = '' + data;
+			var dot = str.indexOf('.');
+			return dot ? 1 / Math.pow(10, str.length - dot - 1) : 1;
 		};
 
 		if (data.min != undefined)

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -406,8 +406,24 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		if (data.max != undefined)
 			$(spinfield).attr('max', data.max);
 
-		if (data.step != undefined)
-			$(spinfield).attr('step', data.step);
+		if (data.step != undefined) {
+			// we don't want to show error popups due to browser step validation
+			// so be sure all the values will be acceptted, check only precision
+			var step = data.step;
+			if (step < 0)
+				step = step * -1;
+
+			if (step < 0.01)
+				step = 0.001;
+			else if (step < 0.1)
+				step = 0.01;
+			else if (step < 1)
+				step = 0.1;
+			else if (step > 0)
+				step = 1;
+
+			$(spinfield).attr('step', step);
+		}
 
 		if (data.enabled === 'false' || data.enabled === false) {
 			$(spinfield).attr('disabled', 'disabled');

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -400,6 +400,16 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			unit.textContent = builder._unitToVisibleString(data.unit);
 		}
 
+		var getPrecision = function (data) {
+			data = Math.abs(data);
+			var counter = 1;
+
+			while (Math.floor(data * counter) < (data * counter))
+				counter *= 10;
+
+			return 1/counter;
+		};
+
 		if (data.min != undefined)
 			$(spinfield).attr('min', data.min);
 
@@ -409,18 +419,11 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		if (data.step != undefined) {
 			// we don't want to show error popups due to browser step validation
 			// so be sure all the values will be acceptted, check only precision
-			var step = data.step;
-			if (step < 0)
-				step = step * -1;
+			var step = getPrecision(data.step);
+			var minStep = getPrecision(data.min);
+			var maxStep = getPrecision(data.max);
 
-			if (step < 0.01)
-				step = 0.001;
-			else if (step < 0.1)
-				step = 0.01;
-			else if (step < 1)
-				step = 0.1;
-			else if (step > 0)
-				step = 1;
+			step = Math.min(step, minStep, maxStep);
 
 			$(spinfield).attr('step', step);
 		}


### PR DESCRIPTION
Fixes case when:
1. in calc, right click column header, open column width
2. set 1.7, ok
3. open column width dialog again
4. try to set 1.62, ok
Result: there was validation error, cannot close dialog