### PR TITLE
formulabar: fix css for accept / cancel formula

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1837,16 +1837,16 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	border-radius: var(--border-radius) 0 var(--border-radius) var(--border-radius) !important;
 }
 
+#formulabar-buttons-toolbox.formulabar {
+	display: grid;
+	grid-auto-flow: column;
+	height: min-content;
+}
+
 .formulabar.unotoolbutton {
 	margin: 0 !important;
 	padding: 0 !important;
 	opacity: 0.8;
-}
-
-#acceptformula {
-	/* Align it. Sum menu button occupies 2x a button size */
-	/* so, move acceptformula one button to the right */
-	margin-inline-start: var(--btn-size) !important;
 }
 
 .formulabar.unotoolbutton:hover {

--- a/browser/css/spreadsheet.css
+++ b/browser/css/spreadsheet.css
@@ -253,7 +253,7 @@
 
 #formulabar > .root-container > .formulabar {
 	display: grid;
-	grid-template-columns: 110px 106px auto;
+	grid-template-columns: 110px 112px auto;
 	grid-template-rows: 30px;
 }
 


### PR DESCRIPTION
When editing formula buttons were misaligned. Now they are stretched to fit the empty space.

After:
![buttonsalign](https://github.com/CollaboraOnline/online/assets/5307369/07bafa6c-188b-454c-bc65-23d2aa8e29f4)
