### PR TITLE
browser: fix print menu for Calc

### DIFF
--- a/browser/src/control/jsdialog/Definitions.Menu.ts
+++ b/browser/src/control/jsdialog/Definitions.Menu.ts
@@ -122,8 +122,8 @@ menuDefinitions.set('MenuPrintRanges', [
 ] as Array<MenuDefinition>);
 
 menuDefinitions.set('Print', [
-	{ text: _('Active sheet'), id: 'print-active-sheet', type: 'action' },
-	{ text: _('All Sheets'), id: 'print-all-sheets', type: 'action' },
+	{ text: _('Active sheet'), action: 'print-active-sheet' },
+	{ text: _('All Sheets'), action: 'print-all-sheets' },
 ] as Array<MenuDefinition>);
 
 menuDefinitions.set('MenuRowHeight', [


### PR DESCRIPTION
Changed the menu entries to conform to the new format used by
JSDialog menu since 07da50a.

Signed-off-by: Jaume Pujantell <jaume.pujantell@collabora.com>
Change-Id: I69109675ec69d66eb25ae128a6bb102e4628c705
