### PR TITLE
enable window.logging before dumping delayed log

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -5157,8 +5157,8 @@ L.CanvasTileLayer = L.Layer.extend({
 				} else if (e.layer === this._debugTrace) {
 					app.socket.setTraceEventLogging(true);
 				} else if (e.layer === this._debugLogging) {
-					L.Log.print();
 					window.setLogging(true);
+					L.Log.print();
 				} else if (e.layer === this._debugTileDumping) {
 					app.socket.sendMessage('toggletiledumping true');
 				}


### PR DESCRIPTION
otherwise the carefully retained startup log message don't appear in a non-debugging online version


Change-Id: Ie4caf3462539e07f14f6c84bccab47fcbe9d5203


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

