### PR TITLE
canvas:svg: update inner text area of shape/textbox based on input

### DIFF
--- a/cypress_test/integration_tests/mobile/impress/spellchecking_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/spellchecking_spec.js
@@ -36,7 +36,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Spell checking menu.', func
 		// Open context menu
 		cy.cGet('g path.leaflet-interactive')
 			.then(function(shape) {
-				expect(shape.length).to.be.equal(1);
+				expect(shape.length).to.be.equal(2);
 				var XPos = (shape[0].getBoundingClientRect().left + shape[0].getBoundingClientRect().right) / 2;
 				var YPos = (shape[0].getBoundingClientRect().top + shape[0].getBoundingClientRect().bottom) / 2;
 

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -2865,6 +2865,9 @@ void ChildSession::loKitCallback(const int type, const std::string& payload)
     case LOK_CALLBACK_GRAPHIC_SELECTION:
         sendTextFrame("graphicselection: " + payload);
         break;
+    case LOK_CALLBACK_SHAPE_INNER_TEXT:
+        sendTextFrame("graphicinnertextarea: " + payload);
+        break;
     case LOK_CALLBACK_CELL_CURSOR:
         sendTextFrame("cellcursor: " + payload);
         break;


### PR DESCRIPTION
problem:
before this patch innert textarea svg was not updated after changing text, it was static based on first selection of textbox/shape, to update the textarea we needed to unselect and reselect shape/textbox


Change-Id: I11ceaf76867cecf5a356149d2072181e9f10b86e


* Target version: master 



### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

