### PR TITLE
wasm: don't try to package obsolete and/or renamed online.data

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -485,7 +485,6 @@ $(DIST_FOLDER)/soffice%: $(abs_top_builddir)/wasm/soffice%
 	@cp $< $@
 
 WASM_FILES= \
-	$(DIST_FOLDER)/online.data \
 	$(DIST_FOLDER)/online.js \
 	$(DIST_FOLDER)/online.wasm \
 	$(DIST_FOLDER)/online.wasm.debug.wasm \


### PR DESCRIPTION
    presumably a regression from 158fe2f93:

    Trying to init LOKit cause mysterious runtime error...

Change-Id: I28603a98a7c9015afc76d46a302a23ccf4ece261


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

