### PR TITLE
Backport: Reuse Response in all File Server Scenarios

### DIFF
--- a/common/Authorization.hpp
+++ b/common/Authorization.hpp
@@ -10,7 +10,6 @@
 #pragma once
 
 #include <string>
-#include <vector>
 
 namespace Poco
 {

--- a/net/HttpHelper.cpp
+++ b/net/HttpHelper.cpp
@@ -85,14 +85,9 @@ void sendDeflatedFileContent(const std::shared_ptr<StreamSocket>& socket, const 
 }
 
 void sendFileAndShutdown(const std::shared_ptr<StreamSocket>& socket, const std::string& path,
-                         const std::string& mediaType, Poco::Net::HTTPResponse* optResponse,
+                         const std::string& mediaType, http::Response& response,
                          const bool noCache, const bool deflate, const bool headerOnly)
 {
-    Poco::Net::HTTPResponse* response = optResponse;
-    Poco::Net::HTTPResponse localResponse;
-    if (!response)
-        response = &localResponse;
-
     FileUtil::Stat st(path);
     if (st.bad())
     {
@@ -104,19 +99,19 @@ void sendFileAndShutdown(const std::shared_ptr<StreamSocket>& socket, const std:
     if (!noCache)
     {
         // 60 * 60 * 24 * 128 (days) = 11059200
-        response->set("Cache-Control", "max-age=11059200");
-        response->set("ETag", "\"" COOLWSD_VERSION_HASH "\"");
+        response.set("Cache-Control", "max-age=11059200");
+        response.set("ETag", "\"" COOLWSD_VERSION_HASH "\"");
     }
     else
     {
-        response->set("Cache-Control", "no-cache");
+        response.set("Cache-Control", "no-cache");
     }
 
-    response->setContentType(mediaType);
-    response->add("X-Content-Type-Options", "nosniff");
+    response.setContentType(mediaType);
+    response.add("X-Content-Type-Options", "nosniff");
     //Should we add the header anyway ?
     if (headerOnly)
-        response->add("Connection", "close");
+        response.add("Connection", "close");
 
     int bufferSize = std::min<std::size_t>(st.size(), Socket::MaximumSendBufferSize);
     if (static_cast<long>(st.size()) >= socket->getSendBufferSize())
@@ -130,20 +125,20 @@ void sendFileAndShutdown(const std::shared_ptr<StreamSocket>& socket, const std:
     // IE/Edge before enabling the deflate again
     if (!deflate || true)
     {
-        response->setContentLength(st.size());
+        response.setContentLength(st.size());
         LOG_TRC('#' << socket->getFD() << ": Sending " << (headerOnly ? "header for " : "")
                     << " file [" << path << "].");
-        socket->send(*response);
+        socket->send(response);
 
         if (!headerOnly)
             sendUncompressedFileContent(socket, path, bufferSize);
     }
     else
     {
-        response->set("Content-Encoding", "deflate");
+        response.set("Content-Encoding", "deflate");
         LOG_TRC('#' << socket->getFD() << ": Sending " << (headerOnly ? "header for " : "")
                     << " file [" << path << "].");
-        socket->send(*response);
+        socket->send(response);
 
         if (!headerOnly)
             sendDeflatedFileContent(socket, path, st.size());

--- a/net/HttpHelper.hpp
+++ b/net/HttpHelper.hpp
@@ -10,13 +10,7 @@
 #include <memory>
 #include <string>
 
-namespace Poco
-{
-    namespace Net
-    {
-        class HTTPResponse;
-    }
-}
+#include <HttpRequest.hpp>
 
 class StreamSocket;
 
@@ -35,7 +29,7 @@ void sendErrorAndShutdown(int errorCode, const std::shared_ptr<StreamSocket>& so
 /// Sends file as HTTP response and shutdown the socket.
 void sendFileAndShutdown(const std::shared_ptr<StreamSocket>& socket, const std::string& path,
                          const std::string& mediaType,
-                         Poco::Net::HTTPResponse* optResponse = nullptr, bool noCache = false,
+                         http::Response& response, bool noCache = false,
                          bool deflate = false, const bool headerOnly = false);
 
 } // namespace HttpHelper

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -832,6 +832,12 @@ public:
     /// Set an HTTP header field, replacing an earlier value, if exists.
     void set(const std::string& key, std::string value) { _header.set(key, std::move(value)); }
 
+    /// Set the Content-Type header.
+    void setContentType(std::string type) { _header.setContentType(std::move(type)); }
+
+    /// Set the Content-Length header.
+    void setContentLength(int64_t length) { _header.setContentLength(length); }
+
     /// Get a header entry value by key, if found, defaulting to @def, if missing.
     std::string get(const std::string& key, const std::string& def = std::string()) const
     {

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -429,8 +429,11 @@ public:
     /// Return true iff Transfer-Encoding is set to chunked (the last entry).
     bool getChunkedTransferEncoding() const { return _chunked; }
 
-    /// Adds a new "Cookie" header entry with the given cookies.
-    void addCookies(const Container& pairs)
+    /// Adds a new "Cookie" header entry with the given content.
+    void addCookie(const std::string& cookie) { add(COOKIE, cookie); }
+
+    /// Adds a new "Cookie" header entry with the given pairs.
+    void addCookie(const Container& pairs)
     {
         std::string s;
         s.reserve(256);
@@ -824,6 +827,7 @@ public:
 
     const StatusLine& statusLine() const { return _statusLine; }
 
+    Header& header() { return _header; }
     const Header& header() const { return _header; }
 
     /// Add an HTTP header field.

--- a/test/UnitHTTP.cpp
+++ b/test/UnitHTTP.cpp
@@ -176,18 +176,20 @@ public:
         LOG_TST("Receiving...");
         char buffer[4096] = { 0, };
         int got = socket->receiveBytes(buffer, 4096);
-        static const std::string start =
-            "HTTP/1.0 200 OK\r\n"
-            "Content-Disposition: attachment; filename=\"test.txt\"\r\n";
 
-        if (strncmp(buffer, start.c_str(), start.size()))
-        {
-            LOG_TST("missing pre-amble " << got << " [" << buffer << "] vs. expected [" << start
-                                         << ']');
-            LOK_ASSERT(Util::startsWith(std::string(buffer), start));
-            exitTest(TestResult::Failed);
-            return;
-        }
+        http::Response httpResponse;
+        LOK_ASSERT_MESSAGE("Expected to receive valid data",
+                           httpResponse.readData(buffer, got) > 0);
+        LOK_ASSERT(!httpResponse.statusLine().httpVersion().empty());
+        LOK_ASSERT(!httpResponse.statusLine().reasonPhrase().empty());
+        LOK_ASSERT_EQUAL(static_cast<int>(http::StatusCode::OK),
+                         static_cast<int>(httpResponse.statusLine().statusCode()));
+        LOK_ASSERT(httpResponse.statusLine().statusCategory() ==
+                   http::StatusLine::StatusCodeClass::Successful);
+        LOK_ASSERT_EQUAL(std::string("HTTP/1.1"), httpResponse.statusLine().httpVersion());
+        LOK_ASSERT_EQUAL(std::string("OK"), httpResponse.statusLine().reasonPhrase());
+        LOK_ASSERT_EQUAL(std::string("attachment; filename=\"test.txt\""),
+                         httpResponse.header().get("Content-Disposition"));
 
         // TODO: check content-length etc.
 

--- a/test/UnitWOPITemplate.cpp
+++ b/test/UnitWOPITemplate.cpp
@@ -93,7 +93,9 @@ public:
         {
             LOG_TST("FakeWOPIHost: Handling template GetFile: " << uriReq.getPath());
 
-            HttpHelper::sendFileAndShutdown(socket, TDOC "/test.ott", "");
+            http::Response response(http::StatusCode::OK);
+            HttpHelper::sendFileAndShutdown(socket, TDOC "/test.ott", /*mediaType=*/std::string(),
+                                            response);
 
             return true;
         }

--- a/wsd/Admin.cpp
+++ b/wsd/Admin.cpp
@@ -12,7 +12,6 @@
 #include <sys/poll.h>
 #include <unistd.h>
 
-#include <Poco/Net/HTTPCookie.h>
 #include <Poco/Net/HTTPRequest.h>
 #include <Poco/Net/HTTPResponse.h>
 

--- a/wsd/Admin.cpp
+++ b/wsd/Admin.cpp
@@ -980,13 +980,16 @@ void Admin::getMetrics(std::ostringstream &metrics)
     _model.getMetrics(metrics);
 }
 
-void Admin::sendMetrics(const std::shared_ptr<StreamSocket>& socket, const std::shared_ptr<Poco::Net::HTTPResponse>& response)
+void Admin::sendMetrics(const std::shared_ptr<StreamSocket>& socket,
+                        const std::shared_ptr<http::Response>& response)
 {
     std::ostringstream oss;
-    response->add("Connection", "close");
-    response->write(oss);
     getMetrics(oss);
-    socket->send(oss.str());
+
+    response->add("Connection", "close");
+    response->setBody(oss.str(), "text/plain");
+
+    socket->send(*response);
     socket->shutdown();
 }
 

--- a/wsd/Admin.hpp
+++ b/wsd/Admin.hpp
@@ -155,7 +155,8 @@ public:
     /// Attempt a synchronous connection to a monitor with @uri @when that future comes
     void scheduleMonitorConnect(const std::string &uri, std::chrono::steady_clock::time_point when);
 
-    void sendMetrics(const std::shared_ptr<StreamSocket>& socket, const std::shared_ptr<Poco::Net::HTTPResponse>& response);
+    void sendMetrics(const std::shared_ptr<StreamSocket>& socket,
+                     const std::shared_ptr<http::Response>& response);
 
     void setViewLoadDuration(const std::string& docKey, const std::string& sessionId, std::chrono::milliseconds viewLoadDuration);
     void setDocWopiDownloadDuration(const std::string& docKey, std::chrono::milliseconds wopiDownloadDuration);

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -3859,7 +3859,8 @@ private:
                      requestDetails.equals(1, "getMetrics"))
             {
                 // See metrics.txt
-                std::shared_ptr<Poco::Net::HTTPResponse> response(new Poco::Net::HTTPResponse());
+                std::shared_ptr<http::Response> response =
+                    std::make_shared<http::Response>(http::StatusCode::OK);
 
                 if (!COOLWSD::AdminEnabled)
                     throw Poco::FileAccessDeniedException("Admin console disabled");

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -774,7 +774,7 @@ bool ClientSession::_handleInput(const char *buffer, int length)
     }
     else if (tokens.equals(0, "moveselectedclientparts"))
     {
-        if(!_isTextDocument)
+        if (!_isTextDocument)
         {
             int nPosition;
             if (tokens.size() != 2 ||
@@ -1729,11 +1729,11 @@ bool ClientSession::handleKitToClientMessage(const std::shared_ptr<Message>& pay
                 LOG_TRC("Sending file: " << resultURL.getPath());
 
                 const std::string fileName = Poco::Path(resultURL.getPath()).getFileName();
-                Poco::Net::HTTPResponse response;
+                http::Response response(http::StatusCode::OK);
                 if (!fileName.empty())
                     response.set("Content-Disposition", "attachment; filename=\"" + fileName + '"');
 
-                HttpHelper::sendFileAndShutdown(_saveAsSocket, resultURL.getPath(), mimeType, &response);
+                HttpHelper::sendFileAndShutdown(_saveAsSocket, resultURL.getPath(), mimeType, response);
             }
 
             // Conversion is done, cleanup this fake session.
@@ -2138,20 +2138,20 @@ bool ClientSession::handleKitToClientMessage(const std::shared_ptr<Message>& pay
             LOG_TRC("Sending get-thumbnail response.");
             bool error = false;
 
-            if (firstLine.find("error") != std::string::npos)
-                error = true;
+                if (firstLine.find("error") != std::string::npos)
+                    error = true;
 
-            if (!error)
-            {
-                int firstLineSize = firstLine.size() + 1;
-                std::string thumbnail(payload->data().data() + firstLineSize, payload->data().size() - firstLineSize);
+                if (!error)
+                {
+                    int firstLineSize = firstLine.size() + 1;
+                    std::string thumbnail(payload->data().data() + firstLineSize, payload->data().size() - firstLineSize);
 
-                http::Response httpResponse(http::StatusCode::OK);
-                httpResponse.set("Last-Modified", Util::getHttpTimeNow());
-                httpResponse.set("X-Content-Type-Options", "nosniff");
-                httpResponse.setBody(thumbnail, "image/png");
-                _saveAsSocket->sendAndShutdown(httpResponse);
-            }
+                    http::Response httpResponse(http::StatusCode::OK);
+                    httpResponse.set("Last-Modified", Util::getHttpTimeNow());
+                    httpResponse.set("X-Content-Type-Options", "nosniff");
+                    httpResponse.setBody(thumbnail, "image/png");
+                    _saveAsSocket->sendAndShutdown(httpResponse);
+                }
 
             if (error)
             {

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -201,7 +201,13 @@ bool isConfigAuthOk(const std::string& userProvidedUsr, const std::string& userP
     return pass == userProvidedPwd;
 }
 
+std::string stringifyBoolFromConfig(const Poco::Util::LayeredConfiguration& config,
+                                    const std::string& propertyName, bool defaultValue)
+{
+    return config.getBool(propertyName, defaultValue) ? "true" : "false";
 }
+
+} // namespace
 
 bool FileServerRequestHandler::isAdminLoggedIn(const Poco::Net::HTTPRequest& request,
                                                std::string& jwtToken)

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -13,8 +13,9 @@
 #include "Auth.hpp"
 #include "COOLWSD.hpp"
 #include "Exceptions.hpp"
-#include "FileServer.hpp"
 #include "FileUtil.hpp"
+#include "HttpRequest.hpp"
+#include "RequestDetails.hpp"
 #include "ServerURL.hpp"
 #include <Common.hpp>
 #include <Crypto.hpp>
@@ -240,8 +241,7 @@ bool FileServerRequestHandler::isAdminLoggedIn(const Poco::Net::HTTPRequest& req
 }
 
 bool FileServerRequestHandler::authenticateAdmin(const Poco::Net::HTTPBasicCredentials& credentials,
-                                                 Poco::Net::HTTPResponse& response,
-                                                 std::string& jwtToken)
+                                                 http::Response& response, std::string& jwtToken)
 {
     assert(COOLWSD::AdminEnabled);
 
@@ -279,35 +279,16 @@ bool FileServerRequestHandler::authenticateAdmin(const Poco::Net::HTTPBasicCrede
     // bundlify appears to add an extra /dist -> dist/dist/admin
     cookie.setPath(COOLWSD::ServiceRoot + "/browser/dist/");
     cookie.setSecure(COOLWSD::isSSLEnabled());
-    response.addCookie(cookie);
+    response.header().addCookie(cookie.toString());
 
     return true;
 }
 
-bool FileServerRequestHandler::isAdminLoggedIn(const HTTPRequest& request,
-                                               HTTPResponse &response)
+bool FileServerRequestHandler::isAdminLoggedIn(const HTTPRequest& request, http::Response& response)
 {
     std::string jwtToken;
     return isAdminLoggedIn(request, jwtToken) ||
            authenticateAdmin(Poco::Net::HTTPBasicCredentials(request), response, jwtToken);
-}
-
-bool FileServerRequestHandler::isAdminLoggedIn(const HTTPRequest& request, http::Response& response)
-{
-    // For now, we reuse the exiting implementation, which uses Poco HTTPCookie.
-    Poco::Net::HTTPResponse pocoResponse;
-    if (isAdminLoggedIn(request, pocoResponse))
-    {
-        // Copy the headers, including the cookies.
-        for (const auto& pair : pocoResponse)
-        {
-            response.set(pair.first, pair.second);
-        }
-
-        return true;
-    }
-
-    return false;
 }
 
 #if ENABLE_DEBUG
@@ -1304,7 +1285,7 @@ void FileServerRequestHandler::preprocessAdminFile(const HTTPRequest& request,
     if (!COOLWSD::AdminEnabled)
         throw Poco::FileAccessDeniedException("Admin console disabled");
 
-    Poco::Net::HTTPResponse response;
+    http::Response response(http::StatusCode::OK);
     std::string jwtToken;
     if (!isAdminLoggedIn(request, jwtToken))
     {
@@ -1368,13 +1349,8 @@ void FileServerRequestHandler::preprocessAdminFile(const HTTPRequest& request,
     response.set("Server", HTTP_SERVER_STRING);
     response.set("Date", Util::getHttpTimeNow());
 
-    response.setContentType("text/html");
-    response.setChunkedTransferEncoding(false);
-
-    std::ostringstream oss;
-    response.write(oss);
-    oss << templateFile;
-    socket->send(oss.str());
+    response.setBody(std::move(templateFile));
+    socket->send(response);
 }
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -1,5 +1,9 @@
 /* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
 /*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -72,7 +76,8 @@ using Poco::Util::Application;
 
 std::map<std::string, std::pair<std::string, std::string>> FileServerRequestHandler::FileHash;
 
-namespace {
+namespace
+{
 
 int functionConversation(int /*num_msg*/, const struct pam_message** /*msg*/,
                          struct pam_response **reply, void *appdata_ptr)
@@ -523,9 +528,10 @@ void FileServerRequestHandler::handleRequest(const HTTPRequest& request,
         {
             if (config.getBool("ssl.sts.enabled", false))
             {
-                const auto maxAge = config.getInt("ssl.sts.max_age", 31536000); // Default 1 year.
+                const auto maxAge =
+                    config.getInt("ssl.sts.max_age", 31536000); // Default 1 year.
                 response.add("Strict-Transport-Security",
-                             "max-age=" + std::to_string(maxAge) + "; includeSubDomains");
+                                "max-age=" + std::to_string(maxAge) + "; includeSubDomains");
             }
         }
 #endif
@@ -857,6 +863,7 @@ std::string FileServerRequestHandler::getRequestPathname(const HTTPRequest& requ
     requestUri.normalize();
 
     std::string path(requestUri.getPath());
+
     Poco::RegularExpression gitHashRe("/([0-9a-f]+)/");
     std::string gitHash;
     if (gitHashRe.extract(path, gitHash))
@@ -1167,23 +1174,19 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
         LOG_TRC("Denied all frame ancestors");
     }
 
+    http::Response httpResponse(http::StatusCode::OK);
+    httpResponse.set("Last-Modified", Util::getHttpTimeNow());
+    httpResponse.set("Cache-Control", "max-age=11059200");
+    httpResponse.set("ETag", COOLWSD_VERSION_HASH);
+
+    httpResponse.add("X-Content-Type-Options", "nosniff");
+    httpResponse.add("X-XSS-Protection", "1; mode=block");
+    httpResponse.add("Referrer-Policy", "no-referrer");
+
     csp.merge(config.getString("net.content_security_policy", ""));
 
-    std::ostringstream oss;
-    oss << "HTTP/1.1 200 OK\r\n"
-        "Date: " << Util::getHttpTimeNow() << "\r\n"
-        "Last-Modified: " << Util::getHttpTimeNow() << "\r\n"
-        "User-Agent: " << WOPI_AGENT_STRING << "\r\n"
-        "Cache-Control:max-age=11059200\r\n"
-        "ETag: \"" COOLWSD_VERSION_HASH "\"\r\n"
-        "Content-Length: " << preprocess.size() << "\r\n"
-        "Content-Type: " << mimeType << "\r\n"
-        "X-Content-Type-Options: nosniff\r\n"
-        "X-XSS-Protection: 1; mode=block\r\n"
-        "Referrer-Policy: no-referrer\r\n";
-
     // Append CSP to response headers too
-    oss << "Content-Security-Policy: " << csp.generate() << "\r\n";
+    httpResponse.add("Content-Security-Policy", csp.generate());
 
     // Setup HTTP Public key pinning
     if ((COOLWSD::isSSLEnabled() || COOLWSD::isSSLTermination()) && config.getBool("ssl.hpkp[@enable]", false))
@@ -1233,22 +1236,20 @@ void FileServerRequestHandler::preprocessFile(const HTTPRequest& request,
             {
                 // Only send validation failure reports to reportUri while still allowing UAs to
                 // connect to the server
-                oss << "Public-Key-Pins-Report-Only: " << hpkpOss.str() << "\r\n";
+                httpResponse.add("Public-Key-Pins-Report-Only", hpkpOss.str());
             }
             else
             {
-                oss << "Public-Key-Pins: " << hpkpOss.str() << "\r\n";
+                httpResponse.add("Public-Key-Pins", hpkpOss.str());
             }
         }
     }
 
-    oss << "\r\n"
-        << preprocess;
+    httpResponse.setBody(preprocess, mimeType);
 
-    socket->send(oss.str());
+    socket->send(httpResponse);
     LOG_TRC("Sent file: " << relPath << ": " << preprocess);
 }
-
 
 void FileServerRequestHandler::preprocessWelcomeFile(const HTTPRequest& request,
                                                      const RequestDetails &/*requestDetails*/,

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -292,69 +292,9 @@ bool FileServerRequestHandler::authenticateAdmin(const Poco::Net::HTTPBasicCrede
 bool FileServerRequestHandler::isAdminLoggedIn(const HTTPRequest& request,
                                                HTTPResponse &response)
 {
-    assert(COOLWSD::AdminEnabled);
-
-    const auto& config = Application::instance().config();
-
-    NameValueCollection cookies;
-    request.getCookies(cookies);
-    try
-    {
-        const std::string jwtToken = cookies.get("jwt");
-        LOG_INF("Verifying JWT token: " << jwtToken);
-        JWTAuth authAgent("admin", "admin", "admin");
-        if (authAgent.verify(jwtToken))
-        {
-            LOG_TRC("JWT token is valid");
-            return true;
-        }
-
-        LOG_INF("Invalid JWT token, let the administrator re-login");
-    }
-    catch (const Poco::Exception& exc)
-    {
-        LOG_INF("No existing JWT cookie found");
-    }
-
-    // If no cookie found, or is invalid, let the admin re-login
-    HTTPBasicCredentials credentials(request);
-    const std::string& userProvidedUsr = credentials.getUsername();
-    const std::string& userProvidedPwd = credentials.getPassword();
-
-    // Deny attempts to login without providing a username / pwd and fail right away
-    // We don't even want to allow a password-less PAM module to be used here,
-    // or anything.
-    if (userProvidedUsr.empty() || userProvidedPwd.empty())
-    {
-        LOG_ERR("An attempt to log into Admin Console without username or password.");
-        return false;
-    }
-
-    // Check if the user is allowed to use the admin console
-    if (config.getBool("admin_console.enable_pam", "false"))
-    {
-        // use PAM - it needs the username too
-        if (!isPamAuthOk(userProvidedUsr, userProvidedPwd))
-            return false;
-    }
-    else
-    {
-        // use the hash or password in the config file
-        if (!isConfigAuthOk(userProvidedUsr, userProvidedPwd))
-            return false;
-    }
-
-    // authentication passed, generate and set the cookie
-    JWTAuth authAgent("admin", "admin", "admin");
-    const std::string jwtToken = authAgent.getAccessToken();
-
-    Poco::Net::HTTPCookie cookie("jwt", jwtToken);
-    // bundlify appears to add an extra /dist -> dist/dist/admin
-    cookie.setPath(COOLWSD::ServiceRoot + "/browser/dist/");
-    cookie.setSecure(COOLWSD::isSSLEnabled());
-    response.addCookie(cookie);
-
-    return true;
+    std::string jwtToken;
+    return isAdminLoggedIn(request, jwtToken) ||
+           authenticateAdmin(Poco::Net::HTTPBasicCredentials(request), response, jwtToken);
 }
 
 #if ENABLE_DEBUG

--- a/wsd/FileServer.hpp
+++ b/wsd/FileServer.hpp
@@ -38,15 +38,18 @@ class FileServerRequestHandler
     static std::string getRequestPathname(const Poco::Net::HTTPRequest& request);
 
     static void preprocessFile(const Poco::Net::HTTPRequest& request,
+                               http::Response& httpResponse,
                                const RequestDetails &requestDetails,
                                Poco::MemoryInputStream& message,
                                const std::shared_ptr<StreamSocket>& socket);
     static void preprocessWelcomeFile(const Poco::Net::HTTPRequest& request,
-                                      const RequestDetails &requestDetails,
-                                      Poco::MemoryInputStream& message,
+                                      http::Response& httpResponse,
+                                      const RequestDetails& /*requestDetails*/,
+                                      Poco::MemoryInputStream& /*message*/,
                                       const std::shared_ptr<StreamSocket>& socket);
     static void preprocessAdminFile(const Poco::Net::HTTPRequest& request,
-                                    const RequestDetails &requestDetails,
+                                    http::Response& httpResponse,
+                                    const RequestDetails& requestDetails,
                                     const std::shared_ptr<StreamSocket>& socket);
 
     /// Construct a JSON to be accepted by the cool.html from a list like

--- a/wsd/FileServer.hpp
+++ b/wsd/FileServer.hpp
@@ -65,6 +65,7 @@ public:
 
     /// Evaluate if the cookie exists, and if not, ask for the credentials.
     static bool isAdminLoggedIn(const Poco::Net::HTTPRequest& request, Poco::Net::HTTPResponse& response);
+    static bool isAdminLoggedIn(const Poco::Net::HTTPRequest& request, http::Response& response);
 
     /// Authenticate the admin.
     static bool authenticateAdmin(const Poco::Net::HTTPBasicCredentials& credentials,

--- a/wsd/FileServer.hpp
+++ b/wsd/FileServer.hpp
@@ -47,10 +47,6 @@ class FileServerRequestHandler
 
     static std::string cssVarsToStyle(const std::string& cssVars);
 
-    static std::string stringifyBoolFromConfig(const Poco::Util::LayeredConfiguration& config,
-                                               std::string propertyName,
-                                               bool defaultValue);
-
 public:
     /// Evaluate if the cookie exists and returns it when it does.
     static bool isAdminLoggedIn(const Poco::Net::HTTPRequest& request, std::string& jwtToken);

--- a/wsd/FileServer.hpp
+++ b/wsd/FileServer.hpp
@@ -69,7 +69,7 @@ public:
 
     /// Authenticate the admin.
     static bool authenticateAdmin(const Poco::Net::HTTPBasicCredentials& credentials,
-                                  Poco::Net::HTTPResponse& response, std::string& jwtToken);
+                                  http::Response& response, std::string& jwtToken);
 
     static void handleRequest(const Poco::Net::HTTPRequest& request,
                               const RequestDetails &requestDetails,

--- a/wsd/FileServer.hpp
+++ b/wsd/FileServer.hpp
@@ -66,6 +66,10 @@ public:
     /// Evaluate if the cookie exists, and if not, ask for the credentials.
     static bool isAdminLoggedIn(const Poco::Net::HTTPRequest& request, Poco::Net::HTTPResponse& response);
 
+    /// Authenticate the admin.
+    static bool authenticateAdmin(const Poco::Net::HTTPBasicCredentials& credentials,
+                                  Poco::Net::HTTPResponse& response, std::string& jwtToken);
+
     static void handleRequest(const Poco::Net::HTTPRequest& request,
                               const RequestDetails &requestDetails,
                               Poco::MemoryInputStream& message,

--- a/wsd/FileServer.hpp
+++ b/wsd/FileServer.hpp
@@ -12,12 +12,24 @@
 #pragma once
 
 #include <string>
-#include "Socket.hpp"
+#include <unordered_map>
 
-#include <Poco/MemoryStream.h>
-#include <Poco/Util/LayeredConfiguration.h>
+#include <HttpRequest.hpp>
+#include <Socket.hpp>
 
 class RequestDetails;
+
+namespace Poco
+{
+namespace Net
+{
+class HTTPRequest;
+class HTTPResponse;
+class HTTPBasicCredentials;
+} // namespace Net
+
+} // namespace Poco
+
 /// Handles file requests over HTTP(S).
 class FileServerRequestHandler
 {

--- a/wsd/FileServer.hpp
+++ b/wsd/FileServer.hpp
@@ -1,5 +1,9 @@
 /* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
 /*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -48,6 +52,9 @@ class FileServerRequestHandler
                                                bool defaultValue);
 
 public:
+    /// Evaluate if the cookie exists and returns it when it does.
+    static bool isAdminLoggedIn(const Poco::Net::HTTPRequest& request, std::string& jwtToken);
+
     /// Evaluate if the cookie exists, and if not, ask for the credentials.
     static bool isAdminLoggedIn(const Poco::Net::HTTPRequest& request, Poco::Net::HTTPResponse& response);
 

--- a/wsd/FileServerUtil.cpp
+++ b/wsd/FileServerUtil.cpp
@@ -217,15 +217,4 @@ std::string FileServerRequestHandler::cssVarsToStyle(const std::string& cssVars)
     return previousStyle;
 }
 
-std::string FileServerRequestHandler::stringifyBoolFromConfig(
-                                                const Poco::Util::LayeredConfiguration& config,
-                                                std::string propertyName,
-                                                bool defaultValue)
-{
-    std::string value = "false";
-    if (config.getBool(propertyName, defaultValue))
-        value = "true";
-    return value;
-}
-
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/FileServerUtil.cpp
+++ b/wsd/FileServerUtil.cpp
@@ -9,7 +9,6 @@
 
 #include "FileServer.hpp"
 #include "StringVector.hpp"
-#include "Util.hpp"
 
 #include <Poco/JSON/Object.h>
 


### PR DESCRIPTION
- wsd: new isAdminLoggedIn that only verifies a valid token
- wsd: move stringifyBoolFromConfig to anonymous namespace
- wsd: include cleanup
- wsd: add authenticateAdmin helper
- wsd: simplify isAdminLoggedIn
- wsd: simplify jwtToken extraction
- killpoco: replace HTTPResponse in sendFileAndShutdown
- killpoco: use http::Response for Admin metrics
- killpoco: use http::Response in admin file serving
- wsd: use http::Response in FileServerRequestHandler::preprocessFile
- wsd: reuse the response in FileServer
