### PR TITLE
Watchdog: re-direct USR2 when enabled to snapshot a late thread.

### DIFF
--- a/common/Util.cpp
+++ b/common/Util.cpp
@@ -671,6 +671,15 @@ namespace Util
         return replace(r, "\n", " / ");
     }
 
+    void killThreadById(int tid, int signal)
+    {
+#if defined __linux__
+        ::syscall(SYS_tgkill, getpid(), tid, signal);
+#else
+        LOG_WRN("No tgkill for thread " << tid);
+#endif
+    }
+
     // prctl(2) supports names of up to 16 characters, including null-termination.
     // Although in practice on linux more than 16 chars is supported.
     static thread_local char ThreadName[32] = {0};

--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -298,6 +298,8 @@ namespace Util
     long getThreadId();
 #endif
 
+    void killThreadById(int tid, int signal);
+
     /// Get version information
     void getVersionInfo(std::string& version, std::string& hash);
 

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -660,19 +660,7 @@ public:
     }
 
     /// Kit poll can be called from LOK's Yield in any thread, adapt to that.
-    void checkAndReThread()
-    {
-        if (InhibitThreadChecks)
-            return; // in late shutdown
-        const std::thread::id us = std::this_thread::get_id();
-        if (_owner == us)
-            return; // all well
-        LOG_DBG("Unusual - SocketPoll used from a new thread");
-        _owner = us;
-        for (const auto& it : _pollSockets)
-            it->setThreadOwner(us);
-        // _newSockets are adapted as they are inserted.
-    }
+    void checkAndReThread();
 
     /// Poll the sockets for available data to read or buffer to write.
     /// Returns the return-value of poll(2): 0 on timeout,
@@ -897,6 +885,7 @@ private:
     std::atomic<bool> _runOnClientThread;
     std::thread::id _owner;
     /// Time-stamp for profiling
+    int _ownerThreadId;
     std::atomic<uint64_t> _watchdogTime;
 };
 


### PR DESCRIPTION
By tracking the thread-id, we can deliver a SIGUSR2 to the right thread at the right time; this avoids perf polling our uninteresting watchdog thread.

In that thread use Caolan's suitably obscure futimestat system-call, so that we can record based on that to see only slow things:

perf record -e syscalls:sys_enter_futimesat -ag --call-graph dwarf,65528

Change-Id: Iad05d8589fdc9541a7d0599f63625d2cde5fdf89
Signed-off-by: Michael Meeks <michael.meeks@collabora.com>
(cherry picked from commit 588aabb7c33242d82aa01f24b6a603c25fed08ca)


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

