### PR TITLE
Direct Label Association

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -1345,7 +1345,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 
 		var radiobuttonLabel = L.DomUtil.createWithId('label', data.id + '-label', container);
 		radiobuttonLabel.textContent = builder._cleanText(data.text);
-		radiobuttonLabel.htmlFor = data.id;
+		radiobuttonLabel.htmlFor = data.id + '-input';
 
 		radiobutton.setAttribute('aria-labelledby', radiobuttonLabel.id);
 
@@ -1385,7 +1385,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		var checkboxLabel = L.DomUtil.create('label', builder.options.cssClass, div);
 		checkboxLabel.id = data.id + '-label';
 		checkboxLabel.textContent = builder._cleanText(data.text);
-		checkboxLabel.htmlFor = data.id;
+		checkboxLabel.htmlFor = data.id + '-input';
 
 		checkbox.setAttribute('aria-labelledby', checkboxLabel.id);
 
@@ -1801,7 +1801,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		var fixedtext = L.DomUtil.create('label', builder.options.cssClass, parentContainer);
 
 		if (data.labelFor)
-			fixedtext.htmlFor = data.labelFor;
+			fixedtext.htmlFor = data.labelFor + '-input';
 
 		if (data.text)
 			fixedtext.textContent = builder._cleanText(data.text);


### PR DESCRIPTION
A11y improvement

Problem

-  The labels for the `select` elements are being associated with a `div` element that surrounds the corresponding `select` element, instead of directly linking it to the `select` element.

-  This creates an unclear semantic relationship between the label and the actual form element, affecting usability for users with assistive technologies

-  this was not only issue with `select` element but for all input selection elements in JSDialogBuilder

Solution

-  `lable` and it's corresponding `input/select` element should have same `for` and `id` values
-   this patch will make `for` attr of `label` equals to `id` attr value of 'input/select' elements

Change-Id: If341174edcdb72af6fde3da14d5ed36ba0c3ae95


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

