### PR TITLE
Revert "Default to four pre-spawned children."

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -427,10 +427,6 @@ experimental_msg="disabled by default"
 bundle_msg="using uglified bundled JS and CSS"
 LOK_LOG_ASSERTIONS=0
 log_asserts_msg="disabled"
-
-# a reasonable default
-NUM_PRESPAWN_CHILDREN=4
-
 AC_MSG_CHECKING([whether to enable debug build])
 if test "$enable_debug" = "yes"; then
    AC_MSG_RESULT([yes])
@@ -444,9 +440,6 @@ if test "$enable_debug" = "yes"; then
    COOLWSD_ANONYMIZE_USER_DATA=false
    BROWSER_LOGGING="true"
    debug_msg="low security debugging mode"
-
-   # helps attaching to the right process
-   NUM_PRESPAWN_CHILDREN=1
 
    AC_MSG_CHECKING([whether to bundle JS and CSS files])
    if test "$enable_bundle" != "yes"; then
@@ -474,7 +467,6 @@ AC_SUBST(ENABLE_BUNDLE)
 AC_SUBST(COOLWSD_LOGLEVEL)
 AC_SUBST(COOLWSD_LOG_TO_FILE)
 AC_SUBST(BROWSER_LOGGING)
-AC_SUBST(NUM_PRESPAWN_CHILDREN)
 
 if test "$enable_debug_protocol" = no; then
    ENABLE_DEBUG_PROTOCOL=false

--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -44,7 +44,7 @@
     <experimental_features desc="Enable/Disable experimental features" type="bool" default="@ENABLE_EXPERIMENTAL@">@ENABLE_EXPERIMENTAL@</experimental_features>
 
     <memproportion desc="The maximum percentage of available memory consumed by all of the @APP_NAME@ processes, after which we start cleaning up idle documents. If cgroup memory limits are set, this is the maximum percentage of that limit to consume." type="double" default="80.0"></memproportion>
-    <num_prespawn_children desc="Number of child processes to keep started in advance and waiting for new clients." type="uint" default="4">@NUM_PRESPAWN_CHILDREN@</num_prespawn_children>
+    <num_prespawn_children desc="Number of child processes to keep started in advance and waiting for new clients." type="uint" default="1">1</num_prespawn_children>
     <!-- <fetch_update_check desc="Every number of hours will fetch latest version data. Defaults to 10 hours." type="uint" default="10">10</fetch_update_check> -->
     <per_document desc="Document-specific settings, including LO Core settings.">
         <max_concurrency desc="The maximum number of threads to use while processing a document." type="uint" default="4">4</max_concurrency>


### PR DESCRIPTION
This reverts commit 8b558a23720e7bdbc72767c549ada0910ad73115. It seems we have some c++ unit test failures.