### PR TITLE
Variable Substitution in Files

### DIFF
--- a/test/FileServeWhiteBoxTests.cpp
+++ b/test/FileServeWhiteBoxTests.cpp
@@ -11,11 +11,13 @@
 
 #include <config.h>
 
+#include <memory>
 #include <test/lokassert.hpp>
 #include <cppunit/TestAssert.h>
 #include <cstddef>
 
 #include <wsd/FileServer.hpp>
+#include <common/FileUtil.hpp>
 
 #include <cppunit/extensions/HelperMacros.h>
 
@@ -26,11 +28,13 @@ class FileServeTests : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST(testUIDefaults);
     CPPUNIT_TEST(testCSSVars);
     CPPUNIT_TEST(testPreProcessedFile);
+    // CPPUNIT_TEST(testPreProcessedFileRoundtrip);
     CPPUNIT_TEST_SUITE_END();
 
     void testUIDefaults();
     void testCSSVars();
     void testPreProcessedFile();
+    void testPreProcessedFileRoundtrip();
 };
 
 void FileServeTests::testUIDefaults()
@@ -177,6 +181,16 @@ void FileServeTests::testPreProcessedFile()
     }
 
     {
+        const std::string data = "Data 5% Data 7%";
+        const PreProcessedFile ppf("filename", data);
+        LOK_ASSERT_EQUAL(ppf.filename(), std::string("filename"));
+        LOK_ASSERT_EQUAL(ppf.size(), data.size());
+        LOK_ASSERT_EQUAL(1UL, ppf._segments.size());
+        LOK_ASSERT_EQUAL(false, ppf._segments[0].first);
+        LOK_ASSERT_EQUAL(std::string("Data 5% Data 7%"), ppf._segments[0].second);
+    }
+
+    {
         const std::string data = "Data <!--%VAR%--> Data";
         const PreProcessedFile ppf("filename", data);
         LOK_ASSERT_EQUAL(ppf.filename(), std::string("filename"));
@@ -243,19 +257,19 @@ void FileServeTests::testPreProcessedFile()
     }
 
     {
-        const std::string data = "<!--%VAR1% Data2 <!--%VAR3%--> Data4<!--%VAR5%-->";
+        const std::string data = "<!--%VARA% Data2 <!--%VARB%--> Data4<!--%VARC%-->";
         const PreProcessedFile ppf("filename", data);
         LOK_ASSERT_EQUAL(ppf.filename(), std::string("filename"));
         LOK_ASSERT_EQUAL(ppf.size(), data.size());
         LOK_ASSERT_EQUAL(4UL, ppf._segments.size());
         LOK_ASSERT_EQUAL(false, ppf._segments[0].first);
-        LOK_ASSERT_EQUAL(std::string("<!--%VAR1% Data2 "), ppf._segments[0].second);
+        LOK_ASSERT_EQUAL(std::string("<!--%VARA% Data2 "), ppf._segments[0].second);
         LOK_ASSERT_EQUAL(true, ppf._segments[1].first);
-        LOK_ASSERT_EQUAL(std::string("VAR3"), ppf._segments[1].second);
+        LOK_ASSERT_EQUAL(std::string("VARB"), ppf._segments[1].second);
         LOK_ASSERT_EQUAL(false, ppf._segments[2].first);
         LOK_ASSERT_EQUAL(std::string(" Data4"), ppf._segments[2].second);
         LOK_ASSERT_EQUAL(true, ppf._segments[3].first);
-        LOK_ASSERT_EQUAL(std::string("VAR5"), ppf._segments[3].second);
+        LOK_ASSERT_EQUAL(std::string("VARC"), ppf._segments[3].second);
     }
 
     {
@@ -272,6 +286,85 @@ void FileServeTests::testPreProcessedFile()
         LOK_ASSERT_EQUAL(std::string("VAR"), ppf._segments[2].second);
         LOK_ASSERT_EQUAL(false, ppf._segments[3].first);
         LOK_ASSERT_EQUAL(std::string(" Data2<!--%VAR%"), ppf._segments[3].second);
+    }
+
+    {
+        const std::string data = R"xxx(<!DOCTYPE html>
+<!-- saved from url=(0054)http://leafletjs.com/examples/quick-start-example.html -->
+<html %UI_RTL_SETTINGS% style="height:100%"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>Online Editor</title>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0 minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
+
+<script>
+
+
+
+
+
+// FIXME: This is temporary and not what we actually eventually want.
+
+// What we really want is not a separate HTML file (produced with M4 conditionals on the below
+// ) for a "WASM app". What we want is that the same cool.html page adapts on demand to
+// instead run locally using WASM, if the connection to the COOL server breaks. (And then
+// re-connects to the COOL server when possible.)
+
+
+
+window.welcomeUrl = '%WELCOME_URL%';
+  window.feedbackUrl = '%FEEDBACK_URL%';
+  window.buyProductUrl = '%BUYPRODUCT_URL%';
+)xxx";
+        const PreProcessedFile ppf("filename", data);
+        LOK_ASSERT_EQUAL(ppf.filename(), std::string("filename"));
+        LOK_ASSERT_EQUAL(ppf.size(), data.size());
+        LOK_ASSERT_EQUAL(9UL, ppf._segments.size());
+        LOK_ASSERT_EQUAL(false, ppf._segments[0].first);
+        // LOK_ASSERT_EQUAL(std::string("VAR"), ppf._segments[0].second);
+        LOK_ASSERT_EQUAL(true, ppf._segments[1].first);
+        LOK_ASSERT_EQUAL(std::string("UI_RTL_SETTINGS"), ppf._segments[1].second);
+        LOK_ASSERT_EQUAL(false, ppf._segments[2].first);
+        LOK_ASSERT_EQUAL(true, ppf._segments[3].first);
+        LOK_ASSERT_EQUAL(std::string("WELCOME_URL"), ppf._segments[3].second);
+        LOK_ASSERT_EQUAL(false, ppf._segments[4].first);
+        LOK_ASSERT_EQUAL(true, ppf._segments[5].first);
+        LOK_ASSERT_EQUAL(std::string("FEEDBACK_URL"), ppf._segments[5].second);
+        LOK_ASSERT_EQUAL(false, ppf._segments[6].first);
+        LOK_ASSERT_EQUAL(true, ppf._segments[7].first);
+        LOK_ASSERT_EQUAL(std::string("BUYPRODUCT_URL"), ppf._segments[7].second);
+        LOK_ASSERT_EQUAL(false, ppf._segments[8].first);
+    }
+}
+
+void FileServeTests::testPreProcessedFileRoundtrip()
+{
+    constexpr auto testname = __func__;
+
+    const Poco::Path path(TDOC "/../../browser/dist");
+
+    std::vector<std::string> files;
+    Poco::File(path).list(files);
+    for (const std::string& file : files)
+    {
+        std::unique_ptr<std::vector<char>> data =
+            FileUtil::readFile(Poco::Path(path, file).toString());
+
+        if (data)
+        {
+            const std::string orig(data->data(), data->size());
+            PreProcessedFile ppf(file, orig);
+            LOK_ASSERT_EQUAL(file, ppf.filename());
+            LOK_ASSERT_EQUAL(data->size(), ppf.size());
+
+            std::string recon;
+            recon.reserve(ppf.size());
+            for (const auto& seg : ppf._segments)
+            {
+                recon.append(seg.second);
+            }
+
+            LOK_ASSERT_EQUAL(orig, recon);
+        }
     }
 }
 

--- a/test/FileServeWhiteBoxTests.cpp
+++ b/test/FileServeWhiteBoxTests.cpp
@@ -384,7 +384,8 @@ void FileServeTests::testPreProcessedFileSubstitution()
         { "CSS_VARIABLES",
           "<style>:root {--co-somestyle-text:#123456;--co-somestyle-size:15px;}</style>" },
         { "POSTMESSAGE_ORIGIN", "https://www.example.com:8080" },
-        { "BRANDING_THEME", "cool_brand" }
+        { "BRANDING_THEME", "cool_brand" },
+        { "CHECK_FILE_INFO_OVERRIDE", "DownloadAsPostMessage=true;blah=bleh" }
     };
 
     std::vector<std::string> files;
@@ -414,6 +415,8 @@ void FileServeTests::testPreProcessedFileSubstitution()
                                  variables["POSTMESSAGE_ORIGIN"]);
             Poco::replaceInPlace(orig, std::string("%BRANDING_THEME%"),
                                  variables["BRANDING_THEME"]);
+            Poco::replaceInPlace(orig, std::string("%CHECK_FILE_INFO_OVERRIDE%"),
+                                 variables["CHECK_FILE_INFO_OVERRIDE"]);
 
             LOK_ASSERT_EQUAL(orig, recon);
         }

--- a/test/FileServeWhiteBoxTests.cpp
+++ b/test/FileServeWhiteBoxTests.cpp
@@ -383,7 +383,8 @@ void FileServeTests::testPreProcessedFileSubstitution()
           "false},\"text\":{\"ShowRuler\":true},\"uiMode\":\"notebookbar\"}" },
         { "CSS_VARIABLES",
           "<style>:root {--co-somestyle-text:#123456;--co-somestyle-size:15px;}</style>" },
-        { "POSTMESSAGE_ORIGIN", "https://www.example.com:8080" }
+        { "POSTMESSAGE_ORIGIN", "https://www.example.com:8080" },
+        { "BRANDING_THEME", "cool_brand" }
     };
 
     std::vector<std::string> files;
@@ -411,6 +412,8 @@ void FileServeTests::testPreProcessedFileSubstitution()
                                  variables["CSS_VARIABLES"]);
             Poco::replaceInPlace(orig, std::string("%POSTMESSAGE_ORIGIN%"),
                                  variables["POSTMESSAGE_ORIGIN"]);
+            Poco::replaceInPlace(orig, std::string("%BRANDING_THEME%"),
+                                 variables["BRANDING_THEME"]);
 
             LOK_ASSERT_EQUAL(orig, recon);
         }

--- a/test/FileServeWhiteBoxTests.cpp
+++ b/test/FileServeWhiteBoxTests.cpp
@@ -28,7 +28,7 @@ class FileServeTests : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST(testUIDefaults);
     CPPUNIT_TEST(testCSSVars);
     CPPUNIT_TEST(testPreProcessedFile);
-    // CPPUNIT_TEST(testPreProcessedFileRoundtrip);
+    CPPUNIT_TEST(testPreProcessedFileRoundtrip);
     CPPUNIT_TEST_SUITE_END();
 
     void testUIDefaults();
@@ -356,12 +356,7 @@ void FileServeTests::testPreProcessedFileRoundtrip()
             LOK_ASSERT_EQUAL(file, ppf.filename());
             LOK_ASSERT_EQUAL(data->size(), ppf.size());
 
-            std::string recon;
-            recon.reserve(ppf.size());
-            for (const auto& seg : ppf._segments)
-            {
-                recon.append(seg.second);
-            }
+            std::string recon = ppf.substitute({});
 
             LOK_ASSERT_EQUAL(orig, recon);
         }

--- a/test/FileServeWhiteBoxTests.cpp
+++ b/test/FileServeWhiteBoxTests.cpp
@@ -110,11 +110,11 @@ void FileServeTests::testPreProcessedFile()
         LOK_ASSERT_EQUAL(ppf.filename(), std::string("filename"));
         LOK_ASSERT_EQUAL(ppf.size(), data.size());
         LOK_ASSERT_EQUAL(3UL, ppf._segments.size());
-        LOK_ASSERT_EQUAL(false, ppf._segments[0].first);
+        LOK_ASSERT_EQUAL(PreProcessedFile::SegmentType::Data, ppf._segments[0].first);
         LOK_ASSERT_EQUAL(std::string("Data "), ppf._segments[0].second);
-        LOK_ASSERT_EQUAL(true, ppf._segments[1].first);
+        LOK_ASSERT_EQUAL(PreProcessedFile::SegmentType::Variable, ppf._segments[1].first);
         LOK_ASSERT_EQUAL(std::string("VAR"), ppf._segments[1].second);
-        LOK_ASSERT_EQUAL(false, ppf._segments[2].first);
+        LOK_ASSERT_EQUAL(PreProcessedFile::SegmentType::Data, ppf._segments[2].first);
         LOK_ASSERT_EQUAL(std::string(" Data"), ppf._segments[2].second);
     }
 
@@ -124,9 +124,9 @@ void FileServeTests::testPreProcessedFile()
         LOK_ASSERT_EQUAL(ppf.filename(), std::string("filename"));
         LOK_ASSERT_EQUAL(ppf.size(), data.size());
         LOK_ASSERT_EQUAL(2UL, ppf._segments.size());
-        LOK_ASSERT_EQUAL(false, ppf._segments[0].first);
+        LOK_ASSERT_EQUAL(PreProcessedFile::SegmentType::Data, ppf._segments[0].first);
         LOK_ASSERT_EQUAL(std::string("Data "), ppf._segments[0].second);
-        LOK_ASSERT_EQUAL(true, ppf._segments[1].first);
+        LOK_ASSERT_EQUAL(PreProcessedFile::SegmentType::Variable, ppf._segments[1].first);
         LOK_ASSERT_EQUAL(std::string("VAR"), ppf._segments[1].second);
     }
 
@@ -136,9 +136,9 @@ void FileServeTests::testPreProcessedFile()
         LOK_ASSERT_EQUAL(ppf.filename(), std::string("filename"));
         LOK_ASSERT_EQUAL(ppf.size(), data.size());
         LOK_ASSERT_EQUAL(2UL, ppf._segments.size());
-        LOK_ASSERT_EQUAL(true, ppf._segments[0].first);
+        LOK_ASSERT_EQUAL(PreProcessedFile::SegmentType::Variable, ppf._segments[0].first);
         LOK_ASSERT_EQUAL(std::string("VAR"), ppf._segments[0].second);
-        LOK_ASSERT_EQUAL(false, ppf._segments[1].first);
+        LOK_ASSERT_EQUAL(PreProcessedFile::SegmentType::Data, ppf._segments[1].first);
         LOK_ASSERT_EQUAL(std::string(" Data"), ppf._segments[1].second);
     }
 
@@ -148,7 +148,7 @@ void FileServeTests::testPreProcessedFile()
         LOK_ASSERT_EQUAL(ppf.filename(), std::string("filename"));
         LOK_ASSERT_EQUAL(ppf.size(), data.size());
         LOK_ASSERT_EQUAL(1UL, ppf._segments.size());
-        LOK_ASSERT_EQUAL(true, ppf._segments[0].first);
+        LOK_ASSERT_EQUAL(PreProcessedFile::SegmentType::Variable, ppf._segments[0].first);
         LOK_ASSERT_EQUAL(std::string("VAR"), ppf._segments[0].second);
     }
 
@@ -158,15 +158,15 @@ void FileServeTests::testPreProcessedFile()
         LOK_ASSERT_EQUAL(ppf.filename(), std::string("filename"));
         LOK_ASSERT_EQUAL(ppf.size(), data.size());
         LOK_ASSERT_EQUAL(5UL, ppf._segments.size());
-        LOK_ASSERT_EQUAL(true, ppf._segments[0].first);
+        LOK_ASSERT_EQUAL(PreProcessedFile::SegmentType::Variable, ppf._segments[0].first);
         LOK_ASSERT_EQUAL(std::string("VAR"), ppf._segments[0].second);
-        LOK_ASSERT_EQUAL(false, ppf._segments[1].first);
+        LOK_ASSERT_EQUAL(PreProcessedFile::SegmentType::Data, ppf._segments[1].first);
         LOK_ASSERT_EQUAL(std::string("Data1 "), ppf._segments[1].second);
-        LOK_ASSERT_EQUAL(true, ppf._segments[2].first);
+        LOK_ASSERT_EQUAL(PreProcessedFile::SegmentType::Variable, ppf._segments[2].first);
         LOK_ASSERT_EQUAL(std::string("VAR"), ppf._segments[2].second);
-        LOK_ASSERT_EQUAL(false, ppf._segments[3].first);
+        LOK_ASSERT_EQUAL(PreProcessedFile::SegmentType::Data, ppf._segments[3].first);
         LOK_ASSERT_EQUAL(std::string(" Data"), ppf._segments[3].second);
-        LOK_ASSERT_EQUAL(true, ppf._segments[4].first);
+        LOK_ASSERT_EQUAL(PreProcessedFile::SegmentType::Variable, ppf._segments[4].first);
         LOK_ASSERT_EQUAL(std::string("VAR"), ppf._segments[4].second);
     }
 
@@ -176,7 +176,7 @@ void FileServeTests::testPreProcessedFile()
         LOK_ASSERT_EQUAL(ppf.filename(), std::string("filename"));
         LOK_ASSERT_EQUAL(ppf.size(), data.size());
         LOK_ASSERT_EQUAL(1UL, ppf._segments.size());
-        LOK_ASSERT_EQUAL(false, ppf._segments[0].first);
+        LOK_ASSERT_EQUAL(PreProcessedFile::SegmentType::Data, ppf._segments[0].first);
         LOK_ASSERT_EQUAL(std::string("Data %VAR Data"), ppf._segments[0].second);
     }
 
@@ -186,7 +186,7 @@ void FileServeTests::testPreProcessedFile()
         LOK_ASSERT_EQUAL(ppf.filename(), std::string("filename"));
         LOK_ASSERT_EQUAL(ppf.size(), data.size());
         LOK_ASSERT_EQUAL(1UL, ppf._segments.size());
-        LOK_ASSERT_EQUAL(false, ppf._segments[0].first);
+        LOK_ASSERT_EQUAL(PreProcessedFile::SegmentType::Data, ppf._segments[0].first);
         LOK_ASSERT_EQUAL(std::string("Data 5% Data 7%"), ppf._segments[0].second);
     }
 
@@ -196,11 +196,11 @@ void FileServeTests::testPreProcessedFile()
         LOK_ASSERT_EQUAL(ppf.filename(), std::string("filename"));
         LOK_ASSERT_EQUAL(ppf.size(), data.size());
         LOK_ASSERT_EQUAL(3UL, ppf._segments.size());
-        LOK_ASSERT_EQUAL(false, ppf._segments[0].first);
+        LOK_ASSERT_EQUAL(PreProcessedFile::SegmentType::Data, ppf._segments[0].first);
         LOK_ASSERT_EQUAL(std::string("Data "), ppf._segments[0].second);
-        LOK_ASSERT_EQUAL(true, ppf._segments[1].first);
+        LOK_ASSERT_EQUAL(PreProcessedFile::SegmentType::CommentedVariable, ppf._segments[1].first);
         LOK_ASSERT_EQUAL(std::string("VAR"), ppf._segments[1].second);
-        LOK_ASSERT_EQUAL(false, ppf._segments[2].first);
+        LOK_ASSERT_EQUAL(PreProcessedFile::SegmentType::Data, ppf._segments[2].first);
         LOK_ASSERT_EQUAL(std::string(" Data"), ppf._segments[2].second);
     }
 
@@ -210,9 +210,9 @@ void FileServeTests::testPreProcessedFile()
         LOK_ASSERT_EQUAL(ppf.filename(), std::string("filename"));
         LOK_ASSERT_EQUAL(ppf.size(), data.size());
         LOK_ASSERT_EQUAL(2UL, ppf._segments.size());
-        LOK_ASSERT_EQUAL(false, ppf._segments[0].first);
+        LOK_ASSERT_EQUAL(PreProcessedFile::SegmentType::Data, ppf._segments[0].first);
         LOK_ASSERT_EQUAL(std::string("Data "), ppf._segments[0].second);
-        LOK_ASSERT_EQUAL(true, ppf._segments[1].first);
+        LOK_ASSERT_EQUAL(PreProcessedFile::SegmentType::CommentedVariable, ppf._segments[1].first);
         LOK_ASSERT_EQUAL(std::string("VAR"), ppf._segments[1].second);
     }
 
@@ -222,9 +222,9 @@ void FileServeTests::testPreProcessedFile()
         LOK_ASSERT_EQUAL(ppf.filename(), std::string("filename"));
         LOK_ASSERT_EQUAL(ppf.size(), data.size());
         LOK_ASSERT_EQUAL(2UL, ppf._segments.size());
-        LOK_ASSERT_EQUAL(true, ppf._segments[0].first);
+        LOK_ASSERT_EQUAL(PreProcessedFile::SegmentType::CommentedVariable, ppf._segments[0].first);
         LOK_ASSERT_EQUAL(std::string("VAR"), ppf._segments[0].second);
-        LOK_ASSERT_EQUAL(false, ppf._segments[1].first);
+        LOK_ASSERT_EQUAL(PreProcessedFile::SegmentType::Data, ppf._segments[1].first);
         LOK_ASSERT_EQUAL(std::string(" Data"), ppf._segments[1].second);
     }
 
@@ -234,7 +234,7 @@ void FileServeTests::testPreProcessedFile()
         LOK_ASSERT_EQUAL(ppf.filename(), std::string("filename"));
         LOK_ASSERT_EQUAL(ppf.size(), data.size());
         LOK_ASSERT_EQUAL(1UL, ppf._segments.size());
-        LOK_ASSERT_EQUAL(true, ppf._segments[0].first);
+        LOK_ASSERT_EQUAL(PreProcessedFile::SegmentType::CommentedVariable, ppf._segments[0].first);
         LOK_ASSERT_EQUAL(std::string("VAR"), ppf._segments[0].second);
     }
 
@@ -244,15 +244,15 @@ void FileServeTests::testPreProcessedFile()
         LOK_ASSERT_EQUAL(ppf.filename(), std::string("filename"));
         LOK_ASSERT_EQUAL(ppf.size(), data.size());
         LOK_ASSERT_EQUAL(5UL, ppf._segments.size());
-        LOK_ASSERT_EQUAL(true, ppf._segments[0].first);
+        LOK_ASSERT_EQUAL(PreProcessedFile::SegmentType::CommentedVariable, ppf._segments[0].first);
         LOK_ASSERT_EQUAL(std::string("VAR"), ppf._segments[0].second);
-        LOK_ASSERT_EQUAL(false, ppf._segments[1].first);
+        LOK_ASSERT_EQUAL(PreProcessedFile::SegmentType::Data, ppf._segments[1].first);
         LOK_ASSERT_EQUAL(std::string("Data1 "), ppf._segments[1].second);
-        LOK_ASSERT_EQUAL(true, ppf._segments[2].first);
+        LOK_ASSERT_EQUAL(PreProcessedFile::SegmentType::CommentedVariable, ppf._segments[2].first);
         LOK_ASSERT_EQUAL(std::string("VAR"), ppf._segments[2].second);
-        LOK_ASSERT_EQUAL(false, ppf._segments[3].first);
+        LOK_ASSERT_EQUAL(PreProcessedFile::SegmentType::Data, ppf._segments[3].first);
         LOK_ASSERT_EQUAL(std::string(" Data2"), ppf._segments[3].second);
-        LOK_ASSERT_EQUAL(true, ppf._segments[4].first);
+        LOK_ASSERT_EQUAL(PreProcessedFile::SegmentType::CommentedVariable, ppf._segments[4].first);
         LOK_ASSERT_EQUAL(std::string("VAR"), ppf._segments[4].second);
     }
 
@@ -262,13 +262,13 @@ void FileServeTests::testPreProcessedFile()
         LOK_ASSERT_EQUAL(ppf.filename(), std::string("filename"));
         LOK_ASSERT_EQUAL(ppf.size(), data.size());
         LOK_ASSERT_EQUAL(4UL, ppf._segments.size());
-        LOK_ASSERT_EQUAL(false, ppf._segments[0].first);
+        LOK_ASSERT_EQUAL(PreProcessedFile::SegmentType::Data, ppf._segments[0].first);
         LOK_ASSERT_EQUAL(std::string("<!--%VARA% Data2 "), ppf._segments[0].second);
-        LOK_ASSERT_EQUAL(true, ppf._segments[1].first);
+        LOK_ASSERT_EQUAL(PreProcessedFile::SegmentType::CommentedVariable, ppf._segments[1].first);
         LOK_ASSERT_EQUAL(std::string("VARB"), ppf._segments[1].second);
-        LOK_ASSERT_EQUAL(false, ppf._segments[2].first);
+        LOK_ASSERT_EQUAL(PreProcessedFile::SegmentType::Data, ppf._segments[2].first);
         LOK_ASSERT_EQUAL(std::string(" Data4"), ppf._segments[2].second);
-        LOK_ASSERT_EQUAL(true, ppf._segments[3].first);
+        LOK_ASSERT_EQUAL(PreProcessedFile::SegmentType::CommentedVariable, ppf._segments[3].first);
         LOK_ASSERT_EQUAL(std::string("VARC"), ppf._segments[3].second);
     }
 
@@ -278,13 +278,13 @@ void FileServeTests::testPreProcessedFile()
         LOK_ASSERT_EQUAL(ppf.filename(), std::string("filename"));
         LOK_ASSERT_EQUAL(ppf.size(), data.size());
         LOK_ASSERT_EQUAL(4UL, ppf._segments.size());
-        LOK_ASSERT_EQUAL(true, ppf._segments[0].first);
+        LOK_ASSERT_EQUAL(PreProcessedFile::SegmentType::CommentedVariable, ppf._segments[0].first);
         LOK_ASSERT_EQUAL(std::string("VAR"), ppf._segments[0].second);
-        LOK_ASSERT_EQUAL(false, ppf._segments[1].first);
+        LOK_ASSERT_EQUAL(PreProcessedFile::SegmentType::Data, ppf._segments[1].first);
         LOK_ASSERT_EQUAL(std::string("Data1 "), ppf._segments[1].second);
-        LOK_ASSERT_EQUAL(true, ppf._segments[2].first);
+        LOK_ASSERT_EQUAL(PreProcessedFile::SegmentType::CommentedVariable, ppf._segments[2].first);
         LOK_ASSERT_EQUAL(std::string("VAR"), ppf._segments[2].second);
-        LOK_ASSERT_EQUAL(false, ppf._segments[3].first);
+        LOK_ASSERT_EQUAL(PreProcessedFile::SegmentType::Data, ppf._segments[3].first);
         LOK_ASSERT_EQUAL(std::string(" Data2<!--%VAR%"), ppf._segments[3].second);
     }
 
@@ -319,20 +319,20 @@ window.welcomeUrl = '%WELCOME_URL%';
         LOK_ASSERT_EQUAL(ppf.filename(), std::string("filename"));
         LOK_ASSERT_EQUAL(ppf.size(), data.size());
         LOK_ASSERT_EQUAL(9UL, ppf._segments.size());
-        LOK_ASSERT_EQUAL(false, ppf._segments[0].first);
+        LOK_ASSERT_EQUAL(PreProcessedFile::SegmentType::Data, ppf._segments[0].first);
         // LOK_ASSERT_EQUAL(std::string("VAR"), ppf._segments[0].second);
-        LOK_ASSERT_EQUAL(true, ppf._segments[1].first);
+        LOK_ASSERT_EQUAL(PreProcessedFile::SegmentType::Variable, ppf._segments[1].first);
         LOK_ASSERT_EQUAL(std::string("UI_RTL_SETTINGS"), ppf._segments[1].second);
-        LOK_ASSERT_EQUAL(false, ppf._segments[2].first);
-        LOK_ASSERT_EQUAL(true, ppf._segments[3].first);
+        LOK_ASSERT_EQUAL(PreProcessedFile::SegmentType::Data, ppf._segments[2].first);
+        LOK_ASSERT_EQUAL(PreProcessedFile::SegmentType::Variable, ppf._segments[3].first);
         LOK_ASSERT_EQUAL(std::string("WELCOME_URL"), ppf._segments[3].second);
-        LOK_ASSERT_EQUAL(false, ppf._segments[4].first);
-        LOK_ASSERT_EQUAL(true, ppf._segments[5].first);
+        LOK_ASSERT_EQUAL(PreProcessedFile::SegmentType::Data, ppf._segments[4].first);
+        LOK_ASSERT_EQUAL(PreProcessedFile::SegmentType::Variable, ppf._segments[5].first);
         LOK_ASSERT_EQUAL(std::string("FEEDBACK_URL"), ppf._segments[5].second);
-        LOK_ASSERT_EQUAL(false, ppf._segments[6].first);
-        LOK_ASSERT_EQUAL(true, ppf._segments[7].first);
+        LOK_ASSERT_EQUAL(PreProcessedFile::SegmentType::Data, ppf._segments[6].first);
+        LOK_ASSERT_EQUAL(PreProcessedFile::SegmentType::Variable, ppf._segments[7].first);
         LOK_ASSERT_EQUAL(std::string("BUYPRODUCT_URL"), ppf._segments[7].second);
-        LOK_ASSERT_EQUAL(false, ppf._segments[8].first);
+        LOK_ASSERT_EQUAL(PreProcessedFile::SegmentType::Data, ppf._segments[8].first);
     }
 }
 

--- a/test/FileServeWhiteBoxTests.cpp
+++ b/test/FileServeWhiteBoxTests.cpp
@@ -385,7 +385,8 @@ void FileServeTests::testPreProcessedFileSubstitution()
           "<style>:root {--co-somestyle-text:#123456;--co-somestyle-size:15px;}</style>" },
         { "POSTMESSAGE_ORIGIN", "https://www.example.com:8080" },
         { "BRANDING_THEME", "cool_brand" },
-        { "CHECK_FILE_INFO_OVERRIDE", "DownloadAsPostMessage=true;blah=bleh" }
+        { "CHECK_FILE_INFO_OVERRIDE", "DownloadAsPostMessage=true;blah=bleh" },
+        { "BUYPRODUCT_URL", "https://buy.ourproduct.com/'" }
     };
 
     std::vector<std::string> files;
@@ -417,6 +418,8 @@ void FileServeTests::testPreProcessedFileSubstitution()
                                  variables["BRANDING_THEME"]);
             Poco::replaceInPlace(orig, std::string("%CHECK_FILE_INFO_OVERRIDE%"),
                                  variables["CHECK_FILE_INFO_OVERRIDE"]);
+            Poco::replaceInPlace(orig, std::string("%BUYPRODUCT_URL%"),
+                                 variables["BUYPRODUCT_URL"]);
 
             LOK_ASSERT_EQUAL(orig, recon);
         }

--- a/test/integration-http-server.cpp
+++ b/test/integration-http-server.cpp
@@ -204,6 +204,7 @@ void HTTPServerTest::testCoolPost()
         "access_token=choMXq0rSMcsm0RoZZWDWsrgAcE5AHwc&ui_defaults=TextRuler%3Dfalse%3BTextSidebar%"
         "3Dfalse%3BTextStatusbar%3Dfalse%3BPresentationSidebar%3Dfalse%3BPresentationStatusbar%"
         "3Dfalse%3BSpreadsheetSidebar%3Dfalse%3BSpreadsheetStatusbar%3Dfalse%3BUIMode%3Dclassic%3B&"
+        "postmessage_origin=https://www.example.com:8080&"
         "css_variables=--co-primary-text%3D%23ffffff%3B--co-primary-element%3D%230082c9%3B--co-"
         "text-accent%3D%230082c9%3B--co-primary-light%3D%23e6f3fa%3B--co-primary-element-light%3D%"
         "2317adff%3B--co-color-error%3D%23e9322d%3B--co-color-warning%3D%23eca700%3B--co-color-"
@@ -229,7 +230,8 @@ void HTTPServerTest::testCoolPost()
                std::string::npos);
     LOK_ASSERT(html.find("window.accessTokenTTL = '0';") != std::string::npos);
     LOK_ASSERT(html.find("window.accessHeader = '';") != std::string::npos);
-    LOK_ASSERT(html.find("window.postMessageOriginExt = '';") != std::string::npos);
+    LOK_ASSERT(html.find("window.postMessageOriginExt = 'https://www.example.com:8080';") !=
+               std::string::npos);
     LOK_ASSERT(
         html.find(
             "window.frameAncestors = decodeURIComponent('%20127.0.0.1:%2A%20localhost:%2A');") !=

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -995,6 +995,7 @@ constexpr char BRANDING_UNSUPPORTED[] = "branding-unsupported";
 static const std::string ACCESS_TOKEN = "%ACCESS_TOKEN%";
 static const std::string ACCESS_TOKEN_TTL = "%ACCESS_TOKEN_TTL%";
 static const std::string ACCESS_HEADER = "%ACCESS_HEADER%";
+static const std::string UI_DEFAULTS = "%UI_DEFAULTS%";
 
 /// Per user request variables.
 /// Holds access_token, css_variables, postmessage_origin, etc.
@@ -1054,6 +1055,8 @@ public:
                 << "] for var [" << ACCESS_TOKEN_TTL << "] = [" << tokenTtl << ']');
 
         extractVariable(form, "access_header", ACCESS_HEADER);
+
+        extractVariable(form, "ui_defaults", UI_DEFAULTS);
     }
 
     const std::string& operator[](const std::string& key) const
@@ -1088,8 +1091,6 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
 
     const UserRequestVars urv(request, form);
 
-    const std::string uiDefaults = form.get("ui_defaults", "");
-    LOG_TRC("ui_defaults=" << uiDefaults);
     const std::string cssVars = form.get("css_variables", "");
     LOG_TRC("css_variables=" << cssVars);
     std::string buyProduct;
@@ -1129,7 +1130,8 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     Poco::replaceInPlace(preprocess, std::string("%VERSION%"), std::string(COOLWSD_VERSION_HASH));
     Poco::replaceInPlace(preprocess, std::string("%COOLWSD_VERSION%"), std::string(COOLWSD_VERSION));
     Poco::replaceInPlace(preprocess, std::string("%SERVICE_ROOT%"), responseRoot);
-    Poco::replaceInPlace(preprocess, std::string("%UI_DEFAULTS%"), uiDefaultsToJSON(uiDefaults, userInterfaceMode, userInterfaceTheme, savedUIState));
+    Poco::replaceInPlace(preprocess, UI_DEFAULTS,
+                         uiDefaultsToJSON(urv[UI_DEFAULTS], userInterfaceMode, userInterfaceTheme, savedUIState));
     Poco::replaceInPlace(preprocess, std::string("%UI_THEME%"), userInterfaceTheme); // UI_THEME refers to light or dark theme
     Poco::replaceInPlace(preprocess, std::string("%BRANDING_THEME%"), theme);
     Poco::replaceInPlace(preprocess, std::string("%SAVED_UI_STATE%"), savedUIState);

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -994,6 +994,7 @@ constexpr char BRANDING_UNSUPPORTED[] = "branding-unsupported";
 
 static const std::string ACCESS_TOKEN = "%ACCESS_TOKEN%";
 static const std::string ACCESS_TOKEN_TTL = "%ACCESS_TOKEN_TTL%";
+static const std::string ACCESS_HEADER = "%ACCESS_HEADER%";
 
 /// Per user request variables.
 /// Holds access_token, css_variables, postmessage_origin, etc.
@@ -1051,6 +1052,8 @@ public:
         LOG_TRC("Field ["
                 << "access_token_ttl"
                 << "] for var [" << ACCESS_TOKEN_TTL << "] = [" << tokenTtl << ']');
+
+        extractVariable(form, "access_header", ACCESS_HEADER);
     }
 
     const std::string& operator[](const std::string& key) const
@@ -1085,8 +1088,6 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
 
     const UserRequestVars urv(request, form);
 
-    const std::string accessHeader = form.get("access_header", "");
-    LOG_TRC("access_header=" << accessHeader);
     const std::string uiDefaults = form.get("ui_defaults", "");
     LOG_TRC("ui_defaults=" << uiDefaults);
     const std::string cssVars = form.get("css_variables", "");
@@ -1109,7 +1110,6 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     // Escape bad characters in access token.
     // This is placed directly in javascript in cool.html, we need to make sure
     // that no one can do anything nasty with their clever inputs.
-    const std::string escapedAccessHeader = Util::encodeURIComponent(accessHeader, "'");
     const std::string escapedPostmessageOrigin = Util::encodeURIComponent(postMessageOrigin, "'");
 
     std::string socketProxy = "false";
@@ -1124,7 +1124,7 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
 
     Poco::replaceInPlace(preprocess, ACCESS_TOKEN, urv[ACCESS_TOKEN]);
     Poco::replaceInPlace(preprocess, ACCESS_TOKEN_TTL, urv[ACCESS_TOKEN_TTL]);
-    Poco::replaceInPlace(preprocess, std::string("%ACCESS_HEADER%"), escapedAccessHeader);
+    Poco::replaceInPlace(preprocess, ACCESS_HEADER, urv[ACCESS_HEADER]);
     Poco::replaceInPlace(preprocess, std::string("%HOST%"), cnxDetails.getWebSocketUrl());
     Poco::replaceInPlace(preprocess, std::string("%VERSION%"), std::string(COOLWSD_VERSION_HASH));
     Poco::replaceInPlace(preprocess, std::string("%COOLWSD_VERSION%"), std::string(COOLWSD_VERSION));

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -999,6 +999,7 @@ static const std::string UI_DEFAULTS = "%UI_DEFAULTS%";
 static const std::string CSS_VARS = "<!--%CSS_VARIABLES%-->";
 static const std::string POSTMESSAGE_ORIGIN = "%POSTMESSAGE_ORIGIN%";
 static const std::string BRANDING_THEME = "%BRANDING_THEME%";
+static const std::string CHECK_FILE_INFO_OVERRIDE = "%CHECK_FILE_INFO_OVERRIDE%";
 
 /// Per user request variables.
 /// Holds access_token, css_variables, postmessage_origin, etc.
@@ -1083,6 +1084,8 @@ public:
         extractVariable(form, "postmessage_origin", POSTMESSAGE_ORIGIN);
 
         extractVariable(form, "theme", BRANDING_THEME);
+
+        extractVariable(form, "checkfileinfo_override", CHECK_FILE_INFO_OVERRIDE);
     }
 
     const std::string& operator[](const std::string& key) const
@@ -1125,8 +1128,6 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     if (buyProduct.empty())
         buyProduct = form.get("buy_product", "");
     LOG_TRC("buy_product=" << buyProduct);
-    const std::string checkfileinfo_override = form.get("checkfileinfo_override", "");
-    LOG_TRC("checkfileinfo_override=" << checkfileinfo_override);
 
     std::string socketProxy = "false";
     if (requestDetails.isProxy())
@@ -1152,8 +1153,8 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     Poco::replaceInPlace(preprocess, BRANDING_THEME, urv[BRANDING_THEME]);
     Poco::replaceInPlace(preprocess, std::string("%SAVED_UI_STATE%"), savedUIState);
     Poco::replaceInPlace(preprocess, POSTMESSAGE_ORIGIN, urv[POSTMESSAGE_ORIGIN]);
-    Poco::replaceInPlace(preprocess, std::string("%CHECK_FILE_INFO_OVERRIDE%"),
-                         checkFileInfoToJSON(checkfileinfo_override));
+    Poco::replaceInPlace(preprocess, CHECK_FILE_INFO_OVERRIDE,
+                         checkFileInfoToJSON(urv[CHECK_FILE_INFO_OVERRIDE]));
 
     const auto& config = Application::instance().config();
 

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -997,6 +997,7 @@ static const std::string ACCESS_TOKEN_TTL = "%ACCESS_TOKEN_TTL%";
 static const std::string ACCESS_HEADER = "%ACCESS_HEADER%";
 static const std::string UI_DEFAULTS = "%UI_DEFAULTS%";
 static const std::string CSS_VARS = "<!--%CSS_VARIABLES%-->";
+static const std::string POSTMESSAGE_ORIGIN = "%POSTMESSAGE_ORIGIN%";
 
 /// Per user request variables.
 /// Holds access_token, css_variables, postmessage_origin, etc.
@@ -1077,6 +1078,8 @@ public:
         extractVariable(form, "ui_defaults", UI_DEFAULTS);
 
         extractVariablePlain(form, "css_variables", CSS_VARS);
+
+        extractVariable(form, "postmessage_origin", POSTMESSAGE_ORIGIN);
     }
 
     const std::string& operator[](const std::string& key) const
@@ -1119,17 +1122,10 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     if (buyProduct.empty())
         buyProduct = form.get("buy_product", "");
     LOG_TRC("buy_product=" << buyProduct);
-    const std::string postMessageOrigin = form.get("postmessage_origin", "");
-    LOG_TRC("postmessage_origin" << postMessageOrigin);
     const std::string theme = form.get("theme", "");
     LOG_TRC("theme=" << theme);
     const std::string checkfileinfo_override = form.get("checkfileinfo_override", "");
     LOG_TRC("checkfileinfo_override=" << checkfileinfo_override);
-
-    // Escape bad characters in access token.
-    // This is placed directly in javascript in cool.html, we need to make sure
-    // that no one can do anything nasty with their clever inputs.
-    const std::string escapedPostmessageOrigin = Util::encodeURIComponent(postMessageOrigin, "'");
 
     std::string socketProxy = "false";
     if (requestDetails.isProxy())
@@ -1153,7 +1149,7 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     Poco::replaceInPlace(preprocess, std::string("%UI_THEME%"), userInterfaceTheme); // UI_THEME refers to light or dark theme
     Poco::replaceInPlace(preprocess, std::string("%BRANDING_THEME%"), theme);
     Poco::replaceInPlace(preprocess, std::string("%SAVED_UI_STATE%"), savedUIState);
-    Poco::replaceInPlace(preprocess, std::string("%POSTMESSAGE_ORIGIN%"), escapedPostmessageOrigin);
+    Poco::replaceInPlace(preprocess, POSTMESSAGE_ORIGIN, urv[POSTMESSAGE_ORIGIN]);
     Poco::replaceInPlace(preprocess, std::string("%CHECK_FILE_INFO_OVERRIDE%"),
                          checkFileInfoToJSON(checkfileinfo_override));
 

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -998,6 +998,7 @@ static const std::string ACCESS_HEADER = "%ACCESS_HEADER%";
 static const std::string UI_DEFAULTS = "%UI_DEFAULTS%";
 static const std::string CSS_VARS = "<!--%CSS_VARIABLES%-->";
 static const std::string POSTMESSAGE_ORIGIN = "%POSTMESSAGE_ORIGIN%";
+static const std::string BRANDING_THEME = "%BRANDING_THEME%";
 
 /// Per user request variables.
 /// Holds access_token, css_variables, postmessage_origin, etc.
@@ -1080,6 +1081,8 @@ public:
         extractVariablePlain(form, "css_variables", CSS_VARS);
 
         extractVariable(form, "postmessage_origin", POSTMESSAGE_ORIGIN);
+
+        extractVariable(form, "theme", BRANDING_THEME);
     }
 
     const std::string& operator[](const std::string& key) const
@@ -1122,8 +1125,6 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     if (buyProduct.empty())
         buyProduct = form.get("buy_product", "");
     LOG_TRC("buy_product=" << buyProduct);
-    const std::string theme = form.get("theme", "");
-    LOG_TRC("theme=" << theme);
     const std::string checkfileinfo_override = form.get("checkfileinfo_override", "");
     LOG_TRC("checkfileinfo_override=" << checkfileinfo_override);
 
@@ -1136,6 +1137,7 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     std::string userInterfaceMode;
     std::string userInterfaceTheme;
     std::string savedUIState = "true";
+    const std::string& theme = urv[BRANDING_THEME];
 
     Poco::replaceInPlace(preprocess, ACCESS_TOKEN, urv[ACCESS_TOKEN]);
     Poco::replaceInPlace(preprocess, ACCESS_TOKEN_TTL, urv[ACCESS_TOKEN_TTL]);
@@ -1147,7 +1149,7 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     Poco::replaceInPlace(preprocess, UI_DEFAULTS,
                          uiDefaultsToJSON(urv[UI_DEFAULTS], userInterfaceMode, userInterfaceTheme, savedUIState));
     Poco::replaceInPlace(preprocess, std::string("%UI_THEME%"), userInterfaceTheme); // UI_THEME refers to light or dark theme
-    Poco::replaceInPlace(preprocess, std::string("%BRANDING_THEME%"), theme);
+    Poco::replaceInPlace(preprocess, BRANDING_THEME, urv[BRANDING_THEME]);
     Poco::replaceInPlace(preprocess, std::string("%SAVED_UI_STATE%"), savedUIState);
     Poco::replaceInPlace(preprocess, POSTMESSAGE_ORIGIN, urv[POSTMESSAGE_ORIGIN]);
     Poco::replaceInPlace(preprocess, std::string("%CHECK_FILE_INFO_OVERRIDE%"),
@@ -1162,11 +1164,12 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
         COOLWSD::getConfigValue<bool>("hexify_embedded_urls", false) ? "true" : "false";
     Poco::replaceInPlace(preprocess, std::string("%HEXIFY_URL%"), hexifyEmbeddedUrls);
 
-
-    bool useIntegrationTheme = config.getBool("user_interface.use_integration_theme", true);
-    bool hasIntegrationTheme = (theme != "") && FileUtil::Stat(COOLWSD::FileServerRoot + "/browser/dist/" + theme).exists();
-    const std::string escapedTheme = Util::encodeURIComponent(theme, "'");
-    const std::string themePreFix = hasIntegrationTheme && useIntegrationTheme ? escapedTheme + "/" : "";
+    static const bool useIntegrationTheme =
+        config.getBool("user_interface.use_integration_theme", true);
+    const bool hasIntegrationTheme =
+        !theme.empty() &&
+        FileUtil::Stat(COOLWSD::FileServerRoot + "/browser/dist/" + theme).exists();
+    const std::string themePreFix = hasIntegrationTheme && useIntegrationTheme ? theme + "/" : "";
     const std::string linkCSS("<link rel=\"stylesheet\" href=\"%s/browser/" COOLWSD_VERSION_HASH "/" + themePreFix + "%s.css\">");
     const std::string scriptJS("<script src=\"%s/browser/" COOLWSD_VERSION_HASH "/" + themePreFix + "%s.js\"></script>");
 

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -992,6 +992,8 @@ constexpr char BRANDING[] = "branding";
 constexpr char BRANDING_UNSUPPORTED[] = "branding-unsupported";
 #endif
 
+static const std::string ACCESS_TOKEN = "%ACCESS_TOKEN%";
+
 /// Per user request variables.
 /// Holds access_token, css_variables, postmessage_origin, etc.
 class UserRequestVars
@@ -1009,11 +1011,13 @@ class UserRequestVars
     }
 
 public:
-    UserRequestVars(const HTTPRequest& /*request*/, const Poco::Net::HTMLForm& /*form*/)
+    UserRequestVars(const HTTPRequest& /*request*/, const Poco::Net::HTMLForm& form)
     {
         // We need to pass certain parameters from the cool html GET URI
         // to the embedded document URI. Here we extract those params
         // from the GET URI and set them in the generated html (see cool.html.m4).
+
+        const std::string accessToken = extractVariable(form, "access_token", ACCESS_TOKEN);
     }
 
     const std::string& operator[](const std::string& key) const
@@ -1045,6 +1049,9 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     // to the embedded document URI. Here we extract those params
     // from the GET URI and set them in the generated html (see cool.html.m4).
     HTMLForm form(request, message);
+
+    const UserRequestVars urv(request, form);
+
     const std::string accessToken = form.get("access_token", "");
     const std::string accessTokenTtl = form.get("access_token_ttl", "");
     LOG_TRC("access_token=" << accessToken << ", access_token_ttl=" << accessTokenTtl);
@@ -1072,7 +1079,6 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     // Escape bad characters in access token.
     // This is placed directly in javascript in cool.html, we need to make sure
     // that no one can do anything nasty with their clever inputs.
-    const std::string escapedAccessToken = Util::encodeURIComponent(accessToken, "'");
     const std::string escapedAccessHeader = Util::encodeURIComponent(accessHeader, "'");
     const std::string escapedPostmessageOrigin = Util::encodeURIComponent(postMessageOrigin, "'");
 
@@ -1106,7 +1112,7 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     std::string userInterfaceTheme;
     std::string savedUIState = "true";
 
-    Poco::replaceInPlace(preprocess, std::string("%ACCESS_TOKEN%"), escapedAccessToken);
+    Poco::replaceInPlace(preprocess, ACCESS_TOKEN, urv[ACCESS_TOKEN]);
     Poco::replaceInPlace(preprocess, std::string("%ACCESS_TOKEN_TTL%"), std::to_string(tokenTtl));
     Poco::replaceInPlace(preprocess, std::string("%ACCESS_HEADER%"), escapedAccessHeader);
     Poco::replaceInPlace(preprocess, std::string("%HOST%"), cnxDetails.getWebSocketUrl());

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -1000,6 +1000,7 @@ static const std::string CSS_VARS = "<!--%CSS_VARIABLES%-->";
 static const std::string POSTMESSAGE_ORIGIN = "%POSTMESSAGE_ORIGIN%";
 static const std::string BRANDING_THEME = "%BRANDING_THEME%";
 static const std::string CHECK_FILE_INFO_OVERRIDE = "%CHECK_FILE_INFO_OVERRIDE%";
+static const std::string BUYPRODUCT_URL = "%BUYPRODUCT_URL%";
 
 /// Per user request variables.
 /// Holds access_token, css_variables, postmessage_origin, etc.
@@ -1086,6 +1087,25 @@ public:
         extractVariable(form, "theme", BRANDING_THEME);
 
         extractVariable(form, "checkfileinfo_override", CHECK_FILE_INFO_OVERRIDE);
+
+        extractVariable(form, "buy_product", BUYPRODUCT_URL);
+
+        std::string buyProduct;
+        {
+            std::lock_guard<std::mutex> lock(COOLWSD::RemoteConfigMutex);
+            buyProduct = COOLWSD::BuyProductUrl;
+        }
+
+        if (buyProduct.empty())
+        {
+            buyProduct = form.get("buy_product", "");
+        }
+
+        const std::string escapedBuyProduct = Util::encodeURIComponent(buyProduct, "'");
+        _vars[BUYPRODUCT_URL] = escapedBuyProduct;
+
+        LOG_TRC("Field [buy_product] for var [" << BUYPRODUCT_URL << "] = [" << escapedBuyProduct
+                                                << ']');
     }
 
     const std::string& operator[](const std::string& key) const
@@ -1262,8 +1282,7 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     Poco::replaceInPlace(preprocess, std::string("%FEEDBACK_URL%"), std::string(FEEDBACK_URL));
     Poco::replaceInPlace(preprocess, std::string("%WELCOME_URL%"), std::string(WELCOME_URL));
 
-    const std::string escapedBuyProduct = Util::encodeURIComponent(buyProduct, "'");
-    Poco::replaceInPlace(preprocess, std::string("%BUYPRODUCT_URL%"), escapedBuyProduct);
+    Poco::replaceInPlace(preprocess, BUYPRODUCT_URL, urv[BUYPRODUCT_URL]);
 
     Poco::replaceInPlace(preprocess, std::string("%DEEPL_ENABLED%"), (config.getBool("deepl.enabled", false) ? std::string("true"): std::string("false")));
     Poco::replaceInPlace(preprocess, std::string("%ZOTERO_ENABLED%"), (config.getBool("zotero.enable", true) ? std::string("true"): std::string("false")));
@@ -1280,7 +1299,7 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     csp.appendDirective("frame-src", "'self'");
     csp.appendDirective("frame-src", WELCOME_URL);
     csp.appendDirective("frame-src", FEEDBACK_URL);
-    csp.appendDirective("frame-src", buyProduct);
+    csp.appendDirective("frame-src", Util::decodeURIComponent(urv[BUYPRODUCT_URL]));
     csp.appendDirective("frame-src", "blob:"); // Equivalent to unsafe-eval!
     csp.appendDirective("connect-src", "'self'");
     csp.appendDirective("connect-src", "https://www.zotero.org");

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -992,6 +992,41 @@ constexpr char BRANDING[] = "branding";
 constexpr char BRANDING_UNSUPPORTED[] = "branding-unsupported";
 #endif
 
+/// Per user request variables.
+/// Holds access_token, css_variables, postmessage_origin, etc.
+class UserRequestVars
+{
+    std::string extractVariable(const HTMLForm& form, const std::string& field,
+                                const std::string& var)
+    {
+        std::string value = form.get(field, "");
+        const std::string escaped = Util::encodeURIComponent(value, "'");
+        _vars[var] = escaped;
+
+        LOG_TRC("Field [" << field << "] for var [" << var << "] = [" << escaped << ']');
+
+        return value;
+    }
+
+public:
+    UserRequestVars(const HTTPRequest& /*request*/, const Poco::Net::HTMLForm& /*form*/)
+    {
+        // We need to pass certain parameters from the cool html GET URI
+        // to the embedded document URI. Here we extract those params
+        // from the GET URI and set them in the generated html (see cool.html.m4).
+    }
+
+    const std::string& operator[](const std::string& key) const
+    {
+        const auto it = _vars.find(key);
+        return it != _vars.end() ? it->second : _blank;
+    }
+
+private:
+    std::unordered_map<std::string, std::string> _vars;
+    const std::string _blank;
+};
+
 void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
                                               const RequestDetails &requestDetails,
                                               Poco::MemoryInputStream& message,

--- a/wsd/FileServer.hpp
+++ b/wsd/FileServer.hpp
@@ -12,6 +12,7 @@
 #pragma once
 
 #include <string>
+#include <unordered_map>
 
 #include <HttpRequest.hpp>
 #include <Socket.hpp>
@@ -39,6 +40,9 @@ public:
 
     const std::string& filename() const { return _filename; }
     std::size_t size() const { return _size; }
+
+    /// Substitute variables per the given map.
+    std::string substitute(const std::unordered_map<std::string, std::string>& values);
 
 private:
     const std::string _filename; //< Filename on disk, with extension.

--- a/wsd/FileServer.hpp
+++ b/wsd/FileServer.hpp
@@ -28,6 +28,13 @@ class PreProcessedFile
     friend class FileServeTests;
 
 public:
+    enum class SegmentType : char
+    {
+        Data,
+        Variable,
+        CommentedVariable
+    };
+
     PreProcessedFile(std::string filename, const std::string& data);
 
     const std::string& filename() const { return _filename; }
@@ -37,8 +44,26 @@ private:
     const std::string _filename; //< Filename on disk, with extension.
     const std::size_t _size; //< Number of bytes in original file.
     /// The segments of the file in <IsVariable, Data> pairs.
-    std::vector<std::pair<bool, std::string>> _segments;
+    std::vector<std::pair<SegmentType, std::string>> _segments;
 };
+
+inline std::ostream& operator<<(std::ostream& os, const PreProcessedFile::SegmentType type)
+{
+    switch (type)
+    {
+        case PreProcessedFile::SegmentType::Data:
+            os << "Data";
+            break;
+        case PreProcessedFile::SegmentType::Variable:
+            os << "Variable";
+            break;
+        case PreProcessedFile::SegmentType::CommentedVariable:
+            os << "CommentedVariable";
+            break;
+    }
+
+    return os;
+}
 
 /// Handles file requests over HTTP(S).
 class FileServerRequestHandler

--- a/wsd/FileServer.hpp
+++ b/wsd/FileServer.hpp
@@ -20,6 +20,26 @@
 #include <Poco/Util/LayeredConfiguration.h>
 
 class RequestDetails;
+
+/// Represents a file that is preprocessed for variable
+/// expansion/replacement before serving.
+class PreProcessedFile
+{
+    friend class FileServeTests;
+
+public:
+    PreProcessedFile(std::string filename, const std::string& data);
+
+    const std::string& filename() const { return _filename; }
+    std::size_t size() const { return _size; }
+
+private:
+    const std::string _filename; //< Filename on disk, with extension.
+    const std::size_t _size; //< Number of bytes in original file.
+    /// The segments of the file in <IsVariable, Data> pairs.
+    std::vector<std::pair<bool, std::string>> _segments;
+};
+
 /// Handles file requests over HTTP(S).
 class FileServerRequestHandler
 {

--- a/wsd/FileServerUtil.cpp
+++ b/wsd/FileServerUtil.cpp
@@ -139,6 +139,50 @@ PreProcessedFile::PreProcessedFile(std::string filename, const std::string& data
     }
 }
 
+std::string PreProcessedFile::substitute(const std::unordered_map<std::string, std::string>& values)
+{
+    std::string recon;
+    recon.reserve(_size * 2);
+    for (const auto& seg : _segments)
+    {
+        switch (seg.first)
+        {
+            case SegmentType::Data:
+                recon.append(seg.second);
+                break;
+            case SegmentType::Variable:
+            case SegmentType::CommentedVariable:
+            {
+                const auto it = values.find(seg.second);
+                if (it == values.end())
+                {
+                    // Leave original variable as-is.
+                    if (seg.first == SegmentType::Variable)
+                    {
+                        recon.append("%");
+                        recon.append(seg.second);
+                        recon.append("%");
+                    }
+                    else if (seg.first == SegmentType::CommentedVariable)
+                    {
+                        recon.append("<!--%");
+                        recon.append(seg.second);
+                        recon.append("%-->");
+                    }
+                }
+                else
+                {
+                    // Substitute with the given value.
+                    recon.append(it->second);
+                }
+            }
+            break;
+        }
+    }
+
+    return recon;
+}
+
 std::string FileServerRequestHandler::uiDefaultsToJSON(const std::string& uiDefaults, std::string& uiMode, std::string& uiTheme, std::string& savedUIState)
 {
     static std::string previousUIDefaults;

--- a/wsd/FileServerUtil.cpp
+++ b/wsd/FileServerUtil.cpp
@@ -91,11 +91,12 @@ PreProcessedFile::PreProcessedFile(std::string filename, const std::string& data
             // Insert previous literal.
             if (newpos > lastpos)
             {
-                _segments.emplace_back(false, data.substr(lastpos, newpos - lastpos));
+                _segments.emplace_back(SegmentType::Data, data.substr(lastpos, newpos - lastpos));
             }
 
             lastpos = endpos + 1;
-            _segments.emplace_back(true, data.substr(varstart + 1, varend - varstart - 1));
+            _segments.emplace_back(SegmentType::CommentedVariable,
+                                   data.substr(varstart + 1, varend - varstart - 1));
         }
         else
         {
@@ -121,11 +122,12 @@ PreProcessedFile::PreProcessedFile(std::string filename, const std::string& data
             // Insert previous literal.
             if (newpos > lastpos)
             {
-                _segments.emplace_back(false, data.substr(lastpos, newpos - lastpos));
+                _segments.emplace_back(SegmentType::Data, data.substr(lastpos, newpos - lastpos));
             }
 
             lastpos = varend + 1;
-            _segments.emplace_back(true, data.substr(newpos + 1, varend - newpos - 1));
+            _segments.emplace_back(SegmentType::Variable,
+                                   data.substr(newpos + 1, varend - newpos - 1));
         }
 
         pos = lastpos;
@@ -133,7 +135,7 @@ PreProcessedFile::PreProcessedFile(std::string filename, const std::string& data
 
     if (lastpos < _size)
     {
-        _segments.emplace_back(false, data.substr(lastpos));
+        _segments.emplace_back(SegmentType::Data, data.substr(lastpos));
     }
 }
 


### PR DESCRIPTION
This reworks the variable-substitution logic in files by first extracting all the user-variables into an object. Next step will be to kill Poco.
This is a prerequisite for async loading.

Most of the new lines are new test code. Functional code is actually small.

- wsd: new PreProcessedFile class
- wsd: better PreProcessedFile and new disabled test
- wsd: improved PreProcessedFile with SegmentType
- wsd: new Substitute helper for PreProcessedFile
- wsd: test: Sustitution of PreProcessedFile
- wsd: new helper class UserRequestVars
- wsd: access_token substitution
- wsd: access_token_ttl substitution
- wsd: access_header substitution
- wsd: ui_defaults substitution
- wsd: css_variables substitution
- wsd: postmessage substitution
- wsd: branding theme substitution
- wsd: checkfileinfo_override substitution
- wsd: buy url substitution
- js: update package.json sorting
