### PR TITLE
annotation: reset comment id if autosave is cancelled

### DIFF
--- a/browser/src/layer/tile/CommentListSection.ts
+++ b/browser/src/layer/tile/CommentListSection.ts
@@ -1159,9 +1159,8 @@ export class CommentSection extends CanvasSectionObject {
 		}
 		if (action === 'Add') {
 			if (app.view.commentAutoSave) {
-				// preserve the id of the root comment and use it when reply button is clicked
-				if (app.view.commentAutoSave.sectionProperties.data.reply)
-					app.view.commentAutoSave.sectionProperties.data.oldId = app.view.commentAutoSave.sectionProperties.data.id;
+				// preserve original Id, can be used in case of reply to find parent comment, or revert the id in case comment insertion is cancelled
+				app.view.commentAutoSave.sectionProperties.data.oldId = app.view.commentAutoSave.sectionProperties.data.id;
 				app.view.commentAutoSave.sectionProperties.data.id = obj.comment.id;
 				app.view.commentAutoSave.sectionProperties.autoSave.innerText = _('Autosaved') ;
 				app.view.commentAutoSave = null;

--- a/browser/src/layer/tile/CommentSection.ts
+++ b/browser/src/layer/tile/CommentSection.ts
@@ -826,6 +826,8 @@ export class Comment extends CanvasSectionObject {
 			return;
 		if (app.view.commentAutoAdded) {
 			this.sectionProperties.commentListSection.remove(this.sectionProperties.data.id);
+			app.view.commentAutoAdded = false;
+			this.sectionProperties.data.id = this.sectionProperties.data.oldId;
 			if (this.sectionProperties.commentListSection.sectionProperties.selectedComment.sectionProperties.container.classList.contains('reply-annotation-container')) {
 				this.show();
 				return;


### PR DESCRIPTION
problem:
User A writes Comment 1 and saves
User A replies to himself, write something, click away to autosave, Cancel
user A modifies Comment 1 and OK - comment disappears, although it is there, seen after reload, but without modification.

Change-Id: I5d83936f26939b5a05a0ce3099c01923a55c9606

* Target version: master 


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

