### PR TITLE
macro: open document without macros enabled

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -282,8 +282,8 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			// returns docnotloaded error. Instead of this we can return to the integration
 			if (!builder.map._docLoaded &&
 				 !window._firstDialogHandled &&
-				 ((object.id === 'cancel' || eventType === 'close') ||
-				 (objectType === 'responsebutton' && (data == 0 || data == 7)))) {
+				 (eventType === 'close' ||
+				 (objectType === 'responsebutton' && data == 7))) {
 				window.onClose();
 			}
 			switch (typeof data) {


### PR DESCRIPTION
problem:
when user selected disable macro in the opening dialog
document used to close and return to integrator
but now cancel button in csv import dialog is hidden,
so no need to distinguish there and we can continue to load without macros
In addition we still close the file if user clicks "X" button on title bar


* Target version: master 


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

