### PR TITLE
Impress: Disable 'Present in Windows' Button on Mobile and Tablet

### DIFF
--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -443,13 +443,14 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'command': 'presentation',
 				'accessibility': { focusBack: true, combination: 'PR', de: null }
 			},
-			{
-				'id': 'view-presentation-in-window',
-				'type': 'bigcustomtoolitem',
-				'text': _('Present in Window'),
-				'command': 'presentinwindow',
-				'accessibility': { focusBack: true, combination: 'PW', de: null }
-			},
+			window.mode.isDesktop() ?
+				{
+					'id': 'view-presentation-in-window',
+					'type': 'bigcustomtoolitem',
+					'text': _('Present in Window'),
+					'command': 'presentinwindow',
+					'accessibility': { focusBack: true, combination: 'PW', de: null }
+				} : {},
 			{
 				'id': 'fullscreen',
 				'type': 'bigtoolitem',


### PR DESCRIPTION
This commit hides the 'Present in Windows' button in Impress on mobile and tablet devices. This change is necessary because, on tablets, pressing this button currently results in the presentation being saved as an SVG file, which is not the intended behavior. The button should only be available on desktop environments.


Change-Id: I362183d899409f3c3075aeaaa3e50cde11e59925


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

