### PR TITLE
wsd: Blank stored timestamp if an up-load times out.

### DIFF
--- a/test/UnitQuarantine.cpp
+++ b/test/UnitQuarantine.cpp
@@ -32,6 +32,7 @@ class UnitQuarantineConflict : public WOPIUploadConflictCommon
 
     std::string _quarantinePath;
     bool _unloadingModifiedDocDetected;
+    bool _putFailed;
 
     static constexpr std::size_t LimitStoreFailures = 2;
     static constexpr bool SaveOnExit = true;
@@ -61,6 +62,9 @@ public:
 
     void onDocBrokerCreate(const std::string& docKey) override
     {
+        // reset for the next document
+        _putFailed = false;
+
         Base::onDocBrokerCreate(docKey);
 
         if (_scenario == Scenario::VerifyOverwrite)
@@ -104,7 +108,9 @@ public:
         const bool force = wopiTimestamp.empty(); // Without a timestamp we force to always store.
 
         // We don't expect overwriting by forced uploading.
-        LOK_ASSERT_EQUAL_MESSAGE("Unexpected overwritting the document in storage", false, force);
+        LOK_ASSERT_EQUAL_MESSAGE("Unexpected overwritting the document in storage", _putFailed, force);
+
+        _putFailed = true;
 
         // Internal Server Error.
         return std::make_unique<http::Response>(http::StatusCode::InternalServerError);

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -1275,7 +1275,7 @@ void WopiStorage::uploadLocalFileToStorageAsync(const Authorization& auth, LockC
                 httpHeader.set("X-LOOL-WOPI-ExtendedData", attribs.getExtendedData());
             }
 
-            if (!attribs.isForced())
+            if (!attribs.isForced() && isLastModifiedTimeSafe())
             {
                 // Request WOPI host to not overwrite if timestamps mismatch
                 httpHeader.set("X-COOL-WOPI-Timestamp", getLastModifiedTime());
@@ -1520,6 +1520,10 @@ WopiStorage::handleUploadToStorageResponse(const WopiUploadDetails& details,
                     << "]: " << details.httpResponseCode << ' ' << details.httpResponseReason
                     << ": " << responseString);
             result.setResult(StorageBase::UploadResult::Result::FAILED);
+
+            // If we cannot be sure whether we up-loaded successfully eg. we got
+            // a timeout then be tolerant of subsequent timestamp mismatch problems
+            setLastModifiedTimeUnSafe();
         }
     }
     catch (const Poco::Exception& pexc)

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -128,8 +128,14 @@ public:
         /// Set the last modified time as reported to the WOPI host.
         void setLastModifiedTime(const std::string& modifiedTime) { _modifiedTime = modifiedTime; }
 
-        /// Get the last modified time as reported by the WOPI host.
+        /// Get the last modified time as reported by the WOPI host, empty if unsafe to rely on
         const std::string& getLastModifiedTime() const { return _modifiedTime; }
+
+        /// Sometimes an up-load fails, leaving our timestamp in an unknown state
+        bool isLastModifiedTimeSafe() const { return !_modifiedTime.empty(); }
+
+        /// Set last modified time as unsafe
+        void setLastModifiedTimeUnSafe() { _modifiedTime.clear(); }
 
     private:
         std::string _filename;
@@ -367,10 +373,9 @@ public:
     const FileInfo& getFileInfo() const { return _fileInfo; }
 
     const std::string& getLastModifiedTime() const { return _fileInfo.getLastModifiedTime(); }
-    void setLastModifiedTime(const std::string& modifiedTime)
-    {
-        _fileInfo.setLastModifiedTime(modifiedTime);
-    }
+    void setLastModifiedTime(const std::string& modifiedTime) { _fileInfo.setLastModifiedTime(modifiedTime); }
+    bool isLastModifiedTimeSafe() const { return _fileInfo.isLastModifiedTimeSafe(); }
+    void setLastModifiedTimeUnSafe() { _fileInfo.setLastModifiedTimeUnSafe(); }
 
     std::string getFileExtension() const { return Poco::Path(_fileInfo.getFilename()).getExtension(); }
 


### PR DESCRIPTION
Quite possibly we did successfully up-load, or at least our timestamp may not match, but we cannot be sure enough to warn the user in this case. We cannot reliably get notified of remote alteration on the server of files, so wait until a more succesful save or new user join to get an improved timestamp.

Change-Id: I5c8124ed74ba5c26371768ac778b9670282c87a3

forward port to master ...