### PR TITLE
backport: dragging: Fix undefined _map error

### DIFF
--- a/browser/src/dom/Draggable.js
+++ b/browser/src/dom/Draggable.js
@@ -120,11 +120,11 @@ L.Draggable = L.Evented.extend({
 		    newPoint = new L.Point(first.clientX, first.clientY),
 		    offset = newPoint.subtract(this._startPoint);
 
-		if (this._map._docLayer.isCalcRTL()) {
-			offset.x = -offset.x;
-		}
-
 		if (this._map) {
+			if (this._map._docLayer.isCalcRTL()) {
+				offset.x = -offset.x;
+			}
+
 			// needed in order to avoid a jump when the document is dragged and the mouse pointer move
 			// from over the map into the html document element area which is not covered by tiles
 			// (resize-detector iframe)


### PR DESCRIPTION
In Iea4d16918b054d355e6d8695e0dc1d6ededd6793, a regression was introduced where we would check for a specific property of _map when dragging anything. This was needed only in calc to determine the RTLness of the sheet. Unfortunately, _map can sometimes be undefined (such as when dragging around a comment in impress or when resizing a table in writer).

By moving the RTL check so it only executes if there is a map, we can avoid this error, but the check will still run where it needs to.

This is a backport of https://github.com/CollaboraOnline/online/pull/8632

Change-Id: I9994a3957e37975360126fab33ba08e807d723dd


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

