### PR TITLE
doc broker: handle no _storage in uploadToStorageInternal()

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1717,7 +1717,11 @@ void DocumentBroker::uploadToStorageInternal(const std::shared_ptr<ClientSession
         Util::mapAnonymized(newFilename, fileId);
     }
 
-    assert(_storage && "Must have a valid Storage instance");
+    if (!_storage)
+    {
+        LOG_WRN("Expected to have a valid Storage instance, but doesn't have one");
+        return;
+    }
 
     const std::string uriAnonym = COOLWSD::anonymizeUrl(uri);
 


### PR DESCRIPTION
Similar to commit eb5c86a4d32d4e84a0e6dddaa6c4b5772435b85f
(DocumentBroker::saveToStorage: guard against nullptr _storage,
2020-10-26), with the same input.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I17ac2bc12ba086d16ccbf3d5c758e081a32cbf5a
