### PR TITLE
Hide exportpdf command in the android app

### DIFF
--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -2124,6 +2124,9 @@ L.Control.Menubar = L.Control.extend({
 		if (menuItem.id && (menuItem.id.startsWith('exportas')) && this._map['wopi'].UserCanNotWriteRelative)
 			return false;
 
+		if (menuItem.id && menuItem.id === 'exportpdf' && window.ThisIsTheAndroidApp)
+			return false;
+
 		if ((menuItem.id === 'shareas' || menuItem.id === 'ShareAs') && !this._map['wopi'].EnableShare)
 			return false;
 

--- a/browser/src/control/Control.NotebookbarBuilder.js
+++ b/browser/src/control/Control.NotebookbarBuilder.js
@@ -551,12 +551,13 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 					'text': _('PDF Document (.pdf)'),
 					'command': !window.ThisIsAMobileApp ? 'exportdirectpdf' : 'downloadas-pdf'
 				},
+			].concat(!window.ThisIsTheAndroidApp ? [
 				{
 					'id': 'exportpdf' ,
 					'text': _('PDF Document (.pdf) as...'),
-					'command': 'exportpdf' 
+					'command': 'exportpdf'
 				}
-			];
+			] : []);
 		} else if (docType === 'spreadsheet') {
 			submenuOpts = [
 				{
@@ -580,12 +581,13 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 					'text': _('PDF Document (.pdf)'),
 					'command': !window.ThisIsAMobileApp ? 'exportdirectpdf' : 'downloadas-pdf'
 				},
+			].concat(!window.ThisIsTheAndroidApp ? [
 				{
 					'id': 'exportpdf' ,
 					'text': _('PDF Document (.pdf) as...'),
-					'command': 'exportpdf' 
+					'command': 'exportpdf'
 				}
-			];
+			] : []);
 		} else if (docType === 'presentation') {
 			submenuOpts = [
 				{
@@ -609,12 +611,13 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 					'text': _('PDF Document (.pdf)'),
 					'command': !window.ThisIsAMobileApp ? 'exportdirectpdf' : 'downloadas-pdf'
 				},
+			].concat(!window.ThisIsTheAndroidApp ? [
 				{
 					'id': 'exportpdf' ,
 					'text': _('PDF Document (.pdf) as...'),
-					'command': 'exportpdf' 
+					'command': 'exportpdf'
 				}
-			];
+			] : []);
 		}
 
 		submenuOpts.forEach(function mapIconToItem(menuItem) {


### PR DESCRIPTION
Curently, the exportpdf command hangs in the android app. A fix is in progress, but as a stopgap solution disabling the command will avoid people getting stuck


Change-Id: Ied74c3f1fa57356542f3f71e1becbae81f5af7fc

