### PR TITLE
Logging - dump our log history to the console when asked.

### DIFF
--- a/browser/src/core/Log.js
+++ b/browser/src/core/Log.js
@@ -1,28 +1,37 @@
 /* -*- js-indent-level: 8 -*- */
 /*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
  * L.Log contains methods for logging the activity
  */
 
 L.Log = {
-	log: function (msg, direction, tileCoords, time) {
-		if (!time) {
-			time = Date.now();
-		}
-		if (!this._logs) {
+	log: function (msg, direction) {
+		if (!this._logs)
 			this._logs = [];
-		}
+		var time = Date.now();
+		if (!this.startTime)
+			this.startTime = time;
+
 		// Limit memory usage of log by only keeping the latest entries
 		var maxEntries = 100;
+		if (time - this.startTime < 60 * 1000 /* ms */)
+			maxEntries = 500; // enough to capture early start.
 		while (this._logs.length > maxEntries)
 			this._logs.shift();
+
 		// Limit memory usage of log by limiting length of message
 		var maxMsgLen = 128;
 		if (msg.length > maxMsgLen)
 			msg = msg.substring(0, maxMsgLen);
 		msg = msg.replace(/(\r\n|\n|\r)/gm, ' ');
-		this._logs.push({msg : msg, direction : direction,
-			coords : tileCoords, time : time});
-		//window.app.console.log(time + '-' + direction + ': ' + msg);
+		this._logs.push({msg : msg, direction : direction, time : time});
 	},
 
 	_getEntries: function () {
@@ -34,14 +43,16 @@ L.Log = {
 		var data = '';
 		for (var i = 0; i < this._logs.length; i++) {
 			data += this._logs[i].time + '.' + this._logs[i].direction + '.' +
-					this._logs[i].msg + '.' + this._logs[i].coords;
+				this._logs[i].msg;
 			data += '\n';
 		}
 		return data;
 	},
 
 	print: function () {
-		// window.app.console.log(this._getEntries());
+		window.app.console.log('Queued log messages:');
+		window.app.console.log(this._getEntries());
+		window.app.console.log('End of queued log messages:');
 	},
 
 	save: function () {

--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -271,9 +271,6 @@ app.definitions.Socket = L.Class.extend({
 		if (fullDebug)
 			this._map._docLayer._debugSetPostMessage(type,msg);
 
-		if (!window.protocolDebug && !fullDebug)
-			return;
-
 		if (!fullDebug && msg.length > 256) // for reasonable performance.
 			msg = msg.substring(0,256) + '<truncated ' + (msg.length - 256) + 'chars>';
 
@@ -282,6 +279,11 @@ app.definitions.Socket = L.Class.extend({
 			status += '[!fullyLoadedAndReady]';
 		if (!window.bundlejsLoaded)
 			status += '[!bundlejsLoaded]';
+
+		L.Log.log(msg, type + status);
+
+		if (!window.protocolDebug && !fullDebug)
+			return;
 
 		var color = type === 'OUTGOING' ? 'color:red' : 'color:#2e67cf';
 		window.app.console.log(+new Date() + ' %c' + type + status + '%c: ' + msg.concat(' ').replace(' ', '%c '),

--- a/browser/src/layer/marker/TextInput.js
+++ b/browser/src/layer/marker/TextInput.js
@@ -574,9 +574,6 @@ L.TextInput = L.Layer.extend({
 		else if (payload === null)
 			payload = 'null';
 
-		// Save to downloadable log
-		L.Log.log(payload.toString(), 'INPUT');
-
 		// Pretty-print on console (but only if "tile layer debug mode" is active)
 		if (this._isDebugOn) {
 			var state = this._isComposing ? 'C' : 'N';

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -5157,6 +5157,7 @@ L.CanvasTileLayer = L.Layer.extend({
 				} else if (e.layer === this._debugTrace) {
 					app.socket.setTraceEventLogging(true);
 				} else if (e.layer === this._debugLogging) {
+					L.Log.print();
 					window.setLogging(true);
 				} else if (e.layer === this._debugTileDumping) {
 					app.socket.sendMessage('toggletiledumping true');
@@ -7162,8 +7163,6 @@ L.CanvasTileLayer = L.Layer.extend({
 				this._debugLoadTile++;
 		}
 		this._showDebugForTile(key);
-
-		L.Log.log(textMsg, 'INCOMING', key);
 
 		// updates don't need more chattiness with a tileprocessed
 		if (hasContent)


### PR DESCRIPTION
Remove unused co-ordinates parameter, and unhelpful L.Log call locations, ensure that all protocol messages are logged.

Increase the buffer to record startup and replay it for easier debugging after startup.

Now when enabling "Protocol Logging" in the first minute from document load, we get:

INCOMING[!fullyLoadedAndReady].statusindicator: find INCOMING[!fullyLoadedAndReady].statusindicator: connect INCOMING[!fullyLoadedAndReady].statusindicator: ready INCOMING[!fullyLoadedAndReady].perm: edit
INCOMING[!fullyLoadedAndReady].filemode:{"readOnly": false, "editComment": true} etc.


Change-Id: I5d2a8639e8038dbcc31d6e8fd1b8f8ebf2fff7bc


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

