### PR TITLE
private/ash/parallel download2

### DIFF
--- a/common/MobileApp.cpp
+++ b/common/MobileApp.cpp
@@ -11,14 +11,15 @@
 
 #include "config.h"
 
+#if MOBILEAPP
+
+#include "MobileApp.hpp"
+
 #include <cassert>
 #include <map>
 #include <mutex>
 
 #include "Log.hpp"
-#include "MobileApp.hpp"
-
-#if MOBILEAPP
 
 static std::map<unsigned, DocumentData*> idToDocDataMap;
 static std::mutex idToDocDataMapMutex;

--- a/common/MobileApp.hpp
+++ b/common/MobileApp.hpp
@@ -15,6 +15,8 @@
 
 #include <LibreOfficeKit/LibreOfficeKit.hxx>
 
+#include <Storage.hpp>
+
 #ifdef IOS
 #import "CODocument.h"
 #import <set>
@@ -57,6 +59,33 @@ public:
 #ifdef IOS
     CODocument *coDocument;
 #endif
+};
+
+/// Stub/Dummy WOPI types/interface.
+class WopiStorage : public StorageBase
+{
+public:
+    class WOPIFileInfo : public FileInfo
+    {
+    public:
+        enum class TriState
+        {
+            False,
+            True,
+            Unset
+        };
+
+        std::string getTemplateSource() const { return std::string(); }
+
+        bool getDisablePrint() const { return false; }
+        bool getDisableExport() const { return false; }
+        bool getDisableCopy() const { return false; }
+        bool getEnableOwnerTermination() const { return false; }
+
+        TriState getDisableChangeTrackingShow() const { return TriState::Unset; }
+        TriState getDisableChangeTrackingRecord() const { return TriState::Unset; }
+        TriState getHideChangeTrackingControls() const { return TriState::Unset; }
+    };
 };
 
 #endif

--- a/test/UnitWopiOwnertermination.cpp
+++ b/test/UnitWopiOwnertermination.cpp
@@ -82,21 +82,11 @@ public:
     bool onDocumentError(const std::string& message) override
     {
         LOK_ASSERT_STATE(_phase, Phase::WaitLoadStatus);
-        if (message != "error: cmd=internal kind=load")
-        {
-            LOK_ASSERT_EQUAL_MESSAGE("Expect only documentunloading errors",
-                                     std::string("error: cmd=load kind=docunloading"), message);
-        }
-        else
-        {
-            // We send out two errors when we fail to load.
-            // This is the second one, which is 'cmd=internal kind=load'.
 
-            LOK_ASSERT_EQUAL_MESSAGE("Expect only documentunloading errors",
-                                     std::string("error: cmd=internal kind=load"), message);
+        LOK_ASSERT_EQUAL_MESSAGE("Expect only documentunloading errors",
+                                 std::string("error: cmd=load kind=docunloading"), message);
 
-            TRANSITION_STATE(_phase, Phase::Done);
-        }
+        TRANSITION_STATE(_phase, Phase::Done);
 
         return true;
     }

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -182,43 +182,6 @@ findOrCreateDocBroker(DocumentBroker::ChildType type, const std::string& uri,
     return std::make_pair(docBroker, std::string());
 }
 
-/// Find the DocumentBroker for the given docKey, if one exists.
-/// Otherwise, creates and adds a new one to DocBrokers.
-/// May return null if terminating or MaxDocuments limit is reached.
-/// After returning a valid instance DocBrokers must be cleaned up after exceptions.
-std::shared_ptr<DocumentBroker>
-findOrCreateDocBroker(const std::shared_ptr<ProtocolHandlerInterface>& proto,
-                      DocumentBroker::ChildType type, const std::string& uri,
-                      const std::string& docKey, const std::string& id, const Poco::URI& uriPublic,
-                      unsigned mobileAppDocId = 0)
-{
-    const auto pair = findOrCreateDocBroker(type, uri, docKey, id, uriPublic, mobileAppDocId);
-    const std::shared_ptr<DocumentBroker>& docBroker = pair.first;
-
-    if (docBroker)
-    {
-        // Indicate to the client that we're connecting to the docbroker.
-        if (proto)
-        {
-            const std::string statusConnect = "statusindicator: connect";
-            LOG_TRC("Sending to Client [" << statusConnect << ']');
-            proto->sendTextMessage(statusConnect.data(), statusConnect.size());
-        }
-
-        return docBroker;
-    }
-
-    // Failed.
-    if (proto)
-    {
-        const std::string& error = pair.second;
-        proto->sendTextMessage(error.data(), error.size(), /*flush=*/true);
-        proto->shutdown(true, error);
-    }
-
-    return nullptr;
-}
-
 #if !MOBILEAPP
 
 /// For clipboard setting

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -174,7 +174,7 @@ findOrCreateDocBroker(DocumentBroker::ChildType type, const std::string& uri,
 
         // Set the one we just created.
         LOG_DBG("New DocumentBroker for docKey [" << docKey << ']');
-        docBroker = std::make_shared<DocumentBroker>(type, uri, uriPublic, docKey, mobileAppDocId);
+        docBroker = std::make_shared<DocumentBroker>(type, uri, uriPublic, docKey, mobileAppDocId, nullptr);
         DocBrokers.emplace(docKey, docBroker);
         LOG_TRC("Have " << DocBrokers.size() << " DocBrokers after inserting [" << docKey << ']');
     }

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -1626,10 +1626,9 @@ void ClientRequestDispatcher::handleClientProxyRequest(const Poco::Net::HTTPRequ
     (void)message;
     (void)disposition;
 
-    std::shared_ptr<ProtocolHandlerInterface> none;
     // Request a kit process for this doc.
-    std::shared_ptr<DocumentBroker> docBroker = findOrCreateDocBroker(
-        none, DocumentBroker::ChildType::Interactive, url, docKey, _id, uriPublic);
+    auto [docBroker, errorMsg] =
+        findOrCreateDocBroker(DocumentBroker::ChildType::Interactive, url, docKey, _id, uriPublic);
     if (docBroker)
     {
         // need to move into the DocumentBroker context before doing session lookup / creation etc.
@@ -1673,9 +1672,9 @@ void ClientRequestDispatcher::handleClientProxyRequest(const Poco::Net::HTTPRequ
     }
     else
     {
-        auto streamSocket = std::static_pointer_cast<StreamSocket>(disposition.getSocket());
-        LOG_ERR("Failed to find document");
+        LOG_ERR("Failed to find document [" << docKey << "]: " << errorMsg);
         // badness occurred:
+        auto streamSocket = std::static_pointer_cast<StreamSocket>(disposition.getSocket());
         HttpHelper::sendErrorAndShutdown(http::StatusCode::BadRequest, streamSocket);
         // FIXME: send docunloading & re-try on client ?
     }

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1445,13 +1445,14 @@ bool DocumentBroker::download(
         Poco::DigestOutputStream dos(sha1);
         Poco::StreamCopier::copyStream(istr, dos);
         dos.close();
-        LOG_INF("SHA1 for DocKey [" << _docKey << "] of [" << COOLWSD::anonymizeUrl(localPath) << "]: " <<
-                Poco::DigestEngine::digestToHex(sha1.digest()));
+        LOG_INF("SHA1 for DocKey [" << _docKey << "] of [" << COOLWSD::anonymizeUrl(localPath)
+                                    << "]: " << Poco::DigestEngine::digestToHex(sha1.digest()));
 
         std::string localPathEncoded;
         Poco::URI::encode(localPath, "#?", localPathEncoded);
         _uriJailed = Poco::URI(Poco::URI("file://"), localPathEncoded).toString();
-        _uriJailedAnonym = Poco::URI(Poco::URI("file://"), COOLWSD::anonymizeUrl(localPathEncoded)).toString();
+        _uriJailedAnonym =
+            Poco::URI(Poco::URI("file://"), COOLWSD::anonymizeUrl(localPathEncoded)).toString();
 
         _filename = fileInfo.getFilename();
 #if !MOBILEAPP
@@ -1470,7 +1471,8 @@ bool DocumentBroker::download(
             // Use the local temp file's timestamp.
             const auto timepoint = FileUtil::Stat(localFilePath).modifiedTimepoint();
             _saveManager.setLastModifiedTime(timepoint);
-            _storageManager.setLastUploadedFileModifiedTime(timepoint); // Used to detect modifications.
+            _storageManager.setLastUploadedFileModifiedTime(
+                timepoint); // Used to detect modifications.
         }
 
         bool dontUseCache = Util::isMobileApp();
@@ -1489,8 +1491,8 @@ bool DocumentBroker::download(
         // Add the time taken to load the file from storage and to check file info.
         _wopiDownloadDuration += getFileCallDurationMs + checkFileInfoCallDurationMs;
         const auto downloadSecs = _wopiDownloadDuration.count() / 1000.;
-        const std::string msg
-            = "stats: wopiloadduration " + std::to_string(downloadSecs); // In seconds.
+        const std::string msg =
+            "stats: wopiloadduration " + std::to_string(downloadSecs); // In seconds.
         LOG_TRC("Sending to Client [" << msg << "].");
         session->sendTextFrame(msg);
     }

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -146,7 +146,8 @@ public:
 std::atomic<unsigned> DocumentBroker::DocBrokerId(1);
 
 DocumentBroker::DocumentBroker(ChildType type, const std::string& uri, const Poco::URI& uriPublic,
-                               const std::string& docKey, unsigned mobileAppDocId)
+                               const std::string& docKey, unsigned mobileAppDocId,
+                               std::unique_ptr<WopiStorage::WOPIFileInfo> wopiFileInfo)
     : _limitLifeSeconds(std::chrono::seconds::zero())
     , _uriOrig(uri)
     , _type(type)
@@ -204,17 +205,13 @@ DocumentBroker::DocumentBroker(ChildType type, const std::string& uri, const Poc
     {
         _unitWsd->onDocBrokerCreate(_docKey);
     }
-}
 
-DocumentBroker::DocumentBroker(ChildType type, const std::string& uri, const Poco::URI& uriPublic,
-                               const std::string& docKey,
-                               std::unique_ptr<WopiStorage::WOPIFileInfo> wopiFileInfo)
-    : DocumentBroker(type, uri, uriPublic, docKey, /*mobileAppDocId=*/0)
-{
     _initialWopiFileInfo = std::move(wopiFileInfo);
-
-    LOG_DBG("Starting DocBrokerPoll thread");
-    _poll->startThread();
+    if (_initialWopiFileInfo)
+    {
+        LOG_DBG("Starting DocBrokerPoll thread");
+        _poll->startThread();
+    }
 }
 
 void DocumentBroker::setupPriorities()

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -321,9 +321,6 @@ public:
         Interactive, Batch
     };
 
-    /// Dummy document broker that is marked to destroy.
-    DocumentBroker();
-
     DocumentBroker(ChildType type,
                    const std::string& uri,
                    const Poco::URI& uriPublic,

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -327,6 +327,11 @@ public:
                    const std::string& docKey,
                    unsigned mobileAppDocId = 0);
 
+    /// Overloaded for early loading.
+    DocumentBroker(ChildType type, const std::string& uri, const Poco::URI& uriPublic,
+                   const std::string& docKey,
+                   std::unique_ptr<WopiStorage::WOPIFileInfo> wopiFileInfo);
+
     virtual ~DocumentBroker();
 
     /// Called when removed from the DocBrokers list
@@ -602,6 +607,9 @@ private:
     std::shared_ptr<ClientSession> getWriteableSession() const;
 
     void refreshLock();
+
+    /// Downloads the document ahead-of-time.
+    bool downloadAdvance(const std::string& jailId, const WopiStorage::WOPIFileInfo& wopiFileInfo);
 
     /// Loads a document from the public URI into the jail.
     bool download(const std::shared_ptr<ClientSession>& session, const std::string& jailId,
@@ -1360,6 +1368,10 @@ private:
     std::string _uriJailedAnonym;
     std::string _jailId;
     std::string _filename;
+
+    /// The WopiFileInfo of the initial request loading the document for the first time.
+    /// This has a single-use, and then it's reset.
+    std::unique_ptr<WopiStorage::WOPIFileInfo> _initialWopiFileInfo;
 
     /// The state of the document.
     /// This regulates all other primary operations.

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -592,6 +592,10 @@ private:
     /// Loads a document from the public URI into the jail.
     bool download(const std::shared_ptr<ClientSession>& session, const std::string& jailId,
                   std::unique_ptr<WopiStorage::WOPIFileInfo> wopiFileInfo);
+
+    /// Process the configured plugins, if any, after downloading the document file.
+    bool processPlugins(std::string& localPath);
+
     bool isLoaded() const { return _docState.hadLoaded(); }
     bool isInteractive() const { return _docState.isInteractive(); }
 

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -37,34 +37,9 @@
 #if !MOBILEAPP
 #include "Admin.hpp"
 #include <wopi/WopiStorage.hpp>
-#else
-//FIXME: Move to a stub file.
-class WopiStorage : public StorageBase
-{
-public:
-    class WOPIFileInfo : public FileInfo
-    {
-    public:
-        enum class TriState
-        {
-            False,
-            True,
-            Unset
-        };
-
-        std::string getTemplateSource() const { return std::string(); }
-
-        bool getDisablePrint() const { return false; }
-        bool getDisableExport() const { return false; }
-        bool getDisableCopy() const { return false; }
-        bool getEnableOwnerTermination() const { return false; }
-
-        TriState getDisableChangeTrackingShow() const { return TriState::Unset; }
-        TriState getDisableChangeTrackingRecord() const { return TriState::Unset; }
-        TriState getHideChangeTrackingControls() const { return TriState::Unset; }
-    };
-};
-#endif
+#else // MOBILEAPP
+#include <MobileApp.hpp>
+#endif // MOBILEAPP
 
 // Forwards.
 class PrisonerRequestDispatcher;

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -296,17 +296,20 @@ public:
         Interactive, Batch
     };
 
-    DocumentBroker(ChildType type,
-                   const std::string& uri,
-                   const Poco::URI& uriPublic,
-                   const std::string& docKey,
-                   unsigned mobileAppDocId = 0);
-
-    /// Overloaded for early loading.
     DocumentBroker(ChildType type, const std::string& uri, const Poco::URI& uriPublic,
-                   const std::string& docKey,
+                   const std::string& docKey, unsigned mobileAppDocId,
                    std::unique_ptr<WopiStorage::WOPIFileInfo> wopiFileInfo);
 
+protected:
+    /// Used by derived classes.
+    DocumentBroker(ChildType type, const std::string& uri, const Poco::URI& uriPublic,
+                   const std::string& docKey)
+        : DocumentBroker(type, uri, uriPublic, docKey, /*mobileAppDocId=*/0,
+                         /*wopiFileInfo=*/nullptr)
+    {
+    }
+
+public:
     virtual ~DocumentBroker();
 
     /// Called when removed from the DocBrokers list

--- a/wsd/RequestVettingStation.cpp
+++ b/wsd/RequestVettingStation.cpp
@@ -40,8 +40,8 @@ findOrCreateDocBroker(const std::shared_ptr<ProtocolHandlerInterface>& proto,
                       const std::string& docKey, const std::string& id, const Poco::URI& uriPublic,
                       unsigned mobileAppDocId = 0)
 {
-    const auto pair = findOrCreateDocBroker(type, uri, docKey, id, uriPublic, mobileAppDocId);
-    const std::shared_ptr<DocumentBroker>& docBroker = pair.first;
+    const auto [docBroker, error] =
+        findOrCreateDocBroker(type, uri, docKey, id, uriPublic, mobileAppDocId);
 
     if (docBroker)
     {
@@ -59,7 +59,6 @@ findOrCreateDocBroker(const std::shared_ptr<ProtocolHandlerInterface>& proto,
     // Failed.
     if (proto)
     {
-        const std::string& error = pair.second;
         proto->sendTextMessage(error.data(), error.size(), /*flush=*/true);
         proto->shutdown(true, error);
     }

--- a/wsd/RequestVettingStation.cpp
+++ b/wsd/RequestVettingStation.cpp
@@ -23,13 +23,50 @@
 #include <common/JsonUtil.hpp>
 #include <Util.hpp>
 
-extern std::shared_ptr<DocumentBroker>
+extern std::pair<std::shared_ptr<DocumentBroker>, std::string>
+findOrCreateDocBroker(DocumentBroker::ChildType type, const std::string& uri,
+                      const std::string& docKey, const std::string& id, const Poco::URI& uriPublic,
+                      unsigned mobileAppDocId = 0);
+
+namespace
+{
+/// Find the DocumentBroker for the given docKey, if one exists.
+/// Otherwise, creates and adds a new one to DocBrokers.
+/// May return null if terminating or MaxDocuments limit is reached.
+/// After returning a valid instance DocBrokers must be cleaned up after exceptions.
+std::shared_ptr<DocumentBroker>
 findOrCreateDocBroker(const std::shared_ptr<ProtocolHandlerInterface>& proto,
                       DocumentBroker::ChildType type, const std::string& uri,
                       const std::string& docKey, const std::string& id, const Poco::URI& uriPublic,
-                      unsigned mobileAppDocId = 0);
-namespace
+                      unsigned mobileAppDocId = 0)
 {
+    const auto pair = findOrCreateDocBroker(type, uri, docKey, id, uriPublic, mobileAppDocId);
+    const std::shared_ptr<DocumentBroker>& docBroker = pair.first;
+
+    if (docBroker)
+    {
+        // Indicate to the client that we're connecting to the docbroker.
+        if (proto)
+        {
+            const std::string statusConnect = "statusindicator: connect";
+            LOG_TRC("Sending to Client [" << statusConnect << ']');
+            proto->sendTextMessage(statusConnect.data(), statusConnect.size());
+        }
+
+        return docBroker;
+    }
+
+    // Failed.
+    if (proto)
+    {
+        const std::string& error = pair.second;
+        proto->sendTextMessage(error.data(), error.size(), /*flush=*/true);
+        proto->shutdown(true, error);
+    }
+
+    return nullptr;
+}
+
 void sendLoadResult(const std::shared_ptr<ClientSession>& clientSession, bool success,
                     const std::string& errorMsg)
 {

--- a/wsd/RequestVettingStation.cpp
+++ b/wsd/RequestVettingStation.cpp
@@ -327,11 +327,10 @@ bool RequestVettingStation::createDocBroker(const std::string& docKey, const std
     }
 
     // Failed.
-    LOG_ERR("Failed to create DocBroker [" << docKey << ']');
+    LOG_ERR("Failed to create DocBroker [" << docKey << "]: " << error);
     if (_ws)
     {
-        sendErrorAndShutdown(_ws, "error: cmd=internal kind=load",
-                             WebSocketHandler::StatusCodes::UNEXPECTED_CONDITION);
+        sendErrorAndShutdown(_ws, error, WebSocketHandler::StatusCodes::UNEXPECTED_CONDITION);
     }
 
     return false;

--- a/wsd/RequestVettingStation.cpp
+++ b/wsd/RequestVettingStation.cpp
@@ -26,7 +26,8 @@
 extern std::pair<std::shared_ptr<DocumentBroker>, std::string>
 findOrCreateDocBroker(DocumentBroker::ChildType type, const std::string& uri,
                       const std::string& docKey, const std::string& id, const Poco::URI& uriPublic,
-                      unsigned mobileAppDocId = 0);
+                      unsigned mobileAppDocId,
+                      std::unique_ptr<WopiStorage::WOPIFileInfo> wopiFileInfo);
 
 namespace
 {
@@ -273,9 +274,9 @@ void RequestVettingStation::checkFileInfo(const Poco::URI& uri, bool isReadOnly,
             {
                 LOG_DBG("WOPI::CheckFileInfo succeeded but we don't have the client's "
                         "WebSocket yet. Creating DocBroker without connection");
-                auto [docBroker, errorMsg] =
-                    findOrCreateDocBroker(DocumentBroker::ChildType::Interactive, url, docKey, _id,
-                                          uriPublic, _mobileAppDocId);
+                auto [docBroker, errorMsg] = findOrCreateDocBroker(
+                    DocumentBroker::ChildType::Interactive, url, docKey, _id, uriPublic,
+                    _mobileAppDocId, _checkFileInfo->wopiFileInfo(uriPublic));
                 _docBroker = docBroker;
                 if (!_docBroker)
                 {
@@ -308,8 +309,9 @@ bool RequestVettingStation::createDocBroker(const std::string& docKey, const std
                                             const Poco::URI& uriPublic)
 {
     // Request a kit process for this doc.
-    const auto [docBroker, error] = findOrCreateDocBroker(
-        DocumentBroker::ChildType::Interactive, url, docKey, _id, uriPublic, _mobileAppDocId);
+    const auto [docBroker, error] =
+        findOrCreateDocBroker(DocumentBroker::ChildType::Interactive, url, docKey, _id, uriPublic,
+                              _mobileAppDocId, /*wopiFileInfo=*/nullptr);
 
     _docBroker = docBroker;
     if (_docBroker)

--- a/wsd/RequestVettingStation.cpp
+++ b/wsd/RequestVettingStation.cpp
@@ -390,7 +390,7 @@ void RequestVettingStation::createClientSession(const std::string& docKey, const
                 // when reaching max documents or connections
                 COOLWSD::checkSessionLimitsAndWarnClients();
 
-                sendLoadResult(clientSession, true, "");
+                sendLoadResult(clientSession, /*success=*/true, /*errorMsg=*/std::string());
             }
             catch (const UnauthorizedRequestException& exc)
             {

--- a/wsd/RequestVettingStation.cpp
+++ b/wsd/RequestVettingStation.cpp
@@ -385,15 +385,15 @@ void RequestVettingStation::createClientSession(const std::string& docKey, const
                 if (wopiInfo)
                 {
                     std::size_t size = 0;
-                    std::string filename, ownerId, lastModifiedTime;
+                    std::string filename, ownerId, modifiedTime;
 
                     JsonUtil::findJSONValue(wopiInfo, "Size", size);
                     JsonUtil::findJSONValue(wopiInfo, "OwnerId", ownerId);
                     JsonUtil::findJSONValue(wopiInfo, "BaseFileName", filename);
-                    JsonUtil::findJSONValue(wopiInfo, "LastModifiedTime", lastModifiedTime);
+                    JsonUtil::findJSONValue(wopiInfo, "LastModifiedTime", modifiedTime);
 
                     StorageBase::FileInfo fileInfo =
-                        StorageBase::FileInfo({ filename, ownerId, lastModifiedTime });
+                        StorageBase::FileInfo({ size, filename, ownerId, modifiedTime });
 
                     wopiFileInfo =
                         std::make_unique<WopiStorage::WOPIFileInfo>(fileInfo, wopiInfo, uriPublic);

--- a/wsd/RequestVettingStation.hpp
+++ b/wsd/RequestVettingStation.hpp
@@ -46,6 +46,7 @@ public:
                           const RequestDetails& requestDetails)
         : _poll(poll)
         , _requestDetails(requestDetails)
+        , _mobileAppDocId(0)
     {
     }
 

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -312,7 +312,7 @@ std::unique_ptr<LocalStorage::LocalFileInfo> LocalStorage::getLocalFileInfo()
     const FileUtil::Stat stat(path.toString());
     const std::chrono::system_clock::time_point lastModified = stat.modifiedTimepoint();
 
-    setFileInfo(FileInfo(path.getFileName(), "LocalOwner",
+    setFileInfo(FileInfo(stat.size(), path.getFileName(), "LocalOwner",
                          Util::getIso8601FracformatTime(lastModified)));
 
     // Set automatic userid and username.

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -88,8 +88,10 @@ public:
     class FileInfo
     {
     public:
-        FileInfo(std::string filename, std::string ownerId, std::string modifiedTime)
-            : _filename(std::move(filename))
+        FileInfo(std::size_t size, std::string filename, std::string ownerId,
+                 std::string modifiedTime)
+            : _size(size)
+            , _filename(std::move(filename))
             , _ownerId(std::move(ownerId))
             , _modifiedTime(std::move(modifiedTime))
         {
@@ -120,6 +122,8 @@ public:
             return !_filename.empty();
         }
 
+        std::size_t getSize() const { return _size; }
+
         const std::string& getFilename() const { return _filename; }
 
         const std::string& getOwnerId() const { return _ownerId; }
@@ -137,6 +141,7 @@ public:
         void setLastModifiedTimeUnSafe() { _modifiedTime.clear(); }
 
     private:
+        std::size_t _size;
         std::string _filename;
         std::string _ownerId;
         std::string _modifiedTime; //< Opaque modified timestamp as received from the server.
@@ -317,13 +322,13 @@ public:
 
     /// localStorePath the absolute root path of the chroot.
     /// jailPath the path within the jail that the child uses.
-    StorageBase(const Poco::URI& uri,
-                const std::string& localStorePath,
-                const std::string& jailPath) :
-        _localStorePath(localStorePath),
-        _jailPath(jailPath),
-        _fileInfo(std::string(), "cool", std::string()),
-        _isDownloaded(false)
+    StorageBase(const Poco::URI& uri, const std::string& localStorePath,
+                const std::string& jailPath)
+        : _localStorePath(localStorePath)
+        , _jailPath(jailPath)
+        , _fileInfo(/*size=*/0, /*filename=*/std::string(), /*ownerId=*/"cool",
+                    /*modifiledTime=*/std::string())
+        , _isDownloaded(false)
     {
         setUri(uri);
         LOG_DBG("Storage ctor: " << COOLWSD::anonymizeUrl(_uri.toString()));

--- a/wsd/wopi/CheckFileInfo.cpp
+++ b/wsd/wopi/CheckFileInfo.cpp
@@ -157,3 +157,29 @@ void CheckFileInfo::checkFileInfo(int redirectLimit)
     // We're in business.
     _state = State::Active;
 }
+
+std::unique_ptr<WopiStorage::WOPIFileInfo>
+CheckFileInfo::wopiFileInfo(const Poco::URI& uriPublic) const
+{
+    std::unique_ptr<WopiStorage::WOPIFileInfo> wopiFileInfo;
+    if (_wopiInfo)
+    {
+        std::size_t size = 0;
+        std::string filename;
+        std::string ownerId;
+        std::string modifiedTime;
+        if (_wopiInfo)
+        {
+            JsonUtil::findJSONValue(_wopiInfo, "Size", size);
+            JsonUtil::findJSONValue(_wopiInfo, "OwnerId", ownerId);
+            JsonUtil::findJSONValue(_wopiInfo, "BaseFileName", filename);
+            JsonUtil::findJSONValue(_wopiInfo, "LastModifiedTime", modifiedTime);
+        }
+
+        Poco::JSON::Object::Ptr wopiInfo = _wopiInfo;
+        wopiFileInfo = std::make_unique<WopiStorage::WOPIFileInfo>(
+            StorageBase::FileInfo(size, filename, ownerId, modifiedTime), wopiInfo, uriPublic);
+    }
+
+    return wopiFileInfo;
+}

--- a/wsd/wopi/CheckFileInfo.hpp
+++ b/wsd/wopi/CheckFileInfo.hpp
@@ -19,6 +19,7 @@
 #include <RequestDetails.hpp>
 #include <Socket.hpp>
 #include <StateEnum.hpp>
+#include <wopi/WopiStorage.hpp>
 #include <TraceEvent.hpp>
 
 #include <Poco/JSON/Object.h>
@@ -65,6 +66,9 @@ public:
 
     /// Returns the parsed response JSON, if any.
     Poco::JSON::Object::Ptr wopiInfo() const { return _wopiInfo; }
+
+    /// Returns the parsed wopiInfo JSON into FileInfo.
+    std::unique_ptr<WopiStorage::WOPIFileInfo> wopiFileInfo(const Poco::URI& uriPublic) const;
 
 private:
     inline void logPrefix(std::ostream& os) const

--- a/wsd/wopi/CheckFileInfo.hpp
+++ b/wsd/wopi/CheckFileInfo.hpp
@@ -64,7 +64,7 @@ public:
     const std::string& docKey() const { return _docKey; }
 
     /// Returns the parsed response JSON, if any.
-    Poco::JSON::Object::Ptr wopiInfo() const { return _wopiInfo; };
+    Poco::JSON::Object::Ptr wopiInfo() const { return _wopiInfo; }
 
 private:
     inline void logPrefix(std::ostream& os) const

--- a/wsd/wopi/WopiProxy.cpp
+++ b/wsd/wopi/WopiProxy.cpp
@@ -143,7 +143,7 @@ void WopiProxy::checkFileInfo(const std::shared_ptr<TerminatingPoll>& poll, cons
             JsonUtil::findJSONValue(object, "LastModifiedTime", lastModifiedTime);
 
             LocalStorage::FileInfo fileInfo =
-                LocalStorage::FileInfo({ filename, ownerId, lastModifiedTime });
+                LocalStorage::FileInfo({ size, filename, ownerId, lastModifiedTime });
 
             // if (COOLWSD::AnonymizeUserData)
             //     Util::mapAnonymized(Util::getFilenameFromURL(filename),


### PR DESCRIPTION
- wsd: cosmetics
- wsd: simplify findOrCreateDocBroker call
- wsd: move overloaded findOrCreateDocBroker to RVS
- wsd: structured binding in findOrCreateDocBroker
- wsd: uninitialized member
- wsd: create DocBroker once CheckFileInfo clears
- wsd: Support ahead-of-time document loading
- wsd: merge single-use findOrCreateDocBroker overload
- wsd: more accurate load error message
- wsd: move wopi stub/dummy interface to MobileApp.hpp
- wsd: simplify DocumentBroker construction
- wsd: capture the file size in StorageBase::FileInfo
- wsd: CheckFileInfo parses the JSON response
- wsd: DocBroker with wopiFileInfo
- wsd: remove MOBILEAPP for parsing CheckFileInfo json
- wsd: minor formatting
- wsd: refactor the plugin processing
