### PR TITLE
Fix for unit-httpws failure

### DIFF
--- a/test/helpers.hpp
+++ b/test/helpers.hpp
@@ -13,6 +13,7 @@
 
 #include <test/testlog.hpp>
 #include <test/lokassert.hpp>
+#include <test/test.hpp>
 
 #include <Poco/BinaryReader.h>
 #include <Poco/Dynamic/Var.h>
@@ -962,6 +963,53 @@ inline std::string getAllText(const std::shared_ptr<http::WebSocketSession>& soc
     }
 
     return std::string();
+}
+
+
+inline std::string getPidList(std::set<pid_t> pids)
+{
+    std::ostringstream oss;
+    oss << "[";
+    for (pid_t i : pids)
+    {
+        oss << i << ", ";
+    }
+    oss << "]";
+    return oss.str();
+}
+
+
+inline void waitForKitProcessToStop(
+        const pid_t pid,
+        const std::string& testname,
+        const std::chrono::milliseconds timeoutMs = std::chrono::milliseconds(COMMAND_TIMEOUT_MS * 8),
+        const std::chrono::milliseconds retryMs = std::chrono::milliseconds(10))
+{
+
+    TST_LOG("Waiting for kit process " << pid << " to stop.");
+
+    std::set<pid_t> pids = getDocKitPids();
+    TST_LOG("Active kit pids are: " << getPidList(pids));
+
+    int tries = (timeoutMs / retryMs);
+    while(pids.contains(pid) && tries >= 0)
+    {
+        std::this_thread::sleep_for(retryMs);
+        pids = getDocKitPids();
+        tries--;
+    }
+
+    if (pids.contains(pid))
+    {
+        std::ostringstream oss;
+        oss << "Timed out waiting for kit process " << pid << " to stop. Active kit pids are: " << getPidList(pids);
+        LOK_ASSERT_FAIL(oss.str());
+    }
+    else
+    {
+        TST_LOG("Finished waiting for kit process " << pid << " to stop.");
+        TST_LOG("Active kit pids are: " << getPidList(pids));
+    }
 }
 
 }

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -300,6 +300,14 @@ std::set<pid_t> getKitPids()
 {
     return COOLWSD::getKitPids();
 }
+std::set<pid_t> getSpareKitPids()
+{
+    return COOLWSD::getSpareKitPids();
+}
+std::set<pid_t> getDocKitPids()
+{
+    return COOLWSD::getDocKitPids();
+}
 
 /// Get the PID of the forkit
 std::set<pid_t> getForKitPids()

--- a/test/test.hpp
+++ b/test/test.hpp
@@ -24,7 +24,6 @@ bool runClientTests(const char* cmd, bool standalone, bool verbose);
 
 /// Get the list of all kit PIDs
 std::set<pid_t> getKitPids();
-
 /// Get the list of spare (unused) kit PIDs
 std::set<pid_t> getSpareKitPids();
 /// Get the list of doc (loaded) kit PIDs

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -4637,6 +4637,13 @@ std::vector<std::shared_ptr<DocumentBroker>> COOLWSD::getBrokersTestOnly()
 
 std::set<pid_t> COOLWSD::getKitPids()
 {
+    std::set<pid_t> pids = getSpareKitPids();
+    pids.merge(getDocKitPids());
+    return pids;
+}
+
+std::set<pid_t> COOLWSD::getSpareKitPids()
+{
     std::set<pid_t> pids;
     pid_t pid;
     {
@@ -4648,6 +4655,13 @@ std::set<pid_t> COOLWSD::getKitPids()
                 pids.emplace(pid);
         }
     }
+    return pids;
+}
+
+std::set<pid_t> COOLWSD::getDocKitPids()
+{
+    std::set<pid_t> pids;
+    pid_t pid;
     {
         std::unique_lock<std::mutex> lock(DocBrokersMutex);
         for (const auto &it : DocBrokers)

--- a/wsd/COOLWSD.hpp
+++ b/wsd/COOLWSD.hpp
@@ -339,6 +339,8 @@ public:
 
     // Return a map for fast searches. Used in testing and in admin for cleanup
     static std::set<pid_t> getKitPids();
+    static std::set<pid_t> getSpareKitPids();
+    static std::set<pid_t> getDocKitPids();
 
     static std::string GetConnectionId()
     {


### PR DESCRIPTION
Fix race condition in testSaveOnDisconnect by waiting for kit process to stop instead of just counting total kit processes


Change-Id: I6bda6b114070123a1366bc04eac1873f19928ac0


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

