### PR TITLE
Make sure to clear "menu-opened" on popup close

### DIFF
--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -147,6 +147,8 @@ L.Control.JSDialog = L.Control.extend({
 		}
 		else {
 			this.clearDialog(id);
+			if (L.DomUtil.hasClass(clickToClose, 'menu-opened'))
+				L.DomUtil.removeClass(clickToClose, 'menu-opened');
 		}
 
 		this.focusToLastElement(id);

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2522,17 +2522,14 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			var arrowbackground = L.DomUtil.create('div', 'arrowbackground', div);
 			var arrow = L.DomUtil.create('i', 'unoarrow', arrowbackground);
 			controls['arrow'] = arrow;
-			var menuIsOpened = false;
 			$(arrowbackground).click(function (event) {
 				if (!$(div).hasClass('disabled')) {
-					if (menuIsOpened) {
+					if ($(div).hasClass('menu-opened')) {
 						builder.callback('toolbox', 'closemenu', parentContainer, data.command, builder);
-						menuIsOpened = false;
 						$(div).removeClass('menu-opened');
 					} else {
-						menuIsOpened = true;
-						builder.callback('toolbox', 'openmenu', parentContainer, data.command, builder);
 						$(div).addClass('menu-opened');
+						builder.callback('toolbox', 'openmenu', parentContainer, data.command, builder);
 					}
 
 					event.stopPropagation();


### PR DESCRIPTION
Some popups call closePopover passing sendCloseEvent=false. This keeps the toolbutton's state as "opened"; and so, the next click on it would perform "close" cleanup. Only then a following click would activate the popup.

This was seen when clicking on the arrow of sidebar's Paragraph's Ordered List toolbar. Clicking on a popup's element to select a style, and then immediately clicking on the arrow again didn't open the popup.

Make sure that closePopover cleans the respective class from the element, even when not sending events. Simplify the arrow click handler, to not use a local variable, and rely on the class.


Change-Id: I923cbe28212e7fdedf91a78f64f9c1cae3d8b26f


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

