### PR TITLE
Better logging for cy.cGet()

### DIFF
--- a/cypress_test/support/index.js
+++ b/cypress_test/support/index.js
@@ -71,22 +71,50 @@ Cypress.Commands.overwrite('waitUntil', function(originalFn, subject, checkFunct
 });
 
 Cypress.Commands.add('cSetActiveFrame', function(frameID) {
+	Cypress.log();
 	cy.cActiveFrame = frameID;
 });
 
 Cypress.Commands.add('cSetLevel', function(level) {
+	Cypress.log();
 	cy.cLevel = level;
 });
 
 Cypress.Commands.add('cGet', function(selector, options) {
+	if (options) {
+		if (options.log != false) {
+			Cypress.log();
+		}
+	} else {
+		Cypress.log();
+	}
+
+	var optionsWithLogFalse;
+	if (options) {
+		optionsWithLogFalse = options;
+		optionsWithLogFalse.log = false;
+	} else {
+		optionsWithLogFalse = {log: false};
+	}
+
 	if (cy.cLevel === '1') {
 		if (selector)
-			return cy.get(cy.cActiveFrame).its('0.contentDocument').should('exist').then(cy.wrap).find(selector, options);
+			return cy.get(cy.cActiveFrame, {log: false})
+				.its('0.contentDocument', {log: false})
+				.find(selector, optionsWithLogFalse);
 		else
-			return cy.get(cy.cActiveFrame, options).its('0.contentDocument').should('exist').then(cy.wrap);
+			return cy.get(cy.cActiveFrame, optionsWithLogFalse)
+				.its('0.contentDocument', {log: false});
 	}
 	else if (selector) // This is not cool frame and there is a selector.
-		return cy.get(cy.cActiveFrame).its('0.contentDocument').find('#coolframe').its('0.contentDocument').then(cy.wrap).find(selector, options);
+		return cy.get(cy.cActiveFrame, {log: false})
+			.its('0.contentDocument', {log: false})
+			.find('#coolframe', {log: false})
+			.its('0.contentDocument', {log: false})
+			.find(selector, optionsWithLogFalse);
 	else // Not cool frame without a selector.
-		return cy.get(cy.cActiveFrame, options).its('0.contentDocument').find('#coolframe').its('0.contentDocument').then(cy.wrap);
+		return cy.get(cy.cActiveFrame, optionsWithLogFalse)
+			.its('0.contentDocument', {log: false})
+			.find('#coolframe', {log: false})
+			.its('0.contentDocument', {log: false});
 });


### PR DESCRIPTION
Change-Id: I587415c7601fd6bb10f3aa6e708109fd7ccd3b81

### Summary
Use Cypress.log to properly log custom cGet command.
Allows pass through of options, suppression with {log: false} option.

Reduces
```
      cy:command ✔  get	#coolframe
      cy:command ✔  its	.0.contentDocument
      cy:command ✔  assert	expected **<document>** to exist
      cy:command ✔  wrap	<document>
      cy:command ✔  find	#copy-paste-container p
```
to
```
      cy:command ✔  cGet	#copy-paste-container p
```
thousands of times per log file.

### Checklist

- [X] Code is properly formatted
- [X] All commits have Change-Id
- [X] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

### TODO

- [ ] Confirm `.should('exist')` is safe to delete. https://docs.cypress.io/guides/core-concepts/introduction-to-cypress#Implicit-Assertions says "You **never** need to write `.should('exist')` after querying the DOM." (emphasis theirs)
- [ ] Confirm `.then(cy.wrap)` is safe to delete. Seems to do nothing as far as I can tell.