### PR TITLE
cool#8734 browser: allow enabling dark mode from a URL parameter

### DIFF
--- a/browser/html/cool.html.m4
+++ b/browser/html/cool.html.m4
@@ -362,9 +362,8 @@ m4_ifelse(IOSAPP,[true],
 m4_ifelse(ANDROIDAPP,[true],
      [window.userInterfaceMode = window.coolParams.get('userinterfacemode');])
 
-m4_ifelse(ANDROIDAPP,[true],
-     [var darkTheme = window.coolParams.get('darkTheme');
-      if (darkTheme) {window.uiDefaults = {'darkTheme': true};}])
+var darkTheme = window.coolParams.get('darkTheme');
+if (darkTheme) {window.uiDefaults = {'darkTheme': true};}
 
 m4_ifelse(EMSCRIPTENAPP,[true],
      [window.userInterfaceMode = 'notebookbar';])

--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -1218,7 +1218,14 @@ window.app = {
 					var docTypes = ['text', 'spreadsheet', 'presentation', 'drawing'];
 					for (var i = 0; i < docTypes.length; ++i) {
 						var docType = docTypes[i];
-						var darkTheme = global.localStorage.getItem('UIDefaults_' + docType + '_darkTheme');
+						var darkTheme = false;
+						if (window.uiDefaults) {
+							darkTheme = window.uiDefaults.darkTheme === true;
+						}
+						var item = global.localStorage.getItem('UIDefaults_' + docType + '_darkTheme');
+						if (item) {
+							darkTheme = item;
+						}
 						if (darkTheme) {
 							msg += ' ' + docType + 'DarkTheme=' + darkTheme;
 						}


### PR DESCRIPTION
One way for integrations to ask for dark mode is to set URL parameters.
This works for e.g. the language, but didn't work for dark mode.

There was already a parameter for this, but it was limited to Android.

Fix the problem by exposing the parameter for non-Android as well, and
also extend global.js to default to this, but keep the local storage as
an option to customize the setting if the user wants to.

Tested with 'make run', <input type=hidden> way may need more work on
top of this.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I78c4115a8e337ef2b1ea9e498db2572965762bef
