### PR TITLE
fix: data loss when shutting down while using typer

### DIFF
--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -788,6 +788,8 @@ app.definitions.Socket = L.Class.extend({
 			else if (textMsg === 'shuttingdown') {
 				msg = _('Server is shutting down for maintenance (auto-saving)');
 				postMsgData['Reason'] = 'ShuttingDown';
+				app.idleHandler._active = false;
+				app.idleHandler._serverRecycling = true;
 			}
 			else if (textMsg === 'docdisconnected') {
 				msg = _('Oops, there is a problem connecting the document');
@@ -1223,6 +1225,11 @@ app.definitions.Socket = L.Class.extend({
 			else if (textMsg.startsWith('statusindicatorfinish:')) {
 				this._map.fire('statusindicator', {statusType : 'finish'});
 				this._map._fireInitComplete('statusindicatorfinish');
+				// show shutting down popup after saving is finished
+				// if we show the popup just after the shuttingdown messsage, it will be overwitten by save popup
+				if (app.idleHandler._serverRecycling) {
+					this._map.showBusy(_('Server is shutting down'), false);
+				}
 				return;
 			}
 		}

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -6320,6 +6320,8 @@ int COOLWSD::innerMain()
     // atexit handlers tend to free Admin before Documents
     LOG_INF("Exiting. Cleaning up lingering documents.");
 #if !MOBILEAPP
+    COOLWSD::alertAllUsersInternal("close: shuttingdown");
+
     if (!SigUtil::getShutdownRequestFlag())
     {
         // This shouldn't happen, but it's fail safe to always cleanup properly.

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -3654,6 +3654,13 @@ bool DocumentBroker::forwardToChild(const std::shared_ptr<ClientSession>& sessio
         return true;
     }
 
+    // Ignore textinput, mouse and key message when document is unloading
+    if (isUnloading() && (Util::startsWith(message, "textinput ") ||
+                          Util::startsWith(message, "mouse ") || Util::startsWith(message, "key ")))
+    {
+        return true;
+    }
+
     const std::string viewId = session->getId();
 
     LOG_TRC("Forwarding payload to child [" << viewId << "]: " << getAbbreviatedMessage(message));
@@ -3779,7 +3786,6 @@ void DocumentBroker::terminateChild(const std::string& closeReason)
 
         _childProcess->close();
     }
-
     stop(closeReason);
 }
 


### PR DESCRIPTION
- Docbroker only uploads the document when the document is already saved and there are no further modifications.
- But when using typer once dockerbroker saves the document and tries to upload there are already new changes to the document. Therefore, docbroker keeps on saving this new changes and keeps on skiping the upload as there are new changes to the document; until it times out


Change-Id: I427d37a6228299006530daddebdf4365af63588b
