### PR TITLE
fix(browser): Emit proper UI_PickLink post message

### DIFF
--- a/browser/src/docdispatcher.ts
+++ b/browser/src/docdispatcher.ts
@@ -45,7 +45,7 @@ class Dispatcher {
 		};
 
 		this.actionsMap['remotelink'] = function () {
-			app.map.fire('postMessage', { msgId: 'UI UI_PickLink' });
+			app.map.fire('postMessage', { msgId: 'UI_PickLink' });
 		};
 		// TODO: deduplicate
 		this.actionsMap['hyperlinkdialog'] = function () {


### PR DESCRIPTION
Signed-off-by: Julius Härtl <jus@bitgrid.net>
Change-Id: I635780723b98887e6c35a397940cc2517a6a9025
### Summary

Fixes a regression in 24.04 where the link picker button emitted a post message `UI UI_PickLink` instead of the documented and previously used `UI_PickLink`

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

