### PR TITLE
Close mobile icon should be hidden in desktop

### DIFF
--- a/browser/src/control/jsdialog/Component.Toolbar.ts
+++ b/browser/src/control/jsdialog/Component.Toolbar.ts
@@ -132,6 +132,7 @@ class Toolbar {
 
 	updateItem(data: ToolbarItem) {
 		this.builder.updateWidget(this.parentContainer, data);
+		this.updateVisibilityForToolbar('');
 		JSDialog.RefreshScrollables();
 	}
 


### PR DESCRIPTION
- if we switch to compact mode & server get reconnected, some icons are visible in desktop which should be only visible in mobile view.
- in control.toolbar.js we call updateItem method for icon in mobile - `toolbar.updateItem({id: 'closemobile', type: 'customtoolitem', w2icon: 'editmode'});`
- after this updateItem call we should also check all condition about that item like - item should be visible in mobile or not - item should be available in tablet or not etc
- this patch will do that checks

Signed-off-by: Darshan-upadhyay1110 <darshan.upadhyay@collabora.com>

Change-Id: I11adc3d94cacd4afe85e177d050ccc73f3112872


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

