### PR TITLE
cool#8023 clipboard: remove old marker

### DIFF
--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -127,7 +127,6 @@ L.Clipboard = L.Class.extend({
 		if (isStub)
 			text += '    ' + this._getHtmlStubMarker() + '\n';
 		text +=     '    <meta http-equiv="content-type" content="text/html; charset=utf-8"/>\n' +
-			    '    <meta name="origin" content="' + encodedOrigin + '"/>\n' +
 			    '  </head>\n' +
 			    '  <body lang="' + lang + '" dir="ltr"><div id="meta-origin" data-coolorigin="' + encodedOrigin + '">\n' +
 			    body +
@@ -368,12 +367,6 @@ L.Clipboard = L.Class.extend({
 		//   cf. ClientSession.cpp /textselectioncontent:/
 
 		var meta = this._getMetaOrigin(htmlText, '<div id="meta-origin" data-coolorigin="');
-		var newStyle = true;
-		if (meta === '')
-		{
-			meta = this._getMetaOrigin(htmlText, '<meta name="origin" content="');
-			newStyle = false;
-		}
 		var id = this.getMetaPath(0);
 		var idOld = this.getMetaPath(1);
 
@@ -382,7 +375,7 @@ L.Clipboard = L.Class.extend({
 		    (meta.indexOf(id) >= 0 || meta.indexOf(idOld) >= 0))
 		{
 			// Home from home: short-circuit internally.
-			window.app.console.log('short-circuit, internal paste, new style? ' + newStyle);
+			window.app.console.log('short-circuit, internal paste');
 			this._doInternalPaste(this._map, usePasteKeyEvent);
 			return true;
 		}


### PR DESCRIPTION
The old marker is stripped away when Chrome sanitizes the incoming
clipboard HTML. We used to go with both markers to allow an incremental
conversion.

By now, there are no remaining consumers of the old marker, so remove it
before somebody would depend on both markers by accident.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Ib9dd0e7cf64e1a99d6038a179651ef5e114c6f8b
