### PR TITLE
Fix Content control "down arrow" cannot be recognized in dark mode

### DIFF
--- a/browser/css/writer.css
+++ b/browser/css/writer.css
@@ -10,3 +10,8 @@
 	box-sizing: border-box;
 	box-shadow: 0 0 1px 1px #00000015;
 }
+[data-theme='dark'] .writer-drop-down-marker {
+	background: url('images/dark/unfold.svg') center/16px var(--color-background-lighter) no-repeat;
+	border: 1px solid var(--color-primary-lighter);
+
+}

--- a/browser/src/layer/tile/ContentControlSection.ts
+++ b/browser/src/layer/tile/ContentControlSection.ts
@@ -27,6 +27,7 @@ export class ContentControlSection extends CanvasSectionObject {
 		this.onClickDropdown = this.onClickDropdown.bind(this);
 		this.sectionProperties.dropdownButton.addEventListener('click', this.onClickDropdown, false);
 		this.map.on('dropdownmarkertapped', this.onClickDropdown, this);
+		this.map.on('darkmodechanged', this.changeBorderStyle, this);
 
 		var container = L.DomUtil.createWithId('div', 'datepicker');
 		container.style.zIndex = '12';
@@ -152,6 +153,7 @@ export class ContentControlSection extends CanvasSectionObject {
 
 		if (!this.sectionProperties.frame) {
 			this.sectionProperties.frame = new CPolygon(this.sectionProperties.pointSet, this.sectionProperties.polyAttri);
+			this.changeBorderStyle();
 			this.map._docLayer._canvasOverlay.initPath(this.sectionProperties.frame);
 		}
 		this.sectionProperties.frame.setPointSet(this.sectionProperties.pointSet);
@@ -358,6 +360,11 @@ export class ContentControlSection extends CanvasSectionObject {
 			}
 		}
 		return rectangles;
+	}
+
+	private changeBorderStyle(): void {
+		var borderColor = this.map.uiManager.getDarkModeState() ? 'white' : 'black';
+		this.sectionProperties.frame.color = borderColor;
 	}
 }
 


### PR DESCRIPTION
- add missing image path for data-them dark

Signed-off-by: Darshan-upadhyay1110 <darshan.upadhyay@collabora.com>
Change-Id: If6850770548d35eb95125ce0be1c52a557f5b344