### PR TITLE
postmessage: Add a show/hide command

### DIFF
--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -2271,6 +2271,51 @@ L.Control.Menubar = L.Control.extend({
 		}
 	},
 
+	_getItemsForCommand: function(commandId) {
+		var items = this._getItems();
+		var found = $(items).filter(function() {
+			var item = $(this.children[0]);
+			var type = item.data('type');
+			var id = null;
+			if (type == 'unocommand') {
+				id = $(item).data('uno');
+			} else if (type == 'action') {
+				id = $(item).data('id');
+			}
+			if (id && id == commandId) {
+				return true;
+			}
+			return false;
+		});
+		return found.length ? found : null;
+	},
+
+	hideUnoItem: function(targetId) {
+		var items = this._getItemsForCommand(targetId);
+		var menubar = this;
+		if (items) {
+			$(items).each(function() {
+				if ($.inArray(this.id, menubar._hiddenItems) == -1) {
+					menubar._hiddenItems.push(this.id);
+				}
+			});
+			$(items).css('display', 'none');
+		}
+	},
+
+	showUnoItem: function(targetId) {
+		var items = this._getItemsForCommand(targetId);
+		var menubar = this;
+		if (items) {
+			$(items).each(function() {
+				if ($.inArray(this.id, menubar._hiddenItems) !== -1) {
+					menubar._hiddenItems.splice(menubar._hiddenItems.indexOf(this.id), 1);
+				}
+			});
+			$(items).css('display', '');
+		}
+	},
+
 	_initializeMenu: function(menu) {
 		this._isFileODF = L.LOUtil.isFileODF(this._map);
 		var menuHtml = this._createMenu(menu);

--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -282,6 +282,17 @@ L.Control.Notebookbar = L.Control.extend({
 
 		for (var j in toolitems) {
 			item = toolitems[j];
+			var hidden = false;
+			var commands = this.map._extractCommand(item);
+			commands.forEach(function(command) {
+				if (!this.map.uiManager.isCommandVisible(command)) {
+					toolitems.splice(j, 1);
+					hidden = true;
+				}
+			}.bind(this));
+			if (hidden) {
+				break;
+			}
 			if (!this.map.uiManager.isButtonVisible(item.id)) {
 				toolitems.splice(j, 1);
 				break;
@@ -325,6 +336,21 @@ L.Control.Notebookbar = L.Control.extend({
 
 	showNotebookbarButton: function(buttonId, show) {
 		var button = $('.notebookbar-scroll-wrapper #' + buttonId);
+		if (show) {
+			button.show();
+		} else {
+			button.hide();
+		}
+	},
+
+        showNotebookbarCommand: function(commandId, show) {
+		var cssClass;
+		if (commandId.indexOf('.uno:') == 0) {
+			cssClass = 'uno' + commandId.substring(5);
+		} else {
+			cssClass = commandId;
+		}
+		var button = $('.notebookbar-scroll-wrapper div.' + cssClass);
 		if (show) {
 			button.show();
 		} else {

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -2889,6 +2889,9 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 			if (!uiManager.isButtonVisible(c.id)) {
 				return null;
 			}
+			if (!uiManager.isCommandVisible(c.command)) {
+				return null;
+			}
 
 			var opts = Object.assign(c, {});
 

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -18,6 +18,7 @@ L.Control.UIManager = L.Control.extend({
 	busyPopupTimer: null,
 	customButtons: [], // added by WOPI InsertButton
 	hiddenButtons: {},
+	hiddenCommands: {},
 	previousTheme: null,
 
 	onAdd: function (map) {
@@ -676,6 +677,62 @@ L.Control.UIManager = L.Control.extend({
 
 	isButtonVisible: function(buttonId) {
 		return !(buttonId in this.hiddenButtons);
+	},
+
+	// Commands
+
+	showCommandInMenubar: function(command, show) {
+		var menubar = this._map.menubar;
+		if (show) {
+			menubar.showUnoItem(command);
+		} else {
+			menubar.hideUnoItem(command);
+		}
+	},
+
+	showCommandInClassicToolbar: function(command, show) {
+		var toolbars = [w2ui['toolbar-up'], w2ui['actionbar'], w2ui['editbar']];
+		var found = false;
+
+		toolbars.forEach(function(toolbar) {
+			if (!toolbar)
+				return;
+			toolbar.items.forEach(function(item) {
+				var commands = this.map._extractCommand(item);
+				if (commands.indexOf(command) != -1) {
+					found = true;
+					if (show) {
+						toolbar.show(item.id);
+					} else {
+						toolbar.hide(item.id);
+					}
+				}
+			}.bind(this));
+		}.bind(this));
+
+		if (!found) {
+			window.app.console.error('Toolbar item with command "' + command + '" not found.');
+			return;
+		}
+	},
+
+	showCommand: function(command, show) {
+		if (show) {
+			delete this.hiddenCommands[command];
+		} else {
+			this.hiddenCommands[command] = true;
+		}
+		if (!this.notebookbar) {
+			this.showCommandInClassicToolbar(command, show);
+			this.showCommandInMenubar(command, show);
+		} else {
+			this.notebookbar.reloadShortcutsBar();
+			this.notebookbar.showNotebookbarCommand(command, show);
+		}
+	},
+
+	isCommandVisible: function(command) {
+		return !(command in this.hiddenCommands);
 	},
 
 	// Menubar

--- a/browser/src/map/handler/Map.WOPI.js
+++ b/browser/src/map/handler/Map.WOPI.js
@@ -274,6 +274,20 @@ L.Map.WOPI = L.Handler.extend({
 			this._map.uiManager.showButton(msg.Values.id, show);
 			return;
 		}
+		else if (msg.MessageId === 'Show_Command' || msg.MessageId === 'Hide_Command') {
+			if (!msg.Values) {
+				window.app.console.error('Property "Values" not set');
+				return;
+			}
+
+			if (!msg.Values.id) {
+				window.app.console.error('Property "Values.id" not set');
+				return;
+			}
+			var show = msg.MessageId === 'Show_Command';
+			this._map.uiManager.showCommand(msg.Values.id, show);
+			return;
+		}
 		else if (msg.MessageId === 'Remove_Statusbar_Element') {
 			if (!msg.Values) {
 				window.app.console.error('Property "Values" not set');


### PR DESCRIPTION
Change-Id: Idaa86f7a936a282c636fa0532ab165c6977db873


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

postmessage: Add a show/hide command
    
New postmessage `Show_Command` and `Hide_Command`.
Pass a command name (uno or otherwise) in `Values.id`.
    
Will hide the corresponding toolbar, menu and notebookbar items.

### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

