### PR TITLE
fix: tiles not getting updated after migration

### DIFF
--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -1403,6 +1403,7 @@ app.definitions.Socket = L.Class.extend({
 		}
 		else if (this._reconnecting) {
 			// we are reconnecting ...
+			this._map._docLayer._resetClientVisArea();
 			this._map._docLayer._refreshTilesInBackground();
 			this._map.fire('statusindicator', { statusType: 'reconnected' });
 

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1315,8 +1315,8 @@ L.CanvasTileLayer = L.Layer.extend({
 
 	_refreshTilesInBackground: function() {
 		for (var key in this._tiles) {
-			this._tiles[key].wireId = 1;
-			this._tiles[key].invalidFrom = 1;
+			this._tiles[key].wireId = 0;
+			this._tiles[key].invalidFrom = 0;
 		}
 	},
 


### PR DESCRIPTION
- when migrating document from one server to another using indirection server tiles were not getting updated
- _resetClientVisArea should be called even if there are no changes to the client because the server needs new data even if the client is unmodified.
- changing wireId and invalidFrom values to 0, 0 to force a keyframe https://github.com/CollaboraOnline/online/blob/b1f0834ac45c459ca904406bf32254c074b91c64/browser/src/layer/tile/CanvasTileLayer.js#L7266


Change-Id: I9aa0b34c3b1f157f3e4494568802588e00376d7e

* Target version: master 
