### PR TITLE
Kill Poco Logger (Partially)

### DIFF
--- a/common/Log.cpp
+++ b/common/Log.cpp
@@ -29,6 +29,7 @@
 #include <Poco/PatternFormatter.h>
 #include <Poco/SplitterChannel.h>
 
+#include "Common.hpp"
 #include "Log.hpp"
 #include "Util.hpp"
 
@@ -364,7 +365,12 @@ namespace Log
             channel->setProperty("warningColor", "magenta");
         }
         else
-            channel = static_cast<Poco::Channel*>(new Log::ConsoleChannel());
+        {
+            if (EnableExperimental)
+                channel = static_cast<Poco::Channel*>(new Log::ConsoleChannel());
+            else
+                channel = static_cast<Poco::Channel*>(new Poco::ConsoleChannel());
+        }
 
         /**
          * Open the channel explicitly, instead of waiting for first log message
@@ -394,7 +400,7 @@ namespace Log
         struct tm tm;
         LOG_INF("Initializing " << name << ". Local time: "
                                 << std::put_time(localtime_r(&t, &tm), "%a %F %T %z")
-                                << ". Log level is [" << logger->getLevel() << "].");
+                                << ". Log level is [" << logger->getLevel() << ']');
     }
 
     Poco::Logger& logger()

--- a/common/Log.hpp
+++ b/common/Log.hpp
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <sys/time.h>
 #include <sys/syscall.h>
 #include <unistd.h>
 
@@ -18,9 +19,6 @@
 #include <sstream>
 #include <string>
 
-#include <Poco/LocalDateTime.h>
-#include <Poco/DateTimeFormat.h>
-#include <Poco/DateTimeFormatter.h>
 #include <Poco/Logger.h>
 
 #ifdef __ANDROID__
@@ -56,13 +54,16 @@ namespace Log
 #endif
 
     /// Generates log entry prefix. Example follows (without the pipes).
-    /// |wsd-07272-07298 2020-04-25 17:29:28.928697 [ websrv_poll ] TRC  |
+    /// |wsd-07272-07298 2020-04-25 17:29:28.928697 -0400 [ websrv_poll ] TRC  |
     /// This is fully signal-safe. Buffer must be at least 128 bytes.
-    char* prefix(const Poco::LocalDateTime& time, char* buffer, const char* level);
+    char* prefix(const timeval& tv, char* buffer, const char* level);
     template <int Size> inline char* prefix(char buffer[Size], const char* level)
     {
         static_assert(Size >= 128, "Buffer size must be at least 128 bytes.");
-        return prefix(Poco::LocalDateTime(), buffer, level);
+
+        struct timeval tv;
+        gettimeofday(&tv, NULL);
+        return prefix(tv, buffer, level);
     }
 
     inline bool traceEnabled() { return logger().trace(); }

--- a/common/RenderTiles.hpp
+++ b/common/RenderTiles.hpp
@@ -50,7 +50,10 @@ public:
         for (int i = 1; i < maxConcurrency; ++i)
             _threads.push_back(std::thread(&ThreadPool::work, this));
     }
-    ~ThreadPool()
+
+    ~ThreadPool() { stop(); }
+
+    void stop()
     {
         {
             std::unique_lock< std::mutex > lock(_mutex);
@@ -58,7 +61,7 @@ public:
             _shutdown = true;
         }
         _cond.notify_all();
-        for (auto &it : _threads)
+        for (auto& it : _threads)
             it.join();
     }
 

--- a/common/SigUtil.cpp
+++ b/common/SigUtil.cpp
@@ -150,6 +150,13 @@ void requestShutdown()
     /// Close the signalLog file.
     void signalLogClose()
     {
+        // We cannot shutdown the logging subsystem
+        // because freeing memory is not signal safe.
+
+        // Flush the IO buffers.
+        fflush(stdout);
+        fflush(stderr);
+
         fsync(SignalLogFD);
     }
 

--- a/common/Util.cpp
+++ b/common/Util.cpp
@@ -1140,6 +1140,7 @@ namespace Util
             LOG_FTL("Forced Exit with code: " << code);
         else
             LOG_INF("Forced Exit with code: " << code);
+
         Log::shutdown();
 
 #if CODE_COVERAGE

--- a/net/clientnb.cpp
+++ b/net/clientnb.cpp
@@ -47,6 +47,7 @@ constexpr int HttpPortNumber = 9191;
 constexpr int SslPortNumber = 9193;
 
 static bool EnableHttps = false;
+bool EnableExperimental = false;
 
 struct Session
 {

--- a/test/fakesockettest.cpp
+++ b/test/fakesockettest.cpp
@@ -30,6 +30,8 @@
                     // and probably it is not a good idea to remove that?
 #include "FakeSocket.hpp"
 
+bool EnableExperimental = false;
+
 class FakeSocketTest : public CPPUNIT_NS::TestFixture
 {
     CPPUNIT_TEST_SUITE(FakeSocketTest);

--- a/tools/Config.cpp
+++ b/tools/Config.cpp
@@ -42,6 +42,8 @@ using Poco::Util::XMLConfiguration;
 #define MIN_PWD_ITERATIONS 1000
 #define MIN_PWD_HASH_LENGTH 20
 
+bool EnableExperimental = false;
+
 class CoolConfig final: public XMLConfiguration
 {
 public:

--- a/tools/Connect.cpp
+++ b/tools/Connect.cpp
@@ -56,6 +56,7 @@ using Poco::TemporaryFile;
 using Poco::URI;
 using Poco::Util::Application;
 
+bool EnableExperimental = false;
 static bool closeExpected = false;
 static std::mutex coutMutex;
 

--- a/tools/KitClient.cpp
+++ b/tools/KitClient.cpp
@@ -31,6 +31,8 @@
 using Poco::TemporaryFile;
 using Poco::Util::Application;
 
+bool EnableExperimental = false;
+
 extern "C"
 {
     static void myCallback(int type, const char* payload, void*)

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -5779,11 +5779,6 @@ std::string COOLWSD::getServerURL()
 int COOLWSD::innerMain()
 {
 #if !MOBILEAPP
-    SigUtil::setUserSignals();
-    SigUtil::setFatalSignals("wsd " COOLWSD_VERSION " " COOLWSD_VERSION_HASH);
-#endif
-
-#if !MOBILEAPP
 #  ifdef __linux__
     // down-pay all the forkit linking cost once & early.
     setenv("LD_BIND_NOW", "1", 1);
@@ -6378,7 +6373,22 @@ void forwardSigUsr2()
 // Avoid this in the Util::isFuzzing() case because libfuzzer defines its own main().
 #if !MOBILEAPP && !LIBFUZZER
 
-POCO_SERVER_MAIN(COOLWSD)
+int main(int argc, char** argv)
+{
+    SigUtil::setUserSignals();
+    SigUtil::setFatalSignals("wsd " COOLWSD_VERSION " " COOLWSD_VERSION_HASH);
+
+    try
+    {
+        COOLWSD app;
+        return app.run(argc, argv);
+    }
+    catch (Poco::Exception& exc)
+    {
+        std::cerr << exc.displayText() << std::endl;
+        return EX_SOFTWARE;
+    }
+}
 
 #endif
 


### PR DESCRIPTION
These patches replace the Console Channel of Poco with our faster and simpler implementations. The new loggers are behind EnableExperimental, so this change is safe to go in.

- wsd: test: enable experimental features in tests
- wsd: set up signal handlers early
- killpoco: our implementation of ConsoleChannel
- wsd: log: retry on write failure and flush
- wsd: support EnableExperimental in Log
- killpoco: own implementation of BufferedConsoleChannel
- killpoco: own implementation of ColorConsoleChannel
- wsd: stop the rendering thread pool before exiting
- wsd: log: BufferedConsoleChannel with thread-local buffer
- wsd: log: verify that all threads are stopped
- killpoco: replace LocalDateTime
