### PR TITLE
canvas:svg: remove old inner text svg is before new is created

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -4578,6 +4578,10 @@ L.CanvasTileLayer = L.Layer.extend({
 					this._twipsToLatLng(this._innerTextRectTwips.getTopLeft(), this._map.getZoom()),
 					this._twipsToLatLng(this._innerTextRectTwips.getBottomRight(), this._map.getZoom()));
 
+
+				if (this._innerTextRectMarker)
+					this._map.removeLayer(this._innerTextRectMarker);
+
 				this._innerTextRectMarker = L.svgGroup(this._innerTextRect, {
 					draggable: extraInfo.isDraggable,
 					dragConstraint: extraInfo.dragInfo,


### PR DESCRIPTION
problem:
if we recived multiple msgs that included inner text rectangle details, all created corresponding svgs but only last was deleted.


already included as backport in #8464 

Change-Id: If5ea609d2daf8070eced27f667b8149eae32569c

* Target version: master 



### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

