### PR TITLE
use of gseparate-dwarf can block some optimizations

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -487,10 +487,15 @@ $(DIST_FOLDER)/soffice%: $(abs_top_builddir)/wasm/soffice%
 WASM_FILES= \
 	$(DIST_FOLDER)/online.js \
 	$(DIST_FOLDER)/online.wasm \
-	$(DIST_FOLDER)/online.wasm.debug.wasm \
 	$(DIST_FOLDER)/online.worker.js \
 	$(DIST_FOLDER)/soffice.data \
 	$(DIST_FOLDER)/soffice.data.js.metadata
+
+if ENABLE_DEBUG
+WASM_FILES += \
+	$(DIST_FOLDER)/online.wasm.debug.wasm
+endif
+
 endif
 
 $(TYPESCRIPT_JS_DIR)/%.js: $(srcdir)/%.ts

--- a/wasm/Makefile.am
+++ b/wasm/Makefile.am
@@ -68,8 +68,12 @@ online_LDADD = \
 # TODO these are just copypasta from core
 online_LDFLAGS = \
 	-pthread -s MODULARIZE -s EXPORT_NAME=createOnlineModule -s USE_PTHREADS=1 -s TOTAL_MEMORY=1GB -s PTHREAD_POOL_SIZE=15 --bind -s FORCE_FILESYSTEM=1 -s WASM_BIGINT=1 -s ERROR_ON_UNDEFINED_SYMBOLS=1 -s FETCH=1 -s ASSERTIONS=1 -s EXIT_RUNTIME=0 -s EXPORTED_RUNTIME_METHODS=["UTF16ToString","stringToUTF16","UTF8ToString","allocateUTF8","ccall","cwrap","FS"] -pthread -s USE_PTHREADS=1 -s DISABLE_EXCEPTION_CATCHING=0 -s EXPORTED_FUNCTIONS=["_main","_libreofficekit_hook","_libreofficekit_hook_2","_lok_preinit","_lok_preinit_2","_handle_cool_message"] \
-	-gseparate-dwarf \
 	--pre-js @LOBUILDDIR@/workdir/CustomTarget/static/emscripten_fs_image/soffice.data.js.link
+
+if ENABLE_DEBUG
+online_LDFLAGS += \
+	-gseparate-dwarf
+endif
 
 if ENABLE_WASM_ADDITIONAL_FILES
 online_LDFLAGS += \


### PR DESCRIPTION
The warning is:

em++: warning: running limited binaryen optimizations because DWARF info requested (or indirectly required) [-Wlimited-postlink-optimizations]

With an non-debugging build dropping gseparate-dwarf for online.wasm gives an approx 13M saving.

And leave gseparate-dwarf  enabled for debugging builds

* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

