### PR TITLE
CanvasTileLayer: allow empty string as payload of the state changed callback in json, too

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -3130,7 +3130,9 @@ L.CanvasTileLayer = L.Layer.extend({
 		var isPureJSON = textMsg.indexOf('=') === -1 && textMsg.indexOf('{') !== -1;
 		if (isPureJSON) {
 			var json = JSON.parse(textMsg);
-			if (json.commandName && json.state) {
+			// json.state as empty string is fine, for example it means no selection
+			// when json.commandName is '.uno:RowColSelCount'.
+			if (json.commandName && json.state !== undefined) {
 				this._map.fire('commandstatechanged', json);
 			}
 		} else {


### PR DESCRIPTION
Once core emits JSON format for the LOK_CALLBACK_STATE_CHANGED callback
for the .uno:RowColSelCount uno command, select 2 cells in Calc ->
status bar is updated correctly, now select a single cell again in Calc
-> status bar is not updated. We want to emit JSON format for more uno
commands in the future, for example that is meant to allow testing the
fix for the statusbar part of
<https://github.com/CollaboraOnline/online/issues/7492>.

CanvasTileLayer's _onStateChangedMsg handles a mix of plain text and
json payloads, and the plain text case already allows an empty payload,
while the JSON one does not.

Fix the problem by assuming the intention in commit
403fe10c9d068317359310bd6005ed7f2163715d (jsdialog: handle graphic items
updates, 2019-11-28) was to make sure the json key is not missing, not
to block empty string values for the 'state' key.

Once this is in, core.git can emit JSON for .uno:RowColSelCount, can say
which locale was used to generate the payload and we can assert the
correct language in a test.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I145a552e88fdc869a151a0bd07e8b42474ffd6b8
