### PR TITLE
cypress: enable all slide operation tests

### DIFF
--- a/cypress_test/integration_tests/desktop/impress/slide_operations_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/slide_operations_spec.js
@@ -44,7 +44,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Slide operations', functio
 
 	});
 
-	it.only('Duplicate slide', function() {
+	it('Duplicate slide', function() {
 		// Also check if comments are getting duplicated
 		cy.cGet('#options-modify-page').click();
 		desktopHelper.insertMultipleComment('impress', 1, false, '#insert-insert-annotation-button');


### PR DESCRIPTION
test got disabled in e81b53a


Change-Id: Ie40dc67d7f45dac702d69d7222c2bc32a4c89dd0


* Target version: master 


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

