### PR TITLE
rng::getHardRandomHexString is now the same impl as rng::getHexString

### DIFF
--- a/common/Util.cpp
+++ b/common/Util.cpp
@@ -148,21 +148,6 @@ namespace Util
             return ss.str().substr(0, length);
         }
 
-        /// Generate a string of harder random characters.
-        std::string getHardRandomHexString(const std::size_t length)
-        {
-            std::stringstream ss;
-            Poco::HexBinaryEncoder hex(ss);
-
-            // a poor fallback but something.
-            std::vector<char> random = getBytes(length);
-
-            hex.rdbuf()->setLineLength(0); // Don't insert line breaks.
-            hex.write(random.data(), length);
-            hex.close(); // Flush.
-            return ss.str().substr(0, length);
-        }
-
         /// Generates a random string in Base64.
         /// Note: May contain '/' characters.
         std::string getB64String(const std::size_t length)

--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -95,9 +95,6 @@ namespace Util
         /// Generate a string of random characters.
         std::string getHexString(const size_t length);
 
-        /// Generate a hard random string of characters.
-        std::string getHardRandomHexString(const size_t length);
-
         /// Generates a random string suitable for
         /// file/directory names.
         std::string getFilename(const size_t length);

--- a/test/HttpRequestTests.cpp
+++ b/test/HttpRequestTests.cpp
@@ -334,7 +334,7 @@ void HttpRequestTests::testSimpleGetSync()
 {
     constexpr auto testname = "simpleGetSync";
 
-    const auto data = Util::rng::getHardRandomHexString(Util::rng::getNext() % 1024);
+    const auto data = Util::rng::getHexString(Util::rng::getNext() % 1024);
     const auto body = std::string(data.data(), data.size());
     const std::string URL = "/echo/" + body;
     TST_LOG("Requesting URI: [" << URL << ']');
@@ -371,7 +371,7 @@ void HttpRequestTests::testChunkedGetSync()
 {
     constexpr auto testname = "chunkedGetSync";
 
-    const auto data = Util::rng::getHardRandomHexString(Util::rng::getNext() % 1024);
+    const auto data = Util::rng::getHexString(Util::rng::getNext() % 1024);
     const auto body = std::string(data.data(), data.size());
     const std::string URL = "/echo/chunked/" + body;
     TST_LOG("Requesting URI: [" << URL << ']');

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -2426,7 +2426,7 @@ void COOLWSD::innerInitialize(Application& self)
 
     if (getConfigValue<bool>(conf, "browser_logging", "false"))
     {
-        LogToken = Util::rng::getHardRandomHexString(16);
+        LogToken = Util::rng::getHexString(16);
     }
 
     // First log entry.
@@ -2663,7 +2663,7 @@ void COOLWSD::innerInitialize(Application& self)
         CleanupChildRoot = ChildRoot;
 
         // Encode the process id into the path for parallel re-use of jails/
-        ChildRoot += std::to_string(getpid()) + '-' + Util::rng::getHardRandomHexString(8) + '/';
+        ChildRoot += std::to_string(getpid()) + '-' + Util::rng::getHexString(8) + '/';
 
         LOG_INF("Creating childroot: " + ChildRoot);
     }

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -198,7 +198,7 @@ void ClientSession::rotateClipboardKey(bool notifyClient)
         return;
 
     _clipboardKeys[1] = _clipboardKeys[0];
-    _clipboardKeys[0] = Util::rng::getHardRandomHexString(
+    _clipboardKeys[0] = Util::rng::getHexString(
         ClipboardTokenLengthBytes);
     LOG_TRC("Clipboard key on [" << getId() << "] set to " << _clipboardKeys[0] <<
             " last was " << _clipboardKeys[1]);
@@ -2551,7 +2551,7 @@ void ClientSession::dumpState(std::ostream& os)
 const std::string &ClientSession::getOrCreateProxyAccess()
 {
     if (_proxyAccess.size() <= 0)
-        _proxyAccess = Util::rng::getHardRandomHexString(
+        _proxyAccess = Util::rng::getHexString(
             ProxyAccessTokenLengthBytes);
     return _proxyAccess;
 }


### PR DESCRIPTION
so remove one in favor of the other


Change-Id: I47778f7bce24f0687565aa179b7a3bbea9d95120


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

