### PR TITLE
Lat / Lng Removal

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -3877,7 +3877,7 @@ L.CanvasTileLayer = L.Layer.extend({
 
 	// Scrolls the view to selected position
 	scrollToPos: function(pos) {
-		if (pos.pX) // Turn into lat/lng if required.
+		if (pos.pX) // Turn into lat/lng if required (pos may also be a simplePoint.).
 			pos = this._twipsToLatLng({ x: pos.x, y: pos.y });
 
 		var center = this._map.project(pos);
@@ -4664,7 +4664,6 @@ L.CanvasTileLayer = L.Layer.extend({
 		this._updateCursorAndOverlay();
 	},
 
-	// TODO: unused variables: horizontalDirection, verticalDirection
 	// TODO: used only in calc: move to CalcTileLayer
 	_onUpdateCellCursor: function (onPgUpDn, scrollToCursor, sameAddress) {
 		this._onUpdateCellResizeMarkers();
@@ -6472,26 +6471,6 @@ L.CanvasTileLayer = L.Layer.extend({
 
 	_keyToTileCoords: function (key) {
 		return L.TileCoordData.parseKey(key);
-	},
-
-	_keyToBounds: function (key) {
-		return this._tileCoordsToBounds(this._keyToTileCoords(key));
-	},
-
-	_tileCoordsToBounds: function (coords) {
-
-		var map = this._map;
-		var tileSize = this._getTileSize();
-
-		var nwPoint = new L.Point(coords.x, coords.y);
-		var sePoint = nwPoint.add([tileSize, tileSize]);
-		nwPoint = this._corePixelsToCss(nwPoint);
-		sePoint = this._corePixelsToCss(sePoint);
-
-		var nw = map.unproject(nwPoint, coords.z);
-		var se = map.unproject(sePoint, coords.z);
-
-		return new L.LatLngBounds(nw, se);
 	},
 
 	// Fix for cool#5876 allow immediate reuse of canvas context memory

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -893,9 +893,8 @@ L.CanvasTileLayer = L.Layer.extend({
 		this._graphicSelection = new L.LatLngBounds(new L.LatLng(0, 0), new L.LatLng(0, 0));
 		// Rotation angle of selected graphic object
 		this._graphicSelectionAngle = 0;
-		// Rectangle for cell cursor
-		this._cellCursor =  L.LatLngBounds.createDefault();
-		this._prevCellCursor = L.LatLngBounds.createDefault();
+		app.calc.cellCursorVisible = false;
+		this._prevCellCursor = null;
 		this._prevCellCursorAddress = null;
 		this._cellCursorOnPgUp = null;
 		this._cellCursorOnPgDn = null;
@@ -2489,18 +2488,10 @@ L.CanvasTileLayer = L.Layer.extend({
 	_onCellCursorMsg: function (textMsg) {
 		var autofillMarkerSection = app.sectionContainer.getSectionWithName(L.CSections.AutoFillMarker.name);
 
-		if (!this._cellCursor) {
-			this._cellCursor = L.LatLngBounds.createDefault();
-		}
-		if (!this._prevCellCursor) {
-			this._prevCellCursor = L.LatLngBounds.createDefault();
-		}
-
 		var oldCursorAddress = app.calc.cellAddress.clone();
 
 		if (textMsg.match('EMPTY')) {
 			app.calc.cellCursorVisible = false;
-			this._cellCursor = L.LatLngBounds.createDefault();
 			if (autofillMarkerSection)
 				autofillMarkerSection.calculatePositionViaCellCursor(null);
 			if (this._map._clip)
@@ -2514,10 +2505,6 @@ L.CanvasTileLayer = L.Layer.extend({
 			var bottomRightTwips = topLeftTwips.add(offset);
 			let _cellCursorTwips = this._convertToTileTwipsSheetArea(new L.Bounds(topLeftTwips, bottomRightTwips));
 
-			this._cellCursor = new L.LatLngBounds(
-				this._twipsToLatLng(_cellCursorTwips.getTopLeft(), this._map.getZoom()),
-				this._twipsToLatLng(_cellCursorTwips.getBottomRight(), this._map.getZoom()));
-
 			app.calc.cellAddress = new app.definitions.simplePoint(parseInt(strTwips[4]), parseInt(strTwips[5]));
 			let tempRectangle = _cellCursorTwips.toRectangle();
 			app.calc.cellCursorRectangle = new app.definitions.simpleRectangle(tempRectangle[0], tempRectangle[1], tempRectangle[2], tempRectangle[3]);
@@ -2528,35 +2515,20 @@ L.CanvasTileLayer = L.Layer.extend({
 				autofillMarkerSection.calculatePositionViaCellCursor([app.calc.cellCursorRectangle.pX2, app.calc.cellCursorRectangle.pY2]);
 		}
 
-		var horizontalDirection = 0;
-		var verticalDirection = 0;
-		var sign = function(x) {
-			return x > 0 ? 1 : x < 0 ? -1 : x;
-		};
-		if (!this._isEmptyRectangle(this._prevCellCursor) && !this._isEmptyRectangle(this._cellCursor)) {
-			horizontalDirection = sign(this._cellCursor.getWest() - this._prevCellCursor.getWest());
-			verticalDirection = sign(this._cellCursor.getNorth() - this._prevCellCursor.getNorth());
-		}
-		else if (!this._isEmptyRectangle(this._cellCursor)) {
-			// This is needed for jumping view to cursor position on tab switch
-			horizontalDirection = sign(this._cellCursor.getWest());
-			verticalDirection = sign(this._cellCursor.getNorth());
-		}
-
 		var onPgUpDn = false;
-		if (!this._isEmptyRectangle(this._cellCursor) && !this._prevCellCursor.equals(this._cellCursor)) {
-			if ((this._cellCursorOnPgUp && this._cellCursorOnPgUp.equals(this._prevCellCursor)) ||
-				(this._cellCursorOnPgDn && this._cellCursorOnPgDn.equals(this._prevCellCursor))) {
+		if (app.calc.cellCursorVisible && this._prevCellCursor && !this._prevCellCursor.equals(app.calc.cellCursorRectangle.toArray())) {
+			if ((this._cellCursorOnPgUp && this._cellCursorOnPgUp.equals(this._prevCellCursor.toArray())) ||
+				(this._cellCursorOnPgDn && this._cellCursorOnPgDn.equals(this._prevCellCursor.toArray()))) {
 				onPgUpDn = true;
 			}
-			this._prevCellCursor = new L.LatLngBounds(this._cellCursor.getSouthWest(), this._cellCursor.getNorthEast());
+			this._prevCellCursor = app.calc.cellCursorRectangle.clone();
 		}
 
 		var sameAddress = oldCursorAddress.equals(app.calc.cellAddress.toArray());
 
 		var scrollToCursor = this._sheetSwitch.tryRestore(sameAddress, this._selectedPart);
 
-		this._onUpdateCellCursor(horizontalDirection, verticalDirection, onPgUpDn, scrollToCursor, sameAddress);
+		this._onUpdateCellCursor(onPgUpDn, scrollToCursor, sameAddress);
 
 		// Remove input help if there is any:
 		this._removeInputHelpMarker();
@@ -3471,26 +3443,44 @@ L.CanvasTileLayer = L.Layer.extend({
 			return false;
 	},
 
+	_latLngBoundsToSimpleRectangle: function(latLngBounds) {
+		let topLeft = this._latLngToTwips(latLngBounds.getNorthWest());
+		let bottomRight = this._latLngToTwips(latLngBounds.getSouthEast());
+
+		return new app.definitions.simpleRectangle(topLeft.x, topLeft.y, bottomRight.x - topLeft.x, bottomRight.y - topLeft.y);
+	},
+
+	_simpleRectangleToLatLngBounds: function(simpleRectangle) {
+		return new L.LatLngBounds(
+			this._twipsToLatLng({ x: simpleRectangle.x1, y: simpleRectangle.y1 }, this._map.getZoom()),
+			this._twipsToLatLng({ x: simpleRectangle.x2, y: simpleRectangle.y2 }, this._map.getZoom()));
+	},
+
 	_updateScrollOnCellSelection: function (oldSelection, newSelection) {
 		if (this.isCalc() && oldSelection) {
-			var mapBounds = this._map.getBounds();
-			if (!mapBounds.contains(newSelection) && !newSelection.equals(oldSelection)) {
-				var spacingX = Math.abs(this._cellCursor.getEast() - this._cellCursor.getWest()) / 4.0;
-				var spacingY = Math.abs((this._cellCursor.getSouth() - this._cellCursor.getNorth())) / 2.0;
+			if (oldSelection._northEast) // Is object's type latLngBounds
+				oldSelection = this._latLngBoundsToSimpleRectangle(oldSelection);
+
+			if (newSelection._northEast) // Is object's type latLngBounds
+				newSelection = this._latLngBoundsToSimpleRectangle(newSelection);
+
+			if (!app.file.viewedRectangle.containsRectangle(newSelection.toArray()) && !newSelection.equals(oldSelection.toArray())) {
+				var spacingX = Math.abs(app.calc.cellCursorRectangle.pWidth) / 4.0;
+				var spacingY = Math.abs(app.calc.cellCursorRectangle.pHeight) / 2.0;
 
 				var scrollX = 0, scrollY = 0;
-				if (newSelection.getEast() > mapBounds.getEast() && newSelection.getEast() > oldSelection.getEast())
-					scrollX = newSelection.getEast() - mapBounds.getEast() + spacingX;
-				else if (newSelection.getWest() < mapBounds.getWest() && newSelection.getWest() < oldSelection.getWest())
-					scrollX = newSelection.getWest() - mapBounds.getWest() - spacingX;
-				if (newSelection.getNorth() > mapBounds.getNorth() && newSelection.getNorth() > oldSelection.getNorth())
-					scrollY = newSelection.getNorth() - mapBounds.getNorth() + spacingY;
-				else if (newSelection.getSouth() < mapBounds.getSouth() && newSelection.getSouth() < oldSelection.getSouth())
-					scrollY = newSelection.getSouth() - mapBounds.getSouth() - spacingY;
+				if (newSelection.pX2 > app.file.viewedRectangle.pX2 && newSelection.pX2 > oldSelection.pX2)
+					scrollX = newSelection.pX2 - app.file.viewedRectangle.pX2 + spacingX;
+				else if (newSelection.pX1 < app.file.viewedRectangle.pX1 && newSelection.pX1 < oldSelection.pX1)
+					scrollX = newSelection.pX1 - app.file.viewedRectangle.pX1 - spacingX;
+				if (newSelection.pY1 > app.file.viewedRectangle.pY1 && newSelection.pY1 > oldSelection.pY1)
+					scrollY = newSelection.pY1 - app.file.viewedRectangle.pY1 + spacingY;
+				else if (newSelection.pY2 < app.file.viewedRectangle.pY2 && newSelection.pY2 < oldSelection.pY2)
+					scrollY = newSelection.pY2 - app.file.viewedRectangle.pY2 - spacingY;
 				if (scrollX !== 0 || scrollY !== 0) {
-					var newCenter = mapBounds.getCenter();
-					newCenter.lng += scrollX;
-					newCenter.lat += scrollY;
+					var newCenter = new app.definitions.simplePoint(app.file.viewedRectangle.center[0], app.file.viewedRectangle.center[1]);
+					newCenter.pX += scrollX;
+					newCenter.pY += scrollY;
 					if (!this._map.wholeColumnSelected && !this._map.wholeRowSelected) {
 						var address = document.getElementById('addressInput').value;
 						if (!this._isWholeColumnSelected(address) && !this._isWholeRowSelected(address))
@@ -3568,9 +3558,6 @@ L.CanvasTileLayer = L.Layer.extend({
 			if (autofillMarkerSection)
 				autofillMarkerSection.calculatePositionViaCellSelection([cellSelectionAreaPixels.getX2(), cellSelectionAreaPixels.getY2()]);
 
-			if (this._cellCursor === null) {
-				this._cellCursor = L.LatLngBounds.createDefault();
-			}
 			this._updateScrollOnCellSelection(oldSelection, this._cellSelectionArea);
 		} else {
 			this._cellSelectionArea = null;
@@ -3688,7 +3675,6 @@ L.CanvasTileLayer = L.Layer.extend({
 		// hide the graphic selection
 		this._graphicSelection = new L.LatLngBounds(new L.LatLng(0, 0), new L.LatLng(0, 0));
 		this._onUpdateGraphicSelection();
-		this._cellCursor = null;
 		app.calc.cellCursorVisible = false;
 		this._prevCellCursor = null;
 		this._onUpdateCellCursor();
@@ -3791,13 +3777,13 @@ L.CanvasTileLayer = L.Layer.extend({
 				if (this._cellCursorOnPgUp) {
 					return;
 				}
-				this._cellCursorOnPgUp = new L.LatLngBounds(this._prevCellCursor.getSouthWest(), this._prevCellCursor.getNorthEast());
+				this._cellCursorOnPgUp = this._prevCellCursor.clone();
 			}
 			else if (unoKeyCode === UNOKey.PAGEDOWN) {
 				if (this._cellCursorOnPgDn) {
 					return;
 				}
-				this._cellCursorOnPgDn = new L.LatLngBounds(this._prevCellCursor.getSouthWest(), this._prevCellCursor.getNorthEast());
+				this._cellCursorOnPgDn = this._prevCellCursor.clone();
 			}
 			else if (unoKeyCode === UNOKey.SPACE + UNOModifier.CTRL) { // Select whole column.
 				this._map.wholeColumnSelected = true;
@@ -3891,6 +3877,9 @@ L.CanvasTileLayer = L.Layer.extend({
 
 	// Scrolls the view to selected position
 	scrollToPos: function(pos) {
+		if (pos.pX) // Turn into lat/lng if required.
+			pos = this._twipsToLatLng({ x: pos.x, y: pos.y });
+
 		var center = this._map.project(pos);
 		center = center.subtract(this._map.getSize().divideBy(2));
 		center.x = Math.round(center.x < 0 ? 0 : center.x);
@@ -4677,9 +4666,9 @@ L.CanvasTileLayer = L.Layer.extend({
 
 	// TODO: unused variables: horizontalDirection, verticalDirection
 	// TODO: used only in calc: move to CalcTileLayer
-	_onUpdateCellCursor: function (horizontalDirection, verticalDirection, onPgUpDn, scrollToCursor, sameAddress) {
+	_onUpdateCellCursor: function (onPgUpDn, scrollToCursor, sameAddress) {
 		this._onUpdateCellResizeMarkers();
-		if (this._cellCursor && !this._isEmptyRectangle(this._cellCursor)) {
+		if (app.calc.cellCursorVisible) {
 			var mapBounds = this._map.getBounds();
 			if (scrollToCursor && (!this._prevCellCursorAddress || !app.calc.cellAddress.equals(this._prevCellCursorAddress.toArray())) &&
 			    !this._map.calcInputBarHasFocus()) {
@@ -4775,7 +4764,8 @@ L.CanvasTileLayer = L.Layer.extend({
 		});
 
 		this._removeInputHelpMarker();
-		var inputHelpMarker = L.marker(this._cellCursor.getNorthEast(), { icon: icon });
+		var pos = this._twipsToLatLng({ x: app.calc.cellCursorRectangle.x2, y: app.calc.cellCursorRectangle.y1 });
+		var inputHelpMarker = L.marker(pos, { icon: icon });
 		inputHelpMarker.addTo(this._map);
 		document.getElementById('input-help-title').innerText = message.title;
 		document.getElementById('input-help-content').innerText = message.content;
@@ -4784,7 +4774,8 @@ L.CanvasTileLayer = L.Layer.extend({
 
 	_addDropDownMarker: function () {
 		if (this._validatedCellAddress && app.calc.cellCursorVisible && this._validatedCellAddress.equals(app.calc.cellAddress.toArray())) {
-			var pos = this._cellCursor.getNorthEast();
+			var pos = this._twipsToLatLng({ x: app.calc.cellCursorRectangle.x2, y: app.calc.cellCursorRectangle.y1 });
+
 			var dropDownMarker = this._getDropDownMarker(16);
 			dropDownMarker.setLatLng(pos);
 			this._map.addLayer(dropDownMarker);
@@ -4809,17 +4800,17 @@ L.CanvasTileLayer = L.Layer.extend({
 	},
 
 	_onUpdateCellResizeMarkers: function () {
-		var selectionOnDesktop = window.mode.isDesktop()
-									&& (this._cellSelectionArea
-									|| (this._cellCursor && !this._isEmptyRectangle(this._cellCursor)));
+		var selectionOnDesktop = window.mode.isDesktop() && (this._cellSelectionArea || app.calc.cellCursorVisible);
 
 		if (!selectionOnDesktop &&
-			(!this._cellCSelections.empty() || (this._cellCursor && !this._isEmptyRectangle(this._cellCursor)))) {
-			if (this._isEmptyRectangle(this._cellSelectionArea) && this._isEmptyRectangle(this._cellCursor)) {
+			(!this._cellCSelections.empty() || app.calc.cellCursorVisible)) {
+			if (this._isEmptyRectangle(this._cellSelectionArea) && !app.calc.cellCursorVisible) {
 				return;
 			}
 
-			var cellRectangle = this._cellSelectionArea ? this._cellSelectionArea : this._cellCursor;
+			let latLngCursor = this._simpleRectangleToLatLngBounds(app.calc.cellCursorRectangle.clone());
+
+			var cellRectangle = this._cellSelectionArea ? this._cellSelectionArea : latLngCursor;
 
 			if (!this._cellResizeMarkerStart.isDragged) {
 				this._map.addLayer(this._cellResizeMarkerStart);


### PR DESCRIPTION
Remove _cellCursor and use app.calc.cellCursorRectangle -> SimpleRectangle.

Turn _prevCellCursor,_cellCursorOnPgUp, _cellCursorOnPgDn into SimpleRectangle.

Remove horizontalDirection and verticalDirection calculations. They are not used. Also remove them from _onUpdateCellCursor function.

Use app.calc.cellCursorVisible instead of empty rectangle checks. Set variables to null to re-init them instead of assigning them empty rectangles.

Push lat/lng usage through markers (leaflet things).


Change-Id: I4b258a72f1ac3c94ccf25a07d0e7dab232165b90


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

