### PR TITLE
remove mention of saveDataToFileSafely that doesn't exist

### DIFF
--- a/common/FileUtil.hpp
+++ b/common/FileUtil.hpp
@@ -36,13 +36,6 @@ namespace FileUtil
     /// Create a secure, random directory path.
     std::string createRandomDir(const std::string& path);
 
-    // Save data to a file (overwriting an existing file if necessary) with checks for errors. Write
-    // to a temporary file in the same directory that is then atomically renamed to the desired name
-    // if everything goes well. In case of any error, both the destination file (if it already
-    // exists) and the temporary file (if was created, or existed already) are removed. Return true
-    // if everything succeeded.
-    bool saveDataToFileSafely(const std::string& fileName, const char* data, std::size_t size);
-
     // We work around some of the mess of using the same sources both on the server side and in unit
     // tests with conditional compilation based on BUILDING_TESTS.
 


### PR DESCRIPTION
doesn't exist since:

commit fdf5687d7c76d8bea3268bcc65a42fcfc45b1877
Date:   Mon Apr 20 16:30:05 2020 +0300

    Bin some dead code, this gets rid of a use of Util::alertAllUsers(), yay


Change-Id: I90976ab75649ab58197d593520d90d6579a07cfe


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

