### PR TITLE
Stop page scrolling

### DIFF
--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -1285,6 +1285,7 @@ window.app = {
 	function handleViewportChange(event) {
 		var visualViewport = event.target;
 
+		window.scroll(0, 0);
 		document.body.style.height = visualViewport.height + 'px';
 	}
 


### PR DESCRIPTION
Sometimes an input we are focusing on is considered out of the viewport by the browser. This is not always the case, and, even when it is, it's not trivial to move it back in.

Instead, this change detects scrolling and re-scrolls the view to 0, 0.

Doing so is not without consequence, as there is a slight jitter before we can scroll back, however this is substantially better than having the controls off-the-page.


Change-Id: Ie5003f9244ce1c0e8a183de5fdbcf3a880b13a13


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

