### PR TITLE
the viewrenderedstate=string string is only used in debugging

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1451,7 +1451,7 @@ private:
         std::string stateName;
         if (!viewRenderedState.empty())
         {
-            stateName = viewRenderedState.substr(viewRenderedState.find(';') + 1);
+            stateName = viewRenderedState;
         }
         else
         {


### PR DESCRIPTION
so we can pass through the full state that the view reports which makes it easy to see if a browser side is given a view whose render settings are unexpected.

e.g. clicking "formatting marks" and not getting a viewrenderedstate with 'P' or view#1 clicks their "formatting marks" and view#2 receives a 'P'ilcrow state.


Change-Id: I31d3a8397f02dedf2505bed5dd83576f3138b504


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

