### PR TITLE
context menu: allow unfloat table for Writer text frames

### DIFF
--- a/browser/src/control/Control.ContextMenu.js
+++ b/browser/src/control/Control.ContextMenu.js
@@ -51,7 +51,7 @@ L.Control.ContextMenu = L.Control.extend({
 				   'UpdateCurIndex','RemoveTableOf',
 				   'ReplyComment', 'DeleteComment', 'DeleteAuthor', 'DeleteAllNotes',
 				   'SpellingAndGrammarDialog', 'FontDialog', 'FontDialogForParagraph', 'TableDialog',
-				   'SpellCheckIgnore', 'FrameDialog'],
+				   'SpellCheckIgnore', 'FrameDialog', 'UnfloatFrame'],
 
 			spreadsheet: ['MergeCells', 'SplitCell', 'InsertCell', 'DeleteCell',
 				      'RecalcPivotTable', 'DataDataPilotRun', 'DeletePivotTable',

--- a/browser/src/unocommands.js
+++ b/browser/src/unocommands.js
@@ -475,6 +475,7 @@ var unoCommandsArray = {
 	'Underline':{global:{menu:_('Underline'),},},
 	'UnderlineDouble':{global:{menu:_('Double Underline'),},},
 	'Undo':{global:{menu:_('~Undo'),},},
+	'UnfloatFrame':{text:{menu:_('Unfloat Frame Content'),},},
 	'Ungroup':{global:{menu:_('~Ungroup...'),},},
 	'UngroupSparklines':{spreadsheet:{menu:_('Ungroup Sparklines'),},},
 	'UnsetCellsReadOnly':{text:{menu:_('Unprotect Cells'),},},


### PR DESCRIPTION
This is safe to do as it's not interactive, so it happens synchronously.
The matching uno command was added on core.git co-23.05 in commit
1f5c20352725cd6133e68e80e8523d865006161f (sw floattable, delete UI: add
an uno command to unfloat frame from context menu, 2023-11-17).

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I74736c7d589c2062a8e9255a42f81bf790b7d3e3
