### PR TITLE
a11y: on Firefox delete key doesn't work in some specific case

### DIFF
--- a/browser/src/layer/marker/TextInput.js
+++ b/browser/src/layer/marker/TextInput.js
@@ -659,7 +659,7 @@ L.TextInput = L.Layer.extend({
 		}
 		// Firefox is not able to delete the <img> post space. Since no 'input' event is generated,
 		// we need to handle a <delete> at the end of the paragraph, here.
-		if (L.Browser.gecko && this.getPlainTextContent().length === 0 && this._deleteHint === 'delete') {
+		if (L.Browser.gecko && this._isCursorAtEnd() && this._deleteHint === 'delete') {
 			window.app.console.log('Sending delete');
 			this._removeTextContent(0, 1);
 			this._emptyArea();


### PR DESCRIPTION
The problem occurs when accessibility is disabled
Exactly when the editable area is not empty and the cursor inside the
editable area is at the end.

Signed-off-by: Marco Cecchetti <marco.cecchetti@collabora.com>
Change-Id: Ia69e0f56233497e91babf9e33080701e1f1adad2
