### PR TITLE
Do not refresh notebookbar when we start in read-only mode for txt an…

### DIFF
--- a/browser/src/control/Control.Zotero.js
+++ b/browser/src/control/Control.Zotero.js
@@ -136,7 +136,7 @@ L.Control.Zotero = L.Control.extend({
 	},
 
 	refreshUI: function () {
-		if (this.map.uiManager.notebookbar)
+		if (this.map.uiManager.notebookbar && !this.map._shouldStartReadOnly())
 			this.map.uiManager.refreshNotebookbar();
 		else
 			this.map.uiManager.refreshMenubar();


### PR DESCRIPTION
…d csv

This is a workaround for the bug, when a txt or a csv file was opened, and there were both the classic menu and the menu of the notebookbar at the same time at the top of the window. This bug occurred because regardless of the user's UI mode setting, the read-only mode has the classic menu. The fix also have a side effect, that is better than the original symptom. Now when a txt file is opened, and user starts editing it, the Zotero buttons won't be on the References tab. I think it's a good trade-off, but FIXME.
Eventually, when we won't have the classic UI mode any more, this problem would be solved better, for all corner cased (txt. csv, pdf, read-only shares etc.)


Change-Id: Ic3f95c02a0b75136a0b8069fa8297ed129b63865


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
![image](https://github.com/CollaboraOnline/online/assets/290614/5487c029-1a1f-4a8d-b2f6-a13a26c59f8f)


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

