### PR TITLE
fix(ci): do not set helm to current github-release

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -31,7 +31,8 @@ jobs:
           version: v3.12.1
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.5.0
+        # for use with make-release-latest
+        uses: helm/chart-releaser-action@fdfc0aa11c813b419cc28971327031c3119bec63
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:

--- a/kubernetes/helm/cr.yaml
+++ b/kubernetes/helm/cr.yaml
@@ -1,1 +1,2 @@
 release-name-template: "helm-{{ .Name }}-{{ .Version }}"
+make-release-latest: false


### PR DESCRIPTION
Change-Id: I2658fdefde7e40ab46cae2b9a3c0bfcac4ce626f


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
current the helm-release set his helm to latest github-release, lets disable.
On this way just collabora releases (and not helm-chart) is marked as latest.
