### PR TITLE
fix: docker failed to initialize when aliasgroups is passed

### DIFF
--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -3137,7 +3137,7 @@ void COOLWSD::initializeEnvOptions()
             {
                 const std::string path = "storage.wopi.alias_groups.group[" + std::to_string(n) + "].host";
                 _overrideSettings[path] = alias;
-                _overrideSettings[path + "[@allow]"] = true;
+                _overrideSettings[path + "[@allow]"] = "true";
                 first = false;
             }
             else


### PR DESCRIPTION
wsd-00001-00001 2023-09-07 06:57:38.412560 +0000 [ coolwsd ] FTL  Failed to initialize COOLWSD: Syntax error: Cannot convert to boolean: | wsd/COOLWSD.hpp:513
Syntax error: Cannot convert to boolean:
<shutdown>-00001 2023-09-07 06:57:38.413335 +0000 [ coolwsd ] SIG   Fatal signal received: SIGABRT code: 18446744073709551610 for address: 0x6400000001


Change-Id: I446bc9b2c2172d820da2ea148eefd1d7f964be80

* Target version: master 

### Summary



