### PR TITLE
fix helm chart releaser

### DIFF
--- a/kubernetes/helm/collabora-online/Chart.yaml
+++ b/kubernetes/helm/collabora-online/Chart.yaml
@@ -4,7 +4,7 @@ type: "application"
 name: collabora-online
 description: Collabora Online helm chart
 
-version: 1.1.3
+version: 1.1.4
 appVersion: "23.05.5.3.1"
 
 home: "https://www.collaboraoffice.com/code/"


### PR DESCRIPTION
- from the logs Error: error creating GitHub release helm-collabora-online-1.1.3: POST https://api.github.com/repos/CollaboraOnline/online/releases: 422 Validation Failed [{Resource:Release Field:tag_name Code:already_exists Message:}]


Change-Id: I434963728bf935204a4dc6e533aaa1b5a8408350

* Target version: master 
