### PR TITLE
wsd, DocumentBroker: check for missing child process

### DIFF
--- a/fuzzer/data/crash-10e0695bfc04df35d8390f1b2f03eb72f45a2957
+++ b/fuzzer/data/crash-10e0695bfc04df35d8390f1b2f03eb72f45a2957
@@ -1,0 +1,2 @@
+load url=)
+removesession 2

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -2868,7 +2868,8 @@ void DocumentBroker::disconnectSessionInternal(const std::shared_ptr<ClientSessi
                 LOG_INF("Session [" << session->getName() << "] disconnected but DocKey ["
                                     << _docKey
                                     << "] isn't loaded yet. Terminating the child roughly");
-                _childProcess->terminate();
+                if (_childProcess)
+                    _childProcess->terminate();
             }
 #endif
         }


### PR DESCRIPTION
wsd/DocumentBroker.cpp:2861:32: runtime error: member call on null pointer of type 'WSProcess'
    #0 0x55cbce63d7d9 in DocumentBroker::disconnectSessionInternal(std::shared_ptr<ClientSession> const&) /home/vmiklos/git/collaboraonline/online-fuzz/wsd/DocumentBroker.cpp:2861:32
    #1 0x55cbce66c74d in DocumentBroker::removeSession(std::shared_ptr<ClientSession> const&) /home/vmiklos/git/collaboraonline/online-fuzz/wsd/DocumentBroker.cpp:2764:13
    #2 0x55cbce944614 in ClientSession::_handleInput(char const*, int) /home/vmiklos/git/collaboraonline/online-fuzz/wsd/ClientSession.cpp:886:24
    #3 0x55cbced66255 in Session::handleMessage(std::vector<char, std::allocator<char>> const&) /home/vmiklos/git/collaboraonline/online-fuzz/common/Session.cpp:271:13

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I2a6f830de82ec8189312e57e6554a57909a0aaaa
