### PR TITLE
After fork we don't have a watchdog thread

### DIFF
--- a/common/Watchdog.hpp
+++ b/common/Watchdog.hpp
@@ -52,7 +52,8 @@ public:
 
     ~Watchdog()
     {
-        joinThread();
+        if (_thread)
+            joinThread();
     }
 
     static uint64_t getDisableStamp() { return 0; }


### PR DESCRIPTION
So watchdog won't fire for a stalling kit.

After a fork the child has only one thread, but a copy of the watchdog object.

Stop the watchdog thread before fork, let the child discard its copy of the watchdog that is now in a discardable state.

And allow it to create a new one on the next SocketPoll ctor.


Change-Id: I7dc166dca3996401fbdc20cd7643f944662454c8


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

