### PR TITLE
Use new custom command cy.getFrameWindow()

### DIFF
--- a/cypress_test/integration_tests/common/helper.js
+++ b/cypress_test/integration_tests/common/helper.js
@@ -1182,12 +1182,6 @@ function assertFocus(selectorType, selector) {
 	cy.cGet().its('activeElement.'+selectorType).should('be.eq', selector);
 }
 
-function getCoolFrameWindow() {
-	return cy.get('#coolframe')
-		.its('0.contentWindow')
-		.should('exist');
-}
-
 // Create an alias to a point whose coordinate are the middle point of the blinking cursor
 // It should be used with clickAt (see function below)
 function getBlinkingCursorPosition(aliasName) {
@@ -1263,7 +1257,6 @@ module.exports.overlayItemHasDifferentBoundsThan = overlayItemHasDifferentBounds
 module.exports.typeIntoInputField = typeIntoInputField;
 module.exports.getVisibleBounds = getVisibleBounds;
 module.exports.assertFocus = assertFocus;
-module.exports.getCoolFrameWindow = getCoolFrameWindow;
 module.exports.loadTestDocNoIntegration = loadTestDocNoIntegration;
 module.exports.getBlinkingCursorPosition = getBlinkingCursorPosition;
 module.exports.clickAt = clickAt;

--- a/cypress_test/integration_tests/desktop/calc/jsdialog_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/jsdialog_spec.js
@@ -15,8 +15,8 @@ describe(['tagdesktop'], 'JSDialog unit test', function() {
 	});
 
 	it('JSDialog popup dialog', function() {
-		cy.get(cy.cActiveFrame)
-			.its('0.contentWindow.L')
+		cy.getFrameWindow()
+			.its('L')
 			.then(function(L) {
 				var jsonDialog = {
 					id: 'testpopup',

--- a/cypress_test/integration_tests/desktop/calc/top_toolbar_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/top_toolbar_spec.js
@@ -55,7 +55,8 @@ describe(['tagdesktop'], 'Top toolbar tests.', function() {
 
 	it('Print', function() {
 		// A new window should be opened with the PDF.
-		helper.getCoolFrameWindow().then(function(win) {
+		cy.getFrameWindow()
+			.then(function(win) {
 				cy.stub(win, 'open').as('windowOpen');
 			});
 

--- a/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
@@ -259,17 +259,15 @@ describe(['tagdesktop'], 'Top toolbar tests.', function() {
 
 	it('Print', function() {
 		// A new window should be opened with the PDF.
-		helper.getCoolFrameWindow()
+		cy.getFrameWindow()
 			.then(function(win) {
-				cy.stub(win, 'open');
+				cy.stub(win, 'open').as('windowOpen');
 			});
 
 		cy.cGet('#File-tab-label').click();
 		cy.cGet('#File-container .unoPrint').click();
-		helper.getCoolFrameWindow()
-			.then(function(win) {
-				cy.wrap(win).its('open').should('be.called');
-			});
+
+		cy.get('@windowOpen').should('be.called');
 	});
 
 	it('Apply Undo/Redo.', function() {

--- a/cypress_test/integration_tests/mobile/calc/hamburger_menu_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/hamburger_menu_spec.js
@@ -43,17 +43,14 @@ describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 		before('hamburger_menu.ods');
 
 		// A new window should be opened with the PDF.
-		helper.getCoolFrameWindow()
+		cy.getFrameWindow()
 			.then(function(win) {
 				cy.stub(win, 'open');
 			});
 
 		mobileHelper.selectHamburgerMenuItem(['File', 'Print']);
 
-		helper.getCoolFrameWindow()
-			.then(function(win) {
-				cy.wrap(win).its('open').should('be.called');
-			});
+		cy.getFrameWindow().its('open').should('be.called');
 	});
 
 	it('Download as PDF', function() {

--- a/cypress_test/integration_tests/mobile/impress/hamburger_menu_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/hamburger_menu_spec.js
@@ -55,17 +55,14 @@ describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 		before('hamburger_menu.odp');
 
 		// A new window should be opened with the PDF.
-		helper.getCoolFrameWindow()
+		cy.getFrameWindow()
 			.then(function(win) {
 				cy.stub(win, 'open');
 			});
 
 		mobileHelper.selectHamburgerMenuItem(['File', 'Print']);
 
-		helper.getCoolFrameWindow()
-			.then(function(win) {
-				cy.wrap(win).its('open').should('be.called');
-			});
+		cy.getFrameWindow().its('open').should('be.called');
 	});
 
 	it('Download as PDF', function() {

--- a/cypress_test/integration_tests/mobile/writer/hamburger_menu_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/hamburger_menu_spec.js
@@ -60,17 +60,14 @@ describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 
 	it('Print', function() {
 		// A new window should be opened with the PDF.
-		helper.getCoolFrameWindow()
+		cy.getFrameWindow()
 			.then(function(win) {
 				cy.stub(win, 'open');
 			});
 
 		mobileHelper.selectHamburgerMenuItem(['File', 'Print']);
 
-		helper.getCoolFrameWindow()
-			.then(function(win) {
-				cy.wrap(win).its('open').should('be.called');
-			});
+		cy.getFrameWindow().its('open').should('be.called');
 	});
 
 	it('Download as PDF', function() {

--- a/cypress_test/support/index.js
+++ b/cypress_test/support/index.js
@@ -106,14 +106,13 @@ Cypress.Commands.add('getFrame', function(options) {
  * Get the current iFrame window to be chained with other queries.
  * Use cy.cSetActiveFrame to set the active frame first.
  */
-Cypress.Commands.add('getFrameWindow', function(options) {
+Cypress.Commands.add('getFrameWindow', function() {
 	if (!cy.cActiveFrame) {
 		throw new Error('getFrame: Active frame not set');
 	}
 
-	if (options && options.log) {
-		Cypress.log({message: 'Current iFrame: ' + cy.cActiveFrame});
-	}
+	Cypress.log({message: 'Current iFrame: ' + cy.cActiveFrame});
+
 	return cy.get(cy.cActiveFrame, {log: false})
 		.its('0.contentWindow', {log: false});
 });


### PR DESCRIPTION
Change-Id: I4f54b35f01b41bfb47a1d5d359de5cdab4cb9640

### Summary
Use cy.getFrameWindow() custom command added in https://github.com/CollaboraOnline/online/commit/5979eb9a1f7d68ce3ff326a1567e96767c8a60eb
Replaces and removes helper.getCoolFrameWindow()

### Checklist

- [X] Code is properly formatted
- [X] All commits have Change-Id
- [X] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

