### PR TITLE
css: fix button-box alignment (backport)

### DIFF
--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -82,12 +82,14 @@ button.jsdialog img {
 }
 
 .jsdialog.ui-button-box-right {
+	grid-column: 2;
 	display: flex;
 	justify-self: end;
 	margin-inline-end: -5px;
 }
 
 .jsdialog.ui-button-box-left {
+	grid-column: 1;
 	display: flex;
 	justify-self: start;
 	margin-inline-start: -5px;


### PR DESCRIPTION
in 24.04 more elements are grid now, it seems to be a regression in button box:
1. enable macro execution in coolwsd.xml
2. open spreadsheet with macro Result: you see the dialog with buttons in 2 rows
Expected: all buttons are in the same row

it seems to be missing grid placement for left and right sections

before:
![button-box-2404](https://github.com/CollaboraOnline/online/assets/5307369/6abfc630-b7de-4db9-bda5-4623f9cfdc80)
