### PR TITLE
zotero: fix: can't select language or store as option in citation style

### DIFF
--- a/browser/src/control/Control.Zotero.js
+++ b/browser/src/control/Control.Zotero.js
@@ -1064,7 +1064,7 @@ L.Control.Zotero = L.Control.extend({
 		var targetEntry = this._findEntryWithUrl(searchArray, row);
 
 		if (entry && targetEntry) {
-			if (targetEntry.children.length === 1
+			if (targetEntry.children && targetEntry.children.length === 1
 				&& targetEntry.children[0].text === '<dummy>') {
 				targetEntry.children = [];
 				targetEntry.ondemand = undefined;
@@ -1133,7 +1133,8 @@ L.Control.Zotero = L.Control.extend({
 			}
 		}
 		if (element === 'edit' && data.id === 'zoterosearch') {
-			document.getElementById('zoterolist').filterEntries(data.value);
+			if (data.value)
+				document.getElementById('zoterolist').filterEntries(data.value);
 			return;
 		}
 		if (data.id == 'ok') {

--- a/browser/src/control/jsdialog/Widget.Combobox.js
+++ b/browser/src/control/jsdialog/Widget.Combobox.js
@@ -279,7 +279,7 @@ JSDialog.combobox = function (parentContainer, data, builder) {
 		var callback = function(objectType, eventType, object, data) {
 			// send command with correct WindowId (from parent, not dropdown)
 			if (eventType !== 'close')
-				parentBuilder._defaultCallbackHandler(objectType, eventType, object, data, parentBuilder);
+				parentBuilder.callback(objectType, eventType, object, data, parentBuilder);
 
 			// close after selection
 			if (eventType === 'selected') {


### PR DESCRIPTION
- problem: in combobox widget we were always passing the `_defaultCallback` which will send `dialogevent` to server but in zotero's case the callback is different
- also fixes some `undefined type` errors


Change-Id: I7bd7aff6a1a3a9715123c1335ea83ab13fd7b22a


* Resolves: #9108 #9109 
* Target version: master 

