### PR TITLE
Quarantine Improvements

### DIFF
--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -284,7 +284,7 @@
     <quarantine_files desc="Files are stored here to be examined later in cases of crashes or similar situation." default="false" enable="false">
         <limit_dir_size_mb desc="Maximum directory size. On exceeding the specified limit, older files will be deleted." default="250" type="uint"></limit_dir_size_mb>
         <max_versions_to_maintain desc="How many versions of the same file to keep." default="2" type="uint"></max_versions_to_maintain>
-        <path desc="Path to directory under which quarantined files will be stored" type="path" relative="true" default="quarantine"></path>
+        <path desc="Absolute path of the directory under which quarantined files will be stored. Do not use a relative path." type="path" relative="false"></path>
         <expiry_min desc="Time in mins after quarantined files will be deleted." type="int" default="30"></expiry_min>
     </quarantine_files>
 

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -2698,6 +2698,7 @@ void COOLWSD::innerInitialize(Application& self)
     if (getConfigValue<bool>(conf, "quarantine_files[@enable]", false))
     {
         std::string path = Util::trimmed(getPathFromConfig("quarantine_files.path"));
+        LOG_INF("Quarantine path is set to [" << path << "] in config");
         if (path.empty())
         {
             LOG_WRN("Quarantining is enabled via quarantine_files config, but no path is set in "
@@ -2707,6 +2708,10 @@ void COOLWSD::innerInitialize(Application& self)
         {
             if (path[path.size() - 1] != '/')
                 path += '/';
+
+            if (path[0] != '/')
+                LOG_WRN("Quarantine path is relative. Please use an absolute path for better "
+                        "reliability");
 
             Poco::File p(path);
             try
@@ -2728,6 +2733,10 @@ void COOLWSD::innerInitialize(Application& self)
                 Quarantine::initialize(path);
             }
         }
+    }
+    else
+    {
+        LOG_INF("Quarantine is disabled in config");
     }
 
     NumPreSpawnedChildren = getConfigValue<int>(conf, "num_prespawn_children", 1);

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -646,8 +646,10 @@ void DocumentBroker::pollThread()
     if (dataLoss || _docState.disconnected() == DocumentState::Disconnected::Unexpected)
     {
         // Quarantine the last copy, if different.
-        LOG_WRN((dataLoss ? "Data loss " : "Crash ") << "detected, will quarantine last version of ["
-                << getDocKey() << "] if necessary. Quarantine enabled: " << bool(_quarantine)
+        LOG_WRN((dataLoss ? "Data loss " : "Crash ")
+                << "detected, will quarantine last version of [" << getDocKey()
+                << "] if necessary. Quarantine enabled: "
+                << (_quarantine && _quarantine->isEnabled())
                 << ", Storage available: " << bool(_storage));
         if (_storage && _quarantine)
         {

--- a/wsd/QuarantineUtil.cpp
+++ b/wsd/QuarantineUtil.cpp
@@ -100,7 +100,7 @@ void Quarantine::initialize(const std::string& path)
 
 void Quarantine::removeQuarantine()
 {
-    if (!isQuarantineEnabled())
+    if (!isEnabled())
         return;
 
     FileUtil::removeFile(QuarantinePath, true);
@@ -108,7 +108,7 @@ void Quarantine::removeQuarantine()
 
 std::size_t Quarantine::quarantineSize()
 {
-    if (!isQuarantineEnabled())
+    if (!isEnabled())
         return 0;
 
     std::vector<std::string> files;
@@ -125,7 +125,7 @@ std::size_t Quarantine::quarantineSize()
 
 void Quarantine::makeQuarantineSpace()
 {
-    if (!isQuarantineEnabled())
+    if (!isEnabled())
         return;
 
     LOG_ASSERT_MSG(!Mutex.try_lock(), "Quarantine Mutex must be taken");
@@ -181,7 +181,7 @@ void Quarantine::makeQuarantineSpace()
 
 void Quarantine::clearOldQuarantineVersions()
 {
-    if (!isQuarantineEnabled())
+    if (!isEnabled())
         return;
 
     LOG_ASSERT_MSG(!Mutex.try_lock(), "Quarantine Mutex must be taken");
@@ -208,7 +208,7 @@ void Quarantine::clearOldQuarantineVersions()
 
 bool Quarantine::quarantineFile(const std::string& docPath)
 {
-    if (!isQuarantineEnabled())
+    if (!isEnabled())
         return false;
 
     const std::string linkedFilePath =
@@ -250,7 +250,7 @@ bool Quarantine::quarantineFile(const std::string& docPath)
 
 std::string Quarantine::lastQuarantinedFilePath() const
 {
-    if (!isQuarantineEnabled())
+    if (!isEnabled())
         return std::string();
 
     std::lock_guard<std::mutex> lock(Mutex);

--- a/wsd/QuarantineUtil.cpp
+++ b/wsd/QuarantineUtil.cpp
@@ -79,7 +79,7 @@ void Quarantine::initialize(const std::string& path)
               });
 
     std::vector<StringToken> tokens;
-    for (const auto& file : files)
+    for (const std::string& file : files)
     {
         StringVector::tokenize(file.c_str(), file.size(), Delimiter, tokens);
         if (tokens.size() >= 3)

--- a/wsd/QuarantineUtil.hpp
+++ b/wsd/QuarantineUtil.hpp
@@ -25,6 +25,8 @@ public:
 
     static void initialize(const std::string& path);
 
+    bool isEnabled() const { return !QuarantinePath.empty(); }
+
     /// Quarantines a new version of the document.
     bool quarantineFile(const std::string& docName);
 
@@ -35,8 +37,6 @@ public:
     void removeQuarantinedFiles();
 
 private:
-    bool isQuarantineEnabled() const { return !QuarantinePath.empty(); }
-
     /// Returns quarantine directory size in bytes.
     std::size_t quarantineSize();
 


### PR DESCRIPTION
Improves the quarantine path config and corrects the enabled/disabled state of quarantine.

    The quarantine path should be an absolute path.
    
    Unfortunately, because we had relative=true in
    the path config, we couldn't detect empty configs.
    This is because with relative=true the getter
    would create a path based on the current directory
    and the config value, which would default to
    "quarantine" when empty.
    This would result in /opt/cool/quarantine or
    /usr/bin/quarantine when in fact the path is
    really empty.
    
    Now, the config has relative=false and
    there is no default. In addition, we
    warn if the path is no absolute.
    


- wsd: quarantine: isQuarantineEnabled -> isEnabled and log it
- wsd: quarantine: absolute-path and better logging
