### PR TITLE
bgsave: ensure that a bgsave process doesn't have a tile queue.

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1441,6 +1441,10 @@ bool Document::forkToSave(const std::function<void()> &childSave, int viewId)
 
         UnitKit::get().postBackgroundSaveFork();
 
+        // other queued messages should be handled in the parent kit
+        if (_tileQueue)
+            _tileQueue->clear();
+
         // Hard drop our previous connections to coolwsd and shared wakeups.
         KitSocketPoll::cleanupChildProcess();
 


### PR DESCRIPTION
Otherwise we go on doing work that the parent kit process should do eg.

[ kitbgsv_006_002 ] TRC  ToMaster-8f9: saveDocumentBackground returns succesful start.| kit/ChildSession.cpp:887 [ kitbgsv_006_002 ] TRC  Calling paintPartTile(0x4c0716f0)| common/RenderTiles.hpp:130


Change-Id: I257f61d05d8a0da0c8eb9d8c60e502da66dc8cdd


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

