### PR TITLE
Fix pasting image assertion (22.05)

### DIFF
--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1328,7 +1328,8 @@ bool ClientSession::sendCombinedTiles(const char* /*buffer*/, int /*length*/, co
 bool ClientSession::forwardToChild(const std::string& message,
                                    const std::shared_ptr<DocumentBroker>& docBroker)
 {
-    return docBroker->forwardToChild(client_from_this(), message);
+    const bool binary = Util::startsWith(message, "paste") ? true : false;
+    return docBroker->forwardToChild(client_from_this(), message, binary);
 }
 
 bool ClientSession::filterMessage(const std::string& message) const


### PR DESCRIPTION
Revert "Avoid crash when pasting image in debug mode" This reverts commit 78558fe9af361dd0238bd3021c67e9d431dcf981.

Instead of detecting paste command and not trigerring assertion: fix frame type so it will be binary in case of paste.

This is backport.

How to reproduce:
- open website in browser and right click any image and do "copy image"
- open COOL and try to paste using ctrl + v (in debug build it crashes)