### PR TITLE
Click on a resume message to dismiss it

### DIFF
--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -227,8 +227,12 @@ L.Control.JSDialog = L.Control.extend({
 
 		instance.form = L.DomUtil.create('form', 'jsdialog-container ui-dialog ui-widget-content lokdialog_container', instance.container);
 
-		// Prevent overlay from getting the click.
-		instance.container.onclick = function(e) { e.stopPropagation(); };
+		// Prevent overlay from getting the click, except if we want click to dismiss
+		// Like in the case of the inactivity message.
+		// https://github.com/CollaboraOnline/online/issues/7403
+		if (!instance.clickToDismiss) {
+			instance.container.onclick = function(e) { e.stopPropagation(); };
+		}
 
 		if (instance.collapsed && (instance.collapsed === 'true' || instance.collapsed === true))
 			L.DomUtil.addClass(instance.container, 'collapsed');

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -1152,7 +1152,7 @@ L.Control.UIManager = L.Control.extend({
 		return JSDialog.generateModalId(givenId);
 	},
 
-	_modalDialogJSON: function(id, title, cancellable, widgets, focusId) {
+	_modalDialogJSON: function(id, title, cancellable, widgets, focusId, clickToDismiss) {
 		var dialogId = this.generateModalId(id);
 		focusId = focusId ? focusId : 'response';
 		return {
@@ -1165,6 +1165,7 @@ L.Control.UIManager = L.Control.extend({
 			cancellable: cancellable,
 			jsontype: 'dialog',
 			'init_focus_id': focusId,
+			clickToDismiss: clickToDismiss,
 			children: [
 				{
 					id: 'info-modal-container',
@@ -1178,6 +1179,7 @@ L.Control.UIManager = L.Control.extend({
 
 	/// DEPRECATED: use JSDialog.showInfoModalWithOptions instead
 	/// shows simple info modal (message + ok button)
+	/// When called with just an id (one argument), the popup will be click dismissable.
 	/// id - id of a dialog
 	/// title - title of a dialog
 	/// message1 - 1st line of message
@@ -1189,6 +1191,8 @@ L.Control.UIManager = L.Control.extend({
 		var dialogId = this.generateModalId(id);
 		var responseButtonId = id + '-response';
 		var cancelButtonId = id + '-cancel';
+		// If called with only id, then we want clickToDismiss.
+		var clickToDismiss = arguments.length < 2;
 
 		var json = this._modalDialogJSON(id, title, true, [
 			{
@@ -1229,7 +1233,7 @@ L.Control.UIManager = L.Control.extend({
 				vertical: false,
 				layoutstyle: 'end'
 			},
-		], focusId);
+		], focusId, clickToDismiss);
 
 		var that = this;
 		this.showModal(json, [


### PR DESCRIPTION
See https://github.com/CollaboraOnline/online/issues/7403


Change-Id: I20aa320a6efbbf8ce19eda34c3d5278a601e15fc


* Resolves: #7403 
* Target version: master 

### Summary

When you get the idle message, click on the message like you'd click in the document to dismiss. It feels more natural.

To trigger the message, in the JS Console, in the COOL frame, type:
```javascript
app.idleHandler._dim()
```

### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

