### PR TITLE
fix(userlist): XSS escaping: fix double escape

### DIFF
--- a/browser/src/control/Control.UserList.js
+++ b/browser/src/control/Control.UserList.js
@@ -100,7 +100,7 @@ L.Control.UserList = L.Control.extend({
 		w2ui['actionbar'].uncheck('userlist');
 	},
 
-	createAvatar: function (viewId, userName, extraInfo, color) {
+	createAvatar: function (viewId, extraInfo, color) {
 		var img;
 		if (extraInfo !== undefined && extraInfo.avatar !== undefined) {
 			img = L.DomUtil.create('img', 'avatar-img');
@@ -122,7 +122,7 @@ L.Control.UserList = L.Control.extend({
 		var iconTd = L.DomUtil.create('td', 'usercolor', content);
 		var nameTd = L.DomUtil.create('td', 'username cool-font', content);
 
-		iconTd.appendChild(this.createAvatar(viewId, userName, extraInfo, color));
+		iconTd.appendChild(this.createAvatar(viewId, extraInfo, color));
 		nameTd.textContent = userName;
 
 		return content;
@@ -184,7 +184,7 @@ L.Control.UserList = L.Control.extend({
 		// Summary rendering
 		headerUserList.forEach(function (user) {
 			if (!document.querySelector('#userListSummary [data-view-id="' + user.viewId + '"]')) {
-				document.getElementById('userListSummary').appendChild(this.createAvatar(user.viewId, user.userName, user.extraInfo, user.color));
+				document.getElementById('userListSummary').appendChild(this.createAvatar(user.viewId, user.extraInfo, user.color));
 			}
 		}.bind(this));
 
@@ -206,7 +206,7 @@ L.Control.UserList = L.Control.extend({
 			var listItem = L.DomUtil.create('div', 'user-list-item');
 			listItem.setAttribute('data-view-id', user.viewId);
 			listItem.setAttribute('role', 'button');
-			listItem.appendChild(this.createAvatar(user.viewId, user.userName, user.extraInfo, user.color));
+			listItem.appendChild(this.createAvatar(user.viewId, user.extraInfo, user.color));
 			listItem.appendChild(userLabelContainer);
 			listItem.addEventListener('click', function () {
 				this.followUser(user.viewId);
@@ -310,7 +310,6 @@ L.Control.UserList = L.Control.extend({
 
 	onAddView: function(e) {
 		var userlistItem = w2ui['actionbar'].get('userlist');
-		var username = this.escapeHtml(e.username);
 		var showPopup = false;
 
 		if (userlistItem !== null)
@@ -320,7 +319,7 @@ L.Control.UserList = L.Control.extend({
 			$('#tb_actionbar_item_userlist')
 				.w2overlay({
 					class: 'cool-font',
-					html: this.options.userJoinedPopupMessage.replace('%user', username),
+					html: this.options.userJoinedPopupMessage.replace('%user', this.escapeHtml(e.username)),
 					style: 'padding: 5px'
 				});
 			clearTimeout(this.options.userPopupTimeout);
@@ -332,6 +331,7 @@ L.Control.UserList = L.Control.extend({
 			}, 3000);
 		}
 
+		var username = e.username;
 		var color = L.LOUtil.rgbToHex(this.map.getViewColor(e.viewId));
 		if (e.viewId === this.map._docLayer._viewId) {
 			username = _('You');


### PR DESCRIPTION
Previously we escaped usernames as soon as we got them in onAddView. Unfortunately, this led to some inconsistent behavior at the output, where we used a mixture of functions setting HTML directly and innerText/textContent attributes.

Sometimes this led to "double-escaping", where a username like '<script>' would initially be escaped to '&lt;script&gt;', and then further escaped to '&amp;lt&semi;script&amp;gt&semi;'. When this was displayed, it would incorrectly be shown to the user as'&lt;script&gt;'.

This commit moves escaping so it's always when we are about to display the username, either with innerText/textContent, or with our escapeHtml method

This was also fixed in 24.04 by a major refactor of the userlist, so there's no need to forward-port this fix

As this commit is touching security-related code, it needs 2 reviewer sign-offs


Change-Id: Idcc5c09ce453315790dd4474996313c1ad79f379


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

