### PR TITLE
Core side handles the right click with mouse down event.

### DIFF
--- a/browser/src/map/handler/Map.TouchGesture.js
+++ b/browser/src/map/handler/Map.TouchGesture.js
@@ -240,8 +240,8 @@ L.Map.TouchGesture = L.Handler.extend({
 		};
 
 		var rightClick = function () {
+			// We will only send "buttondown" event because core side fires "buttonup" event internally.
 			docLayer._postMouseEvent('buttondown', mousePos.x, mousePos.y, 1, 4, 0);
-			docLayer._postMouseEvent('buttonup', mousePos.x, mousePos.y, 1, 4, 0);
 		};
 
 		var waitForSelectionMsg = function () {


### PR DESCRIPTION
It internally handles the mouseup. So we don't send it again.

Without this change, context menus can't behave normal. Because mouse pointer is set to somewhere else with the mouse up event.


Change-Id: I719565b1ce192045250f9217e971725d8cc1003b


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

