### PR TITLE
Custom properties dialog: fix grid and misalignments

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -2054,36 +2054,24 @@ kbd,
 }
 
 /* DocumentPropertiesDialog Custom props */
-#DocumentPropertiesDialog #customprops .jsdialog .ui-grid .menubutton {
+#DocumentPropertiesDialog #headerbox,
+#DocumentPropertiesDialog #properties > .jsdialog.ui-grid {
+	grid-template-columns: 128px 128px auto 26px !important;
+	align-items: center;
+	margin-block-start: 4px;
+}
+
+#DocumentPropertiesDialog #properties > .jsdialog.ui-grid > .ui-grid-cell > .ui-grid-cell {
+	align-items: center;
+	grid-column-gap: 4px;
+}
+
+#DocumentPropertiesDialog #customprops button {
 	line-height: 16px;
-}
-
-#DocumentPropertiesDialog #customprops div.jsdialog.ui-grid-cell,
-#DocumentPropertiesDialog #customprops .spinfieldcontainer,
-#DocumentPropertiesDialog #customprops input.ui-timefield {
-	margin-top: auto;
-	margin-bottom: auto;
-}
-
-#DocumentPropertiesDialog #customprops #properties > .ui-grid {
-	display: flex;
-}
-
-#DocumentPropertiesDialog #customprops #properties > .ui-grid > div:nth-child(1) {
-	width: 150px;
-}
-
-#DocumentPropertiesDialog #customprops #properties > .ui-grid > div:nth-child(2) {
-	width: 100px;
-}
-
-#DocumentPropertiesDialog #customprops #properties > .ui-grid > div:nth-child(3) {
 	width: 100%;
+	margin: 0;
 }
 
-#DocumentPropertiesDialog #customprops #properties > .ui-grid > div:nth-child(4) {
-	width: 45px;
-}
 #DocumentPropertiesDialog #customprops .jsdialog.ui-scrollwindow {
 	max-height: min-content;
 }


### PR DESCRIPTION
- Fix alignment between rows by:
  - Setting some of the columns' width
  - Removing margin from all buttons & set width. Add column gap
- Fix vertical alignment
- Fix header alignment (Name, Type, Value) so it aligns to the content
- Make "Add property" occupy full width (ideally this button would be
  part of the inner grid "last row" but for now this is already an
  improvement)
- Remove lengthly css targets and the use of nth-child

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I85d9bdbcc365c735757ee086f6e4912d694a011c
