### PR TITLE
Fix TypeErrors in Calc

### DIFF
--- a/browser/src/control/Control.ColumnHeader.ts
+++ b/browser/src/control/Control.ColumnHeader.ts
@@ -254,7 +254,7 @@ export class ColumnHeader extends Header {
 			const entry = this._mouseOverEntry;
 			let modifier = 0;
 
-			if (this._startSelectionEntry && this._startSelectionEntry.index !== entry.index) {
+			if (entry && this._startSelectionEntry && this._startSelectionEntry.index !== entry.index) {
 				this._selectColumn(this._startSelectionEntry.index, modifier);
 				modifier += UNOModifier.SHIFT;
 				this._selectColumn(entry.index, modifier);

--- a/browser/src/control/Control.RowHeader.ts
+++ b/browser/src/control/Control.RowHeader.ts
@@ -242,7 +242,7 @@ export class RowHeader extends cool.Header {
 			const entry = this._mouseOverEntry;
 			let modifier = 0;
 
-			if (this._startSelectionEntry && this._startSelectionEntry.index !== entry.index) {
+			if (entry && this._startSelectionEntry && this._startSelectionEntry.index !== entry.index) {
 				this._selectRow(this._startSelectionEntry.index, modifier);
 				modifier += UNOModifier.SHIFT;
 				this._selectRow(entry.index, modifier);

--- a/browser/src/control/jsdialog/Widget.Combobox.js
+++ b/browser/src/control/jsdialog/Widget.Combobox.js
@@ -270,7 +270,8 @@ JSDialog.combobox = function (parentContainer, data, builder) {
 
 	container.onSelect = function (pos) {
 		resetSelection();
-		entries[pos].selected = true;
+		if (pos >= 0)
+			entries[pos].selected = true;
 	};
 
 	container.onSetText = function (text) {


### PR DESCRIPTION
    Fix Uncaught TypeError in combobox selection
    
    TypeError: Cannot set properties of undefined (setting 'selected') emitting event jsdialog: { "jsontype": "sidebar", "action": "action", "id": 0, "data": { "control_id": "applystyle", "position": "-1", "action_type": "select"}}
    
    When selecting whole column in Calc
    
----------------------------------

    Fix Uncaught TypeError in col/rows headers selection
    
    Uncaught TypeError: Cannot read properties of null (reading 'index')
        at RowHeader.onMouseUp (bundle.js:24879:87)
        at CanvasSectionContainer.propagateOnMouseUp (bundle.js:14350:24)
        at CanvasSectionContainer.onMouseUp (bundle.js:14442:6)