### PR TITLE
force the tabbed user interface for new installations and containers

### DIFF
--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -211,7 +211,7 @@
     @WELCOME_CONFIG_FRAGMENT@
 
     <user_interface>
-      <mode type="string" desc="Controls the user interface style. The 'default' means: Take the value from ui_defaults, or decide for one of compact or tabbed (default|compact|tabbed)" default="default">default</mode>
+      <mode type="string" desc="Controls the user interface style. The 'default' means: Take the value from ui_defaults, or decide for one of compact or tabbed (default|compact|tabbed)" default="tabbed">tabbed</mode>
       <use_integration_theme desc="Use theme from the integrator" type="bool" default="true">true</use_integration_theme>
     </user_interface>
 

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -2181,7 +2181,7 @@ void COOLWSD::innerInitialize(Application& self)
 #if ENABLE_FEATURE_RESTRICTION
         { "restricted_commands", "" },
 #endif
-        { "user_interface.mode", "default" },
+        { "user_interface.mode", "tabbed" },
         { "user_interface.use_integration_theme", "true" },
         { "quarantine_files[@enable]", "false" },
         { "quarantine_files.limit_dir_size_mb", "250" },
@@ -2253,7 +2253,7 @@ void COOLWSD::innerInitialize(Application& self)
     EnableAccessibility = getConfigValue<bool>(conf, "accessibility.enable", false);
 
     // Setup user interface mode
-    UserInterface = getConfigValue<std::string>(conf, "user_interface.mode", "default");
+    UserInterface = getConfigValue<std::string>(conf, "user_interface.mode", "tabbed");
 
     if (UserInterface == "compact")
         UserInterface = "classic";

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -989,7 +989,7 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
 
     // the config value of 'notebookbar/tabbed' or 'classic/compact' overrides the UIMode
     // from the WOPI
-    std::string userInterfaceModeConfig = config.getString("user_interface.mode", "default");
+    std::string userInterfaceModeConfig = config.getString("user_interface.mode", "tabbed");
     if (userInterfaceModeConfig == "compact")
         userInterfaceModeConfig = "classic";
 


### PR DESCRIPTION
Previously we respected the choice of integrator, i.e. the "default" was the integrator's preference, either compact mode or tabbed mode. But clearly the tabbed mode is the future, compact mode is legacy and not developed. Compact mode is not a good default. Tabbed mode is the preferred default, it's modern and accessible. Users who like compact mode better, can switch back easily.


Change-Id: If772bad748662090edaf57fc233415f74346da8b


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

