### PR TITLE
fix: persistent snackbar after the document get idle

### DIFF
--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -87,7 +87,7 @@ L.Control.JSDialog = L.Control.extend({
 	closeAll: function(leaveSnackbar) {
 		var dialogs = Object.keys(this.dialogs);
 		for (var i = 0; i < dialogs.length; i++) {
-			if (leaveSnackbar && dialogs[i] && dialogs[i].isSnackbar)
+			if (leaveSnackbar && dialogs[i] && dialogs[i] === 'snackbar')
 				continue;
 
 			this.close(dialogs[i], true);

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -1049,6 +1049,8 @@ L.Control.UIManager = L.Control.extend({
 					callback();
 
 				that.closeSnackbar();
+			} else if (object.id === '__POPOVER__' && objectType === 'popover' && eventType === 'close') {
+				that.closeSnackbar();
 			}
 		};
 


### PR DESCRIPTION
Change-Id: I4ccc93dabb4dd260338d5a941b18ebaf8e42b1ad

- previously, when document was getting idle, it was
  showing a snackbar "The server is disconnected" which
  unnecessary plus the snackbar was persistent even
  after reconnection.
- There are two scenarios to be tested,
 1. It shouldn't show snackbar on idle
    - Set per_document / idle_timeout_secs to something small, eg. 30,
    - Open a document, and wait until it idles out.
    - make sure it doesn't show "The server is disconnected" snackbar
 2. It should show "The server is disconnected" snackbar when you shutdown
    the server, when you start the server again snackbar should disappear

* Resolves: # <!-- related github issue -->
* Target version: master 


