### PR TITLE
MessageQueue cleanup, and avoid accidental use in tests.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -109,7 +109,6 @@ shared_sources = common/FileUtil.cpp \
                  common/StringVector.cpp \
                  common/Session.cpp \
                  common/Seccomp.cpp \
-                 common/MessageQueue.cpp \
                  common/MobileApp.cpp \
                  common/TraceEvent.cpp \
                  common/SigUtil.cpp \
@@ -121,6 +120,7 @@ shared_sources = common/FileUtil.cpp \
                  common/Authorization.cpp \
                  common/CommandControl.cpp \
                  common/Simd.cpp \
+                 kit/KitQueue.cpp \
                  net/DelaySocket.cpp \
                  net/HttpRequest.cpp \
                  net/HttpHelper.cpp \
@@ -351,7 +351,6 @@ shared_headers = common/Common.hpp \
                  common/Util.hpp \
                  common/ConfigUtil.hpp \
                  common/Authorization.hpp \
-                 common/MessageQueue.hpp \
                  common/Message.hpp \
                  common/MobileApp.hpp \
                  common/Png.hpp \
@@ -365,6 +364,7 @@ shared_headers = common/Common.hpp \
                  common/Simd.hpp \
                  common/ThreadPool.hpp \
                  common/Watchdog.hpp \
+                 kit/KitQueue.hpp \
                  net/Buffer.hpp \
                  net/DelaySocket.hpp \
                  net/FakeSocket.hpp \

--- a/android/lib/src/main/cpp/CMakeLists.txt.in
+++ b/android/lib/src/main/cpp/CMakeLists.txt.in
@@ -11,7 +11,6 @@ add_library(androidapp SHARED
             ../../../../../common/Crypto-stub.cpp
             ../../../../../common/FileUtil.cpp
             ../../../../../common/Log.cpp
-            ../../../../../common/MessageQueue.cpp
             ../../../../../common/TraceEvent.cpp
             ../../../../../common/Protocol.cpp
             ../../../../../common/Simd.cpp
@@ -25,6 +24,7 @@ add_library(androidapp SHARED
             ../../../../../kit/ChildSession.cpp
             ../../../../../kit/DeltaSimd.c
             ../../../../../kit/Kit.cpp
+            ../../../../../kit/KitQueue.cpp
             ../../../../../kit/KitWebSocket.cpp
             ../../../../../net/FakeSocket.cpp
             ../../../../../net/Socket.cpp

--- a/common/MessageQueue.hpp
+++ b/common/MessageQueue.hpp
@@ -366,4 +366,7 @@ private:
     std::vector<int> _viewOrder;
 };
 
+// Really this queue is used only in the Kit process
+typedef TileQueue KitQueue;
+
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/common/Session.hpp
+++ b/common/Session.hpp
@@ -23,7 +23,6 @@
 
 #include "Protocol.hpp"
 #include "Log.hpp"
-#include "MessageQueue.hpp"
 #include "Message.hpp"
 #include "TileCache.hpp"
 #include "WebSocketHandler.hpp"

--- a/gtk/Makefile.am
+++ b/gtk/Makefile.am
@@ -23,7 +23,6 @@ common_sources = \
                  ../common/ConfigUtil.cpp \
                  ../common/FileUtil.cpp \
                  ../common/Log.cpp \
-                 ../common/MessageQueue.cpp \
                  ../common/Protocol.cpp \
                  ../common/Session.cpp \
                  ../common/SigUtil.cpp \
@@ -36,6 +35,7 @@ common_sources = \
 
 kit_sources = ../kit/ChildSession.cpp \
               ../kit/Kit.cpp \
+              ../kit/KitQueue.cpp \
               ../kit/KitWebSocket.cpp
 
 net_sources = ../net/FakeSocket.cpp \

--- a/ios/Mobile.xcodeproj/project.pbxproj
+++ b/ios/Mobile.xcodeproj/project.pbxproj
@@ -28,7 +28,7 @@
 		BE5EB5C2213FE29900E0826C /* SpookyV2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BE5EB5BA213FE29900E0826C /* SpookyV2.cpp */; };
 		BE5EB5C3213FE29900E0826C /* Session.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BE5EB5BB213FE29900E0826C /* Session.cpp */; };
 		BE5EB5C4213FE29900E0826C /* Util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BE5EB5BC213FE29900E0826C /* Util.cpp */; };
-		BE5EB5C5213FE29900E0826C /* MessageQueue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BE5EB5BD213FE29900E0826C /* MessageQueue.cpp */; };
+		BE5EB5C5213FE29900E0826C /* KitQueue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BE5EB5BD213FE29900E0826C /* KitQueue.cpp */; };
 		BE5EB5C6213FE29900E0826C /* SigUtil.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BE5EB5BE213FE29900E0826C /* SigUtil.cpp */; };
 		BE5EB5C7213FE29900E0826C /* Protocol.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BE5EB5BF213FE29900E0826C /* Protocol.cpp */; };
 		BE5EB5C8213FE29900E0826C /* FileUtil.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BE5EB5C0213FE29900E0826C /* FileUtil.cpp */; };
@@ -558,7 +558,7 @@
 		BE58E12A217F295B00249358 /* Png.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = Png.hpp; sourceTree = "<group>"; };
 		BE58E12B217F295B00249358 /* SigUtil.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = SigUtil.hpp; sourceTree = "<group>"; };
 		BE58E12C217F295B00249358 /* Util.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = Util.hpp; sourceTree = "<group>"; };
-		BE58E12D217F295B00249358 /* MessageQueue.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = MessageQueue.hpp; sourceTree = "<group>"; };
+		BE58E12D217F295B00249358 /* KitQueue.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = KitQueue.hpp; sourceTree = "<group>"; };
 		BE58E12E217F295B00249358 /* Protocol.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = Protocol.hpp; sourceTree = "<group>"; };
 		BE58E12F217F295B00249358 /* Session.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = Session.hpp; sourceTree = "<group>"; };
 		BE58E13021874A2E00249358 /* Mobile.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Mobile.entitlements; sourceTree = "<group>"; };
@@ -577,7 +577,7 @@
 		BE5EB5BA213FE29900E0826C /* SpookyV2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SpookyV2.cpp; sourceTree = "<group>"; };
 		BE5EB5BB213FE29900E0826C /* Session.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Session.cpp; sourceTree = "<group>"; };
 		BE5EB5BC213FE29900E0826C /* Util.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Util.cpp; sourceTree = "<group>"; };
-		BE5EB5BD213FE29900E0826C /* MessageQueue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MessageQueue.cpp; sourceTree = "<group>"; };
+		BE5EB5BD213FE29900E0826C /* KitQueue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = KitQueue.cpp; sourceTree = "<group>"; };
 		BE5EB5BE213FE29900E0826C /* SigUtil.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SigUtil.cpp; sourceTree = "<group>"; };
 		BE5EB5BF213FE29900E0826C /* Protocol.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Protocol.cpp; sourceTree = "<group>"; };
 		BE5EB5C0213FE29900E0826C /* FileUtil.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FileUtil.cpp; sourceTree = "<group>"; };
@@ -2189,8 +2189,6 @@
 				BE5EB5C0213FE29900E0826C /* FileUtil.cpp */,
 				BE5EB5B9213FE29900E0826C /* Log.cpp */,
 				BE58E129217F295B00249358 /* Log.hpp */,
-				BE5EB5BD213FE29900E0826C /* MessageQueue.cpp */,
-				BE58E12D217F295B00249358 /* MessageQueue.hpp */,
 				BEDCC84C2452F82800FB02BD /* MobileApp.cpp */,
 				BEDCC84D2452F82800FB02BD /* MobileApp.hpp */,
 				BE58E12A217F295B00249358 /* Png.hpp */,
@@ -2915,6 +2913,8 @@
 				A5C2FA5C2AC1BEC500265946 /* DeltaSimd.h */,
 				BEA283572146945500848631 /* ChildSession.cpp */,
 				BEA2835521467FDD00848631 /* Kit.cpp */,
+				BE5EB5BD213FE29900E0826C /* KitQueue.cpp */,
+				BE58E12D217F295B00249358 /* KitQueue.hpp */,
 				BEA2835521467F0D00848631 /* KitWebSocket.cpp */,
 			);
 			name = kit;
@@ -3678,7 +3678,7 @@
 				BE9ADE3F265D046600BC034A /* TraceEvent.cpp in Sources */,
 				BE5EB5D0213FE2D000E0826C /* TileCache.cpp in Sources */,
 				1F957DC22BA8229A006C9E78 /* Util-mobile.cpp in Sources */,
-				BE5EB5C5213FE29900E0826C /* MessageQueue.cpp in Sources */,
+				BE5EB5C5213FE29900E0826C /* KitQueue.cpp in Sources */,
 				BE7228E22417BC9F000ADABD /* StringVector.cpp in Sources */,
 				BE55E0EB2653FCCB007DDF29 /* ConfigUtil.cpp in Sources */,
 				BE55E0EB3653FCCB007DDF29 /* Crypto-stub.cpp in Sources */,

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -697,7 +697,7 @@ Document::Document(const std::shared_ptr<lok::Office>& loKit,
       _docId(docId),
       _url(url),
       _obfuscatedFileId(Util::getFilenameFromURL(docKey)),
-      _tileQueue(std::make_shared<TileQueue>()),
+      _queue(std::make_shared<KitQueue>()),
       _websocketHandler(websocketHandler),
       _modified(ModifiedState::UnModified),
       _isBgSaveProcess(false),
@@ -1082,8 +1082,8 @@ void Document::trimAfterInactivity()
     assert(descriptor && "Null callback data.");
     assert(descriptor->getDoc() && "Null Document instance.");
 
-    std::shared_ptr<TileQueue> tileQueue = descriptor->getDoc()->_tileQueue;
-    assert(tileQueue && "Null TileQueue.");
+    std::shared_ptr<KitQueue> tileQueue = descriptor->getDoc()->_queue;
+    assert(tileQueue && "Null KitQueue.");
 
     const std::string payload = p ? p : "(nil)";
     LOG_TRC("Document::ViewCallback [" << descriptor->getViewId() <<
@@ -1243,7 +1243,7 @@ void Document::onUnload(const ChildSession& session)
     LOG_INF("Unloading session [" << sessionId << "] on url [" << anonymizeUrl(_url) << "].");
 
     const int viewId = session.getViewId();
-    _tileQueue->removeCursorPosition(viewId);
+    _queue->removeCursorPosition(viewId);
 
     if (_loKitDocument == nullptr)
     {
@@ -1346,8 +1346,8 @@ void Document::handleSaveMessage(const std::string &)
             LOG_TRC("Shutting down already shutdown bgsv child's socket to parent kit post save");
 
         // any further messages are not interesting.
-        if (_tileQueue)
-            _tileQueue->clear();
+        if (_queue)
+            _queue->clear();
 
         // cleanup any lingering file-system pieces
         _loKitDocument.reset();
@@ -1443,8 +1443,8 @@ bool Document::forkToSave(const std::function<void()> &childSave, int viewId)
         UnitKit::get().postBackgroundSaveFork();
 
         // other queued messages should be handled in the parent kit
-        if (_tileQueue)
-            _tileQueue->clear();
+        if (_queue)
+            _queue->clear();
 
         // Hard drop our previous connections to coolwsd and shared wakeups.
         KitSocketPoll::cleanupChildProcess();
@@ -2128,7 +2128,7 @@ void Document::drainQueue()
         std::vector<TileCombined> tileRequests;
 
         if (hasQueueItems())
-            LOG_TRC("drainQueue with " << _tileQueue->size() <<
+            LOG_TRC("drainQueue with " << _queue->size() <<
                     " items: " << (processInputEnabled() ? "processing" : "blocked") );
 
         while (processInputEnabled() && hasQueueItems())
@@ -2141,7 +2141,7 @@ void Document::drainQueue()
                 break;
             }
 
-            const TileQueue::Payload input = _tileQueue->pop();
+            const KitQueue::Payload input = _queue->pop();
 
             LOG_TRC("Kit handling queue message: " << COOLProtocol::getAbbreviatedMessage(input));
 
@@ -2406,7 +2406,7 @@ void Document::dumpState(std::ostream& oss)
 
     // dumpState:
     // TODO: _websocketHandler - but this is an odd one.
-    _tileQueue->dumpState(oss);
+    _queue->dumpState(oss);
     oss << "\tviewIdToCallbackDescr:";
     for (const auto &it : _viewIdToCallbackDescr)
     {

--- a/kit/Kit.hpp
+++ b/kit/Kit.hpp
@@ -19,6 +19,8 @@
 #include <common/StateEnum.hpp>
 #include <common/Session.hpp>
 #include <common/ThreadPool.hpp>
+#include <common/MessageQueue.hpp>
+
 #include <wsd/TileDesc.hpp>
 
 #include "Socket.hpp"

--- a/kit/Kit.hpp
+++ b/kit/Kit.hpp
@@ -19,7 +19,7 @@
 #include <common/StateEnum.hpp>
 #include <common/Session.hpp>
 #include <common/ThreadPool.hpp>
-#include <common/MessageQueue.hpp>
+#include <kit/KitQueue.hpp>
 
 #include <wsd/TileDesc.hpp>
 
@@ -184,7 +184,7 @@ public:
 #endif
 };
 
-class TileQueue;
+class KitQueue;
 class ChildSession;
 
 /// A document container.
@@ -259,7 +259,7 @@ private:
     /// Helper method to broadcast callback and its payload to all clients
     void broadcastCallbackToClients(const int type, const std::string& payload)
     {
-        _tileQueue->put("callback all " + std::to_string(type) + ' ' + payload);
+        _queue->put("callback all " + std::to_string(type) + ' ' + payload);
     }
 
 public:
@@ -324,8 +324,8 @@ public:
     bool processInputEnabled() const;
 
     /// A new message from wsd for the queue
-    void queueMessage(const std::string &msg) { _tileQueue->put(msg); }
-    bool hasQueueItems() const { return _tileQueue && !_tileQueue->isEmpty(); }
+    void queueMessage(const std::string &msg) { _queue->put(msg); }
+    bool hasQueueItems() const { return _queue && !_queue->isEmpty(); }
 
     // poll is idle, are we ?
     void checkIdle();
@@ -383,7 +383,7 @@ private:
 #ifdef __ANDROID__
     static std::shared_ptr<lok::Document> _loKitDocumentForAndroidOnly;
 #endif
-    std::shared_ptr<TileQueue> _tileQueue;
+    std::shared_ptr<KitQueue> _queue;
 
     // Connection to the coolwsd process
     std::shared_ptr<WebSocketHandler> _websocketHandler;

--- a/kit/KitQueue.cpp
+++ b/kit/KitQueue.cpp
@@ -11,7 +11,7 @@
 
 #include <config.h>
 
-#include "MessageQueue.hpp"
+#include "KitQueue.hpp"
 #include <climits>
 #include <algorithm>
 #include <string>
@@ -24,7 +24,7 @@
 #include "Log.hpp"
 #include <TileDesc.hpp>
 
-void TileQueue::put_impl(const Payload& value)
+void KitQueue::put_impl(const Payload& value)
 {
     StringVector tokens = StringVector::tokenize(value.data(), value.size());
 
@@ -80,7 +80,7 @@ void TileQueue::put_impl(const Payload& value)
         _queue.emplace_back(value);
 }
 
-void TileQueue::removeTileDuplicate(const std::string& tileMsg)
+void KitQueue::removeTileDuplicate(const std::string& tileMsg)
 {
     assert(COOLProtocol::matchPrefix("tile", tileMsg, /*ignoreWhitespace*/ true));
 
@@ -227,7 +227,7 @@ public:
 
 }
 
-std::string TileQueue::removeCallbackDuplicate(const std::string& callbackMsg)
+std::string KitQueue::removeCallbackDuplicate(const std::string& callbackMsg)
 {
     assert(COOLProtocol::matchPrefix("callback", callbackMsg, /*ignoreWhitespace*/ true));
 
@@ -474,7 +474,7 @@ std::string TileQueue::removeCallbackDuplicate(const std::string& callbackMsg)
     return std::string();
 }
 
-int TileQueue::priority(const std::string& tileMsg)
+int KitQueue::priority(const std::string& tileMsg)
 {
     TileDesc tile = TileDesc::parse(tileMsg); //FIXME: Expensive, avoid.
 
@@ -489,7 +489,7 @@ int TileQueue::priority(const std::string& tileMsg)
     return -1;
 }
 
-void TileQueue::deprioritizePreviews()
+void KitQueue::deprioritizePreviews()
 {
     for (size_t i = 0; i < getQueue().size(); ++i)
     {
@@ -509,9 +509,9 @@ void TileQueue::deprioritizePreviews()
     }
 }
 
-TileQueue::Payload TileQueue::get_impl()
+KitQueue::Payload KitQueue::get_impl()
 {
-    LOG_TRC("MessageQueue depth: " << getQueue().size());
+    LOG_TRC("KitQueue depth: " << getQueue().size());
 
     const Payload front = getQueue().front();
 
@@ -523,7 +523,7 @@ TileQueue::Payload TileQueue::get_impl()
     if (!isTile || isPreview)
     {
         // Don't combine non-tiles or tiles with id.
-        LOG_TRC("MessageQueue res: " << COOLProtocol::getAbbreviatedMessage(msg));
+        LOG_TRC("KitQueue res: " << COOLProtocol::getAbbreviatedMessage(msg));
         getQueue().erase(getQueue().begin());
 
         // de-prioritize the other tiles with id - usually the previews in
@@ -605,7 +605,7 @@ TileQueue::Payload TileQueue::get_impl()
     if (tiles.size() == 1)
     {
         msg = tiles[0].serialize("tile");
-        LOG_TRC("MessageQueue res: " << COOLProtocol::getAbbreviatedMessage(msg));
+        LOG_TRC("KitQueue res: " << COOLProtocol::getAbbreviatedMessage(msg));
         return Payload(msg.data(), msg.data() + msg.size());
     }
 
@@ -625,7 +625,7 @@ TileQueue::Payload TileQueue::get_impl()
             if (a.getTilePosX() == b.getTilePosX() &&
                 a.getTilePosY() == b.getTilePosY())
             {
-                LOG_TRC("MessageQueue: dropping duplicate tile: " <<
+                LOG_TRC("KitQueue: dropping duplicate tile: " <<
                         j << " vs. " << i << " at: " <<
                         a.getTilePosX() << "," << b.getTilePosY());
                 tiles.erase(tiles.begin() + j);
@@ -638,11 +638,11 @@ TileQueue::Payload TileQueue::get_impl()
     TileCombined combined = TileCombined::create(tiles);
     assert(!combined.hasDuplicates());
     std::string tileCombined = combined.serialize("tilecombine");
-    LOG_TRC("MessageQueue res: " << COOLProtocol::getAbbreviatedMessage(tileCombined));
+    LOG_TRC("KitQueue res: " << COOLProtocol::getAbbreviatedMessage(tileCombined));
     return Payload(tileCombined.data(), tileCombined.data() + tileCombined.size());
 }
 
-void TileQueue::dumpState(std::ostream& oss)
+void KitQueue::dumpState(std::ostream& oss)
 {
     oss << "\ttileQueue:"
         << "\n\t\tcursorPositions:";

--- a/kit/KitQueue.hpp
+++ b/kit/KitQueue.hpp
@@ -22,24 +22,24 @@
 #include "Protocol.hpp"
 
 /// Queue for handling the Kit's messaging needs
-class TileQueue
+class KitQueue
 {
-    friend class TileQueueTests;
+    friend class KitQueueTests;
 
 public:
     typedef std::vector<char> Payload;
 
-    TileQueue()
+    KitQueue()
     {
     }
 
-    virtual ~TileQueue()
+    virtual ~KitQueue()
     {
         clear();
     }
 
-    TileQueue(const TileQueue&) = delete;
-    TileQueue& operator=(const TileQueue&) = delete;
+    KitQueue(const KitQueue&) = delete;
+    KitQueue& operator=(const KitQueue&) = delete;
 
     /// insert the message.
     void put(const Payload& value)
@@ -260,7 +260,7 @@ private:
 public:
     void updateCursorPosition(int viewId, int part, int x, int y, int width, int height)
     {
-        const TileQueue::CursorPosition cursorPosition = CursorPosition(part, x, y, width, height);
+        const KitQueue::CursorPosition cursorPosition = CursorPosition(part, x, y, width, height);
 
         auto it = _cursorPositions.lower_bound(viewId);
         if (it != _cursorPositions.end() && it->first == viewId)
@@ -325,8 +325,5 @@ private:
     /// been happening (0 == oldest, size() - 1 == newest).
     std::vector<int> _viewOrder;
 };
-
-// Really this queue is used only in the Kit process
-typedef TileQueue KitQueue;
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/kit/KitWebSocket.cpp
+++ b/kit/KitWebSocket.cpp
@@ -24,9 +24,9 @@
 #include <common/Seccomp.hpp>
 #include <common/JsonUtil.hpp>
 #include <common/TraceEvent.hpp>
-#include <common/MessageQueue.hpp>
 
-#include <Kit.hpp>
+#include "Kit.hpp"
+#include "KitQueue.hpp"
 #include "KitWebSocket.hpp"
 
 using Poco::Exception;

--- a/kit/KitWebSocket.hpp
+++ b/kit/KitWebSocket.hpp
@@ -16,12 +16,12 @@
 #include <net/WebSocketHandler.hpp>
 
 class Document;
-class TileQueue;
+class KitQueue;
 class KitSocketPoll;
 
 class KitWebSocketHandler final : public WebSocketHandler
 {
-    std::shared_ptr<TileQueue> _queue;
+    std::shared_ptr<KitQueue> _queue;
     std::string _socketName;
     std::shared_ptr<lok::Office> _loKit;
     std::string _jailId;

--- a/test/KitQueueTests.cpp
+++ b/test/KitQueueTests.cpp
@@ -16,18 +16,18 @@
 #include <Common.hpp>
 #include <Protocol.hpp>
 #include <Message.hpp>
-#include <MessageQueue.hpp>
+#include <kit/KitQueue.hpp>
 #include <SenderQueue.hpp>
 #include <Util.hpp>
 
 #include <cppunit/extensions/HelperMacros.h>
 
-/// TileQueue unit-tests.
-class TileQueueTests : public CPPUNIT_NS::TestFixture
+/// KitQueue unit-tests.
+class KitQueueTests : public CPPUNIT_NS::TestFixture
 {
-    CPPUNIT_TEST_SUITE(TileQueueTests);
+    CPPUNIT_TEST_SUITE(KitQueueTests);
 
-    CPPUNIT_TEST(testTileQueuePriority);
+    CPPUNIT_TEST(testKitQueuePriority);
     CPPUNIT_TEST(testTileCombinedRendering);
     CPPUNIT_TEST(testTileRecombining);
     CPPUNIT_TEST(testViewOrder);
@@ -43,7 +43,7 @@ class TileQueueTests : public CPPUNIT_NS::TestFixture
 
     CPPUNIT_TEST_SUITE_END();
 
-    void testTileQueuePriority();
+    void testKitQueuePriority();
     void testTileCombinedRendering();
     void testTileRecombining();
     void testViewOrder();
@@ -58,18 +58,18 @@ class TileQueueTests : public CPPUNIT_NS::TestFixture
     void testCallbackPageSize();
 };
 
-void TileQueueTests::testTileQueuePriority()
+void KitQueueTests::testKitQueuePriority()
 {
     constexpr auto testname = __func__;
 
     const std::string reqHigh = "tile nviewid=0 part=0 width=256 height=256 tileposx=0 tileposy=0 tilewidth=3840 tileheight=3840 oldwid=0 wid=0";
     const std::string resHigh = "tile nviewid=0 part=0 width=256 height=256 tileposx=0 tileposy=0 tilewidth=3840 tileheight=3840 oldwid=0 wid=0 ver=-1";
-    const TileQueue::Payload payloadHigh(resHigh.data(), resHigh.data() + resHigh.size());
+    const KitQueue::Payload payloadHigh(resHigh.data(), resHigh.data() + resHigh.size());
     const std::string reqLow = "tile nviewid=0 part=0 width=256 height=256 tileposx=0 tileposy=253440 tilewidth=3840 tileheight=3840 oldwid=0 wid=0";
     const std::string resLow = "tile nviewid=0 part=0 width=256 height=256 tileposx=0 tileposy=253440 tilewidth=3840 tileheight=3840 oldwid=0 wid=0 ver=-1";
-    const TileQueue::Payload payloadLow(resLow.data(), resLow.data() + resLow.size());
+    const KitQueue::Payload payloadLow(resLow.data(), resLow.data() + resLow.size());
 
-    TileQueue queue;
+    KitQueue queue;
 
     // Request the tiles.
     queue.put(reqLow);
@@ -106,7 +106,7 @@ void TileQueueTests::testTileQueuePriority()
     LOK_ASSERT_EQUAL_STR(payloadHigh, queue.get());
 }
 
-void TileQueueTests::testTileCombinedRendering()
+void KitQueueTests::testTileCombinedRendering()
 {
     constexpr auto testname = __func__;
 
@@ -115,13 +115,13 @@ void TileQueueTests::testTileCombinedRendering()
     const std::string req3 = "tile nviewid=0 part=0 width=256 height=256 tileposx=0 tileposy=3840 tilewidth=3840 tileheight=3840";
 
     const std::string resHor = "tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0,3840 tileposy=0,0 imgsize=0,0 tilewidth=3840 tileheight=3840 ver=-1,-1 oldwid=0,0 wid=0,0";
-    const TileQueue::Payload payloadHor(resHor.data(), resHor.data() + resHor.size());
+    const KitQueue::Payload payloadHor(resHor.data(), resHor.data() + resHor.size());
     const std::string resVer = "tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0,0 tileposy=0,3840 imgsize=0,0 tilewidth=3840 tileheight=3840 ver=-1,-1 oldwid=0,0 wid=0,0";
-    const TileQueue::Payload payloadVer(resVer.data(), resVer.data() + resVer.size());
+    const KitQueue::Payload payloadVer(resVer.data(), resVer.data() + resVer.size());
     const std::string resFull = "tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0,3840,0 tileposy=0,0,3840 imgsize=0,0,0 tilewidth=3840 tileheight=3840 ver=-1,-1,-1 oldwid=0,0,0 wid=0,0,0";
-    const TileQueue::Payload payloadFull(resFull.data(), resFull.data() + resFull.size());
+    const KitQueue::Payload payloadFull(resFull.data(), resFull.data() + resFull.size());
 
-    TileQueue queue;
+    KitQueue queue;
 
     // Horizontal.
     queue.put(req1);
@@ -140,11 +140,11 @@ void TileQueueTests::testTileCombinedRendering()
     LOK_ASSERT_EQUAL_STR(payloadFull, queue.get());
 }
 
-void TileQueueTests::testTileRecombining()
+void KitQueueTests::testTileRecombining()
 {
     constexpr auto testname = __func__;
 
-    TileQueue queue;
+    KitQueue queue;
 
     queue.put("tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0,3840,7680 tileposy=0,0,0 tilewidth=3840 tileheight=3840");
     queue.put("tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0,3840 tileposy=0,0 tilewidth=3840 tileheight=3840");
@@ -162,11 +162,11 @@ void TileQueueTests::testTileRecombining()
     LOK_ASSERT_EQUAL(0, static_cast<int>(queue.getQueue().size()));
 }
 
-void TileQueueTests::testViewOrder()
+void KitQueueTests::testViewOrder()
 {
     constexpr auto testname = __func__;
 
-    TileQueue queue;
+    KitQueue queue;
 
     // should result in the 3, 2, 1, 0 order of the views
     queue.updateCursorPosition(0, 0, 0, 0, 10, 100);
@@ -197,11 +197,11 @@ void TileQueueTests::testViewOrder()
     }
 }
 
-void TileQueueTests::testPreviewsDeprioritization()
+void KitQueueTests::testPreviewsDeprioritization()
 {
     constexpr auto testname = __func__;
 
-    TileQueue queue;
+    KitQueue queue;
 
     // simple case - put previews to the queue and get everything back again
     const std::vector<std::string> previews =
@@ -271,7 +271,7 @@ namespace {
     }
 }
 
-void TileQueueTests::testSenderQueue()
+void KitQueueTests::testSenderQueue()
 {
     constexpr auto testname = __func__;
 
@@ -315,7 +315,7 @@ void TileQueueTests::testSenderQueue()
     LOK_ASSERT_EQUAL(static_cast<size_t>(0), queue.size());
 }
 
-void TileQueueTests::testSenderQueueProgress()
+void KitQueueTests::testSenderQueueProgress()
 {
     constexpr auto testname = __func__;
 
@@ -352,7 +352,7 @@ void TileQueueTests::testSenderQueueProgress()
     LOK_ASSERT_EQUAL(static_cast<size_t>(0), queue.size());
 }
 
-void TileQueueTests::testSenderQueueTileDeduplication()
+void KitQueueTests::testSenderQueueTileDeduplication()
 {
     constexpr auto testname = __func__;
 
@@ -406,7 +406,7 @@ void TileQueueTests::testSenderQueueTileDeduplication()
     LOK_ASSERT_EQUAL(static_cast<size_t>(0), queue.size());
 }
 
-void TileQueueTests::testInvalidateViewCursorDeduplication()
+void KitQueueTests::testInvalidateViewCursorDeduplication()
 {
     constexpr auto testname = __func__;
 
@@ -470,11 +470,11 @@ void TileQueueTests::testInvalidateViewCursorDeduplication()
     LOK_ASSERT_EQUAL(static_cast<size_t>(0), queue.size());
 }
 
-void TileQueueTests::testCallbackInvalidation()
+void KitQueueTests::testCallbackInvalidation()
 {
     constexpr auto testname = __func__;
 
-    TileQueue queue;
+    KitQueue queue;
 
     // join tiles
     queue.put("callback all 0 284, 1418, 11105, 275, 0");
@@ -499,11 +499,11 @@ void TileQueueTests::testCallbackInvalidation()
     LOK_ASSERT_EQUAL_STR("callback all 0 EMPTY, 0", queue.get());
 }
 
-void TileQueueTests::testCallbackIndicatorValue()
+void KitQueueTests::testCallbackIndicatorValue()
 {
     constexpr auto testname = __func__;
 
-    TileQueue queue;
+    KitQueue queue;
 
     // join tiles
     queue.put("callback all 10 25");
@@ -513,11 +513,11 @@ void TileQueueTests::testCallbackIndicatorValue()
     LOK_ASSERT_EQUAL_STR("callback all 10 50", queue.get());
 }
 
-void TileQueueTests::testCallbackPageSize()
+void KitQueueTests::testCallbackPageSize()
 {
     constexpr auto testname = __func__;
 
-    TileQueue queue;
+    KitQueue queue;
 
     // join tiles
     queue.put("callback all 13 12474, 188626");
@@ -527,11 +527,11 @@ void TileQueueTests::testCallbackPageSize()
     LOK_ASSERT_EQUAL_STR("callback all 13 12474, 205748", queue.get());
 }
 
-void TileQueueTests::testCallbackModifiedStatusIsSkipped()
+void KitQueueTests::testCallbackModifiedStatusIsSkipped()
 {
     constexpr auto testname = __func__;
 
-    TileQueue queue;
+    KitQueue queue;
     std::stringstream ss;
     ss << "callback all " << LOK_CALLBACK_STATE_CHANGED;
 
@@ -556,6 +556,6 @@ void TileQueueTests::testCallbackModifiedStatusIsSkipped()
     LOK_ASSERT_EQUAL_STR(messages[3], queue.get());
 }
 
-CPPUNIT_TEST_SUITE_REGISTRATION(TileQueueTests);
+CPPUNIT_TEST_SUITE_REGISTRATION(KitQueueTests);
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -128,7 +128,7 @@ wsd_sources = \
             ../wsd/ProofKey.cpp
 
 test_base_sources = \
-	TileQueueTests.cpp \
+	KitQueueTests.cpp \
 	RequestDetailsTests.cpp \
 	StringVectorTests.cpp \
 	FileServeWhiteBoxTests.cpp \
@@ -144,7 +144,6 @@ common_sources = \
 	../common/ConfigUtil.cpp \
 	../common/DummyTraceEventEmitter.cpp \
 	../common/Log.cpp \
-	../common/MessageQueue.cpp \
 	../common/Session.cpp \
 	../common/SigUtil.cpp \
 	../common/Unit.cpp \
@@ -154,6 +153,7 @@ common_sources = \
 	../common/StringVector.cpp \
 	../common/TraceEvent.cpp \
 	../common/Simd.cpp \
+	../kit/KitQueue.cpp \
 	../wsd/Exceptions.cpp \
 	../net/HttpRequest.cpp \
 	../net/Socket.cpp \

--- a/test/TileCacheTests.cpp
+++ b/test/TileCacheTests.cpp
@@ -27,7 +27,6 @@
 
 #include <Common.hpp>
 #include <Protocol.hpp>
-#include <MessageQueue.hpp>
 #include <Png.hpp>
 #include <TileCache.hpp>
 #include <kit/Delta.hpp>

--- a/test/UnitTyping.cpp
+++ b/test/UnitTyping.cpp
@@ -18,10 +18,10 @@
 #include <Log.hpp>
 #include <Unit.hpp>
 #include <UnitHTTP.hpp>
-#include <MessageQueue.hpp>
 #include <WebSocketSession.hpp>
 #include <helpers.hpp>
 #include <wsd/TileDesc.hpp>
+#include <kit/KitQueue.hpp>
 
 #include <random>
 #include <iostream>
@@ -130,7 +130,7 @@ public:
         return TestResult::Ok;
     }
 
-    TestResult testMessageQueueMerging()
+    TestResult testKitQueueMerging()
     {
         KitQueue queue;
 
@@ -404,7 +404,7 @@ public:
         if (res != TestResult::Ok)
             return res;
 
-        res = testMessageQueueMerging();
+        res = testKitQueueMerging();
         if (res != TestResult::Ok)
             return res;
 

--- a/test/UnitTyping.cpp
+++ b/test/UnitTyping.cpp
@@ -18,6 +18,7 @@
 #include <Log.hpp>
 #include <Unit.hpp>
 #include <UnitHTTP.hpp>
+#include <MessageQueue.hpp>
 #include <WebSocketSession.hpp>
 #include <helpers.hpp>
 #include <wsd/TileDesc.hpp>
@@ -131,13 +132,12 @@ public:
 
     TestResult testMessageQueueMerging()
     {
-        MessageQueue queue;
+        KitQueue queue;
 
         queue.put("child-foo textinput id=0 text=a");
         queue.put("child-foo textinput id=0 text=b");
 
-        MessageQueue::Payload v;
-        v = queue.get();
+        auto v = queue.get();
 
         if (!queue.isEmpty())
         {
@@ -201,7 +201,7 @@ public:
         v = queue.get();
         if (!queue.isEmpty())
         {
-            LOG_ERR("MessageQueue contains more than was put into it");
+            LOG_ERR("KitQueue contains more than was put into it");
             return TestResult::Failed;
         }
 

--- a/test/WhiteBoxTests.cpp
+++ b/test/WhiteBoxTests.cpp
@@ -20,7 +20,6 @@
 #include <Common.hpp>
 #include <FileUtil.hpp>
 #include <Kit.hpp>
-#include <MessageQueue.hpp>
 #include <Protocol.hpp>
 #include <TileDesc.hpp>
 #include <Util.hpp>

--- a/wasm/Makefile.am
+++ b/wasm/Makefile.am
@@ -27,7 +27,6 @@ online_SOURCES = \
 	../common/FileUtil.cpp \
 	../common/CommandControl.cpp \
 	../common/Log.cpp \
-	../common/MessageQueue.cpp \
 	../common/TraceEvent.cpp \
 	../common/Protocol.cpp \
 	../common/StringVector.cpp \
@@ -40,6 +39,7 @@ online_SOURCES = \
 	../common/Util-mobile.cpp \
 	../kit/ChildSession.cpp \
 	../kit/Kit.cpp \
+	../kit/KitQueue.cpp \
 	../kit/KitWebSocket.cpp \
 	../kit/DeltaSimd.c \
 	../net/FakeSocket.cpp \


### PR DESCRIPTION
The MessageQueue is not a generic message queue, it has much more un-anticipated functionality; so don't use it where we don't need to.

In particular unexpected re-writing and merging of messages during tests is probably not a great idea.


Change-Id: I657738307e611be18f5f83e11c055bf8a88826da


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

