### PR TITLE
sidebar: reinitialize after reconnect only (23.05)

### DIFF
--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -1418,6 +1418,7 @@ app.definitions.Socket = L.Class.extend({
 			this._map.uiManager.closeAll();
 			this._map.setPermission(app.file.permission);
 			window.migrating = false;
+			this._map.uiManager.initializeSidebar();
 		}
 
 		this._map.fire('docloaded', {status: true});

--- a/browser/src/map/Map.js
+++ b/browser/src/map/Map.js
@@ -295,7 +295,7 @@ L.Map = L.Evented.extend({
 				this.initializeModificationIndicator();
 
 			// Show sidebar.
-			if (this._docLayer) {
+			if (this._docLayer && !this._docLoadedOnce) {
 				// Let the first page finish loading then load the sidebar.
 				setTimeout(this.uiManager.initializeSidebar.bind(this.uiManager), 200);
 			}


### PR DESCRIPTION
It seems that commit 2d7743cb734b31b763f389d686ca349661de9739 sidebar: initialize after recover from idle

Introduced a regression, in multi user case sometimes sidebar is shown/hidden by other users. Also app was slow sometimes what could be a sidebar reloading all the time.

Revert previous single-init on docloaded and use dedicated reconnection code to reinitialize sidebar.

This should still fix the problem that when doc become unloaded with sidebar opened - after reconnecting it was not possible to close.

Perf problem visible in profile: https://github.com/CollaboraOnline/online/issues/8051#issuecomment-1909953739