### PR TITLE
Use existing viewId in commentListSection avatar

### DIFF
--- a/browser/src/layer/tile/CommentListSection.ts
+++ b/browser/src/layer/tile/CommentListSection.ts
@@ -462,8 +462,8 @@ export class CommentSection extends CanvasSectionObject {
 		var tdImg = L.DomUtil.create(tagTd, 'cool-annotation-img', tr);
 		var tdAuthor = L.DomUtil.create(tagTd, 'cool-annotation-author', tr);
 		var imgAuthor = L.DomUtil.create('img', 'avatar-img', tdImg);
-		var viewId = this.map._docLayer._viewId;
-		L.LOUtil.setUserImage(imgAuthor, this.map, viewId);
+		var user = this.map.getViewId(commentData.author);
+		L.LOUtil.setUserImage(imgAuthor, this.map, user);
 		imgAuthor.setAttribute('width', 32);
 		imgAuthor.setAttribute('height', 32);
 		var authorAvatarImg = imgAuthor;
@@ -472,7 +472,6 @@ export class CommentSection extends CanvasSectionObject {
 
 		$(contentAuthor).text(commentData.author);
 		$(authorAvatarImg).attr('src', commentData.avatar);
-		var user = this.map.getViewId(commentData.author);
 		if (user >= 0) {
 			var color = L.LOUtil.rgbToHex(this.map.getViewColor(user));
 			$(authorAvatarImg).css('border-color', color);


### PR DESCRIPTION
In 79028c6f881dd19ecbffa2c0653634879dd35496 I replaced an instance of using this.map._docLayer._viewId as if the user is not in the document this becomes your own view ID and shows the wrong avatar. Unfortunately I missed CommentListSection which has the same code.

As we already have a viewId fetched a little later down, I opted to use it rather than get another myself


Change-Id: Ieda06e03902effe9be8fef3623b73d3caeef6f65


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

