### PR TITLE
Add accesibility support to comboboxes inside font panel in sidebar

### DIFF
--- a/browser/src/control/jsdialog/Widget.Combobox.js
+++ b/browser/src/control/jsdialog/Widget.Combobox.js
@@ -215,10 +215,15 @@ JSDialog.combobox = function (parentContainer, data, builder) {
 
 	var content = L.DomUtil.create('input', 'ui-combobox-content ' + builder.options.cssClass, container);
 	content.value = data.text;
-	content.setAttribute('aria-labelledby', data.id);
+	content.role = 'combobox';
+
+	if (data.aria) {
+		content.setAttribute("aria-label",data.aria.label);
+	}
 
 	var button = L.DomUtil.create('div', 'ui-combobox-button ' + builder.options.cssClass, container);
 	button.tabIndex = '0';
+	button.role = 'button';
 
 	var arrow = L.DomUtil.create('span', builder.options.cssClass + ' ui-listbox-arrow', button);
 	arrow.id = 'listbox-arrow-' + data.id;
@@ -292,7 +297,7 @@ JSDialog.combobox = function (parentContainer, data, builder) {
 
 	button.addEventListener('click', clickFunction);
 	button.addEventListener('keypress', function (event) {
-		if (event.key === 'Enter')
+		if (event.key === 'Enter' || event.key === ' ')
 			clickFunction();
 	});
 


### PR DESCRIPTION
### Summary

Add accessibility support to combo-boxes inside font panel in sidebar so that screen reader can read with ease.

### Changes

- Add aria-label to input if aria properties present in the widget data
- Add appropriate roles to input and div as per standards mentioned in MDN docs for accessbility combobox
- Modified combobox button click event to open popup using Space key as well, as mentioned in the MDN docs for accessbility

### Commit Info

Change-Id: I66ebc6897e6a9a73a65f53d5cbd2f06a645dcb3f
Change-Id: Id39242ea2fa57f8f5a46efca7a73b529ceae088d

* Target version: master 

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

