### PR TITLE
keep focus on input field on document load

### DIFF
--- a/browser/src/control/Control.IdleHandler.ts
+++ b/browser/src/control/Control.IdleHandler.ts
@@ -80,7 +80,7 @@ class IdleHandler {
 			}
 		}
 
-		if (window.mode.isDesktop() && !this.map.uiManager.isAnyDialogOpen()) {
+		if (window.mode.isDesktop() && !this.map.uiManager.isAnyDialogOpen() && $('input:focus').length === 0) {
 			this.map.focus();
 		}
 


### PR DESCRIPTION
If the document reloads while the user is on an input field, do not
take the focus away to the document.

Signed-off-by: Jaume Pujantell <jaume.pujantell@collabora.com>
Change-Id: If5e97a666ddef6e7c28a30c8bd8ef8bca5f5b336
