### PR TITLE
Memory Accounting

### DIFF
--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -43,7 +43,7 @@
     <hexify_embedded_urls desc="Enable to protect encoded URLs from getting decoded by intermediate hops. Particularly useful on Azure deployments" type="bool" default="false"></hexify_embedded_urls>
     <experimental_features desc="Enable/Disable experimental features" type="bool" default="@ENABLE_EXPERIMENTAL@">@ENABLE_EXPERIMENTAL@</experimental_features>
 
-    <memproportion desc="The maximum percentage of system memory consumed by all of the @APP_NAME@, after which we start cleaning up idle documents" type="double" default="80.0"></memproportion>
+    <memproportion desc="The maximum percentage of available memory consumed by all of the @APP_NAME@ processes, after which we start cleaning up idle documents. If cgroup memory limits are set, this is the maximum percentage of that limit to consume." type="double" default="80.0"></memproportion>
     <num_prespawn_children desc="Number of child processes to keep started in advance and waiting for new clients." type="uint" default="1">1</num_prespawn_children>
     <!-- <fetch_update_check desc="Every number of hours will fetch latest version data. Defaults to 10 hours." type="uint" default="10">10</fetch_update_check> -->
     <per_document desc="Document-specific settings, including LO Core settings.">

--- a/wsd/Admin.cpp
+++ b/wsd/Admin.cpp
@@ -496,26 +496,26 @@ bool AdminSocketHandler::handleInitialRequest(
 }
 
 /// An admin command processor.
-Admin::Admin() :
-    SocketPoll("admin"),
-    _forKitPid(-1),
-    _lastTotalMemory(0),
-    _lastJiffies(0),
-    _lastSentCount(0),
-    _lastRecvCount(0),
-    _cpuStatsTaskIntervalMs(DefStatsIntervalMs),
-    _memStatsTaskIntervalMs(DefStatsIntervalMs * 2),
-    _netStatsTaskIntervalMs(DefStatsIntervalMs * 2),
-    _cleanupIntervalMs(DefStatsIntervalMs * 10)
+Admin::Admin()
+    : SocketPoll("admin")
+    , _totalSysMemKb(Util::getTotalSystemMemoryKb())
+    , _totalAvailMemKb(_totalSysMemKb)
+    , _forKitPid(-1)
+    , _lastTotalMemory(0)
+    , _lastJiffies(0)
+    , _lastSentCount(0)
+    , _lastRecvCount(0)
+    , _cpuStatsTaskIntervalMs(DefStatsIntervalMs)
+    , _memStatsTaskIntervalMs(DefStatsIntervalMs * 2)
+    , _netStatsTaskIntervalMs(DefStatsIntervalMs * 2)
+    , _cleanupIntervalMs(DefStatsIntervalMs * 10)
 {
-    LOG_INF("Admin ctor.");
+    LOG_INF("Admin ctor");
 
-    _totalSysMemKb = Util::getTotalSystemMemoryKb();
-    LOG_TRC("Total system memory:  " << _totalSysMemKb << " KB.");
+    LOG_TRC("Total system memory:  " << _totalSysMemKb << " KB");
 
     const auto memLimit = COOLWSD::getConfigValue<double>("memproportion", 0.0);
-    _totalAvailMemKb = _totalSysMemKb;
-    if (memLimit != 0.0)
+    if (memLimit > 0.0)
         _totalAvailMemKb = _totalSysMemKb * memLimit / 100.;
 
     LOG_TRC("Total available memory: " << _totalAvailMemKb << " KB (memproportion: " << memLimit << "%).");

--- a/wsd/Admin.hpp
+++ b/wsd/Admin.hpp
@@ -206,6 +206,12 @@ private:
     void connectToMonitorSync(const std::string &uri);
 
 private:
+    /// The total installed system memory (RAM).
+    /// Technically, can be augmented at runtime, but we don't update it.
+    const size_t _totalSysMemKb;
+    /// The total available memory to our process, per memproportion.
+    size_t _totalAvailMemKb;
+
     /// The model is accessed only during startup & in
     /// the Admin Poll thread.
     AdminModel _model;
@@ -214,8 +220,6 @@ private:
     size_t _lastJiffies;
     uint64_t _lastSentCount;
     uint64_t _lastRecvCount;
-    size_t _totalSysMemKb;
-    size_t _totalAvailMemKb;
     std::string _forkitLogLevel;
 
     struct MonitorConnectRecord

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -5962,29 +5962,6 @@ int COOLWSD::innerMain()
     Util::getVersionInfo(version, hash);
     LOG_INF("Coolwsd version details: " << version << " - " << hash << " - id " << Util::getProcessIdentifier() << " - on " << Util::getLinuxVersion());
 
-    std::size_t availableMemoryMb = Util::getTotalSystemMemoryKb()/1024;
-    LOG_INF("available memory: " << availableMemoryMb << " MB");
-    std::size_t cgroupMemLimitMb = Util::getCGroupMemLimit()/(1024*1024);
-    if (cgroupMemLimitMb > 0 && cgroupMemLimitMb < availableMemoryMb)
-    {
-        LOG_INF("cgroup memory limit: " << cgroupMemLimitMb << " MB");
-        availableMemoryMb = cgroupMemLimitMb;
-    }
-    else
-        LOG_INF("no cgroup memory limit");
-
-    std::size_t cgroupMemSoftLimitMb = Util::getCGroupMemSoftLimit()/(1024*1024);
-    if (cgroupMemSoftLimitMb > 0 && cgroupMemSoftLimitMb < availableMemoryMb)
-    {
-        LOG_INF("cgroup memory soft limit: " << cgroupMemSoftLimitMb << " MB");
-        availableMemoryMb = cgroupMemSoftLimitMb;
-    }
-    else
-        LOG_INF("no cgroup memory soft limit");
-    LOG_INF("hardware threads: " << std::thread::hardware_concurrency());
-
-    if (availableMemoryMb < 1000)
-        LOG_WRN("Low memory condition detected: only " << availableMemoryMb << " MB of RAM available");
 #endif
 
     initializeSSL();


### PR DESCRIPTION
This applies the cgroup memory limit, if set,
such that if it is lower than the configured
memproportion percentage, we do not exceed it.
Otherwise, we risk running out of our cgroup
limit and by then it is too late to do anything
but die due to OOM.

This also moves the logging of the cgroup memory
stats from COOLWSD into Admin, to avoid duplicate
logging.

Also updated the description of memproportion
config entry to account for the cgroup logic.

- wsd: admin: minor clean-up of memory-tracking members
- wsd: admin: use the cgroup limit as available memory
