### PR TITLE
css: fix progress bar overflowing in compact mode

### DIFF
--- a/browser/css/menubar.css
+++ b/browser/css/menubar.css
@@ -44,6 +44,7 @@
 	justify-content: center;
 	gap: 5px;
 	flex-direction: column;
+	width: fit-content;
 }
 
 .readonly .document-title {


### PR DESCRIPTION
Change-Id: I8f60eadf53f173f26d47d3959589a233673703ee


Before:
![image](https://github.com/CollaboraOnline/online/assets/26241069/c7029ac7-d64d-453a-a212-14aee196f3a2)

* Resolves: # <!-- related github issue -->
* Target version: master 
