### PR TITLE
Correctly extract file name for exported file

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -3364,7 +3364,7 @@ void ChildSession::loKitCallback(const int type, const std::string& payload)
         // it was download request
 
         // Register download id -> URL mapping in the DocumentBroker
-        auto url = std::string("../../") + payload.substr(strlen("file:///tmp/"));
+        auto url = std::string("../../") + payload.substr(payload.find_last_of("/"));
         auto downloadId = Util::rng::getFilename(64);
         std::string docBrokerMessage = "registerdownload: downloadid=" + downloadId + " url=" + url + " clientid=" + getId();
         _docManager->sendFrame(docBrokerMessage.c_str(), docBrokerMessage.length());


### PR DESCRIPTION
We assumed in the code that LO will return in a
LOK_CALLBACK_EXPORT_FILE url starting with "file:///tmp/" But that is not true for all the cases. Let's use
more generic approach to extract file name.