### PR TITLE
Reorder the user list

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -361,7 +361,7 @@ COOL_JS_LST =\
 	src/control/Control.SearchBar.js \
 	src/control/Control.MobileTopBar.js \
 	src/control/Control.MobileBottomBar.js \
-	src/control/Control.UserList.js \
+	src/control/Control.UserList.ts \
 	src/control/Control.FormulaBar.js \
 	src/control/Control.FormulaBarJSDialog.js \
 	src/control/Control.SheetsBar.js \
@@ -766,7 +766,7 @@ pot:
 		src/control/Control.Toolbar.js \
 		src/control/Control.TopToolbar.js \
 		src/control/Control.UIManager.js \
-		src/control/Control.UserList.js \
+		src/control/Control.UserList.ts \
 		src/control/Control.Zotero.js \
 		src/control/Parts.js \
 		src/control/Permission.js \

--- a/browser/package.json
+++ b/browser/package.json
@@ -9,6 +9,7 @@
     "@types/jqueryui": "^1.12.21",
     "@types/mocha": "8.2.0",
     "@types/node": "14.14.25",
+    "@types/w2ui": "^1.4.37",
     "@typescript-eslint/eslint-plugin": "^4.21.0",
     "@typescript-eslint/parser": "^4.21.0",
     "autolinker": "3.14.1",

--- a/browser/package.json
+++ b/browser/package.json
@@ -4,6 +4,9 @@
   "description": "Collabora Online front-end",
   "devDependencies": {
     "@braintree/sanitize-url": "6.0.2",
+    "@types/jquery": "^3.5.29",
+    "@types/jquery.contextmenu": "^1.7.38",
+    "@types/jqueryui": "^1.12.21",
     "@types/mocha": "8.2.0",
     "@types/node": "14.14.25",
     "@typescript-eslint/eslint-plugin": "^4.21.0",
@@ -27,7 +30,7 @@
     "shrinkpack": "1.0.0-alpha",
     "smartmenus": "1.0.0",
     "stylelint": "13.7.0",
-    "typescript": "4.2.3",
+    "typescript": "4.4.2",
     "uglify-js": "3.17.4",
     "uglifycss": "0.0.29",
     "uglifyify": "5.0.2"

--- a/browser/src/control/Control.UserList.ts
+++ b/browser/src/control/Control.UserList.ts
@@ -178,11 +178,19 @@ class UserList extends L.Control {
 
 	hideUserList() {
 		return (window as any /* TODO: remove cast after gh#8221 */).ThisIsAMobileApp ||
-		(this.map['wopi'].HideUserList !== null && this.map['wopi'].HideUserList !== undefined &&
-			($.inArray('true', this.map['wopi'].HideUserList) >= 0) ||
-			(window.mode.isMobile() && $.inArray('mobile', this.map['wopi'].HideUserList) >= 0) ||
-			(window.mode.isTablet() && $.inArray('tablet', this.map['wopi'].HideUserList) >= 0) ||
-			(window.mode.isDesktop() && $.inArray('desktop', this.map['wopi'].HideUserList) >= 0));
+			(this.map['wopi'].HideUserList !== null && this.map['wopi'].HideUserList !== undefined &&
+				($.inArray('true', this.map['wopi'].HideUserList) >= 0) ||
+				(window.mode.isMobile() && $.inArray('mobile', this.map['wopi'].HideUserList) >= 0) ||
+				(window.mode.isTablet() && $.inArray('tablet', this.map['wopi'].HideUserList) >= 0) ||
+				(window.mode.isDesktop() && $.inArray('desktop', this.map['wopi'].HideUserList) >= 0));
+	}
+
+	getSortedUsers() {
+		if (this.users.get(this.map._docLayer._viewId) === undefined) {
+			return [];
+		}
+
+		return [[this.map._docLayer._viewId, this.users.get(this.map._docLayer._viewId)]].concat(Array.from(this.users.entries()).filter(([id, _user]) => id != this.map._docLayer._viewId));
 	}
 
 	renderHeaderAvatars() {
@@ -194,8 +202,7 @@ class UserList extends L.Control {
 			return;
 		}
 
-		const users = this.users.entries();
-		const avatarUsers = [users.next().value, users.next().value, users.next().value].filter(user => user !== undefined);
+		const avatarUsers = this.getSortedUsers().slice(0, 3);
 
 		userListElement.setAttribute('accesskey','UP');
 
@@ -325,7 +332,7 @@ class UserList extends L.Control {
 	}
 
 	renderUserList() {
-		const headerUserList = Array.from(this.users.entries());
+		const headerUserList = this.getSortedUsers();
 
 		const userItems = headerUserList.map(([viewId, user]) => {
 			let username = user.username;
@@ -346,7 +353,7 @@ class UserList extends L.Control {
 
 	renderHeaderAvatarPopover() {
 		// Popover rendering
-		const users = Array.from(this.users.entries());
+		const users = this.getSortedUsers();
 		const popoverElement = document.getElementById('userListPopover');
 
 		const userElements = users.map(([viewId, user]) => {

--- a/browser/src/control/Control.UserList.ts
+++ b/browser/src/control/Control.UserList.ts
@@ -185,12 +185,41 @@ class UserList extends L.Control {
 				(window.mode.isDesktop() && $.inArray('desktop', this.map['wopi'].HideUserList) >= 0));
 	}
 
-	getSortedUsers() {
-		if (this.users.get(this.map._docLayer._viewId) === undefined) {
-			return [];
-		}
+	getSortedUsers(): Generator<[number, User], undefined, undefined> {
+		return (function* (this: UserList): Generator<[number, User], undefined, undefined> {
+			const self = this.users.get(this.map._docLayer._viewId);
 
-		return [[this.map._docLayer._viewId, this.users.get(this.map._docLayer._viewId)]].concat(Array.from(this.users.entries()).filter(([id, _user]) => id != this.map._docLayer._viewId));
+			if (this.users.get(this.map._docLayer._viewId) === undefined) {
+				return;
+			}
+
+			const followedUser = this.getFollowedUser();
+
+			if (followedUser !== undefined) {
+				yield followedUser;
+			}
+
+			yield [this.map._docLayer._viewId, self];
+
+			const readonlyUsers: [number, User][] = [];
+
+			for (const [viewId, user] of Array.from(this.users.entries()).reverse()) {
+				const isSelf = viewId === this.map._docLayer._viewId;
+				const isFollowed = followedUser !== undefined && viewId === followedUser[0];
+				if (isSelf || isFollowed) {
+					continue;
+				}
+
+				if (user.readonly) {
+					readonlyUsers.push([viewId, user]);
+					continue;
+				}
+
+				yield [viewId, user];
+			}
+
+			yield* readonlyUsers;
+		}).bind(this)();
 	}
 
 	renderHeaderAvatars() {
@@ -202,7 +231,7 @@ class UserList extends L.Control {
 			return;
 		}
 
-		const avatarUsers = this.getSortedUsers().slice(0, 3);
+		const avatarUsers = Array.from(this.getSortedUsers()).slice(0, this.options.userLimitHeader);
 
 		userListElement.setAttribute('accesskey','UP');
 
@@ -332,7 +361,7 @@ class UserList extends L.Control {
 	}
 
 	renderUserList() {
-		const headerUserList = this.getSortedUsers();
+		const headerUserList = Array.from(this.getSortedUsers());
 
 		const userItems = headerUserList.map(([viewId, user]) => {
 			let username = user.username;
@@ -353,7 +382,7 @@ class UserList extends L.Control {
 
 	renderHeaderAvatarPopover() {
 		// Popover rendering
-		const users = this.getSortedUsers();
+		const users = Array.from(this.getSortedUsers());
 		const popoverElement = document.getElementById('userListPopover');
 
 		const userElements = users.map(([viewId, user]) => {

--- a/browser/src/control/Control.UserList.ts
+++ b/browser/src/control/Control.UserList.ts
@@ -17,18 +17,15 @@ interface UserExtraInfo {
 }
 
 interface User {
-	userName: string;
-	viewId: number;
-	extraInfo: UserExtraInfo;
-	color: string;
-}
-
-interface UserEvent {
 	username: string;
 	extraInfo: UserExtraInfo;
 	color: string;
-	viewId: number;
 	readonly: boolean;
+	you: boolean;
+}
+
+interface UserEvent extends User {
+	viewId: number;
 }
 
 class UserList extends L.Control {
@@ -40,7 +37,6 @@ class UserList extends L.Control {
 		nUsers?: string,
 		oneUser?: string,
 		noUser?: string,
-		listUser?: User[]
 	} = {
 		userLimitHeader: 6,
 		userPopupTimeout: null,
@@ -49,8 +45,9 @@ class UserList extends L.Control {
 		nUsers: undefined,
 		oneUser: undefined,
 		noUser: undefined,
-		listUser: []
 	};
+
+	users: Map<number, User> = new Map();
 
 	onAdd(map: ReturnType<typeof L.map>) {
 		this.map = map;
@@ -124,7 +121,7 @@ class UserList extends L.Control {
 		w2ui['actionbar'].uncheck('userlist');
 	}
 
-	createAvatar(viewId: number, _userName: string, extraInfo: UserExtraInfo, color: string) {
+	createAvatar(viewId: number, extraInfo: UserExtraInfo, color: string) {
 		var img;
 		if (extraInfo !== undefined && extraInfo.avatar !== undefined) {
 			img = L.DomUtil.create('img', 'avatar-img');
@@ -141,7 +138,7 @@ class UserList extends L.Control {
 		return img;
 	}
 
-	getUserItem(viewId: number, userName: string, extraInfo: UserExtraInfo, color: string) {
+	getUserItem(viewId: number, username: string, extraInfo: UserExtraInfo, color: string) {
 		var content = L.DomUtil.create('tr', 'useritem');
 		content.id = 'user-' + viewId;
 		$(document).on('click', '#' + content.id, this.onUseritemClicked.bind(this));
@@ -149,8 +146,8 @@ class UserList extends L.Control {
 		var iconTd = L.DomUtil.create('td', 'usercolor', content);
 		var nameTd = L.DomUtil.create('td', 'username cool-font', content);
 
-		iconTd.appendChild(this.createAvatar(viewId, userName, extraInfo, color));
-		nameTd.textContent = userName;
+		iconTd.appendChild(this.createAvatar(viewId, extraInfo, color));
+		nameTd.textContent = username;
 
 		return content;
 	}
@@ -189,91 +186,22 @@ class UserList extends L.Control {
 	}
 
 	renderHeaderAvatars() {
-		if (window.mode.isMobile() || this.hideUserList() || this.options.listUser.length === 1) {
-			document.getElementById('userListSummary').removeAttribute('accesskey');
+		const userListElement = document.getElementById('userListSummary');
+
+		if (window.mode.isMobile() || this.hideUserList() || this.users.size === 1) {
+			userListElement.removeAttribute('accesskey');
+			userListElement.replaceChildren();
 			return;
 		}
 
-		var headerUserList = this.options.listUser.slice(-this.options.userLimitHeader);
-		document.getElementById('userListSummary').setAttribute('accesskey','UP');
+		const users = this.users.entries();
+		const avatarUsers = [users.next().value, users.next().value, users.next().value].filter(user => user !== undefined);
 
-		// Remove users that should no longer be in the header
-		Array.from(document.querySelectorAll('#userListSummary [data-view-id]')).map(function(element) {
-			return element.getAttribute('data-view-id');
-		}).filter(function(viewId) {
-			return headerUserList.map(function(user: User) {
-				return user.viewId;
-			}).indexOf(parseInt(viewId)) === -1;
-		}).forEach(function(viewId) {
-			L.DomUtil.remove(document.querySelector('#userListSummary [data-view-id="' + viewId + '"]'));
-		});
+		userListElement.setAttribute('accesskey','UP');
 
-		// Summary rendering
-		headerUserList.forEach(function (user: User) {
-			if (!document.querySelector('#userListSummary [data-view-id="' + user.viewId + '"]')) {
-				document.getElementById('userListSummary').appendChild(this.createAvatar(user.viewId, user.userName, user.extraInfo, user.color));
-			}
-		}.bind(this));
-
-		// Popover rendering
-		this.options.listUser.forEach(function (user: User) {
-			if (document.querySelector('#userListPopover .user-list-item[data-view-id="' + user.viewId + '"]')) {
-				return;
-			}
-
-			var userLabel = L.DomUtil.create('div', 'user-list-item--name');
-			userLabel.innerText = user.userName;
-
-			var userFollowingLabel = L.DomUtil.create('div', 'user-list-item--following-label');
-			userFollowingLabel.innerText = _('Following');
-			var userLabelContainer = L.DomUtil.create('div', 'user-list-item--name-container');
-			userLabelContainer.appendChild(userLabel);
-			userLabelContainer.appendChild(userFollowingLabel);
-
-			var listItem = L.DomUtil.create('div', 'user-list-item');
-			listItem.setAttribute('data-view-id', user.viewId);
-			listItem.setAttribute('role', 'button');
-			listItem.appendChild(this.createAvatar(user.viewId, user.userName, user.extraInfo, user.color));
-			listItem.appendChild(userLabelContainer);
-			listItem.addEventListener('click', function () {
-				this.followUser(user.viewId);
-			}.bind(this), false);
-
-			var popoverList = document.getElementById('userListPopover');
-			popoverList.insertBefore(listItem, popoverList.lastChild);
-		}.bind(this));
-
-		if (!document.getElementById('follow-editor')) {
-			var followEditorWrapper = L.DomUtil.create('div', '');
-			followEditorWrapper.id = 'follow-editor';
-			var followEditorCheckbox = L.DomUtil.create('input', 'follow-editor-checkbox', followEditorWrapper);
-			followEditorCheckbox.id = 'follow-editor-checkbox';
-			followEditorCheckbox.setAttribute('type', 'checkbox');
-			followEditorCheckbox.onchange = function(event: Event) {
-				(window as any /* TODO: remove cast after gh#8221 */).editorUpdate(event);
-			};
-			var followEditorCheckboxLabel = L.DomUtil.create('label', 'follow-editor-label', followEditorWrapper);
-			followEditorCheckboxLabel.innerText = _('Always follow the editor');
-			followEditorCheckboxLabel.setAttribute('for', 'follow-editor-checkbox');
-
-			document.getElementById('userListPopover').appendChild(followEditorWrapper);
-		}
-
-		(document.getElementById('follow-editor-checkbox') as HTMLInputElement).checked = this.map._docLayer._followEditor;
-	}
-
-	removeUserFromHeaderAvatars(viewId: number) {
-		var index = null;
-		this.options.listUser.forEach(function(item, idx) {
-			if (item.viewId == viewId) {
-				index = idx;
-			}
-		});
-
-		L.DomUtil.remove(document.querySelector('#userListSummary [data-view-id="' + viewId + '"]'));
-		L.DomUtil.remove(document.querySelector('#userListPopover .user-list-item[data-view-id="' + viewId + '"]'));
-		this.options.listUser.splice(index, 1);
-		this.renderHeaderAvatars();
+		userListElement.replaceChildren(...avatarUsers.map(([viewId, user]) => {
+			return this.createAvatar(viewId, user.extraInfo, user.color);
+		}));
 	}
 
 	updateUserListCount() {
@@ -335,75 +263,130 @@ class UserList extends L.Control {
 	}
 
 	onAddView(e: UserEvent) {
-		var userlistItem = w2ui['actionbar'].get('userlist');
-		var username = this.escapeHtml(e.username);
-		var showPopup = false;
+		let color;
+		let username;
+		let you;
 
-		if (userlistItem !== null)
-			showPopup = $(userlistItem.html).find('#userlist_table tbody tr').length > 0;
-
-		if (showPopup) {
-			$('#tb_actionbar_item_userlist')
-				.w2overlay({
-					class: 'cool-font',
-					html: this.options.userJoinedPopupMessage.replace('%user', username),
-					style: 'padding: 5px'
-				});
-			clearTimeout(this.options.userPopupTimeout);
-			this.options.userPopupTimeout = setTimeout(() => {
-				$('#tb_actionbar_item_userlist').w2overlay('');
-				clearTimeout(this.options.userPopupTimeout);
-				this.options.userPopupTimeout = null;
-			}, 3000);
-		}
-
-		var color = L.LOUtil.rgbToHex(this.map.getViewColor(e.viewId));
 		if (e.viewId === this.map._docLayer._viewId) {
 			username = _('You');
 			color = '#000';
+			you = true;
+		} else {
+			username = this.escapeHtml(e.username);
+			color = L.LOUtil.rgbToHex(this.map.getViewColor(e.viewId));
+			you = false;
 		}
 
-		// Mention readonly sessions in userlist
-		if (e.readonly) {
-			username += ' (' +  _('Readonly') + ')';
+		this.users.set(e.viewId, {you: you, username: username, extraInfo: e.extraInfo, color: color, readonly: e.readonly});
+
+		if (!you) {
+			this.showJoinLeaveMessage('join', username, color);
 		}
 
-		if (userlistItem !== null) {
-			var newhtml = $(userlistItem.html).find('#userlist_table tbody').append(this.getUserItem(e.viewId, username, e.extraInfo, color)).parent().parent()[0].outerHTML;
-			userlistItem.html = newhtml;
-			this.updateUserListCount();
-		}
-
-		this.options.listUser.push({viewId: e.viewId, userName: username, extraInfo: e.extraInfo, color: color});
-		this.renderHeaderAvatars();
+		this.renderAll();
 	}
 
 	onRemoveView(e: UserEvent) {
-		var username = this.escapeHtml(e.username);
+		const user = this.users.get(e.viewId);
+		this.users.delete(e.viewId);
+
+		if (user !== undefined) {
+			this.showJoinLeaveMessage('leave', user.username, user.color);
+		}
+
+		this.renderAll();
+	}
+
+	renderAll() {
+		this.updateUserListCount();
+		this.renderHeaderAvatars();
+		this.renderHeaderAvatarPopover();
+		this.renderUserList();
+	}
+
+	showJoinLeaveMessage(type: 'join' | 'leave', username: string, _color: string /* TODO: make this display in user colors */) {
+		let message;
+
+		if (type === 'join') {
+			message = this.options.userJoinedPopupMessage.replace('%user', username);
+		} else {
+			message = this.options.userLeftPopupMessage.replace('%user', username);
+		}
+
 		$('#tb_actionbar_item_userlist')
 			.w2overlay({
 				class: 'cool-font',
-				html: this.options.userLeftPopupMessage.replace('%user', username),
+				html: message,
 				style: 'padding: 5px'
 			});
+
 		clearTimeout(this.options.userPopupTimeout);
-		this.options.userPopupTimeout = setTimeout(() => {
-			$('#tb_actionbar_item_userlist').w2overlay('');
-			clearTimeout(this.options.userPopupTimeout);
-			this.options.userPopupTimeout = null;
-		}, 3000);
+		this.options.userPopupTimeout = setTimeout(() => $('#tb_actionbar_item_userlist').w2overlay(''), 3000);
+	}
 
-		if (e.viewId === this.map._docLayer._followThis) {
-			this.map._docLayer._followThis = -1;
-			this.map._docLayer._followUser = false;
-		}
+	renderUserList() {
+		const headerUserList = Array.from(this.users.entries());
 
-		var userlistItem = w2ui['actionbar'].get('userlist');
-		if (userlistItem !== null) {
-			userlistItem.html = $(userlistItem.html).find('#user-' + e.viewId).remove().end()[0].outerHTML;
-			this.updateUserListCount();
-			this.removeUserFromHeaderAvatars(e.viewId);
-		}
+		const userItems = headerUserList.map(([viewId, user]) => {
+			let username = user.username;
+
+			if (user.readonly) {
+				username += ' (' +  _('Readonly') + ')';
+			}
+
+			return this.getUserItem(viewId, username, user.extraInfo, user.color);
+		});
+
+		const userlistItem = w2ui['actionbar'].get('userlist');
+		const userlistElement = $(userlistItem.html).find('#userlist_table tbody');
+		userlistElement.children().replaceWith(userItems);
+		const newHtml = userlistElement.parent().parent()[0].outerHTML;
+		userlistItem.html = newHtml;
+	}
+
+	renderHeaderAvatarPopover() {
+		// Popover rendering
+		const users = Array.from(this.users.entries());
+		const popoverElement = document.getElementById('userListPopover');
+
+		const userElements = users.map(([viewId, user]) => {
+			const userLabel = L.DomUtil.create('div', 'user-list-item--name');
+			userLabel.innerText = user.username;
+
+			const userFollowingLabel = L.DomUtil.create('div', 'user-list-item--following-label');
+			userFollowingLabel.innerText = _('Following');
+
+			const userLabelContainer = L.DomUtil.create('div', 'user-list-item--name-container');
+			userLabelContainer.appendChild(userLabel);
+			userLabelContainer.appendChild(userFollowingLabel);
+
+			const listItem = L.DomUtil.create('div', 'user-list-item');
+			listItem.setAttribute('data-view-id', viewId);
+			listItem.setAttribute('role', 'button');
+			listItem.appendChild(this.createAvatar(viewId, user.extraInfo, user.color));
+			listItem.appendChild(userLabelContainer);
+			listItem.addEventListener('click', () => {
+				this.followUser(viewId);
+			});
+
+			return listItem;
+		});
+
+		const followEditorWrapper = L.DomUtil.create('div', '');
+		followEditorWrapper.id = 'follow-editor';
+		const followEditorCheckbox = L.DomUtil.create('input', 'follow-editor-checkbox', followEditorWrapper);
+		followEditorCheckbox.id = 'follow-editor-checkbox';
+		followEditorCheckbox.setAttribute('type', 'checkbox');
+		followEditorCheckbox.onchange = function(event: Event) {
+			(window as any).editorUpdate(event);
+		};
+		const followEditorCheckboxLabel = L.DomUtil.create('label', 'follow-editor-label', followEditorWrapper);
+		followEditorCheckboxLabel.innerText = _('Always follow the editor');
+		followEditorCheckboxLabel.setAttribute('for', 'follow-editor-checkbox');
+
+		popoverElement.replaceChildren(...userElements, followEditorWrapper);
+
+		(document.getElementById('follow-editor-checkbox') as HTMLInputElement).checked = this.map._docLayer._followEditor;
 	}
 }
 

--- a/browser/src/layer/marker/Cursor.ts
+++ b/browser/src/layer/marker/Cursor.ts
@@ -1,6 +1,5 @@
 /* eslint-disable */
 
-declare var $: any;
 declare var L: any;
 
 /*

--- a/browser/src/layer/tile/CommentListSection.ts
+++ b/browser/src/layer/tile/CommentListSection.ts
@@ -43,7 +43,6 @@ L.Map.include({
 
 declare var L: any;
 declare var app: any;
-declare var $: any;
 declare var _: any;
 
 namespace cool {

--- a/browser/src/layer/tile/CommentSection.ts
+++ b/browser/src/layer/tile/CommentSection.ts
@@ -14,7 +14,6 @@ declare var app: any;
 declare var _: any;
 declare var Autolinker: any;
 declare var Hammer: any;
-declare var $: any;
 
 namespace cool {
 

--- a/browser/src/layer/tile/TilesSection.ts
+++ b/browser/src/layer/tile/TilesSection.ts
@@ -11,7 +11,6 @@
 /* See CanvasSectionContainer.ts for explanations. */
 
 declare var L: any;
-declare var $: any;
 declare var Hammer: any;
 declare var app: any;
 

--- a/browser/src/w2overlay.d.ts
+++ b/browser/src/w2overlay.d.ts
@@ -1,0 +1,3 @@
+interface JQuery {
+	w2overlay: any;
+}


### PR DESCRIPTION
This pull request includes all changes from #8408, please don't comment on any commits before 9995a26dfb542905010ce58e909e0a036c0d922c as they will be removed via rebase when that is merged. You can view a diff [here](https://github.com/CollaboraOnline/online/compare/private/skyler/following-ui-parts/typescript..private/skyler/following-ui-parts/user-list-reorder) or select only the right commits in the GitHub pull request review UI

**Use a map for users and rerender all on changes**:
This stops us from iterating through dom elements to modify them
directly, which should make it easier for us to reorder them or change
their state at relevant points. Additionally, using a Map rather than a
list will make it easier to address users by their view ID which will
help modify specific users (e.g. for following status)

**Reorder the user list so you are top**:
The user list is currently haphazardly ordered, which makes it hard to
find yourself in the list. This is especially important as unfollowing
someone currently requires you to press on yourself (although I'm
making changes so this will no longer be the case).

This commit also lays part of the groundwork for sorting the user you
are following at the top of the list, and readonly users at the bottom.

**Reorder users so important users are higher**:
This commit makes 3 changes to the user list order

Moving the followed user to the top of the list, above you:
- Moving the followed user to the top continues my effort to move the
  most important information to the top of the user list. It's crucial
  to see who you're following, and I have a planned feature to allow you
  to click to unfollow them too. Moving the users to the top of the list
  will make this planned feature easier to reach
- Additionally, this will let us use the left side of the avatar list to
  add extra context to the followed user, such as a chip which says
  their name, while making it clear which user we're talking about.

Moving readonly users to the bottom of the list (excepting you if you
are readonly):
- This commit also moves readonly users to the bottom of the user list,
  as they are generally not as important as regular, editing users.

Flipping all other users so users who joined more recently are at the
top:
- This gives a bit more feedback when a user joins, as in addition to
  the popup in the top left corner of the screen you are also able to
  see their avatar in the list