### PR TITLE
wsd: test: give up attempting to connect if the test finished

### DIFF
--- a/test/helpers.hpp
+++ b/test/helpers.hpp
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "Unit.hpp"
 #include <test/lokassert.hpp>
 #include <test/testlog.hpp>
 
@@ -569,6 +570,12 @@ connectLOKit(const std::shared_ptr<SocketPoll>& socketPoll, const Poco::URI& uri
             if (SigUtil::getShutdownRequestFlag())
             {
                 TST_LOG("Shutdown requested, giving up connectLOKit");
+                break;
+            }
+
+            if (UnitBase::get().isFinished())
+            {
+                TST_LOG("The test has finished, giving up connectLOKit");
                 break;
             }
 


### PR DESCRIPTION
Some tests are designed to exercise the reconnection
logic. Once the test validates that the correct
reconnection logic is used, the test is considered
finished. In those cases, we need to break the
test framework's retry logic.

Change-Id: Ie0bb5dcc430a954910c2af4817a500f5b576bd4c
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
