### PR TITLE
keep quarantine files on SIGABRT too

### DIFF
--- a/kit/ForKit.cpp
+++ b/kit/ForKit.cpp
@@ -298,7 +298,9 @@ static void cleanupChildren()
         const auto it = childJails.find(exitedChildPid);
         if (it != childJails.end())
         {
-            if (WIFSIGNALED(status) && (WTERMSIG(status) == SIGSEGV || WTERMSIG(status) == SIGBUS))
+            if (WIFSIGNALED(status) && (WTERMSIG(status) == SIGSEGV ||
+                                        WTERMSIG(status) == SIGBUS ||
+                                        WTERMSIG(status) == SIGABRT))
             {
                 ++segFaultCount;
 


### PR DESCRIPTION
AdminModel::cleanupResourceConsumingDocs uses SIGABRT as first attept to kill misbehaving documents, we should give DocumentBroker a chance to quarantine documents killed off by SIGABRT as we do SIGSEGV/SIGBUS


Change-Id: Ic3a703572393050379b5a1444a5380bbeafcf2d3


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

