### PR TITLE
calc: Fix pinch zoom positioning

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -667,12 +667,6 @@ L.TileSectionManager = L.Class.extend({
 			yMin = splitPos.y;
 		}
 
-
-		pinchCenter = {
-			x: clamp(pinchCenter.x, paneBounds.min.x, paneBounds.max.x),
-			y: clamp(pinchCenter.y, paneBounds.min.y, paneBounds.max.y)
-		};
-
 		const documentTopLeft = new L.Point(xMin, yMin);
 
 		const paneSize = paneBounds.getSize();

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -647,7 +647,7 @@ L.TileSectionManager = L.Class.extend({
 	 *
 	 * @param findFreePaneCenter {boolean} Wether to return a center point
 	 *
-	 * @returns {{topLeft: {x: number, y: number}, center?: {x: number, y: number}}} An object with a top left point in core-pixels and optionally a center point in core-pixels
+	 * @returns {{topLeft: {x: number, y: number}, center?: {x: number, y: number}}} An object with a top left point in core-pixels and optionally a center point
 	 * Center is included iff findFreePaneCenter is true
 	 * (probably this should be encoded into the type, e.g. with an overload when this is converted to TypeScript)
 	 **/
@@ -699,12 +699,12 @@ L.TileSectionManager = L.Class.extend({
 		}
 
 		const newPaneCenter = new L.Point(
-			(docTopLeft.x - splitPos.x + (paneSize.x + splitPos.x) / (2 * scale)) * scale / app.dpiScale,
-			(docTopLeft.y - splitPos.y + (paneSize.y + splitPos.y) / (2 * scale)) * scale / app.dpiScale);
+			(docTopLeft.x - splitPos.x + (paneSize.x + splitPos.x) * 0.5 / scale) / app.dpiScale,
+			(docTopLeft.y - splitPos.y + (paneSize.y + splitPos.y) * 0.5 / scale) / app.dpiScale);
 
 		return {
 			topLeft: docTopLeft,
-			center: newPaneCenter
+			center: this._map.project(this._map.unproject(newPaneCenter, this._map.getZoom()), this._map.getScaleZoom(scale))
 		};
 	},
 

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -627,43 +627,78 @@ L.TileSectionManager = L.Class.extend({
 		this._sectionContainer.requestReDraw();
 	},
 
-	_getZoomDocPos: function (pinchCenter, paneBounds, splitPos, scale, findFreePaneCenter) {
-		var inXBounds = (pinchCenter.x >= paneBounds.min.x) && (pinchCenter.x <= paneBounds.max.x);
-		var inYBounds = (pinchCenter.y >= paneBounds.min.y) && (pinchCenter.y <= paneBounds.max.y);
-
-		// Calculate the pinch-center in off-screen canvas coordinates.
-		var center = paneBounds.min.clone();
-		if (inXBounds)
-			center.x = pinchCenter.x;
-		if (inYBounds)
-			center.y = pinchCenter.y;
-
-		var xMin = 0;
-		var hasXMargin = !this._layer.isCalc();
-		if (hasXMargin)
+	/**
+	 * Everything in this doc comment is speculation: I didn't write the code that supplies it and I'm guessing to
+	 * have something to work on for this function. That said, given my observations, they seem incredibly likely to be correct
+	 *
+	 * @param pinchCenter {{x: number, y: number}} The current pinch center in doc core-pixels
+	 * Normally expressed as an L.Point instance
+	 *
+	 * @param pinchStartCenter {{x: number, y: number}} The pinch center at the start of the pinch in doc core-pixels
+	 * Normally expressed as an L.Point instance
+	 *
+	 * @param paneBounds {{min: {x: number, y: number}, max: {x: number, y: number}}} The edges of the current pane
+	 * Traditionally this is the map border at the start of the pinch
+	 *
+	 * @param splitPos {{x: number, y: number}} The inset in core-pixels into the document caused by any splits (e.g. a frozen row at the start of the document)
+	 *
+	 * @param scale {number} The scale, relative to the initial size, of the document currently
+	 * Or rather this is equivalent to: old_width / new_width
+	 *
+	 * @param findFreePaneCenter {boolean} Wether to return a center point
+	 *
+	 * @returns {{topLeft: {x: number, y: number}, center?: {x: number, y: number}}} An object with a top left point in core-pixels and optionally a center point in core-pixels
+	 * Center is included iff findFreePaneCenter is true
+	 * (probably this should be encoded into the type, e.g. with an overload when this is converted to TypeScript)
+	 **/
+	_getZoomDocPos: function (pinchCenter, pinchStartCenter, paneBounds, splitPos, scale, findFreePaneCenter) {
+		let xMin = 0;
+		const hasXMargin = !this._layer.isCalc();
+		if (hasXMargin) {
 			xMin = -Infinity;
-		else if (paneBounds.min.x > 0)
+		} else if (paneBounds.min.x > 0) {
 			xMin = splitPos.x;
+		}
 
-		var yMin = 0;
-		if (paneBounds.min.y < 0)
+		let yMin = 0;
+		if (paneBounds.min.y < 0) {
 			yMin = -Infinity;
-		else if (paneBounds.min.y > 0)
+		} else if (paneBounds.min.y > 0) {
 			yMin = splitPos.y;
+		}
+
+
+		pinchCenter = {
+			x: clamp(pinchCenter.x, paneBounds.min.x, paneBounds.max.x),
+			y: clamp(pinchCenter.y, paneBounds.min.y, paneBounds.max.y)
+		};
+
+		const documentTopLeft = new L.Point(xMin, yMin);
+
+		const paneSize = paneBounds.getSize();
+
+		let centerOffset = {
+			x: pinchCenter.x - pinchStartCenter.x,
+			y: pinchCenter.y - pinchStartCenter.y,
+		};
+
+		// Portion of the pane away that our pinchStart (which should be where we zoom round) is
+		const panePortion = {
+			x: (pinchStartCenter.x - paneBounds.min.x) / paneSize.x,
+			y: (pinchStartCenter.y - paneBounds.min.y) / paneSize.y,
+		};
 
 		// Top left in document coordinates.
-		var docTopLeft = new L.Point(
-			Math.max(xMin,
-				center.x - (center.x - paneBounds.min.x) / scale),
-			Math.max(yMin,
-				center.y - (center.y - paneBounds.min.y) / scale));
+		const docTopLeft = new L.Point(
+			Math.max(documentTopLeft.x, pinchStartCenter.x + (centerOffset.x - paneSize.x * panePortion.x) / scale),
+			Math.max(documentTopLeft.y, pinchStartCenter.y + (centerOffset.y - paneSize.y * panePortion.y) / scale)
+		);
 
-		if (!findFreePaneCenter)
+		if (!findFreePaneCenter) {
 			return { topLeft: docTopLeft };
+		}
 
-		// Assumes paneBounds is the bounds of the free pane.
-		var paneSize = paneBounds.getSize();
-		var newPaneCenter = new L.Point(
+		const newPaneCenter = new L.Point(
 			(docTopLeft.x - splitPos.x + (paneSize.x + splitPos.x) / (2 * scale)) * scale / app.dpiScale,
 			(docTopLeft.y - splitPos.y + (paneSize.y + splitPos.y) / (2 * scale)) * scale / app.dpiScale);
 
@@ -680,7 +715,7 @@ L.TileSectionManager = L.Class.extend({
 		var viewBounds = ctx.viewBounds;
 		var freePaneBounds = new L.Bounds(viewBounds.min.add(splitPos), viewBounds.max);
 
-		return this._getZoomDocPos(this._newCenter, freePaneBounds, splitPos, scale, true /* findFreePaneCenter */).center;
+		return this._getZoomDocPos(this._newCenter, this._layer._pinchStartCenter, freePaneBounds, splitPos, scale, true /* findFreePaneCenter */).center;
 	},
 
 	_zoomAnimation: function () {
@@ -5633,7 +5668,9 @@ L.CanvasTileLayer = L.Layer.extend({
 		this._painter.zoomStepEnd(zoom, newCenter, mapUpdater, runAtFinish, noGap);
 	},
 
-	preZoomAnimation: function () {
+	preZoomAnimation: function (pinchStartCenter) {
+		this._pinchStartCenter = this._map.project(pinchStartCenter).multiplyBy(app.dpiScale); // in core pixels
+
 		if (this.isCursorVisible()) {
 			this._cursorMarker.setOpacity(0);
 		}
@@ -5656,6 +5693,9 @@ L.CanvasTileLayer = L.Layer.extend({
 				viewCursorMarker.setOpacity(0);
 			}
 		}, this, true);
+
+
+
 	},
 
 	postZoomAnimation: function () {
@@ -5688,7 +5728,7 @@ L.CanvasTileLayer = L.Layer.extend({
 	// Meant for desktop case, where the ending zoom and centers are all known in advance.
 	runZoomAnimation: function (zoomEnd, pinchCenter, mapUpdater, runAtFinish) {
 
-		this.preZoomAnimation();
+		this.preZoomAnimation(pinchCenter);
 		this.zoomStep(this._map.getZoom(), pinchCenter);
 		var thisObj = this;
 		this.zoomStepEnd(zoomEnd, pinchCenter,

--- a/browser/src/layer/tile/TilesSection.ts
+++ b/browser/src/layer/tile/TilesSection.ts
@@ -766,7 +766,7 @@ export class TilesSection extends CanvasSectionObject {
 			var paneSize = paneBounds.getSize();
 
 			// Calculate top-left in doc core-pixels for the frame.
-			var docPos = tsManager._getZoomDocPos(tsManager._newCenter, paneBounds, splitPos, scale, false /* findFreePaneCenter? */);
+			var docPos = tsManager._getZoomDocPos(tsManager._newCenter, tsManager._layer._pinchStartCenter, paneBounds, splitPos, scale, false /* findFreePaneCenter? */);
 
 			var destPos = new L.Point(0, 0);
 			var docAreaSize = paneSize.divideBy(scale);

--- a/browser/src/map/handler/Map.Scroll.js
+++ b/browser/src/map/handler/Map.Scroll.js
@@ -118,7 +118,7 @@ L.Map.Scroll = L.Handler.extend({
 
 		if (newAnimation) {
 			this._inZoomAnimation = true;
-			this._map._docLayer.preZoomAnimation();
+			this._map._docLayer.preZoomAnimation(this._zoomCenter);
 			this._zoomInterpolateRAF = requestAnimationFrame(this._zoomInterpolateRAFFunc.bind(this));
 		}
 	},

--- a/browser/src/map/handler/Map.TouchGesture.js
+++ b/browser/src/map/handler/Map.TouchGesture.js
@@ -578,7 +578,6 @@ L.Map.TouchGesture = L.Handler.extend({
 
 		if (this._inSwipeAction) {
 			this._cancelAutoscrollRAF();
-			return;
 		}
 
 		if (isNaN(e.center.x) || isNaN(e.center.y))

--- a/browser/src/map/handler/Map.TouchGesture.js
+++ b/browser/src/map/handler/Map.TouchGesture.js
@@ -599,7 +599,6 @@ L.Map.TouchGesture = L.Handler.extend({
 		var offset = {x: e.center.x - this._pinchStartCenter.x, y: e.center.y - this._pinchStartCenter.y};
 		var center = {x: this._pinchStartCenter.x - offset.x, y: this._pinchStartCenter.y - offset.y};
 		this._zoom = this._map._limitZoom(this._map.getScaleZoom(e.scale));
-		this._center = this._map.mouseEventToLatLng({clientX: center.x, clientY: center.y});
 		this._origCenter = this._map.mouseEventToLatLng({clientX: center.x, clientY: center.y});
 
 
@@ -625,7 +624,7 @@ L.Map.TouchGesture = L.Handler.extend({
 			var thisObj = this;
 			this._map._docLayer.zoomStepEnd(finalZoom, this._origCenter,
 				function (newMapCenter) { // mapUpdater
-					thisObj._map.setView(newMapCenter || thisObj._center, finalZoom);
+					thisObj._map.setView(newMapCenter, finalZoom);
 				},
 				// showMarkers
 				function () {

--- a/browser/src/map/handler/Map.TouchGesture.js
+++ b/browser/src/map/handler/Map.TouchGesture.js
@@ -583,8 +583,9 @@ L.Map.TouchGesture = L.Handler.extend({
 		if (isNaN(e.center.x) || isNaN(e.center.y))
 			return;
 
-		this._pinchStartCenter = {x: e.center.x, y: e.center.y};
-		this._map._docLayer.preZoomAnimation();
+		this._pinchStartCenter = { x: e.center.x, y: e.center.y };
+		const _pinchStartLatLng = this._map.mouseEventToLatLng({ clientX: e.center.x, clientY: e.center.y });
+		this._map._docLayer.preZoomAnimation(_pinchStartLatLng);
 	},
 
 	_onPinch: function (e) {
@@ -598,11 +599,9 @@ L.Map.TouchGesture = L.Handler.extend({
 		var offset = {x: e.center.x - this._pinchStartCenter.x, y: e.center.y - this._pinchStartCenter.y};
 		var center = {x: this._pinchStartCenter.x - offset.x, y: this._pinchStartCenter.y - offset.y};
 		this._zoom = this._map._limitZoom(this._map.getScaleZoom(e.scale));
-		this._center = this._map._limitCenter(this._map.mouseEventToLatLng({clientX: center.x, clientY: center.y}),
-						      this._zoom, this._map.options.maxBounds);
+		this._center = this._map.mouseEventToLatLng({clientX: center.x, clientY: center.y});
+		this._origCenter = this._map.mouseEventToLatLng({clientX: center.x, clientY: center.y});
 
-		this._origCenter = this._map._limitCenter(this._map.mouseEventToLatLng({clientX: center.x, clientY: center.y}),
-							  this._map.getZoom(), this._map.options.maxBounds);
 
 		if (this._map._docLayer.zoomStep) {
 			this._map._docLayer.zoomStep(this._zoom, this._origCenter);


### PR DESCRIPTION
Previously, the document would not always properly follow your finger
when you tried to pan while in a pinch-zoom. In particular, we would
sometimes get this disatrously wrong (e.g. at some zoom levels we would
move our fingers one way and have the document go the other!).

I have rewritten the _getZoomDocPos function to avoid this, in
particular by adding a parameter to keep track of where our zoom started
from which lets us know where we need to zoom around. In the
mouse/button zoom case this doesn't change, but in the touchscreen zoom
case it informs us how much the viewport should have been moved.

I've also changed the surrounding code to use the new logic, in particular
the code which positions the mouse cursor