### PR TITLE
[Backport] fix : Present in the window button hides only for mobile apps

### DIFF
--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -443,7 +443,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'command': 'presentation',
 				'accessibility': { focusBack: true, combination: 'PR', de: null }
 			},
-			window.mode.isDesktop() ?
+			!window.ThisIsAMobileApp ?
 				{
 					'id': 'view-presentation-in-window',
 					'type': 'bigcustomtoolitem',


### PR DESCRIPTION
Change-Id: I8b2824f6a17091d1a5202051cc95b6a53013f0cf


* Resolves: # <!-- related github issue -->
* Target version: master 
