### PR TITLE
cool#8648 clipboard: fix insert hyperlink dialog

### DIFF
--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -982,7 +982,12 @@ L.Map.include({
 			text = this.hyperlinkUnderCursor.text;
 		} else if (this._clip && this._clip._selectionType == 'text') {
 			if (map['stateChangeHandler'].getItemValue('.uno:Copy') === 'enabled') {
-				text = this.extractContent(this._clip._selectionContent);
+				if (navigator.clipboard.write) {
+					// Async copy, trigger fetching the text selection.
+					app.socket.sendMessage('gettextselection mimetype=text/html,text/plain;charset=utf-8');
+				} else {
+					text = this.extractContent(this._clip._selectionContent);
+				}
 			}
 		} else if (this._docLayer._selectedTextContent) {
 			text = this.extractContent(this._docLayer._selectedTextContent);

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1706,7 +1706,13 @@ L.CanvasTileLayer = L.Layer.extend({
 				// Single format: as-is.
 				textMsgHtml = textMsgContent;
 			}
-			if (this._map._clip) {
+			const hyperlinkTextBox = document.getElementById('hyperlink-text-box');
+			if (hyperlinkTextBox) {
+				// Hyperlink dialog is open, the text selection is for the link text
+				// widget.
+				const extracted = this._map.extractContent(textMsgHtml);
+				hyperlinkTextBox.value = extracted.trim();
+			} else if (this._map._clip) {
 				this._map._clip.setTextSelectionHTML(textMsgHtml, textMsgPlainText);
 			} else
 				// hack for ios and android to get selected text into hyperlink insertion dialog

--- a/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
@@ -246,6 +246,9 @@ describe(['tagdesktop'], 'Top toolbar tests.', function() {
 	});
 
 	it('Insert hyperlink.', function() {
+		helper.setDummyClipboardForCopy();
+		writerHelper.selectAllTextOfDoc();
+		helper.copy();
 		helper.expectTextForClipboard('text text1');
 		cy.wait(500);
 		cy.cGet('#Insert-tab-label').click();
@@ -254,6 +257,7 @@ describe(['tagdesktop'], 'Top toolbar tests.', function() {
 		cy.cGet('#hyperlink-text-box').type('link');
 		cy.cGet('#hyperlink-link-box').type('www.something.com');
 		cy.cGet('#response-ok').click();
+		helper.copy();
 		helper.expectTextForClipboard('text text1link');
 		cy.cGet('#copy-paste-container p a').should('have.attr', 'href', 'http://www.something.com/');
 	});


### PR DESCRIPTION
Type a word into Writer, select it, Ctrl-K, the link text should default
to the selection, but it was empty.

This happens because Toolbar.js getTextForLink() doesn't have the
pre-fetched clipboard anymore, so we return an empty string there.

Fix the problem by triggering a text selection fetch (and leaving the
clipboard alone), and then handling the hyperlink dialog on the
CanvasTileLayer.js side.

Once this is done, the usual dummy clipboard registration & copy() calls
need adding and the test passes even with the patch from
<https://github.com/CollaboraOnline/online/issues/8648#issuecomment-2037278091>.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Ibd8313588e705c4b027643b452099bbf02cfe8ec
