### PR TITLE
shutdown AsyncDNS before WebServerPoll shutdown

### DIFF
--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -1951,10 +1951,6 @@ void COOLWSD::innerInitialize(Application& self)
 
     StartTime = std::chrono::steady_clock::now();
 
-#if !MOBILEAPP
-    net::AsyncDNS::startAsyncDNS();
-#endif
-
     LayeredConfiguration& conf = config();
 
     // Add default values of new entries here, so there is a sensible default in case
@@ -2837,6 +2833,10 @@ void COOLWSD::innerInitialize(Application& self)
 #endif
 
     WebServerPoll = std::make_unique<TerminatingPoll>("websrv_poll");
+
+#if !MOBILEAPP
+    net::AsyncDNS::startAsyncDNS();
+#endif
 
     PrisonerPoll = std::make_unique<PrisonPoll>();
 
@@ -4549,6 +4549,10 @@ int COOLWSD::innerMain()
 
     PrisonerPoll.reset();
 
+#if !MOBILEAPP
+    net::AsyncDNS::stopAsyncDNS();
+#endif
+
     WebServerPoll.reset();
 
     // Terminate child processes
@@ -4577,10 +4581,6 @@ int COOLWSD::innerMain()
     const int returnValue = UnitBase::uninit();
 
     LOG_INF("Process [coolwsd] finished with exit status: " << returnValue);
-
-#if !MOBILEAPP
-    net::AsyncDNS::stopAsyncDNS();
-#endif
 
     // At least on centos7, Poco deadlocks while
     // cleaning up its SSL context singleton.


### PR DESCRIPTION
and start it after WebServerPoll start.

AsyncDNS depends on COOLWSD::getWebServerPoll()
existing.

```
/lib/x86_64-linux-gnu/libc.so.6
	__GI_abort
		/build/glibc-bkR840/glibc-2.27/stdlib/abort.c:81
/lib/x86_64-linux-gnu/libpthread.so.0
	__restore_rt
		??:?
/lib/x86_64-linux-gnu/libpthread.so.0
	__GI___pthread_mutex_lock
		/build/glibc-bkR840/glibc-2.27/nptl/../nptl/pthread_mutex_lock.c:67
/usr/bin/coolwsd
	ConvertToAddressResolver::dispatchNextLookup()::{lambda(std::string const&, std::string const&)#1}::operator()(std::string const&, std::string const&) const
		??:?
/usr/bin/coolwsd
	net::AsyncDNS::resolveDNS()
		??:?
/lib/x86_64-linux-gnu/libpthread.so.0
	start_thread
		/build/glibc-bkR840/glibc-2.27/nptl/pthread_create.c:463
```

Change-Id: I372802b872bc899874404e7317ecd9ecb1d0757a


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

