### PR TITLE
Fix processing of URL parameters (in proxy.php case)

### DIFF
--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -80,8 +80,9 @@ window.app = {
 
 	global.setLogging(global.coolLogging != '');
 
+	var gls = global.location.search;
 	var coolParams = {
-		p: new URLSearchParams(global.location.search),
+		p: new URLSearchParams(gls.slice(gls.lastIndexOf('?') + 1)),
 	};
 	/* We need to return an empty string instead of `null` */
 	coolParams.get = function(name) {


### PR DESCRIPTION
The URLSearchParams() function was confused in the proxy.php case, because the global.location.search contained two '?' marks, like ?req=/browser/dist/cool.html?WOPISrc=...&lang=..&etc... In the normal case the string started with ?WOPISrc=


Change-Id: I566935656be6622d698ea2ba3c949455877526f6

