### PR TITLE
this._mouseOverEntry can be null on resizing header/footer

### DIFF
--- a/browser/src/control/Control.ColumnHeader.ts
+++ b/browser/src/control/Control.ColumnHeader.ts
@@ -254,7 +254,7 @@ export class ColumnHeader extends Header {
 			const entry = this._mouseOverEntry;
 			let modifier = 0;
 
-			if (this._startSelectionEntry && this._startSelectionEntry.index !== entry.index) {
+			if (this._startSelectionEntry && entry && this._startSelectionEntry.index !== entry.index) {
 				this._selectColumn(this._startSelectionEntry.index, modifier);
 				modifier += UNOModifier.SHIFT;
 				this._selectColumn(entry.index, modifier);

--- a/browser/src/control/Control.RowHeader.ts
+++ b/browser/src/control/Control.RowHeader.ts
@@ -242,7 +242,7 @@ export class RowHeader extends cool.Header {
 			const entry = this._mouseOverEntry;
 			let modifier = 0;
 
-			if (this._startSelectionEntry && this._startSelectionEntry.index !== entry.index) {
+			if (this._startSelectionEntry && entry && this._startSelectionEntry.index !== entry.index) {
 				this._selectRow(this._startSelectionEntry.index, modifier);
 				modifier += UNOModifier.SHIFT;
 				this._selectRow(entry.index, modifier);


### PR DESCRIPTION
seen sometimes when debugging moving rows and cols with comments in them


Change-Id: I20a01f27957b5fa507cd37a1020a93bbba05c630


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

