### PR TITLE
Formula Wizard: better alignment of label that under the Structure tab

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1933,10 +1933,12 @@ input[type='number']:hover::-webkit-outer-spin-button {
 }
 #FormulaDialog .jsdialog.ui-tabpage > .ui-grid {
 	grid-template-rows: 0 auto !important;
+	grid-gap: 0px;
 }
 #FormulaDialog #StructPage {
 	display: grid;
 	grid-template-rows: auto 1fr;
+	grid-row-gap: 4px;
 }
 #FormulaDialog #StructPage .ui-treeview-entry {
 	background-color: transparent;
@@ -1967,6 +1969,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 #FormulaDialog .ui-tabs-content.jsdialog {
 	grid-auto-columns: 250px;
 	margin-right: 0.2em;
+	margin-top: 0px;
 }
 
 div [id^='TemplateDialog'] {


### PR DESCRIPTION
- the label between Structure tab and TreeView was misaligned. This is corrected with this commit.
- label "Structure:" changed to "Functions in use and their validity:" with https://gerrit.libreoffice.org/c/core/+/168161 (6c15d246afa1774298e1438f2117b593a065bfe4)


Change-Id: I197fb84154226709395f4f2789fc288367c00f05


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

