### PR TITLE
Fix desktop/calc/focus_spec.js (23.05)

### DIFF
--- a/cypress_test/integration_tests/common/calc_helper.js
+++ b/cypress_test/integration_tests/common/calc_helper.js
@@ -95,17 +95,17 @@ function typeIntoFormulabar(text) {
 
 	cy.cGet('#sc_input_window.formulabar').click(); // This probably shouldn't be here, but acceptformula doesn't get visible without a click.
 	cy.cGet('#sc_input_window.formulabar').should('have.class', 'focused');
-	cy.cGet('body').type(text);
 
 	helper.doIfOnMobile(function() {
 		cy.cGet('#tb_actionbar_item_acceptformula').should('be.visible');
 		cy.cGet('#tb_actionbar_item_cancelformula').should('be.visible');
 	});
-
 	helper.doIfOnDesktop(function() {
 		cy.cGet('#acceptformula').should('be.visible');
 		cy.cGet('#cancelformula').should('be.visible');
 	});
+
+	cy.cGet('body').type(text);
 
 	cy.log('<< typeIntoFormulabar - end');
 }


### PR DESCRIPTION
Wait for formula bar buttons before typing


Change-Id: I0603fee2acd7ba3090f7b8536a5e5d6f18a52179


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

