### PR TITLE
allow a test to start without sidebar

### DIFF
--- a/cypress_test/integration_tests/common/helper.js
+++ b/cypress_test/integration_tests/common/helper.js
@@ -352,7 +352,8 @@ function documentChecks() {
 	// Wait for the sidebar to open.
 	if (Cypress.env('INTEGRATION') !== 'nextcloud') {
 		doIfOnDesktop(function() {
-			if (Cypress.env('pdf-view') !== true)
+			var showSidebar = localStorage.getItem('UIDefaults_text_ShowSidebar');
+			if (Cypress.env('pdf-view') !== true && showSidebar !== 'false')
 				cy.cframe().find('#sidebar-panel').should('be.visible');
 
 			// Check that the document does not take the whole window width.


### PR DESCRIPTION
instead of starting with sidebar and then removing it


Change-Id: If2ea433cd3d5fc18ad549bd3df095de15c126ad0


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

