### PR TITLE
Add an endpoint to check connectivity to WOPI server

### DIFF
--- a/net/NetUtil.cpp
+++ b/net/NetUtil.cpp
@@ -577,7 +577,7 @@ connect(std::string uri, const std::shared_ptr<ProtocolHandlerInterface>& protoc
 }
 
 bool parseUri(std::string uri, std::string& scheme, std::string& host, std::string& port,
-              std::string& url)
+              std::string& pathAndQuery)
 {
     const auto itScheme = uri.find("://");
     if (itScheme != uri.npos)
@@ -594,12 +594,12 @@ bool parseUri(std::string uri, std::string& scheme, std::string& host, std::stri
     const auto itUrl = uri.find('/');
     if (itUrl != uri.npos)
     {
-        url = uri.substr(itUrl); // Including the first foreslash.
+        pathAndQuery = uri.substr(itUrl); // Including the first foreslash.
         uri = uri.substr(0, itUrl);
     }
     else
     {
-        url.clear();
+        pathAndQuery.clear();
     }
 
     const auto itPort = uri.find(':');

--- a/net/NetUtil.hpp
+++ b/net/NetUtil.hpp
@@ -112,14 +112,14 @@ connect(std::string uri, const std::shared_ptr<ProtocolHandlerInterface>& protoc
 /// Decomposes a URI into its components.
 /// Returns true if parsing was successful.
 bool parseUri(std::string uri, std::string& scheme, std::string& host, std::string& port,
-              std::string& url);
+              std::string& pathAndQuery);
 
 /// Decomposes a URI into its components.
 /// Returns true if parsing was successful.
 inline bool parseUri(std::string uri, std::string& scheme, std::string& host, std::string& port)
 {
-    std::string url;
-    return parseUri(std::move(uri), scheme, host, port, url);
+    std::string pathAndQuery;
+    return parseUri(std::move(uri), scheme, host, port, pathAndQuery);
 }
 
 /// Return the locator given a URI.

--- a/net/NetUtil.hpp
+++ b/net/NetUtil.hpp
@@ -89,7 +89,16 @@ std::shared_ptr<StreamSocket>
 connect(const std::string& host, const std::string& port, const bool isSSL,
         const std::shared_ptr<ProtocolHandlerInterface>& protocolHandler);
 
-typedef std::function<void(std::shared_ptr<StreamSocket>)> asyncConnectCB;
+enum class AsyncConnectResult{
+    Ok = 0,
+    SocketError,
+    ConnectionError,
+    HostNameError,
+    UnknownHostError,
+    SSLHandShakeFailure,
+};
+
+typedef std::function<void(std::shared_ptr<StreamSocket>, AsyncConnectResult result)> asyncConnectCB;
 
 void
 asyncConnect(const std::string& host, const std::string& port, const bool isSSL,

--- a/test/HttpRequestTests.cpp
+++ b/test/HttpRequestTests.cpp
@@ -311,7 +311,7 @@ void HttpRequestTests::testSimpleGet()
 
         std::unique_lock<std::mutex> lock(mutex);
 
-        httpSession->setConnectFailHandler([]() {
+        httpSession->setConnectFailHandler([](const std::shared_ptr<http::Session>&) {
             LOK_ASSERT_FAIL("Unexpected connection failure");
         });
 
@@ -535,7 +535,7 @@ void HttpRequestTests::test500GetStatuses()
         std::unique_lock<std::mutex> lock(mutex);
         timedout = true; // Assume we timed out until we prove otherwise.
 
-        httpSession->setConnectFailHandler([]() {
+        httpSession->setConnectFailHandler([](const std::shared_ptr<http::Session>&) {
             LOK_ASSERT_FAIL("Unexpected connection failure");
         });
 
@@ -628,7 +628,7 @@ void HttpRequestTests::testSimplePost_External()
 
     std::unique_lock<std::mutex> lock(mutex);
 
-    httpSession->setConnectFailHandler([]() {
+    httpSession->setConnectFailHandler([](const std::shared_ptr<http::Session>&) {
         LOK_ASSERT_FAIL("Unexpected connection failure");
     });
 

--- a/test/UnitProxy.cpp
+++ b/test/UnitProxy.cpp
@@ -53,7 +53,7 @@ public:
         // Request from rating.collaboraonline.com.
         _req = http::Request("/browser/a90f83c/foo/remote/static/lokit-extra-img.svg");
 
-        httpSession->setConnectFailHandler([this]() {
+        httpSession->setConnectFailHandler([this](const std::shared_ptr<http::Session>&) {
             LOK_ASSERT_FAIL("Unexpected connection failure");
         });
 

--- a/test/WhiteBoxTests.cpp
+++ b/test/WhiteBoxTests.cpp
@@ -1099,72 +1099,72 @@ void WhiteBoxTests::testParseUriUrl()
     std::string scheme = "***";
     std::string host = "***";
     std::string port = "***";
-    std::string url = "***";
+    std::string pathAndQuery = "***";
 
-    LOK_ASSERT(!net::parseUri(std::string(), scheme, host, port, url));
+    LOK_ASSERT(!net::parseUri(std::string(), scheme, host, port, pathAndQuery));
     LOK_ASSERT(scheme.empty());
     LOK_ASSERT(host.empty());
     LOK_ASSERT(port.empty());
-    LOK_ASSERT(url.empty());
+    LOK_ASSERT(pathAndQuery.empty());
 
-    LOK_ASSERT(net::parseUri("localhost", scheme, host, port, url));
+    LOK_ASSERT(net::parseUri("localhost", scheme, host, port, pathAndQuery));
     LOK_ASSERT(scheme.empty());
     LOK_ASSERT_EQUAL(std::string("localhost"), host);
     LOK_ASSERT(port.empty());
-    LOK_ASSERT(url.empty());
+    LOK_ASSERT(pathAndQuery.empty());
 
-    LOK_ASSERT(net::parseUri("127.0.0.1", scheme, host, port, url));
+    LOK_ASSERT(net::parseUri("127.0.0.1", scheme, host, port, pathAndQuery));
     LOK_ASSERT(scheme.empty());
     LOK_ASSERT_EQUAL(std::string("127.0.0.1"), host);
     LOK_ASSERT(port.empty());
-    LOK_ASSERT(url.empty());
+    LOK_ASSERT(pathAndQuery.empty());
 
-    LOK_ASSERT(net::parseUri("domain.com", scheme, host, port, url));
+    LOK_ASSERT(net::parseUri("domain.com", scheme, host, port, pathAndQuery));
     LOK_ASSERT(scheme.empty());
     LOK_ASSERT_EQUAL(std::string("domain.com"), host);
     LOK_ASSERT(port.empty());
-    LOK_ASSERT(url.empty());
+    LOK_ASSERT(pathAndQuery.empty());
 
-    LOK_ASSERT(net::parseUri("127.0.0.1:9999", scheme, host, port, url));
+    LOK_ASSERT(net::parseUri("127.0.0.1:9999", scheme, host, port, pathAndQuery));
     LOK_ASSERT(scheme.empty());
     LOK_ASSERT_EQUAL(std::string("127.0.0.1"), host);
     LOK_ASSERT_EQUAL(std::string("9999"), port);
-    LOK_ASSERT(url.empty());
+    LOK_ASSERT(pathAndQuery.empty());
 
-    LOK_ASSERT(net::parseUri("domain.com:88", scheme, host, port, url));
+    LOK_ASSERT(net::parseUri("domain.com:88", scheme, host, port, pathAndQuery));
     LOK_ASSERT(scheme.empty());
     LOK_ASSERT_EQUAL(std::string("domain.com"), host);
     LOK_ASSERT_EQUAL(std::string("88"), port);
-    LOK_ASSERT(url.empty());
+    LOK_ASSERT(pathAndQuery.empty());
 
-    LOK_ASSERT(net::parseUri("http://domain.com", scheme, host, port, url));
+    LOK_ASSERT(net::parseUri("http://domain.com", scheme, host, port, pathAndQuery));
     LOK_ASSERT_EQUAL(std::string("http://"), scheme);
     LOK_ASSERT_EQUAL(std::string("domain.com"), host);
     LOK_ASSERT(port.empty());
-    LOK_ASSERT(url.empty());
+    LOK_ASSERT(pathAndQuery.empty());
 
-    LOK_ASSERT(net::parseUri("https://domain.com:88", scheme, host, port, url));
+    LOK_ASSERT(net::parseUri("https://domain.com:88", scheme, host, port, pathAndQuery));
     LOK_ASSERT_EQUAL(std::string("https://"), scheme);
     LOK_ASSERT_EQUAL(std::string("domain.com"), host);
     LOK_ASSERT_EQUAL(std::string("88"), port);
 
-    LOK_ASSERT(net::parseUri("http://domain.com/path/to/file", scheme, host, port, url));
+    LOK_ASSERT(net::parseUri("http://domain.com/path/to/file", scheme, host, port, pathAndQuery));
     LOK_ASSERT_EQUAL(std::string("http://"), scheme);
     LOK_ASSERT_EQUAL(std::string("domain.com"), host);
     LOK_ASSERT(port.empty());
-    LOK_ASSERT_EQUAL(std::string("/path/to/file"), url);
+    LOK_ASSERT_EQUAL(std::string("/path/to/file"), pathAndQuery);
 
-    LOK_ASSERT(net::parseUri("https://domain.com:88/path/to/file", scheme, host, port, url));
+    LOK_ASSERT(net::parseUri("https://domain.com:88/path/to/file", scheme, host, port, pathAndQuery));
     LOK_ASSERT_EQUAL(std::string("https://"), scheme);
     LOK_ASSERT_EQUAL(std::string("domain.com"), host);
     LOK_ASSERT_EQUAL(std::string("88"), port);
-    LOK_ASSERT_EQUAL(std::string("/path/to/file"), url);
+    LOK_ASSERT_EQUAL(std::string("/path/to/file"), pathAndQuery);
 
-    LOK_ASSERT(net::parseUri("wss://127.0.0.1:9999/", scheme, host, port, url));
+    LOK_ASSERT(net::parseUri("wss://127.0.0.1:9999/", scheme, host, port, pathAndQuery));
     LOK_ASSERT_EQUAL(std::string("wss://"), scheme);
     LOK_ASSERT_EQUAL(std::string("127.0.0.1"), host);
     LOK_ASSERT_EQUAL(std::string("9999"), port);
-    LOK_ASSERT_EQUAL(std::string("/"), url);
+    LOK_ASSERT_EQUAL(std::string("/"), pathAndQuery);
 }
 
 void WhiteBoxTests::testParseUrl()

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -23,6 +23,8 @@
 #include <Exceptions.hpp>
 #include <FileServer.hpp>
 #include <HttpRequest.hpp>
+#include <NetUtil.hpp>
+#include <JsonUtil.hpp>
 #include <JailUtil.hpp>
 #include <ProofKey.hpp>
 #include <ProxyRequestHandler.hpp>

--- a/wsd/ClientRequestDispatcher.hpp
+++ b/wsd/ClientRequestDispatcher.hpp
@@ -71,6 +71,10 @@ private:
     bool handleCapabilitiesRequest(const Poco::Net::HTTPRequest& request,
                                    const std::shared_ptr<StreamSocket>& socket);
 
+    bool handleWopiAccessCheckRequest(const Poco::Net::HTTPRequest& request,
+                                   Poco::MemoryInputStream& message,
+                                   const std::shared_ptr<StreamSocket>& socket);
+
     /// @return true if request has been handled synchronously and response sent, otherwise false
     static bool handleClipboardRequest(const Poco::Net::HTTPRequest& request,
                                        Poco::MemoryInputStream& message,

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -369,7 +369,7 @@ void ClientSession::handleClipboardRequest(DocumentBroker::ClipboardRequest     
                         {
                             httpSession->setFinishedHandler(std::move(finishedCallback));
 
-                            http::Session::ConnectFailCallback connectFailCallback = [this, url]()
+                            http::Session::ConnectFailCallback connectFailCallback = [this, url](const std::shared_ptr<http::Session>& /* session */)
                             {
                                 LOG_ERR(
                                     "Failed to start an async clipboard download request with URL ["

--- a/wsd/HostUtil.cpp
+++ b/wsd/HostUtil.cpp
@@ -240,6 +240,11 @@ void HostUtil::setFirstHost(const Poco::URI& uri)
     }
 }
 
+bool HostUtil::isWopiHostsEmpty()
+{
+    return WopiHosts.empty();
+}
+
 #endif // !MOBILEAPP
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/HostUtil.hpp
+++ b/wsd/HostUtil.hpp
@@ -55,6 +55,8 @@ public:
 
     static void setFirstHost(const Poco::URI& uri);
 
+    static bool isWopiHostsEmpty();
+
 private:
     /// add host to WopiHosts
     static void addWopiHost(const std::string& host, bool allow);

--- a/wsd/ProxyRequestHandler.cpp
+++ b/wsd/ProxyRequestHandler.cpp
@@ -90,7 +90,7 @@ void ProxyRequestHandler::handleRequest(const std::string& relPath,
     sessionProxy->setFinishedHandler(std::move(proxyCallback));
 
     http::Session::ConnectFailCallback connectFailCallback =
-        [socket]() {
+        [socket](const std::shared_ptr<http::Session>& /* session */) {
             HttpHelper::sendErrorAndShutdown(http::StatusCode::BadRequest, socket);
     };
     sessionProxy->setConnectFailHandler(std::move(connectFailCallback));

--- a/wsd/wopi/CheckFileInfo.cpp
+++ b/wsd/wopi/CheckFileInfo.cpp
@@ -145,7 +145,7 @@ void CheckFileInfo::checkFileInfo(int redirectLimit)
     _httpSession->setFinishedHandler(std::move(finishedCallback));
 
     http::Session::ConnectFailCallback connectFailCallback =
-        [this]()
+        [this](const std::shared_ptr<http::Session>& /* httpSession */)
     {
         _state = State::Fail;
         LOG_ERR("Failed to start an async CheckFileInfo request");

--- a/wsd/wopi/WopiStorage.cpp
+++ b/wsd/wopi/WopiStorage.cpp
@@ -899,7 +899,7 @@ std::size_t WopiStorage::uploadLocalFileToStorageAsync(
 
         LOG_DBG(wopiLog << " async upload request: " << httpRequest.header().toString());
 
-        _uploadHttpSession->setConnectFailHandler([asyncUploadCallback]() {
+        _uploadHttpSession->setConnectFailHandler([asyncUploadCallback](const std::shared_ptr<http::Session>& /* httpSession */) {
             LOG_ERR("Cannot connect for uploading to wopi storage.");
             asyncUploadCallback(AsyncUpload(AsyncUpload::State::Error,
                             UploadResult(UploadResult::Result::FAILED, "Connection failed.")));


### PR DESCRIPTION
The endpoint is accessible at /hosting/wopiAccessCheck

You send it a POST with input json:
{
	"callbackUrl: "<url-to-my-wopi-host>"
}

For instance:
curl -ki https://localhost:9980/hosting/wopiAccessCheck --header "Content-Type: application/json" -d '{"callbackUrl":"https://cool.local"}'

Returns json such as:
{
	"status": 0,
	"details": "OK"
}
With status and details giving hints to what went wrong if it did.

The callbackUrl needs just to be an HTTPS endpoint, it does not need to be the wopi service but can be only a healthcheck url for instance.


Change-Id: Ibdef0bbf0d2fd98e3d293a06dfcfc79478d618e5



cc @juliushaertl 

Superseeds https://github.com/CollaboraOnline/online/pull/4353

