### PR TITLE
annotation: refresh annotation on part updates

### DIFF
--- a/browser/src/layer/tile/ImpressTileLayer.js
+++ b/browser/src/layer/tile/ImpressTileLayer.js
@@ -275,7 +275,9 @@ L.ImpressTileLayer = L.CanvasTileLayer.extend({
 			this._update();
 			var partMatch = textMsg.match(/[^\r\n]+/g);
 			// only get the last matches
-			this._partHashes = partMatch.slice(partMatch.length - this._parts);
+			var newPartHashes = partMatch.slice(partMatch.length - this._parts);
+			var refreshAnnotation = this._partHashes && (this._partHashes.length !== newPartHashes.length || !this._partHashes.every(function(element,i) { return element === newPartHashes[i]; }));
+			this._partHashes = newPartHashes;
 			this._hiddenSlides = new Set(command.hiddenparts);
 			this._map.fire('updateparts', {
 				selectedPart: this._selectedPart,
@@ -284,6 +286,8 @@ L.ImpressTileLayer = L.CanvasTileLayer.extend({
 				docType: this._docType,
 				partNames: this._partHashes
 			});
+			if (refreshAnnotation)
+				app.socket.sendMessage('commandvalues command=.uno:ViewAnnotations');
 		}
 
 		if (app.file.fileBasedView)

--- a/cypress_test/integration_tests/desktop/impress/slide_operations_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/slide_operations_spec.js
@@ -3,6 +3,7 @@
 
 var helper = require('../../common/helper');
 var impressHelper = require('../../common/impress_helper');
+var desktopHelper = require('../../common/desktop_helper');
 
 describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Slide operations', function() {
 	var origTestFileName = 'slide_operations.odp';
@@ -10,6 +11,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Slide operations', functio
 
 	beforeEach(function() {
 		testFileName = helper.beforeAll(origTestFileName, 'impress');
+		desktopHelper.switchUIToNotebookbar();
 	});
 
 	afterEach(function() {
@@ -42,10 +44,16 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Slide operations', functio
 
 	});
 
-	it('Duplicate slide', function() {
+	it.only('Duplicate slide', function() {
+		// Also check if comments are getting duplicated
+		cy.cGet('#options-modify-page').click();
+		desktopHelper.insertMultipleComment('impress', 1, false, '#insert-insert-annotation-button');
+		cy.cGet('#annotation-content-area-1').should('include.text', 'some text0');
 		helper.clickOnIdle('#tb_presentation-toolbar_item_duplicatepage');
 
 		impressHelper.assertNumberOfSlidePreviews(2);
+		cy.cGet('#PageStatus').should('have.text', 'Slide 2 of 2');
+		cy.cGet('#annotation-content-area-2').should('include.text', 'some text0');
 
 	});
 


### PR DESCRIPTION
problem:
1. Duplicating slide with comment will not have any comment
2. Rearranging slides, causes comments to stay with its previous slide location, i.e: if earlier comments were on the first slide and they are rearranged to be nth slide, comments will be displayed on the first slide
3. Deleting slide, displays comment on the next slide

all these problems are just display problems in online, if you reload the document, comments are displayed correctly.


Change-Id: Ie494761802f133f5f433053456edfd7d55d1312a


* Target version: master 



### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

