### PR TITLE
Avoid exception on view list update (backport 23.05)

### DIFF
--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -960,7 +960,17 @@ L.Control.UIManager = L.Control.extend({
 	},
 
 	onUpdateViews: function () {
-		var userPrivateInfo = this.map._docLayer ? this.map._viewInfo[this.map._docLayer._viewId].userprivateinfo : null;
+		if (!this.map._docLayer)
+			return;
+
+		var myViewId = this.map._docLayer._viewId;
+		var myViewData = this.map._viewInfo[myViewId];
+		if (!myViewData) {
+			console.error('Not found view data for viewId: "' + myViewId + '"');
+			return;
+		}
+
+		var userPrivateInfo = myViewData.userprivateinfo;
 		if (userPrivateInfo) {
 			var apiKey = userPrivateInfo.ZoteroAPIKey;
 			if (apiKey !== undefined && !this.map.zotero) {


### PR DESCRIPTION
Fixes and gives more details for debugging in case of:

INCOMING: viewinfo: [{"id":3,"userid":"admin","username":"admin","userextrainfo":{"avatar":"http://.../avatar/admin/64","is_admin":true},"readonly":"0","color":0}] cool.html:323:37
Exception TypeError: this.map._viewInfo[this.map._docLayer._viewId] is undefined emitting event [object Object] onUpdateViews@http://.....:9980/browser/08e0fd2e1b/src/control/Control.UIManager.js:823:31


Change-Id: I915f4d6e235426d1ae1d12c64629a6e250c16766

