### PR TITLE
css: pivot table dialog separator fix

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1882,3 +1882,8 @@ kbd,
 #modal-dialog-online-help-content-box {
 	min-width: 75%;
 }
+
+/* Calc -> Insert -> Pivot Table */
+#PivotTableLayout #box2 {
+	grid-gap: 12px; /* make space for vertical separator */
+}


### PR DESCRIPTION
vertical separator was overlapping other widgets

can be found in: Calc -> Insert -> Pivot Table -> next

Before:
![pivot-before](https://github.com/CollaboraOnline/online/assets/5307369/0b5677e3-6f7f-4e61-857e-ea83ae0b6269)

After:
![pivot-after](https://github.com/CollaboraOnline/online/assets/5307369/f81a9432-2666-4afd-a61c-26587c53b0ab)
