### PR TITLE
Bug: When a parent comment is removed, child comment is disabled.

### DIFF
--- a/browser/src/layer/tile/CommentListSection.ts
+++ b/browser/src/layer/tile/CommentListSection.ts
@@ -234,8 +234,8 @@ export class CommentSection extends CanvasSectionObject {
 		var openArray = [];
 
 		for (var i = 0; i < this.sectionProperties.commentList.length; i++) {
-			openArray.push(this.sectionProperties.commentList[i]);
-			if (this.sectionProperties.commentList[i].sectionProperties.data.parentId === '0') {
+			if (this.sectionProperties.commentList[i].sectionProperties.data.parent === '0') {
+				openArray.push(this.sectionProperties.commentList[i]);
 				if (this.sectionProperties.commentList[i].sectionProperties.children.length > 0)
 					this.getChildren(this.sectionProperties.commentList[i], openArray);
 			}
@@ -1123,10 +1123,20 @@ export class CommentSection extends CanvasSectionObject {
 	public adjustParentRemove (comment: any): void {
 		var parentIdx = this.getIndexOf(comment.sectionProperties.data.parent);
 
+		// If a child comment is removed.
 		var parentComment = this.sectionProperties.commentList[parentIdx];
-		if (parentComment && parentComment.sectionProperties.children.includes(comment.sectionProperties.data.id)) {
-			var index = parentComment.sectionProperties.children.indexOf(comment.sectionProperties.data.id);
+		if (parentComment && parentComment.sectionProperties.children.includes(comment)) {
+			var index = parentComment.sectionProperties.children.indexOf(comment);
 			parentComment.sectionProperties.children.splice(index, 1);
+		}
+
+		// If a parent comment is removed.
+		for (var i = 0; i < comment.sectionProperties.children.length; i++) {
+			if (comment.sectionProperties.children[i]) {
+				comment.sectionProperties.children[i].sectionProperties.data.parent = '0';
+				if (this.sectionProperties.docLayer._docType === 'text')
+					comment.sectionProperties.children[i].sectionProperties.data.parentId = '0';
+			}
 		}
 	}
 
@@ -1141,7 +1151,7 @@ export class CommentSection extends CanvasSectionObject {
 
 		if (!changetrack && obj.comment.parent === undefined) {
 			if (obj.comment.parentId)
-				obj.comment.parent = obj.comment.parentId;
+				obj.comment.parent = String(obj.comment.parentId);
 			else
 				obj.comment.parent = '0';
 		}
@@ -1677,14 +1687,18 @@ export class CommentSection extends CanvasSectionObject {
 	// Returns the sub-root comment index of given id
 	private getSubRootIndexOf (id: any): number {
 		var index = this.getIndexOf(id);
-		var comment = this.sectionProperties.commentList[index];
-		var parentId = comment.sectionProperties.data.parent;
 
-		while (index >= 0) {
-			if (this.sectionProperties.commentList[index].sectionProperties.data.id !== parentId && this.sectionProperties.commentList[index].sectionProperties.data.parent !== '0')
-				index--;
-			else
-				break;
+		if (index !== -1)
+		{
+			var comment = this.sectionProperties.commentList[index];
+			var parentId = comment.sectionProperties.data.parent;
+
+			while (index >= 0) {
+				if (this.sectionProperties.commentList[index].sectionProperties.data.id !== parentId && this.sectionProperties.commentList[index].sectionProperties.data.parent !== '0')
+					index--;
+				else
+					break;
+			}
 		}
 
 		return index;

--- a/browser/src/layer/tile/CommentListSection.ts
+++ b/browser/src/layer/tile/CommentListSection.ts
@@ -234,7 +234,7 @@ export class CommentSection extends CanvasSectionObject {
 		var openArray = [];
 
 		for (var i = 0; i < this.sectionProperties.commentList.length; i++) {
-			if (this.sectionProperties.commentList[i].sectionProperties.data.parent === '0') {
+			if (this.sectionProperties.commentList[i].isRootComment()) {
 				openArray.push(this.sectionProperties.commentList[i]);
 				if (this.sectionProperties.commentList[i].sectionProperties.children.length > 0)
 					this.getChildren(this.sectionProperties.commentList[i], openArray);
@@ -254,7 +254,7 @@ export class CommentSection extends CanvasSectionObject {
 		}
 
 		for (var i = 0; i < commentList.length; i++) {
-			if (commentList[i].sectionProperties.data.parent === '0' || commentList[i].sectionProperties.data.trackchange) {
+			if (commentList[i].isRootComment() || commentList[i].sectionProperties.data.trackchange) {
 				var commentThread = [];
 				do {
 					comment = {
@@ -464,7 +464,7 @@ export class CommentSection extends CanvasSectionObject {
 		while (true && lastChild >= 0) {
 			commentList[lastChild].highlight();
 
-			if (commentList[lastChild].sectionProperties.data.parent === '0')
+			if (commentList[lastChild].isRootComment())
 				break;
 
 			lastChild = this.getIndexOf(commentList[lastChild].sectionProperties.data.parent);
@@ -1121,22 +1121,21 @@ export class CommentSection extends CanvasSectionObject {
 
 	// Adjust parent-child relationship, if required, after `comment` is removed
 	public adjustParentRemove (comment: any): void {
-		var parentIdx = this.getIndexOf(comment.sectionProperties.data.parent);
+		var parentIdx = this.getIndexOf(comment.getParentCommentId());
 
 		// If a child comment is removed.
 		var parentComment = this.sectionProperties.commentList[parentIdx];
-		if (parentComment && parentComment.sectionProperties.children.includes(comment)) {
-			var index = parentComment.sectionProperties.children.indexOf(comment);
-			parentComment.sectionProperties.children.splice(index, 1);
+		if (parentComment) {
+			var index = parentComment.getIndexOfChild(comment);
+			if (index >= 0)
+				parentComment.removeChildByIndex(index); // Removed comment has a parent. Remove the comment also from its parent's list.
 		}
 
 		// If a parent comment is removed.
-		for (var i = 0; i < comment.sectionProperties.children.length; i++) {
-			if (comment.sectionProperties.children[i]) {
-				comment.sectionProperties.children[i].sectionProperties.data.parent = '0';
-				if (this.sectionProperties.docLayer._docType === 'text')
-					comment.sectionProperties.children[i].sectionProperties.data.parentId = '0';
-			}
+		for (var i = 0; i < comment.getChildrenLength(); i++) { // Loop over removed comment's children.
+			var childComment = comment.getChildByIndex(i);
+			if (childComment)
+				childComment.setAsRootComment(); // The children have no parent comment any more.
 		}
 	}
 
@@ -1650,7 +1649,7 @@ export class CommentSection extends CanvasSectionObject {
 			var comment = this.sectionProperties.commentList[i];
 			var replyCount = 0;
 
-			if (comment && comment.sectionProperties.data.parent === '0') {
+			if (comment && comment.isRootComment()) {
 				var lastIndex = this.getLastChildIndexOf(comment.sectionProperties.data.id);
 				var j = i;
 				while (this.sectionProperties.commentList[j] && j <= lastIndex) {
@@ -1817,7 +1816,7 @@ export class CommentSection extends CanvasSectionObject {
 		for (var i = 0; i < this.sectionProperties.commentList.length; i++) {
 			var comment = this.sectionProperties.commentList[i];
 
-			if (comment.sectionProperties.data.parent === '0') {
+			if (comment.isRootComment()) {
 				newOrder.push(comment);
 
 				if (comment.sectionProperties.children.length > 0)

--- a/browser/src/layer/tile/CommentSection.ts
+++ b/browser/src/layer/tile/CommentSection.ts
@@ -1228,6 +1228,7 @@ export class Comment extends CanvasSectionObject {
 		this.show();
 
 		if (this.isRootComment() || this.sectionProperties.docLayer._docType === 'presentation' || this.sectionProperties.docLayer._docType === 'drawing') {
+			this.sectionProperties.container.style.display = '';
 			this.sectionProperties.container.style.visibility = 'hidden';
 
 			if (this.sectionProperties.docLayer._docType === 'text') {

--- a/browser/src/layer/tile/CommentSection.ts
+++ b/browser/src/layer/tile/CommentSection.ts
@@ -1214,8 +1214,41 @@ export class Comment extends CanvasSectionObject {
 		}
 	}
 
-	private isRootComment() {
+	public isRootComment() {
 		return this.sectionProperties.data.parent === '0';
+	}
+
+	public setAsRootComment() {
+		this.sectionProperties.data.parent = '0';
+		if (this.sectionProperties.docLayer._docType === 'text')
+			this.sectionProperties.data.parentId = '0';
+	}
+
+	public getChildrenLength() {
+		return this.sectionProperties.children.length;
+	}
+
+	public getChildByIndex(index: number) {
+		if (this.sectionProperties.children.length > index)
+			return this.sectionProperties.children[index];
+		else
+			return null;
+	}
+
+	public removeChildByIndex(index: number) {
+		if (this.sectionProperties.children.length > index)
+			this.sectionProperties.children.splice(index, 1);
+	}
+
+	public getParentCommentId() {
+		if (this.sectionProperties.data.parent && this.sectionProperties.data.parent !== '0')
+			return this.sectionProperties.data.parent;
+		else
+			return null;
+	}
+
+	public getIndexOfChild(comment: Comment) {
+		return this.sectionProperties.children.indexOf(comment);
 	}
 
 	public setCollapsed(): void {


### PR DESCRIPTION
When a parent comment is removed, child comment is disabled.

* When a parent comment is removed, the children of that comment are not informed.
* We have adjustParentRemove function. ** Function wasn't handling the "parent is removed" case. ** Function was handling the "child is removed" case in a wrong way. Children list has pointers, not indexes.

* When a parent is removed, child wasn't shown. Now we re-set the display property in case it was set to 'none' before.

* getSubRootIndexOf function was trying to continue with index=-1.

On mobile, a reply was added twice, fixed.


Change-Id: Id8f95bbe1cb78bf93bf35fe73a6e86203455691c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

