### PR TITLE
notebookbar: enable currency dropdown (backport to 23.05)

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2536,7 +2536,15 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			controls['arrow'] = arrow;
 			$(arrowbackground).click(function (event) {
 				if (!$(div).hasClass('disabled')) {
-					builder.callback('toolbox', 'openmenu', parentContainer, data.command, builder);
+					// 23.05: notebookbar structure contains additional "table-xxx" containers
+					var realToolboxParent = parentContainer;
+					while (realToolboxParent && (!realToolboxParent.id
+						|| realToolboxParent.id.indexOf('table-') >= 0
+						|| realToolboxParent.id.indexOf('-row') >= 0)) {
+						realToolboxParent = realToolboxParent.parentNode;
+					}
+
+					builder.callback('toolbox', 'openmenu', realToolboxParent, data.command, builder);
 					event.stopPropagation();
 				}
 			});

--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -673,12 +673,13 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 						'type': 'container',
 						'children': [
 							{
-								'id': 'second9',
+								'id': 'WeldedToolbar', // has to match core .ui file toolbox id!
 								'type': 'toolbox',
 								'children': [
 									{
 										'id': 'home-number-format-currency',
 										'type': 'toolitem',
+										'dropdown': true,
 										'text': _UNO('.uno:NumberFormatCurrency', 'spreadsheet'),
 										'command': '.uno:NumberFormatCurrency',
 										'accessibility': { focusBack: true,	combination: 'P', de: null }


### PR DESCRIPTION
jsdialog: openmenu action support in notebookbar
    
    In notebookbar we insert additional containers for rows and cells.
    When sending openmenu action we need to pass id of the real parent
    of a button which is a toolbox. Go up in the structure to get
    correct node.
    
    This is 23.05 only as in master we already have simplified structure.

--------------------------

notebookbar: enable dropdown for currency toolitem
    
    use toolbar from notebookbar_online.ui in the core