### PR TITLE
cool#8342 browser, clipboard: start improving the paste special dialog's button

### DIFF
--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -1037,7 +1037,7 @@ L.Clipboard = L.Class.extend({
 		this.pasteSpecialDialogId = this._map.uiManager.generateModalId('paste_special_dialog') + '-box';
 
 		var id = 'paste_special_dialog';
-		this._map.uiManager.showYesNoButton(id + '-box', '', '', _('OK'), null, null, null, true);
+		this._map.uiManager.showYesNoButton(id + '-box', '', '', _('Cancel'), null, null, null, true);
 		var box = document.getElementById(id + '-box');
 		var innerDiv = L.DomUtil.create('div', '', null);
 		box.insertBefore(innerDiv, box.firstChild);


### PR DESCRIPTION
If the user doesn't read the text of the dialog, make it clear that
pressing the button will cancel the process, this is not a warning
dialog to be just ignored.

This is a minimal fix that introduces no new l10n strings.