### PR TITLE
browser: don't show socket error message if we are reconnecting

### DIFF
--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -1526,7 +1526,7 @@ app.definitions.Socket = L.Class.extend({
 
 	_onSocketClose: function () {
 		window.app.console.debug('_onSocketClose:');
-		if (!this._map._docLoadedOnce) {
+		if (!this._map._docLoadedOnce && this.ReconnectCount === 0) {
 			var postMessageObj = {
 				errorType: 'websocketconnectionfailed',
 				success: false,


### PR DESCRIPTION
- specifically a case where coolwsd is cleaning up the document we don't want to give up on clientside and show the error message to user


Change-Id: Ie75fa3e19f97ca18acc8e881813d6c617fc9f7b7


* Resolves: # <!-- related github issue -->
* Target version: master 
