### PR TITLE
backport 23.05: Fix LOUtil.checkIfImageExists reprocessing errors

### DIFF
--- a/browser/src/control/Control.UserList.js
+++ b/browser/src/control/Control.UserList.js
@@ -113,7 +113,7 @@ L.Control.UserList = L.Control.extend({
 			$(img).css({'border-color': color, 'background-color': '#eee', 'background-image': 'url("' + L.LOUtil.getImageURL('user.svg', this.map._docLayer._docType) + '")'});
 		}
 		img.setAttribute('data-view-id', viewId);
-		L.LOUtil.checkIfImageExists(img);
+		L.LOUtil.checkIfImageExists(img, true);
 		return img;
 	},
 

--- a/browser/src/core/LOUtil.js
+++ b/browser/src/core/LOUtil.js
@@ -128,19 +128,34 @@ L.LOUtil = {
 		}
 		return defaultImageURL;
 	},
-	checkIfImageExists : function(imageElement) {
-		imageElement.addEventListener('error', function() {
-			if (imageElement.src && imageElement.src.includes('images/branding/dark')) {
-				imageElement.src = imageElement.src.replace('images/branding/dark', 'images/dark');
+	checkIfImageExists: function (imageElement, imageIsLayoutCritical) {
+		imageElement.addEventListener('error', function (e) {
+			if (e.loUtilProcessed) {
 				return;
 			}
-			if (imageElement.src && (imageElement.src.includes('images/dark')|| imageElement.src.includes('images/branding'))) {
-				imageElement.src = imageElement.src.replace('images/dark', 'images');
-				imageElement.src = imageElement.src.replace('images/branding', 'images');
+
+			if (imageElement.src && imageElement.src.includes('/images/branding/dark/')) {
+				imageElement.src = imageElement.src.replace('/images/branding/dark/', '/images/dark/');
+				e.loUtilProcessed = true;
 				return;
 			}
+			if (imageElement.src && (imageElement.src.includes('/images/dark/') || imageElement.src.includes('/images/branding/'))) {
+				imageElement.src = imageElement.src.replace('/images/dark/', '/images/');
+				imageElement.src = imageElement.src.replace('/images/branding/', '/images/');
+				e.loUtilProcessed = true;
+				return;
+			}
+
+			if (imageIsLayoutCritical) {
+                imageElement.src = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
+                // We cannot set visibility: hidden because that would hide other attributes of the image, e.g. its border
+				e.loUtilProcessed = true;
+                return;
+			}
+
 			imageElement.style.display = 'none';
-			});
+			e.loUtilProcessed = true;
+		});
 	},
 	/// oldFileName = Example.odt, suffix = new
 	/// returns: Example_new.odt


### PR DESCRIPTION
This is a backport of only the fixing commit of #8633. It doesn't contain the reversion, because the reverted commit was never backported.

> Previously, we would sometimes get the same error event mulitple times,
leading to us erroneously believing that an image which loaded correctly
was invalid. This caused images to sometimes disappear, particularly
when switching to dark mode.
> 
> Additionally, some images are critical to layout so even if they fail to
load we should not 'display: none' them. We can set their src to an
invisible pixel to get a similar effect. We must assume that they have
their width/height correctly set elsewhere or things such as the broken
image would also break the layout.