### PR TITLE
jsdialog: treegrid

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -370,6 +370,7 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 	overflow-x: hidden;
 	max-width: 1000px;
 	min-width: 150px;
+	width: max-content;
 	padding: 1px;
 	padding-inline-end: 3px;
 }
@@ -518,7 +519,7 @@ input[type='checkbox']:checked.autofilter, .jsdialog input[type='checkbox']:chec
 	vertical-align: top;
 }
 
-.ui-treeview tr:not([aria-expanded]) > td:first-child::before {
+.ui-treeview tr[aria-level]:not([aria-expanded]) > td:first-child::before {
 	font-family: monospace;
 	content: 'V';
 	color: transparent;
@@ -1820,7 +1821,3 @@ kbd,
 	min-width: 75%;
 }
 
-/* Review -> Manage changes */
-#AcceptRejectChangesDialog .ui-treeview {
-	width: max-content;
-}

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -283,7 +283,8 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 }
 
 .ui-expander-label::before,
-.ui-treeview-expandable.collapsed > .ui-treeview-expander::before {
+.ui-treeview-expandable.collapsed > .ui-treeview-expander::before,
+.ui-treeview tr[aria-expanded='false'] > td > .ui-treeview-expander::before {
 	display: inline-block;
 	content: 'V';
 	color: transparent;
@@ -293,7 +294,8 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 }
 
 .ui-expander-label.expanded::before,
-.ui-treeview-expandable:not(.collapsed) > .ui-treeview-expander::before  {
+.ui-treeview-expandable:not(.collapsed) > .ui-treeview-expander::before,
+.ui-treeview tr[aria-expanded='true'] > td > .ui-treeview-expander::before  {
 	content: 'V';
 	color: transparent;
 	margin-inline-end: 7px;
@@ -303,14 +305,17 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 }
 
 [data-theme='dark'] .ui-expander-label::before,
-[data-theme='dark'] .ui-treeview-expandable > .ui-treeview-expander::before  {
+[data-theme='dark'] .ui-treeview-expandable > .ui-treeview-expander::before,
+[data-theme='dark'] .ui-treeview tr[aria-expanded] > td > .ui-treeview-expander::before  {
 	filter: brightness(1);
 }
 
-.ui-treeview-expandable > .ui-treeview-expander::before {
+.ui-treeview-expandable > .ui-treeview-expander::before,
+.ui-treeview tr[aria-expanded] > td > .ui-treeview-expander::before {
 	margin-inline-end: 7px !important;
 	display: inline-block;
 	position: relative !important;
+	cursor: pointer;
 }
 
 .ui-treeview-header-sort-icon::after {
@@ -332,6 +337,7 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 	height: var(--btn-size);
 	width: var(--btn-size);
 	margin-inline-end: 8px;
+	vertical-align: middle;
 }
 
 .ui-expander-label.expanded {
@@ -455,6 +461,10 @@ input[type='checkbox']:checked.autofilter, .jsdialog input[type='checkbox']:chec
 	padding-right: 10px;
 }
 
+.ui-treeview .ui-listview-entry td {
+	vertical-align: middle;
+}
+
 .ui-treeview-entry.selected,
 .ui-listview-entry.selected {
 	background-color: var(--color-background-dark);
@@ -483,6 +493,38 @@ input[type='checkbox']:checked.autofilter, .jsdialog input[type='checkbox']:chec
 .ui-treeview.droptarget:hover{
 	border: 1px solid #888;
 	box-shadow: 0 0 2px 0 #777;
+}
+
+/* tree grid */
+
+.ui-treeview tr[aria-level='2'] > td:first-child {
+	padding-left: 2.5ch;
+}
+
+.ui-treeview tr[aria-level='3'] > td:first-child {
+	padding-left: 5ch;
+}
+
+.ui-treeview tr[aria-level='4'] > td:first-child {
+	padding-left: 7.5ch;
+}
+
+.ui-treeview tr[aria-level='5'] > td:first-child {
+	padding-left: 10ch;
+}
+
+.ui-treeview tr > td:first-child .ui-treeview-expander {
+	display: inline-block;
+	vertical-align: top;
+}
+
+.ui-treeview tr:not([aria-expanded]) > td:first-child::before {
+	font-family: monospace;
+	content: 'V';
+	color: transparent;
+	display: inline-block;
+	margin-inline-end: 7px;
+	vertical-align: top;
 }
 
 /* context menu */

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1777,3 +1777,8 @@ kbd,
 #modal-dialog-online-help-content-box {
 	min-width: 75%;
 }
+
+/* Review -> Manage changes */
+#AcceptRejectChangesDialog .ui-treeview {
+	width: max-content;
+}

--- a/browser/src/control/jsdialog/Widget.TreeView.js
+++ b/browser/src/control/jsdialog/Widget.TreeView.js
@@ -30,6 +30,21 @@
  *     ]
  * }
  *
+ * c) with header and is a tree, not a list
+ * {
+ *     id: 'id',
+ *     type: 'treelistbox',
+ *     headers: [ { text: 'first column' }, { text: 'second' }],
+ *     entries: [
+ *         { row: 0, columns [ { text: 'a' }, { collapsed: 'collapsedIcon.svg' } ] },
+ *         { row: 1, columns [ { text: 'a' }, { collapsed: 'collapsedIcon.svg' } ],
+ * 			   children: [
+ *                 { row: 2, columns [ { text: 'a2' }, { expanded: 'expandedIcon.svg' }, selected: true ]}
+ *             ]
+ *         },
+ *     ]
+ * }
+ *
  * 'row' property is used in the callback to differentiate entries
  * 'state' property defines if entry has the checkbox (false/true), when is missing - no checkbox
  * 'ondemand' property can be set to provide nodes lazy loading

--- a/browser/src/control/jsdialog/Widget.TreeView.js
+++ b/browser/src/control/jsdialog/Widget.TreeView.js
@@ -408,7 +408,7 @@ function _makeTreeFlat(entries, depth) {
 	return flatList;
 }
 
-function _createHeaders(tbody, data, builder) {
+function _createHeaders(tbody, data, builder, depth) {
 	var headers = L.DomUtil.create('tr', builder.options.cssClass + ' ui-treeview-header', tbody);
 	headers.setAttribute('role', 'row');
 	var hasCheckboxes = data.entries && data.entries.length && data.entries[0].state !== undefined;
@@ -417,7 +417,7 @@ function _createHeaders(tbody, data, builder) {
 	var hasIcons = data.entries && data.entries.length && _hasIcon(data.entries[0].columns);
 	if (hasIcons)
 		data.headers = [{ text: '' }].concat(data.headers);
-	var isTreeGrid = _calulateTreeDepth(data.entries) > 0;
+	var isTreeGrid = depth > 0;
 
 	for (var h in data.headers) {
 		var header = L.DomUtil.create('th', builder.options.cssClass, headers);
@@ -587,9 +587,10 @@ function _treelistboxControl(parentContainer, data, builder) {
 
 	var tbody = L.DomUtil.create('tbody', builder.options.cssClass + ' ui-treeview-body', table);
 
+	var depth = _calulateTreeDepth(data.entries);
 	var isHeaderListBox = data.headers && data.headers.length !== 0;
 	if (isHeaderListBox)
-		_createHeaders(tbody, data, builder);
+		_createHeaders(tbody, data, builder, depth);
 
 	if (!disabled) {
 		tbody.ondrop = function (ev) {
@@ -625,7 +626,8 @@ function _treelistboxControl(parentContainer, data, builder) {
 			var tr = L.DomUtil.create('tr', builder.options.cssClass + ' ui-listview-entry', tbody);
 			tr.setAttribute('role', 'row');
 			var entry = flatEntries[i];
-			tr.setAttribute('aria-level', entry.depth + 1);
+			if (depth > 0)
+				tr.setAttribute('aria-level', entry.depth + 1);
 			if (entry.children && entry.children.length)
 				tr.setAttribute('aria-expanded', true);
 			_headerlistboxEntry(tr, data, entry, builder);

--- a/browser/src/control/jsdialog/Widget.TreeView.js
+++ b/browser/src/control/jsdialog/Widget.TreeView.js
@@ -331,6 +331,8 @@ function _headerlistboxEntry(parentContainer, treeViewData, entry, builder) {
 	var clickFunction = _createClickFunction('.ui-listview-entry', parentContainer.parentNode,
 		parentContainer, checkbox, true, false, builder, treeViewData, entry);
 
+	var expander = null; // present in TreeGrid
+
 	for (var i in entry.columns) {
 		var td = L.DomUtil.create('td', '', parentContainer);
 		td.setAttribute('role', 'gridcell');
@@ -356,7 +358,12 @@ function _headerlistboxEntry(parentContainer, treeViewData, entry, builder) {
 
 	if (!disabled) {
 		parentContainer.addEventListener('keydown', function onEvent(event) {
-			if (event.key === 'Enter' || event.key === ' ') {
+			if (event.key === ' ' && expander) {
+				expander.click();
+				parentContainer.focus();
+				event.preventDefault();
+				event.stopPropagation();
+			} else if (event.key === 'Enter' || event.key === ' ') {
 				clickFunction();
 				if (checkbox)
 					checkbox.click();


### PR DESCRIPTION
Use pure CSS to make margins for different levels.
Inspired by: https://www.w3.org/WAI/ARIA/apg/patterns/treegrid/examples/treegrid-1/#ex_label
    
    - reuse arrow from tree view and expander widget
    - center verticaly entries in the tree grid / list view
    - add pointer cursor for expander arrow
    - do not allow to sort tree grid - it makes no sense
    
Tree grid is a kind of table with headers but rows can be expanded
and have subentries with different "level" in the tree.

It can be tested in Writer -> Review -> Manage Changes