### PR TITLE
make this other test more robust if partial page 1 is still visible

### DIFF
--- a/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
@@ -374,7 +374,7 @@ describe(['tagdesktop'], 'Top toolbar tests.', function() {
 		helper.typeIntoDocument('{ctrl}{leftarrow}');
 		cy.cGet('#Insert-tab-label').click();
 		cy.cGet('#Insert-container-row .unoInsertPagebreak').click();
-		cy.cGet('#StatePageNumber').should('have.text', 'Pages 1 and 2 of 2');
+		cy.cGet('#StatePageNumber').invoke('text').should('be.oneOf', ['Page 2 of 2', 'Pages 1 and 2 of 2']);
 		helper.selectAllText();
 
 		//var data = [];


### PR DESCRIPTION
when cursor is on page 2


Change-Id: Iae8d28ad54401fbbe78a2f2429f1a6912f1ea967


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

