### PR TITLE
Remove trendy C++ & Poco wrappers for random numbers.

### DIFF
--- a/common/Util.cpp
+++ b/common/Util.cpp
@@ -65,7 +65,6 @@
 #include <Poco/JSON/JSON.h>
 #include <Poco/JSON/Object.h>
 #include <Poco/JSON/Parser.h>
-#include <Poco/RandomStream.h>
 #include <Poco/TemporaryFile.h>
 #include <Poco/Util/Application.h>
 #include <Poco/URI.h>
@@ -79,22 +78,25 @@ namespace Util
 {
     namespace rng
     {
-        static std::random_device _rd;
         static std::mutex _rngMutex;
-        static Poco::RandomBuf _randBuf;
 
         // Create the prng with a random-device for seed.
         // If we don't have a hardware random-device, we will get the same seed.
         // In that case we are better off with an arbitrary, but changing, seed.
-        static std::mt19937_64 _rng = std::mt19937_64(_rd.entropy()
-                                                    ? _rd()
-                                                    : (clock() + getpid()));
+        static std::mt19937_64 _rng = std::mt19937_64(rng::getSeed());
+
+        uint_fast64_t getSeed()
+        {
+            std::vector<char> hardRandom = getBytes(16);
+            uint_fast64_t seed = *reinterpret_cast<uint_fast64_t *>(hardRandom.data());
+            return seed;
+        }
 
         // A new seed is used to shuffle the sequence.
         // N.B. Always reseed after getting forked!
         void reseed()
         {
-            _rng.seed(_rd.entropy() ? _rd() : (clock() + getpid()));
+            _rng.seed(rng::getSeed());
         }
 
         // Returns a new random number.
@@ -107,7 +109,27 @@ namespace Util
         std::vector<char> getBytes(const std::size_t length)
         {
             std::vector<char> v(length);
-            _randBuf.readFromDevice(v.data(), v.size());
+
+            int len = 0;
+#ifdef HAVE_SYS_RANDOM_H
+            len = getrandom(v.data(), length, GRND_NONBLOCK);
+
+            // if getrandom() fails, we fall back to "/dev/[u]random" approach.
+            if (len != length)
+#endif
+            {
+                LOG_TRC("Lower performance fallback - missing getrandom function");
+                const int fd = open("/dev/urandom", O_RDONLY);
+                if (fd < 0 ||
+                    (len = read(fd, v.data(), length)) < 0 ||
+                    std::size_t(len) < length)
+                {
+                    LOG_ERR("failed to read " << length << " hard random bytes, got " << len << " for hash: " << errno);
+                }
+                if (fd >= 0)
+                    close(fd);
+            }
+
             return v;
         }
 
@@ -130,24 +152,6 @@ namespace Util
 
             // a poor fallback but something.
             std::vector<char> random = getBytes(length);
-            int len = 0;
-#ifdef HAVE_SYS_RANDOM_H
-            len = getrandom(random.data(), length, GRND_NONBLOCK);
-
-            // if getrandom() fails, we fall back to "/dev/[u]random" approach.
-            if (len != length)
-#endif
-            {
-                const int fd = open("/dev/urandom", O_RDONLY);
-                if (fd < 0 ||
-                    (len = read(fd, random.data(), length)) < 0 ||
-                    std::size_t(len) < length)
-                {
-                    LOG_ERR("failed to read " << length << " hard random bytes, got " << len << " for hash: " << errno);
-                }
-                if (fd >= 0)
-                    close(fd);
-            }
 
             hex.rdbuf()->setLineLength(0); // Don't insert line breaks.
             hex.write(random.data(), length);

--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -85,6 +85,7 @@ namespace Util
 {
     namespace rng
     {
+        uint_fast64_t getSeed();
         void reseed();
         unsigned getNext();
 


### PR DESCRIPTION
And improve quality of low-grade random numbers significantly. _rd.entropy() ? is not your friend.

Change-Id: I477557245949334bec517cdeae653c7452ed2049
Signed-off-by: Michael Meeks <michael.meeks@collabora.com>
(cherry picked from commit b627777b13a32cb17ac17d575f300eb411cd2bc5)


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

