### PR TITLE
snackbar regression fixes

### DIFF
--- a/browser/css/device-mobile.css
+++ b/browser/css/device-mobile.css
@@ -683,7 +683,8 @@ td[id^='tb_spreadsheet-toolbar_item']:focus table.w2ui-button div.w2ui-icon, td[
 #mobile-wizard.popup:not(.snackbar) {
 	border-radius: 16px 16px 0 0;
 }
-#mobile-wizard.popup #mobile-wizard-content {
+#mobile-wizard.popup #mobile-wizard-content,
+#mobile-wizard.popup .mobile-wizard-content {
 	display: flex;
 	align-items: center;
 	justify-content: center;

--- a/browser/css/mobilewizard.css
+++ b/browser/css/mobilewizard.css
@@ -754,6 +754,11 @@ a.leaflet-control-zoom-in {
 	clear: both;
 }
 
+#mobile-wizard.snackbar .mobile-wizard.ui-text {
+	border: none;
+	line-height: inherit;
+}
+
 #mobile-wizard [id^='info-modal-label'].mobile-wizard.ui-text {
 	border: none;
 	color: var(--color-text-dark) !important;


### PR DESCRIPTION
mobile: fix snackbar button position
    
    This fixes regression from:
    commit 07c353858971d83a651b667efe827973dc70c2ae
    mobile-wizard: create separate window container
    
    The snackbar with action button like "leave feedback | ok"
    or "we can reconnect | reload" had buttons below text
    what looked bad and it was not possible to click
    
 ------------------------------------------------

mobile: fix snackbar text
    
    This fixes regression introduced in:
    commit b6c26bee914a39b803a1a1ae78dfaf9a280b131e
    Mobile sidebar header layout #6861
    
    - remove additional top border
    - make line height regular so text will fit into snackbar
      without scrollbar

![snackbar-regression](https://github.com/CollaboraOnline/online/assets/5307369/60613c07-af04-476c-992f-523719ca2705)

