### PR TITLE
Add touch detection for pointer:course media query

### DIFF
--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -108,7 +108,8 @@ window.app = {
 	var chromebook = window.ThisIsTheAndroidApp && window.COOLMessageHandler.isChromeOS();
 
 	var touch = !window.L_NO_TOUCH && (pointer || 'ontouchstart' in window ||
-			(window.DocumentTouch && document instanceof window.DocumentTouch)) && !chromebook;
+			(window.DocumentTouch && document instanceof window.DocumentTouch) ||
+			window.matchMedia('(pointer: coarse)').matches) && !chromebook;
 
 	var isInternetExplorer = (navigator.userAgent.toLowerCase().indexOf('msie') != -1 ||
 				  navigator.userAgent.toLowerCase().indexOf('trident') != -1);


### PR DESCRIPTION
matchMedia allows you to check matches for CSS media queries from JavaScript. By checking if the primary pointer is 'coarse' we have a pretty good shot at guessing that it's a touch device (mice, etc. are 'fine' instead). This expands our current touch detection so it detects more screens, while making sure it doesn't detect devices which have a touchscreen but also a mouse/touchpad/whatever. This non-detection is important, because our touch support currently breaks things like the rightclick menu on calc.

Touchscreen detection is useful for devices that are being used as touch devices, because it enables some features like pinch-to-zoom and hold-for-rightclick-menu which improve usability when you are using a touchscreen. These are particularly important without a mouse.

Some devices are 2-in-1 laptops, which have a touchscreen and a touchpad, but can be collapsed so only the touchscreen is active. These devices will be detected as touch only when they are in their 'tablet' form. *As we setup parts of the page differently, the page will need to be refreshed if they change from tablet form to laptop form and vice-versa*. Hopefully in the future we will make a followup so that both input schemes can be enabled at the same time and extend this media query detection to (any-pointer: coarse)


Change-Id: Ied4f61a1ffb06bd63359bc6d81c6a6c23436cc23


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

