### PR TITLE
Stop onscreen keyboard when panning calc on tablet

### DIFF
--- a/browser/html/framed.doc.html
+++ b/browser/html/framed.doc.html
@@ -120,6 +120,12 @@
             });
       }
 
+      function HintOnscreenKeyboard(hint) {
+        post({'MessageId': hint ? 'Hint_OnscreenKeyboard' : 'Hint_NoOnscreenKeyboard',
+              'Values': null
+            });
+      }
+
       function ShowMenubar(visible) {
         var messageId = visible ? 'Show_Menubar' : 'Hide_Menubar';
         post({'MessageId': 'Host_PostmessageReady'});
@@ -340,6 +346,8 @@
       <button onclick="show_commands('print'); return false;">Show Print Commands</button></br></br>
       <button onclick="disable_default_uiaction('UI_Save', true); return false;">Disable default save action</button></br>
       <button onclick="disable_default_uiaction('UI_Save', false); return false;">Enable default save action</button></br></br>
+      <button onclick="HintOnscreenKeyboard(true); return false;">Hint that there is an onscreen keyboard</button>
+      <button onclick="HintOnscreenKeyboard(false); return false;">Hint that there is not an onscreen keyboard</button><br/><br/>
       <label for="new-access-token"><b>New Access-Token</b>: </label><br>
       <textarea name="new-access-token" id="new-access-token" value="" rows="1" cols="30">123456789AA</textarea><br>
       <button onclick="reset_access_token(document.getElementById('new-access-token').value); return false;">Reset Access-Token</button>

--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -255,6 +255,26 @@ window.app = {
 		lang: navigatorLang
 	};
 
+	global.keyboard = {
+		onscreenKeyboardHint: undefined,
+		// If there's an onscreen keyboard, we don't want to trigger it with innocuous actions like panning around a spreadsheet
+		// on the other hand, if there is a hardware keyboard we want to do things like focusing contenteditables so that typing is
+		// recognized without tapping again. This is an impossible problem, because browsers do not give us enough information
+		// Instead, let's just guess
+		guessOnscreenKeyboard: function() {
+			if (global.keyboard.onscreenKeyboardHint != undefined) return global.keyboard.onscreenKeyboardHint;
+			return window.ThisIsAMobileApp || global.mode.isMobile() || global.mode.isTablet();
+			// It's better to guess that more devices will have an onscreen keyboard than reality,
+			// because calc becomes borderline unusable if you miss a device that pops up an onscreen keyboard which covers
+			// a sizeable portion of the screen
+		},
+		// alternatively, maybe someone else (e.g. an integrator) knows more about the situation than we do. In this case, let's
+		// let them override our default
+		hintOnscreenKeyboard: function(hint) {
+			global.keyboard.onscreenKeyboardHint = hint;
+		},
+	};
+
 	global.mode = {
 		isChromebook: function() {
 			return chromebook;

--- a/browser/src/layer/marker/TextInput.js
+++ b/browser/src/layer/marker/TextInput.js
@@ -266,11 +266,11 @@ L.TextInput = L.Layer.extend({
 		// Trick to avoid showing the software keyboard: Set the textarea
 		// read-only before focus() and reset it again after the blur()
 		if (!window.ThisIsTheiOSApp && navigator.platform !== 'iPhone' && !window.mode.isChromebook()) {
-			if ((window.ThisIsAMobileApp || window.mode.isMobile()) && acceptInput !== true)
+			if (window.keyboard.guessOnscreenKeyboard() && acceptInput !== true)
 				this._textArea.setAttribute('readonly', true);
 		}
 
-		if (!window.ThisIsTheiOSApp && navigator.platform !== 'iPhone' && !window.ThisIsAMobileApp && !window.mode.isMobile()) {
+		if (!window.ThisIsTheiOSApp && navigator.platform !== 'iPhone' && !window.keyboard.guessOnscreenKeyboard()) {
 			this._textArea.focus();
 		} else if (acceptInput === true) {
 			// On the iPhone, only call the textarea's focus() when we get an explicit
@@ -293,7 +293,7 @@ L.TextInput = L.Layer.extend({
 		}
 
 		if (!window.ThisIsTheiOSApp && navigator.platform !== 'iPhone' && !window.mode.isChromebook()) {
-			if ((window.ThisIsAMobileApp || window.mode.isMobile()) && acceptInput !== true) {
+			if (window.keyboard.guessOnscreenKeyboard() && acceptInput !== true) {
 				this._setAcceptInput(false);
 				this._textArea.blur();
 				this._textArea.removeAttribute('readonly');

--- a/browser/src/map/handler/Map.WOPI.js
+++ b/browser/src/map/handler/Map.WOPI.js
@@ -343,6 +343,14 @@ L.Map.WOPI = L.Handler.extend({
 			this._map.sendUnoCommand(msg.Values.Command, msg.Values.Args || '');
 			return;
 		}
+		else if (msg.MessageId === 'Hint_OnscreenKeyboard') {
+			window.keyboard.hintOnscreenKeyboard(true);
+			return;
+		}
+		else if (msg.MessageId === 'Hint_NoOnscreenKeyboard') {
+			window.keyboard.hintOnscreenKeyboard(false);
+			return;
+		}
 		else if (msg.MessageId === 'Disable_Default_UIAction') {
 			// Disable the default handler and action for a UI command.
 			// When set to true, the given UI command will issue a postmessage


### PR DESCRIPTION
Before this change, panning a calc spreadsheet would cause the onscreen keyboard to pop up when in tablet mode. Dismissing the keyboard would not stop it from being popped up the next time you panned around. This made it very difficult to pan around spreadsheets in calc without either using an external keyboard, the mobile app or another device altogether.

This commit introduces a known regression: when you are on a tablet and have a physical external keyboard, you could previously select the cell and start typing. Now you must tap into the cell in the same way you would if you have an onscreen keyboard. This matches the behavior on mobile devices. I consider this regression a reasonable tradeoff, so notwithstanding I believe this should be merged.

~~A followup is planned to add a POST message so that integrators etc. can toggle this setting, as they may have better knowledge than us of whether someone is using an onscreen keyboard. I believe it's best to merge this without the followup because calc is borderline unusable on tablets (in browser, without an external keyboard). Additionally, getting this up quickly allows us to start testing it a bit earlier to find any urgent issues.~~ The POST messages have been added in this commit

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

