### PR TITLE
Make freeze shadow move with a pinch-zoom

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -269,6 +269,9 @@ L.TileSectionManager = L.Class.extend({
 			that._layer._syncTileContainerSize();
 		});
 		this.resObserver.observe(canvasContainer);
+
+		this._zoomAtDocEdgeX = true;
+		this._zoomAtDocEdgeY = true;
 	},
 
 	// Map and TilesSection overlap entirely. Map is above tiles section. In order to handle events in tiles section, we need to mirror them from map.
@@ -6205,12 +6208,11 @@ L.CanvasTileLayer = L.Layer.extend({
 					+ ' splitx=' + Math.round(splitPos.x)
 					+ ' splity=' + Math.round(splitPos.y);
 
-		// Set transparent gradient over the area where cells are concealed
 		if (this._ySplitter) {
-			this._setSpliterGradient(this._ySplitter, visibleTopLeft.y);
+			this._ySplitter.onPositionChange();
 		}
 		if (this._xSplitter) {
-			this._setSpliterGradient(this._xSplitter, visibleTopLeft.x);
+			this._xSplitter.onPositionChange();
 		}
 		if (this._clientVisibleArea !== newClientVisibleArea || forceUpdate) {
 			// Visible area is dirty, update it on the server
@@ -6219,22 +6221,6 @@ L.CanvasTileLayer = L.Layer.extend({
 				this._clientVisibleArea = newClientVisibleArea;
 			if (this._debug.tileInvalidationsOn)
 				this._debug._tileInvalidationLayer.clearLayers();
-		}
-	},
-
-	_setSpliterGradient: function (splitter, visibleTopLeft) {
-
-		var origTopOrLeftOfSplitPane = splitter.isTopOrLeftOfSplitPane;
-
-		if (Math.round(visibleTopLeft) == 0) {
-			splitter.isTopOrLeftOfSplitPane = true;
-		}
-		else {
-			splitter.isTopOrLeftOfSplitPane = false;
-		}
-
-		if (origTopOrLeftOfSplitPane != splitter.isTopOrLeftOfSplitPane) {
-			splitter.onPositionChange();
 		}
 	},
 

--- a/browser/src/layer/tile/TilesSection.ts
+++ b/browser/src/layer/tile/TilesSection.ts
@@ -786,7 +786,7 @@ export class TilesSection extends CanvasSectionObject {
 			} else {
 				// Pane is free to move in X direction.
 				destPos.x = splitPos.x;
-				paneSize.x -= splitPos.x;
+				docAreaSize.x += splitPos.x / scale;
 				freezeX = false;
 			}
 
@@ -797,7 +797,7 @@ export class TilesSection extends CanvasSectionObject {
 			} else {
 				// Pane is free to move in Y direction.
 				destPos.y = splitPos.y;
-				paneSize.y -= splitPos.y;
+				docAreaSize.y += splitPos.y / scale;
 				freezeY = false;
 			}
 

--- a/browser/src/layer/tile/TilesSection.ts
+++ b/browser/src/layer/tile/TilesSection.ts
@@ -812,6 +812,14 @@ export class TilesSection extends CanvasSectionObject {
 				false /* findFreePaneCenter? */
 			);
 
+			if (!freezeX) {
+				tsManager._zoomAtDocEdgeX = docPos.topLeft.x == splitPos.x;
+			}
+
+			if (!freezeY) {
+				tsManager._zoomAtDocEdgeY = docPos.topLeft.y == splitPos.y;
+			}
+
 			var docRange = new L.Bounds(docPos.topLeft, docPos.topLeft.add(docAreaSize));
 			if (tsManager._calcGridSection) {
 				tsManager._calcGridSection.onDrawArea(docRange, docRange.min.subtract(destPos), this.context);

--- a/browser/src/layer/vector/CPath.ts
+++ b/browser/src/layer/vector/CPath.ts
@@ -14,6 +14,7 @@ abstract class CPath extends CEventsHandler {
 	lineCap: CanvasLineCap = 'round';
 	lineJoin: CanvasLineJoin = 'round';
 	fill: boolean = false;
+	fillGradient: boolean = false;
 	fillColor: string = this.color;
 	fillOpacity: number = 0.2;
 	fillRule: CanvasFillRule = 'evenodd';
@@ -29,8 +30,6 @@ abstract class CPath extends CEventsHandler {
 	radiusY: number = 0;
 	point: cool.Point;
 	zIndex: number = 0;
-
-	isTopOrLeftOfSplitPane: boolean = true;
 
 	static countObjects: number = 0;
 	private id: number;

--- a/browser/src/layer/vector/CSplitterLine.ts
+++ b/browser/src/layer/vector/CSplitterLine.ts
@@ -42,7 +42,39 @@ class CSplitterLine extends CRectangle {
 	onChange() {
 		var newBounds = this.computeBounds();
 		this.fillOpacity = this.inactive ? 0 : this.origOpacity;
+		this.fillGradient = this.computeShouldFillGradient();
 		this.setBounds(newBounds);
+	}
+
+	computeShouldFillGradient() {
+		const tsManager = this.map._docLayer._painter;
+		const splitPos = tsManager.getSplitPos();
+
+		if ((this.isHoriz && !splitPos.x) || (!this.isHoriz && !splitPos.y)
+		) {
+			return false;
+		}
+
+		if (tsManager._inZoomAnim) {
+			if (this.isHoriz) {
+				return !tsManager._zoomAtDocEdgeX;
+			} else {
+				return !tsManager._zoomAtDocEdgeY;
+			}
+		}
+
+		const pixelBounds = this.map.getPixelBounds();
+
+		if (this.isHoriz) {
+			return !!pixelBounds.min.x;
+		} else {
+			return !!pixelBounds.min.y;
+		}
+	}
+
+	updatePathAllPanes(paintArea?: Bounds) {
+		this.fillGradient = this.computeShouldFillGradient();
+		super.updatePathAllPanes(paintArea);
 	}
 
 	private computeBounds(): cool.Bounds {

--- a/browser/src/layer/vector/CanvasOverlay.ts
+++ b/browser/src/layer/vector/CanvasOverlay.ts
@@ -464,11 +464,11 @@ class CanvasOverlay extends CanvasSectionObject {
 	}
 
 	private fillStroke(path: CPath) {
-
 		if (path.fill) {
 			this.ctx.globalAlpha = path.fillOpacity;
 			this.ctx.fillStyle = path.fillColor || path.color;
-			if (!path.isTopOrLeftOfSplitPane) {
+
+			if (path.fillGradient) {
 				this.setBoxGradient(path);
 			}
 

--- a/browser/src/layer/vector/CanvasOverlay.ts
+++ b/browser/src/layer/vector/CanvasOverlay.ts
@@ -491,6 +491,11 @@ class CanvasOverlay extends CanvasSectionObject {
 		const splitPos = this.tsManager.getSplitPos();
 		let selectionBackgroundGradient = null;
 
+		if (this.tsManager._inZoomAnim) {
+			splitPos.x *= this.tsManager._zoomFrameScale;
+			splitPos.y *= this.tsManager._zoomFrameScale;
+		}
+
 		// last row geometry data will be a good for setting deafult raw height
 		const spanlist = this.map._docLayer.sheetGeometry.getRowsGeometry()._visibleSizes._spanlist;
 		const rowData = spanlist[spanlist.length - 1];


### PR DESCRIPTION
Previously the freeze shadow would stay where it was, creating a hard
edge and confusion about where was frozen. With this change, the freeze
shadow moves with the zoom.

Previously when panning with zoom, the freeze shadow would stay in its
initial state (either hidden or shown) whether or not it should actually
be shown at the current position.

Previously when there was a frozen pane we calculated an incorrect
size on the unfrozen pane, leading to slight blank edges when you were
mid-zoom-out.

This pull request fixes all 3 of these issues

Signed-off-by: Skyler Grey <skyler.grey@collabora.com>