### PR TITLE
Add empty handler for LOK_CALLBACK_VERTICAL_RULER_UPDATE

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -3147,6 +3147,8 @@ void ChildSession::loKitCallback(const int type, const std::string& payload)
     case LOK_CALLBACK_RULER_UPDATE:
         sendTextFrame("rulerupdate: " + payload);
         break;
+    case LOK_CALLBACK_VERTICAL_RULER_UPDATE:
+        break;
     case LOK_CALLBACK_WINDOW:
         sendTextFrame("window: " + payload);
         break;


### PR DESCRIPTION
To silence errors until feature arrives. Occurs after following core commit:
11b936629dd4ef9308d63b312900b8b7c8ff19b4


Change-Id: I6d9b01b265e3f07db2bc4ac7da46cbfcd0e17da5

* Target version: master 

### Checklist

- [X] Code is properly formatted
- [X] All commits have Change-Id
- [ ] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

