### PR TITLE
Calc: clone formatting cursor has misaligned hotspot

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -158,7 +158,7 @@
 }
 
 .bucket-cursor {
-	cursor: url('images/cursors/fill.png') 4 9, auto !important;/*setting coordinates to align the tip of the bucket icon */
+	cursor: url('images/cursors/fill.png') 4 18, auto !important;/*setting coordinates to align the tip of the brush icon */
 }
 .cool-scrollbar-show {
 	opacity: 1 !important;


### PR DESCRIPTION
Before:
"When I use the "clone formatting" tool, I have to point the handle of
the brush icon to the cell I want to clone rather than the
brush. Logically I would expect to point the brush part to the cell I
want to clone, but because the handle seems to be the point at which
cloning occurs, I end up cloning the cell above and not the actual
cell I want to clone."

Fix vertical coordinate so the bottom of the hotspot is in the brush
and change the outdate comment WRT the png in question.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I69e0935542c068016366a26d8100866c23ca17dc
