### PR TITLE
Fix: Select of content in Formula Bar is hard as it changes position

### DIFF
--- a/browser/src/control/Control.FormulaBar.js
+++ b/browser/src/control/Control.FormulaBar.js
@@ -139,7 +139,7 @@ L.Map.include({
 			target = mobileTopBar;
 		} else {
 			jsdialogFormulabar.hide('startformula');
-			jsdialogFormulabar.hide('AutoSumMenu');
+			$('#AutoSumMenu').hide();
 		}
 		target.show('cancelformula');
 		target.show('acceptformula');
@@ -165,11 +165,11 @@ L.Map.include({
 			mobileTopBar.show('undo');
 			mobileTopBar.show('redo');
 
-			$('#AutoSumMenuimg').css('margin-inline', '0');
+			$('#AutoSumMenu-button').css('margin-inline', '0');
 			$('#AutoSumMenu .unoarrow').css('margin', '0');
 
 			jsdialogFormulabar.show('startformula');
-			jsdialogFormulabar.show('AutoSumMenu');
+			$('#AutoSumMenu').show();
 
 			// clear reference marks
 			map._docLayer._clearReferences();

--- a/browser/src/control/Control.FormulaBarJSDialog.js
+++ b/browser/src/control/Control.FormulaBarJSDialog.js
@@ -50,7 +50,8 @@ L.Control.FormulaBarJSDialog = L.Control.extend({
 							command: '.uno:FunctionDialog'
 						},
 						{
-							id: 'autosummenu:AutoSumMenu',
+							id: 'AutoSumMenu',
+							'class': 'AutoSumMenu',
 							type: 'menubutton',
 							command: '.uno:AutoSumMenu'
 						},


### PR DESCRIPTION
- Fix illegal HTML id `autosummenu:AutoSumMenu`
- Update CSS rules: img if doesn't exist anymore, apply margin reset
to new button instead
- Also Add missing css class, we used to have that before the
Accessibility commit 1a2500c

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: If4c2fa9ff99a6c09f42d6ba4db3f1dd186e099ea
