### PR TITLE
bgsave: have a single source for InputProcessing enable & disable.

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -711,7 +711,6 @@ Document::Document(const std::shared_ptr<lok::Office>& loKit,
       _editorChangeWarning(false),
       _lastMemTrimTime(std::chrono::steady_clock::now()),
       _mobileAppDocId(mobileAppDocId),
-      _inputProcessingEnabled(true),
       _duringLoad(0)
 {
     LOG_INF("Document ctor for [" << _docKey <<
@@ -2090,13 +2089,12 @@ void Document::checkIdle()
     ProcessToIdleDeadline = std::chrono::steady_clock::now() - std::chrono::milliseconds(10);
 }
 
-void Document::enableProcessInput(bool enable)
+bool Document::processInputEnabled() const
 {
-    LOG_TRC("Document - input processing now: " <<
-            (enable ? "enabled" : "disabled") <<
-            " was " <<
-            (_inputProcessingEnabled ? "enabled" : "disabled"));
-    _inputProcessingEnabled = enable;
+    bool enabled = !_websocketHandler || _websocketHandler->processInputEnabled();
+    if (!enabled)
+        LOG_TRC("Document - not processing input");
+    return enabled;
 }
 
 void Document::drainQueue()
@@ -2285,7 +2283,7 @@ void Document::dumpState(std::ostream& oss)
         << "\n\teditorId: " << _editorId
         << "\n\teditorChangeWarning: " << _editorChangeWarning
         << "\n\tmobileAppDocId: " << _mobileAppDocId
-        << "\n\tinputProcessingEnabled: " << _inputProcessingEnabled
+        << "\n\tinputProcessingEnabled: " << processInputEnabled()
         << "\n\tduringLoad: " << _duringLoad
         << "\n";
 

--- a/kit/Kit.hpp
+++ b/kit/Kit.hpp
@@ -374,8 +374,7 @@ private:
     bool isTileRequestInsideVisibleArea(const TileCombined& tileCombined);
 
 public:
-    void enableProcessInput(bool enable = true);
-    bool processInputEnabled() const { return _inputProcessingEnabled; }
+    bool processInputEnabled() const;
     bool hasQueueItems() const { return _tileQueue && !_tileQueue->isEmpty(); }
 
     // poll is idle, are we ?
@@ -453,7 +452,6 @@ private:
 #endif
 
     const unsigned _mobileAppDocId;
-    bool _inputProcessingEnabled;
     int _duringLoad;
 };
 

--- a/kit/KitWebSocket.cpp
+++ b/kit/KitWebSocket.cpp
@@ -157,9 +157,11 @@ void KitWebSocketHandler::handleMessage(const std::vector<char>& data)
 
 void KitWebSocketHandler::enableProcessInput(bool enable)
 {
+    LOG_TRC("Kit socket - input processing now: " <<
+            (enable ? "enabled" : "disabled") <<
+            " was " <<
+            (WebSocketHandler::processInputEnabled() ? "enabled" : "disabled"));
     WebSocketHandler::enableProcessInput(enable);
-    if (_document)
-        _document->enableProcessInput(enable);
 
     // Wake up poll to process data from socket input buffer
     if (enable && _ksPoll)

--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -691,6 +691,15 @@ public:
         return sendFrame(socket, data, len, WSFrameMask::Fin | static_cast<unsigned char>(code), flush);
     }
 
+    virtual bool processInputEnabled() const override
+    {
+        std::shared_ptr<StreamSocket> socket = _socket.lock();
+        if (socket)
+            return socket->processInputEnabled();
+
+        return true;
+    }
+
 protected:
 
 #if !MOBILEAPP
@@ -1037,15 +1046,6 @@ protected:
         std::shared_ptr<StreamSocket> socket = _socket.lock();
         if (socket)
             socket->enableProcessInput(enable);
-    }
-
-    virtual bool processInputEnabled() const override
-    {
-        std::shared_ptr<StreamSocket> socket = _socket.lock();
-        if (socket)
-            return socket->processInputEnabled();
-
-        return false;
     }
 
     virtual void gotPing(WSOpCode /* code */, int /* pingTimeUs */)


### PR DESCRIPTION
Somehow this state can get confused in a bgsave process:

   Kit Document:
         ...
         inputProcessingEnabled: false
         ...
   SocketPoll:
     Poll [kit] with 1 socket - wakeup rfd: 39 wfd: 45
             fd        events        rbuffered        wbuffered        rtotal        wtotal
             52        0x1        process             0             0         r:    825

'process' should read 'ignore' for disabled input.


Change-Id: I787eebe6fda3ae1b527d7605b8813fa764e81890


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

