### PR TITLE
Remove cSetLevel (unused)

### DIFF
--- a/cypress_test/integration_tests/common/helper.js
+++ b/cypress_test/integration_tests/common/helper.js
@@ -513,7 +513,6 @@ function beforeAll(fileName, subFolder, noFileCopy, isMultiUser, subsequentLoad,
 	cy.log('Starting test: ' + Cypress.spec.relative + ' / ' + Cypress.currentTest.titlePath.join(' / '));
 	// Set defaults here in order to remove checks from cy.cGet function.
 	cy.cSetActiveFrame('#coolframe');
-	cy.cSetLevel('1');
 
 	return loadTestDoc(fileName, subFolder, noFileCopy, isMultiUser, subsequentLoad, hasInteractionBeforeLoad, noRename);
 }

--- a/cypress_test/support/index.js
+++ b/cypress_test/support/index.js
@@ -80,11 +80,6 @@ Cypress.Commands.add('cSetActiveFrame', function(frameID) {
 	cy.cActiveFrame = frameID;
 });
 
-Cypress.Commands.add('cSetLevel', function(level) {
-	Cypress.log();
-	cy.cLevel = level;
-});
-
 /**
  * Get the current iFrame body to be chained with other queries.
  * Example: cy.cframe().find('#my-item');
@@ -150,24 +145,12 @@ Cypress.Commands.add('cGet', function(selector, options) {
 		optionsWithLogFalse = {log: false};
 	}
 
-	if (cy.cLevel === '1') {
-		if (selector)
-			return cy.get(cy.cActiveFrame, {log: false})
-				.its('0.contentDocument', {log: false})
-				.find(selector, optionsWithLogFalse);
-		else
-			return cy.get(cy.cActiveFrame, optionsWithLogFalse)
-				.its('0.contentDocument', {log: false});
-	}
-	else if (selector) // This is not cool frame and there is a selector.
+	if (selector) {
 		return cy.get(cy.cActiveFrame, {log: false})
 			.its('0.contentDocument', {log: false})
-			.find('#coolframe', {log: false})
-			.its('0.contentDocument', {log: false})
 			.find(selector, optionsWithLogFalse);
-	else // Not cool frame without a selector.
+	} else {
 		return cy.get(cy.cActiveFrame, optionsWithLogFalse)
-			.its('0.contentDocument', {log: false})
-			.find('#coolframe', {log: false})
 			.its('0.contentDocument', {log: false});
+	}
 });


### PR DESCRIPTION
Change-Id: Ic1eaae123ae70f5f09553d6c69bfa699a02a921f

* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

Seems to have been added to support Nextcloud tests but is now unused.

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

