### PR TITLE
annotation: show dialog for conflicting comment modification

### DIFF
--- a/browser/src/canvas/sections/CommentListSection.ts
+++ b/browser/src/canvas/sections/CommentListSection.ts
@@ -868,6 +868,8 @@ export class CommentSection extends app.definitions.canvasSectionObject {
 			}
 		};
 
+		var removedComment = this.getComment(id);
+		removedComment.sectionProperties.selfRemoved = true;
 		if (app.file.fileBasedView) // We have to set the part from which the comment will be removed as selected part before the process.
 			this.map.setPart(this.sectionProperties.docLayer._selectedPart, false);
 
@@ -1254,7 +1256,10 @@ export class CommentSection extends app.definitions.canvasSectionObject {
 	public onACKComment (obj: any): void {
 		var id;
 		const anyEdit = Comment.isAnyEdit();
-		if (anyEdit && anyEdit.sectionProperties.data.id === obj.comment.id && CommentSection.autoSavedComment !== anyEdit) {
+		if (anyEdit
+			&& !anyEdit.sectionProperties.selfRemoved
+			&& anyEdit.sectionProperties.data.id === obj.comment.id
+			&& CommentSection.autoSavedComment !== anyEdit) {
 			this.handleCommentConflict(obj, anyEdit);
 			return;
 		}

--- a/browser/src/canvas/sections/CommentListSection.ts
+++ b/browser/src/canvas/sections/CommentListSection.ts
@@ -1216,6 +1216,25 @@ export class CommentSection extends app.definitions.canvasSectionObject {
 
 	public onACKComment (obj: any): void {
 		var id;
+		const anyEdit = Comment.isAnyEdit();
+		if (anyEdit && anyEdit.sectionProperties.data.id === obj.comment.id) {
+			if (document.getElementById(this.map.uiManager.generateModalId('comments-update')))
+				return;
+			this.map.uiManager.showYesNoButton(
+				'comments-update',
+				_('Comments updated'),
+				_('Another user has updated the comment. Would you like to overwrite those changes?'),
+				_('Overwrite'),
+				_('Update'),
+				null,
+				() => {
+					this.clearAutoSaveStatus();
+					anyEdit.onCancelClick(null);
+					this.onACKComment(obj);
+				}, false
+			);
+			return;
+		}
 		var changetrack = obj.redline ? true : false;
 		var dataroot = changetrack ? 'redline' : 'comment';
 		if (changetrack) {

--- a/browser/src/canvas/sections/CommentSection.ts
+++ b/browser/src/canvas/sections/CommentSection.ts
@@ -1033,11 +1033,11 @@ export class Comment extends app.definitions.canvasSectionObject {
 		       (this.sectionProperties.nodeReply && this.sectionProperties.nodeReply.style.display !== 'none'));
 	}
 
-	public static isAnyEdit (): boolean {
+	public static isAnyEdit (): Comment {
 		var section = app.sectionContainer && app.sectionContainer instanceof CanvasSectionContainer ?
 			app.sectionContainer.getSectionWithName(L.CSections.CommentList.name) : null;
 		if (!section) {
-			return false;
+			return null;
 		}
 
 		var commentList = section.sectionProperties.commentList;
@@ -1047,9 +1047,9 @@ export class Comment extends app.definitions.canvasSectionObject {
 			if (!commentList[i].pendingInit &&
 				((modifyNode && modifyNode.style.display !== 'none') ||
 				(replyNode && replyNode.style.display !== 'none')))
-					return true;
+					return commentList[i];
 		}
-		return false;
+		return null;
 	}
 
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types


### PR DESCRIPTION
problem:
when we imported comments we cleared all the comments and inserted every comments from start.
This caused problem if some action from another user caused to import the comments for all users(i.e: show/hide changes) This means if comments are in autosave state, import will fail


Change-Id: I888dfeb53fb215f7c7a0507593a06b09da7caf64

* Target version: master 



### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

