### PR TITLE
drop additional activation of dark theme

### DIFF
--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -143,7 +143,6 @@ L.Control.UIManager = L.Control.extend({
 		else {
 			this.loadLightMode();
 		}
-		this.activateDarkModeInCore(selectedMode);
 	},
 
 	activateDarkModeInCore: function(activate) {


### PR DESCRIPTION
we now load the document in the initial theme, so we don't need this additional activation of the dark theme.

Change-Id: I523dda19cacd6fd3f81cd86ee554aacd5f73edea


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

