### PR TITLE
jsdialog: handle disable action on mobile

### DIFF
--- a/browser/css/mobilewizard.css
+++ b/browser/css/mobilewizard.css
@@ -345,7 +345,7 @@ p.mobile-wizard.ui-combobox-text.selected {
 	justify-content: space-between;
 }
 
-.ui-header.mobile-wizard.disabled .ui-header-left * {
+.ui-explorable-entry.mobile-wizard.disabled .ui-header .ui-header-left * {
 	color: var(--color-text-lighter) !important;
 }
 

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -606,14 +606,43 @@ L.Control.JSDialogBuilder = L.Control.extend({
 	},
 
 	_toolboxHandler: function(parentContainer, data, builder) {
-		var toolbox = L.DomUtil.create('div', builder.options.cssClass + ' toolbox', parentContainer);
+		var levelClass = (builder._currentDepth !== undefined) ? ' level-' + builder._currentDepth : '';
+		var toolbox = L.DomUtil.create('div',
+			builder.options.cssClass + ' toolbox' + levelClass, parentContainer);
 		toolbox.id = data.id;
 
-		if (data.enabled === false || data.enabled === 'false') {
+		if (data.enabled === false) {
+			toolbox.setAttribute('disabled', '');
 			for (var index in data.children) {
 				data.children[index].enabled = false;
 			}
 		}
+
+		var enabledCallback = function (mutations) {
+			for (var i in mutations) {
+				if (mutations[i].attributeName === 'disabled') {
+					var enable = mutations[i].oldValue !== null;
+					// schedule children update, don't do it in mutation observer callback
+					setTimeout(function () {
+						for (var j in data.children) {
+							var childId = data.children[j].id;
+							var toolboxChild = toolbox.querySelector('#' + childId);
+							if (!toolboxChild)
+								continue;
+							if (enable) {
+								toolboxChild.removeAttribute('disabled');
+								toolboxChild.classList.remove('disabled');
+							} else {
+								toolboxChild.setAttribute('disabled', '');
+								toolboxChild.classList.add('disabled');
+							}
+						}
+					}, 0);
+				}
+			}
+		};
+		var enableObserver = new MutationObserver(enabledCallback);
+		enableObserver.observe(toolbox, { attributeFilter: ['disabled'], attributeOldValue: true });
 
 		var noLabels = builder.options.noLabelsForUnoButtons;
 		builder.options.noLabelsForUnoButtons = true;
@@ -820,8 +849,10 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		var sectionTitle = L.DomUtil.create('div', 'ui-header level-' + builder._currentDepth + ' ' + builder.options.cssClass + ' ui-widget', mainContainer);
 		$(sectionTitle).css('justify-content', 'space-between');
 
-		if (data.enabled === 'false' || data.enabled === false)
-			$(sectionTitle).addClass('disabled');
+		if (data.enabled === 'false' || data.enabled === false) {
+			mainContainer.setAttribute('disabled', '');
+			$(mainContainer).addClass('disabled');
+		}
 
 		var leftDiv = L.DomUtil.create('div', 'ui-header-left', sectionTitle);
 		var titleClass = '';
@@ -882,13 +913,15 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		{
 			$(contentDiv).hide();
 			if (builder.wizard) {
-				if (data.enabled !== 'false' && data.enabled !== false) {
-					$(sectionTitle).click(function(event, data) {
+				$(sectionTitle).click(function(event, data) {
+					if (!mainContainer.hasAttribute('disabled')) {
 						builder.wizard.goLevelDown(mainContainer, data);
 						if (contentNode && contentNode.onshow && !builder.wizard._inBuilding)
 							contentNode.onshow();
-					});
-				} else {
+					}
+				});
+
+				if (mainContainer.hasAttribute('disabled')) {
 					$(arrowSpan).hide();
 				}
 			} else {
@@ -3104,10 +3137,12 @@ L.Control.JSDialogBuilder = L.Control.extend({
 
 		case 'enable':
 			control.disabled = false;
+			control.removeAttribute('disabled');
 			break;
 
 		case 'disable':
 			control.disabled = true;
+			control.setAttribute('disabled', '');
 			break;
 
 		case 'setText':

--- a/browser/src/control/Control.MobileWizardBuilder.js
+++ b/browser/src/control/Control.MobileWizardBuilder.js
@@ -38,7 +38,6 @@ L.Control.MobileWizardBuilder = L.Control.JSDialogBuilder.extend({
 		this._controlHandlers['radiobutton'] = this._radiobuttonControl;
 		this._controlHandlers['scrollwindow'] = undefined;
 		this._controlHandlers['tabcontrol'] = JSDialog.mobileTabControl;
-		this._controlHandlers['toolbox'] = this._toolboxHandler;
 		this._controlHandlers['borderstyle'] = JSDialog.mobileBorderSelector;
 
 		this._toolitemHandlers['.uno:FontworkAlignmentFloater'] = function () { return false; };
@@ -633,21 +632,6 @@ L.Control.MobileWizardBuilder = L.Control.JSDialogBuilder.extend({
 			if (control)
 				L.DomUtil.addClass(control, 'hidden');
 		}
-
-		return false;
-	},
-
-	_toolboxHandler: function(parentContainer, data, builder) {
-		var toolbox = L.DomUtil.create('div', builder.options.cssClass + ' toolbox level-' + builder._currentDepth, parentContainer);
-		toolbox.id = data.id;
-
-		if (data.enabled === false || data.enabled === 'false') {
-			for (var index in data.children) {
-				data.children[index].enabled = false;
-			}
-		}
-
-		builder.build(toolbox, data.children, false, false);
 
 		return false;
 	},

--- a/browser/src/control/jsdialog/Widget.MobileBorderSelector.js
+++ b/browser/src/control/jsdialog/Widget.MobileBorderSelector.js
@@ -88,6 +88,10 @@ JSDialog.mobileBorderSelector = function (parentContainer, data, builder) {
 	var mainContainer = L.DomUtil.create('div', builder.options.cssClass + ' ui-mobileborderselector', parentContainer);
 	mainContainer.id = data.id;
 
+	if (data.enabled === false) {
+		mainContainer.disabled = true;
+	}
+
 	var bordercontrollabel = L.DomUtil.create('label', builder.options.cssClass + ' ui-text', mainContainer);
 	bordercontrollabel.textContent = _('Cell borders');
 	bordercontrollabel.id = data.id + 'label';


### PR DESCRIPTION
- unify desktop and mobile toolbox code
- toolbox should apply disabled state on child nodes
- this is needed to handle disable action, previously we received JSON for complete widget

requires: https://gerrit.libreoffice.org/c/core/+/163288