### PR TITLE
Fix compiler warnings when building on macOS Sonoma

### DIFF
--- a/common/MessageQueue.hpp
+++ b/common/MessageQueue.hpp
@@ -82,7 +82,7 @@ public:
     /// Thread safe remove_if.
     void remove_if(const std::function<bool(const Payload&)>& pred)
     {
-        std::remove_if(_queue.begin(), _queue.end(), pred);
+        (void)std::remove_if(_queue.begin(), _queue.end(), pred);
     }
 
 protected:

--- a/kit/DeltaSimd.c
+++ b/kit/DeltaSimd.c
@@ -84,7 +84,7 @@ static uint64_t diffMask(__m256i prev, __m256i curr)
 
 #endif
 
-void simd_deltaInit()
+void simd_deltaInit(void)
 {
 #if ENABLE_SIMD
     init_gather_lut();

--- a/kit/DeltaSimd.h
+++ b/kit/DeltaSimd.h
@@ -14,7 +14,7 @@
 extern "C" {
 #endif
 
-void simd_deltaInit();
+void simd_deltaInit(void);
 
 int simd_initPixRowSimd(const uint32_t *from, uint32_t *scratch, size_t *scratchLen, uint64_t *rleMask);
 


### PR DESCRIPTION
Note: no patches were needed to build LibreOffice branch distro/collabora/co-23.05 on macOS Sonoma.