### PR TITLE
browser: fix scroll the currently selected tab

### DIFF
--- a/browser/src/control/Control.Tabs.js
+++ b/browser/src/control/Control.Tabs.js
@@ -220,6 +220,10 @@ L.Control.Tabs = L.Control.extend({
 							}(i).bind(this));
 					}
 
+					if (i === selectedPart) {
+						horizScrollPos = tab.offsetLeft;
+					}
+
 					if (!window.mode.isMobile()) {
 						L.DomEvent.on(tab, 'dblclick', function(j) {
 							return function() {


### PR DESCRIPTION
1) Load a document with a large number of tabs
2) The last tab was selected

Change-Id: I0326bf2e374dddd7e075ea5806e5aefe5f598611
Signed-off-by: Henry Castro <hcastro@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

