### PR TITLE
Add new Cypress command cy.getFrame()

### DIFF
--- a/cypress_test/integration_tests/desktop/calc/row_column_operation_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/row_column_operation_spec.js
@@ -39,7 +39,7 @@ describe(['tagdesktop'], 'Row Column Operation', function() {
 		//calcHelper.assertDataClipboardTable(['Hello','Hi','','','World','Bye']);
 	});
 
-	it.only('Insert/Delete Column', function() {
+	it('Insert/Delete Column', function() {
 		//insert column before
 		cy.cGet('#home-insert-columns-before-button').click();
 		calcHelper.selectEntireSheet();

--- a/cypress_test/support/index.js
+++ b/cypress_test/support/index.js
@@ -70,6 +70,10 @@ Cypress.Commands.overwrite('waitUntil', function(originalFn, subject, checkFunct
 	return originalFn(subject, checkFunction, options);
 });
 
+/**
+ * Set the current iFrame
+ * Example: cy.cSetActiveFrame('#coolframe');
+ */
 Cypress.Commands.add('cSetActiveFrame', function(frameID) {
 	Cypress.log();
 	cy.cActiveFrame = frameID;
@@ -80,6 +84,44 @@ Cypress.Commands.add('cSetLevel', function(level) {
 	cy.cLevel = level;
 });
 
+/**
+ * Get the current iFrame body to be chained with other queries.
+ * Example: cy.getFrame().find('#my-item');
+ * It is not necessary to chain .should('exist') after this.
+ * Use cy.cSetActiveFrame to set the active frame first.
+ */
+Cypress.Commands.add('getFrame', function(options) {
+	if (!cy.cActiveFrame) {
+		throw new Error('getFrame: Active frame not set');
+	}
+
+	if (options && options.log) {
+		Cypress.log({message: 'Current iFrame: ' + cy.cActiveFrame});
+	}
+	return cy.get(cy.cActiveFrame, {log: false})
+		.its('0.contentDocument', {log: false});
+});
+
+/**
+ * Get the current iFrame window to be chained with other queries.
+ * Use cy.cSetActiveFrame to set the active frame first.
+ */
+Cypress.Commands.add('getFrameWindow', function(options) {
+	if (!cy.cActiveFrame) {
+		throw new Error('getFrame: Active frame not set');
+	}
+
+	if (options && options.log) {
+		Cypress.log({message: 'Current iFrame: ' + cy.cActiveFrame});
+	}
+	return cy.get(cy.cActiveFrame, {log: false})
+		.its('0.contentWindow', {log: false});
+});
+
+/**
+ * Find an element within the current iFrame
+ * Note: Use cy.getFrame().find() instead, which offers better logging on failure
+ */
 Cypress.Commands.add('cGet', function(selector, options) {
 	if (options) {
 		if (options.log != false) {


### PR DESCRIPTION
### Summary
Even after https://github.com/CollaboraOnline/online/pull/7877, I am still not happy with the cGet logging. In order to get reasonable logging on failure, the extra assertion `.should('exist')` is required, which is explicitly discouraged in the cypress docs, and is easy to forget. And as a side effect of including .should('exist'), several noisy lines are logged each time, and there is no way to disable it (https://github.com/cypress-io/cypress/issues/7693).

cy.getFrame() does the same thing as cy.cGet() but with simpler code and a slight reordering of commands. It also produces reasonable logs on both pass and fail.

The behavior should be identical so replacing one command with the other should be easy. However it is used thousands of times so it will take some time to do the changes and make sure everything still works. Only then can we delete the old commands.

Compare:

**cy.getFrame()**
Code:
```
	cy.getFrame().find('.leaflet-selection-marker-start');
```
Pass:
```
      cy:command ✔  find	.leaflet-selection-marker-start
```
Fail:
```
      cy:command ✘  find	.leaflet-selection-marker-start
      cy:command ✔  fail:	/home/neilguertin/build/collabora-online/cypress_test/integration_tests/common/helper.js:846:19
                      844 | function textSelectionShouldExist() {
                      845 |     cy.log('Make sure text selection exists - start.');
                    > 846 |     cy.getFrame().find('.leaflet-selection-marker-start');
                          |                   ^
                      847 |     cy.getFrame().find('.leaflet-selection-marker-end');
                      848 |     // One of the marker should be visible at least (if not both).
                      849 |     cy.getFrame().find('.leaflet-selection-marker-start, .leaflet-selection-marker-end').should('be.visible');
```

**cy.cGet()**
Note the multiple noisy, attention-grabbing, meaningless lines on success.
Code:
```
	cy.cGet('.leaflet-selection-marker-start').should('exist');
```
Pass:
```
      cy:command ✔  cGet	.leaflet-selection-marker-start
      cy:command ✔  assert	expected **.leaflet-selection-marker-start** to exist in the DOM
                    Actual: 	".leaflet-selection-marker-start"
                    Expected: 	".leaflet-selection-marker-start"
```
Fail:
```
      cy:command ✔  cGet	.leaflet-selection-marker-start
      cy:command ✘  assert	expected **.leaflet-selection-marker-start** to exist in the DOM
                    Actual: 	".leaflet-selection-marker-start"
                    Expected: 	".leaflet-selection-marker-start"
      cy:command ✔  fail:	/home/neilguertin/build/collabora-online/cypress_test/integration_tests/common/helper.js:846:48
                      844 | function textSelectionShouldExist() {
                      845 |     cy.log('Make sure text selection exists - start.');
                    > 846 |     cy.cGet('.leaflet-selection-marker-start').should('exist');
                          |                                                ^
                      847 |     cy.cGet('.leaflet-selection-marker-end').should('exist');
                      848 |     // One of the marker should be visible at least (if not both).
                      849 |     cy.cGet('.leaflet-selection-marker-start, .leaflet-selection-marker-end').should('be.visible');
```

**Without .should('exist')**
Note that without the extra assertion, it is the find command that reports the failure, so the code snippet from cGet is displayed.
Code:
```
	cy.cGet('.leaflet-selection-marker-start');
```
Pass:
```
      cy:command ✔  cGet	.leaflet-selection-marker-start
```
Fail:
```
      cy:command ✔  cGet	.leaflet-selection-marker-start
      cy:command ✔  fail:	/home/neilguertin/build/collabora-online/cypress_test/support/index.js:121:1
                      119 | 			return cy.get(cy.cActiveFrame, {log: false})
                      120 | 				.its('0.contentDocument', {log: false})
                    > 121 | 				.find(selector, optionsWithLogFalse);
                          | ^
                      122 | 		else
                      123 | 			return cy.get(cy.cActiveFrame, optionsWithLogFalse)
                      124 | 				.its('0.contentDocument', {log: false});
```

### Checklist

- [X] Code is properly formatted
- [X] All commits have Change-Id
- [X] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

