### PR TITLE
Fix &debug=true and &randomUser=true url parameters

### DIFF
--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -89,8 +89,8 @@ window.app = {
 		var value = this.p.get(name);
 		return value === null ? '' : value;
 	}.bind(coolParams);
-	coolParams.set = function(name) {
-		this.p.set(name);
+	coolParams.set = function(name, value) {
+		this.p.set(name, value);
 	}.bind(coolParams);
 	global.coolParams = coolParams;
 

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -5496,9 +5496,6 @@ L.CanvasTileLayer = L.Layer.extend({
 		}
 
 		this._debug = map._debug;
-		if (map.options.debug && !this._debug.debugOn) {
-			this._debug.toggle();
-		}
 
 		this._searchResultsLayer = new L.LayerGroup();
 		map.addLayer(this._searchResultsLayer);

--- a/browser/src/map/Map.js
+++ b/browser/src/map/Map.js
@@ -154,6 +154,11 @@ L.Map = L.Evented.extend({
 		this._progressBar = L.progressOverlay(new L.point(150, 25));
 
 		this._debug = new L.DebugManager(this);
+		this.on('docloaded', function() {
+			if (this.options.debug && !this._debug.debugOn) {
+				this._debug.toggle();
+			}
+		});
 
 		// When all these conditions are met, fire statusindicator:initializationcomplete
 		this.initConditions = {


### PR DESCRIPTION
Randomized settings had been getting overwritten by later setup. This change moves the randomization to after the other setup.

Move debug toggle to after docloaded message
Move sidebar toggle even later than that

Change-Id: Ib72b5ef4c2c31f7707a384b2d819d5cde57a796d


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

