### PR TITLE
Improvment in spinfield conatiner class.

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -649,6 +649,7 @@ input[type='checkbox']:checked.autofilter, .jsdialog input[type='checkbox']:chec
 
 .ui-dialog-content .jsdialog.ui-text {
 	padding-inline-start: 0;
+	margin: auto 5px;
 }
 
 .jsdialog.ui-text {
@@ -656,6 +657,12 @@ input[type='checkbox']:checked.autofilter, .jsdialog input[type='checkbox']:chec
 }
 
 /* spinfield */
+
+.spinfieldcontainer {
+	margin-right: 5px;
+	min-width: 70px;
+	width: 100%;
+}
 
 .spinfieldcontainer input {
 	border: 1px solid var(--color-border-dark);


### PR DESCRIPTION
Steps to reproduce:
    - Insert chart in odt
    - right click and select properties
    - see dialog looks odd

Problem:
- label element after spinfieldunit getting overlapped
- user can not see label tag after spinfield conatiner

Improvment:
- added css for spinfieldconatiner to fix overlapping issue.
- improve margin for more readability of .jsdialog.ui-text

Change-Id: If64d30d10021a023c76852647ef8aebdede0513a


Before:
![image](https://github.com/CollaboraOnline/online/assets/61383886/eb819ad6-40b2-441a-9ca0-7afdd18bf976)


After: 
![image](https://github.com/CollaboraOnline/online/assets/61383886/628c29d7-6104-4fb3-afe7-09eee12bbafa)

