### PR TITLE
Makefile: added a target to run with heaptrack

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -548,6 +548,12 @@ run-massif-inproc: setup-wsd
 	valgrind --tool=massif --num-callers=64 --trace-children=no -v \
 		./coolwsd-inproc $(COMMON_PARAMS) \
 			--o:logging.file[@enable]=false --o:logging.level=trace
+
+run-heaptrack-inproc: setup-wsd
+	@echo "Launching coolwsd under heaptrack for single process"
+	heaptrack \
+		./coolwsd-inproc $(COMMON_PARAMS) \
+			--o:logging.file[@enable]=false --o:logging.level=trace
 endif
 
 sync-writer:


### PR DESCRIPTION
It will launch the gui at the end if found
It's much faster than valgrind+massif


Change-Id: Ied5a00ab634f78bbb0dd24a48a83ae4293183cd4


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

