### PR TITLE
UI: improve combobox appearence

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -753,8 +753,6 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	-webkit-appearance: none;
 	-moz-appearance: none;
 	appearance: none;
-	min-width: 100px;
-	width: 100%;
 	height: 28px;
 	line-height: normal;
 	font-size: var(--default-font-size);
@@ -768,6 +766,8 @@ input[type='number']:hover::-webkit-outer-spin-button {
 .jsdialog-window .ui-combobox,
 .jsdialog-window .ui-timefield {
 	height: 32px;/* Use the same height as in .jsdialog.ui-edit */
+	min-width: 100px;
+	width: 100%;
 }
 
 .ui-listbox option {

--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -379,11 +379,14 @@ button.ui-tab.notebookbar {
 }
 
 #fontsizecombobox.notebookbar {
-	width: 50px !important;
+	width: 5em;
 }
 
 .notebookbar.ui-combobox * {
 	line-height: 22px;
+}
+.ui-combobox-content {
+	padding-inline: 5px;
 }
 
 /* Styles preview */


### PR DESCRIPTION
Since f7491e1f62de5401529db40b8b899e5c0563badc all combobox started having a with and min-width of 100px, this wasn't meant to be. Restrict this width setting to .jsDialog.

Add 5 px left padding to combobox, this looks better.

Set the font combobox width to 5em instead of 50px.

After:

<img src="https://github.com/CollaboraOnline/online/assets/620941/d51b2c2f-6fb3-417f-aa5b-4901a978f647.png" width=50% height=50%>

Change-Id: I0f0247471376e4633f3bbffab89285e16f78cde9


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

