### PR TITLE
set the initial rendering state before the first invalidateCanonicalId

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1777,6 +1777,13 @@ private:
                 viewCount << " view" << (viewCount != 1 ? "s." : "."));
 
         session->initWatermark();
+
+        if (char* viewRenderState = _loKitDocument->getCommandValues(".uno:ViewRenderState"))
+        {
+            session->setViewRenderState(viewRenderState);
+            free(viewRenderState);
+        }
+
         invalidateCanonicalId(session->getId());
 
         return _loKitDocument;


### PR DESCRIPTION
now that we will typically init the document theme, etc. from the users last used settings, the current rendering state is likely the one that the user wants to use.

The browser-side throws away all tiles, etc on getting a canonidalidchange, so get the current document renderering state to describe this initial state so later LOK_CALLBACK_VIEW_RENDER_STATE events can be compared to this initial state and only emit canonidalidchange if there is a need.

requires https://gerrit.libreoffice.org/c/core/+/163666 to be merged first


Change-Id: I2902ff4e143f432755c335e1225149207fafdfc3


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

