### PR TITLE
fix: metrics change doc_pid to doc_info use pid as label

### DIFF
--- a/kubernetes/helm/collabora-online/grafana_dashboards/ha-allocation.json
+++ b/kubernetes/helm/collabora-online/grafana_dashboards/ha-allocation.json
@@ -458,7 +458,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "count(doc_pid{env_id=~\"$env_id\"})by(host,env_id)",
+          "expr": "count(doc_info{env_id=~\"$env_id\"})by(host,env_id)",
           "legendFormat": "{{env_id}}: {{host}}",
           "range": true,
           "refId": "A"
@@ -1267,7 +1267,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "avg(count(doc_pid{env_id=~\"$env_id\"})by(key)>1)",
+          "expr": "avg(count(doc_info{env_id=~\"$env_id\"})by(key)>1)",
           "hide": false,
           "legendFormat": "Avg",
           "range": true,
@@ -1279,7 +1279,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "max(count(doc_pid{env_id=~\"$env_id\"})by(key)>1)",
+          "expr": "max(count(doc_info{env_id=~\"$env_id\"})by(key)>1)",
           "hide": false,
           "legendFormat": "Max",
           "range": true,
@@ -1291,7 +1291,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "count(count(doc_pid{env_id=~\"$env_id\"})by(key)>1)",
+          "expr": "count(count(doc_info{env_id=~\"$env_id\"})by(key)>1)",
           "hide": false,
           "legendFormat": "Count",
           "range": true,
@@ -1366,7 +1366,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "count(count(doc_pid{env_id=~\"$env_id\"})by(key,env_id)>1)by(env_id)",
+          "expr": "count(count(doc_info{env_id=~\"$env_id\"})by(key,env_id)>1)by(env_id)",
           "legendFormat": "{{env_id}}",
           "range": true,
           "refId": "A"

--- a/kubernetes/helm/collabora-online/templates/prometheus-rules.yaml
+++ b/kubernetes/helm/collabora-online/templates/prometheus-rules.yaml
@@ -79,7 +79,7 @@ spec:
         `}}
       {{- end }}
       - alert: "Collabora same Document open Multiple time"
-        expr: 'count(doc_pid) by (key) > 1'
+        expr: 'count(doc_info) by (key) > 1'
         labels:
           severity: "warning"
         {{`
@@ -87,7 +87,7 @@ spec:
           summary: "a key/document is open multiple times in namespace: {{ $labels.namespace }}"
         `}}
       - alert: "Collabora same Document open Multiple time"
-        expr: 'count(count(doc_pid)by(key)>1) > {{ .Values.prometheus.rules.defaults.docs.duplicated }}'
+        expr: 'count(count(doc_info)by(key)>1) > {{ .Values.prometheus.rules.defaults.docs.duplicated }}'
         labels:
           severity: "critical"
         {{`

--- a/wsd/AdminModel.cpp
+++ b/wsd/AdminModel.cpp
@@ -1193,7 +1193,8 @@ void AdminModel::getMetrics(std::ostringstream &oss)
         Poco::URI::encode(doc.getFilename(), " ", encodedFilename);
         oss << "doc_pid{host=\"" << doc.getHostName() << "\","
                "key=\"" << doc.getDocKey() << "\","
-               "filename=\"" << encodedFilename << "\"} " << pid << "\n";
+               "filename=\"" << encodedFilename << "\","
+               "pid=\"" << pid << "\"} 1\n";
 
         std::string suffix = "{pid=\"" + pid + "\"} ";
         oss << "doc_views" << suffix << doc.getViews().size() << "\n";

--- a/wsd/AdminModel.cpp
+++ b/wsd/AdminModel.cpp
@@ -1191,7 +1191,7 @@ void AdminModel::getMetrics(std::ostringstream &oss)
 
         std::string encodedFilename;
         Poco::URI::encode(doc.getFilename(), " ", encodedFilename);
-        oss << "doc_pid{host=\"" << doc.getHostName() << "\","
+        oss << "doc_info{host=\"" << doc.getHostName() << "\","
                "key=\"" << doc.getDocKey() << "\","
                "filename=\"" << encodedFilename << "\","
                "pid=\"" << pid << "\"} 1\n";

--- a/wsd/metrics.txt
+++ b/wsd/metrics.txt
@@ -173,11 +173,11 @@ SELECTED ERRORS - all integer counts
     error_parse_error - badly formed data provided for us to parse.
 
 PER DOCUMENT DETAILS - suffixed by {pid=<pid>} for each document:
-
-    doc_pid - define the pid of the related document with these labels:
+    doc_info - define the info of the related document with these data as labels:
         host= - host this document was fetched from
         key= - key often WOPISrc used to fetch the document
 	filename= - filename of the document
+        pid= - processid of the open document
     doc_active_views - number of views/users currently
     doc_is_modified - is the document modified, or not ie. saved/readonly
     doc_memory_used_bytes - bytes of memory dirtied by this process


### PR DESCRIPTION
@mmeeks i like to have the pid value as an label so it would be use on the other metrics for lookup with [promql group_left](https://prometheus.io/docs/prometheus/latest/querying/operators/#group-modifiers)

i believe it is usefull to rename that metrics afterwards my suggestion `doc_info` as an representer for all the metrics

After this change i will enrich the PrometheusRules / Alerts to show more information (based on the instance and pid label) - current i believe the following should work:
`doc_active_views * group_left(doc_info)`


### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] Documentation (manuals or wiki) has been updated or is not required

