### PR TITLE
browser: notify user for unsupported video

### DIFF
--- a/browser/src/layer/vector/SVGGroup.js
+++ b/browser/src/layer/vector/SVGGroup.js
@@ -3,6 +3,8 @@
  * L.SVGGroup
  */
 
+/* global _ */
+
 L.SVGGroup = L.Layer.extend({
 
 	options: {
@@ -78,6 +80,46 @@ L.SVGGroup = L.Layer.extend({
 		var point = this._map.latLngToLayerPoint(this._bounds.getNorthWest());
 		svgLastChild.setAttribute('x', point.x);
 		svgLastChild.setAttribute('y', point.y);
+
+		var videos = svgLastChild.getElementsByTagName('video');
+		this.addVideoSupportHandlers(videos);
+	},
+
+	addVideoSupportHandlers: function(videos) {
+		if (!videos)
+			return;
+
+		var that = this;
+
+		// slide show may have more than one video and it does not require any selection
+		for (var i = 0; i < videos.length; i++) {
+			var video = videos[i];
+			var sources = video.getElementsByTagName('source');
+
+			video.addEventListener('playing', function() {
+				window.setTimeout(function() {
+					if (video.webkitDecodedFrameCount === 0) {
+						that.showUnsupportedVideoWarning();
+					}
+				}, 1000);
+			});
+
+			video.addEventListener('error', function() {
+				that.showUnsupportedVideoWarning();
+			});
+
+			if (sources.length) {
+				sources[0].addEventListener('error', function() {
+					that.showUnsupportedVideoWarning();
+				});
+			}
+		}
+
+	},
+
+	showUnsupportedVideoWarning: function() {
+		var videoWarning = _('Document contains unsupported video');
+		L.Map.THIS.uiManager.showSnackbar(videoWarning);
 	},
 
 	addEmbeddedSVG: function (svgString) {


### PR DESCRIPTION
detect if video is being played by browser using fps, if fps is near zero that means video is not able to play


Change-Id: I22bfc836a98ec0eb2caa58b89332b2531d69d18f

* Target version: master 



### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

