### PR TITLE
if we can't call _onMessage yet, delay all messages until we can

### DIFF
--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -1179,12 +1179,9 @@ app.definitions.Socket = L.Class.extend({
 			this._onHyperlinkClickedMsg(textMsg);
 		}
 
-		var msgDelayed = false;
 		if (!this._isReady() || !this._map._docLayer || this._delayedMessages.length || this._handlingDelayedMessages) {
-			msgDelayed = this._tryToDelayMessage(textMsg);
-		}
-
-		if (this._map._docLayer && !msgDelayed) {
+			this._delayMessage(textMsg);
+		} else {
 			this._map._docLayer._onMessage(textMsg, e.image);
 		}
 	},
@@ -1299,25 +1296,13 @@ app.definitions.Socket = L.Class.extend({
 		// var name = command.name; - ignored, we get the new name via the wopi's BaseFileName
 	},
 
-	_tryToDelayMessage: function(textMsg) {
-		var delayed = false;
-		if (textMsg.startsWith('window:') ||
-			textMsg.startsWith('canonicalidchange:') ||
-			textMsg.startsWith('celladdress:') ||
-			textMsg.startsWith('cellviewcursor:') ||
-			textMsg.startsWith('statechanged:') ||
-			textMsg.startsWith('invalidatecursor:') ||
-			textMsg.startsWith('viewinfo:')) {
-			//window.app.console.log('_tryToDelayMessage: textMsg: ' + textMsg);
-			var message = {msg: textMsg};
-			this._delayedMessages.push(message);
-			delayed  = true;
-		}
+	_delayMessage: function(textMsg) {
+		var message = {msg: textMsg};
+		this._delayedMessages.push(message);
 
-		if (delayed && !this._delayedMsgHandlerTimeoutId) {
+		if (!this._delayedMsgHandlerTimeoutId) {
 			this._handleDelayedMessages();
 		}
-		return delayed;
 	},
 
 	_handleDelayedMessages: function() {


### PR DESCRIPTION
and not just some of them discarding the others, so we always apply all messages received in order the arrived without omissions.

TODO: apply them when the conditions application requires become true rather than depending on a timer poll.


Change-Id: I265b6ccb45e211c15c5f4daf9d6572fa051b68eb


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

