### PR TITLE
missing continue keyword

### DIFF
--- a/wsd/FileServerUtil.cpp
+++ b/wsd/FileServerUtil.cpp
@@ -63,8 +63,9 @@ std::string FileServerRequestHandler::uiDefaultsToJSON(const std::string& uiDefa
         // detect the UITheme default, light or dark
         if (keyValue.equals(0, "UITheme"))
         {
-                json.set("darkTheme", keyValue.equals(1, "dark"));
-                uiTheme = keyValue[1];
+            json.set("darkTheme", keyValue.equals(1, "dark"));
+            uiTheme = keyValue[1];
+            continue;
         }
         if (keyValue.equals(0, "SaveAsMode"))
         {


### PR DESCRIPTION
Caused log ERR on startup:
[ websrv_poll ] ERR  unknown UI default's component UITheme| wsd/FileServerUtil.cpp:99


Change-Id: I82f036e393cfb271e2dec2c52c5dc512aed265c8
