### PR TITLE
Upgrade to Cypress 13

### DIFF
--- a/cypress_test/package.json
+++ b/cypress_test/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cypress_test",
   "version": "1.0.0",
-  "description": "Cypress integration test suit",
+  "description": "Cypress integration test suite",
   "license": "MPL-2.0",
   "devDependencies": {
     "@babel/core": "^7.22.8",
@@ -10,12 +10,11 @@
     "@typescript-eslint/eslint-plugin": "^4.21.0",
     "@typescript-eslint/parser": "^4.21.0",
     "babel-loader": "^9.1.3",
-    "cypress": "^12.17.0",
+    "cypress": "13.5.1",
     "cypress-file-upload": "5.0.8",
-    "cypress-iframe": "1.0.1",
     "cypress-log-to-output": "1.1.2",
     "cypress-terminal-report": "^5.3.0",
-    "cypress-wait-until": "1.7.2",
+    "cypress-wait-until": "^3.0.1",
     "eslint": "7.19.0",
     "eslint-plugin-cypress-rules": "file:eslint_plugin",
     "get-port-cli": "2.0.0",

--- a/cypress_test/support/index.js
+++ b/cypress_test/support/index.js
@@ -3,7 +3,6 @@
 
 require('cypress-wait-until');
 require('cypress-file-upload');
-require('cypress-iframe');
 import installLogsCollector from 'cypress-terminal-report/src/installLogsCollector';
 
 installLogsCollector();


### PR DESCRIPTION
Change-Id: I8edbcbb72e1ad016df0ff6a2466d20865f517683

### Summary
I am affected by https://github.com/cypress-io/cypress/issues/27869 which causes random crashes when using make run. Some days it's worse than others but today it was preventing me from using make run at all. The recommended solution is to upgrade to at least Cypress 13.3.

I also upgraded cypress-wait-until, which has a major update in 3.0.0 regarding measuring timeouts.

I also deleted cypress-iframe which was unused, no longer updated, and throwing npm errors.

There are still some errors thrown from cypress-tags via its dependency @cypress/browserify-preprocessor. Unfortunately there's no more recent version.
```
npm WARN deprecated @babel/plugin-proposal-class-properties@7.18.6: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-class-properties instead.
npm WARN deprecated @babel/plugin-proposal-object-rest-spread@7.20.7: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-object-rest-spread instead.
```


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

