### PR TITLE
do a syscall from the watchdog

### DIFF
--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -1343,6 +1343,13 @@ extern "C" {
         // connect perf probes here
         LOG_TRC("Watchdog triggered");
         volatile int i = 42; (void)i;
+#if defined(__linux__) && !defined(__ANDROID__)
+        const struct timeval times[2] = {};
+        // call something fairly obscure that perf can trigger on.  futimesat
+        // look a good candidate (calling "futimesat" typically results in
+        // using syscall SYS_utimensat so use SYS_futimesat directly).
+        syscall(SYS_futimesat, -1, "/tmp/kit-watchdog", times);
+#endif
     }
 }
 


### PR DESCRIPTION
perf probe -x /usr/bin/coolwsd watchdog_probe
is not (yet?) universally available, at least
Ubuntu 22.04.4 doesn't link per to libtraceevent
https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2019247

so use a (obscure) syscall to use as an event instead


Change-Id: I1e4b7ab702b1a25b2ecd627dea4580eef10f8a7c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

