### PR TITLE
avoid recreating the core notebookbar when we don't have to

### DIFF
--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -102,7 +102,10 @@ L.Control.Notebookbar = L.Control.extend({
 
 	onRemove: function() {
 		clearTimeout(this.retry);
-		this.resetInCore();
+		// in the refresh case we don't have to expensively destroy the
+		// code-side navigator to recreate it
+		if (!this.map.uiManager.refreshingNotebookbar)
+		    this.resetInCore();
 		this.map.off('contextchange', this.onContextChange, this);
 		this.map.off('updatepermission', this.onUpdatePermission, this);
 		this.map.off('notebookbar');

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -15,6 +15,7 @@ L.Control.UIManager = L.Control.extend({
 	mobileWizard: null,
 	documentNameInput: null,
 	blockedUI: false,
+	refreshingNotebookbar: false,
 	busyPopupTimer: null,
 	customButtons: [], // added by WOPI InsertButton
 	previousTheme: null,
@@ -457,6 +458,9 @@ L.Control.UIManager = L.Control.extend({
 
 	refreshNotebookbar: function() {
 			var selectedTab = $('.ui-tab.notebookbar[aria-selected="true"]').attr('id') || 'Home-tab-label';
+
+			this.refreshingNotebookbar = true;
+			var wasNotebookbarLoadedOnCore = this.notebookbar && this.notebookbar._isNotebookbarLoadedOnCore;
 			this.removeNotebookbarUI();
 			this.createNotebookbarControl(this.map.getDocType());
 			if (this._map._permission === 'edit') {
@@ -465,7 +469,10 @@ L.Control.UIManager = L.Control.extend({
 			$('#' + selectedTab).click();
 			this.makeSpaceForNotebookbar();
 			this.notebookbar._showNotebookbar = true;
+			this.notebookbar._isNotebookbarLoadedOnCore = wasNotebookbarLoadedOnCore;
 			this.notebookbar.showTabs();
+			this.refreshingNotebookbar = false;
+
 			$('#map').addClass('notebookbar-opened');
 			this.insertCustomButtons();
 			this.map.sendInitUNOCommands();


### PR DESCRIPTION
this is inspired by trying to reproduce:

https://github.com/CollaboraOnline/online/issues/7428

Where I see that we tear down and recreate the notebookbar when we switch from light to dark mode, and we recreate it when Zotero support is enabled.


Change-Id: I4a95af357a95931df12ff96d9378b235d27e3eaf


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

