### PR TITLE
wsd: comments can be added to PDF files which otherwise are readonly

### DIFF
--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -810,7 +810,8 @@ bool ClientSession::_handleInput(const char *buffer, int length)
             }
             else
             {
-                docBroker->updateLastModifyingActivityTime();
+                if (isEditable())
+                    docBroker->updateLastModifyingActivityTime();
                 return forwardToChild(std::string(buffer, length), docBroker);
             }
         }
@@ -1072,7 +1073,7 @@ bool ClientSession::_handleInput(const char *buffer, int length)
         if (tokens.equals(0, "key"))
             _keyEvents++;
 
-        if (COOLProtocol::tokenIndicatesDocumentModification(tokens))
+        if (isEditable() && COOLProtocol::tokenIndicatesDocumentModification(tokens))
         {
             docBroker->updateLastModifyingActivityTime();
         }


### PR DESCRIPTION
This fixes a regression where PDF comments were lost when
the document closed immediately after adding a comment.

Change-Id: Iac78ec13fdbaa7d1ffe25067ea0f41704abb3312
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
