### PR TITLE
browser: fix triple click event

### DIFF
--- a/browser/src/dom/DomEvent.MultiClick.js
+++ b/browser/src/dom/DomEvent.MultiClick.js
@@ -6,7 +6,7 @@
 
 L.extend(L.DomEvent, {
 
-	addMultiClickListener: function (obj, handler, id) {
+	addMultiClickListener: function (obj, handler, id, type) {
 		var last = [],
 		    delay = 250;
 
@@ -46,7 +46,8 @@ L.extend(L.DomEvent, {
 					isMouseEvent: e instanceof MouseEvent
 				};
 
-				handler(eOut);
+				if (type == eOut.type)
+					handler(eOut);
 			}
 
 			last.push(now);


### PR DESCRIPTION
The 'addMultiClickListener' fires 2 times
'triple click', because it also registers
for 'quadruple click' too.

Change-Id: Iee7565163e64373c87016743c06fe1cc084b80f4
Signed-off-by: Henry Castro <hcastro@collabora.com>
