### PR TITLE
update impress/apply_font_shape_spec.js to pass

### DIFF
--- a/cypress_test/integration_tests/mobile/impress/apply_font_shape_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/apply_font_shape_spec.js
@@ -148,7 +148,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Apply font on selected shap
 		triggerNewSVG();
 
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextPosition')
-			.should('have.attr', 'y', '3285');
+			.should('have.attr', 'y', '3286');
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition tspan')
 			.should('have.attr', 'font-size', '368px');
 	});


### PR DESCRIPTION
probably since merge of

commit 5140abd2c94b96f2a32f0f7416ae79239a2af187
Date:   Fri May 3 14:14:26 2024 +0500

    tdf#152906: use correct Y offset

or similar of that topic

change 3285 to 3286


Change-Id: I4bd3509313c7a5801d5284eebc3882bf3550eed9


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

