### PR TITLE
fuzzer: fix default log level

### DIFF
--- a/fuzzer/Common.cpp
+++ b/fuzzer/Common.cpp
@@ -20,7 +20,7 @@ namespace fuzzer
 {
 bool DoInitialization()
 {
-    std::string logLevel("none");
+    std::string logLevel("fatal");
     bool withColor = false;
     bool logToFile = false;
     std::map<std::string, std::string> logProperties;


### PR DESCRIPTION
Recent a failed jenkins job had a lot of output, the tail of the log
starts with: "Skipping 3,970,746 KB".

I guessed that the problem is that the fuzzer figured out what is the
protocol to change log levels, but it isn't there yet.

What seems to happen is that fuzzer/Common.cpp defines the log level to
be "none", but this is not handled at GenericLogger::mapToLevel(), so we
managed to enable trace level for known-broken input where we're not
interested in the errors/warnings.

The fix can be tested by adding assert(false); to Log::log(), previously
the fuzzer failed with an assertion failure for a simple input like "12"
(unknown command) and now it just exits silently.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Ib5f4bedca706d7a0310a2eb9f661053a3095822d
