### PR TITLE
Revert "wsd: disable ctrl+s when HideSaveOption is true"

### DIFF
--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -690,11 +690,6 @@ bool ClientSession::_handleInput(const char *buffer, int length)
                                 << "] has no write permissions in Storage and cannot save.");
             sendTextFrameAndLogError("error: cmd=save kind=savefailed");
         }
-        else if (_wopiFileInfo && _wopiFileInfo->getHideSaveOption())
-        {
-            LOG_WRN("Session [" << getId() << "] on document [" << docBroker->getDocKey()
-                            << "] has HideSaveOption set to true by CheckFileInfo, cannot save");
-        }
         else
         {
             // Don't save unmodified docs by default.


### PR DESCRIPTION
- fix: disabled 'Action_Save' postmessage when HideSaveOption is true

This reverts commit 34f3dd4a625796e5be41176184caee5381176b4c.

* Target version: master 


