### PR TITLE
cid#318817 avoid Uncaught exception

### DIFF
--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -5495,8 +5495,11 @@ class COOLWSDServer
     // allocate port & hold temporarily.
     std::shared_ptr<ServerSocket> _serverSocket;
 public:
-    COOLWSDServer() :
-        _acceptPoll("accept_poll")
+    COOLWSDServer()
+        : _acceptPoll("accept_poll")
+#if !MOBILEAPP
+        , _admin(Admin::instance())
+#endif
     {
     }
 
@@ -5534,7 +5537,7 @@ public:
         WebServerPoll->startThread();
 
 #if !MOBILEAPP
-        Admin::instance().start();
+        _admin.start();
 #endif
     }
 
@@ -5544,7 +5547,7 @@ public:
         if (WebServerPoll)
             WebServerPoll->joinThread();
 #if !MOBILEAPP
-        Admin::instance().stop();
+        _admin.stop();
 #endif
     }
 
@@ -5609,7 +5612,7 @@ public:
 
 #if !MOBILEAPP
         os << "Admin poll:\n";
-        Admin::instance().dumpState(os);
+        _admin.dumpState(os);
 
         // If we have any delaying work going on.
         Delay::dumpState(os);
@@ -5641,6 +5644,10 @@ private:
     };
     /// This thread & poll accepts incoming connections.
     AcceptPoll _acceptPoll;
+
+#if !MOBILEAPP
+    Admin& _admin;
+#endif
 
     /// Create the internal only, local socket for forkit / kits prisoners to talk to.
     std::shared_ptr<ServerSocket> findPrisonerServerPort()

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -1539,6 +1539,10 @@ private:
     /// True iff the config per_document.always_save_on_exit is true.
     const bool _alwaysSaveOnExit;
 
+#if !MOBILEAPP
+    Admin& _admin;
+#endif
+
     // Last member.
     /// The UnitWSD instance. We capture it here since
     /// this is our instance, but the test framework


### PR DESCRIPTION
and

cid#318819 Uncaught exception

take a reference in the COOLWSD/DocumentBroker ctor, so indicating it exists before the calls in the COOLWSD/DocumentBroker dtor, and so the Admin ctor doesn't throw during the COOLWSD/DocumentBroker dtor.


Change-Id: I8190cc3594a5f81fedd355aeadcca45e532bda90


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

