### PR TITLE
Coverity Fixes

### DIFF
--- a/common/MessageQueue.hpp
+++ b/common/MessageQueue.hpp
@@ -165,9 +165,17 @@ protected:
                 // Remove the queued textinput message and combine it with the current one
                 getQueue().erase(getQueue().begin() + i);
 
-                std::string newMsg = queuedTokens[0] + " textinput id=" + id + " text=" + queuedText + text;
+                std::string newMsg;
+                newMsg.reserve(it.size() * 2);
+                newMsg.append(queuedTokens[0]);
+                newMsg.append(" textinput id=");
+                newMsg.append(id);
+                newMsg.append(" text=");
+                newMsg.append(queuedText);
+                newMsg.append(text);
 
-                LOG_TRC("Combined [" << queuedMessage << "] with current message to [" << newMsg << "]");
+                LOG_TRC("Combined [" << queuedMessage << "] with current message to [" << newMsg
+                                     << ']');
 
                 return newMsg;
             }

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -734,8 +734,6 @@ Document::~Document()
     // Wait for the callback worker to finish.
     _stop = true;
 
-    _tileQueue->put("eof");
-
     for (const auto& session : _sessions)
     {
         session.second->resetDocManager();

--- a/test/FileServeWhiteBoxTests.cpp
+++ b/test/FileServeWhiteBoxTests.cpp
@@ -437,7 +437,7 @@ void FileServeTests::testPreProcessedFileSubstitution()
         { "BUYPRODUCT_URL", "https://buy.ourproduct.com/'" }
     };
 
-    preProcessedFileSubstitution(testname, variables);
+    preProcessedFileSubstitution(testname, std::move(variables));
     preProcessedFileSubstitution(std::string(testname) + "_empty",
                                  std::unordered_map<std::string, std::string>());
 }


### PR DESCRIPTION
- wsd: redunce string concatenation churn
- wsd: test: move single-use local map
- wsd: remove unused eof from the TileQueue
