### PR TITLE
Rewrite desktopHelper.insertComment()

### DIFF
--- a/cypress_test/integration_tests/desktop/calc/annotation_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/annotation_spec.js
@@ -1,7 +1,6 @@
 /* global describe it require cy afterEach beforeEach */
 
 var helper = require('../../common/helper');
-var { insertMultipleComment, setupUIforCommentInsert, createComment } = require('../../common/desktop_helper');
 var desktopHelper = require('../../common/desktop_helper');
 
 describe(['tagdesktop'], 'Annotation Tests', function() {
@@ -18,7 +17,7 @@ describe(['tagdesktop'], 'Annotation Tests', function() {
 	});
 
 	it('Insert',function() {
-		insertMultipleComment('calc', 1, false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment();
 
 		cy.cGet('.cool-annotation').should('exist');
 		cy.cGet('#comment-container-1').then(function (element) {
@@ -30,7 +29,7 @@ describe(['tagdesktop'], 'Annotation Tests', function() {
 	});
 
 	it('Modify',function() {
-		insertMultipleComment('calc', 1, false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment();
 
 		cy.cGet('#comment-container-1').should('exist');
 
@@ -54,7 +53,7 @@ describe(['tagdesktop'], 'Annotation Tests', function() {
 	});
 
 	it('Reply should not be possible', function() {
-		insertMultipleComment('calc', 1, false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment();
 
 		cy.cGet('#comment-container-1').should('exist');
 
@@ -69,7 +68,7 @@ describe(['tagdesktop'], 'Annotation Tests', function() {
 	});
 
 	it('Remove',function() {
-		insertMultipleComment('calc', 1, false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment();
 
 		cy.cGet('#comment-container-1').should('exist');
 
@@ -99,8 +98,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 	});
 
 	it('Insert autosave',function() {
-		setupUIforCommentInsert('calc');
-		createComment('writer', 'Test Comment', false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment(undefined, false);
 		cy.cGet('#map').focus();
 		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
 		cy.cGet('.cool-annotation-edit.modify-annotation').should('be.visible');
@@ -113,12 +111,11 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 			element[0].style.display = '';
 		});
 		cy.cGet('#comment-container-1').trigger('mouseover');
-		cy.cGet('#annotation-content-area-1').should('have.text','Test Comment');
+		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
 	});
 
 	it('Insert autosave save',function() {
-		setupUIforCommentInsert('calc');
-		createComment('writer', 'Test Comment', false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment(undefined, false);
 		cy.cGet('#map').focus();
 		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
 		cy.cGet('.cool-annotation-edit.modify-annotation').should('be.visible');
@@ -130,7 +127,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		});
 		cy.cGet('.cool-annotation-autosavelabel').should('be.not.visible');
 		cy.cGet('#comment-container-1').trigger('mouseover');
-		cy.cGet('#annotation-content-area-1').should('have.text','Test Comment');
+		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
 
 		helper.closeDocument(testFileName, '');
 		helper.beforeAll(testFileName, 'calc', true, false, false, true);
@@ -140,12 +137,11 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 			element[0].style.display = '';
 		});
 		cy.cGet('#comment-container-1').trigger('mouseover');
-		cy.cGet('#annotation-content-area-1').should('have.text','Test Comment');
+		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
 	});
 
 	it('Insert autosave cancel',function() {
-		setupUIforCommentInsert('calc');
-		createComment('writer', 'Test Comment', false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment(undefined, false);
 		cy.cGet('#map').focus();
 		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
 		cy.cGet('.cool-annotation-edit.modify-annotation').should('be.visible');
@@ -159,7 +155,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 	});
 
 	it('Modify autosave',function() {
-		insertMultipleComment('calc', 1, false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment();
 
 		cy.cGet('#comment-container-1').should('exist');
 
@@ -188,7 +184,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 	});
 
 	it('Modify autosave save',function() {
-		insertMultipleComment('calc', 1, false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment();
 
 		cy.cGet('#comment-container-1').should('exist');
 
@@ -225,7 +221,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 	});
 
 	it('Modify autosave cancel',function() {
-		insertMultipleComment('calc', 1, false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment();
 
 		cy.cGet('#comment-container-1').should('exist');
 

--- a/cypress_test/integration_tests/desktop/draw/pdf_page_up_down_spec.js
+++ b/cypress_test/integration_tests/desktop/draw/pdf_page_up_down_spec.js
@@ -27,7 +27,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'PDF View Tests', function(
 	it.skip('PDF insert comment', { env: { 'pdf-view': true }, defaultCommandTimeout: 60000 }, function() {
 
 		// Insert some comment into the PDF.
-		desktopHelper.insertMultipleComment('draw', 1, false);
+		desktopHelper.insertComment();
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
 		cy.cGet('#annotation-content-area-1').should('contain','some text0');
 

--- a/cypress_test/integration_tests/desktop/impress/annotation_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/annotation_spec.js
@@ -3,13 +3,14 @@
 var desktopHelper = require('../../common/desktop_helper');
 var helper = require('../../common/helper');
 var { addSlide, changeSlide } = require('../../common/impress_helper');
-var { insertMultipleComment, setupUIforCommentInsert, createComment } = require('../../common/desktop_helper');
 
 describe(['tagdesktop'], 'Annotation Tests', function() {
 	var origTestFileName = 'comment_switching.odp';
 	var testFileName;
 
 	beforeEach(function() {
+		// Give more horizontal room so that comments do not fall off the right
+		// side of the screen, causing scrolling or hidden buttons
 		cy.viewport(1500, 600);
 		testFileName = helper.beforeAll(origTestFileName, 'impress');
 		desktopHelper.switchUIToNotebookbar();
@@ -27,18 +28,17 @@ describe(['tagdesktop'], 'Annotation Tests', function() {
 	});
 
 	it('Insert', function() {
-		insertMultipleComment('impress', 1, false, '#insert-insert-annotation-button');
+		desktopHelper.insertComment();
 		cy.cGet('.leaflet-marker-icon').should('exist');
 		cy.cGet('.cool-annotation-content > div').should('contain','some text');
 	});
 
 	it('Modify', function() {
-		insertMultipleComment('impress', 1, false, '#insert-insert-annotation-button');
+		desktopHelper.insertComment();
 		cy.cGet('.leaflet-marker-icon').should('exist');
 		cy.cGet('#annotation-content-area-1').should('contain','some text0');
 		cy.cGet('.cool-annotation-content-wrapper:visible .cool-annotation-menu').click();
 		cy.cGet('body').contains('.context-menu-item','Modify').click();
-		cy.cGet('#annotation-modify-textarea-1').type('{home}');
 		cy.cGet('#annotation-modify-textarea-1').type('some other text, ');
 		cy.cGet('#annotation-save-1').click();
 		cy.cGet('#annotation-content-area-1').should('contain','some other text, some text0');
@@ -46,7 +46,7 @@ describe(['tagdesktop'], 'Annotation Tests', function() {
 	});
 
 	it('Remove',function() {
-		insertMultipleComment('impress', 1, false, '#insert-insert-annotation-button');
+		desktopHelper.insertComment();
 		cy.cGet('.leaflet-marker-icon').should('exist');
 		cy.cGet('.cool-annotation-content > div').should('contain','some text');
 		cy.cGet('.cool-annotation-content-wrapper:visible .cool-annotation-menu').click();
@@ -55,7 +55,7 @@ describe(['tagdesktop'], 'Annotation Tests', function() {
 	});
 
 	it('Reply',function() {
-		insertMultipleComment('impress', 1, false, '#insert-insert-annotation-button');
+		desktopHelper.insertComment();
 		cy.cGet('.leaflet-marker-icon').should('exist');
 		cy.cGet('.cool-annotation-content > div').should('contain','some text');
 		cy.cGet('.cool-annotation-content-wrapper:visible .cool-annotation-menu').click();
@@ -70,6 +70,7 @@ describe(['tagdesktop'], 'Collapsed Annotation Tests', function() {
 	var testFileName = 'comment_switching.odp';
 
 	beforeEach(function() {
+		cy.viewport(1500, 600);
 		helper.beforeAll(testFileName, 'impress');
 		desktopHelper.switchUIToNotebookbar();
 
@@ -86,19 +87,18 @@ describe(['tagdesktop'], 'Collapsed Annotation Tests', function() {
 	});
 
 	it('Insert', function() {
-		insertMultipleComment('impress', 1, false, '#insert-insert-annotation-button');
+		desktopHelper.insertComment();
 		cy.cGet('.leaflet-marker-icon').should('exist');
 		cy.cGet('.cool-annotation-content > div').should('contain','some text');
 	});
 
 	it('Modify', function() {
-		insertMultipleComment('impress', 1, false, '#insert-insert-annotation-button');
+		desktopHelper.insertComment();
 		cy.cGet('.leaflet-marker-icon').should('exist');
 		cy.cGet('#annotation-content-area-1').should('contain','some text0');
 		cy.cGet('.cool-annotation-table .avatar-img').click();
 		cy.cGet('.cool-annotation-menu').click();
 		cy.cGet('body').contains('.context-menu-item','Modify').click();
-		cy.cGet('#annotation-modify-textarea-1').type('{home}');
 		cy.cGet('#annotation-modify-textarea-1').type('some other text, ');
 		cy.cGet('#annotation-save-1').click();
 		cy.cGet('#annotation-content-area-1').should('contain','some other text, some text0');
@@ -106,7 +106,7 @@ describe(['tagdesktop'], 'Collapsed Annotation Tests', function() {
 	});
 
 	it('Remove',function() {
-		insertMultipleComment('impress', 1, false, '#insert-insert-annotation-button');
+		desktopHelper.insertComment();
 		cy.cGet('.leaflet-marker-icon').should('exist');
 		cy.cGet('.cool-annotation-content > div').should('contain','some text');
 		cy.cGet('.cool-annotation-table .avatar-img').click();
@@ -116,7 +116,7 @@ describe(['tagdesktop'], 'Collapsed Annotation Tests', function() {
 	});
 
 	it('Reply',function() {
-		insertMultipleComment('impress', 1, false, '#insert-insert-annotation-button');
+		desktopHelper.insertComment();
 		cy.cGet('.leaflet-marker-icon').should('exist');
 		cy.cGet('.cool-annotation-content > div').should('contain','some text');
 		cy.cGet('.cool-annotation-table .avatar-img').click();
@@ -133,6 +133,7 @@ describe(['tagdesktop'], 'Comment Scrolling',function() {
 	var testFileName;
 
 	beforeEach(function() {
+		cy.viewport(1500, 600);
 		testFileName = helper.beforeAll(origTestFileName, 'impress');
 		desktopHelper.switchUIToNotebookbar();
 
@@ -146,15 +147,15 @@ describe(['tagdesktop'], 'Comment Scrolling',function() {
 
 	it('no comment or one comment', function() {
 		cy.cGet('.leaflet-control-scroll-down').should('not.exist');
-		insertMultipleComment('impress', 1, false, '#insert-insert-annotation-button');
+		desktopHelper.insertComment();
 		cy.cGet('.leaflet-marker-icon').should('exist');
 	});
 
-	it('omit slides without comments', function() {
+	it.only('omit slides without comments', function() {
 		//scroll up
-		insertMultipleComment('impress', 1, false, '#insert-insert-annotation-button');
+		desktopHelper.insertComment();
 		addSlide(2);
-		insertMultipleComment('impress', 1, false, '#insert-insert-annotation-button');
+		desktopHelper.insertComment();
 		helper.waitUntilIdle('.leaflet-control-scroll-up');
 		cy.cGet('.leaflet-control-scroll-up').should('be.visible');
 		cy.cGet('.leaflet-control-scroll-up').click().wait(300);
@@ -168,7 +169,8 @@ describe(['tagdesktop'], 'Comment Scrolling',function() {
 
 	it('switch to previous or next slide',function() {
 		addSlide(1);
-		insertMultipleComment('impress', 2, false, '#insert-insert-annotation-button');
+		desktopHelper.insertComment();
+		desktopHelper.insertComment();
 
 		//scroll up
 		addSlide(1);
@@ -206,8 +208,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 	});
 
 	it('Insert autosave', function() {
-		setupUIforCommentInsert('impress');
-		createComment('impress', 'Test Comment', false, '#insert-insert-annotation-button');
+		desktopHelper.insertComment(undefined, false);
 		cy.cGet('#map').focus();
 		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
 		cy.cGet('.cool-annotation-edit.modify-annotation').should('be.visible');
@@ -215,12 +216,11 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		helper.closeDocument(testFileName, '');
 		helper.beforeAll(testFileName, 'impress', true, false, false, true);
 		cy.cGet('.leaflet-marker-icon').should('exist');
-		cy.cGet('.cool-annotation-content > div').should('have.text','Test Comment');
+		cy.cGet('.cool-annotation-content > div').should('have.text','some text0');
 	});
 
 	it('Insert autosave save', function() {
-		setupUIforCommentInsert('impress');
-		createComment('impress', 'Test Comment', false, '#insert-insert-annotation-button');
+		desktopHelper.insertComment(undefined, false);
 		cy.cGet('#map').focus();
 		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
 		cy.cGet('.cool-annotation-edit.modify-annotation').should('be.visible');
@@ -228,17 +228,16 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('.cool-annotation-autosavelabel').should('be.not.visible');
 		cy.cGet('.cool-annotation-edit.modify-annotation').should('be.not.visible');
 		cy.cGet('.leaflet-marker-icon').should('exist');
-		cy.cGet('.cool-annotation-content > div').should('have.text','Test Comment');
+		cy.cGet('.cool-annotation-content > div').should('have.text','some text0');
 
 		helper.closeDocument(testFileName, '');
 		helper.beforeAll(testFileName, 'impress', true, false, false, true);
 		cy.cGet('.leaflet-marker-icon').should('exist');
-		cy.cGet('.cool-annotation-content > div').should('have.text','Test Comment');
+		cy.cGet('.cool-annotation-content > div').should('have.text','some text0');
 	});
 
 	it('Insert autosave cancel', function() {
-		setupUIforCommentInsert('impress');
-		createComment('impress', 'Test Comment', false, '#insert-insert-annotation-button');
+		desktopHelper.insertComment(undefined, false);
 		cy.cGet('#map').focus();
 		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
 		cy.cGet('.cool-annotation-edit.modify-annotation').should('be.visible');
@@ -255,12 +254,11 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 	});
 
 	it('Modify autosave', function() {
-		insertMultipleComment('impress', 1, false, '#insert-insert-annotation-button');
+		desktopHelper.insertComment();
 		cy.cGet('.leaflet-marker-icon').should('exist');
 		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
 		cy.cGet('.cool-annotation-content-wrapper:visible .cool-annotation-menu').click();
 		cy.cGet('body').contains('.context-menu-item','Modify').click();
-		cy.cGet('#annotation-modify-textarea-1').type('{home}');
 		cy.cGet('#annotation-modify-textarea-1').type('some other text, ');
 		cy.cGet('#map').focus();
 		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
@@ -273,12 +271,11 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 	});
 
 	it('Modify autosave save', function() {
-		insertMultipleComment('impress', 1, false, '#insert-insert-annotation-button');
+		desktopHelper.insertComment();
 		cy.cGet('.leaflet-marker-icon').should('exist');
 		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
 		cy.cGet('.cool-annotation-content-wrapper:visible .cool-annotation-menu').click();
 		cy.cGet('body').contains('.context-menu-item','Modify').click();
-		cy.cGet('#annotation-modify-textarea-1').type('{home}');
 		cy.cGet('#annotation-modify-textarea-1').type('some other text, ');
 		cy.cGet('#map').focus();
 		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
@@ -294,12 +291,11 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 	});
 
 	it('Modify autosave cancel', function() {
-		insertMultipleComment('impress', 1, false, '#insert-insert-annotation-button');
+		desktopHelper.insertComment();
 		cy.cGet('.leaflet-marker-icon').should('exist');
 		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
 		cy.cGet('.cool-annotation-content-wrapper:visible .cool-annotation-menu').click();
 		cy.cGet('body').contains('.context-menu-item','Modify').click();
-		cy.cGet('#annotation-modify-textarea-1').type('{home}');
 		cy.cGet('#annotation-modify-textarea-1').type('some other text, ');
 		cy.cGet('#map').focus();
 		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
@@ -315,7 +311,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 	});
 
 	it('Reply autosave',function() {
-		insertMultipleComment('impress', 1, false, '#insert-insert-annotation-button');
+		desktopHelper.insertComment();
 		cy.cGet('.leaflet-marker-icon').should('exist');
 		cy.cGet('.cool-annotation-content > div').should('have.text','some text0');
 		cy.cGet('.cool-annotation-content-wrapper:visible .cool-annotation-menu').click();
@@ -334,7 +330,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 	});
 
 	it('Reply autosave save',function() {
-		insertMultipleComment('impress', 1, false, '#insert-insert-annotation-button');
+		desktopHelper.insertComment();
 		cy.cGet('.leaflet-marker-icon').should('exist');
 		cy.cGet('.cool-annotation-content > div').should('have.text','some text0');
 		cy.cGet('.cool-annotation-content-wrapper:visible .cool-annotation-menu').click();
@@ -358,7 +354,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 	});
 
 	it('Reply autosave cancel',function() {
-		insertMultipleComment('impress', 1, false, '#insert-insert-annotation-button');
+		desktopHelper.insertComment();
 		cy.cGet('.leaflet-marker-icon').should('exist');
 		cy.cGet('.cool-annotation-content > div').should('have.text','some text0');
 		cy.cGet('.cool-annotation-content-wrapper:visible .cool-annotation-menu').click();

--- a/cypress_test/integration_tests/desktop/impress/slide_operations_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/slide_operations_spec.js
@@ -47,7 +47,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Slide operations', functio
 	it('Duplicate slide', function() {
 		// Also check if comments are getting duplicated
 		cy.cGet('#options-modify-page').click();
-		desktopHelper.insertMultipleComment('impress', 1, false, '#insert-insert-annotation-button');
+		desktopHelper.insertComment();
 		cy.cGet('#annotation-content-area-1').should('include.text', 'some text0');
 		helper.clickOnIdle('#tb_presentation-toolbar_item_duplicatepage');
 

--- a/cypress_test/integration_tests/desktop/writer/annotation_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/annotation_spec.js
@@ -1,7 +1,7 @@
 /* global describe it cy require afterEach beforeEach */
 
 var helper = require('../../common/helper');
-var { insertMultipleComment, selectZoomLevel, setupUIforCommentInsert, createComment } = require('../../common/desktop_helper');
+var { selectZoomLevel } = require('../../common/desktop_helper');
 var desktopHelper = require('../../common/desktop_helper');
 
 describe(['tagdesktop'], 'Annotation Tests', function() {
@@ -21,14 +21,14 @@ describe(['tagdesktop'], 'Annotation Tests', function() {
 	});
 
 	it('Insert', function() {
-		insertMultipleComment('writer', 1, false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment();
 
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
 		cy.cGet('#annotation-content-area-1').should('contain','some text0');
 	});
 
 	it('Modify', function() {
-		insertMultipleComment('writer', 1, false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment();
 
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
 		cy.cGet('#annotation-content-area-1').should('contain','some text0');
@@ -41,7 +41,7 @@ describe(['tagdesktop'], 'Annotation Tests', function() {
 	});
 
 	it('Reply', function() {
-		insertMultipleComment('writer', 1, false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment();
 
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
 		cy.cGet('#annotation-content-area-1').should('contain','some text');
@@ -53,7 +53,7 @@ describe(['tagdesktop'], 'Annotation Tests', function() {
 	});
 
 	it('Remove', function() {
-		insertMultipleComment('writer', 1, false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment();
 
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
 		cy.cGet('.cool-annotation-content > div').should('contain','some text');
@@ -78,14 +78,14 @@ describe(['tagdesktop'], 'Collapsed Annotation Tests', function() {
 	});
 
 	it('Insert', function() {
-		insertMultipleComment('writer', 1, false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment();
 
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
 		cy.cGet('#annotation-content-area-1').should('contain','some text0');
 	});
 
 	it('Modify', function() {
-		insertMultipleComment('writer', 1, false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment();
 
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
 		cy.cGet('#annotation-content-area-1').should('contain','some text0');
@@ -99,7 +99,7 @@ describe(['tagdesktop'], 'Collapsed Annotation Tests', function() {
 	});
 
 	it('Reply', function() {
-		insertMultipleComment('writer', 1, false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment();
 
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
 		cy.cGet('#annotation-content-area-1').should('contain','some text');
@@ -112,7 +112,7 @@ describe(['tagdesktop'], 'Collapsed Annotation Tests', function() {
 	});
 
 	it('Remove', function() {
-		insertMultipleComment('writer', 1, false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment();
 
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
 		cy.cGet('.cool-annotation-content > div').should('contain','some text');
@@ -142,8 +142,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 	});
 
 	it('Insert autosave', function() {
-		setupUIforCommentInsert('writer');
-		createComment('writer', 'Test Comment', false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment(undefined, false);
 		cy.cGet('#map').focus();
 		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
 		cy.cGet('.cool-annotation-edit.modify-annotation').should('be.visible');
@@ -151,28 +150,26 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		helper.closeDocument(testFileName, '');
 		helper.beforeAll(testFileName, 'writer', true, false, false, true);
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
-		cy.cGet('#annotation-content-area-1').should('have.text','Test Comment');
+		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
 	});
 
 	it('Insert autosave save', function() {
-		setupUIforCommentInsert('writer');
-		createComment('writer', 'Test Comment', false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment(undefined, false);
 		cy.cGet('#map').focus();
 		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
 		cy.cGet('.cool-annotation-edit.modify-annotation').should('be.visible');
 		cy.cGet('#annotation-save-1').click();
-		cy.cGet('#annotation-content-area-1').should('have.text','Test Comment');
+		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
 		cy.cGet('.cool-annotation-autosavelabel').should('be.not.visible');
 
 		helper.closeDocument(testFileName, '');
 		helper.beforeAll(testFileName, 'writer', true, false, false, true);
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
-		cy.cGet('#annotation-content-area-1').should('have.text','Test Comment');
+		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
 	});
 
 	it('Insert autosave cancel', function() {
-		setupUIforCommentInsert('writer');
-		createComment('writer', 'Test Comment', false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment(undefined, false);
 		cy.cGet('#map').focus();
 		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
 		cy.cGet('.cool-annotation-edit.modify-annotation').should('be.visible');
@@ -187,7 +184,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 	});
 
 	it('Modify autosave', function() {
-		insertMultipleComment('writer', 1, false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment();
 
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
 		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
@@ -205,7 +202,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 	});
 
 	it('Modify autosave save', function() {
-		insertMultipleComment('writer', 1, false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment();
 
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
 		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
@@ -226,7 +223,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 	});
 
 	it('Modify autosave cancel', function() {
-		insertMultipleComment('writer', 1, false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment();
 
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
 		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
@@ -248,7 +245,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 	});
 
 	it('Reply autosave', function() {
-		insertMultipleComment('writer', 1, false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment();
 
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
 		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
@@ -266,7 +263,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 	});
 
 	it('Reply autosave save', function() {
-		insertMultipleComment('writer', 1, false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment();
 
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
 		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
@@ -290,7 +287,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 	});
 
 	it('Reply autosave cancel', function() {
-		insertMultipleComment('writer', 1, false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment();
 
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
 		cy.cGet('#annotation-content-area-1').should('have.text','some text0');

--- a/cypress_test/integration_tests/multiuser/calc/annotation_spec.js
+++ b/cypress_test/integration_tests/multiuser/calc/annotation_spec.js
@@ -1,7 +1,6 @@
 /* global describe it require cy afterEach beforeEach */
 
 var helper = require('../../common/helper');
-var { insertMultipleComment, setupUIforCommentInsert, createComment } = require('../../common/desktop_helper');
 var desktopHelper = require('../../common/desktop_helper');
 
 describe(['tagmultiuser'], 'Multiuser Annotation Tests', function() {
@@ -19,7 +18,7 @@ describe(['tagmultiuser'], 'Multiuser Annotation Tests', function() {
 
 	it('Insert',function() {
 		cy.cSetActiveFrame('#iframe1');
-		insertMultipleComment('calc', 1, false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment();
 
 		cy.cGet('.cool-annotation').should('exist');
 		cy.cGet('#comment-container-1').then(function (element) {
@@ -41,7 +40,7 @@ describe(['tagmultiuser'], 'Multiuser Annotation Tests', function() {
 
 	it('Modify',function() {
 		cy.cSetActiveFrame('#iframe1');
-		insertMultipleComment('calc', 1, false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment();
 
 		cy.cGet('#comment-container-1').should('exist');
 
@@ -75,7 +74,7 @@ describe(['tagmultiuser'], 'Multiuser Annotation Tests', function() {
 
 	it('Remove',function() {
 		cy.cSetActiveFrame('#iframe1');
-		insertMultipleComment('calc', 1, false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment();
 
 		cy.cGet('#comment-container-1').should('exist');
 
@@ -109,8 +108,7 @@ describe(['tagmultiuser'], 'Multiuser Annotation Autosave Tests', function() {
 
 	it('Insert autosave',function() {
 		cy.cSetActiveFrame('#iframe1');
-		setupUIforCommentInsert('calc');
-		createComment('writer', 'Test Comment', false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment(undefined, false);
 		cy.cGet('#map').focus();
 		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
 		cy.cGet('.cool-annotation-edit.modify-annotation').should('be.visible');
@@ -122,13 +120,12 @@ describe(['tagmultiuser'], 'Multiuser Annotation Autosave Tests', function() {
 			element[0].style.display = '';
 		});
 		cy.cGet('#comment-container-1').trigger('mouseover');
-		cy.cGet('#annotation-content-area-1').should('have.text','Test Comment');
+		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
 	});
 
 	it('Insert autosave save',function() {
 		cy.cSetActiveFrame('#iframe1');
-		setupUIforCommentInsert('calc');
-		createComment('writer', 'Test Comment', false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment(undefined, false);
 		cy.cGet('#map').focus();
 		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
 		cy.cGet('.cool-annotation-edit.modify-annotation').should('be.visible');
@@ -140,7 +137,7 @@ describe(['tagmultiuser'], 'Multiuser Annotation Autosave Tests', function() {
 		});
 		cy.cGet('.cool-annotation-autosavelabel').should('be.not.visible');
 		cy.cGet('#comment-container-1').trigger('mouseover');
-		cy.cGet('#annotation-content-area-1').should('have.text','Test Comment');
+		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
 
 		cy.cSetActiveFrame('#iframe2');
 		cy.cGet('.cool-annotation').should('exist');
@@ -149,13 +146,12 @@ describe(['tagmultiuser'], 'Multiuser Annotation Autosave Tests', function() {
 			element[0].style.display = '';
 		});
 		cy.cGet('#comment-container-1').trigger('mouseover');
-		cy.cGet('#annotation-content-area-1').should('have.text','Test Comment');
+		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
 	});
 
 	it('Insert autosave cancel',function() {
 		cy.cSetActiveFrame('#iframe1');
-		setupUIforCommentInsert('calc');
-		createComment('writer', 'Test Comment', false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment(undefined, false);
 		cy.cGet('#map').focus();
 		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
 		cy.cGet('.cool-annotation-edit.modify-annotation').should('be.visible');
@@ -169,7 +165,7 @@ describe(['tagmultiuser'], 'Multiuser Annotation Autosave Tests', function() {
 
 	it('Modify autosave',function() {
 		cy.cSetActiveFrame('#iframe1');
-		insertMultipleComment('calc', 1, false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment();
 
 		cy.cGet('#comment-container-1').should('exist');
 
@@ -198,7 +194,7 @@ describe(['tagmultiuser'], 'Multiuser Annotation Autosave Tests', function() {
 
 	it('Modify autosave save',function() {
 		cy.cSetActiveFrame('#iframe1');
-		insertMultipleComment('calc', 1, false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment();
 
 		cy.cGet('#comment-container-1').should('exist');
 
@@ -235,7 +231,7 @@ describe(['tagmultiuser'], 'Multiuser Annotation Autosave Tests', function() {
 
 	it('Modify autosave cancel',function() {
 		cy.cSetActiveFrame('#iframe1');
-		insertMultipleComment('calc', 1, false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment();
 
 		cy.cGet('#comment-container-1').should('exist');
 

--- a/cypress_test/integration_tests/multiuser/impress/annotation_spec.js
+++ b/cypress_test/integration_tests/multiuser/impress/annotation_spec.js
@@ -2,7 +2,6 @@
 
 var desktopHelper = require('../../common/desktop_helper');
 var helper = require('../../common/helper');
-var { insertMultipleComment, setupUIforCommentInsert, createComment } = require('../../common/desktop_helper');
 
 describe(['tagmultiuser'], 'Multiuser Annotation Tests', function() {
 	var origTestFileName = 'comment_switching.odp';
@@ -35,7 +34,7 @@ describe(['tagmultiuser'], 'Multiuser Annotation Tests', function() {
 
 	it('Insert', function() {
 		cy.cSetActiveFrame('#iframe1');
-		insertMultipleComment('impress', 1, false, '#insert-insert-annotation-button');
+		desktopHelper.insertComment();
 		cy.cGet('.leaflet-marker-icon').should('exist');
 		cy.cGet('.cool-annotation-content > div').should('contain','some text');
 
@@ -46,7 +45,7 @@ describe(['tagmultiuser'], 'Multiuser Annotation Tests', function() {
 
 	it('Modify', function() {
 		cy.cSetActiveFrame('#iframe1');
-		insertMultipleComment('impress', 1, false, '#insert-insert-annotation-button');
+		desktopHelper.insertComment();
 		cy.cGet('.leaflet-marker-icon').should('exist');
 		cy.cGet('#annotation-content-area-1').should('contain','some text0');
 		cy.cGet('.cool-annotation-content-wrapper:visible .cool-annotation-menu').click();
@@ -64,7 +63,7 @@ describe(['tagmultiuser'], 'Multiuser Annotation Tests', function() {
 
 	it('Remove',function() {
 		cy.cSetActiveFrame('#iframe1');
-		insertMultipleComment('impress', 1, false, '#insert-insert-annotation-button');
+		desktopHelper.insertComment();
 		cy.cGet('.leaflet-marker-icon').should('exist');
 		cy.cGet('.cool-annotation-content > div').should('contain','some text');
 		cy.cGet('.cool-annotation-content-wrapper:visible .cool-annotation-menu').click();
@@ -77,7 +76,7 @@ describe(['tagmultiuser'], 'Multiuser Annotation Tests', function() {
 
 	it('Reply',function() {
 		cy.cSetActiveFrame('#iframe1');
-		insertMultipleComment('impress', 1, false, '#insert-insert-annotation-button');
+		desktopHelper.insertComment();
 		cy.cGet('.leaflet-marker-icon').should('exist');
 		cy.cGet('.cool-annotation-content > div').should('contain','some text');
 		cy.cGet('.cool-annotation-content-wrapper:visible .cool-annotation-menu').click();
@@ -120,7 +119,7 @@ describe(['tagmultiuser'], 'Multiuser Collapsed Annotation Tests', function() {
 
 	it('Insert', function() {
 		cy.cSetActiveFrame('#iframe1');
-		insertMultipleComment('impress', 1, false, '#insert-insert-annotation-button');
+		desktopHelper.insertComment();
 		cy.cGet('.leaflet-marker-icon').should('exist');
 		cy.cGet('.cool-annotation-content > div').should('contain','some text');
 
@@ -131,7 +130,7 @@ describe(['tagmultiuser'], 'Multiuser Collapsed Annotation Tests', function() {
 
 	it('Modify', function() {
 		cy.cSetActiveFrame('#iframe1');
-		insertMultipleComment('impress', 1, false, '#insert-insert-annotation-button');
+		desktopHelper.insertComment();
 		cy.cGet('.leaflet-marker-icon').should('exist');
 		cy.cGet('#annotation-content-area-1').should('contain','some text0');
 		cy.cGet('.cool-annotation-table .avatar-img').click();
@@ -150,7 +149,7 @@ describe(['tagmultiuser'], 'Multiuser Collapsed Annotation Tests', function() {
 
 	it('Remove',function() {
 		cy.cSetActiveFrame('#iframe1');
-		insertMultipleComment('impress', 1, false, '#insert-insert-annotation-button');
+		desktopHelper.insertComment();
 		cy.cGet('.leaflet-marker-icon').should('exist');
 		cy.cGet('.cool-annotation-content > div').should('contain','some text');
 		cy.cGet('.cool-annotation-table .avatar-img').click();
@@ -164,7 +163,7 @@ describe(['tagmultiuser'], 'Multiuser Collapsed Annotation Tests', function() {
 
 	it('Reply',function() {
 		cy.cSetActiveFrame('#iframe1');
-		insertMultipleComment('impress', 1, false, '#insert-insert-annotation-button');
+		desktopHelper.insertComment();
 		cy.cGet('.leaflet-marker-icon').should('exist');
 		cy.cGet('.cool-annotation-content > div').should('contain','some text');
 		cy.cGet('.cool-annotation-table .avatar-img').click();
@@ -209,21 +208,19 @@ describe(['tagmultiuser'], 'Multiuser Annotation Autosave Tests', function() {
 
 	it('Insert autosave', function() {
 		cy.cSetActiveFrame('#iframe1');
-		setupUIforCommentInsert('impress');
-		createComment('impress', 'Test Comment', false, '#insert-insert-annotation-button');
+		desktopHelper.insertComment(undefined, false);
 		cy.cGet('#map').focus();
 		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
 		cy.cGet('.cool-annotation-edit.modify-annotation').should('be.visible');
 
 		cy.cSetActiveFrame('#iframe2');
 		cy.cGet('.leaflet-marker-icon').should('exist');
-		cy.cGet('.cool-annotation-content > div').should('have.text','Test Comment');
+		cy.cGet('.cool-annotation-content > div').should('have.text','some text0');
 	});
 
 	it('Insert autosave save', function() {
 		cy.cSetActiveFrame('#iframe1');
-		setupUIforCommentInsert('impress');
-		createComment('impress', 'Test Comment', false, '#insert-insert-annotation-button');
+		desktopHelper.insertComment(undefined, false);
 		cy.cGet('#map').focus();
 		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
 		cy.cGet('.cool-annotation-edit.modify-annotation').should('be.visible');
@@ -231,17 +228,16 @@ describe(['tagmultiuser'], 'Multiuser Annotation Autosave Tests', function() {
 		cy.cGet('.cool-annotation-autosavelabel').should('be.not.visible');
 		cy.cGet('.cool-annotation-edit.modify-annotation').should('be.not.visible');
 		cy.cGet('.leaflet-marker-icon').should('exist');
-		cy.cGet('.cool-annotation-content > div').should('have.text','Test Comment');
+		cy.cGet('.cool-annotation-content > div').should('have.text','some text0');
 
 		cy.cSetActiveFrame('#iframe2');
 		cy.cGet('.leaflet-marker-icon').should('exist');
-		cy.cGet('.cool-annotation-content > div').should('have.text','Test Comment');
+		cy.cGet('.cool-annotation-content > div').should('have.text','some text0');
 	});
 
 	it('Insert autosave cancel', function() {
 		cy.cSetActiveFrame('#iframe1');
-		setupUIforCommentInsert('impress');
-		createComment('impress', 'Test Comment', false, '#insert-insert-annotation-button');
+		desktopHelper.insertComment(undefined, false);
 		cy.cGet('#map').focus();
 		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
 		cy.cGet('.cool-annotation-edit.modify-annotation').should('be.visible');
@@ -258,7 +254,7 @@ describe(['tagmultiuser'], 'Multiuser Annotation Autosave Tests', function() {
 
 	it('Modify autosave', function() {
 		cy.cSetActiveFrame('#iframe1');
-		insertMultipleComment('impress', 1, false, '#insert-insert-annotation-button');
+		desktopHelper.insertComment();
 		cy.cGet('.leaflet-marker-icon').should('exist');
 		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
 		cy.cGet('.cool-annotation-content-wrapper:visible .cool-annotation-menu').click();
@@ -276,7 +272,7 @@ describe(['tagmultiuser'], 'Multiuser Annotation Autosave Tests', function() {
 
 	it('Modify autosave save', function() {
 		cy.cSetActiveFrame('#iframe1');
-		insertMultipleComment('impress', 1, false, '#insert-insert-annotation-button');
+		desktopHelper.insertComment();
 		cy.cGet('.leaflet-marker-icon').should('exist');
 		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
 		cy.cGet('.cool-annotation-content-wrapper:visible .cool-annotation-menu').click();
@@ -297,7 +293,7 @@ describe(['tagmultiuser'], 'Multiuser Annotation Autosave Tests', function() {
 
 	it('Modify autosave cancel', function() {
 		cy.cSetActiveFrame('#iframe1');
-		insertMultipleComment('impress', 1, false, '#insert-insert-annotation-button');
+		desktopHelper.insertComment();
 		cy.cGet('.leaflet-marker-icon').should('exist');
 		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
 		cy.cGet('.cool-annotation-content-wrapper:visible .cool-annotation-menu').click();
@@ -318,7 +314,7 @@ describe(['tagmultiuser'], 'Multiuser Annotation Autosave Tests', function() {
 
 	it('Reply autosave',function() {
 		cy.cSetActiveFrame('#iframe1');
-		insertMultipleComment('impress', 1, false, '#insert-insert-annotation-button');
+		desktopHelper.insertComment();
 		cy.cGet('.leaflet-marker-icon').should('exist');
 		cy.cGet('.cool-annotation-content > div').should('have.text','some text0');
 		cy.cGet('.cool-annotation-content-wrapper:visible .cool-annotation-menu').click();
@@ -337,7 +333,7 @@ describe(['tagmultiuser'], 'Multiuser Annotation Autosave Tests', function() {
 
 	it('Reply autosave save',function() {
 		cy.cSetActiveFrame('#iframe1');
-		insertMultipleComment('impress', 1, false, '#insert-insert-annotation-button');
+		desktopHelper.insertComment();
 		cy.cGet('.leaflet-marker-icon').should('exist');
 		cy.cGet('.cool-annotation-content > div').should('have.text','some text0');
 		cy.cGet('.cool-annotation-content-wrapper:visible .cool-annotation-menu').click();
@@ -361,7 +357,7 @@ describe(['tagmultiuser'], 'Multiuser Annotation Autosave Tests', function() {
 
 	it('Reply autosave cancel',function() {
 		cy.cSetActiveFrame('#iframe1');
-		insertMultipleComment('impress', 1, false, '#insert-insert-annotation-button');
+		desktopHelper.insertComment();
 		cy.cGet('.leaflet-marker-icon').should('exist');
 		cy.cGet('.cool-annotation-content > div').should('have.text','some text0');
 		cy.cGet('.cool-annotation-content-wrapper:visible .cool-annotation-menu').click();

--- a/cypress_test/integration_tests/multiuser/writer/annotation_spec.js
+++ b/cypress_test/integration_tests/multiuser/writer/annotation_spec.js
@@ -1,7 +1,7 @@
 /* global describe it cy beforeEach require afterEach*/
 
 var helper = require('../../common/helper');
-var { insertMultipleComment, selectZoomLevel, setupUIforCommentInsert, createComment } = require('../../common/desktop_helper');
+var { selectZoomLevel } = require('../../common/desktop_helper');
 var desktopHelper = require('../../common/desktop_helper');
 
 describe(['tagmultiuser'], 'Multiuser Annotation Test', function () {
@@ -26,7 +26,7 @@ describe(['tagmultiuser'], 'Multiuser Annotation Test', function () {
 
 	it('Insert', function() {
 		cy.cSetActiveFrame('#iframe1');
-		insertMultipleComment('writer', 1, false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment();
 
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
 		cy.cGet('#annotation-content-area-1').should('contain','some text0');
@@ -38,7 +38,7 @@ describe(['tagmultiuser'], 'Multiuser Annotation Test', function () {
 
 	it('Modify', function() {
 		cy.cSetActiveFrame('#iframe1');
-		insertMultipleComment('writer', 1, false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment();
 
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
 		cy.cGet('#annotation-content-area-1').should('contain','some text0');
@@ -56,7 +56,7 @@ describe(['tagmultiuser'], 'Multiuser Annotation Test', function () {
 
 	it('Reply', function() {
 		cy.cSetActiveFrame('#iframe1');
-		insertMultipleComment('writer', 1, false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment();
 
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
 		cy.cGet('#annotation-content-area-1').should('contain','some text');
@@ -72,7 +72,7 @@ describe(['tagmultiuser'], 'Multiuser Annotation Test', function () {
 
 	it('Remove', function() {
 		cy.cSetActiveFrame('#iframe1');
-		insertMultipleComment('writer', 1, false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment();
 
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
 		cy.cGet('.cool-annotation-content > div').should('contain','some text');
@@ -103,7 +103,7 @@ describe(['tagmultiuser'], 'Multiuser Collapsed Annotation Tests', function() {
 	it('Insert', function() {
 		cy.cSetActiveFrame('#iframe1');
 		helper.typeIntoDocument('Hello World');
-		insertMultipleComment('writer', 1, false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment();
 
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
 		cy.cGet('#annotation-content-area-1').should('contain','some text0');
@@ -116,7 +116,7 @@ describe(['tagmultiuser'], 'Multiuser Collapsed Annotation Tests', function() {
 	it('Modify', function() {
 		cy.cSetActiveFrame('#iframe1');
 		helper.typeIntoDocument('Hello World');
-		insertMultipleComment('writer', 1, false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment();
 
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
 		cy.cGet('#annotation-content-area-1').should('contain','some text0');
@@ -136,7 +136,7 @@ describe(['tagmultiuser'], 'Multiuser Collapsed Annotation Tests', function() {
 	it('Reply', function() {
 		cy.cSetActiveFrame('#iframe1');
 		helper.typeIntoDocument('Hello World');
-		insertMultipleComment('writer', 1, false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment();
 
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
 		cy.cGet('#annotation-content-area-1').should('contain','some text');
@@ -156,7 +156,7 @@ describe(['tagmultiuser'], 'Multiuser Collapsed Annotation Tests', function() {
 	it('Remove', function() {
 		cy.cSetActiveFrame('#iframe1');
 		helper.typeIntoDocument('Hello World');
-		insertMultipleComment('writer', 1, false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment();
 
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
 		cy.cGet('.cool-annotation-content > div').should('contain','some text');
@@ -194,37 +194,34 @@ describe(['tagmultiuser'], 'Multiuser Annotation Autosave Tests', function() {
 
 	it('Insert autosave', function() {
 		cy.cSetActiveFrame('#iframe1');
-		setupUIforCommentInsert('writer');
-		createComment('writer', 'Test Comment', false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment(undefined, false);
 		cy.cGet('#map').focus();
 		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
 		cy.cGet('.cool-annotation-edit.modify-annotation').should('be.visible');
 
 		cy.cSetActiveFrame('#iframe2');
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
-		cy.cGet('#annotation-content-area-1').should('have.text','Test Comment');
+		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
 	});
 
 	it('Insert autosave save', function() {
 		cy.cSetActiveFrame('#iframe1');
-		setupUIforCommentInsert('writer');
-		createComment('writer', 'Test Comment', false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment(undefined, false);
 		cy.cGet('#map').focus();
 		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
 		cy.cGet('.cool-annotation-edit.modify-annotation').should('be.visible');
 		cy.cGet('#annotation-save-1').click();
-		cy.cGet('#annotation-content-area-1').should('have.text','Test Comment');
+		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
 		cy.cGet('.cool-annotation-autosavelabel').should('be.not.visible');
 
 		cy.cSetActiveFrame('#iframe2');
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
-		cy.cGet('#annotation-content-area-1').should('have.text','Test Comment');
+		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
 	});
 
 	it('Insert autosave cancel', function() {
 		cy.cSetActiveFrame('#iframe1');
-		setupUIforCommentInsert('writer');
-		createComment('writer', 'Test Comment', false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment(undefined, false);
 		cy.cGet('#map').focus();
 		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
 		cy.cGet('.cool-annotation-edit.modify-annotation').should('be.visible');
@@ -239,7 +236,7 @@ describe(['tagmultiuser'], 'Multiuser Annotation Autosave Tests', function() {
 
 	it('Modify autosave', function() {
 		cy.cSetActiveFrame('#iframe1');
-		insertMultipleComment('writer', 1, false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment();
 
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
 		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
@@ -257,7 +254,7 @@ describe(['tagmultiuser'], 'Multiuser Annotation Autosave Tests', function() {
 
 	it('Modify autosave save', function() {
 		cy.cSetActiveFrame('#iframe1');
-		insertMultipleComment('writer', 1, false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment();
 
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
 		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
@@ -278,7 +275,7 @@ describe(['tagmultiuser'], 'Multiuser Annotation Autosave Tests', function() {
 
 	it('Modify autosave cancel', function() {
 		cy.cSetActiveFrame('#iframe1');
-		insertMultipleComment('writer', 1, false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment();
 
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
 		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
@@ -300,7 +297,7 @@ describe(['tagmultiuser'], 'Multiuser Annotation Autosave Tests', function() {
 
 	it('Reply autosave', function() {
 		cy.cSetActiveFrame('#iframe1');
-		insertMultipleComment('writer', 1, false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment();
 
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
 		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
@@ -318,7 +315,7 @@ describe(['tagmultiuser'], 'Multiuser Annotation Autosave Tests', function() {
 
 	it('Reply autosave save', function() {
 		cy.cSetActiveFrame('#iframe1');
-		insertMultipleComment('writer', 1, false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment();
 
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
 		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
@@ -342,7 +339,7 @@ describe(['tagmultiuser'], 'Multiuser Annotation Autosave Tests', function() {
 
 	it('Reply autosave cancel', function() {
 		cy.cSetActiveFrame('#iframe1');
-		insertMultipleComment('writer', 1, false, '[id=insert-insert-annotation]');
+		desktopHelper.insertComment();
 
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
 		cy.cGet('#annotation-content-area-1').should('have.text','some text0');


### PR DESCRIPTION
The annotation tests have always been very flaky and very hard to debug. This should make them simpler and more stable.

Replace four helper functions (insertMultipleComment setupUIforCommentInsert createComment saveComment) with one (insertComment)
Simplify code flow
Remove unneeded docType conditionals
Remove unneded arguments from every call
Use force click to remove extra toolbar clicks
Add more relevant assertions

Apologies for the hard to follow diff in desktop_helper.js because it matched on a random `else`.

The diff in the spec files is all like this:
```
- insertMultipleComment('calc', 1, false, '[id=insert-insert-annotation]');
+ desktopHelper.insertComment();
```

except for the autosave tests, which do not click the save button:
```
- setupUIforCommentInsert('calc');
- createComment('writer', 'Test Comment', false, '[id=insert-insert-annotation]');
+ desktopHelper.insertComment(undefined, false);

- cy.cGet('#annotation-content-area-1').should('have.text','Test Comment');
+ cy.cGet('#annotation-content-area-1').should('have.text','some text0');
```

Change-Id: Ia4bc4ac964fd0ee754a481843d55682b87b63086
