### PR TITLE
aarch64 doesn't have SYS_futimesat

### DIFF
--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -1501,7 +1501,7 @@ namespace http
 extern "C" {
     void handleUserProfileSignal(const int /* signal */)
     {
-#if defined(__linux__) && !defined(__ANDROID__)
+#if defined(__linux__) && !defined(__ANDROID__) && defined(SYS_futimesat)
         const struct timeval times[2] = {};
         // call something fairly obscure that perf can trigger on.  futimesat
         // look a good candidate (calling "futimesat" typically results in


### PR DESCRIPTION
we picked something obscure, and clearly aarch64 took advantage of not adding something obscure unnecessary for backwards compatibility on that arch


Change-Id: I097ef24c98e23931a3997c743d17d52c0afd52b7


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

