### PR TITLE
Initialize parent for red lines.

### DIFF
--- a/browser/src/layer/tile/CommentListSection.ts
+++ b/browser/src/layer/tile/CommentListSection.ts
@@ -1074,6 +1074,7 @@ export class CommentSection extends CanvasSectionObject {
 
 		// transform change tracking index into an id
 		redline.id = 'change-' + redline.index;
+		redline.parent = '0'; // Redlines don't have parents, we need to specify this for consistency.
 		redline.anchorPos = this.stringToRectangles(redline.textRange)[0];
 		redline.anchorPix = this.numberArrayToCorePixFromTwips(redline.anchorPos, 0, 2);
 		redline.trackchange = true;


### PR DESCRIPTION
Lack of "parent" property was causing inconsistent behaviour for redlines.

Change-Id: Iaa2424aeee160a9b28d6b0a29b456ddbc3a1b620


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

