### PR TITLE
clean up and simplify logging framework

### DIFF
--- a/common/Log.hpp
+++ b/common/Log.hpp
@@ -294,6 +294,17 @@ static constexpr std::size_t skipPathPrefix(const char (&s)[N], std::size_t n = 
         LOG.flush();                                                                               \
     } while (false)
 
+#define LOG_MESSAGE_(LVL, X, TYPE, PREFIX, SUFFIX)                                                 \
+    do                                                                                             \
+    {                                                                                              \
+        auto& log_ = Log::logger();                                                                \
+        if (LOG_CONDITIONAL(log_, TYPE))                                                           \
+        {                                                                                          \
+            LOG_BODY_(log_, LVL, X, PREFIX, SUFFIX);                                               \
+        }                                                                                          \
+    } while (false)
+
+
 #define LOG_BODY_(LOG, LVL, X, PREFIX, END)                        \
     char b_[1024];                                                                                 \
     std::ostringstream oss_(Log::prefix<sizeof(b_) - 1>(b_, #LVL), std::ostringstream::ate);       \
@@ -320,74 +331,25 @@ static constexpr std::size_t skipPathPrefix(const char (&s)[N], std::size_t n = 
 #endif
 
 #define LOG_TRC(X)                                                                                 \
-    do                                                                                             \
-    {                                                                                              \
-        auto& log_ = Log::logger();                                                                \
-        if (LOG_CONDITIONAL(log_, trace))                                                          \
-        {                                                                                          \
-            LOG_BODY_(log_, TRC, X, logPrefix, LOG_END);                                           \
-        }                                                                                          \
-    } while (false)
+    LOG_MESSAGE_(TRC, X, trace, logPrefix, LOG_END)                                                \
 
 #define LOG_TRC_NOFILE(X)                                                                          \
-    do                                                                                             \
-    {                                                                                              \
-        auto& log_ = Log::logger();                                                                \
-        if (LOG_CONDITIONAL(log_, trace))                                                          \
-        {                                                                                          \
-            LOG_BODY_(log_, TRC, X, logPrefix, LOG_END_NOFILE);                                    \
-        }                                                                                          \
-    } while (false)
+    LOG_MESSAGE_(TRC, X, trace, logPrefix, LOG_END_NOFILE)                                         \
 
 #define LOG_DBG(X)                                                                                 \
-    do                                                                                             \
-    {                                                                                              \
-        auto& log_ = Log::logger();                                                                \
-        if (LOG_CONDITIONAL(log_, debug))                                                          \
-        {                                                                                          \
-            LOG_BODY_(log_, DBG, X, logPrefix, LOG_END);                                           \
-        }                                                                                          \
-    } while (false)
+    LOG_MESSAGE_(DBG, X, debug, logPrefix, LOG_END)                                                \
 
 #define LOG_INF(X)                                                                                 \
-    do                                                                                             \
-    {                                                                                              \
-        auto& log_ = Log::logger();                                                                \
-        if (LOG_CONDITIONAL(log_, information))                                                    \
-        {                                                                                          \
-            LOG_BODY_(log_, INF, X, logPrefix, LOG_END);                                           \
-        }                                                                                          \
-    } while (false)
+    LOG_MESSAGE_(INF, X, information, logPrefix, LOG_END)                                          \
 
 #define LOG_INF_NOFILE(X)                                                                          \
-    do                                                                                             \
-    {                                                                                              \
-        auto& log_ = Log::logger();                                                                \
-        if (LOG_CONDITIONAL(log_, information))                                                    \
-        {                                                                                          \
-            LOG_BODY_(log_, INF, X, logPrefix, LOG_END_NOFILE);                                    \
-        }                                                                                          \
-    } while (false)
+    LOG_MESSAGE_(INF, X, information, logPrefix, LOG_END_NOFILE)                                   \
 
 #define LOG_WRN(X)                                                                                 \
-    do                                                                                             \
-    {                                                                                              \
-        auto& log_ = Log::logger();                                                                \
-        if (LOG_CONDITIONAL(log_, warning))                                                        \
-        {                                                                                          \
-            LOG_BODY_(log_, WRN, X, logPrefix, LOG_END);                                           \
-        }                                                                                          \
-    } while (false)
+    LOG_MESSAGE_(WRN, X, warning, logPrefix, LOG_END)                                              \
 
 #define LOG_ERR(X)                                                                                 \
-    do                                                                                             \
-    {                                                                                              \
-        auto& log_ = Log::logger();                                                                \
-        if (LOG_CONDITIONAL(log_, error))                                                          \
-        {                                                                                          \
-            LOG_BODY_(log_, ERR, X, logPrefix, LOG_END);                                           \
-        }                                                                                          \
-    } while (false)
+    LOG_MESSAGE_(ERR, X, error, logPrefix, LOG_END)                                                \
 
 /// Log an ERR entry with the given errno appended.
 #define LOG_SYS_ERRNO(ERRNO, X)                                                                    \
@@ -424,58 +386,23 @@ static constexpr std::size_t skipPathPrefix(const char (&s)[N], std::size_t n = 
 
 /// No-prefix version of LOG_TRC.
 #define LOG_TRC_S(X)                                                                               \
-    do                                                                                             \
-    {                                                                                              \
-        auto& log_ = Log::logger();                                                                \
-        if (LOG_CONDITIONAL(log_, debug))                                                          \
-        {                                                                                          \
-            LOG_BODY_(log_, TRC, X, (void), LOG_END);                                              \
-        }                                                                                          \
-    } while (false)
+    LOG_MESSAGE_(TRC, X, debug, (void), LOG_END)                                                   \
 
 /// No-prefix version of LOG_DBG.
 #define LOG_DBG_S(X)                                                                               \
-    do                                                                                             \
-    {                                                                                              \
-        auto& log_ = Log::logger();                                                                \
-        if (LOG_CONDITIONAL(log_, debug))                                                          \
-        {                                                                                          \
-            LOG_BODY_(log_, DBG, X, (void), LOG_END);                                              \
-        }                                                                                          \
-    } while (false)
+    LOG_MESSAGE_(DBG, X, debug, (void), LOG_END)                                                   \
 
 /// No-prefix version of LOG_INF.
 #define LOG_INF_S(X)                                                                               \
-    do                                                                                             \
-    {                                                                                              \
-        auto& log_ = Log::logger();                                                                \
-        if (LOG_CONDITIONAL(log_, error))                                                          \
-        {                                                                                          \
-            LOG_BODY_(log_, INF, X, (void), LOG_END);                                              \
-        }                                                                                          \
-    } while (false)
+    LOG_MESSAGE_(INF, X, error, (void), LOG_END)                                                   \
 
 /// No-prefix version of LOG_WRN.
 #define LOG_WRN_S(X)                                                                               \
-    do                                                                                             \
-    {                                                                                              \
-        auto& log_ = Log::logger();                                                                \
-        if (LOG_CONDITIONAL(log_, error))                                                          \
-        {                                                                                          \
-            LOG_BODY_(log_, WRN, X, (void), LOG_END);                                              \
-        }                                                                                          \
-    } while (false)
+    LOG_MESSAGE_(WRN, X, error, (void), LOG_END)                                                   \
 
 /// No-prefix version of LOG_ERR.
 #define LOG_ERR_S(X)                                                                               \
-    do                                                                                             \
-    {                                                                                              \
-        auto& log_ = Log::logger();                                                                \
-        if (LOG_CONDITIONAL(log_, error))                                                          \
-        {                                                                                          \
-            LOG_BODY_(log_, ERR, X, (void), LOG_END);                                              \
-        }                                                                                          \
-    } while (false)
+    LOG_MESSAGE_(ERR, X, error, (void), LOG_END)                                                   \
 
 #define LOG_CHECK(X)                                                                               \
     do                                                                                             \

--- a/common/Log.hpp
+++ b/common/Log.hpp
@@ -260,13 +260,13 @@ static constexpr std::size_t skipPathPrefix(const char (&s)[N], std::size_t n = 
 
 #ifdef __ANDROID__
 
-#define LOG_LOG(LOG, PRIO, LVL, STR)                                                               \
+#define LOG_LOG(LOG, NAME, PRIO, LVL, STR)                               \
     ((void)__android_log_print(ANDROID_LOG_DEBUG, "coolwsd", "%s %s", LVL, STR.c_str()))
 
 #else
 
-#define LOG_LOG(LOG, PRIO, LVL, STR)                                                               \
-    LOG.log(Poco::Message(LOG.name(), STR, Poco::Message::PRIO_##PRIO))
+#define LOG_LOG(LOG, NAME, PRIO, LVL, STR)                           \
+    LOG.log(Poco::Message(NAME, STR, Poco::Message::PRIO_##PRIO))
 
 #endif
 
@@ -282,13 +282,13 @@ static constexpr std::size_t skipPathPrefix(const char (&s)[N], std::size_t n = 
         LOG.flush();                                                                               \
     } while (false)
 
-#define LOG_BODY_(LOG, PRIO, LVL, X, PREFIX, END)                                                  \
+#define LOG_BODY_(LOG, PRIO, LVL, X, PREFIX, END)                        \
     char b_[1024];                                                                                 \
     std::ostringstream oss_(Log::prefix<sizeof(b_) - 1>(b_, LVL), std::ostringstream::ate);        \
     PREFIX(oss_);                                                                                  \
     oss_ << std::boolalpha << X;                                                                   \
     END(oss_);                                                                                     \
-    LOG_LOG(LOG, PRIO, LVL, oss_.str())
+    LOG_LOG(LOG, LOG.name(), PRIO, LVL, oss_.str())
 
 #define LOG_ANY(X)                                                                                 \
     char b_[1024];                                                                                 \

--- a/common/Log.hpp
+++ b/common/Log.hpp
@@ -314,13 +314,16 @@ static constexpr std::size_t skipPathPrefix(const char (&s)[N], std::size_t n = 
     LOG_LOG(LOG, LOG.name(), LVL, oss_.str())
 
 #define LOG_ANY(X)                                                                                 \
-    char b_[1024];                                                                                 \
-    std::ostringstream oss_(Log::prefix<sizeof(b_) - 1>(b_, "INF"), std::ostringstream::ate);      \
-    logPrefix(oss_);                                                                               \
-    oss_ << std::boolalpha << X;                                                                   \
-    LOG_END(oss_);                                                                                 \
-    Poco::AutoPtr<Poco::Channel> channel = Log::logger().getChannel();                             \
-    channel->log(Poco::Message("", oss_.str(), Poco::Message::Priority::PRIO_INFORMATION))
+    do                                                                                             \
+    {                                                                                              \
+        char b_[1024];                                                                             \
+        std::ostringstream oss_(Log::prefix<sizeof(b_) - 1>(b_, "INF"), std::ostringstream::ate);  \
+        logPrefix(oss_);                                                                           \
+        oss_ << std::boolalpha << X;                                                               \
+        LOG_END(oss_);                                                                             \
+        auto& log_ = Log::logger();                                                                \
+        LOG_LOG(log_, "", FTL, oss_.str());                                                        \
+    } while (false)
 
 #if defined __GNUC__ || defined __clang__
 #  define LOG_CONDITIONAL(log,type)                                                                \


### PR DESCRIPTION
AutoPtr release the Channel instance

Backtrace 25378 - wsd 23.05.10.1 6fe1a82ff4:
./coolwsd(_ZN7SigUtil13dumpBacktraceEv+0x83)[0x555fb7731bff]
./coolwsd(+0x51ab3c)[0x555fb7731b3c]
/lib/x86_64-linux-gnu/libc.so.6(+0x3c050)[0x7f9d3245b050]
/home/hcastro/build/online/install/poco/v-1.9.1/lib/libPocoFoundationd.so.61(_ZN4Poco6Logger3logERKNS_7MessageE+0x5c)[0x7f9d32bcb23a]
./coolwsd(_ZN12StreamSocket17writeOutgoingDataEv+0x88e)[0x555fb777873a]
./coolwsd(_ZN12StreamSocket4sendEPKcib+0x7a)[0x555fb74c5456]
./coolwsd(_ZN12StreamSocket4sendERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEb+0x4b)[0x555fb74c54a5]
./coolwsd(_ZN24FileServerRequestHandler19preprocessAdminFileERKN4Poco3Net11HTTPRequestERK14RequestDetailsRKSt10shared_ptrI12StreamSocketE+0x1700)[0x555fb769afc4]
./coolwsd(_ZN24FileServerRequestHandler13handleRequestERKN4Poco3Net11HTTPRequestERK14RequestDetailsRNS0_17MemoryInputStreamERKSt10shared_ptrI12StreamSocketE+0x1119)[0x555fb7688311]
./coolwsd(_ZN23ClientRequestDispatcher21handleIncomingMessageER17SocketDisposition+0xc58)[0x555fb76041f0]
./coolwsd(_ZN12StreamSocket10handlePollER17SocketDispositionNSt6chrono10time_pointINS2_3_V212steady_clockENS2_8durationIlSt5ratioILl1ELl1000000000EEEEEEi+0xa6b)[0x555fb7776d97]
./coolwsd(_ZN10SocketPoll4pollEl+0x18c5)[0x555fb776480b]
./coolwsd(_ZN10SocketPoll4pollENSt6chrono8durationIlSt5ratioILl1ELl1000000EEEE+0x2e)[0x555fb74c4be0]
./coolwsd(_ZN10SocketPoll13pollingThreadEv+0x24)[0x555fb757920e]
./coolwsd(_ZN10SocketPoll18pollingThreadEntryEv+0x2c4)[0x555fb776291e]
./coolwsd(_ZSt13__invoke_implIvM10SocketPollFvvEPS0_JEET_St21__invoke_memfun_derefOT0_OT1_DpOT2_+0x66)[0x555fb7782c6c]
./coolwsd(_ZSt8__invokeIM10SocketPollFvvEJPS0_EENSt15__invoke_resultIT_JDpT0_EE4typeEOS5_DpOS6_+0x37)[0x555fb7782b3b]
./coolwsd(_ZNSt6thread8_InvokerISt5tupleIJM10SocketPollFvvEPS2_EEE9_M_invokeIJLm0ELm1EEEEvSt12_Index_tupleIJXspT_EEE+0x43)[0x555fb7782a61]
./coolwsd(_ZNSt6thread8_InvokerISt5tupleIJM10SocketPollFvvEPS2_EEEclEv+0x18)[0x555fb77829e4]
./coolwsd(_ZNSt6thread11_State_implINS_8_InvokerISt5tupleIJM10SocketPollFvvEPS3_EEEEE6_M_runEv+0x1c)[0x555fb7782944]
/lib/x86_64-linux-gnu/libstdc++.so.6(+0xd44a3)[0x7f9d326d44a3]
/lib/x86_64-linux-gnu/libc.so.6(+0x89134)[0x7f9d324a8134]
/lib/x86_64-linux-gnu/libc.so.6(+0x1097dc)[0x7f9d325287dc]

Change-Id: I54afb7fcb1aa05c6dddceb0a8b366985bbe83448
Signed-off-by: Henry Castro <hcastro@collabora.com>
