### PR TITLE
Removed Group download as option from coolwsd.xml

### DIFF
--- a/.gitpod-files/coolwsd-gitpod.xml
+++ b/.gitpod-files/coolwsd-gitpod.xml
@@ -47,7 +47,6 @@
     </per_document>
 
     <per_view desc="View-specific settings.">
-        <group_download_as desc="If set to true, groups download as icons into a dropdown for the notebookbar view." type="bool" default="true">true</group_download_as>
         <out_of_focus_timeout_secs desc="The maximum number of seconds before dimming and stopping updates when the browser tab is no longer in focus. Defaults to 120 seconds." type="uint" default="120">120</out_of_focus_timeout_secs>
         <idle_timeout_secs desc="The maximum number of seconds before dimming and stopping updates when the user is no longer active (even if the browser is in focus). Defaults to 15 minutes." type="uint" default="900">900</idle_timeout_secs>
     </per_view>

--- a/browser/html/cool.html.m4
+++ b/browser/html/cool.html.m4
@@ -310,7 +310,6 @@ m4_ifelse(MOBILEAPP,[true],
       window.frameAncestors = '';
       window.socketProxy = false;
       window.tileSize = 256;
-      window.groupDownloadAsForNb = 'true'
       window.uiDefaults = {};
       window.useIntegrationTheme = 'false';
       window.checkFileInfoOverride = {};
@@ -342,7 +341,6 @@ m4_ifelse(MOBILEAPP,[true],
       window.frameAncestors = decodeURIComponent('%FRAME_ANCESTORS%');
       window.socketProxy = %SOCKET_PROXY%;
       window.tileSize = 256;
-      window.groupDownloadAsForNb = %GROUP_DOWNLOAD_AS%;
       window.uiDefaults = %UI_DEFAULTS%;
       window.checkFileInfoOverride = %CHECK_FILE_INFO_OVERRIDE%;
       window.deeplEnabled = %DEEPL_ENABLED%;

--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -203,7 +203,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 			});
 		}
 
-		if (!!window.groupDownloadAsForNb && !this._map['wopi'].HideExportOption) {
+		if (!this._map['wopi'].HideExportOption) {
 			content.push({
 				'id': 'downloadas:DownloadAsMenu',
 				'command': 'downloadas',
@@ -212,74 +212,6 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				'text': _('Download'),
 				'accessibility': { focusBack: true,	combination: 'DA', de: null }
 			});
-		} else if (!this._map['wopi'].HideExportOption) {
-			content.push(
-				{
-					'id': 'file-downloadas-ods-downloadas-csv',
-					'type': 'container',
-					'children': [
-						{
-							'id': 'downloadas-ods',
-							'type': 'menubartoolitem',
-							'text': _('ODF Spreadsheet (.ods)'),
-							'command': '',
-							'accessibility': { focusBack: true,	combination: 'DS', de: null }
-						},
-						{
-							'id': 'downloadas-csv',
-							'type': 'menubartoolitem',
-							'text': _('CSV File (.csv)'),
-							'command': '',
-							'accessibility': { focusBack: true,	combination: 'DV', de: null }
-						},
-					],
-					'vertical': 'true'
-				},
-				{
-					'id': 'file-downloadas-xls-downloadas-xlsx',
-					'type': 'container',
-					'children': [
-						{
-							'id': 'downloadas-xls',
-							'type': 'menubartoolitem',
-							'text': _('Excel 2003 Spreadsheet (.xls)'),
-							'command': '',
-							'accessibility': { focusBack: true,	combination: 'DX', de: null }
-						},
-						{
-							'id': 'downloadas-xlsx',
-							'type': 'menubartoolitem',
-							'text': _('Excel Spreadsheet (.xlsx)'),
-							'command': '',
-							'accessibility': { focusBack: true,	combination: 'DL', de: null }
-						},
-					],
-					'vertical': 'true'
-				},
-				{
-					'id': 'file-exportpdf',
-					'type': 'container',
-					'children': [
-						{
-							'id': !window.ThisIsAMobileApp ? 'exportdirectpdf' : 'downloadas-pdf',
-							'type': 'customtoolitem',
-							'text': _('PDF Document (.pdf)'),
-							'command': !window.ThisIsAMobileApp ? 'exportdirectpdf' : 'downloadas-pdf',
-							'inlineLabel': true,
-							'accessibility': { focusBack: true,	combination: 'EP', de: null }
-						},
-						{
-							'id': 'exportpdf' ,
-							'type': 'customtoolitem',
-							'text': _('PDF Document (.pdf) - Expert'),
-							'command': 'exportpdf' ,
-							'inlineLabel': true,
-							'accessibility': { focusBack: true,	combination: 'ED', de: null }
-						},
-					],
-					'vertical': 'true'
-				}
-			);
 		}
 
 		if (!this._map['wopi'].HideRepairOption) {

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -269,7 +269,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 			});
 		}
 
-		if ((!!window.groupDownloadAsForNb) && !this._map['wopi'].HideExportOption) {
+		if (!this._map['wopi'].HideExportOption) {
 			content.push({
 				'id': 'downloadas:DownloadAsMenu',
 				'command': 'downloadas',
@@ -295,80 +295,6 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 					'vertical': 'true'
 				});
 			}
-		} else if (!this._map['wopi'].HideExportOption) {
-			content = content.concat([
-				{
-					'id': 'file-downloadas-odp-downloadas-odg',
-					'type': 'container',
-					'children': [
-						{
-							'id': 'downloadas-odp',
-							'class': 'unodownloadas-odp',
-							'type': 'menubartoolitem',
-							'text': _('ODF Presentation (.odp)'),
-							'command': '',
-							'accessibility': { focusBack: true, combination: 'DA', de: null }
-						},
-						{
-							'id': 'downloadas-odg',
-							'class': 'unodownloadas-odg',
-							'type': 'menubartoolitem',
-							'text': _('ODF Drawing (.odg)'),
-							'command': '',
-							'accessibility': { focusBack: true, combination: 'DO', de: null }
-						},
-					],
-					'vertical': 'true'
-				},
-				{
-					'id': 'file-downloadas-ppt-downloadas-pptx',
-					'type': 'container',
-					'children': [
-						{
-							'id': 'downloadas-ppt',
-							'class': 'unodownloadas-ppt',
-							'type': 'menubartoolitem',
-							'text': _('PowerPoint 2003 Presentation (.ppt)'),
-							'command': '',
-							'accessibility': { focusBack: true, combination: 'DP', de: null }
-						},
-						{
-							'id': 'downloadas-pptx',
-							'class': 'unodownloadas-pptx',
-							'type': 'menubartoolitem',
-							'text': _('PowerPoint Presentation (.pptx)'),
-							'command': '',
-							'accessibility': { focusBack: true, combination: 'DX', de: null }
-						},
-					],
-					'vertical': 'true'
-				},
-				{
-					'id': 'file-exportdirectpdf',
-					'type': 'container',
-					'children': [
-						{
-							'id': !window.ThisIsAMobileApp ? 'exportdirectpdf' : 'downloadas-pdf',
-							'class': 'unoexportpdf',
-							'type': 'customtoolitem',
-							'text': _('PDF Document (.pdf)'),
-							'command': !window.ThisIsAMobileApp ? 'exportdirectpdf' : 'downloadas-pdf',
-							'inlineLabel': true,
-							'accessibility': { focusBack: true, combination: 'ED', de: null }
-						},
-						{
-							'id': 'exportpdf' ,
-							'class': 'unoexportpdf',
-							'type': 'customtoolitem',
-							'text': _('PDF Document (.pdf) - Expert'),
-							'command': 'exportpdf' ,
-							'inlineLabel': true,
-							'accessibility': { focusBack: true, combination: 'DF', de: null }
-						},
-					],
-					'vertical': 'true'
-				}
-			]);
 			if (!this._map['wopi'].HideRepairOption) {
 				content.push({
 					'type': 'container',

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -137,14 +137,11 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 		var hasSaveAs = !this._map['wopi'].UserCanNotWriteRelative;
 		var hasShare = this._map['wopi'].EnableShare;
 		var hideDownload = this._map['wopi'].HideExportOption;
-		var hasGroupedDownloadAs = !!window.groupDownloadAsForNb;
 		var hasGroupedSaveAs = window.uiDefaults && window.uiDefaults.saveAsMode === 'group';
 		var hasRunMacro = !(window.enableMacrosExecution  === 'false');
 		var hasSave = !this._map['wopi'].HideSaveOption;
 		var content = [];
 
-		var addRepairToDownloads = hasRepair && !hideDownload;
-		var addRepairToColumn = hasRepair && (hideDownload || hasGroupedDownloadAs);
 
 		content = [];
 
@@ -246,7 +243,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 			});
 		}
 
-		if (hasGroupedDownloadAs && !hideDownload) {
+		if (!hideDownload) {
 			content.push({
 				'id': 'downloadas:DownloadAsMenu',
 				'command': 'downloadas',
@@ -255,87 +252,9 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				'text': !window.ThisIsAMobileApp ? _('Download') : _('Save As'),
 				'accessibility': { focusBack: true,	combination: 'A', de: 'M' }
 			});
-		} else if (!hideDownload) {
-			content.push(
-				{
-					'type': 'container',
-					'children': [
-						{
-							'id': 'downloadas-odt',
-							'type': 'menubartoolitem',
-							'text': _('ODF Text Document (.odt)'),
-							'command': ''
-						},
-						{
-							'id': 'downloadas-rtf',
-							'type': 'menubartoolitem',
-							'text': _('Rich Text (.rtf)'),
-							'command': ''
-						},
-					],
-					'vertical': 'true'
-				},
-				{
-					'type': 'container',
-					'children': [
-						{
-							'id': 'downloadas-doc',
-							'type': 'menubartoolitem',
-							'text': _('Word 2003 Document (.doc)'),
-							'command': ''
-						},
-						{
-							'id': 'downloadas-docx',
-							'type': 'menubartoolitem',
-							'text': _('Word Document (.docx)'),
-							'command': ''
-						},
-					],
-					'vertical': 'true'
-				},
-				{
-					'type': 'container',
-					'children': [
-						{
-							'id': !window.ThisIsAMobileApp ? 'exportdirectpdf' : 'downloadas-pdf',
-							'type': 'customtoolitem',
-							'text': _('PDF Document (.pdf)'),
-							'command': !window.ThisIsAMobileApp ? 'exportdirectpdf' : 'downloadas-pdf',
-							'inlineLabel': true
-						},
-						{
-							'id': 'exportpdf' ,
-							'type': 'customtoolitem',
-							'text': _('PDF Document (.pdf) - Expert'),
-							'command': 'exportpdf' ,
-							'inlineLabel': true
-						},
-					],
-					'vertical': 'true'
-				},
-				{
-					'type': 'container',
-					'children': [
-						{
-							'id': !window.ThisIsAMobileApp ? 'exportepub' : 'downloadas-epub',
-							'type': 'customtoolitem',
-							'text': _('EPUB Document (.epub)'),
-							'command': !window.ThisIsAMobileApp ? 'exportepub' : 'downloadas-epub',
-							'inlineLabel': true
-						},
-						addRepairToDownloads? {
-							'id': 'repair',
-							'type': 'menubartoolitem',
-							'text': _('Repair'),
-							'command': _('Repair')
-						} : {}
-					],
-					'vertical': 'true'
-				}
-			);
 		}
 
-		if (addRepairToColumn) {
+		if (hasRepair) {
 			content.push({
 				'type': 'container',
 				'children': [

--- a/browser/test/load.js
+++ b/browser/test/load.js
@@ -91,7 +91,6 @@ data = data.replace(/%IDLE_TIMEOUT_SECS%/g, '1000000');
 data = data.replace(/%PROTOCOL_DEBUG%/g, 'true');
 data = data.replace(/%FRAME_ANCESTORS%/g, '');
 data = data.replace(/%SOCKET_PROXY%/g, 'false');
-data = data.replace(/%GROUP_DOWNLOAD_AS%/g, 'false');
 data = data.replace(/%UI_DEFAULTS%/g, '{}');
 data = data.replace(/%HEXIFY_URL%/g, '""');
 data = data.replace(/%CHECK_FILE_INFO_OVERRIDE%/g, 'false');

--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -75,7 +75,6 @@
     </per_document>
 
     <per_view desc="View-specific settings.">
-        <group_download_as desc="If set to true, groups download as icons into a dropdown for the notebookbar view." type="bool" default="true">true</group_download_as>
         <out_of_focus_timeout_secs desc="The maximum number of seconds before dimming and stopping updates when the browser tab is no longer in focus. Defaults to 300 seconds." type="uint" default="300">300</out_of_focus_timeout_secs>
         <idle_timeout_secs desc="The maximum number of seconds before dimming and stopping updates when the user is no longer active (even if the browser is in focus). Defaults to 15 minutes." type="uint" default="900">900</idle_timeout_secs>
         <custom_os_info desc="Custom string shown as OS version in About dialog, get from system if empty." type="string" default=""></custom_os_info>

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -2043,7 +2043,6 @@ void COOLWSD::innerInitialize(Application& self)
         { "per_document.batch_priority", "5" },
         { "per_document.pdf_resolution_dpi", "96" },
         { "per_document.redlining_as_comments", "false" },
-        { "per_view.group_download_as", "true" },
         { "per_view.idle_timeout_secs", "900" },
         { "per_view.out_of_focus_timeout_secs", "120" },
         { "per_view.custom_os_info", "" },

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -1236,8 +1236,6 @@ FileServerRequestHandler::ResourceAccessDetails FileServerRequestHandler::prepro
     else
         Poco::replaceInPlace(preprocess, std::string("%BROWSER_LOGGING%"), std::string());
 
-    const auto groupDownloadAs = stringifyBoolFromConfig(config, "per_view.group_download_as", true);
-    Poco::replaceInPlace(preprocess, std::string("%GROUP_DOWNLOAD_AS%"), groupDownloadAs);
     const unsigned int outOfFocusTimeoutSecs = config.getUInt("per_view.out_of_focus_timeout_secs", 60);
     Poco::replaceInPlace(preprocess, std::string("%OUT_OF_FOCUS_TIMEOUT_SECS%"), std::to_string(outOfFocusTimeoutSecs));
     const unsigned int idleTimeoutSecs = config.getUInt("per_view.idle_timeout_secs", 900);


### PR DESCRIPTION
Change-Id: I47c07ed88d68de5fc65b2e5e1e0896bc2a082131


* Resolves: #8484
* Target version: master

### Summary
The changes included:
1. Removal of the `group_download_as` from relavant files.
2. Modification of the relevant logic to default the group_download_as option.


### Checklist

- [X] Code is properly formatted
- [X] All commits have Change-Id
- [ ] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

