### PR TITLE
Convert Control.UserList.js to typescript

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -361,7 +361,7 @@ COOL_JS_LST =\
 	src/control/Control.SearchBar.js \
 	src/control/Control.MobileTopBar.js \
 	src/control/Control.MobileBottomBar.js \
-	src/control/Control.UserList.js \
+	src/control/Control.UserList.ts \
 	src/control/Control.FormulaBar.js \
 	src/control/Control.FormulaBarJSDialog.js \
 	src/control/Control.SheetsBar.js \
@@ -766,7 +766,7 @@ pot:
 		src/control/Control.Toolbar.js \
 		src/control/Control.TopToolbar.js \
 		src/control/Control.UIManager.js \
-		src/control/Control.UserList.js \
+		src/control/Control.UserList.ts \
 		src/control/Control.Zotero.js \
 		src/control/Parts.js \
 		src/control/Permission.js \

--- a/browser/package.json
+++ b/browser/package.json
@@ -9,6 +9,7 @@
     "@types/jqueryui": "^1.12.21",
     "@types/mocha": "8.2.0",
     "@types/node": "14.14.25",
+    "@types/w2ui": "^1.4.37",
     "@typescript-eslint/eslint-plugin": "^4.21.0",
     "@typescript-eslint/parser": "^4.21.0",
     "autolinker": "3.14.1",

--- a/browser/package.json
+++ b/browser/package.json
@@ -4,6 +4,9 @@
   "description": "Collabora Online front-end",
   "devDependencies": {
     "@braintree/sanitize-url": "6.0.2",
+    "@types/jquery": "^3.5.29",
+    "@types/jquery.contextmenu": "^1.7.38",
+    "@types/jqueryui": "^1.12.21",
     "@types/mocha": "8.2.0",
     "@types/node": "14.14.25",
     "@typescript-eslint/eslint-plugin": "^4.21.0",
@@ -27,7 +30,7 @@
     "shrinkpack": "1.0.0-alpha",
     "smartmenus": "1.0.0",
     "stylelint": "13.7.0",
-    "typescript": "4.2.3",
+    "typescript": "4.4.2",
     "uglify-js": "3.17.4",
     "uglifycss": "0.0.29",
     "uglifyify": "5.0.2"

--- a/browser/src/layer/marker/Cursor.ts
+++ b/browser/src/layer/marker/Cursor.ts
@@ -1,6 +1,5 @@
 /* eslint-disable */
 
-declare var $: any;
 declare var L: any;
 
 /*

--- a/browser/src/layer/tile/CommentListSection.ts
+++ b/browser/src/layer/tile/CommentListSection.ts
@@ -43,7 +43,6 @@ L.Map.include({
 
 declare var L: any;
 declare var app: any;
-declare var $: any;
 declare var _: any;
 
 namespace cool {

--- a/browser/src/layer/tile/CommentSection.ts
+++ b/browser/src/layer/tile/CommentSection.ts
@@ -14,7 +14,6 @@ declare var app: any;
 declare var _: any;
 declare var Autolinker: any;
 declare var Hammer: any;
-declare var $: any;
 
 namespace cool {
 

--- a/browser/src/layer/tile/TilesSection.ts
+++ b/browser/src/layer/tile/TilesSection.ts
@@ -11,7 +11,6 @@
 /* See CanvasSectionContainer.ts for explanations. */
 
 declare var L: any;
-declare var $: any;
 declare var Hammer: any;
 declare var app: any;
 

--- a/browser/src/w2overlay.d.ts
+++ b/browser/src/w2overlay.d.ts
@@ -1,0 +1,3 @@
+interface JQuery {
+	w2overlay: any;
+}


### PR DESCRIPTION
**Add @types/jquery**:
Previously we were declaring $ as "any" but a type package for jquery
exists. Using it will provide us type definitions for jquery throughout
the project. This means we need to remove our previous definitions and
install the package

**Convert Control.UserList.js to typescript**:
I'm working on a set of patches to improve the userlist/following UI in
Collabora Online. Using typescript will allow me to be more certain
about the code I'm writing and make my code easier for other people to
understand.

Additionally, as I'm about to make significant changes to this file,
updating it to typescript now won't even damage the ability to blame too
much!

---

This is a prerequisite for my userlist/following changes

