### PR TITLE
Hide outline format button for mobile

### DIFF
--- a/browser/src/control/Control.MobileWizardBuilder.js
+++ b/browser/src/control/Control.MobileWizardBuilder.js
@@ -49,6 +49,7 @@ L.Control.MobileWizardBuilder = L.Control.JSDialogBuilder.extend({
 		this._toolitemHandlers['.uno:StyleUpdateByExampleimg'] = function () { return false; };
 		this._toolitemHandlers['.uno:StyleNewByExampleimg'] = function () { return false; };
 		this._toolitemHandlers['.uno:LineEndStyle'] = function () { return false; };
+		this._toolitemHandlers['.uno:SetOutline'] = function () { return false; };
 
 		this._toolitemHandlers['.uno:FontworkShapeType'] = this._fontworkShapeControl;
 		this._toolitemHandlers['SelectWidth'] = this._lineWidthControl;


### PR DESCRIPTION
- Hide `Set outline format` uno button
- we will add this option again after fixing the dialog issue on mobile view for Outline option in `Bullets and numbering`
Signed-off-by: Darshan-upadhyay1110 <darshan.upadhyay@collabora.com>
Change-Id: I270b78b7b9f00fd7b0f12c348794e3d3da3e653e (cherry picked from commit 4690d8ec28d62704f36d3d69217e37361fd4b5f7)

* Target version: 23.05 

### Checklist

- [X] Code is properly formatted
- [X] All commits have Change-Id
- [ ] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

