### PR TITLE
annotation: avoid resetting comment show state if being edited (backport)

### DIFF
--- a/browser/src/layer/tile/CommentListSection.ts
+++ b/browser/src/layer/tile/CommentListSection.ts
@@ -1526,7 +1526,8 @@ export class CommentSection extends CanvasSectionObject {
 			height = subList[i].sectionProperties.container.getBoundingClientRect().height;
 			lastY = subList[i].sectionProperties.data.anchorPix[1] + height < lastY ? subList[i].sectionProperties.data.anchorPix[1]: lastY - height;
 			(new L.PosAnimation()).run(subList[i].sectionProperties.container, {x: Math.round(actualPosition[0] / app.dpiScale), y: Math.round(lastY / app.dpiScale)});
-			subList[i].show();
+			if (!subList[i].isEdit())
+				subList[i].show();
 		}
 		return lastY;
 	}


### PR DESCRIPTION
problem:
when try to insert comment(inside text with existing comment) and comment field is empty, click on some other comment(which is on same text), it will cause an empty comment insertion in DOM which can not be removed until doc reload.
This subsequently prevented new comment insertion.


Change-Id: I29294dcfbbaddddaa768e08b47b855b3e8c7f454


* Target version: distro/collabora/co-23.05 



### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

