### PR TITLE
Change convoluted url and name in windowed presentation

### DIFF
--- a/browser/src/map/handler/Map.SlideShow.js
+++ b/browser/src/map/handler/Map.SlideShow.js
@@ -160,8 +160,8 @@ L.Map.SlideShow = L.Handler.extend({
 					_('OK'), null, false);
 			}
 
-			this._slideShowWindowProxy.document.write(htmlContent)
-			this._slideShowWindowProxy.document.close()
+			this._slideShowWindowProxy.document.documentElement.innerHTML = htmlContent;
+			this._slideShowWindowProxy.document.close();
 			this._slideShowWindowProxy.focus();
 
 			this._slideShowWindowProxy.onload = this._handleSlideWindowLoaded.bind(this);

--- a/browser/src/map/handler/Map.SlideShow.js
+++ b/browser/src/map/handler/Map.SlideShow.js
@@ -3,7 +3,7 @@
  * L.Map.SlideShow is handling the slideShow action
  */
 
-/* global _ */
+/* global _ sanitizeUrl */
 L.Map.mergeOptions({
 	slideShow: true
 });
@@ -211,13 +211,18 @@ L.Map.SlideShow = L.Handler.extend({
 	},
 
 	_generateSlideWindowHtml: function(title, slideURL) {
+		var sanitizer = document.createElement('div');
+		sanitizer.innerText = title;
+
+		var sanitizedTitle = sanitizer.innerHTML;
+		var sanitizedUrl = sanitizeUrl(slideURL);
 		return `
 		<!DOCTYPE html>
 		<html lang="en">
 		<head>
 			<meta charset="UTF-8">
 			<meta name="viewport" content="width=device-width, initial-scale=1.0">
-			<title>${title}</title>
+			<title>${sanitizedTitle}</title>
 			<style>
 				body, html {
 					margin: 0;
@@ -233,7 +238,7 @@ L.Map.SlideShow = L.Handler.extend({
 			</style>
 		</head>
 		<body>
-			<iframe src="${slideURL}"></iframe>
+			<iframe src="${sanitizedUrl}"></iframe>
 		</body>
 		</html>
 		`;

--- a/browser/src/map/handler/Map.SlideShow.js
+++ b/browser/src/map/handler/Map.SlideShow.js
@@ -148,7 +148,7 @@ L.Map.SlideShow = L.Handler.extend({
 		// Windowed Presentation
 		if (this._presentInWindow) {
 
-			var popupTitle = "Windowed Presentation: " + this._map['wopi'].BaseFileName;
+			var popupTitle = _('Windowed Presentation: ') + this._map['wopi'].BaseFileName;
 			const htmlContent = this._generateSlideWindowHtml(popupTitle, this._slideURL);
 
 			this._slideShowWindowProxy = window.open('', '_blank', 'popup');


### PR DESCRIPTION
Open an empty popup with a blank url, then set the content of the popup to be our slideURL wrapped inside an iframe with a user friendly title.
Focus the iframe on load so that arrowkey navigation works and forward the eventlisterner of the iframe to the parent window to watch for escape key calls

Change-Id: Ie1063095db51119fd45453b8b4b180fcacb6d7c1


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

