### PR TITLE
postmessage: Added Action_Fullscreen and Action_FullscreenPresentation

### DIFF
--- a/browser/html/framed.doc.html
+++ b/browser/html/framed.doc.html
@@ -120,6 +120,18 @@
             });
       }
 
+      function fullscreenDocument() {
+        post({'MessageId': 'Action_Fullscreen',
+              'Values': null
+            });
+      }
+
+      function startPresentation() {
+        post({'MessageId': 'Action_FullscreenPresentation',
+              'Values': null
+            });
+      }
+
       function exportAsHtml() {
         post({'MessageId': 'Action_Export',
               'Values': { 'Format': 'html', }
@@ -445,6 +457,9 @@
           <div class="grid">
             <button onclick="save(); return false;">Save</button>
             <button onclick="closeDocument(); return false;">Close</button>
+
+            <button onclick="fullscreenDocument(); return false;">Fullscreen</button>
+            <button onclick="startPresentation(); return false;">Start presentation</button>
 
             <button onclick="exportAsHtml(); return false;">Export as HTML</button>
             <button onclick="getExportFormats(); return false;">Get export formats</button>

--- a/browser/src/map/handler/Map.WOPI.js
+++ b/browser/src/map/handler/Map.WOPI.js
@@ -465,6 +465,25 @@ L.Map.WOPI = L.Handler.extend({
 		else if (msg.MessageId === 'Action_Close') {
 			this._map.remove();
 		}
+		else if (msg.MessageId === 'Action_Fullscreen') {
+			L.toggleFullScreen();
+		}
+		else if (msg.MessageId === 'Action_FullscreenPresentation' && this._map.getDocType() === 'presentation') {
+			if (msg.Values) {
+				var slideNumber;
+				if (typeof msg.Values.StartSlideNumber != 'undefined') {
+					slideNumber = msg.Values.StartSlideNumber;
+				} else if (msg.Values.CurrentSlide) {
+					slideNumber = this._map.getCurrentPartNumber();
+				}
+				this._map.fire('fullscreen',
+					       {
+						       startSlideNumber: slideNumber
+					       });
+			} else {
+				this._map.fire('fullscreen');
+			}
+		}
 		else if (msg.MessageId === 'Action_Print') {
 			this._map.print();
 		}


### PR DESCRIPTION
They allow respectively to switch to fullscreen, or to start the presentation in impress in fullscreen
Action_FullscreenPresentation can get the following arguments:
- StartSlideNumber: the slide to start at
- CurrentSlide: start at the current slide The options are exclusive to each other. StartSlideNumber takes precedence


Change-Id: I4d97eadf8c119e70e5738df4063d209feb5db793


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

Added Action_Fullscreen and Action_FullscreenPresentation post message

### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

