### PR TITLE
Prevent mouse button up event to click on menu item.

### DIFF
--- a/browser/src/control/Control.ColumnHeader.ts
+++ b/browser/src/control/Control.ColumnHeader.ts
@@ -143,6 +143,8 @@ export class ColumnHeader extends Header {
 		this.context.strokeStyle = this._borderColor;
 		this.context.lineWidth = app.dpiScale;
 		this.context.strokeRect(startX - 0.5, 0.5, entry.size, this.size[1]);
+
+        this._map._contextMenu.stopRightMouseUpEvent();
 	}
 
 	getHeaderEntryBoundingClientRect (index: number): Partial<DOMRect> {

--- a/browser/src/control/Control.ContextMenu.js
+++ b/browser/src/control/Control.ContextMenu.js
@@ -296,7 +296,19 @@ L.Control.ContextMenu = L.Control.extend({
 		}
 
 		return contextMenu;
-	}
+	},
+
+    // Prevents right mouse button's mouseup event from triggering menu item accidentally.
+    stopRightMouseUpEvent: function() {
+        var menuItems = document.getElementsByClassName('context-menu-item');
+
+        for (var i = 0 ; i < menuItems.length; i++) {
+            menuItems[i].addEventListener('mouseup', function(e) {
+                if (e.button == 2) // Is a right mouse button event?
+                    e.stopPropagation();
+            });
+        }
+    }
 });
 
 L.control.contextMenu = function (options) {

--- a/browser/src/control/Control.RowHeader.ts
+++ b/browser/src/control/Control.RowHeader.ts
@@ -140,6 +140,8 @@ export class RowHeader extends cool.Header {
 		this.context.strokeStyle = this._borderColor;
 		this.context.lineWidth = app.dpiScale;
 		this.context.strokeRect(0.5, startY - 0.5, this.size[0], entry.size);
+
+        this._map._contextMenu.stopRightMouseUpEvent();
 	}
 
 	getHeaderEntryBoundingClientRect (index: number): Partial<DOMRect> {


### PR DESCRIPTION
In some case[*] when we right click on row header and release mouse button, first element of the context menu is invoked. To prevent this, I planned just prevent the mouseup event on context menu items but it prevented to do click event too.

[*] 1920x1080 resolution with %75 browser zoom


Change-Id: I28299e7a7cf83eaed27ef4ed6c3555fb2cc80682


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

