### PR TITLE
jsdialog: use minial size of a dialog needed

### DIFF
--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -53,6 +53,7 @@ button:not(.ui-corner-all):not(.button-primary):not(.form-field-button) {
 	border-radius: var(--border-radius);
 	margin: 5px;
 	vertical-align: middle;
+	width: max-content;
 }
 
 .vex.vex-theme-plain .vex-dialog-form .vex-dialog-buttons {

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -17,13 +17,22 @@
 	background: transparent;
 }
 
-.lokdialog_container.ui-dialog.ui-widget-content.modalpopup {
+.lokdialog_container.ui-dialog.ui-widget-content.modalpopup,
+.jsdialog-window.modalpopup {
 	z-index: 2001;
+}
+
+.jsdialog-window {
+	position: absolute;
+	z-index: 1105;
 }
 
 .jsdialog-container {
 	position: absolute;
-	z-index: 1105;
+}
+
+.jsdialog-window:not(.modalpopup) .jsdialog-container:not(.snackbar) {
+	min-width: 400px;
 }
 
 .jsdialog.one-child-popup {
@@ -31,12 +40,16 @@
 	margin: 0 !important;
 }
 
-.jsdialog-container.modalpopup {
+.jsdialog-window.modalpopup {
 	min-width: 198px;
 	max-width: 498px;
 	border: 1px solid #a4a4a4 !important;
 	border-radius: var(--border-radius);
 	box-shadow: 0 -1px 2px 0 rgba(0, 0, 0, 0.15), 0 2px 2px 0 rgba(0, 0, 0, 0.1);
+}
+
+.jsdialog-window.modalpopup .jsdialog-container {
+	position: relative;
 }
 
 .jsdialog-container .ui-dialog-titlebar {
@@ -47,6 +60,10 @@
 	background-color: var(--color-background-lighter) !important;
 	font-family: var(--jquery-ui-font);
 	line-height: 1.5;
+}
+
+.jsdialog-container .lokdialog.ui-dialog-content.ui-widget-content {
+	overflow: hidden;
 }
 
 .jsdialog.vertical p, .ui-frame-label {
@@ -182,10 +199,7 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 	border-radius: var(--border-radius);
 	background-color: var(--color-main-background);
 	margin-inline-end: 12px;
-}
-
-.ui-tab.jsdialog:first-child {
-	margin-inline-start: 12px;
+	margin-bottom: 6px;
 }
 
 .ui-tab.hidden.jsdialog {
@@ -1117,12 +1131,17 @@ input[type='number']:hover::-webkit-outer-spin-button {
 #snackbar {
 	border: none !important;
 }
+.snackbar.jsdialog-window {
+	overflow: visible;
+}
 #mobile-wizard.popup.snackbar,
 .snackbar.jsdialog-container .ui-dialog-content {
 	min-width: 200px;
 	background-color: #323232 !important;
 }
-
+.snackbar.jsdialog-container .ui-dialog-content {
+	width: max-content !important;
+}
 #mobile-wizard.popup.snackbar #label,
 .snackbar.jsdialog-container #label,
 #mobile-wizard.popup.snackbar #label-no-action,

--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -231,13 +231,16 @@ L.Control.JSDialog = L.Control.extend({
 		}
 
 		// it has to be form to handle default button
-		container = L.DomUtil.create('form', 'jsdialog-container ui-dialog ui-widget-content lokdialog_container', containerParent);
+		container = L.DomUtil.create('div', 'jsdialog-window', containerParent);
 		container.id = data.id;
 		container.style.visibility = 'hidden';
 		if (data.collapsed && (data.collapsed === 'true' || data.collapsed === true))
 			L.DomUtil.addClass(container, 'collapsed');
+
+		var form = L.DomUtil.create('form', 'jsdialog-container ui-dialog ui-widget-content lokdialog_container', container);
+
 		// prevent from reloading
-		container.addEventListener('submit', function (event) { event.preventDefault(); });
+		form.addEventListener('submit', function (event) { event.preventDefault(); });
 
 		var defaultButtonId = this._getDefaultButtonId(data.children);
 
@@ -246,18 +249,18 @@ L.Control.JSDialog = L.Control.extend({
 		}
 
 		// it has to be first button in the form
-		var defaultButton = L.DomUtil.createWithId('button', 'default-button', container);
+		var defaultButton = L.DomUtil.createWithId('button', 'default-button', form);
 		defaultButton.style.display = 'none';
 		defaultButton.onclick = function() {
 			if (defaultButtonId) {
-				var button = container.querySelector('#' + defaultButtonId);
+				var button = form.querySelector('#' + defaultButtonId);
 				if (button)
 					button.click();
 			}
 		};
 
 		if (!isModalPopup || (data.hasClose)) {
-			var titlebar = L.DomUtil.create('div', 'ui-dialog-titlebar ui-corner-all ui-widget-header ui-helper-clearfix', container);
+			var titlebar = L.DomUtil.create('div', 'ui-dialog-titlebar ui-corner-all ui-widget-header ui-helper-clearfix', form);
 			var title = L.DomUtil.create('span', 'ui-dialog-title', titlebar);
 			title.innerText = data.title;
 			var button = L.DomUtil.create('button', 'ui-button ui-corner-all ui-widget ui-button-icon-only ui-dialog-titlebar-close', titlebar);
@@ -265,12 +268,14 @@ L.Control.JSDialog = L.Control.extend({
 		}
 		if (isModalPopup) {
 			L.DomUtil.addClass(container, 'modalpopup');
-			if (isSnackbar)
+			if (isSnackbar) {
 				L.DomUtil.addClass(container, 'snackbar');
+				L.DomUtil.addClass(form, 'snackbar');
+			}
 		}
 
-		var tabs = L.DomUtil.create('div', 'jsdialog-tabs', container);
-		var content = L.DomUtil.create('div', 'lokdialog ui-dialog-content ui-widget-content', container);
+		var tabs = L.DomUtil.create('div', 'jsdialog-tabs', form);
+		var content = L.DomUtil.create('div', 'lokdialog ui-dialog-content ui-widget-content', form);
 
 		// required to exist before builder was launched (for setTabs)
 		this.dialogs[data.id] = {
@@ -389,7 +394,7 @@ L.Control.JSDialog = L.Control.extend({
 					if (posY + content.clientHeight > window.innerHeight)
 						posY -= posY + content.clientHeight + 10 - window.innerHeight;
 				} else if (isDocumentAreaPopup) {
-					var height = container.getBoundingClientRect().height;
+					var height = form.getBoundingClientRect().height;
 					if (posY + height > containerParent.getBoundingClientRect().height) {
 						var newTopPosition = posY - height;
 						if (newTopPosition < 0)
@@ -397,7 +402,7 @@ L.Control.JSDialog = L.Control.extend({
 						posY = newTopPosition;
 					}
 
-					var width = container.getBoundingClientRect().width;
+					var width = form.getBoundingClientRect().width;
 					if (posX + width > containerParent.getBoundingClientRect().width) {
 						var newLeftPosition = posX - width;
 						if (newLeftPosition < 0)
@@ -406,11 +411,11 @@ L.Control.JSDialog = L.Control.extend({
 					}
 				}
 			} else if (isSnackbar) {
-				posX = window.innerWidth/2 - container.offsetWidth/2;
-				posY = window.innerHeight - container.offsetHeight - 40;
+				posX = window.innerWidth/2 - form.offsetWidth/2;
+				posY = window.innerHeight - form.offsetHeight - 40;
 			} else if (force || (posX === 0 && posY === 0)) {
-				posX = window.innerWidth/2 - container.offsetWidth/2;
-				posY = window.innerHeight/2 - container.offsetHeight/2;
+				posX = window.innerWidth/2 - form.offsetWidth/2;
+				posY = window.innerHeight/2 - form.offsetHeight/2;
 			}
 		};
 

--- a/cypress_test/integration_tests/desktop/impress/sidebar_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/sidebar_spec.js
@@ -32,7 +32,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Sidebar Tests', function()
 		cy.cGet('#fillattr3').should('be.visible');
 		helper.waitUntilIdle('#fillattr2');
 		cy.cGet('#fillattr2').click();
-		cy.cGet('.modalpopup').should('be.visible');
+		cy.cGet('.modalpopup .jsdialog-container').should('be.visible');
 		cy.cGet('#colorset').should('be.visible');
 	});
 
@@ -42,7 +42,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Sidebar Tests', function()
 		impressHelper.selectTextOfShape();
 		cy.cGet('#layoutvalueset').should('not.be.visible');
 		cy.cGet('#Underline .arrowbackground').click();
-		cy.cGet('.modalpopup').should('be.visible');
+		cy.cGet('.modalpopup .jsdialog-container').should('be.visible');
 		cy.cGet('#single').click();
 		impressHelper.triggerNewSVGForShapeInTheCenter();
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph')


### PR DESCRIPTION
Use 'position: absolute' in jsdialog-window and jsdialog-container so we don't stretch the dialog. It will use minimal needed size.

this is backport of: https://github.com/CollaboraOnline/online/commit/afbf052bb5d1f9b74389c068552c40878301aa43

fixes super long warning dialogs:

![error](https://github.com/CollaboraOnline/online/assets/5307369/1e59d3b8-16ed-49ea-a07d-b1d6a2235bff)
