### PR TITLE
android: fix build error

### DIFF
--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -4383,8 +4383,6 @@ int COOLWSD::innerMain()
 #endif
     }
 
-    COOLWSD::alertAllUsersInternal("close: shuttingdown");
-
     // Lots of polls will stop; stop watching them first.
     SocketPoll::shutdownWatchdog();
 
@@ -4411,6 +4409,8 @@ int COOLWSD::innerMain()
     // atexit handlers tend to free Admin before Documents
     LOG_INF("Exiting. Cleaning up lingering documents.");
 #if !MOBILEAPP
+    COOLWSD::alertAllUsersInternal("close: shuttingdown");
+
     if (!SigUtil::getShutdownRequestFlag())
     {
         // This shouldn't happen, but it's fail safe to always cleanup properly.


### PR DESCRIPTION
- alertAllUsersInternal is not used for mobile apps


Change-Id: I44ecc10e64b98be58d5774e2ba14744815f75658


* Resolves: # <!-- related github issue -->
* Target version: master 

