### PR TITLE
formulabar: select formulas on mouseleave event

### DIFF
--- a/browser/src/control/jsdialog/Widget.FormulabarEdit.js
+++ b/browser/src/control/jsdialog/Widget.FormulabarEdit.js
@@ -230,7 +230,7 @@ function _formulabarEditControl(parentContainer, data, builder) {
 		textLayer.setAttribute('contenteditable', 'false');
 	};
 
-	['click', 'dblclick'].forEach(function (ev) {
+	['click', 'dblclick', 'mouseleave'].forEach(function (ev) {
 		textLayer.addEventListener(ev, function(event) {
 			if (L.DomUtil.hasClass(container, 'disabled')) {
 				event.preventDefault();
@@ -250,6 +250,8 @@ function _formulabarEditControl(parentContainer, data, builder) {
 
 	// hide old selection when user starts to select something else
 	textLayer.addEventListener('mousedown', function() {
+		builder.callback('edit', 'grab_focus', container, null, builder);
+
 		cursorLayer.querySelectorAll('.selection').forEach(function (element) {
 			L.DomUtil.addClass(element, 'hidden');
 		});


### PR DESCRIPTION
problem:
In a spreadsheet, click on a cell with content,
In the formula bar, select the content in a way that the mouse key is lifted outside the edit field Note how the formula bar doesn't get into edit mode, but you can still edit the content


Change-Id: Ib4f193b897d57e0ffa9c3bfdd598e0c3c4201195

* Target version: master 


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

