### PR TITLE
Enable new copy handler on mobile platforms

### DIFF
--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -890,11 +890,6 @@ L.Clipboard = L.Class.extend({
 	// Pull UNO clipboard commands out from menus and normal user input.
 	// We try to massage and re-emit these, to get good security event / credentials.
 	filterExecCopyPaste: function(cmd) {
-		if (window.ThisIsAMobileApp) {
-			// We do native copy/paste in the iOS and Android cases
-			return false;
-		}
-
 		if (this._map['wopi'].DisableCopy && (cmd === '.uno:Copy' || cmd === '.uno:Cut')) {
 			// perform internal operations
 			app.socket.sendMessage('uno ' + cmd);

--- a/browser/src/map/Map.js
+++ b/browser/src/map/Map.js
@@ -70,8 +70,7 @@ L.Map = L.Evented.extend({
 			this.options.documentContainer = L.DomUtil.get(this.options.documentContainer);
 		}
 
-		if (!window.ThisIsAMobileApp)
-			this._clip = L.clipboard(this);
+		this._clip = L.clipboard(this);
 		this._initContainer(id);
 		this._initLayout();
 


### PR DESCRIPTION
At least on iOS, the new copy handler works as intended and sends an uno message to the LibreOffice code.