### PR TITLE
Fix desktop/writer/statusbar_spec.js

### DIFF
--- a/cypress_test/integration_tests/desktop/writer/statusbar_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/statusbar_spec.js
@@ -40,6 +40,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Statubar tests.', function
 	it('Text entering mode.', function() {
 		cy.cGet('#InsertMode').should('have.text', 'Insert');
 		helper.typeIntoDocument('{insert}');
+		cy.cGet('.ui-dialog-titlebar-close').click();
 		cy.cGet('#InsertMode').should('have.text', 'Overwrite');
 		helper.typeIntoDocument('{insert}');
 		cy.cGet('#InsertMode').should('have.text', 'Insert');


### PR DESCRIPTION
Close confirm overwrite dialog after pressing insert

The test was failing because there is a dialog to confirm entering overwrite mode. I couldn't find exactly when or where the dialog was introduced.

Annoyingly, the dialog is just a canvas so I couldn't easily click the yes or no button from cypress. Fortunately, the close button is clickable and continues entering overwrite mode.

Change-Id: I4dacb731c70b1bfd9bcbc2134f6e3cd7e242d468


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

