### PR TITLE
Set window.savedUIState to false in iOS app

### DIFF
--- a/browser/html/cool.html.m4
+++ b/browser/html/cool.html.m4
@@ -140,7 +140,10 @@ var Base64ToArrayBuffer = function(base64Str) {
     window.fullyLoadedAndReady = true;
   }, false);
 
-window.savedUIState = %SAVED_UI_STATE%;
+m4_ifelse(IOSAPP,[true],
+  [   window.savedUIState = false;],
+  [   window.savedUIState = %SAVED_UI_STATE%;])
+
 window.isLocalStorageAllowed = (function() {
   var str = 'localstorage_test';
   try {

--- a/ios/Mobile/Info.plist.in
+++ b/ios/Mobile/Info.plist.in
@@ -21,6 +21,8 @@
 		<dict>
 			<key>CFBundleTypeName</key>
 			<string>OpenDocument Text</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
 			<key>LSHandlerRank</key>
 			<string>Owner</string>
 			<key>LSItemContentTypes</key>
@@ -31,6 +33,8 @@
 		<dict>
 			<key>CFBundleTypeName</key>
 			<string>OpenDocument Flat Text</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
 			<key>LSHandlerRank</key>
 			<string>Default</string>
 			<key>LSItemContentTypes</key>
@@ -127,6 +131,8 @@
 		<dict>
 			<key>CFBundleTypeName</key>
 			<string>OpenDocument Presentation</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
 			<key>LSHandlerRank</key>
 			<string>Owner</string>
 			<key>LSItemContentTypes</key>


### PR DESCRIPTION
When building the iOS app, the %SAVED_UI_STATE% does not get replaced with a quoted string during the build and the resulting unquoted string causes document loading to stop.

Also, eliminate warnings when running in Xcode by adding missing CFBundleTypeRole entries in the iOS app's Info.plist.