### PR TITLE
fix prettier builddir != srcdir

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -519,7 +519,7 @@ COMMON_PARAMS = \
 	--o:ssl.ca_file_path="$(abs_top_srcdir)/etc/ca-chain.cert.pem" \
 	--o:admin_console.username=admin --o:admin_console.password=admin
 
-run: prettier-write setup-wsd
+run: setup-wsd
 	./coolwsd $(COMMON_PARAMS) \
 			--o:security.capabilities="$(CAPABILITIES)" \
 			--o:logging.file[@enable]=${OUTPUT_TO_FILE} --o:logging.level=trace \
@@ -659,12 +659,7 @@ prettier: browser/node_modules
 	@make -C browser prettier
 
 prettier-write: browser/node_modules
-	browser/node_modules/.bin/prettier \
-		--config browser/.prettierrc \
-		--ignore-path browser/.prettierignore \
-		--ignore-path browser/.beforeprettier \
-		--write \
-		browser/src browser/js browser/admin/src
+	@make -C browser prettier-write
 
 install-exec-hook:
 	cd $(DESTDIR)$(bindir) && \

--- a/Makefile.am
+++ b/Makefile.am
@@ -653,12 +653,7 @@ browser/node_modules: browser/package.json browser/archived-packages
 	@cd browser && npm install
 
 eslint: browser/node_modules
-	browser/node_modules/.bin/eslint browser/src browser/js browser/admin/src \
-		--max-warnings 0 \
-		--resolve-plugins-relative-to browser \
-		--ignore-path browser/.eslintignore \
-		--no-eslintrc \
-		--config browser/.eslintrc
+	@make -C browser eslint
 
 prettier: browser/node_modules
 	browser/node_modules/.bin/prettier \

--- a/Makefile.am
+++ b/Makefile.am
@@ -656,13 +656,7 @@ eslint: browser/node_modules
 	@make -C browser eslint
 
 prettier: browser/node_modules
-	browser/node_modules/.bin/prettier \
-		--config browser/.prettierrc \
-		--ignore-path browser/.prettierignore \
-		--ignore-path browser/.beforeprettier \
-		--check \
-		browser/src browser/js browser/admin/src \
-		|| echo "To run prettier, you can use 'make prettier-write' or run COOLWSD with 'make run'"
+	@make -C browser prettier
 
 prettier-write: browser/node_modules
 	browser/node_modules/.bin/prettier \

--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -481,8 +481,8 @@ endef
 
 define run_prettier_check
 	@$(NODE) node_modules/.bin/prettier \
-		--ignore-path $(srcdir)/browser/.prettierignore \
-		--ignore-path $(srcdir)/browser/.beforeprettier \
+		--ignore-path $(srcdir)/.prettierignore \
+		--ignore-path $(srcdir)/.beforeprettier \
 		$(1)
 endef
 

--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -471,6 +471,14 @@ define global_file
 		@$(NODE) node_modules/uglify-js/bin/uglifyjs $< --output $@)
 endef
 
+define run_eslint_check
+	@$(NODE) node_modules/eslint/bin/eslint.js \
+		--resolve-plugins-relative-to $(abs_builddir) \
+		--ignore-path $(srcdir)/.eslintignore \
+		--config .eslintrc \
+		--no-eslintrc $(1)
+endef
+
 .PHONY: build-cool
 
 all-local: build-cool
@@ -543,7 +551,7 @@ $(DIST_FOLDER)/admin-bundle.js: $(COOL_ADMIN_DST) \
 $(INTERMEDIATE_DIR)/admin-src.js: $(COOL_ADMIN_TS_JS) $(COOL_ADMIN_JS)
 	@mkdir -p $(dir $@)
 	@echo "Checking for admin JS errors..."
-	@$(NODE) node_modules/eslint/bin/eslint.js --resolve-plugins-relative-to $(abs_builddir) --ignore-path $(srcdir)/.eslintignore --config .eslintrc --no-eslintrc  --ignore-pattern $(COOL_ADMIN_TS_JS)  $(srcdir)/admin/src
+	$(call run_eslint_check,--ignore-pattern $(COOL_ADMIN_TS_JS) $(srcdir)/admin/src)
 	@$(NODE) node_modules/.bin/prettier \
 		--ignore-path $(srcdir)/browser/.prettierignore \
 		--ignore-path $(srcdir)/browser/.beforeprettier \
@@ -557,8 +565,7 @@ $(INTERMEDIATE_DIR)/cool-src.js: tscompile.done $(call prereq_cool) $(COOL_JS_DS
 	@printf "Checking for obsolete JS build intermediates in this makefile... "
 	@if ! test "z$(COOL_ASSERT_INTERSECT)" == "z"; then echo; echo "Error: please remove obsolete files:"; echo "$(COOL_ASSERT_INTERSECT)"; exit 1; else echo "clean"; fi
 	@echo "Checking for cool JS errors..."
-	@$(NODE) node_modules/eslint/bin/eslint.js $(srcdir)/src --resolve-plugins-relative-to $(abs_builddir) \
-		$(srcdir)/js --ignore-path $(srcdir)/.eslintignore --no-eslintrc --config .eslintrc
+	$(call run_eslint_check,$(srcdir)/src $(srcdir)/js)
 	@$(NODE) node_modules/.bin/prettier \
 		--ignore-path $(srcdir)/browser/.prettierignore \
 		--ignore-path $(srcdir)/browser/.beforeprettier \

--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -543,7 +543,7 @@ $(DIST_FOLDER)/admin-bundle.js: $(COOL_ADMIN_DST) \
 $(INTERMEDIATE_DIR)/admin-src.js: $(COOL_ADMIN_TS_JS) $(COOL_ADMIN_JS)
 	@mkdir -p $(dir $@)
 	@echo "Checking for admin JS errors..."
-	@$(NODE) node_modules/eslint/bin/eslint.js --resolve-plugins-relative-to $(abs_builddir) --ignore-path $(srcdir)/.eslintignore --config $(srcdir)/.eslintrc --no-eslintrc $(srcdir)/admin/src
+	@$(NODE) node_modules/eslint/bin/eslint.js --resolve-plugins-relative-to $(abs_builddir) --ignore-path $(srcdir)/.eslintignore --config .eslintrc --no-eslintrc $(srcdir)/admin/src
 	@awk 'FNR == 1 {print ""} 1' $(COOL_ADMIN_TS_JS) $(patsubst %.js,$(srcdir)/%.js,$(COOL_ADMIN_JS)) > $@
 
 $(INTERMEDIATE_DIR)/cool-src.js: tscompile.done $(call prereq_cool) $(COOL_JS_DST) $(abs_top_srcdir)/scripts/unocommands.py
@@ -553,7 +553,7 @@ $(INTERMEDIATE_DIR)/cool-src.js: tscompile.done $(call prereq_cool) $(COOL_JS_DS
 	@if ! test "z$(COOL_ASSERT_INTERSECT)" == "z"; then echo; echo "Error: please remove obsolete files:"; echo "$(COOL_ASSERT_INTERSECT)"; exit 1; else echo "clean"; fi
 	@echo "Checking for cool JS errors..."
 	@$(NODE) node_modules/eslint/bin/eslint.js $(srcdir)/src --resolve-plugins-relative-to $(abs_builddir) \
-		$(srcdir)/js --ignore-path $(srcdir)/.eslintignore --no-eslintrc --config $(srcdir)/.eslintrc
+		$(srcdir)/js --ignore-path $(srcdir)/.eslintignore --no-eslintrc --config .eslintrc
 	@echo "Bundling cool..."
 	$(call bundle_cool)
 

--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -879,6 +879,12 @@ prettier:
 		$(srcdir)/js \
 		$(srcdir)/admin/src)
 
+prettier-write:
+	$(call run_prettier_check,--write \
+		$(srcdir)/src \
+		$(srcdir)/js \
+		$(srcdir)/admin/src)
+
 MOCHA_TEST_LOG = "`pwd`/mocha.log"
 DUPLICATION_TEST_LOG = "`pwd`/duplication.log"
 check-local: $(MOCHA_TS_JS_FILES)

--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -873,6 +873,12 @@ eslint: $(COOL_ADMIN_TS_JS)
 		$(srcdir)/js \
 		$(srcdir)/admin/src)
 
+prettier:
+	$(call run_prettier_check,--check \
+		$(srcdir)/src \
+		$(srcdir)/js \
+		$(srcdir)/admin/src)
+
 MOCHA_TEST_LOG = "`pwd`/mocha.log"
 DUPLICATION_TEST_LOG = "`pwd`/duplication.log"
 check-local: $(MOCHA_TS_JS_FILES)

--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -543,7 +543,7 @@ $(DIST_FOLDER)/admin-bundle.js: $(COOL_ADMIN_DST) \
 $(INTERMEDIATE_DIR)/admin-src.js: $(COOL_ADMIN_TS_JS) $(COOL_ADMIN_JS)
 	@mkdir -p $(dir $@)
 	@echo "Checking for admin JS errors..."
-	@$(NODE) node_modules/eslint/bin/eslint.js --resolve-plugins-relative-to $(abs_builddir) --ignore-path $(srcdir)/.eslintignore --config .eslintrc --no-eslintrc $(srcdir)/admin/src
+	@$(NODE) node_modules/eslint/bin/eslint.js --resolve-plugins-relative-to $(abs_builddir) --ignore-path $(srcdir)/.eslintignore --config .eslintrc --no-eslintrc  --ignore-pattern $(COOL_ADMIN_TS_JS)  $(srcdir)/admin/src
 	@awk 'FNR == 1 {print ""} 1' $(COOL_ADMIN_TS_JS) $(patsubst %.js,$(srcdir)/%.js,$(COOL_ADMIN_JS)) > $@
 
 $(INTERMEDIATE_DIR)/cool-src.js: tscompile.done $(call prereq_cool) $(COOL_JS_DST) $(abs_top_srcdir)/scripts/unocommands.py

--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -479,6 +479,13 @@ define run_eslint_check
 		--no-eslintrc $(1)
 endef
 
+define run_prettier_check
+	@$(NODE) node_modules/.bin/prettier \
+		--ignore-path $(srcdir)/browser/.prettierignore \
+		--ignore-path $(srcdir)/browser/.beforeprettier \
+		$(1)
+endef
+
 .PHONY: build-cool
 
 all-local: build-cool
@@ -552,11 +559,7 @@ $(INTERMEDIATE_DIR)/admin-src.js: $(COOL_ADMIN_TS_JS) $(COOL_ADMIN_JS)
 	@mkdir -p $(dir $@)
 	@echo "Checking for admin JS errors..."
 	$(call run_eslint_check,--ignore-pattern $(COOL_ADMIN_TS_JS) $(srcdir)/admin/src)
-	@$(NODE) node_modules/.bin/prettier \
-		--ignore-path $(srcdir)/browser/.prettierignore \
-		--ignore-path $(srcdir)/browser/.beforeprettier \
-		--debug-check \
-		$(srcdir)/admin/src
+	$(call run_prettier_check,--debug-check $(srcdir)/admin/src)
 	@awk 'FNR == 1 {print ""} 1' $(COOL_ADMIN_TS_JS) $(patsubst %.js,$(srcdir)/%.js,$(COOL_ADMIN_JS)) > $@
 
 $(INTERMEDIATE_DIR)/cool-src.js: tscompile.done $(call prereq_cool) $(COOL_JS_DST) $(abs_top_srcdir)/scripts/unocommands.py
@@ -566,11 +569,7 @@ $(INTERMEDIATE_DIR)/cool-src.js: tscompile.done $(call prereq_cool) $(COOL_JS_DS
 	@if ! test "z$(COOL_ASSERT_INTERSECT)" == "z"; then echo; echo "Error: please remove obsolete files:"; echo "$(COOL_ASSERT_INTERSECT)"; exit 1; else echo "clean"; fi
 	@echo "Checking for cool JS errors..."
 	$(call run_eslint_check,$(srcdir)/src $(srcdir)/js)
-	@$(NODE) node_modules/.bin/prettier \
-		--ignore-path $(srcdir)/browser/.prettierignore \
-		--ignore-path $(srcdir)/browser/.beforeprettier \
-		--debug-check \
-		$(srcdir)/src
+	$(call run_prettier_check,--debug-check $(srcdir)/src $(srcdir)/js/global.js)
 	@echo "Bundling cool..."
 	$(call bundle_cool)
 

--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -544,6 +544,11 @@ $(INTERMEDIATE_DIR)/admin-src.js: $(COOL_ADMIN_TS_JS) $(COOL_ADMIN_JS)
 	@mkdir -p $(dir $@)
 	@echo "Checking for admin JS errors..."
 	@$(NODE) node_modules/eslint/bin/eslint.js --resolve-plugins-relative-to $(abs_builddir) --ignore-path $(srcdir)/.eslintignore --config .eslintrc --no-eslintrc  --ignore-pattern $(COOL_ADMIN_TS_JS)  $(srcdir)/admin/src
+	@$(NODE) node_modules/.bin/prettier \
+		--ignore-path $(srcdir)/browser/.prettierignore \
+		--ignore-path $(srcdir)/browser/.beforeprettier \
+		--debug-check \
+		$(srcdir)/admin/src
 	@awk 'FNR == 1 {print ""} 1' $(COOL_ADMIN_TS_JS) $(patsubst %.js,$(srcdir)/%.js,$(COOL_ADMIN_JS)) > $@
 
 $(INTERMEDIATE_DIR)/cool-src.js: tscompile.done $(call prereq_cool) $(COOL_JS_DST) $(abs_top_srcdir)/scripts/unocommands.py
@@ -554,6 +559,11 @@ $(INTERMEDIATE_DIR)/cool-src.js: tscompile.done $(call prereq_cool) $(COOL_JS_DS
 	@echo "Checking for cool JS errors..."
 	@$(NODE) node_modules/eslint/bin/eslint.js $(srcdir)/src --resolve-plugins-relative-to $(abs_builddir) \
 		$(srcdir)/js --ignore-path $(srcdir)/.eslintignore --no-eslintrc --config .eslintrc
+	@$(NODE) node_modules/.bin/prettier \
+		--ignore-path $(srcdir)/browser/.prettierignore \
+		--ignore-path $(srcdir)/browser/.beforeprettier \
+		--debug-check \
+		$(srcdir)/src
 	@echo "Bundling cool..."
 	$(call bundle_cool)
 

--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -867,6 +867,13 @@ jsconfig: $(abs_srcdir)/jsconfig.json $(abs_srcdir)/admin/jsconfig.json
 build-tests: $(MOCHA_TS_JS_FILES)
 	@echo "Build of mocha test finished."
 
+eslint: $(COOL_ADMIN_TS_JS)
+	$(call run_eslint_check,--max-warnings 0 \
+		--ignore-pattern $(COOL_ADMIN_TS_JS) \
+		$(srcdir)/src \
+		$(srcdir)/js \
+		$(srcdir)/admin/src)
+
 MOCHA_TEST_LOG = "`pwd`/mocha.log"
 DUPLICATION_TEST_LOG = "`pwd`/duplication.log"
 check-local: $(MOCHA_TS_JS_FILES)

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1387,8 +1387,8 @@ L.CanvasTileLayer = L.Layer.extend({
 			partMode[pmKey].push(coords);
 		}
 
-		for (var pmKey in partMode) // no keys method
-		{
+		for (var pmKey in partMode) {
+			// no keys method
 			var partTileQueue = partMode[pmKey];
 			var part = partTileQueue[0].part;
 			var mode = partTileQueue[0].mode;

--- a/configure.ac
+++ b/configure.ac
@@ -1404,6 +1404,7 @@ AC_SUBST(ENABLE_SETCAP)
 AC_CONFIG_LINKS([discovery.xml:discovery.xml])
 AC_CONFIG_LINKS([browser/package.json:browser/package.json])
 AC_CONFIG_LINKS([browser/.eslintrc:browser/.eslintrc])
+AC_CONFIG_LINKS([browser/.prettierrc:browser/.prettierrc])
 AC_CONFIG_LINKS([cypress_test/package.json:cypress_test/package.json])
 AC_CONFIG_COMMANDS_PRE([
 if test "$srcdir" != '.'; then

--- a/configure.ac
+++ b/configure.ac
@@ -1403,6 +1403,7 @@ AC_SUBST(ENABLE_SETCAP)
 
 AC_CONFIG_LINKS([discovery.xml:discovery.xml])
 AC_CONFIG_LINKS([browser/package.json:browser/package.json])
+AC_CONFIG_LINKS([browser/.eslintrc:browser/.eslintrc])
 AC_CONFIG_LINKS([cypress_test/package.json:cypress_test/package.json])
 AC_CONFIG_COMMANDS_PRE([
 if test "$srcdir" != '.'; then


### PR DESCRIPTION
- config: fix eslint 'prettier' package extension
- browser: admin: ignore eslint transpilation code
- config: add 'prettier' command before bundeling process
- browser: fix format style
- browser: simplify eslint call
- browser: create eslint rule
- browser: simplify 'prettier' call
- browser: create prettier rule
- browser: create 'prettier-write' rule


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

