### PR TITLE
Remove ~ character from translatable strings.

### DIFF
--- a/browser/js/l10n.js
+++ b/browser/js/l10n.js
@@ -123,7 +123,8 @@ var
 
 					for (message in localization) {
 						if (has_own_prop.call(localization, message)) {
-							localizations[locale][message] = localization[message];
+							// Replace the first occurance of the "~" symbol.
+							localizations[locale][message.replace('~', '')] = localization[message];
 						}
 					}
 				}


### PR DESCRIPTION
Reason: Some of the translatables are not read from the JSON file for some reason.

This is a workaround until we remove all ~ symbols from tab contents.


Change-Id: Ic3ffc9e3410099fc0d87ffbf46d208b9fc07c788


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

