### PR TITLE
add parameter "theme" to load a document

### DIFF
--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -264,7 +264,26 @@ window.app = {
 
 		// @property lang: String
 		// browser language locale
-		lang: navigatorLang
+		lang: navigatorLang,
+
+		docs: ['presentation', 'spreadsheet', 'text', 'drawing'],
+
+		getTheme: function () {
+			var docTheme;
+			var themes = [];
+			if (global.isLocalStorageAllowed) {
+				for (var theme in global.L.Browser.docs) {
+					docTheme = global.localStorage.getItem('UIDefaults_' +
+									       global.L.Browser.docs[theme] +
+									       '_darkTheme');
+					if (docTheme) {
+						themes.push(global.L.Browser.docs[theme] + ':' +
+							    (docTheme === 'true' ? 'Dark' : 'Light'));
+					}
+				}
+			}
+			return themes.join(';');
+		}
 	};
 
 	global.keyboard = {
@@ -1216,6 +1235,10 @@ window.app = {
 					}
 
 				}
+
+				var docTheme = global.L.Browser.getTheme();
+				if (docTheme)
+					msg += ' theme=' + docTheme;
 
 				msg += ' timezone=' + Intl.DateTimeFormat().resolvedOptions().timeZone;
 

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -143,7 +143,6 @@ L.Control.UIManager = L.Control.extend({
 		else {
 			this.loadLightMode();
 		}
-		this.activateDarkModeInCore(selectedMode);
 	},
 
 	activateDarkModeInCore: function(activate) {

--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -249,6 +249,10 @@ app.definitions.Socket = L.Class.extend({
 			msg += ' accessibilityState=' + accessibilityState;
 		}
 
+		var docTheme = L.Browser.getTheme();
+		if (docTheme)
+			msg += ' theme=' + docTheme;
+
 		this._doSend(msg);
 		for (var i = 0; i < this._msgQueue.length; i++) {
 			this._doSend(this._msgQueue[i]);

--- a/common/Session.cpp
+++ b/common/Session.cpp
@@ -215,6 +215,11 @@ void Session::parseDocOptions(const StringVector& tokens, int& part, std::string
             _accessibilityState = value == "true";
             ++offset;
         }
+        else if (name == "theme")
+        {
+            _theme = value;
+            ++offset;
+        }
     }
 
     Util::mapAnonymized(_userId, _userIdAnonym);

--- a/common/Session.hpp
+++ b/common/Session.hpp
@@ -262,6 +262,8 @@ public:
 
     bool getAccessibilityState() const { return _accessibilityState; }
 
+    const std::string& getTheme() const { return _theme; }
+
 protected:
     Session(const std::shared_ptr<ProtocolHandlerInterface> &handler,
             const std::string& name, const std::string& id, bool readonly);
@@ -381,6 +383,9 @@ private:
 
     /// Specifies whether accessibility support is enabled for this session.
     bool _accessibilityState;
+
+    /// Specifies the theme
+    std::string _theme;
 };
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1279,6 +1279,12 @@ bool ClientSession::loadDocument(const char* /*buffer*/, int /*length*/,
         {
             oss << " batch=" << getBatchMode();
         }
+
+        if (!getTheme().empty())
+        {
+            oss << " theme=" << getTheme();
+        }
+
 #if ENABLE_FEATURE_LOCK
         sendLockedInfo();
 #endif


### PR DESCRIPTION
The UNO command is dispatched to change the theme when loading the
document, it causes serious problems the "kit" process changes the
canonical view id.

So this patch avoids sending UNO command and add a parameter to set
the initial theme.

Change-Id: I523dda19cacd6fd3f81cd86ee554aacd5f73edea
Signed-off-by: Henry Castro <hcastro@collabora.com>
