### PR TITLE
mount: better check the target jail directory exits

### DIFF
--- a/tools/mount.cpp
+++ b/tools/mount.cpp
@@ -170,7 +170,7 @@ int main(int argc, char** argv)
         const char* target = argv[2];
 
         struct stat sb;
-        const bool target_exists = (stat(target, &sb) == 0 && S_ISDIR(sb.st_mode));
+        const bool target_exists = (stat(target, &sb) == 0) && S_ISDIR(sb.st_mode);
 
         // Do nothing if target doesn't exist.
         if (target_exists)


### PR DESCRIPTION
paranthesis made the check running havoc.

https://github.com/CollaboraOnline/online/pull/8730#issuecomment-2102569063

Change-Id: Ib68d765e88d344234c70bcf331cb1c1ac6779f5b


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

