### PR TITLE
Revert "Update index.yaml"

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -4,46 +4,6 @@ entries:
   - annotations:
       artifacthub.io/images: |
         - name: collabora
-          image: docker.io/collabora/code:23.05.5.5.1
-        - name: nginx
-          image: docker.io/nginx:1.25
-        - name: twostoryrobot/simple-file-upload
-          image: docker.io/twostoryrobot/simple-file-upload@sha256:547fc4360b31d8604b7a26202914e87cd13609cc938fd83f412c77eb44aa1cc4
-    apiVersion: v2
-    appVersion: 23.05.5.5.1
-    created: "2023-11-24T06:16:16.567686188Z"
-    description: Collabora Online helm chart
-    digest: 6c177e3eb457aeb912084bcab5745953b4b26138fd27234eab2ace98f01dbb5a
-    home: https://www.collaboraoffice.com/code/
-    icon: https://avatars0.githubusercontent.com/u/22418908?s=200&v=4
-    keywords:
-    - collabora-online
-    - collabora
-    - code
-    - nextcloud
-    - office
-    maintainers:
-    - email: k.erber@erber-freelance.de
-      name: Klaus Erber
-      url: https://www.erber-freelance.de/
-    - email: martin.mueller@dataport.de
-      name: Martin Müller
-      url: https://dphoenixsuite.de
-    - email: geno+dev@fireorbit.de
-      name: Geno
-      url: https://fireorbit.de
-    name: collabora-online
-    sources:
-    - https://github.com/CollaboraOnline/online
-    - https://github.com/CollaboraOnline/online/tree/master/docker
-    - https://github.com/CollaboraOnline/online/tree/master/kubernetes/helm/collabora-online
-    type: application
-    urls:
-    - https://github.com/CollaboraOnline/online/releases/download/helm-collabora-online-1.1.6/collabora-online-1.1.6.tgz
-    version: 1.1.6
-  - annotations:
-      artifacthub.io/images: |
-        - name: collabora
           image: docker.io/collabora/code:23.05.5.4.1
         - name: nginx
           image: docker.io/nginx:1.25
@@ -351,4 +311,4 @@ entries:
     urls:
     - https://github.com/CollaboraOnline/online/releases/download/helm-collabora-online-1.0.1/collabora-online-1.0.1.tgz
     version: 1.0.1
-generated: "2023-11-24T06:16:16.567727495Z"
+generated: "2023-11-12T22:33:23.883604851Z"


### PR DESCRIPTION
- unnecessary release of chart before even code changes are released

This reverts commit dd2b6178fcc3d4285930b15879d8b4530bdd2337.


* Resolves: # <!-- related github issue -->
* Target version: master 

