### PR TITLE
Lock cypress-tags to 1.1.2

### DIFF
--- a/cypress_test/package.json
+++ b/cypress_test/package.json
@@ -28,6 +28,6 @@
     "url": "https://github.com/CollaboraOnline/online.git"
   },
   "dependencies": {
-    "cypress-tags": "^1.1.2"
+    "cypress-tags": "1.1.2"
   }
 }


### PR DESCRIPTION
cypress-tags published an update today with some missing files. This keeps us on the old version until they can fix their release.

cypress-tags:
https://www.npmjs.com/package/cypress-tags
https://github.com/infosum/cypress-tags

Change-Id: Ie7b2ec506cae4bc244a70b4502a85d3a7530954b
