### PR TITLE
private/ash/msic test

### DIFF
--- a/test/UnitBadDocLoad.cpp
+++ b/test/UnitBadDocLoad.cpp
@@ -83,7 +83,8 @@ UnitBase::TestResult UnitBadDocLoad::testBadDocLoadFail()
         if (Util::startsWith(response, "error: cmd=notasync"))
         {
             // Continue searching for the interesting failure.
-            response = helpers::getResponseString(socket, "error:", testname);
+            response =
+                helpers::getResponseString(socket, "error:", testname, std::chrono::seconds(30));
         }
         StringVector tokens(StringVector::tokenize(response, ' '));
         LOK_ASSERT_EQUAL(static_cast<size_t>(3), tokens.size());

--- a/test/httpwstest.cpp
+++ b/test/httpwstest.cpp
@@ -110,10 +110,12 @@ void HTTPWSTest::testExoticLang()
 
     try
     {
-        std::shared_ptr<http::WebSocketSession> socket
-            = loadDocAndGetSession(_socketPoll, _uri, documentURL,
-                                   "exoticlocale", true, true,
-                                   " lang=es-419");
+        // es-419 locale takes significantly longer than the default.
+        // 22+ seconds has been observed.
+        const auto timeout = std::chrono::seconds(COMMAND_TIMEOUT_SECS * 6);
+        std::shared_ptr<http::WebSocketSession> socket = loadDocAndGetSession(
+            _socketPoll, _uri, documentURL, "exoticlocale", /*isView=*/true, /*isAssert=*/true,
+            /*loadParams=*/" lang=es-419", timeout);
         socket->asyncShutdown();
     }
     catch (const Poco::Exception& exc)


### PR DESCRIPTION
- wsd: test: empty file-substitution test
- wsd: test: wait longer to load exoticlocale test
- wsd: test: allow more time for repair dialog messages
