### PR TITLE
wsd: move deprecated logic under legacy_server config

### DIFF
--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -254,6 +254,7 @@
             <!-- More "group"s possible here -->
             </alias_groups>
 
+            <is_legacy_server desc="Set to true for legacy server that need deprecated headers." type="bool" default="false"></is_legacy_server>
         </wopi>
         <ssl desc="SSL settings">
             <as_scheme type="bool" default="true" desc="When set we exclusively use the WOPI URI's scheme to enable SSL for storage">true</as_scheme>

--- a/test/UnitWOPIAsyncUpload_ModifyClose.cpp
+++ b/test/UnitWOPIAsyncUpload_ModifyClose.cpp
@@ -44,11 +44,11 @@ public:
         {
             // The document is modified.
             LOK_ASSERT_EQUAL(std::string("true"), request.get("X-COOL-WOPI-IsModifiedByUser"));
-            LOK_ASSERT_EQUAL(std::string("true"), request.get("X-LOOL-WOPI-IsModifiedByUser"));
+            LOK_ASSERT_EQUAL(false, request.has("X-LOOL-WOPI-IsModifiedByUser"));
 
             // Triggered manually or during closing, not auto-save.
             LOK_ASSERT_EQUAL(std::string("false"), request.get("X-COOL-WOPI-IsAutosave"));
-            LOK_ASSERT_EQUAL(std::string("false"), request.get("X-LOOL-WOPI-IsAutosave"));
+            LOK_ASSERT_EQUAL(false, request.has("X-LOOL-WOPI-IsAutosave"));
 
             TRANSITION_STATE(_phase, Phase::WaitDestroy);
 

--- a/test/UnitWOPIFailUpload.cpp
+++ b/test/UnitWOPIFailUpload.cpp
@@ -483,6 +483,7 @@ public:
         // We intentionally fail uploading twice, so need at least 3 tries.
         config.setUInt("per_document.limit_store_failures", 3);
         config.setBool("per_document.always_save_on_exit", false);
+        config.setBool("storage.wopi.is_legacy_server", true);
     }
 
     std::unique_ptr<http::Response>
@@ -653,10 +654,10 @@ public:
     assertPutFileRequest(const Poco::Net::HTTPRequest& request) override
     {
         LOK_ASSERT_EQUAL(std::string("true"), request.get("X-COOL-WOPI-IsModifiedByUser"));
-        LOK_ASSERT_EQUAL(std::string("true"), request.get("X-LOOL-WOPI-IsModifiedByUser"));
+        LOK_ASSERT_EQUAL(false, request.has("X-LOOL-WOPI-IsModifiedByUser"));
 
         LOK_ASSERT_EQUAL(std::string("false"), request.get("X-COOL-WOPI-IsAutosave"));
-        LOK_ASSERT_EQUAL(std::string("false"), request.get("X-LOOL-WOPI-IsAutosave"));
+        LOK_ASSERT_EQUAL(false, request.has("X-LOOL-WOPI-IsAutosave"));
 
         // We save twice. First right after loading, unmodified.
         if (_phase == Phase::WaitFirstPutFile)
@@ -665,7 +666,7 @@ public:
 
             // Certainly not exiting yet.
             LOK_ASSERT_EQUAL(std::string("false"), request.get("X-COOL-WOPI-IsExitSave"));
-            LOK_ASSERT_EQUAL(std::string("false"), request.get("X-LOOL-WOPI-IsExitSave"));
+            LOK_ASSERT_EQUAL(false, request.has("X-LOOL-WOPI-IsExitSave"));
 
             // Fail with error.
             LOG_TST("Returning 500 to simulate PutFile failure");
@@ -678,7 +679,7 @@ public:
 
         // Triggered while closing.
         LOK_ASSERT_EQUAL(std::string("true"), request.get("X-COOL-WOPI-IsExitSave"));
-        LOK_ASSERT_EQUAL(std::string("true"), request.get("X-LOOL-WOPI-IsExitSave"));
+        LOK_ASSERT_EQUAL(false, request.has("X-LOOL-WOPI-IsExitSave"));
 
         return nullptr;
     }

--- a/test/UnitWOPILock.cpp
+++ b/test/UnitWOPILock.cpp
@@ -225,11 +225,11 @@ public:
 
         // The document is modified.
         LOK_ASSERT_EQUAL(std::string("true"), request.get("X-COOL-WOPI-IsModifiedByUser"));
-        LOK_ASSERT_EQUAL(std::string("true"), request.get("X-LOOL-WOPI-IsModifiedByUser"));
+        LOK_ASSERT_EQUAL(false, request.has("X-LOOL-WOPI-IsModifiedByUser"));
 
         // Triggered manually or during closing, not auto-save.
         LOK_ASSERT_EQUAL(std::string("false"), request.get("X-COOL-WOPI-IsAutosave"));
-        LOK_ASSERT_EQUAL(std::string("false"), request.get("X-LOOL-WOPI-IsAutosave"));
+        LOK_ASSERT_EQUAL(false, request.has("X-LOOL-WOPI-IsAutosave"));
 
         // The only editor goes away.
         // LOK_ASSERT_EQUAL(std::string("true"), request.get("X-COOL-WOPI-IsExitSave"));

--- a/test/WopiTestServer.hpp
+++ b/test/WopiTestServer.hpp
@@ -246,6 +246,9 @@ protected:
         UnitWSD::configure(config);
         // we're still internally confused as to https vs. http in places.
         config.setBool("storage.ssl.as_scheme", false);
+
+        // Reset to default.
+        config.setBool("storage.wopi.is_legacy_server", false);
     }
 
     /// Returns the default CheckFileInfo json.

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -2052,6 +2052,7 @@ void COOLWSD::innerInitialize(Application& self)
         { "storage.wopi.max_file_size", "0" },
         { "storage.wopi[@allow]", "true" },
         { "storage.wopi.locking.refresh", "900" },
+        { "storage.wopi.is_legacy_server", "false" },
         { "sys_template_path", "systemplate" },
         { "trace_event[@enable]", "false" },
         { "trace.path[@compress]", "true" },

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -24,7 +24,6 @@
 #include "HttpRequest.hpp"
 #include "COOLWSD.hpp"
 #include "Log.hpp"
-#include "Util.hpp"
 #include <common/Authorization.hpp>
 #include <net/HttpRequest.hpp>
 
@@ -698,11 +697,16 @@ public:
                 const std::string& jailPath)
         : StorageBase(uri, localStorePath, jailPath)
         , _wopiSaveDuration(std::chrono::milliseconds::zero())
+        , _legacyServer(COOLWSD::getConfigValue<bool>("storage.wopi.is_legacy_server", false))
     {
         LOG_INF("WopiStorage ctor with localStorePath: ["
                 << localStorePath << "], jailPath: [" << jailPath << "], uri: ["
-                << COOLWSD::anonymizeUrl(uri.toString()) << ']');
+                << COOLWSD::anonymizeUrl(uri.toString()) << "], legacy server: " << _legacyServer);
     }
+
+    /// Signifies if the server is legacy or not, based on the headers
+    /// it sent us on first contact.
+    bool isLegacyServer() const { return _legacyServer; }
 
     /// Handles the response from CheckFileInfo, as converted into WOPIFileInfo.
     /// Also extracts the basic file information from the response
@@ -774,6 +778,9 @@ private:
 
     /// The http::Session used for uploading asynchronously.
     std::shared_ptr<http::Session> _uploadHttpSession;
+
+    /// Whether or not this is a legacy server.
+    const bool _legacyServer;
 #endif // !MOBILEAPP
 };
 


### PR DESCRIPTION
We no longer send LOOL-WOPI headers, unless
the configuration specifically flags for
legacy servers. But we always send COOL-WOPI
even to legacy servers, to help them upgrade
seamlessly.

Change-Id: Ifc919ed8f6665cd8f846117ef4e8b7ef09fbd563
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
