### PR TITLE
calc: fix header context menu on touch devices

### DIFF
--- a/browser/package.json
+++ b/browser/package.json
@@ -7,6 +7,7 @@
     "@types/jquery": "^3.5.29",
     "@types/jquery.contextmenu": "^1.7.38",
     "@types/jqueryui": "^1.12.21",
+    "@types/hammerjs": "^2.0.45",
     "@types/mocha": "8.2.0",
     "@types/node": "14.14.25",
     "@types/w2ui": "^1.4.37",

--- a/browser/src/control/Control.Header.ts
+++ b/browser/src/control/Control.Header.ts
@@ -56,6 +56,11 @@ export class Header extends CanvasSectionObject {
 	constructor (options?: HeaderInitProperties) {
 		super(options);
 		this.options =  { cursor: options.cursor };
+
+		this.callbacks.onContextMenu = (evt: MouseEvent) => {
+			this._bindContextMenu();
+			$('#document-canvas').contextMenu({x: evt.clientX, y: evt.clientY});
+		};
 	}
 
 	_initHeaderEntryStyles (className: string): void {

--- a/browser/src/layer/tile/CommentSection.ts
+++ b/browser/src/layer/tile/CommentSection.ts
@@ -13,7 +13,6 @@ declare var L: any;
 declare var app: any;
 declare var _: any;
 declare var Autolinker: any;
-declare var Hammer: any;
 
 namespace cool {
 

--- a/browser/src/layer/tile/TilesSection.ts
+++ b/browser/src/layer/tile/TilesSection.ts
@@ -11,7 +11,6 @@
 /* See CanvasSectionContainer.ts for explanations. */
 
 declare var L: any;
-declare var Hammer: any;
 declare var app: any;
 
 namespace cool {


### PR DESCRIPTION
Previously we did not register or trigger the context menu when long-pressing on the headers in calc on mobile devices. This commit registers and activates the context menu when we detect a longpress

To avoid harming devices that are both touchscreen and mouse we do not unregister the context menu after activating it (as on mouse-devices we register/unregister the context menu based on the position of the mouse). I believe this to never actually cause an issue however it's plausible that triggering the context menu again on an area that doesn't have a context menu could cause a context menu for a header to show. I still think this is significantly better than the status-quo


Change-Id: Ib5e9cbdb3d7e10ed58396e8559ab2230f2b76c4c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

