### PR TITLE
css: fix insert shape popup

### DIFF
--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -1500,6 +1500,7 @@ button.leaflet-control-search-next
 	height: auto;
 	position: static;
 	text-align: left;
+	display: flex;
 }
 
 .insertshape-grid.insertconnectors .row {


### PR DESCRIPTION
insert shape popup now shows all the items in one column. fix it so we have rows