### PR TITLE
Color selector: add no-fill as button

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -132,14 +132,21 @@
 }
 
 .auto-color-button {
-	width: 100% !important;
+	width: calc(100% - 10px) !important;
 	padding: 0;
-	margin: auto !important;
+	margin: 5px !important;
 }
 
 .color-palette-selector {
+	margin: 0 5px !important;
+}
+
+.color-palette-selector > select {
 	width: 100% !important;
-	margin-top: 8px !important;
+	padding: 0 14px 0 4px;
+	height: 28px;
+	font-size: var(--default-font-size);
+	font-family: var(--jquery-ui-font);
 }
 
 #toolbar-wrapper.readonly {

--- a/browser/js/w2ui-1.5.rc1.js
+++ b/browser/js/w2ui-1.5.rc1.js
@@ -2814,15 +2814,6 @@ w2utils.event = {
             color: options,
             transparent: true
         };
-        // add remove transparent color
-        if (options.transparent && pal[0][1] == '555555') {
-            pal[0].splice(1, 1);
-            pal[0].push('');
-        }
-        if (!options.transparent && pal[0][1] != '555555') {
-            pal[0].splice(1, 0, '555555');
-            pal[0].pop();
-        }
 
         return pal;
     };
@@ -2900,6 +2891,12 @@ w2utils.event = {
                     setTimeout(function() { $('#w2ui-overlay input')[0].focus(); }, 100);
                 })
                 .w2field('hex');
+
+                $('#transparent-color-button')
+                    .on('mousedown.w2color keydown.w2color', function () {
+                        $(el).data('_color', '');
+                        $(el).data('_theme', undefined);
+                    });
         }
 
         var currentPalette = getCurrentPaletteName();
@@ -2925,16 +2922,16 @@ w2utils.event = {
         bindEvents(pal);
 
         var updatePalette = function () {
-            var palette = $('#w2ui-overlay .color-palette-selector option:selected').get(0).value;
+            var palette = $('#w2ui-overlay .color-palette-selector select option:selected').get(0).value;
             localStorage.setItem('colorPalette', palette);
             var pal = generatePalette(palette, options);
             $('#w2ui-overlay .w2ui-color').parent().html(getColorHTML(pal, options));
             bindEvents(pal);
-            $('#w2ui-overlay .color-palette-selector')
+            $('#w2ui-overlay .color-palette-selector select')
                 .on('change', updatePalette);
         };
 
-        $('#w2ui-overlay .color-palette-selector')
+        $('#w2ui-overlay .color-palette-selector select')
             .on('change', updatePalette);
 
         el.nav = function (direction) {
@@ -2965,11 +2962,17 @@ w2utils.event = {
         function getColorHTML(pal, options) {
             var html = '';
             var currentPalette = getCurrentPaletteName();
+            var hasTransparent = options.transparent;
 
-            html += '<select class="color-palette-selector">';
-            for (var i in window.app.colorPalettes)
+            var buttonText = hasTransparent ? _('No fill') : _('Automatic');
+            html += '<button id="transparent-color-button" onmousedown="event.stopPropagation(); event.preventDefault()" class="jsdialog ui-pushbutton auto-color-button">' + buttonText + '</button>';
+
+            html += '<div class="jsdialog ui-listbox-container color-palette-selector">'
+                + '<select class="jsdialog ui-listbox">';
+            for (var i in window.app.colorPalettes) {
                 html += '<option value="' + i + '" ' + (i === currentPalette ? 'selected="selected"' : '') + '>' + window.app.colorPalettes[i].name + '</option>';
-            html += '</select>';
+            }
+            html += '</select><span class="jsdialog ui-listbox-arrow"/></div>';
 
             var detailedPalette = window.app.colorPalettes[currentPalette].colors
 

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2882,9 +2882,8 @@ L.Control.JSDialogBuilder = L.Control.extend({
 					});
 
 					if (data.command === '.uno:FontColor' || data.command === '.uno:Color') {
-						var autoColorButton = document.createElement('button');
-						autoColorButton.textContent = _('Automatic');
-						autoColorButton.classList.add('auto-color-button');
+						var colorDiv = document.getElementById('w2ui-overlay');
+						var autoColorButton = colorDiv.querySelector('.auto-color-button');
 
 						autoColorButton.onclick = function() {
 							updateFunction(-1);
@@ -2898,9 +2897,6 @@ L.Control.JSDialogBuilder = L.Control.extend({
 							builder.map.sendUnoCommand(data.command, parameters);
 							document.getElementById('document-container').click();
 						}.bind(this);
-
-						var colorDiv = document.getElementById('w2ui-overlay');
-						colorDiv.insertBefore(autoColorButton, colorDiv.firstChild);
 					}
 				}
 			};

--- a/browser/src/control/Control.Toolbar.js
+++ b/browser/src/control/Control.Toolbar.js
@@ -825,7 +825,7 @@ function showColorPicker(id) {
 	var it = w2ui['editbar'].get(id);
 	var obj = w2ui['editbar'];
 	var el = '#tb_editbar_item_' + id;
-	if (it.transparent == null) it.transparent = true;
+	if (it.transparent == null && id !== 'fontcolor') it.transparent = true;
 	$(el).w2color({ color: it.color, transparent: it.transparent }, function (color, themeData) {
 		if (color != null) {
 			obj.colorClick({ name: obj.name, item: it, color: color, themeData: themeData });


### PR DESCRIPTION
Make it more unified with "Office" color picker.
Use styling from jsdialog for color picker to match all other ui components.

Unified with existing "Automatic" button for font color.

Before:
![colors](https://github.com/CollaboraOnline/online/assets/5307369/f52db902-d687-4dad-925f-18e87ad5e898)

After:
![colornofill](https://github.com/CollaboraOnline/online/assets/5307369/209c2cc1-2ee9-4e99-95f4-7932b95cd78d)

Core for comparison:
![colorcore](https://github.com/CollaboraOnline/online/assets/5307369/6b4d6779-7163-42d7-a947-ee30312efcb7)
