### PR TITLE
try rm -f coolwsd instead of rm coolwsd

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -452,7 +452,7 @@ else
 # Use coolwsd to cleanup jails, if any. If it fails, we may have a broken/old coolwsd binary, remove it to rebuild.
 # A CI box may switch branches without cleaning up the binaries, if coolwsd from a broken branch is used here
 # it will fail all subsequent builds, until it's rebuilt from the new branch. So removing coolwsd after failing is needed.
-CLEANUP_COMMAND=if test -s ./coolwsd; then echo "Cleaning up..." && ./coolwsd --disable-cool-user-checking --cleanup --o:logging.level=trace || rm ./coolwsd; fi
+CLEANUP_COMMAND=if test -s ./coolwsd; then echo "Cleaning up..." && ./coolwsd --disable-cool-user-checking --cleanup --o:logging.level=trace || rm -f ./coolwsd; fi
 endif
 
 CLEANUP_COVERAGE=rm -rf ${abs_top_srcdir}/gcov; find . -iname "*.gc??" -delete


### PR DESCRIPTION
Making check in .
make[1]: Entering directory '/home/collabora/jenkins/workspace/github_online_master_debug_vs_co-24.04' fatal: ref HEAD is not a symbolic ref
Cleaning up...
/bin/sh: ./coolwsd: No such file or directory
rm: cannot remove './coolwsd': No such file or directory make[1]: *** [Makefile:7155: /home/collabora/jenkins/workspace/github_online_master_debug_vs_co-24.04/jails] Error 1 make[1]: *** Waiting for unfinished jobs....


Change-Id: I31748354bb55f26a8a5b8475a4daa74b3ba5d729


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

