### PR TITLE
fix:navigator hyperlinks line-breaking on chrome and firefox

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -395,6 +395,8 @@ button#button2.ui-pushbutton.jsdialog.sidebar {
 	/* Move this whole block away and fix in the main control */
 	display: flex;
 	align-items: center;
+	width: 200px;
+	word-break: break-word;
 }
 
 span.jsdialog.sidebar.ui-treeview-entry.ui-treeview-notexpandable {


### PR DESCRIPTION
Change-Id: Icbd85bdd3ec400a016f2c9affdfca04b78711987


* Resolves: # [ Chrome: Navigator Hyperlinks Don't Linebreak #7425 ](https://github.com/CollaboraOnline/online/issues/7425)
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

