### PR TITLE
wasm: limit threads using for scaling

### DIFF
--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -2771,6 +2771,9 @@ void COOLWSD::innerInitialize(Application& self)
         setenv("MAX_CONCURRENCY", std::to_string(maxConcurrency).c_str(), 1);
     }
     LOG_INF("MAX_CONCURRENCY set to " << maxConcurrency << '.');
+#elif defined(__EMSCRIPTEN__)
+    // disable threaded image scaling for wasm for now
+    setenv("VCL_NO_THREAD_SCALE", "1", 1);
 #endif
 
     const auto redlining = getConfigValue<bool>(conf, "per_document.redlining_as_comments", false);


### PR DESCRIPTION
disable this with VCL_NO_THREAD_SCALE for wasm

"Yacht.odt" document with lots of large images fails to render:

Tried to spawn a new thread, but the thread pool is exhausted. This might result in a deadlock unless some threads eventually exit or the code explicitly breaks out to the event loop. If you want to increase the pool size, use setting `-sPTHREAD_POOL_SIZE=...`. If you want to throw an explicit error instead of the risk of deadlocking in those cases, use setting `-sPTHREAD_POOL_SIZE_STRICT=2`.


Change-Id: I8b2f994d2d3d23f8a0043f0c7fefa4d5e250b8bc


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

