### PR TITLE
browser: remove 'tmp' dependency

### DIFF
--- a/browser/package.json
+++ b/browser/package.json
@@ -44,8 +44,7 @@
   ],
   "license": "BSD-2-Clause",
   "dependencies": {
-    "jsdom": "^16.4.0",
-    "tmp": "^0.2.1"
+    "jsdom": "^16.4.0"
   },
   "scripts": {
     "test": "mocha 'mocha_tests/**/*.js'",


### PR DESCRIPTION
It was a dependency of "pako" package, which it was removed.

Change-Id: Ia35b4c4ff9ee5e9ab1f09da398f6d93e51d24a1f
Signed-off-by: Henry Castro <hcastro@collabora.com>
