### PR TITLE
wsd: log TCP_NODELAY error only once

### DIFF
--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -203,7 +203,14 @@ public:
 #if !MOBILEAPP
         const int val = 1;
         if (::setsockopt(_fd, IPPROTO_TCP, TCP_NODELAY, (char *) &val, sizeof(val)) == -1)
-            LOG_SYS("Failed setsockopt TCP_NODELAY: " << strerror(errno));
+        {
+            static std::once_flag once;
+            std::call_once(once,
+                           [&]() {
+                               LOG_SYS("Failed setsockopt TCP_NODELAY. Will not report further "
+                                       "failures to set TCP_NODELAY");
+                           });
+        }
 #endif
     }
 


### PR DESCRIPTION
It seems that when TCP_NODELAY fails to be set,
the failure is permanent. As such, there is no
point in filling the logs with the same error.

This patch logs the error only once, per process,
and supresses further logs from Socket::setNoDelay().

Change-Id: I52c6b8cca35a8c281b4c4639d61a7e2521775d49
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
