### PR TITLE
Fix media request error

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -3300,7 +3300,16 @@ void DocumentBroker::handleMediaRequest(std::string range,
         {
             // For now, we only support file:// schemes.
             // In the future, we may/should support http.
-            const std::string path = getJailRoot() + url.substr(sizeof("file://") - 1);
+#if !MOBILEAPP
+            // We always extract media files in /tmp. Normally, we are in jail (chroot),
+            // and this would need to be accessed from WSD through the JailRoot path.
+            // But, when we have NoCapsForKit there is no jail, so the media file ends
+            // up in the host (AppImage) /tmp
+            const std::string root = COOLWSD::NoCapsForKit ? "/" : getJailRoot();
+#else
+            const std::string root = getJailRoot();
+#endif
+            const std::string path = root + url.substr(sizeof("file://") - 1);
 
             auto session = std::make_shared<http::server::Session>();
             session->asyncUpload(path, "video/mp4", range);


### PR DESCRIPTION
It fixes richdocumentscode case when trying to request media:
`[ websrv_poll ] ERR  #-1: Failed to open file [.../9a2gf9.ogg] for uploading| net/HttpRequest.hpp:1603`