### PR TITLE
Remove inadvertent it.only to re-enable tests

### DIFF
--- a/cypress_test/integration_tests/desktop/calc/row_column_operation_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/row_column_operation_spec.js
@@ -39,7 +39,7 @@ describe(['tagdesktop'], 'Row Column Operation', function() {
 		//calcHelper.assertDataClipboardTable(['Hello','Hi','','','World','Bye']);
 	});
 
-	it.only('Insert/Delete Column', function() {
+	it('Insert/Delete Column', function() {
 		//insert column before
 		cy.cGet('#home-insert-columns-before-button').click();
 		calcHelper.selectEntireSheet();


### PR DESCRIPTION
Change-Id: Ia9f2a35f0e334c97565edc4334df943723a958d7

### Summary
Found this after stumbling on another one introduced a couple days ago. That one was fixed in https://github.com/CollaboraOnline/online/pull/7883.

Ran the test with `make check-desktop spec=calc/row_column_operation_spec.js` and the other testpoint passed.

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

