### PR TITLE
use erase/remove idiom to clean pollSockets

### DIFF
--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -572,13 +572,11 @@ int SocketPoll::poll(int64_t timeoutMaxMicroS)
             LOG_TRC("Scanning to removing " << itemsErased << " defunct sockets from "
                     << _pollSockets.size() << " sockets");
 
-            for (auto it = _pollSockets.begin(); it != _pollSockets.end();)
-            {
-                if (!*it)
-                    it = _pollSockets.erase(it);
-                else
-                    ++it;
-            }
+            _pollSockets.erase(
+                std::remove_if(_pollSockets.begin(), _pollSockets.end(),
+                    [](const std::shared_ptr<Socket>& s)->bool
+                    { return !s; }),
+                _pollSockets.end());
         }
     }
 


### PR DESCRIPTION
which is more efficient than repeatedly erasing in a vector.

* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

