### PR TITLE
browser: adjust initial annotation height

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -664,7 +664,7 @@ nav.spreadsheet-color-indicator ~ #sidebar-dock-wrapper {
 	background-color: var(--color-background-dark);
 	color: var(--color-main-text);
 	overflow-x: hidden;
-	height: 50px;
+	height: 54px;
 	width: 100%;
 	box-sizing: border-box;
 }


### PR DESCRIPTION
It is a bug from Firefox, according to records
https://bugzilla.mozilla.org/show_bug.cgi?id=292284

The vertical scroll bar requires minimum height to render.

Change-Id: I93b06c625bc98c307dde0c1d6331d457ff99baa5
Signed-off-by: Henry Castro <hcastro@collabora.com>
