### PR TITLE
Calc: fix drop zone indicator regression

### DIFF
--- a/browser/css/spreadsheet.css
+++ b/browser/css/spreadsheet.css
@@ -288,7 +288,6 @@
 	vertical-align: bottom;
 	display: inline-block;
 	background-color: var(--color-main-background);
-	padding-bottom: 5px;
 }
 
 .tab-drop-area-active {

--- a/browser/src/control/Control.Tabs.js
+++ b/browser/src/control/Control.Tabs.js
@@ -440,13 +440,14 @@ L.Control.Tabs = L.Control.extend({
 		// support duplication with ctrl in the future.
 		e.dataTransfer.dropEffect = 'move';
 
-		e.target.previousElementSibling.classList.add('tab-drop-area-active');
+		e.currentTarget.previousElementSibling.classList.add('tab-drop-area-active');
 
 		return false;
 	},
 
 	_handleDragLeave: function (e) {
-		e.target.previousElementSibling.classList.remove('tab-drop-area-active');
+		if ($(e.target).hasClass('spreadsheet-tab') || (e.target.getAttribute('id') == 'drop-zone-end-container'))
+			e.currentTarget.previousElementSibling.classList.remove('tab-drop-area-active');
 	},
 
 	_handleDrop: function(e) {
@@ -454,13 +455,13 @@ L.Control.Tabs = L.Control.extend({
 			e.stopPropagation();
 		}
 
-		e.target.previousElementSibling.classList.remove('tab-drop-area-active');
+		e.currentTarget.previousElementSibling.classList.remove('tab-drop-area-active');
 		var targetIndex = this._map._docLayer._partNames.indexOf(e.target.innerText);
 		this._moveSheet(targetIndex + 1); // drop to left side of the tab
 	},
 
 	_handleDragEnd: function (e) {
-		e.target.previousElementSibling.classList.remove('tab-drop-area-active');
+		e.currentTarget.previousElementSibling.classList.remove('tab-drop-area-active');
 	}
 });
 


### PR DESCRIPTION
with cbf452b03d71e4ed773e059b83b86af102c473eb drop indicator was not shown if the cursor is over the <div> elements that inside the tabs.

- fix by using `e.currentTarget` instead of `e.target` and do some checks while on `_handleDragLeave`
- fix the misalignment of drop zone

Change-Id: Iec8e246f18e553487b0eb0d9264cff8bb37b6305


* Resolves: # <!-- related github issue -->
* See also:  #8266, #7846
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

