### PR TITLE
Cypress: Join subFolder and fileName into filePath

### DIFF
--- a/cypress_test/integration_tests/common/desktop_helper.js
+++ b/cypress_test/integration_tests/common/desktop_helper.js
@@ -420,12 +420,12 @@ function pressKey(n, key) {
 	cy.log('<< pressKey - end');
 }
 
-function openReadOnlyFile(subFolder, fileName) {
+function openReadOnlyFile(filePath) {
 	cy.log('>> openReadOnlyFile - start');
 
-	var newFileName = helper.setupDocument(fileName, subFolder);
+	var newFilePath = helper.setupDocument(filePath);
 	// Skip document checks because sidebar does not appear
-	helper.loadDocument(newFileName, subFolder, true);
+	helper.loadDocument(filePath, true);
 
 	//check doc is loaded
 	cy.cGet('.leaflet-canvas-container canvas', {timeout : Cypress.config('defaultCommandTimeout') * 2.0});
@@ -435,7 +435,7 @@ function openReadOnlyFile(subFolder, fileName) {
 	cy.cGet('#PermissionMode').should('be.visible').should('have.text', ' Read-only ');
 
 	cy.log('<< openReadOnlyFile - end');
-	return newFileName;
+	return newFilePath;
 }
 
 function checkAccessibilityEnabledToBe(state) {

--- a/cypress_test/integration_tests/common/interference_user_spec.js
+++ b/cypress_test/integration_tests/common/interference_user_spec.js
@@ -31,7 +31,7 @@ describe('Interfering second user.', function() {
 				.then(function(text) {
 
 					// We open the same document
-					helper.loadDocument(text, getComponent(text));
+					helper.loadDocument(getComponent(text) + '/' + text);
 				});
 
 			cy.get('#toolbar-up #userlist', { timeout: Cypress.config('defaultCommandTimeout') * 2.0 })

--- a/cypress_test/integration_tests/desktop/calc/annotation_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/annotation_spec.js
@@ -98,10 +98,10 @@ describe(['tagdesktop'], 'Annotation Tests', function() {
 });
 
 describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
-	var newFileName;
+	var newFilePath;
 
 	beforeEach(function() {
-		newFileName = helper.setupAndLoadDocument('calc/annotation.ods');
+		newFilePath = helper.setupAndLoadDocument('calc/annotation.ods');
 		desktopHelper.switchUIToNotebookbar();
 	});
 
@@ -111,7 +111,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
 		cy.cGet('.cool-annotation-edit.modify-annotation').should('be.visible');
 
-		helper.reloadDocument(newFileName,'calc');
+		helper.reloadDocument(newFilePath);
 		cy.cGet('.cool-annotation').should('exist');
 		cy.cGet('#comment-container-1').then(function (element) {
 			element[0].style.visibility = '';
@@ -136,7 +136,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('#comment-container-1').trigger('mouseover');
 		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
 
-		helper.reloadDocument(newFileName,'calc');
+		helper.reloadDocument(newFilePath);
 		cy.cGet('.cool-annotation').should('exist');
 		cy.cGet('#comment-container-1').then(function (element) {
 			element[0].style.visibility = '';
@@ -155,7 +155,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('.cool-annotation').should('not.exist');
 		cy.cGet('.cool-annotation-autosavelabel').should('not.exist');
 
-		helper.reloadDocument(newFileName,'calc');
+		helper.reloadDocument(newFilePath);
 		cy.cGet('.cool-annotation').should('not.exist');
 	});
 
@@ -177,7 +177,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
 		cy.cGet('.cool-annotation-edit.modify-annotation').should('be.visible');
 
-		helper.reloadDocument(newFileName,'calc');
+		helper.reloadDocument(newFilePath);
 		cy.cGet('.cool-annotation').should('exist');
 		cy.cGet('#comment-container-1').then(function (element) {
 			element[0].style.visibility = '';
@@ -213,7 +213,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('#annotation-content-area-1').should('have.text','some other text, some text0');
 		cy.cGet('#comment-container-1').should('exist');
 
-		helper.reloadDocument(newFileName,'calc');
+		helper.reloadDocument(newFilePath);
 		cy.cGet('.cool-annotation').should('exist');
 		cy.cGet('#comment-container-1').then(function (element) {
 			element[0].style.visibility = '';
@@ -249,7 +249,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
 		cy.cGet('#comment-container-1').should('exist');
 
-		helper.reloadDocument(newFileName,'calc');
+		helper.reloadDocument(newFilePath);
 		cy.cGet('.cool-annotation').should('exist');
 		cy.cGet('#comment-container-1').then(function (element) {
 			element[0].style.visibility = '';

--- a/cypress_test/integration_tests/desktop/calc/macro_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/macro_spec.js
@@ -6,9 +6,9 @@ var calcHelper = require('../../common/calc_helper');
 describe(['tagdesktop', 'tagproxy'], 'macro dialog tests', function() {
 
 	beforeEach(function() {
-		var newFileName = helper.setupDocument('macro.ods','calc');
+		var newFilePath = helper.setupDocument('calc/macro.ods');
 		// Skip document check to click through accept macro dialog first
-		helper.loadDocument(newFileName,'calc',true);
+		helper.loadDocument(newFilePath,true);
 		acceptMacroExecution();
 		helper.documentChecks();
 	});

--- a/cypress_test/integration_tests/desktop/calc/open_different_file_types_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/open_different_file_types_spec.js
@@ -34,9 +34,9 @@ describe.skip(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Open different file t
 		//to fit csv jsdialog in window
 		cy.viewport(1280, 960);
 
-		var newFileName = helper.setupDocument('testfile.csv','calc');
+		var newFilePath = helper.setupDocument('calc/testfile.csv');
 		// Skip document check to click through import csv dialog first
-		helper.loadDocument(newFileName,'calc',true);
+		helper.loadDocument(newFilePath,true);
 
 		cy.cGet('form.jsdialog-container.lokdialog_container').should('exist');
 		cy.cGet('.ui-pushbutton.jsdialog.button-primary').click();
@@ -54,7 +54,7 @@ describe.skip(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Open different file t
 	});
 
 	it('Open xlsb file', { defaultCommandTimeout: 60000 }, function() {
-		desktopHelper.openReadOnlyFile('testfile.xlsb');
+		desktopHelper.openReadOnlyFile('calc/testfile.xlsb');
 
 		cy.cGet('#mobile-edit-button').should('be.visible').click();
 		cy.cGet('#modal-dialog-switch-to-edit-mode-modal-overlay').should('be.visible');
@@ -74,13 +74,13 @@ describe.skip(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Open different file t
 	});
 
 	it('Open xltm file', { defaultCommandTimeout: 60000 }, function() {
-		desktopHelper.openReadOnlyFile('testfile.xltm');
+		desktopHelper.openReadOnlyFile('calc/testfile.xltm');
 
 		cy.cGet('#mobile-edit-button').should('not.be.visible');
 	});
 
 	it('Open xltx file', { defaultCommandTimeout: 60000 }, function() {
-		desktopHelper.openReadOnlyFile('testfile.xltm');
+		desktopHelper.openReadOnlyFile('calc/testfile.xltm');
 
 		cy.cGet('#mobile-edit-button').should('not.be.visible');
 	});

--- a/cypress_test/integration_tests/desktop/calc/top_toolbar_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/top_toolbar_spec.js
@@ -5,10 +5,10 @@ var desktopHelper = require('../../common/desktop_helper');
 var calcHelper = require('../../common/calc_helper');
 
 describe(['tagdesktop'], 'Top toolbar tests.', function() {
-	var newFileName;
+	var newFilePath;
 
 	beforeEach(function() {
-		newFileName = helper.setupAndLoadDocument('calc/top_toolbar.ods');
+		newFilePath = helper.setupAndLoadDocument('calc/top_toolbar.ods');
 		desktopHelper.switchUIToCompact();
 		calcHelper.clickOnFirstCell();
 	});
@@ -17,7 +17,7 @@ describe(['tagdesktop'], 'Top toolbar tests.', function() {
 		cy.cGet('#bold').click();
 		cy.cGet('#save').click();
 
-		helper.reloadDocument(newFileName,'calc');
+		helper.reloadDocument(newFilePath);
 
 		helper.setDummyClipboardForCopy();
 		calcHelper.selectEntireSheet();

--- a/cypress_test/integration_tests/desktop/draw/pdf_page_up_down_spec.js
+++ b/cypress_test/integration_tests/desktop/draw/pdf_page_up_down_spec.js
@@ -4,10 +4,10 @@ var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
 
 describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'PDF View Tests', function() {
-	var newFileName;
+	var newFilePath;
 
 	beforeEach(function() {
-		newFileName = helper.setupAndLoadDocument('draw/pdf_page_up_down.pdf');
+		newFilePath = helper.setupAndLoadDocument('draw/pdf_page_up_down.pdf');
 	});
 
 	it('PDF page down', { env: { 'pdf-view': true } }, function() {
@@ -31,9 +31,9 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'PDF View Tests', function(
 		// directly, rather save-as is used. This failed because
 		// DocBroker expected to get ModifiedStatus=false, which
 		// never happens with save-as and so we couldn't unload.
-		helper.closeDocument(newFileName);
+		helper.closeDocument(newFilePath);
 
 		// TODO: verify comment still exists
-		// helper.reloadDocument(newFileName,'draw');
+		// helper.reloadDocument(newFilePath);
 	});
 });

--- a/cypress_test/integration_tests/desktop/impress/annotation_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/annotation_spec.js
@@ -61,10 +61,10 @@ describe(['tagdesktop'], 'Annotation Tests', function() {
 });
 
 describe(['tagdesktop'], 'Collapsed Annotation Tests', function() {
-	var newFileName;
+	var newFilePath;
 
 	beforeEach(function() {
-		newFileName = helper.setupAndLoadDocument('impress/comment_switching.odp');
+		newFilePath = helper.setupAndLoadDocument('impress/comment_switching.odp');
 		desktopHelper.switchUIToNotebookbar();
 
 		if (Cypress.env('INTEGRATION') === 'nextcloud') {
@@ -134,7 +134,7 @@ describe(['tagdesktop'], 'Collapsed Annotation Tests', function() {
 		cy.cGet('#map').focus();
 		cy.cGet('.cool-annotation-info-collapsed').should('be.not.visible');
 
-		helper.reloadDocument(newFileName, 'impress');
+		helper.reloadDocument(newFilePath);
 		cy.cGet('.cool-annotation-img').click();
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
 		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
@@ -195,11 +195,11 @@ describe(['tagdesktop'], 'Comment Scrolling',function() {
 });
 
 describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
-	var newFileName;
+	var newFilePath;
 
 	beforeEach(function() {
 		cy.viewport(2400, 600);
-		newFileName = helper.setupAndLoadDocument('impress/comment_switching.odp');
+		newFilePath = helper.setupAndLoadDocument('impress/comment_switching.odp');
 		desktopHelper.switchUIToNotebookbar();
 
 		// TODO: skip sidebar detection on reload
@@ -217,7 +217,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
 		cy.cGet('.cool-annotation-edit.modify-annotation').should('be.visible');
 
-		helper.reloadDocument(newFileName,'impress');
+		helper.reloadDocument(newFilePath);
 		cy.cGet('.leaflet-marker-icon').should('exist');
 		cy.cGet('.cool-annotation-content > div').should('have.text','some text0');
 	});
@@ -233,7 +233,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('.leaflet-marker-icon').should('exist');
 		cy.cGet('.cool-annotation-content > div').should('have.text','some text0');
 
-		helper.reloadDocument(newFileName,'impress');
+		helper.reloadDocument(newFilePath);
 		cy.cGet('.leaflet-marker-icon').should('exist');
 		cy.cGet('.cool-annotation-content > div').should('have.text','some text0');
 	});
@@ -249,7 +249,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('.leaflet-marker-icon').should('not.exist');
 		cy.cGet('.cool-annotation-content > div').should('not.exist');
 
-		helper.reloadDocument(newFileName,'impress');
+		helper.reloadDocument(newFilePath);
 		cy.cGet('.leaflet-marker-icon').should('not.exist');
 		cy.cGet('.cool-annotation-content > div').should('not.exist');
 	});
@@ -265,7 +265,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
 		cy.cGet('.cool-annotation-edit.modify-annotation').should('be.visible');
 
-		helper.reloadDocument(newFileName,'impress');
+		helper.reloadDocument(newFilePath);
 		cy.cGet('.leaflet-marker-icon').should('exist');
 		cy.cGet('.cool-annotation-content > div').should('have.text','some other text, some text0');
 	});
@@ -284,7 +284,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('#annotation-content-area-1').should('have.text','some other text, some text0');
 		cy.cGet('.leaflet-marker-icon').should('exist');
 
-		helper.reloadDocument(newFileName,'impress');
+		helper.reloadDocument(newFilePath);
 		cy.cGet('.leaflet-marker-icon').should('exist');
 		cy.cGet('.cool-annotation-content > div').should('have.text','some other text, some text0');
 	});
@@ -303,7 +303,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
 		cy.cGet('.leaflet-marker-icon').should('exist');
 
-		helper.reloadDocument(newFileName,'impress');
+		helper.reloadDocument(newFilePath);
 		cy.cGet('.leaflet-marker-icon').should('exist');
 		cy.cGet('.cool-annotation-content > div').should('have.text','some text0');
 	});
@@ -321,7 +321,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('#annotation-modify-textarea-1').should('include.text', 'some text0');
 		cy.cGet('#annotation-modify-textarea-1').should('include.text', 'some reply text');
 
-		helper.reloadDocument(newFileName,'impress');
+		helper.reloadDocument(newFilePath);
 		cy.cGet('.cool-annotation-edit.reply-annotation').should('be.not.visible');
 		cy.cGet('.cool-annotation-content > div').should('include.text','some reply text');
 	});
@@ -344,7 +344,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('.cool-annotation-content > div').should('include.text','some text0');
 		cy.cGet('.cool-annotation-content > div').should('include.text','some reply text');
 
-		helper.reloadDocument(newFileName,'impress');
+		helper.reloadDocument(newFilePath);
 		cy.cGet('.cool-annotation-edit.reply-annotation').should('be.not.visible');
 		cy.cGet('.cool-annotation-content > div').should('include.text','some reply text');
 	});
@@ -366,7 +366,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('.cool-annotation-edit.reply-annotation').should('be.not.visible');
 		cy.cGet('.cool-annotation-content > div').should('have.text','some text0');
 
-		helper.reloadDocument(newFileName,'impress');
+		helper.reloadDocument(newFilePath);
 		cy.cGet('.cool-annotation-edit.reply-annotation').should('be.not.visible');
 		cy.cGet('.cool-annotation-content > div').should('have.text','some text0');
 	});

--- a/cypress_test/integration_tests/desktop/impress/fullscreen_presentation_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/fullscreen_presentation_spec.js
@@ -11,8 +11,8 @@ describe.skip(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Fullscreen Presentati
 			});
 	}
 
-	function before(fileName) {
-		helper.setupAndLoadDocument('impress/' + fileName);
+	function before(filePath) {
+		helper.setupAndLoadDocument(filePath);
 
 		if (Cypress.env('INTEGRATION') === 'nextcloud') {
 			desktopHelper.hideSidebarIfVisible();
@@ -25,7 +25,7 @@ describe.skip(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Fullscreen Presentati
 	}
 
 	it('Text fields.', function() {
-		before('text_fields.odp');
+		before('impress/text_fields.odp');
 
 		cy.wait(3000);
 
@@ -62,7 +62,7 @@ describe.skip(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Fullscreen Presentati
 	});
 
 	it('Custom background.', function() {
-		before('slide-bitmap-background.odp');
+		before('impress/slide-bitmap-background.odp');
 
 		cy.wait(3000);
 
@@ -79,7 +79,7 @@ describe.skip(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Fullscreen Presentati
 	});
 
 	it.skip('Leading spaces shorter than a text line.', function() {
-		before('white-spaces.odp');
+		before('impress/white-spaces.odp');
 
 		cy.wait(3000);
 
@@ -101,7 +101,7 @@ describe.skip(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Fullscreen Presentati
 	});
 
 	it('Leading spaces as long as a text line.', function() {
-		before('white-spaces.odp');
+		before('impress/white-spaces.odp');
 
 		cy.wait(3000);
 
@@ -125,7 +125,7 @@ describe.skip(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Fullscreen Presentati
 	});
 
 	it('Leading spaces longer than a text line.', function() {
-		before('white-spaces.odp');
+		before('impress/white-spaces.odp');
 
 		cy.wait(3000);
 
@@ -147,7 +147,7 @@ describe.skip(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Fullscreen Presentati
 	});
 
 	it('Internal spaces up to the end of the line.', function() {
-		before('white-spaces.odp');
+		before('impress/white-spaces.odp');
 
 		cy.wait(3000);
 
@@ -168,7 +168,7 @@ describe.skip(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Fullscreen Presentati
 	});
 
 	it('Internal spaces crossing two lines.', function() {
-		before('white-spaces.odp');
+		before('impress/white-spaces.odp');
 
 		cy.wait(3000);
 
@@ -190,7 +190,7 @@ describe.skip(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Fullscreen Presentati
 	});
 
 	it('Animation: Emphasis: Spin.', function() {
-		before('anim-spin.odp');
+		before('impress/anim-spin.odp');
 
 		cy.wait(3000);
 
@@ -224,7 +224,7 @@ describe.skip(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Fullscreen Presentati
 	});
 
 	it.skip('Animation: Emphasis: Grow and Shrink.', function() {
-		before('anim-grow-and-shrink.odp');
+		before('impress/anim-grow-and-shrink.odp');
 
 		cy.wait(3000);
 

--- a/cypress_test/integration_tests/desktop/impress/open_different_file_types_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/open_different_file_types_spec.js
@@ -1,12 +1,13 @@
 /* global describe it cy require expect */
 var helper = require('../../common/helper');
-const { selectZoomLevel, openReadOnlyFile } = require('../../common/desktop_helper');
+const { selectZoomLevel } = require('../../common/desktop_helper');
+var desktopHelper = require('../../common/desktop_helper');
 // const { selectTextShapeInTheCenter } = require('../../common/impress_helper');
 
 describe.skip(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Open different file types', function() {
 
-	function before(fileName) {
-		helper.setupAndLoadDocument('impress/' + fileName);
+	function before(filePath) {
+		helper.setupAndLoadDocument(filePath);
 
 		selectZoomLevel('50');
 
@@ -54,43 +55,43 @@ describe.skip(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Open different file t
 	}
 
 	it('Open pptx file', { defaultCommandTimeout: 60000 }, function() {
-		before('testfile.pptx');
+		before('impress/testfile.pptx');
 
 		assertData();
 	});
 
 	it('Open ppt file', { defaultCommandTimeout: 60000 }, function() {
-		before('testfile.ppt');
+		before('impress/testfile.ppt');
 
 		assertData();
 	});
 
 	it('Open pptm file', { defaultCommandTimeout: 60000 }, function() {
-		before('testfile.pptm');
+		before('impress/testfile.pptm');
 
 		assertData();
 	});
 
 	it('Open pot file', { defaultCommandTimeout: 60000 }, function() {
-		openReadOnlyFile('impress', 'testfile.pot');
+		desktopHelper.openReadOnlyFile('impress/testfile.pot');
 	});
 
 	it('Open potx file', { defaultCommandTimeout: 60000 }, function() {
-		openReadOnlyFile('impress', 'testfile.potx');
+		desktopHelper.openReadOnlyFile('impress/testfile.potx');
 	});
 
 	it('Open potm file', { defaultCommandTimeout: 60000 }, function() {
-		openReadOnlyFile('impress', 'testfile.potm');
+		desktopHelper.openReadOnlyFile('impress/testfile.potm');
 	});
 
 	it('Open fodp file', { defaultCommandTimeout: 60000 }, function() {
-		before('testfile.fodp');
+		before('impress/testfile.fodp');
 
 		assertData();
 	});
 
 	it('Open ppsx file', { defaultCommandTimeout: 60000 }, function() {
-		before('testfile.ppsx');
+		before('impress/testfile.ppsx');
 
 		assertData();
 	});

--- a/cypress_test/integration_tests/desktop/writer/annotation_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/annotation_spec.js
@@ -59,10 +59,10 @@ describe(['tagdesktop'], 'Annotation Tests', function() {
 });
 
 describe(['tagdesktop'], 'Collapsed Annotation Tests', function() {
-	var newFileName;
+	var newFilePath;
 
 	beforeEach(function() {
-		newFileName = helper.setupAndLoadDocument('writer/annotation.odt');
+		newFilePath = helper.setupAndLoadDocument('writer/annotation.odt');
 		desktopHelper.switchUIToNotebookbar();
 
 		// TODO: skip sidebar detection on reload
@@ -132,7 +132,7 @@ describe(['tagdesktop'], 'Collapsed Annotation Tests', function() {
 		helper.typeIntoDocument('{home}');
 		cy.cGet('.cool-annotation-info-collapsed').should('be.not.visible');
 
-		helper.reloadDocument(newFileName,'writer');
+		helper.reloadDocument(newFilePath);
 		cy.cGet('#optionscontainer div[id$="SidebarDeck.PropertyDeck"]').click(); // show sidebar.
 		cy.cGet('.cool-annotation-img').click();
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
@@ -143,11 +143,11 @@ describe(['tagdesktop'], 'Collapsed Annotation Tests', function() {
 });
 
 describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
-	var newFileName;
+	var newFilePath;
 
 	beforeEach(function() {
 		cy.viewport(1400, 600);
-		newFileName = helper.setupAndLoadDocument('writer/annotation.odt');
+		newFilePath = helper.setupAndLoadDocument('writer/annotation.odt');
 		desktopHelper.switchUIToNotebookbar();
 		// TODO: skip sidebar detection on reload
 		//cy.cGet('#optionscontainer div[id$="SidebarDeck.PropertyDeck"]').click(); // Hide sidebar.
@@ -160,7 +160,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
 		cy.cGet('.cool-annotation-edit.modify-annotation').should('be.visible');
 
-		helper.reloadDocument(newFileName,'writer');
+		helper.reloadDocument(newFilePath);
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
 		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
 	});
@@ -174,7 +174,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
 		cy.cGet('.cool-annotation-autosavelabel').should('be.not.visible');
 
-		helper.reloadDocument(newFileName,'writer');
+		helper.reloadDocument(newFilePath);
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
 		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
 	});
@@ -188,7 +188,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('#comment-container-1').should('not.exist');
 		cy.cGet('.cool-annotation-autosavelabel').should('not.exist');
 
-		helper.reloadDocument(newFileName,'writer');
+		helper.reloadDocument(newFilePath);
 		cy.cGet('.cool-annotation-content-wrapper').should('not.exist');
 		cy.cGet('#comment-container-1').should('not.exist');
 	});
@@ -205,7 +205,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
 		cy.cGet('.cool-annotation-edit.modify-annotation').should('be.visible');
 
-		helper.reloadDocument(newFileName,'writer');
+		helper.reloadDocument(newFilePath);
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
 		cy.cGet('#annotation-content-area-1').should('have.text','some other text, some text0');
 	});
@@ -225,7 +225,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('#annotation-content-area-1').should('have.text','some other text, some text0');
 		cy.cGet('.cool-annotation-autosavelabel').should('be.not.visible');
 
-		helper.reloadDocument(newFileName,'writer');
+		helper.reloadDocument(newFilePath);
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
 		cy.cGet('#annotation-content-area-1').should('have.text','some other text, some text0');
 	});
@@ -246,7 +246,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('.cool-annotation-autosavelabel').should('be.not.visible');
 		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
 
-		helper.reloadDocument(newFileName,'writer');
+		helper.reloadDocument(newFilePath);
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
 		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
 	});
@@ -263,7 +263,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
 		cy.cGet('#annotation-modify-textarea-2').should('be.visible');
 
-		helper.reloadDocument(newFileName,'writer');
+		helper.reloadDocument(newFilePath);
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
 		cy.cGet('#annotation-content-area-2').should('have.text','some reply text');
 	});
@@ -286,7 +286,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
 		cy.cGet('#annotation-content-area-2').should('have.text','some reply text');
 
-		helper.reloadDocument(newFileName,'writer');
+		helper.reloadDocument(newFilePath);
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
 		cy.cGet('#annotation-content-area-2').should('have.text','some reply text');
 	});
@@ -311,7 +311,7 @@ describe(['tagdesktop'], 'Annotation Autosave Tests', function() {
 		cy.cGet('#comment-container-1 .cool-annotation-autosavelabel').should('be.not.visible');
 		cy.cGet('#comment-container-2 .cool-annotation-autosavelabel').should('not.exist');
 
-		helper.reloadDocument(newFileName,'writer');
+		helper.reloadDocument(newFilePath);
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
 		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
 		cy.cGet('#annotation-content-area-2').should('not.exist');

--- a/cypress_test/integration_tests/desktop/writer/form_field_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/form_field_spec.js
@@ -5,8 +5,8 @@ var desktopHelper = require('../../common/desktop_helper');
 
 describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Form field button tests.', function() {
 
-	function before(fileName) {
-		helper.setupAndLoadDocument('writer/' + fileName);
+	function before(filePath) {
+		helper.setupAndLoadDocument(filePath);
 
 		if (Cypress.env('INTEGRATION') === 'nextcloud') {
 			desktopHelper.showStatusBarIfHidden();
@@ -49,7 +49,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Form field button tests.',
 	}
 
 	it('Activate and deactivate form field button.', function() {
-		before('form_field.odt');
+		before('writer/form_field.odt');
 
 		// We don't have the button by default
 		buttonShouldNotExist();
@@ -76,7 +76,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Form field button tests.',
 	});
 
 	it('Check drop down list.', function() {
-		before('form_field.odt');
+		before('writer/form_field.odt');
 
 		// Move the cursor next to the form field
 		helper.moveCursor('right');
@@ -107,7 +107,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Form field button tests.',
 	});
 
 	it('Test field editing', function() {
-		before('form_field.odt');
+		before('writer/form_field.odt');
 
 		// Move the cursor next to the form field
 		helper.moveCursor('right');
@@ -143,7 +143,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Form field button tests.',
 	});
 
 	it('Multiple form field button activation.', function() {
-		before('multiple_form_fields.odt');
+		before('writer/multiple_form_fields.odt');
 
 		// We don't have the button by default
 		buttonShouldNotExist();
@@ -174,7 +174,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Form field button tests.',
 	});
 
 	it('Test drop-down field with no selection.', function() {
-		before('drop_down_form_field_noselection.odt');
+		before('writer/drop_down_form_field_noselection.odt');
 
 		// Move the cursor next to the form field
 		helper.moveCursor('right');
@@ -186,7 +186,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Form field button tests.',
 	});
 
 	it('Test drop-down field with no items.', function() {
-		before('drop_down_form_field_noitem.odt');
+		before('writer/drop_down_form_field_noitem.odt');
 
 		// Move the cursor next to the form field
 		helper.moveCursor('right');
@@ -202,7 +202,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Form field button tests.',
 	});
 
 	it('Test field button after zoom.', function() {
-		before('form_field.odt');
+		before('writer/form_field.odt');
 
 		// Move the cursor next to the form field
 		helper.moveCursor('right');
@@ -229,7 +229,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Form field button tests.',
 	});
 
 	it('Test dynamic font size.', function() {
-		before('form_field.odt');
+		before('writer/form_field.odt');
 
 		// Move the cursor next to the form field
 		helper.moveCursor('right');

--- a/cypress_test/integration_tests/desktop/writer/open_different_file_types_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/open_different_file_types_spec.js
@@ -1,6 +1,7 @@
 /* global describe it cy require */
-const { assertImageSize, openReadOnlyFile } = require('../../common/desktop_helper');
+const { assertImageSize  } = require('../../common/desktop_helper');
 var helper = require('../../common/helper');
+var desktopHelper = require('../../common/desktop_helper');
 
 describe.skip(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Open different file types', function() {
 
@@ -58,14 +59,14 @@ describe.skip(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Open different file t
 	});
 
 	it('Open dot file', { defaultCommandTimeout: 60000 }, function() {
-		openReadOnlyFile('writer', 'testfile.dot');
+		desktopHelper.openReadOnlyFile('writer/testfile.dot');
 	});
 
 	it('Open dotm file', { defaultCommandTimeout: 60000 }, function() {
-		openReadOnlyFile('writer', 'testfile.dotm');
+		desktopHelper.openReadOnlyFile('writer/testfile.dotm');
 	});
 
 	it('Open dotx file', { defaultCommandTimeout: 60000 }, function() {
-		openReadOnlyFile('writer','testfile.dotx');
+		desktopHelper.openReadOnlyFile('writer/testfile.dotx');
 	});
 });

--- a/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
@@ -5,10 +5,10 @@ var desktopHelper = require('../../common/desktop_helper');
 var writerHelper = require('../../common/writer_helper');
 
 describe(['tagdesktop'], 'Top toolbar tests.', function() {
-	var newFileName;
+	var newFilePath;
 
 	beforeEach(function() {
-		newFileName = helper.setupAndLoadDocument('writer/top_toolbar.odt');
+		newFilePath = helper.setupAndLoadDocument('writer/top_toolbar.odt');
 		desktopHelper.switchUIToNotebookbar();
 
 		if (Cypress.env('INTEGRATION') === 'nextcloud') {
@@ -285,7 +285,7 @@ describe(['tagdesktop'], 'Top toolbar tests.', function() {
 	it('Save.', function() {
 		cy.cGet('.notebookbar > .unoBold > button').click();
 		cy.cGet('.notebookbar-shortcuts-bar .unoSave').click();
-		helper.reloadDocument(newFileName,'writer');
+		helper.reloadDocument(newFilePath);
 		helper.setDummyClipboardForCopy();
 		writerHelper.selectAllTextOfDoc();
 		helper.copy();

--- a/cypress_test/integration_tests/mobile/calc/annotation_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/annotation_spec.js
@@ -4,10 +4,10 @@ var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
 
 describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Annotation Tests',function() {
-	var newFileName;
+	var newFilePath;
 
 	beforeEach(function() {
-		newFileName = helper.setupAndLoadDocument('calc/annotation.ods');
+		newFilePath = helper.setupAndLoadDocument('calc/annotation.ods');
 
 		// Click on edit button
 		mobileHelper.enableEditingMobile();
@@ -18,7 +18,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Annotation Tests',function(
 		cy.cGet('#comment-container-1').should('exist');
 		mobileHelper.selectHamburgerMenuItem(['File', 'Save']);
 
-		helper.reloadDocument(newFileName, 'calc');
+		helper.reloadDocument(newFilePath);
 		mobileHelper.enableEditingMobile();
 		mobileHelper.openCommentWizard();
 		helper.waitUntilIdle('#mobile-wizard-content', undefined);

--- a/cypress_test/integration_tests/mobile/calc/hamburger_menu_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/hamburger_menu_spec.js
@@ -8,7 +8,7 @@ var repairHelper = require('../../common/repair_document_helper');
 describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 
 	it('Save', { defaultCommandTimeout: 60000 }, function() {
-		var newFileName = helper.setupAndLoadDocument('calc/hamburger_menu.ods');
+		var newFilePath = helper.setupAndLoadDocument('calc/hamburger_menu.ods');
 		mobileHelper.enableEditingMobile();
 
 		calcHelper.selectEntireSheet();
@@ -22,7 +22,7 @@ describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 		mobileHelper.selectHamburgerMenuItem(['File', 'Save']);
 
 		// Reopen the document and check content.
-		helper.reloadDocument(newFileName, 'calc');
+		helper.reloadDocument(newFilePath);
 
 		mobileHelper.enableEditingMobile();
 		calcHelper.selectEntireSheet();

--- a/cypress_test/integration_tests/mobile/calc/nextcloud_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/nextcloud_spec.js
@@ -10,7 +10,7 @@ describe(['tagnextcloud'], 'Nextcloud specific tests.', function() {
 		helper.setupAndLoadDocument('calc/nextcloud.ods');
 		mobileHelper.enableEditingMobile();
 
-		helper.upLoadFileToNextCloud('image_to_insert.png', 'calc');
+		helper.upLoadFileToNextCloud('calc/image_to_insert.png');
 		nextcloudHelper.insertImageFromStorage('image_to_insert.png');
 
 		// TODO
@@ -19,7 +19,8 @@ describe(['tagnextcloud'], 'Nextcloud specific tests.', function() {
 	});
 
 	it('Save as.', function() {
-		var newFileName = helper.setupAndLoadDocument('calc/nextcloud.ods');
+		var newFilePath = helper.setupAndLoadDocument('calc/nextcloud.ods');
+		var newFileName = helper.getFileName(newFilePath);
 		mobileHelper.enableEditingMobile();
 
 		nextcloudHelper.saveFileAs('1' + newFileName);

--- a/cypress_test/integration_tests/mobile/impress/annotation_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/annotation_spec.js
@@ -4,10 +4,10 @@ var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
 
 describe(['tagmobile'], 'Annotation tests.', function() {
-	var newFileName;
+	var newFilePath;
 
 	beforeEach(function() {
-		newFileName = helper.setupAndLoadDocument('impress/annotation.odp');
+		newFilePath = helper.setupAndLoadDocument('impress/annotation.odp');
 
 		mobileHelper.enableEditingMobile();
 	});
@@ -17,7 +17,7 @@ describe(['tagmobile'], 'Annotation tests.', function() {
 
 		mobileHelper.selectHamburgerMenuItem(['File', 'Save']);
 
-		helper.reloadDocument(newFileName,'impress');
+		helper.reloadDocument(newFilePath);
 
 		mobileHelper.enableEditingMobile();
 

--- a/cypress_test/integration_tests/mobile/impress/hamburger_menu_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/hamburger_menu_spec.js
@@ -6,10 +6,10 @@ var mobileHelper = require('../../common/mobile_helper');
 var repairHelper = require('../../common/repair_document_helper');
 
 describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
-	var newFileName;
+	var newFilePath;
 
 	beforeEach(function() {
-		newFileName = helper.setupAndLoadDocument('impress/hamburger_menu.odp');
+		newFilePath = helper.setupAndLoadDocument('impress/hamburger_menu.odp');
 
 		// Click on edit button
 		mobileHelper.enableEditingMobile();
@@ -35,7 +35,7 @@ describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 		mobileHelper.selectHamburgerMenuItem(['File', 'Save']);
 
 		// Reopen the document and check content.
-		helper.reloadDocument(newFileName,'impress');
+		helper.reloadDocument(newFilePath);
 
 		mobileHelper.enableEditingMobile();
 

--- a/cypress_test/integration_tests/mobile/impress/nextcloud_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/nextcloud_spec.js
@@ -13,13 +13,14 @@ describe(['tagnextcloud'], 'Nextcloud specific tests.', function() {
 		helper.setupAndLoadDocument('impress/nextcloud.odp');
 		mobileHelper.enableEditingMobile();
 
-		helper.upLoadFileToNextCloud('image_to_insert.png', 'impress');
+		helper.upLoadFileToNextCloud('impress/image_to_insert.png');
 		nextcloudHelper.insertImageFromStorage('image_to_insert.png');
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane svg g').should('exist');
 	});
 
 	it('Save as.', function() {
-		var newFileName = helper.setupAndLoadDocument('impress/nextcloud.odp');
+		var newFilePath = helper.setupAndLoadDocument('impress/nextcloud.odp');
+		var newFileName = helper.getFileName(newFilePath);
 		mobileHelper.enableEditingMobile();
 
 		nextcloudHelper.saveFileAs('1' + newFileName);

--- a/cypress_test/integration_tests/mobile/writer/annotation_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/annotation_spec.js
@@ -4,10 +4,10 @@ var helper = require('../../common/helper');
 var mobileHelper = require('../../common/mobile_helper');
 
 describe(['tagmobile'], 'Annotation tests.', function() {
-	var newFileName;
+	var newFilePath;
 
 	beforeEach(function() {
-		newFileName = helper.setupAndLoadDocument('writer/annotation.odt');
+		newFilePath = helper.setupAndLoadDocument('writer/annotation.odt');
 
 		mobileHelper.enableEditingMobile();
 	});
@@ -15,7 +15,7 @@ describe(['tagmobile'], 'Annotation tests.', function() {
 	it('Saving comment.', { defaultCommandTimeout: 60000 }, function() {
 		mobileHelper.insertComment();
 		mobileHelper.selectHamburgerMenuItem(['File', 'Save']);
-		helper.reloadDocument(newFileName, 'writer');
+		helper.reloadDocument(newFilePath);
 		mobileHelper.enableEditingMobile();
 		mobileHelper.openCommentWizard();
 		helper.waitUntilIdle('#mobile-wizard-content', undefined);

--- a/cypress_test/integration_tests/mobile/writer/cursor_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/cursor_spec.js
@@ -6,14 +6,14 @@ var writerHelper = require('../../common/writer_helper');
 
 describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Text cursor tests.', function() {
 
-	function before(fileName) {
-		helper.setupAndLoadDocument('writer/' + fileName);
+	function before(filePath) {
+		helper.setupAndLoadDocument(filePath);
 
 		mobileHelper.enableEditingMobile();
 	}
 
 	it('Extensive cursor movements.', function() {
-		before('cursor.odt');
+		before('writer/cursor.odt');
 
 		for (var i = 0; i < 5; i++) {
 			helper.moveCursor('right');
@@ -24,7 +24,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Text cursor tests.', functi
 	});
 
 	it('View jumps by cursor movement.', function() {
-		before('cursor.odt');
+		before('writer/cursor.odt');
 
 		for (var i = 0; i < 5; i++) {
 			helper.moveCursor('end');
@@ -33,7 +33,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Text cursor tests.', functi
 	});
 
 	it('Cursor is visible after text selection.', function() {
-		before('cursor.odt');
+		before('writer/cursor.odt');
 		writerHelper.selectAllTextOfDoc();
 		cy.cGet('.blinking-cursor').should('be.visible');
 		// Blinking cursor and so the view should be at the end of the text selection.
@@ -42,7 +42,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Text cursor tests.', functi
 	});
 
 	it('Move cursor through table.', function() {
-		before('cursor_in_table.odt');
+		before('writer/cursor_in_table.odt');
 
 		for (var i = 0; i < 5; i++) {
 			helper.moveCursor('down');

--- a/cypress_test/integration_tests/mobile/writer/hamburger_menu_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/hamburger_menu_spec.js
@@ -6,10 +6,10 @@ var writerHelper = require('../../common/writer_helper');
 var repairHelper = require('../../common/repair_document_helper');
 
 describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
-	var newFileName;
+	var newFilePath;
 
 	beforeEach(function() {
-		newFileName = helper.setupAndLoadDocument('writer/hamburger_menu.odt');
+		newFilePath = helper.setupAndLoadDocument('writer/hamburger_menu.odt');
 
 		mobileHelper.enableEditingMobile();
 	});
@@ -47,7 +47,7 @@ describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 		helper.expectTextForClipboard('new');
 		mobileHelper.selectHamburgerMenuItem(['File', 'Save']);
 		// Reopen the document and check content.
-		helper.reloadDocument(newFileName, 'writer');
+		helper.reloadDocument(newFilePath);
 		mobileHelper.enableEditingMobile();
 		writerHelper.selectAllTextOfDoc();
 		helper.expectTextForClipboard('new');

--- a/cypress_test/integration_tests/mobile/writer/nextcloud_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/nextcloud_spec.js
@@ -10,7 +10,7 @@ describe(['tagnextcloud'], 'Nextcloud specific tests.', function() {
 		helper.setupAndLoadDocument('writer/nextcloud.odt');
 		mobileHelper.enableEditingMobile();
 
-		helper.upLoadFileToNextCloud('image_to_insert.png', 'writer');
+		helper.upLoadFileToNextCloud('writer/image_to_insert.png');
 		nextcloudHelper.insertImageFromStorage('image_to_insert.png');
 
 		cy.get('.leaflet-pane.leaflet-overlay-pane svg g.Graphic')
@@ -18,7 +18,8 @@ describe(['tagnextcloud'], 'Nextcloud specific tests.', function() {
 	});
 
 	it('Save as.', function() {
-		var newFileName = helper.setupAndLoadDocument('writer/nextcloud.odt');
+		var newFilePath = helper.setupAndLoadDocument('writer/nextcloud.odt');
+		var newFileName = helper.getFileName(newFilePath);
 		mobileHelper.enableEditingMobile();
 
 		nextcloudHelper.saveFileAs('1' + newFileName);

--- a/cypress_test/integration_tests/mobile/writer/table_properties_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/table_properties_spec.js
@@ -6,8 +6,8 @@ var writerHelper = require('../../common/writer_helper');
 
 describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Change table properties / layout via mobile wizard.', function() {
 
-	function before(fileName) {
-		helper.setupAndLoadDocument('writer/' + fileName);
+	function before(filePath) {
+		helper.setupAndLoadDocument(filePath);
 
 		// Click on edit button
 		mobileHelper.enableEditingMobile();
@@ -30,7 +30,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Change table properties / l
 	}
 
 	it('Insert row before.', function() {
-		before('table_properties.odt');
+		before('writer/table_properties.odt');
 		helper.setDummyClipboardForCopy();
 		openTablePanel();
 		cy.cGet('.unoInsertRowsBefore').click();
@@ -48,7 +48,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Change table properties / l
 	});
 
 	it('Insert row after.', function() {
-		before('table_properties.odt');
+		before('writer/table_properties.odt');
 		helper.setDummyClipboardForCopy();
 		openTablePanel();
 		cy.cGet('.unoInsertRowsAfter').click();
@@ -66,7 +66,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Change table properties / l
 	});
 
 	it('Insert column before.', function() {
-		before('table_properties.odt');
+		before('writer/table_properties.odt');
 		helper.setDummyClipboardForCopy();
 		openTablePanel();
 		cy.cGet('.unoInsertColumnsBefore').click();
@@ -83,7 +83,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Change table properties / l
 	});
 
 	it('Insert column after.', function() {
-		before('table_properties.odt');
+		before('writer/table_properties.odt');
 		helper.setDummyClipboardForCopy();
 		openTablePanel();
 		cy.cGet('.unoInsertColumnsAfter').click();
@@ -100,7 +100,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Change table properties / l
 	});
 
 	it('Delete row.', function() {
-		before('table_properties.odt');
+		before('writer/table_properties.odt');
 		helper.setDummyClipboardForCopy();
 		openTablePanel();
 		cy.cGet('.unoDeleteRows').click();
@@ -119,7 +119,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Change table properties / l
 	});
 
 	it('Delete column.', function() {
-		before('table_properties.odt');
+		before('writer/table_properties.odt');
 		// Insert column first
 		openTablePanel();
 		cy.cGet('.unoInsertColumnsBefore').click();
@@ -132,7 +132,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Change table properties / l
 	});
 
 	it('Delete table.', function() {
-		before('table_properties.odt');
+		before('writer/table_properties.odt');
 		openTablePanel();
 		cy.cGet('.unoDeleteTable').click();
 		cy.cGet('.leaflet-marker-icon.table-column-resize-marker').should('not.exist');
@@ -146,7 +146,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Change table properties / l
 	});
 
 	it('Merge cells.', function() {
-		before('table_properties.odt');
+		before('writer/table_properties.odt');
 		helper.setDummyClipboardForCopy();
 		// Select 2x2 part of the table.
 		helper.moveCursor('down', 'shift');
@@ -173,7 +173,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Change table properties / l
 	});
 
 	it('Change row height.', function() {
-		before('table_properties.odt');
+		before('writer/table_properties.odt');
 		helper.setDummyClipboardForCopy();
 		openTablePanel();
 		cy.wait(500);
@@ -185,7 +185,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Change table properties / l
 	});
 
 	it('Change column width.', function() {
-		before('table_properties.odt');
+		before('writer/table_properties.odt');
 		helper.setDummyClipboardForCopy();
 		openTablePanel();
 		cy.wait(500);
@@ -196,7 +196,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Change table properties / l
 	});
 
 	it('Set minimal row height.', function() {
-		before('table_with_text.odt');
+		before('writer/table_with_text.odt');
 		helper.setDummyClipboardForCopy();
 		// Select full table (3x2)
 		helper.moveCursor('down', 'shift');
@@ -213,7 +213,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Change table properties / l
 	});
 
 	it('Set optimal row height.', function() {
-		before('table_with_text.odt');
+		before('writer/table_with_text.odt');
 		helper.setDummyClipboardForCopy();
 		openTablePanel();
 		selectFullTable();
@@ -230,7 +230,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Change table properties / l
 	});
 
 	it('Distribute rows.', function() {
-		before('table_with_text.odt');
+		before('writer/table_with_text.odt');
 		helper.setDummyClipboardForCopy();
 
 		// Select full table (3x2)
@@ -258,7 +258,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Change table properties / l
 	});
 
 	it('Set minimal column width.', function() {
-		before('table_with_text.odt');
+		before('writer/table_with_text.odt');
 		helper.setDummyClipboardForCopy();
 
 		// Select full table (3x2)
@@ -274,7 +274,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Change table properties / l
 	});
 
 	it('Set optimal column width.', function() {
-		before('table_with_text.odt');
+		before('writer/table_with_text.odt');
 		helper.setDummyClipboardForCopy();
 
 		// Select full table (3x2)
@@ -292,7 +292,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Change table properties / l
 	});
 
 	it('Distribute columns.', function() {
-		before('table_with_text.odt');
+		before('writer/table_with_text.odt');
 		helper.setDummyClipboardForCopy();
 
 		// Select full table (3x2)


### PR DESCRIPTION
Removes the need to add subFolder information separately or duplicate it. For example, calc/macro_spec.js changes from
```
var newFileName = helper.setupDocument('macro.ods','calc');
helper.loadDocument(newFileName,'calc',true);
```
to
```
var newFilePath = helper.setupDocument('calc/macro.ods');
helper.loadDocument(newFilePath,true);
```

Follow up of https://github.com/CollaboraOnline/online/pull/8832 

Change-Id: I361d523f564e7b9a46dd2398080eef110eeae79c
