### PR TITLE
Fix sporadically failing autofilter test, simplify autofilter and other calc tests

### DIFF
--- a/cypress_test/integration_tests/common/calc_helper.js
+++ b/cypress_test/integration_tests/common/calc_helper.js
@@ -194,20 +194,26 @@ function ensureViewContainsCellCursor() {
 	});
 }
 
+function assertSheetContents(expectedData) {
+	selectEntireSheet();
+	assertDataClipboardTable(expectedData);
+}
+
 function assertDataClipboardTable(expectedData) {
 	cy.cGet('#copy-paste-container table td')
 		.should(function(cells) {
 			expect(cells).to.have.lengthOf(expectedData.length);
 		});
 
-	// Wait for clipboard to update anyways, in case previous contents were same length
+	// Wait for clipboard to update anyways, in case we get here before the
+	// update because the new contents are the same length as the previous
 	cy.wait(200);
 
 	var data = [];
 
 	cy.cGet('#copy-paste-container tbody').find('td').each(($el) => {
-		cy.wrap($el)
-			.invoke('text')
+		cy.wrap($el,{log: false})
+			.invoke({log: false}, 'text')
 			.then(text => {
 				data.push(text);
 			});
@@ -240,6 +246,6 @@ module.exports.removeTextSelection = removeTextSelection;
 module.exports.selectEntireSheet = selectEntireSheet;
 module.exports.selectFirstColumn = selectFirstColumn;
 module.exports.ensureViewContainsCellCursor = ensureViewContainsCellCursor;
-module.exports.assertDataClipboardTable = assertDataClipboardTable;
+module.exports.assertSheetContents = assertSheetContents;
 module.exports.selectCellsInRange = selectCellsInRange;
 module.exports.openAutoFilterMenu = openAutoFilterMenu;

--- a/cypress_test/integration_tests/desktop/calc/autofilter_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/autofilter_spec.js
@@ -110,20 +110,19 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'AutoFilter', function() {
 	});
 
 	it('Close autofilter popup by click outside', function() {
+		// Test sometimes fails without this wait, no idea why.
+		cy.wait(1000);
+
 		calcHelper.openAutoFilterMenu();
 
 		cy.cGet('.autofilter .vertical').should('be.visible');
-
 		cy.cGet('div.jsdialog-overlay').should('be.visible');
-
 		cy.cGet('div.jsdialog-overlay').click();
 
-		cy.cGet('.jsdialog.autofilter').should('not.exist');
-
-		// check if spreadsheet is interactive - prevent core block by hanging popup
+		// Wait for autofilter dialog to close
+		cy.cGet('div.autofilter').should('not.exist');
 
 		calcHelper.dblClickOnFirstCell();
-
 		helper.typeIntoDocument('New content{enter}');
 
 		calcHelper.selectEntireSheet();
@@ -144,9 +143,6 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'AutoFilter', function() {
 		
 		//Click on `Filter by Color`
 		cy.cGet('body').contains('.autofilter', 'Filter by Color').click();
-
-		//wait after apply filter by color filter
-		cy.wait(500);
 
 		// Find the table element with ID "background"
 		cy.cGet('table#background')

--- a/cypress_test/integration_tests/desktop/calc/open_different_file_types_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/open_different_file_types_spec.js
@@ -29,11 +29,6 @@ describe.skip(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Open different file t
 	});
 
 	function assertData() {
-		//select all the content of doc
-		calcHelper.selectEntireSheet();
-
-		helper.waitUntilIdle('#copy-paste-container');
-
 		var expectedData = [
 			'0', 'First Name', 'Last Name', 'Gender', 'Country', 'Age', 'Date', 'Id',
 			'1', 'Dulce', 'Abril', 'Female', 'United States', '32', '15/10/2017', '1562',
@@ -41,8 +36,7 @@ describe.skip(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Open different file t
 			'3', 'Philip', 'Gent', 'Male', 'France', '36', '21/05/2015', '2587',
 			'4', 'Kathleen', 'Hanner', 'Female', 'United States', '25', '15/10/2017', '3549',
 		];
-
-		calcHelper.assertDataClipboardTable(expectedData);
+		calcHelper.assertSheetContents(expectedData);
 	}
 
 	it('Open xls file', { defaultCommandTimeout: 60000 }, function () {

--- a/cypress_test/integration_tests/desktop/calc/row_column_operation_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/row_column_operation_spec.js
@@ -9,8 +9,7 @@ describe(['tagdesktop'], 'Row Column Operation', function() {
 	beforeEach(function() {
 		helper.beforeAll(testFileName, 'calc');
 		desktopHelper.switchUIToNotebookbar();
-		calcHelper.selectEntireSheet();
-		calcHelper.assertDataClipboardTable(['Hello','Hi','World','Bye']);
+		calcHelper.assertSheetContents(['Hello','Hi','World','Bye']);
 		calcHelper.clickOnFirstCell(true,false);
 		cy.cGet('#toolbar-up .w2ui-scroll-right').click();
 	});
@@ -23,39 +22,33 @@ describe(['tagdesktop'], 'Row Column Operation', function() {
 		//Insert row above
 		cy.cGet('#home-insert-columns-before-button').click();
 
-		calcHelper.selectEntireSheet();
-		//calcHelper.assertDataClipboardTable(['','','Hello','Hi','World','Bye']);
+		//calcHelper.assertSheetContents(['','','Hello','Hi','World','Bye']);
 		//delete row
 		calcHelper.clickOnFirstCell(true, false);
 
 		cy.cGet('#home-delete-rows-button').click();
-		calcHelper.selectEntireSheet();
-		//calcHelper.assertDataClipboardTable(['Hello','Hi','World','Bye']);
+		//calcHelper.assertSheetContents(['Hello','Hi','World','Bye']);
 
 		//insert row below
 		calcHelper.clickOnFirstCell(true, false);
 		cy.cGet('#home-insert-rows-after-button').click();
-		calcHelper.selectEntireSheet();
-		//calcHelper.assertDataClipboardTable(['Hello','Hi','','','World','Bye']);
+		//calcHelper.assertSheetContents(['Hello','Hi','','','World','Bye']);
 	});
 
 	it('Insert/Delete Column', function() {
 		//insert column before
 		cy.cGet('#home-insert-columns-before-button').click();
-		calcHelper.selectEntireSheet();
-		//calcHelper.assertDataClipboardTable(['','Hello','Hi','','World','Bye']);
+		//calcHelper.assertSheetContents(['','Hello','Hi','','World','Bye']);
 		calcHelper.clickOnFirstCell(true, false);
 
 		//delete column
 		cy.cGet('#home-delete-columns-button').click();
-		calcHelper.selectEntireSheet();
 		cy.wait(500);
-		//calcHelper.assertDataClipboardTable(['Hello','Hi','World','Bye']);
+		//calcHelper.assertSheetContents(['Hello','Hi','World','Bye']);
 		calcHelper.clickOnFirstCell(true,false);
 
 		//insert column after
 		cy.cGet('#home-insert-columns-after-button').click();
-		calcHelper.selectEntireSheet();
-		//calcHelper.assertDataClipboardTable(['Hello','','Hi','World','','Bye']);
+		//calcHelper.assertSheetContents(['Hello','','Hi','World','','Bye']);
 	});
 });

--- a/cypress_test/integration_tests/idle/calc/idle_spec.js
+++ b/cypress_test/integration_tests/idle/calc/idle_spec.js
@@ -22,11 +22,7 @@ describe(['tagdesktop'], 'Idle', function() {
 		const content = 'New content';
 		helper.typeIntoDocument(content + '{enter}');
 
-		calcHelper.selectEntireSheet();
-
-		helper.waitUntilIdle('#copy-paste-container tbody');
-
-		calcHelper.assertDataClipboardTable(['C' + content + 'ypress Test', 'Status', 'Test 1', 'Pass', 'Test 2', 'Fail', 'Test 3', 'Pass', 'Test 4', '', 'Test 5', 'Fail']);
+		calcHelper.assertSheetContents(['C' + content + 'ypress Test', 'Status', 'Test 1', 'Pass', 'Test 2', 'Fail', 'Test 3', 'Pass', 'Test 4', '', 'Test 5', 'Fail']);
 	}
 
 	it('Check idle out of focus', function() {

--- a/cypress_test/integration_tests/mobile/calc/autofilter_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/autofilter_spec.js
@@ -12,8 +12,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'AutoFilter', function() {
 		testFileName = helper.beforeAll(origTestFileName, 'calc');
 		// Click on edit button
 		mobileHelper.enableEditingMobile();
-		calcHelper.selectEntireSheet();
-		calcHelper.assertDataClipboardTable(['Cypress Test', 'Status', 'Test 1', 'Pass', 'Test 2', 'Fail', 'Test 3', 'Pass', 'Test 4', '', 'Test 5', 'Fail']);
+		calcHelper.assertSheetContents(['Cypress Test', 'Status', 'Test 1', 'Pass', 'Test 2', 'Fail', 'Test 3', 'Pass', 'Test 4', '', 'Test 5', 'Fail']);
 	});
 
 	afterEach(function() {
@@ -28,8 +27,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'AutoFilter', function() {
 		// Wait for autofilter dialog to close
 		cy.cGet('.mobile-wizard').should('not.exist');
 
-		calcHelper.selectEntireSheet();
-		calcHelper.assertDataClipboardTable(['Cypress Test', 'Status', 'Test 5', 'Fail', 'Test 4', '', 'Test 3', 'Pass', 'Test 2', 'Fail', 'Test 1', 'Pass']);
+		calcHelper.assertSheetContents(['Cypress Test', 'Status', 'Test 5', 'Fail', 'Test 4', '', 'Test 3', 'Pass', 'Test 2', 'Fail', 'Test 1', 'Pass']);
 
 		//sort by ascending order
 		calcHelper.openAutoFilterMenu();
@@ -38,7 +36,6 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'AutoFilter', function() {
 		// Wait for autofilter dialog to close
 		cy.cGet('.mobile-wizard').should('not.exist');
 
-		calcHelper.selectEntireSheet();
-		calcHelper.assertDataClipboardTable(['Cypress Test', 'Status', 'Test 1', 'Pass', 'Test 2', 'Fail', 'Test 3', 'Pass', 'Test 4', '', 'Test 5', 'Fail']);
+		calcHelper.assertSheetContents(['Cypress Test', 'Status', 'Test 1', 'Pass', 'Test 2', 'Fail', 'Test 3', 'Pass', 'Test 4', '', 'Test 5', 'Fail']);
 	});
 });

--- a/cypress_test/integration_tests/mobile/calc/row_column_operation_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/row_column_operation_spec.js
@@ -11,9 +11,7 @@ describe.skip(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Row Column Operation',
 
 		mobileHelper.enableEditingMobile();
 
-		calcHelper.selectEntireSheet();
-
-		calcHelper.assertDataClipboardTable(['Hello','Hi','World','Bye']);
+		calcHelper.assertSheetContents(['Hello','Hi','World','Bye']);
 
 		calcHelper.clickOnFirstCell(true,false);
 	});
@@ -36,44 +34,38 @@ describe.skip(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Row Column Operation',
 		//Insert row above
 		selectOption('Insert Rows', 'Rows Above');
 
-		calcHelper.selectEntireSheet();
-		calcHelper.assertDataClipboardTable(['','','Hello','Hi','World','Bye']);
+		calcHelper.assertSheetContents(['','','Hello','Hi','World','Bye']);
 		//delete row
 		calcHelper.clickOnFirstCell(true, false);
 
 		selectOption('Delete Rows');
 
-		calcHelper.selectEntireSheet();
-		calcHelper.assertDataClipboardTable(['Hello','Hi','World','Bye']);
+		calcHelper.assertSheetContents(['Hello','Hi','World','Bye']);
 
 		//insert row below
 		calcHelper.clickOnFirstCell(true, false);
 
 		selectOption('Insert Rows', 'Rows Below');
 
-		calcHelper.selectEntireSheet();
-		calcHelper.assertDataClipboardTable(['Hello','Hi','','','World','Bye']);
+		calcHelper.assertSheetContents(['Hello','Hi','','','World','Bye']);
 	});
 
 	it('Insert/Delete Column', function() {
 		//insert column before
 		selectOption('Insert Columns', 'Columns Before');
 
-		calcHelper.selectEntireSheet();
-		calcHelper.assertDataClipboardTable(['','Hello','Hi','','World','Bye']);
+		calcHelper.assertSheetContents(['','Hello','Hi','','World','Bye']);
 		calcHelper.clickOnFirstCell(true, false);
 
 		//delete column
 		selectOption('Delete Columns');
 
-		calcHelper.selectEntireSheet();
-		calcHelper.assertDataClipboardTable(['Hello','Hi','World','Bye']);
+		calcHelper.assertSheetContents(['Hello','Hi','World','Bye']);
 		calcHelper.clickOnFirstCell(true,false);
 
 		//insert column after
 		selectOption('Insert Columns', 'Columns After');
 
-		calcHelper.selectEntireSheet();
-		calcHelper.assertDataClipboardTable(['Hello','','Hi','World','','Bye']);
+		calcHelper.assertSheetContents(['Hello','','Hi','World','','Bye']);
 	});
 });

--- a/cypress_test/integration_tests/multiuser/calc/repair_document_spec.js
+++ b/cypress_test/integration_tests/multiuser/calc/repair_document_spec.js
@@ -19,11 +19,9 @@ describe.skip('Repair Document', function() {
 		cy.cSetActiveFrame(frameId1);
 		helper.typeIntoDocument('Hello World{enter}');
 		cy.cSetActiveFrame(frameId2);
-		calcHelper.selectEntireSheet();
-		calcHelper.assertDataClipboardTable(['Hello World\n']);
+		calcHelper.assertSheetContents(['Hello World\n']);
 		cy.cSetActiveFrame(frameId1);
-		calcHelper.selectEntireSheet();
-		calcHelper.assertDataClipboardTable(['Hello World\n']);
+		calcHelper.assertSheetContents(['Hello World\n']);
 		cy.cSetActiveFrame(frameId2);
 		cy.cGet('#menu-editmenu').click().cGet('#menu-repair').click();
 		cy.cGet('#DocumentRepairDialog').should('exist');


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
Commit 1:
The autofilter test was failing quite often in the tinderbox. It regularly failed and then passed on rerun locally.
I could not figure out exactly why, but I added a wait so that it will pass.

Commit 2:
I also cleaned up the verification of sheet contents, replacing the custom autofilter function with the one in calc_helper. And I wrapped the function with one whose name says what it does (assert the sheet contents) instead of how it does it (look at the clipboard).

### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

