### PR TITLE
Fileserver Cache Improvements

### DIFF
--- a/common/FileUtil.cpp
+++ b/common/FileUtil.cpp
@@ -363,54 +363,6 @@ namespace FileUtil
                           std::istreambuf_iterator<char>(lhs.rdbuf()));
     }
 
-    ssize_t readFile(const std::string& path, std::vector<char>& data, int maxSize)
-    {
-        const int fd = ::open(path.c_str(), O_RDONLY);
-        if (fd < 0)
-            return -1;
-
-        struct stat st;
-        if (::fstat(fd, &st) != 0 || st.st_size > maxSize)
-        {
-            ::close(fd);
-            return -1;
-        }
-
-        const std::size_t originalSize = data.size();
-        auto remainingSize = st.st_size;
-        data.resize(originalSize + remainingSize);
-        off_t off = originalSize;
-        for (;;)
-        {
-            if (remainingSize == 0)
-            {
-                // Nothing to read.
-                break;
-            }
-
-            int n;
-            while ((n = ::read(fd, &data[off], remainingSize)) < 0 && errno == EINTR)
-            {
-            }
-
-            if (n <= 0)
-            {
-                if (n == 0) // EOF.
-                    break;
-
-                ::close(fd);
-                data.resize(originalSize);
-                return -1; // Error.
-            }
-
-            off += n;
-            remainingSize -= n;
-        }
-
-        close(fd);
-        return st.st_size;
-    }
-
     std::unique_ptr<std::vector<char>> readFile(const std::string& path, int maxSize)
     {
         auto data = std::make_unique<std::vector<char>>(maxSize);

--- a/common/FileUtil.hpp
+++ b/common/FileUtil.hpp
@@ -140,6 +140,10 @@ namespace FileUtil
     /// have equal size and every byte of their contents match.
     bool compareFileContents(const std::string& rhsPath, const std::string& lhsPath);
 
+    /// Reads the whole file into the given buffer. Only for small files.
+    /// Does *not* clear the buffer before writing to it. Returns the number of bytes read, -1 for error.
+    ssize_t readFile(const std::string& path, std::vector<char>& buffer, int maxSize = 256 * 1024);
+
     /// Reads the whole file to memory. Only for small files.
     std::unique_ptr<std::vector<char>> readFile(const std::string& path, int maxSize = 256 * 1024);
 

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -235,7 +235,6 @@ static std::chrono::milliseconds careerSpanMs(std::chrono::milliseconds::zero())
 int ChildSpawnTimeoutMs = CHILD_TIMEOUT_MS * 4;
 std::atomic<unsigned> COOLWSD::NumConnections;
 std::unordered_set<std::string> COOLWSD::EditFileExtensions;
-std::unordered_set<std::string> COOLWSD::ViewWithCommentsFileExtensions;
 
 #if MOBILEAPP
 

--- a/wsd/COOLWSD.hpp
+++ b/wsd/COOLWSD.hpp
@@ -317,7 +317,6 @@ public:
 #endif
 
     static std::unordered_set<std::string> EditFileExtensions;
-    static std::unordered_set<std::string> ViewWithCommentsFileExtensions;
     static unsigned MaxConnections;
     static unsigned MaxDocuments;
     static std::string OverrideWatermark;
@@ -382,22 +381,6 @@ public:
             return false; // mark everything else editable on mobile
         }
         return EditFileExtensions.find(lowerCaseExtension) == EditFileExtensions.end();
-    }
-
-    /// Return true if extension is marked as view_comment action in discovery.xml.
-    static bool IsViewWithCommentsFileExtension(const std::string& extension)
-    {
-
-        std::string lowerCaseExtension = extension;
-        std::transform(lowerCaseExtension.begin(), lowerCaseExtension.end(), lowerCaseExtension.begin(), ::tolower);
-        if (Util::isMobileApp())
-        {
-            if (lowerCaseExtension == "pdf")
-                return true; // true for only pdf - it is not editable
-            return false; // mark everything else editable on mobile
-        }
-        return ViewWithCommentsFileExtensions.find(lowerCaseExtension) !=
-               ViewWithCommentsFileExtensions.end();
     }
 
     /// Returns the value of the specified application configuration,

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -1903,9 +1903,9 @@ std::string ClientRequestDispatcher::getDiscoveryXML()
         }
         else if (elem->getAttribute("name") == "view_comment")
         {
-            const std::string ext = elem->getAttribute("ext");
-            if (COOLWSD::ViewWithCommentsFileExtensions.insert(ext).second) // Skip duplicates.
-                LOG_DBG_S("Enabling commenting on [" << ext << "] extension files");
+            // We don't seem to treat this list differently.
+            // The assumption seems to be that if a file is not editable,
+            // then it's view-only. And if it's view-only, it supports comments.
         }
     }
 

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -68,9 +68,7 @@
 #include <openssl/evp.h>
 
 using Poco::Net::HTMLForm;
-using Poco::Net::HTTPBasicCredentials;
 using Poco::Net::HTTPRequest;
-using Poco::Net::HTTPResponse;
 using Poco::Net::NameValueCollection;
 using Poco::Util::Application;
 

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -74,6 +74,9 @@ using Poco::Util::Application;
 
 std::map<std::string, std::pair<std::string, std::string>> FileServerRequestHandler::FileHash;
 
+// We have files that are at least 2.5 MB already.
+constexpr auto MaxFileSizeToCacheInBytes = 5 * 1024 * 1024;
+
 namespace
 {
 
@@ -823,22 +826,8 @@ void FileServerRequestHandler::readDirToHash(const std::string &basePath, const 
             filesRead.append(currentFile->d_name);
             filesRead += ' ';
 
-            std::ifstream file(basePath + relPath, std::ios::binary);
-
             std::string uncompressedFile;
-            uncompressedFile.resize(fileStat.st_size);
-            long unsigned int pos = 0;
-            do
-            {
-                file.read(&uncompressedFile[pos], fileStat.st_size);
-                const long unsigned int size = file.gcount();
-                if (size == 0)
-                    break;
-
-                pos += size;
-
-            } while (true);
-
+            FileUtil::readFile(basePath + relPath, uncompressedFile);
             FileHash.emplace(prefix + relPath,
                              std::make_pair(std::move(uncompressedFile), std::string()));
         }
@@ -859,43 +848,39 @@ void FileServerRequestHandler::readDirToHash(const std::string &basePath, const 
             filesRead.append(currentFile->d_name);
             filesRead += ' ';
 
-            std::ifstream file(basePath + relPath, std::ios::binary);
-
-            std::unique_ptr<char[]> buf = std::make_unique<char[]>(fileStat.st_size);
             std::string compressedFile;
-            compressedFile.reserve(fileStat.st_size);
             std::string uncompressedFile;
-            uncompressedFile.reserve(fileStat.st_size);
-            do
+            const ssize_t size =
+                FileUtil::readFile(basePath + relPath, uncompressedFile, MaxFileSizeToCacheInBytes);
+            assert(size < MaxFileSizeToCacheInBytes && "MaxFileSizeToCacheInBytes is too small for "
+                                                       "static-file serving; please increase it");
+            if (size > 0)
             {
-                file.read(&buf[0], fileStat.st_size);
-                const long unsigned int size = file.gcount();
-                if (size == 0)
-                    break;
-
                 const long unsigned int compSize = compressBound(size);
-                char *cbuf = (char *)calloc(compSize, sizeof(char));
-
-                strm.next_in = (unsigned char *)&buf[0];
+                compressedFile.resize(compSize);
+                strm.next_in = (unsigned char*)&uncompressedFile[0];
                 strm.avail_in = size;
                 strm.avail_out = compSize;
-                strm.next_out = (unsigned char *)&cbuf[0];
+                strm.next_out = (unsigned char*)&compressedFile[0];
                 strm.total_out = strm.total_in = 0;
 
                 const int deflateResult = deflate(&strm, Z_FINISH);
                 if (deflateResult != Z_OK && deflateResult != Z_STREAM_END)
                 {
-                    LOG_ERR("Failed to deflate, result: " << deflateResult);
-                    free(cbuf);
-                    break;
+                    LOG_ERR("Failed to deflate [" << basePath + relPath
+                                                  << "], result: " << deflateResult);
+                    compressedFile.clear();
                 }
-
-                compressedFile.append(cbuf, compSize - strm.avail_out);
-                free(cbuf);
-
-                uncompressedFile.append(buf.get(), size);
-
-            } while(true);
+                else
+                {
+                    compressedFile.resize(compSize - strm.avail_out);
+                }
+            }
+            else if (size != 0)
+            {
+                LOG_ERR("File [" << basePath + relPath
+                                 << "] is too large to cache and serve. Ignoring");
+            }
 
             FileHash.emplace(prefix + relPath, std::make_pair(std::move(uncompressedFile),
                                                               std::move(compressedFile)));


### PR DESCRIPTION
Reuses file-reading utility, handles errors during compression better (always inserts an uncompressed version of each file and serves it if the compressed version is missing), reduces memory allocation/copying churn, deletes dead code, and adds comments. (Commit log messages have the details.) 

- wsd: FileServer cleanup
- wsd: refactored readFile to take buffer
- wsd: generic readFile
- wsd: simplify file-server caching
- wsd: fileserver: better compression failure handling
- wsd: remove unused (Is)ViewWithCommentsFileExtension(s)
