### PR TITLE
Changes for handling readonly mode click events:

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1925,6 +1925,11 @@ L.CanvasTileLayer = L.Layer.extend({
 			var json = JSON.parse(textMsg.substring('colorpalettes:'.length + 1));
 			app.colorPalettes['ThemeColors'].colors = json.ThemeColors;
 		}
+		else if (textMsg.startsWith('readonlyhyperlinkclicked: ')) {
+			var json = JSON.parse(textMsg.replace('readonlyhyperlinkclicked: ', ''));
+			var position = this._twipsToLatLng(json.position);
+			this._showURLPopUp(position, json.link);
+		}
 	},
 
 	_onTabStopListUpdate: function (textMsg) {
@@ -2595,28 +2600,40 @@ L.CanvasTileLayer = L.Layer.extend({
 		link.innerText = url;
 		var copyBtn = L.DomUtil.createWithId('div', 'hyperlink-pop-up-copy', parent);
 		L.DomUtil.addClass(copyBtn, 'hyperlink-popup-btn');
-		copyBtn.setAttribute('title', _('Copy link location'));
+
+		if (app.file.permission !== 'readonly')
+			copyBtn.setAttribute('title', _('Copy link location'));
+		else
+			copyBtn.setAttribute('title', _('Select link text'));
+
 		var imgCopyBtn = L.DomUtil.create('img', 'hyperlink-pop-up-copyimg', copyBtn);
 		L.LOUtil.setImage(imgCopyBtn, 'lc_copyhyperlinklocation.svg', this._map);
 		imgCopyBtn.setAttribute('width', 18);
 		imgCopyBtn.setAttribute('height', 18);
 		imgCopyBtn.setAttribute('style', 'padding: 4px');
-		var editBtn = L.DomUtil.createWithId('div', 'hyperlink-pop-up-edit', parent);
-		L.DomUtil.addClass(editBtn, 'hyperlink-popup-btn');
-		editBtn.setAttribute('title', _('Edit link'));
-		var imgEditBtn = L.DomUtil.create('img', 'hyperlink-pop-up-editimg', editBtn);
-		L.LOUtil.setImage(imgEditBtn, 'lc_edithyperlink.svg', this._map);
-		imgEditBtn.setAttribute('width', 18);
-		imgEditBtn.setAttribute('height', 18);
-		imgEditBtn.setAttribute('style', 'padding: 4px');
-		var removeBtn = L.DomUtil.createWithId('div', 'hyperlink-pop-up-remove', parent);
-		L.DomUtil.addClass(removeBtn, 'hyperlink-popup-btn');
-		removeBtn.setAttribute('title', _('Remove link'));
-		var imgRemoveBtn = L.DomUtil.create('img', 'hyperlink-pop-up-removeimg', removeBtn);
-		L.LOUtil.setImage(imgRemoveBtn, 'lc_removehyperlink.svg', this._map);
-		imgRemoveBtn.setAttribute('width', 18);
-		imgRemoveBtn.setAttribute('height', 18);
-		imgRemoveBtn.setAttribute('style', 'padding: 4px');
+
+		if (app.file.permission !== 'readonly') {
+			var editBtn = L.DomUtil.createWithId('div', 'hyperlink-pop-up-edit', parent);
+			L.DomUtil.addClass(editBtn, 'hyperlink-popup-btn');
+			editBtn.setAttribute('title', _('Edit link'));
+			var imgEditBtn = L.DomUtil.create('img', 'hyperlink-pop-up-editimg', editBtn);
+			L.LOUtil.setImage(imgEditBtn, 'lc_edithyperlink.svg', this._map);
+			imgEditBtn.setAttribute('width', 18);
+			imgEditBtn.setAttribute('height', 18);
+			imgEditBtn.setAttribute('style', 'padding: 4px');
+
+			var removeBtn = L.DomUtil.createWithId('div', 'hyperlink-pop-up-remove', parent);
+			L.DomUtil.addClass(removeBtn, 'hyperlink-popup-btn');
+			removeBtn.setAttribute('title', _('Remove link'));
+			var imgRemoveBtn = L.DomUtil.create('img', 'hyperlink-pop-up-removeimg', removeBtn);
+			L.LOUtil.setImage(imgRemoveBtn, 'lc_removehyperlink.svg', this._map);
+			imgRemoveBtn.setAttribute('width', 18);
+			imgRemoveBtn.setAttribute('height', 18);
+			imgRemoveBtn.setAttribute('style', 'padding: 4px');
+		}
+		else // Readonly.
+			link.style.userSelect = 'auto';
+
 		this._map.hyperlinkPopup = new L.Popup({className: 'hyperlink-popup', closeButton: false, closeOnClick: false, autoPan: false})
 			.setHTMLContent(parent)
 			.setLatLng(position)
@@ -2627,6 +2644,7 @@ L.CanvasTileLayer = L.Layer.extend({
 		if (offsetDiffTop < 10) this._movePopUpBelow();
 		if (offsetDiffLeft < 10) this._movePopUpRight();
 		var map_ = this._map;
+
 		this._setupClickFuncForId('hyperlink-pop-up', function() {
 			if (!url.startsWith('#'))
 				map_.fire('warn', {url: url, map: map_, cmd: 'openlink'});
@@ -2634,14 +2652,24 @@ L.CanvasTileLayer = L.Layer.extend({
 				map_.sendUnoCommand('.uno:JumpToMark?Bookmark:string=' + encodeURIComponent(url.substring(1)));
 		});
 		this._setupClickFuncForId('hyperlink-pop-up-copy', function () {
-			map_.sendUnoCommand('.uno:CopyHyperlinkLocation');
+			if (app.file.permission !== 'readonly')
+				map_.sendUnoCommand('.uno:CopyHyperlinkLocation');
+			else {
+				document.getSelection().removeAllRanges();
+				var range = new Range();
+				range.selectNodeContents(link);
+				document.getSelection().addRange(range);
+			}
 		});
-		this._setupClickFuncForId('hyperlink-pop-up-edit', function () {
-			map_.sendUnoCommand('.uno:EditHyperlink');
-		});
-		this._setupClickFuncForId('hyperlink-pop-up-remove', function () {
-			map_.sendUnoCommand('.uno:RemoveHyperlink');
-		});
+
+		if (app.file.permission !== 'readonly') {
+			this._setupClickFuncForId('hyperlink-pop-up-edit', function () {
+				map_.sendUnoCommand('.uno:EditHyperlink');
+			});
+			this._setupClickFuncForId('hyperlink-pop-up-remove', function () {
+				map_.sendUnoCommand('.uno:RemoveHyperlink');
+			});
+		}
 
 		if (this._map['wopi'].EnableRemoteLinkPicker)
 			this._map.fire('postMessage', { msgId: 'Action_GetLinkPreview', args: { url: url } });
@@ -3677,10 +3705,16 @@ L.CanvasTileLayer = L.Layer.extend({
 
 		this._sendClientVisibleArea();
 
-		app.socket.sendMessage('mouse type=' + type +
-				' x=' + x + ' y=' + y + ' count=' + count +
-				' buttons=' + buttons + ' modifier=' + modifier);
-
+		// Writer only for now.
+		if (app.file.permission === 'readonly' && type === 'buttonup' && this._docType === 'text') {
+			this._closeURLPopUp();
+			app.socket.sendMessage('readonlyclick x=' + x + ' y=' + y);
+		}
+		else {
+			app.socket.sendMessage('mouse type=' + type +
+					' x=' + x + ' y=' + y + ' count=' + count +
+					' buttons=' + buttons + ' modifier=' + modifier);
+		}
 
 		if (type === 'buttondown') {
 			this._clearSearchResults();

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -459,7 +459,8 @@ bool ChildSession::_handleInput(const char *buffer, int length)
                tokens.equals(0, "a11ystate") ||
                tokens.equals(0, "geta11yfocusedparagraph") ||
                tokens.equals(0, "geta11ycaretposition") ||
-               tokens.equals(0, "toggletiledumping"));
+               tokens.equals(0, "toggletiledumping") ||
+               tokens.equals(0, "readonlyclick"));
 
         std::string pzName("ChildSession::_handleInput:" + tokens[0]);
         ProfileZone pz(pzName.c_str());
@@ -522,6 +523,10 @@ bool ChildSession::_handleInput(const char *buffer, int length)
         else if (tokens.equals(0, "windowmouse"))
         {
             return mouseEvent(tokens, LokEventTargetEnum::Window);
+        }
+        else if (tokens.equals(0, "readonlyclick"))
+        {
+            return readOnlyClickEvent(tokens);
         }
         else if (tokens.equals(0, "windowgesture"))
         {
@@ -1634,6 +1639,35 @@ bool ChildSession::mouseEvent(const StringVector& tokens,
         break;
     default:
         assert(false && "Unsupported mouse target type");
+    }
+
+    return true;
+}
+
+bool ChildSession::readOnlyClickEvent(const StringVector& tokens)
+{
+    getLOKitDocument()->setView(_viewId);
+
+    if (tokens.size() != 3)
+        return false;
+
+    const int x = Util::safe_atoi(tokens[1].data(), tokens[1].size());
+    const int y = Util::safe_atoi(tokens[2].data(), tokens[2].size());
+    char* test = getLOKitDocument()->hyperlinkInfoAtPosition(x, y);
+
+    if (test != nullptr)
+    {
+        std::string result(test);
+        std::free(test);
+
+        if (!result.empty() && x != 0 && y != 0)
+        {
+            std::ostringstream message;
+            message << "readonlyhyperlinkclicked: { \"link\": \"" << result << "\""
+                    << " \"position\": { \"x\": " << x << ", \"y\": " << y << " }";
+
+            sendTextFrame(message.str());
+        }
     }
 
     return true;

--- a/kit/ChildSession.hpp
+++ b/kit/ChildSession.hpp
@@ -312,6 +312,7 @@ private:
     bool extTextInputEvent(const StringVector& tokens);
     bool dialogKeyEvent(const char* buffer, int length, const std::vector<std::string>& tokens);
     bool mouseEvent(const StringVector& tokens, const LokEventTargetEnum target);
+    bool readOnlyClickEvent(const StringVector& tokens);
     bool gestureEvent(const StringVector& tokens);
     bool dialogEvent(const StringVector& tokens);
     bool completeFunction(const StringVector& tokens);

--- a/kit/DummyLibreOfficeKit.cpp
+++ b/kit/DummyLibreOfficeKit.cpp
@@ -99,6 +99,9 @@ static void doc_setTextSelection (LibreOfficeKitDocument* pThis,
                                   int nType,
                                   int nX,
                                   int nY);
+static char* doc_hyperlinkInfoAtPosition () (LibreOfficeKitDocument* pThis,
+                                  int nX,
+                                  int nY);
 static char* doc_getTextSelection(LibreOfficeKitDocument* pThis,
                                   const char* pMimeType,
                                   char** pUsedMimeType);
@@ -169,6 +172,7 @@ LibLODocument_Impl::LibLODocument_Impl()
         m_pDocumentClass->postMouseEvent = doc_postMouseEvent;
         m_pDocumentClass->postUnoCommand = doc_postUnoCommand;
         m_pDocumentClass->setTextSelection = doc_setTextSelection;
+        m_pDocumentClass->hyperlinkInfoAtPosition = doc_hyperlinkInfoAtPosition;
         m_pDocumentClass->getTextSelection = doc_getTextSelection;
         m_pDocumentClass->paste = doc_paste;
         m_pDocumentClass->setGraphicSelection = doc_setGraphicSelection;
@@ -433,6 +437,13 @@ static void doc_setTextSelection(LibreOfficeKitDocument* pThis, int nType, int n
 {
     (void) pThis;
     (void) nType;
+    (void) nX;
+    (void) nY;
+}
+
+static char* doc_hyperlinkInfoAtPosition(LibreOfficeKitDocument* pThis, int nX, int nY)
+{
+    (void) pThis;
     (void) nX;
     (void) nY;
 }

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1117,6 +1117,10 @@ bool ClientSession::_handleInput(const char *buffer, int length)
             return forwardToChild(std::string(buffer, length), docBroker);
         }
     }
+    else if (tokens.equals(0, "readonlyclick"))
+    {
+        return forwardToChild(std::string(buffer, length), docBroker);
+    }
     else if (tokens.equals(0, "attemptlock"))
     {
         return attemptLock(docBroker);


### PR DESCRIPTION
* These changes are made primarily for reading the hyperlink data from the document in readonly mode.
* Added readonlyclick event.
* Added readonlyhyperlinkclicked event.
* And the handlers for these.

When user clicks on document in readonly mode, a readonlyclick event is sent to the server. Childsession checks if there is a hyperlink at the clicked location. If so, the information of the hyperlink is sent to the client.


Change-Id: I9c104a1ec770491725337b9bbb1e2d1c2851321b


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

