### PR TITLE
jsdialog: create also combobox without entries

### DIFF
--- a/browser/src/control/Control.NotebookbarBuilder.js
+++ b/browser/src/control/Control.NotebookbarBuilder.js
@@ -280,9 +280,6 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 	},
 
 	_comboboxControl: function(parentContainer, data, builder) {
-		if (!data.entries || data.entries.length === 0)
-			return false;
-
 		if (window.ThisIsTheiOSApp && data.id === 'fontnamecombobox') {
 			this._createiOsFontButton(parentContainer, data, builder);
 			return false;


### PR DESCRIPTION
this fixes missing font name and font size comboboxes when opened spreadsheet protected from editing