### PR TITLE
Idle Handler fix

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -734,7 +734,7 @@ pot:
 		src/control/Control.DownloadProgress.js \
 		src/control/Control.FormulaBar.js \
 		src/control/Control.FormulaBarJSDialog.js \
-		src/control/jsdialog/Widget.MobileBorderSelector.js \
+		src/control/Control.IdleHandler.ts \
 		src/control/Control.JSDialogBuilder.js \
 		src/control/Control.LanguageDialog.js \
 		src/control/Control.Menubar.js \
@@ -767,6 +767,7 @@ pot:
 		src/control/Ruler.js \
 		src/control/Signing.js \
 		src/control/Toolbar.js \
+		src/control/jsdialog/Widget.MobileBorderSelector.js \
 		src/control/jsdialog/Widget.TreeView.js \
 		src/core/Socket.js \
 		src/docstate.js \

--- a/browser/src/control/Control.IdleHandler.ts
+++ b/browser/src/control/Control.IdleHandler.ts
@@ -108,8 +108,7 @@ class IdleHandler {
 			return;
 		}
 
-		var hasDimDialog = !!document.getElementById(this.dimId);
-		if (window.mode.isDesktop() && (!this._active || hasDimDialog)) {
+		if (window.mode.isDesktop() && (!this._active || this.isDimActive())) {
 			// A dialog is already dimming the screen and probably
 			// shows an error message. Leave it alone.
 			this._active = false;

--- a/browser/src/control/Control.IdleHandler.ts
+++ b/browser/src/control/Control.IdleHandler.ts
@@ -52,9 +52,7 @@ class IdleHandler {
 			}
 		}
 
-		// Ideally instead of separate isAnyEdit check here, we could check isAnyEdit inside isAnyDialogOpen,
-		// but unfortunatly that causes problem in _deactivate and unnecessary 'userinactive' message is sent
-		if (window.mode.isDesktop() && !this.map.uiManager.isAnyDialogOpen() && !cool.Comment.isAnyEdit()) {
+		if (window.mode.isDesktop() && !this.map.uiManager.isAnyDialogOpen()) {
 			this.map.focus();
 		}
 

--- a/browser/src/control/Control.IdleHandler.ts
+++ b/browser/src/control/Control.IdleHandler.ts
@@ -18,6 +18,16 @@ class IdleHandler {
     map: any;
 	dimId: string = 'inactive_user_message';
 
+	getIdleMessage(): string {
+		if (this.map['wopi'] && this.map['wopi'].DisableInactiveMessages) {
+			return '';
+		} else if (window.mode.isDesktop()) {
+			return _('Idle document - please click to reload and resume editing');
+		} else {
+			return _('Idle document - please tap to reload and resume editing');
+		}
+	}
+
 	isDimActive(): boolean {
 		return !!document.getElementById(this.map.uiManager.generateModalId(this.dimId));
 	}
@@ -28,6 +38,8 @@ class IdleHandler {
 	}
 
 	_activate() {
+		window.app.console.debug('IdleHandler: _activate()');
+
 		if (this._serverRecycling || this._documentIdle) {
 			return false;
 		}
@@ -59,7 +71,11 @@ class IdleHandler {
 		return false;
 	}
 
-	_dim(message: string) {
+	_dim() {
+		const message = this.getIdleMessage();
+
+		window.app.console.debug('IdleHandler: _dim(' + message + ')');
+
 		this._active = false;
 		var map = this.map;
 
@@ -102,6 +118,8 @@ class IdleHandler {
 	}
 
 	_deactivate() {
+		window.app.console.debug('IdleHandler: _deactivate()');
+
 		if (this._serverRecycling || this._documentIdle || !this.map._docLoaded) {
 			return;
 		}

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -14,7 +14,7 @@
  *			 and allows to controll them (show/hide)
  */
 
-/* global app $ setupToolbar w2ui toolbarUpMobileItems _ Hammer JSDialog */
+/* global app cool $ setupToolbar w2ui toolbarUpMobileItems _ Hammer JSDialog */
 L.Control.UIManager = L.Control.extend({
 	mobileWizard: null,
 	documentNameInput: null,
@@ -1138,6 +1138,9 @@ L.Control.UIManager = L.Control.extend({
 	},
 
 	isAnyDialogOpen: function() {
+		if (cool.Comment.isAnyEdit())
+			return true;
+
 		if (this.map.jsdialog)
 			return this.map.jsdialog.hasDialogOpened();
 		else

--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -779,11 +779,6 @@ app.definitions.Socket = L.Class.extend({
 				postMsgData['Reason'] = 'OwnerTermination';
 			}
 			else if (textMsg === 'idle' || textMsg === 'oom') {
-				if (window.mode.isDesktop()) {
-					msg = _('Idle document - please click to reload and resume editing');
-				} else {
-					msg = _('Idle document - please tap to reload and resume editing');
-				}
 				app.idleHandler._documentIdle = true;
 				this._map._docLayer._documentInfo = undefined;
 				postMsgData['Reason'] = 'DocumentIdle';
@@ -867,13 +862,8 @@ app.definitions.Socket = L.Class.extend({
 			// Close any open dialogs first.
 			this._map.uiManager.closeAll();
 
-			var message = '';
-			if (!this._map['wopi'].DisableInactiveMessages) {
-				message = msg;
-			}
-
 			if (textMsg === 'idle' || textMsg === 'oom') {
-				app.idleHandler._dim(message);
+				app.idleHandler._dim();
 			}
 
 			if (postMsgData['Reason']) {


### PR DESCRIPTION
Check for comments in isAnyDialogOpen
    
As described in the comment there was problem with
userinactive command. This is now solved due to:
commit fa006fc3afacc7c7369ceaed20833c8c9ba05989
Don't make view inactive when dialog is opened
    
Comment was from commit 6550e713c4bf687931aa721f36d0a28ac70e94f0
annotation: calc scroll vertical to make selected comment visible

-------

IdleHandler: bring back idle timeout for view
    
This fixes regression introduced in
commit 86e8491707c8f25b106909a340f45edd65e704e5
For .eslintrc change, see: https://github.com/typescript-eslint/typescript-eslint/issues/1824
    
Where per_view.idle_timeout_secs and out_of_focus_timeout_secs
settings didn't have any effect.
    
    <out_of_focus_timeout_secs desc="The maximum number of seconds before dimming and stopping updates when the browser tab is no longer in focus. Defaults to 120 seconds." type="uint" default="120">120</out_of_focus_timeout_secs>
    
    <idle_timeout_secs desc="The maximum number of seconds before dimming and stopping updates when the user is no longer active (even if the browser is in focus). Defaults to 15 minutes." type="uint" default="900">900</idle_timeout_secs>
