### PR TITLE
Stop following anyone when you start typing

### DIFF
--- a/browser/src/control/Control.UserList.ts
+++ b/browser/src/control/Control.UserList.ts
@@ -123,8 +123,12 @@ class UserList extends L.Control {
 	}
 
 	unfollowAll() {
-		this.map._docLayer._followEditor = false;
-		this.followUser(this.map._docLayer._viewId);
+		if (this.getFollowedUser() !== undefined) {
+			this.followUser(this.map._docLayer._viewId);
+		} else if (this.map._docLayer._followEditor) {
+			this.map._docLayer._followEditor = false;
+			this.map._docLayer._followThis = -1;
+		}
 	}
 
 	followUser(viewId: number) {

--- a/browser/src/layer/marker/TextInput.js
+++ b/browser/src/layer/marker/TextInput.js
@@ -1171,6 +1171,8 @@ L.TextInput = L.Layer.extend({
 			window.app.console.log('Remove ' + before + ' before, and ' + after + ' after');
 		}
 
+		this._map.userList.unfollowAll();
+
 		/// TODO: rename the event to 'removetextcontent' as soon as coolwsd supports it
 		/// TODO: Ask Marco about it
 		app.socket.sendMessage(
@@ -1200,6 +1202,7 @@ L.TextInput = L.Layer.extend({
 		{
 			var encodedText = encodeURIComponent(text);
 			var winId = this._map.getWinId();
+			this._map.userList.unfollowAll();
 			app.socket.sendMessage(
 				'textinput id=' + winId + ' text=' + encodedText);
 		}
@@ -1208,6 +1211,7 @@ L.TextInput = L.Layer.extend({
 	// Tiny helper - encapsulates sending a 'key' or 'windowkey' websocket message
 	// "type" can be "input" (default) or "up"
 	_sendKeyEvent: function(charCode, unoKeyCode, type) {
+		this._map.userList.unfollowAll();
 		if (!type) {
 			type = 'input';
 		}


### PR DESCRIPTION
When you are following someone and start typing, it's a pretty good indication that you don't want to be following that person, particularly because if they edit you will then be jumped over to where they are

We also need to stop unfollowAll from always rerendering the user list, as when we rerendered on every keypress there was a noticable performance degredation. Instead, we can make it only rerender when we're following someone, which is a lot better.


Change-Id: I110ca74859b7cee03c6a58c87d3975275f29760d