### PR TITLE
annotation: prevent page up/down button from messing the view(backport)

### DIFF
--- a/browser/src/layer/tile/CommentSection.ts
+++ b/browser/src/layer/tile/CommentSection.ts
@@ -866,8 +866,20 @@ export class Comment extends CanvasSectionObject {
 		if ((<any>window).mode.isDesktop()) {
 			if (e.keyCode === 27) {
 				this.onCancelClick(e);
+			} else if (e.keyCode === 33 /*PageUp*/ || e.keyCode === 34 /*PageDown*/) {
+				// work around for a chrome issue https://issues.chromium.org/issues/41417806
+				L.DomEvent.preventDefault(e);
+				var pos = e.keyCode === 33 ? 0 : e.target.textLength;
+				var currentPos = e.target.selectionStart;
+				if (e.shiftKey) {
+					var [start, end] = currentPos <= pos ? [currentPos, pos] : [pos, currentPos];
+					e.target.setSelectionRange(start, end, currentPos > pos ? 'backward' : 'forward');
+				} else {
+					e.target.setSelectionRange(pos, pos);
+				}
 			}
 		}
+
 	}
 
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types


### PR DESCRIPTION
problem:
when pressed page up/down button inside the annotation textarea, entire view is forcefully pushed upwards to put the cursor at the top of view. This is a chrome bug reported at: https://issues.chromium.org/issues/41417806


Change-Id: I30048374e7b8330cd8c865010e3b4237d355391e


* Target version: distro/collabora/co-23.05 


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

