### PR TITLE
Cypress: Fix mobile/impress/apply_font_text_spec.js

### DIFF
--- a/cypress_test/integration_tests/mobile/impress/apply_font_text_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/apply_font_text_spec.js
@@ -139,12 +139,18 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Apply font on selected text
 		cy.cGet('#CharBackColor .color-sample-selected')
 			.should('have.attr', 'style', 'background-color: rgb(204, 0, 0);');
 
+		helper.setDummyClipboardForCopy();
+
 		triggerNewSVG();
 
 		// TODO: highlight color is not in the SVG
 		// At least check the mobile wizard's state
 		impressHelper.selectTextOfShape();
 
+		// Wait for selection before opening mobile wizard
+		helper.copy();
+		helper.expectTextForClipboard('X');
+		cy.wait(200);
 		mobileHelper.openTextPropertiesPanel();
 
 		cy.cGet('#CharBackColor .color-sample-selected')


### PR DESCRIPTION
Failed because mobile wizard opened too soon.
Fix: Wait for selection before opening mobile wizard.


Change-Id: Ie29e3f5be17bafa2dd09b3f8f5b6415104456cb7


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

