### PR TITLE
cherry-pick browser: move  impl of savecomments command to Toolbar dispatch

### DIFF
--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -1885,12 +1885,7 @@ L.Control.Menubar = L.Control.extend({
 		} else if (id === 'saveas' && type !== 'menu') { // jsdialog has no type='action'
 			this._map.openSaveAs();
 		} else if (id === 'savecomments') {
-			if (this._map.isPermissionEditForComments()) {
-				this._map.fire('postMessage', {msgId: 'UI_Save'});
-				if (!this._map._disableDefaultAction['UI_Save']) {
-					this._map.save(false, false);
-				}
-			}
+			this._map.dispatch('savecomments');
 		} else if (id === 'shareas' || id === 'ShareAs') {
 			this._map.dispatch('shareas');
 		} else if (id === 'print') {

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -1299,6 +1299,14 @@ L.Map.include({
 			var commentSection = app.sectionContainer.getSectionWithName(L.CSections.CommentList.name);
 			commentSection.rejectAllTrackedCommentChanges();
 			break;
+		case 'savecomments':
+			if (this.isPermissionEditForComments()) {
+				this.fire('postMessage', {msgId: 'UI_Save'});
+				if (!this._disableDefaultAction['UI_Save']) {
+					this.save(false, false);
+				}
+			}
+			break;
 		default:
 			console.error('unknown dispatch: "' + action + '"');
 		}


### PR DESCRIPTION
Signed-off-by: Méven Car <meven.car@collabora.com>
Change-Id: Ifcb34977b72bb0eccd23667deb4750637810e569 (cherry picked from commit 95cc0f6dd48303597bfdd5646990afb1fe615499)


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

