### PR TITLE
postmessage: Fix show hide / button / command in Notebookbar

### DIFF
--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -336,7 +336,7 @@ L.Control.Notebookbar = L.Control.extend({
 	},
 
 	showNotebookbarButton: function(buttonId, show) {
-		var button = $(this.container).children('#' + buttonId);
+		var button = $(this.container).find('#' + buttonId);
 		if (show) {
 			button.show();
 		} else {
@@ -344,14 +344,14 @@ L.Control.Notebookbar = L.Control.extend({
 		}
 	},
 
-    showNotebookbarCommand: function(commandId, show) {
+	showNotebookbarCommand: function(commandId, show) {
 		var cssClass;
 		if (commandId.indexOf('.uno:') == 0) {
 			cssClass = 'uno' + commandId.substring(5);
 		} else {
 			cssClass = commandId;
 		}
-		var button = $(this.container).children('div.' + cssClass);
+		var button = $(this.container).find('div.' + cssClass);
 		if (show) {
 			button.show();
 		} else {


### PR DESCRIPTION
This is a regression from commit 9923e695959
This is because jQuery .child() is only for the direct descendants. Use .find() instead which will search down the DOM tree.

This restore postmessage Hide_Command / Hide_Button and Show.


Change-Id: Ibe84c520c9786c6c0026d3507a27a8d3580b38a0


* Resolves: # <!-- related github issue -->
* Target version: master (24.04)

### Summary

This is in 24.04 only

### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

