### PR TITLE
Upgrade to cypress-tags 1.2.2

### DIFF
--- a/cypress_test/package.json
+++ b/cypress_test/package.json
@@ -28,6 +28,6 @@
     "url": "https://github.com/CollaboraOnline/online.git"
   },
   "dependencies": {
-    "cypress-tags": "1.1.2"
+    "cypress-tags": "^1.2.2"
   }
 }


### PR DESCRIPTION
cypress-tags has fixed their npm publishing
Upgrade to take advantage of dependency updates
Reverts commit 873485f479ffa4fcdc607b6427475fd201ff0f1b


Change-Id: Ib4128dd4224a70777eaace0bf1e4bc14974a5189