### PR TITLE
backport(23.05): fix(desktop): Prevent zoom view jump

### DIFF
--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -365,7 +365,7 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 	},
 
 	/// take into account only data area to reduce scrollbar range
-	updateScollLimit: function () {
+	updateScrollLimit: function () {
 		if (this.sheetGeometry && this._lastColumn && this._lastRow) {
 			this._restrictDocumentSize();
 		}

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -686,8 +686,8 @@ L.TileSectionManager = L.Class.extend({
 		}
 
 		var newPaneCenter = new L.Point(
-			(docTopLeft.x - splitPos.x + (paneSize.x + splitPos.x) * 0.5 / scale) / app.dpiScale,
-			(docTopLeft.y - splitPos.y + (paneSize.y + splitPos.y) * 0.5 / scale) / app.dpiScale);
+			(docTopLeft.x - splitPos.x + (paneSize.x + splitPos.x) * 0.5 / scale),
+			(docTopLeft.y - splitPos.y + (paneSize.y + splitPos.y) * 0.5 / scale));
 
 		return {
 			topLeft: docTopLeft,
@@ -785,7 +785,7 @@ L.TileSectionManager = L.Class.extend({
 		var map = this._map;
 
 		// Calculate the final center at final zoom in advance.
-		var newMapCenter = this._getZoomMapCenter(zoom);
+		var newMapCenter = this._getZoomMapCenter(zoom).divideBy(app.dpiScale);
 		var newMapCenterLatLng = map.unproject(newMapCenter, zoom);
 		painter._sectionContainer.setZoomChanged(true);
 
@@ -6507,7 +6507,7 @@ L.CanvasTileLayer = L.Layer.extend({
 	preZoomAnimation: function (pinchStartCenter) {
 		this._pinchStartCenter = this._map.project(pinchStartCenter).multiplyBy(app.dpiScale); // in core pixels
 
-		if (this.isCursorVisible()) {
+		if (this._cursorMarker && this.isCursorVisible()) {
 			this._cursorMarker.setOpacity(0);
 		}
 		if (this._map._textInput._cursorHandler) {

--- a/browser/src/layer/tile/ScrollSection.ts
+++ b/browser/src/layer/tile/ScrollSection.ts
@@ -350,7 +350,7 @@ export class ScrollSection extends CanvasSectionObject {
 	public onUpdateScrollOffset (): void {
 		if (this.map._docLayer._docType === 'spreadsheet') {
 			this.map._docLayer.refreshViewData();
-			this.map._docLayer.updateScollLimit();
+			this.map._docLayer.updateScrollLimit();
 		}
 	}
 


### PR DESCRIPTION
This is a backport of #9154

Previously, zooming using the +/- zoom buttons caused your view to jump such that alternating in/out zooms would move you to the top left of the document

Additionally, the zoom did not zoom around the correct position, so a cursor in the frame would not correctly zoom around the cursor

This is now fixed


Change-Id: I6d468795abbb972174774cf1620cb4a0959142f2