### PR TITLE
browser: fix cell selection if ESC is pressed

### DIFF
--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -961,7 +961,8 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 	_onTextSelectionMsg: function (textMsg) {
 		L.CanvasTileLayer.prototype._onTextSelectionMsg.call(this, textMsg);
 		// If this is a cellSelection message, user shouldn't be editing a cell. Below check is for ensuring that.
-		if (this.insertMode === false && this._cellCursorXY && this._cellCursorXY.x !== -1) {
+		if ((this.insertMode === false || this._map._isCursorVisible == false) &&
+		    this._cellCursorXY && this._cellCursorXY.x !== -1) {
 			// When insertMode is false, this is a cell selection message.
 			textMsg = textMsg.replace('textselection:', '');
 			if (textMsg.trim() !== 'EMPTY' && textMsg.trim() !== '') {


### PR DESCRIPTION
If a cell is edited and suddenly press ESC key,
followed by Shitf + Arrow down to select more cells,
so the "uno:InsertMode" state arrives late and
it cannot update the row header selection.

Change-Id: Ib0e4e0699336e07d96efd96559f7b47caa285921
Signed-off-by: Henry Castro <hcastro@collabora.com>
