### PR TITLE
Assertion in DocumentBroker::sendRequestedTiles fails on running cypr…

### DIFF
--- a/wsd/TileDesc.hpp
+++ b/wsd/TileDesc.hpp
@@ -163,7 +163,9 @@ public:
         return intersects(other);
     }
 
-    bool onSameRow(const TileDesc& other) const
+    // return false if the TileDesc cannot appear in the same TileCombine
+    // because their fields differ for the shared tilecombine case
+    bool sameTileCombineParams(const TileDesc& other) const
     {
         if (other.getPart() != getPart() ||
             other.getEditMode() != getEditMode() ||
@@ -175,6 +177,13 @@ public:
         {
             return false;
         }
+        return true;
+    }
+
+    bool onSameRow(const TileDesc& other) const
+    {
+        if (!sameTileCombineParams(other))
+            return false;
 
         return other.getTilePosY() + other.getTileHeight() >= getTilePosY() &&
                other.getTilePosY() <= getTilePosY() + getTileHeight();


### PR DESCRIPTION
…ess impress tests

make -C cypress_test check-desktop

asserts seen in cypress_test/cypress/wsd_logs/coolwsd_output.log of:

coolwsd: wsd/DocumentBroker.cpp:3134: void DocumentBroker::sendTileCombine(const TileCombined&): Assertion `!newTileCombined.hasDuplicates()' failed.

If we check for, and don't reuse, an old request with a different NormalizedViewId then we could end up with multiple requests with different NormalizedViewIds that end up in the same final tilecombine.

similarly there was no check for different modes ending up in the same tilecombine.

just split out the logic we have to see if two tiles have the same properties that appear as a shared set of properties for tilecombine and use that in the two relevant places.


Change-Id: Ieb2ee0e85f124dd57c6b050e5b669dd808cf6bbf


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

