### PR TITLE
annotation: do not scroll to root comment while editing

### DIFF
--- a/browser/src/layer/tile/CommentListSection.ts
+++ b/browser/src/layer/tile/CommentListSection.ts
@@ -738,7 +738,7 @@ export class CommentSection extends CanvasSectionObject {
 				const annotationHeight = this.cssToCorePixels(rect.height);
 				const annotationBottom = position[1] + annotationHeight;
 
-				if (!this.isInViewPort([annotationTop, annotationBottom]) && position[1] !== 0) {
+				if (!this.isInViewPort([annotationTop, annotationBottom]) && position[1] !== 0 && !annotation.isEdit()) {
 					console.debug('Annotation outside view - scroll');
 					const scrollSection = app.sectionContainer.getSectionWithName(L.CSections.Scroll.name);
 					const screenTopBottom = this.getScreenTopBottom();


### PR DESCRIPTION
problem:
if comment thread is very long and some action is
performed to the last comments which puts root comment out of view, entering modify or reply mode will make scroll to root comment. This makes editing comment/reply go out of view


Change-Id: I99f8df6886a69242b3db92674516678a61d2904f


* Target version: master 


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

