### PR TITLE
Remove "updateResolvedState" function.

### DIFF
--- a/browser/src/layer/tile/CommentListSection.ts
+++ b/browser/src/layer/tile/CommentListSection.ts
@@ -1836,15 +1836,6 @@ export class CommentSection extends CanvasSectionObject {
 		this.update();
 	}
 
-	private updateResolvedState (comment: any): void {
-		var threadIndexFirst = this.getSubRootIndexOf(comment.sectionProperties.data.id);
-		if (threadIndexFirst !== -1 && this.sectionProperties.commentList[threadIndexFirst].sectionProperties.data.resolved !== comment.sectionProperties.data.resolved) {
-			comment.sectionProperties.data.resolved = this.sectionProperties.commentList[threadIndexFirst].sectionProperties.data.resolved;
-			comment.update();
-			this.update();
-		}
-	}
-
 	private orderCommentList (): void {
 		this.sectionProperties.commentList.sort(function(a: any, b: any) {
 			return Math.abs(a.sectionProperties.data.anchorPos[1]) - Math.abs(b.sectionProperties.data.anchorPos[1]) ||
@@ -2045,7 +2036,6 @@ export class CommentSection extends CanvasSectionObject {
 					continue;
 				this.sectionProperties.commentList.push(commentSection);
 				this.idIndexMap.set(commentSection.sectionProperties.data.id, i);
-				this.updateResolvedState(this.sectionProperties.commentList[i]);
 			}
 
 			if (this.sectionProperties.docLayer._docType === 'text')


### PR DESCRIPTION
It sets a reply's status to "resolved" only if its parent is resolved.

I can't remember why we implemented this like this before.

But now, we don't need to.


Change-Id: Ia31dab0237d3b89e5d391cf87394514d18b595f7


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

