### PR TITLE
Sometimes we only request two rows of tiles in writer on an initial load

### DIFF
--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -79,14 +79,6 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 			}
 		}.bind(this));
 
-		// This is called when page size is increased
-		// the content of the cells that become visible may stay empty
-		// unless we have the tiles in the cache already
-		// This will only fetch the tiles which are invalid or does not exist
-		map.on('sizeincreased', function() {
-			this._update();
-		}.bind(this));
-
 		app.sectionContainer.addSection(new app.definitions.AutoFillMarkerSection());
 
 		this.insertMode = false;

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -5693,6 +5693,14 @@ L.CanvasTileLayer = L.Layer.extend({
 		this._requestNewTiles();
 
 		map.setZoom();
+
+		// This is called when page size is increased
+		// the content of the page that become visible may stay empty
+		// unless we have the tiles in the cache already
+		// This will only fetch the tiles which are invalid or does not exist
+		map.on('sizeincreased', function() {
+			this._update();
+		}.bind(this));
 	},
 
 	onRemove: function (map) {

--- a/cypress_test/integration_tests/mobile/writer/shape_properties_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/shape_properties_spec.js
@@ -4,7 +4,7 @@ var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
 
 describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Change shape properties via mobile wizard.', function() {
-	const defaultStartPoint = [1953, 4796];
+	const defaultStartPoint = [1947, 5308];
 	const defaultBase = 5992;
 	const defaultAltitude = 5992;
 	const unitScale = 2540.37;


### PR DESCRIPTION
Sometimes we only request and only get two rows of tiles in writer on an initial load. Most frequently I see this with a non-debug online server via nextcloud of the default "Welcome to Nextcloud" docx in firefox in the 2nd or 3rd tab of opening the same document. While the page doesn't visually resize there is a resize delivered after the initial request of tiles.

Change-Id: Id263adbbd98ad0a7c6143d241d0d91e1c28eaac5


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

