### PR TITLE
fix: zotero options not visible when viewId is zero

### DIFF
--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -956,7 +956,7 @@ L.Control.UIManager = L.Control.extend({
 	},
 
 	onUpdateViews: function () {
-		if (!this.map._docLayer || !this.map._docLayer._viewId)
+		if (!this.map._docLayer || typeof this.map._docLayer._viewId === 'undefined')
 			return;
 
 		var myViewId = this.map._docLayer._viewId;


### PR DESCRIPTION
- regression from 9202365fc6dac4ab964c12a1b0858644435e1191

Change-Id: I4554a5fcc9b0c5dce48c8b35ea32142ff1c323f3

