### PR TITLE
zotero: fix long title taking all the space in dialog (backport)

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1050,6 +1050,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 
 #ZoteroDialog .ui-treeview-body {
 	max-height: 500px;
+	max-width: 100%;
 }
 
 .autofilter-container-submenu > .autofilter-container {


### PR DESCRIPTION

* Target version: distro/collabora/co-23.05 



### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

