### PR TITLE
Handle LOK_CALLBACK_TOOLTIP in wsd

### DIFF
--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -1166,6 +1166,10 @@ app.definitions.Socket = L.Class.extend({
 			// Switching modes.
 			window.location.reload(false);
 		}
+		else if (textMsg.startsWith('tooltip: ')) {
+			var tooltipInfo = JSON.parse(textMsg.substring(textMsg.indexOf('{')));
+			this._map.showDocumentTooltip(tooltipInfo, $('.leaflet-layer'));
+		}
 		else if (!textMsg.startsWith('tile:') && !textMsg.startsWith('delta:') &&
 			 !textMsg.startsWith('renderfont:') && !textMsg.startsWith('windowpaint:')) {
 

--- a/browser/src/map/Map.js
+++ b/browser/src/map/Map.js
@@ -424,6 +424,24 @@ L.Map = L.Evented.extend({
 		}
 	},
 
+	showDocumentTooltip: function(tooltipInfo, elem) {
+		var split = tooltipInfo.rectangle.split(',');
+		var latlng = this._docLayer._twipsToLatLng(new L.Point(+split[0], +split[1]));
+		var pt = this.latLngToContainerPoint(latlng);
+
+		elem.tooltip();
+		elem.tooltip('enable');
+		elem.tooltip('option', 'content', tooltipInfo.text);
+		elem.tooltip('option', 'items', elem[0]);
+		elem.tooltip('option', 'position', { my: 'left bottom',  at: 'left+' + pt.x + ' top+' + pt.y, collision: 'fit fit' });
+		elem.tooltip('open');
+		document.addEventListener('mousemove', function closeTooltip() {
+			elem.tooltip('close');
+			elem.tooltip('disable');
+			document.removeEventListener('mousemove', closeTooltip);
+		});
+	},
+
 	updateModificationIndicator: function(newModificationTime) {
 		var timeout;
 

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -3209,6 +3209,11 @@ void ChildSession::loKitCallback(const int type, const std::string& payload)
         sendTextFrame("corelog: " + payload);
         break;
     }
+    case LOK_CALLBACK_TOOLTIP:
+    {
+        sendTextFrame("tooltip: " + payload);
+        break;
+    }
     default:
         LOG_ERR("Unknown callback event (" << lokCallbackTypeToString(type) << "): " << payload);
     }


### PR DESCRIPTION
Send "tooltip: <payload>" to client for this callback type.
Client-side handling should be implemented separately.

Signed-off-by: Mike Kaganski <mike.kaganski@collabora.com>
Change-Id: I2d1a07dd36fa20a4b5ff785da788356e0f41d62f
