### PR TITLE
tsc can report an error but create js output, so 2nd make's 'succeed'

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -31,8 +31,10 @@ endif
 MOCHA_DIR = $(srcdir)/mocha_tests
 MOCHA_TS_FILES = $(wildcard $(MOCHA_DIR)/*.ts)
 MOCHA_TS_JS_FILES := $(MOCHA_TS_FILES:.ts=.js)
+# tsc can report a failure, but still create a .js and a second make attempt will succeed,
+# so if this returns an error then delete the target
 $(MOCHA_TS_JS_FILES): %.js: %.ts
-	$(builddir)/node_modules/typescript/bin/tsc $< --outfile $@ --module none --lib dom,es2016 --target ES5
+	$(builddir)/node_modules/typescript/bin/tsc $< --outfile $@ --module none --lib dom,es2016 --target ES5 || (rm -f $@ && false)
 
 JQUERY_LIGHTNESS_IMAGE_PATH = $(srcdir)/images/jquery-ui-lightness
 JQUERY_LIGHTNESS_IMAGES = $(wildcard $(JQUERY_LIGHTNESS_IMAGE_PATH)/*.png)


### PR DESCRIPTION
so on failure remove the output so a second attempt doesn't appear to succeed


Change-Id: Ibc1f7d46c2946cdc6a4dbcd6181872fb12e19fb6


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

