### PR TITLE
accessebility: replace `span` tag with header tag in modal(js dialog) title

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -819,6 +819,7 @@ nav.spreadsheet-color-indicator ~ #sidebar-dock-wrapper {
 
 .ui-dialog-title {
 	min-height: 1em;
+	font-size: var(--header-font-size);
 }
 
 .lokdialog_container.ui-dialog.ui-widget-content {

--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -262,7 +262,7 @@ L.Control.JSDialog = L.Control.extend({
 
 		if (instance.haveTitlebar) {
 			instance.titlebar = L.DomUtil.create('div', 'ui-dialog-titlebar ui-corner-all ui-widget-header ui-helper-clearfix', instance.form);
-			var title = L.DomUtil.create('span', 'ui-dialog-title', instance.titlebar);
+			var title = L.DomUtil.create('h2', 'ui-dialog-title', instance.titlebar);
 			title.innerText = instance.title;
 			instance.titleCloseButton = L.DomUtil.create('button', 'ui-button ui-corner-all ui-widget ui-button-icon-only ui-dialog-titlebar-close', instance.titlebar);
 			instance.titleCloseButton.setAttribute('aria-label', _('Close dialog'));


### PR DESCRIPTION

 - The title of the modal window is currently marked with a `span` tag instead of an appropriate heading tag (such as `h2`, `h3`, etc.).
 - This affects the semantic structure of the page and makes it difficult for users with assistive technologies like screen readers to effectively navigate the page.
- The modal title is not recognized as such, which hinders orientation and understanding of the content.

- Solution:
   - replace `span` tag with `h2`(header tag) for `ui-dialog-title`. 
   - to make font-size consistent, added CSS rule for `ui-dialog-title`.

Note: this will change all JS dialog title with header tags (not only specific to writer but also effected for every document type)

Change-Id: I5a1e276c3a129400aa5834e186a263db95f01833