### PR TITLE
delta: fix threading gotcha when working.

### DIFF
--- a/common/RenderTiles.hpp
+++ b/common/RenderTiles.hpp
@@ -34,10 +34,12 @@ class ThreadPool {
     std::vector<std::thread> _threads;
     size_t _working;
     bool   _shutdown;
+    std::atomic<bool> _running;
 public:
     ThreadPool()
         : _working(0),
-          _shutdown(false)
+          _shutdown(false),
+          _running(false)
     {
         int maxConcurrency = 2;
 #ifdef __EMSCRIPTEN__
@@ -77,12 +79,14 @@ public:
     void pushWork(const ThreadFn &fn)
     {
         std::unique_lock< std::mutex > lock(_mutex);
+        assert(!_running);
         assert(_working == 0);
         _work.push(fn);
     }
 
     void runOne(std::unique_lock< std::mutex >& lock)
     {
+        assert(_running);
         assert(!_work.empty());
 
         ThreadFn fn = _work.front();
@@ -105,7 +109,10 @@ public:
     void run()
     {
         std::unique_lock< std::mutex > lock(_mutex);
+        assert(!_running);
         assert(_working == 0);
+
+        _running = true;
 
         // Avoid notifying threads if we don't need to.
         bool useThreads = _threads.size() > 1 && _work.size() > 1;
@@ -118,6 +125,8 @@ public:
         if (useThreads && (_working > 0 || !_work.empty()))
             _complete.wait(lock, [this]() { return _working == 0 && _work.empty(); } );
 
+        _running = false;
+
         assert(_working==0);
         assert(_work.empty());
     }
@@ -128,7 +137,7 @@ public:
         while (!_shutdown)
         {
             _cond.wait(lock);
-            while (!_shutdown && !_work.empty())
+            while (!_shutdown && !_work.empty() && _running)
                 runOne(lock);
         }
     }


### PR DESCRIPTION
The ThreadPool::work function can get its condition signalled -very- late.

With bad timing, this can occur after all the work is done, and when the next batch of work is being fed into the pool.

This can mean that it takes work from the queue, and subverts the:

        bool useThreads = _threads.size() > 1 && _work.size() > 1;

check in ThreadPool::run - which can believe we are in a single threaded, single tile mode - and not wait for this thread to complete.

That's not good [!] so ensure that threads are only runnable during ThreadPool::run.


Change-Id: Ifebb0f15cbb4c22ef33ffba06e7c6c87493818be


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

