### PR TITLE
mobile: Use SavedUIState=true

### DIFF
--- a/browser/html/cool.html.m4
+++ b/browser/html/cool.html.m4
@@ -314,7 +314,7 @@ m4_ifelse(MOBILEAPP,[true],
       window.checkFileInfoOverride = {};
       window.deeplEnabled = false;
       window.zoteroEnabled = false;
-      window.savedUIState = false;
+      window.savedUIState = true;
       window.wasmEnabled = false;
       window.indirectionUrl='';],
      [window.host = '%HOST%';


### PR DESCRIPTION
SavedUIState is a ui_defaults option to ignore any user preferences for state when loading, it was added in
https://github.com/CollaboraOnline/online/pull/7575

We need to set SavedUIState explicitly on mobile, which the following pulls do for iOS and Android respectively:
- https://github.com/CollaboraOnline/online/pull/7908
- https://github.com/CollaboraOnline/online/pull/7912

Unfortunately, setting it to false can cause some nasty bugs, such as inability to change theme to light. It also intentionally ignores user preferences when you reopen a document, but this isn't particularly desirable on mobile.

I believe it to be an oversight that the option was set to `false` rather than `true`, as `true` was the behavior before the ui_default option was added and neither change gives a reason for it to be false rather than true.


Change-Id: I30ce445db1b7e69a3b44eec3fb4689c463233b1f


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

