### PR TITLE
annotation: fix cancelled modification of autosaved comment

### DIFF
--- a/browser/src/layer/tile/CommentSection.ts
+++ b/browser/src/layer/tile/CommentSection.ts
@@ -820,6 +820,13 @@ export class Comment extends CanvasSectionObject {
 		}
 		if (e)
 			L.DomEvent.stopPropagation(e);
+
+		if (this.sectionProperties.nodeModify.originalText &&
+			this.sectionProperties.nodeModify.originalText !== this.sectionProperties.data.text) {
+				this.sectionProperties.nodeModifyText.value = this.sectionProperties.nodeModify.originalText;
+				this.handleSaveCommentButton(e);
+				return;
+		}
 		this.sectionProperties.nodeModifyText.value = this.sectionProperties.contentText.origText;
 		this.sectionProperties.nodeReplyText.value = '';
 		if (this.sectionProperties.docLayer._docType !== 'spreadsheet')
@@ -899,6 +906,7 @@ export class Comment extends CanvasSectionObject {
 		this.sectionProperties.nodeReply.style.display = 'none';
 		this.sectionProperties.container.style.visibility = '';
 		this.sectionProperties.contentNode.style.display = 'none';
+		this.sectionProperties.nodeModify.originalText = this.sectionProperties.nodeModify.textContent;
 		return this;
 	}
 


### PR DESCRIPTION
problem:
when a user modifies a comment and its autosaved,
if user then cancels the modification they were still added


Change-Id: I26c872f0957f0815882c4b1aedae83fe6736b7a2


* Target version: master 

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

