### PR TITLE
We don't always need to redraw the entire canvas

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -6419,7 +6419,7 @@ L.CanvasTileLayer = L.Layer.extend({
 		// Don't paint the tile, only dirty the sectionsContainer if it is in the visible area.
 		// _emitSlurpedTileEvents() will repaint canvas (if it is dirty).
 		if (this._painter.coordsIntersectVisible(coords)) {
-			this._painter._sectionContainer.setDirty();
+			this._painter._sectionContainer.setDirty(coords);
 		}
 	},
 


### PR DESCRIPTION
If we end up dirtying only due to a series of TileRange reasons then we only need to redraw the bounds of those tiles.

https://github.com/CollaboraOnline/online/issues/7166

checked: split calc sheets and rtl calc sheets


Change-Id: If468b735bdff85408155fb23ebf6db891a449d5e


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

