### PR TITLE
Fix JS error on translations.

### DIFF
--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -520,10 +520,11 @@ L.Map.include({
 		}
 
 		//translatable screenshots
-		var supportedLanguage = ['fr', 'it', 'de', 'es', 'pt-BR'];
+		var supportedLanguage = ['fr', 'it', 'es', 'pt-BR'];
 		var currentLanguage = String.locale;
 		if (supportedLanguage.indexOf(currentLanguage) >= 0) {
-			translatableContent = $(contentElement.querySelectorAll('.screenshot')).querySelectorAll('img');
+			translatableContent = $(contentElement.querySelectorAll('.screenshot img'));
+
 			for (i = 0, max = translatableContent.length; i < max; i++) {
 				translatableContent[i].src = translatableContent[i].src.replace('/en/', '/'+currentLanguage+'/');
 			}


### PR DESCRIPTION
queryselectorall('something').queryselectorall('something else') fails.

^ This JS error is fixed.

Also we don't have specific images for German help page. So we removed the "de" from that language list.


Change-Id: I69b56e8f4bd2b92835c4aca9c2284750f3df9455


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

