### PR TITLE
Close all dialogs on document idle

### DIFF
--- a/browser/src/control/Control.IdleHandler.ts
+++ b/browser/src/control/Control.IdleHandler.ts
@@ -124,6 +124,7 @@ class IdleHandler {
 	}
 
 	_dim() {
+		this.map.fire('closealldialogs');
 		const message = this.getIdleMessage();
 
 		window.app.console.debug('IdleHandler: _dim()');

--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -96,7 +96,7 @@ L.Control.JSDialog = L.Control.extend({
 			if (leaveSnackbar && dialogs[i] && dialogs[i] === 'snackbar')
 				continue;
 
-			this.close(dialogs[i], true);
+			this.close(dialogs[i], app.idleHandler._active);
 		}
 	},
 
@@ -154,6 +154,8 @@ L.Control.JSDialog = L.Control.extend({
 
 	onCloseAll: function() {
 		this.closeAll(/*leaveSnackbar*/ true);
+		// should also close all dropdowns on close all dialogs
+		this.closeAllDropdowns();
 	},
 
 	focusToLastElement: function(id) {

--- a/cypress_test/integration_tests/idle/calc/idle_spec.js
+++ b/cypress_test/integration_tests/idle/calc/idle_spec.js
@@ -46,4 +46,24 @@ describe(['tagdesktop'], 'Idle', function() {
 
 		checkIfIsInteractiveAgain();
 	});
+
+	it('Check interactivity of document after dialog close', function() {
+		// Check if sidebar-dock-wrapper is visible
+		cy.cGet('#sidebar-dock-wrapper').should('be.visible').then(($sidebar) => {
+			// If it's not visible, click on SidebarDeck.PropertyDeck to make it visible
+			if (!$sidebar.is(':visible')) {
+				cy.cGet('#SidebarDeck.PropertyDeck').click();
+			}
+		});
+		cy.cGet('div.sidebar#fontnamecombobox > div').click();
+		cy.cGet(dimDialogSelector).should('not.exist');
+		cy.wait(7100); // inactivity timeout is 7s
+		cy.cGet(dimDialogSelector).should('exist');
+
+		// check if cell is editable or not after document again become active
+		checkIfIsInteractiveAgain();
+
+		// Make sure the sidebar dropdown is closed after document again become interactive
+		cy.get('#fontnamecombobox-entries').should('not.exist');
+	});
 });

--- a/cypress_test/integration_tests/idle/calc/idle_spec.js
+++ b/cypress_test/integration_tests/idle/calc/idle_spec.js
@@ -55,7 +55,8 @@ describe(['tagdesktop'], 'Idle', function() {
 				cy.cGet('#SidebarDeck.PropertyDeck').click();
 			}
 		});
-		cy.cGet('div.sidebar#fontnamecombobox > div').click();
+		cy.cGet('div.sidebar#Underline > .arrowbackground').click();
+		cy.cGet('.jsdialog-window.modalpopup').should('exist');
 		cy.cGet(dimDialogSelector).should('not.exist');
 		cy.wait(7100); // inactivity timeout is 7s
 		cy.cGet(dimDialogSelector).should('exist');
@@ -64,6 +65,6 @@ describe(['tagdesktop'], 'Idle', function() {
 		checkIfIsInteractiveAgain();
 
 		// Make sure the sidebar dropdown is closed after document again become interactive
-		cy.get('#fontnamecombobox-entries').should('not.exist');
+		cy.cGet('.jsdialog-window.modalpopup').should('not.exist');
 	});
 });


### PR DESCRIPTION
- All dialogs should be closed if document become idle
- There are 2 cases for which all dialogs are being closed before socket closed or before screen dim 1. Document idle : we disconnect from server 2. View idle: only screen dim, server is still connected

To test:
    - add auto filter in calc sheet
    - open autofilter popup
    - wait for document to become idle

Note: change value of `idle_timeout_secs` in coolwsd.xml to test

Change-Id: If76f03d830b8b3744fd2b54d131c5fa85a024c5c




