### PR TITLE
draw: Don't force the shape be inside the page

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -4254,23 +4254,27 @@ L.CanvasTileLayer = L.Layer.extend({
 					this._graphicSelectionTwips.min.x + deltaPos.x,
 					this._graphicSelectionTwips.min.y + deltaPos.y);
 
-				var size = this._graphicSelectionTwips.getSize();
-
 				if (calcRTL) {
 					// make x coordinate of newPos +ve
 					newPos.x = -newPos.x;
 				}
 
-				// try to keep shape inside document
-				if (newPos.x + size.x > this._docWidthTwips)
-					newPos.x = this._docWidthTwips - size.x;
-				if (newPos.x < 0)
-					newPos.x = 0;
+				if (this.isWriter() || this.isCalc()) {
+					// try to keep shape inside document
+					// This is required in Writer, but Impress and Draw
+					// allow shapes outside of the page/slide boundaries.
+					var size = this._graphicSelectionTwips.getSize();
 
-				if (newPos.y + size.y > this._docHeightTwips)
-					newPos.y = this._docHeightTwips - size.y;
-				if (newPos.y < 0)
-					newPos.y = 0;
+					if (newPos.x + size.x > this._docWidthTwips)
+						newPos.x = this._docWidthTwips - size.x;
+					if (newPos.x < 0)
+						newPos.x = 0;
+
+					if (newPos.y + size.y > this._docHeightTwips)
+						newPos.y = this._docHeightTwips - size.y;
+					if (newPos.y < 0)
+						newPos.y = 0;
+				}
 
 				if (this.isCalc() && this.options.printTwipsMsgsEnabled) {
 					newPos = this.sheetGeometry.getPrintTwipsPointFromTile(newPos);


### PR DESCRIPTION
Change-Id: I071572976df602a346d581eb45cf3706c09e7d19


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

We can't drag object out of the page. It seems deliberate, because of Calc and Writer. However Draw and Impress allow this.

### TODO

- [ ] Figure out how to have the out of page layer.
- [x] make sure it doesn't break calc and writer.

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

