### PR TITLE
widgets: Add a time field

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -346,6 +346,7 @@ COOL_JS_LST =\
 	src/control/jsdialog/Widget.MultilineEdit.js \
 	src/control/jsdialog/Widget.Progressbar.js \
 	src/control/jsdialog/Widget.ScrolledWindow.js \
+	src/control/jsdialog/Widget.Timefield.js \
 	src/control/jsdialog/Widget.TreeView.js \
 	src/control/Control.JSDialog.js \
 	src/control/Control.JSDialogBuilder.js \

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -723,7 +723,8 @@ input[type='number']:hover::-webkit-outer-spin-button {
 }
 
 .ui-listbox,
-.ui-combobox {
+.ui-combobox,
+.ui-timefield  {
 	box-sizing: border-box;
 	-webkit-appearance: none;
 	-moz-appearance: none;
@@ -777,7 +778,8 @@ input[type='number']:hover::-webkit-outer-spin-button {
 }
 
 /* ui-combobox */
-.ui-combobox {
+.ui-combobox,
+.ui-timefield {
 	border: 1px solid var(--color-border);
 }
 
@@ -1906,4 +1908,9 @@ kbd,
 /* Modal info with 2 line message*/
 .jsdialog-container [id^='info-modal-label'] {
 	display: flex;
+}
+
+#DocumentPropertiesDialog #customprops input.ui-timefield {
+	margin-top: auto;
+	margin-bottom: auto;
 }

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -91,6 +91,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		this._controlHandlers['basespinfield'] = this.baseSpinField;
 		this._controlHandlers['spinfield'] = this._spinfieldControl;
 		this._controlHandlers['metricfield'] = this._metricfieldControl;
+		this._controlHandlers['time'] = JSDialog.timeField;
 		this._controlHandlers['formattedfield'] = this._formattedfieldControl;
 		this._controlHandlers['edit'] = this._editControl;
 		this._controlHandlers['formulabaredit'] = JSDialog.formulabarEdit;
@@ -3272,7 +3273,9 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			&& data.type !== 'expander'
 			&& data.type !== 'panel'
 			&& data.type !== 'buttonbox'
-			&& data.type !== 'treelistbox')
+			&& data.type !== 'treelistbox'
+			&& data.type !== 'time'
+			)
 			control.setAttribute('tabIndex', '0');
 	},
 

--- a/browser/src/control/jsdialog/Widget.Timefield.js
+++ b/browser/src/control/jsdialog/Widget.Timefield.js
@@ -1,0 +1,47 @@
+/* -*- js-indent-level: 8 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * JSDialog.Timefield - input field for time data
+ *
+ * Example JSON:
+ * {
+ *     id: 'time',
+ *     type: 'time',
+ *     text: '01:01:01'
+ * }
+ */
+
+/* global JSDialog */
+
+JSDialog.timeField = function (parentContainer, data, builder) {
+	var inputTimeField = L.DomUtil.create('input', builder.options.cssClass + ' ui-timefield', parentContainer);
+	inputTimeField.setAttribute('type', 'time');
+	inputTimeField.setAttribute('step', 1); // forces the display of seconds
+	inputTimeField.setAttribute('id', data.id);
+	inputTimeField.value = data.text;
+
+	inputTimeField.addEventListener('change', function (event) {
+		var timefield = event.target;
+
+		var attrdisabled = timefield.getAttribute('disabled');
+		if (attrdisabled !== 'disabled') {
+			builder.callback('spinfield', 'change', timefield, timefield.value, builder);
+		}
+	});
+
+	var disabled = data.enabled === 'false' || data.enabled === false;
+	if (disabled) {
+		inputTimeField.disabled = true;
+	}
+
+	return false;
+};


### PR DESCRIPTION
Change-Id: I9e3e280db4a0b1f3e3a9df5fe8b6e0bfd97ddaa5


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

It uses input[type=time] which might not be looking as good as we'd like.

![image](https://github.com/CollaboraOnline/online/assets/620941/4ce16904-b197-4e0b-ad85-c6011a3e9483)

Requires CORE patch: https://gerrit.libreoffice.org/c/core/+/161892 to expose the custom properties tab.

And https://gerrit.libreoffice.org/c/core/+/162598 to expose the field.

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay

