### PR TITLE
cypress: refector mismatching parameter in function call

### DIFF
--- a/cypress_test/integration_tests/common/helper.js
+++ b/cypress_test/integration_tests/common/helper.js
@@ -519,13 +519,13 @@ function clipboardTextShouldBeDifferentThan(text) {
 // This is called during a test to reload the same document after
 // some modification. The purpose is typically to verify that
 // said changes were preserved in the document upon closing.
-function reload(fileName, subFolder, noFileCopy, subsequentLoad) {
+function reload(fileName, subFolder, noFileCopy, isMultiUser, subsequentLoad, hasInteractionBeforeLoad) {
 	cy.log('Reloading document: ' + subFolder + '/' + fileName);
 	cy.log('Reloading document - noFileCopy: ' + noFileCopy);
 	cy.log('Reloading document - subsequentLoad: ' + subsequentLoad);
 	closeDocument(fileName, '');
 	var noRename = true;
-	return loadTestDoc(fileName, subFolder, noFileCopy, subsequentLoad, noRename);
+	return loadTestDoc(fileName, subFolder, noFileCopy, isMultiUser, subsequentLoad, hasInteractionBeforeLoad, noRename);
 }
 
 // noRename - whether or not to give the file a unique name, if noFileCopy is false.


### PR DESCRIPTION
added and rearranged new parameters in the reload function call, its safe because so far all the calls to reload are made using only three parameters...

Change-Id: I8fa8e4b1e20de0af16368cb23ca641b8d7186bfc


* Target version: master 


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

