### PR TITLE
Cypress: Add cypress-terminal-report printLogsToConsole option

### DIFF
--- a/cypress_test/cypress.config.ts
+++ b/cypress_test/cypress.config.ts
@@ -19,7 +19,9 @@ export default defineConfig({
 	e2e: {
 		baseUrl: 'http://' + process.env.COOLWSD_SERVER + ':' + process.env.FREE_PORT,
 		setupNodeEvents(on, config) {
-			installLogsPrinter(on);
+			installLogsPrinter(on, {
+				printLogsToConsole: 'onFail', // 'always', 'onFail', 'never'
+			});
 			plugin(on, config);
 		},
 		specPattern: 'integration_tests/**/*_spec.js',


### PR DESCRIPTION
This is already the default behavior. Writing it here just makes it easier to change.

I cannot count the number of times I've typed the word "printLogsToConsole" to always hide or always show the logs. This is just a quality of life improvement so I don't have to type it out every time I want to change it.


Change-Id: Iebde47f5b64ae1509e7f37b884ad71fdc067b164