### PR TITLE
postmessage: added message to collapse / extend notebookbar

### DIFF
--- a/browser/html/framed.doc.html
+++ b/browser/html/framed.doc.html
@@ -139,6 +139,12 @@
               'Values': {'Mode': value}});
       }
 
+      function CollapseNotebookbar(collapse) {
+        post({'MessageId': collapse ? 'Collapse_Notebookbar' : 'Extend_Notebookbar',
+              'Values': null
+            });
+      }
+
       function Execute(messageId, values) {
         post({'MessageId': messageId, 'Values': values});
       }
@@ -361,6 +367,8 @@
       <p>
       <button onclick="ShowNotebookbar(false); return false;">Compact Toolbar</button>
       <button onclick="ShowNotebookbar(true); return false;">Tabbed Toolbar</button>
+      <button onclick="CollapseNotebookbar(true); return false;">Collapse Tabbed Toolbar</button>
+      <button onclick="CollapseNotebookbar(false); return false;">Extend Tabbed Toolbar</button>
     </form>
 
     <h3>Send UNO Commands</h3>

--- a/browser/src/map/handler/Map.WOPI.js
+++ b/browser/src/map/handler/Map.WOPI.js
@@ -306,6 +306,14 @@ L.Map.WOPI = L.Handler.extend({
 			this._map.uiManager.hideRuler();
 			return;
 		}
+		else if (msg.MessageId === 'Collapse_Notebookbar') {
+			this._map.uiManager.collapseNotebookbar();
+			return;
+		}
+		else if (msg.MessageId === 'Extend_Notebookbar') {
+			this._map.uiManager.extendNotebookbar();
+			return;
+		}
 		else if (msg.MessageId === 'Show_Menu_Item' || msg.MessageId === 'Hide_Menu_Item') {
 			if (!msg.Values) {
 				window.app.console.error('Property "Values" not set');


### PR DESCRIPTION
The new messages are: Collapse_Notebookbar and Extend_Notebookbar As a side effect they also hide the classic toolbar the same way


Change-Id: Ic9d04876acb06f2885a6be1e171df7f87e513ed8


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

Add two postmessage to show hide the notebookbar. Due to the UI layout, they also hide
the classic toolbar in that mode.

### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

