### PR TITLE
Text selections handles should be active when there is a text selection.

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -3567,8 +3567,7 @@ L.CanvasTileLayer = L.Layer.extend({
 
 			if (!app.isPointVisibleInTheDisplayedArea(new app.definitions.simplePoint(correctedCursor.x1, correctedCursor.y1).toArray()) ||
 				!app.isPointVisibleInTheDisplayedArea(new app.definitions.simplePoint(correctedCursor.x2, correctedCursor.y2).toArray())) {
-				if (!this._selectionHandles.active &&
-				    !(app.isFollowingEditor() || app.isFollowingUser()) &&
+				if (!(app.isFollowingEditor() || app.isFollowingUser()) &&
 				    !this._map.calcInputBarHasFocus()) {
 					this.scrollToPos(new app.definitions.simplePoint(correctedCursor.x1, correctedCursor.y1));
 				}


### PR DESCRIPTION
That condition shouldn't be checked before scrolling to selection position.

This fixes "doesn't scroll to searched text" issue.


Change-Id: I9f901ba2fa15ade5416ad68f62e356e34163c641


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

