### PR TITLE
Use escape in removeShapeSelection

### DIFF
--- a/cypress_test/integration_tests/common/impress_helper.js
+++ b/cypress_test/integration_tests/common/impress_helper.js
@@ -120,11 +120,13 @@ function removeShapeSelection() {
 				var XPos = items[0].getBoundingClientRect().left + 10;
 				var YPos = items[0].getBoundingClientRect().top + 10;
 				cy.cGet('body').click(XPos, YPos);
+				cy.cGet('body').type('{esc}');
+				cy.cGet('body').type('{esc}');
 			});
 
 		return cy.cGet('.leaflet-overlay-pane svg')
-		.then(function(overlay) {
-				return overlay.find('[style*="cursor"]').length === 0;
+			.then(function(overlay) {
+				return overlay.children('g').length === 0;
 			});
 	});
 


### PR DESCRIPTION
Creates more reliable svg dom

Follow up from https://github.com/CollaboraOnline/online/pull/8545

Change-Id: Ie8adb7b2e543c93a4a23c49dd84aac973543f208


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

