### PR TITLE
Fix failing cypress tests in writer

### DIFF
--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -1191,7 +1191,7 @@ app.definitions.Socket = L.Class.extend({
 			this._onHyperlinkClickedMsg(textMsg);
 		}
 
-		if (!this._map._docLayer || this._handlingDelayedMessages) {
+		if (!this._isReady() || !this._map._docLayer || this._handlingDelayedMessages) {
 			this._delayMessage(textMsg);
 		} else {
 			this._map._docLayer._onMessage(textMsg, e.image);


### PR DESCRIPTION
This reverts partially commit af31870.

From the CI history I see that first time when 4 tests failed is on that PR. Which also passed only sometimes before merge:

https://cpci.cbg.collabora.co.uk:8080/job/github_online_master_debug_vs_co-23.05/7848/

Failing tests:
writer/table_operation_spec.js
writer/top_toolbar_spec.js
writer/track_changes_spec.js
writer/undo_redo_spec.js
