### PR TITLE
Don't warn about version mismatch for admin console

### DIFF
--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -528,7 +528,8 @@ void FileServerRequestHandler::handleRequest(const HTTPRequest& request,
         LOG_TRC("Fileserver request: " << requestUri.toString());
         requestUri.normalize(); // avoid .'s and ..'s
 
-        if (requestUri.getPath().find("browser/" COOLWSD_VERSION_HASH "/") == std::string::npos)
+        if (requestUri.getPath().find("browser/" COOLWSD_VERSION_HASH "/") == std::string::npos &&
+            requestUri.getPath().find("admin/") == std::string::npos)
         {
             LOG_WRN("Client - server version mismatch, disabling browser cache. "
                     "Expected: " COOLWSD_VERSION_HASH "; Actual URI path with version hash: "


### PR DESCRIPTION
It's only relevant for regular URLs that contain version hash.


Change-Id: I73afaa0559c3dddc09a8ed5f786fb5126e1c8f0c


* Target version: master 

### Checklist

- [X] Code is properly formatted
- [X] All commits have Change-Id
- [ ] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

