### PR TITLE
getComputedStyle is very slow, but we don't need it for LTR comments

### DIFF
--- a/browser/src/layer/tile/CommentSection.ts
+++ b/browser/src/layer/tile/CommentSection.ts
@@ -708,14 +708,18 @@ export class Comment extends CanvasSectionObject {
 		}
 	}
 
+	private getCommentWidth() {
+		// note: getComputedStyle can be an exceptional bottle-neck with many comments
+		return parseFloat(getComputedStyle(this.sectionProperties.container).width) * app.dpiScale;
+	}
+
 	public positionCalcComment(): void {
 		if (!(<any>window).mode.isMobile()) {
 			var ratio: number = (app.tile.size.pixels[0] / app.tile.size.twips[0]);
 			var cellPos = this.map._docLayer._cellRangeToTwipRect(this.sectionProperties.data.cellRange).toRectangle();
 			var originalSize = [Math.round((cellPos[2]) * ratio), Math.round((cellPos[3]) * ratio)];
 
-			const commentWidth = parseFloat(getComputedStyle(this.sectionProperties.container).width) * app.dpiScale;
-			const startX = this.isCalcRTL() ? this.myTopLeft[0] - commentWidth : this.myTopLeft[0] + originalSize[0] - 3;
+			const startX = this.isCalcRTL() ? this.myTopLeft[0] - this.getCommentWidth() : this.myTopLeft[0] + originalSize[0] - 3;
 
 			var pos: Array<number> = [Math.round(startX / app.dpiScale), Math.round(this.myTopLeft[1] / app.dpiScale)];
 			this.sectionProperties.container.style.transform = 'translate3d(' + pos[0] + 'px, ' + pos[1] + 'px, 0px)';


### PR DESCRIPTION
but it gets computed anyway, move it so its only called if actually needed

Signed-off-by: Caolán McNamara <caolan.mcnamara@collabora.com>
Change-Id: I187540df6def6b4f92199e273665e04ed493035a (cherry picked from commit 2132613139ba07fd592bdef7f0fee1e4b080d44a)


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

