### PR TITLE
Private/mmeeks/unitfixes

### DIFF
--- a/common/MessageQueue.cpp
+++ b/common/MessageQueue.cpp
@@ -657,6 +657,16 @@ void TileQueue::dumpState(std::ostream& oss)
         separator = ", ";
     }
     oss << "]\n";
+
+    MessageQueue::dumpState(oss);
+}
+
+void MessageQueue::dumpState(std::ostream& oss)
+{
+    oss << "\tQueue size: " << _queue.size() << "\n";
+    size_t i = 0;
+    for (Payload &it : _queue)
+        oss << "\t\t" << i++ << ": " << COOLProtocol::getFirstLine(it) << "\n";
 }
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/common/MessageQueue.hpp
+++ b/common/MessageQueue.hpp
@@ -241,6 +241,8 @@ protected:
         return std::string();
     }
 
+    void dumpState(std::ostream& oss);
+
 private:
     std::vector<Payload> _queue;
 };

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -717,7 +717,8 @@ public:
         _editorChangeWarning(false),
         _lastMemTrimTime(std::chrono::steady_clock::now()),
         _mobileAppDocId(mobileAppDocId),
-        _inputProcessingEnabled(true)
+        _inputProcessingEnabled(true),
+        _duringLoad(0)
     {
         LOG_INF("Document ctor for [" << _docKey <<
                 "] url [" << anonymizeUrl(_url) << "] on child [" << _jailId <<
@@ -951,6 +952,13 @@ public:
         }
 
         return false;
+    }
+
+    void alertNotAsync()
+    {
+        // load unfortunately enables inputprocessing in some cases.
+        if (processInputEnabled() && !_duringLoad)
+            notifyAll("error: cmd=notasync kind=failure");
     }
 
     void alertAllUsers(const std::string& cmd, const std::string& kind) override
@@ -1224,6 +1232,10 @@ private:
     {
         LOG_INF("Loading url [" << uriAnonym << "] for session [" << sessionId <<
                 "] which has " << (_sessions.size() - 1) << " sessions.");
+
+        _duringLoad++;
+        // wouldn't it be nice to have a custom destructor to do this.
+        std::unique_ptr<void, std::function<void(void *)>> guard(nullptr, [&](void*) { _duringLoad--; });
 
         // This shouldn't happen, but for sanity.
         const auto it = _sessions.find(sessionId);
@@ -2118,6 +2130,7 @@ public:
             << "\n\teditorChangeWarning: " << _editorChangeWarning
             << "\n\tmobileAppDocId: " << _mobileAppDocId
             << "\n\tinputProcessingEnabled: " << _inputProcessingEnabled
+            << "\n\tduringLoad: " << _duringLoad
             << "\n";
 
         // dumpState:
@@ -2227,6 +2240,7 @@ private:
 
     const unsigned _mobileAppDocId;
     bool _inputProcessingEnabled;
+    int _duringLoad;
 };
 
 #if !defined BUILDING_TESTS && !MOBILEAPP && !LIBFUZZER
@@ -2415,9 +2429,8 @@ public:
         {
             LOG_ERR("non-async dialog triggered");
 #if !MOBILEAPP
-            if (singletonDocument && lastWarned < reentries &&
-                singletonDocument->processInputEnabled()) // ie. not loading/saving
-                singletonDocument->notifyAll("error: cmd=notasync kind=failure");
+            if (singletonDocument && lastWarned < reentries)
+                singletonDocument->alertNotAsync();
 #endif
             lastWarned = reentries;
         }

--- a/test/UnitBadDocLoad.cpp
+++ b/test/UnitBadDocLoad.cpp
@@ -82,6 +82,7 @@ UnitBase::TestResult UnitBadDocLoad::testBadDocLoadFail()
         auto response = helpers::getResponseString(socket, "error:", testname);
         if (Util::startsWith(response, "error: cmd=notasync"))
         {
+            TST_LOG("Ignoring initial notasync error - waiting again");
             // Continue searching for the interesting failure.
             response =
                 helpers::getResponseString(socket, "error:", testname, std::chrono::seconds(30));


### PR DESCRIPTION
Szymon oddness here re: jsdialog - nowadays I get:

fullyLoadedAndReady]: jsdialog: { "id": "", "type": "messagebox", "text": "Collabora OfficeDev 24.04", "enabled": true, "children": [ { "id": "", "type": "container", "text": "", "enabled": true, "children": [ { "id": "", "type": "container", "text": "", "enabled": true, "child<truncated 3785chars> 
dialogevent 6 {"id":"yes", "cmd": "click", "data": "2", "type": "responsebutton"} 
jsdialog: { "id": 6, "jsontype": "dialog", "action": "close"} 
jsdialog: { "id": "", "type": "messagebox", "text": "Warning", "enabled": true, "visible": false, "children": [ { "id": "", "type": "container", "text": "", "enabled": true, "children": [ { "id": "", "type": "container", "text": "", "enabled": true, "child<truncated 2463chars> 
jsdialog: { "id": "", "type": "messagebox", "text": "Collabora OfficeDev 24.04", "enabled": true, "children": [ { "id": "", "type": "container", "text": "", "enabled": true, "children": [ { "id": "", "type": "container", "text": "", "enabled": true, "child<truncated 2481chars> 
dialogevent 7 {"id":"ok", "cmd": "click", "data": "1", "type": "responsebutton"} 
jsdialog: { "id": 7, "jsontype": "dialog", "action": "close"} 
error: cmd=load kind=faileddocloading 

Might be interesting.