### PR TITLE
canvas: svg: show textbox move animation while edit (backport)

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1561,6 +1561,9 @@ L.CanvasTileLayer = L.Layer.extend({
 		else if (textMsg.startsWith('graphicselection:')) {
 			this._onGraphicSelectionMsg(textMsg);
 		}
+		else if (textMsg.startsWith('graphicinnertextarea:')) {
+			this._onGraphicInnerTextAreaMsg(textMsg);
+		}
 		else if (textMsg.startsWith('cellcursor:')) {
 			this._onCellCursorMsg(textMsg);
 		}
@@ -2282,6 +2285,11 @@ L.CanvasTileLayer = L.Layer.extend({
 		var bounds = new L.Bounds(northEastPoint, southWestPoint);
 
 		this._oleCSelections.setPointSet(CPointSet.fromBounds(bounds));
+	},
+
+	_onGraphicInnerTextAreaMsg: function (textMsg) {
+		var msgData = JSON.parse(textMsg.substr('graphicinnertextarea: "innerTextRect":'.length));
+		this._onUpdateGraphicInnerTextArea(msgData, true /*force add layer*/);
 	},
 
 	_onGraphicSelectionMsg: function (textMsg) {
@@ -4539,6 +4547,35 @@ L.CanvasTileLayer = L.Layer.extend({
 		}
 	},
 
+	_onUpdateGraphicInnerTextArea: function (rect, force) {
+		var topLeftTwips = new L.Point(rect[0], rect[1]);
+		var offset = new L.Point(rect[2], rect[3]);
+		var bottomRightTwips = topLeftTwips.add(offset);
+
+		this._innerTextRectTwips = this._getGraphicSelectionRectangle(
+			new L.Bounds(topLeftTwips, bottomRightTwips));
+
+		this._innerTextRect = new L.LatLngBounds(
+			this._twipsToLatLng(this._innerTextRectTwips.getTopLeft(), this._map.getZoom()),
+			this._twipsToLatLng(this._innerTextRectTwips.getBottomRight(), this._map.getZoom()));
+
+		if (this._innerTextRectMarker)
+			this._map.removeLayer(this._innerTextRectMarker);
+
+		this._innerTextRectMarker = L.svgGroup(this._innerTextRect, {
+			draggable: true,
+			dragConstraint: undefined,
+			transform: false,
+			stroke: false,
+			fillOpacity: 0,
+			fill: true,
+			isText: true
+		});
+
+		if (force)
+			this._map.addLayer(this._innerTextRectMarker);
+	},
+
 	// Update group layer selection handler.
 	_onUpdateGraphicSelection: function () {
 		if (this._graphicSelection && !this._isEmptyRectangle(this._graphicSelection)) {
@@ -4578,28 +4615,7 @@ L.CanvasTileLayer = L.Layer.extend({
 			}
 
 			if (extraInfo.innerTextRect) {
-				var topLeftTwips = new L.Point(extraInfo.innerTextRect[0], extraInfo.innerTextRect[1]);
-				var offset = new L.Point(extraInfo.innerTextRect[2], extraInfo.innerTextRect[3]);
-				var bottomRightTwips = topLeftTwips.add(offset);
-
-				this._innerTextRectTwips = this._getGraphicSelectionRectangle(
-					new L.Bounds(topLeftTwips, bottomRightTwips));
-
-				this._innerTextRect = new L.LatLngBounds(
-					this._twipsToLatLng(this._innerTextRectTwips.getTopLeft(), this._map.getZoom()),
-					this._twipsToLatLng(this._innerTextRectTwips.getBottomRight(), this._map.getZoom()));
-
-				this._innerTextRectMarker = L.svgGroup(this._innerTextRect, {
-					draggable: extraInfo.isDraggable,
-					dragConstraint: extraInfo.dragInfo,
-					svg: this._map._cacheSVG[extraInfo.id + '-text'],
-					transform: false,
-					stroke: false,
-					fillOpacity: 0,
-					fill: true,
-					isText: true
-				});
-
+				this._onUpdateGraphicInnerTextArea(extraInfo.innerTextRect);
 			}
 
 			this._graphicMarker.on('graphicmovestart graphicmoveend', this._onGraphicMove, this);

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -3972,7 +3972,8 @@ L.CanvasTileLayer = L.Layer.extend({
 		&& !this._map.isSearching()  	// not when searching within the doc
 		&& !this._isZooming             // not when zooming
 		&& !this._isEmptyRectangle(this._visibleCursor)) {
-
+			if (this._innerTextRectMarker)
+				this._map.addLayer(this._innerTextRectMarker);
 			this._updateCursorPos();
 
 			var scrollSection = app.sectionContainer.getSectionWithName(L.CSections.Scroll.name);
@@ -4004,6 +4005,8 @@ L.CanvasTileLayer = L.Layer.extend({
 			if (this._map.editorHasFocus() && !this._map.uiManager.isAnyDialogOpen() && !this._map.isSearching()
 				&& !this._isAnyInputFocused())
 				this._map.focus(false);
+			if (this._innerTextRectMarker)
+				this._map.removeLayer(this._innerTextRectMarker);
 		}
 
 		// when first time we updated the cursor - document is loaded
@@ -4572,6 +4575,31 @@ L.CanvasTileLayer = L.Layer.extend({
 			if (!this._graphicMarker) {
 				this._map.fire('error', {msg: 'Graphic marker initialization', cmd: 'marker', kind: 'failed', id: 1});
 				return;
+			}
+
+			if (extraInfo.innerTextRect) {
+				var topLeftTwips = new L.Point(extraInfo.innerTextRect[0], extraInfo.innerTextRect[1]);
+				var offset = new L.Point(extraInfo.innerTextRect[2], extraInfo.innerTextRect[3]);
+				var bottomRightTwips = topLeftTwips.add(offset);
+
+				this._innerTextRectTwips = this._getGraphicSelectionRectangle(
+					new L.Bounds(topLeftTwips, bottomRightTwips));
+
+				this._innerTextRect = new L.LatLngBounds(
+					this._twipsToLatLng(this._innerTextRectTwips.getTopLeft(), this._map.getZoom()),
+					this._twipsToLatLng(this._innerTextRectTwips.getBottomRight(), this._map.getZoom()));
+
+				this._innerTextRectMarker = L.svgGroup(this._innerTextRect, {
+					draggable: extraInfo.isDraggable,
+					dragConstraint: extraInfo.dragInfo,
+					svg: this._map._cacheSVG[extraInfo.id + '-text'],
+					transform: false,
+					stroke: false,
+					fillOpacity: 0,
+					fill: true,
+					isText: true
+				});
+
 			}
 
 			this._graphicMarker.on('graphicmovestart graphicmoveend', this._onGraphicMove, this);

--- a/browser/src/layer/vector/SVGGroup.js
+++ b/browser/src/layer/vector/SVGGroup.js
@@ -174,7 +174,7 @@ L.SVGGroup = L.Layer.extend({
 	_onDragStart: function(evt) {
 		if (!this._map || !this._dragShapePresent || !this.dragging)
 			return;
-		if (this._map._docLayer._cursorMarker && this._map._docLayer._cursorMarker.isVisible())
+		if (this._map._docLayer._cursorMarker && this._map._docLayer._cursorMarker.isVisible() && this.options.isText)
 			return;
 		this._dragStarted = true;
 		this._moved = false;

--- a/cypress_test/integration_tests/common/impress_helper.js
+++ b/cypress_test/integration_tests/common/impress_helper.js
@@ -145,7 +145,6 @@ function selectTextOfShape(selectAllText = true) {
 	cy.waitUntil(function() {
 		cy.cGet('svg g .leaflet-interactive')
 			.then(function(items) {
-				expect(items).to.have.length(1);
 				// Slide does not fit the viewport in cypress.
 				// Use the center of the visible area of the svg group element else the click
 				// event could go to other elements like slide sorter.

--- a/cypress_test/integration_tests/mobile/impress/spellchecking_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/spellchecking_spec.js
@@ -36,7 +36,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Spell checking menu.', func
 		// Open context menu
 		cy.cGet('g path.leaflet-interactive')
 			.then(function(shape) {
-				expect(shape.length).to.be.equal(1);
+				expect(shape.length).to.be.equal(2);
 				var XPos = (shape[0].getBoundingClientRect().left + shape[0].getBoundingClientRect().right) / 2;
 				var YPos = (shape[0].getBoundingClientRect().top + shape[0].getBoundingClientRect().bottom) / 2;
 

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -2874,6 +2874,9 @@ void ChildSession::loKitCallback(const int type, const std::string& payload)
     case LOK_CALLBACK_GRAPHIC_SELECTION:
         sendTextFrame("graphicselection: " + payload);
         break;
+    case LOK_CALLBACK_SHAPE_INNER_TEXT:
+        sendTextFrame("graphicinnertextarea: " + payload);
+        break;
     case LOK_CALLBACK_CELL_CURSOR:
         sendTextFrame("cellcursor: " + payload);
         break;


### PR DESCRIPTION
problem:
if a textbox/shape is being edited and try to move it while still in editing, it was not animated, so user gets illusion that shape was not moved, but in fact it moved and directly appears at the last moved position without animation


Change-Id: I830e368e162b3b38edea0d9240cf82800fa8080a


* Resolves: # <!-- related github issue -->
* Target version: distro/collabora/co-23.05 


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

