### PR TITLE
admin:log activities irrespective of logging.level

### DIFF
--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -253,6 +253,12 @@
         <enable_pam desc="Enable admin user authentication with PAM" type="bool" default="false">false</enable_pam>
         <username desc="The username of the admin console. Ignored if PAM is enabled."></username>
         <password desc="The password of the admin console. Deprecated on most platforms. Instead, use PAM or coolconfig to set up a secure password."></password>
+        <logging desc="Log admin activities irrespective of logging.level">
+            <admin_login desc="log when an admin logged into the console" type="bool" default="true">true</admin_login>
+            <metrics_fetch desc="log when metrics endpoint is accessed and metrics endpoint authentication is enabled" type="bool" default="true">true</metrics_fetch>
+            <monitor_connect desc="log when external monitor gets connected" type="bool" default="true">true</monitor_connect>
+            <admin_action desc="log when admin does some action for example killing a process" type="bool" default="true">true</admin_action>
+        </logging>
     </admin_console>
 
     <monitors desc="Addresses of servers we connect to on start for monitoring">

--- a/wsd/Admin.hpp
+++ b/wsd/Admin.hpp
@@ -45,6 +45,7 @@ private:
     Admin* _admin;
     int _sessionId;
     bool _isAuthenticated;
+    std::string _clientIPAdress;
 };
 
 class MonitorSocketHandler : public AdminSocketHandler
@@ -170,6 +171,11 @@ public:
 
     // delete entry from _monitorSocket map
     void deleteMonitorSocket(const std::string &uriWithoutParam);
+
+    bool logAdminAction()
+    {
+        return COOLWSD::getConfigValue<bool>("admin_console.logging.admin_action", true);
+    }
 
 private:
     /// Notify Forkit of changed settings.

--- a/wsd/AdminModel.cpp
+++ b/wsd/AdminModel.cpp
@@ -1326,4 +1326,16 @@ void AdminModel::resetMigratingInfo()
     _targetMigServerId = std::string();
 }
 
+std::string AdminModel::getFilename(int pid)
+{
+    for (auto& it : _documents)
+    {
+        if (it.second->getPid() == pid)
+        {
+            return it.second->getFilename();
+        }
+    }
+    return std::string();
+}
+
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/AdminModel.hpp
+++ b/wsd/AdminModel.hpp
@@ -434,6 +434,7 @@ public:
     std::string getTargetMigServerId() { return _targetMigServerId; }
     void sendMigrateMsgAfterSave(bool lastSaveSuccessful, const std::string& docKey);
     std::string getWopiSrcMap();
+    std::string getFilename(int pid);
 
 private:
     void doRemove(std::map<std::string, std::unique_ptr<Document>>::iterator &docIt);

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -2063,7 +2063,7 @@ void COOLWSD::innerInitialize(Application& self)
     // 3) the default parameter of getConfigValue() call. That is used when the
     //    setting is present in coolwsd.xml, but empty (i.e. use the default).
     static const std::map<std::string, std::string> DefAppConfig = {
-        { "accessibility.enable", "false"},
+        { "accessibility.enable", "false" },
         { "allowed_languages", "de_DE en_GB en_US es_ES fr_FR it nl pt_BR pt_PT ru" },
         { "admin_console.enable_pam", "false" },
         { "child_root_path", "jails" },
@@ -2209,7 +2209,11 @@ void COOLWSD::innerInitialize(Application& self)
 #if !MOBILEAPP
         { "help_url", HELP_URL },
 #endif
-        { "product_name", APP_NAME }
+        { "product_name", APP_NAME },
+        { "admin_console.logging.admin_login", "true" },
+        { "admin_console.logging.metrics_fetch", "true" },
+        { "admin_console.logging.monitor_connect", "true" },
+        { "admin_console.logging.admin_action", "true" }
     };
 
     // Set default values, in case they are missing from the config file.

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -1274,6 +1274,15 @@ void FileServerRequestHandler::preprocessAdminFile(const HTTPRequest& request,
         if (resCookies[it].getName() == "jwt")
         {
             jwtToken = resCookies[it].getValue();
+            // when response contains the jwt we can determine that admin console is
+            // accessed for the first time by a specific client
+            bool showLog =
+                COOLWSD::getConfigValue<bool>("admin_console.logging.admin_login", true);
+            if (showLog)
+            {
+                LOG_ANY("Admin logged in with source IPAddress [" << socket->clientAddress()
+                                                                  << ']');
+            }
             break;
         }
     }


### PR DESCRIPTION
- It logs activities like when admin logged in, authenticated metrics endpoint accessed, external monitor getting connected and admin actions like kill the document etc


Change-Id: I059f6b6ee0d8269aec7e3f521622773e348304a3


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

