### PR TITLE
Fix mobile-ui-tabs Misaligned Headings

### DIFF
--- a/browser/css/mobilewizard.css
+++ b/browser/css/mobilewizard.css
@@ -477,9 +477,10 @@ p.mobile-wizard.ui-combobox-text.selected {
 .ui-tabs.mobile-wizard {
 	text-align: center;
 	height: 42px;
-	display: table;
+	display: flex;
 	width: 100%;
 	padding: 0px;
+	overflow-x: auto;
 }
 
 #mobile-wizard-tabs {
@@ -490,12 +491,12 @@ p.mobile-wizard.ui-combobox-text.selected {
 }
 
 .ui-tab.mobile-wizard {
+	flex: auto;
 	display: table-cell;
-	width: 49%;
 	height: 36px;
 	line-height: 36px;
 	vertical-align: middle;
-	margin: 0px 1%;
+	margin: 0px 5%;
 	border-radius: 10px;
 	border: none;
 	color: var(--color-text-lighter);

--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -926,8 +926,6 @@ L.Control.Menubar = L.Control.extend({
 				{name: _('See revision history'), id: 'rev-history', type: 'action'},
 				{type: 'separator'},
 				{name: _UNO('.uno:Print', 'text'), id: 'print', type: 'action'},
-				{name: _UNO('.uno:SetDocumentProperties', 'text'), uno: '.uno:SetDocumentProperties', id: 'properties'}
-
 			]},
 			{name: !window.ThisIsAMobileApp ? _('Download as') : _('Export as'), id: 'downloadas', type: 'menu', menu: [
 				{name: _('PDF Document (.pdf)'), id: !window.ThisIsAMobileApp ? 'exportdirectpdf' : 'downloadas-pdf', type: 'action'},
@@ -992,7 +990,6 @@ L.Control.Menubar = L.Control.extend({
 				{name: _('See revision history'), id: 'rev-history', type: 'action'},
 				{type: 'separator'},
 				{name: _UNO('.uno:Print', 'presentation'), id: 'print', type: 'action'},
-				{name: _UNO('.uno:SetDocumentProperties', 'presentation'), uno: '.uno:SetDocumentProperties', id: 'properties'}
 			]},
 			{name: !window.ThisIsAMobileApp ? _('Download as') : _('Export as'), id:'downloadas', type: 'menu', menu: [
 				{name: _('PDF Document (.pdf)'), id: !window.ThisIsAMobileApp ? 'exportdirectpdf' : 'downloadas-pdf', type: 'action'},
@@ -1056,7 +1053,6 @@ L.Control.Menubar = L.Control.extend({
 				{name: _('Share...'), id:'shareas', type: 'action'},
 				{name: _UNO('.uno:Print', 'presentation'), id: 'print', type: 'action'},
 				{name: _('See revision history'), id: 'rev-history', type: 'action'},
-				{name: _UNO('.uno:SetDocumentProperties', 'presentation'), uno: '.uno:SetDocumentProperties', id: 'properties'}
 			]},
 			{name: !window.ThisIsAMobileApp ? _('Download as') : _('Export as'), id:'downloadas', type: 'menu', menu: [
 				{name: _('PDF Document (.pdf)'), id: !window.ThisIsAMobileApp ? 'exportdirectpdf' : 'downloadas-pdf', type: 'action'},
@@ -1114,7 +1110,6 @@ L.Control.Menubar = L.Control.extend({
 				{name: _UNO('.uno:Print', 'spreadsheet'), id: 'print', type: 'action'},
 				{name: _('Define print area', 'spreadsheet'), uno: '.uno:DefinePrintArea' },
 				{name: _('Remove print area', 'spreadsheet'), uno: '.uno:DeletePrintArea' },
-				{name: _UNO('.uno:SetDocumentProperties', 'spreadsheet'), uno: '.uno:SetDocumentProperties', id: 'properties'}
 			]},
 			{name: !window.ThisIsAMobileApp ? _('Download as') : _('Export as'), id:'downloadas', type: 'menu', menu: [
 				{name: _('PDF Document (.pdf)'), id: !window.ThisIsAMobileApp ? 'exportdirectpdf' : 'downloadas-pdf', type: 'action'},


### PR DESCRIPTION
Signed-off-by: Darshan-upadhyay1110 <darshan.upadhyay@collabora.com>
Change-Id: Ib982a59c141d937c7f92eb9684b91fc7f2548df5

- will fix Misaligned ui-tabs in mobile wizard
- also added scrollable property that will handle more fields in tabs if it does not fit into screen

* Resolves: #7638 
* Target version: master 

### Summary

- Before
![image](https://github.com/CollaboraOnline/online/assets/61383886/9a810883-7efe-4be5-9ffc-5af8067d3aa7)


-After

![image](https://github.com/CollaboraOnline/online/assets/61383886/c12aad30-ab49-490d-bcb8-c0cb7e7b4514)

