### PR TITLE
Fix CSS selector: make checkboxes visible in light mode

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -432,7 +432,7 @@ input[type='checkbox'].autofilter, .jsdialog input[type='checkbox'] {
 	margin: 1px 8px;
 }
 
-[data-theme='dark'] input[type='checkbox'].autofilter, .jsdialog input[type='checkbox'] {
+[data-theme='dark'] input[type='checkbox'].autofilter, [data-theme='dark'] .jsdialog input[type='checkbox'] {
 	background: url('images/dark/lc_checkboxoff.svg') no-repeat center;
 }
 
@@ -441,7 +441,7 @@ input[type='checkbox']:checked.autofilter, .jsdialog input[type='checkbox']:chec
 	background-image: url('images/lc_checkbox.svg');
 }
 
-[data-theme='dark'] input[type='checkbox']:checked.autofilter, .jsdialog input[type='checkbox']:checked {
+[data-theme='dark'] input[type='checkbox']:checked.autofilter, [data-theme='dark'] .jsdialog input[type='checkbox']:checked {
 	background-image: url('images/dark/lc_checkbox.svg');
 }
 


### PR DESCRIPTION
Change-Id: I6e8194ea456e4af3104754cf9219be22f135c042


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

