### PR TITLE
chart-releaser: fix 422 Validation Failed

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -35,6 +35,7 @@ jobs:
         uses: helm/chart-releaser-action@v1
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_SKIP_EXISTING: true
         with:
           charts_dir: "kubernetes/helm"
           config: kubernetes/helm/cr.yaml

--- a/kubernetes/helm/collabora-online/Chart.yaml
+++ b/kubernetes/helm/collabora-online/Chart.yaml
@@ -4,8 +4,8 @@ type: "application"
 name: collabora-online
 description: Collabora Online helm chart
 
-version: 1.1.6
-appVersion: "23.05.5.5.1"
+version: 1.1.5
+appVersion: "23.05.5.4.1"
 
 home: "https://www.collaboraoffice.com/code/"
 icon: "https://avatars0.githubusercontent.com/u/22418908?s=200&v=4"
@@ -35,7 +35,7 @@ maintainers:
 annotations:
   artifacthub.io/images: |
     - name: collabora
-      image: docker.io/collabora/code:23.05.5.5.1
+      image: docker.io/collabora/code:23.05.5.4.1
     - name: nginx
       image: docker.io/nginx:1.25
     - name: twostoryrobot/simple-file-upload


### PR DESCRIPTION
- from the logs Error: error creating GitHub release helm-collabora-online-1.1.5: POST https://api.github.com/repos/CollaboraOnline/online/releases: 422 Validation Failed [{Resource:Release Field:tag_name Code:already_exists Message:}]


Change-Id: I7b10e972564eae2cd6ad2146470d16fd05401361

* Target version: master 
