### PR TITLE
Fix styling of selected toolbar buttons

### DIFF
--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -15,6 +15,52 @@
 	width: var(--btn-size);
 	height: var(--btn-size);
 }
+.unotoolbutton .unobutton.selected + .ui-content.unolabel {
+	color: var(--color-text-dark);
+}
+/* toolbuttons non selected */
+#clearFormatting,
+.hasnotebookbar .ui-content.unotoolbutton.has-label,
+.hasnotebookbar .ui-content.unotoolbutton.inline,
+.hasnotebookbar .ui-content.unotoolbutton:not(.has-label):not(.inline),
+.sidebar.unotoolbutton,
+.jsdialog.unotoolbutton {
+	background-color: transparent;
+	border: 1px solid transparent;
+	color: var(--color-main-text);
+	border-radius: var(--border-radius);
+}
+/* toolbuttons selected */
+.hasnotebookbar .ui-content.unotoolbutton.selected.has-label,
+.hasnotebookbar .ui-content.unotoolbutton.selected.inline,
+.hasnotebookbar .ui-content.unotoolbutton.selected:not(.has-label):not(.inline),
+.sidebar.unotoolbutton.selected,
+.jsdialog.unotoolbutton.selected {
+	background-color: var(--color-background-dark);
+	border: 1px solid var(--color-border-dark);
+	color: var(--color-text-dark);
+	border-radius: var(--border-radius);
+}
+[data-theme='dark'] .hasnotebookbar .ui-content.unotoolbutton.selected.has-label,
+[data-theme='dark'] #toggledarktheme,
+[data-theme='dark'] .hasnotebookbar .ui-content.unotoolbutton.selected.inline,
+[data-theme='dark'] .hasnotebookbar .ui-content.unotoolbutton.selected:not(.has-label):not(.inline),
+[data-theme='dark'] .sidebar.unotoolbutton.selected {
+	background-color: var(--color-background-darker);
+	border-color: var(--color-border-darker);
+}
+/* toolbuttons selected hover */
+.hasnotebookbar .ui-content.unotoolbutton.selected:hover,
+.unotoolbutton.notebookbar:hover,
+.unotoolbutton.jsdialog:hover,
+.hasnotebookbar .ui-content.unotoolbutton.selected:not(.has-label):not(.inline):hover,
+.sidebar.unotoolbutton.selected:hover,
+.jsdialog.unotoolbutton.selected:hover {
+	background-color: var(--color-background-darker) !important;
+	border: 1px solid var(--color-border-darker);
+	color: var(--color-text-darker);
+	border-radius: var(--border-radius);
+}
 
 /*limit icon to button height*/
 button.jsdialog img {

--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -170,52 +170,6 @@ div.sidebar.ui-grid .checkbutton.sidebar,
 	width: 198px;
 }
 
-/* widget selected */
-
-/* non selected */
-#clearFormatting,
-.hasnotebookbar .ui-content.unotoolbutton.has-label,
-.hasnotebookbar .ui-content.unotoolbutton.inline,
-.hasnotebookbar .ui-content.unotoolbutton:not(.has-label):not(.inline),
-.sidebar.unotoolbutton,
-.jsdialog.unotoolbutton {
-	background-color: transparent;
-	border: 1px solid transparent;
-	color: var(--color-main-text);
-	border-radius: var(--border-radius);
-}
-/* selected */
-.hasnotebookbar .ui-content.unotoolbutton.selected.has-label,
-.hasnotebookbar .ui-content.unotoolbutton.selected.inline,
-.hasnotebookbar .ui-content.unotoolbutton.selected:not(.has-label):not(.inline),
-.sidebar.unotoolbutton.selected {
-	background-color: var(--color-background-dark);
-	border: 1px solid var(--color-border-dark);
-	color: var(--color-text-dark);
-	border-radius: var(--border-radius);
-}
-[data-theme='dark'] .hasnotebookbar .ui-content.unotoolbutton.selected.has-label,
-[data-theme='dark'] #toggledarktheme,
-[data-theme='dark'] .hasnotebookbar .ui-content.unotoolbutton.selected.inline,
-[data-theme='dark'] .hasnotebookbar .ui-content.unotoolbutton.selected:not(.has-label):not(.inline),
-[data-theme='dark'] .sidebar.unotoolbutton.selected {
-	background-color: var(--color-background-darker);
-	border-color: var(--color-border-darker);
-}
-/* selected hover */
-.hasnotebookbar .ui-content.unotoolbutton.selected:hover,
-.unotoolbutton.notebookbar:hover,
-.unotoolbutton.jsdialog:hover,
-.hasnotebookbar .ui-content.unotoolbutton.selected:not(.has-label):not(.inline):hover,
-.sidebar.unotoolbutton:hover,
-.sidebar.unotoolbutton.selected:hover {
-	background-color: var(--color-background-darker) !important;
-	border: 1px solid var(--color-border-darker);
-	color: var(--color-text-darker);
-	border-radius: var(--border-radius);
-}
-
-
 /* fixes */
 
 .sidebar.ui-grid-cell .sidebar.ui-pushbutton {

--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -268,10 +268,6 @@ button.ui-tab.notebookbar {
 	padding: 4px;
 }
 
-.unotoolbutton.notebookbar .unobutton.selected + .ui-content.unolabel {
-	color: var(--color-text-dark);
-}
-
 .unotoolbutton.notebookbar.disabled:not(.unospan-shortcutstoolbox),
 .unotoolbutton[disabled]:not(.unospan-shortcutstoolbox),
 .mobile-wizard-widebutton.disabled,

--- a/browser/src/control/Control.Toolbar.js
+++ b/browser/src/control/Control.Toolbar.js
@@ -913,8 +913,9 @@ function onWopiProps(e) {
 }
 
 function processStateChangedCommand(commandName, state) {
-	var toolbar = w2ui['editbar'];
-	if (!toolbar)
+	var toolbar = window.mode.isMobile() ? w2ui['editbar'] : null;
+	var topToolbar = app.map.topToolbar;
+	if (!toolbar && !topToolbar)
 		return;
 
 	var color, div;
@@ -926,6 +927,7 @@ function processStateChangedCommand(commandName, state) {
 		$('.styles-select').val(state).trigger('change');
 	}
 	else if (commandName === '.uno:FontColor' || commandName === '.uno:Color') {
+		if (!toolbar) return;
 		// confusingly, the .uno: command is named differently in Writer, Calc and Impress
 		color = parseInt(state);
 		if (color === -1) {
@@ -944,6 +946,7 @@ function processStateChangedCommand(commandName, state) {
 		}
 	}
 	else if (commandName === '.uno:BackColor' || commandName === '.uno:BackgroundColor' || commandName === '.uno:CharBackColor') {
+		if (!toolbar) return;
 		// confusingly, the .uno: command is named differently in Writer, Calc and Impress
 		color = parseInt(state);
 		if (color === -1) {
@@ -967,24 +970,28 @@ function processStateChangedCommand(commandName, state) {
 		}
 	}
 	else if (commandName === '.uno:ModifiedStatus') {
+		if (!toolbar) return;
+		// TODO: topToolbar case
 		if (state === 'true') {
-			w2ui['editbar'].set('save', {img:'savemodified'});
+			toolbar.set('save', {img:'savemodified'});
 		}
 		else {
-			w2ui['editbar'].set('save', {img:'save'});
+			toolbar.set('save', {img:'save'});
 		}
 	}
 	else if (commandName === '.uno:DocumentRepair') {
 		if (state === 'true') {
-			toolbar.enable('repair');
+			if (toolbar) toolbar.enable('repair');
+			if (topToolbar) topToolbar.enableItem('repair', true);
 		} else {
-			toolbar.disable('repair');
+			if (toolbar) toolbar.disable('repair');
+			if (topToolbar) topToolbar.enableItem('repair', false);
 		}
 	}
 
 	if (commandName === '.uno:SpacePara1' || commandName === '.uno:SpacePara15'
 		|| commandName === '.uno:SpacePara2') {
-		toolbar.refresh();
+		if (toolbar) toolbar.refresh();
 	}
 
 	var id = unoCmdToToolbarId(commandName);
@@ -994,25 +1001,32 @@ function processStateChangedCommand(commandName, state) {
 
 	if (state === 'true') {
 		if (map.isEditMode()) {
-			toolbar.enable(id);
+			if (toolbar) toolbar.enable(id);
+			if (topToolbar) topToolbar.enableItem(id, true);
 		}
-		toolbar.check(id);
+		if (toolbar) toolbar.check(id);
+		// TODO: topToolbar case
 	}
 	else if (state === 'false') {
 		if (map.isEditMode()) {
-			toolbar.enable(id);
+			if (toolbar) toolbar.enable(id);
+			if (topToolbar) topToolbar.enableItem(id, true);
 		}
-		toolbar.uncheck(id);
+		if (toolbar) toolbar.uncheck(id);
+		// TODO: topToolbar case
 	}
 	// Change the toolbar button states if we are in editmode
 	// If in non-edit mode, will be taken care of when permission is changed to 'edit'
 	else if (map.isEditMode() && (state === 'enabled' || state === 'disabled')) {
-		var toolbarUp = toolbar;
 		if (state === 'enabled') {
-			toolbarUp.enable(id);
+			if (toolbar) toolbar.enable(id);
+			if (topToolbar) topToolbar.enableItem(id, true);
 		} else {
-			toolbarUp.uncheck(id);
-			toolbarUp.disable(id);
+			if (toolbar) toolbar.uncheck(id);
+			// TODO: topToolbar case
+
+			if (toolbar) toolbar.disable(id);
+			if (topToolbar) topToolbar.enableItem(id, false);
 		}
 	}
 }


### PR DESCRIPTION
Selected state for top toolbar in compact mode. Some code still in unused so added TODOs for later, when we remove w2ui.

    jsdialog: css: put toolbuttons rules in btns.css
    
    - put in single place with other button rules
    - apply also to .jsdialog case (selected, hover)
      so it will be used in new toolbars

-------------------------------------

    remove-w2ui: update toolbar item status
    
    - toolbar had it's own status updates
    - adjust the old code to use new toolbar functions