### PR TITLE
widgets: combobox border-radius handle rtl languages

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -784,7 +784,8 @@ input[type='number']:hover::-webkit-outer-spin-button {
 .ui-combobox-content {
 	width: 100%;
 	border: none;
-	border-radius: var(--border-radius) 0px 0px var(--border-radius);
+	border-start-start-radius: var(--border-radius);
+	border-end-start-radius: var(--border-radius);
 	color: var(--color-text-dark);
 	background-color: var(--color-background-lighter);
 }


### PR DESCRIPTION
Change-Id: Ib9c6d8e972ff061223af4fa96a63b8e96d21e772

* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

Before:

![image](https://github.com/CollaboraOnline/online/assets/620941/6c94cd92-3640-4a4f-96bc-7a41dbbcaef4)


After:
![image](https://github.com/CollaboraOnline/online/assets/620941/28db1503-ca05-4290-961d-c93467d64af2)

No changes for ltr languages

Follow-up to https://github.com/CollaboraOnline/online/pull/8024

### Checklist

- [x ] Code is properly formatted
- [x ] All commits have Change-Id
- [x ] I have issued `make run` and manually verified that everything looks okay

