### PR TITLE
Handle specific tooltip message for function usage tooltip

### DIFF
--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -1027,13 +1027,35 @@ L.Control.UIManager = L.Control.extend({
 		this.map.fire('hidebusy');
 	},
 
+	// Document area tooltip
+
+	/// Shows general tooltips in the document area
+	/// tooltipInfo contains rectangle (position in twips) and text properties
+	showDocumentTooltip: function(tooltipInfo) {
+		var split = tooltipInfo.rectangle.split(',');
+		var latlng = this.map._docLayer._twipsToLatLng(new L.Point(+split[0], +split[1]));
+		var pt = this.map.latLngToContainerPoint(latlng);
+		var elem = $('.leaflet-layer');
+
+		elem.tooltip();
+		elem.tooltip('enable');
+		elem.tooltip('option', 'content', tooltipInfo.text);
+		elem.tooltip('option', 'items', elem[0]);
+		elem.tooltip('option', 'position', { my: 'left bottom',  at: 'left+' + pt.x + ' top+' + pt.y, collision: 'fit fit' });
+		elem.tooltip('open');
+		document.addEventListener('mousemove', function() {
+			elem.tooltip('close');
+			elem.tooltip('disable');
+		}, {once: true});
+	},
+
 	// Calc function tooltip
 
 	/// Shows tooltip over the cell while typing a function in a cell.
 	/// tooltipInfo contains possible function list. If you type a valid
-	/// function it'll show the usage of the function. elem has to be
-	/// jQuery selector output eg. $('.leaflet-layer')
-	showDocumentTooltip: function(tooltipInfo, elem, pos) {
+	/// function it'll show the usage of the function.
+	showFormulaTooltip: function(tooltipInfo, pos) {
+		var elem = $('.leaflet-layer');
 		var pt = this.map.latLngToContainerPoint(pos);
 		pt.y -=35; //Show tooltip above the cursor.
 
@@ -1053,7 +1075,8 @@ L.Control.UIManager = L.Control.extend({
 		}
 	},
 
-	hideDocumentTooltip: function(elem) {
+	hideFormulaTooltip: function() {
+		var elem = $('.leaflet-layer');
 		if ($('.ui-tooltip').length > 0)
 			elem.tooltip('option', 'disabled', true);
 	},

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1756,7 +1756,17 @@ L.CanvasTileLayer = L.Layer.extend({
 			this._onCalcFunctionListMsg(textMsg.substring('calcfunctionlist:'.length + 1));
 		}
 		else if (textMsg.startsWith('tooltip:')) {
-			this._onCalcFunctionUsageMsg(textMsg.substring('tooltip:'.length + 1));
+			var tooltipInfo = JSON.parse(textMsg.substring('tooltip:'.length + 1));
+			if (tooltipInfo.type === 'formulausage') {
+				this._onCalcFunctionUsageMsg(tooltipInfo.text);
+			}
+			else if (tooltipInfo.type === 'generaltooltip') {
+				var tooltipInfo = JSON.parse(textMsg.substring(textMsg.indexOf('{')));
+				this._map.uiManager.showDocumentTooltip(tooltipInfo);
+			}
+			else {
+				console.error('unknown tooltip type');
+			}
 		}
 		else if (textMsg.startsWith('tabstoplistupdate:')) {
 			this._onTabStopListUpdate(textMsg);
@@ -1950,12 +1960,12 @@ L.CanvasTileLayer = L.Layer.extend({
 
 	_onCalcFunctionUsageMsg: function (textMsg) {
 		var pos = this._lastVisibleCursorRef._northEast;
-		this._map.uiManager.showDocumentTooltip(textMsg, $('.leaflet-layer'), pos);
+		this._map.uiManager.showFormulaTooltip(textMsg, pos);
 	},
 
 	_onCalcFunctionListMsg: function (textMsg) {
 		if (textMsg.startsWith('hidetip')) {
-			this._map.uiManager.hideDocumentTooltip($('.leaflet-layer'));
+			this._map.uiManager.hideFormulaTooltip();
 		}
 		else {
 			var funcData = JSON.parse(textMsg);
@@ -1984,7 +1994,7 @@ L.CanvasTileLayer = L.Layer.extend({
 			else {
 				var pos = this._lastVisibleCursorRef._northEast;
 				var tooltipinfo = this._getFunctionList(textMsg);
-				this._map.uiManager.showDocumentTooltip(tooltipinfo, $('.leaflet-layer'), pos);
+				this._map.uiManager.showFormulaTooltip(tooltipinfo, pos);
 			}
 		}
 	},


### PR DESCRIPTION
Using same callback caused a regression about showing tooltip while reviewing a change in writer. So we have to use a special message for function usage tooltip.


Change-Id: I6f769a43af6a01ed8e13abfd9c35a57ccd47c1ac


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

