### PR TITLE
Fix "Format > Columns" Menu Has Dark Icons

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1619,7 +1619,8 @@ input[type='number']:hover::-webkit-outer-spin-button {
 }
 
 /* Writer - Table of Contents, Index or Bibliography dialog, Columns tab */
-[data-theme='dark'] #ColumnPage #pageexample-img, #ColumnPage #valueset-img {
+[data-theme='dark'] #ColumnPage #pageexample-img,
+[data-theme='dark'] #ColumnPage #valueset-img {
 	filter: invert(.9)
 }
 


### PR DESCRIPTION
- Added missing data-theme = dark for #valueset-img

![image](https://github.com/CollaboraOnline/online/assets/61383886/684b5c8d-8ed2-4464-964c-16829603232c)

Signed-off-by: Darshan-upadhyay1110 <darshan.upadhyay@collabora.com>
Change-Id: Ibddeaa28089ba21250753f121af4746e3947cf38


* Resolves: #7590
* Target version: master 

