### PR TITLE
wopi: Added DisableInsertLocalImage

### DIFF
--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -2118,6 +2118,9 @@ L.Control.Menubar = L.Control.extend({
 		if (menuItem.id === 'insertgraphicremote' && !this._map['wopi'].EnableInsertRemoteImage)
 			return false;
 
+		if (menuItem.id === 'insertgraphic' && this._map['wopi'].DisableInsertLocalImage)
+			return false;
+
 		if (menuItem.id && menuItem.id.startsWith('fullscreen-presentation') && this._map['wopi'].HideExportOption)
 			return false;
 

--- a/browser/src/control/Control.NotebookbarBuilder.js
+++ b/browser/src/control/Control.NotebookbarBuilder.js
@@ -884,12 +884,16 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 	},
 
 	_insertGraphicControl: function(parentContainer, data, builder) {
-		var options = {hasDropdownArrow: builder.map['wopi'].EnableInsertRemoteImage};
+		var options = {
+			hasDropdownArrow: builder.map['wopi'].EnableInsertRemoteImage && !builder.map['wopi'].DisableInsertLocalImage
+		};
 		var control = builder._unoToolButton(parentContainer, data, builder, options);
 
 		$(control.container).unbind('click.toolbutton');
 		$(control.container).click(function () {
-			if (builder.map['wopi'].EnableInsertRemoteImage) {
+			var hasRemote = builder.map['wopi'].EnableInsertRemoteImage;
+			var hasLocal = !builder.map['wopi'].DisableInsertLocalImage;
+			if (hasRemote && hasLocal) {
 				var menu = [
 					{id: 'localgraphic', text: _('Insert Local Image')},
 					{id: 'remotegraphic', text: _UNO('.uno:InsertGraphic', '', true)}
@@ -909,8 +913,10 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 					onSelect: itemCallback
 				});
 				builder._makeW2MenuFocusable(builder, 'w2ui-overlay-insert-graphic-menu', menu, data.id, itemCallback);
-			} else {
+			} else if (hasLocal) {
 				L.DomUtil.get('insertgraphic').click();
+			} else if (hasRemote) {
+				builder.map.fire('postMessage', {msgId: 'UI_InsertGraphic'});
 			}
 		});
 		builder._preventDocumentLosingFocusOnClick(control.container);

--- a/browser/src/control/Control.Toolbar.js
+++ b/browser/src/control/Control.Toolbar.js
@@ -126,7 +126,7 @@ function onClick(e, id, item) {
 	else if (id === 'insertgraphic' || item.id === 'localgraphic') {
 		L.DomUtil.get('insertgraphic').click();
 	}
-	else if (item.id === 'remotegraphic') {
+	else if (item.id === 'remotegraphic' || item.id === 'insertremotegraphic') {
 		map.fire('postMessage', {msgId: 'UI_InsertGraphic'});
 	}
 	else if (id === 'fontcolor' && typeof e.color === 'undefined') {

--- a/browser/src/control/Control.TopToolbar.js
+++ b/browser/src/control/Control.TopToolbar.js
@@ -227,6 +227,7 @@ L.Control.TopToolbar = L.Control.extend({
 			{type: 'break',   id: 'break-number', hidden: true},
 			{type: 'drop',  id: 'inserttable',  img: 'inserttable', hint: _('Insert table'), hidden: true, overlay: {onShow: window.insertTable}, html: window.getInsertTablePopupHtml(), lockUno: '.uno:InsertTable'},
 			{type: 'button',  id: 'insertgraphic',  img: 'insertgraphic', hint: _UNO('.uno:InsertGraphic', '', true), lockUno: '.uno:InsertGraphic'},
+			{type: 'button',  id: 'insertremotegraphic',  img: 'insertgraphic', hint: _UNO('.uno:InsertGraphic', '', true),  hidden: true, lockUno: '.uno:InsertGraphic'},
 			{type: 'menu', id: 'menugraphic', img: 'insertgraphic', hint: _UNO('.uno:InsertGraphic', '', true), hidden: true, lockUno: '.uno:InsertGraphic',
 				items: [
 					{id: 'localgraphic', text: _('Insert Local Image')},
@@ -434,9 +435,24 @@ L.Control.TopToolbar = L.Control.extend({
 			w2ui['editbar'].hide('savebreak');
 		}
 
-		if (e.EnableInsertRemoteImage === true && w2ui['editbar']) {
-			w2ui['editbar'].hide('insertgraphic');
-			w2ui['editbar'].show('menugraphic');
+		if (w2ui['editbar']) {
+			if (e.EnableInsertRemoteImage && !e.DisableInsertLocalImage) {
+				w2ui['editbar'].hide('insertgraphic');
+				w2ui['editbar'].hide('insertremotegraphic');
+				w2ui['editbar'].show('menugraphic');
+			} else {
+				w2ui['editbar'].hide('menugraphic');
+				if (e.EnableInsertRemoteImage) {
+					w2ui['editbar'].show('insertremotegraphic');
+				} else {
+					w2ui['editbar'].hide('insertremotegraphic');
+				}
+				if (e.DisableInsertLocalImage) {
+					w2ui['editbar'].hide('insertgraphic');
+				} else {
+					w2ui['editbar'].show('insertgraphic');
+				}
+			}
 		}
 	},
 

--- a/browser/src/map/handler/Map.WOPI.js
+++ b/browser/src/map/handler/Map.WOPI.js
@@ -24,6 +24,7 @@ L.Map.WOPI = L.Handler.extend({
 	DownloadAsPostMessage: false,
 	UserCanNotWriteRelative: true,
 	EnableInsertRemoteImage: false,
+	DisableInsertLocalImage: false,
 	EnableInsertRemoteLink: false,
 	EnableShare: false,
 	HideUserList: null,
@@ -119,6 +120,7 @@ L.Map.WOPI = L.Handler.extend({
 			overridenFileInfo.DownloadAsPostMessage : !!wopiInfo['DownloadAsPostMessage'];
 		this.UserCanNotWriteRelative = !!wopiInfo['UserCanNotWriteRelative'];
 		this.EnableInsertRemoteImage = !!wopiInfo['EnableInsertRemoteImage'];
+		this.DisableInsertLocalImage = !!wopiInfo['DisableInsertLocalImage'];
 		this.EnableRemoteLinkPicker = !!wopiInfo['EnableRemoteLinkPicker'];
 		this.SupportsRename = !!wopiInfo['SupportsRename'];
 		this.UserCanRename = !!wopiInfo['UserCanRename'];

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -928,6 +928,7 @@ bool DocumentBroker::download(const std::shared_ptr<ClientSession>& session, con
         wopiInfo->set("DownloadAsPostMessage", wopiFileInfo->getDownloadAsPostMessage());
         wopiInfo->set("UserCanNotWriteRelative", wopiFileInfo->getUserCanNotWriteRelative());
         wopiInfo->set("EnableInsertRemoteImage", wopiFileInfo->getEnableInsertRemoteImage());
+        wopiInfo->set("DisableInsertLocalImage", wopiFileInfo->getDisableInsertLocalImage());
         wopiInfo->set("EnableRemoteLinkPicker", wopiFileInfo->getEnableRemoteLinkPicker());
         wopiInfo->set("EnableShare", wopiFileInfo->getEnableShare());
         wopiInfo->set("HideUserList", wopiFileInfo->getHideUserList());

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -855,6 +855,7 @@ WopiStorage::WOPIFileInfo::WOPIFileInfo(const FileInfo& fileInfo,
     JsonUtil::findJSONValue(object, "DownloadAsPostMessage", _downloadAsPostMessage);
     JsonUtil::findJSONValue(object, "UserCanNotWriteRelative", _userCanNotWriteRelative);
     JsonUtil::findJSONValue(object, "EnableInsertRemoteImage", _enableInsertRemoteImage);
+    JsonUtil::findJSONValue(object, "DisableInsertLocalImage", _disableInsertLocalImage);
     JsonUtil::findJSONValue(object, "EnableRemoteLinkPicker", _enableRemoteLinkPicker);
     JsonUtil::findJSONValue(object, "EnableShare", _enableShare);
     JsonUtil::findJSONValue(object, "HideUserList", _hideUserList);

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -611,6 +611,7 @@ public:
         bool getDownloadAsPostMessage() const { return _downloadAsPostMessage; }
         bool getUserCanNotWriteRelative() const { return _userCanNotWriteRelative; }
         bool getEnableInsertRemoteImage() const { return _enableInsertRemoteImage; }
+        bool getDisableInsertLocalImage() const { return _disableInsertLocalImage; }
         bool getEnableRemoteLinkPicker() const { return _enableRemoteLinkPicker; }
         bool getEnableShare() const { return _enableShare; }
         bool getSupportsRename() const { return _supportsRename; }
@@ -682,6 +683,8 @@ public:
         bool _userCanNotWriteRelative = true;
         /// If set to true, users can access the insert remote image functionality
         bool _enableInsertRemoteImage = false;
+        /// If set to true, users can't insert an image from the local machine
+        bool _disableInsertLocalImage = false;
         /// If set to true, users can access the remote link picker functionality
         bool _enableRemoteLinkPicker = false;
         /// If set to true, users can access the file share functionality


### PR DESCRIPTION
This disable being able to pick up a local image. Handle the UI as well. To be used with `EnableInsertRemoteImage`

Return `DisableInsertLocalImage`: true as part of the WOPI CheckFileInfo reply


Change-Id: I1925f804433a7bda6025cb65b0943d78927bea15


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

