### PR TITLE
Fix spinfield doesn't adjust the value

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -427,7 +427,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			data = Math.abs(data);
 			var str = '' + data;
 			var dot = str.indexOf('.');
-			return dot ? 1 / Math.pow(10, str.length - dot - 1) : 1;
+			return dot > 0 ? 1 / Math.pow(10, str.length - dot - 1) : 1;
 		};
 
 		if (data.min != undefined)


### PR DESCRIPTION

Signed-off-by: Darshan-upadhyay1110 <darshan.upadhyay@collabora.com>
Change-Id: I740f86e9477656d371ba3b8793bff99671444d7c

    - Condition modified for getPrecision.
    - it was not handling the cases for dot value less then 0.
   
* Resolves: #7236
* Target version: master 

