### PR TITLE
exclude debug/dev files from production packages

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -687,7 +687,14 @@ $(DIST_FOLDER)/admin/%: $(srcdir)/admin/%
 
 install-data-hook:
 	mkdir -p $(DESTDIR)$(pkgdatadir)/browser; \
-	cp -a dist/ $(DESTDIR)$(pkgdatadir)/browser/;
+	rsync -a --exclude='src' \
+		--exclude='debug.html' \
+		--exclude='framed.doc.html' \
+		--exclude='framed.html' \
+		--exclude='load.doc.html' \
+		--exclude='multidocs.html' \
+		--exclude='tsconfig.tsbuildinfo' \
+		dist $(DESTDIR)$(pkgdatadir)/browser/;
 
 libs:
 	@mkdir -p $(abs_srcdir)/libs


### PR DESCRIPTION
Change-Id: Ic9b49a401b63af65f4e53e3eb2584b8258575c2a


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

