### PR TITLE
Add Invert Background Color buttons

### DIFF
--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -143,6 +143,7 @@ L.Control.Menubar = L.Control.extend({
 					{name: _('Show Status Bar'), id: 'showstatusbar', type: 'action'},
 					{name: _('Hide Menu Bar'), id: 'togglemenubar', type: 'action'},
 					{name: _('Dark Mode'), id: 'toggledarktheme', type: 'action'},
+					{name: _('Invert Background'), id: 'invertbackground', type: 'action'},
 					{uno: '.uno:SidebarDeck.PropertyDeck', name: _UNO('.uno:Sidebar')},
 					{uno: '.uno:Navigator', id: 'navigator'},
 					{type: 'separator'},
@@ -440,6 +441,7 @@ L.Control.Menubar = L.Control.extend({
 				   {name: _('Show Status Bar'), id: 'showstatusbar', type: 'action'},
 				   {name: _('Hide Menu Bar'), id: 'togglemenubar', type: 'action'},
 				   {name: _('Dark Mode'), id: 'toggledarktheme', type: 'action'},
+				   {name: _('Invert Background'), id: 'invertbackground', type: 'action'},
 				   {name: _('Master View'), uno: '.uno:SlideMasterPage'},
 				   {uno: '.uno:SidebarDeck.PropertyDeck', name: _UNO('.uno:Sidebar')},
 				   {uno: '.uno:Navigator', id: 'navigator'},
@@ -587,6 +589,7 @@ L.Control.Menubar = L.Control.extend({
 					{type: 'separator'},
 					{name: _('Toggle UI Mode'), id: 'toggleuimode', type: 'action'},
 					{name: _('Dark Mode'), id: 'toggledarktheme', type: 'action'},
+					{name: _('Invert Background'), id: 'invertbackground', type: 'action'},
 					{uno: '.uno:SidebarDeck.PropertyDeck', name: _UNO('.uno:Sidebar')},
 					{uno: '.uno:Navigator', id: 'navigator'},
 					{name: _('Show Status Bar'), id: 'showstatusbar', type: 'action'},
@@ -726,6 +729,7 @@ L.Control.Menubar = L.Control.extend({
 				   {name: _('Show Status Bar'), id: 'showstatusbar', type: 'action'},
 				   {name: _('Hide Menu Bar'), id: 'togglemenubar', type: 'action'},
 				   {name: _('Dark Mode'), id: 'toggledarktheme', type: 'action'},
+				   {name: _('Invert Background'), id: 'invertbackground', type: 'action'},
 				   {uno: '.uno:SidebarDeck.PropertyDeck', name: _UNO('.uno:Sidebar')},
 				   {uno: '.uno:Navigator', id: 'navigator'},
 				   {type: 'separator'},
@@ -1725,8 +1729,10 @@ L.Control.Menubar = L.Control.extend({
 					} else if (id == 'toggledarktheme') {
 						if (self._map.uiManager.getDarkModeState()) {
 							$(aItem).addClass(constChecked);
+							$('#menu-invertbackground').show();
 						} else {
 							$(aItem).removeClass(constChecked);
+							$('#menu-invertbackground').hide();
 						}
 					} else if (id === 'showstatusbar') {
 						if (self._map.uiManager.isStatusBarVisible()) {

--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -89,6 +89,9 @@ L.Control.Notebookbar = L.Control.extend({
 		$(docLogo).data('id', 'document-logo');
 		$(docLogo).data('type', 'action');
 		$('.main-nav').prepend(docLogoHeader);
+		var isDarkMode = this.map.uiManager.getDarkModeState();
+		if (isDarkMode)
+			$('#invertbackground').hide();
 
 		var that = this;
 		var retryNotebookbarInit = function() {
@@ -457,9 +460,11 @@ L.Control.Notebookbar = L.Control.extend({
 	onDarkModeToggleChange: function() {
 		if (this.map.uiManager.getDarkModeState()) {
 			$('#toggledarktheme').addClass('selected');
+			$('#invertbackground').show();
 		}
 		else {
 			$('#toggledarktheme').removeClass('selected');
+			$('#invertbackground').hide();
 		}
 	},
 

--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -1247,6 +1247,13 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				'accessibility': { focusBack: true,	combination: 'DT', de: null }
 			},
 			{
+				'id':'invertbackground',
+				'class': 'unoinvertbackground',
+				'type': 'bigcustomtoolitem',
+				'text': _('Invert Background'),
+				'accessibility': { focusBack: true, combination: 'DT', de: null }
+			},
+			{
 				'id': 'view-sidebardeck',
 				'type': 'bigtoolitem',
 				'text': _UNO('.uno:Sidebar'),

--- a/browser/src/control/Control.NotebookbarDraw.js
+++ b/browser/src/control/Control.NotebookbarDraw.js
@@ -427,6 +427,13 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 				'accessibility': { focusBack: true, combination: 'DT', de: null }
 			},
 			{
+                'id':'invertbackground',
+                'class': 'unoinvertbackground',
+                'type': 'bigcustomtoolitem',
+                'text': _('Invert Background'),
+                'accessibility': { focusBack: true, combination: 'DT', de: null }
+            },
+			{
 				'id': 'view-sidebar',
 				'type': 'bigtoolitem',
 				'text': _UNO('.uno:Sidebar'),

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -453,6 +453,13 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'accessibility': { focusBack: true, combination: 'TT', de: null }
 			},
 			{
+				'id':'invertbackground',
+				'class': 'unoinvertbackground',
+				'type': 'bigcustomtoolitem',
+				'text': _('Invert Background'),
+				'accessibility': { focusBack: true, combination: 'TT', de: null }
+			},
+			{
 				'id': 'view-side-bar',
 				'type': 'bigtoolitem',
 				'text': _UNO('.uno:Sidebar'),

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -1461,6 +1461,13 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				'accessibility': { focusBack: true, combination: 'D', de: null }
 			},
 			{
+			    'id':'invertbackground',
+			    'class': 'unoinvertbackground',
+			    'type': 'bigcustomtoolitem',
+			    'text': _('Invert Background'),
+			    'accessibility': { focusBack: true, combination: 'D', de: null }
+			},
+			{
 				'id': 'view-sidebar-property-deck',
 				'type': 'bigtoolitem',
 				'text': _UNO('.uno:Sidebar'),

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -108,6 +108,10 @@ L.Control.UIManager = L.Control.extend({
 		}
 	},
 
+	invertBackground: function() {
+		// Implement this
+	},
+
 	toggleDarkMode: function() {
 		// get the initial mode
 		var selectedMode = this.getDarkModeState();

--- a/browser/src/docdispatcher.ts
+++ b/browser/src/docdispatcher.ts
@@ -82,6 +82,9 @@ class Dispatcher {
 		this.actionsMap['toggledarktheme'] = function () {
 			app.map.uiManager.toggleDarkMode();
 		};
+		this.actionsMap['invertbackground'] = function () {
+			app.map.uiManager.invertBackground();
+		};
 		this.actionsMap['home-search'] = function () {
 			app.map.uiManager.focusSearch();
 		};


### PR DESCRIPTION
We have that button for Writer, Calc, Draw, Impress menubar and notebookbar


Change-Id: I745c010749b8c5b88c0d181418f2a47921a94620


* Resolves: #9061
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

