### PR TITLE
jsdialog: cleanup and deduplicate

### DIFF
--- a/browser/src/control/AutoCompletePopup.ts
+++ b/browser/src/control/AutoCompletePopup.ts
@@ -14,46 +14,10 @@
 
 /* global app */
 
-interface WidgetJSON {
-	id: string; // unique id of a widget
-	type: string; // type of widget
-	enabled: boolean | undefined; // enabled state
-	visible: boolean | undefined; // visibility state
-	children: Array<WidgetJSON> | undefined; // child nodes
-	title?: string;
-}
-
-interface JSDialogJSON extends WidgetJSON {
-	id: string; // unique windowId
-	jsontype: string; // specifies target componenet, on root level only
-	action: string | undefined; // optional name of an action
-	control?: WidgetJSON;
-}
-
-interface PopupData extends JSDialogJSON {
-	isAutoCompletePopup?: boolean;
-	cancellable?: boolean;
-	popupParent?: string;
-	clickToClose?: string;
-	posx: number;
-	posy: number;
-}
-
 interface Entry {
 	text: string;
 	columns: { text: any }[];
 	row: string;
-}
-
-interface TextWidget extends WidgetJSON {
-	text: string;
-}
-
-interface TreeWidget extends WidgetJSON {
-	text: string;
-	singleclickactivate: boolean;
-	fireKeyEvents: boolean;
-	entries: Array<Entry>;
 }
 
 interface Point {

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -1094,84 +1094,21 @@ L.Control.UIManager = L.Control.extend({
 	// Snack bar
 
 	closeSnackbar: function() {
-		var closeMessage = { id: 'snackbar', jsontype: 'dialog', type: 'snackbar', action: 'close' };
-		app.socket._onMessage({ textMsg: 'jsdialog: ' + JSON.stringify(closeMessage) });
+		JSDialog.SnackbarController.closeSnackbar();
 	},
 
 	showSnackbar: function(label, action, callback, timeout, hasProgress, withDismiss) {
-		if (!app.socket)
-			return;
-
-		this.closeSnackbar();
-
-		var buttonId = 'button';
-		var labelId = 'label';
-
-		var json = {
-			id: 'snackbar',
-			jsontype: 'dialog',
-			type: 'snackbar',
-			timeout: timeout,
-			'init_focus_id': action ? buttonId : undefined,
-			children: [
-				{
-					id: hasProgress ? 'snackbar-container-progress' : 'snackbar-container',
-					type: 'container',
-					children: [
-						action ? {id: labelId, type: 'fixedtext', text: label, labelFor: buttonId} : {id: 'label-no-action', type: 'fixedtext', text: label},
-						withDismiss ? {id: 'snackbar-dismiss-button', type: 'pushbutton', text: _('Dismiss')} : {},
-						hasProgress ? {id: 'progress', type: 'progressbar', value: 0, maxValue: 100} : {},
-						action ? {id: buttonId, type: 'pushbutton', text: action, labelledBy: labelId} : {}
-					]
-				}
-			]
-		};
-
-		var that = this;
-		var builderCallback = function(objectType, eventType, object, data) {
-			window.app.console.debug('control: \'' + objectType + '\' id:\'' + object.id + '\' event: \'' + eventType + '\' state: \'' + data + '\'');
-
-			if (object.id === buttonId && objectType === 'pushbutton' && eventType === 'click') {
-				if (callback)
-					callback();
-
-				that.closeSnackbar();
-			} else if (object.id === '__POPOVER__' && objectType === 'popover' && eventType === 'close') {
-				that.closeSnackbar();
-			}
-
-			if (object.id === 'snackbar-dismiss-button' && objectType === 'pushbutton' && eventType === 'click') {
-				that.closeSnackbar();
-			}
-		};
-
-		app.socket._onMessage({textMsg: 'jsdialog: ' + JSON.stringify(json), callback: builderCallback});
+		JSDialog.SnackbarController.showSnackbar(label, action, callback, timeout, hasProgress, withDismiss);
 	},
 
 	/// shows snackbar with progress
 	showProgressBar: function(message, buttonText, callback, timeout, withDismiss) {
-		this.showSnackbar(message, buttonText, callback, timeout ? timeout : -1, true, withDismiss);
+		JSDialog.SnackbarController.showSnackbar(message, buttonText, callback, timeout ? timeout : -1, true, withDismiss);
 	},
 
 	/// sets progressbar status, value should be in range 0-100
 	setSnackbarProgress: function(value) {
-		if (!app.socket)
-			return;
-
-		var json = {
-			id: 'snackbar',
-			jsontype: 'dialog',
-			type: 'snackbar',
-			action: 'update',
-			control: {
-				id: 'progress',
-				type: 'progressbar',
-				value: value,
-				maxValue: 100
-			}
-		};
-
-		app.socket._onMessage({textMsg: 'jsdialog: ' + JSON.stringify(json)});
+		JSDialog.SnackbarController.setSnackbarProgress(value);
 	},
 
 	// Modals

--- a/browser/src/control/jsdialog/Definitions.Menu.ts
+++ b/browser/src/control/jsdialog/Definitions.Menu.ts
@@ -16,20 +16,6 @@
 declare var L: any;
 declare var JSDialog: any;
 
-type MenuDefinition = {
-	id: string; // unique identifier
-	type: undefined | 'action' | 'menu' | 'separator' | 'html'; // type of entry
-	text: string; // displayed text
-	hint: string; // hint text
-	uno: string; // uno command
-	action: string; // dispatch command
-	htmlId: string; // id of HTMLContent
-	img: string; // icon name
-	icon: string; // icon name FIXME: duplicated property, used in exportMenuButton
-	checked: boolean; // state of check mark
-	items: Array<any>; // submenu
-};
-
 const menuDefinitions = new Map<string, Array<MenuDefinition>>();
 
 menuDefinitions.set('AutoSumMenu', [

--- a/browser/src/control/jsdialog/Definitions.Types.ts
+++ b/browser/src/control/jsdialog/Definitions.Types.ts
@@ -1,0 +1,77 @@
+/* -*- js-indent-level: 8 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Definitions.Types - types and interfaces for JSDialog
+ */
+
+// common for all widgets
+interface WidgetJSON {
+	id: string; // unique id of a widget
+	type: string; // type of widget
+	enabled: boolean | undefined; // enabled state
+	visible: boolean | undefined; // visibility state
+	children: Array<WidgetJSON> | undefined; // child nodes
+	title?: string;
+}
+
+// JSDialog message (full, update or action)
+interface JSDialogJSON extends WidgetJSON {
+	id: string; // unique windowId
+	jsontype: string; // specifies target componenet, on root level only
+	action: string | undefined; // optional name of an action
+	control?: WidgetJSON;
+}
+
+// JSDialog message for popup
+interface PopupData extends JSDialogJSON {
+	isAutoCompletePopup?: boolean;
+	cancellable?: boolean;
+	popupParent?: string;
+	clickToClose?: string;
+	posx: number;
+	posy: number;
+}
+
+// callback triggered by user actions
+type JSDialogCallback = (
+	objectType: string,
+	eventType: string,
+	object: any,
+	data: any,
+	builder: any,
+) => void;
+
+// used to define menus
+type MenuDefinition = {
+	id: string; // unique identifier
+	type: undefined | 'action' | 'menu' | 'separator' | 'html'; // type of entry
+	text: string; // displayed text
+	hint: string; // hint text
+	uno: string; // uno command
+	action: string; // dispatch command
+	htmlId: string; // id of HTMLContent
+	img: string; // icon name
+	icon: string; // icon name FIXME: duplicated property, used in exportMenuButton
+	checked: boolean; // state of check mark
+	items: Array<any>; // submenu
+};
+
+interface TextWidget extends WidgetJSON {
+	text: string;
+}
+
+interface TreeWidget extends WidgetJSON {
+	text: string;
+	singleclickactivate: boolean;
+	fireKeyEvents: boolean;
+	entries: Array<Entry>;
+}

--- a/browser/src/control/jsdialog/Util.MessageRouter.ts
+++ b/browser/src/control/jsdialog/Util.MessageRouter.ts
@@ -15,28 +15,6 @@
 
 declare var JSDialog: any;
 
-interface WidgetJSON {
-	id: string; // unique id of a widget
-	type: string; // type of widget
-	enabled: boolean | undefined; // enabled state
-	visible: boolean | undefined; // visibility state
-	children: Array<WidgetJSON> | undefined; // child nodes
-}
-
-interface JSDialogJSON extends WidgetJSON {
-	id: string; // unique windowId
-	jsontype: string; // specifies target componenet, on root level only
-	action: string | undefined; // optional name of an action
-}
-
-type JSDialogCallback = (
-	objectType: string,
-	eventType: string,
-	object: any,
-	data: any,
-	builder: any,
-) => void;
-
 class JSDialogMessageRouter {
 	// show labels instead of editable fields in message boxes
 	private _preProcessMessageDialog(msgData: WidgetJSON) {

--- a/browser/src/control/jsdialog/Util.SnackbarController.ts
+++ b/browser/src/control/jsdialog/Util.SnackbarController.ts
@@ -1,0 +1,161 @@
+/* -*- js-indent-level: 8 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Util.SnackbarController - helper for managing the snackbars queue
+ */
+
+declare var JSDialog: any;
+
+class SnackbarController {
+	public closeSnackbar() {
+		var closeMessage = {
+			id: 'snackbar',
+			jsontype: 'dialog',
+			type: 'snackbar',
+			action: 'close',
+		};
+		app.socket._onMessage({
+			textMsg: 'jsdialog: ' + JSON.stringify(closeMessage),
+		});
+	}
+
+	public showSnackbar(
+		label: string,
+		action: string,
+		callback: () => void,
+		timeout: number,
+		hasProgress: boolean,
+		withDismiss: boolean,
+	) {
+		if (!app.socket) return;
+
+		this.closeSnackbar();
+
+		var buttonId = 'button';
+		var labelId = 'label';
+
+		var json = {
+			id: 'snackbar',
+			jsontype: 'dialog',
+			type: 'snackbar',
+			timeout: timeout,
+			init_focus_id: action ? buttonId : undefined,
+			children: [
+				{
+					id: hasProgress
+						? 'snackbar-container-progress'
+						: 'snackbar-container',
+					type: 'container',
+					children: [
+						action
+							? {
+									id: labelId,
+									type: 'fixedtext',
+									text: label,
+									labelFor: buttonId,
+								}
+							: { id: 'label-no-action', type: 'fixedtext', text: label },
+						withDismiss
+							? {
+									id: 'snackbar-dismiss-button',
+									type: 'pushbutton',
+									text: _('Dismiss'),
+								}
+							: {},
+						hasProgress
+							? { id: 'progress', type: 'progressbar', value: 0, maxValue: 100 }
+							: {},
+						action
+							? {
+									id: buttonId,
+									type: 'pushbutton',
+									text: action,
+									labelledBy: labelId,
+								}
+							: {},
+					],
+				},
+			],
+		};
+
+		var builderCallback: JSDialogCallback = (
+			objectType: string,
+			eventType: string,
+			object: any,
+			data: any,
+			builder: any,
+		) => {
+			window.app.console.debug(
+				"control: '" +
+					objectType +
+					"' id:'" +
+					object.id +
+					"' event: '" +
+					eventType +
+					"' state: '" +
+					data +
+					"'",
+			);
+
+			if (
+				object.id === buttonId &&
+				objectType === 'pushbutton' &&
+				eventType === 'click'
+			) {
+				if (callback) callback();
+
+				this.closeSnackbar();
+			} else if (
+				object.id === '__POPOVER__' &&
+				objectType === 'popover' &&
+				eventType === 'close'
+			) {
+				this.closeSnackbar();
+			}
+
+			if (
+				object.id === 'snackbar-dismiss-button' &&
+				objectType === 'pushbutton' &&
+				eventType === 'click'
+			) {
+				this.closeSnackbar();
+			}
+		};
+
+		app.socket._onMessage({
+			textMsg: 'jsdialog: ' + JSON.stringify(json),
+			callback: builderCallback,
+		});
+	}
+
+	// value should be in range 0-100
+	public setSnackbarProgress(value: number) {
+		if (!app.socket) return;
+
+		var json = {
+			id: 'snackbar',
+			jsontype: 'dialog',
+			type: 'snackbar',
+			action: 'update',
+			control: {
+				id: 'progress',
+				type: 'progressbar',
+				value: value,
+				maxValue: 100,
+			},
+		};
+
+		app.socket._onMessage({ textMsg: 'jsdialog: ' + JSON.stringify(json) });
+	}
+}
+
+JSDialog.SnackbarController = new SnackbarController();


### PR DESCRIPTION
- no functional changes, just a cleanup
- move types into single file and remove duplicates
- move snackbar internals into separate TS file (to be continued)