### PR TITLE
ui-tooltip: don't inherit the same shadow values as regular overlays

### DIFF
--- a/browser/css/jquery-ui-lightness.css
+++ b/browser/css/jquery-ui-lightness.css
@@ -938,6 +938,9 @@ body .ui-tooltip,
 	color: var(--color-main-text);
 	background: var(--color-background-lighter);
 }
+.ui-tooltip.ui-widget-shadow {
+	box-shadow: 0px 0px 4px 0 var(--color-box-shadow);
+}
 
 /* Interaction states
 ----------------------------------*/


### PR DESCRIPTION
what: jquery ui-tooltip visible when user hovers buttons in the
notebookbar on when user starts a formula in calc (helpful floating
tooltip appears)

Before this commit, ui-tooltip was being set with a harsh
shadow making it more of a main element than a simple tooltip. Best to
don't inherit that strong shadow from .ui-widget-shadow (used in
overlays) and instead set a new one just for tooltip elements.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ibf3ad525f97decc1d82ca7172ca1fb2bb7c1a6f2
