### PR TITLE
Do not supress ChnageTheme event in readonly mode for any document

### DIFF
--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -505,8 +505,10 @@ L.Control.UIManager = L.Control.extend({
 
 	},
 	refreshToolbar: function() {
-		w2ui['editbar'].refresh();
-		w2ui['actionbar'].refresh();
+		if (w2ui['editbar'])
+			w2ui['editbar'].refresh();
+		if (w2ui['actionbar'])
+			w2ui['actionbar'].refresh();
 	},
 	addNotebookbarUI: function() {
 		this.refreshNotebookbar();

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1481,7 +1481,8 @@ bool ClientSession::filterMessage(const std::string& message) const
             if (tokens.size() > 1 && (tokens.equals(1, ".uno:ExecuteSearch") || tokens.equals(1, ".uno:Signature")
                  || tokens.equals(1, ".uno:ExportToPDF")
                  || tokens.equals(1,".uno:ExportDirectToPDF")
-                 || tokens.equals(1,".uno:ExportToEPUB")))
+                 || tokens.equals(1,".uno:ExportToEPUB")
+                 || tokens.equals(1,".uno:ChangeTheme")))
             {
                 allowed = true;
             }


### PR DESCRIPTION
- allow `ChangeTheme` event to update document theme in read-only mode

Signed-off-by: Darshan-upadhyay1110 <darshan.upadhyay@collabora.com>
Change-Id: Ic64bc61011a9e053c105e5c7540dddd4eb530681


* Resolves: #7888 
* Target version: master 