### PR TITLE
Calm down warnings.

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -956,9 +956,9 @@ void Document::trimIfInactive()
             return;
         }
     }
-    // FIXME: be more clever - detect if we rendered recently,
-    // measure memory pressure etc.
-    LOG_WRN("Sessions are all inactive - trim memory");
+    // TODO: be more clever - detect if we mutated the documen
+    // recently, measure memory pressure etc.
+    LOG_DBG("Sessions are all inactive - trim memory");
     SigUtil::addActivity("trimIfInactive");
     _loKit->trimMemory(4096);
     _deltaGen->dropCache();

--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -385,7 +385,7 @@ private:
             case WSOpCode::Ping:
                 {
                     if (!_isClient)
-                        LOG_ERR("Clients should not send pings, only servers");
+                        LOG_DBG("Clients should not send pings, only servers");
 
                     const auto now = std::chrono::steady_clock::now();
                     _pingTimeUs = std::chrono::duration_cast<std::chrono::microseconds>


### PR DESCRIPTION
Seems browsers start to ping servers on their websockets, so don't warn about that.

We trim memory left and right in clients, that doesn't deserve a warning either.

Change-Id: I7bdcc99d167a8df3c847a1893dee8cd9123250f2


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

