### PR TITLE
randomness: abort if we can't get randomness, with a message.

### DIFF
--- a/common/Util.cpp
+++ b/common/Util.cpp
@@ -119,13 +119,16 @@ namespace Util
             if (len != length)
 #endif
             {
-                LOG_TRC("Lower performance fallback - missing getrandom function");
                 const int fd = open("/dev/urandom", O_RDONLY);
                 if (fd < 0 ||
                     (len = read(fd, v.data(), length)) < 0 ||
                     std::size_t(len) < length)
                 {
-                    LOG_ERR("failed to read " << length << " hard random bytes, got " << len << " for hash: " << errno);
+                    fprintf(stderr, "No adequate source of randomness, "
+                            "failed to read %ld bytes: with error %s\n",
+                            (long int)length, strerror(errno));
+                    // Potentially dangerous to continue without randomness
+                    abort();
                 }
                 if (fd >= 0)
                     close(fd);


### PR DESCRIPTION
Avoid using LOG_TRC etc. during static initializers before logging is setup:

 #0  0x00007ffff7362183 in std::string::size() const () from /lib64/libstdc++.so.6
 #1  0x00000000007d1acc in std::operator==<char> (__lhs="", __rhs=<error reading variable: Cannot access memory at address 0xffffffffffffffe8>)
     at /opt/rh/devtoolset-12/root/usr/include/c++/12/bits/basic_string.h:3586
 #2  0x00000000008fdc04 in Poco::Logger::unsafeGet (name="") at src/Logger.cpp:289
 #3  0x00000000008fdb81 in Poco::Logger::get (name="") at src/Logger.cpp:280
 #4  0x000000000066a30f in Log::logger () at /opt/rh/devtoolset-12/root/usr/include/c++/12/bits/new_allocator.h:90
 #5  0x0000000000692f8e in Util::rng::getBytes (length=16) at ../common/Util.cpp:122
 #6  0x0000000000693312 in Util::rng::getSeed () at ../common/Util.cpp:91
 #7  0x000000000044f987 in __static_initialization_and_destruction_0 (__initialize_p=1, __priority=65535) at ../common/Log.hpp:87

Change-Id: I6a32a0d3f50a8e769994737d4c09befe11599b4e


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

