### PR TITLE
iOS: stop keyboard pushing content offscreen

### DIFF
--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -1281,4 +1281,15 @@ window.app = {
 			this.socket.onopen();
 		}
 	}
+
+	function handleViewportChange(event) {
+		var visualViewport = event.target;
+
+		document.body.style.height = visualViewport.height + 'px';
+	}
+
+	if (window.visualViewport !== undefined) {
+		window.visualViewport.addEventListener('scroll', handleViewportChange);
+		window.visualViewport.addEventListener('resize', handleViewportChange);
+	}
 }(window));


### PR DESCRIPTION
Previously using the onscreen keyboard would shrink the visual viewport while leaving the elements at the same size, meaning some of the content had to be offscreen. As we scrolled the page to have the cursor in view, this would move the notebook bar offscreen.

This commit does 2 things:
- First, we stick the viewport to the top of the screen with CSS, this avoids the possibility of the notebook bar being moved offscreen
- Then, to avoid the possibility of the cursor leaving the screen or the bottom toolbar being offscren, we use the VisualViewport API to force the logical viewport to have the same size as the visual one

Together, these vastly improve the iOS keyboard popup experience


Change-Id: I07726bee8b61334f6a32e873ab2d5428fa60dca3


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

