### PR TITLE
browser: fix removing new comment

### DIFF
--- a/browser/src/canvas/sections/CommentListSection.ts
+++ b/browser/src/canvas/sections/CommentListSection.ts
@@ -2114,7 +2114,7 @@ export class CommentSection extends app.definitions.canvasSectionObject {
 	public onCommentsDataUpdate(): void {
 		for (var i: number = this.sectionProperties.commentList.length -1; i > -1; i--) {
 			var comment = this.sectionProperties.commentList[i];
-			if (!comment.valid) {
+			if (!comment.valid && comment.sectionProperties.data.id !== 'new') {
 				comment.sectionProperties.commentListSection.removeItem(comment.sectionProperties.data.id);
 			}
 			comment.onCommentDataUpdate();


### PR DESCRIPTION
1) User1 start resizing row/column
2) User2 create a new annotation
3) User1 finish resizing row/column
4) Server update comment position
5) User2 new annotation is hidden

if comment is new, do not hide when updating new comment data.

Change-Id: I593dff167f75cc3dc451467a7d76a09f94a3a556
Signed-off-by: Henry Castro <hcastro@collabora.com>
