### PR TITLE
annotation: don't count deleted reply when tracked change show off (backport)

### DIFF
--- a/browser/src/layer/tile/CommentListSection.ts
+++ b/browser/src/layer/tile/CommentListSection.ts
@@ -1748,7 +1748,9 @@ export class CommentSection extends CanvasSectionObject {
 				var j = i;
 				while (this.sectionProperties.commentList[j] && j <= lastIndex) {
 					if (this.sectionProperties.commentList[j].sectionProperties.data.parent !== '0') {
-						if (this.sectionProperties.commentList[j].sectionProperties.data.resolved !== 'true') {
+						if ((this.sectionProperties.commentList[j].sectionProperties.data.layoutStatus !== CommentLayoutStatus.DELETED ||
+							this.map['stateChangeHandler'].getItemValue('.uno:ShowTrackedChanges') === 'true') &&
+							this.sectionProperties.commentList[j].sectionProperties.data.resolved !== 'true') {
 							replyCount++;
 						}
 					}


### PR DESCRIPTION
problem:
when tracked change show is off, and reply is deleted, it will not be visible so but count shows it, it may cause counfusion to user


Change-Id: I730ebb1b5909b3db75611b5b6d60498d0b796c58


* Target version: distro/collabora/co-23.05 

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

