### PR TITLE
Remove Redundant Linkage: `aria-labelledby`

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -326,8 +326,6 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		spinfield.tabIndex = '0';
 		controls['spinfield'] = spinfield;
 
-		if (data.labelledBy)
-			spinfield.setAttribute('aria-labelledby', data.labelledBy);
 
 		if (data.unit && data.unit !== ':') {
 			var unit = L.DomUtil.create('span', builder.options.cssClass + ' spinfieldunit', div);
@@ -1347,8 +1345,6 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		radiobuttonLabel.textContent = builder._cleanText(data.text);
 		radiobuttonLabel.htmlFor = data.id;
 
-		radiobutton.setAttribute('aria-labelledby', radiobuttonLabel.id);
-
 		var toggleFunction = function() {
 			builder.callback('radiobutton', 'change', container, this.checked, builder);
 		};
@@ -1386,8 +1382,6 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		checkboxLabel.id = data.id + '-label';
 		checkboxLabel.textContent = builder._cleanText(data.text);
 		checkboxLabel.htmlFor = data.id;
-
-		checkbox.setAttribute('aria-labelledby', checkboxLabel.id);
 
 		var toggleFunction = function() {
 			builder.callback('checkbox', 'change', div, this.checked, builder);
@@ -1715,8 +1709,6 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		var listboxArrow = L.DomUtil.create('span', builder.options.cssClass + ' ui-listbox-arrow', container);
 		listboxArrow.id = 'listbox-arrow-' + data.id;
 
-		if (data.labelledBy)
-			listbox.setAttribute('aria-labelledby', data.labelledBy);
 
 		JSDialog.SynchronizeDisabledState(container, [listbox]);
 
@@ -3111,8 +3103,6 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			control.style.gridColumn = 'span ' + parseInt(data.width);
 		}
 
-		if (control && data.labelledBy)
-			control.setAttribute('aria-labelledby', data.labelledBy);
 
 		// natural tab-order when using keyboard navigation
 		if (control && !control.hasAttribute('tabIndex')

--- a/browser/src/control/jsdialog/Widget.ColorPicker.ts
+++ b/browser/src/control/jsdialog/Widget.ColorPicker.ts
@@ -183,6 +183,8 @@ function createPaletteSwitch(
 		paletteListbox,
 	);
 
+	listbox.setAttribute('aria-labelledby', 'color-palette');
+
 	for (const i in window.app.colorPalettes) {
 		const paletteOption = L.DomUtil.create('option', '', listbox);
 		if (i === getCurrentPaletteName())

--- a/browser/src/control/jsdialog/Widget.Combobox.js
+++ b/browser/src/control/jsdialog/Widget.Combobox.js
@@ -215,6 +215,7 @@ JSDialog.combobox = function (parentContainer, data, builder) {
 
 	var content = L.DomUtil.create('input', 'ui-combobox-content ' + builder.options.cssClass, container);
 	content.value = data.text;
+	content.setAttribute('aria-labelledby', data.id);
 
 	var button = L.DomUtil.create('div', 'ui-combobox-button ' + builder.options.cssClass, container);
 	button.tabIndex = '0';


### PR DESCRIPTION
A11y improvements

Problem:

    - At various places, form elements are linked to the same label both through the 'for' attribute in the
associated label, and through the 'aria-labelled by' attribute in the element itself.
    -  This double linkage
can lead to confusion and redundancy, especially when using assistive technologies.

What should we do:

    - Remove Redundant Linkage: In most cases, the 'for' attribute in the label is sufficient to
    establish a clear linkage. The 'aria-labelled by' attribute can be removed in this case to avoid
    redundancy.

    - Consistent Use of Attributes: Ensure consistent use of attributes throughout the website. Use
    either 'for' or 'aria-labelled by' depending on the context and requirements, but avoid double
    linkage

Solution :

    - as we made label `for` attribute value consistent with `id` value for its corresponding `input/select` element
        - https://github.com/CollaboraOnline/online/pull/8646
    - now we can remove 'aria-labelled by' as there is already linkage present
    - there are some cases where labels are not present, we must use `aria-labelledby` in that case.
    
Signed-off-by: Darshan-upadhyay1110 <darshan.upadhyay@collabora.com>

Change-Id: I389d271280a80835fd7345e8221e3777f8f8ed51


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

