### PR TITLE
calc:  Receive the sheet protected status

### DIFF
--- a/browser/css/spreadsheet.css
+++ b/browser/css/spreadsheet.css
@@ -25,7 +25,8 @@
 	text-decoration: none;
 
 	font: var(--default-font-size)/1.5 var(--cool-font);
-	display: inline-block;
+	display: inline-grid;
+	grid-auto-flow: column;
 	border: 1px solid transparent;
 	border-radius: var(--border-radius);
 	background: var(--color-main-background);
@@ -36,6 +37,13 @@
 	background-color: var(--color-primary) !important;
 	color: var(--color-primary-text) !important;
 	border: 1px solid var(--color-border-dark);
+}
+
+.spreadsheet-tab.spreadsheet-tab-protected > .lock, .spreadsheet-tab.spreadsheet-tab-protected:hover > .lock {
+	width: 16px;
+	height: 16px;
+	background-image: url('images/lc_protect.svg') !important;
+	background-repeat: no-repeat !important;
 }
 
 #spreadsheet-tab-scroll button.spreadsheet-tab-selected:hover {

--- a/browser/src/control/Control.Tabs.js
+++ b/browser/src/control/Control.Tabs.js
@@ -69,10 +69,15 @@ L.Control.Tabs = L.Control.extend({
 			'.uno:Remove': {
 				name: _UNO('.uno:Remove', 'spreadsheet', true),
 				callback: (this._deleteSheet).bind(this),
-				visible: areTabsMultiple
+				visible: function() {
+					return areTabsMultiple() && !this._isProtectedSheet(this._tabForContextMenu);
+				}.bind(this)
 			},
 			'.uno:Name': {name: _UNO('.uno:RenameTable', 'spreadsheet', true),
-				callback: (this._renameSheet).bind(this)
+				      callback: (this._renameSheet).bind(this),
+				      visible: function() {
+					      return !this._isProtectedSheet(this._tabForContextMenu);
+				      }.bind(this)
 			},
 			'.uno:Protect': {
 				name: _UNO('.uno:Protect', 'spreadsheet', true),
@@ -393,6 +398,11 @@ L.Control.Tabs = L.Control.extend({
 		if (!this._setPartIndex(this._tabForContextMenu)) {
 			this._map.sendUnoCommand('.uno:Protect');
 		}
+	},
+
+	_isProtectedSheet: function(idx) {
+		let tab = L.DomUtil.get('spreadsheet-tab' + idx);
+		return tab && L.DomUtil.hasClass(tab, 'spreadsheet-tab-protected');
 	},
 
 	_showSheet: function() {

--- a/browser/src/control/Control.Tabs.js
+++ b/browser/src/control/Control.Tabs.js
@@ -203,6 +203,8 @@ L.Control.Tabs = L.Control.extend({
 					dropZoneIndicator.id = 'drop-zone-' + i;
 					var id = 'spreadsheet-tab' + i;
 					var tab = L.DomUtil.create('button', 'spreadsheet-tab', ssTabScroll);
+					L.DomUtil.create('div', 'lock', tab);
+					let label = L.DomUtil.create('div', '', tab);
 					if (window.mode.isMobile() || window.mode.isTablet()) {
 						(new Hammer(tab, {recognizers: [[Hammer.Press]]}))
 							.on('press', function (j) {
@@ -235,7 +237,13 @@ L.Control.Tabs = L.Control.extend({
 						}(i).bind(this));
 					}
 
-					tab.textContent = e.partNames[i];
+					if (e.protectedParts[i]) {
+						L.DomUtil.addClass(tab, 'spreadsheet-tab-protected');
+					}
+					else {
+						L.DomUtil.removeClass(tab, 'spreadsheet-tab-protected');
+					}
+					label.textContent = e.partNames[i];
 					tab.id = id;
 
 					L.DomEvent
@@ -307,7 +315,7 @@ L.Control.Tabs = L.Control.extend({
 	},
 
 	_setPart: function (e) {
-		var part =  e.target.id.match(/\d+/g)[0];
+		var part =  e.currentTarget.id.match(/\d+/g)[0];
 		if (part !== null) {
 			this._setPartIndex(parseInt(part));
 		}

--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -1760,6 +1760,13 @@ app.definitions.Socket = L.Class.extend({
 					command.rtlParts.push(parseInt(item));
 				});
 			}
+			else if (tokens[i].startsWith('protectedparts=')) {
+				let protectedParts = tokens[i].substring(15).split(',');
+				command.protectedParts = [];
+				protectedParts.forEach(function (item) {
+					command.protectedParts.push(parseInt(item));
+				});
+			}
 			else if (tokens[i].startsWith('hash=')) {
 				command.hash = tokens[i].substring('hash='.length);
 			}

--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -430,6 +430,14 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 				this._updateMaxBounds(true);
 			}
 			this._hiddenParts = command.hiddenparts || [];
+
+			let pparts = [];
+			pparts.length = command.parts;
+			this._protectedParts = pparts.fill(false, 0, command.parts);
+			if (command.protectedParts) {
+				command.protectedParts.forEach(i => this._protectedParts[i] = true);
+			}
+
 			this._handleRTLFlags(command);
 			this._documentInfo = textMsg;
 			var partNames = textMsg.match(/[^\r\n]+/g);
@@ -441,6 +449,7 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 				docType: this._docType,
 				partNames: this._partNames,
 				hiddenParts: this._hiddenParts,
+				protectedParts: this._protectedParts,
 				source: 'status'
 			});
 			this._resetPreFetching(true);

--- a/kit/KitHelper.hpp
+++ b/kit/KitHelper.hpp
@@ -14,6 +14,7 @@
 #include <sstream>
 #include <string>
 
+#include <JsonUtil.hpp>
 #include <Util.hpp>
 
 #define LOK_USE_UNSTABLE_API
@@ -79,6 +80,7 @@ namespace LOKitHelper
             std::ostringstream hposs;
             std::ostringstream sposs;
             std::ostringstream rtlposs;
+            std::ostringstream protectss;
             std::string mode;
             for (int i = 0; i < parts; ++i)
             {
@@ -102,6 +104,11 @@ namespace LOKitHelper
                     {
                         if (prop.second == "1")
                             rtlposs << i << ',';
+                    }
+                    else if (name == "protected")
+                    {
+                        if (prop.second == "1")
+                            protectss << i << ',';
                     }
                     else if (name == "mode" && mode.empty())
                     {
@@ -134,6 +141,13 @@ namespace LOKitHelper
             {
                 rtlparts.pop_back(); // Remove last ','
                 oss << " rtlparts=" << rtlparts;
+            }
+
+            std::string protectparts = protectss.str();
+            if (!protectparts.empty())
+            {
+                protectparts.pop_back(); // Remove last ','
+                oss << " protectedparts=" << protectparts;
             }
 
             if (type == LOK_DOCTYPE_SPREADSHEET)


### PR DESCRIPTION
This set the CSS class 'spreadsheet-tab-protected' on the sheet tab.

Requires LOKit change https://gerrit.libreoffice.org/c/core/+/163325

Also set the state of the state of the context menu UI.

* Resolves: # <!-- related github issue --> See #551 
* Target version: master 

### Summary

This show the status.

![image](https://github.com/CollaboraOnline/online/assets/114441/c6da6b91-9ec9-43c1-a5c0-4fce2c72da18)

Not sure how correct that UI code is.

### TODO

- [ ] Land the change in Core.

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

