### PR TITLE
wsd: disable ctrl+s when HideSaveOption is true

### DIFF
--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -690,6 +690,11 @@ bool ClientSession::_handleInput(const char *buffer, int length)
                                 << "] has no write permissions in Storage and cannot save.");
             sendTextFrameAndLogError("error: cmd=save kind=savefailed");
         }
+        else if (_wopiFileInfo && _wopiFileInfo->getHideSaveOption())
+        {
+            LOG_WRN("Session [" << getId() << "] on document [" << docBroker->getDocKey()
+                            << "] has HideSaveOption set to true by CheckFileInfo, cannot save");
+        }
         else
         {
             // Don't save unmodified docs by default.


### PR DESCRIPTION
Change-Id: I190a03abcf80176cc2da77fd32190c683852b9a7


* Resolves: follow up of https://github.com/CollaboraOnline/online/commit/6b06f1d8fec1788c18c5755d7e5c2046c3407cbf
* Target version: master 

