### PR TITLE
annotation: avoid resetting comment show state if being edited

### DIFF
--- a/browser/src/layer/tile/CommentSection.ts
+++ b/browser/src/layer/tile/CommentSection.ts
@@ -760,7 +760,7 @@ export class Comment extends CanvasSectionObject {
 		if ((<any>window).mode.isMobile() && this.sectionProperties.container.parentElement === document.getElementById('document-container'))
 			this.sectionProperties.container.style.visibility = 'hidden';
 
-		if (cool.CommentSection.commentWasAutoAdded)
+		if (cool.CommentSection.commentWasAutoAdded || this.isEdit())
 			return;
 		if (this.sectionProperties.docLayer._docType === 'text')
 			this.showWriter();


### PR DESCRIPTION
problem:
when try to insert comment and comment field is empty, click on some other comment, it will cause an empty comment insertion in DOM which can not be removed until doc reload. This subsequently prevented new comment insertion.


Change-Id: I4abb521653cf28ddc89f182988674db5885f29fb

* Target version: master 


- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

