### PR TITLE
Tabbed view: Remotelink: Add missing CSS class

### DIFF
--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -1379,6 +1379,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 			},
 			(this._map['wopi'].EnableRemoteLinkPicker) ? {
 				'id': 'insert-smart-picker',
+				'class': 'unoremotelink',
 				'type': 'bigcustomtoolitem',
 				'text': _('Smart Picker'),
 				'command': 'remotelink',

--- a/browser/src/control/Control.NotebookbarDraw.js
+++ b/browser/src/control/Control.NotebookbarDraw.js
@@ -1192,6 +1192,7 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 			},
 			(this._map['wopi'].EnableRemoteLinkPicker) ? {
 				'id': 'insert-remote-link',
+				'class': 'unoremotelink',
 				'type': 'bigcustomtoolitem',
 				'text': _('Smart Picker'),
 				'command': 'remotelink',

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -1043,6 +1043,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 						'children': [
 							{
 								'id': 'insert-insert-remote-link',
+								'class': 'unoremotelink',
 								'type': 'customtoolitem',
 								'text': _('Smart Picker'),
 								'command': 'remotelink'


### PR DESCRIPTION
It seems the CSS class was only added to impress in
c582d75f5744b7fb8d3ebbabbc7bd647793c0294

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I4e8884004bbd1a4f6e4e62a841eb940e23065f50
