### PR TITLE
Use /proc/self/smaps_rollup for improved perf #7927

### DIFF
--- a/common/Util.cpp
+++ b/common/Util.cpp
@@ -498,8 +498,15 @@ namespace Util
     {
         if (pid > 0)
         {
-            const auto cmd = "/proc/" + std::to_string(pid) + "/smaps";
-            FILE* fp = fopen(cmd.c_str(), "r");
+            // beautifully aggregated data in a single entry:
+            const auto cmd_rollup = "/proc/" + std::to_string(pid) + "/smaps_rollup";
+            FILE* fp = fopen(cmd_rollup.c_str(), "r");
+            if (!fp)
+            {
+                const auto cmd = "/proc/" + std::to_string(pid) + "/smaps";
+                fp = fopen(cmd.c_str(), "r");
+            }
+
             if (fp != nullptr)
             {
                 const std::size_t pss = getPssAndDirtyFromSMaps(fp).first;

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -3025,9 +3025,14 @@ void lokit_main(
                 std::chrono::steady_clock::now() - jailSetupStartTime);
             LOG_DBG("Initialized jail files in " << ms);
 
-            ProcSMapsFile = open("/proc/self/smaps", O_RDONLY);
+            ProcSMapsFile = open("/proc/self/smaps_rollup", O_RDONLY);
             if (ProcSMapsFile < 0)
-                LOG_SYS("Failed to open /proc/self/smaps. Memory stats will be missing.");
+            {
+                LOG_WRN("Failed to open /proc/self/smaps_rollup. Memory stats will be slower");
+                ProcSMapsFile = open("/proc/self/smaps", O_RDONLY);
+                if (ProcSMapsFile < 0)
+                    LOG_SYS("Failed to open /proc/self/smaps. Memory stats will be missing.");
+            }
 
             LOG_INF("chroot(\"" << jailPathStr << "\")");
             if (chroot(jailPathStr.c_str()) == -1)


### PR DESCRIPTION
Using the aggregated file saves a hundred+ system-calls per pid we're getting data for, and presumably also lots of time.


Change-Id: I41c40982ebbec44aba72a1d15dabf24a8986f59e


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

