### PR TITLE
Add  filter content with entry widget in help => online-help

### DIFF
--- a/browser/html/cool-help.html
+++ b/browser/html/cool-help.html
@@ -53,7 +53,6 @@
       border: 1px solid;
       border-radius: 5px;
       font-size: 16px;
-      transition: box-shadow 0.3s ease;
       outline: none;
     }
     #online-help-search-input:focus {

--- a/browser/html/cool-help.html
+++ b/browser/html/cool-help.html
@@ -6,494 +6,657 @@
     .productname { font-weight:bold; font-style:italic; }
     .ui { font-weight:bold; }
     .def { font-weight:bold; }
-    .toc-h2 { font-weight:bold; }
-    .toc-h3 { margin-left:0.1965in; }
+    /* Style for toc-h2 and toc-h3 */
+    .toc-h2 button,
+    .toc-h3 button {
+        border-radius: 5px; /* Add rounded corners */
+        transition: background-color 0.3s ease; /* Smooth transition effect */
+        font-family: Arial, sans-serif; /* Use a common font family */
+        font-size: 16px; /* Font size */
+        color: #333; /* Dark text color */
+    }
+
+    /* Hover effect for toc-h2 and toc-h3 button */
+    .toc-h2 button:hover,
+    .toc-h3 button:hover {
+        background-color: #e0e0e0; /* Darker gray background on hover */
+    }
+
+    /* Style for toc-h2 and toc-h3 button text when clicked */
+    .toc-h2 button:active,
+    .toc-h3 button:active {
+        color: #555; /* Darker text color when clicked */
+    }
+
+    /* Style for toc-h2 and toc-h3 button text when focused */
+    .toc-h2 button:focus,
+    .toc-h3 button:focus {
+        outline: none; /* Remove outline when focused */
+    }
+
+    /* Add margin to the paragraph to separate each item */
+    .toc-h2,
+    .toc-h3 {
+        margin-bottom: 2px; /* Adjust margin bottom */
+    }
+
     .screenshot { text-align:center; margin: 0.1in; }
     .screenshot > img { max-width: 100%; height: auto; }
     .blue { color:#63bbee; }
     button.border-0 { font-family: "Helvetica Neue", sans-serif; background: none!important; border: none; padding: 0!important; color: -webkit-link; cursor: pointer; text-decoration: underline; font-size: 1em; line-height: 1.5em; }
     button:active { color: -webkit-activelink; }
     button:focus { outline: -webkit-focus-ring-color auto 1px; }
+
+    #online-help-search-input {
+      width: 30%;
+      padding: 5px 10px 5px 15px;
+      border: 1px solid;
+      border-radius: 5px;
+      font-size: 16px;
+      transition: box-shadow 0.3s ease;
+      outline: none;
+    }
+    #online-help-search-input:focus {
+      box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
+    }
+    #online-help-search-input::placeholder {
+      color: #999;
+    }
     [data-theme='dark'] span.cool-annotation-menu { filter: invert(1);}
 </style>
+
+<div class="search-container">
+  <input size="20" id="online-help-search-input" placeholder="Search..." />
+</div>
+
 <div id="keyboard-shortcuts-content">
     <h1>Keyboard Shortcuts</h1>
-    <div id="general-shortcuts">
-        <h2>General Keyboard Shortcuts</h2>
+    <div class="section" id="general-shortcuts">
+        <h2 class="section-header">General Keyboard Shortcuts</h2>
         <table class="help">
-            <tr> <td class="function">Undo</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Z</kbd></td> </tr>
-            <tr> <td class="function">Redo</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Y</kbd></td> </tr>
-            <tr> <td class="function">Cut</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>X</kbd></td> </tr>
-            <tr> <td class="function">Paste as unformatted text</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>V</kbd></td> </tr>
-            <tr> <td class="function">Paste special</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>V</kbd></td> </tr>
-            <tr> <td class="function">Print (Download as PDF)</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>P</kbd></td> </tr>
-            <tr> <td class="function">Display the Keyboard shortcuts help</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>?</kbd></td> </tr>
-            <tr> <td class="function">Focus to notebookbar menu</td> <td class="shortcut"><kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>F1</kbd></td> </tr>
-            <tr> <td class="function">Focus to document from menu</td> <td class="shortcut"><kbd>ESC</kbd></td> </tr>
-            <tr> <td class="function">Focus to selected comment's menu</td> <td class="shortcut"><kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>C</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Undo</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Z</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Redo</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Y</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Cut</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>X</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Paste as unformatted text</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>V</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Paste special</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>V</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Print (Download as PDF)</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>P</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Display the Keyboard shortcuts help</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>?</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Focus to notebookbar menu</td> <td class="shortcut"><kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>F1</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Focus to document from menu</td> <td class="shortcut"><kbd>ESC</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Focus to selected comment's menu</td> <td class="shortcut"><kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>C</kbd></td> </tr>
         </table>
     </div>
     <div id="text-shortcuts" style="display: none;">
-        <h2>Text formatting</h2>
+      <div class="section">
+        <h2 class="section-header">Text formatting</h2>
         <table class="help">
-            <tr> <td class="function">Bold</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>B</kbd></td> </tr>
-            <tr> <td class="function">Italic</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>I</kbd></td> </tr>
-            <tr> <td class="function">Underline</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>U</kbd></td> </tr>
-            <tr> <td class="function">Double Underline</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>D</kbd></td> </tr>
-            <tr> <td class="function">Strikethrough</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>5</kbd></td> </tr>
-            <tr> <td class="function">Superscript</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>P</kbd></td> </tr>
-            <tr> <td class="function">Subscript</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>B</kbd></td> </tr>
-            <tr> <td class="function">Remove direct formatting</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>M</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Bold</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>B</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Italic</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>I</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Underline</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>U</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Double Underline</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>D</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Strikethrough</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>5</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Superscript</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>P</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Subscript</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>B</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Remove direct formatting</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>M</kbd></td> </tr>
         </table>
-        <h2>Paragraph formatting</h2>
+      </div>
+      <div class="section">
+        <h2 class="section-header">Paragraph formatting</h2>
         <table class="help">
-            <tr> <td class="function">Align Center</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>E</kbd></td> </tr>
-            <tr> <td class="function">Align Left</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>L</kbd></td> </tr>
-            <tr> <td class="function">Align Right</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>R</kbd></td> </tr>
-            <tr> <td class="function">Justify</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>J</kbd></td> </tr>
-            <tr> <td class="function">Apply Default paragraph style</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>0</kbd></td> </tr>
-            <tr> <td class="function">Apply Heading 1 paragraph style</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>1</kbd></td> </tr>
-            <tr> <td class="function">Apply Heading 2 paragraph style</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>2</kbd></td> </tr>
-            <tr> <td class="function">Apply Heading 3 paragraph style</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>3</kbd></td> </tr>
-            <tr> <td class="function">Apply Heading 4 paragraph style</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>4</kbd></td> </tr>
-            <tr> <td class="function">Apply Heading 5 paragraph style</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>5</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Align Center</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>E</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Align Left</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>L</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Align Right</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>R</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Justify</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>J</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Apply Default paragraph style</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>0</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Apply Heading 1 paragraph style</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>1</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Apply Heading 2 paragraph style</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>2</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Apply Heading 3 paragraph style</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>3</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Apply Heading 4 paragraph style</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>4</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Apply Heading 5 paragraph style</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>5</kbd></td> </tr>
         </table>
-        <h2>Text selection and navigation in document</h2>
+      </div>
+      <div class="section">
+        <h2 class="section-header">Text selection and navigation in document</h2>
         <table class="help">
-            <tr> <td class="function">Select All</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>A</kbd></td> </tr>
-            <tr> <td class="function">Move cursor to the left</td> <td class="shortcut"><kbd>Arrow Left</kbd></td> </tr>
-            <tr> <td class="function">Move cursor with selection to the left</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Left</kbd></td> </tr>
-            <tr> <td class="function">Go to beginning of a word</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Arrow Left</kbd></td> </tr>
-            <tr> <td class="function">Select to the left word by word</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Left</kbd></td> </tr>
-            <tr> <td class="function">Move cursor to the right</td> <td class="shortcut"><kbd>Arrow Right</kbd></td> </tr>
-            <tr> <td class="function">Move cursor with selection to the right</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Right</kbd></td> </tr>
-            <tr> <td class="function">Go to start of the next word</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Arrow Right</kbd></td> </tr>
-            <tr> <td class="function">Select to the right word by word</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Right</kbd></td> </tr>
-            <tr> <td class="function">Move cursor up one line</td> <td class="shortcut"><kbd>Arrow Up</kbd></td> </tr>
-            <tr> <td class="function">Select lines in upwards direction</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Up</kbd></td> </tr>
-            <tr> <td class="function">Move cursor to beginning of the previous paragraph</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Arrow Up</kbd></td> </tr>
-            <tr> <td class="function">Select to beginning of paragraph</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Up</kbd></td> </tr>
-            <tr> <td class="function">Move cursor down one line</td> <td class="shortcut"><kbd>Arrow Down</kbd></td> </tr>
-            <tr> <td class="function">Select lines in downwards direction</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Down</kbd></td> </tr>
-            <tr> <td class="function">Move cursor to beginning of the next paragraph</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Arrow Down</kbd></td> </tr>
-            <tr> <td class="function">Select to end of paragraph</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Down</kbd></td> </tr>
-            <tr> <td class="function">Go to beginning of line</td> <td class="shortcut"><kbd>Home</kbd></td> </tr>
-            <tr> <td class="function">Go and select to the beginning of a line</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Home</kbd></td> </tr>
-            <tr> <td class="function">Go to start of document</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Home</kbd></td> </tr>
-            <tr> <td class="function">Go and select text to start of document</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Home</kbd></td> </tr>
-            <tr> <td class="function">Go to end of line</td> <td class="shortcut"><kbd>End</kbd></td> </tr>
-            <tr> <td class="function">Go and select to the end of a line</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>End</kbd></td> </tr>
-            <tr> <td class="function">Go to end of document</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>End</kbd></td> </tr>
-            <tr> <td class="function">Go and select text to end of document</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>End</kbd></td> </tr>
-            <tr> <td class="function">Move the view up one page</td> <td class="shortcut"><kbd>PageUp</kbd></td> </tr>
-            <tr> <td class="function">Switch cursor between text and header</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>PageUp</kbd></td> </tr>
-            <tr> <td class="function">Extend the selection up one page</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>PageUp</kbd></td> </tr>
-            <tr> <td class="function">Move the view down one page</td> <td class="shortcut"><kbd>PageDown</kbd></td> </tr>
-            <tr> <td class="function">Switch cursor between text and footer</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>PageDown</kbd></td> </tr>
-            <tr> <td class="function">Extend the selection down one page</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>PageDown</kbd></td> </tr>
-            <tr> <td class="function">Delete to beginning of word</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Backspace</kbd></td> </tr>
-            <tr> <td class="function">Delete to end of word</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Del</kbd></td> </tr>
-            <tr> <td class="function">Delete to beginning of sentence</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Backspace</kbd></td> </tr>
-            <tr> <td class="function">Delete to end of sentence</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Del</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Select All</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>A</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Move cursor to the left</td> <td class="shortcut"><kbd>Arrow Left</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Move cursor with selection to the left</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Left</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Go to beginning of a word</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Arrow Left</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Select to the left word by word</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Left</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Move cursor to the right</td> <td class="shortcut"><kbd>Arrow Right</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Move cursor with selection to the right</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Right</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Go to start of the next word</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Arrow Right</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Select to the right word by word</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Right</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Move cursor up one line</td> <td class="shortcut"><kbd>Arrow Up</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Select lines in upwards direction</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Up</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Move cursor to beginning of the previous paragraph</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Arrow Up</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Select to beginning of paragraph</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Up</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Move cursor down one line</td> <td class="shortcut"><kbd>Arrow Down</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Select lines in downwards direction</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Down</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Move cursor to beginning of the next paragraph</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Arrow Down</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Select to end of paragraph</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Down</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Go to beginning of line</td> <td class="shortcut"><kbd>Home</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Go and select to the beginning of a line</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Home</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Go to start of document</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Home</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Go and select text to start of document</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Home</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Go to end of line</td> <td class="shortcut"><kbd>End</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Go and select to the end of a line</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>End</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Go to end of document</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>End</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Go and select text to end of document</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>End</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Move the view up one page</td> <td class="shortcut"><kbd>PageUp</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Switch cursor between text and header</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>PageUp</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Extend the selection up one page</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>PageUp</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Move the view down one page</td> <td class="shortcut"><kbd>PageDown</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Switch cursor between text and footer</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>PageDown</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Extend the selection down one page</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>PageDown</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Delete to beginning of word</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Backspace</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Delete to end of word</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Del</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Delete to beginning of sentence</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Backspace</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Delete to end of sentence</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Del</kbd></td> </tr>
         </table>
-        <h2>Shortcut Keys for Tables</h2>
+      </div>
+      <div class="section">
+        <h2 class="section-header">Shortcut Keys for Tables</h2>
         <table class="help">
-            <tr> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>A</kbd></td>  <td class="function">If the active cell is empty: selects the whole table. Otherwise: selects the contents of the active cell. Pressing again selects the entire table.</td>  </tr>
-            <tr> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Home</kbd></td>  <td class="function">If the active cell is empty: goes to the beginning of the table. Otherwise: first press goes to beginning of the active cell, second press goes to beginning of the current table, third press goes to beginning of document.</td>  </tr>
-            <tr> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>End</kbd></td>  <td class="function">If the active cell is empty: goes to the end of the table. Otherwise: first press goes to the end of the active cell, second press goes to the end of the current table, third press goes to the end of the document.</td>  </tr>
-            <tr> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Tab</kbd></td>  <td class="function">Inserts a tab stop (only in tables). Depending on the Window Manager in use, <kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>Tab</kbd> may be used instead.</td>  </tr>
-            <tr> <td class="shortcut"><kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>Arrow Keys</kbd></td>  <td class="function">Increases/decreases the size of the column/row on the right/bottom cell edge</td>  </tr>
-            <tr> <td class="shortcut"><kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Keys</kbd></td>  <td class="function">Increase/decrease the size of the column/row on the left/top cell edge</td>  </tr>
-            <tr> <td class="shortcut"><kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Arrow Keys</kbd></td>  <td class="function">Like Alt, but only the active cell is modified</td>  </tr>
-            <tr> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Keys</kbd></td>  <td class="function">Like Alt, but only the active cell is modified</td>  </tr>
-            <tr> <td class="shortcut"><kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>Insert</kbd></td>  <td class="function">3 seconds in Insert mode, Arrow Key inserts row/column, <kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Arrow Key</kbd> inserts cell</td>  </tr>
-            <tr> <td class="shortcut"><kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>Del</kbd></td>  <td class="function">3 seconds in Delete mode, Arrow key deletes row/column, <kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Arrow key</kbd> merges cell with neighboring cell</td>  </tr>
-            <tr> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Del</kbd></td>  <td class="function"> <p>If no whole cell is selected, the text from the cursor to the end of the current sentence is deleted. If the cursor is at the end of a cell, and no whole cell is selected, the contents of the next cell are deleted.</p>
+            <tr class="sub-section"> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>A</kbd></td>  <td class="function">If the active cell is empty: selects the whole table. Otherwise: selects the contents of the active cell. Pressing again selects the entire table.</td>  </tr>
+            <tr class="sub-section"> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Home</kbd></td>  <td class="function">If the active cell is empty: goes to the beginning of the table. Otherwise: first press goes to beginning of the active cell, second press goes to beginning of the current table, third press goes to beginning of document.</td>  </tr>
+            <tr class="sub-section"> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>End</kbd></td>  <td class="function">If the active cell is empty: goes to the end of the table. Otherwise: first press goes to the end of the active cell, second press goes to the end of the current table, third press goes to the end of the document.</td>  </tr>
+            <tr class="sub-section"> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Tab</kbd></td>  <td class="function">Inserts a tab stop (only in tables). Depending on the Window Manager in use, <kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>Tab</kbd> may be used instead.</td>  </tr>
+            <tr class="sub-section"> <td class="shortcut"><kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>Arrow Keys</kbd></td>  <td class="function">Increases/decreases the size of the column/row on the right/bottom cell edge</td>  </tr>
+            <tr class="sub-section"> <td class="shortcut"><kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Keys</kbd></td>  <td class="function">Increase/decrease the size of the column/row on the left/top cell edge</td>  </tr>
+            <tr class="sub-section"> <td class="shortcut"><kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Arrow Keys</kbd></td>  <td class="function">Like Alt, but only the active cell is modified</td>  </tr>
+            <tr class="sub-section"> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Keys</kbd></td>  <td class="function">Like Alt, but only the active cell is modified</td>  </tr>
+            <tr class="sub-section"> <td class="shortcut"><kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>Insert</kbd></td>  <td class="function">3 seconds in Insert mode, Arrow Key inserts row/column, <kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Arrow Key</kbd> inserts cell</td>  </tr>
+            <tr class="sub-section"> <td class="shortcut"><kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>Del</kbd></td>  <td class="function">3 seconds in Delete mode, Arrow key deletes row/column, <kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Arrow key</kbd> merges cell with neighboring cell</td>  </tr>
+            <tr class="sub-section"> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Del</kbd></td>  <td class="function"> <p>If no whole cell is selected, the text from the cursor to the end of the current sentence is deleted. If the cursor is at the end of a cell, and no whole cell is selected, the contents of the next cell are deleted.</p>
 <p>If no whole cell is selected and the cursor is at the end of the table, the paragraph following the table will be deleted, unless it is the last paragraph in the document.</p>
 <p>If one or more cells are selected, the whole rows containing the selection will be deleted. If all rows are selected completely or partially, the entire table will be deleted.</p>
 </td>  </tr>
         </table>
-        <h2>Word processor functions</h2>
+      </div>
+      <div class="section">
+        <h2 class="section-header">Word processor functions</h2>
         <table class="help">
-            <tr> <td class="function">Insert footnote</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>F</kbd></td> </tr>
-            <tr> <td class="function">Insert endnote</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>D</kbd></td> </tr>
-            <tr> <td class="function">Insert comment</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>C</kbd></td> </tr>
-            <!-- <tr> <td class="function">Calculates the selected text and copies the result to the clipboard.</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span>Plus Key(+)</td> </tr> -->
-            <tr> <td class="function">Insert soft hyphen</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>-</kbd></td> </tr>
-            <tr> <td class="function">Insert non-breaking hyphen</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>-</kbd></td> </tr>
-            <!-- <tr> <td class="function">Run macro field</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span>* (on numeric keypad)</td> </tr> -->
-            <tr> <td class="function">Insert non-breaking space</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Space</kbd></td> </tr>
-            <tr> <td class="function">Insert line break</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Enter</kbd></td> </tr>
-            <tr> <td class="function">Manual page break</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Enter</kbd></td> </tr>
-            <tr> <td class="function">Column break (in multicolumnar text)</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Enter</kbd></td> </tr>
-            <tr> <td class="function">Insert new paragraph directly before or after a section, or before a table</td> <td class="shortcut"><kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>Enter</kbd></td> </tr>
-            <tr> <td class="function">Insert new paragraph without numbering inside a list. Does not work when the cursor is at the end of the list.</td> <td class="shortcut"><kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>Enter</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Insert footnote</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>F</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Insert endnote</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>D</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Insert comment</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>C</kbd></td> </tr>
+            <!-- <tr class="sub-section"> <td class="function">Calculates the selected text and copies the result to the clipboard.</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span>Plus Key(+)</td> </tr> -->
+            <tr class="sub-section"> <td class="function">Insert soft hyphen</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>-</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Insert non-breaking hyphen</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>-</kbd></td> </tr>
+            <!-- <tr class="sub-section"> <td class="function">Run macro field</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span>* (on numeric keypad)</td> </tr> -->
+            <tr class="sub-section"> <td class="function">Insert non-breaking space</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Space</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Insert line break</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Enter</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Manual page break</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Enter</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Column break (in multicolumnar text)</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Enter</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Insert new paragraph directly before or after a section, or before a table</td> <td class="shortcut"><kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>Enter</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Insert new paragraph without numbering inside a list. Does not work when the cursor is at the end of the list.</td> <td class="shortcut"><kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>Enter</kbd></td> </tr>
         </table>
+      </div>
     </div>
     <div id="spreadsheet-shortcuts" style="display: none;">
-        <h2>Navigating in Spreadsheets</h2>
+      <div class="section">
+        <h2 class="section-header">Navigating in Spreadsheets</h2>
           <table class="help">
-            <tr> <td class="function">Moves the cursor to the first cell in the sheet (A1).</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Home</kbd></td> </tr>
-            <tr> <td class="function">Moves the cursor to the last cell on the sheet that contains data.</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>End</kbd></td> </tr>
-            <tr> <td class="function">Moves the cursor to the first cell of the current row.</td> <td class="shortcut"><kbd>Home</kbd></td> </tr>
-            <tr> <td class="function">Moves the cursor to the last cell of the current row.</td> <td class="shortcut"><kbd>End</kbd></td> </tr>
-            <tr> <td class="function">Selects cells from the current cell to the first cell of the current row.</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Home</kbd></td> </tr>
-            <tr> <td class="function">Selects cells from the current cell to the last cell of the current row.</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>End</kbd></td> </tr>
-            <tr> <td class="function">Selects cells from the current cell up to one page in the current column or extends the existing selection one page up.</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Page Up</kbd></td> </tr>
-            <tr> <td class="function">Selects cells from the current cell down to one page in the current column or extends the existing selection one page down.</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Page Down</kbd></td> </tr>
-            <tr> <td class="function">Moves the cursor to the left edge of the current data range. If the column to the left of the cell that contains the cursor is empty, the cursor moves to the next column to the left that contains data</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Left Arrow</kbd></td> </tr>
-            <tr> <td class="function">Moves the cursor to the right edge of the current data range. If the column to the right of the cell that contains the cursor is empty, the cursor moves to the next column to the right that contains data.</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Right Arrow</kbd></td> </tr>
-            <tr> <td class="function">Moves the cursor to the top edge of the current data range. If the row above the cell that contains the cursor is empty, the cursor moves up to the next row that contains data.</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Up Arrow</kbd></td> </tr>
-            <tr> <td class="function">Moves the cursor to the bottom edge of the current data range. If the row below the cell that contains the cursor is empty, the cursor moves down to the next row that contains data.</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Down Arrow</kbd></td> </tr>
-            <tr> <td class="function">Go to next sheet.</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>Page Down</kbd></td> </tr>
-            <tr> <td class="function">Go to previous sheet.</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>Page Up</kbd></td> </tr>
-            <tr> <td class="function">Selects all cells containing data from the current cell to the end of the continuous range of data cells, in the direction of the arrow pressed. If used to select rows and columns together, a rectangular cell range is selected.</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow</kbd></td> </tr>
-            <tr> <td class="function">Moves one sheet to the left.</td> <td class="shortcut"><kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>Page Up</kbd></td> </tr>
-            <tr> <td class="function">Moves one screen page to the right.</td> <td class="shortcut"><kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>Page Down</kbd></td> </tr>
-            <tr> <td class="function">Adds the previous sheet to the current selection of sheets. If all the sheets in a spreadsheet are selected, this shortcut key combination only selects the previous sheet. Makes the previous sheet the current sheet.</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Page Up</kbd></td> </tr>
-            <tr> <td class="function">Adds the next sheet to the current selection of sheets. If all the sheets in a spreadsheet are selected, this shortcut key combination only selects the next sheet. Makes the next sheet the current sheet.</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Page Down</kbd></td> </tr>
-            <tr> <td class="function">where (*) is the multiplication sign on the numeric key pad. Selects the data range that contains the cursor. A range is a contiguous cell range that contains data and is bounded by empty row and columns.</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>*</kbd></td> </tr>
-            <tr> <td class="function">where (/) is the division sign on the numeric key pad. Selects the matrix formula range that contains the cursor.</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>/</kbd></td> </tr>
-            <tr> <td class="function">Insert cells (as in menu Insert - Cells)</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Plus key</kbd></td> </tr>
-            <tr> <td class="function">Delete cells (as in menu Edit - Delete Cells)</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Minus key</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Moves the cursor to the first cell in the sheet (A1).</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Home</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Moves the cursor to the last cell on the sheet that contains data.</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>End</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Moves the cursor to the first cell of the current row.</td> <td class="shortcut"><kbd>Home</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Moves the cursor to the last cell of the current row.</td> <td class="shortcut"><kbd>End</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Selects cells from the current cell to the first cell of the current row.</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Home</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Selects cells from the current cell to the last cell of the current row.</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>End</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Selects cells from the current cell up to one page in the current column or extends the existing selection one page up.</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Page Up</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Selects cells from the current cell down to one page in the current column or extends the existing selection one page down.</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Page Down</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Moves the cursor to the left edge of the current data range. If the column to the left of the cell that contains the cursor is empty, the cursor moves to the next column to the left that contains data</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Left Arrow</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Moves the cursor to the right edge of the current data range. If the column to the right of the cell that contains the cursor is empty, the cursor moves to the next column to the right that contains data.</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Right Arrow</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Moves the cursor to the top edge of the current data range. If the row above the cell that contains the cursor is empty, the cursor moves up to the next row that contains data.</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Up Arrow</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Moves the cursor to the bottom edge of the current data range. If the row below the cell that contains the cursor is empty, the cursor moves down to the next row that contains data.</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Down Arrow</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Go to next sheet.</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>Page Down</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Go to previous sheet.</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>Page Up</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Selects all cells containing data from the current cell to the end of the continuous range of data cells, in the direction of the arrow pressed. If used to select rows and columns together, a rectangular cell range is selected.</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Moves one sheet to the left.</td> <td class="shortcut"><kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>Page Up</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Moves one screen page to the right.</td> <td class="shortcut"><kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>Page Down</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Adds the previous sheet to the current selection of sheets. If all the sheets in a spreadsheet are selected, this shortcut key combination only selects the previous sheet. Makes the previous sheet the current sheet.</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Page Up</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Adds the next sheet to the current selection of sheets. If all the sheets in a spreadsheet are selected, this shortcut key combination only selects the next sheet. Makes the next sheet the current sheet.</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Page Down</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">where (*) is the multiplication sign on the numeric key pad. Selects the data range that contains the cursor. A range is a contiguous cell range that contains data and is bounded by empty row and columns.</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>*</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">where (/) is the division sign on the numeric key pad. Selects the matrix formula range that contains the cursor.</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>/</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Insert cells (as in menu Insert - Cells)</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Plus key</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Delete cells (as in menu Edit - Delete Cells)</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Minus key</kbd></td> </tr>
         </table>
-        <h2>Cell formatting</h2>
+      </div>
+        <div class="section">
+        <h2 class="section-header">Cell formatting</h2>
         <table class="help">
-            <tr> <td class="function">Bold</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>B</kbd></td> </tr>
-            <tr> <td class="function">Italic</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>I</kbd></td> </tr>
-            <tr> <td class="function">Underline</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>U</kbd></td> </tr>
-            <tr> <td class="function">Strikethrough</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>5</kbd></td> </tr>
-            <tr> <td class="function">Remove direct formatting</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>M</kbd></td> </tr>
-            <tr> <td class="function">Insert comment</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>C</kbd></td> </tr>
-            <tr> <td class="function">Display comment</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>F1</kbd></td> </tr>
-            <tr> <td class="function">Fill Down</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>D</kbd></td> </tr>
-            <tr> <td class="function">Select All</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>A</kbd></td> </tr>
-            <tr> <td class="function">Align Center</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>E</kbd></td> </tr>
-            <tr> <td class="function">Align Left</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>L</kbd></td> </tr>
-            <tr> <td class="function">Align Right</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>R</kbd></td> </tr>
-            <tr> <td class="function">Justify</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>J</kbd></td> </tr>
-            <tr> <td class="function">Set Optimal Column Width</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>3</kbd></td> </tr>
-            <tr> <td class="function">Two decimal places, thousands separator</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>1</kbd></td> </tr>
-            <tr> <td class="function">Standard exponential format</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>2</kbd></td> </tr>
-            <tr> <td class="function">Standard date format</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>3</kbd></td> </tr>
-            <tr> <td class="function">Standard currency format</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>4</kbd></td> </tr>
-            <tr> <td class="function">Standard percentage format (two decimal places)</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>5</kbd></td> </tr>
-            <tr> <td class="function">Standard format</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>6</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Bold</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>B</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Italic</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>I</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Underline</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>U</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Strikethrough</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>5</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Remove direct formatting</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>M</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Insert comment</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>C</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Display comment</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>F1</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Fill Down</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>D</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Select All</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>A</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Align Center</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>E</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Align Left</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>L</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Align Right</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>R</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Justify</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>J</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Set Optimal Column Width</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>3</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Two decimal places, thousands separator</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>1</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Standard exponential format</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>2</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Standard date format</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>3</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Standard currency format</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>4</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Standard percentage format (two decimal places)</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>5</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Standard format</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>6</kbd></td> </tr>
         </table>
+        </div>
     </div>
     <div id="presentation-shortcuts" style="display: none;">
-        <h2>Text formatting</h2>
+        <div class="section">
+        <h2 class="section-header">Text formatting</h2>
         <table class="help">
-            <tr> <td class="function">Bold</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>B</kbd></td> </tr>
-            <tr> <td class="function">Italic</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>I</kbd></td> </tr>
-            <tr> <td class="function">Underline</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>U</kbd></td> </tr>
-            <tr> <td class="function">Strikethrough</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>5</kbd></td> </tr>
-            <tr> <td class="function">Superscript</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>P</kbd></td> </tr>
-            <tr> <td class="function">Subscript</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>B</kbd></td> </tr>
-            <tr> <td class="function">Select All</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>A</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Bold</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>B</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Italic</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>I</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Underline</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>U</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Strikethrough</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>5</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Superscript</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>P</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Subscript</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>B</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Select All</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>A</kbd></td> </tr>
         </table>
-        <h2>Paragraph formatting</h2>
+        </div>
+        <div class="section">
+        <h2 class="section-header">Paragraph formatting</h2>
         <table class="help">
-            <tr> <td class="function">Align Center</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>E</kbd></td> </tr>
-            <tr> <td class="function">Align Left</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>L</kbd></td> </tr>
-            <tr> <td class="function">Align Right</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>R</kbd></td> </tr>
-            <tr> <td class="function">Justify</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>J</kbd></td> </tr>
-            <tr> <td class="function">Demote list item (list item has to be selected)</td> <td class="shortcut"><kbd>Tab</kbd></td> </tr>
-            <tr> <td class="function">Promote list item (list item has to be selected)</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Tab</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Align Center</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>E</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Align Left</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>L</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Align Right</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>R</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Justify</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>J</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Demote list item (list item has to be selected)</td> <td class="shortcut"><kbd>Tab</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Promote list item (list item has to be selected)</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Tab</kbd></td> </tr>
         </table>
-        <h2>Text selection and navigation in a textbox</h2>
+        </div>
+        <div class="section">
+        <h2 class="section-header">Text selection and navigation in a textbox</h2>
         <table class="help">
-            <tr> <td class="function">Select All</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>A</kbd></td> </tr>
-            <tr> <td class="function">Move cursor to the left</td> <td class="shortcut"><kbd>Arrow Left</kbd></td> </tr>
-            <tr> <td class="function">Move cursor with selection to the left</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Left</kbd></td> </tr>
-            <tr> <td class="function">Go to beginning of a word</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Arrow Left</kbd></td> </tr>
-            <tr> <td class="function">Select to the left word by word</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Left</kbd></td> </tr>
-            <tr> <td class="function">Move cursor to the right</td> <td class="shortcut"><kbd>Arrow Right</kbd></td> </tr>
-            <tr> <td class="function">Move cursor with selection to the right</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Right</kbd></td> </tr>
-            <tr> <td class="function">Go to start of the next word</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Arrow Right</kbd></td> </tr>
-            <tr> <td class="function">Select to the right word by word</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Right</kbd></td> </tr>
-            <tr> <td class="function">Move cursor up one line</td> <td class="shortcut"><kbd>Arrow Up</kbd></td> </tr>
-            <tr> <td class="function">Select lines in upwards direction</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Up</kbd></td> </tr>
-            <tr> <td class="function">Move cursor to beginning of the previous paragraph</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Arrow Up</kbd></td> </tr>
-            <tr> <td class="function">Select to beginning of paragraph</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Up</kbd></td> </tr>
-            <tr> <td class="function">Move cursor down one line</td> <td class="shortcut"><kbd>Arrow Down</kbd></td> </tr>
-            <tr> <td class="function">Select lines in downwards direction</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Down</kbd></td> </tr>
-            <tr> <td class="function">Move cursor to beginning of the next paragraph</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Arrow Down</kbd></td> </tr>
-            <tr> <td class="function">Select to end of paragraph</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Down</kbd></td> </tr>
-            <tr> <td class="function">Go to beginning of line</td> <td class="shortcut"><kbd>Home</kbd></td> </tr>
-            <tr> <td class="function">Go and select to the beginning of a line</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Home</kbd></td> </tr>
-            <tr> <td class="function">Go to start of document</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Home</kbd></td> </tr>
-            <tr> <td class="function">Go and select text to start of textbox</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Home</kbd></td> </tr>
-            <tr> <td class="function">Go to end of line</td> <td class="shortcut"><kbd>End</kbd></td> </tr>
-            <tr> <td class="function">Go and select to the end of a line</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>End</kbd></td> </tr>
-            <tr> <td class="function">Go to end of document</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>End</kbd></td> </tr>
-            <tr> <td class="function">Go and select text to end of textbox</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>End</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Select All</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>A</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Move cursor to the left</td> <td class="shortcut"><kbd>Arrow Left</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Move cursor with selection to the left</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Left</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Go to beginning of a word</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Arrow Left</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Select to the left word by word</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Left</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Move cursor to the right</td> <td class="shortcut"><kbd>Arrow Right</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Move cursor with selection to the right</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Right</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Go to start of the next word</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Arrow Right</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Select to the right word by word</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Right</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Move cursor up one line</td> <td class="shortcut"><kbd>Arrow Up</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Select lines in upwards direction</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Up</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Move cursor to beginning of the previous paragraph</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Arrow Up</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Select to beginning of paragraph</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Up</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Move cursor down one line</td> <td class="shortcut"><kbd>Arrow Down</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Select lines in downwards direction</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Down</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Move cursor to beginning of the next paragraph</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Arrow Down</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Select to end of paragraph</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Down</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Go to beginning of line</td> <td class="shortcut"><kbd>Home</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Go and select to the beginning of a line</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Home</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Go to start of document</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Home</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Go and select text to start of textbox</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Home</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Go to end of line</td> <td class="shortcut"><kbd>End</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Go and select to the end of a line</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>End</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Go to end of document</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>End</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Go and select text to end of textbox</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>End</kbd></td> </tr>
         </table>
-        <h2>Slide keyboard shortcuts</h2>
+        </div>
+        <div class="section">
+        <h2 class="section-header">Slide keyboard shortcuts</h2>
         <table class="help">
-            <tr> <td class="function">Escape current mode, i.e. from edit mode switch to object selection mode, from object selection mode switch to view mode.</td> <td class="shortcut"><kbd>Esc</kbd></td> </tr>
-            <tr> <td class="function">Select objects in the order in which they were created</td> <td class="shortcut"><kbd>Tab</kbd></td> </tr>
-            <tr> <td class="function">Select objects in the reverse order in which they were created</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Tab</kbd></td> </tr>
-            <tr> <td class="function">Move to next text object on slide</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Enter</kbd></td> </tr>
-            <tr> <td class="function">Select all in slide</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>A</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Escape current mode, i.e. from edit mode switch to object selection mode, from object selection mode switch to view mode.</td> <td class="shortcut"><kbd>Esc</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Select objects in the order in which they were created</td> <td class="shortcut"><kbd>Tab</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Select objects in the reverse order in which they were created</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Tab</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Move to next text object on slide</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Enter</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Select all in slide</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>A</kbd></td> </tr>
         </table>
+        </div>
     </div>
         <div id="drawing-shortcuts" style="display: none;">
-        <h2>Text formatting</h2>
+        <div class="section">
+        <h2 class="section-header">Text formatting</h2>
         <table class="help">
-            <tr> <td class="function">Bold</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>B</kbd></td> </tr>
-            <tr> <td class="function">Italic</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>I</kbd></td> </tr>
-            <tr> <td class="function">Underline</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>U</kbd></td> </tr>
-            <tr> <td class="function">Strikethrough</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>5</kbd></td> </tr>
-            <tr> <td class="function">Superscript</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>P</kbd></td> </tr>
-            <tr> <td class="function">Subscript</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>B</kbd></td> </tr>
-            <tr> <td class="function">Select All</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>A</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Bold</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>B</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Italic</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>I</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Underline</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>U</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Strikethrough</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>5</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Superscript</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>P</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Subscript</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>B</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Select All</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>A</kbd></td> </tr>
         </table>
-        <h2>Paragraph formatting</h2>
+        </div>
+        <div class="section">
+        <h2 class="section-header">Paragraph formatting</h2>
         <table class="help">
-            <tr> <td class="function">Align Center</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>E</kbd></td> </tr>
-            <tr> <td class="function">Align Left</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>L</kbd></td> </tr>
-            <tr> <td class="function">Align Right</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>R</kbd></td> </tr>
-            <tr> <td class="function">Justify</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>J</kbd></td> </tr>
-            <tr> <td class="function">Demote list item (list item has to be selected)</td> <td class="shortcut"><kbd>Tab</kbd></td> </tr>
-            <tr> <td class="function">Promote list item (list item has to be selected)</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Tab</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Align Center</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>E</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Align Left</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>L</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Align Right</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>R</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Justify</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>J</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Demote list item (list item has to be selected)</td> <td class="shortcut"><kbd>Tab</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Promote list item (list item has to be selected)</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Tab</kbd></td> </tr>
         </table>
-        <h2>Text selection and navigation in a textbox</h2>
+        </div>
+        <div class="section">
+        <h2 class="section-header">Text selection and navigation in a textbox</h2>
         <table class="help">
-            <tr> <td class="function">Select All</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>A</kbd></td> </tr>
-            <tr> <td class="function">Move cursor to the left</td> <td class="shortcut"><kbd>Arrow Left</kbd></td> </tr>
-            <tr> <td class="function">Move cursor with selection to the left</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Left</kbd></td> </tr>
-            <tr> <td class="function">Go to beginning of a word</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Arrow Left</kbd></td> </tr>
-            <tr> <td class="function">Select to the left word by word</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Left</kbd></td> </tr>
-            <tr> <td class="function">Move cursor to the right</td> <td class="shortcut"><kbd>Arrow Right</kbd></td> </tr>
-            <tr> <td class="function">Move cursor with selection to the right</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Right</kbd></td> </tr>
-            <tr> <td class="function">Go to start of the next word</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Arrow Right</kbd></td> </tr>
-            <tr> <td class="function">Select to the right word by word</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Right</kbd></td> </tr>
-            <tr> <td class="function">Move cursor up one line</td> <td class="shortcut"><kbd>Arrow Up</kbd></td> </tr>
-            <tr> <td class="function">Select lines in upwards direction</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Up</kbd></td> </tr>
-            <tr> <td class="function">Move cursor to beginning of the previous paragraph</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Arrow Up</kbd></td> </tr>
-            <tr> <td class="function">Select to beginning of paragraph</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Up</kbd></td> </tr>
-            <tr> <td class="function">Move cursor down one line</td> <td class="shortcut"><kbd>Arrow Down</kbd></td> </tr>
-            <tr> <td class="function">Select lines in downwards direction</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Down</kbd></td> </tr>
-            <tr> <td class="function">Move cursor to beginning of the next paragraph</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Arrow Down</kbd></td> </tr>
-            <tr> <td class="function">Select to end of paragraph</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Down</kbd></td> </tr>
-            <tr> <td class="function">Go to beginning of line</td> <td class="shortcut"><kbd>Home</kbd></td> </tr>
-            <tr> <td class="function">Go and select to the beginning of a line</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Home</kbd></td> </tr>
-            <tr> <td class="function">Go to start of document</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Home</kbd></td> </tr>
-            <tr> <td class="function">Go and select text to start of textbox</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Home</kbd></td> </tr>
-            <tr> <td class="function">Go to end of line</td> <td class="shortcut"><kbd>End</kbd></td> </tr>
-            <tr> <td class="function">Go and select to the end of a line</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>End</kbd></td> </tr>
-            <tr> <td class="function">Go to end of document</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>End</kbd></td> </tr>
-            <tr> <td class="function">Go and select text to end of textbox</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>End</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Select All</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>A</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Move cursor to the left</td> <td class="shortcut"><kbd>Arrow Left</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Move cursor with selection to the left</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Left</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Go to beginning of a word</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Arrow Left</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Select to the left word by word</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Left</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Move cursor to the right</td> <td class="shortcut"><kbd>Arrow Right</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Move cursor with selection to the right</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Right</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Go to start of the next word</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Arrow Right</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Select to the right word by word</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Right</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Move cursor up one line</td> <td class="shortcut"><kbd>Arrow Up</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Select lines in upwards direction</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Up</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Move cursor to beginning of the previous paragraph</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Arrow Up</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Select to beginning of paragraph</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Up</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Move cursor down one line</td> <td class="shortcut"><kbd>Arrow Down</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Select lines in downwards direction</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Down</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Move cursor to beginning of the next paragraph</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Arrow Down</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Select to end of paragraph</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Arrow Down</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Go to beginning of line</td> <td class="shortcut"><kbd>Home</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Go and select to the beginning of a line</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Home</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Go to start of document</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Home</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Go and select text to start of textbox</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Home</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Go to end of line</td> <td class="shortcut"><kbd>End</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Go and select to the end of a line</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>End</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Go to end of document</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>End</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Go and select text to end of textbox</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>End</kbd></td> </tr>
         </table>
-        <h2>Draw page keyboard shortcuts</h2>
+        </div>
+        <div class="section">
+        <h2 class="section-header">Draw page keyboard shortcuts</h2>
         <table class="help">
-            <tr> <td class="function">Escape current mode, i.e. from edit mode switch to object selection mode, from object selection mode switch to view mode.</td> <td class="shortcut"><kbd>Esc</kbd></td> </tr>
-            <tr> <td class="function">Select objects in the order in which they were created</td> <td class="shortcut"><kbd>Tab</kbd></td> </tr>
-            <tr> <td class="function">Select objects in the reverse order in which they were created</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Tab</kbd></td> </tr>
-            <tr> <td class="function">Move to next text object on drawing page</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Enter</kbd></td> </tr>
-            <tr> <td class="function">Select all in drawing page</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>A</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Escape current mode, i.e. from edit mode switch to object selection mode, from object selection mode switch to view mode.</td> <td class="shortcut"><kbd>Esc</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Select objects in the order in which they were created</td> <td class="shortcut"><kbd>Tab</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Select objects in the reverse order in which they were created</td> <td class="shortcut"><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>Tab</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Move to next text object on drawing page</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Enter</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Select all in drawing page</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>A</kbd></td> </tr>
         </table>
+        </div>
     </div>
 </div>
 <div id="online-help-content">
-    <h1><span class="productname">%productName</span> Help</h1>
+    <h1 class="help-dialog-header"><span class="productname">%productName</span> Help</h1>
     <p class="toc-h3 m-v-0"><button class="border-0" onClick='document.getElementById(1327).scrollIntoView();'>Collaborative editing</button></p>
     <p class="toc-h3 m-v-0"><button class="border-0" onClick='document.getElementById(1333).scrollIntoView();'><span class="productname">%productName</span> user interface</button></p>
     <p class="toc-h3 m-v-0"><button class="border-0" onClick='document.getElementById(1335).scrollIntoView();'>Opening, closing, saving, printing and downloading documents</button></p>
     <p class="toc-h3 m-v-0"><button class="border-0" onClick='document.getElementById(1337).scrollIntoView();'>Editing documents</button></p>
     <p class="toc-h3 m-v-0"><button class="border-0" onClick='document.getElementById(1338).scrollIntoView();'>Advanced features</button></p>
-    <div class="spreadsheet" style="display: none;">
+    <div class="spreadsheet link-section" style="display: none;">
         <p class="toc-h2 m-v-0"><button class="border-0" onClick='document.getElementById(1359).scrollIntoView();'><span class="productname">%productName</span> spreadsheets</button></p>
         <p class="toc-h3 m-v-0"><button class="border-0" onClick='document.getElementById(1361).scrollIntoView();'>Editing spreadsheets</button></p>
         <p class="toc-h3 m-v-0"><button class="border-0" onClick='document.getElementById(1363).scrollIntoView();'>Formulas</button></p>
-        <p class="toc-h3 m-v-0"><button class="border-0" honClick='document.getElementById(1367).scrollIntoView();'>Formatting spreadsheets</button></p>
+        <p class="toc-h3 m-v-0"><button class="border-0" onClick='document.getElementById(1367).scrollIntoView();'>Formatting spreadsheets</button></p>
         <p class="toc-h3 m-v-0"><button class="border-0" onClick='document.getElementById(1371).scrollIntoView();'>Advanced features</button></p>
+        <p class="toc-h3 m-v-0"><button class="border-0" onClick='document.getElementById(1409).scrollIntoView();'>Spreadsheets</button></p>
     </div>
-    <div class="text" style="display: none;">
+    <div class="text link-section" style="display: none;">
         <p class="toc-h2 m-v-0"><button class="border-0" onClick='document.getElementById(1373).scrollIntoView();'><span class="productname">%productName</span> text documents</button></p>
         <p class="toc-h3 m-v-0"><button class="border-0" onClick='document.getElementById(1375).scrollIntoView();'>Editing text documents</button></p>
         <p class="toc-h3 m-v-0"><button class="border-0" onClick='document.getElementById(1377).scrollIntoView();'>Context menus</button></p>
         <p class="toc-h3 m-v-0"><button class="border-0" onClick='document.getElementById(1383).scrollIntoView();'>Advanced text document editor features</button></p>
+        <p class="toc-h3 m-v-0"><button class="border-0" onClick='document.getElementById(1407).scrollIntoView();'>Text documents</button></p>
     </div>
-    <div class="presentation" style="display: none;">
+    <div class="presentation link-section" style="display: none;">
         <p class="toc-h2 m-v-0"><button class="border-0" onClick='document.getElementById(1391).scrollIntoView();'><span class="productname">%productName</span> presentations</button></p>
         <p class="toc-h3 m-v-0"><button class="border-0" onClick='document.getElementById(1393).scrollIntoView();'>Editing presentations</button></p>
         <p class="toc-h3 m-v-0"><button class="border-0" onClick='document.getElementById(1395).scrollIntoView();'>Slide show</button></p>
         <p class="toc-h3 m-v-0"><button class="border-0" onClick='document.getElementById(1397).scrollIntoView();'>Slide pane</button></p>
         <p class="toc-h3 m-v-0"><button class="border-0" onClick='document.getElementById(1401).scrollIntoView();'>Advanced features</button></p>
-    </div>
-    <p class="toc-h2 m-v-0"><button class="border-0" onClick='document.getElementById(1403).scrollIntoView();'>Frequently Asked Questions</button></p>
-    <p class="toc-h3 m-v-0"><button class="border-0" onClick='document.getElementById(1405).scrollIntoView();'>General</button></p>
-    <div class="text" style="display: none;">
-        <p class="toc-h3 m-v-0"><button class="border-0" onClick='document.getElementById(1407).scrollIntoView();'>Text documents</button></p>
-    </div>
-    <div class="spreadsheet" style="display: none;">
-        <p class="toc-h3 m-v-0"><button class="border-0" onClick='document.getElementById(1409).scrollIntoView();'>Spreadsheets</button></p>
-    </div>
-    <div class="presentation" style="display: none;">
         <p class="toc-h3 m-v-0"><button class="border-0" onClick='document.getElementById(1411).scrollIntoView();'>Presentations</button></p>
     </div>
-    <p><span class="productname">%productName</span> allows you to create and edit office documents text documents, spreadsheets and presentations directly in your browser, in a simple and straight-forward way. You can work alone on a document, or collaboratively as part of a team.</p>
+    <p class="toc-h2 m-v-0"><button class="border-0" onClick='document.getElementById(1403).scrollIntoView();'>Frequently Asked Questions</button></p>
+
+    <div class="section">
+    <p class="section-header"><span class="productname">%productName</span> allows you to create and edit office documents text documents, spreadsheets and presentations directly in your browser, in a simple and straight-forward way. You can work alone on a document, or collaboratively as part of a team.</p>
+    </div>
+    
     <a id="1327"/>
-    <h3>Collaborative editing</h3>
+  <div class="section">
+    <h3 class="section-header">Collaborative editing</h3>
+    <div class="sub-section">
     <ul>
       <li><p>Each user gets assigned a color. The cursor of each user will be shown in the assigned color. Note: you will see your cursor as black, blinking cursor, although others will see you with a different color.</p></li>
       <li><p>You can jump to the cursor of a user by clicking on the name (or avatar) of the user. It is possible to follow the editor.</p></li>
       <li><p><span class="productname">%productName</span> notifies you with a small notification in the footer when a new user enters or when a user leaves.</p></li>
     </ul>
+    </div>
+  </div>
     <a id="1333"/>
-    <h3><span class="productname">%productName</span> user interface</h3>
-    <p><span class="productname">%productName</span> uses modern browser resources to adapt the user interface to the size of the viewing area, including small screens found in mobile devices. The interface is composed of:</p>
+<div class="section">
+    <h3 class="section-header"><span class="productname">%productName</span> user interface</h3>
+    <div class="sub-section"><p><span class="productname">%productName</span> uses modern browser resources to adapt the user interface to the size of the viewing area, including small screens found in mobile devices. The interface is composed of:</p></div>
+  <div class="sub-section">
     <p><span class="def">The document area:</span> The application area shows the document contents, either spreadsheets, presentations or text documents.</p>
+  </div>
+  <div class="sub-section">
     <p><span class="def">The menu bar:</span> The main menu is placed on the top and includes many options, commands for printing, editing, viewing and other advanced commands. You can hide the menu bar clicking on the <span style="height:0.6cm;width:0.6cm; margin: 0px;" class="w2ui-icon fold" ></span> icon on the far right. Click on the <span style="height:0.6cm;width:0.6cm; margin: 0px;" class="w2ui-icon unfold" ></span> icon to show the menu.</p>
+  </div>
+  <div class="sub-section">
     <p><span class="def">Context menus:</span> On clicking with the right mouse button, a menu appears with commands associated with the underlying object.</p>
+  </div>
+  <div class="sub-section">
     <p><span class="def">The toolbar:</span> The toolbar contains the most used options for daily editing. Toolbar buttons are dynamic, meaning that their state (on or off) depends on different factors.</p>
+  </div>
+  <div class="sub-section">
     <p><span class="def">The status bar:</span> The status bar is shown in the bottom, and contains several useful options and features.</p>
     <div class="screenshot"><img alt="" src="images/help/en/status-bar.png"/></div>
+  </div>
+  <div class="sub-section">
     <p><span class="def">The search bar:</span> Searching starts automatically when content is inserted in the search box, and the document window automatically moves to the first occurrence found. Searching is not case-sensitive. There are three buttons right next to the search box:</p>
     <ul>
       <li><p>Search backwards</p></li>
       <li><p>Search forward</p></li>
       <li><p>Cancel the search (appears only when a text has been searched)</p></li>
     </ul>
+  </div>
+  <div class="sub-section">
     <p><span class="def">The zoom bar:</span> At the right of the status bar, there is a set of buttons that allow you to zoom to 100%, zoom out and zoom in. The zoom applies to the document area, the user interface is not affected. The current level of zoom is shown in this area.</p>
     <p>Text, charts, shapes and svg images will stay sharp, when zooming in, you will only see pixels appear at inserted images, such as jpg’s or png’s.</p>
     <p>Using the browser zoom affects the document and user interface areas.</p>
+  </div>
+  <div class="sub-section">
     <p><span class="def">The information bar:</span> At the right of the search bar, a set of information on the document is displayed. The actual information depends on the nature of the document.</p>
     <div class="screenshot"><img alt="" src="images/help/en/information-bar.png"/></div>
+  </div>
+</div>
     <a id="1335"/>
-    <h3>Opening, closing, saving, printing and downloading documents</h3>
+    <div class="section">
+    <h3 class="section-header">Opening, closing, saving, printing and downloading documents</h3>
     <p>Your documents are stored and managed in the cloud storage that is integrated with <span class="productname">%productName</span>.</p>
-    <p>To download a document download it from the <span class="productname">%productName</span> application’s <span class="ui">File</span> menu. The download formats available depends on the application. All applications exports documents in PDF format.</p>
-    <p>To open document, click on the file to open the <span class="productname">%productName</span> module associated to the document format.</p>
-    <p>Documents in <span class="productname">%productName</span> save automatically, but if you are concerned that a document is synchronized as quickly as possible you can also force saving using the <span class="ui">File</span> menu’s <span class="ui">Save</span> entry.</p>
-    <p>Depending on the capabilities of your browser the print window may appear or a “Download PDF export?” popup shows. You can print this PDF in your favorite PDF reader.</p>
-    <p>When closing a document, it is automatically saved if it has been changed.</p>
+    <div class="sub-section"><p>To download a document download it from the <span class="productname">%productName</span> application’s <span class="ui">File</span> menu. The download formats available depends on the application. All applications exports documents in PDF format.</p></div>
+    <div class="sub-section"><p>To open document, click on the file to open the <span class="productname">%productName</span> module associated to the document format.</p></div>
+    <div class="sub-section"><p>Documents in <span class="productname">%productName</span> save automatically, but if you are concerned that a document is synchronized as quickly as possible you can also force saving using the <span class="ui">File</span> menu’s <span class="ui">Save</span> entry.</p></div>
+    <div class="sub-section"><p>Depending on the capabilities of your browser the print window may appear or a “Download PDF export?” popup shows. You can print this PDF in your favorite PDF reader.</p></div>
+    <div class="sub-section"><p>When closing a document, it is automatically saved if it has been changed.</p></div>
+    </div>
     <a id="1337"/>
-    <h3>Editing documents</h3>
+    <div class="section">
+    <h3 class="section-header">Editing documents</h3>
     <p>Document editing should be familiar to everyone that has used an office application before, but here are some distinctive features:</p>
+    <div class="sub-section">
     <h4>Copy and Paste</h4>
     <p>Rich content copy/cut and paste is supported, not only within a given document, but also across documents on the same or different <span class="productname">%productName</span>. For these internal uses, users can copy/cut content, including images and mixed content, on PC by using the keyboard shortcuts directly (<kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>X</kbd>, <kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>C</kbd>, <kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>V</kbd>). For security reasons it is necessary to use <kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>V</kbd> to paste on PC, but context menus can be used for cut and copy. On Android or iOS selecting text by double tapping, and using a long-tap to access copy/cut/paste via the context menu is required.</p>
     <p>To copy larger pieces of content to other applications on your device, users need to press the <span class="ui">Start download</span> button, and then re-copy this to their clipboard in order to make it available to the target application to read. This is possible via a tiny widget that pops up in the bottom-right corner, and is only necessary to export the content for pasting in external applications. This step also converts complex object types into static images.</p>
+    </div>
+    <div class="sub-section">
     <h4>Document repair</h4>
     <p>When multiple people edit the same document concurrently, it is possible for their changes to conflict and this can cause some confusion. The Document Repair function allows users to undo other editor’s changes to the document to a previous state.</p>
     <p>To jump back to the selected state, select it with the mouse and hit <span class="ui">Jump to state</span>.</p>
-    <div class="screenshot"><img alt="" src="images/help/en/repair-document.png"/></div>
+    <div class="screenshot"><img alt="document repair" src="images/help/en/repair-document.png"/></div>
     <p>This is particularly useful – say when a colleague inadvertently selected all text in the document with <kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>A</kbd> and proceeded to type over it destroying it – while you were concurrently editing.</p>
+    </div>
+    <div class="sub-section">
     <h4>Inactive document</h4>
     <p>When <span class="productname">%productName</span> detects that there has not been any activity in the browser for a while, it puts the document in an “Inactive” state. The document is shown with a transparent gray overlay, with the message “Inactive document – please click to resume editing”.</p>
-    <div class="screenshot"><img alt="" src="images/help/en/inactive-document.png"/></div>
+    <div class="screenshot"><img alt="inactive document" src="images/help/en/inactive-document.png"/></div>
     <p>To continue editing, click on the document and the layover and message disappear. Any changes that may have been made by other users – while collaboratively editing the document – are re-loaded.</p>
+    </div>
+    <div class="sub-section">
     <h4>Pasting</h4>
     <p>When you paste content copied from within the same document, the format and elements are maintained. If you copy from another document, in another tab or browser window, or from outside of the browser, the pasted content will preserve rich text.</p>
     <p>You can paste as unformatted text with the keyboard shortcut: <kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>V</kbd></p>
     <p>When you paste text from within the document, formatting will be respected. You can also paste objects, such as images, if they are copied from the document you are working in.</p>
     <p>When you paste text from outside of the document (another browser window or a desktop application, it will be pasted as rich text.</p>
     <p>When you have internal cut or copied content, you can paste this content using the context menu.</p>
+    </div>
+    </div>
     <a id="1338"/>
-    <h3>Advanced features</h3>
+<div class="section">
+  <h3 class="section-header">Advanced features</h3>
+  <div class="sub-section">
     <h4>Adding charts</h4>
     <p><span class="productname">%productName</span> supports inserting and visualization of charts in documents. To add a chart:</p>
     <ol>
       <li><p>Select a table in text document, a range in a spreadsheet or a table in a presentation.</p></li>
       <li>
         <p>Choose <span class="ui">Insert</span> → <span class="ui">Charts</span>. Customize your chart on the sidebar:</p>
-        <div class="screenshot"><img alt="" src="images/help/en/chart-wizard.png"/></div>
       </li>
+      <div class="screenshot"><img alt="chart" src="images/help/en/chart-wizard.png"/></div>
       <li><p>If no table or range was selected, a prototype chart is displayed.</p></li>
     </ol>
     <div class="screenshot"><img alt="" src="images/help/en/chart.png"/></div>
-    <p><span class="def">Chart editing:</span> Double click the chart to select. Use context menus to add chart elements such as title, axis, and other. Choose <span class="ui">Data Range</span> and <span class="ui">Chart Type</span> to edit chart data and select chart type.</p>
-    <p><span class="def">Chart formatting:</span> The same context menu brings you to chart data table and chart type selection.</p>
-    <p><span class="def">Data series formatting:</span> Open the context menu and choose <span class="ui">Format data series</span>.</p>
+  </div>
+  <div class="sub-section"><p><span class="def">Chart editing:</span> Double click the chart to select. Use context menus to add chart elements such as title, axis, and other. Choose <span class="ui">Data Range</span> and <span class="ui">Chart Type</span> to edit chart data and select chart type.</p></div>
+  <div class="sub-section"><p><span class="def">Chart formatting:</span> The same context menu brings you to chart data table and chart type selection.</p></div>
+  <div class="sub-section"><p><span class="def">Data series formatting:</span> Open the context menu and choose <span class="ui">Format data series</span>.</p></div>
+  <div class="sub-section">
     <h4>Handling images</h4>
     <p><span class="productname">%productName</span> inserts images in the text document from your local computer or from your cloud storage. Inserted images are always embedded in the document.</p>
     <p><span class="def">Insert image:</span> Clicking on the <span class="ui">Insert image</span> icon allows you to choose an image from the cloud storage's folders and shares.</p>
     <p><span class="def">Insert local image:</span> opens the browser file picker to upload the image from your local computer and insert it into the document.</p>
     <p>Images can be resized, rotated and anchored. Text can be wrapped around the image. Select the image and open the context menu. Use the images handles to resize the image with the mouse.</p>
+  </div>
+  <div class="sub-section">
     <h4>Comments in documents</h4>
     <p>Insert comments in <span class="productname">%productName</span> in places that need special reader attention. Comments are displayed on the right and carry the name and date of the issuer.</p>
-    <div class="screenshot"><img alt="" src="images/help/en/comment.png"/></div>
+    <div class="screenshot"><img alt="comment" src="images/help/en/comment.png"/></div>
     <p>Click on the submenu (<span class="cool-annotation-menu" style="height:0.6cm;width:0.6cm;" ></span>) icon to reply, move and delete comments.</p>
+  </div>
+  <div class="sub-section">
     <h4>Spellchecking</h4>
     <p><span class="productname">%productName</span> can check spelling in text documents, spreadsheets and presentations. A red wavy underline indicates misspelled words. Click on the right mouse button to open a context menu with suggested misspelling corrections.</p>
-    <div class="screenshot"><img alt="" src="images/help/en/red-wavy-underline.png"/></div>
+    <div class="screenshot"><img alt="spellchecking" src="images/help/en/red-wavy-underline.png"/></div>
     <p>To systematically spell-check the whole document use the <span class="ui">Tools</span> menu’s <span class="ui">Spelling</span> option.</p>
+  </div>
+</div>
 <div class="spreadsheet" style="display: none;">
     <a id="1359"/>
-    <h2><span class="productname">%productName</span> spreadsheets</h2>
+    <h2 class="product-header"><span class="productname">%productName</span> spreadsheets</h2>
     <a id="1361"/>
-    <h3>Editing spreadsheets</h3>
-    <p>You edit an online spreadsheet in the same way you edit a desktop spreadsheet. Operations like entering data, selecting ranges, columns, rows or sheets are the same. Use the keyboard, menus or toolbar to command actions in the spreadsheet. Dragging cells contents to fill cells with data is also supported. Copy, cut and paste commands are available from the context menu. Following entered data with a <kbd>Tab</kbd> will move the cursor to the next cell to the right, and with an <kbd>Enter</kbd> to the cell below for easy further data entry.</p>
+    <div class="section">
+    <h3 class="section-header">Editing spreadsheets</h3>
+    <div class="sub-section"><p>You edit an online spreadsheet in the same way you edit a desktop spreadsheet. Operations like entering data, selecting ranges, columns, rows or sheets are the same. Use the keyboard, menus or toolbar to command actions in the spreadsheet. Dragging cells contents to fill cells with data is also supported. Copy, cut and paste commands are available from the context menu. Following entered data with a <kbd>Tab</kbd> will move the cursor to the next cell to the right, and with an <kbd>Enter</kbd> to the cell below for easy further data entry.</p></div>
+    </div>
     <a id="1363"/>
-    <h3>Formulas</h3>
+    <div class="section">
+    <h3 class="section-header">Formulas</h3>
+    <div class="sub-section">
     <p>Formulas are entered in the formula bar. Enter '=' and insert the formula.</p>
     <p>All spreadsheets functions and mathematical rules applies.</p>
-    <div class="screenshot"><img alt="" src="images/help/en/formula-bar.png"/></div>
+    <div class="screenshot"><img alt="Formulas" src="images/help/en/formula-bar.png"/></div>
     <p>The formula language should be extremely familiar to any spreadsheet user, and is specified in great detail in the <a href="https://www.oasis-open.org/committees/download.php/16826/openformula-spec-20060221.html" target="_blank" rel="noopener noreferrer">OASIS OpenFormula specification</a>.</p>
+    </div>
+    </div>
     <a id="1367"/>
-    <h3>Formatting spreadsheets</h3>
+    <div class="section">
+    <h3 class="section-header">Formatting spreadsheets</h3>
+    <div class="sub-section">
     <p><span class="def">Direct formatting:</span> You can format spreadsheets cells, columns, rows and sheets by formatting directly from the menus, toolbar or context menus. Direct formatting applies only to the current object selected. To format a cell either use the menu or hit <kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>1</kbd>. The dialog allows complex and custom number formatting, as well as font, complex border, background, cell protection and other options.</p>
     <div class="screenshot"><img alt="" src="images/help/en/format-cells.png"/></div>
+    </div>
+    </div>
     <a id="1371"/>
-    <h3>Advanced features</h3>
-    <p><span class="def">Sorting data:</span> You can sort a list of numbers or text ascending or descending. <span class="productname">%productName</span> automatically detects cells that are headers, and adjoining columns, to extend the selection.</p>
-    <p><span class="def">Filtering data:</span> Filters and advanced filters allow you to work on certain filtered rows (records) of a data range. In the spreadsheets in <span class="productname">%productName</span> there are various possibilities for applying filters.</p>
+    <div class="section">
+    <h3 class="section-header">Advanced features</h3>
+    <div class="sub-section"><p><span class="def">Sorting data:</span> You can sort a list of numbers or text ascending or descending. <span class="productname">%productName</span> automatically detects cells that are headers, and adjoining columns, to extend the selection.</p></div>
+    <div class="sub-section"><p><span class="def">Filtering data:</span> Filters and advanced filters allow you to work on certain filtered rows (records) of a data range. In the spreadsheets in <span class="productname">%productName</span> there are various possibilities for applying filters.</p>
     <ol>
       <li>
          <p>One use for the <span class="ui">AutoFilter</span> function is to quickly restrict the display to records with identical entries in a data field.</p>
-         <div class="screenshot"><img alt="" src="images/help/en/autofilter.png"/></div>
-      </li>
+         <div class="screenshot"><img alt="filter" src="images/help/en/autofilter.png"/></div>
+        </li>
       <li><p>In the <span class="ui">Standard Filter</span> dialog, you can also define ranges which contain the values in particular data fields. You can use the standard filter to connect the conditions with either a logical AND or a logical OR operator.</p></li>
       <li><p>The <span class="ui">Advanced Filter</span> allows up to a total of eight filter conditions. With advanced filters you enter the conditions directly into the sheet.</p></li>
     </ol>
+    </div>
+    <div class="sub-section">
     <p><span class="def">Outlining:</span> You can create an outline of your data and group rows and columns together so that you can collapse and expand the groups with a single click making it easy to represent hierarchical data.</p>
     <div class="screenshot"><img alt="" src="images/help/en/outlining.png"/></div>
+    </div>
+    <div class="sub-section">
     <p><span class="def">Data validation:</span> For each cell, you can define entries to be valid. Invalid entries to a cell will be rejected. To enable data validation:</p>
     <ol>
       <li>
         <p>Choose <span class="ui">Validity</span> from the <span class="ui">Data</span> menu. The <span class="ui">Validity</span> dialog opens.</p>
-        <div class="screenshot"><img alt="" src="images/help/en/data-validation.png"/></div>
       </li>
+      <div class="screenshot"><img alt="data validate" src="images/help/en/data-validation.png"/></div>
       <li><p>Select the validity criterion in the <span class="ui">Allow</span> drop-box list. Depending on the criterion, more options shows. Fill the required data.</p></li>
       <li>
         <p>Use the <span class="ui">Input Help</span> and <span class="ui">Error Alert</span> tabs to enhance the user interactions. Click <span class="ui">OK</span> to close the dialog.</p>
-        <div class="screenshot"><img alt="" src="images/help/en/selection-list.png"/></div>
       </li>
+      <div class="screenshot"><img alt="data validate" src="images/help/en/selection-list.png"/></div>
       <li><p>To remove the validity of the cell, open the dialog and set the <span class="ui">Allow</span> list to “All values”.</p></li>
     </ol>
+    </div>
+    <div class="sub-section">
     <p><span class="def">Comments:</span> In a spreadsheet you can insert one comment per cell. When you select <span class="ui">Insert comment</span>, a popup appears that allows you to write the content for the comment. A red dot shows on the top right corner of the cell when it has a comment. Hover the mouse on the cell to display comments.</p>
     <div class="screenshot"><img alt="" src="images/help/en/cell-comment.png"/></div>
+    </div>
+    <div class="sub-section">
     <p><span class="def">Conditional formatting:</span> <span class="productname">%productName</span> adds symbols to each cell of a range based on cells conditions. Select the cell range and click the <span class="ui">Conditional Formatting</span> icon on the toolbar. Select the symbol set to apply on the range.</p>
     <div class="screenshot"><img alt="" src="images/help/en/conditional-formatting.png"/></div>
+    </div>
+    </div>
 </div>
 <div class="text" style="display: none;">
     <a id="1373"/>
-    <h2><span class="productname">%productName</span> text documents</h2>
+    <h2 class="product-header"><span class="productname">%productName</span> text documents</h2>
     <a id="1375"/>
-    <h3>Editing text documents</h3>
-    <p><span class="productname">%productName</span> edits text documents in the same way you edit a desktop document. It provides a What You See Is What You Get (WYSIWYG) layout – that conveniently lays out the document as it will be printed. Operations like typing text, cut, copy and pasting contents, selecting text, inserting, resizing, anchoring images, adding and handling tables and charts, are similar to a desktop word processor. Use the keyboard, menus and toolbars to interact with your document.</p>
+    <div class="section">
+    <h3 class="section-header">Editing text documents</h3>
+    <div class="sub-section"><p><span class="productname">%productName</span> edits text documents in the same way you edit a desktop document. It provides a What You See Is What You Get (WYSIWYG) layout – that conveniently lays out the document as it will be printed. Operations like typing text, cut, copy and pasting contents, selecting text, inserting, resizing, anchoring images, adding and handling tables and charts, are similar to a desktop word processor. Use the keyboard, menus and toolbars to interact with your document.</p></div>
     <a id="1377"/>
-    <h3>Context menus</h3>
-    <p>Context menus are available on clicking the right mouse button. The commands available in the context menu are related - not extensively - to the underlying object in the document.</p>
+    </div>
+    <div class="section">
+    <h3 class="section-header">Context menus</h3>
+    <div class="sub-section"><p>Context menus are available on clicking the right mouse button. The commands available in the context menu are related - not extensively - to the underlying object in the document.</p></div>
+    </div>
     <a id="1381"/>
-    <h3>Formatting text</h3>
+    <div class="section">
+    <h3 class="section-header">Formatting text</h3>
+    <div class="sub-section">
     <p><span class="productname">%productName</span> supports modern techniques for paragraph formatting through styles. A style is a set of text properties (font, color, background and many more) labeled with a name, the style name. Use  style to apply the same set of properties to many paragraphs in the document and produce a uniform, professional look. Also, if you change one of the style formatting properties, all paragraphs with the same style changes formatting as well, simplifying the effort of formatting many paragraph individually.</p>
     <p>In contrast, direct formatting applies formatting to selected excerpts of the document contents. On a long document, direct formatting must be applied in every text excerpt, turning text formatting a long task, subject to errors and delays.</p>
-    <p><span class="def">Direct formatting:</span> You can format text document objects by formatting directly from the menus, toolbar or context menus. Direct formatting applies only to the current object selected.</p>
+    </div>
+    <div class="sub-section"><p><span class="def">Direct formatting:</span> You can format text document objects by formatting directly from the menus, toolbar or context menus. Direct formatting applies only to the current object selected.</p></div>
+    <div class="sub-section">
     <p><span class="def">Style formatting:</span> <span class="productname">%productName</span> supports paragraph styles. You can apply an existing paragraph style to a paragraph. Choose menu <span class="ui">Edit</span> → <span class="ui">Edit styles</span> to change style.</p>
     <div class="screenshot"><img alt="" src="images/help/en/paragraph-dialog.png"/></div>
+    </div>
+    </div>
     <a id="1383"/>
-    <h3>Advanced text document editor features</h3>
+    <div class="section">
+    <h3 class="section-header">Advanced text document editor features</h3>
+    <div class="sub-section">
     <h4>Handling Tables</h4>
     <p>Insert tables with proper icon in the toolbar. Select the initial number of rows and columns. Add rows and columns with the cell context menu. Merge cells with the <span class="ui">Table</span> menu. The default paragraph style inside cells is “Table contents”.</p>
     <div class="screenshot"><img alt="" src="images/help/en/insert-table.png"/></div>
+    </div>
+    <div class="sub-section">
     <p><span class="def">Formatting cells:</span> Click in the cell or range of cells and choose menu <span class="ui">Table</span> → <span class="ui">Properties</span>. Fine tune the table with the properties dialog.</p>
+    </div>
+    <div class="sub-section">
     <h4>Track changes</h4>
     <p>When you turn on Track Changes, <span class="productname">%productName</span> marks up new changes made to the document. Select this option again to turn it off.</p>
-    <div class="screenshot"><img alt="" src="images/help/en/track-changes-comment.png"/></div>
+    <div class="screenshot"><img alt="track changes" src="images/help/en/track-changes-comment.png"/></div>
     <p>Changes made by different people are shown in different colors and each tracked change can be accepted or rejected, using the box the appears on the right. You can also add a comment there.</p>
+    </div>
+    <div class="sub-section">
     <h4>Other advanced features</h4>
     <p><span class="def">Comments:</span> Comments are inserted in the text and displayed on the right side of the screen.</p>
     <p><span class="def">Formatting marks:</span> Paragraph, page and unbreakable spaces are shown as marks to assisting text alignment, editing and formatting.</p>
@@ -501,32 +664,50 @@
     <p><span class="def">Alphabetical index:</span> Existing alphabetical index can be updated with new entries.</p>
     <p><span class="def">Page header and footer:</span> Headers and footers are available for the existing page style applied in the document at the cursor position.</p>
     <p><span class="def">Footnotes and endnotes:</span> Footnotes and endnotes are supported.</p>
+    </div>
+    </div>
 </div>
 <div class="presentation" style="display: none;">
     <a id="1391"/>
-    <h2><span class="productname">%productName</span> presentations</h2>
+    <h2 class="product-header"><span class="productname">%productName</span> presentations</h2>
     <a id="1393"/>
-    <h3>Editing presentations</h3>
-    <p><span class="productname">%productName</span> Impress edits presentations in a way that should be familiar to people. Operations like typing text, cut, copy and pasting contents, selecting text , inserting, resizing, anchoring images, adding and handling tables, are similar to a desktop presentation application. Use the keyboard, menus and toolbars to perform actions in your document.</p>
+    <div class="section">
+    <h3 class="section-header">Editing presentations</h3>
+    <div class="sub-section"><p><span class="productname">%productName</span> Impress edits presentations in a way that should be familiar to people. Operations like typing text, cut, copy and pasting contents, selecting text , inserting, resizing, anchoring images, adding and handling tables, are similar to a desktop presentation application. Use the keyboard, menus and toolbars to perform actions in your document.</p></div>
+    </div>
     <a id="1395"/>
-    <h3>Slide show</h3>
+    <div class="section">
+    <h3 class="section-header">Slide show</h3>
+    <div class="sub-section">
     <p><span class="productname">%productName</span> displays presentation slide shows, including a subset of slide transitions and object animations. Choose the slide show from the menu or click on icon in the bottom left toolbar in the slide pane.</p>
     <p>To exit a <span class="productname">%productName</span> slide show, press the <kbd>Esc</kbd> key to return to the presentation edit mode.</p>
+    </div>
+    </div>
     <a id="1397"/>
-    <h3>Slide pane</h3>
+    <div class="section">
+    <h3 class="section-header">Slide pane</h3>
+    <div class="sub-section">
     <p>Click on any slide thumbnail in the pane to switch to this slide to view or edit it.</p>
     <p>Use the slide pane toolbar in the bottom to start the slideshow, add slide, duplicate or delete the current slide.</p>
+    </div>
+    </div>
     <a id="1401"/>
-    <h3>Advanced features</h3>
+    <div class="section">
+    <h3 class="section-header">Advanced features</h3>
+    <div class="sub-section">
     <p><span class="def">Slide layouts:</span> <span class="productname">%productName</span> Impress let you change the slide layout. Select the desired slide layout in the drop-down layout list.</p>
     <div class="screenshot"><img alt="" src="images/help/en/slide-layouts.png"/></div>
-    <p><span class="def">Master slide:</span> Select the master slide associated to the current slide. Format and arrange slide elements in the master slide.</p>
-    <p><span class="def">Slide transitions:</span> <span class="productname">%productName</span> Impress provides visual effects when displaying a new slide in the slide show. Slide transitions are property of the slide, use the side bar to set the slide transition when in edit mode.</p>
-    <p><span class="def">Object animation:</span> Individual object in the slide can have animation. Use the side bar to configure the slide transition for a selected object or set of objects.</p>
-    <p><span class="def">Tables:</span> Insert tables in the presentation. Use the sidebar to select the table theme.</p>
+    </div>
+    <div class="sub-section"><p><span class="def">Master slide:</span> Select the master slide associated to the current slide. Format and arrange slide elements in the master slide.</p></div>
+    <div class="sub-section"><p><span class="def">Slide transitions:</span> <span class="productname">%productName</span> Impress provides visual effects when displaying a new slide in the slide show. Slide transitions are property of the slide, use the side bar to set the slide transition when in edit mode.</p></div>
+    <div class="sub-section"><p><span class="def">Object animation:</span> Individual object in the slide can have animation. Use the side bar to configure the slide transition for a selected object or set of objects.</p></div>
+    <div class="sub-section"><p><span class="def">Tables:</span> Insert tables in the presentation. Use the sidebar to select the table theme.</p></div>
+    </div>
 </div>
     <a id="1403"/>
-    <h2>Frequently Asked Questions</h2>
+    <div class="section">
+    <h2 class="section-header">Frequently Asked Questions</h2>
+    <div class="sub-section">
     <h4>What are the documents file formats supported by <span class="productname">%productName</span>?</h4>
     <p><span class="productname">%productName</span> supports both reading and writing for the following file formats:</p>
     <ul>
@@ -534,45 +715,69 @@
       <li><p>Spreadsheets: Microsoft formats XLS, XLSX, OpenDocument Format ODS</p></li>
       <li><p>Presentations: Microsoft formats PPT, PPTX, OpenDocument Format ODP</p></li>
     </ul>
+  </div>
+  <div class="sub-section">
     <h4>How do I save a document with another name?</h4>
     <ol>
       <li><p>Hover the mouse on the document name in the menu bar.</p></li>
       <li><p>Type the new file name in the text box and press <kbd>Enter</kbd>.</p></li>
     </ol>
     <p>A copy of the document is saved with the new name in the same folder.</p>
+  </div>
+  <div class="sub-section">
     <h4>How can I quit <span class="productname">%productName</span> without saving my edits?</h4>
     <p><span class="productname">%productName</span> saves the document in the background regularly, you can't just close without saving it. To abandon your changes, you must either undo them, or use the <span class="ui">Revision History </span> in the <span class="ui">File</span> menu.</p>
+  </div>
+  <div class="sub-section">
     <h4>Can <span class="productname">%productName</span> open a password-protected document?</h4>
     <p>Yes. <span class="productname">%productName</span> opens password-protected documents, but it is necessary to supply the password in the “Enter password” prompt at load time.</p>
+  </div>
+  <div class="sub-section">
     <h4>How can I check spelling in my language?</h4>
     <p>Choose menu <span class="ui">Tools</span> → <span class="ui">Languages</span> and select the language for the whole document. Optionally you can set languages for the selected text and for the current paragraph.</p>
+  </div>
+  <div class="sub-section">        
     <h4>How can I remove the red wavy lines in my document?</h4>
     <p>Choose menu <span class="ui">Tools</span> and uncheck <span class="ui">Automatic Spell Checking</span>.</p>
+  </div>
+  <div class="sub-section">
     <h4>What is the blue wavy underline in some words in the text?</h4>
     <p>Grammar errors in the text is marked with the blue wavy underline. Click on the underlined text with the right mouse button to open a menu with suggestions to correct the grammar error and the offended grammar rules. Select the right suggestion to change the text.</p>
+  </div>
+  <div class="sub-section">
     <h4>Is there a thesaurus?</h4>
     <p>Yes. Click in the word you want and choose <span class="ui">Tools</span> → <span class="ui">Thesaurus</span>. A dialog opens with many suggestions for replacements.</p>
     <div class="screenshot"><img alt="" src="images/help/en/thesaurus.png"/></div>
+  </div>
+  <div class="sub-section">
     <h4>What are the blue <span class="blue">¶</span> symbol and how can I remove from my text document?</h4>
     <p>The <span class="blue">¶</span> symbol is a formatting mark. It is used to help text alignment and editing and is not printed. To toggle it in the document display, choose menu <span class="ui">View</span> → <span class="ui">Formatting mark</span>.</p>
+      </div>
+    </div>
 <div class="text" style="display: none;">
     <a id="1407"/>
-    <h3>Text documents</h3>
+    <div class="section">
+    <h3 class="section-header">Text documents</h3>
+    <div class="sub-section">
     <h4>How do I get a word count of my document?</h4>
     <p>Word count is available in <span class="ui">Tools</span> → <span class="ui">Word count</span>. A dialog shows word counts for selection and for the whole document.</p>
-    <div class="screenshot"><img alt="" src="images/help/en/word-count.png"/></div>
+    <div class="screenshot"><img alt="word count" src="images/help/en/word-count.png"/></div>
     <p>Word count is also displayed in the status bar. If no text is selected the word count is for the whole document. Otherwise the word count is for the selected text.</p>
+    </div>
+    <div class="sub-section">
     <h4>How can I insert a currency, copyright or trademark symbol in the document?</h4>
     <p>You can insert these special characters in the document using the <span class="ui">Special Character</span> dialog.</p>
     <ol>
       <li><p>Place the cursor in the position to insert the character.</p></li>
       <li>
         <p>Choose <span class="ui">Insert</span> → <span class="ui">Special Characters </span> or click the corresponding icon in the toolbar. A dialog shows.</p>
-        <div class="screenshot"><img alt="" src="images/help/en/special-character.png"/></div>
       </li>
+      <div class="screenshot"><img alt="Special Characters" src="images/help/en/special-character.png"/></div>
       <li><p>You can either browse the characters displayed with the drop lists or type a search key in the <span class="ui">Search</span> box. If you know the Unicode numeric code of the special character, enter in the boxes on the right.</p></li>
       <li><p>Press <span class="ui">Insert</span> button. To close the dialog, press <span class="ui">Cancel</span>.</p></li>
     </ol>
+    </div>
+    <div class="sub-section">
     <h4>Why can't I delete text? It just gets a strike-through?</h4>
     <p>You have the Track Changes feature enabled for the document. Track Changes records all changes in the text and shows the editions for later revision. Useful for marking changes in text and spreadsheets. Track changes are enabled choosing <span class="ui">Edit</span> → <span class="ui">Track Changes </span> → <span class="ui">Record</span>.</p>
     <p>With track changes enabled your document is shown the following manner:</p>
@@ -582,11 +787,13 @@
       <li><p>All changes are marked with a vertical bar in the right margin.</p></li>
       <li><p>Changes are displayed as comment in the right of the document area.</p></li>
     </ul>
-    <div class="screenshot"><img alt="" src="images/help/en/track-changes-comment.png"/></div>
+    <div class="screenshot"><img alt="track changes" src="images/help/en/track-changes-comment.png"/></div>
     <p>The color assigned to the changes depends on the user that changes the document.</p>
     <p>To display or hide track changes choose <span class="ui">Edit</span> → <span class="ui">Track Changes </span> → <span class="ui">Show</span>. Beware that if track changes are enabled but hidden, you still record changes and may inadvertently leave unwanted text available in the document.</p>
     <p>Changes can be accepted or rejected. To accept or reject changes, click on the corresponding icons in the comment box on the right of the document. Alternatively, choose <span class="ui">Edit</span> → <span class="ui">Track Changes </span> → <span class="ui">Accept</span> or <span class="ui">Reject</span>. Furthermore, if you need to filter changes before accepting or rejecting, choose <span class="ui">Edit</span> → <span class="ui">Track Changes </span> → <span class="ui">Manage</span>. A dialog shows a list of all tracked changes. Use the dialog buttons accordingly.</p>
     <div class="screenshot"><img alt="" src="images/help/en/manage-changes.png"/></div>
+    </div>
+    <div class="sub-section">
     <h4>How do I set the margins of the document?</h4>
     <p>Using the ruler drag the leftmost edge of the ruler to adjust the left margin, or the rightmost for the right margin.</p>
     <p>Using the page style</p>
@@ -595,6 +802,8 @@
       <li><p>Set the page margins in the dialog.</p></li>
     </ol>
     <div class="screenshot"><img alt="" src="images/help/en/page-style.png"/></div>
+    </div>
+    <div class="sub-section">
     <h4>How do I change the page orientation to landscape inside my document</h4>
     <ol>
       <li><p>Place the cursor at the place where the page orientation is to change. Add an empty paragraph.</p></li>
@@ -604,6 +813,8 @@
       <li><p>Select if you want to change page numbering.</p></li>
     </ol>
     <p>To return to portrait orientation, repeat the procedure, choosing Portrait in “With page style”.</p>
+    </div>
+    <div class="sub-section">
     <h4>How can I make the new text look like other existing text?</h4>
     <p>Directly:</p>
     <ol>
@@ -611,30 +822,42 @@
       <li><p>Click on the clone formatting icon <img style="height:0.6cm;width:0.6cm;" alt="" src="images/lc_formatpaintbrush.svg">. The mouse pointer turns to a paint bucket.</p></li>
       <li><p>Select the text you want to apply the new format.</p></li>
     </ol>
+    </div>
+    <div class="sub-section">
     <p>Applying a paragraph style:</p>
     <ol>
       <li><p>Place the cursor at the paragraph to be formatted</p></li>
       <li><p>Select the style to apply in the style dropdown list. The paragraph displays the styles attributes.</p></li>
     </ol>
+    </div>
+    <div class="sub-section">
     <h4>Why did the text I just typed change automatically? How can I revert it?</h4>
     <p>You have the AutoCorrection enabled. AutoCorrection changes the text just typed into an internal table of corresponding text. In most cases, AutoCorrection fixes typos while you are typing. If AutoCorrection is not necessary, disable it in <span class="ui">Tools</span> → <span class="ui">AutoCorrection</span> → <span class="ui">While typing</span>.</p>
+    </div>
+    </div>
 </div>
 <div class="spreadsheet" style="display: none;">
     <a id="1409"/>
-    <h3>Spreadsheets</h3>
+    <div class="section">
+    <h3 class="section-header">Spreadsheets</h3>
+    <div class="sub-section">
     <h4>How can I select data to print?</h4>
     <p>Insert column and row breaks in the spreadsheet to narrow the print range and print the document to download. On printing the PDF, select the pages of interest.</p>
+    </div>
+    <div class="sub-section">
     <h4>How can I import CSV data?</h4>
     <ol>
       <li><p>Load your CSV data in some native tool to your platform, select and copy it to the clipboard</p></li>
       <li><p>Activate the <span class="productname">%productName</span> spreadsheet window.</p></li>
       <li>
         <p>Paste from the browser <span class="ui">Edit</span> → <span class="ui">Paste</span> or press <kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>V</kbd>. The <span class="ui">Text Import</span> dialog opens to let you describe the precise format of the CSV data.</p>
-        <div class="screenshot"><img alt="" src="images/help/en/text-import.png"/></div>
       </li>
+      <div class="screenshot"><img alt="import" src="images/help/en/text-import.png"/></div>
       <li><p>Select the character set, language and separator options for the CSV file.</p></li>
     </ol>
     <p>The CSV data is loaded into the selected cell where you pasted, according to these settings.</p>
+    </div>
+    <div class="sub-section">
     <h4>How can I copy the formatting of existing cells to new ones?</h4>
     <p>This is easy to do using the Paintbrush tool in the toolbar.</p>
     <ol>
@@ -642,27 +865,39 @@
       <li><p>Click on the clone formatting icon <img style="height:0.6cm;width:0.6cm;" alt="" src="images/lc_formatpaintbrush.svg">. The mouse pointer turns to a paint bucket.</p></li>
       <li><p>Select the cells you want to format. Release the mouse button.</p></li>
     </ol>
+    </div>
+    <div class="sub-section">
     <h4>What is “Clear Direct Formatting” icon?</h4>
     <p>Direct formatting is formatting applied directly to the selected contents of a paragraph or a spreadsheet cell, and overlaps its assigned style formatting. To restore the formatting to the style settings, select the text or spreadsheet cell and choose <span class="ui">Format</span> → <span class="ui">Clear Direct Formatting</span> or use the button in the toolbar.</p>
+    </div>
+    <div class="sub-section">
     <h4>How do I rename a sheet?</h4>
     <p>Rename a sheet in the spreadsheet document using the context menu (using the right mouse button) over the sheet tab in the bottom. Enter the new sheet name in the dialog that follows.</p>
+    </div>
+    </div>
 </div>
 <div class="presentation" style="display: none;">
     <a id="1411"/>
-    <h3>Presentations</h3>
+    <div class="section">
+    <h3 class="section-header">Presentations</h3>
+    <div class="sub-section">
     <h4>How can I run my slide show?</h4>
     <ol>
       <li><p>Open the presentation in <span class="productname">%productName</span></p></li>
       <li><p>Either choose <span class="ui">Slide Show</span> → <span class="ui">Full Screen Presentation</span> or click on the left-most icon in the bottom of the slide panel: <img style="height:0.6cm;width:0.6cm;" alt="" src="images/lc_dia.svg"></p></li>
     </ol>
+    </div>
+    <div class="sub-section">
     <h4>How can I change the line, area and position of a shape in my slides?</h4>
     <ol>
       <li><p>Select the shape in your slide. A set of handles shows.</p></li>
       <li>
         <p>Choose <span class="ui">Format</span> → <span class="ui">Line</span> (or <span class="ui">Area</span>, or <span class="ui">Position and Size</span>). A dialog opens.</p>
-        <div class="screenshot"><img alt="" src="images/help/en/area-dialog.png"/></div>
       </li>
+      <div class="screenshot"><img alt="Position and Size" src="images/help/en/area-dialog.png"/></div>
       <li><p>Set the properties of the element of the object.</p></li>
     </ol>
+    </div>
+    </div>
 </div>
 </div>

--- a/browser/html/cool-help.html
+++ b/browser/html/cool-help.html
@@ -13,7 +13,7 @@
         transition: background-color 0.3s ease; /* Smooth transition effect */
         font-family: Arial, sans-serif; /* Use a common font family */
         font-size: 16px; /* Font size */
-        color: #333; /* Dark text color */
+        color: var(--color-main-text);
     }
 
     /* Hover effect for toc-h2 and toc-h3 button */

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -551,11 +551,14 @@ L.Map.include({
 		}
 		var searchInput = document.getElementById('online-help-search-input');
 		searchInput.focus(); // auto focus on user input field
+		var helpContentParent = document.getElementsByClassName('ui-dialog-content')[0];
+		searchInput.focus();
 		var startFilter = false;
 		var isAnyMatchingContent = false;
 		searchInput.addEventListener('input', function () {
 			// Hide all elements within the #online-help-content on first key stroke/at start of filter content
 			if (!startFilter || !isAnyMatchingContent) {
+				helpContentParent.setAttribute('style', 'background-color: var(--color-background-dark) !important');
 				// Hide all <p> tags within .text, .spreadsheet, or .presentation sections
 				document.querySelectorAll('#online-help-content > *:not(a), .link-section p, .product-header').forEach(function (element) {
 					// Check if the element has class text, spreadsheet, or presentation
@@ -602,10 +605,14 @@ L.Map.include({
 			if (containsTermInHeader) {
 				// first need to reset display of subsection
 				subSections.forEach(function(subSection) {
-					subSection.style.backgroundColor = '';
+					mainSection.style.backgroundColor = '';
+					mainSection.style.paddingInline = '';
+					mainSection.style.borderRadius = '';
 					subSection.style.display = 'block';
 				});
-				mainSection.style.backgroundColor = 'yellow';
+				mainSection.style.backgroundColor = 'var(--color-background-lighter)';
+				mainSection.style.paddingInline = '12px';
+				mainSection.style.borderRadius = 'var(--border-radius-large)';
 				mainSection.style.display = 'block';
 			}
 			else {
@@ -613,14 +620,16 @@ L.Map.include({
 				subSections.forEach(function (subSection) {
 					// Highlight matching sub-sections
 					if (subSection.textContent.toLowerCase().includes(searchTerm.toLowerCase())) {
-						subSection.style.backgroundColor = 'yellow';
+						subSection.style.color = 'var(--color-text-darker)';
 						subSection.style.display = 'block';
+						mainSection.style.backgroundColor = 'var(--color-background-lighter)';
+						mainSection.style.paddingInline = '12px';
+						mainSection.style.borderRadius = 'var(--border-radius-large)';
 						// make sure main section of matched subsection is visible
 						mainSection.style.display = 'block';
-						mainSection.style.backgroundColor = '';
 						subSectionContainsTerm = true;
 					} else {
-						subSection.style.backgroundColor = ''; // Remove previous highlighting
+						subSection.style.color = ''; // Remove previous highlighting
 						subSection.style.display = 'none';
 					}
 				});
@@ -645,6 +654,8 @@ L.Map.include({
 	},
 
 	resetFilterResults: function () {
+		var helpContentParent = document.getElementsByClassName('ui-dialog-content')[0];
+		helpContentParent.style.backgroundColor='';
 		// Select main sections and make it visible
 		var mainSections = document.querySelectorAll('.section');
 		mainSections.forEach(function(mainSection) {
@@ -653,7 +664,6 @@ L.Map.include({
 
 			var subSections = mainSection.querySelectorAll('.sub-section');
 			subSections.forEach(function(subSection) {
-				subSection.style.backgroundColor = '';
 				subSection.style.display = 'block';
 			});
 		});

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -550,11 +550,12 @@ L.Map.include({
 			document.getElementById('keyboard-shortcuts-content').innerHTML = L.Util.replaceCtrlAltInMac(document.getElementById('keyboard-shortcuts-content').innerHTML);
 		}
 		var searchInput = document.getElementById('online-help-search-input');
-		searchInput.focus();
+		searchInput.focus(); // auto focus on user input field
 		var startFilter = false;
+		var isAnyMatchingContent = false;
 		searchInput.addEventListener('input', function () {
 			// Hide all elements within the #online-help-content on first key stroke/at start of filter content
-			if (!startFilter) {
+			if (!startFilter || !isAnyMatchingContent) {
 				// Hide all <p> tags within .text, .spreadsheet, or .presentation sections
 				document.querySelectorAll('#online-help-content > *:not(a), .link-section p, .product-header').forEach(function (element) {
 					// Check if the element has class text, spreadsheet, or presentation
@@ -572,16 +573,17 @@ L.Map.include({
 				startFilter = false;
 			}
 			else {
-				this.filterResults(searchTerm);
+				this.filterResults(searchTerm, isAnyMatchingContent);
 			}
 		}.bind(this));
 	},
 
 
-	filterResults: function (searchTerm) {
+	filterResults: function (searchTerm, isAnyMatchingContent) {
 
 		// Select main sections
 		var mainSections = document.querySelectorAll('.section');
+		isAnyMatchingContent = false;
 
 		// Loop through each main section
 		mainSections.forEach(function (mainSection) {
@@ -615,6 +617,7 @@ L.Map.include({
 						subSection.style.display = 'block';
 						// make sure main section of matched subsection is visible
 						mainSection.style.display = 'block';
+						mainSection.style.backgroundColor = '';
 						subSectionContainsTerm = true;
 					} else {
 						subSection.style.backgroundColor = ''; // Remove previous highlighting
@@ -626,9 +629,19 @@ L.Map.include({
 			if (!subSectionContainsTerm && !containsTerm) {
 				mainSection.style.display = 'none';
 			}
+			else {
+				isAnyMatchingContent = true;
+			}
 
 		}.bind(this));
 
+		if (!isAnyMatchingContent) {
+			this.resetFilterResults();
+			$('#online-help-search-input').addClass('search-not-found');
+			setTimeout(function () {
+				$('#online-help-search-input').removeClass('search-not-found');
+			}, 800);
+		}
 	},
 
 	resetFilterResults: function () {
@@ -648,6 +661,7 @@ L.Map.include({
 		// select all event scroll elements, main-header elements, product header elements and make visible to user if search term is empty
 		document.querySelectorAll('.m-v-0, .product-header, .help-dialog-header').forEach(function(element) {
 			element.style.display = 'block';
+			element.style.backgroundColor = '';
 		});
 	},
 


### PR DESCRIPTION
Change-Id: I7578c621c28b7a5d18c76f2fff834ad2edd68ca5

- this filter not works same as we do search by `Ctrl + F`. 
- it will help user to find sections by search term, it means it will show highlighted sections which have the search term. 
- Also, other section which does not have these matching values will be hidden.
 
I consider some priorities like Whether to highlight a full section or just a subsection.
- Priority 1: if search term matches main section header, then show that full main section
- Priority 2: if content matches with subsection and not with headers, then show that subsection with main section header.
  - Reason to show header with subsection, so user knows better in which context this paragraph/content is about

Test cases

1. Try to search header tags only: it will height light full section with all subsection in it
   - collaborative editing
   - advanced features 
   - formatting spreadsheets etc...

2. Try with subsection content: it will only highlight the subsection part with header info
   - information bar
   - print
   - margins
   - slide-show (in odp)
   - conditional (in ods)

These are not all the cases but some to get a reference from. 


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

