### PR TITLE
zotero: fix long title taking all the space in dialog

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1057,6 +1057,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 
 #ZoteroDialog .ui-treeview-body {
 	max-height: 500px;
+	max-width: 100%;
 }
 
 .autofilter-container-submenu > .autofilter-container {


### PR DESCRIPTION
problem:
when titles are long they go beyond dialog area and are not scrollable, this hides the date and author details which can not be scrolled either


Change-Id: Iae8a5affb870faff0639ac9083e118cec40debd0


* Target version: master 


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

