### PR TITLE
Fix uncaught TypeError in isAnyEdit 2

### DIFF
--- a/browser/src/layer/tile/CommentSection.ts
+++ b/browser/src/layer/tile/CommentSection.ts
@@ -988,9 +988,11 @@ export class Comment extends CanvasSectionObject {
 	}
 
 	public static isAnyEdit (): boolean {
-		var section = app.sectionContainer.getSectionWithName(L.CSections.CommentList.name);
-		if (!section)
+		var section = app.sectionContainer ?
+			app.sectionContainer.getSectionWithName(L.CSections.CommentList.name) : null;
+		if (!section) {
 			return false;
+		}
 
 		var commentList = section.sectionProperties.commentList;
 		for (var i in commentList) {


### PR DESCRIPTION
followup for commit 4c70df5

Fixes case:
Uncaught TypeError: app.sectionContainer is undefined
    isAnyEdit CommentSection.ts:991
    isAnyDialogOpen Control.UIManager.js:1141
    _activate Control.IdleHandler.ts:83
    _onSocketOpen Socket.js:256
    connect Socket.js:72
    loadDocument Map.js:326
    <anonymous> main.js:117
    <anonymous> main.js:137
