### PR TITLE
Scripts: profile-cool: Add echo: openSUSE dependency

### DIFF
--- a/scripts/profile-cool
+++ b/scripts/profile-cool
@@ -12,6 +12,7 @@ fi
 if ! which flamegraph.pl > /dev/null 2>&1; then
     echo "no flamegraph.pl found"
     echo "On fedora install systemwide with: sudo dnf install flamegraph"
+    echo "On openSUSE Leap install systemwide with: sudo zypper install perl-Devel-NYTProf"
     echo "Otherwise install locally manually into ~/FlameGraph"
     exit 1
 fi


### PR DESCRIPTION
Probably people should just run "cnf flamegraph.pl" in their own
distribution. Nevertheless and because there are multiple flamegraph
packages (unrelated to this one) on the official and community
repositories, probably best to mention the package where people can
get the mentioned perl profiler.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Icd4139fd01418892eaad7c23d6346d9fda543b7d
