### PR TITLE
fix: data loss when shutting down while using typer

### DIFF
--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -791,6 +791,8 @@ app.definitions.Socket = L.Class.extend({
 			else if (textMsg === 'shuttingdown') {
 				msg = _('Server is shutting down for maintenance (auto-saving)');
 				postMsgData['Reason'] = 'ShuttingDown';
+				app.idleHandler._active = false;
+				app.idleHandler._serverRecycling = true;
 			}
 			else if (textMsg === 'docdisconnected') {
 				msg = _('Oops, there is a problem connecting the document');
@@ -1219,6 +1221,11 @@ app.definitions.Socket = L.Class.extend({
 			else if (textMsg.startsWith('statusindicatorfinish:')) {
 				this._map.fire('statusindicator', {statusType : 'finish'});
 				this._map._fireInitComplete('statusindicatorfinish');
+				// show shutting down popup after saving is finished
+				// if we show the popup just after the shuttingdown messsage, it will be overwitten by save popup
+				if (app.idleHandler._serverRecycling) {
+					this._map.showBusy(_('Server is shutting down'), false);
+				}
 				return;
 			}
 		}

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -4408,6 +4408,8 @@ int COOLWSD::innerMain()
 #endif
     }
 
+    COOLWSD::alertAllUsersInternal("close: shuttingdown");
+
     // Lots of polls will stop; stop watching them first.
     SocketPoll::shutdownWatchdog();
 

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -3674,6 +3674,13 @@ bool DocumentBroker::forwardToChild(const std::shared_ptr<ClientSession>& sessio
         return true;
     }
 
+    // Ignore textinput, mouse and key message when document is unloading
+    if (isUnloading() && (message.starts_with("textinput ") || message.starts_with("mouse ") ||
+                          message.starts_with("key ")))
+    {
+        return true;
+    }
+
     const std::string viewId = session->getId();
 
     LOG_TRC("Forwarding payload to child [" << viewId << "]: " << getAbbreviatedMessage(message));
@@ -3799,7 +3806,6 @@ void DocumentBroker::terminateChild(const std::string& closeReason)
 
         _childProcess->close();
     }
-
     stop(closeReason);
 }
 


### PR DESCRIPTION
- Docbroker only uploads the document when the document is already saved and there are no further modifications.
- But when using typer once dockerbroker saves the document and tries to upload there are already new changes to the document. Therefore, docbroker keeps on saving this new changes and keeps on skiping the upload as there are new changes to the document; until it times out


Change-Id: I427d37a6228299006530daddebdf4365af63588b


* Resolves: # <!-- related github issue -->
* Target version: master

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

