### PR TITLE
browser: fix scroll tab when loading document

### DIFF
--- a/browser/src/control/Control.Tabs.js
+++ b/browser/src/control/Control.Tabs.js
@@ -217,7 +217,7 @@ L.Control.Tabs = L.Control.extend({
 							}(i).bind(this));
 					}
 
-					if (i === selectedPart) {
+					if (!scrollDiv && i === selectedPart) {
 						horizScrollPos = tab.offsetLeft;
 					}
 


### PR DESCRIPTION
If the element 'spreadsheet-tab-scroll' does not exist
when loads document, then scroll to the selected tab.

Change-Id: Iec86225f7ea97a149d455210921daaf91a4e761a
Signed-off-by: Henry Castro <hcastro@collabora.com>
