### PR TITLE
permission: Don't show the edit button if read-only

### DIFF
--- a/browser/src/control/Permission.js
+++ b/browser/src/control/Permission.js
@@ -68,7 +68,7 @@ L.Map.include({
 				button.on('click', function () {
 					that._requestFileCopy();
 				});
-			} else if (!this.options.canTryLock && (window.mode.isMobile() || window.mode.isTablet())) {
+			} else if ((!window.ThisIsAMobileApp && !this['wopi'].UserCanWrite) || (!this.options.canTryLock && (window.mode.isMobile() || window.mode.isTablet()))) {
 				$('#mobile-edit-button').hide();
 			}
 


### PR DESCRIPTION
If wopi.UserCanWrite tells us we can't write the file no reason to show the edit button that would do nothing anyway.

Fix https://github.com/CollaboraOnline/online/issues/8686


Change-Id: I4f6d1f8d8be520e422e260f2e532cb86541e8d0f


* Resolves: #8686
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

