### PR TITLE
Remove waits from cypress tests (make cypress tests 45% faster)

### DIFF
--- a/cypress_test/integration_tests/common/calc_helper.js
+++ b/cypress_test/integration_tests/common/calc_helper.js
@@ -35,7 +35,6 @@ function clickOnFirstCell(firstClick = true, dblClick = false, isA1 = true) {
 	cy.log('Param - firstClick: ' + firstClick);
 	cy.log('Param - dblClick: ' + dblClick);
 
-	cy.wait(2000);
 	// Use the tile's edge to find the first cell's position
 	cy.cGet('#map')
 		.then(function(items) {
@@ -56,10 +55,6 @@ function clickOnFirstCell(firstClick = true, dblClick = false, isA1 = true) {
 			});
 	} else {
 		cy.cGet('.cursor-overlay .blinking-cursor').should('be.visible');
-
-		helper.doIfOnDesktop(function() {
-			cy.wait(500);
-		});
 	}
 
 	if (isA1)
@@ -204,6 +199,9 @@ function assertDataClipboardTable(expectedData) {
 		.should(function(cells) {
 			expect(cells).to.have.lengthOf(expectedData.length);
 		});
+
+	// Wait for clipboard to update anyways, in case previous contents were same length
+	cy.wait(200);
 
 	var data = [];
 

--- a/cypress_test/integration_tests/common/contenteditable_helper.js
+++ b/cypress_test/integration_tests/common/contenteditable_helper.js
@@ -19,7 +19,6 @@ function type(text, times = 1) {
 	}
 
 	cy.log('Clipboard - typing start.');
-	// cy.wait(50);
 	cy.get('@clipboard').type(input, {delay: 10, force: true});
 	cy.log('Clipboard - typing end.');
 }
@@ -77,14 +76,12 @@ function select(start, end) {
 }
 
 function checkHTMLContent(content) {
-	cy.wait(1000);
 	cy.get('@clipboard').should(($c) => {
 		expect($c).have.html($c.get(0)._wrapContent(content));
 	});
 }
 
 function checkPlainContent(content) {
-	cy.wait(1000);
 	cy.get('@clipboard').should('have.text', content);
 }
 
@@ -94,25 +91,21 @@ function checkSelectionRange(start, end) {
 		start = end;
 		end = t;
 	}
-	cy.wait(500);
 	cy.get('@clipboard').should('have.prop', 'isSelectionNull', false);
 	_checkSelectionStart(start);
 	_checkSelectionEnd(end);
 }
 
 function checkCaretPosition(pos) {
-	cy.wait(500);
 	_checkSelectionStart(pos);
 	_checkSelectionEnd(pos);
 }
 
 function checkSelectionIsNull() {
-	cy.wait(500);
 	cy.get('@clipboard').should('have.prop', 'isSelectionNull', true);
 }
 
 function checkSelectionIsEmpty(pos) {
-	cy.wait(500);
 	cy.get('@clipboard').should('have.prop', 'isSelectionNull', false);
 	_checkSelectionStart(pos);
 	_checkSelectionEnd(pos);

--- a/cypress_test/integration_tests/common/helper.js
+++ b/cypress_test/integration_tests/common/helper.js
@@ -1,8 +1,6 @@
 /* -*- js-indent-level: 8 -*- */
 /* global cy Cypress expect */
 
-var mobileWizardIdleTime = 1250;
-
 function copyFile(fileName, newFileName, subFolder) {
 	if (subFolder === undefined) {
 		cy.task('copyFile', {
@@ -521,8 +519,6 @@ function beforeAll(fileName, subFolder, noFileCopy, isMultiUser, subsequentLoad,
 }
 
 function afterAll(fileName, testState) {
-	if (Cypress.browser.isHeaded)
-		cy.wait(2000);
 	closeDocument(fileName, testState);
 	cy.log('Finished test: ' + Cypress.spec.relative + ' / ' + Cypress.currentTest.titlePath.join(' / '));
 }
@@ -589,6 +585,7 @@ function closeDocument(fileName, testState) {
 			'/browser/dist/admin/admin.html');
 
 		// https://github.com/cypress-io/cypress/issues/9207
+		// TODO reproduce or remove
 		if (testState === 'failed') {
 			cy.wait(5000);
 			return;
@@ -776,64 +773,16 @@ function isCanvasWhite(expectWhite = true) {
 // selector - a CSS selector to query a DOM element to wait on to be idle.
 // content - a string, a content selector used by cy.contains() to select the correct DOM element.
 // waitingTime - how much time to wait before we say the item is idle.
-function waitUntilIdle(selector, content, waitingTime = mobileWizardIdleTime) {
-	cy.log('Waiting item to be idle - start.');
-	cy.log('Param - selector: ' + selector);
-	cy.log('Param - content: ' + content);
-	cy.log('Param - waitingTime: ' + waitingTime);
-
-	var item;
-	// We check every 'waitOnce' time whether we are idle.
-	var waitOnce = 250;
-	// 'idleSince' variable counts the idle time so far.
-	var idleSince = 0;
+function waitUntilIdle(selector, content) {
+	// waitUntilIdle has been stubbed in order to reduce the number of calls to cy.wait().
+	// Find a specific condition to wait for using waitUntil, or even better use Cypress's
+	// built-in retrying functionality on find, should, and other functions.
+	cy.log('waitUntilIdle stubbed');
 	if (content) {
-		// We get the initial DOM item first.
-		cy.cGet().contains(selector, content, { log: false })
-			.then(function(itemToIdle) {
-				item = itemToIdle;
-			});
-
-		cy.waitUntil(function() {
-			cy.wait(waitOnce, { log: false });
-
-			return cy.cGet().contains(selector, content, { log: false })
-				.then(function(itemToIdle) {
-					if (Cypress.dom.isDetached(item[0])) {
-						cy.log('Item was detached after ' + (idleSince + waitOnce).toString() + ' ms.');
-						item = itemToIdle;
-						idleSince = 0;
-					} else {
-						idleSince += waitOnce;
-					}
-					return idleSince > waitingTime;
-				});
-		});
+		cy.cGet(selector, content);
 	} else {
-		// We get the initial DOM item first.
-		cy.cGet(selector, { log: false })
-			.then(function(itemToIdle) {
-				item = itemToIdle;
-			});
-
-		cy.waitUntil(function() {
-			cy.wait(waitOnce, { log: false });
-
-			return cy.cGet(selector, { log: false })
-				.then(function(itemToIdle) {
-					if (Cypress.dom.isDetached(item[0])) {
-						cy.log('Item was detached after ' + (idleSince + waitOnce).toString() + ' ms.');
-						item = itemToIdle;
-						idleSince = 0;
-					} else {
-						idleSince += waitOnce;
-					}
-					return idleSince > waitingTime;
-				});
-		});
+		cy.cGet(selector);
 	}
-
-	cy.log('Waiting item to be idle - end.');
 }
 
 // Waits for the DOM element to be idle and clicks on it afterward.
@@ -849,17 +798,17 @@ function waitUntilIdle(selector, content, waitingTime = mobileWizardIdleTime) {
 // selector - a CSS selector to query a DOM element to wait on to be idle.
 // content - a string, a content selector used by cy.contains() to select the correct DOM element.
 // waitingTime - how much time to wait before we say the item is idle.
-function clickOnIdle(selector, content, waitingTime = mobileWizardIdleTime) {
-	cy.log('Clicking on item when idle - start.');
-
-	waitUntilIdle(selector, content, waitingTime);
-
-	if (content)
-		cy.cGet('body').contains(selector, content).click();
-	else
+function clickOnIdle(selector, content) {
+	// waitUntilIdle has been stubbed and clickOnIdle will be removed soon.
+	// Find a specific condition to wait for using waitUntil, or even better use Cypress's
+	// built-in retrying functionality on find, should, and other functions.
+	// Then call .click() directly from the test
+	cy.log('clickOnIdle stubbed');
+	if (content) {
+		cy.cGet(selector, content).click();
+	} else {
 		cy.cGet(selector).click();
-
-	cy.log('Clicking on item when idle - end.');
+	}
 }
 
 // Waits for the DOM element to be idle and types into it afterward.
@@ -868,17 +817,17 @@ function clickOnIdle(selector, content, waitingTime = mobileWizardIdleTime) {
 // selector - a CSS selector to query a DOM element to wait on to be idle.
 // input - text to be typed into the selected DOM element.
 // waitingTime - how much time to wait before we say the item is idle.
-function inputOnIdle(selector, input, waitingTime = mobileWizardIdleTime) {
-	cy.log('Type into an input item when idle - start.');
-
-	waitUntilIdle(selector, undefined, waitingTime);
+function inputOnIdle(selector, input) {
+	// waitUntilIdle has been stubbed and inputOnIdle will be removed soon.
+	// Find a specific condition to wait for using waitUntil, or even better use Cypress's
+	// built-in retrying functionality on find, should, and other functions.
+	// Then call .type() directly from the test
+	cy.log('inputOnIdle stubbed');
 
 	cy.cGet(selector)
 		.clear()
 		.type(input)
 		.type('{enter}');
-
-	cy.log('Type into an input item when idle - end.');
 }
 
 // Run a code snippet if we are in a mobile test.
@@ -1145,12 +1094,13 @@ function typeIntoInputField(selector, text, clearBefore = true)
 {
 	cy.log('Typing into input field - start.');
 
-	if (clearBefore)
-		cy.cGet(selector).focus().clear().type(text + '{enter}');
-	else
-		cy.cGet(selector).type(text + '{enter}');
-
-	cy.cGet(selector).should('have.value', text);
+	cy.cGet(selector).as('input');
+	if (clearBefore) {
+		cy.get('@input').focus();
+		cy.get('@input').clear();
+	}
+	cy.get('@input').type(text + '{enter}');
+	cy.get('@input').should('have.value', text);
 
 	cy.log('Typing into input field - end.');
 }

--- a/cypress_test/integration_tests/common/mobile_helper.js
+++ b/cypress_test/integration_tests/common/mobile_helper.js
@@ -30,9 +30,6 @@ function enableEditingMobile() {
 			.should('be.visible');
 	});
 
-	// wait editable area for receiving paragraph content
-	cy.wait(500);
-
 	cy.log('Enabling editing mode - end.');
 }
 
@@ -57,6 +54,7 @@ function longPressOnDocument(posX, posY) {
 				.trigger('pointerdown', eventOptions)
 				.trigger('pointermove', eventOptions);
 
+			// Wait for long press
 			// This value is set in Map.TouchGesture.js.
 			cy.wait(500);
 
@@ -111,8 +109,6 @@ function openMobileWizard() {
 	cy.cGet('#tb_actionbar_item_mobile_wizard')
 		.should('not.have.class', 'disabled')
 		.click();
-
-	cy.wait(1000);
 
 	// Mobile wizard is opened and it has content
 	cy.cGet('#mobile-wizard-content')
@@ -213,11 +209,9 @@ function closeInsertionWizard() {
 function selectFromColorPalette(paletteNum, groupNum, paletteAfterChangeNum, colorNum) {
 	cy.log('Selecting a color from the color palette - start.');
 	cy.cGet('#color-picker-' + paletteNum.toString() + '-basic-color-' + groupNum.toString()).click();
-	cy.wait(1000);
 	if (paletteAfterChangeNum !== undefined && colorNum !== undefined) {
 		cy.cGet('#color-picker-' + paletteAfterChangeNum.toString() + '-tint-' + colorNum.toString()).click();
 	}
-	cy.wait(1000);
 	cy.cGet('#mobile-wizard-back').click();
 	cy.log('Selecting a color from the color palette - end.');
 }
@@ -228,14 +222,10 @@ function selectFromColorPicker(pickerId, groupNum, colorNum) {
 	cy.cGet(pickerId + ' [id^=color-picker-][id$=-basic-color-' + groupNum.toString() + ']')
 		.click();
 
-	cy.wait(1000);
-
 	if (colorNum !== undefined) {
 		cy.cGet(pickerId + ' [id^=color-picker-][id$=-tint-' + colorNum.toString() + ']')
 			.click();
 	}
-
-	cy.wait(1000);
 
 	cy.cGet('#mobile-wizard-back')
 		.click();
@@ -312,8 +302,6 @@ function selectListBoxItem2(listboxSelector, item) {
 
 	helper.clickOnIdle(parentId + ' .ui-combobox-text', item);
 
-	cy.wait(1000);
-
 	cy.cGet(listboxSelector + ' .ui-header-left')
 		.should('have.text', item);
 
@@ -353,7 +341,7 @@ function deleteImage() {
 
 	cy.cGet('.leaflet-control-buttons-disabled > .leaflet-interactive')
 		.trigger('pointerdown', eventOptions)
-		.wait(1000)
+		.wait(500) // Wait for long press
 		.trigger('pointerup', eventOptions);
 
 	cy.cGet('body').contains('.menu-entry-with-icon', 'Delete')

--- a/cypress_test/integration_tests/common/writer_helper.js
+++ b/cypress_test/integration_tests/common/writer_helper.js
@@ -13,13 +13,10 @@ function selectAllTextOfDoc() {
 	cy.log('Select all text of Writer document - start.');
 
 	// Remove selection if exist
-	cy.wait(500);
-
 	cy.cGet('.leaflet-marker-pane')
 		.then(function(body) {
 			if (body.find('.leaflet-selection-marker-start').length !== 0) {
 				helper.typeIntoDocument('{downarrow}');
-				cy.wait(1000);
 			}
 		});
 

--- a/cypress_test/integration_tests/desktop/calc/autofilter_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/autofilter_spec.js
@@ -29,17 +29,18 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'AutoFilter', function() {
 	//If we select entire sheet , there is no data about table in copy-paste-container when autofilter
 	//is enabled
 	function assertDataOnFilter(arr1) {
-		cy.wait(500);
-
 		calcHelper.clickOnFirstCell();
 
 		for (let i=0; i < arr1.length; i+=2) {
 			helper.typeIntoDocument('{shift}{rightarrow}');
 
-			helper.waitUntilIdle('#copy-paste-container tbody');
+			// Wait for row to be selected
+			cy.cGet('#copy-paste-container tbody td').should('have.length',2);
+			// Wait anyways because copy-paste-container needs to update
+			// It would be better if we could use an assertion that can be retried
+			cy.wait(200);
 
 			var tableData = [];
-
 			cy.cGet('#copy-paste-container tbody').find('td').each(($el) => {
 				cy.wrap($el)
 					.invoke('text')
@@ -50,30 +51,27 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'AutoFilter', function() {
 				expect(tableData).to.deep.eq([arr1[i], arr1[i+1]]);
 				tableData = [];
 			});
-
 			helper.typeIntoDocument('{downarrow}');
 		}
 		calcHelper.clickOnFirstCell();
 	}
 
 	it('Enable/Disable autofilter', function() {
-		//it gets enable before the test body starts
 		//filter by pass
 		calcHelper.openAutoFilterMenu(true);
-
 		cy.cGet('.autofilter .vertical').should('be.visible');
 		cy.cGet('.autofilter .ui-treeview-checkbox').eq(0).uncheck();
 		cy.cGet('.autofilter .ui-treeview-checkbox').eq(1).uncheck();
 		cy.cGet('.autofilter .ui-button-box-right #ok').click();
+		// Wait for autofilter dialog to close
+		cy.cGet('div.autofilter').should('not.exist');
 
 		assertDataOnFilter(['Cypress Test', 'Status', 'Test 1', 'Pass', 'Test 3', 'Pass']);
 
 		//disable autofilter
-		//all the data should be unfiltered
 		toggleAutofilter();
 
 		calcHelper.selectEntireSheet();
-
 		calcHelper.assertDataClipboardTable(['Cypress Test', 'Status', 'Test 1', 'Pass', 'Test 2', 'Fail', 'Test 3', 'Pass', 'Test 4', '', 'Test 5', 'Fail']);
 	});
 
@@ -82,32 +80,31 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'AutoFilter', function() {
 
 		//sort by descending order
 		cy.cGet('body').contains('.autofilter', 'Sort Descending').click();
+		// Wait for autofilter dialog to close
+		cy.cGet('div.autofilter').should('not.exist');
 
-		helper.waitUntilIdle('#copy-paste-container tbody');
-
+		calcHelper.selectEntireSheet();
 		calcHelper.assertDataClipboardTable(['Cypress Test', 'Status', 'Test 5', 'Fail', 'Test 4', '', 'Test 3', 'Pass', 'Test 2', 'Fail', 'Test 1', 'Pass']);
 
 		//sort by ascending order
 		calcHelper.openAutoFilterMenu();
-
 		cy.cGet('body').contains('.autofilter', 'Sort Ascending').click();
+		// Wait for autofilter dialog to close
+		cy.cGet('div.autofilter').should('not.exist');
 
-		// Without this the copy-paste-container doesn't seem to get updated although the table
-		// has correct values.
 		calcHelper.selectEntireSheet();
-
-		helper.waitUntilIdle('#copy-paste-container tbody');
-
+		// Still have to wait for clipboard to update
+		cy.wait(200);
 		calcHelper.assertDataClipboardTable(['Cypress Test', 'Status', 'Test 1', 'Pass', 'Test 2', 'Fail', 'Test 3', 'Pass', 'Test 4', '', 'Test 5', 'Fail']);
 	});
 
 	it('Filter empty/non-empty cells', function() {
 		//empty
 		calcHelper.openAutoFilterMenu(true);
-
 		cy.cGet('#check_list_box > tbody > ul > li:nth-child(1) > span > input').click();
-
 		cy.cGet('#ok').click();
+		// Wait for autofilter dialog to close
+		cy.cGet('div.autofilter').should('not.exist');
 
 		assertDataOnFilter(['Cypress Test', 'Status', 'Test 1', 'Pass', 'Test 2', 'Fail', 'Test 3', 'Pass', 'Test 5', 'Fail']);
 	});

--- a/cypress_test/integration_tests/desktop/impress/apply_paragraph_props_text_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/apply_paragraph_props_text_spec.js
@@ -99,8 +99,11 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Apply paragraph properties
 			.should('have.attr', 'y', '6600');
 
 		impressHelper.selectTextOfShape();
+		// Need to wait for click to work, not sure why
+		cy.wait(500);
 		cy.cGet('#tb_editbar_item_linespacing').click();
 		cy.cGet('body').contains('td','Increase Paragraph Spacing').click();
+
 		impressHelper.triggerNewSVGForShapeInTheCenter();
 
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph:nth-of-type(2) tspan')

--- a/cypress_test/integration_tests/desktop/impress/table_operation_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/table_operation_spec.js
@@ -37,14 +37,15 @@ describe(['tagdesktop'], 'Table operations', function() {
 		helper.typeIntoDocument('{ctrl}{a}');
 
 		impressHelper.selectTableInTheCenter();
-
 		cy.cGet('.leaflet-marker-icon.table-row-resize-marker')
 			.should('have.length', 3);
-
 		cy.cGet('.leaflet-marker-icon.table-column-resize-marker')
 			.should('have.length', 2);
 
+		// Click doesn't work without wait
+		cy.wait(500);
 		cy.cGet('text.SVGTextShape').click({force: true});
+
 	}
 
 	it('Insert Row Before', function() {

--- a/cypress_test/integration_tests/desktop/writer/editable_area_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/editable_area_spec.js
@@ -230,6 +230,9 @@ describe(['taga11yenabled'], 'Editable area - Basic typing and caret moving', fu
 		// typing paragraph 4
 		ceHelper.type('{enter}');
 		ceHelper.type('green red');
+		// Need to wait here after typing paragraph in
+		// order for caret position to stick later
+		cy.wait(200);
 		ceHelper.checkPlainContent('green red');
 		ceHelper.moveCaret('left', '', 4);
 		ceHelper.checkCaretPosition(5);
@@ -249,6 +252,8 @@ describe(['taga11yenabled'], 'Editable area - Basic typing and caret moving', fu
 		helper.clickAt('P1');
 		ceHelper.checkPlainContent('');
 		ceHelper.checkCaretPosition(0);
+		// Need to wait between clicks
+		cy.wait(200);
 		// click on paragraph 4
 		helper.clickAt('P2');
 		ceHelper.checkPlainContent('green red');

--- a/cypress_test/integration_tests/desktop/writer/invalidations_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/invalidations_spec.js
@@ -62,6 +62,9 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Invalidation tests.', func
 		cy.cGet('.empty-deltas').then(($before) => {
 			const beforeCount = $before.text();
 
+			// Selects the wrong paragraph without this wait, not sure why
+			cy.wait(200);
+
 			// click in header area
 			cy.cGet('.leaflet-layer').click(200, 50);
 

--- a/cypress_test/integration_tests/desktop/writer/table_operation_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/table_operation_spec.js
@@ -129,7 +129,6 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Table operations', functio
 	});
 
 	it('Merge cells.', function() {
-
 		// Select 2x2 part of the table.
 		helper.moveCursor('down', 'shift');
 		helper.moveCursor('right', 'shift');
@@ -141,7 +140,8 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Table operations', functio
 		// With merging two rows, the cursor is moved into the first row.
 		cy.get('@origCursorPos')
 			.then(function(origCursorPos) {
-				helper.clickOnIdle('#split_merge .unoMergeCells');
+				helper.clickOnIdle('#split_merge .unoMergeCells button');
+
 				cy.cGet('.blinking-cursor')
 					.should(function(cursor) {
 						expect(cursor.offset().top).to.be.lessThan(origCursorPos);
@@ -196,7 +196,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Table operations', functio
 		helper.moveCursor('down', 'shift');
 		helper.moveCursor('down', 'shift');
 		helper.moveCursor('right', 'shift');
-		helper.clickOnIdle('#rowsizing .unoSetOptimalRowHeight');
+		helper.clickOnIdle('#rowsizing .unoSetOptimalRowHeight button');
 		selectFullTable();
 
 		// Check new row height
@@ -218,7 +218,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Table operations', functio
 		helper.moveCursor('down', 'shift');
 		helper.moveCursor('right', 'shift');
 
-		helper.clickOnIdle('#rowsizing .unoDistributeRows');
+		helper.clickOnIdle('#rowsizing .unoDistributeRows button');
 
 		selectFullTable();
 

--- a/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
@@ -271,19 +271,18 @@ describe(['tagdesktop'], 'Top toolbar tests.', function() {
 	});
 
 	it('Apply Undo/Redo.', function() {
+		//Do
 		cy.cGet('.notebookbar > .unoItalic > button').click();
 		writerHelper.selectAllTextOfDoc();
 		cy.cGet('#copy-paste-container p i').should('exist');
 
 		//Undo
-		cy.cGet('#Home-container .unoUndo').click();
-
+		cy.cGet('#Home-container .unoUndo').should('not.have.class','disabled').click();
 		writerHelper.selectAllTextOfDoc();
 		cy.cGet('#copy-paste-container p i').should('not.exist');
 
 		//Redo
 		cy.cGet('#Home-container .unoRedo').click();
-
 		writerHelper.selectAllTextOfDoc();
 		cy.cGet('#copy-paste-container p i').should('exist');
 	});

--- a/cypress_test/integration_tests/mobile/calc/autofilter_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/autofilter_spec.js
@@ -25,22 +25,20 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'AutoFilter', function() {
 
 		//sort by descending order
 		cy.cGet('body').contains('.mobile-wizard', 'Sort Descending').click();
+		// Wait for autofilter dialog to close
+		cy.cGet('.mobile-wizard').should('not.exist');
 
-		helper.waitUntilIdle('#copy-paste-container tbody');
-
+		calcHelper.selectEntireSheet();
 		calcHelper.assertDataClipboardTable(['Cypress Test', 'Status', 'Test 5', 'Fail', 'Test 4', '', 'Test 3', 'Pass', 'Test 2', 'Fail', 'Test 1', 'Pass']);
 
 		//sort by ascending order
 		calcHelper.openAutoFilterMenu();
 
 		cy.cGet('body').contains('.mobile-wizard', 'Sort Ascending').click();
+		// Wait for autofilter dialog to close
+		cy.cGet('.mobile-wizard').should('not.exist');
 
-		// Without this the copy-paste-container doesn't seem to get updated although the table
-		// has correct values.
 		calcHelper.selectEntireSheet();
-
-		helper.waitUntilIdle('#copy-paste-container tbody');
-
 		calcHelper.assertDataClipboardTable(['Cypress Test', 'Status', 'Test 1', 'Pass', 'Test 2', 'Fail', 'Test 3', 'Pass', 'Test 4', '', 'Test 5', 'Fail']);
 	});
 });

--- a/cypress_test/integration_tests/mobile/calc/cell_appearance_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/cell_appearance_spec.js
@@ -233,7 +233,9 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Change cell appearance.', f
 		helper.clickOnIdle('#border-2');
 
 		// Then apply border color
-		helper.clickOnIdle('#FrameLineColor > .ui-header');
+		cy.cGet('#FrameLineColor > .ui-header')
+			.should('not.have.class','disabled')
+			.click();
 
 		mobileHelper.selectFromColorPicker('#FrameLineColor', 3);
 

--- a/cypress_test/integration_tests/mobile/impress/slide_properties_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/slide_properties_spec.js
@@ -158,17 +158,19 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Changing slide properties.'
 	});
 
 	it('Remove slide fill.', function() {
+		// Wait for mobile wizard menu
+		cy.wait(500);
+
 		// Apply color fill first
 		cy.cGet('#fillstyle').click();
 		cy.cGet('#fillstyle').contains('Color').click();
+		cy.cGet('#fillstyle .ui-header-left').should('have.text', 'Color');
 
 		previewShouldBeFullWhite(false);
 
-		// Reopen mobile wizard
-		mobileHelper.closeMobileWizard();
-		mobileHelper.openMobileWizard();
-
-		cy.cGet('#fillstyle .ui-header-left').should('have.text', 'Color');
+		// Need to wait between background changes
+		// https://github.com/CollaboraOnline/online/issues/8096
+		cy.wait(2000);
 
 		// Remove fill
 		cy.cGet('#fillstyle').click();
@@ -184,6 +186,9 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Changing slide properties.'
 	});
 
 	it('Change master background.', function() {
+		// Wait for mobile wizard menu
+		cy.wait(500);
+
 		// The default master slide does not have background
 		// So switch to a different master slide first
 		cy.cGet('#masterslide').click();
@@ -191,22 +196,21 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Changing slide properties.'
 
 		previewShouldBeFullWhite(false);
 
-		// Reopen mobile wizard and change the setting
-		mobileHelper.closeMobileWizard();
-		mobileHelper.openMobileWizard();
+		// Need to wait between background changes
+		// https://github.com/CollaboraOnline/online/issues/8096
+		cy.wait(2000);
 
-		// Randomly fails
-		//cy.get('input#displaymasterbackground')
-		//	.should('have.prop', 'checked', true);
-
-		helper.clickOnIdle('input#displaymasterbackground');
-
+		cy.cGet('input#displaymasterbackground').should('have.prop', 'checked', true);
+		cy.cGet('input#displaymasterbackground').click();
 		cy.cGet('input#displaymasterbackground').should('not.have.prop', 'checked', true);
 
 		previewShouldBeFullWhite();
 	});
 
 	it('Change master objects visibility.', function() {
+		// Wait for mobile wizard menu
+		cy.wait(500);
+
 		previewShouldBeFullWhite();
 
 		// Master objects are disabled, enable the settings first
@@ -221,7 +225,10 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Changing slide properties.'
 
 		// Reopen mobile wizard and change the settings again
 		mobileHelper.closeMobileWizard();
+		cy.wait(100);
 		mobileHelper.openMobileWizard();
+		// Wait for mobile wizard menu
+		cy.wait(500);
 
 		// Randomly fails
 		//cy.get('input#displaymasterobjects')
@@ -292,6 +299,9 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Changing slide properties.'
 	});
 
 	it('Apply master slide layout.', function() {
+		// Wait for mobile wizard menu
+		cy.wait(500);
+
 		// We have white background by deafult checked by before() method
 		// Select a new master slide with a background color
 		cy.cGet('#masterslide .ui-header-left').should('have.text', 'Default');

--- a/cypress_test/integration_tests/mobile/writer/focus_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/focus_spec.js
@@ -43,6 +43,8 @@ describe(['tagmobile', 'tagproxy'], 'Focus tests', function() {
 		// Open paragraph properties
 		helper.clickOnIdle('#Paragraph');
 		cy.cGet('#aboveparaspacing .spinfield').should('have.value', '0');
+		// Need to wait before clicking on spinfield
+		cy.wait(500);
 		helper.clickOnIdle('#aboveparaspacing .spinfield');
 		// The spinfield should have the focus now.
 		helper.assertFocus('className', 'spinfield');

--- a/cypress_test/integration_tests/mobile/writer/shape_properties_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/shape_properties_spec.js
@@ -81,7 +81,6 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Change shape properties via
 
 	function triggerNewSVG() {
 		mobileHelper.closeMobileWizard();
-		cy.wait(1000);
 		// Change width
 		openPosSizePanel();
 		cy.cGet('#selectwidth .plus').should('be.visible');
@@ -119,7 +118,6 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Change shape properties via
 	it('Change shape width.', function() {
 		openPosSizePanel();
 		helper.typeIntoInputField('#selectwidth .spinfield', '4.2', true, false);
-		cy.wait(1000);
 		const matcher = new TriangleCoordinatesMatcher(defaultStartPoint, Math.floor(4.2 * unitScale) /* new base */, defaultAltitude);
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane svg g svg g g g path').invoke('attr', 'd').should(matcher.match.bind(matcher));
 	});
@@ -127,7 +125,6 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Change shape properties via
 	it('Change shape height.', function() {
 		openPosSizePanel();
 		helper.typeIntoInputField('#selectheight .spinfield', '5.2', true, false);
-		cy.wait(1000);
 		const matcher = new TriangleCoordinatesMatcher(defaultStartPoint, defaultBase, Math.ceil(5.2 * unitScale) /* new altitude */);
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane svg g svg g g g path').invoke('attr', 'd').should(matcher.match.bind(matcher));
 	});
@@ -139,7 +136,6 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Change shape properties via
 		cy.cGet('#ratio #ratio').should('have.prop', 'checked', true);
 		// Change height
 		helper.inputOnIdle('#selectheight .spinfield', '5.2');
-		cy.wait(1000);
 		const matcher = new TriangleCoordinatesMatcher(defaultStartPoint, Math.floor(5.2 * unitScale), Math.ceil(5.2 * unitScale));
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane svg g svg g g g path').invoke('attr', 'd').should(matcher.match.bind(matcher));
 	});
@@ -147,7 +143,6 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Change shape properties via
 	it('Vertical mirroring', function() {
 		openPosSizePanel();
 		helper.clickOnIdle('.unoFlipVertical');
-		cy.wait(1000);
 		const matcher = new TriangleCoordinatesMatcher(defaultStartPoint, defaultBase, defaultAltitude, false /* horiz mirroring */, true /* vert mirroring */);
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane svg g svg g g g path').invoke('attr', 'd').should(matcher.match.bind(matcher));
 	});
@@ -156,7 +151,6 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Change shape properties via
 		openPosSizePanel();
 		helper.clickOnIdle('.unoFlipHorizontal');
 		triggerNewSVG();
-		cy.wait(1000);
 		const matcher = new TriangleCoordinatesMatcher(defaultStartPoint, defaultBase, defaultAltitude, true /* horiz mirroring */, false /* vert mirroring */);
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane svg g svg g g g path').invoke('attr', 'd').should(matcher.match.bind(matcher));
 	});

--- a/cypress_test/integration_tests/mobile/writer/table_properties_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/table_properties_spec.js
@@ -21,7 +21,10 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Change table properties / l
 	function openTablePanel() {
 		mobileHelper.openMobileWizard();
 
-		helper.clickOnIdle('#TableEditPanel');
+		cy.cGet('#TableEditPanel > .ui-header')
+			.should('not.have.class','disabled')
+			.click();
+
 		cy.cGet('.unoInsertRowsBefore').should('be.visible');
 	}
 
@@ -170,6 +173,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Change table properties / l
 	it('Change row height.', function() {
 		before('table_properties.odt');
 		openTablePanel();
+		cy.wait(500);
 		cy.cGet('#rowheight .spinfield').should('have.value', '0');
 		helper.typeIntoInputField('#rowheight .spinfield', '1.4', true, false);
 		selectFullTable();
@@ -180,6 +184,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Change table properties / l
 	it('Change column width.', function() {
 		before('table_properties.odt');
 		openTablePanel();
+		cy.wait(500);
 		helper.typeIntoInputField('#columnwidth .spinfield', '1.6', true, false);
 		selectFullTable();
 		// Check column width
@@ -224,7 +229,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Change table properties / l
 		openTablePanel();
 		selectFullTable();
 
-		helper.clickOnIdle('.unoDistributeRows');
+		helper.clickOnIdle('.unoDistributeRows button');
 
 		selectFullTable();
 
@@ -280,7 +285,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Change table properties / l
 		openTablePanel();
 		selectFullTable();
 
-		helper.clickOnIdle('.unoDistributeColumns');
+		helper.clickOnIdle('.unoDistributeColumns button');
 
 		selectFullTable();
 

--- a/cypress_test/support/index.js
+++ b/cypress_test/support/index.js
@@ -66,7 +66,9 @@ Cypress.Commands.overwrite('waitUntil', function(originalFn, subject, checkFunct
 	if (!options)
 		options = {};
 	if (!options.interval)
-		options.interval = 10; // ms
+		options.interval = 100; // ms
+	if (!options.verbose)
+		options.verbose = true;
 	return originalFn(subject, checkFunction, options);
 });
 


### PR DESCRIPTION
Change-Id: I6b7bbcfd580a7ddb454218eeba96019b408f53e5

### Summary
- Removed calls to cy.wait()
- Stubbed waitUntilIdle, which was usually acting as wait(1250)
- Added comments to some waits that are necessary (like holding for long press on mobile)
- Fixed failing tests by taking advantage of cypress's retry functionality. For example:
-- Add assertions that items have appeared, disappeared, or are no longer disabled
-- Replace .then() with .should()
-- Click on the underlying button instead of the div (better actionability detection)
-- Force click (skip actionability detection)
-- Use waitUntil to retry unsafe commands like clicking
-- Remove chained unsafe commands

### Not done
- I did not actually remove the waitUntilIdle or clickOnIdle functions because that would require touching many files.
- I focused on removing waits in helper files because they have the greatest impact. Waits in spec files are likely only called once and are more likely to be necessary.
- There are likely some flaky tests that I wasn't able to detect and fix.
- There are were some failing or flaky tests from before these changes that I did not attempt to fix.
- I did not run Nextcloud, proxy, or interference tests.

### Results
Time to run all desktop, mobile, and multiuser tests reduced from 85:11 to 47:01 (45% faster)

### Checklist

- [X] Code is properly formatted
- [X] All commits have Change-Id
- [X] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

