### PR TITLE
Parallel Loading of Users' Requests

### DIFF
--- a/android/lib/src/main/cpp/CMakeLists.txt.in
+++ b/android/lib/src/main/cpp/CMakeLists.txt.in
@@ -28,6 +28,7 @@ add_library(androidapp SHARED
             ../../../../../wsd/COOLWSD.cpp
             ../../../../../wsd/ClientRequestDispatcher.cpp
             ../../../../../wsd/RequestDetails.cpp
+            ../../../../../wsd/RequestVettingStation.cpp
             ../../../../../wsd/Storage.cpp
             ../../../../../wsd/TileCache.cpp
             ../../../../../wsd/coolwsd-fork.cpp)

--- a/ios/Mobile.xcodeproj/project.pbxproj
+++ b/ios/Mobile.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		BE5EB5D22140039100E0826C /* COOLWSD.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BE5EB5D12140039100E0826C /* COOLWSD.cpp */; };
 		BE5EB5D22140039100E0826D /* ClientRequestDispatcher.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BE5EB5D12140039100E0826D /* ClientRequestDispatcher.cpp */; };
 		BE5EB5D421400DC100E0826C /* DocumentBroker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BE5EB5D321400DC100E0826C /* DocumentBroker.cpp */; };
+		BE5EB5E721401E0F00E0826C /* RequestVettingStation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BE5EB5E621401E0F00E0826C /* RequestVettingStation.cpp */; };
 		BE5EB5D621401E0F00E0826C /* Storage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BE5EB5D521401E0F00E0826C /* Storage.cpp */; };
 		BE5EB5DA2140363100E0826C /* ios.mm in Sources */ = {isa = PBXBuildFile; fileRef = BE5EB5D92140363100E0826C /* ios.mm */; };
 		BE5EB5DC2140480B00E0826C /* ICU.dat in Resources */ = {isa = PBXBuildFile; fileRef = BE5EB5DB2140480B00E0826C /* ICU.dat */; };
@@ -580,6 +581,7 @@
 		BE5EB5D12140039100E0826C /* COOLWSD.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = COOLWSD.cpp; sourceTree = "<group>"; };
 		BE5EB5D12140039100E0826D /* ClientRequestDispatcher.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ClientRequestDispatcher.cpp; sourceTree = "<group>"; };
 		BE5EB5D321400DC100E0826C /* DocumentBroker.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DocumentBroker.cpp; sourceTree = "<group>"; };
+		BE5EB5E621401E0F00E0826C /* RequestVettingStation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RequestVettingStation.cpp; sourceTree = "<group>"; };
 		BE5EB5D521401E0F00E0826C /* Storage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Storage.cpp; sourceTree = "<group>"; };
 		BE5EB5D92140363100E0826C /* ios.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = ios.mm; path = ../../ios/ios.mm; sourceTree = "<group>"; };
 		BE5EB5DB2140480B00E0826C /* ICU.dat */ = {isa = PBXFileReference; lastKnownFileType = file; name = ICU.dat; path = ../../../ICU.dat; sourceTree = "<group>"; };
@@ -2215,6 +2217,7 @@
 				BE484B71228D8622001EE76C /* DocumentBroker.hpp */,
 				BE5EB5D12140039100E0826C /* COOLWSD.cpp */,
 				BE5EB5D12140039100E0826D /* ClientRequestDispatcher.cpp */,
+				BE5EB5E621401E0F00E0826C /* RequestVettingStation.cpp */,
 				BE5EB5D521401E0F00E0826C /* Storage.cpp */,
 				BE5EB5CD213FE2D000E0826C /* TileCache.cpp */,
 			);
@@ -3668,6 +3671,8 @@
 				BE5EB5C5213FE29900E0826C /* MessageQueue.cpp in Sources */,
 				BE7228E22417BC9F000ADABD /* StringVector.cpp in Sources */,
 				BE55E0EB2653FCCB007DDF29 /* ConfigUtil.cpp in Sources */,
+				BE5EB5E721401E0F00E0826C /* RequestVettingStation.cpp in Sources */,
+				BE5EB5F821401E0F00E0826C /* Storage.cpp in Sources */,
 				BE5EB5D621401E0F00E0826C /* Storage.cpp in Sources */,
 				BEA2835621467FDD00848631 /* Kit.cpp in Sources */,
 				BE8D77322136762500AC58EA /* DocumentViewController.mm in Sources */,

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -4138,7 +4138,6 @@ int COOLWSD::innerMain()
     std::string version, hash;
     Util::getVersionInfo(version, hash);
     LOG_INF("Coolwsd version details: " << version << " - " << hash << " - id " << Util::getProcessIdentifier() << " - on " << Util::getLinuxVersion());
-
 #endif
 
     initializeSSL();

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -147,6 +147,7 @@ using Poco::Net::PartHandler;
 
 #include <common/SigUtil.hpp>
 
+#include <RequestVettingStation.hpp>
 #include <ServerSocket.hpp>
 
 #if MOBILEAPP

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -62,6 +62,7 @@
 #include <chrono>
 #include <iostream>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <regex>
 #include <sstream>

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -50,6 +50,7 @@
 #include <Poco/SAX/InputSource.h>
 
 #include <map>
+#include <memory>
 #include <string>
 
 std::map<std::string, std::string> ClientRequestDispatcher::StaticFileContentCache;
@@ -1635,16 +1636,14 @@ void ClientRequestDispatcher::handleClientWsUpgrade(const Poco::Net::HTTPRequest
 #endif
         }
 
-        auto rvs =
-            std::make_shared<RequestVettingStation>(COOLWSD::getWebServerPoll(), requestDetails);
-        _requestVettingStations.emplace(_id, rvs);
+        _rvs = std::make_shared<RequestVettingStation>(COOLWSD::getWebServerPoll(), requestDetails);
 
         // Indicate to the client that document broker is searching.
         static constexpr const char* const status = "statusindicator: find";
         LOG_TRC("Sending to Client [" << status << ']');
         ws->sendMessage(status);
 
-        rvs->handleRequest(_id, ws, socket, mobileAppDocId, disposition);
+        _rvs->handleRequest(_id, ws, socket, mobileAppDocId, disposition);
     }
     catch (const std::exception& exc)
     {

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -556,8 +556,9 @@ void ClientRequestDispatcher::handleIncomingMessage(SocketDisposition& dispositi
             }
             else
             {
-                COOLWSD::FileRequestHandler->handleRequest(request, requestDetails, message,
-                                                           socket);
+                FileServerRequestHandler::ResourceAccessDetails accessDetails;
+                COOLWSD::FileRequestHandler->handleRequest(request, requestDetails, message, socket,
+                                                           accessDetails);
                 socket->shutdown();
             }
         }

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -1635,10 +1635,16 @@ void ClientRequestDispatcher::handleClientWsUpgrade(const Poco::Net::HTTPRequest
 #endif
         }
 
-        auto rvs = std::make_shared<RequestVettingStation>(_id, ws, requestDetails, socket,
-                                                           mobileAppDocId);
+        auto rvs =
+            std::make_shared<RequestVettingStation>(COOLWSD::getWebServerPoll(), requestDetails);
         _requestVettingStations.emplace(_id, rvs);
-        rvs->handleRequest(*COOLWSD::getWebServerPoll(), disposition);
+
+        // Indicate to the client that document broker is searching.
+        static constexpr const char* const status = "statusindicator: find";
+        LOG_TRC("Sending to Client [" << status << ']');
+        ws->sendMessage(status);
+
+        rvs->handleRequest(_id, ws, socket, mobileAppDocId, disposition);
     }
     catch (const std::exception& exc)
     {

--- a/wsd/ClientRequestDispatcher.hpp
+++ b/wsd/ClientRequestDispatcher.hpp
@@ -11,14 +11,13 @@
 
 #pragma once
 
+#include <RequestVettingStation.hpp>
 #include <RequestDetails.hpp>
 #include <Socket.hpp>
 #include <WopiProxy.hpp>
 
 #include <string>
 #include <memory>
-
-class WopiProxy;
 
 /// Handles incoming connections and dispatches to the appropriate handler.
 class ClientRequestDispatcher final : public SimpleSocketHandler
@@ -113,6 +112,10 @@ private:
 
     /// WASM document request handler. Used only when WASM is enabled.
     std::unique_ptr<WopiProxy> _wopiProxy;
+
+    /// External requests are first vetted before allocating DocBroker and Kit process.
+    /// This is a map of the request URI to the RequestVettingStation for vetting.
+    std::unordered_map<std::string, std::shared_ptr<RequestVettingStation>> _requestVettingStations;
 
     /// Cache for static files, to avoid reading and processing from disk.
     static std::map<std::string, std::string> StaticFileContentCache;

--- a/wsd/ClientRequestDispatcher.hpp
+++ b/wsd/ClientRequestDispatcher.hpp
@@ -119,7 +119,8 @@ private:
 
     /// External requests are first vetted before allocating DocBroker and Kit process.
     /// This is a map of the request URI to the RequestVettingStation for vetting.
-    std::unordered_map<std::string, std::shared_ptr<RequestVettingStation>> _requestVettingStations;
+    static std::unordered_map<std::string, std::shared_ptr<RequestVettingStation>>
+        RequestVettingStations;
 
     /// Cache for static files, to avoid reading and processing from disk.
     static std::map<std::string, std::string> StaticFileContentCache;

--- a/wsd/ClientRequestDispatcher.hpp
+++ b/wsd/ClientRequestDispatcher.hpp
@@ -113,6 +113,10 @@ private:
     /// WASM document request handler. Used only when WASM is enabled.
     std::unique_ptr<WopiProxy> _wopiProxy;
 
+    /// The private RequestVettingStation. Held privately after the
+    /// WS is created and as long as it is connected.
+    std::shared_ptr<RequestVettingStation> _rvs;
+
     /// External requests are first vetted before allocating DocBroker and Kit process.
     /// This is a map of the request URI to the RequestVettingStation for vetting.
     std::unordered_map<std::string, std::shared_ptr<RequestVettingStation>> _requestVettingStations;

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -853,8 +853,7 @@ bool DocumentBroker::download(const std::shared_ptr<ClientSession>& session,
     {
         LOG_DBG("CheckFileInfo for docKey [" << _docKey << ']');
         std::chrono::steady_clock::time_point start = std::chrono::steady_clock::now();
-        if (!wopiFileInfo)
-            wopiFileInfo = wopiStorage->getWOPIFileInfo(session->getAuthorization(), *_lockCtx);
+        wopiStorage->handleWOPIFileInfo(*wopiFileInfo, *_lockCtx);
 
         checkFileInfoCallDurationMs = std::chrono::duration_cast<std::chrono::milliseconds>(
             std::chrono::steady_clock::now() - start);

--- a/wsd/FileServer.hpp
+++ b/wsd/FileServer.hpp
@@ -72,15 +72,40 @@ inline std::ostream& operator<<(std::ostream& os, const PreProcessedFile::Segmen
 /// Handles file requests over HTTP(S).
 class FileServerRequestHandler
 {
+public:
+    /// The WOPI URL and authentication details,
+    /// as extracted from the cool.html file-serving request.
+    class ResourceAccessDetails
+    {
+    public:
+        ResourceAccessDetails() = default;
+
+        ResourceAccessDetails(std::string wopiSrc, std::string accessToken)
+            : _wopiSrc(std::move(wopiSrc))
+            , _accessToken(std::move(accessToken))
+        {
+        }
+
+        bool isValid() const { return !_wopiSrc.empty() && !_accessToken.empty(); }
+
+        const std::string wopiSrc() const { return _wopiSrc; }
+        const std::string accessToken() const { return _accessToken; }
+
+    private:
+        std::string _wopiSrc;
+        std::string _accessToken;
+    };
+
+private:
     friend class FileServeTests; // for unit testing
 
     static std::string getRequestPathname(const Poco::Net::HTTPRequest& request,
                                           const RequestDetails& requestDetails);
 
-    static void preprocessFile(const Poco::Net::HTTPRequest& request,
-                               const RequestDetails &requestDetails,
-                               Poco::MemoryInputStream& message,
-                               const std::shared_ptr<StreamSocket>& socket);
+    static ResourceAccessDetails preprocessFile(const Poco::Net::HTTPRequest& request,
+                                                const RequestDetails& requestDetails,
+                                                Poco::MemoryInputStream& message,
+                                                const std::shared_ptr<StreamSocket>& socket);
     static void preprocessWelcomeFile(const Poco::Net::HTTPRequest& request,
                                       const RequestDetails &requestDetails,
                                       Poco::MemoryInputStream& message,
@@ -113,9 +138,10 @@ public:
     static bool isAdminLoggedIn(const Poco::Net::HTTPRequest& request, http::Response& response);
 
     static void handleRequest(const Poco::Net::HTTPRequest& request,
-                              const RequestDetails &requestDetails,
+                              const RequestDetails& requestDetails,
                               Poco::MemoryInputStream& message,
-                              const std::shared_ptr<StreamSocket>& socket);
+                              const std::shared_ptr<StreamSocket>& socket,
+                              ResourceAccessDetails& accessDetails);
 
     static void readDirToHash(const std::string &basePath, const std::string &path, const std::string &prefix = std::string());
 

--- a/wsd/RequestDetails.hpp
+++ b/wsd/RequestDetails.hpp
@@ -133,6 +133,14 @@ public:
     RequestDetails(Poco::Net::HTTPRequest &request, const std::string& serviceRoot);
     RequestDetails(const std::string &mobileURI);
 
+    /// Constructs from its components.
+    /// wopiSrc is typically encoded.
+    /// options are in the form of 'x=y' strings.
+    /// compat is in the form of '/sessionId/command/serial' string. Optional.
+    /// /cool/<encoded-document-URI+options>/ws?WOPISrc=<encoded-document-URI>&compat=/ws[/<sessionId>/<command>/<serial>]
+    RequestDetails(const std::string& wopiSrc, const std::vector<std::string>& options,
+                   const std::string& compat);
+
     /// Decode and sanitize a URI.
     static Poco::URI sanitizeURI(const std::string& uri);
 

--- a/wsd/RequestDetails.hpp
+++ b/wsd/RequestDetails.hpp
@@ -154,12 +154,48 @@ public:
     /// Returns false if the WOPISrc is not encoded correctly.
     static bool validateWOPISrc(const std::string& uri) { return !Util::needsURIEncoding(uri); }
 
+    /// This is a per-document, per-user request key.
+    /// If a user makes two requests on the same document at the same time,
+    /// they will have the same request-key and we won't differentiate between them.
+    static std::string getRequestKey(const std::string& wopiSrc, const std::string& accessToken)
+    {
+        const std::string decodedWopiSrc = Util::decodeURIComponent(wopiSrc);
+        const Poco::URI wopiSrcSanitized = RequestDetails::sanitizeURI(decodedWopiSrc);
+
+        std::string requestKey = RequestDetails::getDocKey(wopiSrcSanitized);
+        requestKey += '_';
+        requestKey += accessToken;
+
+        return requestKey;
+    }
+
+    /// This is a per-document, per-user request key.
+    std::string getRequestKey() const
+    {
+        const std::string wopiSrc = getField(RequestDetails::Field::WOPISrc);
+        if (!wopiSrc.empty())
+        {
+            std::string accessToken;
+            getParamByName("access_token", accessToken);
+
+            return getRequestKey(wopiSrc, accessToken);
+        }
+
+        return std::string();
+    }
+
     // matches the WOPISrc if used. For load balancing
     // must be 2nd element in the path after /cool/<here>
     std::string getLegacyDocumentURI() const { return getField(Field::LegacyDocumentURI); }
 
     /// The DocumentURI, decoded. Doesn't contain WOPISrc or any other appendages.
     std::string getDocumentURI() const { return getField(Field::DocumentURI); }
+
+    /// Returns the document-specific key from the DocumentURI.
+    std::string getDocKey() const
+    {
+        return RequestDetails::getDocKey(RequestDetails::sanitizeURI(getDocumentURI()));
+    }
 
     /// The DocumentURI, decoded and sanitized. Doesn't contain WOPISrc or any other appendages.
     std::string getDocumentURISanitized() const

--- a/wsd/RequestVettingStation.cpp
+++ b/wsd/RequestVettingStation.cpp
@@ -56,19 +56,10 @@ void RequestVettingStation::handleRequest(const std::string& id)
 
     const std::string url = _requestDetails.getDocumentURI();
 
-    LOG_INF("URL [" << url << "] will be proactively vetted");
     const auto uriPublic = RequestDetails::sanitizeURI(url);
     const auto docKey = RequestDetails::getDocKey(uriPublic);
     const std::string fileId = Util::getFilenameFromURL(docKey);
     Util::mapAnonymized(fileId, fileId); // Identity mapping, since fileId is already obfuscated
-
-    LOG_INF("Starting GET request handler for session [" << _id << "] on url ["
-                                                         << COOLWSD::anonymizeUrl(url) << ']');
-
-    LOG_INF("Sanitized URI [" << COOLWSD::anonymizeUrl(url) << "] to ["
-                              << COOLWSD::anonymizeUrl(uriPublic.toString())
-                              << "] and mapped to docKey [" << docKey << "] for session [" << _id
-                              << ']');
 
     // Check if readonly session is required
     bool isReadOnly = false;
@@ -81,8 +72,11 @@ void RequestVettingStation::handleRequest(const std::string& id)
         }
     }
 
-    LOG_INF("URL [" << COOLWSD::anonymizeUrl(url) << "] is "
-                    << (isReadOnly ? "readonly" : "writable"));
+    LOG_INF("URL [" << COOLWSD::anonymizeUrl(url)
+                    << "] will be proactively vetted. Sanitized uriPublic: ["
+                    << COOLWSD::anonymizeUrl(uriPublic.toString()) << "], docKey: [" << docKey
+                    << "], session: [" << _id << "], fileId: [" << fileId << "] "
+                    << (isReadOnly ? "(readonly)" : "(writable)"));
 
     // Before we create DocBroker with a SocketPoll thread, a ClientSession, and a Kit process,
     // we need to vet this request by invoking CheckFileInfo.
@@ -135,19 +129,10 @@ void RequestVettingStation::handleRequest(const std::string& id,
 
     const std::string url = _requestDetails.getDocumentURI();
 
-    LOG_INF("URL [" << url << "] for WS Request.");
     const auto uriPublic = RequestDetails::sanitizeURI(url);
     const auto docKey = RequestDetails::getDocKey(uriPublic);
     const std::string fileId = Util::getFilenameFromURL(docKey);
     Util::mapAnonymized(fileId, fileId); // Identity mapping, since fileId is already obfuscated
-
-    LOG_INF("Starting GET request handler for session [" << _id << "] on url ["
-                                                         << COOLWSD::anonymizeUrl(url) << ']');
-
-    LOG_INF("Sanitized URI [" << COOLWSD::anonymizeUrl(url) << "] to ["
-                              << COOLWSD::anonymizeUrl(uriPublic.toString())
-                              << "] and mapped to docKey [" << docKey << "] for session [" << _id
-                              << ']');
 
     // Check if readonly session is required
     bool isReadOnly = false;
@@ -160,8 +145,10 @@ void RequestVettingStation::handleRequest(const std::string& id,
         }
     }
 
-    LOG_INF("URL [" << COOLWSD::anonymizeUrl(url) << "] is "
-                    << (isReadOnly ? "readonly" : "writable"));
+    LOG_INF("URL [" << COOLWSD::anonymizeUrl(url) << "] for WS Request. Sanitized uriPublic: ["
+                    << COOLWSD::anonymizeUrl(uriPublic.toString()) << "], docKey: [" << docKey
+                    << "], session: [" << _id << "], fileId: [" << fileId << "] "
+                    << (isReadOnly ? "(readonly)" : "(writable)"));
 
     // Before we create DocBroker with a SocketPoll thread, a ClientSession, and a Kit process,
     // we need to vet this request by invoking CheckFileInfo.

--- a/wsd/RequestVettingStation.hpp
+++ b/wsd/RequestVettingStation.hpp
@@ -66,8 +66,11 @@ public:
                        SocketDisposition& disposition);
 
 private:
-    void createDocBroker(const std::string& docKey, const std::string& url,
-                         const Poco::URI& uriPublic, const bool isReadOnly);
+    bool createDocBroker(const std::string& docKey, const std::string& url,
+                         const Poco::URI& uriPublic);
+
+    void createClientSession(const std::string& docKey, const std::string& url,
+                             const Poco::URI& uriPublic, const bool isReadOnly);
 
 #if !MOBILEAPP
     void checkFileInfo(const std::string& url, const Poco::URI& uriPublic,
@@ -89,5 +92,5 @@ private:
     unsigned _mobileAppDocId;
     CFIState _cfiState;
     Poco::JSON::Object::Ptr _wopiInfo;
-    LockContext _lockCtx;
+    std::shared_ptr<DocumentBroker> _docBroker;
 };

--- a/wsd/RequestVettingStation.hpp
+++ b/wsd/RequestVettingStation.hpp
@@ -36,8 +36,7 @@ public:
 
 private:
     void createDocBroker(const std::string& docKey, const std::string& url,
-                         const Poco::URI& uriPublic, const bool isReadOnly,
-                         Poco::JSON::Object::Ptr wopiInfo = nullptr);
+                         const Poco::URI& uriPublic, const bool isReadOnly);
 
 #if !MOBILEAPP
     void checkFileInfo(const std::string& url, const Poco::URI& uriPublic,
@@ -57,6 +56,6 @@ private:
     std::shared_ptr<StreamSocket> _socket;
     std::shared_ptr<http::Session> _httpSession;
     unsigned _mobileAppDocId;
-    std::unique_ptr<WopiStorage::WOPIFileInfo> _wopiInfo;
+    Poco::JSON::Object::Ptr _wopiInfo;
     LockContext _lockCtx;
 };

--- a/wsd/RequestVettingStation.hpp
+++ b/wsd/RequestVettingStation.hpp
@@ -9,6 +9,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#pragma once
+
 #include "RequestDetails.hpp"
 #include <Storage.hpp>
 #include "WebSocketHandler.hpp"

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -704,17 +704,11 @@ public:
                 << COOLWSD::anonymizeUrl(uri.toString()) << ']');
     }
 
-    /// Returns the response of CheckFileInfo WOPI call for URI that was
-    /// provided during the initial creation of the WOPI storage.
+    /// Handles the response from CheckFileInfo, as converted into WOPIFileInfo.
     /// Also extracts the basic file information from the response
     /// which can then be obtained using getFileInfo()
     /// Also sets up the locking context for future operations.
-    std::unique_ptr<WOPIFileInfo> getWOPIFileInfo(const Authorization& auth, LockContext& lockCtx);
-    /// Implementation of getWOPIFileInfo for specific URI
-    std::unique_ptr<WOPIFileInfo> getWOPIFileInfoForUri(Poco::URI uriObject,
-                                                        const Authorization& auth,
-                                                        LockContext& lockCtx,
-                                                        unsigned redirectLimit);
+    void handleWOPIFileInfo(const WOPIFileInfo& wopiFileInfo, LockContext& lockCtx);
 
     /// Update the locking state (check-in/out) of the associated file
     LockUpdateResult updateLockState(const Authorization& auth, LockContext& lockCtx, bool lock,


### PR DESCRIPTION
- wsd: use RequestVettingStation for async loading
- wsd: restructure RequestVettingStation interface 
- wsd: use a single shared_ptr instead of container for RequestVettingS… 
- wsd: extract ResourceAccessDetails from cool.html file request 
- wsd: make wopiInfo a member of RequestVettingStation 
- wsd: RequestDetails from document-load URI components 
- wsd: parallel load with cool.html 
- wsd: better logging in RequestVettingStation::handleRequest 
- wsd: split createDocBroker into createClientSession