### PR TITLE
unwanted extra quote at end of true in json

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -2671,7 +2671,7 @@ bool DocumentBroker::sendUnoSave(const std::shared_ptr<ClientSession>& session,
         // We do not want save to terminate editing mode if we are in edit mode now.
         //TODO: Perhaps we want to terminate if forced by the user,
         // otherwise autosave doesn't terminate?
-        oss << "\"DontTerminateEdit\" : { \"type\":\"boolean\", \"value\":true\" }";
+        oss << "\"DontTerminateEdit\" : { \"type\":\"boolean\", \"value\":true }";
     }
 
     if (dontSaveIfUnmodified)
@@ -2679,7 +2679,7 @@ bool DocumentBroker::sendUnoSave(const std::shared_ptr<ClientSession>& session,
         if (dontTerminateEdit)
             oss << ',';
 
-        oss << "\"DontSaveIfUnmodified\" : { \"type\":\"boolean\", \"value\":true\" }";
+        oss << "\"DontSaveIfUnmodified\" : { \"type\":\"boolean\", \"value\":true }";
     }
 
     // arguments end


### PR DESCRIPTION
Change-Id: I66d80d415ea8e19823ccb7e6b3e8b6af1df51fbc


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

