### PR TITLE
Calc: Sheet tab context menu: Rename Sheet has extra padding

### DIFF
--- a/browser/src/control/Control.Tabs.js
+++ b/browser/src/control/Control.Tabs.js
@@ -156,19 +156,19 @@ L.Control.Tabs = L.Control.extend({
 					{
 						'insertsheetbefore' : this._menuItem['insertsheetbefore'],
 						'insertsheetafter'  :   this._menuItem['insertsheetafter'],
-						'.uno:Name' : this._menuItem['.uno:Name'],
+						'Name' : this._menuItem['.uno:Name'],
 					}
 				);
 				if (this._map.hasAnyHiddenPart()) {
 					Object.assign(menuItemMobile, {
-						'.uno:Show' : this._menuItem['.uno:Show'],
+						'Show' : this._menuItem['.uno:Show'],
 					});
 				}
 				if (this._map.getNumberOfVisibleParts() !== 1) {
 					Object.assign(menuItemMobile,
 						{
-							'.uno:Remove': this._menuItem['.uno:Remove'],
-							'.uno:Hide': this._menuItem['.uno:Hide'],
+							'Remove': this._menuItem['.uno:Remove'],
+							'Hide': this._menuItem['.uno:Hide'],
 							'movesheetleft': this._menuItem['movesheetleft'],
 							'movesheetright': this._menuItem['movesheetright'],
 						}


### PR DESCRIPTION

Signed-off-by: Darshan-upadhyay1110 <darshan.upadhyay@collabora.com>
Change-Id: I5139e0072caabd7db7c4d1255b497cf24e1359e6

Fix extra padding for sheets tab on mobile view

![image](https://github.com/CollaboraOnline/online/assets/61383886/c6f9127d-54c1-4e26-9469-f2d58b720f4b)

* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

