### PR TITLE
Make sure to clear headers' background

### DIFF
--- a/browser/src/control/Control.ColumnHeader.ts
+++ b/browser/src/control/Control.ColumnHeader.ts
@@ -116,6 +116,8 @@ export class ColumnHeader extends Header {
 
 		// draw background
 		this.context.beginPath();
+		// Clear background and erase text - own fillStyle may be transparent!
+		this.containerObject.fillRect(startX, 0, entry.size, this.size[1]);
 		this.context.fillStyle = highlight ? selectionBackgroundGradient : entry.isOver ? this._hoverColor : this._backgroundColor;
 		this.context.fillRect(startX, 0, entry.size, this.size[1]);
 

--- a/browser/src/control/Control.RowHeader.ts
+++ b/browser/src/control/Control.RowHeader.ts
@@ -119,6 +119,8 @@ export class RowHeader extends cool.Header {
 
 		// draw background
 		this.context.beginPath();
+		// Clear background and erase text - own fillStyle may be transparent!
+		this.containerObject.fillRect(0, startY, this.size[0], entry.size);
 		this.context.fillStyle = highlight ? selectionBackgroundGradient : entry.isOver ? this._hoverColor : this._backgroundColor;
 		this.context.fillRect(0, startY, this.size[0], entry.size);
 

--- a/browser/src/layer/tile/CanvasSectionContainer.ts
+++ b/browser/src/layer/tile/CanvasSectionContainer.ts
@@ -587,10 +587,14 @@ class CanvasSectionContainer {
 		}
 	}
 
-	private clearCanvas() {
+	fillRect(x: number, y: number, w: number, h: number) {
 		this.context.fillStyle = this.clearColor;
-		this.context.clearRect(0, 0, this.canvas.width, this.canvas.height);
-		this.context.fillRect(0, 0, this.canvas.width, this.canvas.height);
+		this.context.clearRect(x, y, w, h);
+		this.context.fillRect(x, y, w, h);
+	}
+
+	private clearCanvas() {
+		this.fillRect(0, 0, this.canvas.width, this.canvas.height);
 	}
 
 	getContext () {


### PR DESCRIPTION
Headers' drawHeaderEntry call context's fillRect to clean the
background. But when the fillStyle (from _backgroundColor or
_hoverColor) is "rgba(0, 0, 0, 0)", i.e. completely transparent,
the call does nothing, and the old text stays. Then, a call to
fillText will draw text over the old one, the second time.

The issue is, with anti-aliasing, second draw makes partially
covered pixels brighter, creating an appearamce of bold text,
which doesn't disappear until a full headers redraw operation
(e.g., scroll).

It is impossible to test if the style is transparent (fully
or partially): it is a string, coming from CSS, and might have
old / new rgb(a) syntax, percent values, etc. So the fix calls
the parent object's new drawRect method, which makes sure to
fill the rectangle the same way as done when doing full redraw.

Signed-off-by: Mike Kaganski <mike.kaganski@collabora.com>
Change-Id: I38cae5ca70db6356b9c397e8cede0fa67a49f8fa
