### PR TITLE
apply delayed messages after docLayer.map is set

### DIFF
--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -1377,11 +1377,11 @@ app.definitions.Socket = L.Class.extend({
 				});
 			}
 
-			if (docLayer !== null) {
-				this._handleDelayedMessages(docLayer);
-			}
 			this._map._docLayer = docLayer;
 			this._map.addLayer(docLayer);
+			// docLayer.map is set by addLayer and docLayer.map should be set before
+			// applying delayed messages
+			this._handleDelayedMessages(docLayer);
 			this._map.fire('doclayerinit');
 		}
 		else if (this._reconnecting) {


### PR DESCRIPTION
which is done by addLayer, otherwise its possible to handle a onViewInfoMsg before map is set


Change-Id: If6e6d15c90de129614bcc2b64705d0b51b5c4e83


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

