### PR TITLE
wsd: fix -Werror,-Wimplicit-const-int-float-conversion

### DIFF
--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -517,7 +517,7 @@ bool ClientSession::_handleInput(const char *buffer, int length)
                 endptr = nullptr;
                 double counter = strtod(str, &endptr);
                 if (*endptr == '\0' && counter > 0 &&
-                    (counter < (uint64_t)(std::numeric_limits<uint64_t>::max() / 1000)))
+                    (counter < (double)(uint64_t)(std::numeric_limits<uint64_t>::max() / 1000)))
                 {
                     // Now we know how to translate from the client's performance.now() values to
                     // microseconds since the epoch.


### PR DESCRIPTION
wsd/ClientSession.cpp:520:32: error: implicit conversion from 'uint64_t' (aka 'unsigned long') to 'double' changes value from 18446744073709551 to 18446744073709552 [-Werror,-Wimplicit-const-int-float-conversion]
                    (counter < (uint64_t)(std::numeric_limits<uint64_t>::max() / 1000)))
                             ~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Which is a problem since commit e0b70657fa3575f1a85e020869d10f171dc079e0
(cid#318912 Result is not floating-point, 2023-08-23).

Let's make the conversion explicit, hoping that makes both Coverity and
clang happy at the same time. No change in actual behavior intended.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Ib9727f0df4df65a9504d421654d519bee0733b80
