### PR TITLE
Fixed Autosaved comment are half visible

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -544,7 +544,7 @@ nav.spreadsheet-color-indicator ~ #sidebar-dock-wrapper {
 	overflow: auto;
 }
 
-.cool-annotation-reply-count-collapsed {
+.cool-annotation-info-collapsed {
 	text-align: center;
 	margin: 0;
 	padding: 0;

--- a/browser/src/layer/tile/CommentListSection.ts
+++ b/browser/src/layer/tile/CommentListSection.ts
@@ -211,6 +211,8 @@ export class CommentSection extends CanvasSectionObject {
 		for (var i: number = 0; i < this.sectionProperties.commentList.length; i++) {
 			if (this.sectionProperties.commentList[i].sectionProperties.data.id !== 'new')
 				this.sectionProperties.commentList[i].setCollapsed();
+			if (this.sectionProperties.commentList[i].isRootComment())
+				this.collapseReplies(i, this.sectionProperties.commentList[i].sectionProperties.data.id);
 		}
 	}
 
@@ -671,19 +673,26 @@ export class CommentSection extends CanvasSectionObject {
 	}
 
 	private showCollapsedReplies(rootIndex: number) {
-		rootIndex++;
-		while (rootIndex < this.sectionProperties.commentList.length && this.sectionProperties.commentList[rootIndex].sectionProperties.data.parent !== '0') {
+		if (!this.sectionProperties.commentList.length)
+			return;
+		var lastIndex = this.getLastChildIndexOf(this.sectionProperties.commentList[rootIndex].sectionProperties.data.id);
+		var rootComment = this.sectionProperties.commentList[rootIndex];
+
+		while (rootIndex <= lastIndex) {
 			this.sectionProperties.commentList[rootIndex].sectionProperties.container.style.display = '';
 			this.sectionProperties.commentList[rootIndex].sectionProperties.container.style.visibility = '';
 			rootIndex++;
 		}
+		rootComment.updateThreadCountIndicator();
 	}
 
 	private collapseReplies(rootIndex: number, rootId: number) {
 		var lastChild = this.getLastChildIndexOf(rootId);
 
-		for (var i = lastChild; i > rootIndex; i--)
+		for (var i = lastChild; i > rootIndex; i--) {
 			this.sectionProperties.commentList[i].sectionProperties.container.style.display = 'none';
+			this.sectionProperties.commentList[i].updateThreadCountIndicator();
+		}
 	}
 
 	private cssToCorePixels(cssPixels: number) {
@@ -1335,6 +1344,8 @@ export class CommentSection extends CanvasSectionObject {
 					if (this.sectionProperties.docLayer._docType === 'spreadsheet')
 						modified.show();
 					modified.edit();
+					if(this.shouldCollapse())
+						modified.setCollapsed();
 				}
 			}
 		} else if (action === 'Resolve') {
@@ -1755,11 +1766,13 @@ export class CommentSection extends CanvasSectionObject {
 		for (var i = 0; i < this.sectionProperties.commentList.length; i++) {
 			var comment = this.sectionProperties.commentList[i];
 			var replyCount = 0;
+			var anyEdit = false;
 
 			if (comment && comment.isRootComment()) {
 				var lastIndex = this.getLastChildIndexOf(comment.sectionProperties.data.id);
 				var j = i;
 				while (this.sectionProperties.commentList[j] && j <= lastIndex) {
+					anyEdit = this.sectionProperties.commentList[j].isEdit() || anyEdit;
 					if (this.sectionProperties.commentList[j].sectionProperties.data.parent !== '0') {
 						if ((this.sectionProperties.commentList[j].sectionProperties.data.layoutStatus !== CommentLayoutStatus.DELETED ||
 							this.map['stateChangeHandler'].getItemValue('.uno:ShowTrackedChanges') === 'true') &&
@@ -1770,11 +1783,10 @@ export class CommentSection extends CanvasSectionObject {
 					j++;
 				}
 			}
-
-			if (replyCount >= 1)
-				comment.sectionProperties.replyCountNode.innerText = replyCount;
+			if (anyEdit)
+				comment.updateThreadCountIndicator('!');
 			else
-				comment.sectionProperties.replyCountNode.innerText = '';
+				comment.updateThreadCountIndicator(replyCount);
 		}
 	}
 

--- a/browser/src/layer/tile/CommentListSection.ts
+++ b/browser/src/layer/tile/CommentListSection.ts
@@ -683,7 +683,7 @@ export class CommentSection extends CanvasSectionObject {
 			this.sectionProperties.commentList[rootIndex].sectionProperties.container.style.visibility = '';
 			rootIndex++;
 		}
-		rootComment.updateThreadCountIndicator();
+		rootComment.updateThreadInfoIndicator();
 	}
 
 	private collapseReplies(rootIndex: number, rootId: number) {
@@ -691,8 +691,8 @@ export class CommentSection extends CanvasSectionObject {
 
 		for (var i = lastChild; i > rootIndex; i--) {
 			this.sectionProperties.commentList[i].sectionProperties.container.style.display = 'none';
-			this.sectionProperties.commentList[i].updateThreadCountIndicator();
 		}
+		this.sectionProperties.commentList[i].updateThreadInfoIndicator();
 	}
 
 	private cssToCorePixels(cssPixels: number) {
@@ -764,9 +764,7 @@ export class CommentSection extends CanvasSectionObject {
 
 			if (this.isCollapsed) {
 				this.showCollapsedReplies(idx);
-				if (docType === 'text') {
-					selectedComment.sectionProperties.replyCountNode.style.display = 'none';
-				}
+				selectedComment.updateThreadInfoIndicator();
 			}
 
 			this.update();
@@ -1382,7 +1380,7 @@ export class CommentSection extends CanvasSectionObject {
 		}
 
 		if (this.sectionProperties.docLayer._docType === 'text')
-			this.updateReplyCount();
+			this.updateThreadInfoIndicator();
 	}
 
 	public selectById (commentId: any): void {
@@ -1758,11 +1756,11 @@ export class CommentSection extends CanvasSectionObject {
 
 	private update (): void {
 		if (this.sectionProperties.docLayer._docType === 'text')
-			this.updateReplyCount();
+			this.updateThreadInfoIndicator();
 		this.layout();
 	}
 
-	private updateReplyCount(): void {
+	private updateThreadInfoIndicator(): void {
 		for (var i = 0; i < this.sectionProperties.commentList.length; i++) {
 			var comment = this.sectionProperties.commentList[i];
 			var replyCount = 0;
@@ -1784,9 +1782,9 @@ export class CommentSection extends CanvasSectionObject {
 				}
 			}
 			if (anyEdit)
-				comment.updateThreadCountIndicator('!');
+				comment.updateThreadInfoIndicator('!');
 			else
-				comment.updateThreadCountIndicator(replyCount);
+				comment.updateThreadInfoIndicator(replyCount);
 		}
 	}
 

--- a/browser/src/layer/tile/CommentSection.ts
+++ b/browser/src/layer/tile/CommentSection.ts
@@ -275,8 +275,8 @@ export class Comment extends CanvasSectionObject {
 		imgAuthor.setAttribute('height', this.sectionProperties.imgSize[1]);
 
 		if (this.sectionProperties.docLayer._docType !== 'spreadsheet') {
-			this.sectionProperties.replyCountNode = L.DomUtil.create('div', 'cool-annotation-reply-count-collapsed', tdImg);
-			this.sectionProperties.replyCountNode.style.display = 'none';
+			this.sectionProperties.collapsedInfoNode = L.DomUtil.create('div', 'cool-annotation-info-collapsed', tdImg);
+			this.sectionProperties.collapsedInfoNode.style.display = 'none';
 		}
 
 		this.sectionProperties.authorAvatarImg = imgAuthor;
@@ -687,7 +687,7 @@ export class Comment extends CanvasSectionObject {
 		this.sectionProperties.contentNode.style.display = '';
 		this.sectionProperties.nodeModify.style.display = 'none';
 		this.sectionProperties.nodeReply.style.display = 'none';
-		this.sectionProperties.replyCountNode.style.visibility = '';
+		this.sectionProperties.collapsedInfoNode.style.visibility = '';
 		this.sectionProperties.showSelectedCoordinate = true;
 	}
 
@@ -1368,7 +1368,7 @@ export class Comment extends CanvasSectionObject {
 			this.sectionProperties.container.style.display = '';
 			this.sectionProperties.container.style.visibility = 'hidden';
 		}
-		this.updateThreadCountIndicator();
+		this.updateThreadInfoIndicator();
 		if (this.sectionProperties.data.resolved === 'false'
 		|| this.sectionProperties.commentListSection.sectionProperties.showResolved
 		|| this.sectionProperties.docLayer._docType === 'presentation'
@@ -1376,21 +1376,21 @@ export class Comment extends CanvasSectionObject {
 			L.DomUtil.addClass(this.sectionProperties.container, 'cool-annotation-collapsed-show');
 	}
 
-	public updateThreadCountIndicator(replycount:number | string = -1): void {
+	public updateThreadInfoIndicator(replycount:number | string = -1): void {
 		if (this.sectionProperties.docLayer._docType === 'spreadsheet')
 			return;
 
 		if (this.isEdit())
-			this.sectionProperties.replyCountNode.innerText = '!';
+			this.sectionProperties.collapsedInfoNode.innerText = '!';
 		else if (replycount === '!' || typeof replycount === "number" && replycount > 0)
-			this.sectionProperties.replyCountNode.innerText = replycount;
+			this.sectionProperties.collapsedInfoNode.innerText = replycount;
 		else
-			this.sectionProperties.replyCountNode.innerText = '';
+			this.sectionProperties.collapsedInfoNode.innerText = '';
 
-		if (this.sectionProperties.replyCountNode.innerText === '' || this.isContainerVisible())
-			this.sectionProperties.replyCountNode.style.display = 'none';
-		else if ((!this.isContainerVisible() && this.sectionProperties.replyCountNode.innerText !== ''))
-			this.sectionProperties.replyCountNode.style.display = '';
+		if (this.sectionProperties.collapsedInfoNode.innerText === '' || this.isContainerVisible())
+			this.sectionProperties.collapsedInfoNode.style.display = 'none';
+		else if ((!this.isContainerVisible() && this.sectionProperties.collapsedInfoNode.innerText !== ''))
+			this.sectionProperties.collapsedInfoNode.style.display = '';
 	}
 
 	public setExpanded(): void {
@@ -1402,7 +1402,7 @@ export class Comment extends CanvasSectionObject {
 			this.sectionProperties.container.style.visibility = '';
 		}
 		if (this.sectionProperties.docLayer._docType === 'text')
-			this.sectionProperties.replyCountNode.style.display = 'none';
+			this.sectionProperties.collapsedInfoNode.style.display = 'none';
 		L.DomUtil.removeClass(this.sectionProperties.container, 'cool-annotation-collapsed-show');
 	}
 }

--- a/browser/src/layer/tile/CommentSection.ts
+++ b/browser/src/layer/tile/CommentSection.ts
@@ -274,7 +274,7 @@ export class Comment extends CanvasSectionObject {
 		imgAuthor.setAttribute('width', this.sectionProperties.imgSize[0]);
 		imgAuthor.setAttribute('height', this.sectionProperties.imgSize[1]);
 
-		if (this.sectionProperties.docLayer._docType === 'text') {
+		if (this.sectionProperties.docLayer._docType !== 'spreadsheet') {
 			this.sectionProperties.replyCountNode = L.DomUtil.create('div', 'cool-annotation-reply-count-collapsed', tdImg);
 			this.sectionProperties.replyCountNode.style.display = 'none';
 		}
@@ -1359,30 +1359,38 @@ export class Comment extends CanvasSectionObject {
 	}
 
 	public setCollapsed(): void {
-		if (this.isEdit())
-			return;
 		this.isCollapsed = true;
 
-		this.show();
+		if (!this.isEdit())
+			this.show();
 
 		if (this.isRootComment() || this.sectionProperties.docLayer._docType === 'presentation' || this.sectionProperties.docLayer._docType === 'drawing') {
 			this.sectionProperties.container.style.display = '';
 			this.sectionProperties.container.style.visibility = 'hidden';
-
-			if (this.sectionProperties.docLayer._docType === 'text') {
-				if (this.sectionProperties.replyCountNode.innerText !== '')
-					this.sectionProperties.replyCountNode.style.display = '';
-				else
-					this.sectionProperties.replyCountNode.style.display = 'none';
-			}
 		}
-		else {
-			this.sectionProperties.container.style.display = 'none';
-			if (this.sectionProperties.docLayer._docType === 'text')
-				this.sectionProperties.replyCountNode.style.display = 'none';
-		}
-		if (this.sectionProperties.data.resolved === 'false' || this.sectionProperties.commentListSection.sectionProperties.showResolved)
+		this.updateThreadCountIndicator();
+		if (this.sectionProperties.data.resolved === 'false'
+		|| this.sectionProperties.commentListSection.sectionProperties.showResolved
+		|| this.sectionProperties.docLayer._docType === 'presentation'
+		|| this.sectionProperties.docLayer._docType === 'drawing')
 			L.DomUtil.addClass(this.sectionProperties.container, 'cool-annotation-collapsed-show');
+	}
+
+	public updateThreadCountIndicator(replycount:number | string = -1): void {
+		if (this.sectionProperties.docLayer._docType === 'spreadsheet')
+			return;
+
+		if (this.isEdit())
+			this.sectionProperties.replyCountNode.innerText = '!';
+		else if (replycount === '!' || typeof replycount === "number" && replycount > 0)
+			this.sectionProperties.replyCountNode.innerText = replycount;
+		else
+			this.sectionProperties.replyCountNode.innerText = '';
+
+		if (this.sectionProperties.replyCountNode.innerText === '' || this.isContainerVisible())
+			this.sectionProperties.replyCountNode.style.display = 'none';
+		else if ((!this.isContainerVisible() && this.sectionProperties.replyCountNode.innerText !== ''))
+			this.sectionProperties.replyCountNode.style.display = '';
 	}
 
 	public setExpanded(): void {

--- a/cypress_test/integration_tests/common/desktop_helper.js
+++ b/cypress_test/integration_tests/common/desktop_helper.js
@@ -329,6 +329,8 @@ function insertComment(text = 'some text0', save = true) {
 	cy.cGet('.cool-annotation').last({log: false}).find('#annotation-modify-textarea-new').type(text);
 	// Click outside modify area to trigger update
 	cy.cGet('.cool-annotation').last({log: false}).find('.cool-annotation-table').click();
+	// In case of small window to expand the comments
+	cy.cGet('.cool-annotation').last({log: false}).find('.cool-annotation-img').click();
 	// Check that comment exists
 	cy.cGet('.cool-annotation').last({log: false}).find('.cool-annotation-textarea').should('contain',text);
 

--- a/cypress_test/integration_tests/common/impress_helper.js
+++ b/cypress_test/integration_tests/common/impress_helper.js
@@ -225,9 +225,9 @@ function changeSlide(changeNum,direction) {
 
 	var slideButton;
 	if (direction === 'next') {
-		slideButton = cy.cGet('#toolbar-up #next');
+		slideButton = cy.cGet('#next-button');
 	} else if (direction === 'previous') {
-		slideButton = cy.cGet('#toolbar-up #prev');
+		slideButton = cy.cGet('#prev-button');
 	}
 	if (slideButton) {
 		for (var n = 0; n < changeNum; n++) {

--- a/cypress_test/integration_tests/desktop/impress/annotation_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/annotation_spec.js
@@ -139,9 +139,9 @@ describe(['tagdesktop'], 'Collapsed Annotation Tests', function() {
 		cy.cGet('.cool-annotation-img').click();
 		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
 		cy.cGet('.cool-annotation-autosavelabel').should('be.not.visible');
-		cy.cGet('.cool-annotation-reply-count-collapsed').should('not.have.text','!');
+		cy.cGet('.cool-annotation-info-collapsed').should('not.have.text','!');
 		cy.cGet('#map').focus();
-		cy.cGet('.cool-annotation-reply-count-collapsed').should('be.not.visible');
+		cy.cGet('.cool-annotation-info-collapsed').should('be.not.visible');
 
 		helper.closeDocument(testFileName, '');
 		helper.beforeAll(testFileName, 'impress', true, false, false, true);

--- a/cypress_test/integration_tests/desktop/impress/annotation_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/annotation_spec.js
@@ -67,11 +67,11 @@ describe(['tagdesktop'], 'Annotation Tests', function() {
 });
 
 describe(['tagdesktop'], 'Collapsed Annotation Tests', function() {
-	var testFileName = 'comment_switching.odp';
+	var origTestFileName = 'comment_switching.odp';
+	var testFileName;
 
 	beforeEach(function() {
-		cy.viewport(1500, 600);
-		helper.beforeAll(testFileName, 'impress');
+		testFileName = helper.beforeAll(origTestFileName, 'impress');
 		desktopHelper.switchUIToNotebookbar();
 
 		if (Cypress.env('INTEGRATION') === 'nextcloud') {
@@ -126,6 +126,30 @@ describe(['tagdesktop'], 'Collapsed Annotation Tests', function() {
 		cy.cGet('#annotation-reply-1').click();
 		cy.cGet('.cool-annotation-content > div').should('include.text','some reply text');
 	});
+
+	it('Autosave Collapse', function() {
+		desktopHelper.insertComment(undefined, false);
+		cy.cGet('#map').focus();
+		helper.typeIntoDocument('{home}');
+		cy.cGet('.cool-annotation-info-collapsed').should('have.text','!');
+		cy.cGet('.cool-annotation-info-collapsed').should('be.visible');
+		cy.cGet('.cool-annotation-img').click();
+		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
+		cy.cGet('#annotation-save-1').click();
+		cy.cGet('.cool-annotation-img').click();
+		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
+		cy.cGet('.cool-annotation-autosavelabel').should('be.not.visible');
+		cy.cGet('.cool-annotation-reply-count-collapsed').should('not.have.text','!');
+		cy.cGet('#map').focus();
+		cy.cGet('.cool-annotation-reply-count-collapsed').should('be.not.visible');
+
+		helper.closeDocument(testFileName, '');
+		helper.beforeAll(testFileName, 'impress', true, false, false, true);
+		cy.cGet('.cool-annotation-img').click();
+		cy.cGet('.cool-annotation-content-wrapper').should('exist');
+		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
+		cy.cGet('.cool-annotation-info-collapsed').should('be.not.visible');
+	})
 });
 
 describe(['tagdesktop'], 'Comment Scrolling',function() {
@@ -151,7 +175,7 @@ describe(['tagdesktop'], 'Comment Scrolling',function() {
 		cy.cGet('.leaflet-marker-icon').should('exist');
 	});
 
-	it.only('omit slides without comments', function() {
+	it('omit slides without comments', function() {
 		//scroll up
 		desktopHelper.insertComment();
 		addSlide(2);

--- a/cypress_test/integration_tests/desktop/writer/annotation_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/annotation_spec.js
@@ -127,8 +127,8 @@ describe(['tagdesktop'], 'Collapsed Annotation Tests', function() {
 		desktopHelper.insertComment(undefined, false);
 		cy.cGet('#map').focus();
 		helper.typeIntoDocument('{home}');
-		cy.cGet('.cool-annotation-reply-count-collapsed').should('have.text','!');
-		cy.cGet('.cool-annotation-reply-count-collapsed').should('be.visible');
+		cy.cGet('.cool-annotation-info-collapsed').should('have.text','!');
+		cy.cGet('.cool-annotation-info-collapsed').should('be.visible');
 		cy.cGet('.cool-annotation-img').click();
 		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
 		cy.cGet('#annotation-save-1').click();
@@ -136,10 +136,10 @@ describe(['tagdesktop'], 'Collapsed Annotation Tests', function() {
 		cy.cGet('.cool-annotation-img').click();
 		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
 		cy.cGet('.cool-annotation-autosavelabel').should('be.not.visible');
-		cy.cGet('.cool-annotation-reply-count-collapsed').should('not.have.text','!');
+		cy.cGet('.cool-annotation-info-collapsed').should('not.have.text','!');
 		cy.cGet('#map').focus();
 		helper.typeIntoDocument('{home}');
-		cy.cGet('.cool-annotation-reply-count-collapsed').should('be.not.visible');
+		cy.cGet('.cool-annotation-info-collapsed').should('be.not.visible');
 
 		helper.closeDocument(testFileName, '');
 		helper.beforeAll(testFileName, 'writer', true, false, false, true);

--- a/cypress_test/integration_tests/desktop/writer/annotation_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/annotation_spec.js
@@ -65,10 +65,11 @@ describe(['tagdesktop'], 'Annotation Tests', function() {
 });
 
 describe(['tagdesktop'], 'Collapsed Annotation Tests', function() {
-	var testFileName = 'annotation.odt';
+	var origTestFileName = 'annotation.odt';
+	var testFileName;
 
 	beforeEach(function() {
-		helper.beforeAll(testFileName, 'writer');
+		testFileName = helper.beforeAll(origTestFileName, 'writer');
 		desktopHelper.switchUIToNotebookbar();
 		cy.cGet('#optionscontainer div[id$="SidebarDeck.PropertyDeck"]').click(); // Hide sidebar.
 	});
@@ -121,6 +122,33 @@ describe(['tagdesktop'], 'Collapsed Annotation Tests', function() {
 		cy.cGet('body').contains('.context-menu-item','Remove').click();
 		cy.cGet('.cool-annotation-content-wrapper').should('not.exist');
 	});
+
+	it('Autosave Collapse', function() {
+		desktopHelper.insertComment(undefined, false);
+		cy.cGet('#map').focus();
+		helper.typeIntoDocument('{home}');
+		cy.cGet('.cool-annotation-reply-count-collapsed').should('have.text','!');
+		cy.cGet('.cool-annotation-reply-count-collapsed').should('be.visible');
+		cy.cGet('.cool-annotation-img').click();
+		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
+		cy.cGet('#annotation-save-1').click();
+		helper.typeIntoDocument('{home}');
+		cy.cGet('.cool-annotation-img').click();
+		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
+		cy.cGet('.cool-annotation-autosavelabel').should('be.not.visible');
+		cy.cGet('.cool-annotation-reply-count-collapsed').should('not.have.text','!');
+		cy.cGet('#map').focus();
+		helper.typeIntoDocument('{home}');
+		cy.cGet('.cool-annotation-reply-count-collapsed').should('be.not.visible');
+
+		helper.closeDocument(testFileName, '');
+		helper.beforeAll(testFileName, 'writer', true, false, false, true);
+		cy.cGet('#optionscontainer div[id$="SidebarDeck.PropertyDeck"]').click(); // show sidebar.
+		cy.cGet('.cool-annotation-img').click();
+		cy.cGet('.cool-annotation-content-wrapper').should('exist');
+		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
+		cy.cGet('.cool-annotation-info-collapsed').should('be.not.visible');
+	})
 
 });
 

--- a/cypress_test/integration_tests/multiuser/writer/annotation_spec.js
+++ b/cypress_test/integration_tests/multiuser/writer/annotation_spec.js
@@ -146,11 +146,11 @@ describe(['tagmultiuser'], 'Multiuser Collapsed Annotation Tests', function() {
 		cy.cGet('#annotation-reply-textarea-1').type('some reply text');
 		cy.cGet('#annotation-reply-1').click();
 		cy.cGet('#annotation-content-area-2').should('contain','some reply text');
-		cy.cGet('#comment-container-1 .cool-annotation-reply-count-collapsed').should('have.text', '1');
+		cy.cGet('#comment-container-1 .cool-annotation-info-collapsed').should('have.text', '1');
 
 		cy.cSetActiveFrame('#iframe2');
 		cy.cGet('#annotation-content-area-2').should('contain','some reply text');
-		cy.cGet('#comment-container-1 .cool-annotation-reply-count-collapsed').should('have.text', '1');
+		cy.cGet('#comment-container-1 .cool-annotation-info-collapsed').should('have.text', '1');
 	});
 
 	it('Remove', function() {


### PR DESCRIPTION
problem:
when in small window, comment was autosaved,
it wasn't collapsed but would hang on the edge of the screen half visible.
We can't collapse the comment directly as user will not be able to find again
which comment was being edited.

* Target version: master 



### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

