### PR TITLE
bind noManualDrag in Path.Drag.js

### DIFF
--- a/browser/src/layer/vector/Path.Drag.js
+++ b/browser/src/layer/vector/Path.Drag.js
@@ -62,13 +62,13 @@ L.Handler.PathDrag = L.Handler.extend(/** @lends  L.Path.Drag.prototype */ {
 
 	},
 
-	noManualDrag: function(f) {
+	noManualDrag: window.memo.decorator(function(f) {
 		if ('noManualDrag' in this._path) {
-			return this._path.noManualDrag(f);
+			return this._path.noManualDrag.bind(this._path)(f).bind(this._path);
 		} else {
 			return f;
 		}
-	},
+	}),
 
 	/**
 	* Enable dragging
@@ -94,8 +94,8 @@ L.Handler.PathDrag = L.Handler.extend(/** @lends  L.Path.Drag.prototype */ {
 
 		this._path.removeClass(L.Handler.PathDrag.DRAGGING_CLS);
 
-		L.DomEvent.off(document, 'mousemove touchmove', this.noManualDrag(this._onDrag),    this);
-		L.DomEvent.off(document, 'mouseup touchend',    this.noManualDrag(this._onDragEnd), this);
+		L.DomEvent.off(document, 'mousemove touchmove', this.noManualDrag(window.memo.bind(this._onDrag, this)),    this);
+		L.DomEvent.off(document, 'mouseup touchend',    this.noManualDrag(window.memo.bind(this._onDragEnd, this)), this);
 	},
 
 	/**
@@ -125,8 +125,8 @@ L.Handler.PathDrag = L.Handler.extend(/** @lends  L.Path.Drag.prototype */ {
 		this._path._renderer.addContainerClass('leaflet-interactive');
 
 		L.DomEvent
-		 .on(document, MOVE[eventType], this.noManualDrag(this._onDrag),    this)
-		 .on(document, END[eventType],  this.noManualDrag(this._onDragEnd), this);
+		 .on(document, MOVE[eventType], this.noManualDrag(window.memo.bind(this._onDrag, this)),    this)
+		 .on(document, END[eventType],  this.noManualDrag(window.memo.bind(this._onDragEnd, this)), this);
 
 		if (this._path._map.dragging.enabled()) {
 			// I guess it's required because mousedown gets simulated with a delay
@@ -238,8 +238,8 @@ L.Handler.PathDrag = L.Handler.extend(/** @lends  L.Path.Drag.prototype */ {
 			this._path._transform(null);
 		}
 
-		L.DomEvent.off(document, 'mousemove touchmove', this.noManualDrag(this._onDrag),    this);
-		L.DomEvent.off(document, 'mouseup touchend',    this.noManualDrag(this._onDragEnd), this);
+		L.DomEvent.off(document, 'mousemove touchmove', this.noManualDrag(window.memo.bind(this._onDrag, this)),    this);
+		L.DomEvent.off(document, 'mouseup touchend',    this.noManualDrag(window.memo.bind(this._onDragEnd, this)), this);
 
 		this._restoreCoordGetters();
 


### PR DESCRIPTION
Previously, noManualDrag was not bound to any object. This worked fine in SVGGroup.js because the 'this' that was inferred was the correct 'this', however in Path.Drag.js the 'this' inferred was incorrect. This code path was occasionally called when dragging which caused an intermittent error while dragging objects in draw

This is a followup to Iab0d3bcca588eaed14469597868a9c4e2dcf8488, which I believe introduced this regression


Change-Id: If8657133a1b6c000b1096fb2c822d02d728de80c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

