### PR TITLE
cypress: replace incorrect class name checking

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -506,11 +506,11 @@ nav.spreadsheet-color-indicator ~ #sidebar-dock-wrapper {
 	max-width: 250px;
 }
 
-.cool-annotation.tracked-deteled-comment-show {
+.cool-annotation.tracked-deleted-comment-show {
 	opacity: 0.5;
 }
 
-.cool-annotation.tracked-deteled-comment-hide {
+.cool-annotation.tracked-deleted-comment-hide {
 	display: none;
 }
 

--- a/browser/src/layer/tile/CommentSection.ts
+++ b/browser/src/layer/tile/CommentSection.ts
@@ -742,11 +742,11 @@ export class Comment extends CanvasSectionObject {
 	}
 
 	public setLayoutClass(): void {
-		this.sectionProperties.container.classList.remove('tracked-deteled-comment-show');
-		this.sectionProperties.container.classList.remove('tracked-deteled-comment-hide');
+		this.sectionProperties.container.classList.remove('tracked-deleted-comment-show');
+		this.sectionProperties.container.classList.remove('tracked-deleted-comment-hide');
 
 		var showTrackedChanges: boolean = this.map['stateChangeHandler'].getItemValue('.uno:ShowTrackedChanges') === 'true';
-		var layoutClass: string = showTrackedChanges ? 'tracked-deteled-comment-show' : 'tracked-deteled-comment-hide';
+		var layoutClass: string = showTrackedChanges ? 'tracked-deleted-comment-show' : 'tracked-deleted-comment-hide';
 		if (this.sectionProperties.data.layoutStatus === CommentLayoutStatus.DELETED) {
 			this.sectionProperties.container.classList.add(layoutClass);
 		}

--- a/cypress_test/integration_tests/desktop/writer/track_changes_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/track_changes_spec.js
@@ -64,7 +64,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Track Changes', function (
 		cy.cGet('#comment-container-2').should('contain','some text1');
 		cy.cGet('#comment-container-2 .cool-annotation-menubar').click();
 		cy.cGet('body').contains('.context-menu-item', 'Remove').click();
-		cy.cGet('#comment-container-2').should('have.class','greyed');
+		cy.cGet('#comment-container-2').should('have.class','tracked-deleted-comment-show');
 		cy.cGet('#comment-container-2').should('contain','some text1');
 		cy.cGet('div.cool-annotation').should('have.length', 3);
 
@@ -104,14 +104,14 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Track Changes', function (
 		cy.cGet('#comment-container-2').should('contain','some text1');
 		cy.cGet('#comment-container-2 .cool-annotation-menubar').click();
 		cy.cGet('body').contains('.context-menu-item', 'Remove').click();
-		cy.cGet('#comment-container-2').should('have.class','greyed');
+		cy.cGet('#comment-container-2').should('have.class','tracked-deleted-comment-show');
 		cy.cGet('#comment-container-2').should('contain','some text1');
 		cy.cGet('div.cool-annotation').should('have.length', 3);
 
 		confirmChange('Reject All');
 		cy.cGet('#comment-container-1').should('contain','some text0');
 		cy.cGet('#comment-container-2').should('contain','some text1');
-		cy.cGet('#comment-container-2').should('not.have.class','greyed');
+		cy.cGet('#comment-container-2').should('not.have.class','tracked-deleted-comment-show');
 		cy.cGet('#comment-container-3').should('not.exist');
 		cy.cGet('div.cool-annotation').should('have.length', 2);
 
@@ -160,12 +160,12 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Track Changes', function (
 		cy.cGet('#comment-container-2').should('contain','some text1');
 		cy.cGet('#comment-container-2 .cool-annotation-menubar').click();
 		cy.cGet('body').contains('.context-menu-item', 'Remove').click();
-		cy.cGet('#comment-container-2').should('have.class','greyed');
+		cy.cGet('#comment-container-2').should('have.class','tracked-deleted-comment-show');
 		cy.cGet('div.cool-annotation').should('have.length', 3);
 		cy.cGet('#tb_editbar_item_undo').click();
 
 		cy.cGet('#comment-container-2').should('contain','some text1');
-		cy.cGet('#comment-container-2').should('not.have.class','greyed');
+		cy.cGet('#comment-container-2').should('not.have.class','tracked-deleted-comment-show');
 		cy.cGet('div.cool-annotation').should('have.length', 3);
 
 		// redo
@@ -173,7 +173,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Track Changes', function (
 		cy.wait(500);
 
 		cy.cGet('#comment-container-2').should('contain','some text1');
-		cy.cGet('#comment-container-2').should('have.class','greyed');
+		cy.cGet('#comment-container-2').should('have.class','tracked-deleted-comment-show');
 		cy.cGet('div.cool-annotation').should('have.length', 3);
 
 	});


### PR DESCRIPTION
regression from 4a2e256


Change-Id: Icddb4e5ef631574773e716e02df1a20ac078d44f


* Target version: master 



### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

