### PR TITLE
fix(zoom,pan): Make screen edge offset document

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -672,9 +672,11 @@ L.TileSectionManager = L.Class.extend({
 			yMin = splitPos.y;
 		}
 
-		const documentTopLeft = new L.Point(xMin, yMin);
+		const minTopLeft = new L.Point(xMin, yMin);
 
 		const paneSize = paneBounds.getSize();
+
+		pinchCenter = pinchCenter.subtract(this._offset);
 
 		let centerOffset = {
 			x: pinchCenter.x - pinchStartCenter.x,
@@ -683,26 +685,39 @@ L.TileSectionManager = L.Class.extend({
 
 		// Portion of the pane away that our pinchStart (which should be where we zoom round) is
 		const panePortion = {
-			x: (pinchStartCenter.x - paneBounds.min.x) / paneSize.x,
-			y: (pinchStartCenter.y - paneBounds.min.y) / paneSize.y,
+			x: (pinchStartCenter.x - this._offset.x - paneBounds.min.x) / paneSize.x,
+			y: (pinchStartCenter.y - this._offset.y - paneBounds.min.y) / paneSize.y,
 		};
 
-		// Top left in document coordinates.
-		const docTopLeft = new L.Point(
-			Math.max(documentTopLeft.x, pinchStartCenter.x + (centerOffset.x - paneSize.x * panePortion.x) / scale),
-			Math.max(documentTopLeft.y, pinchStartCenter.y + (centerOffset.y - paneSize.y * panePortion.y) / scale)
+		let docTopLeft = new L.Point(
+			pinchStartCenter.x + (centerOffset.x - paneSize.x * panePortion.x) / scale,
+			pinchStartCenter.y + (centerOffset.y - paneSize.y * panePortion.y) / scale
 		);
+
+		// Top left in document coordinates.
+		const clampedDocTopLeft = new L.Point(
+			Math.max(minTopLeft.x, docTopLeft.x),
+			Math.max(minTopLeft.y, docTopLeft.y)
+		);
+
+		const offset = clampedDocTopLeft.subtract(docTopLeft);
 
 		if (freezePane.freezeX) {
 			docTopLeft.x = paneBounds.min.x;
+		} else {
+			this._offset.x = Math.round(Math.max(this._offset.x, offset.x));
+			docTopLeft.x += this._offset.x;
 		}
 
 		if (freezePane.freezeY) {
 			docTopLeft.y = paneBounds.min.y;
+		} else {
+			this._offset.y = Math.round(Math.max(this._offset.y, offset.y));
+			docTopLeft.y += this._offset.y;
 		}
 
 		if (!findFreePaneCenter) {
-			return { topLeft: docTopLeft };
+			return { offset: this._offset, topLeft: docTopLeft };
 		}
 
 		const newPaneCenter = new L.Point(
@@ -710,7 +725,8 @@ L.TileSectionManager = L.Class.extend({
 			(docTopLeft.y - splitPos.y + (paneSize.y + splitPos.y) * 0.5 / scale) / app.dpiScale);
 
 		return {
-			topLeft: docTopLeft,
+			offset: this._offset,
+			topLeft: docTopLeft.add(this._offset),
 			center: this._map.project(this._map.unproject(newPaneCenter, this._map.getZoom()), this._map.getScaleZoom(scale))
 		};
 	},
@@ -5380,6 +5396,7 @@ L.CanvasTileLayer = L.Layer.extend({
 
 	preZoomAnimation: function (pinchStartCenter) {
 		this._pinchStartCenter = this._map.project(pinchStartCenter).multiplyBy(app.dpiScale); // in core pixels
+		this._painter._offset = new L.Point(0, 0);
 
 		if (this.isCursorVisible()) {
 			this._cursorMarker.setOpacity(0);

--- a/browser/src/map/handler/Map.Drag.js
+++ b/browser/src/map/handler/Map.Drag.js
@@ -39,6 +39,8 @@ L.Map.Drag = L.Handler.extend({
 	},
 
 	_onDragStart: function () {
+		this._dragEdgeOffset = new L.Point(0, 0);
+
 		var map = this._map;
 
 		map
@@ -56,12 +58,23 @@ L.Map.Drag = L.Handler.extend({
 		var org = this._map.getPixelOrigin();
 		var pos = this._map._getMapPanePos();
 		var size = this._map.getLayerMaxBounds().getSize().subtract(this._map.getSize());
+
 		if (this._draggable._newPos.x !== pos.x) {
-			this._draggable._newPos.x = Math.max(Math.min(org.x, this._draggable._newPos.x), org.x - Math.max(size.x, 0));
+			let clampedX = Math.max(
+				Math.min(org.x, this._draggable._newPos.x),
+				org.x - Math.max(size.x, 0)
+			);
+			this._dragEdgeOffset.x = Math.min(this._dragEdgeOffset.x, clampedX - this._draggable._newPos.x);
+			this._draggable._newPos.x = this._draggable._newPos.x + this._dragEdgeOffset.x;
 		}
 
 		if (this._draggable._newPos.y !== pos.y) {
-			this._draggable._newPos.y = Math.max(Math.min(org.y, this._draggable._newPos.y), org.y - Math.max(size.y, 0));
+			let clampedY = Math.max(
+				Math.min(org.y, this._draggable._newPos.y),
+				org.y - Math.max(size.y, 0)
+			);
+			this._dragEdgeOffset.y = Math.min(this._dragEdgeOffset.y, clampedY - this._draggable._newPos.y);
+			this._draggable._newPos.y = this._draggable._newPos.y + this._dragEdgeOffset.y;
 		}
 	},
 


### PR DESCRIPTION
Zooming always leads to same backwards and forwards, even when you have
hit the screen edge. At the edge of the screen, you can move no further,
which causes the illusion of it being "sticky" on the return journey.

By adding an offset when we reach the edge, we can avoid the stickiness.

I have made
panning past the document edge create an offset too. This provides
similar benefits to the fluidity of scrolling at document edges.
