### PR TITLE
cool#8023 browser: try to use the new Chrome clipboard in non-experimental mode

### DIFF
--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -765,11 +765,6 @@ L.Clipboard = L.Class.extend({
 
 	// Executes the navigator.clipboard.read() call, if it's available.
 	_navigatorClipboardRead: function(isSpecial) {
-		if (window.app.socket.WSDServer.Options.indexOf('E') === -1) {
-			// Experimental features are disabled, don't try to use navigator.clipboard.
-			return false;
-		}
-
 		if (navigator.clipboard.read === undefined) {
 			return false;
 		}


### PR DESCRIPTION
Now that
<https://sdk.collaboraonline.com/docs/advanced_integration.html#clipboard-handling>
is figured out, this should be less risky.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I549adad6386d328d7dc5f7e4eeee16446665df82