### PR TITLE
Kill Poco Logging

### DIFF
--- a/common/Log.cpp
+++ b/common/Log.cpp
@@ -29,13 +29,8 @@
 #include <unordered_map>
 
 #include <Poco/AutoPtr.h>
-#include <Poco/ConsoleChannel.h>
 #include <Poco/FileChannel.h>
-#include <Poco/FormattingChannel.h>
-#include <Poco/PatternFormatter.h>
-#include <Poco/SplitterChannel.h>
 
-#include "Common.hpp"
 #include "Log.hpp"
 #include "Util.hpp"
 
@@ -553,17 +548,11 @@ namespace Log
         }
         else if (withColor)
         {
-            if (EnableExperimental)
-                channel = static_cast<Poco::Channel*>(new Log::ColorConsoleChannel());
-            else
-                channel = static_cast<Poco::Channel*>(new Poco::ColorConsoleChannel());
+            channel = static_cast<Poco::Channel*>(new Log::ColorConsoleChannel());
         }
         else
         {
-            if (EnableExperimental)
-                channel = static_cast<Poco::Channel*>(new Log::BufferedConsoleChannel());
-            else
-                channel = static_cast<Poco::Channel*>(new Poco::ConsoleChannel());
+            channel = static_cast<Poco::Channel*>(new Log::BufferedConsoleChannel());
         }
 
         /**

--- a/common/Util.cpp
+++ b/common/Util.cpp
@@ -1,5 +1,9 @@
 /* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
 /*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -14,7 +18,6 @@
 
 #include "Util.hpp"
 
-#include <csignal>
 #include <poll.h>
 
 #ifdef HAVE_SYS_RANDOM_H
@@ -70,7 +73,6 @@
 #include <Poco/Util/Application.h>
 #include <Poco/URI.h>
 
-#include "Common.hpp"
 #include "Log.hpp"
 #include "Protocol.hpp"
 #include "TraceEvent.hpp"

--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -1,5 +1,9 @@
 /* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
 /*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -18,8 +22,6 @@
 #include <cstring>
 #include <algorithm>
 #include <atomic>
-#include <functional>
-#include <memory>
 #include <mutex>
 #include <set>
 #include <sstream>

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -2955,12 +2955,17 @@ void lokit_main(
 
                 // Mount loTemplate inside it.
                 LOG_INF("Mounting " << loTemplate << " -> " << loJailDestPath);
-                JailUtil::createJailPath(loJailDestPath);
+                if (!FileUtil::Stat(loJailDestPath).exists())
+                {
+                    LOG_DBG("The mount-point [" << loJailDestPath
+                                                << "] doesn't exist. Binding will likely fail");
+                }
+
                 if (!JailUtil::bind(loTemplate, loJailDestPath)
                     || !JailUtil::remountReadonly(loTemplate, loJailDestPath))
                 {
                     LOG_WRN("Failed to mount [" << loTemplate << "] -> [" << loJailDestPath
-                                                << "], will link/copy contents.");
+                                                << "], will link/copy contents");
                     return false;
                 }
 


### PR DESCRIPTION
- wsd: header clean up and SPDX license
- killpoco: move own logging out of experimental
- wsd: no need to create existing mount-point
