### PR TITLE
Stop following text overflowing chip

### DIFF
--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -1659,8 +1659,6 @@ menu-entry-with-icon.padding-left + menu-entry-icon.width */
 	border-radius: var(--btn-size); /* We expect the height to be --btn-size, give a bit for a border. To fully round the corners, this needs to be at least 50% of the height so --btn-size should do */
 	padding: 2px; /* This will become the grey border around the inner elements */
 
-	font-size: 0.8em; /* The "Following foo" text overflows the box at the default size, 0.8em seems about right */
-
 	display: none;
 }
 
@@ -1700,10 +1698,6 @@ menu-entry-with-icon.padding-left + menu-entry-icon.width */
 	flex-direction: column;
 	justify-content: center;
 	align-items: center;
-}
-
-#followingChipBackground > #followingChip > #followingChipLine1 {
-	font-weight: bold;
 }
 
 #userListSummaryBackground > #userListSummary {

--- a/browser/html/cool.html.m4
+++ b/browser/html/cool.html.m4
@@ -191,10 +191,7 @@ m4_ifelse(MOBILEAPP,[true],
 
       <div id="userListHeader">
         <div id="followingChipBackground">
-          <div id="followingChip">
-            <div id="followingChipLine1"></div>
-            <div id="followingChipLine2"></div>
-          </div>
+          <div id="followingChip"></div>
         </div>
         <div id="userListSummaryBackground"><button id="userListSummary"></button></div>
         <div id="userListPopover"></div>

--- a/browser/src/control/Control.UserList.ts
+++ b/browser/src/control/Control.UserList.ts
@@ -40,9 +40,9 @@ class UserList extends L.Control {
 		userPopupTimeout: null | ReturnType<typeof setTimeout>;
 		userJoinedPopupMessage: string;
 		userLeftPopupMessage: string;
-		followingChipLine1TextUser: string;
-		followingChipLine1TextEditor: string;
-		followingChipLine2Text: string;
+		followingChipTextUser: string;
+		followingChipTextEditor: string;
+		followingChipTooltipText: string;
 		userAvatarAlt: string;
 		nUsers?: string;
 		oneUser?: string;
@@ -53,9 +53,9 @@ class UserList extends L.Control {
 		userPopupTimeout: null,
 		userJoinedPopupMessage: _('%user has joined'),
 		userLeftPopupMessage: _('%user has left'),
-		followingChipLine1TextUser: _('Following %user'),
-		followingChipLine1TextEditor: _('Following the editor'),
-		followingChipLine2Text: _('Click to stop following'),
+		followingChipTextUser: _('Following %user'),
+		followingChipTextEditor: _('Following the editor'),
+		followingChipTooltipText: _('Stop following'),
 		userAvatarAlt: _('Avatar for %user'),
 		nUsers: undefined,
 		oneUser: undefined,
@@ -640,8 +640,6 @@ class UserList extends L.Control {
 			'followingChipBackground',
 		);
 		const followingChip = document.getElementById('followingChip');
-		const followingChipLine1 = document.getElementById('followingChipLine1');
-		const followingChipLine2 = document.getElementById('followingChipLine2');
 
 		const following = this.getFollowedUser();
 
@@ -653,22 +651,22 @@ class UserList extends L.Control {
 		const topAvatarZIndex = this.options.userLimitHeaderWhenFollowing;
 
 		if (this.map._docLayer._followEditor) {
-			followingChipLine1.innerText = this.options.followingChipLine1TextEditor;
+			followingChip.innerText = this.options.followingChipTextEditor;
 			followingChip.style.borderColor = '#000';
 		} else {
-			followingChipLine1.innerText =
-				this.options.followingChipLine1TextUser.replace(
-					'%user',
-					following[1].username,
-				);
+			followingChip.innerText = this.options.followingChipTextUser.replace(
+				'%user',
+				following[1].username,
+			);
 			followingChip.style.borderColor = following[1].color;
 		}
-
-		followingChipLine2.innerText = this.options.followingChipLine2Text;
 
 		followingChip.onclick = () => {
 			this.unfollowAll();
 		};
+
+		followingChip.title = this.options.followingChipTooltipText;
+		$(followingChip).tooltip();
 
 		followingChipBackground.style.display = 'block';
 		followingChipBackground.style.zIndex = topAvatarZIndex.toString();


### PR DESCRIPTION
~~Depending on the page font size, 0.8em may resolve to a different size.~~
~~If this is larger the text will overflow the --btn-size heighted container.~~

~~By sizing based on --btn-size instead, we can avoid this issue. A smaller button can have smaller text.~~

With some styles the following text was too large for the chip.
Unfortunately, sizing it to be consistent made it unreadably small. To
solve this, we can show only the first line of the text in the following
chip and show the second as a tooltip instead.


Change-Id: I4b5306370c31f4d0b13e1a91bf17a9d491807c45