### PR TITLE
Improve Update state of uno Tool button state on stateChanged

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2395,7 +2395,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 
 				controls['label'] = label;
 			}
-
+			var disabled = data.enabled === 'false' || data.enabled === false;
 			if (data.command) {
 				var updateFunction = function() {
 					var items = builder.map['stateChangeHandler'];
@@ -2410,7 +2410,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 						$(div).removeClass('selected');
 					}
 
-					if (state && state === 'disabled') {
+					if (disabled) {
 						if (data.command === '.uno:Paste') {
 							// Fix GitHub issue #5839 and never disable Paste toolbar button
 							// Behave the same as Contol.Menubar and never
@@ -2435,12 +2435,18 @@ L.Control.JSDialogBuilder = L.Control.extend({
 				updateFunction();
 
 				builder.map.on('commandstatechanged', function(e) {
+					disabled = false;
 					if (e.commandName === data.command)
+					{
+						// in some cases we will get both property like state and disabled
+						// to handle it we will set disable var based on INCOMING info (ex: .uno:ParaRightToLft) 
+						disabled = e.disabled || e.state == 'disabled';
 						updateFunction();
+					}
 				}, this);
 			}
 
-			if (data.enabled === 'false' || data.enabled === false)
+			if (disabled)
 				L.DomUtil.addClass(div, 'disabled');
 
 			if (data.selected === true) {


### PR DESCRIPTION
- We made some adjustment in core side
- it will now send both property 
     1." State" = either button is selected or not 
     2."disabled" = either it is disabled or not
- based on above message made some adjustment and refactoring in update function

Core patch : https://gerrit.libreoffice.org/c/core/+/164767

Signed-off-by: Darshan-upadhyay1110 <darshan.upadhyay@collabora.com>

Change-Id: I7aa9bae647252782fcc88bd11b34bf9954741502



