### PR TITLE
Fix click in impress annotation tests

### DIFF
--- a/cypress_test/integration_tests/desktop/impress/annotation_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/annotation_spec.js
@@ -95,7 +95,7 @@ describe(['tagdesktop'], 'Collapsed Annotation Tests', function() {
 		insertMultipleComment('impress', 1, false, '#insert-insert-annotation-button');
 		cy.cGet('.leaflet-marker-icon').should('exist');
 		cy.cGet('#annotation-content-area-1').should('contain','some text0');
-		cy.cGet('.avatar-img').click();
+		cy.cGet('.cool-annotation-table .avatar-img').click();
 		cy.cGet('.cool-annotation-menu').click();
 		cy.cGet('body').contains('.context-menu-item','Modify').click();
 		cy.cGet('#annotation-modify-textarea-1').type('{home}');
@@ -109,7 +109,7 @@ describe(['tagdesktop'], 'Collapsed Annotation Tests', function() {
 		insertMultipleComment('impress', 1, false, '#insert-insert-annotation-button');
 		cy.cGet('.leaflet-marker-icon').should('exist');
 		cy.cGet('.cool-annotation-content > div').should('contain','some text');
-		cy.cGet('.avatar-img').click();
+		cy.cGet('.cool-annotation-table .avatar-img').click();
 		cy.cGet('.cool-annotation-menu').click();
 		cy.cGet('body').contains('.context-menu-item','Remove').click();
 		cy.cGet('.leaflet-marker-icon').should('not.exist');
@@ -119,7 +119,7 @@ describe(['tagdesktop'], 'Collapsed Annotation Tests', function() {
 		insertMultipleComment('impress', 1, false, '#insert-insert-annotation-button');
 		cy.cGet('.leaflet-marker-icon').should('exist');
 		cy.cGet('.cool-annotation-content > div').should('contain','some text');
-		cy.cGet('.avatar-img').click();
+		cy.cGet('.cool-annotation-table .avatar-img').click();
 		cy.cGet('.cool-annotation-menu').click();
 		cy.cGet('body').contains('.context-menu-item','Reply').click();
 		cy.cGet('#annotation-reply-textarea-1').type('some reply text');

--- a/cypress_test/integration_tests/multiuser/impress/annotation_spec.js
+++ b/cypress_test/integration_tests/multiuser/impress/annotation_spec.js
@@ -134,7 +134,7 @@ describe(['tagmultiuser'], 'Multiuser Collapsed Annotation Tests', function() {
 		insertMultipleComment('impress', 1, false, '#insert-insert-annotation-button');
 		cy.cGet('.leaflet-marker-icon').should('exist');
 		cy.cGet('#annotation-content-area-1').should('contain','some text0');
-		cy.cGet('.avatar-img').click();
+		cy.cGet('.cool-annotation-table .avatar-img').click();
 		cy.cGet('.cool-annotation-menu').click();
 		cy.cGet('body').contains('.context-menu-item','Modify').click();
 		cy.cGet('#annotation-modify-textarea-1').type('{home}');
@@ -153,7 +153,7 @@ describe(['tagmultiuser'], 'Multiuser Collapsed Annotation Tests', function() {
 		insertMultipleComment('impress', 1, false, '#insert-insert-annotation-button');
 		cy.cGet('.leaflet-marker-icon').should('exist');
 		cy.cGet('.cool-annotation-content > div').should('contain','some text');
-		cy.cGet('.avatar-img').click();
+		cy.cGet('.cool-annotation-table .avatar-img').click();
 		cy.cGet('.cool-annotation-menu').click();
 		cy.cGet('body').contains('.context-menu-item','Remove').click();
 		cy.cGet('.leaflet-marker-icon').should('not.exist');
@@ -167,7 +167,7 @@ describe(['tagmultiuser'], 'Multiuser Collapsed Annotation Tests', function() {
 		insertMultipleComment('impress', 1, false, '#insert-insert-annotation-button');
 		cy.cGet('.leaflet-marker-icon').should('exist');
 		cy.cGet('.cool-annotation-content > div').should('contain','some text');
-		cy.cGet('.avatar-img').click();
+		cy.cGet('.cool-annotation-table .avatar-img').click();
 		cy.cGet('.cool-annotation-menu').click();
 		cy.cGet('body').contains('.context-menu-item','Reply').click();
 		cy.cGet('#annotation-reply-textarea-1').type('some reply text');


### PR DESCRIPTION
There are now two .avatar-img elements after recent user list changes


Change-Id: Ia229422b4dc3e90ede240e36927b4615091cb97d


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

