### PR TITLE
NC: Accessibility toggle button not set to the right state on doc load

### DIFF
--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -345,7 +345,7 @@ L.Control.Menubar = L.Control.extend({
 				]},
 				{uno: '.uno:WordCountDialog'},
 				window.enableAccessibility ?
-					{name: _('Accessibility Support'), id: 'togglea11ystate', type: 'action'} : {},
+					{name: _('Voice Over'), id: 'togglea11ystate', type: 'action'} : {},
 				{uno: '.uno:AccessibilityCheck'},
 				{type: 'separator'},
 				{name: _UNO('.uno:AutoFormatMenu', 'text'), type: 'menu', menu: [
@@ -965,7 +965,7 @@ L.Control.Menubar = L.Control.extend({
 			]
 			},
 			window.enableAccessibility ?
-				{name: _('Accessibility Support'), id: 'togglea11ystate', type: 'action'} : {},
+				{name: _('Voice Over'), id: 'togglea11ystate', type: 'action'} : {},
 			{id: 'watermark', uno: '.uno:Watermark'},
 			{name: _('Page Setup'), id: 'pagesetup', type: 'action'},
 			{uno: '.uno:WordCountDialog'},

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -427,7 +427,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 						{
 							'id':'togglea11ystate',
 							'type': 'bigmenubartoolitem',
-							'text': _('Accessibility Support')
+							'text': _('Voice Over')
 						} : {},
 					hasAccessibilityCheck ?
 						{

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -294,8 +294,6 @@ L.Control.UIManager = L.Control.extend({
 
 		this.initDarkModeFromSettings();
 
-		this.map.fire('a11ystatechanged');
-
 		if (docType === 'spreadsheet') {
 			this.map.addControl(L.control.sheetsBar({shownavigation: isDesktop || window.mode.isTablet()}));
 			this.map.addControl(L.control.formulaBar());
@@ -442,7 +440,7 @@ L.Control.UIManager = L.Control.extend({
 
 		this.notebookbar = notebookbar;
 		this.map.addControl(notebookbar);
-
+		this.map.fire('a11ystatechanged');
 		app.UI.notebookbarAccessibility.initialize();
 	},
 

--- a/browser/src/layer/marker/TextInput.js
+++ b/browser/src/layer/marker/TextInput.js
@@ -443,7 +443,7 @@ L.TextInput = L.Layer.extend({
 				_('Screen reader support for text content is disabled. ') +
 				_('You need to enable it both at server level and in the UI. ') +
 				_('Look for the accessibility section in coolwsd.xml for server setting. ') +
-				_('Also check the accessibility support toggle under %parentControl.').replace(
+				_('Also check the voice over toggle under %parentControl.').replace(
 					'%parentControl',
 					window.userInterfaceMode === 'notebookbar' ? _('the Help tab') : _('the View menu')
 				);

--- a/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
@@ -290,7 +290,7 @@ describe(['tagdesktop'], 'Top toolbar tests.', function() {
 		cy.cGet('#copy-paste-container p i').should('exist');
 	});
 
-	it('Enable/Disable Accessibility Support', function() {
+	it('Enable/Disable Voice Over', function() {
 		// when accessibility is disabled at server level
 		// this unit passes but doesn't perform any check
 		desktopHelper.switchUIToNotebookbar();


### PR DESCRIPTION
When a document is loaded the Accessibility Support toggle button was
not set to the right state.
The problem affeced Online when integrated in Nextcloud.

Moreover the button label has been renamed to 'Voice Over' in
accordance with what suggested by NGI audit

Signed-off-by: Marco Cecchetti <marco.cecchetti@collabora.com>
Change-Id: I5bc7d8348397691f469b6274af58e18a8d6d603c
