### PR TITLE
tile.canvas is always true after a successful _ensureContext(tile)

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -6738,6 +6738,8 @@ L.CanvasTileLayer = L.Layer.extend({
 	},
 
 	_applyDelta: function(tile, rawDelta, isKeyframe, wireMessage) {
+		// 'Uint8Array' rawDelta
+
 		if (this._debugDeltas)
 			window.app.console.log('Applying a raw ' + (isKeyframe ? 'keyframe' : 'delta') +
 					       ' of length ' + rawDelta.length +
@@ -6801,14 +6803,6 @@ L.CanvasTileLayer = L.Layer.extend({
 			tmp.set(tile.rawDeltas, 0);
 			tmp.set(rawDelta, tile.rawDeltas.byteLength);
 			tile.rawDeltas = tmp;
-		}
-
-		// 'Uint8Array' delta
-		if (!tile.canvas)
-		{
-			// defer constructing the image & applying these deltas
-			// until the tile is rendered via ensureCanvas.
-			return;
 		}
 
 		// apply potentially several deltas in turn.


### PR DESCRIPTION
_applyDelta returns early if the initial "ensureContext" of the tile fails.

i.e.

  var ctx = this._ensureContext(tile);
  if (!ctx) // out of canvas / texture memory.
    return;

and ensureContext already calls ensureCanvas, so tile.canvas is always true in the remainder of this function.

The "defer constructing the image & applying these deltas until the tile is rendered via ensureCanvas." implied a sort of deliberate optimization to wait until render time to apply the delta which doesn't actually exist.

Also move the stray "// 'Uint8Array' delta" comment back to where it originally came from as documentation of the type of the param, as in

commit 4140bf87417f4aa99780fc3d6c0438d4d469a53a
Date:   Sat Nov 6 11:11:13 2021 +0000

    Bring back the delta application JS from the 6.4 branch.

...

 _applyDelta: function(tile, delta) {
         // 'Uint8Array' delta

...


Change-Id: If15a897c3251f28639c9f1112687e543421e457d


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

