### PR TITLE
net: fix clang-15 build in resolveDNS()

### DIFF
--- a/net/NetUtil.cpp
+++ b/net/NetUtil.cpp
@@ -62,7 +62,7 @@ Poco::Net::HostEntry resolveDNS(const std::string& addressToCheck)
 
     // lookup and cache
     auto hostEntry = Poco::Net::DNS::resolve(addressToCheck);
-    queries.push_back(DNSCacheEntry(addressToCheck, hostEntry, now));
+    queries.push_back(DNSCacheEntry{addressToCheck, hostEntry, now});
     return hostEntry;
 }
 


### PR DESCRIPTION
net/NetUtil.cpp:65:23: error: no matching constructor for initialization of 'net::DNSCacheEntry'
    queries.push_back(DNSCacheEntry(addressToCheck, hostEntry, now));
                      ^             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Went wrong in commit 5be3ccc8718c93c5e60ab6b6ace9b8747d0e1aa0 (cache DNS
results for 20 seconds, 2024-05-14), the rest of the code builds with
this toolchain.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Idc8ed4d88a7f955cf2cdc1e10ac9931823950126
