### PR TITLE
added check for undefined properties (backport)

### DIFF
--- a/browser/src/control/jsdialog/Widget.TreeView.js
+++ b/browser/src/control/jsdialog/Widget.TreeView.js
@@ -326,6 +326,8 @@ function _getLevel(element) {
 }
 
 function _isSeparator(element) {
+	if (!element.text)
+		return false;
 	return element.text.toLowerCase() === 'separator';
 }
 function _expandTreeGrid(element) {

--- a/browser/src/map/handler/Map.StateChanges.js
+++ b/browser/src/map/handler/Map.StateChanges.js
@@ -33,8 +33,14 @@ L.Map.StateChangeHandler = L.Handler.extend({
 		if (typeof (e.state) == 'object') {
 			state = e.state;
 		} else if (typeof (e.state) == 'string') {
-			var index = e.state.indexOf('{');
-			state = index !== -1 ? JSON.parse(e.state.substring(index)) : e.state;
+			var firstIndex = e.state.indexOf('{');
+			var lastIndex = e.state.lastIndexOf('}');
+
+			if (firstIndex !== -1 && lastIndex !== -1) {
+				state = JSON.parse(e.state.substring(firstIndex, lastIndex + 1));
+			} else {
+				state = e.state;
+			}
 		}
 
 		this._items[e.commandName] = state;


### PR DESCRIPTION
problem:
zotero was not loading because element.text didn't exist on adding bibliography there was error to parse JSON, because there's some more data in string after JSON


Change-Id: If34791ae7ca79ca7fd304b506cd483e929f4d2ac


* Target version: distro/collabora/co-23.05


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

