### PR TITLE
ProcSMapsFile might not be a valid file descriptor

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -3167,7 +3167,8 @@ void lokit_main(
 #if !MOBILEAPP
 
         std::vector<int> shareFDs;
-        shareFDs.push_back(ProcSMapsFile);
+        if (ProcSMapsFile >= 0)
+            shareFDs.push_back(ProcSMapsFile);
 
         if (isURPEnabled())
         {

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -626,7 +626,7 @@ bool SocketPoll::insertNewUnixSocket(
     req.set("Pragma", "no-cache");
 
     LOG_TRC("Requesting upgrade of websocket at path " << pathAndQuery << " #" << socket->getFD());
-    if (!shareFDs)
+    if (!shareFDs || shareFDs->empty())
     {
         socket->send(req);
     }


### PR DESCRIPTION
in which case don't send it, which then implies we might have an empty shareFDs which we can treat the same as a nonexisting shareFDs


Change-Id: I80a78a01c69dbee5ee28a64442a5069a6c2b4dbe


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

