### PR TITLE
highlight row/col header when editing

### DIFF
--- a/browser/src/control/Control.Header.ts
+++ b/browser/src/control/Control.Header.ts
@@ -657,6 +657,10 @@ export class HeaderInfo {
 			currentIndex = this._isColumn ? this._map._docLayer._cellCursorXY.x: this._map._docLayer._cellCursorXY.y;
 		}
 
+		if (currentIndex === -1 && this._map._docLayer._prevCellCursorXY) {
+			currentIndex = this._isColumn ? this._map._docLayer._prevCellCursorXY.x : this._map._docLayer._prevCellCursorXY.y;
+		}
+
 		const startPx = this._isColumn === true ? section.documentTopLeft[0]: section.documentTopLeft[1];
 		this._docVisStart = startPx;
 		const endPx = startPx + (this._isColumn === true ? section.size[0]: section.size[1]);


### PR DESCRIPTION
The header highlighting was tied to the position of the cell cursor
so when editing a cell the highlights disapeared with the cell cursor.

This also checks the previous cursor position if there isn't a current one.

Signed-off-by: Jaume Pujantell <jaume.pujantell@collabora.com>
Change-Id: I93bf38b42cbaf091511c05e38bfab331e9532f4a
