### PR TITLE
Parallel Loading Prerequisites

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -141,6 +141,7 @@ coolwsd_sources = common/Crypto.cpp \
                   wsd/ProxyRequestHandler.cpp \
                   wsd/FileServerUtil.cpp \
                   wsd/RequestDetails.cpp \
+                  wsd/RequestVettingStation.cpp \
                   wsd/Storage.cpp \
                   wsd/StorageConnectionManager.cpp \
                   wsd/HostUtil.cpp \
@@ -296,6 +297,7 @@ wsd_headers = wsd/Admin.hpp \
               wsd/COOLWSD.hpp \
               wsd/ProofKey.hpp \
               wsd/RequestDetails.hpp \
+              wsd/RequestVettingStation.hpp \
               wsd/SenderQueue.hpp \
               wsd/ServerURL.hpp \
               wsd/Storage.hpp \

--- a/wsd/Admin.cpp
+++ b/wsd/Admin.cpp
@@ -563,14 +563,16 @@ Admin::Admin()
     const size_t totalUsedMemKb = getTotalMemoryUsage();
     _model.addMemStats(totalUsedMemKb);
 
-    LOG_INF("Total available memory: "
-            << _totalAvailMemKb << " KB, System memory: " << _totalSysMemKb
-            << " KB, configured memproportion: " << memLimit
-            << "%, actual percentage of system total: " << std::setprecision(2)
-            << (_totalSysMemKb ? (_totalAvailMemKb * 100. / _totalSysMemKb) : 100)
-            << "%, current usage: " << totalUsedMemKb << " KB ("
-            << (_totalAvailMemKb ? (totalUsedMemKb * 100. / _totalAvailMemKb) : 100)
-            << "% of limit)");
+    LOG_INF(
+        std::setprecision(2)
+        << "Total available memory: " << _totalAvailMemKb << " KB ("
+        << _totalAvailMemKb / (1024 * 1024.) << " GB), System memory: " << _totalSysMemKb << " KB ("
+        << _totalSysMemKb / (1024 * 1024.) << " GB), cgroup limit: " << cgroupMemLimitKb
+        << " KB, cgroup soft-limit: " << cgroupMemSoftLimitKb
+        << " KB, configured memproportion: " << memLimit << "%, actual percentage of system total: "
+        << (_totalSysMemKb ? (_totalAvailMemKb * 100. / _totalSysMemKb) : 100)
+        << "%, current usage: " << totalUsedMemKb << " KB ("
+        << (_totalAvailMemKb ? (totalUsedMemKb * 100. / _totalAvailMemKb) : 100) << "% of limit)");
 
     if (_totalAvailMemKb < 1000 * 1024)
         LOG_WRN("Low memory condition detected: only " << _totalAvailMemKb / 1024

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -3663,14 +3663,11 @@ void COOLWSD::sendMessageToForKit(const std::string& message)
 /// Otherwise, creates and adds a new one to DocBrokers.
 /// May return null if terminating or MaxDocuments limit is reached.
 /// After returning a valid instance DocBrokers must be cleaned up after exceptions.
-static std::shared_ptr<DocumentBroker>
-    findOrCreateDocBroker(const std::shared_ptr<ProtocolHandlerInterface>& proto,
-                          DocumentBroker::ChildType type,
-                          const std::string& uri,
-                          const std::string& docKey,
-                          const std::string& id,
-                          const Poco::URI& uriPublic,
-                          unsigned mobileAppDocId = 0)
+std::shared_ptr<DocumentBroker>
+findOrCreateDocBroker(const std::shared_ptr<ProtocolHandlerInterface>& proto,
+                      DocumentBroker::ChildType type, const std::string& uri,
+                      const std::string& docKey, const std::string& id, const Poco::URI& uriPublic,
+                      unsigned mobileAppDocId = 0)
 {
     LOG_INF("Find or create DocBroker for docKey ["
             << docKey << "] for session [" << id << "] on url ["

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -404,7 +404,8 @@ public:
     std::string getJailRoot() const;
 
     /// Add a new session. Returns the new number of sessions.
-    std::size_t addSession(const std::shared_ptr<ClientSession>& session);
+    std::size_t addSession(const std::shared_ptr<ClientSession>& session,
+                           std::unique_ptr<WopiStorage::WOPIFileInfo> wopiFileInfo = nullptr);
 
     /// Removes a session by ID. Returns the new number of sessions.
     std::size_t removeSession(const std::shared_ptr<ClientSession>& session);
@@ -570,7 +571,8 @@ private:
     void refreshLock();
 
     /// Loads a document from the public URI into the jail.
-    bool download(const std::shared_ptr<ClientSession>& session, const std::string& jailId);
+    bool download(const std::shared_ptr<ClientSession>& session, const std::string& jailId,
+                  std::unique_ptr<WopiStorage::WOPIFileInfo> wopiFileInfo);
     bool isLoaded() const { return _docState.hadLoaded(); }
     bool isInteractive() const { return _docState.isInteractive(); }
 
@@ -761,7 +763,8 @@ private:
     std::size_t countActiveSessions() const;
 
     /// Loads a new session and adds to the sessions container.
-    std::size_t addSessionInternal(const std::shared_ptr<ClientSession>& session);
+    std::size_t addSessionInternal(const std::shared_ptr<ClientSession>& session,
+                                   std::unique_ptr<WopiStorage::WOPIFileInfo> wopiFileInfo);
 
     /// Starts the Kit <-> DocumentBroker shutdown handshake
     void disconnectSessionInternal(const std::shared_ptr<ClientSession>& session);

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -306,6 +306,10 @@ public:
     void setupTransfer(SocketDisposition &disposition,
                        SocketDisposition::MoveFunction transferFn);
 
+    /// setup the transfer of a socket into this DocumentBroker poll.
+    void setupTransfer(const std::shared_ptr<StreamSocket>& socket,
+                       const SocketDisposition::MoveFunction& transferFn);
+
     /// Flag for termination. Note that this doesn't save any unsaved changes in the document
     void stop(const std::string& reason);
 

--- a/wsd/RequestVettingStation.cpp
+++ b/wsd/RequestVettingStation.cpp
@@ -96,9 +96,8 @@ void RequestVettingStation::handleRequest(SocketPoll& poll, SocketDisposition& d
         case StorageBase::StorageType::Unauthorized:
             LOG_ERR("No authorized hosts found matching the target host [" << uriPublic.getHost()
                                                                            << "] in config");
-            _ws->shutdown(WebSocketHandler::StatusCodes::POLICY_VIOLATION,
-                          "error: cmd=internal kind=unauthorized");
-            _socket->ignoreInput();
+            sendErrorAndShutdown(_ws, _socket, "error: cmd=internal kind=unauthorized",
+                                 WebSocketHandler::StatusCodes::POLICY_VIOLATION);
             break;
 
         case StorageBase::StorageType::FileSystem:
@@ -218,16 +217,14 @@ void RequestVettingStation::checkFileInfo(SocketPoll& poll, const std::string& u
             if (httpResponse->statusLine().statusCode() == http::StatusCode::Forbidden)
             {
                 LOG_ERR("Access denied to [" << uriAnonym << ']');
-                const std::string msg = "error: cmd=storage kind=unauthorized";
-                _ws->shutdown(WebSocketHandler::StatusCodes::POLICY_VIOLATION, msg);
-                _socket->ignoreInput();
+                sendErrorAndShutdown(_ws, _socket, "error: cmd=storage kind=unauthorized",
+                                     WebSocketHandler::StatusCodes::POLICY_VIOLATION);
                 return;
             }
 
             LOG_ERR("Invalid URI or access denied to [" << uriAnonym << ']');
-            const std::string msg = "error: cmd=storage kind=unauthorized";
-            _ws->shutdown(WebSocketHandler::StatusCodes::POLICY_VIOLATION, msg);
-            _socket->ignoreInput();
+            sendErrorAndShutdown(_ws, _socket, "error: cmd=storage kind=unauthorized",
+                                 WebSocketHandler::StatusCodes::POLICY_VIOLATION);
             return;
         }
 
@@ -274,6 +271,8 @@ void RequestVettingStation::createDocBroker(const std::string& docKey, const std
     if (!docBroker)
     {
         LOG_ERR("Failed to create DocBroker [" << docKey << ']');
+        sendErrorAndShutdown(_ws, _socket, "error: cmd=internal kind=load",
+                             WebSocketHandler::StatusCodes::UNEXPECTED_CONDITION);
         return;
     }
 
@@ -283,6 +282,8 @@ void RequestVettingStation::createDocBroker(const std::string& docKey, const std
     if (!clientSession)
     {
         LOG_ERR("Failed to create Client Session [" << _id << "] on docKey [" << docKey << ']');
+        sendErrorAndShutdown(_ws, _socket, "error: cmd=internal kind=load",
+                             WebSocketHandler::StatusCodes::UNEXPECTED_CONDITION);
         return;
     }
 
@@ -340,18 +341,16 @@ void RequestVettingStation::createDocBroker(const std::string& docKey, const std
                 LOG_ERR_S("Unauthorized Request while starting session on "
                           << docBroker->getDocKey() << " for socket #" << moveSocket->getFD()
                           << ". Terminating connection. Error: " << exc.what());
-                const std::string msg = "error: cmd=internal kind=unauthorized";
-                _ws->shutdown(WebSocketHandler::StatusCodes::POLICY_VIOLATION, msg);
-                moveSocket->ignoreInput();
+                sendErrorAndShutdown(_ws, moveSocket, "error: cmd=internal kind=unauthorized",
+                                     WebSocketHandler::StatusCodes::POLICY_VIOLATION);
             }
             catch (const StorageConnectionException& exc)
             {
                 LOG_ERR_S("Storage error while starting session on "
                           << docBroker->getDocKey() << " for socket #" << moveSocket->getFD()
                           << ". Terminating connection. Error: " << exc.what());
-                const std::string msg = "error: cmd=storage kind=loadfailed";
-                _ws->shutdown(WebSocketHandler::StatusCodes::POLICY_VIOLATION, msg);
-                moveSocket->ignoreInput();
+                sendErrorAndShutdown(_ws, moveSocket, "error: cmd=storage kind=loadfailed",
+                                     WebSocketHandler::StatusCodes::POLICY_VIOLATION);
             }
             catch (const StorageSpaceLowException& exc)
             {
@@ -367,9 +366,18 @@ void RequestVettingStation::createDocBroker(const std::string& docKey, const std
                 LOG_ERR_S("Error while starting session on "
                           << docBroker->getDocKey() << " for socket #" << moveSocket->getFD()
                           << ". Terminating connection. Error: " << exc.what());
-                const std::string msg = "error: cmd=storage kind=loadfailed";
-                _ws->shutdown(WebSocketHandler::StatusCodes::POLICY_VIOLATION, msg);
-                moveSocket->ignoreInput();
+                sendErrorAndShutdown(_ws, moveSocket, "error: cmd=storage kind=loadfailed",
+                                     WebSocketHandler::StatusCodes::POLICY_VIOLATION);
             }
         });
+}
+
+void RequestVettingStation::sendErrorAndShutdown(const std::shared_ptr<WebSocketHandler>& ws,
+                                                 const std::shared_ptr<Socket>& socket,
+                                                 const std::string& msg,
+                                                 WebSocketHandler::StatusCodes statusCode)
+{
+    ws->sendMessage(msg);
+    ws->shutdown(statusCode, msg);
+    socket->ignoreInput();
 }

--- a/wsd/RequestVettingStation.cpp
+++ b/wsd/RequestVettingStation.cpp
@@ -101,6 +101,9 @@ void RequestVettingStation::handleRequest(SocketPoll& poll, SocketDisposition& d
                 "] in config");
             break;
         case StorageBase::StorageType::FileSystem:
+            LOG_INF("URI [" << COOLWSD::anonymizeUrl(uriPublic.toString()) << "] on docKey ["
+                            << docKey << "] is for a FileSystem document");
+
             // Remove from the current poll and transfer.
             disposition.setMove(
                 [this, docKey, url, uriPublic,
@@ -116,6 +119,8 @@ void RequestVettingStation::handleRequest(SocketPoll& poll, SocketDisposition& d
                 });
             break;
         case StorageBase::StorageType::Wopi:
+            LOG_INF("URI [" << COOLWSD::anonymizeUrl(uriPublic.toString()) << "] on docKey ["
+                            << docKey << "] is for a WOPI document");
             // Remove from the current poll and transfer.
             disposition.setMove(
                 [this, &poll, docKey, url, uriPublic,

--- a/wsd/RequestVettingStation.cpp
+++ b/wsd/RequestVettingStation.cpp
@@ -1,0 +1,264 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <config.h>
+
+#include <RequestVettingStation.hpp>
+
+#include <COOLWSD.hpp>
+#include <TraceEvent.hpp>
+#include <StorageConnectionManager.hpp>
+#include <Exceptions.hpp>
+#include <Log.hpp>
+#include <DocumentBroker.hpp>
+#include <ClientSession.hpp>
+#include <common/JsonUtil.hpp>
+#include <Util.hpp>
+
+extern std::shared_ptr<DocumentBroker>
+findOrCreateDocBroker(const std::shared_ptr<ProtocolHandlerInterface>& proto,
+                      DocumentBroker::ChildType type, const std::string& uri,
+                      const std::string& docKey, const std::string& id, const Poco::URI& uriPublic,
+                      unsigned mobileAppDocId = 0);
+namespace
+{
+void sendLoadResult(const std::shared_ptr<ClientSession>& clientSession, bool success,
+                    const std::string& errorMsg)
+{
+    const std::string result = success ? "" : "Error while loading document";
+    const std::string resultstr = success ? "true" : "false";
+    // Some sane limit, otherwise we get problems transferring this
+    // to the client with large strings (can be a whole webpage)
+    // Replace reserved characters
+    std::string errorMsgFormatted = COOLProtocol::getAbbreviatedMessage(errorMsg);
+    errorMsgFormatted = Poco::translate(errorMsg, "\"", "'");
+    clientSession->sendMessage("commandresult: { \"command\": \"load\", \"success\": " + resultstr +
+                               ", \"result\": \"" + result + "\", \"errorMsg\": \"" +
+                               errorMsgFormatted + "\"}");
+}
+
+} // anonymous namespace
+
+void RequestVettingStation::handleRequest(SocketPoll& poll)
+{
+    const std::string url = _requestDetails.getDocumentURI();
+
+    LOG_INF("URL [" << url << "] for WS Request.");
+    const auto uriPublic = RequestDetails::sanitizeURI(url);
+    const auto docKey = RequestDetails::getDocKey(uriPublic);
+    const std::string fileId = Util::getFilenameFromURL(docKey);
+    Util::mapAnonymized(fileId, fileId); // Identity mapping, since fileId is already obfuscated
+
+    LOG_INF("Starting GET request handler for session [" << _id << "] on url ["
+                                                         << COOLWSD::anonymizeUrl(url) << ']');
+
+    // Indicate to the client that document broker is searching.
+    static const std::string status("statusindicator: find");
+    LOG_TRC("Sending to Client [" << status << ']');
+    _ws->sendMessage(status);
+
+    LOG_INF("Sanitized URI [" << COOLWSD::anonymizeUrl(url) << "] to ["
+                              << COOLWSD::anonymizeUrl(uriPublic.toString())
+                              << "] and mapped to docKey [" << docKey << "] for session [" << _id
+                              << ']');
+
+    // Check if readonly session is required
+    bool isReadOnly = false;
+    for (const auto& param : uriPublic.getQueryParameters())
+    {
+        LOG_TRC("Query param: " << param.first << ", value: " << param.second);
+        if (param.first == "permission" && param.second == "readonly")
+        {
+            isReadOnly = true;
+        }
+    }
+
+    LOG_INF("URL [" << COOLWSD::anonymizeUrl(url) << "] is "
+                    << (isReadOnly ? "readonly" : "writable"));
+
+    // Before we create DocBroker with a SocketPoll thread, a ClientSession, and a Kit process,
+    // we need to vet this request by invoking CheckFileInfo.
+    // For that, we need the storage settings to create a connection.
+    const StorageBase::StorageType storageType =
+        StorageBase::validate(uriPublic, /*takeOwnership=*/false);
+    switch (storageType)
+    {
+        case StorageBase::StorageType::Unsupported:
+            LOG_ERR("Unsupported URI [" << COOLWSD::anonymizeUrl(uriPublic.toString())
+                                        << "] or no storage configured");
+            throw BadRequestException("No Storage configured or invalid URI " +
+                                      COOLWSD::anonymizeUrl(uriPublic.toString()) + ']');
+
+            break;
+        case StorageBase::StorageType::Unauthorized:
+            LOG_ERR("No acceptable WOPI hosts found matching the target host ["
+                    << uriPublic.getHost() << "] in config");
+            throw UnauthorizedRequestException(
+                "No acceptable WOPI hosts found matching the target host [" + uriPublic.getHost() +
+                "] in config");
+            break;
+        case StorageBase::StorageType::FileSystem:
+            break;
+        case StorageBase::StorageType::Wopi:
+            break;
+    }
+
+    ProfileZone profileZone("WopiStorage::getWOPIFileInfo", { { "url", url } });
+
+    Poco::URI uriObject(uriPublic);
+    const std::string uriAnonym = COOLWSD::anonymizeUrl(uriObject.toString());
+
+    LOG_DBG("Getting info for wopi uri [" << uriAnonym << ']');
+    _httpSession = StorageConnectionManager::getHttpSession(uriObject);
+    Authorization auth = Authorization::create(uriPublic);
+    http::Request httpRequest = StorageConnectionManager::createHttpRequest(uriObject, auth);
+
+    const auto startTime = std::chrono::steady_clock::now();
+
+    LOG_TRC("WOPI::CheckFileInfo request header for URI [" << uriAnonym << "]:\n"
+                                                           << httpRequest.header());
+
+    http::Session::FinishedCallback finishedCallback =
+        [this, docKey, startTime, url, uriObject, uriPublic, isReadOnly,
+         uriAnonym](const std::shared_ptr<http::Session>& session)
+    {
+        const std::shared_ptr<const http::Response> httpResponse = session->response();
+
+        std::chrono::milliseconds callDurationMs =
+            std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() -
+                                                                  startTime);
+
+        // Note: we don't log the response if obfuscation is enabled, except for failures.
+        std::string wopiResponse = httpResponse->getBody();
+        const bool failed = (httpResponse->statusLine().statusCode() != http::StatusCode::OK);
+
+        Log::StreamLogger logRes = failed ? Log::error() : Log::trace();
+        if (logRes.enabled())
+        {
+            logRes << "WOPI::CheckFileInfo " << (failed ? "failed" : "returned") << " for URI ["
+                   << uriAnonym << "]: " << httpResponse->statusLine().statusCode() << ' '
+                   << httpResponse->statusLine().reasonPhrase()
+                   << ". Headers: " << httpResponse->header()
+                   << (failed ? "\tBody: [" + wopiResponse + ']' : std::string());
+
+            LOG_END_FLUSH(logRes);
+        }
+
+        if (failed)
+        {
+            if (httpResponse->statusLine().statusCode() == http::StatusCode::Forbidden)
+                throw UnauthorizedRequestException(
+                    "Access denied, 403. WOPI::CheckFileInfo failed on: " + uriAnonym);
+
+            throw StorageConnectionException("WOPI::CheckFileInfo failed: " + wopiResponse);
+        }
+
+        Poco::JSON::Object::Ptr object;
+        if (!JsonUtil::parseJSON(wopiResponse, object))
+        {
+            if (COOLWSD::AnonymizeUserData)
+                wopiResponse = "obfuscated";
+
+            LOG_ERR("WOPI::CheckFileInfo ("
+                    << callDurationMs
+                    << ") failed or no valid JSON payload returned. Access denied. "
+                       "Original response: ["
+                    << wopiResponse << ']');
+
+            throw UnauthorizedRequestException("Access denied. WOPI::CheckFileInfo failed on: " +
+                                               uriAnonym);
+        }
+
+        // Request a kit process for this doc.
+        std::shared_ptr<DocumentBroker> docBroker = findOrCreateDocBroker(
+            std::static_pointer_cast<ProtocolHandlerInterface>(_ws),
+            DocumentBroker::ChildType::Interactive, url, docKey, _id, uriPublic, _mobileAppDocId);
+        if (!docBroker)
+        {
+            throw ServiceUnavailableException("Failed to create DocBroker with docKey [" + docKey +
+                                              ']');
+        }
+
+        LOG_DBG("DocBroker [" << docKey << "] acquired for [" << url << ']');
+        std::shared_ptr<ClientSession> clientSession =
+            docBroker->createNewClientSession(_ws, _id, uriPublic, isReadOnly, _requestDetails);
+        if (!clientSession)
+        {
+            LOG_WRN("Failed to create Client Session with id [" << _id << "] on docKey [" << docKey
+                                                                << ']');
+            throw std::runtime_error("Cannot create client session for doc " + docKey);
+        }
+
+        LOG_DBG("ClientSession [" << clientSession->getName() << "] for [" << docKey
+                                  << "] acquired for [" << url << ']');
+
+        // Transfer the client socket to the DocumentBroker when we get back to the poll:
+        docBroker->setupTransfer(
+            _socket,
+            [docBroker, clientSession, this](const std::shared_ptr<Socket>& moveSocket)
+            {
+                try
+                {
+                    LOG_DBG_S("Transfering docBroker [" << docBroker->getDocKey() << ']');
+
+                    auto streamSocket = std::static_pointer_cast<StreamSocket>(moveSocket);
+
+                    // Set WebSocketHandler's socket after its construction for shared_ptr goodness.
+                    streamSocket->setHandler(_ws);
+
+                    LOG_DBG_S('#' << moveSocket->getFD() << " handler is "
+                                  << clientSession->getName());
+
+                    // Add and load the session.
+                    docBroker->addSession(clientSession);
+
+                    COOLWSD::checkDiskSpaceAndWarnClients(true);
+                    // Users of development versions get just an info
+                    // when reaching max documents or connections
+                    COOLWSD::checkSessionLimitsAndWarnClients();
+
+                    sendLoadResult(clientSession, true, "");
+                }
+                catch (const UnauthorizedRequestException& exc)
+                {
+                    LOG_ERR_S("Unauthorized Request while starting session on "
+                              << docBroker->getDocKey() << " for socket #" << moveSocket->getFD()
+                              << ". Terminating connection. Error: " << exc.what());
+                    const std::string msg = "error: cmd=internal kind=unauthorized";
+                    _ws->shutdown(WebSocketHandler::StatusCodes::POLICY_VIOLATION, msg);
+                    moveSocket->ignoreInput();
+                }
+                catch (const StorageConnectionException& exc)
+                {
+                    LOG_ERR_S("Storage error while starting session on "
+                              << docBroker->getDocKey() << " for socket #" << moveSocket->getFD()
+                              << ". Terminating connection. Error: " << exc.what());
+                    const std::string msg = "error: cmd=storage kind=loadfailed";
+                    _ws->shutdown(WebSocketHandler::StatusCodes::POLICY_VIOLATION, msg);
+                    moveSocket->ignoreInput();
+                }
+                catch (const std::exception& exc)
+                {
+                    LOG_ERR_S("Error while starting session on "
+                              << docBroker->getDocKey() << " for socket #" << moveSocket->getFD()
+                              << ". Terminating connection. Error: " << exc.what());
+                    const std::string msg = "error: cmd=storage kind=loadfailed";
+                    _ws->shutdown(WebSocketHandler::StatusCodes::POLICY_VIOLATION, msg);
+                    moveSocket->ignoreInput();
+                }
+            });
+    };
+
+    _httpSession->setFinishedHandler(finishedCallback);
+
+    // Run the CheckFileInfo request on the WebServer Poll.
+    _httpSession->asyncRequest(httpRequest, poll);
+}

--- a/wsd/RequestVettingStation.cpp
+++ b/wsd/RequestVettingStation.cpp
@@ -263,6 +263,15 @@ void RequestVettingStation::createDocBroker(const std::string& docKey, const std
                 _ws->shutdown(WebSocketHandler::StatusCodes::POLICY_VIOLATION, msg);
                 moveSocket->ignoreInput();
             }
+            catch (const StorageSpaceLowException& exc)
+            {
+                LOG_ERR_S("Disk-Full error while starting session on "
+                          << docBroker->getDocKey() << " for socket #" << moveSocket->getFD()
+                          << ". Terminating connection. Error: " << exc.what());
+                const std::string msg = "error: cmd=internal kind=diskfull";
+                _ws->shutdown(WebSocketHandler::StatusCodes::UNEXPECTED_CONDITION, msg);
+                moveSocket->ignoreInput();
+            }
             catch (const std::exception& exc)
             {
                 LOG_ERR_S("Error while starting session on "

--- a/wsd/RequestVettingStation.hpp
+++ b/wsd/RequestVettingStation.hpp
@@ -18,12 +18,11 @@ class RequestVettingStation
 {
 public:
     RequestVettingStation(std::string id, std::shared_ptr<WebSocketHandler> ws,
-                          const RequestDetails& requestDetails, SocketDisposition& disposition,
+                          const RequestDetails& requestDetails,
                           const std::shared_ptr<StreamSocket>& socket, unsigned mobileAppDocId)
         : _id(std::move(id))
         , _ws(ws)
         , _requestDetails(requestDetails)
-        , _disposition(disposition)
         , _socket(socket)
         , _mobileAppDocId(mobileAppDocId)
     {
@@ -31,13 +30,16 @@ public:
 
     inline void logPrefix(std::ostream& os) const { os << '#' << _socket->getFD() << ": "; }
 
-    void handleRequest(SocketPoll& poll);
+    void handleRequest(SocketPoll& poll, SocketDisposition& disposition);
+
+private:
+    void createDocBroker(const std::string& docKey, const std::string& url,
+                         const Poco::URI& uriPublic, const bool isReadOnly);
 
 private:
     const std::string _id;
     std::shared_ptr<WebSocketHandler> _ws;
     const RequestDetails _requestDetails;
-    SocketDisposition _disposition;
     const std::shared_ptr<StreamSocket> _socket;
     std::shared_ptr<http::Session> _httpSession;
     unsigned _mobileAppDocId;

--- a/wsd/RequestVettingStation.hpp
+++ b/wsd/RequestVettingStation.hpp
@@ -27,6 +27,10 @@ public:
         , _socket(socket)
         , _mobileAppDocId(mobileAppDocId)
     {
+        // Indicate to the client that document broker is searching.
+        static const std::string status("statusindicator: find");
+        LOG_TRC("Sending to Client [" << status << "].");
+        _ws->sendMessage(status);
     }
 
     inline void logPrefix(std::ostream& os) const { os << '#' << _socket->getFD() << ": "; }
@@ -37,6 +41,9 @@ private:
     void createDocBroker(const std::string& docKey, const std::string& url,
                          const Poco::URI& uriPublic, const bool isReadOnly,
                          Poco::JSON::Object::Ptr wopiInfo = nullptr);
+
+    void checkFileInfo(SocketPoll& poll, const std::string& url, const Poco::URI& uriPublic,
+                       const std::string& docKey, bool isReadOnly);
 
 private:
     const std::string _id;

--- a/wsd/RequestVettingStation.hpp
+++ b/wsd/RequestVettingStation.hpp
@@ -45,6 +45,11 @@ private:
     void checkFileInfo(SocketPoll& poll, const std::string& url, const Poco::URI& uriPublic,
                        const std::string& docKey, bool isReadOnly, int redirectionLimit);
 
+    /// Send an error to the client and disconnect the socket.
+    static void sendErrorAndShutdown(const std::shared_ptr<WebSocketHandler>& ws,
+                                     const std::shared_ptr<Socket>& socket, const std::string& msg,
+                                     WebSocketHandler::StatusCodes statusCode);
+
 private:
     const std::string _id;
     std::shared_ptr<WebSocketHandler> _ws;

--- a/wsd/RequestVettingStation.hpp
+++ b/wsd/RequestVettingStation.hpp
@@ -10,6 +10,7 @@
  */
 
 #include "RequestDetails.hpp"
+#include <Storage.hpp>
 #include "WebSocketHandler.hpp"
 
 #include <string>
@@ -34,7 +35,8 @@ public:
 
 private:
     void createDocBroker(const std::string& docKey, const std::string& url,
-                         const Poco::URI& uriPublic, const bool isReadOnly);
+                         const Poco::URI& uriPublic, const bool isReadOnly,
+                         Poco::JSON::Object::Ptr wopiInfo = nullptr);
 
 private:
     const std::string _id;
@@ -42,5 +44,7 @@ private:
     const RequestDetails _requestDetails;
     const std::shared_ptr<StreamSocket> _socket;
     std::shared_ptr<http::Session> _httpSession;
-    unsigned _mobileAppDocId;
+    const unsigned _mobileAppDocId;
+    std::unique_ptr<WopiStorage::WOPIFileInfo> _wopiInfo;
+    LockContext _lockCtx;
 };

--- a/wsd/RequestVettingStation.hpp
+++ b/wsd/RequestVettingStation.hpp
@@ -1,0 +1,44 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include "RequestDetails.hpp"
+#include "WebSocketHandler.hpp"
+
+#include <string>
+
+class RequestVettingStation
+{
+public:
+    RequestVettingStation(std::string id, std::shared_ptr<WebSocketHandler> ws,
+                          const RequestDetails& requestDetails, SocketDisposition& disposition,
+                          const std::shared_ptr<StreamSocket>& socket, unsigned mobileAppDocId)
+        : _id(std::move(id))
+        , _ws(ws)
+        , _requestDetails(requestDetails)
+        , _disposition(disposition)
+        , _socket(socket)
+        , _mobileAppDocId(mobileAppDocId)
+    {
+    }
+
+    inline void logPrefix(std::ostream& os) const { os << '#' << _socket->getFD() << ": "; }
+
+    void handleRequest(SocketPoll& poll);
+
+private:
+    const std::string _id;
+    std::shared_ptr<WebSocketHandler> _ws;
+    const RequestDetails _requestDetails;
+    SocketDisposition _disposition;
+    const std::shared_ptr<StreamSocket> _socket;
+    std::shared_ptr<http::Session> _httpSession;
+    unsigned _mobileAppDocId;
+};

--- a/wsd/RequestVettingStation.hpp
+++ b/wsd/RequestVettingStation.hpp
@@ -43,7 +43,7 @@ private:
                          Poco::JSON::Object::Ptr wopiInfo = nullptr);
 
     void checkFileInfo(SocketPoll& poll, const std::string& url, const Poco::URI& uriPublic,
-                       const std::string& docKey, bool isReadOnly);
+                       const std::string& docKey, bool isReadOnly, int redirectionLimit);
 
 private:
     const std::string _id;


### PR DESCRIPTION
This non-functional PR only adds new code, without making any changes to existing code in any way (with one exception in DocBroker, where an new optional parameter is added to `addSession`). This new code is all required for async/parallel loading, which will come in a much smaller patches.

This code primarily adds two new class: `StorageConnectionManager`, responsible for creating connections to the Storage server (extracted from the Storage namespace) and will refactor code there later. And `RequestVettingStation`, responsible for doing the authentication of new connections, asynchronously, before creating DocBroker, committing resources, and spinning a new Kit instance.

- wsd: add StorageConnectionManager
- configure: enable rtti with sanitizers on C++ TUs only
- wsd: add StorageConnectionManager::createHttpRequest
- wsd: make findOrCreateDocBroker non-static
- wsd: new setupTransfer into DocBroker
- wsd: rvs: add RequestVettingStation
- wsd: rvs: refactor createDocBroker
- wsd: rvs: handle StorageSpaceLowException
- wsd: rvs: pass wopiFileInfo around
- wsd: rvs: refactor CheckFileInfo
- wsd: rvs: support redirection of CheckFileInfo
- wsd: rvs: better logging
- wsd: rvs: avoid exceptions when handled gracefully already
- wsd: rvs: refactor send error and shutdown socket
- wsd: rvs: copy the WS before passing it to docBroker
