### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.{js,ts}]
+charset = utf-8
+indent_style = tab


### PR DESCRIPTION
.editorconfig is "a file format for defining coding styles" which is understood by various editors. It can allow for, for example, vscode to automatically configure whether to use tabs or spaces.

I'm adding it both because my editor seems to incorrectly assume the Javascript in the project should use spaces, as well as to be a precursor for adding prettier in a later commit. I've split it off from prettier as it shouldn't have an effect on the build so should be able to be merged before CI is able to run on the prettier build.

See also: #7857

Change-Id: Id0b1da1388a1fb2706d64623a6d8f35f9a1c605f


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

