### PR TITLE
Calc: added scrolling to row of sheet names

### DIFF
--- a/browser/css/spreadsheet.css
+++ b/browser/css/spreadsheet.css
@@ -16,7 +16,13 @@
 	height: 100%;
 	overflow-y: hidden;
 	overflow-x: auto;
+	scrollbar-width: none; /* Firefox */
+	-ms-overflow-style: none; /* IE and Edge */
 	margin-left: 6px;
+}
+
+.spreadsheet-tab-scroll::-webkit-scrollbar {
+	display: none;
 }
 
 .spreadsheet-tab {

--- a/browser/src/control/Control.SheetsBar.js
+++ b/browser/src/control/Control.SheetsBar.js
@@ -44,6 +44,21 @@ L.Control.SheetsBar = L.Control.extend({
 				window.hideTooltip(this, e.target);
 			}
 		});
+
+		toolbar.find('.w2ui-button').on('mousedown', function (e) {
+			if (e.button != 0) {
+				return; //if the right mouse button is pressed do nothing.
+			}
+
+			const pressAndHoldTimer = setTimeout(function () {
+				that.handlePressAndHold(e);
+			}, 500);
+
+			$(document).one('mouseup', function () {
+				clearTimeout(pressAndHoldTimer);
+			});
+		});
+
 		this.map.uiManager.enableTooltip(toolbar);
 
 		toolbar.bind('touchstart', function(e) {
@@ -88,6 +103,26 @@ L.Control.SheetsBar = L.Control.extend({
 			// https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollLeft
 			L.DomUtil.get('spreadsheet-tab-scroll').scrollLeft = 100000;
 		}
+	},
+
+	handlePressAndHold: function(e) {
+		var that = this;
+		var id;
+		if (e.target.classList.contains('nextrecord')) {
+			id = 'nextrecord';
+		} else if (e.target.classList.contains('prevrecord')) {
+			id = 'prevrecord';
+		} else  {
+			return;
+		}
+
+		const scrollingInterval = setInterval(function () {
+			that.onClick(e, id);
+		}, 100);
+
+		$(document).one('mouseup', function () {
+			clearInterval(scrollingInterval);
+		});
 	},
 
 	onDocLayerInit: function() {

--- a/browser/src/control/Control.Tabs.js
+++ b/browser/src/control/Control.Tabs.js
@@ -166,7 +166,7 @@ L.Control.Tabs = L.Control.extend({
 				var ssTabScroll = L.DomUtil.create('div', 'spreadsheet-tab-scroll', this._tabsCont);
 				ssTabScroll.id = 'spreadsheet-tab-scroll';
 				if (!window.mode.isMobile())
-					ssTabScroll.style.overflow = 'hidden';
+					ssTabScroll.style.overflowX = 'scroll';
 
 				this._tabsCont.style.display = 'grid';
 


### PR DESCRIPTION
Change-Id: If0c4b45d256e98eb71d8935f506d1ff3c0e8b84d


* Resolves: #8358
* Target version: master 

### Summary
The solution introduces mouse scrolling and press + hold functionality for scrolling through records. It optimizes event handling by triggering the scrolling action after a delay when the left mouse button is pressed and held down. This is achieved by setting a timeout to execute the scrolling function after 500 milliseconds of continuous pressing. The scrolling action continues until the mouse button is released. In the scrolling function, it calls onClick handler to avoid code duplication at 100 millisecond interval.

### Checklist

- [X] Code is properly formatted
- [X] All commits have Change-Id
- [ ] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required