### PR TITLE
notebookbar: event prevent default for insert annotation button (backport)

### DIFF
--- a/browser/src/control/Control.NotebookbarBuilder.js
+++ b/browser/src/control/Control.NotebookbarBuilder.js
@@ -943,7 +943,8 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 	_insertAnnotationControl: function(parentContainer, data, builder) {
 		var control = builder._unoToolButton(parentContainer, data, builder);
 		$(control.container).unbind('click.toolbutton');
-		$(control.container).click(function () {
+		$(control.container).click(function (e) {
+			e.preventDefault();
 			var docLayer = builder.map._docLayer;
 			if (!(docLayer._docType === 'spreadsheet' && docLayer._hasActiveSelection)) {
 				builder.map.insertComment();


### PR DESCRIPTION
problem:
if writer->insert tab-> insert comment button is clicked, if button is clicked from icon is works fine,
but if button is clicked on label event is triggered twice, which caused js errors


Change-Id: I3956083b02204733abc3543c73f6019d3a3b4c67


* Target version: distro/collabora/co-23.05 


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

