### PR TITLE
Unload Kit Session/View

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -806,9 +806,8 @@ bool Document::createSession(const std::string& sessionId)
         _lastUpdatedAt[viewId] = std::chrono::steady_clock::now();
         _speedCount[viewId] = 0;
 
-        LOG_DBG("Have " << _sessions.size() << " active sessions after creating "
-                << session->getId());
-        LOG_INF("New session [" << sessionId << "]");
+        LOG_INF("New session [" << sessionId << "] created. Have " << _sessions.size()
+                                << " sessions now");
 
         updateActivityHeader();
         return true;


### PR DESCRIPTION
wsd: always exit Kit when unloading

We never re-use a Kit process. Therefore,
when we unload a document, we must also
exit the Kit process.

Alternatively, when there is at least
1 session, we keep the document loaded
and the Kit process so that a new
view can be created.
