### PR TITLE
sidebar: initialize after recover from idle

### DIFF
--- a/browser/src/map/Map.js
+++ b/browser/src/map/Map.js
@@ -295,7 +295,7 @@ L.Map = L.Evented.extend({
 				this.initializeModificationIndicator();
 
 			// Show sidebar.
-			if (this._docLayer && !this._docLoadedOnce) {
+			if (this._docLayer) {
 				// Let the first page finish loading then load the sidebar.
 				setTimeout(this.uiManager.initializeSidebar.bind(this.uiManager), 200);
 			}


### PR DESCRIPTION
After document idle (document become unloaded on the server) when we click in the popup and document was reloaded - if sidebar was present previously it should be reinitialized.

Without that it was visible but not interactive and it was not possible to hide it.

1. To test that use small timeout in the coolwsd.xml: per_document.idle_timeout_secs
2. Open sidebar
3. Wait for idle
4. Click in the idle popup

Sidebar should be interactive and it should be possible to hide it.
