### PR TITLE
_setSpliterGradient triggers excess drawing

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -6228,13 +6228,19 @@ L.CanvasTileLayer = L.Layer.extend({
 	},
 
 	_setSpliterGradient: function (splitter, visibleTopLeft) {
+
+		var origTopOrLeftOfSplitPane = splitter.isTopOrLeftOfSplitPane;
+
 		if (Math.round(visibleTopLeft) == 0) {
 			splitter.isTopOrLeftOfSplitPane = true;
 		}
 		else {
 			splitter.isTopOrLeftOfSplitPane = false;
 		}
-		splitter.onPositionChange();
+
+		if (origTopOrLeftOfSplitPane != splitter.isTopOrLeftOfSplitPane) {
+			splitter.onPositionChange();
+		}
 	},
 
 	_updateOnChangePart: function () {


### PR DESCRIPTION
every _postMouseEvent in a spreadsheet calls _setSpliterGradient which triggers a redraw

```
_applyDelta [bundle.js:18978:86]
ensureCanvas [bundle.js:18941:64]
TilesSection.prototype.ensureCanvas [bundle.js:15642:88]
TilesSection.prototype.drawTileToCanvasCrop [bundle.js:15654:54]
TilesSection.prototype.drawTileInPane [bundle.js:15503:66]
TilesSection.prototype.paintWithPanes [bundle.js:15481:48]
TilesSection.prototype.paint [bundle.js:15532:78]
TilesSection.prototype.onDraw/< [bundle.js:15602:52]
TilesSection.prototype.forEachTileInView [bundle.js:15536:71]
TilesSection.prototype.onDraw [bundle.js:15592:56]
CanvasSectionContainer.prototype.drawSections [bundle.js:14091:56]
CanvasSectionContainer.prototype.requestReDraw [bundle.js:13724:76]
CanvasOverlay.prototype.redraw [bundle.js:16337:41]
CanvasOverlay.prototype.updatePath [bundle.js:16320:80]
CPath.prototype.redraw [bundle.js:15929:33]
CPolyline.prototype.setPointSet [bundle.js:16015:63]
CRectangle.prototype.setBounds [bundle.js:16103:55]
CSplitterLine.prototype.onChange [bundle.js:16172:43]
CSplitterLine.prototype.onPositionChange [bundle.js:16171:51]
_setSpliterGradient [bundle.js:18874:67]
_sendClientVisibleArea [bundle.js:18860:73]
_postMouseEvent [bundle.js:17904:75]
L.Map.Mouse<._onMouseEvent</< [bundle.js:22844:16]
_executeMouseEvents [bundle.js:22878:61]
setTimeout handler

```

Change-Id: I7eb9668edda38730daebb7a342b7a9c44677fabb


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

