### PR TITLE
Followup to unified touch handling

### DIFF
--- a/browser/src/control/Permission.js
+++ b/browser/src/control/Permission.js
@@ -193,7 +193,8 @@ L.Map.include({
 	_enterEditMode: function (perm) {
 		this._permission = perm;
 
-		this.dragging.disable();
+		this.dragging.disable(); // FIXME: before unification, this was only called when not on a touch device.
+		// It would be better to split dragging.disable into a touch version and a mouse version but this looks like it will require a major rework of its own...
 
 		if ((window.mode.isMobile() || window.mode.isTablet()) && this._textInput && this.getDocType() === 'text') {
 			this._textInput.setSwitchedToEditMode();

--- a/browser/src/control/Ruler.js
+++ b/browser/src/control/Ruler.js
@@ -137,9 +137,9 @@ L.Control.Ruler = L.Control.extend({
 			self._moveIndentationEnd(event);
 		}));
 
-		L.DomEvent.on(this._firstLineMarker, 'mousedown', this._initiateIndentationDrag, this);
-		L.DomEvent.on(this._pStartMarker, 'mousedown', this._initiateIndentationDrag, this);
-		L.DomEvent.on(this._pEndMarker, 'mousedown', this._initiateIndentationDrag, this);
+		L.DomEvent.on(this._firstLineMarker, 'mousedown', window.touch.mouseOnly(this._initiateIndentationDrag), this);
+		L.DomEvent.on(this._pStartMarker, 'mousedown', window.touch.mouseOnly(this._initiateIndentationDrag), this);
+		L.DomEvent.on(this._pEndMarker, 'mousedown', window.touch.mouseOnly(this._initiateIndentationDrag), this);
 	},
 
 	_initLayout: function() {

--- a/browser/src/dom/DomEvent.MultiClick.js
+++ b/browser/src/dom/DomEvent.MultiClick.js
@@ -41,7 +41,9 @@ L.extend(L.DomEvent, {
 					clientX: e.clientX,
 					clientY: e.clientY,
 					button: e.button,
-					target: e.target
+					target: e.target,
+					pointerType: e.pointerType,
+					isMouseEvent: e instanceof MouseEvent
 				};
 
 				handler(eOut);

--- a/browser/src/dom/Draggable.js
+++ b/browser/src/dom/Draggable.js
@@ -21,6 +21,18 @@ L.Draggable = L.Evented.extend({
 		}
 	},
 
+	_manualDrag: function() {
+		return false;
+	},
+
+	noManualDrag: window.memo.decorator(function(f) {
+		return function(e) {
+			if (!this._manualDrag(e)) {
+				return f.apply(this, arguments);
+			}
+		};
+	}),
+
 	initialize: function (element, dragStartTarget, preventOutline) {
 		this._element = element;
 		this._dragStartTarget = dragStartTarget || element;
@@ -38,17 +50,17 @@ L.Draggable = L.Evented.extend({
 	},
 
 	enable: function () {
-		if (this._manualDrag || this._enabled) { return; }
+		if (this._enabled) { return; }
 
-		L.DomEvent.on(this._dragStartTarget, L.Draggable.START.join(' '), this._onDown, this);
+		L.DomEvent.on(this._dragStartTarget, L.Draggable.START.join(' '), this.noManualDrag(this._onDown), this);
 
 		this._enabled = true;
 	},
 
 	disable: function () {
-		if (this._manualDrag || !this._enabled) { return; }
+		if (!this._enabled) { return; }
 
-		L.DomEvent.off(this._dragStartTarget, L.Draggable.START.join(' '), this._onDown, this);
+		L.DomEvent.off(this._dragStartTarget, L.Draggable.START.join(' '), this.noManualDrag(this._onDown), this);
 
 		this._enabled = false;
 		this._moved = false;
@@ -90,8 +102,8 @@ L.Draggable = L.Evented.extend({
 		this.startOffset = this._startPoint.subtract(new L.Point(startBoundingRect.left, startBoundingRect.top));
 
 		L.DomEvent
-			.on(document, L.Draggable.MOVE[e.type], window.touch.mouseOnly(this._onMove), this)
-			.on(document, L.Draggable.END[e.type], window.touch.mouseOnly(this._onUp), this);
+		 .on(document, L.Draggable.MOVE[e.type], this.noManualDrag(this._onMove), this)
+		 .on(document, L.Draggable.END[e.type], this.noManualDrag(this._onUp), this);
 	},
 
 	_onMove: function (e) {
@@ -178,8 +190,8 @@ L.Draggable = L.Evented.extend({
 
 		for (var i in L.Draggable.MOVE) {
 			L.DomEvent
-			    .off(document, L.Draggable.MOVE[i], this._onMove, this)
-			    .off(document, L.Draggable.END[i], this._onUp, this);
+			 .off(document, L.Draggable.MOVE[i], this.noManualDrag(this._onMove), this)
+			 .off(document, L.Draggable.END[i], this.noManualDrag(this._onUp), this);
 		}
 
 		L.DomUtil.enableImageDrag();

--- a/browser/src/layer/vector/Path.Drag.js
+++ b/browser/src/layer/vector/Path.Drag.js
@@ -62,6 +62,14 @@ L.Handler.PathDrag = L.Handler.extend(/** @lends  L.Path.Drag.prototype */ {
 
 	},
 
+	noManualDrag: function(f) {
+		if ('noManualDrag' in this._path) {
+			return this._path.noManualDrag(f);
+		} else {
+			return f;
+		}
+	},
+
 	/**
 	* Enable dragging
 	*/
@@ -86,8 +94,8 @@ L.Handler.PathDrag = L.Handler.extend(/** @lends  L.Path.Drag.prototype */ {
 
 		this._path.removeClass(L.Handler.PathDrag.DRAGGING_CLS);
 
-		L.DomEvent.off(document, 'mousemove touchmove', this._onDrag,    this);
-		L.DomEvent.off(document, 'mouseup touchend',    this._onDragEnd, this);
+		L.DomEvent.off(document, 'mousemove touchmove', this.noManualDrag(this._onDrag),    this);
+		L.DomEvent.off(document, 'mouseup touchend',    this.noManualDrag(this._onDragEnd), this);
 	},
 
 	/**
@@ -117,8 +125,8 @@ L.Handler.PathDrag = L.Handler.extend(/** @lends  L.Path.Drag.prototype */ {
 		this._path._renderer.addContainerClass('leaflet-interactive');
 
 		L.DomEvent
-			.on(document, MOVE[eventType], this._onDrag,    this)
-			.on(document, END[eventType],  this._onDragEnd, this);
+		 .on(document, MOVE[eventType], this.noManualDrag(this._onDrag),    this)
+		 .on(document, END[eventType],  this.noManualDrag(this._onDragEnd), this);
 
 		if (this._path._map.dragging.enabled()) {
 			// I guess it's required because mousedown gets simulated with a delay
@@ -230,8 +238,8 @@ L.Handler.PathDrag = L.Handler.extend(/** @lends  L.Path.Drag.prototype */ {
 			this._path._transform(null);
 		}
 
-		L.DomEvent.off(document, 'mousemove touchmove', this._onDrag,    this);
-		L.DomEvent.off(document, 'mouseup touchend',    this._onDragEnd, this);
+		L.DomEvent.off(document, 'mousemove touchmove', this.noManualDrag(this._onDrag),    this);
+		L.DomEvent.off(document, 'mouseup touchend',    this.noManualDrag(this._onDragEnd), this);
 
 		this._restoreCoordGetters();
 
@@ -260,7 +268,7 @@ L.Handler.PathDrag = L.Handler.extend(/** @lends  L.Path.Drag.prototype */ {
 			this._path._map.dragging.enable();
 		}
 
-		if (!moved && this._mouseDown && !window.touch.isTouchEvent(this._mouseDown)) {
+		if (!moved && this._mouseDown && !this._path.options.manualDrag(this._mouseDown)) {
 			this._path._map._handleDOMEvent(this._mouseDown);
 			this._path._map._handleDOMEvent(evt);
 		}

--- a/browser/src/map/Map.js
+++ b/browser/src/map/Map.js
@@ -137,12 +137,13 @@ L.Map = L.Evented.extend({
 
 		this.addHandler('keyboard', L.Map.Keyboard);
 		this.addHandler('dragging', L.Map.Drag);
-
-		this.addHandler('touchGesture', L.Map.TouchGesture);
-
+		this.dragging.disable(); // FIXME: before unification, this was only called when on a touch device or in a mobile cypress test
+		// It would be better to split dragging.disable into a touch version and a mouse version but this looks like it will require a major rework of its own...
 		this.addHandler('mouse', L.Map.Mouse);
 		this.addHandler('scrollHandler', L.Map.Scroll);
 		this.addHandler('doubleClickZoom', L.Map.DoubleClickZoom);
+		this.addHandler('touchGesture', L.Map.TouchGesture);
+		this.dragging._draggable._manualDrag = window.touch.isTouchEvent;
 
 		if (this.options.imagePath) {
 			L.Icon.Default.imagePath = this.options.imagePath;
@@ -1221,7 +1222,8 @@ L.Map = L.Evented.extend({
 
 		this._fadeAnimated = this.options.fadeAnimation && L.Browser.any3d;
 
-		L.DomUtil.addClass(container, 'leaflet-container leaflet-touch' +
+		L.DomUtil.addClass(container, 'leaflet-container' +
+			(window.touch.hasAnyTouchscreen() ? ' leaflet-touch' : '') +
 			(L.Browser.retina ? ' leaflet-retina' : '') +
 			(L.Browser.ielt9 ? ' leaflet-oldie' : '') +
 			(L.Browser.safari ? ' leaflet-safari' : '') +

--- a/browser/src/map/handler/Map.DoubleClickZoom.js
+++ b/browser/src/map/handler/Map.DoubleClickZoom.js
@@ -9,14 +9,14 @@ L.Map.mergeOptions({
 
 L.Map.DoubleClickZoom = L.Handler.extend({
 	addHooks: function () {
-		this._map.on('dblclick', window.touch.mouseOnly(this._onDoubleClick), this);
+		this._map.on('dblclick', this._onDoubleClick, this);
 	},
 
 	removeHooks: function () {
-		this._map.off('dblclick', window.touch.mouseOnly(this._onDoubleClick), this);
+		this._map.off('dblclick', this._onDoubleClick, this);
 	},
 
-	_onDoubleClick: function (e) {
+	_onDoubleClick: window.touch.mouseOnly(function (e) {
 		var map = this._map,
 		    oldZoom = map.getZoom(),
 		    zoom = e.originalEvent.shiftKey ? Math.ceil(oldZoom) - 1 : Math.floor(oldZoom) + 1;
@@ -26,5 +26,5 @@ L.Map.DoubleClickZoom = L.Handler.extend({
 		} else {
 			map.setZoomAround(e.containerPoint, zoom);
 		}
-	}
+	})
 });

--- a/browser/src/map/handler/Map.Mouse.js
+++ b/browser/src/map/handler/Map.Mouse.js
@@ -39,7 +39,7 @@ L.Map.Mouse = L.Handler.extend({
 		right: 2
 	},
 
-	_onMouseEvent: function (e) {
+	_onMouseEvent: window.touch.mouseOnly(function (e) {
 		if (this._map.uiManager.isUIBlocked())
 			return;
 
@@ -233,7 +233,7 @@ L.Map.Mouse = L.Handler.extend({
 			L.DomEvent.on(document, 'mousemove', this._onMouseMoveOutside, this);
 			L.DomEvent.on(document, 'mouseup', this._onMouseUpOutside, this);
 		}
-	},
+	}),
 
 	_executeMouseEvents: function () {
 		this._holdMouseEvent = null;
@@ -243,14 +243,14 @@ L.Map.Mouse = L.Handler.extend({
 		this._mouseEventsQueue = [];
 	},
 
-	_onMouseMoveOutside: function (e) {
+	_onMouseMoveOutside: window.touch.mouseOnly(function (e) {
 		this._map._handleDOMEvent(e);
 		if (this._map.dragging.enabled()) {
 			this._map.dragging._draggable._onMove(e);
 		}
-	},
+	}),
 
-	_onMouseUpOutside: function (e) {
+	_onMouseUpOutside: window.touch.mouseOnly(function (e) {
 		this._mouseDown = false;
 		L.DomEvent.off(document, 'mousemove', this._onMouseMoveOutside, this);
 		L.DomEvent.off(document, 'mouseup', this._onMouseUpOutside, this);
@@ -263,5 +263,5 @@ L.Map.Mouse = L.Handler.extend({
 		if (this._map.dragging.enabled()) {
 			this._map.dragging._draggable._onUp(e);
 		}
-	}
+	})
 });

--- a/browser/src/map/handler/Map.Scroll.js
+++ b/browser/src/map/handler/Map.Scroll.js
@@ -14,11 +14,12 @@ L.Map.mergeOptions({
 });
 
 L.Map.Scroll = L.Handler.extend({
+	_mouseOnlyPreventDefault: window.touch.mouseOnly(L.DomEvent.preventDefault),
 	addHooks: function () {
 		L.DomEvent.on(this._map._container, {
 			wheel: this._onWheelScroll,
 			mousewheel: this._onWheelScroll,
-			MozMousePixelScroll: L.DomEvent.preventDefault
+			MozMousePixelScroll: this._mouseOnlyPreventDefault
 		}, this);
 
 		this._delta = 0;
@@ -37,7 +38,7 @@ L.Map.Scroll = L.Handler.extend({
 	removeHooks: function () {
 		L.DomEvent.off(this._map._container, {
 			mousewheel: this._onWheelScroll,
-			MozMousePixelScroll: L.DomEvent.preventDefault
+			MozMousePixelScroll: this._mouseOnlyPreventDefault
 		}, this);
 		if (!this._map.touchGesture) {
 			L.DomEvent.off(this._map._container, {
@@ -47,12 +48,12 @@ L.Map.Scroll = L.Handler.extend({
 		}
 	},
 
-	_onTouchScrollStart: this.touch.mouseOnly(function (e) {
+	_onTouchScrollStart: window.touch.mouseOnly(function (e) {
 		this.lastX = e.touches[0].clientX;
 		this.lastY = e.touches[0].clientY;
 	}),
 
-	_onTouchScroll: this.touch.mouseOnly(function (e) {
+	_onTouchScroll: window.touch.mouseOnly(function (e) {
 		var top = e.touches[0].clientY;
 		var start = e.touches[0].clientX;
 		var deltaX = (start - this.lastX);
@@ -75,7 +76,7 @@ L.Map.Scroll = L.Handler.extend({
 		this._timer = setTimeout(L.bind(this._performScroll, this), left);
 	}),
 
-	_onWheelScroll: this.touch.mouseOnly(function (e) {
+	_onWheelScroll: window.touch.mouseOnly(function (e) {
 		var delta =  -1 * e.deltaY; // L.DomEvent.getWheelDelta(e);
 		var debounce = this._map.options.wheelDebounceTime;
 

--- a/browser/src/map/handler/Map.TouchGesture.js
+++ b/browser/src/map/handler/Map.TouchGesture.js
@@ -99,43 +99,43 @@ L.Map.TouchGesture = L.Handler.extend({
 	},
 
 	addHooks: function () {
-		this._hammer.on('hammer.input', L.bind(window.touch.touchOnly(this._onHammer), this));
-		this._hammer.on('tap', L.bind(window.touch.touchOnly(this._onTap), this));
-		this._hammer.on('panstart', L.bind(window.touch.touchOnly(this._onPanStart), this));
-		this._hammer.on('pan', L.bind(window.touch.touchOnly(this._onPan), this));
-		this._hammer.on('panend', L.bind(window.touch.touchOnly(this._onPanEnd), this));
-		this._hammer.on('pinchstart', L.bind(window.touch.touchOnly(this._onPinchStart), this));
-		this._hammer.on('pinchmove', L.bind(window.touch.touchOnly(this._onPinch), this));
-		this._hammer.on('pinchend', L.bind(window.touch.touchOnly(this._onPinchEnd), this));
-		this._hammer.on('tripletap', L.bind(window.touch.touchOnly(this._onTripleTap), this));
-		this._hammer.on('swipe', L.bind(window.touch.touchOnly(this._onSwipe), this));
+		this._hammer.on('hammer.input', window.memo.bind(window.touch.touchOnly(this._onHammer), this));
+		this._hammer.on('tap', window.memo.bind(window.touch.touchOnly(this._onTap), this));
+		this._hammer.on('panstart', window.memo.bind(window.touch.touchOnly(this._onPanStart), this));
+		this._hammer.on('pan', window.memo.bind(window.touch.touchOnly(this._onPan), this));
+		this._hammer.on('panend', window.memo.bind(window.touch.touchOnly(this._onPanEnd), this));
+		this._hammer.on('pinchstart', window.memo.bind(window.touch.touchOnly(this._onPinchStart), this));
+		this._hammer.on('pinchmove', window.memo.bind(window.touch.touchOnly(this._onPinch), this));
+		this._hammer.on('pinchend', window.memo.bind(window.touch.touchOnly(this._onPinchEnd), this));
+		this._hammer.on('tripletap', window.memo.bind(window.touch.touchOnly(this._onTripleTap), this));
+		this._hammer.on('swipe', window.memo.bind(window.touch.touchOnly(this._onSwipe), this));
 		this._map.on('updatepermission', this._onPermission, this);
 		this._onPermission({perm: this._map._permission});
 	},
 
 	removeHooks: function () {
-		this._hammer.off('hammer.input', L.bind(window.touch.touchOnly(this._onHammer), this));
-		this._hammer.off('tap', L.bind(window.touch.touchOnly(this._onTap), this));
-		this._hammer.off('panstart', L.bind(window.touch.touchOnly(this._onPanStart), this));
-		this._hammer.off('pan', L.bind(window.touch.touchOnly(this._onPan), this));
-		this._hammer.off('panend', L.bind(window.touch.touchOnly(this._onPanEnd), this));
-		this._hammer.off('pinchstart', L.bind(window.touch.touchOnly(this._onPinchStart), this));
-		this._hammer.off('pinchmove', L.bind(window.touch.touchOnly(this._onPinch), this));
-		this._hammer.off('pinchend', L.bind(window.touch.touchOnly(this._onPinchEnd), this));
-		this._hammer.off('doubletap', L.bind(window.touch.touchOnly(this._onDoubleTap), this));
-		this._hammer.off('press', L.bind(window.touch.touchOnly(this._onPress), this));
-		this._hammer.off('tripletap', L.bind(window.touch.touchOnly(this._onTripleTap), this));
-		this._hammer.off('swipe', L.bind(window.touch.touchOnly(this._onSwipe), this));
+		this._hammer.off('hammer.input', window.memo.bind(window.touch.touchOnly(this._onHammer), this));
+		this._hammer.off('tap', window.memo.bind(window.touch.touchOnly(this._onTap), this));
+		this._hammer.off('panstart', window.memo.bind(window.touch.touchOnly(this._onPanStart), this));
+		this._hammer.off('pan', window.memo.bind(window.touch.touchOnly(this._onPan), this));
+		this._hammer.off('panend', window.memo.bind(window.touch.touchOnly(this._onPanEnd), this));
+		this._hammer.off('pinchstart', window.memo.bind(window.touch.touchOnly(this._onPinchStart), this));
+		this._hammer.off('pinchmove', window.memo.bind(window.touch.touchOnly(this._onPinch), this));
+		this._hammer.off('pinchend', window.memo.bind(window.touch.touchOnly(this._onPinchEnd), this));
+		this._hammer.off('doubletap', window.memo.bind(window.touch.touchOnly(this._onDoubleTap), this));
+		this._hammer.off('press', window.memo.bind(window.touch.touchOnly(this._onPress), this));
+		this._hammer.off('tripletap', window.memo.bind(window.touch.touchOnly(this._onTripleTap), this));
+		this._hammer.off('swipe', window.memo.bind(window.touch.touchOnly(this._onSwipe), this));
 		this._map.off('updatepermission', this._onPermission, this);
 	},
 
 	_onPermission: function (e) {
 		if (e.perm == 'edit') {
-			this._hammer.on('doubletap', L.bind(window.touch.touchOnly(this._onDoubleTap), this));
-			this._hammer.on('press', L.bind(window.touch.touchOnly(this._onPress), this));
+			this._hammer.on('doubletap', window.memo.bind(window.touch.touchOnly(this._onDoubleTap), this));
+			this._hammer.on('press', window.memo.bind(window.touch.touchOnly(this._onPress), this));
 		} else {
-			this._hammer.off('doubletap', L.bind(window.touch.touchOnly(this._onDoubleTap), this));
-			this._hammer.off('press', L.bind(window.touch.touchOnly(this._onPress), this));
+			this._hammer.off('doubletap', window.memo.bind(window.touch.touchOnly(this._onDoubleTap), this));
+			this._hammer.off('press', window.memo.bind(window.touch.touchOnly(this._onPress), this));
 		}
 	},
 

--- a/cypress_test/integration_tests/common/mobile_helper.js
+++ b/cypress_test/integration_tests/common/mobile_helper.js
@@ -48,7 +48,7 @@ function longPressOnDocument(posX, posY) {
 			var eventOptions = {
 				force: true,
 				button: 0,
-				pointerType: 'touch',
+				pointerType: 'mouse',
 				x: posX - items[0].getBoundingClientRect().left,
 				y: posY - items[0].getBoundingClientRect().top
 			};
@@ -348,7 +348,7 @@ function deleteImage() {
 	var eventOptions = {
 		force: true,
 		button: 0,
-		pointerType: 'touch'
+		pointerType: 'mouse'
 	};
 
 	cy.cGet('.leaflet-control-buttons-disabled > .leaflet-interactive')

--- a/cypress_test/integration_tests/mobile/calc/delete_objects_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/delete_objects_spec.js
@@ -11,7 +11,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Delete Objects',function() 
 	var eventOptions = {
 		force: true,
 		button: 0,
-		pointerType: 'touch'
+		pointerType: 'mouse'
 	};
 
 	beforeEach(function() {

--- a/cypress_test/integration_tests/mobile/calc/image_operation_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/image_operation_spec.js
@@ -28,7 +28,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Image Operation Tests', fun
 		var eventOptions = {
 			force: true,
 			button: 0,
-			pointerType: 'touch'
+			pointerType: 'mouse'
 		};
 
 		cy.cGet('.bottomright-svg-pane > .leaflet-control-buttons-disabled > .leaflet-interactive')

--- a/cypress_test/integration_tests/mobile/calc/sheet_operation_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/sheet_operation_spec.js
@@ -25,7 +25,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Sheet Operation', function 
 		var eventOptions = {
 			force: true,
 			button: 0,
-			pointerType: 'touch'
+			pointerType: 'mouse'
 		};
 
 		cy.cGet('.spreadsheet-tab.spreadsheet-tab-selected')

--- a/cypress_test/integration_tests/mobile/impress/delete_objects_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/delete_objects_spec.js
@@ -10,7 +10,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Delete Objects', function()
 	var eventOptions = {
 		force: true,
 		button: 0,
-		pointerType: 'touch'
+		pointerType: 'mouse'
 	};
 
 	beforeEach(function() {

--- a/cypress_test/integration_tests/mobile/writer/delete_objects_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/delete_objects_spec.js
@@ -10,7 +10,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Delete Objects', function()
 	var eventOptions = {
 		force: true,
 		button: 0,
-		pointerType: 'touch'
+		pointerType: 'mouse'
 	};
 
 	beforeEach(function() {


### PR DESCRIPTION
Touch unification (https://github.com/CollaboraOnline/online/commit/b3bff28bede07a48cdecefcda14a6fc9da86e4bb, change ID
I9016fc15ad3ccb3664af348fdcdca006495b0778) was a rework of the input
system to better support touch devices, but unfortunately it caused some
fairly serious regressions. This commit fixes the following:
- Triple/Quadruple clicking was no longer recognized on non-touch
  devices.
- There were some issues recognizing wrapped events
- Pens were considered to be touch devices, but this broke some
  remote/virtual machine setups. It's possible that this change will
  cause a regression for apple pencil users. I plan to get an Apple
  pencil to test whether preventing pens from being touch devices breaks
  the Apple pencil workflow instead
- manualDrag was taken to mean "is on a touch device". This is only
  almost true, causing some input to be incorrectly ingnored when it was
  not
- manualDrag and _manualDrag were confused. They affect different
  things, and we now recognize this

A second followup may be needed to fix the two instances of `this.dragging.disable`. One of them was present from the initial unification commit, the other was not. I don't know what issue they cause, and I expect this will take an amount of work that puts it out-of-scope for this commit.