### PR TITLE
calc: tab drag&drop does not work properly

### DIFF
--- a/browser/src/control/Control.Tabs.js
+++ b/browser/src/control/Control.Tabs.js
@@ -332,7 +332,11 @@ L.Control.Tabs = L.Control.extend({
 
 	//selected sheet is moved to new index
 	_moveSheet: function (newIndex) {
-		this._map._docLayer._sheetSwitch.updateOnSheetMoved(this._map.getPartNumber(), newIndex - 1);
+		var currentTab = this._map.getCurrentPartNumber();
+		// odd but true: the base index changes according to the tab is dragged
+		// on the left or on the right wrt the current tab position
+		var newIndexZeroBased = newIndex > currentTab ? newIndex - 2 : newIndex - 1;
+		this._map._docLayer._sheetSwitch.updateOnSheetMoved(currentTab, newIndexZeroBased);
 		this._map.sendUnoCommand('.uno:Move?Copy:bool=false&UseCurrentDocument:bool=true&Index=' + newIndex);
 	},
 

--- a/browser/src/layer/tile/SheetSwitch.ts
+++ b/browser/src/layer/tile/SheetSwitch.ts
@@ -54,7 +54,6 @@ export class SheetSwitchViewRestore {
 	}
 
 	public updateOnSheetMoved(oldIndex: number, newIndex: number): void {
-		window.app.console.log('SheetSwitchViewRestore.updateOnSheetMoved: oldIndex: ' + oldIndex + ', newIndex: ' + newIndex);
 		if (oldIndex < 0 || newIndex < 0 || oldIndex === newIndex)
 			return;
 


### PR DESCRIPTION
This is a regression from 74a4484e "calc: on tab switching document
view can be restored to a wrong position"

Moreover the passed index was wrong when tab is dragged on the right
wrt to current tab position. Now the correct zero based index is
always computed.

Signed-off-by: Marco Cecchetti <marco.cecchetti@collabora.com>
Change-Id: I7395773da5a846ce61d8508bbd1d6e2e833d4511
