### PR TITLE
[backport] use getentropy() for BSD systems

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1113,6 +1113,18 @@ else
     AC_DEFINE([HAVE_SYS_RANDOM_H],0,[Define to 1 if you have the <sys/random.h> header file.])
 fi
 
+AC_LINK_IFELSE(
+    [AC_LANG_SOURCE([[
+    #include <unistd.h>
+    int main()
+    {
+        char buffer[8];
+        getentropy(buffer, sizeof(buffer));
+    }
+    ]])],
+    [AC_DEFINE([HAVE_GETENTROPY],1,[Define to 1 if you have getentropy() function in <unistd.h> header file.])],
+    [AC_DEFINE([HAVE_GETENTROPY],0,[Define to 1 if you have getentropy() function in <unistd.h> header file.])])
+
 AS_IF([test -n "$LOKIT_PATH"],
       [CPPFLAGS="$CPPFLAGS -I${LOKIT_PATH}"])
 lokit_msg="$LOKIT_PATH"


### PR DESCRIPTION
- instead of using /dev/[u]random devices, use getentropy() to make direct system calls
if the system is a BSD.

- if getentropy() fails, we need to fall back to "/dev/[u]random" approach.

Signed-off-by: Bayram Çiçek <bayram.cicek@libreoffice.org>
Change-Id: Id6a2629c06d641eb4e7cf3991de4036d2f7b346e (cherry picked from commit 93f3bcff825b728ae4756c91172086adf08b7052)


* Resolves: #5851
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

