### PR TITLE
browser: fix dialog warning alerts (23.05)

### DIFF
--- a/browser/src/control/Control.AlertDialog.js
+++ b/browser/src/control/Control.AlertDialog.js
@@ -21,7 +21,7 @@ L.Control.AlertDialog = L.Control.extend({
 	},
 
 	_onError: function(e) {
-		if (!this._map._fatal) {
+		if (!this._map._fatal && e.type !== 'warn') {
 			this._map.uiManager.closeAll();
 		}
 


### PR DESCRIPTION
* Enable security.enable_macros_execution in coolwsd.xml.
* Open a file with a macro.
* Click Help.

Expected result: the popup dialog should not close

Change-Id: I3981c1ddbb3782dd9ee43dc0c9dce282d2f21392
Signed-off-by: Henry Castro <hcastro@collabora.com>
(cherry picked from commit 5210cf752fb44974b4a222e4b250d879849ce36f)


* Target version: 23.05

### Checklist

- [X`] Code is properly formatted
- [X] All commits have Change-Id
- [ ] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

