### PR TITLE
private/marco/back porting

### DIFF
--- a/browser/src/control/Control.Tabs.js
+++ b/browser/src/control/Control.Tabs.js
@@ -332,6 +332,7 @@ L.Control.Tabs = L.Control.extend({
 
 	//selected sheet is moved to new index
 	_moveSheet: function (newIndex) {
+		this._map._docLayer._sheetSwitch.updateOnSheetMoved(this._map.getPartNumber(), newIndex - 1);
 		this._map.sendUnoCommand('.uno:Move?Copy:bool=false&UseCurrentDocument:bool=true&Index=' + newIndex);
 	},
 
@@ -351,6 +352,8 @@ L.Control.Tabs = L.Control.extend({
 		var contextMenuTab = this._tabForContextMenu;
 		if (contextMenuTab <= 0) return;
 
+		this._map._docLayer._sheetSwitch.updateOnSheetMoved(contextMenuTab, contextMenuTab - 1);
+
 		// core handles the decreasing of contextMenuTab by 1
 		// so, no need to do it here (for the second parameter)
 		this._moveSheetLR(contextMenuTab, contextMenuTab);
@@ -358,6 +361,8 @@ L.Control.Tabs = L.Control.extend({
 
 	_moveSheetRight: function () {
 		var contextMenuTab = this._tabForContextMenu;
+
+		this._map._docLayer._sheetSwitch.updateOnSheetMoved(contextMenuTab, contextMenuTab + 1);
 
 		/*
 		Why there is '+3' ?

--- a/browser/src/control/Parts.js
+++ b/browser/src/control/Parts.js
@@ -302,6 +302,7 @@ L.Map.include({
 			app.socket.sendMessage('uno .uno:InsertPage');
 		}
 		else if (this.getDocType() === 'spreadsheet') {
+			this._docLayer._sheetSwitch.updateOnSheetInsertion(nPos);
 			var command = {
 				'Name': {
 					'type': 'string',
@@ -362,6 +363,7 @@ L.Map.include({
 			app.socket.sendMessage('uno .uno:DeletePage');
 		}
 		else if (this.getDocType() === 'spreadsheet') {
+			this._docLayer._sheetSwitch.updateOnSheetDeleted(nPos);
 			var command = {
 				'Index': {
 					'type': 'long',

--- a/browser/src/control/Parts.js
+++ b/browser/src/control/Parts.js
@@ -26,6 +26,7 @@ L.Map.include({
 		if (docLayer.isCalc())
 			docLayer._sheetSwitch.save(part /* toPart */);
 
+		docLayer._clearMsgReplayStore();
 		docLayer._prevSelectedPart = docLayer._selectedPart;
 		docLayer._selectedParts = [];
 		if (part === 'prev') {

--- a/browser/src/layer/marker/TextInput.js
+++ b/browser/src/layer/marker/TextInput.js
@@ -964,12 +964,12 @@ L.TextInput = L.Layer.extend({
 		this._newlineHint = ev.keyCode === 13;
 		this._linebreakHint = this._newlineHint && ev.shiftKey;
 
-		// In Firefox 117 and greater no copy/cut input event is emitted when CTRL+C/X is pressed
+		// In Firefox 117 up to 120 no copy/cut input event is emitted when CTRL+C/X is pressed
 		// with no selection in a text element with contenteditable='true'. Since no copy/cut event
 		// is emitted, Clipboard.copy/cut is never invoked. So we need to emit it manually.
 		// To be honest it seems a Firefox bug. We need to check if they fix it in later version.
 		if (!this.hasAccessibilitySupport() && !L.Browser.win &&
-			L.Browser.gecko && L.Browser.geckoVersion >= '117.0' &&
+			L.Browser.gecko && L.Browser.geckoVersion >= '117.0' && L.Browser.geckoVersion <= '120.0' &&
 			ev.ctrlKey && window.getSelection().isCollapsed) {
 			if (ev.key === 'c') {
 				document.execCommand('copy');

--- a/kit/TestStubs.cpp
+++ b/kit/TestStubs.cpp
@@ -21,6 +21,7 @@
 
 void ChildSession::loKitCallback(const int /* type */, const std::string& /* payload */) {}
 void ChildSession::disconnect() {}
+int ChildSession::getSpeed() { return 0; }
 bool ChildSession::_handleInput(const char* /*buffer*/, int /*length*/) { return false; }
 bool ChildSession::isTileInsideVisibleArea(const TileDesc& /*tile*/) const { return false; }
 ChildSession::~ChildSession() {}


### PR DESCRIPTION
- fix linking error for clang 17
- calc: cut/paste for a cell content doesn't work in Firefox >= 121
- calc: on tab switching do not replay print twips messages
- calc: on tab switching document view can be restored to a wrong position ￼…
