### PR TITLE
Add CTRL + ALT + N shortcut for new documents

### DIFF
--- a/browser/src/map/handler/Map.Keyboard.js
+++ b/browser/src/map/handler/Map.Keyboard.js
@@ -734,6 +734,13 @@ L.Map.Keyboard = L.Handler.extend({
 			e.preventDefault();
 		}
 
+		// CTRL + ALT + N for new document. This needs to be handled by the integrator.
+		if (this._isCtrlKey(e) && e.altKey && e.key.toUpperCase() === 'N') {
+			this._map.fire('postMessage', {msgId: 'UI_CreateFile', args: { DocumentType: this._map.getDocType() }});
+			e.preventDefault();
+			return true;
+		}
+
 		// CTRL + SHIFT + L is added to the core side for writer. Others can also be checked.
 		if (this._isCtrlKey(e) && e.shiftKey && e.key === 'L' && this._map.getDocType() !== 'text' && this._map.getDocType() !== 'spreadsheet') {
 			app.socket.sendMessage('uno .uno:DefaultBullet');


### PR DESCRIPTION
Added CTRL + ALT + N shortcut.
* This sends the NewDocument postmessage to integrator along with the document type.
* Integrator should handle the message.

Change-Id: I8458f382771211b245ad4cedf501b73b50afc1c7


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

