### PR TITLE
Make 'File > Repair' date and time human-readable

### DIFF
--- a/browser/src/control/Control.DocumentRepair.js
+++ b/browser/src/control/Control.DocumentRepair.js
@@ -114,7 +114,7 @@ L.Control.DocumentRepair = L.Control.extend({
 			if (parseInt(actions[iterator].viewId) === this._map._docLayer._viewId) {
 				userName = _('You');
 			}
-			this.createAction(type, actions[iterator].index, actions[iterator].comment, userName, actions[iterator].dateTime);
+			this.createAction(type, actions[iterator].index, actions[iterator].comment, userName, this.transformTimestamp(actions[iterator].dateTime));
 		}
 	},
 
@@ -197,6 +197,14 @@ L.Control.DocumentRepair = L.Control.extend({
 			value: index + 1
 		};
 		this._map.sendUnoCommand('.uno:' + action, command, true);
+	},
+
+	// Transform timestamp from ISO8601 to human readable format with Local time
+	transformTimestamp: function (timestamp) {
+		var d = new Date(timestamp.split(',')[0] + 'Z');
+		var dateOptions = { year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: true };
+		var formattedDateTime = d.toLocaleString(String.locale, dateOptions);
+		return formattedDateTime;
 	}
 });
 


### PR DESCRIPTION
Change-Id: Ib8b745fd10aca2eea2e829ad42cf1d91f7ff2129

* Resolves: #7795 
* Target version: master 

### Summary
We are receiving actions dates in ISO8601 format from Core. We can convert them to both local date and a human-readable format.

Before:
![image](https://github.com/CollaboraOnline/online/assets/61119120/86ff78b5-46ec-4b25-b63f-bfa8c853ed52)

After: 
![Screenshot from 2024-01-01 20-54-18](https://github.com/CollaboraOnline/online/assets/61119120/47f26f7a-d1f9-4301-8316-6f758f2d00e3)