### PR TITLE
Remove protocol when adding to lok_allow

### DIFF
--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -308,6 +308,17 @@ void COOLWSD::appendAllowedHostsFrom(LayeredConfiguration& conf, const std::stri
     }
 }
 
+namespace {
+std::string removeProtocol(const std::string& host)
+{
+    size_t nPos = host.find("//");
+    if (nPos != std::string::npos)
+        return host.substr(nPos + 2);
+
+    return host;
+}
+}
+
 void COOLWSD::appendAllowedAliasGroups(LayeredConfiguration& conf, std::vector<std::string>& allowed)
 {
     for (size_t i = 0;; i++)
@@ -318,7 +329,7 @@ void COOLWSD::appendAllowedAliasGroups(LayeredConfiguration& conf, std::vector<s
             break;
         }
 
-        const std::string host = conf.getString(path + ".host", "");
+        std::string host = conf.getString(path + ".host", "");
         bool allow = conf.getBool(path + ".host[@allow]", false);
         if (!allow)
         {
@@ -327,6 +338,7 @@ void COOLWSD::appendAllowedAliasGroups(LayeredConfiguration& conf, std::vector<s
 
         if (!host.empty())
         {
+            host = removeProtocol(host);
             LOG_INF_S("Adding trusted LOK_ALLOW host: [" << host << ']');
             allowed.push_back(host);
         }
@@ -339,10 +351,11 @@ void COOLWSD::appendAllowedAliasGroups(LayeredConfiguration& conf, std::vector<s
                 break;
             }
 
-            const std::string alias = getConfigValue<std::string>(conf, aliasPath, "");
+            std::string alias = getConfigValue<std::string>(conf, aliasPath, "");
 
             if (!aliasPath.empty())
             {
+                alias = removeProtocol(alias);
                 LOG_INF_S("Adding trusted LOK_ALLOW alias: [" << alias << ']');
                 allowed.push_back(alias);
             }


### PR DESCRIPTION
We automatically add allowed wopi hosts to lok_allow. But we expect to have plain host names, we need to remove protocol if it is present.

Example:
wopi - group - host: `https://.*\.mydomain.com`
we need to add: `.*\.mydomain.com` to lok_allow list.