### PR TITLE
comments: fix avatar when author is not in document

### DIFF
--- a/browser/src/core/LOUtil.js
+++ b/browser/src/core/LOUtil.js
@@ -122,10 +122,14 @@ L.LOUtil = {
 		var docType = map.getDocType();
 		// set avatar image if it exist in user extract info
 		var defaultImage = L.LOUtil.getImageURL('user.svg', docType);
-		var extraInfo = map._viewInfo[viewId].userextrainfo;
-		if (extraInfo !== undefined && extraInfo.avatar !== undefined) {
+		var viewInfo = map._viewInfo[viewId];
+		if (
+			viewInfo !== undefined
+			&& viewInfo.userextrainfo !== undefined
+			&& viewInfo.userextrainfo.avatar !== undefined
+		) {
 			// set user avatar
-			img.src = extraInfo.avatar;
+			img.src = viewInfo.userextrainfo.avatar;
 			// Track if error event is already bound to this image
 			img.addEventListener('error', function () {
 				img.src = defaultImage;

--- a/browser/src/layer/tile/CommentSection.ts
+++ b/browser/src/layer/tile/CommentSection.ts
@@ -269,7 +269,7 @@ export class Comment extends CanvasSectionObject {
 		var tdImg = L.DomUtil.create('td', 'cool-annotation-img', tr);
 		var tdAuthor = L.DomUtil.create('td', 'cool-annotation-author', tr);
 		var imgAuthor = L.DomUtil.create('img', 'avatar-img', tdImg);
-		var viewId = this.map._docLayer._viewId;
+		var viewId = this.map.getViewId(this.sectionProperties.data.author);
 		L.LOUtil.setUserImage(imgAuthor, this.map, viewId);
 		imgAuthor.setAttribute('width', this.sectionProperties.imgSize[0]);
 		imgAuthor.setAttribute('height', this.sectionProperties.imgSize[1]);


### PR DESCRIPTION
In e855aa6114bda90fdd64fbcbb32a77adcf7938f4 a regression was introduced where a comment avatar was set to your avatar if the user was not in the document

This commit returns it to the previous behavior, which had a "default" avatar instead. It might instead be nice to embed avatars in the document to avoid the avatars being missing, however the previous behavior is far less confusing than the regressed behavior and is far easier to get to than embedding avatars in the document


Change-Id: I82834089062b1e7c2570d9fd78c7e1a3077f4c96


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

