### PR TITLE
add missing css class to dark mode icon in Calc

### DIFF
--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -1290,6 +1290,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 			},
 			{
 				'id':'toggledarktheme',
+				'class': 'unotoggledarktheme',
 				'type': 'bigmenubartoolitem',
 				'text': _('Dark Mode'),
 				'accessibility': { focusBack: true,	combination: 'DT', de: null }


### PR DESCRIPTION
Change-Id: Ic5f69b64221ca9890794b1b3dcb5dbe069992459


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

