### PR TITLE
Fix text in font and style dropdown types dark in Dark mode

### DIFF
--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -516,6 +516,7 @@ button.leaflet-control-search-next
 	background-color: var(--color-background-lighter);
 	border: 1px solid var(--color-border);
 	border-radius: var(--border-radius);
+	color: var(--color-text-dark);
 }
 .select2-container--default .select2-results__option[aria-disabled='true'] {
 	color: var(--color-border-lighter);


### PR DESCRIPTION
- in Compact/Classic mode typing text are dark in dark mode

To reproduce:

- change to dark mode and select Compact mode
- type in input field of Font or in Font size
- without this patch, color will be dark in dark mode
Signed-off-by: Darshan-upadhyay1110 <darshan.upadhyay@collabora.com>
Change-Id: I4510001cfdf26acf8419eb0aa4ee3611b0a51b09


Before:

![image](https://github.com/CollaboraOnline/online/assets/61383886/c2130920-26df-4bef-9b9f-99118ae04e71)


After:

![image](https://github.com/CollaboraOnline/online/assets/61383886/88c957d7-3b33-400e-a872-bfe52393ec08)
