### PR TITLE
Clipboard: add new-style metadata that survives browser sanitize

### DIFF
--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -60,14 +60,18 @@ L.Clipboard = L.Class.extend({
 		document.onbeforepaste = beforeSelect;
 	},
 
-	// We can do a much better job when we fetch text/plain too.
-	stripHTML: function(html) {
-		var tmp = new DOMParser().parseFromString(html, 'text/html').body;
-		// attempt to cleanup unwanted elements
-		var styles = tmp.querySelectorAll('style');
+	// Attempt to cleanup unwanted elements
+	stripStyle: function(domNode) {
+		var styles = domNode.querySelectorAll('style');
 		for (var i = 0; i < styles.length; i++) {
 			styles[i].parentNode.removeChild(styles[i]);
 		}
+	},
+
+	// We can do a much better job when we fetch text/plain too.
+	stripHTML: function(html) {
+		var tmp = new DOMParser().parseFromString(html, 'text/html').body;
+		this.stripStyle(tmp);
 		return tmp.textContent.trim() || tmp.innerText.trim() || '';
 	},
 
@@ -793,7 +797,9 @@ L.Clipboard = L.Class.extend({
 	// textselectioncontent: message
 	setTextSelectionHTML: function(html) {
 		this._selectionType = 'text';
-		this._selectionContent = html;
+		var tmp = new DOMParser().parseFromString(html, 'text/html').body;
+		this.stripStyle(tmp);
+		this._selectionContent = tmp.innerHTML;
 		if (L.Browser.cypressTest) {
 			this._dummyDiv.innerHTML = html;
 		}

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -2785,6 +2785,36 @@ void ClientSession::preProcessSetClipboardPayload(std::string& payload)
         std::size_t len = end - start + 4;
         payload.erase(start, len);
     }
+
+    start = payload.find("<div id=\"meta-origin\" data-coolorigin=\"");
+    if (start != std::string::npos)
+    {
+        std::size_t end = payload.find("\">\n", start);
+        if (end == std::string::npos)
+        {
+            LOG_DBG("Found unbalanced starting meta <div> tag in setclipboard payload.");
+            return;
+        }
+
+        std::size_t len = end - start + 3;
+        payload.erase(start, len);
+
+        static int counter = 0;
+        counter++;
+        std::string path("/tmp/debug/data");
+        path += std::to_string(counter);
+        std::ofstream out(path);
+        out << payload;
+        out.close();
+        start = payload.find("</html></div>");
+        if (start == std::string::npos)
+        {
+            LOG_DBG("Found unbalanced ending meta <div> tag in setclipboard payload.");
+            return;
+        }
+
+        payload.erase(start + strlen("</html>"), strlen("</div>"));
+    }
 }
 
 std::string ClientSession::processSVGContent(const std::string& svg)

--- a/wsd/ClientSession.hpp
+++ b/wsd/ClientSession.hpp
@@ -243,6 +243,10 @@ public:
     /// Adds and/or modified the copied payload before sending on to the client.
     void postProcessCopyPayload(const std::shared_ptr<Message>& payload);
 
+    /// Removes the <meta name="origin" ...> tag which was added in
+    /// ClientSession::postProcessCopyPayload().
+    void preProcessSetClipboardPayload(std::string& payload);
+
     /// Returns true if we're expired waiting for a clipboard and should be removed
     bool staleWaitDisconnect(const std::chrono::steady_clock::time_point &now);
 
@@ -315,10 +319,6 @@ private:
 
     /// If this session is read-only because of failed lock, try to unlock and make it read-write.
     bool attemptLock(const std::shared_ptr<DocumentBroker>& docBroker);
-
-    /// Removes the <meta name="origin" ...> tag which was added in
-    /// ClientSession::postProcessCopyPayload().
-    void preProcessSetClipboardPayload(std::string& payload);
 
 private:
     std::weak_ptr<DocumentBroker> _docBroker;


### PR DESCRIPTION
- this is a first step towards fixing https://github.com/CollaboraOnline/online/issues/8023
- this doesn't switch to the new API yet, but adds a new markup to recognize if the clipboard has our own HTML or something else
- the new markup is better, because <meta> tags are removed by the browser when using the new navigator.clipboard API, and this one is not
- this is meant to be a safe set of first commits, we already write the new markup, but we don't remove the old one yet, e.g. Android needs updating still
- on the other hand, this already provides enough markup so src/map/Clipboard.js can start experimenting with the new API, including the internal paste codepath