### PR TITLE
cool#9120 - use a simple hash to avoid most tile: comparisons.

### DIFF
--- a/common/Message.hpp
+++ b/common/Message.hpp
@@ -38,7 +38,8 @@ public:
         _data(copyDataAfterOffset(message.data(), message.size(), _forwardToken.size())),
         _tokens(StringVector::tokenize(_data.data(), _data.size())),
         _id(makeId(dir)),
-        _type(detectType())
+        _type(detectType()),
+        _hash(0)
     {
         LOG_TRC("Message " << abbr());
     }
@@ -53,7 +54,8 @@ public:
         _data(copyDataAfterOffset(message.data(), message.size(), _forwardToken.size())),
         _tokens(StringVector::tokenize(message.data() + _forwardToken.size(), message.size() - _forwardToken.size())),
         _id(makeId(dir)),
-        _type(detectType())
+        _type(detectType()),
+        _hash(0)
     {
         _data.reserve(std::max(reserve, message.size()));
         LOG_TRC("Message " << abbr());
@@ -68,7 +70,8 @@ public:
         _data(copyDataAfterOffset(p, len, _forwardToken.size())),
         _tokens(StringVector::tokenize(_data.data(), _data.size())),
         _id(makeId(dir)),
-        _type(detectType())
+        _type(detectType()),
+        _hash(0)
     {
         LOG_TRC("Message " << abbr());
     }
@@ -81,6 +84,10 @@ public:
     std::string firstToken() const { return _tokens[0]; }
     bool firstTokenMatches(const std::string& target) const { return _tokens[0] == target; }
     std::string operator[](size_t index) const { return _tokens[index]; }
+
+    /// Allow a message to annotate a hash of its content for use later
+    uint32_t getHash() const { return _hash; }
+    void setHash(uint32_t hash) { _hash = hash; }
 
     /// Find a subarray in the raw message.
     int find(const char* sub, const std::size_t subLen) const
@@ -218,6 +225,7 @@ private:
     const std::string _id;
     std::string _firstLine;
     const Type _type;
+    uint32_t _hash;
 };
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/TileDesc.hpp
+++ b/wsd/TileDesc.hpp
@@ -23,7 +23,6 @@
 
 #define TILE_WIRE_ID
 using TileWireId = uint32_t;
-using TileBinaryHash = uint64_t;
 
 namespace TileParse
 {
@@ -131,6 +130,21 @@ public:
                _id == other._id &&
                _normalizedViewId == other._normalizedViewId &&
                _mode == other._mode;
+    }
+
+    // used to cache a hash of the key elements compared in ==
+    uint32_t equalityHash() const
+    {
+        uint32_t a = _normalizedViewId << 17;
+        uint32_t b = _tilePosX << 7;
+
+        a ^= _part;
+        b ^= _tilePosY;
+        a ^= _mode << 30;
+        b ^= _tileWidth << 20;
+        a ^= _width << 19;
+
+        return a ^ b;
     }
 
     static bool rectanglesIntersect(int x1, int y1, int w1, int h1, int x2, int y2, int w2, int h2)


### PR DESCRIPTION
Parsing a string to a TileDesc and then comparing is inefficient enough, without doing that in an N^2 loop for the SenderQueue.

Still N^2 - and of dubious value in the world of deltas; but in almost all cases a simple string + integer compare.


Change-Id: Ibe8230679e27b98cfa95567fea700e2f7d5ac09c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

