### PR TITLE
admin: improve error handling on bad json for updateroutetoken

### DIFF
--- a/common/JsonUtil.hpp
+++ b/common/JsonUtil.hpp
@@ -34,9 +34,16 @@ inline bool parseJSON(const std::string& json, Poco::JSON::Object::Ptr& object)
     {
         const std::string stringJSON = json.substr(index);
         Poco::JSON::Parser parser;
-        const Poco::Dynamic::Var result = parser.parse(stringJSON);
-        object = result.extract<Poco::JSON::Object::Ptr>();
-        return true;
+        try
+        {
+            const Poco::Dynamic::Var result = parser.parse(stringJSON);
+            object = result.extract<Poco::JSON::Object::Ptr>();
+            return true;
+        }
+        catch (const Poco::JSON::JSONException& exception)
+        {
+            LOG_WRN("parseJSON: failed to parse '" << stringJSON << "': '" << exception.what() << "'");
+        }
     }
 
     return false;

--- a/fuzzer/admin-data/crash-f0458999f81408ca2bc48148d30c0a000b07ea2d
+++ b/fuzzer/admin-data/crash-f0458999f81408ca2bc48148d30c0a000b07ea2d
@@ -1,0 +1,1 @@
+   updateroutetoken  {


### PR DESCRIPTION
terminate called after throwing an instance of 'Poco::JSON::JSONException'
...
    #11 0x7f70540e006a in Poco::JSON::ParserImpl::parseImpl(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) (/usr/lib64/libPocoJSON.so.92+0x4206a) (BuildId: 149b3c1772e35fcbe5692d435f1b06820707bad3)
    #12 0x556a70a9511b in Poco::JSON::Parser::parse(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) /usr/include/Poco/JSON/Parser.h:202:9
    #13 0x556a70a9511b in JsonUtil::parseJSON(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, Poco::SharedPtr<Poco::JSON::Object, Poco::ReferenceCounter, Poco::ReleasePolicy<Poco::JSON::Object>>&) /home/vmiklos/git/collaboraonline/online-fuzz/./common/JsonUtil.hpp:37:50
    #14 0x556a70a7edde in AdminSocketHandler::handleMessage(std::vector<char, std::allocator<char>> const&) /home/vmiklos/git/collaboraonline/online-fuzz/wsd/Admin.cpp:325:13

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Iebe0f5d689032a8b3c1e5d38c5ee80d344d1cbed
