### PR TITLE
Reuse Response in all File Server Scenarios

### DIFF
--- a/common/Authorization.hpp
+++ b/common/Authorization.hpp
@@ -14,7 +14,6 @@
 #pragma once
 
 #include <string>
-#include <vector>
 
 namespace Poco
 {

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -934,6 +934,10 @@ public:
     /// Serializes the Server Response into the given buffer.
     bool writeData(Buffer& out) const
     {
+        assert(!get("Date").empty() && "Date is always set in http::Response ctor");
+        assert(get("Server") == http::getServerString() &&
+               "Server Agent is always set in http::Response ctor");
+
         _statusLine.writeData(out);
         _header.writeData(out);
         out.append("\r\n"); // End of header.

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -440,8 +440,11 @@ public:
     /// Return true iff Transfer-Encoding is set to chunked (the last entry).
     bool getChunkedTransferEncoding() const { return _chunked; }
 
-    /// Adds a new "Cookie" header entry with the given cookies.
-    void addCookies(const Container& pairs)
+    /// Adds a new "Cookie" header entry with the given content.
+    void addCookie(const std::string& cookie) { add(COOKIE, cookie); }
+
+    /// Adds a new "Cookie" header entry with the given pairs.
+    void addCookie(const Container& pairs)
     {
         std::string s;
         s.reserve(256);
@@ -853,6 +856,7 @@ public:
 
     const StatusLine& statusLine() const { return _statusLine; }
 
+    Header& header() { return _header; }
     const Header& header() const { return _header; }
 
     /// Add an HTTP header field.

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -790,8 +790,9 @@ void StreamSocket::dumpState(std::ostream& os)
 
 void StreamSocket::sendWithDateAndAgent(http::Response& response)
 {
-    response.set("Server", http::getServerString());
-    response.set("Date", Util::getHttpTimeNow());
+    assert(response.get("Server") == http::getServerString() &&
+           "Server Agent is always set in http::Response ctor");
+    assert(!response.get("Date").empty() && "Date is always set in http::Response ctor");
 
     send(response);
 }

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -788,15 +788,6 @@ void StreamSocket::dumpState(std::ostream& os)
     _outBuffer.dumpHex(os, "\t\toutBuffer:\n", "\t\t");
 }
 
-void StreamSocket::sendWithDateAndAgent(http::Response& response)
-{
-    assert(response.get("Server") == http::getServerString() &&
-           "Server Agent is always set in http::Response ctor");
-    assert(!response.get("Date").empty() && "Date is always set in http::Response ctor");
-
-    send(response);
-}
-
 bool StreamSocket::send(const http::Response& response)
 {
     if (response.writeData(_outBuffer))

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -1031,10 +1031,6 @@ public:
         send(str.data(), str.size(), doFlush);
     }
 
-    /// Sends HTTP response.
-    /// Adds Date and User-Agent.
-    void sendWithDateAndAgent(http::Response& response);
-
     /// Send an http::Request and flush.
     /// Does not add any fields to the header.
     /// Will shutdown the socket upon error and return false.

--- a/tools/WebSocketDump.cpp
+++ b/tools/WebSocketDump.cpp
@@ -148,7 +148,7 @@ private:
                 http::Response response(http::StatusCode::BadRequest);
                 response.setContentLength(0);
                 LOG_INF("DumpWebSockets bad request");
-                socket->sendWithDateAndAgent(response);
+                socket->send(response);
                 disposition.setClosed();
             }
         }

--- a/wsd/Admin.cpp
+++ b/wsd/Admin.cpp
@@ -819,11 +819,12 @@ std::string Admin::getLogLines()
 {
     ASSERT_CORRECT_THREAD();
 
-    try {
-        int lineCount = 500;
+    try
+    {
         static const std::string fName = COOLWSD::getPathFromConfig("logging.file.property[0]");
         std::ifstream infile(fName);
 
+        std::size_t lineCount = 500;
         std::string line;
         std::deque<std::string> lines;
 
@@ -831,7 +832,7 @@ std::string Admin::getLogLines()
         {
             std::istringstream iss(line);
             lines.push_back(line);
-            if (lines.size() > (size_t)lineCount)
+            if (lines.size() > lineCount)
             {
                 lines.pop_front();
             }
@@ -839,16 +840,21 @@ std::string Admin::getLogLines()
 
         infile.close();
 
-        if (lines.size() < (size_t)lineCount)
+        if (lines.size() < lineCount)
         {
-            lineCount = (int)lines.size();
+            lineCount = lines.size();
         }
 
         line.clear(); // Use the same variable to include result.
-        // Newest will be on top.
-        for (int i = lineCount - 1; i >= 0; i--)
+        if (lineCount > 0)
         {
-            line += "\n" + lines[i];
+            line.reserve(lineCount * 128); // Avoid repeated resizing.
+            // Newest will be on top.
+            for (int i = static_cast<int>(lineCount) - 1; i >= 0; i--)
+            {
+                line += '\n';
+                line += lines[i];
+            }
         }
 
         return line;

--- a/wsd/Admin.cpp
+++ b/wsd/Admin.cpp
@@ -494,7 +494,7 @@ bool AdminSocketHandler::handleInitialRequest(
     http::Response response(http::StatusCode::BadRequest);
     response.setContentLength(0);
     LOG_INF_S("Admin::handleInitialRequest bad request");
-    socket->sendWithDateAndAgent(response);
+    socket->send(response);
 
     return false;
 }

--- a/wsd/Admin.cpp
+++ b/wsd/Admin.cpp
@@ -1141,13 +1141,16 @@ void Admin::getMetrics(std::ostringstream &metrics)
     _model.getMetrics(metrics);
 }
 
-void Admin::sendMetrics(const std::shared_ptr<StreamSocket>& socket, const std::shared_ptr<Poco::Net::HTTPResponse>& response)
+void Admin::sendMetrics(const std::shared_ptr<StreamSocket>& socket,
+                        const std::shared_ptr<http::Response>& response)
 {
     std::ostringstream oss;
-    response->add("Connection", "close");
-    response->write(oss);
     getMetrics(oss);
-    socket->send(oss.str());
+
+    response->add("Connection", "close");
+    response->setBody(oss.str(), "text/plain");
+
+    socket->send(*response);
     socket->shutdown();
 
     static bool skipAuthentication =

--- a/wsd/Admin.cpp
+++ b/wsd/Admin.cpp
@@ -16,7 +16,6 @@
 #include <sys/poll.h>
 #include <unistd.h>
 
-#include <Poco/Net/HTTPCookie.h>
 #include <Poco/Net/HTTPRequest.h>
 #include <Poco/Net/HTTPResponse.h>
 

--- a/wsd/Admin.cpp
+++ b/wsd/Admin.cpp
@@ -821,7 +821,7 @@ std::string Admin::getLogLines()
 
     try {
         int lineCount = 500;
-        std::string fName = COOLWSD::getPathFromConfig("logging.file.property[0]");
+        static const std::string fName = COOLWSD::getPathFromConfig("logging.file.property[0]");
         std::ifstream infile(fName);
 
         std::string line;
@@ -1098,10 +1098,13 @@ void Admin::connectToMonitorSync(const std::string &uri)
     }
 
     LOG_TRC("Add monitor " << uri);
-    if (COOLWSD::getConfigValue<bool>("admin_console.logging.monitor_connect", true))
+    static const bool logMonitorConnect =
+        COOLWSD::getConfigValue<bool>("admin_console.logging.monitor_connect", true);
+    if (logMonitorConnect)
     {
         LOG_ANY("Connected to remote monitor with uri [" << uriWithoutParam << ']');
     }
+
     auto handler = std::make_shared<MonitorSocketHandler>(this, uri);
     _monitorSockets.insert({uriWithoutParam, handler});
     insertNewWebSocketSync(Poco::URI(uri), handler);
@@ -1140,8 +1143,11 @@ void Admin::sendMetrics(const std::shared_ptr<StreamSocket>& socket, const std::
     getMetrics(oss);
     socket->send(oss.str());
     socket->shutdown();
-    bool skipAuthentication = COOLWSD::getConfigValue<bool>("security.enable_metrics_unauthenticated", false);
-    bool showLog = COOLWSD::getConfigValue<bool>("admin_console.logging.metrics_fetch", true);
+
+    static bool skipAuthentication =
+        COOLWSD::getConfigValue<bool>("security.enable_metrics_unauthenticated", false);
+    static bool showLog =
+        COOLWSD::getConfigValue<bool>("admin_console.logging.metrics_fetch", true);
     if (!skipAuthentication && showLog)
     {
         LOG_ANY("Metrics endpoint has been accessed by source IPAddress [" << socket->clientAddress() << ']');

--- a/wsd/Admin.hpp
+++ b/wsd/Admin.hpp
@@ -162,7 +162,8 @@ public:
     /// Attempt a synchronous connection to a monitor with @uri @when that future comes
     void scheduleMonitorConnect(const std::string &uri, std::chrono::steady_clock::time_point when);
 
-    void sendMetrics(const std::shared_ptr<StreamSocket>& socket, const std::shared_ptr<Poco::Net::HTTPResponse>& response);
+    void sendMetrics(const std::shared_ptr<StreamSocket>& socket,
+                     const std::shared_ptr<http::Response>& response);
 
     void setViewLoadDuration(const std::string& docKey, const std::string& sessionId, std::chrono::milliseconds viewLoadDuration);
     void setDocWopiDownloadDuration(const std::string& docKey, std::chrono::milliseconds wopiDownloadDuration);

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -19,35 +19,38 @@
 #endif
 
 #include <Admin.hpp>
-#include <ClientSession.hpp>
 #include <COOLWSD.hpp>
+#include <ClientSession.hpp>
+#include <ConfigUtil.hpp>
 #include <DocumentBroker.hpp>
 #include <Exceptions.hpp>
 #include <FileServer.hpp>
+#include <HttpRequest.hpp>
+#include <JailUtil.hpp>
+#include <ProofKey.hpp>
+#include <ProxyRequestHandler.hpp>
+#include <RequestDetails.hpp>
+#include <Socket.hpp>
+#include <Util.hpp>
+#include <net/HttpHelper.hpp>
 #if !MOBILEAPP
 #include <HostUtil.hpp>
 #endif // !MOBILEAPP
-#include <RequestDetails.hpp>
-#include <ProxyRequestHandler.hpp>
-#include <net/HttpHelper.hpp>
-#include <ConfigUtil.hpp>
-#include <JailUtil.hpp>
-#include <ProofKey.hpp>
-#include <Util.hpp>
 
-#include <Poco/File.h>
-#include <Poco/StreamCopier.h>
 #include <Poco/DOM/AutoPtr.h>
+#include <Poco/DOM/DOMParser.h>
 #include <Poco/DOM/DOMWriter.h>
 #include <Poco/DOM/Document.h>
-#include <Poco/DOM/DOMParser.h>
 #include <Poco/DOM/Element.h>
 #include <Poco/DOM/NodeList.h>
+#include <Poco/File.h>
+#include <Poco/MemoryStream.h>
 #include <Poco/Net/DNS.h>
-#include <Poco/Net/NetException.h>
 #include <Poco/Net/HTMLForm.h>
+#include <Poco/Net/NetException.h>
 #include <Poco/Net/PartHandler.h>
 #include <Poco/SAX/InputSource.h>
+#include <Poco/StreamCopier.h>
 
 #include <map>
 #include <memory>

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -623,8 +623,8 @@ void ClientRequestDispatcher::handleIncomingMessage(SocketDisposition& dispositi
                  requestDetails.equals(1, "getMetrics"))
         {
             // See metrics.txt
-            std::shared_ptr<Poco::Net::HTTPResponse> response =
-                std::make_shared<Poco::Net::HTTPResponse>();
+            std::shared_ptr<http::Response> response =
+                std::make_shared<http::Response>(http::StatusCode::OK);
 
             if (!COOLWSD::AdminEnabled)
                 throw Poco::FileAccessDeniedException("Admin console disabled");
@@ -654,7 +654,6 @@ void ClientRequestDispatcher::handleIncomingMessage(SocketDisposition& dispositi
             response->add("X-XSS-Protection", "1; mode=block");
             // No referrer-policy
             response->add("Referrer-Policy", "no-referrer");
-            response->add("Content-Type", "text/plain");
             response->add("X-Content-Type-Options", "nosniff");
 
             disposition.setTransfer(Admin::instance(),

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -654,7 +654,6 @@ void ClientRequestDispatcher::handleIncomingMessage(SocketDisposition& dispositi
             response->add("X-XSS-Protection", "1; mode=block");
             // No referrer-policy
             response->add("Referrer-Policy", "no-referrer");
-            response->set("Server", http::getServerString());
             response->add("Content-Type", "text/plain");
             response->add("X-Content-Type-Options", "nosniff");
 

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1710,7 +1710,7 @@ bool ClientSession::handleKitToClientMessage(const std::shared_ptr<Message>& pay
                     {
                         http::Response response(http::StatusCode::Unauthorized);
                         response.set("X-ERROR-KIND", errorKind);
-                        _saveAsSocket->sendWithDateAndAgent(response);
+                        _saveAsSocket->send(response);
 
                         // Conversion failed, cleanup fake session.
                         LOG_TRC("Removing save-as ClientSession after conversion error.");

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -264,6 +264,51 @@ bool FileServerRequestHandler::isAdminLoggedIn(const Poco::Net::HTTPRequest& req
     return false;
 }
 
+bool FileServerRequestHandler::authenticateAdmin(const Poco::Net::HTTPBasicCredentials& credentials,
+                                                 Poco::Net::HTTPResponse& response,
+                                                 std::string& jwtToken)
+{
+    assert(COOLWSD::AdminEnabled);
+
+    const std::string& userProvidedUsr = credentials.getUsername();
+    const std::string& userProvidedPwd = credentials.getPassword();
+
+    // Deny attempts to login without providing a username / pwd and fail right away
+    // We don't even want to allow a password-less PAM module to be used here,
+    // or anything.
+    if (userProvidedUsr.empty() || userProvidedPwd.empty())
+    {
+        LOG_ERR("An attempt to log into Admin Console without username or password.");
+        return false;
+    }
+
+    // Check if the user is allowed to use the admin console
+    if (COOLWSD::getConfigValue<bool>("admin_console.enable_pam", false))
+    {
+        // use PAM - it needs the username too
+        if (!isPamAuthOk(userProvidedUsr, userProvidedPwd))
+            return false;
+    }
+    else
+    {
+        // use the hash or password in the config file
+        if (!isConfigAuthOk(userProvidedUsr, userProvidedPwd))
+            return false;
+    }
+
+    // authentication passed, generate and set the cookie
+    JWTAuth authAgent("admin", "admin", "admin");
+    jwtToken = authAgent.getAccessToken();
+
+    Poco::Net::HTTPCookie cookie("jwt", jwtToken);
+    // bundlify appears to add an extra /dist -> dist/dist/admin
+    cookie.setPath(COOLWSD::ServiceRoot + "/browser/dist/");
+    cookie.setSecure(COOLWSD::isSSLEnabled());
+    response.addCookie(cookie);
+
+    return true;
+}
+
 bool FileServerRequestHandler::isAdminLoggedIn(const HTTPRequest& request,
                                                HTTPResponse &response)
 {

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -691,9 +691,6 @@ void FileServerRequestHandler::handleRequest(const HTTPRequest& request,
                 }
             }
 
-            response.set("Server", http::getServerString());
-            response.set("Date", Util::getHttpTimeNow());
-
 #if !MOBILEAPP
             if (COOLWSD::WASMState != COOLWSD::WASMActivationState::Disabled &&
                 relPath.find("wasm") != std::string::npos)
@@ -1555,8 +1552,6 @@ void FileServerRequestHandler::preprocessWelcomeFile(const HTTPRequest& request,
     // No referrer-policy
     httpResponse.add("Referrer-Policy", "no-referrer");
     httpResponse.add("X-Content-Type-Options", "nosniff");
-    httpResponse.set("Server", http::getServerString());
-    httpResponse.set("Date", Util::getHttpTimeNow());
 
     httpResponse.setBody(std::move(templateWelcome));
     socket->send(httpResponse);

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -226,6 +226,34 @@ FileServerRequestHandler::~FileServerRequestHandler()
     FileHash.clear();
 }
 
+bool FileServerRequestHandler::isAdminLoggedIn(const Poco::Net::HTTPRequest& request,
+                                               std::string& jwtToken)
+{
+    assert(COOLWSD::AdminEnabled);
+
+    try
+    {
+        NameValueCollection cookies;
+        request.getCookies(cookies);
+        jwtToken = cookies.get("jwt");
+        LOG_INF("Verifying JWT token: " << jwtToken);
+        JWTAuth authAgent("admin", "admin", "admin");
+        if (authAgent.verify(jwtToken))
+        {
+            LOG_TRC("JWT token is valid");
+            return true;
+        }
+
+        LOG_INF("Invalid JWT token, let the administrator re-login");
+    }
+    catch (const Poco::Exception& exc)
+    {
+        LOG_INF("No existing JWT cookie found");
+    }
+
+    return false;
+}
+
 bool FileServerRequestHandler::isAdminLoggedIn(const HTTPRequest& request,
                                                HTTPResponse &response)
 {

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -18,6 +18,7 @@
 #include "COOLWSD.hpp"
 #include "Exceptions.hpp"
 #include "FileUtil.hpp"
+#include "HttpRequest.hpp"
 #include "RequestDetails.hpp"
 #include "ServerURL.hpp"
 #include <Common.hpp>
@@ -265,8 +266,7 @@ bool FileServerRequestHandler::isAdminLoggedIn(const Poco::Net::HTTPRequest& req
 }
 
 bool FileServerRequestHandler::authenticateAdmin(const Poco::Net::HTTPBasicCredentials& credentials,
-                                                 Poco::Net::HTTPResponse& response,
-                                                 std::string& jwtToken)
+                                                 http::Response& response, std::string& jwtToken)
 {
     assert(COOLWSD::AdminEnabled);
 
@@ -304,35 +304,16 @@ bool FileServerRequestHandler::authenticateAdmin(const Poco::Net::HTTPBasicCrede
     // bundlify appears to add an extra /dist -> dist/dist/admin
     cookie.setPath(COOLWSD::ServiceRoot + "/browser/dist/");
     cookie.setSecure(COOLWSD::isSSLEnabled());
-    response.addCookie(cookie);
+    response.header().addCookie(cookie.toString());
 
     return true;
 }
 
-bool FileServerRequestHandler::isAdminLoggedIn(const HTTPRequest& request,
-                                               HTTPResponse &response)
+bool FileServerRequestHandler::isAdminLoggedIn(const HTTPRequest& request, http::Response& response)
 {
     std::string jwtToken;
     return isAdminLoggedIn(request, jwtToken) ||
            authenticateAdmin(Poco::Net::HTTPBasicCredentials(request), response, jwtToken);
-}
-
-bool FileServerRequestHandler::isAdminLoggedIn(const HTTPRequest& request, http::Response& response)
-{
-    // For now, we reuse the exiting implementation, which uses Poco HTTPCookie.
-    Poco::Net::HTTPResponse pocoResponse;
-    if (isAdminLoggedIn(request, pocoResponse))
-    {
-        // Copy the headers, including the cookies.
-        for (const auto& pair : pocoResponse)
-        {
-            response.set(pair.first, pair.second);
-        }
-
-        return true;
-    }
-
-    return false;
 }
 
 #if ENABLE_DEBUG
@@ -1566,7 +1547,7 @@ void FileServerRequestHandler::preprocessAdminFile(const HTTPRequest& request,
     if (!COOLWSD::AdminEnabled)
         throw Poco::FileAccessDeniedException("Admin console disabled");
 
-    Poco::Net::HTTPResponse response;
+    http::Response response(http::StatusCode::OK);
     std::string jwtToken;
     if (!isAdminLoggedIn(request, jwtToken))
     {
@@ -1646,13 +1627,8 @@ void FileServerRequestHandler::preprocessAdminFile(const HTTPRequest& request,
     response.set("Server", http::getServerString());
     response.set("Date", Util::getHttpTimeNow());
 
-    response.setContentType("text/html");
-    response.setChunkedTransferEncoding(false);
-
-    std::ostringstream oss;
-    response.write(oss);
-    oss << templateFile;
-    socket->send(oss.str());
+    response.setBody(std::move(templateFile));
+    socket->send(response);
 }
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -72,7 +72,8 @@ using Poco::Util::Application;
 
 std::map<std::string, std::pair<std::string, std::string>> FileServerRequestHandler::FileHash;
 
-namespace {
+namespace
+{
 
 int functionConversation(int /*num_msg*/, const struct pam_message** /*msg*/,
                          struct pam_response **reply, void *appdata_ptr)
@@ -204,7 +205,13 @@ bool isConfigAuthOk(const std::string& userProvidedUsr, const std::string& userP
     return pass == userProvidedPwd;
 }
 
+std::string stringifyBoolFromConfig(const Poco::Util::LayeredConfiguration& config,
+                                    const std::string& propertyName, bool defaultValue)
+{
+    return config.getBool(propertyName, defaultValue) ? "true" : "false";
 }
+
+} // namespace
 
 FileServerRequestHandler::FileServerRequestHandler(const std::string& root)
 {

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -1568,13 +1568,27 @@ void FileServerRequestHandler::preprocessAdminFile(const HTTPRequest& request,
                                                    const RequestDetails &requestDetails,
                                                    const std::shared_ptr<StreamSocket>& socket)
 {
-    Poco::Net::HTTPResponse response;
-
     if (!COOLWSD::AdminEnabled)
         throw Poco::FileAccessDeniedException("Admin console disabled");
 
-    if (!FileServerRequestHandler::isAdminLoggedIn(request, response))
-        throw Poco::Net::NotAuthenticatedException("Invalid admin login");
+    Poco::Net::HTTPResponse response;
+    std::string jwtToken;
+    if (!isAdminLoggedIn(request, jwtToken))
+    {
+        // Not logged in, so let's log in now.
+        if (!authenticateAdmin(Poco::Net::HTTPBasicCredentials(request), response, jwtToken))
+        {
+            throw Poco::Net::NotAuthenticatedException("Invalid admin login");
+        }
+
+        // New login, log.
+        static bool showLog =
+            COOLWSD::getConfigValue<bool>("admin_console.logging.admin_login", true);
+        if (showLog)
+        {
+            LOG_ANY("Admin logged in with source IPAddress [" << socket->clientAddress() << ']');
+        }
+    }
 
     const ServerURL cnxDetails(requestDetails);
     const std::string responseRoot = cnxDetails.getResponseRoot();
@@ -1588,38 +1602,6 @@ void FileServerRequestHandler::preprocessAdminFile(const HTTPRequest& request,
     const std::string templatePath =
         Poco::Path(relPath).setFileName("admintemplate.html").toString();
     std::string templateFile = *getUncompressedFile(templatePath);
-
-    std::string jwtToken;
-    Poco::Net::NameValueCollection reqCookies;
-    std::vector<Poco::Net::HTTPCookie> resCookies;
-
-    response.getCookies(resCookies);
-    for (size_t it = 0; it < resCookies.size(); ++it)
-    {
-        if (resCookies[it].getName() == "jwt")
-        {
-            jwtToken = resCookies[it].getValue();
-            // when response contains the jwt we can determine that admin console is
-            // accessed for the first time by a specific client
-            bool showLog =
-                COOLWSD::getConfigValue<bool>("admin_console.logging.admin_login", true);
-            if (showLog)
-            {
-                LOG_ANY("Admin logged in with source IPAddress [" << socket->clientAddress()
-                                                                  << ']');
-            }
-            break;
-        }
-    }
-
-    if (jwtToken.empty())
-    {
-        request.getCookies(reqCookies);
-        if (reqCookies.has("jwt"))
-        {
-            jwtToken = reqCookies.get("jwt");
-        }
-    }
 
     const std::string escapedJwtToken = Util::encodeURIComponent(jwtToken, "'");
     Poco::replaceInPlace(templateFile, std::string("%JWT_TOKEN%"), escapedJwtToken);

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -12,6 +12,47 @@
 #include <config.h>
 #include <config_version.h>
 
+#include "FileServer.hpp"
+
+#include "Auth.hpp"
+#include "COOLWSD.hpp"
+#include "Exceptions.hpp"
+#include "FileUtil.hpp"
+#include "RequestDetails.hpp"
+#include "ServerURL.hpp"
+#include <Common.hpp>
+#include <Crypto.hpp>
+#include <Log.hpp>
+#include <Protocol.hpp>
+#include <Util.hpp>
+#include <common/ConfigUtil.hpp>
+#include <common/LangUtil.hpp>
+#if !MOBILEAPP
+#include <net/HttpHelper.hpp>
+#endif
+#include <ContentSecurityPolicy.hpp>
+
+#include <Poco/DateTime.h>
+#include <Poco/DateTimeFormat.h>
+#include <Poco/DateTimeFormatter.h>
+#include <Poco/Exception.h>
+#include <Poco/FileStream.h>
+#include <Poco/JSON/Object.h>
+#include <Poco/MemoryStream.h>
+#include <Poco/Net/HTMLForm.h>
+#include <Poco/Net/HTTPBasicCredentials.h>
+#include <Poco/Net/HTTPCookie.h>
+#include <Poco/Net/HTTPRequest.h>
+#include <Poco/Net/HTTPResponse.h>
+#include <Poco/Net/NameValueCollection.h>
+#include <Poco/Net/NetException.h>
+#include <Poco/RegularExpression.h>
+#include <Poco/Runnable.h>
+#include <Poco/SHA1Engine.h>
+#include <Poco/StreamCopier.h>
+#include <Poco/URI.h>
+#include <Poco/Util/LayeredConfiguration.h>
+
 #include <chrono>
 #include <iomanip>
 #include <string>
@@ -24,44 +65,6 @@
 #include <security/pam_appl.h>
 
 #include <openssl/evp.h>
-
-#include <Poco/DateTime.h>
-#include <Poco/DateTimeFormat.h>
-#include <Poco/DateTimeFormatter.h>
-#include <Poco/Exception.h>
-#include <Poco/FileStream.h>
-#include <Poco/SHA1Engine.h>
-#include <Poco/Net/HTMLForm.h>
-#include <Poco/Net/HTTPBasicCredentials.h>
-#include <Poco/Net/HTTPCookie.h>
-#include <Poco/Net/HTTPRequest.h>
-#include <Poco/Net/HTTPResponse.h>
-#include <Poco/Net/NameValueCollection.h>
-#include <Poco/Net/NetException.h>
-#include <Poco/RegularExpression.h>
-#include <Poco/Runnable.h>
-#include <Poco/StreamCopier.h>
-#include <Poco/URI.h>
-#include <Poco/JSON/Object.h>
-#include "Exceptions.hpp"
-
-#include "Auth.hpp"
-#include <Common.hpp>
-#include <Crypto.hpp>
-#include "FileServer.hpp"
-#include "COOLWSD.hpp"
-#include "FileUtil.hpp"
-#include "RequestDetails.hpp"
-#include "ServerURL.hpp"
-#include <Log.hpp>
-#include <Protocol.hpp>
-#include <Util.hpp>
-#include <common/ConfigUtil.hpp>
-#include <common/LangUtil.hpp>
-#if !MOBILEAPP
-#include <net/HttpHelper.hpp>
-#endif
-#include <ContentSecurityPolicy.hpp>
 
 using Poco::Net::HTMLForm;
 using Poco::Net::HTTPBasicCredentials;

--- a/wsd/FileServer.hpp
+++ b/wsd/FileServer.hpp
@@ -136,6 +136,9 @@ public:
     FileServerRequestHandler(const std::string& root);
     ~FileServerRequestHandler();
 
+    /// Evaluate if the cookie exists and returns it when it does.
+    static bool isAdminLoggedIn(const Poco::Net::HTTPRequest& request, std::string& jwtToken);
+
     /// Evaluate if the cookie exists, and if not, ask for the credentials.
     static bool isAdminLoggedIn(const Poco::Net::HTTPRequest& request, Poco::Net::HTTPResponse& response);
     static bool isAdminLoggedIn(const Poco::Net::HTTPRequest& request, http::Response& response);

--- a/wsd/FileServer.hpp
+++ b/wsd/FileServer.hpp
@@ -144,12 +144,11 @@ public:
     static bool isAdminLoggedIn(const Poco::Net::HTTPRequest& request, std::string& jwtToken);
 
     /// Evaluate if the cookie exists, and if not, ask for the credentials.
-    static bool isAdminLoggedIn(const Poco::Net::HTTPRequest& request, Poco::Net::HTTPResponse& response);
     static bool isAdminLoggedIn(const Poco::Net::HTTPRequest& request, http::Response& response);
 
     /// Authenticate the admin.
     static bool authenticateAdmin(const Poco::Net::HTTPBasicCredentials& credentials,
-                                  Poco::Net::HTTPResponse& response, std::string& jwtToken);
+                                  http::Response& response, std::string& jwtToken);
 
     static void handleRequest(const Poco::Net::HTTPRequest& request,
                               const RequestDetails& requestDetails,

--- a/wsd/FileServer.hpp
+++ b/wsd/FileServer.hpp
@@ -114,15 +114,18 @@ private:
                                           const RequestDetails& requestDetails);
 
     static ResourceAccessDetails preprocessFile(const Poco::Net::HTTPRequest& request,
+                                                http::Response& httpResponse,
                                                 const RequestDetails& requestDetails,
                                                 Poco::MemoryInputStream& message,
                                                 const std::shared_ptr<StreamSocket>& socket);
     static void preprocessWelcomeFile(const Poco::Net::HTTPRequest& request,
-                                      const RequestDetails &requestDetails,
+                                      http::Response& httpResponse,
+                                      const RequestDetails& requestDetails,
                                       Poco::MemoryInputStream& message,
                                       const std::shared_ptr<StreamSocket>& socket);
     static void preprocessAdminFile(const Poco::Net::HTTPRequest& request,
-                                    const RequestDetails &requestDetails,
+                                    http::Response& httpResponse,
+                                    const RequestDetails& requestDetails,
                                     const std::shared_ptr<StreamSocket>& socket);
 
     /// Construct a JSON to be accepted by the cool.html from a list like

--- a/wsd/FileServer.hpp
+++ b/wsd/FileServer.hpp
@@ -17,10 +17,18 @@
 #include <HttpRequest.hpp>
 #include <Socket.hpp>
 
-#include <Poco/MemoryStream.h>
-#include <Poco/Util/LayeredConfiguration.h>
-
 class RequestDetails;
+
+namespace Poco
+{
+namespace Net
+{
+class HTTPRequest;
+class HTTPResponse;
+class HTTPBasicCredentials;
+} // namespace Net
+
+} // namespace Poco
 
 /// Represents a file that is preprocessed for variable
 /// expansion/replacement before serving.

--- a/wsd/FileServer.hpp
+++ b/wsd/FileServer.hpp
@@ -128,10 +128,6 @@ private:
 
     static std::string cssVarsToStyle(const std::string& cssVars);
 
-    static std::string stringifyBoolFromConfig(const Poco::Util::LayeredConfiguration& config,
-                                               std::string propertyName,
-                                               bool defaultValue);
-
 public:
     FileServerRequestHandler(const std::string& root);
     ~FileServerRequestHandler();

--- a/wsd/FileServer.hpp
+++ b/wsd/FileServer.hpp
@@ -147,6 +147,10 @@ public:
     static bool isAdminLoggedIn(const Poco::Net::HTTPRequest& request, Poco::Net::HTTPResponse& response);
     static bool isAdminLoggedIn(const Poco::Net::HTTPRequest& request, http::Response& response);
 
+    /// Authenticate the admin.
+    static bool authenticateAdmin(const Poco::Net::HTTPBasicCredentials& credentials,
+                                  Poco::Net::HTTPResponse& response, std::string& jwtToken);
+
     static void handleRequest(const Poco::Net::HTTPRequest& request,
                               const RequestDetails& requestDetails,
                               Poco::MemoryInputStream& message,

--- a/wsd/FileServerUtil.cpp
+++ b/wsd/FileServerUtil.cpp
@@ -422,15 +422,4 @@ std::string FileServerRequestHandler::cssVarsToStyle(const std::string& cssVars)
     return previousStyle;
 }
 
-std::string FileServerRequestHandler::stringifyBoolFromConfig(
-                                                const Poco::Util::LayeredConfiguration& config,
-                                                std::string propertyName,
-                                                bool defaultValue)
-{
-    std::string value = "false";
-    if (config.getBool(propertyName, defaultValue))
-        value = "true";
-    return value;
-}
-
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/FileServerUtil.cpp
+++ b/wsd/FileServerUtil.cpp
@@ -13,7 +13,6 @@
 
 #include "FileServer.hpp"
 #include "StringVector.hpp"
-#include "Util.hpp"
 
 #include <Poco/JSON/Object.h>
 

--- a/wsd/ProxyRequestHandler.cpp
+++ b/wsd/ProxyRequestHandler.cpp
@@ -65,8 +65,6 @@ void ProxyRequestHandler::handleRequest(const std::string& relPath,
 
                         CacheFileHash[httpSession->getUrl()] = httpResponse;
 
-                        httpResponse->add("Server", http::getServerString());
-                        httpResponse->add("Date", Util::getHttpTimeNow());
                         socket->sendAndShutdown(*httpResponse);
                     }
                     else


### PR DESCRIPTION
- wsd: new isAdminLoggedIn that only verifies a valid token
- wsd: move stringifyBoolFromConfig to anonymous namespace
- wsd: include cleanup
- wsd: add authenticateAdmin helper
- wsd: simplify isAdminLoggedIn
- wsd: simplify jwtToken extraction
- wsd: parse config only once in Admin
- wsd: minor cleanup of Admin::getLogLines
- wsd: remove duplicate Server and Date headers
- wsd: remove sendWithDateAndAgent
- killpoco: use http::Response for Admin metrics
- killpoco: use http::Response in admin file serving
- wsd: reuse the response in FileServer
