### PR TITLE
Fix failing test desktop/calc/focus_spec.js

### DIFF
--- a/cypress_test/integration_tests/desktop/calc/focus_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/focus_spec.js
@@ -16,39 +16,38 @@ describe(['tagdesktop'], 'Calc focus tests', function() {
 	});
 
 	it('Formula-bar focus', function() {
-
-		// Select the first cell to edit the same one.
-		// Use the tile's edge to find the first cell's position
+		// Select first cell
 		calcHelper.clickOnFirstCell();
-
-		// Click in the formula-bar.
-		calcHelper.clickFormulaBar();
-		//helper.assertCursorAndFocus();
+		cy.wait(200);
 
 		// Type some text.
 		var text1 = 'Hello from Calc';
 		calcHelper.typeIntoFormulabar(text1);
 		calcHelper.typeIntoFormulabar('{enter}');
 
-		// Select the first cell to edit the same one.
+		// Unselect formulabar and reselect cell
 		calcHelper.clickOnFirstCell();
-		calcHelper.clickFormulaBar();
-		// Validate.
+		cy.wait(200);
+
+		// Check text in formulabar
 		calcHelper.typeIntoFormulabar('{ctrl}a');
 		helper.expectTextForClipboard(text1);
-		// End editing.
+		// Clear selection
 		calcHelper.typeIntoFormulabar('{enter}');
 
+
 		// Type some more text, at the end.
-		cy.log('Appending text at the end.');
 		calcHelper.clickOnFirstCell();
-		calcHelper.clickFormulaBar();
-		//var text2 = ', this is a test.';
-		//helper.typeText('textarea.clipboard', text2);
-		// Validate.
-		//calcHelper.typeIntoFormulabar('{ctrl}a');
-		//helper.expectTextForClipboard(text1 + text2);
-		// End editing.
-		//calcHelper.typeIntoFormulabar('{enter}');
+		cy.wait(200);
+		var text2 = ', this is a test.';
+		calcHelper.typeIntoFormulabar('{end}'+text2);
+		calcHelper.typeIntoFormulabar('{enter}');
+
+		// Check text in formulabar
+		calcHelper.clickOnFirstCell();
+		cy.wait(200);
+		calcHelper.typeIntoFormulabar('{ctrl}a');
+		helper.expectTextForClipboard(text1+text2);
+		calcHelper.typeIntoFormulabar('{enter}');
 	});
 });


### PR DESCRIPTION
Change-Id: Ibcd6a2b3d27cbd56d8a24de5f12316bacbd2061f

* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
The test is about typing into the formula bar. The issue was that clickOnFirstCell hasn't finished, so clicking on the formula bar didn't work. Specifically, the accept and cancel buttons weren't visible.

I added a short wait after calling clickOnFirstCell, and cleaned up the code a bit. Also uncommented the second half of the test.

### Checklist

- [X] Code is properly formatted
- [X] All commits have Change-Id
- [X] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

