### PR TITLE
Load balancing fix

### DIFF
--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -1045,7 +1045,7 @@ window.app = {
 	global.makeDocAndWopiSrcUrl = function (root, docUrlParams, suffix, wopiSrcParam) {
 		var wopiSrc = '';
 		if (global.wopiSrc != '') {
-			wopiSrc = '?WOPISrc=' + global.wopiSrc;
+			wopiSrc = '?WOPISrc=' + encodeURIComponent(global.wopiSrc);
 			if (global.routeToken != '')
 				wopiSrc += '&RouteToken=' + global.routeToken;
 			wopiSrc += '&compat=';

--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -311,7 +311,7 @@ L.Clipboard = L.Class.extend({
 				if (that._isStubHtml(fallbackHtml))
 				{
 					// Let the user know they haven't really copied document content.
-					this._map.uiManager.showInfoModal('data transfer warning', '', _('Failed to download clipboard, please re-copy'));
+					that._map.uiManager.showInfoModal('data transfer warning', '', _('Failed to download clipboard, please re-copy'));
 					return;
 				}
 


### PR DESCRIPTION
Fix error on clipboard download fail

----------------------------------

Use encoded WOPISrc in ws requests
    
    This is an issue if we use encoded and decoded WOPISrc for the
    same document when using load balancers like HAProxy. It should
    be always encoded.
    
    What we did:
    
    cool.html:
    http://haproxy.local:9980/browser/2a43eb3236/cool.html?WOPISrc=http%3A%2F%2Fsomewopisrcfileaddress&title=title
    
    ws:
    ws://haproxy.local:9980/cool/http%3A%2F%2Fsomewopisrcfileaddress/ws?WOPISrc=http://somewopisrcfileaddress&compat=/ws
    
    These 2 were redirected to different nodes when balancing
    was done based on WOPISrc
    
This is regression from commit https://github.com/CollaboraOnline/online/commit/a722687c116f81be19423fc92630cb7d7209b65a
browser: simplify getParameterByName