### PR TITLE
add hasWASMSupport to capabilities

### DIFF
--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -5548,6 +5548,9 @@ private:
         // Set if this instance supports Zotero
         capabilities->set("hasZoteroSupport", config::getBool("zotero.enable", true));
 
+        // Set if this instance supports Zotero
+        capabilities->set("hasWASMSupport", COOLWSD::WASMState != COOLWSD::WASMActivationState::Disabled);
+
         std::ostringstream ostrJSON;
         capabilities->stringify(ostrJSON);
         return ostrJSON.str();

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -1254,10 +1254,16 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     // addHeader('Cross-Origin-Opener-Policy', 'same-origin');
     // addHeader('Cross-Origin-Embedder-Policy', 'require-corp');
     // then we seem to have to have this to avoid
-    // NS_ERROR_DOM_CORP_FAILED
-    oss << "Cross-Origin-Opener-Policy: same-origin\r\n";
-    oss << "Cross-Origin-Embedder-Policy: require-corp\r\n";
-    oss << "Cross-Origin-Resource-Policy: cross-origin\r\n";
+    // NS_ERROR_DOM_CORP_FAILED.
+    //
+    // We expect richdocuments to require these headers if our
+    // capabilities shows hasWASMSupport
+    if (COOLWSD::WASMState != COOLWSD::WASMActivationState::Disabled)
+    {
+        oss << "Cross-Origin-Opener-Policy: same-origin\r\n";
+        oss << "Cross-Origin-Embedder-Policy: require-corp\r\n";
+        oss << "Cross-Origin-Resource-Policy: cross-origin\r\n";
+    }
 
     const bool wasm = (relPath.find("wasm") != std::string::npos);
     if (wasm)


### PR DESCRIPTION
so the launching site can query if wasm is enabled to see if it needs to insert the required headers, so we can then in turn make it optional on those being set to also require matching headers.


Change-Id: Icd73081809abb8098c21bc61a8357869db45ff6c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

