### PR TITLE
notebookbar: don't send events to core

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -1210,9 +1210,12 @@ L.Control.JSDialogBuilder = L.Control.extend({
 					builder.wizard.setTabs(tabsContainer, builder);
 
 				tabs.forEach(function (tab, index) {
+					var eventHandler = builder._createTabClick(builder, index, tabs, contentDivs, tabIds);
 					tab.addEventListener('click', function(event) {
-						builder._createTabClick(builder, index, tabs, contentDivs, tabIds)(event);
-						builder.callback('tabcontrol', 'selecttab', tabWidgetRootContainer, index, builder);
+						eventHandler(event);
+						if (!data.noCoreEvents) {
+							builder.callback('tabcontrol', 'selecttab', tabWidgetRootContainer, index, builder);
+						}
 					});
 				});
 

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -2863,6 +2863,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 						{
 							'id': 'ContextContainer',
 							'type': 'tabcontrol',
+							'noCoreEvents': true,
 							'text': '',
 							'enabled': 'true',
 							'selected': selectedPage,


### PR DESCRIPTION
switching tabs should not send events to the core
notebookbar is online-only widget
