### PR TITLE
On mobile platforms, the default poll time needs to be short

### DIFF
--- a/kit/Kit.hpp
+++ b/kit/Kit.hpp
@@ -165,7 +165,7 @@ public:
 
 #ifdef IOS
     static std::mutex KSPollsMutex;
-    // static std::condition_variable KSPollsCV;
+    static std::condition_variable KSPollsCV;
     static std::vector<std::weak_ptr<KitSocketPoll>> KSPolls;
 
     std::mutex terminationMutex;


### PR DESCRIPTION
It needs to be short as it directly affects the time needed to load a document.