### PR TITLE
we don't need to round-trip through core to reposition notes

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1565,15 +1565,21 @@ L.CanvasTileLayer = L.Layer.extend({
 		}
 	},
 
-	_cellRangeToTwipRect: function(cellRange) {
+	_parseCellRange: function(cellRange) {
 		var strTwips = cellRange.match(/\d+/g);
 		var startCellAddress = [parseInt(strTwips[0]), parseInt(strTwips[1])];
-		var startCellRectPixel = this.sheetGeometry.getCellRect(startCellAddress[0], startCellAddress[1]);
-		var topLeftTwips = this._corePixelsToTwips(startCellRectPixel.min);
 		var endCellAddress = [parseInt(strTwips[2]), parseInt(strTwips[3])];
-		var endCellRectPixel = this.sheetGeometry.getCellRect(endCellAddress[0], endCellAddress[1]);
+		return new L.Bounds(startCellAddress, endCellAddress);
+	},
+
+	_cellRangeToTwipRect: function(cellRange) {
+		var startCell = cellRange.getTopLeft();
+		var startCellRectPixel = this.sheetGeometry.getCellRect(startCell.x, startCell.y);
+		var topLeftTwips = this._corePixelsToTwips(startCellRectPixel.min);
+		var endCell = cellRange.getBottomRight();
+		var endCellRectPixel = this.sheetGeometry.getCellRect(endCell.x, endCell.y);
 		var bottomRightTwips = this._corePixelsToTwips(endCellRectPixel.max);
-		return new L.Bounds(new L.Point(topLeftTwips.x, topLeftTwips.y), new L.Point(bottomRightTwips.x, bottomRightTwips.y));
+		return new L.Bounds(topLeftTwips, bottomRightTwips);
 	},
 
 	_onMessage: function (textMsg, img) {
@@ -1831,10 +1837,6 @@ L.CanvasTileLayer = L.Layer.extend({
 		}
 		else if (textMsg.startsWith('comment:')) {
 			var obj = JSON.parse(textMsg.substring('comment:'.length + 1));
-			if (obj.comment.cellRange) {
-				// convert cellRange e.g. "A1 B2" to its bounds in display twips.
-				obj.comment.cellPos = this._cellRangeToTwipRect(obj.comment.cellRange).toCoreString();
-			}
 			app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).onACKComment(obj);
 		}
 		else if (textMsg.startsWith('redlinetablemodified:')) {

--- a/browser/src/layer/tile/CommentSection.ts
+++ b/browser/src/layer/tile/CommentSection.ts
@@ -380,16 +380,17 @@ export class Comment extends CanvasSectionObject {
 			if (this.size[0] < 5)
 				this.size[0] = 5;
 		}
-		else if (this.sectionProperties.data.cellPos && this.sectionProperties.docLayer._docType === 'spreadsheet') {
+		else if (this.sectionProperties.data.cellRange && this.sectionProperties.docLayer._docType === 'spreadsheet') {
 			var ratio: number = (app.tile.size.pixels[0] / app.tile.size.twips[0]);
 			this.size = this.calcCellSize();
-			let startX = this.sectionProperties.data.cellPos[0];
+			var cellPos = this.map._docLayer._cellRangeToTwipRect(this.sectionProperties.data.cellRange).toRectangle();
+			let startX = cellPos[0];
 			if (this.isCalcRTL()) { // Mirroring is done in setPosition
-				const sizeX = this.sectionProperties.data.cellPos[2];
+				const sizeX = cellPos[2];
 				startX += sizeX;  // but adjust for width of the cell.
 			}
 			this.showSection = true;
-			var position: Array<number> = [Math.round(this.sectionProperties.data.cellPos[0] * ratio), Math.round(this.sectionProperties.data.cellPos[1] * ratio)];
+			var position: Array<number> = [Math.round(cellPos[0] * ratio), Math.round(cellPos[1] * ratio)];
 			var splitPosCore = {x: 0, y: 0};
 			if (this.map._docLayer.getSplitPanesContext())
 				splitPosCore = this.map._docLayer.getSplitPanesContext().getSplitPos();
@@ -655,7 +656,8 @@ export class Comment extends CanvasSectionObject {
 
 		if (!(<any>window).mode.isMobile()) {
 			var ratio: number = (app.tile.size.pixels[0] / app.tile.size.twips[0]);
-			var originalSize = [Math.round((this.sectionProperties.data.cellPos[2]) * ratio), Math.round((this.sectionProperties.data.cellPos[3]) * ratio)];
+			var cellPos = this.map._docLayer._cellRangeToTwipRect(this.sectionProperties.data.cellRange).toRectangle();
+			var originalSize = [Math.round((cellPos[2]) * ratio), Math.round((cellPos[3]) * ratio)];
 
 			this.sectionProperties.container.style.visibility = '';
 
@@ -1115,7 +1117,8 @@ export class Comment extends CanvasSectionObject {
 
 	public calcCellSize (): number[] {
 		var ratio: number = (app.tile.size.pixels[0] / app.tile.size.twips[0]);
-		return [Math.round((this.sectionProperties.data.cellPos[2]) * ratio), Math.round((this.sectionProperties.data.cellPos[3]) * ratio)];
+		var cellPos = this.map._docLayer._cellRangeToTwipRect(this.sectionProperties.data.cellRange).toRectangle();
+		return [Math.round((cellPos[2]) * ratio), Math.round((cellPos[3]) * ratio)];
 	}
 
 	public onMouseEnter (): void {
@@ -1135,7 +1138,8 @@ export class Comment extends CanvasSectionObject {
 
 				var containerWidth: number = this.sectionProperties.container.getBoundingClientRect().width;
 				var ratio: number = (app.tile.size.pixels[0] / app.tile.size.twips[0]);
-				this.size = [Math.round((this.sectionProperties.data.cellPos[2]) * ratio + containerWidth), Math.round((this.sectionProperties.data.cellPos[3]) * ratio)];
+				var cellPos = this.map._docLayer._cellRangeToTwipRect(this.sectionProperties.data.cellRange).toRectangle();
+				this.size = [Math.round((cellPos[2]) * ratio + containerWidth), Math.round((cellPos[3]) * ratio)];
 				this.sectionProperties.commentListSection.selectById(this.sectionProperties.data.id);
 				this.show();
 			}


### PR DESCRIPTION
we know where they are by cell addresses, so defer getting the screen positions until we need them and we don't need to get core to trigger recalculating them. When we redraw the comments after the new geometry arrives then we can place them via the address.

When adding a new note we want to know the range of the potentially merged cells we are inserting into.

https://github.com/CollaboraOnline/online/issues/7334

https://gerrit.libreoffice.org/c/core/+/158560 needs to be applied to solve the problem described there that becomes apparent when this is in place.


Change-Id: I3228dc8fa8d47ba4e796e50427c125d7f78fe5fc


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

