### PR TITLE
unit-bad-doc-load: fix this to pass again

### DIFF
--- a/test/UnitBadDocLoad.cpp
+++ b/test/UnitBadDocLoad.cpp
@@ -79,7 +79,12 @@ UnitBase::TestResult UnitBadDocLoad::testBadDocLoadFail()
         // Click "Ok"
         helpers::sendTextFrame(socket, "dialogevent 2 {\"id\":\"ok\", \"cmd\": \"click\", \"data\": \"1\", \"type\": \"responsebutton\"}", testname);
 
-        const auto response = helpers::getResponseString(socket, "error:", testname);
+        auto response = helpers::getResponseString(socket, "error:", testname);
+        if (Util::startsWith(response, "error: cmd=notasync"))
+        {
+            // Continue searching for the interesting failure.
+            response = helpers::getResponseString(socket, "error:", testname);
+        }
         StringVector tokens(StringVector::tokenize(response, ' '));
         LOK_ASSERT_EQUAL(static_cast<size_t>(3), tokens.size());
 


### PR DESCRIPTION
Probably went wrong with bf8b9945ab304c3c4604ff296ff33b3f127accf7 (Warn
on non-async dialog usage when in debug mode., 2024-01-26).

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Ifb92e0d9431f252cdf26ac92dd428b87e5d6e8e0
