### PR TITLE
annotation: make sure comment list is fetched correctly

### DIFF
--- a/browser/src/layer/tile/CommentSection.ts
+++ b/browser/src/layer/tile/CommentSection.ts
@@ -909,7 +909,7 @@ export class Comment extends CanvasSectionObject {
 	}
 
 	public isAnyEdit (): boolean {
-		var commentList = this.sectionProperties.commentList;
+		var commentList = app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).sectionProperties.commentList;
 		for (var i in commentList) {
 			var modifyNode = commentList[i].sectionProperties.nodeModify;
 			var replyNode = commentList[i].sectionProperties.nodeReply;


### PR DESCRIPTION
problem:
this caused problem in autosaved comments,
when comment list is empty autosaved comments may be closed when focus is lost


Change-Id: I1fc2d087828ce44495001f97b5323dffb8adb2ef


* Target version: master 


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

