### PR TITLE
23.05: Comment (Annotation): Fix inconsistent width

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -503,7 +503,7 @@ nav.spreadsheet-color-indicator ~ #sidebar-dock-wrapper {
 	-webkit-user-select: text;
 	-ms-user-select: text;
 	z-index: 10;
-	max-width: 250px;
+	width: 250px;
 }
 
 .cool-annotation.greyed {


### PR DESCRIPTION
Before this commit annotations could have different widths. A comment
with a very short text - not filling a line - would result in a
abnormal narrow annotation card, screenshot of the observed bug:
https://archive.org/download/collabora-online-comment-width-bug/collabora-online-comment-width-bug.png

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I7d51ebf53d5eb9e1361c59cee9ce9ba19e703299
