### PR TITLE
globals: Make sure coolParams.get() return an empty string instead of null

### DIFF
--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -80,7 +80,19 @@ window.app = {
 
 	global.setLogging(global.coolLogging != '');
 
-	global.coolParams = new URLSearchParams(global.location.search);
+	var coolParams = {
+		p: new URLSearchParams(global.location.search),
+	};
+	/* We need to return an empty string instead of `null` */
+	coolParams.get = function(name) {
+		var value = this.p.get(name);
+		return value === null ? '' : value;
+	}.bind(coolParams);
+	coolParams.set = function(name) {
+		this.p.set(name);
+	}.bind(coolParams);
+	global.coolParams = coolParams;
+
 	var ua = navigator.userAgent.toLowerCase(),
 	    uv = navigator.vendor.toLowerCase(),
 	    doc = document.documentElement,


### PR DESCRIPTION
This fixes a regression where `framed.doc.html` wouldn't load.


Change-Id: I57b4a617755be4615ec6ec734f6e084d57eaebce


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

