### PR TITLE
wsd: rescue the clipboard before autosaving on unload

### DIFF
--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -159,11 +159,6 @@ bool ClientSession::disconnectFromKit()
     {
         setState(SessionState::WAIT_DISCONNECT);
 
-#ifndef IOS
-        LOG_TRC("request/rescue clipboard on disconnect for " << getId());
-        // rescue clipboard before shutdown.
-        docBroker->forwardToChild(client_from_this(), "getclipboard");
-#endif
         // handshake nicely; so wait for 'disconnected'
         LOG_TRC("Sending 'disconnect' command to session " << getId());
         docBroker->forwardToChild(client_from_this(), "disconnect");
@@ -1824,8 +1819,7 @@ bool ClientSession::handleKitToClientMessage(const std::shared_ptr<Message>& pay
         const bool empty = header >= payload->size();
 
         // final cleanup ...
-        if (!empty && _state == SessionState::WAIT_DISCONNECT &&
-            (!_wopiFileInfo || !_wopiFileInfo->getDisableCopy()))
+        if (!empty && (!_wopiFileInfo || !_wopiFileInfo->getDisableCopy()))
             COOLWSD::SavedClipboards->insertClipboard(
                 _clipboardKeys, &payload->data()[header], payload->size() - header);
 

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -2579,6 +2579,22 @@ std::size_t DocumentBroker::removeSession(const std::shared_ptr<ClientSession>& 
                                      << ", DontSaveIfUnmodified: " << dontSaveIfUnmodified
                                      << ", IsPossiblyModified: " << isPossiblyModified());
 
+#ifndef IOS
+        if (activeSessionCount <= 1)
+        {
+            // rescue clipboard before shutdown.
+            // N.B. If the user selects then copies, most likely we will
+            // mark the document as possibly-modified. This will issue
+            // a save (below) before removing the session, guaranteeing
+            // that we wait for the save to complete, which is after
+            // rescuing the clipboard via getclipboard. Conversely,
+            // if there is no reason to think the document is possibly-
+            // modified, then it's unlikely there is anything in the clipboard.
+            LOG_TRC("request/rescue clipboard on disconnect for " << session->getId());
+            forwardToChild(session, "getclipboard");
+        }
+#endif
+
         // In theory, we almost could do this here:
 
         // #if MOBILEAPP


### PR DESCRIPTION
This moves the clipboard resque logic earlier to
make sure it is cached before the Kit process
exits.

By putting the clipboard-fetching command before
the save-before-exit, we should get the clipboard
in most-all cases. There are still edge-cases
that can slip through, but they should be much
less frequent, and they will require much more
involved logic (tbd).

Change-Id: I0eff95c28524002a6131fa0a57ef8e09ae21ca59
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
