### PR TITLE
Change the local storage setting name 'CompactMode' to 'compactMode'

### DIFF
--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -67,7 +67,7 @@ L.Control.UIManager = L.Control.extend({
 	},
 
 	shouldUseNotebookbarMode: function() {
-		var forceCompact = this.getSavedStateOrDefault('CompactMode', null);
+		var forceCompact = this.getSavedStateOrDefault('compactMode', null);
 		return (window.userInterfaceMode === 'notebookbar' && forceCompact === null)
 			|| forceCompact === false;
 	},
@@ -543,7 +543,7 @@ L.Control.UIManager = L.Control.extend({
 			break;
 		}
 
-		this.setSavedState('CompactMode', uiMode.mode === 'classic');
+		this.setSavedState('compactMode', uiMode.mode === 'classic');
 		this.initializeSidebar();
 		this.insertCustomButtons();
 
@@ -1370,15 +1370,15 @@ L.Control.UIManager = L.Control.extend({
 	},
 
 	setSavedState: function(name, state) {
-		var docType = (name === 'CompactMode') ? null : this.map.getDocType();
+		var docType = (name === 'compactMode') ? null : this.map.getDocType();
 		if (window.isLocalStorageAllowed)
 			localStorage.setItem('UIDefaults_' + docType + '_' + name, state);
 	},
 
 	getSavedStateOrDefault: function(name, forcedDefault) {
 		var retval = forcedDefault !== undefined ? forcedDefault : true;
-		// we request CompactMode very early, no info about doctype so unify all the calls
-		var docType = (name === 'CompactMode') ? null : this.map.getDocType();
+		// we request compactMode very early, no info about doctype so unify all the calls
+		var docType = (name === 'compactMode') ? null : this.map.getDocType();
 		var state = null;
 		if (window.isLocalStorageAllowed)
 			state = localStorage.getItem('UIDefaults_' + docType + '_' + name);


### PR DESCRIPTION
We want to re-force the choice, i.e. people who mistakenly set their UI to compact mode, now will get tabbed mode and can decide, if they like it better or not.


Change-Id: Ic5810321abf2cbc3996478816fe153d848c66c71

