### PR TITLE
cool#8328 - config header fixup.

### DIFF
--- a/common/Common.hpp
+++ b/common/Common.hpp
@@ -77,15 +77,6 @@ constexpr const char UPLOADING_SUFFIX[] = "ing";
 /// the code: they are logical execution unit names.
 #define SHARED_DOC_THREADNAME_SUFFIX "broker_"
 
-/// The HTTP request User-Agent. Used only in Requests.
-#define HTTP_AGENT_STRING "COOLWSD HTTP Agent " COOLWSD_VERSION
-
-/// The WOPI User-Agent. Depricated: use HTTP_AGENT_STRING.
-#define WOPI_AGENT_STRING HTTP_AGENT_STRING
-
-/// The HTTP response Server. Used only in Responses.
-#define HTTP_SERVER_STRING "COOLWSD HTTP Server " COOLWSD_VERSION
-
 /// The client port number, both coolwsd and the kits have this.
 extern int ClientPortNumber;
 extern std::string MasterLocation;

--- a/common/DummyTraceEventEmitter.cpp
+++ b/common/DummyTraceEventEmitter.cpp
@@ -11,6 +11,8 @@
 
 // Compile and link this into test and utility executables that need it to link
 
+#include "config.h"
+
 #include <common/TraceEvent.hpp>
 
 void TraceEvent::emitOneRecordingIfEnabled(const std::string &recording)

--- a/common/MobileApp.cpp
+++ b/common/MobileApp.cpp
@@ -9,6 +9,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include "config.h"
+
 #include <cassert>
 #include <map>
 #include <mutex>

--- a/common/MobileApp.hpp
+++ b/common/MobileApp.hpp
@@ -11,8 +11,6 @@
 
 #pragma once
 
-#include "config.h"
-
 #if MOBILEAPP
 
 #include <LibreOfficeKit/LibreOfficeKit.hxx>

--- a/common/Simd.hpp
+++ b/common/Simd.hpp
@@ -11,8 +11,6 @@
 
 #pragma once
 
-#include <config.h>
-
 namespace simd {
     bool init();
     extern bool HasAVX2;

--- a/common/StringVector.cpp
+++ b/common/StringVector.cpp
@@ -5,6 +5,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include "config.h"
+
 #include "StringVector.hpp"
 
 #include "Util.hpp"

--- a/common/TraceEvent.cpp
+++ b/common/TraceEvent.cpp
@@ -8,6 +8,8 @@
 // To build a freestanding test executable for just Tracevent:
 // clang++ -Wall -Wextra -DTEST_TRACEEVENT_EXE TraceEvent.cpp -o TraceEvent -pthread
 
+#include "config.h"
+
 #include <cassert>
 #include <mutex>
 #include <sstream>

--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -11,8 +11,6 @@
 
 #pragma once
 
-#include <config.h>
-
 #include <cassert>
 #include <cerrno>
 #include <chrono>

--- a/kit/DeltaSimd.c
+++ b/kit/DeltaSimd.c
@@ -10,7 +10,8 @@
 // versions of inlined code that get injected outside of this
 // module by the linker.
 
-#include <config.h>
+#include "config.h"
+
 #include <assert.h>
 #include <string.h>
 #include <stdio.h>

--- a/net/FakeSocket.cpp
+++ b/net/FakeSocket.cpp
@@ -9,6 +9,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include "config.h"
+
 #include <errno.h>
 #include <fcntl.h>
 #include <poll.h>

--- a/net/HttpHelper.cpp
+++ b/net/HttpHelper.cpp
@@ -33,7 +33,7 @@ void sendError(http::StatusCode errorCode, const std::shared_ptr<StreamSocket>& 
     std::ostringstream oss;
     oss << "HTTP/1.1 " << errorCode << "\r\n"
         << "Date: " << Util::getHttpTimeNow() << "\r\n"
-        << "User-Agent: " << WOPI_AGENT_STRING << "\r\n"
+        << "User-Agent: " << http::getAgentString() << "\r\n"
         << "Content-Length: " << body.size() << "\r\n"
         << extraHeader << "\r\n"
         << body;

--- a/net/HttpRequest.cpp
+++ b/net/HttpRequest.cpp
@@ -9,7 +9,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-#include <config.h>
+#include "config.h"
 
 #include "HttpRequest.hpp"
 

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -11,8 +11,6 @@
 
 #pragma once
 
-#include <config_version.h>
-
 #include <fcntl.h>
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -325,6 +323,9 @@ static inline const char* getReasonPhraseForCode(StatusCode statusCode)
 {
     return getReasonPhraseForCode(static_cast<unsigned>(statusCode));
 }
+
+std::string getAgentString();
+std::string getServerString();
 
 /// The callback signature for handling IO writes.
 /// Returns the number of bytes read from the buffer,
@@ -822,7 +823,7 @@ public:
         , _fd(fd)
     {
         _header.add("Date", Util::getHttpTimeNow());
-        _header.add("Server", HTTP_SERVER_STRING);
+        _header.add("Server", http::getServerString());
     }
 
     /// A response sent from a server.
@@ -1358,7 +1359,7 @@ private:
         }
         _request.set("Host", host); // Make sure the host is set.
         _request.set("Date", Util::getHttpTimeNow());
-        _request.set("User-Agent", HTTP_AGENT_STRING);
+        _request.set("User-Agent", http::getAgentString());
     }
 
     void onConnect(const std::shared_ptr<StreamSocket>& socket) override

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -9,7 +9,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-#include <config.h>
+#include "config.h"
+#include "config_version.h"
 
 #include "Socket.hpp"
 #include "TraceEvent.hpp"
@@ -753,7 +754,7 @@ void StreamSocket::dumpState(std::ostream& os)
 
 void StreamSocket::send(Poco::Net::HTTPResponse& response)
 {
-    response.set("Server", HTTP_SERVER_STRING);
+    response.set("Server", http::getServerString());
     response.set("Date", Util::getHttpTimeNow());
 
     std::ostringstream oss;
@@ -1316,5 +1317,19 @@ bool StreamSocket::sniffSSL() const
 }
 
 #endif // !MOBILEAPP
+
+// Required by Android and iOS apps.
+namespace http
+{
+    std::string getAgentString()
+    {
+        return "COOLWSD HTTP Agent " COOLWSD_VERSION;
+    }
+
+    std::string getServerString()
+    {
+        return "COOLWSD HTTP Server " COOLWSD_VERSION;
+    }
+}
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -156,7 +156,7 @@ public:
 
         req.set("Host", hostAndPort); // Make sure the host is set.
         req.set("Date", Util::getHttpTimeNow());
-        req.set("User-Agent", HTTP_AGENT_STRING);
+        req.set("User-Agent", http::getAgentString());
 
         req.set("Connection", "Upgrade");
         req.set("Upgrade", "websocket");

--- a/test/HttpTestServer.hpp
+++ b/test/HttpTestServer.hpp
@@ -19,7 +19,7 @@
 #include <chrono>
 #include <string>
 
-#ifndef COOLWSD_VERSION
+#ifndef APP_NAME
 static_assert(false, "config.h must be included in the .cpp being compiled");
 #endif
 

--- a/test/RequestDetailsTests.cpp
+++ b/test/RequestDetailsTests.cpp
@@ -16,6 +16,7 @@
 
 #include <Common.hpp>
 #include <common/Authorization.hpp>
+#include <HttpRequest.hpp>
 #include <RequestDetails.hpp>
 
 #include <cppunit/extensions/HelperMacros.h>
@@ -144,7 +145,7 @@ void RequestDetailsTests::testLocal()
         Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, URI,
                                        Poco::Net::HTTPMessage::HTTP_1_1);
         request.setHost(Root);
-        request.set("User-Agent", WOPI_AGENT_STRING);
+        request.set("User-Agent", http::getAgentString());
         request.set("ProxyPrefix", ProxyPrefix);
 
         RequestDetails details(request, "");
@@ -191,7 +192,7 @@ void RequestDetailsTests::testLocal()
         Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, URI,
                                        Poco::Net::HTTPMessage::HTTP_1_1);
         request.setHost(Root);
-        request.set("User-Agent", WOPI_AGENT_STRING);
+        request.set("User-Agent", http::getAgentString());
         request.set("ProxyPrefix", ProxyPrefix);
 
         RequestDetails details(request, "");
@@ -236,7 +237,7 @@ void RequestDetailsTests::testLocal()
         Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, URI,
                                        Poco::Net::HTTPMessage::HTTP_1_1);
         request.setHost(Root);
-        request.set("User-Agent", WOPI_AGENT_STRING);
+        request.set("User-Agent", http::getAgentString());
         request.set("ProxyPrefix", ProxyPrefix);
 
         RequestDetails details(request, "");
@@ -294,7 +295,7 @@ void RequestDetailsTests::testLocalHexified()
         Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, URI,
                                        Poco::Net::HTTPMessage::HTTP_1_1);
         request.setHost(Root);
-        request.set("User-Agent", WOPI_AGENT_STRING);
+        request.set("User-Agent", http::getAgentString());
         request.set("ProxyPrefix", ProxyPrefix);
 
         RequestDetails details(request, "");
@@ -334,7 +335,7 @@ void RequestDetailsTests::testLocalHexified()
         Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, URI,
                                        Poco::Net::HTTPMessage::HTTP_1_1);
         request.setHost(Root);
-        request.set("User-Agent", WOPI_AGENT_STRING);
+        request.set("User-Agent", http::getAgentString());
         request.set("ProxyPrefix", ProxyPrefix);
 
         RequestDetails details(request, "");
@@ -372,7 +373,7 @@ void RequestDetailsTests::testLocalHexified()
         Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, URI,
                                        Poco::Net::HTTPMessage::HTTP_1_1);
         request.setHost(Root);
-        request.set("User-Agent", WOPI_AGENT_STRING);
+        request.set("User-Agent", http::getAgentString());
         request.set("ProxyPrefix", ProxyPrefix);
 
         RequestDetails details(request, "");
@@ -435,7 +436,7 @@ void RequestDetailsTests::testRequestDetails()
         Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, URI,
                                        Poco::Net::HTTPMessage::HTTP_1_1);
         request.setHost(Root);
-        request.set("User-Agent", WOPI_AGENT_STRING);
+        request.set("User-Agent", http::getAgentString());
         request.set("ProxyPrefix", ProxyPrefix);
 
         RequestDetails details(request, "");
@@ -534,7 +535,7 @@ void RequestDetailsTests::testRequestDetails()
         Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, URI,
                                        Poco::Net::HTTPMessage::HTTP_1_1);
         request.setHost(Root);
-        request.set("User-Agent", WOPI_AGENT_STRING);
+        request.set("User-Agent", http::getAgentString());
         request.set("ProxyPrefix", ProxyPrefix);
 
         RequestDetails details(request, "");
@@ -604,7 +605,7 @@ void RequestDetailsTests::testRequestDetails()
         Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, URI,
                                        Poco::Net::HTTPMessage::HTTP_1_1);
         request.setHost(Root);
-        request.set("User-Agent", WOPI_AGENT_STRING);
+        request.set("User-Agent", http::getAgentString());
         request.set("ProxyPrefix", ProxyPrefix);
 
         RequestDetails details(request, "");
@@ -649,7 +650,7 @@ void RequestDetailsTests::testRequestDetails()
         Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, URI,
                                        Poco::Net::HTTPMessage::HTTP_1_1);
         request.setHost(Root);
-        request.set("User-Agent", WOPI_AGENT_STRING);
+        request.set("User-Agent", http::getAgentString());
         request.set("ProxyPrefix", ProxyPrefix);
 
         RequestDetails details(request, "");
@@ -698,7 +699,7 @@ void RequestDetailsTests::testRequestDetails()
         Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, URI,
                                        Poco::Net::HTTPMessage::HTTP_1_1);
         request.setHost(Root);
-        request.set("User-Agent", WOPI_AGENT_STRING);
+        request.set("User-Agent", http::getAgentString());
         request.set("ProxyPrefix", ProxyPrefix);
 
         RequestDetails details(request, "");

--- a/test/WopiTestServer.hpp
+++ b/test/WopiTestServer.hpp
@@ -11,8 +11,6 @@
 
 #pragma once
 
-#include "config.h"
-
 #include "Protocol.hpp"
 #include "HttpRequest.hpp"
 #include "helpers.hpp"

--- a/test/integration-http-server.cpp
+++ b/test/integration-http-server.cpp
@@ -10,6 +10,7 @@
  */
 
 #include <config.h>
+#include <config_version.h>
 
 #include <helpers.hpp>
 #include <lokassert.hpp>

--- a/tools/ConfigMigrationAssistant.cpp
+++ b/tools/ConfigMigrationAssistant.cpp
@@ -9,6 +9,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include "config.h"
+
 #include <cassert>
 #include <iostream>
 #include <memory>

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -1983,7 +1983,7 @@ private:
         std::shared_ptr<http::Session> httpSession(StorageBase::getHttpSession(fontUri));
         http::Request request(fontUri.getPathAndQuery());
 
-        request.set("User-Agent", WOPI_AGENT_STRING);
+        request.set("User-Agent", http::getAgentString());
 
         const std::shared_ptr<const http::Response> httpResponse
             = httpSession->syncRequest(request);
@@ -2002,7 +2002,7 @@ private:
             request.set("If-None-Match", oldETag);
         }
 
-        request.set("User-Agent", WOPI_AGENT_STRING);
+        request.set("User-Agent", http::getAgentString());
 
         const std::shared_ptr<const http::Response> httpResponse
             = httpSession->syncRequest(request);
@@ -2027,7 +2027,7 @@ private:
             request.set("If-None-Match", oldETag);
         }
 
-        request.set("User-Agent", WOPI_AGENT_STRING);
+        request.set("User-Agent", http::getAgentString());
 
         const std::shared_ptr<const http::Response> httpResponse
             = httpSession->syncRequest(request);
@@ -4362,7 +4362,7 @@ private:
                 response->add("X-XSS-Protection", "1; mode=block");
                 // No referrer-policy
                 response->add("Referrer-Policy", "no-referrer");
-                response->set("Server", HTTP_SERVER_STRING);
+                response->set("Server", http::getServerString());
                 response->add("Content-Type", "text/plain");
                 response->add("X-Content-Type-Options", "nosniff");
 

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -293,7 +293,7 @@ void ClientSession::handleClipboardRequest(DocumentBroker::ClipboardRequest     
             std::ostringstream oss;
             oss << "HTTP/1.1 403 Forbidden\r\n"
                 << "Date: " << Util::getHttpTimeNow() << "\r\n"
-                << "User-Agent: " << WOPI_AGENT_STRING << "\r\n"
+                << "User-Agent: " << http::getAgentString() << "\r\n"
                 << "Content-Length: 0\r\n"
                 << "Connection: close\r\n"
                 << "\r\n";
@@ -320,7 +320,7 @@ void ClientSession::handleClipboardRequest(DocumentBroker::ClipboardRequest     
             std::ostringstream oss;
             oss << "HTTP/1.1 200 OK\r\n"
                 << "Date: " << Util::getHttpTimeNow() << "\r\n"
-                << "User-Agent: " << WOPI_AGENT_STRING << "\r\n"
+                << "User-Agent: " << http::getAgentString() << "\r\n"
                 << "Content-Length: 0\r\n"
                 << "Connection: close\r\n"
                 << "\r\n";
@@ -1949,7 +1949,7 @@ bool ClientSession::handleKitToClientMessage(const std::shared_ptr<Message>& pay
             std::ostringstream oss;
             oss << "HTTP/1.1 200 OK\r\n"
                 << "Last-Modified: " << Util::getHttpTimeNow() << "\r\n"
-                << "User-Agent: " << WOPI_AGENT_STRING << "\r\n"
+                << "User-Agent: " << http::getAgentString() << "\r\n"
                 << "Content-Length: " << (empty ? 0 : (payload->size() - header)) << "\r\n"
                 << "Content-Type: application/octet-stream\r\n"
                 << "X-Content-Type-Options: nosniff\r\n"

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -3323,7 +3323,7 @@ bool DocumentBroker::lookupSendClipboardTag(const std::shared_ptr<StreamSocket> 
             std::ostringstream oss;
             oss << "HTTP/1.1 200 OK\r\n"
                 << "Last-Modified: " << Util::getHttpTimeNow() << "\r\n"
-                << "User-Agent: " << WOPI_AGENT_STRING << "\r\n"
+                << "User-Agent: " << http::getAgentString() << "\r\n"
                 << "Content-Length: " << saved->length() << "\r\n"
                 << "Content-Type: application/octet-stream\r\n"
                 << "X-Content-Type-Options: nosniff\r\n"

--- a/wsd/Exceptions.cpp
+++ b/wsd/Exceptions.cpp
@@ -9,6 +9,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include "config.h"
+
 #include "Exceptions.hpp"
 
 #undef EXCEPTION_DECL

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -666,7 +666,7 @@ void FileServerRequestHandler::handleRequest(const HTTPRequest& request,
                 }
             }
 
-            response.set("Server", HTTP_SERVER_STRING);
+            response.set("Server", http::getServerString());
             response.set("Date", Util::getHttpTimeNow());
 
 #if !MOBILEAPP
@@ -1399,7 +1399,7 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
     oss << "HTTP/1.1 200 OK\r\n"
         "Date: " << Util::getHttpTimeNow() << "\r\n"
         "Last-Modified: " << Util::getHttpTimeNow() << "\r\n"
-        "User-Agent: " << WOPI_AGENT_STRING << "\r\n"
+        "User-Agent: " << http::getAgentString() << "\r\n"
         "Cache-Control:max-age=11059200\r\n"
         "ETag: \"" COOLWSD_VERSION_HASH "\"\r\n"
         "Content-Length: " << preprocess.size() << "\r\n"
@@ -1523,7 +1523,7 @@ void FileServerRequestHandler::preprocessWelcomeFile(const HTTPRequest& request,
     // No referrer-policy
     httpResponse.add("Referrer-Policy", "no-referrer");
     httpResponse.add("X-Content-Type-Options", "nosniff");
-    httpResponse.set("Server", HTTP_SERVER_STRING);
+    httpResponse.set("Server", http::getServerString());
     httpResponse.set("Date", Util::getHttpTimeNow());
 
     httpResponse.setBody(std::move(templateWelcome));
@@ -1634,7 +1634,7 @@ void FileServerRequestHandler::preprocessAdminFile(const HTTPRequest& request,
     // No referrer-policy
     response.add("Referrer-Policy", "no-referrer");
     response.add("X-Content-Type-Options", "nosniff");
-    response.set("Server", HTTP_SERVER_STRING);
+    response.set("Server", http::getServerString());
     response.set("Date", Util::getHttpTimeNow());
 
     response.setContentType("text/html");

--- a/wsd/HostUtil.cpp
+++ b/wsd/HostUtil.cpp
@@ -9,11 +9,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include "config.h"
+
 #include "HostUtil.hpp"
 #include <common/ConfigUtil.hpp>
 #include <common/Log.hpp>
 #include <common/CommandControl.hpp>
-#include <config.h>
 
 Util::RegexListMatcher HostUtil::WopiHosts;
 std::map<std::string, std::string> HostUtil::AliasHosts;

--- a/wsd/ProxyProtocol.cpp
+++ b/wsd/ProxyProtocol.cpp
@@ -59,7 +59,7 @@ void DocumentBroker::handleProxyRequest(
         std::ostringstream oss;
         oss << "HTTP/1.1 200 OK\r\n"
             "Last-Modified: " << Util::getHttpTimeNow() << "\r\n"
-            "User-Agent: " WOPI_AGENT_STRING "\r\n"
+            "User-Agent: " << http::getAgentString() << "\r\n"
             "Content-Length: " << sessionId.size() << "\r\n"
             "Content-Type: application/json; charset=utf-8\r\n"
             "X-Content-Type-Options: nosniff\r\n"
@@ -217,7 +217,7 @@ void ProxyProtocolHandler::handleRequest(bool isWaiting, const std::shared_ptr<S
             std::ostringstream oss;
             oss << "HTTP/1.1 200 OK\r\n"
                 "Last-Modified: " << Util::getHttpTimeNow() << "\r\n"
-                "User-Agent: " WOPI_AGENT_STRING "\r\n"
+                "User-Agent: " << http::getAgentString() << "\r\n"
                 "Content-Length: " << 0 << "\r\n"
                 "\r\n";
             streamSocket->send(oss.str());
@@ -345,7 +345,7 @@ bool ProxyProtocolHandler::flushQueueTo(const std::shared_ptr<StreamSocket> &soc
     std::ostringstream oss;
     oss << "HTTP/1.1 200 OK\r\n"
         "Last-Modified: " << Util::getHttpTimeNow() << "\r\n"
-        "User-Agent: " WOPI_AGENT_STRING "\r\n"
+        "User-Agent: " << http::getAgentString() << "\r\n"
         "Content-Length: " << totalSize << "\r\n"
         "Content-Type: application/json; charset=utf-8\r\n"
         "X-Content-Type-Options: nosniff\r\n"

--- a/wsd/ProxyRequestHandler.cpp
+++ b/wsd/ProxyRequestHandler.cpp
@@ -65,7 +65,7 @@ void ProxyRequestHandler::handleRequest(const std::string& relPath,
 
                         CacheFileHash[httpSession->getUrl()] = httpResponse;
 
-                        httpResponse->add("Server", HTTP_SERVER_STRING);
+                        httpResponse->add("Server", http::getServerString());
                         httpResponse->add("Date", Util::getHttpTimeNow());
                         socket->sendAndShutdown(*httpResponse);
                     }

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -608,7 +608,7 @@ void LockContext::dumpState(std::ostream& os) const
 void WopiStorage::initHttpRequest(Poco::Net::HTTPRequest& request, const Poco::URI& uri,
                                   const Authorization& auth) const
 {
-    request.set("User-Agent", WOPI_AGENT_STRING);
+    request.set("User-Agent", http::getAgentString());
 
     auth.authorizeRequest(request);
 

--- a/wsd/StorageConnectionManager.cpp
+++ b/wsd/StorageConnectionManager.cpp
@@ -82,7 +82,7 @@ std::map<std::string, std::string> GetQueryParams(const Poco::URI& uri)
 void initHttpRequest(Poco::Net::HTTPRequest& request, const Poco::URI& uri,
                      const Authorization& auth)
 {
-    request.set("User-Agent", WOPI_AGENT_STRING);
+    request.set("User-Agent", http::getAgentString());
 
     auth.authorizeRequest(request);
 

--- a/wsd/coolwsd-fork.cpp
+++ b/wsd/coolwsd-fork.cpp
@@ -7,6 +7,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
+#include "config.h"
+
 #include "StringVector.hpp"
 #include "Util.hpp"
 #include "TraceEvent.hpp"

--- a/wsd/coolwsd-inproc.cpp
+++ b/wsd/coolwsd-inproc.cpp
@@ -7,6 +7,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
+#include "config.h"
+
 #include "StringVector.hpp"
 #include "Util.hpp"
 #include "COOLWSD.hpp"


### PR DESCRIPTION
config.h should be included as the 1st line in each source file. It should not be included in headers.

config_version.h which changes on every commit should not be included widely - so remove it from the HttpRequest heeader to save tinderbox's ccache.

Fetch version info from helper methods rather than in-lining via defines, to better encapsulate.


Change-Id: If449a36f1ac61940f04d70d5f4180db389d9b4c4


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

