### PR TITLE
Do not upload unmodified document

### DIFF
--- a/test/UnitWOPISaveOnExit.cpp
+++ b/test/UnitWOPISaveOnExit.cpp
@@ -19,11 +19,7 @@
 
 #include <Poco/Net/HTTPRequest.h>
 
-#include "Util.hpp"
-#include "Log.hpp"
 #include "Unit.hpp"
-#include "UnitHTTP.hpp"
-#include "helpers.hpp"
 #include "lokassert.hpp"
 
 class UnitWOPISaveOnExit : public WOPIUploadConflictCommon
@@ -213,7 +209,7 @@ public:
     /// The document is loaded.
     bool onDocumentLoaded(const std::string& message) override
     {
-        LOG_TST("onDocumentLoaded: [" << message << ']');
+        LOG_TST("Got: [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitLoadStatus);
 
         LOG_TST("Modifying the document");
@@ -228,7 +224,7 @@ public:
 
     bool onDocumentModified(const std::string& message) override
     {
-        LOG_TST("onDocumentModified: [" << message << ']');
+        LOG_TST("Got: [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitModifiedStatus);
 
         TRANSITION_STATE(_phase, Phase::WaitUploadAfterSave);
@@ -322,14 +318,14 @@ class UnitSaveOnExitUnmodified : public WopiTestServer
 
 public:
     UnitSaveOnExitUnmodified()
-        : WopiTestServer("UnitSaveOnExitUnmodified")
+        : Base("UnitSaveOnExitUnmodified")
         , _phase(Phase::Load)
     {
     }
 
     void configure(Poco::Util::LayeredConfiguration& config) override
     {
-        WopiTestServer::configure(config);
+        Base::configure(config);
 
         // Make it more likely to force uploading.
         config.setBool("per_document.always_save_on_exit", true);
@@ -347,7 +343,7 @@ public:
     /// The document is loaded.
     bool onDocumentLoaded(const std::string& message) override
     {
-        LOG_TST("onDocumentLoaded: [" << message << ']');
+        LOG_TST("Got: [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitLoadStatus);
 
         TRANSITION_STATE(_phase, Phase::WaitDestroy);

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -2725,7 +2725,12 @@ std::size_t DocumentBroker::removeSession(const std::shared_ptr<ClientSession>& 
         const std::size_t activeSessionCount = countActiveSessions();
 
         const bool lastEditableSession = session->isEditable() && !haveAnotherEditableSession(id);
-        const bool dontSaveIfUnmodified = !_alwaysSaveOnExit;
+        // Forcing a save when always_save_on_exit=true creates a new
+        // file on disk, with a new timestamp, which makes it hard to
+        // avoid uploading when there really isn't any modifications.
+        // Instead, we rely on always issuing a save through forced
+        // auto-save and expect Core has the correct modified flag.
+        constexpr bool dontSaveIfUnmodified = true;
 
         LOG_INF("Removing session [" << id << "] on docKey [" << _docKey << "]. Have "
                                      << _sessions.size() << " sessions (" << activeSessionCount

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -1012,12 +1012,21 @@ private:
         /// Sets whether the last save was successful or not.
         void setLastSaveResult(bool success, bool newVersion)
         {
-            LOG_DBG("Saving version #" << version() + 1 << (success ? " succeeded" : " failed")
-                                       << " after " << _request.timeSinceLastRequest());
-            _request.setLastRequestResult(success);
-
             if (newVersion)
+            {
                 ++_version; // Bump the version.
+                LOG_DBG("Saving of new version #"
+                        << _version << (success ? " succeeded" : " failed") << " after "
+                        << _request.timeSinceLastRequest());
+            }
+            else
+            {
+                LOG_DBG("Saving" << (success ? " succeeded" : " failed") << " after "
+                                 << _request.timeSinceLastRequest()
+                                 << " but no newer version than #" << _version << " is produced");
+            }
+
+            _request.setLastRequestResult(success);
         }
 
         /// Returns the last save request time.


### PR DESCRIPTION
When always_save_on_exit=true we should
still not upload the document when it
isn't modified.

In this case, because we now always
save the document (forced) when
always_save_on_exit=true, and because
saving always generates a new file on
disk, with a new timestamp, we couldn't
detect that there are no modifications.

We now still force save, but ask Core
to skip it if the document is unmodified.

This is safe since we now always issue
the save, but rely on Core to do the
right thing. When the document is saved,
we do the normal upload as in that case
we know we have a new version of the
document, which must be uploaded.

Worth noting that the closedocument
command doesn't trigger the same path.
To reproduce the issue, we need a new
test that disconnects, instead of the
graceful closedocument command.

- wsd: logging and cosmetics
- wsd: do not upload unmodified document
