### PR TITLE
Fix zoom button click in cypress tests (part 2)

### DIFF
--- a/cypress_test/integration_tests/common/desktop_helper.js
+++ b/cypress_test/integration_tests/common/desktop_helper.js
@@ -188,11 +188,9 @@ function zoomOut() {
 // zoomLevel - a number specifing the zoom level  (e.g. '100' means 100%).
 //             See also the status bar's zoom level list for possible values.
 function selectZoomLevel(zoomLevel) {
-	// We cannot interact with this menu if it's not visible
-	makeZoomItemsVisible();
-
-	cy.cGet('#tb_actionbar_item_zoom .w2ui-button').click();
-	cy.cGet('#w2ui-overlay-actionbar').contains('.menu-text', zoomLevel).click();
+	// Force because sometimes the icons are scrolled off the screen to the right
+	cy.cGet('#tb_actionbar_item_zoom .w2ui-button').click({force: true});
+	cy.cGet('#w2ui-overlay-actionbar').contains('.menu-text', zoomLevel).click({force: true});
 	shouldHaveZoomLevel(zoomLevel);
 }
 


### PR DESCRIPTION
Use force click on buttons instead of scrolling the statusbar to make them visible


Change-Id: Ib6e7eadcfb02f47e7bd4b44c71f44387f0b19168


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
Previous change (https://github.com/CollaboraOnline/online/pull/8362) did not fix all failures.

### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

