### PR TITLE
serve wasm metadata

### DIFF
--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -971,12 +971,10 @@ std::string FileServerRequestHandler::getRequestPathname(const HTTPRequest& requ
         {
             isWasm = true;
         }
-#if ENABLE_DEBUG
         else if (endPoint == "online.wasm.debug.wasm" || endPoint == "soffice.data.js.metadata")
         {
             isWasm = true;
         }
-#endif
     }
 
     if (isWasm)


### PR DESCRIPTION
[ websrv_poll ] ERR  FileServerRequestHandler: File not found: Invalid URI request: [/browser/515f66e2bc/soffice.data.js.metadata].| wsd/FileServer.cpp:738


Change-Id: I6e4bb8a5a617f4ff8921430eae1f23147fd1a8cd


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

