### PR TITLE
Exit cell edit mode before add a new sheet

### DIFF
--- a/browser/src/control/Parts.js
+++ b/browser/src/control/Parts.js
@@ -278,6 +278,11 @@ L.Map.include({
 	},
 
 	insertPage: function(nPos) {
+		// Make sure we exit cell edit mode.
+		if (this._docLayer.insertMode) {
+			this._docLayer.postKeyboardEvent('input', 0, 1280);
+		}
+
 		if (this.isPresentationOrDrawing()) {
 			app.socket.sendMessage('uno .uno:InsertPage');
 		}


### PR DESCRIPTION
To exit cell edit mode we send a KEY_RETURN event. That prevents to move last edited cell to new sheet.


Change-Id: I115be45c170789011d51d4d7914bd4825efb48f3


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

