### PR TITLE
Calc: don't stop dragging the selection on quick move

### DIFF
--- a/browser/src/map/handler/Map.Mouse.js
+++ b/browser/src/map/handler/Map.Mouse.js
@@ -176,6 +176,9 @@ L.Map.Mouse = L.Handler.extend({
 			this._map.fire('scrollvelocity', {vx: 0, vy: 0});
 		}
 		else if (e.type === 'mousemove' && this._mouseDown) {
+			if (this._mouseOverTimeout)
+				clearTimeout(this._mouseOverTimeout);
+
 			if (this._holdMouseEvent) {
 				clearTimeout(this._holdMouseEvent);
 				this._holdMouseEvent = null;


### PR DESCRIPTION
This fixes view jumps in the Calc when some user tried to drag a selection but did it very quickly so it was interrupted by the _mouseOverTimeout callback.

Timer was introduced in commit 72c407e0ed5c3a9ffd2ae518f9f5d4407e1f5d61 loleaflet: support mouse cursor calback

But we noticed the issue recently. I remember that dragging the selection was not working some time ago, it is possible that it was fixed and because of that we experience this bug.

What it does is that it stops dragging mode in half-done state so then other views sometimes use the leftover data. To be 100% fixed it should be also protected on the core side.

Steps to reproduce:
1. Open calc in 2 sessions
2. A selects some range of cells (for example 3x3)
3. A clicks inside selected range and holding the mouse button does rapid move to drag the selection (move the content of cells) - it has to be done very quickly < 100 ms after initial click It is done properly when you see on the screen selected range and cell selection, but the two are not overlapping
4. User B goes somewhere far in the sheet and:
   - changes font size
   - or selectes some rows, deletes them, then opens right-click "row height" dialog, press ok Result: User B jumps to the selection of user A
Expected: no jump


Change-Id: Ia35377771df6b04584eebb76c25290482b7a4b93

