### PR TITLE
Add url parameter to launch with random settings

### DIFF
--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -1118,6 +1118,21 @@ window.app = {
 		}
 	}
 
+	var isRandomUser = global.coolParams.get('randomUser');
+	if (isRandomUser) {
+		// List of languages supported in core
+		var randomUserLangs = [
+			'ar', 'bg', 'ca', 'cs', 'da', 'de', 'el', 'en-US',
+			'en-GB', 'eo', 'es', 'eu', 'fi', 'fr', 'gl', 'he',
+			'hr', 'hu', 'id', 'is', 'it', 'ja', 'ko', 'lo',
+			'nb', 'nl', 'oc', 'pl', 'pt', 'pt-BR', 'sq', 'ru',
+			'sk', 'sl', 'sv', 'tr', 'uk', 'vi', 'zh-CN', 'zh-TW'];
+		var randomUserLang = randomUserLangs[Math.floor(Math.random() * randomUserLangs.length)];
+		window.app.console.log('Randomize Settings: Set language to: ',randomUserLang);
+		global.coolParams.set('lang', randomUserLang);
+		global.coolParams.set('debug',true);
+	}
+
 	var lang = global.coolParams.get('lang');
 	if (lang)
 		global.langParam = encodeURIComponent(lang);

--- a/browser/src/core/Debug.js
+++ b/browser/src/core/Debug.js
@@ -303,7 +303,7 @@ L.DebugManager = L.Class.extend({
 		this._addDebugTool({
 			name: 'Randomize user settings',
 			category: 'Automated User',
-			startsOn: false,
+			startsOn: !!window.coolParams.get('randomUser'),
 			onAdd: function () {
 				self._randomizeSettings();
 			},


### PR DESCRIPTION
Sets random language and launches debug mode,
turning on the Randomize User Settings tool


Change-Id: I5e06be624cd5383784ea640304980a82e76be229

### Summary
Start random user with
`http://.../...html?...&randomUser=true`

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

