### PR TITLE
postmessage: Add field to allow sending arbitrary postmessages

### DIFF
--- a/browser/html/framed.doc.html
+++ b/browser/html/framed.doc.html
@@ -139,6 +139,10 @@
               'Values': {'Mode': value}});
       }
 
+      function Execute(messageId, values) {
+        post({'MessageId': messageId, 'Values': values});
+      }
+
       function reset_access_token(accesstoken) {
         post({'MessageId': 'Reset_Access_Token',
               'Values': { 'token': accesstoken, }
@@ -333,6 +337,18 @@
       <label for="new-access-token"><b>New Access-Token</b>: </label><br>
       <textarea name="new-access-token" id="new-access-token" value="" rows="1" cols="30">123456789AA</textarea><br>
       <button onclick="reset_access_token(document.getElementById('new-access-token').value); return false;">Reset Access-Token</button>
+    </form>
+
+    <h3>Send a message</h3>
+
+    <form>
+      <label for="execute-message"><b>Message</b>: </label><br>
+      <input type="text" name="execute-message" id="execute-message" /><br>
+      <label for="execute-param"><b>Values</b>: </label><br>
+      <p>This is the JSON format 'Values'.</p>
+      <textarea name="execute-param" id="execute-param">{}</textarea>
+      <br>
+      <button onclick="Execute(document.getElementById('execute-message').value, JSON.parse(document.getElementById('execute-param').value)); return false;">Execute</button>
     </form>
 
     <h3>Modified Status: <span id="ModifiedStatus">Saved</span></h3>


### PR DESCRIPTION
Change-Id: I13976c21ebea018150469dd56f93b3b1ab2105cc


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

This allow to send arbitrary post message. This is just UI in the postmessage interface page.

This is how I did test #7517 

### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

