### PR TITLE
menuItemHandler: add additional identifier as css class to ui-header

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2925,6 +2925,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 
 	_menuItemHandler: function(parentContainer, data, builder) {
 		var title = data.text;
+		var cssClassHeader = 'ui-header';
 		// separator
 		if (title === '') {
 			return false;
@@ -2932,6 +2933,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 
 		var id = data.id;
 		if (id) {
+			cssClassHeader += ' ui-header-' + id;
 			var handler = builder._menuItemHandlers[id];
 			if (handler) {
 				handler(parentContainer, data, builder);
@@ -2939,7 +2941,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			}
 		}
 
-		var menuEntry = L.DomUtil.create('div', 'ui-header level-' + builder._currentDepth + ' ' + builder.options.cssClass + ' ui-widget', parentContainer);
+		var menuEntry = L.DomUtil.create('div', cssClassHeader + ' level-' + builder._currentDepth + ' ' + builder.options.cssClass + ' ui-widget', parentContainer);
 
 		if (data.hyperlink) {
 			menuEntry = L.DomUtil.create('a', 'context-menu-link', menuEntry);


### PR DESCRIPTION
Before it was impossible to correctly target one dimensional menu
entries such as Help, About, Feedback and Latest updates.

This affects places such as Mobile: hamburger menu where now menu entries
get automatically assign an additional css class based on its data.id.

Note: we could also employ the same thing within explorableEntry if
needed. But that's outside of the scope of this change.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ib50cf1e29f4fae072b8739c76e7facaa540c0ad5
