### PR TITLE
UI: slightly make the font size combo larger

### DIFF
--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -379,7 +379,7 @@ button.ui-tab.notebookbar {
 }
 
 #fontsizecombobox.notebookbar {
-	width: 5em;
+	width: 4.6rem;
 }
 
 .notebookbar.ui-combobox * {


### PR DESCRIPTION
So even '88 pt' fit in without getting cut.

Change-Id: I950b99b2bed7b1e038e1847586b517807f3aa9b0

### Summary

After:

![image](https://github.com/CollaboraOnline/online/assets/620941/8c72fea8-4525-47ca-9fcc-cec82657ce3c)

Before:

![image](https://github.com/CollaboraOnline/online/assets/620941/47f732b1-b843-47ff-82cf-88399a6a7a89)

Follow-up of https://github.com/CollaboraOnline/online/pull/8979
