### PR TITLE
cool#8648 clipboard: fix desktop/writer/copy_paste_spec.js

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -3267,7 +3267,7 @@ L.CanvasTileLayer = L.Layer.extend({
 			this._map.removeLayer(this._map._textInput._cursorHandler); // User selected a text, we remove the carret marker.
 			// Keep fetching the text selection during testing, for now: too many tests
 			// depend on this behavior currently.
-			if (navigator.clipboard.write && !L.Browser.cypressTest) {
+			if (navigator.clipboard.write && !(L.Browser.cypressTest && !this._map._clip._dummyClipboard.useAsyncWrite)) {
 				this._map._clip.setTextSelectionType('text');
 			} else {
 				if (this._selectionContentRequest) {


### PR DESCRIPTION
Once the patch from
<https://github.com/CollaboraOnline/online/issues/8648#issuecomment-2037278091>
is applied to make CanvasTileLayer.js _onTextSelectionMsg() not fetch
the clipboard proactively, this test started to fail.

This happened because the test assumed that once a text selection is
created, we have the HTML for it, which is no longer the case.

Fix the problem by extending the dummy clipboard code to also handle
plain text and by adding a function which triggers the copy(), to
minimize the changes to the actual test code.

This is just a start, lots of other tests still need fixing, and once
the pattern is clear, common code should be extracted to
cypress_test/integration_tests/common/helper.js, probably.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I21ed1143470fa8026e133b0519e114a40fc0ed90
