### PR TITLE
Modals should always be placed on top of tooltips

### DIFF
--- a/browser/README
+++ b/browser/README
@@ -387,10 +387,10 @@ x				menu-nb-hamburger > ul (calculated from jquery.smartmenus.js)
 -------------------------------------------
 		on the top
 -------------------------------------------
-1105			dialogs
+1105			dialogs, tooltips
 1001			mobile-edit-button
 1500			mobile-wizard (with class=menuwizard)
 1501			toolbar-hamburger (with class=menuwizard-opened)
-2000			vex-overlay // JSDialog overlay?
-2001			vex dialog (vex-content) // JSDialog content?
+2000			JSDialog overlay
+2001			JSDialog modal
 -------------------------------------------

--- a/browser/css/jquery-ui-lightness.css
+++ b/browser/css/jquery-ui-lightness.css
@@ -923,7 +923,7 @@ button.ui-button::-moz-focus-inner {
 [data-title]:after {
 	padding: 7px 9px;
 	position: absolute;
-	z-index: 9999;
+	z-index: 1105;
 	max-width: 300px;
 	background: var(--color-background-lighter);
 }


### PR DESCRIPTION
Before this commit, already opened ui-tooltips were being placed on top
of everything, including modal dailogs. Fix that, set jquery css
line to the same z-index used by non-modal dialogs.

Additionally: update browser/README file so it documents this change
and clean up vex legacy bits.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ie7123822d96c594433ac197aeb9c651aa9b14461
