### PR TITLE
wasm often doesn't get tiles after invalidates

### DIFF
--- a/wasm/wasmapp.cpp
+++ b/wasm/wasmapp.cpp
@@ -148,14 +148,11 @@ void handle_cool_message(const char *string_value)
         LOG_TRC_NOFILE("Actually sending to Online:" << fileURL);
         std::cout << "Loading file [" << fileURL << "]" << std::endl;
 
-        std::thread([]
-                    {
-                        struct pollfd pollfd;
-                        pollfd.fd = fakeClientFd;
-                        pollfd.events = POLLOUT;
-                        fakeSocketPoll(&pollfd, 1, -1);
-                        fakeSocketWrite(fakeClientFd, fileURL.c_str(), fileURL.size());
-                    }).detach();
+        struct pollfd pollfd;
+        pollfd.fd = fakeClientFd;
+        pollfd.events = POLLOUT;
+        fakeSocketPoll(&pollfd, 1, -1);
+        fakeSocketWrite(fakeClientFd, fileURL.c_str(), fileURL.size());
     }
     else if (strcmp(string_value, "BYE") == 0)
     {
@@ -167,16 +164,11 @@ void handle_cool_message(const char *string_value)
     else
     {
         // As above
-        char *string_copy = strdup(string_value);
-        std::thread([=]
-                    {
-                        struct pollfd pollfd;
-                        pollfd.fd = fakeClientFd;
-                        pollfd.events = POLLOUT;
-                        fakeSocketPoll(&pollfd, 1, -1);
-                        fakeSocketWrite(fakeClientFd, string_copy, strlen(string_copy));
-                        free(string_copy);
-                    }).detach();
+        struct pollfd pollfd;
+        pollfd.fd = fakeClientFd;
+        pollfd.events = POLLOUT;
+        fakeSocketPoll(&pollfd, 1, -1);
+        fakeSocketWrite(fakeClientFd, string_value, strlen(string_value));
     }
 }
 


### PR DESCRIPTION
ClientSession::handleTileInvalidation returns early with _tileWidthPixel (etc) of 0 because _tileWidthPixel (etc) never get set

These are supposed to get set from 'clientzoom' which the javascript side sends. clientzoom arrives, but the attempt is made to dispatch via a thread and during startup there are enough messages dispatched via threads to overwhelm wasm

```
bundle.js:56376 ================ handle_cool_message(): 'clientvisiblearea x=-3915 y=0 width=20640 height=7980 splitx=0 splity=0'
bundle.js:56377 Tried to spawn a new thread, but the thread pool is exhausted. This might result in a deadlock unless some threads eventually exit or the code explicitly breaks out to the event loop. If you want to increase the pool size, use setting `-sPTHREAD_POOL_SIZE=...`. If you want to throw an explicit error instead of the risk of deadlocking in those cases, use setting `-sPTHREAD_POOL_SIZE_STRICT=2`.
bundle.js:56376 ================ handle_cool_message(): 'clientzoom tilepixelwidth=256 tilepixelheight=256 tiletwipwidth=1536 tiletwipheight=1536'
bundle.js:56377 Tried to spawn a new thread, but the thread pool is exhausted. This might result in a deadlock unless some threads eventually exit or the code explicitly breaks out to the event loop. If you want to increase the pool size, use setting `-sPTHREAD_POOL_SIZE=...`. If you want to throw an explicit error instead of the risk of deadlocking in those cases, use setting `-sPTHREAD_POOL_SIZE_STRICT=2`.
bundle.js:56376 ================ handle_cool_message(): 'tilecombine...'
```

The 'clientzoom' never get processed and so
ClientSession::handleTileInvalidation returns early with _tileWidthPixel (etc) of 0 because _tileWidthPixel (etc) never get set.

this std::thread dispatching of messages is similar to seen in gtk/mobile.cpp in similar code, and also existed in android/lib/src/main/cpp/androidapp.cpp before getting replaced in:

commit 155718796ea0020a0cff2429813644a6e1c96794
Date:   Fri Jul 19 16:43:44 2019 +0200

    android: Fix a threading / ordering issue.

follow the same simpler android model here.


Change-Id: I3b5e57b3d91bb80fbae90b269300581825518d7f


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

