### PR TITLE
non-calc: Revert "Stop onscreen keyboard when panning calc on tablet"

### DIFF
--- a/browser/src/layer/marker/TextInput.js
+++ b/browser/src/layer/marker/TextInput.js
@@ -263,14 +263,23 @@ L.TextInput = L.Layer.extend({
 			return;
 		}
 
+
+		var isCalc = this._map._docLayer.isCalc();
+
 		// Trick to avoid showing the software keyboard: Set the textarea
 		// read-only before focus() and reset it again after the blur()
 		if (!window.ThisIsTheiOSApp && navigator.platform !== 'iPhone' && !window.mode.isChromebook()) {
-			if (window.keyboard.guessOnscreenKeyboard() && acceptInput !== true)
+			if ((
+				(isCalc && window.keyboard.guessOnscreenKeyboard())
+				|| (!isCalc && (window.ThisIsAMobileApp || window.mode.isMobile()))
+			) && acceptInput !== true)
 				this._textArea.setAttribute('readonly', true);
 		}
 
-		if (!window.ThisIsTheiOSApp && navigator.platform !== 'iPhone' && !window.keyboard.guessOnscreenKeyboard()) {
+		if (!window.ThisIsTheiOSApp && navigator.platform !== 'iPhone' && (
+			(isCalc && !window.keyboard.guessOnscreenKeyboard())
+			|| (!isCalc && !window.ThisIsAMobileApp && !window.mode.isMobile())
+		)) {
 			this._textArea.focus();
 		} else if (acceptInput === true) {
 			// On the iPhone, only call the textarea's focus() when we get an explicit
@@ -293,7 +302,10 @@ L.TextInput = L.Layer.extend({
 		}
 
 		if (!window.ThisIsTheiOSApp && navigator.platform !== 'iPhone' && !window.mode.isChromebook()) {
-			if (window.keyboard.guessOnscreenKeyboard() && acceptInput !== true) {
+			if ((
+				(isCalc && window.keyboard.guessOnscreenKeyboard())
+				|| (!isCalc && (window.ThisIsAMobileApp || window.mode.isMobile()))
+			) && acceptInput !== true) {
 				this._setAcceptInput(false);
 				this._textArea.blur();
 				this._textArea.removeAttribute('readonly');


### PR DESCRIPTION
This ignores the hints from commit
f62f365a0ed26b21e1f86b0e028cf80fc6b2b9df when not using calc. This is because they were causing an undefined reference in WASM. (window.keyboard.guessOnscreenKeyboard). To me, this looks like a bug in our WASM implementation, as I think WASM should get window globals, but as it's blocking us we're partially rolling this commit back.

I expect to revert this revert as soon as it no longer breaks WASM.


Change-Id: I91bab273d400bf7925e338631e74dabc8a01e529


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

