### PR TITLE
fix: can't open readonly files

### DIFF
--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -2040,7 +2040,7 @@ bool ClientSession::handleKitToClientMessage(const std::shared_ptr<Message>& pay
         }
     }
 #if ENABLE_FEATURE_LOCK || ENABLE_FEATURE_RESTRICTION
-    else if (tokens.equals(0, "statusindicatorfinish:"))
+    else if (tokens.equals(0, "status:") && !isViewLoaded())
     {
         std::ostringstream blockingCommandStatus;
         blockingCommandStatus << "blockingcommandstatus isRestrictedUser="


### PR DESCRIPTION
- regression from https://github.com/CollaboraOnline/online/commit/d118874bee9196206d3de24a89df8700f62cd89b which was a fix for regression from 93b5bdf
- previously we used to send blockingcommandstatus message to the core when we were getting statusindicatorfinish but when file is readonly we load the document first therefore we get the statusindicatorfinish first then wait for the input from the to whether to open the readonly document or not
- now we send the blockingcommandstatus only after we get the first status message which indicates document is loaded and opened


Change-Id: I0f4934e085befa6f9a918ac61a265391b217a2f2

* Things I  tested:
  - [x] Feature locking, make sure that this feature works properly
  - [x] Password protected file
  - [x] CSV file
  - [x] Readonly file 

* Resolves: # <!-- related github issue -->
* Target version: master 

