### PR TITLE
Move freeze options to view tab and add freeze-panes options to column/row header context menu

### DIFF
--- a/browser/src/control/Control.ColumnHeader.ts
+++ b/browser/src/control/Control.ColumnHeader.ts
@@ -86,6 +86,10 @@ export class ColumnHeader extends Header {
 			'.uno:ShowColumn': {
 				name: _UNO('.uno:ShowColumn', 'spreadsheet', true),
 				callback: (this._showColumn).bind(this)
+			},
+			'.uno:FreezePanes': {
+				name: _UNO('.uno:FreezePanes', 'spreadsheet', true),
+				callback: (this._freezePanes).bind(this)
 			}
 		};
 

--- a/browser/src/control/Control.Header.ts
+++ b/browser/src/control/Control.Header.ts
@@ -426,6 +426,10 @@ export class Header extends CanvasSectionObject {
 		}
 	}
 
+	_freezePanes (): void {
+		this._map.sendUnoCommand('.uno:FreezePanes');
+	}
+
 	_entryAtPoint(point: number[]): PointEntryQueryResult {
 		if (!this._headerInfo)
 			return undefined;

--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -1042,43 +1042,6 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				'vertical': 'true'
 			},
 			{
-				'id': 'layout-freeze-panes',
-				'type': 'bigtoolitem',
-				'text': _UNO('.uno:FreezePanes', 'spreadsheet', true),
-				'command': '.uno:FreezePanes',
-				'accessibility': { focusBack: true,	combination: 'FP', de: null }
-			},
-			{
-				'type': 'container',
-				'children': [
-					{
-						'type': 'toolbox',
-						'children': [
-							{
-								'id': 'layout-freeze-panes-column',
-								'type': 'toolitem',
-								'text':_UNO('.uno:FreezePanesColumn', 'spreadsheet', true),
-								'command': '.uno:FreezePanesColumn',
-								'accessibility': { focusBack: true,	combination: 'FC', de: null }
-							}
-						]
-					},
-					{
-						'type': 'toolbox',
-						'children': [
-							{
-								'id': 'layout-freeze-panes-row',
-								'type': 'toolitem',
-								'text': _UNO('.uno:FreezePanesRow', 'spreadsheet', true),
-								'command': '.uno:FreezePanesRow',
-								'accessibility': { focusBack: true,	combination: 'FR', de: null }
-							}
-						]
-					}
-				],
-				'vertical': 'true'
-			},
-			{
 				'id': 'layout-select-all',
 				'type': 'bigtoolitem',
 				'text': _UNO('.uno:SelectAll'),
@@ -1200,6 +1163,43 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 
 	getViewTab: function() {
 		var content = [
+			{
+				'id': 'layout-freeze-panes',
+				'type': 'bigtoolitem',
+				'text': _UNO('.uno:FreezePanes', 'spreadsheet', true),
+				'command': '.uno:FreezePanes',
+				'accessibility': { focusBack: true,	combination: 'FP', de: null }
+			},
+			{
+				'type': 'container',
+				'children': [
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'id': 'layout-freeze-panes-column',
+								'type': 'toolitem',
+								'text':_UNO('.uno:FreezePanesColumn', 'spreadsheet', true),
+								'command': '.uno:FreezePanesColumn',
+								'accessibility': { focusBack: true,	combination: 'FC', de: null }
+							}
+						]
+					},
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'id': 'layout-freeze-panes-row',
+								'type': 'toolitem',
+								'text': _UNO('.uno:FreezePanesRow', 'spreadsheet', true),
+								'command': '.uno:FreezePanesRow',
+								'accessibility': { focusBack: true,	combination: 'FR', de: null }
+							}
+						]
+					}
+				],
+				'vertical': 'true'
+			},
 			(window.mode.isTablet()) ?
 				{
 					'id': 'closemobile',

--- a/browser/src/control/Control.RowHeader.ts
+++ b/browser/src/control/Control.RowHeader.ts
@@ -90,6 +90,10 @@ export class RowHeader extends cool.Header {
 			'.uno:ShowRow': {
 				name: _UNO('.uno:ShowRow', 'spreadsheet', true),
 				callback: (this._showRow).bind(this)
+			},
+			'.uno:FreezePanes': {
+				name: _UNO('.uno:FreezePanes', 'spreadsheet', true),
+				callback: (this._freezePanes).bind(this)
 			}
 		};
 


### PR DESCRIPTION
- move freeze options from layout tab to view tab
- options should be consistent for both compact and tabbed view
- Add freeze-panes options to column/row headers