### PR TITLE
make profiling script find all coolwsds

### DIFF
--- a/scripts/profile-cool
+++ b/scripts/profile-cool
@@ -31,7 +31,13 @@ pkill -SIGUSR1 kitbroker
 echo Waiting 1 second for results
 sleep 1
 echo ---systemd journal---
-journalctl --since @$date -u coolwsd --output=cat | grep -P "\Wpid:|\WjailedUrl:|\WviewId:.*userExtraInfo:"
+# We might have multiple coolwsds and we want the output from all of them.
+# But we want lines from each pid to be grouped together, and each group
+# of lines to be in chronological order.
+# So use short-unix to retain the name[pid], stable sort on that key
+# then use cut to remove the columns we only included to get the desired
+# order
+journalctl --since @$date -t "coolwsd" -o short-unix | sort -s -k3,3 | cut -d " " -f 4- | grep -P "\Wpid:|\WjailedUrl:|\WviewId:.*userExtraInfo:"
 if [ -e /tmp/coolwsd.log ]; then
   echo ---local dev log---
   tail -c +$locallogsize /tmp/coolwsd.log | grep -P "\Wpid:|\WjailedUrl:|\WviewId:.*userExtraInfo:"


### PR DESCRIPTION
there might be coolwsds launched from another service which doesn't match -u coolwsd, so use -t coolwsd instead to capture all of them

then their output might be interleaved, so switch to another log format that retains the name[pid] and stable sort on that column so we have all the matching lines for a name[pid] contiguous but ordered within that by time. After the sort, cut to drop the columns that are additional over the 'cat' format.


Change-Id: Id1d1c37001249ff348d6c09c005fb0836133258c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

