### PR TITLE
missing tiles in multi-pane spreadsheets

### DIFF
--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -2363,10 +2363,10 @@ size_t ClientSession::getTilesOnFlyUpperLimit() const
     float tilesOnFlyUpperLimit = 0;
     if (normalizedVisArea.hasSurface() && getTileWidthInTwips() != 0 && getTileHeightInTwips() != 0)
     {
-        const int tilesFitOnWidth = std::ceil(normalizedVisArea.getRight() / getTileWidthInTwips()) -
-                                    std::ceil(normalizedVisArea.getLeft() / getTileWidthInTwips()) + 1;
-        const int tilesFitOnHeight = std::ceil(normalizedVisArea.getBottom() / getTileHeightInTwips()) -
-                                     std::ceil(normalizedVisArea.getTop() / getTileHeightInTwips()) + 1;
+        const int tilesFitOnWidth = (normalizedVisArea.getRight() / getTileWidthInTwips()) -
+                                    (normalizedVisArea.getLeft() / getTileWidthInTwips()) + 1;
+        const int tilesFitOnHeight = (normalizedVisArea.getBottom() / getTileHeightInTwips()) -
+                                     (normalizedVisArea.getTop() / getTileHeightInTwips()) + 1;
         const int tilesInVisArea = tilesFitOnWidth * tilesFitOnHeight;
 
         tilesOnFlyUpperLimit = std::max(TILES_ON_FLY_MIN_UPPER_LIMIT, tilesInVisArea * 1.1f);

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -2583,12 +2583,13 @@ void ClientSession::handleTileInvalidation(const std::string& message,
         for(int paneIdx = 0; paneIdx < numPanes; ++paneIdx)
         {
             const Util::Rectangle& normalizedVisArea = paneRects[paneIdx];
+            int lastVertTile = std::ceil(normalizedVisArea.getBottom() / static_cast<double>(_tileHeightTwips));
+            int lastHoriTile = std::ceil(normalizedVisArea.getRight() / static_cast<double>(_tileWidthTwips));
+
             // Iterate through visible tiles
-            for(int i = std::ceil(normalizedVisArea.getTop() / _tileHeightTwips);
-                        i <= std::ceil(normalizedVisArea.getBottom() / _tileHeightTwips); ++i)
+            for(int i = normalizedVisArea.getTop() / _tileHeightTwips; i <= lastVertTile; ++i)
             {
-                for(int j = std::ceil(normalizedVisArea.getLeft() / _tileWidthTwips);
-                    j <= std::ceil(normalizedVisArea.getRight() / _tileWidthTwips); ++j)
+                for(int j = normalizedVisArea.getLeft() / _tileWidthTwips; j <= lastHoriTile; ++j)
                 {
                     // Find tiles affected by invalidation
                     Util::Rectangle tileRect (j * _tileWidthTwips, i * _tileHeightTwips, _tileWidthTwips, _tileHeightTwips);


### PR DESCRIPTION
here std::ceil is operating on the result of an int divided by an int so the input is already an effectively floor-ed int result of the division so the ceil doesn't do anything

so we end up filtering out some of the invalidates for tiles in frozen panes.


Change-Id: Ibfb25fdfdfb84735ca9410f8250d2e5b9fa1070e


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

