### PR TITLE
cool#8806 clipboard: improve detection of HTML that's just an image

### DIFF
--- a/cypress_test/integration_tests/desktop/calc/clipboard_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/clipboard_spec.js
@@ -15,7 +15,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Calc clipboard tests.', fu
 		helper.afterAll(testFileName, this.currentTest.state);
 	});
 
-	function setDummyClipboard(type, content, image = false, fail = false) {
+	function setDummyClipboard(type, content, image = false, fail = false, imageHtml = undefined) {
 		cy.window().then(win => {
 			var app = win['0'].app;
 			var metaURL = encodeURIComponent(app.map._clip.getMetaURL());
@@ -29,7 +29,10 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Calc clipboard tests.', fu
 					return {
 						then: function(resolve/*, reject*/) {
 							if (image && type === 'text/html') {
-								resolve(new Blob(['<img></img>']));
+								if (imageHtml === undefined) {
+									imageHtml = '<img></img>';
+								}
+								resolve(new Blob([imageHtml]));
 							} else {
 								resolve(blob);
 							}
@@ -129,6 +132,26 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Calc clipboard tests.', fu
 		cy.cGet('#home-paste-entries .ui-combobox-entry').contains('Paste').click();
 
 		// Then make sure the paste happened:
+		cy.cGet('.leaflet-pane.leaflet-overlay-pane svg g').should('exist');
+	});
+
+	it('Image paste with meta', function() {
+		// Given a Calc document:
+		cy.cGet('#map').focus();
+		calcHelper.clickOnFirstCell();
+		let base64 = 'iVBORw0KGgoAAAANSUhEUgAAAQAAAAEAAQMAAABmvDolAAAAA1BMVEW10NBjBBbqAAAAH0lEQVRo';
+		base64 += 'ge3BAQ0AAADCoPdPbQ43oAAAAAAAAAAAvg0hAAABmmDh1QAAAABJRU5ErkJggg==';
+		let blob = Cypress.Blob.base64StringToBlob(base64, 'image/png');
+		let imageHtml = '<meta http-equiv="content-type" content="text/html; charset=utf-8"><img></img>';
+		setDummyClipboard('image/png', blob, /*image=*/true, /*fail=*/false, imageHtml);
+
+		// When pasting the clipboard:
+		cy.cGet('#home-paste-button').click();
+		cy.cGet('#home-paste-entries .ui-combobox-entry').contains('Paste').click();
+
+		// Then make sure the paste happened:
+		// Without the accompanying fix in place, this test would have failed, no image was
+		// pasted.
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane svg g').should('exist');
 	});
 


### PR DESCRIPTION
Copy an image in Firefox, paste in Chrome with the Paste button or with
Ctrl-V. Nothing happens in Calc, Writer gives you a popup to copy the
image, which is already the case.

What happens is that Clipboard.js already had some code to guess when
the HTML only contains an image, but while Chrome puts '<img ...' to the
clipboard, Firefox puts '<meta ...><img ...', so we don't recognize the
content as image.

Fix the problem by adding a new isHtmlImage() function to Clipboard.js
that handles both markups and use it from both places that deal with
paste (Paste button, keyboard).

Note that this also helps in case the HTML starts with a small
difference that is normalized during parsing, e.g. '<IMG ...'.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Ia1340cd3777c5597e3fd257e905e9cc637802bcc
