### PR TITLE
wasm attempt to download file that doesn't exist with reverse proxy e…

### DIFF
--- a/wsd/RequestDetails.cpp
+++ b/wsd/RequestDetails.cpp
@@ -146,7 +146,7 @@ void RequestDetails::processURI()
 
     const auto posLastWS = uriRes.rfind("/ws");
     // DocumentURI is the second segment in cool URIs.
-    if (_pathSegs.equals(0, "cool"))
+    if (_pathSegs.equals(0, "cool") || _pathSegs.equals(0, "wasm"))
     {
         //FIXME: For historic reasons the DocumentURI includes the WOPISrc.
         // This is problematic because decoding a URI that embeds not one, but


### PR DESCRIPTION
…nabled

Handling request: /wasm/https:%252F%252Fwhatever%252Fnextcloud%252Findex.php%252Fapps%252Frichdocuments%252Fwopi%252Ffiles%252Fwhatever%3Faccess_token=ozxpkBByLTd9XnWaWHdrTVhMp3Exf1mt&access_token_ttl=0| wsd/COOLWSD.cpp:4093 [ websrv_poll ] INF  #22: Starting GET request handler for session [032] on url [https:%252F%252Fwhatever%252Fnextcloud%252Findex.php%252Fapps%252Frichdocuments%252Fwopi%252Ffiles%252Fwhatever%3Faccess_token=ozxpkBByLTd9XnWaWHdrTVhMp3Exf1mt&access_token_ttl=0].| wsd/WopiProxy.cpp:37 [ websrv_poll ] DBG  #22: Getting info for wopi uri [https://whatever/nextcloud/index.php/apps/richdocuments/wopi/files/212272_ocbizrjb36ht?access_token=whatever&access_token_ttl=0]| wsd/WopiProxy.cpp:120 [ websrv_poll ] ERR  Invalid URI [] to http::Session::create| net/HttpRequest.cpp:664


Change-Id: I8471ee4247ecab62284e06330bd157aa126b9cd8


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

