### PR TITLE
23.05 backport impress: Make sure that dropping a slide between slides reorder correctly.

### DIFF
--- a/browser/src/control/Control.PartsPreview.js
+++ b/browser/src/control/Control.PartsPreview.js
@@ -863,7 +863,13 @@ L.Control.PartsPreview = L.Control.extend({
 			e.stopPropagation();
 		}
 
-		var part = this.partsPreview._findClickedPart(e.target.parentNode);
+		// When dropping on a thumbnail we get an `img` tag as a target, so we need to get the
+		// parent.
+		// Otherwise dropping between slides doesn't work.
+		// See https://github.com/CollaboraOnline/online/issues/6941
+		var target = e.target.classList.contains('preview-img') ? e.target.parentNode : e.target;
+
+		var part = this.partsPreview._findClickedPart(target);
 		if (part !== null) {
 			var partId = parseInt(part) - 1; // First frame is a drop-site for reordering.
 			if (partId < 0)


### PR DESCRIPTION
Backport to 23.05 from #8388

We need to get the right node in the control

See https://github.com/CollaboraOnline/online/issues/6941


Change-Id: Ib37c6411667fcbf4714e6f6448292c84adc78f0e


* Resolves: #6941, #8388 <!-- related github issue -->  
* Target version: 23.05 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

