### PR TITLE
Avoid TypeError in getCorePxDocBounds

### DIFF
--- a/browser/src/layer/marker/Cursor.ts
+++ b/browser/src/layer/marker/Cursor.ts
@@ -143,7 +143,7 @@ class Cursor {
 	}
 
 	private update() {
-		if (!this.container || !this.map)
+		if (!this.container || !this.map || !this.map.hasDocBounds())
 			return;
 
 		var docBounds = <cool.Bounds>this.map.getCorePxDocBounds();

--- a/browser/src/map/Map.js
+++ b/browser/src/map/Map.js
@@ -737,7 +737,14 @@ L.Map = L.Evented.extend({
 		this.options.docBounds = bounds;
 	},
 
+	hasDocBounds: function () {
+		return this.options.docBounds;
+	},
+
 	getCorePxDocBounds: function () {
+		if (!this.options.docBounds)
+			return new L.Bounds(0, 0);
+
 		var topleft = this.project(this.options.docBounds.getNorthWest());
 		var bottomRight = this.project(this.options.docBounds.getSouthEast());
 		return new L.Bounds(this._docLayer._cssPixelsToCore(topleft),


### PR DESCRIPTION
It was reported on some iOS devices that we fail with TypeError in getCorePxDocBounds - missing this.options.docBounds.

getCorePxDocBounds is used in Cursor class, check if we have docBounds before use so we don't try to update without valid data