### PR TITLE
JSDialog: Dialogs shouldn't be taller than viewport

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -73,6 +73,8 @@
 }
 
 .jsdialog-container .ui-dialog-content {
+	max-height: calc( 90vh - 34px);
+	overflow-y: auto !important;
 	background-color: var(--color-background-lighter) !important;
 	font-family: var(--jquery-ui-font);
 	line-height: 1.5;


### PR DESCRIPTION
Don't allow dialogs to grow taller than the web browser's viewport
instead,
 - Set (for dialog's content) a max of 90% of the View height and subtract the dialog's
header. This way the header with the close button stays always visible
 - Set overflow accordingly so it can be  scrollable

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I61a2a41d8b1198fe00b939427cde43d247dc08bb
