### PR TITLE
Mobile: buttons with text color discrepancies

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -502,7 +502,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 	},
 
 	_stressAccessKey: function(element, accessKey) {
-		if (!accessKey)
+		if (!accessKey || window.mode.isMobile())
 			return;
 
 		var text = element.textContent;


### PR DESCRIPTION
Will not create `<u>` element for mobile wizard
Signed-off-by: Darshan-upadhyay1110 <darshan.upadhyay@collabora.com>

Change-Id: Iaca88ac4be2c95dc4781180019ba8fede9cdc81a


* Resolves: #7141 
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

