### PR TITLE
Handle sperator case for tree Widget

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -419,7 +419,7 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 	min-height: 100px;
 	min-width: 100px;
 	max-height: 150px;
-	width: max-content;
+	width: inherit;
 }
 
 .ui-treeview.empty .ui-treeview-body {

--- a/browser/src/control/jsdialog/Widget.TreeView.js
+++ b/browser/src/control/jsdialog/Widget.TreeView.js
@@ -174,6 +174,9 @@ function _treelistboxEntry(parentContainer, treeViewData, entry, builder, isTree
 	var disabled = treeViewData.enabled === 'false' || treeViewData.enabled === false;
 
 	var li = L.DomUtil.create('li', builder.options.cssClass, parentContainer);
+	if (_isSeparator(entry)) {
+		L.DomUtil.addClass(li,'context-menu-separator');
+	}
 
 	if (!disabled && entry.state == null) {
 		li.draggable = treeType === 'navigator' ? false: true;
@@ -217,7 +220,7 @@ function _treelistboxEntry(parentContainer, treeViewData, entry, builder, isTree
 			var iconName = builder._createIconURL(iconId, true);
 			L.LOUtil.setImage(icon, iconName, builder.map);
 			L.DomUtil.addClass(span, 'ui-listview-expandable-with-icon');
-		} else if (entry.columns[i].text) {
+		} else if (entry.columns[i].text && !_isSeparator(entry.columns[i])) {
 			var innerText = L.DomUtil.create('span', builder.options.cssClass + ' ui-treeview-cell-text', text);
 			innerText.innerText = entry.columns[i].text || entry.text;
 		}
@@ -322,6 +325,9 @@ function _getLevel(element) {
 	return element.getAttribute('aria-level');
 }
 
+function _isSeparator(element) {
+	return element.text.toLowerCase() === 'separator';
+}
 function _expandTreeGrid(element) {
 	var wasExpanded = element.getAttribute('aria-expanded') === 'true';
 	var level = _getLevel(element);


### PR DESCRIPTION
- separator should be treated as UI not any object value

Before:
![image](https://github.com/CollaboraOnline/online/assets/61383886/cf1b2c3a-ce12-4dfa-bcf6-02e29f3f1fa3)

After:
![image](https://github.com/CollaboraOnline/online/assets/61383886/49da0419-a0e3-48b3-972d-edd80e31c8b5)

Signed-off-by: Darshan-upadhyay1110 <darshan.upadhyay@collabora.com>
Change-Id: Ie6182dda40b7fd3c0d1ea87c5df78a46239677ed