### PR TITLE
drop pako dependency.

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -165,7 +165,6 @@ NODE_MODULES_JS =\
 	node_modules/jquery-ui/dist/jquery-ui.js \
 	$(shell find node_modules/jquery-ui/ui/i18n -name '*.js') \
 	node_modules/smartmenus/dist/jquery.smartmenus.js \
-	node_modules/pako/dist/pako_inflate.es5.js \
 	node_modules/fzstd/umd/index.js
 
 COOL_LIBS_JS =\

--- a/browser/package.json
+++ b/browser/package.json
@@ -23,7 +23,6 @@
     "jscpd": "3.5.10",
     "l10n-for-node": "0.0.1",
     "mocha": "8.2.1",
-    "pako": "2.0.4",
     "select2": "4.0.13",
     "shrinkpack": "1.0.0-alpha",
     "smartmenus": "1.0.0",


### PR DESCRIPTION
Unused in the package since:

    commit 2def6dc3d5c30fb4be8268536bfb988655693a1f
    Date:   Sat Aug 27 17:49:50 2022 +0100

    Switch to zstd image compression.

Change-Id: I785ad2c1522721ed34cf89a1922ee06d5e2507e4


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

