### PR TITLE
Revert "cool#8023 clipboard: remove old marker"

### DIFF
--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -127,6 +127,7 @@ L.Clipboard = L.Class.extend({
 		if (isStub)
 			text += '    ' + this._getHtmlStubMarker() + '\n';
 		text +=     '    <meta http-equiv="content-type" content="text/html; charset=utf-8"/>\n' +
+			    '    <meta name="origin" content="' + encodedOrigin + '"/>\n' +
 			    '  </head>\n' +
 			    '  <body lang="' + lang + '" dir="ltr"><div id="meta-origin" data-coolorigin="' + encodedOrigin + '">\n' +
 			    body +
@@ -367,6 +368,12 @@ L.Clipboard = L.Class.extend({
 		//   cf. ClientSession.cpp /textselectioncontent:/
 
 		var meta = this._getMetaOrigin(htmlText, '<div id="meta-origin" data-coolorigin="');
+		var newStyle = true;
+		if (meta === '')
+		{
+			meta = this._getMetaOrigin(htmlText, '<meta name="origin" content="');
+			newStyle = false;
+		}
 		var id = this.getMetaPath(0);
 		var idOld = this.getMetaPath(1);
 
@@ -375,7 +382,7 @@ L.Clipboard = L.Class.extend({
 		    (meta.indexOf(id) >= 0 || meta.indexOf(idOld) >= 0))
 		{
 			// Home from home: short-circuit internally.
-			window.app.console.log('short-circuit, internal paste');
+			window.app.console.log('short-circuit, internal paste, new style? ' + newStyle);
 			this._doInternalPaste(this._map, usePasteKeyEvent);
 			return true;
 		}

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1599,10 +1599,33 @@ void ClientSession::writeQueuedMessages(std::size_t capacity)
 
 // NB. also see browser/src/map/Clipboard.js that does this in JS for stubs.
 // See also ClientSession::preProcessSetClipboardPayload() which removes the
-// <div id="meta-origin"...>  tag added here.
+// <meta name="origin"...>  tag added here.
 void ClientSession::postProcessCopyPayload(const std::shared_ptr<Message>& payload)
 {
     // Insert our meta origin if we can
+    payload->rewriteDataBody([=](std::vector<char>& data) {
+            std::size_t pos = Util::findInVector(data, "<meta name=\"generator\" content=\"");
+
+            if (pos == std::string::npos)
+                pos = Util::findInVector(data, "<meta http-equiv=\"content-type\" content=\"text/html;");
+
+            // cf. TileLayer.js /_dataTransferToDocument/
+            if (pos != std::string::npos) // assume text/html
+            {
+                const std::string meta = getClipboardURI();
+                LOG_TRC("Inject clipboard meta origin of '" << meta << '\'');
+                const std::string origin = "<meta name=\"origin\" content=\"" + meta + "\"/>\n";
+                data.insert(data.begin() + pos, origin.begin(), origin.end());
+                return true;
+            }
+            else
+            {
+                LOG_DBG("Missing generator in textselectioncontent/clipboardcontent payload.");
+                return false;
+            }
+        });
+
+    // New-style: <div> inside <body>, that is not sanitized by Chrome.
     payload->rewriteDataBody([=](std::vector<char>& data) {
             std::size_t pos = Util::findInVector(data, "<body");
             if (pos != std::string::npos)
@@ -1610,7 +1633,6 @@ void ClientSession::postProcessCopyPayload(const std::shared_ptr<Message>& paylo
                 pos = Util::findInVector(data, ">", pos);
             }
 
-            // cf. TileLayer.js /_dataTransferToDocument/
             if (pos != std::string::npos)
             {
                 const std::string meta = getClipboardURI();
@@ -2745,7 +2767,7 @@ bool ClientSession::isTileInsideVisibleArea(const TileDesc& tile) const
     return false;
 }
 
-// This removes the <div id="meta-origin" ...> tag which was added in
+// This removes the <meta name="origin" ...> tag which was added in
 // ClientSession::postProcessCopyPayload(), else the payload parsing
 // in ChildSession::setClipboard() will fail.
 // To see why, refer
@@ -2754,7 +2776,21 @@ bool ClientSession::isTileInsideVisibleArea(const TileDesc& tile) const
 // 2. The clipboard payload parsing code in ClipboardData::read().
 void ClientSession::preProcessSetClipboardPayload(std::string& payload)
 {
-    std::size_t start = payload.find("<div id=\"meta-origin\" data-coolorigin=\"");
+    std::size_t start = payload.find("<meta name=\"origin\" content=\"");
+    if (start != std::string::npos)
+    {
+        std::size_t end = payload.find("\"/>\n", start);
+        if (end == std::string::npos)
+        {
+            LOG_DBG("Found unbalanced <meta name=\"origin\".../> tag in setclipboard payload.");
+            return;
+        }
+
+        std::size_t len = end - start + 4;
+        payload.erase(start, len);
+    }
+
+    start = payload.find("<div id=\"meta-origin\" data-coolorigin=\"");
     if (start != std::string::npos)
     {
         std::size_t end = payload.find("\">\n", start);


### PR DESCRIPTION
This reverts commit cc12a1b060adb31afe037bb5e18f1cbe4885c3e6, because
there is not much short-term benefit of this and it may cause problems,
as it affects builds produced without --enable-experimental, too.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I4c27614e9ee26c8aaa2c510ee6bd115cd19a45f3
