### PR TITLE
Cypress test logging improvements (backport to 23.05)

### DIFF
--- a/cypress_test/integration_tests/common/helper.js
+++ b/cypress_test/integration_tests/common/helper.js
@@ -512,7 +512,6 @@ function reload(fileName, subFolder, noFileCopy, isMultiUser, subsequentLoad, ha
 
 // noRename - whether or not to give the file a unique name, if noFileCopy is false.
 function beforeAll(fileName, subFolder, noFileCopy, isMultiUser, subsequentLoad, hasInteractionBeforeLoad, noRename) {
-	cy.log('Starting test: ' + Cypress.spec.relative + ' / ' + Cypress.currentTest.titlePath.join(' / '));
 	// Set defaults here in order to remove checks from cy.cGet function.
 	cy.cSetActiveFrame('#coolframe');
 	cy.cSetLevel('1');
@@ -524,7 +523,6 @@ function afterAll(fileName, testState) {
 	if (Cypress.browser.isHeaded)
 		cy.wait(2000);
 	closeDocument(fileName, testState);
-	cy.log('Finished test: ' + Cypress.spec.relative + ' / ' + Cypress.currentTest.titlePath.join(' / '));
 }
 
 // This method is intended to call after each test case.


### PR DESCRIPTION
Backport of https://github.com/CollaboraOnline/online/pull/8214
Description and screenshots there.

Has had no issues in 24.04. Would be nice to have these improvements in 23.05 too.

Change-Id: Ic1a20481c05afb05b9c29d0bd428b59615d49dc7