### PR TITLE
Fix excessive logging when a session hard quits very early on.

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1987,7 +1987,7 @@ bool Document::forwardToChild(const std::string& prefix, const std::vector<char>
                 if(session->getViewId() == _editorId) {
                     _editorId = -1;
                 }
-                LOG_DBG("Removing ChildSession [" << sessionId << "].");
+                LOG_INF("Removing ChildSession [" << sessionId << "].");
 
                 // Tell them we're going quietly.
                 session->sendTextFrame("disconnected:");

--- a/test/UnitJoinDisconnect.cpp
+++ b/test/UnitJoinDisconnect.cpp
@@ -169,18 +169,6 @@ public:
     }
 };
 
-#if 1
-
-UnitBase** unit_create_wsd_multi(void)
-{
-    return new UnitBase* [2]
-    {
-        new SecondJoinQuitNormal(), nullptr
-    };
-}
-
-#else
-
 /* In this case, we are currently failing.
 
    We have one user connected, the 2nd user join, and immediately drop
@@ -211,7 +199,5 @@ UnitBase** unit_create_wsd_multi(void)
         new SecondJoinQuitNormal(), new SecondJoinQuitEarly(), nullptr
     };
 }
-
-#endif
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -170,7 +170,7 @@ bool ClientSession::disconnectFromKit()
 {
     assert(_state != SessionState::WAIT_DISCONNECT);
     auto docBroker = getDocumentBroker();
-    if (_state == SessionState::LIVE && docBroker)
+    if (docBroker && (_state == SessionState::LIVE || _state == SessionState::LOADING))
     {
         setState(SessionState::WAIT_DISCONNECT);
 


### PR DESCRIPTION
Enable Caolan's unit test, pass the proper 'disconnect' message to the Kit so it can close the underlying window / resource for the view.

Potentially this also removes 'phantom' users in the user-list which might be another symptom of this issue.


Change-Id: Ib0d0c5cefa7033fff5827d0a825a932cc12f8323


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

