### PR TITLE
fix error in RPM postinstall scriptlet on RHEL8 (#7071)

### DIFF
--- a/coolwsd.spec.in
+++ b/coolwsd.spec.in
@@ -97,7 +97,7 @@ setcap cap_fowner,cap_chown,cap_mknod,cap_sys_chroot=ep /usr/bin/coolforkit
 setcap cap_sys_admin=ep /usr/bin/coolmount
 if [ -f /etc/loolwsd/loolwsd.xml ]; then /usr/bin/coolconfig migrateconfig --write; fi
 # compatibility with older systemd versions
-SYSTEMD_VERSION=$(busctl --system get-property org.freedesktop.systemd1 /org/freedesktop/systemd1 org.freedesktop.systemd1.Manager Version | grep -Eo [0-9]{3})
+SYSTEMD_VERSION=$(busctl --system get-property org.freedesktop.systemd1 /org/freedesktop/systemd1 org.freedesktop.systemd1.Manager Version | grep -Eo [0-9]{3} | head -n 1)
 if [[ "$SYSTEMD_VERSION" -lt "228" ]]; then
     sed -i "/^ProtectSystem/d" /usr/lib/systemd/system/coolwsd.service
 fi


### PR DESCRIPTION
Change-Id: Ia022c46e7ada12e6e07b2da95e3cdccc026609cc


* Resolves: #7071
* Target version: master 

### Summary
A change in the output of `busctl --system get-property org.freedesktop.systemd1 /org/freedesktop/systemd1 org.freedesktop.systemd1.Manager Version` causes some `if`-statements to fail when installing the RPM package on RHEL8 (or derivatives). This PR adjusts for that.

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check` (no change to actual code)
- [ ] I have issued `make run` and manually verified that everything looks okay (no change to actual code)
- [x] Documentation (manuals or wiki) has been updated or is not required

