### PR TITLE
Fix the thickness dialog is shown cut

### DIFF
--- a/browser/src/control/jsdialog/Widget.DrawingArea.js
+++ b/browser/src/control/jsdialog/Widget.DrawingArea.js
@@ -39,6 +39,12 @@ function _drawingAreaControl (parentContainer, data, builder) {
 	image.ondragstart = function() { return false; };
 	builder.map.uiManager.enableTooltip(image);
 
+	// If the image render is delayed, use width and height of the data
+	if (image.width == 0 && image.height == 0) {
+		image.width = data.imagewidth;
+		image.height = data.imageheight;
+	}
+
 	if (data.loading && data.loading === 'true') {
 		var loaderContainer = L.DomUtil.create('div', 'ui-drawing-area-loader-container', container);
 		L.DomUtil.create('div', 'ui-drawing-area-loader', loaderContainer);


### PR DESCRIPTION
Thickness dialog has an image in. When the image render is delayed we are getting image size 0x0. That wrong size caused wrong resizing of the parent containers. To show better result, we need to get image's actual size from core.


Change-Id: I207fd2fcca63deee21f51ef34c1ad670e15afd87


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

