### PR TITLE
fix(impress): Allow rightclick on selected videos

### DIFF
--- a/browser/src/layer/vector/SVGGroup.js
+++ b/browser/src/layer/vector/SVGGroup.js
@@ -91,7 +91,7 @@ L.SVGGroup = L.Layer.extend({
 
 		var videoContainer = svgLastChild.querySelector('body');
 		var videos = svgLastChild.getElementsByTagName('video');
-		this.addVideoSupportHandlers(videos);
+		this.addVideoEventHandlers(videos);
 
 		function _fixSVGPos() {
 			var mat = svgLastChild.getScreenCTM();
@@ -110,7 +110,7 @@ L.SVGGroup = L.Layer.extend({
 		}
 	},
 
-	addVideoSupportHandlers: function(videos) {
+	addVideoEventHandlers: function(videos) {
 		if (!videos)
 			return;
 
@@ -138,8 +138,17 @@ L.SVGGroup = L.Layer.extend({
 					that.showUnsupportedVideoWarning();
 				});
 			}
-		}
 
+			/* When we try to open the video context menu, don't block the rightclick sending to core */
+			video.addEventListener('contextmenu', (event) => {
+				const latLng = this._map.mouseEventToLatLng(event);
+				const position = this._map._docLayer._latLngToTwips(latLng);
+				this._map._docLayer._postMouseEvent('buttondown', position.x, position.y, 1, 4, 0);
+
+				event.preventDefault();
+				event.stopPropagation();
+			});
+		}
 	},
 
 	showUnsupportedVideoWarning: function() {


### PR DESCRIPTION
Previously you were unable to open the context menu on desktop (via right click) if the video had been selected (with left click) beforehand. This was frustrating if you knew about it, and confusing if you didn't

We can fix this by sending the rightclick event to core if it's triggered on a video.


Change-Id: Icb275854c8dfb0349ce6ef401b14adeb152e53f6

