### PR TITLE
notebookbar: event prevent default for theme toggle button

### DIFF
--- a/browser/src/control/Control.NotebookbarBuilder.js
+++ b/browser/src/control/Control.NotebookbarBuilder.js
@@ -336,7 +336,8 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 		$(control.button).unbind('click');
 		$(control.label).unbind('click');
 		if (!builder.map.isLockedItem(data)) {
-			$(control.container).click(function () {
+			$(control.container).click(function (e) {
+				e.preventDefault();
 				L.control.menubar()._executeAction.bind({_map: builder.options.map})(undefined, {id: data.id});
 			});
 		}


### PR DESCRIPTION
problem:
if calc->view tab-> dark theme button is clicked, if button is clicked from icon it works fine,
but if button is clicked on label event is triggered twice, which means theme would be restored to first

reproducible only in firefox


Change-Id: Ie645df86651a7507582de44147885a2b62384ddb


* Target version: master 


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

