### PR TITLE
Calc grouping: find parent groups correctly

### DIFF
--- a/browser/src/control/Control.ColumnGroup.ts
+++ b/browser/src/control/Control.ColumnGroup.ts
@@ -194,7 +194,9 @@ export class ColumnGroup extends GroupBase {
 						const startY = this._levelSpacing + (this._groupHeadSize + this._levelSpacing) * group_.level;
 						const endX = startX + this._groupHeadSize;
 						const endY = startY + this._groupHeadSize;
-						if (this._isPreviousGroupVisible(group_.index, group_.level) && this.isPointInRect(point, startX, startY, endX, endY, mirrorX)) {
+						if (group_.level == 0 && this.isPointInRect(point, startX, startY, endX, endY, mirrorX))
+							return group_;
+						else if (this._isPreviousGroupVisible(group_.level, group_.startPos, group_.endPos, group_.hidden) && this.isPointInRect(point, startX, startY, endX, endY, mirrorX)) {
 							return group_;
 						}
 					}

--- a/browser/src/control/Control.GroupBase.ts
+++ b/browser/src/control/Control.GroupBase.ts
@@ -127,8 +127,8 @@ export abstract class GroupBase extends CanvasSectionObject {
 				if (!moved && lastGroupIndex[level] !== undefined) {
 					const prevGroupEntry = this._groups[level][lastGroupIndex[level]];
 					if (prevGroupEntry.hidden) {
-						if (startPos > prevGroupEntry.startPos && startPos < prevGroupEntry.endPos) {
-							startPos = prevGroupEntry.endPos;
+						if (startPos <= prevGroupEntry.endPos) {
+							startPos = prevGroupEntry.endPos + this._groupHeadSize;
 						}
 					}
 				}

--- a/browser/src/control/Control.RowGroup.ts
+++ b/browser/src/control/Control.RowGroup.ts
@@ -194,7 +194,9 @@ export class RowGroup extends GroupBase {
 						const startY = this.getRelativeY(group_.startPos);
 						const endX = startX + this._groupHeadSize;
 						const endY = startY + this._groupHeadSize;
-						if (this._isPreviousGroupVisible(group_.index, group_.level) && this.isPointInRect(point, startX, startY, endX, endY, mirrorX)) {
+						if (group_.level == 0 && this.isPointInRect(point, startX, startY, endX, endY, mirrorX))
+							return group_;
+						else if (this._isPreviousGroupVisible(group_.level, group_.startPos, group_.endPos, group_.hidden) && this.isPointInRect(point, startX, startY, endX, endY, mirrorX)) {
 							return group_;
 						}
 					}


### PR DESCRIPTION
- groups was using indexes to find their parent groups.
  - this does not work properly and causes following issues: 
    - some groups are created but not drawn (so they are invisible)
    - some parent groups does not hide their child groups

- this patch:
  - removes the index-based search of parent groups.
  - implements startPos and endPos based search.


Change-Id: Ia3b85f3d9a032008f8abbc7b38ad2417aa0ec6c8


* Resolves: #7811
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

