### PR TITLE
Fix view pushed up in Calc for autfilter popup

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -12,6 +12,7 @@
 	max-height: 100%;
 	z-index: 2000;
 	display: flex;
+	overflow: hidden;
 }
 
 .jsdialog-overlay.cancellable {

--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -523,8 +523,11 @@ L.Control.JSDialog = L.Control.extend({
 		instance.posy = top + offsetY;
 
 		var width = instance.form.getBoundingClientRect().width;
+		var height = instance.form.getBoundingClientRect().height;
 		if (instance.posx + width > window.innerWidth)
 			instance.posx = window.innerWidth - width;
+		if (instance.posy + height > window.innerHeight)
+			instance.posy = window.innerHeight - height;
 
 		this.updatePosition(instance.container, instance.posx, instance.posy);
 	},


### PR DESCRIPTION
- fix view jump by adding display `hidden` in js-dialog overlay 


Signed-off-by: Darshan-upadhyay1110 <darshan.upadhyay@collabora.com>
Change-Id: I4e48fd2d7363db53d4bf3a1d85f9897de3b1e91a

