### PR TITLE
fix(desktop): Prevent zoom view jump

### DIFF
--- a/browser/src/canvas/sections/ScrollSection.ts
+++ b/browser/src/canvas/sections/ScrollSection.ts
@@ -344,7 +344,7 @@ export class ScrollSection extends app.definitions.canvasSectionObject {
 	public onUpdateScrollOffset (): void {
 		if (this.map._docLayer._docType === 'spreadsheet') {
 			this.map._docLayer.refreshViewData();
-			this.map._docLayer.updateScollLimit();
+			this.map._docLayer.updateScrollLimit();
 		}
 	}
 

--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -361,7 +361,7 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 	},
 
 	/// take into account only data area to reduce scrollbar range
-	updateScollLimit: function () {
+	updateScrollLimit: function () {
 		if (this.sheetGeometry && this._lastColumn && this._lastRow) {
 			this._restrictDocumentSize();
 		}

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -480,8 +480,8 @@ L.TileSectionManager = L.Class.extend({
 		}
 
 		const newPaneCenter = new L.Point(
-			(docTopLeft.x - splitPos.x + (paneSize.x + splitPos.x) * 0.5 / scale) / app.dpiScale,
-			(docTopLeft.y - splitPos.y + (paneSize.y + splitPos.y) * 0.5 / scale) / app.dpiScale);
+			(docTopLeft.x - splitPos.x + (paneSize.x + splitPos.x) * 0.5 / scale),
+			(docTopLeft.y - splitPos.y + (paneSize.y + splitPos.y) * 0.5 / scale));
 
 		return {
 			offset: this._offset,
@@ -582,7 +582,7 @@ L.TileSectionManager = L.Class.extend({
 		var map = this._map;
 
 		// Calculate the final center at final zoom in advance.
-		var newMapCenter = this._getZoomMapCenter(zoom);
+		var newMapCenter = this._getZoomMapCenter(zoom).divideBy(app.dpiScale);
 		var newMapCenterLatLng = map.unproject(newMapCenter, zoom);
 		app.sectionContainer.setZoomChanged(true);
 
@@ -5060,7 +5060,7 @@ L.CanvasTileLayer = L.Layer.extend({
 		this._pinchStartCenter = this._map.project(pinchStartCenter).multiplyBy(app.dpiScale); // in core pixels
 		this._painter._offset = new L.Point(0, 0);
 
-		if (app.file.textCursor.visible) {
+		if (this._cursorMarker && app.file.textCursor.visible) {
 			this._cursorMarker.setOpacity(0);
 		}
 		if (this._map._textInput._cursorHandler) {


### PR DESCRIPTION
Previously, zooming using the +/- zoom buttons caused your view to jump such that alternating in/out zooms would move you to the top left of the document

Additionally, the zoom did not zoom around the correct position, so a cursor in the frame would not correctly zoom around the cursor

Change-Id: I6d468795abbb972174774cf1620cb4a0959142f2