### PR TITLE
wsd: force autoSave on always_save_on_exit

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -2751,9 +2751,10 @@ std::size_t DocumentBroker::removeSession(const std::shared_ptr<ClientSession>& 
 
         // If last editable, save (if not saving already) and
         // don't remove until after uploading to storage.
+        // If always_save_on_exit=true, issue a save to guarantee uploading if necessary.
         if (!lastEditableSession ||
             (!_saveManager.isSaving() &&
-             !autoSave(/*force=*/isPossiblyModified(), dontSaveIfUnmodified)))
+             !autoSave(/*force=*/_alwaysSaveOnExit || isPossiblyModified(), dontSaveIfUnmodified)))
         {
             disconnectSessionInternal(session);
         }


### PR DESCRIPTION
This forces autoSave when always_save_on_exit
is true. This is needed so we can guarantee
that we don't have modification and that
we upload if there has every been one.
The latter case is checked in
DocumentBroker::needToUploadToStorage(),
which is called from
DocumentBroker::checkAndUploadToStorage().

A new test reproduces the issue and defends
the fix.

Change-Id: I0b2105a57cfd7049ba7b1f63e62a700fdc3744c2
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
