### PR TITLE
Enable drawing even if the first cell cursor message is empty.

### DIFF
--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -970,7 +970,7 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 	_onCellCursorMsg: function (textMsg) {
 		L.CanvasTileLayer.prototype._onCellCursorMsg.call(this, textMsg);
 		this._refreshRowColumnHeaders();
-		if (!this._gotFirstCellCursor && !textMsg.match('EMPTY')) {
+		if (!this._gotFirstCellCursor) {
 			// Drawing is disabled from CalcTileLayer construction, enable it now.
 			this._gotFirstCellCursor = true;
 			this._update();


### PR DESCRIPTION
Reason:
Sometimes cell address is at the end of a merged cells block. That kind of cell address is invalid. Example:
Merged cells: A1-A5.
When example merged block is selected, cell address should be A1. If it is A5, cell cursor is not drawn.
If cell cursor is not drawn "EMPTY" message is sent from core side. And we cannot enable drawing in this case.
So we enable drawing even if the cell cursor message is "EMPTY".


Change-Id: I456bc757725c9bfaede20068cf165310712488e7


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

