### PR TITLE
calc header: avoid selecting row/col while resizing them

### DIFF
--- a/browser/src/control/Control.Header.ts
+++ b/browser/src/control/Control.Header.ts
@@ -545,7 +545,7 @@ export class Header extends CanvasSectionObject {
 			this._dragDistance = dragDistance;
 			this.containerObject.requestReDraw(); // Remove previously drawn line and paint a new one.
 
-			if (this._lastSelectedIndex == this._mouseOverEntry.index)
+			if (this._lastSelectedIndex == this._mouseOverEntry.index || this._dragEntry)
 				return;
 			const modifier = this._lastSelectedIndex ? UNOModifier.SHIFT : 0;
 			this._lastSelectedIndex = this._mouseOverEntry.index;


### PR DESCRIPTION
problem:
while resizing row/column it would select all the rows and column user hovers over

regression from: 87a55af


Change-Id: If786c57222b9bb89ac3faa1e645acc223a8dcd7e

* Target version: master 

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

