### PR TITLE
jsdialog: close dropdown properly

### DIFF
--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -212,8 +212,11 @@ L.Control.JSDialog = L.Control.extend({
 		if (!overlay) {
 			overlay = L.DomUtil.create('div', 'jsdialog-overlay ' + (instance.cancellable && !instance.hasOverlay ? 'cancellable' : ''), instance.containerParent);
 			overlay.id = instance.id + '-overlay';
-			if (instance.cancellable)
-				overlay.onclick = function () { this.close(instance.id, true); }.bind(this);
+			if (instance.cancellable) {
+				// dropdowns are online-only components, don't exist in core
+				var hasToNotifyServer = !instance.isDropdown;
+				overlay.onclick = function () { this.close(instance.id, hasToNotifyServer); }.bind(this);
+			}
 		}
 		instance.overlay = overlay;
 	},

--- a/cypress_test/integration_tests/desktop/calc/jsdialog_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/jsdialog_spec.js
@@ -40,4 +40,18 @@ describe(['tagdesktop'], 'JSDialog unit test', function() {
 				expect(fnClosePopup).to.be.called;
 			});
 	});
+
+	it('JSDialog dropdown', function() {
+		// Open conditional format menu
+		cy.cGet('#toolbar-up .w2ui-scroll-right').click();
+		cy.cGet('#toolbar-up .w2ui-scroll-right').click();
+		cy.cGet('#toolbar-up #home-conditional-format-menu-button').click();
+
+		// Click on overlay to close
+		cy.cGet('.jsdialog-overlay').click();
+
+		// Dropdown should be closed
+		cy.cGet('.jsdialog-overlay').should('not.exist');
+		cy.cGet('#home-conditional-format-menu-dropdown').should('not.exist');
+	});
 });


### PR DESCRIPTION
Make sure we don't expect response from server for online-only component: dropdown which doesn't have corresponding widget in the core

fixes regression on close from:
commit a23adac78c34d3ea1717954fcab1a3caaeef0bbb
browser: fix undefined property 'isPopup'