### PR TITLE
Fix uncaught TypeError in Comment.isAnyEdit

### DIFF
--- a/browser/src/layer/tile/CommentSection.ts
+++ b/browser/src/layer/tile/CommentSection.ts
@@ -988,7 +988,11 @@ export class Comment extends CanvasSectionObject {
 	}
 
 	public static isAnyEdit (): boolean {
-		var commentList = app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).sectionProperties.commentList;
+		var section = app.sectionContainer.getSectionWithName(L.CSections.CommentList.name);
+		if (!section)
+			return false;
+
+		var commentList = section.sectionProperties.commentList;
 		for (var i in commentList) {
 			var modifyNode = commentList[i].sectionProperties.nodeModify;
 			var replyNode = commentList[i].sectionProperties.nodeReply;


### PR DESCRIPTION
Steps to reproduce:
1. open empty spreadsheet
2. see error in the browser console:

Uncaught TypeError: Cannot read properties of undefined (reading 'getSectionWithName')
    at Comment.isAnyEdit (CommentSection.ts:991:42)
    at IdleHandler._activate (Control.IdleHandler.ts:57:89)
    at NewClass._onSocketOpen (Socket.js:256:19)