### PR TITLE
cool#8648 clipboard: fix idle tests

### DIFF
--- a/cypress_test/integration_tests/idle/calc/idle_spec.js
+++ b/cypress_test/integration_tests/idle/calc/idle_spec.js
@@ -16,10 +16,11 @@ describe(['tagdesktop'], 'Idle', function() {
 		const content = 'New content';
 		helper.typeIntoDocument(content + '{enter}');
 
-		calcHelper.assertSheetContents(['C' + content + 'ypress Test', 'Status', 'Test 1', 'Pass', 'Test 2', 'Fail', 'Test 3', 'Pass', 'Test 4', '', 'Test 5', 'Fail']);
+		calcHelper.assertSheetContents(['C' + content + 'ypress Test', 'Status', 'Test 1', 'Pass', 'Test 2', 'Fail', 'Test 3', 'Pass', 'Test 4', '', 'Test 5', 'Fail'], true);
 	}
 
 	it('Check idle out of focus', function() {
+		helper.setDummyClipboardForCopy();
 		cy.getFrameWindow()
 			.its('L')
 			.then(function(L) {
@@ -34,6 +35,7 @@ describe(['tagdesktop'], 'Idle', function() {
 	});
 
 	it('Check idle after inactivity', function() {
+		helper.setDummyClipboardForCopy();
 		cy.cGet(dimDialogSelector).should('not.exist');
 		cy.wait(7100); // inactivity timeout is 7s
 		cy.cGet(dimDialogSelector).should('exist');
@@ -42,6 +44,7 @@ describe(['tagdesktop'], 'Idle', function() {
 	});
 
 	it('Check interactivity of document after dialog close', function() {
+		helper.setDummyClipboardForCopy();
 		// Check if sidebar-dock-wrapper is visible
 		cy.cGet('#sidebar-dock-wrapper').should('be.visible').then(($sidebar) => {
 			// If it's not visible, click on SidebarDeck.PropertyDeck to make it visible


### PR DESCRIPTION
This is not part of CI at the moment, so I didn't notice it till Szymon
pointed it out.

	make -C cypress_test check-idle spec=calc/idle_spec.js

passes with this, which is the only suite in 'make check-idle'.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Ieeb15653abcc016bc7de87115df136dfe3f27d0d
