### PR TITLE
improve perf, calloc->malloc

### DIFF
--- a/common/RenderTiles.hpp
+++ b/common/RenderTiles.hpp
@@ -169,7 +169,7 @@ namespace RenderTiles
         void allocate(size_t x, size_t y)
         {
             assert(!_data);
-            _data = static_cast<unsigned char *>(calloc(x * y, 4));
+            _data = static_cast<unsigned char *>(malloc(x * y * 4));
         }
         ~Buffer()
         {


### PR DESCRIPTION
This buffer is completely overwritten by tile generation, so there is no need to use calloc, which needlessly zeros the buffer. (this is on a hotpath, so it shows up on the perf profiles).


Change-Id: If85874cb9f8e2c2489450336d351fce566a42101


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

