### PR TITLE
Update Matrix room name and url

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Master: Pull request policy](https://img.shields.io/badge/Master-protected%2C%20PRs%20need%20approval-red?logoColor=lightred&logo=git "Collabora Team is preparing for the next release, therefore 'master' branch is protected now, PRs need 1 review before merging. Thanks for your support and contributions! :)")](https://github.com/CollaboraOnline/online/blob/master/CONTRIBUTING.md#contributing-to-source-code)
 
 
-[![Matrix](https://img.shields.io/badge/Matrix-%23cool--dev-turquoise.svg)](https://matrix.to/#/#cool-dev:clicks.codes)
+[![Matrix](https://img.shields.io/badge/Matrix-%23cool--dev-turquoise.svg)](https://matrix.to/#/#cool-dev:matrix.org)
 [![Telegram](https://img.shields.io/badge/Telegram-Collabora%20Online-green.svg)](https://t.me/CollaboraOnline)
 [![Forum](https://img.shields.io/badge/Forum-Discourse-blue.svg)](https://forum.collaboraonline.com/)
 [![Website](https://img.shields.io/badge/Website-collaboraonline.github.io-blueviolet.svg)](https://collaboraonline.github.io/)
@@ -39,7 +39,7 @@ For many more details, build instructions, downloads and more please visit https
 
 ## Developer assistance
 Please ask your questions on any of the bridged Matrix/Telegram rooms
-* Matrix: [#cool-dev:clicks.codes](https://matrix.to/#/#cool-dev:clicks.codes)
+* Matrix: [#cool-dev:matrix.org](https://matrix.to/#/#cool-dev:matrix.org)
 * Telegram: [CollaboraOnline](https://t.me/CollaboraOnline)
 
 Join the conversation on our Discourse server at https://forum.collaboraonline.com/


### PR DESCRIPTION
The matrix saga seems to be solved now

- There were 3 rooms. I needed to remove both local and published address from there (the old matrix.org room)
- Skyler helped by setting the local address of the active room to the matrix.org
- Then we could set the published and the main address as #cool-dev:matrix.org


Change-Id: I7e73e0750dd94744eb0706230da40ab51bbad7f7


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

