### PR TITLE
Fix warning for unocommands.py

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -544,7 +544,7 @@ $(INTERMEDIATE_DIR)/admin-src.js: $(COOL_ADMIN_TS_JS) $(COOL_ADMIN_JS)
 	@$(NODE) node_modules/eslint/bin/eslint.js --resolve-plugins-relative-to $(abs_builddir) --ignore-path $(srcdir)/.eslintignore --config $(srcdir)/.eslintrc --no-eslintrc $(srcdir)/admin/src
 	@awk 'FNR == 1 {print ""} 1' $(COOL_ADMIN_TS_JS) $(patsubst %.js,$(srcdir)/%.js,$(COOL_ADMIN_JS)) > $@
 
-$(INTERMEDIATE_DIR)/cool-src.js: tscompile.done $(call prereq_cool) $(COOL_JS_DST)
+$(INTERMEDIATE_DIR)/cool-src.js: tscompile.done $(call prereq_cool) $(COOL_JS_DST) $(abs_top_srcdir)/scripts/unocommands.py
 	@mkdir -p $(dir $@)
 	$(abs_top_srcdir)/scripts/unocommands.py --check $(abs_top_srcdir)
 	@printf "Checking for obsolete JS build intermediates in this makefile... "

--- a/scripts/unocommands.py
+++ b/scripts/unocommands.py
@@ -349,7 +349,7 @@ window._UNO = function(string, component, isContext) {
 window.removeAccessKey = function(text) {
 \t// Remove access key markers from translated strings
 \t// 1. access key in parenthesis in case of non-latin scripts
-\ttext = text.replace(/\(~[A-Za-z]\)/, '');
+\ttext = text.replace(/\\(~[A-Za-z]\\)/, '');
 \t// 2. remove normal access key
 \ttext = text.replace('~', '');
 


### PR DESCRIPTION
This resolves the following Python warning.
unocommands.py:319: SyntaxWarning: invalid escape sequence '\('
  f.write('''};

Also make sure the output depends on the script


Change-Id: I11f1e028c9c132f4afc66f9b5a6137b478f00774


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

I was seeing this warning. Escaping rules applied. I compared the output and it is unchanged. I run Python 3.12.1 in case this started to only pop on recent Python.

### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

