### PR TITLE
empty updates seen on first view of document

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -3411,8 +3411,8 @@ void DocumentBroker::sendRequestedTiles(const std::shared_ptr<ClientSession>& se
                     tilesNeedsRendering.push_back(tile);
                     _debugRenderedTileCount++;
                 }
-                tileCache().subscribeToTileRendering(tile, session, now);
-                beingRendered++;
+                if (tileCache().subscribeToTileRendering(tile, session, now))
+                    beingRendered++;
             }
             requestedTiles.pop_front();
         }

--- a/wsd/TileCache.cpp
+++ b/wsd/TileCache.cpp
@@ -431,7 +431,7 @@ bool TileCache::intersectsTile(const TileDesc &tileDesc, int part, int mode, int
 }
 
 // FIXME: to be further simplified when we centralize tile messages.
-void TileCache::subscribeToTileRendering(const TileDesc& tile, const std::shared_ptr<ClientSession>& subscriber,
+bool TileCache::subscribeToTileRendering(const TileDesc& tile, const std::shared_ptr<ClientSession>& subscriber,
                                          const std::chrono::steady_clock::time_point &now)
 {
     ASSERT_CORRECT_THREAD_OWNER(_owner);
@@ -450,7 +450,7 @@ void TileCache::subscribeToTileRendering(const TileDesc& tile, const std::shared
                 LOG_TRC("Redundant request to subscribe on tile " << tile.debugName());
                 // the version stops us unsubscribing when we get there.
                 tileBeingRendered->setVersion(tile.getVersion());
-                return;
+                return false;
             }
         }
 
@@ -469,6 +469,7 @@ void TileCache::subscribeToTileRendering(const TileDesc& tile, const std::shared
         tileBeingRendered->getSubscribers().push_back(subscriber);
         _tilesBeingRendered[tile] = tileBeingRendered;
     }
+    return true;
 }
 
 Tile TileCache::findTile(const TileDesc &desc)

--- a/wsd/TileCache.hpp
+++ b/wsd/TileCache.hpp
@@ -221,9 +221,9 @@ public:
     TileCache(const TileCache&) = delete;
     TileCache& operator=(const TileCache&) = delete;
 
-    /// Subscribes if no subscription exists and returns the version number.
-    /// Otherwise returns 0 to signify a subscription exists.
-    void subscribeToTileRendering(const TileDesc& tile, const std::shared_ptr<ClientSession>& subscriber,
+    /// Subscribes if no subscription exists and returns true.
+    /// Otherwise returns false to signify a subscription already exists.
+    bool subscribeToTileRendering(const TileDesc& tile, const std::shared_ptr<ClientSession>& subscriber,
                                   const std::chrono::steady_clock::time_point& now);
 
     /// Cancels all tile requests by the given subscriber.


### PR DESCRIPTION
this is visible even with hello-world.odt in the debugging overlay where I have 9 cols and 7 rows visible.

Load hello-world.odt and from the 4th row, 8th col onwards each tile has a "upd: 1" of an additional empty delta update to the original tile

browser-side:
a) we have one OUTGOING: tilecombine request which which requests an
   initial 72 tiles (9 cols, 8 rows)
b) we then receive 72 tiles as requested
c) and browser sends back tileprocessed for each
d) but we then get a series of (38) delta: requests after that which are
   unexplained

server-side:
a) on the initial tilecombine, DocumentBroker::handleTileCombinedRequest
   sends the 72 requested tiles for rendering and registers to send each when
   ready.

    for (auto& tile : tileCombined.getTiles())
    {
        ...
        tilesNeedsRendering.push_back(tile);
        ...
        tileCache().subscribeToTileRendering(tile, session, now);
    }

    // Send rendering request, prerender before we actually send the tiles
    if (!tilesNeedsRendering.empty())
        sendTileCombine(TileCombined::create(tilesNeedsRendering));

    and stores what tiles it want to send in session->getRequestedTiles()

    before calling sendRequestedTiles(session);

b) at this sendRequestedTiles (also later when tileprocessed is seen from
   each tile response from the browser which also calls sendRequestedTiles), then:

c) DocumentBroker::sendRequestedTiles loops over existing requests and drops
   from session->getRequestedTiles() both the tiles that it can send immediately,
   and those that are queued to get rendered.

d) But it only does this for a max amount of tiles, based on beingRendered, up to
   a tilesOnFlyUpperLimit. beingRendered is bumped for each tile not ready yet,
   on the assumption that it needs to be rendered.

e) But we already have some getting rendered, and bump beingRendered anyway,
   so tilesOnFlyUpperLimit can easily get exceeded on a first page, typically this
   first sendRequestedTiles loop stops early, and stops dropping tiles from the
   request queue that are already queued to be rendered.

f) at some point we get a tileprocessed and sendRequestedTiles is called again,
   the request queue wasn't emptied, and by now it is likely the tile cache has
   results for them (which were already sent) and sendTileNow is used to send those,
   resulting in additional empty deltas sent for fulfilled queries.

logs will show "Redundant request to subscribe on tile" warnings in this case

Here as a conservative improvement only increase beingRendered if the sendRequestedTiles subscribeToTileRendering actually does anything.

There is a mismatch in what handleTileCombinedRequest does vs what sendRequestedTiles does. Maybe handleTileCombinedRequest should leave it to sendRequestedTiles to do the sendTileCombine, or maybe handleTileCombinedRequest shouldn't add those tiles to the session requestedTiles.


Change-Id: I3044f4b3e47f00c680aa5b87dd7bdad2f27e8c73


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

