### PR TITLE
cool#8806 clipboard: don't assume that navigator.clipboard is always defined

### DIFF
--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -101,6 +101,11 @@ window.app = {
 	    ie = 'ActiveXObject' in global,
 
 	    cypressTest = ua.indexOf('cypress') !== -1,
+	    // Firefox has undefined navigator.clipboard.read and navigator.clipboard.write,
+	    // unsecure contexts (such as http + non-localhost) has the entire navigator.clipboard
+	    // undefined.
+	    hasNavigatorClipboardRead = navigator.clipboard && navigator.clipboard.read,
+	    hasNavigatorClipboardWrite = navigator.clipboard && navigator.clipboard.write,
 	    webkit    = ua.indexOf('webkit') !== -1,
 	    phantomjs = ua.indexOf('phantom') !== -1,
 	    android23 = ua.search('android [23]') !== -1,
@@ -250,6 +255,14 @@ window.app = {
 		// @property cypressTest: Boolean
 		// `true` when the browser run by cypress
 		cypressTest: cypressTest,
+
+		// @property hasNavigatorClipboardRead: Boolean
+		// `true` when permission-based clipboard paste is available.
+		hasNavigatorClipboardRead: hasNavigatorClipboardRead,
+
+		// @property hasNavigatorClipboardWrite: Boolean
+		// `true` when permission-based clipboard copy is available.
+		hasNavigatorClipboardWrite: hasNavigatorClipboardWrite,
 
 		// @property msPointer: Boolean
 		// `true` for browsers implementing the Microsoft touch events model (notably IE10).

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -982,7 +982,7 @@ L.Map.include({
 			text = this.hyperlinkUnderCursor.text;
 		} else if (this._clip && this._clip._selectionType == 'text') {
 			if (map['stateChangeHandler'].getItemValue('.uno:Copy') === 'enabled') {
-				if (navigator.clipboard.write) {
+				if (L.Browser.hasNavigatorClipboardWrite) {
 					// Async copy, trigger fetching the text selection.
 					app.socket.sendMessage('gettextselection mimetype=text/html,text/plain;charset=utf-8');
 				} else {

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -3270,7 +3270,7 @@ L.CanvasTileLayer = L.Layer.extend({
 			this._map.removeLayer(this._map._textInput._cursorHandler); // User selected a text, we remove the carret marker.
 			// Keep fetching the text selection during testing, for now: too many tests
 			// depend on this behavior currently.
-			if (navigator.clipboard.write && !(L.Browser.cypressTest && !this._map._clip._dummyClipboard.useAsyncWrite)) {
+			if (L.Browser.hasNavigatorClipboardWrite && !(L.Browser.cypressTest && !this._map._clip._dummyClipboard.useAsyncWrite)) {
 				this._map._clip.setTextSelectionType('text');
 			} else {
 				if (this._selectionContentRequest) {

--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -794,7 +794,7 @@ L.Clipboard = L.Class.extend({
 
 	// Executes the navigator.clipboard.write() call, if it's available.
 	_navigatorClipboardWrite: function() {
-		if (navigator.clipboard.write === undefined) {
+		if (!L.Browser.hasNavigatorClipboardWrite) {
 			return false;
 		}
 
@@ -860,7 +860,7 @@ L.Clipboard = L.Class.extend({
 
 	// Executes the navigator.clipboard.read() call, if it's available.
 	_navigatorClipboardRead: function(isSpecial) {
-		if (navigator.clipboard.read === undefined) {
+		if (!L.Browser.hasNavigatorClipboardRead) {
 			return false;
 		}
 


### PR DESCRIPTION
Trying to paste from the notebookbar in a setup which is not localhost
but uses http resulted in a JS exception:

> Clipboard.js:863 Uncaught TypeError: Cannot read properties of undefined (reading 'read')

We assumed that navigator.clipboard is always defined, but then its
'read' and 'write' properties may be undefined.

Fix the problem by abstracting this, and check for navigator.clipboard
as well in global.js.

Can be tested by disabling https in coolwsd.xml and changing localhost
to the real local IP in the make run URL.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I1dab14e311066fa640dbba65dfcc35526a6886d7
