### PR TITLE
Tabbed: Calc: Scroll indicator is 3 pixels misaligned

### DIFF
--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -207,6 +207,13 @@ w2ui-toolbar {
 	background-color: var(--color-background-dark);
 	box-shadow: 0px 0px 7px var(--color-box-shadow);
 }
+#toolbar-wrapper.hasnotebookbar .w2ui-scroll-left,
+#toolbar-wrapper.hasnotebookbar .w2ui-scroll-right {
+	/* .notebookbar-scroll-wrapper's height */
+	height: 72px;
+	/* #toolbar-wrapper:not(.mobile)'s top padding */
+	top: 3px;
+}
 .w2ui-scroll-left:hover,
 .w2ui-scroll-right:hover {
 	background-color: var(--color-background-darker);

--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -340,9 +340,6 @@ L.Control.Notebookbar = L.Control.extend({
 		var left = L.DomUtil.create('div', 'w2ui-scroll-left', parent);
 		var right = L.DomUtil.create('div', 'w2ui-scroll-right', parent);
 
-		$(left).css({'height': '72px'});
-		$(right).css({'height': '72px'});
-
 		$(left).click(function () {
 			var scroll = $('.notebookbar-scroll-wrapper').scrollLeft() - 300;
 			$('.notebookbar-scroll-wrapper').animate({ scrollLeft: scroll }, 300);


### PR DESCRIPTION
The scroll indicator set with an absolute position ends up being
positioned in the 0 y coordinate. Since the wrapper has a top padding
of 3 pixel it means the scroll indicator is not 3 pixel off.

Also, and since these measurements are set in the CSS (the height of
the wrapper and the padding of the other wrapper), better to just move
everything to the CSS and avoid unnecessary inline styles.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Icc1e51b2590ee27b318f9e4c3d550183b08cb49d
