### PR TITLE
test: fix -Werror,-Winconsistent-missing-override in WhiteBoxTests

### DIFF
--- a/test/WhiteBoxTests.cpp
+++ b/test/WhiteBoxTests.cpp
@@ -657,7 +657,7 @@ public:
         return DocumentPasswordType::ToView;
     }
 
-    void updateActivityHeader() const
+    void updateActivityHeader() const override
     {
     }
 };


### PR DESCRIPTION
WhiteBoxTests.cpp:660:10: error: 'updateActivityHeader' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
    void updateActivityHeader() const
         ^
../kit/ChildSession.hpp:89:18: note: overridden virtual function is here
    virtual void updateActivityHeader() const = 0;
                 ^

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I12f21fd9fbe0ba77d2196bfcd1cbdb5ef07e5d06
