### PR TITLE
use SigUtil::setUserSignals before creating SocketPoll

### DIFF
--- a/kit/ForKit.cpp
+++ b/kit/ForKit.cpp
@@ -807,6 +807,11 @@ int forkit_main(int argc, char** argv)
         Log::logger().setLevel(LogLevel);
     }
 
+    // The SocketPoll ctor which may, depending on COOL_WATCHDOG env variable,
+    // want to override the SIG2 handler so set user signal handlers before
+    // that otherwise that choice is overwritten
+    SigUtil::setUserSignals();
+
     ForKitPoll.reset(new SocketPoll (Util::getThreadName()));
     ForKitPoll->runOnClientThread(); // We will do the polling on this thread.
 
@@ -821,8 +826,6 @@ int forkit_main(int argc, char** argv)
         LOG_SFL("Failed to connect to WSD. Will exit.");
         Util::forcedExit(EX_SOFTWARE);
     }
-
-    SigUtil::setUserSignals();
 
     const int parentPid = getppid();
     LOG_INF("ForKit process is ready. Parent: " << parentPid);


### PR DESCRIPTION
The SocketPoll ctor which may, depending on COOL_WATCHDOG env variable, want to override the SIG2 handler so set user signal handlers before that otherwise tthat choice is overwritten


Change-Id: I305570ab8becb41f0696e60908c1ca26fd9ba14a


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

