### PR TITLE
browser: display unauthorized error message

### DIFF
--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -988,7 +988,13 @@ app.definitions.Socket = L.Class.extend({
 				this._map.fire('error', {msg: errorMessages.diskfull});
 			}
 			else if (command.errorKind === 'unauthorized') {
-				this._map.fire('error', {msg: errorMessages.unauthorized});
+				var postMessageObj = {
+					errorType: 'websocketunauthorized',
+					success: false,
+					errorMsg: errorMessages.unauthorized,
+					result: '',
+				};
+				this._map.fire('postMessage', { msgId: 'Action_Load_Resp', args: postMessageObj });
 			}
 
 			if (this._map._docLayer) {


### PR DESCRIPTION
It seems there are two handler for this message.
Since we moved the authentication logic ahead
of the web-socket upgrade, the handler for
the unauthorized error doesn't display the
message. This fixes the it so now we correctly
display the unauthorized message.

Change-Id: Ic62476c74ce1583a2d7f33e1233e6fafd43d3bc4
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
