### PR TITLE
Hide unwanted toolbar btns for readonly in mobile & Add reaonly option for other application in mobile view

### DIFF
--- a/browser/src/control/Control.MobileTopBar.js
+++ b/browser/src/control/Control.MobileTopBar.js
@@ -22,24 +22,14 @@ class MobileTopBar extends JSDialog.Toolbar {
 	}
 
 	getToolItems() {
-		var isReadOnlyMode = app.map ? app.map.isReadOnlyMode() : true;
-		var canUserWrite = !app.isReadOnly();
-
 		if (this.docType == 'text') {
 			return [
 				{type: 'toolitem', id: 'signstatus', command: '.uno:Signature', w2icon: '', text: _UNO('.uno:Signature'), visible: false},
 				{type: 'toolitem',  id: 'undo', text: _UNO('.uno:Undo'), command: '.uno:Undo', enabled: false},
 				{type: 'toolitem',  id: 'redo', text: _UNO('.uno:Redo'), command: '.uno:Redo', enabled: false},
-				{type: 'spacer', id: 'before-PermissionMode'},
-				{
-					type: 'container',
-					id: 'permissionmode-container',
-					children: [
-						{type: 'htmlcontent', id: 'PermissionMode', htmlId: 'permissionmode', text: '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp', isReadOnlyMode: isReadOnlyMode, canUserWrite: canUserWrite, visible: false},
-						{type: 'spacer', id: 'after-PermissionMode', visible: false},
-					],
-					vertical: false,
-				},
+				{type: 'spacer', id: 'before-permissionmode'},
+				this._generateHtmlItem('permissionmode'),
+				{type: 'spacer', id: 'after-permissionmode'},
 				{type: 'customtoolitem',  id: 'mobile_wizard', command: 'mobile_wizard'},
 				{type: 'customtoolitem',  id: 'insertion_mobile_wizard', command: 'insertion_mobile_wizard'},
 				{type: 'customtoolitem',  id: 'comment_wizard', command: 'comment_wizard', w2icon: 'viewcomments'},
@@ -52,7 +42,9 @@ class MobileTopBar extends JSDialog.Toolbar {
 				{type: 'toolitem',  id: 'redo', text: _UNO('.uno:Redo'), command: '.uno:Redo', enabled: false},
 				{type: 'customtoolitem', visible: false, id: 'acceptformula', command: 'acceptformula', text: _('Accept')},
 				{type: 'customtoolitem', visible: false, id: 'cancelformula', command: 'cancelformula', text: _('Cancel')},
-				{type: 'spacer'},
+				{type: 'spacer', id: 'before-PermissionMode'},
+				this._generateHtmlItem('permissionmode'),
+				{type: 'spacer', id: 'after-PermissionMode'},
 				{type: 'customtoolitem',  id: 'mobile_wizard', command: 'mobile_wizard'},
 				{type: 'customtoolitem',  id: 'insertion_mobile_wizard', command: 'insertion_mobile_wizard'},
 				{type: 'customtoolitem',  id: 'comment_wizard', command: 'comment_wizard', w2icon: 'viewcomments'},
@@ -63,7 +55,9 @@ class MobileTopBar extends JSDialog.Toolbar {
 				{type: 'toolitem', id: 'signstatus', command: '.uno:Signature', w2icon: '', text: _UNO('.uno:Signature'), visible: false},
 				{type: 'toolitem',  id: 'undo', text: _UNO('.uno:Undo'), command: '.uno:Undo', enabled: false},
 				{type: 'toolitem',  id: 'redo', text: _UNO('.uno:Redo'), command: '.uno:Redo', enabled: false},
-				{type: 'spacer'},
+				{type: 'spacer', id: 'before-permissionmode'},
+				this._generateHtmlItem('permissionmode'),
+				{type: 'spacer', id: 'after-permissionmode'},
 				{type: 'customtoolitem',  id: 'mobile_wizard', command: 'mobile_wizard'},
 				{type: 'customtoolitem',  id: 'insertion_mobile_wizard', command: 'insertion_mobile_wizard'},
 				{type: 'customtoolitem',  id: 'comment_wizard', command: 'comment_wizard', w2icon: 'viewcomments'},
@@ -75,7 +69,9 @@ class MobileTopBar extends JSDialog.Toolbar {
 				{type: 'toolitem', id: 'signstatus', command: '.uno:Signature', w2icon: '', text: _UNO('.uno:Signature'), visible: false},
 				{type: 'toolitem',  id: 'undo', text: _UNO('.uno:Undo'), command: '.uno:Undo', enabled: false},
 				{type: 'toolitem',  id: 'redo', text: _UNO('.uno:Redo'), command: '.uno:Redo', enabled: false},
-				{type: 'spacer'},
+				{type: 'spacer', id: 'before-PermissionMode'},
+				this._generateHtmlItem('permissionmode'),
+				{type: 'spacer', id: 'after-PermissionMode'},
 				{type: 'customtoolitem',  id: 'mobile_wizard', command: 'mobile_wizard'},
 				{type: 'customtoolitem',  id: 'insertion_mobile_wizard', command: 'insertion_mobile_wizard'},
 				{type: 'customtoolitem',  id: 'comment_wizard', command: 'comment_wizard', w2icon: 'viewcomments'},
@@ -121,6 +117,21 @@ class MobileTopBar extends JSDialog.Toolbar {
 				this.enableItem(id, false);
 			}
 		}
+	}
+
+	_generateHtmlItem(id) {
+		var isReadOnlyMode = app.map ? app.isReadOnly() : true;
+		var canUserWrite = !app.isReadOnly();
+
+		return {
+			type: 'container',
+			id: id + '-container',
+			children: [
+				{type: 'htmlcontent', id: id, htmlId: id, text: '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp', isReadOnlyMode: isReadOnlyMode, canUserWrite: canUserWrite, visible: false},
+				{type: 'spacer', id: id + '-break'}
+			],
+			vertical: false,
+		};
 	}
 }
 

--- a/browser/src/control/Control.MobileTopBar.js
+++ b/browser/src/control/Control.MobileTopBar.js
@@ -90,17 +90,17 @@ class MobileTopBar extends JSDialog.Toolbar {
 	}
 
 	onUpdatePermission(e) {
-		var toolbarButtons = ['next', 'prev', 'mobile_wizard', 'insertion_mobile_wizard', 'comment_wizard'];
+		var toolbarButtons = ['undo', 'redo', 'mobile_wizard', 'insertion_mobile_wizard', 'comment_wizard'];
 		if (e.perm === 'edit') {
 			toolbarButtons.forEach((id) => {
-				this.enableItem(id, true);
+				this.showItem(id, true);
 			});
 			this.showItem('PermissionMode', false);
 		} else {
 			toolbarButtons.forEach((id) => {
-				this.enableItem(id, false);
+				this.showItem(id, false);
 			});
-			this.enableItem('comment_wizard', true);
+			this.showItem('comment_wizard', true);
 			if ($('#mobile-edit-button').is(':hidden')) {
 				this.showItem('PermissionMode', true);
 			}

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -1085,7 +1085,7 @@ L.Map.include({
 			if ($('.leaflet-cursor').is(':visible'))
 				return;
 
-			if (window.mode.isMobile()) {
+			if (window.mode.isMobile() && this.isEditMode()) {
 				var mobileTopBar = map.mobileTopBar;
 				mobileTopBar.showItem('cancelformula', false);
 				mobileTopBar.showItem('acceptformula', false);

--- a/cypress_test/integration_tests/mobile/writer/toolbar_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/toolbar_spec.js
@@ -17,7 +17,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Toolbar tests', function() 
 
 	it('State of mobile wizard toolbar item.', function() {
 		// Mobile wizard toolbar button is disabled by default
-		cy.cGet('#toolbar-up #mobile_wizard').should('have.attr', 'disabled');
+		cy.cGet('#toolbar-up #mobile_wizard').should('not.be.visible');
 		// Click on edit button
 		mobileHelper.enableEditingMobile();
 		// Button should be enabled now
@@ -26,7 +26,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Toolbar tests', function() 
 
 	it('State of insertion mobile wizard toolbar item.', function() {
 		// Insertion mobile wizard toolbar button is disabled by default
-		cy.cGet('#toolbar-up #insertion_mobile_wizard').should('have.attr', 'disabled');
+		cy.cGet('#toolbar-up #insertion_mobile_wizard').should('not.be.visible');
 		// Click on edit button
 		mobileHelper.enableEditingMobile();
 		// Button should be enabled now


### PR DESCRIPTION

Hide disabled elements on mobile top-toolbar
- we disabled some specific button on mobile top toolbar
- but just disabling it won't hide that from UI
- maybe it is better to not show those buttons
- it also occupies much space in top view

Add read-only option in JSON for all application
- Read-only option was only present in writer before this patch
- this will add option for all other Apps: Calc,Draw,Impress
- There is slight issue while getting the read-only flag for MobileTopBar . 
                - `app.map. isReadOnlyMode ()`: Still not work because at point of getToolItems() no permission had be setted in permission.js file for function `isReadOnly()`
                - it means this._permission still undefined when we cal `app.map. isReadOnlyMode ()` from Control.MobileTopBar.js
      
          
