### PR TITLE
android: add support for c++20 and std::filesystem

### DIFF
--- a/android/app/build.gradle.in
+++ b/android/app/build.gradle.in
@@ -6,7 +6,7 @@ apply from: 'appSettings.gradle'
 android {
     compileSdkVersion 33
     buildDir = "${rootProject.getBuildDir()}/app"
-    ndkVersion "20.1.5948944"
+    ndkVersion "22.1.7171670"
 
     defaultConfig {
         // applicationId, versionCode and versionName are defined in appSettings.gradle

--- a/android/lib/build.gradle.in
+++ b/android/lib/build.gradle.in
@@ -6,7 +6,7 @@ apply from: 'libSettings.gradle'
 android {
     compileSdkVersion 33
     buildDir = "${rootProject.getBuildDir()}/lib"
-    ndkVersion "20.1.5948944"
+    ndkVersion "22.1.7171670"
 
     defaultConfig {
         minSdkVersion 21

--- a/android/lib/src/main/cpp/CMakeLists.txt.in
+++ b/android/lib/src/main/cpp/CMakeLists.txt.in
@@ -1,6 +1,8 @@
 
 cmake_minimum_required(VERSION 3.4.1)
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++2a")
+
 add_library(androidapp SHARED
             androidapp.cpp
             ../../../../../common/Authorization.cpp


### PR DESCRIPTION
Android build fails due to use of std::filesystem and
c++20 features like string::starts_with.

cmake requires c++2a flag
std::filesystem requires ndk 22+

Signed-off-by: Jaume Pujantell <jaume.pujantell@collabora.com>
Change-Id: Ibba1e5e76a32ba5526d9d7111b810a650f372a02
