### PR TITLE
fix: close userListSummary popover on click

### DIFF
--- a/browser/src/control/Control.UserList.js
+++ b/browser/src/control/Control.UserList.js
@@ -136,7 +136,12 @@ L.Control.UserList = L.Control.extend({
 		document.getElementById('userListSummary').addEventListener('click', function(e) {
 			e.stopPropagation();
 			$('.main-nav.hasnotebookbar').css('overflow', 'visible');
-			$('#userListPopover').show();
+			var selector = '#userListPopover';	
+			if ($(selector).is(':hidden')) {
+				$(selector).show();
+			} else {	
+				outsideClickListener(e);
+			}
 			document.addEventListener('click', outsideClickListener);
 		});
 	},


### PR DESCRIPTION
Change-Id: Idc467c33e690c6e13023ad022b7cf57380d32ff3


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
This pull request addresses the issue where the userListSummary popover remains open when it should close upon clicking on user list icons. The implementation ensures that the popover is closed when a user clicks on user list icons of the popover, providing a more intuitive and user-friendly experience.

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

