### PR TITLE
Stop onscreen keyboards closing when used to move

### DIFF
--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -264,6 +264,18 @@ window.app = {
 		// alternatively, maybe someone else (e.g. an integrator) knows more about the situation than we do. In this case, let's
 		// let them override our default
 		hintOnscreenKeyboard: function(hint) {
+			if (global.app
+					&& global.L.Map
+					&& global.L.Map.THIS._docLayer.isCalc()
+					&& hint !== undefined) {
+				var command = {
+					Enable: {
+						type: 'boolean',
+						value: hint
+					}
+				};
+				global.L.Map.THIS.sendUnoCommand('.uno:MoveKeepInsertMode', command);
+			}
 			global.keyboard.onscreenKeyboardHint = hint;
 		},
 	};

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -367,7 +367,7 @@ L.Map.include({
 		var allowedCommands = ['.uno:Save', '.uno:WordCountDialog',
 			'.uno:Signature', '.uno:ShowResolvedAnnotations',
 			'.uno:ToolbarMode?Mode:string=notebookbar_online.ui', '.uno:ToolbarMode?Mode:string=Default',
-			'.uno:ExportToEPUB', '.uno:ExportToPDF', '.uno:ExportDirectToPDF'];
+			'.uno:ExportToEPUB', '.uno:ExportToPDF', '.uno:ExportDirectToPDF', '.uno:MoveKeepInsertMode'];
 		if (this.isPermissionEditForComments()) {
 			allowedCommands.push('.uno:InsertAnnotation','.uno:DeleteCommentThread', '.uno:DeleteAnnotation', '.uno:DeleteNote',
 				'.uno:DeleteComment', '.uno:ReplyComment', '.uno:ReplyToAnnotation', '.uno:ResolveComment',

--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -67,6 +67,7 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 		map.on('splitposchanged', this.setSplitCellFromPos, this);
 		map.on('commandstatechanged', this._onCommandStateChanged, this);
 		map.uiManager.initializeSpecializedUI('spreadsheet');
+		window.keyboard.hintOnscreenKeyboard(window.keyboard.onscreenKeyboardHint);
 	},
 
 	onAdd: function (map) {
@@ -399,6 +400,7 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 			if (app.socket._reconnecting) {
 				app.socket.sendMessage('setclientpart part=' + this._selectedPart);
 				this._resetInternalState();
+				window.keyboard.hintOnscreenKeyboard(window.keyboard.onscreenKeyboardHint);
 			} else {
 				this._selectedPart = command.selectedPart;
 			}


### PR DESCRIPTION
This relies on core change I5e6c93c64af0d201a8ec045fea5546e189baca74 (https://gerrit.libreoffice.org/c/core/+/160313) as the logic to keep the cell focused is from there.

Here we set the new option when there is an onscreen keyboard hint given by ui_defaults or a postmessage. As ui_defaults are set at page load, we need to wait to send our message until we're initializing everything else to set our options. Additionally, we need to use the socket directly rather than sending this through the map so that this bypasses things like readonly mode


Change-Id: Ie6d80c0e1ebca607b9d705b673ab8008fae39260


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

