### PR TITLE
annotation: remove redundant condition

### DIFF
--- a/browser/src/layer/tile/CommentListSection.ts
+++ b/browser/src/layer/tile/CommentListSection.ts
@@ -633,7 +633,7 @@ export class CommentSection extends CanvasSectionObject {
 			}.bind(this), /* isMod */ true);
 		}
 		else {
-			if (this.sectionProperties.docLayer._docType !== 'spreadsheet' && this.sectionProperties.selectedComment !== annotation) {
+			if (this.sectionProperties.docLayer._docType !== 'spreadsheet') {
 				this.unselect();
 				this.select(annotation);
 			}


### PR DESCRIPTION
it did not make sense to check for selection if we are unselecting before selecting

problem:
when already selected comment try to modify,
it will not rearrange replies in the thread this caused overlapping of the comments and bad user experience


Change-Id: I276c34301b45951a7051018770e21b4970603861


* Target version: master 


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

