### PR TITLE
Draggable, TouchGesture: Fix panning with RTL

### DIFF
--- a/browser/src/dom/Draggable.js
+++ b/browser/src/dom/Draggable.js
@@ -120,6 +120,10 @@ L.Draggable = L.Evented.extend({
 		    newPoint = new L.Point(first.clientX, first.clientY),
 		    offset = newPoint.subtract(this._startPoint);
 
+		if (this._map._docLayer.isCalcRTL()) {
+			offset.x = -offset.x;
+		}
+
 		if (this._map) {
 			// needed in order to avoid a jump when the document is dragged and the mouse pointer move
 			// from over the map into the html document element area which is not covered by tiles

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1001,7 +1001,7 @@ L.CanvasTileLayer = L.Layer.extend({
 		this._painter._addTilesSection();
 		this._painter._sectionContainer.getSectionWithName('tiles').onResize();
 		this._painter._addOverlaySection();
-		this._painter._sectionContainer.addSection(L.getNewScrollSection());
+		this._painter._sectionContainer.addSection(L.getNewScrollSection(function () { return this._map._docLayer.isCalcRTL(); }.bind(this)));
 
 		// For mobile/tablet the hammerjs swipe handler already uses a requestAnimationFrame to fire move/drag events
 		// Using L.TileSectionManager's own requestAnimationFrame loop to do the updates in that case does not perform well.

--- a/browser/src/layer/tile/ScrollSection.ts
+++ b/browser/src/layer/tile/ScrollSection.ts
@@ -22,7 +22,9 @@ export class ScrollSection extends CanvasSectionObject {
 	pendingScrollEvent: any = null;
 	stepByStepScrolling: boolean = false; // quick scroll will move "page up/down" not "jump to"
 
-	constructor () {
+	isRTL: () => boolean;
+
+	constructor (isRTL?: () => boolean) {
 		super({
 			name: L.CSections.Scroll.name,
 			anchor: [],
@@ -40,6 +42,8 @@ export class ScrollSection extends CanvasSectionObject {
 		this.sectionProperties = {};
 
 		this.map = L.Map.THIS;
+
+		this.isRTL = isRTL ?? (function () { return false; });
 
 		this.map.on('scrollto', this.onScrollTo, this);
 		this.map.on('scrollby', this.onScrollBy, this);
@@ -702,6 +706,10 @@ export class ScrollSection extends CanvasSectionObject {
 	}
 
 	public scrollHorizontalWithOffset (offset: number): void {
+		if (this.isRTL()) {
+			offset = -offset;
+		}
+
 		var go = true;
 		if (offset > 0) {
 			if (this.documentTopLeft[0] + offset > this.sectionProperties.xMax)
@@ -1063,6 +1071,6 @@ export class ScrollSection extends CanvasSectionObject {
 
 }
 
-L.getNewScrollSection = function () {
-	return new cool.ScrollSection();
+L.getNewScrollSection = function (isRTL?: () => boolean) {
+	return new cool.ScrollSection(isRTL);
 };

--- a/browser/src/map/handler/Map.TouchGesture.js
+++ b/browser/src/map/handler/Map.TouchGesture.js
@@ -665,11 +665,13 @@ L.Map.TouchGesture = L.Handler.extend({
 		if (this._map.uiManager.isUIBlocked())
 			return;
 
+		var velocityX = this._map._docLayer.isCalcRTL() ? -e.velocityX : e.velocityX;
+		var pointVelocity = new L.Point(velocityX, e.velocityY);
 		if (this._inSwipeAction) {
-			this._velocity = this._velocity.add(new L.Point(e.velocityX, e.velocityY));
+			this._velocity = this._velocity.add(pointVelocity);
 		}
 		else {
-			this._velocity = new L.Point(e.velocityX, e.velocityY);
+			this._velocity = pointVelocity;
 		}
 		this._amplitude = this._velocity.multiplyBy(32);
 		this._newPos = L.DomUtil.getPosition(this._map._mapPane);


### PR DESCRIPTION
Previously when we were in RTL mode panning would be flipped. This
commit unflips it

This is a nontrivial backport of #8565, nontrivial only because that contained some es6-specific code that cannot be backported

I also didn't backport removing the dead code, because I don't want to make any backport that's unnecessary to fix something

Signed-off-by: Skyler Grey <skyler.grey@collabora.com>
Change-Id: Iea4d16918b054d355e6d8695e0dc1d6ededd6793* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

