### PR TITLE
UI: avoid changing back to original name after renaming

### DIFF
--- a/browser/src/control/Control.DocumentNameInput.js
+++ b/browser/src/control/Control.DocumentNameInput.js
@@ -15,6 +15,7 @@ L.Control.DocumentNameInput = L.Control.extend({
 
 	documentNameConfirm: function(value) {
 		if (value !== null && value != '' && value != this.map['wopi'].BaseFileName) {
+			this._renaming = true;
 			if (this.map['wopi'].UserCanRename && this.map['wopi'].SupportsRename) {
 				if (value.lastIndexOf('.') > 0) {
 					var fname = this.map['wopi'].BaseFileName;
@@ -42,6 +43,9 @@ L.Control.DocumentNameInput = L.Control.extend({
 	},
 
 	documentNameCancel: function() {
+		if (this._renaming)
+			return;
+
 		$('#document-name-input').val(this.map['wopi'].BreadcrumbDocName);
 		this.map._onGotFocus();
 	},
@@ -57,6 +61,7 @@ L.Control.DocumentNameInput = L.Control.extend({
 
 	onDocumentNameFocus: function() {
 		// hide the caret in the main document
+		delete this._renaming;
 		this.map._onLostFocus();
 		var name = this.map['wopi'].BaseFileName;
 		var extn = name.lastIndexOf('.');


### PR DESCRIPTION
problem:
filename textbox will revert to original name after user confirms the name and then again changes to new name after its processed

fixes: #6131

Change-Id: Ibb1645e5e6517b391d475add7b7d421a260e0ba8

* Target version: master 

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

