### PR TITLE
context menu: allow edit section for Writer text sections

### DIFF
--- a/browser/src/control/Control.ContextMenu.js
+++ b/browser/src/control/Control.ContextMenu.js
@@ -55,7 +55,7 @@ L.Control.ContextMenu = L.Control.extend({
 			text: ['TableInsertMenu',
 				   'InsertRowsBefore', 'InsertRowsAfter', 'InsertColumnsBefore', 'InsertColumnsAfter',
 				   'TableDeleteMenu', 'SetObjectToBackground', 'SetObjectToForeground',
-				   'DeleteRows', 'DeleteColumns', 'DeleteTable',
+				   'DeleteRows', 'DeleteColumns', 'DeleteTable', 'EditCurrentRegion',
 				   'MergeCells', 'SetOptimalColumnWidth', 'SetOptimalRowHeight',
 				   'UpdateCurIndex','RemoveTableOf',
 				   'ReplyComment', 'DeleteComment', 'DeleteAuthor', 'DeleteAllNotes',

--- a/browser/src/unocommands.js
+++ b/browser/src/unocommands.js
@@ -117,6 +117,7 @@ var unoCommandsArray = {
 	'DrawText':{global:{context:_('Insert Text Box'),menu:_('~Text Box'),},},
 	'DuplicatePage':{presentation:{menu:_('Duplicate Page'),},},
 	'DuplicateSlide':{presentation:{menu:_('Duplicate ~Slide'),},},
+	'EditCurrentRegion':{text:{menu:_('Edit Section...'),},},
 	'EditHeaderAndFooter':{spreadsheet:{menu:_('~Headers and Footers...'),},},
 	'EditHyperlink':{global:{context:_('Edit Hyperlink...'),menu:_('~Hyperlink'),},},
 	'EditMenu':{global:{menu:_('~Edit'),},},


### PR DESCRIPTION
Change-Id: I40a40a99551a756ad234e73956169018b761fa42

* Target version: master 

### Summary

Allow edit section for Writer text sections, the dialog is made async in https://gerrit.libreoffice.org/c/core/+/161828.

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

