### PR TITLE
admin: send shutdown_received before shutting down

### DIFF
--- a/common/SigUtil.hpp
+++ b/common/SigUtil.hpp
@@ -28,6 +28,8 @@ namespace SigUtil
     bool getTerminationFlag();
     /// Set the flag to stop pump loops forcefully and request shutting down.
     void setTerminationFlag();
+    /// Set the flag to send message to indirection server to migrate all the document in Admin.cpp
+    bool getDelayedShutdownRequestFlag();
 #if MOBILEAPP
     /// Reset the flags to stop pump loops forcefully.
     /// Only necessary in Mobile.
@@ -100,6 +102,9 @@ namespace SigUtil
 
     /// Update version info
     void setVersionInfo(const std::string &versionInfo);
+
+    // set IndirectionServerEnabled value
+    void setIndirectionServerEnabled(const bool enabled);
 
     /// Trap generally useful signals
     void setUserSignals();

--- a/wsd/Admin.hpp
+++ b/wsd/Admin.hpp
@@ -182,6 +182,9 @@ public:
 
     void routeTokenSanityCheck();
 
+    // send shutdown_received message
+    void sendShutdownReceivedMsg();
+
 private:
     /// Notify Forkit of changed settings.
     void notifyForkit();
@@ -247,6 +250,8 @@ private:
 
     // map to make sure only connection with unique monitor uri exists
     std::map<std::string, std::shared_ptr<MonitorSocketHandler>> _monitorSockets;
+
+    bool _shutdownReceivedMsgSent = false;
 };
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/AdminModel.cpp
+++ b/wsd/AdminModel.cpp
@@ -1353,4 +1353,13 @@ void AdminModel::routeTokenSanityCheck()
     notify(oss.str());
 }
 
+void AdminModel::sendShutdownReceivedMsg()
+{
+    ASSERT_CORRECT_THREAD_OWNER(_owner);
+
+    std::ostringstream oss;
+    oss << "shutdown_received";
+    notify(oss.str());
+}
+
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/AdminModel.hpp
+++ b/wsd/AdminModel.hpp
@@ -440,6 +440,7 @@ public:
     std::string getWopiSrcMap();
     std::string getFilename(int pid);
     void routeTokenSanityCheck();
+    void sendShutdownReceivedMsg();
 
 private:
     void doRemove(std::map<std::string, std::unique_ptr<Document>>::iterator &docIt);

--- a/wsd/COOLWSD.hpp
+++ b/wsd/COOLWSD.hpp
@@ -496,6 +496,9 @@ public:
     /// Autosave a given document (currently only called from Admin).
     static void autoSave(const std::string& docKey);
 
+    /// Autosave a given document and stop (currently only called from Admin)
+    static void autoSaveAndStop(const std::string& docKey, const std::string& reason);
+
     /// Sets the log level of current kits.
     static void setLogLevelsOfKits(const std::string& level);
 

--- a/wsd/protocol.txt
+++ b/wsd/protocol.txt
@@ -959,6 +959,10 @@ section). Others are just response messages to some client command.
     }
     <JSON string> contains the map wopiSrc<->routeToken
 
+[*] shutdown_received
+
+    sent when indirection server is enabled and COOLWSD receives SIGTERM signal
+
 InvalidAuthToken
 
     This is sent when invalid auth token is provided in 'auth' and 'verifyauth' command. See


### PR DESCRIPTION
- added a new RunState::Migrate use this state when indirection_endpoint is configured
- indirection server send shutdown message once migration of unsaved documents is complete


Change-Id: I2606b24efcf3b1080ead35bb8535c11b4419e939


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

