### PR TITLE
Copying the hyperlink issue:

### DIFF
--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -484,7 +484,6 @@ L.Clipboard = L.Class.extend({
 		this._checkSelection();
 
 		var text = this._getHtmlForClipboard();
-		//this._stopHideDownload(); - this confuses the browser ruins copy/cut on iOS
 
 		var plainText = this.stripHTML(text);
 		if (ev.clipboardData) { // Standard
@@ -525,7 +524,7 @@ L.Clipboard = L.Class.extend({
 			&& !this.isPasteSpecialDialogOpen())
 			return true;
 
-		if ($('.annotation-active').length && $('.cool-annotation-edit').is(':visible'))
+		if (app.view.commentHasFocus)
 		    return true;
 
 		return false;
@@ -609,7 +608,7 @@ L.Clipboard = L.Class.extend({
 
 		this._unoCommandForCopyCutPaste = cmd;
 		if (document.execCommand(operation) &&
-		    serial !== this._clipboardSerial) {
+			serial !== this._clipboardSerial) {
 			window.app.console.log('copied successfully');
 			this._unoCommandForCopyCutPaste = null;
 			return;


### PR DESCRIPTION
* Add a paragraph.
* Select the whole paragraph and add comment.
* Add hyperlink to a word in the paragraph.
* Try to copy the hyperlink via its menu.
* It sometimes doesn't copy the hyperlink.

We are checking if a comment has focus or not before doing the copy operation. This check is for another issue. I changed the check with "app.view.commentHasFocus" which seems reliable. Then tested the previous fix.

Also commented out code is removed.
White space change is automatic.


Change-Id: Ibc2c5e550eb8a3e24b734e0371c87dac44b2ff6d


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

