### PR TITLE
Extract debug tools to new file core/Debug.js

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -206,6 +206,7 @@ COOL_JS_LST =\
 	src/core/Events.js \
 	src/core/Socket.js \
 	src/core/Matrix.js \
+	src/core/Debug.js \
 	src/geometry/Point.ts \
 	src/geometry/Bounds.ts \
 	src/geometry/Transformation.ts \
@@ -772,6 +773,7 @@ pot:
 		src/control/jsdialog/Widget.MobileBorderSelector.js \
 		src/control/jsdialog/Widget.TreeView.js \
 		src/core/Socket.js \
+		src/core/Debug.js \
 		src/docstate.js \
 		src/errormessages.js \
 		src/layer/tile/CanvasTileLayer.js \

--- a/browser/src/control/Control.LokDialog.js
+++ b/browser/src/control/Control.LokDialog.js
@@ -227,6 +227,7 @@ L.Control.LokDialog = L.Control.extend({
 		this._sendPaintWindow(id, this._createRectStr(id, x, y, width, height));
 	},
 
+	// TODO: Extract to tool in Debug.js
 	_debugPaintWindow: function(id, rectangle) {
 		var strId = this._toStrId(id);
 		var canvas = document.getElementById(strId + '-canvas');
@@ -251,7 +252,7 @@ L.Control.LokDialog = L.Control.extend({
 		//window.app.console.log('_sendPaintWindow: rectangle: ' + rectangle + ', dpiscale: ' + dpiscale);
 		app.socket.sendMessage('paintwindow ' + id + ' rectangle=' + rectangle + ' dpiscale=' + app.roundedDpiScale);
 
-		if (this._map._docLayer && this._map._docLayer._debug)
+		if (this._map._debug.debugOn)
 			this._debugPaintWindow(id, rectangle);
 	},
 

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -583,7 +583,7 @@ L.Map.include({
 
 	aboutDialogKeyHandler: function(event) {
 		if (event.key === 'd') {
-			this._docLayer.toggleDebugMode();
+			this._debug.toggle();
 		} else if (event.key === 'l') {
 			// L toggges the Online logging level between the default (whatever
 			// is set in coolwsd.xml or on the coolwsd command line) and the
@@ -615,8 +615,9 @@ L.Map.include({
 	},
 
 	aboutDialogClickHandler: function(event) {
-		if (event.detail === 3)
-			this._docLayer.toggleDebugMode();
+		if (event.detail === 3) {
+			this._debug.toggle();
+		}
 	},
 
 	showLOAboutDialog: function() {

--- a/browser/src/core/Debug.js
+++ b/browser/src/core/Debug.js
@@ -1,0 +1,673 @@
+/* -*- js-indent-level: 8; fill-column: 100 -*- */
+
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * L.DebugManager contains debugging tools and support for toggling them.
+ * Open the Debug Menu with
+ * - Ctrl+Shift+Alt+D (Map.Keyboard.js _handleCtrlCommand)
+ * - Help > About > D (Toolbar.js aboutDialogKeyHandler)
+ * - Help > About > Triple Click (Toolbar.js aboutDialogClickHandler)
+ */
+
+/* global app L */
+
+L.DebugManager = L.Class.extend({
+	initialize: function(map) {
+		this._map = map;
+		this.debugOn = false;
+	},
+
+	toggle: function() {
+		if (!this.debugOn) {
+			this._start();
+		} else {
+			this._stop();
+		}
+
+		// redraw canvas with changed debug overlays
+		this._painter.update();
+	},
+
+	_start: function() {
+		this._docLayer = this._map._docLayer;
+		this._painter = this._map._docLayer._painter;
+
+		this.debugOn = true;
+		this._controls = {};
+		this._toolLayers = [];
+		this._addDebugTools();
+
+		// Initialize state that we build in debug mode whether visible or not
+		// TODO: Associate to specific tools
+		this._debugInvalidBounds = {};
+		this._debugInvalidBoundsMessage = {};
+		this._debugId = 0;
+		this._debugLoadTile = 0;
+		this._debugLoadDelta = 0;
+		this._debugLoadUpdate = 0;
+		this._debugInvalidateCount = 0;
+		this._debugTimeKeypress = this.getTimeArray();
+		this._debugKeypressQueue = [];
+		this._debugRenderCount = 0;
+		this._debugTimePING = this.getTimeArray();
+		this._debugPINGQueue = [];
+
+		// Initialize here because tasks can add themselves to the queue even
+		// if the user is not active
+		this._automatedUserQueue = [];
+		this._automatedUserTasks = {};
+
+		// TODO: Extract to named tool
+		if (this._docLayer.isCalc()) {
+			this._painter._addSplitsSection();
+			this._painter._sectionContainer.reNewAllSections(true /* redraw */);
+		}
+	},
+
+	_stop: function() {
+		this.debugOn = false;
+
+		// Remove layers
+		for (var i in this._toolLayers) {
+			this._map.removeLayer(this._toolLayers[i]);
+		}
+
+		// Remove controls
+		for (var category in this._controls) {
+			this._controls[category].remove();
+		}
+		this._controls = {};
+
+		// TODO: Extract to named tool
+		if (this._docLayer.isCalc()) {
+			var section = this._painter._sectionContainer.getSectionWithName('calc grid');
+			if (section) {
+				section.setDrawingOrder(L.CSections.CalcGrid.drawingOrder);
+				section.sectionProperties.strokeStyle = '#c0c0c0';
+			}
+			this._painter._sectionContainer.removeSection('splits');
+			this._painter._sectionContainer.reNewAllSections(true /* redraw */);
+		}
+	},
+
+	_addDebugTool: function (tool) {
+		// Create control if it doesn't exist
+		if (!(tool.category in this._controls)) {
+			this._controls[tool.category] = L.control.layers({}, {}, {collapsed: false, sortLayers: true}).addTo(this._map);
+			// Add a title
+			var b = document.createElement('b');
+			b.append(tool.category);
+			this._controls[tool.category]._container.prepend(b);
+		}
+
+		// Create layer
+		var layer = new L.LayerGroup();
+		this._toolLayers.push(layer);
+		this._controls[tool.category]._addLayer(layer, tool.name, true);
+		this._controls[tool.category]._update();
+
+		this._map.on('layeradd', function(e) {
+			if (e.layer === layer) {
+				tool.onAdd();
+			}
+		}, this);
+		this._map.on('layerremove', function(e) {
+			if (e.layer === layer) {
+				tool.onRemove();
+			}
+		}, this);
+		if (tool.startsOn) {
+			this._map.addLayer(layer);
+		}
+	},
+
+	_addDebugTools: function () {
+		var self = this; // easier than using (function (){}).bind(this) each time
+
+		this._addDebugTool({
+			name: 'Data Overlay',
+			category: 'Display',
+			startsOn: true,
+			onAdd: function () {
+				self.overlayOn = true;
+				self.overlayData = {};
+				var names = ['canonicalViewId', 'tileCombine', 'fromKeyInputToInvalidate', 'ping', 'loadCount', 'postMessage'];
+				for (var i = 0; i < names.length; i++) {
+					self.overlayData[names[i]] = L.control.attribution({prefix: '', position: 'bottomleft'}).addTo(self._map);
+					self.overlayData[names[i]].addTo(self._map);
+				}
+				names = ['nullUpdateMetric', 'newTileMetric'];
+				for (var i = 0; i < names.length; i++) {
+					self.overlayData[names[i]] = L.control.attribution({prefix: '', position: 'topleft'}).addTo(self._map);
+					self.overlayData[names[i]].addTo(self._map);
+					self.overlayData[names[i]]._container.style.fontSize = '14px';
+				}
+			},
+			onRemove: function () {
+				self.overlayOn = false;
+				for (var i in self.overlayData) {
+					self.overlayData[i].remove();
+				}
+				delete self.overlayData;
+			},
+		});
+
+		this._addDebugTool({
+			name: 'Tile Overlays',
+			category: 'Display',
+			startsOn: false,
+			onAdd: function () {
+				self.tileOverlaysOn = true;
+				self._painter.update();
+			},
+			onRemove: function () {
+				self.tileOverlaysOn = false;
+				self._painter.update();
+			},
+		});
+
+		this._addDebugTool({
+			name: 'Tile Invalidations',
+			category: 'Display',
+			startsOn: false,
+			onAdd: function () {
+				self.tileInvalidationsOn = true;
+				self._tileInvalidationTimeout();
+				self._tileInvalidationLayer = new L.LayerGroup();
+				self._map.addLayer(self._tileInvalidationLayer);
+			},
+			onRemove: function () {
+				self.tileInvalidationsOn = false;
+				clearTimeout(self._tileInvalidationTimeoutId);
+				self._map.removeLayer(self._tileInvalidationLayer);
+				self._painter.update();
+			},
+		});
+
+		/*
+		 * Doesn't seem to do anything
+		 * TODO: Reenable
+		this._addDebugTool({
+			name: 'Always Active',
+			category: 'Functionality',
+			startsOn: false,
+			onAdd: function () {
+				self._map._debugAlwaysActive = true;
+			},
+			onRemove: function () {
+				self._map._debugAlwaysActive = false;
+			},
+		});
+		*/
+
+		this._addDebugTool({
+			name: 'Show Clipboard',
+			category: 'Display',
+			startsOn: false,
+			onAdd: function () {
+				self._map._textInput.debug(true);
+			},
+			onRemove: function () {
+				self._map._textInput.debug(false);
+			},
+		});
+
+		this._addDebugTool({
+			name: 'Tiles device pixel grid',
+			category: 'Display',
+			startsOn: false,
+			onAdd: function () {
+				self._painter._addTilePixelGridSection();
+				self._painter._sectionContainer.reNewAllSections(true);
+			},
+			onRemove: function () {
+				self._painter._sectionContainer.removeSection('tile pixel grid');
+				self._painter._sectionContainer.reNewAllSections(true);
+			},
+		});
+
+		this._addDebugTool({
+			name: 'Performance Tracing',
+			category: 'Logging',
+			startsOn: app.socket.traceEventRecordingToggle,
+			onAdd: function () {
+				app.socket.setTraceEventLogging(true);
+			},
+			onRemove: function () {
+				app.socket.setTraceEventLogging(false);
+			},
+		});
+
+		this._addDebugTool({
+			name: 'Protocol Logging',
+			category: 'Logging',
+			startsOn: true,
+			onAdd: function () {
+				window.setLogging(true);
+				L.Log.print();
+			},
+			onRemove: function () {
+				window.setLogging(false);
+			},
+		});
+
+		this._addDebugTool({
+			name: 'Tile Dumping',
+			category: 'Logging',
+			startsOn: false,
+			onAdd: function () {
+				app.socket.sendMessage('toggletiledumping true');
+			},
+			onRemove: function () {
+				app.socket.sendMessage('toggletiledumping false');
+			},
+		});
+
+		this._addDebugTool({
+			name: 'Debug Deltas',
+			category: 'Logging',
+			startsOn: false,
+			onAdd: function () {
+				self._docLayer._debugDeltas = true;
+				self._docLayer._debugDeltasDetail = true;
+			},
+			onRemove: function () {
+				self._docLayer._debugDeltas = false;
+				self._docLayer._debugDeltasDetail = false;
+			},
+		});
+
+		this._addDebugTool({
+			name: 'Typer',
+			category: 'Automated User',
+			startsOn: false,
+			onAdd: function () {
+				self._typerLorem = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.\n';
+				self._typerLoremPos = 0;
+				self._typerTimeout();
+			},
+			onRemove: function () {
+				clearTimeout(self._typerTimeoutId);
+			},
+		});
+
+		this._addDebugTool({
+			name: 'Randomize user settings',
+			category: 'Automated User',
+			startsOn: false,
+			onAdd: function () {
+				self._randomizeSettings();
+			},
+			onRemove: function () {
+				// do nothing
+			},
+		});
+
+		this._addDebugTool({
+			name: 'Automated user input',
+			category: 'Automated User',
+			startsOn: false,
+			onAdd: function () {
+				self._automatedUserTimeout();
+			},
+			onRemove: function () {
+				clearTimeout(self._automatedUserTimeoutId);
+				self._automatedUserTask = undefined;
+				self._automatedUserPhase = 0;
+			},
+		});
+
+		if (this._docLayer.isCalc()) {
+			this._addDebugTool({
+				name: 'Click, type, delete, cells & formulas',
+				category: 'Automated User',
+				startsOn: false,
+				onAdd: function () {
+					self._automatedUserAddTask(this.name, L.bind(self._automatedUserTypeCellFormula, self));
+				},
+				onRemove: function () {
+					self._automatedUserRemoveTask(this.name);
+				},
+			});
+		}
+
+		this._addDebugTool({
+			name: 'Insert and delete shape',
+			category: 'Automated User',
+			startsOn: false,
+			onAdd: function () {
+				self._automatedUserAddTask(this.name, L.bind(self._automatedUserInsertTypeShape, self));
+			},
+			onRemove: function () {
+				self._automatedUserRemoveTask(this.name);
+			},
+		});
+	},
+
+	_randomizeSettings: function() {
+		// Toggle dark mode
+		var isDark = this._map.uiManager.getDarkModeState();
+		if (Math.random() < 0.5) {
+			window.app.console.log('Randomize Settings: Toggle dark mode to ' + (isDark?'Light':'Dark'));
+			this._map.uiManager.toggleDarkMode();
+		} else {
+			window.app.console.log('Randomize Settings: Leave dark mode as ' + (isDark?'Dark':'Light'));
+		}
+
+		// Set zoom
+		var targetZoom = Math.floor(Math.random() * 18) + 1;
+		window.app.console.log('Randomize Settings: Set zoom to '+targetZoom);
+		this._map.setZoom(targetZoom, null, false);
+
+		// Toggle spell check
+		var isSpellCheck = this._map['stateChangeHandler'].getItemValue('.uno:SpellOnline');
+		if (Math.random() < 0.5) {
+			window.app.console.log('Randomize Settings: Toggle spell check to ' + (isSpellCheck=='true'?'off':'on'));
+			this._map.sendUnoCommand('.uno:SpellOnline');
+		} else {
+			window.app.console.log('Randomize Settings: Leave spell check as ' + (isSpellCheck=='true'?'on':'off'));
+		}
+
+		// Move to different part of sheet
+		if (this._docLayer.isCalc()) {
+			// Select random position
+			var docSize = this._map.getDocSize();
+			var maxX = docSize.x; //Math.min(docSize.x, 10000);
+			var maxY = docSize.y; //Math.min(docSize.y, 10000);
+			var positions = [
+				{x: maxX, y: 0}, // top right
+				{x: 0, y: maxY}, // bottom left
+				{x: maxX, y: maxY}, // bottom right
+				{x: maxX/2, y: maxY/2}, // center
+			];
+			var pos = positions[Math.floor(Math.random()*positions.length)];
+
+			// Calculate mouse click position
+			var viewSize = this._map.getSize();
+			var centerPos = {x: pos.x + viewSize.x/2, y: pos.y + viewSize.y/2};
+			var centerTwips = this._docLayer._pixelsToTwips(centerPos);
+
+			// Perform action
+			window.app.console.log('Randomize Settings: Move to ',pos,' click at ', centerPos, centerTwips);
+			this._map.fire('scrollto', pos);
+			this._docLayer._postMouseEvent('buttondown', centerTwips.x, centerTwips.y, 1, 1, 0);
+			this._docLayer._postMouseEvent('buttonup', centerTwips.x, centerTwips.y, 1, 1, 0);
+		}
+
+		// Toggle sidebar
+		if (Math.random() < 0.5) {
+			window.app.console.log('Randomize Settings: Toggle sidebar');
+			this._map.sendUnoCommand('.uno:SidebarDeck.PropertyDeck');
+		} else {
+			window.app.console.log('Randomize Settings: Leave sidebar');
+		}
+
+		this._painter.update();
+	},
+
+	_automatedUserAddTask: function(name, taskFn) {
+		// task function takes phase number, returns waitTime
+		// When waitTime == 0, task is done.
+
+		// Save taskFn
+		this._automatedUserTasks[name] = taskFn;
+		// Add to queue
+		if (!this._automatedUserQueue.includes(name)) {
+			this._automatedUserQueue.push(name);
+		}
+	},
+
+	_automatedUserRemoveTask: function(name) {
+		// Don't bother deleting function from _debugAutomatedUserTasks
+		// Remove from queue
+		if (this._automatedUserQueue.includes(name)) {
+			this._automatedUserQueue.splice(
+				this._automatedUserQueue.indexOf(name),
+				1);
+		}
+	},
+
+	_automatedUserTimeout: function () {
+		if (!this._automatedUserTask) {
+			// Not in the middle of a task, pick a new one
+			window.app.console.log('Automated User: Pick a new task. Current queue: ',this._automatedUserQueue);
+			this._automatedUserTask = this._automatedUserQueue.shift();
+			this._automatedUserPhase = 0;
+		}
+
+		if (this._automatedUserTask && this._automatedUserPhase == 0) {
+			window.app.console.log('Automated User: Starting task ' + this._automatedUserTask);
+			// Re-enqueue task
+			this._automatedUserQueue.push(this._automatedUserTask);
+		}
+
+		if (this._automatedUserTask) {
+			window.app.console.log('Automated User: Current task: ' + this._automatedUserTask + ' Current phase: ' + this._automatedUserPhase);
+			var taskFn = this._automatedUserTasks[this._automatedUserTask];
+			var waitTime = taskFn(this._automatedUserPhase);
+			this._automatedUserPhase++;
+			if (waitTime == 0) {
+				window.app.console.log('Automated User: Task complete: ' + this._automatedUserTask);
+				this._automatedUserTask = undefined;
+				this._automatedUserPhase = 0;
+			}
+			this._automatedUserTimeoutId = setTimeout(L.bind(this._automatedUserTimeout, this), waitTime);
+		} else {
+			window.app.console.log('Automated User: Waiting for tasks');
+			// Nothing in queue, check again in 1s
+			this._automatedUserTimeoutId = setTimeout(L.bind(this._automatedUserTimeout, this), 1000);
+		}
+	},
+
+	_automatedUserTypeCellFormula: function (phase) {
+		var waitTime = 0;
+		switch (phase) {
+			case 0:
+				window.app.console.log('Automated User: Click somewhere visible');
+				var pos = this._docLayer._pixelsToTwips(this._map._getCenterLayerPoint());
+				this._docLayer._postMouseEvent('buttondown',pos.x,pos.y,1,1,0);
+				this._docLayer._postMouseEvent('buttonup',pos.x,pos.y,1,1,0);
+				waitTime = 500;
+				break;
+			case 1:
+				window.app.console.log('Automated User: Type text');
+				this._typeText('asdf\nqwer\n', 100);
+				waitTime = 1000;
+				break;
+			case 2:
+				window.app.console.log('Automated User: Click formula bar');
+				this._map.sendUnoCommand('.uno:StartFormula');
+				waitTime = 500;
+				break;
+			case 3:
+				window.app.console.log('Automated User: Type formula');
+				this._typeText('A1\n', 100);
+				waitTime = 1000;
+				break;
+			case 4:
+				window.app.console.log('Automated User: Delete row');
+				this._docLayer.postKeyboardEvent('input', 0, 1025); //up
+				this._docLayer.postKeyboardEvent('input', 0, 1025); //up
+				this._map.sendUnoCommand('.uno:DeleteRows');
+				waitTime = 1000;
+				break;
+			case 5:
+				window.app.console.log('Automated User: Delete cells');
+				app.socket.sendMessage('removetextcontext id=0 before=0 after=1'); //delete
+				this._docLayer.postKeyboardEvent('input', 0, 1025); //up
+				app.socket.sendMessage('removetextcontext id=0 before=0 after=1'); //delete
+				waitTime = 500;
+				break;
+		}
+		return waitTime;
+	},
+
+	_automatedUserInsertTypeShape: function (phase) {
+		var waitTime = 0;
+		switch (phase) {
+			case 0:
+				window.app.console.log('Automated User: Insert Shape');
+				var shapes = ['rectangle','circle','diamond','pentagon'];
+				var shape = shapes[Math.floor(Math.random() * shapes.length)];
+				this._map.sendUnoCommand('.uno:BasicShapes.'+shape);
+				// app.socket.sendMessage('removetextcontext id=0 before=0 after=1');
+				waitTime = 1000;
+				break;
+			case 1:
+				window.app.console.log('Automated User: Type in Shape');
+				this._docLayer.postKeyboardEvent('input',0, 1280); // enter to select text
+				this._typeText('textinshape', 100);
+				waitTime = 1500;
+				break;
+			case 2:
+				window.app.console.log('Automated User: Type Escape');
+				this._docLayer.postKeyboardEvent('input',0, 1281); // esc
+				waitTime = 500;
+				break;
+		}
+		return waitTime;
+	},
+
+	_typerTimeout: function() {
+		var letter = this._typerLorem.charCodeAt(this._typerLoremPos % this._typerLorem.length);
+		this._typeChar(letter);
+		this._typerLoremPos++;
+		this._typerTimeoutId = setTimeout(L.bind(this._typerTimeout, this), 50);
+	},
+
+	_typeText: function(text, delayMs) {
+		for (var i=0; i<text.length; i++) {
+			if (delayMs) {
+				setTimeout(L.bind(this._typeChar, this, text.charCodeAt(i)), i*delayMs);
+			} else {
+				this._typeChar(text.charCodeAt(i));
+			}
+		}
+	},
+
+	_typeChar: function(charCode) {
+		if (this.tileInvalidationsOn) {
+			this._debugKeypressQueue.push(+new Date());
+		}
+		if (charCode === '\n'.charCodeAt(0)) {
+			this._docLayer.postKeyboardEvent('input', 0, 1280);
+		} else {
+			this._docLayer.postKeyboardEvent('input', charCode, 0);
+		}
+	},
+
+	setOverlayPostMessage: function(type,msg) {
+		if (this.overlayOn) {
+			this.overlayData['postMessage'].setPrefix(type+': '+ msg);
+		}
+	},
+
+	getTimeArray: function() {
+		return {count: 0, ms: 0, best: Number.MAX_SAFE_INTEGER, worst: 0, date: 0};
+	},
+
+	updateTimeArray: function(times, value) {
+		if (value < times.best) {
+			times.best = value;
+		}
+		if (value > times.worst) {
+			times.worst = value;
+		}
+		times.ms += value;
+		times.count++;
+		return 'best: ' + times.best + ' ms, avg: ' + Math.round(times.ms/times.count) + ' ms, worst: ' + times.worst + ' ms, last: ' + value + ' ms';
+	},
+
+
+	_overlayShowTileData: function() {
+		this.overlayData['loadCount'].setPrefix(
+			'Total of requested tiles: ' + this._debugInvalidateCount + ', ' +
+			'recv-tiles: ' + this._debugLoadTile + ', ' +
+			'recv-delta: ' + this._debugLoadDelta + ', ' +
+			'recv-update: ' + this._debugLoadUpdate);
+		var allDeltas = this._debugLoadDelta + this._debugLoadUpdate;
+		this.overlayData['nullUpdateMetric'].setPrefix(
+			'<b>Tile update waste: ' + Math.round(100.0 * this._debugLoadUpdate / allDeltas) + '%</b>'
+		);
+		this.overlayData['newTileMetric'].setPrefix(
+			'<b>New Tile ratio: ' + Math.round(100.0 * this._debugLoadTile / (allDeltas + this._debugLoadTile)) + '%</b>'
+		);
+	},
+
+	_tileInvalidationTimeout: function() {
+		for (var key in this._debugInvalidBounds) {
+			var rect = this._debugInvalidBounds[key];
+			var opac = rect.options.fillOpacity;
+			if (opac <= 0.04) {
+				if (key < this._debugId - 5) {
+					this._tileInvalidationLayer.removeLayer(rect);
+					delete this._debugInvalidBounds[key];
+					delete this._debugInvalidBoundsMessage[key];
+				} else {
+					rect.setStyle({fillOpacity: 0, opacity: 1 - (this._debugId - key) / 7});
+				}
+			} else {
+				rect.setStyle({fillOpacity: opac - 0.04});
+			}
+		}
+		this._tileInvalidationTimeoutId = setTimeout(L.bind(this._tileInvalidationTimeout, this), 50);
+	},
+
+	addInvalidationMessage: function(message) {
+		this._debugInvalidBoundsMessage[this._debugId - 1] = message;
+		var messages = '';
+		for (var i = this._debugId - 1; i > this._debugId - 6; i--) {
+			if (i >= 0 && this._debugInvalidBoundsMessage[i]) {
+				messages += '' + i + ': ' + this._debugInvalidBoundsMessage[i] + ' <br>';
+			}
+		}
+		if (this.overlayOn) {
+			this.overlayData['tileCombine'].setPrefix(messages);
+			this._overlayShowTileData();
+		}
+	},
+
+
+	addInvalidationRectangle: function(topLeftTwips, bottomRightTwips, command) {
+		var now = +new Date();
+
+		var signX =  this._docLayer.isCalcRTL() ? -1 : 1;
+
+		var absTopLeftTwips = L.point(topLeftTwips.x * signX, topLeftTwips.y);
+		var absBottomRightTwips = L.point(bottomRightTwips.x * signX, bottomRightTwips.y);
+
+		var invalidBoundCoords = new L.LatLngBounds(
+			this._docLayer._twipsToLatLng(absTopLeftTwips, this._docLayer._tileZoom),
+			this._docLayer._twipsToLatLng(absBottomRightTwips, this._docLayer._tileZoom)
+		);
+		var rect = L.rectangle(invalidBoundCoords, {color: 'red', weight: 1, opacity: 1, fillOpacity: 0.4, pointerEvents: 'none'});
+		this._debugInvalidBounds[this._debugId] = rect;
+		this._debugInvalidBoundsMessage[this._debugId] = command;
+		this._debugId++;
+		this._tileInvalidationLayer.addLayer(rect);
+
+		var oldestKeypress = this._debugKeypressQueue.shift();
+		if (oldestKeypress) {
+			var timeText = this.updateTimeArray(this._debugTimeKeypress, now - oldestKeypress);
+			this.overlayData['fromKeyInputToInvalidate'].setPrefix(
+				'Elapsed time between key input and next invalidate: ' + timeText
+			);
+		}
+
+		// query server ping time after invalidation messages
+		// pings will be paired with the pong messages
+		this._debugPINGQueue.push(+new Date());
+		app.socket.sendMessage('ping');
+	},
+
+
+});

--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -289,12 +289,12 @@ app.definitions.Socket = L.Class.extend({
 		if (window.ThisIsTheGtkApp)
 			window.postMobileDebug(type + ' ' + msg);
 
-		var fullDebug = this._map._docLayer && this._map._docLayer._debug;
+		var debugOn = this._map._debug.debugOn;
 
-		if (fullDebug)
-			this._map._docLayer._debugSetPostMessage(type,msg);
+		if (debugOn)
+			this._map._debug.setOverlayPostMessage(type,msg);
 
-		if (!fullDebug && msg.length > 256) // for reasonable performance.
+		if (!debugOn && msg.length > 256) // for reasonable performance.
 			msg = msg.substring(0,256) + '<truncated ' + (msg.length - 256) + 'chars>';
 
 		var status = '';
@@ -305,7 +305,7 @@ app.definitions.Socket = L.Class.extend({
 
 		L.Log.log(msg, type + status);
 
-		if (!window.protocolDebug && !fullDebug)
+		if (!window.protocolDebug && !debugOn)
 			return;
 
 		var color = type === 'OUTGOING' ? 'color:red' : 'color:#2e67cf';
@@ -1070,15 +1070,17 @@ app.definitions.Socket = L.Class.extend({
 					});
 			}
 		}
-		else if (textMsg.startsWith('pong ') && this._map._docLayer && this._map._docLayer._debug) {
-			var times = this._map._docLayer._debugTimePING;
-			var timeText = this._map._docLayer._debugSetTimes(times, +new Date() - this._map._docLayer._debugPINGQueue.shift());
-			if (this._map._docLayer._debugData) {
-				this._map._docLayer._debugData['ping'].setPrefix('Server ping time: ' + timeText +
-						'. Rendered tiles: ' + command.rendercount +
-						', last: ' + (command.rendercount - this._map._docLayer._debugRenderCount));
+		else if (textMsg.startsWith('pong ') && this._map._debug.debugOn) {
+			var times = this._map._debug._debugTimePING;
+			var timeText = this._map._debug.updateTimeArray(times, +new Date() - this._map._debug._debugPINGQueue.shift());
+			if (this._map._debug.overlayOn) {
+				this._map._debug.overlayData['ping'].setPrefix(
+					'Server ping time: ' + timeText + '. ' +
+					'Rendered tiles: ' + command.rendercount + ', ' + 
+					'last: ' + (command.rendercount - this._map._debug._debugRenderCount)
+				);
 			}
-			this._map._docLayer._debugRenderCount = command.rendercount;
+			this._map._debug._debugRenderCount = command.rendercount;
 		}
 		else if (textMsg.startsWith('saveas:') || textMsg.startsWith('renamefile:')) {
 			this._renameOrSaveAsCallback(textMsg, command);

--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -194,8 +194,8 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 		var topLeftTwips = new L.Point(command.x, command.y);
 		var offset = new L.Point(command.width, command.height);
 		var bottomRightTwips = topLeftTwips.add(offset);
-		if (this._debugTileInvalidations) {
-			this._debugAddInvalidationRectangle(topLeftTwips, bottomRightTwips, textMsg);
+		if (this._debug.tileInvalidationsOn) {
+			this._debug.addInvalidationRectangle(topLeftTwips, bottomRightTwips, textMsg);
 		}
 
 		var invalidBounds = new L.Bounds(topLeftTwips, bottomRightTwips);
@@ -224,9 +224,8 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 		}
 
 		if (needsNewTiles && command.part === this._selectedPart
-			&& command.mode === this._selectedMode && this._debugTileInvalidations)
-		{
-			this._debugAddInvalidationMessage(textMsg);
+			&& command.mode === this._selectedMode && this._debug.tileInvalidationsOn) {
+			this._debug.addInvalidationMessage(textMsg);
 		}
 
 		this._previewInvalidations.push(invalidBounds);

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1775,10 +1775,12 @@ L.CanvasTileLayer = L.Layer.extend({
 		else if (textMsg.startsWith('canonicalidchange:')) {
 			var payload = textMsg.substring('canonicalidchange:'.length + 1);
 			var viewRenderedState = payload.split('=')[3].split(' ')[0];
-			if (this._debugData) {
+			if (this._debug.overlayOn) {
 				var viewId = payload.split('=')[1].split(' ')[0];
 				var canonicalId = payload.split('=')[2].split(' ')[0];
-				this._debugData['canonicalViewId'].setPrefix('Canonical id changed to: ' + canonicalId + ' for view id: ' + viewId + ' with view renderend state: ' + viewRenderedState);
+				this._debug.overlayData['canonicalViewId'].setPrefix(
+					'Canonical id changed to: ' + canonicalId + ' for view id: ' + viewId + ' with view renderend state: ' + viewRenderedState
+				);
 			}
 			if (!this._canonicalIdInitialized) {
 				this._canonicalIdInitialized = true;
@@ -5072,642 +5074,6 @@ L.CanvasTileLayer = L.Layer.extend({
 		});
 	},
 
-	toggleDebugMode: function() {
-		this._debug = !this._debug;
-		if (this._debug) {
-			this._debugInit();
-		} else {
-			this._debugStop();
-		}
-
-		// redraw canvas with changed debug overlays
-		this._painter.update();
-	},
-
-	_debugInit: function() {
-		this._debugControls = {};
-		this._debugLayers = [];
-		this._addDebugTools();
-		// initialize state that we build in debug mode whether visible or not
-		this._debugInvalidBounds = {};
-		this._debugInvalidBoundsMessage = {};
-		this._debugId = 0;
-		this._debugLoadTile = 0;
-		this._debugLoadDelta = 0;
-		this._debugLoadUpdate = 0;
-		this._debugInvalidateCount = 0;
-		this._debugTimeKeypress = this._debugGetTimeArray();
-		this._debugKeypressQueue = [];
-		this._debugRenderCount = 0;
-		this._debugTimePING = this._debugGetTimeArray();
-		this._debugPINGQueue = [];
-		this._debugAutomatedUserQueue = [];
-		this._debugAutomatedUserTasks = {};
-
-		if (this.isCalc()) {
-			this._painter._addSplitsSection();
-			this._painter._sectionContainer.reNewAllSections(true /* redraw */);
-		}
-	},
-
-	_debugStop: function () {
-		// Remove layers
-		for (var i in this._debugLayers) {
-			this._map.removeLayer(this._debugLayers[i]);
-		}
-
-		// Remove controls
-		for (var category in this._debugControls) {
-			this._debugControls[category].remove();
-		}
-		this._debugControls = {};
-
-		if (this.isCalc()) {
-			var section = this._painter._sectionContainer.getSectionWithName('calc grid');
-			if (section) {
-				section.setDrawingOrder(L.CSections.CalcGrid.drawingOrder);
-				section.sectionProperties.strokeStyle = '#c0c0c0';
-			}
-			this._painter._sectionContainer.removeSection('splits');
-			this._painter._sectionContainer.reNewAllSections(true /* redraw */);
-		}
-	},
-
-	_debugGetTimeArray: function() {
-		return {count: 0, ms: 0, best: Number.MAX_SAFE_INTEGER, worst: 0, date: 0};
-	},
-
-	_debugShowTileData: function() {
-		this._debugData['loadCount'].setPrefix('Total of requested tiles: ' +
-				this._debugInvalidateCount + ', recv-tiles: ' + this._debugLoadTile +
-						       ', recv-delta: ' + this._debugLoadDelta +
-						       ', recv-update: ' + this._debugLoadUpdate);
-		var allDeltas = this._debugLoadDelta + this._debugLoadUpdate;
-		this._debugData['nullUpdateMetric'].setPrefix('<b>Tile update waste: ' +
-				Math.round(100.0 * this._debugLoadUpdate / allDeltas) + '%</b>');
-		this._debugData['newTileMetric'].setPrefix('<b>New Tile ratio: ' +
-				Math.round(100.0 * this._debugLoadTile / (allDeltas + this._debugLoadTile)) + '%</b>');
-	},
-
-	_addDebugTool: function (tool) {
-		// Create control if it doesn't exist
-		if (!(tool.category in this._debugControls)) {
-			this._debugControls[tool.category] = L.control.layers({}, {}, {collapsed: false, sortLayers: true}).addTo(this._map);
-			// Add a title
-			var b = document.createElement('b');
-			b.append(tool.category);
-			this._debugControls[tool.category]._container.prepend(b);
-		}
-
-		// Create layer
-		var layer = new L.LayerGroup();
-		this._debugLayers.push(layer);
-		this._debugControls[tool.category]._addLayer(layer, tool.name, true);
-		this._debugControls[tool.category]._update();
-
-		this._map.on('layeradd', function(e) {
-			if (e.layer === layer) {
-				tool.onAdd();
-			}
-		}, this);
-		this._map.on('layerremove', function(e) {
-			if (e.layer === layer) {
-				tool.onRemove();
-			}
-		}, this);
-		if (tool.startsOn) {
-			this._map.addLayer(layer);
-		}
-	},
-
-	_addDebugTools: function () {
-		var self = this; // easier than using (function (){}).bind(this) each time
-
-		this._addDebugTool({
-			name: 'Screen Overlays',
-			category: 'Display',
-			startsOn: true,
-			onAdd: function () {
-				self._debugData = {};
-				var _debugDataNames = ['canonicalViewId', 'tileCombine', 'fromKeyInputToInvalidate', 'ping', 'loadCount', 'postMessage'];
-				for (var i = 0; i < _debugDataNames.length; i++) {
-					self._debugData[_debugDataNames[i]] = L.control.attribution({prefix: '', position: 'bottomleft'}).addTo(self._map);
-					self._debugData[_debugDataNames[i]].addTo(self._map);
-				}
-				_debugDataNames = ['nullUpdateMetric', 'newTileMetric'];
-				for (var i = 0; i < _debugDataNames.length; i++) {
-					self._debugData[_debugDataNames[i]] = L.control.attribution({prefix: '', position: 'topleft'}).addTo(self._map);
-					self._debugData[_debugDataNames[i]].addTo(self._map);
-					self._debugData[_debugDataNames[i]]._container.style.fontSize = '14px';
-				}
-			},
-			onRemove: function () {
-				for (var i in self._debugData) {
-					self._debugData[i].remove();
-				}
-				delete self._debugData;
-			},
-		});
-
-		this._addDebugTool({
-			name: 'Tile Overlays',
-			category: 'Display',
-			startsOn: false,
-			onAdd: function () {
-				self._debugTileOverlays = true;
-				self._painter.update();
-			},
-			onRemove: function () {
-				self._debugTileOverlays = false;
-				self._painter.update();
-			},
-		});
-
-		this._addDebugTool({
-			name: 'Tile Invalidations',
-			category: 'Display',
-			startsOn: false,
-			onAdd: function () {
-				self._debugTileInvalidations = true;
-				self._debugTileInvalidationTimeout();
-				self._debugTileLayer = new L.LayerGroup();
-				self._map.addLayer(self._debugTileLayer);
-			},
-			onRemove: function () {
-				self._debugTileInvalidations = false;
-				self._map.removeLayer(self._debugTileLayer);
-				self._painter.update();
-			},
-		});
-
-		/*
-		 * Doesn't seem to do anything
-		this._addDebugTool({
-			name: 'Always Active',
-			category: 'Functionality',
-			startsOn: false,
-			onAdd: function () {
-				self._map._debugAlwaysActive = true;
-			},
-			onRemove: function () {
-				self._map._debugAlwaysActive = false;
-			},
-		});
-		*/
-
-		this._addDebugTool({
-			name: 'Show Clipboard',
-			category: 'Display',
-			startsOn: false,
-			onAdd: function () {
-				self._map._textInput.debug(true);
-			},
-			onRemove: function () {
-				self._map._textInput.debug(false);
-			},
-		});
-
-		this._addDebugTool({
-			name: 'Tiles device pixel grid',
-			category: 'Display',
-			startsOn: false,
-			onAdd: function () {
-				self._map._docLayer._painter._addTilePixelGridSection();
-				self._map._docLayer._painter._sectionContainer.reNewAllSections(true);
-			},
-			onRemove: function () {
-				self._map._docLayer._painter._sectionContainer.removeSection('tile pixel grid');
-				self._map._docLayer._painter._sectionContainer.reNewAllSections(true);
-			},
-		});
-
-		/*
-		 * Doesn't seem to do anything
-		this._addDebugTool({
-			name: 'Sidebar Rerendering',
-			category: 'Display',
-			startsOn: false,
-			onAdd: function () {
-				self._map._debugSidebar = true;
-			},
-			onRemove: function () {
-				self._map._debugSidebar = false;
-			},
-		});
-		*/
-
-		this._addDebugTool({
-			name: 'Performance Tracing',
-			category: 'Logging',
-			startsOn: app.socket.traceEventRecordingToggle,
-			onAdd: function () {
-				app.socket.setTraceEventLogging(true);
-			},
-			onRemove: function () {
-				app.socket.setTraceEventLogging(false);
-			},
-		});
-
-		this._addDebugTool({
-			name: 'Protocol Logging',
-			category: 'Logging',
-			startsOn: true,
-			onAdd: function () {
-				window.setLogging(true);
-				L.Log.print();
-			},
-			onRemove: function () {
-				window.setLogging(false);
-			},
-		});
-
-		this._addDebugTool({
-			name: 'Tile Dumping',
-			category: 'Logging',
-			startsOn: false,
-			onAdd: function () {
-				app.socket.sendMessage('toggletiledumping true');
-			},
-			onRemove: function () {
-				app.socket.sendMessage('toggletiledumping false');
-			},
-		});
-
-		this._addDebugTool({
-			name: 'Debug Deltas',
-			category: 'Logging',
-			startsOn: false,
-			onAdd: function () {
-				self._debugDeltas = true;
-				self._debugDeltasDetail = true;
-			},
-			onRemove: function () {
-				self._debugDeltas = true;
-				self._debugDeltasDetail = true;
-			},
-		});
-
-		this._addDebugTool({
-			name: 'Typer',
-			category: 'Automated User',
-			startsOn: false,
-			onAdd: function () {
-				self._debugLorem = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.\n';
-				self._debugLoremPos = 0;
-				self._debugTyperTimeout();
-			},
-			onRemove: function () {
-				clearTimeout(self._debugTyperTimeoutId);
-			},
-		});
-
-		this._addDebugTool({
-			name: 'Randomize user settings',
-			category: 'Automated User',
-			startsOn: false,
-			onAdd: function () {
-				self._debugRandomizeSettings();
-			},
-			onRemove: function () {
-			},
-		});
-
-		this._addDebugTool({
-			name: 'Automated user input',
-			category: 'Automated User',
-			startsOn: false,
-			onAdd: function () {
-				self._debugAutomatedUserTimeout();
-			},
-			onRemove: function () {
-				clearTimeout(self._debugAutomatedUserTimeoutId);
-				self._debugAutomatedUserTask = undefined;
-				self._debugAutomatedUserPhase = 0;
-			},
-		});
-
-		if (this.isCalc()) {
-			this._addDebugTool({
-				name: 'Click, type, delete, cells & formulas',
-				category: 'Automated User',
-				startsOn: false,
-				onAdd: function () {
-					self._debugAutomatedUserAddTask(this.name, L.bind(self._debugAutomatedUserTypeCellFormula, self));
-				},
-				onRemove: function () {
-					self._debugAutomatedUserRemoveTask(this.name);
-				},
-			});
-		}
-
-		this._addDebugTool({
-			name: 'Insert and delete shape',
-			category: 'Automated User',
-			startsOn: false,
-			onAdd: function () {
-				self._debugAutomatedUserAddTask(this.name, L.bind(self._debugAutomatedUserInsertTypeShape, self));
-			},
-			onRemove: function () {
-				self._debugAutomatedUserRemoveTask(this.name);
-			},
-		});
-	},
-
-	_debugRandomizeSettings: function() {
-		// Toggle dark mode
-		var isDark = this._map.uiManager.getDarkModeState();
-		if (Math.random() < 0.5) {
-			console.log('Randomize Settings: Toggle dark mode to ' + (isDark?'Light':'Dark'));
-			this._map.uiManager.toggleDarkMode();
-		} else {
-			console.log('Randomize Settings: Leave dark mode as ' + (isDark?'Dark':'Light'));
-		}
-
-		// Set zoom
-		var targetZoom = Math.floor(Math.random() * 18) + 1;
-		console.log('Randomize Settings: Set zoom to '+targetZoom);
-		this._map.setZoom(targetZoom, null, false);
-
-		// Toggle spell check
-		var isSpellCheck = this._map['stateChangeHandler'].getItemValue('.uno:SpellOnline');
-		if (Math.random() < 0.5) {
-			console.log('Randomize Settings: Toggle spell check to ' + (isSpellCheck=='true'?'off':'on'));
-			this._map.sendUnoCommand('.uno:SpellOnline');
-		} else {
-			console.log('Randomize Settings: Leave spell check as ' + (isSpellCheck=='true'?'on':'off'));
-		}
-
-		// Move to different part of sheet
-		if (this.isCalc()) {
-			// Select random position
-			var docSize = this._map.getDocSize();
-			var maxX = docSize.x; //Math.min(docSize.x, 10000);
-			var maxY = docSize.y; //Math.min(docSize.y, 10000);
-			var positions = [
-				{x: maxX, y: 0}, // top right
-				{x: 0, y: maxY}, // bottom left
-				{x: maxX, y: maxY}, // bottom right
-				{x: maxX/2, y: maxY/2}, // center
-			];
-			var pos = positions[Math.floor(Math.random()*positions.length)];
-
-			// Calculate mouse click position
-			var viewSize = this._map.getSize();
-			var centerPos = {x: pos.x + viewSize.x/2, y: pos.y + viewSize.y/2};
-			var centerTwips = this._pixelsToTwips(centerPos);
-
-			// Perform action
-			console.log('Randomize Settings: Move to ',pos,' click at ', centerPos, centerTwips);
-			this._map.fire('scrollto', pos);
-			this._postMouseEvent('buttondown', centerTwips.x, centerTwips.y, 1, 1, 0);
-			this._postMouseEvent('buttonup', centerTwips.x, centerTwips.y, 1, 1, 0);
-		}
-
-		// Toggle sidebar
-		if (Math.random() < 0.5) {
-			console.log('Randomize Settings: Toggle sidebar');
-			this._map.sendUnoCommand('.uno:SidebarDeck.PropertyDeck');
-		} else {
-			console.log('Randomize Settings: Leave sidebar');
-		}
-
-		this._painter.update();
-	},
-
-	_debugAutomatedUserTypeCellFormula: function (phase) {
-		var waitTime = 0;
-		switch (phase) {
-			case 0:
-				console.log('Automated User: Click somewhere visible');
-				var pos = this._pixelsToTwips(this._map._getCenterLayerPoint());
-				this._postMouseEvent('buttondown',pos.x,pos.y,1,1,0);
-				this._postMouseEvent('buttonup',pos.x,pos.y,1,1,0);
-				waitTime = 500;
-				break;
-			case 1:
-				console.log('Automated User: Type text');
-				this._debugTypeText('asdf\nqwer\n', 100);
-				waitTime = 1000;
-				break;
-			case 2:
-				console.log('Automated User: Click formula bar');
-				this._map.sendUnoCommand('.uno:StartFormula');
-				waitTime = 500;
-				break;
-			case 3:
-				console.log('Automated User: Type formula');
-				this._debugTypeText('A1\n', 100);
-				waitTime = 1000;
-				break;
-			case 4:
-				console.log('Automated User: Delete row');
-				this.postKeyboardEvent('input', 0, 1025); //up
-				this.postKeyboardEvent('input', 0, 1025); //up
-				this._map.sendUnoCommand('.uno:DeleteRows');
-				waitTime = 1000;
-				break;
-			case 5:
-				console.log('Automated User: Delete cells');
-				app.socket.sendMessage('removetextcontext id=0 before=0 after=1'); //delete
-				this.postKeyboardEvent('input', 0, 1025); //up
-				app.socket.sendMessage('removetextcontext id=0 before=0 after=1'); //delete
-				waitTime = 500;
-				break;
-		}
-		return waitTime;
-	},
-
-	_debugAutomatedUserInsertTypeShape: function (phase) {
-		var waitTime = 0;
-		switch (phase) {
-			case 0:
-				console.log('Automated User: Insert Shape');
-				var shapes = ['rectangle','circle','diamond','pentagon'];
-				var shape = shapes[Math.floor(Math.random() * shapes.length)];
-				this._map.sendUnoCommand('.uno:BasicShapes.'+shape);
-				// app.socket.sendMessage('removetextcontext id=0 before=0 after=1');
-				waitTime = 1000;
-				break;
-			case 1:
-				console.log('Automated User: Type in Shape');
-				this.postKeyboardEvent('input',0, 1280); // enter to select text
-				this._debugTypeText('textinshape', 100);
-				waitTime = 1500;
-				break;
-			case 2:
-				console.log('Automated User: Type Escape');
-				this.postKeyboardEvent('input',0, 1281); // esc
-				waitTime = 500;
-				break;
-		}
-		return waitTime;
-	},
-
-
-	_debugAutomatedUserAddTask: function(name, taskFn) {
-		// Save taskFn
-		this._debugAutomatedUserTasks[name] = taskFn;
-		// Add to queue
-		if (!this._debugAutomatedUserQueue.includes(name)) {
-			this._debugAutomatedUserQueue.push(name);
-		}
-	},
-
-	_debugAutomatedUserRemoveTask: function(name) {
-		// Don't bother deleting function from _debugAutomatedUserTasks
-		// Remove from queue
-		if (this._debugAutomatedUserQueue.includes(name)) {
-			this._debugAutomatedUserQueue.splice(
-				this._debugAutomatedUserQueue.indexOf(name),
-				1);
-		}
-	},
-
-
-	// task function takes phase number, returns waitTime
-	// When waitTime =0, task is done.
-
-	_debugAutomatedUserTimeout: function () {
-		if (!this._debugAutomatedUserTask) {
-			// Not in the middle of a task, pick a new one
-			console.log('Automated User: Pick a new task. Current queue: ',this._debugAutomatedUserQueue);
-			this._debugAutomatedUserTask = this._debugAutomatedUserQueue.shift();
-			this._debugAutomatedUserPhase = 0;
-		}
-
-		if (this._debugAutomatedUserTask && this._debugAutomatedUserPhase == 0) {
-			console.log('Automated User: Starting task ' + this._debugAutomatedUserTask);
-			// Re-enqueue task
-			this._debugAutomatedUserQueue.push(this._debugAutomatedUserTask);
-		}
-
-		if (this._debugAutomatedUserTask) {
-			console.log('Automated User: Current task: ' + this._debugAutomatedUserTask + ' Current phase: ' + this._debugAutomatedUserPhase);
-			var taskFn = this._debugAutomatedUserTasks[this._debugAutomatedUserTask];
-			var waitTime = taskFn(this._debugAutomatedUserPhase);
-			this._debugAutomatedUserPhase++;
-			if (waitTime == 0) {
-				console.log('Automated User: Task complete: ' + this._debugAutomatedUserTask);
-				this._debugAutomatedUserTask = undefined;
-				this._debugAutomatedUserPhase = 0;
-			}
-			this._debugAutomatedUserTimeoutId = setTimeout(L.bind(this._debugAutomatedUserTimeout, this), waitTime);
-		} else {
-			console.log('Automated User: Waiting for tasks');
-			// Nothing in queue, check again in 1s
-			this._debugAutomatedUserTimeoutId = setTimeout(L.bind(this._debugAutomatedUserTimeout, this), 1000);
-		}
-	},
-
-	_debugSetPostMessage: function(type,msg) {
-		if (this._debugData) {
-			this._debugData['postMessage'].setPrefix(type+': '+ msg);
-		}
-	},
-
-	_debugSetTimes: function(times, value) {
-		if (value < times.best) {
-			times.best = value;
-		}
-		if (value > times.worst) {
-			times.worst = value;
-		}
-		times.ms += value;
-		times.count++;
-		return 'best: ' + times.best + ' ms, avg: ' + Math.round(times.ms/times.count) + ' ms, worst: ' + times.worst + ' ms, last: ' + value + ' ms';
-	},
-
-	_debugAddInvalidationRectangle: function(topLeftTwips, bottomRightTwips, command) {
-		var now = +new Date();
-
-		var signX =  this.isCalcRTL() ? -1 : 1;
-
-		var absTopLeftTwips = L.point(topLeftTwips.x * signX, topLeftTwips.y);
-		var absBottomRightTwips = L.point(bottomRightTwips.x * signX, bottomRightTwips.y);
-
-		var invalidBoundCoords = new L.LatLngBounds(this._twipsToLatLng(absTopLeftTwips, this._tileZoom),
-			this._twipsToLatLng(absBottomRightTwips, this._tileZoom));
-		var rect = L.rectangle(invalidBoundCoords, {color: 'red', weight: 1, opacity: 1, fillOpacity: 0.4, pointerEvents: 'none'});
-		this._debugInvalidBounds[this._debugId] = rect;
-		this._debugInvalidBoundsMessage[this._debugId] = command;
-		this._debugId++;
-		this._debugTileLayer.addLayer(rect);
-
-		var oldestKeypress = this._debugKeypressQueue.shift();
-		if (oldestKeypress) {
-			var timeText = this._debugSetTimes(this._debugTimeKeypress, now - oldestKeypress);
-			this._debugData['fromKeyInputToInvalidate'].setPrefix('Elapsed time between key input and next invalidate: ' + timeText);
-		}
-
-		// query server ping time after invalidation messages
-		// pings will be paired with the pong messages
-		this._debugPINGQueue.push(+new Date());
-		app.socket.sendMessage('ping');
-	},
-
-	_debugAddInvalidationMessage: function(message) {
-		this._debugInvalidBoundsMessage[this._debugId - 1] = message;
-		var messages = '';
-		for (var i = this._debugId - 1; i > this._debugId - 6; i--) {
-			if (i >= 0 && this._debugInvalidBoundsMessage[i]) {
-				messages += '' + i + ': ' + this._debugInvalidBoundsMessage[i] + ' <br>';
-			}
-		}
-		if (this._debugData) {
-			this._debugData['tileCombine'].setPrefix(messages);
-			this._debugShowTileData();
-		}
-	},
-
-	_debugTileInvalidationTimeout: function() {
-		if (this._debug) {
-			for (var key in this._debugInvalidBounds) {
-				var rect = this._debugInvalidBounds[key];
-				var opac = rect.options.fillOpacity;
-				if (opac <= 0.04) {
-					if (key < this._debugId - 5) {
-						this._debugTileLayer.removeLayer(rect);
-						delete this._debugInvalidBounds[key];
-						delete this._debugInvalidBoundsMessage[key];
-					} else {
-						rect.setStyle({fillOpacity: 0, opacity: 1 - (this._debugId - key) / 7});
-					}
-				} else {
-					rect.setStyle({fillOpacity: opac - 0.04});
-				}
-			}
-			this._debugTileInvalidationTimeoutId = setTimeout(L.bind(this._debugTileInvalidationTimeout, this), 50);
-		}
-	},
-
-	_debugTyperTimeout: function() {
-		var letter = this._debugLorem.charCodeAt(this._debugLoremPos % this._debugLorem.length);
-		this._debugTypeChar(letter);
-		this._debugLoremPos++;
-		this._debugTyperTimeoutId = setTimeout(L.bind(this._debugTyperTimeout, this), 50);
-	},
-
-	_debugTypeText: function(text, delayMs) {
-		for (var i=0; i<text.length; i++) {
-			if (delayMs) {
-				setTimeout(L.bind(this._debugTypeChar, this, text.charCodeAt(i)), i*delayMs);
-			} else {
-				this._debugTypeChar(text.charCodeAt(i));
-			}
-		}
-	},
-
-	_debugTypeChar: function(charCode) {
-		if (this._debugTileInvalidations) {
-			this._debugKeypressQueue.push(+new Date());
-		}
-		if (charCode === '\n'.charCodeAt(0)) {
-			this.postKeyboardEvent('input', 0, 1280);
-		} else {
-			this.postKeyboardEvent('input', charCode, 0);
-		}
-	},
-
 	/// onlyThread - takes annotation indicating which thread will be generated
 	getCommentWizardStructure: function(menuStructure, onlyThread) {
 		var customTitleBar = L.DomUtil.create('div');
@@ -6042,9 +5408,9 @@ L.CanvasTileLayer = L.Layer.extend({
 			map.addLayer(this._viewLayerGroup);
 		}
 
-		this._debug = map.options.debug;
-		if (this._debug) {
-			this._debugInit();
+		this._debug = map._debug;
+		if (map.options.debug && !this._debug.debugOn) {
+			this._debug.toggle();
 		}
 
 		this._searchResultsLayer = new L.LayerGroup();
@@ -6733,8 +6099,8 @@ L.CanvasTileLayer = L.Layer.extend({
 			app.socket.sendMessage(newClientVisibleArea);
 			if (!this._map._fatal && app.idleHandler._active && app.socket.connected())
 				this._clientVisibleArea = newClientVisibleArea;
-			if (this._debugTileInvalidations)
-				this._debugTileLayer.clearLayers();
+			if (this._debug.tileInvalidationsOn)
+				this._debug._tileInvalidationLayer.clearLayers();
 		}
 	},
 
@@ -7021,8 +6387,8 @@ L.CanvasTileLayer = L.Layer.extend({
 
 		tile.invalidateCount++;
 
-		if (this._debugTileInvalidations)
-			this._debugInvalidateCount++;
+		if (this._debug.tileInvalidationsOn)
+			this._debug._debugInvalidateCount++;
 
 		if (!tile.hasContent())
 			this._removeTile(key);
@@ -7490,14 +6856,14 @@ L.CanvasTileLayer = L.Layer.extend({
 
 	// Update debug overlay for a tile
 	_showDebugForTile: function(key) {
-		if (!this._debug)
+		if (!this._debug.debugOn)
 			return;
 
 		var tile = this._tiles[key];
-		tile._debugTime = this._debugGetTimeArray();
+		tile._debugTime = this._debug.getTimeArray();
 
-		if (this._debugData) {
-			this._debugShowTileData();
+		if (this._debug.overlayOn) {
+			this._debug._overlayShowTileData();
 		}
 	},
 
@@ -7559,21 +6925,19 @@ L.CanvasTileLayer = L.Layer.extend({
 			hasContent = false;
 		}
 
-		if (this._debug) {
-			if (!img)
-			{
+		if (this._debug.debugOn) {
+			if (!img) {
 				tile.updateCount++;
-				this._debugLoadUpdate++;
+				this._debug._debugLoadUpdate++;
+			} else if (img.rawData && !img.isKeyframe) {
+				if (img.rawData.length === 0) {
+					this._debug._debugLoadUpdate++;
+				} else {
+					this._debug._debugLoadDelta++;
+				}
+			} else if (img.rawData) {
+				this._debug._debugLoadTile++;
 			}
-			else if (img.rawData && !img.isKeyframe)
-			{
-				if (img.rawData.length === 0)
-					this._debugLoadUpdate++;
-				else
-					this._debugLoadDelta++;
-			}
-			else if (img.rawData)
-				this._debugLoadTile++;
 		}
 		this._showDebugForTile(key);
 

--- a/browser/src/layer/tile/ImpressTileLayer.js
+++ b/browser/src/layer/tile/ImpressTileLayer.js
@@ -191,8 +191,8 @@ L.ImpressTileLayer = L.CanvasTileLayer.extend({
 		var topLeftTwips = new L.Point(command.x, command.y);
 		var offset = new L.Point(command.width, command.height);
 		var bottomRightTwips = topLeftTwips.add(offset);
-		if (this._debugTileInvalidations) {
-			this._debugAddInvalidationRectangle(topLeftTwips, bottomRightTwips, textMsg);
+		if (this._debug.tileInvalidationsOn) {
+			this._debug.addInvalidationRectangle(topLeftTwips, bottomRightTwips, textMsg);
 		}
 		var invalidBounds = new L.Bounds(topLeftTwips, bottomRightTwips);
 		var visibleTopLeft = this._latLngToTwips(this._map.getBounds().getNorthWest());
@@ -211,9 +211,8 @@ L.ImpressTileLayer = L.CanvasTileLayer.extend({
 			}
 		}
 
-		if (needsNewTiles && command.part === this._selectedPart && this._debugTileInvalidations)
-		{
-			this._debugAddInvalidationMessage(textMsg);
+		if (needsNewTiles && command.part === this._selectedPart && this._debug.tileInvalidationsOn) {
+			this._debug.addInvalidationMessage(textMsg);
 		}
 
 		if (command.part === this._selectedPart &&

--- a/browser/src/layer/tile/TilesSection.ts
+++ b/browser/src/layer/tile/TilesSection.ts
@@ -438,10 +438,10 @@ export class TilesSection extends CanvasSectionObject {
 			// Ensure tile is within document bounds.
 			if (tile && docLayer._isValidTile(coords)) {
 				if (!this.isJSDOM) { // perf-test code
-					if (tile.hasContent() || docLayer._debugTileOverlays) { // Ensure tile is loaded
+					if (tile.hasContent() || this.map._debug.tileOverlaysOn) { // Ensure tile is loaded
 						this.paint(tile, ctx, false /* async? */, now);
 					}
-					// else if (docLayer._debugTileOverlays) {
+					// else if (this.map._debug.tileOverlaysOn) {
 						// // when debugging draw a checkerboard for the missing tile
 						// var oldcanvas = tile.canvas;
 						// tile.canvas = this.checkpattern;
@@ -658,7 +658,7 @@ export class TilesSection extends CanvasSectionObject {
 		else */
 		canvas.drawImage(tile.canvas, sx, sy, sWidth, sHeight, dx, dy, dWidth, dHeight);
 
-		if (this.sectionProperties.docLayer._debugTileOverlays)
+		if (this.map._debug.tileOverlaysOn)
 		{
 			this.beforeDraw(canvas);
 
@@ -717,7 +717,7 @@ export class TilesSection extends CanvasSectionObject {
 			];
 // FIXME: generate metrics of how long a tile has been visible & invalid for.
 //			if (tile._debugTime && tile._debugTime.date !== 0)
-//					lines.push(this.sectionProperties.docLayer._debugSetTimes(tile._debugTime, +new Date() - tile._debugTime.date));
+//					lines.push(this.map._debug.updateTimeArray(tile._debugTime, +new Date() - tile._debugTime.date));
 
 			const startY = tSize - 12 * lines.length;
 

--- a/browser/src/layer/tile/WriterTileLayer.js
+++ b/browser/src/layer/tile/WriterTileLayer.js
@@ -94,8 +94,8 @@ L.WriterTileLayer = L.CanvasTileLayer.extend({
 		var topLeftTwips = new L.Point(command.x, command.y);
 		var offset = new L.Point(command.width, command.height);
 		var bottomRightTwips = topLeftTwips.add(offset);
-		if (this._debugTileInvalidations) {
-			this._debugAddInvalidationRectangle(topLeftTwips, bottomRightTwips, textMsg);
+		if (this._debug.tileInvalidationsOn) {
+			this._debug.addInvalidationRectangle(topLeftTwips, bottomRightTwips, textMsg);
 		}
 		var invalidBounds = new L.Bounds(topLeftTwips, bottomRightTwips);
 		var visibleTopLeft = this._latLngToTwips(this._map.getBounds().getNorthWest());
@@ -114,9 +114,8 @@ L.WriterTileLayer = L.CanvasTileLayer.extend({
 			}
 		}
 
-		if (needsNewTiles && this._debugTileInvalidations)
-		{
-			this._debugAddInvalidationMessage(textMsg);
+		if (needsNewTiles && this._debug.tileInvalidationsOn) {
+			this._debug.addInvalidationMessage(textMsg);
 		}
 
 		this._previewInvalidations.push(invalidBounds);

--- a/browser/src/map/Map.js
+++ b/browser/src/map/Map.js
@@ -153,6 +153,8 @@ L.Map = L.Evented.extend({
 
 		this._progressBar = L.progressOverlay(new L.point(150, 25));
 
+		this._debug = new L.DebugManager(this);
+
 		// When all these conditions are met, fire statusindicator:initializationcomplete
 		this.initConditions = {
 			'doclayerinit': false,

--- a/browser/src/map/handler/Map.Keyboard.js
+++ b/browser/src/map/handler/Map.Keyboard.js
@@ -663,9 +663,9 @@ L.Map.Keyboard = L.Handler.extend({
 					keyCode = 0;
 					unoKeyCode = this._toUNOKeyCode(keyCode);
 				}
-				if (docLayer._debugTileInvalidations) {
+				if (this._map._debug.tileInvalidationsOn) {
 					// key press times will be paired with the invalidation messages
-					docLayer._debugKeypressQueue.push(+new Date());
+					this._debug._debugKeypressQueue.push(+new Date());
 				}
 
 				if (keyEventFn) {
@@ -916,8 +916,8 @@ L.Map.Keyboard = L.Handler.extend({
 				}
 			} else if (e.altKey) {
 				switch (e.keyCode) {
-				case this.keyCodes.D: // Ctrl + Shift + Alt + d for tile debugging mode
-					this._map._docLayer.toggleDebugMode();
+					case this.keyCodes.D: // Ctrl + Shift + Alt + d for tile debugging mode
+						this._map._debug.toggle();
 				}
 			}
 


### PR DESCRIPTION
Change-Id: I20f42d24a6af91bdcf79dc7fe19e1cf25f90bd89

* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
Moves 600+ lines out of CanvasTileLayer.js into an new file core/Debug.js. Most of this code had nothing to do with the CanvasTileLayer, that's just where it was put because the first debug tool happened to have been put there.

The only changes are to move the code, move the ownership from the doc layer to the map, and rename variables and functions. There is no functional change.

I'm looking for feedback on the new file location (perhaps map/Debug.js would be better?), gotchas around adding a new js file (I added it to the two lists in the Makefile but I'm not sure it needs to be in the pot section), and anything else.

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

