### PR TITLE
calc: split pane mis-rendering.

### DIFF
--- a/browser/src/layer/tile/CanvasSectionContainer.ts
+++ b/browser/src/layer/tile/CanvasSectionContainer.ts
@@ -718,7 +718,10 @@ class CanvasSectionContainer {
 	private setDirty(coords: any) {
 		if (this.dirty == DirtyType.All)
 			return;
-		if (coords === null) {
+		if (coords === null ||
+		    // multi-clip needed for split-panes in drawSections.
+		    app.map._docLayer.getSplitPanesContext())
+		{
 			this.dirty = DirtyType.All;
 			this.dirtySubset = null;
 		}
@@ -2069,6 +2072,7 @@ class CanvasSectionContainer {
 			if (subsetBounds) {
 				this.context.save();
 
+				// FIXME: needs re-thinking for split-panes
 				this.context.translate(tileSection.myTopLeft[0], tileSection.myTopLeft[1]);
 				tileSection.clipSubsetBounds(this.context, subsetBounds);
 				this.context.translate(-tileSection.myTopLeft[0], -tileSection.myTopLeft[1]);
@@ -2091,7 +2095,6 @@ class CanvasSectionContainer {
 				}
 
 				this.sections[i].onDraw(frameCount, elapsedTime, subsetBounds);
-
 				if (this.sections[i].borderColor) { // If section's border is set, draw its borders after section's "onDraw" function is called.
 					this.context.lineWidth = app.dpiScale;
 					this.context.strokeStyle = this.sections[i].borderColor;


### PR DESCRIPTION
Invalidations were not cropped to the split pane, such that large invalidations that crossed from the mane pane over another top/left split pane, would cause partial re-render, flicker and other problems.

Regression from: 0453140f6180c4f82ec66c9515014b7341d732c4

Potential fix is to have a complex multi-rectangle clip region, or to only do this for simple cases, which are common: of invalidation within a single split pane, doing a complete re-render elsewhere.

Change-Id: I255806286f6c80a233d4c6ade2bcb4e12f2bf753


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

