### PR TITLE
zotero: fix missing field data in the dialog (backport)

### DIFF
--- a/browser/src/control/Control.Zotero.js
+++ b/browser/src/control/Control.Zotero.js
@@ -644,11 +644,13 @@ L.Control.Zotero = L.Control.extend({
 
 			var creatorArray = [];
 			for (var creator = 0; items[iterator].data.creators && creator < items[iterator].data.creators.length; ++creator) {
-				creatorArray.push(items[iterator].data.creators[creator].firstName + ' ' + items[iterator].data.creators[creator].lastName);
+				creatorArray.push(items[iterator].data.creators[creator].name ?
+					items[iterator].data.creators[creator].name:
+					items[iterator].data.creators[creator].firstName + ' ' + items[iterator].data.creators[creator].lastName);
 			}
 			var creatorString = creatorArray.join(', ');
 			this.createEntry(index++,
-				[items[iterator].data.title, creatorString, items[iterator].data.date],
+				[items[iterator].csljson.title, creatorString, items[iterator].data.date ? items[iterator].data.date : items[iterator].data.dateDecided],
 				{type: 'item', itemType: items[iterator].data.itemType, item: items[iterator]},
 				true
 			);


### PR DESCRIPTION
problem:
in some types of items fields may be named differently, leading to fields not being found and empty dialog entries.

currently only itemType 'case' was culprit but in future there maybe some other types too


Change-Id: I24b58dc474a555b3f26c34bb4ae0b144c06abc57


* Target version: distro/collabora/co-23.05 

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

