### PR TITLE
Help window was too narrow

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1772,3 +1772,8 @@ kbd,
 #modal-dialog-copy_paste_download_progress .ui-dialog-content {
 	width: 450px;
 }
+
+/* help */
+#modal-dialog-online-help-content-box {
+	min-width: 75%;
+}


### PR DESCRIPTION
Change-Id: I245e0979cd069f13eb8237eb155aa1760289a180


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

I did not modify the keyboard shortcut window, because I found that it is better when keyboard shortcuts and their descriptions are close to each other.

### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

