### PR TITLE
Fixed the name of the new comment.

### DIFF
--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -40,8 +40,8 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 				author: this._map.getViewName(this._viewId)
 			};
 
-			if (app.sectionContainer.doesSectionExist(newComment.name)) // If adding a new comment has failed, we need to remove the leftover.
-				app.sectionContainer.removeSection(newComment.name);
+			if (app.sectionContainer.doesSectionExist('new comment')) // If adding a new comment has failed, we need to remove the leftover.
+				app.sectionContainer.removeSection('new comment');
 
 			comment = app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).add(newComment);
 			comment.show();


### PR DESCRIPTION
With this fix, user can open a new commen popup without closing a previous new comment popup.

Without this, a new comment section lingers at the background and new comment command fails until user refreshes page.


Change-Id: If7f151eb11d3f5d26dae2ca6331eb5dc0dfd9881


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

