### PR TITLE
compile check of -D_FORTIFY_SOURCE=2 not failing with CFLAGS=-O0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -958,7 +958,7 @@ if test "$enable_hardening_flags" = no -o "$host_os" = "emscripten" -o "x$with_s
     save_CFLAGS=$CFLAGS
     CFLAGS="$CFLAGS -Werror -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=2"
     AC_LINK_IFELSE(
-        [AC_LANG_PROGRAM(, [[return 0;]])],
+        [AC_LANG_PROGRAM(, [[#include <string.h> return 0;]])],
         [AC_MSG_RESULT([yes]); HARDENING_CFLAGS="$HARDENING_CFLAGS -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=2"],
         [AC_MSG_RESULT([no])])
     CFLAGS=$save_CFLAGS


### PR DESCRIPTION
need to include some typical headers to get it to issue a failure diagnostic


Change-Id: I37d6e0f342698507952a8006b88d56e55060270e


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

