### PR TITLE
Introduce redlinedDeletion type for comments.

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -506,6 +506,10 @@ nav.spreadsheet-color-indicator ~ #sidebar-dock-wrapper {
 	max-width: 250px;
 }
 
+.cool-annotation.greyed {
+	opacity: 0.5;
+}
+
 .cool-annotation > .modalpopup {
 	max-height: initial !important;
 }

--- a/browser/src/layer/tile/CommentSection.ts
+++ b/browser/src/layer/tile/CommentSection.ts
@@ -64,6 +64,12 @@ export class Comment extends CanvasSectionObject {
 		this.sectionProperties.margin = options.margin ? options.margin : [40, 40];
 		this.sectionProperties.noMenu = options.noMenu ? options.noMenu : false;
 
+		/*
+			data.layoutStatus: Enumartion sent from the core side.
+			0: INVISIBLE, 1: VISIBLE, 2: INSERTED, 3: DELETED, 4: NONE, 5: HIDDEN
+			Ex: "DELETED" means that the comment is deleted while the "track changes" is on.
+		*/
+
 		if (data.parent === undefined)
 			data.parent = '0';
 
@@ -723,6 +729,14 @@ export class Comment extends CanvasSectionObject {
 		}
 	}
 
+	public setLayoutClass(): void {
+		this.sectionProperties.container.classList.remove('greyed');
+
+		if (this.sectionProperties.data.layoutStatus === 3) {
+			this.sectionProperties.container.classList.add('greyed');
+		}
+	}
+
 	public show(): void {
 		this.doPendingInitializationInView(true /* force */);
 		this.showMarker();
@@ -739,6 +753,8 @@ export class Comment extends CanvasSectionObject {
 			this.showImpressDraw();
 		else if (this.sectionProperties.docLayer._docType === 'spreadsheet')
 			this.showCalc();
+
+		this.setLayoutClass();
 	}
 
 	private hideWriter() {


### PR DESCRIPTION
When a comment is deleted while tracking is on, we need to show it if showChanges is also on. This PR improves the handling of tracked changes for comments.


Change-Id: I2f6956fa18504995f91e6e1c0fa3d633f4317f5c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

