### PR TITLE
context menu: allow frame properties for Writer text frames

### DIFF
--- a/browser/src/control/Control.ContextMenu.js
+++ b/browser/src/control/Control.ContextMenu.js
@@ -51,7 +51,7 @@ L.Control.ContextMenu = L.Control.extend({
 				   'UpdateCurIndex','RemoveTableOf',
 				   'ReplyComment', 'DeleteComment', 'DeleteAuthor', 'DeleteAllNotes',
 				   'SpellingAndGrammarDialog', 'FontDialog', 'FontDialogForParagraph', 'TableDialog',
-				   'SpellCheckIgnore'],
+				   'SpellCheckIgnore', 'FrameDialog'],
 
 			spreadsheet: ['MergeCells', 'SplitCell', 'InsertCell', 'DeleteCell',
 				      'RecalcPivotTable', 'DataDataPilotRun', 'DeletePivotTable',

--- a/browser/src/unocommands.js
+++ b/browser/src/unocommands.js
@@ -203,6 +203,7 @@ var unoCommandsArray = {
 	'FormatYErrorBars':{global:{menu:_('Format Y Error Bars...'),},},
 	'FormattingMarkMenu':{global:{menu:_('Formatting Mark'),},},
 	'FourierAnalysisDialog':{spreadsheet:{menu:_('F~ourier Analysis...'),},},
+	'FrameDialog':{text:{menu:_('~Properties...'),},},
 	'FreezeCellsMenu':{spreadsheet:{menu:_('Freeze ~Cells'),},},
 	'FreezePanes':{spreadsheet:{menu:_('Freeze ~Rows and Columns'),},},
 	'FreezePanesColumn':{spreadsheet:{menu:_('Freeze First Column'),},},


### PR DESCRIPTION
This is now safe to show, as it'll trigger the frame insert/properties
dialog, which was converted to jsdialog in core.git commit
355681eead2411d70caf4f52f1b802cf8c61a981 (sw floattable: make Insert
Frame dialog async and mark it as a jsdialog, 2023-11-06).

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I910012286416231d607cf79cc9b3811803c52768
