### PR TITLE
Fix cropped userlist popup

### DIFF
--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -1660,6 +1660,9 @@ menu-entry-with-icon.padding-left + menu-entry-icon.width */
 	filter: drop-shadow(0 1px 3px var(--color-box-shadow));
 	min-width: 150px;
 	font-size: var(--default-font-size);
+	max-height: 85vh;
+	overflow-y: auto;
+	overflow-x: hidden;
 }
 
 #userListPopover::after {
@@ -1731,6 +1734,25 @@ html[dir='rtl'] #userListPopover::after {
 
 #userListPopover .user-list-item.selected-user .user-list-item--name {
 	padding: 4px 0 0 8px;
+}
+/* Style for the scrollbar track */
+#userListPopover::-webkit-scrollbar {
+	width: 6px;
+}
+
+/* Style for the scrollbar handle (thumb) */
+#userListPopover::-webkit-scrollbar-thumb {
+	background-color: var(--color-border);
+}
+
+/* Style for the scrollbar track when handle is being dragged */
+#userListPopover::-webkit-scrollbar-thumb:hover {
+	width: 8px;
+}
+
+/* Style for the scrollbar track (not the handle) */
+#userListPopover::-webkit-scrollbar-track {
+	background: transparent;
 }
 
 @media only screen and (max-width: 600px) {


### PR DESCRIPTION
- avatar popup list in the top right corner was getting cropped if we have multiple users ( like more than 10=12)
- this patch will make overflow auto and add scroll option to tackle this issue

[Screencast from 2024-01-25 22-06-50.webm](https://github.com/CollaboraOnline/online/assets/61383886/ae7872fd-6a2d-4d4e-ac92-9452c180fee3)


Signed-off-by: Darshan-upadhyay1110 <darshan.upadhyay@collabora.com>
Change-Id: Id57539cb91a7f4a2a3766e6d01f0e6a00d3af92a
