### PR TITLE
remove-w2ui: statusbar focus fix

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -225,7 +225,7 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 .jsdialog.ui-separator.vertical {
 	margin: 5px 0px;
 	padding-right: 1px;
-	background-color: #888;
+	background-color: var(--color-background-darker);
 }
 
 .jsdialog.ui-separator.horizontal {

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -3145,6 +3145,8 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			&& data.type !== 'buttonbox'
 			&& data.type !== 'treelistbox'
 			&& data.type !== 'time'
+			&& data.type !== 'separator'
+			&& data.type !== 'spacer'
 			)
 			control.setAttribute('tabIndex', '0');
 	},


### PR DESCRIPTION
- do not focus separators or spacers on tab keyboard button
- use variable for separator color

