### PR TITLE
don't request new tiles unnecessarily on canonicalidchange

### DIFF
--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -12,6 +12,7 @@ L.Control.UIManager = L.Control.extend({
 	busyPopupTimer: null,
 	customButtons: [], // added by WOPI InsertButton
 	modalIdPretext: 'modal-dialog-',
+	previousTheme: null,
 
 	onAdd: function (map) {
 		this.map = map;
@@ -103,6 +104,7 @@ L.Control.UIManager = L.Control.extend({
 		var selectedMode = this.getDarkModeState();
 		// swap them by invoking the appropriate load function and saving the state
 		if (selectedMode) {
+			this.previousTheme = 'Dark';
 			this.setSavedState('darkTheme',false);
 			this.loadLightMode();
 			var cmd = {
@@ -111,6 +113,7 @@ L.Control.UIManager = L.Control.extend({
 			app.socket.sendMessage('uno .uno:ChangeTheme ' + JSON.stringify(cmd));
 		}
 		else {
+			this.previousTheme = 'Light';
 			this.setSavedState('darkTheme',true);
 			this.loadDarkMode();
 			var cmd = {
@@ -131,6 +134,7 @@ L.Control.UIManager = L.Control.extend({
 		}
 
 		if (selectedMode) {
+			this.previousTheme = 'Dark';
 			this.loadDarkMode();
 			var cmd = {
 				'NewTheme': { 'type': 'string', 'value': 'Dark' }
@@ -138,6 +142,7 @@ L.Control.UIManager = L.Control.extend({
 			app.socket.sendMessage('uno .uno:ChangeTheme ' + JSON.stringify(cmd));
 		}
 		else {
+			this.previousTheme = 'Light';
 			this.loadLightMode();
 			var cmd = {
 				'NewTheme': { 'type': 'string', 'value': 'Light' }

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1802,20 +1802,21 @@ L.CanvasTileLayer = L.Layer.extend({
 			this._onFormFieldButtonMsg(textMsg);
 		}
 		else if (textMsg.startsWith('canonicalidchange:')) {
+			var payload = textMsg.substring('canonicalidchange:'.length + 1);
+			var viewRenderedState = payload.split('=')[3].split(' ')[0];
 			if (this._debugData) {
-				var payload = textMsg.substring('canonicalidchange:'.length + 1);
 				var viewId = payload.split('=')[1].split(' ')[0];
 				var canonicalId = payload.split('=')[2].split(' ')[0];
-				this._debugData['canonicalViewId'].setPrefix('Canonical id changed to: ' + canonicalId + ' for view id: ' + viewId);
+				this._debugData['canonicalViewId'].setPrefix('Canonical id changed to: ' + canonicalId + ' for view id: ' + viewId + ' with view renderend state: ' + viewRenderedState);
 			}
-			if (!this._canonicalIdInitialized)
-			{
+			if (!this._canonicalIdInitialized) {
 				this._canonicalIdInitialized = true;
 				this._update();
+			} else if (viewRenderedState !== this._map.uiManager.previousTheme) {
+				this._requestNewTiles();
+				this._invalidateAllPreviews();
+				this.redraw();
 			}
-			this._requestNewTiles();
-			this._invalidateAllPreviews();
-			this.redraw();
 		}
 		else if (textMsg.startsWith('comment:')) {
 			var obj = JSON.parse(textMsg.substring('comment:'.length + 1));

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1436,7 +1436,19 @@ private:
         if (newCanonicalId == session->getCanonicalViewId())
             return;
         session->setCanonicalViewId(newCanonicalId);
-        std::string message = "canonicalidchange: viewid=" + std::to_string(session->getViewId()) + " canonicalid=" + std::to_string(newCanonicalId);
+        const std::string viewRenderedState = session->getViewRenderState();
+        std::string stateName;
+        if (!viewRenderedState.empty())
+        {
+            stateName = viewRenderedState.substr(viewRenderedState.find(';') + 1);
+        }
+        else
+        {
+            stateName = "Empty";
+        }
+        std::string message = "canonicalidchange: viewid=" + std::to_string(session->getViewId()) +
+                              " canonicalid=" + std::to_string(newCanonicalId) +
+                              " viewrenderedstate=" + stateName;
         session->sendTextFrame(message);
     }
 

--- a/wsd/protocol.txt
+++ b/wsd/protocol.txt
@@ -687,6 +687,7 @@ contentcontrol: <JSON>
         - date - boolean to indicate date content control
         - items - array of items for dropdown
 
+canonicalidchange: viewid=<id> canonicalid=<id> viewrenderedstate=<Light|Dark|Empty>
 
 child -> parent
 ===============


### PR DESCRIPTION
- it applies for 2 cases:
1. when document is loaded for the first time document already has tiles of respective theme
2. when Kit loads the document it sends canonicalidchange  unconditionally (https://github.com/CollaboraOnline/online/blob/5520965b151cb854acbac3f1bbb68aec5ac2e1f2/kit/Kit.cpp#L1708) we don't need to request new tiles for that also


Change-Id: I42cdc5a03e70c3d3d653f3124d3d5ed9382e22c0


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

