### PR TITLE
Cypress test logging improvements

### DIFF
--- a/cypress_test/integration_tests/common/helper.js
+++ b/cypress_test/integration_tests/common/helper.js
@@ -510,7 +510,6 @@ function reload(fileName, subFolder, noFileCopy, isMultiUser, subsequentLoad, ha
 
 // noRename - whether or not to give the file a unique name, if noFileCopy is false.
 function beforeAll(fileName, subFolder, noFileCopy, isMultiUser, subsequentLoad, hasInteractionBeforeLoad, noRename) {
-	cy.log('Starting test: ' + Cypress.spec.relative + ' / ' + Cypress.currentTest.titlePath.join(' / '));
 	// Set defaults here in order to remove checks from cy.cGet function.
 	cy.cSetActiveFrame('#coolframe');
 	cy.cSetLevel('1');
@@ -520,7 +519,6 @@ function beforeAll(fileName, subFolder, noFileCopy, isMultiUser, subsequentLoad,
 
 function afterAll(fileName, testState) {
 	closeDocument(fileName, testState);
-	cy.log('Finished test: ' + Cypress.spec.relative + ' / ' + Cypress.currentTest.titlePath.join(' / '));
 }
 
 // This method is intended to call after each test case.

--- a/cypress_test/support/index.js
+++ b/cypress_test/support/index.js
@@ -1,11 +1,40 @@
 /* -*- js-indent-level: 8 -*- */
-/* global require cy Cypress */
+/* global require cy Cypress beforeEach afterEach */
 
 require('cypress-wait-until');
 require('cypress-file-upload');
 import installLogsCollector from 'cypress-terminal-report/src/installLogsCollector';
 
-installLogsCollector();
+
+beforeEach(function() {
+	cy.log('Starting test: ' + getFullTestName());
+});
+
+// This afterEach must be before installLogsCollector, otherwise the
+// cypress-terminal-report afterEach gets called first, and so this log does
+// not get printed
+afterEach(function() {
+	cy.log('Finishing test: ' + getFullTestName());
+});
+
+installLogsCollector({
+	// Filter xhr requests from log
+	filterLog: function(log) {
+		var type = log[0];
+		return type !== 'cy:xhr';
+	},
+	// Filter assertion values when assertion passes
+	processLog: function(log) {
+		var type = log[0];
+		var message = log[1];
+		var severity = log[2];
+		if (type == 'cy:command' && message.startsWith('assert') && severity !== 'error') {
+			return [type,message.split('\n')[0],severity];
+		} else {
+			return log;
+		}
+	}
+});
 
 if (Cypress.env('INTEGRATION') === 'php-proxy') {
 	Cypress.Server.defaults({
@@ -34,11 +63,14 @@ if (Cypress.env('INTEGRATION') === 'nextcloud') {
 }
 
 Cypress.on('fail', function(error) {
-	Cypress.log({ name:'fail:',
-		      message: error.codeFrame.absoluteFile + ':'
-		      + error.codeFrame.line + ':'
-		      + error.codeFrame.column + '\n'
-		      + error.codeFrame.frame });
+	var message = '\n';
+	message += 'Test failed: ' + getFullTestName() + '\n';
+	message += '\n';
+	message += error.message + '\n';
+	message += '\n';
+	message += error.codeFrame.absoluteFile + ':' + error.codeFrame.line + ':' + error.codeFrame.column + '\n';
+	message += error.codeFrame.frame;
+	Cypress.log({name: 'fail:', message: message});
 
 	//https://stackoverflow.com/a/63519375/1592055
 	//returning false here prevents Cypress from failing the test */
@@ -171,3 +203,7 @@ Cypress.Commands.add('cGet', function(selector, options) {
 			.find('#coolframe', {log: false})
 			.its('0.contentDocument', {log: false});
 });
+
+function getFullTestName() {
+	return Cypress.spec.relative + ' / ' + Cypress.currentTest.titlePath.join(' / ');
+}


### PR DESCRIPTION
- Print full test name in beforeEach and afterEach
  - Originally added to beforeAll and afterAll in helper.js in https://github.com/CollaboraOnline/online/pull/8120
  - Moving to beforeEach and afterEach in support/index.js
  - No functional change
- Hide xhr requests
  - Before: 
    ![image](https://github.com/CollaboraOnline/online/assets/153108452/7df8a25d-4cdc-4fa1-81f7-b4a150c26efb)
  - After:
    - No logs
- Hide repeated actual and expected values on passed assertions
  - Before: 
![image](https://github.com/CollaboraOnline/online/assets/153108452/f4e2b8a2-bd0b-4a8d-8372-42b6c0dc3ede)
  - After:
![image](https://github.com/CollaboraOnline/online/assets/153108452/8fc6df17-b02b-432d-bb8e-b3f9447cf5bd)
    - Failed assertions still display
![image](https://github.com/CollaboraOnline/online/assets/153108452/bb7b8d26-d3fe-4f8b-8521-366cb3b2f1c4)
- Add test name and error message to failure display
  - Before:
![image](https://github.com/CollaboraOnline/online/assets/153108452/a14e8bb6-c000-413d-90c5-f2b958124755)
  - After:
![image](https://github.com/CollaboraOnline/online/assets/153108452/e16e2b6a-35eb-45f6-b090-30f5758c7861)


Change-Id: Ic1a20481c05afb05b9c29d0bd428b59615d49dc7


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

