### PR TITLE
annotation: refresh comments on accept/reject all tracked changes

### DIFF
--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -116,8 +116,8 @@ L.Control.Menubar = L.Control.extend({
 					{uno: '.uno:ShowTrackedChanges'},
 					{type: 'separator'},
 					{uno: '.uno:AcceptTrackedChanges'},
-					{uno: '.uno:AcceptAllTrackedChanges'},
-					{uno: '.uno:RejectAllTrackedChanges'},
+					{name: _UNO('.uno:AcceptAllTrackedChanges', 'text'), id: 'acceptalltrackedchanges', type: 'action'},
+					{name: _UNO('.uno:RejectAllTrackedChanges', 'text'), id: 'rejectalltrackedchanges', type: 'action'},
 					{uno: '.uno:PreviousTrackedChange'},
 					{uno: '.uno:NextTrackedChange'}
 				]},
@@ -960,8 +960,8 @@ L.Control.Menubar = L.Control.extend({
 				{uno: '.uno:TrackChanges'},
 				{uno: '.uno:ShowTrackedChanges'},
 				{type: 'separator'},
-				{uno: '.uno:AcceptAllTrackedChanges'},
-				{uno: '.uno:RejectAllTrackedChanges'},
+				{name: _UNO('.uno:AcceptAllTrackedChanges', 'text'), id: 'acceptalltrackedchanges', type: 'action'},
+				{name: _UNO('.uno:RejectAllTrackedChanges', 'text'), id: 'rejectalltrackedchanges', type: 'action'},
 				{uno: '.uno:PreviousTrackedChange'},
 				{uno: '.uno:NextTrackedChange'}
 			]},
@@ -1969,6 +1969,11 @@ L.Control.Menubar = L.Control.extend({
 			this._map.hideSlide();
 		} else if (id.indexOf('morelanguages-') != -1) {
 			this._map.fire('morelanguages', { applyto: id.substr('morelanguages-'.length) });
+		} else if (id === 'acceptalltrackedchanges') {
+			this._map.dispatch('acceptalltrackedchanges');
+
+		} else if (id === 'rejectalltrackedchanges') {
+			this._map.dispatch('rejectalltrackedchanges');
 		}
 		// Inform the host if asked
 		if (postmessage)

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -2283,10 +2283,10 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 						'type': 'toolbox',
 						'children': [
 							{
-								'id': 'review-accept-all-tracked-changes',
-								'type': 'toolitem',
+								'id': 'acceptalltrackedchanges',
+								'type': 'customtoolitem',
 								'text': _UNO('.uno:AcceptAllTrackedChanges', 'text'),
-								'command': '.uno:AcceptAllTrackedChanges',
+								'command': 'acceptalltrackedchanges',
 								'accessibility': { focusBack: true, combination: 'A2', de: 'A2' }
 							}
 						]
@@ -2295,10 +2295,10 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 						'type': 'toolbox',
 						'children': [
 							{
-								'id': 'review-reject-all-tracked-changes',
-								'type': 'toolitem',
+								'id': 'rejectalltrackedchanges',
+								'type': 'customtoolitem',
 								'text': _UNO('.uno:RejectAllTrackedChanges', 'text'),
-								'command': '.uno:RejectAllTrackedChanges',
+								'command': 'rejectalltrackedchanges',
 								'accessibility': { focusBack: true, combination: 'J', de: 'J' }
 							}
 						]

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -1161,6 +1161,15 @@ L.Map.include({
 				}
 			}
 			break;
+		case 'acceptalltrackedchanges':
+			this.sendUnoCommand('.uno:AcceptAllTrackedChanges');
+			app.socket.sendMessage('commandvalues command=.uno:ViewAnnotations');
+			break;
+		case 'rejectalltrackedchanges':
+			this.sendUnoCommand('.uno:RejectAllTrackedChanges');
+			var commentSection = app.sectionContainer.getSectionWithName(L.CSections.CommentList.name);
+			commentSection.rejectAllTrackedCommentChanges();
+			break;
 		default:
 			console.error('unknown dispatch: "' + action + '"');
 		}

--- a/browser/src/layer/tile/CommentListSection.ts
+++ b/browser/src/layer/tile/CommentListSection.ts
@@ -1992,6 +1992,16 @@ export class CommentSection extends CanvasSectionObject {
 			comment.onCommentDataUpdate();
 		}
 	}
+
+	public rejectAllTrackedCommentChanges(): void {
+		for (var i = 0; i < this.sectionProperties.commentList.length; i++) {
+			var comment = this.sectionProperties.commentList[i];
+			if (comment.sectionProperties.data.layoutStatus === 3) {
+				comment.sectionProperties.data.layoutStatus = 2;
+				comment.sectionProperties.container.classList.remove('greyed');
+			}
+		}
+	}
 }
 
 }

--- a/browser/src/layer/tile/CommentListSection.ts
+++ b/browser/src/layer/tile/CommentListSection.ts
@@ -1264,7 +1264,7 @@ export class CommentSection extends CanvasSectionObject {
 			id = obj[dataroot].id;
 			var _redlined = this.getComment(id);
 			if (_redlined) {
-				_redlined.sectionProperties.data.layoutStatus = 3;
+				_redlined.sectionProperties.data.layoutStatus = CommentLayoutStatus.DELETED;
 				_redlined.setLayoutClass();
 			}
 		} else if (action === 'Modify') {
@@ -1996,8 +1996,8 @@ export class CommentSection extends CanvasSectionObject {
 	public rejectAllTrackedCommentChanges(): void {
 		for (var i = 0; i < this.sectionProperties.commentList.length; i++) {
 			var comment = this.sectionProperties.commentList[i];
-			if (comment.sectionProperties.data.layoutStatus === 3) {
-				comment.sectionProperties.data.layoutStatus = 2;
+			if (comment.sectionProperties.data.layoutStatus === CommentLayoutStatus.DELETED) {
+				comment.sectionProperties.data.layoutStatus = CommentLayoutStatus.VISIBLE;
 				comment.sectionProperties.container.classList.remove('greyed');
 			}
 		}

--- a/browser/src/layer/tile/CommentSection.ts
+++ b/browser/src/layer/tile/CommentSection.ts
@@ -18,6 +18,20 @@ declare var $: any;
 
 namespace cool {
 
+/*
+	data.layoutStatus: Enumartion sent from the core side.
+	0: INVISIBLE, 1: VISIBLE, 2: INSERTED, 3: DELETED, 4: NONE, 5: HIDDEN
+	Ex: "DELETED" means that the comment is deleted while the "track changes" is on.
+*/
+export enum CommentLayoutStatus {
+	INVISIBLE,
+	VISIBLE,
+	INSERTED,
+	DELETED,
+	NONE,
+	HIDDEN
+}
+
 export class Comment extends CanvasSectionObject {
 
 	valid: boolean = true;
@@ -63,12 +77,6 @@ export class Comment extends CanvasSectionObject {
 		this.sectionProperties.imgSize = options.imgSize ? options.imgSize : [32, 32];
 		this.sectionProperties.margin = options.margin ? options.margin : [40, 40];
 		this.sectionProperties.noMenu = options.noMenu ? options.noMenu : false;
-
-		/*
-			data.layoutStatus: Enumartion sent from the core side.
-			0: INVISIBLE, 1: VISIBLE, 2: INSERTED, 3: DELETED, 4: NONE, 5: HIDDEN
-			Ex: "DELETED" means that the comment is deleted while the "track changes" is on.
-		*/
 
 		if (data.parent === undefined)
 			data.parent = '0';
@@ -732,7 +740,7 @@ export class Comment extends CanvasSectionObject {
 	public setLayoutClass(): void {
 		this.sectionProperties.container.classList.remove('greyed');
 
-		if (this.sectionProperties.data.layoutStatus === 3) {
+		if (this.sectionProperties.data.layoutStatus === CommentLayoutStatus.DELETED) {
 			this.sectionProperties.container.classList.add('greyed');
 		}
 	}


### PR DESCRIPTION
problem:
tracked comments deletion was not reflected with accept/reject all changes


Change-Id: I0964fbd220f450cb144a115e8203250467e7edae

* Target version: master 


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

