### PR TITLE
bgsave: don't try to save twice in the same background process.

### DIFF
--- a/common/MessageQueue.hpp
+++ b/common/MessageQueue.hpp
@@ -77,7 +77,7 @@ public:
         return _queue.empty();
     }
 
-    bool size()
+    size_t size()
     {
         return _queue.size();
     }

--- a/common/MessageQueue.hpp
+++ b/common/MessageQueue.hpp
@@ -77,7 +77,7 @@ public:
         return _queue.empty();
     }
 
-    size_t size()
+    size_t size() const
     {
         return _queue.size();
     }

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -879,8 +879,9 @@ bool ChildSession::saveDocumentBackground(const StringVector &tokens)
         sendTextFrame("asyncsave end");
 
         LOG_TRC("Finished synchronous background saving ...");
-        // Now we wait for an async UNO_COMMAND_RESULT on .uno:Save
-    }, getViewId())) // FIXME: shared_from_this surely ?
+        // Next: we wait for an async UNO_COMMAND_RESULT on .uno:Save
+        // cf. Document::handleSaveMessage.
+    }, getViewId()))
         return false; // fork failed
 
     LOG_TRC("saveDocumentBackground returns succesful start.");

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -573,11 +573,10 @@ bool ChildSession::_handleInput(const char *buffer, int length)
 
             bool saving = false;
             if (background)
-                saving = !saveDocumentBackground(unoSave);
+                saving = saveDocumentBackground(unoSave);
 
             if (!saving)
             { // fallback to foreground save
-
                 // Disable processing of other messages while saving document
                 InputProcessingManager processInput(getProtocol(), false);
                 return unoCommand(unoSave);

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1339,6 +1339,9 @@ void Document::handleSaveMessage(const std::string &)
 
             // We don't want to wait around for the parent's websocket
             socket->shutdownAfterWriting();
+
+            // This means we don't get to send statechanged: .uno:ModifiedStatus
+            // which is fine - we want to leave that to the Kit process.
         }
         else
             LOG_TRC("Shutting down already shutdown bgsv child's socket to parent kit post save");
@@ -2087,6 +2090,8 @@ bool Document::isTileRequestInsideVisibleArea(const TileCombined& tileCombined)
 // poll is idle, are we ?
 void Document::checkIdle()
 {
+    // FIXME: can have Idle CallbackFlushHandler work in the core.
+
     if (!processInputEnabled() || hasQueueItems())
     {
         LOG_TRC("Nearly idle - but have more queued items to process");

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1360,6 +1360,13 @@ bool Document::forkToSave(const std::function<void()> &childSave, int viewId)
 #if MOBILEAPP
     return false;
 #else // !MOBILEAPP
+    if (_isBgSaveProcess)
+    {
+        LOG_ERR("Serious error bgsv process trying to fork again");
+        assert(false);
+        return false;
+    }
+
     if (!joinThreads())
     {
         LOG_WRN("Failed to join threads before async save");
@@ -1372,6 +1379,9 @@ bool Document::forkToSave(const std::function<void()> &childSave, int viewId)
         LOG_WRN("Failed to ensure we have just one, we have: " << threads);
         return false;
     }
+
+    // Oddly we have seen this broken in the past.
+    assert(processInputEnabled());
 
 #if 0
     // TODO: compare FD count in a normal process with how


### PR DESCRIPTION
Get the polarity of the check on whether we succeeded to spawn a background save process right, so we don't spawn two saves concurrently, and block input processing in the wrong place.

Also a few obvious sillies fixed, and some more assertions for good measure; was not good:

[ kitbgsv_001_001 ] TRC  ToMaster-002: Finished synchronous background saving ...| kit/ChildSession.cpp:882
[ kitbgsv_001_001 ] TRC  ToMaster-002: saveDocumentBackground returns succesful start.| kit/ChildSession.cpp:887
[ kitbgsv_001_001 ] TRC  Document - input processing now: disabled was enabled| kit/Kit.cpp:2095
[ kitbgsv_001_001 ] TRC  ToMaster-002: uno command .uno:Save {... notify: true| kit/ChildSession.cpp:1944


Change-Id: Ie06a74a538bdd5038ca9c94b422f27cff9e4a82e


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

