### PR TITLE
browser: ignore validation of hidden inputs

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -192,6 +192,9 @@ L.Control.JSDialogBuilder = L.Control.extend({
 
 		var inputs = this._container.querySelectorAll('input[type="number"]');
 		for (var item = 0; item < inputs.length; item++) {
+			if (!inputs[item].checkVisibility())
+				continue;
+
 			isValid = inputs[item].reportValidity();
 			if (!isValid)
 				break;


### PR DESCRIPTION
"An invalid form control with name='' is not focusable."

Change-Id: Ic81d91748371147beed6cbc7b43cc569412760ba
Signed-off-by: Henry Castro <hcastro@collabora.com>
