### PR TITLE
Fix permanent tooltips on dialogs

### DIFF
--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -1714,7 +1714,7 @@ L.Control.UIManager = L.Control.extend({
 		var elem = $(element);
 		if (window.mode.isDesktop()) {
 			elem.tooltip();
-			elem.click(function() {
+			elem.on("mousedown", function() {
 				$('.ui-tooltip').fadeOut(function() {
 					$(this).remove();
 				});


### PR DESCRIPTION
Position and Size dialog of the shape has a rotation angle widget in rotation tab. User can drag move instead only one click on the rotation angle widget. It causes a permanent tooltip on document. So It is better to handle mousedown instead click to close tooltip.


Change-Id: Idbea0bb8a56568a92f3f4d4c9ee6df1da01b7c24


* Resolves: #8045
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

