### PR TITLE
notebookbar: enable currency dropdown

### DIFF
--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -351,10 +351,11 @@ button.ui-tab.notebookbar {
 /* unobuttons with inline labels */
 
 .inline.notebookbar {
-	float: inline-start;
 	width: max-content;
 	white-space: nowrap;
-	display: inline-table;
+	display: grid;
+	grid-auto-flow: column;
+	align-items: center;
 }
 
 #FormatPaintbrush span

--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -200,18 +200,18 @@ button.ui-tab.notebookbar {
 	z-index: 11;
 }
 
-.cell.notebookbar {
-	display: table-cell;
-	vertical-align: middle;
-	padding: 2px;
-}
-
-.row.notebookbar {
-	display: table-row;
-}
-
 .vertical.notebookbar {
 	width: max-content;
+	display: grid;
+	grid-auto-flow: row;
+	grid-gap: 4px;
+}
+
+.horizontal.notebookbar {
+	display: grid;
+	grid-auto-flow: column;
+	grid-gap: 4px;
+	align-items: center;
 }
 
 /* unobuttons */

--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -322,7 +322,7 @@ button.ui-tab.notebookbar {
 	align-items: center;
 }
 
-#zoomreset, .unotoolbutton.notebookbar.has-label > *{ /*so they stay side by side*/
+.unotoolbutton.notebookbar.has-label > *{ /*so they stay side by side*/
 	display: table-cell;
 	width: 100%;
 	height: 100%;

--- a/browser/src/control/Control.NotebookbarBuilder.js
+++ b/browser/src/control/Control.NotebookbarBuilder.js
@@ -1132,13 +1132,11 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 		this._updateWidgetImpl(container, data, this.buildControl);
 	},
 
-	build: function(parent, data, hasVerticalParent, parentHasManyChildren) {
+	build: function(parent, data, hasVerticalParent) {
 		if (hasVerticalParent === undefined) {
 			parent = L.DomUtil.create('div', 'root-container ' + this.options.cssClass, parent);
 			parent = L.DomUtil.create('div', 'vertical ' + this.options.cssClass, parent);
 		}
-
-		var containerToInsert = parent;
 
 		for (var childIndex in data) {
 			var childData = data[childIndex];
@@ -1146,18 +1144,6 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 				continue;
 
 			var childType = childData.type;
-
-			if (parentHasManyChildren) {
-				if (!hasVerticalParent)
-					var td = L.DomUtil.create('div', 'cell ' + this.options.cssClass, containerToInsert);
-				else {
-					containerToInsert = L.DomUtil.create('div', 'row ' + this.options.cssClass, parent);
-					td = L.DomUtil.create('div', 'cell ' + this.options.cssClass, containerToInsert);
-				}
-			} else {
-				td = containerToInsert;
-			}
-
 			var isVertical = (childData.vertical === 'true' || childData.vertical === true) ? true : false;
 
 			this._parentize(childData);
@@ -1170,14 +1156,18 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 
 			var hasManyChildren = childData.children && childData.children.length > 1;
 			if (hasManyChildren) {
+				if (childData.id && childData.id.indexOf(' ') >= 0)
+					console.error('notebookbar: space in the id: "' + childData.id + '"');
 				var tableId = childData.id ? childData.id.replace(' ', '') : '';
-				var table = L.DomUtil.createWithId('div', tableId, td);
-				$(table).addClass(this.options.cssClass);
-				$(table).addClass('vertical');
-				var childObject = L.DomUtil.create('div', 'row ' + this.options.cssClass, table);
-				childObject.id = tableId ? tableId + '-row' : '';
+				var table = L.DomUtil.createWithId('div', tableId, parent);
+				L.DomUtil.addClass(table, this.options.cssClass);
+				if (isVertical)
+					L.DomUtil.addClass(table, 'vertical');
+				else
+					L.DomUtil.addClass(table, 'horizontal');
+				var childObject = table;
 			} else {
-				childObject = td;
+				childObject = parent;
 			}
 
 			var handler = this._controlHandlers[childType];

--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -673,12 +673,13 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 						'type': 'container',
 						'children': [
 							{
-								'id': 'second9',
+								'id': 'WeldedToolbar', // has to match core .ui file toolbox id!
 								'type': 'toolbox',
 								'children': [
 									{
 										'id': 'home-number-format-currency',
 										'type': 'toolitem',
+										'dropdown': true,
 										'text': _UNO('.uno:NumberFormatCurrency', 'spreadsheet'),
 										'command': '.uno:NumberFormatCurrency',
 										'accessibility': { focusBack: true,	combination: 'P', de: null }

--- a/cypress_test/integration_tests/desktop/calc/cell_appearance_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/cell_appearance_spec.js
@@ -29,7 +29,7 @@ describe(['tagdesktop'], 'Change cell appearance.', function() {
 	it('Apply left border', function() {
 		desktopHelper.switchUIToNotebookbar();
 		calcHelper.clickOnFirstCell();
-		cy.cGet('.cell.notebookbar .unoSetBorderStyle').click();
+		cy.cGet('.notebookbar .unoSetBorderStyle').click();
 		cy.cGet('.w2ui-tb-image.w2ui-icon.frame02').should($el => { expect(Cypress.dom.isDetached($el)).to.eq(false); }).click();
 		calcHelper.selectEntireSheet();
 		cy.cGet('#copy-paste-container table td').should('have.attr', 'style', 'border-left: 1px solid #000000');
@@ -39,13 +39,13 @@ describe(['tagdesktop'], 'Change cell appearance.', function() {
 		desktopHelper.switchUIToNotebookbar();
 		calcHelper.clickOnFirstCell();
 		// First add left border
-		cy.cGet('.cell.notebookbar .unoSetBorderStyle').click();
+		cy.cGet('.notebookbar .unoSetBorderStyle').click();
 		cy.cGet('.w2ui-tb-image.w2ui-icon.frame02').should($el => { expect(Cypress.dom.isDetached($el)).to.eq(false); }).click();
 		calcHelper.selectEntireSheet();
 		cy.cGet('#copy-paste-container table td').should('have.attr', 'style', 'border-left: 1px solid #000000');
 		// Then remove it
 		calcHelper.clickOnFirstCell();
-		cy.cGet('.cell.notebookbar .unoSetBorderStyle').click();
+		cy.cGet('.notebookbar .unoSetBorderStyle').click();
 		cy.cGet('.w2ui-tb-image.w2ui-icon.frame01').should($el => { expect(Cypress.dom.isDetached($el)).to.eq(false); }).click();
 		calcHelper.selectEntireSheet();
 		cy.cGet('#copy-paste-container table td').should('not.have.attr', 'style');
@@ -54,7 +54,7 @@ describe(['tagdesktop'], 'Change cell appearance.', function() {
 	it('Apply right border', function() {
 		desktopHelper.switchUIToNotebookbar();
 		calcHelper.clickOnFirstCell();
-		cy.cGet('.cell.notebookbar .unoSetBorderStyle').click();
+		cy.cGet('.notebookbar .unoSetBorderStyle').click();
 		cy.cGet('.w2ui-tb-image.w2ui-icon.frame03').should($el => { expect(Cypress.dom.isDetached($el)).to.eq(false); }).click();
 		calcHelper.selectEntireSheet();
 		cy.cGet('#copy-paste-container table td').should('have.attr', 'style', 'border-right: 1px solid #000000');
@@ -63,7 +63,7 @@ describe(['tagdesktop'], 'Change cell appearance.', function() {
 	it('Apply left and right border', function() {
 		desktopHelper.switchUIToNotebookbar();
 		calcHelper.clickOnFirstCell();
-		cy.cGet('.cell.notebookbar .unoSetBorderStyle').click();
+		cy.cGet('.notebookbar .unoSetBorderStyle').click();
 		cy.cGet('.w2ui-tb-image.w2ui-icon.frame04').should($el => { expect(Cypress.dom.isDetached($el)).to.eq(false); }).click();
 		calcHelper.selectEntireSheet();
 		cy.cGet('#copy-paste-container table td').should('have.attr', 'style', 'border-left: 1px solid #000000; border-right: 1px solid #000000');
@@ -72,7 +72,7 @@ describe(['tagdesktop'], 'Change cell appearance.', function() {
 	it('Apply top border', function() {
 		desktopHelper.switchUIToNotebookbar();
 		calcHelper.clickOnFirstCell();
-		cy.cGet('.cell.notebookbar .unoSetBorderStyle').click();
+		cy.cGet('.notebookbar .unoSetBorderStyle').click();
 		cy.cGet('.w2ui-tb-image.w2ui-icon.frame05').should($el => { expect(Cypress.dom.isDetached($el)).to.eq(false); }).click();
 		calcHelper.selectEntireSheet();
 		cy.cGet('#copy-paste-container table td').should('have.attr', 'style', 'border-top: 1px solid #000000');
@@ -81,7 +81,7 @@ describe(['tagdesktop'], 'Change cell appearance.', function() {
 	it('Apply bottom border', function() {
 		desktopHelper.switchUIToNotebookbar();
 		calcHelper.clickOnFirstCell();
-		cy.cGet('.cell.notebookbar .unoSetBorderStyle').click();
+		cy.cGet('.notebookbar .unoSetBorderStyle').click();
 		cy.cGet('.w2ui-tb-image.w2ui-icon.frame06').should($el => { expect(Cypress.dom.isDetached($el)).to.eq(false); }).click();
 		calcHelper.selectEntireSheet();
 		cy.cGet('#copy-paste-container table td').should('have.attr', 'style', 'border-bottom: 1px solid #000000');
@@ -90,7 +90,7 @@ describe(['tagdesktop'], 'Change cell appearance.', function() {
 	it('Apply top and bottom border', function() {
 		desktopHelper.switchUIToNotebookbar();
 		calcHelper.clickOnFirstCell();
-		cy.cGet('.cell.notebookbar .unoSetBorderStyle').click();
+		cy.cGet('.notebookbar .unoSetBorderStyle').click();
 		cy.cGet('.w2ui-tb-image.w2ui-icon.frame07').should($el => { expect(Cypress.dom.isDetached($el)).to.eq(false); }).click();
 		calcHelper.selectEntireSheet();
 		cy.cGet('#copy-paste-container table td').should('have.attr', 'style', 'border-top: 1px solid #000000; border-bottom: 1px solid #000000');
@@ -99,7 +99,7 @@ describe(['tagdesktop'], 'Change cell appearance.', function() {
 	it('Apply border for all sides', function() {
 		desktopHelper.switchUIToNotebookbar();
 		calcHelper.clickOnFirstCell();
-		cy.cGet('.cell.notebookbar .unoSetBorderStyle').click();
+		cy.cGet('.notebookbar .unoSetBorderStyle').click();
 		cy.cGet('.w2ui-tb-image.w2ui-icon.frame08').should($el => { expect(Cypress.dom.isDetached($el)).to.eq(false); }).click();
 		calcHelper.selectEntireSheet();
 		cy.cGet('#copy-paste-container table td')
@@ -110,7 +110,7 @@ describe(['tagdesktop'], 'Change cell appearance.', function() {
 		desktopHelper.switchUIToNotebookbar();
 		calcHelper.selectEntireSheet();
 		// Click on the one in notebookbar (not sidebar).
-		cy.cGet('.cell.notebookbar .unoSetBorderStyle').click();
+		cy.cGet('.notebookbar .unoSetBorderStyle').click();
 		cy.cGet('.w2ui-tb-image.w2ui-icon.frame09').should($el => { expect(Cypress.dom.isDetached($el)).to.eq(false); }).click();
 		calcHelper.selectEntireSheet();
 
@@ -126,7 +126,7 @@ describe(['tagdesktop'], 'Change cell appearance.', function() {
 	it('Apply horizontal inner borders and vertical outer borders', function() {
 		desktopHelper.switchUIToNotebookbar();
 		calcHelper.selectEntireSheet();
-		cy.cGet('.cell.notebookbar .unoSetBorderStyle').click();
+		cy.cGet('.notebookbar .unoSetBorderStyle').click();
 		cy.cGet('.w2ui-tb-image.w2ui-icon.frame10').should($el => { expect(Cypress.dom.isDetached($el)).to.eq(false); }).click();
 		calcHelper.selectEntireSheet();
 		//cy.cGet('#copy-paste-container table td')
@@ -144,7 +144,7 @@ describe(['tagdesktop'], 'Change cell appearance.', function() {
 	it('Apply vertical inner borders and horizontal outer borders', function() {
 		desktopHelper.switchUIToNotebookbar();
 		calcHelper.selectEntireSheet();
-		cy.cGet('.cell.notebookbar .unoSetBorderStyle').click();
+		cy.cGet('.notebookbar .unoSetBorderStyle').click();
 		cy.cGet('.w2ui-tb-image.w2ui-icon.frame11').should($el => { expect(Cypress.dom.isDetached($el)).to.eq(false); }).click();
 		calcHelper.selectEntireSheet();
 		//cy.cGet('#copy-paste-container table td')
@@ -162,7 +162,7 @@ describe(['tagdesktop'], 'Change cell appearance.', function() {
 	it('Apply all inner and outer borders', function() {
 		desktopHelper.switchUIToNotebookbar();
 		calcHelper.selectEntireSheet();
-		cy.cGet('.cell.notebookbar .unoSetBorderStyle').click();
+		cy.cGet('.notebookbar .unoSetBorderStyle').click();
 		cy.cGet('.w2ui-tb-image.w2ui-icon.frame12').should($el => { expect(Cypress.dom.isDetached($el)).to.eq(false); }).click();
 		calcHelper.selectEntireSheet();
 		//cy.cGet('#copy-paste-container table td')
@@ -178,7 +178,7 @@ describe(['tagdesktop'], 'Change cell appearance.', function() {
 		desktopHelper.switchUIToNotebookbar();
 		calcHelper.clickOnFirstCell();
 		// Apply left border first
-		cy.cGet('.cell.notebookbar .unoSetBorderStyle').click();
+		cy.cGet('.notebookbar .unoSetBorderStyle').click();
 		cy.cGet('.w2ui-tb-image.w2ui-icon.frame02').should($el => { expect(Cypress.dom.isDetached($el)).to.eq(false); }).click();
 
 		cy.wait(500); // Wait for first popup to close.

--- a/cypress_test/integration_tests/desktop/impress/table_operation_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/table_operation_spec.js
@@ -176,7 +176,7 @@ describe(['tagdesktop'], 'Table operations', function() {
 		cy.cGet('.leaflet-marker-icon.table-column-resize-marker')
 			.should('have.length', 3);
 
-		selectOptionNotebookbar('#table-delete-columns');
+		selectOptionNotebookbar('#table-delete-columns-button');
 
 		cy.cGet('.leaflet-marker-icon.table-column-resize-marker')
 			.should('have.length', 2);
@@ -279,7 +279,7 @@ describe(['tagdesktop'], 'Table operations', function() {
 		cy.cGet('.leaflet-marker-icon.table-row-resize-marker')
 			.should('have.length', 3);
 
-		selectOptionNotebookbar('.cell.notebookbar #SplitCell');
+		selectOptionNotebookbar('.notebookbar #SplitCell');
 
 		cy.cGet('#SplitCellsDialog').should('be.visible');
 

--- a/cypress_test/integration_tests/desktop/writer/invalidations_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/invalidations_spec.js
@@ -51,7 +51,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Invalidation tests.', func
 
 		// Add a header with YY in it
 		cy.cGet('#Insert-tab-label').click();
-		cy.cGet('.cell.notebookbar > .unoInsertPageHeader > button').click();
+		cy.cGet('.notebookbar > .unoInsertPageHeader > button').click();
 		ceHelper.type('YY');
 
 		// Click back in main document
@@ -97,7 +97,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Invalidation tests.', func
 
 		// Add some main body text of X and bullet
 		ceHelper.type('XX');
-		cy.cGet('.cell.notebookbar > .unoDefaultBullet > button').click();
+		cy.cGet('.notebookbar > .unoDefaultBullet > button').click();
 		cy.cGet('#tb_actionbar_item_StateWordCount').should('have.text', '    2 words, 3 characters');
 
 		cy.cGet('.empty-deltas').then(($before) => {

--- a/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
@@ -57,25 +57,25 @@ describe(['tagdesktop'], 'Top toolbar tests.', function() {
 	});
 
 	it('Apply bold font.', function() {
-		cy.cGet('.cell.notebookbar > .unoBold > button').click();
+		cy.cGet('.notebookbar > .unoBold > button').click();
 		writerHelper.selectAllTextOfDoc();
 		cy.cGet('#copy-paste-container p b').should('exist');
 	});
 
 	it('Apply italic font.', function() {
-		cy.cGet('.cell.notebookbar > .unoItalic > button').click();
+		cy.cGet('.notebookbar > .unoItalic > button').click();
 		writerHelper.selectAllTextOfDoc();
 		cy.cGet('#copy-paste-container p i').should('exist');
 	});
 
 	it('Apply underline.', function() {
-		cy.cGet('.cell.notebookbar > .unoUnderline > button').click();
+		cy.cGet('.notebookbar > .unoUnderline > button').click();
 		writerHelper.selectAllTextOfDoc();
 		cy.cGet('#copy-paste-container p u').should('exist');
 	});
 
 	it('Apply strikethrough.', function() {
-		cy.cGet('.cell.notebookbar > .unoStrikeout > button').click();
+		cy.cGet('.notebookbar > .unoStrikeout > button').click();
 		writerHelper.selectAllTextOfDoc();
 		cy.cGet('#copy-paste-container p strike').should('exist');
 	});
@@ -88,55 +88,55 @@ describe(['tagdesktop'], 'Top toolbar tests.', function() {
 	});
 
 	it('Clear direct formatting', function() {
-		cy.cGet('.cell.notebookbar > .unoBold > button').click();
+		cy.cGet('.notebookbar > .unoBold > button').click();
 		writerHelper.selectAllTextOfDoc();
 		cy.cGet('#copy-paste-container p b').should('exist');
-		cy.cGet('.cell.notebookbar > .unoResetAttributes').click();
+		cy.cGet('.notebookbar > .unoResetAttributes').click();
 		writerHelper.selectAllTextOfDoc();
 		cy.cGet('#copy-paste-container p b').should('not.exist');
 	});
 
 	it('Apply left/right alignment.', function() {
-		cy.cGet('#Home .cell.notebookbar > .unoBold > button').click();
+		cy.cGet('#Home .notebookbar > .unoBold > button').click();
 		writerHelper.selectAllTextOfDoc();
 		//cy.cGet('#copy-paste-container p').should('have.attr', 'align', 'right');
-		cy.cGet('#Home .cell.notebookbar > .unoRightPara').click();
+		cy.cGet('#Home .notebookbar > .unoRightPara').click();
 		writerHelper.selectAllTextOfDoc();
 		//cy.cGet('#copy-paste-container p').should('have.attr', 'align', 'left');
 	});
 
 	it('Apply center alignment.', function() {
-		cy.cGet('#Home .cell.notebookbar > .unoCenterPara').click();
+		cy.cGet('#Home .notebookbar > .unoCenterPara').click();
 		writerHelper.selectAllTextOfDoc();
 		//cy.cGet('#copy-paste-container p').should('have.attr', 'align', 'center');
 	});
 
 	it('Apply justified.', function() {
-		cy.cGet('#Home .cell.notebookbar > div.unoJustifyPara > button.unobutton').click();
+		cy.cGet('#Home .notebookbar > div.unoJustifyPara > button.unobutton').click();
 		writerHelper.selectAllTextOfDoc();
 		cy.cGet('#copy-paste-container p').should('have.attr', 'align', 'justify');
 	});
 
 	it('Apply Line spacing: 1 and 1.5', function() {
-		cy.cGet('#Home .cell.notebookbar .unoLineSpacing button').click();
+		cy.cGet('#Home .notebookbar .unoLineSpacing button').click();
 		cy.cGet('[id$=line-spacing-menu]').contains('.menu-text', 'Line Spacing: 1.5').click();
 		writerHelper.selectAllTextOfDoc();
 		cy.cGet('#copy-paste-container p').should('have.attr', 'style').should('contain', 'line-height: 150%');
-		cy.cGet('#Home .cell.notebookbar .unoLineSpacing button').click();
+		cy.cGet('#Home .notebookbar .unoLineSpacing button').click();
 		cy.cGet('[id$=line-spacing-menu]').contains('.menu-text', 'Line Spacing: 1').click();
 		writerHelper.selectAllTextOfDoc();
 		cy.cGet('#copy-paste-container p').should('have.attr', 'style').should('contain', 'line-height: 100%');
 	});
 
 	it('Apply Line spacing: 2', function() {
-		cy.cGet('#Home .cell.notebookbar .unoLineSpacing button').click();
+		cy.cGet('#Home .notebookbar .unoLineSpacing button').click();
 		cy.cGet('[id$=line-spacing-menu]').contains('.menu-text', 'Line Spacing: 2').click();
 		writerHelper.selectAllTextOfDoc();
 		cy.cGet('#copy-paste-container p').should('have.attr', 'style').should('contain', 'line-height: 200%');
 	});
 
 	it('Increase/Decrease Paragraph spacing', function() {
-		cy.cGet('.cell.notebookbar .unoLineSpacing button').click();
+		cy.cGet('.notebookbar .unoLineSpacing button').click();
 		cy.cGet('[id$=line-spacing-menu]').contains('.menu-text', 'Increase Paragraph Spacing').click();
 
 		writerHelper.selectAllTextOfDoc();
@@ -146,7 +146,7 @@ describe(['tagdesktop'], 'Top toolbar tests.', function() {
 
 		writerHelper.selectAllTextOfDoc();
 
-		cy.cGet('.cell.notebookbar .unoLineSpacing button').click();
+		cy.cGet('.notebookbar .unoLineSpacing button').click();
 		cy.cGet('[id$=line-spacing-menu]').contains('.menu-text', 'Decrease Paragraph Spacing').click();
 
 		writerHelper.selectAllTextOfDoc();
@@ -248,7 +248,7 @@ describe(['tagdesktop'], 'Top toolbar tests.', function() {
 	});
 
 	it('Save.', { defaultCommandTimeout: 60000 }, function() {
-		cy.cGet('.cell.notebookbar > .unoBold > button').click();
+		cy.cGet('.notebookbar > .unoBold > button').click();
 		cy.cGet('.notebookbar-shortcuts-bar .unoSave').click();
 		helper.reload(testFileName, 'writer', true);
 		cy.wait(2000);
@@ -271,7 +271,7 @@ describe(['tagdesktop'], 'Top toolbar tests.', function() {
 	});
 
 	it('Apply Undo/Redo.', function() {
-		cy.cGet('.cell.notebookbar > .unoItalic > button').click();
+		cy.cGet('.notebookbar > .unoItalic > button').click();
 		writerHelper.selectAllTextOfDoc();
 		cy.cGet('#copy-paste-container p i').should('exist');
 
@@ -346,8 +346,8 @@ describe(['tagdesktop'], 'Top toolbar tests.', function() {
 		helper.textSelectionShouldExist();
 
 		// Apply bold and try to clone it to the whole word.
-		cy.cGet('.cell.notebookbar > .unoBold > button').click();
-		cy.cGet('.cell.notebookbar > .unoFormatPaintbrush').click();
+		cy.cGet('.notebookbar > .unoBold > button').click();
+		cy.cGet('.notebookbar > .unoFormatPaintbrush').click();
 
 		// Click at the blinking cursor position.
 		cy.cGet('.leaflet-cursor.blinking-cursor')
@@ -401,7 +401,7 @@ describe(['tagdesktop'], 'Top toolbar tests.', function() {
 
 	it('Apply superscript.', function() {
 		writerHelper.selectAllTextOfDoc();
-		cy.cGet('.cell.notebookbar .unoSuperScript').click();
+		cy.cGet('.notebookbar .unoSuperScript').click();
 		cy.cGet('.leaflet-layer').click('center');
 		writerHelper.selectAllTextOfDoc();
 		cy.cGet('#copy-paste-container p sup').should('exist');
@@ -409,7 +409,7 @@ describe(['tagdesktop'], 'Top toolbar tests.', function() {
 
 	it('Apply subscript.', function() {
 		writerHelper.selectAllTextOfDoc();
-		cy.cGet('.cell.notebookbar .unoSubScript').click();
+		cy.cGet('.notebookbar .unoSubScript').click();
 		cy.cGet('.leaflet-layer').click('center');
 		writerHelper.selectAllTextOfDoc();
 		cy.cGet('#copy-paste-container p sub').should('exist');

--- a/cypress_test/integration_tests/multiuser/writer/invalidations_spec.js
+++ b/cypress_test/integration_tests/multiuser/writer/invalidations_spec.js
@@ -26,7 +26,7 @@ describe(['tagmultiuser'], 'Joining a document should not trigger an invalidatio
 		// TODO: Grammar checking, when available, adds an extra empty update when
 		// it kicks in after a change
 		cy.cGet('#Review-tab-label').click();
-		cy.cGet('.cell.notebookbar > .unoSpellOnline > button').click();
+		cy.cGet('.notebookbar > .unoSpellOnline > button').click();
 
 		ceHelper.type('X');
 
@@ -66,7 +66,7 @@ describe(['tagmultiuser'], 'Joining a document should not trigger an invalidatio
 		// TODO: Grammar checking, when available, adds an extra empty update when
 		// it kicks in after a change
 		cy.cGet('#Review-tab-label').click();
-		cy.cGet('.cell.notebookbar > .unoSpellOnline > button').click();
+		cy.cGet('.notebookbar > .unoSpellOnline > button').click();
 
 		ceHelper.type('X');
 
@@ -84,7 +84,7 @@ describe(['tagmultiuser'], 'Joining a document should not trigger an invalidatio
 
 			// joins after a save triggered excessive invalidations on changes
 			cy.cGet('#File-tab-label').click();
-			cy.cGet('.cell.notebookbar > .unoSave > button').click();
+			cy.cGet('.notebookbar-shortcuts-bar .unoSave > button').click();
 
 			// Reload page
 			cy.cSetActiveFrame('#iframe2');


### PR DESCRIPTION
It is request from user that currency icon has no dropdown to select something else than USD.

To enable that we need widget from core be enabled + restructure notebookbar so we use correct id's in the communication with core.

To get this done I simplified notebookbar by using CSS grid and removing old cell/row containers structure.
So similar to sidebar we will have plain structure of widgets.