### PR TITLE
autogen: conditionally invoke configure at the end

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -31,8 +31,22 @@ autoreconf || failed "autoreconf"
 
 scripts/refresh-git-hooks || failed "refresh-git-hooks"
 
+if [ $# -gt 0 ]; then
+    # If we got parameters, we can execute configure directly.
+    echo -n "Result: All went OK, running $srcdir/configure "
+    for arg in "$@"
+    do
+        echo -n "'${arg}' "
+    done
+    echo "now."
+    $srcdir/configure "$@" || failed "configure"
+    exit 0
+fi
+
 cat << EOF
 
 Result: All went OK, please run $srcdir/configure (with the appropriate parameters) now.
 
 EOF
+
+# vim:set shiftwidth=4 softtabstop=4 expandtab:


### PR DESCRIPTION
This is backwards-compatible and core.git autogen.sh executes
configure, so it eliminates a pointless difference.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I897bd2f6464201a19e26e55006cd52727abdfc41
