### PR TITLE
Revert "cypress: disable mobile, idle, multi tests for now"

### DIFF
--- a/cypress_test/Makefile.am
+++ b/cypress_test/Makefile.am
@@ -106,8 +106,7 @@ MULTIUSER_TESTS_DONE= \
 check-local: do-check
 	$(if $(wildcard $(ERROR_LOG)),$(error CypressError: some tests failed!))
 
-# TODO: enable other tests $(MOBILE_TEST_FILES_DONE) $(IDLE_TEST_FILES_DONE) $(MULTIUSER_TESTS_DONE)
-do-check: $(DESKTOP_TEST_FILES_DONE)
+do-check: $(DESKTOP_TEST_FILES_DONE) $(MOBILE_TEST_FILES_DONE) $(IDLE_TEST_FILES_DONE) $(MULTIUSER_TESTS_DONE)
 	$(V)$(KILL_COMMAND) || true
 	$(if $(HEADLESS_BUILD),$(V)pkill Xvfb,)
 	$(if $(wildcard $(ERROR_LOG)),$(V)cat $(ERROR_LOG))


### PR DESCRIPTION
This reverts commit aa259d73378c19317ca08573536d3cc69ebf17ee.

