### PR TITLE
browser: Add ui_default to hide the toolbar

### DIFF
--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -292,6 +292,10 @@ L.Control.UIManager = L.Control.extend({
 			// makeSpaceForNotebookbar call in onUpdatePermission
 		}
 
+		if (window.uiDefaults[docType] && window.uiDefaults[docType]['ShowToolbar'] === false) {
+			this.collapseNotebookbar();
+		}
+
 		this.initDarkModeFromSettings();
 
 		this.map.fire('a11ystatechanged');

--- a/wsd/FileServerUtil.cpp
+++ b/wsd/FileServerUtil.cpp
@@ -124,7 +124,7 @@ std::string FileServerRequestHandler::uiDefaultsToJSON(const std::string& uiDefa
         assert(currentDef);
 
         // detect the actual UI widget we want to hide or show
-        if (key == "Ruler" || key == "Sidebar" || key == "Statusbar")
+        if (key == "Ruler" || key == "Sidebar" || key == "Statusbar" || key == "Toolbar")
         {
             bool value(true);
             if (keyValue.equals(1, "false") || keyValue.equals(1, "False") || keyValue.equals(1, "0"))


### PR DESCRIPTION
Change-Id: I189224581451c9f5d534593696b060c8efb23414


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

Pass `{Text,Spreadsheet,Presentation,Draw}Toolbar=false` in the POST to hide the toolbar in compact mode.

### TODO

- [ ] Have it work with the notebook, but this is only the same as "click" on a tab.

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

