### PR TITLE
duplicate jsdialog messages seen in UnitBadDocLoad

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1063,6 +1063,7 @@ public:
                     // TODO.  It should filter some messages
                     // before loading the document
                     session->getProtocol()->enableProcessInput(true);
+                    return;
                 }
             }
         }


### PR DESCRIPTION
debugging some intermittent failures in UnitBadDocLoad I see that there are some duplicate jsdialog messages appearing which is easily reproducible by just opening test/data/corrupted.odt in online.

probably has been like this since:

commit 7f7019772316ade43f2241e7f99e35c20424768a
Date:   Mon Dec 28 11:37:27 2020 -0400

    kit: enable input process when early dialog show

and possibly not the problem I was originally trying to chase


Change-Id: I7aa342e86ad9ae73082cb71f1b2c9b2bf0f212b9


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

