### PR TITLE
Slide sorter: presentation toolbar: Remove ui break

### DIFF
--- a/browser/src/control/Control.PresentationBar.js
+++ b/browser/src/control/Control.PresentationBar.js
@@ -55,11 +55,6 @@ class PresentationBar {
 						command: 'presentation'
 					},
 					{
-						id: 'presentationbreak',
-						type: 'separator',
-						orientation: 'vertical',
-					},
-					{
 						id: 'insertpage',
 						type: 'customtoolitem',
 						text: this._getItemUnoName('insertpage'),
@@ -100,7 +95,6 @@ class PresentationBar {
 
 		if (this.map.getDocType() === 'drawing') {
 			this.showItem('presentation', false);
-			this.showItem('presentationbreak', false);
 		}
 	}
 
@@ -144,14 +138,12 @@ class PresentationBar {
 	onWopiProps(e) {
 		if (e.HideExportOption) {
 			this.showItem('presentation', false);
-			this.showItem('presentationbreak', false);
 		}
 	}
 
 	onDocLayerInit() {
 		if (!this.map['wopi'].HideExportOption && this.map.getDocType() !== 'drawing') {
 			this.showItem('presentation', true);
-			this.showItem('presentationbreak', true);
 		}
 
 		if (!window.mode.isMobile())


### PR DESCRIPTION
There is no need to add a visual break/divider between "Fullscreen presentation" and the "Insert Slide" buttons:
1. They are visually very well distinctive so there seems to be not a need for a division
2. There is not so much white space so the more we can reduce visually the better


Change-Id: I27b84782e5af987d9aec3734f7557c746a03667c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

