### PR TITLE
jsdailog:css: increase width to fit content in manage changes dialog

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -42,6 +42,15 @@
 	min-width: 400px;
 }
 
+.jsdialog-container:not(.snackbar) td[role='gridcell'] {
+	padding-left: 5px;
+	padding-right: 5px;
+}
+
+#AcceptRejectChangesDialog {
+	width: max-content;
+	max-width: 1000px;
+}
 .jsdialog.one-child-popup {
 	border: 0;
 	margin: 0 !important;


### PR DESCRIPTION
increased jsdialog width to fit content when necessary. max width is set to 1000px because some other dialog(i.e: Zotero) already uses tree widget width 800px which makes the entire dialog approx 990px.

removed margin from icon to make it look even spaced in listview (i.e: manage changes, zotero add citation)


Change-Id: I225b5b5d42d573cb4afcdb428e2eb3b81aa99073


* Target version: master 


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

