### PR TITLE
docker: fix all aliasgroup env variable added to blocked list

### DIFF
--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -3135,8 +3135,9 @@ void COOLWSD::initializeEnvOptions()
         {
             if (first)
             {
-                _overrideSettings["storage.wopi.alias_groups.group[" + std::to_string(n) +
-                                  "].host"] = alias;
+                const std::string path = "storage.wopi.alias_groups.group[" + std::to_string(n) + "].host";
+                _overrideSettings[path] = alias;
+                _overrideSettings[path + "[@allow]"] = true;
                 first = false;
             }
             else


### PR DESCRIPTION
Change-Id: Id7480ab88564965cc7aba34c5020daaf18259815

* Target version: master 

### TODO
- [ ] Need manually test by building docker image

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

