### PR TITLE
js: show progress bar during background save

### DIFF
--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -27,6 +27,30 @@
 	to { left: 100%; }
 }
 
+#document-name-input-progress-bar {
+	width: 100%;
+	height: 2px;
+	border: none;
+	background-color: var(--color-background-dark);
+	overflow: hidden;
+	position: relative;
+	display: none;
+	margin-block-end: -7px;
+	appearance: none;
+}
+
+#document-name-input-progress-bar::-webkit-progress-bar {
+	background-color: transparent;
+}
+
+#document-name-input-progress-bar::-webkit-progress-value {
+	background-color: var(--color-main-text);
+}
+
+#document-name-input-progress-bar::-moz-progress-bar {
+	background-color: var(--color-main-text);
+}
+
 /* general toolbar rules */
 
 .ui-toolbar {

--- a/browser/html/cool.html.m4
+++ b/browser/html/cool.html.m4
@@ -188,6 +188,7 @@ m4_ifelse(MOBILEAPP,[true],
           <label class="visuallyhidden" for="document-name-input" aria-hidden="false">Document name</label>
           <input id="document-name-input" type="text" spellcheck="false" disabled="true" style="display: none"/>
           <div id="document-name-input-loading-bar"></div>
+          <progress id="document-name-input-progress-bar" value="0" max="99"></progress>
         </div>
       </div>
 

--- a/browser/src/control/Control.DocumentNameInput.js
+++ b/browser/src/control/Control.DocumentNameInput.js
@@ -153,9 +153,26 @@ L.Control.DocumentNameInput = L.Control.extend({
 		}
 	},
 
+	showProgressBar : function() {
+		this.disableDocumentNameInput();
+		var progressBar = document.getElementById('document-name-input-progress-bar');
+		progressBar.style.display = 'block';
+	},
+
+	hideProgressBar : function() {
+		this.enableDocumentNameInput();
+		var progressBar = document.getElementById('document-name-input-progress-bar');
+		progressBar.style.display = 'none';
+	},
+
+	setProgressBarValue: function(value) {
+		var progressBar = document.getElementById('document-name-input-progress-bar');
+		progressBar.value = value;
+	},
+
 	showLoadingAnimation : function() {
 		this.disableDocumentNameInput();
-		$('#document-name-input-loading-bar').css('display', 'block');	
+		$('#document-name-input-loading-bar').css('display', 'block');
 	},
 
 	hideLoadingAnimation : function() {

--- a/browser/src/map/Map.js
+++ b/browser/src/map/Map.js
@@ -1430,13 +1430,13 @@ L.Map = L.Evented.extend({
 			switch (e.statusType)
 			{
 			case 'start':
-				this.uiManager.documentNameInput.showLoadingAnimation();
+				this.uiManager.documentNameInput.showProgressBar();
 				break;
 			case 'setvalue':
-				// this.uiManager.documentNameInput.setValue(e.value);
+				this.uiManager.documentNameInput.setProgressBarValue(e.value);
 				break;
 			case 'finish':
-				this.uiManager.documentNameInput.hideLoadingAnimation();
+				this.uiManager.documentNameInput.hideProgressBar();
 				break;
 			}
 		}


### PR DESCRIPTION
Change-Id: I3608bf597ab8d2c7660a1f884cf2c763c7652415

[Screencast from 2024-05-16 21-09-10.webm](https://github.com/CollaboraOnline/online/assets/26241069/b91591a4-c0ce-43af-aba7-a6699e167385)

* TODO:
   - [x]  firefox colors are not correct, need to fix that


* To Test:
  1. Make autosave interval to something like 30 seconds
  2. Open a huge document
  3. Edit the document and wait for background autosave to happen

* Resolves: # <!-- related github issue -->
* Target version: master 
