### PR TITLE
Prevent opening multiple tooltips on drawing area widgets

### DIFF
--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -1710,7 +1710,11 @@ L.Control.UIManager = L.Control.extend({
 	enableTooltip: function(element) {
 		var elem = $(element);
 		if (window.mode.isDesktop()) {
-			elem.tooltip();
+			if (this._tooltip) {
+				$(".ui-tooltip").remove();
+				this._tooltip = undefined;
+			}
+			this._tooltip = elem.tooltip();
 			elem.on("mousedown", function() {
 				$('.ui-tooltip').fadeOut(function() {
 					$(this).remove();


### PR DESCRIPTION
We see multiple tooltip problem on drawing area widgets. Example case:
    Add basic shape into a writer document
    Right click on shape and open Position and Size dialog
    Select the Rotation tab
    Hold the rotation angle widget and drag around itself
When you inspect the "Rotation Angle" tooltip, count may be 600 We expect only 1.

So we prevent to show another tooltip if we have already one.


Change-Id: I2f548f8c7afce8095e83a6faa3722e164f990210


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

