### PR TITLE
iOS: update Info.plist -> master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,6 @@ Makecache
 
 # autoconf stuff
 autogen.input
+
+# MacOS file manager metadata
+.DS_Store

--- a/ios/Mobile/Info.plist.in
+++ b/ios/Mobile/Info.plist.in
@@ -260,6 +260,12 @@
 	<string>$(PRODUCT_NAME) requires access to the camera in order for you to be able to take photos to be inserted while editing a document.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>$(PRODUCT_NAME) requires access to the photo library in order for you to be able to insert images into documents.</string>
+	<key>NSPrivacyAccessedAPITypeReasons</key>
+	<array>
+		<string>AC6B.1</string><!-- Allow reading com.apple.configuration.managed preferences (to use username if it is set in a profile) -->
+		<string>35F9.1</string><!-- Allow reading boot time to use timers -->
+		<string>3B52.1</string><!-- Allow reading file metadata when the user opens a file in Collabora Mobile -->
+	</array>
 	<key>UIAppFonts</key>
 	<array>
 		<string>share/fonts/truetype/Alef-Bold.ttf</string>

--- a/ios/Mobile/Info.plist.in
+++ b/ios/Mobile/Info.plist.in
@@ -24,7 +24,7 @@
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
 			<key>LSHandlerRank</key>
-			<string>Owner</string>
+			<string>Default</string>
 			<key>LSItemContentTypes</key>
 			<array>
 				<string>org.oasis-open.opendocument.text</string>
@@ -36,7 +36,7 @@
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
 			<key>LSHandlerRank</key>
-			<string>Default</string>
+			<string>Owner</string>
 			<key>LSItemContentTypes</key>
 			<array>
 				<string>com.collabora.office.uti.fodt</string>
@@ -93,7 +93,7 @@
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
 			<key>LSHandlerRank</key>
-			<string>Owner</string>
+			<string>Default</string>
 			<key>LSItemContentTypes</key>
 			<array>
 				<string>org.oasis-open.opendocument.spreadsheet</string>
@@ -134,7 +134,7 @@
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
 			<key>LSHandlerRank</key>
-			<string>Owner</string>
+			<string>Default</string>
 			<key>LSItemContentTypes</key>
 			<array>
 				<string>org.oasis-open.opendocument.presentation</string>
@@ -189,7 +189,7 @@
 			<key>CFBundleTypeName</key>
 			<string>PDF Document</string>
 			<key>CFBundleTypeRole</key>
-			<string>Editor</string>
+			<string>Viewer</string>
 			<key>LSHandlerRank</key>
 			<string>Alternate</string>
 			<key>LSItemContentTypes</key>

--- a/ios/Mobile/Info.plist.in
+++ b/ios/Mobile/Info.plist.in
@@ -266,6 +266,18 @@
 		<string>35F9.1</string><!-- Allow reading boot time to use timers -->
 		<string>3B52.1</string><!-- Allow reading file metadata when the user opens a file in Collabora Mobile -->
 	</array>
+	<key>NSUbiquitousContainers</key>
+	<dict>
+		<key>iCloud.com.collabora.office.Mobile</key>
+		<dict>
+			<key>NSUbiquitousContainerIsDocumentScopePublic</key>
+			<true/>
+			<key>NSUbiquitousContainerSupportedFolderLevels</key>
+			<string>Any</string>
+			<key>NSUbiquitousContainerName</key>
+			<string>@APP_NAME@</string>
+		</dict>
+	</dict>
 	<key>UIAppFonts</key>
 	<array>
 		<string>share/fonts/truetype/Alef-Bold.ttf</string>


### PR DESCRIPTION
There are various settings in Info.plist (generated from Info.plist.in at configure time) which are incorrect. Particularly important are the API and encryption declarations (which will be required to upload builds from tomorrow), and making the Collabora Office folder visible in iCloud (which stops files created from the recents tab being hidden)

This is a forward-port of #8933 

Signed-off-by: Skyler <skyler.grey@collabora.com>

