### PR TITLE
fixed js console error

### DIFF
--- a/browser/src/layer/vector/Path.Transform.js
+++ b/browser/src/layer/vector/Path.Transform.js
@@ -1433,6 +1433,8 @@ L.Handler.PathTransform = L.Handler.extend({
 
 		this._rect._transform(matrix);
 		rect._updatePath();
+		if (!this._rect._map)
+			this._rect._map = rect._map = this._map;
 		rect._project();
 	},
 


### PR DESCRIPTION
problem:
in impress get into textbox editing and then try to drag and move text box, you get js error because map is null

regression from 9cf64b0726a5b8850db02363f125c9a8d285e4e4


Change-Id: I586c5f242241aa50f62c49371c994aeb7c370525


* Target version: master 


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

