### PR TITLE
private/vmiklos/backport 23.05

### DIFF
--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -60,14 +60,18 @@ L.Clipboard = L.Class.extend({
 		document.onbeforepaste = beforeSelect;
 	},
 
-	// We can do a much better job when we fetch text/plain too.
-	stripHTML: function(html) {
-		var tmp = new DOMParser().parseFromString(html, 'text/html').body;
-		// attempt to cleanup unwanted elements
-		var styles = tmp.querySelectorAll('style');
+	// Attempt to cleanup unwanted elements
+	stripStyle: function(domNode) {
+		var styles = domNode.querySelectorAll('style');
 		for (var i = 0; i < styles.length; i++) {
 			styles[i].parentNode.removeChild(styles[i]);
 		}
+	},
+
+	// We can do a much better job when we fetch text/plain too.
+	stripHTML: function(html) {
+		var tmp = new DOMParser().parseFromString(html, 'text/html').body;
+		this.stripStyle(tmp);
 		return tmp.textContent.trim() || tmp.innerText.trim() || '';
 	},
 
@@ -793,7 +797,9 @@ L.Clipboard = L.Class.extend({
 	// textselectioncontent: message
 	setTextSelectionHTML: function(html) {
 		this._selectionType = 'text';
-		this._selectionContent = html;
+		var tmp = new DOMParser().parseFromString(html, 'text/html').body;
+		this.stripStyle(tmp);
+		this._selectionContent = tmp.innerHTML;
 		if (L.Browser.cypressTest) {
 			this._dummyDiv.innerHTML = html;
 		}

--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -117,37 +117,36 @@ L.Clipboard = L.Class.extend({
 
 	// wrap some content with our stub magic
 	_originWrapBody: function(body, isStub) {
+		var lang = 'en_US'; // FIXME: l10n
 		var encodedOrigin = encodeURIComponent(this.getMetaURL());
 		var text =  '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">\n' +
-		            '<div id="meta-origin" data-coolorigin="' + encodedOrigin + '"><html>\n' +
+		            '<html>\n' +
 		            '  <head>\n';
 		if (isStub)
 			text += '    ' + this._getHtmlStubMarker() + '\n';
 		text +=     '    <meta http-equiv="content-type" content="text/html; charset=utf-8"/>\n' +
 			    '    <meta name="origin" content="' + encodedOrigin + '"/>\n' +
-			    '  </head>\n'
-			    + body +
-			'</html></div>';
+			    '  </head>\n' +
+			    '  <body lang="' + lang + '" dir="ltr"><div id="meta-origin" data-coolorigin="' + encodedOrigin + '">\n' +
+			    body +
+			    '  </div></body>\n' +
+			'</html>';
 		return text;
 	},
 
 	// what an empty clipboard has on it
 	_getStubHtml: function() {
-		var lang = 'en_US'; // FIXME: l10n
 		return this._substProductName(this._originWrapBody(
-		    '  <body lang="' + lang + '" dir="ltr">\n' +
-		    '    <p>' + _('To paste outside %productName, please first click the \'download\' button') + '</p>\n' +
-		    '  </body>\n', true
+		    '    <p>' + _('To paste outside %productName, please first click the \'download\' button') + '</p>\n',
+		    true
 		));
 	},
 
 	// used for DisableCopy mode to fill the clipboard
 	_getDisabledCopyStubHtml: function() {
-		var lang = 'en_US'; // FIXME: l10n
 		return this._substProductName(this._originWrapBody(
-		    '  <body lang="' + lang + '" dir="ltr">\n' +
-		    '    <p>' + _('Copying from the document disabled') + '</p>\n' +
-		    '  </body>\n', true
+		    '    <p>' + _('Copying from the document disabled') + '</p>\n',
+		    true
 		));
 	},
 
@@ -797,9 +796,7 @@ L.Clipboard = L.Class.extend({
 	// textselectioncontent: message
 	setTextSelectionHTML: function(html) {
 		this._selectionType = 'text';
-		var tmp = new DOMParser().parseFromString(html, 'text/html').body;
-		this.stripStyle(tmp);
-		this._selectionContent = tmp.innerHTML;
+		this._selectionContent = html;
 		if (L.Browser.cypressTest) {
 			this._dummyDiv.innerHTML = html;
 		}
@@ -817,8 +814,7 @@ L.Clipboard = L.Class.extend({
 			return;
 		}
 		this._selectionType = 'text';
-		this._selectionContent = this._originWrapBody(
-			'<body>' + text + '</body>');
+		this._selectionContent = this._originWrapBody(text);
 		this._scheduleHideDownload();
 	},
 

--- a/common/FileUtil.cpp
+++ b/common/FileUtil.cpp
@@ -445,6 +445,12 @@ namespace FileUtil
         off_t off = 0;
         for (;;)
         {
+            if (st.st_size == 0)
+            {
+                // Nothing to read.
+                break;
+            }
+
             int n;
             while ((n = ::read(fd, &(*data)[off], st.st_size)) < 0 && errno == EINTR)
             {

--- a/common/Util.cpp
+++ b/common/Util.cpp
@@ -978,16 +978,16 @@ namespace Util
         return http_time;
     }
 
-    std::size_t findInVector(const std::vector<char>& tokens, const char *cstring)
+    std::size_t findInVector(const std::vector<char>& tokens, const char *cstring, std::size_t offset)
     {
         assert(cstring);
-        for (std::size_t i = 0; i < tokens.size(); ++i)
+        for (std::size_t i = 0; i < tokens.size() - offset; ++i)
         {
             std::size_t j;
-            for (j = 0; i + j < tokens.size() && cstring[j] != '\0' && tokens[i + j] == cstring[j]; ++j)
+            for (j = 0; i + j < tokens.size() - offset && cstring[j] != '\0' && tokens[i + j + offset] == cstring[j]; ++j)
                 ;
             if (cstring[j] == '\0')
-                return i;
+                return i + offset;
         }
         return std::string::npos;
     }

--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -516,7 +516,7 @@ namespace Util
         return oss.str();
     }
 
-    size_t findInVector(const std::vector<char>& tokens, const char *cstring);
+    size_t findInVector(const std::vector<char>& tokens, const char *cstring, std::size_t offset = 0);
 
     /// Trim spaces from the left. Just spaces.
     inline std::string& ltrim(std::string& s)

--- a/test/WhiteBoxTests.cpp
+++ b/test/WhiteBoxTests.cpp
@@ -70,6 +70,7 @@ class WhiteBoxTests : public CPPUNIT_NS::TestFixture
 #if ENABLE_DEBUG
     CPPUNIT_TEST(testUtf8);
 #endif
+    CPPUNIT_TEST(testFindInVector);
     CPPUNIT_TEST_SUITE_END();
 
     void testCOOLProtocolFunctions();
@@ -100,6 +101,7 @@ class WhiteBoxTests : public CPPUNIT_NS::TestFixture
     void testBytesToHex();
     void testJsonUtilEscapeJSONValue();
     void testUtf8();
+    void testFindInVector();
 };
 
 void WhiteBoxTests::testCOOLProtocolFunctions()
@@ -1382,6 +1384,28 @@ void WhiteBoxTests::testUtf8()
     LOK_ASSERT(Util::isValidUtf8("🏃 is not 🏊."));
     LOK_ASSERT(!Util::isValidUtf8("\xff\x03"));
 #endif
+}
+
+void WhiteBoxTests::testFindInVector()
+{
+    constexpr auto testname = __func__;
+    std::string s("fooBarfooBaz");
+    std::vector<char> v(s.begin(), s.end());
+
+    // Normal case, we find the first "foo".
+    std::size_t ret = Util::findInVector(v, "foo");
+    std::size_t expected = 0;
+    LOK_ASSERT_EQUAL(expected, ret);
+
+    // Offset, so we find the second "foo".
+    ret = Util::findInVector(v, "foo", 1);
+    expected = 6;
+    LOK_ASSERT_EQUAL(expected, ret);
+
+    // Negative testing.
+    ret = Util::findInVector(v, "blah");
+    expected = std::string::npos;
+    LOK_ASSERT_EQUAL(expected, ret);
 }
 
 CPPUNIT_TEST_SUITE_REGISTRATION(WhiteBoxTests);

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -2785,6 +2785,36 @@ void ClientSession::preProcessSetClipboardPayload(std::string& payload)
         std::size_t len = end - start + 4;
         payload.erase(start, len);
     }
+
+    start = payload.find("<div id=\"meta-origin\" data-coolorigin=\"");
+    if (start != std::string::npos)
+    {
+        std::size_t end = payload.find("\">\n", start);
+        if (end == std::string::npos)
+        {
+            LOG_DBG("Found unbalanced starting meta <div> tag in setclipboard payload.");
+            return;
+        }
+
+        std::size_t len = end - start + 3;
+        payload.erase(start, len);
+
+        static int counter = 0;
+        counter++;
+        std::string path("/tmp/debug/data");
+        path += std::to_string(counter);
+        std::ofstream out(path);
+        out << payload;
+        out.close();
+        start = payload.find("</html></div>");
+        if (start == std::string::npos)
+        {
+            LOG_DBG("Found unbalanced ending meta <div> tag in setclipboard payload.");
+            return;
+        }
+
+        payload.erase(start + strlen("</html>"), strlen("</div>"));
+    }
 }
 
 std::string ClientSession::processSVGContent(const std::string& svg)

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1627,27 +1627,25 @@ void ClientSession::postProcessCopyPayload(const std::shared_ptr<Message>& paylo
 
     // New-style: <div> inside <body>, that is not sanitized by Chrome.
     payload->rewriteDataBody([=](std::vector<char>& data) {
-            const char* pos = strstr(data.data(), "<body");
-            if (pos)
+            std::size_t pos = Util::findInVector(data, "<body");
+            if (pos != std::string::npos)
             {
-                pos = strstr(pos, ">");
+                pos = Util::findInVector(data, ">", pos);
             }
 
-            if (pos)
+            if (pos != std::string::npos)
             {
                 const std::string meta = getClipboardURI();
                 LOG_TRC("Inject clipboard cool origin of '" << meta << "'");
                 std::string origin = "<div id=\"meta-origin\" data-coolorigin=\"" + meta + "\">\n";
-                size_t offset = pos - data.data();
-                data.insert(data.begin() + offset + strlen(">"), origin.begin(), origin.end());
+                data.insert(data.begin() + pos + strlen(">"), origin.begin(), origin.end());
 
                 const char* end = "</body>";
-                pos = strstr(data.data(), end);
-                if (pos)
+                pos = Util::findInVector(data, end);
+                if (pos != std::string::npos)
                 {
                     origin = "</div>";
-                    offset = pos - data.data();
-                    data.insert(data.begin() + offset, origin.begin(), origin.end());
+                    data.insert(data.begin() + pos, origin.begin(), origin.end());
                 }
                 return true;
             }

--- a/wsd/ClientSession.hpp
+++ b/wsd/ClientSession.hpp
@@ -243,6 +243,10 @@ public:
     /// Adds and/or modified the copied payload before sending on to the client.
     void postProcessCopyPayload(const std::shared_ptr<Message>& payload);
 
+    /// Removes the <meta name="origin" ...> tag which was added in
+    /// ClientSession::postProcessCopyPayload().
+    void preProcessSetClipboardPayload(std::string& payload);
+
     /// Returns true if we're expired waiting for a clipboard and should be removed
     bool staleWaitDisconnect(const std::chrono::steady_clock::time_point &now);
 
@@ -315,10 +319,6 @@ private:
 
     /// If this session is read-only because of failed lock, try to unlock and make it read-write.
     bool attemptLock(const std::shared_ptr<DocumentBroker>& docBroker);
-
-    /// Removes the <meta name="origin" ...> tag which was added in
-    /// ClientSession::postProcessCopyPayload().
-    void preProcessSetClipboardPayload(std::string& payload);
 
 private:
     std::weak_ptr<DocumentBroker> _docBroker;


### PR DESCRIPTION
- cool#8023 wsd, ClientSession: add new style clipboard marker to our HTML output
- cool#8023 wsd, ClientSession: extend HTML clipboard marker removal
- cool#8023 Remove HTML marker in unit-copy-paste
- cool#8023 browser: generate and interpret new-style clipboard marker
- cool#8023 browser: make sure 'style' content doesn't affect plain text selection
- cool#8023 clipboard: switch marker from outside-html to inside-body
- common: fix 0 read size in FileUtil::readFile()
- wsd: fix reading past the end of the clipboard in postProcessCopyPayload()
