### PR TITLE
Debug tool improvements

### DIFF
--- a/browser/src/core/Debug.js
+++ b/browser/src/core/Debug.js
@@ -107,14 +107,14 @@ L.DebugManager = L.Class.extend({
 			startsOn: true,
 			onAdd: function () {
 				self.overlayOn = true;
-				self.overlayData = {};
+				self._overlayData = {};
 			},
 			onRemove: function () {
 				self.overlayOn = false;
-				for (var i in self.overlayData) {
-					self.overlayData[i].remove();
+				for (var i in self._overlayData) {
+					self._overlayData[i].remove();
 				}
-				delete self.overlayData;
+				delete self._overlayData;
 			},
 		});
 
@@ -149,6 +149,8 @@ L.DebugManager = L.Class.extend({
 			},
 			onRemove: function () {
 				self.tileInvalidationsOn = false;
+				self.clearOverlayMessage('tileInvalidationMessages');
+				self.clearOverlayMessage('tileInvalidationTime');
 				clearTimeout(self._tileInvalidationTimeoutId);
 				self._map.removeLayer(self._tileInvalidationLayer);
 				self._painter.update();
@@ -170,7 +172,7 @@ L.DebugManager = L.Class.extend({
 			},
 			onRemove: function () {
 				self.tileDataOn = false;
-				self.setOverlayMessage('tileData','');
+				self.clearOverlayMessage('tileData');
 			},
 		});
 
@@ -240,6 +242,8 @@ L.DebugManager = L.Class.extend({
 			},
 			onRemove: function () {
 				self.pingOn = false;
+				self.clearOverlayMessage('rendercount');
+				self.clearOverlayMessage('ping');
 				clearTimeout(self._pingTimeoutId);
 			},
 		});
@@ -786,20 +790,21 @@ L.DebugManager = L.Class.extend({
 
 	setOverlayMessage: function(id, message) {
 		if (this.overlayOn) {
-			if (!this.overlayData[id]) {
+			if (!this._overlayData[id]) {
 				var topLeftNames = ['tileData'];
 				var position = topLeftNames.includes(id) ? 'topleft' : 'bottomleft';
-				this.overlayData[id] = L.control.attribution({prefix: '', position: position});
-				this.overlayData[id].addTo(this._map);
+				this._overlayData[id] = L.control.attribution({prefix: '', position: position});
+				this._overlayData[id].addTo(this._map);
 			}
-			this.overlayData[id].setPrefix(message);
+			this._overlayData[id].setPrefix(message);
 		}
 	},
 
 	clearOverlayMessage: function(id) {
 		if (this.overlayOn) {
-			if (this.overlayData[id]) {
-				this.overlayData[id].remove();
+			if (this._overlayData[id]) {
+				this._overlayData[id].remove();
+				delete this._overlayData[id];
 			}
 		}
 	},

--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -1077,17 +1077,8 @@ app.definitions.Socket = L.Class.extend({
 					});
 			}
 		}
-		else if (textMsg.startsWith('pong ') && this._map._debug.debugOn) {
-			var times = this._map._debug._debugTimePING;
-			var timeText = this._map._debug.updateTimeArray(times, +new Date() - this._map._debug._debugPINGQueue.shift());
-			if (this._map._debug.overlayOn) {
-				this._map._debug.setOverlayMessage('ping',
-					'Server ping time: ' + timeText + '. ' +
-					'Rendered tiles: ' + command.rendercount + ', ' + 
-					'last: ' + (command.rendercount - this._map._debug._debugRenderCount)
-				);
-			}
-			this._map._debug._debugRenderCount = command.rendercount;
+		else if (textMsg.startsWith('pong ') && this._map._debug.pingOn) {
+			this._map._debug.reportPong(command.rendercount);
 		}
 		else if (textMsg.startsWith('saveas:') || textMsg.startsWith('renamefile:')) {
 			this._renameOrSaveAsCallback(textMsg, command);

--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -195,7 +195,7 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 		var offset = new L.Point(command.width, command.height);
 		var bottomRightTwips = topLeftTwips.add(offset);
 		if (this._debug.tileInvalidationsOn && command.part === this._selectedPart) {
-			this._debug.addInvalidationRectangle(topLeftTwips, bottomRightTwips, textMsg);
+			this._debug.addTileInvalidationRectangle(topLeftTwips, bottomRightTwips, textMsg);
 		}
 
 		var invalidBounds = new L.Bounds(topLeftTwips, bottomRightTwips);
@@ -225,7 +225,7 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 
 		if (needsNewTiles && command.part === this._selectedPart
 			&& command.mode === this._selectedMode && this._debug.tileInvalidationsOn) {
-			this._debug.addInvalidationMessage(textMsg);
+			this._debug.addTileInvalidationMessage(textMsg);
 		}
 
 		this._previewInvalidations.push(invalidBounds);

--- a/browser/src/layer/tile/ImpressTileLayer.js
+++ b/browser/src/layer/tile/ImpressTileLayer.js
@@ -192,7 +192,7 @@ L.ImpressTileLayer = L.CanvasTileLayer.extend({
 		var offset = new L.Point(command.width, command.height);
 		var bottomRightTwips = topLeftTwips.add(offset);
 		if (this._debug.tileInvalidationsOn && command.part === this._selectedPart) {
-			this._debug.addInvalidationRectangle(topLeftTwips, bottomRightTwips, textMsg);
+			this._debug.addTileInvalidationRectangle(topLeftTwips, bottomRightTwips, textMsg);
 		}
 		var invalidBounds = new L.Bounds(topLeftTwips, bottomRightTwips);
 		var visibleTopLeft = this._latLngToTwips(this._map.getBounds().getNorthWest());
@@ -212,7 +212,7 @@ L.ImpressTileLayer = L.CanvasTileLayer.extend({
 		}
 
 		if (needsNewTiles && command.part === this._selectedPart && this._debug.tileInvalidationsOn) {
-			this._debug.addInvalidationMessage(textMsg);
+			this._debug.addTileInvalidationMessage(textMsg);
 		}
 
 		if (command.part === this._selectedPart &&

--- a/browser/src/layer/tile/WriterTileLayer.js
+++ b/browser/src/layer/tile/WriterTileLayer.js
@@ -95,7 +95,7 @@ L.WriterTileLayer = L.CanvasTileLayer.extend({
 		var offset = new L.Point(command.width, command.height);
 		var bottomRightTwips = topLeftTwips.add(offset);
 		if (this._debug.tileInvalidationsOn) {
-			this._debug.addInvalidationRectangle(topLeftTwips, bottomRightTwips, textMsg);
+			this._debug.addTileInvalidationRectangle(topLeftTwips, bottomRightTwips, textMsg);
 		}
 		var invalidBounds = new L.Bounds(topLeftTwips, bottomRightTwips);
 		var visibleTopLeft = this._latLngToTwips(this._map.getBounds().getNorthWest());
@@ -115,7 +115,7 @@ L.WriterTileLayer = L.CanvasTileLayer.extend({
 		}
 
 		if (needsNewTiles && this._debug.tileInvalidationsOn) {
-			this._debug.addInvalidationMessage(textMsg);
+			this._debug.addTileInvalidationMessage(textMsg);
 		}
 
 		this._previewInvalidations.push(invalidBounds);

--- a/browser/src/map/handler/Map.Keyboard.js
+++ b/browser/src/map/handler/Map.Keyboard.js
@@ -658,6 +658,9 @@ L.Map.Keyboard = L.Handler.extend({
 						}
 					}
 				}
+				if (this._map._debug.tileInvalidationsOn) {
+					this._map._debug.addTileInvalidationKeypress();
+				}
 			}
 			else if ((ev.type === 'keypress') && (!this.handleOnKeyDownKeys[keyCode] || charCode !== 0)) {
 				if (keyCode === this.keyCodes.BACKSPACE || keyCode === this.keyCodes.DELETE || keyCode === this.keyCodes.enter)
@@ -673,8 +676,7 @@ L.Map.Keyboard = L.Handler.extend({
 					unoKeyCode = this._toUNOKeyCode(keyCode);
 				}
 				if (this._map._debug.tileInvalidationsOn) {
-					// key press times will be paired with the invalidation messages
-					this._debug._debugKeypressQueue.push(+new Date());
+					this._map._debug.addTileInvalidationKeypress();
 				}
 
 				if (keyEventFn) {


### PR DESCRIPTION
### Summary
The goal was to get that long list of variables associated with their individual tools.
You can view the changes by commit if you want.

1. Tile Invalidations tool
Rename and reduce scope of variables associated with tile invalidations debug tool

2. Ping tool/Tile invalidations tool
Rename variables and functions
Move server ping to separate tool
Fix keypress detection for timing

3. Tile data tool
Rename variables, make them all behave the same, rewrite display

4. Overlay tool
Tools can clear their messages when they get turned off

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

