### PR TITLE
User avatar should be consistent after mode change

### DIFF
--- a/browser/src/control/Control.UserList.ts
+++ b/browser/src/control/Control.UserList.ts
@@ -163,17 +163,7 @@ class UserList extends L.Control {
 			img = L.DomUtil.create('img', 'avatar-img') as HTMLImageElement;
 		}
 
-		const defaultImage = L.LOUtil.getImageURL(
-			'user.svg',
-			this.map._docLayer._docType,
-		);
-
-		if (extraInfo !== undefined && extraInfo.avatar !== undefined) {
-			img.src = extraInfo.avatar;
-			img.addEventListener('error', () => (img.src = defaultImage));
-		} else {
-			img.src = defaultImage;
-		}
+		L.LOUtil.setUserImage(img, this.map);
 
 		img.alt = this.options.userAvatarAlt.replace('%user', username);
 
@@ -182,8 +172,6 @@ class UserList extends L.Control {
 		img.style.backgroundColor = 'var(--color-background-lighter)';
 
 		img.setAttribute('data-view-id', viewId.toString());
-
-		L.LOUtil.checkIfImageExists(img, true);
 
 		return img;
 	}

--- a/browser/src/core/LOUtil.js
+++ b/browser/src/core/LOUtil.js
@@ -118,6 +118,25 @@ L.LOUtil = {
 
 		map.on('themechanged', setupIcon, this);
 	},
+	setUserImage: function(img, map) {
+		var docType = map.getDocType();
+		// set avatar image if it exist in user extract info
+		var defaultImage = L.LOUtil.getImageURL('user.svg', docType);
+		var myViewId = map._docLayer._viewId;
+		var extraInfo = map._viewInfo[myViewId].userextrainfo;
+		if (extraInfo !== undefined && extraInfo.avatar !== undefined) {
+			// set user avatar
+			img.src = extraInfo.avatar;
+			// Track if error event is already bound to this image
+			img.addEventListener('error', function () {
+				img.src = defaultImage;
+				this.checkIfImageExists(img, true);
+			}.bind(this), {once:true});
+			return;
+		}
+		img.src = defaultImage;
+		this.checkIfImageExists(img, true);
+	},
 	getImageURL: function(imgName, docType) {
 		var defaultImageURL = this.getURL('images/' + imgName);
 		if (window.isLocalStorageAllowed) {

--- a/browser/src/layer/tile/CommentListSection.ts
+++ b/browser/src/layer/tile/CommentListSection.ts
@@ -462,7 +462,7 @@ export class CommentSection extends CanvasSectionObject {
 		var tdImg = L.DomUtil.create(tagTd, 'cool-annotation-img', tr);
 		var tdAuthor = L.DomUtil.create(tagTd, 'cool-annotation-author', tr);
 		var imgAuthor = L.DomUtil.create('img', 'avatar-img', tdImg);
-		L.LOUtil.setImage(imgAuthor, 'user.svg', this.map);
+		L.LOUtil.setUserImage(imgAuthor, this.map);
 		imgAuthor.setAttribute('width', 32);
 		imgAuthor.setAttribute('height', 32);
 		var authorAvatarImg = imgAuthor;

--- a/browser/src/layer/tile/CommentSection.ts
+++ b/browser/src/layer/tile/CommentSection.ts
@@ -270,7 +270,7 @@ export class Comment extends CanvasSectionObject {
 		var tdAuthor = L.DomUtil.create('td', 'cool-annotation-author', tr);
 		var imgAuthor = L.DomUtil.create('img', 'avatar-img', tdImg);
 
-		L.LOUtil.setImage(imgAuthor, 'user.svg', this.map);
+		L.LOUtil.setUserImage(imgAuthor, this.map);
 		imgAuthor.setAttribute('width', this.sectionProperties.imgSize[0]);
 		imgAuthor.setAttribute('height', this.sectionProperties.imgSize[1]);
 


### PR DESCRIPTION
- User avatar should first consider if there is already extract info available or not
- if we already have that image source data then please do not set default value
- also when mode change we do preform some refresh function on all icons
    - `map.on('themechanged', setupIcon, this);`
- in that case as well, first check if we have user extract info or not
- and based on that set image source URL

Signed-off-by: Darshan-upadhyay1110 <darshan.upadhyay@collabora.com>

Change-Id: Ifbd543322f5222fa7717b40a5ae565ed2f3c9891


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

