### PR TITLE
wsd: fix missing session handling in DocumentBroker::forwardToChild()

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -3610,8 +3610,11 @@ bool DocumentBroker::forwardToChild(const std::shared_ptr<ClientSession>& sessio
 
     ASSERT_CORRECT_THREAD();
     LOG_ASSERT_MSG(session, "Must have a valid ClientSession");
-    LOG_ASSERT_MSG(_sessions.find(session->getId()) != _sessions.end(),
-                   "ClientSession must be known");
+    if (_sessions.find(session->getId()) == _sessions.end())
+    {
+        LOG_WRN("ClientSession must be known");
+        return false;
+    }
 
     // Ignore userinactive, useractive message until document is loaded
     if (!isLoaded() && (message == "userinactive" || message == "useractive"))


### PR DESCRIPTION
To reproduce:

	./clientsession_fuzzer -max_len=16384 fuzzer/data/crash-32e5136d2291e6c5fa99aa5942acded42b66a528

Failed with:

    #7 0x7f1aeb9c9cf1 in __assert_fail (/lib64/libc.so.6+0x42cf1) (BuildId: f732026552f6adff988b338e92d466bc81a01c37)
    #8 0x55a9f13968a5 in DocumentBroker::forwardToChild(std::shared_ptr<ClientSession> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, bool) /home/vmiklos/git/collaboraonline/online-fuzz/wsd/DocumentBroker.cpp:3613:5
    #9 0x55a9f1676a9a in ClientSession::forwardToChild(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::shared_ptr<DocumentBroker> const&) /home/vmiklos/git/collaboraonline/online-fuzz/wsd/ClientSession.cpp:1414:23
    #10 0x55a9f166f96a in ClientSession::_handleInput(char const*, int) /home/vmiklos/git/collaboraonline/online-fuzz/wsd/ClientSession.cpp:1100:20

The reproducer was originally added in commit
aefc65465b255e09ee2f66cbebaf1b2e54ded40c (wsd: fix crash when downloadas
has not enough parameters, 2020-02-21), but now it also triggered this
assertion failure problem as well.

The brave assert was added in commit
b2aff3e8178cd6642242749209ebf238b00ff3d9 (wsd: pass ClientSession to
forwardToChild, 2022-11-26).

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I4a0adda49aa2d24925d448fa5753509917d2585a
