### PR TITLE
check for _docLayer existence before deref of _docLayer

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -7157,7 +7157,7 @@ L.TilesPreFetcher = L.Class.extend({
 		if (app.file.fileBasedView && this._docLayer)
 			this._docLayer._updateFileBasedView();
 
-		if (this._docLayer._emptyTilesCount > 0 || !this._map || !this._docLayer || !this._canonicalIdInitialized) {
+		if (!this._docLayer || !this._map || this._docLayer._emptyTilesCount > 0 || !this._canonicalIdInitialized) {
 			return;
 		}
 


### PR DESCRIPTION
order is since:

commit 06e4722cc93a4acdbf47700de97ea1a8e98ad6fa
Date:   Fri Aug 7 18:37:11 2020 +0530

    loleaflet: rewrite tile-prefetcher for L.CanvasTileLayer...


Change-Id: I69b7dd8974d2333cecbc38f94d4851bb0c5f44fc


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

