### PR TITLE
Cypress calc helper: make assertDataClipboardTable retriable (backport)

### DIFF
--- a/cypress_test/integration_tests/common/calc_helper.js
+++ b/cypress_test/integration_tests/common/calc_helper.js
@@ -215,21 +215,14 @@ function ensureViewContainsCellCursor() {
 
 function assertDataClipboardTable(expectedData) {
 	cy.log('>> assertDataClipboardTable - start');
-
-	cy.cGet('#copy-paste-container table td')
-		.should(function(cells) {
-			expect(cells).to.have.lengthOf(expectedData.length);
-		});
-
-	var data = [];
-
-	cy.cGet('#copy-paste-container tbody').find('td').each(($el) => {
-		cy.wrap($el)
-			.invoke('text')
-			.then(text => {
-				data.push(text);
-			});
-	}).then(() => expect(data).to.deep.eq(expectedData));
+	
+	cy.cGet('#copy-paste-container table td').should(function($td) {
+		expect($td).to.have.length(expectedData.length);
+		var actualData = $td.map(function(i,el) {
+			return Cypress.$(el).text();
+		}).get();
+		expect(actualData).to.deep.eq(expectedData);
+	});
 
 	cy.log('<< assertDataClipboardTable - end');
 }


### PR DESCRIPTION
Finally, a robust solution for checking sheet contents Uses .should() to make a retriable assertion, subject to normal timeouts and with no need to wait before.
Fixes sporadic failures in desktop/calc/autofilter_spec.js

Backport of https://github.com/CollaboraOnline/online/pull/8608/. Example logs there.

Change-Id: I9c4e36b3bcdf0968e9b95237f3f17f284d2628de


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

