### PR TITLE
[Backport] Fix unobutton's lack of pointer cursor

### DIFF
--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -231,6 +231,7 @@ button.ui-tab.notebookbar {
 }
 
 .unotoolbutton.notebookbar .unobutton {
+	cursor: pointer;
 	box-sizing: border-box;
 	padding: 0;
 	width: var(--btn-size);


### PR DESCRIPTION
Before this commit buttons such as bold (in the notebookbar) or
sidebar button (in the top toolbar) would not change the cursor on hover

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ief075b4f4d187f6a5d87458d02077c0deaf69fe6
