### PR TITLE
Fix failing test mobile/writer/table_properties_spec.js

### DIFF
--- a/cypress_test/integration_tests/mobile/writer/table_properties_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/table_properties_spec.js
@@ -199,15 +199,13 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Change table properties / l
 	it('Set minimal row height.', function() {
 		before('writer/table_with_text.odt');
 		helper.setDummyClipboardForCopy();
-		// Select full table (3x2)
-		helper.moveCursor('down', 'shift');
-		helper.moveCursor('down', 'shift');
-		helper.moveCursor('right', 'shift');
 		openTablePanel();
+		selectFullTable();
+		// Check old row height
+		cy.cGet('#copy-paste-container td').first().should('have.attr', 'height');
+
 		cy.cGet('#mobile-wizard .unoSetMinimalRowHeight').click();
-		helper.moveCursor('up', 'shift');
-		helper.moveCursor('up', 'shift');
-		helper.moveCursor('left', 'shift');
+		// Table still selected
 		helper.copy();
 		// Check new row height
 		cy.cGet('#copy-paste-container td').should('not.have.attr', 'height');


### PR DESCRIPTION
Was failing in moveCursor after slowdown introduced by https://git.libreoffice.org/core/+/ca31493a
Rewrote test to use the same select helper as all the other tests in the file


Change-Id: I5197a095d47e727526636b232df1f3be45e5bb52


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

