### PR TITLE
Rewinding and rereading proc/smaps_rollup doubles the values on some …

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -3025,7 +3025,10 @@ void lokit_main(
                 std::chrono::steady_clock::now() - jailSetupStartTime);
             LOG_DBG("Initialized jail files in " << ms);
 
-            ProcSMapsFile = open("/proc/self/smaps_rollup", O_RDONLY);
+            // The bug is that rewinding and rereading /proc/self/smaps_rollup doubles the previous
+            // values, so it only affects the case where we reuse the fd from opening smaps_rollup
+            const bool bBrokenSmapsRollup = (std::getenv("COOL_DISABLE_SMAPS_ROLLUP") != nullptr);
+            ProcSMapsFile = !bBrokenSmapsRollup ? open("/proc/self/smaps_rollup", O_RDONLY) : -1;
             if (ProcSMapsFile < 0)
             {
                 LOG_WRN("Failed to open /proc/self/smaps_rollup. Memory stats will be slower");


### PR DESCRIPTION
…kernels

So this only affects the case where we reuse the fd from opening smaps_rollup

Bug seen in 4.15.0 and not in 6.5.10, suspected to be fixed by: https://github.com/torvalds/linux/commit/258f669e7e88c18edbc23fe5ce00a476b924551f included in >= v4.19

Test for this in coolwsd and set a flag if it is broken


Change-Id: I0a4aca77b9d9201e4f70172340296e5eb5460229


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

