### PR TITLE
lok_allow: remove also port (backport)

### DIFF
--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -311,13 +311,28 @@ void COOLWSD::appendAllowedHostsFrom(LayeredConfiguration& conf, const std::stri
 }
 
 namespace {
-std::string removeProtocol(const std::string& host)
+std::string removeProtocolAndPort(const std::string& host)
 {
+    std::string result;
+
+    // protocol
     size_t nPos = host.find("//");
     if (nPos != std::string::npos)
-        return host.substr(nPos + 2);
+        result = host.substr(nPos + 2);
+    else
+        result = host;
 
-    return host;
+    // port
+    nPos = result.find(":");
+    if (nPos != std::string::npos)
+    {
+        if (nPos == 0)
+            return "";
+
+        result = result.substr(0, nPos);
+    }
+
+    return result;
 }
 
 bool isValidRegex(const std::string& expression)
@@ -350,9 +365,10 @@ void COOLWSD::appendAllowedAliasGroups(LayeredConfiguration& conf, std::vector<s
             break;
         }
 
+        host = removeProtocolAndPort(host);
+
         if (!host.empty())
         {
-            host = removeProtocol(host);
             LOG_INF_S("Adding trusted LOK_ALLOW host: [" << host << ']');
             allowed.push_back(host);
         }
@@ -367,9 +383,9 @@ void COOLWSD::appendAllowedAliasGroups(LayeredConfiguration& conf, std::vector<s
 
             std::string alias = getConfigValue<std::string>(conf, aliasPath, "");
 
-            if (!aliasPath.empty())
+            alias = removeProtocolAndPort(alias);
+            if (!alias.empty())
             {
-                alias = removeProtocol(alias);
                 LOG_INF_S("Adding trusted LOK_ALLOW alias: [" << alias << ']');
                 allowed.push_back(alias);
             }


### PR DESCRIPTION
Noticed in some k8s deployments where alias groups were defined with port. For lok_allow we need only host name. Avoid adding empty hosts.