### PR TITLE
Private/pedro/insert annotation more consistency writer impress

### DIFF
--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -696,6 +696,13 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'vertical': 'true'
 			},
 			{
+				'id': 'home-insert-annotation',
+				'type': 'bigtoolitem',
+				'text': _UNO('.uno:InsertAnnotation'),
+				'command': '.uno:InsertAnnotation',
+				'accessibility': { focusBack: false, combination: 'ZC', de: 'ZC' }
+			},
+			{
 				'type': 'container',
 				'children': [
 					{
@@ -948,6 +955,14 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 						'type': 'toolbox',
 						'children': [
 							{
+								'id': 'home-insert-table:InsertTableMenu',
+								'type': 'menubutton',
+								'noLabel': true,
+								'text': _UNO('.uno:InsertTable', 'presentation'),
+								'command': '.uno:InsertTable',
+								'accessibility': { focusBack: true, combination: 'IT', de: null }
+							},
+							{
 								'id': 'home-insert-graphic:InsertImageMenu',
 								'type': 'menubutton',
 								'noLabel': true,
@@ -980,14 +995,6 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 								'text': _UNO('.uno:InsertObjectChart'),
 								'command': '.uno:InsertObjectChart',
 								'accessibility': { focusBack: true, combination: 'IC', de: null }
-							},
-							{
-								'id': 'home-insert-table:InsertTableMenu',
-								'type': 'menubutton',
-								'noLabel': true,
-								'text': _UNO('.uno:InsertTable', 'presentation'),
-								'command': '.uno:InsertTable',
-								'accessibility': { focusBack: true, combination: 'IT', de: null }
 							}
 						]
 					}

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -1185,7 +1185,38 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				],
 				'vertical': 'true'
 			},
-			{
+			(this._map['wopi'].EnableRemoteLinkPicker) ? {
+				'type': 'container',
+				'children': [
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'id': 'insert-hyperlink-dialog',
+								'class': 'unoHyperlinkDialog',
+								'type': 'customtoolitem',
+								'text': _UNO('.uno:HyperlinkDialog'),
+								'command': 'hyperlinkdialog',
+								'accessibility': { focusBack: true, combination: 'IL', de: null }
+							}
+						]
+					},
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'id': 'insert-insert-remote-link',
+								'class': 'unoremotelink',
+								'type': 'customtoolitem',
+								'text': _('Smart Picker'),
+								'command': 'remotelink',
+								'accessibility': { focusBack: true, combination: 'RL', de: null }
+							}
+						]
+					}
+				],
+			'vertical': 'true'
+			} : {
 				'id': 'HyperlinkDialog',
 				'class': 'unoHyperlinkDialog',
 				'type': 'bigcustomtoolitem',
@@ -1193,14 +1224,13 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'command': 'hyperlinkdialog',
 				'accessibility': { focusBack: true, combination: 'IL', de: null }
 			},
-			(this._map['wopi'].EnableRemoteLinkPicker) ? {
-				'id': 'insert-insert-smart-picker',
-				'class': 'unoremotelink',
-				'type': 'bigcustomtoolitem',
-				'text': _('Smart Picker'),
-				'command': 'remotelink',
-				'accessibility': { focusBack: true, combination: 'RL', de: null }
-			} : {},
+			{
+				'id': 'insert-insert-annotation',
+				'type': 'bigtoolitem',
+				'text': _UNO('.uno:InsertAnnotation', 'text'),
+				'command': '.uno:InsertAnnotation',
+				'accessibility': { focusBack: false, combination: 'ZC', de: 'ZC' }
+			},
 			{
 				'type': 'container',
 				'children': [
@@ -1337,15 +1367,20 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'vertical': 'true'
 			},
 			{
-				'id': 'insert-header-and-footer',
-				'type': 'bigtoolitem',
-				'text': _UNO('.uno:HeaderAndFooter', 'presentation'),
-				'command': '.uno:HeaderAndFooter',
-				'accessibility': { focusBack: true, combination: 'HF', de: null }
-			},
-			{
 				'type': 'container',
 				'children': [
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'id': 'insert-header-and-footer',
+								'type': 'toolitem',
+								'text': _UNO('.uno:HeaderAndFooter', 'presentation'),
+								'command': '.uno:HeaderAndFooter',
+								'accessibility': { focusBack: true, combination: 'HF', de: null }
+							}
+						]
+					},
 					{
 						'type': 'toolbox',
 						'children': [
@@ -1356,18 +1391,6 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 								'text': _UNO('.uno:CharmapControl'),
 								'command': 'charmapcontrol',
 								'accessibility': { focusBack: true, combination: 'IM', de: null }
-							}
-						]
-					},
-					{
-						'type': 'toolbox',
-						'children': [
-							{
-								'id': 'insert-insert-annotation',
-								'type': 'toolitem',
-								'text': _UNO('.uno:InsertAnnotation', 'text'),
-								'command': '.uno:InsertAnnotation',
-								'accessibility': { focusBack: true, combination: 'L', de: null }
 							}
 						]
 					}

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -642,6 +642,13 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				'vertical': 'true'
 			},
 			{
+				'id': 'home-insert-annotation',
+				'type': 'bigtoolitem',
+				'text': _UNO('.uno:InsertAnnotation'),
+				'command': '.uno:InsertAnnotation',
+				'accessibility': { focusBack: false, combination: 'ZC', de: 'ZC' }
+			},
+			{
 				'type': 'container',
 				'children': [
 					{
@@ -782,12 +789,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 								'text': _UNO('.uno:InsertTable', 'text'),
 								'command': '.uno:InsertTable',
 								'accessibility': { focusBack: false,	combination: 'IT',	de:	null }
-							}
-						]
-					},
-					{
-						'type': 'toolbox',
-						'children': [
+							},
 							{
 								'id': 'home-insert-graphic:InsertImageMenu',
 								'type': 'menubutton',
@@ -795,7 +797,12 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 								'text': _UNO('.uno:InsertGraphic'),
 								'command': '.uno:InsertGraphic',
 								'accessibility': { focusBack: true, 	combination: 'IG',	de: null }
-							},
+							}
+						]
+					},
+					{
+						'type': 'toolbox',
+						'children': [
 							{
 								'id': 'home-insert-page-break',
 								'type': 'toolitem',
@@ -810,13 +817,6 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 								'text': _UNO('.uno:CharmapControl'),
 								'command': 'charmapcontrol',
 								'accessibility': { focusBack: false,	combination: 'IS',	de:	null }
-							},
-							{
-								'id': 'home-insert-annotation',
-								'type': 'toolitem',
-								'text': _UNO('.uno:InsertAnnotation'),
-								'command': '.uno:InsertAnnotation',
-								'accessibility': { focusBack: false, 	combination: 'ZC',	de: 'ZC' }
 							}
 						]
 					}

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -1034,7 +1034,8 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 								'class': 'unoremotelink',
 								'type': 'customtoolitem',
 								'text': _('Smart Picker'),
-								'command': 'remotelink'
+								'command': 'remotelink',
+								'accessibility': { focusBack: true, combination: 'RL', de: null }
 							}
 						]
 					}
@@ -1053,7 +1054,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				'type': 'bigtoolitem',
 				'text': _UNO('.uno:InsertAnnotation', 'text'),
 				'command': '.uno:InsertAnnotation',
-				'accessibility': { focusBack: false,	combination: 'L',	de:	'N' }
+				'accessibility': { focusBack: false, combination: 'ZC', de: 'ZC' }
 			},
 			{
 				'type': 'container',

--- a/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
@@ -227,6 +227,7 @@ describe(['tagdesktop'], 'Top toolbar tests.', function() {
 		cy.cGet('#toolbar-up .w2ui-scroll-right').click();
 		cy.cGet('#toolbar-up .w2ui-scroll-right').click();
 		cy.cGet('#toolbar-up .w2ui-scroll-right').click();
+		cy.cGet('#toolbar-up .w2ui-scroll-right').click();
 		cy.cGet('#Home-container .unoInsertTable button').click();
 		cy.cGet('.inserttable-grid > .row > .col').eq(3).click();
 		helper.typeIntoDocument('{ctrl}a');
@@ -320,6 +321,7 @@ describe(['tagdesktop'], 'Top toolbar tests.', function() {
 		cy.cGet('#copy-paste-container p i').should('exist');
 
 		//Undo
+		cy.cGet('#toolbar-up .w2ui-scroll-left').click();
 		cy.cGet('#Home-container .unoUndo').should('not.be.disabled').click();
 		helper.copy();
 		cy.wait(500); // wait for new clipboard


### PR DESCRIPTION
Overall idea: Facilitate user's spatial memory by making sure Insert comment is reachable at similar spots between writer and impress and between home and insert tab with no scrolling

Commits

-----

Writer, Impress Home tab: Promote insert annotation to bigtoolitem

- Promote to big button
  - Use the same from the previous position to make the whole tab more
  - compact by changing the insert image to a simple toolitem
- Change location in the home tab so it's easier to reach and it's
more consistent between writer and impress
- Use the same accesskey (accessibility, aka shortcut) between both apps


-----

Writer, Impress Insert tab: Annotation & Remotelink to similar place

- Make the Insert tab : insert annotation in similar place between
apps
- Use the same accesskey (accessibility, shortcut) in between apps and
the same as the one used inside of Home tab
  - Writer: Insert tab
    - Insert annotation: Add missing DE accesskey
    - Insert remotelink: Add missing accesskey
- Make both insert tabs more compact by making sure hyperlink and
remotelink stacked on both apps


