### PR TITLE
browser: correct avatar css on userlist

### DIFF
--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -1563,7 +1563,8 @@ menu-entry-with-icon.padding-left + menu-entry-icon.width */
 	justify-content: end;
 }
 
-#userListHeader .avatar-img {
+#userListHeader .avatar-img,
+#userlist-dropdown .avatar-img {
 	width: var(--btn-size);
 	height: var(--btn-size);
 	background-color: var(--color-background-lighter);


### PR DESCRIPTION
Avatars on the user list where shown too big

When userlist-dropdown was separated from userListHeader as a
JSDialog, the proper avatar-img css stopped applying.

Signed-off-by: Jaume Pujantell <jaume.pujantell@collabora.com>
Change-Id: I58539c492758c4ecea09d598ba7e113034078cd9
