### PR TITLE
fix: duplicate `You` on reconnect

### DIFF
--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -959,7 +959,7 @@ L.Control.UIManager = L.Control.extend({
 	},
 
 	onUpdateViews: function () {
-		if (!this.map._docLayer)
+		if (!this.map._docLayer || !this.map._docLayer._viewId)
 			return;
 
 		var myViewId = this.map._docLayer._viewId;

--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -1460,6 +1460,11 @@ app.definitions.Socket = L.Class.extend({
 		this._map.fire('docloaded', {status: true});
 		if (this._map._docLayer) {
 			this._map._docLayer._onMessage(textMsg);
+
+			// call update view list viewId if it is not defined yet
+			if (!this._map._docLayer._getViewId())
+				this._map.fire('updateviewslist');
+
 			this._reconnecting = false;
 
 			// Applying delayed messages
@@ -1629,6 +1634,7 @@ app.definitions.Socket = L.Class.extend({
 				this._map._isCursorVisible = false;
 
 			this._map._docLayer._resetCanonicalIdStatus();
+			this._map._docLayer._resetViewId();
 		}
 
 		if (isActive && this._reconnecting) {

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1178,6 +1178,14 @@ L.CanvasTileLayer = L.Layer.extend({
 		this._canonicalIdInitialized = false;
 	},
 
+	_resetViewId: function () {
+		this._viewId = undefined;
+	},
+
+	_getViewId: function () {
+		return this._viewId;
+	},
+
 	_updateTileTwips: function () {
 		// smaller zoom = zoom in
 		var factor = Math.pow(1.2, (this._map.options.zoom - this._tileZoom));


### PR DESCRIPTION
- it might happen viewinfo message arrives before status message, viewinfo message update view list with old _viewId because new _viewId after reconnection is not avaialable yet
- this patch fixes this by reseting the _viewId on socket close and call updateviewlist event after client gets new _viewId from status message


Change-Id: I88a6ade574faa1368b1635db891fe87f89fa080e


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

