### PR TITLE
Refresh cell cursor after recover from idle in Calc

### DIFF
--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -90,10 +90,14 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 		app.sectionContainer.addSection(new app.definitions.AutoFillMarkerSection());
 
 		this.insertMode = false;
+		this._resetInternalState();
+		this._sheetSwitch = new L.SheetSwitchViewRestore(map);
+	},
+
+	_resetInternalState: function() {
 		this._cellSelections = Array(0);
 		this._cellCursorXY = new L.Point(-1, -1);
 		this._gotFirstCellCursor = false;
-		this._sheetSwitch = new L.SheetSwitchViewRestore(map);
 		this._lastColumn = 0; // with data
 		this._lastRow = 0; // with data
 		this.requestCellCursor();
@@ -387,8 +391,6 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 				this._map.setPermission('readonly');
 			this._docWidthTwips = command.width;
 			this._docHeightTwips = command.height;
-			this._lastColumn = command.lastcolumn;
-			this._lastRow = command.lastrow;
 			app.file.size.twips = [this._docWidthTwips, this._docHeightTwips];
 			app.file.size.pixels = [Math.round(this._tileSize * (this._docWidthTwips / this._tileWidthTwips)), Math.round(this._tileSize * (this._docHeightTwips / this._tileHeightTwips))];
 			app.view.size.pixels = app.file.size.pixels.slice();
@@ -396,9 +398,12 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 			this._parts = command.parts;
 			if (app.socket._reconnecting) {
 				app.socket.sendMessage('setclientpart part=' + this._selectedPart);
+				this._resetInternalState();
 			} else {
 				this._selectedPart = command.selectedPart;
 			}
+			this._lastColumn = command.lastcolumn;
+			this._lastRow = command.lastrow;
 			this._selectedMode = (command.mode !== undefined) ? command.mode : 0;
 			if (this.sheetGeometry && this._selectedPart != this.sheetGeometry.getPart()) {
 				// Core initiated sheet switch, need to get full sheetGeometry data for the selected sheet.


### PR DESCRIPTION
We were using old cursor data after recovering the view from idle state. For the user there was impression that view jumped at some point - caused by other user action. But it was just an update to real cursor position which scrolled view to it, because previously we were showing some other place in the spreadsheet.

Steps to reproduce bug:

1. Open spreadsheet with 2 views
2. B should have cursor in the bottom part of sheet, let's say row 600
3. Wait for idle in both sessions
4. Open the same spreadsheet with some other user C
5. C does some action on row 300 and goes away (closes tab)
6. User B activates view and selects row 600
7. User A activates view (he should be at the top still)
8. User B changes font size using dropdown in notebookbar, or double clicks on any row header

Result: view A jumps to other place

When we initially connect to the spreadsheet then
requestCellCursor is called in onAdd. Also
_gotFirstCellCursor is not set.

Let's do the same on reconnect so we will have similar effect to clean startup.