### PR TITLE
UnitBadDocLoad - adapt to new jsdialog behavior.

### DIFF
--- a/test/UnitBadDocLoad.cpp
+++ b/test/UnitBadDocLoad.cpp
@@ -65,21 +65,34 @@ UnitBase::TestResult UnitBadDocLoad::testBadDocLoadFail()
         // Send a load request with incorrect password
         helpers::sendTextFrame(socket, "load url=" + documentURL, testname);
 
+        std::map<std::string, std::string> items;
+
         // We receive jsdialog with question about repair
         const auto dialog = helpers::getResponseString(socket, "jsdialog:", testname);
         LOK_ASSERT_EQUAL(true, dialog.size() > 0);
 
-        // Click "Yes" in a dialog
-        helpers::sendTextFrame(socket, "dialogevent 1 {\"id\":\"yes\", \"cmd\": \"click\", \"data\": \"2\", \"type\": \"responsebutton\"}", testname);
+        // Extract all json entries into a map.
+        items = Util::JsonToMap(dialog.substr(sizeof("jsdialog:")));
+        auto firstId = items["id"];
 
-        // We receive jsdialog with warning that repair failed
-        const auto dialog2 = helpers::getResponseString(socket, "jsdialog:", testname);
-        LOK_ASSERT_EQUAL(true, dialog2.size() > 0);
+        // Click "Yes" in a dialog
+        helpers::sendTextFrame(socket, "dialogevent " + firstId + " {\"id\":\"yes\", \"cmd\": \"click\", \"data\": \"2\", \"type\": \"responsebutton\"}", testname);
+
+        // we can potentially receive multiple jsdialog update messages
+        std::string dialog2;
+        do {
+            dialog2 = helpers::getResponseString(socket, "jsdialog:", testname);
+            LOK_ASSERT_EQUAL(true, dialog2.size() > 0);
+            items = Util::JsonToMap(dialog2.substr(sizeof("jsdialog:")));
+        } while(items["id"] == firstId); // a duplicate update of existing dialog
+
+        // Now we received jsdialog with warning that repair failed
 
         // Click "Ok"
-        helpers::sendTextFrame(socket, "dialogevent 2 {\"id\":\"ok\", \"cmd\": \"click\", \"data\": \"1\", \"type\": \"responsebutton\"}", testname);
+        helpers::sendTextFrame(socket, "dialogevent " + items["id"] + " {\"id\":\"ok\", \"cmd\": \"click\", \"data\": \"1\", \"type\": \"responsebutton\"}", testname);
 
-        const auto response = helpers::getResponseString(socket, "error:", testname);
+        auto response = helpers::getResponseString(socket, "error:", testname);
+
         StringVector tokens(StringVector::tokenize(response, ' '));
         LOK_ASSERT_EQUAL(static_cast<size_t>(3), tokens.size());
 


### PR DESCRIPTION
Parse jsdialog responses, and send the right dialog id to click items on.

Adapt to unexpected multiple updates for the corrupted document warning dialog on load.

Signed-off-by: Michael Meeks <michael.meeks@collabora.com>
Change-Id: I0f934cdc60b2204afc493cf367f98a9cfa0aa6c0 (cherry picked from commit 2be1f8c3457b2966144268c212bcf025a6d6b65b)


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

