### PR TITLE
different 'parts' in requestedTiles on switching calc tabs

### DIFF
--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -442,6 +442,7 @@ public:
     void handleTileCombinedRequest(TileCombined& tileCombined, bool forceKeyframe,
                                    const std::shared_ptr<ClientSession>& session);
     void sendRequestedTiles(const std::shared_ptr<ClientSession>& session);
+    void sendTileCombine(const TileCombined& tileCombined);
 
     enum ClipboardRequest {
         CLIP_REQUEST_SET,


### PR DESCRIPTION
can result in still unfulfilled requests for the first tab in requestedTiles when the new requests are compared with those for duplicates


Change-Id: Id8d40f0a7e7f9d32fed67a415756284d7f6a53d4


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

