### PR TITLE
 Replace total-pid-count waits with targeted waits 

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -378,7 +378,7 @@ noinst_HEADERS = $(wsd_headers) $(shared_headers) $(kit_headers) \
                  test/UnitHTTP.hpp \
                  test/HttpTestServer.hpp \
                  test/WopiTestServer.hpp \
-                 test/countcoolkits.hpp \
+                 test/KitPidHelpers.hpp \
                  test/lokassert.hpp \
                  test/test.hpp \
                  test/testlog.hpp \

--- a/test/KitPidHelpers.cpp
+++ b/test/KitPidHelpers.cpp
@@ -8,29 +8,47 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
+#include "KitPidHelpers.hpp"
 
-#pragma once
-
+#include <set>
 #include <chrono>
 #include <iostream>
 #include <thread>
 
-#include <cppunit/extensions/HelperMacros.h>
-
-#include <Poco/DirectoryIterator.h>
-#include <Poco/FileStream.h>
-#include <Poco/StreamCopier.h>
-
+#include <wsd/COOLWSD.hpp>
 #include <Common.hpp>
-#include "Util.hpp"
-#include "lokassert.hpp"
-#include "test.hpp"
-#include "testlog.hpp"
+#include <Util.hpp>
 
-static int countCoolKitProcesses(const int expected,
-                                 std::chrono::milliseconds timeoutMs
-                                 = std::chrono::milliseconds(COMMAND_TIMEOUT_MS * 8))
+#include <lokassert.hpp>
+#include <test.hpp>
+#include <testlog.hpp>
+
+std::string getPidList(std::set<pid_t> pids);
+
+std::set<pid_t> helpers::getKitPids() { return COOLWSD::getKitPids(); }
+
+std::set<pid_t> helpers::getSpareKitPids() { return COOLWSD::getSpareKitPids(); }
+
+std::set<pid_t> helpers::getDocKitPids() { return COOLWSD::getDocKitPids(); }
+
+/// Get the PID of the forkit
+std::set<pid_t> helpers::getForKitPids()
 {
+    std::set<pid_t> pids;
+    if (COOLWSD::ForKitProcId >= 0)
+        pids.emplace(COOLWSD::ForKitProcId);
+    return pids;
+}
+
+/// How many live coolkit processes do we have ?
+int helpers::getCoolKitProcessCount()
+{
+    return getKitPids().size();
+}
+
+int helpers::countCoolKitProcesses(const int expected)
+{
+    std::chrono::milliseconds timeoutMs = std::chrono::milliseconds(COMMAND_TIMEOUT_MS) * 8;
     const auto testname = "countCoolKitProcesses ";
     TST_LOG_BEGIN("Waiting until coolkit processes are exactly " << expected << ". Coolkits: ");
 
@@ -64,6 +82,7 @@ static int countCoolKitProcesses(const int expected,
     }
 
     TST_LOG_END;
+    LOK_ASSERT(expected == count);
     if (expected != count)
     {
         TST_LOG_BEGIN("Found " << count << " LoKit processes but was expecting " << expected << ": [");
@@ -87,37 +106,69 @@ static int countCoolKitProcesses(const int expected,
     return count;
 }
 
-// FIXME: we probably should make this extern
-// and reuse it. As it stands now, it is per
-// translation unit, which isn't desirable if
-// (in the non-ideal event that) it's not 1,
-// it will cause testNoExtraCoolKitsLeft to
-// wait unnecessarily and fail.
-static int InitialCoolKitCount = 1;
-static std::chrono::steady_clock::time_point TestStartTime;
-
-static void testCountHowManyCoolkits()
+void helpers::testCountHowManyCoolkits()
 {
     const char testname[] = "countHowManyCoolkits ";
-    TestStartTime = std::chrono::steady_clock::now();
+    resetTestStartTime();
 
-    InitialCoolKitCount = countCoolKitProcesses(InitialCoolKitCount);
+    countCoolKitProcesses(InitialCoolKitCount);
     TST_LOG("Initial coolkit count is " << InitialCoolKitCount);
     LOK_ASSERT(InitialCoolKitCount > 0);
 
-    TestStartTime = std::chrono::steady_clock::now();
+    resetTestStartTime();
 }
 
-static void testNoExtraCoolKitsLeft()
+void helpers::testNoExtraCoolKitsLeft()
 {
     const char testname[] = "noExtraCoolKitsLeft ";
     const int countNow = countCoolKitProcesses(InitialCoolKitCount);
     LOK_ASSERT_EQUAL(InitialCoolKitCount, countNow);
 
-    const auto duration = (std::chrono::steady_clock::now() - TestStartTime);
-    const auto durationMs = std::chrono::duration_cast<std::chrono::milliseconds>(duration);
+    const auto durationMs = timeSinceTestStartMs();
 
     TST_LOG(" (" << durationMs << ')');
 }
 
-/* vim:set shiftwidth=4 softtabstop=4 expandtab: */
+void helpers::waitForKitProcessToStop(
+        const pid_t pid,
+        const std::string& testname,
+        const std::chrono::milliseconds timeoutMs /* = COMMAND_TIMEOUT_MS * 8 */,
+        const std::chrono::milliseconds retryMs /* = 10ms */)
+{
+    TST_LOG("Waiting for kit process " << pid << " to stop.");
+
+    std::set<pid_t> pids = getDocKitPids();
+    TST_LOG("Active kit pids are: " << getPidList(pids));
+
+    int tries = (timeoutMs / retryMs);
+    while(pids.contains(pid) && tries >= 0)
+    {
+        std::this_thread::sleep_for(retryMs);
+        pids = getDocKitPids();
+        tries--;
+    }
+
+    if (pids.contains(pid))
+    {
+        std::ostringstream oss;
+        oss << "Timed out waiting for kit process " << pid << " to stop. Active kit pids are: " << getPidList(pids);
+        LOK_ASSERT_FAIL(oss.str());
+    }
+    else
+    {
+        TST_LOG("Finished waiting for kit process " << pid << " to stop.");
+        TST_LOG("Active kit pids are: " << getPidList(pids));
+    }
+}
+
+std::string getPidList(std::set<pid_t> pids)
+{
+    std::ostringstream oss;
+    oss << "[";
+    for (pid_t i : pids)
+    {
+        oss << i << ", ";
+    }
+    oss << "]";
+    return oss.str();
+}

--- a/test/KitPidHelpers.cpp
+++ b/test/KitPidHelpers.cpp
@@ -14,13 +14,11 @@
 #include <chrono>
 #include <iostream>
 #include <thread>
+#include <string>
 
 #include <wsd/COOLWSD.hpp>
-#include <Common.hpp>
-#include <Util.hpp>
 
 #include <lokassert.hpp>
-#include <test.hpp>
 #include <testlog.hpp>
 
 std::string getPidList(std::set<pid_t> pids);
@@ -31,134 +29,12 @@ std::set<pid_t> helpers::getSpareKitPids() { return COOLWSD::getSpareKitPids(); 
 
 std::set<pid_t> helpers::getDocKitPids() { return COOLWSD::getDocKitPids(); }
 
-/// Get the PID of the forkit
-std::set<pid_t> helpers::getForKitPids()
+pid_t helpers::getForKitPid()
 {
-    std::set<pid_t> pids;
-    if (COOLWSD::ForKitProcId >= 0)
-        pids.emplace(COOLWSD::ForKitProcId);
-    return pids;
-}
-
-/// How many live coolkit processes do we have ?
-int helpers::getCoolKitProcessCount()
-{
-    return getKitPids().size();
-}
-
-int helpers::countCoolKitProcesses(const int expected)
-{
-    std::chrono::milliseconds timeoutMs = std::chrono::milliseconds(COMMAND_TIMEOUT_MS) * 8;
-    const auto testname = "countCoolKitProcesses ";
-    TST_LOG_BEGIN("Waiting until coolkit processes are exactly " << expected << ". Coolkits: ");
-
-    Util::Stopwatch stopwatch;
-
-    // This does not need to depend on any constant from Common.hpp.
-    // The shorter the better (the quicker the test runs).
-    constexpr int sleepMs = 10;
-
-    // This has to cause waiting for at least COMMAND_TIMEOUT_MS. Tolerate more for safety.
-    const std::size_t repeat = (timeoutMs.count() / sleepMs);
-    int count = getCoolKitProcessCount();
-    for (std::size_t i = 0; i < repeat; ++i)
-    {
-        TST_LOG_APPEND(count << ' ');
-        if (count == expected)
-        {
-            break;
-        }
-
-        // Give polls in the cool processes time to time out etc
-        std::this_thread::sleep_for(std::chrono::milliseconds(sleepMs));
-
-        const int newCount = getCoolKitProcessCount();
-        if (count != newCount)
-        {
-            // Allow more time until the number settles.
-            i = 0;
-            count = newCount;
-        }
-    }
-
-    TST_LOG_END;
-    LOK_ASSERT(expected == count);
-    if (expected != count)
-    {
-        TST_LOG_BEGIN("Found " << count << " LoKit processes but was expecting " << expected << ": [");
-        for (pid_t i : getKitPids())
-        {
-            TST_LOG_APPEND(i << ' ');
-        }
-        TST_LOG_APPEND(']');
-        TST_LOG_END;
-
-    }
-
-    std::set<pid_t> pids = getKitPids();
-    std::ostringstream oss;
-    oss << "Test kit pids are [";
-    for (pid_t i : pids)
-        oss << i << ' ';
-    oss << "] after waiting for " << stopwatch.elapsed();
-    TST_LOG(oss.str());
-
-    return count;
-}
-
-void helpers::testCountHowManyCoolkits()
-{
-    const char testname[] = "countHowManyCoolkits ";
-    resetTestStartTime();
-
-    countCoolKitProcesses(InitialCoolKitCount);
-    TST_LOG("Initial coolkit count is " << InitialCoolKitCount);
-    LOK_ASSERT(InitialCoolKitCount > 0);
-
-    resetTestStartTime();
-}
-
-void helpers::testNoExtraCoolKitsLeft()
-{
-    const char testname[] = "noExtraCoolKitsLeft ";
-    const int countNow = countCoolKitProcesses(InitialCoolKitCount);
-    LOK_ASSERT_EQUAL(InitialCoolKitCount, countNow);
-
-    const auto durationMs = timeSinceTestStartMs();
-
-    TST_LOG(" (" << durationMs << ')');
-}
-
-void helpers::waitForKitProcessToStop(
-        const pid_t pid,
-        const std::string& testname,
-        const std::chrono::milliseconds timeoutMs /* = COMMAND_TIMEOUT_MS * 8 */,
-        const std::chrono::milliseconds retryMs /* = 10ms */)
-{
-    TST_LOG("Waiting for kit process " << pid << " to stop.");
-
-    std::set<pid_t> pids = getDocKitPids();
-    TST_LOG("Active kit pids are: " << getPidList(pids));
-
-    int tries = (timeoutMs / retryMs);
-    while(pids.contains(pid) && tries >= 0)
-    {
-        std::this_thread::sleep_for(retryMs);
-        pids = getDocKitPids();
-        tries--;
-    }
-
-    if (pids.contains(pid))
-    {
-        std::ostringstream oss;
-        oss << "Timed out waiting for kit process " << pid << " to stop. Active kit pids are: " << getPidList(pids);
-        LOK_ASSERT_FAIL(oss.str());
-    }
-    else
-    {
-        TST_LOG("Finished waiting for kit process " << pid << " to stop.");
-        TST_LOG("Active kit pids are: " << getPidList(pids));
-    }
+    std::string testname = "getForKitPid";
+    pid_t pid = COOLWSD::ForKitProcId;
+    LOK_ASSERT_MESSAGE("Expected forkit process id to be >= 0", pid > 0);
+    return pid;
 }
 
 std::string getPidList(std::set<pid_t> pids)
@@ -171,4 +47,83 @@ std::string getPidList(std::set<pid_t> pids)
     }
     oss << "]";
     return oss.str();
+}
+
+void helpers::logKitProcesses(const std::string& testname)
+{
+    std::set<pid_t> docKitPids = getDocKitPids();
+    std::set<pid_t> spareKitPids = getSpareKitPids();
+    TST_LOG("Current kit processes: "
+            << "Doc Kits: " << getPidList(docKitPids)
+            << " Spare Kits: " << getPidList(spareKitPids));
+}
+
+void helpers::waitForKitProcessCount(
+        const std::string& testname,
+        int numDocKits,
+        int numSpareKits /* = -1 */,
+        const std::chrono::milliseconds timeoutMs /* = COMMAND_TIMEOUT_MS * 8 */,
+        const std::chrono::milliseconds retryMs /* = 10ms */)
+{
+    TST_LOG("Waiting for kit process count: "
+            << (numDocKits >= 0 ? "Doc Kits: " + std::to_string(numDocKits) + " " : "")
+            << (numSpareKits >= 0 ? " Spare Kits: " + std::to_string(numSpareKits) + " " : ""));
+
+    std::set<pid_t> docKitPids = getDocKitPids();
+    std::set<pid_t> spareKitPids = getSpareKitPids();
+    bool pass = (numDocKits < 0 || docKitPids.size() == static_cast<size_t>(numDocKits)) &&
+        (numSpareKits < 0 || spareKitPids.size() == static_cast<size_t>(numSpareKits));
+    int tries = (timeoutMs / retryMs);
+
+    TST_LOG("Current kit processes: "
+            << "Doc Kits: " << getPidList(docKitPids)
+            << " Spare Kits: " << getPidList(spareKitPids));
+
+    while (tries >= 0 && !pass)
+    {
+        std::this_thread::sleep_for(retryMs);
+
+        docKitPids = getDocKitPids();
+        spareKitPids = getSpareKitPids();
+        pass = (numDocKits < 0 || docKitPids.size() == static_cast<size_t>(numDocKits)) &&
+            (numSpareKits < 0 || spareKitPids.size() == static_cast<size_t>(numSpareKits));
+        tries--;
+
+        TST_LOG("Current kit processes: "
+                << "Doc Kits: " << getPidList(docKitPids)
+                << " Spare Kits: " << getPidList(spareKitPids));
+    }
+
+    if (pass)
+    {
+        TST_LOG("Finished waiting for kit process count: "
+                << (numDocKits >= 0 ? "Doc Kits: " + std::to_string(numDocKits) + " " : "")
+                << (numSpareKits >= 0 ? " Spare Kits: " + std::to_string(numSpareKits) + " " : ""));
+    }
+    else
+    {
+        std::ostringstream oss;
+        oss << (numDocKits >= 0 ? "Doc Kits: " + std::to_string(numDocKits) + " " : "")
+            << (numSpareKits >= 0 ? " Spare Kits: " + std::to_string(numSpareKits) + " " : "")
+            << "Current kit processes: "
+            << "Doc Kits: " << getPidList(docKitPids)
+            << " Spare Kits: " << getPidList(spareKitPids);
+        LOK_ASSERT_FAIL("Timed out waiting for kit process count: " + oss.str());
+    }
+}
+
+void helpers::waitForKitPidsReady(
+        const std::string& testname,
+        const std::chrono::milliseconds timeoutMs /* = KIT_PID_TIMEOUT_MS */,
+        const std::chrono::milliseconds retryMs /* = KIT_PID_RETRY_MS */)
+{
+    waitForKitProcessCount(testname, 0, 1, timeoutMs, retryMs);
+}
+
+void helpers::waitForKitPidsKilled(
+        const std::string& testname,
+        const std::chrono::milliseconds timeoutMs /* = KIT_PID_TIMEOUT_MS */,
+        const std::chrono::milliseconds retryMs /* = KIT_PID_RETRY_MS */)
+{
+    waitForKitProcessCount(testname, 0, 0, timeoutMs, retryMs);
 }

--- a/test/KitPidHelpers.hpp
+++ b/test/KitPidHelpers.hpp
@@ -21,32 +21,59 @@
 namespace helpers
 {
 
-const int InitialCoolKitCount = 1;
-void testCountHowManyCoolkits();
-void testNoExtraCoolKitsLeft();
+constexpr int KIT_PID_TIMEOUT_MS = 4000 * TRACE_MULTIPLIER;
+constexpr int KIT_PID_RETRY_MS = 20;
 
-int countCoolKitProcesses(const int expected);/*,
-                                 std::chrono::milliseconds timeoutMs
-                                 = std::chrono::milliseconds(COMMAND_TIMEOUT_MS * 8));
-                                 */
-
-/// Get the list of all kit PIDs
+/*
+ * Get the list of all kit pids
+ */
 std::set<pid_t> getKitPids();
-/// Get the list of spare (unused) kit PIDs
+
+/*
+ * Get the list of spare (unused) kit pids
+ */
 std::set<pid_t> getSpareKitPids();
-/// Get the list of doc (loaded) kit PIDs
+
+/*
+ * Get the list of doc (loaded) kit pids
+ */
 std::set<pid_t> getDocKitPids();
 
-/// Get the PID of the forkit
-std::set<pid_t> getForKitPids();
+/*
+ * Get the pid of the coolforkit process
+ */
+pid_t getForKitPid();
 
-/// How many live coolkit processes do we have ?
-int getCoolKitProcessCount();
+/*
+ * Log the current doc and spare kit pids
+ * Useful for debugging
+ */
+void logKitProcesses(const std::string& testname);
 
-void waitForKitProcessToStop(
-        const pid_t pid,
+/*
+ * Wait until the number of kit processes matches the desired count.
+ * Set numDocKits and numSpareKits to -1 to skip counting those processes
+ */
+void waitForKitProcessCount(const std::string& testname, int numDocKits, int numSpareKits,
+        const std::chrono::milliseconds timeoutMs,
+        const std::chrono::milliseconds retryMs);
+
+/*
+ * Wait until ready with 0 doc kits and 1 spare kit
+ * Used to wait for spare kit to start up before use
+ * or to wait for doc kits to shut down after
+ */
+void waitForKitPidsReady(
         const std::string& testname,
-        const std::chrono::milliseconds timeoutMs = std::chrono::milliseconds(COMMAND_TIMEOUT_MS * 8),
-        const std::chrono::milliseconds retryMs = std::chrono::milliseconds(10));
+        const std::chrono::milliseconds timeoutMs = std::chrono::milliseconds(KIT_PID_TIMEOUT_MS),
+        const std::chrono::milliseconds retryMs = std::chrono::milliseconds(KIT_PID_RETRY_MS));
 
-}
+/*
+ * Wait until all doc and spare kits are closed
+ */
+void waitForKitPidsKilled(
+        const std::string& testname,
+        const std::chrono::milliseconds timeoutMs = std::chrono::milliseconds(KIT_PID_TIMEOUT_MS),
+        const std::chrono::milliseconds retryMs = std::chrono::milliseconds(KIT_PID_RETRY_MS));
+
+} // namespace helpers

--- a/test/KitPidHelpers.hpp
+++ b/test/KitPidHelpers.hpp
@@ -1,0 +1,52 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <config.h>
+
+#include <chrono>
+#include <set>
+
+#include <Common.hpp>
+
+namespace helpers
+{
+
+const int InitialCoolKitCount = 1;
+void testCountHowManyCoolkits();
+void testNoExtraCoolKitsLeft();
+
+int countCoolKitProcesses(const int expected);/*,
+                                 std::chrono::milliseconds timeoutMs
+                                 = std::chrono::milliseconds(COMMAND_TIMEOUT_MS * 8));
+                                 */
+
+/// Get the list of all kit PIDs
+std::set<pid_t> getKitPids();
+/// Get the list of spare (unused) kit PIDs
+std::set<pid_t> getSpareKitPids();
+/// Get the list of doc (loaded) kit PIDs
+std::set<pid_t> getDocKitPids();
+
+/// Get the PID of the forkit
+std::set<pid_t> getForKitPids();
+
+/// How many live coolkit processes do we have ?
+int getCoolKitProcessCount();
+
+void waitForKitProcessToStop(
+        const pid_t pid,
+        const std::string& testname,
+        const std::chrono::milliseconds timeoutMs = std::chrono::milliseconds(COMMAND_TIMEOUT_MS * 8),
+        const std::chrono::milliseconds retryMs = std::chrono::milliseconds(10));
+
+}

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -183,13 +183,13 @@ fakesockettest_LDADD = $(CPPUNIT_LIBS)
 
 # old-style unit tests - bootstrapped via UnitClient
 unit_base_la_SOURCES = UnitClient.cpp ${test_base_sources}
-unit_tiletest_la_SOURCES = UnitClient.cpp TileCacheTests.cpp
+unit_tiletest_la_SOURCES = UnitClient.cpp TileCacheTests.cpp KitPidHelpers.cpp
 unit_tiletest_la_LIBADD = $(CPPUNIT_LIBS)
-unit_integration_la_SOURCES = UnitClient.cpp integration-http-server.cpp
+unit_integration_la_SOURCES = UnitClient.cpp integration-http-server.cpp KitPidHelpers.cpp
 unit_integration_la_LIBADD = $(CPPUNIT_LIBS)
-unit_httpws_la_SOURCES = UnitClient.cpp httpwstest.cpp
+unit_httpws_la_SOURCES = UnitClient.cpp httpwstest.cpp KitPidHelpers.cpp
 unit_httpws_la_LIBADD = $(CPPUNIT_LIBS)
-unit_crash_la_SOURCES = UnitClient.cpp httpcrashtest.cpp
+unit_crash_la_SOURCES = UnitClient.cpp httpcrashtest.cpp KitPidHelpers.cpp
 unit_crash_la_LIBADD = $(CPPUNIT_LIBS)
 
 # unit test modules:

--- a/test/TileCacheTests.cpp
+++ b/test/TileCacheTests.cpp
@@ -22,6 +22,9 @@
 
 #include <cppunit/extensions/HelperMacros.h>
 
+#include <sstream>
+#include <random>
+
 #include <Common.hpp>
 #include <Protocol.hpp>
 #include <MessageQueue.hpp>
@@ -171,7 +174,7 @@ public:
     void setUp()
     {
         resetTestStartTime();
-        testCountHowManyCoolkits();
+        waitForKitPidsReady("setUp");
         resetTestStartTime();
         _socketPoll->startThread();
     }
@@ -180,7 +183,7 @@ public:
     {
         _socketPoll->joinThread();
         resetTestStartTime();
-        testNoExtraCoolKitsLeft();
+        waitForKitPidsReady("tearDown");
         resetTestStartTime();
     }
 };
@@ -451,13 +454,14 @@ void TileCacheTests::testDisconnectMultiView()
     constexpr size_t repeat = 2;
     for (size_t j = 1; j <= repeat; ++j)
     {
-        std::string documentPath, documentURL;
-        getDocumentPathAndURL("setclientpart.ods", documentPath, documentURL, "disconnectMultiView ");
+        // Make sure previous sessions have closed
+        waitForKitPidsReady(testname);
 
         TST_LOG("disconnectMultiView try #" << j);
 
-        // Wait to clear previous sessions.
-        countCoolKitProcesses(InitialCoolKitCount);
+        std::string documentPath, documentURL;
+        getDocumentPathAndURL("setclientpart.ods", documentPath, documentURL, "disconnectMultiView ");
+
 
         // Request a huge tile, and cancel immediately.
         std::shared_ptr<http::WebSocketSession> socket1

--- a/test/TileCacheTests.cpp
+++ b/test/TileCacheTests.cpp
@@ -13,6 +13,9 @@
 
 #include "WebSocketSession.hpp"
 
+#include <sstream>
+#include <random>
+
 #include <Poco/Net/AcceptCertificateHandler.h>
 #include <Poco/Net/InvalidCertificateHandler.h>
 #include <Poco/Net/SSLManager.h>
@@ -28,11 +31,9 @@
 #include <Unit.hpp>
 #include <Util.hpp>
 
-#include <countcoolkits.hpp>
 #include <helpers.hpp>
 #include <test.hpp>
-#include <sstream>
-#include <random>
+#include <KitPidHelpers.hpp>
 
 using namespace helpers;
 

--- a/test/UnitCursor.cpp
+++ b/test/UnitCursor.cpp
@@ -268,9 +268,6 @@ UnitBase::TestResult UnitCursor::testInsertAnnotationWriter()
     LOK_ASSERT_MESSAGE("Expected successful disconnection of the WebSocket",
                        socket->waitForDisconnection(std::chrono::seconds(5)));
 
-    // Make sure the document is fully unloaded.
-    // testNoExtraCoolKitsLeft();
-
     TST_LOG("Reloading ");
     socket = helpers::loadDocAndGetSession(socketPoll, uri, documentURL, testname);
 
@@ -340,8 +337,6 @@ UnitBase::TestResult UnitCursor::testEditAnnotationWriter()
     LOK_ASSERT_EQUAL(
         std::string("textselectioncontent: and now for something completely different"), res);
 
-    // const int kitcount = getCoolKitProcessCount();
-
     // Close and reopen the same document and test again.
     TST_LOG("Closing connection after pasting.");
     socket->shutdownWS();
@@ -350,9 +345,6 @@ UnitBase::TestResult UnitCursor::testEditAnnotationWriter()
 
     TST_LOG("Reloading ");
     socket = helpers::loadDocAndGetSession(socketPoll, uri, documentURL, testname);
-
-    // Should have no new instances.
-    // LOK_ASSERT_EQUAL(kitcount, countCoolKitProcesses(kitcount));
 
     // Confirm that the text is in the comment and not doc body.
     // Click in the body.

--- a/test/helpers.hpp
+++ b/test/helpers.hpp
@@ -13,7 +13,6 @@
 
 #include <test/testlog.hpp>
 #include <test/lokassert.hpp>
-#include <test/test.hpp>
 
 #include <Poco/BinaryReader.h>
 #include <Poco/Dynamic/Var.h>
@@ -949,53 +948,6 @@ inline std::string getAllText(const std::shared_ptr<http::WebSocketSession>& soc
     }
 
     return std::string();
-}
-
-
-inline std::string getPidList(std::set<pid_t> pids)
-{
-    std::ostringstream oss;
-    oss << "[";
-    for (pid_t i : pids)
-    {
-        oss << i << ", ";
-    }
-    oss << "]";
-    return oss.str();
-}
-
-
-inline void waitForKitProcessToStop(
-        const pid_t pid,
-        const std::string& testname,
-        const std::chrono::milliseconds timeoutMs = std::chrono::milliseconds(COMMAND_TIMEOUT_MS * 8),
-        const std::chrono::milliseconds retryMs = std::chrono::milliseconds(10))
-{
-
-    TST_LOG("Waiting for kit process " << pid << " to stop.");
-
-    std::set<pid_t> pids = getDocKitPids();
-    TST_LOG("Active kit pids are: " << getPidList(pids));
-
-    int tries = (timeoutMs / retryMs);
-    while(pids.contains(pid) && tries >= 0)
-    {
-        std::this_thread::sleep_for(retryMs);
-        pids = getDocKitPids();
-        tries--;
-    }
-
-    if (pids.contains(pid))
-    {
-        std::ostringstream oss;
-        oss << "Timed out waiting for kit process " << pid << " to stop. Active kit pids are: " << getPidList(pids);
-        LOK_ASSERT_FAIL(oss.str());
-    }
-    else
-    {
-        TST_LOG("Finished waiting for kit process " << pid << " to stop.");
-        TST_LOG("Active kit pids are: " << getPidList(pids));
-    }
 }
 
 }

--- a/test/httpcrashtest.cpp
+++ b/test/httpcrashtest.cpp
@@ -39,7 +39,7 @@
 #include <Protocol.hpp>
 #include <test.hpp>
 #include <helpers.hpp>
-#include <countcoolkits.hpp>
+#include <KitPidHelpers.hpp>
 
 using namespace helpers;
 
@@ -153,7 +153,7 @@ void HTTPCrashTest::testCrashKit()
         TST_LOG("Killing coolkit instances.");
 
         killLoKitProcesses();
-        countCoolKitProcesses(0, std::chrono::seconds(1));
+        countCoolKitProcesses(0);//, std::chrono::seconds(1));
 
         TST_LOG("Reading the error code from the socket.");
         //FIXME: implement in WebSocketSession.
@@ -188,7 +188,7 @@ void HTTPCrashTest::testRecoverAfterKitCrash()
         TST_LOG("Killing coolkit instances.");
 
         killLoKitProcesses();
-        countCoolKitProcesses(0, std::chrono::seconds(1));
+        countCoolKitProcesses(0);//, std::chrono::seconds(1));
 
         // We expect the client connection to close.
         TST_LOG("Reconnect after kill.");
@@ -270,7 +270,6 @@ static void killPids(const std::set<pid_t> &pids, const std::string& testname)
 void HTTPCrashTest::killLoKitProcesses()
 {
     killPids(getKitPids(), "killLoKitProcesses ");
-    InitialCoolKitCount = 1; // non-intuitive but it will arrive soon.
 }
 
 void HTTPCrashTest::killForkitProcess()

--- a/test/httpwstest.cpp
+++ b/test/httpwstest.cpp
@@ -30,9 +30,9 @@
 #include <Common.hpp>
 #include <Protocol.hpp>
 
-#include "lokassert.hpp"
-#include <countcoolkits.hpp>
+#include <lokassert.hpp>
 #include <helpers.hpp>
+#include <KitPidHelpers.hpp>
 
 using namespace helpers;
 
@@ -126,6 +126,7 @@ void HTTPWSTest::testExoticLang()
 
 void HTTPWSTest::testSaveOnDisconnect()
 {
+
     const std::string testname = "saveOnDisconnect- ";
 
     const std::string text = helpers::genRandomString(40);

--- a/test/httpwstest.cpp
+++ b/test/httpwstest.cpp
@@ -87,7 +87,7 @@ public:
     void setUp()
     {
         resetTestStartTime();
-        testCountHowManyCoolkits();
+        waitForKitPidsReady("setUp");
         resetTestStartTime();
         _socketPoll->startThread();
     }
@@ -96,7 +96,7 @@ public:
     {
         _socketPoll->joinThread();
         resetTestStartTime();
-        testNoExtraCoolKitsLeft();
+        waitForKitPidsReady("tearDown");
         resetTestStartTime();
     }
 };
@@ -135,7 +135,6 @@ void HTTPWSTest::testSaveOnDisconnect()
     std::string documentPath, documentURL;
     getDocumentPathAndURL("hello.odt", documentPath, documentURL, testname);
 
-    pid_t origPid;
     try
     {
         std::shared_ptr<http::WebSocketSession> socket1
@@ -149,11 +148,6 @@ void HTTPWSTest::testSaveOnDisconnect()
         sendTextFrame(socket1, "paste mimetype=text/plain;charset=utf-8\n" + text, testname);
         getResponseMessage(socket1, "pasteresult: success", testname);
 
-        std::set<pid_t> origPids = getDocKitPids();
-        LOK_ASSERT_EQUAL(static_cast<size_t>(1), origPids.size());
-        origPid = *(origPids.begin());
-        TST_LOG("Original pid: " << origPid);
-
         // Shutdown abruptly.
         TST_LOG("Closing connection after pasting.");
 
@@ -164,28 +158,14 @@ void HTTPWSTest::testSaveOnDisconnect()
                            socket1->waitForDisconnection(std::chrono::seconds(5)));
         LOK_ASSERT_MESSAGE("Expected successful disconnection of the WebSocket 2",
                            socket2->waitForDisconnection(std::chrono::seconds(5)));
-    }
-    catch (const Poco::Exception& exc)
-    {
-        LOK_ASSERT_FAIL(exc.displayText());
-    }
 
-    // Allow time to save and destroy before we connect again.
-    waitForKitProcessToStop(origPid,testname);
+        // Allow time to save and destroy before we connect again.
+        waitForKitPidsReady(testname);
 
-    TST_LOG("Loading again.");
-    try
-    {
+        TST_LOG("Loading again.");
         // Load the same document and check that the last changes (pasted text) is saved.
         std::shared_ptr<http::WebSocketSession> socket
             = loadDocAndGetSession(_socketPoll, _uri, documentURL, testname + "3 ");
-
-        // Should have no new instances.
-        std::set<pid_t> newPids = getDocKitPids();
-        LOK_ASSERT_EQUAL(static_cast<size_t>(1), newPids.size());
-        pid_t newPid = *(newPids.begin());
-        TST_LOG("New pid: " << newPid);
-        LOK_ASSERT_MESSAGE("New pid ("<<newPid<<") should not match old pid ("<<origPid<<")", newPid != origPid);
 
         // Check if the document contains the pasted text.
         const std::string selection = getAllText(socket, testname, text);
@@ -221,20 +201,18 @@ void HTTPWSTest::testReloadWhileDisconnecting()
         // the socket is closed, when the doc is not even modified yet.
         getResponseMessage(socket, "statechanged", testname);
 
-        const int kitcount = getCoolKitProcessCount();
-
         // Shutdown abruptly.
         TST_LOG("Closing connection after pasting.");
         socket->asyncShutdown();
         LOK_ASSERT_MESSAGE("Expected successful disconnection of the WebSocket",
                            socket->waitForDisconnection(std::chrono::seconds(5)));
 
+        // Do not wait here. Reconnect before disconnect finishes
+        // TODO: Test fails because it is unable to reconnect
+
         // Load the same document and check that the last changes (pasted text) is saved.
         TST_LOG("Loading again.");
         socket = loadDocAndGetSession(_socketPoll, _uri, documentURL, testname);
-
-        // Should have no new instances.
-        LOK_ASSERT_EQUAL(kitcount, countCoolKitProcesses(kitcount));
 
         // Check if the document contains the pasted text.
         const std::string expected = "aaa bbb ccc";

--- a/test/integration-http-server.cpp
+++ b/test/integration-http-server.cpp
@@ -100,14 +100,14 @@ public:
     void setUp()
     {
         helpers::resetTestStartTime();
-        helpers::testCountHowManyCoolkits();
+        helpers::waitForKitPidsReady("setUp");
         helpers::resetTestStartTime();
     }
 
     void tearDown()
     {
         helpers::resetTestStartTime();
-        helpers::testNoExtraCoolKitsLeft();
+        helpers::waitForKitPidsReady("tearDown");
         helpers::resetTestStartTime();
     }
 

--- a/test/integration-http-server.cpp
+++ b/test/integration-http-server.cpp
@@ -18,7 +18,7 @@
 #include <Session.hpp>
 #include <Common.hpp>
 #include <common/FileUtil.hpp>
-#include <countcoolkits.hpp>
+#include <KitPidHelpers.hpp>
 
 #include <Poco/Net/AcceptCertificateHandler.h>
 #include <Poco/Net/FilePartSource.h>
@@ -100,14 +100,14 @@ public:
     void setUp()
     {
         helpers::resetTestStartTime();
-        testCountHowManyCoolkits();
+        helpers::testCountHowManyCoolkits();
         helpers::resetTestStartTime();
     }
 
     void tearDown()
     {
         helpers::resetTestStartTime();
-        testNoExtraCoolKitsLeft();
+        helpers::testNoExtraCoolKitsLeft();
         helpers::resetTestStartTime();
     }
 

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -37,7 +37,6 @@
 
 #include <helpers.hpp>
 #include <Unit.hpp>
-#include <wsd/COOLWSD.hpp>
 #if ENABLE_SSL
 #include <Ssl.hpp>
 #include <SslSocket.hpp>
@@ -292,37 +291,5 @@ bool runClientTests(const char* cmd, bool standalone, bool verbose)
 
     return result.wasSuccessful();
 }
-
-// Standalone tests don't really use WSD
-#ifndef STANDALONE_CPPUNIT
-
-std::set<pid_t> getKitPids()
-{
-    return COOLWSD::getKitPids();
-}
-std::set<pid_t> getSpareKitPids()
-{
-    return COOLWSD::getSpareKitPids();
-}
-std::set<pid_t> getDocKitPids()
-{
-    return COOLWSD::getDocKitPids();
-}
-
-/// Get the PID of the forkit
-std::set<pid_t> getForKitPids()
-{
-    std::set<pid_t> pids;
-    if (COOLWSD::ForKitProcId >= 0)
-        pids.emplace(COOLWSD::ForKitProcId);
-    return pids;
-}
-
-/// How many live coolkit processes do we have ?
-int getCoolKitProcessCount()
-{
-    return getKitPids().size();
-}
-#endif
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/test/test.hpp
+++ b/test/test.hpp
@@ -11,31 +11,10 @@
 
 #pragma once
 
-#include <ctime>
-#include <set>
-
 /// Are we running inside WSD or by ourselves.
 bool isStandalone();
 
 /// Run the set of client tests we have
 bool runClientTests(const char* cmd, bool standalone, bool verbose);
-
-// ---- Abstraction for standalone vs. WSD ----
-
-/// Get the list of all kit PIDs
-std::set<pid_t> getKitPids();
-/// Get the list of spare (unused) kit PIDs
-std::set<pid_t> getSpareKitPids();
-/// Get the list of doc (loaded) kit PIDs
-std::set<pid_t> getDocKitPids();
-
-/// Get the PID of the forkit
-std::set<pid_t> getForKitPids();
-
-/// Which port should we connect to get to WSD.
-int getClientPort();
-
-/// How many live coolkit processes do we have ?
-int getCoolKitProcessCount();
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */


### PR DESCRIPTION
Wait for doc kits or spare kit counts specifically. This removes the chance of
race conditions between waiting for doc kits to shutdown and the spare kit to
start back up.

Follow up to https://github.com/CollaboraOnline/online/pull/8463, addressing other tests that were using the same helpers.

### Summary
An incomplete list of things changed:
* Consolidated pid-related functions from countcoolkits.hpp and test.cpp to a new file kit_pid_helpers.cpp/hpp
* Rewrote the retry loop
* Added or clarified lots of log messages
* Simplified pid killing in HTTPCrashTest
* Fixed HTTPCrashTest::testBarren
* HTTPCrashTest::testRecoverAfterKitCrash no longer wastes 20s trying then retrying to connect
* HTTPWSTest::testReloadWhileDisconnecting still failing, it passes if you wait for the process to go away but I don't think that's the intent of the test
* Can log pids with kit_pid_helpers::logKitProcesses. This isn't used directly in the tests but is useful for debugging.

Things I specifically want feedback on:
* Names. Is kit_pid_helpers okay? How about the phrases "Doc Kits" and "Spare Kits". Or anything else, just let me know what you would have named them. 
* Makefile. It seems that because the cpp and hpp files are separate I need to add the cpp to the unit test sources. Is there a better way to do that?
** I tried adding kit_pid_helpers.cpp to unittest_SOURCES but I get linking errors for COOLWSD::getKitPids() etc
** I tried adding COOLWSD.cpp to wsd_sources but it complains that there are multiple main functions
** I tired adding the stubs to wsd/TestStubs.cpp but I can't because they're static

Example logs, not exactly representative of the log viewing experience because I only grabbed the TST lines and because this is only one test that doesn't exercise all the functions.
Before:
```
wsd-1467117-1467227 2024-03-07 16:19:59.636363 -0500 [ coolwsd ] TST  countCoolKitProcesses  [countCoolKitProcesses] (+0ms): Waiting until coolkit processes are exactly 1. Coolkits: 1 | countcoolkits.hpp:66
wsd-1467117-1467227 2024-03-07 16:19:59.636367 -0500 [ coolwsd ] TST  countCoolKitProcesses  [countCoolKitProcesses] (+0ms): Test kit pids are [1467195 ] after waiting for 0ms| countcoolkits.hpp:85
wsd-1467117-1467227 2024-03-07 16:19:59.636368 -0500 [ coolwsd ] TST  countHowManyCoolkits  [testCountHowManyCoolkits] (+0ms): Initial coolkit count is 1| countcoolkits.hpp:105
wsd-1467117-1467227 2024-03-07 16:19:59.636369 -0500 [ coolwsd ] TST  countHowManyCoolkits  [testCountHowManyCoolkits] (+0ms): PASS: InitialCoolKitCount > 0 [true]| countcoolkits.hpp:106
wsd-1467117-1467227 2024-03-07 16:19:59.636477 -0500 [ coolwsd ] TST  crashKit  [getDocumentPathAndURL] (+0ms): Test file: /tmp/crashKit_46ccbe28_empty.odt| helpers.hpp:194
wsd-1467117-1467227 2024-03-07 16:19:59.636837 -0500 [ coolwsd ] TST  crashKit  [sendTextFrame] (+0ms): Sending 66 bytes: load url=cool/file%3A%2F%2F%2Ftmp%2FcrashKit_46ccbe28_empty.odt/ws| helpers.hpp:213
wsd-1467117-1467227 2024-03-07 16:20:00.118810 -0500 [ coolwsd ] TST  crashKit  [loadDocAndGetSession] (+482ms): PASS: isLoaded [true]| helpers.hpp:631
wsd-1467117-1467227 2024-03-07 16:20:00.118813 -0500 [ coolwsd ] TST  crashKit  [loadDocAndGetSession] (+482ms): Loaded document [cool/file%3A%2F%2F%2Ftmp%2FcrashKit_46ccbe28_empty.odt/ws].| helpers.hpp:633
wsd-1467117-1467227 2024-03-07 16:20:00.118817 -0500 [ coolwsd ] TST  crashKit  [testCrashKit] (+482ms): Allowing time for kits to spawn and connect to wsd to get cleanly killed| httpcrashtest.cpp:150
wsd-1467117-1467227 2024-03-07 16:20:01.119029 -0500 [ coolwsd ] TST  crashKit  [testCrashKit] (+1482ms): Killing coolkit instances.| httpcrashtest.cpp:153
wsd-1467117-1467227 2024-03-07 16:20:01.119099 -0500 [ coolwsd ] TST  killLoKitProcesses  [killPids] (+1482ms): kill pids 2| httpcrashtest.cpp:259
wsd-1467117-1467227 2024-03-07 16:20:01.119106 -0500 [ coolwsd ] TST  killLoKitProcesses  [killPids] (+1482ms): Killing 1467195| httpcrashtest.cpp:266
wsd-1467117-1467227 2024-03-07 16:20:01.119128 -0500 [ coolwsd ] TST  killLoKitProcesses  [killPids] (+1482ms): Killing 1467231| httpcrashtest.cpp:266
wsd-1467117-1467227 2024-03-07 16:20:01.119139 -0500 [ coolwsd ] TST  countCoolKitProcesses  [countCoolKitProcesses] (+1482ms): Waiting until coolkit processes are exactly 0. Coolkits: 2 wsd-1467117-1467230 2024-03-07 16:20:00.731638 -0500 [ docbroker_001 ] TRC  #33: setupPollFds getPollEvents: 0x1| net/Socket.hpp:859
0 | countcoolkits.hpp:66
wsd-1467117-1467227 2024-03-07 16:20:01.894950 -0500 [ coolwsd ] TST  countCoolKitProcesses  [countCoolKitProcesses] (+2258ms): Test kit pids are [] after waiting for 775ms| countcoolkits.hpp:85
wsd-1467117-1467227 2024-03-07 16:20:01.894959 -0500 [ coolwsd ] TST  crashKit  [testCrashKit] (+2258ms): Reading the error code from the socket.| httpcrashtest.cpp:158
wsd-1467117-1467227 2024-03-07 16:20:01.894967 -0500 [ coolwsd ] TST  crashKit  [testCrashKit] (+2258ms): Shutting down socket.| httpcrashtest.cpp:165
wsd-1467117-1467227 2024-03-07 16:20:01.894986 -0500 [ coolwsd ] TST  crashKit  [testCrashKit] (+2258ms): PASS: socket->waitForDisconnection(std::chrono::seconds(5)) [true]| httpcrashtest.cpp:168
wsd-1467117-1467227 2024-03-07 16:20:01.895292 -0500 [ coolwsd ] TST  countCoolKitProcesses  [countCoolKitProcesses] (+0ms): Waiting until coolkit processes are exactly 1. Coolkits: 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 wsd-1467117-1467117 2024-03-07 16:20:01.889354 -0500 [ coolwsd ] TRC  ppoll start, timeoutMicroS: 250000 size 0| net/Socket.cpp:348
1 | countcoolkits.hpp:66
wsd-1467117-1467227 2024-03-07 16:20:02.180636 -0500 [ coolwsd ] TST  countCoolKitProcesses  [countCoolKitProcesses] (+285ms): Test kit pids are [1467283 ] after waiting for 285ms| countcoolkits.hpp:85
wsd-1467117-1467227 2024-03-07 16:20:02.180640 -0500 [ coolwsd ] TST  noExtraCoolKitsLeft  [testNoExtraCoolKitsLeft] (+285ms): PASS: InitialCoolKitCount == countNow == [1]| countcoolkits.hpp:115
wsd-1467117-1467227 2024-03-07 16:20:02.180643 -0500 [ coolwsd ] TST  noExtraCoolKitsLeft  [testNoExtraCoolKitsLeft] (+285ms):  (2544ms)| countcoolkits.hpp:120
```

After:
```
wsd-1458824-1458922 2024-03-07 16:18:38.908134 -0500 [ coolwsd ] TST  setUp [waitForKitProcessCount] (+0ms): Waiting for kit process count: Doc Kits: 0  Spare Kits: 1 | kit_pid_helpers.cpp:73
wsd-1458824-1458922 2024-03-07 16:18:38.908137 -0500 [ coolwsd ] TST  setUp [waitForKitProcessCount] (+0ms): Current kit processes: Doc Kits: [] Spare Kits: [1458964, ]| kit_pid_helpers.cpp:83
wsd-1458824-1458922 2024-03-07 16:18:38.908139 -0500 [ coolwsd ] TST  setUp [waitForKitProcessCount] (+0ms): Finished waiting for kit process count: Doc Kits: 0  Spare Kits: 1 | kit_pid_helpers.cpp:104
wsd-1458824-1458922 2024-03-07 16:18:38.908167 -0500 [ coolwsd ] TST  crashKit  [testCrashKit] (+0ms): Loading document| httpcrashtest.cpp:144
wsd-1458824-1458922 2024-03-07 16:18:38.908248 -0500 [ coolwsd ] TST  crashKit  [getDocumentPathAndURL] (+0ms): Test file: /tmp/crashKit_5654a31b_empty.odt| helpers.hpp:194
wsd-1458824-1458922 2024-03-07 16:18:38.908580 -0500 [ coolwsd ] TST  crashKit  [sendTextFrame] (+0ms): Sending 66 bytes: load url=cool/file%3A%2F%2F%2Ftmp%2FcrashKit_5654a31b_empty.odt/ws| helpers.hpp:213
wsd-1458824-1458922 2024-03-07 16:18:39.059931 -0500 [ coolwsd ] TST  crashKit  [loadDocAndGetSession] (+151ms): PASS: isLoaded [true]| helpers.hpp:631
wsd-1458824-1458922 2024-03-07 16:18:39.059946 -0500 [ coolwsd ] TST  crashKit  [loadDocAndGetSession] (+151ms): Loaded document [cool/file%3A%2F%2F%2Ftmp%2FcrashKit_5654a31b_empty.odt/ws].| helpers.hpp:633
wsd-1458824-1458922 2024-03-07 16:18:39.059950 -0500 [ coolwsd ] TST  crashKit  [testCrashKit] (+151ms): Allowing time for kit to connect to wsd to get cleanly killed| httpcrashtest.cpp:148
wsd-1458824-1458922 2024-03-07 16:18:40.060128 -0500 [ coolwsd ] TST  crashKit  [testCrashKit] (+1152ms): Killing coolkit instances.| httpcrashtest.cpp:151
wsd-1458824-1458922 2024-03-07 16:18:40.060204 -0500 [ coolwsd ] TST  crashKit  [killPid] (+1152ms): Killing 1458964| httpcrashtest.cpp:247
wsd-1458824-1458922 2024-03-07 16:18:40.060227 -0500 [ coolwsd ] TST  crashKit  [killPid] (+1152ms): Killing 1459018| httpcrashtest.cpp:247
wsd-1458824-1458922 2024-03-07 16:18:40.060245 -0500 [ coolwsd ] TST  crashKit  [waitForKitProcessCount] (+1152ms): Waiting for kit process count: Doc Kits: 0  Spare Kits: 0 | kit_pid_helpers.cpp:73
wsd-1458824-1458922 2024-03-07 16:18:40.060255 -0500 [ coolwsd ] TST  crashKit  [waitForKitProcessCount] (+1152ms): Current kit processes: Doc Kits: [1458964, ] Spare Kits: [1459018, ]| kit_pid_helpers.cpp:83
wsd-1458824-1458922 2024-03-07 16:18:40.070358 -0500 [ coolwsd ] TST  crashKit  [waitForKitProcessCount] (+1162ms): Current kit processes: Doc Kits: [1458964, ] Spare Kits: [1459018, ]| kit_pid_helpers.cpp:97
wsd-1458824-1458922 2024-03-07 16:18:40.080553 -0500 [ coolwsd ] TST  crashKit  [waitForKitProcessCount] (+1172ms): Current kit processes: Doc Kits: [1458964, ] Spare Kits: [1459018, ]| kit_pid_helpers.cpp:97
...
wsd-1458824-1458922 2024-03-07 16:18:40.245112 -0500 [ coolwsd ] TST  crashKit  [waitForKitProcessCount] (+1336ms): Current kit processes: Doc Kits: [1458964, ] Spare Kits: [1459018, ]| kit_pid_helpers.cpp:97
wsd-1458824-1458922 2024-03-07 16:18:40.255411 -0500 [ coolwsd ] TST  crashKit  [waitForKitProcessCount] (+1347ms): Current kit processes: Doc Kits: [1458964, ] Spare Kits: [1459018, ]| kit_pid_helpers.cpp:97
wsd-1458824-1458922 2024-03-07 16:18:40.265700 -0500 [ coolwsd ] TST  crashKit  [waitForKitProcessCount] (+1357ms): Current kit processes: Doc Kits: [1458964, ] Spare Kits: [1459018, ]| kit_pid_helpers.cpp:97
wsd-1458824-1458922 2024-03-07 16:18:40.275933 -0500 [ coolwsd ] TST  crashKit  [waitForKitProcessCount] (+1367ms): Current kit processes: Doc Kits: [] Spare Kits: [1459018, ]| kit_pid_helpers.cpp:97
wsd-1458824-1458922 2024-03-07 16:18:40.286188 -0500 [ coolwsd ] TST  crashKit  [waitForKitProcessCount] (+1378ms): Current kit processes: Doc Kits: [] Spare Kits: [1459018, ]| kit_pid_helpers.cpp:97
wsd-1458824-1458922 2024-03-07 16:18:40.296482 -0500 [ coolwsd ] TST  crashKit  [waitForKitProcessCount] (+1388ms): Current kit processes: Doc Kits: [] Spare Kits: [1459018, ]| kit_pid_helpers.cpp:97
...
wsd-1458824-1458922 2024-03-07 16:18:41.116437 -0500 [ coolwsd ] TST  crashKit  [waitForKitProcessCount] (+2208ms): Current kit processes: Doc Kits: [] Spare Kits: [1459018, ]| kit_pid_helpers.cpp:97
wsd-1458824-1458922 2024-03-07 16:18:41.126725 -0500 [ coolwsd ] TST  crashKit  [waitForKitProcessCount] (+2218ms): Current kit processes: Doc Kits: [] Spare Kits: [1459018, ]| kit_pid_helpers.cpp:97
wsd-1458824-1458922 2024-03-07 16:18:41.137076 -0500 [ coolwsd ] TST  crashKit  [waitForKitProcessCount] (+2228ms): Current kit processes: Doc Kits: [] Spare Kits: []| kit_pid_helpers.cpp:97
wsd-1458824-1458922 2024-03-07 16:18:41.137120 -0500 [ coolwsd ] TST  crashKit  [waitForKitProcessCount] (+2228ms): Finished waiting for kit process count: Doc Kits: 0  Spare Kits: 0 | kit_pid_helpers.cpp:104
wsd-1458824-1458922 2024-03-07 16:18:41.137131 -0500 [ coolwsd ] TST  crashKit  [testCrashKit] (+2228ms): Shutting down socket.| httpcrashtest.cpp:162
wsd-1458824-1458922 2024-03-07 16:18:41.137139 -0500 [ coolwsd ] TST  crashKit  [testCrashKit] (+2228ms): PASS: socket->waitForDisconnection(std::chrono::seconds(5)) [true]| httpcrashtest.cpp:165
wsd-1458824-1458922 2024-03-07 16:18:41.137557 -0500 [ coolwsd ] TST  tearDown [waitForKitProcessCount] (+0ms): Waiting for kit process count: Doc Kits: 0 | kit_pid_helpers.cpp:73
wsd-1458824-1458922 2024-03-07 16:18:41.137615 -0500 [ coolwsd ] TST  tearDown [waitForKitProcessCount] (+0ms): Current kit processes: Doc Kits: [] Spare Kits: []| kit_pid_helpers.cpp:83
wsd-1458824-1458922 2024-03-07 16:18:41.137625 -0500 [ coolwsd ] TST  tearDown [waitForKitProcessCount] (+0ms): Finished waiting for kit process count: Doc Kits: 0 | kit_pid_helpers.cpp:104
```


### Checklist

- [X] Code is properly formatted
- [X] All commits have Change-Id
- [X] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

