### PR TITLE
typically contemporary browsers don't cache files over 50M by default

### DIFF
--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -711,6 +711,8 @@ void FileServerRequestHandler::handleRequest(const HTTPRequest& request,
                         << "compressed : file [" << relPath << "]: " << response.header());
 
             socket->send(response);
+            if (content->size() > 50L * 1024 * 1024)
+                LOG_WRN("Serving oversized file: " << relPath << " which is larger than the typical browser 50M max file cache size");
             socket->send(*content);
             // shutdown by caller
         }


### PR DESCRIPTION
So warn when we serve something over that size that it won't typically be cached.

The default max individual file size that firefox caches is that of about:config browser.cache.disk.max_entry_size which is 50M out of the box

It's not quite as clear in chrome to see what the size it, but in practice I see the same behaviour by default.


Change-Id: Ifa484e08ad64a7f4e7970d828d4c209a46e26fb2


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

