### PR TITLE
Writer: Fix broken urls, preserve valid URL protocol and enable auto-focus when hyperlink modal open

### DIFF
--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -892,8 +892,16 @@ L.Map.include({
 
 	makeURLFromStr: function(str) {
 		str = str.trim();
-		if (!(str.toLowerCase().startsWith('http://') || str.toLowerCase().startsWith('https://'))) {
-			str = 'http://' + str;
+		const lowerStr = str.toLowerCase();
+
+		if (!(lowerStr.startsWith('http://') || lowerStr.startsWith('https://') ||
+			  lowerStr.startsWith('ftp://') || lowerStr.startsWith('mailto:'))) {
+			// Regular expression to test if the string is an email address
+			const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+			if (emailPattern.test(str)) 
+				str = 'mailto:' + str;
+			else
+				str = 'http://' + str;
 		}
 		return str;
 	},

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -891,6 +891,7 @@ L.Map.include({
 	},
 
 	makeURLFromStr: function(str) {
+		str = str.trim();
 		if (!(str.toLowerCase().startsWith('http://') || str.toLowerCase().startsWith('https://'))) {
 			str = 'http://' + str;
 		}
@@ -947,7 +948,7 @@ L.Map.include({
 				vertical: false,
 				layoutstyle: 'end'
 			},
-		], 'hyperlink-link-box');
+		], 'hyperlink-link-box-input');
 
 		map.uiManager.showModal(json, [
 			{id: 'response-ok', func: function() {
@@ -1009,7 +1010,7 @@ L.Map.include({
 		if (this.hyperlinkUnderCursor && this.hyperlinkUnderCursor.link)
 			link = this.hyperlinkUnderCursor.link;
 
-		this._createAndRunHyperlinkDialog(text ? text.trim() : '', link);
+		this._createAndRunHyperlinkDialog(text ? text.replace(/^[\n\r]+|[\n\r]+$/g, '') : '', link);
 	},
 
 	cancelSearch: function() {


### PR DESCRIPTION
Change-Id: Ife153056b3dccb64b66a614c37532c59690bd792


* Resolves: 
#8876
#8280

* Target version: master 

### Summary
- Fix Text box to not gobble up spaces before/after text
- Fix broken url when link has a leading space
- Added autofocus on input box of link when hyperlink modal opens
- Preserve Valid URL Protocols
- Automatically Add 'mailto:' for Email Addresses

### Checklist

- [X] Code is properly formatted
- [X] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

