### PR TITLE
Annotation thread scrolling improvement

### DIFF
--- a/browser/src/layer/tile/CommentListSection.ts
+++ b/browser/src/layer/tile/CommentListSection.ts
@@ -693,16 +693,19 @@ export class CommentSection extends CanvasSectionObject {
 	}
 
 	public select (annotation: Comment, force: boolean = false): void {
-		if (annotation && ((!annotation.pendingInit && annotation !== this.sectionProperties.selectedComment) || force)) {
-			// Unselect first if there anything selected.
-			if (this.sectionProperties.selectedComment)
-				this.unselect();
-
+		if (force || (annotation && !annotation.pendingInit && annotation !== this.sectionProperties.selectedComment)) {
 			// Select the root comment
 			var idx = this.getRootIndexOf(annotation.sectionProperties.data.id);
 
-			if (this.sectionProperties.selectedComment && $(this.sectionProperties.selectedComment.sectionProperties.container).hasClass('annotation-active'))
-				$(this.sectionProperties.selectedComment.sectionProperties.container).removeClass('annotation-active');
+			// no need to reselect comment, it will cuase to scroll to root comment unnecessarily
+			if (this.sectionProperties.selectedComment === this.sectionProperties.commentList[idx]) {
+				this.update();
+				return;
+			}
+
+			// Unselect first if there anything selected
+			if (this.sectionProperties.selectedComment)
+				this.unselect();
 
 			this.sectionProperties.selectedComment = this.sectionProperties.commentList[idx];
 
@@ -740,7 +743,7 @@ export class CommentSection extends CanvasSectionObject {
 				const annotationHeight = this.cssToCorePixels(rect.height);
 				const annotationBottom = position[1] + annotationHeight;
 
-				if (!this.isInViewPort([annotationTop, annotationBottom]) && position[1] !== 0 && !annotation.isEdit()) {
+				if (!this.isInViewPort([annotationTop, annotationBottom]) && position[1] !== 0 && annotation === selectedComment) {
 					console.debug('Annotation outside view - scroll');
 					const scrollSection = app.sectionContainer.getSectionWithName(L.CSections.Scroll.name);
 					const screenTopBottom = this.getScreenTopBottom();

--- a/browser/src/layer/tile/CommentListSection.ts
+++ b/browser/src/layer/tile/CommentListSection.ts
@@ -1731,11 +1731,8 @@ export class CommentSection extends CanvasSectionObject {
 
 		lastY += this.containerObject.getDocumentTopLeft()[1];
 		if (lastY > app.file.size.pixels[1]) {
-			if (app.view.size.pixels[1] !== lastY) {
-				app.view.size.pixels[1] = lastY;
-				this.onResize(); // Annotation goes beyond document and can't be scrolled further unless resized
-				this.select(this.sectionProperties.selectedComment, true); // Reselecting will bring entire comment in view
-			  }
+			app.view.size.pixels[1] = lastY;
+			this.containerObject.requestReDraw();
 		}
 		else
 			app.view.size.pixels[1] = app.file.size.pixels[1];

--- a/browser/src/layer/tile/CommentListSection.ts
+++ b/browser/src/layer/tile/CommentListSection.ts
@@ -1885,7 +1885,8 @@ export class CommentSection extends CanvasSectionObject {
 			const maxMaxHeight = Number(getComputedStyle(document.documentElement).getPropertyValue('--annotation-max-size'));
 			for (var i = 0; i < this.sectionProperties.commentList.length;i++) {
 				// Only if ContentNode is displayed.
-				if (this.sectionProperties.commentList[i].sectionProperties.contentNode.style.display !== 'none') {
+				if (this.sectionProperties.commentList[i].sectionProperties.contentNode.style.display !== 'none'
+				&& !this.sectionProperties.commentList[i].isEdit()) {
 					// act commentText height
 					var actHeight = this.sectionProperties.commentList[i].sectionProperties.contentText.getBoundingClientRect().height;
 					// if the comment is taller then minimal, we may want to make it taller

--- a/browser/src/layer/tile/CommentListSection.ts
+++ b/browser/src/layer/tile/CommentListSection.ts
@@ -631,9 +631,8 @@ export class CommentSection extends CanvasSectionObject {
 			}
 		}
 		else {
-			this.unselect();
 			annotation.reply();
-			this.select(annotation);
+			this.select(annotation, true);
 			annotation.focus();
 		}
 	}
@@ -649,11 +648,6 @@ export class CommentSection extends CanvasSectionObject {
 			}.bind(this), /* isMod */ true);
 		}
 		else {
-			if (this.sectionProperties.docLayer._docType !== 'spreadsheet') {
-				this.unselect();
-				this.select(annotation);
-			}
-
 			// Make sure that comment is not transitioning and comment menu is not open.
 			var tempFunction = function() {
 				setTimeout(function() {

--- a/browser/src/layer/tile/CommentSection.ts
+++ b/browser/src/layer/tile/CommentSection.ts
@@ -170,6 +170,8 @@ export class Comment extends CanvasSectionObject {
 		var events = ['click', 'dblclick', 'mousedown', 'mouseup', 'mouseover', 'mouseout', 'keydown', 'keypress', 'keyup', 'touchstart', 'touchmove', 'touchend'];
 		L.DomEvent.on(this.sectionProperties.container, 'click', this.onMouseClick, this);
 		L.DomEvent.on(this.sectionProperties.container, 'keydown', this.onEscKey, this);
+		L.DomEvent.on(this.sectionProperties.container, 'wheel', this.map._docLayer._painter._sectionContainer.onMouseWheel, this.map._docLayer._painter._sectionContainer);
+		L.DomEvent.on(this.sectionProperties.contentNode, 'wheel', this.onMouseWheel, this);
 
 		for (var it = 0; it < events.length; it++) {
 			L.DomEvent.on(this.sectionProperties.container, events[it], L.DomEvent.stopPropagation, this);
@@ -186,6 +188,18 @@ export class Comment extends CanvasSectionObject {
 		this.update();
 
 		this.pendingInit = false;
+	}
+
+	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+	public onMouseWheel (e: any) : void {
+		if (e.currentTarget.clientHeight === e.currentTarget.scrollHeight)
+			return;
+
+		var _scrollTop = e.currentTarget.scrollTop;
+		if (e.deltaY < 0 && _scrollTop > 0)
+			e.stopPropagation();
+		else if (e.deltaY > 0 && _scrollTop + $(e.currentTarget).height() < e.target.scrollHeight)
+			e.stopPropagation();
 	}
 
 	public onInitialize (): void {


### PR DESCRIPTION
fixes:
1. Couldn't expand comments if the thread could not fit in view
2. Performing an action on last comments of the thread caused to scroll back to the root comment
3. Now the mouse scroll wheel works on the comment section too
4. Some code cleaning to avoid unnecessary unselect calls 

it nullifies the effect from 81b00e7
now if a comment is added at the end of the document and it goes beyond doc boundary doc will not scroll automatically to make the entire comment visible


* Target version: master 


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

