### PR TITLE
we never have an empty std::unique_ptr for .second

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1046,10 +1046,8 @@ public:
             for (auto& it : self->_sessions)
             {
                 std::shared_ptr<ChildSession> session = it.second;
-                if (session && !session->isCloseFrame())
-                {
+                if (!session->isCloseFrame())
                     session->loKitCallback(type, payload);
-                }
             }
             return;
         }
@@ -1440,7 +1438,7 @@ private:
     {
         for (const auto& it : _sessions)
         {
-            if (it.second && it.second->getViewId() == viewId)
+            if (it.second->getViewId() == viewId)
                 return it.second;
         }
 
@@ -1990,9 +1988,6 @@ public:
                         bool isFound = false;
                         for (const auto& it : _sessions)
                         {
-                            if (!it.second)
-                                continue;
-
                             ChildSession& session = *it.second;
                             if (broadcast || (!broadcast && (session.getViewId() == viewId)))
                             {


### PR DESCRIPTION
and don't check for it in the other cases, so drop it in these ones


Change-Id: Ie343178869cadc127ee898968fef8f798b6068d5


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

