### PR TITLE
Fix media request error

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -3315,7 +3315,8 @@ void DocumentBroker::handleMediaRequest(std::string range,
         {
             // For now, we only support file:// schemes.
             // In the future, we may/should support http.
-            const std::string path = getJailRoot() + url.substr(sizeof("file://") - 1);
+            const std::string root = COOLWSD::NoCapsForKit ? "/" : getJailRoot();
+            const std::string path = root + url.substr(sizeof("file://") - 1);
 
             auto session = std::make_shared<http::server::Session>();
             session->asyncUpload(path, "video/mp4", range);


### PR DESCRIPTION
It fixes richdocumentscode case when trying to request media:
[ websrv_poll ] ERR  #-1: Failed to open file [.../9a2gf9.ogg] for uploading| net/HttpRequest.hpp:1603
