### PR TITLE
calc & impress: show invalidations debug only for the current part.

### DIFF
--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -194,7 +194,7 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 		var topLeftTwips = new L.Point(command.x, command.y);
 		var offset = new L.Point(command.width, command.height);
 		var bottomRightTwips = topLeftTwips.add(offset);
-		if (this._debug.tileInvalidationsOn) {
+		if (this._debug.tileInvalidationsOn && command.part === this._selectedPart) {
 			this._debug.addInvalidationRectangle(topLeftTwips, bottomRightTwips, textMsg);
 		}
 

--- a/browser/src/layer/tile/ImpressTileLayer.js
+++ b/browser/src/layer/tile/ImpressTileLayer.js
@@ -191,7 +191,7 @@ L.ImpressTileLayer = L.CanvasTileLayer.extend({
 		var topLeftTwips = new L.Point(command.x, command.y);
 		var offset = new L.Point(command.width, command.height);
 		var bottomRightTwips = topLeftTwips.add(offset);
-		if (this._debug.tileInvalidationsOn) {
+		if (this._debug.tileInvalidationsOn && command.part === this._selectedPart) {
 			this._debug.addInvalidationRectangle(topLeftTwips, bottomRightTwips, textMsg);
 		}
 		var invalidBounds = new L.Bounds(topLeftTwips, bottomRightTwips);


### PR DESCRIPTION
Helps us to catch un-necessary invalidations more precisely.

I think this will help improve the hunt for bogus invalidations for now.