### PR TITLE
Reenable logging socket messages before debug mode

### DIFF
--- a/browser/src/core/Debug.js
+++ b/browser/src/core/Debug.js
@@ -24,6 +24,7 @@ L.DebugManager = L.Class.extend({
 	initialize: function(map) {
 		this._map = map;
 		this.debugOn = false;
+		this.debugNeverStarted = true;
 	},
 
 	toggle: function() {
@@ -42,6 +43,7 @@ L.DebugManager = L.Class.extend({
 		this._painter = this._map._docLayer._painter;
 
 		this.debugOn = true;
+		this.debugNeverStarted = false;
 
 		this._controls = {};
 		// Add header

--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -176,7 +176,7 @@ app.definitions.Socket = L.Class.extend({
 	},
 
 	_doSend: function(msg) {
-		if (this._map._debug.logOutgoingMessages) {
+		if (this._map._debug.debugNeverStarted || this._map._debug.logOutgoingMessages) {
 			// Only attempt to log text frames, not binary ones.
 			if (typeof msg === 'string')
 				this._logSocket('OUTGOING', msg);
@@ -563,7 +563,7 @@ app.definitions.Socket = L.Class.extend({
 		textMsg = e.textMsg;
 		imgBytes = e.imgBytes;
 
-		if (this._map._debug.logIncomingMessages) {
+		if (this._map._debug.debugNeverStarted || this._map._debug.logIncomingMessages) {
 			this._logSocket('INCOMING', textMsg);
 		}
 


### PR DESCRIPTION
Change-Id: I2452d4c7e3e3152533b676fb2db81ef95d96fb54


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

