### PR TITLE
annotation: fix parent comment being deleted if reply cancelled

### DIFF
--- a/browser/src/layer/tile/CommentSection.ts
+++ b/browser/src/layer/tile/CommentSection.ts
@@ -697,6 +697,7 @@ export class Comment extends CanvasSectionObject {
 			this.showImpressDraw();
 		else if (this.sectionProperties.docLayer._docType === 'spreadsheet')
 			this.showCalc();
+		this.sectionProperties.autoSave.innerText = '';
 	}
 
 	private hideWriter() {
@@ -813,8 +814,10 @@ export class Comment extends CanvasSectionObject {
 			return;
 		if (app.view.commentAutoAdded) {
 			this.sectionProperties.commentListSection.remove(this.sectionProperties.data.id);
-			if (this.sectionProperties.commentListSection.sectionProperties.selectedComment.sectionProperties.container.classList.contains('reply-annotation-container'))
+			if (this.sectionProperties.commentListSection.sectionProperties.selectedComment.sectionProperties.container.classList.contains('reply-annotation-container')) {
 				this.show();
+				return;
+			}
 			else
 				this.onRemove();
 		}


### PR DESCRIPTION
part 2

fix from #7552 stopped working, this patch amends it


Change-Id: I8c1227199112599fc2ade4e425452709e9cd05e5


* Target version: master 


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

