### PR TITLE
uno: .uno:SetDocumentProperties: add file path parameter (backport)

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -553,6 +553,21 @@ bool ChildSession::_handleInput(const char *buffer, int length)
                 InputProcessingManager processInput(getProtocol(), false);
                 return unoCommand(tokens);
             }
+            else if (tokens[1].find(".uno:SetDocumentProperties") != std::string::npos)
+            {
+                std::string PossibleFileExtensions[3] = {"", TO_UPLOAD_SUFFIX + std::string(UPLOADING_SUFFIX), TO_UPLOAD_SUFFIX};
+                for (size_t i = 0; i < 3; i++)
+                {
+                    const auto st = FileUtil::Stat(Poco::URI(getJailedFilePath()).getPath() + PossibleFileExtensions[i]);
+                    if (st.exists())
+                    {
+                        const std::size_t size = (st.good() ? st.size() : 0);
+                        std::string addedProperty = firstLine + "?FileSize:string=" + std::to_string(size);
+                        StringVector newTokens = StringVector::tokenize(addedProperty.data(), addedProperty.size());
+                        return unoCommand(newTokens);
+                    }
+                }
+            }
 
             return unoCommand(tokens);
         }


### PR DESCRIPTION
problem:
in LOK/online to support async save, files in jails may have different extensions (ie: .upload, .uploading)
this caused problem to detect files as original file name may not exist. As result property like file size were always set to 0

chronology of events:
1. File is saved normally with existing name
2. After saved we make it ready for upload and add extension .upload in "renameForUpload"(kit/ChildSession.cpp) 3  We change to .uploading extension when we are uploading (DocumentBroker::handleSaveResponse, DocumentBroker::uploadAfterLoadingTemplate)


Change-Id: Ibda40b0c134ef6baef9edb0427b3c56340924858


* Target version: distro/collabora/co-23.05 

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

