### PR TITLE
draw: constrain object move with Shift

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -283,6 +283,7 @@ COOL_JS_LST =\
 	src/layer/vector/Path.Transform.SVG.VML.js \
 	src/layer/vector/Canvas.js \
 	src/layer/vector/Path.Transform.Canvas.js \
+	src/layer/vector/Path.Constraint.ts \
 	src/layer/FormFieldButtonLayer.js \
 	src/dom/DomEvent.js \
 	src/dom/Draggable.js \

--- a/browser/src/geometry/Point.ts
+++ b/browser/src/geometry/Point.ts
@@ -120,6 +120,24 @@ export class Point {
 		return Math.sqrt(x * x + y * y);
 	}
 
+	/**
+	* Return the angle of the vector / point in rad.
+	*/
+	public angleOf(): number {
+		var angle;
+		if (this.x != 0) {
+			angle = Math.atan(this.y / Math.abs(this.x));
+		} else if (this.y > 0) {
+			angle = Math.PI / 2;
+		} else {
+			angle = - Math.PI / 2;
+		}
+		if (this.x < 0) {
+			angle = Math.PI - angle;
+		}
+		return angle;
+	}
+
 	public equals(point: Point): boolean {
 		point = Point.toPoint(point);
 

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -4233,6 +4233,9 @@ L.CanvasTileLayer = L.Layer.extend({
 				}
 			}
 			else {
+				if (e.target.dragging.shiftConstraint) {
+					deltaPos = L.Constraint.shiftConstraint(deltaPos);
+				}
 				var newPos = new L.Point(
 					// Choose the logical left of the shape.
 					this._graphicSelectionTwips.min.x + deltaPos.x,

--- a/browser/src/layer/vector/Path.Constraint.ts
+++ b/browser/src/layer/vector/Path.Constraint.ts
@@ -1,0 +1,44 @@
+declare var L: any;
+
+namespace cool {
+
+export class Constraint {
+	/**
+	* Near means within +/- PI / 8 since we do diagonals
+	*/
+	public static angleNear (angle: number, near: number): boolean {
+		return Math.abs(near - angle) < (Math.PI / 8);
+	}
+
+	/**
+	* Will recalculate delta based on a shift constraint
+	*/
+	public static shiftConstraint (delta: Point): Point {
+		var angle = delta.angleOf();
+
+		if (Constraint.angleNear(angle, 0) || Constraint.angleNear(angle, Math.PI)) {
+			// Snap back the y to 0
+			return new Point(delta.x, 0);
+		} else if (Constraint.angleNear(angle, Math.PI / 2) ||
+			Constraint.angleNear(angle, -Math.PI / 2)) {
+
+			// Snap back the x to 0
+			return new Point(0, delta.y);
+		} else {
+			var deltaD = (Math.abs(delta.x) + Math.abs(delta.y)) / 2;
+			if (Constraint.angleNear(angle, Math.PI / 4)) {
+				return new Point(deltaD, deltaD);
+			} else if (Constraint.angleNear(angle, -Math.PI / 4)) {
+				return new Point(deltaD, -deltaD);
+			} else if (Constraint.angleNear(angle, Math.PI * 0.75)) {
+				return new Point(-deltaD, deltaD);
+			} else {
+				return new Point(-deltaD, -deltaD);
+			}
+		}
+	}
+}
+
+}
+
+L.Constraint = cool.Constraint;


### PR DESCRIPTION
Issue https://github.com/CollaboraOnline/online/issues/7933


Change-Id: Ie39c15a8552276bc5919ffbbd5dd859695048b9c


* Resolves: #7933 
* Target version: master 

### Summary

Press shift when dragging (screencast out of date)

[Screencast from 2024-01-05 17-49-59.webm](https://github.com/CollaboraOnline/online/assets/114441/6ea2f0da-0dda-4e8f-a491-f4843658778b)


### TODO

- [x] cleanup log
- [x] implement 45 deg constrain like on desktop
- [x] split out the geometry functions
- [x] add a threshold on the directional change (see screencast)
- [x] fix the issue where the move seems to not complete (see screencast)
- [ ] test other apps: writer and calc
- [ ] fix #7821 (separate issue)

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

