### PR TITLE
Add aria lables to more option button in sidebar

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2322,7 +2322,11 @@ L.Control.JSDialogBuilder = L.Control.extend({
 				label.textContent = builder._cleanText(data.text);
 				button.setAttribute('alt', label.textContent);
 				if (buttonImage !== false) {
-					buttonImage.alt = label.textContent;
+					if(data.aria) {
+						buttonImage.alt = data.aria.label;
+					} else {
+						buttonImage.alt = label.textContent;
+					}
 				}
 				builder._stressAccessKey(label, button.accessKey);
 				controls['label'] = label;

--- a/browser/src/control/jsdialog/Widget.SidebarContainers.ts
+++ b/browser/src/control/jsdialog/Widget.SidebarContainers.ts
@@ -67,6 +67,14 @@ JSDialog.panel = function (
 			{
 				type: 'toolitem',
 				command: expanderData.command,
+				aria: {
+					label: expanderData.children[0].text
+						? _('More options for {name}').replace(
+								'{name}',
+								expanderData.children[0].text,
+							)
+						: '',
+				},
 				icon: builder._createIconURL('morebutton'),
 			},
 			builder,


### PR DESCRIPTION
### Summary

Add aria labels to 'More option' button in sidebar

### Changes

- Add aria>label data to toolbutton struct when creating more option button for Panel
- Removed alt attribute from Tool Button since buttons don't support alt attribute
- Added condition to set alt for button image from aria>label, if present

### Commit Info

Change-Id: Ic608ee29891154e0f46523a1f5b1e5c249c54c6a

* Target version: master 

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

