### PR TITLE
annotation: avoid marking comment autosave if its not saved

### DIFF
--- a/browser/src/layer/tile/CommentSection.ts
+++ b/browser/src/layer/tile/CommentSection.ts
@@ -844,22 +844,15 @@ export class Comment extends CanvasSectionObject {
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 	public onLostFocus (e: any): void {
 		if (!this.sectionProperties.isRemoved) {
-			if (!this.sectionProperties.nodeModifyText.value &&
-				!this.sectionProperties.contentText.origText)
-				return;
-			app.view.commentAutoSave = this;
 			if (this.sectionProperties.contentText.origText !== this.sectionProperties.nodeModifyText.value) {
+				app.view.commentAutoSave = this;
 				this.onSaveComment(e);
 			}
-			else {
-				if (!this.containerObject.testing) // eslint-disable-line no-lonely-if
-					this.onCancelClick(e);
-				else {
-					var insertButton = document.getElementById('menu-insertcomment');
-					if (insertButton) {
-						if (window.getComputedStyle(insertButton).display === 'none') {
-							this.onCancelClick(e);
-						}
+			else if (this.containerObject.testing) {
+				var insertButton = document.getElementById('menu-insertcomment');
+				if (insertButton) {
+					if (window.getComputedStyle(insertButton).display === 'none') {
+						this.onCancelClick(e);
 					}
 				}
 			}


### PR DESCRIPTION
problem:
After entering the comment modify mode and clicking somewhere else, to lose comment focus, comment cannot be closed by clicking cancel.


Change-Id: I05ce2b4f6dcba47d40095bb16fdb56ce5b9c20cf


* Target version: master 



### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

