### PR TITLE
_sessionUserInfo tracks disconnected sessions

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1985,6 +1985,8 @@ bool Document::forwardToChild(const std::string& prefix, const std::vector<char>
 
                 _deltaGen->setSessionCount(count);
 
+                _sessionUserInfo[session->getViewId()].setDisconnected();
+
                 // No longer needed, and allow session dtor to take it.
                 session.reset();
                 return true;
@@ -2349,7 +2351,8 @@ void Document::dumpState(std::ostream& oss)
             << " userId: " << it.second.getUserId()
             << " userName: " << it.second.getUserName()
             << " userExtraInfo: " << it.second.getUserExtraInfo()
-            << " readOnly: " << it.second.isReadOnly();
+            << " readOnly: " << it.second.isReadOnly()
+            << " connected: " << it.second.isConnected();
     }
     oss << "\n";
 

--- a/kit/Kit.hpp
+++ b/kit/Kit.hpp
@@ -86,6 +86,7 @@ struct UserInfo
         , _userExtraInfo(userExtraInfo)
         , _userPrivateInfo(userPrivateInfo)
         , _readOnly(readOnly)
+        , _connected(true)
     {
     }
 
@@ -99,12 +100,17 @@ struct UserInfo
 
     bool isReadOnly() const { return _readOnly; }
 
+    bool isConnected() const { return _connected; }
+
+    void setDisconnected() { _connected = false; }
+
 private:
     std::string _userId;
     std::string _userName;
     std::string _userExtraInfo;
     std::string _userPrivateInfo;
     bool _readOnly;
+    bool _connected;
 };
 
 /// We have two types of password protected documents


### PR DESCRIPTION
as well as current ones.

i.e.

/// User Info container used to store user information /// till the end of process lifecycle - including
/// after any child session goes away

so add some info in the log to flag which ones are still connected and which ones are not.

https: //github.com/CollaboraOnline/online/issues/8943

Change-Id: I5350c04d1a7bb8095464881fba97e5910f71ffb3


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

