### PR TITLE
annotation: remove empty comment on losing focus

### DIFF
--- a/browser/src/layer/tile/CommentSection.ts
+++ b/browser/src/layer/tile/CommentSection.ts
@@ -954,7 +954,9 @@ export class Comment extends CanvasSectionObject {
 	public onLostFocus (e: any): void {
 		if (!this.sectionProperties.isRemoved) {
 			$(this.sectionProperties.container).removeClass('annotation-active reply-annotation-container modify-annotation-container');
-			if (this.sectionProperties.contentText.origText !== this.sectionProperties.nodeModifyText.value) {
+			if (this.sectionProperties.nodeModifyText.value === '') {
+				this.onCancelClick(e);
+			} else if (this.sectionProperties.contentText.origText !== this.sectionProperties.nodeModifyText.value) {
 				if (!this.sectionProperties.contentText.unedited)
 					this.sectionProperties.contentText.unedited = this.sectionProperties.contentText.origText;
 				cool.CommentSection.autoSavedComment = this;


### PR DESCRIPTION
problem:
when try to insert comment and comment field is empty, click on some other comment, it will cause an empty comment insertion in DOM which can not be removed until doc reload. This subsequently prevented new comment insertion.


Change-Id: Idccf77d29730a3ca81ecf8ba2c3c9e4d6029a3e3


* Target version: master 


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

