### PR TITLE
cool#8016 speed up spawning/execing child programs

### DIFF
--- a/common/Util.cpp
+++ b/common/Util.cpp
@@ -213,13 +213,33 @@ namespace Util
             params.push_back(const_cast<char *>(i.c_str()));
         params.push_back(nullptr);
 
+        // By default, all file descriptors are inherited by the new child process, except for
+        // those marked close-on-exec (FD_CLOEXEC). Since we don't know for sure that all the descriptors
+        // in our address are correctly tagged, close everything except the stdin/stdout/stderr descriptors.
+        posix_spawn_file_actions_t fileActions;
+        int status = posix_spawn_file_actions_init(&fileActions);
+        if (status < 0)
+        {
+            LOG_ERR("Failed to posix_spawn_file_actions_init for command '" << cmd);
+            throw Poco::SystemException("Failed to posix_spawn_file_actions_init for command ", cmd);
+        }
+        status = posix_spawn_file_actions_addclosefrom_np(&fileActions, STDERR_FILENO + 1);
+        if (status < 0)
+        {
+            LOG_ERR("Failed to posix_spawn_file_actions_addclosefrom_np stdout for command '" << cmd);
+            throw Poco::SystemException("Failed to posix_spawn_file_actions_addclosefrom_np stdout for command ", cmd);
+        }
+
+
         pid_t pid = -1;
-        int status = posix_spawn(&pid, params[0], nullptr, nullptr, params.data(), environ);
+        status = posix_spawn(&pid, params[0], nullptr, nullptr, params.data(), environ);
         if (status < 0)
         {
             LOG_ERR("Failed to posix_spawn for command '" << cmd);
             throw Poco::SystemException("Failed to fork posix_spawn command ", cmd);
         }
+
+        posix_spawn_file_actions_destroy(&fileActions);
 
         return pid;
     }

--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -137,10 +137,8 @@ namespace Util
     /// Get number of threads in this process or -1 on error
     int getProcessThreadCount();
 
-    /// Spawn a process if stdInput is non-NULL it contains a writable descriptor
-    /// to send data to the child.
-    int spawnProcess(const std::string &cmd, const StringVector &args,
-                     const std::vector<int>* fdsToKeep = nullptr, int *stdInput = nullptr);
+    /// Spawn a process.
+    int spawnProcess(const std::string &cmd, const StringVector &args);
 
 #endif
 


### PR DESCRIPTION
using fork(), the kernel needs to copy the VM data structures, which can be quite large for the main COOL processes.

I looked into things like vfork(), clone() and using a helper-process, but it looks like posix_spawn is sufficient for our needs. Internally it uses clone(CLONE_VM) which means we avoid the VMA copies.

Also, simplify the arguments of spawnProcess,
we don't use the optional params anymore.


Change-Id: I8f943541dc4d7f56c2d36ccbf7b78c40ec14b8e0


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

