### PR TITLE
Fix failing test multiuser/writer/annotation_spec.js

### DIFF
--- a/cypress_test/integration_tests/common/desktop_helper.js
+++ b/cypress_test/integration_tests/common/desktop_helper.js
@@ -278,6 +278,8 @@ function saveComment(isMobile) {
 		cy.cGet('#response-ok').click();
 	} else {
 		cy.cGet('#annotation-save-new').click();
+		// Wait for animation
+		cy.wait(500);
 	}
 }
 

--- a/cypress_test/integration_tests/multiuser/writer/annotation_spec.js
+++ b/cypress_test/integration_tests/multiuser/writer/annotation_spec.js
@@ -34,7 +34,6 @@ describe(['tagmultiuser'], 'Multiuser Annotation Test', function () {
 		cy.cSetActiveFrame('#iframe2');
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
 		cy.cGet('#annotation-content-area-1').should('contain','some text0');
-
 	});
 
 	it('Modify', function() {


### PR DESCRIPTION
Change-Id: Id1be5607e15ac23596e527c3e27fca83c91ee380


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
Many testpoints in this file were sporadically failing. Tests add a comment and then immediately modify it. I'm not sure how exactly, but starting to edit the annotation as it was animating from the top left to the right caused text to be inserted in the wrong spot.

I added a wait directly after saving the new annotations. I ran the tests several times with no failures. Tests failed about half the time before adding the wait.

### Checklist

- [X] Code is properly formatted
- [X] All commits have Change-Id
- [X] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

