### PR TITLE
Make sure to set the correct normalized view id for the tiles.

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -3198,6 +3198,12 @@ void DocumentBroker::handleTileCombinedRequest(TileCombined& tileCombined, bool 
     // Drop duplicated tiles, but use newer version number
     else
     {
+        // Make sure that the old request has the same normalizedviewid with the new request.
+        for (size_t i = 0; i < requestedTiles.size(); i++) {
+            if (requestedTiles[i].getNormalizedViewId() != session->getCanonicalViewId())
+                requestedTiles[i].setNormalizedViewId(session->getCanonicalViewId());
+        }
+
         for (const auto& newTile : tileCombined.getTiles())
         {
             bool tileFound = false;


### PR DESCRIPTION
When user switches to dark theme, previously requested tiles' normalizedViewIds may need to be updated.

Issue:
Users sometimes were getting tiles from the wrong theme.


Change-Id: Ie3324eb3f4879da5bfd0738513409e190422a9c0


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

