### PR TITLE
annotation: avoid wheel event handling for comments

### DIFF
--- a/browser/src/layer/tile/CommentSection.ts
+++ b/browser/src/layer/tile/CommentSection.ts
@@ -146,13 +146,6 @@ export class Comment extends CanvasSectionObject {
 			},
 			this);
 
-		if ((<any>window).mode.isDesktop()) {
-			L.DomEvent.on(this.sectionProperties.container, {
-				mousewheel: this.map.scrollHandler._onWheelScroll,
-				MozMousePixelScroll: L.DomEvent.preventDefault
-			}, this.map.scrollHandler);
-		}
-
 		this.update();
 
 		this.pendingInit = false;


### PR DESCRIPTION
it was previously required to handle comment scrolling separately but not anymore it was introduced in a3e59d1

current problem:
when a comment is very long that it overflows and has a scroll bar, it is only possible to scroll using the scroll bar and mouse wheel didn't work

fixes #7735

Change-Id: I6d9f85c61b837f86e021a795e8af43b375a318d1


* Resolves: #7735
* Target version: master 


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

