### PR TITLE
Cypress: Retry selectTextOfShape

### DIFF
--- a/cypress_test/integration_tests/common/impress_helper.js
+++ b/cypress_test/integration_tests/common/impress_helper.js
@@ -161,12 +161,31 @@ function triggerNewSVGForShapeInTheCenter() {
 // Select the text inside a preselected shape. So we assume
 // we have already a shape selected. We try to select the
 // text of this shape by double clicking into it, until the
-// cursor becomes visible.
-function selectTextOfShape(selectAllText = true) {
+// cursor becomes visible and the text is selected
+function selectTextOfShape() {
 	cy.log('>> selectTextOfShape - start');
 
 	// Double click onto the selected shape
-	// Retry until the cursor appears
+	// Retry until the cursor appears and the text is selected
+	cy.waitUntil(function() {
+		cy.cGet('svg g svg').dblclick({force: true});
+		helper.typeIntoDocument('{ctrl}a');
+		return cy.cGet('.leaflet-marker-pane')
+			.then(function(markerPane) {
+				return markerPane.children().length !== 0;
+			});
+	});
+
+	helper.textSelectionShouldExist();
+
+	cy.log('<< selectTextOfShape - end');
+}
+
+// Double click on the shape to edit the text
+// and wait for the cursor to appear
+function editTextInShape() {
+	cy.log('>> editTextInShape - start');
+
 	cy.waitUntil(function() {
 		cy.cGet('svg g .leaflet-interactive').dblclick({force: true});
 		return cy.cGet('.cursor-overlay')
@@ -174,13 +193,9 @@ function selectTextOfShape(selectAllText = true) {
 				return overlay.children('.leaflet-cursor-container').length !== 0;
 			});
 	});
-
 	cy.cGet('.leaflet-cursor.blinking-cursor').should('exist');
 
-	if (selectAllText)
-		helper.selectAllText();
-
-	cy.log('<< selectTextOfShape - end');
+	cy.log('<< editTextInShape - end');
 }
 
 // Step into text editing of the preselected shape. So we assume
@@ -249,6 +264,7 @@ module.exports.selectTextShapeInTheCenter = selectTextShapeInTheCenter;
 module.exports.triggerNewSVGForShapeInTheCenter = triggerNewSVGForShapeInTheCenter;
 module.exports.removeShapeSelection = removeShapeSelection;
 module.exports.selectTextOfShape = selectTextOfShape;
+module.exports.editTextInShape =editTextInShape;
 module.exports.dblclickOnSelectedShape = dblclickOnSelectedShape;
 module.exports.addSlide = addSlide;
 module.exports.changeSlide = changeSlide;

--- a/cypress_test/integration_tests/desktop/impress/editable_area_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/editable_area_spec.js
@@ -5,7 +5,6 @@ var desktopHelper = require('../../common/desktop_helper');
 var impressHelper = require('../../common/impress_helper');
 var ceHelper = require('../../common/contenteditable_helper');
 
-
 function selectTextShape(i) {
     cy.log('Selecting text shape - start.');
     if (typeof i !== 'number' || i <= 0 || i > 2)
@@ -41,7 +40,7 @@ describe(['taga11yenabled'], 'Editable area - Basic typing and caret moving', fu
     it.skip('Editing top text shape', function () {
         // select shape and activate editing
         selectTextShape(1);
-        impressHelper.selectTextOfShape(false);
+        impressHelper.editTextInShape();
         // initial position
         ceHelper.checkHTMLContent('');
         ceHelper.checkCaretPosition(0);
@@ -54,7 +53,7 @@ describe(['taga11yenabled'], 'Editable area - Basic typing and caret moving', fu
         ceHelper.checkHTMLContent('');
         // activate editing again
         selectTextShape(1);
-        impressHelper.selectTextOfShape(false);
+        impressHelper.editTextInShape();
         ceHelper.checkPlainContent('Hello World');
         ceHelper.moveCaret('end');
         ceHelper.checkCaretPosition(11);
@@ -64,7 +63,7 @@ describe(['taga11yenabled'], 'Editable area - Basic typing and caret moving', fu
     it('Deleting text', function () {
         // select shape and activate editing
         selectTextShape(1);
-        impressHelper.selectTextOfShape(false);
+        impressHelper.editTextInShape();
         // initial position
         ceHelper.checkHTMLContent('');
         ceHelper.checkCaretPosition(0);
@@ -88,7 +87,7 @@ describe(['taga11yenabled'], 'Editable area - Basic typing and caret moving', fu
     it.skip('Editing bottom text shape', function () {
         // select shape and activate editing
         selectTextShape(2);
-        impressHelper.selectTextOfShape(false);
+        impressHelper.editTextInShape();
         // initial position
         ceHelper.checkHTMLContent('');
         ceHelper.checkCaretPosition(0);
@@ -99,7 +98,7 @@ describe(['taga11yenabled'], 'Editable area - Basic typing and caret moving', fu
         impressHelper.removeShapeSelection();
         // activate editing again
         selectTextShape(2);
-        impressHelper.selectTextOfShape(false);
+        impressHelper.editTextInShape();
         ceHelper.checkPlainContent('Hello World');
         ceHelper.moveCaret('end');
         ceHelper.checkCaretPosition(11);
@@ -110,7 +109,7 @@ describe(['taga11yenabled'], 'Editable area - Basic typing and caret moving', fu
         impressHelper.removeShapeSelection();
         // activate editing again
         selectTextShape(2);
-        impressHelper.selectTextOfShape(false);
+        impressHelper.editTextInShape();
         // navigating between paragraphs
         ceHelper.checkPlainContent('Green red');
         ceHelper.moveCaret('up');
@@ -121,7 +120,7 @@ describe(['taga11yenabled'], 'Editable area - Basic typing and caret moving', fu
     it.skip('Editing both text shapes', function () {
         // select top shape and activate editing
         selectTextShape(1);
-        impressHelper.selectTextOfShape(false);
+        impressHelper.editTextInShape();
         // initial position
         ceHelper.checkHTMLContent('');
         ceHelper.checkCaretPosition(0);
@@ -132,7 +131,7 @@ describe(['taga11yenabled'], 'Editable area - Basic typing and caret moving', fu
         // select bottom shape and activate editing
         selectTextShape(2);
         ceHelper.checkHTMLContent('');
-        impressHelper.selectTextOfShape(false);
+        impressHelper.editTextInShape();
         // typing
         ceHelper.checkHTMLContent('');
         ceHelper.checkCaretPosition(0);
@@ -142,7 +141,7 @@ describe(['taga11yenabled'], 'Editable area - Basic typing and caret moving', fu
         // select top shape and activate editing
         selectTextShape(1);
         ceHelper.checkHTMLContent('');
-        impressHelper.selectTextOfShape(false);
+        impressHelper.editTextInShape();
         ceHelper.checkPlainContent('Hello World');
         ceHelper.moveCaret('end');
         ceHelper.type(' Yellow');
@@ -150,7 +149,7 @@ describe(['taga11yenabled'], 'Editable area - Basic typing and caret moving', fu
         // select bottom shape and activate editing
         selectTextShape(2);
         ceHelper.checkHTMLContent('');
-        impressHelper.selectTextOfShape(false);
+        impressHelper.editTextInShape();
         ceHelper.checkPlainContent('Green red');
         // remove shape selection
         impressHelper.removeShapeSelection();

--- a/cypress_test/integration_tests/desktop/impress/undo_redo_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/undo_redo_spec.js
@@ -12,7 +12,7 @@ describe(['tagdesktop'], 'Editing Operations', function() {
 		desktopHelper.switchUIToCompact();
 		desktopHelper.selectZoomLevel('30');
 		impressHelper.selectTextShapeInTheCenter();
-		impressHelper.selectTextOfShape(false);
+		impressHelper.editTextInShape();
 	});
 
 	function undo() {


### PR DESCRIPTION
Most users of selectTextOfShape also need to select all text. Sometimes the cursor appears but does not allow CTRL+a to select all text. Work around this by including the selection in the retry using waitUntil.

Fixes mobile/impress/apply_paragraph_props_text_spec.js, which started failing sporadically after commit e0a0646ce15c8390f6a1f9b159cdafac63ceee93.

I also adjusted the dblclick selector because it was finding multiple elements but I think that is unrelated

Change-Id: Icdfa731ba9a5f8d08a858192a4f1f5bc79b09b76


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

