### PR TITLE
Only create Unit-test SocketPoll when used.

### DIFF
--- a/common/Unit.cpp
+++ b/common/Unit.cpp
@@ -384,11 +384,25 @@ int UnitBase::uninit()
     return GlobalResult == TestResult::Ok ? EX_OK : EX_SOFTWARE;
 }
 
+std::shared_ptr<SocketPoll> UnitBase::socketPoll()
+{
+    if (!_socketPoll)
+        _socketPoll = std::make_shared<SocketPoll>(getTestname());
+    return _socketPoll;
+}
+
+void UnitKit::postFork()
+{
+    // Don't drag wakeup pipes into the new process.
+    if (_socketPoll)
+        _socketPoll.reset();
+}
+
 void UnitBase::initialize()
 {
     assert(DlHandle != nullptr && "Invalid handle to set");
     LOG_TST("==================== Starting [" << getTestname() << "] ====================");
-    _socketPoll->startThread();
+    socketPoll()->startThread();
 }
 
 bool UnitBase::isUnitTesting()
@@ -407,7 +421,8 @@ UnitBase::~UnitBase()
 {
     LOG_TST(getTestname() << ": ~UnitBase: " << (failed() ? "FAILED" : "SUCCESS"));
 
-    _socketPoll->joinThread();
+    if (_socketPoll)
+        _socketPoll->joinThread();
 }
 
 bool UnitBase::filterLOKitMessage(const std::shared_ptr<Message>& message)
@@ -542,8 +557,9 @@ void UnitBase::returnValue(int& retValue)
 
 void UnitBase::endTest(const std::string& reason)
 {
-    LOG_TST("Ending test by stopping SocketPoll [" << _socketPoll->name() << "]: " << reason);
-    _socketPoll->joinThread();
+    LOG_TST("Ending test by stopping SocketPoll [" << getTestname() << "]: " << reason);
+    if (_socketPoll)
+        _socketPoll->joinThread();
 
     // tell the timeout thread that the work has finished
     TimeoutConditionVariable.notify_all();

--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -126,7 +126,7 @@ protected:
         , _timeoutMilliSeconds(std::chrono::seconds(30))
         , _startTimeMilliSeconds(std::chrono::milliseconds::zero())
         , _type(type)
-        , _socketPoll(std::make_shared<SocketPoll>(name))
+        , _socketPoll(nullptr)
         , testname(name)
     {
     }
@@ -272,7 +272,7 @@ public:
     const std::string& getTestname() const { return testname; }
     void setTestname(const std::string& name) { testname = name; }
 
-    std::shared_ptr<SocketPoll> socketPoll() { return _socketPoll; }
+    std::shared_ptr<SocketPoll> socketPoll();
 
 private:
     /// Initialize the test.
@@ -522,7 +522,7 @@ public:
     // ---------------- Kit hooks ----------------
 
     /// Post fork hook - just before we init the child kit
-    virtual void postFork() {}
+    virtual void postFork();
 
     /// Kit got a message
     virtual bool filterKitMessage(WebSocketHandler *, std::string &/* message */ )


### PR DESCRIPTION
We don't need a SocketPoll and its wake-pipes before we run a test - obviously, and we should close it when we fork a new test.


Change-Id: I56875b66ce2ba141baacdd70c973e9e9af02d1d0


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

