### PR TITLE
common: fix 0 read size in FileUtil::readFile()

### DIFF
--- a/common/FileUtil.cpp
+++ b/common/FileUtil.cpp
@@ -445,6 +445,12 @@ namespace FileUtil
         off_t off = 0;
         for (;;)
         {
+            if (st.st_size == 0)
+            {
+                // Nothing to read.
+                break;
+            }
+
             int n;
             while ((n = ::read(fd, &(*data)[off], st.st_size)) < 0 && errno == EINTR)
             {


### PR DESCRIPTION
/usr/bin/../lib64/gcc/x86_64-suse-linux/12/../../../../include/c++/12/bits/stl_vector.h:1124:9: runtime error: reference binding to null pointer of type 'char'
    #0 0x557ce8c06055 in std::vector<char, std::allocator<char>>::operator[](unsigned long) /usr/bin/../lib64/gcc/x86_64-suse-linux/12/../../../../include/c++/12/bits/stl_vector.h:1124:2
    #1 0x557ce8f16e3f in FileUtil::readFile(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, int) /home/vmiklos/git/collaboraonline/online-23.05-san/test/../common/FileUtil.cpp:449:37

While running toplevel 'make'. Both 'st.st_size' and 'off' were 0, so
this is an edge case.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I4899bffa48a761c84b6ee7d42776453b641ff5a7
