### PR TITLE
cool#8648 clipboard: stop fetching the clipboard on text selection create in tests

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -3258,11 +3258,12 @@ L.CanvasTileLayer = L.Layer.extend({
 				this._cellCSelections.setPointSet(pointSet);
 
 			this._map.removeLayer(this._map._textInput._cursorHandler); // User selected a text, we remove the carret marker.
-			// Keep fetching the text selection during testing, for now: too many tests
-			// depend on this behavior currently.
-			if (L.Browser.hasNavigatorClipboardWrite && !(L.Browser.cypressTest && !this._map._clip._dummyClipboard.useAsyncWrite)) {
+			if (L.Browser.hasNavigatorClipboardWrite) {
+				// Just set the selection type, no fetch of the content.
 				this._map._clip.setTextSelectionType('text');
 			} else {
+				// Trigger fetching the selection content, we already need to have
+				// it locally by the time 'copy' is executed.
 				if (this._selectionContentRequest) {
 					clearTimeout(this._selectionContentRequest);
 				}

--- a/cypress_test/integration_tests/common/helper.js
+++ b/cypress_test/integration_tests/common/helper.js
@@ -1172,8 +1172,6 @@ function setDummyClipboardForCopy(type) {
 					},
 				};
 			},
-
-			useAsyncWrite: true,
 		};
 	});
 }


### PR DESCRIPTION
This was just a workaround to keep tests working till they are fixed to
not assume we do an implicit 'copy' as soon as we have a text selection.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I37d16ee2841c41593a5af2fb6ceba025fe1c79e0
