### PR TITLE
Unify touchscreen handling, remove L.Browser.touch

### DIFF
--- a/browser/src/control/Control.FormulaBar.js
+++ b/browser/src/control/Control.FormulaBar.js
@@ -110,6 +110,7 @@ L.Control.FormulaBar = L.Control.extend({
 	onAddressInput: function(e) {
 		if (e.keyCode === 13) {
 			// address control should not have focus anymore
+			L.DomUtil.get('addressInput').blur();
 			this.map.focus();
 			var value = L.DomUtil.get('addressInput').value;
 			var command = {
@@ -122,6 +123,7 @@ L.Control.FormulaBar = L.Control.extend({
 			this.map.sendUnoCommand('.uno:GoToCell', command);
 		} else if (e.keyCode === 27) { // 27 = esc key
 			this.map.sendUnoCommand('.uno:Cancel');
+			L.DomUtil.get('addressInput').blur();
 			this.map.focus();
 		}
 	}

--- a/browser/src/control/Control.Layers.js
+++ b/browser/src/control/Control.Layers.js
@@ -48,13 +48,10 @@ L.Control.Layers = L.Control.extend({
 		// makes this work on IE touch devices by stopping it from firing a mouseout event when the touch is released
 		container.setAttribute('aria-haspopup', true);
 
-		if (!L.Browser.touch) {
-			L.DomEvent
-				.disableClickPropagation(container)
-				.disableScrollPropagation(container);
-		} else {
-			L.DomEvent.on(container, 'click', L.DomEvent.stopPropagation);
-		}
+		L.DomEvent
+			.disableMouseClickPropagation(container)
+			.disableScrollPropagation(container);
+		L.DomEvent.on(container, 'click', window.touch.touchOnly(L.DomEvent.stopPropagation));
 
 		var form = this._form = L.DomUtil.create('form', className + '-list');
 
@@ -70,13 +67,10 @@ L.Control.Layers = L.Control.extend({
 			link.href = '#';
 			link.title = 'Layers';
 
-			if (L.Browser.touch) {
-				L.DomEvent
-				    .on(link, 'click', L.DomEvent.stop)
-				    .on(link, 'click', this._expand, this);
-			} else {
-				L.DomEvent.on(link, 'focus', this._expand, this);
-			}
+			L.DomEvent
+				.on(link, 'click', window.touch.touchOnly(L.DomEvent.stop))
+				.on(link, 'click', window.touch.touchOnly(this._expand), this);
+			L.DomEvent.on(link, 'focus', window.touch.mouseOnly(this._expand), this);
 
 			// work around for Firefox Android issue https://github.com/Leaflet/Leaflet/issues/2033
 			L.DomEvent.on(form, 'click', function () {

--- a/browser/src/control/Permission.js
+++ b/browser/src/control/Permission.js
@@ -193,9 +193,7 @@ L.Map.include({
 	_enterEditMode: function (perm) {
 		this._permission = perm;
 
-		if (!L.Browser.touch) {
-			this.dragging.disable();
-		}
+		this.dragging.disable();
 
 		if ((window.mode.isMobile() || window.mode.isTablet()) && this._textInput && this.getDocType() === 'text') {
 			this._textInput.setSwitchedToEditMode();

--- a/browser/src/control/Ruler.js
+++ b/browser/src/control/Ruler.js
@@ -89,60 +89,57 @@ L.Control.Ruler = L.Control.extend({
 
 		// Now we have indentation markers. Next we should bind drag initializers to them..
 		// We will use 3 hammers. 1 hammer is not usable for this case.
-		if (L.Browser.touch) {
-			// Hammer for first line indentation..
-			this._firstLineHammer = new Hammer(this._firstLineMarker);
-			this._firstLineHammer.add(new Hammer.Pan({ threshold: 0, pointers: 0 }));
-			this._firstLineHammer.get('press').set({
-				time: 500
-			});
-			this._firstLineHammer.on('panstart', function (event) {
-				self._initiateIndentationDrag(event);
-			});
-			this._firstLineHammer.on('panmove', function (event) {
-				self._moveIndentation(event);
-			});
-			this._firstLineHammer.on('panend', function (event) {
-				self._moveIndentationEnd(event);
-			});
+		// Hammer for first line indentation..
+		this._firstLineHammer = new Hammer(this._firstLineMarker);
+		this._firstLineHammer.add(new Hammer.Pan({ threshold: 0, pointers: 0 }));
+		this._firstLineHammer.get('press').set({
+			time: 500
+		});
+		this._firstLineHammer.on('panstart', window.touch.touchOnly(function (event) {
+			self._initiateIndentationDrag(event);
+		}));
+		this._firstLineHammer.on('panmove', window.touch.touchOnly(function (event) {
+			self._moveIndentation(event);
+		}));
+		this._firstLineHammer.on('panend', window.touch.touchOnly(function (event) {
+			self._moveIndentationEnd(event);
+		}));
 
-			// Hammer for paragraph start indentation..
-			this._pStartHammer = new Hammer(this._pStartMarker);
-			this._pStartHammer.add(new Hammer.Pan({ threshold: 0, pointers: 0 }));
-			this._pStartHammer.get('press').set({
-				time: 500
-			});
-			this._pStartHammer.on('panstart', function (event) {
-				self._initiateIndentationDrag(event);
-			});
-			this._pStartHammer.on('panmove', function (event) {
-				self._moveIndentation(event);
-			});
-			this._pStartHammer.on('panend', function (event) {
-				self._moveIndentationEnd(event);
-			});
+		// Hammer for paragraph start indentation..
+		this._pStartHammer = new Hammer(this._pStartMarker);
+		this._pStartHammer.add(new Hammer.Pan({ threshold: 0, pointers: 0 }));
+		this._pStartHammer.get('press').set({
+			time: 500
+		});
+		this._pStartHammer.on('panstart', window.touch.touchOnly(function(event) {
+			self._initiateIndentationDrag(event);
+		}));
+		this._pStartHammer.on('panmove', window.touch.touchOnly(function(event) {
+			self._moveIndentation(event);
+		}));
+		this._pStartHammer.on('panend', window.touch.touchOnly(function(event) {
+			self._moveIndentationEnd(event);
+		}));
 
-			// Hammer for paragraph end indentation..
-			this._pEndHammer = new Hammer(this._pEndMarker);
-			this._pEndHammer.add(new Hammer.Pan({ threshold: 0, pointers: 0 }));
-			this._pEndHammer.get('press').set({
-				time: 500
-			});
-			this._pEndHammer.on('panstart', function (event) {
-				self._initiateIndentationDrag(event);
-			});
-			this._pEndHammer.on('panmove', function (event) {
-				self._moveIndentation(event);
-			});
-			this._pEndHammer.on('panend', function (event) {
-				self._moveIndentationEnd(event);
-			});
-		}
-		else {
-			L.DomEvent.on(this._firstLineMarker, 'mousedown', this._initiateIndentationDrag, this);
-			L.DomEvent.on(this._pStartMarker, 'mousedown', this._initiateIndentationDrag, this);
-			L.DomEvent.on(this._pEndMarker, 'mousedown', this._initiateIndentationDrag, this);
-		}
+		// Hammer for paragraph end indentation..
+		this._pEndHammer = new Hammer(this._pEndMarker);
+		this._pEndHammer.add(new Hammer.Pan({ threshold: 0, pointers: 0 }));
+		this._pEndHammer.get('press').set({
+			time: 500
+		});
+		this._pEndHammer.on('panstart', window.touch.touchOnly(function(event) {
+			self._initiateIndentationDrag(event);
+		}));
+		this._pEndHammer.on('panmove', window.touch.touchOnly(function(event) {
+			self._moveIndentation(event);
+		}));
+		this._pEndHammer.on('panend', window.touch.touchOnly(function(event) {
+			self._moveIndentationEnd(event);
+		}));
+
+		L.DomEvent.on(this._firstLineMarker, 'mousedown', this._initiateIndentationDrag, this);
+		L.DomEvent.on(this._pStartMarker, 'mousedown', this._initiateIndentationDrag, this);
+		L.DomEvent.on(this._pEndMarker, 'mousedown', this._initiateIndentationDrag, this);
 	},
 
 	_initLayout: function() {
@@ -167,25 +164,23 @@ L.Control.Ruler = L.Control.extend({
 
 		var self = this;
 
-		if (L.Browser.touch) {
-			this._hammer = new Hammer(this._rTSContainer);
-			this._hammer.add(new Hammer.Pan({ threshold: 0, pointers: 0 }));
-			this._hammer.get('press').set({
-				time: 500
-			});
-			this._hammer.on('panstart', function (event) {
-				self._initiateTabstopDrag(event);
-			});
-			this._hammer.on('panmove', function (event) {
-				self._moveTabstop(event);
-			});
-			this._hammer.on('panend', function (event) {
-				self._endTabstopDrag(event);
-			});
-			this._hammer.on('press', function (event) {
-				self._onTabstopContainerLongPress(event);
-			});
-		}
+		this._hammer = new Hammer(this._rTSContainer);
+		this._hammer.add(new Hammer.Pan({ threshold: 0, pointers: 0 }));
+		this._hammer.get('press').set({
+			time: 500
+		});
+		this._hammer.on('panstart', window.touch.touchOnly(function (event) {
+			self._initiateTabstopDrag(event);
+		}));
+		this._hammer.on('panmove', window.touch.touchOnly(function (event) {
+			self._moveTabstop(event);
+		}));
+		this._hammer.on('panend', window.touch.touchOnly(function (event) {
+			self._endTabstopDrag(event);
+		}));
+		this._hammer.on('press', window.touch.touchOnly(function (event) {
+			self._onTabstopContainerLongPress(event);
+		}));
 
 		this._initiateIndentationMarkers();
 
@@ -439,7 +434,7 @@ L.Control.Ruler = L.Control.extend({
 	_moveIndentationEnd: function(e) {
 		this._map.rulerActive = false;
 
-		if (e.type !== 'panend') { // The screen may support touch and click at the same time, so we do not use L.Browser.touch while checking the event type in order to support both.
+		if (e.type !== 'panend') {
 			L.DomEvent.off(this._rFace, 'mousemove', this._moveIndentation, this);
 			L.DomEvent.off(this._map, 'mouseup', this._moveIndentationEnd, this);
 		}

--- a/browser/src/dom/DomEvent.js
+++ b/browser/src/dom/DomEvent.js
@@ -56,8 +56,8 @@ L.DomEvent = {
 		if (L.Browser.pointer && type.indexOf('touch') === 0) {
 			this.addPointerListener(obj, type, handler, id);
 
-		} else if (L.Browser.touch && (type === 'dblclick') && this.addDoubleTapListener) {
-			this.addDoubleTapListener(obj, handler, id);
+		} else if ((type === 'dblclick') && this.addDoubleTapListener) {
+			this.addDoubleTapListener(obj, window.touch.touchOnly(handler), id);
 
 		} else if (type === 'trplclick' || type === 'qdrplclick') {
 			this.addMultiClickListener(obj, handler, id, type);
@@ -106,7 +106,7 @@ L.DomEvent = {
 		if (L.Browser.pointer && type.indexOf('touch') === 0) {
 			this.removePointerListener(obj, type, id);
 
-		} else if (L.Browser.touch && (type === 'dblclick') && this.removeDoubleTapListener) {
+		} else if ((type === 'dblclick') && this.removeDoubleTapListener) {
 			this.removeDoubleTapListener(obj, id);
 
 		} else if (type === 'trplclick' || type === 'qdrplclick') {
@@ -143,6 +143,17 @@ L.DomEvent = {
 		L.DomEvent._skipped(e);
 
 		return this;
+	},
+
+	disableMouseClickPropagation: function (el) {
+		var stop = window.touch.mouseOnly(L.DomEvent.stopPropagation);
+
+		L.DomEvent.on(el, L.Draggable.START.join(' '), stop);
+
+		return L.DomEvent.on(el, {
+			click: window.touch.mouseOnly(L.DomEvent._fakeStop),
+			dblclick: stop
+		});
 	},
 
 	disableScrollPropagation: function (el) {

--- a/browser/src/dom/Draggable.js
+++ b/browser/src/dom/Draggable.js
@@ -6,7 +6,7 @@
 L.Draggable = L.Evented.extend({
 
 	statics: {
-		START: L.Browser.touch ? ['touchstart', 'mousedown'] : ['mousedown'],
+		START: ['touchstart', 'mousedown'],
 		END: {
 			mousedown: 'mouseup',
 			touchstart: 'touchend',
@@ -89,11 +89,9 @@ L.Draggable = L.Evented.extend({
 		// for scrolling during cursor dragging.
 		this.startOffset = this._startPoint.subtract(new L.Point(startBoundingRect.left, startBoundingRect.top));
 
-		if (!this._manualDrag) {
-			L.DomEvent
-				.on(document, L.Draggable.MOVE[e.type], this._onMove, this)
-				.on(document, L.Draggable.END[e.type], this._onUp, this);
-		}
+		L.DomEvent
+			.on(document, L.Draggable.MOVE[e.type], window.touch.mouseOnly(this._onMove), this)
+			.on(document, L.Draggable.END[e.type], window.touch.mouseOnly(this._onUp), this);
 	},
 
 	_onMove: function (e) {
@@ -132,7 +130,7 @@ L.Draggable = L.Evented.extend({
 			}
 		}
 		if (!offset.x && !offset.y) { return; }
-		if (L.Browser.touch && Math.abs(offset.x) + Math.abs(offset.y) < 3 && !e.autoscroll) { return; }
+		if (window.touch.isTouchEvent(e) && Math.abs(offset.x) + Math.abs(offset.y) < 3 && !e.autoscroll) { return; }
 
 		L.DomEvent.preventDefault(e);
 

--- a/browser/src/layer/marker/TextInput.js
+++ b/browser/src/layer/marker/TextInput.js
@@ -500,7 +500,8 @@ L.TextInput = L.Layer.extend({
 		this._map._docLayer._cursorMarker.setMouseCursorForTextBox();
 
 		// Move and display under-caret marker
-		if (L.Browser.touch) {
+
+		if (window.touch.hasAnyTouchscreen()) {
 			if (this._map._docLayer._textCSelections.empty()) {
 				this._cursorHandler.setLatLng(bottom).addTo(this._map);
 			} else {

--- a/browser/src/layer/vector/CPath.ts
+++ b/browser/src/layer/vector/CPath.ts
@@ -31,7 +31,6 @@ abstract class CPath extends CEventsHandler {
 	zIndex: number = 0;
 
 	static countObjects: number = 0;
-	static isTouchDevice: boolean = false; // Need to set this from current L.Browser.touch
 	private id: number;
 	private isDeleted: boolean = false;
 	private testDiv: HTMLDivElement;
@@ -238,7 +237,7 @@ abstract class CPath extends CEventsHandler {
 
 	clickTolerance(): number {
 		// used when doing hit detection for Canvas layers
-		return (this.stroke ? this.weight / 2 : 0) + (CPath.isTouchDevice ? 10 : 0);
+		return (this.stroke ? this.weight / 2 : 0) + ((window as typeof window & { touch: any; }).touch.hasAnyTouchscreen() ? 10 : 0);
 	}
 
 	setCursorType(cursorType: string) {

--- a/browser/src/layer/vector/Path.Drag.js
+++ b/browser/src/layer/vector/Path.Drag.js
@@ -86,10 +86,8 @@ L.Handler.PathDrag = L.Handler.extend(/** @lends  L.Path.Drag.prototype */ {
 
 		this._path.removeClass(L.Handler.PathDrag.DRAGGING_CLS);
 
-		if (!this._path.options.manualDrag) {
-			L.DomEvent.off(document, 'mousemove touchmove', this._onDrag,    this);
-			L.DomEvent.off(document, 'mouseup touchend',    this._onDragEnd, this);
-		}
+		L.DomEvent.off(document, 'mousemove touchmove', this._onDrag,    this);
+		L.DomEvent.off(document, 'mouseup touchend',    this._onDragEnd, this);
 	},
 
 	/**
@@ -118,11 +116,9 @@ L.Handler.PathDrag = L.Handler.extend(/** @lends  L.Path.Drag.prototype */ {
 
 		this._path._renderer.addContainerClass('leaflet-interactive');
 
-		if (!this._path.options.manualDrag) {
-			L.DomEvent
-				.on(document, MOVE[eventType], this._onDrag,    this)
-				.on(document, END[eventType],  this._onDragEnd, this);
-		}
+		L.DomEvent
+			.on(document, MOVE[eventType], this._onDrag,    this)
+			.on(document, END[eventType],  this._onDragEnd, this);
 
 		if (this._path._map.dragging.enabled()) {
 			// I guess it's required because mousedown gets simulated with a delay
@@ -234,10 +230,8 @@ L.Handler.PathDrag = L.Handler.extend(/** @lends  L.Path.Drag.prototype */ {
 			this._path._transform(null);
 		}
 
-		if (!this._path.options.manualDrag) {
-			L.DomEvent.off(document, 'mousemove touchmove', this._onDrag,    this);
-			L.DomEvent.off(document, 'mouseup touchend',    this._onDragEnd, this);
-		}
+		L.DomEvent.off(document, 'mousemove touchmove', this._onDrag,    this);
+		L.DomEvent.off(document, 'mouseup touchend',    this._onDragEnd, this);
 
 		this._restoreCoordGetters();
 
@@ -266,7 +260,7 @@ L.Handler.PathDrag = L.Handler.extend(/** @lends  L.Path.Drag.prototype */ {
 			this._path._map.dragging.enable();
 		}
 
-		if (!this._path.options.manualDrag && !moved && this._mouseDown) {
+		if (!moved && this._mouseDown && !window.touch.isTouchEvent(this._mouseDown)) {
 			this._path._map._handleDOMEvent(this._mouseDown);
 			this._path._map._handleDOMEvent(evt);
 		}

--- a/browser/src/layer/vector/Path.Transform.js
+++ b/browser/src/layer/vector/Path.Transform.js
@@ -112,7 +112,7 @@ L.Handler.PathTransform = L.Handler.extend({
 		shapeType: 0,
 		// edge handlers
 		handlerOptions: {
-			radius:      L.Browser.touch && !L.Browser.pointer ? 10 : 5,
+			radius:      window.touch.hasAnyTouchscreen() ? 10 : 5,
 			fillColor:   '#ffffff',
 			color:       '#202020',
 			fillOpacity: 1,
@@ -122,7 +122,7 @@ L.Handler.PathTransform = L.Handler.extend({
 		},
 
 		gluePointOptions: {
-			radius:      L.Browser.touch && !L.Browser.pointer ? 10 : 5,
+			radius:      window.touch.hasAnyTouchscreen() ? 10 : 5,
 			fillColor:   '#EE3E3E',
 			color:       '#202020',
 			fillOpacity: 1,
@@ -156,7 +156,7 @@ L.Handler.PathTransform = L.Handler.extend({
 			interactive: false
 		},
 		// rotation handle length
-		handleLength: L.Browser.touch && !L.Browser.pointer ? 40 : 20,
+		handleLength: window.touch.hasAnyTouchscreen() ? 40 : 20,
 
 		// maybe I'll add skewing in the future
 		edgesCount:   4,

--- a/browser/src/layer/vector/Path.js
+++ b/browser/src/layer/vector/Path.js
@@ -81,7 +81,7 @@ L.Path = L.Layer.extend({
 
 	_clickTolerance: function () {
 		// used when doing hit detection for Canvas layers
-		return (this.options.stroke ? this.options.weight / 2 : 0) + (L.Browser.touch ? 10 : 0);
+		return (this.options.stroke ? this.options.weight / 2 : 0) + (window.touch.hasAnyTouchscreen() ? 10 : 0);
 	},
 
 	addPathNode: function (pathNode, actualRenderer) {

--- a/browser/src/layer/vector/SVGGroup.js
+++ b/browser/src/layer/vector/SVGGroup.js
@@ -9,7 +9,6 @@ L.SVGGroup = L.Layer.extend({
 
 	options: {
 		noClip: true,
-		manualDrag: false
 	},
 
 	initialize: function (bounds, options) {
@@ -18,9 +17,6 @@ L.SVGGroup = L.Layer.extend({
 		this._bounds = bounds;
 		this._rect = L.rectangle(bounds, this.options);
 		this._hasSVGNode = false;
-		if (L.Browser.touch && !L.Browser.pointer) {
-			this.options.manualDrag = true;
-		}
 
 		this.on('dragstart scalestart rotatestart', this._showEmbeddedSVG, this);
 		this.on('dragend scaleend rotateend', this._hideEmbeddedSVG, this);
@@ -174,14 +170,12 @@ L.SVGGroup = L.Layer.extend({
 		this._dragStarted = true;
 		this._moved = false;
 
-		if (!this.options.manualDrag) {
-			this._forEachDragShape(function (dragShape) {
-				L.DomEvent.on(dragShape, 'mousemove', this._onDrag, this);
-				L.DomEvent.on(dragShape, 'mouseup', this._onDragEnd, this);
-				if (this.dragging.constraint)
-					L.DomEvent.on(dragShape, 'mouseout', this._onDragEnd, this);
-			}.bind(this));
-		}
+		this._forEachDragShape(function (dragShape) {
+			L.DomEvent.on(dragShape, 'mousemove', this._onDrag, this);
+			L.DomEvent.on(dragShape, 'mouseup', this._onDragEnd, this);
+			if (this.dragging.constraint)
+				L.DomEvent.on(dragShape, 'mouseout', this._onDragEnd, this);
+		}.bind(this));
 
 		var data = {
 			originalEvent: evt,
@@ -212,14 +206,12 @@ L.SVGGroup = L.Layer.extend({
 		if (!this._map || !this._dragShapePresent || !this.dragging)
 			return;
 
-		if (!this.options.manualDrag) {
-			this._forEachDragShape(function (dragShape) {
-				L.DomEvent.off(dragShape, 'mousemove', this._onDrag, this);
-				L.DomEvent.off(dragShape, 'mouseup', this._onDragEnd, this);
-				if (this.dragging.constraint)
-					L.DomEvent.off(dragShape, 'mouseout', this._onDragEnd, this);
-			}.bind(this));
-		}
+		this._forEachDragShape(function (dragShape) {
+			L.DomEvent.off(dragShape, 'mousemove', this._onDrag, this);
+			L.DomEvent.off(dragShape, 'mouseup', this._onDragEnd, this);
+			if (this.dragging.constraint)
+				L.DomEvent.off(dragShape, 'mouseout', this._onDragEnd, this);
+		}.bind(this));
 
 		this._moved = false;
 		this._hideEmbeddedSVG();
@@ -232,7 +224,7 @@ L.SVGGroup = L.Layer.extend({
 			this.fire('graphicmoveend', {pos: pos});
 		}
 
-		if (this.options.manualDrag || evt.type === 'mouseup')
+		if (window.touch.isTouchEvent(evt) || evt.type === 'mouseup')
 			this.dragging._onDragEnd(evt);
 		this._dragStarted = false;
 	},
@@ -292,9 +284,7 @@ L.SVGGroup = L.Layer.extend({
 			nodeData.setCustomField('dragShape', rectNode);
 			this._dragShapePresent = true;
 
-			if (!this.options.manualDrag) {
-				L.DomEvent.on(rectNode, 'mousedown', this._onDragStart, this);
-			}
+			L.DomEvent.on(rectNode, 'mousedown', this._onDragStart, this);
 		}.bind(this));
 
 		this.sizeSVG();

--- a/browser/src/map/Map.js
+++ b/browser/src/map/Map.js
@@ -137,16 +137,12 @@ L.Map = L.Evented.extend({
 
 		this.addHandler('keyboard', L.Map.Keyboard);
 		this.addHandler('dragging', L.Map.Drag);
-		if ((L.Browser.touch && !L.Browser.pointer) || (L.Browser.cypressTest && (window.mode.isMobile() || window.mode.isTablet()))) {
-			this.dragging.disable();
-			this.dragging._draggable._manualDrag = true;
-			this._mainEvents('off');
-			this.addHandler('touchGesture', L.Map.TouchGesture);
-		} else {
-			this.addHandler('mouse', L.Map.Mouse);
-			this.addHandler('scrollHandler', L.Map.Scroll);
-			this.addHandler('doubleClickZoom', L.Map.DoubleClickZoom);
-		}
+
+		this.addHandler('touchGesture', L.Map.TouchGesture);
+
+		this.addHandler('mouse', L.Map.Mouse);
+		this.addHandler('scrollHandler', L.Map.Scroll);
+		this.addHandler('doubleClickZoom', L.Map.DoubleClickZoom);
 
 		if (this.options.imagePath) {
 			L.Icon.Default.imagePath = this.options.imagePath;
@@ -1225,8 +1221,7 @@ L.Map = L.Evented.extend({
 
 		this._fadeAnimated = this.options.fadeAnimation && L.Browser.any3d;
 
-		L.DomUtil.addClass(container, 'leaflet-container' +
-			(L.Browser.touch ? ' leaflet-touch' : '') +
+		L.DomUtil.addClass(container, 'leaflet-container leaflet-touch' +
 			(L.Browser.retina ? ' leaflet-retina' : '') +
 			(L.Browser.ielt9 ? ' leaflet-oldie' : '') +
 			(L.Browser.safari ? ' leaflet-safari' : '') +
@@ -1324,7 +1319,7 @@ L.Map = L.Evented.extend({
 	_mainEvents: function (onOff) {
 		L.DomEvent[onOff](this._container, 'click dblclick mousedown mouseup ' +
 			'mouseover mouseout mousemove dragover drop ' +
-			'trplclick qdrplclick', this._handleDOMEvent, this);
+			'trplclick qdrplclick', window.touch.mouseOnly(this._handleDOMEvent), this);
 	},
 
 	_initEvents: function (remove) {

--- a/browser/src/map/handler/Map.DoubleClickZoom.js
+++ b/browser/src/map/handler/Map.DoubleClickZoom.js
@@ -9,11 +9,11 @@ L.Map.mergeOptions({
 
 L.Map.DoubleClickZoom = L.Handler.extend({
 	addHooks: function () {
-		this._map.on('dblclick', this._onDoubleClick, this);
+		this._map.on('dblclick', window.touch.mouseOnly(this._onDoubleClick), this);
 	},
 
 	removeHooks: function () {
-		this._map.off('dblclick', this._onDoubleClick, this);
+		this._map.off('dblclick', window.touch.mouseOnly(this._onDoubleClick), this);
 	},
 
 	_onDoubleClick: function (e) {

--- a/browser/src/map/handler/Map.Scroll.js
+++ b/browser/src/map/handler/Map.Scroll.js
@@ -47,12 +47,12 @@ L.Map.Scroll = L.Handler.extend({
 		}
 	},
 
-	_onTouchScrollStart: function (e) {
+	_onTouchScrollStart: this.touch.mouseOnly(function (e) {
 		this.lastX = e.touches[0].clientX;
 		this.lastY = e.touches[0].clientY;
-	},
+	}),
 
-	_onTouchScroll: function (e) {
+	_onTouchScroll: this.touch.mouseOnly(function (e) {
 		var top = e.touches[0].clientY;
 		var start = e.touches[0].clientX;
 		var deltaX = (start - this.lastX);
@@ -73,9 +73,9 @@ L.Map.Scroll = L.Handler.extend({
 			this._vertical = 1;
 		}
 		this._timer = setTimeout(L.bind(this._performScroll, this), left);
-	},
+	}),
 
-	_onWheelScroll: function (e) {
+	_onWheelScroll: this.touch.mouseOnly(function (e) {
 		var delta =  -1 * e.deltaY; // L.DomEvent.getWheelDelta(e);
 		var debounce = this._map.options.wheelDebounceTime;
 
@@ -116,7 +116,7 @@ L.Map.Scroll = L.Handler.extend({
 		}
 
 		L.DomEvent.stop(e);
-	},
+	}),
 
 	_performScroll: function () {
 		var map = this._map,

--- a/browser/src/map/handler/Map.TouchGesture.js
+++ b/browser/src/map/handler/Map.TouchGesture.js
@@ -54,28 +54,26 @@ L.Map.TouchGesture = L.Handler.extend({
 			this._hammer.add(tripleTap);
 			tripleTap.recognizeWith([doubleTap, singleTap]);
 			var hammer = this._hammer;
-			if (L.Browser.touch) {
-				L.DomEvent.on(this._map._mapPane, 'touchstart touchmove touchcancel', L.DomEvent.preventDefault);
-				L.DomEvent.on(this._map._mapPane, 'touchend', function(e) {
-					// sometimes inputs get stuck in hammer and further events get mixed with the old ones
-					// this causes to a failure to use all the gestures properly.
-					// This is a workaround until it is fixed by hammer.js
-					if (hammer.input) {
-						if (hammer.input.store)  {
-							hammer.input.store = [];
-						}
+			L.DomEvent.on(this._map._mapPane, 'touchstart touchmove touchcancel', window.touch.touchOnly(L.DomEvent.preventDefault));
+			L.DomEvent.on(this._map._mapPane, 'touchend', window.touch.touchOnly(function(e) {
+				// sometimes inputs get stuck in hammer and further events get mixed with the old ones
+				// this causes to a failure to use all the gestures properly.
+				// This is a workaround until it is fixed by hammer.js
+				if (hammer.input) {
+					if (hammer.input.store)  {
+						hammer.input.store = [];
 					}
-					L.DomEvent.preventDefault(e);
-				});
-			}
+				}
+				L.DomEvent.preventDefault(e);
+			}));
 
 			if (Hammer.prefixed(window, 'PointerEvent') !== undefined) {
-				L.DomEvent.on(this._map._mapPane, 'pointerdown pointermove pointerup pointercancel', L.DomEvent.preventDefault);
+				L.DomEvent.on(this._map._mapPane, 'pointerdown pointermove pointerup pointercancel', window.touch.touchOnly(L.DomEvent.preventDefault));
 			}
 
 			// IE10 has prefixed support, and case-sensitive
 			if (window.MSPointerEvent && !window.PointerEvent) {
-				L.DomEvent.on(this._map._mapPane, 'MSPointerDown MSPointerMove MSPointerUp MSPointerCancel', L.DomEvent.preventDefault);
+				L.DomEvent.on(this._map._mapPane, 'MSPointerDown MSPointerMove MSPointerUp MSPointerCancel', window.touch.touchOnly(L.DomEvent.preventDefault));
 			}
 
 			L.DomEvent.on(this._map._mapPane, 'mousedown mousemove mouseup', L.DomEvent.preventDefault);
@@ -101,43 +99,43 @@ L.Map.TouchGesture = L.Handler.extend({
 	},
 
 	addHooks: function () {
-		this._hammer.on('hammer.input', L.bind(this._onHammer, this));
-		this._hammer.on('tap', L.bind(this._onTap, this));
-		this._hammer.on('panstart', L.bind(this._onPanStart, this));
-		this._hammer.on('pan', L.bind(this._onPan, this));
-		this._hammer.on('panend', L.bind(this._onPanEnd, this));
-		this._hammer.on('pinchstart', L.bind(this._onPinchStart, this));
-		this._hammer.on('pinchmove', L.bind(this._onPinch, this));
-		this._hammer.on('pinchend', L.bind(this._onPinchEnd, this));
-		this._hammer.on('tripletap', L.bind(this._onTripleTap, this));
-		this._hammer.on('swipe', L.bind(this._onSwipe, this));
+		this._hammer.on('hammer.input', L.bind(window.touch.touchOnly(this._onHammer), this));
+		this._hammer.on('tap', L.bind(window.touch.touchOnly(this._onTap), this));
+		this._hammer.on('panstart', L.bind(window.touch.touchOnly(this._onPanStart), this));
+		this._hammer.on('pan', L.bind(window.touch.touchOnly(this._onPan), this));
+		this._hammer.on('panend', L.bind(window.touch.touchOnly(this._onPanEnd), this));
+		this._hammer.on('pinchstart', L.bind(window.touch.touchOnly(this._onPinchStart), this));
+		this._hammer.on('pinchmove', L.bind(window.touch.touchOnly(this._onPinch), this));
+		this._hammer.on('pinchend', L.bind(window.touch.touchOnly(this._onPinchEnd), this));
+		this._hammer.on('tripletap', L.bind(window.touch.touchOnly(this._onTripleTap), this));
+		this._hammer.on('swipe', L.bind(window.touch.touchOnly(this._onSwipe), this));
 		this._map.on('updatepermission', this._onPermission, this);
 		this._onPermission({perm: this._map._permission});
 	},
 
 	removeHooks: function () {
-		this._hammer.off('hammer.input', L.bind(this._onHammer, this));
-		this._hammer.off('tap', L.bind(this._onTap, this));
-		this._hammer.off('panstart', L.bind(this._onPanStart, this));
-		this._hammer.off('pan', L.bind(this._onPan, this));
-		this._hammer.off('panend', L.bind(this._onPanEnd, this));
-		this._hammer.off('pinchstart', L.bind(this._onPinchStart, this));
-		this._hammer.off('pinchmove', L.bind(this._onPinch, this));
-		this._hammer.off('pinchend', L.bind(this._onPinchEnd, this));
-		this._hammer.off('doubletap', L.bind(this._onDoubleTap, this));
-		this._hammer.off('press', L.bind(this._onPress, this));
-		this._hammer.off('tripletap', L.bind(this._onTripleTap, this));
-		this._hammer.off('swipe', L.bind(this._onSwipe, this));
+		this._hammer.off('hammer.input', L.bind(window.touch.touchOnly(this._onHammer), this));
+		this._hammer.off('tap', L.bind(window.touch.touchOnly(this._onTap), this));
+		this._hammer.off('panstart', L.bind(window.touch.touchOnly(this._onPanStart), this));
+		this._hammer.off('pan', L.bind(window.touch.touchOnly(this._onPan), this));
+		this._hammer.off('panend', L.bind(window.touch.touchOnly(this._onPanEnd), this));
+		this._hammer.off('pinchstart', L.bind(window.touch.touchOnly(this._onPinchStart), this));
+		this._hammer.off('pinchmove', L.bind(window.touch.touchOnly(this._onPinch), this));
+		this._hammer.off('pinchend', L.bind(window.touch.touchOnly(this._onPinchEnd), this));
+		this._hammer.off('doubletap', L.bind(window.touch.touchOnly(this._onDoubleTap), this));
+		this._hammer.off('press', L.bind(window.touch.touchOnly(this._onPress), this));
+		this._hammer.off('tripletap', L.bind(window.touch.touchOnly(this._onTripleTap), this));
+		this._hammer.off('swipe', L.bind(window.touch.touchOnly(this._onSwipe), this));
 		this._map.off('updatepermission', this._onPermission, this);
 	},
 
 	_onPermission: function (e) {
 		if (e.perm == 'edit') {
-			this._hammer.on('doubletap', L.bind(this._onDoubleTap, this));
-			this._hammer.on('press', L.bind(this._onPress, this));
+			this._hammer.on('doubletap', L.bind(window.touch.touchOnly(this._onDoubleTap), this));
+			this._hammer.on('press', L.bind(window.touch.touchOnly(this._onPress), this));
 		} else {
-			this._hammer.off('doubletap', L.bind(this._onDoubleTap, this));
-			this._hammer.off('press', L.bind(this._onPress, this));
+			this._hammer.off('doubletap', L.bind(window.touch.touchOnly(this._onDoubleTap), this));
+			this._hammer.off('press', L.bind(window.touch.touchOnly(this._onPress), this));
 		}
 	},
 

--- a/cypress_test/integration_tests/common/mobile_helper.js
+++ b/cypress_test/integration_tests/common/mobile_helper.js
@@ -48,7 +48,7 @@ function longPressOnDocument(posX, posY) {
 			var eventOptions = {
 				force: true,
 				button: 0,
-				pointerType: 'mouse',
+				pointerType: 'touch',
 				x: posX - items[0].getBoundingClientRect().left,
 				y: posY - items[0].getBoundingClientRect().top
 			};
@@ -348,7 +348,7 @@ function deleteImage() {
 	var eventOptions = {
 		force: true,
 		button: 0,
-		pointerType: 'mouse'
+		pointerType: 'touch'
 	};
 
 	cy.cGet('.leaflet-control-buttons-disabled > .leaflet-interactive')

--- a/cypress_test/integration_tests/mobile/calc/delete_objects_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/delete_objects_spec.js
@@ -11,7 +11,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Delete Objects',function() 
 	var eventOptions = {
 		force: true,
 		button: 0,
-		pointerType: 'mouse'
+		pointerType: 'touch'
 	};
 
 	beforeEach(function() {

--- a/cypress_test/integration_tests/mobile/calc/image_operation_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/image_operation_spec.js
@@ -28,7 +28,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Image Operation Tests', fun
 		var eventOptions = {
 			force: true,
 			button: 0,
-			pointerType: 'mouse'
+			pointerType: 'touch'
 		};
 
 		cy.cGet('.bottomright-svg-pane > .leaflet-control-buttons-disabled > .leaflet-interactive')

--- a/cypress_test/integration_tests/mobile/calc/sheet_operation_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/sheet_operation_spec.js
@@ -25,7 +25,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Sheet Operation', function 
 		var eventOptions = {
 			force: true,
 			button: 0,
-			pointerType: 'mouse'
+			pointerType: 'touch'
 		};
 
 		cy.cGet('.spreadsheet-tab.spreadsheet-tab-selected')

--- a/cypress_test/integration_tests/mobile/impress/delete_objects_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/delete_objects_spec.js
@@ -10,7 +10,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Delete Objects', function()
 	var eventOptions = {
 		force: true,
 		button: 0,
-		pointerType: 'mouse'
+		pointerType: 'touch'
 	};
 
 	beforeEach(function() {

--- a/cypress_test/integration_tests/mobile/writer/delete_objects_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/delete_objects_spec.js
@@ -10,7 +10,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Delete Objects', function()
 	var eventOptions = {
 		force: true,
 		button: 0,
-		pointerType: 'mouse'
+		pointerType: 'touch'
 	};
 
 	beforeEach(function() {


### PR DESCRIPTION
L.Browser.touch is sometimes nice, but it's ultimately a flawed concept to use it for input events. Using L.Browser.touch for input handicaps people with mice if it's too liberal in what it classes as touchscreens, and handicaps people with touchscreens if it's too conservative. There's also no sweet spot: it's impossible to choose correctly if someone is using both a touchscreen and a pointer device, as there's no right option!

Previously many of our event handlers and some of our UI was gated behind L.Browser.touch. This commit adds a new "window.touch" property which is used instead. It has functions to help with event detection, allowing you to easily make event handlers that work for only the input devices they are designed for, without gating them behind feature detection. This has the added bonus that - as you register all the events - switching between a touchscreen and pointer is now not only possible but already implemented!

For cases which don't have reasonable events to tag onto (e.g. the teardrop for cursor movement) this commit adds "hasPrimaryTouchscreen" and "hasAnyTouchscreen" which use the CSS media queries to detect if there's a touchscreen attached to your device (either as the primary input mechanism or at all). This works a lot more similarly to L.Browser.mode, but being dynamically updated allows you to effectively swich between touchscreen and not at-will. This still has all of the disadvantages that L.Browser.touch did when used to register event handlers, so my advice would be to avoid using it with events.


Change-Id: I9016fc15ad3ccb3664af348fdcdca006495b0778


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

