### PR TITLE
Fix failing test multiuser/writer/invalidations_spec.js

### DIFF
--- a/cypress_test/integration_tests/multiuser/writer/invalidations_spec.js
+++ b/cypress_test/integration_tests/multiuser/writer/invalidations_spec.js
@@ -86,8 +86,11 @@ describe(['tagmultiuser'], 'Joining a document should not trigger an invalidatio
 			cy.cGet('#File-tab-label').click();
 			cy.cGet('.cell.notebookbar > .unoSave > button').click();
 
+			// Reload page
 			cy.cSetActiveFrame('#iframe2');
 			cy.get('#form2').submit();
+			// Wait for page to finish loading
+			helper.checkIfDocIsLoaded(true);
 
 			cy.cSetActiveFrame('#iframe1');
 			writerHelper.selectAllTextOfDoc();


### PR DESCRIPTION
Change-Id: If34a07e6a70f2c4293e8a2eb9d5e3d5fd14258ac


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
Test was failing because second user wasn't completely reloaded.

### Checklist

- [X] Code is properly formatted
- [X] All commits have Change-Id
- [X] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

