### PR TITLE
Fix downlaod options (PDF/PDF as/EPUB) in read only mode

### DIFF
--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -366,7 +366,8 @@ L.Map.include({
 		var isAllowedInReadOnly = false;
 		var allowedCommands = ['.uno:Save', '.uno:WordCountDialog',
 			'.uno:Signature', '.uno:ShowResolvedAnnotations',
-			'.uno:ToolbarMode?Mode:string=notebookbar_online.ui', '.uno:ToolbarMode?Mode:string=Default'];
+			'.uno:ToolbarMode?Mode:string=notebookbar_online.ui', '.uno:ToolbarMode?Mode:string=Default',
+			'.uno:ExportToEPUB', '.uno:ExportToPDF', '.uno:ExportDirectToPDF'];
 		if (this.isPermissionEditForComments()) {
 			allowedCommands.push('.uno:InsertAnnotation','.uno:DeleteCommentThread', '.uno:DeleteAnnotation', '.uno:DeleteNote',
 				'.uno:DeleteComment', '.uno:ReplyComment', '.uno:ReplyToAnnotation', '.uno:ResolveComment',

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1469,7 +1469,9 @@ bool ClientSession::filterMessage(const std::string& message) const
         else if (tokens.equals(0, "uno"))
         {
             if (tokens.size() > 1 && (tokens.equals(1, ".uno:ExecuteSearch") || tokens.equals(1, ".uno:Signature")
-                 || tokens.equals(1, ".uno:ExportToPDF")))
+                 || tokens.equals(1, ".uno:ExportToPDF")
+                 || tokens.equals(1,".uno:ExportDirectToPDF")
+                 || tokens.equals(1,".uno:ExportToEPUB")))
             {
                 allowed = true;
             }


### PR DESCRIPTION
- Allowed downlaod options for PDF/PDF as /EPUB
- PDf/PDF as/EPUB will be downlaod in read only mode
Signed-off-by: Darshan-upadhyay1110 <darshan.upadhyay@collabora.com>
Change-Id: Ic6e0c4a16fa5dffc61e61fd4ece9aeeaec1450b9


* Resolves: #6653 
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

