### PR TITLE
calc: select whole row/column on mouse drag

### DIFF
--- a/browser/src/control/Control.ColumnHeader.ts
+++ b/browser/src/control/Control.ColumnHeader.ts
@@ -251,15 +251,7 @@ export class ColumnHeader extends Header {
 		super.onMouseUp();
 
 		if (!(this.containerObject.isDraggingSomething() && this._dragEntry)) {
-			const entry = this._mouseOverEntry;
-			let modifier = 0;
-
-			if (entry && this._startSelectionEntry && this._startSelectionEntry.index !== entry.index) {
-				this._selectColumn(this._startSelectionEntry.index, modifier);
-				modifier += UNOModifier.SHIFT;
-				this._selectColumn(entry.index, modifier);
-			}
-
+			this._lastSelectedIndex = null;
 			this._startSelectionEntry = null;
 		}
 	}
@@ -296,6 +288,10 @@ export class ColumnHeader extends Header {
 
 	_getOrthogonalPos (point: cool.Point): number {
 		return point.y;
+	}
+
+	selectIndex(index: number, modifier: number): void {
+		this._selectColumn(index, modifier);
 	}
 }
 

--- a/browser/src/control/Control.Header.ts
+++ b/browser/src/control/Control.Header.ts
@@ -34,6 +34,7 @@ export class Header extends CanvasSectionObject {
 	_dragEntry: HeaderEntryData;
 	_mouseOverEntry: HeaderEntryData;
 	_startSelectionEntry: HeaderEntryData;
+	_lastSelectedIndex: number;
 	_hitResizeArea: boolean;
 	_menuItem: any;
 	_dragDistance: number[];
@@ -543,7 +544,17 @@ export class Header extends CanvasSectionObject {
 		else { // We are in dragging mode.
 			this._dragDistance = dragDistance;
 			this.containerObject.requestReDraw(); // Remove previously drawn line and paint a new one.
+
+			if (this._lastSelectedIndex == this._mouseOverEntry.index)
+				return;
+			const modifier = this._lastSelectedIndex ? UNOModifier.SHIFT : 0;
+			this._lastSelectedIndex = this._mouseOverEntry.index;
+			this.selectIndex(this._mouseOverEntry.index, modifier);
 		}
+	}
+
+	selectIndex(index: number, modifier: number): void {
+		return;
 	}
 
 	setOptimalWidthAuto(): void {
@@ -579,6 +590,7 @@ export class Header extends CanvasSectionObject {
 		}
 
 		this._startSelectionEntry = this._mouseOverEntry;
+		this._lastSelectedIndex = null;
 	}
 
 	onMouseUp(): void {

--- a/browser/src/control/Control.RowHeader.ts
+++ b/browser/src/control/Control.RowHeader.ts
@@ -239,15 +239,7 @@ export class RowHeader extends cool.Header {
 		super.onMouseUp();
 
 		if (!(this.containerObject.isDraggingSomething() && this._dragEntry)) {
-			const entry = this._mouseOverEntry;
-			let modifier = 0;
-
-			if (entry && this._startSelectionEntry && this._startSelectionEntry.index !== entry.index) {
-				this._selectRow(this._startSelectionEntry.index, modifier);
-				modifier += UNOModifier.SHIFT;
-				this._selectRow(entry.index, modifier);
-			}
-
+			this._lastSelectedIndex = null;
 			this._startSelectionEntry = null;
 		}
 	}
@@ -284,6 +276,10 @@ export class RowHeader extends cool.Header {
 
 	_getOrthogonalPos (point: cool.Point): number {
 		return point.x;
+	}
+
+	selectIndex(index: number, modifier: number): void {
+		this._selectRow(index, modifier);
 	}
 }
 


### PR DESCRIPTION
problem:
In Calc click on a row header and drag the mouse. The selection does not follow the mouse, selection only appears when you release the mouse button


Change-Id: I510f35d9f61fca63a619e83c04ff340f9578f5d2


* Target version: master 



### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

