### PR TITLE
cool#6893 Avoid zeroing memory we will immediately overwrite in doRender

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -334,6 +334,7 @@ COOL_JS_LST =\
 	src/control/jsdialog/Widget.Combobox.js \
 	src/control/jsdialog/Widget.DrawingArea.js \
 	src/control/jsdialog/Widget.FormulabarEdit.js \
+	src/control/jsdialog/Widget.Frame.js \
 	src/control/jsdialog/Widget.IconView.js \
 	src/control/jsdialog/Widget.LanguageSelector.js \
 	src/control/jsdialog/Widget.MenuButton.js \

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -73,6 +73,8 @@
 }
 
 .jsdialog-container .ui-dialog-content {
+	max-height: calc( 90vh - 34px);
+	overflow-y: auto !important;
 	background-color: var(--color-background-lighter) !important;
 	font-family: var(--jquery-ui-font);
 	line-height: 1.5;

--- a/browser/src/control/Control.FormulaBarJSDialog.js
+++ b/browser/src/control/Control.FormulaBarJSDialog.js
@@ -1,6 +1,12 @@
 /* -*- js-indent-level: 8 -*- */
 /*
- * L.Control.FormulaBarJSDialog
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+/*
+ * L.Control.FormulaBarJSDialog - implementation of formulabar edit field
  */
 
 /* global _ _UNO UNOKey */

--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -1,5 +1,11 @@
 /* -*- js-indent-level: 8 -*- */
 /*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+/*
  * L.Control.JSDialog - class which creates and updates dialogs, popups, snackbar
  */
 

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -105,7 +105,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		this._controlHandlers['grid'] = this._gridHandler;
 		this._controlHandlers['alignment'] = this._alignmentHandler;
 		this._controlHandlers['buttonbox'] = this._buttonBox;
-		this._controlHandlers['frame'] = this._frameHandler;
+		this._controlHandlers['frame'] = JSDialog.frame;
 		this._controlHandlers['deck'] = this._deckHandler;
 		this._controlHandlers['panel'] = this._panelHandler;
 		this._controlHandlers['calcfuncpanel'] = this._calcFuncListPanelHandler;
@@ -1066,52 +1066,6 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		} else {
 			window.app.console.debug('Builder used outside of mobile wizard: please implement the click handler');
 		}
-	},
-
-	_frameHandler: function(parentContainer, data, builder) {
-		if (data.children.length > 1) {
-			var container = L.DomUtil.create('div', 'ui-frame-container ' + builder.options.cssClass, parentContainer);
-			container.id = data.id;
-
-			var frame = L.DomUtil.create('div', 'ui-frame ' + builder.options.cssClass, container);
-			frame.id = data.id + '-frame';
-			var label = L.DomUtil.create('label', 'ui-frame-label ' + builder.options.cssClass, frame);
-			label.innerText = builder._cleanText(builder._extractLabelText(data.children[0]));
-			label.id = data.children[0].id;
-			if (data.children[0].visible === false)
-				L.DomUtil.addClass(label, 'hidden');
-			builder.postProcess(frame, data.children[0]);
-
-			var frameChildren = L.DomUtil.create('div', 'ui-expander-content ' + builder.options.cssClass, container);
-			frameChildren.id = data.id + '-content';
-			label.htmlFor = frameChildren.id;
-			$(frameChildren).addClass('expanded');
-
-			var children = [];
-			for (var i = 1; i < data.children.length; i++) {
-				children.push(data.children[i]);
-			}
-
-			builder.build(frameChildren, children);
-		} else {
-			return builder._containerHandler(parentContainer, data, builder);
-		}
-
-		return false;
-	},
-
-	_extractLabelText: function(data) {
-		if (data.type === 'fixedtext') {
-			return data.visible != false ? data.text : ''; // visible can be undefined too, in that case it means its visible
-		}
-
-		for (var i = 0; i < data.children.length; i++) {
-			var label = this._extractLabelText(data.children[i]);
-			if (label)
-				return label;
-		}
-
-		return '';
 	},
 
 	_deckHandler: function(parentContainer, data, builder) {

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -541,6 +541,8 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			return '';
 		if (text.endsWith('...'))
 			text = text.slice(0, -3);
+		if (text.endsWith('…'))
+			text = text.slice(0, -1);
 		return text.replace('~', '');
 	},
 

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -1076,7 +1076,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			var frame = L.DomUtil.create('div', 'ui-frame ' + builder.options.cssClass, container);
 			frame.id = data.id + '-frame';
 			var label = L.DomUtil.create('label', 'ui-frame-label ' + builder.options.cssClass, frame);
-			label.innerText = builder._cleanText(data.children[0].text);
+			label.innerText = builder._cleanText(builder._extractLabelText(data.children[0]));
 			label.id = data.children[0].id;
 			if (data.children[0].visible === false)
 				L.DomUtil.addClass(label, 'hidden');
@@ -1098,6 +1098,20 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		}
 
 		return false;
+	},
+
+	_extractLabelText: function(data) {
+		if (data.type === 'fixedtext') {
+			return data.visible != false ? data.text : ''; // visible can be undefined too, in that case it means its visible
+		}
+
+		for (var i = 0; i < data.children.length; i++) {
+			var label = this._extractLabelText(data.children[i]);
+			if (label)
+				return label;
+		}
+
+		return '';
 	},
 
 	_deckHandler: function(parentContainer, data, builder) {

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -1,5 +1,11 @@
 /* -*- js-indent-level: 8 -*- */
 /*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+/*
  * L.Control.JSDialogBuilder used for building the native HTML components
  * from the JSON description provided by the server.
  */

--- a/browser/src/control/Control.LanguageDialog.js
+++ b/browser/src/control/Control.LanguageDialog.js
@@ -1,5 +1,11 @@
 /* -*- js-indent-level: 8 -*- */
 /*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+/*
  * L.Control.LanguageDialog used for spellchecking language
  */
 

--- a/browser/src/control/Control.MobileWizard.js
+++ b/browser/src/control/Control.MobileWizard.js
@@ -1,5 +1,11 @@
 /* -*- js-indent-level: 8 -*- */
 /*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+/*
  * L.Control.MobileWizard - main container can contain few MobileWizardWindows
  */
 

--- a/browser/src/control/Control.MobileWizardBuilder.js
+++ b/browser/src/control/Control.MobileWizardBuilder.js
@@ -1,7 +1,13 @@
 /* -*- js-indent-level: 8 -*- */
 /*
- * L.Control.MobileWizardBuilder used for building the native HTML components
- * from the JSON description provided by the server.
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+/*
+ * L.Control.MobileWizardBuilder used for building the native HTML component
+ * variants for mobile/touch devices from the JSON description provided by the server.
  */
 
 /* global $ _UNO _ JSDialog */

--- a/browser/src/control/Control.MobileWizardPopup.js
+++ b/browser/src/control/Control.MobileWizardPopup.js
@@ -1,10 +1,16 @@
 /* -*- js-indent-level: 8 -*- */
 /*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+/*
  * L.Control.MobileWizardPopup - shows a popup with content styled like in mobile-wizard.
-                                 it will be used to show touch-device friendly UI in popups
-								 on devices with smaller screens which are not smartphones
-								 (desktop and tablets). Example of usage: show comments preview
-								 when browser has reduced size.
+ *                               it will be used to show touch-device friendly UI in popups
+ *                               on devices with smaller screens which are not smartphones
+ *                               (desktop and tablets). Example of usage: show comments preview
+ *                               when browser has reduced size.
  */
 
 /* global app $ */

--- a/browser/src/control/Control.MobileWizardWindow.js
+++ b/browser/src/control/Control.MobileWizardWindow.js
@@ -1,5 +1,11 @@
 /* -*- js-indent-level: 8 -*- */
 /*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+/*
  * L.Control.MobileWizardWindow - contains one unique window instance inside mobile-wizard
  */
 

--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -1,6 +1,12 @@
 /* -*- js-indent-level: 8 -*- */
 /*
- * L.Control.Notebookbar
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+/*
+ * L.Control.Notebookbar - container for tabbed menu on the top of application
  */
 
 /* global $ _ _UNO */

--- a/browser/src/control/Control.NotebookbarBuilder.js
+++ b/browser/src/control/Control.NotebookbarBuilder.js
@@ -1,6 +1,12 @@
 /* -*- js-indent-level: 8 -*- */
 /*
- * L.Control.NotebookbarBuilder
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+/*
+ * L.Control.NotebookbarBuilder - builder of native HTML widgets for tabbed menu
  */
 
 /* global $ _ _UNO JSDialog app */

--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -1,6 +1,12 @@
 /* -*- js-indent-level: 8 -*- */
 /*
- * L.Control.NotebookbarCalc
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+/*
+ * L.Control.NotebookbarCalc - definition of notebookbar content in Calc
  */
 
 /* global _ _UNO */

--- a/browser/src/control/Control.NotebookbarDraw.js
+++ b/browser/src/control/Control.NotebookbarDraw.js
@@ -1,6 +1,12 @@
 /* -*- js-indent-level: 8 -*- */
 /*
- * L.Control.NotebookbarDraw
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+/*
+ * L.Control.NotebookbarDraw - definition of notebookbar content in Draw
  */
 
 /* global _ _UNO */

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -1,6 +1,12 @@
 /* -*- js-indent-level: 8 -*- */
 /*
- * L.Control.NotebookbarImpress
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+/*
+ * L.Control.NotebookbarImpress - definition of notebookbar content in Impress
  */
 
 /* global _ _UNO */

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -1,6 +1,12 @@
 /* -*- js-indent-level: 8 -*- */
 /*
- * L.Control.NotebookbarWriter
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+/*
+ * L.Control.NotebookbarWriter - definition of notebookbar content in Writer
  */
 
 /* global _ _UNO */

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -1,7 +1,13 @@
 /* -*- js-indent-level: 8 -*- */
 /*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+/*
  * L.Control.UIManager - initializes the UI elements like toolbars, menubar or ruler
-			 and allows to controll them (show/hide)
+ *			 and allows to controll them (show/hide)
  */
 
 /* global app $ setupToolbar w2ui toolbarUpMobileItems _ Hammer JSDialog */

--- a/browser/src/control/Control.Zotero.js
+++ b/browser/src/control/Control.Zotero.js
@@ -1,6 +1,12 @@
 /* -*- js-indent-level: 8; fill-column: 100 -*- */
 /*
- * L.Control.Zotero
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+/*
+ * L.Control.Zotero - bibliography dialogs implementation
  */
 
 /* global _ Promise app Set */

--- a/browser/src/control/jsdialog/Util.FocusCycle.js
+++ b/browser/src/control/jsdialog/Util.FocusCycle.js
@@ -1,10 +1,12 @@
 /* -*- js-indent-level: 8 -*- */
 /*
- * JSDialog.FocusCycle - focus related functions
- *
  * Copyright the Collabora Online contributors.
  *
  * SPDX-License-Identifier: MPL-2.0
+ */
+
+/*
+ * JSDialog.FocusCycle - focus related functions
  */
 
 /* global JSDialog */

--- a/browser/src/control/jsdialog/Util.ModalHelper.js
+++ b/browser/src/control/jsdialog/Util.ModalHelper.js
@@ -1,10 +1,12 @@
 /* -*- js-indent-level: 8 -*- */
 /*
- * JSDialog.ModalHelper - helper functions for manipulating modals built using jsdialog
- *
  * Copyright the Collabora Online contributors.
  *
  * SPDX-License-Identifier: MPL-2.0
+ */
+
+/*
+ * JSDialog.ModalHelper - helper functions for manipulating modals built using jsdialog
  */
 
 /* global JSDialog app */

--- a/browser/src/control/jsdialog/Widget.Calendar.js
+++ b/browser/src/control/jsdialog/Widget.Calendar.js
@@ -1,5 +1,11 @@
 /* -*- js-indent-level: 8 -*- */
 /*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+/*
  * JSDialog.Calendar - calendar widget
  *
  * Example JSON:
@@ -10,10 +16,6 @@
  *     month: 3,
  * 	   year: 2023
  * }
- *
- * Copyright the Collabora Online contributors.
- *
- * SPDX-License-Identifier: MPL-2.0
  */
 
 /* global JSDialog $ */

--- a/browser/src/control/jsdialog/Widget.Combobox.js
+++ b/browser/src/control/jsdialog/Widget.Combobox.js
@@ -1,5 +1,11 @@
 /* -*- js-indent-level: 8 -*- */
 /*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+/*
  * JSDialog.Combobox - combobox widget with support for custom renders of entries
  *
  * Example JSON:
@@ -12,10 +18,6 @@
  * }
  *
  * customEntryRenderer - specifies if entries have custom content which is rendered by the core
- *
- * Copyright the Collabora Online contributors.
- *
- * SPDX-License-Identifier: MPL-2.0
  */
 
 /* global JSDialog */

--- a/browser/src/control/jsdialog/Widget.DrawingArea.js
+++ b/browser/src/control/jsdialog/Widget.DrawingArea.js
@@ -1,5 +1,11 @@
 /* -*- js-indent-level: 8 -*- */
 /*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+/*
  * JSDialog.DrawingArea - drawing area displaying picture sent from the server
  *
  * Example JSON:
@@ -11,10 +17,6 @@
  *     loading: true, - show additional spinner div
  *     placeholderText: false,  - 'show text next to image'
  * }
- *
- * Copyright the Collabora Online contributors.
- *
- * SPDX-License-Identifier: MPL-2.0
  */
 
 /* global JSDialog $ UNOKey UNOModifier */

--- a/browser/src/control/jsdialog/Widget.FormulabarEdit.js
+++ b/browser/src/control/jsdialog/Widget.FormulabarEdit.js
@@ -1,5 +1,11 @@
 /* -*- js-indent-level: 8 -*- */
 /*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+/*
  * JSDialog.FormulabarEdit - text field in the fromulabar
  *
  * Example JSON:
@@ -13,10 +19,6 @@
  *
  * 'cursor' specifies if user can type into the field or it is readonly
  * 'enabled' editable field can be temporarily disabled
- *
- * Copyright the Collabora Online contributors.
- *
- * SPDX-License-Identifier: MPL-2.0
  */
 
 /* global JSDialog */

--- a/browser/src/control/jsdialog/Widget.Frame.js
+++ b/browser/src/control/jsdialog/Widget.Frame.js
@@ -1,0 +1,69 @@
+/* -*- js-indent-level: 8 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+/*
+ * JSDialog.Frame - frame widget, label + content we can fold
+ *
+ * Example JSON:
+ * {
+ *     id: 'id',
+ *     type: 'frame',
+ *     children: [
+ *         {id: 'label', type: 'fixedtext', text: 'This is label', visible: true}, // could be fixedtext inside container
+ *         {id: 'firstChild', type: 'fixedtext', text: 'This is first element inside frame'},
+ *         ...
+ * 	   ]
+ * }
+ */
+
+/* global JSDialog $ */
+
+function _extractLabelText(data) {
+	if (data.type === 'fixedtext') {
+		return data.visible != false ? data.text : ''; // visible can be undefined too, in that case it means its visible
+	}
+
+	for (var i = 0; i < data.children.length; i++) {
+		var label = this._extractLabelText(data.children[i]);
+		if (label)
+			return label;
+	}
+
+	return '';
+}
+
+JSDialog.frame = function _frameHandler(parentContainer, data, builder) {
+	if (data.children.length > 1) {
+		var container = L.DomUtil.create('div', 'ui-frame-container ' + builder.options.cssClass, parentContainer);
+		container.id = data.id;
+
+		var frame = L.DomUtil.create('div', 'ui-frame ' + builder.options.cssClass, container);
+		frame.id = data.id + '-frame';
+		var label = L.DomUtil.create('label', 'ui-frame-label ' + builder.options.cssClass, frame);
+		label.innerText = builder._cleanText(_extractLabelText(data.children[0]));
+		label.id = data.children[0].id;
+		if (data.children[0].visible === false)
+			L.DomUtil.addClass(label, 'hidden');
+		builder.postProcess(frame, data.children[0]);
+
+		var frameChildren = L.DomUtil.create('div', 'ui-expander-content ' + builder.options.cssClass, container);
+		frameChildren.id = data.id + '-content';
+		label.htmlFor = frameChildren.id;
+		$(frameChildren).addClass('expanded');
+
+		var children = [];
+		for (var i = 1; i < data.children.length; i++) {
+			children.push(data.children[i]);
+		}
+
+		builder.build(frameChildren, children);
+	} else {
+		return builder._controlHandlers['container'](parentContainer, data, builder);
+	}
+
+	return false;
+};

--- a/browser/src/control/jsdialog/Widget.IconView.js
+++ b/browser/src/control/jsdialog/Widget.IconView.js
@@ -1,5 +1,11 @@
 /* -*- js-indent-level: 8 -*- */
 /*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+/*
  * JSDialog.IconView - icon view widget
  *
  * Example JSON:
@@ -11,10 +17,6 @@
  *         { text: 'some text', tooltip: 'some tooltip', image: 'encoded png', selected: false }
  *     ]
  * }
- *
- * Copyright the Collabora Online contributors.
- *
- * SPDX-License-Identifier: MPL-2.0
  */
 
 /* global JSDialog $ */

--- a/browser/src/control/jsdialog/Widget.LanguageSelector.js
+++ b/browser/src/control/jsdialog/Widget.LanguageSelector.js
@@ -1,10 +1,12 @@
 /* -*- js-indent-level: 8 -*- */
 /*
- * JSDialog.LanguageSelector - widgets for selecting spell/grammar checking language
- *
  * Copyright the Collabora Online contributors.
  *
  * SPDX-License-Identifier: MPL-2.0
+ */
+
+/*
+ * JSDialog.LanguageSelector - widgets for selecting spell/grammar checking language
  */
 
 /* global _UNO JSDialog $ */

--- a/browser/src/control/jsdialog/Widget.MenuButton.js
+++ b/browser/src/control/jsdialog/Widget.MenuButton.js
@@ -1,5 +1,11 @@
 /* -*- js-indent-level: 8 -*- */
 /*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+/*
  * JSDialog.MenuButton - button which can trigger some action or open a menu
  *
  * Example JSON:
@@ -11,10 +17,6 @@
  *     command: '.uno:Command',
  *     enabled: false
  * }
- *
- * Copyright the Collabora Online contributors.
- *
- * SPDX-License-Identifier: MPL-2.0
  */
 
 /* global JSDialog $ */

--- a/browser/src/control/jsdialog/Widget.MobileTabControl.js
+++ b/browser/src/control/jsdialog/Widget.MobileTabControl.js
@@ -1,5 +1,11 @@
 /* -*- js-indent-level: 8 -*- */
 /*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+/*
  * JSDialog.MobileTabControl - widgets handling tabs on mobile
  *
  * Example JSON:
@@ -8,10 +14,6 @@
  *     type: 'tabcontrol',
  *     children: [...]
  * }
- *
- * Copyright the Collabora Online contributors.
- *
- * SPDX-License-Identifier: MPL-2.0
  */
 
 /* global JSDialog $ */

--- a/browser/src/control/jsdialog/Widget.MultilineEdit.js
+++ b/browser/src/control/jsdialog/Widget.MultilineEdit.js
@@ -1,5 +1,11 @@
 /* -*- js-indent-level: 8 -*- */
 /*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+/*
  * JSDialog.MultilineEdit - text field with multiple lines and scrollbar
  *
  * Example JSON:
@@ -13,10 +19,6 @@
  *
  * 'cursor' specifies if user can type into the field or it is readonly
  * 'enabled' editable field can be temporarily disabled
- *
- * Copyright the Collabora Online contributors.
- *
- * SPDX-License-Identifier: MPL-2.0
  */
 
 /* global JSDialog */

--- a/browser/src/control/jsdialog/Widget.Progressbar.js
+++ b/browser/src/control/jsdialog/Widget.Progressbar.js
@@ -1,5 +1,11 @@
 /* -*- js-indent-level: 8 -*- */
 /*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+/*
  * JSDialog.Progressbar - progress bar widget
  *
  * Example JSON:
@@ -9,10 +15,6 @@
  *     value: 30,
  *     maxValue: 100
  * }
- *
- * Copyright the Collabora Online contributors.
- *
- * SPDX-License-Identifier: MPL-2.0
  */
 
 /* global JSDialog $ */

--- a/browser/src/control/jsdialog/Widget.ScrolledWindow.js
+++ b/browser/src/control/jsdialog/Widget.ScrolledWindow.js
@@ -1,5 +1,11 @@
 /* -*- js-indent-level: 8 -*- */
 /*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+/*
  * JSDialog.ScrolledWindow - container with scrollbars
  *
  * Example JSON:
@@ -20,10 +26,6 @@
  *     },
  *     children: [...]
  * }
- *
- * Copyright the Collabora Online contributors.
- *
- * SPDX-License-Identifier: MPL-2.0
  */
 
 /* global JSDialog */

--- a/browser/src/control/jsdialog/Widget.TreeView.js
+++ b/browser/src/control/jsdialog/Widget.TreeView.js
@@ -1,5 +1,11 @@
 /* -*- js-indent-level: 8 -*- */
 /*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+/*
  * JSDialog.TreeView - tree view widget with or without header
  *
  * Example JSON:
@@ -29,10 +35,6 @@
  * 'ondemand' property can be set to provide nodes lazy loading
  * 'collapsed' property means, this entry have childrens, but they are not visible, because
  *             this branch is collapsed.
- *
- * Copyright the Collabora Online contributors.
- *
- * SPDX-License-Identifier: MPL-2.0
  */
 
 /* global $ _ JSDialog */

--- a/cypress_test/integration_tests/desktop/impress/editable_area_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/editable_area_spec.js
@@ -43,7 +43,7 @@ describe(['taga11yenabled'], 'Editable area - Basic typing and caret moving', fu
         helper.afterAll(testFileName, this.currentTest.state);
     });
 
-    it('Editing top text shape', function () {
+    it.skip('Editing top text shape', function () {
         // select shape and activate editing
         selectTextShape(1);
         impressHelper.selectTextOfShape(false);
@@ -90,7 +90,7 @@ describe(['taga11yenabled'], 'Editable area - Basic typing and caret moving', fu
         impressHelper.removeShapeSelection();
     });
 
-    it('Editing bottom text shape', function () {
+    it.skip('Editing bottom text shape', function () {
         // select shape and activate editing
         selectTextShape(2);
         impressHelper.selectTextOfShape(false);
@@ -123,7 +123,7 @@ describe(['taga11yenabled'], 'Editable area - Basic typing and caret moving', fu
         impressHelper.removeShapeSelection();
     });
 
-    it('Editing both text shapes', function () {
+    it.skip('Editing both text shapes', function () {
         // select top shape and activate editing
         selectTextShape(1);
         impressHelper.selectTextOfShape(false);

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -3167,7 +3167,8 @@ void lokit_main(
 #if !MOBILEAPP
 
         std::vector<int> shareFDs;
-        shareFDs.push_back(ProcSMapsFile);
+        if (ProcSMapsFile >= 0)
+            shareFDs.push_back(ProcSMapsFile);
 
         if (isURPEnabled())
         {

--- a/net/HttpHelper.cpp
+++ b/net/HttpHelper.cpp
@@ -77,8 +77,12 @@ void sendDeflatedFileContent(const std::shared_ptr<StreamSocket>& socket, const 
         const long unsigned int size = file.gcount();
         long unsigned int compSize = compressBound(size);
         std::unique_ptr<char[]> cbuf = std::make_unique<char[]>(compSize);
-        compress2((Bytef*)&cbuf[0], &compSize, (Bytef*)&buf[0], size, Level);
-
+        int result = compress2((Bytef*)&cbuf[0], &compSize, (Bytef*)&buf[0], size, Level);
+        if (result != Z_OK)
+        {
+             LOG_ERR("failed compress of: " << path << " result: " << result);
+             return;
+        }
         if (size > 0)
             socket->send(&cbuf[0], compSize, true);
     }

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -626,7 +626,7 @@ bool SocketPoll::insertNewUnixSocket(
     req.set("Pragma", "no-cache");
 
     LOG_TRC("Requesting upgrade of websocket at path " << pathAndQuery << " #" << socket->getFD());
-    if (!shareFDs)
+    if (!shareFDs || shareFDs->empty())
     {
         socket->send(req);
     }

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -442,6 +442,7 @@ public:
     void handleTileCombinedRequest(TileCombined& tileCombined, bool forceKeyframe,
                                    const std::shared_ptr<ClientSession>& session);
     void sendRequestedTiles(const std::shared_ptr<ClientSession>& session);
+    void sendTileCombine(const TileCombined& tileCombined);
 
     enum ClipboardRequest {
         CLIP_REQUEST_SET,

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -748,17 +748,22 @@ void FileServerRequestHandler::readDirToHash(const std::string &basePath, const 
 
         else if (S_ISREG(fileStat.st_mode))
         {
+            z_stream strm;
+            strm.zalloc = Z_NULL;
+            strm.zfree = Z_NULL;
+            strm.opaque = Z_NULL;
+            int result = deflateInit2(&strm, Z_DEFAULT_COMPRESSION, Z_DEFLATED, 31, 8, Z_DEFAULT_STRATEGY);
+            if (result != Z_OK)
+            {
+                 LOG_ERR("Failed to deflateInit2, result: " << result);
+                 continue;
+            }
+
             fileCount++;
             filesRead.append(currentFile->d_name);
             filesRead += ' ';
 
             std::ifstream file(basePath + relPath, std::ios::binary);
-
-            z_stream strm;
-            strm.zalloc = Z_NULL;
-            strm.zfree = Z_NULL;
-            strm.opaque = Z_NULL;
-            deflateInit2(&strm, Z_DEFAULT_COMPRESSION, Z_DEFLATED, 31, 8, Z_DEFAULT_STRATEGY);
 
             std::unique_ptr<char[]> buf = std::make_unique<char[]>(fileStat.st_size);
             std::string compressedFile;


### PR DESCRIPTION
On a long running session flamegraph, we are spending 4% of the time zeroing this buffer, which we will immediately overwrite with data. Just skip the zeroing phase, and simplify the code.


Change-Id: I2b5e17e4d4cf3076d0aa244d96f9987eec3d2010


* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

