### PR TITLE
calc: cut/paste for a cell content doesn't work in Firefox >= 121

### DIFF
--- a/browser/src/layer/marker/TextInput.js
+++ b/browser/src/layer/marker/TextInput.js
@@ -972,12 +972,12 @@ L.TextInput = L.Layer.extend({
 		this._newlineHint = ev.keyCode === 13;
 		this._linebreakHint = this._newlineHint && ev.shiftKey;
 
-		// In Firefox 117 and greater no copy/cut input event is emitted when CTRL+C/X is pressed
+		// In Firefox 117 up to 120 no copy/cut input event is emitted when CTRL+C/X is pressed
 		// with no selection in a text element with contenteditable='true'. Since no copy/cut event
 		// is emitted, Clipboard.copy/cut is never invoked. So we need to emit it manually.
 		// To be honest it seems a Firefox bug. We need to check if they fix it in later version.
 		if (!this.hasAccessibilitySupport() && !L.Browser.win &&
-			L.Browser.gecko && L.Browser.geckoVersion >= '117.0' &&
+			L.Browser.gecko && L.Browser.geckoVersion >= '117.0' && L.Browser.geckoVersion <= '120.0' &&
 			ev.ctrlKey && window.getSelection().isCollapsed) {
 			if (ev.key === 'c') {
 				document.execCommand('copy');


### PR DESCRIPTION
Limit the workaround for "no copy event is emitted by hitting CTRL+C/X
with no selection" to Firefox version from 117 to 120.

Signed-off-by: Marco Cecchetti <marco.cecchetti@collabora.com>
Change-Id: I00d3addc0330862bf07eebb8d030d1156fc6e321
