### PR TITLE
More Parallel Loading Prerequisites

### DIFF
--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -252,8 +252,9 @@ public:
             if (!_shuttingDown)
                 sendCloseFrame(statusCode, statusMessage);
             socket->closeConnection();
-            socket->getInBuffer().clear();
             socket->ignoreInput();
+            assert(socket->getInBuffer().empty() &&
+                   "Socket buffer must be empty after ignoreInput");
         }
 
         _wsPayload.clear();

--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -653,6 +653,11 @@ public:
         return sendTextMessage(msg.c_str(), msg.size());
     }
 
+    template <std::size_t N> int sendMessage(const char (&msg)[N]) const
+    {
+        return sendTextMessage(msg, N - 1); // Minus the null-terminator.
+    }
+
     /// Implementation of the ProtocolHandlerInterface.
     int sendTextMessage(const char* msg, const size_t len, bool flush = false) const override
     {

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -3669,10 +3669,9 @@ void COOLWSD::sendMessageToForKit(const std::string& message)
 /// Find the DocumentBroker for the given docKey, if one exists.
 /// Otherwise, creates and adds a new one to DocBrokers.
 /// May return null if terminating or MaxDocuments limit is reached.
-/// After returning a valid instance DocBrokers must be cleaned up after exceptions.
-std::shared_ptr<DocumentBroker>
-findOrCreateDocBroker(const std::shared_ptr<ProtocolHandlerInterface>& proto,
-                      DocumentBroker::ChildType type, const std::string& uri,
+/// Returns the error message, if any, when no DocBroker is created/found.
+std::pair<std::shared_ptr<DocumentBroker>, std::string>
+findOrCreateDocBroker(DocumentBroker::ChildType type, const std::string& uri,
                       const std::string& docKey, const std::string& id, const Poco::URI& uriPublic,
                       unsigned mobileAppDocId = 0)
 {
@@ -3689,14 +3688,8 @@ findOrCreateDocBroker(const std::shared_ptr<ProtocolHandlerInterface>& proto,
         // TerminationFlag implies ShutdownRequested.
         LOG_WRN((SigUtil::getTerminationFlag() ? "TerminationFlag" : "ShudownRequestedFlag")
                 << " set. Not loading new session [" << id << "] for docKey [" << docKey << ']');
-        if (proto)
-        {
-            const std::string msg("error: cmd=load kind=recycling");
-            proto->sendTextMessage(msg.data(), msg.size());
-            proto->shutdown(true, msg);
-        }
 
-        return nullptr;
+        return std::make_pair(nullptr, "error: cmd=load kind=recycling");
     }
 
     std::shared_ptr<DocumentBroker> docBroker;
@@ -3715,14 +3708,8 @@ findOrCreateDocBroker(const std::shared_ptr<ProtocolHandlerInterface>& proto,
             LOG_WRN("DocBroker [" << docKey
                                   << "] is unloading. Rejecting client request to load session ["
                                   << id << ']');
-            if (proto)
-            {
-                const std::string msg("error: cmd=load kind=docunloading");
-                proto->sendTextMessage(msg.data(), msg.size());
-                proto->shutdown(true, msg);
-            }
 
-            return nullptr;
+            return std::make_pair(nullptr, "error: cmd=load kind=docunloading");
         }
     }
     else
@@ -3736,22 +3723,8 @@ findOrCreateDocBroker(const std::shared_ptr<ProtocolHandlerInterface>& proto,
         // TerminationFlag implies ShutdownRequested.
         LOG_ERR((SigUtil::getTerminationFlag() ? "TerminationFlag" : "ShudownRequestedFlag")
                 << " set. Not loading new session [" << id << "] for docKey [" << docKey << ']');
-        if (proto)
-        {
-            const std::string msg("error: cmd=load kind=recycling");
-            proto->sendTextMessage(msg.data(), msg.size());
-            proto->shutdown(true, msg);
-        }
 
-        return nullptr;
-    }
-
-    // Indicate to the client that we're connecting to the docbroker.
-    if (proto)
-    {
-        const std::string statusConnect = "statusindicator: connect";
-        LOG_TRC("Sending to Client [" << statusConnect << ']');
-        proto->sendTextMessage(statusConnect.data(), statusConnect.size());
+        return std::make_pair(nullptr, "error: cmd=load kind=recycling");
     }
 
     if (!docBroker)
@@ -3775,7 +3748,43 @@ findOrCreateDocBroker(const std::shared_ptr<ProtocolHandlerInterface>& proto,
         LOG_TRC("Have " << DocBrokers.size() << " DocBrokers after inserting [" << docKey << ']');
     }
 
-    return docBroker;
+    return std::make_pair(docBroker, std::string());
+}
+
+/// Find the DocumentBroker for the given docKey, if one exists.
+/// Otherwise, creates and adds a new one to DocBrokers.
+/// May return null if terminating or MaxDocuments limit is reached.
+/// After returning a valid instance DocBrokers must be cleaned up after exceptions.
+std::shared_ptr<DocumentBroker>
+findOrCreateDocBroker(const std::shared_ptr<ProtocolHandlerInterface>& proto,
+                      DocumentBroker::ChildType type, const std::string& uri,
+                      const std::string& docKey, const std::string& id, const Poco::URI& uriPublic,
+                      unsigned mobileAppDocId = 0)
+{
+    const auto& [docBroker, error] =
+        findOrCreateDocBroker(type, uri, docKey, id, uriPublic, mobileAppDocId);
+
+    if (docBroker)
+    {
+        // Indicate to the client that we're connecting to the docbroker.
+        if (proto)
+        {
+            const std::string statusConnect = "statusindicator: connect";
+            LOG_TRC("Sending to Client [" << statusConnect << ']');
+            proto->sendTextMessage(statusConnect.data(), statusConnect.size());
+        }
+
+        return docBroker;
+    }
+
+    // Failed.
+    if (proto)
+    {
+        proto->sendTextMessage(error.data(), error.size(), /*flush=*/true);
+        proto->shutdown(true, error);
+    }
+
+    return nullptr;
 }
 
 /// Handles the socket that the prisoner kit connected to WSD on.

--- a/wsd/RequestVettingStation.hpp
+++ b/wsd/RequestVettingStation.hpp
@@ -18,18 +18,18 @@
 class RequestVettingStation
 {
 public:
-    RequestVettingStation(std::string id, std::shared_ptr<WebSocketHandler> ws,
+    RequestVettingStation(const std::string& id, const std::shared_ptr<WebSocketHandler>& ws,
                           const RequestDetails& requestDetails,
                           const std::shared_ptr<StreamSocket>& socket, unsigned mobileAppDocId)
-        : _id(std::move(id))
+        : _id(id)
         , _ws(ws)
         , _requestDetails(requestDetails)
         , _socket(socket)
         , _mobileAppDocId(mobileAppDocId)
     {
         // Indicate to the client that document broker is searching.
-        static const std::string status("statusindicator: find");
-        LOG_TRC("Sending to Client [" << status << "].");
+        static constexpr const char* const status = "statusindicator: find";
+        LOG_TRC("Sending to Client [" << status << ']');
         _ws->sendMessage(status);
     }
 

--- a/wsd/RequestVettingStation.hpp
+++ b/wsd/RequestVettingStation.hpp
@@ -42,8 +42,10 @@ private:
                          const Poco::URI& uriPublic, const bool isReadOnly,
                          Poco::JSON::Object::Ptr wopiInfo = nullptr);
 
+#if !MOBILEAPP
     void checkFileInfo(SocketPoll& poll, const std::string& url, const Poco::URI& uriPublic,
                        const std::string& docKey, bool isReadOnly, int redirectionLimit);
+#endif //!MOBILEAPP
 
     /// Send an error to the client and disconnect the socket.
     static void sendErrorAndShutdown(const std::shared_ptr<WebSocketHandler>& ws,

--- a/wsd/RequestVettingStation.hpp
+++ b/wsd/RequestVettingStation.hpp
@@ -49,7 +49,7 @@ private:
 
     /// Send an error to the client and disconnect the socket.
     static void sendErrorAndShutdown(const std::shared_ptr<WebSocketHandler>& ws,
-                                     const std::shared_ptr<Socket>& socket, const std::string& msg,
+                                     const std::string& msg,
                                      WebSocketHandler::StatusCodes statusCode);
 
 private:

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -300,11 +300,11 @@ std::unique_ptr<StorageBase> StorageBase::create(const Poco::URI& uri, const std
         case StorageBase::StorageType::FileSystem:
             return std::make_unique<LocalStorage>(uri, jailRoot, jailPath, takeOwnership);
             break;
-        case StorageBase::StorageType::Wopi:
 #if !MOBILEAPP
+        case StorageBase::StorageType::Wopi:
             return std::make_unique<WopiStorage>(uri, jailRoot, jailPath);
-#endif
             break;
+#endif //!MOBILEAPP
     }
 
     throw BadRequestException("No Storage configured or invalid URI " +

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -422,7 +422,9 @@ public:
                Unsupported, //< An unsupported type.
                Unauthorized, //< The host is not allowed by the admin.
                FileSystem, //< File-System storage. Only for testing.
+#if !MOBILEAPP
                Wopi //< WOPI-like storage.
+#endif //!MOBILEAPP
     );
 
     /// Validates the given URI.
@@ -556,16 +558,6 @@ private:
 class WopiStorage : public StorageBase
 {
 public:
-    WopiStorage(const Poco::URI& uri, const std::string& localStorePath,
-                const std::string& jailPath)
-        : StorageBase(uri, localStorePath, jailPath)
-        , _wopiSaveDuration(std::chrono::milliseconds::zero())
-    {
-        LOG_INF("WopiStorage ctor with localStorePath: ["
-                << localStorePath << "], jailPath: [" << jailPath << "], uri: ["
-                << COOLWSD::anonymizeUrl(uri.toString()) << ']');
-    }
-
     class WOPIFileInfo : public FileInfo
     {
         void init();
@@ -695,6 +687,18 @@ public:
         bool _userCanRename = false;
     };
 
+#if !MOBILEAPP
+
+    WopiStorage(const Poco::URI& uri, const std::string& localStorePath,
+                const std::string& jailPath)
+        : StorageBase(uri, localStorePath, jailPath)
+        , _wopiSaveDuration(std::chrono::milliseconds::zero())
+    {
+        LOG_INF("WopiStorage ctor with localStorePath: ["
+                << localStorePath << "], jailPath: [" << jailPath << "], uri: ["
+                << COOLWSD::anonymizeUrl(uri.toString()) << ']');
+    }
+
     /// Returns the response of CheckFileInfo WOPI call for URI that was
     /// provided during the initial creation of the WOPI storage.
     /// Also extracts the basic file information from the response
@@ -771,6 +775,7 @@ private:
 
     /// The http::Session used for uploading asynchronously.
     std::shared_ptr<http::Session> _uploadHttpSession;
+#endif // !MOBILEAPP
 };
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/StorageConnectionManager.hpp
+++ b/wsd/StorageConnectionManager.hpp
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <memory>
 #include <string>
 
@@ -14,6 +15,7 @@
 #include <Poco/Util/Application.h>
 
 #include "Authorization.hpp"
+#include "HttpRequest.hpp"
 
 /// A Storage Manager is responsible for the settings
 /// of Storage and the creation of http::Session and
@@ -35,7 +37,10 @@ public:
     }
 
     /// Create an http::Session from a URI.
-    static std::shared_ptr<http::Session> getHttpSession(const Poco::URI& uri);
+    /// The configured timeout (net.connection_timeout_secs) is used when 0 is given.
+    static std::shared_ptr<http::Session>
+    getHttpSession(const Poco::URI& uri,
+                   std::chrono::seconds timeout = std::chrono::seconds::zero());
 
     /// Create an http::Request with the common headers.
     static http::Request createHttpRequest(const Poco::URI& uri, const Authorization& auth);

--- a/wsd/WopiProxy.cpp
+++ b/wsd/WopiProxy.cpp
@@ -19,7 +19,7 @@
 #include <common/JsonUtil.hpp>
 #include <Util.hpp>
 
-void WopiProxy::handleRequest(SocketPoll& poll, SocketDisposition& disposition)
+void WopiProxy::handleRequest([[maybe_unused]] SocketPoll& poll, SocketDisposition& disposition)
 {
     std::string url = _requestDetails.getDocumentURI();
     if (Util::startsWith(url, "/wasm/"))
@@ -91,6 +91,7 @@ void WopiProxy::handleRequest(SocketPoll& poll, SocketDisposition& disposition)
                     }
                 });
             break;
+#if !MOBILEAPP
         case StorageBase::StorageType::Wopi:
             LOG_INF("URI [" << COOLWSD::anonymizeUrl(uriPublic.toString()) << "] on docKey ["
                             << docKey << "] is for a WOPI document");
@@ -109,9 +110,11 @@ void WopiProxy::handleRequest(SocketPoll& poll, SocketDisposition& disposition)
                     checkFileInfo(poll, url, uriPublic, docKey, RedirectionLimit);
                 });
             break;
+#endif //!MOBILEAPP
     }
 }
 
+#if !MOBILEAPP
 void WopiProxy::checkFileInfo(SocketPoll& poll, const std::string& url, const Poco::URI& uriPublic,
                               const std::string& docKey, int redirectLimit)
 {
@@ -382,5 +385,6 @@ void WopiProxy::download(SocketPoll& poll, const std::string& url, const Poco::U
     // Run the CheckFileInfo request on the WebServer Poll.
     _httpSession->asyncRequest(httpRequest, poll);
 }
+#endif //!MOBILEAPP
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/WopiProxy.hpp
+++ b/wsd/WopiProxy.hpp
@@ -28,10 +28,12 @@ public:
 private:
     inline void logPrefix(std::ostream& os) const { os << '#' << _socket->getFD() << ": "; }
 
+#if !MOBILEAPP
     void checkFileInfo(SocketPoll& poll, const std::string& url, const Poco::URI& uriPublic,
                        const std::string& docKey, int redirectionLimit);
     void download(SocketPoll& poll, const std::string& url, const Poco::URI& uriPublic,
                   const std::string& docKey, int redirectionLimit);
+#endif //!MOBILEAPP
 
 private:
     const std::string _id;


### PR DESCRIPTION
Non-functional changes in preparation for parallel loading. This should help reduce the review of #8052.

- wsd: exclude WopiStorage in mobile builds
- wsd: simplify WebSocketHandler::sendErrorAndShutdown
- wsd: support sendMessage with string literals
- wsd: optional timeout to getHttpSession helper
- wsd: refactor findOrCreateDocBroker
