### PR TITLE
backport: Add loading indicator for document title saving

### DIFF
--- a/browser/css/menubar.css
+++ b/browser/css/menubar.css
@@ -40,8 +40,10 @@
 	height: 32px;
 	white-space: nowrap;
 	display: flex;
-	align-items: center;
-	justify-content: flex-start;
+	align-items: flex-start;
+	justify-content: center;
+	gap: 5px;
+	flex-direction: column;
 }
 
 .readonly .document-title {

--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -9,6 +9,30 @@
 	background-color: transparent;
 }
 
+#document-name-input-loading-bar {
+	width: 100%;
+	height: 2px;
+	background-color: var(--color-background-dark);
+	overflow: hidden;
+	position: relative;
+	display: none;
+	margin-block-end: -7px;
+}
+
+#document-name-input-loading-bar::after {
+	content: '';
+	position: absolute;
+	height: 100%;
+	width: 25%;
+	background-color: var(--color-main-text);
+	animation: moveIndicator 2s linear infinite;
+}
+
+@keyframes moveIndicator {
+	from { left: -25%; }
+	to { left: 100%; }
+}
+
 #toolbar-down {
 	left: 0;
 	right: 0;
@@ -288,7 +312,6 @@ w2ui-toolbar {
 	background-color: transparent;
 	border-radius: var(--border-radius);
 	padding: 0px 2px;
-	transition: 0.5s;
 }
 
 #document-name-input.editable {

--- a/browser/html/cool.html.m4
+++ b/browser/html/cool.html.m4
@@ -185,6 +185,7 @@ m4_ifelse(MOBILEAPP,[true],
           <!-- visuallyhidden: hide it visually but keep it available to screen reader and other assistive technology -->
           <label class="visuallyhidden" for="document-name-input" aria-hidden="false">Document name</label>
           <input id="document-name-input" type="text" spellcheck="false" disabled="true" style="display: none"/>
+          <div id="document-name-input-loading-bar"></div>
         </div>
       </div>
 

--- a/browser/src/control/Control.DocumentNameInput.js
+++ b/browser/src/control/Control.DocumentNameInput.js
@@ -139,6 +139,15 @@ L.Control.DocumentNameInput = L.Control.extend({
 		}
 	},
 
+	showLoadingAnimation : function() {
+		$('#document-name-input').prop('disabled', true);
+		$('#document-name-input-loading-bar').css('display', 'block');	
+	},
+
+	hideLoadingAnimation : function() {
+		$('#document-name-input-loading-bar').css('display', 'none');
+	},
+
 	_getMaxAvailableWidth: function() {
 		var x = $('#document-titlebar').prop('offsetLeft') + $('.document-title').prop('offsetLeft') + $('#document-name-input').prop('offsetLeft');
 		var containerWidth = parseInt($('.main-nav').css('width'));

--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -848,11 +848,13 @@ app.definitions.Socket = L.Class.extend({
 				// Reload the document
 				app.idleHandler._active = false;
 				map = this._map;
+				var that = this;
 				clearTimeout(this.timer);
 				this.timer = setInterval(function() {
 					try {
 						// Activate and cancel timer and dialogs.
 						app.idleHandler._activate();
+						that._map.uiManager.documentNameInput.hideLoadingAnimation();
 					} catch (error) {
 						window.app.console.warn('Cannot activate map');
 					}
@@ -1298,6 +1300,7 @@ app.definitions.Socket = L.Class.extend({
 			window.wopiSrc = this._map.options.wopiSrc;
 
 			if (textMsg.startsWith('renamefile:')) {
+				this._map.uiManager.documentNameInput.showLoadingAnimation();
 				this._map.fire('postMessage', {
 					msgId: 'File_Rename',
 					args: {


### PR DESCRIPTION
To address the lack of visual feedback during the delayed saving of document titles, a loading bar has been introduced below the document name/title input field. This provides users with a clear indication of the ongoing save operation. Additionally, the delay that previously occurred after entering a new document name and pressing Enter has been eliminated, streamlining the save process.


Change-Id: I9c5a41f999d02dcfaa24e7925029499cf310b2e0


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

