### PR TITLE
WOPI: Action_Export responses

### DIFF
--- a/browser/html/framed.doc.html
+++ b/browser/html/framed.doc.html
@@ -138,6 +138,12 @@
             });
       }
 
+      function exportAsPdfWithNotify() {
+        post({'MessageId': 'Action_Export',
+              'Values': { 'Format': 'pdf', Notify: true }
+            });
+      }
+
       function getExportFormats() {
         post({'MessageId': 'Get_Export_Formats',
               'Values': null
@@ -476,7 +482,9 @@
             <button onclick="startPresentation(); return false;">Start presentation</button>
 
             <button onclick="exportAsHtml(); return false;">Export as HTML</button>
+            <button onclick="exportAsPdfWithNotify(); return false;">Export as PDF with Notify set</button>
             <button onclick="getExportFormats(); return false;">Get export formats</button>
+            <div></div>
 
             <button onclick="ShowSave(false); return false;">Hide Save Commands</button>
             <button onclick="ShowSave(true); return false;">Show Save Commands</button>

--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -880,7 +880,10 @@ app.definitions.Socket = L.Class.extend({
 			return;
 		}
 		else if (textMsg.startsWith('error:')
-			&& (command.errorCmd === 'storage' || command.errorCmd === 'saveas') || command.errorCmd === 'downloadas')  {
+			&& (command.errorCmd === 'storage'
+			|| command.errorCmd === 'saveas')
+			|| command.errorCmd === 'downloadas'
+			|| command.errorCmd === 'exportas')  {
 
 			if (command.errorCmd === 'saveas') {
 				this._map.fire('postMessage', {

--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -939,7 +939,19 @@ app.definitions.Socket = L.Class.extend({
 				tmpLink.href = this._map.options.doc;
 				// Insert the storage server address to be more friendly
 				storageError = storageError.replace('%storageserver', tmpLink.host);
+
+				// show message to the user in Control.AlertDialog
 				this._map.fire('warn', {msg: storageError});
+
+				// send to wopi handler so we can respond
+				var postMessageObj = {
+					success: false,
+					cmd: command.errorCmd,
+					result: command.errorKind,
+					errorMsg: storageError
+				};
+
+				this._map.fire('postMessage', {msgId: 'Action_Save_Resp', args: postMessageObj});
 
 				return;
 			}
@@ -1219,6 +1231,17 @@ app.definitions.Socket = L.Class.extend({
 		}
 		else if (textMsg.startsWith('hyperlinkclicked:')) {
 			this._onHyperlinkClickedMsg(textMsg);
+		}
+
+		if (textMsg.startsWith('downloadas:')) {
+			var postMessageObj = {
+				success: true,
+				result: 'exportas',
+				errorMsg: ''
+			};
+
+			this._map.fire('postMessage', {msgId: 'Action_Save_Resp', args: postMessageObj});
+			// intentional falltrough
 		}
 
 		if (!this._map._docLayer || this._handlingDelayedMessages) {

--- a/browser/src/map/handler/Map.WOPI.js
+++ b/browser/src/map/handler/Map.WOPI.js
@@ -489,6 +489,7 @@ L.Map.WOPI = L.Handler.extend({
 		}
 		else if (msg.MessageId === 'Action_Export') {
 			if (msg.Values) {
+				this._notifySave = msg.Values['Notify'];
 				var format = msg.Values.Format;
 				var fileName = this._map['wopi'].BaseFileName;
 				fileName = fileName.substr(0, fileName.lastIndexOf('.'));

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -3149,7 +3149,7 @@ void ChildSession::loKitCallback(const int type, const std::string& payload)
         if (isError) // local save failed
         {
             _exportAsWopiUrl.clear();
-            sendTextFrameAndLogError("error: cmd=exportas kind=failure");
+            sendTextFrameAndLogError("error: cmd=exportas kind=saveasfailed");
             return;
         }
 


### PR DESCRIPTION
    PostMessage test page: add export with notify set
    
    This allows to test responses.
    
    Signed-off-by: Szymon Kłos <szymon.klos@collabora.com>
    Change-Id: Idfee8632ac0aeb8a105555e7c9d527288568091e

-----------------------

    Notify WOPI host about status after export
    
    It requires to add `Notify: true` in the Action_Export
    postmessage. Result will be sent with `Action_Save_Resp`
    
    Signed-off-by: Szymon Kłos <szymon.klos@collabora.com>
    Change-Id: Iaeee2e22bf1a2ae934eb657116c1878cb6ed50f6

----------------------

    Make exportas error more informative for user
    
    Replace "The server encountered a xxx error while parsing
    the yyy command." with more informative "Document cannot
    be exported. Please try again." on export issues.
