### PR TITLE
jsdialog: simplify dropdown closing

### DIFF
--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -129,16 +129,10 @@ L.Control.JSDialog = L.Control.extend({
 		var builder = this.dialogs[id].builder;
 
 		if (sendCloseEvent) {
-			var isDropdownToolItem =
-				clickToClose && L.DomUtil.hasClass(clickToClose, 'has-dropdown');
-
-			// try to toggle the dropdown first
-			if (isDropdownToolItem) {
-				var dropdownArrow = clickToClose.querySelector('.arrowbackground');
-				dropdownArrow.click();
-			}
-
-			if (clickToClose && !isDropdownToolItem && L.DomUtil.hasClass(clickToClose, 'menubutton'))
+			// first try to close the dropdown if exists
+			if (clickToClose && typeof clickToClose.closeDropdown === 'function')
+				clickToClose.closeDropdown();
+			if (clickToClose && L.DomUtil.hasClass(clickToClose, 'menubutton'))
 				clickToClose.click();
 			else if (builder)
 				builder.callback('popover', 'close', {id: '__POPOVER__'}, null, builder);

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2522,22 +2522,16 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			var arrowbackground = L.DomUtil.create('div', 'arrowbackground', div);
 			var arrow = L.DomUtil.create('i', 'unoarrow', arrowbackground);
 			controls['arrow'] = arrow;
-			var menuIsOpened = false;
 			$(arrowbackground).click(function (event) {
 				if (!$(div).hasClass('disabled')) {
-					if (menuIsOpened) {
-						builder.callback('toolbox', 'closemenu', parentContainer, data.command, builder);
-						menuIsOpened = false;
-						$(div).removeClass('menu-opened');
-					} else {
-						menuIsOpened = true;
-						builder.callback('toolbox', 'openmenu', parentContainer, data.command, builder);
-						$(div).addClass('menu-opened');
-					}
-
+					builder.callback('toolbox', 'openmenu', parentContainer, data.command, builder);
 					event.stopPropagation();
 				}
 			});
+
+			div.closeDropdown = function() {
+				builder.callback('toolbox', 'closemenu', parentContainer, data.command, builder);
+			};
 		}
 
 		$(div).on('click.toolbutton',function (e) {


### PR DESCRIPTION
This is partial revert of "jsdialog: use open/close instead of toggle for dropdowns" commit 0833ec64894fc6815748bb9ab7f7cc02073842a9.

Which introduced "state" variable which was desynchronised with core in some cases. Now directly call desired close command in closePopover.

This fixes bug:
1. Click on the sidebar's Paragraph's "Ordered list" dropdown arrow;
2. Click on any kind of the list (so that the current paragraph gets the chosen list style);
3. Click on the drop-down arrow again, expecting the drop-down to open. Result: you need to click two times to open menu again
