### PR TITLE
signal activity dumping: enrich with session details and state.

### DIFF
--- a/common/SigUtil.cpp
+++ b/common/SigUtil.cpp
@@ -64,6 +64,7 @@ static std::atomic<bool> ForwardSigUsr2Flag(false); //< Flags to forward SIG_USR
 #endif
 
 static size_t ActivityStringIndex = 0;
+static std::string ActivityHeader = "";
 static std::array<std::string, 16> ActivityStrings;
 static bool UnattendedRun = false;
 #if !MOBILEAPP
@@ -132,9 +133,19 @@ void requestShutdown()
 #endif
     }
 
+    void setActivityHeader(const std::string &message)
+    {
+        ActivityHeader = message;
+    }
+
     void addActivity(const std::string &message)
     {
         ActivityStrings[ActivityStringIndex++ % ActivityStrings.size()] = message;
+    }
+
+    void addActivity(const std::string &viewId, const std::string &message)
+    {
+        addActivity("session: " + viewId + ": " + message);
     }
 
     void setUnattended()
@@ -388,6 +399,7 @@ void requestShutdown()
         signalLog("\n");
 
         signalLog("Recent activity:\n");
+        signalLog(ActivityHeader.c_str());
         for (size_t i = 0; i < ActivityStrings.size(); ++i)
         {
             size_t idx = (ActivityStringIndex + i) % ActivityStrings.size();

--- a/common/SigUtil.hpp
+++ b/common/SigUtil.hpp
@@ -58,8 +58,14 @@ namespace SigUtil
 
     void checkForwardSigUsr2(ForwardSigUsr2Fn forwardSigUsr2);
 
+    /// Add a pre-amble message to be dumped on fatal signal
+    void setActivityHeader(const std::string &message);
+
     /// Add a message to a round-robin buffer to be dumped on fatal signal
     void addActivity(const std::string &message);
+
+    /// Add a message on a view to a round-robin buffer to be dumped on fatal signal
+    void addActivity(const std::string &id, const std::string &message);
 
     /// Called to flag that we are running in unattended mode, not interactive.
     /// In unattended mode we know there is no one to attach a debugger on

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -760,7 +760,7 @@ bool ChildSession::loadDocument(const StringVector& tokens)
     }
 #endif
 
-    SigUtil::addActivity("load view: " + getId() + " doc: " + getJailedFilePathAnonym());
+    SigUtil::addActivity(getId(), "load doc: " + getJailedFilePathAnonym());
 
     const bool loaded = _docManager->onLoad(getId(), getJailedFilePathAnonym(), renderOpts);
     if (!loaded || _viewId < 0)
@@ -827,6 +827,9 @@ bool ChildSession::loadDocument(const StringVector& tokens)
     // Inform everyone (including this one) about updated view info
     _docManager->notifyViewInfo();
     sendTextFrame("editor: " + std::to_string(_docManager->getEditorId()));
+
+    // now we have the doc options parsed and set.
+    _docManager->updateActivityHeader();
 
     LOG_INF("Loaded session " << getId());
     return true;
@@ -1181,7 +1184,7 @@ bool ChildSession::getTextSelection(const StringVector& tokens)
         return false;
     }
 
-    SigUtil::addActivity("getTextSelection");
+    SigUtil::addActivity(getId(), "getTextSelection");
 
     if (getLOKitDocument()->getDocumentType() != LOK_DOCTYPE_TEXT &&
         getLOKitDocument()->getDocumentType() != LOK_DOCTYPE_SPREADSHEET)
@@ -1233,7 +1236,7 @@ bool ChildSession::getClipboard(const StringVector& tokens)
         pMimeTypes[1] = nullptr;
     }
 
-    SigUtil::addActivity("getClipboard");
+    SigUtil::addActivity(getId(), "getClipboard");
 
     bool success = false;
     getLOKitDocument()->setView(_viewId);
@@ -1286,7 +1289,7 @@ bool ChildSession::setClipboard(const char* buffer, int length, const StringVect
         ClipboardData data;
         Poco::MemoryInputStream stream(buffer, length);
 
-        SigUtil::addActivity("setClipboard " + std::to_string(length) + " bytes");
+        SigUtil::addActivity(getId(), "setClipboard " + std::to_string(length) + " bytes");
 
         std::string command; // skip command
         std::getline(stream, command, '\n');
@@ -1390,7 +1393,7 @@ bool ChildSession::insertFile(const StringVector& tokens)
     }
 #endif
 
-    SigUtil::addActivity("insertFile " + type);
+    SigUtil::addActivity(getId(), "insertFile " + type);
 
     if (type == "graphic" || type == "graphicurl" || type == "selectbackground")
     {
@@ -1860,7 +1863,7 @@ bool ChildSession::unoCommand(const StringVector& tokens)
         return false;
     }
 
-    SigUtil::addActivity(formatUnoCommandInfo(getId(), tokens[1]));
+    SigUtil::addActivity(getId(), formatUnoCommandInfo(getId(), tokens[1]));
 
     // we need to get LOK_CALLBACK_UNO_COMMAND_RESULT callback when saving
     const bool bNotify = (tokens.equals(1, ".uno:Save") ||

--- a/kit/ChildSession.hpp
+++ b/kit/ChildSession.hpp
@@ -85,6 +85,8 @@ public:
     virtual std::string getDocPassword() const = 0;
 
     virtual DocumentPasswordType getDocPasswordType() const = 0;
+
+    virtual void updateActivityHeader() const = 0;
 };
 
 struct RecordedEvent
@@ -379,6 +381,20 @@ private:
     }
 
 public:
+    // simple one line for priming
+    std::string getActivityState()
+    {
+        std::stringstream ss;
+        ss << "view: " << _viewId
+           << ", session " << getId()
+           << (isReadOnly() ? ", ro": ", rw")
+           << ", user: '" << getUserNameAnonym() << "'"
+           << ", load" << (_isDocLoaded ? "ed" : "ing")
+           << ", type: " << _docType
+           << ", lang: " << getLang();
+        return ss.str();
+    }
+
     void dumpState(std::ostream& oss) override
     {
         Session::dumpState(oss);

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -795,6 +795,8 @@ public:
             LOG_DBG("Have " << _sessions.size() << " active sessions after creating "
                             << session->getId());
             LOG_INF("New session [" << sessionId << "]");
+
+            updateActivityHeader();
             return true;
         }
         catch (const std::exception& ex)
@@ -1344,6 +1346,17 @@ private:
     DocumentPasswordType getDocPasswordType() const override
     {
         return _docPasswordType;
+    }
+
+    void updateActivityHeader() const override
+    {
+        // pre-prepare and set details in case of a signal later
+        std::stringstream ss;
+        ss << "Session count: " << _sessions.size() << "\n";
+        for (const auto& it : _sessions)
+            ss << "\t" << it.second->getActivityState() << "\n";
+        ss << "Commands:\n";
+        SigUtil::setActivityHeader(ss.str());
     }
 
     /// Notify all views of viewId and their associated usernames

--- a/test/WhiteBoxTests.cpp
+++ b/test/WhiteBoxTests.cpp
@@ -656,6 +656,10 @@ public:
     {
         return DocumentPasswordType::ToView;
     }
+
+    void updateActivityHeader() const
+    {
+    }
 };
 
 void WhiteBoxTests::testEmptyCellCursor()


### PR DESCRIPTION
Cue up some basic state for being signal safe dumped on crash/abort.


Change-Id: Ibc6713aef2a0e7b878b178b05f0e13c8d40b47fc


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

