### PR TITLE
apply delayed messages after docLayer.viewid is set

### DIFF
--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -1379,9 +1379,6 @@ app.definitions.Socket = L.Class.extend({
 
 			this._map._docLayer = docLayer;
 			this._map.addLayer(docLayer);
-			// docLayer.map is set by addLayer and docLayer.map should be set before
-			// applying delayed messages
-			this._handleDelayedMessages(docLayer);
 			this._map.fire('doclayerinit');
 		}
 		else if (this._reconnecting) {
@@ -1407,6 +1404,13 @@ app.definitions.Socket = L.Class.extend({
 		if (this._map._docLayer) {
 			this._map._docLayer._onMessage(textMsg);
 			this._reconnecting = false;
+
+			// Applying delayed messages
+			// note: delayed messages cannot be done before:
+			// a) docLayer.map is set by map.addLayer(docLayer)
+			// b) docLayer._onStatusMsg (via _docLayer._onMessage)
+			// has set the viewid
+			this._handleDelayedMessages(docLayer);
 		}
 	},
 


### PR DESCRIPTION
which is done by docLayer._onStatusMsg(), otherwise its possible to handle a onViewInfoMsg before viewid is set


Change-Id: Id68dba5f5cdc8efd0b5f6ed429ac4f105cef4866


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

