### PR TITLE
Remove extra grid cell space from header in autofilter child popup

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1106,6 +1106,8 @@ input[type='number']:hover::-webkit-outer-spin-button {
 }
 
 /* hide radio in filter by color */
+.jsdialog.autofilter #background tr th:nth-of-type(1),
+.jsdialog.autofilter #textcolor tr th:nth-of-type(1),
 .jsdialog.autofilter #background tr td:nth-of-type(1),
 .jsdialog.autofilter #textcolor tr td:nth-of-type(1) {
 	display: none;


### PR DESCRIPTION
- we need to also consider `th` tag to make it display none
- it's an empty text span, so do not that extra space.

Before:

![image](https://github.com/CollaboraOnline/online/assets/61383886/906dfc46-7369-44a7-bd73-3818e26a241a)

After:

![image](https://github.com/CollaboraOnline/online/assets/61383886/d986e022-7b7e-4f56-a174-68a38f18a19a)


You can see in Header "Background color" there is extra space in before image.

Signed-off-by: Darshan-upadhyay1110 <darshan.upadhyay@collabora.com>
Change-Id: Ib83d42f64a0115fdc4d17a8f7e952419a84cc9d5