### PR TITLE
Related: cool#8023 wsd, ClientSession: fix bogus <body> warning with plain text

### DIFF
--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1609,6 +1609,12 @@ void ClientSession::postProcessCopyPayload(const std::shared_ptr<Message>& paylo
 {
     // Insert our meta origin if we can
     payload->rewriteDataBody([this](std::vector<char>& data) {
+            if (Util::findInVector(data, "clipboardcontent: content\ntext/plain") == 0)
+            {
+                // Single format and it's plain text (not HTML): no need to rewrite anything.
+                return false;
+            }
+
             bool json = Util::findInVector(data, "textselectioncontent:\n{") == 0;
             if (!json)
             {


### PR DESCRIPTION
E.g. unit-copy-paste emitted a warning like this:
wsd-1576653-1576734 2024-03-20 21:28:53.448488 +0000 [ docbroker_002 ] DBG  ToClient-005: Missing <body> ...

This is a real problem in case the clipboard has HTML, but it's fine
when the clipboard is just plain text.

Fix the noise by returning early when the body of the clipboardcontent
message contains just plain text.

This works because the body never starts with plain text when HTML is
also available: the JSON case is not an issue and the entire clipboard
dump lists HTML before plain text.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I1ff51249fb710e3a9c127917aae4178c22738668
