### PR TITLE
Allow http Range header for media files

### DIFF
--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -1555,6 +1555,10 @@ public:
         , _size(0)
         , _fd(-1)
         , _connected(false)
+        , _start(0)
+        , _end(-1)
+        , _startIsSuffix(false)
+        , _statusCode(http::StatusCode::OK)
     {
     }
 
@@ -1584,8 +1588,13 @@ public:
     /// Note: when reusing this Session, it is assumed that the socket
     /// is already added to the SocketPoll on a previous call (do not
     /// use multiple SocketPoll instances on the same Session).
-    bool asyncUpload(std::string fromFile, std::string mimeType)
+    bool asyncUpload(std::string fromFile, std::string mimeType, int start, int end, bool startIsSuffix, http::StatusCode statusCode = http::StatusCode::OK)
     {
+        _start = start;
+        _end = end;
+        _startIsSuffix = startIsSuffix;
+        _statusCode = statusCode;
+
         LOG_TRC("asyncUpload from file [" << fromFile << ']');
 
         _fd = open(fromFile.c_str(), O_RDONLY);
@@ -1608,7 +1617,88 @@ public:
         _size = sb.st_size;
         _data = std::move(fromFile);
         _mimeType = std::move(mimeType);
+
+        int firstBytePos = getStart();
+        lseek(_fd, firstBytePos, SEEK_SET);
+        _pos = firstBytePos;
+
         return true;
+    }
+
+    /// Start an asynchronous upload of a whole file
+    bool asyncUpload(std::string fromFile, std::string mimeType)
+    {
+        return asyncUpload(fromFile, mimeType, 0, -1, false);
+    }
+
+    /// Start a partial asynchronous upload from a file based on the contents of a "Range" header
+    bool asyncUpload(std::string fromFile, std::string mimeType, std::string rangeHeader)
+    {
+        size_t equalsPos = rangeHeader.find("=");
+        if (equalsPos == std::string::npos) return asyncUpload(fromFile, mimeType);
+
+        std::string unit = rangeHeader.substr(0, equalsPos);
+        if (unit != "bytes") return asyncUpload(fromFile, mimeType);
+
+        std::string range = rangeHeader.substr(equalsPos + 1);
+
+        size_t dashPos = range.find("-");
+        std::string startString = range.substr(0, dashPos);
+        std::string endString = "-1";
+
+        if (dashPos != std::string::npos) {
+            endString = range.substr(dashPos + 1);
+        }
+
+        int start = 0;
+        int end = -1;
+        bool startIsSuffix = false;
+
+        if (startString == "") {
+            // Could be a suffix
+            try {
+                start = std::stoi(endString);
+                startIsSuffix = true;
+            }
+            catch (std::invalid_argument&) {}
+            catch (std::out_of_range&) {}
+
+            return asyncUpload(fromFile, mimeType, start, end, startIsSuffix, http::StatusCode::PartialContent);
+        }
+
+        try {
+            start = std::stoi(startString);
+            end = std::stoi(endString) + 1;
+        }
+        catch (std::invalid_argument&) {}
+        catch (std::out_of_range&) {}
+
+        // FIXME: does not support ranges that specify multiple comma-separated values
+
+        return asyncUpload(fromFile, mimeType, start, end, startIsSuffix, http::StatusCode::PartialContent);
+    }
+
+    int getStart() {
+        if (_startIsSuffix) return _size - _start;
+        return _start;
+    }
+
+    int getEnd() {
+        if (_startIsSuffix) return _size;
+        if (_end == -1) return _size;
+        if (_end > _size) return _size;
+
+        return _end;
+    }
+
+    /// Calculate how much we're going to send based on the file size and the range
+    int getSendSize() {
+        int end = getEnd();
+        int start = getStart();
+
+        if (start > _size) return 0;
+
+        return end - start;
     }
 
     void asyncShutdown()
@@ -1642,13 +1732,13 @@ private:
                 LOG_TRC("Connected");
                 _connected = true;
 
-                LOG_DBG("Sending header with size " << _size);
-                http::Response httpResponse(http::StatusCode::OK);
-                httpResponse.set("Content-Length", std::to_string(_size));
+                LOG_DBG("Sending header with size " << getSendSize());
+                http::Response httpResponse(_statusCode);
+                httpResponse.set("Content-Length", std::to_string(getSendSize()));
                 httpResponse.set("Content-Type", _mimeType);
-                httpResponse.set("accept-ranges", "bytes");
-                httpResponse.set("Content-Range", "bytes 0-" + std::to_string(_size - 1) + '/' +
-                                                      std::to_string(_size));
+                httpResponse.set("Accept-Ranges", "bytes");
+                httpResponse.set("Content-Range", "bytes " + std::to_string(getStart()) + "-" + std::to_string(getEnd() - 1) + '/' +
+                                    std::to_string(_size));
 
                 socket->send(httpResponse);
                 return;
@@ -1716,14 +1806,14 @@ private:
             {
                 //FIXME: replace with in-place read into the output buffer.
                 char buffer[64 * 1024];
-                const auto size = std::min(sizeof(buffer), capacity);
+                const auto size = std::min({sizeof(buffer), capacity, (size_t)(getEnd() - _pos)});
                 int n;
                 while ((n = ::read(_fd, buffer, size)) < 0 && errno == EINTR)
                     LOG_TRC("EINTR reading from " << _data);
 
-                if (n <= 0)
+                if (n <= 0 || _pos >= getEnd())
                 {
-                    if (n == 0)
+                    if (n >= 0)
                     {
                         LOG_TRC("performWrites finished uploading");
                     }
@@ -1739,6 +1829,7 @@ private:
                 }
 
                 _socket->send(buffer, n);
+                _pos += n;
                 LOG_ASSERT(static_cast<std::size_t>(n) <= capacity);
                 capacity -= n;
                 LOG_TRC("performWrites wrote " << n << " bytes, capacity: " << capacity);
@@ -1773,6 +1864,17 @@ private:
     int _size; //< The size of the data in bytes.
     int _fd; //< The descriptor of the file to upload.
     bool _connected;
+    int _start; //< The position we start reading from, the data includes this first byte
+                //  If this is greater than _size we will return no bytes
+                //  If this is less than 0 or greater than _end behavior is unspecified
+    int _end; //< The position we stop reading at, the data does not include this last byte
+              //  If this is greater than or equal to _start we will only return bytes in the range
+              //  If this is greater than _size we will return all bytes between _start and _size
+              //  If this is -1 we will treat it as if it were equal to _size
+    bool _startIsSuffix; //< If this is true, we'll treat _start as an offset from the end, not from the start
+                         //  In that case, we'll ignore end entirely
+                         //  e.g. if this is true and start is 5, we will send the last 5 bytes
+    http::StatusCode _statusCode;
     FinishedCallback _onFinished;
     std::shared_ptr<StreamSocket> _socket; //< Must be the last member.
 };

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -4594,7 +4594,9 @@ private:
         {
             // Do things in the right thread.
             LOG_TRC_S("Move media request " << tag << " to docbroker thread");
-            docBroker->handleMediaRequest(socket, tag);
+
+            std::string range = request.get("Range", "none");
+            docBroker->handleMediaRequest(range, socket, tag);
         }
     }
 

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -3293,7 +3293,8 @@ void DocumentBroker::handleClipboardRequest(ClipboardRequest type,  const std::s
         LOG_ERR("Could not find matching session to handle clipboard request for " << viewId << " tag: " << tag);
 }
 
-void DocumentBroker::handleMediaRequest(const std::shared_ptr<Socket>& socket,
+void DocumentBroker::handleMediaRequest(std::string range,
+                                        const std::shared_ptr<Socket>& socket,
                                         const std::string& tag)
 {
     LOG_DBG("handleMediaRequest: " << tag);
@@ -3325,8 +3326,9 @@ void DocumentBroker::handleMediaRequest(const std::shared_ptr<Socket>& socket,
             // For now, we only support file:// schemes.
             // In the future, we may/should support http.
             const std::string path = getJailRoot() + url.substr(sizeof("file://") - 1);
+
             auto session = std::make_shared<http::server::Session>();
-            session->asyncUpload(path, "video/mp4");
+            session->asyncUpload(path, "video/mp4", range);
             auto handler = std::static_pointer_cast<ProtocolHandlerInterface>(session);
             streamSocket->setHandler(handler);
         }

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -454,7 +454,7 @@ public:
     static bool lookupSendClipboardTag(const std::shared_ptr<StreamSocket> &socket,
                                        const std::string &tag, bool sendError = false);
 
-    void handleMediaRequest(const std::shared_ptr<Socket>& socket, const std::string& tag);
+    void handleMediaRequest(std::string range, const std::shared_ptr<Socket>& socket, const std::string& tag);
 
     /// True if any flag to unload or terminate is set.
     bool isUnloading() const


### PR DESCRIPTION
The range header allows a client to specify that they would like only part of a file, e.g. only the first 1000 bytes of a video. When playing video on Apple devices (Macs, iPads, iPhones etc.) this is required to avoid Safari rejecting the video as broken. This is the first part of a fix to embedded videos on Safari.

This pull request does not implement specifying multiple ranges at once (e.g. bytes=0-9,-100 to get the first 10 and last 100 bytes).

This feature is necessary to play video on Apple devices, but it is not sufficient. In particular, I believe some further client-side fixes will be needed to make the video play properly.


Change-Id: Id89a06d374b7d0efbf2b3184d8618df61684dcb6

* Target version: master 

### Checklist

- [ ] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

