### PR TITLE
Make JSDialogs fully reachable when wider than the screen

### DIFF
--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -780,9 +780,9 @@ L.Control.JSDialog = L.Control.extend({
 		builder.executeAction(dialogContainer, innerData);
 	},
 
-    _clamp: function(value, min, max) {
-        return Math.min(Math.max(value, min), max);
-    },
+	_clamp: function(value, min, max) {
+		return Math.min(Math.max(value, min), max);
+	},
 
 	onPan: function (ev) {
 		const target = this.draggingObject;
@@ -799,7 +799,16 @@ L.Control.JSDialog = L.Control.extend({
 			let newX = startX + ev.deltaX * (isRTL ? -1 : 1);
 			let newY = startY + ev.deltaY;
 
-            newX = this._clamp(newX, 0, window.innerWidth - width);
+			// We want to allow dragging the dialog offscreen iff it also drags another part of the dialog onscreen
+			if (newX < 0 && newX + width < window.innerWidth) {
+				newX = Math.min(0, window.innerWidth - width);
+			}
+
+			if (newX + width > window.innerWidth && newX > 0) {
+				newX = Math.max(window.innerWidth - width, 0);
+			}
+
+			// Happily for us, jsdialogs scroll in the y direction if the screen is too small anyway which lets us not worry about the title bar going fully offscreen
 			newY = this._clamp(newY, 0, window.innerHeight - height);
 
 			target.translateX = newX;

--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -1,4 +1,3 @@
-/* -*- js-indent-level: 8 -*- */
 /*
  * Copyright the Collabora Online contributors.
  *
@@ -781,26 +780,32 @@ L.Control.JSDialog = L.Control.extend({
 		builder.executeAction(dialogContainer, innerData);
 	},
 
+    _clamp: function(value, min, max) {
+        return Math.min(Math.max(value, min), max);
+    },
+
 	onPan: function (ev) {
-		var target = this.draggingObject;
+		const target = this.draggingObject;
 		if (target) {
-			var isRTL = document.documentElement.dir === 'rtl';
+			const isRTL = document.documentElement.dir === 'rtl';
 
-			var startX = target.startX ? target.startX : 0;
-			var startY = target.startY ? target.startY : 0;
+			const dialogBounds = target.form.getBoundingClientRect();
+			const width = dialogBounds.width;
+			const height = dialogBounds.height;
 
-			var newX = startX + ev.deltaX * (isRTL ? -1 : 1);
-			var newY = startY + ev.deltaY;
+			const startX = target.startX ? target.startX : 0;
+			const startY = target.startY ? target.startY : 0;
 
-			// Don't allow to put dialog outside the view
-			if (!(newX < 0 || newY < 0
-				|| newX > window.innerWidth - target.offsetWidth/2
-				|| newY > window.innerHeight - target.offsetHeight/2)) {
-				target.translateX = newX;
-				target.translateY = newY;
+			let newX = startX + ev.deltaX * (isRTL ? -1 : 1);
+			let newY = startY + ev.deltaY;
 
-				this.updatePosition(target.container, newX, newY);
-			}
+            newX = this._clamp(newX, 0, window.innerWidth - width);
+			newY = this._clamp(newY, 0, window.innerHeight - height);
+
+			target.translateX = newX;
+			target.translateY = newY;
+
+			this.updatePosition(target.container, newX, newY);
 		}
 	},
 


### PR DESCRIPTION
[Improve screen-edge jsdialog drag ergonomics](https://github.com/CollaboraOnline/online/commit/b4dc25401442955925833803663047a3ad014f5b) 

When trying to drag a jsdialog offscreen, we previously froze the
dialog. This was frustrating if you dragged a jsdialog to the edge of
the screen, because you then couldn't continue to drag it at all without
moving it away from the edge of the screen, even if the direction you
tried to drag it would not move it offscreen.

An example is if I dragged a jsdialog to the right edge of the screen,
it would be harder to drag it up as it would "stick" to the edge. I
would expect the upwards component of the movement to be honored, even
if the rightwards component could not be.

[jsdialogs: allow limited dragging offscreen](https://github.com/CollaboraOnline/online/commit/5fb75a11edd29cdd4c101dc7c7f43b836bb24a04)

You should be able to drag part of a JSDialog offscreen, so long as you
are also dragging another part of them onscreen. This allows you to
access the whole jsdialog even if you have a small device, which
otherwise would not be possible.