### PR TITLE
safari: fix contenteditable on old versions

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -1156,3 +1156,8 @@ nav.spreadsheet-color-indicator ~ #sidebar-dock-wrapper {
 	-ms-user-select: none;
 	user-select: none;
 }
+
+[contenteditable] { /* in old Safari, omitting this prevents editing */
+	-webkit-user-select: text;
+	user-select: text;
+}


### PR DESCRIPTION
In old versions of Safari, typing text would not input anything. This appears to be a regression from replacing the input area with a contenteditable div (1d2607e8363dab839e7060ab38612123d284c98f).

This seems to be caused by "Safari has the user-select CSS setting as none by default" (see https://stackoverflow.com/a/31831776/12293760). From my research, this only affects old versions of Safari, but adding this CSS fixes it and does not prevent editing in other browsers.


Change-Id: I708708b87f3169f6f69cab28003379519ce114dd


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

