### PR TITLE
formulabar: optimization

### DIFF
--- a/browser/src/control/Control.ColumnHeader.ts
+++ b/browser/src/control/Control.ColumnHeader.ts
@@ -143,8 +143,6 @@ export class ColumnHeader extends Header {
 		this.context.strokeStyle = this._borderColor;
 		this.context.lineWidth = app.dpiScale;
 		this.context.strokeRect(startX - 0.5, 0.5, entry.size, this.size[1]);
-
-        this._map._contextMenu.stopRightMouseUpEvent();
 	}
 
 	getHeaderEntryBoundingClientRect (index: number): Partial<DOMRect> {

--- a/browser/src/control/Control.Header.ts
+++ b/browser/src/control/Control.Header.ts
@@ -477,6 +477,7 @@ export class Header extends CanvasSectionObject {
 			callback: function() { return; }
 		});
 		$('#document-canvas').contextMenu('update');
+		this._map._contextMenu.stopRightMouseUpEvent();
 	}
 
 	_unBindContextMenu(): void {

--- a/browser/src/control/Control.RowHeader.ts
+++ b/browser/src/control/Control.RowHeader.ts
@@ -140,8 +140,6 @@ export class RowHeader extends cool.Header {
 		this.context.strokeStyle = this._borderColor;
 		this.context.lineWidth = app.dpiScale;
 		this.context.strokeRect(0.5, startY - 0.5, this.size[0], entry.size);
-
-        this._map._contextMenu.stopRightMouseUpEvent();
 	}
 
 	getHeaderEntryBoundingClientRect (index: number): Partial<DOMRect> {

--- a/browser/src/control/jsdialog/Widget.FormulabarEdit.js
+++ b/browser/src/control/jsdialog/Widget.FormulabarEdit.js
@@ -23,6 +23,8 @@
 
 /* global JSDialog */
 
+var scrollToCursorTimeout = null;
+
 function _sendSelection(edit, builder, id, event) {
 	if (document.activeElement != edit)
 		return;
@@ -172,8 +174,17 @@ function _setSelection(cursorLayer, text, startX, endX, startY, endY) {
 
 	// possible after cursor is added to the DOM
 	if (cursor) {
-		var blockOption = JSDialog._scrollIntoViewBlockOption('nearest');
-		cursor.scrollIntoView({behavior: 'smooth', block: blockOption, inline: 'nearest'});
+		if (scrollToCursorTimeout)
+			clearTimeout(scrollToCursorTimeout);
+
+		// put scrol at the end of the task queue so we will not scroll multiple times
+		// during one session of processing events where multiple setSelection actions
+		// can be found, profiling shows it is heavy operation
+		scrollToCursorTimeout = setTimeout(function () {
+			var blockOption = JSDialog._scrollIntoViewBlockOption('nearest');
+			cursor.scrollIntoView({behavior: 'smooth', block: blockOption, inline: 'nearest'});
+			scrollToCursorTimeout = null;
+		}, 0);
 	}
 }
 


### PR DESCRIPTION
formulabar: modify DOM only when content is complete

createDocumentFragment creates out of the DOM nodes which we can use while building the new content of the formulabar. This reduces reflow and similar operations on node insertion.

------------------------------

perf: do not call addEventListener on every header update

This helps with performance of typing into spreadsheets.

Regression from commit https://github.com/CollaboraOnline/online/commit/46c1248c770c2409ebb3b38c796690220ea98880
Prevent right mouse button up event to click on menu item.

Do not add new event listener on every header update what
happens often but rather apply right click blocker when
context menu is opened. Original commit was trying to prevent
menu items activation on right click.

