### PR TITLE
Cypress: Clean up document loading and test setup

### DIFF
--- a/cypress_test/integration_tests/common/desktop_helper.js
+++ b/cypress_test/integration_tests/common/desktop_helper.js
@@ -420,10 +420,12 @@ function pressKey(n, key) {
 	cy.log('<< pressKey - end');
 }
 
-function openReadOnlyFile(type, filename) {
+function openReadOnlyFile(subFolder, fileName) {
 	cy.log('>> openReadOnlyFile - start');
 
-	var testFileName = helper.loadTestDocNoIntegration(filename, type, false, false, false);
+	var newFileName = helper.setupDocument(fileName, subFolder);
+	// Skip document checks because sidebar does not appear
+	helper.loadDocument(newFileName, subFolder, true);
 
 	//check doc is loaded
 	cy.cGet('.leaflet-canvas-container canvas', {timeout : Cypress.config('defaultCommandTimeout') * 2.0});
@@ -433,7 +435,7 @@ function openReadOnlyFile(type, filename) {
 	cy.cGet('#PermissionMode').should('be.visible').should('have.text', ' Read-only ');
 
 	cy.log('<< openReadOnlyFile - end');
-	return testFileName;
+	return newFileName;
 }
 
 function checkAccessibilityEnabledToBe(state) {

--- a/cypress_test/integration_tests/common/helper.js
+++ b/cypress_test/integration_tests/common/helper.js
@@ -545,12 +545,6 @@ function beforeAll(fileName, subFolder, noFileCopy, isMultiUser, subsequentLoad,
 	return loadTestDoc(fileName, subFolder, noFileCopy, isMultiUser, subsequentLoad, hasInteractionBeforeLoad, noRename);
 }
 
-// testState no longer used, but not removed from all calls to afterAll yet
-// eslint-disable-next-line no-unused-vars
-function afterAll(fileName, testState) {
-	closeDocument(fileName);
-}
-
 // This method is intended to call after each test case.
 // We use this method to close the document, before step
 // on to the next test case.
@@ -1197,7 +1191,6 @@ module.exports.matchClipboardText = matchClipboardText;
 module.exports.clipboardTextShouldBeDifferentThan = clipboardTextShouldBeDifferentThan;
 module.exports.closeDocument = closeDocument;
 module.exports.reload = reload;
-module.exports.afterAll = afterAll;
 module.exports.initAliasToNegative = initAliasToNegative;
 module.exports.doIfInCalc = doIfInCalc;
 module.exports.doIfInImpress = doIfInImpress;

--- a/cypress_test/integration_tests/common/helper.js
+++ b/cypress_test/integration_tests/common/helper.js
@@ -1,6 +1,35 @@
 /* -*- js-indent-level: 8 -*- */
 /* global cy Cypress expect */
 
+/*
+ * Covers most use cases. For more flexibility,
+ * call setupDocument and loadDocument directly
+ * fileName: Includes subFolder, for example: 'calc/hello-world.ods'
+ */
+function setupAndLoadDocument(fullFileName, isMultiUser = false) {
+	cy.log('>> setupAndLoadDocument - start');
+
+	// split 'calc/hello-world.ods' to 'calc' and 'hello-world.ods'
+	var subFolder;
+	var fileName;
+	if (fullFileName.includes('/')) {
+		subFolder = fullFileName.substr(0, fullFileName.lastIndexOf('/'));
+		fileName = fullFileName.substr(fullFileName.lastIndexOf('/')+1, fullFileName.length);
+	} else {
+		subFolder = undefined;
+		fileName = fullFileName;
+	}
+
+	// TODO: replace with loadDocument and setupDocument
+	if (isMultiUser) {
+		beforeAll(fileName, subFolder, undefined, isMultiUser);
+	} else {
+		beforeAll(fileName, subFolder);
+	}
+
+	cy.log('<< setupAndLoadDocument - end');
+}
+
 function copyFile(fileName, newFileName, subFolder) {
 	if (subFolder === undefined) {
 		cy.task('copyFile', {
@@ -1179,6 +1208,7 @@ function copy() {
 	});
 }
 
+module.exports.setupAndLoadDocument = setupAndLoadDocument;
 module.exports.loadTestDoc = loadTestDoc;
 module.exports.checkIfDocIsLoaded = checkIfDocIsLoaded;
 module.exports.assertCursorAndFocus = assertCursorAndFocus;

--- a/cypress_test/integration_tests/common/interference_user_spec.js
+++ b/cypress_test/integration_tests/common/interference_user_spec.js
@@ -31,7 +31,7 @@ describe('Interfering second user.', function() {
 				.then(function(text) {
 
 					// We open the same document
-					helper.beforeAll(text, getComponent(text), true);
+					helper.loadDocument(text, getComponent(text));
 				});
 
 			cy.get('#toolbar-up #userlist', { timeout: Cypress.config('defaultCommandTimeout') * 2.0 })

--- a/cypress_test/integration_tests/desktop/calc/annotation_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/annotation_spec.js
@@ -98,11 +98,10 @@ describe(['tagdesktop'], 'Annotation Tests', function() {
 });
 
 describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
-	var origTestFileName = 'annotation.ods';
-	var testFileName;
+	var newFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'calc');
+		newFileName = helper.setupAndLoadDocument('calc/annotation.ods');
 		desktopHelper.switchUIToNotebookbar();
 	});
 
@@ -112,8 +111,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
 		cy.cGet('.cool-annotation-edit.modify-annotation').should('be.visible');
 
-		helper.closeDocument(testFileName);
-		helper.beforeAll(testFileName, 'calc', true, false, false, true);
+		helper.reloadDocument(newFileName,'calc');
 		cy.cGet('.cool-annotation').should('exist');
 		cy.cGet('#comment-container-1').then(function (element) {
 			element[0].style.visibility = '';
@@ -138,8 +136,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('#comment-container-1').trigger('mouseover');
 		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
 
-		helper.closeDocument(testFileName);
-		helper.beforeAll(testFileName, 'calc', true, false, false, true);
+		helper.reloadDocument(newFileName,'calc');
 		cy.cGet('.cool-annotation').should('exist');
 		cy.cGet('#comment-container-1').then(function (element) {
 			element[0].style.visibility = '';
@@ -158,8 +155,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('.cool-annotation').should('not.exist');
 		cy.cGet('.cool-annotation-autosavelabel').should('not.exist');
 
-		helper.closeDocument(testFileName);
-		helper.beforeAll(testFileName, 'calc', true, false, false, true);
+		helper.reloadDocument(newFileName,'calc');
 		cy.cGet('.cool-annotation').should('not.exist');
 	});
 
@@ -181,8 +177,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
 		cy.cGet('.cool-annotation-edit.modify-annotation').should('be.visible');
 
-		helper.closeDocument(testFileName);
-		helper.beforeAll(testFileName, 'calc', true, false, false, true);
+		helper.reloadDocument(newFileName,'calc');
 		cy.cGet('.cool-annotation').should('exist');
 		cy.cGet('#comment-container-1').then(function (element) {
 			element[0].style.visibility = '';
@@ -218,8 +213,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('#annotation-content-area-1').should('have.text','some other text, some text0');
 		cy.cGet('#comment-container-1').should('exist');
 
-		helper.closeDocument(testFileName);
-		helper.beforeAll(testFileName, 'calc', true, false, false, true);
+		helper.reloadDocument(newFileName,'calc');
 		cy.cGet('.cool-annotation').should('exist');
 		cy.cGet('#comment-container-1').then(function (element) {
 			element[0].style.visibility = '';
@@ -255,8 +249,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
 		cy.cGet('#comment-container-1').should('exist');
 
-		helper.closeDocument(testFileName);
-		helper.beforeAll(testFileName, 'calc', true, false, false, true);
+		helper.reloadDocument(newFileName,'calc');
 		cy.cGet('.cool-annotation').should('exist');
 		cy.cGet('#comment-container-1').then(function (element) {
 			element[0].style.visibility = '';

--- a/cypress_test/integration_tests/desktop/calc/annotation_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/annotation_spec.js
@@ -1,4 +1,4 @@
-/* global describe it require cy afterEach beforeEach */
+/* global describe it require cy beforeEach */
 
 var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
@@ -11,10 +11,6 @@ describe(['tagdesktop'], 'Annotation Tests', function() {
 	beforeEach(function() {
 		testFileName = helper.beforeAll(origTestFileName, 'calc');
 		desktopHelper.switchUIToNotebookbar();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Insert',function() {
@@ -110,10 +106,6 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 	beforeEach(function() {
 		testFileName = helper.beforeAll(origTestFileName, 'calc');
 		desktopHelper.switchUIToNotebookbar();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Insert autosave',function() {

--- a/cypress_test/integration_tests/desktop/calc/annotation_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/annotation_spec.js
@@ -5,11 +5,9 @@ var desktopHelper = require('../../common/desktop_helper');
 var calcHelper = require('../../common/calc_helper');
 
 describe(['tagdesktop'], 'Annotation Tests', function() {
-	var origTestFileName = 'annotation.ods';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'calc');
+		helper.setupAndLoadDocument('calc/annotation.ods');
 		desktopHelper.switchUIToNotebookbar();
 	});
 

--- a/cypress_test/integration_tests/desktop/calc/autofilter_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/autofilter_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach */
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 var calcHelper = require('../../common/calc_helper');
@@ -14,10 +14,6 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'AutoFilter', function() {
 		toggleAutofilter();
 		helper.setDummyClipboardForCopy();
 		calcHelper.assertSheetContents(['Cypress Test', 'Status', 'Test 1', 'Pass', 'Test 2', 'Fail', 'Test 3', 'Pass', 'Test 4', '', 'Test 5', 'Fail'], true);
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	function toggleAutofilter() {

--- a/cypress_test/integration_tests/desktop/calc/autofilter_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/autofilter_spec.js
@@ -5,11 +5,9 @@ var calcHelper = require('../../common/calc_helper');
 var desktopHelper = require('../../common/desktop_helper');
 
 describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'AutoFilter', function() {
-	var origTestFileName = 'autofilter.ods';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'calc');
+		helper.setupAndLoadDocument('calc/autofilter.ods');
 		desktopHelper.switchUIToCompact();
 		toggleAutofilter();
 		helper.setDummyClipboardForCopy();

--- a/cypress_test/integration_tests/desktop/calc/bottom_bar_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/bottom_bar_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach */
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 var calcHelper = require('../../common/calc_helper');
@@ -10,10 +10,6 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Calc bottom bar tests.', f
 
 	beforeEach(function() {
 		testFileName = helper.beforeAll(origTestFileName, 'calc');
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Bottom tool bar.', function() {

--- a/cypress_test/integration_tests/desktop/calc/bottom_bar_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/bottom_bar_spec.js
@@ -5,11 +5,9 @@ var calcHelper = require('../../common/calc_helper');
 var desktophelper = require('../../common/desktop_helper');
 
 describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Calc bottom bar tests.', function() {
-	var origTestFileName = 'BottomBar.ods';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'calc');
+		helper.setupAndLoadDocument('calc/BottomBar.ods');
 	});
 
 	it('Bottom tool bar.', function() {

--- a/cypress_test/integration_tests/desktop/calc/cell_appearance_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/cell_appearance_spec.js
@@ -5,11 +5,9 @@ var calcHelper = require('../../common/calc_helper');
 var desktopHelper = require('../../common/desktop_helper');
 
 describe(['tagdesktop'], 'Change cell appearance.', function() {
-	var origTestFileName = 'cell_appearance.ods';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'calc');
+		helper.setupAndLoadDocument('calc/cell_appearance.ods');
 	});
 
 	it('Apply background color', function() {

--- a/cypress_test/integration_tests/desktop/calc/cell_appearance_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/cell_appearance_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach expect Cypress */
+/* global describe it cy beforeEach require expect Cypress */
 
 var helper = require('../../common/helper');
 var calcHelper = require('../../common/calc_helper');
@@ -10,10 +10,6 @@ describe(['tagdesktop'], 'Change cell appearance.', function() {
 
 	beforeEach(function() {
 		testFileName = helper.beforeAll(origTestFileName, 'calc');
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Apply background color', function() {

--- a/cypress_test/integration_tests/desktop/calc/cell_cursor_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/cell_cursor_spec.js
@@ -5,10 +5,9 @@ var calcHelper = require('../../common/calc_helper');
 var desktopHelper = require('../../common/desktop_helper');
 
 describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Test jumping on large cell selection', function() {
-	var testFileName = 'cell_cursor.ods';
 
 	beforeEach(function() {
-		helper.beforeAll(testFileName, 'calc');
+		helper.setupAndLoadDocument('calc/cell_cursor.ods');
 		desktopHelper.switchUIToCompact();
 		cy.cGet('#toolbar-up .w2ui-scroll-right').click();
 		cy.cGet('#sidebar').click({force: true});
@@ -23,10 +22,9 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Test jumping on large cell
 });
 
 describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Test jumping on large cell selection with split panes', function() {
-	var testFileName = 'cell_cursor_split.ods';
 
 	beforeEach(function() {
-		helper.beforeAll(testFileName, 'calc');
+		helper.setupAndLoadDocument('calc/cell_cursor_split.ods');
 		desktopHelper.switchUIToCompact();
 		cy.cGet('#toolbar-up .w2ui-scroll-right').click();
 		cy.cGet('#sidebar').click({force: true});

--- a/cypress_test/integration_tests/desktop/calc/cell_cursor_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/cell_cursor_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach expect require afterEach */
+/* global describe it cy beforeEach expect require */
 
 var helper = require('../../common/helper');
 var calcHelper = require('../../common/calc_helper');
@@ -12,10 +12,6 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Test jumping on large cell
 		desktopHelper.switchUIToCompact();
 		cy.cGet('#toolbar-up .w2ui-scroll-right').click();
 		cy.cGet('#sidebar').click({force: true});
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('No jump on long merged cell', function() {
@@ -34,10 +30,6 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Test jumping on large cell
 		desktopHelper.switchUIToCompact();
 		cy.cGet('#toolbar-up .w2ui-scroll-right').click();
 		cy.cGet('#sidebar').click({force: true});
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('No jump on long merged cell with split panes', function() {

--- a/cypress_test/integration_tests/desktop/calc/clipboard_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/clipboard_spec.js
@@ -4,11 +4,9 @@ var helper = require('../../common/helper');
 var calcHelper = require('../../common/calc_helper');
 
 describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Calc clipboard tests.', function() {
-	var origTestFileName = 'clipboard.ods';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'calc');
+		helper.setupAndLoadDocument('calc/clipboard.ods');
 	});
 
 	function setDummyClipboard(type, content, image = false, fail = false) {

--- a/cypress_test/integration_tests/desktop/calc/clipboard_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/clipboard_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach Cypress */
+/* global describe it cy beforeEach require Cypress */
 
 var helper = require('../../common/helper');
 var calcHelper = require('../../common/calc_helper');
@@ -9,10 +9,6 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Calc clipboard tests.', fu
 
 	beforeEach(function() {
 		testFileName = helper.beforeAll(origTestFileName, 'calc');
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	function setDummyClipboard(type, content, image = false, fail = false) {

--- a/cypress_test/integration_tests/desktop/calc/delete_objects_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/delete_objects_spec.js
@@ -3,11 +3,9 @@ var helper = require('../../common/helper');
 const desktopHelper = require('../../common/desktop_helper');
 
 describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Delete Objects', function() {
-	var origTestFileName = 'delete_objects.ods';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'calc');
+		helper.setupAndLoadDocument('calc/delete_objects.ods');
 		desktopHelper.switchUIToCompact();
 	});
 

--- a/cypress_test/integration_tests/desktop/calc/delete_objects_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/delete_objects_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy require afterEach beforeEach expect Cypress*/
+/* global describe it cy require beforeEach expect Cypress*/
 var helper = require('../../common/helper');
 const desktopHelper = require('../../common/desktop_helper');
 
@@ -9,10 +9,6 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Delete Objects', function(
 	beforeEach(function() {
 		testFileName = helper.beforeAll(origTestFileName, 'calc');
 		desktopHelper.switchUIToCompact();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Delete Text', function() {

--- a/cypress_test/integration_tests/desktop/calc/focus_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/focus_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach */
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 var calcHelper = require('../../common/calc_helper');
@@ -9,10 +9,6 @@ describe(['tagdesktop'], 'Calc focus tests', function() {
 
 	beforeEach(function() {
 		testFileName = helper.beforeAll(origTestFileName, 'calc');
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Formula-bar focus', function() {

--- a/cypress_test/integration_tests/desktop/calc/focus_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/focus_spec.js
@@ -4,11 +4,9 @@ var helper = require('../../common/helper');
 var calcHelper = require('../../common/calc_helper');
 
 describe(['tagdesktop'], 'Calc focus tests', function() {
-	var origTestFileName = 'focus.ods';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'calc');
+		helper.setupAndLoadDocument('calc/focus.ods');
 	});
 
 	it('Formula-bar focus', function() {

--- a/cypress_test/integration_tests/desktop/calc/help_dialog_update_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/help_dialog_update_spec.js
@@ -10,10 +10,9 @@ var helper = require('../../common/helper');
 var calcHelper = require('../../common/calc_helper');
 
 describe(['tagscreenshot'], 'Help dialog update', function() {
-	var testFileName = 'help_dialog.ods';
 
 	beforeEach(function() {
-		helper.beforeAll(testFileName, 'calc');
+		helper.setupAndLoadDocument('calc/help_dialog.ods');
 	});
 
 	it('Chart selected sidebar open', function() {

--- a/cypress_test/integration_tests/desktop/calc/help_dialog_update_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/help_dialog_update_spec.js
@@ -5,7 +5,7 @@
 // UPDATE_SCREENSHOT needs to be true otherwise cypress will not run the spec file and
 // update the screenshot
 
-/* global describe it cy require Cypress afterEach beforeEach */
+/* global describe it cy require Cypress beforeEach */
 var helper = require('../../common/helper');
 var calcHelper = require('../../common/calc_helper');
 
@@ -14,10 +14,6 @@ describe(['tagscreenshot'], 'Help dialog update', function() {
 
 	beforeEach(function() {
 		helper.beforeAll(testFileName, 'calc');
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Chart selected sidebar open', function() {

--- a/cypress_test/integration_tests/desktop/calc/image_operation_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/image_operation_spec.js
@@ -5,11 +5,9 @@ var { insertImage, deleteImage, assertImageSize } = require('../../common/deskto
 var desktopHelper = require('../../common/desktop_helper');
 
 describe(['tagdesktop'], 'Image Operation Tests', function() {
-	var origTestFileName = 'image_operation.ods';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'calc');
+		helper.setupAndLoadDocument('calc/image_operation.ods');
 		desktopHelper.switchUIToNotebookbar();
 	});
 

--- a/cypress_test/integration_tests/desktop/calc/image_operation_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/image_operation_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy require afterEach beforeEach */
+/* global describe it cy require beforeEach */
 
 var helper = require('../../common/helper');
 var { insertImage, deleteImage, assertImageSize } = require('../../common/desktop_helper');
@@ -11,10 +11,6 @@ describe(['tagdesktop'], 'Image Operation Tests', function() {
 	beforeEach(function() {
 		testFileName = helper.beforeAll(origTestFileName, 'calc');
 		desktopHelper.switchUIToNotebookbar();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Insert/Delete Image',function() {

--- a/cypress_test/integration_tests/desktop/calc/jsdialog_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/jsdialog_spec.js
@@ -4,10 +4,9 @@
 var helper = require('../../common/helper');
 
 describe(['tagdesktop'], 'JSDialog unit test', function() {
-	var testFileName = 'help_dialog.ods';
 
 	beforeEach(function() {
-		helper.beforeAll(testFileName, 'calc');
+		helper.setupAndLoadDocument('calc/help_dialog.ods');
 	});
 
 	it('JSDialog popup dialog', function() {

--- a/cypress_test/integration_tests/desktop/calc/jsdialog_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/jsdialog_spec.js
@@ -1,6 +1,6 @@
 /* -*- js-indent-level: 8 -*- */
 
-/* global describe it cy require expect afterEach beforeEach */
+/* global describe it cy require expect beforeEach */
 var helper = require('../../common/helper');
 
 describe(['tagdesktop'], 'JSDialog unit test', function() {
@@ -8,10 +8,6 @@ describe(['tagdesktop'], 'JSDialog unit test', function() {
 
 	beforeEach(function() {
 		helper.beforeAll(testFileName, 'calc');
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('JSDialog popup dialog', function() {

--- a/cypress_test/integration_tests/desktop/calc/macro_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/macro_spec.js
@@ -4,7 +4,14 @@ var helper = require('../../common/helper');
 var calcHelper = require('../../common/calc_helper');
 
 describe(['tagdesktop', 'tagproxy'], 'macro dialog tests', function() {
-	var testFileName = 'macro.ods';
+
+	beforeEach(function() {
+		var newFileName = helper.setupDocument('macro.ods','calc');
+		// Skip document check to click through accept macro dialog first
+		helper.loadDocument(newFileName,'calc',true);
+		acceptMacroExecution();
+		helper.documentChecks();
+	});
 
 	function acceptMacroExecution() {
 		cy.get('#MacroWarnMedium.jsdialog')
@@ -12,12 +19,6 @@ describe(['tagdesktop', 'tagproxy'], 'macro dialog tests', function() {
 
 		cy.cGet('#MacroWarnMedium.jsdialog #ok').click();
 	}
-
-	beforeEach(function() {
-		helper.beforeAll(testFileName, 'calc', undefined, undefined, undefined, true);
-		acceptMacroExecution();
-		helper.checkIfDocIsLoaded();
-	});
 
 	function expandEntryInTreeView(entryText) {
 		cy.cGet().contains('.jsdialog.ui-treeview-cell', entryText)

--- a/cypress_test/integration_tests/desktop/calc/macro_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/macro_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach */
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 var calcHelper = require('../../common/calc_helper');
@@ -17,10 +17,6 @@ describe(['tagdesktop', 'tagproxy'], 'macro dialog tests', function() {
 		helper.beforeAll(testFileName, 'calc', undefined, undefined, undefined, true);
 		acceptMacroExecution();
 		helper.checkIfDocIsLoaded();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	function expandEntryInTreeView(entryText) {

--- a/cypress_test/integration_tests/desktop/calc/navigator_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/navigator_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach */
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 var { insertImage, deleteImage } = require('../../common/desktop_helper');
@@ -12,10 +12,6 @@ describe.skip(['tagdesktop'], 'Navigator tests.', function () {
 
 		cy.cGet('#menu-view').click();
 		cy.cGet('#menu-navigator').click();
-	});
-
-	afterEach(function () {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Jump to element. Navigator -> Document', function() {

--- a/cypress_test/integration_tests/desktop/calc/navigator_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/navigator_spec.js
@@ -4,11 +4,9 @@ var helper = require('../../common/helper');
 var { insertImage, deleteImage } = require('../../common/desktop_helper');
 
 describe.skip(['tagdesktop'], 'Navigator tests.', function () {
-	var origTestFileName = 'navigator.ods';
-	var testFileName;
 
 	beforeEach(function () {
-		testFileName = helper.beforeAll(origTestFileName, 'calc');
+		helper.setupAndLoadDocument('calc/navigator.ods');
 
 		cy.cGet('#menu-view').click();
 		cy.cGet('#menu-navigator').click();

--- a/cypress_test/integration_tests/desktop/calc/open_different_file_types_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/open_different_file_types_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy require Cypress afterEach */
+/* global describe it cy require Cypress */
 var helper = require('../../common/helper');
 var calcHelper = require('../../common/calc_helper');
 const { insertImage } = require('../../common/desktop_helper');
@@ -23,10 +23,6 @@ describe.skip(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Open different file t
 
 		cy.cGet('#PermissionMode').should('be.visible').should('have.text', ' Read-only ');
 	}
-
-	afterEach(function () {
-		helper.afterAll(testFileName, this.currentTest.state);
-	});
 
 	function assertData() {
 		var expectedData = [

--- a/cypress_test/integration_tests/desktop/calc/open_different_file_types_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/open_different_file_types_spec.js
@@ -5,16 +5,8 @@ const { insertImage } = require('../../common/desktop_helper');
 
 describe.skip(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Open different file types', function () {
 
-	var testFileName = '';
-
-	function before(filename) {
-		var origTestFileName = filename;
-
-		testFileName = helper.beforeAll(origTestFileName, 'calc');
-	}
-
 	function openReadOnlyFile(filename) {
-		testFileName = helper.loadTestDocNoIntegration(filename, 'calc', false, false, false);
+		helper.loadTestDocNoIntegration(filename, 'calc', false, false, false);
 
 		//check doc is loaded
 		cy.cGet('.leaflet-canvas-container canvas', {timeout : Cypress.config('defaultCommandTimeout') * 2.0});
@@ -36,7 +28,7 @@ describe.skip(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Open different file t
 	}
 
 	it('Open xls file', { defaultCommandTimeout: 60000 }, function () {
-		before('testfile.xls');
+		helper.setupAndLoadDocument('calc/testfile.xls');
 
 		assertData();
 
@@ -44,7 +36,7 @@ describe.skip(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Open different file t
 	});
 
 	it('Open xlsx file', { defaultCommandTimeout: 60000 }, function () {
-		before('testfile.xlsx');
+		helper.setupAndLoadDocument('calc/testfile.xlsx');
 
 		assertData();
 	});
@@ -56,7 +48,7 @@ describe.skip(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Open different file t
 		//to fit csv jsdialog in window
 		cy.viewport(1280, 960);
 
-		testFileName = helper.loadTestDocNoIntegration('testfile.csv', 'calc', false, false, false);
+		helper.loadTestDocNoIntegration('testfile.csv', 'calc', false, false, false);
 
 		cy.cGet('form.jsdialog-container.lokdialog_container').should('exist');
 
@@ -89,7 +81,7 @@ describe.skip(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Open different file t
 	});
 
 	it('Open xlsm file', { defaultCommandTimeout: 60000 }, function() {
-		before('testfile.xlsm');
+		helper.setupAndLoadDocument('calc/testfile.xlsm');
 
 		assertData();
 
@@ -109,7 +101,7 @@ describe.skip(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Open different file t
 	});
 
 	it('Open fods file', { defaultCommandTimeout: 60000 }, function() {
-		before('testfile.fods');
+		helper.setupAndLoadDocument('calc/testfile.fods');
 
 		//select all the content of doc
 		assertData();

--- a/cypress_test/integration_tests/desktop/calc/open_different_file_types_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/open_different_file_types_spec.js
@@ -1,20 +1,9 @@
-/* global describe it cy require Cypress */
+/* global describe it cy require */
 var helper = require('../../common/helper');
 var calcHelper = require('../../common/calc_helper');
-const { insertImage } = require('../../common/desktop_helper');
+var desktopHelper = require('../../common/desktop_helper');
 
 describe.skip(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Open different file types', function () {
-
-	function openReadOnlyFile(filename) {
-		helper.loadTestDocNoIntegration(filename, 'calc', false, false, false);
-
-		//check doc is loaded
-		cy.cGet('.leaflet-canvas-container canvas', {timeout : Cypress.config('defaultCommandTimeout') * 2.0});
-
-		helper.isCanvasWhite(false);
-
-		cy.cGet('#PermissionMode').should('be.visible').should('have.text', ' Read-only ');
-	}
 
 	function assertData() {
 		var expectedData = [
@@ -32,7 +21,7 @@ describe.skip(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Open different file t
 
 		assertData();
 
-		insertImage();
+		desktopHelper.insertImage();
 	});
 
 	it('Open xlsx file', { defaultCommandTimeout: 60000 }, function () {
@@ -41,23 +30,19 @@ describe.skip(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Open different file t
 		assertData();
 	});
 
-	//we are not using before because it loads the document and directly asserts if document is loaded but in
-	//case of csv file 1st when you try to load the doc it opens up jsdialog to import csv which requires user
-	//input and after click ok the doc starts to load
 	it('Open csv file', { defaultCommandTimeout: 60000 }, function() {
 		//to fit csv jsdialog in window
 		cy.viewport(1280, 960);
 
-		helper.loadTestDocNoIntegration('testfile.csv', 'calc', false, false, false);
+		var newFileName = helper.setupDocument('testfile.csv','calc');
+		// Skip document check to click through import csv dialog first
+		helper.loadDocument(newFileName,'calc',true);
 
 		cy.cGet('form.jsdialog-container.lokdialog_container').should('exist');
-
 		cy.cGet('.ui-pushbutton.jsdialog.button-primary').click();
 
 		//check doc is loaded
-		cy.cGet('.leaflet-canvas-container canvas', {timeout : Cypress.config('defaultCommandTimeout') * 2.0});
-
-		helper.isCanvasWhite(false);
+		helper.documentChecks();
 
 		cy.cGet('#mobile-edit-button')
 			.should('be.visible')
@@ -69,7 +54,7 @@ describe.skip(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Open different file t
 	});
 
 	it('Open xlsb file', { defaultCommandTimeout: 60000 }, function() {
-		openReadOnlyFile('testfile.xlsb');
+		desktopHelper.openReadOnlyFile('testfile.xlsb');
 
 		cy.cGet('#mobile-edit-button').should('be.visible').click();
 		cy.cGet('#modal-dialog-switch-to-edit-mode-modal-overlay').should('be.visible');
@@ -85,17 +70,17 @@ describe.skip(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Open different file t
 
 		assertData();
 
-		insertImage();
+		desktopHelper.insertImage();
 	});
 
 	it('Open xltm file', { defaultCommandTimeout: 60000 }, function() {
-		openReadOnlyFile('testfile.xltm');
+		desktopHelper.openReadOnlyFile('testfile.xltm');
 
 		cy.cGet('#mobile-edit-button').should('not.be.visible');
 	});
 
 	it('Open xltx file', { defaultCommandTimeout: 60000 }, function() {
-		openReadOnlyFile('testfile.xltm');
+		desktopHelper.openReadOnlyFile('testfile.xltm');
 
 		cy.cGet('#mobile-edit-button').should('not.be.visible');
 	});
@@ -106,6 +91,6 @@ describe.skip(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Open different file t
 		//select all the content of doc
 		assertData();
 
-		insertImage();
+		desktopHelper.insertImage();
 	});
 });

--- a/cypress_test/integration_tests/desktop/calc/row_column_operation_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/row_column_operation_spec.js
@@ -4,10 +4,9 @@ var calcHelper = require('../../common/calc_helper');
 var desktopHelper = require('../../common/desktop_helper');
 
 describe(['tagdesktop'], 'Row Column Operation', function() {
-	var testFileName = 'row_column_operation.ods';
 
 	beforeEach(function() {
-		helper.beforeAll(testFileName, 'calc');
+		helper.setupAndLoadDocument('calc/row_column_operation.ods');
 		desktopHelper.switchUIToNotebookbar();
 		helper.setDummyClipboardForCopy();
 		calcHelper.assertSheetContents(['Hello','Hi','World','Bye'], true);

--- a/cypress_test/integration_tests/desktop/calc/row_column_operation_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/row_column_operation_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy require afterEach beforeEach */
+/* global describe it cy require beforeEach */
 var helper = require('../../common/helper');
 var calcHelper = require('../../common/calc_helper');
 var desktopHelper = require('../../common/desktop_helper');
@@ -13,10 +13,6 @@ describe(['tagdesktop'], 'Row Column Operation', function() {
 		calcHelper.assertSheetContents(['Hello','Hi','World','Bye'], true);
 		calcHelper.clickOnFirstCell(true,false);
 		cy.cGet('#toolbar-up .w2ui-scroll-right').click();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Insert/Delete row' , function() {

--- a/cypress_test/integration_tests/desktop/calc/scrolling_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/scrolling_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach */
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
@@ -11,10 +11,6 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Scroll through document', 
 		desktopHelper.switchUIToCompact();
 		cy.cGet('#toolbar-up .w2ui-scroll-right').click();
 		cy.cGet('#sidebar').click({force: true});
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Scrolling to bottom/top', function() {

--- a/cypress_test/integration_tests/desktop/calc/scrolling_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/scrolling_spec.js
@@ -4,10 +4,9 @@ var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
 
 describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Scroll through document', function() {
-	var testFileName = 'scrolling.ods';
 
 	beforeEach(function() {
-		helper.beforeAll(testFileName, 'calc');
+		helper.setupAndLoadDocument('calc/scrolling.ods');
 		desktopHelper.switchUIToCompact();
 		cy.cGet('#toolbar-up .w2ui-scroll-right').click();
 		cy.cGet('#sidebar').click({force: true});

--- a/cypress_test/integration_tests/desktop/calc/searchbar_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/searchbar_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach*/
+/* global describe it cy beforeEach require*/
 
 var helper = require('../../common/helper');
 var searchHelper = require('../../common/search_helper');
@@ -9,10 +9,6 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Searching via search bar.'
 
 	beforeEach(function() {
 		testFileName = helper.beforeAll(origTestFileName, 'calc');
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Search existing word.', function() {

--- a/cypress_test/integration_tests/desktop/calc/searchbar_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/searchbar_spec.js
@@ -4,11 +4,9 @@ var helper = require('../../common/helper');
 var searchHelper = require('../../common/search_helper');
 
 describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Searching via search bar.', function() {
-	var origTestFileName = 'search_bar.ods';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'calc');
+		helper.setupAndLoadDocument('calc/search_bar.ods');
 	});
 
 	it('Search existing word.', function() {

--- a/cypress_test/integration_tests/desktop/calc/sheet_operation_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/sheet_operation_spec.js
@@ -4,11 +4,9 @@ var helper = require('../../common/helper');
 var calcHelper = require('../../common/calc_helper');
 
 describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Sheet Operations.', function () {
-	var origTestFileName = 'sheet_operation.ods';
-	var testFileName;
 
 	beforeEach(function () {
-		testFileName = helper.beforeAll(origTestFileName, 'calc');
+		helper.setupAndLoadDocument('calc/sheet_operation.ods');
 	});
 
 	it('Insert sheet', function () {

--- a/cypress_test/integration_tests/desktop/calc/sheet_operation_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/sheet_operation_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach */
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 var calcHelper = require('../../common/calc_helper');
@@ -9,10 +9,6 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Sheet Operations.', functi
 
 	beforeEach(function () {
 		testFileName = helper.beforeAll(origTestFileName, 'calc');
-	});
-
-	afterEach(function () {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Insert sheet', function () {

--- a/cypress_test/integration_tests/desktop/calc/sheet_switch_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/sheet_switch_spec.js
@@ -4,10 +4,9 @@ var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
 
 describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Sheet switching tests', function() {
-	var testFileName = 'switch.ods';
 
 	beforeEach(function() {
-		helper.beforeAll(testFileName, 'calc');
+		helper.setupAndLoadDocument('calc/switch.ods');
 	});
 
 	/* switch.ods has 2 sheets, 1st with data in G45, 2nd with data in F720*/

--- a/cypress_test/integration_tests/desktop/calc/sheet_switch_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/sheet_switch_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach */
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
@@ -8,10 +8,6 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Sheet switching tests', fu
 
 	beforeEach(function() {
 		helper.beforeAll(testFileName, 'calc');
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	/* switch.ods has 2 sheets, 1st with data in G45, 2nd with data in F720*/

--- a/cypress_test/integration_tests/desktop/calc/sidebar_dialog_image_caching_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/sidebar_dialog_image_caching_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach */
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 
@@ -8,10 +8,6 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Calc sidebar dialog image 
 
 	beforeEach(function() {
 		testFileName = helper.beforeAll(origTestFileName, 'calc');
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Sidebar image caching', function() {

--- a/cypress_test/integration_tests/desktop/calc/sidebar_dialog_image_caching_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/sidebar_dialog_image_caching_spec.js
@@ -3,11 +3,9 @@
 var helper = require('../../common/helper');
 
 describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Calc sidebar dialog image caching', function() {
-	var origTestFileName = 'many-sizes.ods';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'calc');
+		helper.setupAndLoadDocument('calc/many-sizes.ods');
 	});
 
 	it('Sidebar image caching', function() {

--- a/cypress_test/integration_tests/desktop/calc/statusbar_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/statusbar_spec.js
@@ -5,11 +5,9 @@ var desktopHelper = require('../../common/desktop_helper');
 var calcHelper = require('../../common/calc_helper');
 
 describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Statubar tests.', function() {
-	var origTestFileName = 'statusbar.ods';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'calc');
+		helper.setupAndLoadDocument('calc/statusbar.ods');
 
 		if (Cypress.env('INTEGRATION') === 'nextcloud') {
 			desktopHelper.showStatusBarIfHidden();

--- a/cypress_test/integration_tests/desktop/calc/statusbar_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/statusbar_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach Cypress */
+/* global describe it cy beforeEach require Cypress */
 
 var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
@@ -14,10 +14,6 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Statubar tests.', function
 		if (Cypress.env('INTEGRATION') === 'nextcloud') {
 			desktopHelper.showStatusBarIfHidden();
 		}
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Selected sheet.', function() {

--- a/cypress_test/integration_tests/desktop/calc/top_toolbar_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/top_toolbar_spec.js
@@ -5,21 +5,20 @@ var desktopHelper = require('../../common/desktop_helper');
 var calcHelper = require('../../common/calc_helper');
 
 describe(['tagdesktop'], 'Top toolbar tests.', function() {
-	var origTestFileName = 'top_toolbar.ods';
-	var testFileName;
+	var newFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'calc');
+		newFileName = helper.setupAndLoadDocument('calc/top_toolbar.ods');
 		desktopHelper.switchUIToCompact();
 		calcHelper.clickOnFirstCell();
 	});
 
-	it('Save.', { defaultCommandTimeout: 60000 }, function() {
+	it('Save.', function() {
 		cy.cGet('#bold').click();
 		cy.cGet('#save').click();
 
-		helper.reload(testFileName, 'calc', true);
-		cy.log('reload happened');
+		helper.reloadDocument(newFileName,'calc');
+
 		helper.setDummyClipboardForCopy();
 		calcHelper.selectEntireSheet();
 		helper.copy();

--- a/cypress_test/integration_tests/desktop/calc/top_toolbar_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/top_toolbar_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach expect */
+/* global describe it cy beforeEach require expect */
 
 var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
@@ -12,10 +12,6 @@ describe(['tagdesktop'], 'Top toolbar tests.', function() {
 		testFileName = helper.beforeAll(origTestFileName, 'calc');
 		desktopHelper.switchUIToCompact();
 		calcHelper.clickOnFirstCell();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Save.', { defaultCommandTimeout: 60000 }, function() {

--- a/cypress_test/integration_tests/desktop/calc/undo_redo_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/undo_redo_spec.js
@@ -6,10 +6,9 @@ var repairHelper = require('../../common/repair_document_helper');
 const desktopHelper = require('../../common/desktop_helper');
 
 describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Editing Operations', function() {
-	var testFileName = 'undo_redo.ods';
 
 	beforeEach(function() {
-		helper.beforeAll(testFileName, 'calc');
+		helper.setupAndLoadDocument('calc/undo_redo.ods');
 		desktopHelper.switchUIToCompact();
 	});
 

--- a/cypress_test/integration_tests/desktop/calc/undo_redo_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/undo_redo_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach*/
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 var calcHelper = require('../../common/calc_helper');
@@ -11,10 +11,6 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Editing Operations', funct
 	beforeEach(function() {
 		helper.beforeAll(testFileName, 'calc');
 		desktopHelper.switchUIToCompact();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	function undo() {

--- a/cypress_test/integration_tests/desktop/draw/navigator_spec.js
+++ b/cypress_test/integration_tests/desktop/draw/navigator_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy require afterEach beforeEach */
+/* global describe it cy require beforeEach */
 
 var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
@@ -13,10 +13,6 @@ describe.skip(['tagdesktop'], 'Scroll through document, insert/delete items', fu
 		desktopHelper.selectZoomLevel('100');
 		cy.cGet('#menu-view').click();
 		cy.cGet('#menu-navigator').click();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	function checkIfItemNotExist(itemName) {

--- a/cypress_test/integration_tests/desktop/draw/navigator_spec.js
+++ b/cypress_test/integration_tests/desktop/draw/navigator_spec.js
@@ -4,11 +4,9 @@ var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
 
 describe.skip(['tagdesktop'], 'Scroll through document, insert/delete items', function() {
-	var origTestFileName = 'navigator.odg';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'draw');
+		helper.setupAndLoadDocument('draw/navigator.odg');
 
 		desktopHelper.selectZoomLevel('100');
 		cy.cGet('#menu-view').click();

--- a/cypress_test/integration_tests/desktop/draw/pdf_page_up_down_spec.js
+++ b/cypress_test/integration_tests/desktop/draw/pdf_page_up_down_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy require afterEach beforeEach */
+/* global describe it cy require beforeEach */
 
 var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
@@ -9,10 +9,6 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'PDF View Tests', function(
 
 	beforeEach(function() {
 		testFileName = helper.beforeAll(origTestFileName, 'draw');
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('PDF page down', { env: { 'pdf-view': true } }, function() {

--- a/cypress_test/integration_tests/desktop/draw/pdf_page_up_down_spec.js
+++ b/cypress_test/integration_tests/desktop/draw/pdf_page_up_down_spec.js
@@ -4,11 +4,10 @@ var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
 
 describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'PDF View Tests', function() {
-	var origTestFileName = 'pdf_page_up_down.pdf';
-	var testFileName;
+	var newFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'draw');
+		newFileName = helper.setupAndLoadDocument('draw/pdf_page_up_down.pdf');
 	});
 
 	it('PDF page down', { env: { 'pdf-view': true } }, function() {
@@ -27,11 +26,14 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'PDF View Tests', function(
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
 		cy.cGet('#annotation-content-area-1').should('contain','some text0');
 
-		// Reload to close and save. PDFs cannot really be edited,
+		// Close to test save. PDFs cannot really be edited,
 		// only comments can be inserted, so they are not saved
 		// directly, rather save-as is used. This failed because
 		// DocBroker expected to get ModifiedStatus=false, which
 		// never happens with save-as and so we couldn't unload.
-		helper.reload(testFileName, 'draw', true);
+		helper.closeDocument(newFileName);
+
+		// TODO: verify comment still exists
+		// helper.reloadDocument(newFileName,'draw');
 	});
 });

--- a/cypress_test/integration_tests/desktop/impress/annotation_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/annotation_spec.js
@@ -5,14 +5,12 @@ var helper = require('../../common/helper');
 var { addSlide, changeSlide } = require('../../common/impress_helper');
 
 describe(['tagdesktop'], 'Annotation Tests', function() {
-	var origTestFileName = 'comment_switching.odp';
-	var testFileName;
 
 	beforeEach(function() {
 		// Give more horizontal room so that comments do not fall off the right
 		// side of the screen, causing scrolling or hidden buttons
 		cy.viewport(1500, 600);
-		testFileName = helper.beforeAll(origTestFileName, 'impress');
+		helper.setupAndLoadDocument('impress/comment_switching.odp');
 		desktopHelper.switchUIToNotebookbar();
 
 		if (Cypress.env('INTEGRATION') === 'nextcloud') {
@@ -145,12 +143,10 @@ describe(['tagdesktop'], 'Collapsed Annotation Tests', function() {
 });
 
 describe(['tagdesktop'], 'Comment Scrolling',function() {
-	var origTestFileName = 'comment_switching.odp';
-	var testFileName;
 
 	beforeEach(function() {
 		cy.viewport(1500, 600);
-		testFileName = helper.beforeAll(origTestFileName, 'impress');
+		helper.setupAndLoadDocument('impress/comment_switching.odp');
 		desktopHelper.switchUIToNotebookbar();
 
 		cy.cGet('#options-modify-page').click();

--- a/cypress_test/integration_tests/desktop/impress/annotation_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/annotation_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy require afterEach beforeEach Cypress */
+/* global describe it cy require beforeEach Cypress */
 
 var desktopHelper = require('../../common/desktop_helper');
 var helper = require('../../common/helper');
@@ -21,10 +21,6 @@ describe(['tagdesktop'], 'Annotation Tests', function() {
 
 		cy.cGet('#options-modify-page').click();
 		desktopHelper.selectZoomLevel('50');
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Insert', function() {
@@ -80,10 +76,6 @@ describe(['tagdesktop'], 'Collapsed Annotation Tests', function() {
 
 		cy.cGet('#options-modify-page').click();
 		desktopHelper.selectZoomLevel('50');
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Insert', function() {
@@ -165,10 +157,6 @@ describe(['tagdesktop'], 'Comment Scrolling',function() {
 		desktopHelper.selectZoomLevel('50');
 	});
 
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
-	});
-
 	it('no comment or one comment', function() {
 		cy.cGet('.leaflet-control-scroll-down').should('not.exist');
 		desktopHelper.insertComment();
@@ -225,10 +213,6 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 
 		cy.cGet('#options-modify-page').click();
 		desktopHelper.selectZoomLevel('50');
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Insert autosave', function() {

--- a/cypress_test/integration_tests/desktop/impress/annotation_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/annotation_spec.js
@@ -61,18 +61,19 @@ describe(['tagdesktop'], 'Annotation Tests', function() {
 });
 
 describe(['tagdesktop'], 'Collapsed Annotation Tests', function() {
-	var origTestFileName = 'comment_switching.odp';
-	var testFileName;
+	var newFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'impress');
+		newFileName = helper.setupAndLoadDocument('impress/comment_switching.odp');
 		desktopHelper.switchUIToNotebookbar();
 
 		if (Cypress.env('INTEGRATION') === 'nextcloud') {
 			desktopHelper.hideSidebarIfVisible();
 		}
 
-		cy.cGet('#options-modify-page').click();
+		// TODO: skip sidebar detection on reload
+		// cy.cGet('#options-modify-page').click();
+
 		desktopHelper.selectZoomLevel('50');
 	});
 
@@ -133,8 +134,7 @@ describe(['tagdesktop'], 'Collapsed Annotation Tests', function() {
 		cy.cGet('#map').focus();
 		cy.cGet('.cool-annotation-info-collapsed').should('be.not.visible');
 
-		helper.closeDocument(testFileName, '');
-		helper.beforeAll(testFileName, 'impress', true, false, false, true);
+		helper.reloadDocument(newFileName, 'impress');
 		cy.cGet('.cool-annotation-img').click();
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
 		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
@@ -195,19 +195,19 @@ describe(['tagdesktop'], 'Comment Scrolling',function() {
 });
 
 describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
-	var origTestFileName = 'comment_switching.odp';
-	var testFileName;
+	var newFileName;
 
 	beforeEach(function() {
-		cy.viewport(1500, 600);
-		testFileName = helper.beforeAll(origTestFileName, 'impress');
+		cy.viewport(2400, 600);
+		newFileName = helper.setupAndLoadDocument('impress/comment_switching.odp');
 		desktopHelper.switchUIToNotebookbar();
 
-		if (Cypress.env('INTEGRATION') === 'nextcloud') {
-			desktopHelper.hideSidebarIfVisible();
-		}
+		// TODO: skip sidebar detection on reload
+		// if (Cypress.env('INTEGRATION') === 'nextcloud') {
+			// desktopHelper.hideSidebarIfVisible();
+		// }
+		// cy.cGet('#options-modify-page').click();
 
-		cy.cGet('#options-modify-page').click();
 		desktopHelper.selectZoomLevel('50');
 	});
 
@@ -217,8 +217,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
 		cy.cGet('.cool-annotation-edit.modify-annotation').should('be.visible');
 
-		helper.closeDocument(testFileName);
-		helper.beforeAll(testFileName, 'impress', true, false, false, true);
+		helper.reloadDocument(newFileName,'impress');
 		cy.cGet('.leaflet-marker-icon').should('exist');
 		cy.cGet('.cool-annotation-content > div').should('have.text','some text0');
 	});
@@ -234,8 +233,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('.leaflet-marker-icon').should('exist');
 		cy.cGet('.cool-annotation-content > div').should('have.text','some text0');
 
-		helper.closeDocument(testFileName);
-		helper.beforeAll(testFileName, 'impress', true, false, false, true);
+		helper.reloadDocument(newFileName,'impress');
 		cy.cGet('.leaflet-marker-icon').should('exist');
 		cy.cGet('.cool-annotation-content > div').should('have.text','some text0');
 	});
@@ -251,8 +249,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('.leaflet-marker-icon').should('not.exist');
 		cy.cGet('.cool-annotation-content > div').should('not.exist');
 
-		helper.closeDocument(testFileName);
-		helper.beforeAll(testFileName, 'impress', true, false, false, true);
+		helper.reloadDocument(newFileName,'impress');
 		cy.cGet('.leaflet-marker-icon').should('not.exist');
 		cy.cGet('.cool-annotation-content > div').should('not.exist');
 	});
@@ -268,8 +265,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
 		cy.cGet('.cool-annotation-edit.modify-annotation').should('be.visible');
 
-		helper.closeDocument(testFileName);
-		helper.beforeAll(testFileName, 'impress', true, false, false, true);
+		helper.reloadDocument(newFileName,'impress');
 		cy.cGet('.leaflet-marker-icon').should('exist');
 		cy.cGet('.cool-annotation-content > div').should('have.text','some other text, some text0');
 	});
@@ -288,8 +284,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('#annotation-content-area-1').should('have.text','some other text, some text0');
 		cy.cGet('.leaflet-marker-icon').should('exist');
 
-		helper.closeDocument(testFileName);
-		helper.beforeAll(testFileName, 'impress', true, false, false, true);
+		helper.reloadDocument(newFileName,'impress');
 		cy.cGet('.leaflet-marker-icon').should('exist');
 		cy.cGet('.cool-annotation-content > div').should('have.text','some other text, some text0');
 	});
@@ -308,8 +303,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
 		cy.cGet('.leaflet-marker-icon').should('exist');
 
-		helper.closeDocument(testFileName);
-		helper.beforeAll(testFileName, 'impress', true, false, false, true);
+		helper.reloadDocument(newFileName,'impress');
 		cy.cGet('.leaflet-marker-icon').should('exist');
 		cy.cGet('.cool-annotation-content > div').should('have.text','some text0');
 	});
@@ -327,8 +321,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('#annotation-modify-textarea-1').should('include.text', 'some text0');
 		cy.cGet('#annotation-modify-textarea-1').should('include.text', 'some reply text');
 
-		helper.closeDocument(testFileName);
-		helper.beforeAll(testFileName, 'impress', true, false, false, true);
+		helper.reloadDocument(newFileName,'impress');
 		cy.cGet('.cool-annotation-edit.reply-annotation').should('be.not.visible');
 		cy.cGet('.cool-annotation-content > div').should('include.text','some reply text');
 	});
@@ -351,8 +344,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('.cool-annotation-content > div').should('include.text','some text0');
 		cy.cGet('.cool-annotation-content > div').should('include.text','some reply text');
 
-		helper.closeDocument(testFileName);
-		helper.beforeAll(testFileName, 'impress', true, false, false, true);
+		helper.reloadDocument(newFileName,'impress');
 		cy.cGet('.cool-annotation-edit.reply-annotation').should('be.not.visible');
 		cy.cGet('.cool-annotation-content > div').should('include.text','some reply text');
 	});
@@ -374,8 +366,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('.cool-annotation-edit.reply-annotation').should('be.not.visible');
 		cy.cGet('.cool-annotation-content > div').should('have.text','some text0');
 
-		helper.closeDocument(testFileName);
-		helper.beforeAll(testFileName, 'impress', true, false, false, true);
+		helper.reloadDocument(newFileName,'impress');
 		cy.cGet('.cool-annotation-edit.reply-annotation').should('be.not.visible');
 		cy.cGet('.cool-annotation-content > div').should('have.text','some text0');
 	});

--- a/cypress_test/integration_tests/desktop/impress/apply_paragraph_props_text_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/apply_paragraph_props_text_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach*/
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 var impressHelper = require('../../common/impress_helper');
@@ -14,10 +14,6 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Apply paragraph properties
 		cy.cGet('#toolbar-up > .w2ui-scroll-right').click();
 		cy.cGet('#modifypage').click({force: true});
 		impressHelper.selectTextShapeInTheCenter();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Apply left/right alignment on selected text.', function() {

--- a/cypress_test/integration_tests/desktop/impress/apply_paragraph_props_text_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/apply_paragraph_props_text_spec.js
@@ -5,11 +5,9 @@ var impressHelper = require('../../common/impress_helper');
 const desktopHelper = require('../../common/desktop_helper');
 
 describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Apply paragraph properties on selected shape.', function() {
-	var origTestFileName = 'apply_paragraph_props_text.odp';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'impress');
+		helper.setupAndLoadDocument('impress/apply_paragraph_props_text.odp');
 		desktopHelper.switchUIToCompact();
 		cy.cGet('#toolbar-up > .w2ui-scroll-right').click();
 		cy.cGet('#modifypage').click({force: true});

--- a/cypress_test/integration_tests/desktop/impress/delete_objects_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/delete_objects_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy require afterEach beforeEach expect Cypress */
+/* global describe it cy require beforeEach expect Cypress */
 
 var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
@@ -10,10 +10,6 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Delete Objects', function(
 	beforeEach(function() {
 		testFileName = helper.beforeAll(origTestFileName, 'impress');
 		desktopHelper.switchUIToCompact();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Delete Text', function() {

--- a/cypress_test/integration_tests/desktop/impress/delete_objects_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/delete_objects_spec.js
@@ -4,11 +4,9 @@ var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
 
 describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Delete Objects', function() {
-	var origTestFileName = 'delete_objects.odp';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'impress');
+		helper.setupAndLoadDocument('impress/delete_objects.odp');
 		desktopHelper.switchUIToCompact();
 	});
 

--- a/cypress_test/integration_tests/desktop/impress/editable_area_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/editable_area_spec.js
@@ -29,10 +29,9 @@ function selectTextShape(i) {
 }
 
 describe(['taga11yenabled'], 'Editable area - Basic typing and caret moving', function() {
-    var testFileName = 'two_text_shapes.odp';
 
     beforeEach(function () {
-        helper.beforeAll(testFileName, 'impress');
+        helper.setupAndLoadDocument('impress/two_text_shapes.odp');
         desktopHelper.switchUIToCompact();
         cy.cGet('#toolbar-up > .w2ui-scroll-right').click();
         cy.cGet('#modifypage').click({force: true});

--- a/cypress_test/integration_tests/desktop/impress/editable_area_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/editable_area_spec.js
@@ -1,4 +1,4 @@
-/* global describe expect it cy beforeEach require afterEach Cypress */
+/* global describe expect it cy beforeEach require Cypress */
 
 var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
@@ -37,10 +37,6 @@ describe(['taga11yenabled'], 'Editable area - Basic typing and caret moving', fu
         cy.cGet('#toolbar-up > .w2ui-scroll-right').click();
         cy.cGet('#modifypage').click({force: true});
         cy.cGet('div.clipboard').as('clipboard');
-    });
-
-    afterEach(function () {
-        helper.afterAll(testFileName, this.currentTest.state);
     });
 
     it.skip('Editing top text shape', function () {

--- a/cypress_test/integration_tests/desktop/impress/fullscreen_presentation_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/fullscreen_presentation_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy require afterEach Cypress expect */
+/* global describe it cy require Cypress expect */
 
 var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
@@ -25,10 +25,6 @@ describe.skip(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Fullscreen Presentati
 		cy.cGet('#menu-slide > a').click();
 		cy.cGet('#menu-fullscreen-presentation > a').click();
 	}
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
-	});
 
 	it('Text fields.', function() {
 		before('text_fields.odp');

--- a/cypress_test/integration_tests/desktop/impress/fullscreen_presentation_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/fullscreen_presentation_spec.js
@@ -4,7 +4,6 @@ var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
 
 describe.skip(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Fullscreen Presentation.', function() {
-	var testFileName = 'text_fields.odp';
 
 	function getSlideShowContent() {
 		return cy.cGet().find('.leaflet-slideshow').then(($iframe) =>{
@@ -13,8 +12,7 @@ describe.skip(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Fullscreen Presentati
 	}
 
 	function before(fileName) {
-		testFileName = fileName;
-		helper.beforeAll(testFileName, 'impress');
+		helper.setupAndLoadDocument('impress/' + fileName);
 
 		if (Cypress.env('INTEGRATION') === 'nextcloud') {
 			desktopHelper.hideSidebarIfVisible();

--- a/cypress_test/integration_tests/desktop/impress/image_operation_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/image_operation_spec.js
@@ -6,11 +6,9 @@ var desktopHelper = require('../../common/desktop_helper');
 var { triggerNewSVGForShapeInTheCenter } = require('../../common/impress_helper');
 
 describe(['tagdesktop'], 'Image Operation Tests', function() {
-	var origTestFileName = 'image_operation.odp';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'impress');
+		helper.setupAndLoadDocument('impress/image_operation.odp');
 	});
 
 	it('Insert/Delete image',function() {

--- a/cypress_test/integration_tests/desktop/impress/image_operation_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/image_operation_spec.js
@@ -1,4 +1,4 @@
-/* global describe it require cy afterEach beforeEach */
+/* global describe it require cy beforeEach */
 
 var helper = require('../../common/helper');
 var { insertImage, deleteImage, assertImageSize } = require('../../common/desktop_helper');
@@ -11,10 +11,6 @@ describe(['tagdesktop'], 'Image Operation Tests', function() {
 
 	beforeEach(function() {
 		testFileName = helper.beforeAll(origTestFileName, 'impress');
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Insert/Delete image',function() {

--- a/cypress_test/integration_tests/desktop/impress/jsdialog_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/jsdialog_spec.js
@@ -3,10 +3,9 @@
 var helper = require('../../common/helper');
 
 describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'JSDialog Tests', function() {
-	var testFileName = 'jsdialog.odp';
 
 	beforeEach(function() {
-		helper.beforeAll(testFileName, 'impress');
+		helper.setupAndLoadDocument('impress/jsdialog.odp');
 	});
 
 	it('Check disabled state in animation sidebar', function() {

--- a/cypress_test/integration_tests/desktop/impress/jsdialog_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/jsdialog_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy require afterEach beforeEach */
+/* global describe it cy require beforeEach */
 
 var helper = require('../../common/helper');
 
@@ -7,10 +7,6 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'JSDialog Tests', function(
 
 	beforeEach(function() {
 		helper.beforeAll(testFileName, 'impress');
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Check disabled state in animation sidebar', function() {

--- a/cypress_test/integration_tests/desktop/impress/navigator_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/navigator_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach*/
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
@@ -13,10 +13,6 @@ describe.skip(['tagdesktop'], 'Scroll through document, insert/delete items', fu
 		desktopHelper.selectZoomLevel('100');
 		cy.cGet('#menu-view').click();
 		cy.cGet('#menu-navigator').click();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	function checkIfItemNotExist(itemName) {

--- a/cypress_test/integration_tests/desktop/impress/navigator_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/navigator_spec.js
@@ -4,11 +4,9 @@ var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
 
 describe.skip(['tagdesktop'], 'Scroll through document, insert/delete items', function() {
-	var origTestFileName = 'navigator.odp';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'impress');
+		helper.setupAndLoadDocument('impress/navigator.odp');
 
 		desktopHelper.selectZoomLevel('100');
 		cy.cGet('#menu-view').click();

--- a/cypress_test/integration_tests/desktop/impress/open_different_file_types_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/open_different_file_types_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy require expect afterEach */
+/* global describe it cy require expect */
 var helper = require('../../common/helper');
 const { selectZoomLevel, openReadOnlyFile } = require('../../common/desktop_helper');
 // const { selectTextShapeInTheCenter } = require('../../common/impress_helper');
@@ -18,10 +18,6 @@ describe.skip(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Open different file t
 
 		cy.cGet('#modifypage').click();
 	}
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
-	});
 
 	function assertData() {
 		//select all the content of doc

--- a/cypress_test/integration_tests/desktop/impress/open_different_file_types_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/open_different_file_types_spec.js
@@ -5,12 +5,8 @@ const { selectZoomLevel, openReadOnlyFile } = require('../../common/desktop_help
 
 describe.skip(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Open different file types', function() {
 
-	var testFileName = '';
-
 	function before(filename) {
-		var origTestFileName = filename;
-
-		testFileName = helper.beforeAll(origTestFileName, 'impress');
+		helper.setupAndLoadDocument('impress/' + filename);
 
 		selectZoomLevel('50');
 
@@ -76,15 +72,15 @@ describe.skip(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Open different file t
 	});
 
 	it('Open pot file', { defaultCommandTimeout: 60000 }, function() {
-		testFileName = openReadOnlyFile('impress', 'testfile.pot');
+		openReadOnlyFile('impress', 'testfile.pot');
 	});
 
 	it('Open potx file', { defaultCommandTimeout: 60000 }, function() {
-		testFileName = openReadOnlyFile('impress', 'testfile.potx');
+		openReadOnlyFile('impress', 'testfile.potx');
 	});
 
 	it('Open potm file', { defaultCommandTimeout: 60000 }, function() {
-		testFileName = openReadOnlyFile('impress', 'testfile.potm');
+		openReadOnlyFile('impress', 'testfile.potm');
 	});
 
 	it('Open fodp file', { defaultCommandTimeout: 60000 }, function() {

--- a/cypress_test/integration_tests/desktop/impress/open_different_file_types_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/open_different_file_types_spec.js
@@ -5,8 +5,8 @@ const { selectZoomLevel, openReadOnlyFile } = require('../../common/desktop_help
 
 describe.skip(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Open different file types', function() {
 
-	function before(filename) {
-		helper.setupAndLoadDocument('impress/' + filename);
+	function before(fileName) {
+		helper.setupAndLoadDocument('impress/' + fileName);
 
 		selectZoomLevel('50');
 

--- a/cypress_test/integration_tests/desktop/impress/scrolling_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/scrolling_spec.js
@@ -4,10 +4,9 @@ var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
 
 describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Scroll through document', function() {
-	var testFileName = 'scrolling.odp';
 
 	beforeEach(function() {
-		helper.beforeAll(testFileName, 'impress');
+		helper.setupAndLoadDocument('impress/scrolling.odp');
 		desktopHelper.switchUIToCompact();
 		cy.cGet('#toolbar-up .w2ui-scroll-right').click();
 		cy.cGet('#modifypage').click({force: true});

--- a/cypress_test/integration_tests/desktop/impress/scrolling_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/scrolling_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach expect */
+/* global describe it cy beforeEach require expect */
 
 var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
@@ -12,10 +12,6 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Scroll through document', 
 		cy.cGet('#toolbar-up .w2ui-scroll-right').click();
 		cy.cGet('#modifypage').click({force: true});
 		desktopHelper.selectZoomLevel('200');
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	function clickOnTheCenter() {

--- a/cypress_test/integration_tests/desktop/impress/searchbar_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/searchbar_spec.js
@@ -4,11 +4,9 @@ var helper = require('../../common/helper');
 var searchHelper = require('../../common/search_helper');
 
 describe.skip(['tagdesktop'], 'Searching via search bar' ,function() {
-	var origTestFileName = 'search_bar.odp';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'impress');
+		helper.setupAndLoadDocument('impress/search_bar.odp');
 	});
 
 	it('Search existing word.', function() {

--- a/cypress_test/integration_tests/desktop/impress/searchbar_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/searchbar_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy expect beforeEach require afterEach*/
+/* global describe it cy expect beforeEach require */
 
 var helper = require('../../common/helper');
 var searchHelper = require('../../common/search_helper');
@@ -9,10 +9,6 @@ describe.skip(['tagdesktop'], 'Searching via search bar' ,function() {
 
 	beforeEach(function() {
 		testFileName = helper.beforeAll(origTestFileName, 'impress');
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Search existing word.', function() {

--- a/cypress_test/integration_tests/desktop/impress/sidebar_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/sidebar_spec.js
@@ -5,10 +5,9 @@ var impressHelper = require('../../common/impress_helper');
 const desktopHelper = require('../../common/desktop_helper');
 
 describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Sidebar Tests', function() {
-	var testFileName = 'sidebar.odp';
 
 	beforeEach(function() {
-		helper.beforeAll(testFileName, 'impress');
+		helper.setupAndLoadDocument('impress/sidebar.odp');
 		desktopHelper.switchUIToCompact();
 	});
 

--- a/cypress_test/integration_tests/desktop/impress/sidebar_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/sidebar_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy require afterEach beforeEach */
+/* global describe it cy require beforeEach */
 
 var helper = require('../../common/helper');
 var impressHelper = require('../../common/impress_helper');
@@ -10,10 +10,6 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Sidebar Tests', function()
 	beforeEach(function() {
 		helper.beforeAll(testFileName, 'impress');
 		desktopHelper.switchUIToCompact();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it.skip('Switch to slide transition Deck', function() {

--- a/cypress_test/integration_tests/desktop/impress/slide_operations_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/slide_operations_spec.js
@@ -1,5 +1,5 @@
 /* -*- js-indent-level: 8 -*- */
-/* global describe it cy require expect afterEach beforeEach*/
+/* global describe it cy require expect beforeEach*/
 
 var helper = require('../../common/helper');
 var impressHelper = require('../../common/impress_helper');
@@ -12,10 +12,6 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Slide operations', functio
 	beforeEach(function() {
 		testFileName = helper.beforeAll(origTestFileName, 'impress');
 		desktopHelper.switchUIToNotebookbar();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Add slides', function() {

--- a/cypress_test/integration_tests/desktop/impress/slide_operations_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/slide_operations_spec.js
@@ -6,11 +6,9 @@ var impressHelper = require('../../common/impress_helper');
 var desktopHelper = require('../../common/desktop_helper');
 
 describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Slide operations', function() {
-	var origTestFileName = 'slide_operations.odp';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'impress');
+		helper.setupAndLoadDocument('impress/slide_operations.odp');
 		desktopHelper.switchUIToNotebookbar();
 	});
 

--- a/cypress_test/integration_tests/desktop/impress/statusbar_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/statusbar_spec.js
@@ -4,11 +4,9 @@ var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
 
 describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Statubar tests.', function() {
-	var origTestFileName = 'statusbar.odp';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'impress');
+		helper.setupAndLoadDocument('impress/statusbar.odp');
 
 		if (Cypress.env('INTEGRATION') === 'nextcloud') {
 			desktopHelper.showStatusBarIfHidden ();

--- a/cypress_test/integration_tests/desktop/impress/statusbar_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/statusbar_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach Cypress */
+/* global describe it cy beforeEach require Cypress */
 
 var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
@@ -13,10 +13,6 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Statubar tests.', function
 		if (Cypress.env('INTEGRATION') === 'nextcloud') {
 			desktopHelper.showStatusBarIfHidden ();
 		}
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Selected slide.', function() {

--- a/cypress_test/integration_tests/desktop/impress/table_operation_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/table_operation_spec.js
@@ -1,4 +1,4 @@
-/* global describe  cy beforeEach it expect require afterEach  */
+/* global describe  cy beforeEach it expect require */
 
 var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
@@ -11,10 +11,6 @@ describe(['tagdesktop'], 'Table operations', function() {
 	beforeEach(function() {
 		testFileName = helper.beforeAll(origTestFileName, 'impress');
 		desktopHelper.selectZoomLevel('50');
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	function selectOptionNotebookbar(optionId) {

--- a/cypress_test/integration_tests/desktop/impress/table_operation_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/table_operation_spec.js
@@ -5,11 +5,9 @@ var desktopHelper = require('../../common/desktop_helper');
 var impressHelper = require('../../common/impress_helper');
 
 describe(['tagdesktop'], 'Table operations', function() {
-	var origTestFileName = 'table_operation.odp';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'impress');
+		helper.setupAndLoadDocument('impress/table_operation.odp');
 		desktopHelper.selectZoomLevel('50');
 	});
 

--- a/cypress_test/integration_tests/desktop/impress/top_toolbar_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/top_toolbar_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach Cypress */
+/* global describe it cy beforeEach require Cypress */
 
 var helper = require('../../common/helper');
 var impressHelper = require('../../common/impress_helper');
@@ -17,10 +17,6 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Top toolbar tests.', funct
 		} else {
 			desktopHelper.hideSidebarImpress();
 		}
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Apply bold on text shape.', function() {

--- a/cypress_test/integration_tests/desktop/impress/top_toolbar_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/top_toolbar_spec.js
@@ -5,11 +5,9 @@ var impressHelper = require('../../common/impress_helper');
 var desktopHelper = require('../../common/desktop_helper');
 
 describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Top toolbar tests.', function() {
-	var origTestFileName = 'top_toolbar.odp';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'impress');
+		helper.setupAndLoadDocument('impress/top_toolbar.odp');
 		desktopHelper.switchUIToCompact();
 
 		if (Cypress.env('INTEGRATION') === 'nextcloud') {

--- a/cypress_test/integration_tests/desktop/impress/undo_redo_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/undo_redo_spec.js
@@ -1,4 +1,4 @@
-/* global describe it beforeEach require afterEach*/
+/* global describe it beforeEach require */
 
 var helper = require('../../common/helper');
 var impressHelper = require('../../common/impress_helper');
@@ -14,10 +14,6 @@ describe(['tagdesktop'], 'Editing Operations', function() {
 		desktopHelper.selectZoomLevel('30');
 		impressHelper.selectTextShapeInTheCenter();
 		impressHelper.selectTextOfShape(false);
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	function undo() {

--- a/cypress_test/integration_tests/desktop/impress/undo_redo_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/undo_redo_spec.js
@@ -6,10 +6,9 @@ var desktopHelper = require('../../common/desktop_helper');
 var repairHelper = require('../../common/repair_document_helper');
 
 describe(['tagdesktop'], 'Editing Operations', function() {
-	var testFileName = 'undo_redo.odp';
 
 	beforeEach(function() {
-		helper.beforeAll(testFileName, 'impress');
+		helper.setupAndLoadDocument('impress/undo_redo.odp');
 		desktopHelper.switchUIToCompact();
 		desktopHelper.selectZoomLevel('30');
 		impressHelper.selectTextShapeInTheCenter();

--- a/cypress_test/integration_tests/desktop/writer/annotation_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/annotation_spec.js
@@ -5,12 +5,10 @@ var { selectZoomLevel } = require('../../common/desktop_helper');
 var desktopHelper = require('../../common/desktop_helper');
 
 describe(['tagdesktop'], 'Annotation Tests', function() {
-	var origTestFileName = 'annotation.odt';
-	var testFileName;
 
 	beforeEach(function() {
 		cy.viewport(1400, 600);
-		testFileName = helper.beforeAll(origTestFileName, 'writer');
+		helper.setupAndLoadDocument('writer/annotation.odt');
 		desktopHelper.switchUIToNotebookbar();
 		cy.cGet('#optionscontainer div[id$="SidebarDeck.PropertyDeck"]').click(); // Hide sidebar.
 		selectZoomLevel('50');

--- a/cypress_test/integration_tests/desktop/writer/annotation_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/annotation_spec.js
@@ -59,13 +59,14 @@ describe(['tagdesktop'], 'Annotation Tests', function() {
 });
 
 describe(['tagdesktop'], 'Collapsed Annotation Tests', function() {
-	var origTestFileName = 'annotation.odt';
-	var testFileName;
+	var newFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'writer');
+		newFileName = helper.setupAndLoadDocument('writer/annotation.odt');
 		desktopHelper.switchUIToNotebookbar();
-		cy.cGet('#optionscontainer div[id$="SidebarDeck.PropertyDeck"]').click(); // Hide sidebar.
+
+		// TODO: skip sidebar detection on reload
+		// cy.cGet('#optionscontainer div[id$="SidebarDeck.PropertyDeck"]').click(); // Hide sidebar.
 	});
 
 	it('Insert', function() {
@@ -131,8 +132,7 @@ describe(['tagdesktop'], 'Collapsed Annotation Tests', function() {
 		helper.typeIntoDocument('{home}');
 		cy.cGet('.cool-annotation-info-collapsed').should('be.not.visible');
 
-		helper.closeDocument(testFileName, '');
-		helper.beforeAll(testFileName, 'writer', true, false, false, true);
+		helper.reloadDocument(newFileName,'writer');
 		cy.cGet('#optionscontainer div[id$="SidebarDeck.PropertyDeck"]').click(); // show sidebar.
 		cy.cGet('.cool-annotation-img').click();
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
@@ -143,16 +143,15 @@ describe(['tagdesktop'], 'Collapsed Annotation Tests', function() {
 });
 
 describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
-	var origTestFileName = 'annotation.odt';
-	var testFileName;
+	var newFileName;
 
 	beforeEach(function() {
 		cy.viewport(1400, 600);
-		testFileName = helper.beforeAll(origTestFileName, 'writer');
+		newFileName = helper.setupAndLoadDocument('writer/annotation.odt');
 		desktopHelper.switchUIToNotebookbar();
-		cy.cGet('#optionscontainer div[id$="SidebarDeck.PropertyDeck"]').click(); // Hide sidebar.
+		// TODO: skip sidebar detection on reload
+		//cy.cGet('#optionscontainer div[id$="SidebarDeck.PropertyDeck"]').click(); // Hide sidebar.
 		selectZoomLevel('50');
-
 	});
 
 	it('Insert autosave', function() {
@@ -161,8 +160,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
 		cy.cGet('.cool-annotation-edit.modify-annotation').should('be.visible');
 
-		helper.closeDocument(testFileName);
-		helper.beforeAll(testFileName, 'writer', true, false, false, true);
+		helper.reloadDocument(newFileName,'writer');
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
 		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
 	});
@@ -176,8 +174,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
 		cy.cGet('.cool-annotation-autosavelabel').should('be.not.visible');
 
-		helper.closeDocument(testFileName);
-		helper.beforeAll(testFileName, 'writer', true, false, false, true);
+		helper.reloadDocument(newFileName,'writer');
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
 		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
 	});
@@ -191,8 +188,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('#comment-container-1').should('not.exist');
 		cy.cGet('.cool-annotation-autosavelabel').should('not.exist');
 
-		helper.closeDocument(testFileName);
-		helper.beforeAll(testFileName, 'writer', true, false, false, true);
+		helper.reloadDocument(newFileName,'writer');
 		cy.cGet('.cool-annotation-content-wrapper').should('not.exist');
 		cy.cGet('#comment-container-1').should('not.exist');
 	});
@@ -209,8 +205,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
 		cy.cGet('.cool-annotation-edit.modify-annotation').should('be.visible');
 
-		helper.closeDocument(testFileName);
-		helper.beforeAll(testFileName, 'writer', true, false, false, true);
+		helper.reloadDocument(newFileName,'writer');
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
 		cy.cGet('#annotation-content-area-1').should('have.text','some other text, some text0');
 	});
@@ -230,8 +225,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('#annotation-content-area-1').should('have.text','some other text, some text0');
 		cy.cGet('.cool-annotation-autosavelabel').should('be.not.visible');
 
-		helper.closeDocument(testFileName);
-		helper.beforeAll(testFileName, 'writer', true, false, false, true);
+		helper.reloadDocument(newFileName,'writer');
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
 		cy.cGet('#annotation-content-area-1').should('have.text','some other text, some text0');
 	});
@@ -252,8 +246,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('.cool-annotation-autosavelabel').should('be.not.visible');
 		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
 
-		helper.closeDocument(testFileName);
-		helper.beforeAll(testFileName, 'writer', true, false, false, true);
+		helper.reloadDocument(newFileName,'writer');
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
 		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
 	});
@@ -270,8 +263,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
 		cy.cGet('#annotation-modify-textarea-2').should('be.visible');
 
-		helper.closeDocument(testFileName);
-		helper.beforeAll(testFileName, 'writer', true, false, false, true);
+		helper.reloadDocument(newFileName,'writer');
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
 		cy.cGet('#annotation-content-area-2').should('have.text','some reply text');
 	});
@@ -294,8 +286,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
 		cy.cGet('#annotation-content-area-2').should('have.text','some reply text');
 
-		helper.closeDocument(testFileName);
-		helper.beforeAll(testFileName, 'writer', true, false, false, true);
+		helper.reloadDocument(newFileName,'writer');
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
 		cy.cGet('#annotation-content-area-2').should('have.text','some reply text');
 	});
@@ -320,8 +311,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('#comment-container-1 .cool-annotation-autosavelabel').should('be.not.visible');
 		cy.cGet('#comment-container-2 .cool-annotation-autosavelabel').should('not.exist');
 
-		helper.closeDocument(testFileName);
-		helper.beforeAll(testFileName, 'writer', true, false, false, true);
+		helper.reloadDocument(newFileName,'writer');
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
 		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
 		cy.cGet('#annotation-content-area-2').should('not.exist');

--- a/cypress_test/integration_tests/desktop/writer/annotation_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/annotation_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy require afterEach beforeEach */
+/* global describe it cy require beforeEach */
 
 var helper = require('../../common/helper');
 var { selectZoomLevel } = require('../../common/desktop_helper');
@@ -14,10 +14,6 @@ describe(['tagdesktop'], 'Annotation Tests', function() {
 		desktopHelper.switchUIToNotebookbar();
 		cy.cGet('#optionscontainer div[id$="SidebarDeck.PropertyDeck"]').click(); // Hide sidebar.
 		selectZoomLevel('50');
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Insert', function() {
@@ -72,10 +68,6 @@ describe(['tagdesktop'], 'Collapsed Annotation Tests', function() {
 		testFileName = helper.beforeAll(origTestFileName, 'writer');
 		desktopHelper.switchUIToNotebookbar();
 		cy.cGet('#optionscontainer div[id$="SidebarDeck.PropertyDeck"]').click(); // Hide sidebar.
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Insert', function() {
@@ -163,10 +155,6 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('#optionscontainer div[id$="SidebarDeck.PropertyDeck"]').click(); // Hide sidebar.
 		selectZoomLevel('50');
 
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Insert autosave', function() {

--- a/cypress_test/integration_tests/desktop/writer/complex_image_operation_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/complex_image_operation_spec.js
@@ -3,12 +3,10 @@
 var helper = require('../../common/helper');
 
 describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Complex image operation test', function() {
-	var origTestFileName = 'complex_image_operation.odt';
-	var testFileName;
 
 	beforeEach(function() {
 		localStorage.setItem('image_validation_test', true);
-		testFileName = helper.beforeAll(origTestFileName, 'writer');
+		helper.setupAndLoadDocument('writer/complex_image_operation.odt');
 	});
 
 	it('tile image validation test',function() {

--- a/cypress_test/integration_tests/desktop/writer/complex_image_operation_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/complex_image_operation_spec.js
@@ -1,4 +1,4 @@
-/* global cy expect describe it require afterEach beforeEach */
+/* global cy expect describe it require beforeEach */
 
 var helper = require('../../common/helper');
 
@@ -9,10 +9,6 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Complex image operation te
 	beforeEach(function() {
 		localStorage.setItem('image_validation_test', true);
 		testFileName = helper.beforeAll(origTestFileName, 'writer');
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('tile image validation test',function() {

--- a/cypress_test/integration_tests/desktop/writer/copy_paste_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/copy_paste_spec.js
@@ -3,14 +3,9 @@
 var helper = require('../../common/helper');
 
 describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Clipboard operations.', function() {
-	var testFileName;
-
-	function before(filename) {
-		testFileName = helper.beforeAll(filename, 'writer');
-	}
 
 	it('Copy and Paste text.', function() {
-		before('copy_paste.odt');
+		helper.setupAndLoadDocument('writer/copy_paste.odt');
 		// Select some text
 		helper.selectAllText();
 
@@ -32,7 +27,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Clipboard operations.', fu
 	});
 
 	it('Copy plain text.', function() {
-		before('copy_paste_simple.odt');
+		helper.setupAndLoadDocument('writer/copy_paste_simple.odt');
 
 		helper.setDummyClipboardForCopy('text/plain');
 		helper.selectAllText();

--- a/cypress_test/integration_tests/desktop/writer/copy_paste_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/copy_paste_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy require expect afterEach*/
+/* global describe it cy require expect */
 
 var helper = require('../../common/helper');
 
@@ -8,10 +8,6 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Clipboard operations.', fu
 	function before(filename) {
 		testFileName = helper.beforeAll(filename, 'writer');
 	}
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
-	});
 
 	it('Copy and Paste text.', function() {
 		before('copy_paste.odt');

--- a/cypress_test/integration_tests/desktop/writer/editable_area_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/editable_area_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach */
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
@@ -11,10 +11,6 @@ describe(['taga11ydisabled'], 'Editable area [a11y disabled] - Empty paragraph',
 	beforeEach(function () {
 		helper.beforeAll(testFileName, 'writer');
 		cy.cGet('div.clipboard').as('clipboard');
-	});
-
-	afterEach(function () {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Typing in an empty paragraph', function () {
@@ -53,10 +49,6 @@ describe(['taga11ydisabled'], 'Editable area [a11y disabled] - Basic typing', fu
 	beforeEach(function () {
 		helper.beforeAll(testFileName, 'writer');
 		cy.cGet('div.clipboard').as('clipboard');
-	});
-
-	afterEach(function () {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Typing at paragraph beginning', function () {
@@ -135,10 +127,6 @@ describe(['taga11yenabled'], 'Editable area - Empty paragraph', function() {
 		cy.cGet('div.clipboard').as('clipboard');
 	});
 
-	afterEach(function () {
-		helper.afterAll(testFileName, this.currentTest.state);
-	});
-
 	it('Typing in an empty paragraph', function () {
 		// initial position
 		ceHelper.checkHTMLContent('');
@@ -180,10 +168,6 @@ describe(['taga11yenabled'], 'Editable area - Basic typing and caret moving', fu
 	beforeEach(function () {
 		helper.beforeAll(testFileName, 'writer');
 		cy.cGet('div.clipboard').as('clipboard');
-	});
-
-	afterEach(function () {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Moving inside paragraph', function () {
@@ -498,10 +482,6 @@ describe(['taga11yenabled'], 'Editable area - Inner selection', function() {
 		cy.cGet('div.clipboard').as('clipboard');
 	});
 
-	afterEach(function () {
-		helper.afterAll(testFileName, this.currentTest.state);
-	});
-
 	it('Selecting inside paragraph', function () {
 		ceHelper.type('Hello World');
 		ceHelper.checkPlainContent('Hello World');
@@ -657,10 +637,6 @@ describe(['taga11yenabled'], 'Editable area - Multi-paragraph selection', functi
 		cy.cGet('div.clipboard').as('clipboard');
 	});
 
-	afterEach(function () {
-		helper.afterAll(testFileName, this.currentTest.state);
-	});
-
 	it('Selection starts in previous paragraph', function () {
 		ceHelper.type('Hello World');
 		ceHelper.type('{enter}');
@@ -812,10 +788,6 @@ describe(['taga11yenabled'], 'Editable area - Empty selection', function() {
 		cy.cGet('div.clipboard').as('clipboard');
 	});
 
-	afterEach(function () {
-		helper.afterAll(testFileName, this.currentTest.state);
-	});
-
 	it('Typing <backspace> with empty selection', function () {
 		ceHelper.type('Green red');
 		ceHelper.checkPlainContent('Green red');
@@ -898,10 +870,6 @@ describe(['taga11yenabled'], 'Editable area - Undo/Redo', function() {
 		cy.cGet('div.clipboard').as('clipboard');
 	});
 
-	afterEach(function () {
-		helper.afterAll(testFileName, this.currentTest.state);
-	});
-
 	it('Undo/Redo after typing', function () {
 		ceHelper.type('Hello World');
 		ceHelper.checkPlainContent('Hello World');
@@ -976,10 +944,6 @@ describe(['taga11yenabled'], 'Editable area - More typing', function() {
 	beforeEach(function() {
 		helper.beforeAll(testFileName, 'writer');
 		cy.cGet('div.clipboard').as('clipboard');
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Typing after undo command', function() {
@@ -1068,10 +1032,6 @@ describe(['taga11yenabled'], 'Editable area - Unordered lists', function() {
 	beforeEach(function () {
 		helper.beforeAll(testFileName, 'writer');
 		cy.cGet('div.clipboard').as('clipboard');
-	});
-
-	afterEach(function () {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Check content', function () {
@@ -1256,10 +1216,6 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Editing - Basic typing', f
 	beforeEach(function () {
 		helper.beforeAll(testFileName, 'writer');
 		cy.cGet('div.clipboard').as('clipboard');
-	});
-
-	afterEach(function () {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	function selectAndCheckText(upTo, expectedText) {

--- a/cypress_test/integration_tests/desktop/writer/editable_area_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/editable_area_spec.js
@@ -6,10 +6,9 @@ var ceHelper = require('../../common/contenteditable_helper');
 // var repairHelper = require('../../common/repair_document_helper');
 
 describe(['taga11ydisabled'], 'Editable area [a11y disabled] - Empty paragraph', function() {
-	var testFileName = 'undo_redo.odt';
 
 	beforeEach(function () {
-		helper.beforeAll(testFileName, 'writer');
+		helper.setupAndLoadDocument('writer/undo_redo.odt');
 		cy.cGet('div.clipboard').as('clipboard');
 	});
 
@@ -44,10 +43,9 @@ describe(['taga11ydisabled'], 'Editable area [a11y disabled] - Empty paragraph',
 });
 
 describe(['taga11ydisabled'], 'Editable area [a11y disabled] - Basic typing', function() {
-	var testFileName = 'undo_redo.odt';
 
 	beforeEach(function () {
-		helper.beforeAll(testFileName, 'writer');
+		helper.setupAndLoadDocument('writer/undo_redo.odt');
 		cy.cGet('div.clipboard').as('clipboard');
 	});
 
@@ -120,10 +118,9 @@ describe(['taga11ydisabled'], 'Editable area [a11y disabled] - Basic typing', fu
 });
 
 describe(['taga11yenabled'], 'Editable area - Empty paragraph', function() {
-	var testFileName = 'undo_redo.odt';
 
 	beforeEach(function () {
-		helper.beforeAll(testFileName, 'writer');
+		helper.setupAndLoadDocument('writer/undo_redo.odt');
 		cy.cGet('div.clipboard').as('clipboard');
 	});
 
@@ -163,10 +160,9 @@ describe(['taga11yenabled'], 'Editable area - Empty paragraph', function() {
 });
 
 describe(['taga11yenabled'], 'Editable area - Basic typing and caret moving', function() {
-	var testFileName = 'undo_redo.odt';
 
 	beforeEach(function () {
-		helper.beforeAll(testFileName, 'writer');
+		helper.setupAndLoadDocument('writer/undo_redo.odt');
 		cy.cGet('div.clipboard').as('clipboard');
 	});
 
@@ -475,10 +471,9 @@ describe(['taga11yenabled'], 'Editable area - Basic typing and caret moving', fu
 });
 
 describe(['taga11yenabled'], 'Editable area - Inner selection', function() {
-	var testFileName = 'undo_redo.odt';
 
 	beforeEach(function () {
-		helper.beforeAll(testFileName, 'writer');
+		helper.setupAndLoadDocument('writer/undo_redo.odt');
 		cy.cGet('div.clipboard').as('clipboard');
 	});
 
@@ -630,10 +625,9 @@ describe(['taga11yenabled'], 'Editable area - Inner selection', function() {
 });
 
 describe(['taga11yenabled'], 'Editable area - Multi-paragraph selection', function() {
-	var testFileName = 'undo_redo.odt';
 
 	beforeEach(function () {
-		helper.beforeAll(testFileName, 'writer');
+		helper.setupAndLoadDocument('writer/undo_redo.odt');
 		cy.cGet('div.clipboard').as('clipboard');
 	});
 
@@ -781,10 +775,9 @@ describe(['taga11yenabled'], 'Editable area - Multi-paragraph selection', functi
 });
 
 describe(['taga11yenabled'], 'Editable area - Empty selection', function() {
-	var testFileName = 'undo_redo.odt';
 
 	beforeEach(function () {
-		helper.beforeAll(testFileName, 'writer');
+		helper.setupAndLoadDocument('writer/undo_redo.odt');
 		cy.cGet('div.clipboard').as('clipboard');
 	});
 
@@ -863,10 +856,9 @@ describe(['taga11yenabled'], 'Editable area - Empty selection', function() {
 });
 
 describe(['taga11yenabled'], 'Editable area - Undo/Redo', function() {
-	var testFileName = 'undo_redo.odt';
 
 	beforeEach(function () {
-		helper.beforeAll(testFileName, 'writer');
+		helper.setupAndLoadDocument('writer/undo_redo.odt');
 		cy.cGet('div.clipboard').as('clipboard');
 	});
 
@@ -939,10 +931,9 @@ describe(['taga11yenabled'], 'Editable area - Undo/Redo', function() {
 });
 
 describe(['taga11yenabled'], 'Editable area - More typing', function() {
-	var testFileName = 'undo_redo.odt';
 
 	beforeEach(function() {
-		helper.beforeAll(testFileName, 'writer');
+		helper.setupAndLoadDocument('writer/undo_redo.odt');
 		cy.cGet('div.clipboard').as('clipboard');
 	});
 
@@ -1027,10 +1018,9 @@ describe(['taga11yenabled'], 'Editable area - More typing', function() {
 // • Item 2
 // • Item 3
 describe(['taga11yenabled'], 'Editable area - Unordered lists', function() {
-	var testFileName = 'unordered_list.odt';
 
 	beforeEach(function () {
-		helper.beforeAll(testFileName, 'writer');
+		helper.setupAndLoadDocument('writer/unordered_list.odt');
 		cy.cGet('div.clipboard').as('clipboard');
 	});
 
@@ -1211,10 +1201,9 @@ describe(['taga11yenabled'], 'Editable area - Unordered lists', function() {
 });
 
 describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Editing - Basic typing', function() {
-	var testFileName = 'undo_redo.odt';
 
 	beforeEach(function () {
-		helper.beforeAll(testFileName, 'writer');
+		helper.setupAndLoadDocument('writer/undo_redo.odt');
 		cy.cGet('div.clipboard').as('clipboard');
 	});
 

--- a/cypress_test/integration_tests/desktop/writer/file_properties_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/file_properties_spec.js
@@ -5,11 +5,9 @@ var writerHelper = require('../../common/writer_helper');
 const desktopHelper = require('../../common/desktop_helper');
 
 describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'File Property Tests', function() {
-	var origTestFileName = 'file_properties.odt';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'writer');
+		helper.setupAndLoadDocument('writer/file_properties.odt');
 		desktopHelper.switchUIToNotebookbar();
 	});
 

--- a/cypress_test/integration_tests/desktop/writer/file_properties_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/file_properties_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach */
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 var writerHelper = require('../../common/writer_helper');
@@ -11,10 +11,6 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'File Property Tests', func
 	beforeEach(function() {
 		testFileName = helper.beforeAll(origTestFileName, 'writer');
 		desktopHelper.switchUIToNotebookbar();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Add File Description.', function() {

--- a/cypress_test/integration_tests/desktop/writer/focus_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/focus_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach */
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 const desktopHelper = require('../../common/desktop_helper');
@@ -10,10 +10,6 @@ describe(['tagdesktop', 'tagproxy'], 'Focus tests', function() {
 	beforeEach(function() {
 		testFileName = helper.beforeAll(origTestFileName, 'writer');
 		desktopHelper.switchUIToCompact();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Basic document focus.', function() {

--- a/cypress_test/integration_tests/desktop/writer/focus_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/focus_spec.js
@@ -4,11 +4,9 @@ var helper = require('../../common/helper');
 const desktopHelper = require('../../common/desktop_helper');
 
 describe(['tagdesktop', 'tagproxy'], 'Focus tests', function() {
-	var origTestFileName = 'focus.odt';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'writer');
+		helper.setupAndLoadDocument('writer/focus.odt');
 		desktopHelper.switchUIToCompact();
 	});
 

--- a/cypress_test/integration_tests/desktop/writer/form_field_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/form_field_spec.js
@@ -4,10 +4,9 @@ var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
 
 describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Form field button tests.', function() {
-	var testFileName = 'shape_operations.odt';
 
 	function before(fileName) {
-		testFileName = helper.beforeAll(fileName, 'writer');
+		helper.setupAndLoadDocument('writer/' + fileName);
 
 		if (Cypress.env('INTEGRATION') === 'nextcloud') {
 			desktopHelper.showStatusBarIfHidden();

--- a/cypress_test/integration_tests/desktop/writer/form_field_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/form_field_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy require afterEach expect Cypress */
+/* global describe it cy require expect Cypress */
 
 var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
@@ -19,10 +19,6 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Form field button tests.',
 		cy.cGet('.blinking-cursor')
 			.should('be.visible');
 	}
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
-	});
-
 	function buttonShouldNotExist() {
 		cy.cGet('.form-field-frame').should('not.exist');
 		cy.cGet('.form-field-button').should('not.exist');

--- a/cypress_test/integration_tests/desktop/writer/help_dialog_update_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/help_dialog_update_spec.js
@@ -4,7 +4,7 @@
 // UPDATE_SCREENSHOT needs to be true otherwise cypress will not run the spec file and
 // update the screenshot
 
-/* global describe it cy require afterEach beforeEach Cypress*/
+/* global describe it cy require beforeEach Cypress*/
 
 const { hideSidebar } = require('../../common/desktop_helper');
 var helper = require('../../common/helper');
@@ -13,10 +13,6 @@ describe(['tagscreenshot'], 'Help dialog screenshot updation', function() {
 
 	beforeEach(function() {
 		helper.beforeAll(testFileName, 'writer');
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	function copyScreenshot(fileName) {

--- a/cypress_test/integration_tests/desktop/writer/help_dialog_update_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/help_dialog_update_spec.js
@@ -9,10 +9,9 @@
 const { hideSidebar } = require('../../common/desktop_helper');
 var helper = require('../../common/helper');
 describe(['tagscreenshot'], 'Help dialog screenshot updation', function() {
-	var testFileName = 'help_dialog.odt';
 
 	beforeEach(function() {
-		helper.beforeAll(testFileName, 'writer');
+		helper.setupAndLoadDocument('writer/help_dialog.odt');
 	});
 
 	function copyScreenshot(fileName) {

--- a/cypress_test/integration_tests/desktop/writer/image_operation_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/image_operation_spec.js
@@ -1,4 +1,4 @@
-/* global describe it require cy afterEach beforeEach */
+/* global describe it require cy beforeEach */
 
 var helper = require('../../common/helper');
 var { insertImage, deleteImage, assertImageSize } = require('../../common/desktop_helper');
@@ -11,10 +11,6 @@ describe(['tagdesktop'], 'Image Operation Tests', function() {
 	beforeEach(function() {
 		testFileName = helper.beforeAll(origTestFileName, 'writer');
 		desktopHelper.switchUIToNotebookbar();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Insert Image',function() {

--- a/cypress_test/integration_tests/desktop/writer/image_operation_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/image_operation_spec.js
@@ -5,11 +5,9 @@ var { insertImage, deleteImage, assertImageSize } = require('../../common/deskto
 var desktopHelper = require('../../common/desktop_helper');
 
 describe(['tagdesktop'], 'Image Operation Tests', function() {
-	var origTestFileName = 'image_operation.odt';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'writer');
+		helper.setupAndLoadDocument('writer/image_operation.odt');
 		desktopHelper.switchUIToNotebookbar();
 	});
 

--- a/cypress_test/integration_tests/desktop/writer/invalidations_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/invalidations_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach expect require afterEach*/
+/* global describe it cy beforeEach expect require */
 
 var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
@@ -13,10 +13,6 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Invalidation tests.', func
 		testFileName = helper.beforeAll(origTestFileName, 'writer');
 		desktopHelper.switchUIToNotebookbar();
 		cy.cGet('div.clipboard').as('clipboard');
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	// Clicking in an empty header area shouldn't invalidate anything

--- a/cypress_test/integration_tests/desktop/writer/invalidations_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/invalidations_spec.js
@@ -6,11 +6,9 @@ var ceHelper = require('../../common/contenteditable_helper');
 var writerHelper = require('../../common/writer_helper');
 
 describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Invalidation tests.', function() {
-	var origTestFileName = 'invalidations.odt';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'writer');
+		helper.setupAndLoadDocument('writer/invalidations.odt');
 		desktopHelper.switchUIToNotebookbar();
 		cy.cGet('div.clipboard').as('clipboard');
 	});

--- a/cypress_test/integration_tests/desktop/writer/navigator_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/navigator_spec.js
@@ -4,10 +4,9 @@ var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
 
 describe.skip(['tagdesktop'], 'Scroll through document, modify heading', function() {
-	var testFileName = 'navigator.odt';
 
 	beforeEach(function() {
-		helper.beforeAll(testFileName, 'writer');
+		helper.setupAndLoadDocument('writer/navigator.odt');
 
 		cy.cGet('#menu-view').click();
 		cy.cGet('#menu-navigator').click();

--- a/cypress_test/integration_tests/desktop/writer/navigator_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/navigator_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach */
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
@@ -11,10 +11,6 @@ describe.skip(['tagdesktop'], 'Scroll through document, modify heading', functio
 
 		cy.cGet('#menu-view').click();
 		cy.cGet('#menu-navigator').click();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Jump to element. Navigator -> Document', function() {

--- a/cypress_test/integration_tests/desktop/writer/notebookbar_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/notebookbar_spec.js
@@ -5,11 +5,9 @@ var desktopHelper = require('../../common/desktop_helper');
 var writerHelper = require('../../common/writer_helper');
 
 describe(['tagdesktop'], 'Notebookbar tests.', function() {
-	var origTestFileName = 'notebookbar.odt';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'writer');
+		helper.setupAndLoadDocument('writer/notebookbar.odt');
 		desktopHelper.switchUIToNotebookbar();
 
 		if (Cypress.env('INTEGRATION') === 'nextcloud') {

--- a/cypress_test/integration_tests/desktop/writer/notebookbar_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/notebookbar_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach Cypress */
+/* global describe it cy beforeEach require Cypress */
 
 var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
@@ -17,10 +17,6 @@ describe(['tagdesktop'], 'Notebookbar tests.', function() {
 		}
 
 		writerHelper.selectAllTextOfDoc();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Apply bold font from dropdown in Format tab', function() {

--- a/cypress_test/integration_tests/desktop/writer/open_different_file_types_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/open_different_file_types_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy require afterEach */
+/* global describe it cy require */
 const { assertImageSize, openReadOnlyFile } = require('../../common/desktop_helper');
 var helper = require('../../common/helper');
 
@@ -11,10 +11,6 @@ describe.skip(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Open different file t
 
 		testFileName = helper.beforeAll(origTestFileName, 'writer');
 	}
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
-	});
 
 	function assertData() {
 		//select all the content of doc

--- a/cypress_test/integration_tests/desktop/writer/open_different_file_types_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/open_different_file_types_spec.js
@@ -4,14 +4,6 @@ var helper = require('../../common/helper');
 
 describe.skip(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Open different file types', function() {
 
-	var testFileName = '';
-
-	function before(filename) {
-		var origTestFileName = filename;
-
-		testFileName = helper.beforeAll(origTestFileName, 'writer');
-	}
-
 	function assertData() {
 		//select all the content of doc
 		helper.typeIntoDocument('{shift}{end}');
@@ -46,34 +38,34 @@ describe.skip(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Open different file t
 	}
 
 	it('Open doc file', { defaultCommandTimeout: 60000 }, function() {
-		before('testfile.doc');
+		helper.setupAndLoadDocument('writer/testfile.doc');
 		assertData();
 	});
 
 	it('Open docx file', { defaultCommandTimeout: 60000 }, function() {
-		before('testfile.docx');
+		helper.setupAndLoadDocument('writer/testfile.docx');
 		assertData();
 	});
 
 	it('Open docm file', { defaultCommandTimeout: 60000 }, function() {
-		before('testfile.docm');
+		helper.setupAndLoadDocument('writer/testfile.docm');
 		assertData();
 	});
 
 	it('Open fodt file', { defaultCommandTimeout: 60000 }, function() {
-		before('testfile.fodt');
+		helper.setupAndLoadDocument('writer/testfile.fodt');
 		assertData();
 	});
 
 	it('Open dot file', { defaultCommandTimeout: 60000 }, function() {
-		testFileName = openReadOnlyFile('writer', 'testfile.dot');
+		openReadOnlyFile('writer', 'testfile.dot');
 	});
 
 	it('Open dotm file', { defaultCommandTimeout: 60000 }, function() {
-		testFileName = openReadOnlyFile('writer', 'testfile.dotm');
+		openReadOnlyFile('writer', 'testfile.dotm');
 	});
 
 	it('Open dotx file', { defaultCommandTimeout: 60000 }, function() {
-		testFileName = openReadOnlyFile('writer','testfile.dotx');
+		openReadOnlyFile('writer','testfile.dotx');
 	});
 });

--- a/cypress_test/integration_tests/desktop/writer/scrolling_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/scrolling_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach */
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
@@ -12,10 +12,6 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Scroll through document', 
 
 		cy.cGet('#toolbar-up .w2ui-scroll-right').click();
 		cy.cGet('#sidebar').click({force: true});
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Scrolling to bottom/top', function() {

--- a/cypress_test/integration_tests/desktop/writer/scrolling_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/scrolling_spec.js
@@ -4,10 +4,9 @@ var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
 
 describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Scroll through document', function() {
-	var testFileName = 'scrolling.odt';
 
 	beforeEach(function() {
-		helper.beforeAll(testFileName, 'writer');
+		helper.setupAndLoadDocument('writer/scrolling.odt');
 		desktopHelper.switchUIToCompact();
 
 		cy.cGet('#toolbar-up .w2ui-scroll-right').click();

--- a/cypress_test/integration_tests/desktop/writer/searchbar_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/searchbar_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach*/
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 var searchHelper = require('../../common/search_helper');
@@ -10,10 +10,6 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Searching via search bar' 
 
 	beforeEach(function() {
 		testFileName = helper.beforeAll(origTestFileName, 'writer');
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Search existing word.', function() {

--- a/cypress_test/integration_tests/desktop/writer/searchbar_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/searchbar_spec.js
@@ -5,11 +5,9 @@ var searchHelper = require('../../common/search_helper');
 var writerHelper = require('../../common/writer_helper');
 
 describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Searching via search bar' ,function() {
-	var origTestFileName = 'search_bar.odt';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'writer');
+		helper.setupAndLoadDocument('writer/search_bar.odt');
 	});
 
 	it('Search existing word.', function() {

--- a/cypress_test/integration_tests/desktop/writer/statusbar_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/statusbar_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach Cypress */
+/* global describe it cy beforeEach require Cypress */
 
 var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
@@ -14,10 +14,6 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Statubar tests.', function
 		if (Cypress.env('INTEGRATION') === 'nextcloud') {
 			desktopHelper.showStatusBarIfHidden ();
 		}
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Text selection.', function() {

--- a/cypress_test/integration_tests/desktop/writer/statusbar_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/statusbar_spec.js
@@ -4,11 +4,9 @@ var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
 
 describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Statubar tests.', function() {
-	var origTestFileName = 'statusbar.odt';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'writer');
+		helper.setupAndLoadDocument('writer/statusbar.odt');
 		desktopHelper.switchUIToCompact();
 
 		if (Cypress.env('INTEGRATION') === 'nextcloud') {

--- a/cypress_test/integration_tests/desktop/writer/table_accessibility_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/table_accessibility_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach */
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 // var desktopHelper = require('../../common/desktop_helper');
@@ -10,10 +10,6 @@ describe(['taga11yenabled'], 'Table accessibility', function() {
 	beforeEach(function () {
 		helper.beforeAll(testFileName, 'writer');
 		cy.cGet('div.clipboard').as('clipboard');
-	});
-
-	afterEach(function () {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	function checkCellDescription(expectedDescription) {

--- a/cypress_test/integration_tests/desktop/writer/table_accessibility_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/table_accessibility_spec.js
@@ -5,10 +5,9 @@ var helper = require('../../common/helper');
 var ceHelper = require('../../common/contenteditable_helper');
 
 describe(['taga11yenabled'], 'Table accessibility', function() {
-	var testFileName = 'table_accessibility.odt';
 
 	beforeEach(function () {
-		helper.beforeAll(testFileName, 'writer');
+		helper.setupAndLoadDocument('writer/table_accessibility.odt');
 		cy.cGet('div.clipboard').as('clipboard');
 	});
 

--- a/cypress_test/integration_tests/desktop/writer/table_operation_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/table_operation_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach Cypress require afterEach expect */
+/* global describe it cy beforeEach Cypress require expect */
 
 var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
@@ -12,10 +12,6 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Table operations', functio
 		testFileName = helper.beforeAll(origTestFileName, 'writer');
 		desktopHelper.switchUIToNotebookbar();
 		desktopHelper.selectZoomLevel('70');
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	function selectFullTable() {

--- a/cypress_test/integration_tests/desktop/writer/table_operation_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/table_operation_spec.js
@@ -5,11 +5,9 @@ var desktopHelper = require('../../common/desktop_helper');
 var mode = Cypress.env('USER_INTERFACE');
 
 describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Table operations', function() {
-	var origTestFileName = 'table_operation.odt';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'writer');
+		helper.setupAndLoadDocument('writer/table_operation.odt');
 		desktopHelper.switchUIToNotebookbar();
 		desktopHelper.selectZoomLevel('70');
 	});

--- a/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach Cypress */
+/* global describe it cy beforeEach require Cypress */
 
 var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
@@ -17,10 +17,6 @@ describe(['tagdesktop'], 'Top toolbar tests.', function() {
 		}
 
 		writerHelper.selectAllTextOfDoc();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	function refreshCopyPasteContainer() {

--- a/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
@@ -5,11 +5,10 @@ var desktopHelper = require('../../common/desktop_helper');
 var writerHelper = require('../../common/writer_helper');
 
 describe(['tagdesktop'], 'Top toolbar tests.', function() {
-	var origTestFileName = 'top_toolbar.odt';
-	var testFileName;
+	var newFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'writer');
+		newFileName = helper.setupAndLoadDocument('writer/top_toolbar.odt');
 		desktopHelper.switchUIToNotebookbar();
 
 		if (Cypress.env('INTEGRATION') === 'nextcloud') {
@@ -283,14 +282,12 @@ describe(['tagdesktop'], 'Top toolbar tests.', function() {
 			.should('not.exist');
 	});
 
-	it('Save.', { defaultCommandTimeout: 60000 }, function() {
+	it('Save.', function() {
 		cy.cGet('.notebookbar > .unoBold > button').click();
 		cy.cGet('.notebookbar-shortcuts-bar .unoSave').click();
-		helper.reload(testFileName, 'writer', true);
+		helper.reloadDocument(newFileName,'writer');
 		helper.setDummyClipboardForCopy();
-		cy.wait(2000);
 		writerHelper.selectAllTextOfDoc();
-		cy.wait(2000);
 		helper.copy();
 		cy.cGet('#copy-paste-container p b').should('exist');
 	});

--- a/cypress_test/integration_tests/desktop/writer/track_changes_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/track_changes_spec.js
@@ -4,12 +4,10 @@ var helper = require('../../common/helper');
 const desktopHelper = require('../../common/desktop_helper');
 
 describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Track Changes', function () {
-	var origTestFileName = 'track_changes.odt';
-	var testFileName;
 
 	beforeEach(function () {
 		cy.viewport(1400, 600);
-		testFileName = helper.beforeAll(origTestFileName, 'writer');
+		helper.setupAndLoadDocument('writer/track_changes.odt');
 		desktopHelper.switchUIToCompact();
 		cy.cGet('#sidebar').click({force: true}); // Hide sidebar.
 		desktopHelper.selectZoomLevel('50');

--- a/cypress_test/integration_tests/desktop/writer/track_changes_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/track_changes_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach Cypress expect */
+/* global describe it cy beforeEach require Cypress expect */
 
 var helper = require('../../common/helper');
 const desktopHelper = require('../../common/desktop_helper');
@@ -13,10 +13,6 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Track Changes', function (
 		desktopHelper.switchUIToCompact();
 		cy.cGet('#sidebar').click({force: true}); // Hide sidebar.
 		desktopHelper.selectZoomLevel('50');
-	});
-
-	afterEach(function () {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	function confirmChange(action) {

--- a/cypress_test/integration_tests/desktop/writer/undo_redo_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/undo_redo_spec.js
@@ -1,4 +1,4 @@
-/* global cy describe it beforeEach require afterEach*/
+/* global cy describe it beforeEach require */
 
 var helper = require('../../common/helper');
 var repairHelper = require('../../common/repair_document_helper');
@@ -10,10 +10,6 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Editing Operations', funct
 	beforeEach(function() {
 		helper.beforeAll(testFileName, 'writer');
 		desktopHelper.switchUIToCompact();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	function undo() {

--- a/cypress_test/integration_tests/desktop/writer/undo_redo_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/undo_redo_spec.js
@@ -5,10 +5,9 @@ var repairHelper = require('../../common/repair_document_helper');
 const desktopHelper = require('../../common/desktop_helper');
 
 describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Editing Operations', function() {
-	var testFileName = 'undo_redo.odt';
 
 	beforeEach(function() {
-		helper.beforeAll(testFileName, 'writer');
+		helper.setupAndLoadDocument('writer/undo_redo.odt');
 		desktopHelper.switchUIToCompact();
 	});
 

--- a/cypress_test/integration_tests/idle/calc/idle_spec.js
+++ b/cypress_test/integration_tests/idle/calc/idle_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach */
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 var calcHelper = require('../../common/calc_helper');
@@ -10,10 +10,6 @@ describe(['tagdesktop'], 'Idle', function() {
 
 	beforeEach(function() {
 		testFileName = helper.beforeAll(origTestFileName, 'calc');
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	function checkIfIsInteractiveAgain() {

--- a/cypress_test/integration_tests/idle/calc/idle_spec.js
+++ b/cypress_test/integration_tests/idle/calc/idle_spec.js
@@ -4,12 +4,10 @@ var helper = require('../../common/helper');
 var calcHelper = require('../../common/calc_helper');
 
 describe(['tagdesktop'], 'Idle', function() {
-	var origTestFileName = 'idle.ods';
-	var testFileName;
 	var dimDialogSelector = '#modal-dialog-inactive_user_message-overlay';
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'calc');
+		helper.setupAndLoadDocument('calc/idle.ods');
 	});
 
 	function checkIfIsInteractiveAgain() {

--- a/cypress_test/integration_tests/mobile/calc/alignment_options_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/alignment_options_spec.js
@@ -5,11 +5,9 @@ var calcHelper = require('../../common/calc_helper');
 var mobileHelper = require('../../common/mobile_helper');
 
 describe.skip(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Change alignment settings.', function() {
-	var origTestFileName = 'alignment_options.ods';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'calc');
+		helper.setupAndLoadDocument('calc/alignment_options.ods');
 
 		// Click on edit button
 		mobileHelper.enableEditingMobile();

--- a/cypress_test/integration_tests/mobile/calc/alignment_options_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/alignment_options_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach Cypress require afterEach expect*/
+/* global describe it cy beforeEach Cypress require expect */
 
 var helper = require('../../common/helper');
 var calcHelper = require('../../common/calc_helper');
@@ -13,10 +13,6 @@ describe.skip(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Change alignment setti
 
 		// Click on edit button
 		mobileHelper.enableEditingMobile();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	function getTextEndPosForFirstCell() {

--- a/cypress_test/integration_tests/mobile/calc/annotation_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/annotation_spec.js
@@ -4,11 +4,10 @@ var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
 
 describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Annotation Tests',function() {
-	var origTestFileName = 'annotation.ods';
-	var testFileName;
+	var newFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'calc');
+		newFileName = helper.setupAndLoadDocument('calc/annotation.ods');
 
 		// Click on edit button
 		mobileHelper.enableEditingMobile();
@@ -19,7 +18,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Annotation Tests',function(
 		cy.cGet('#comment-container-1').should('exist');
 		mobileHelper.selectHamburgerMenuItem(['File', 'Save']);
 
-		helper.reload(testFileName, 'calc', true);
+		helper.reloadDocument(newFileName, 'calc');
 		mobileHelper.enableEditingMobile();
 		mobileHelper.openCommentWizard();
 		helper.waitUntilIdle('#mobile-wizard-content', undefined);

--- a/cypress_test/integration_tests/mobile/calc/annotation_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/annotation_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach */
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
@@ -12,10 +12,6 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Annotation Tests',function(
 
 		// Click on edit button
 		mobileHelper.enableEditingMobile();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Saving comment.', function() {

--- a/cypress_test/integration_tests/mobile/calc/apply_font_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/apply_font_spec.js
@@ -5,11 +5,9 @@ var calcHelper = require('../../common/calc_helper');
 var mobileHelper = require('../../common/mobile_helper');
 
 describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Apply font changes.', function() {
-	var origTestFileName = 'apply_font.ods';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'calc');
+		helper.setupAndLoadDocument('calc/apply_font.ods');
 
 		// Click on edit button
 		mobileHelper.enableEditingMobile();

--- a/cypress_test/integration_tests/mobile/calc/apply_font_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/apply_font_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach */
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 var calcHelper = require('../../common/calc_helper');
@@ -18,10 +18,6 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Apply font changes.', funct
 
 		// Open character properties
 		mobileHelper.openTextPropertiesPanel();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Apply bold.', function() {

--- a/cypress_test/integration_tests/mobile/calc/autofilter_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/autofilter_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach */
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 var calcHelper = require('../../common/calc_helper');
@@ -14,10 +14,6 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'AutoFilter', function() {
 		mobileHelper.enableEditingMobile();
 		helper.setDummyClipboardForCopy();
 		calcHelper.assertSheetContents(['Cypress Test', 'Status', 'Test 1', 'Pass', 'Test 2', 'Fail', 'Test 3', 'Pass', 'Test 4', '', 'Test 5', 'Fail'], true);
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Sort by ascending/descending', function() {

--- a/cypress_test/integration_tests/mobile/calc/autofilter_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/autofilter_spec.js
@@ -5,11 +5,9 @@ var calcHelper = require('../../common/calc_helper');
 var mobileHelper = require('../../common/mobile_helper');
 
 describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'AutoFilter', function() {
-	var origTestFileName = 'autofilter.ods';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'calc');
+		helper.setupAndLoadDocument('calc/autofilter.ods');
 		// Click on edit button
 		mobileHelper.enableEditingMobile();
 		helper.setDummyClipboardForCopy();

--- a/cypress_test/integration_tests/mobile/calc/bottom_toolbar_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/bottom_toolbar_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy Cypress require afterEach */
+/* global describe it cy Cypress require */
 
 var helper = require('../../common/helper');
 var calcHelper = require('../../common/calc_helper');
@@ -17,10 +17,6 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Interact with bottom toolba
 
 		calcHelper.clickOnFirstCell();
 	}
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
-	});
 
 	function getTextEndPosForFirstCell() {
 		calcHelper.dblClickOnFirstCell();

--- a/cypress_test/integration_tests/mobile/calc/bottom_toolbar_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/bottom_toolbar_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy Cypress require */
+/* global describe it cy Cypress require beforeEach */
 
 var helper = require('../../common/helper');
 var calcHelper = require('../../common/calc_helper');
@@ -6,8 +6,8 @@ var mobileHelper = require('../../common/mobile_helper');
 
 describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Interact with bottom toolbar.', function() {
 
-	function before(fileName) {
-		helper.setupAndLoadDocument('calc/' + fileName);
+	beforeEach(function() {
+		helper.setupAndLoadDocument('calc/bottom_toolbar.ods');
 
 		// Click on edit button
 		mobileHelper.enableEditingMobile();
@@ -15,7 +15,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Interact with bottom toolba
 		helper.waitUntilIdle('#toolbar-down');
 
 		calcHelper.clickOnFirstCell();
-	}
+	});
 
 	function getTextEndPosForFirstCell() {
 		calcHelper.dblClickOnFirstCell();
@@ -33,7 +33,6 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Interact with bottom toolba
 	}
 
 	it('Apply bold.', function() {
-		before('bottom_toolbar.ods');
 		helper.setDummyClipboardForCopy();
 		cy.cGet('#toolbar-down #bold').click();
 		calcHelper.selectEntireSheet();
@@ -42,7 +41,6 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Interact with bottom toolba
 	});
 
 	it('Apply italic.', function() {
-		before('bottom_toolbar.ods');
 		helper.setDummyClipboardForCopy();
 
 		cy.cGet('#toolbar-down #italic').click();
@@ -52,7 +50,6 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Interact with bottom toolba
 	});
 
 	it('Apply underline.', function() {
-		before('bottom_toolbar.ods');
 		helper.setDummyClipboardForCopy();
 		cy.cGet('#toolbar-down #underline').click();
 		calcHelper.selectEntireSheet();
@@ -61,14 +58,12 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Interact with bottom toolba
 	});
 
 	it.skip('Apply strikeout.', function() {
-		before('bottom_toolbar.ods');
 		cy.cGet('#toolbar-down #strikeout').click();
 		calcHelper.selectEntireSheet();
 		cy.cGet('#copy-paste-container table td s').should('exist');
 	});
 
 	it('Apply font color.', function() {
-		before('bottom_toolbar.ods');
 		helper.setDummyClipboardForCopy();
 		cy.cGet('#toolbar-down #fontcolor').click();
 		mobileHelper.selectFromColorPalette(0, 5);
@@ -78,7 +73,6 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Interact with bottom toolba
 	});
 
 	it('Apply highlight color.', function() {
-		before('bottom_toolbar.ods');
 		helper.setDummyClipboardForCopy();
 		cy.cGet('#toolbar-down #backcolor').click();
 		mobileHelper.selectFromColorPalette(0, 5);
@@ -88,7 +82,6 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Interact with bottom toolba
 	});
 
 	it.skip('Merge cells', function() {
-		before('bottom_toolbar.ods');
 		// Select 100 cells in first row
 		calcHelper.selectCellsInRange('A1:CV1');
 		// Despite the selection is there, merge cells needs more time here.
@@ -99,7 +92,6 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Interact with bottom toolba
 	});
 
 	it.skip('Enable text wrapping.', function() {
-		before('bottom_toolbar.ods');
 		helper.initAliasToNegative('originalTextEndPos');
 		getTextEndPosForFirstCell();
 		cy.get('@currentTextEndPos').as('originalTextEndPos');

--- a/cypress_test/integration_tests/mobile/calc/bottom_toolbar_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/bottom_toolbar_spec.js
@@ -5,10 +5,9 @@ var calcHelper = require('../../common/calc_helper');
 var mobileHelper = require('../../common/mobile_helper');
 
 describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Interact with bottom toolbar.', function() {
-	var testFileName;
 
 	function before(fileName) {
-		testFileName = helper.beforeAll(fileName, 'calc');
+		helper.setupAndLoadDocument('calc/' + fileName);
 
 		// Click on edit button
 		mobileHelper.enableEditingMobile();

--- a/cypress_test/integration_tests/mobile/calc/cell_appearance_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/cell_appearance_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach expect*/
+/* global describe it cy beforeEach require expect*/
 
 var helper = require('../../common/helper');
 var calcHelper = require('../../common/calc_helper');
@@ -13,10 +13,6 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Change cell appearance.', f
 
 		// Click on edit button
 		mobileHelper.enableEditingMobile();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	function openAppearencePanel() {

--- a/cypress_test/integration_tests/mobile/calc/cell_appearance_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/cell_appearance_spec.js
@@ -5,11 +5,9 @@ var calcHelper = require('../../common/calc_helper');
 var mobileHelper = require('../../common/mobile_helper');
 
 describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Change cell appearance.', function() {
-	var origTestFileName = 'cell_appearance.ods';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'calc');
+		helper.setupAndLoadDocument('calc/cell_appearance.ods');
 
 		// Click on edit button
 		mobileHelper.enableEditingMobile();

--- a/cypress_test/integration_tests/mobile/calc/chart_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/chart_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach expect*/
+/* global describe it cy beforeEach require expect*/
 
 var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
@@ -13,10 +13,6 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Chart tests.', function() {
 		mobileHelper.enableEditingMobile();
 		calcHelper.selectFirstColumn();
 		insertChart();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	function insertChart() {

--- a/cypress_test/integration_tests/mobile/calc/chart_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/chart_spec.js
@@ -5,11 +5,9 @@ var mobileHelper = require('../../common/mobile_helper');
 var calcHelper = require('../../common/calc_helper');
 
 describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Chart tests.', function() {
-	var origTestFileName = 'chart.ods';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'calc');
+		helper.setupAndLoadDocument('calc/chart.ods');
 		mobileHelper.enableEditingMobile();
 		calcHelper.selectFirstColumn();
 		insertChart();

--- a/cypress_test/integration_tests/mobile/calc/delete_objects_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/delete_objects_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach */
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
@@ -19,10 +19,6 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Delete Objects',function() 
 
 		// Click on edit button
 		mobileHelper.enableEditingMobile();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Delete Text', function() {

--- a/cypress_test/integration_tests/mobile/calc/delete_objects_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/delete_objects_spec.js
@@ -5,8 +5,6 @@ var mobileHelper = require('../../common/mobile_helper');
 var calcHelper = require('../../common/calc_helper');
 
 describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Delete Objects',function() {
-	var origTestFileName = 'delete_objects.ods';
-	var testFileName;
 
 	var eventOptions = {
 		force: true,
@@ -15,7 +13,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Delete Objects',function() 
 	};
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'calc');
+		helper.setupAndLoadDocument('calc/delete_objects.ods');
 
 		// Click on edit button
 		mobileHelper.enableEditingMobile();

--- a/cypress_test/integration_tests/mobile/calc/focus_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/focus_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach expect*/
+/* global describe it cy beforeEach require expect*/
 
 var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
@@ -13,10 +13,6 @@ describe.skip(['tagmobile'], 'Calc focus tests', function() {
 
 		// Wait until the Formula-Bar is loaded.
 		cy.cGet('.inputbar_container', {timeout : 10000});
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Basic document focus.', function() {

--- a/cypress_test/integration_tests/mobile/calc/focus_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/focus_spec.js
@@ -5,11 +5,9 @@ var mobileHelper = require('../../common/mobile_helper');
 var calcHelper = require('../../common/calc_helper');
 
 describe.skip(['tagmobile'], 'Calc focus tests', function() {
-	var origTestFileName = 'focus.ods';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'calc');
+		helper.setupAndLoadDocument('calc/focus.ods');
 
 		// Wait until the Formula-Bar is loaded.
 		cy.cGet('.inputbar_container', {timeout : 10000});

--- a/cypress_test/integration_tests/mobile/calc/formulabar_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/formulabar_spec.js
@@ -5,11 +5,9 @@ var calcHelper = require('../../common/calc_helper');
 var mobileHelper = require('../../common/mobile_helper');
 
 describe(['tagmobile', 'tagnextcloud'], 'Formula bar tests.', function() {
-	var origTestFileName = 'formulabar.ods';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'calc');
+		helper.setupAndLoadDocument('calc/formulabar.ods');
 
 		mobileHelper.enableEditingMobile();
 	});

--- a/cypress_test/integration_tests/mobile/calc/formulabar_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/formulabar_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach expect Cypress*/
+/* global describe it cy beforeEach require expect Cypress*/
 
 var helper = require('../../common/helper');
 var calcHelper = require('../../common/calc_helper');
@@ -12,10 +12,6 @@ describe(['tagmobile', 'tagnextcloud'], 'Formula bar tests.', function() {
 		testFileName = helper.beforeAll(origTestFileName, 'calc');
 
 		mobileHelper.enableEditingMobile();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Select a cell by address', function() {

--- a/cypress_test/integration_tests/mobile/calc/hamburger_menu_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/hamburger_menu_spec.js
@@ -6,16 +6,11 @@ var mobileHelper = require('../../common/mobile_helper');
 var repairHelper = require('../../common/repair_document_helper');
 
 describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
-	var testFileName;
-
-	function before(testFile) {
-		helper.setupAndLoadDocument('calc' + testFile);
-
-		// Click on edit button
-		mobileHelper.enableEditingMobile();
-	}
 
 	it('Save', { defaultCommandTimeout: 60000 }, function() {
+		var newFileName = helper.setupAndLoadDocument('calc/hamburger_menu.ods');
+		mobileHelper.enableEditingMobile();
+
 		calcHelper.selectEntireSheet();
 
 		cy.cGet('#copy-paste-container table td').should('contain.text', 'Textx');
@@ -27,7 +22,7 @@ describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 		mobileHelper.selectHamburgerMenuItem(['File', 'Save']);
 
 		// Reopen the document and check content.
-		helper.reload(testFileName, 'calc', true);
+		helper.reloadDocument(newFileName, 'calc');
 
 		mobileHelper.enableEditingMobile();
 		calcHelper.selectEntireSheet();
@@ -35,7 +30,8 @@ describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 	});
 
 	it('Print', function() {
-		before('hamburger_menu.ods');
+		helper.setupAndLoadDocument('calc/hamburger_menu.ods');
+		mobileHelper.enableEditingMobile();
 
 		// A new window should be opened with the PDF.
 		cy.getFrameWindow()
@@ -49,32 +45,41 @@ describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 	});
 
 	it('Download as PDF', function() {
-		before('hamburger_menu.ods');
+		helper.setupAndLoadDocument('calc/hamburger_menu.ods');
+		mobileHelper.enableEditingMobile();
+
 		mobileHelper.selectHamburgerMenuItem(['Download as', 'PDF Document (.pdf)']);
 		mobileHelper.pressPushButtonOfDialog('Export');
 		cy.cGet('iframe').should('have.attr', 'data-src').should('contain', 'download');
 	});
 
 	it('Download as ODS', function() {
-		before('hamburger_menu.ods');
+		helper.setupAndLoadDocument('calc/hamburger_menu.ods');
+		mobileHelper.enableEditingMobile();
+
 		mobileHelper.selectHamburgerMenuItem(['Download as', 'ODF spreadsheet (.ods)']);
 		cy.cGet('iframe').should('have.attr', 'data-src').should('contain', 'download');
 	});
 
 	it('Download as XLS', function() {
-		before('hamburger_menu.ods');
+		helper.setupAndLoadDocument('calc/hamburger_menu.ods');
+		mobileHelper.enableEditingMobile();
+
 		mobileHelper.selectHamburgerMenuItem(['Download as', 'Excel 2003 Spreadsheet (.xls)']);
 		cy.cGet('iframe').should('have.attr', 'data-src').should('contain', 'download');
 	});
 
 	it('Download as XLSX', function() {
-		before('hamburger_menu.ods');
+		helper.setupAndLoadDocument('calc/hamburger_menu.ods');
+		mobileHelper.enableEditingMobile();
+
 		mobileHelper.selectHamburgerMenuItem(['Download as', 'Excel Spreadsheet (.xlsx)']);
 		cy.cGet('iframe').should('have.attr', 'data-src').should('contain', 'download');
 	});
 
 	it('Undo/redo.', function() {
-		before('hamburger_menu.ods');
+		helper.setupAndLoadDocument('calc/hamburger_menu.ods');
+		mobileHelper.enableEditingMobile();
 
 		// Type a new character
 		calcHelper.clickOnFirstCell(true, true);
@@ -100,7 +105,8 @@ describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 	});
 
 	it('Repair Document', function() {
-		before('hamburger_menu.ods');
+		helper.setupAndLoadDocument('calc/hamburger_menu.ods');
+		mobileHelper.enableEditingMobile();
 
 		// Type a new character
 		calcHelper.clickOnFirstCell(true, true);
@@ -121,35 +127,45 @@ describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 	});
 
 	it('Cut.', function() {
-		before('hamburger_menu.ods');
+		helper.setupAndLoadDocument('calc/hamburger_menu.ods');
+		mobileHelper.enableEditingMobile();
+
 		calcHelper.selectEntireSheet();
 		mobileHelper.selectHamburgerMenuItem(['Edit', 'Cut']);
 		cy.cGet('#mobile-wizard-content-modal-dialog-copy_paste_warning-box').should('exist');
 	});
 
 	it('Copy.', function() {
-		before('hamburger_menu.ods');
+		helper.setupAndLoadDocument('calc/hamburger_menu.ods');
+		mobileHelper.enableEditingMobile();
+
 		calcHelper.selectEntireSheet();
 		mobileHelper.selectHamburgerMenuItem(['Edit', 'Copy']);
 		cy.cGet('#mobile-wizard-content-modal-dialog-copy_paste_warning-box').should('exist');
 	});
 
 	it('Paste.', function() {
-		before('hamburger_menu.ods');
+		helper.setupAndLoadDocument('calc/hamburger_menu.ods');
+		mobileHelper.enableEditingMobile();
+
 		calcHelper.selectEntireSheet();
 		mobileHelper.selectHamburgerMenuItem(['Edit', 'Paste']);
 		cy.cGet('#mobile-wizard-content-modal-dialog-copy_paste_warning-box').should('exist');
 	});
 
 	it('Select all.', function() {
-		before('hamburger_menu.ods');
+		helper.setupAndLoadDocument('calc/hamburger_menu.ods');
+		mobileHelper.enableEditingMobile();
+
 		mobileHelper.selectHamburgerMenuItem(['Edit', 'Select All']);
 		cy.cGet('.spreadsheet-cell-resize-marker').should('be.visible');
 		cy.cGet('#copy-paste-container table td').should('contain.text', 'Text');
 	});
 
 	it('Search some word.', function() {
-		before('hamburger_menu_search.ods');
+		helper.setupAndLoadDocument('calc/hamburger_menu_search.ods');
+		mobileHelper.enableEditingMobile();
+
 		mobileHelper.selectHamburgerMenuItem(['Search']);
 		// Search bar become visible
 		cy.cGet('#mobile-wizard-content').should('not.be.empty');
@@ -162,7 +178,9 @@ describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 	});
 
 	it('Sheet: insert row before.', function() {
-		before('hamburger_menu_sheet.ods');
+		helper.setupAndLoadDocument('calc/hamburger_menu_sheet.ods');
+		mobileHelper.enableEditingMobile();
+
 		calcHelper.clickOnFirstCell();
 		mobileHelper.selectHamburgerMenuItem(['Sheet', 'Insert Rows', 'Rows Above']);
 		calcHelper.selectEntireSheet();
@@ -177,7 +195,9 @@ describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 	});
 
 	it('Sheet: insert row after.', function() {
-		before('hamburger_menu_sheet.ods');
+		helper.setupAndLoadDocument('calc/hamburger_menu_sheet.ods');
+		mobileHelper.enableEditingMobile();
+
 		calcHelper.clickOnFirstCell();
 		mobileHelper.selectHamburgerMenuItem(['Sheet', 'Insert Rows', 'Rows Below']);
 		calcHelper.selectEntireSheet();
@@ -192,7 +212,9 @@ describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 	});
 
 	it('Sheet: insert column before.', function() {
-		before('hamburger_menu_sheet.ods');
+		helper.setupAndLoadDocument('calc/hamburger_menu_sheet.ods');
+		mobileHelper.enableEditingMobile();
+
 		calcHelper.clickOnFirstCell();
 		mobileHelper.selectHamburgerMenuItem(['Sheet', 'Insert Columns', 'Columns Before']);
 		calcHelper.selectEntireSheet();
@@ -207,7 +229,9 @@ describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 	});
 
 	it('Sheet: insert column after.', function() {
-		before('hamburger_menu_sheet.ods');
+		helper.setupAndLoadDocument('calc/hamburger_menu_sheet.ods');
+		mobileHelper.enableEditingMobile();
+
 		calcHelper.clickOnFirstCell();
 		mobileHelper.selectHamburgerMenuItem(['Sheet', 'Insert Columns', 'Columns After']);
 		calcHelper.selectEntireSheet();
@@ -222,7 +246,9 @@ describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 	});
 
 	it('Sheet: delete rows.', function() {
-		before('hamburger_menu_sheet.ods');
+		helper.setupAndLoadDocument('calc/hamburger_menu_sheet.ods');
+		mobileHelper.enableEditingMobile();
+
 		calcHelper.clickOnFirstCell();
 		mobileHelper.selectHamburgerMenuItem(['Sheet', 'Delete Rows']);
 		calcHelper.selectEntireSheet();
@@ -235,7 +261,9 @@ describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 	});
 
 	it('Sheet: delete columns.', function() {
-		before('hamburger_menu_sheet.ods');
+		helper.setupAndLoadDocument('calc/hamburger_menu_sheet.ods');
+		mobileHelper.enableEditingMobile();
+
 		calcHelper.clickOnFirstCell();
 		mobileHelper.selectHamburgerMenuItem(['Sheet', 'Delete Columns']);
 		calcHelper.selectEntireSheet();
@@ -248,7 +276,8 @@ describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 	});
 
 	it('Data: sort ascending.', function() {
-		before('hamburger_menu_sort.ods');
+		helper.setupAndLoadDocument('calc/hamburger_menu_sort.ods');
+		mobileHelper.enableEditingMobile();
 
 		// Sort the first column's data
 		calcHelper.selectFirstColumn();
@@ -266,7 +295,8 @@ describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 	});
 
 	it('Data: sort descending.', function() {
-		before('hamburger_menu_sort.ods');
+		helper.setupAndLoadDocument('calc/hamburger_menu_sort.ods');
+		mobileHelper.enableEditingMobile();
 
 		// Sort the first column's data
 		calcHelper.selectFirstColumn();
@@ -284,7 +314,8 @@ describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 	});
 
 	it('Data: grouping / ungrouping.', function() {
-		before('hamburger_menu.ods');
+		helper.setupAndLoadDocument('calc/hamburger_menu.ods');
+		mobileHelper.enableEditingMobile();
 
 		// Group first
 		calcHelper.selectFirstColumn();
@@ -296,7 +327,8 @@ describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 	});
 
 	it('Data: remove grouping outline.', function() {
-		before('hamburger_menu.ods');
+		helper.setupAndLoadDocument('calc/hamburger_menu.ods');
+		mobileHelper.enableEditingMobile();
 
 		// Group first
 		calcHelper.selectFirstColumn();
@@ -309,7 +341,8 @@ describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 	});
 
 	it('Data: show / hide grouping details.', function() {
-		before('hamburger_menu.ods');
+		helper.setupAndLoadDocument('calc/hamburger_menu.ods');
+		mobileHelper.enableEditingMobile();
 
 		// Group first
 		calcHelper.selectFirstColumn();
@@ -341,7 +374,8 @@ describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 	});
 
 	it('Check version information.', function() {
-		before('hamburger_menu.ods');
+		helper.setupAndLoadDocument('calc/hamburger_menu.ods');
+		mobileHelper.enableEditingMobile();
 
 		mobileHelper.selectHamburgerMenuItem(['About']);
 

--- a/cypress_test/integration_tests/mobile/calc/hamburger_menu_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/hamburger_menu_spec.js
@@ -9,14 +9,13 @@ describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 	var testFileName;
 
 	function before(testFile) {
-		testFileName = helper.beforeAll(testFile, 'calc');
+		helper.setupAndLoadDocument('calc' + testFile);
 
 		// Click on edit button
 		mobileHelper.enableEditingMobile();
 	}
 
 	it('Save', { defaultCommandTimeout: 60000 }, function() {
-		before('hamburger_menu.ods');
 		calcHelper.selectEntireSheet();
 
 		cy.cGet('#copy-paste-container table td').should('contain.text', 'Textx');

--- a/cypress_test/integration_tests/mobile/calc/hamburger_menu_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/hamburger_menu_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy require afterEach expect */
+/* global describe it cy require expect */
 
 var helper = require('../../common/helper');
 var calcHelper = require('../../common/calc_helper');
@@ -14,10 +14,6 @@ describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 		// Click on edit button
 		mobileHelper.enableEditingMobile();
 	}
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
-	});
 
 	it('Save', { defaultCommandTimeout: 60000 }, function() {
 		before('hamburger_menu.ods');

--- a/cypress_test/integration_tests/mobile/calc/image_operation_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/image_operation_spec.js
@@ -1,4 +1,4 @@
-/* global describe cy it beforeEach require afterEach */
+/* global describe cy it beforeEach require */
 
 var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
@@ -13,11 +13,6 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Image Operation Tests', fun
 		// Click on edit button
 		mobileHelper.enableEditingMobile();
 	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
-	});
-
 
 	it('Insert Image', function() {
 		mobileHelper.insertImage();

--- a/cypress_test/integration_tests/mobile/calc/image_operation_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/image_operation_spec.js
@@ -4,11 +4,9 @@ var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
 
 describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Image Operation Tests', function() {
-	var origTestFileName = 'image_operation.ods';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'calc');
+		helper.setupAndLoadDocument('calc/image_operation.ods');
 
 		// Click on edit button
 		mobileHelper.enableEditingMobile();

--- a/cypress_test/integration_tests/mobile/calc/insertion_wizard_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/insertion_wizard_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach expect*/
+/* global describe it cy beforeEach require expect*/
 
 var helper = require('../../common/helper');
 var calcHelper = require('../../common/calc_helper');
@@ -17,10 +17,6 @@ describe(['tagmobile', 'tagnextcloud'], 'Calc insertion wizard.', function() {
 		calcHelper.clickOnFirstCell();
 
 		mobileHelper.openInsertionWizard();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Inset local image.', function() {

--- a/cypress_test/integration_tests/mobile/calc/insertion_wizard_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/insertion_wizard_spec.js
@@ -5,11 +5,9 @@ var calcHelper = require('../../common/calc_helper');
 var mobileHelper = require('../../common/mobile_helper');
 
 describe(['tagmobile', 'tagnextcloud'], 'Calc insertion wizard.', function() {
-	var origTestFileName = 'insertion_wizard.ods';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'calc');
+		helper.setupAndLoadDocument('calc/insertion_wizard.ods');
 
 		// Click on edit button
 		mobileHelper.enableEditingMobile();

--- a/cypress_test/integration_tests/mobile/calc/nextcloud_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/nextcloud_spec.js
@@ -5,16 +5,12 @@ var mobileHelper = require('../../common/mobile_helper');
 var nextcloudHelper = require('../../common/nextcloud_helper');
 
 describe(['tagnextcloud'], 'Nextcloud specific tests.', function() {
-	var origTestFileName = 'nextcloud.ods';
-	var testFileName;
 
 	it('Insert image from storage.', function() {
-		helper.upLoadFileToNextCloud('image_to_insert.png', 'calc');
-
-		testFileName = helper.beforeAll(origTestFileName, 'calc', undefined, true);
-
+		helper.setupAndLoadDocument('calc/nextcloud.ods');
 		mobileHelper.enableEditingMobile();
 
+		helper.upLoadFileToNextCloud('image_to_insert.png', 'calc');
 		nextcloudHelper.insertImageFromStorage('image_to_insert.png');
 
 		// TODO
@@ -23,12 +19,10 @@ describe(['tagnextcloud'], 'Nextcloud specific tests.', function() {
 	});
 
 	it('Save as.', function() {
-		testFileName = helper.beforeAll(origTestFileName, 'calc');
-
-		// Click on edit button
+		var newFileName = helper.setupAndLoadDocument('calc/nextcloud.ods');
 		mobileHelper.enableEditingMobile();
 
-		nextcloudHelper.saveFileAs('1' + testFileName);
+		nextcloudHelper.saveFileAs('1' + newFileName);
 
 		// Close the document
 		cy.cGet('#mobile-edit-button')
@@ -41,16 +35,15 @@ describe(['tagnextcloud'], 'Nextcloud specific tests.', function() {
 				Cypress.env('IFRAME_LEVEL', '');
 			});
 
-		cy.cGet('tr[data-file=\'1' + testFileName + '\']')
+		cy.cGet('tr[data-file=\'1' + newFileName + '\']')
 			.should('be.visible');
 
-		cy.cGet('tr[data-file=\'' + testFileName + '\']')
+		cy.cGet('tr[data-file=\'' + newFileName + '\']')
 			.should('be.visible');
 	});
 
 	it('Share.', function() {
-		testFileName = helper.beforeAll(origTestFileName, 'calc');
-
+		helper.setupAndLoadDocument('calc/nextcloud.ods');
 		mobileHelper.enableEditingMobile();
 
 		nextcloudHelper.checkAndCloseSharing();

--- a/cypress_test/integration_tests/mobile/calc/nextcloud_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/nextcloud_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy require afterEach Cypress */
+/* global describe it cy require Cypress */
 
 var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
@@ -7,10 +7,6 @@ var nextcloudHelper = require('../../common/nextcloud_helper');
 describe(['tagnextcloud'], 'Nextcloud specific tests.', function() {
 	var origTestFileName = 'nextcloud.ods';
 	var testFileName;
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
-	});
 
 	it('Insert image from storage.', function() {
 		helper.upLoadFileToNextCloud('image_to_insert.png', 'calc');

--- a/cypress_test/integration_tests/mobile/calc/number_format_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/number_format_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach */
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 var calcHelper = require('../../common/calc_helper');
@@ -19,10 +19,6 @@ describe.skip(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Apply number formattin
 		mobileHelper.openMobileWizard();
 		cy.cGet('#ScNumberFormatPropertyPanel').click();
 		cy.cGet('#numberformatcombobox > .ui-header').should('be.visible');
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	function selectFormatting(formattingString) {

--- a/cypress_test/integration_tests/mobile/calc/number_format_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/number_format_spec.js
@@ -5,11 +5,9 @@ var calcHelper = require('../../common/calc_helper');
 var mobileHelper = require('../../common/mobile_helper');
 
 describe.skip(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Apply number formatting.', function() {
-	var origTestFileName = 'number_format.ods';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'calc');
+		helper.setupAndLoadDocument('calc/number_format.ods');
 
 		// Click on edit button
 		mobileHelper.enableEditingMobile();

--- a/cypress_test/integration_tests/mobile/calc/overlays_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/overlays_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach */
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 var calcHelper = require('../../common/calc_helper');
@@ -13,10 +13,6 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Overlay bounds.', function 
 		testFileName = helper.beforeAll(origTestFileName, 'calc');
 
 		mobileHelper.enableEditingMobile();
-	});
-
-	afterEach(function () {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Cell cursor overlay bounds', function () {

--- a/cypress_test/integration_tests/mobile/calc/overlays_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/overlays_spec.js
@@ -4,13 +4,10 @@ var helper = require('../../common/helper');
 var calcHelper = require('../../common/calc_helper');
 var mobileHelper = require('../../common/mobile_helper');
 
-var origTestFileName = 'overlays.ods';
-var testFileName;
-
 describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Overlay bounds.', function () {
 
 	beforeEach(function () {
-		testFileName = helper.beforeAll(origTestFileName, 'calc');
+		helper.setupAndLoadDocument('calc/overlays.ods');
 
 		mobileHelper.enableEditingMobile();
 	});

--- a/cypress_test/integration_tests/mobile/calc/row_column_operation_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/row_column_operation_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy require afterEach beforeEach */
+/* global describe it cy require beforeEach */
 var helper = require('../../common/helper');
 var calcHelper = require('../../common/calc_helper');
 var mobileHelper = require('../../common/mobile_helper');
@@ -14,10 +14,6 @@ describe.skip(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Row Column Operation',
 		calcHelper.assertSheetContents(['Hello','Hi','World','Bye']);
 
 		calcHelper.clickOnFirstCell(true,false);
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	function selectOption(submenu, option) {

--- a/cypress_test/integration_tests/mobile/calc/row_column_operation_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/row_column_operation_spec.js
@@ -4,10 +4,9 @@ var calcHelper = require('../../common/calc_helper');
 var mobileHelper = require('../../common/mobile_helper');
 
 describe.skip(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Row Column Operation', function() {
-	var testFileName = 'row_column_operation.ods';
 
 	beforeEach(function() {
-		helper.beforeAll(testFileName, 'calc');
+		helper.setupAndLoadDocument('calc/row_column_operation.ods');
 
 		mobileHelper.enableEditingMobile();
 

--- a/cypress_test/integration_tests/mobile/calc/searchbar_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/searchbar_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach*/
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 var searchHelper = require('../../common/search_helper');
@@ -14,10 +14,6 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Searching via search bar.',
 		mobileHelper.enableEditingMobile();
 
 		searchHelper.showSearchBar();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Search existing word.', function() {

--- a/cypress_test/integration_tests/mobile/calc/searchbar_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/searchbar_spec.js
@@ -5,11 +5,9 @@ var searchHelper = require('../../common/search_helper');
 var mobileHelper = require('../../common/mobile_helper');
 
 describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Searching via search bar.', function() {
-	var origTestFileName = 'search_bar.ods';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'calc');
+		helper.setupAndLoadDocument('calc/search_bar.ods');
 
 		mobileHelper.enableEditingMobile();
 

--- a/cypress_test/integration_tests/mobile/calc/sheet_operation_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/sheet_operation_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach */
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
@@ -12,10 +12,6 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Sheet Operation', function 
 		testFileName = helper.beforeAll(origTestFileName, 'calc');
 
 		mobileHelper.enableEditingMobile();
-	});
-
-	afterEach(function () {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Insert sheet', function () {

--- a/cypress_test/integration_tests/mobile/calc/sheet_operation_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/sheet_operation_spec.js
@@ -5,11 +5,9 @@ var mobileHelper = require('../../common/mobile_helper');
 var calcHelper = require('../../common/calc_helper');
 
 describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Sheet Operation', function () {
-	var origTestFileName = 'sheet_operation.ods';
-	var testFileName;
 
 	beforeEach(function () {
-		testFileName = helper.beforeAll(origTestFileName, 'calc');
+		helper.setupAndLoadDocument('calc/sheet_operation.ods');
 
 		mobileHelper.enableEditingMobile();
 	});

--- a/cypress_test/integration_tests/mobile/calc/spellchecking_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/spellchecking_spec.js
@@ -5,11 +5,9 @@ var calcHelper = require('../../common/calc_helper');
 var mobileHelper = require('../../common/mobile_helper');
 
 describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Calc spell checking menu.', function() {
-	var origTestFileName = 'spellchecking.ods';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'calc');
+		helper.setupAndLoadDocument('calc/spellchecking.ods');
 
 		// Click on edit button
 		mobileHelper.enableEditingMobile();

--- a/cypress_test/integration_tests/mobile/calc/spellchecking_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/spellchecking_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach expect*/
+/* global describe it cy beforeEach require expect*/
 
 var helper = require('../../common/helper');
 var calcHelper = require('../../common/calc_helper');
@@ -13,10 +13,6 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Calc spell checking menu.',
 
 		// Click on edit button
 		mobileHelper.enableEditingMobile();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	function openContextMenu() {

--- a/cypress_test/integration_tests/mobile/calc/undo_redo_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/undo_redo_spec.js
@@ -6,10 +6,9 @@ var calcHelper = require('../../common/calc_helper');
 var repairHelper = require('../../common/repair_document_helper');
 
 describe.skip(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Editing Operations', function() {
-	var testFileName = 'undo_redo.ods';
 
 	beforeEach(function() {
-		helper.beforeAll(testFileName, 'calc');
+		helper.setupAndLoadDocument('calc/undo_redo.ods');
 
 		// Click on edit button
 		mobileHelper.enableEditingMobile();

--- a/cypress_test/integration_tests/mobile/calc/undo_redo_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/undo_redo_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach */
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
@@ -13,10 +13,6 @@ describe.skip(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Editing Operations', f
 
 		// Click on edit button
 		mobileHelper.enableEditingMobile();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	function undo() {

--- a/cypress_test/integration_tests/mobile/impress/annotation_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/annotation_spec.js
@@ -4,11 +4,10 @@ var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
 
 describe(['tagmobile'], 'Annotation tests.', function() {
-	var origTestFileName = 'annotation.odp';
-	var testFileName;
+	var newFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'impress');
+		newFileName = helper.setupAndLoadDocument('impress/annotation.odp');
 
 		mobileHelper.enableEditingMobile();
 	});
@@ -18,7 +17,7 @@ describe(['tagmobile'], 'Annotation tests.', function() {
 
 		mobileHelper.selectHamburgerMenuItem(['File', 'Save']);
 
-		helper.reload(testFileName, 'impress', true);
+		helper.reloadDocument(newFileName,'impress');
 
 		mobileHelper.enableEditingMobile();
 

--- a/cypress_test/integration_tests/mobile/impress/annotation_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/annotation_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach */
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
@@ -11,10 +11,6 @@ describe(['tagmobile'], 'Annotation tests.', function() {
 		testFileName = helper.beforeAll(origTestFileName, 'impress');
 
 		mobileHelper.enableEditingMobile();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Saving comment.', function() {

--- a/cypress_test/integration_tests/mobile/impress/apply_font_shape_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/apply_font_shape_spec.js
@@ -5,11 +5,9 @@ var mobileHelper = require('../../common/mobile_helper');
 var impressHelper = require('../../common/impress_helper');
 
 describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Apply font on selected shape.', function() {
-	var origTestFileName = 'apply_font_shape.odp';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'impress');
+		helper.setupAndLoadDocument('impress/apply_font_shape.odp');
 
 		mobileHelper.enableEditingMobile();
 

--- a/cypress_test/integration_tests/mobile/impress/apply_font_shape_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/apply_font_shape_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach*/
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
@@ -14,10 +14,6 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Apply font on selected shap
 		mobileHelper.enableEditingMobile();
 
 		impressHelper.selectTextShapeInTheCenter();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	function triggerNewSVG() {

--- a/cypress_test/integration_tests/mobile/impress/apply_font_text_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/apply_font_text_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach*/
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
@@ -11,10 +11,6 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Apply font on selected text
 	beforeEach(function() {
 		testFileName = helper.beforeAll(origTestFileName, 'impress');
 		mobileHelper.enableEditingMobile();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	function triggerNewSVG() {

--- a/cypress_test/integration_tests/mobile/impress/apply_font_text_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/apply_font_text_spec.js
@@ -5,11 +5,9 @@ var mobileHelper = require('../../common/mobile_helper');
 var impressHelper = require('../../common/impress_helper');
 
 describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Apply font on selected text.', function() {
-	var origTestFileName = 'apply_font_text.odp';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'impress');
+		helper.setupAndLoadDocument('impress/apply_font_text.odp');
 		mobileHelper.enableEditingMobile();
 	});
 

--- a/cypress_test/integration_tests/mobile/impress/apply_paragraph_props_shape_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/apply_paragraph_props_shape_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach*/
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
@@ -14,10 +14,6 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Apply paragraph properties 
 		mobileHelper.enableEditingMobile();
 
 		impressHelper.selectTextShapeInTheCenter();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	function triggerNewSVG() {

--- a/cypress_test/integration_tests/mobile/impress/apply_paragraph_props_shape_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/apply_paragraph_props_shape_spec.js
@@ -5,11 +5,9 @@ var mobileHelper = require('../../common/mobile_helper');
 var impressHelper = require('../../common/impress_helper');
 
 describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Apply paragraph properties on selected shape.', function() {
-	var origTestFileName = 'apply_paragraph_props_shape.odp';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'impress');
+		helper.setupAndLoadDocument('impress/apply_paragraph_props_shape.odp');
 
 		mobileHelper.enableEditingMobile();
 

--- a/cypress_test/integration_tests/mobile/impress/apply_paragraph_props_text_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/apply_paragraph_props_text_spec.js
@@ -5,11 +5,9 @@ var mobileHelper = require('../../common/mobile_helper');
 var impressHelper = require('../../common/impress_helper');
 
 describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Apply paragraph properties on selected text.', function() {
-	var origTestFileName = 'apply_paragraph_props_text.odp';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'impress');
+		helper.setupAndLoadDocument('impress/apply_paragraph_props_text.odp');
 
 		mobileHelper.enableEditingMobile();
 

--- a/cypress_test/integration_tests/mobile/impress/apply_paragraph_props_text_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/apply_paragraph_props_text_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach*/
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
@@ -14,10 +14,6 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Apply paragraph properties 
 		mobileHelper.enableEditingMobile();
 
 		impressHelper.selectTextShapeInTheCenter();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	function triggerNewSVG() {

--- a/cypress_test/integration_tests/mobile/impress/delete_objects_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/delete_objects_spec.js
@@ -1,4 +1,4 @@
-/* global describe cy it expect beforeEach require afterEach */
+/* global describe cy it expect beforeEach require */
 
 var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
@@ -18,11 +18,6 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Delete Objects', function()
 
 		mobileHelper.enableEditingMobile();
 	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
-	});
-
 
 	it('Delete Text', function() {
 		helper.setDummyClipboardForCopy();

--- a/cypress_test/integration_tests/mobile/impress/delete_objects_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/delete_objects_spec.js
@@ -4,8 +4,6 @@ var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
 
 describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Delete Objects', function() {
-	var origTestFileName = 'delete_objects.odp';
-	var testFileName;
 
 	var eventOptions = {
 		force: true,
@@ -14,7 +12,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Delete Objects', function()
 	};
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'impress');
+		helper.setupAndLoadDocument('impress/delete_objects.odp');
 
 		mobileHelper.enableEditingMobile();
 	});

--- a/cypress_test/integration_tests/mobile/impress/hamburger_menu_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/hamburger_menu_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy require afterEach */
+/* global describe it cy require */
 
 var helper = require('../../common/helper');
 var impressHelper = require('../../common/impress_helper');
@@ -14,10 +14,6 @@ describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 		// Click on edit button
 		mobileHelper.enableEditingMobile();
 	}
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
-	});
 
 	it('Save', { defaultCommandTimeout: 60000 }, function() {
 		before('hamburger_menu.odp');

--- a/cypress_test/integration_tests/mobile/impress/hamburger_menu_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/hamburger_menu_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy require */
+/* global describe it cy require beforeEach */
 
 var helper = require('../../common/helper');
 var impressHelper = require('../../common/impress_helper');
@@ -6,18 +6,16 @@ var mobileHelper = require('../../common/mobile_helper');
 var repairHelper = require('../../common/repair_document_helper');
 
 describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
-	var testFileName = '';
+	var newFileName;
 
-	function before(testFile) {
-		testFileName = helper.beforeAll(testFile, 'impress');
+	beforeEach(function() {
+		newFileName = helper.setupAndLoadDocument('impress/hamburger_menu.odp');
 
 		// Click on edit button
 		mobileHelper.enableEditingMobile();
-	}
+	});
 
 	it('Save', { defaultCommandTimeout: 60000 }, function() {
-		before('hamburger_menu.odp');
-
 		// Change the document content and save it
 		impressHelper.selectTextShapeInTheCenter();
 
@@ -37,7 +35,7 @@ describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 		mobileHelper.selectHamburgerMenuItem(['File', 'Save']);
 
 		// Reopen the document and check content.
-		helper.reload(testFileName, 'impress', true);
+		helper.reloadDocument(newFileName,'impress');
 
 		mobileHelper.enableEditingMobile();
 
@@ -48,8 +46,6 @@ describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 	});
 
 	it('Print', function() {
-		before('hamburger_menu.odp');
-
 		// A new window should be opened with the PDF.
 		cy.getFrameWindow()
 			.then(function(win) {
@@ -62,8 +58,6 @@ describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 	});
 
 	it('Download as PDF', function() {
-		before('hamburger_menu.odp');
-
 		mobileHelper.selectHamburgerMenuItem(['Download as', 'PDF Document (.pdf)']);
 		mobileHelper.pressPushButtonOfDialog('Export');
 
@@ -73,8 +67,6 @@ describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 	});
 
 	it('Download as ODP', function() {
-		before('hamburger_menu.odp');
-
 		mobileHelper.selectHamburgerMenuItem(['Download as', 'ODF presentation (.odp)']);
 
 		cy.cGet('iframe')
@@ -83,8 +75,6 @@ describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 	});
 
 	it('Download as PPT', function() {
-		before('hamburger_menu.odp');
-
 		mobileHelper.selectHamburgerMenuItem(['Download as', 'PowerPoint 2003 Presentation (.ppt)']);
 
 		cy.cGet('iframe')
@@ -93,8 +83,6 @@ describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 	});
 
 	it('Download as PPTX', function() {
-		before('hamburger_menu.odp');
-
 		mobileHelper.selectHamburgerMenuItem(['Download as', 'PowerPoint Presentation (.pptx)']);
 
 		cy.cGet('iframe')
@@ -103,8 +91,6 @@ describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 	});
 
 	it('Undo/redo.', function() {
-		before('hamburger_menu.odp');
-
 		impressHelper.selectTextShapeInTheCenter();
 
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextPosition tspan')
@@ -138,8 +124,6 @@ describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 	});
 
 	it('Repair.', function() {
-		before('hamburger_menu.odp');
-
 		impressHelper.selectTextShapeInTheCenter();
 
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextPosition tspan')
@@ -164,8 +148,6 @@ describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 	});
 
 	it('Cut.', function() {
-		before('hamburger_menu.odp');
-
 		impressHelper.selectTextShapeInTheCenter();
 		impressHelper.selectTextOfShape();
 
@@ -175,8 +157,6 @@ describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 	});
 
 	it('Copy.', function() {
-		before('hamburger_menu.odp');
-
 		impressHelper.selectTextShapeInTheCenter();
 		impressHelper.selectTextOfShape();
 
@@ -186,8 +166,6 @@ describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 	});
 
 	it('Paste.', function() {
-		before('hamburger_menu.odp');
-
 		impressHelper.selectTextShapeInTheCenter();
 		impressHelper.selectTextOfShape();
 
@@ -197,8 +175,6 @@ describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 	});
 
 	it('Select all.', function() {
-		before('hamburger_menu.odp');
-
 		impressHelper.selectTextShapeInTheCenter();
 
 		impressHelper.dblclickOnSelectedShape();
@@ -214,8 +190,6 @@ describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 	});
 
 	it.skip('Search some word.', function() {
-		before('hamburger_menu.odp');
-
 		mobileHelper.selectHamburgerMenuItem(['Search']);
 
 		// Search bar become visible
@@ -238,8 +212,6 @@ describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 	});
 
 	it('Slide: New Slide.', function() {
-		before('hamburger_menu.odp');
-
 		impressHelper.assertNumberOfSlidePreviews(1);
 
 		mobileHelper.selectHamburgerMenuItem(['Slide', 'New Slide']);
@@ -248,8 +220,6 @@ describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 	});
 
 	it('Slide: Duplicate Slide.', function() {
-		before('hamburger_menu.odp');
-
 		impressHelper.assertNumberOfSlidePreviews(1);
 
 		mobileHelper.selectHamburgerMenuItem(['Slide', 'Duplicate Slide']);
@@ -258,8 +228,6 @@ describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 	});
 
 	it('Slide: Delete Slide.', function() {
-		before('hamburger_menu.odp');
-
 		impressHelper.assertNumberOfSlidePreviews(1);
 
 		mobileHelper.selectHamburgerMenuItem(['Slide', 'New Slide']);
@@ -276,8 +244,6 @@ describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 	});
 
 	it('Full Screen.', function() {
-		before('hamburger_menu.odp');
-
 		mobileHelper.selectHamburgerMenuItem(['Full Screen']);
 
 		// TODO: We can't hit the actual full screen from cypress
@@ -285,8 +251,6 @@ describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 	});
 
 	it('Fullscreen presentation.', function() {
-		before('hamburger_menu.odp');
-
 		cy.cGet('iframe.leaflet-slideshow')
 			.should('not.exist');
 
@@ -297,8 +261,6 @@ describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 	});
 
 	it('Check version information.', function() {
-		before('hamburger_menu.odp');
-
 		mobileHelper.selectHamburgerMenuItem(['About']);
 
 		cy.cGet('#mobile-wizard-content')

--- a/cypress_test/integration_tests/mobile/impress/image_operation_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/image_operation_spec.js
@@ -4,11 +4,9 @@ var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
 
 describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Image Operation Tests', function() {
-	var origTestFileName = 'image_operation.odp';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'impress');
+		helper.setupAndLoadDocument('impress/image_operation.odp');
 
 		// Click on edit button
 		mobileHelper.enableEditingMobile();

--- a/cypress_test/integration_tests/mobile/impress/image_operation_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/image_operation_spec.js
@@ -1,4 +1,4 @@
-/* global describe it beforeEach require afterEach */
+/* global describe it beforeEach require */
 
 var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
@@ -12,10 +12,6 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Image Operation Tests', fun
 
 		// Click on edit button
 		mobileHelper.enableEditingMobile();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Insert Image', function() {

--- a/cypress_test/integration_tests/mobile/impress/impress_focus_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/impress_focus_spec.js
@@ -5,11 +5,9 @@ var mobileHelper = require('../../common/mobile_helper');
 var impressHelper = require('../../common/impress_helper');
 
 describe(['tagmobile', 'tagproxy'], 'Impress focus tests', function() {
-	var origTestFileName = 'focus.odp';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'impress');
+		helper.setupAndLoadDocument('impress/focus.odp');
 	});
 
 	it('Select text box, no editing', function() {

--- a/cypress_test/integration_tests/mobile/impress/impress_focus_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/impress_focus_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach expect */
+/* global describe it cy beforeEach require expect */
 
 var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
@@ -10,10 +10,6 @@ describe(['tagmobile', 'tagproxy'], 'Impress focus tests', function() {
 
 	beforeEach(function() {
 		testFileName = helper.beforeAll(origTestFileName, 'impress');
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Select text box, no editing', function() {

--- a/cypress_test/integration_tests/mobile/impress/insertion_wizard_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/insertion_wizard_spec.js
@@ -5,11 +5,9 @@ var mobileHelper = require('../../common/mobile_helper');
 var impressHelper = require('../../common/impress_helper');
 
 describe(['tagmobile', 'tagnextcloud'], 'Impress insertion wizard.', function() {
-	var origTestFileName = 'insertion_wizard.odp';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'impress');
+		helper.setupAndLoadDocument('impress/insertion_wizard.odp');
 
 		mobileHelper.enableEditingMobile();
 	});

--- a/cypress_test/integration_tests/mobile/impress/insertion_wizard_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/insertion_wizard_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require expect afterEach Cypress*/
+/* global describe it cy beforeEach require expect Cypress*/
 
 var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
@@ -12,10 +12,6 @@ describe(['tagmobile', 'tagnextcloud'], 'Impress insertion wizard.', function() 
 		testFileName = helper.beforeAll(origTestFileName, 'impress');
 
 		mobileHelper.enableEditingMobile();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	function selectionShouldBeTextShape(checkShape) {

--- a/cypress_test/integration_tests/mobile/impress/nextcloud_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/nextcloud_spec.js
@@ -1,26 +1,28 @@
-/* global describe it cy require Cypress */
+/* global describe it cy require Cypress beforeEach */
 
 var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
 var nextcloudHelper = require('../../common/nextcloud_helper');
 
 describe(['tagnextcloud'], 'Nextcloud specific tests.', function() {
-	var origTestFileName = 'nextcloud.odp';
-	var testFileName;
+
+	beforeEach(function() {
+	});
 
 	it('Insert image from storage.', function() {
-		helper.upLoadFileToNextCloud('image_to_insert.png', 'impress');
-		testFileName = helper.beforeAll(origTestFileName, 'impress', undefined, true);
+		helper.setupAndLoadDocument('impress/nextcloud.odp');
 		mobileHelper.enableEditingMobile();
+
+		helper.upLoadFileToNextCloud('image_to_insert.png', 'impress');
 		nextcloudHelper.insertImageFromStorage('image_to_insert.png');
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane svg g').should('exist');
 	});
 
 	it('Save as.', function() {
-		testFileName = helper.beforeAll(origTestFileName, 'impress');
-		// Click on edit button
+		var newFileName = helper.setupAndLoadDocument('impress/nextcloud.odp');
 		mobileHelper.enableEditingMobile();
-		nextcloudHelper.saveFileAs('1' + testFileName);
+
+		nextcloudHelper.saveFileAs('1' + newFileName);
 		// Close the document
 		cy.cGet('#mobile-edit-button').should('be.visible');
 		cy.cGet('#toolbar-mobile-back').then(function(item) {
@@ -29,13 +31,14 @@ describe(['tagnextcloud'], 'Nextcloud specific tests.', function() {
 				Cypress.env('IFRAME_LEVEL', '');
 			});
 
-		cy.cGet('tr[data-file=\'1' + testFileName + '\']').should('be.visible');
-		cy.cGet('tr[data-file=\'' + testFileName + '\']').should('be.visible');
+		cy.cGet('tr[data-file=\'1' + newFileName + '\']').should('be.visible');
+		cy.cGet('tr[data-file=\'' + newFileName + '\']').should('be.visible');
 	});
 
 	it('Share.', function() {
-		testFileName = helper.beforeAll(origTestFileName, 'impress');
+		helper.setupAndLoadDocument('impress/nextcloud.odp');
 		mobileHelper.enableEditingMobile();
+
 		nextcloudHelper.checkAndCloseSharing();
 	});
 });

--- a/cypress_test/integration_tests/mobile/impress/nextcloud_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/nextcloud_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy require afterEach Cypress */
+/* global describe it cy require Cypress */
 
 var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
@@ -7,10 +7,6 @@ var nextcloudHelper = require('../../common/nextcloud_helper');
 describe(['tagnextcloud'], 'Nextcloud specific tests.', function() {
 	var origTestFileName = 'nextcloud.odp';
 	var testFileName;
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
-	});
 
 	it('Insert image from storage.', function() {
 		helper.upLoadFileToNextCloud('image_to_insert.png', 'impress');

--- a/cypress_test/integration_tests/mobile/impress/searchbar_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/searchbar_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach expect */
+/* global describe it cy beforeEach require expect */
 
 var helper = require('../../common/helper');
 var searchHelper = require('../../common/search_helper');
@@ -15,10 +15,6 @@ describe.skip('Searching via search bar.', function() {
 		mobileHelper.enableEditingMobile();
 
 		searchHelper.showSearchBar();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Search existing word.', function() {

--- a/cypress_test/integration_tests/mobile/impress/searchbar_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/searchbar_spec.js
@@ -6,11 +6,9 @@ var mobileHelper = require('../../common/mobile_helper');
 var impressHelper = require('../../common/impress_helper');
 
 describe.skip('Searching via search bar.', function() {
-	var origTestFileName = 'search_bar.odp';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'impress');
+		helper.setupAndLoadDocument('impress/search_bar.odp');
 
 		mobileHelper.enableEditingMobile();
 

--- a/cypress_test/integration_tests/mobile/impress/slide_operation_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/slide_operation_spec.js
@@ -5,11 +5,9 @@ var impressHelper = require('../../common/impress_helper');
 var mobileHelper = require('../../common/mobile_helper');
 
 describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Slide operations', function() {
-	var origTestFileName = 'slide_operations.odp';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'impress');
+		helper.setupAndLoadDocument('impress/slide_operations.odp');
 
 		mobileHelper.enableEditingMobile();
 	});

--- a/cypress_test/integration_tests/mobile/impress/slide_operation_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/slide_operation_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy require afterEach beforeEach*/
+/* global describe it cy require beforeEach*/
 
 var helper = require('../../common/helper');
 var impressHelper = require('../../common/impress_helper');
@@ -12,10 +12,6 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Slide operations', function
 		testFileName = helper.beforeAll(origTestFileName, 'impress');
 
 		mobileHelper.enableEditingMobile();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Add slides', function() {

--- a/cypress_test/integration_tests/mobile/impress/slide_properties_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/slide_properties_spec.js
@@ -4,11 +4,9 @@ var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
 
 describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Changing slide properties.', function() {
-	var origTestFileName = 'slide_properties.odp';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'impress');
+		helper.setupAndLoadDocument('impress/slide_properties.odp');
 		mobileHelper.enableEditingMobile();
 		previewShouldBeFullWhite();
 		mobileHelper.openMobileWizard();

--- a/cypress_test/integration_tests/mobile/impress/slide_properties_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/slide_properties_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy require afterEach expect beforeEach */
+/* global describe it cy require expect beforeEach */
 
 var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
@@ -12,10 +12,6 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Changing slide properties.'
 		mobileHelper.enableEditingMobile();
 		previewShouldBeFullWhite();
 		mobileHelper.openMobileWizard();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	function previewShouldBeFullWhite(fullWhite = true, slideNumber = 1) {

--- a/cypress_test/integration_tests/mobile/impress/slide_properties_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/slide_properties_spec.js
@@ -293,10 +293,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Changing slide properties.'
 	});
 
 	it('Apply master slide layout.', function() {
-		// Wait for mobile wizard menu
-		cy.wait(500);
-
-		// We have white background by deafult checked by before() method
+		// We have white background by deafult checked by beforeEach() method
 		// Select a new master slide with a background color
 		cy.cGet('#masterslide .ui-header-left').should('have.text', 'Default');
 

--- a/cypress_test/integration_tests/mobile/impress/spellchecking_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/spellchecking_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach expect*/
+/* global describe it cy beforeEach require expect*/
 
 var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
@@ -13,10 +13,6 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Spell checking menu.', func
 
 		// Click on edit button
 		mobileHelper.enableEditingMobile();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	function openContextMenu() {

--- a/cypress_test/integration_tests/mobile/impress/spellchecking_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/spellchecking_spec.js
@@ -5,11 +5,9 @@ var mobileHelper = require('../../common/mobile_helper');
 var impressHelper = require('../../common/impress_helper');
 
 describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Spell checking menu.', function() {
-	var origTestFileName = 'spellchecking.odp';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'impress');
+		helper.setupAndLoadDocument('impress/spellchecking.odp');
 
 		// Click on edit button
 		mobileHelper.enableEditingMobile();

--- a/cypress_test/integration_tests/mobile/impress/table_operation_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/table_operation_spec.js
@@ -5,11 +5,9 @@ var mobileHelper = require('../../common/mobile_helper');
 var impressHelper = require('../../common/impress_helper');
 
 describe.skip(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Table Operation', function() {
-	var origTestFileName = 'table_operation.odp';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'impress');
+		helper.setupAndLoadDocument('impress/table_operation.odp');
 
 		mobileHelper.enableEditingMobile();
 	});

--- a/cypress_test/integration_tests/mobile/impress/table_operation_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/table_operation_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach expect require afterEach */
+/* global describe it cy beforeEach expect require */
 
 var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
@@ -12,10 +12,6 @@ describe.skip(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Table Operation', func
 		testFileName = helper.beforeAll(origTestFileName, 'impress');
 
 		mobileHelper.enableEditingMobile();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	function retriggerNewSvgForTableInTheCenter() {

--- a/cypress_test/integration_tests/mobile/impress/undo_redo_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/undo_redo_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach */
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
@@ -22,11 +22,6 @@ describe.skip(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Editing Operations', f
 
 		helper.typeIntoDocument('Hello World');
 	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
-	});
-
 
 	function undo() {
 		cy.cGet('path.leaflet-interactive').dblclick();

--- a/cypress_test/integration_tests/mobile/impress/undo_redo_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/undo_redo_spec.js
@@ -6,10 +6,9 @@ var impressHelper = require('../../common/impress_helper');
 var repairHelper = require('../../common/repair_document_helper');
 
 describe.skip(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Editing Operations', function() {
-	var testFileName = 'undo_redo.odp';
 
 	beforeEach(function() {
-		helper.beforeAll(testFileName, 'impress');
+		helper.setupAndLoadDocument('impress/undo_redo.odp');
 
 		// Click on edit button
 		mobileHelper.enableEditingMobile();

--- a/cypress_test/integration_tests/mobile/writer/annotation_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/annotation_spec.js
@@ -4,21 +4,18 @@ var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
 
 describe(['tagmobile'], 'Annotation tests.', function() {
-	var origTestFileName = 'annotation.odt';
-	var testFileName;
+	var newFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'writer');
+		newFileName = helper.setupAndLoadDocument('writer/annotation.odt');
 
-		// Click on edit button
 		mobileHelper.enableEditingMobile();
 	});
 
 	it('Saving comment.', { defaultCommandTimeout: 60000 }, function() {
-		cy.wait(1000);
 		mobileHelper.insertComment();
 		mobileHelper.selectHamburgerMenuItem(['File', 'Save']);
-		helper.reload(testFileName, 'writer', true);
+		helper.reloadDocument(newFileName, 'writer');
 		mobileHelper.enableEditingMobile();
 		mobileHelper.openCommentWizard();
 		helper.waitUntilIdle('#mobile-wizard-content', undefined);

--- a/cypress_test/integration_tests/mobile/writer/annotation_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/annotation_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach */
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
@@ -13,11 +13,6 @@ describe(['tagmobile'], 'Annotation tests.', function() {
 		// Click on edit button
 		mobileHelper.enableEditingMobile();
 	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
-	});
-
 
 	it('Saving comment.', { defaultCommandTimeout: 60000 }, function() {
 		cy.wait(1000);

--- a/cypress_test/integration_tests/mobile/writer/apply_font_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/apply_font_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach */
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
@@ -13,10 +13,6 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Apply font changes.', funct
 		mobileHelper.enableEditingMobile();
 		writerHelper.selectAllTextOfDoc();
 		mobileHelper.openMobileWizard();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Apply font name.', function() {

--- a/cypress_test/integration_tests/mobile/writer/apply_font_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/apply_font_spec.js
@@ -5,11 +5,9 @@ var mobileHelper = require('../../common/mobile_helper');
 var writerHelper = require('../../common/writer_helper');
 
 describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Apply font changes.', function() {
-	var origTestFileName = 'apply_font.odt';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'writer');
+		helper.setupAndLoadDocument('writer/apply_font.odt');
 		mobileHelper.enableEditingMobile();
 		writerHelper.selectAllTextOfDoc();
 		mobileHelper.openMobileWizard();

--- a/cypress_test/integration_tests/mobile/writer/apply_paragraph_properties_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/apply_paragraph_properties_spec.js
@@ -5,11 +5,9 @@ var mobileHelper = require('../../common/mobile_helper');
 var writerHelper = require('../../common/writer_helper');
 
 describe.skip('Apply paragraph properties.', function() {
-	var origTestFileName = 'apply_paragraph_properties.odt';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'writer');
+		helper.setupAndLoadDocument('writer/apply_paragraph_properties.odt');
 		mobileHelper.enableEditingMobile();
 		writerHelper.selectAllTextOfDoc();
 		mobileHelper.openMobileWizard();

--- a/cypress_test/integration_tests/mobile/writer/apply_paragraph_properties_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/apply_paragraph_properties_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach */
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
@@ -17,10 +17,6 @@ describe.skip('Apply paragraph properties.', function() {
 		cy.cGet('#Paragraph').click();
 		cy.cGet('#Paragraph').should('have.class', 'selected');
 		cy.cGet('#LeftPara').should('be.visible');
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	/*it('Apply left/right alignment.', function() {

--- a/cypress_test/integration_tests/mobile/writer/bottom_toolbar_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/bottom_toolbar_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach*/
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
@@ -14,10 +14,6 @@ describe.skip('Pushing bottom toolbar items.', function() {
 		mobileHelper.enableEditingMobile();
 
 		writerHelper.selectAllTextOfDoc();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Apply bold.', function() {

--- a/cypress_test/integration_tests/mobile/writer/bottom_toolbar_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/bottom_toolbar_spec.js
@@ -5,11 +5,9 @@ var mobileHelper = require('../../common/mobile_helper');
 var writerHelper = require('../../common/writer_helper');
 
 describe.skip('Pushing bottom toolbar items.', function() {
-	var origTestFileName = 'bottom_toolbar.odt';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'writer');
+		helper.setupAndLoadDocument('writer/bottom_toolbar.odt');
 
 		mobileHelper.enableEditingMobile();
 

--- a/cypress_test/integration_tests/mobile/writer/cursor_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/cursor_spec.js
@@ -5,10 +5,9 @@ var mobileHelper = require('../../common/mobile_helper');
 var writerHelper = require('../../common/writer_helper');
 
 describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Text cursor tests.', function() {
-	var testFileName;
 
 	function before(fileName) {
-		testFileName = helper.beforeAll(fileName, 'writer');
+		helper.setupAndLoadDocument('writer/' + fileName);
 
 		mobileHelper.enableEditingMobile();
 	}

--- a/cypress_test/integration_tests/mobile/writer/cursor_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/cursor_spec.js
@@ -1,4 +1,4 @@
-/* global describe it require afterEach cy */
+/* global describe it require cy */
 
 var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
@@ -12,10 +12,6 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Text cursor tests.', functi
 
 		mobileHelper.enableEditingMobile();
 	}
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
-	});
 
 	it('Extensive cursor movements.', function() {
 		before('cursor.odt');

--- a/cypress_test/integration_tests/mobile/writer/delete_objects_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/delete_objects_spec.js
@@ -4,8 +4,6 @@ var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
 
 describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Delete Objects', function() {
-	var origTestFileName = 'delete_objects.odt';
-	var testFileName;
 
 	var eventOptions = {
 		force: true,
@@ -14,7 +12,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Delete Objects', function()
 	};
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'writer');
+		helper.setupAndLoadDocument('writer/delete_objects.odt');
 
 		// Click on edit button
 		mobileHelper.enableEditingMobile();

--- a/cypress_test/integration_tests/mobile/writer/delete_objects_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/delete_objects_spec.js
@@ -1,4 +1,4 @@
-/* global describe beforeEach cy it expect require afterEach */
+/* global describe beforeEach cy it expect require */
 
 var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
@@ -18,10 +18,6 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Delete Objects', function()
 
 		// Click on edit button
 		mobileHelper.enableEditingMobile();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Delete Text', function() {

--- a/cypress_test/integration_tests/mobile/writer/focus_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/focus_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach expect*/
+/* global describe it cy beforeEach require expect*/
 
 var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
@@ -9,10 +9,6 @@ describe(['tagmobile', 'tagproxy'], 'Focus tests', function() {
 
 	beforeEach(function() {
 		testFileName = helper.beforeAll(origTestFileName, 'writer');
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Basic document focus.', function() {

--- a/cypress_test/integration_tests/mobile/writer/focus_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/focus_spec.js
@@ -4,11 +4,9 @@ var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
 
 describe(['tagmobile', 'tagproxy'], 'Focus tests', function() {
-	var origTestFileName = 'focus.odt';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'writer');
+		helper.setupAndLoadDocument('writer/focus.odt');
 	});
 
 	it('Basic document focus.', function() {

--- a/cypress_test/integration_tests/mobile/writer/hamburger_menu_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/hamburger_menu_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach expect */
+/* global describe it cy beforeEach require expect */
 
 var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
@@ -13,10 +13,6 @@ describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 		testFileName = helper.beforeAll(origTestFileName, 'writer');
 
 		mobileHelper.enableEditingMobile();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	function hideText() {

--- a/cypress_test/integration_tests/mobile/writer/hamburger_menu_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/hamburger_menu_spec.js
@@ -6,11 +6,10 @@ var writerHelper = require('../../common/writer_helper');
 var repairHelper = require('../../common/repair_document_helper');
 
 describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
-	var origTestFileName = 'hamburger_menu.odt';
-	var testFileName;
+	var newFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'writer');
+		newFileName = helper.setupAndLoadDocument('writer/hamburger_menu.odt');
 
 		mobileHelper.enableEditingMobile();
 	});
@@ -48,7 +47,7 @@ describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 		helper.expectTextForClipboard('new');
 		mobileHelper.selectHamburgerMenuItem(['File', 'Save']);
 		// Reopen the document and check content.
-		helper.reload(testFileName, 'writer', true);
+		helper.reloadDocument(newFileName, 'writer');
 		mobileHelper.enableEditingMobile();
 		writerHelper.selectAllTextOfDoc();
 		helper.expectTextForClipboard('new');

--- a/cypress_test/integration_tests/mobile/writer/image_operation_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/image_operation_spec.js
@@ -1,4 +1,4 @@
-/* global describe it beforeEach require afterEach */
+/* global describe it beforeEach require */
 
 var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
@@ -12,10 +12,6 @@ describe.skip('Image Operation Tests', function() {
 
 		// Click on edit button
 		mobileHelper.enableEditingMobile();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Insert Image', function() {

--- a/cypress_test/integration_tests/mobile/writer/image_operation_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/image_operation_spec.js
@@ -4,11 +4,9 @@ var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
 
 describe.skip('Image Operation Tests', function() {
-	var origTestFileName = 'image_operation.odt';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'writer');
+		helper.setupAndLoadDocument('writer/image_operation.odt');
 
 		// Click on edit button
 		mobileHelper.enableEditingMobile();

--- a/cypress_test/integration_tests/mobile/writer/insert_content_control_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/insert_content_control_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach expect */
+/* global describe it cy beforeEach require expect */
 
 var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
@@ -12,10 +12,6 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Insert objects via insertio
 
 		// Click on edit button
 		mobileHelper.enableEditingMobile();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Insert Dropdown.', function() {

--- a/cypress_test/integration_tests/mobile/writer/insert_content_control_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/insert_content_control_spec.js
@@ -4,11 +4,9 @@ var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
 
 describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Insert objects via insertion wizard.', function() {
-	var origTestFileName = 'insert_object.odt';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'writer');
+		helper.setupAndLoadDocument('writer/insert_object.odt');
 
 		// Click on edit button
 		mobileHelper.enableEditingMobile();

--- a/cypress_test/integration_tests/mobile/writer/insert_field_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/insert_field_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach*/
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
@@ -16,10 +16,6 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Insert fields via insertion
 		// Open fields submenu
 		cy.cGet('body').contains('.menu-entry-with-icon.flex-fullwidth', 'More Fields...').click();
 		cy.cGet('.ui-content.level-0.mobile-wizard').should('be.visible');
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Insert page number field.', function() {

--- a/cypress_test/integration_tests/mobile/writer/insert_field_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/insert_field_spec.js
@@ -5,11 +5,9 @@ var mobileHelper = require('../../common/mobile_helper');
 var writerHelper = require('../../common/writer_helper');
 
 describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Insert fields via insertion wizard.', function() {
-	var origTestFileName = 'insert_field.odt';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'writer');
+		helper.setupAndLoadDocument('writer/insert_field.odt');
 		// Click on edit button
 		mobileHelper.enableEditingMobile();
 		mobileHelper.openInsertionWizard();

--- a/cypress_test/integration_tests/mobile/writer/insert_formatting_mark_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/insert_formatting_mark_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach*/
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
@@ -16,10 +16,6 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Insert formatting mark via 
 		// Open formatting marks
 		cy.cGet('body').contains('.menu-entry-with-icon.flex-fullwidth', 'Formatting Mark').click();
 		cy.cGet('.ui-content.level-0.mobile-wizard').should('be.visible');
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Insert non-breaking space.', function() {

--- a/cypress_test/integration_tests/mobile/writer/insert_formatting_mark_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/insert_formatting_mark_spec.js
@@ -5,11 +5,9 @@ var mobileHelper = require('../../common/mobile_helper');
 var writerHelper = require('../../common/writer_helper');
 
 describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Insert formatting mark via insertion wizard.', function() {
-	var origTestFileName = 'insert_formatting_mark.odt';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'writer');
+		helper.setupAndLoadDocument('writer/insert_formatting_mark.odt');
 		// Click on edit button
 		mobileHelper.enableEditingMobile();
 		mobileHelper.openInsertionWizard();

--- a/cypress_test/integration_tests/mobile/writer/insert_object_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/insert_object_spec.js
@@ -5,11 +5,9 @@ var mobileHelper = require('../../common/mobile_helper');
 var writerHelper = require('../../common/writer_helper');
 
 describe(['tagmobile', 'tagnextcloud'], 'Insert objects via insertion wizard.', function() {
-	var origTestFileName = 'insert_object.odt';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'writer');
+		helper.setupAndLoadDocument('writer/insert_object.odt');
 		// Click on edit button
 		mobileHelper.enableEditingMobile();
 	});

--- a/cypress_test/integration_tests/mobile/writer/insert_object_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/insert_object_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require expect afterEach */
+/* global describe it cy beforeEach require expect */
 
 var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
@@ -12,10 +12,6 @@ describe(['tagmobile', 'tagnextcloud'], 'Insert objects via insertion wizard.', 
 		testFileName = helper.beforeAll(origTestFileName, 'writer');
 		// Click on edit button
 		mobileHelper.enableEditingMobile();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Insert local image.', function() {

--- a/cypress_test/integration_tests/mobile/writer/mobile_wizard_state_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/mobile_wizard_state_spec.js
@@ -4,11 +4,9 @@ var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
 
 describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Mobile wizard state tests', function() {
-	var origTestFileName = 'mobile_wizard_state.odt';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'writer');
+		helper.setupAndLoadDocument('writer/mobile_wizard_state.odt');
 	});
 
 	it('Open and close mobile wizard by toolbar item.', function() {

--- a/cypress_test/integration_tests/mobile/writer/mobile_wizard_state_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/mobile_wizard_state_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach */
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
@@ -9,10 +9,6 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Mobile wizard state tests',
 
 	beforeEach(function() {
 		testFileName = helper.beforeAll(origTestFileName, 'writer');
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Open and close mobile wizard by toolbar item.', function() {

--- a/cypress_test/integration_tests/mobile/writer/nextcloud_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/nextcloud_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy require afterEach Cypress */
+/* global describe it cy require Cypress */
 
 var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
@@ -7,10 +7,6 @@ var nextcloudHelper = require('../../common/nextcloud_helper');
 describe(['tagnextcloud'], 'Nextcloud specific tests.', function() {
 	var origTestFileName = 'nextcloud.odt';
 	var testFileName;
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
-	});
 
 	it('Insert image from storage.', function() {
 		helper.upLoadFileToNextCloud('image_to_insert.png', 'writer');

--- a/cypress_test/integration_tests/mobile/writer/nextcloud_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/nextcloud_spec.js
@@ -5,16 +5,12 @@ var mobileHelper = require('../../common/mobile_helper');
 var nextcloudHelper = require('../../common/nextcloud_helper');
 
 describe(['tagnextcloud'], 'Nextcloud specific tests.', function() {
-	var origTestFileName = 'nextcloud.odt';
-	var testFileName;
 
 	it('Insert image from storage.', function() {
-		helper.upLoadFileToNextCloud('image_to_insert.png', 'writer');
-
-		testFileName = helper.beforeAll(origTestFileName, 'writer', undefined, true);
-
+		helper.setupAndLoadDocument('writer/nextcloud.odt');
 		mobileHelper.enableEditingMobile();
 
+		helper.upLoadFileToNextCloud('image_to_insert.png', 'writer');
 		nextcloudHelper.insertImageFromStorage('image_to_insert.png');
 
 		cy.get('.leaflet-pane.leaflet-overlay-pane svg g.Graphic')
@@ -22,11 +18,10 @@ describe(['tagnextcloud'], 'Nextcloud specific tests.', function() {
 	});
 
 	it('Save as.', function() {
-		testFileName = helper.beforeAll(origTestFileName, 'writer');
-
+		var newFileName = helper.setupAndLoadDocument('writer/nextcloud.odt');
 		mobileHelper.enableEditingMobile();
 
-		nextcloudHelper.saveFileAs('1' + testFileName);
+		nextcloudHelper.saveFileAs('1' + newFileName);
 
 		// Close the document
 		cy.get('#mobile-edit-button')
@@ -39,16 +34,15 @@ describe(['tagnextcloud'], 'Nextcloud specific tests.', function() {
 				Cypress.env('IFRAME_LEVEL', '');
 			});
 
-		cy.get('tr[data-file=\'1' + testFileName + '\']')
+		cy.get('tr[data-file=\'1' + newFileName + '\']')
 			.should('be.visible');
 
-		cy.get('tr[data-file=\'' + testFileName + '\']')
+		cy.get('tr[data-file=\'' + newFileName + '\']')
 			.should('be.visible');
 	});
 
 	it('Share.', function() {
-		testFileName = helper.beforeAll(origTestFileName, 'writer');
-
+		helper.setupAndLoadDocument('writer/nextcloud.odt');
 		mobileHelper.enableEditingMobile();
 
 		nextcloudHelper.checkAndCloseSharing();

--- a/cypress_test/integration_tests/mobile/writer/searchbar_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/searchbar_spec.js
@@ -6,11 +6,9 @@ var mobileHelper = require('../../common/mobile_helper');
 var writerHelper = require('../../common/writer_helper');
 
 describe.skip('Searching via search bar.', function() {
-	var origTestFileName = 'search_bar.odt';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'writer');
+		helper.setupAndLoadDocument('writer/search_bar.odt');
 		mobileHelper.enableEditingMobile();
 		searchHelper.showSearchBar();
 	});

--- a/cypress_test/integration_tests/mobile/writer/searchbar_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/searchbar_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach*/
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 var searchHelper = require('../../common/search_helper');
@@ -13,10 +13,6 @@ describe.skip('Searching via search bar.', function() {
 		testFileName = helper.beforeAll(origTestFileName, 'writer');
 		mobileHelper.enableEditingMobile();
 		searchHelper.showSearchBar();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Search existing word.', function() {

--- a/cypress_test/integration_tests/mobile/writer/shape_properties_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/shape_properties_spec.js
@@ -9,9 +9,6 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Change shape properties via
 	const defaultAltitude = 5992;
 	const unitScale = 2540.37;
 
-	var origTestFileName = 'shape_properties.odt';
-	var testFileName;
-
 	class TriangleCoordinatesMatcher {
 		/**
 		 * @param {number} start
@@ -63,7 +60,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Change shape properties via
 	}
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'writer');
+		helper.setupAndLoadDocument('writer/shape_properties.odt');
 		mobileHelper.enableEditingMobile();
 		helper.moveCursor('end');
 		helper.moveCursor('home');

--- a/cypress_test/integration_tests/mobile/writer/shape_properties_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/shape_properties_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach Cypress expect */
+/* global describe it cy beforeEach require Cypress expect */
 
 var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
@@ -73,10 +73,6 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Change shape properties via
 		cy.cGet('.basicshapes_right-triangle').click();
 		// Check that the shape is there
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane svg g svg g', { timeout: Cypress.config('defaultCommandTimeout') * 2.0 }).should('have.class', 'com.sun.star.drawing.CustomShape');
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	function triggerNewSVG() {

--- a/cypress_test/integration_tests/mobile/writer/spellchecking_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/spellchecking_spec.js
@@ -5,11 +5,9 @@ var mobileHelper = require('../../common/mobile_helper');
 var writerHelper = require('../../common/writer_helper');
 
 describe.skip('Spell checking menu.', function() {
-	var origTestFileName = 'spellchecking.odt';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'writer');
+		helper.setupAndLoadDocument('writer/spellchecking.odt');
 
 		// Click on edit button
 		mobileHelper.enableEditingMobile();

--- a/cypress_test/integration_tests/mobile/writer/spellchecking_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/spellchecking_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach expect*/
+/* global describe it cy beforeEach require expect*/
 
 var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
@@ -13,10 +13,6 @@ describe.skip('Spell checking menu.', function() {
 
 		// Click on edit button
 		mobileHelper.enableEditingMobile();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	function openContextMenu() {

--- a/cypress_test/integration_tests/mobile/writer/table_properties_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/table_properties_spec.js
@@ -5,10 +5,9 @@ var mobileHelper = require('../../common/mobile_helper');
 var writerHelper = require('../../common/writer_helper');
 
 describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Change table properties / layout via mobile wizard.', function() {
-	var testFileName = '';
 
 	function before(testFile) {
-		testFileName = helper.beforeAll(testFile, 'writer');
+		helper.setupAndLoadDocument('writer/' + testFile);
 
 		// Click on edit button
 		mobileHelper.enableEditingMobile();

--- a/cypress_test/integration_tests/mobile/writer/table_properties_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/table_properties_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy require expect afterEach */
+/* global describe it cy require expect */
 
 var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
@@ -13,10 +13,6 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Change table properties / l
 		// Click on edit button
 		mobileHelper.enableEditingMobile();
 	}
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
-	});
 
 	function openTablePanel() {
 		mobileHelper.openMobileWizard();

--- a/cypress_test/integration_tests/mobile/writer/table_properties_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/table_properties_spec.js
@@ -6,8 +6,8 @@ var writerHelper = require('../../common/writer_helper');
 
 describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Change table properties / layout via mobile wizard.', function() {
 
-	function before(testFile) {
-		helper.setupAndLoadDocument('writer/' + testFile);
+	function before(fileName) {
+		helper.setupAndLoadDocument('writer/' + fileName);
 
 		// Click on edit button
 		mobileHelper.enableEditingMobile();

--- a/cypress_test/integration_tests/mobile/writer/toolbar_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/toolbar_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach*/
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
@@ -9,10 +9,6 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Toolbar tests', function() 
 
 	beforeEach(function() {
 		testFileName = helper.beforeAll(origTestFileName, 'writer');
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('State of mobile wizard toolbar item.', function() {

--- a/cypress_test/integration_tests/mobile/writer/toolbar_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/toolbar_spec.js
@@ -4,11 +4,9 @@ var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
 
 describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Toolbar tests', function() {
-	var origTestFileName = 'toolbar.odt';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'writer');
+		helper.setupAndLoadDocument('writer/toolbar.odt');
 	});
 
 	it('State of mobile wizard toolbar item.', function() {

--- a/cypress_test/integration_tests/mobile/writer/track_changes_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/track_changes_spec.js
@@ -4,11 +4,9 @@ var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
 
 describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Track Changes', function() {
-	var origTestFileName = 'track_changes.odt';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'writer');
+		helper.setupAndLoadDocument('writer/track_changes.odt');
 
 		// Click on edit button
 		mobileHelper.enableEditingMobile();

--- a/cypress_test/integration_tests/mobile/writer/track_changes_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/track_changes_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach */
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
@@ -12,10 +12,6 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Track Changes', function() 
 
 		// Click on edit button
 		mobileHelper.enableEditingMobile();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	function confirmChange(action) {

--- a/cypress_test/integration_tests/mobile/writer/undo_redo_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/undo_redo_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach */
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
@@ -11,10 +11,6 @@ describe.skip(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Editing Operations', f
 		helper.beforeAll(testFileName, 'writer');
 		// Click on edit button
 		mobileHelper.enableEditingMobile();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	function undo() {

--- a/cypress_test/integration_tests/mobile/writer/undo_redo_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/undo_redo_spec.js
@@ -5,10 +5,9 @@ var mobileHelper = require('../../common/mobile_helper');
 var repairHelper = require('../../common/repair_document_helper');
 
 describe.skip(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Editing Operations', function() {
-	var testFileName = 'undo_redo.odt';
 
 	beforeEach(function() {
-		helper.beforeAll(testFileName, 'writer');
+		helper.setupAndLoadDocument('writer/undo_redo.odt');
 		// Click on edit button
 		mobileHelper.enableEditingMobile();
 	});

--- a/cypress_test/integration_tests/multiuser/calc/annotation_spec.js
+++ b/cypress_test/integration_tests/multiuser/calc/annotation_spec.js
@@ -1,4 +1,4 @@
-/* global describe it require cy afterEach beforeEach */
+/* global describe it require cy beforeEach */
 
 var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
@@ -10,10 +10,6 @@ describe(['tagmultiuser'], 'Multiuser Annotation Tests', function() {
 	beforeEach(function() {
 		testFileName = helper.beforeAll(origTestFileName, 'calc', undefined, true);
 		desktopHelper.switchUIToNotebookbar();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Insert',function() {
@@ -100,10 +96,6 @@ describe(['tagmultiuser'], 'Multiuser Annotation Autosave Tests', function() {
 	beforeEach(function() {
 		testFileName = helper.beforeAll(origTestFileName, 'calc', undefined, true);
 		desktopHelper.switchUIToNotebookbar();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Insert autosave',function() {

--- a/cypress_test/integration_tests/multiuser/calc/annotation_spec.js
+++ b/cypress_test/integration_tests/multiuser/calc/annotation_spec.js
@@ -4,11 +4,9 @@ var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
 
 describe(['tagmultiuser'], 'Multiuser Annotation Tests', function() {
-	var origTestFileName = 'annotation.ods';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'calc', undefined, true);
+		helper.setupAndLoadDocument('calc/annotation.ods',true);
 		desktopHelper.switchUIToNotebookbar();
 	});
 
@@ -90,11 +88,10 @@ describe(['tagmultiuser'], 'Multiuser Annotation Tests', function() {
 });
 
 describe(['tagmultiuser'], 'Multiuser Annotation Autosave Tests', function() {
-	var origTestFileName = 'annotation.ods';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'calc', undefined, true);
+
+		helper.setupAndLoadDocument('calc/annotation.ods',true);
 		desktopHelper.switchUIToNotebookbar();
 	});
 

--- a/cypress_test/integration_tests/multiuser/calc/invalidations_spec.js
+++ b/cypress_test/integration_tests/multiuser/calc/invalidations_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach expect require afterEach */
+/* global describe it cy beforeEach expect require */
 
 var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
@@ -10,10 +10,6 @@ describe(['tagmultiuser'], 'Joining a document should not trigger an invalidatio
 	beforeEach(function() {
 		testFileName = helper.beforeAll(origTestFileName, 'calc', undefined, true);
 		desktopHelper.switchUIToNotebookbar();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Join document', function() {

--- a/cypress_test/integration_tests/multiuser/calc/invalidations_spec.js
+++ b/cypress_test/integration_tests/multiuser/calc/invalidations_spec.js
@@ -27,10 +27,14 @@ describe(['tagmultiuser'], 'Joining a document should not trigger an invalidatio
 			const beforeCount = $before.text();
 
 			// joining triggered some theme related invalidations
+
+			// Reload page
 			cy.cSetActiveFrame('#iframe2');
 			cy.get('#form2').submit();
+			// Wait for page to unload
+			cy.wait(1000);
 			// Wait for page to finish loading
-			helper.checkIfDocIsLoaded(true);
+			helper.documentChecks();
 
 			cy.cSetActiveFrame('#iframe1');
 			cy.cGet('input#addressInput').should('have.prop', 'value', 'A1');

--- a/cypress_test/integration_tests/multiuser/calc/invalidations_spec.js
+++ b/cypress_test/integration_tests/multiuser/calc/invalidations_spec.js
@@ -4,11 +4,9 @@ var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
 
 describe(['tagmultiuser'], 'Joining a document should not trigger an invalidation', function() {
-	var origTestFileName = 'invalidations.ods';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'calc', undefined, true);
+		helper.setupAndLoadDocument('calc/invalidations.ods',true);
 		desktopHelper.switchUIToNotebookbar();
 	});
 

--- a/cypress_test/integration_tests/multiuser/calc/repair_document_spec.js
+++ b/cypress_test/integration_tests/multiuser/calc/repair_document_spec.js
@@ -4,11 +4,9 @@ var helper = require('../../common/helper');
 var calcHelper = require('../../common/calc_helper');
 
 describe.skip('Repair Document', function() {
-	var origTestFileName = 'repair_doc.ods';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'calc', undefined, true);
+		helper.setupAndLoadDocument('calc/repair_doc.ods',true);
 	});
 
 	function repairDoc(frameId1, frameId2) {

--- a/cypress_test/integration_tests/multiuser/calc/repair_document_spec.js
+++ b/cypress_test/integration_tests/multiuser/calc/repair_document_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach */
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 var calcHelper = require('../../common/calc_helper');
@@ -9,10 +9,6 @@ describe.skip('Repair Document', function() {
 
 	beforeEach(function() {
 		testFileName = helper.beforeAll(origTestFileName, 'calc', undefined, true);
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	function repairDoc(frameId1, frameId2) {

--- a/cypress_test/integration_tests/multiuser/calc/sheet_operations_spec.js
+++ b/cypress_test/integration_tests/multiuser/calc/sheet_operations_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach expect */
+/* global describe it cy beforeEach require expect */
 
 var helper = require('../../common/helper');
 
@@ -8,10 +8,6 @@ describe.skip(['tagmultiuser'], 'Multiuser sheet operations', function() {
 
 	beforeEach(function() {
 		testFileName = helper.beforeAll(origTestFileName, 'calc', undefined, true);
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	function testInsertDelete(frameId1, frameId2) {
@@ -70,10 +66,6 @@ describe(['tagmultiuser'], 'Check overlays after tab switching/operations', func
 
 	beforeEach(function() {
 		testFileName = helper.beforeAll(origTestFileName, 'calc', undefined, true);
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Check cell cursor overlay bounds after switching tab', function () {

--- a/cypress_test/integration_tests/multiuser/calc/sheet_operations_spec.js
+++ b/cypress_test/integration_tests/multiuser/calc/sheet_operations_spec.js
@@ -3,11 +3,9 @@
 var helper = require('../../common/helper');
 
 describe.skip(['tagmultiuser'], 'Multiuser sheet operations', function() {
-	var origTestFileName = 'sheet_operations.ods';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'calc', undefined, true);
+		helper.setupAndLoadDocument('calc/sheet_operations.ods',true);
 	});
 
 	function testInsertDelete(frameId1, frameId2) {
@@ -61,11 +59,9 @@ describe.skip(['tagmultiuser'], 'Multiuser sheet operations', function() {
 });
 
 describe(['tagmultiuser'], 'Check overlays after tab switching/operations', function() {
-	const origTestFileName = 'cell_cursor_overlay.ods';
-	let testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'calc', undefined, true);
+		helper.setupAndLoadDocument('calc/cell_cursor_overlay.ods',true);
 	});
 
 	it('Check cell cursor overlay bounds after switching tab', function () {

--- a/cypress_test/integration_tests/multiuser/impress/annotation_spec.js
+++ b/cypress_test/integration_tests/multiuser/impress/annotation_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy require afterEach beforeEach Cypress */
+/* global describe it cy require beforeEach Cypress */
 
 var desktopHelper = require('../../common/desktop_helper');
 var helper = require('../../common/helper');
@@ -26,10 +26,6 @@ describe(['tagmultiuser'], 'Multiuser Annotation Tests', function() {
 		}
 		cy.cGet('#options-modify-page').click();
 		desktopHelper.selectZoomLevel('50');
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Insert', function() {
@@ -111,10 +107,6 @@ describe(['tagmultiuser'], 'Multiuser Collapsed Annotation Tests', function() {
 		}
 		cy.cGet('#options-modify-page').click();
 		desktopHelper.selectZoomLevel('50');
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Insert', function() {
@@ -200,10 +192,6 @@ describe(['tagmultiuser'], 'Multiuser Annotation Autosave Tests', function() {
 		}
 		cy.cGet('#options-modify-page').click();
 		desktopHelper.selectZoomLevel('50');
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Insert autosave', function() {

--- a/cypress_test/integration_tests/multiuser/impress/annotation_spec.js
+++ b/cypress_test/integration_tests/multiuser/impress/annotation_spec.js
@@ -4,12 +4,10 @@ var desktopHelper = require('../../common/desktop_helper');
 var helper = require('../../common/helper');
 
 describe(['tagmultiuser'], 'Multiuser Annotation Tests', function() {
-	var origTestFileName = 'comment_switching.odp';
-	var testFileName;
 
 	beforeEach(function() {
 
-		testFileName = helper.beforeAll(origTestFileName, 'impress', undefined, true);
+		helper.setupAndLoadDocument('impress/comment_switching.odp',true);
 		cy.viewport(2600, 800);
 		desktopHelper.switchUIToNotebookbar();
 
@@ -87,10 +85,9 @@ describe(['tagmultiuser'], 'Multiuser Annotation Tests', function() {
 });
 
 describe(['tagmultiuser'], 'Multiuser Collapsed Annotation Tests', function() {
-	var testFileName = 'comment_switching.odp';
 
 	beforeEach(function() {
-		helper.beforeAll(testFileName, 'impress', undefined, true);
+		helper.setupAndLoadDocument('impress/comment_switching.odp',true);
 		cy.viewport(2400, 800);
 		desktopHelper.switchUIToNotebookbar();
 
@@ -171,11 +168,9 @@ describe(['tagmultiuser'], 'Multiuser Collapsed Annotation Tests', function() {
 });
 
 describe(['tagmultiuser'], 'Multiuser Annotation Autosave Tests', function() {
-	var origTestFileName = 'comment_switching.odp';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'impress', undefined, true);
+		helper.setupAndLoadDocument('impress/comment_switching.odp',true);
 		cy.viewport(2600, 800);
 		desktopHelper.switchUIToNotebookbar();
 

--- a/cypress_test/integration_tests/multiuser/impress/repair_document_spec.js
+++ b/cypress_test/integration_tests/multiuser/impress/repair_document_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach */
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 describe.skip('Repair Document', function() {
@@ -7,10 +7,6 @@ describe.skip('Repair Document', function() {
 
 	beforeEach(function() {
 		testFileName = helper.beforeAll(origTestFileName, 'impress', undefined, true);
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	function repairDoc(frameId1, frameId2) {

--- a/cypress_test/integration_tests/multiuser/impress/repair_document_spec.js
+++ b/cypress_test/integration_tests/multiuser/impress/repair_document_spec.js
@@ -2,11 +2,9 @@
 
 var helper = require('../../common/helper');
 describe.skip('Repair Document', function() {
-	var origTestFileName = 'repair_doc.odp';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'impress', undefined, true);
+		helper.setupAndLoadDocument('impress/repair_doc.odp',true);
 	});
 
 	function repairDoc(frameId1, frameId2) {

--- a/cypress_test/integration_tests/multiuser/writer/annotation_spec.js
+++ b/cypress_test/integration_tests/multiuser/writer/annotation_spec.js
@@ -5,11 +5,9 @@ var { selectZoomLevel } = require('../../common/desktop_helper');
 var desktopHelper = require('../../common/desktop_helper');
 
 describe(['tagmultiuser'], 'Multiuser Annotation Tests', function () {
-	var origTestFileName = 'annotation.odt';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'writer', undefined, true);
+		helper.setupAndLoadDocument('writer/annotation.odt',true);
 		cy.viewport(2400,800);
 		desktopHelper.switchUIToNotebookbar();
 		cy.cSetActiveFrame('#iframe1');

--- a/cypress_test/integration_tests/multiuser/writer/annotation_spec.js
+++ b/cypress_test/integration_tests/multiuser/writer/annotation_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach*/
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 var { selectZoomLevel } = require('../../common/desktop_helper');
@@ -20,10 +20,6 @@ describe(['tagmultiuser'], 'Multiuser Annotation Tests', function () {
 		cy.cGet('#sidebar-dock-wrapper').should('be.visible');
 		cy.cGet('#optionscontainer div[id$="SidebarDeck.PropertyDeck"] button').click(); // Hide sidebar.
 		selectZoomLevel('50');
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	describe(['tagmultiuser'], 'Annotation Tests', function () {

--- a/cypress_test/integration_tests/multiuser/writer/invalidations_spec.js
+++ b/cypress_test/integration_tests/multiuser/writer/invalidations_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach expect require afterEach */
+/* global describe it cy beforeEach expect require */
 
 var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
@@ -12,10 +12,6 @@ describe(['tagmultiuser'], 'Joining a document should not trigger an invalidatio
 	beforeEach(function() {
 		testFileName = helper.beforeAll(origTestFileName, 'writer', undefined, true);
 		desktopHelper.switchUIToNotebookbar();
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Join document', function() {

--- a/cypress_test/integration_tests/multiuser/writer/invalidations_spec.js
+++ b/cypress_test/integration_tests/multiuser/writer/invalidations_spec.js
@@ -6,11 +6,9 @@ var ceHelper = require('../../common/contenteditable_helper');
 var writerHelper = require('../../common/writer_helper');
 
 describe(['tagmultiuser'], 'Joining a document should not trigger an invalidation', function() {
-	var origTestFileName = 'invalidations.odt';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'writer', undefined, true);
+		helper.setupAndLoadDocument('writer/invalidations.odt',true);
 		desktopHelper.switchUIToNotebookbar();
 	});
 

--- a/cypress_test/integration_tests/multiuser/writer/invalidations_spec.js
+++ b/cypress_test/integration_tests/multiuser/writer/invalidations_spec.js
@@ -83,8 +83,10 @@ describe(['tagmultiuser'], 'Joining a document should not trigger an invalidatio
 			// Reload page
 			cy.cSetActiveFrame('#iframe2');
 			cy.get('#form2').submit();
+			// Wait for page to unload
+			cy.wait(1000);
 			// Wait for page to finish loading
-			helper.checkIfDocIsLoaded(true);
+			helper.documentChecks();
 
 			cy.cSetActiveFrame('#iframe1');
 			writerHelper.selectAllTextOfDoc();

--- a/cypress_test/integration_tests/multiuser/writer/navigator_spec.js
+++ b/cypress_test/integration_tests/multiuser/writer/navigator_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach */
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 
@@ -8,10 +8,6 @@ describe.skip(['tagmultiuser'], 'Navigator follow the change of document', funct
 
 	beforeEach(function() {
 		testFileName = helper.beforeAll(origTestFileName, 'writer', undefined, true);
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Create Heading, Table, then modify, and delete', function() {

--- a/cypress_test/integration_tests/multiuser/writer/navigator_spec.js
+++ b/cypress_test/integration_tests/multiuser/writer/navigator_spec.js
@@ -3,11 +3,9 @@
 var helper = require('../../common/helper');
 
 describe.skip(['tagmultiuser'], 'Navigator follow the change of document', function() {
-	var origTestFileName = 'paragraph_prop.odt';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'writer', undefined, true);
+		helper.setupAndLoadDocument('writer/paragraph_prop.odt',true);
 	});
 
 	it('Create Heading, Table, then modify, and delete', function() {

--- a/cypress_test/integration_tests/multiuser/writer/paragraph_prop_spec.js
+++ b/cypress_test/integration_tests/multiuser/writer/paragraph_prop_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach */
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 
@@ -8,10 +8,6 @@ describe.skip(['tagmultiuser'], 'Change paragraph properties', function() {
 
 	beforeEach(function() {
 		testFileName = helper.beforeAll(origTestFileName, 'writer', undefined, true);
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	it('Change paragraph alignment.', function() {

--- a/cypress_test/integration_tests/multiuser/writer/paragraph_prop_spec.js
+++ b/cypress_test/integration_tests/multiuser/writer/paragraph_prop_spec.js
@@ -3,11 +3,9 @@
 var helper = require('../../common/helper');
 
 describe.skip(['tagmultiuser'], 'Change paragraph properties', function() {
-	var origTestFileName = 'paragraph_prop.odt';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'writer', undefined, true);
+		helper.setupAndLoadDocument('writer/paragraph_prop.odt',true);
 	});
 
 	it('Change paragraph alignment.', function() {

--- a/cypress_test/integration_tests/multiuser/writer/repair_document_spec.js
+++ b/cypress_test/integration_tests/multiuser/writer/repair_document_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach */
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 var repairHelper = require('../../common/repair_document_helper');
@@ -9,10 +9,6 @@ describe.skip(['tagmultiuser'], 'Repair Document', function() {
 
 	beforeEach(function() {
 		testFileName = helper.beforeAll(origTestFileName, 'writer', undefined, true);
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	function repairDoc(frameId1, frameId2) {

--- a/cypress_test/integration_tests/multiuser/writer/repair_document_spec.js
+++ b/cypress_test/integration_tests/multiuser/writer/repair_document_spec.js
@@ -4,11 +4,9 @@ var helper = require('../../common/helper');
 var repairHelper = require('../../common/repair_document_helper');
 
 describe.skip(['tagmultiuser'], 'Repair Document', function() {
-	var origTestFileName = 'repair_doc.odt';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'writer', undefined, true);
+		helper.setupAndLoadDocument('writer/repair_doc.odt',true);
 	});
 
 	function repairDoc(frameId1, frameId2) {

--- a/cypress_test/integration_tests/multiuser/writer/sidebar_visibility_spec.js
+++ b/cypress_test/integration_tests/multiuser/writer/sidebar_visibility_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach */
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
@@ -9,10 +9,6 @@ describe.skip(['tagmultiuser'], 'Sidebar visibility', function() {
 
 	beforeEach(function() {
 		testFileName = helper.beforeAll(origTestFileName, 'writer', undefined, true);
-	});
-
-	afterEach(function() {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	function testSidebarVisiblity(frameId1 ,frameId2) {

--- a/cypress_test/integration_tests/multiuser/writer/sidebar_visibility_spec.js
+++ b/cypress_test/integration_tests/multiuser/writer/sidebar_visibility_spec.js
@@ -4,11 +4,9 @@ var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
 
 describe.skip(['tagmultiuser'], 'Sidebar visibility', function() {
-	var origTestFileName = 'sidebar_visibility.odt';
-	var testFileName;
 
 	beforeEach(function() {
-		testFileName = helper.beforeAll(origTestFileName, 'writer', undefined, true);
+		helper.setupAndLoadDocument('writer/sidebar_visibility.odt',true);
 	});
 
 	function testSidebarVisiblity(frameId1 ,frameId2) {

--- a/cypress_test/integration_tests/multiuser/writer/track_changes_spec.js
+++ b/cypress_test/integration_tests/multiuser/writer/track_changes_spec.js
@@ -3,11 +3,9 @@
 var helper = require('../../common/helper');
 
 describe.skip(['tagmultiuser'], 'Track Changes', function () {
-	var origTestFileName = 'track_changes.odt';
-	var testFileName;
 
 	beforeEach(function () {
-		testFileName = helper.beforeAll(origTestFileName, 'writer', undefined, true);
+		helper.setupAndLoadDocument('writer/track_changes.odt',true);
 	});
 
 	function confirmChange(action) {

--- a/cypress_test/integration_tests/multiuser/writer/track_changes_spec.js
+++ b/cypress_test/integration_tests/multiuser/writer/track_changes_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require afterEach*/
+/* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
 
@@ -8,10 +8,6 @@ describe.skip(['tagmultiuser'], 'Track Changes', function () {
 
 	beforeEach(function () {
 		testFileName = helper.beforeAll(origTestFileName, 'writer', undefined, true);
-	});
-
-	afterEach(function () {
-		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
 	function confirmChange(action) {


### PR DESCRIPTION
This is a big change, sorry. I tried to make smaller chunks but there was no easy way. It should be manageable if you review it one commit at a time.

The commits do work independently and I did make sure they pass CI after each commit. However I didn't want to submit them separately because the first two leave warnings and messy code that are cleaned up by the last one.

## The problem
- Many helper functions have a huge list of parameters
  - The list is copied at least five times
  - The list has changed over time without updating all of the tests that call helpers using it
    - So some tests currently open documents with the wrong parameters
  - noRename and noFileCopy do *almost* the same thing, and subsequentLoad is similar but totally different
- The helper functions have misleading names
  - "beforeAll", "loadTestDocNoIntegration", and "reload" are all used in different places to reopen a document
- There is lots of boilerplate test setup code, which makes it harder to write new tests

## Changes
### Commit 1: Remove afterEach/afterAll
Skip closing the document at the end of the test.
 - Cypress strongly recommends NOT cleaning up after tests ([The docs explain why](https://docs.cypress.io/guides/references/best-practices#Using-after-Or-afterEach-Hooks))
 - Documents get closed automatically after leaving the page anyways 
   - There is a C++ test explicitly for this, no need to test it with every cypress test
 - Many tests verified the wrong document was closed anyways (the original file instead of the copied file with a random name).
 - Removes a small amount of boilerplate from every test
 - Removes the need for most tests to know the name of the new random file name (necessary for later cleanup)
 - This makes failure investigations slightly easier because the page stays open after the test finishes when using make run

### Commit 2: Replace beforeAll with setupAndLoadDocument
Add convenience function "setupAndLoadDocument" used by most tests.
 - Does the same thing as beforeAll but simpler and more explicitly
 - Uses a relative path like 'calc/hello.ods' instead of separate parameters 'hello.ods' and 'calc'.
 - Applied to most test files, where it was straightforward to do so
 
### Commit 3: Remove beforeAll and rewrite document loading helpers
Separate the document setup and load.
- Splits huge parameter list and removes the need for some of the parameters altogether

Modify all remaining tests to use the new functions.
- Mostly documents that need to reload the file
- Also spec files without beforeEach because the individual testpoints use different documents
- Also tests that skip documentChecks because of an interaction before load

Functions changed in helper.js:
  - getRandomFileName, generateDocumentURL, generateDocumentURI: inlined
  - logLoadingParameters: deleted
  - loadTestDocNoIntegration: renamed to loadDocumentNoIntegration, made private
  - loadTestDocNextcloud: renamed to loadDocumentNextcloud
  - loadTestDoc: split functionality to setupDocument and loadDocument
  - checkIfDocIsLoaded: inlined. documentChecks is now public.
  - reload: renamed to reloadDocument

## Risks
- Many tests are currently skipped
  - I did run these where possible. The document loading worked, but many were failing for other reasons. Without full qualification in CI there is a chance that some minor issue won't be caught. But it would be fixed when the test is re-enabled anyways.
- Nextcloud/php-proxy tests
  - I did not run these tests. They are already broken, but there is a small chance I broke them more.

## Example
Here is an example to show you how this change affects a basic test.
![Screenshot from 2024-04-24 14-03-48](https://github.com/CollaboraOnline/online/assets/153108452/44c5321f-73ca-488c-857c-36e3bfe4b029)

- beforeEach: clearer
- afterEach: deleted
- filename variables: not needed