### PR TITLE
Update viewId in Writer after recover from idle

### DIFF
--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -405,6 +405,7 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 				this.requestSheetGeometryData();
 			}
 			this._viewId = parseInt(command.viewid);
+			console.assert(this._viewId >= 0, 'Incorrect viewId received: ' + this._viewId);
 			var mapSize = this._map.getSize();
 			var sizePx = this._twipsToPixels(new L.Point(this._docWidthTwips, this._docHeightTwips));
 			var width = sizePx.x;

--- a/browser/src/layer/tile/ImpressTileLayer.js
+++ b/browser/src/layer/tile/ImpressTileLayer.js
@@ -255,6 +255,7 @@ L.ImpressTileLayer = L.CanvasTileLayer.extend({
 			this._updateMaxBounds(true);
 			this._documentInfo = textMsg;
 			this._viewId = parseInt(command.viewid);
+			console.assert(this._viewId >= 0, 'Incorrect viewId received: ' + this._viewId);
 			if (app.socket._reconnecting) {
 				app.socket.sendMessage('setclientpart part=' + this._selectedPart);
 			} else {

--- a/browser/src/layer/tile/WriterTileLayer.js
+++ b/browser/src/layer/tile/WriterTileLayer.js
@@ -143,6 +143,12 @@ L.WriterTileLayer = L.CanvasTileLayer.extend({
 			return;
 
 		var sizeChanged = command.width !== this._docWidthTwips || command.height !== this._docHeightTwips;
+
+		if (command.viewid) {
+			this._viewId = parseInt(command.viewid);
+		}
+		console.assert(this._viewId >= 0, 'Incorrect viewId received: ' + this._viewId);
+
 		if (sizeChanged) {
 			this._docWidthTwips = command.width;
 			this._docHeightTwips = command.height;
@@ -150,7 +156,6 @@ L.WriterTileLayer = L.CanvasTileLayer.extend({
 			app.file.size.pixels = [Math.round(this._tileSize * (this._docWidthTwips / this._tileWidthTwips)), Math.round(this._tileSize * (this._docHeightTwips / this._tileHeightTwips))];
 			app.view.size.pixels = app.file.size.pixels.slice();
 			this._docType = command.type;
-			this._viewId = parseInt(command.viewid);
 			this._updateMaxBounds(true);
 		}
 


### PR DESCRIPTION
There was a bug in Writer not allowing to successfully reconnect after idle state if we were not a first view in the initial document. Let's update view id even if document size wasn't changed. Added also additional error logging to be sure we never use -1 viewId which is a default "bad value" when we enter some unwanted state in the core.

Steps to reproduce:
1. set per_document.idle_timeout_secs to something small, eg. 30, so sessions time out quickly,
2. Open a document with 2 sessions (remember which one was loaded first - A, important!)
3. wait for it to idle out in both sessions
4. activate SECOND session (B) by click on the document area

Result:
in the browser console you can see an exception:
Exception TypeError: this.map._viewInfo[this.map._docLayer._viewId] is undefined emitting event viewinfo: [{"id":0,"userid":"2","username":"LocalUser#2","readonly":"0","color":411298}] cool.html:359:37
