### PR TITLE
Close autofilter popovers when click or change the sheet tab

### DIFF
--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -29,6 +29,7 @@ L.Control.JSDialog = L.Control.extend({
 		this.map.on('jsdialogaction', this.onJSAction, this);
 		this.map.on('zoomend', this.onZoomEnd, this);
 		this.map.on('closealldialogs', this.onCloseAll, this);
+		this.map.on('closeAutoFilterDialog', this.closeAutoFilterDialogsOnTabChange, this);
 	},
 
 	onRemove: function() {
@@ -37,6 +38,7 @@ L.Control.JSDialog = L.Control.extend({
 		this.map.off('jsdialogaction', this.onJSAction, this);
 		this.map.off('zoomend', this.onZoomEnd, this);
 		this.map.off('closealldialogs', this.onCloseAll, this);
+		this.map.off('closeAutoFilterDialog', this.closeAutoFilterDialogsOnTabChange, this);
 	},
 
 	hasDialogOpened: function() {
@@ -588,6 +590,22 @@ L.Control.JSDialog = L.Control.extend({
 			instance.posy = window.innerHeight - height;
 
 		this.updatePosition(instance.container, instance.posx, instance.posy);
+	},
+
+	closeAutoFilterDialogsOnTabChange: function() {
+		//this.dialogs is an object
+		var dialogKeys = Object.keys(this.dialogs);
+
+		for (var i = 0; i < dialogKeys.length; i++) {
+			var autoFilterDialogId = dialogKeys[i];
+			var dialog = this.dialogs[autoFilterDialogId];
+
+			// Check if the current dialog has the isAutofilter property set to true
+			if (dialog.isAutofilter) {
+				// Call this.close(key, true) for the current dialog
+				this.close(autoFilterDialogId, true);
+			}
+		}
 	},
 
 	onJSDialog: function(e) {

--- a/browser/src/control/Control.Tabs.js
+++ b/browser/src/control/Control.Tabs.js
@@ -259,6 +259,8 @@ L.Control.Tabs = L.Control.extend({
 				var part =  parseInt(key.match(/\d+/g)[0]);
 				L.DomUtil.removeClass(this._spreadsheetTabs[key], 'spreadsheet-tab-selected');
 				if (part === selectedPart) {
+					// close auto filter popups on sheet tab selected
+					this._map.fire('closeAutoFilterDialog');
 					L.DomUtil.addClass(this._spreadsheetTabs[key], 'spreadsheet-tab-selected');
 				}
 			}


### PR DESCRIPTION
- jsdialog not getting close when we change tab
- this will close all dialogs when we click on tab or change the tab

To test this patch
    - add 2 or 3 tab sheet in calc
    - add `autofilter` in any calc sheet tab
    - open autofilter popup
    - change sheet tab

Before this patch:
    - popup not getting close when focus goes away.

After: - all dialogs should be closed now when change the sheet tab.

Change-Id: I4eb308e499853a6e1d86b8dc7f60aa938e9c03b9

