### PR TITLE
Calc: sidebar: Hide Styles dialog button

### DIFF
--- a/browser/css/spreadsheet.css
+++ b/browser/css/spreadsheet.css
@@ -220,3 +220,11 @@
 #toolbar-wrapper.spreadsheet.tablet.readonly {
 	z-index: -1;
 }
+
+/* Sidebar: Style: Hide dialog button
+   - There is no paragraph style dialog in calc
+   - The style sidebar pane visible on core side is not implemented in online
+*/
+.spreadsheet ~ #main-document-content #sidebar-dock-wrapper .unoEditStyle.sidebar {
+	display: none;
+}


### PR DESCRIPTION
This button does nothing (Sidebar: Style: dialog button [square with arrow])
   - There is no paragraph style dialog in calc
   - The style sidebar pane visible on core side is not implemented in
   online

Better to hide it for now.

Fixes https://github.com/CollaboraOnline/online/issues/8135

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I62db3ec6466782a9dc2cb89deffec8023851de2d
