### PR TITLE
Writer: Accessibility Check: Add missing CSS class

### DIFF
--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -373,6 +373,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 					hasAccessibilityCheck ?
 						{
 							'id': 'accessibility-check',
+							'class': 'unoAccessibilityCheck',
 							'type': 'bigtoolitem',
 							'text': _UNO('.uno:SidebarDeck.A11yCheckDeck', 'text'),
 							'command': '.uno:SidebarDeck.A11yCheckDeck',


### PR DESCRIPTION
Now that accessibility checker has change its command it's best to add
back in the CSS class that was being added automatically (based on the
uno command) for various reasons:
- Main one: the ".unoSidebarDeck.A11yCheckDeck" is less than ideal
class name (it includes a dot in the middle)
- Integrators might have customizations targeting the previous known
css class

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I7685d000a2110872cdbe83323136b7a6be604ca3
