### PR TITLE
fix spinfieldcontainer regression

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -659,7 +659,7 @@ input[type='checkbox']:checked.autofilter, .jsdialog input[type='checkbox']:chec
 /* spinfield */
 
 .spinfieldcontainer {
-	margin-right: 5px;
+	margin-inline-end: 5px;
 	min-width: 70px;
 	width: 100%;
 }


### PR DESCRIPTION
- use margin-inline-start/end instead of margin left / right.
- This is important for RTL mode

Signed-off-by: Darshan-upadhyay1110 <darshan.upadhyay@collabora.com>
Change-Id: Ie352a247aeedb1d1e9ff331a442a1c5214dbb470

Regression PR: https://github.com/CollaboraOnline/online/pull/7937

