### PR TITLE
Avoid using undefine in custom button insertion

### DIFF
--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -561,7 +561,7 @@ L.Control.UIManager = L.Control.extend({
 	// UI modification
 
 	insertButtonToClassicToolbar: function(button) {
-		if (!w2ui['editbar'].get(button.id)) {
+		if (w2ui['editbar'] && !w2ui['editbar'].get(button.id)) {
 			if (this.map.isEditMode()) {
 				// add the css rule for the image
 				var style = $('html > head > style');


### PR DESCRIPTION
If postmessage to insert custom button will arrive early before we initialized notebookbar it could
fail in insertion into compact mode toolbar due to not existing toolbar.

This prevents us from that error. It will be not added at the time of postmessage execution
but we remember all the custom buttons in special
array, so when UI will be initialized it will be added there.

