### PR TITLE
browser: fix regression print range

### DIFF
--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -1270,7 +1270,6 @@ L.Map.include({
 			this.uiManager.toggleWasm();
 			break;
 		case 'print-active-sheet':
-			this.sendUnoCommand('.uno:DeletePrintArea');
 			var currentSheet = this._docLayer._selectedPart + 1;
 			var options  = {
 				ExportFormFields: {
@@ -1290,7 +1289,6 @@ L.Map.include({
 			this.print(options);
 			break;
 		case 'print-all-sheets':
-			this.sendUnoCommand('.uno:DeletePrintArea');
 			this.print();
 			break;
 		case 'savecomments':


### PR DESCRIPTION
Do not send the command ".uno:DeletePrintArea" to server side,
it disables printing range feature.

Change-Id: I8bb1ec9ab01793e6bf3b74b8cb121a5fbad3b8e2
Signed-off-by: Henry Castro <hcastro@collabora.com>