### PR TITLE
Toolitem: Set Clear direct formatting btns with the same css class

### DIFF
--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -536,6 +536,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 							},
 							{
 								'id': 'home-set-default',
+								'class': 'unoResetAttributes',
 								'type': 'toolitem',
 								'text': _UNO('.uno:SetDefault'),
 								'command': '.uno:SetDefault',

--- a/browser/src/control/Control.TopToolbar.js
+++ b/browser/src/control/Control.TopToolbar.js
@@ -115,7 +115,7 @@ class TopToolbar extends JSDialog.Toolbar {
 			{type: 'separator', orientation: 'vertical', id: 'redobreak', mobile: false, tablet: false,},
 			{type: 'toolitem',  id: 'formatpaintbrush', text: _UNO('.uno:FormatPaintbrush'), command: '.uno:FormatPaintbrush', mobile: false},
 			{type: 'toolitem',  id: 'reset', text: _UNO('.uno:ResetAttributes', 'text'), visible: false, command: '.uno:ResetAttributes', mobile: false},
-			{type: 'toolitem',  id: 'resetimpress', text: _UNO('.uno:SetDefault', 'presentation', 'true'), visible: false, command: '.uno:SetDefault', mobile: false},
+			{type: 'toolitem',  id: 'resetimpress', class: 'unoResetAttributes', text: _UNO('.uno:SetDefault', 'presentation', 'true'), visible: false, command: '.uno:SetDefault', mobile: false},
 			{type: 'separator', orientation: 'vertical', id: 'breakreset', invisible: true, mobile: false, tablet: false,},
 			{type: 'listbox', id: 'styles', text: _('Default Style'), desktop: true, mobile: false, tablet: false},
 			{type: 'listbox', id: 'fontnamecombobox', text: 'Carlito', command: '.uno:CharFontName', mobile: false},


### PR DESCRIPTION
Before this commit:
- Impress on tabbed and compact view didn't have the common (and in
used in the other apps) 'unoResetAttributes' css class

Set all with the same CSS class so integrators with customizations
are not force to single out special cases.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I82deb98a628b527470fcd2e54f1374df21380bfa
