### PR TITLE
'Tileprocessed message did not arrive in time' for slide preview

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -7080,6 +7080,14 @@ L.CanvasTileLayer = L.Layer.extend({
 		this._debugShowTileData();
 	},
 
+	_queueAcknowledgement: function (tileMsgObj) {
+		// Queue acknowledgment, that the tile message arrived
+		var mode = (tileMsgObj.mode !== undefined) ? tileMsgObj.mode : 0;
+		var tileID = tileMsgObj.part + ':' + mode + ':' + tileMsgObj.x + ':' + tileMsgObj.y + ':'
+		    + tileMsgObj.tileWidth + ':' + tileMsgObj.tileHeight + ':' + tileMsgObj.nviewid;
+		this._queuedProcessed.push(tileID);
+	},
+
 	_onTileMsg: function (textMsg, img) {
 		var tileMsgObj = app.socket.parseServerCmd(textMsg);
 		this._checkTileMsgObject(tileMsgObj);
@@ -7095,6 +7103,7 @@ L.CanvasTileLayer = L.Layer.extend({
 				mode: (tileMsgObj.mode !== undefined) ? tileMsgObj.mode : 0,
 				docType: this._docType
 			});
+			this._queueAcknowledgement(tileMsgObj);
 			return;
 		}
 
@@ -7154,11 +7163,7 @@ L.CanvasTileLayer = L.Layer.extend({
 			this._tileReady(coords);
 		}
 
-		// Queue acknowledgment, that the tile message arrived
-		var mode = (tileMsgObj.mode !== undefined) ? tileMsgObj.mode : 0;
-		var tileID = tileMsgObj.part + ':' + mode + ':' + tileMsgObj.x + ':' + tileMsgObj.y + ':'
-		    + tileMsgObj.tileWidth + ':' + tileMsgObj.tileHeight + ':' + tileMsgObj.nviewid;
-		this._queuedProcessed.push(tileID);
+		this._queueAcknowledgement(tileMsgObj);
 	},
 
 	_sendProcessedResponse: function() {


### PR DESCRIPTION
A slide preview tile falls into the special case with early return and no tileprocessed is sent back to the server, so eventually a 'Tileprocessed message did not arrive in time' will be reported


Change-Id: Iab85e5eca535ce377508e91cf67f1435e9242bc4


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

