### PR TITLE
Don't select columns, when clicks are over resize area

### DIFF
--- a/browser/src/control/Control.ColumnHeader.ts
+++ b/browser/src/control/Control.ColumnHeader.ts
@@ -180,6 +180,9 @@ export class ColumnHeader extends Header {
 		if (!this._mouseOverEntry)
 			return;
 
+		if (this._hitResizeArea)
+			return;
+
 		const col = this._mouseOverEntry.index;
 
 		let modifier = 0;
@@ -259,16 +262,19 @@ export class ColumnHeader extends Header {
 	setOptimalWidthAuto(): void {
 		if (this._mouseOverEntry) {
 			const column = this._mouseOverEntry.index;
-			const command = {
-				Column: {
-					type: 'long',
-					value: column
-				},
-				Modifier: {
-					type: 'unsigned short',
-					value: 0
-				}
-			};
+			if (!this._hitResizeArea) {
+				const command = {
+					Column: {
+						type: 'long',
+						value: column
+					},
+					Modifier: {
+						type: 'unsigned short',
+						value: 0
+					}
+				};
+				this._map.sendUnoCommand('.uno:SelectColumn', command);
+			}
 
 			const extra = {
 				aExtraHeight: {
@@ -277,7 +283,6 @@ export class ColumnHeader extends Header {
 				}
 			};
 
-			this._map.sendUnoCommand('.uno:SelectColumn', command);
 			this._map.sendUnoCommand('.uno:SetOptimalColumnWidthDirect', extra);
 		}
 	}


### PR DESCRIPTION
This allows to select several columns (or individual cells) at once,
and then double-click on the respective "border" area to resize them
automatically to their content (.uno:SetOptimalColumnWidthDirect).

Signed-off-by: Mike Kaganski <mike.kaganski@collabora.com>
Change-Id: I8b19ecb00a6285fec90d73ca09731b4393be6981
