### PR TITLE
Enable search input in keyboard shortcut dialog and refactor main section selection query

### DIFF
--- a/browser/html/cool-help.html
+++ b/browser/html/cool-help.html
@@ -85,7 +85,7 @@
             <tr class="sub-section"> <td class="function">Focus to selected comment's menu</td> <td class="shortcut"><kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>C</kbd></td> </tr>
         </table>
     </div>
-    <div id="text-shortcuts" style="display: none;">
+    <div id="text-shortcuts" class="text" style="display: none;">
       <div class="section">
         <h2 class="section-header">Text formatting</h2>
         <table class="help">
@@ -192,7 +192,7 @@
         </table>
       </div>
     </div>
-    <div id="spreadsheet-shortcuts" style="display: none;">
+    <div id="spreadsheet-shortcuts" class="spreadsheet" style="display: none;">
       <div class="section">
         <h2 class="section-header">Navigating in Spreadsheets</h2>
           <table class="help">
@@ -247,7 +247,7 @@
         </table>
         </div>
     </div>
-    <div id="presentation-shortcuts" style="display: none;">
+    <div id="presentation-shortcuts" class="presentation" style="display: none;">
         <div class="section">
         <h2 class="section-header">Text formatting</h2>
         <table class="help">
@@ -312,7 +312,7 @@
         </table>
         </div>
     </div>
-        <div id="drawing-shortcuts" style="display: none;">
+        <div id="drawing-shortcuts" class="presentation" style="display: none;">
         <div class="section">
         <h2 class="section-header">Text formatting</h2>
         <table class="help">

--- a/browser/html/cool-help.html
+++ b/browser/html/cool-help.html
@@ -47,6 +47,18 @@
     button:active { color: -webkit-activelink; }
     button:focus { outline: -webkit-focus-ring-color auto 1px; }
 
+    .hide {
+      display: none;
+    }
+
+    .show {
+      display: block;
+    }
+
+    tr.show {
+      display: table-row; 
+    }
+
     #online-help-search-input {
       width: 30%;
       padding: 5px 10px 5px 15px;

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -576,16 +576,22 @@ L.Map.include({
 				startFilter = false;
 			}
 			else {
-				this.filterResults(searchTerm, isAnyMatchingContent);
+				this.filterResults(searchTerm, isAnyMatchingContent, id);
 			}
 		}.bind(this));
 	},
 
 
-	filterResults: function (searchTerm, isAnyMatchingContent) {
+	filterResults: function (searchTerm, isAnyMatchingContent, id) {
 
-		// Select main sections
-		var mainSections = document.querySelectorAll('.section');
+		var mainDiv = document.getElementById(id);
+		// Combine query parameters to select main sections
+		var mainSectionsQuery = '.section:not(div.text .section, div.spreadsheet .section, div.presentation .section)';
+		var docType = this.getDocType() === 'drawing' ? 'presentation' : this.getDocType();
+		mainSectionsQuery += ', div.' + docType + ' .section';
+
+		// Select nain sections elements within the mainDiv
+		var mainSections = mainDiv.querySelectorAll(mainSectionsQuery);
 		isAnyMatchingContent = false;
 
 		// Loop through each main section

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -552,7 +552,6 @@ L.Map.include({
 		var searchInput = document.getElementById('online-help-search-input');
 		searchInput.focus(); // auto focus on user input field
 		var helpContentParent = document.getElementsByClassName('ui-dialog-content')[0];
-		searchInput.focus();
 		var startFilter = false;
 		var isAnyMatchingContent = false;
 		searchInput.addEventListener('input', function () {
@@ -563,9 +562,9 @@ L.Map.include({
 				document.querySelectorAll('#online-help-content > *:not(a), .link-section p, .product-header').forEach(function (element) {
 					// Check if the element has class text, spreadsheet, or presentation
 					if (!element.classList.contains('text') && !element.classList.contains('spreadsheet') && !element.classList.contains('presentation')) {
-						element.style.display = 'none';
+						this.hide(element);
 					}
-				});
+				}.bind(this));
 
 				startFilter = true;
 			}
@@ -614,12 +613,12 @@ L.Map.include({
 					mainSection.style.backgroundColor = '';
 					mainSection.style.paddingInline = '';
 					mainSection.style.borderRadius = '';
-					subSection.style.display = 'block';
-				});
+					this.show(subSection);
+				}.bind(this));
 				mainSection.style.backgroundColor = 'var(--color-background-lighter)';
 				mainSection.style.paddingInline = '12px';
 				mainSection.style.borderRadius = 'var(--border-radius-large)';
-				mainSection.style.display = 'block';
+				this.show(mainSection);
 			}
 			else {
 				// else Loop through each sub-section and display subsections with matching text has search term
@@ -627,22 +626,22 @@ L.Map.include({
 					// Highlight matching sub-sections
 					if (subSection.textContent.toLowerCase().includes(searchTerm.toLowerCase())) {
 						subSection.style.color = 'var(--color-text-darker)';
-						subSection.style.display = 'block';
+						this.show(subSection);
 						mainSection.style.backgroundColor = 'var(--color-background-lighter)';
 						mainSection.style.paddingInline = '12px';
 						mainSection.style.borderRadius = 'var(--border-radius-large)';
 						// make sure main section of matched subsection is visible
-						mainSection.style.display = 'block';
+						this.show(mainSection);
 						subSectionContainsTerm = true;
 					} else {
 						subSection.style.color = ''; // Remove previous highlighting
-						subSection.style.display = 'none';
+						this.hide(subSection);
 					}
-				});
+				}.bind(this));
 			}
 
 			if (!subSectionContainsTerm && !containsTerm) {
-				mainSection.style.display = 'none';
+				this.hide(mainSection);
 			}
 			else {
 				isAnyMatchingContent = true;
@@ -666,19 +665,29 @@ L.Map.include({
 		var mainSections = document.querySelectorAll('.section');
 		mainSections.forEach(function(mainSection) {
 			mainSection.style.backgroundColor = '';
-			mainSection.style.display = 'block';
+			this.show(mainSection);
 
 			var subSections = mainSection.querySelectorAll('.sub-section');
 			subSections.forEach(function(subSection) {
-				subSection.style.display = 'block';
-			});
-		});
+				this.show(subSection);
+			}.bind(this));
+		}.bind(this));
 
 		// select all event scroll elements, main-header elements, product header elements and make visible to user if search term is empty
 		document.querySelectorAll('.m-v-0, .product-header, .help-dialog-header').forEach(function(element) {
-			element.style.display = 'block';
+			this.show(element);
 			element.style.backgroundColor = '';
-		});
+		}.bind(this));
+	},
+
+	show: function(element) {
+		element.classList.remove('hide');
+		element.classList.add('show');
+	},
+
+	hide: function(element) {
+		element.classList.remove('show');
+		element.classList.add('hide');
 	},
 
 	_doOpenHelpFile: function(data, id, map) {

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -451,7 +451,6 @@ L.Map.include({
 			else if (map.getDocType() === 'drawing') {
 				document.getElementById('drawing-shortcuts').style.display='block';
 			}
-			document.getElementById('online-help-search-input').style.display='none';
 		} else /* id === 'online-help' */ {
 			document.getElementById('keyboard-shortcuts-content').style.display='none';
 			if (window.socketProxy) {


### PR DESCRIPTION
   Enable search input in keyboard shortcut dialog
   
   Refactor main section selection query
      -  Select section based on dialog type (either "help-content" or "Keyboard-shortcut-content")
      -  There are some section specific to DOCTYPE, so only consider the section based on current DOCTYPE
    
   Refactor show/hide section code
      -  we need to add display clock or table-row according to section tag
      -  add generic function to show or hide any section or subsection

