### PR TITLE
jsdialog: fix scrollbars inside dialogs

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -80,6 +80,19 @@
 	line-height: 1.5;
 }
 
+#SortKeyWindow {
+	/* As used in .jsdialog-container .ui-dialog-content 90 % of the viewport
+	   minus 352px:
+		- 34px the dialog's header
+		- 112px the next sibling
+		- 50px the dialog's buttons
+		- 80px status bar and calc sheet bar
+		- 38px formulabar
+		- 38px document-header
+   */
+	max-height: calc( 90vh - 352px);
+}
+
 .jsdialog-container .ui-dialog-content > div:not(.ui-scrollwindow) {
 	overflow: hidden; /* don't inherit scrollbar from parent */
 }

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -80,6 +80,10 @@
 	line-height: 1.5;
 }
 
+.jsdialog-container .ui-dialog-content > div:not(.ui-scrollwindow) {
+	overflow: hidden; /* don't inherit scrollbar from parent */
+}
+
 .jsdialog-container .lokdialog.ui-dialog-content.ui-widget-content {
 	overflow: hidden;
 }

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -206,6 +206,10 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 	overflow: auto;
 	max-height: 500px;
 	max-width: 700px;
+}
+/* - Also used in SpellingDialog where suggestion come in form
+     of an image*/
+.jsdialog.ui-scrollwindow.has-ui-drawing-area {
 	width: max-content;
 }
 

--- a/browser/src/control/jsdialog/Widget.ScrolledWindow.js
+++ b/browser/src/control/jsdialog/Widget.ScrolledWindow.js
@@ -30,10 +30,28 @@
 
 /* global JSDialog */
 
+function _hasDrawingAreaInside(children) {
+	if (!children)
+		return false;
+
+	for (var i in children) {
+		if (children[i].type === 'drawingarea')
+			return true;
+		if (_hasDrawingAreaInside(children[i].children))
+			return true;
+	}
+
+	return false;
+}
+
 function _scrolledWindowControl(parentContainer, data, builder) {
 	var scrollwindow = L.DomUtil.create('div', builder.options.cssClass + ' ui-scrollwindow', parentContainer);
 	if (data.id)
 		scrollwindow.id = data.id;
+
+	// drawing areas inside scrollwindows should be not cropped so we add special class
+	if (_hasDrawingAreaInside(data.children))
+		L.DomUtil.addClass(scrollwindow, 'has-ui-drawing-area');
 
 	var content = L.DomUtil.create('div', builder.options.cssClass + ' ui-scrollwindow-content', scrollwindow);
 


### PR DESCRIPTION
This fixes side effect from commit a1b2091ae622437f531f1126a8de9c143b06be68
JSDialog: Dialogs shouldn't be taller than viewport

which introduced scrollbars to dialogs when not needed, examples:
   Writer -> Format -> Character
   Calc -> Data -> Validity
