### PR TITLE
Cypress calc helper: make assertDataClipboardTable retriable

### DIFF
--- a/cypress_test/integration_tests/common/calc_helper.js
+++ b/cypress_test/integration_tests/common/calc_helper.js
@@ -220,24 +220,13 @@ function assertSheetContents(expectedData) {
 function assertDataClipboardTable(expectedData) {
 	cy.log('>> assertDataClipboardTable - start');
 
-	cy.cGet('#copy-paste-container table td')
-		.should(function(cells) {
-			expect(cells).to.have.lengthOf(expectedData.length);
-		});
-
-	// Wait for clipboard to update anyways, in case we get here before the
-	// update because the new contents are the same length as the previous
-	cy.wait(200);
-
-	var data = [];
-
-	cy.cGet('#copy-paste-container tbody').find('td').each(($el) => {
-		cy.wrap($el,{log: false})
-			.invoke({log: false}, 'text')
-			.then(text => {
-				data.push(text);
-			});
-	}).then(() => expect(data).to.deep.eq(expectedData));
+	cy.cGet('#copy-paste-container table td').should(function($td) {
+		expect($td).to.have.length(expectedData.length);
+		var actualData = $td.map(function(i,el) {
+			return Cypress.$(el).text();
+		}).get();
+		expect(actualData).to.deep.eq(expectedData);
+	});
 
 	cy.log('<< assertDataClipboardTable - end');
 }


### PR DESCRIPTION
Finally, a robust solution for checking sheet contents
Uses .should() to make a retriable assertion, subject to normal timeouts and with no need to wait before.
Fixes sporadic failures in desktop/calc/autofilter_spec.js

Example logs:
Pass:
```
          cy:log ✱  >> assertDataClipboardTable - start
      cy:command ✔  cGet	#copy-paste-container table td
      cy:command ✔  assert	expected **[ <td>, 5 more... ]** to have a length of **6**
      cy:command ✔  assert	expected **[ Array(6) ]** to deeply equal **[ Array(6) ]**
          cy:log ✱  << assertDataClipboardTable - end
```

Fail length:
```
          cy:log ✱  >> assertDataClipboardTable - start
      cy:command ✔  cGet	#copy-paste-container table td
      cy:command ✘  assert	expected **[ <td>, 5 more... ]** to have a length of **5** but got **6**
      cy:command ✔  fail:	
                    Test failed: integration_tests/desktop/calc/autofilter_spec.js / AutoFilter / Enable/Disable autofilter
                    
                    Timed out retrying after 10000ms: Too many elements found. Found '6', expected '5'.
                    
                    /home/neilguertin/build/online2/cypress_test/integration_tests/common/calc_helper.js:187:29
                      185 |         */
                      186 |     cy.cGet('#copy-paste-container table td').should(function ($td) {
                    > 187 |         expect($td).to.have.length(expectedData.length);
                          |                             ^
                      188 |         var actualData = $td.map(function (i, el) {
                      189 |             return Cypress.$(el).text();
                      190 |         }).get();
```

Fail content:
```
          cy:log ✱  >> assertDataClipboardTable - start
      cy:command ✔  cGet	#copy-paste-container table td
      cy:command ✔  assert	expected **[ <td>, 5 more... ]** to have a length of **6**
      cy:command ✘  assert	expected **[ Array(6) ]** to deeply equal **[ Array(6) ]**
                    Actual: 	["Cypress Test","Status","Test 1","Pass","Test 3","Pass"]
                    Expected: 	["Cypress Test","Status","Test 1","Pass","Test 3","XXXX"]
      cy:command ✔  fail:	
                    Test failed: integration_tests/desktop/calc/autofilter_spec.js / AutoFilter / Enable/Disable autofilter
                    
                    Timed out retrying after 10000ms: expected [ Array(6) ] to deeply equal [ Array(6) ]
                    
                    /home/neilguertin/build/online2/cypress_test/integration_tests/common/calc_helper.js:191:36
                      189 |             return Cypress.$(el).text();
                      190 |         }).get();
                    > 191 |         expect(actualData).to.deep.eq(expectedData);
                          |                                    ^
                      192 |     });
                      193 |     cy.log('<< assertDataClipboardTable - end');
                      194 | }
```



Change-Id: I9c4e36b3bcdf0968e9b95237f3f17f284d2628de


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

