### PR TITLE
Add explanation for invalidatecursor with different viewId

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -2682,7 +2682,10 @@ L.CanvasTileLayer = L.Layer.extend({
 			this.persistCursorPositionInWriter = false;
 			return;
 		}
+
+		// tells who trigerred cursor invalidation, but recCursors is stil "our"
 		var modifierViewId = parseInt(obj.viewId);
+		var weAreModifier = (modifierViewId === this._viewId);
 
 		this._cursorAtMispelledWord = obj.mispelledWord ? Boolean(parseInt(obj.mispelledWord)).valueOf() : false;
 
@@ -2718,7 +2721,7 @@ L.CanvasTileLayer = L.Layer.extend({
 			this._showURLPopUp(cursorPos, obj.hyperlink.link);
 		}
 
-		if (!this._map.editorHasFocus() && this._map._isCursorVisible && (modifierViewId === this._viewId) && (this._map.isEditMode())) {
+		if (!this._map.editorHasFocus() && this._map._isCursorVisible && weAreModifier && (this._map.isEditMode())) {
 			// Regain cursor if we had been out of focus and now have input.
 			// Unless the focus is in the Calc Formula-Bar, don't steal the focus.
 			if (!this._map.calcInputBarHasFocus())
@@ -2735,8 +2738,13 @@ L.CanvasTileLayer = L.Layer.extend({
 			this.lastCursorPos = recCursor.getTopLeft();
 		}
 
-		// If modifier view is different than the current view, then set last variable to "true". We'll keep the caret position at the same point relative to screen.
-		this._onUpdateCursor(updateCursor && (modifierViewId === this._viewId), undefined /* zoom */, !(this._viewId === modifierViewId));
+		// If modifier view is different than the current view
+		// we'll keep the caret position at the same point relative to screen.
+		this._onUpdateCursor(
+			/* scroll */ updateCursor && weAreModifier,
+			/* zoom */ undefined,
+			/* keepCaretPositionRelativeToScreen */ !weAreModifier);
+
 		// Only for reference equality comparison.
 		this._lastVisibleCursorRef = this._visibleCursor;
 	},


### PR DESCRIPTION
I noticed that it directly modifies `this._visibleCursor`
which should be our own cursor. So it was not clear if
`modifierViewId === this._viewId` check if something left
from the past or that message can be received with
different viewId...

It seems that received viewId only tells us who "triggered"
the cursor movement, but position in the message is still "our".
It is used with different viewId in Writer but not in Calc.

protocol.txt comment about the message:
The payload contains a rectangle describing the cursor position
and the id of the view which triggered the invalidation. JSON payload.

and seems to be introduced in:
commit https://github.com/CollaboraOnline/online/commit/ffd7151443ee360c7764aaa77f9e7fe5f5d64eee
Date:   Sun Apr 8 00:00:53 2018 +0200
Writer: View jumps to cursor position even if it is moved by an other view.