### PR TITLE
[co-23.05] cool#8465 clipboard: fix skipping the header of the complex case in JS

### DIFF
--- a/browser/src/control/Control.DownloadProgress.js
+++ b/browser/src/control/Control.DownloadProgress.js
@@ -303,6 +303,9 @@ L.Control.DownloadProgress = L.Control.extend({
 					var text = reader.result;
 					window.app.console.log('async clipboard parse done: ' + text.substring(0, 256));
 					var idx = text.indexOf('<!DOCTYPE HTML');
+					if (idx === -1) {
+						idx = text.indexOf('<!DOCTYPE html');
+					}
 					if (idx > 0)
 						text = text.substring(idx, text.length);
 					that._map._clip.setTextSelectionHTML(text);


### PR DESCRIPTION
Have 3 paragraphs in Writer, insert an image in the middle with
(to-char) anchoring. Select all text, copy to trigger the complex copy
codepath. Insert the result to Wrtier, some "text/html" and a number
extra paragraphs appear before the result content in the past result.

Seems the root of the problem is that the clipboard format generated by
ChildSession::getClipboard() is 1) a mime type on its own line 2) size
3) real content; but we just skipped 1) and 2) in the past, but now this
doesn't work, presumably due to a change on the core side.

Fix the problem by just making the header check case-insensitive for
now.

Once I add a html+plain text mode here, I'll probably switch to properly
skipping the first two lines instead, since the plain text won't have a
well-known header to identify the content. No testcase, this complex
download codepath will be Firefox-only in the future, so not easy to
cover with cypress.

(cherry picked from commit b1917aab1db0d2ca43e005dc3d7a71b0aae642f5)

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Ia99e5325188e5a34b56962cf4e3e9b8287e267c0
