### PR TITLE
UI: fix rename dialog flickering

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2611,7 +2611,8 @@ L.Control.JSDialogBuilder = L.Control.extend({
 
 		$(control.container).unbind('click.toolbutton');
 		if (!builder.map.isLockedItem(data)) {
-			$(control.container).click(function () {
+			$(control.container).click(function (e) {
+				e.preventDefault();
 				builder.map.dispatch(data.command);
 			});
 		}


### PR DESCRIPTION
problem:
rename dialog sometimes flickered in Firefox
it flickered when the button label was clicked,
it made the event bubble and triggered the click event multiple times. trying to open dialog when already opened makes it flicker intentionally

fixes: #7479

Change-Id: I290c905ac321650bd7979495c78de7d66f188ffd


* Target version: master 

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

