### PR TITLE
kit: set creation date when online creates file from template

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -783,7 +783,7 @@ bool ChildSession::loadDocument(const StringVector& tokens)
 
         LOG_INF("Saving the template document after loading to [" << url << ']');
 
-        const bool success = getLOKitDocument()->saveAs(url.c_str(), nullptr, "TakeOwnership");
+        const bool success = getLOKitDocument()->saveAs(url.c_str(), nullptr, "TakeOwnership,FromTemplate");
         if (!success)
         {
             LOG_ERR("Failed to save template [" << url << ']');


### PR DESCRIPTION
problem:
when online created file using WOPI clients, creation dates were never set. in online files are created using templates, even empty files are created using an empty template


Change-Id: I312d7af17bf322ca55b6e20bba344e4fc6628e66


* Target version: master 


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

