### PR TITLE
use erase/remove idiom to clean pollSockets

### DIFF
--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -573,13 +573,11 @@ int SocketPoll::poll(int64_t timeoutMaxMicroS)
             LOG_TRC("Scanning to removing " << itemsErased << " defunct sockets from "
                     << _pollSockets.size() << " sockets");
 
-            for (auto it = _pollSockets.begin(); it != _pollSockets.end();)
-            {
-                if (!*it)
-                    it = _pollSockets.erase(it);
-                else
-                    ++it;
-            }
+            _pollSockets.erase(
+                std::remove_if(_pollSockets.begin(), _pollSockets.end(),
+                    [](const std::shared_ptr<Socket>& s)->bool
+                    { return !s; }),
+                _pollSockets.end());
         }
     }
 


### PR DESCRIPTION
which is more efficient than repeatedly erasing in a vector.


Change-Id: Iebd41130b37a67ffd74fa2d692b83220b1cab3f4


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

