### PR TITLE
bgsave: ensure kit processes die when their parents do.

### DIFF
--- a/common/SigUtil.cpp
+++ b/common/SigUtil.cpp
@@ -24,6 +24,10 @@
 #include <sys/uio.h>
 #include <unistd.h>
 
+#if !defined(ANDROID) && !defined(IOS)
+#  include <sys/prctl.h>
+#endif
+
 #include <atomic>
 #include <cassert>
 #include <chrono>
@@ -544,6 +548,13 @@ void requestShutdown()
 
         sigaction(SIGCHLD, &action, nullptr);
 
+    }
+
+    void dieOnParentDeath()
+    {
+#if !defined(ANDROID) && !defined(IOS)
+        prctl(PR_SET_PDEATHSIG, SIGKILL);
+#endif
     }
 
     static

--- a/common/SigUtil.hpp
+++ b/common/SigUtil.hpp
@@ -126,6 +126,9 @@ namespace SigUtil
     /// Sets a child death signal handler
     void setSigChildHandler(SigChildHandler fn);
 
+    /// Ensure that if a parent process is killed we go down too
+    void dieOnParentDeath();
+
     /// Dump a signal-safe back-trace
     void dumpBacktrace();
 

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1420,6 +1420,8 @@ bool Document::forkToSave(const std::function<void()> &childSave, int viewId)
         SigUtil::addActivity("forked background save process: " +
                              std::to_string(pid));
 
+        SigUtil::dieOnParentDeath();
+
         childSocket.reset();
         // now we just have a single socket to our parent
 


### PR DESCRIPTION
Potentially zombie / badly behaving kits should be taken down by the kernel, and this lets us continue our cleanup by killing just the parent process.

Change-Id: I1e81f41cded0c67b72622f8ed88602daf427238c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

