### PR TITLE
Do not scroll the view outside of page bounds

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -25,6 +25,11 @@ function hex2string(inData)
 	return hexified.join('');
 }
 
+function clamp(num, min, max)
+{
+	return Math.min(Math.max(num, min), max);
+}
+
 // CStyleData is used to obtain CSS property values from style data
 // stored in DOM elements in the form of custom CSS properties/variables.
 var CStyleData = L.Class.extend({
@@ -3842,7 +3847,6 @@ L.CanvasTileLayer = L.Layer.extend({
 			return;
 		}
 
-		var cursorPos = this._visibleCursor.getNorthWest();
 		var docLayer = this._map._docLayer;
 
 		if (!zoom
@@ -3857,13 +3861,28 @@ L.CanvasTileLayer = L.Layer.extend({
 			// Cursor invalidation should take most precedence among all the scrolling to follow the cursor
 			// so here we disregard all the pending scrolling
 			this._map._docLayer._painter._sectionContainer.getSectionWithName(L.CSections.Scroll.name).pendingScrollEvent = null;
+			var correctedCursor = this._visibleCursor;
+
+			if (this._docType === 'text') {
+				// For Writer documents, disallow scrolling to cursor outside of the page (horizontally)
+				// Use document dimensions to approximate page width
+				var documentLatLngBounds = new L.LatLngBounds(
+					this._twipsToLatLng(new L.Point(0, 0), this._map.getZoom()),
+					this._twipsToLatLng(new L.Point(this._docWidthTwips - 1, 0), this._map.getZoom()));
+				var correctedWest = clamp(correctedCursor.getWest(), documentLatLngBounds.getWest(), documentLatLngBounds.getEast());
+				var correctedEast = clamp(correctedCursor.getEast(), documentLatLngBounds.getWest(), documentLatLngBounds.getEast());
+				correctedCursor = new L.LatLngBounds(
+					new L.LatLng(correctedCursor.getSouth(), correctedWest),
+					new L.LatLng(correctedCursor.getNorth(), correctedEast));
+			}
+
 			var paneRectsInLatLng = this.getPaneLatLngRectangles();
-			if (!this._visibleCursor.isInAny(paneRectsInLatLng)) {
+			if (!correctedCursor.isInAny(paneRectsInLatLng)) {
 				if (!(this._selectionHandles.start && this._selectionHandles.start.isDragged) &&
 				    !(this._selectionHandles.end && this._selectionHandles.end.isDragged) &&
 				    !(docLayer._followEditor || docLayer._followUser) &&
 				    !this._map.calcInputBarHasFocus()) {
-					this.scrollToPos(cursorPos);
+					this.scrollToPos(correctedCursor.getNorthWest());
 				}
 			}
 		}


### PR DESCRIPTION
Since core commit 690d4eb71509649ad147cfe60f5b97e2cfaaa519 (tdf#43100
tdf#104683 tdf#120715 sw: cursor on spaces over margin, 2022-07-04)
the cursor travels outside of text body area in Writer. Desktop view
doesn't follow the cursor in that case; the problem in Online was
that its view did follow the cursor. This resulted in the following
scenario:

1. Have a document with a thousand of trailing spaces in some line,
   before a word that would appear on a next line;
2. Put cursor to the beginning of that following line;
3. Press backspace (or left arrow key)

This resulted in the view jumping far to the right, with the page
being completely out of the view; the user only saw an empty screen
without any text, which was highly confusing.

Fix this by limiting the coordinates in _onUpdateCursor; use known
document size for that. This could still be problematic in case the
document has different-sized pages: the current page bound could be
narrower than document width. Yet, this seems to not be a big deal:
the view will likely still include part of a document, giving the
user a clue. An alternative would be to pass current page size with
invalidatecursor message from core.

Signed-off-by: Mike Kaganski <mike.kaganski@collabora.com>
Change-Id: I4d6cba7105d5aa2d1847bcb3994f93248b3f5ec6
