### PR TITLE
typescript: use defined types for CommentSection properties

### DIFF
--- a/browser/src/layer/tile/CommentListSection.ts
+++ b/browser/src/layer/tile/CommentListSection.ts
@@ -41,6 +41,19 @@ namespace cool {
 
 export class CommentSection extends CanvasSectionObject {
 	map: any;
+	sectionProperties: {
+		commentList: Array<Comment>;
+		selectedComment: Comment | null;
+		calcCurrentComment: Comment | null;
+		marginY: number;
+		offset: number;
+		width: number;
+		commentWidth: number;
+		collapsedMarginToTheEdge: number;
+		deflectionOfSelectedComment: number;
+		commentsAreListed: boolean;
+		[key: string]: any;
+	};
 	static autoSavedComment: cool.Comment;
 	static commentWasAutoAdded: boolean;
 
@@ -1084,7 +1097,7 @@ export class CommentSection extends CanvasSectionObject {
 
 	private checkIfCommentHasPreAssignedChildren(comment: CommentSection) {
 		for (var i = 0; i < this.sectionProperties.commentList.length; i++) {
-			var possibleChild: CommentSection = this.sectionProperties.commentList[i];
+			var possibleChild: Comment = this.sectionProperties.commentList[i];
 			if (possibleChild.sectionProperties.possibleParentCommentId !== null) {
 				if (possibleChild.sectionProperties.possibleParentCommentId === comment.sectionProperties.data.id) {
 					if (!comment.sectionProperties.children.includes(possibleChild))

--- a/browser/src/layer/tile/CommentSection.ts
+++ b/browser/src/layer/tile/CommentSection.ts
@@ -636,7 +636,7 @@ export class Comment extends CanvasSectionObject {
 			);
 	}
 
-	private update (): void {
+	public update (): void {
 		this.updateContent();
 		this.updateLayout();
 		this.updatePosition();
@@ -707,7 +707,7 @@ export class Comment extends CanvasSectionObject {
 		}
 	}
 
-	private show(): void {
+	public show(): void {
 		this.doPendingInitializationInView(true /* force */);
 		this.showMarker();
 
@@ -767,7 +767,7 @@ export class Comment extends CanvasSectionObject {
 		return authorMatch;
 	}
 
-	private hide (): void {
+	public hide (): void {
 		if (this.sectionProperties.data.id === 'new') {
 			this.sectionProperties.commentListSection.removeItem(this.sectionProperties.data.id);
 			return;


### PR DESCRIPTION
use strict datatypes for the properties where possible, also allow to add new properties dynamically


Change-Id: Ia2eb850f61031f91b0e37339475e1ca4e768dad1


* Target version: master 


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

