### PR TITLE
fix language issue in datepicker control

### DIFF
--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -974,7 +974,11 @@ window.app = {
 	}
 
 	var lang = encodeURIComponent(global.getParameterByName('lang'));
-	window.langParam = lang;
+	if (lang)
+		window.langParam = lang;
+	else
+		window.langParam = 'en-US';
+	window.langParamLocale = new Intl.Locale(window.langParam);
 	global.queueMsg = [];
 	if (window.ThisIsTheEmscriptenApp)
 		// Temporary hack

--- a/browser/src/control/jsdialog/Widget.Calendar.js
+++ b/browser/src/control/jsdialog/Widget.Calendar.js
@@ -24,7 +24,7 @@ function _calendarControl(parentContainer, data, builder) {
 	var container = L.DomUtil.create('div', 'ui-calendar ' + builder.options.cssClass, parentContainer);
 	container.id = data.id;
 
-	$.datepicker.setDefaults($.datepicker.regional[window.langParam]);
+	$.datepicker.setDefaults($.datepicker.regional[window.langParamLocale.language]);
 	$(container).datepicker({
 		defaultDate: new Date(data.year, data.month - 1, data.day),
 		dateFormat: 'mm/dd/yy',

--- a/browser/src/layer/tile/ContentControlSection.ts
+++ b/browser/src/layer/tile/ContentControlSection.ts
@@ -69,7 +69,7 @@ export class ContentControlSection extends CanvasSectionObject {
 
 		if (json.date) {
 			this.sectionProperties.datePicker = true;
-			$.datepicker.setDefaults($.datepicker.regional[(<any>window).langParam]);
+			$.datepicker.setDefaults($.datepicker.regional[(<any>window).langParamLocale.language]);
 			$('#datepicker').datepicker({
 				onSelect: function (date: any, datepicker: any) {
 					if (date != '') {


### PR DESCRIPTION
It seems that datepicker control expects only a language input in regional property (e.g. fr) instead of language-country (e.g. fr-FR).


Change-Id: I7d5ac40cfa4a72cdc7862a8b4c4d14bdecad6c3b


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

