### PR TITLE
Fix formatting on JQuery join tooltip

### DIFF
--- a/browser/src/control/Control.UserList.ts
+++ b/browser/src/control/Control.UserList.ts
@@ -468,7 +468,7 @@ class UserList extends L.Control {
 		const sanitizer = document.createElement('div');
 		sanitizer.innerText = message;
 
-		this.showTooltip(sanitizer.innerText);
+		this.showTooltip(sanitizer.innerHTML);
 
 		clearTimeout(this.options.userPopupTimeout);
 		this.options.userPopupTimeout = setTimeout(() => {


### PR DESCRIPTION
A nice followup would be a change to automatically do this on all JQuery tooltips, maybe I will make a commit to do that later


Change-Id: I545f5e8d45849fb1b000c321b3554efd874eaaf8


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

