### PR TITLE
clipboard: do no compare wth invalid metapath

### DIFF
--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -75,6 +75,8 @@ L.Clipboard = L.Class.extend({
 	getMetaPath: function(idx) {
 		if (!idx)
 			idx = 0;
+		if (this._accessKey[idx] === '')
+			return '';
 
 		var metaPath = '/cool/clipboard?WOPISrc=' + encodeURIComponent(this._map.options.doc) +
 			'&ServerId=' + app.socket.WSDServer.Id +
@@ -356,7 +358,7 @@ L.Clipboard = L.Class.extend({
 
 		// for the paste, we always prefer the internal LOK's copy/paste
 		if (preferInternal === true &&
-		    (meta.indexOf(id) >= 0 || meta.indexOf(idOld) >= 0))
+			((id !== '' && meta.indexOf(id) >= 0) || (idOld !== '' && meta.indexOf(idOld) >= 0)))
 		{
 			// Home from home: short-circuit internally.
 			window.app.console.log('short-circuit, internal paste');


### PR DESCRIPTION
Copying from a document, closing it, reopening it and then pasting
did nothing.

The short-circuit for internal paste gave a false positive.

Signed-off-by: Jaume Pujantell <jaume.pujantell@collabora.com>
Change-Id: Ib21faf270d2ed03af2954f79bee8c1efbb0fd0ca
