### PR TITLE
Cypress: log helper function start and end

### DIFF
--- a/cypress_test/integration_tests/common/calc_helper.js
+++ b/cypress_test/integration_tests/common/calc_helper.js
@@ -6,6 +6,7 @@ var helper = require('./helper');
 // mouseover is triggered to avoid leaving the mouse on the Formula-Bar,
 // which shows the tooltip and messes up tests.
 function clickFormulaBar() {
+	cy.log('>> clickFormulaBar - start');
 
 	// The inputbar_container is 100% width, which
 	// can extend behind the sidebar. So we can't
@@ -19,6 +20,8 @@ function clickFormulaBar() {
 
 	cy.cGet('#sc_input_window.formulabar').focus();
 	cy.cGet('body').trigger('mouseover');
+
+	cy.log('<< clickFormulaBar - end');
 }
 
 // Click on the first cell of the sheet (A1), we use the document
@@ -31,7 +34,7 @@ function clickFormulaBar() {
 // dblClick - to do a double click or not. The result of double click is that the cell
 //            editing it triggered both on desktop and mobile.
 function clickOnFirstCell(firstClick = true, dblClick = false, isA1 = true) {
-	cy.log('Clicking on first cell - start.');
+	cy.log('>> clickOnFirstCell - start');
 	cy.log('Param - firstClick: ' + firstClick);
 	cy.log('Param - dblClick: ' + dblClick);
 
@@ -60,19 +63,23 @@ function clickOnFirstCell(firstClick = true, dblClick = false, isA1 = true) {
 	if (isA1)
 		cy.cGet('input#addressInput').should('have.prop', 'value', 'A1');
 
-	cy.log('Clicking on first cell - end.');
+	cy.log('<< clickOnFirstCell - end');
 }
 
 // Double click on the A1 cell.
 function dblClickOnFirstCell() {
+	cy.log('>> dblClickOnFirstCell - start');
+
 	clickOnFirstCell(false, true);
+
+	cy.log('<< dblClickOnFirstCell - end');
 }
 
 // Type some text into the formula bar.
 // Parameters:
 // text - the text the method type into the formula bar's intput field.
 function typeIntoFormulabar(text) {
-	cy.log('Typing into formulabar - start.');
+	cy.log('>> typeIntoFormulabar - start');
 
 	cy.cGet('#sc_input_window.formulabar')
 		.then(function(cursor) {
@@ -95,14 +102,14 @@ function typeIntoFormulabar(text) {
 		cy.cGet('#cancelformula').should('be.visible');
 	});
 
-	cy.log('Typing into formulabar - end.');
+	cy.log('<< typeIntoFormulabar - end');
 }
 
 // Remove exisiting text selection by clicking on
 // row headers at the center position, until a
 // a row is selected (and text seletion is removed).
 function removeTextSelection() {
-	cy.log('Removing text selection - start.');
+	cy.log('>> removeTextSelection - start');
 
 	cy.cGet('[id="test-div-row header"]')
 		.then(function(header) {
@@ -125,8 +132,7 @@ function removeTextSelection() {
 			});
 		});
 
-
-	cy.log('Removing text selection - end.');
+	cy.log('<< removeTextSelection - end');
 }
 
 // Select the enitre sheet, using the select all button
@@ -136,7 +142,7 @@ function removeTextSelection() {
 // text selection, select all would select only the content
 // of the currently edited cell instead of the whole table.
 function selectEntireSheet() {
-	cy.log('Selecting entire sheet - start.');
+	cy.log('>> selectEntireSheet - start');
 
 	removeTextSelection();
 
@@ -160,7 +166,7 @@ function selectEntireSheet() {
 			return regex.test(value);
 		});
 
-	cy.log('Selecting entire sheet - end.');
+	cy.log('<< selectEntireSheet - end');
 }
 
 // Select first column of a calc document.
@@ -168,6 +174,8 @@ function selectEntireSheet() {
 // of the column headers. Of course if the first column
 // has a very small width, then this might fail.
 function selectFirstColumn() {
+	cy.log('>> selectFirstColumn - start');
+
 	cy.cGet('[id="test-div-column header"]')
 		.then(function(items) {
 			expect(items).to.have.lengthOf(1);
@@ -179,9 +187,13 @@ function selectFirstColumn() {
 		});
 
 		cy.cGet('input#addressInput').should('have.prop', 'value', 'A1:A1048576');
+
+	cy.log('<< selectFirstColumn - end');
 }
 
 function ensureViewContainsCellCursor() {
+	cy.log('>> ensureViewContainsCellCursor - start');
+
 	var sheetViewBounds = new helper.Bounds();
 	var sheetCursorBounds = new helper.Bounds();
 
@@ -192,14 +204,22 @@ function ensureViewContainsCellCursor() {
 		cy.log('ensureViewContainsCellCursor: cursor-area is ' + sheetCursorBounds.toString() + ' view-area is ' + sheetViewBounds.toString());
 		expect(sheetViewBounds.contains(sheetCursorBounds)).to.equal(true, 'view-area must contain cursor-area');
 	});
+
+	cy.log('<< ensureViewContainsCellCursor - end');
 }
 
 function assertSheetContents(expectedData) {
+	cy.log('>> assertSheetContents - start');
+
 	selectEntireSheet();
 	assertDataClipboardTable(expectedData);
+
+	cy.log('<< assertSheetContents - end');
 }
 
 function assertDataClipboardTable(expectedData) {
+	cy.log('>> assertDataClipboardTable - start');
+
 	cy.cGet('#copy-paste-container table td')
 		.should(function(cells) {
 			expect(cells).to.have.lengthOf(expectedData.length);
@@ -218,15 +238,23 @@ function assertDataClipboardTable(expectedData) {
 				data.push(text);
 			});
 	}).then(() => expect(data).to.deep.eq(expectedData));
+
+	cy.log('<< assertDataClipboardTable - end');
 }
 
 function selectCellsInRange(range) {
+	cy.log('>> selectCellsInRange - start');
+
 	cy.cGet('#tb_formulabar_item_address #addressInput')
 		.clear()
 		.type(range + '{enter}');
+
+	cy.log('<< selectCellsInRange - end');
 }
 
 function openAutoFilterMenu(secondColumn) {
+	cy.log('>> openAutoFilterMenu - start');
+
 	let XPos = 95;
 	let YPos = 10;
 
@@ -236,6 +264,8 @@ function openAutoFilterMenu(secondColumn) {
 
 	cy.cGet('#map').then(function(items) { expect(items).to.have.lengthOf(1); });
 	cy.cGet('#map').click(XPos, YPos);
+
+	cy.log('<< openAutoFilterMenu - end');
 }
 
 module.exports.clickOnFirstCell = clickOnFirstCell;

--- a/cypress_test/integration_tests/common/contenteditable_helper.js
+++ b/cypress_test/integration_tests/common/contenteditable_helper.js
@@ -13,19 +13,22 @@ function _checkSelectionEnd(value) {
 }
 
 function type(text, times = 1) {
+	cy.log('>> type - start');
+
 	var input = '';
 	for (var i = 0; i < times; ++i) {
 		input += text;
 	}
 
-	cy.log('Clipboard - typing start.');
 	cy.get('@clipboard').type(input, {delay: 10, force: true});
-	cy.log('Clipboard - typing end.');
+
+	cy.log('<< type - end');
 }
 
 function moveCaret(direction, modifier = '', times = 1) {
-	cy.log('Clipboard - moving caret start');
+	cy.log('>> moveCaret - start');
 	cy.log('  Param - direction: ' + direction);
+
 	if (modifier)
 		cy.log('  Param - modifier: ' + modifier);
 	if (times > 1)
@@ -61,10 +64,13 @@ function moveCaret(direction, modifier = '', times = 1) {
 	}
 
 	cy.get('@clipboard').type(key, {delay: 10, force: true});
-	cy.log('Clipboard - moving caret end');
+
+	cy.log('<< moveCaret - end');
 }
 
 function select(start, end) {
+	cy.log('>> select - start');
+
 	moveCaret('home');
 	moveCaret('right', '', start);
 	if (start < end) {
@@ -73,19 +79,31 @@ function select(start, end) {
 	else if (start > end) {
 		moveCaret('left', 'shift', start - end);
 	}
+
+	cy.log('<< select - end');
 }
 
 function checkHTMLContent(content) {
+	cy.log('>> checkHTMLContent - start');
+
 	cy.get('@clipboard').should(($c) => {
 		expect($c).have.html($c.get(0)._wrapContent(content));
 	});
+
+	cy.log('<< checkHTMLContent - end');
 }
 
 function checkPlainContent(content) {
+	cy.log('>> checkPlainContent - start');
+
 	cy.get('@clipboard').should('have.text', content);
+
+	cy.log('<< checkPlainContent - end');
 }
 
 function checkSelectionRange(start, end) {
+	cy.log('>> checkSelectionRange - start');
+
 	if (start > end) {
 		var t = start;
 		start = end;
@@ -94,21 +112,35 @@ function checkSelectionRange(start, end) {
 	cy.get('@clipboard').should('have.prop', 'isSelectionNull', false);
 	_checkSelectionStart(start);
 	_checkSelectionEnd(end);
+
+	cy.log('<< checkSelectionRange - end');
 }
 
 function checkCaretPosition(pos) {
+	cy.log('>> checkCaretPosition - start');
+
 	_checkSelectionStart(pos);
 	_checkSelectionEnd(pos);
+
+	cy.log('<< checkCaretPosition - end');
 }
 
 function checkSelectionIsNull() {
+	cy.log('>> checkSelectionIsNull - start');
+
 	cy.get('@clipboard').should('have.prop', 'isSelectionNull', true);
+
+	cy.log('<< checkSelectionIsNull - end');
 }
 
 function checkSelectionIsEmpty(pos) {
+	cy.log('>> checkSelectionIsEmpty - start');
+
 	cy.get('@clipboard').should('have.prop', 'isSelectionNull', false);
 	_checkSelectionStart(pos);
 	_checkSelectionEnd(pos);
+
+	cy.log('<< checkSelectionIsEmpty - end');
 }
 
 module.exports.type = type;

--- a/cypress_test/integration_tests/common/desktop_helper.js
+++ b/cypress_test/integration_tests/common/desktop_helper.js
@@ -6,7 +6,7 @@ var helper = require('./helper');
 // We assume that the sidebar is hidden, when this method is called.
 
 function showSidebar() {
-	cy.log('Showing sidebar - start.');
+	cy.log('>> showSidebar - start');
 
 	cy.cGet('#tb_editbar_item_sidebar .w2ui-button').should('not.have.class', 'checked');
 	cy.cGet('#sidebar-dock-wrapper').should('not.be.visible');
@@ -14,13 +14,13 @@ function showSidebar() {
 	cy.cGet('#tb_editbar_item_sidebar .w2ui-button').should('have.class', 'checked');
 	cy.cGet('#sidebar-dock-wrapper').should('be.visible');
 
-	cy.log('Showing sidebar - end.');
+	cy.log('<< showSidebar - end');
 }
 
 // Hide the sidebar by clicking on the corresponding toolbar item.
 // We assume that the sidebar is visible, when this method is called.
 function hideSidebar() {
-	cy.log('Hiding sidebar - start.');
+	cy.log('>> hideSidebar - start');
 
 	cy.cGet('#tb_editbar_item_sidebar .w2ui-button').should('have.class', 'checked');
 	cy.cGet('#sidebar-dock-wrapper').should('be.visible');
@@ -28,12 +28,14 @@ function hideSidebar() {
 	cy.cGet('#tb_editbar_item_sidebar .w2ui-button').should('not.have.class', 'checked');
 	cy.cGet('#sidebar-dock-wrapper').should('not.be.visible');
 
-	cy.log('Hiding sidebar - end.');
+	cy.log('<< hideSidebar - end');
 }
 
 // Make the status bar visible if it's hidden at the moment.
 // We use the menu option under 'View' menu to make it visible.
 function showStatusBarIfHidden() {
+	cy.log('>> showStatusBarIfHidden - start');
+
 	cy.cGet('#toolbar-down')
 		.then(function(statusbar) {
 			if (!Cypress.dom.isVisible(statusbar[0])) {
@@ -46,10 +48,14 @@ function showStatusBarIfHidden() {
 		});
 
 	cy.cGet('#toolbar-down').should('be.visible');
+
+	cy.log('<< showStatusBarIfHidden - end');
 }
 
 // Make the sidebar visible if it's hidden at the moment.
 function showSidebarIfHidden() {
+	cy.log('>> showSidebarIfHidden - start');
+
 	cy.get('#tb_editbar_item_sidebar .w2ui-button')
 		.then(function(sidebarItem) {
 			if (!sidebarItem.hasClass('checked')) {
@@ -59,10 +65,14 @@ function showSidebarIfHidden() {
 
 	cy.get('#sidebar-dock-wrapper')
 		.should('be.visible');
+
+	cy.log('<< showSidebarIfHidden - end');
 }
 
 // Hide the sidebar if it's visible at the moment.
 function hideSidebarIfVisible() {
+	cy.log('>> hideSidebarIfVisible - start');
+
 	cy.get('#tb_editbar_item_sidebar .w2ui-button')
 		.then(function(sidebarItem) {
 			if (sidebarItem.hasClass('checked')) {
@@ -72,31 +82,43 @@ function hideSidebarIfVisible() {
 
 	cy.get('#sidebar-dock-wrapper')
 		.should('not.be.visible');
+
+	cy.log('<< hideSidebarIfVisible - end');
 }
 
 // Select a color from colour palette widget used on top toolbar.
 // Parameters:
 // color - a hexadecimal color code without the '#' mark (e.g. 'FF011B')
 function selectColorFromPalette(color) {
+	cy.log('>> selectColorFromPalette - start');
+
 	cy.cGet('.w2ui-overlay').should('be.visible');
 	cy.cGet('.w2ui-color [name="' + color + '"]').click();
 	cy.cGet('.w2ui-overlay').should('not.exist');
+
+	cy.log('<< selectColorFromPalette - end');
 }
 
 // Select an item from a listbox widget used on top toolbar.
 // Parameters:
 // item - item string, that we use a selector to find the right list item.
 function selectFromListbox(item) {
+	cy.log('>> selectFromListbox - start');
+
 	cy.cGet('.select2-dropdown').should('be.visible');
 	// We use force because the tooltip sometimes hides the items.
 	cy.cGet('body').contains('.select2-results__option', item).click({force: true});
 	cy.cGet('.select2-dropdown').should('not.exist');
+
+	cy.log('<< selectFromListbox - end');
 }
 
 // Select an item from a JSDialog dropdown widget used on top toolbar.
 // Parameters:
 // item - item string, that we use a selector to find the right list item.
 function selectFromJSDialogListbox(item, isImage) {
+	cy.log('>> selectFromJSDialogListbox - start');
+
 	cy.cGet('[id$="-dropdown"].modalpopup').should('be.visible');
 	// We use force because the tooltip sometimes hides the items.
 	if (isImage) {
@@ -106,6 +128,8 @@ function selectFromJSDialogListbox(item, isImage) {
 		cy.cGet('[id$="-dropdown"].modalpopup').contains('span', item).click({force: true});
 
 	cy.cGet('[id$="-dropdown"].modalpopup').should('not.exist');
+
+	cy.log('<< selectFromJSDialogListbox - end');
 }
 
 // Make sure the right dialog is opened and then we close it.
@@ -115,6 +139,8 @@ function selectFromJSDialogListbox(item, isImage) {
 // Parameters:
 // dialogTitle - a title string to make sure the right dialog was opened.
 function checkDialogAndClose(dialogTitle) {
+	cy.log('>> checkDialogAndClose - start');
+
 	// Dialog is opened
 	cy.cGet('.lokdialog_canvas').should('be.visible');
 	cy.cGet('.ui-dialog-title').should('have.text', dialogTitle);
@@ -122,19 +148,27 @@ function checkDialogAndClose(dialogTitle) {
 	// Close the dialog
 	cy.cGet('body').type('{esc}');
 	cy.cGet('.lokdialog_canvas').should('not.exist');
+
+	cy.log('<< checkDialogAndClose - end');
 }
 
 // Checks wether the document has the given zoom level according to the status bar.
 // Parameters:
 // zoomLevel        the expected zoom level (e.g. '100' means 100%).
 function shouldHaveZoomLevel(zoomLevel) {
+	cy.log('>> shouldHaveZoomLevel - start');
+
 	cy.cGet('#tb_actionbar_item_zoom .w2ui-tb-caption').should('have.text', zoomLevel);
+
+	cy.log('<< shouldHaveZoomLevel - end');
 }
 
 // Make the zoom related status bar items visible if they are hidden.
 // The status bar can be long to not fit on the screen. We have a scroll
 // item for navigation in this case.
 function makeZoomItemsVisible() {
+	cy.log('>> makeZoomItemsVisible - start');
+
 	cy.cGet('.w2ui-tb-image.w2ui-icon.zoomin')
 		.then(function(zoomInItem) {
 			if (!Cypress.dom.isVisible(zoomInItem)) {
@@ -143,12 +177,16 @@ function makeZoomItemsVisible() {
 		});
 
 	cy.cGet('.w2ui-tb-image.w2ui-icon.zoomin').should('be.visible');
+
+	cy.log('<< makeZoomItemsVisible - end');
 }
 
 // Increase / decrease the zoom level using the status bar related items.
 // Parameters:
 // zoomIn - do a zoom in (e.g. increase zoom level) or zoom out.
 function doZoom(zoomIn) {
+	cy.log('>> doZoom - start');
+
 	var prevZoom = '';
 	cy.cGet('#tb_actionbar_item_zoom .w2ui-tb-caption')
 		.should(function(zoomLevel) {
@@ -170,6 +208,8 @@ function doZoom(zoomIn) {
 		.should(function(zoomLevel) {
 			expect(zoomLevel.text()).to.not.equal(prevZoom);
 		});
+
+	cy.log('<< doZoom - end');
 }
 
 // Zoom in the document.
@@ -188,20 +228,30 @@ function zoomOut() {
 // zoomLevel - a number specifing the zoom level  (e.g. '100' means 100%).
 //             See also the status bar's zoom level list for possible values.
 function selectZoomLevel(zoomLevel) {
+	cy.log('>> selectZoomLevel - start');
+
 	// Force because sometimes the icons are scrolled off the screen to the right
 	cy.cGet('#tb_actionbar_item_zoom .w2ui-button').click({force: true});
 	cy.cGet('#w2ui-overlay-actionbar').contains('.menu-text', zoomLevel).click({force: true});
 	shouldHaveZoomLevel(zoomLevel);
+
+	cy.log('<< selectZoomLevel - end');
 }
 
 // Reset zoom level to 100%.
 function resetZoomLevel() {
+	cy.log('>> resetZoomLevel - start');
+
 	// Force because sometimes the icons are scrolled off the screen to the right
 	cy.cGet('#tb_actionbar_item_zoomreset .w2ui-button').click({force: true});
 	shouldHaveZoomLevel('100');
+
+	cy.log('<< resetZoomLevel - end');
 }
 
 function insertImage(docType) {
+	cy.log('>> insertImage - start');
+
 	selectZoomLevel('50');
 
 	cy.cGet('#toolbar-up .w2ui-scroll-right').click();
@@ -221,14 +271,22 @@ function insertImage(docType) {
 
 	cy.cGet('#insertgraphic[type=file]').attachFile('/desktop/writer/image_to_insert.png');
 	cy.cGet('.leaflet-pane.leaflet-overlay-pane svg g').should('exist');
+
+	cy.log('<< insertImage - end');
 }
 
 function deleteImage() {
+	cy.log('>> deleteImage - start');
+
 	helper.typeIntoDocument('{del}');
 	cy.cGet('.leaflet-pane.leaflet-overlay-pane svg g').should('not.exist');
+
+	cy.log('<< deleteImage - end');
 }
 
 function assertImageSize(expectedWidth, expectedHeight) {
+	cy.log('>> assertImageSize - start');
+
 	cy.cGet('.leaflet-pane.leaflet-overlay-pane svg svg')
 		.should('exist')
 		.then($ele => {
@@ -238,9 +296,13 @@ function assertImageSize(expectedWidth, expectedHeight) {
 			expect(actualWidth).to.be.closeTo(expectedWidth, 10);
 			expect(actualHeight).to.be.closeTo(expectedHeight, 10);
 		});
+
+	cy.log('<< assertImageSize - end');
 }
 
 function createComment(docType, text, isMobile, selector) {
+	cy.log('>> createComment - start');
+
 	if (docType === 'draw') {
 		cy.cGet('#menu-insert').click();
 		cy.cGet('#menu-insertcomment').click();
@@ -260,9 +322,13 @@ function createComment(docType, text, isMobile, selector) {
 
 	cy.cGet('#annotation-modify-textarea-new').type(text);
 	// Cannot have any action between type and subsequent save button click
+
+	cy.log('<< createComment - end');
 }
 
 function saveComment(isMobile) {
+	cy.log('>> saveComment - start');
+
 	if (isMobile) {
 		cy.cGet('#response-ok').click();
 	} else {
@@ -272,9 +338,13 @@ function saveComment(isMobile) {
 		// Wait for animation
 		cy.wait(100);
 	}
+
+	cy.log('<< saveComment - end');
 }
 
 function setupUIforCommentInsert(docType) {
+	cy.log('>> setupUIforCommentInsert - start');
+
 	var mode = Cypress.env('USER_INTERFACE');
 
 	if (docType !== 'draw') {
@@ -300,44 +370,50 @@ function setupUIforCommentInsert(docType) {
 			}
 		});
 	}
+
+	cy.log('<< setupUIforCommentInsert - end');
 }
 
 function insertMultipleComment(docType, numberOfComments = 1, isMobile = false, selector) {
+	cy.log('>> insertMultipleComment - start');
+
 	setupUIforCommentInsert(docType);
 
 	for (var n = 0; n < numberOfComments; n++) {
 		createComment(docType, 'some text' + n, isMobile, selector);
 		saveComment(isMobile);
 	}
+
+	cy.log('<< insertMultipleComment - end');
 }
 
 function switchUIToNotebookbar() {
+	cy.log('>> switchUIToNotebookbar - start');
+
 	cy.window().then(win => {
 		var userInterfaceMode = win['0'].userInterfaceMode;
 		if (userInterfaceMode !== 'notebookbar') {
-			cy.log('switchUIToNotebookbar start');
 			cy.cGet('#menu-view').click();
 			cy.cGet('#menu-toggleuimode').should($el => { expect(Cypress.dom.isDetached($el)).to.eq(false); }).click();
-			cy.log('switchUIToNotebookbar end');
-		} else {
-			cy.log('switchUIToNotebookbar: already notebookbar UI');
 		}
 		Cypress.env('USER_INTERFACE', 'notebookbar');
 	});
+
+	cy.log('<< switchUIToNotebookbar - end');
 }
 
 function switchUIToCompact() {
+	cy.log('>> switchUIToCompact - start');
+
 	cy.window().then(win => {
 		var userInterfaceMode = win['0'].userInterfaceMode;
 		if (userInterfaceMode === 'notebookbar') {
-			cy.log('switchUIToCompact start');
 			cy.cGet('#View-tab-label').click();
 			cy.cGet('#toggleuimode').click();
-			cy.log('switchUIToCompact end');
-		} else {
-			cy.log('switchUIToCompact: already compact UI');
 		}
 	});
+
+	cy.log('<< switchUIToCompact - end');
 }
 
 function actionOnSelector(name, func) {
@@ -353,20 +429,30 @@ function actionOnSelector(name, func) {
 //arr : In both cypress GUI and CLI the scrollposition are slightly different
 //so we are passing both in array and assert using oneOf
 function assertScrollbarPosition(type, lowerBound, upperBound) {
+	cy.log('>> assertScrollbarPosition - start');
+
 	cy.cGet('#test-div-' + type + '-scrollbar')
 		.should(function($item) {
 			const x = parseInt($item.text());
 			expect(x).to.be.within(lowerBound, upperBound);
 		});
+
+	cy.log('<< assertScrollbarPosition - end');
 }
 
 function pressKey(n, key) {
+	cy.log('>> pressKey - start');
+
 	for (let i=0; i<n; i++) {
 		helper.typeIntoDocument('{' + key + '}');
 	}
+
+	cy.log('<< pressKey - end');
 }
 
 function openReadOnlyFile(type, filename) {
+	cy.log('>> openReadOnlyFile - start');
+
 	var testFileName = helper.loadTestDocNoIntegration(filename, type, false, false, false);
 
 	//check doc is loaded
@@ -376,10 +462,13 @@ function openReadOnlyFile(type, filename) {
 
 	cy.cGet('#PermissionMode').should('be.visible').should('have.text', ' Read-only ');
 
+	cy.log('<< openReadOnlyFile - end');
 	return testFileName;
 }
 
 function checkAccessibilityEnabledToBe(state) {
+	cy.log('>> checkAccessibilityEnabledToBe - start');
+
 	cy.window().then(win => {
 		cy.log('check accessibility enabled to be: ' + state);
 		var isAccessibilityEnabledAtServerLevel = win['0'].enableAccessibility;
@@ -408,9 +497,13 @@ function checkAccessibilityEnabledToBe(state) {
 			cy.log('accessibility disabled at server level');
 		}
 	});
+
+	cy.log('<< checkAccessibilityEnabledToBe - end');
 }
 
 function setAccessibilityState(enable) {
+	cy.log('>> setAccessibilityState - start');
+
 	cy.window().then(win => {
 		cy.log('set accessibility state to: ' + enable);
 		var a11yEnabled = win['0'].enableAccessibility;
@@ -447,6 +540,8 @@ function setAccessibilityState(enable) {
 			cy.log('accessibility disabled at server level');
 		}
 	});
+
+	cy.log('<< setAccessibilityState - end');
 }
 
 module.exports.showSidebar = showSidebar;

--- a/cypress_test/integration_tests/common/helper.js
+++ b/cypress_test/integration_tests/common/helper.js
@@ -86,7 +86,7 @@ Parameters:
 	noRename - whether or not to give the file a unique name, if noFileCopy is false.
  */
 function loadTestDocNoIntegration(fileName, subFolder, noFileCopy, isMultiUser, noRename) {
-	cy.log('Loading test document with a local build - start.');
+	cy.log('>> loadTestDocNoIntegration - start');
 
 	var newFileName = getRandomFileName(noRename, noFileCopy, fileName);
 
@@ -115,7 +115,7 @@ function loadTestDocNoIntegration(fileName, subFolder, noFileCopy, isMultiUser, 
 		}
 	});
 
-	cy.log('Loading test document with a local build - end.');
+	cy.log('<< loadTestDocNoIntegration - end');
 
 	return newFileName;
 }
@@ -128,7 +128,7 @@ function loadTestDocNoIntegration(fileName, subFolder, noFileCopy, isMultiUser, 
 //                  test case or not. It's important because we need to sign in
 //                  with the username + password only for the first time.
 function loadTestDocNextcloud(fileName, subFolder, subsequentLoad) {
-	cy.log('Loading test document with nextcloud - start.');
+	cy.log('>> loadTestDocNextcloud - start');
 	cy.log('Param - fileName: ' + fileName);
 	cy.log('Param - subFolder: ' + subFolder);
 	cy.log('Param - subsequentLoad: ' + subsequentLoad);
@@ -161,13 +161,15 @@ function loadTestDocNextcloud(fileName, subFolder, subsequentLoad) {
 			Cypress.env('IFRAME_LEVEL', '2');
 		});
 
-	cy.log('Loading test document with nextcloud - end.');
+	cy.log('<< loadTestDocNextcloud - end');
 }
 
 // Hide NC's first run wizard, which is opened by the first run of
 // nextcloud. When we run cypress in headless mode, NC don't detect
 // that we already used it and so it always opens this wizard.
 function hideNCFirstRunWizard() {
+	cy.log('>> hideNCFirstRunWizard - start');
+
 	// Hide first run wizard if it's there
 	cy.wait(2000); // Wait some time to the wizard become visible, if it's there.
 	cy.cGet('body')
@@ -179,6 +181,8 @@ function hideNCFirstRunWizard() {
 					});
 			}
 		});
+
+	cy.log('<< hideNCFirstRunWizard - end');
 }
 
 // Upload a test document into Nexcloud and open it.
@@ -189,7 +193,7 @@ function hideNCFirstRunWizard() {
 //                  test case or not. It's important because we need to sign in
 //                  with the username + password only for the first time.
 function upLoadFileToNextCloud(fileName, subFolder, subsequentLoad) {
-	cy.log('Uploading test document into nextcloud - start.');
+	cy.log('>> loadTestDocNextcloud - start');
 	cy.log('Param - fileName: ' + fileName);
 	cy.log('Param - subFolder: ' + subFolder);
 	cy.log('Param - subsequentLoad: ' + subsequentLoad);
@@ -264,7 +268,7 @@ function upLoadFileToNextCloud(fileName, subFolder, subsequentLoad) {
 	cy.cGet('tr[data-file=\'' + fileName + '\']')
 		.should('be.visible');
 
-	cy.log('Uploading test document into nextcloud - end.');
+	cy.log('<< loadTestDocNextcloud - end');
 }
 
 // Used for interference testing. We wait until the interfering user loads
@@ -272,10 +276,14 @@ function upLoadFileToNextCloud(fileName, subFolder, subsequentLoad) {
 // So we can be sure the interference actions are made during the test
 // user does the actual test steps.
 function waitForInterferingUser() {
+	cy.log('>> waitForInterferingUser - start');
+
 	cy.cGet('#tb_actionbar_item_userlist', { timeout: Cypress.config('defaultCommandTimeout') * 2.0 })
 		.should('be.visible');
 
 	cy.wait(10000);
+
+	cy.log('<< waitForInterferingUser - end');
 }
 
 // Loading the test document inside Collabora Online (directly or via some integration).
@@ -291,8 +299,9 @@ function waitForInterferingUser() {
 //                  with the username + password only for the first time.
 // noRename - whether or not to give the file a unique name, if noFileCopy is false.
 function loadTestDoc(fileName, subFolder, noFileCopy, isMultiUser, subsequentLoad, hasInteractionBeforeLoad, noRename) {
+	cy.log('>> loadTestDoc - start');
+
 	var server = Cypress.env('SERVER');
-	cy.log('Loading test document - start.');
 	logLoadingParameters(fileName, subFolder, noFileCopy, isMultiUser, subsequentLoad, hasInteractionBeforeLoad, noRename);
 
 	// We set the mobile screen size here. We could use any other phone type here.
@@ -316,12 +325,12 @@ function loadTestDoc(fileName, subFolder, noFileCopy, isMultiUser, subsequentLoa
 
 	checkIfDocIsLoaded(isMultiUser);
 
-	cy.log('Loading test document - end.');
+	cy.log('<< loadTestDoc - end');
 	return destFileName;
 }
 
 function documentChecks() {
-	cy.log('documentChecks - start.');
+	cy.log('>> documentChecks - start');
 
 	cy.cframe().find('#document-canvas', {timeout : Cypress.config('defaultCommandTimeout') * 2.0});
 
@@ -358,11 +367,11 @@ function documentChecks() {
 		waitForInterferingUser();
 	}
 
-	cy.log('documentChecks - end.');
+	cy.log('<< documentChecks - end');
 }
 
 function checkIfDocIsLoaded(isMultiUser) {
-	cy.log('checkIfDocIsLoaded - start.');
+	cy.log('>> checkIfDocIsLoaded - start');
 
 	if (isMultiUser) {
 		cy.cSetActiveFrame('#iframe1');
@@ -379,22 +388,30 @@ function checkIfDocIsLoaded(isMultiUser) {
 		documentChecks();
 	}
 
-	cy.log('checkIfDocIsLoaded - end.');
+	cy.log('<< checkIfDocIsLoaded - end');
 }
 
 // Assert that NO keyboard input is accepted (i.e. keyboard should be HIDDEN).
 function assertNoKeyboardInput() {
+	cy.log('>> assertNoKeyboardInput - start');
+
 	cy.cGet('div.clipboard').should('have.attr', 'data-accept-input', 'false');
+
+	cy.log('<< assertNoKeyboardInput - end');
 }
 
 // Assert that keyboard input is accepted (i.e. keyboard should be VISIBLE).
 function assertHaveKeyboardInput() {
+	cy.log('>> assertHaveKeyboardInput - start');
+
 	cy.cGet('div.clipboard').should('have.attr', 'data-accept-input', 'true');
+
+	cy.log('<< assertHaveKeyboardInput - end');
 }
 
 // Assert that we have cursor and focus on the text area of the document.
 function assertCursorAndFocus() {
-	cy.log('Verifying Cursor and Focus - start');
+	cy.log('>> assertCursorAndFocus - start');
 
 	if (Cypress.env('INTEGRATION') !== 'nextcloud') {
 		// Active element must be the textarea named clipboard.
@@ -407,23 +424,23 @@ function assertCursorAndFocus() {
 
 	assertHaveKeyboardInput();
 
-	cy.log('Verifying Cursor and Focus - end');
+	cy.log('<< assertCursorAndFocus - end');
 }
 
 // Select all text via CTRL+A shortcut.
 function selectAllText() {
-	cy.log('Select all text - start');
+	cy.log('>> selectAllText - start');
 
 	typeIntoDocument('{ctrl}a');
 
 	textSelectionShouldExist();
 
-	cy.log('Select all text - end');
+	cy.log('<< selectAllText - end');
 }
 
 // Clear all text by selecting all and deleting.
 function clearAllText() {
-	cy.log('Clear all text - start');
+	cy.log('>> clearAllText - start');
 
 	//assertCursorAndFocus();
 
@@ -435,13 +452,15 @@ function clearAllText() {
 
 	textSelectionShouldNotExist();
 
-	cy.log('Clear all text - end');
+	cy.log('<< clearAllText - end');
 }
 
 // Check that the clipboard text matches with the specified text.
 // Parameters:
 // expectedPlainText - a string, the clipboard container should have.
 function expectTextForClipboard(expectedPlainText) {
+	cy.log('>> expectTextForClipboard - start');
+
 	cy.log('Text:' + expectedPlainText);
 	doIfInWriter(function() {
 		cy.cGet('#copy-paste-container p')
@@ -465,6 +484,8 @@ function expectTextForClipboard(expectedPlainText) {
 		cy.cGet('#copy-paste-container pre')
 			.should('have.text', expectedPlainText);
 	});
+
+	cy.log('<< expectTextForClipboard - end');
 }
 
 // Check that the clipboard text matches with the
@@ -473,6 +494,8 @@ function expectTextForClipboard(expectedPlainText) {
 // regexp - a regular expression to match the content with.
 //          https://docs.cypress.io/api/commands/contains.html#Regular-Expression
 function matchClipboardText(regexp) {
+	cy.log('>> matchClipboardText - start');
+
 	doIfInWriter(function() {
 		cy.cGet('body').contains('#copy-paste-container p font', regexp).should('exist');
 	});
@@ -482,9 +505,13 @@ function matchClipboardText(regexp) {
 	doIfInImpress(function() {
 		cy.cGet('body').contains('#copy-paste-container pre', regexp).should('exist');
 	});
+
+	cy.log('<< matchClipboardText - end');
 }
 
 function clipboardTextShouldBeDifferentThan(text) {
+	cy.log('>> clipboardTextShouldBeDifferentThan - start');
+
 	doIfInWriter(function() {
 		cy.cGet('body').contains('#copy-paste-container p font', text).should('not.exist');
 	});
@@ -494,6 +521,8 @@ function clipboardTextShouldBeDifferentThan(text) {
 	doIfInImpress(function() {
 		cy.cGet('body').contains('#copy-paste-container pre', text).should('not.exist');
 	});
+
+	cy.log('<< clipboardTextShouldBeDifferentThan - end');
 }
 
 // This is called during a test to reload the same document after
@@ -527,7 +556,7 @@ function afterAll(fileName, testState) {
 // fileName - test document name (we can check it on the admin console).
 // testState - whether the test passed or failed before this method was called.
 function closeDocument(fileName, testState) {
-	cy.log('Waiting for closing the document - start.');
+	cy.log('>> closeDocument - start');
 
 	if (Cypress.env('INTEGRATION') === 'nextcloud') {
 		if (testState === 'failed') {
@@ -605,7 +634,7 @@ function closeDocument(fileName, testState) {
 			.should('not.match', regex);
 	}
 
-	cy.log('Waiting for closing the document - end.');
+	cy.log('<< closeDocument - end');
 }
 
 // Initialize an alias to a negative number value. It can be useful
@@ -614,7 +643,7 @@ function closeDocument(fileName, testState) {
 // Parameters:
 // aliasName - a string, expected to be used as alias.
 function initAliasToNegative(aliasName) {
-	cy.log('Initializing alias to a negative value - start.');
+	cy.log('>> initAliasToNegative - start');
 	cy.log('Param - aliasName: ' + aliasName);
 
 	cy.cGet('#copy-paste-container')
@@ -624,7 +653,7 @@ function initAliasToNegative(aliasName) {
 
 	cy.get('@' + aliasName).should('be.lessThan', 0);
 
-	cy.log('Initializing alias to a negative value - end.');
+	cy.log('<< initAliasToNegative - end');
 }
 
 // Run a code snippet if we are inside Calc.
@@ -695,16 +724,20 @@ function doIfNotInWriter(callback) {
 // text - a text, what we'll type char-by-char.
 // delayMs - delay in ms between the characters.
 function typeText(selector, text, delayMs = 0) {
+	cy.log('>> typeText - start');
+
 	for (var i = 0; i < text.length; i++) {
 		cy.cGet(selector).type(text.charAt(i));
 		if (delayMs > 0)
 			cy.wait(delayMs);
 	}
+
+	cy.log('<< typeText - end');
 }
 
 // Check whether an img DOM element has only white colored pixels or not.
 function isImageWhite(selector, expectWhite = true) {
-	cy.log('Check whether an image is full white or not - start.');
+	cy.log('>> isImageWhite - start');
 
 	expect(selector).to.have.string('img');
 
@@ -738,11 +771,12 @@ function isImageWhite(selector, expectWhite = true) {
 				expect(result).to.be.false;
 		});
 
-	cy.log('Check whether an image is full white or not - end.');
+	cy.log('<< isImageWhite - end');
 }
 
 function isCanvasWhite(expectWhite = true) {
-	cy.log('Check whether a canvas is full white or not - start.');
+	cy.log('>> isCanvasWhite - start');
+
 	cy.wait(300);
 	cy.cGet('#document-canvas').should('exist').then(function(canvas) {
 		var result = true;
@@ -760,6 +794,8 @@ function isCanvasWhite(expectWhite = true) {
 		else
 			expect(result).to.be.false;
 	});
+
+	cy.log('<< isCanvasWhite - end');
 }
 
 // Waits until a DOM element becomes idle (does not change for a given time).
@@ -857,7 +893,7 @@ function doIfOnDesktop(callback) {
 function moveCursor(direction, modifier,
 	checkCursorVis = true,
 	cursorSelector = '.cursor-overlay .blinking-cursor') {
-	cy.log('Moving text cursor - start.');
+	cy.log('>> moveCursor - start');
 	cy.log('Param - direction: ' + direction);
 	cy.log('Param - modifier: ' + modifier);
 	cy.log('Param - checkCursorVis: ' + checkCursorVis);
@@ -926,16 +962,16 @@ function moveCursor(direction, modifier,
 		cy.cGet(cursorSelector).should('be.visible');
 	}
 
-	cy.log('Moving text cursor - end.');
+	cy.log('<< moveCursor - end');
 }
 
 // Type something into the document. It can be some text or special characters too.
 function typeIntoDocument(text) {
-	cy.log('Typing into document - start.');
+	cy.log('>> typeIntoDocument - start');
 
 	cy.cGet('div.clipboard').type(text, {force: true});
 
-	cy.log('Typing into document - end.');
+	cy.log('<< typeIntoDocument - end');
 }
 
 // Get cursor's current position.
@@ -944,6 +980,8 @@ function typeIntoDocument(text) {
 // aliasName - we create an alias with the queried position.
 // cursorSelector - selector to find the correct cursor element in the DOM.
 function getCursorPos(offsetProperty, aliasName, cursorSelector = '.cursor-overlay .blinking-cursor') {
+	cy.log('>> getCursorPos - start');
+
 	initAliasToNegative(aliasName);
 
 	cy.cGet(cursorSelector)
@@ -958,11 +996,13 @@ function getCursorPos(offsetProperty, aliasName, cursorSelector = '.cursor-overl
 
 	cy.get('@' + aliasName)
 		.should('be.greaterThan', 0);
+
+	cy.log('<< getCursorPos - end');
 }
 
 // We make sure we have a text selection..
 function textSelectionShouldExist() {
-	cy.log('Make sure text selection exists - start.');
+	cy.log('>> textSelectionShouldExist - start');
 
 	cy.cGet('.leaflet-selection-marker-start').should('exist');
 	cy.cGet('.leaflet-selection-marker-end').should('exist');
@@ -970,17 +1010,17 @@ function textSelectionShouldExist() {
 	// One of the marker should be visible at least (if not both).
 	cy.cGet('.leaflet-selection-marker-start, .leaflet-selection-marker-end').should('be.visible');
 
-	cy.log('Make sure text selection exists - end.');
+	cy.log('<< textSelectionShouldExist - end');
 }
 
 // We make sure we don't have a text selection..
 function textSelectionShouldNotExist() {
-	cy.log('Make sure there is no text selection - start.');
+	cy.log('>> textSelectionShouldNotExist - start');
 
 	cy.cGet('.leaflet-selection-marker-start').should('not.exist');
 	cy.cGet('.leaflet-selection-marker-end').should('not.exist');
 
-	cy.log('Make sure there is no text selection - end.');
+	cy.log('<< textSelectionShouldNotExist - end');
 }
 
 // Used to represent the bounds of overlays like cell-cursor, document selections etc.
@@ -1047,11 +1087,15 @@ class Bounds {
 // bounds - A Bounds object in which this function stores the bounds of the overlay item.
 //          The bounds unit is core pixels in document coordinates.
 function getItemBounds(itemDivId, bounds) {
+	cy.log('>> getItemBounds - start');
+
 	cy.cGet(itemDivId)
 		.should(function (itemDiv) {
 			bounds.parseSetJson(itemDiv.text());
 			expect(bounds.isValid()).to.be.true;
 		});
+
+	cy.log('<< getItemBounds - end');
 }
 
 var getOverlayItemBounds = getItemBounds;
@@ -1062,11 +1106,15 @@ var getOverlayItemBounds = getItemBounds;
 // bounds - A Bounds object with the expected bounds data.
 //          The bounds unit should be core pixels in document coordinates.
 function overlayItemHasBounds(itemDivId, expectedBounds) {
+	cy.log('>> overlayItemHasBounds - start');
+
 	cy.cGet(itemDivId)
 		.should(function (elem) {
 			expect(Bounds.parseBoundsJson(elem.text()))
 				.to.deep.equal(expectedBounds, 'Bounds of ' + itemDivId);
 		});
+
+	cy.log('<< overlayItemHasBounds - end');
 }
 
 // This ensures that the overlay item has different bounds from the given one
@@ -1075,11 +1123,15 @@ function overlayItemHasBounds(itemDivId, expectedBounds) {
 // itemDivId - The id of the test div element corresponding to the overlay item.
 // bounds - A Bounds object with the bounds data to compare.
 function overlayItemHasDifferentBoundsThan(itemDivId, bounds) {
+	cy.log('>> overlayItemHasDifferentBoundsThan - start');
 	cy.log(bounds.toString());
+
 	cy.cGet(itemDivId)
 		.should(function (elem) {
 			expect(elem.text()).to.not.equal(bounds.toString());
 		});
+
+	cy.log('<< overlayItemHasDifferentBoundsThan - end');
 }
 
 // Type some text into an input DOM item.
@@ -1089,7 +1141,7 @@ function overlayItemHasDifferentBoundsThan(itemDivId, bounds) {
 // clearBefore - whether clear the existing content or not.
 function typeIntoInputField(selector, text, clearBefore = true)
 {
-	cy.log('Typing into input field - start.');
+	cy.log('>> typeIntoInputField - start');
 
 	cy.cGet(selector).as('input');
 	if (clearBefore) {
@@ -1099,7 +1151,7 @@ function typeIntoInputField(selector, text, clearBefore = true)
 	cy.get('@input').type(text + '{enter}');
 	cy.get('@input').should('have.value', text);
 
-	cy.log('Typing into input field - end.');
+	cy.log('<< typeIntoInputField - end');
 }
 
 function getVisibleBounds(domRect) {
@@ -1111,12 +1163,18 @@ function getVisibleBounds(domRect) {
 }
 
 function assertFocus(selectorType, selector) {
+	cy.log('>> assertFocus - start');
+
 	cy.cGet().its('activeElement.'+selectorType).should('be.eq', selector);
+
+	cy.log('<< assertFocus - end');
 }
 
 // Create an alias to a point whose coordinate are the middle point of the blinking cursor
 // It should be used with clickAt (see function below)
 function getBlinkingCursorPosition(aliasName) {
+	cy.log('>> getBlinkingCursorPosition - start');
+
 	var cursorSelector = '.cursor-overlay .blinking-cursor';
 	cy.cGet(cursorSelector).then(function(cursor) {
 		var boundRect = cursor[0].getBoundingClientRect();
@@ -1129,12 +1187,16 @@ function getBlinkingCursorPosition(aliasName) {
 		expect(point.x).to.be.greaterThan(0);
 		expect(point.y).to.be.greaterThan(0);
 	});
+
+	cy.log('<< getBlinkingCursorPosition - end');
 }
 
 // Simulate a click at the point referenced by the passed alias.
 // If the 'double' parameter is true, a double click is simulated.
 // To be used in pair with getBlinkingCursorPosition (see function above)
 function clickAt(aliasName, double = false) {
+	cy.log('>> clickAt - start');
+
 	cy.get('@' + aliasName).then(point => {
 		expect(point.x).to.be.greaterThan(0);
 		expect(point.y).to.be.greaterThan(0);
@@ -1144,6 +1206,8 @@ function clickAt(aliasName, double = false) {
 			cy.cGet('body').click(point.x, point.y);
 		}
 	});
+
+	cy.log('<< clickAt - end');
 }
 
 module.exports.loadTestDoc = loadTestDoc;

--- a/cypress_test/integration_tests/common/impress_helper.js
+++ b/cypress_test/integration_tests/common/impress_helper.js
@@ -4,27 +4,33 @@ var helper = require('./helper');
 
 // Assert that Impress is *not* in Text Edit Mode.
 function assertNotInTextEditMode() {
-	cy.log('Verifying NO Text-Edit context.');
+	cy.log('>> assertNotInTextEditMode - start');
+
 	// In edit mode, we should have the blinking cursor.
 	cy.cGet('.leaflet-cursor.blinking-cursor').should('not.exist');
 	cy.cGet('.leaflet-cursor-container').should('not.exist');
 	helper.assertNoKeyboardInput();
-	cy.log('NO Text-Edit context verified.');
+
+	cy.log('<< assertNotInTextEditMode - end');
 }
 
 // Assert that Impress is in Text Edit Mode.
 function assertInTextEditMode() {
-	cy.log('Verifying Impress in Text-Edit context.');
+	cy.log('>> assertInTextEditMode - start');
+
 	// In edit mode, we should have the edit container.
 	cy.cGet('#doc-clipboard-container').should('exist');
 	cy.cGet('.leaflet-interactive').should('exist');
 	cy.cGet('.leaflet-pane.leaflet-overlay-pane svg g').should('exist');
 	helper.assertCursorAndFocus();
-	cy.log('Impress Text-Edit context verified.');
+
+	cy.log('<< assertInTextEditMode - end');
 }
 
 // Enter some text and confirm we get it back.
 function typeTextAndVerify(text, expected) {
+	cy.log('>> typeTextAndVerify - start');
+
 	if (!expected)
 		expected = text;
 
@@ -39,6 +45,8 @@ function typeTextAndVerify(text, expected) {
 	helper.selectAllText();
 
 	helper.expectTextForClipboard(expected);
+
+	cy.log('<< typeTextAndVerify - end');
 }
 
 // Make sure we have the right number of slides in the document.
@@ -46,15 +54,19 @@ function typeTextAndVerify(text, expected) {
 // Parameters:
 // slides - number of expected slides
 function assertNumberOfSlidePreviews(slides) {
+	cy.log('>> assertNumberOfSlidePreviews - start');
+
 	cy.cGet('#slide-sorter .preview-frame')
 		.should('have.length', slides + 1);
+
+	cy.log('<< assertNumberOfSlidePreviews - end');
 }
 
 // Select a text shape at the center of the slide / view.
 // This method triggers mouse click in the center to achive
 // a shape selection. It fails, if there is no shape there.
 function selectTextShapeInTheCenter() {
-	cy.log('Selecting text shape - start.');
+	cy.log('>> selectTextShapeInTheCenter - start');
 
 	// Click on the center of the slide to select the text shape there
 	cy.cGet('#document-container')
@@ -67,11 +79,12 @@ function selectTextShapeInTheCenter() {
 
 	cy.cGet('.leaflet-drag-transform-marker').should($el => { expect(Cypress.dom.isDetached($el)).to.eq(false); }).should('be.visible');
 	cy.cGet('.leaflet-pane.leaflet-overlay-pane svg g.Page g').should('exist');
-	cy.log('Selecting text shape - end.');
+
+	cy.log('<< selectTextShapeInTheCenter - end');
 }
 
 function selectTableInTheCenter() {
-	cy.log('Selecting table - start.');
+	cy.log('>> selectTableInTheCenter - start');
 
 	// Click on the center of the slide to select the text shape there
 	// Retry until it works
@@ -93,12 +106,12 @@ function selectTableInTheCenter() {
 	cy.cGet('.leaflet-marker-icon.table-row-resize-marker').should($el => { expect(Cypress.dom.isDetached($el)).to.eq(false); }).should('be.visible');
 	cy.cGet('.leaflet-pane.leaflet-overlay-pane svg g.Page g').should('exist');
 
-	cy.log('Selecting table - end.');
+	cy.log('<< selectTableInTheCenter - end');
 }
 
 // Remove existing shape selection by clicking outside of the shape.
 function removeShapeSelection() {
-	cy.log('Removing shape selection - start.');
+	cy.log('>> removeShapeSelection - start');
 
 	// Remove selection with clicking on the top-left corner of the slide
 	cy.waitUntil(function() {
@@ -117,7 +130,7 @@ function removeShapeSelection() {
 
 	cy.cGet('.leaflet-drag-transform-marker').should('not.exist');
 
-	cy.log('Removing shape selection - end.');
+	cy.log('<< removeShapeSelection - end');
 }
 
 
@@ -126,7 +139,7 @@ function removeShapeSelection() {
 // this method to trigger the update of the SVG representation
 // so we can be sure that it's in an updated state.
 function triggerNewSVGForShapeInTheCenter() {
-	cy.log('Triggering new SVG for shape - start.');
+	cy.log('>> triggerNewSVGForShapeInTheCenter - start');
 
 	removeShapeSelection();
 
@@ -137,7 +150,7 @@ function triggerNewSVGForShapeInTheCenter() {
 	// Select text shape again which will retrigger a new SVG from core
 	selectTextShapeInTheCenter();
 
-	cy.log('Triggering new SVG for shape - end.');
+	cy.log('<< triggerNewSVGForShapeInTheCenter - end');
 }
 
 // Select the text inside a preselected shape. So we assume
@@ -145,7 +158,7 @@ function triggerNewSVGForShapeInTheCenter() {
 // text of this shape by double clicking into it, until the
 // cursor becomes visible.
 function selectTextOfShape(selectAllText = true) {
-	cy.log('Selecting text of shape - start.');
+	cy.log('>> selectTextOfShape - start');
 
 	// Double click onto the selected shape
 	// Retry until the cursor appears
@@ -162,13 +175,15 @@ function selectTextOfShape(selectAllText = true) {
 	if (selectAllText)
 		helper.selectAllText();
 
-	cy.log('Selecting text of shape - end.');
+	cy.log('<< selectTextOfShape - end');
 }
 
 // Step into text editing of the preselected shape. So we assume
 // we have already a shape selected. We try to make the document
 // to switch text editing mode by double clicking into the shape.
 function dblclickOnSelectedShape() {
+	cy.log('>> dblclickOnSelectedShape - start');
+
 	cy.cGet('.transform-handler--rotate')
 		.then(function(items) {
 			expect(items).to.have.length(1);
@@ -180,10 +195,14 @@ function dblclickOnSelectedShape() {
 
 	cy.cGet('.leaflet-cursor.blinking-cursor')
 		.should('exist');
+
+	cy.log('<< dblclickOnSelectedShape - end');
 }
 
 //add multiple slides
 function addSlide(numberOfSlides) {
+	cy.log('>> addSlide - start');
+
 	cy.cGet('.preview-frame').then(function (result) {
 		var origSlides = result.length;
 		for (let i = 0; i < numberOfSlides; i++) {
@@ -194,10 +213,14 @@ function addSlide(numberOfSlides) {
 		cy.cGet('.preview-frame')
 			.should('have.length',origSlides+numberOfSlides);
 	});
+
+	cy.log('<< addSlide - end');
 }
 
 //change multiple slides
 function changeSlide(changeNum,direction) {
+	cy.log('>> changeSlide - start');
+
 	var slideButton;
 	if (direction === 'next') {
 		slideButton = cy.cGet('#tb_actionbar_item_next');
@@ -209,6 +232,8 @@ function changeSlide(changeNum,direction) {
 			slideButton.click();
 		}
 	}
+
+	cy.log('<< changeSlide - end');
 }
 
 module.exports.assertNotInTextEditMode = assertNotInTextEditMode;

--- a/cypress_test/integration_tests/common/mobile_helper.js
+++ b/cypress_test/integration_tests/common/mobile_helper.js
@@ -4,7 +4,7 @@ var helper = require('./helper');
 
 // Enable editing if we are in read-only mode.
 function enableEditingMobile() {
-	cy.log('Enabling editing mode - start.');
+	cy.log('>> enableEditingMobile - start');
 
 	cy.cGet('#mobile-edit-button').click();
 
@@ -30,11 +30,11 @@ function enableEditingMobile() {
 			.should('be.visible');
 	});
 
-	cy.log('Enabling editing mode - end.');
+	cy.log('<< enableEditingMobile - end');
 }
 
 function longPressOnDocument(posX, posY) {
-	cy.log('Emulating a long press - start.');
+	cy.log('>> longPressOnDocument - start');
 	cy.log('Param - posX: ' + posX);
 	cy.log('Param - posY: ' + posY);
 
@@ -62,11 +62,11 @@ function longPressOnDocument(posX, posY) {
 				.trigger('pointerup', eventOptions);
 		});
 
-	cy.log('Emulating a long press - end.');
+	cy.log('<< longPressOnDocument - end');
 }
 
 function openHamburgerMenu() {
-	cy.log('Opening hamburger menu - start.');
+	cy.log('>> openHamburgerMenu - start');
 
 	cy.cGet('#toolbar-hamburger')
 		.should('not.have.class', 'menuwizard-opened');
@@ -80,11 +80,11 @@ function openHamburgerMenu() {
 	cy.cGet('#mobile-wizard-content-menubar')
 		.should('not.be.empty');
 
-	cy.log('Opening hamburger menu - end.');
+	cy.log('<< openHamburgerMenu - end');
 }
 
 function closeHamburgerMenu() {
-	cy.log('Closing hamburger menu - start.');
+	cy.log('>> closeHamburgerMenu - start');
 
 	cy.cGet('#toolbar-hamburger')
 		.should('have.class', 'menuwizard-opened');
@@ -98,11 +98,11 @@ function closeHamburgerMenu() {
 	cy.cGet('#mobile-wizard-content-menubar')
 		.should('not.exist');
 
-	cy.log('Closing hamburger menu - end.');
+	cy.log('<< closeHamburgerMenu - end');
 }
 
 function openMobileWizard() {
-	cy.log('Opening mobile wizard - start.');
+	cy.log('>> openMobileWizard - start');
 
 	helper.waitUntilIdle('#tb_actionbar_item_mobile_wizard');
 	// Open mobile wizard
@@ -116,11 +116,11 @@ function openMobileWizard() {
 	cy.cGet('#tb_actionbar_item_mobile_wizard table')
 		.should('have.class', 'checked');
 
-	cy.log('Opening mobile wizard - end.');
+	cy.log('<< openMobileWizard - end');
 }
 
 function closeMobileWizard() {
-	cy.log('Closing mobile wizard - start.');
+	cy.log('>> closeMobileWizard - start');
 
 	cy.cGet('#tb_actionbar_item_mobile_wizard table')
 		.should('have.class', 'checked');
@@ -133,11 +133,11 @@ function closeMobileWizard() {
 	cy.cGet('#tb_actionbar_item_mobile_wizard table')
 		.should('not.have.class', 'checked');
 
-	cy.log('Closing mobile wizard - end.');
+	cy.log('<< closeMobileWizard - end');
 }
 
 function executeCopyFromContextMenu(XPos, YPos) {
-	cy.log('Executing copy from context menu - start.');
+	cy.log('>> executeCopyFromContextMenu - start');
 	cy.log('Param - XPos: ' + XPos);
 	cy.log('Param - YPos: ' + YPos);
 
@@ -155,11 +155,11 @@ function executeCopyFromContextMenu(XPos, YPos) {
 	cy.cGet('.vex-overlay')
 		.should('not.exist');
 
-	cy.log('Executing copy from context menu - end.');
+	cy.log('<< executeCopyFromContextMenu - end');
 }
 
 function openInsertionWizard() {
-	cy.log('Opening insertion wizard - start.');
+	cy.log('>> openInsertionWizard - start');
 
 	cy.cGet('#tb_actionbar_item_insertion_mobile_wizard')
 		.should('not.have.class', 'disabled')
@@ -171,11 +171,11 @@ function openInsertionWizard() {
 	cy.cGet('#tb_actionbar_item_insertion_mobile_wizard table')
 		.should('have.class', 'checked');
 
-	cy.log('Opening insertion wizard - end.');
+	cy.log('<< openInsertionWizard - end');
 }
 
 function openCommentWizard() {
-	cy.log('Opening Comment wizard - start.');
+	cy.log('>> openCommentWizard - start');
 
 	cy.cGet('#tb_actionbar_item_comment_wizard')
 		.should('not.have.class', 'disabled')
@@ -184,11 +184,11 @@ function openCommentWizard() {
 	cy.cGet('#tb_actionbar_item_comment_wizard table')
 		.should('have.class', 'checked');
 
-	cy.log('Opening Comment wizard - end.');
+	cy.log('<< openCommentWizard - end');
 }
 
 function closeInsertionWizard() {
-	cy.log('Closing insertion wizard - start.');
+	cy.log('>> closeInsertionWizard - start');
 
 	cy.cGet('#tb_actionbar_item_insertion_mobile_wizard table')
 		.should('have.class', 'checked');
@@ -202,22 +202,24 @@ function closeInsertionWizard() {
 	cy.cGet('#tb_actionbar_item_insertion_mobile_wizard table')
 		.should('not.have.class', 'checked');
 
-	cy.log('Closing insertion wizard - end.');
+	cy.log('<< closeInsertionWizard - end');
 }
 
 /// deprecated: see selectFromColorPicker function instead
 function selectFromColorPalette(paletteNum, groupNum, paletteAfterChangeNum, colorNum) {
-	cy.log('Selecting a color from the color palette - start.');
+	cy.log('>> selectFromColorPalette - start');
+
 	cy.cGet('#color-picker-' + paletteNum.toString() + '-basic-color-' + groupNum.toString()).click();
 	if (paletteAfterChangeNum !== undefined && colorNum !== undefined) {
 		cy.cGet('#color-picker-' + paletteAfterChangeNum.toString() + '-tint-' + colorNum.toString()).click();
 	}
 	cy.cGet('#mobile-wizard-back').click();
-	cy.log('Selecting a color from the color palette - end.');
+
+	cy.log('<< selectFromColorPalette - end');
 }
 
 function selectFromColorPicker(pickerId, groupNum, colorNum) {
-	cy.log('Selecting a color from the color palette - start.');
+	cy.log('>> selectFromColorPicker - start');
 
 	cy.cGet(pickerId + ' [id^=color-picker-][id$=-basic-color-' + groupNum.toString() + ']')
 		.click();
@@ -230,19 +232,23 @@ function selectFromColorPicker(pickerId, groupNum, colorNum) {
 	cy.cGet('#mobile-wizard-back')
 		.click();
 
-	cy.log('Selecting a color from the color palette - end.');
+	cy.log('<< selectFromColorPicker - end');
 }
 
 function openTextPropertiesPanel() {
+	cy.log('>> openTextPropertiesPanel - start');
+
 	openMobileWizard();
 
 	helper.clickOnIdle('#TextPropertyPanel');
 
 	cy.cGet('#Bold').should('be.visible');
+
+	cy.log('<< openTextPropertiesPanel - end');
 }
 
 function selectHamburgerMenuItem(menuItems) {
-	cy.log('Selecting hamburger menu item - start.');
+	cy.log('>> selectHamburgerMenuItem - start');
 	cy.log('Param - menuItems: ' + menuItems);
 
 	openHamburgerMenu();
@@ -258,11 +264,12 @@ function selectHamburgerMenuItem(menuItems) {
 			}
 		}
 	}
-	cy.log('Selecting hamburger menu item - end.');
+
+	cy.log('<< selectHamburgerMenuItem - end');
 }
 
 function selectAnnotationMenuItem(menuItem) {
-	cy.log('Selecting annotation menu item - start.');
+	cy.log('>> selectAnnotationMenuItem - start');
 
 	cy.cGet('#mobile-wizard .wizard-comment-box .cool-annotation-menu')
 		.click({force: true});
@@ -273,11 +280,11 @@ function selectAnnotationMenuItem(menuItem) {
 	cy.cGet('body').contains('.context-menu-item', menuItem)
 		.click();
 
-	cy.log('Selecting annotation menu item - end.');
+	cy.log('<< selectAnnotationMenuItem - end');
 }
 
 function selectListBoxItem(listboxSelector, item) {
-	cy.log('Selecting an item from listbox - start.');
+	cy.log('>> selectListBoxItem - start');
 
 	helper.clickOnIdle(listboxSelector);
 
@@ -287,11 +294,11 @@ function selectListBoxItem(listboxSelector, item) {
 	cy.cGet(listboxSelector + ' .ui-header-right .entry-value')
 		.should('have.text', item);
 
-	cy.log('Selecting an item from listbox - end.');
+	cy.log('<< selectListBoxItem - end');
 }
 
 function selectListBoxItem2(listboxSelector, item) {
-	cy.log('Selecting an item from listbox 2 - start.');
+	cy.log('>> selectListBoxItem2 - start');
 
 	helper.clickOnIdle(listboxSelector);
 
@@ -305,9 +312,11 @@ function selectListBoxItem2(listboxSelector, item) {
 	cy.cGet(listboxSelector + ' .ui-header-left')
 		.should('have.text', item);
 
-	cy.log('Selecting an item from listbox 2 - end.');
+	cy.log('<< selectListBoxItem2 - end');
 }
 function insertComment() {
+	cy.log('>> insertComment - start');
+
 	openInsertionWizard();
 	cy.cGet('body').contains('.menu-entry-with-icon', 'Comment').click();
 	cy.cGet('.cool-annotation-table').should('exist');
@@ -315,9 +324,13 @@ function insertComment() {
 	cy.cGet('#response-ok').click();
 	cy.cGet('#comment-container-1').should('exist').wait(300);
 	cy.cGet('#annotation-content-area-1').should('have.text', 'some text');
+
+	cy.log('<< insertComment - end');
 }
 
 function insertImage() {
+	cy.log('>> insertImage - start');
+
 	openInsertionWizard();
 
 	// We can't use the menu item directly, because it would open file picker.
@@ -329,9 +342,13 @@ function insertImage() {
 
 	cy.cGet('.leaflet-pane.leaflet-overlay-pane svg g')
 		.should('exist');
+
+	cy.log('<< insertImage - end');
 }
 
 function deleteImage() {
+	cy.log('>> deleteImage - start');
+
 	insertImage();
 	var eventOptions = {
 		force: true,
@@ -349,10 +366,16 @@ function deleteImage() {
 
 	cy.cGet('.leaflet-pane.leaflet-overlay-pane svg g')
 		.should('not.exist');
+
+	cy.log('<< deleteImage - end');
 }
 
 function pressPushButtonOfDialog(name) {
+	cy.log('>> pressPushButtonOfDialog - start');
+
 	cy.cGet('body').contains('.ui-pushbutton', name).click();
+
+	cy.log('<< pressPushButtonOfDialog - end');
 }
 
 module.exports.enableEditingMobile = enableEditingMobile;

--- a/cypress_test/integration_tests/common/nextcloud_helper.js
+++ b/cypress_test/integration_tests/common/nextcloud_helper.js
@@ -8,6 +8,8 @@ var mobileHelper = require('./mobile_helper');
 // We check whether the NC sidebar is opened and then we
 // close it.
 function checkAndCloseSharing() {
+	cy.log('>> checkAndCloseSharing - start');
+
 	mobileHelper.selectHamburgerMenuItem(['File']);
 
 	cy.contains('.menu-entry-with-icon', 'Share...')
@@ -30,6 +32,8 @@ function checkAndCloseSharing() {
 			cy.wrap(item)
 				.click();
 		});
+
+	cy.log('<< checkAndCloseSharing - end');
 }
 
 // Insert an image from NC storage. We use the "Insert"
@@ -39,6 +43,8 @@ function checkAndCloseSharing() {
 // Parameters:
 // fileName - name of the image file.
 function insertImageFromStorage(fileName) {
+	cy.log('>> insertImageFromStorage - start');
+
 	mobileHelper.openInsertionWizard();
 
 	cy.get('.insertgraphicremote')
@@ -60,6 +66,8 @@ function insertImageFromStorage(fileName) {
 			cy.wrap(item)
 				.click();
 		});
+
+	cy.log('<< insertImageFromStorage - end');
 }
 
 // Save an existing and opened document with a different
@@ -69,6 +77,8 @@ function insertImageFromStorage(fileName) {
 // Parameters:
 // fileName - the new filename we would like to save as.
 function saveFileAs(fileName) {
+	cy.log('>> saveFileAs - start');
+
 	mobileHelper.enableEditingMobile();
 
 	mobileHelper.selectHamburgerMenuItem(['File']);
@@ -93,6 +103,8 @@ function saveFileAs(fileName) {
 			cy.wrap(item)
 				.click();
 		});
+
+	cy.log('<< saveFileAs - end');
 }
 
 module.exports.checkAndCloseSharing = checkAndCloseSharing;

--- a/cypress_test/integration_tests/common/repair_document_helper.js
+++ b/cypress_test/integration_tests/common/repair_document_helper.js
@@ -10,10 +10,14 @@ var mobileHelper = require('./mobile_helper');
  * @returns {void}
  */
 function openRepairDialog(mobile = false) {
+	cy.log('>> openRepairDialog - start');
+
 	if (mobile) {
 		return mobileHelper.selectHamburgerMenuItem(['Edit', 'Repair']);
 	}
 	cy.cGet('#menu-editmenu').click().cGet('#menu-repair').click();
+
+	cy.log('<< openRepairDialog - end');
 }
 
 /**
@@ -24,6 +28,8 @@ function openRepairDialog(mobile = false) {
  * @returns {void}
  */
 function rollbackPastChange(selector, mobile = false) {
+	cy.log('>> rollbackPastChange - start');
+
 	openRepairDialog(mobile);
 
 	cy.cGet('#DocumentRepairDialog').should('exist');
@@ -39,6 +45,8 @@ function rollbackPastChange(selector, mobile = false) {
 	} else {
 		cy.cGet('#ok.ui-pushbutton.jsdialog').click();
 	}
+
+	cy.log('<< rollbackPastChange - end');
 }
 
 module.exports = {

--- a/cypress_test/integration_tests/common/search_helper.js
+++ b/cypress_test/integration_tests/common/search_helper.js
@@ -4,12 +4,16 @@
 
 // Make the searchbar visible on the bottom toolbar.
 function showSearchBar() {
+	cy.log('>> showSearchBar - start');
+
 	cy.cGet('#tb_editbar_item_showsearchbar').click();
 	cy.cGet('input#search-input').should('be.visible');
 	cy.cGet('#tb_editbar_item_bold').should('not.be.visible');
 	cy.cGet('#tb_searchbar_item_searchprev').should('have.class', 'disabled');
 	cy.cGet('#tb_searchbar_item_searchnext').should('have.class', 'disabled');
 	cy.cGet('#tb_searchbar_item_cancelsearch').should('not.be.visible');
+
+	cy.log('<< showSearchBar - end');
 }
 
 // Type some text into the search field, which will
@@ -17,62 +21,98 @@ function showSearchBar() {
 // Parameters:
 // text - the text to type in
 function tpyeIntoSearchField(text) {
+	cy.log('>> tpyeIntoSearchField - start');
+
 	cy.cGet('input#search-input').clear().type(text);
 	cy.cGet('input#search-input').should('have.prop', 'value', text);
 	cy.cGet('#tb_searchbar_item_searchprev').should('not.have.class', 'disabled');
 	cy.cGet('#tb_searchbar_item_searchnext').should('not.have.class', 'disabled');
 	cy.cGet('#tb_searchbar_item_cancelsearch').should('be.visible');
+
+	cy.log('<< tpyeIntoSearchField - end');
 }
 
 function typeIntoSearchFieldDesktop(text) {
+	cy.log('>> typeIntoSearchFieldDesktop - start');
+
 	cy.cGet('input#search-input').clear().type(text);
 	cy.cGet('input#search-input').should('have.prop', 'value', text);
 	cy.cGet('#tb_actionbar_item_searchprev').should('not.have.class', 'disabled');
 	cy.cGet('#tb_actionbar_item_searchnext').should('not.have.class', 'disabled');
 	cy.cGet('#tb_actionbar_item_cancelsearch').should('be.visible');
+
+	cy.log('<< typeIntoSearchFieldDesktop - end');
 }
 
 // Move to the next search result in the document.
 function searchNext() {
+	cy.log('>> searchNext - start');
+
 	cy.cGet('#tb_searchbar_item_searchnext').click();
+
+	cy.log('<< searchNext - end');
 }
 
 function searchNextDesktop() {
+	cy.log('>> searchNextDesktop - start');
+
 	cy.cGet('#tb_actionbar_item_searchnext').click();
+
+	cy.log('<< searchNextDesktop - end');
 }
 
 // Move to the previous search result in the document.
 function searchPrev() {
+	cy.log('>> searchPrev - start');
+
 	cy.cGet('#tb_searchbar_item_searchnext').click();
+
+	cy.log('<< searchPrev - end');
 }
 
 function searchPrevDesktop() {
+	cy.log('>> searchPrevDesktop - start');
+
 	cy.cGet('#tb_actionbar_item_searchprev').click();
+
+	cy.log('<< searchPrevDesktop - end');
 }
 
 // Cancel search with the specified text.
 // This will remove the search string from the input field.
 function cancelSearch() {
+	cy.log('>> cancelSearch - start');
+
 	cy.cGet('#tb_searchbar_item_cancelsearch').click();
 	cy.cGet('input#search-input').should('have.prop', 'value', '');
 	cy.cGet('#tb_searchbar_item_searchprev').should('have.class', 'disabled');
 	cy.cGet('#tb_searchbar_item_searchnext').should('have.class', 'disabled');
 	cy.cGet('#tb_searchbar_item_cancelsearch').should('not.be.visible');
+
+	cy.log('<< cancelSearch - end');
 }
 
 function cancelSearchDesktop() {
+	cy.log('>> cancelSearchDesktop - start');
+
 	cy.cGet('#tb_actionbar_item_cancelsearch').click();
 	cy.cGet('input#search-input').should('have.prop', 'value', '');
 	cy.cGet('#tb_actionbar_item_searchprev').should('have.class', 'disabled');
 	cy.cGet('#tb_actionbar_item_searchnext').should('have.class', 'disabled');
 	cy.cGet('#tb_actionbar_item_cancelsearch').should('not.be.visible');
+
+	cy.log('<< cancelSearchDesktop - end');
 }
 
 // Hide the searchbar from the bottom toolbar.
 function closeSearchBar() {
+	cy.log('>> closeSearchBar - start');
+
 	cy.cGet('#tb_searchbar_item_hidesearchbar').click();
 	cy.cGet('input#search-input').should('not.be.visible');
 	cy.cGet('#tb_editbar_item_bold').should('be.visible');
+
+	cy.log('<< closeSearchBar - end');
 }
 
 module.exports.showSearchBar = showSearchBar;

--- a/cypress_test/integration_tests/common/writer_helper.js
+++ b/cypress_test/integration_tests/common/writer_helper.js
@@ -10,7 +10,7 @@ var helper = require('./helper');
 // on this content, so we don't need to worry about testing an
 // out-dated content.
 function selectAllTextOfDoc() {
-	cy.log('Select all text of Writer document - start.');
+	cy.log('>> selectAllTextOfDoc - start');
 
 	// Remove selection if exist
 	cy.cGet('.leaflet-marker-pane')
@@ -24,16 +24,20 @@ function selectAllTextOfDoc() {
 
 	helper.selectAllText();
 
-	cy.log('Select all text of Writer document - end.');
+	cy.log('<< selectAllTextOfDoc - end');
 }
 
 function openFileProperties() {
+	cy.log('>> openFileProperties - start');
+
 	cy.cGet('#File-tab-label').then(function(element) {
 		if (!element.hasClass('selected'))
 			element.click();
 
 		cy.cGet('#File-container .unoSetDocumentProperties').click();
 	});
+
+	cy.log('<< openFileProperties - end');
 }
 
 module.exports.selectAllTextOfDoc = selectAllTextOfDoc;


### PR DESCRIPTION
Cypress makes it really hard to compare logs to code or to get a backtrace of a failure. This change will make it easier to see when cypress is in a helper function.

There was some of this already, but it was not consistent and it was hard to see in the logs. By using ">>" and "<<" I hope it will be easier to see. And by applying it on nearly every helper function I hope it will be more likely to show the exact point of failure.

Example: It is immediately obvious that the failure is in selectTextOfShape:
```
    4) Change bulleting level of selected text.
          cy:log ✱  Starting test: integration_tests/mobile/impress/apply_paragraph_props_text_spec.js / Apply paragraph properties on selected text. / Change bulleting level of selected text.
      cy:command ✔  cSetActiveFrame	#coolframe
          cy:log ✱  >> loadTestDoc - start
          cy:log ✱  Param - fileName: apply_paragraph_props_text.odp
          cy:log ✱  Param - subFolder: impress
      cy:command ✔  viewport	iphone-6
          cy:log ✱  >> loadTestDocNoIntegration - start
          cy:log ✱  Param - fileName: apply_paragraph_props_text.odp -> Change-bulleting-level-of-selected-text.-1h5nj-apply_paragraph_props_text.odp
      cy:command ✔  task	copyFile, Object{4}
      cy:command ✔  visit	/browser/690bab18e/debug.html?lang=en-US&file_path=/home/neilguertin/build/online-24/cypress_test/workdir/data/mobile/impress/Change-bulleting-level-of-selected-text.-1h5nj-apply_paragraph_props_text.odp
          cy:log ✱  << loadTestDocNoIntegration - end
          cy:log ✱  >> checkIfDocIsLoaded - start
      cy:command ✔  cSetActiveFrame	#coolframe
      cy:command ✔  its	.body
      cy:command ✔  assert	expected **<body>** not to be undefined
          cy:log ✱  >> documentChecks - start
      cy:command ✔  find	#document-canvas
          cy:log ✱  << documentChecks - end
          cy:log ✱  << checkIfDocIsLoaded - end
          cy:log ✱  << loadTestDoc - end
          cy:log ✱  >> enableEditingMobile - start
      cy:command ✔  cGet	#mobile-edit-button
      cy:command ✔  click	
      cy:command ✔  cGet	#toolbar-mobile-back
      cy:command ✔  assert	expected **<td#toolbar-mobile-back.editmode-on>** to have class **editmode-on**
      cy:command ✔  cGet	#toolbar-mobile-back
      cy:command ✔  assert	expected **<td#toolbar-mobile-back.editmode-on>** not to have class **editmode-off**
          cy:log ✱  Enabling editing mode - now editable.
      cy:command ✔  cGet	#toolbar-down
      cy:command ✔  assert	expected **<div#toolbar-down.w2ui-reset.w2ui-toolbar>** to be **visible**
          cy:log ✱  Enabling editing mode - toolbar update done.
          cy:log ✱  << enableEditingMobile - end
          cy:log ✱  >> selectTextShapeInTheCenter - start
      cy:command ✔  cGet	#document-container
      cy:command ✔  assert	expected **<div#document-container.portrait.mobile.presentation-doctype.parts-preview-document>** to have a length of **1**
      cy:command ✔  cGet	body
      cy:command ✔  click	187.5, 303.5
      cy:command ✔  cGet	.leaflet-drag-transform-marker
      cy:command ✔  assert	expected **false** to equal **false**
      cy:command ✔  assert	expected **[ <path.leaflet-drag-transform-marker.drag-marker--0.leaflet-interactive>, 7 more... ]** to be **visible**
      cy:command ✔  cGet	.leaflet-pane.leaflet-overlay-pane svg g.Page g
      cy:command ✔  assert	expected **[ <g.Outline>, 1 more... ]** to exist in the DOM
          cy:log ✱  << selectTextShapeInTheCenter - end
      cy:command ✔  cGet	.leaflet-pane.leaflet-overlay-pane g.Page .BulletChars
      cy:command ✔  assert	expected **.leaflet-pane.leaflet-overlay-pane g.Page .BulletChars** not to exist in the DOM
          cy:log ✱  >> selectTextOfShape - start
      cy:command ✔  waitUntil	{interval: 100, verbose: true}
      cy:command ✔  cGet	svg g .leaflet-interactive
      cy:command ✔  dblclick	{force: true}
      cy:command ✔  cGet	.cursor-overlay
      cy:command ✔  waitUntil	false
      cy:command ✔  cGet	svg g .leaflet-interactive
      cy:command ✔  dblclick	{force: true}
      cy:command ✘  dblclick	{force: true}
      cy:command ✔  fail:	
                    Test failed: integration_tests/mobile/impress/apply_paragraph_props_text_spec.js / Apply paragraph properties on selected text. / Change bulleting level of selected text.
                    
                    Timed out retrying after 10100ms: `cy.dblclick()` failed because the page updated while this command was executing. Cypress tried to locate elements based on this query:
                    
                    > cy.get(#coolframe, [object Object]).its(0.contentDocument, [object Object]).find(svg g .leaflet-interactive, [object Object])
                    
                    We initially found matching element(s), but while waiting for them to become actionable, they disappeared from the page. Common situations why this happens:
                      - Your JS framework re-rendered asynchronously
                      - Your app code reacted to an event firing and removed the element
                    
                    You can typically solve this by breaking up a ...
          cy:log ✱  >> closeDocument - start
      cy:command ✔  visit	http://admin:admin@localhost:9900/browser/dist/admin/admin.html
      cy:command ✔  wait	5000
          cy:log ✱  Finishing test: integration_tests/mobile/impress/apply_paragraph_props_text_spec.js / Apply paragraph properties on selected text. / Change bulleting level of selected text.
```

Another example, showing the diff:
![image](https://github.com/CollaboraOnline/online/assets/153108452/88582b05-ea2b-479a-8997-8712afe578fc)






Change-Id: I61812b730fa58ee1c2969f4ded84b08f5eca981a


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

