### PR TITLE
disable getting the host printer queue

### DIFF
--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -2810,6 +2810,9 @@ void COOLWSD::innerInitialize(Application& self)
 
     // Otherwise we profile the soft-device at jail creation time.
     setenv("SAL_DISABLE_OPENCL", "true", 1);
+    // Disable getting the OS print queue and default printer
+    setenv("SAL_DISABLE_PRINTERLIST", "true", 1);
+    setenv("SAL_DISABLE_DEFAULTPRINTER", "true", 1);
 
     // Log the connection and document limits.
 #if ENABLE_WELCOME_MESSAGE


### PR DESCRIPTION
and default printer. In typical deployment these should be effectively no no-op, so mostly aligns debugging env with deployment env so whatever printer happens to be installed locally has no effect.


Change-Id: I09651d9af2de9817d4d278d25937c9ce0dc87352


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

