### PR TITLE
CanonicalViewId fixes

### DIFF
--- a/browser/src/control/Control.PartsPreview.js
+++ b/browser/src/control/Control.PartsPreview.js
@@ -366,9 +366,6 @@ L.Control.PartsPreview = L.Control.extend({
 	},
 
 	_layoutPreview: function (i, img, bottomBound) {
-		if (this._map._docLayer._canonicalViewId == -1) {
-			return;
-		}
 		var topBound = this._previewContTop;
 		var previewFrameTop = 0;
 		var previewFrameBottom = 0;

--- a/browser/src/control/Parts.js
+++ b/browser/src/control/Parts.js
@@ -127,6 +127,9 @@ L.Map.include({
 	},
 
 	_processPreviewQueue: function() {
+		if (!this._docLayer._canonicalIdInitialized)
+			return;
+
 		if (this._previewRequestsOnFly > 1) {
 			// we don't always get a response for each tile requests
 			// especially when we have more than one view

--- a/browser/src/control/Parts.js
+++ b/browser/src/control/Parts.js
@@ -170,14 +170,9 @@ L.Map.include({
 		if (!this._docPreviews) {
 			this._docPreviews = {};
 		}
-
 		var autoUpdate = options ? !!options.autoUpdate : false;
 		var fetchThumbnail = options && options.fetchThumbnail ? options.fetchThumbnail : true;
 		this._docPreviews[id] = {id: id, index: index, maxWidth: maxWidth, maxHeight: maxHeight, autoUpdate: autoUpdate, invalid: false};
-
-		if (this._docLayer._canonicalViewId == -1) {
-			return;
-		}
 
 		var docLayer = this._docLayer;
 		if (docLayer._docType === 'text') {
@@ -203,7 +198,7 @@ L.Map.include({
 		if (fetchThumbnail) {
 			var mode = docLayer._selectedMode;
 			this._addPreviewToQueue(part, 'tile ' +
-							'nviewid=' + this._docLayer._canonicalViewId + ' ' +
+							'nviewid=0' + ' ' +
 							'part=' + part + ' ' +
 							((mode !== 0) ? ('mode=' + mode + ' ') : '') +
 							'width=' + maxWidth * app.roundedDpiScale + ' ' +
@@ -227,18 +222,13 @@ L.Map.include({
 		if (!this._docPreviews) {
 			this._docPreviews = {};
 		}
-
 		var autoUpdate = options ? options.autoUpdate : false;
 		this._docPreviews[id] = {id: id, part: part, width: width, height: height, tilePosX: tilePosX,
 			tilePosY: tilePosY, tileWidth: tileWidth, tileHeight: tileHeight, autoUpdate: autoUpdate, invalid: false};
 
-		if (this._docLayer._canonicalViewId == -1) {
-			return;
-		}
-
 		var mode = this._docLayer._selectedMode;
 		this._addPreviewToQueue(part, 'tile ' +
-							'nviewid=' + this._docLayer._canonicalViewId + ' ' +
+							'nviewid=0' + ' ' +
 							'part=' + part + ' ' +
 							((mode !== 0) ? ('mode=' + mode + ' ') : '') +
 							'width=' + width * app.roundedDpiScale + ' ' +

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -969,7 +969,6 @@ L.CanvasTileLayer = L.Layer.extend({
 		this._mentionText = [];
 
 		this._moveInProgress = false;
-		this._canonicalViewId = -1;
 	},
 
 	_initContainer: function () {
@@ -1386,9 +1385,6 @@ L.CanvasTileLayer = L.Layer.extend({
 		if (tileCombineQueue.length <= 0)
 			return;
 
-		if (this._canonicalViewId == -1)
-			return;
-
 		// Sort into buckets of consistent part & mode.
 		var partMode = {};
 		for (var i = 0; i < tileCombineQueue.length; ++i)
@@ -1431,7 +1427,7 @@ L.CanvasTileLayer = L.Layer.extend({
 			}
 
 			var msg = 'tilecombine ' +
-			    'nviewid=' + this._canonicalViewId + ' ' +
+			    'nviewid=0 ' +
 			    'part=' + part + ' ' +
 			    ((mode !== 0) ? ('mode=' + mode + ' ') : '') +
 			    'width=' + this._tileWidthPx + ' ' +
@@ -1805,16 +1801,13 @@ L.CanvasTileLayer = L.Layer.extend({
 			this._onFormFieldButtonMsg(textMsg);
 		}
 		else if (textMsg.startsWith('canonicalidchange:')) {
-			var payload = textMsg.substring('canonicalidchange:'.length + 1);
-			var canonicalId = payload.split('=')[2].split(' ')[0];
 			if (this._debugData) {
+				var payload = textMsg.substring('canonicalidchange:'.length + 1);
 				var viewId = payload.split('=')[1].split(' ')[0];
+				var canonicalId = payload.split('=')[2].split(' ')[0];
 				this._debugData['canonicalViewId'].setPrefix('Canonical id changed to: ' + canonicalId + ' for view id: ' + viewId);
 			}
-			this._canonicalViewId = canonicalId;
-			this._invalidateAllPreviews();
 			this._requestNewTiles();
-			this.redraw();
 		}
 		else if (textMsg.startsWith('comment:')) {
 			var obj = JSON.parse(textMsg.substring('comment:'.length + 1));
@@ -4884,16 +4877,6 @@ L.CanvasTileLayer = L.Layer.extend({
 			+ '&outputWidth=' + this._tileHeightPx
 			+ '&tileHeight=' + this._tileWidthTwips
 			+ '&tileWidth=' + this._tileHeightTwips);
-	},
-
-	_invalidateAllPreviews: function () {
-		this._previewInvalidations = [];
-		for (var key in this._map._docPreviews) {
-			var preview = this._map._docPreviews[key];
-			preview.invalid = true;
-			this._previewInvalidations.push(new L.Bounds(new L.Point(0, 0), new L.Point(preview.maxWidth, preview.maxHeight)));
-		}
-		this._invalidatePreviews();
 	},
 
 	_invalidatePreviews: function () {

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -969,6 +969,7 @@ L.CanvasTileLayer = L.Layer.extend({
 		this._mentionText = [];
 
 		this._moveInProgress = false;
+		this._canonicalIdInitialized = false;
 	},
 
 	_initContainer: function () {
@@ -1807,7 +1808,14 @@ L.CanvasTileLayer = L.Layer.extend({
 				var canonicalId = payload.split('=')[2].split(' ')[0];
 				this._debugData['canonicalViewId'].setPrefix('Canonical id changed to: ' + canonicalId + ' for view id: ' + viewId);
 			}
+			if (!this._canonicalIdInitialized)
+			{
+				this._canonicalIdInitialized = true;
+				this._update();
+			}
 			this._requestNewTiles();
+			this._invalidateAllPreviews();
+			this.redraw();
 		}
 		else if (textMsg.startsWith('comment:')) {
 			var obj = JSON.parse(textMsg.substring('comment:'.length + 1));
@@ -4879,6 +4887,16 @@ L.CanvasTileLayer = L.Layer.extend({
 			+ '&tileWidth=' + this._tileHeightTwips);
 	},
 
+	_invalidateAllPreviews: function () {
+		this._previewInvalidations = [];
+		for (var key in this._map._docPreviews) {
+			var preview = this._map._docPreviews[key];
+			preview.invalid = true;
+			this._previewInvalidations.push(new L.Bounds(new L.Point(0, 0), new L.Point(preview.maxWidth, preview.maxHeight)));
+		}
+		this._invalidatePreviews();
+	},
+
 	_invalidatePreviews: function () {
 		if (this._map && this._map._docPreviews && this._previewInvalidations.length > 0) {
 			var toInvalidate = {};
@@ -6171,7 +6189,7 @@ L.CanvasTileLayer = L.Layer.extend({
 
 	_update: function (center, zoom) {
 		var map = this._map;
-		if (!map || this._documentInfo === '') {
+		if (!map || this._documentInfo === '' || !this._canonicalIdInitialized) {
 			return;
 		}
 
@@ -7231,7 +7249,7 @@ L.TilesPreFetcher = L.Class.extend({
 		if (app.file.fileBasedView && this._docLayer)
 			this._docLayer._updateFileBasedView();
 
-		if (this._docLayer._emptyTilesCount > 0 || !this._map || !this._docLayer) {
+		if (this._docLayer._emptyTilesCount > 0 || !this._map || !this._docLayer || !this._canonicalIdInitialized) {
 			return;
 		}
 

--- a/common/Session.hpp
+++ b/common/Session.hpp
@@ -39,18 +39,14 @@ public:
     int createCanonicalId(const std::string &viewProps)
     {
         if (viewProps.empty())
-        {
-            LOG_ERR("Cannot create canonical id for empty viewProps");
             return 0;
-        }
-
         for (const auto& it : _canonicalIds)
         {
             if (it.first == viewProps)
                 return it.second;
         }
 
-        const std::size_t id = (_canonicalIds.size() + 1) + 1000;
+        const std::size_t id = _canonicalIds.size() + 1000;
         _canonicalIds[viewProps] = id;
         return id;
     }

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -109,7 +109,7 @@ ChildSession::ChildSession(
     _viewId(-1),
     _isDocLoaded(false),
     _copyToClipboard(false),
-    _canonicalViewId(-1),
+    _canonicalViewId(0),
     _isDumpingTiles(false),
     _clientVisibleArea(0, 0, 0, 0)
 {

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1706,7 +1706,6 @@ private:
 
         session->initWatermark();
 
-        invalidateCanonicalId(sessionId);
         return _loKitDocument;
     }
 

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1705,6 +1705,10 @@ private:
                 viewCount << " view" << (viewCount != 1 ? "s." : "."));
 
         session->initWatermark();
+        if (session->hasWatermark())
+        {
+            invalidateCanonicalId(session->getId());
+        }
 
         return _loKitDocument;
     }

--- a/test/TileCacheTests.cpp
+++ b/test/TileCacheTests.cpp
@@ -1366,7 +1366,7 @@ void TileCacheTests::requestTiles(std::shared_ptr<http::WebSocketSession>& socke
             // expected tile: part= width= height= tileposx= tileposy= tilewidth= tileheight=
             StringVector tokens(StringVector::tokenize(tile, ' '));
             LOK_ASSERT_EQUAL(std::string("tile:"), tokens[0]);
-            LOK_ASSERT_EQUAL(1000, std::stoi(tokens[1].substr(std::string("nviewid=").size())));
+            LOK_ASSERT_EQUAL(0, std::stoi(tokens[1].substr(std::string("nviewid=").size())));
             LOK_ASSERT_EQUAL(part, std::stoi(tokens[2].substr(std::string("part=").size())));
             LOK_ASSERT_EQUAL(pixTileSize,
                              std::stoi(tokens[3].substr(std::string("width=").size())));

--- a/test/TileCacheTests.cpp
+++ b/test/TileCacheTests.cpp
@@ -267,14 +267,14 @@ void TileCacheTests::testSimpleCombine()
     std::shared_ptr<http::WebSocketSession> socket1
         = loadDocAndGetSession(_socketPoll, _uri, documentURL, testname + "1 ");
 
-    sendTextFrame(socket1, "tilecombine nviewid=1001 part=0 width=256 height=256 tileposx=0,3840 tileposy=0,0 tilewidth=3840 tileheight=3840");
+    sendTextFrame(socket1, "tilecombine nviewid=0  part=0 width=256 height=256 tileposx=0,3840 tileposy=0,0 tilewidth=3840 tileheight=3840");
 
     std::vector<char> tile1a = getResponseMessage(socket1, "tile:", testname + "1 ");
     LOK_ASSERT_MESSAGE("did not receive a tile: message as expected", !tile1a.empty());
     std::vector<char> tile1b = getResponseMessage(socket1, "tile:", testname + "1 ");
     LOK_ASSERT_MESSAGE("did not receive a tile: message as expected", !tile1b.empty());
 
-    sendTextFrame(socket1, "tilecombine nviewid=1001 part=0 width=256 height=256 tileposx=0,3840 tileposy=0,0 oldwid=42,42 tilewidth=3840 tileheight=3840");
+    sendTextFrame(socket1, "tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0,3840 tileposy=0,0 oldwid=42,42 tilewidth=3840 tileheight=3840");
     tile1a = getResponseMessage(socket1, "delta:", testname + "1 ", std::chrono::seconds(10));
 //  TST_LOG("Response is: " + Util::dumpHex(tile1a) << "\n");
     // no content in an update delta: - so ends with a '\n'
@@ -287,7 +287,7 @@ void TileCacheTests::testSimpleCombine()
     std::shared_ptr<http::WebSocketSession> socket2
         = loadDocAndGetSession(_socketPoll, _uri, documentURL, testname + "2 ");
 
-    sendTextFrame(socket2, "tilecombine nviewid=1001 part=0 width=256 height=256 tileposx=0,3840 tileposy=0,0 tilewidth=3840 tileheight=3840");
+    sendTextFrame(socket2, "tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0,3840 tileposy=0,0 tilewidth=3840 tileheight=3840");
 
     std::vector<char> tile2a = getResponseMessage(socket2, "tile:", testname + "2 ");
     LOK_ASSERT_MESSAGE("did not receive a tile: message as expected", !tile2a.empty());
@@ -295,7 +295,7 @@ void TileCacheTests::testSimpleCombine()
     LOK_ASSERT_MESSAGE("did not receive a tile: message as expected", !tile2b.empty());
 
     // First - check force keyframe
-    sendTextFrame(socket1, "tilecombine nviewid=1001 part=0 width=256 height=256 tileposx=0,3840 tileposy=0,0 oldwid=0,0 tilewidth=3840 tileheight=3840");
+    sendTextFrame(socket1, "tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0,3840 tileposy=0,0 oldwid=0,0 tilewidth=3840 tileheight=3840");
     tile1a = getResponseMessage(socket1, "tile:", testname + "1 ");
     LOK_ASSERT_MESSAGE("did not receive a tile: message as expected", !tile1a.empty());
     tile1b = getResponseMessage(socket1, "tile:", testname + "1 ");
@@ -320,7 +320,7 @@ void TileCacheTests::testTileSubscription()
     std::shared_ptr<http::WebSocketSession> socket1
         = loadDocAndGetSession(_socketPoll, _uri, documentURL, testname + "1 ");
 
-    sendTextFrame(socket1, "tilecombine nviewid=1001  part=0 width=256 height=256 tileposx=0,3840 tileposy=0,0 tilewidth=3840 tileheight=3840");
+    sendTextFrame(socket1, "tilecombine nviewid=0  part=0 width=256 height=256 tileposx=0,3840 tileposy=0,0 tilewidth=3840 tileheight=3840");
 
     // std::shared_ptr<TileDesc>
     auto tile1a = getResponseDesc(socket1, "tile:", testname + "1 ");
@@ -332,7 +332,7 @@ void TileCacheTests::testTileSubscription()
     sendChar(socket1, '.', skNone, testname);
 
     // no viewport set so we have to re-request:
-    sendTextFrame(socket1, "tilecombine nviewid=1001  part=0 width=256 height=256 tileposx=0,3840 tileposy=0,0 oldwid=42,42 tilewidth=3840 tileheight=3840");
+    sendTextFrame(socket1, "tilecombine nviewid=0  part=0 width=256 height=256 tileposx=0,3840 tileposy=0,0 oldwid=42,42 tilewidth=3840 tileheight=3840");
 
     auto delta1a = getResponseDesc(socket1, "delta:", testname + "1 ");
     LOK_ASSERT_MESSAGE("did not receive a delta: message as expected", !!delta1a);
@@ -365,9 +365,9 @@ void TileCacheTests::testTileSubscription()
     assertResponseString(socket1, "invalidatetiles:", testname);
 
     // two subscriptions on a tile we hope from three requests
-    sendTextFrame(socket1, "tilecombine nviewid=1001 part=0 width=256 height=256 tileposx=0,3840 oldwid=42,42 tileposy=0,0 tilewidth=3840 tileheight=3840");
-    sendTextFrame(socket1, "tilecombine nviewid=1001 part=0 width=256 height=256 tileposx=0,3840 oldwid=42,42 tileposy=0,0 tilewidth=3840 tileheight=3840");
-    sendTextFrame(socket2, "tilecombine nviewid=1001 part=0 width=256 height=256 tileposx=0,3840 tileposy=0,0 tilewidth=3840 tileheight=3840");
+    sendTextFrame(socket1, "tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0,3840 oldwid=42,42 tileposy=0,0 tilewidth=3840 tileheight=3840");
+    sendTextFrame(socket1, "tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0,3840 oldwid=42,42 tileposy=0,0 tilewidth=3840 tileheight=3840");
+    sendTextFrame(socket2, "tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0,3840 tileposy=0,0 tilewidth=3840 tileheight=3840");
 
     // User 2 should get tiles
     auto tile2a = getResponseDesc(socket2, "tile:", testname + "1 ");
@@ -461,12 +461,12 @@ void TileCacheTests::testDisconnectMultiView()
             = loadDocAndGetSession(_socketPoll, _uri, documentURL, "disconnectMultiView-2 ", true);
 
         sendTextFrame(socket1,
-                      "tilecombine nviewid=1001 part=0 width=256 height=256 "
+                      "tilecombine nviewid=0 part=0 width=256 height=256 "
                       "tileposx=0,3840,7680,11520,0,3840,7680,11520 "
                       "tileposy=0,0,0,0,3840,3840,3840,3840 tilewidth=3840 tileheight=3840",
                       "cancelTilesMultiView-1 ");
         sendTextFrame(socket2,
-                      "tilecombine nviewid=1001 part=0 width=256 height=256 tileposx=0,3840,7680,0 "
+                      "tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0,3840,7680,0 "
                       "tileposy=0,0,0,22520 tilewidth=3840 tileheight=3840",
                       "cancelTilesMultiView-2 ");
 
@@ -527,14 +527,14 @@ void TileCacheTests::testUnresponsiveClient()
         assertResponseString(socket2, "invalidatetiles:", testname + "2 ");
 
         // Ask for tiles and don't read!
-        sendTextFrame(socket1, "tilecombine nviewid=1001 part=0 width=256 height=256 "
+        sendTextFrame(socket1, "tilecombine nviewid=0 part=0 width=256 height=256 "
                                "tileposx=0,3840,7680,11520,0,3840,7680,11520 "
                                "tileposy=0,0,0,0,3840,3840,3840,3840 tilewidth=3840 "
                                "tileheight=3840",
                       testname + "1 ");
 
         // Verify that we get all 8 tiles.
-        sendTextFrame(socket2, "tilecombine nviewid=1001 part=0 width=256 height=256 "
+        sendTextFrame(socket2, "tilecombine nviewid=0 part=0 width=256 height=256 "
                                "tileposx=0,3840,7680,11520,0,3840,7680,11520 "
                                "tileposy=0,0,0,0,3840,3840,3840,3840 tilewidth=3840 "
                                "tileheight=3840",
@@ -566,7 +566,7 @@ void TileCacheTests::testImpressTiles()
             = loadDocAndGetSession(_socketPoll, "setclientpart.odp", _uri, testname);
 
         sendTextFrame(socket,
-                      "tile nviewid=1001 part=0 width=180 height=135 tileposx=0 tileposy=0 "
+                      "tile nviewid=0 part=0 width=180 height=135 tileposx=0 tileposy=0 "
                       "tilewidth=15875 tileheight=11906 id=0",
                       testname);
         getTileMessage(socket, testname);
@@ -644,7 +644,7 @@ void TileCacheTests::testTilesRenderedJustOnce()
         assertResponseString(socket, "invalidatetiles:", testname);
 
         // Get 3 tiles.
-        sendTextFrame(socket, "tilecombine nviewid=1001 part=0 width=256 height=256 tileposx=0,3840,7680 tileposy=0,0,0 tilewidth=3840 tileheight=3840", testname);
+        sendTextFrame(socket, "tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0,3840,7680 tileposy=0,0,0 tilewidth=3840 tileheight=3840", testname);
         assertResponseString(socket, "tile:", testname);
         assertResponseString(socket, "tile:", testname);
         assertResponseString(socket, "tile:", testname);
@@ -657,7 +657,7 @@ void TileCacheTests::testTilesRenderedJustOnce()
         LOK_ASSERT_EQUAL((i+1) * 3, renderCount2);
 
         // Get same 3 tiles.
-        sendTextFrame(socket, "tilecombine nviewid=1001 part=0 width=256 height=256 tileposx=0,3840,7680 tileposy=0,0,0 tilewidth=3840 tileheight=3840", testname);
+        sendTextFrame(socket, "tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0,3840,7680 tileposy=0,0,0 tilewidth=3840 tileheight=3840", testname);
         const auto tile1 = assertResponseString(socket, "tile:", testname);
 
         // monotonically increasing id.
@@ -732,25 +732,25 @@ void TileCacheTests::testTilesRenderedJustOnceMultiClient()
         assertResponseString(socket1, "invalidatetiles:", testname1);
 
         // Get 3 tiles.
-        sendTextFrame(socket1, "tilecombine nviewid=1001 part=0 width=256 height=256 tileposx=0,3840,7680 tileposy=0,0,0 tilewidth=3840 tileheight=3840", testname1);
+        sendTextFrame(socket1, "tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0,3840,7680 tileposy=0,0,0 tilewidth=3840 tileheight=3840", testname1);
         assertResponseString(socket1, "tile:", testname1);
         assertResponseString(socket1, "tile:", testname1);
         assertResponseString(socket1, "tile:", testname1);
 
         assertResponseString(socket2, "invalidatetiles:", testname2);
-        sendTextFrame(socket2, "tilecombine nviewid=1001 part=0 width=256 height=256 tileposx=0,3840,7680 tileposy=0,0,0 tilewidth=3840 tileheight=3840", testname2);
+        sendTextFrame(socket2, "tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0,3840,7680 tileposy=0,0,0 tilewidth=3840 tileheight=3840", testname2);
         assertResponseString(socket2, "tile:", testname2);
         assertResponseString(socket2, "tile:", testname2);
         assertResponseString(socket2, "tile:", testname2);
 
         assertResponseString(socket3, "invalidatetiles:", testname3);
-        sendTextFrame(socket3, "tilecombine nviewid=1001 part=0 width=256 height=256 tileposx=0,3840,7680 tileposy=0,0,0 tilewidth=3840 tileheight=3840", testname3);
+        sendTextFrame(socket3, "tilecombine nviewid=0 part=0 nviewid=0 width=256 height=256 tileposx=0,3840,7680 tileposy=0,0,0 tilewidth=3840 tileheight=3840", testname3);
         assertResponseString(socket3, "tile:", testname3);
         assertResponseString(socket3, "tile:", testname3);
         assertResponseString(socket3, "tile:", testname3);
 
         assertResponseString(socket4, "invalidatetiles:", testname4);
-        sendTextFrame(socket4, "tilecombine nviewid=1001 part=0 width=256 height=256 tileposx=0,3840,7680 tileposy=0,0,0 tilewidth=3840 tileheight=3840", testname4);
+        sendTextFrame(socket4, "tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0,3840,7680 tileposy=0,0,0 tilewidth=3840 tileheight=3840", testname4);
         assertResponseString(socket4, "tile:", testname4);
         assertResponseString(socket4, "tile:", testname4);
         assertResponseString(socket4, "tile:", testname4);
@@ -763,7 +763,7 @@ void TileCacheTests::testTilesRenderedJustOnceMultiClient()
         LOK_ASSERT_EQUAL((i+1) * 3, renderCount2);
 
         // Get same 3 tiles.
-        sendTextFrame(socket1, "tilecombine nviewid=1001 part=0 width=256 height=256 tileposx=0,3840,7680 tileposy=0,0,0 tilewidth=3840 tileheight=3840", testname1);
+        sendTextFrame(socket1, "tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0,3840,7680 tileposy=0,0,0 tilewidth=3840 tileheight=3840", testname1);
         const auto tile1 = assertResponseString(socket1, "tile:", testname1);
         std::string renderId1;
         COOLProtocol::getTokenStringFromMessage(tile1, "renderid", renderId1);
@@ -820,8 +820,8 @@ void TileCacheTests::testSimultaneousTilesRenderedJustOnce()
     assertResponseString(socket1, "statechanged:", "client1 ");
     assertResponseString(socket2, "statechanged:", "client2 ");
 
-    sendTextFrame(socket1, "tile nviewid=1001 part=42 width=256 height=256 tileposx=1000 tileposy=2000 tilewidth=3000 tileheight=3000");
-    sendTextFrame(socket2, "tile nviewid=1001 part=42 width=256 height=256 tileposx=1000 tileposy=2000 tilewidth=3000 tileheight=3000");
+    sendTextFrame(socket1, "tile nviewid=0 part=42 width=256 height=256 tileposx=1000 tileposy=2000 tilewidth=3000 tileheight=3000");
+    sendTextFrame(socket2, "tile nviewid=0 part=42 width=256 height=256 tileposx=1000 tileposy=2000 tilewidth=3000 tileheight=3000");
 
     const auto response1 = assertResponseString(socket1, "tile:", "client1 ");
     const auto response2 = assertResponseString(socket2, "tile:", "client2 ");
@@ -918,7 +918,7 @@ void TileCacheTests::checkBlackTiles(std::shared_ptr<http::WebSocketSession>& so
     // render correctly and there are no black tiles.
     // Current cap of table size ends at 257280 twips (for load12.ods),
     // otherwise 2035200 should be rendered successfully.
-    const char* req = "tile nviewid=1001 part=0 width=256 height=256 tileposx=0 tileposy=253440 "
+    const char* req = "tile nviewid=0 part=0 width=256 height=256 tileposx=0 tileposy=253440 "
                       "tilewidth=3840 tileheight=3840";
     sendTextFrame(socket, req);
 
@@ -1357,7 +1357,7 @@ void TileCacheTests::requestTiles(std::shared_ptr<http::WebSocketSession>& socke
             tileX = tileSize * itCol;
             tileY = tileSize * itRow;
             text
-                = Poco::format("tile nviewid=1001 part=%d width=%d height=%d tileposx=%d tileposy=%d "
+                = Poco::format("tile nviewid=0 part=%d width=%d height=%d tileposx=%d tileposy=%d "
                                "tilewidth=%d tileheight=%d",
                                part, pixTileSize, pixTileSize, tileX, tileY, tileWidth, tileHeight);
 
@@ -1366,7 +1366,7 @@ void TileCacheTests::requestTiles(std::shared_ptr<http::WebSocketSession>& socke
             // expected tile: part= width= height= tileposx= tileposy= tilewidth= tileheight=
             StringVector tokens(StringVector::tokenize(tile, ' '));
             LOK_ASSERT_EQUAL(std::string("tile:"), tokens[0]);
-            LOK_ASSERT_EQUAL(1001, std::stoi(tokens[1].substr(std::string("nviewid=").size())));
+            LOK_ASSERT_EQUAL(1000, std::stoi(tokens[1].substr(std::string("nviewid=").size())));
             LOK_ASSERT_EQUAL(part, std::stoi(tokens[2].substr(std::string("part=").size())));
             LOK_ASSERT_EQUAL(pixTileSize,
                              std::stoi(tokens[3].substr(std::string("width=").size())));
@@ -1441,7 +1441,7 @@ void TileCacheTests::testTileRequestByZoom()
     sendTextFrame(socket, "clientzoom tilepixelwidth=256 tilepixelheight=256 tiletwipwidth=3200 tiletwipheight=3200");
 
     // Request all tile of the visible area (it happens by zoom)
-    sendTextFrame(socket, "tilecombine nviewid=1001 part=0 width=256 height=256 tileposx=0,3200,6400,9600,12800,0,3200,6400,9600,12800,0,3200,6400,9600,12800,0,3200,6400,9600,12800 tileposy=0,0,0,0,0,3200,3200,3200,3200,3200,6400,6400,6400,6400,6400,9600,9600,9600,9600,9600 tilewidth=3200 tileheight=3200");
+    sendTextFrame(socket, "tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0,3200,6400,9600,12800,0,3200,6400,9600,12800,0,3200,6400,9600,12800,0,3200,6400,9600,12800 tileposy=0,0,0,0,0,3200,3200,3200,3200,3200,6400,6400,6400,6400,6400,9600,9600,9600,9600,9600 tilewidth=3200 tileheight=3200");
 
     // Check that we get all the tiles without we send back the tileprocessed message
     for (int i = 0; i < 20; ++i)
@@ -1537,7 +1537,7 @@ void TileCacheTests::testTileProcessed()
         getResponseMessage(socket, "spinandwait:", testname, std::chrono::milliseconds(10));
 
     // Request a lots of tiles ~25 ie. more than wsd can send back at once.
-    sendTextFrame(socket, "tilecombine nviewid=1001 part=0 width=256 height=256 tileposx=0,3200,6400,9600,12800,0,3200,6400,9600,12800,0,3200,6400,9600,12800,0,3200,6400,9600,12800,0,3200,6400,9600,12800 tileposy=0,0,0,0,0,3200,3200,3200,3200,3200,6400,6400,6400,6400,6400,9600,9600,9600,9600,9600,12800,12800,12800,12800,12800 tilewidth=3200 tileheight=3200");
+    sendTextFrame(socket, "tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0,3200,6400,9600,12800,0,3200,6400,9600,12800,0,3200,6400,9600,12800,0,3200,6400,9600,12800,0,3200,6400,9600,12800 tileposy=0,0,0,0,0,3200,3200,3200,3200,3200,6400,6400,6400,6400,6400,9600,9600,9600,9600,9600,12800,12800,12800,12800,12800 tilewidth=3200 tileheight=3200");
 
     std::vector<std::string> tileIDs;
     int arrivedTile = 0;
@@ -1757,7 +1757,7 @@ void TileCacheTests::testWireIDFilteringOnWSDSide()
 
     //2. Now request the same tiles by the other client (e.g. scroll to the same view)
 
-    sendTextFrame(socket2, "tilecombine nviewid=1001 part=0 width=256 height=256 tileposx=0,3840,7680 tileposy=0,0,0 tilewidth=3840 tileheight=3840");
+    sendTextFrame(socket2, "tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0,3840,7680 tileposy=0,0,0 tilewidth=3840 tileheight=3840");
 
     // We expect three tiles sent to the second client
     LOK_ASSERT_EQUAL(3, countMessages(socket2, "tile:", testname, std::chrono::seconds(1)));

--- a/test/UnitWOPIWatermark.cpp
+++ b/test/UnitWOPIWatermark.cpp
@@ -58,7 +58,7 @@ public:
             }
             case Phase::TileRequest:
             {
-                WSD_CMD("tilecombine nviewid=1001 part=0 width=256 height=256 tileposx=0,3840 "
+                WSD_CMD("tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0,3840 "
                         "tileposy=0,0 tilewidth=3840 tileheight=3840");
                 const std::string tile =
                     helpers::getResponseString(getWs()->getWebSocket(), "tile:", testName);
@@ -67,7 +67,7 @@ public:
                 {
                     StringVector tokens(StringVector::tokenize(tile, ' '));
                     std::string nviewid = tokens[1].substr(std::string("nviewid=").size());
-                    if (!nviewid.empty() && nviewid == "1001")
+                    if (!nviewid.empty() && nviewid != "0")
                     {
                         LOG_INF(
                             "Watermark is hashed into integer successfully nviewid=" << nviewid);

--- a/test/httpwstest.cpp
+++ b/test/httpwstest.cpp
@@ -268,10 +268,7 @@ void HTTPWSTest::testInactiveClient()
                     // expected.
                     LOK_ASSERT_MESSAGE("unexpected message: " + msg,
                                             token == "a11yfocuschanged:" ||
-                                            token == "applicationbackgroundcolor:" ||
-                                            token == "canonicalidchange:" ||
                                             token == "cursorvisible:" ||
-                                            token == "documentbackgroundcolor:" ||
                                             token == "graphicselection:" ||
                                             token == "graphicviewselection:" ||
                                             token == "invalidatecursor:" ||

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -653,12 +653,12 @@ bool ClientSession::_handleInput(const char *buffer, int length)
     }
     else if (tokens.equals(0, "tile"))
     {
-        assert(getCanonicalViewId() != 0 && getCanonicalViewId() >= 1000);
+        assert(UnitWSD::isUnitTesting() ? true : getCanonicalViewId() != 0 && getCanonicalViewId() >= 1000);
         return sendTile(buffer, length, tokens, docBroker);
     }
     else if (tokens.equals(0, "tilecombine"))
     {
-        assert(getCanonicalViewId() != 0 && getCanonicalViewId() >= 1000);
+        assert(UnitWSD::isUnitTesting() ? true : getCanonicalViewId() != 0 && getCanonicalViewId() >= 1000);
         return sendCombinedTiles(buffer, length, tokens, docBroker);
     }
     else if (tokens.equals(0, "save"))

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -78,7 +78,8 @@ ClientSession::ClientSession(
     _kitViewId(-1),
     _serverURL(requestDetails),
     _isTextDocument(false),
-    _thumbnailSession(false)
+    _thumbnailSession(false),
+    _canonicalViewId(0)
 {
     const std::size_t curConnections = ++COOLWSD::NumConnections;
     LOG_INF("ClientSession ctor [" << getName() << "] for URI: [" << _uriPublic.toString()
@@ -652,10 +653,12 @@ bool ClientSession::_handleInput(const char *buffer, int length)
     }
     else if (tokens.equals(0, "tile"))
     {
+        assert(getCanonicalViewId() != 0 && getCanonicalViewId() >= 1000);
         return sendTile(buffer, length, tokens, docBroker);
     }
     else if (tokens.equals(0, "tilecombine"))
     {
+        assert(getCanonicalViewId() != 0 && getCanonicalViewId() >= 1000);
         return sendCombinedTiles(buffer, length, tokens, docBroker);
     }
     else if (tokens.equals(0, "save"))


### PR DESCRIPTION
@caolanm @mmeeks 

Following up on #7170

I'll summarize the issue as I understand it.

The issue is that when the client gets created, it doesn't have a canonical id yet, because the view options haven't been made clear from the browser side yet. The browser side loads, then sends an uno command to set the theme, and that triggers a canonicalidchange and that's what gives the first canonicalid to the client. However during that whole exchange, the client sometimes sends some tile/tilecombined requests. Since there's no canonical id yet, that would result in buggy behavior.

I reverted my old two patches that would send a canonical id with the tile/tilecombine command, as Michael pointed out that was a bad idea. Instead I added a couple asserts that should trigger if we ever receive a tile/tilecombine without having a canonicalviewid, and also made it so that if a canonicalidchange command hasn't been received on the browser side, those commands are not sent.

