### PR TITLE
Calc: Selecting columns by dragging mouse deselect the first column

### DIFF
--- a/browser/src/control/Control.Header.ts
+++ b/browser/src/control/Control.Header.ts
@@ -563,7 +563,7 @@ export class Header extends CanvasSectionObject {
 
 			if (this._lastSelectedIndex == this._prevMouseOverEntry.index || this._dragEntry)
 				return;
-			const modifier = this._lastSelectedIndex ? UNOModifier.SHIFT : 0;
+			const modifier = typeof this._lastSelectedIndex === 'number' && this._lastSelectedIndex >= 0 ? UNOModifier.SHIFT : 0;
 			this._lastSelectedIndex = this._mouseOverEntry.index;
 			this.selectIndex(this._mouseOverEntry.index, modifier);
 		}


### PR DESCRIPTION
problem:
drag selection starting from the first row or column would result in first col or row being unselected. It was caused by index being 0 resulting in condition being false


Change-Id: I3619f52ccc7fdb2883af547f1c907c07ef27ddf9


* Target version: 23.05 

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

