### PR TITLE
Calc: improve drag&drop functionality of sheet tabs

### DIFF
--- a/browser/css/spreadsheet.css
+++ b/browser/css/spreadsheet.css
@@ -20,7 +20,7 @@
 }
 
 .spreadsheet-tab {
-	margin: 5px 4px 0px 0px !important;
+	margin: 5px 0px 0px !important;
 	padding: 6px 9px 4px !important;
 	text-decoration: none;
 
@@ -44,9 +44,9 @@
 	color: var(--color-text-darker) !important;
 }
 
-#first-tab-drop-site {
-	height: 20px;
-	width: 3px;
+.tab-drop-area {
+	height: 32px;
+	width: 4px;
 	opacity: 0;
 	margin-top: 4px;
 	padding-top: 8px;
@@ -56,13 +56,21 @@
 	padding-bottom: 5px;
 }
 
-.tab-dropsite {
-	border-right: 5px solid var(--color-border);
+.tab-drop-area-active {
+	background-color: rgb(109, 109, 211);
 }
 
-#first-tab-drop-site.tab-dropsite {
-	width: 0 !important;
+.tab-drop-area.tab-drop-area-active {
 	opacity: 100% !important;
+}
+
+#drop-zone-end-container {
+	height: 32px;
+	width: 128px;
+	opacity: 0;
+	vertical-align: bottom;
+	display: inline-block;
+	background-color: var(--color-main-background);
 }
 
 #spreadsheet-header-corner-container {

--- a/browser/src/control/Control.Tabs.js
+++ b/browser/src/control/Control.Tabs.js
@@ -180,14 +180,14 @@ L.Control.Tabs = L.Control.extend({
 					var menuData = L.Control.JSDialogBuilder.getMenuStructureForMobileWizard(menuItemMobile, true, '');
 				}
 
-				var frame = L.DomUtil.create('div', '', ssTabScroll);
-				frame.setAttribute('draggable', false);
-				frame.setAttribute('id', 'first-tab-drop-site');
-				this._addDnDHandlers(frame);
-
 				for (var i = 0; i < parts; i++) {
 					if (e.hiddenParts.indexOf(i) !== -1)
 						continue;
+
+					// create a drop zone indicator for the sheet tab
+					// put the indicator on the left of the tab
+					var dropZoneIndicator = L.DomUtil.create('div', 'tab-drop-area', ssTabScroll);
+					dropZoneIndicator.id = 'drop-zone-' + i;
 					var id = 'spreadsheet-tab' + i;
 					var tab = L.DomUtil.create('button', 'spreadsheet-tab', ssTabScroll);
 					if (window.mode.isMobile() || window.mode.isTablet()) {
@@ -235,6 +235,18 @@ L.Control.Tabs = L.Control.extend({
 					this._addDnDHandlers(tab);
 					this._spreadsheetTabs[id] = tab;
 				}
+
+				// add an additional dropZoneIndicator for the last sheet tab
+				// put the indicator on the right of the last tab
+				var dropZoneIndicatorForTheLastTab = L.DomUtil.create('div', 'tab-drop-area', ssTabScroll);
+				dropZoneIndicatorForTheLastTab.id = 'drop-zone-end';
+
+				// create drop zone container for the last drop zone indicator
+				// when a tab is over this container, dropZoneIndicatorForTheLastTab will be shown
+				var dropZoneEndContainer = L.DomUtil.create('div', '', ssTabScroll);
+				dropZoneEndContainer.id = 'drop-zone-end-container';
+				this._addDnDHandlers(dropZoneEndContainer);
+				dropZoneEndContainer.setAttribute('draggable', false);
 			}
 			for (var key in this._spreadsheetTabs) {
 				var part =  parseInt(key.match(/\d+/g)[0]);
@@ -354,26 +366,26 @@ L.Control.Tabs = L.Control.extend({
 		// support duplication with ctrl in the future.
 		e.dataTransfer.dropEffect = 'move';
 
-		this.classList.add('tab-dropsite');
+		e.target.previousElementSibling.classList.add('tab-drop-area-active');
+
 		return false;
 	},
 
-	_handleDragLeave: function() {
-		this.classList.remove('tab-dropsite');
+	_handleDragLeave: function (e) {
+		e.target.previousElementSibling.classList.remove('tab-drop-area-active');
 	},
 
 	_handleDrop: function(e) {
 		if (e.stopPropagation) {
 			e.stopPropagation();
 		}
-		e.target.classList.remove('tab-dropsite');
-		var targetIndex = this._map._docLayer._partNames.indexOf(e.target.innerText);
 
-		this._moveSheet(targetIndex+2);
+		var targetIndex = this._map._docLayer._partNames.indexOf(e.target.innerText);
+		this._moveSheet(targetIndex + 1); // drop to left side of the tab
 	},
 
-	_handleDragEnd: function() {
-		this.classList.remove('tab-dropsite');
+	_handleDragEnd: function (e) {
+		e.target.previousElementSibling.classList.remove('tab-drop-area-active');
 	}
 });
 


### PR DESCRIPTION
- drop zone indicator added to the left of all tabs
- additional drop zone indicator added to the right of the last tab
- added drop zone container at the end of tabs for the last drop zone indicator

- div#drop-zone-end-container element also adds a space to the end of the tabs so that the last tab can be seen easily after scrolling to the end.

Change-Id: I25a87bc1798b94c5f294532d308cd46292ef1795


* Resolves: #7813
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

