### PR TITLE
Small tooltip refactor

### DIFF
--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -1017,6 +1017,29 @@ L.Control.UIManager = L.Control.extend({
 		this.map.fire('hidebusy');
 	},
 
+	// Document area tooltip
+
+	/// Shows tooltip in the document area
+	/// tooltipInfo contains rectangle (position in twips) and text properties
+	/// elem has to be jQuery selector output eg. $('.leaflet-layer')
+	showDocumentTooltip: function(tooltipInfo, elem) {
+		var split = tooltipInfo.rectangle.split(',');
+		var latlng = this.map._docLayer._twipsToLatLng(new L.Point(+split[0], +split[1]));
+		var pt = this.map.latLngToContainerPoint(latlng);
+
+		elem.tooltip();
+		elem.tooltip('enable');
+		elem.tooltip('option', 'content', tooltipInfo.text);
+		elem.tooltip('option', 'items', elem[0]);
+		elem.tooltip('option', 'position', { my: 'left bottom',  at: 'left+' + pt.x + ' top+' + pt.y, collision: 'fit fit' });
+		elem.tooltip('open');
+		document.addEventListener('mousemove', function closeTooltip() {
+			elem.tooltip('close');
+			elem.tooltip('disable');
+			document.removeEventListener('mousemove', closeTooltip);
+		});
+	},
+
 	// Snack bar
 
 	closeSnackbar: function() {

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -1033,11 +1033,10 @@ L.Control.UIManager = L.Control.extend({
 		elem.tooltip('option', 'items', elem[0]);
 		elem.tooltip('option', 'position', { my: 'left bottom',  at: 'left+' + pt.x + ' top+' + pt.y, collision: 'fit fit' });
 		elem.tooltip('open');
-		document.addEventListener('mousemove', function closeTooltip() {
+		document.addEventListener('mousemove', function() {
 			elem.tooltip('close');
 			elem.tooltip('disable');
-			document.removeEventListener('mousemove', closeTooltip);
-		});
+		}, {once: true});
 	},
 
 	// Snack bar

--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -1160,7 +1160,7 @@ app.definitions.Socket = L.Class.extend({
 		}
 		else if (textMsg.startsWith('tooltip: ')) {
 			var tooltipInfo = JSON.parse(textMsg.substring(textMsg.indexOf('{')));
-			this._map.showDocumentTooltip(tooltipInfo, $('.leaflet-layer'));
+			this._map.uiManager.showDocumentTooltip(tooltipInfo, $('.leaflet-layer'));
 		}
 		else if (!textMsg.startsWith('tile:') && !textMsg.startsWith('delta:') &&
 			 !textMsg.startsWith('renderfont:') && !textMsg.startsWith('windowpaint:')) {

--- a/browser/src/map/Map.js
+++ b/browser/src/map/Map.js
@@ -424,24 +424,6 @@ L.Map = L.Evented.extend({
 		}
 	},
 
-	showDocumentTooltip: function(tooltipInfo, elem) {
-		var split = tooltipInfo.rectangle.split(',');
-		var latlng = this._docLayer._twipsToLatLng(new L.Point(+split[0], +split[1]));
-		var pt = this.latLngToContainerPoint(latlng);
-
-		elem.tooltip();
-		elem.tooltip('enable');
-		elem.tooltip('option', 'content', tooltipInfo.text);
-		elem.tooltip('option', 'items', elem[0]);
-		elem.tooltip('option', 'position', { my: 'left bottom',  at: 'left+' + pt.x + ' top+' + pt.y, collision: 'fit fit' });
-		elem.tooltip('open');
-		document.addEventListener('mousemove', function closeTooltip() {
-			elem.tooltip('close');
-			elem.tooltip('disable');
-			document.removeEventListener('mousemove', closeTooltip);
-		});
-	},
-
 	updateModificationIndicator: function(newModificationTime) {
 		var timeout;
 


### PR DESCRIPTION
Use once to call event handler just one time
    
    Use dedicated option, don't do it manually.
    
    https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#once

-----------------------------------------------------

Move document tooltip helper to UIManager
    
    so it is with all other showXXXX helpers