### PR TITLE
wsd: do not remove quarantine files explicitly

### DIFF
--- a/test/UnitQuarantine.cpp
+++ b/test/UnitQuarantine.cpp
@@ -190,17 +190,8 @@ public:
         std::vector<std::string> files;
         Poco::File(_quarantinePath).list(files);
 
-        // VerifyOverwrite doesn't modify the document.
-        if (_scenario == Scenario::VerifyOverwrite)
-        {
-            LOK_ASSERT_MESSAGE("Expected no quaratined files in [" << _quarantinePath << ']',
-                               files.empty());
-        }
-        else
-        {
-            LOK_ASSERT_MESSAGE("Expected quaratined files in [" << _quarantinePath << ']',
-                               !files.empty());
-        }
+        LOK_ASSERT_MESSAGE("Expected 1 quaratined files in [" << _quarantinePath << ']',
+                           files.size() == 1);
 
         Base::onDocBrokerDestroy(docKey);
     }

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -674,12 +674,6 @@ void DocumentBroker::pollThread()
             }
         }
     }
-    else if (_quarantine)
-    {
-        // Gracefully unloaded.
-        LOG_DBG("Cleaning up quarantined files for [" << getDocKey() << ']');
-        _quarantine->removeQuarantinedFiles();
-    }
 
     // Async cleanup.
     COOLWSD::doHousekeeping();

--- a/wsd/QuarantineUtil.hpp
+++ b/wsd/QuarantineUtil.hpp
@@ -31,7 +31,7 @@ public:
     /// Returns the last quarantined file's path.
     std::string lastQuarantinedFilePath() const;
 
-    /// Removes the quarantined files for the given DocKey when we unload gracefully.
+    /// Removes the quarantined files for our DocKey.
     void removeQuarantinedFiles();
 
 private:


### PR DESCRIPTION
Let clearOldQuarantineVersions() remove quarantined
files only when necessary and per the config settings.

Change-Id: Ie1fb18c02d61a710546e9b5962ab8b7973c2066e
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
