### PR TITLE
Add a ui_defaults option for onscreen keyboards

### DIFF
--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -256,7 +256,7 @@ window.app = {
 	};
 
 	global.keyboard = {
-		onscreenKeyboardHint: undefined,
+		onscreenKeyboardHint: window.uiDefaults['onscreenKeyboardHint'],
 		// If there's an onscreen keyboard, we don't want to trigger it with innocuous actions like panning around a spreadsheet
 		// on the other hand, if there is a hardware keyboard we want to do things like focusing contenteditables so that typing is
 		// recognized without tapping again. This is an impossible problem, because browsers do not give us enough information

--- a/wsd/FileServerUtil.cpp
+++ b/wsd/FileServerUtil.cpp
@@ -74,6 +74,11 @@ std::string FileServerRequestHandler::uiDefaultsToJSON(const std::string& uiDefa
             }
             continue;
         }
+        if (keyValue.equals(0, "OnscreenKeyboardHint"))
+        {
+            json.set("onscreenKeyboardHint", keyValue.equals(1, "true"));
+            continue;
+        }
         else if (keyValue.startsWith(0, "Text"))
         {
             currentDef = &textDefs;


### PR DESCRIPTION
The new ui_defaults option OnscreenKeyboardHint is a tristate denoting whether the device accessing Collabora Online has an onscreen keyboard

If unset, Collabora Online will do its best to guess. At time of writing, this is the same as checking if the device is a mobile phone or a tablet (note: only tablets which have the browser registered as a "mobile" browser will be detected, e.g. the Microsoft Surface tablets would not be detected)

If "true", Collabora will assume the device has an onscreen keyboard. This will change when we trigger the keyboard, for example in calc if we know of an onscreen keyboard we will not automatically focus a cell for editing when it is selected, as this would pop up the keyboard.

If "false", Collabora will assume the device does not have an onscreen keyboard, effectively doing the inverse of the "true" option above.

This is a followup to #7580 (0bf054c9a3cdee16bdbb5e8a8ddfdb8799469852) which had Hint_OnscreenKeyboard and Hint_NoOnscreenKeyboard as postmessage IDs to do the same thing.


Change-Id: I5deeb87a410c135d4cabda7ed24dc37e791800cd