### PR TITLE
cool#8806 clipboard: fix paste special of images in Firefox

### DIFF
--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -467,6 +467,11 @@ L.Clipboard = L.Class.extend({
 						this._asyncReadPasteImage(dataTransfer.items[t].getAsFile());
 				}
 			}
+
+			// If any paste special dialog is open, close it here, because we won't call
+			// _doInternalPaste() that would do the closing.
+			this._checkAndDisablePasteSpecial();
+
 			return;
 		}
 


### PR DESCRIPTION
Copy an image to the clipboard, click Paste -> Paste special on the
notebookbar in Firefox: the image is pasted, but the paste special
dialog doesn't close.

What happens here is that Firefox lacks navigator.clipboard.read(), so
the relevant code is Clipboard.js dataTransferToDocumentFallback(), not
the new _navigatorClipboardGetTypeCallback(). Here e.g. copy from
desktop Writer (html+text) would lead to a _doInternalPaste(), which
would call _checkAndDisablePasteSpecial() for us, but the image case
returns early, so the closing doesn't happen.

Fix the problem by explicitly calling _checkAndDisablePasteSpecial()
before returning early.  In contrast with the other uses of
_checkAndDisablePasteSpecial(), we don't need to call the paste or paste
special uno command (since _asyncReadPasteImage() takes care of pasting
with a websocket comment), so it's fine to ignore the return value.

No testcase, our cypress tests run on Chrome, and this happens only with
Firefox.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I751d234edfdf9e8fb37f2bf2d6b3f3d8e65a27f4
