### PR TITLE
a11y: impress: help screen reader to report shape selection

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1887,11 +1887,23 @@ L.CanvasTileLayer = L.Layer.extend({
 			var col = parseInt(obj.col);
 			var rowSpan = obj.rowSpan !== undefined ? parseInt(obj.rowSpan) : 1;
 			var colSpan = obj.colSpan !== undefined ? parseInt(obj.colSpan) : 1;
-			this._map._textInput.onAccessibilityFocusedCellChanged(outCount, inList, row, col, rowSpan, colSpan, obj.paragraph);
+			this._map._textInput.onAccessibilityFocusedCellChanged(
+				outCount, inList, row, col, rowSpan, colSpan, obj.paragraph);
+		}
+		else if (textMsg.startsWith('a11yeditinginselectionstate:')) {
+			obj = JSON.parse(textMsg.substring('a11yeditinginselectionstate:'.length + 1));
+			this._map._textInput.onAccessibilityEditingInSelectionState(
+				parseInt(obj.cell) > 0, parseInt(obj.enabled) > 0, obj.selection, obj.paragraph);
+		}
+		else if (textMsg.startsWith('a11yselectionchanged:')) {
+			obj = JSON.parse(textMsg.substring('a11yselectionchanged:'.length + 1));
+			this._map._textInput.onAccessibilitySelectionChanged(
+				parseInt(obj.cell) > 0, obj.action, obj.name, obj.text);
 		}
 		else if (textMsg.startsWith('a11yfocusedparagraph:')) {
 			obj = JSON.parse(textMsg.substring('a11yfocusedparagraph:'.length + 1));
-			this._map._textInput.setA11yFocusedParagraph(obj.content, parseInt(obj.position), parseInt(obj.start), parseInt(obj.end));
+			this._map._textInput.setA11yFocusedParagraph(
+				obj.content, parseInt(obj.position), parseInt(obj.start), parseInt(obj.end));
 		}
 		else if (textMsg.startsWith('a11ycaretposition:')) {
 			var pos = textMsg.substring('a11ycaretposition:'.length + 1);

--- a/browser/src/map/handler/Map.Keyboard.js
+++ b/browser/src/map/handler/Map.Keyboard.js
@@ -256,6 +256,39 @@ L.Map.Keyboard = L.Handler.extend({
 		zoomOut: [189, 109, 173]
 	},
 
+	allowedKeyCodeWhenNotEditing: {
+		27:    true,  // ESC
+		33:    true,  // pageUp
+		34:    true,  // pageDown
+		13:    true,  // enter
+		 8:    true,  // BACKSPACE
+		16:    true,  // SHIFT
+		17:    true,  // CTRL
+		18:    true,  // ALT
+		19:    true,  // PAUSE
+		20:    true,  // CAPSLOCK
+		35:    true,  // END
+		36:    true,  // HOME
+		45:    true,  // INSERT
+		46:    true,  // DELETE
+		91:    true,  // LEFTWINDOWKEY
+		92:    true,  // RIGHTWINDOWKEY
+		112:    true,  //F1
+		113:    true,  //F2
+		114:    true,  //F3
+		115:    true,  //F4
+		116:    true,  //F5
+		117:    true,  //F6
+		118:    true,  //F7
+		119:    true,  //F8
+		120:    true,  //F9
+		121:    true,  //F10
+		122:    true,  //F11
+		123:    true,  //F12
+		144:    true,  //NUMLOCK
+		145:    true,  //SCROLLLOCK
+	},
+
 	initialize: function (map) {
 		this._map = map;
 		this._setPanOffset(map.options.keyboardPanOffset);

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -3159,6 +3159,16 @@ void ChildSession::loKitCallback(const int type, const std::string& payload)
     case LOK_CALLBACK_COLOR_PALETTES:
         sendTextFrame("colorpalettes: " + payload);
         break;
+    case LOK_CALLBACK_A11Y_EDITING_IN_SELECTION_STATE:
+    {
+        sendTextFrame("a11yeditinginselectionstate: " + payload);
+        break;
+    }
+    case LOK_CALLBACK_A11Y_SELECTION_CHANGED:
+    {
+        sendTextFrame("a11yselectionchanged: " + payload);
+        break;
+    }
     default:
         LOG_ERR("Unknown callback event (" << lokCallbackTypeToString(type) << "): " << payload);
     }


### PR DESCRIPTION
Avoid screen reader to wrongly report text when a shape or image is
selected:
- Got editable area to be made empty when user is not editing text
- Got default for any input to be prevented (except for some special
cases) when user is not editing text so editable area is kept empty

The selection action and the selected object name (e.g. "Rectangle",
"Presentation Title", etc.) are sent to the client.
That allows screen reader to report: "Presentation Title selected" or
"Rectangle unselected", according to the action type.
Selection text content is reported too when available.

Something alike is reported on cell navigation in a spreadsheet.

Signed-off-by: Marco Cecchetti <marco.cecchetti@collabora.com>
Change-Id: I75a8b66ef8cb7b24b28d749f0b24afe2587de45e
