### PR TITLE
try adding {force: true} to leaflet-layer clicks

### DIFF
--- a/cypress_test/integration_tests/multiuser/writer/invalidations_spec.js
+++ b/cypress_test/integration_tests/multiuser/writer/invalidations_spec.js
@@ -36,7 +36,7 @@ describe(['tagmultiuser'], 'Joining a document should not trigger an invalidatio
 		cy.cSetActiveFrame('#iframe1');
 		writerHelper.selectAllTextOfDoc();
 		cy.cGet('#toolbar-down #StateWordCount').should('have.text', 'Selected: 1 word, 1 character');
-		cy.cGet('.leaflet-layer').click();
+		cy.cGet('.leaflet-layer').click({force:true});
 		cy.cGet('#toolbar-down #StateWordCount').should('have.text', '1 word, 1 character');
 
 		cy.cGet('.empty-deltas').then(($before) => {
@@ -49,7 +49,7 @@ describe(['tagmultiuser'], 'Joining a document should not trigger an invalidatio
 			cy.cSetActiveFrame('#iframe1');
 			writerHelper.selectAllTextOfDoc();
 			cy.cGet('#toolbar-down #StateWordCount').should('have.text', 'Selected: 1 word, 1 character');
-			cy.cGet('.leaflet-layer').click();
+			cy.cGet('.leaflet-layer').click({force:true});
 			cy.cGet('#toolbar-down #StateWordCount').should('have.text', '1 word, 1 character');
 
 			cy.cGet('.empty-deltas').should(($after) => {
@@ -76,7 +76,7 @@ describe(['tagmultiuser'], 'Joining a document should not trigger an invalidatio
 		cy.cSetActiveFrame('#iframe1');
 		writerHelper.selectAllTextOfDoc();
 		cy.cGet('#toolbar-down #StateWordCount').should('have.text', 'Selected: 1 word, 1 character');
-		cy.cGet('.leaflet-layer').click();
+		cy.cGet('.leaflet-layer').click({force:true});
 		cy.cGet('#toolbar-down #StateWordCount').should('have.text', '1 word, 1 character');
 
 		cy.cGet('.empty-deltas').then(($before) => {
@@ -95,7 +95,7 @@ describe(['tagmultiuser'], 'Joining a document should not trigger an invalidatio
 			cy.cSetActiveFrame('#iframe1');
 			writerHelper.selectAllTextOfDoc();
 			cy.cGet('#toolbar-down #StateWordCount').should('have.text', 'Selected: 1 word, 1 character');
-			cy.cGet('.leaflet-layer').click();
+			cy.cGet('.leaflet-layer').click({force:true});
 			cy.cGet('#toolbar-down #StateWordCount').should('have.text', '1 word, 1 character');
 			ceHelper.type('X');
 			cy.cGet('#toolbar-down #StateWordCount').should('have.text', '1 word, 2 characters');


### PR DESCRIPTION
error is:

1) Joining a document should not trigger an invalidation
       Join after document save and modify:
     CypressError: Timed out retrying after 10050ms: `cy.click()` failed because this element:

`<div class="leaflet-layer" style="position: absolute; width: 642px; height: 484px;"></div>`

is being covered by another element:

`<div class="jsdialog ui-button-box end" id="">...</div>`

Fix this problem, or use {force: true} to disable error checking.


Change-Id: I8b0dde030b2aadf554db75872facb6c5c96a321c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

