### PR TITLE
New copy paste dialogs / snackbars

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -329,6 +329,7 @@ COOL_JS_LST =\
 	src/control/Control.AlertDialog.js \
 	src/control/ColorPicker.js \
 	src/control/jsdialog/Util.FocusCycle.js \
+	src/control/jsdialog/Util.ModalHelper.js \
 	src/control/jsdialog/Widget.Calendar.js \
 	src/control/jsdialog/Widget.Combobox.js \
 	src/control/jsdialog/Widget.DrawingArea.js \

--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -338,6 +338,7 @@ COOL_JS_LST =\
 	src/control/jsdialog/Widget.MenuButton.js \
 	src/control/jsdialog/Widget.MobileTabControl.js \
 	src/control/jsdialog/Widget.MultilineEdit.js \
+	src/control/jsdialog/Widget.Progressbar.js \
 	src/control/jsdialog/Widget.ScrolledWindow.js \
 	src/control/jsdialog/Widget.TreeView.js \
 	src/control/Control.JSDialog.js \

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1370,6 +1370,10 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	align-items: center;
 }
 
+.ui-progressbar progress {
+	width: 100%;
+}
+
 /* snackbar */
 .snackbar {
 	border: none !important;

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1374,6 +1374,11 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	width: 100%;
 }
 
+.snackbar .ui-progressbar progress {
+	min-width: 120px;
+	margin-right: 10px;
+}
+
 /* snackbar */
 .snackbar {
 	border: none !important;

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1377,6 +1377,9 @@ input[type='number']:hover::-webkit-outer-spin-button {
 .snackbar.jsdialog-window {
 	overflow: visible;
 }
+.snackbar #snackbar-container {
+	align-items: center;
+}
 #mobile-wizard.popup.snackbar,
 .snackbar.jsdialog-container .ui-dialog-content {
 	min-width: 200px;

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1386,7 +1386,8 @@ input[type='number']:hover::-webkit-outer-spin-button {
 .snackbar.jsdialog-window {
 	overflow: visible;
 }
-.snackbar #snackbar-container {
+.snackbar #snackbar-container,
+.snackbar #snackbar-container-progress {
 	align-items: center;
 	max-width: calc(80vw);
 }
@@ -1435,6 +1436,16 @@ input[type='number']:hover::-webkit-outer-spin-button {
 
 .snackbar.jsdialog-container #button.ui-pushbutton.jsdialog {
 	padding: 8px;
+}
+
+#snackbar-container-progress .ui-progressbar {
+	display: grid;
+	grid-column: 1 / 3;
+}
+
+#snackbar-container-progress {
+	grid-template-rows: repeat(2, auto);
+	grid-template-columns: repeat(2, auto);
 }
 
 #mobile-wizard.popup.snackbar #button,

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1749,3 +1749,8 @@ kbd,
 	min-width: 1em;
 	margin-inline-start: 0.5em;
 }
+
+/* clipboard warning dialog */
+#modal-dialog-copy_paste_download_progress .ui-dialog-content {
+	width: 450px;
+}

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1434,7 +1434,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 }
 
 .snackbar.jsdialog-container #button.ui-pushbutton.jsdialog {
-	padding-right: 0;
+	padding: 8px;
 }
 
 #mobile-wizard.popup.snackbar #button,

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1379,6 +1379,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 }
 .snackbar #snackbar-container {
 	align-items: center;
+	max-width: calc(80vw);
 }
 #mobile-wizard.popup.snackbar,
 .snackbar.jsdialog-container .ui-dialog-content {

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1364,6 +1364,12 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	stop-opacity: 0.2;
 }
 
+/* progressbar */
+.ui-progressbar {
+	display: flex;
+	align-items: center;
+}
+
 /* snackbar */
 .snackbar {
 	border: none !important;

--- a/browser/src/control/Control.DownloadProgress.js
+++ b/browser/src/control/Control.DownloadProgress.js
@@ -112,8 +112,10 @@ L.Control.DownloadProgress = L.Control.extend({
 		var buttonText = _('Copy') + ' (Ctrl + C)'; // TODO: on Mac Ctrl == Command?
 
 		if (inSnackbar) {
-			this._map.uiManager.showSnackbar(snackbarMsg, buttonText,
+			this._map.uiManager.showProgressBar(snackbarMsg, buttonText,
 				this._onConfirmCopyAction.bind(this), this.options.snackbarTimeout);
+
+			this._map.uiManager.setSnackbarProgress(100);
 
 			this.setupKeyboardShortcutForSnackbar();
 		} else {

--- a/browser/src/control/Control.DownloadProgress.js
+++ b/browser/src/control/Control.DownloadProgress.js
@@ -107,16 +107,17 @@ L.Control.DownloadProgress = L.Control.extend({
 
 	_showDownloadComplete: function (inSnackbar) {
 		var modalId = this._getDownloadProgressDialogId();
-		var msg = _('Download completed and ready to be copied to clipboard.');
+		var snackbarMsg = _('Download completed and ready to be copied to clipboard.');
+		var dialogMsg = snackbarMsg + ' ' + _('From now on clipboard notifications will discreetly appear at the bottom.');
 		var buttonText = _('Copy') + ' (Ctrl + C)'; // TODO: on Mac Ctrl == Command?
 
 		if (inSnackbar) {
-			this._map.uiManager.showSnackbar(msg, buttonText,
+			this._map.uiManager.showSnackbar(snackbarMsg, buttonText,
 				this._onConfirmCopyAction.bind(this), this.options.snackbarTimeout);
 
 			this.setupKeyboardShortcutForSnackbar();
 		} else {
-			JSDialog.setMessageInModal(modalId, msg, '');
+			JSDialog.setMessageInModal(modalId, dialogMsg, '');
 			JSDialog.enableButtonInModal(modalId, modalId + '-response', true);
 			this.setupKeyboardShortcutForDialog(modalId);
 		}
@@ -250,6 +251,9 @@ L.Control.DownloadProgress = L.Control.extend({
 		this._map._clip.filterExecCopyPaste('.uno:Copy');
 		this._onClose();
 		this._setUserAlreadyWarned();
+
+		var msg = _('Content copied to clipboard');
+		this._map.uiManager.showSnackbar(msg);
 	},
 
 	_onClose: function () {

--- a/browser/src/control/Control.DownloadProgress.js
+++ b/browser/src/control/Control.DownloadProgress.js
@@ -2,7 +2,7 @@
 /*
  * L.Control.DownloadProgress.
  */
-/* global _ $ */
+/* global _ $ JSDialog */
 L.Control.DownloadProgress = L.Control.extend({
 	options: {
 		snackbarTimeout: 20000,
@@ -77,13 +77,15 @@ L.Control.DownloadProgress = L.Control.extend({
 	_showDownloadProgress: function (inSnackbar) {
 		var modalId = this._getDownloadProgressDialogId();
 		var msg = _('Downloading clipboard content');
-		var buttonText = _('Cancel');
+		var buttonText = _('Copy') + ' (Ctrl + C)'; // TODO: on Mac Ctrl == Command?
 
 		if (inSnackbar) {
 			this._map.uiManager.showProgressBar(msg, buttonText, this._onClose.bind(this));
 		} else {
 			this._map.uiManager.showProgressBarDialog(modalId, this._getDialogTitle(), msg,
-				buttonText, this._onClose.bind(this), 0);
+				buttonText, this._onConfirmCopyAction.bind(this), 0, this._onClose.bind(this));
+
+			JSDialog.enableButtonInModal(modalId, modalId + '-response', false);
 		}
 	},
 
@@ -106,9 +108,8 @@ L.Control.DownloadProgress = L.Control.extend({
 
 			this.setupKeyboardShortcutForSnackbar();
 		} else {
-			this._map.uiManager.showInfoModal(modalId, this._getDialogTitle(), msg, '',
-				buttonText, this._onConfirmCopyAction.bind(this), true, modalId + '-response');
-
+			JSDialog.setMessageInModal(modalId, msg, '');
+			JSDialog.enableButtonInModal(modalId, modalId + '-response', true);
 			this.setupKeyboardShortcutForDialog(modalId);
 		}
 	},

--- a/browser/src/control/Control.DownloadProgress.js
+++ b/browser/src/control/Control.DownloadProgress.js
@@ -53,7 +53,7 @@ L.Control.DownloadProgress = L.Control.extend({
 		var modalId = 'large_copy_paste_warning';
 
 		var msg = this._getLargeCopyPasteMessage();
-		var buttonText = _('Download') + ' (Alt + C)'; // TODO: on Mac Alt == Option
+		var buttonText = _('Download') + ' (Ctrl + C)'; // TODO: on Mac Ctrl == Command
 
 		if (inSnackbar) {
 			this._map.uiManager.showSnackbar(
@@ -98,7 +98,7 @@ L.Control.DownloadProgress = L.Control.extend({
 	_showDownloadComplete: function (inSnackbar) {
 		var modalId = 'copy_paste_complete';
 		var msg = _('Download completed and ready to be copied to clipboard.');
-		var buttonText = _('Copy') + ' (Alt + C)'; // TODO: on Mac Alt == Option
+		var buttonText = _('Copy') + ' (Ctrl + C)'; // TODO: on Mac Ctrl == Command?
 
 		if (inSnackbar) {
 			this._map.uiManager.showSnackbar(msg, buttonText,
@@ -115,7 +115,7 @@ L.Control.DownloadProgress = L.Control.extend({
 
 	_setupKeyboardShortcutForElement: function (eventTargetId, buttonId) {
 		var keyDownCallback = function(e) {
-			if (e.altKey && e.keyCode === 67 /*C*/) {
+			if (!e.altKey && !e.shiftKey && e.ctrlKey && e.key === 'c') { // CTRL + C
 				document.getElementById(buttonId).click();
 				e.preventDefault();
 			}

--- a/browser/src/control/Control.DownloadProgress.js
+++ b/browser/src/control/Control.DownloadProgress.js
@@ -5,65 +5,18 @@
 /* global _ $ */
 L.Control.DownloadProgress = L.Control.extend({
 	options: {
-		position: 'bottomright'
+		snackbarTimeout: 20000
 	},
 
 	initialize: function (options) {
 		L.setOptions(this, options);
 	},
 
-	onAdd: function () {
-		this._initLayout();
-		return this._container;
-	},
-
-	// we really don't want mouse and other events propagating
-	// to the parent map - since they affect the context.
-	_ignoreEvents: function(elem) {
-		L.DomEvent.on(elem, 'mousedown mouseup mouseover mouseout mousemove',
-			      function(e) {
-				      L.DomEvent.stopPropagation(e);
-				      return false;
-			      }, this);
-	},
-
-	_initLayout: function () {
-		this._container = L.DomUtil.create('div', 'leaflet-control-layers');
-		this._container.style.visibility = 'hidden';
-		this._ignoreEvents(this._container);
-
-		var closeButton = L.DomUtil.create('a', 'leaflet-popup-close-button download-popup', this._container);
-		closeButton.href = '#close';
-		closeButton.innerHTML = '&#215;';
-		L.DomEvent.on(closeButton, 'click', this._onClose, this);
-
-		var wrapper = L.DomUtil.create('div', 'leaflet-popup-content-wrapper', this._container);
-		var content = this._content = L.DomUtil.create('div', 'leaflet-popup-content', wrapper);
-		content.style.width  = '100px';
-
-		// start download button
-		var startDownload = this._downloadButton = document.createElement('a');
-		startDownload.href = '#start';
-		startDownload.innerHTML = _('Start download');
-		startDownload.style.font = '13px/11px Tahoma, Verdana, sans-serif';
-		startDownload.style.alignment = 'center';
-		startDownload.style.height = 20 + 'px';
-		L.DomEvent.on(startDownload, 'click', this._onStartDownload, this);
-
-		// download progress bar
-		this._progress = L.DomUtil.create('div', 'leaflet-paste-progress', null);
-		this._bar = L.DomUtil.create('span', '', this._progress);
-		this._value = L.DomUtil.create('span', '', this._bar);
-		L.DomUtil.setStyle(this._value, 'line-height', '14px');
-
-		// confirm button
-		var confirmCopy = this._confirmPasteButton = document.createElement('a');
-		confirmCopy.href = '#complete';
-		confirmCopy.innerHTML = _('Confirm copy to clipboard');
-		confirmCopy.style.font = '13px/11px Tahoma, Verdana, sans-serif';
-		confirmCopy.style.alignment = 'center';
-		confirmCopy.style.height = 20 + 'px';
-		L.DomEvent.on(confirmCopy, 'click', this._onConfirmCopyAction, this);
+	onAdd: function (map) {
+		this._map = map;
+		this._started = false;
+		this._complete = false;
+		this._closed = false;
 	},
 
 	show: function () {
@@ -73,8 +26,11 @@ L.Control.DownloadProgress = L.Control.extend({
 		this._started = false;
 		this._complete = false;
 		this._closed = false;
-		this._content.appendChild(this._downloadButton);
-		this._container.style.visibility = '';
+
+		var msg = _('Start download') + ' (Alt + C)'; // TODO: on Mac Alt == Option
+		this._map.uiManager.showSnackbar(
+			_('To copy outside, you have to download the content'),
+			msg, this._onStartDownload.bind(this), this.options.snackbarTimeout);
 	},
 
 	isClosed: function () {
@@ -88,11 +44,11 @@ L.Control.DownloadProgress = L.Control.extend({
 	currentStatus: function () {
 		if (this._closed)
 			return 'closed';
-		if (this._content.contains(this._downloadButton))
+		if (!this._started && !this._complete)
 			return 'downloadButton';
-		if (this._content.contains(this._progress))
+		if (this._started)
 			return 'progress';
-		if (this._content.contains(this._confirmPasteButton))
+		if (this._complete)
 			return 'confirmPasteButton';
 	},
 
@@ -102,8 +58,7 @@ L.Control.DownloadProgress = L.Control.extend({
 	},
 
 	setValue: function (value) {
-		this._bar.style.width = Math.round(value) + '%';
-		this._value.innerHTML = Math.round(value) + '%';
+		this._map.uiManager.setSnackbarProgress(Math.round(value));
 	},
 
 	_setProgressCursor: function() {
@@ -117,9 +72,9 @@ L.Control.DownloadProgress = L.Control.extend({
 	startProgressMode: function() {
 		this._setProgressCursor();
 		this._started = true;
+		this._map.uiManager.showProgressBar(
+			'Downloading clipboard content', 'Cancel', this._onClose.bind(this));
 		this.setValue(0);
-		this._content.removeChild(this._downloadButton);
-		this._content.appendChild(this._progress);
 	},
 
 	_onStartDownload: function () {
@@ -143,10 +98,12 @@ L.Control.DownloadProgress = L.Control.extend({
 			return;
 		this._setNormalCursor();
 		this._complete = true;
-		if (this._content.contains(this._progress))
-			this._content.removeChild(this._progress);
-		this._content.style.width  = '150px';
-		this._content.appendChild(this._confirmPasteButton);
+		this._started = false;
+
+		var msg = _('Confirm copy to clipboard');
+		// TODO: on Mac Alt == Option
+		this._map.uiManager.showSnackbar(msg, _('Confirm') + ' (Alt + C)',
+			this._onConfirmCopyAction.bind(this), this.options.snackbarTimeout);
 	},
 
 	_onConfirmCopyAction: function () {
@@ -155,16 +112,17 @@ L.Control.DownloadProgress = L.Control.extend({
 	},
 
 	_onClose: function () {
+		if (this._userAlreadyWarned())
+			this._map.uiManager.closeSnackbar();
+
+		this._started = false;
+		this._complete = false;
+		this._closed = true;
+
 		this._setNormalCursor();
 		this._cancelDownload();
-		if (this._content.contains(this._confirmPasteButton))
-			this._content.removeChild(this._confirmPasteButton);
-		if (this._content.contains(this._progress))
-			this._content.removeChild(this._progress);
 		if (this._map)
 			this._map.focus();
-		this.remove();
-		this._closed = true;
 	},
 
 	_download: function () {
@@ -186,7 +144,12 @@ L.Control.DownloadProgress = L.Control.extend({
 				// TODO: failure to parse ? ...
 				reader.readAsText(response);
 			},
-			function(progress) { return progress/2; }
+			function(progress) { return progress/2; },
+			function () {
+				that._onClose();
+				that._map.uiManager.showSnackbar(
+					_('Download failed'), '', null,this.options.snackbarTimeout);
+			}
 		);
 	},
 

--- a/browser/src/control/Control.DownloadProgress.js
+++ b/browser/src/control/Control.DownloadProgress.js
@@ -47,10 +47,14 @@ L.Control.DownloadProgress = L.Control.extend({
 			_('If you want to share large elements outside of %productName it\'s necessary to first download them.'));
 	},
 
+	_getDownloadProgressDialogId: function () {
+		return 'copy_paste_download_progress';
+	},
+
 	// Step 1. Large copy paste warning
 
 	_showLargeCopyPasteWarning: function (inSnackbar) {
-		var modalId = 'large_copy_paste_warning';
+		var modalId = this._getDownloadProgressDialogId();
 
 		var msg = this._getLargeCopyPasteMessage();
 		var buttonText = _('Download') + ' (Ctrl + C)'; // TODO: on Mac Ctrl == Command
@@ -69,10 +73,6 @@ L.Control.DownloadProgress = L.Control.extend({
 	},
 
 	// Step 2. Download progress
-
-	_getDownloadProgressDialogId: function () {
-		return 'copy_paste_download_progress';
-	},
 
 	_showDownloadProgress: function (inSnackbar) {
 		var modalId = this._getDownloadProgressDialogId();
@@ -96,7 +96,7 @@ L.Control.DownloadProgress = L.Control.extend({
 	// Step 3. Download complete
 
 	_showDownloadComplete: function (inSnackbar) {
-		var modalId = 'copy_paste_complete';
+		var modalId = this._getDownloadProgressDialogId();
 		var msg = _('Download completed and ready to be copied to clipboard.');
 		var buttonText = _('Copy') + ' (Ctrl + C)'; // TODO: on Mac Ctrl == Command?
 
@@ -202,6 +202,8 @@ L.Control.DownloadProgress = L.Control.extend({
 
 		this.startProgressMode();
 		this._download();
+
+		return true;
 	},
 
 	_onUpdateProgress: function (e) {
@@ -216,11 +218,10 @@ L.Control.DownloadProgress = L.Control.extend({
 	_onComplete: function () {
 		if (this._complete)
 			return;
+		this.setValue(100);
 		this._setNormalCursor();
 		this._complete = true;
 		this._started = false;
-
-		this._closeDownloadProgressDialog();
 
 		this._showDownloadComplete(this._userAlreadyWarned());
 	},

--- a/browser/src/control/Control.DownloadProgress.js
+++ b/browser/src/control/Control.DownloadProgress.js
@@ -58,11 +58,13 @@ L.Control.DownloadProgress = L.Control.extend({
 		if (inSnackbar) {
 			this._map.uiManager.showSnackbar(
 				msg, buttonText, this._onStartDownload.bind(this), this.options.snackbarTimeout);
+
+			this.setupKeyboardShortcutForSnackbar();
 		} else {
 			this._map.uiManager.showInfoModal(modalId, this._getDialogTitle(), msg, '',
 				buttonText, this._onStartDownload.bind(this), true, modalId + '-response');
 
-			this.setupKeyboardShortcut(modalId);
+			this.setupKeyboardShortcutForDialog(modalId);
 		}
 	},
 
@@ -101,23 +103,33 @@ L.Control.DownloadProgress = L.Control.extend({
 		if (inSnackbar) {
 			this._map.uiManager.showSnackbar(msg, buttonText,
 				this._onConfirmCopyAction.bind(this), this.options.snackbarTimeout);
+
+			this.setupKeyboardShortcutForSnackbar();
 		} else {
 			this._map.uiManager.showInfoModal(modalId, this._getDialogTitle(), msg, '',
 				buttonText, this._onConfirmCopyAction.bind(this), true, modalId + '-response');
 
-			this.setupKeyboardShortcut(modalId);
+			this.setupKeyboardShortcutForDialog(modalId);
 		}
 	},
 
-	setupKeyboardShortcut: function (modalId) {
+	_setupKeyboardShortcutForElement: function (eventTargetId, buttonId) {
 		var keyDownCallback = function(e) {
 			if (e.altKey && e.keyCode === 67 /*C*/) {
-				document.getElementById(modalId + '-response').click();
+				document.getElementById(buttonId).click();
 				e.preventDefault();
 			}
 		};
+		document.getElementById(eventTargetId).onkeydown = keyDownCallback.bind(this);
+	},
+
+	setupKeyboardShortcutForDialog: function (modalId) {
 		var dialogId = this._map.uiManager.generateModalId(modalId);
-		document.getElementById(dialogId).onkeydown = keyDownCallback.bind(this);
+		this._setupKeyboardShortcutForElement(dialogId, modalId + '-response');
+	},
+
+	setupKeyboardShortcutForSnackbar: function () {
+		this._setupKeyboardShortcutForElement('snackbar', 'button');
 	},
 
 	show: function () {

--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -53,6 +53,9 @@ L.Control.JSDialog = L.Control.extend({
 			if (!sendCloseEvent && this.dialogs[id].overlay)
 				L.DomUtil.remove(this.dialogs[id].overlay);
 
+			if (this.dialogs[id].timeoutId)
+				clearTimeout(this.dialogs[id].timeoutId);
+
 			if (this.dialogs[id].isPopup)
 				this.closePopover(id, sendCloseEvent);
 			else
@@ -576,7 +579,7 @@ L.Control.JSDialog = L.Control.extend({
 			this.dialogs[instance.id] = instance;
 
 			if (instance.isSnackbar && instance.snackbarTimeout > 0) {
-				setTimeout(function () { instance.that.closePopover(instance.id, false); }, instance.snackbarTimeout);
+				instance.timeoutId = setTimeout(function () { instance.that.closePopover(instance.id, false); }, instance.snackbarTimeout);
 			}
 		}
 	},

--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -35,6 +35,12 @@ L.Control.JSDialog = L.Control.extend({
 			.length > 0;
 	},
 
+	hasSnackbarOpened: function() {
+		return Object.keys(this.dialogs)
+			.filter(function (key) { return key == 'snackbar'; })
+			.length > 0;
+	},
+
 	clearDialog: function(id) {
 		var builder = this.dialogs[id].builder;
 

--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -575,7 +575,7 @@ L.Control.JSDialog = L.Control.extend({
 
 			this.dialogs[instance.id] = instance;
 
-			if (instance.isSnackbar) {
+			if (instance.isSnackbar && instance.snackbarTimeout > 0) {
 				setTimeout(function () { instance.that.closePopover(instance.id, false); }, instance.snackbarTimeout);
 			}
 		}

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -76,7 +76,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 
 		this._controlHandlers = {};
 		this._controlHandlers['radiobutton'] = this._radiobuttonControl;
-		this._controlHandlers['progresssbar'] = this._progressbarControl;
+		this._controlHandlers['progresssbar'] = JSDialog.progressbar;
 		this._controlHandlers['checkbox'] = this._checkboxControl;
 		this._controlHandlers['basespinfield'] = this.baseSpinField;
 		this._controlHandlers['spinfield'] = this._spinfieldControl;
@@ -1486,35 +1486,6 @@ L.Control.JSDialogBuilder = L.Control.extend({
 
 		if (data.hidden)
 			$(radiobutton).hide();
-
-		return false;
-	},
-
-	_progressbarControl: function(parentContainer, data, builder) {
-		var div = L.DomUtil.createWithId('div', data.id, parentContainer);
-		L.DomUtil.addClass(div, 'cool-progressbar');
-		L.DomUtil.addClass(div, builder.options.cssClass);
-
-		var progressbar = L.DomUtil.create('progress', builder.options.cssClass, div);
-		progressbar.id = data.id + '-progress';
-		progressbar.tabIndex = '0';
-
-		if (data.value !== undefined)
-			progressbar.value = data.value;
-		else
-			progressbar.value = 0;
-
-		if (data.maxValue !== undefined)
-			progressbar.max = data.maxValue;
-		else
-			progressbar.max = 100;
-
-		if (data.enabled === 'false' || data.enabled === false) {
-			$(progressbar).prop('disabled', true);
-		}
-
-		if (data.hidden)
-			$(progressbar).hide();
 
 		return false;
 	},

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -76,7 +76,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 
 		this._controlHandlers = {};
 		this._controlHandlers['radiobutton'] = this._radiobuttonControl;
-		this._controlHandlers['progresssbar'] = JSDialog.progressbar;
+		this._controlHandlers['progressbar'] = JSDialog.progressbar;
 		this._controlHandlers['checkbox'] = this._checkboxControl;
 		this._controlHandlers['basespinfield'] = this.baseSpinField;
 		this._controlHandlers['spinfield'] = this._spinfieldControl;

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -3249,6 +3249,14 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			$(control).addClass('hidden');
 			break;
 
+		case 'enable':
+			control.disabled = false;
+			break;
+
+		case 'disable':
+			control.disabled = true;
+			break;
+
 		case 'setText':
 			// eg. in mobile wizard input is inside spin button div
 			var innerInput = control.querySelector('input');

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -76,6 +76,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 
 		this._controlHandlers = {};
 		this._controlHandlers['radiobutton'] = this._radiobuttonControl;
+		this._controlHandlers['progresssbar'] = this._progressbarControl;
 		this._controlHandlers['checkbox'] = this._checkboxControl;
 		this._controlHandlers['basespinfield'] = this.baseSpinField;
 		this._controlHandlers['spinfield'] = this._spinfieldControl;
@@ -1485,6 +1486,35 @@ L.Control.JSDialogBuilder = L.Control.extend({
 
 		if (data.hidden)
 			$(radiobutton).hide();
+
+		return false;
+	},
+
+	_progressbarControl: function(parentContainer, data, builder) {
+		var div = L.DomUtil.createWithId('div', data.id, parentContainer);
+		L.DomUtil.addClass(div, 'cool-progressbar');
+		L.DomUtil.addClass(div, builder.options.cssClass);
+
+		var progressbar = L.DomUtil.create('progress', builder.options.cssClass, div);
+		progressbar.id = data.id + '-progress';
+		progressbar.tabIndex = '0';
+
+		if (data.value !== undefined)
+			progressbar.value = data.value;
+		else
+			progressbar.value = 0;
+
+		if (data.maxValue !== undefined)
+			progressbar.max = data.maxValue;
+		else
+			progressbar.max = 100;
+
+		if (data.enabled === 'false' || data.enabled === false) {
+			$(progressbar).prop('disabled', true);
+		}
+
+		if (data.hidden)
+			$(progressbar).hide();
 
 		return false;
 	},

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -1132,7 +1132,7 @@ L.Control.UIManager = L.Control.extend({
 	},
 
 	/// shows modal dialog with progress
-	showProgressBarDialog: function(id, title, message, buttonText, callback, value, maxValue) {
+	showProgressBarDialog: function(id, title, message, buttonText, callback, value) {
 		var dialogId = this.generateModalId(id);
 		var responseButtonId = dialogId + '-response';
 
@@ -1152,7 +1152,7 @@ L.Control.UIManager = L.Control.extend({
 				id: dialogId + '-progressbar',
 				type: 'progressbar',
 				value: (value !== undefined && value !== null ? value: 0),
-				maxValue: (maxValue !== undefined && maxValue !== null ? maxValue: 100)
+				maxValue: 100
 			},
 			{
 				id: '',
@@ -1181,6 +1181,29 @@ L.Control.UIManager = L.Control.extend({
 				that.closeModal(dialogId);
 			}}
 		]);
+	},
+
+	/// sets progressbar status, value should be in range 0-100
+	setDialogProgress: function(id, value) {
+		if (!app.socket)
+			return;
+
+		var dialogId = this.generateModalId(id);
+
+		var json = {
+			id: id,
+			jsontype: 'dialog',
+			type: 'modalpopup',
+			action: 'update',
+			control: {
+				id: dialogId + '-progressbar',
+				type: 'progressbar',
+				value: value,
+				maxValue: 100
+			}
+		};
+
+		app.socket._onMessage({textMsg: 'jsdialog: ' + JSON.stringify(json)});
 	},
 
 	/// buttonObjectList: [{id: button's id, text: button's text, ..other properties if needed}, ...]

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -938,7 +938,7 @@ L.Control.UIManager = L.Control.extend({
 			'init_focus_id': action ? buttonId : undefined,
 			children: [
 				{
-					id: 'snackbar-container',
+					id: hasProgress ? 'snackbar-container-progress' : 'snackbar-container',
 					type: 'container',
 					children: [
 						action ? {id: labelId, type: 'fixedtext', text: label, labelFor: buttonId} : {id: 'label-no-action', type: 'fixedtext', text: label},

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -1121,9 +1121,11 @@ L.Control.UIManager = L.Control.extend({
 		var that = this;
 		this.showModal(json, [
 			{id: responseButtonId, func: function() {
+				var dontClose = false;
 				if (typeof callback === 'function')
-					callback();
-				that.closeModal(dialogId);
+					dontClose = callback();
+				if (!dontClose)
+					that.closeModal(dialogId);
 			}}
 		], cancelButtonId);
 		if (!buttonText && !withCancel) {
@@ -1138,17 +1140,17 @@ L.Control.UIManager = L.Control.extend({
 	/// shows modal dialog with progress
 	showProgressBarDialog: function(id, title, message, buttonText, callback, value) {
 		var dialogId = this.generateModalId(id);
-		var responseButtonId = dialogId + '-response';
+		var responseButtonId = id + '-response';
 
 		var json = this._modalDialogJSON(id, title, true, [
 			{
-				id: dialogId + '-title',
+				id: 'info-modal-tile-m',
 				type: 'fixedtext',
 				text: title,
 				hidden: !window.mode.isMobile()
 			},
 			{
-				id: dialogId + '-label',
+				id: 'info-modal-label1',
 				type: 'fixedtext',
 				text: message
 			},
@@ -1180,9 +1182,11 @@ L.Control.UIManager = L.Control.extend({
 		var that = this;
 		this.showModal(json, [
 			{id: responseButtonId, func: function() {
+				var dontClose = false;
 				if (typeof callback === 'function')
-					callback();
-				that.closeModal(dialogId);
+					dontClose = callback();
+				if (!dontClose)
+					that.closeModal(dialogId);
 			}}
 		]);
 	},

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -965,8 +965,8 @@ L.Control.UIManager = L.Control.extend({
 	},
 
 	/// shows snackbar with progress
-	showProgressBar: function(message, buttonText, callback) {
-		this.showSnackbar(message, buttonText, callback, -1, true);
+	showProgressBar: function(message, buttonText, callback, timeout) {
+		this.showSnackbar(message, buttonText, callback, timeout ? timeout : -1, true);
 	},
 
 	/// sets progressbar status, value should be in range 0-100

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -928,19 +928,23 @@ L.Control.UIManager = L.Control.extend({
 
 		this.closeSnackbar();
 
+		var buttonId = 'button';
+		var labelId = 'label';
+
 		var json = {
 			id: 'snackbar',
 			jsontype: 'dialog',
 			type: 'snackbar',
 			timeout: timeout,
+			'init_focus_id': action ? buttonId : undefined,
 			children: [
 				{
 					id: 'snackbar-container',
 					type: 'container',
 					children: [
-						action ? {id: 'label', type: 'fixedtext', text: label} : {id: 'label-no-action', type: 'fixedtext', text: label},
+						action ? {id: labelId, type: 'fixedtext', text: label, labelFor: buttonId} : {id: 'label-no-action', type: 'fixedtext', text: label},
 						hasProgress ? {id: 'progress', type: 'progressbar', value: 0, maxValue: 100} : {},
-						action ? {id: 'button', type: 'pushbutton', text: action} : {}
+						action ? {id: buttonId, type: 'pushbutton', text: action, labelledBy: labelId} : {}
 					]
 				}
 			]
@@ -950,7 +954,7 @@ L.Control.UIManager = L.Control.extend({
 		var builderCallback = function(objectType, eventType, object, data) {
 			window.app.console.debug('control: \'' + objectType + '\' id:\'' + object.id + '\' event: \'' + eventType + '\' state: \'' + data + '\'');
 
-			if (object.id === 'button' && objectType === 'pushbutton' && eventType === 'click') {
+			if (object.id === buttonId && objectType === 'pushbutton' && eventType === 'click') {
 				if (callback)
 					callback();
 

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -1105,6 +1105,57 @@ L.Control.UIManager = L.Control.extend({
 		}
 	},
 
+	showProgressBar: function(id, title, message, buttonText, callback, value, maxValue) {
+		var dialogId = this.generateModalId(id);
+		var responseButtonId = dialogId + '-response';
+
+		var json = this._modalDialogJSON(id, title, true, [
+			{
+				id: dialogId + '-title',
+				type: 'fixedtext',
+				text: title,
+				hidden: !window.mode.isMobile()
+			},
+			{
+				id: dialogId + '-label',
+				type: 'fixedtext',
+				text: message
+			},
+			{
+				id: dialogId + '-progresssbar',
+				type: 'progresssbar',
+				value: (value !== undefined && value !== null ? value: 0),
+				maxValue: (maxValue !== undefined && maxValue !== null ? maxValue: 100)
+			},
+			{
+				id: '',
+				type: 'buttonbox',
+				text: '',
+				enabled: true,
+				children: [
+					{
+						id: responseButtonId,
+						type: 'pushbutton',
+						text: buttonText,
+						'has_default': true,
+						hidden: buttonText ? false: true // Hide if no text is given. So we can use one modal type for various purposes.
+					}
+				],
+				vertical: false,
+				layoutstyle: 'end'
+			},
+		], responseButtonId);
+
+		var that = this;
+		this.showModal(json, [
+			{id: responseButtonId, func: function() {
+				if (typeof callback === 'function')
+					callback();
+				that.closeModal(dialogId);
+			}}
+		]);
+	},
+
 	/// buttonObjectList: [{id: button's id, text: button's text, ..other properties if needed}, ...]
 	/// callbackList: [{id: button's id, func_: function}, ...]
 	showModalWithCustomButtons: function(id, title, message, cancellable, buttonObjectList, callbackList) {

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -917,18 +917,16 @@ L.Control.UIManager = L.Control.extend({
 
 	// Snack bar
 
+	closeSnackbar: function() {
+		var closeMessage = { id: 'snackbar', jsontype: 'dialog', type: 'snackbar', action: 'close' };
+		app.socket._onMessage({ textMsg: 'jsdialog: ' + JSON.stringify(closeMessage) });
+	},
+
 	showSnackbar: function(label, action, callback, timeout, hasProgress) {
 		if (!app.socket)
 			return;
 
-		var closeJson = {
-			id: 'snackbar',
-			jsontype: 'dialog',
-			type: 'snackbar',
-			action: 'fadeout'
-		};
-
-		app.socket._onMessage({textMsg: 'jsdialog: ' + JSON.stringify(closeJson)});
+		this.closeSnackbar();
 
 		var json = {
 			id: 'snackbar',
@@ -948,6 +946,7 @@ L.Control.UIManager = L.Control.extend({
 			]
 		};
 
+		var that = this;
 		var builderCallback = function(objectType, eventType, object, data) {
 			window.app.console.debug('control: \'' + objectType + '\' id:\'' + object.id + '\' event: \'' + eventType + '\' state: \'' + data + '\'');
 
@@ -955,8 +954,7 @@ L.Control.UIManager = L.Control.extend({
 				if (callback)
 					callback();
 
-				var closeMessage = { id: 'snackbar', jsontype: 'dialog', type: 'snackbar', action: 'close' };
-				app.socket._onMessage({ textMsg: 'jsdialog: ' + JSON.stringify(closeMessage) });
+				that.closeSnackbar();
 			}
 		};
 

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -1182,7 +1182,7 @@ L.Control.UIManager = L.Control.extend({
 				vertical: false,
 				layoutstyle: 'end'
 			},
-		], responseButtonId);
+		], buttonText ? responseButtonId : cancelButtonId);
 
 		var that = this;
 		this.showModal(json, [

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -917,7 +917,7 @@ L.Control.UIManager = L.Control.extend({
 
 	// Snack bar
 
-	showSnackbar: function(label, action, callback, timeout) {
+	showSnackbar: function(label, action, callback, timeout, hasProgress) {
 		if (!app.socket)
 			return;
 
@@ -940,6 +940,7 @@ L.Control.UIManager = L.Control.extend({
 					type: 'container',
 					children: [
 						action ? {id: 'label', type: 'fixedtext', text: label} : {id: 'label-no-action', type: 'fixedtext', text: label},
+						hasProgress ? {id: 'progress', type: 'progressbar', value: 0, maxValue: 100} : {},
 						action ? {id: 'button', type: 'pushbutton', text: action} : {}
 					]
 				}
@@ -959,6 +960,32 @@ L.Control.UIManager = L.Control.extend({
 		};
 
 		app.socket._onMessage({textMsg: 'jsdialog: ' + JSON.stringify(json), callback: builderCallback});
+	},
+
+	/// shows snackbar with progress
+	showProgressBar: function(message, buttonText, callback) {
+		this.showSnackbar(message, buttonText, callback, -1, true);
+	},
+
+	/// sets progressbar status, value should be in range 0-100
+	setSnackbarProgress: function(value) {
+		if (!app.socket)
+			return;
+
+		var json = {
+			id: 'snackbar',
+			jsontype: 'dialog',
+			type: 'snackbar',
+			action: 'update',
+			control: {
+				id: 'progress',
+				type: 'progressbar',
+				value: value,
+				maxValue: 100
+			}
+		};
+
+		app.socket._onMessage({textMsg: 'jsdialog: ' + JSON.stringify(json)});
 	},
 
 	// Modals
@@ -1105,7 +1132,8 @@ L.Control.UIManager = L.Control.extend({
 		}
 	},
 
-	showProgressBar: function(id, title, message, buttonText, callback, value, maxValue) {
+	/// shows modal dialog with progress
+	showProgressBarDialog: function(id, title, message, buttonText, callback, value, maxValue) {
 		var dialogId = this.generateModalId(id);
 		var responseButtonId = dialogId + '-response';
 
@@ -1122,8 +1150,8 @@ L.Control.UIManager = L.Control.extend({
 				text: message
 			},
 			{
-				id: dialogId + '-progresssbar',
-				type: 'progresssbar',
+				id: dialogId + '-progressbar',
+				type: 'progressbar',
 				value: (value !== undefined && value !== null ? value: 0),
 				maxValue: (maxValue !== undefined && maxValue !== null ? maxValue: 100)
 			},

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -937,6 +937,7 @@ L.Control.UIManager = L.Control.extend({
 			timeout: timeout,
 			children: [
 				{
+					id: 'snackbar-container',
 					type: 'container',
 					children: [
 						action ? {id: 'label', type: 'fixedtext', text: label} : {id: 'label-no-action', type: 'fixedtext', text: label},

--- a/browser/src/control/jsdialog/Util.ModalHelper.js
+++ b/browser/src/control/jsdialog/Util.ModalHelper.js
@@ -1,0 +1,64 @@
+/* -*- js-indent-level: 8 -*- */
+/*
+ * JSDialog.ModalHelper - helper functions for manipulating modals built using jsdialog
+ *
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+/* global JSDialog app */
+
+var modalIdPretext = 'modal-dialog-';
+
+/// Returns generated (or to be generated) id for the modal container.
+function generateModalId(givenId) {
+	return modalIdPretext + givenId;
+}
+
+function sendJSON(json) {
+	if (!app.socket)
+		return;
+
+	app.socket._onMessage({textMsg: 'jsdialog: ' + JSON.stringify(json)});
+}
+
+function setMessageInModal(id, msg1) {
+	var dialogId = generateModalId(id);
+
+	var json = {
+		id: dialogId,
+		jsontype: 'dialog',
+		type: 'modalpopup',
+		action: 'update',
+		control: {
+			id: 'info-modal-label1',
+			type: 'fixedtext',
+			text: msg1
+		}
+	};
+
+	sendJSON(json);
+}
+
+function enableButtonInModal(id, buttonId, enable) {
+	var dialogId = generateModalId(id);
+
+	var json = {
+		id: dialogId,
+		jsontype: 'dialog',
+		type: 'modalpopup',
+		action: 'action',
+		data: {
+			'control_id': buttonId,
+			'action_type': (enable ? 'enable' : 'disable')
+		}
+	};
+
+	sendJSON(json);
+}
+
+JSDialog.generateModalId = generateModalId;
+JSDialog.sendJSON = sendJSON;
+JSDialog.setMessageInModal = setMessageInModal;
+JSDialog.enableButtonInModal = enableButtonInModal;

--- a/browser/src/control/jsdialog/Widget.Progressbar.js
+++ b/browser/src/control/jsdialog/Widget.Progressbar.js
@@ -1,0 +1,47 @@
+/* -*- js-indent-level: 8 -*- */
+/*
+ * JSDialog.Progressbar - progress bar widget
+ *
+ * Example JSON:
+ * {
+ *     id: 'id',
+ *     type: 'progressbar',
+ *     value: 30,
+ *     maxValue: 100
+ * }
+ *
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+/* global JSDialog $ */
+
+JSDialog.progressbar = function (parentContainer, data, builder) {
+	var div = L.DomUtil.createWithId('div', data.id, parentContainer);
+	L.DomUtil.addClass(div, 'ui-progressbar');
+	L.DomUtil.addClass(div, builder.options.cssClass);
+
+	var progressbar = L.DomUtil.create('progress', builder.options.cssClass, div);
+	progressbar.id = data.id + '-progress';
+	progressbar.tabIndex = '0';
+
+	if (data.value !== undefined)
+		progressbar.value = data.value;
+	else
+		progressbar.value = 0;
+
+	if (data.maxValue !== undefined)
+		progressbar.max = data.maxValue;
+	else
+		progressbar.max = 100;
+
+	if (data.enabled === 'false' || data.enabled === false) {
+		$(progressbar).prop('disabled', true);
+	}
+
+	if (data.hidden)
+		$(progressbar).hide();
+
+	return false;
+};

--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -208,7 +208,7 @@ L.Clipboard = L.Class.extend({
 
 			// avoid to invoke the following code if the download widget depends on user interaction
 			if (!that._downloadProgress || that._downloadProgress.isClosed()) {
-				that._startProgress();
+				that._startProgress(false);
 				that._downloadProgress.startProgressMode();
 			}
 			request.onload = function() {
@@ -801,12 +801,12 @@ L.Clipboard = L.Class.extend({
 		this._scheduleHideDownload();
 	},
 
-	_startProgress: function() {
+	_startProgress: function(isLargeCopy) {
 		if (!this._downloadProgress) {
 			this._downloadProgress = L.control.downloadProgress();
 			this._map.addControl(this._downloadProgress);
 		}
-		this._downloadProgress.show();
+		this._downloadProgress.show(isLargeCopy);
 	},
 
 	_onDownloadOnLargeCopyPaste: function () {
@@ -815,7 +815,7 @@ L.Clipboard = L.Class.extend({
 			// Otherwise, it's easier to flash the widget or something.
 			this._warnLargeCopyPasteAlreadyStarted();
 		} else {
-			this._startProgress();
+			this._startProgress(true);
 		}
 	},
 

--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -520,7 +520,9 @@ L.Clipboard = L.Class.extend({
 		if ($('.w2ui-input').is(':focus'))
 			return true;
 
-		if (this._map.uiManager.isAnyDialogOpen() && !this.isPasteSpecialDialogOpen())
+		if (this._map.uiManager.isAnyDialogOpen()
+			&& !this.isCopyPasteDialogReadyForCopy()
+			&& !this.isPasteSpecialDialogOpen())
 			return true;
 
 		if ($('.annotation-active').length && $('.cool-annotation-edit').is(':visible'))
@@ -883,6 +885,10 @@ L.Clipboard = L.Class.extend({
 			var result = document.getElementById(this.pasteSpecialDialogId);
 			return result !== undefined && result !== null ? true: false;
 		}
+	},
+
+	isCopyPasteDialogReadyForCopy: function () {
+		return this._downloadProgress && this._downloadProgress.isComplete();
 	},
 
 	_openPasteSpecialPopup: function () {

--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -812,9 +812,7 @@ L.Clipboard = L.Class.extend({
 			// Need to show this only when a download is really in progress and we block it.
 			// Otherwise, it's easier to flash the widget or something.
 			this._warnLargeCopyPasteAlreadyStarted();
-		}
-		else {
-			this._warnFirstLargeCopyPaste();
+		} else {
 			this._startProgress();
 		}
 	},
@@ -850,18 +848,6 @@ L.Clipboard = L.Class.extend({
 		this._downloadProgress._onClose();
 	},
 
-	_userAlreadyWarned: function (warning) {
-		var itemKey = warning;
-		var storage = localStorage;
-		if (storage && !storage.getItem(itemKey)) {
-			storage.setItem(itemKey, '1');
-			return false;
-		} else if (!storage)
-			return false;
-
-		return true;
-	},
-
 	_warnCopyPaste: function() {
 		var msg;
 		if (window.mode.isMobile() || window.mode.isTablet()) {
@@ -882,33 +868,6 @@ L.Clipboard = L.Class.extend({
 	_substProductName: function (msg) {
 		var productName = (typeof brandProductName !== 'undefined') ? brandProductName : 'Collabora Online Development Edition (unbranded)';
 		return msg.replace('%productName', productName);
-	},
-
-	_warnFirstLargeCopyPaste: function () {
-		if (this._userAlreadyWarned('warnedAboutLargeCopy'))
-			return;
-
-		var modalId = 'large_copy_paste_warning';
-
-		var buttonCallback = function() {
-			if (this._downloadProgress) {
-				this._downloadProgress._onStartDownload();
-			}
-		};
-
-		var msg = _('If you want to share large elements with other applications (outside of Collabora Online) it\'s necessary to first download them.');
-		this._map.uiManager.showInfoModal(modalId, _('Download Selection'), msg, '', 'Download (Alt + C)', buttonCallback.bind(this), true, modalId + '-response');
-
-		var keyDownCallback = function(e) {
-			if (e.altKey && e.keyCode === 67 /*C*/) {
-				if (this._downloadProgress) {
-					document.getElementById(modalId + '-response').click();
-					e.preventDefault();
-				}
-			}
-		};
-		var dialogId = this._map.uiManager.generateModalId(modalId);
-		document.getElementById(dialogId).onkeydown = keyDownCallback.bind(this);
 	},
 
 	_warnLargeCopyPasteAlreadyStarted: function () {

--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -773,7 +773,7 @@ L.Clipboard = L.Class.extend({
 	clearSelection: function() {
 		this._selectionContent = '';
 		this._selectionType = null;
-		this._scheduleHideDownload(15);
+		this._scheduleHideDownload();
 	},
 
 	// textselectioncontent: message
@@ -783,7 +783,7 @@ L.Clipboard = L.Class.extend({
 		if (L.Browser.cypressTest) {
 			this._dummyDiv.innerHTML = html;
 		}
-		this._scheduleHideDownload(15);
+		this._scheduleHideDownload();
 	},
 
 	// sets the selection to some (cell formula) text)
@@ -791,14 +791,14 @@ L.Clipboard = L.Class.extend({
 		this._selectionType = 'text';
 		this._selectionContent = this._originWrapBody(
 			'<body>' + text + '</body>');
-		this._scheduleHideDownload(15);
+		this._scheduleHideDownload();
 	},
 
 	// complexselection: message
 	onComplexSelection: function (/*text*/) {
 		// Mark this selection as complex.
 		this._selectionType = 'complex';
-		this._scheduleHideDownload(15);
+		this._scheduleHideDownload();
 	},
 
 	_startProgress: function() {
@@ -825,26 +825,16 @@ L.Clipboard = L.Class.extend({
 	},
 
 	// Download button is still shown after selection changed -> user has changed their mind...
-	_scheduleHideDownload: function(s) {
+	_scheduleHideDownload: function() {
 		if (!this._downloadProgress || this._downloadProgress.isClosed())
 			return;
 
-		// If no other copy/paste things occurred then ...
-		var that = this;
-		var serial = this._clipboardSerial;
-		if (!this._hideDownloadTimer)
-			this._hideDownloadTimer = setTimeout(function() {
-				that._hideDownloadTimer = null;
-				if (serial == that._clipboardSerial && that._downloadProgressStatus() === 'downloadButton')
-					that._stopHideDownload();
-			}, 1000 * s);
+		if (this._downloadProgressStatus() === 'downloadButton')
+			this._stopHideDownload();
 	},
 
 	// useful if we did an internal paste already and don't want that.
 	_stopHideDownload: function() {
-		clearTimeout(this._hideDownloadTimer);
-		this._hideDownloadTimer = null;
-
 		if (!this._downloadProgress || this._downloadProgress.isClosed())
 			return;
 		this._downloadProgress._onClose();

--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -207,7 +207,7 @@ L.Clipboard = L.Class.extend({
 			var request = new XMLHttpRequest();
 
 			// avoid to invoke the following code if the download widget depends on user interaction
-			if (!that._downloadProgress || !that._downloadProgress.isVisible()) {
+			if (!that._downloadProgress || that._downloadProgress.isClosed()) {
 				that._startProgress();
 				that._downloadProgress.startProgressMode();
 			}
@@ -802,33 +802,31 @@ L.Clipboard = L.Class.extend({
 	_startProgress: function() {
 		if (!this._downloadProgress) {
 			this._downloadProgress = L.control.downloadProgress();
-		}
-		if (!this._downloadProgress.isVisible()) {
-			this._downloadProgress.addTo(this._map);
+			this._map.addControl(this._downloadProgress);
 		}
 		this._downloadProgress.show();
 	},
 
 	_onDownloadOnLargeCopyPaste: function () {
-		if (!this._downloadProgress || this._downloadProgress.isClosed()) {
-			this._warnFirstLargeCopyPaste();
-			this._startProgress();
-		}
-		else if (this._downloadProgress.isStarted()) {
+		if (this._downloadProgress && this._downloadProgress.isStarted()) {
 			// Need to show this only when a download is really in progress and we block it.
 			// Otherwise, it's easier to flash the widget or something.
 			this._warnLargeCopyPasteAlreadyStarted();
 		}
+		else {
+			this._warnFirstLargeCopyPaste();
+			this._startProgress();
+		}
 	},
 
 	_downloadProgressStatus: function() {
-		if (this._downloadProgress && this._downloadProgress.isVisible())
+		if (this._downloadProgress)
 			return this._downloadProgress.currentStatus();
 	},
 
 	// Download button is still shown after selection changed -> user has changed their mind...
 	_scheduleHideDownload: function(s) {
-		if (!this._downloadProgress || !this._downloadProgress.isVisible())
+		if (!this._downloadProgress || this._downloadProgress.isClosed())
 			return;
 
 		// If no other copy/paste things occurred then ...
@@ -847,9 +845,7 @@ L.Clipboard = L.Class.extend({
 		clearTimeout(this._hideDownloadTimer);
 		this._hideDownloadTimer = null;
 
-		if (!this._downloadProgress ||
-		    !this._downloadProgress.isVisible() ||
-		    this._downloadProgress.isClosed())
+		if (!this._downloadProgress || this._downloadProgress.isClosed())
 			return;
 		this._downloadProgress._onClose();
 	},

--- a/browser/src/map/handler/Map.Keyboard.js
+++ b/browser/src/map/handler/Map.Keyboard.js
@@ -358,7 +358,8 @@ L.Map.Keyboard = L.Handler.extend({
 		if (this._map.uiManager.isUIBlocked())
 			return;
 
-		if (this._map.jsdialog && this._map.jsdialog.hasDialogOpened()
+		if (this._map.jsdialog
+			&& (this._map.jsdialog.hasDialogOpened() || this._map.jsdialog.hasSnackbarOpened())
 			&& this._map.jsdialog.handleKeyEvent(ev)) {
 			ev.preventDefault();
 			return;


### PR DESCRIPTION
Improvements in copy-paste:
- all dialogs/popups converted to jsdialogs
- when user does complex copy first time - dialogs explaining the process are present
- when user does complex copy after on fully successful process - snackbar is used for messages
- to quickly copy, download, confirm copy to clipboard - shortcut 3x CTRL + C can be used
- when snackbar with download button appears but user changes selection -> we hide snackbar