### PR TITLE
Resolve TS build error

### DIFF
--- a/browser/src/layer/tile/TilesSection.ts
+++ b/browser/src/layer/tile/TilesSection.ts
@@ -131,7 +131,7 @@ export class TilesSection extends CanvasSectionObject {
 		var ctx = this.sectionProperties.tsManager._paintContext();
 
 		var bounds: cool.Bounds;
-		for (const coords of tileSubset.values()) {
+		for (const coords of Array.from(tileSubset)) {
 			var topLeft = new L.Point(coords.getPos().x, coords.getPos().y);
 			var rightBottom = new L.Point(topLeft.x + ctx.tileSize.x, topLeft.y + ctx.tileSize.y);
 


### PR DESCRIPTION
Change-Id: Ic25805de741d6d71153211de68fb0ccc88e62d40

### Summary
Follow up from https://github.com/CollaboraOnline/online/pull/8007/files

The error is TS2569: Type 'IterableIterator<any>' is not an array type or a string type. TS is complaining about the use of an iterator in the for loop where it expects an array or string.

The error message and everyone on stackoverflow recommend setting the compiler option --downlevelIteration. But wrapping in Array.from() is simpler.

Compiles on my machine with `./node_modules/typescript/bin/tsc mocha_tests/CanvasSectionContainer.test.ts --outfile mocha_tests/CanvasSectionContainer.test.js --module none --lib dom,es2016 --target ES5` when before it didn't. But I didn't run any other tests.

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

