### PR TITLE
Allow to embed the presentation in window

### DIFF
--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -1489,6 +1489,15 @@ void ClientRequestDispatcher::handlePostRequest(const RequestDetails& requestDet
             if (serveAsAttachment && contentType != "image/svg+xml")
                 response.set("Content-Disposition", "attachment; filename=\"" + fileName + '"');
 
+#if !MOBILEAPP
+            if (COOLWSD::WASMState != COOLWSD::WASMActivationState::Disabled)
+            {
+                response.add("Cross-Origin-Opener-Policy", "same-origin");
+                response.add("Cross-Origin-Embedder-Policy", "require-corp");
+                response.add("Cross-Origin-Resource-Policy", "cross-origin");
+            }
+#endif // !MOBILEAPP
+
             try
             {
                 HttpHelper::sendFileAndShutdown(socket, filePath.toString(), response);


### PR DESCRIPTION
Similar like in:
commit d9d13d7092d2d597eb34d657945f2678756fb800
wasm: support serving wasm files

add headers required when we use WASM so we are able to embed presentation in window.

Without that we get:
not-set Cross-Origin-Embedder-Policy