### PR TITLE
Update bug_report.md with Collabora

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,43 +8,34 @@ assignees: ''
 ---
 
 ### Describe the Bug
-
 A clear and concise description of what the bug is.
 
 ### Steps to Reproduce
-
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
 ### Expected Behavior
-
 A clear and concise description of what you expected to happen.
 
 ### Actual Behavior
-
 A clear and concise description of what actually happens.
 
 ### Screenshots
-
 If applicable, add screenshots to help explain your problem.
 
 ### Desktop
-
 (Please complete the following information)
- - **OS:** [e.g. Windows 11]
- - **Browser:** [e.g. Chrome]
- - **Version:** [e.g. 114.0]
+ - **Collabora version:** [e.g. 23.05.5.3]
+ - **OS and version:** [e.g. Windows 11]
+ - **Browser and version:** [e.g. Chrome 114.0]
 
 ### Smartphone
-
 (Please complete the following information)
- - **Device:** [e.g. iPhone14]
- - **OS:** [e.g. iOS16.5]
- - **Browser:** [e.g. Safari]
- - **Version:** [e.g. 16.4]
+ - **Device:** [e.g. iPhone 14]
+ - **OS:** [e.g. iOS 16.5]
+ - **Browser and version:** [e.g. Safari 16.4]
 
 ### Additional Context
-
 Add any other context about the problem here.


### PR DESCRIPTION
When creating NEW bug in GITHUB, there is template text, it includes OS, Browser, Version, but missing is COLLABORA Version. I am seeing reports with all fillied, but missing that which is most important. In addiiton, I set Browser with Versoin to be single line with e.g. Chrome 114.


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

