### PR TITLE
fix; error TS2304: Cannot find name 'TilesSection'

### DIFF
--- a/browser/src/layer/tile/CanvasSectionContainer.ts
+++ b/browser/src/layer/tile/CanvasSectionContainer.ts
@@ -2062,7 +2062,7 @@ class CanvasSectionContainer {
 		var subsetBounds: cool.Bounds = null;
 		// if there is a tileSubset we only want to draw the miniumum region of its bounds
 		if (tileSubset) {
-			var tileSection = <TilesSection>(this.getSectionWithName(L.CSections.Tiles.name));
+			var tileSection = this.getSectionWithName(L.CSections.Tiles.name) as cool.TilesSection;
 			if (tileSection && this.shouldDrawSection(tileSection)) {
 				subsetBounds = tileSection.getSubsetBounds(this.context, tileSubset);
 			}

--- a/browser/src/layer/tile/TilesSection.ts
+++ b/browser/src/layer/tile/TilesSection.ts
@@ -6,7 +6,9 @@ declare var $: any;
 declare var Hammer: any;
 declare var app: any;
 
-class TilesSection extends CanvasSectionObject {
+namespace cool {
+
+export class TilesSection extends CanvasSectionObject {
 	map: any;
 	isJSDOM: boolean = false; // testing
 	checkpattern: any;
@@ -868,6 +870,8 @@ class TilesSection extends CanvasSectionObject {
 	}
 }
 
+}
+
 L.getNewTilesSection = function () {
-	return new TilesSection();
+	return new cool.TilesSection();
 };


### PR DESCRIPTION
doesn't happen in ci, but is happening in tinderbox and for some users.

Seeing as ScrollSection doesn't have the problem, follow the export and namespace pattern used there.


Change-Id: I4c4916ba7a3ad19275bd8b0f5bc53111b3b30cd5


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

