### PR TITLE
sidebar: fix paragraph panel layout

### DIFF
--- a/browser/css/device-mobile.css
+++ b/browser/css/device-mobile.css
@@ -720,6 +720,13 @@ td[id^='tb_spreadsheet-toolbar_item']:focus table.w2ui-button div.w2ui-icon, td[
 #mobile-wizard.popup.snackbar #button {
 	font-size: 14px !important;
 }
+/* Separators */
+.mobile-wizard.ui-separator {
+	/* Hide separators coming from core when on mobile
+	since we are already adding border top on every
+	#mobile-wizard .mobile-wizard.ui-text */
+	display: none;
+}
 /*   - Import text */
 #mobile-wizard-content #separatoroptions {
 	margin-top: 54px;

--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -266,7 +266,10 @@ div.sidebar.ui-grid .checkbutton.sidebar,
 	column-gap: 5px;
 }
 
+/* Separators */
 .jsdialog.sidebar.ui-separator {
+	/* Hide separators for now.
+	 TODO: re-test and possibily enable them with different style*/
 	display: none;
 }
 

--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -266,6 +266,10 @@ div.sidebar.ui-grid .checkbutton.sidebar,
 	column-gap: 5px;
 }
 
+.jsdialog.sidebar.ui-separator {
+	display: none;
+}
+
 button#button2.ui-pushbutton.jsdialog.sidebar {
 	width: 151px;
 	padding: 4px;


### PR DESCRIPTION
This fixes regression from commit c77f1041a58cd4606c69a0808888dc16dd654785 jsdialog: implement horizontal separator

Where horizontal separator widget was implemented
and now it appears in the sidebar, but as we have grid layout there - it occupies only half of the sidebar because we have 2 columns.