### PR TITLE
copy CA certificates to jail

### DIFF
--- a/coolwsd-systemplate-setup
+++ b/coolwsd-systemplate-setup
@@ -65,6 +65,14 @@ find etc/fonts \
      usr/lib/*/libsqlite* \
 	-type l 2>/dev/null
 
+# Find the first of these that exist to fulfill ssltls
+# via openssl requirements
+find etc/pki/tls/certs/ca-bundle.crt \
+     etc/pki/tls/certs/ca-bundle.trust.crt \
+     etc/ssl/certs/ca-certificates.crt \
+     var/lib/ca-certificates/ca-bundle.pem \
+	-type l,f -print -quit 2>/dev/null
+
 # Go through the LO shared objects and check what system libraries
 # they link to.
 find $INSTDIR -name 'xpdfimport' |


### PR DESCRIPTION
for curl >= 8.3.0 which removed the nss backend, requiring the certs with the OpenSSL backend.

DeepL access doesn't work otherwise.

Use the same list and order as used in core:

see: similar to https://gerrit.libreoffice.org/c/core/+/158915
and: https://www.happyassassin.net/posts/2015/01/12/a-note-about-ssltls-trusted-certificate-stores-and-platforms/

Change-Id: Ic9de1e926977f63592146ac17df42704c8d86ccd


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

