### PR TITLE
Fix: Multiple Encoding of wopiSrc  During Document Renaming

### DIFF
--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -1294,7 +1294,7 @@ app.definitions.Socket = L.Class.extend({
 			var docUrl = url.split('?')[0];
 			this._map.options.doc = docUrl;
 			this._map.options.previousWopiSrc = this._map.options.wopiSrc; // After save-as op, we may connect to another server, then code will think that server has restarted. In this case, we don't want to reload the page (detect the file name is different).
-			this._map.options.wopiSrc = encodeURIComponent(docUrl);
+			this._map.options.wopiSrc = docUrl;
 			window.wopiSrc = this._map.options.wopiSrc;
 
 			if (textMsg.startsWith('renamefile:')) {


### PR DESCRIPTION
On the client side, when setting up the socket, we encode  beforehand, so there's no need to encode it again.

Change-Id: I09e59c6fdda4c93de5dd36fca5023ac88926c4d4
* Resolves: #8303
* Target version: master 