### PR TITLE
Add a ui_defaults hint for touchscreens

### DIFF
--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -107,9 +107,12 @@ window.app = {
 
 	var chromebook = window.ThisIsTheAndroidApp && window.COOLMessageHandler.isChromeOS();
 
-	var touch = !window.L_NO_TOUCH && (pointer || 'ontouchstart' in window ||
-			(window.DocumentTouch && document instanceof window.DocumentTouch) ||
-			window.matchMedia('(pointer: coarse)').matches) && !chromebook;
+	if (window.uiDefaults['touchscreenHint'] !== undefined)
+		var touch = window.uiDefaults['touchscreenHint'];
+	else
+		var touch = !window.L_NO_TOUCH && (pointer || 'ontouchstart' in window ||
+				(window.DocumentTouch && document instanceof window.DocumentTouch) ||
+				window.matchMedia('(pointer: coarse)').matches) && !chromebook;
 
 	var isInternetExplorer = (navigator.userAgent.toLowerCase().indexOf('msie') != -1 ||
 				  navigator.userAgent.toLowerCase().indexOf('trident') != -1);

--- a/wsd/FileServerUtil.cpp
+++ b/wsd/FileServerUtil.cpp
@@ -91,6 +91,11 @@ std::string FileServerRequestHandler::uiDefaultsToJSON(const std::string& uiDefa
             }
             continue;
         }
+        if (keyValue.equals(0, "TouchscreenHint"))
+        {
+            json.set("touchscreenHint", keyValue.equals(1, "true"));
+            continue;
+        }
         if (keyValue.equals(0, "OnscreenKeyboardHint"))
         {
             json.set("onscreenKeyboardHint", keyValue.equals(1, "true"));


### PR DESCRIPTION
At the moment, we try to detect whether the browser is running with a touchscreen, however this is very imperfect. It's possible an integrator may have more information about whether COOL is running on a device with a touchscreen, so this ui_defaults property allows us to specify. Touch mode binds inputs for touchscreen devices (long press for menu, pinch to zoom, etc.) and does not bind the normal inputs (right click for menu, etc.), so it's crucial to get it on all touch devices and no desktop devices, as input is severely hampered if they are the wrong way round.

The property is called TouchscreenHint. Setting it to 'true' will enable touchscreen mode, setting it to 'false' will disable touchscreen mode. Leaving it undefined will keep our detection active.

This property must be set at page load so we can register the right events at creation time. Therefore, ui_defaults is perfect as a method to override this.

This is not a long-term solution. Instead, "The right thing" is to look specifically for touch events and specifically for mouse events, rather than using the default hammer.js behavior which is to look for both... that should be an eventual followup to this. However, this was a lot faster to implement and helps with the most pressing issue: not being able to override our detection when it goes wrong.

Change-Id: Id28a156fe352fe6565ce6b472b7aa54d0869c48e


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

