### PR TITLE
Fix strange looking UI separator in impress

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -223,6 +223,7 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 	background-color: transparent;
 }
 .jsdialog.ui-separator.vertical {
+	width: 0px;
 	margin: 5px 0px;
 	padding-right: 1px;
 	background-color: var(--color-background-darker);


### PR DESCRIPTION
- After run presentation button in Slide pane, we can see a strange thick element
- this is vertical separator, and it should have width 0px
- this patch will fix that

Before
![image](https://github.com/CollaboraOnline/online/assets/61383886/7982f994-91c8-433c-841c-b31034907361)


After:
![image](https://github.com/CollaboraOnline/online/assets/61383886/fcea9bc0-7198-4eea-8ae1-8dfebb4fb4ee)

Signed-off-by: Darshan-upadhyay1110 <darshan.upadhyay@collabora.com>
Change-Id: I30a4506d331431359f9bdb80519dc0e773793929


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

