### PR TITLE
Cypress: Fix selectTextOfShape

### DIFF
--- a/cypress_test/integration_tests/common/impress_helper.js
+++ b/cypress_test/integration_tests/common/impress_helper.js
@@ -166,13 +166,14 @@ function selectTextOfShape(selectAllText = true) {
 	cy.log('>> selectTextOfShape - start');
 
 	// Double click onto the selected shape
-	// Retry until the cursor appears
+	// Retry until the selection works (fails about 30% of the time).
+	// Note, retrying until the cursor (.leaflet-cursor-container) appears is not enough.
+	// There is no difference in the DOM to indicate the selection is working.
 	cy.waitUntil(function() {
 		cy.cGet('svg g .leaflet-interactive').dblclick({force: true});
-		return cy.cGet('.cursor-overlay')
-			.then(function(overlay) {
-				return overlay.children('.leaflet-cursor-container').length !== 0;
-			});
+		return cy.getFrameWindow().its('L').then(function(L) {
+			return L.Map.THIS._textInput._isEditingInSelection == true;
+		});
 	});
 
 	cy.cGet('.leaflet-cursor.blinking-cursor').should('exist');


### PR DESCRIPTION
Fixes mobile/impress/apply_paragraph_props_text_spec.js
Text selection did not always work. Use different check in
waitUntil to retry until the selection works.


Change-Id: Iad0944735bfea06ba5361a17fbd67ea474be3c25