### PR TITLE
remove-unused-darke-theme-css-for-dropdown

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -556,11 +556,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 .ui-listbox::-ms-expand {
 	display: none;
 }
-@media (prefers-color-scheme: dark) {
-	.ui-listbox-arrow {
-		background: url('images/jquery-ui-lightness/ui-icons_ffffff_256x240.png') no-repeat transparent !important;
-	}
-}
+
 .ui-listbox-arrow {
 	content: '';
 	background: url('images/jquery-ui-lightness/ui-icons_222222_256x240.png') no-repeat transparent;


### PR DESCRIPTION
- we do not need this media query here
- 23.05 have already a case which handles the dark mode
Signed-off-by: Darshan-upadhyay1110 <darshan.upadhyay@collabora.com>
Change-Id: I3a28d686972d8f69ca6702bf4af2b23813cad975


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

