### PR TITLE
browser: fix dialog warning alerts

### DIFF
--- a/browser/src/control/Control.AlertDialog.js
+++ b/browser/src/control/Control.AlertDialog.js
@@ -21,7 +21,9 @@ L.Control.AlertDialog = L.Control.extend({
 	},
 
 	_onError: function(e) {
-		if (!this._map._fatal && e.cmd != 'notasync') {
+		if (!this._map._fatal &&
+		    e.cmd !== 'notasync' &&
+		    e.type !== 'warn') {
 			this._map.uiManager.closeAll();
 		}
 


### PR DESCRIPTION
* Enable security.enable_macros_execution in coolwsd.xml.
* Open a file with a macro.
* Click Help.

Expected result: the popup dialog should not close

Change-Id: I3981c1ddbb3782dd9ee43dc0c9dce282d2f21392
Signed-off-by: Henry Castro <hcastro@collabora.com>