### PR TITLE
calc: Properly handle the disable state

### DIFF
--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -841,10 +841,14 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 			this.insertMode = e.state.trim() === '' ? false: true;
 		}
 		else if (e.commandName === '.uno:ToggleSheetGrid') {
-			let newState = e.state.trim() === 'true';
-			if (this._sheetGrid != newState) {
-				this._sheetGrid = newState;
-				this._painter._sectionContainer.requestReDraw();
+			let trimmedState = e.state.trim();
+			// Disabled mean we don't change the sheet grid state.
+			if (trimmedState != 'disabled') {
+				let newState = trimmedState === 'true';
+				if (this._sheetGrid != newState) {
+					this._sheetGrid = newState;
+					this._painter._sectionContainer.requestReDraw();
+				}
 			}
 		}
 	},


### PR DESCRIPTION
Doesn't hide the grid when the Function wizard is open anymore when disabling the ToggleSheetGrid button.

This is a follow up for issue #8066.

Requires https://gerrit.libreoffice.org/c/core/+/167370
**But this should land first.**

Change-Id: I79ba99716eb1103e7239fe5cc302c64827c9ef53


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

