### PR TITLE
jsdialog: avoid error when container is missing

### DIFF
--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -543,7 +543,8 @@ L.Control.JSDialog = L.Control.extend({
 			if (dialogs.length) {
 				var lastKey = dialogs[dialogs.length - 1];
 				var container = this.dialogs[lastKey].container;
-				container.focus();
+				if (container)
+					container.focus();
 				var initialFocusElement = JSDialog.GetFocusableElements(container);
 				if (initialFocusElement && initialFocusElement.length)
 					initialFocusElement[0].focus();

--- a/browser/src/control/jsdialog/Util.FocusCycle.js
+++ b/browser/src/control/jsdialog/Util.FocusCycle.js
@@ -12,6 +12,9 @@
 /* global JSDialog */
 
 function getFocusableElements(container) {
+	if (!container)
+		return null;
+
 	var ret = container.querySelectorAll('[tabIndex="0"]:not(.jsdialog-begin-marker, .jsdialog-end-marker):not([disabled]):not(.hidden)');
 	if (!ret.length)
 		ret = container.querySelectorAll('input:not([disabled]):not(.hidden)');


### PR DESCRIPTION
TypeError was noticed where container was undefined. This was case where snackbar was closed.
