### PR TITLE
fix broken forum link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 ## Get in touch 💬
 
-* [📋 Forum](forum.collaboraonline.com/)
+* [📋 Forum](https://forum.collaboraonline.com/)
 * [👥 Facebook](https://www.facebook.com/collaboraoffice/)
 * [🐣 Twitter](https://twitter.com/CollaboraOffice)
 * [🐘 Mastodon](https://mastodon.social/@CollaboraOffice)


### PR DESCRIPTION
The forum link in the README is missing https://. This PR fixes that