### PR TITLE
fix(browser): Limit size of user list avatars

### DIFF
--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -1697,6 +1697,11 @@ menu-entry-with-icon.padding-left + menu-entry-icon.width */
 	grid-template-columns: 0fr 1fr;
 }
 
+.user-list-item img {
+	width: 32px;
+	height: 32px;
+}
+
 #follow-editor {
 	padding: 8px;
 }


### PR DESCRIPTION
Signed-off-by: Julius Härtl <jus@bitgrid.net>
Change-Id: I9750f345a98e89711f679f8d4c5ff9e2d99e0648

* Target version: master 

### Summary

Fix the avatar size in the user list popover menu by setting a fixed size

| Before | After |
|---|---|
| <img width="292" alt="Screenshot 2024-04-09 at 10 07 27" src="https://github.com/CollaboraOnline/online/assets/3404133/9308b9ea-8398-4493-8b49-567ef4f7b97e"> | <img width="282" alt="Screenshot 2024-04-09 at 10 07 21" src="https://github.com/CollaboraOnline/online/assets/3404133/728f3f82-dc13-4211-b89e-73d966233ac9"> |

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

