### PR TITLE
Missing icon for show menubar

### DIFF
--- a/browser/images/dark/fold.svg
+++ b/browser/images/dark/fold.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 11 11" xmlns="http://www.w3.org/2000/svg" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" transform="matrix(1,0,0,-1,0,0)">
+  <path d="m.5 3.5 5 5 5-5" fill="none" stroke="#1e8bcd" stroke-linecap="round" stroke-linejoin="round"></path>
+</svg>


### PR DESCRIPTION
Signed-off-by: Darshan-upadhyay1110 <darshan.upadhyay@collabora.com>
Change-Id: I650a9adcdbbd768017d4ba0e17277de562e7d184

added fold svg icon which was missing for dark mode

![image](https://github.com/CollaboraOnline/online/assets/61383886/24bb4097-46a8-4152-9700-d1b02a66743c)

* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

