### PR TITLE
Related: cool#8648 clipboard: use JSON when requesting HTML only

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -1273,7 +1273,7 @@ bool ChildSession::getClipboard(const StringVector& tokens)
 
     // FIXME: extra 'content' is necessary for Message parsing.
     Util::vectorAppend(output, "clipboardcontent: content\n");
-    bool json = specifics.size() > 1;
+    bool json = !specifics.empty();
     Poco::JSON::Object selectionObject;
     LOG_TRC("Building clipboardcontent: " << nOutCount << " items");
     for (size_t i = 0; i < nOutCount; ++i)


### PR DESCRIPTION
Visit the
/cool/clipboard?WOPISrc=...&MimeType=text/html,text/plain;charset=utf-8
endpoint, you get a JSON with HTML and plain text. Visit
/cool/clipboard?WOPISrc=...&MimeType=text/html, you get HTML with a
custom header that is only possibly to skip easily because HTML itself
has as well-known header.

This is decied in ChildSession::getClipboard(), which has 3 cases: 1)
single specific format 2) multiple specific formats and 3) all formats.
So far only 2) used JSON, but the new async clipboard copy will want to
(als) request just plain text, where skipping our own custom header is
hard, given that the text itself has no well-known header (unlike HTML).

Solve the problem by always using JSON when a specific format is
requested, so both the HTML and HTML+plaintext case gives JSON.

The client side of this is the recently introduced Clipboard.js
parseClipboard(), which can cope with JSON already.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I8298f3f82d2a3871777c369f5aee6bb81d66a553
