### PR TITLE
C++17 Remove checks on std::filesystem

### DIFF
--- a/common/FileUtil.cpp
+++ b/common/FileUtil.cpp
@@ -32,21 +32,10 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <filesystem>
 #include <fstream>
 #include <mutex>
 #include <string>
-
-#if HAVE_STD_FILESYSTEM
-# if HAVE_STD_FILESYSTEM_EXPERIMENTAL
-#  include <experimental/filesystem>
-namespace filesystem = ::std::experimental::filesystem;
-# else
-#  include <filesystem>
-namespace filesystem = ::std::filesystem;
-# endif
-#else
-# include <Poco/TemporaryFile.h>
-#endif
 
 #include <Poco/File.h>
 #include <Poco/Path.h>
@@ -60,11 +49,7 @@ namespace FileUtil
     std::string createRandomDir(const std::string& path)
     {
         std::string name = Util::rng::getFilename(64);
-#if HAVE_STD_FILESYSTEM
-        filesystem::create_directory(path + '/' + name);
-#else
-        Poco::File(Poco::Path(path, name)).createDirectories();
-#endif
+        std::filesystem::create_directory(path + '/' + name);
         return name;
     }
 
@@ -151,11 +136,7 @@ namespace FileUtil
     std::string getSysTempDirectoryPath()
     {
         // Don't const to allow for automatic move on return.
-#if HAVE_STD_FILESYSTEM
-        std::string path = filesystem::temp_directory_path();
-#else
-        std::string path = Poco::Path::temp();
-#endif
+        std::string path = std::filesystem::temp_directory_path();
 
         if (!path.empty())
             return path;
@@ -231,9 +212,9 @@ namespace FileUtil
 #if 0 // HAVE_STD_FILESYSTEM
         std::error_code ec;
         if (recursive)
-            filesystem::remove_all(path, ec);
+            std::filesystem::remove_all(path, ec);
         else
-            filesystem::remove(path, ec);
+            std::filesystem::remove(path, ec);
 
         // Already removed or we don't care about failures.
         (void) ec;

--- a/config.h.in
+++ b/config.h.in
@@ -55,12 +55,6 @@
 /* Define to 1 if you have the `ppoll' function. */
 #define HAVE_PPOLL 0
 
-/* Whether the used C++ has support for std::filesystem. */
-#undef HAVE_STD_FILESYSTEM
-
-/* Whether the std::filesystem is in the experimental header. */
-#undef HAVE_STD_FILESYSTEM_EXPERIMENTAL
-
 /* Default value of help root URL */
 #undef HELP_URL
 

--- a/configure.ac
+++ b/configure.ac
@@ -1050,49 +1050,6 @@ AC_SUBST(HAVE_CLANG)
 AS_IF([test "$ENABLE_GTKAPP" != true],
 [CXXFLAGS="$CXXFLAGS $CXXFLAGS_CXXSTD"])
 
-STD_FILESYSTEM=
-if test "$HAVE_CXXSTD" = TRUE -a "$ENABLE_ANDROIDAPP" != "true" ; then
-    save_CXXFLAGS=$CXXFLAGS
-    CXXFLAGS="$CXXFLAGS -Werror"
-    save_LIBS=$LIBS
-    LIBS="$save_LIBS -lstdc++fs"
-    AC_LANG_PUSH([C++])
-    AC_LINK_IFELSE([AC_LANG_SOURCE([[
-        #include <experimental/filesystem>
-        int main()
-        {
-            if (!std::experimental::filesystem::temp_directory_path().empty())
-                return 0;
-            return 1;
-        }
-        ]])],[STD_FILESYSTEM=experimental])
-    AC_LINK_IFELSE([AC_LANG_SOURCE([[
-        #include <filesystem>
-        int main()
-        {
-            if (!std::filesystem::temp_directory_path().empty())
-                return 0;
-            return 1;
-        }
-        ]])],[STD_FILESYSTEM=TRUE])
-    AC_LANG_POP([C++])
-    CXXFLAGS=$save_CXXFLAGS
-    LIBS=$save_LIBS
-fi
-
-if test -n "$STD_FILESYSTEM" ; then
-    LIBS="$LIBS -lstdc++fs"
-    AC_DEFINE([HAVE_STD_FILESYSTEM],1,[Whether the used C++ has support for std::filesystem.])
-    if test "$STD_FILESYSTEM" = "experimental" ; then
-        AC_DEFINE([HAVE_STD_FILESYSTEM_EXPERIMENTAL],1,[Whether the std::filesystem is in the experimental header.])
-    else
-        AC_DEFINE([HAVE_STD_FILESYSTEM_EXPERIMENTAL],0,[Whether the std::filesystem is in the experimental header.])
-    fi
-else
-    AC_DEFINE([HAVE_STD_FILESYSTEM],0,[Whether the used C++ has support for std::filesystem.])
-    AC_DEFINE([HAVE_STD_FILESYSTEM_EXPERIMENTAL],0,[Whether the std::filesystem is in the experimental header.])
-fi
-
 SYS_RANDOM=
 AC_LANG_PUSH([C++])
 AC_LINK_IFELSE(

--- a/test/helpers.hpp
+++ b/test/helpers.hpp
@@ -38,26 +38,15 @@
 #include <net/WebSocketSession.hpp>
 #include <wsd/TileDesc.hpp>
 
-#include <iterator>
-#include <fstream>
-#include <string>
 #include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <string>
 #include <thread>
 
 #ifndef TDOC
 #error TDOC must be defined (see Makefile.am)
-#endif
-
-#if HAVE_STD_FILESYSTEM
-# if HAVE_STD_FILESYSTEM_EXPERIMENTAL
-#  include <experimental/filesystem>
-namespace filesystem = ::std::experimental::filesystem;
-# else
-#  include <filesystem>
-namespace filesystem = ::std::filesystem;
-# endif
-#else
-# include <Poco/TemporaryFile.h>
 #endif
 
 // Sometimes we need to retry some commands as they can (due to timing or load) soft-fail.
@@ -128,7 +117,6 @@ std::vector<char> readDataFromFile(std::unique_ptr<std::fstream>& file)
 
 namespace
 {
-#if HAVE_STD_FILESYSTEM
 /// Class to delete files when the process ends.
 class FileDeleter
 {
@@ -140,7 +128,7 @@ public:
     {
         std::unique_lock<std::mutex> guard(_lock);
         for (const std::string& file: _filesToDelete)
-            filesystem::remove(file);
+            std::filesystem::remove(file);
     }
 
     void registerForDeletion(const std::string& file)
@@ -149,7 +137,6 @@ public:
         _filesToDelete.push_back(file);
     }
 };
-#endif
 }
 
 /// Make a temp copy of a file, and prepend it with a prefix.
@@ -157,7 +144,6 @@ public:
 inline std::string getTempFileCopyPath(const std::string& srcDir, const std::string& srcFilename, const std::string& dstFilenamePrefix)
 {
     const std::string srcPath = srcDir + '/' + srcFilename;
-#if HAVE_STD_FILESYSTEM
     std::string dstPath;
 
     bool retry;
@@ -165,9 +151,9 @@ inline std::string getTempFileCopyPath(const std::string& srcDir, const std::str
         std::string dstFilename = dstFilenamePrefix + Util::encodeId(Util::rng::getNext()) + '_' + srcFilename;
 
         retry = false;
-        dstPath = filesystem::temp_directory_path() / dstFilename;
+        dstPath = std::filesystem::temp_directory_path() / dstFilename;
         try {
-            filesystem::copy(srcPath, dstPath);
+            std::filesystem::copy(srcPath, dstPath);
         }
         catch (const std::exception& ex)
         {
@@ -178,13 +164,6 @@ inline std::string getTempFileCopyPath(const std::string& srcDir, const std::str
 
     static FileDeleter fileDeleter;
     fileDeleter.registerForDeletion(dstPath);
-#else
-    const std::string dstFilename = dstFilenamePrefix + Util::encodeId(Util::rng::getNext()) + '_' + srcFilename;
-    const std::string dstPath = Poco::Path(Poco::Path::temp(), dstFilename).toString();
-    copyFileTo(srcPath, dstPath);
-    Poco::TemporaryFile::registerForDeletion(dstPath);
-#endif
-
     return dstPath;
 }
 


### PR DESCRIPTION
Should be fully supported on compilers now.

Except leave this workaround in place for now:
b30757417b73180bb02c0e3f20b194ece1516ea1

Change-Id: I6e19ec034b3c64e66f5bf5ff1f436f94514fabd0

* Target version: master 
### Checklist

- [X] Code is properly formatted
- [X] All commits have Change-Id
- [ ] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

