### PR TITLE
jsdialog: fix id for buttons with menu #7548

### DIFF
--- a/browser/src/control/Control.FormulaBar.js
+++ b/browser/src/control/Control.FormulaBar.js
@@ -165,7 +165,7 @@ L.Map.include({
 			mobileTopBar.show('undo');
 			mobileTopBar.show('redo');
 
-			$('#AutoSumMenuimg').css('margin-inline', '0');
+			$('#AutoSumMenu-button').css('margin-inline', '0');
 			$('#AutoSumMenu .unoarrow').css('margin', '0');
 
 			jsdialogFormulabar.show('startformula');

--- a/browser/src/control/Control.FormulaBarJSDialog.js
+++ b/browser/src/control/Control.FormulaBarJSDialog.js
@@ -50,8 +50,9 @@ L.Control.FormulaBarJSDialog = L.Control.extend({
 							command: '.uno:FunctionDialog'
 						},
 						{
-							id: 'autosummenu:AutoSumMenu',
+							id: 'AutoSumMenu:AutoSumMenu',
 							type: 'menubutton',
+							class: 'AutoSumMenu',
 							command: '.uno:AutoSumMenu'
 						},
 						{
@@ -307,11 +308,6 @@ L.Control.FormulaBarJSDialog = L.Control.extend({
 				}
 				return;
 			}
-
-			// ignore some actions to not spam in the console, we don't support them now
-			if ((window.mode.isMobile() && innerData.control_id === 'startformula')
-				|| innerData.control_id === 'AutoSumMenu')
-				return;
 
 			this.builder.executeAction(this.container, innerData);
 		} else

--- a/browser/src/control/jsdialog/Widget.MenuButton.js
+++ b/browser/src/control/jsdialog/Widget.MenuButton.js
@@ -75,10 +75,12 @@ function _menubuttonControl (parentContainer, data, builder) {
 	if (data.id.includes(':')) {
 		ids = data.id.split(':');
 		menuId = ids[1];
+		data.id = ids[0];
 	}
 	else if (data.id.includes('-')) {
 		ids = data.id.split('-');
 		menuId = ids[1];
+		data.id = ids[0];
 	}
 	else
 		menuId = data.id;


### PR DESCRIPTION
- fixes regression from Accessibility commit 1a2500c
- it fixes formulabar control of AutoSum button #7548
- removes useless commit a7ece5d: jsdialog: reduce warnings in console for formulabar
- id with ":" contains "id : menuId", so we can identify menu which should be used, let's not use whole string as HTML element id - we don't want ":" there