### PR TITLE
Fix state update of input element

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -1603,6 +1603,8 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		if (data.enabled === 'false' || data.enabled === false)
 			$(edit).prop('disabled', true);
 
+		JSDialog.SynchronizeDisabledState(container, [edit]);
+
 		edit.addEventListener('keyup', function(e) {
 			var callbackToUse =
 				(e.key === 'Enter' && data.changedCallback) ? data.changedCallback : null;

--- a/cypress_test/integration_tests/desktop/calc/jsdialog_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/jsdialog_spec.js
@@ -49,4 +49,18 @@ describe(['tagdesktop'], 'JSDialog unit test', function() {
 		cy.cGet('.jsdialog-overlay').should('not.exist');
 		cy.cGet('#home-conditional-format-menu-dropdown').should('not.exist');
 	});
+
+	it('JSDialog check enable edit input', function() {
+		cy.cGet('#File-tab-label').click();
+		cy.cGet('#File-container .unodownloadas button').click();
+
+		// open "PDF options JsDialog"
+		cy.cGet('.exportpdf-submenu-icon').click();
+
+		// check water marker checkbox to enable water mark entry input
+		cy.cGet('#watermark-input').check();
+		// after enable eatermark checkbox the input filed beside should also be in enabled state
+		cy.cGet('#watermarkentry-input').should('not.be.disabled');
+
+	});
 });


### PR DESCRIPTION

- Input elements in jsDialog does not change state after CORE update message
- this is because in previous commits we changed input element structure.
- we should synchronize the child elements with parent.
- this patch will Synchronize disable state of parent with it's child elements

Signed-off-by: Darshan-upadhyay1110 <darshan.upadhyay@collabora.com>

Change-Id: Ice94de732dc7392f3c79100e6a2d60480294eb0e


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

