### PR TITLE
Misc Improvements

### DIFF
--- a/common/FileUtil.cpp
+++ b/common/FileUtil.cpp
@@ -424,6 +424,37 @@ namespace FileUtil
                           std::istreambuf_iterator<char>(lhs.rdbuf()));
     }
 
+    std::unique_ptr<std::vector<char>> readFile(const std::string& path, int maxSize)
+    {
+        const int fd = ::open(path.c_str(), O_RDONLY);
+        struct stat st;
+        if (fd < 0 || ::fstat(fd, &st) != 0 || st.st_size > maxSize)
+            return nullptr;
+
+        auto data = std::make_unique<std::vector<char>>(st.st_size);
+        off_t off = 0;
+        for (;;)
+        {
+            int n;
+            while ((n = ::read(fd, &(*data)[off], st.st_size)) < 0 && errno == EINTR)
+            {
+            }
+
+            if (n <= 0)
+            {
+                if (n == 0) // EOF.
+                    break;
+
+                return nullptr; // Error.
+            }
+
+            off += n;
+        }
+
+        close(fd);
+        return data;
+    }
+
 } // namespace FileUtil
 
 namespace

--- a/common/FileUtil.hpp
+++ b/common/FileUtil.hpp
@@ -150,6 +150,9 @@ namespace FileUtil
     /// have equal size and every byte of their contents match.
     bool compareFileContents(const std::string& rhsPath, const std::string& lhsPath);
 
+    /// Reads the whole file to memory. Only for small files.
+    std::unique_ptr<std::vector<char>> readFile(const std::string& path, int maxSize = 256 * 1024);
+
     /// File/Directory stat helper.
     class Stat
     {

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -987,7 +987,7 @@ public:
         {
             LOG_DBG("Trimming Core caches");
             SigUtil::addActivity("trimAfterInactivity");
-            _loKit->trimMemory(4096);
+            _loKit->trimMemory(1024);
 
             _lastMemTrimTime = std::chrono::steady_clock::now();
         }

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -1475,7 +1475,8 @@ private:
         _socket.reset(); // Reset to make sure we are disconnected.
         std::shared_ptr<StreamSocket> socket =
             net::connect(_host, _port, isSecure(), shared_from_this());
-        assert(_fd == socket->getFD() && "The socket FD must have been set in onConnect");
+        assert((!socket || _fd == socket->getFD()) &&
+               "The socket FD must have been set in onConnect");
 
         // When used with proxy.php we may indeed get nullptr here.
         // assert(socket && "Unexpected nullptr returned from net::connect");

--- a/test/helpers.hpp
+++ b/test/helpers.hpp
@@ -499,7 +499,7 @@ connectLOKit(const std::shared_ptr<SocketPoll>& socketPoll, const Poco::URI& uri
             http::Request req(url);
             ws->asyncRequest(req, socketPoll);
 
-            const char* expected_response = "statusindicator: ready";
+            const char* expected_response = "statusindicator: find";
 
             TST_LOG("Connected to " << uri.toString() << ", waiting for response ["
                                     << expected_response << "]");

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -6173,7 +6173,6 @@ int COOLWSD::innerMain()
 
     const int returnValue = UnitBase::uninit();
 
-    UnitBase::uninit();
     LOG_INF("Process [coolwsd] finished with exit status: " << returnValue);
 
     // At least on centos7, Poco deadlocks while

--- a/wsd/COOLWSD.hpp
+++ b/wsd/COOLWSD.hpp
@@ -35,6 +35,7 @@ class ChildProcess;
 class TraceFileWriter;
 class DocumentBroker;
 class ClipboardCache;
+class FileServerRequestHandler;
 
 std::shared_ptr<ChildProcess> getNewChild_Blocks(unsigned mobileAppDocId);
 
@@ -287,6 +288,9 @@ public:
     static std::unique_ptr<TraceFileWriter> TraceDumper;
 #if !MOBILEAPP
     static std::unique_ptr<ClipboardCache> SavedClipboards;
+
+    /// The file request handler used for file-serving.
+    static std::unique_ptr<FileServerRequestHandler> FileRequestHandler;
 #endif
 
     static std::unordered_set<std::string> EditFileExtensions;

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -2393,8 +2393,10 @@ void DocumentBroker::autoSaveAndStop(const std::string& reason)
         // very late, or not at all. We care that there is nothing to upload
         // and the last save succeeded, possibly because there was no
         // modifications, and there has been no activity since.
-        if (!haveModifyActivityAfterSaveRequest() && !_saveManager.isSaving() &&
-            _saveManager.lastSaveSuccessful())
+        LOG_ASSERT_MSG(_saveManager.lastSaveRequestTime() < _saveManager.lastSaveResponseTime(),
+                       "Unexpected active save in flight");
+        LOG_ASSERT_MSG(!_saveManager.isSaving(), "Unexpected active save in flight");
+        if (!haveModifyActivityAfterSaveRequest() && _saveManager.lastSaveSuccessful())
         {
             // We can stop, but the modified flag is set. Delayed ModifiedStatus?
             if (isModified())
@@ -2415,9 +2417,10 @@ void DocumentBroker::autoSaveAndStop(const std::string& reason)
             LOG_TRC("autoSaveAndStop for docKey ["
                     << getDocKey() << "]: no modifications since last successful save. Stopping.");
         }
-        else if (!isPossiblyModified())
+        else if (needToSave == NeedToSave::No)
         {
             // Nothing to upload and no modifications; stop.
+            LOG_ASSERT_MSG(!isPossiblyModified(), "Unexpected isPossiblyModified with NeedToSave::No");
             canStop = true;
             LOG_TRC("autoSaveAndStop for docKey [" << getDocKey() << "]: not modified. Stopping.");
         }

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -783,12 +783,10 @@ void FileServerRequestHandler::readDirToHash(const std::string &basePath, const 
 
                 deflate(&strm, Z_FINISH);
 
-                const long unsigned int haveComp = compSize - strm.avail_out;
-                std::string partialcompFile(cbuf, haveComp);
-                std::string partialuncompFile(buf.get(), size);
-                compressedFile += partialcompFile;
-                uncompressedFile += partialuncompFile;
+                compressedFile.append(cbuf, compSize - strm.avail_out);
                 free(cbuf);
+
+                uncompressedFile.append(buf.get(), size);
 
             } while(true);
 

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -840,7 +840,7 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
                                               Poco::MemoryInputStream& message,
                                               const std::shared_ptr<StreamSocket>& socket)
 {
-    ServerURL cnxDetails(requestDetails);
+    const ServerURL cnxDetails(requestDetails);
 
     const Poco::URI::QueryParameters params = Poco::URI(request.getURI()).getQueryParameters();
 
@@ -909,7 +909,7 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
         socketProxy = "true";
     Poco::replaceInPlace(preprocess, std::string("%SOCKET_PROXY%"), socketProxy);
 
-    std::string responseRoot = cnxDetails.getResponseRoot();
+    const std::string responseRoot = cnxDetails.getResponseRoot();
     std::string userInterfaceMode;
     std::string userInterfaceTheme;
 
@@ -1251,8 +1251,8 @@ void FileServerRequestHandler::preprocessAdminFile(const HTTPRequest& request,
     if (!FileServerRequestHandler::isAdminLoggedIn(request, response))
         throw Poco::Net::NotAuthenticatedException("Invalid admin login");
 
-    ServerURL cnxDetails(requestDetails);
-    std::string responseRoot = cnxDetails.getResponseRoot();
+    const ServerURL cnxDetails(requestDetails);
+    const std::string responseRoot = cnxDetails.getResponseRoot();
 
     static const std::string scriptJS("<script src=\"%s/browser/" COOLWSD_VERSION_HASH "/%s.js\"></script>");
     static const std::string footerPage("<footer class=\"footer has-text-centered\"><strong>Key:</strong> %s &nbsp;&nbsp;<strong>Expiry Date:</strong> %s</footer>");

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -199,6 +199,26 @@ bool isConfigAuthOk(const std::string& userProvidedUsr, const std::string& userP
 
 }
 
+FileServerRequestHandler::FileServerRequestHandler(const std::string& root)
+{
+    // Read all files that we can serve into memory and compress them.
+    // cool files
+    try
+    {
+        readDirToHash(root, "/browser/dist");
+    }
+    catch (...)
+    {
+        LOG_ERR("Failed to read from directory " << root);
+    }
+}
+
+FileServerRequestHandler::~FileServerRequestHandler()
+{
+    // Clean cached files.
+    FileHash.clear();
+}
+
 bool FileServerRequestHandler::isAdminLoggedIn(const HTTPRequest& request,
                                                HTTPResponse &response)
 {
@@ -780,16 +800,6 @@ void FileServerRequestHandler::readDirToHash(const std::string &basePath, const 
 
     if (fileCount > 0)
         LOG_TRC("Pre-read " << fileCount << " file(s) from directory: " << basePath << path << ": " << filesRead);
-}
-
-void FileServerRequestHandler::initialize(const std::string& root)
-{
-    // cool files
-    try {
-        readDirToHash(root, "/browser/dist");
-    } catch (...) {
-        LOG_ERR("Failed to read from directory " << root);
-    }
 }
 
 const std::string *FileServerRequestHandler::getCompressedFile(const std::string &path)

--- a/wsd/FileServer.hpp
+++ b/wsd/FileServer.hpp
@@ -48,6 +48,9 @@ class FileServerRequestHandler
                                                bool defaultValue);
 
 public:
+    FileServerRequestHandler(const std::string& root);
+    ~FileServerRequestHandler();
+
     /// Evaluate if the cookie exists, and if not, ask for the credentials.
     static bool isAdminLoggedIn(const Poco::Net::HTTPRequest& request, Poco::Net::HTTPResponse& response);
 
@@ -55,12 +58,6 @@ public:
                               const RequestDetails &requestDetails,
                               Poco::MemoryInputStream& message,
                               const std::shared_ptr<StreamSocket>& socket);
-
-    /// Read all files that we can serve into memory and compress them.
-    static void initialize(const std::string& root);
-
-    /// Clean cached files.
-    static void uninitialize() { FileHash.clear(); }
 
     static void readDirToHash(const std::string &basePath, const std::string &path, const std::string &prefix = std::string());
 


### PR DESCRIPTION
- wsd: FileServerRequestHandler instance
- wsd: utility to read small files in memory
- wsd: const correctness
- killpoco: serve the Welcome file using http::Response
- wsd: simpler string appending in readDirToHash
- wsd: test: wait for 'statusindicator: find' instead of 'ready'
- wsd: add LOG_ASSERT to replace assert with extra logging
- wsd: improved assertion
- wsd: test: remove duplicate uninit
- wsd: use a smaller value when trimming after inactivity
