### PR TITLE
a11y: accessible description to describe how to turn on accessible mode

### DIFF
--- a/browser/src/layer/marker/TextInput.js
+++ b/browser/src/layer/marker/TextInput.js
@@ -8,7 +8,7 @@
  * text area itself.
  */
 
-/* global app */
+/* global app _ */
 
 L.TextInput = L.Layer.extend({
 	initialize: function() {
@@ -437,6 +437,18 @@ L.TextInput = L.Layer.extend({
 		this._setupStyles();
 
 		this._emptyArea();
+
+		if (!this.hasAccessibilitySupport()) {
+			var warningMessage =
+				_('Screen reader support for text content is disabled. ') +
+				_('You need to enable it both at server level and in the UI. ') +
+				_('Look for the accessibility section in coolwsd.xml for server setting. ') +
+				_('Also check the accessibility support toggle under %parentControl.').replace(
+					'%parentControl',
+					window.userInterfaceMode === 'notebookbar' ? _('the Help tab') : _('the View menu')
+				);
+			this._textArea.setAttribute('aria-description', warningMessage);
+		}
 	},
 
 	_setupStyles: function() {


### PR DESCRIPTION
Set up accessible text through aria-description for describing how to
enable accessibility support for text content when it is disabled.

The description is reported by the screen reader on document load and
on explicit request to read current text content.

Signed-off-by: Marco Cecchetti <marco.cecchetti@collabora.com>
Change-Id: I439b7703c15d3b38c39181d27c11da438834c414
