### PR TITLE
kit: improve date format of UNO commands in crashreports

### DIFF
--- a/common/Util.cpp
+++ b/common/Util.cpp
@@ -852,16 +852,21 @@ namespace Util
         return base + Util::anonymize(filename, nAnonymizationSalt) + ext + params;
     }
 
-    std::string getHttpTimeNow()
+    std::string getTimeNow(const char* format)
     {
         char time_now[64];
         std::chrono::system_clock::time_point now = std::chrono::system_clock::now();
         std::time_t now_c = std::chrono::system_clock::to_time_t(now);
         std::tm now_tm;
         gmtime_r(&now_c, &now_tm);
-        strftime(time_now, sizeof(time_now), "%a, %d %b %Y %T", &now_tm);
+        strftime(time_now, sizeof(time_now), format, &now_tm);
 
         return time_now;
+    }
+
+    std::string getHttpTimeNow()
+    {
+        return getTimeNow("%a, %d %b %Y %T");
     }
 
     std::string getHttpTime(std::chrono::system_clock::time_point time)

--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -1223,6 +1223,8 @@ int main(int argc, char**argv)
     //// Return current time in HTTP format.
     std::string getHttpTimeNow();
 
+    std::string getTimeNow(const char* format);
+
     //// Return time in HTTP format.
     std::string getHttpTime(std::chrono::system_clock::time_point time);
 

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -77,11 +77,12 @@ namespace {
 /// Formats the uno command information for logging
 std::string formatUnoCommandInfo(const std::string& sessionId, const std::string& unoCommand)
 {
-    std::string recorded_time = Util::getHttpTimeNow();
+    // E.g. '2023-09-06 12:19:32', matching systemd format.
+    std::string recorded_time = Util::getTimeNow("%Y-%m-%d %T");
 
     std::string unoCommandInfo;
 
-    // unoCommand(sessionId) : command - HttpTime
+    // unoCommand(sessionId) : command - time
     unoCommandInfo.append("unoCommand");
     unoCommandInfo.push_back('(');
     unoCommandInfo.append(sessionId);


### PR DESCRIPTION
Old format:

	kit-27634-02839 2023-08-30 11:08:43.590564 +0000 [ kitbroker_17a ] SIG   Fatal signal received: SIGSEGV code: 1 for address: 0x4f00000007
	      unoCommand(2552f) : ToolbarMode?Mode:string=notebookbar_online.ui - Wed, 30 Aug 2023 11:08:31

New format:

	kit-30199-30197 2023-09-06 14:30:21.417817 +0200 [ kitbroker_001 ] SIG   Fatal signal received: SIGABRT code: 18446744073709551610 for address: 0x3e8000075f7
	Recent activity:
		unoCommand(064) : ToolbarMode?Mode:string=notebookbar_online.ui - 2023-09-06 12:29:56

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Idf62ea18c75c453d188d8c25723a43824d5fc147
