### PR TITLE
annotation: if comment is not initialised its not in editing mode

### DIFF
--- a/browser/src/layer/tile/CommentSection.ts
+++ b/browser/src/layer/tile/CommentSection.ts
@@ -967,8 +967,8 @@ export class Comment extends CanvasSectionObject {
 	}
 
 	public isEdit (): boolean {
-		return (this.sectionProperties.nodeModify && this.sectionProperties.nodeModify.style.display !== 'none') ||
-		       (this.sectionProperties.nodeReply && this.sectionProperties.nodeReply.style.display !== 'none');
+		return !this.pendingInit && ((this.sectionProperties.nodeModify && this.sectionProperties.nodeModify.style.display !== 'none') ||
+		       (this.sectionProperties.nodeReply && this.sectionProperties.nodeReply.style.display !== 'none'));
 	}
 
 	public static isAnyEdit (): boolean {


### PR DESCRIPTION
this caused problem when new doc is loading and we are settings up comments, but they are not initialised and marked as being in editing. i.e: this will cause problem with showing reply count(in collapsed view) initially


Change-Id: Ia688ca0bfc37dd925bd74dc5826d43fdb37c81db


* Target version: master 



### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

