### PR TITLE
Avoid exception on view list update

### DIFF
--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -960,7 +960,17 @@ L.Control.UIManager = L.Control.extend({
 	},
 
 	onUpdateViews: function () {
-		var userPrivateInfo = this.map._docLayer ? this.map._viewInfo[this.map._docLayer._viewId].userprivateinfo : null;
+		if (!this.map._docLayer)
+			return;
+
+		var myViewId = this.map._docLayer._viewId;
+		var myViewData = this.map._viewInfo[myViewId];
+		if (!myViewData) {
+			console.error('Not found view data for viewId: "' + myViewId + '"');
+			return;
+		}
+
+		var userPrivateInfo = myViewData.userprivateinfo;
 		if (userPrivateInfo) {
 			var apiKey = userPrivateInfo.ZoteroAPIKey;
 			if (apiKey !== undefined && !this.map.zotero) {


### PR DESCRIPTION
Fixes and gives more details for debugging in case of:

INCOMING: viewinfo: [{"id":3,"userid":"admin","username":"admin","userextrainfo":{"avatar":"http://.../avatar/admin/64","is_admin":true},"readonly":"0","color":0}] cool.html:323:37
Exception TypeError: this.map._viewInfo[this.map._docLayer._viewId] is undefined emitting event [object Object] onUpdateViews@http://.....:9980/browser/08e0fd2e1b/src/control/Control.UIManager.js:823:31

1. Open spreadsheet with 2 views in Nextcloud
2. close with view B
3. Open again with view B
Result: TypeError