### PR TITLE
Private/gokay/impres cut

### DIFF
--- a/browser/src/docstate.js
+++ b/browser/src/docstate.js
@@ -28,6 +28,18 @@ window.app = { // Shouldn't have any functions defined.
 		readOnly: true,
 		permission: 'readonly',
 		disableSidebar: false,
+		cursor: {
+			visible: false,
+
+			/*
+				Starts as null, so we can see if the first invalidation happened or not.
+				This is a rectangle: [x, y, w, h].
+				One should consider this as a document object coordinate as in CanvasSectionContainer.
+				This gives the coordinate relative to the document, not relative to the UI.
+				In core pixels.
+			*/
+			rectangle: null
+		},
 		size: {
 			pixels: [0, 0], // This can change according to the zoom level and document's size.
 			twips: [0, 0]
@@ -46,14 +58,6 @@ window.app = { // Shouldn't have any functions defined.
 		},
 		writer: {
 			pageRectangleList: [], // Array of arrays: [x, y, w, h] (as usual) // twips only. Pixels will be calculated on the fly. Corresponding pixels may change too ofte
-
-			/*
-				Starts as null, so we can see if the first invalidation happened or not.
-				This is a rectangle: [x, y, w, h].
-				One should consider this as a document object coordinate  as in CanvasSectionContainer.
-				This gives the coordinate relative to the document, not relative to the UI.
-			*/
-			cursorPosition: null,
 		},
 	},
 	view: {

--- a/browser/src/layer/tile/CanvasSectionContainer.ts
+++ b/browser/src/layer/tile/CanvasSectionContainer.ts
@@ -989,7 +989,7 @@ class CanvasSectionContainer {
 		for (var j: number = 0; j < this.windowSectionList.length; j++) {
 			var windowSection = this.windowSectionList[j];
 			if (windowSection.interactable)
-				windowSection.onCursorPositionChanged(app.file.writer.cursorPosition);
+				windowSection.onCursorPositionChanged(app.file.cursor.rectangle);
 
 			if (this.lowestPropagatedBoundSection === windowSection.name)
 				propagate = false; // Window sections can not stop the propagation of the event for other window sections.
@@ -998,7 +998,7 @@ class CanvasSectionContainer {
 		if (propagate) {
 			for (var i: number = this.sections.length - 1; i > -1; i--) {
 				if (this.sections[i].interactable)
-					this.sections[i].onCursorPositionChanged(app.file.writer.cursorPosition);
+					this.sections[i].onCursorPositionChanged(app.file.cursor.rectangle);
 			}
 		}
 	}
@@ -1343,7 +1343,7 @@ class CanvasSectionContainer {
 	*/
 	public onCursorPositionChanged() {
 		if (app.map._docLayer._docType === 'text') {
-			// Global state holder should already have the latest information: app.file.writer.cursorPosition.
+			// Global state holder should already have the latest information: app.file.cursor.rectangle.
 			this.propagateCursorPositionChanged();
 		}
 	}

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -2103,12 +2103,14 @@ L.CanvasTileLayer = L.Layer.extend({
 	_onCursorVisibleMsg: function(textMsg) {
 		var command = textMsg.match('cursorvisible: true');
 		this._map._isCursorVisible = command ? true : false;
+		app.file.cursor.visible = this._map.isCursorVisible;
 		this._removeSelection();
 		this._onUpdateCursor();
 	},
 
 	_setCursorVisible: function() {
 		this._map._isCursorVisible = true;
+		app.file.cursor.visible = true;
 	},
 
 	_onDownloadAsMsg: function (textMsg) {
@@ -2725,14 +2727,16 @@ L.CanvasTileLayer = L.Layer.extend({
 		this._visibleCursor = new L.LatLngBounds(
 			this._twipsToLatLng(recCursor.getTopLeft(), this._map.getZoom()),
 			this._twipsToLatLng(recCursor.getBottomRight(), this._map.getZoom()));
+
 		this._cursorCorePixels = this._twipsToCorePixelsBounds(recCursor);
+		app.file.cursor.rectangle = [
+			Math.round(this._cursorCorePixels.getTopLeft().x), // x
+			Math.round(this._cursorCorePixels.getTopLeft().y), // y
+			Math.round(this._cursorCorePixels.getSize().x), // width
+			Math.round(this._cursorCorePixels.getSize().y) // height
+		];
+
 		if (this._docType === 'text') {
-			app.file.writer.cursorPosition = [
-				Math.round(this._cursorCorePixels.getTopLeft().x), // x
-				Math.round(this._cursorCorePixels.getTopLeft().y), // y
-				Math.round(this._cursorCorePixels.getSize().x), // width
-				Math.round(this._cursorCorePixels.getSize().y) // height
-			];
 			app.sectionContainer.onCursorPositionChanged();
 		}
 

--- a/browser/src/map/handler/Map.Mouse.js
+++ b/browser/src/map/handler/Map.Mouse.js
@@ -113,6 +113,7 @@ L.Map.Mouse = L.Handler.extend({
 		else if (e.type === 'mousedown') {
 			docLayer._resetPreFetching();
 			this._mouseDown = true;
+			this._buttonDown = buttons;
 			if (this._holdMouseEvent) {
 				clearTimeout(this._holdMouseEvent);
 			}
@@ -130,6 +131,13 @@ L.Map.Mouse = L.Handler.extend({
 					return;
 				}
 			}
+
+			// Core side is handling the mouseup by itself when the right button is down.
+			// If we fire mouseup for right button, there will be duplicate.
+			// Without this, selected text in a text box is un-selected via a right click. Therefore, copy / cut operations are disabled.
+			if (this._buttonDown === this.LOButtons.right && modifier === 0)
+				return;
+
 			clearTimeout(this._holdMouseEvent);
 			this._holdMouseEvent = null;
 			var timeDiff = Date.now() - this._clickTime;


### PR DESCRIPTION
Core side seems to handle the mouseup event automatically for the right mouse button.
When we send another mouseup event, selected text can get unselected and context menu can't find a selected text.

Issue is:
* In Impress, select a text in a textbox and right click.
* Context menu cut operations don't work.

Cause:
* We send the right mouseup twice, the second event unselects the text and sets the cursor position to somewhere else.

Signed-off-by: Gökay Şatır <gokaysatir@gmail.com>
Change-Id: Idae749da42443ccdd7ef2fc795b042536fae0db6