### PR TITLE
wasm is derived from the mobile, but doesn't have on-screen keyboard

### DIFF
--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -256,7 +256,7 @@ window.app = {
 		// Instead, let's just guess
 		guessOnscreenKeyboard: function() {
 			if (global.keyboard.onscreenKeyboardHint != undefined) return global.keyboard.onscreenKeyboardHint;
-			return window.ThisIsAMobileApp || global.mode.isMobile() || global.mode.isTablet();
+			return (window.ThisIsAMobileApp && !window.ThisIsTheEmscriptenApp) || global.mode.isMobile() || global.mode.isTablet();
 			// It's better to guess that more devices will have an onscreen keyboard than reality,
 			// because calc becomes borderline unusable if you miss a device that pops up an onscreen keyboard which covers
 			// a sizeable portion of the screen


### PR DESCRIPTION
There's a bit of a mobile/wasm munge with wasm considered a subset of mobile in some places which should be unwound a bit, but for the purposes of usable wasm by default, don't assume that wasm has an onscreen keyboard so we don't lose keystrokes on assuming that there will be an onscreen keyboard appearing when we lose and regain focus.


Change-Id: I0baae0d414ce9aafd1c27d74bcdad2276d104ee5


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

