### PR TITLE
clipboard: do not put formulas into client clipboard

### DIFF
--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -787,6 +787,14 @@ L.Clipboard = L.Class.extend({
 
 	// sets the selection to some (cell formula) text)
 	setTextSelectionText: function(text) {
+		// Usually 'text' is what we see in the formulabar
+		// In case of actual formula we don't wish to put forumla into client clipboard
+		// Putting formula in clipboard means user will paste formula outside of online
+		// Pasting inside online is handled by internal paste
+		if (this._map.getDocType() === 'spreadsheet' && text.startsWith('=')) {
+			app.socket.sendMessage('gettextselection mimetype=text/html');
+			return;
+		}
 		this._selectionType = 'text';
 		this._selectionContent = this._originWrapBody(
 			'<body>' + text + '</body>');


### PR DESCRIPTION
problem:
when user copy cell with formula and paste it outside of online, formulas are pasted instead of values.

Ideally we should always put real value in client clipboard


Change-Id: I93af2fffa501c3cdc3d8ecc78d3c44121784d3e8


* Target version: master 


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

