### PR TITLE
Fix failing test mobile/calc/spellchecking_spec.js

### DIFF
--- a/cypress_test/integration_tests/mobile/calc/spellchecking_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/spellchecking_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy Cypress beforeEach require afterEach expect*/
+/* global describe it cy beforeEach require afterEach expect*/
 
 var helper = require('../../common/helper');
 var calcHelper = require('../../common/calc_helper');
@@ -20,76 +20,40 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Calc spell checking menu.',
 	});
 
 	function openContextMenu() {
-		// Step into edit mode
-		calcHelper.dblClickOnFirstCell();
-
-		// Select text content
-		helper.typeIntoDocument('{ctrl}a');
-
-		// Open context menu
-		cy.cGet('.leaflet-selection-marker-start,.leaflet-selection-marker-end')
-			.then(function(markers) {
-				expect(markers.length).to.be.equal(2);
-				for (var i = 0; i < markers.length; i++) {
-					if (markers[i].classList.contains('leaflet-selection-marker-start')) {
-						cy.log('Found start marker at pos: ' + markers[i].getBoundingClientRect().right);
-						var XPos = markers[i].getBoundingClientRect().right + 10;
-					} else if (markers[i].classList.contains('leaflet-selection-marker-end')) {
-						cy.log('Found end marker at pos: ' + markers[i].getBoundingClientRect().top);
-						var YPos = markers[i].getBoundingClientRect().top - 10;
-					}
-				}
-
-				// Remove selection
-				cy.cGet('#tb_actionbar_item_acceptformula').then($ele =>{
-					cy.wait(1000);
-					if (Cypress.dom.isVisible($ele)) {
-						cy.wrap($ele).click();
-					}
-				});
-
-				cy.cGet('.cursor-overlay .blinking-cursor')
-					.should('not.exist');
-
-				// Step into edit mode again
-				calcHelper.dblClickOnFirstCell();
-
+		// Click and then long press on first cell
+		cy.cGet('#map')
+			.then(function(items) {
+				expect(items).to.have.lengthOf(1);
+				var XPos = items[0].getBoundingClientRect().left + 10;
+				var YPos = items[0].getBoundingClientRect().top + 10;
+				cy.cGet('body').click(XPos, YPos);
 				mobileHelper.longPressOnDocument(XPos, YPos);
 			});
 
-		cy.cGet('#mobile-wizard-content')
-			.should('be.visible');
+		cy.cGet('#mobile-wizard-content').should('be.visible');
 	}
 
 	it('Apply suggestion.', function() {
 		openContextMenu();
-
-		cy.cGet('body').contains('.context-menu-link', 'hello')
-			.click();
+		cy.cGet('body').contains('.context-menu-link', 'hello').click();
 
 		calcHelper.selectEntireSheet();
+		cy.cGet('#copy-paste-container table td').should('contain.text', 'hello');
 
-		cy.cGet('#copy-paste-container table td')
-			.should('contain.text', 'hello');
+		// We don't get the spell check context menu any more
+		openContextMenu();
+		cy.cGet('body').contains('.context-menu-link', 'Paste').should('be.visible');
 	});
 
 	it('Ignore all.', function() {
 		openContextMenu();
-
 		cy.cGet('body').contains('.context-menu-link', 'Ignore All').click();
 
-		// Click outside of the cell
-		cy.cGet('.leaflet-marker-icon')
-			.then(function(items) {
-				expect(items).to.have.length(2);
-				var XPos = items[0].getBoundingClientRect().right;
-				var YPos = items[0].getBoundingClientRect().bottom + 10;
-				cy.cGet('body').click(XPos, YPos);
-			});
-
-		openContextMenu();
+		calcHelper.selectEntireSheet();
+		cy.cGet('#copy-paste-container table td').should('contain.text', 'helljo');
 
 		// We don't get the spell check context menu any more
+		openContextMenu();
 		cy.cGet('body').contains('.context-menu-link', 'Paste').should('be.visible');
 	});
 });


### PR DESCRIPTION
Test failed because of a change in .leaflet-marker-icon
Rewrite openContextMenu and remove uses of .leaflet-marker-icon

23.05 core change that caused the failure: https://gerrit.libreoffice.org/c/core/+/164701
24.04 pull request: https://github.com/CollaboraOnline/online/pull/8589

Change-Id: Iecfacdd192ea723001ed56e6c9f0c32645a6af2c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

