### PR TITLE
After fork we don't have a watchdog thread

### DIFF
--- a/common/Watchdog.hpp
+++ b/common/Watchdog.hpp
@@ -52,7 +52,8 @@ public:
 
     ~Watchdog()
     {
-        joinThread();
+        if (_thread)
+            joinThread();
     }
 
     static uint64_t getDisableStamp() { return 0; }

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -1372,4 +1372,18 @@ void SocketPoll::shutdownWatchdog()
     PollWatchdog.reset();
 }
 
+bool SocketPoll::joinWatchdogThread()
+{
+    if (!PollWatchdog)
+        return false;
+    PollWatchdog->joinThread();
+    return true;
+}
+
+void SocketPoll::relaunchWatchdogThread()
+{
+    if (PollWatchdog)
+        PollWatchdog->startThread();
+}
+
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -606,7 +606,12 @@ public:
     /// Create a socket poll, called rather infrequently.
     explicit SocketPoll(std::string threadName);
     virtual ~SocketPoll();
+    /// discard Watchdog
     static void shutdownWatchdog();
+    /// join watchdog thread if it exists, return true if there was a watchdog
+    static bool joinWatchdogThread();
+    /// re-launch watchdog thread if it exists
+    static void relaunchWatchdogThread();
 
     /// Default poll time - useful to increase for debugging.
     static constexpr std::chrono::microseconds DefaultPollTimeoutMicroS = std::chrono::seconds(5);


### PR DESCRIPTION
So watchdog won't fire for a stalling kit.

After a fork the child has only one thread, but a copy of the watchdog object.

Stop the watchdog thread before fork, let the child discard its copy of the watchdog that is now in a discardable state.

And allow it to create a new one on the next SocketPoll ctor.

Signed-off-by: Caolán McNamara <caolan.mcnamara@collabora.com>
Change-Id: I7dc166dca3996401fbdc20cd7643f944662454c8 (cherry picked from commit bb7cd9f35704d1391874d3e302dc7a66570cd242)


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

