### PR TITLE
Make browser/ clean before building

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -468,7 +468,7 @@ define global_file
 		@$(NODE) node_modules/uglify-js/bin/uglifyjs $< --output $@)
 endef
 
-.PHONY: build-cool
+.PHONY: build-cool mostlyclean-local
 
 all-local: build-cool
 
@@ -504,6 +504,7 @@ $(TYPESCRIPT_JS_DIR)/%.js: $(srcdir)/%.ts
 	$(builddir)/node_modules/typescript/bin/tsc --outFile $@ $<
 
 build-cool: \
+	mostlyclean-local \
 	$(COOL_L10N_DST) \
 	$(L10N_JSON) \
 	$(SRC_TS_JS_DST) \
@@ -798,9 +799,12 @@ l10n: pot
 	for i in po/ui-*.po; do pot2po --input=po/templates/cool-ui.pot --template=$$i --output=$$i.new; mv $$i.new $$i;done
 	for i in po/help-*.po; do pot2po --input=po/templates/cool-help.pot --template=$$i --output=$$i.new; mv $$i.new $$i;done
 
-clean-local:
+mostlyclean-local:
+	@rm -f tscompile.done
 	@rm -rf $(DIST_FOLDER)
 	@rm -rf $(INTERMEDIATE_DIR)
+
+clean-local: mostlyclean-local
 	@rm -rf node_modules
 	@rm -f $(abs_srcdir)/jsconfig.json
 	@rm -f $(abs_srcdir)/admin/jsconfig.json


### PR DESCRIPTION
We create our bundle.js from our browser/dist/ directory, but this is not cleaned before building. Normally this is not an issue but occasionally we have a file that stops being there from one build to another (maybe it got deleted or there was a checkout). In this case the file persists in dist/ and still makes it into the new bundle.js. This is horrible in CI, but generally an exciting footgun at all times, and should be promptly removed.


Change-Id: Iadb69c5164cbc99062c14c8ce9de0ea5aa5d5680


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

