### PR TITLE
Private/mmeeks/socketcleanup

### DIFF
--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -126,7 +126,7 @@ protected:
         , _timeoutMilliSeconds(std::chrono::seconds(30))
         , _startTimeMilliSeconds(std::chrono::milliseconds::zero())
         , _type(type)
-        , _socketPoll(std::make_shared<SocketPoll>(name))
+        , _socketPoll(nullptr)
         , testname(name)
     {
     }
@@ -272,7 +272,7 @@ public:
     const std::string& getTestname() const { return testname; }
     void setTestname(const std::string& name) { testname = name; }
 
-    std::shared_ptr<SocketPoll> socketPoll() { return _socketPoll; }
+    std::shared_ptr<SocketPoll> socketPoll();
 
 private:
     /// Initialize the test.
@@ -522,7 +522,7 @@ public:
     // ---------------- Kit hooks ----------------
 
     /// Post fork hook - just before we init the child kit
-    virtual void postFork() {}
+    virtual void postFork();
 
     /// Kit got a message
     virtual bool filterKitMessage(WebSocketHandler *, std::string &/* message */ )

--- a/common/Util.cpp
+++ b/common/Util.cpp
@@ -175,19 +175,19 @@ namespace Util
     }
 
 #if !MOBILEAPP
-    ThreadCounter::ThreadCounter() :
-        _tasks(opendir("/proc/self/task"))
+    DirectoryCounter::DirectoryCounter(const char *procPath) :
+        _tasks(opendir(procPath))
     {
         if (!_tasks)
             LOG_ERR("No proc mounted, can't count threads");
     }
 
-    ThreadCounter::~ThreadCounter()
+    DirectoryCounter::~DirectoryCounter()
     {
         closedir(reinterpret_cast<DIR *>(_tasks));
     }
 
-    int ThreadCounter::count()
+    int DirectoryCounter::count()
     {
         auto dir = reinterpret_cast<DIR *>(_tasks);
 

--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -132,16 +132,28 @@ namespace Util
     };
 
 #if !MOBILEAPP
-    /// Needs to open dirent before forking in Kit process
-    class ThreadCounter
+    class DirectoryCounter
     {
         void *_tasks;
     public:
-        ThreadCounter();
-        ~ThreadCounter();
-
-        /// Get number of threads in this process or -1 on error
+        DirectoryCounter(const char *procPath);
+        ~DirectoryCounter();
+        /// Get number of items in this directory or -1 on error
         int count();
+    };
+
+    /// Needs to open dirent before forking in Kit process
+    class ThreadCounter : public DirectoryCounter
+    {
+    public:
+        ThreadCounter() : DirectoryCounter("/proc/self/task") {}
+    };
+
+    /// Needs to open dirent before forking in Kit process
+    class FDCounter : public DirectoryCounter
+    {
+    public:
+        FDCounter() : DirectoryCounter("/proc/self/fd") {}
     };
 
     /// Spawn a process.

--- a/kit/ForKit.cpp
+++ b/kit/ForKit.cpp
@@ -70,6 +70,9 @@ static std::map<pid_t, std::string> childJails;
 /// The jails that need cleaning up. This should be small.
 static std::vector<std::string> cleanupJailPaths;
 
+/// The Main polling main-loop of this (single threaded) process
+static std::unique_ptr<SocketPoll> ForKitPoll;
+
 extern "C" { void dump_forkit_state(void); /* easy for gdb */ }
 
 void dump_forkit_state()
@@ -428,6 +431,11 @@ static int createLibreOfficeKit(const std::string& childRoot,
             // Close the pipe from coolwsd
             close(0);
 
+            // Close the ForKit main-loop's sockets
+            if (ForKitPoll)
+                ForKitPoll->closeAllSockets();
+            // else very first kit process spawned
+
             UnitKit::get().postFork();
 
             sleepForDebugger();
@@ -773,13 +781,13 @@ int forkit_main(int argc, char** argv)
         Log::logger().setLevel(LogLevel);
     }
 
-    SocketPoll mainPoll(Util::getThreadName());
-    mainPoll.runOnClientThread(); // We will do the polling on this thread.
+    ForKitPoll.reset(new SocketPoll (Util::getThreadName()));
+    ForKitPoll->runOnClientThread(); // We will do the polling on this thread.
 
     WSHandler = std::make_shared<ServerWSHandler>("forkit_ws");
 
 #if !MOBILEAPP
-    if (!mainPoll.insertNewUnixSocket(MasterLocation, FORKIT_URI, WSHandler))
+    if (!ForKitPoll->insertNewUnixSocket(MasterLocation, FORKIT_URI, WSHandler))
     {
         LOG_SFL("Failed to connect to WSD. Will exit.");
         Util::forcedExit(EX_SOFTWARE);
@@ -795,7 +803,7 @@ int forkit_main(int argc, char** argv)
     {
         UnitKit::get().invokeForKitTest();
 
-        mainPoll.poll(std::chrono::microseconds(POLL_TIMEOUT_MICRO_S));
+        ForKitPoll->poll(std::chrono::microseconds(POLL_TIMEOUT_MICRO_S));
 
         SigUtil::checkDumpGlobalState(dump_forkit_state);
 

--- a/kit/ForKit.cpp
+++ b/kit/ForKit.cpp
@@ -421,6 +421,10 @@ static int createLibreOfficeKit(const std::string& childRoot,
         {
             // Child
 
+            // sort out thread local variables to get logging right from
+            // as early as possible.
+            Util::setThreadName("kit_spare_" + Util::encodeId(spareKitId, 3));
+
             // Close the pipe from coolwsd
             close(0);
 

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -2542,8 +2542,6 @@ void lokit_main(
         SigUtil::setUserSignals();
     }
 
-    Util::setThreadName("kit_spare_" + Util::encodeId(numericIdentifier, 3));
-
     // Reinitialize logging when forked.
     const bool logToFile = std::getenv("COOL_LOGFILE");
     const char* logFilename = std::getenv("COOL_LOGFILENAME");

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -634,6 +634,9 @@ public:
     /// Remove all the sockets we own.
     void removeSockets();
 
+    /// After a fork - close all associated sockets without shutdown.
+    void closeAllSockets();
+
     bool isAlive() const { return (_threadStarted && !_threadFinished) || _runOnClientThread; }
 
     /// Check if we should continue polling
@@ -810,6 +813,9 @@ protected:
     {
         return _stop;
     }
+
+    void removeFromWakeupArray();
+
     bool hasCallbacks()
     {
         std::lock_guard<std::mutex> lock(_mutex);


### PR DESCRIPTION
Cleans up a lot of leaked sockets being pushed into new threads.

Also should make an 'exit' cleaner in the Kit process - since running 'shutdown' on the pointlessly inherited forkit socket to coolwsd would be a really bad idea.

lsof -p <kit_spare_process>

should show 4 fewer pipes with this.