### PR TITLE
add auto fill popup: Copy cells and Fill series

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -376,6 +376,7 @@ COOL_JS_LST =\
 	src/control/Control.Sidebar.js \
 	src/control/AutoCompletePopup.ts \
 	src/control/Control.Mention.ts \
+	src/control/Control.AutoFillOptions.ts \
 	src/control/Control.Zotero.js \
 	src/control/Search.js \
 	src/control/Permission.js \

--- a/browser/src/control/Control.AutoFillOptions.ts
+++ b/browser/src/control/Control.AutoFillOptions.ts
@@ -21,7 +21,6 @@ class AutoFillOptions extends L.Control.AutoCompletePopup {
 	users: any;
 	itemList: Array<any>;
 	data: MessageEvent<any>;
-	autoFillPopupPoint: Point;
 
 	constructor(map: ReturnType<typeof L.map>) {
 		super('autoFillPopup', map);
@@ -30,7 +29,7 @@ class AutoFillOptions extends L.Control.AutoCompletePopup {
 	onAdd() {
 		this.newPopupData.isAutoCompletePopup = true;
 		this.map.on('openautofillpopup', this.openAutoFillPopup, this);
-		this.map.on('closementionpopup', this.closeMentionPopup, this);
+		this.map.on('closeautofillpopup', this.closeMentionPopup, this);
 		this.map.on('sendautofilllocation', this.sendAutoFillLocation, this);
 		this.firstChar = null;
 		this.users = null;
@@ -76,20 +75,20 @@ class AutoFillOptions extends L.Control.AutoCompletePopup {
 		data.posx = framePos.x;
 		data.posy = framePos.y;
 		this.sendJSON(data);
+
+		this.map._docLayer.isAutoFillPopupOpen = true;
 	}
 
 	closeMentionPopup(ev: CloseMessageEvent) {
-		// console.error('close closeMentionPopup');
-
 		super.closePopup();
 		if (!ev.typingMention) {
 			this.map._docLayer._typingMention = false;
 			this.map._docLayer._mentionText = [];
 		}
+		this.map._docLayer.isAutoFillPopupOpen = false;
 	}
 
 	callback(objectType: any, eventType: any, object: any, index: number) {
-		// console.error("eventType: " + eventType);
 		if (eventType === 'close') {
 			// console.error('close callback');
 			this.closeMentionPopup({ typingMention: false } as CloseMessageEvent);

--- a/browser/src/control/Control.AutoFillOptions.ts
+++ b/browser/src/control/Control.AutoFillOptions.ts
@@ -95,11 +95,21 @@ class AutoFillOptions extends L.Control.AutoCompletePopup {
 			this.map.fire('closeautofillpopup');
 
 			if (index == 0) {
-				// Copy cells
-				this.map.sendUnoCommand('.uno:FillSeries?FillStep:string=0');
+				/*
+					- Copy cells
+					undo needed here, "Copy cells" should operate on the original content,
+					not the new content of the cells.
+				*/
+				this.map.sendUnoCommand('.uno:Undo');
+				this.map.sendUnoCommand('.uno:AutoFill?Copy:bool=true');
 			} else if (index == 1) {
-				// Fill series
-				this.map.sendUnoCommand('.uno:FillSeries?FillStep:string=1');
+				/*
+					- Fill series
+					undo needed here, "Fill series" should operate on the original content,
+					not the new content of the cells.
+				*/
+				this.map.sendUnoCommand('.uno:Undo');
+				this.map.sendUnoCommand('.uno:AutoFill?Copy:bool=false');
 			}
 
 		} else if (eventType === 'keydown') {

--- a/browser/src/control/Control.AutoFillOptions.ts
+++ b/browser/src/control/Control.AutoFillOptions.ts
@@ -1,0 +1,106 @@
+/* -*- js-indent-level: 8 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+/*
+ * Control.AutoFillOptions - class for auto fill popup
+ */
+
+/* global app */
+
+class AutoFillOptions extends L.Control.AutoCompletePopup {
+	map: ReturnType<typeof L.map>;
+	newPopupData: PopupData;
+	firstChar: string;
+	users: any;
+	itemList: Array<any>;
+	data: MessageEvent<any>;
+	autoFillPopupPoint: Point;
+
+	constructor(map: ReturnType<typeof L.map>) {
+		super('autoFillPopup', map);
+	}
+
+	onAdd() {
+		this.newPopupData.isAutoCompletePopup = true;
+		this.map.on('openautofillpopup', this.openAutoFillPopup, this);
+		this.map.on('closementionpopup', this.closeMentionPopup, this);
+		this.map.on('sendautofilllocation', this.sendAutoFillLocation, this);
+		this.firstChar = null;
+		this.users = null;
+		this.itemList = null;
+	}
+
+	getAutoFillRectanglePosition(ev: FireEvent): Point {
+		var currPos = ev.data;
+		var origin = this.map.getPixelOrigin();
+		var panePos = this.map._getMapPanePos();
+		return new L.Point(
+			Math.round(currPos.x + panePos.x - origin.x),
+			Math.round(currPos.y + panePos.y - origin.y),
+		);
+	}
+
+	sendAutoFillLocation(ev: FireEvent) {
+		this.openAutoFillPopup({ data: ev.data });
+	}
+
+	getPopupEntries(): any[] {
+		const entries: any[] = [{ text: '', columns: [{ text: 'Copy cells' }], row: '' },
+		{ text: '', columns: [{ text: 'Fill series' }], row: '' }];
+		return entries;
+	}
+
+	openAutoFillPopup(ev: FireEvent): void {
+		const framePos = this.getAutoFillRectanglePosition(ev); // bottom-right position
+		const entries = this.getPopupEntries();
+		let data: PopupData;
+
+		if (entries.length > 0) {
+			const control = this.getTreeJSON();
+
+			if (L.DomUtil.get(this.popupId))
+				this.closeMentionPopup({ typingMention: true } as CloseMessageEvent);
+			data = this.newPopupData;
+			data.children[0].children[0] = control;
+			(data.children[0].children[0] as TreeWidget).entries = entries;
+		}
+
+		// add position
+		data.posx = framePos.x;
+		data.posy = framePos.y;
+		this.sendJSON(data);
+	}
+
+	closeMentionPopup(ev: CloseMessageEvent) {
+		// console.error('close closeMentionPopup');
+
+		super.closePopup();
+		if (!ev.typingMention) {
+			this.map._docLayer._typingMention = false;
+			this.map._docLayer._mentionText = [];
+		}
+	}
+
+	callback(objectType: any, eventType: any, object: any, index: number) {
+		// console.error("eventType: " + eventType);
+		if (eventType === 'close') {
+			// console.error('close callback');
+			this.closeMentionPopup({ typingMention: false } as CloseMessageEvent);
+		} else if (eventType === 'select' || eventType === 'activate') {
+			// console.error('select or activate triggered');
+		} else if (eventType === 'keydown') {
+			// console.error('keydown');
+		}
+		return false;
+	}
+}
+L.control.autofilloptions = function (map: any) {
+	return new AutoFillOptions(map);
+};

--- a/browser/src/control/Control.AutoFillOptions.ts
+++ b/browser/src/control/Control.AutoFillOptions.ts
@@ -113,7 +113,10 @@ class AutoFillOptions extends L.Control.AutoCompletePopup {
 			}
 
 		} else if (eventType === 'keydown') {
-			// TODO: handle arrowDown key
+			if (object.key !== 'Tab' && object.key !== 'Shift') {
+				this.map.focus();
+				return true;
+			}
 		}
 		return false;
 	}

--- a/browser/src/control/Control.AutoFillOptions.ts
+++ b/browser/src/control/Control.AutoFillOptions.ts
@@ -75,20 +75,20 @@ class AutoFillOptions extends L.Control.AutoCompletePopup {
 		data.posx = framePos.x;
 		data.posy = framePos.y;
 		this.sendJSON(data);
-
-		this.map._docLayer.isAutoFillPopupOpen = true;
 	}
 
 	closeMentionPopup(ev: CloseMessageEvent) {
+		this.map._docLayer.isAutoFillFromOnMouseUp = false;
 		super.closePopup();
 		if (!ev.typingMention) {
 			this.map._docLayer._typingMention = false;
 			this.map._docLayer._mentionText = [];
 		}
-		this.map._docLayer.isAutoFillPopupOpen = false;
 	}
 
 	callback(objectType: any, eventType: any, object: any, index: number) {
+		this.map._docLayer.isAutoFillFromOnMouseUp = false;
+
 		if (eventType === 'close') {
 			this.closeMentionPopup({ typingMention: false } as CloseMessageEvent);
 		} else if (eventType === 'select' || eventType === 'activate') {

--- a/browser/src/control/Control.AutoFillOptions.ts
+++ b/browser/src/control/Control.AutoFillOptions.ts
@@ -51,8 +51,8 @@ class AutoFillOptions extends L.Control.AutoCompletePopup {
 	}
 
 	getPopupEntries(): any[] {
-		const entries: any[] = [{ text: '', columns: [{ text: 'Copy cells' }], row: '' },
-		{ text: '', columns: [{ text: 'Fill series' }], row: '' }];
+		const entries: any[] = [{ text: 'copy', columns: [{ text: 'Copy cells' }], row: '0' },
+		{ text: 'fill', columns: [{ text: 'Fill series' }], row: '1' }];
 		return entries;
 	}
 
@@ -90,12 +90,20 @@ class AutoFillOptions extends L.Control.AutoCompletePopup {
 
 	callback(objectType: any, eventType: any, object: any, index: number) {
 		if (eventType === 'close') {
-			// console.error('close callback');
 			this.closeMentionPopup({ typingMention: false } as CloseMessageEvent);
 		} else if (eventType === 'select' || eventType === 'activate') {
-			// console.error('select or activate triggered');
+			this.map.fire('closeautofillpopup');
+
+			if (index == 0) {
+				// Copy cells
+				this.map.sendUnoCommand('.uno:FillSeries?FillStep:string=0');
+			} else if (index == 1) {
+				// Fill series
+				this.map.sendUnoCommand('.uno:FillSeries?FillStep:string=1');
+			}
+
 		} else if (eventType === 'keydown') {
-			// console.error('keydown');
+			// TODO: handle arrowDown key
 		}
 		return false;
 	}

--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -602,7 +602,8 @@ L.Control.JSDialog = L.Control.extend({
 			var dialog = this.dialogs[autoFilterDialogId];
 
 			// Check if the current dialog has the isAutofilter property set to true
-			if (dialog.isAutofilter) {
+			// and if it is not an autoFillPopup
+			if (dialog.isAutofilter && (autoFilterDialogId !== 'autoFillPopup')) {
 				// Call this.close(key, true) for the current dialog
 				this.close(autoFilterDialogId, true);
 			}

--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -600,10 +600,17 @@ L.Control.JSDialog = L.Control.extend({
 		for (var i = 0; i < dialogKeys.length; i++) {
 			var autoFilterDialogId = dialogKeys[i];
 			var dialog = this.dialogs[autoFilterDialogId];
+			var isAutoFillFromOnMouseUp = this.map._docLayer.isAutoFillFromOnMouseUp;
 
 			// Check if the current dialog has the isAutofilter property set to true
-			// and if it is not an autoFillPopup
-			if (dialog.isAutofilter && (autoFilterDialogId !== 'autoFillPopup')) {
+			if (dialog.isAutofilter) {
+
+				// don't hide AutoFill popup if it comes from onMouseUp event (see AutoFillMarkerSection.ts)
+				if (isAutoFillFromOnMouseUp && (autoFilterDialogId === 'autoFillPopup')) {
+					this.map._docLayer.isAutoFillFromOnMouseUp = false;
+					continue;
+				}
+
 				// Call this.close(key, true) for the current dialog
 				this.close(autoFilterDialogId, true);
 			}

--- a/browser/src/control/Control.SheetsBar.js
+++ b/browser/src/control/Control.SheetsBar.js
@@ -69,9 +69,7 @@ L.Control.SheetsBar = L.Control.extend({
 		}
 
 		if (id === 'insertsheet') {
-			if (this.map._docLayer.isAutoFillPopupOpen)
-				this._map.fire('closeautofillpopup');
-
+			this.map._docLayer.isAutoFillFromOnMouseUp = false;
 			var nPos = $('#spreadsheet-tab-scroll')[0].childElementCount;
 			this.map.insertPage(nPos);
 			this.map.insertPage.scrollToEnd = true;

--- a/browser/src/control/Control.SheetsBar.js
+++ b/browser/src/control/Control.SheetsBar.js
@@ -69,6 +69,9 @@ L.Control.SheetsBar = L.Control.extend({
 		}
 
 		if (id === 'insertsheet') {
+			if (this.map._docLayer.isAutoFillPopupOpen)
+				this._map.fire('closeautofillpopup');
+
 			var nPos = $('#spreadsheet-tab-scroll')[0].childElementCount;
 			this.map.insertPage(nPos);
 			this.map.insertPage.scrollToEnd = true;

--- a/browser/src/control/Control.Tabs.js
+++ b/browser/src/control/Control.Tabs.js
@@ -334,9 +334,6 @@ L.Control.Tabs = L.Control.extend({
 		if (part !== this._map._docLayer._selectedPart) {
 			this._setPartIndex(part);
 		}
-
-		if (this._map._docLayer.isAutoFillPopupOpen)
-			this._map.fire('closeautofillpopup');
 	},
 
 	//selected sheet is moved to new index
@@ -429,10 +426,14 @@ L.Control.Tabs = L.Control.extend({
 
 	_showSheet: function() {
 		this._map.showPage();
+		// required for AutoFill popup on empty cells
+		this._map._docLayer.isAutoFillFromOnMouseUp = false;
 	},
 
 	_hideSheet: function() {
 		this._map.hidePage(this._tabForContextMenu);
+		// hiding the active sheet should close the AutoFill popup
+		this._map._docLayer.isAutoFillFromOnMouseUp = false;
 	},
 
 	_handleDragStart: function(e) {

--- a/browser/src/control/Control.Tabs.js
+++ b/browser/src/control/Control.Tabs.js
@@ -334,6 +334,9 @@ L.Control.Tabs = L.Control.extend({
 		if (part !== this._map._docLayer._selectedPart) {
 			this._setPartIndex(part);
 		}
+
+		if (this._map._docLayer.isAutoFillPopupOpen)
+			this._map.fire('closeautofillpopup');
 	},
 
 	//selected sheet is moved to new index

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -220,6 +220,7 @@ L.Control.UIManager = L.Control.extend({
 			this.map.addControl(L.control.mobileWizardPopup());
 
 			this.map.mention = L.control.mention(this.map);
+			this.map.autofilloptions = L.control.autofilloptions(this.map);
 		}
 
 		setupToolbar(this.map);

--- a/browser/src/layer/marker/TextInput.js
+++ b/browser/src/layer/marker/TextInput.js
@@ -1112,6 +1112,26 @@ L.TextInput = L.Layer.extend({
 				this._map.fire('closementionpopup', { 'typingMention': false });
 			}
 		}
+
+		var autoFillPopup = L.DomUtil.get('autoFillPopup');
+		if (autoFillPopup) {
+			if (ev.key === 'ArrowDown') {
+				var initialFocusElement = document.querySelector('#autoFillPopup span');
+				if (initialFocusElement) {
+					initialFocusElement.tabIndex = 0;
+					initialFocusElement.focus();
+					ev.preventDefault();
+					ev.stopPropagation();
+				}
+			} else if (ev.key === 'ArrowLeft' || ev.key === 'ArrowRight' ||
+				ev.key === 'ArrowUp' || ev.key === 'Home' ||
+				ev.key === 'End' || ev.key === 'PageUp' ||
+				ev.key === 'PageDown' || ev.key === 'Enter' ||
+				ev.key === 'Escape' || ev.key === 'Control' ||
+				ev.key === 'Tab' || ev.key === ' ') {
+				this._map.fire('closeautofillpopup', { 'typingMention': false });
+			}
+		}
 	},
 
 	// Check arrow keys on 'keyup' event; using 'ArrowLeft' or 'ArrowRight'

--- a/browser/src/layer/tile/AutoFillMarkerSection.ts
+++ b/browser/src/layer/tile/AutoFillMarkerSection.ts
@@ -208,7 +208,6 @@ class AutoFillMarkerSection extends CanvasSectionObject {
 			this.sectionProperties.docLayer._postMouseEvent('buttonup', pos.x, pos.y, 1, 1, 0);
 		}
 
-		// console.error("--- MOUSE UP");
 		this.map._docLayer.isFromAutoFill = true;
 
 		this.map.scrollingIsHandled = false;

--- a/browser/src/layer/tile/AutoFillMarkerSection.ts
+++ b/browser/src/layer/tile/AutoFillMarkerSection.ts
@@ -208,7 +208,7 @@ class AutoFillMarkerSection extends CanvasSectionObject {
 			this.sectionProperties.docLayer._postMouseEvent('buttonup', pos.x, pos.y, 1, 1, 0);
 		}
 
-		this.map._docLayer.isFromAutoFill = true;
+		this.map._docLayer.isAutoFillFromOnMouseUp = true;
 
 		this.map.scrollingIsHandled = false;
 		this.stopPropagating();

--- a/browser/src/layer/tile/AutoFillMarkerSection.ts
+++ b/browser/src/layer/tile/AutoFillMarkerSection.ts
@@ -208,6 +208,9 @@ class AutoFillMarkerSection extends CanvasSectionObject {
 			this.sectionProperties.docLayer._postMouseEvent('buttonup', pos.x, pos.y, 1, 1, 0);
 		}
 
+		// console.error("--- MOUSE UP");
+		this.map._docLayer.isFromAutoFill = true;
+
 		this.map.scrollingIsHandled = false;
 		this.stopPropagating();
 		e.stopPropagation();

--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -92,8 +92,7 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 		app.sectionContainer.addSection(new app.definitions.AutoFillMarkerSection());
 
 		this.insertMode = false;
-		this.isFromAutoFill = false;
-		this.isAutoFillPopupOpen = false;
+		this.isAutoFillFromOnMouseUp = false;
 		this._resetInternalState();
 		this._sheetSwitch = new L.SheetSwitchViewRestore(map);
 	},

--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -92,6 +92,7 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 		app.sectionContainer.addSection(new app.definitions.AutoFillMarkerSection());
 
 		this.insertMode = false;
+		this.isFromAutoFill = false;
 		this._resetInternalState();
 		this._sheetSwitch = new L.SheetSwitchViewRestore(map);
 	},

--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -93,6 +93,7 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 
 		this.insertMode = false;
 		this.isFromAutoFill = false;
+		this.isAutoFillPopupOpen = false;
 		this._resetInternalState();
 		this._sheetSwitch = new L.SheetSwitchViewRestore(map);
 	},

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -3620,6 +3620,13 @@ L.CanvasTileLayer = L.Layer.extend({
 			var topLeftPixels = this._twipsToCorePixels(topLeftTwips);
 			var offsetPixels = this._twipsToCorePixels(offset);
 			this._cellAutoFillAreaPixels = L.LOUtil.createRectangle(topLeftPixels.x, topLeftPixels.y, offsetPixels.x, offsetPixels.y);
+
+			// if comes from onMouseUp event of browser/src/canvas/sections/AutoFillMarkerSection.ts
+			// open popup with location data
+			if (this._map._docLayer.isFromAutoFill) {
+				this._map.fire('sendautofilllocation', { data: topLeftPixels });
+				this._map._docLayer.isFromAutoFill = false;
+			}
 		}
 		else {
 			this._cellAutoFillAreaPixels = null;

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -3621,11 +3621,10 @@ L.CanvasTileLayer = L.Layer.extend({
 			var offsetPixels = this._twipsToCorePixels(offset);
 			this._cellAutoFillAreaPixels = L.LOUtil.createRectangle(topLeftPixels.x, topLeftPixels.y, offsetPixels.x, offsetPixels.y);
 
-			// if comes from onMouseUp event of browser/src/canvas/sections/AutoFillMarkerSection.ts
-			// open popup with location data
-			if (this._map._docLayer.isFromAutoFill) {
+			// if comes from onMouseUp event of AutoFillMarkerSection.ts, open AutoFill popup with location data
+			if (this._map._docLayer.isAutoFillFromOnMouseUp) {
+				// TODO: don't open AutoFill popup if empty cells are selected
 				this._map.fire('sendautofilllocation', { data: topLeftPixels });
-				this._map._docLayer.isFromAutoFill = false;
 			}
 		}
 		else {

--- a/browser/src/map/handler/Map.Keyboard.js
+++ b/browser/src/map/handler/Map.Keyboard.js
@@ -914,6 +914,10 @@ L.Map.Keyboard = L.Handler.extend({
 						else {
 							partToSelect = currentSelectedPart != 0 ? currentSelectedPart - 1 : parts - 1;
 						}
+
+						if (this._map._docLayer.isAutoFillPopupOpen)
+							this._map.fire('closeautofillpopup');
+
 						this._map.setPart(parseInt(partToSelect), /*external:*/ false, /*calledFromSetPartHandler:*/ true);
 						return;
 					}

--- a/browser/src/map/handler/Map.Keyboard.js
+++ b/browser/src/map/handler/Map.Keyboard.js
@@ -914,10 +914,6 @@ L.Map.Keyboard = L.Handler.extend({
 						else {
 							partToSelect = currentSelectedPart != 0 ? currentSelectedPart - 1 : parts - 1;
 						}
-
-						if (this._map._docLayer.isAutoFillPopupOpen)
-							this._map.fire('closeautofillpopup');
-
 						this._map.setPart(parseInt(partToSelect), /*external:*/ false, /*calledFromSetPartHandler:*/ true);
 						return;
 					}


### PR DESCRIPTION
AutoFill popup has two options:
- Copy cells
- Fill series

requires: https://gerrit.libreoffice.org/c/core/+/167726
5ab9b63e6624947a6076a01f9bab0d7a925e0e40

Change-Id: I08ad88afad1bb6bd2d746a9a8964f1b4446ae7c7


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
- This enhancement is for co-23.05

- Added UI
- close AutoFill popup when
  - sheet tab is clicked
  - new sheet is inserted
  - sheet tab is switched using Ctrl+Alt+PageUp/PageDown keyboard shortcuts
- Added functionalities for "Copy cells" and "Fill series".
- close AutoFill popup on some contextmenu entries from sheet tabs
  - insert sheet before/after
  - delete / hide / show sheet


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

