### PR TITLE
fix linking error for clang 17

### DIFF
--- a/kit/TestStubs.cpp
+++ b/kit/TestStubs.cpp
@@ -21,6 +21,7 @@
 
 void ChildSession::loKitCallback(const int /* type */, const std::string& /* payload */) {}
 void ChildSession::disconnect() {}
+int ChildSession::getSpeed() { return 0; }
 bool ChildSession::_handleInput(const char* /*buffer*/, int /*length*/) { return false; }
 bool ChildSession::isTileInsideVisibleArea(const TileDesc& /*tile*/) const { return false; }
 ChildSession::~ChildSession() {}


### PR DESCRIPTION
CXXLD    unittest
/usr/bin/ld: ../kit/unittest-Kit.o: in function
`Document::updateEditorSpeeds(int, int)':
/opt/shared/work/libreoffice/repo-online/online-cl/test/../kit/Kit.cpp:1488:(.text._ZN8Document18updateEditorSpeedsEii[_ZN8Document18updateEditorSpeedsEii]+0x2d9):
undefined reference to `ChildSession::getSpeed()'

Signed-off-by: Marco Cecchetti <marco.cecchetti@collabora.com>
Change-Id: If95662647d33f80dd98013b6bc81be897dd6ffc5
