### PR TITLE
config: remove scheme document background colors

### DIFF
--- a/coolkitconfig.xcu
+++ b/coolkitconfig.xcu
@@ -62,11 +62,6 @@
 <!-- Light Theme -->
 <item oor:path="/org.openoffice.Office.UI/ColorScheme/ColorSchemes">
     <node oor:name="Light" oor:op="replace">
-        <node oor:name="DocColor">
-            <prop oor:name="Color" oor:op="fuse">
-                <value>16777215</value>
-            </prop>
-        </node>
         <node oor:name="DocBoundaries">
             <prop oor:name="Color" oor:op="fuse">
                 <value>12632256</value>
@@ -381,11 +376,6 @@
 <!-- Dark Theme -->
 <item oor:path="/org.openoffice.Office.UI/ColorScheme/ColorSchemes">
     <node oor:name="Dark" oor:op="replace">
-        <node oor:name="DocColor">
-            <prop oor:name="Color" oor:op="fuse">
-                <value>1842204</value>
-            </prop>
-        </node>
         <node oor:name="DocBoundaries">
             <prop oor:name="Color" oor:op="fuse">
                 <value>8421504</value>


### PR DESCRIPTION
The desktop app writer, calc and impress does not change
the document background color when switch to "Dark".

If we change the color we should change all document property
styles and text background colors.

Change-Id: Ia7e192c2c21fc6e00d7e15de4f72a6300f5bf425
Signed-off-by: Henry Castro <hcastro@collabora.com>