### PR TITLE
calc: Don't use es6 let and () =>

### DIFF
--- a/browser/src/control/Control.Tabs.js
+++ b/browser/src/control/Control.Tabs.js
@@ -209,7 +209,7 @@ L.Control.Tabs = L.Control.extend({
 					var id = 'spreadsheet-tab' + i;
 					var tab = L.DomUtil.create('button', 'spreadsheet-tab', ssTabScroll);
 					L.DomUtil.create('div', 'lock', tab);
-					let label = L.DomUtil.create('div', '', tab);
+					var label = L.DomUtil.create('div', '', tab);
 					if (window.mode.isMobile() || window.mode.isTablet()) {
 						(new Hammer(tab, {recognizers: [[Hammer.Press]]}))
 							.on('press', function (j) {
@@ -405,7 +405,7 @@ L.Control.Tabs = L.Control.extend({
 	},
 
 	_isProtectedSheet: function(idx) {
-		let tab = L.DomUtil.get('spreadsheet-tab' + idx);
+		var tab = L.DomUtil.get('spreadsheet-tab' + idx);
 		return tab && L.DomUtil.hasClass(tab, 'spreadsheet-tab-protected');
 	},
 

--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -1763,7 +1763,7 @@ app.definitions.Socket = L.Class.extend({
 				});
 			}
 			else if (tokens[i].startsWith('protectedparts=')) {
-				let protectedParts = tokens[i].substring(15).split(',');
+				var protectedParts = tokens[i].substring(15).split(',');
 				command.protectedParts = [];
 				protectedParts.forEach(function (item) {
 					command.protectedParts.push(parseInt(item));

--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -432,11 +432,13 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 			}
 			this._hiddenParts = command.hiddenparts || [];
 
-			let pparts = [];
+			var pparts = [];
 			pparts.length = command.parts;
 			this._protectedParts = pparts.fill(false, 0, command.parts);
 			if (command.protectedParts) {
-				command.protectedParts.forEach(i => this._protectedParts[i] = true);
+				command.protectedParts.forEach(function(i) {
+					return this._protectedParts[i] = true;
+				}.bind(this));
 			}
 
 			this._handleRTLFlags(command);


### PR DESCRIPTION
This was introduced by backport #8271 of the sheet protection


Change-Id: I07a9fd428b11042ce191a5c7a48d53400253c445


* Resolves: # <!-- related github issue --> #8271 
* Target version: 23.05 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

