### PR TITLE
 Log test name when starting and finishing test (backport to 23.05)

### DIFF
--- a/cypress_test/integration_tests/common/helper.js
+++ b/cypress_test/integration_tests/common/helper.js
@@ -512,6 +512,7 @@ function reload(fileName, subFolder, noFileCopy, isMultiUser, subsequentLoad, ha
 
 // noRename - whether or not to give the file a unique name, if noFileCopy is false.
 function beforeAll(fileName, subFolder, noFileCopy, isMultiUser, subsequentLoad, hasInteractionBeforeLoad, noRename) {
+	cy.log('Starting test: ' + Cypress.spec.relative + ' / ' + Cypress.currentTest.titlePath.join(' / '));
 	// Set defaults here in order to remove checks from cy.cGet function.
 	cy.cSetActiveFrame('#coolframe');
 	cy.cSetLevel('1');
@@ -523,6 +524,7 @@ function afterAll(fileName, testState) {
 	if (Cypress.browser.isHeaded)
 		cy.wait(2000);
 	closeDocument(fileName, testState);
+	cy.log('Finished test: ' + Cypress.spec.relative + ' / ' + Cypress.currentTest.titlePath.join(' / '));
 }
 
 // This method is intended to call after each test case.


### PR DESCRIPTION
Change-Id: I15b3e0c02ad841872dc9d472672c112860f2bf47

### Summary
This is a very low risk quality-of-life improvement, just merged into master but it would be nice to have in 23.05 too.

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

