### PR TITLE
Fix failing test mobile/impress/apply_paragraph_props_text_spec.js

### DIFF
--- a/cypress_test/integration_tests/desktop/impress/apply_paragraph_props_text_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/apply_paragraph_props_text_spec.js
@@ -9,106 +9,113 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Apply paragraph properties
 	beforeEach(function() {
 		helper.setupAndLoadDocument('impress/apply_paragraph_props_text.odp');
 		desktopHelper.switchUIToCompact();
-		cy.cGet('#toolbar-up > .ui-scroll-right').click();
-		cy.cGet('#modifypage').click({force: true});
-		impressHelper.selectTextShapeInTheCenter();
+		cy.cGet('#modifypage').scrollIntoView();
+		cy.cGet('#modifypage button').click();
+		cy.cGet('#sidebar-panel').should('not.be.visible');
 	});
 
-	it('Apply left/right alignment on selected text.', function() {
+	function selectText() {
+		// Select the text in the shape by double
+		// clicking in the center of the shape,
+		// which is in the center of the slide,
+		// which is in the center of the document
+
+		// Only the svg (shape selection) is needed for the verifications,
+		// but the text needs to be selected for the subsequent button clicks
+
+		cy.cGet('#document-container').dblclick('center');
+		helper.typeIntoDocument('{ctrl}a');
+		helper.textSelectionShouldExist();
+	}
+
+	it('Apply horizontal alignment on selected text.', function() {
+		selectText();
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition')
 			.should('have.attr', 'x', '1400');
 
-		impressHelper.selectTextOfShape();
+		// Set right alignment
 		cy.cGet('#rightpara').click();
-		impressHelper.triggerNewSVGForShapeInTheCenter();
+
+		impressHelper.removeShapeSelection();
+		selectText();
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition')
 			.should('have.attr', 'x', '23586');
 
+		// Set left alignment
 		cy.cGet('#leftpara').click();
-		impressHelper.triggerNewSVGForShapeInTheCenter();
 
-		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition')
-			.should('have.attr', 'x', '1400');
-	});
-
-	it('Apply center alignment on selected text.', function() {
+		impressHelper.removeShapeSelection();
+		selectText();
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition')
 			.should('have.attr', 'x', '1400');
 
-		impressHelper.selectTextOfShape();
+		// Set centered alignment
 		cy.cGet('#centerpara').click();
-		impressHelper.triggerNewSVGForShapeInTheCenter();
 
+		impressHelper.removeShapeSelection();
+		selectText();
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition')
 			.should('have.attr', 'x', '12493');
-	});
 
-	it('Apply justified alignment on selected text.', function() {
-		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition')
-			.should('have.attr', 'x', '1400');
-
-		impressHelper.selectTextOfShape();
-		cy.cGet('#rightpara').click();
-		impressHelper.triggerNewSVGForShapeInTheCenter();
-
-		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition')
-			.should('have.attr', 'x', '23586');
-
-		impressHelper.selectTextOfShape();
+		// Set justified alignment
 		cy.cGet('#justifypara').click();
-		impressHelper.triggerNewSVGForShapeInTheCenter();
 
+		impressHelper.removeShapeSelection();
+		selectText();
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition')
 			.should('have.attr', 'x', '1400');
 	});
 
 	it('Apply default bulleting on selected text.', function() {
+		selectText();
 		// We have no bulleting by default
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .BulletChars')
 			.should('not.exist');
 
-		impressHelper.selectTextOfShape();
+		// Apply bulleting
 		cy.cGet('#defaultbullet').click();
-		impressHelper.triggerNewSVGForShapeInTheCenter();
 
+		impressHelper.removeShapeSelection();
+		selectText();
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .BulletChars')
 			.should('exist');
 	});
 
 	it('Apply default numbering on selected text.', function() {
+		selectText();
 		// We have no bulleting by default
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .SVGTextShape tspan')
 			.should('not.have.attr', 'ooo:numbering-type');
 
-		impressHelper.selectTextOfShape();
+		// Apply numbering
 		cy.cGet('#defaultnumbering').click();
-		impressHelper.triggerNewSVGForShapeInTheCenter();
 
+		impressHelper.removeShapeSelection();
+		selectText();
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .SVGTextShape tspan')
 			.should('have.attr', 'ooo:numbering-type', 'number-style');
 	});
 
 	it('Increase/decrease spacing of selected text.', function() {
+		selectText();
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph:nth-of-type(2) tspan')
 			.should('have.attr', 'y', '6600');
 
-		impressHelper.selectTextOfShape();
-		// Need to wait for click to work, not sure why
-		cy.wait(500);
+		// Increase spacing
 		cy.cGet('#linespacing').click();
 		cy.cGet('#linespacing-dropdown .ui-combobox-entry').contains('Increase Paragraph Spacing').click();
 
-		impressHelper.triggerNewSVGForShapeInTheCenter();
-
+		impressHelper.removeShapeSelection();
+		selectText();
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph:nth-of-type(2) tspan')
 			.should('have.attr', 'y', '6700');
 
-		impressHelper.selectTextOfShape();
+		// Decrease spacing
 		cy.cGet('#linespacing').click();
 		cy.cGet('#linespacing-dropdown .ui-combobox-entry').contains('Decrease Paragraph Spacing').click();
 
-		impressHelper.triggerNewSVGForShapeInTheCenter();
-
+		impressHelper.removeShapeSelection();
+		selectText();
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph:nth-of-type(2) tspan')
 			.should('have.attr', 'y', '6600');
 	});

--- a/cypress_test/integration_tests/mobile/impress/apply_paragraph_props_text_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/apply_paragraph_props_text_spec.js
@@ -8,318 +8,270 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Apply paragraph properties 
 
 	beforeEach(function() {
 		helper.setupAndLoadDocument('impress/apply_paragraph_props_text.odp');
-
 		mobileHelper.enableEditingMobile();
-
-		impressHelper.selectTextShapeInTheCenter();
 	});
 
-	function triggerNewSVG() {
-		mobileHelper.closeMobileWizard();
-		impressHelper.triggerNewSVGForShapeInTheCenter();
+	function selectText() {
+		// Select the text in the shape by double
+		// clicking in the center of the shape,
+		// which is in the center of the slide,
+		// which is in the center of the document
+
+		// Only the svg (shape selection) is needed for the verifications,
+		// but the text needs to be selected for the subsequent button clicks
+
+		cy.cGet('#document-container').dblclick('center');
+		helper.typeIntoDocument('{ctrl}a');
+		helper.textSelectionShouldExist();
 	}
 
 	function openParagraphPropertiesPanel() {
 		mobileHelper.openMobileWizard();
-
 		cy.cGet('#ParaPropertyPanel').click();
-
 		cy.cGet('.unoParaLeftToRight').should('be.visible');
 	}
 
 	function openListsPropertiesPanel() {
 		mobileHelper.openMobileWizard();
-
 		cy.cGet('#ListsPropertyPanel').click();
-
 		cy.cGet('.unoDefaultBullet').should('be.visible');
 	}
 
-	it('Apply left/right alignment on selected text.', function() {
+	it('Apply horizontal alignment on selected text.', function() {
+		selectText();
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition')
 			.should('have.attr', 'x', '1400');
 
-		impressHelper.selectTextOfShape();
-
 		// Set right alignment first
 		openParagraphPropertiesPanel();
-
 		cy.cGet('.unoRightPara').click();
+		mobileHelper.closeMobileWizard();
 
-		triggerNewSVG();
-
+		impressHelper.removeShapeSelection();
+		selectText();
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition')
 			.should('have.attr', 'x', '23586');
 
 		// Set left alignment
-		impressHelper.selectTextOfShape();
-
 		openParagraphPropertiesPanel();
-
 		cy.cGet('.unoLeftPara').click();
+		mobileHelper.closeMobileWizard();
 
-		triggerNewSVG();
-
-		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition')
-			.should('have.attr', 'x', '1400');
-	});
-
-	it('Apply center alignment on selected text.', function() {
+		impressHelper.removeShapeSelection();
+		selectText();
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition')
 			.should('have.attr', 'x', '1400');
 
-		impressHelper.selectTextOfShape();
-
+		// Set center alignment
 		openParagraphPropertiesPanel();
-
 		cy.cGet('.unoCenterPara').click();
+		mobileHelper.closeMobileWizard();
 
-		triggerNewSVG();
-
+		impressHelper.removeShapeSelection();
+		selectText();
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition')
 			.should('have.attr', 'x', '12493');
-	});
 
-	it('Apply justified alignment on selected text.', function() {
-		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition')
-			.should('have.attr', 'x', '1400');
-
-		impressHelper.selectTextOfShape();
-
-		// Set right alignment first
+		// Set justified alignment
 		openParagraphPropertiesPanel();
-
-		cy.cGet('.unoRightPara').click();
-
-		triggerNewSVG();
-
-		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition')
-			.should('have.attr', 'x', '23586');
-
-		impressHelper.selectTextOfShape();
-
-		// Then set justified alignment
-		openParagraphPropertiesPanel();
-
 		cy.cGet('.unoJustifyPara').click();
+		mobileHelper.closeMobileWizard();
 
-		triggerNewSVG();
-
+		impressHelper.removeShapeSelection();
+		selectText();
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition')
 			.should('have.attr', 'x', '1400');
 	});
 
-	it('Set top/bottom alignment on selected text.', function() {
+	it('Apply vertical alignment on selected text.', function() {
+		selectText();
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition')
 			.should('have.attr', 'y', '4834');
 
-		impressHelper.selectTextOfShape();
-
-		// Set bottom alignment first
+		// Set bottom alignment
 		openParagraphPropertiesPanel();
-
 		cy.cGet('.unoCellVertBottom').click();
+		mobileHelper.closeMobileWizard();
 
-		triggerNewSVG();
-
+		impressHelper.removeShapeSelection();
+		selectText();
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition')
 			.should('have.attr', 'y', '10811');
 
-		impressHelper.selectTextOfShape();
-
-		// Then set top alignment
+		// Set top alignment
 		openParagraphPropertiesPanel();
-
 		cy.cGet('.unoCellVertTop').click();
+		mobileHelper.closeMobileWizard();
 
-		triggerNewSVG();
-
-		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition')
-			.should('have.attr', 'y', '4834');
-	});
-
-	it('Apply center vertical alignment on selected text.', function() {
+		impressHelper.removeShapeSelection();
+		selectText();
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition')
 			.should('have.attr', 'y', '4834');
 
-		impressHelper.selectTextOfShape();
-
+		// Set center alignment
 		openParagraphPropertiesPanel();
-
 		cy.cGet('.unoCellVertCenter').click();
+		mobileHelper.closeMobileWizard();
 
-		triggerNewSVG();
-
-		cy.wait(2000);
-
+		impressHelper.removeShapeSelection();
+		selectText();
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition').should('have.attr', 'y');
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition').invoke('attr', 'y').then(parseInt).should('be.closeTo', 7822, 5);
 	});
 
 	it('Apply default bulleting on selected text.', function() {
+		selectText();
 		// We have no bulleting by default
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .BulletChars')
 			.should('not.exist');
 
-		impressHelper.selectTextOfShape();
-
+		// Apply bulleting
 		openListsPropertiesPanel();
-
 		cy.cGet('#ListsPropertyPanel .unoDefaultBullet').click();
+		mobileHelper.closeMobileWizard();
 
-		triggerNewSVG();
-
+		impressHelper.removeShapeSelection();
+		selectText();
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .BulletChars')
 			.should('exist');
 	});
 
-	it.skip('Apply default numbering on selected text.', function() {
+	it('Apply default numbering on selected text.', function() {
+		selectText();
 		// We have no bulleting by default
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .SVGTextShape tspan')
 			.should('not.have.attr', 'ooo:numbering-type');
 
-		impressHelper.selectTextOfShape();
-
+		// Apply numbering
 		openListsPropertiesPanel();
-
 		cy.cGet('#ListsPropertyPanel .unoDefaultNumbering').click();
+		mobileHelper.closeMobileWizard();
 
-		triggerNewSVG();
-
-		// TODO: SVG does not get retriggered
-
+		impressHelper.removeShapeSelection();
+		selectText();
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .SVGTextShape tspan')
 			.should('have.attr', 'ooo:numbering-type', 'number-style');
 	});
 
 	it('Apply spacing above on selected text.', function() {
+		selectText();
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph:nth-of-type(2) tspan')
 			.should('have.attr', 'y', '6600');
 
-		impressHelper.selectTextOfShape();
-
+		// Apply spacing above
 		openParagraphPropertiesPanel();
-
 		helper.typeIntoInputField('#aboveparaspacing input', '2', true, false);
+		mobileHelper.closeMobileWizard();
 
-		triggerNewSVG();
-
+		impressHelper.removeShapeSelection();
+		selectText();
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph:nth-of-type(2) tspan')
 			.should('have.attr', 'y', '11180');
 	});
 
 	it('Apply spacing below on selected text.', function() {
+		selectText();
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph:nth-of-type(2) tspan')
 			.should('have.attr', 'y', '6600');
 
-		impressHelper.selectTextOfShape();
-
+		// Apply spacing below
 		openParagraphPropertiesPanel();
-
 		helper.typeIntoInputField('#belowparaspacing input', '2', true, false);
+		mobileHelper.closeMobileWizard();
 
-		triggerNewSVG();
-
+		impressHelper.removeShapeSelection();
+		selectText();
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph:nth-of-type(2) tspan')
 			.should('have.attr', 'y', '11180');
 	});
 
 	it('Increase/decrease spacing of selected text.', function() {
+		selectText();
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph:nth-of-type(2) tspan')
 			.should('have.attr', 'y', '6600');
 
-		impressHelper.selectTextOfShape();
-
+		// Increase spacing
 		openParagraphPropertiesPanel();
-
 		cy.cGet('.unoParaspaceIncrease').click();
+		mobileHelper.closeMobileWizard();
 
-		triggerNewSVG();
-
+		impressHelper.removeShapeSelection();
+		selectText();
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph:nth-of-type(2) tspan')
 			.should('have.attr', 'y', '6700');
 
-		impressHelper.selectTextOfShape();
-
+		// Decrease spacing
 		openParagraphPropertiesPanel();
-
 		cy.cGet('.unoParaspaceDecrease').click();
+		mobileHelper.closeMobileWizard();
 
-		triggerNewSVG();
-
+		impressHelper.removeShapeSelection();
+		selectText();
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph:nth-of-type(2) tspan')
 			.should('have.attr', 'y', '6600');
 	});
 
 	it('Change writing direction of selected text.', function() {
+		selectText();
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition')
 			.should('have.attr', 'x', '1400');
 
 		// Change right-to-left first
-		impressHelper.selectTextOfShape();
-
 		openParagraphPropertiesPanel();
-
 		cy.cGet('.unoParaRightToLeft').click();
+		mobileHelper.closeMobileWizard();
 
-		triggerNewSVG();
-
+		impressHelper.removeShapeSelection();
+		selectText();
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition')
 			.should('have.attr', 'x', '23586');
 
 		// Change back to the default left-to-right
-		impressHelper.selectTextOfShape();
-
 		openParagraphPropertiesPanel();
-
 		cy.cGet('.unoParaLeftToRight').click();
+		mobileHelper.closeMobileWizard();
 
-		triggerNewSVG();
-
+		impressHelper.removeShapeSelection();
+		selectText();
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .TextParagraph .TextPosition')
 			.should('have.attr', 'x', '1400');
 	});
 
 	it('Change bulleting level of selected text.', function() {
+		selectText();
 		// We have no bulleting by default
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .BulletChars')
 			.should('not.exist');
 
 		// Apply bulleting first
-		impressHelper.selectTextOfShape();
-
 		openListsPropertiesPanel();
-
 		cy.cGet('#ListsPropertyPanel .unoDefaultBullet').click();
+		mobileHelper.closeMobileWizard();
 
-		triggerNewSVG();
-
+		impressHelper.removeShapeSelection();
+		selectText();
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .BulletChars')
 			.should('exist');
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .BulletChar:nth-of-type(2) g')
 			.should('have.attr', 'transform', 'translate(1700,4563)');
 
 		// Change bulleting level
-		impressHelper.selectTextOfShape();
-
 		openListsPropertiesPanel();
-
 		cy.cGet('.unoOutlineRight').click();
+		mobileHelper.closeMobileWizard();
 
-		triggerNewSVG();
-
+		impressHelper.removeShapeSelection();
+		selectText();
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .BulletChar:nth-of-type(2) g')
 			.should('have.attr', 'transform', 'translate(2900,4536)');
 
 		// Change bulleting level back to default
-		impressHelper.selectTextOfShape();
-
 		openListsPropertiesPanel();
-
 		cy.cGet('.unoOutlineLeft').click();
+		mobileHelper.closeMobileWizard();
 
-		triggerNewSVG();
-
+		impressHelper.removeShapeSelection();
+		selectText();
 		cy.cGet('.leaflet-pane.leaflet-overlay-pane g.Page .BulletChar:nth-of-type(2) g')
 			.should('have.attr', 'transform', 'translate(1700,4563)');
 	});


### PR DESCRIPTION
Another test failing because of shape selection.
Select text directly and remove calls to shape selection helpers. Unskip a testpoint.
Merge horizontal alignment testpoints (also vertical alignment testpoints).

Similar to https://github.com/CollaboraOnline/online/pull/9020

Change-Id: I729870d6cd43457d2297005f4c815fe29de39f42