### PR TITLE
Fix iOS build error due to call to method not available on mobile

### DIFF
--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -4408,7 +4408,9 @@ int COOLWSD::innerMain()
 #endif
     }
 
+#if !MOBILEAPP
     COOLWSD::alertAllUsersInternal("close: shuttingdown");
+#endif
 
     // Lots of polls will stop; stop watching them first.
     SocketPoll::shutdownWatchdog();


### PR DESCRIPTION
Just an #ifdef for mobile platforms.