### PR TITLE
Fix broken frozen columns mid-pinch-zoom

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -640,6 +640,8 @@ L.TileSectionManager = L.Class.extend({
 	 * @param paneBounds {{min: {x: number, y: number}, max: {x: number, y: number}}} The edges of the current pane
 	 * Traditionally this is the map border at the start of the pinch
 	 *
+	 * @param freezePane {{freezeX: boolean, freezeY: boolean}} Whether the pane is frozen in the x or y directions
+	 *
 	 * @param splitPos {{x: number, y: number}} The inset in core-pixels into the document caused by any splits (e.g. a frozen row at the start of the document)
 	 *
 	 * @param scale {number} The scale, relative to the initial size, of the document currently
@@ -651,7 +653,7 @@ L.TileSectionManager = L.Class.extend({
 	 * Center is included iff findFreePaneCenter is true
 	 * (probably this should be encoded into the type, e.g. with an overload when this is converted to TypeScript)
 	 **/
-	_getZoomDocPos: function (pinchCenter, pinchStartCenter, paneBounds, splitPos, scale, findFreePaneCenter) {
+	_getZoomDocPos: function (pinchCenter, pinchStartCenter, paneBounds, freezePane, splitPos, scale, findFreePaneCenter) {
 		let xMin = 0;
 		const hasXMargin = !this._layer.isCalc();
 		if (hasXMargin) {
@@ -688,6 +690,14 @@ L.TileSectionManager = L.Class.extend({
 			Math.max(documentTopLeft.y, pinchStartCenter.y + (centerOffset.y - paneSize.y * panePortion.y) / scale)
 		);
 
+		if (freezePane.freezeX) {
+			docTopLeft.x = paneBounds.min.x;
+		}
+
+		if (freezePane.freezeY) {
+			docTopLeft.y = paneBounds.min.y;
+		}
+
 		if (!findFreePaneCenter) {
 			return { topLeft: docTopLeft };
 		}
@@ -709,7 +719,15 @@ L.TileSectionManager = L.Class.extend({
 		var viewBounds = ctx.viewBounds;
 		var freePaneBounds = new L.Bounds(viewBounds.min.add(splitPos), viewBounds.max);
 
-		return this._getZoomDocPos(this._newCenter, this._layer._pinchStartCenter, freePaneBounds, splitPos, scale, true /* findFreePaneCenter */).center;
+		return this._getZoomDocPos(
+			this._newCenter,
+			this._layer._pinchStartCenter,
+			freePaneBounds,
+			{ freezeX: false, freezeY: false },
+			splitPos,
+			scale,
+			true /* findFreePaneCenter */
+		).center;
 	},
 
 	_zoomAnimation: function () {

--- a/browser/src/layer/tile/TilesSection.ts
+++ b/browser/src/layer/tile/TilesSection.ts
@@ -761,34 +761,56 @@ export class TilesSection extends CanvasSectionObject {
 
 		var paneBoundsList = ctx.paneBoundsList;
 
+		let maxXBound = 0;
+		let maxYBound = 0;
+
+		for (const paneBounds of paneBoundsList) {
+			maxXBound = Math.max(maxXBound, paneBounds.min.x);
+			maxYBound = Math.max(maxYBound, paneBounds.min.y);
+		}
+
 		for (var k = 0; k < paneBoundsList.length ; ++k) {
 			var paneBounds = paneBoundsList[k];
 			var paneSize = paneBounds.getSize();
 
-			// Calculate top-left in doc core-pixels for the frame.
-			var docPos = tsManager._getZoomDocPos(tsManager._newCenter, tsManager._layer._pinchStartCenter, paneBounds, splitPos, scale, false /* findFreePaneCenter? */);
-
 			var destPos = new L.Point(0, 0);
 			var docAreaSize = paneSize.divideBy(scale);
-			if (paneBoundsList.length > 1) {
-				if (paneBounds.min.x) {
-					// Pane is free to move in X direction.
-					destPos.x = splitPos.x;
-					paneSize.x -= splitPos.x;
-				} else {
-					// Pane is fixed in X direction.
-					docAreaSize.x = paneSize.x;
-				}
 
-				if (paneBounds.min.y) {
-					// Pane is free to move in Y direction.
-					destPos.y = splitPos.y;
-					paneSize.y -= splitPos.y;
-				} else {
-					// Pane is fixed in Y direction.
-					docAreaSize.y = paneSize.y;
-				}
+			let freezeX: boolean;
+			let freezeY: boolean;
+
+			if (paneBounds.min.x === 0 && maxXBound !== 0) {
+				// There is another pane in the X direction and we are at 0, so we are fixed in X
+				docAreaSize.x = paneSize.x;
+				freezeX = true;
+			} else {
+				// Pane is free to move in X direction.
+				destPos.x = splitPos.x;
+				paneSize.x -= splitPos.x;
+				freezeX = false;
 			}
+
+			if (paneBounds.min.y === 0 && maxYBound !== 0) {
+				// There is another pane in the Y direction and we are at 0, so we are fixed in Y
+				docAreaSize.y = paneSize.y;
+				freezeY = true;
+			} else {
+				// Pane is free to move in Y direction.
+				destPos.y = splitPos.y;
+				paneSize.y -= splitPos.y;
+				freezeY = false;
+			}
+
+			// Calculate top-left in doc core-pixels for the frame.
+			var docPos = tsManager._getZoomDocPos(
+				tsManager._newCenter,
+				tsManager._layer._pinchStartCenter,
+				paneBounds,
+				{ freezeX, freezeY },
+				splitPos,
+				scale,
+				false /* findFreePaneCenter? */
+			);
 
 			var docRange = new L.Bounds(docPos.topLeft, docPos.topLeft.add(docAreaSize));
 			if (tsManager._calcGridSection) {

--- a/browser/src/layer/vector/CPath.ts
+++ b/browser/src/layer/vector/CPath.ts
@@ -185,10 +185,18 @@ abstract class CPath extends CEventsHandler {
 			splitPanesContext.getPxBoundList() :
 			[viewBounds];
 
+		let maxXBound = 0;
+		let maxYBound = 0;
+
+		for (const paneBounds of paneBoundsList) {
+			maxXBound = Math.max(maxXBound, paneBounds.min.x);
+			maxYBound = Math.max(maxYBound, paneBounds.min.y);
+		}
+
 		for (var i = 0; i < paneBoundsList.length; ++i) {
 			var panePaintArea = paintArea ? paintArea.clone() : paneBoundsList[i].clone();
+			var paneArea = paneBoundsList[i];
 			if (paintArea) {
-				var paneArea = paneBoundsList[i];
 
 				if (!paneArea.intersects(panePaintArea))
 					continue;
@@ -200,13 +208,27 @@ abstract class CPath extends CEventsHandler {
 				panePaintArea.max.y = Math.min(panePaintArea.max.y, paneArea.max.y);
 			}
 
-			this.updatePath(panePaintArea, paneBoundsList[i]);
+			let freezeX: boolean;
+			let freezeY: boolean;
+			if (paneArea.min.x === 0 && maxXBound !== 0) {
+				freezeX = true;
+			} else {
+				freezeX = false;
+			}
+
+			if (paneArea.min.y === 0 && maxYBound !== 0) {
+				freezeY = true;
+			} else {
+				freezeY = false;
+			}
+
+			this.updatePath(panePaintArea, paneArea, { freezeX, freezeY });
 		}
 
 		this.updateTestData();
 	}
 
-	updatePath(paintArea?: cool.Bounds, paneBounds?: cool.Bounds) {
+	updatePath(paintArea?: cool.Bounds, paneBounds?: cool.Bounds, freezePane?: { freezeX: boolean, freezeY: boolean }) {
 		// Overridden in implementations.
 	}
 

--- a/browser/src/layer/vector/CPolygon.ts
+++ b/browser/src/layer/vector/CPolygon.ts
@@ -40,7 +40,7 @@ class CPolygon extends CPolyline {
 		return new cool.Point(x / area, y / area);
 	}
 
-	updatePath(paintArea?: cool.Bounds, paneBounds?: cool.Bounds) {
+	updatePath(paintArea?: cool.Bounds, paneBounds?: cool.Bounds, freezePane?: { freezeX: boolean, freezeY: boolean }) {
 
 		this.parts = this.rings;
 
@@ -54,7 +54,7 @@ class CPolygon extends CPolyline {
 		}
 
 		this.simplifyPoints();
-		this.renderer.updatePoly(this, true /* closed? */, paintArea, paneBounds);
+		this.renderer.updatePoly(this, true /* closed? */, paintArea, paneBounds, freezePane);
 	}
 
 	anyRingBoundContains(corePxPoint: cool.Point): boolean {

--- a/browser/src/layer/vector/CPolyline.ts
+++ b/browser/src/layer/vector/CPolyline.ts
@@ -145,11 +145,11 @@ class CPolyline extends CPath {
 		return new cool.Bounds(this.bounds.getTopLeft().subtract(p), this.bounds.getBottomRight().add(p));
 	}
 
-	updatePath(paintArea?: cool.Bounds, paneBounds?: cool.Bounds) {
+	updatePath(paintArea?: cool.Bounds, paneBounds?: cool.Bounds, freezePane?: { freezeX: boolean, freezeY: boolean }) {
 		this.clipPoints(paintArea);
 		this.simplifyPoints();
 
-		this.renderer.updatePoly(this, false /* closed? */, paintArea, paneBounds);
+		this.renderer.updatePoly(this, false /* closed? */, paintArea, paneBounds, freezePane);
 	}
 
 	// clip polyline by renderer bounds so that we have less to render for performance


### PR DESCRIPTION
Previously the following issues were present when columns were frozen
- The frozen column was allowed to move, this was exacurbated when I made it easier to move in my 'calc: pinch-zoom:' commits, (3ba8257c6432a5a8f42901c9955c11f83a9a720a...b378a0fd778760dfb0f457c796769d14aaad11f6). This is now fixed
- A regression was also introduced in that range where the selected cell marker would become offset if you placed it in a frozen section then pinched to zoom. This is also fixed


Change-Id: I07f70a32e5cb68aeb759fd6cad626b2d4c0eed72


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

