### PR TITLE
Related: cool#8648 clipboard: extract parseClipboard() from Control.DownloadProgress.js

### DIFF
--- a/browser/src/control/Control.DownloadProgress.js
+++ b/browser/src/control/Control.DownloadProgress.js
@@ -302,20 +302,8 @@ L.Control.DownloadProgress = L.Control.extend({
 				reader.onload = function() {
 					var text = reader.result;
 					window.app.console.log('async clipboard parse done: ' + text.substring(0, 256));
-					if (text.startsWith('{')) {
-						let textJson = JSON.parse(text);
-						let textHtml = textJson['text/html'];
-						let textPlain = textJson['text/plain;charset=utf-8'];
-						that._map._clip.setTextSelectionHTML(textHtml, textPlain);
-					} else {
-						var idx = text.indexOf('<!DOCTYPE HTML');
-						if (idx === -1) {
-							idx = text.indexOf('<!DOCTYPE html');
-						}
-						if (idx > 0)
-							text = text.substring(idx, text.length);
-						that._map._clip.setTextSelectionHTML(text);
-					}
+					let result = that._map._clip.parseClipboard(text);
+					that._map._clip.setTextSelectionHTML(result['html'], result['plain']);
 				};
 				// TODO: failure to parse ? ...
 				reader.readAsText(response);

--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -779,6 +779,29 @@ L.Clipboard = L.Class.extend({
 		this.paste(ev);
 	},
 
+	// Parses the result from the clipboard endpoint into HTML and plain text.
+	parseClipboard: function(text) {
+		let textHtml;
+		let textPlain = '';
+		if (text.startsWith('{')) {
+			let textJson = JSON.parse(text);
+			textHtml = textJson['text/html'];
+			textPlain = textJson['text/plain;charset=utf-8'];
+		} else {
+			var idx = text.indexOf('<!DOCTYPE HTML');
+			if (idx === -1) {
+				idx = text.indexOf('<!DOCTYPE html');
+			}
+			if (idx > 0)
+				text = text.substring(idx, text.length);
+			textHtml = text;
+		}
+		return {
+			'html': textHtml,
+			'plain': textPlain
+		};
+	},
+
 	// Executes the navigator.clipboard.read() call, if it's available.
 	_navigatorClipboardRead: function(isSpecial) {
 		if (navigator.clipboard.read === undefined) {


### PR DESCRIPTION
This way it can be reused in future code in Clipboard.js when
navigator.clipboard.write() is used, without duplication.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I843577e55802bcb7ad6cbdc5f83919172bc7d3e0
