### PR TITLE
cypress test: autofilter

### DIFF
--- a/browser/src/control/Control.IdleHandler.ts
+++ b/browser/src/control/Control.IdleHandler.ts
@@ -106,7 +106,8 @@ class IdleHandler {
 			return;
 		}
 
-		if (window.mode.isDesktop() && (!this._active || this.map.uiManager.isAnyDialogOpen())) {
+		var hasDimDialog = !!document.getElementById(this.dimId);
+		if (window.mode.isDesktop() && (!this._active || hasDimDialog)) {
 			// A dialog is already dimming the screen and probably
 			// shows an error message. Leave it alone.
 			this._active = false;

--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -140,8 +140,10 @@ app.definitions.Socket = L.Class.extend({
 			if (typeof msg !== 'string')
 				return;
 
-			if (!msg.startsWith('useractive') && !msg.startsWith('userinactive'))
+			if (!msg.startsWith('useractive') && !msg.startsWith('userinactive')) {
+				window.app.console.log('Ignore outgoing message due to inactivity: "' + msg + '"');
 				return;
+			}
 		}
 
 		if (this._map.uiManager && this._map.uiManager.isUIBlocked())

--- a/cypress_test/integration_tests/common/calc_helper.js
+++ b/cypress_test/integration_tests/common/calc_helper.js
@@ -223,17 +223,15 @@ function selectCellsInRange(range) {
 }
 
 function openAutoFilterMenu(secondColumn) {
-	let x = 95;
+	let XPos = 95;
+	let YPos = 10;
+
 	if (secondColumn) {
-		x += 105;
+		XPos += 105;
 	}
-	cy.cGet('#map')
-		.then(function(items) {
-			expect(items).to.have.lengthOf(1);
-			var XPos = items[0].getBoundingClientRect().left + x;
-			var YPos = items[0].getBoundingClientRect().top + 10;
-			cy.cGet('body').click(XPos, YPos);
-		});
+
+	cy.cGet('#map').then(function(items) { expect(items).to.have.lengthOf(1); });
+	cy.cGet('#map').click(XPos, YPos);
 }
 
 module.exports.clickOnFirstCell = clickOnFirstCell;

--- a/cypress_test/integration_tests/desktop/calc/autofilter_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/autofilter_spec.js
@@ -112,6 +112,30 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'AutoFilter', function() {
 		assertDataOnFilter(['Cypress Test', 'Status', 'Test 1', 'Pass', 'Test 2', 'Fail', 'Test 3', 'Pass', 'Test 5', 'Fail']);
 	});
 
+	it('Close autofilter popup by click outside', function() {
+		calcHelper.openAutoFilterMenu();
+
+		cy.cGet('.autofilter .vertical').should('be.visible');
+
+		cy.cGet('div.jsdialog-overlay').should('be.visible');
+
+		cy.cGet('div.jsdialog-overlay').click();
+
+		cy.cGet('.jsdialog.autofilter').should('not.exist');
+
+		// check if spreadsheet is interactive - prevent core block by hanging popup
+
+		calcHelper.dblClickOnFirstCell();
+
+		helper.typeIntoDocument('New content{enter}');
+
+		calcHelper.selectEntireSheet();
+
+		helper.waitUntilIdle('#copy-paste-container tbody');
+
+		calcHelper.assertDataClipboardTable(['CNew contentypress Test', 'Status', 'Test 1', 'Pass', 'Test 2', 'Fail', 'Test 3', 'Pass', 'Test 4', '', 'Test 5', 'Fail']);
+	});
+
 	// check if filter by color applied or not
 	it('Filter by color', function() {
 		// apply background color to some cells


### PR DESCRIPTION
Don't make view inactive when dialog is opened
    
    If user opened any dialog and we got blur event on
    map - it was doing the view inactive by sending
    userinactive message to the server and ignoring any
    meesages we tried to send. Because of that it was
    impossible to test in cypress dropdown dismiss by
    click outside popup (due to losing focus from map).
    
    This is regression from rework:
    commit 86e8491707c8f25b106909a340f45edd65e704e5
    For .eslintrc change, see: https://github.com/typescript-eslint/typescript-eslint/issues/1824
    
    where we changed:
    - if (!this._active || isAnyVexDialogActive()) {
    + if (!this._active || isAnyVexDialogActive() || this.map.jsdialog.hasDialogOpened()) {
    
    Make more precise condition so we check if the dialog is a dim one.

cypress: autofilter dismiss by click outside popup

    Integration test