### PR TITLE
init document theme during load

### DIFF
--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -1214,7 +1214,14 @@ window.app = {
 					if (spellOnline) {
 						msg += ' spellOnline=' + spellOnline;
 					}
-
+					var docTypes = ['text', 'spreadsheet', 'presentation', 'drawing'];
+					for (var i = 0; i < docTypes.length; ++i) {
+						var docType = docTypes[i];
+						var darkTheme = global.localStorage.getItem('UIDefaults_' + docType + '_darkTheme');
+						if (darkTheme) {
+							msg += ' ' + docType + 'DarkTheme=' + darkTheme;
+						}
+					}
 				}
 
 				msg += ' timezone=' + Intl.DateTimeFormat().resolvedOptions().timeZone;

--- a/common/Session.cpp
+++ b/common/Session.cpp
@@ -195,6 +195,26 @@ void Session::parseDocOptions(const StringVector& tokens, int& part, std::string
             _spellOnline = value;
             ++offset;
         }
+        else if (name == "textDarkTheme")
+        {
+            _textDarkTheme = value;
+            ++offset;
+        }
+        else if (name == "spreadsheetDarkTheme")
+        {
+            _spreadsheetDarkTheme = value;
+            ++offset;
+        }
+        else if (name == "presentationDarkTheme")
+        {
+            _presentationDarkTheme = value;
+            ++offset;
+        }
+        else if (name == "drawingDarkTheme")
+        {
+            _drawingDarkTheme = value;
+            ++offset;
+        }
         else if (name == "batch")
         {
             _batch = value;

--- a/common/Session.hpp
+++ b/common/Session.hpp
@@ -254,6 +254,11 @@ public:
 
     const std::string& getSpellOnline() const { return _spellOnline; }
 
+    const std::string& getTextDarkTheme() const { return _textDarkTheme; }
+    const std::string& getSpreadsheetDarkTheme() const { return _spreadsheetDarkTheme; }
+    const std::string& getPresentationDarkTheme() const { return _presentationDarkTheme; }
+    const std::string& getDrawingDarkTheme() const { return _drawingDarkTheme; }
+
     const std::string& getBatchMode() const { return _batch; }
 
     const std::string& getEnableMacrosExecution() const { return _enableMacrosExecution; }
@@ -369,6 +374,12 @@ private:
 
     /// The start value of Auto Spell Checking whether it is enabled or disabled on start.
     std::string _spellOnline;
+
+    /// The start value for Dark Theme whether it is active or not on start.
+    std::string _textDarkTheme;
+    std::string _spreadsheetDarkTheme;
+    std::string _presentationDarkTheme;
+    std::string _drawingDarkTheme;
 
     /// Disable dialogs interactivity.
     std::string _batch;

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1562,6 +1562,30 @@ private:
         return viewColors;
     }
 
+    std::string getDefaultTheme(const std::shared_ptr<ChildSession>& session) const
+    {
+        bool darkTheme;
+        switch (_loKitDocument->getDocumentType())
+        {
+            case LOK_DOCTYPE_TEXT:
+                darkTheme = session->getTextDarkTheme() == "true";
+                break;
+            case LOK_DOCTYPE_SPREADSHEET:
+                darkTheme = session->getSpreadsheetDarkTheme() == "true";
+                break;
+            case LOK_DOCTYPE_PRESENTATION:
+                darkTheme = session->getPresentationDarkTheme() == "true";
+                break;
+            case LOK_DOCTYPE_DRAWING:
+                darkTheme = session->getDrawingDarkTheme() == "true";
+                break;
+            default:
+                darkTheme = false;
+                break;
+        }
+        return darkTheme ? "Dark" : "Light";
+    }
+
     std::shared_ptr<lok::Document> load(const std::shared_ptr<ChildSession>& session,
                                         const std::string& renderOpts)
     {
@@ -1708,12 +1732,14 @@ private:
             LOG_TRC("View to url [" << uriAnonym << "] created.");
         }
 
+        std::string theme = getDefaultTheme(session);
+
         LOG_INF("Initializing for rendering session [" << sessionId << "] on document url [" <<
-                anonymizeUrl(_url) << "] with: [" << makeRenderParams(_renderOpts, userNameAnonym, spellOnline) << "].");
+                anonymizeUrl(_url) << "] with: [" << makeRenderParams(_renderOpts, userNameAnonym, spellOnline, theme) << "].");
 
         // initializeForRendering() should be called before
         // registerCallback(), as the previous creates a new view in Impress.
-        const std::string renderParams = makeRenderParams(_renderOpts, userName, spellOnline);
+        const std::string renderParams = makeRenderParams(_renderOpts, userName, spellOnline, theme);
 
         _loKitDocument->initializeForRendering(renderParams.c_str());
 
@@ -1836,7 +1862,8 @@ private:
         return obj;
     }
 
-    static std::string makeRenderParams(const std::string& renderOpts, const std::string& userName, const std::string& spellOnline)
+    static std::string makeRenderParams(const std::string& renderOpts, const std::string& userName,
+                                        const std::string& spellOnline, const std::string& theme)
     {
         Object::Ptr renderOptsObj;
 
@@ -1865,6 +1892,9 @@ private:
             const bool bSet = (spellOnline != "false");
             renderOptsObj->set(".uno:SpellOnline", makePropertyValue("boolean", bSet));
         }
+
+        if (!theme.empty())
+            renderOptsObj->set(".uno:ChangeTheme", makePropertyValue("string", theme));
 
         if (renderOptsObj)
         {

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1241,6 +1241,26 @@ bool ClientSession::loadDocument(const char* /*buffer*/, int /*length*/,
             oss << " spellOnline=" << getSpellOnline();
         }
 
+        if (!getTextDarkTheme().empty())
+        {
+            oss << " textDarkTheme=" << getTextDarkTheme();
+        }
+
+        if (!getSpreadsheetDarkTheme().empty())
+        {
+            oss << " spreadsheetDarkTheme=" << getSpreadsheetDarkTheme();
+        }
+
+        if (!getPresentationDarkTheme().empty())
+        {
+            oss << " presentationDarkTheme=" << getPresentationDarkTheme();
+        }
+
+        if (!getDrawingDarkTheme().empty())
+        {
+            oss << " drawingDarkTheme=" << getDrawingDarkTheme();
+        }
+
         if (!getWatermarkText().empty())
         {
             std::string encodedWatermarkText;


### PR DESCRIPTION
like we do for the spelling setting, so we have the document in the desired state early before any rendering, dropping the early full document invalidations during initial setup

requires https://gerrit.libreoffice.org/c/core/+/163650 in the code to be useful


Change-Id: I6b762c95fd4c00c7da04cf89f7bbeef4bc57375d


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

