### PR TITLE
Fix excessive logging when a session hard quits very early on.

### DIFF
--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -170,7 +170,7 @@ bool ClientSession::disconnectFromKit()
 {
     assert(_state != SessionState::WAIT_DISCONNECT);
     auto docBroker = getDocumentBroker();
-    if (_state == SessionState::LIVE && docBroker)
+    if (docBroker && (_state == SessionState::LIVE || _state == SessionState::LOADING))
     {
         setState(SessionState::WAIT_DISCONNECT);
 


### PR DESCRIPTION
Pass the proper 'disconnect' message to the Kit so it can close the underlying window / resource for the view.

Potentially this also removes 'phantom' users in the user-list which might be another symptom of this issue.


Change-Id: Ib0d0c5cefa7033fff5827d0a825a932cc12f8323


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

