### PR TITLE
Use a map for users and rerender all on changes

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -360,7 +360,7 @@ COOL_JS_LST =\
 	src/control/Control.SearchBar.js \
 	src/control/Control.MobileTopBar.js \
 	src/control/Control.MobileBottomBar.js \
-	src/control/Control.UserList.js \
+	src/control/Control.UserList.ts \
 	src/control/Control.FormulaBar.js \
 	src/control/Control.FormulaBarJSDialog.js \
 	src/control/Control.SheetsBar.js \
@@ -763,7 +763,7 @@ pot:
 		src/control/Control.Toolbar.js \
 		src/control/Control.TopToolbar.js \
 		src/control/Control.UIManager.js \
-		src/control/Control.UserList.js \
+		src/control/Control.UserList.ts \
 		src/control/Control.Zotero.js \
 		src/control/Parts.js \
 		src/control/Permission.js \

--- a/browser/package.json
+++ b/browser/package.json
@@ -9,6 +9,7 @@
     "@types/jqueryui": "^1.12.21",
     "@types/mocha": "8.2.0",
     "@types/node": "14.14.25",
+    "@types/w2ui": "^1.4.37",
     "@typescript-eslint/eslint-plugin": "^4.21.0",
     "@typescript-eslint/parser": "^4.21.0",
     "autolinker": "3.14.1",

--- a/browser/package.json
+++ b/browser/package.json
@@ -4,6 +4,9 @@
   "description": "Collabora Online front-end",
   "devDependencies": {
     "@braintree/sanitize-url": "6.0.2",
+    "@types/jquery": "^3.5.29",
+    "@types/jquery.contextmenu": "^1.7.38",
+    "@types/jqueryui": "^1.12.21",
     "@types/mocha": "8.2.0",
     "@types/node": "14.14.25",
     "@typescript-eslint/eslint-plugin": "^4.21.0",
@@ -27,7 +30,7 @@
     "shrinkpack": "1.0.0-alpha",
     "smartmenus": "1.0.0",
     "stylelint": "13.7.0",
-    "typescript": "4.2.3",
+    "typescript": "4.4.2",
     "uglify-js": "3.17.4",
     "uglifycss": "0.0.29",
     "uglifyify": "5.0.2"

--- a/browser/src/control/Control.UserList.ts
+++ b/browser/src/control/Control.UserList.ts
@@ -12,9 +12,36 @@
  * L.Control.UserList
  */
 
-/* global $ w2ui _ */
-L.Control.UserList = L.Control.extend({
+interface UserExtraInfo {
+	avatar: string;
+}
+
+interface User {
+	userName: string;
+	viewId: number;
+	extraInfo: UserExtraInfo;
+	color: string;
+}
+
+interface UserEvent {
+	username: string;
+	extraInfo: UserExtraInfo;
+	color: string;
+	viewId: number;
+	readonly: boolean;
+}
+
+class UserList extends L.Control {
 	options: {
+		userLimitHeader: number,
+		userPopupTimeout: null | ReturnType<typeof setTimeout>,
+		userJoinedPopupMessage: string,
+		userLeftPopupMessage: string,
+		nUsers?: string,
+		oneUser?: string,
+		noUser?: string,
+		listUser?: User[]
+	} = {
 		userLimitHeader: 6,
 		userPopupTimeout: null,
 		userJoinedPopupMessage: '<div>' + _('%user has joined') + '</div>',
@@ -23,12 +50,9 @@ L.Control.UserList = L.Control.extend({
 		oneUser: undefined,
 		noUser: undefined,
 		listUser: []
-	},
+	};
 
-	initialize: function () {
-	},
-
-	onAdd: function (map) {
+	onAdd(map: ReturnType<typeof L.map>) {
 		this.map = map;
 
 		map.on('addview', this.onAddView, this);
@@ -46,20 +70,20 @@ L.Control.UserList = L.Control.extend({
 			this.options.noUser = _('0 users');
 		}
 
-		map.on('updateEditorName', function(e) {
+		map.on('updateEditorName', function(e: UserEvent) {
 			$('#currently-msg').show();
 			$('#current-editor').text(e.username);
 		});
 
 
 		this.registerHeaderAvatarEvents();
-	},
+	}
 
-	escapeHtml: function(input) {
+	escapeHtml(input: string) {
 		return $('<div>').text(input).html();
-	},
+	}
 
-	selectUser: function(viewId) {
+	selectUser(viewId: number) {
 		var userlistItem = w2ui['actionbar'].get('userlist');
 		if (userlistItem === null) {
 			return;
@@ -67,9 +91,9 @@ L.Control.UserList = L.Control.extend({
 
 		$('#user-' + viewId).addClass('selected-user');
 		L.DomUtil.addClass(document.querySelector('#userListPopover .user-list-item[data-view-id="' + viewId + '"]'), 'selected-user');
-	},
+	}
 
-	followUser: function(viewId) {
+	followUser(viewId: number) {
 		$('#userListPopover').hide();
 		var docLayer = this.map._docLayer;
 		this.map._goToViewId(viewId);
@@ -87,10 +111,10 @@ L.Control.UserList = L.Control.extend({
 		docLayer._followEditor = false;
 
 		this.selectUser(viewId);
-	},
+	}
 
-	onUseritemClicked: function(e) { // eslint-disable-line no-unused-vars
-		var viewId = parseInt(e.currentTarget.id.replace('user-', ''));
+	onUseritemClicked(e: MouseEvent | TouchEvent) {
+		var viewId = parseInt((e.currentTarget as HTMLElement).id.replace('user-', ''));
 
 		if (viewId === this.map._docLayer._viewId) {
 			w2ui['actionbar'].uncheck('userlist');
@@ -98,9 +122,9 @@ L.Control.UserList = L.Control.extend({
 		}
 
 		w2ui['actionbar'].uncheck('userlist');
-	},
+	}
 
-	createAvatar: function (viewId, userName, extraInfo, color) {
+	createAvatar(viewId: number, _userName: string, extraInfo: UserExtraInfo, color: string) {
 		var img;
 		if (extraInfo !== undefined && extraInfo.avatar !== undefined) {
 			img = L.DomUtil.create('img', 'avatar-img');
@@ -115,9 +139,9 @@ L.Control.UserList = L.Control.extend({
 		img.setAttribute('data-view-id', viewId);
 		L.LOUtil.checkIfImageExists(img);
 		return img;
-	},
+	}
 
-	getUserItem: function(viewId, userName, extraInfo, color) {
+	getUserItem(viewId: number, userName: string, extraInfo: UserExtraInfo, color: string) {
 		var content = L.DomUtil.create('tr', 'useritem');
 		content.id = 'user-' + viewId;
 		$(document).on('click', '#' + content.id, this.onUseritemClicked.bind(this));
@@ -129,10 +153,10 @@ L.Control.UserList = L.Control.extend({
 		nameTd.textContent = userName;
 
 		return content;
-	},
+	}
 
-	registerHeaderAvatarEvents: function() {
-		var outsideClickListener = function(e) {
+	registerHeaderAvatarEvents() {
+		var outsideClickListener = function(e: MouseEvent) {
 			$('.main-nav.hasnotebookbar').css('overflow', 'scroll hidden');
 			var selector = '#userListPopover';
 			var $target = $(e.target);
@@ -153,18 +177,18 @@ L.Control.UserList = L.Control.extend({
 			}
 			document.addEventListener('click', outsideClickListener);
 		});
-	},
+	}
 
-	hideUserList: function() {
-		return window.ThisIsAMobileApp ||
+	hideUserList() {
+		return (window as any /* TODO: remove cast after gh#8221 */).ThisIsAMobileApp ||
 		(this.map['wopi'].HideUserList !== null && this.map['wopi'].HideUserList !== undefined &&
 			($.inArray('true', this.map['wopi'].HideUserList) >= 0) ||
 			(window.mode.isMobile() && $.inArray('mobile', this.map['wopi'].HideUserList) >= 0) ||
 			(window.mode.isTablet() && $.inArray('tablet', this.map['wopi'].HideUserList) >= 0) ||
 			(window.mode.isDesktop() && $.inArray('desktop', this.map['wopi'].HideUserList) >= 0));
-	},
+	}
 
-	renderHeaderAvatars: function() {
+	renderHeaderAvatars() {
 		if (window.mode.isMobile() || this.hideUserList() || this.options.listUser.length === 1) {
 			document.getElementById('userListSummary').removeAttribute('accesskey');
 			return;
@@ -177,22 +201,22 @@ L.Control.UserList = L.Control.extend({
 		Array.from(document.querySelectorAll('#userListSummary [data-view-id]')).map(function(element) {
 			return element.getAttribute('data-view-id');
 		}).filter(function(viewId) {
-			return headerUserList.map(function(user) {
+			return headerUserList.map(function(user: User) {
 				return user.viewId;
-			}).indexOf(viewId) === -1;
+			}).indexOf(parseInt(viewId)) === -1;
 		}).forEach(function(viewId) {
 			L.DomUtil.remove(document.querySelector('#userListSummary [data-view-id="' + viewId + '"]'));
 		});
 
 		// Summary rendering
-		headerUserList.forEach(function (user) {
+		headerUserList.forEach(function (user: User) {
 			if (!document.querySelector('#userListSummary [data-view-id="' + user.viewId + '"]')) {
 				document.getElementById('userListSummary').appendChild(this.createAvatar(user.viewId, user.userName, user.extraInfo, user.color));
 			}
 		}.bind(this));
 
 		// Popover rendering
-		this.options.listUser.forEach(function (user) {
+		this.options.listUser.forEach(function (user: User) {
 			if (document.querySelector('#userListPopover .user-list-item[data-view-id="' + user.viewId + '"]')) {
 				return;
 			}
@@ -225,8 +249,8 @@ L.Control.UserList = L.Control.extend({
 			var followEditorCheckbox = L.DomUtil.create('input', 'follow-editor-checkbox', followEditorWrapper);
 			followEditorCheckbox.id = 'follow-editor-checkbox';
 			followEditorCheckbox.setAttribute('type', 'checkbox');
-			followEditorCheckbox.onchange = function(event) {
-				window.editorUpdate(event);
+			followEditorCheckbox.onchange = function(event: Event) {
+				(window as any /* TODO: remove cast after gh#8221 */).editorUpdate(event);
 			};
 			var followEditorCheckboxLabel = L.DomUtil.create('label', 'follow-editor-label', followEditorWrapper);
 			followEditorCheckboxLabel.innerText = _('Always follow the editor');
@@ -235,10 +259,10 @@ L.Control.UserList = L.Control.extend({
 			document.getElementById('userListPopover').appendChild(followEditorWrapper);
 		}
 
-		document.getElementById('follow-editor-checkbox').checked = this.map._docLayer._followEditor;
-	},
+		(document.getElementById('follow-editor-checkbox') as HTMLInputElement).checked = this.map._docLayer._followEditor;
+	}
 
-	removeUserFromHeaderAvatars: function(viewId) {
+	removeUserFromHeaderAvatars(viewId: number) {
 		var index = null;
 		this.options.listUser.forEach(function(item, idx) {
 			if (item.viewId == viewId) {
@@ -250,9 +274,9 @@ L.Control.UserList = L.Control.extend({
 		L.DomUtil.remove(document.querySelector('#userListPopover .user-list-item[data-view-id="' + viewId + '"]'));
 		this.options.listUser.splice(index, 1);
 		this.renderHeaderAvatars();
-	},
+	}
 
-	updateUserListCount: function() {
+	updateUserListCount() {
 		var actionbar = w2ui.actionbar;
 		var userlistItem = actionbar && actionbar.get('userlist');
 		if (userlistItem == null) {
@@ -277,9 +301,9 @@ L.Control.UserList = L.Control.extend({
 			actionbar.hide('userlist');
 			actionbar.hide('userlistbreak');
 		}
-	},
+	}
 
-	deselectUser: function(e) {
+	deselectUser(e: UserEvent) {
 		var userlistItem = w2ui['actionbar'].get('userlist');
 		if (userlistItem === null) {
 			return;
@@ -287,13 +311,12 @@ L.Control.UserList = L.Control.extend({
 
 		$('#user-' + e.viewId).removeClass('selected-user');
 		L.DomUtil.removeClass(document.querySelector('#userListPopover .user-list-item[data-view-id="' + e.viewId + '"]'), 'selected-user');
-	},
+	}
 
-	onOpenUserList: function() {
-		var that = this;
-		setTimeout(function () {
+	onOpenUserList() {
+		setTimeout(() => {
 			var cBox = $('#follow-checkbox')[0];
-			var docLayer = that.map._docLayer;
+			var docLayer = this.map._docLayer;
 			var editorId = docLayer._editorId;
 			var viewId = docLayer._followThis;
 			var followUser = docLayer._followUser;
@@ -301,17 +324,17 @@ L.Control.UserList = L.Control.extend({
 			if (cBox)
 				cBox.checked = docLayer._followEditor;
 
-			if (docLayer.editorId !== -1 && that.map._viewInfo[editorId])
-				$('#current-editor').text(that.map._viewInfo[editorId].username);
+			if (docLayer.editorId !== -1 && this.map._viewInfo[editorId])
+				$('#current-editor').text(this.map._viewInfo[editorId].username);
 			else
 				$('#currently-msg').hide();
 
 			if (followUser)
-				that.selectUser(viewId);
+				this.selectUser(viewId);
 		}, 100);
-	},
+	}
 
-	onAddView: function(e) {
+	onAddView(e: UserEvent) {
 		var userlistItem = w2ui['actionbar'].get('userlist');
 		var username = this.escapeHtml(e.username);
 		var showPopup = false;
@@ -327,11 +350,10 @@ L.Control.UserList = L.Control.extend({
 					style: 'padding: 5px'
 				});
 			clearTimeout(this.options.userPopupTimeout);
-			var that = this;
-			this.options.userPopupTimeout = setTimeout(function() {
+			this.options.userPopupTimeout = setTimeout(() => {
 				$('#tb_actionbar_item_userlist').w2overlay('');
-				clearTimeout(that.options.userPopupTimeout);
-				that.options.userPopupTimeout = null;
+				clearTimeout(this.options.userPopupTimeout);
+				this.options.userPopupTimeout = null;
 			}, 3000);
 		}
 
@@ -354,10 +376,9 @@ L.Control.UserList = L.Control.extend({
 
 		this.options.listUser.push({viewId: e.viewId, userName: username, extraInfo: e.extraInfo, color: color});
 		this.renderHeaderAvatars();
-	},
+	}
 
-	onRemoveView: function(e) {
-		var that = this;
+	onRemoveView(e: UserEvent) {
 		var username = this.escapeHtml(e.username);
 		$('#tb_actionbar_item_userlist')
 			.w2overlay({
@@ -366,10 +387,10 @@ L.Control.UserList = L.Control.extend({
 				style: 'padding: 5px'
 			});
 		clearTimeout(this.options.userPopupTimeout);
-		this.options.userPopupTimeout = setTimeout(function() {
+		this.options.userPopupTimeout = setTimeout(() => {
 			$('#tb_actionbar_item_userlist').w2overlay('');
-			clearTimeout(that.options.userPopupTimeout);
-			that.options.userPopupTimeout = null;
+			clearTimeout(this.options.userPopupTimeout);
+			this.options.userPopupTimeout = null;
 		}, 3000);
 
 		if (e.viewId === this.map._docLayer._followThis) {
@@ -383,11 +404,11 @@ L.Control.UserList = L.Control.extend({
 			this.updateUserListCount();
 			this.removeUserFromHeaderAvatars(e.viewId);
 		}
-	},
-});
+	}
+}
 
 L.control.userList = function () {
-	return new L.Control.UserList();
+	return new UserList();
 };
 
 L.control.createUserListWidget = function () {

--- a/browser/src/layer/marker/Cursor.ts
+++ b/browser/src/layer/marker/Cursor.ts
@@ -1,6 +1,5 @@
 /* eslint-disable */
 
-declare var $: any;
 declare var L: any;
 
 /*

--- a/browser/src/layer/tile/CommentListSection.ts
+++ b/browser/src/layer/tile/CommentListSection.ts
@@ -43,7 +43,6 @@ L.Map.include({
 
 declare var L: any;
 declare var app: any;
-declare var $: any;
 declare var _: any;
 
 namespace cool {

--- a/browser/src/layer/tile/CommentSection.ts
+++ b/browser/src/layer/tile/CommentSection.ts
@@ -14,7 +14,6 @@ declare var app: any;
 declare var _: any;
 declare var Autolinker: any;
 declare var Hammer: any;
-declare var $: any;
 
 namespace cool {
 

--- a/browser/src/layer/tile/TilesSection.ts
+++ b/browser/src/layer/tile/TilesSection.ts
@@ -11,7 +11,6 @@
 /* See CanvasSectionContainer.ts for explanations. */
 
 declare var L: any;
-declare var $: any;
 declare var Hammer: any;
 declare var app: any;
 

--- a/browser/src/w2overlay.d.ts
+++ b/browser/src/w2overlay.d.ts
@@ -1,0 +1,3 @@
+interface JQuery {
+	w2overlay: any;
+}


### PR DESCRIPTION
This stops us from iterating through dom elements to modify them
directly, which should make it easier for us to reorder them or change
their state at relevant points. Additionally, using a Map rather than a
list will make it easier to address users by their view ID which will
help modify specific users (e.g. for following status)

Signed-off-by: Skyler Grey <skyler.grey@collabora.com>
Change-Id: I2e6ca67bfde2519e13a66a25e10d50bb02a88700
