### PR TITLE
Fix mobile/writer/table_properties_spec.js

### DIFF
--- a/cypress_test/integration_tests/mobile/writer/table_properties_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/table_properties_spec.js
@@ -25,6 +25,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Change table properties / l
 
 	function selectFullTable() {
 		cy.cGet('.unoSelectTable').click();
+		cy.cGet('#split_merge .unoMergeCells').should('not.have.attr', 'disabled');
 		helper.copy();
 		cy.cGet('#copy-paste-container table').should('exist');
 	}


### PR DESCRIPTION
Wait for table select to fix copy/paste issue

Fixes copy/paste failure:
```
      cy:command ✔  cGet	.unoSelectTable
      cy:command ✔  click	
      cy:command ✔  window	
      cy:command ✔  cGet	#copy-paste-container table
      cy:command ✘  assert	expected **#copy-paste-container table** to exist in the DOM
                    Actual: 	"#copy-paste-container table"
                    Expected: 	"#copy-paste-container table"
      cy:command ✔  fail:	
                    Test failed: integration_tests/mobile/writer/table_properties_spec.js / Change table properties / layout via mobile wizard. / Distribute columns.
                    
                    Timed out retrying after 10000ms: Expected to find element: `#copy-paste-container table`, but never found it.
```

Test was failing because the copy/paste warning screen was being shown (_warnCopyPaste in Clipboard.js)
![image](https://github.com/CollaboraOnline/online/assets/153108452/e52cf2f3-9eac-489d-86a6-ec89b5e01429)

Not sure if this is the root cause of the failure but it does reliably resolve the issue.

Change-Id: I5d564c062f5c8f5616997cd49222d39f47baa260
