### PR TITLE
es2017: bump eslint version

### DIFF
--- a/browser/.eslintrc
+++ b/browser/.eslintrc
@@ -35,7 +35,7 @@
     "browser": true
   },
   "parserOptions": {
-    "ecmaVersion": 2015
+    "ecmaVersion": 2017
   },
   "overrides": [
     {


### PR DESCRIPTION
This spec was released 7 years ago, and allows e.g. async/await, which
can result in more readable code in some cases.

There is danger that we return to the main loop too easily using this
construct, so no suggestion to rewrite any of the existing code to use 
this, as that can have side effects on how e.g. we process incoming
websocket messages.

Do use await at a single place to make sure await can be indeed used.

Thanks Hubert to notice that the await-using function itself has to be
async, the error message from eslint isn't too clear in that case.