### PR TITLE
Custom properties dialog: Fix height mismatch select and input field

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -744,6 +744,12 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	color: var(--color-text-dark);
 }
 
+.jsdialog-window .ui-listbox,
+.jsdialog-window .ui-combobox,
+.jsdialog-window .ui-timefield {
+	height: 32px;/* Use the same height as in .jsdialog.ui-edit */
+}
+
 .ui-listbox option {
 	font-weight: normal;
 	display: block;


### PR DESCRIPTION
Better to use the same height so to fix the misalignment

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: If3e76a695a943eee4861479e2ce7b6b1dd287d4f
