### PR TITLE
Fix cypress impress text position test failures

### DIFF
--- a/cypress_test/integration_tests/desktop/impress/top_toolbar_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/top_toolbar_spec.js
@@ -17,8 +17,6 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Top toolbar tests.', funct
 		} else {
 			desktopHelper.hideSidebar();
 		}
-
-		impressHelper.selectTextShapeInTheCenter();
 	});
 
 	afterEach(function() {
@@ -26,6 +24,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Top toolbar tests.', funct
 	});
 
 	it('Apply bold on text shape.', function() {
+		impressHelper.selectTextShapeInTheCenter();
 		cy.cGet('#tb_editbar_item_bold').click();
 
 		impressHelper.triggerNewSVGForShapeInTheCenter();
@@ -34,6 +33,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Top toolbar tests.', funct
 	});
 
 	it('Apply italic on text shape.', function() {
+		impressHelper.selectTextShapeInTheCenter();
 		cy.cGet('#tb_editbar_item_italic').click();
 
 		impressHelper.triggerNewSVGForShapeInTheCenter();
@@ -42,6 +42,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Top toolbar tests.', funct
 	});
 
 	it('Apply underline on text shape.', function() {
+		impressHelper.selectTextShapeInTheCenter();
 		cy.cGet('#tb_editbar_item_underline').click();
 
 		impressHelper.triggerNewSVGForShapeInTheCenter();
@@ -50,6 +51,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Top toolbar tests.', funct
 	});
 
 	it('Apply strikethrough on text shape.', function() {
+		impressHelper.selectTextShapeInTheCenter();
 		cy.cGet('#tb_editbar_item_strikeout').click();
 
 		impressHelper.triggerNewSVGForShapeInTheCenter();
@@ -58,6 +60,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Top toolbar tests.', funct
 	});
 
 	it('Apply font color on text shape.', function() {
+		impressHelper.selectTextShapeInTheCenter();
 		cy.cGet('#tb_editbar_item_fontcolor').click();
 		desktopHelper.selectColorFromPalette('FF011B');
 
@@ -67,6 +70,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Top toolbar tests.', funct
 	});
 
 	it('Apply highlight color on text shape.', function() {
+		impressHelper.selectTextShapeInTheCenter();
 		cy.cGet('#tb_editbar_item_backcolor').click();
 		desktopHelper.selectColorFromPalette('FF9838');
 
@@ -77,6 +81,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Top toolbar tests.', funct
 	});
 
 	it('Apply a selected font name on the text shape', function() {
+		impressHelper.selectTextShapeInTheCenter();
 		cy.cGet('#tb_editbar_item_fonts').click();
 		desktopHelper.selectFromListbox('Liberation Mono');
 
@@ -86,6 +91,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Top toolbar tests.', funct
 	});
 
 	it('Apply a selected font size on the text shape', function() {
+		impressHelper.selectTextShapeInTheCenter();
 		cy.cGet('#tb_editbar_item_fontsizes').click();
 		desktopHelper.selectFromListbox('22');
 
@@ -95,10 +101,11 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Top toolbar tests.', funct
 	});
 
 	it('Apply left/right alignment on text selected text.', function() {
+		impressHelper.selectTextShapeInTheCenter();
+		impressHelper.selectTextOfShape();
 		cy.cGet('text tspan.TextPosition').should('have.attr', 'x', '1400');
 
 		// Set right alignment first
-		impressHelper.selectTextOfShape();
 		cy.cGet('#tb_editbar_item_rightpara').click();
 
 		impressHelper.triggerNewSVGForShapeInTheCenter();
@@ -115,6 +122,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Top toolbar tests.', funct
 	});
 
 	it('Apply superscript on selected text.', function() {
+		impressHelper.selectTextShapeInTheCenter();
 		impressHelper.selectTextOfShape();
 
 		cy.cGet('text tspan.TextPosition').should('have.attr', 'y', '8643');
@@ -129,6 +137,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Top toolbar tests.', funct
 	});
 
 	it('Apply subscript on selected text.', function() {
+		impressHelper.selectTextShapeInTheCenter();
 		impressHelper.selectTextOfShape();
 
 		cy.cGet('text tspan.TextPosition').should('have.attr', 'y', '8643');

--- a/cypress_test/integration_tests/desktop/impress/top_toolbar_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/top_toolbar_spec.js
@@ -110,7 +110,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Top toolbar tests.', funct
 
 		impressHelper.triggerNewSVGForShapeInTheCenter();
 
-		cy.cGet('text tspan.TextPosition').should('have.attr', 'x', '24526');
+		cy.cGet('text tspan.TextPosition').should('have.attr', 'x', '24530');
 
 		// Set left alignment
 		impressHelper.selectTextOfShape();
@@ -132,7 +132,8 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Top toolbar tests.', funct
 
 		impressHelper.triggerNewSVGForShapeInTheCenter();
 
-		cy.cGet('text tspan.TextPosition').should('have.attr', 'y', '8271');
+		cy.cGet('text tspan.TextPosition').invoke('attr','y').then((y)=>+y).should('be.gt',8200);
+		cy.cGet('text tspan.TextPosition').invoke('attr','y').then((y)=>+y).should('be.lt',8300);
 		cy.cGet('text tspan.TextPosition tspan').should('have.attr', 'font-size', '655px');
 	});
 
@@ -147,7 +148,8 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Top toolbar tests.', funct
 
 		impressHelper.triggerNewSVGForShapeInTheCenter();
 
-		cy.cGet('text tspan.TextPosition').should('have.attr', 'y', '8734');
+		cy.cGet('text tspan.TextPosition').invoke('attr','y').then((y)=>+y).should('be.gt',8700);
+		cy.cGet('text tspan.TextPosition').invoke('attr','y').then((y)=>+y).should('be.lt',8750);
 		cy.cGet('text tspan.TextPosition tspan').should('have.attr', 'font-size', '655px');
 	});
 });

--- a/cypress_test/integration_tests/desktop/impress/top_toolbar_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/top_toolbar_spec.js
@@ -30,8 +30,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Top toolbar tests.', funct
 
 		impressHelper.triggerNewSVGForShapeInTheCenter();
 
-		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition tspan')
-			.should('have.attr', 'font-weight', '700');
+		cy.cGet('text tspan.TextPosition tspan').should('have.attr', 'font-weight', '700');
 	});
 
 	it('Apply italic on text shape.', function() {
@@ -39,18 +38,15 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Top toolbar tests.', funct
 
 		impressHelper.triggerNewSVGForShapeInTheCenter();
 
-		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition tspan')
-			.should('have.attr', 'font-style', 'italic');
+		cy.cGet('text tspan.TextPosition tspan').should('have.attr', 'font-style', 'italic');
 	});
 
 	it('Apply underline on text shape.', function() {
-		cy.cGet('#tb_editbar_item_underline')
-			.click();
+		cy.cGet('#tb_editbar_item_underline').click();
 
 		impressHelper.triggerNewSVGForShapeInTheCenter();
 
-		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition tspan')
-			.should('have.attr', 'text-decoration', 'underline');
+		cy.cGet('text tspan.TextPosition tspan').should('have.attr', 'text-decoration', 'underline');
 	});
 
 	it('Apply strikethrough on text shape.', function() {
@@ -58,119 +54,91 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Top toolbar tests.', funct
 
 		impressHelper.triggerNewSVGForShapeInTheCenter();
 
-		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition tspan')
-			.should('have.attr', 'text-decoration', 'line-through');
+		cy.cGet('text tspan.TextPosition tspan').should('have.attr', 'text-decoration', 'line-through');
 	});
 
 	it('Apply font color on text shape.', function() {
-		cy.cGet('#tb_editbar_item_fontcolor')
-			.click();
-
+		cy.cGet('#tb_editbar_item_fontcolor').click();
 		desktopHelper.selectColorFromPalette('FF011B');
 
 		impressHelper.triggerNewSVGForShapeInTheCenter();
 
-		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .SVGTextShape .TextParagraph .TextPosition tspan')
-			.should('have.attr', 'fill', 'rgb(255,1,27)');
+		cy.cGet('text tspan.TextPosition tspan').should('have.attr', 'fill', 'rgb(255,1,27)');
 	});
 
 	it('Apply highlight color on text shape.', function() {
 		cy.cGet('#tb_editbar_item_backcolor').click();
-
 		desktopHelper.selectColorFromPalette('FF9838');
 
 		impressHelper.triggerNewSVGForShapeInTheCenter();
 
-		cy.wait(500);
-
 		//highlight color is not in the SVG
 		// that's why we didn't test there
-
 	});
 
 	it('Apply a selected font name on the text shape', function() {
 		cy.cGet('#tb_editbar_item_fonts').click();
-
 		desktopHelper.selectFromListbox('Liberation Mono');
 
 		impressHelper.triggerNewSVGForShapeInTheCenter();
 
-		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .SVGTextShape .TextParagraph .TextPosition tspan')
-			.should('have.attr', 'font-family', 'Liberation Mono');
+		cy.cGet('text tspan.TextPosition tspan').should('have.attr', 'font-family', 'Liberation Mono');
 	});
 
 	it('Apply a selected font size on the text shape', function() {
-
 		cy.cGet('#tb_editbar_item_fontsizes').click();
-
 		desktopHelper.selectFromListbox('22');
 
 		impressHelper.triggerNewSVGForShapeInTheCenter();
 
-		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .SVGTextShape .TextParagraph .TextPosition tspan')
-			.should('have.attr', 'font-size', '776px');
+		cy.cGet('text tspan.TextPosition tspan').should('have.attr', 'font-size', '776px');
 	});
 
 	it('Apply left/right alignment on text selected text.', function() {
-		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition')
-			.should('have.attr', 'x', '1400');
+		cy.cGet('text tspan.TextPosition').should('have.attr', 'x', '1400');
 
 		// Set right alignment first
 		impressHelper.selectTextOfShape();
-
 		cy.cGet('#tb_editbar_item_rightpara').click();
 
 		impressHelper.triggerNewSVGForShapeInTheCenter();
 
-		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition').should('have.attr', 'x', '24526');
+		cy.cGet('text tspan.TextPosition').should('have.attr', 'x', '24526');
 
 		// Set left alignment
 		impressHelper.selectTextOfShape();
-
 		cy.cGet('#tb_editbar_item_leftpara').click();
 
 		impressHelper.triggerNewSVGForShapeInTheCenter();
 
-		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition').should('have.attr', 'x', '1400');
+		cy.cGet('text tspan.TextPosition').should('have.attr', 'x', '1400');
 	});
 
 	it('Apply superscript on selected text.', function() {
 		impressHelper.selectTextOfShape();
 
-		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextPosition')
-			.should('have.attr', 'y', '8643');
-
-		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition tspan')
-			.should('have.attr', 'font-size', '1129px');
+		cy.cGet('text tspan.TextPosition').should('have.attr', 'y', '8643');
+		cy.cGet('text tspan.TextPosition tspan').should('have.attr', 'font-size', '1129px');
 
 		helper.typeIntoDocument('{ctrl}{shift}p');
 
 		impressHelper.triggerNewSVGForShapeInTheCenter();
 
-		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextPosition')
-			.should('have.attr', 'y', '8271');
-
-		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition tspan')
-			.should('have.attr', 'font-size', '655px');
+		cy.cGet('text tspan.TextPosition').should('have.attr', 'y', '8271');
+		cy.cGet('text tspan.TextPosition tspan').should('have.attr', 'font-size', '655px');
 	});
 
 	it('Apply subscript on selected text.', function() {
 		impressHelper.selectTextOfShape();
 
-		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextPosition')
-			.should('have.attr', 'y', '8643');
-
-		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition tspan')
-			.should('have.attr', 'font-size', '1129px');
+		cy.cGet('text tspan.TextPosition').should('have.attr', 'y', '8643');
+		cy.cGet('text tspan.TextPosition tspan').should('have.attr', 'font-size', '1129px');
 
 		helper.typeIntoDocument('{ctrl}{shift}b');
 
 		impressHelper.triggerNewSVGForShapeInTheCenter();
 
-		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextPosition')
-			.should('have.attr', 'y', '8734');
-
-		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition tspan')
-			.should('have.attr', 'font-size', '655px');
+		cy.cGet('text tspan.TextPosition').should('have.attr', 'y', '8734');
+		cy.cGet('text tspan.TextPosition tspan').should('have.attr', 'font-size', '655px');
 	});
 });

--- a/cypress_test/integration_tests/mobile/impress/apply_font_text_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/apply_font_text_spec.js
@@ -34,8 +34,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Apply font on selected text
 
 		triggerNewSVG();
 
-		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition tspan')
-			.should('have.attr', 'font-weight', '700');
+		cy.cGet('text tspan.TextPosition tspan').should('have.attr', 'font-weight', '700');
 	});
 
 	it('Apply italic on selected text.', function() {
@@ -47,8 +46,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Apply font on selected text
 
 		triggerNewSVG();
 
-		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition tspan')
-			.should('have.attr', 'font-style', 'italic');
+		cy.cGet('text tspan.TextPosition tspan').should('have.attr', 'font-style', 'italic');
 	});
 
 	it('Apply underline on selected text.', function() {
@@ -60,8 +58,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Apply font on selected text
 
 		triggerNewSVG();
 
-		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition tspan')
-			.should('have.attr', 'text-decoration', 'underline');
+		cy.cGet('text tspan.TextPosition tspan').should('have.attr', 'text-decoration', 'underline');
 	});
 
 	it('Apply strikeout on selected text.', function() {
@@ -73,8 +70,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Apply font on selected text
 
 		triggerNewSVG();
 
-		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition tspan')
-			.should('have.attr', 'text-decoration', 'line-through');
+		cy.cGet('text tspan.TextPosition tspan').should('have.attr', 'text-decoration', 'line-through');
 	});
 
 	it('Apply shadowed on selected text.', function() {
@@ -98,8 +94,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Apply font on selected text
 
 		triggerNewSVG();
 
-		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition tspan')
-			.should('have.attr', 'font-family', 'Linux Libertine G');
+		cy.cGet('text tspan.TextPosition tspan').should('have.attr', 'font-family', 'Linux Libertine G');
 	});
 
 	it('Change font size of selected text.', function() {
@@ -110,13 +105,11 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Apply font on selected text
 
 		triggerNewSVG();
 
-		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition tspan')
-			.should('have.attr', 'font-size', '847px');
+		cy.cGet('text tspan.TextPosition tspan').should('have.attr', 'font-size', '847px');
 	});
 
 	it('Apply text color on selected text.', function() {
-		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextPosition tspan')
-			.should('have.attr', 'fill', 'rgb(0,0,0)');
+		cy.cGet('text tspan.TextPosition tspan').should('have.attr', 'fill', 'rgb(0,0,0)');
 
 		impressHelper.selectTextOfShape();
 
@@ -128,8 +121,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Apply font on selected text
 
 		triggerNewSVG();
 
-		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextPosition tspan')
-			.should('have.attr', 'fill', 'rgb(106,168,79)');
+		cy.cGet('text tspan.TextPosition tspan').should('have.attr', 'fill', 'rgb(106,168,79)');
 	});
 
 	it('Apply highlight on selected text.', function() {
@@ -162,19 +154,15 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Apply font on selected text
 
 		mobileHelper.openTextPropertiesPanel();
 
-		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextPosition')
-			.should('have.attr', 'y', '3495');
-		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition tspan')
-			.should('have.attr', 'font-size', '635px');
+		cy.cGet('text tspan.TextPosition').should('have.attr', 'y', '3495');
+		cy.cGet('text tspan.TextPosition tspan').should('have.attr', 'font-size', '635px');
 
 		helper.clickOnIdle('.unoSuperScript');
 
 		triggerNewSVG();
 
-		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextPosition')
-			.should('have.attr', 'y', '3285');
-		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition tspan')
-			.should('have.attr', 'font-size', '368px');
+		cy.cGet('text tspan.TextPosition').should('have.attr', 'y', '3285');
+		cy.cGet('text tspan.TextPosition tspan').should('have.attr', 'font-size', '368px');
 	});
 
 	it('Apply subscript on selected text.', function() {
@@ -182,18 +170,14 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Apply font on selected text
 
 		mobileHelper.openTextPropertiesPanel();
 
-		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextPosition')
-			.should('have.attr', 'y', '3495');
-		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition tspan')
-			.should('have.attr', 'font-size', '635px');
+		cy.cGet('text tspan.TextPosition').should('have.attr', 'y', '3495');
+		cy.cGet('text tspan.TextPosition tspan').should('have.attr', 'font-size', '635px');
 
 		helper.clickOnIdle('.unoSubScript');
 
 		triggerNewSVG();
 
-		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextPosition')
-			.should('have.attr', 'y', '3546');
-		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition tspan')
-			.should('have.attr', 'font-size', '368px');
+		cy.cGet('text tspan.TextPosition').should('have.attr', 'y', '3546');
+		cy.cGet('text tspan.TextPosition tspan').should('have.attr', 'font-size', '368px');
 	});
 });

--- a/cypress_test/integration_tests/mobile/impress/apply_font_text_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/apply_font_text_spec.js
@@ -84,7 +84,6 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Apply font on selected text
 
 		triggerNewSVG();
 
-		cy.wait(400);
 		// TODO: shadowed property is not in the SVG
 	});
 
@@ -117,6 +116,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Apply font on selected text
 	it('Apply text color on selected text.', function() {
 		impressHelper.selectTextShapeInTheCenter();
 		impressHelper.selectTextOfShape();
+
 		cy.cGet('text tspan.TextPosition tspan').should('have.attr', 'fill', 'rgb(0,0,0)');
 
 		mobileHelper.openTextPropertiesPanel();
@@ -147,7 +147,6 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Apply font on selected text
 
 		// TODO: highlight color is not in the SVG
 		// At least check the mobile wizard's state
-		cy.wait(400);
 		impressHelper.selectTextOfShape();
 
 		mobileHelper.openTextPropertiesPanel();
@@ -169,7 +168,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Apply font on selected text
 
 		triggerNewSVG();
 
-		cy.cGet('text tspan.TextPosition').should('have.attr', 'y', '3285');
+		cy.cGet('text tspan.TextPosition').should('have.attr', 'y', '3273');
 		cy.cGet('text tspan.TextPosition tspan').should('have.attr', 'font-size', '368px');
 	});
 
@@ -186,7 +185,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Apply font on selected text
 
 		triggerNewSVG();
 
-		cy.cGet('text tspan.TextPosition').should('have.attr', 'y', '3546');
+		cy.cGet('text tspan.TextPosition').should('have.attr', 'y', '3533');
 		cy.cGet('text tspan.TextPosition tspan').should('have.attr', 'font-size', '368px');
 	});
 });

--- a/cypress_test/integration_tests/mobile/impress/apply_font_text_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/apply_font_text_spec.js
@@ -10,10 +10,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Apply font on selected text
 
 	beforeEach(function() {
 		testFileName = helper.beforeAll(origTestFileName, 'impress');
-
 		mobileHelper.enableEditingMobile();
-
-		impressHelper.selectTextShapeInTheCenter();
 	});
 
 	afterEach(function() {
@@ -26,11 +23,12 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Apply font on selected text
 	}
 
 	it('Apply bold on selected text.', function() {
+		impressHelper.selectTextShapeInTheCenter();
 		impressHelper.selectTextOfShape();
 
 		mobileHelper.openTextPropertiesPanel();
 
-		helper.clickOnIdle('.unoBold');
+		cy.cGet('.unoBold').click();
 
 		triggerNewSVG();
 
@@ -38,11 +36,12 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Apply font on selected text
 	});
 
 	it('Apply italic on selected text.', function() {
+		impressHelper.selectTextShapeInTheCenter();
 		impressHelper.selectTextOfShape();
 
 		mobileHelper.openTextPropertiesPanel();
 
-		helper.clickOnIdle('.unoItalic');
+		cy.cGet('.unoItalic').click();
 
 		triggerNewSVG();
 
@@ -50,11 +49,12 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Apply font on selected text
 	});
 
 	it('Apply underline on selected text.', function() {
+		impressHelper.selectTextShapeInTheCenter();
 		impressHelper.selectTextOfShape();
 
 		mobileHelper.openTextPropertiesPanel();
 
-		helper.clickOnIdle('.unoUnderline');
+		cy.cGet('.unoUnderline').click();
 
 		triggerNewSVG();
 
@@ -62,11 +62,12 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Apply font on selected text
 	});
 
 	it('Apply strikeout on selected text.', function() {
+		impressHelper.selectTextShapeInTheCenter();
 		impressHelper.selectTextOfShape();
 
 		mobileHelper.openTextPropertiesPanel();
 
-		helper.clickOnIdle('.unoStrikeout');
+		cy.cGet('.unoStrikeout').click();
 
 		triggerNewSVG();
 
@@ -74,11 +75,12 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Apply font on selected text
 	});
 
 	it('Apply shadowed on selected text.', function() {
+		impressHelper.selectTextShapeInTheCenter();
 		impressHelper.selectTextOfShape();
 
 		mobileHelper.openTextPropertiesPanel();
 
-		helper.clickOnIdle('.unoShadowed');
+		cy.cGet('.unoShadowed').click();
 
 		triggerNewSVG();
 
@@ -87,7 +89,9 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Apply font on selected text
 	});
 
 	it('Change font name of selected text.', function() {
+		impressHelper.selectTextShapeInTheCenter();
 		impressHelper.selectTextOfShape();
+
 		mobileHelper.openTextPropertiesPanel();
 		cy.cGet('#font').click();
 		cy.cGet('#fontnamecombobox').contains('.mobile-wizard.ui-combobox-text', 'Linux Libertine G').click();
@@ -98,7 +102,9 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Apply font on selected text
 	});
 
 	it('Change font size of selected text.', function() {
+		impressHelper.selectTextShapeInTheCenter();
 		impressHelper.selectTextOfShape();
+
 		mobileHelper.openTextPropertiesPanel();
 		cy.cGet('#fontsizecombobox').click();
 		cy.cGet('#fontsizecombobox').contains('.mobile-wizard.ui-combobox-text', '24 pt').click();
@@ -109,13 +115,13 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Apply font on selected text
 	});
 
 	it('Apply text color on selected text.', function() {
-		cy.cGet('text tspan.TextPosition tspan').should('have.attr', 'fill', 'rgb(0,0,0)');
-
+		impressHelper.selectTextShapeInTheCenter();
 		impressHelper.selectTextOfShape();
+		cy.cGet('text tspan.TextPosition tspan').should('have.attr', 'fill', 'rgb(0,0,0)');
 
 		mobileHelper.openTextPropertiesPanel();
 
-		helper.clickOnIdle('#Color .ui-header');
+		cy.cGet('#Color .ui-header').click();
 
 		mobileHelper.selectFromColorPicker('#Color', 5, 2);
 
@@ -125,11 +131,12 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Apply font on selected text
 	});
 
 	it('Apply highlight on selected text.', function() {
+		impressHelper.selectTextShapeInTheCenter();
 		impressHelper.selectTextOfShape();
 
 		mobileHelper.openTextPropertiesPanel();
 
-		helper.clickOnIdle('#CharBackColor .ui-header');
+		cy.cGet('#CharBackColor .ui-header').click();
 
 		mobileHelper.selectFromColorPicker('#CharBackColor', 2, 2);
 
@@ -150,6 +157,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Apply font on selected text
 	});
 
 	it('Apply superscript on selected text.', function() {
+		impressHelper.selectTextShapeInTheCenter();
 		impressHelper.selectTextOfShape();
 
 		mobileHelper.openTextPropertiesPanel();
@@ -157,7 +165,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Apply font on selected text
 		cy.cGet('text tspan.TextPosition').should('have.attr', 'y', '3495');
 		cy.cGet('text tspan.TextPosition tspan').should('have.attr', 'font-size', '635px');
 
-		helper.clickOnIdle('.unoSuperScript');
+		cy.cGet('.unoSuperScript').click();
 
 		triggerNewSVG();
 
@@ -166,6 +174,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Apply font on selected text
 	});
 
 	it('Apply subscript on selected text.', function() {
+		impressHelper.selectTextShapeInTheCenter();
 		impressHelper.selectTextOfShape();
 
 		mobileHelper.openTextPropertiesPanel();
@@ -173,7 +182,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Apply font on selected text
 		cy.cGet('text tspan.TextPosition').should('have.attr', 'y', '3495');
 		cy.cGet('text tspan.TextPosition tspan').should('have.attr', 'font-size', '635px');
 
-		helper.clickOnIdle('.unoSubScript');
+		cy.cGet('.unoSubScript').click();
 
 		triggerNewSVG();
 


### PR DESCRIPTION
Tests desktop/impress/top_toolbar_spec.js and mobile/impress/apply_font_text_spec.js have been failing after a change in core that slightly alters the position of some text elements.

These tests fail when run against core 24.04 but not against 23.05. So there must have been a core that caused them to fail. I have not tried to find the change.

I'm not sure whether to consider this a regression in core or a flaky test here in online. Nevertheless, I'd like to submit these changes to get the tests passing as quickly as possible.

These positions were stable for several years and I don't know why they have changed now.

The new x value of "top_toolbar_spec.js/Apply left/right element" is the same in Jenkins and on my machine, but the y values of "Apply superscript" and "Apply subscript" are different (8711 vs 8745, originally 8734), so I have allowed a range of values. The mobile test hasn't run on Jenkins (because it stops after the desktop tests fail) so I don't know if they will need a range too. It might be good to modify all these tests to use a range, if we see them continue to fail.

I am also including some minor cleanup in separate commits in this pull request.

### Checklist

- [X] Code is properly formatted
- [X] All commits have Change-Id
- [X] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

