### PR TITLE
Private/pedro/fix main nav for smallscreens

### DIFF
--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -18,8 +18,8 @@ button.jsdialog img {
 	flex-wrap: wrap;
 }
 
-.button-secondary,
-button:not(.ui-tab):not(.ui-corner-all):not(.button-primary):not(.unobutton):not(.form-field-button) {
+:not(.main-nav) .button-secondary,
+:not(.main-nav) > div > button:not(.ui-tab):not(.ui-corner-all):not(.button-primary):not(.unobutton):not(.form-field-button) {
 	box-sizing: border-box;
 	height: 32px;
 	line-height: 0em;

--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -20,6 +20,16 @@
 
 	--default-font-size: 12px;
 	--header-font-size: 16px;
+	/* tab min font-size */
+	--tb-min-fs: 11px;
+	/* tab min font-size without units*/
+	--tb-min-fs-u: 11;
+	/* tab max font-size */
+	--tb-max-fs: 16px;
+	/* tab max font-size wihtout units*/
+	--tb-max-fs-u: 16;
+	/* tab font-size preferred value or scaler */
+	--tb-fs-s: 1vw;
 
 	--default-height: 24px;
 	--header-height: 38px;

--- a/browser/css/menubar.css
+++ b/browser/css/menubar.css
@@ -87,7 +87,7 @@
 .main-nav.hasnotebookbar:not(.readonly) {
 	background: var(--color-main-background);
 	padding: 0px;
-	overflow-x: auto;
+	overflow: scroll hidden;
 }
 
 /* Customizations to sm-simple theme to make it look like LO menu, lo-menu class */

--- a/browser/css/menubar.css
+++ b/browser/css/menubar.css
@@ -22,6 +22,14 @@
 .main-nav.hasnotebookbar.readonly > #main-menu #document-header {
 	display: none;
 }
+
+/* hide documen-header to free up space when using narrow windows */
+@media screen and (max-width: 800px) {
+	.main-nav.hasnotebookbar:not(.readonly) #document-header {
+		display: none !important;
+	}
+}
+
 .document-logo {
 	position: relative;
 	width: 30px;
@@ -54,8 +62,14 @@
 }
 
 .main-nav.hasnotebookbar:not(.readonly) #document-titlebar {
-	/* half of #document-name-input height: */
-	top: -9px;
+	display: flex;
+	align-self: center;
+}
+
+@media screen and (max-width: 1238px) {
+	.main-nav.hasnotebookbar:not(.readonly) #document-titlebar {
+		display: none;
+	}
 }
 
 .main-nav.readonly #optionstoolboxdown {
@@ -63,7 +77,7 @@
 }
 .main-nav {
 	height: var(--header-height); /* on mouseover menubar items, border emerges */
-	width: auto;
+	width: 100%;
 	background: var(--color-background-lighter);
 	padding: 3px 3px 3px 0;
 	white-space: nowrap;

--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -20,11 +20,16 @@ button.ui-tab.notebookbar {
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	padding: 0px 1em;
+	padding: 0 clamp(4px, 1vw, 1em);
 	border: 1px solid transparent;
 	border-radius: var(--border-radius);
 	background-color: transparent;
-	font-size: var(--header-font-size);
+	/* calc([minimum size]
+	   + ([maximum size] - [minimum size])
+	   * ((100vw - [minimum viewport width]) / ([maximum viewport width] - [minimum viewport width]))); */
+	font-size: calc(var(--tb-min-fs) + (var(--tb-max-fs-u) - var(--tb-min-fs-u)) * ((100vw - 640px) / (1000 - 640)));
+	/* a minimum value, a preferred value or scaler, and a maximum allowed value. */
+	font-size: clamp(var(--tb-min-fs), var(--tb-fs-s), var(--tb-max-fs));
 	font-family: var(--cool-font);
 	line-height: normal;
 	color: var(--color-main-text);

--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -1490,9 +1490,6 @@ menu-entry-with-icon.padding-left + menu-entry-icon.width */
 	display: flex !important;
 	align-items: center;
 	font-family: var(--cool-font);
-	padding-right: 12px;
-	margin-right: 10px;
-	margin-left: 10px;
 	font-size: var(--default-font-size);
 	justify-content: end;
 }

--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -105,7 +105,7 @@ L.Control.Notebookbar = L.Control.extend({
 		this.map.off('jsdialogupdate', this.onJSUpdate, this);
 		this.map.off('jsdialogaction', this.onJSAction, this);
 		$('.main-nav #document-header').remove();
-		$('.main-nav.hasnotebookbar').css('overflow', 'visible');
+		$('.main-nav.hasnotebookbar').css('overflow', 'scroll hidden');
 		$('.main-nav').removeClass('hasnotebookbar');
 		$('#toolbar-wrapper').removeClass('hasnotebookbar');
 		$('.main-nav').removeClass(this._map.getDocType() + '-color-indicator');


### PR DESCRIPTION
commit 12e38de21912d2e0d73b0897408a4e9b94569ec6
Author: Pedro Pinto Silva <pedro.silva@collabora.com>
Date:   Thu Sep 28 11:32:27 2023 +0200

    Fix main-nav elements being treated as generic primary, secondary btn
    
    With the recent (and very welcoming) changes to steer away for generic
    elements such as div and instead use more appropriate/semantic
    elements such as button we ended up applying new rules to main-nav
    buttons. These rules were only intended to be apply to classic
    buttons (rectangle + text inside). Result:
            - userlistheader even if invisible was getting a background
            on mouseover
            - all <button> elements were getting extra padding and margin
    
    Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
    Change-Id: Ic774fd342df5483cd7210b85c4847688914b28f2

commit 1e4add916dd3419aeaa44b940b876f999eab76f9
Author: Pedro Pinto Silva <pedro.silva@collabora.com>
Date:   Thu Sep 28 11:27:36 2023 +0200

    userListHeader: remove legacy padding and margin
    
    userListHeader, element present in compact and tabbed view to display
    users present in the document (avatars), seems to suffer from a odd
    alignment and duplicated usage of white space.
    
    Best to remove any hard coded pixel that seem to come from legacy css
    and rely on flex if necessary. Also the surrounding elements (doc name
    and sidebar icon) already have save space around so they will never touch
    
    on top of that this was having different result than "expected" when
    using a different RTL system (since we were not using logical css properties)
    
    Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
    Change-Id: Iab0869080231ac734c087afeee97d9cd0243030d

commit 28c275c49bf60a0731459c1f60ff4027212185bc
Author: Pedro Pinto Silva <pedro.silva@collabora.com>
Date:   Tue Sep 19 15:34:43 2023 +0200

    Tabbed view: Fix main-nav for small screens
    
    Make tab's size dynamic
     - Font-size
     Instead of using always a font size that looks nice in a wide screen
     but that  will look cramped and  without space in a narrow window:
       - change it's size depending on  viewport within a safe range
       - new css vars added and respective comment in the code
       - Also we use clamp css function but we also add a fallback for old
       browser using the generic calc css function
     - Padding: allow to get lower levels when the viewport is reduced
    
    Hide document-header when the window is narrower than 800px
    - this frees up space and also benefits tablet us case where user uses
    2 apps side by side
    
    Document-title bar
     - Hide document name if the window is too small. This makes it
     possible to fit all buttons without horizontally scrolling the main-nav
     - Note user can always access the rename feature by going to File > Rename button
     - Remove any hard coded pixel positioning and instead rely solely on
     flex layout
    
    Main-nav
     - should always occupy (width wise) 100% of the viewport. We want
     always the far left icons be always at the end of the viewport
    
    Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
    Change-Id: I58843f40e21d26f955422d6159b5777144b684fd

commit 8607aa73c44ac3d80ae6440ed225e6cc674c5da0
Author: Pedro Pinto Silva <pedro.silva@collabora.com>
Date:   Tue Sep 19 16:52:25 2023 +0200

    Fix tabbed view top bar not being scrollable sometimes
    
    Before this, when using a narrow window, the top bar wouldn't be
    scrollable until we would press the avatar list. Also when switching the
    modes it would becomes unscrollable yet again.
    
    Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
    Change-Id: I01b2afcb125a2addf9847e2581f9498105b54b00