### PR TITLE
Backports 23.05: calc: view jumping fixes

### DIFF
--- a/browser/src/geo/LatLngBounds.js
+++ b/browser/src/geo/LatLngBounds.js
@@ -98,11 +98,11 @@ L.LatLngBounds.prototype = {
 	},
 
 	getWidth: function () {
-		return this.getEast() - this.getWest();
+		return Math.abs(this.getEast() - this.getWest());
 	},
 
 	getHeight: function () {
-		return this.getNorth() - this.getSouth();
+		return Math.abs(this.getNorth() - this.getSouth());
 	},
 
 	contains: function (obj) { // (LatLngBounds) or (LatLng) -> Boolean

--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -1110,13 +1110,12 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 		var noSplit = !this._splitPanesContext
 			|| this._splitPanesContext.getSplitPos().equals(new L.Point(0, 0));
 
-		if (noSplit && this._cellCursor.intersects(paneRectsInLatLng[0])) {
-			// Check if target cell is bigger than screen but partially visible
-			// TODO: handle with split panes
-			var cellWidth = this._cellCursor.getWidth();
-			var paneWidth = paneRectsInLatLng[0].getWidth();
+		var cellWidth = this._cellCursor.getWidth();
+		var cellHeight = this._cellCursor.getHeight();
 
-			var cellHeight = this._cellCursor.getHeight();
+		// No split panes. Check if target cell is bigger than screen but partially visible.
+		if (noSplit && this._cellCursor.intersects(paneRectsInLatLng[0])) {
+			var paneWidth = paneRectsInLatLng[0].getWidth();
 			var paneHeight = paneRectsInLatLng[0].getHeight();
 
 			if (cellWidth > paneWidth || cellHeight > paneHeight)
@@ -1126,23 +1125,32 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 		var freePaneBounds = paneRectsInLatLng[paneRectsInLatLng.length - 1];
 		var splitPoint = map.unproject(this._splitPanesContext ? this._splitPanesContext.getSplitPos() : new L.Point(0, 0));
 
+		// Horizontal split
 		if (this._cellCursor.getEast() > splitPoint.lng) {
+			var freePaneWidth = freePaneBounds.getWidth();
+			var cellWidth = this._cellCursor.getWidth();
 
-			var freePaneWidth = Math.abs(freePaneBounds.getEast() - freePaneBounds.getWest());
-			var cursorWidth = Math.abs(this._cellCursor.getEast() - this._cellCursor.getWest());
-			var spacingX = cursorWidth / 4.0;
+			if (cellWidth > freePaneWidth)
+				return scroll; // no scroll needed.
+
+			var spacingX = cellWidth / 4.0;
 
 			if (this._cellCursor.getWest() < freePaneBounds.getWest()) {
 				scroll.lng = this._cellCursor.getWest() - freePaneBounds.getWest() - spacingX;
 			}
-			else if (cursorWidth < freePaneWidth && this._cellCursor.getEast() > freePaneBounds.getEast()) {
+			else if (cellWidth < freePaneWidth && this._cellCursor.getEast() > freePaneBounds.getEast()) {
 				scroll.lng = this._cellCursor.getEast() - freePaneBounds.getEast() + spacingX;
 			}
 		}
 
+		// Vertical split
 		if (this._cellCursor.getSouth() < splitPoint.lat) {
+			var freePaneHeight = freePaneBounds.getHeight();
 
-			var spacingY = Math.abs((this._cellCursor.getSouth() - this._cellCursor.getNorth())) / 4.0;
+			if (cellHeight > freePaneHeight)
+				return scroll; // no scroll needed.
+
+			var spacingY = cellHeight / 4.0;
 			if (this._cellCursor.getNorth() > freePaneBounds.getNorth()) {
 				scroll.lat = this._cellCursor.getNorth() - freePaneBounds.getNorth() + spacingY;
 			}


### PR DESCRIPTION
calc: avoid view jump when focusing formula wizard
    
    Change from commit 85ff10db7a861ac0a848d6276347b8709d151a23
    calc: avoid view jump when using formula wizard
    
    wasn't enough to fix the issue. When we receive grab_focus
    action for widget which is hidden outside view - browser
    will move the app view leaving blank space on bottom.
    
    Steps to reproduce problem:
        1.    open spreadsheet
        2.    open function wizard (Fx icon next to the formulabar)
        3.    move dialog so it is almost completely outside view (edit field
              with focus has to be outside view)
        4.    select some function and click inside edit field for it's param
        5.    click on the sheet content
        Result: view jumps and moves everything up
    
-----------------------------------------------------------------------------

calc: don't jump on merged cell selection with split panes
    
    This issue can be reproduced in spreadsheet with split pane
    where some cell is merged and longer than a visible area.
    Then every click on that cell will move view to the
    beginning of the cell - we don't want that.