### PR TITLE
do not allow check uncheck for disabled checkbox

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -1487,9 +1487,11 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		};
 
 		$(checkboxLabel).click(function () {
-			var status = $(checkbox).is(':checked');
-			$(checkbox).prop('checked', !status);
-			toggleFunction.bind({checked: !status})();
+			if (data.enabled) {
+				var status = $(checkbox).is(':checked');
+				$(checkbox).prop('checked', !status);
+				toggleFunction.bind({checked: !status})();
+			}
 		});
 
 		if (data.enabled === 'false' || data.enabled === false) {


### PR DESCRIPTION
Signed-off-by: Darshan-upadhyay1110 <darshan.upadhyay@collabora.com>
Change-Id: I3c6f770058ae1409f56d6bd12f5e7a8cd2441941

Previous behaviour was like user is able to check or uncheck a checkbox even if that checkbox is disabled.

For ex : Format => Character => select position option => try to chec/Uncheck the checkboxes which are disabled

- This will fix not to check or uncheck if a checkbox is disabled by clicking on a lable of a checkbox


* Resolves: #7630
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

