### PR TITLE
Calc tabs: remove drop zone indicator after drop

### DIFF
--- a/browser/src/control/Control.Tabs.js
+++ b/browser/src/control/Control.Tabs.js
@@ -380,6 +380,7 @@ L.Control.Tabs = L.Control.extend({
 			e.stopPropagation();
 		}
 
+		e.target.previousElementSibling.classList.remove('tab-drop-area-active');
 		var targetIndex = this._map._docLayer._partNames.indexOf(e.target.innerText);
 		this._moveSheet(targetIndex + 1); // drop to left side of the tab
 	},


### PR DESCRIPTION
- we need to remove 'tab-drop-area-active' class after a sheet tab is dropped, otherwise drop
zone indicator will still be shown after dropping

- this fixes the bug from f8433d323d2f49852501961c7949300b4a59a512 Calc: improve drag&drop functionality of sheet tabs #7846


Change-Id: Iff7ea455452c431907cc7534cbd111e7b4f037d8


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

