### PR TITLE
service: change KillMode to mixed

### DIFF
--- a/coolwsd.service
+++ b/coolwsd.service
@@ -8,7 +8,7 @@ ExecStart=/usr/bin/coolwsd --version --o:sys_template_path=/opt/cool/systemplate
 KillSignal=SIGINT
 TimeoutStopSec=120
 User=cool
-KillMode=control-group
+KillMode=mixed
 Restart=always
 LimitNOFILE=infinity:infinity
 

--- a/debian/coolwsd.service
+++ b/debian/coolwsd.service
@@ -8,7 +8,7 @@ ExecStart=/usr/bin/coolwsd --version --o:sys_template_path=/opt/cool/systemplate
 KillSignal=SIGINT
 TimeoutStopSec=120
 User=cool
-KillMode=control-group
+KillMode=mixed
 Restart=always
 LimitNOFILE=infinity:infinity
 


### PR DESCRIPTION
According to the systemd.kill man page, when
KillMode=control-group "all remaining processes
in the control group of this unit will be killed
on unit stop." This ends up killing the kit
processes as well, which prevents saving any
unsaved modifications before shutting down.

The setting we want is 'mixed'. According to
the man page, with mixed "the SIGTERM signal is
sent to the main process while the subsequent
SIGKILL signal is sent to all remaining processes
of the unit's control group."

In other words, with KillMode=mixed, coolwsd
will receive the termination signal and it will
manage its children. But systemd will still
make sure that when coolwsd terminates, or when
it times out, all children and properly killed.

This changes KillMode to mixed.

Change-Id: I4123dfe5143d2cc6223b1542821a10bad86fb449
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
