### PR TITLE
browser: fix merge conflict in Widget.Combobox.js

### DIFF
--- a/browser/src/control/jsdialog/Widget.Combobox.js
+++ b/browser/src/control/jsdialog/Widget.Combobox.js
@@ -218,7 +218,7 @@ JSDialog.combobox = function (parentContainer, data, builder) {
 	content.role = 'combobox';
 
 	if (data.aria) {
-		content.setAttribute("aria-label",data.aria.label);
+		content.setAttribute('aria-label',data.aria.label);
 	}
 
 	var button = L.DomUtil.create('div', 'ui-combobox-button ' + builder.options.cssClass, container);


### PR DESCRIPTION
eslint now forces single quotes.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Ia462bc21bc720b64caf5d535eb46e637e24b9f4a
