### PR TITLE
clientnb: missing include

### DIFF
--- a/net/clientnb.cpp
+++ b/net/clientnb.cpp
@@ -15,6 +15,7 @@
 #include <cstring>
 #include <iostream>
 #include <thread>
+#include <memory>
 #include <assert.h>
 
 #include <Poco/Net/HTMLForm.h>


### PR DESCRIPTION
<timar> net/clientnb.cpp:117:10: error: ‘shared_ptr’ in namespace ‘std’ does not name a template type
<timar>   117 |     std::shared_ptr<WebSocket> getWebSocket()
<timar>       |          ^~~~~~~~~~
<timar> net/clientnb.cpp:38:1: note: ‘std::shared_ptr’ is defined in header ‘<memory>’; did you forget to ‘#include <memory>’?

IWYU agrees it's a missing include even if this builds for me by
accident.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I367ef3efcf2bdaf1b69c4bf21ef168e03807365c