### PR TITLE
WASM Switching

### DIFF
--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -213,7 +213,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				],
 				'vertical': true
 			});
-		
+
 		if (hasPrint) {
 			content.push(
 			{
@@ -368,6 +368,19 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 					'type': 'bigcustomtoolitem',
 					'text': _('Rename'),
 					'accessibility': { focusBack: true,	combination: 'RN' }
+				}
+			]
+		});
+
+		content.push({
+			'type': 'container',
+			'children': [
+				{
+					'id': 'togglewasm',
+					'class': 'togglewasm',
+					'type': 'bigcustomtoolitem',
+					'text': _(window.ThisIsTheEmscriptenApp ? 'Go Online' : 'Go Offline'),
+					'accessibility': { focusBack: true, combination: 'RN' }
 				}
 			]
 		});

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -163,6 +163,17 @@ L.Control.UIManager = L.Control.extend({
 		});
 	},
 
+	toggleWasm: function () {
+		if (window.ThisIsTheEmscriptenApp) {
+			//TODO: Should use the "external" socket.
+			// app.socket.sendMessage('switch_request online');
+		} else {
+			app.socket.sendMessage('switch_request offline');
+		}
+
+		// Wait for Coolwsd to initiate the switch.
+	},
+
 	getAccessibilityState: function() {
 		return window.isLocalStorageAllowed && window.localStorage.getItem('accessibilityState') === 'true';
 	},

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -1116,6 +1116,9 @@ L.Map.include({
 		case 'renamedocument':
 			this.uiManager.renameDocument();
 			break;
+		case 'togglewasm':
+			this.uiManager.toggleWasm();
+			break;
 		case 'print-active-sheet':
 			this.sendUnoCommand('.uno:DeletePrintArea');
 			var currentSheet = this._docLayer._selectedPart + 1;

--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -1161,6 +1161,10 @@ app.definitions.Socket = L.Class.extend({
 				textMsg = decodeURIComponent(window.escape(textMsg));
 			}
 		}
+		else if (textMsg.startsWith('reload')) {
+			// Switching modes.
+			location.reload();
+		}
 
 		if (textMsg.startsWith('status:')) {
 			this._onStatusMsg(textMsg, command);

--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -1105,6 +1105,9 @@ app.definitions.Socket = L.Class.extend({
 			if (textMsg === 'rename') {
 				msg = _('The document is being renamed and will reload shortly');
 			}
+			else if (textMsg === 'switchingtooffline') {
+				msg = _('The document is switching to Offline mode and will reload shortly');
+			}
 
 			this._map.fire('blockUI', {message: msg});
 			return;
@@ -1137,6 +1140,10 @@ app.definitions.Socket = L.Class.extend({
 			window.routeToken = textMsg.split(' ')[1];
 			window.app.console.log('updated routeToken: ' + window.routeToken);
 		}
+		else if (textMsg.startsWith('reload')) {
+			// Switching modes.
+			window.location.reload(false);
+		}
 		else if (!textMsg.startsWith('tile:') && !textMsg.startsWith('delta:') &&
 			 !textMsg.startsWith('renderfont:') && !textMsg.startsWith('windowpaint:')) {
 
@@ -1160,10 +1167,6 @@ app.definitions.Socket = L.Class.extend({
 				// on here, please replace this comment with an explanation.
 				textMsg = decodeURIComponent(window.escape(textMsg));
 			}
-		}
-		else if (textMsg.startsWith('reload')) {
-			// Switching modes.
-			location.reload();
 		}
 
 		if (textMsg.startsWith('status:')) {

--- a/common/Log.cpp
+++ b/common/Log.cpp
@@ -44,6 +44,14 @@ namespace
 /// Tracks the number of thread-local buffers (for debugging purposes).
 std::atomic_int32_t ThreadLocalBufferCount(0);
 
+#if WASMAPP
+/// In WASM, stdout works best.
+constexpr int LOG_FILE_FD = STDOUT_FILENO;
+#else
+/// By default, write to stderr.
+constexpr int LOG_FILE_FD = STDERR_FILENO;
+#endif
+
 } // namespace
 
 namespace Log
@@ -64,7 +72,7 @@ namespace Log
             for (; i < size;)
             {
                 int wrote;
-                while ((wrote = ::write(STDERR_FILENO, data + i, size - i)) < 0 && errno == EINTR)
+                while ((wrote = ::write(LOG_FILE_FD, data + i, size - i)) < 0 && errno == EINTR)
                 {
                 }
 

--- a/common/RenderTiles.hpp
+++ b/common/RenderTiles.hpp
@@ -42,7 +42,7 @@ public:
           _running(false)
     {
         int maxConcurrency = 2;
-#ifdef __EMSCRIPTEN__
+#if WASMAPP
         // Leave it at that.
 #elif MOBILEAPP && !defined(GTKAPP)
         maxConcurrency = std::max<int>(std::thread::hardware_concurrency(), 2);

--- a/config.h.in
+++ b/config.h.in
@@ -109,3 +109,5 @@
 /* Should we enable SIMD acceleration */
 #undef ENABLE_SIMD
 
+/* Define to 1 if this is the WASM app build. */
+#undef WASMAPP

--- a/configure.ac
+++ b/configure.ac
@@ -866,6 +866,9 @@ dnl ENABLE_WASM means that we are building the WASM "app" that will run locally 
 dnl client when necessary. ENABLE_WASM_FALLBACK and ENABLE_WASM can't both be on simultaneously.
 
 AM_CONDITIONAL([ENABLE_WASM], [test "$host_os" = "emscripten"])
+AS_IF([test "$host_os" = "emscripten"],
+      [AC_DEFINE([WASMAPP],1,[Define to 1 if this is the WASM app build.])],
+      [AC_DEFINE([WASMAPP],0,[Define to 1 if this is the WASM app build.])])
 
 MAX_CONNECTIONS=9999
 AS_IF([test -n "$with_max_connections" && test "$with_max_connections" -gt "0"],

--- a/configure.ac
+++ b/configure.ac
@@ -977,7 +977,7 @@ if test "x$with_sanitizer" != "x"; then
     for flag in -static-libasan -static-libsan ; do
         AC_MSG_CHECKING([whether to use $flag])
         save_CXXFLAGS=$CXXFLAGS
-        CXXFLAGS="$CXXFLAGS -O1 -fno-omit-frame-pointer -fsanitize=$with_sanitizer -frtti $flag -Werror"
+        CXXFLAGS="$CXXFLAGS -O1 -fno-omit-frame-pointer -fsanitize=$with_sanitizer -frtti $flag"
         AC_LANG_PUSH([C++])
         AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
             ]])],[CXXFLAGS_CXXSTD=$flag])
@@ -991,8 +991,8 @@ if test "x$with_sanitizer" != "x"; then
             AC_MSG_RESULT([no])
         fi
     done
-    SANITIZER_FLAGS="-O1 -fno-omit-frame-pointer -fsanitize=$with_sanitizer -frtti $LIBSAN"
-    CXXFLAGS="$CXXFLAGS $SANITIZER_FLAGS"
+    SANITIZER_FLAGS="-O1 -fno-omit-frame-pointer -fsanitize=$with_sanitizer $LIBSAN"
+    CXXFLAGS="$CXXFLAGS -frtti $SANITIZER_FLAGS"
     CFLAGS="$CFLAGS $SANITIZER_FLAGS"
 else
     AC_MSG_RESULT([no])

--- a/wasm/wasmapp.cpp
+++ b/wasm/wasmapp.cpp
@@ -24,7 +24,7 @@
 int coolwsd_server_socket_fd = -1;
 
 const char* user_name;
-const int SHOW_JS_MAXLEN = 200;
+constexpr std::size_t SHOW_JS_MAXLEN = 200;
 
 #define FILE_PATH "/sample.docx"
 static std::string fileURL = "file://" FILE_PATH;
@@ -74,11 +74,8 @@ static void send2JS(const std::vector<char>& buffer)
         js = js + "'});";
     }
 
-    std::string subjs = js.substr(0, std::min(std::string::size_type(SHOW_JS_MAXLEN), js.length()));
-    if (js.length() > SHOW_JS_MAXLEN)
-        subjs += "...";
-
-    LOG_TRC_NOFILE( "Evaluating JavaScript: " << subjs);
+    LOG_TRC_NOFILE("Evaluating JavaScript: " << js.substr(0, std::min(SHOW_JS_MAXLEN, js.size()))
+                                             << (js.size() > SHOW_JS_MAXLEN ? "..." : ""));
 
     MAIN_THREAD_EM_ASM(eval(UTF8ToString($0)), js.c_str());
 }

--- a/wasm/wasmapp.cpp
+++ b/wasm/wasmapp.cpp
@@ -9,7 +9,14 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include <config.h>
+
 #include "wasmapp.hpp"
+
+#include <FakeSocket.hpp>
+#include <Log.hpp>
+#include <COOLWSD.hpp>
+#include <Util.hpp>
 
 #include "base64.hpp"
 #include <emscripten/fetch.h>

--- a/wasm/wasmapp.hpp
+++ b/wasm/wasmapp.hpp
@@ -9,22 +9,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-#include <config.h>
-
-#include <chrono>
-#include <thread>
-
-#include <FakeSocket.hpp>
-#include <Kit.hpp>
-#include <Log.hpp>
-#include <COOLWSD.hpp>
-#include <Protocol.hpp>
-#include <SetupKitEnvironment.hpp>
-#include <Util.hpp>
-
-#include <LibreOfficeKit/LibreOfficeKit.hxx>
-#include <Poco/Base64Encoder.h>
-
 #if WASMAPP
 #include <emscripten.h>
 #include <emscripten/bind.h>

--- a/wasm/wasmapp.hpp
+++ b/wasm/wasmapp.hpp
@@ -25,7 +25,7 @@
 #include <LibreOfficeKit/LibreOfficeKit.hxx>
 #include <Poco/Base64Encoder.h>
 
-#ifdef __EMSCRIPTEN__
+#if WASMAPP
 #include <emscripten.h>
 #include <emscripten/bind.h>
 #include <emscripten/html5.h>

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -11,10 +11,12 @@
 
 #include <config.h>
 #include <config_version.h>
-#include <stdexcept>
+
 #include "COOLWSD.hpp"
 #include "ProofKey.hpp"
+#if ENABLE_FEATURE_LOCK
 #include "CommandControl.hpp"
+#endif
 #include "HostUtil.hpp"
 
 /* Default host used in the start test URI */
@@ -63,6 +65,7 @@
 #include <map>
 #include <mutex>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <thread>
 #include <unordered_map>

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -2358,6 +2358,13 @@ void COOLWSD::innerInitialize(Application& self)
     setenv("SAL_LOG", salLog.c_str(), 0);
 #endif
 
+#if WASMAPP
+    // In WASM, we want to log to the Log Console.
+    // Disable logging to file to log to stdout and
+    // disable color since this isn't going to the terminal.
+    constexpr bool withColor = false;
+    constexpr bool logToFile = false;
+#else
     const bool withColor = getConfigValue<bool>(conf, "logging.color", true) && isatty(fileno(stderr));
     if (withColor)
     {
@@ -2393,6 +2400,7 @@ void COOLWSD::innerInitialize(Application& self)
                       << std::endl;
         }
     }
+#endif
 
     // Log at trace level until we complete the initialization.
     LogLevelStartup = getConfigValue<std::string>(conf, "logging.level_startup", "trace");

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -2460,6 +2460,7 @@ void COOLWSD::innerInitialize(Application& self)
     if (getSafeConfig(conf, "storage.wopi.reuse_cookies", reuseCookies))
         LOG_WRN("NOTE: Deprecated config option storage.wopi.reuse_cookies - no longer supported.");
 
+#if !MOBILEAPP
     COOLWSD::WASMState = getConfigValue<bool>(conf, "wasm.enable", false)
                              ? COOLWSD::WASMActivationState::Enabled
                              : COOLWSD::WASMActivationState::Disabled;
@@ -2477,6 +2478,7 @@ void COOLWSD::innerInitialize(Application& self)
         LOG_INF("WASM is force-enabled. All documents will be loaded through WASM");
         COOLWSD::WASMState = COOLWSD::WASMActivationState::Forced;
     }
+#endif // !MOBILEAPP
 
     // Get anonymization settings.
 #if COOLWSD_ANONYMIZE_USER_DATA
@@ -4352,6 +4354,7 @@ private:
                 // is 'lool' e.g. when integrations use the old /lool/convert-to endpoint
                 handlePostRequest(requestDetails, request, message, disposition, socket);
             }
+#if !MOBILEAPP
             else if (requestDetails.equals(RequestDetails::Field::Type, "wasm"))
             {
                 if (COOLWSD::WASMState == COOLWSD::WASMActivationState::Disabled)
@@ -4368,6 +4371,7 @@ private:
                 _wopiProxy = std::make_unique<WopiProxy>(_id, requestDetails, socket);
                 _wopiProxy->handleRequest(*WebServerPoll, disposition);
             }
+#endif // !MOBILEAPP
             else
             {
                 LOG_ERR("Unknown resource: " << requestDetails.toString());
@@ -5559,8 +5563,10 @@ private:
         // Set if this instance supports Zotero
         capabilities->set("hasZoteroSupport", config::getBool("zotero.enable", true));
 
-        // Set if this instance supports Zotero
+#if !MOBILEAPP
+        // Set if this instance supports WASM.
         capabilities->set("hasWASMSupport", COOLWSD::WASMState != COOLWSD::WASMActivationState::Disabled);
+#endif // !MOBILEAPP
 
         std::ostringstream ostrJSON;
         capabilities->stringify(ostrJSON);

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -975,6 +975,7 @@ bool COOLWSD::SingleKit = false;
 bool COOLWSD::ForceCaching = false;
 #endif
 COOLWSD::WASMActivationState COOLWSD::WASMState = COOLWSD::WASMActivationState::Disabled;
+std::unordered_map<std::string, std::chrono::steady_clock::time_point> COOLWSD::Uri2WasmModeMap;
 #endif
 std::string COOLWSD::SysTemplate;
 std::string COOLWSD::LoTemplate = LO_PATH;

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -166,7 +166,7 @@ using Poco::Net::PartHandler;
 #include "gtk.hpp"
 #elif defined(__ANDROID__)
 #include "androidapp.hpp"
-#elif defined(__EMSCRIPTEN__)
+#elif WASMAPP
 #include "wasmapp.hpp"
 #endif
 #endif
@@ -2879,7 +2879,7 @@ void COOLWSD::innerInitialize(Application& self)
         COOLWSD::MaxDocuments = COOLWSD::MaxConnections;
     }
 
-#if !defined __EMSCRIPTEN__
+#if !WASMAPP
     struct rlimit rlim;
     ::getrlimit(RLIMIT_NOFILE, &rlim);
     LOG_INF("Maximum file descriptor supported by the system: " << rlim.rlim_cur - 1);
@@ -6115,7 +6115,7 @@ int COOLWSD::innerMain()
     // Start the server.
     Server->start();
 
-#if defined(__EMSCRIPTEN__)
+#if WASMAPP
     // It is not at all obvious that this is the ideal place to do the HULLO thing and call onopen
     // on TheFakeWebSocket. But it seems to work.
     handle_cool_message("HULLO");

--- a/wsd/COOLWSD.hpp
+++ b/wsd/COOLWSD.hpp
@@ -276,16 +276,6 @@ public:
     static std::string LOKitVersion;
     static bool EnableTraceEventLogging;
     static bool EnableAccessibility;
-    enum class WASMActivationState
-    {
-        Disabled,
-        Enabled
-#ifdef ENABLE_DEBUG
-        ,
-        Forced //< When Forced, only WASM is served.
-#endif
-    };
-    static WASMActivationState WASMState;
     static FILE *TraceEventFile;
     static void writeTraceEventRecording(const char *data, std::size_t nbytes);
     static void writeTraceEventRecording(const std::string &recording);
@@ -304,6 +294,23 @@ public:
 
     /// The file request handler used for file-serving.
     static std::unique_ptr<FileServerRequestHandler> FileRequestHandler;
+
+    /// The WASM support/activation state.
+    enum class WASMActivationState
+    {
+        Disabled,
+        Enabled
+#ifdef ENABLE_DEBUG
+        ,
+        Forced //< When Forced, only WASM is served.
+#endif
+    };
+    static WASMActivationState WASMState;
+
+    /// Tracks the URIs that are switching to Disconnected (WASM) Mode.
+    /// The time is when the switch request was made. We expire the request after a certain
+    /// time, in case the user fails to load WASM, it will revert to Collaborative mode.
+    static std::unordered_map<std::string, std::chrono::steady_clock::time_point> Uri2WasmModeMap;
 #endif
 
     static std::unordered_set<std::string> EditFileExtensions;

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1050,6 +1050,18 @@ bool ClientSession::_handleInput(const char *buffer, int length)
         _auth.resetAccessToken(tokens[1]);
         return true;
     }
+    else if (tokens.equals(0, "switch_request"))
+    {
+        if (tokens.size() != 2)
+        {
+            LOG_ERR("Bad syntax for: " << tokens[0]);
+            sendTextFrameAndLogError("error: cmd=switch_request kind=syntax");
+            return false;
+        }
+
+        docBroker->switchMode(tokens[1]);
+        return true;
+    }
     else if (tokens.equals(0, "outlinestate") ||
              tokens.equals(0, "downloadas") ||
              tokens.equals(0, "getchildid") ||

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1060,7 +1060,7 @@ bool ClientSession::_handleInput(const char *buffer, int length)
             return false;
         }
 
-        docBroker->switchMode(tokens[1]);
+        docBroker->switchMode(client_from_this(), tokens[1]);
         return true;
     }
 #endif // !MOBILEAPP && !WASMAPP

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1050,6 +1050,7 @@ bool ClientSession::_handleInput(const char *buffer, int length)
         _auth.resetAccessToken(tokens[1]);
         return true;
     }
+#if !MOBILEAPP && !WASMAPP
     else if (tokens.equals(0, "switch_request"))
     {
         if (tokens.size() != 2)
@@ -1062,6 +1063,7 @@ bool ClientSession::_handleInput(const char *buffer, int length)
         docBroker->switchMode(tokens[1]);
         return true;
     }
+#endif // !MOBILEAPP && !WASMAPP
     else if (tokens.equals(0, "outlinestate") ||
              tokens.equals(0, "downloadas") ||
              tokens.equals(0, "getchildid") ||

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -4235,6 +4235,69 @@ void DocumentBroker::onUrpMessage(const char* data, size_t len)
     }
 }
 
+void DocumentBroker::switchMode(const std::string& mode)
+{
+    if (mode == "online")
+    {
+        //TODO: Sanity check that we aren't running in WASM, otherwise we can't do anything.
+        startSwitchingToOnline();
+    }
+    else if (mode == "offline")
+    {
+        // We must be in Collaborative mode.
+
+        startSwitchingToOffline();
+    }
+}
+
+void DocumentBroker::startSwitchingToOffline()
+{
+    LOG_DBG("Starting switching to Offline mode");
+
+    // Transition.
+    if (!startActivity(DocumentState::Activity::SwitchingToOffline))
+    {
+        // The issue is logged.
+        return;
+    }
+
+    // Block the UI to prevent further changes and notify the user.
+    blockUI("switchingtooffline");
+}
+
+void DocumentBroker::endSwitchingToOffline()
+{
+    LOG_DBG("Ending switching to Offline mode");
+
+    unblockUI();
+
+    endActivity();
+}
+
+void DocumentBroker::startSwitchingToOnline()
+{
+    LOG_DBG("Starting switching to Online mode");
+
+    // Transition.
+    if (!startActivity(DocumentState::Activity::SwitchingToOnline))
+    {
+        // The issue is logged.
+        return;
+    }
+
+    // Block the UI to prevent further changes and notify the user.
+    blockUI("switchingtoonline");
+}
+
+void DocumentBroker::endSwitchingToOnline()
+{
+    LOG_DBG("Ending switching to Online mode");
+
+    unblockUI();
+
+    endActivity();
+}
+
 // not beautiful - but neither is editing mobile project files.
 #if MOBILEAPP
 #  include "Exceptions.cpp"

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -4235,6 +4235,8 @@ void DocumentBroker::onUrpMessage(const char* data, size_t len)
     }
 }
 
+#if !MOBILEAPP && !WASMAPP
+
 void DocumentBroker::switchMode(const std::string& mode)
 {
     if (mode == "online")
@@ -4297,6 +4299,8 @@ void DocumentBroker::endSwitchingToOnline()
 
     endActivity();
 }
+
+#endif // !MOBILEAPP && !WASMAPP
 
 // not beautiful - but neither is editing mobile project files.
 #if MOBILEAPP

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -562,8 +562,10 @@ public:
 
     void onUrpMessage(const char* data, size_t len);
 
+#if !MOBILEAPP && !WASMAPP
     /// Switch between Online and Offline modes.
     void switchMode(const std::string& mode);
+#endif // !MOBILEAPP && !WASMAPP
 
 private:
     /// Get the session that can write the document for save / locking / uploading.
@@ -605,6 +607,7 @@ private:
     /// with the child and cleans up ChildProcess etc.
     void terminateChild(const std::string& closeReason);
 
+#if !MOBILEAPP && !WASMAPP
     /// Invoked to switch from Online to Offline mode.
     void startSwitchingToOffline();
     /// Finish switching to Offline.
@@ -614,6 +617,7 @@ private:
     void startSwitchingToOnline();
     /// Finish switching to Online.
     void endSwitchingToOnline();
+#endif // !MOBILEAPP && !WASMAPP
 
     /// Encodes whether or not saving is possible
     /// (regardless of whether we need to or not).
@@ -1342,8 +1346,10 @@ private:
                    Conflict, //< The document is conflicted in storaged.
                    Save, //< The document is being saved, manually or auto-save.
                    Upload, //< The document is being uploaded to storage.
+#if !MOBILEAPP && !WASMAPP
                    SwitchingToOffline, //< The document will switch to Offline mode.
                    SwitchingToOnline, //< The document will switch to Online mode.
+#endif // !MOBILEAPP && !WASMAPP
         );
 
         STATE_ENUM(Disconnected,

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -562,6 +562,9 @@ public:
 
     void onUrpMessage(const char* data, size_t len);
 
+    /// Switch between Online and Offline modes.
+    void switchMode(const std::string& mode);
+
 private:
     /// Get the session that can write the document for save / locking / uploading.
     /// Note that if there is no loaded and writable session, the first will be returned.
@@ -601,6 +604,16 @@ private:
     /// This gracefully terminates the connection
     /// with the child and cleans up ChildProcess etc.
     void terminateChild(const std::string& closeReason);
+
+    /// Invoked to switch from Online to Offline mode.
+    void startSwitchingToOffline();
+    /// Finish switching to Offline.
+    void endSwitchingToOffline();
+
+    /// Invoked to switch from Offline to Online mode.
+    void startSwitchingToOnline();
+    /// Finish switching to Online.
+    void endSwitchingToOnline();
 
     /// Encodes whether or not saving is possible
     /// (regardless of whether we need to or not).
@@ -1329,6 +1342,8 @@ private:
                    Conflict, //< The document is conflicted in storaged.
                    Save, //< The document is being saved, manually or auto-save.
                    Upload, //< The document is being uploaded to storage.
+                   SwitchingToOffline, //< The document will switch to Offline mode.
+                   SwitchingToOnline, //< The document will switch to Online mode.
         );
 
         STATE_ENUM(Disconnected,

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -564,7 +564,7 @@ public:
 
 #if !MOBILEAPP && !WASMAPP
     /// Switch between Online and Offline modes.
-    void switchMode(const std::string& mode);
+    void switchMode(const std::shared_ptr<ClientSession>& session, const std::string& mode);
 #endif // !MOBILEAPP && !WASMAPP
 
 private:
@@ -609,7 +609,7 @@ private:
 
 #if !MOBILEAPP && !WASMAPP
     /// Invoked to switch from Online to Offline mode.
-    void startSwitchingToOffline();
+    void startSwitchingToOffline(const std::shared_ptr<ClientSession>& session);
     /// Finish switching to Offline.
     void endSwitchingToOffline();
 

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -615,6 +615,8 @@ private:
 
     /// Invoked to switch from Offline to Online mode.
     void startSwitchingToOnline();
+    /// Do the switching when all is ready.
+    void switchToOffline();
     /// Finish switching to Online.
     void endSwitchingToOnline();
 #endif // !MOBILEAPP && !WASMAPP

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -12,6 +12,7 @@
 #include <config.h>
 #include <config_version.h>
 
+#include <chrono>
 #include <iomanip>
 #include <string>
 #include <vector>
@@ -49,6 +50,7 @@
 #include "FileServer.hpp"
 #include "COOLWSD.hpp"
 #include "FileUtil.hpp"
+#include "RequestDetails.hpp"
 #include "ServerURL.hpp"
 #include <Log.hpp>
 #include <Protocol.hpp>
@@ -532,7 +534,7 @@ void FileServerRequestHandler::handleRequest(const HTTPRequest& request,
         if (requestSegments.size() < 1)
             throw Poco::FileNotFoundException("Invalid URI request: [" + requestUri.toString() + "].");
 
-        const std::string relPath = getRequestPathname(request);
+        const std::string relPath = getRequestPathname(request, requestDetails);
         const std::string endPoint = requestSegments[requestSegments.size() - 1];
 
         static std::string etagString = "\"" COOLWSD_VERSION_HASH +
@@ -914,7 +916,8 @@ const std::string *FileServerRequestHandler::getUncompressedFile(const std::stri
     return &FileHash[path].first;
 }
 
-std::string FileServerRequestHandler::getRequestPathname(const HTTPRequest& request)
+std::string FileServerRequestHandler::getRequestPathname(const HTTPRequest& request,
+                                                         const RequestDetails& requestDetails)
 {
     Poco::URI requestUri(request.getURI());
     // avoid .'s and ..'s
@@ -931,19 +934,55 @@ std::string FileServerRequestHandler::getRequestPathname(const HTTPRequest& requ
     }
 
 #if !MOBILEAPP
+    bool isWasm = false;
+
     if (COOLWSD::WASMState == COOLWSD::WASMActivationState::Forced)
     {
-        if (path.find("/browser/dist/wasm/") == std::string::npos)
+        isWasm = (path.find("/browser/dist/wasm/") == std::string::npos);
+    }
+    else
+    {
+        const std::string wopiSrc = requestDetails.getLineModeKey(std::string());
+        if (!wopiSrc.empty())
         {
-            Poco::replaceInPlace(path, std::string("/browser/dist/"),
-                                 std::string("/browser/dist/wasm/"));
+            const auto it = COOLWSD::Uri2WasmModeMap.find(wopiSrc);
+            if (it != COOLWSD::Uri2WasmModeMap.end())
+            {
+                const bool isRecent =
+                    (std::chrono::steady_clock::now() - it->second) <= std::chrono::minutes(1);
+                isWasm = (isRecent && path.find("/browser/dist/wasm/") == std::string::npos);
+
+                // Clean up only after it expires, because we need it more than once.
+                if (!isRecent)
+                {
+                    COOLWSD::Uri2WasmModeMap.erase(it);
+                }
+            }
         }
     }
-    else if (COOLWSD::WASMState == COOLWSD::WASMActivationState::Disabled &&
-             path.find("wasm") != std::string::npos)
+
+    if (!isWasm)
     {
-        LOG_ERR("Requesting WASM files when it's disabled: [" << path << ']');
-        throw Poco::FileAccessDeniedException("WASM is disabled");
+        std::vector<std::string> requestSegments;
+        requestUri.getPathSegments(requestSegments);
+        const std::string endPoint = requestSegments[requestSegments.size() - 1];
+        if (endPoint == "online.js" || endPoint == "online.worker.js" ||
+            endPoint == "online.wasm" || endPoint == "online.data" || endPoint == "soffice.data")
+        {
+            isWasm = true;
+        }
+#if ENABLE_DEBUG
+        else if (endPoint == "online.wasm.debug.wasm" || endPoint == "soffice.data.js.metadata")
+        {
+            isWasm = true;
+        }
+#endif
+    }
+
+    if (isWasm)
+    {
+        Poco::replaceInPlace(path, std::string("/browser/dist/"),
+                             std::string("/browser/dist/wasm/"));
     }
 #endif // !MOBILEAPP
 
@@ -965,7 +1004,7 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     const Poco::URI::QueryParameters params = Poco::URI(request.getURI()).getQueryParameters();
 
     // Is this a file we read at startup - if not; it's not for serving.
-    const std::string relPath = getRequestPathname(request);
+    const std::string relPath = getRequestPathname(request, requestDetails);
     LOG_DBG("Preprocessing file: " << relPath);
     std::string preprocess = *getUncompressedFile(relPath);
 
@@ -1352,11 +1391,11 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
 
 
 void FileServerRequestHandler::preprocessWelcomeFile(const HTTPRequest& request,
-                                                     const RequestDetails &/*requestDetails*/,
+                                                     const RequestDetails& requestDetails,
                                                      Poco::MemoryInputStream& message,
                                                      const std::shared_ptr<StreamSocket>& socket)
 {
-    const std::string relPath = getRequestPathname(request);
+    const std::string relPath = getRequestPathname(request, requestDetails);
     LOG_DBG("Preprocessing file: " << relPath);
     std::string templateWelcome = *getUncompressedFile(relPath);
 
@@ -1399,7 +1438,7 @@ void FileServerRequestHandler::preprocessAdminFile(const HTTPRequest& request,
     static const std::string scriptJS("<script src=\"%s/browser/" COOLWSD_VERSION_HASH "/%s.js\"></script>");
     static const std::string footerPage("<footer class=\"footer has-text-centered\"><strong>Key:</strong> %s &nbsp;&nbsp;<strong>Expiry Date:</strong> %s</footer>");
 
-    const std::string relPath = getRequestPathname(request);
+    const std::string relPath = getRequestPathname(request, requestDetails);
     LOG_DBG("Preprocessing file: " << relPath);
     std::string adminFile = *getUncompressedFile(relPath);
     const std::string templatePath =

--- a/wsd/FileServer.hpp
+++ b/wsd/FileServer.hpp
@@ -25,7 +25,8 @@ class FileServerRequestHandler
 {
     friend class FileServeTests; // for unit testing
 
-    static std::string getRequestPathname(const Poco::Net::HTTPRequest& request);
+    static std::string getRequestPathname(const Poco::Net::HTTPRequest& request,
+                                          const RequestDetails& requestDetails);
 
     static void preprocessFile(const Poco::Net::HTTPRequest& request,
                                const RequestDetails &requestDetails,

--- a/wsd/RequestDetails.cpp
+++ b/wsd/RequestDetails.cpp
@@ -247,6 +247,17 @@ Poco::URI RequestDetails::sanitizeURI(const std::string& uri)
     return uriPublic;
 }
 
+std::string RequestDetails::getLineModeKey(const std::string& /*access_token*/) const
+{
+    // This key is based on the WOPISrc and the access_token only.
+    // However, we strip the host:port and scheme from the WOPISrc.
+    const std::string wopiSrc = Poco::URI(getField(RequestDetails::Field::WOPISrc)).getPath();
+
+    //FIXME: For now, just use the path.
+    // return wopiSrc + "?access_token=" + access_token;
+    return wopiSrc;
+}
+
 #if !defined(BUILDING_TESTS)
 std::string RequestDetails::getDocKey(const Poco::URI& uri)
 {

--- a/wsd/RequestDetails.hpp
+++ b/wsd/RequestDetails.hpp
@@ -156,7 +156,24 @@ public:
         return sanitizeURI(getField(Field::DocumentURI)).toString();
     }
 
+    /// Returns a key to be used with Online/Offline mode.
+    /// This is based on the WOPISrc path + access_token.
+    std::string getLineModeKey(const std::string& access_token) const;
+
     const std::map<std::string, std::string>& getDocumentURIParams() const { return _docUriParams; }
+
+    /// Returns a param, if it exists.
+    bool getParamByName(const std::string& name, std::string& value) const
+    {
+        const auto it = _docUriParams.find(name);
+        if (it != _docUriParams.end())
+        {
+            value = it->second;
+            return true;
+        }
+
+        return false;
+    }
 
     std::string getURI() const
     {

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -65,7 +65,7 @@
 #include "androidapp.hpp"
 #elif defined(GTKAPP)
 #include "gtk.hpp"
-#elif defined(__EMSCRIPTEN__)
+#elif WASMAPP
 #include "wasmapp.hpp"
 #endif
 


### PR DESCRIPTION
- configure: enable rtti with sanitizers on C++ TUs only
- wsd: reduce includes where possible
- configure: WASMAPP is now defined for WASM targets
- wasm: header include cleanup
- wasm: truncate string only if will log
- wasm: disable file and color logging
- wasm: log to stdout instead of stderr
- wasm: browser: add UI button to switch modes
- wasm: wsd: switch modes handlers
- wasm: wsd: make switching wasm-only
- wasm: wsd: switch modes handlers - check and save
- wasm: wsd: client handler to switch to disconnected
- wasm: wsd: coolwsd remembers disconnected mode preference
