### PR TITLE
Add list of allowed data sources

### DIFF
--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -160,6 +160,21 @@
         <host desc="The IPv4 private 10.0.0.0/8 subnet (Podman).">10\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}</host>
         <host desc="Ditto, but as IPv4-mapped IPv6 addresses">::ffff:10\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}</host>
       </post_allow>
+      <lok_allow desc="Allowed hosts as an external data source inside edited files. All allowed post_allow.host and storage.wopi entries are also considered to be allowed as a data source. Used for example in: PostMessage Action_InsertGraphics, =WEBSERVICE() function, external reference in the cell.">
+        <host desc="The IPv4 private 192.168 block as plain IPv4 dotted decimal addresses.">192\.168\.[0-9]{1,3}\.[0-9]{1,3}</host>
+        <host desc="Ditto, but as IPv4-mapped IPv6 addresses">::ffff:192\.168\.[0-9]{1,3}\.[0-9]{1,3}</host>
+        <host desc="The IPv4 loopback (localhost) address.">127\.0\.0\.1</host>
+        <host desc="Ditto, but as IPv4-mapped IPv6 address">::ffff:127\.0\.0\.1</host>
+        <host desc="The IPv6 loopback (localhost) address.">::1</host>
+        <host desc="The IPv4 private 172.16.0.0/12 subnet part 1.">172\.1[6789]\.[0-9]{1,3}\.[0-9]{1,3}</host>
+        <host desc="Ditto, but as IPv4-mapped IPv6 addresses">::ffff:172\.1[6789]\.[0-9]{1,3}\.[0-9]{1,3}</host>
+        <host desc="The IPv4 private 172.16.0.0/12 subnet part 2.">172\.2[0-9]\.[0-9]{1,3}\.[0-9]{1,3}</host>
+        <host desc="Ditto, but as IPv4-mapped IPv6 addresses">::ffff:172\.2[0-9]\.[0-9]{1,3}\.[0-9]{1,3}</host>
+        <host desc="The IPv4 private 172.16.0.0/12 subnet part 3.">172\.3[01]\.[0-9]{1,3}\.[0-9]{1,3}</host>
+        <host desc="Ditto, but as IPv4-mapped IPv6 addresses">::ffff:172\.3[01]\.[0-9]{1,3}\.[0-9]{1,3}</host>
+        <host desc="The IPv4 private 10.0.0.0/8 subnet (Podman).">10\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}</host>
+        <host desc="Ditto, but as IPv4-mapped IPv6 addresses">::ffff:10\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}</host>
+      </lok_allow>
       <content_security_policy desc="Customize the CSP header by specifying one or more policy-directive, separated by semicolons. See w3.org/TR/CSP2"></content_security_policy>
       <frame_ancestors desc="OBSOLETE: Use content_security_policy. Specify who is allowed to embed the Collabora Online iframe (coolwsd and WOPI host are always allowed). Separate multiple hosts by space."></frame_ancestors>
       <connection_timeout_secs desc="Specifies the connection, send, recv timeout in seconds for connections initiated by coolwsd (such as WOPI connections)." type="int" default="30"></connection_timeout_secs>

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -287,6 +287,66 @@ inline void shutdownLimitReached(const std::shared_ptr<ProtocolHandlerInterface>
 
 } // end anonymous namespace
 
+void COOLWSD::appendAllowedHostsFrom(LayeredConfiguration& conf, const std::string& root, std::vector<std::string>& allowed)
+{
+    for (size_t i = 0; ; ++i)
+    {
+        const std::string path = root + ".host[" + std::to_string(i) + ']';
+        if (!conf.has(path))
+        {
+            break;
+        }
+        const std::string host = getConfigValue<std::string>(conf, path, "");
+        if (!host.empty())
+        {
+            LOG_INF_S("Adding trusted LOK_ALLOW host: [" << host << ']');
+            allowed.push_back(host);
+        }
+    }
+}
+
+void COOLWSD::appendAllowedAliasGroups(LayeredConfiguration& conf, std::vector<std::string>& allowed)
+{
+    for (size_t i = 0;; i++)
+    {
+        const std::string path = "storage.wopi.alias_groups.group[" + std::to_string(i) + ']';
+        if (!conf.has(path + ".host"))
+        {
+            break;
+        }
+
+        const std::string host = conf.getString(path + ".host", "");
+        bool allow = conf.getBool(path + ".host[@allow]", false);
+        if (!allow)
+        {
+            break;
+        }
+
+        if (!host.empty())
+        {
+            LOG_INF_S("Adding trusted LOK_ALLOW host: [" << host << ']');
+            allowed.push_back(host);
+        }
+
+        for (size_t j = 0;; j++)
+        {
+            const std::string aliasPath = path + ".alias[" + std::to_string(j) + ']';
+            if (!conf.has(aliasPath))
+            {
+                break;
+            }
+
+            const std::string alias = getConfigValue<std::string>(conf, aliasPath, "");
+
+            if (!aliasPath.empty())
+            {
+                LOG_INF_S("Adding trusted LOK_ALLOW alias: [" << alias << ']');
+                allowed.push_back(alias);
+            }
+        }
+    }
+}
+
 #if !MOBILEAPP
 /// Internal implementation to alert all clients
 /// connected to any document.
@@ -2854,6 +2914,30 @@ void COOLWSD::innerInitialize(Application& self)
         const auto takeSnapshot = getConfigValue<bool>(conf, "trace.path[@snapshot]", false);
         TraceDumper = std::make_unique<TraceFileWriter>(path, recordOutgoing, compress,
                                                         takeSnapshot, filters);
+    }
+
+    // Allowed hosts for being external data source in the documents
+    std::vector<std::string> lokAllowedHosts;
+    appendAllowedHostsFrom(conf, "net.lok_allow", lokAllowedHosts);
+    // For backward compatibility post_allow hosts are also allowed
+    bool postAllowed = conf.getBool("net.post_allow[@allow]", false);
+    if (postAllowed)
+        appendAllowedHostsFrom(conf, "net.post_allow", lokAllowedHosts);
+    // For backward compatibility wopi hosts are also allowed
+    bool wopiAllowed = conf.getBool("storage.wopi[@allow]", false);
+    if (wopiAllowed)
+    {
+        appendAllowedHostsFrom(conf, "storage.wopi", lokAllowedHosts);
+        appendAllowedAliasGroups(conf, lokAllowedHosts);
+    }
+
+    if (lokAllowedHosts.size())
+    {
+        std::string sRegex;
+        for (size_t i = 0; i < lokAllowedHosts.size(); i++)
+            sRegex += (i != 0 ? "|" : "") + lokAllowedHosts[i];
+
+        setenv("LOK_HOST_ALLOWLIST", sRegex.c_str(), true);
     }
 
 #if !MOBILEAPP

--- a/wsd/COOLWSD.hpp
+++ b/wsd/COOLWSD.hpp
@@ -636,6 +636,9 @@ private:
         return path;
     }
 
+    static void appendAllowedHostsFrom(Poco::Util::LayeredConfiguration& conf, const std::string& root, std::vector<std::string>& allowed);
+    static void appendAllowedAliasGroups(Poco::Util::LayeredConfiguration& conf, std::vector<std::string>& allowed);
+
 private:
     /// Settings passed from the command-line to override those in the config file.
     std::map<std::string, std::string> _overrideSettings;


### PR DESCRIPTION
- uses new lok_allow setting to provide such list
- for backward compatibility uses also all post_allow and storage.wopi entries
- Used for example in: PostMessage Action_InsertGraphics, =WEBSERVICE() function, external reference in the cell
