### PR TITLE
uno: .uno:SetDocumentProperties: add file path parameter

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -546,6 +546,21 @@ bool ChildSession::_handleInput(const char *buffer, int length)
                 assert(false);
                 return false;
             }
+            else if (tokens[1].find(".uno:SetDocumentProperties") != std::string::npos)
+            {
+                std::string PossibleFileExtensions[3] = {"", TO_UPLOAD_SUFFIX + std::string(UPLOADING_SUFFIX), TO_UPLOAD_SUFFIX};
+                for (size_t i = 0; i < 3; i++)
+                {
+                    const auto st = FileUtil::Stat(Poco::URI(getJailedFilePath()).getPath() + PossibleFileExtensions[i]);
+                    if (st.exists())
+                    {
+                        const std::size_t size = (st.good() ? st.size() : 0);
+                        std::string addedProperty = firstLine + "?FileSize:string=" + std::to_string(size);
+                        StringVector newTokens = StringVector::tokenize(addedProperty.data(), addedProperty.size());
+                        return unoCommand(newTokens);
+                    }
+                }
+            }
 
             return unoCommand(tokens);
         }


### PR DESCRIPTION
problem:
in LOK/online to support async save, files in jails may have different extensions (ie: .upload, .uploading)
this caused problem to detect files as original file name may not exist. As result property like file size were always set to 0


Change-Id: Ia4b39c04412e191742b98046c5c31e3964db7ce9


* Target version: master 



### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

