### PR TITLE
Gitpod: Update branch parity, use core 24.04 instead

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -36,9 +36,9 @@ tasks:
   - name: Get Core & Configure
     before: |
       cd ..
-      wget https://github.com/CollaboraOnline/online/releases/download/for-code-assets/core-co-23.05-assets.tar.gz
-      tar xvf core-co-23.05-assets.tar.gz
-      rm core-co-23.05-assets.tar.gz
+      wget https://github.com/CollaboraOnline/online/releases/download/for-code-assets/core-co-24.04-assets.tar.gz
+      tar xvf core-co-24.04-assets.tar.gz
+      rm core-co-24.04-assets.tar.gz
       cd online
     init: |
       ./autogen.sh


### PR DESCRIPTION
Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ibe21ffb1a9743088d20017d3b64144e69b29c3c1
