### PR TITLE
Tokenize Quotes

### DIFF
--- a/common/StringVector.hpp
+++ b/common/StringVector.hpp
@@ -79,6 +79,52 @@ public:
             tokens.emplace_back(start - data, end - start);
     }
 
+    // Tokenize delimited values outside of quotes until we hit new-line or the end.
+    static void tokenize_outside_quotes(const char* data, const std::size_t size,
+                                        const char delimiter, std::vector<StringToken>& tokens)
+    {
+        if (size == 0 || data == nullptr || *data == '\0')
+            return;
+
+        // if delimiter is a quote default back to standard tokenize
+        if (delimiter == '\'' || delimiter == '"')
+        {
+            tokenize(data, size, delimiter, tokens);
+            return;
+        }
+
+        tokens.reserve(16);
+
+        const char* start = data;
+        const char* end = data;
+        char quote = '\0';
+
+        for (std::size_t i = 0; i < size && data[i] != '\n'; ++i, ++end)
+        {
+            if ((data[i] == '\'' || data[i] == '"') &&
+                (i == 0 || data[i - 1] != '\\')) // check for escaped quote
+            {
+                if (quote == '\0')
+                    quote = data[i];
+                else if (quote == data[i])
+                    quote = '\0';
+            }
+            if (quote == '\0' && data[i] == delimiter)
+            {
+                if (start != end && *start != delimiter)
+                    tokens.emplace_back(start - data, end - start);
+
+                start = end;
+            }
+            else if (*start == delimiter)
+                ++start;
+        }
+
+        if (start != end && *start != delimiter &&
+            *start != '\n') // tokenizes the end of the string
+            tokens.emplace_back(start - data, end - start);
+    }
+
     // call func on each token until func returns true or we run out of tokens
     template <class UnaryFunction>
     static void tokenize_foreach(UnaryFunction&& func, const char* data, const std::size_t size, const char delimiter = ' ')
@@ -133,6 +179,29 @@ public:
         return StringVector(s, std::move(tokens));
     }
 
+    /// Tokenize single-char delimited values outside of quotes until we hit new-line or the end.
+    static StringVector tokenize_outside_quotes(const char* data, const std::size_t size,
+                                                const char delimiter = ' ')
+    {
+        if (size == 0 || data == nullptr || *data == '\0')
+            return StringVector();
+
+        std::vector<StringToken> tokens;
+        tokenize_outside_quotes(data, size, delimiter, tokens);
+        return StringVector(std::string(data, size), std::move(tokens));
+    }
+
+    /// Tokenize single-char delimited values outside of quotes until we hit new-line or the end.
+    static StringVector tokenize_outside_quotes(const std::string& s, const char delimiter = ' ')
+    {
+        if (s.empty())
+            return StringVector();
+
+        std::vector<StringToken> tokens;
+        tokenize_outside_quotes(s.data(), s.size(), delimiter, tokens);
+        return StringVector(s, std::move(tokens));
+    }
+
     /// Tokenize by the delimiter string.
     static StringVector tokenize(const std::string& s, const char* delimiter, int len = -1)
     {
@@ -170,6 +239,61 @@ public:
     static StringVector tokenize(const std::string& s, const std::string& delimiter)
     {
         return tokenize(s, delimiter.data(), delimiter.size());
+    }
+
+    // Tokenize by the delimiter string outside of quotes
+    static StringVector tokenize_outside_quotes(const std::string& s, const char* delimiter,
+                                                int len = -1)
+    {
+        if (s.empty() || len == 0 || delimiter == nullptr || *delimiter == '\0')
+            return StringVector();
+
+        if (len < 0)
+            len = std::strlen(delimiter);
+
+        // if delimiter contains a quote default back to normal tokenize
+        if (strchr(delimiter, '\'') != nullptr || strchr(delimiter, '"') != nullptr)
+        {
+            return tokenize(s, delimiter, len);
+        }
+
+        std::size_t start = 0;
+        char quote = '\0';
+
+        std::vector<StringToken> tokens;
+        tokens.reserve(16);
+
+        for (std::size_t i = 0; i < s.length(); ++i)
+        {
+            if ((s[i] == '\'' || s[i] == '"') &&
+                (i == 0 || s[i - 1] != '\\')) // check for escaped quote
+            {
+                if (quote == '\0')
+                    quote = s[i];
+                else if (quote == s[i])
+                    quote = '\0';
+            }
+            if (quote == '\0' && s.substr(i, len) == delimiter)
+            {
+                tokens.emplace_back(start, i - start);
+                start = i + len;
+            }
+        }
+        if (start < s.length())
+            tokens.emplace_back(start, s.length() - start);
+
+        return StringVector(s, std::move(tokens));
+    }
+
+    template <std::size_t N>
+    static StringVector tokenize_outside_quotes(const std::string& s, const char (&delimiter)[N])
+    {
+        return tokenize_outside_quotes(s, delimiter, N - 1);
+    }
+
+    static StringVector tokenize_outside_quotes(const std::string& s, const std::string& delimiter)
+    {
+        return tokenize_outside_quotes(s, delimiter.data(), delimiter.size());
     }
 
     /** Tokenize based on any of the characters in 'delimiters'.

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -192,7 +192,8 @@ bool ChildSession::_handleInput(const char *buffer, int length)
 {
     LOG_TRC("handling [" << getAbbreviatedMessage(buffer, length) << ']');
     const std::string firstLine = getFirstLine(buffer, length);
-    const StringVector tokens = StringVector::tokenize(firstLine.data(), firstLine.size());
+    const StringVector tokens =
+        StringVector::tokenize_outside_quotes(firstLine.data(), firstLine.size());
 
     // if _clientVisibleArea.getWidth() == 0, then it is probably not a real user.. probably is a convert-to or similar
     LogUiCommands logUndoRelatedcommandAtfunctionEnd(this, &tokens);

--- a/test/StringVectorTests.cpp
+++ b/test/StringVectorTests.cpp
@@ -94,8 +94,38 @@ void StringVectorTests::testTokenizer()
     LOK_ASSERT_EQUAL(std::string("tileheight=3840"), tokens[8]);
     LOK_ASSERT_EQUAL(std::string("ver=-1"), tokens[9]);
 
+    // tokenize_outside_quotes
+    tokens = StringVector::tokenize_outside_quotes(std::string("A='X Y'"));
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(1), tokens.size());
+    LOK_ASSERT_EQUAL(std::string("A='X Y'"), tokens[0]);
+
+    tokens = StringVector::tokenize_outside_quotes(std::string("A=\"X Y\""));
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(1), tokens.size());
+    LOK_ASSERT_EQUAL(std::string("A=\"X Y\""), tokens[0]);
+
+    tokens = StringVector::tokenize_outside_quotes(std::string(" A=\"X Y\" B=\"Z\" C "));
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(3), tokens.size());
+    LOK_ASSERT_EQUAL(std::string("A=\"X Y\""), tokens[0]);
+    LOK_ASSERT_EQUAL(std::string("B=\"Z\""), tokens[1]);
+    LOK_ASSERT_EQUAL(std::string("C"), tokens[2]);
+
+    tokens =
+        StringVector::tokenize_outside_quotes(std::string("\"don't tokenize this\" tokenize this"));
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(3), tokens.size());
+    LOK_ASSERT_EQUAL(std::string("\"don't tokenize this\""), tokens[0]);
+    LOK_ASSERT_EQUAL(std::string("tokenize"), tokens[1]);
+    LOK_ASSERT_EQUAL(std::string("this"), tokens[2]);
+
+    tokens = StringVector::tokenize_outside_quotes(std::string("apost\\'phe don\\'t"));
+    LOK_ASSERT_EQUAL(std::string("apost\\'phe"), tokens[0]);
+    LOK_ASSERT_EQUAL(std::string("don\\'t"), tokens[1]);
+
     // With custom delimiters
     tokens = StringVector::tokenize(std::string("ABC:DEF"), ':');
+    LOK_ASSERT_EQUAL(std::string("ABC"), tokens[0]);
+    LOK_ASSERT_EQUAL(std::string("DEF"), tokens[1]);
+
+    tokens = StringVector::tokenize_outside_quotes(std::string("ABC'DEF"), '\'');
     LOK_ASSERT_EQUAL(std::string("ABC"), tokens[0]);
     LOK_ASSERT_EQUAL(std::string("DEF"), tokens[1]);
 
@@ -119,6 +149,31 @@ void StringVectorTests::testTokenizer()
     tokens = StringVector::tokenize(URI, '/');
     LOK_ASSERT_EQUAL(static_cast<std::size_t>(7), tokens.size());
     LOK_ASSERT_EQUAL(std::string("31"), tokens[6]);
+
+    // tokenize_outside_quotes with string delimiters
+    tokens = StringVector::tokenize_outside_quotes(std::string("ABC<delim>DEF"), "<delim>");
+    LOK_ASSERT_EQUAL(std::string("ABC"), tokens[0]);
+    LOK_ASSERT_EQUAL(std::string("DEF"), tokens[1]);
+
+    tokens =
+        StringVector::tokenize_outside_quotes(std::string("ABC\"<delim>\"DE<delim>F"), "<delim>");
+    LOK_ASSERT_EQUAL(std::string("ABC\"<delim>\"DE"), tokens[0]);
+    LOK_ASSERT_EQUAL(std::string("F"), tokens[1]);
+
+    tokens = StringVector::tokenize_outside_quotes(std::string("ABC'F"), "<delim>");
+    LOK_ASSERT_EQUAL(std::string("ABC'F"), tokens[0]);
+
+    tokens = StringVector::tokenize_outside_quotes(std::string("\"'<delim>'\""), "<delim>");
+    LOK_ASSERT_EQUAL(std::string("\"'<delim>'\""), tokens[0]);
+
+    tokens = StringVector::tokenize_outside_quotes(std::string("\"\"<delim>\"\"A"), "<delim>");
+    LOK_ASSERT_EQUAL(std::string("\"\""), tokens[0]);
+    LOK_ASSERT_EQUAL(std::string("\"\"A"), tokens[1]);
+
+    tokens =
+        StringVector::tokenize_outside_quotes(std::string("apost\\'phe<delim>don\\'t"), "<delim>");
+    LOK_ASSERT_EQUAL(std::string("apost\\'phe"), tokens[0]);
+    LOK_ASSERT_EQUAL(std::string("don\\'t"), tokens[1]);
 }
 
 void StringVectorTests::testTokenizerTokenizeAnyOf()


### PR DESCRIPTION
* Resolves: #8103
* Target version: master 

### Summary

When ignoreQuotes = false delimiters within quotes (' or ") aren't tokenised.
Causes problems especially as space is the default delimiter, so if the input string has any `key="string"` pattern tokens a space will cause issues

For #8103 
Unocommand was being incorrectly tokenized as space is the default delimiter:

`uno .uno:ExecuteSearch {"SearchItem.SearchString":{"type":"string","value":" "}, ...`
`                                                                           ^^^`


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

