### PR TITLE
Cypress: Mobile calc: nonexistent #test-div-cell_selection_handle_start

### DIFF
--- a/cypress_test/integration_tests/common/calc_helper.js
+++ b/cypress_test/integration_tests/common/calc_helper.js
@@ -156,7 +156,7 @@ function selectEntireSheet() {
 		});
 
 	helper.doIfOnMobile(function() {
-		cy.cGet('#test-div-cell_selection_handle_start').should('exist');
+		cy.cGet('.text-selection-handle-start').should('exist');
 	});
 
 	var regex = /^A1:(AMJ|XFD)1048576$/;


### PR DESCRIPTION
I have noticed by looking at one of the PRs
https://github.com/CollaboraOnline/online/pull/9186 that this
unrelated test is failing.

I have tested locally and indeed, sometimes it fails. It seems it
tries to check for '#test-div-cell_selection_handle_start' but I
couldn't find it either. But I did find '.text-selection-handle-start'

Change-Id: I1daec0df5b8135935127b1de1348458b288c2d51

---

Here is the breakdown (v passes, x fails):

Mobile: calc/cell_appearance_spec.js
 Apply left and right border
- [ v ] cGet input#addressInput-input
   - log<< removeTextSelection - end
   [Comment] ^ from calc_helper.js:removeTextSelection()
- [ x ] cGet#test-div-cell_selection_handle_start
  - expected #test-div-cell_selection_handle_start to exist in the DOM
  [Comment] ^ Called in the calc_helper.js:helper.doIfOnMobile()

----

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
