### PR TITLE
wsd: test: extend process timeout

### DIFF
--- a/test/KitPidHelpers.cpp
+++ b/test/KitPidHelpers.cpp
@@ -21,7 +21,7 @@
 #include <lokassert.hpp>
 #include <testlog.hpp>
 
-std::string getPidList(std::set<pid_t> pids);
+std::string getPidList(const std::set<pid_t>& pids);
 
 std::set<pid_t> helpers::getKitPids() { return COOLWSD::getKitPids(); }
 
@@ -37,7 +37,7 @@ pid_t helpers::getForKitPid()
     return pid;
 }
 
-std::string getPidList(std::set<pid_t> pids)
+std::string getPidList(const std::set<pid_t>& pids)
 {
     std::ostringstream oss;
     oss << "[";

--- a/test/KitPidHelpers.hpp
+++ b/test/KitPidHelpers.hpp
@@ -21,7 +21,7 @@
 namespace helpers
 {
 
-constexpr int KIT_PID_TIMEOUT_MS = 4000 * TRACE_MULTIPLIER;
+constexpr int KIT_PID_TIMEOUT_MS = 10000 * TRACE_MULTIPLIER;
 constexpr int KIT_PID_RETRY_MS = 20;
 
 /*


### PR DESCRIPTION
4 seconds proves too short in some cases
and times out occassionally. 10 seconds
seems more reasonable.

Change-Id: Icede882355a66bf383ebdd87858f1ded77825c5f
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
