### PR TITLE
Tablet: Tabbed view: tabs container too wide

### DIFF
--- a/browser/css/device-tablet.css
+++ b/browser/css/device-tablet.css
@@ -64,13 +64,7 @@
 
 .notebookbar-tabs-container > div {
 	white-space: nowrap;
-	-webkit-box-flex: 1;
-	-webkit-flex: 1 0 auto;
-	-ms-flex: 1 0 auto;
-	flex: 1 0 auto;
-	display: -webkit-box;
-	display: -webkit-flex;
-	display: -ms-flexbox;
+	flex: 0 0 auto;
 	display: flex;
 	list-style-type: none;
 }


### PR DESCRIPTION
Tab buttons and their background (gray) looks odd, extending the full
width even if there is no more tabs to show.

This sub container cannot be allow to extend (flex-grow). Otherwise,
we end up with tabs background extending all the available area.
We can safely turn this off because the parent element
".notebookbar-tabs-container" already sits in place and extends the
whole area.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I6ec3fa6f40d4138420569e9acf60c906a7c43035
