### PR TITLE
followup: no copy event is emitted by hitting CTRL+C with no selection

### DIFF
--- a/browser/src/layer/marker/TextInput.js
+++ b/browser/src/layer/marker/TextInput.js
@@ -950,11 +950,12 @@ L.TextInput = L.Layer.extend({
 		this._newlineHint = ev.keyCode === 13;
 		this._linebreakHint = this._newlineHint && ev.shiftKey;
 
-		// In Firefox 117 no copy/cut input event is emitted when CTRL+C/X is pressed with no selection
-		// in a text element with contenteditable='true'. Since no copy/cut event is emitted,
-		// Clipboard.copy/cut is never invoked. So we need to emit it manually.
+		// In Firefox 117 and greater no copy/cut input event is emitted when CTRL+C/X is pressed
+		// with no selection in a text element with contenteditable='true'. Since no copy/cut event
+		// is emitted, Clipboard.copy/cut is never invoked. So we need to emit it manually.
 		// To be honest it seems a Firefox bug. We need to check if they fix it in later version.
-		if (!this.hasAccessibilitySupport() &&  L.Browser.gecko && L.Browser.geckoVersion === '117.0' &&
+		if (!this.hasAccessibilitySupport() && !L.Browser.win &&
+			L.Browser.gecko && L.Browser.geckoVersion >= '117.0' &&
 			ev.ctrlKey && window.getSelection().isCollapsed) {
 			if (ev.key === 'c') {
 				document.execCommand('copy');


### PR DESCRIPTION
This is still occurring also in Firefox 118.
Anyway it seems to never occur on Windows.

Signed-off-by: Marco Cecchetti <marco.cecchetti@collabora.com>
Change-Id: I0e5c643912f2276c60bdba1b2ad1ed801785193f
