### PR TITLE
calc: restore correct position on tab operations

### DIFF
--- a/kit/KitHelper.hpp
+++ b/kit/KitHelper.hpp
@@ -169,7 +169,7 @@ namespace LOKitHelper
                 std::free(ptrValue);
             }
 
-            if (type == LOK_DOCTYPE_PRESENTATION || type == LOK_DOCTYPE_DRAWING)
+            if (type == LOK_DOCTYPE_PRESENTATION || type == LOK_DOCTYPE_DRAWING || type == LOK_DOCTYPE_SPREADSHEET)
             {
                 for (int i = 0; i < parts; ++i)
                 {


### PR DESCRIPTION
This patch improves restoring a view to the previous position on tab
switching, tab operations (move, insert, delete) and tab operations
undo/redo

Signed-off-by: Marco Cecchetti <marco.cecchetti@collabora.com>
Change-Id: Iadce3d4922d94c3417dc9aeddfce5c9018ccdb09
