### PR TITLE
Improvement to conditional formatting

### DIFF
--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -829,15 +829,15 @@ L.Control.Menubar = L.Control.extend({
 				    {uno: '.uno:UngroupSparklines'}
 				]},
 				{name: _UNO('.uno:ConditionalFormatMenu', 'spreadsheet'), type: 'menu', menu: [
-					{name: _('Condition...'), type: 'menu', menu: [
-						{name: _('Greater than...'), uno: '.uno:ConditionalFormatEasy?FormatRule:short=2'},
-						{name: _('Less than...'), uno: '.uno:ConditionalFormatEasy?FormatRule:short=1'},
-						{name: _('Equal to...'), uno: '.uno:ConditionalFormatEasy?FormatRule:short=0'},
-						{name: _('Between...'), uno: '.uno:ConditionalFormatEasy?FormatRule:short=6'},
-						{name: _('Duplicate...'), uno: '.uno:ConditionalFormatEasy?FormatRule:short=8'},
-						{name: _('Contains text...'), uno: '.uno:ConditionalFormatEasy?FormatRule:short=23'},
+					{name: _('Highlight cells with...'), type: 'menu', menu: [
+						{name: _('Values greater than...'), uno: '.uno:ConditionalFormatEasy?FormatRule:short=2'},
+						{name: _('Values less than...'), uno: '.uno:ConditionalFormatEasy?FormatRule:short=1'},
+						{name: _('Values equal to...'), uno: '.uno:ConditionalFormatEasy?FormatRule:short=0'},
+						{name: _('Values between...'), uno: '.uno:ConditionalFormatEasy?FormatRule:short=6'},
+						{name: _('Values duplicate...'), uno: '.uno:ConditionalFormatEasy?FormatRule:short=8'},
+						{name: _('Containing text...'), uno: '.uno:ConditionalFormatEasy?FormatRule:short=23'},
 						{type: 'separator'},
-						{name: _('More conditions...'), uno: '.uno:ConditionalFormatDialog'},
+						{name: _('More highlights...'), uno: '.uno:ConditionalFormatDialog'},
 					]},
 					{name: _('Top/Bottom Rules...'), type: 'menu', menu: [
 						{name: _('Top N elements...'), uno: '.uno:ConditionalFormatEasy?FormatRule:short=11'},
@@ -847,7 +847,7 @@ L.Control.Menubar = L.Control.extend({
 						{name: _('Above Average...'), uno: '.uno:ConditionalFormatEasy?FormatRule:short=15'},
 						{name: _('Below Average...'), uno: '.uno:ConditionalFormatEasy?FormatRule:short=16'},
 						{type: 'separator'},
-						{name: _('More conditions...'), uno: '.uno:ConditionalFormatDialog'},
+						{name: _('More highlights...'), uno: '.uno:ConditionalFormatDialog'},
 					]},
 					{uno: '.uno:ColorScaleFormatDialog'},
 					{uno: '.uno:DataBarFormatDialog'},

--- a/browser/src/control/jsdialog/Definitions.Menu.ts
+++ b/browser/src/control/jsdialog/Definitions.Menu.ts
@@ -283,34 +283,34 @@ menuDefinitions.set('PasteMenu', [
 
 menuDefinitions.set('ConditionalFormatMenu', [
 	{
-		text: _('Condition...'),
+		text: _('Highlight cells with...'),
 		items: [
 			{
-				text: _('Greater than...'),
+				text: _('Values greater than...'),
 				uno: '.uno:ConditionalFormatEasy?FormatRule:short=2',
 			},
 			{
-				text: _('Less than...'),
+				text: _('Values less than...'),
 				uno: '.uno:ConditionalFormatEasy?FormatRule:short=1',
 			},
 			{
-				text: _('Equal to...'),
+				text: _('Values equal to...'),
 				uno: '.uno:ConditionalFormatEasy?FormatRule:short=0',
 			},
 			{
-				text: _('Between...'),
+				text: _('Values between...'),
 				uno: '.uno:ConditionalFormatEasy?FormatRule:short=6',
 			},
 			{
-				text: _('Duplicate...'),
+				text: _('Values duplicate...'),
 				uno: '.uno:ConditionalFormatEasy?FormatRule:short=8',
 			},
 			{
-				text: _('Contains text...'),
+				text: _('Containing text...'),
 				uno: '.uno:ConditionalFormatEasy?FormatRule:short=23',
 			},
 			{ type: 'separator' },
-			{ text: _('More conditions...'), uno: '.uno:ConditionalFormatDialog' },
+			{ text: _('More highlights...'), uno: '.uno:ConditionalFormatDialog' },
 		],
 	},
 	{
@@ -341,7 +341,7 @@ menuDefinitions.set('ConditionalFormatMenu', [
 				uno: '.uno:ConditionalFormatEasy?FormatRule:short=16',
 			},
 			{ type: 'separator' },
-			{ text: _('More conditions...'), uno: '.uno:ConditionalFormatDialog' },
+			{ text: _('More highlights...'), uno: '.uno:ConditionalFormatDialog' },
 		],
 	},
 	{ type: 'separator' },


### PR DESCRIPTION
Previously, the menu and submenu of conditional formatting options were technically correct but not very readable. We replaced 'Condition...' with 'Highlight cells with...'.

![Screenshot from 2024-05-30 11-14-45](https://github.com/CollaboraOnline/online/assets/61119120/6770727a-7c1e-4eb5-8311-903f4b5c36ba)
![Screenshot from 2024-05-30 11-14-19](https://github.com/CollaboraOnline/online/assets/61119120/d3f70b29-1e82-4998-9b1a-7fe1b58d5ceb)
![Screenshot from 2024-05-30 11-14-06](https://github.com/CollaboraOnline/online/assets/61119120/ea235144-f33b-4ea3-a731-360fcf55c2da)



Change-Id: I92a326e1394d1b40211748062c5bcddea049ffb4


* Resolves: # <!-- related github issue -->
* Target version: master 
