### PR TITLE
Refactor: move tile limit accounting into ClientSession.

### DIFF
--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -43,6 +43,7 @@
 
 using namespace COOLProtocol;
 
+static constexpr float TILES_ON_FLY_MIN_UPPER_LIMIT = 10.0;
 static constexpr int SYNTHETIC_COOL_PID_OFFSET = 10000000;
 
 using Poco::Path;
@@ -2347,6 +2348,29 @@ void ClientSession::clearTilesOnFly()
     _tilesOnFly.clear();
 }
 
+size_t ClientSession::getTilesOnFlyUpperLimit() const
+{
+    // How many tiles we have on the visible area, set the upper limit accordingly
+    Util::Rectangle normalizedVisArea = getNormalizedVisibleArea();
+
+    float tilesOnFlyUpperLimit = 0;
+    if (normalizedVisArea.hasSurface() && getTileWidthInTwips() != 0 && getTileHeightInTwips() != 0)
+    {
+        const int tilesFitOnWidth = std::ceil(normalizedVisArea.getRight() / getTileWidthInTwips()) -
+                                    std::ceil(normalizedVisArea.getLeft() / getTileWidthInTwips()) + 1;
+        const int tilesFitOnHeight = std::ceil(normalizedVisArea.getBottom() / getTileHeightInTwips()) -
+                                     std::ceil(normalizedVisArea.getTop() / getTileHeightInTwips()) + 1;
+        const int tilesInVisArea = tilesFitOnWidth * tilesFitOnHeight;
+
+        tilesOnFlyUpperLimit = std::max(TILES_ON_FLY_MIN_UPPER_LIMIT, tilesInVisArea * 1.1f);
+    }
+    else
+    {
+        tilesOnFlyUpperLimit = 200; // Have a big number here to get all tiles requested by file opening
+    }
+    return tilesOnFlyUpperLimit;
+}
+
 void ClientSession::removeOutdatedTilesOnFly()
 {
     // Check only the beginning of the list, tiles are ordered by timestamp
@@ -2455,6 +2479,7 @@ void ClientSession::onDisconnect()
 void ClientSession::dumpState(std::ostream& os)
 {
     Session::dumpState(os);
+    const std::shared_ptr<DocumentBroker> docBroker = _docBroker.lock();
 
     os << "\t\tisLive: " << isLive()
        << "\n\t\tisViewLoaded: " << isViewLoaded()
@@ -2472,7 +2497,11 @@ void ClientSession::dumpState(std::ostream& os)
        << "\n\t\tclipboardKeys[1]: " << _clipboardKeys[1]
        << "\n\t\tclip sockets: " << _clipSockets.size()
        << "\n\t\tproxy access:: " << _proxyAccess
-       << "\n\t\tclientSelectedMode: " << _clientSelectedMode;
+       << "\n\t\tclientSelectedMode: " << _clientSelectedMode
+       << "\n\t\tonFlyCount: " << getTilesOnFlyCount()
+       << "\n\t\tonFlyUpperLimit: " << getTilesOnFlyUpperLimit()
+       << "\n\t\trequestedTiles: " << getRequestedTiles().size()
+       << "\n\t\tbeingRendered: " << (!docBroker ? -1 : docBroker->tileCache().countTilesBeingRenderedForSession(client_from_this(), std::chrono::steady_clock::now()));
 
     if (_protocol)
     {

--- a/wsd/ClientSession.hpp
+++ b/wsd/ClientSession.hpp
@@ -190,6 +190,7 @@ public:
     void addTileOnFly(const TileDesc& tile);
     void clearTilesOnFly();
     size_t getTilesOnFlyCount() const { return _tilesOnFly.size(); }
+    size_t getTilesOnFlyUpperLimit() const;
     void removeOutdatedTilesOnFly();
     size_t countIdenticalTilesOnFly(const TileDesc& tile) const;
 

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -57,8 +57,6 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 
-#define TILES_ON_FLY_MIN_UPPER_LIMIT 10.0f
-
 using namespace COOLProtocol;
 
 using Poco::JSON::Object;
@@ -3339,24 +3337,7 @@ void DocumentBroker::sendRequestedTiles(const std::shared_ptr<ClientSession>& se
 {
     std::unique_lock<std::mutex> lock(_mutex);
 
-    // How many tiles we have on the visible area, set the upper limit accordingly
-    Util::Rectangle normalizedVisArea = session->getNormalizedVisibleArea();
-
-    float tilesOnFlyUpperLimit = 0;
-    if (normalizedVisArea.hasSurface() && session->getTileWidthInTwips() != 0 && session->getTileHeightInTwips() != 0)
-    {
-        const int tilesFitOnWidth = std::ceil(normalizedVisArea.getRight() / session->getTileWidthInTwips()) -
-                                    std::ceil(normalizedVisArea.getLeft() / session->getTileWidthInTwips()) + 1;
-        const int tilesFitOnHeight = std::ceil(normalizedVisArea.getBottom() / session->getTileHeightInTwips()) -
-                                     std::ceil(normalizedVisArea.getTop() / session->getTileHeightInTwips()) + 1;
-        const int tilesInVisArea = tilesFitOnWidth * tilesFitOnHeight;
-
-        tilesOnFlyUpperLimit = std::max(TILES_ON_FLY_MIN_UPPER_LIMIT, tilesInVisArea * 1.1f);
-    }
-    else
-    {
-        tilesOnFlyUpperLimit = 200; // Have a big number here to get all tiles requested by file opening
-    }
+    size_t tilesOnFlyUpperLimit = session->getTilesOnFlyUpperLimit();
 
     // Drop tiles which we are waiting for too long
     session->removeOutdatedTilesOnFly();


### PR DESCRIPTION
Also add state dumping of tile on the fly statistics per session.

Change-Id: I8413cdfd489be3c238738f95d9d5c4aa177ff262


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

