### PR TITLE
backport: Fix video position in safari presentation mode

### DIFF
--- a/browser/src/map/handler/Map.SlideShow.js
+++ b/browser/src/map/handler/Map.SlideShow.js
@@ -134,6 +134,7 @@ L.Map.SlideShow = L.Handler.extend({
 		if ('processCoolUrl' in window) {
 			this._processSlideshowLinks();
 		}
+		this._processSlideshowVideoForSafari();
 
 		this._startPlaying();
 	},
@@ -185,9 +186,8 @@ L.Map.SlideShow = L.Handler.extend({
 	},
 
 	_processSlideshowLinks: function() {
-		var that = this;
-		this._slideShow.onload = function onLoadSlideshow() {
-			var linkElements = [].slice.call(that._slideShow.contentDocument.querySelectorAll('a'))
+		this._slideShow.addEventListener('load', (function onLoadSlideshow() {
+			var linkElements = [].slice.call(this._slideShow.contentDocument.querySelectorAll('a'))
 				.filter(function(el) {
 					return el.getAttribute('href') || el.getAttribute('xlink:href');
 				})
@@ -218,7 +218,7 @@ L.Map.SlideShow = L.Handler.extend({
 				item.parent.parentNode.insertBefore(item.parent.cloneNode(true), item.parent.nextSibling);
 				item.parent.parentNode.removeChild(item.parent);
 			});
-		};
+		}).bind(this));
 	},
 
 	_checkAlreadyPresenting: function() {
@@ -244,6 +244,73 @@ L.Map.SlideShow = L.Handler.extend({
 			this._map.uiManager.closeSnackbar();
 		}
 	},
+
+	_processSlideshowVideoForSafari: function() {
+		// There is an issue where Safari without LBSE renders the video in the wrong place, so we
+		// must move it back into frame
+		// GH#7399 fixed the same issue, but not in presentation mode
+		if (!L.Browser.safari) {
+			return;
+		}
+
+		if (!this._slideShow) {
+			console.error('In Safari without fixing slideshow videos, this may cause videos to be offset');
+			return;
+		}
+
+		this._slideShow.addEventListener('load', (function onLoadSlideshow() {
+			var videos = this._slideShow.contentDocument.querySelectorAll('video');
+
+			var fixSVGPos = function(video) {
+				var videoContainer = video.parentNode;
+				var foreignObject = videoContainer.parentNode;
+				var svg = foreignObject.closest('svg');
+
+				return function() {
+					var widthRatio = svg.width.baseVal.value / svg.viewBox.baseVal.width;
+					var heightRatio = svg.height.baseVal.value / svg.viewBox.baseVal.height;
+					var minRatio = Math.min(widthRatio, heightRatio);
+
+					var leftRightBorders = svg.width.baseVal.value - minRatio * svg.viewBox.baseVal.width;
+					var topBottomBorders = svg.height.baseVal.value - minRatio * svg.viewBox.baseVal.height;
+
+					// revert the scaling positioning to center (back to top-left) by subtracting at 1/2 of width
+					var offsetX = -foreignObject.width.baseVal.value / 2.0;
+					var offsetY = -foreignObject.height.baseVal.value / 2.0;
+
+					// revert the object position
+					offsetX = offsetX - foreignObject.x.baseVal.value + (leftRightBorders / 4.0);
+					offsetY = offsetY - foreignObject.y.baseVal.value + (topBottomBorders / 4.0);
+
+					// reapply the scaling positioning to center by adding 1/2 of the non-scaled width
+					offsetX = offsetX + (foreignObject.width.baseVal.value * widthRatio / 2.0);
+					offsetY = offsetY + (foreignObject.height.baseVal.value * heightRatio / 2.0);
+
+					// reapply the object positioning
+					offsetX = offsetX + foreignObject.x.baseVal.value * widthRatio;
+					offsetY = offsetY + foreignObject.y.baseVal.value * heightRatio;
+
+					var scaleString = 'scale(' + minRatio + ')';
+					var translateString = 'translate(' + offsetX + 'px, ' + offsetY + 'px)';
+
+					videoContainer.style.transform = translateString + ' ' + scaleString;
+				};
+			};
+
+			for (var i = 0; i < videos.length; i++) {
+				var fixThisVideoPos = fixSVGPos(videos[i]);
+
+				fixThisVideoPos();
+				var observer = new MutationObserver(fixThisVideoPos);
+
+				observer.observe(this._slideShow, {
+					attributes: true
+				});
+
+				this._slideShow.contentDocument.defaultView.addEventListener('resize', fixThisVideoPos);
+			}
+		}).bind(this));
+	}
 });
 
 L.Map.addInitHook('addHandler', 'slideShow', L.Map.SlideShow);


### PR DESCRIPTION
This is a backport of #7618

237d9c084a7ebf4681e1e850c4c5df410f8fa67a fixed videos rendering in the wrong place on Safari (and all iOS browsers) in edit mode. Unfortunately, it made the oversight of missing presentation mode, which gets its SVGs from a completely different place :facepalm:.

This commit fixes presentation mode.

After this commit, you will see the video in the right place. Please note that the white border present in edit mode is not there in presentation mode, so if you line the video edge up with something in the presentation you may think the video is offset: I suggest lining something in the video up rather than the edge of the video object.

Known caveats:
- This commit seems to be a few pixels off with larger border sizes. It's a lot better than before, but still not perfect

This commit does not include detection for the upcoming Layer-Based SVG engine <https://wpewebkit.org/blog/05-new-svg-engine.html>. This means that this commit will *break* video if this is enabled in Safari debug mode.  If this commit is merged as-is we need to make a followup to fix this as soon as possible or we will end up with a similar-but-opposite bug when that flag is toggled on by default.

Follow-up-to: I205e692e7027ad917bd6f29aa96b0ac70a4c9e04

Change-Id: Ifeea18874d189c80cbb96029706a6f71d6125898


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

