### PR TITLE
fix helm chart releaser

### DIFF
--- a/kubernetes/helm/collabora-online/Chart.yaml
+++ b/kubernetes/helm/collabora-online/Chart.yaml
@@ -4,7 +4,7 @@ type: "application"
 name: collabora-online
 description: Collabora Online helm chart
 
-version: 1.1.5
+version: 1.1.6
 appVersion: "23.05.5.5.1"
 
 home: "https://www.collaboraoffice.com/code/"


### PR DESCRIPTION
    - from the logs Error: error creating GitHub release
    helm-collabora-online-1.1.5: POST https://api.github.com/repos/CollaboraOnline/online/releases:
    422 Validation Failed [{Resource:Release Field:tag_name Code:already_exists Message:}]


Change-Id: I16d0fa54c0dd9ef5bd96b96366c93037ed7de56e


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

