### PR TITLE
fix the coolwsd.service being disabled after updates (#3125, #7606)

### DIFF
--- a/coolwsd.spec.in
+++ b/coolwsd.spec.in
@@ -134,11 +134,15 @@ if [ $COOLWSD_IS_ACTIVE == "1" ]; then systemctl start coolwsd; fi
 
 
 %preun
-systemctl --no-reload disable coolwsd.service > /dev/null 2>&1 || :
-systemctl stop coolwsd.service > /dev/null 2>&1 || :
+if [ $1 -eq 0 ]; then
+    systemctl --no-reload disable coolwsd.service > /dev/null 2>&1 || :
+    systemctl stop coolwsd.service > /dev/null 2>&1 || :
+fi
 
 %postun
-systemctl daemon-reload >/dev/null 2>&1 || :
+if [ $1 -eq 0 ]; then
+    systemctl daemon-reload >/dev/null 2>&1 || :
+fi
 
 %changelog
 * Mon Aug 03 2015 Mihai Varga


### PR DESCRIPTION
* Resolves: #3125, #7606
* Target version: master 

### Summary

The current `%preun` and `%postun` cause the `coolwsd.service` to be disabled after each update of the RPM. This is due to the [order](https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/#ordering) in which the scripts run. In this case, the `%preun` and `%postun` of the *outdated* package being uninstalled runs after the installation of the updated package - thus always disabling the service.

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check` (no change to actual code)
- [ ] I have issued `make run` and manually verified that everything looks okay (no change to actual code)
- [x] Documentation (manuals or wiki) has been updated or is not required

