### PR TITLE
calc: Add protect sheet command to Tools menu

### DIFF
--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -909,6 +909,7 @@ L.Control.Menubar = L.Control.extend({
 				{name: _UNO('.uno:LanguageMenu'), type: 'menu', menu: [
 					{name: _('None (Do not check spelling)'), id: 'nonelanguage', uno: '.uno:LanguageStatus?Language:string=Default_LANGUAGE_NONE'}]},
 				{uno: '.uno:GoalSeekDialog'},
+				{uno: '.uno:Protect'},
 				{type: 'separator'},
 				{name: _UNO('.uno:RunMacro'), id: 'runmacro', uno: '.uno:RunMacro'}
 			]},


### PR DESCRIPTION
Change-Id: I1511419858e361ad7a7653b2939e8d516c2d7e59


* Resolves: # <!-- related github issue --> See #551 
* Target version: master 

### Summary

This is to be consistent with LibreOffice.

![image](https://github.com/CollaboraOnline/online/assets/114441/32b30821-7326-4b7f-b4c7-bd4c7630045c)

Not sure about the notebook bar.

### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

