### PR TITLE
Fix header avatar have the same image of current UserList

### DIFF
--- a/browser/src/control/Control.UserList.ts
+++ b/browser/src/control/Control.UserList.ts
@@ -163,7 +163,7 @@ class UserList extends L.Control {
 			img = L.DomUtil.create('img', 'avatar-img') as HTMLImageElement;
 		}
 
-		L.LOUtil.setUserImage(img, this.map);
+		L.LOUtil.setUserImage(img, this.map, viewId);
 
 		img.alt = this.options.userAvatarAlt.replace('%user', username);
 

--- a/browser/src/core/LOUtil.js
+++ b/browser/src/core/LOUtil.js
@@ -118,12 +118,11 @@ L.LOUtil = {
 
 		map.on('themechanged', setupIcon, this);
 	},
-	setUserImage: function(img, map) {
+	setUserImage: function(img, map, viewId) {
 		var docType = map.getDocType();
 		// set avatar image if it exist in user extract info
 		var defaultImage = L.LOUtil.getImageURL('user.svg', docType);
-		var myViewId = map._docLayer._viewId;
-		var extraInfo = map._viewInfo[myViewId].userextrainfo;
+		var extraInfo = map._viewInfo[viewId].userextrainfo;
 		if (extraInfo !== undefined && extraInfo.avatar !== undefined) {
 			// set user avatar
 			img.src = extraInfo.avatar;

--- a/browser/src/layer/tile/CommentListSection.ts
+++ b/browser/src/layer/tile/CommentListSection.ts
@@ -462,7 +462,8 @@ export class CommentSection extends CanvasSectionObject {
 		var tdImg = L.DomUtil.create(tagTd, 'cool-annotation-img', tr);
 		var tdAuthor = L.DomUtil.create(tagTd, 'cool-annotation-author', tr);
 		var imgAuthor = L.DomUtil.create('img', 'avatar-img', tdImg);
-		L.LOUtil.setUserImage(imgAuthor, this.map);
+		var viewId = this.map._docLayer._viewId;
+		L.LOUtil.setUserImage(imgAuthor, this.map, viewId);
 		imgAuthor.setAttribute('width', 32);
 		imgAuthor.setAttribute('height', 32);
 		var authorAvatarImg = imgAuthor;

--- a/browser/src/layer/tile/CommentSection.ts
+++ b/browser/src/layer/tile/CommentSection.ts
@@ -269,8 +269,8 @@ export class Comment extends CanvasSectionObject {
 		var tdImg = L.DomUtil.create('td', 'cool-annotation-img', tr);
 		var tdAuthor = L.DomUtil.create('td', 'cool-annotation-author', tr);
 		var imgAuthor = L.DomUtil.create('img', 'avatar-img', tdImg);
-
-		L.LOUtil.setUserImage(imgAuthor, this.map);
+		var viewId = this.map._docLayer._viewId;
+		L.LOUtil.setUserImage(imgAuthor, this.map, viewId);
 		imgAuthor.setAttribute('width', this.sectionProperties.imgSize[0]);
 		imgAuthor.setAttribute('height', this.sectionProperties.imgSize[1]);
 


### PR DESCRIPTION
Problem :
 - Open the document which have some comment from other User
 - we can see that they are same as the logged in user avatar

Regression
    - this is a regression from commit https://github.com/CollaboraOnline/online/pull/8640/commits/e855aa6114bda90fdd64fbcbb32a77adcf7938f4
    - we were passing url of user which is logged in and that should not happening for other user avatar image

Solution: - while setUserImage function pass viewId
    - this will help to identify the user Info from map

Change-Id: I5ee8b41c2e58a4ba15ecf551b264f944aa926da8


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

