### PR TITLE
framed.doc: if entering bad message data, recover

### DIFF
--- a/browser/html/framed.doc.html
+++ b/browser/html/framed.doc.html
@@ -205,6 +205,18 @@
             });
       }
 
+      // Wrap the message execution to catch exceptions
+      function executeMessage() {
+          try {
+              Execute(
+                  document.getElementById('execute-message').value,
+                  JSON.parse(document.getElementById('execute-param').value)
+              );
+          } catch(e) {
+              console.error("Execute message error:", e);
+          }
+      }
+
       function Execute(messageId, values) {
         post({'MessageId': messageId, 'Values': values});
       }
@@ -474,7 +486,7 @@
                 <textarea name="execute-param" id="execute-param">{}</textarea>
               </div>
             </div>
-            <button onclick="Execute(document.getElementById('execute-message').value, JSON.parse(document.getElementById('execute-param').value)); return false;">Execute</button>
+            <button onclick="executeMessage(); return false;">Execute</button>
           </form>
         </div>
       </div>


### PR DESCRIPTION
Change-Id: I6337029fe1eeffb7f20acaa100602ea44a0dbc63


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

If JSON.parse() failed this cause an error that lead to the button click considered
like a form submission.

### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

