### PR TITLE
multiple "EMPTY" invalidations for different parts dropped as dups

### DIFF
--- a/kit/KitQueue.cpp
+++ b/kit/KitQueue.cpp
@@ -173,7 +173,7 @@ bool extractRectangle(const StringVector& tokens, int& x, int& y, int& w, int& h
 
     if (tokens.equals(0, "EMPTY,"))
     {
-        part = std::atoi(tokens[0].c_str());
+        part = std::atoi(tokens[1].c_str());
         return true;
     }
 


### PR DESCRIPTION
since:

commit 6f49f9398e237c46c71910915bf11925b85fd7a7
Date:   Thu May 9 09:19:44 2024 +0100

    Split outbound callback processing from incoming message queueing.

an out by one adjustment


Change-Id: Ie5c2133dd7239aa62c017306c962c26ea6e526bb


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

