### PR TITLE
calc: don't jump to own cursor if not looking

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -2564,7 +2564,9 @@ L.CanvasTileLayer = L.Layer.extend({
 			this._prevCellCursor = new L.LatLngBounds(this._cellCursor.getSouthWest(), this._cellCursor.getNorthEast());
 		}
 
-		var scrollToCursor = this._sheetSwitch.tryRestore(oldCursorXY.equals(this._cellCursorXY), this._selectedPart);
+		var isFollowingOwnCursor = true; // HERE USE REAL VALUE AND MAKE IT ASSIGNED SOMEWHERE
+		var notJump = oldCursorXY.equals(this._cellCursorXY) || !isFollowingOwnCursor;
+		var scrollToCursor = this._sheetSwitch.tryRestore(notJump, this._selectedPart);
 
 		this._onUpdateCellCursor(horizontalDirection, verticalDirection, onPgUpDn, scrollToCursor);
 


### PR DESCRIPTION
If we have cell selected on the bottom of the sheet and we scroll up to watch something else so we don't see the cursor: if other user will add row above - we will jump to our own cursor. It's because it changed the address: like A500 to A5001.

Let's don't do that. Solution could be to enter "non following" mode when we scroll outside our own cursor. So we will not jump to our cell if not needed. Then if we click or do any key press - we should cancel that mode and go back to "following own cursor mode".

This can be additionaly marked by something on the user list.