### PR TITLE
Add color palette selector to Calc and Impress 2

### DIFF
--- a/browser/js/w2ui-1.5.rc1.js
+++ b/browser/js/w2ui-1.5.rc1.js
@@ -2778,6 +2778,10 @@ w2utils.event = {
 
     var toW2Palette = function (corePalette) {
         var pal = [];
+
+        if (!corePalette)
+            return pal;
+
         for (var i = 0; i < corePalette.length; i++) {
             var row = [];
             for (var j = 0; j < corePalette[i].length; j++) {
@@ -2826,6 +2830,12 @@ w2utils.event = {
     $.fn.w2color = function (options, callBack) {
         var el    = $(this)[0];
         var index = [-1, -1];
+
+        function getCurrentPaletteName() {
+            return (localStorage && localStorage.colorPalette
+                && window.app.colorPalettes[localStorage.colorPalette])
+                ? localStorage.colorPalette : 'StandardColors';
+        };
 
         function bindEvents(pal) {
             $('#w2ui-overlay .color')
@@ -2892,8 +2902,7 @@ w2utils.event = {
                 .w2field('hex');
         }
 
-        var currentPalette = (localStorage && localStorage.colorPalette) ? localStorage.colorPalette : 'StandardColors';
-
+        var currentPalette = getCurrentPaletteName();
         var pal = generatePalette(currentPalette, options);
 
         if (options.color) options.color = String(options.color).toUpperCase();
@@ -2955,8 +2964,7 @@ w2utils.event = {
 
         function getColorHTML(pal, options) {
             var html = '';
-
-            var currentPalette = localStorage && localStorage.colorPalette ? localStorage.colorPalette : 'StandardColors';
+            var currentPalette = getCurrentPaletteName();
 
             html += '<select class="color-palette-selector">';
             for (var i in window.app.colorPalettes)

--- a/browser/js/w2ui-1.5.rc1.js
+++ b/browser/js/w2ui-1.5.rc1.js
@@ -2915,22 +2915,18 @@ w2utils.event = {
 
         bindEvents(pal);
 
-        var hasPaletteSelector = window.app.map._docLayer._docType === 'text';
-
-        if (hasPaletteSelector) {
-            var updatePalette = function () {
-                var palette = $('#w2ui-overlay .color-palette-selector option:selected').get(0).value;
-                localStorage.setItem('colorPalette', palette);
-                var pal = generatePalette(palette, options);
-                $('#w2ui-overlay .w2ui-color').parent().html(getColorHTML(pal, options));
-                bindEvents(pal);
-                $('#w2ui-overlay .color-palette-selector')
-                    .on('change', updatePalette);
-            };
-
+        var updatePalette = function () {
+            var palette = $('#w2ui-overlay .color-palette-selector option:selected').get(0).value;
+            localStorage.setItem('colorPalette', palette);
+            var pal = generatePalette(palette, options);
+            $('#w2ui-overlay .w2ui-color').parent().html(getColorHTML(pal, options));
+            bindEvents(pal);
             $('#w2ui-overlay .color-palette-selector')
                 .on('change', updatePalette);
-        }
+        };
+
+        $('#w2ui-overlay .color-palette-selector')
+            .on('change', updatePalette);
 
         el.nav = function (direction) {
             switch (direction) {
@@ -2960,15 +2956,12 @@ w2utils.event = {
         function getColorHTML(pal, options) {
             var html = '';
 
-            var hasPaletteSelector = window.app.map._docLayer._docType === 'text';
             var currentPalette = localStorage && localStorage.colorPalette ? localStorage.colorPalette : 'StandardColors';
 
-            if (hasPaletteSelector) {
-                html += '<select class="color-palette-selector">';
-                for (var i in window.app.colorPalettes)
-                    html += '<option value="' + i + '" ' + (i === currentPalette ? 'selected="selected"' : '') + '>' + window.app.colorPalettes[i].name + '</option>';
-                html += '</select>';
-            }
+            html += '<select class="color-palette-selector">';
+            for (var i in window.app.colorPalettes)
+                html += '<option value="' + i + '" ' + (i === currentPalette ? 'selected="selected"' : '') + '>' + window.app.colorPalettes[i].name + '</option>';
+            html += '</select>';
 
             var detailedPalette = window.app.colorPalettes[currentPalette].colors
 

--- a/browser/src/docstate.js
+++ b/browser/src/docstate.js
@@ -91,6 +91,7 @@ window.app = { // Shouldn't have any functions defined.
 			// ['660205', '783F0B', '7F6011', '274E12', '0C343D', '063762', '20124D', '4C1030'],
 		] },
 		'ThemeColors': { name: _('Theme colors'), colors: [] },
+		'DocumentColors': { name: _('Document colors'), colors: [] },
 	},
 };
 

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1867,7 +1867,21 @@ L.CanvasTileLayer = L.Layer.extend({
 		}
 		else if (textMsg.startsWith('colorpalettes:')) {
 			var json = JSON.parse(textMsg.substring('colorpalettes:'.length + 1));
-			app.colorPalettes['ThemeColors'].colors = json.ThemeColors;
+
+			for (var key in json) {
+				if (app.colorPalettes[key]) {
+					app.colorPalettes[key].colors = json[key];
+				} else {
+					window.app.console.warn('Unknown palette: "' + key + '"');
+				}
+			}
+
+			// Remove empty palettes, eg. Document colors in Impress are empty
+			for (var key in app.colorPalettes) {
+				if (!app.colorPalettes[key].colors || !app.colorPalettes[key].colors.length) {
+					delete app.colorPalettes[key];
+				}
+			}
 		}
 		else if (textMsg.startsWith('readonlyhyperlinkclicked: ')) {
 			var json = JSON.parse(textMsg.replace('readonlyhyperlinkclicked: ', ''));


### PR DESCRIPTION
It will be possible to use "theme colors" then.
It requires core part: https://gerrit.libreoffice.org/c/core/+/161771

sc: announce theme colors with lok callback

