### PR TITLE
improve error message on invalid WOPI host

### DIFF
--- a/browser/src/errormessages.js
+++ b/browser/src/errormessages.js
@@ -36,7 +36,8 @@ errorMessages.docloadtimeout = _('Failed to load the document. This document is 
 errorMessages.docunloadingretry = _('Cleaning up the document from the last session.');
 errorMessages.docunloadinggiveup = _('We are in the process of cleaning up this document from the last session, please try again later.');
 errorMessages.clusterconfiguration = _('Your %productName cluster appear to be mis-configured or scaling rapidly - please contact your system administrator. Continuing with editing may result in multiple users not seeing each other, conflicts in the document storage and/or copy/paste problems. Expected serverId %0 for routeToken %1 but connected to serverId %2');
-errorMessages.websocketconnectionfailed = _('Failed to establish socket connection or socket connection closed unexpectedly. The reverse proxy might be misconfigured, please contact the administrator. For more info on proxy configuration please checkout https://sdk.collaboraonline.com/docs/installation/Proxy_settings.html');
+errorMessages.websocketproxyfailure = _('Failed to establish socket connection or socket connection closed unexpectedly. The reverse proxy might be misconfigured, please contact the administrator. For more info on proxy configuration please checkout https://sdk.collaboraonline.com/docs/installation/Proxy_settings.html');
+errorMessages.websocketgenericfailure = _('Failed to establish socket connection or socket connection closed unexpectedly.');
 if (window.ThisIsAMobileApp) {
 	errorMessages.storage = {
 		loadfailed: _('Failed to load document.'),


### PR DESCRIPTION
- before this patch when socket connection failed, we used to show the same error for socket connection failure and send the 'Action_Load_Resp' with same errorMsg
- now we show/send different message for unauthorized and loading failure

Resolves: #7709
Change-Id: I71b1b7f8e2eca93790d068583370787825911a41

* Target version: master 

