### PR TITLE
annotation: make sure parent-child relation is established

### DIFF
--- a/browser/src/layer/tile/CommentListSection.ts
+++ b/browser/src/layer/tile/CommentListSection.ts
@@ -1043,6 +1043,7 @@ export class CommentSection extends CanvasSectionObject {
 
 		this.sectionProperties.commentList.push(annotation);
 
+		this.adjustParentAdd(annotation);
 		this.orderCommentList();
 		this.updateIdIndexMap();
 		this.checkSize();
@@ -1176,7 +1177,6 @@ export class CommentSection extends CanvasSectionObject {
 			} else {
 				this.adjustComment(obj.comment);
 				annotation = this.add(obj.comment);
-				this.adjustParentAdd(annotation);
 				if (this.sectionProperties.docLayer._docType === 'spreadsheet')
 					annotation.hide();
 			}


### PR DESCRIPTION
problem:
some times we order comments before parent-child relation is established, this caused reply count not being updated correctly for other users

steps to reproduce:
User A open ODT, let us say already with comment or add one, and keep Sidebar open so that comments are short. user B opens the same ODT with full comments. adds reply User A does not update ticket number, does not have +1


Change-Id: If3360c8dd938c6bd177764d3c1383d7f3f845990


* Target version: master 


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

