### PR TITLE
fix: improve prometheus-rules

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run chart-releaser
         # for use with make-release-latest
-        uses: helm/chart-releaser-action@fdfc0aa11c813b419cc28971327031c3119bec63
+        uses: helm/chart-releaser-action@v1
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:

--- a/kubernetes/helm/collabora-online/Chart.yaml
+++ b/kubernetes/helm/collabora-online/Chart.yaml
@@ -5,7 +5,7 @@ name: collabora-online
 description: Collabora Online helm chart
 
 version: 1.1.5
-appVersion: "23.05.5.4.1"
+appVersion: "23.05.5.5.1"
 
 home: "https://www.collaboraoffice.com/code/"
 icon: "https://avatars0.githubusercontent.com/u/22418908?s=200&v=4"
@@ -35,7 +35,7 @@ maintainers:
 annotations:
   artifacthub.io/images: |
     - name: collabora
-      image: docker.io/collabora/code:23.05.5.4.1
+      image: docker.io/collabora/code:23.05.5.5.1
     - name: nginx
       image: docker.io/nginx:1.25
     - name: twostoryrobot/simple-file-upload

--- a/kubernetes/helm/collabora-online/templates/prometheus-rules.yaml
+++ b/kubernetes/helm/collabora-online/templates/prometheus-rules.yaml
@@ -21,7 +21,7 @@ spec:
           severity: "critical"
         {{`
         annotations:
-          summary: "no coolwsd process running: in namespace {{ $labels.namespace }}"
+          summary: "no coolwsd process running: in namespace {{ $labels.namespace }} on pod {{ $labels.pod }}."
         `}}
       {{- range $key, $value := .Values.prometheus.rules.defaults.docs.pod }}
       - alert: "Collabora Open Docs by Pod"
@@ -31,7 +31,7 @@ spec:
           severity: "{{ $key }}"
         {{`
         annotations:
-          summary: "Too many Docs are open on a pod in namespace: {{ $labels.namespace }}"
+          summary: "too many docs ({{ $value }}) are open in namespace {{ $labels.namespace }} on pod {{ $labels.pod }}."
         `}}
       {{- end }}
       {{- range $key, $value := .Values.prometheus.rules.defaults.docs.sum }}
@@ -42,7 +42,7 @@ spec:
           severity: "{{ $key }}"
         {{`
         annotations:
-          summary: "Too many Docs are open on namespace"
+          summary: "too many docs ({{ $value }}) are open in namespace {{ $labels.namespace }}."
         `}}
       {{- end }}
       {{- range $key, $value := .Values.prometheus.rules.defaults.viewers.pod }}
@@ -53,7 +53,7 @@ spec:
           severity: "{{ $key }}"
         {{`
         annotations:
-          summary: "Too many Viewers on a pod in namespace: {{ $labels.namespace }}"
+          summary: "too many viewers ({{ $value }}) in namespace {{ $labels.namespace }} on pod {{ $labels.pod }}."
         `}}
       {{- end }}
       {{- range $key, $value := .Values.prometheus.rules.defaults.viewers.doc }}
@@ -64,7 +64,7 @@ spec:
           severity: "{{ $key }}"
         {{`
         annotations:
-          summary: "Too many Viewers on a document in namespace: {{ $labels.namespace }}"
+          summary: "too many viewers ({{ $value }}) on document {{ $labels.key }} in namespace {{ $labels.namespace }}."
         `}}
       {{- end }}
       {{- range $key, $value := .Values.prometheus.rules.defaults.viewers.sum }}
@@ -75,24 +75,24 @@ spec:
           severity: "{{ $key }}"
         {{`
         annotations:
-          summary: "Too many Viewers on namespace"
+          summary: "too many viewers ({{ $value }}) in namespace {{ $labels.namespace }}."
         `}}
       {{- end }}
-      - alert: "Collabora same Document open Multiple time"
-        expr: 'count(doc_info) by (key) > 1'
-        labels:
-          severity: "warning"
-        {{`
-        annotations:
-          summary: "a key/document is open multiple times in namespace: {{ $labels.namespace }}"
-        `}}
-      - alert: "Collabora same Document open Multiple time"
-        expr: 'count(count(doc_info)by(key)>1) > {{ .Values.prometheus.rules.defaults.docs.duplicated }}'
+      - alert: "Collabora DocumentsOpenSimultaneously"
+        expr: 'count(count (doc_info) by (key, namespace) > 1) by (namespace) / count (doc_info) by (namespace) * 100 > {{ .Values.prometheus.rules.defaults.docs.duplicated }}'
         labels:
           severity: "critical"
         {{`
         annotations:
-          summary: "too many document are open multiple times in namespace: {{ $labels.namespace }}"
+          summary: '{{ printf "%.0f" $value }}% of all documents are opened simultaneously on different pods in namespace {{ $labels.namespace }}. Viewers can not see each others.'
+        `}}
+      - alert: "Collabora DocumentsOpenSimultaneously"
+        expr: 'count(doc_info) by (key, namespace) > 1'
+        labels:
+          severity: "warning"
+        {{`
+        annotations:
+          summary: "the document {{ $labels.key }} is opened simultaneously on different pods in namespace {{ $labels.namespace }}. Viewers can not see each others."
         `}}
       - alert: "Collabora Error StorageSpaceLow"
         expr: 'increase(error_storage_space_low[1m]) > 0'
@@ -100,7 +100,7 @@ spec:
           severity: "warning"
         {{`
         annotations:
-          summary: "local storage space too low to operate in namespace: {{ $labels.namespace }}"
+          summary: "local storage space too low to operate in namespace {{ $labels.namespace }} on pod {{ $labels.pod }}."
         `}}
       {{- range $key, $value := .Values.prometheus.rules.defaults.errorStorageConnections }}
       - alert: "Collabora Error StorageConnection"
@@ -112,14 +112,13 @@ spec:
           summary: "unable to connect to storage in namespace {{ $labels.namespace }} on pod {{ $labels.pod }}."
         `}}
       {{- end }}
-
       - alert: "Collabora Error BadRequest"
         expr: 'increase(error_bad_request[1m]) > 0'
         labels:
           severity: "warning"
         {{`
         annotations:
-          summary: "we returned an HTTP bad request to a caller in namespace: {{ $labels.namespace }}"
+          summary: "we returned an HTTP bad request to a caller in namespace {{ $labels.namespace }} on pod {{ $labels.pod }}."
         `}}
       - alert: "Collabora Error BadArgument"
         expr: 'increase(error_bad_argument[1m]) > 0'
@@ -127,7 +126,7 @@ spec:
           severity: "warning"
         {{`
         annotations:
-          summary: "we returned an HTTP bad argument to a caller in namespace: {{ $labels.namespace }}"
+          summary: "we returned an HTTP bad argument to a caller in namespace {{ $labels.namespace }} on pod {{ $labels.pod }}."
         `}}
       - alert: "Collabora Error UnauthorizedRequest"
         expr: 'increase(error_unauthorized_request[1m]) > 0'
@@ -135,7 +134,7 @@ spec:
           severity: "warning"
         {{`
         annotations:
-          summary: "an authorization exception usually on CheckFileInfo in namespace: {{ $labels.namespace }}"
+          summary: "an authorization exception usually on CheckFileInfo in namespace {{ $labels.namespace }} on pod {{ $labels.pod }}."
         `}}
       {{- range $key, $value := .Values.prometheus.rules.defaults.errorServiceUnavailable }}
       - alert: "Collabora Error ServiceUnavailable"
@@ -153,7 +152,7 @@ spec:
           severity: "warning"
         {{`
         annotations:
-          summary: "badly formed data provided for us to parse in namespace: {{ $labels.namespace }}"
+          summary: "badly formed data provided for us to parse in namespace {{ $labels.namespace }} on pod {{ $labels.pod }}."
         `}}
       {{- end }}
   {{- if .Values.prometheus.rules.additionalRules }}

--- a/kubernetes/helm/collabora-online/values.yaml
+++ b/kubernetes/helm/collabora-online/values.yaml
@@ -54,16 +54,8 @@ prometheus:
     additionalLabels: {}
     defaults:
       enabled: true
-      errorServiceUnavailable:
-        critical: 50
-        warning: 2
-        info: 0
-      errorStorageConnections:
-        critical: 50
-        warning: 2
-        info: 0
       docs:
-        duplicated: 50
+        duplicated: 0
         pod:
           critical: 10
           warning: 8
@@ -72,6 +64,14 @@ prometheus:
           critical: 500
           warning: 200
           info: 50
+      errorServiceUnavailable:
+        critical: 50
+        warning: 2
+        info: 0
+      errorStorageConnections:
+        critical: 50
+        warning: 2
+        info: 0
       viewers:
         pod:
           critical: 100


### PR DESCRIPTION
Change-Id: I5076c74c3beeada0978d5b29dcc4e531cfce9241

* Target version: master 

### Summary

ping @Rash419

we refactoring your default alerts there text and redefined the Alert DocumentsOpenSimultaneously: where on critical, it say how many of all documents are opened simultaneously on different pods procent (if the ingress does not work correct)

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id

