### PR TITLE
backport 23.05 equivalent of honoring window.uiDefaults.darkTheme

### DIFF
--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -280,6 +280,9 @@ window.app = {
 					if (docTheme) {
 						themes.push(global.L.Browser.docs[theme] + ':' +
 							    (docTheme === 'true' ? 'Dark' : 'Light'));
+					} else if (window.uiDefaults) {
+						themes.push(global.L.Browser.docs[theme] + ':' +
+							    (window.uiDefaults.darkTheme ? 'Dark' : 'Light'));
 					}
 				}
 			}


### PR DESCRIPTION
if it exists as the default dark/light theme to use if there is no explicit user setting for it

Related to: https://github.com/CollaboraOnline/online/issues/8734

similar issue as in 24.04 arises from similar 23.05 change of:

commit 100def4c80d6e467c32e2a3300e695905c358838
Date:   Tue Feb 20 16:23:37 2024 -0400

    add parameter "theme" to load a document


Change-Id: I49596768ece16ceee1a74740877550122722d51a


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

