### PR TITLE
fix: tiles not updated after reconnection

### DIFF
--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -1557,6 +1557,7 @@ app.definitions.Socket = L.Class.extend({
 				this._map._isCursorVisible = false;
 
 			this._map._docLayer._resetCanonicalIdStatus();
+			this._map.uiManager.previousTheme = null;
 		}
 
 		if (isActive && this._reconnecting) {


### PR DESCRIPTION
from idle

The following scenario was affected:
- user A and B both goes idle
- user B starts typing
- user A reconnects, all tiles updated by user B were not getting reflected for user A

Mismatch of canonical ids was causing the issue. On reconnection, tilecombine messages were sent before uno:ChangeTheme can update the canonical id on server side, therefore the received tile cache from server were from old canonical id(https://github.com/CollaboraOnline/online/blob/4a8974d107896c7fb4b7c35e326b52a986144a8b/wsd/ClientSession.cpp#L1379).

By reseting the previousTheme on connection we make sure there after canonicalidchange we invalidate all the tiles


Change-Id: I874bfe0bd71d176bacf0c7aa768e49613535ebd5


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

