### PR TITLE
Menubar & Tabs visibility logic fixes

### DIFF
--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -674,11 +674,19 @@ L.Control.UIManager = L.Control.extend({
 		obj.removeClass('w2ui-icon unfold');
 		obj.addClass('w2ui-icon fold');
 		$('#tb_editbar_item_fold').prop('title', _('Hide Menu'));
+
+		if (this._notebookbarShouldBeCollapsed)
+			this.collapseNotebookbar();
 	},
 
 	hideMenubar: function() {
 		if (this.isMenubarHidden())
 			return;
+
+		var notebookbarWasCollapsed = this.isNotebookbarCollapsed();
+		this.extendNotebookbar();  // The notebookbar has the button to show the menu bar, so having it hidden at the same time softlocks you
+		this._notebookbarShouldBeCollapsed = notebookbarWasCollapsed;
+
 		$('.main-nav').hide();
 		if (L.Params.closeButtonEnabled) {
 			$('#closebuttonwrapper').hide();
@@ -752,7 +760,9 @@ L.Control.UIManager = L.Control.extend({
 	},
 
 	collapseNotebookbar: function() {
-		if (this.isNotebookbarCollapsed())
+		this._notebookbarShouldBeCollapsed = true;
+
+		if (this.isNotebookbarCollapsed() || this.isMenubarHidden())
 			return;
 
 		this.moveObjectVertically($('#formulabar'), -1);
@@ -764,6 +774,8 @@ L.Control.UIManager = L.Control.extend({
 	},
 
 	extendNotebookbar: function() {
+		this._notebookbarShouldBeCollapsed = false;
+
 		if (!this.isNotebookbarCollapsed())
 			return;
 

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -429,6 +429,9 @@ L.Control.UIManager = L.Control.extend({
 		this.map._docLayer._requestNewTiles();
 
 		this.map.topToolbar.updateControlsState();
+
+		if (this._menubarShouldBeHidden)
+			this.hideMenubar();
 	},
 
 	createNotebookbarControl: function(docType) {
@@ -496,6 +499,9 @@ L.Control.UIManager = L.Control.extend({
 		this.refreshNotebookbar();
 		this.map._docLayer._resetClientVisArea();
 		this.map._docLayer._requestNewTiles();
+		var menubarWasHidden = this.isMenubarHidden();
+		this.showMenubar();
+		this._menubarShouldBeHidden = menubarWasHidden;
 	},
 
 	removeNotebookbarUI: function() {
@@ -663,6 +669,7 @@ L.Control.UIManager = L.Control.extend({
 	// Menubar
 
 	showMenubar: function() {
+		this._menubarShouldBeHidden = false;
 		if (!this.isMenubarHidden())
 			return;
 		$('.main-nav').show();
@@ -680,7 +687,8 @@ L.Control.UIManager = L.Control.extend({
 	},
 
 	hideMenubar: function() {
-		if (this.isMenubarHidden())
+		this._menubarShouldBeHidden = true;
+		if (this.isMenubarHidden() || this.shouldUseNotebookbarMode())
 			return;
 
 		var notebookbarWasCollapsed = this.isNotebookbarCollapsed();


### PR DESCRIPTION
# Commit 9115d9df8588f4efe21531ff7d8d4fd4e7424e72

Previously, when using the Collapse_Notebookbar postmessage or equivalent ui_defaults (SpreadsheetToolbar=false, etc.), particularly in compact mode, it was possible to additionally hide the menu bar. As the button to show the menu bar is on the notebookbar, this meant that you couldn't reactivate either notebookbar or menubar until you refreshed the page. This is particularly annoying in integrators that may not provide an easy way to reload the page

This commit makes it so that hiding the menu bar automatically uncollapses the notebookbar and won't let it be collapsed again. Whether the notebook bar should be collapsed (the last thing done to it was a collapse) is remembered and restored after the menu bar is shown again, so if you send a postmessage that will affect the state of the notebookbar after the menu is shown (even though it will not affect the notebookbar's state immediately)

Caveats:
- If you are hiding the notebookbar to limit the control the user has, that's broken by this commit as it makes it impossible to hide both the menu and notebook bars at the same time.
- The notebook bar will be hidden again when re-showing the menu bar, however there still isn't a way to hide the notebook bar in normal use (i.e. without using either postmessage or ui_defaults) while in compact mode (although there is a workaround to show it- switching into tabbed mode and then back!). It might be nice to have one.

Other considered solutions:
- We could add a new button that allowed you to reopen the menu if both menu and notebookbar were hidden
  - Not sure there's much benefit to this over just doing what we're doing here, and it's harder to implement
- We could disable the button to hide the menu bar when the notebookbar is collapsed
  - As far as I know, there's no button in the UI to show the notebook bar. This would make it impossible to hide the menu bar if the notebookbar was hidden via postmessage or ui_defaults


Change-Id: Ieab6d72a6be181aba88e9a5b21dda16a369b9e54


# Commit de0410ecaee0a31f9c872d9ae7e5d7a524269308

Prevent hiding the menu bar in tabbed mode

Tabbed mode doesn't have a menu bar, instead it has tabs. These can't be
hidden. Unfortunately, the post messages to hide the menu bar have the
side effect of hiding the tabs. This commit prevents the tabs being
hidden when in tabbed mode, and shows the tabs again when switching from
compact mode into tabbed mode.

When switching back from tabbed into compact mode, the state that you
would like the menu bar to be in (hidden/shown) will be remembered and
restored. This includes any postmessages that were not acted on while in
tabbed mode.


Change-Id: I1177903fe965e354538e6e7bbc3c83af3177938e

* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

