### PR TITLE
Firefox 117 no copy event is emitted by hitting CTRL+C with no selection

### DIFF
--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -116,6 +116,18 @@ window.app = {
 	var navigatorLang = navigator.languages && navigator.languages.length ? navigator.languages[0] :
 	    (navigator.language || navigator.userLanguage || navigator.browserLanguage || navigator.systemLanguage);
 
+	function getFirefoxVersion() {
+		var version = '';
+
+		var userAgent = navigator.userAgent.toLowerCase();
+		if (userAgent.indexOf('firefox') !== -1) {
+			var matches = userAgent.match(/firefox\/([0-9]+\.*[0-9]*)/);
+			if (matches) {
+				version = matches[1];
+			}
+		}
+		return version;
+	}
 
 	global.L = {};
 
@@ -148,6 +160,10 @@ window.app = {
 		// @property gecko: Boolean
 		// `true` for gecko-based browsers like Firefox.
 		gecko: gecko,
+
+		// @property geckoVersion: String
+		// Firefox version: abc.d.
+		geckoVersion: getFirefoxVersion(),
 
 		// @property android: Boolean
 		// `true` for any browser running on an Android platform.

--- a/browser/src/layer/marker/TextInput.js
+++ b/browser/src/layer/marker/TextInput.js
@@ -950,6 +950,20 @@ L.TextInput = L.Layer.extend({
 		this._newlineHint = ev.keyCode === 13;
 		this._linebreakHint = this._newlineHint && ev.shiftKey;
 
+		// In Firefox 117 no copy/cut input event is emitted when CTRL+C/X is pressed with no selection
+		// in a text element with contenteditable='true'. Since no copy/cut event is emitted,
+		// Clipboard.copy/cut is never invoked. So we need to emit it manually.
+		// To be honest it seems a Firefox bug. We need to check if they fix it in later version.
+		if (!this.hasAccessibilitySupport() &&  L.Browser.gecko && L.Browser.geckoVersion === '117.0' &&
+			ev.ctrlKey && window.getSelection().isCollapsed) {
+			if (ev.key === 'c') {
+				document.execCommand('copy');
+			}
+			else if (ev.key === 'x') {
+				document.execCommand('cut');
+			}
+		}
+
 		// In order to allow screen reader to track caret navigation properly even if there is some connection delay
 		// default behaviour for Left/Right arrow key press is no more prevented in Map.Keyboard._handleKeyEvent,
 		// Here we set _isLeftRightArrow flag and handle some special cases.


### PR DESCRIPTION
The problem affects no-a11y case since the editable area is empty.
Since no copy/cut event is emitted, Clipboard.copy/cut is never
invoked. So we need to emit it manually.
To be honest it seems a Firefox bug. We need to check if they fix it
in later version.

Signed-off-by: Marco Cecchetti <marco.cecchetti@collabora.com>
Change-Id: I036414b5ffb5b35ff1ef1d7de1044e890832c673
