### PR TITLE
default to using available compiler hardening flags

### DIFF
--- a/common/FileUtil.cpp
+++ b/common/FileUtil.cpp
@@ -376,18 +376,19 @@ namespace FileUtil
             return nullptr;
         }
 
-        auto data = std::make_unique<std::vector<char>>(st.st_size);
+        auto remainingSize = st.st_size;
+        auto data = std::make_unique<std::vector<char>>(remainingSize);
         off_t off = 0;
         for (;;)
         {
-            if (st.st_size == 0)
+            if (remainingSize == 0)
             {
                 // Nothing to read.
                 break;
             }
 
             int n;
-            while ((n = ::read(fd, &(*data)[off], st.st_size)) < 0 && errno == EINTR)
+            while ((n = ::read(fd, &(*data)[off], remainingSize)) < 0 && errno == EINTR)
             {
             }
 
@@ -401,6 +402,7 @@ namespace FileUtil
             }
 
             off += n;
+            remainingSize -= n;
         }
 
         close(fd);

--- a/configure.ac
+++ b/configure.ac
@@ -122,6 +122,10 @@ AC_ARG_ENABLE([debug],
               AS_HELP_STRING([--enable-debug],
                              [Enable debugging, link with debugging version of Poco libraries]))
 
+AC_ARG_ENABLE([hardening-flags],
+              AS_HELP_STRING([--disable-hardening-flags],
+                             [Disable detection and use of compiler hardening flags]))
+
 AC_ARG_ENABLE([bundle],
               AS_HELP_STRING([--enable-bundle],
                              [Enable creating bundled JS and CSS even with --enable-debug]))
@@ -932,6 +936,73 @@ if test -z "$enable_werror" -o "$enable_werror" = "yes"; then
     CFLAGS="$CFLAGS -Werror"
 else
     AC_MSG_RESULT([no])
+fi
+
+AC_MSG_CHECKING([whether to use extra compiler hardening flags])
+if test "$enable_hardening_flags" = no -o "$host_os" = "emscripten" -o "x$with_sanitizer" != "x"; then
+    AC_MSG_RESULT([no])
+ else
+    AC_MSG_RESULT([yes])
+
+    AC_LANG_PUSH([C])
+    AC_MSG_CHECKING([whether $CC supports -grecord-gcc-switches])
+    save_CFLAGS=$CFLAGS
+    CFLAGS="$CFLAGS -Werror -grecord-gcc-switches"
+    AC_LINK_IFELSE(
+        [AC_LANG_PROGRAM(, [[return 0;]])],
+        [AC_MSG_RESULT([yes]); HARDENING_CFLAGS="$HARDENING_CFLAGS -grecord-gcc-switches"],
+        [AC_MSG_RESULT([no])])
+    CFLAGS=$save_CFLAGS
+
+    AC_MSG_CHECKING([whether $CC supports -D_FORTIFY_SOURCE=2])
+    save_CFLAGS=$CFLAGS
+    CFLAGS="$CFLAGS -Werror -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=2"
+    AC_LINK_IFELSE(
+        [AC_LANG_PROGRAM(, [[return 0;]])],
+        [AC_MSG_RESULT([yes]); HARDENING_CFLAGS="$HARDENING_CFLAGS -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=2"],
+        [AC_MSG_RESULT([no])])
+    CFLAGS=$save_CFLAGS
+
+    AC_MSG_CHECKING([whether $CC supports -D_GLIBCXX_ASSERTIONS])
+    save_CFLAGS=$CFLAGS
+    CFLAGS="$CFLAGS -Werror -Wp,-D_GLIBCXX_ASSERTIONS"
+    AC_LINK_IFELSE(
+        [AC_LANG_PROGRAM(, [[return 0;]])],
+        [AC_MSG_RESULT([yes]); HARDENING_CFLAGS="$HARDENING_CFLAGS -Wp,-D_GLIBCXX_ASSERTIONS"],
+        [AC_MSG_RESULT([no])])
+    CFLAGS=$save_CFLAGS
+
+    AC_MSG_CHECKING([whether $CC supports -fstack-protector-strong])
+    save_CFLAGS=$CFLAGS
+    CFLAGS="$CFLAGS -Werror -fstack-protector-strong"
+    AC_LINK_IFELSE(
+        [AC_LANG_PROGRAM(, [[return 0;]])],
+        [AC_MSG_RESULT([yes]); HARDENING_CFLAGS="$HARDENING_CFLAGS -fstack-protector-strong"],
+        [AC_MSG_RESULT([no])])
+    CFLAGS=$save_CFLAGS
+
+    AC_MSG_CHECKING([whether $CC supports -fstack-clash-protection])
+    save_CFLAGS=$CFLAGS
+    CFLAGS="$CFLAGS -Werror -fstack-clash-protection"
+    AC_LINK_IFELSE(
+        [AC_LANG_PROGRAM(, [[return 0;]])],
+        [AC_MSG_RESULT([yes]); HARDENING_CFLAGS="$HARDENING_CFLAGS -fstack-clash-protection"],
+        [AC_MSG_RESULT([no])])
+    CFLAGS=$save_CFLAGS
+
+    AC_MSG_CHECKING([whether $CC supports -fcf-protection])
+    save_CFLAGS=$CFLAGS
+    CFLAGS="$CFLAGS -Werror -fcf-protection"
+    AC_LINK_IFELSE(
+        [AC_LANG_PROGRAM(, [[return 0;]])],
+        [AC_MSG_RESULT([yes]); HARDENING_CFLAGS="$HARDENING_CFLAGS -fcf-protection"],
+        [AC_MSG_RESULT([no])])
+    CFLAGS=$save_CFLAGS
+
+    AC_LANG_POP([C])
+
+    CFLAGS="$CFLAGS $HARDENING_CFLAGS"
+    CXXFLAGS="$CXXFLAGS $HARDENING_CFLAGS"
 fi
 
 # Code Coverage.


### PR DESCRIPTION
can be disabled with --disable-hardening-flags, defaults on except for wasm and sanitizer cases


Change-Id: Id3ccb7492b73dfa6c7bbd5dd0419927032fc9bdf


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

