### PR TITLE
postmessage: fix get export formats

### DIFF
--- a/browser/html/framed.doc.html
+++ b/browser/html/framed.doc.html
@@ -90,6 +90,12 @@
             });
       }
 
+      function getExportFormats() {
+        post({'MessageId': 'Get_Export_Formats',
+              'Values': null
+            });
+      }
+
       function hide_commands(id) {
         post({'MessageId': 'Hide_Menu_Item',
               'Values': { 'id': id, }
@@ -265,6 +271,12 @@
                 });
             }
           }
+        } else if (msg.MessageId == 'Get_Export_Formats_Resp') {
+          if (msg.Values) {
+            alert(JSON.stringify(msg.Values));
+          } else {
+            alert('Response is empty');
+          }
         }
       }
 
@@ -311,6 +323,7 @@
       <button onclick="save(); return false;">Save</button>
       <button onclick="closeDocument(); return false;">Close</button></br></br>
       <button onclick="exportAsHtml(); return false;">Export as HTML</button></br></br>
+      <button onclick="getExportFormats(); return false;">Get export formats</button>
       <button onclick="hide_commands('save'); return false;">Hide Save Commands</button>
       <button onclick="show_commands('save'); return false;">Show Save Commands</button></br>
       <button onclick="hide_commands('print'); return false;">Hide Print Commands</button>

--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -90,8 +90,10 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 	},
 
 	getFileTab: function() {
-		var content = [
-			!this._map['wopi'].HideSaveOption ? {
+		var content = [];
+
+		if (!this._map['wopi'].HideSaveOption) {
+			content.push({
 				'type': 'toolbox',
 				'children': [
 					{
@@ -102,8 +104,11 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 						'accessibility': { focusBack: true,	combination: 'S', de: null }
 					}
 				]
-			}: {},
-			!this._map['wopi'].UserCanNotWriteRelative ? (
+			});
+		}
+
+		if (!this._map['wopi'].UserCanNotWriteRelative) {
+			content.push(
 				(window.uiDefaults && window.uiDefaults.saveAsMode === 'group') ? {
 					'id': 'saveas',
 					'type': 'bigmenubartoolitem',
@@ -117,14 +122,20 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 					'command': '.uno:SaveAs',
 					'accessibility': { focusBack: true,	combination: 'A', de: null }
 				}
-			): {},
-			!this._map['wopi'].UserCanNotWriteRelative ? {
+			);
+		}
+
+		if (!this._map['wopi'].UserCanNotWriteRelative) {
+			content.push({
 				'id': 'exportas',
 				'class': 'unoexportas',
 				'type': 'bigmenubartoolitem',
 				'text': _('Export As'),
 				'accessibility': { focusBack: true,	combination: 'E', de: null }
-			}: {},
+			});
+		}
+
+		content.push(
 			{
 				'id': 'file-shareas-rev-history',
 				'type': 'container',
@@ -151,17 +162,21 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 						} : {},
 				],
 				'vertical': 'true'
-			},
-			!this._map['wopi'].HidePrintOption ?
-			{
+			}
+		);
+
+		if (!this._map['wopi'].HidePrintOption) {
+			content.push({
 				'id': 'Data-Print:Print',
 				'type': 'menubutton',
 				'text': _UNO('.uno:Print', 'spreadsheet'),
 				'command': '.uno:Print',
 				'accessibility': { focusBack: true,	combination: 'PT', de: null }
-			} : {},
-			(!(window.enableMacrosExecution  === 'false')) ?
-			{
+			});
+		}
+
+		if (!(window.enableMacrosExecution  === 'false')) {
+			content.push({
 				'type': 'toolbox',
 				'children': [
 					{
@@ -172,14 +187,19 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 						'accessibility': { focusBack: true,	combination: 'M', de: null }
 					}
 				]
-			} : {},
-			!!window.groupDownloadAsForNb && !this._map['wopi'].HideExportOption ? {
+			});
+		}
+
+		if (!!window.groupDownloadAsForNb && !this._map['wopi'].HideExportOption) {
+			content.push({
 				'id': 'downloadas',
 				'class': 'unodownloadas',
 				'type': 'bigmenubartoolitem',
 				'text': _('Download'),
 				'accessibility': { focusBack: true,	combination: 'DA', de: null }
-			}: (!this._map['wopi'].HideExportOption ? (
+			});
+		} else if (!this._map['wopi'].HideExportOption) {
+			content.push(
 				{
 					'id': 'file-downloadas-ods-downloadas-csv',
 					'type': 'container',
@@ -244,9 +264,12 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 						},
 					],
 					'vertical': 'true'
-				}): {}
-			),
-			!this._map['wopi'].HideRepairOption ? {
+				}
+			);
+		}
+
+		if (!this._map['wopi'].HideRepairOption) {
+			content.push({
 				'type': 'container',
 				'children': [
 					{
@@ -259,7 +282,10 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 					}
 				],
 				'vertical': 'true'
-			}: {},
+			});
+		}
+
+		content.push(
 			{
 				'type': 'container',
 				'children': [
@@ -283,7 +309,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 					}
 				]
 			}
-		];
+		);
 
 		return this.getTabPage('File', content);
 	},

--- a/browser/src/control/Control.NotebookbarDraw.js
+++ b/browser/src/control/Control.NotebookbarDraw.js
@@ -130,8 +130,10 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 	},
 
 	getFileTab: function() {
-		var content = [
-			(!this._map['wopi'].HideSaveOption) ?
+		var content = [];
+
+		if (!this._map['wopi'].HideSaveOption) {
+			content.push(
 				{
 					'type': 'toolbox',
 					'children': [
@@ -143,23 +145,34 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 							'accessibility': { focusBack: true, combination: 'SF', de: null }
 						}
 					]
-				} : {},
-			(!this._map['wopi'].UserCanNotWriteRelative) ?
+				});
+			}
+
+		if (!this._map['wopi'].UserCanNotWriteRelative) {
+			content.push(
 				{
 					'id': 'file-saveas',
 					'type': 'bigtoolitem',
 					'text': _UNO('.uno:SaveAs', 'presentation'),
 					'command': '.uno:SaveAs',
 					'accessibility': { focusBack: true, combination: 'SA', de: null }
-				} : {},
-			(!this._map['wopi'].UserCanNotWriteRelative) ?
+				}
+			);
+		}
+
+		if (!this._map['wopi'].UserCanNotWriteRelative) {
+			content.push(
 				{
 					'id': 'exportas',
 					'class': 'unoexportas',
 					'type': 'bigmenubartoolitem',
 					'text': _('Export As'),
 					'accessibility': { focusBack: true, combination: 'EA', de: null }
-				} : {},
+				}
+			);
+		}
+
+		content.push(
 			{
 				'id': 'file-shareas-rev-history',
 				'type': 'container',
@@ -186,16 +199,24 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 						} : {},
 				],
 				'vertical': 'true'
-			},
-			(!this._map['wopi'].HidePrintOption) ?
+			}
+		);
+
+		if (!this._map['wopi'].HidePrintOption) {
+			content.push(
 				{
 					'id': 'print',
 					'type': 'bigtoolitem',
 					'text': _UNO('.uno:Print', 'presentation'),
 					'command': '.uno:Print',
 					'accessibility': { focusBack: true, combination: 'P', de: null }
-				} : {},
-			(this._map['wopi'].HideExportOption) ? {} : {
+				}
+			);
+		}
+
+		if (!this._map['wopi'].HideExportOption) {
+			content.push(
+			{
 				'id': 'file-downloadas-odg-downloadas-png',
 				'type': 'container',
 				'children': [
@@ -217,7 +238,10 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 					},
 				],
 				'vertical': 'true'
-			},
+			});
+		}
+
+		content.push(
 			{
 				'id': 'file-exportpdf',
 				'type': 'container',
@@ -242,8 +266,12 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 					},
 				],
 				'vertical': 'true'
-			},
-			(!this._map['wopi'].HideRepairOption) ? {
+			}
+		);
+
+		if (!this._map['wopi'].HideRepairOption) {
+			content.push(
+				{
 				'type': 'container',
 				'children': [
 					{
@@ -255,7 +283,10 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 						'accessibility': { focusBack: true, combination: 'RF', de: null }
 					}
 				]
-			}: {},
+			});
+		}
+
+		content.push(
 			{
 				'type': 'container',
 				'children': [
@@ -279,7 +310,7 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 					}
 				]
 			}
-		];
+		);
 
 		return this.getTabPage('File', content);
 	},

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -153,8 +153,10 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 	},
 
 	getFileTab: function() {
-		var content = [
-			!this._map['wopi'].HideSaveOption ?
+		var content = [];
+
+		if (!this._map['wopi'].HideSaveOption) {
+			content.push(
 			{
 				'type': 'toolbox',
 				'children': [
@@ -166,9 +168,11 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 						'accessibility': { focusBack: true, combination: 'SV', de: null }
 					}
 				]
-			}: {},
-			(!this._map['wopi'].UserCanNotWriteRelative) ?
-			(
+			});
+		}
+
+		if (!this._map['wopi'].UserCanNotWriteRelative) {
+			content.push(
 				(window.uiDefaults && window.uiDefaults.saveAsMode === 'group') ?
 				{
 					'id': 'saveas',
@@ -183,15 +187,21 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 					'command': '.uno:SaveAs',
 					'accessibility': { focusBack: true, combination: 'SA', de: null }
 				}
-			): {},
-			(!this._map['wopi'].UserCanNotWriteRelative) ?
+			);
+		}
+
+		if (!this._map['wopi'].UserCanNotWriteRelative) {
+			content.push(
 			{
 				'id': 'exportas',
 				'class': 'unoexportas',
 				'type': 'bigmenubartoolitem',
 				'text': _('Export As'),
 				'accessibility': { focusBack: true, combination: 'EA', de: null }
-			}: {},
+			});
+		}
+
+		content.push(
 			{
 				'id': 'file-shareas-rev-history',
 				'type': 'container',
@@ -216,16 +226,22 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 						} : {},
 				],
 				'vertical': 'true'
-			},
-			(!this._map['wopi'].HidePrintOption) ?
+			}
+		);
+
+		if (!this._map['wopi'].HidePrintOption) {
+			content.push(
 			{
 				'id': 'file-print',
 				'type': 'bigtoolitem',
 				'text': _UNO('.uno:Print', 'presentation'),
 				'command': '.uno:Print',
 				'accessibility': { focusBack: true, combination: 'PF', de: null }
-			} : {},
-			(!(window.enableMacrosExecution  === 'false')) ?
+			});
+		}
+
+		if (!(window.enableMacrosExecution  === 'false')) {
+			content.push(
 			{
 				'type': 'toolbox',
 				'children': [
@@ -237,8 +253,8 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 						'accessibility': { focusBack: true, combination: 'RM', de: null }
 					}
 				]
-			} : {}
-		];
+			});
+		}
 
 		if ((!!window.groupDownloadAsForNb) && !this._map['wopi'].HideExportOption) {
 			content.push({

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -136,8 +136,10 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 		var addRepairToDownloads = hasRepair && !hideDownload;
 		var addRepairToColumn = hasRepair && (hideDownload || hasGroupedDownloadAs);
 
-		content = [
-			hasSave ? {
+		content = [];
+
+		if (hasSave) {
+			content.push({
 				'type': 'toolbox',
 				'children': [
 					{
@@ -148,29 +150,39 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 						'accessibility': { focusBack: true,	combination: 'SV', de: null }
 					}
 				]
-			}: {},
-			hasSaveAs ?
-				hasGroupedSaveAs ? {
+			});
+		}
+
+		if (hasSaveAs) {
+			if (hasGroupedSaveAs) {
+				content.push({
 					'id': 'saveas',
 					'type': 'bigmenubartoolitem',
 					'text': _('Save As'),
 					'accessibility': { focusBack: true,	combination: 'SA' }
-				}:
-				{
+				});
+			} else {
+				content.push({
 					'id': 'file-saveas',
 					'type': 'bigtoolitem',
 					'text': _UNO('.uno:SaveAs', 'text'),
 					'command': '.uno:SaveAs',
 					'accessibility': { focusBack: true,	combination: 'SA' }
-				}
-			: {},
-			hasSaveAs ? {
+				});
+			}
+		}
+
+		if (hasSaveAs) {
+			content.push({
 				'id': 'exportas',
 				'class': 'unoexportas',
 				'type': 'bigmenubartoolitem',
 				'text': _('Export As'),
 				'accessibility': { focusBack: true,	combination: 'EA' }
-			}: {},
+			});
+		}
+
+		content.push(
 			{
 				'type': 'container',
 				'children': [
@@ -194,16 +206,21 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 					}: {}
 				],
 				'vertical': true
-			},
-			hasPrint ?
+			});
+		
+		if (hasPrint) {
+			content.push(
 			{
 				'id': 'print',
 				'type': 'bigtoolitem',
 				'text': _UNO('.uno:Print', 'text'),
 				'command': '.uno:Print',
 				'accessibility': { focusBack: true,	combination: 'P', de: 'P' }
-			} : {},
-			hasRunMacro ?
+			});
+		}
+
+		if (hasRunMacro) {
+			content.push(
 			{
 				'type': 'toolbox',
 				'children': [
@@ -214,15 +231,19 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 						'command': '.uno:RunMacro'
 					}
 				]
-			} : {},
-			hasGroupedDownloadAs && !hideDownload ? {
+			});
+		}
+
+		if (hasGroupedDownloadAs && !hideDownload) {
+			content.push({
 				'id': 'downloadas',
 				'class': 'unodownloadas',
 				'type': 'bigmenubartoolitem',
 				'text': _('Download'),
 				'accessibility': { focusBack: true,	combination: 'A', de: 'M' }
-			}:
-			!hideDownload ? (
+			});
+		} else if (!hideDownload) {
+			content.push(
 				{
 					'type': 'container',
 					'children': [
@@ -298,8 +319,11 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 					],
 					'vertical': 'true'
 				}
-			): {},
-			addRepairToColumn ? {
+			);
+		}
+
+		if (addRepairToColumn) {
+			content.push({
 				'type': 'container',
 				'children': [
 					{
@@ -312,7 +336,10 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 					}
 				],
 				'vertical': 'true'
-			}: {},
+			});
+		}
+
+		content.push(
 			{
 				'type': 'container',
 				'children': [
@@ -324,8 +351,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 						'accessibility': { focusBack: true,	combination: 'I', de: 'I' }
 					}
 				]
-			}
-		];
+			});
 
 		content.push({
 			'type': 'container',


### PR DESCRIPTION
- added get_export_formats postmessage invoke button in debug postmessage page
- fixed not present download entries when grouped_download_as is disabled

    This fixes regression in Get_Export_Formats where we
    didin't report possible formats when in coolwsd.xml
    option "group_download_as" was set to false.
    
    Regression comes from:
    commit 939a7a030109352a34d9b28a7dcd6f04325cc1b0
    Simplify notebookbarwriter and tab page containers.
    
    Where JSON for File tab was incorrectly built and
    some of the entries were skipped.