### PR TITLE
AddressSanitizer: memcmp issue

### DIFF
--- a/kit/KitQueue.cpp
+++ b/kit/KitQueue.cpp
@@ -43,13 +43,13 @@ namespace {
 
         size_t remaining = value.size() - firstToken.size();
 
-        if (!memcmp(value.data() + offset + 1, "textinput", std::min(remaining, size_t(9))))
+        if (!memcmp(value.data() + offset + 1, "textinput", std::min(remaining - 1, size_t(9))))
         {
             removeText = false;
             return true;
         }
 
-        if (!memcmp(value.data() + offset + 1, "removetextcontext", std::min(remaining, size_t(17))))
+        if (!memcmp(value.data() + offset + 1, "removetextcontext", std::min(remaining - 1, size_t(17))))
         {
             removeText = true;
             return true;


### PR DESCRIPTION
/usr/bin/coolforkit
	memcmp
		asan/../sanitizer_common/sanitizer_common_interceptors.inc:875 (discriminator 9)
/usr/bin/coolforkit
	(anonymous namespace)::textItem(std::vector<char, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool&)
		online/kit/KitQueue.cpp:52
/usr/bin/coolforkit
	KitQueue::put(std::vector<char, std::allocator<char> > const&)
		online/kit/KitQueue.cpp:94

since:

commit f8a0d6c0863f4b7f7b99e9b57f8679168bc7d67f
Date:   Thu May 9 15:29:49 2024 +0100

    Callbacks: minor efficiency wins, avoid tokenizing where we can.


Change-Id: Ie5d0f86bb33c810b6a5f177421485c977b7fc79a


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

