### PR TITLE
Status bar: Fix MenuButtons being generated always with image

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2332,10 +2332,15 @@ L.Control.JSDialogBuilder = L.Control.extend({
 
 		var isRealUnoCommand = true;
 		var hasPopUp = false;
+		var hasImage = true;
 
 		if (data.text && data.text.endsWith('...')) {
 			data.text = data.text.replace('...', '');
 			hasPopUp = true;
+		}
+
+		if (data && data.image === false) {
+			hasImage = false;
 		}
 
 		if (data.command || data.postmessage === true) {
@@ -2374,17 +2379,21 @@ L.Control.JSDialogBuilder = L.Control.extend({
 				// FIXME: DEPRECATED, this is legacy way to setup icon based on CSS class
 				var buttonImage = L.DomUtil.create('div', 'w2ui-icon ' + data.w2icon, button);
 			}
-			else if (data.icon) {
-				buttonImage = L.DomUtil.create('img', '', button);
-				this._isStringCloseToURL(data.icon) ? buttonImage.src = data.icon : L.LOUtil.setImage(buttonImage, data.icon, builder.map);
-			}
-			else if (data.image) {
-				buttonImage = L.DomUtil.create('img', '', button);
-				buttonImage.src =  data.image;
-			}
-			else {
-				buttonImage = L.DomUtil.create('img', '', button);
-				L.LOUtil.setImage(buttonImage, builder._createIconURL(data.command), builder.map);
+			else if (hasImage !== false){
+				if (data.icon) {
+					buttonImage = L.DomUtil.create('img', '', button);
+					this._isStringCloseToURL(data.icon) ? buttonImage.src = data.icon : L.LOUtil.setImage(buttonImage, data.icon, builder.map);
+				}
+				else if (data.image) {
+					buttonImage = L.DomUtil.create('img', '', button);
+					buttonImage.src = data.image;
+				}
+				else {
+					buttonImage = L.DomUtil.create('img', '', button);
+					L.LOUtil.setImage(buttonImage, builder._createIconURL(data.command), builder.map);
+				}
+			} else {
+				buttonImage = false;
 			}
 
 			controls['button'] = button;
@@ -2393,7 +2402,9 @@ L.Control.JSDialogBuilder = L.Control.extend({
 				label.htmlFor = buttonId;
 				label.textContent = builder._cleanText(data.text);
 				button.setAttribute('alt', label.textContent);
-				buttonImage.alt = label.textContent;
+				if (buttonImage !== false) {
+					buttonImage.alt = label.textContent;
+				}
 				builder._stressAccessKey(label, button.accessKey);
 				controls['label'] = label;
 				$(div).addClass('has-label');
@@ -2402,7 +2413,9 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			} else {
 				div.title = data.text;
 				button.setAttribute('alt', data.text);
-				buttonImage.alt = data.text;
+				if (buttonImage !== false) {
+					buttonImage.alt = data.text;
+				}
 				builder.map.uiManager.enableTooltip(div);
 				$(div).addClass('no-label');
 			}

--- a/browser/src/control/Control.StatusBar.js
+++ b/browser/src/control/Control.StatusBar.js
@@ -194,7 +194,7 @@ class StatusBar extends JSDialog.Toolbar {
 		];
 		var selected = submenu.filter((item) => { return item.id === value; });
 		var text = selected.length ? selected[0].text : _('None');
-		return {type: 'menubutton', id: 'StateTableCellMenu', text: text, menu: submenu, visible: visible};
+		return {type: 'menubutton', id: 'StateTableCellMenu', text: text, image: false, menu: submenu, visible: visible};
 	}
 
 	_generateZoomItems() {


### PR DESCRIPTION
Before this commit menu buttons were always generated with img even if
it's not applicable. Example, the StateTableCellMenu (located in Calc
status bar that allows setting a state according to the function
chosen in the submenu): This text-only menu was generated with img
and thus throwing a 404 error in the console.

- Allow any unoToolButton to be set without image via option
- Add image: false option when setting StateTableCellMenu in the
statusbar

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I3fc3b5954f80229835526819b9b80d2a650bd922
