### PR TITLE
Fix error on hide tooltip

### DIFF
--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -1083,8 +1083,10 @@ L.Control.UIManager = L.Control.extend({
 
 	hideFormulaTooltip: function() {
 		var elem = $('.leaflet-layer');
-		if ($('.ui-tooltip').length > 0)
+		if ($('.ui-tooltip').length > 0) {
+			elem.tooltip();
 			elem.tooltip('option', 'disabled', true);
+		}
 	},
 
 	// Snack bar
@@ -1720,6 +1722,7 @@ L.Control.UIManager = L.Control.extend({
 			});
 		}
 		else {
+			elem.tooltip();
 			elem.tooltip({disabled: true});
 			(new Hammer(elem.get(0), {recognizers: [[Hammer.Press]]}))
 				.on('press', function () {


### PR DESCRIPTION
I see logs in 23.05 of:

coolwsd[401]: wsd-00401-136107 2024-04-25 12:48:34.185780 +0000 [ docbroker_62b ] ERR  ToClient-698a: jserror | wsd/ClientSession.cpp:590
coolwsd[401]: wsd-00401-135173 2024-04-25 12:49:30.079639 +0000 [ docbroker_624 ] ERR  ToClient-6964: jserror Exception Error: cannot call methods on tooltip prior to initialization; attempted to call method 'option' emitting event calcfunctionlist: hidetip 
coolwsd[401]: Error: cannot call methods on tooltip prior to initialization; attempted to call method 'option'
coolwsd[401]:     at Function.error (https://share.collaboraonline.com/browser/c6fbf7e/bundle.js:265:40)
coolwsd[401]:     at HTMLDivElement.<anonymous> (https://share.collaboraonline.com/browser/c6fbf7e/bundle.js:2282:80)
coolwsd[401]:     at Function.each (https://share.collaboraonline.com/browser/c6fbf7e/bundle.js:271:86)
coolwsd[401]:     at jQuery.fn.init.each (https://share.collaboraonline.com/browser/c6fbf7e/bundle.js:248:25)
coolwsd[401]:     at $.fn.<computed> [as tooltip] (https://share.collaboraonline.com/browser/c6fbf7e/bundle.js:2281:12)
coolwsd[401]:     at NewClass.hideFormulaTooltip (https://share.collaboraonline.com/browser/c6fbf7e/bundle.js:30749:64)
coolwsd[401]:     at NewClass._onCalcFunctionListMsg (https://share.collaboraonline.com/browser/c6fbf7e/bundle.js:17387:21)
coolwsd[401]:     at NewClass._onMessage (https://share.collaboraonline.com/browser/c6fbf7e/bundle.js:17302:28)
coolwsd[401]:     at NewClass._onMessage (https://share.collaboraonline.com/browser/c6fbf7e/bundle.js:19674:40)
coolwsd[401]:     at NewClass._onMessage (https://share.collaboraonline.com/browser/c6fbf7e/bundle.js:11821:21)
coolwsd[401]: | wsd/ClientSession.cpp:590

which looks like the same problem in 23.05 as fixed in 24.04 by:
https://github.com/CollaboraOnline/online/pull/8644