### PR TITLE
Fix image path for line spacing

### DIFF
--- a/browser/src/control/jsdialog/Widget.Combobox.js
+++ b/browser/src/control/jsdialog/Widget.Combobox.js
@@ -40,7 +40,7 @@ JSDialog.comboboxEntry = function (parentContainer, data, builder) {
 
 	if (data.icon) {
 		var icon = L.DomUtil.create('img', 'ui-combobox-icon', entry);
-		builder._isStringCloseToURL(data.icon) ? icon.src = data.icon : L.LOUtil.setImage(icon, data.icon, builder.map);
+		builder._isStringCloseToURL(data.icon) ? icon.src = data.icon : L.LOUtil.setImage(icon,  builder._createIconURL(data.icon), builder.map);
 	}
 
 	if (data.hint) {


### PR DESCRIPTION
- icon URL passed inside `setImage` function was wrong
- line spacing icons are not correctly
- this patch will correct the URL before setImage

Signed-off-by: Darshan-upadhyay1110 <darshan.upadhyay@collabora.com>
Change-Id: Ie733c79c4edae404d934953eaea20632bc18f8da

* Resolves: #8595 

 - Before:  ![image](https://github.com/CollaboraOnline/online/assets/61383886/406a5447-6b39-41f3-b165-fa14f7c8159a)

 - After:   ![image](https://github.com/CollaboraOnline/online/assets/61383886/865674a4-d696-4197-a399-839b272c45cb) 
