### PR TITLE
Calc: swap Ctrl+Alt+PageUp / PageDown behavior

### DIFF
--- a/browser/src/map/handler/Map.Keyboard.js
+++ b/browser/src/map/handler/Map.Keyboard.js
@@ -903,7 +903,7 @@ L.Map.Keyboard = L.Handler.extend({
 						var partToSelect = 0;
 						this._map._docLayer._clearReferences();
 
-						if (e.keyCode === this.keyCodes.pageUp) {
+						if (e.keyCode === this.keyCodes.pageDown) {
 							partToSelect = currentSelectedPart != parts - 1 ? currentSelectedPart + 1 : 0;
 						}
 						else {


### PR DESCRIPTION
If there are multiple sheets, you can switch between them with Ctrl+Alt+PageUp/PageDown.

this shortcut has been updated as:
- Ctrl+Alt+PageUp -> go to the previous tab
- Ctrl+Alt+PageDown -> go to the next tab


Change-Id: Ic88adbe6cdd629b002810770bc19dc7af35d4499


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

