### PR TITLE
annotation: fixed comments could not expand

### DIFF
--- a/browser/src/layer/tile/CommentListSection.ts
+++ b/browser/src/layer/tile/CommentListSection.ts
@@ -1031,8 +1031,9 @@ export class CommentSection extends CanvasSectionObject {
 		});
 	}
 
-	public onResize (): void {
-		this.checkCollapseState();
+	public onResize (verticalOnly: boolean = false): void {
+		if (!verticalOnly)
+			this.checkCollapseState();
 		this.update();
 		// When window is resized, it may mean that comment wizard is closed. So we hide the highlights.
 		this.removeHighlighters();
@@ -1725,7 +1726,7 @@ export class CommentSection extends CanvasSectionObject {
 		if (lastY > app.file.size.pixels[1]) {
 			if (app.view.size.pixels[1] !== lastY) {
 				app.view.size.pixels[1] = lastY;
-				this.onResize(); // Annotation goes beyond document and can't be scrolled further unless resized
+				this.onResize(true); // Annotation goes beyond document and can't be scrolled further unless resized
 				this.select(this.sectionProperties.selectedComment, true); // Reselecting will bring entire comment in view
 			  }
 		}


### PR DESCRIPTION
problem:
when comment was on the edge of the document/screen(vertically) resize was called which ultimately collapsed the comments in small screen which could not be expanded unless scrolled further from edge. It was more problematic for the threads,
if entire thread could not fit in the screen it was always failing to expand

regression from bac4161


Change-Id: I48de52864f557416b704b48de8ab78cd8ad25239



* Target version: master 


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

