### PR TITLE
Annotation: revamp comment autosaving

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -766,6 +766,11 @@ nav.spreadsheet-color-indicator ~ #sidebar-dock-wrapper {
 	font-size: var(--default-font-size);
 }
 
+.cool-annotation-autosavelabel {
+	font-size: var(--default-font-size);
+	opacity: 75%;
+}
+
 .cool-annotation-menubar {
 	margin: 0;
 	padding: 0;

--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -766,11 +766,6 @@ nav.spreadsheet-color-indicator ~ #sidebar-dock-wrapper {
 	font-size: var(--default-font-size);
 }
 
-.cool-annotation-autosavelabel {
-	font-size: var(--default-font-size);
-	opacity: 75%;
-}
-
 .cool-annotation-menubar {
 	margin: 0;
 	padding: 0;

--- a/browser/src/control/Control.IdleHandler.ts
+++ b/browser/src/control/Control.IdleHandler.ts
@@ -52,12 +52,9 @@ class IdleHandler {
 			}
 		}
 
-		var section = app.sectionContainer ?
-			app.sectionContainer.getSectionWithName(L.CSections.CommentList.name) : null;
-		var hasActiveComment = section && section.sectionProperties.selectedComment;
-
-		if (window.mode.isDesktop() && !this.map.uiManager.isAnyDialogOpen() && !hasActiveComment)
+		if (window.mode.isDesktop() && !this.map.uiManager.isAnyDialogOpen()) {
 			this.map.focus();
+		}
 
 		return false;
 	}

--- a/browser/src/docstate.js
+++ b/browser/src/docstate.js
@@ -51,9 +51,7 @@ window.app = { // Shouldn't have any functions defined.
 		commentHasFocus: false,
 		size: {
 			pixels: [0, 0] // This can be larger than the document's size.
-		},
-		commentAutoSave: null, // if comment lost focus it is automatically saved (modified, new comment or reply)
-		commentAutoAdded: false // if the comment/reply was newly added as the result of an autosaving comment
+		}
 	},
 	tile: {
 		size: {

--- a/browser/src/dom/PosAnimation.js
+++ b/browser/src/dom/PosAnimation.js
@@ -16,7 +16,7 @@ L.PosAnimation = L.Class.extend({
 
 		this.fire('start');
 
-		el.style[L.DomUtil.TRANSITION] = 'all ' + (duration || 0.25) +
+		el.style[L.DomUtil.TRANSITION] = 'all ' + (isNaN(duration) ? 0.25 : 0) +
 		        's cubic-bezier(0,0,' + (easeLinearity || 0.5) + ',1)';
 
 		L.DomEvent.on(el, L.DomUtil.TRANSITION_END, this._onTransitionEnd, this);

--- a/browser/src/layer/tile/CommentListSection.ts
+++ b/browser/src/layer/tile/CommentListSection.ts
@@ -1169,8 +1169,9 @@ export class CommentSection extends CanvasSectionObject {
 		}
 		if (action === 'Add') {
 			if (app.view.commentAutoSave) {
-				// preserve original Id, can be used in case of reply to find parent comment, or revert the id in case comment insertion is cancelled
-				app.view.commentAutoSave.sectionProperties.data.oldId = app.view.commentAutoSave.sectionProperties.data.id;
+				// preserve the id of the root comment and use it when reply button is clicked
+				if (app.view.commentAutoSave.sectionProperties.data.reply)
+					app.view.commentAutoSave.sectionProperties.data.oldId = app.view.commentAutoSave.sectionProperties.data.id;
 				app.view.commentAutoSave.sectionProperties.data.id = obj.comment.id;
 				app.view.commentAutoSave.sectionProperties.autoSave.innerText = _('Autosaved') ;
 				app.view.commentAutoSave = null;

--- a/browser/src/layer/tile/CommentListSection.ts
+++ b/browser/src/layer/tile/CommentListSection.ts
@@ -1861,7 +1861,7 @@ export class CommentSection extends CanvasSectionObject {
 	public onCommentsDataUpdate(): void {
 		for (var i: number = this.sectionProperties.commentList.length -1; i > -1; i--) {
 			var comment = this.sectionProperties.commentList[i];
-			if (!comment.valid &&  (!$(comment.sectionProperties.container).hasClass('reply-annotation-container') && !$(comment.sectionProperties.container).hasClass('modify-annotation-container'))) {
+			if (!comment.valid) {
 				comment.sectionProperties.commentListSection.removeItem(comment.sectionProperties.data.id);
 			}
 			comment.onCommentDataUpdate();

--- a/browser/src/layer/tile/CommentListSection.ts
+++ b/browser/src/layer/tile/CommentListSection.ts
@@ -1370,7 +1370,7 @@ export class CommentSection extends CanvasSectionObject {
 	// Returns the last comment id of comment thread containing the given id
 	private getLastChildIndexOf (id: any): number {
 		var index = this.getIndexOf(id);
-		index = index === -1 ? -1 : this.getRootIndexOf(this.sectionProperties.commentList[index].sectionProperties.data.id);
+		index = this.getRootIndexOf(this.sectionProperties.commentList[index].sectionProperties.data.id);
 
 		while
 		(

--- a/browser/src/layer/tile/CommentListSection.ts
+++ b/browser/src/layer/tile/CommentListSection.ts
@@ -729,43 +729,21 @@ export class CommentSection extends CanvasSectionObject {
 	}
 
 	public saveReply (annotation: any): void {
-		var comment;
-		if (annotation.sectionProperties.data.newReply) {
-			comment = {
-				Id: {
-					type: 'string',
-					value: annotation.sectionProperties.data.id
-				},
-				Text: {
-					type: 'string',
-					value: annotation.sectionProperties.data.reply
-				}
-			};
-			if (this.sectionProperties.docLayer._docType === 'text')
-				this.map.sendUnoCommand('.uno:ReplyComment', comment);
-			else if (this.sectionProperties.docLayer._docType === 'presentation')
-				this.map.sendUnoCommand('.uno:ReplyToAnnotation', comment);
-			annotation.sectionProperties.data.newReply = false;
-		} else {
-			comment = {
-				Id: {
-					type: 'string',
-					value: annotation.sectionProperties.data.id
-				},
-			        Author: {
-					type: 'string',
-					value: annotation.sectionProperties.data.author
-				},
-				Text: {
-					type: 'string',
-					value: annotation.sectionProperties.data.reply
-				}
-			};
-			this.map.sendUnoCommand('.uno:EditAnnotation', comment, true /* force */);
+		var comment = {
+			Id: {
+				type: 'string',
+				value: annotation.sectionProperties.data.id
+			},
+			Text: {
+				type: 'string',
+				value: annotation.sectionProperties.data.reply
+			}
+		};
 
-			if (!app.view.commentAutoSave)
-				annotation.sectionProperties.data.id = annotation.sectionProperties.data.oldId;
-		}
+		if (this.sectionProperties.docLayer._docType === 'text' || this.sectionProperties.docLayer._docType === 'spreadsheet')
+			this.map.sendUnoCommand('.uno:ReplyComment', comment);
+		else if (this.sectionProperties.docLayer._docType === 'presentation')
+			this.map.sendUnoCommand('.uno:ReplyToAnnotation', comment);
 
 		if (app.view.commentAutoSave)
 			return;
@@ -1169,9 +1147,6 @@ export class CommentSection extends CanvasSectionObject {
 		}
 		if (action === 'Add') {
 			if (app.view.commentAutoSave) {
-				// preserve the id of the root comment and use it when reply button is clicked
-				if (app.view.commentAutoSave.sectionProperties.data.reply)
-					app.view.commentAutoSave.sectionProperties.data.oldId = app.view.commentAutoSave.sectionProperties.data.id;
 				app.view.commentAutoSave.sectionProperties.data.id = obj.comment.id;
 				app.view.commentAutoSave.sectionProperties.autoSave.innerText = _('Autosaved') ;
 				app.view.commentAutoSave = null;

--- a/browser/src/layer/tile/CommentListSection.ts
+++ b/browser/src/layer/tile/CommentListSection.ts
@@ -4,6 +4,11 @@
 
 L.Map.include({
 	insertComment: function() {
+		if (cool.Comment.isAnyEdit()) {
+			this.uiManager.showInfoModal('annotation-editing', _('A comment is being edited'),
+			_('Please save or discard the comment currently being edited.'), null, _('Close'));
+			return;
+		}
 		var avatar = undefined;
 		var author = this.getViewName(this._docLayer._viewId);
 		if (author in this._viewInfoByUserName) {

--- a/browser/src/layer/tile/CommentListSection.ts
+++ b/browser/src/layer/tile/CommentListSection.ts
@@ -589,13 +589,9 @@ export class CommentSection extends CanvasSectionObject {
 			}
 		}
 		else {
-			var unselected = this.unselect();
+			this.unselect();
 			annotation.reply();
-			var selected = this.select(annotation);
-			// select and unselect usually updates the layout but,
-			// in case if it failed we manually do the layout update
-			if (!unselected && !selected)
-				this.layout();
+			this.select(annotation);
 			annotation.focus();
 		}
 	}
@@ -607,14 +603,9 @@ export class CommentSection extends CanvasSectionObject {
 			}.bind(this), /* isMod */ true);
 		}
 		else {
-			if (this.sectionProperties.docLayer._docType !== 'spreadsheet') {
-				var unselected = this.unselect();
-				var selected = this.select(annotation);
-
-				// select and unselect usually updates the layout but,
-				// in case if it failed we manually do the layout update
-				if (!unselected && !selected)
-					this.layout();
+			if (this.sectionProperties.docLayer._docType !== 'spreadsheet' && this.sectionProperties.selectedComment !== annotation) {
+				this.unselect();
+				this.select(annotation);
 			}
 
 			// Make sure that comment is not transitioning and comment menu is not open.
@@ -650,7 +641,7 @@ export class CommentSection extends CanvasSectionObject {
 			this.sectionProperties.commentList[i].sectionProperties.container.style.display = 'none';
 	}
 
-	public select (annotation: any): boolean {
+	public select (annotation: any): void {
 		var selectedComment = this.sectionProperties.selectedComment;
 		if (annotation && annotation !== selectedComment
 			&& !(selectedComment && selectedComment.isEdit())) {
@@ -685,9 +676,7 @@ export class CommentSection extends CanvasSectionObject {
 			}
 
 			this.update();
-			return true;
 		}
-		return false;
 	}
 
 	private isInViewPort(annotation: any): boolean {
@@ -705,10 +694,10 @@ export class CommentSection extends CanvasSectionObject {
 		);
 	}
 
-	public unselect (): boolean {
+	public unselect (): void {
 		var selectedComment = this.sectionProperties.selectedComment;
 		if (app.view.commentAutoSave || (selectedComment && selectedComment.isAnyEdit()))
-			return false;
+			return;
 		if (this.sectionProperties.selectedComment && this.sectionProperties.selectedComment.sectionProperties.data.id != 'new') {
 			if (this.sectionProperties.selectedComment && $(this.sectionProperties.selectedComment.sectionProperties.container).hasClass('annotation-active'))
 				$(this.sectionProperties.selectedComment.sectionProperties.container).removeClass('annotation-active');
@@ -723,9 +712,7 @@ export class CommentSection extends CanvasSectionObject {
 			this.sectionProperties.selectedComment = null;
 
 			this.update();
-			return true;
 		}
-		return false;
 	}
 
 	public saveReply (annotation: any): void {

--- a/browser/src/layer/tile/CommentListSection.ts
+++ b/browser/src/layer/tile/CommentListSection.ts
@@ -1043,7 +1043,6 @@ export class CommentSection extends CanvasSectionObject {
 
 		this.sectionProperties.commentList.push(annotation);
 
-		this.adjustParentAdd(annotation);
 		this.orderCommentList();
 		this.updateIdIndexMap();
 		this.checkSize();
@@ -1187,6 +1186,7 @@ export class CommentSection extends CanvasSectionObject {
 			} else {
 				this.adjustComment(obj.comment);
 				annotation = this.add(obj.comment);
+				this.adjustParentAdd(annotation);
 				if (this.sectionProperties.docLayer._docType === 'spreadsheet')
 					annotation.hide();
 			}

--- a/browser/src/layer/tile/CommentSection.ts
+++ b/browser/src/layer/tile/CommentSection.ts
@@ -917,7 +917,7 @@ export class Comment extends CanvasSectionObject {
 	}
 
 	public isAnyEdit (): boolean {
-		var commentList = app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).sectionProperties.commentList;
+		var commentList = this.sectionProperties.commentList;
 		for (var i in commentList) {
 			var modifyNode = commentList[i].sectionProperties.nodeModify;
 			var replyNode = commentList[i].sectionProperties.nodeReply;

--- a/browser/src/layer/tile/CommentSection.ts
+++ b/browser/src/layer/tile/CommentSection.ts
@@ -855,15 +855,22 @@ export class Comment extends CanvasSectionObject {
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 	public onLostFocus (e: any): void {
 		if (!this.sectionProperties.isRemoved) {
+			if (!this.sectionProperties.nodeModifyText.value &&
+				!this.sectionProperties.contentText.origText)
+				return;
+			app.view.commentAutoSave = this;
 			if (this.sectionProperties.contentText.origText !== this.sectionProperties.nodeModifyText.value) {
-				app.view.commentAutoSave = this;
 				this.onSaveComment(e);
 			}
-			else if (this.containerObject.testing) {
-				var insertButton = document.getElementById('menu-insertcomment');
-				if (insertButton) {
-					if (window.getComputedStyle(insertButton).display === 'none') {
-						this.onCancelClick(e);
+			else {
+				if (!this.containerObject.testing) // eslint-disable-line no-lonely-if
+					this.onCancelClick(e);
+				else {
+					var insertButton = document.getElementById('menu-insertcomment');
+					if (insertButton) {
+						if (window.getComputedStyle(insertButton).display === 'none') {
+							this.onCancelClick(e);
+						}
 					}
 				}
 			}

--- a/browser/src/layer/tile/CommentSection.ts
+++ b/browser/src/layer/tile/CommentSection.ts
@@ -831,13 +831,6 @@ export class Comment extends CanvasSectionObject {
 		}
 		if (e)
 			L.DomEvent.stopPropagation(e);
-
-		if (this.sectionProperties.nodeModify.originalText &&
-			this.sectionProperties.nodeModify.originalText !== this.sectionProperties.data.text) {
-				this.sectionProperties.nodeModifyText.value = this.sectionProperties.nodeModify.originalText;
-				this.handleSaveCommentButton(e);
-				return;
-		}
 		this.sectionProperties.nodeModifyText.value = this.sectionProperties.contentText.origText;
 		this.sectionProperties.nodeReplyText.value = '';
 		if (this.sectionProperties.docLayer._docType !== 'spreadsheet')
@@ -914,7 +907,6 @@ export class Comment extends CanvasSectionObject {
 		this.sectionProperties.nodeReply.style.display = 'none';
 		this.sectionProperties.container.style.visibility = '';
 		this.sectionProperties.contentNode.style.display = 'none';
-		this.sectionProperties.nodeModify.originalText = this.sectionProperties.nodeModify.textContent;
 		return this;
 	}
 

--- a/browser/src/layer/tile/CommentSection.ts
+++ b/browser/src/layer/tile/CommentSection.ts
@@ -826,8 +826,6 @@ export class Comment extends CanvasSectionObject {
 			return;
 		if (app.view.commentAutoAdded) {
 			this.sectionProperties.commentListSection.remove(this.sectionProperties.data.id);
-			app.view.commentAutoAdded = false;
-			this.sectionProperties.data.id = this.sectionProperties.data.oldId;
 			if (this.sectionProperties.commentListSection.sectionProperties.selectedComment.sectionProperties.container.classList.contains('reply-annotation-container')) {
 				this.show();
 				return;

--- a/browser/src/layer/tile/CommentSection.ts
+++ b/browser/src/layer/tile/CommentSection.ts
@@ -804,7 +804,6 @@ export class Comment extends CanvasSectionObject {
 	public onReplyClick (e: any): void {
 		L.DomEvent.stopPropagation(e);
 		if ((<any>window).mode.isMobile()) {
-			this.sectionProperties.data.newReply = true;
 			this.sectionProperties.data.reply = this.sectionProperties.data.text;
 			this.sectionProperties.commentListSection.saveReply(this);
 		} else {
@@ -908,7 +907,6 @@ export class Comment extends CanvasSectionObject {
 		this.sectionProperties.contentNode.style.display = '';
 		this.sectionProperties.nodeModify.style.display = 'none';
 		this.sectionProperties.nodeReply.style.display = '';
-		this.sectionProperties.data.newReply = true;
 		return this;
 	}
 

--- a/browser/src/layer/tile/CommentSection.ts
+++ b/browser/src/layer/tile/CommentSection.ts
@@ -631,7 +631,7 @@ export class Comment extends CanvasSectionObject {
 	}
 
 	private showMarker (): void {
-		if (this.sectionProperties.annotationMarker != null && !this.sectionProperties.isRemoved) {
+		if (this.sectionProperties.annotationMarker != null) {
 			this.map.addLayer(this.sectionProperties.annotationMarker);
 		}
 	}

--- a/browser/src/layer/tile/CommentSection.ts
+++ b/browser/src/layer/tile/CommentSection.ts
@@ -708,7 +708,6 @@ export class Comment extends CanvasSectionObject {
 			this.showImpressDraw();
 		else if (this.sectionProperties.docLayer._docType === 'spreadsheet')
 			this.showCalc();
-		this.sectionProperties.autoSave.innerText = '';
 	}
 
 	private hideWriter() {
@@ -825,10 +824,8 @@ export class Comment extends CanvasSectionObject {
 			return;
 		if (app.view.commentAutoAdded) {
 			this.sectionProperties.commentListSection.remove(this.sectionProperties.data.id);
-			if (this.sectionProperties.commentListSection.sectionProperties.selectedComment.sectionProperties.container.classList.contains('reply-annotation-container')) {
+			if (this.sectionProperties.commentListSection.sectionProperties.selectedComment.sectionProperties.container.classList.contains('reply-annotation-container'))
 				this.show();
-				return;
-			}
 			else
 				this.onRemove();
 		}

--- a/browser/src/layer/tile/CommentSection.ts
+++ b/browser/src/layer/tile/CommentSection.ts
@@ -855,9 +855,6 @@ export class Comment extends CanvasSectionObject {
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 	public onLostFocus (e: any): void {
 		if (!this.sectionProperties.isRemoved) {
-			if (!this.sectionProperties.nodeModifyText.value &&
-				!this.sectionProperties.contentText.origText)
-				return;
 			app.view.commentAutoSave = this;
 			if (this.sectionProperties.contentText.origText !== this.sectionProperties.nodeModifyText.value) {
 				this.onSaveComment(e);

--- a/browser/src/layer/tile/CommentSection.ts
+++ b/browser/src/layer/tile/CommentSection.ts
@@ -824,10 +824,7 @@ export class Comment extends CanvasSectionObject {
 			return;
 		if (app.view.commentAutoAdded) {
 			this.sectionProperties.commentListSection.remove(this.sectionProperties.data.id);
-			if (this.sectionProperties.commentListSection.sectionProperties.selectedComment.sectionProperties.container.classList.contains('reply-annotation-container'))
-				this.show();
-			else
-				this.onRemove();
+			this.onRemove();
 		}
 		if (e)
 			L.DomEvent.stopPropagation(e);

--- a/browser/src/layer/tile/CommentSection.ts
+++ b/browser/src/layer/tile/CommentSection.ts
@@ -825,6 +825,24 @@ export class Comment extends CanvasSectionObject {
 
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 	public onLostFocus (e: any): void {
+		if (!this.sectionProperties.isRemoved) {
+			$(this.sectionProperties.container).removeClass('annotation-active reply-annotation-container modify-annotation-container');
+			if (this.sectionProperties.contentText.origText !== this.sectionProperties.nodeModifyText.value) {
+				this.onSaveComment(e);
+			}
+			else {
+				if (!this.containerObject.testing) // eslint-disable-line no-lonely-if
+					this.onCancelClick(e);
+				else {
+					var insertButton = document.getElementById('menu-insertcomment');
+					if (insertButton) {
+						if (window.getComputedStyle(insertButton).display === 'none') {
+							this.onCancelClick(e);
+						}
+					}
+				}
+			}
+		}
 		app.view.commentHasFocus = false;
 	}
 

--- a/browser/src/layer/tile/CommentSection.ts
+++ b/browser/src/layer/tile/CommentSection.ts
@@ -752,7 +752,7 @@ export class Comment extends CanvasSectionObject {
 			return;
 		}
 
-		if (this.isAnyEdit()) {
+		if (Comment.isAnyEdit()) {
 			return;
 		}
 
@@ -947,7 +947,7 @@ export class Comment extends CanvasSectionObject {
 		       (this.sectionProperties.nodeReply && this.sectionProperties.nodeReply.style.display !== 'none');
 	}
 
-	public isAnyEdit (): boolean {
+	public static isAnyEdit (): boolean {
 		var commentList = app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).sectionProperties.commentList;
 		for (var i in commentList) {
 			var modifyNode = commentList[i].sectionProperties.nodeModify;

--- a/browser/src/layer/tile/ImpressTileLayer.js
+++ b/browser/src/layer/tile/ImpressTileLayer.js
@@ -119,7 +119,7 @@ L.ImpressTileLayer = L.CanvasTileLayer.extend({
 	},
 
 	onUpdateParts: function () {
-		if (this._map.uiManager.isAnyDialogOpen() || app.view.commentAutoAdded || app.view.commentAutoSave) // Need this check else dialog loses focus
+		if (this._map.uiManager.isAnyDialogOpen()) // Need this check else dialog loses focus
 			return;
 
 		app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).onPartChange();

--- a/cypress_test/integration_tests/desktop/calc/annotation_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/annotation_spec.js
@@ -122,7 +122,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('#map').focus();
 		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
 		cy.cGet('.cool-annotation-edit.modify-annotation').should('be.visible');
-		cy.cGet('#annotation-save-new').click();
+		cy.cGet('#annotation-save-1').click();
 		cy.cGet('.cool-annotation').should('exist');
 		cy.cGet('#comment-container-1').then(function (element) {
 			element[0].style.visibility = '';
@@ -149,7 +149,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('#map').focus();
 		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
 		cy.cGet('.cool-annotation-edit.modify-annotation').should('be.visible');
-		cy.cGet('#annotation-cancel-new').click();
+		cy.cGet('#annotation-cancel-1').click();
 		cy.cGet('.cool-annotation').should('not.exist');
 		cy.cGet('.cool-annotation-autosavelabel').should('not.exist');
 
@@ -224,7 +224,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('#annotation-content-area-1').should('have.text','some other text, some text0');
 	});
 
-	it.skip('Modify autosave cancel',function() {
+	it('Modify autosave cancel',function() {
 		insertMultipleComment('calc', 1, false, '[id=insert-insert-annotation]');
 
 		cy.cGet('#comment-container-1').should('exist');

--- a/cypress_test/integration_tests/desktop/impress/annotation_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/annotation_spec.js
@@ -224,7 +224,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('#map').focus();
 		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
 		cy.cGet('.cool-annotation-edit.modify-annotation').should('be.visible');
-		cy.cGet('#annotation-save-new').click();
+		cy.cGet('#annotation-save-1').click();
 		cy.cGet('.cool-annotation-autosavelabel').should('be.not.visible');
 		cy.cGet('.cool-annotation-edit.modify-annotation').should('be.not.visible');
 		cy.cGet('.leaflet-marker-icon').should('exist');
@@ -242,7 +242,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('#map').focus();
 		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
 		cy.cGet('.cool-annotation-edit.modify-annotation').should('be.visible');
-		cy.cGet('#annotation-cancel-new').click();
+		cy.cGet('#annotation-cancel-1').click();
 		cy.cGet('.cool-annotation-autosavelabel').should('not.exist');
 		cy.cGet('.cool-annotation-edit.modify-annotation').should('not.exist');
 		cy.cGet('.leaflet-marker-icon').should('not.exist');
@@ -323,7 +323,9 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('#annotation-reply-textarea-1').type('some reply text');
 		cy.cGet('#map').focus();
 		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
-		cy.cGet('.cool-annotation-edit.reply-annotation').should('be.visible');
+		cy.cGet('#annotation-modify-textarea-1').should('be.visible');
+		cy.cGet('#annotation-modify-textarea-1').should('include.text', 'some text0');
+		cy.cGet('#annotation-modify-textarea-1').should('include.text', 'some reply text');
 
 		helper.closeDocument(testFileName, '');
 		helper.beforeAll(testFileName, 'impress', true, false, false, true);
@@ -340,10 +342,13 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('#annotation-reply-textarea-1').type('some reply text');
 		cy.cGet('#map').focus();
 		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
-		cy.cGet('.cool-annotation-edit.reply-annotation').should('be.visible');
-		cy.cGet('#annotation-reply-1').click();
+		cy.cGet('#annotation-modify-textarea-1').should('be.visible');
+		cy.cGet('#annotation-modify-textarea-1').should('include.text', 'some text0');
+		cy.cGet('#annotation-modify-textarea-1').should('include.text', 'some reply text');
+		cy.cGet('#annotation-save-1').click();
 		cy.cGet('.cool-annotation-autosavelabel').should('be.not.visible');
 		cy.cGet('.cool-annotation-edit.reply-annotation').should('be.not.visible');
+		cy.cGet('.cool-annotation-content > div').should('include.text','some text0');
 		cy.cGet('.cool-annotation-content > div').should('include.text','some reply text');
 
 		helper.closeDocument(testFileName, '');
@@ -352,7 +357,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('.cool-annotation-content > div').should('include.text','some reply text');
 	});
 
-	it.skip('Reply autosave cancel',function() {
+	it('Reply autosave cancel',function() {
 		insertMultipleComment('impress', 1, false, '#insert-insert-annotation-button');
 		cy.cGet('.leaflet-marker-icon').should('exist');
 		cy.cGet('.cool-annotation-content > div').should('have.text','some text0');
@@ -361,8 +366,10 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('#annotation-reply-textarea-1').type('some reply text');
 		cy.cGet('#map').focus();
 		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
-		cy.cGet('.cool-annotation-edit.reply-annotation').should('be.visible');
-		cy.cGet('#annotation-cancel-reply-1').click();
+		cy.cGet('#annotation-modify-textarea-1').should('be.visible');
+		cy.cGet('#annotation-modify-textarea-1').should('include.text', 'some text0');
+		cy.cGet('#annotation-modify-textarea-1').should('include.text', 'some reply text');
+		cy.cGet('#annotation-cancel-1').click();
 		cy.cGet('.cool-annotation-autosavelabel').should('be.not.visible');
 		cy.cGet('.cool-annotation-edit.reply-annotation').should('be.not.visible');
 		cy.cGet('.cool-annotation-content > div').should('have.text','some text0');

--- a/cypress_test/integration_tests/desktop/writer/annotation_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/annotation_spec.js
@@ -160,7 +160,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('#map').focus();
 		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
 		cy.cGet('.cool-annotation-edit.modify-annotation').should('be.visible');
-		cy.cGet('#annotation-save-new').click();
+		cy.cGet('#annotation-save-1').click();
 		cy.cGet('#annotation-content-area-1').should('have.text','Test Comment');
 		cy.cGet('.cool-annotation-autosavelabel').should('be.not.visible');
 
@@ -176,7 +176,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('#map').focus();
 		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
 		cy.cGet('.cool-annotation-edit.modify-annotation').should('be.visible');
-		cy.cGet('#annotation-cancel-new').click();
+		cy.cGet('#annotation-cancel-1').click();
 		cy.cGet('#comment-container-1').should('not.exist');
 		cy.cGet('.cool-annotation-autosavelabel').should('not.exist');
 
@@ -225,7 +225,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('#annotation-content-area-1').should('have.text','some other text, some text0');
 	});
 
-	it.skip('Modify autosave cancel', function() {
+	it('Modify autosave cancel', function() {
 		insertMultipleComment('writer', 1, false, '[id=insert-insert-annotation]');
 
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
@@ -257,7 +257,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('#annotation-reply-textarea-1').type('some reply text');
 		cy.cGet('#map').focus();
 		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
-		cy.cGet('.cool-annotation-edit.reply-annotation').should('be.visible');
+		cy.cGet('#annotation-modify-textarea-2').should('be.visible');
 
 		helper.closeDocument(testFileName, '');
 		helper.beforeAll(testFileName, 'writer', true, false, false, true);
@@ -265,19 +265,20 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('#annotation-content-area-2').should('have.text','some reply text');
 	});
 
-	it.skip('Reply autosave save', function() {
+	it('Reply autosave save', function() {
 		insertMultipleComment('writer', 1, false, '[id=insert-insert-annotation]');
 
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
-		cy.cGet('#annotation-content-area-1').should('have.text','some text');
+		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
 		cy.cGet('#comment-annotation-menu-1').click();
 		cy.cGet('body').contains('.context-menu-item', 'Reply').click();
 		cy.cGet('#annotation-reply-textarea-1').type('some reply text');
 		cy.cGet('#map').focus();
 		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
-		cy.cGet('.cool-annotation-edit.reply-annotation').should('be.visible');
-		cy.cGet('#annotation-reply-1').click();
-		cy.cGet('.cool-annotation-edit.reply-annotation').should('be.not.visible');
+		cy.cGet('#annotation-modify-textarea-2').should('be.visible');
+		cy.cGet('#annotation-modify-textarea-2').should('have.text','some reply text');
+		cy.cGet('#annotation-save-2').click();
+		cy.cGet('#annotation-modify-textarea-2').should('be.not.visible');
 		cy.cGet('.cool-annotation-autosavelabel').should('be.not.visible');
 		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
 		cy.cGet('#annotation-content-area-2').should('have.text','some reply text');
@@ -288,7 +289,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('#annotation-content-area-2').should('have.text','some reply text');
 	});
 
-	it.skip('Reply autosave cancel', function() {
+	it('Reply autosave cancel', function() {
 		insertMultipleComment('writer', 1, false, '[id=insert-insert-annotation]');
 
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
@@ -298,9 +299,11 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('#annotation-reply-textarea-1').type('some reply text');
 		cy.cGet('#map').focus();
 		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
-		cy.cGet('.cool-annotation-edit.reply-annotation').should('be.visible');
-		cy.cGet('#annotation-cancel-reply-1').click();
-		cy.cGet('.cool-annotation-edit.reply-annotation').should('be.not.visible');
+		cy.cGet('#annotation-modify-textarea-2').should('be.visible');
+		cy.cGet('#annotation-modify-textarea-2').should('have.text','some reply text');
+		cy.cGet('#annotation-cancel-2').click();
+		cy.cGet('#annotation-modify-textarea-2').should('not.exist');
+		cy.cGet('.cool-annotation-autosavelabel').should('be.not.visible');
 		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
 		cy.cGet('#annotation-content-area-2').should('not.exist');
 		cy.cGet('#comment-container-1 .cool-annotation-autosavelabel').should('be.not.visible');


### PR DESCRIPTION
* Target version: master 

### Summary
Reverts all the previous comment autosave commits and implements a new approach.


Original approach before comment autosave:
When we save a new comment, original DOM element which user was editing
is removed from the DOM and new comment DOM element is created from the data and message sent by core.

Previous comment autosave approach:
When we save a new comment, original DOM element which user was editing
is not removed but kept in editing mode. We register the comment message sent by the core
but react and create new comment DOM element only after user clicks on save or cancel.
This lazy initialization caused many regression due to juggling of the new and old comment DOM element.
All these problems were in JS side only, reloading doc would bring comment in correct state.
This approach gave smoother transition between different comment states without any flickers.

New comment autosave approach:
Simple as the original approach, when comment loses focus we save it as normal comment.
When new DOM element created via core comment message, we immidietly set it to edit mode.
This approach may have a little flicker when we replace old comment DOM element with new comment DOM element.
Overall this approach requires less condition checking which makes it easy to maintain and hopefully reduces any regression from previous method.

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

