### PR TITLE
Misc Improvements and Kill Poco

### DIFF
--- a/browser/html/wasm.html
+++ b/browser/html/wasm.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport"
+        content="width=device-width, initial-scale=1.0 minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <title>Online</title>
+    <style>
+        html,
+        body,
+        iframe {
+            margin: 0px;
+            padding: 0px;
+            border: none;
+        }
+    </style>
+</head>
+
+<body>
+    <form id="form" action enctype="multipart/form-data" target="coolframe" method="post">
+        <input name="access_token" value="test" type="hidden" />
+    </form>
+    <iframe id="coolframe" name="coolframe" style="width:100%;height:100%;position:absolute;">
+    </iframe>
+    <script>
+        function constructWopiUrl() {
+            var localServer = window.location.protocol + "//" + window.location.host;
+            var localUrl = localServer + window.location.pathname + "?";
+            localUrl = localUrl.replace("wasm.html", "/wasm/cool.html");
+            var params = new URLSearchParams(window.location.search);
+            var wopiSrc = params.get('WOPISrc');
+            if (wopiSrc) {
+                params.delete('WOPISrc');
+                wopiSrc = encodeURIComponent(wopiSrc);
+            }
+            else {
+                var filePath = params.get('file_path').substr(1);
+                params.delete('file_path');
+                var wopiSrc = localServer + "/wopi/files/" + encodeURIComponent(filePath);
+            }
+            return localUrl + "WOPISrc=" + wopiSrc + '&' + params.toString();
+        }
+        var form = document.getElementById("form");
+        form.action = constructWopiUrl();
+        form.submit();
+    </script>
+</body>
+
+</html>

--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -74,6 +74,13 @@ inline std::ostream& operator<<(std::ostream& os, const std::chrono::microsecond
     return os;
 }
 
+template <typename S, typename U, typename V>
+inline S& operator<<(S& stream, const std::pair<U, V>& pair)
+{
+    stream << pair.first << ": " << pair.second;
+    return stream;
+}
+
 namespace Util
 {
     namespace rng
@@ -1460,6 +1467,25 @@ int main(int argc, char**argv)
         std::ostringstream oss;
         object.dumpState(oss, indent);
         return oss.str().substr(indent.size());
+    }
+
+    /// Stringify elements from a container of pairs with a delimiter to a stream.
+    template <typename S, typename T>
+    void joinPair(S& stream, const T& container, const char* delimiter = " / ")
+    {
+        unsigned i = 0;
+        for (const auto& pair : container)
+        {
+            stream << (i++ ? delimiter : "") << pair;
+        }
+    }
+
+    /// Stringify elements from a container of pairs with a delimiter to string.
+    template <typename T> std::string joinPair(const T& container, const char* delimiter = " / ")
+    {
+        std::ostringstream oss;
+        joinPair(oss, container, delimiter);
+        return oss.str();
     }
 
     /// Asserts in the debug builds, otherwise just logs.

--- a/net/HttpHelper.cpp
+++ b/net/HttpHelper.cpp
@@ -89,14 +89,9 @@ void sendDeflatedFileContent(const std::shared_ptr<StreamSocket>& socket, const 
 }
 
 void sendFileAndShutdown(const std::shared_ptr<StreamSocket>& socket, const std::string& path,
-                         Poco::Net::HTTPResponse* optResponse, const bool noCache,
+                         http::Response& response, const bool noCache,
                          const bool deflate, const bool headerOnly)
 {
-    Poco::Net::HTTPResponse* response = optResponse;
-    Poco::Net::HTTPResponse localResponse;
-    if (!response)
-        response = &localResponse;
-
     FileUtil::Stat st(path);
     if (st.bad())
     {
@@ -108,18 +103,19 @@ void sendFileAndShutdown(const std::shared_ptr<StreamSocket>& socket, const std:
     if (!noCache)
     {
         // 60 * 60 * 24 * 128 (days) = 11059200
-        response->set("Cache-Control", "max-age=11059200");
-        response->set("ETag", "\"" COOLWSD_VERSION_HASH "\"");
+        response.set("Cache-Control", "max-age=11059200");
+        response.set("ETag", "\"" COOLWSD_VERSION_HASH "\"");
     }
     else
     {
-        response->set("Cache-Control", "no-cache");
+        response.set("Cache-Control", "no-cache");
     }
 
-    response->add("X-Content-Type-Options", "nosniff");
+    response.add("X-Content-Type-Options", "nosniff");
+
     //Should we add the header anyway ?
     if (headerOnly)
-        response->add("Connection", "close");
+        response.add("Connection", "close");
 
     int bufferSize = std::min<std::size_t>(st.size(), Socket::MaximumSendBufferSize);
     if (static_cast<long>(st.size()) >= socket->getSendBufferSize())
@@ -133,20 +129,20 @@ void sendFileAndShutdown(const std::shared_ptr<StreamSocket>& socket, const std:
     // IE/Edge before enabling the deflate again
     if (!deflate || true)
     {
-        response->setContentLength(st.size());
+        response.setContentLength(st.size());
         LOG_TRC('#' << socket->getFD() << ": Sending " << (headerOnly ? "header for " : "")
                     << " file [" << path << "].");
-        socket->send(*response);
+        socket->send(response);
 
         if (!headerOnly)
             sendUncompressedFileContent(socket, path, bufferSize);
     }
     else
     {
-        response->set("Content-Encoding", "deflate");
+        response.set("Content-Encoding", "deflate");
         LOG_TRC('#' << socket->getFD() << ": Sending " << (headerOnly ? "header for " : "")
                     << " file [" << path << "].");
-        socket->send(*response);
+        socket->send(response);
 
         if (!headerOnly)
             sendDeflatedFileContent(socket, path, st.size());

--- a/net/HttpHelper.cpp
+++ b/net/HttpHelper.cpp
@@ -23,8 +23,8 @@
 
 namespace HttpHelper
 {
-void sendError(int errorCode, const std::shared_ptr<StreamSocket>& socket, const std::string& body,
-               const std::string& extraHeader)
+void sendError(http::StatusCode errorCode, const std::shared_ptr<StreamSocket>& socket,
+               const std::string& body, const std::string& extraHeader)
 {
     std::ostringstream oss;
     oss << "HTTP/1.1 " << errorCode << "\r\n"
@@ -36,7 +36,7 @@ void sendError(int errorCode, const std::shared_ptr<StreamSocket>& socket, const
     socket->send(oss.str());
 }
 
-void sendErrorAndShutdown(int errorCode, const std::shared_ptr<StreamSocket>& socket,
+void sendErrorAndShutdown(http::StatusCode errorCode, const std::shared_ptr<StreamSocket>& socket,
                           const std::string& body, const std::string& extraHeader)
 {
     sendError(errorCode, socket, body, extraHeader + "Connection: close\r\n");

--- a/net/HttpHelper.cpp
+++ b/net/HttpHelper.cpp
@@ -89,8 +89,8 @@ void sendDeflatedFileContent(const std::shared_ptr<StreamSocket>& socket, const 
 }
 
 void sendFileAndShutdown(const std::shared_ptr<StreamSocket>& socket, const std::string& path,
-                         const std::string& mediaType, Poco::Net::HTTPResponse* optResponse,
-                         const bool noCache, const bool deflate, const bool headerOnly)
+                         Poco::Net::HTTPResponse* optResponse, const bool noCache,
+                         const bool deflate, const bool headerOnly)
 {
     Poco::Net::HTTPResponse* response = optResponse;
     Poco::Net::HTTPResponse localResponse;
@@ -116,7 +116,6 @@ void sendFileAndShutdown(const std::shared_ptr<StreamSocket>& socket, const std:
         response->set("Cache-Control", "no-cache");
     }
 
-    response->setContentType(mediaType);
     response->add("X-Content-Type-Options", "nosniff");
     //Should we add the header anyway ?
     if (headerOnly)

--- a/net/HttpHelper.hpp
+++ b/net/HttpHelper.hpp
@@ -10,6 +10,8 @@
 #include <memory>
 #include <string>
 
+#include <HttpRequest.hpp>
+
 namespace Poco
 {
     namespace Net
@@ -23,12 +25,12 @@ class StreamSocket;
 namespace HttpHelper
 {
 /// Write headers and body for an error response.
-void sendError(int errorCode, const std::shared_ptr<StreamSocket>& socket,
+void sendError(http::StatusCode errorCode, const std::shared_ptr<StreamSocket>& socket,
                const std::string& body = std::string(),
                const std::string& extraHeader = std::string());
 
 /// Write headers and body for an error response. Afterwards, shutdown the socket.
-void sendErrorAndShutdown(int errorCode, const std::shared_ptr<StreamSocket>& socket,
+void sendErrorAndShutdown(http::StatusCode errorCode, const std::shared_ptr<StreamSocket>& socket,
                           const std::string& body = std::string(),
                           const std::string& extraHeader = std::string());
 

--- a/net/HttpHelper.hpp
+++ b/net/HttpHelper.hpp
@@ -36,7 +36,6 @@ void sendErrorAndShutdown(http::StatusCode errorCode, const std::shared_ptr<Stre
 
 /// Sends file as HTTP response and shutdown the socket.
 void sendFileAndShutdown(const std::shared_ptr<StreamSocket>& socket, const std::string& path,
-                         const std::string& mediaType,
                          Poco::Net::HTTPResponse* optResponse = nullptr, bool noCache = false,
                          bool deflate = false, const bool headerOnly = false);
 

--- a/net/HttpHelper.hpp
+++ b/net/HttpHelper.hpp
@@ -12,14 +12,6 @@
 
 #include <HttpRequest.hpp>
 
-namespace Poco
-{
-    namespace Net
-    {
-        class HTTPResponse;
-    }
-}
-
 class StreamSocket;
 
 namespace HttpHelper
@@ -36,8 +28,8 @@ void sendErrorAndShutdown(http::StatusCode errorCode, const std::shared_ptr<Stre
 
 /// Sends file as HTTP response and shutdown the socket.
 void sendFileAndShutdown(const std::shared_ptr<StreamSocket>& socket, const std::string& path,
-                         Poco::Net::HTTPResponse* optResponse = nullptr, bool noCache = false,
-                         bool deflate = false, const bool headerOnly = false);
+                         http::Response& response,
+                         bool noCache = false, bool deflate = false, const bool headerOnly = false);
 
 } // namespace HttpHelper
 

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -1885,10 +1885,7 @@ private:
 
 inline std::ostream& operator<<(std::ostream& os, const http::Header& header)
 {
-    for (const auto& pair : header)
-    {
-        os << '\t' << pair.first << ": " << pair.second << " / ";
-    }
+    Util::joinPair(os, header, " / ");
 
     return os;
 }

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -856,6 +856,12 @@ public:
     /// Set an HTTP header field, replacing an earlier value, if exists.
     void set(const std::string& key, std::string value) { _header.set(key, std::move(value)); }
 
+    /// Set the Content-Type header.
+    void setContentType(std::string type) { _header.setContentType(std::move(type)); }
+
+    /// Set the Content-Length header.
+    void setContentLength(int64_t length) { _header.setContentLength(length); }
+
     /// Get a header entry value by key, if found, defaulting to @def, if missing.
     std::string get(const std::string& key, const std::string& def = std::string()) const
     {

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -8,6 +8,7 @@
 #include <config.h>
 
 #include "Socket.hpp"
+#include "Util.hpp"
 
 #include <cstring>
 #include <ctype.h>
@@ -1136,14 +1137,8 @@ bool StreamSocket::parseHeader(const char *clientName,
         request.read(message);
 
         LOG_INF(clientName << " HTTP Request: " << request.getMethod() << ' ' << request.getURI()
-                           << ' ' << request.getVersion() <<
-                [&](auto& log)
-                {
-                    for (const auto& it : request)
-                    {
-                        log << " / " << it.first << ": " << it.second;
-                    }
-                });
+                           << ' ' << request.getVersion() << ' '
+                           << [&](auto& log) { Util::joinPair(log, request, " / "); });
 
         const std::streamsize contentLength = request.getContentLength();
         const auto offset = itBody - _inBuffer.begin();

--- a/test/UnitHTTP.cpp
+++ b/test/UnitHTTP.cpp
@@ -186,7 +186,7 @@ public:
         LOK_ASSERT_EQUAL(http::StatusCode::OK, httpResponse.statusLine().statusCode());
         LOK_ASSERT(httpResponse.statusLine().statusCategory() ==
                    http::StatusLine::StatusCodeClass::Successful);
-        LOK_ASSERT_EQUAL(std::string("HTTP/1.0"), httpResponse.statusLine().httpVersion());
+        LOK_ASSERT_EQUAL(std::string("HTTP/1.1"), httpResponse.statusLine().httpVersion());
         LOK_ASSERT_EQUAL(std::string("OK"), httpResponse.statusLine().reasonPhrase());
         LOK_ASSERT_EQUAL(std::string("attachment; filename=\"test.txt\""),
                          httpResponse.header().get("Content-Disposition"));

--- a/test/UnitHTTP.cpp
+++ b/test/UnitHTTP.cpp
@@ -22,6 +22,7 @@
 #include <Log.hpp>
 #include <Util.hpp>
 #include <Unit.hpp>
+#include <lokassert.hpp>
 
 class UnitHTTP : public UnitWSD
 {
@@ -176,18 +177,19 @@ public:
         LOG_TST("Receiving...");
         char buffer[4096] = { 0, };
         int got = socket->receiveBytes(buffer, 4096);
-        static const std::string start =
-            "HTTP/1.0 200 OK\r\n"
-            "Content-Disposition: attachment; filename=\"test.txt\"\r\n";
 
-        if (strncmp(buffer, start.c_str(), start.size()))
-        {
-            LOG_TST("missing pre-amble " << got << " [" << buffer << "] vs. expected [" << start
-                                         << ']');
-            LOK_ASSERT(Util::startsWith(std::string(buffer), start));
-            exitTest(TestResult::Failed);
-            return;
-        }
+        http::Response httpResponse;
+        LOK_ASSERT_MESSAGE("Expected to receive valid data",
+                           httpResponse.readData(buffer, got) > 0);
+        LOK_ASSERT(!httpResponse.statusLine().httpVersion().empty());
+        LOK_ASSERT(!httpResponse.statusLine().reasonPhrase().empty());
+        LOK_ASSERT_EQUAL(http::StatusCode::OK, httpResponse.statusLine().statusCode());
+        LOK_ASSERT(httpResponse.statusLine().statusCategory() ==
+                   http::StatusLine::StatusCodeClass::Successful);
+        LOK_ASSERT_EQUAL(std::string("HTTP/1.0"), httpResponse.statusLine().httpVersion());
+        LOK_ASSERT_EQUAL(std::string("OK"), httpResponse.statusLine().reasonPhrase());
+        LOK_ASSERT_EQUAL(std::string("attachment; filename=\"test.txt\""),
+                         httpResponse.header().get("Content-Disposition"));
 
         // TODO: check content-length etc.
 

--- a/test/UnitWOPIFileUrl.cpp
+++ b/test/UnitWOPIFileUrl.cpp
@@ -114,7 +114,9 @@ public:
             {
                 const std::string filename = std::string(TDOC) + FileUrlFilename;
                 LOG_TST("FakeWOPIHost: Request, WOPI::GetFile sending FileUrl: " << filename);
-                HttpHelper::sendFileAndShutdown(socket, filename);
+
+                http::Response response(http::StatusCode::OK);
+                HttpHelper::sendFileAndShutdown(socket, filename, response);
                 return true;
             }
 
@@ -141,7 +143,9 @@ public:
 
                 const std::string filename = std::string(TDOC) + '/' + DefaultUrlFilename;
                 LOG_TST("FakeWOPIHost: Request, WOPI::GetFile sending Default: " << filename);
-                HttpHelper::sendFileAndShutdown(socket, filename);
+
+                http::Response response(http::StatusCode::OK);
+                HttpHelper::sendFileAndShutdown(socket, filename, response);
                 return true;
             }
         }

--- a/test/UnitWOPIFileUrl.cpp
+++ b/test/UnitWOPIFileUrl.cpp
@@ -114,7 +114,7 @@ public:
             {
                 const std::string filename = std::string(TDOC) + FileUrlFilename;
                 LOG_TST("FakeWOPIHost: Request, WOPI::GetFile sending FileUrl: " << filename);
-                HttpHelper::sendFileAndShutdown(socket, filename, "");
+                HttpHelper::sendFileAndShutdown(socket, filename);
                 return true;
             }
 
@@ -141,7 +141,7 @@ public:
 
                 const std::string filename = std::string(TDOC) + '/' + DefaultUrlFilename;
                 LOG_TST("FakeWOPIHost: Request, WOPI::GetFile sending Default: " << filename);
-                HttpHelper::sendFileAndShutdown(socket, filename, "");
+                HttpHelper::sendFileAndShutdown(socket, filename);
                 return true;
             }
         }

--- a/test/UnitWOPITemplate.cpp
+++ b/test/UnitWOPITemplate.cpp
@@ -79,7 +79,7 @@ public:
         {
             LOG_TST("FakeWOPIHost: Handling template GetFile: " << uriReq.getPath());
 
-            HttpHelper::sendFileAndShutdown(socket, TDOC "/test.ott", "");
+            HttpHelper::sendFileAndShutdown(socket, TDOC "/test.ott");
 
             return true;
         }

--- a/test/UnitWOPITemplate.cpp
+++ b/test/UnitWOPITemplate.cpp
@@ -79,7 +79,8 @@ public:
         {
             LOG_TST("FakeWOPIHost: Handling template GetFile: " << uriReq.getPath());
 
-            HttpHelper::sendFileAndShutdown(socket, TDOC "/test.ott");
+            http::Response response(http::StatusCode::OK);
+            HttpHelper::sendFileAndShutdown(socket, TDOC "/test.ott", response);
 
             return true;
         }

--- a/test/WopiTestServer.hpp
+++ b/test/WopiTestServer.hpp
@@ -531,10 +531,7 @@ protected:
             std::ostringstream oss;
             oss << "FakeWOPIHost: " << request.getMethod() << " request URI [" << uriReq.toString()
                 << "]:\n";
-            for (const auto& pair : request)
-            {
-                oss << '\t' << pair.first << ": " << pair.second << " / ";
-            }
+            Util::joinPair(oss, request, " / ");
 
             if (UnitBase::get().isFinished())
                 oss << "\nIgnoring as test has finished";

--- a/tools/WebSocketDump.cpp
+++ b/tools/WebSocketDump.cpp
@@ -158,7 +158,7 @@ private:
         catch (const std::exception& exc)
         {
             // Bad request.
-            HttpHelper::sendErrorAndShutdown(400, socket);
+            HttpHelper::sendErrorAndShutdown(http::StatusCode::BadRequest, socket);
 
             // NOTE: Check _wsState to choose between HTTP response or WebSocket (app-level) error.
             LOG_INF('#' << socket->getFD() << " Exception while processing incoming request: [" <<

--- a/tools/WebSocketDump.cpp
+++ b/tools/WebSocketDump.cpp
@@ -100,14 +100,8 @@ private:
             request.read(message);
 
             LOG_INF('#' << socket->getFD() << ": Client HTTP Request: " << request.getMethod()
-                        << ' ' << request.getURI() << ' ' << request.getVersion() <<
-                    [&](auto& log)
-                    {
-                        for (const auto& it : request)
-                        {
-                            log << " / " << it.first << ": " << it.second;
-                        }
-                    });
+                        << ' ' << request.getURI() << ' ' << request.getVersion() << ' '
+                        << [&](auto& log) { Util::joinPair(log, request, " / "); });
 
             const std::streamsize contentLength = request.getContentLength();
             const auto offset = itBody - in.begin();

--- a/wasm/README.no-container.md
+++ b/wasm/README.no-container.md
@@ -61,6 +61,25 @@ This will install into `/opt/poco.emsc.3.1.30`.
 
 ## Build Online itself
 
+    # 1. Update the directories in the command below to match your system.
+    # 2. Make sure that a document called sample.docx exists in the root of
+    #    the directory set as --with-wasm-additional-files.
+
     ./autogen.sh
 	emconfigure ./configure --disable-werror --with-lokit-path=/home/tml/lo/core-cool-wasm/include --with-lo-path=/home/tml/lo/core-cool-wasm/instdir --with-lo-builddir=/home/tml/lo/core-cool-wasm --with-zstd-includes=/opt/zstd.emsc.3.1.30/include --with-zstd-libs=/opt/zstd.emsc.3.1.30/lib --with-poco-includes=/opt/poco.emsc.3.1.30/include --with-poco-libs=/opt/poco.emsc.3.1.30/lib --host=wasm32-local-emscripten --with-wasm-additional-files=/home/tml/lo/online-hacking/my-sample-docs
     emmake make
+
+## Running WASM Online
+
+Once the build is done, copy the browser/dist to a safe locataion.
+E.g. cp -a browser/dist dist_wasm
+Next, re-configure Online and rebuild with normal config/settings (i.e. without WASM).
+Alternatively, you may have opted to build WASM in a separate directory.
+Either way, in the normal Online build directory, copy the wasm dist directory
+into the browser/dist, like this:
+cp -a dist_wasm browser/dist/wasm
+
+Now point your browser to https://localhost:9980/browser/c85d8681f3/wasm.html?file_path=/some/unused/path
+
+Notice that as of now, only the default sample.docx will be loaded.
+But the above steps should get one up and running.

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -68,6 +68,7 @@
 #include <Poco/Net/Context.h>
 #include <Poco/Net/HTMLForm.h>
 #include <Poco/Net/HTTPRequest.h>
+#include <Poco/Net/HTTPResponse.h>
 #include <Poco/Net/IPAddress.h>
 #include <Poco/Net/MessageHeader.h>
 #include <Poco/Net/NameValueCollection.h>
@@ -4342,12 +4343,13 @@ private:
         assert(socket && "Must have a valid socket");
 
         LOG_TRC_S("Favicon request: " << requestDetails.getURI());
-        const std::string mimeType = "image/vnd.microsoft.icon";
+        Poco::Net::HTTPResponse response;
+        response.setContentType("image/vnd.microsoft.icon");
         std::string faviconPath = Path(Application::instance().commandPath()).parent().toString() + "favicon.ico";
         if (!File(faviconPath).exists())
             faviconPath = COOLWSD::FileServerRoot + "/favicon.ico";
 
-        HttpHelper::sendFileAndShutdown(socket, faviconPath, mimeType);
+        HttpHelper::sendFileAndShutdown(socket, faviconPath, &response);
     }
 
     void handleWopiDiscoveryRequest(const RequestDetails &requestDetails,
@@ -4978,12 +4980,13 @@ private:
                 // with the exception of SVG where we need the browser to
                 // actually show it.
                 const std::string contentType = getContentType(fileName);
+                response.setContentType(contentType);
                 if (serveAsAttachment && contentType != "image/svg+xml")
                     response.set("Content-Disposition", "attachment; filename=\"" + fileName + '"');
 
                 try
                 {
-                    HttpHelper::sendFileAndShutdown(socket, filePath.toString(), contentType, &response);
+                    HttpHelper::sendFileAndShutdown(socket, filePath.toString(), &response);
                 }
                 catch (const Exception& exc)
                 {

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -4043,7 +4043,7 @@ private:
         if (!COOLWSD::isSSLEnabled() && socket->sniffSSL())
         {
             LOG_ERR("Looks like SSL/TLS traffic on plain http port");
-            HttpHelper::sendErrorAndShutdown(400, socket);
+            HttpHelper::sendErrorAndShutdown(http::StatusCode::BadRequest, socket);
             return;
         }
 
@@ -4238,7 +4238,7 @@ private:
                 LOG_ERR("Unknown resource: " << requestDetails.toString());
 
                 // Bad request.
-                HttpHelper::sendErrorAndShutdown(400, socket);
+                HttpHelper::sendErrorAndShutdown(http::StatusCode::BadRequest, socket);
                 return;
             }
         }
@@ -4249,7 +4249,7 @@ private:
                         << "]: " << ex.what());
 
             // Bad request.
-            HttpHelper::sendErrorAndShutdown(400, socket);
+            HttpHelper::sendErrorAndShutdown(http::StatusCode::BadRequest, socket);
             return;
         }
         catch (const std::exception& exc)
@@ -4500,7 +4500,7 @@ private:
             std::string errMsg = "Empty clipboard item / session tag " + tag;
 
             // Bad request.
-            HttpHelper::sendErrorAndShutdown(400, socket, errMsg);
+            HttpHelper::sendErrorAndShutdown(http::StatusCode::BadRequest, socket, errMsg);
         }
     }
 
@@ -5119,7 +5119,7 @@ private:
                                   << ". Terminating connection. Error: " << exc.what());
                     }
                     // badness occurred:
-                    HttpHelper::sendErrorAndShutdown(400, streamSocket);
+                    HttpHelper::sendErrorAndShutdown(http::StatusCode::BadRequest, streamSocket);
                 });
         }
         else
@@ -5127,7 +5127,7 @@ private:
             auto streamSocket = std::static_pointer_cast<StreamSocket>(disposition.getSocket());
             LOG_ERR("Failed to find document");
             // badness occurred:
-            HttpHelper::sendErrorAndShutdown(400, streamSocket);
+            HttpHelper::sendErrorAndShutdown(http::StatusCode::BadRequest, streamSocket);
             // FIXME: send docunloading & re-try on client ?
         }
     }

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -4343,13 +4343,13 @@ private:
         assert(socket && "Must have a valid socket");
 
         LOG_TRC_S("Favicon request: " << requestDetails.getURI());
-        Poco::Net::HTTPResponse response;
+        http::Response response(http::StatusCode::OK);
         response.setContentType("image/vnd.microsoft.icon");
         std::string faviconPath = Path(Application::instance().commandPath()).parent().toString() + "favicon.ico";
         if (!File(faviconPath).exists())
             faviconPath = COOLWSD::FileServerRoot + "/favicon.ico";
 
-        HttpHelper::sendFileAndShutdown(socket, faviconPath, &response);
+        HttpHelper::sendFileAndShutdown(socket, faviconPath, response);
     }
 
     void handleWopiDiscoveryRequest(const RequestDetails &requestDetails,
@@ -4974,7 +4974,7 @@ private:
                 if (attachmentIt != postRequestQueryParams.end())
                     serveAsAttachment = attachmentIt->second != "0";
 
-                Poco::Net::HTTPResponse response;
+                http::Response response(http::StatusCode::OK);
 
                 // Instruct browsers to download the file, not display it
                 // with the exception of SVG where we need the browser to
@@ -4986,7 +4986,7 @@ private:
 
                 try
                 {
-                    HttpHelper::sendFileAndShutdown(socket, filePath.toString(), &response);
+                    HttpHelper::sendFileAndShutdown(socket, filePath.toString(), response);
                 }
                 catch (const Exception& exc)
                 {

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -259,9 +259,9 @@ void ClientSession::handleClipboardRequest(DocumentBroker::ClipboardRequest     
             return; // the getclipboard already completed.
         if (type == DocumentBroker::CLIP_REQUEST_SET)
         {
-            #if !MOBILEAPP
-            HttpHelper::sendErrorAndShutdown(400, socket);
-            #endif
+#if !MOBILEAPP
+            HttpHelper::sendErrorAndShutdown(http::StatusCode::BadRequest, socket);
+#endif
         }
         else // will be handled during shutdown
         {
@@ -320,9 +320,9 @@ void ClientSession::handleClipboardRequest(DocumentBroker::ClipboardRequest     
         }
         else
         {
-            #if !MOBILEAPP
-            HttpHelper::sendErrorAndShutdown(400, socket);
-            #endif
+#if !MOBILEAPP
+            HttpHelper::sendErrorAndShutdown(http::StatusCode::BadRequest, socket);
+#endif
         }
     }
 }

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1809,15 +1809,16 @@ bool ClientSession::handleKitToClientMessage(const std::shared_ptr<Message>& pay
             // TODO: Send back error when there is no output.
             if (!resultURL.getPath().empty())
             {
-                const std::string mimeType = "application/octet-stream";
                 LOG_TRC("Sending file: " << resultURL.getPath());
 
                 const std::string fileName = Poco::Path(resultURL.getPath()).getFileName();
                 Poco::Net::HTTPResponse response;
+                // We have a fragile test that expects Content-Disposition first.
                 if (!fileName.empty())
                     response.set("Content-Disposition", "attachment; filename=\"" + fileName + '"');
+                response.setContentType("application/octet-stream");
 
-                HttpHelper::sendFileAndShutdown(_saveAsSocket, resultURL.getPath(), mimeType, &response);
+                HttpHelper::sendFileAndShutdown(_saveAsSocket, resultURL.getPath(), &response);
             }
 
             // Conversion is done, cleanup this fake session.

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1813,7 +1813,6 @@ bool ClientSession::handleKitToClientMessage(const std::shared_ptr<Message>& pay
 
                 const std::string fileName = Poco::Path(resultURL.getPath()).getFileName();
                 Poco::Net::HTTPResponse response;
-                // We have a fragile test that expects Content-Disposition first.
                 if (!fileName.empty())
                     response.set("Content-Disposition", "attachment; filename=\"" + fileName + '"');
                 response.setContentType("application/octet-stream");

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1812,12 +1812,12 @@ bool ClientSession::handleKitToClientMessage(const std::shared_ptr<Message>& pay
                 LOG_TRC("Sending file: " << resultURL.getPath());
 
                 const std::string fileName = Poco::Path(resultURL.getPath()).getFileName();
-                Poco::Net::HTTPResponse response;
+                http::Response response(http::StatusCode::OK);
                 if (!fileName.empty())
                     response.set("Content-Disposition", "attachment; filename=\"" + fileName + '"');
                 response.setContentType("application/octet-stream");
 
-                HttpHelper::sendFileAndShutdown(_saveAsSocket, resultURL.getPath(), &response);
+                HttpHelper::sendFileAndShutdown(_saveAsSocket, resultURL.getPath(), response);
             }
 
             // Conversion is done, cleanup this fake session.

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -3247,7 +3247,8 @@ bool DocumentBroker::lookupSendClipboardTag(const std::shared_ptr<StreamSocket> 
 
 #if !MOBILEAPP
     // Bad request.
-    HttpHelper::sendError(400, socket, "Failed to find this clipboard", "Connection: close\r\n");
+    HttpHelper::sendError(http::StatusCode::BadRequest, socket, "Failed to find this clipboard",
+                          "Connection: close\r\n");
 #endif
     socket->shutdown();
     socket->ignoreInput();

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -287,6 +287,24 @@ bool FileServerRequestHandler::isAdminLoggedIn(const HTTPRequest& request,
     return true;
 }
 
+bool FileServerRequestHandler::isAdminLoggedIn(const HTTPRequest& request, http::Response& response)
+{
+    // For now, we reuse the exiting implementation, which uses Poco HTTPCookie.
+    Poco::Net::HTTPResponse pocoResponse;
+    if (isAdminLoggedIn(request, pocoResponse))
+    {
+        // Copy the headers, including the cookies.
+        for (const auto& pair : pocoResponse)
+        {
+            response.set(pair.first, pair.second);
+        }
+
+        return true;
+    }
+
+    return false;
+}
+
 #if ENABLE_DEBUG
     // Represents basic file's attributes.
     // Used for localFile
@@ -476,7 +494,7 @@ void FileServerRequestHandler::handleRequest(const HTTPRequest& request,
 #if ENABLE_DEBUG
         noCache = !COOLWSD::ForceCaching; // for cypress
 #endif
-        Poco::Net::HTTPResponse response;
+        http::Response response(http::StatusCode::OK);
 
         const auto& config = Application::instance().config();
 
@@ -528,10 +546,7 @@ void FileServerRequestHandler::handleRequest(const HTTPRequest& request,
             if (coolLogging != "false")
             {
                 LOG_ERR(message.rdbuf());
-
-                std::ostringstream oss;
-                response.write(oss);
-                socket->send(oss.str());
+                socket->send(response);
                 return;
             }
         }
@@ -632,18 +647,19 @@ void FileServerRequestHandler::handleRequest(const HTTPRequest& request,
             response.set("Server", HTTP_SERVER_STRING);
             response.set("Date", Util::getHttpTimeNow());
 
-            bool gzip = request.hasToken("Accept-Encoding", "gzip");
-            const std::string *content;
 #if ENABLE_DEBUG
             if (std::getenv("COOL_SERVE_FROM_FS"))
             {
                 // Useful to not serve from memory sometimes especially during cool development
                 // Avoids having to restart cool everytime you make a change in cool
                 const std::string filePath = Poco::Path(COOLWSD::FileServerRoot, relPath).absolute().toString();
-                HttpHelper::sendFileAndShutdown(socket, filePath, &response, noCache);
+                HttpHelper::sendFileAndShutdown(socket, filePath, response, noCache);
                 return;
             }
 #endif
+
+            const bool gzip = request.hasToken("Accept-Encoding", "gzip");
+            const std::string* content;
             if (gzip)
             {
                 response.set("Content-Encoding", "gzip");
@@ -658,15 +674,12 @@ void FileServerRequestHandler::handleRequest(const HTTPRequest& request,
                 response.set("Cache-Control", "max-age=11059200");
                 response.set("ETag", etagString);
             }
-            response.setContentType(mimeType);
             response.add("X-Content-Type-Options", "nosniff");
 
-            std::ostringstream oss;
-            response.write(oss);
-            const std::string header = oss.str();
-            LOG_TRC('#' << socket->getFD() << ": Sending " <<
-                    (!gzip ? "un":"") << "compressed : file [" << relPath << "]: " << header);
-            socket->send(header);
+            LOG_TRC('#' << socket->getFD() << ": Sending " << (!gzip ? "un" : "")
+                        << "compressed : file [" << relPath << "]: " << response.header());
+
+            socket->send(response);
             socket->send(*content);
             // shutdown by caller
         }

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -607,6 +607,8 @@ void FileServerRequestHandler::handleRequest(const HTTPRequest& request,
             else
                 mimeType = "text/plain";
 
+            response.setContentType(mimeType);
+
             auto it = request.find("If-None-Match");
             if (it != request.end())
             {
@@ -638,7 +640,7 @@ void FileServerRequestHandler::handleRequest(const HTTPRequest& request,
                 // Useful to not serve from memory sometimes especially during cool development
                 // Avoids having to restart cool everytime you make a change in cool
                 const std::string filePath = Poco::Path(COOLWSD::FileServerRoot, relPath).absolute().toString();
-                HttpHelper::sendFileAndShutdown(socket, filePath, mimeType, &response, noCache);
+                HttpHelper::sendFileAndShutdown(socket, filePath, &response, noCache);
                 return;
             }
 #endif

--- a/wsd/FileServer.hpp
+++ b/wsd/FileServer.hpp
@@ -8,7 +8,9 @@
 #pragma once
 
 #include <string>
-#include "Socket.hpp"
+
+#include <HttpRequest.hpp>
+#include <Socket.hpp>
 
 #include <Poco/MemoryStream.h>
 #include <Poco/Util/LayeredConfiguration.h>
@@ -67,9 +69,10 @@ public:
 
 private:
     static std::map<std::string, std::pair<std::string, std::string>> FileHash;
-    static void sendError(int errorCode, const Poco::Net::HTTPRequest& request,
-                          const std::shared_ptr<StreamSocket>& socket, const std::string& shortMessage,
-                          const std::string& longMessage, const std::string& extraHeader = "");
+    static void sendError(http::StatusCode errorCode, const Poco::Net::HTTPRequest& request,
+                          const std::shared_ptr<StreamSocket>& socket,
+                          const std::string& shortMessage, const std::string& longMessage,
+                          const std::string& extraHeader = std::string());
 };
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/FileServer.hpp
+++ b/wsd/FileServer.hpp
@@ -55,6 +55,7 @@ public:
 
     /// Evaluate if the cookie exists, and if not, ask for the credentials.
     static bool isAdminLoggedIn(const Poco::Net::HTTPRequest& request, Poco::Net::HTTPResponse& response);
+    static bool isAdminLoggedIn(const Poco::Net::HTTPRequest& request, http::Response& response);
 
     static void handleRequest(const Poco::Net::HTTPRequest& request,
                               const RequestDetails &requestDetails,

--- a/wsd/ProxyRequestHandler.cpp
+++ b/wsd/ProxyRequestHandler.cpp
@@ -67,25 +67,25 @@ void ProxyRequestHandler::handleRequest(const std::string& relPath,
                     }
                     else
                     {
-                        HttpHelper::sendErrorAndShutdown(400, socket);
+                        HttpHelper::sendErrorAndShutdown(http::StatusCode::BadRequest, socket);
                     }
                 }
                 catch(std::exception& exc)
                 {
                     LOG_ERR("ProxyCallback: " << exc.what());
-                    HttpHelper::sendErrorAndShutdown(400, socket);
+                    HttpHelper::sendErrorAndShutdown(http::StatusCode::BadRequest, socket);
                 }
                 catch(...)
                 {
                     LOG_ERR("ProxyCallback: Unknown exception");
-                    HttpHelper::sendErrorAndShutdown(400, socket);
+                    HttpHelper::sendErrorAndShutdown(http::StatusCode::BadRequest, socket);
                 }
             };
 
     sessionProxy->setFinishedHandler(proxyCallback);
     if (!sessionProxy->asyncRequest(requestProxy, *COOLWSD::getWebServerPoll()))
     {
-        HttpHelper::sendErrorAndShutdown(400, socket);
+        HttpHelper::sendErrorAndShutdown(http::StatusCode::BadRequest, socket);
     }
 }
 


### PR DESCRIPTION
- wasm: improved build instructions in readme
- wsd: log TCP_NODELAY error only once
- browser: add wasm.html to load documents via wasm
- wsd: http: use named HTTP status-code instead of naked int
- wsd: http: no need to pass the mime-type explicitly to sendFile
- wsd: helper to serialize pairs
- killpoco: replace HTTPResponse in sendFileAndShutdown
- wasm: support serving wasm files
