### PR TITLE
Fix bug in undoing deletion of a parent comment.

### DIFF
--- a/browser/src/layer/tile/CommentSection.ts
+++ b/browser/src/layer/tile/CommentSection.ts
@@ -59,6 +59,21 @@ export class Comment extends CanvasSectionObject {
 			data.parent = '0';
 
 		this.sectionProperties.data = data;
+
+		/*
+			possibleParentCommentId:
+				* User deletes a parent comment.
+				* User deletes also its child comment.
+				* User reverts the last change (deletion of child comment).
+				* A comment "Add" action is sent from the core side.
+				* The child comment has also its parent id.
+				* But there is no such parent at the moment.
+				* So we will remember its possible parent comment in case user also reverts the deletion of parent comment.
+				* In that case, parent comment will come with its old id.
+				* Child comment can now find its parent.
+				* We will check child comment to see if its parent has also been revived.
+		*/
+		this.sectionProperties.possibleParentCommentId = null;
 		this.sectionProperties.annotationMarker = null;
 		this.sectionProperties.wrapper = null;
 		this.sectionProperties.container = null;


### PR DESCRIPTION
Bug:
  When a parent and a child comments are removed then user reverts the action respectively:
    * Child comment is revived first and it cannot find its parent.

* Add a possibleParentCommentId to use in case also the parent comment is revived.
* Consider the child comment as a parent until parent appears.

Other changes:
* Remove duplicate call to updateIdIndexMap.
* Remove duplicate call to unselect.
* Remove duplicate call to adjustParentAdd.
* Reorder the 'remove' operation's rows: To avoid unselecting the comment after it is removed.


Change-Id: I2247b23c710236c578b5b5c78d2b7bb45f7a51b4


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

