### PR TITLE
a11y: improved screen reader caret tracking on text navigation

### DIFF
--- a/browser/src/layer/marker/TextInput.js
+++ b/browser/src/layer/marker/TextInput.js
@@ -195,7 +195,7 @@ L.TextInput = L.Layer.extend({
 
 	_onFocusBlur: function(ev) {
 		this._fancyLog(ev.type, '');
-		this._dbg('_onFocusBlur');
+		this._statusLog('_onFocusBlur');
 		var onoff = (ev.type === 'focus' ? L.DomEvent.on : L.DomEvent.off).bind(L.DomEvent);
 
 		// Debug - connect first for saner logging.
@@ -633,7 +633,7 @@ L.TextInput = L.Layer.extend({
 	_onBeforeInput: function(ev) {
 		if (this._map.uiManager.isUIBlocked())
 			return;
-		this._dbg('_onBeforeInput [');
+		this._statusLog('_onBeforeInput [');
 		this._ignoreNextBackspace = false;
 		if (!this._isSelectionValid()) {
 			this._emptyArea();
@@ -648,7 +648,7 @@ L.TextInput = L.Layer.extend({
 			this._removeTextContent(0, 1);
 			this._emptyArea();
 		}
-		this._dbg('_onBeforeInput ]');
+		this._statusLog('_onBeforeInput ]');
 	},
 
 	_isDigit: function(asciiChar) {
@@ -663,7 +663,7 @@ L.TextInput = L.Layer.extend({
 	_onInput: function(ev) {
 		if (this._map.uiManager.isUIBlocked())
 			return;
-		this._dbg('_onInput [');
+		this._statusLog('_onInput [');
 		app.idleHandler.notifyActive();
 
 		if (this._ignoreInputCount > 0) {
@@ -762,7 +762,7 @@ L.TextInput = L.Layer.extend({
 		// special handling for mentions
 		this._handleMentionInput(ev, removeBefore);
 
-		this._dbg('_onInput ]');
+		this._statusLog('_onInput ]');
 	},
 
 	_sendNewText: function (ev, content, newText) {
@@ -853,7 +853,7 @@ L.TextInput = L.Layer.extend({
 	// (some combination of browser + input method don't fire those on an
 	// empty contenteditable).
 	_emptyArea: function(noSelect) {
-		this._dbg('_emptyArea [');
+		this._statusLog('_emptyArea [');
 		this._fancyLog('empty-area');
 
 		this._ignoreInputCount++;
@@ -880,7 +880,7 @@ L.TextInput = L.Layer.extend({
 		}
 
 		this._fancyLog('empty-area-end');
-		this._dbg('_emptyArea ]');
+		this._statusLog('_emptyArea ]');
 		this._ignoreInputCount--;
 	},
 
@@ -925,6 +925,8 @@ L.TextInput = L.Layer.extend({
 		if (this._isComposing)
 			this._isComposing = false;
 		if (this.hasAccessibilitySupport()) {
+			this._isLeftRightArrow = 0;
+			this._updateFocusedParagraph();
 			this._requestFocusedParagraph();
 		} else {
 			this._emptyArea(document.activeElement !== this._textArea);
@@ -947,6 +949,74 @@ L.TextInput = L.Layer.extend({
 		}
 		this._newlineHint = ev.keyCode === 13;
 		this._linebreakHint = this._newlineHint && ev.shiftKey;
+
+		// In order to allow screen reader to track caret navigation properly even if there is some connection delay
+		// default behaviour for Left/Right arrow key press is no more prevented in Map.Keyboard._handleKeyEvent,
+		// Here we set _isLeftRightArrow flag and handle some special cases.
+		if (this.hasAccessibilitySupport()) {
+			this._isLeftRightArrow = 0;
+			if (ev.key === 'ArrowLeft') {
+				this._isLeftRightArrow = -1;
+			} else if (ev.key === 'ArrowRight') {
+				this._isLeftRightArrow = 1;
+			}
+
+			// If we are at paragraph begin/end and left/right arrow is pressed, we need to prevent default behaviour
+			if (this._isLeftRightArrow) {
+				clearTimeout(this._onNavigationEndTimeout);
+				if (!this._isSelectionValid() || this._isComposing ||
+					(this._isLeftRightArrow > 0 && this._isCursorAtEnd()) ||
+					(this._isLeftRightArrow < 0 && this._isCursorAtStart())) {
+					this._log('_onKeyDown: preventDefault');
+					ev.preventDefault();
+				}
+			}
+
+			if (this._isLeftRightArrow) {
+				if (this._listPrefixLength > 0) {
+					var cursorPosition = this._getSelectionEnd();
+					if (cursorPosition === this._listPrefixLength && this._isLeftRightArrow < 0) {
+						// if caret is at begin of list entry content: "1. |Item 1" and shift+left arrow is pressed,
+						// then caret is moved at the end of previous paragraph, if any; or it's not moved at all
+						// if we are at the document beginning; so we only need to prevent default behaviour
+						ev.preventDefault();
+						if (!ev.shiftKey) {
+							// when shift is not pressed, caret is moved ahead of list prefix: "|1. Item 1",
+							// selection is cleared, if any
+							this._updateCursorPosition(0);
+						}
+					}
+					// if caret is ahead of list prefix: "|1. Item 1" and right arrow is pressed, with or without shift,
+					// caret is moved at begin of list entry content: "1. |Item 1", nothing is selected
+					if (cursorPosition === 0 && this._isLeftRightArrow > 0) {
+						ev.preventDefault();
+						this._updateCursorPosition(this._listPrefixLength);
+					}
+				}
+
+				// When left/right arrow is pressed and text is selected, selection is cleared
+				// and caret needs to be moved by one char left/right.
+				// However, for an editable div the behaviour is different:
+				// - when left arrow is pressed caret moves at start of previously selected text
+				// - when right arrow is pressed caret moves at end of previously selected text
+				// So we need to prevent default behaviour and simulate the same behaviour that occurs in LibreOffice.
+				if (!ev.shiftKey) {
+					var selection = window.getSelection();
+					if (!selection.isCollapsed) {
+						// The case where a left arrow is pressed with caret at the beginning of a list entry content
+						// is already handled earlier.
+						if (!(this._listPrefixLength > 0 &&
+							this._lastCursorPosition === this._listPrefixLength && this._isLeftRightArrow < 0)) {
+							this._log('_onKeyDown: pressed left/right arrows with selected text');
+							ev.preventDefault();
+							var pos = this._lastCursorPosition + this._isLeftRightArrow;
+							// _updateCursorPosition takes care to normalize pos value
+							this._updateCursorPosition(pos);
+						}
+					}
+				}
+			}
+		}
 
 		// We want to open drowdown menu when cursor is above a dropdown content control.
 		if (ev.code === 'Space' || ev.code === 'Enter') {
@@ -1016,6 +1086,24 @@ L.TextInput = L.Layer.extend({
 			ev.key === 'PageUp' || ev.key === 'PageDown' ||
 			ev.key === 'Escape')) {
 			this._emptyArea();
+		}
+
+		if (this.hasAccessibilitySupport()) {
+			if (ev.key === 'ArrowLeft' || ev.key === 'ArrowRight') {
+				clearTimeout(this._onNavigationEndTimeout);
+				this._onNavigationEndTimeout = setTimeout(function () {
+					if (this._isLeftRightArrow) {
+						this._isLeftRightArrow = 0;
+						this._updateFocusedParagraph();
+					}
+				}.bind(this), 1000);
+			}
+			else if (ev.key === 'Shift') {
+				if (this._isLeftRightArrow/* && this._remotePosition !== undefined*/) {
+					this._isLeftRightArrow = 0;
+					this._updateFocusedParagraph();
+				}
+			}
 		}
 
 		if (app.UI.notebookbarAccessibility)
@@ -1178,6 +1266,16 @@ L.TextInput = L.Layer.extend({
 		return typeof this._getSelectionStart() === 'number' && typeof this._getSelectionEnd() === 'number';
 	},
 
+	_isCursorAtStart: function() {
+		var selection = window.getSelection();
+		return selection.isCollapsed && this._getSelectionStart() === 0;
+	},
+
+	_isCursorAtEnd: function() {
+		var selection = window.getSelection();
+		return selection.isCollapsed && this._getSelectionEnd() === this.getPlainTextContent().length;
+	},
+
 	// When the cursor is on a text node return the position wrt the whole plain text content
 	// When the cursor is on a pre- / post-space node return -1 / -2
 	// Otherwise return undefined
@@ -1236,7 +1334,7 @@ L.TextInput = L.Layer.extend({
 	// start/end refer to the string represented by the whole plain text content
 	// it's not possible to set range start/end position at <img> delimiters
 	_setSelectionRange: function(start, end) {
-		this._dbg('_setSelectionRange [');
+		this._statusLog('_setSelectionRange [');
 		var selection = window.getSelection();
 		selection.removeAllRanges();
 		var range = document.createRange();
@@ -1246,7 +1344,7 @@ L.TextInput = L.Layer.extend({
 			range.setStart(this._textArea, 1);
 			range.setEnd(this._textArea, 1);
 			selection.addRange(range);
-			this._dbg('_setSelectionRange ]');
+			this._statusLog('_setSelectionRange ]');
 			return;
 		}
 
@@ -1295,7 +1393,7 @@ L.TextInput = L.Layer.extend({
 		// Get the selection object and add the range to it
 		selection.addRange(range);
 		window.console.log(msg);
-		this._dbg('_setSelectionRange ]');
+		this._statusLog('_setSelectionRange ]');
 	},
 
 	_logCharCodeSequence: function(text) {
@@ -1309,7 +1407,13 @@ L.TextInput = L.Layer.extend({
 		window.app.console.log('L.' + this._className + '._sendText: ' + s);
 	},
 
-	_dbg: function(header) {
+	_log: function(msg) {
+		if (!this._isDebugOn)
+			return;
+		window.app.console.log(msg);
+	},
+	
+	_statusLog: function(header) {
 		if (!this._isDebugOn)
 			return;
 
@@ -1317,6 +1421,7 @@ L.TextInput = L.Layer.extend({
 		msg += '  _lastContent: ' + this._lastContent  +'\n';
 		msg += '  _lastContent: >' + this.codePointsToString(this._lastContent) + '<\n';
 		if (this.hasAccessibilitySupport()) {
+			msg += '  _remotePosition: ' + this._remotePosition + '\n';
 			msg += '  _lastCursorPosition: ' + this._getLastCursorPosition() + '\n';
 			msg += '  _lastSelectionStart: ' + this._lastSelectionStart + '\n';
 			msg += '  _lastSelectionEnd: ' + this._lastSelectionEnd + '\n';

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1854,8 +1854,10 @@ L.CanvasTileLayer = L.Layer.extend({
 		}
 		else if (textMsg.startsWith('a11yfocuschanged:')) {
 			obj = JSON.parse(textMsg.substring('a11yfocuschanged:'.length + 1));
+			var listPrefixLength = obj.listPrefixLength !== undefined ? parseInt(obj.listPrefixLength) : 0;
 			this._map._textInput.onAccessibilityFocusChanged(
-				obj.content, parseInt(obj.position), parseInt(obj.start), parseInt(obj.end), parseInt(obj.force) > 0);
+				obj.content, parseInt(obj.position), parseInt(obj.start), parseInt(obj.end),
+				listPrefixLength, parseInt(obj.force) > 0);
 		}
 		else if (textMsg.startsWith('a11ycaretchanged:')) {
 			obj = JSON.parse(textMsg.substring('a11yfocuschanged:'.length + 1));

--- a/browser/src/map/handler/Map.Keyboard.js
+++ b/browser/src/map/handler/Map.Keyboard.js
@@ -526,7 +526,12 @@ L.Map.Keyboard = L.Handler.extend({
 				if (this.handleOnKeyDownKeys[keyCode] && charCode === 0) {
 					if (keyEventFn) {
 						keyEventFn('input', charCode, unoKeyCode);
-						ev.preventDefault();
+						if (!(this._map._textInput.hasAccessibilitySupport() && this._map._textInput.hasFocus() &&
+							(keyCode === this.keyCodes.LEFT || keyCode === this.keyCodes.RIGHT))) {
+							ev.preventDefault();
+						} else {
+							window.app.console.log('Map.Keyboard._handleKeyEvent: default not prevented for left or right arrow.');
+						}
 					}
 				}
 			}

--- a/cypress_test/integration_tests/desktop/writer/editable_area_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/editable_area_spec.js
@@ -521,15 +521,30 @@ describe(['taga11yenabled'], 'Editable area - Inner selection', function() {
 		helper.clickAt('P');
 		ceHelper.checkSelectionIsNull();
 		ceHelper.checkCaretPosition(7);
-		// select 'World' by a double click
-		helper.clickAt('P', true);
-		ceHelper.checkSelectionRange(6, 11);
 		// check empty selection
+		ceHelper.moveCaret('left');
+		ceHelper.moveCaret('right', 'shift', 5);
 		ceHelper.moveCaret('left', 'shift', 5);
 		ceHelper.checkSelectionIsEmpty(6);
 		ceHelper.moveCaret('left', 'shift');
 		ceHelper.checkSelectionRange(5, 6);
 		ceHelper.moveCaret('right', 'shift');
+		ceHelper.checkSelectionIsEmpty(6);
+	});
+
+	// double click is failing sometimes, so try it one more time
+	it('Selecting by double clicking', {retries: 2}, function () {
+		ceHelper.type('Hello World');
+		ceHelper.checkPlainContent('Hello World');
+		ceHelper.moveCaret('left', '', 4);
+		ceHelper.checkCaretPosition(7);
+		helper.getBlinkingCursorPosition('P');
+		ceHelper.moveCaret('home');
+		// select 'World' by a double click
+		helper.clickAt('P', true);
+		ceHelper.checkSelectionRange(6, 11);
+		// check empty selection
+		ceHelper.moveCaret('left', 'shift', 5);
 		ceHelper.checkSelectionIsEmpty(6);
 	});
 


### PR DESCRIPTION
In order to allow screen reader to track caret navigation properly
even if there is some connection delay default behaviour for
Left/Right arrow key press is no more prevented in
Map.Keyboard._handleKeyEvent. In TextInput._onKeyDown, it has been
needed to handle some special caret position, such as when cursor is
at begin or end of a list item prefix.
When left/right arrow is pressed and text is selected, selection is
cleared and caret needs to be moved by one char left/right.
However, for an editable div the behaviour is different:
- when left arrow is pressed caret moves at start of previously
selected text
- when right arrow is pressed caret moves at end of previously
selected text
So we needed to prevent default behaviour and simulate the same
behaviour that occurs in LibreOffice.

Signed-off-by: Marco Cecchetti <marco.cecchetti@collabora.com>
Change-Id: Ifa5e9847bbbf77b934a3bcbd04545f4a55afd19d
