### PR TITLE
annotation: avoid checking uninitialized comment for editing

### DIFF
--- a/browser/src/layer/tile/CommentSection.ts
+++ b/browser/src/layer/tile/CommentSection.ts
@@ -935,8 +935,9 @@ export class Comment extends CanvasSectionObject {
 		for (var i in commentList) {
 			var modifyNode = commentList[i].sectionProperties.nodeModify;
 			var replyNode = commentList[i].sectionProperties.nodeReply;
-			if ((modifyNode && modifyNode.style.display !== 'none') ||
-				(replyNode && replyNode.style.display !== 'none'))
+			if (!commentList[i].pendingInit &&
+				((modifyNode && modifyNode.style.display !== 'none') ||
+				(replyNode && replyNode.style.display !== 'none')))
 				return true;
 		}
 		return false;


### PR DESCRIPTION
problem:
Uninitialized comments don't have properties set,
which made them seem like comments are being edited. This caused problem when checked if any comments are being edited, and couldn't unselect comments sometimes


Change-Id: I22a465627d361cb3fe42fb69e9c197f0b0e69755


* Target version: master 

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

