### PR TITLE
cypress, desktop/writer/top_toolbar_spec.js, 'Insert Special Character.': add conditional 3rd click

### DIFF
--- a/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
@@ -329,7 +329,7 @@ describe(['tagdesktop'], 'Top toolbar tests.', function() {
 		cy.cGet('#toolbar-up .w2ui-scroll-right').click();
 		cy.cGet('#toolbar-up .w2ui-scroll-right').click();
 		cy.wait(500);
-		cy.cGet('#Home-container .unospan-CharmapControl').click();
+		cy.cGet('#Home-container .unospan-CharmapControl').click({force: true});
 		cy.cGet('.jsdialog-container.ui-dialog.ui-widget-content.lokdialog_container').should('be.visible');
 		cy.cGet('.ui-dialog-title').should('have.text', 'Special Characters');
 


### PR DESCRIPTION
My local run failed in this test, because scrolling to the right just
twice resulted in a partially clicked toolbar item, so:

cy.cGet('#Home-container .unospan-CharmapControl').click();

failed. Add a 3rd click if scrolling to the right is still possible.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I4caa3dc79df1bbbd5bd0c7e88ef1baea8ae4b17e
