### PR TITLE
Backports: sheet protecion + other

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -542,7 +542,7 @@ $(INTERMEDIATE_DIR)/admin-src.js: $(COOL_ADMIN_TS_JS) $(COOL_ADMIN_JS)
 	@$(NODE) node_modules/eslint/bin/eslint.js --resolve-plugins-relative-to $(abs_builddir) --ignore-path $(srcdir)/.eslintignore --config $(srcdir)/.eslintrc --no-eslintrc $(srcdir)/admin/src
 	@awk 'FNR == 1 {print ""} 1' $(COOL_ADMIN_TS_JS) $(patsubst %.js,$(srcdir)/%.js,$(COOL_ADMIN_JS)) > $@
 
-$(INTERMEDIATE_DIR)/cool-src.js: tscompile.done $(call prereq_cool) $(COOL_JS_DST)
+$(INTERMEDIATE_DIR)/cool-src.js: tscompile.done $(call prereq_cool) $(COOL_JS_DST) $(abs_top_srcdir)/scripts/unocommands.py
 	@mkdir -p $(dir $@)
 	$(abs_top_srcdir)/scripts/unocommands.py --check $(abs_top_srcdir)
 	@printf "Checking for obsolete JS build intermediates in this makefile... "

--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -107,6 +107,7 @@ window.app = {
 	    gecko3d = 'MozPerspective' in doc.style,
 	    opera12 = 'OTransition' in doc.style;
 
+	var mac = navigator.appVersion.indexOf('Mac') != -1 || navigator.userAgent.indexOf('Mac') != -1;
 	var chromebook = global.ThisIsTheAndroidApp && global.COOLMessageHandler.isChromeOS();
 
 	var isInternetExplorer = (navigator.userAgent.toLowerCase().indexOf('msie') != -1 ||
@@ -183,6 +184,10 @@ window.app = {
 		// @property win: Boolean
 		// `true` when the browser is running in a Windows platform
 		win: win,
+
+		// @property mac: Boolean
+		// `true` when the browser is running in a Mac platform
+		mac: mac,
 
 		// @property ie3d: Boolean
 		// `true` for all Internet Explorer versions supporting CSS transforms.

--- a/browser/src/control/Control.DownloadProgress.js
+++ b/browser/src/control/Control.DownloadProgress.js
@@ -137,7 +137,7 @@ L.Control.DownloadProgress = L.Control.extend({
 	_setupKeyboardShortcutForElement: function (eventTargetId, buttonId) {
 		var keyDownCallback = function(e) {
 			var modifierKeys = !e.altKey && !e.shiftKey;
-			if (navigator.appVersion.indexOf('Mac') != -1 || navigator.userAgent.indexOf('Mac') != -1) {
+			if (L.Browser.mac) {
 				modifierKeys = modifierKeys && e.metaKey && !e.ctrlKey;
 			} else {
 				modifierKeys = modifierKeys && e.ctrlKey && !e.metaKey;

--- a/browser/src/core/Util.js
+++ b/browser/src/core/Util.js
@@ -227,7 +227,7 @@ L.Util = {
 	},
 
 	replaceCtrlAltInMac: function(msg) {
-		if (navigator.appVersion.indexOf('Mac') != -1 || navigator.userAgent.indexOf('Mac') != -1) {
+		if (L.Browser.mac) {
 			var ctrl = /Ctrl/g;
 			var alt = /Alt/g;
 			if (String.locale.startsWith('de') || String.locale.startsWith('dsb') || String.locale.startsWith('hsb')) {

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -808,8 +808,6 @@ L.TileSectionManager = L.Class.extend({
 
 L.CanvasTileLayer = L.Layer.extend({
 
-	isMacClient: (navigator.appVersion.indexOf('Mac') != -1 || navigator.userAgent.indexOf('Mac') != -1),
-
 	options: {
 		pane: 'tilePane',
 
@@ -3660,7 +3658,7 @@ L.CanvasTileLayer = L.Layer.extend({
 		if (!this._map._docLoaded)
 			return;
 
-		if (this.isMacClient) {
+		if (L.Browser.mac) {
 			// Map Mac standard shortcuts to the LO shortcuts for the corresponding
 			// functions when possible. Note that the Cmd modifier comes here as CTRL.
 

--- a/browser/src/map/handler/Map.Keyboard.js
+++ b/browser/src/map/handler/Map.Keyboard.js
@@ -736,7 +736,7 @@ L.Map.Keyboard = L.Handler.extend({
 	},
 
 	_isCtrlKey: function (e) {
-		if (window.ThisIsTheiOSApp || navigator.appVersion.indexOf('Mac') != -1 || navigator.userAgent.indexOf('Mac') != -1)
+		if (window.ThisIsTheiOSApp || L.Browser.mac)
 			return e.metaKey;
 		else
 			return e.ctrlKey;

--- a/browser/src/map/handler/Map.Mouse.js
+++ b/browser/src/map/handler/Map.Mouse.js
@@ -93,7 +93,7 @@ L.Map.Mouse = L.Handler.extend({
 		buttons |= e.originalEvent.button === this.JSButtons.right ? this.LOButtons.right : 0;
 
 		// Turn ctrl-left-click into right-click for browsers on macOS
-		if (navigator.appVersion.indexOf('Mac') != -1 || navigator.userAgent.indexOf('Mac') != -1) {
+		if (L.Browser.mac) {
 			if (modifier == UNOModifier.CTRL && buttons == this.LOButtons.left) {
 				modifier = 0;
 				buttons = this.LOButtons.right;

--- a/scripts/unocommands.py
+++ b/scripts/unocommands.py
@@ -349,7 +349,7 @@ window._UNO = function(string, component, isContext) {
 window.removeAccessKey = function(text) {
 \t// Remove access key markers from translated strings
 \t// 1. access key in parenthesis in case of non-latin scripts
-\ttext = text.replace(/\(~[A-Za-z]\)/, '');
+\ttext = text.replace(/\\(~[A-Za-z]\\)/, '');
 \t// 2. remove normal access key
 \ttext = text.replace('~', '');
 


### PR DESCRIPTION
* Resolves: # <!-- related github issue --> See #551 
* Target version: co-23.05 

### Summary

Backport the following:

* calc: Enable sheet protection
* Fix warning for unocommands.py
* global: Add L.Browser.mac to not parse user agent everywhere


### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

