### PR TITLE
cool#9072 browser: better error handling when navigator.clipboard.write is advertised but fails

### DIFF
--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -470,6 +470,11 @@ window.app = {
 		}
 	})();
 
+	if (global.isLocalStorageAllowed && global.localStorage.getItem('hasNavigatorClipboardWrite') === 'false') {
+		// navigator.clipboard.write failed on us once, don't even try it.
+		global.L.Browser.hasNavigatorClipboardWrite = false;
+	}
+
 	global.deviceFormFactor = global.mode.getDeviceFormFactor();
 
 	if (global.ThisIsTheiOSApp) {

--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -897,6 +897,16 @@ L.Clipboard = L.Class.extend({
 		clipboard.write([text]).then(function() {
 		}, function(error) {
 			window.app.console.log('navigator.clipboard.write() failed: ' + error.message);
+
+			// Warn that the copy failed.
+			that._warnCopyPaste();
+			// Once broken, always broken.
+			L.Browser.hasNavigatorClipboardWrite = false;
+			if (window.isLocalStorageAllowed) {
+				window.localStorage.setItem('hasNavigatorClipboardWrite', 'false');
+			}
+			// Prefetch selection, so next time copy will work with the keyboard.
+			app.socket.sendMessage('gettextselection mimetype=text/html,text/plain;charset=utf-8');
 		});
 
 		return true;


### PR DESCRIPTION
In case an integration doesn't allow clipboard interaction via
<https://sdk.collaboraonline.com/docs/advanced_integration.html#allow-the-clipboard-permission-query>,
we end up in a situation where navigator.clipboard.write is not
undefined, but is broken.

By the time navigator.clipboard.write() fails, it's too late to fall
back to the old copy code, as the security context is already gone.

Fix the problem by improving the failure handling: show the popup to try
again copying, remember that navigator.clipboard.write() failed and
prefetch the text selection, so next time a copy is tried (via the
keyboard), the selection doesn't need re-creating. (Normally the
selection change would trigger the prefetch, so select->copy->copy-again
would still fail.)

Note that paste doesn't have a similar problem, since there we always
try the old paste code first, and only use the new paste code if the old
one fails.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I12ea4810395970421000d213744d1838213c7a07
