### PR TITLE
Do not force background color for calc sheet tab when hover

### DIFF
--- a/browser/css/device-desktop.css
+++ b/browser/css/device-desktop.css
@@ -29,8 +29,8 @@
 .button-secondary:hover,
 button:not(.ui-corner-all):not(.button-primary):not(.unobutton):not(.form-field-button):hover {
 	cursor: pointer;
-	color: var(--color-text-darker) !important;
-	background-color: var(--color-background-lighter) !important;
+	color: var(--color-text-darker);
+	background-color: var(--color-background-lighter);
 	border: 1px solid var(--color-border-darker);
 }
 


### PR DESCRIPTION
- When we click on any sheet tab it has active + hover effect at same time
- by forcing !important in device-desktop.css it will break the visual effect on active tab when we hover over it


Before:

![image](https://github.com/CollaboraOnline/online/assets/61383886/9729a3cb-b0f2-492a-8b9f-86530611ebd0)


After:

![image](https://github.com/CollaboraOnline/online/assets/61383886/b0eb4b57-d479-47e8-a6ca-3ed4de49cbdf)


Change-Id: I9e10f2a7e435b03e73c859ba742db0d7353aaa52