### PR TITLE
Keyboard shortcuts dialog: don't allow width to change after opened

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1910,6 +1910,12 @@ kbd,
 	min-width: 75%;
 }
 
+/* Keyboard shortcuts */
+#modal-dialog-keyboard-shortcuts-content-box {
+	width: 468px;
+	max-width: 95%; /* Safe guard for when window is too small */
+}
+
 /* Calc -> Insert -> Pivot Table */
 #PivotTableLayout #box2 {
 	grid-gap: 12px; /* make space for vertical separator */


### PR DESCRIPTION
With the inclusion of the searching (actually filtering) input field
the dialog would change width mid typing. Example: 1. open dialog: the
width would be x; 2 type something in the search box: the width would
be < x. Better to set a fixed width so if the biggest element is
hidden the dialog doesn't change in size.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I6662433388efa66812317f60a4e0a6bf36e5e98a
