### PR TITLE
RTL scroll fixes

### DIFF
--- a/browser/src/canvas/sections/ScrollSection.ts
+++ b/browser/src/canvas/sections/ScrollSection.ts
@@ -177,7 +177,7 @@ export class ScrollSection extends app.definitions.canvasSectionObject {
 				&& this.containerObject.isDraggingSomething()
 				&& L.Map.THIS._docLayer._docType === 'spreadsheet') {
 					var temp = this.containerObject.positionOnMouseDown;
-					var tempPos = [(this.isCalcRTL() ? this.map._size.x - temp[0] : temp[0]) * app.dpiScale, temp[1] * app.dpiScale];
+					var tempPos = [(this.isRTL() ? this.map._size.x - temp[0] : temp[0]) * app.dpiScale, temp[1] * app.dpiScale];
 					var docTopLeft = app.sectionContainer.getDocumentTopLeft();
 					tempPos = [tempPos[0] + docTopLeft[0], tempPos[1] + docTopLeft[1]];
 					tempPos = [Math.round(tempPos[0] * app.pixelsToTwips), Math.round(tempPos[1] * app.pixelsToTwips)];
@@ -198,8 +198,8 @@ export class ScrollSection extends app.definitions.canvasSectionObject {
 			vy = -50;
 		}
 
-		const mousePosX: number = this.isCalcRTL() ? e.map._size.x - e.pos.x : e.pos.x;
-		const mapLeft: number = this.isCalcRTL() ? e.map._size.x - e.map._getTopLeftPoint().x : e.map._getTopLeftPoint().x;
+		const mousePosX: number = this.isRTL() ? e.map._size.x - e.pos.x : e.pos.x;
+		const mapLeft: number = this.isRTL() ? e.map._size.x - e.map._getTopLeftPoint().x : e.map._getTopLeftPoint().x;
 		if (mousePosX > e.map._size.x - 50) {
 			vx = 50;
 		} else if (mousePosX < 50 && mapLeft > 50) {
@@ -403,7 +403,7 @@ export class ScrollSection extends app.definitions.canvasSectionObject {
 	private drawVerticalScrollBar (): void {
 		var scrollProps: any = this.getVerticalScrollProperties();
 
-		var startX = this.isCalcRTL() ? this.sectionProperties.edgeOffset : this.size[0] - this.sectionProperties.scrollBarThickness - this.sectionProperties.edgeOffset;
+		var startX = this.isRTL() ? this.sectionProperties.edgeOffset : this.size[0] - this.sectionProperties.scrollBarThickness - this.sectionProperties.edgeOffset;
 
 		if (this.sectionProperties.drawScrollBarRailway) {
 			this.context.globalAlpha = this.sectionProperties.scrollBarRailwayAlpha;
@@ -450,7 +450,7 @@ export class ScrollSection extends app.definitions.canvasSectionObject {
 
 		const sizeX = scrollProps.scrollSize - this.sectionProperties.scrollBarThickness;
 		const docWidth: number = this.map.getPixelBoundsCore().getSize().x;
-		const startX = this.isCalcRTL() ? docWidth - scrollProps.startX - sizeX : scrollProps.startX;
+		const startX = this.isRTL() ? docWidth - scrollProps.startX - sizeX : scrollProps.startX;
 
 		if (this.sectionProperties.drawScrollBarRailway) {
 			this.context.globalAlpha = this.sectionProperties.scrollBarRailwayAlpha;
@@ -639,7 +639,7 @@ export class ScrollSection extends app.definitions.canvasSectionObject {
 	}
 
 	private isMouseOnScrollBar (point: Array<number>): void {
-		const mirrorX = this.isCalcRTL();
+		const mirrorX = this.isRTL();
 		if (this.documentTopLeft[1] >= 0) {
 			if ((!mirrorX && point[0] >= this.size[0] - this.sectionProperties.usableThickness)
 				|| (mirrorX && point[0] <= this.sectionProperties.usableThickness)) {
@@ -777,7 +777,7 @@ export class ScrollSection extends app.definitions.canvasSectionObject {
 
 		const sizeX = scrollProps.scrollSize - this.sectionProperties.scrollBarThickness;
 		const docWidth: number = this.map.getPixelBoundsCore().getSize().x;
-		const startX = this.isCalcRTL() ? docWidth - scrollProps.startX - sizeX : scrollProps.startX;
+		const startX = this.isRTL() ? docWidth - scrollProps.startX - sizeX : scrollProps.startX;
 		const endX = startX + sizeX;
 
 		var pointerIsSyncWithScrollBar = false;
@@ -892,7 +892,7 @@ export class ScrollSection extends app.definitions.canvasSectionObject {
 		var props = this.getHorizontalScrollProperties();
 		const sizeX = props.scrollSize - this.sectionProperties.scrollBarThickness;
 		const docWidth: number = this.map.getPixelBoundsCore().getSize().x;
-		const startX = this.isCalcRTL() ? docWidth - props.startX - sizeX : props.startX;
+		const startX = this.isRTL() ? docWidth - props.startX - sizeX : props.startX;
 		var midX = startX + sizeX * 0.5;
 
 		if (this.stepByStepScrolling) {
@@ -941,7 +941,7 @@ export class ScrollSection extends app.definitions.canvasSectionObject {
 		this.onMouseMove(point, null, e);
 		this.isMouseOnScrollBar(point);
 
-		const mirrorX = this.isCalcRTL();
+		const mirrorX = this.isRTL();
 
 		if (this.documentTopLeft[1] >= 0) {
 			if ((!mirrorX && point[0] >= this.size[0] - this.sectionProperties.usableThickness)

--- a/browser/src/canvas/sections/ScrollSection.ts
+++ b/browser/src/canvas/sections/ScrollSection.ts
@@ -360,7 +360,9 @@ export class ScrollSection extends app.definitions.canvasSectionObject {
 		this.context.fillStyle = 'white';
 
 		var circleStartY = scrollProps.startY + this.sectionProperties.circleSliderRadius;
-		var circleStartX = this.size[0] - this.sectionProperties.circleSliderRadius * 0.5;
+		var circleStartX = this.isRTL()
+			? this.sectionProperties.circleSliderRadius * 0.5
+			: this.size[0] - this.sectionProperties.circleSliderRadius * 0.5;
 
 		this.context.beginPath();
 		this.context.arc(circleStartX, circleStartY, this.sectionProperties.circleSliderRadius, 0, Math.PI * 2, true);

--- a/browser/src/canvas/sections/ScrollSection.ts
+++ b/browser/src/canvas/sections/ScrollSection.ts
@@ -734,7 +734,7 @@ export class ScrollSection extends app.definitions.canvasSectionObject {
 	}
 
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-	private isMousePointerSycnWithVerticalScrollBar (scrollProps: any, position: Array<number>): boolean {
+	private isMousePointerSyncedWithVerticalScrollBar (scrollProps: any, position: Array<number>): boolean {
 		// Keep this desktop-only for now.
 		if (!(<any>window).mode.isDesktop())
 			return true;
@@ -765,7 +765,7 @@ export class ScrollSection extends app.definitions.canvasSectionObject {
 	}
 
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-	private isMousePointerSycnWithHorizontalScrollBar (scrollProps: any, position: Array<number>): boolean {
+	private isMousePointerSyncedWithHorizontalScrollBar (scrollProps: any, position: Array<number>): boolean {
 		// Keep this desktop-only for now.
 		if (!(<any>window).mode.isDesktop())
 			return true;
@@ -815,7 +815,7 @@ export class ScrollSection extends app.definitions.canvasSectionObject {
 			var diffY: number = dragDistance[1] - this.sectionProperties.previousDragDistance[1];
 			var actualDistance = scrollProps.ratio * diffY;
 
-			if (this.isMousePointerSycnWithVerticalScrollBar(scrollProps, position))
+			if (this.isMousePointerSyncedWithVerticalScrollBar(scrollProps, position))
 				this.scrollVerticalWithOffset(actualDistance);
 
 			this.sectionProperties.previousDragDistance[1] = dragDistance[1];
@@ -834,7 +834,7 @@ export class ScrollSection extends app.definitions.canvasSectionObject {
 			var diffX: number = dragDistance[0] - this.sectionProperties.previousDragDistance[0];
 			var actualDistance = scrollProps.ratio * diffX;
 
-			if (this.isMousePointerSycnWithHorizontalScrollBar(scrollProps, position))
+			if (this.isMousePointerSyncedWithHorizontalScrollBar(scrollProps, position))
 				this.scrollHorizontalWithOffset(actualDistance);
 
 			this.sectionProperties.previousDragDistance[0] = dragDistance[0];

--- a/browser/src/canvas/sections/ScrollSection.ts
+++ b/browser/src/canvas/sections/ScrollSection.ts
@@ -830,9 +830,8 @@ export class ScrollSection extends app.definitions.canvasSectionObject {
 
 			this.showHorizontalScrollBar();
 
-			var signX = this.isCalcRTL() ? -1 : 1;
 			var scrollProps: any = this.getHorizontalScrollProperties();
-			var diffX: number = signX * (dragDistance[0] - this.sectionProperties.previousDragDistance[0]);
+			var diffX: number = dragDistance[0] - this.sectionProperties.previousDragDistance[0];
 			var actualDistance = scrollProps.ratio * diffX;
 
 			if (this.isMousePointerSycnWithHorizontalScrollBar(scrollProps, position))


### PR DESCRIPTION
Mobile (not tablet) mode has a different sort of scrollbar to desktop
mode. Like the desktop scrollbar, it should render on the other side if
we are in RTL mode.

---

This is a fix for a regression which I introduced in
If4261a3e32375f6127241b846b97a3b4ac29eb0b.

Before this fix we were flipping the direction of scrolling on RTL mode
twice, once in onMouseMove and once in scrollHorizontalWithOffset. This
had the effect of cancelling to not flip the scroll at all. Oops.

The scrollHorizontalWithOffset isRTL distinction is still important to
keep for panning, so I'll remove the other one.

---

In If4261a3e32375f6127241b846b97a3b4ac29eb0b, I introduced isRTL, which
can be set at construction of a ScrollSection. Unfortunately, some
places in ScrollSection still used isCalcRTL which could theorectically
be out-of-sync with isRTL, causing inconsistency in different parts of
ScrollSection code. This commit standardizes on only using isRTL.

Signed-off-by: Skyler Grey <skyler.grey@collabora.com>