### PR TITLE
Invert Calc document color

### DIFF
--- a/browser/css/color-palette-dark.css
+++ b/browser/css/color-palette-dark.css
@@ -11,7 +11,7 @@
 	--color-text-darker: #c0bfbc;  /* hover */
 	--color-text-lighter: #fff; /* secondard text, disabled */
 
-	--color-canvas: #141414;
+	--color-canvas-dark: #141414;
 	--color-background-document: #121212;
 	--color-main-background: #121212;
 	--color-background-dark: #1E1E1E;  /* select */

--- a/browser/css/color-palette.css
+++ b/browser/css/color-palette.css
@@ -12,7 +12,7 @@
 	--color-text-darker: #000;  /* hover */
 	--color-text-lighter: #696969; /* secondard text, disabled */
 
-	--color-canvas: #f5f5f5;
+	--color-canvas-light: #f5f5f5;
 	--color-background-document: #FFFFFF;
 	--color-main-background: #F8F9FA;
 	--color-background-dark: #e8e8e8;  /* select */

--- a/browser/src/canvas/CanvasSectionContainer.ts
+++ b/browser/src/canvas/CanvasSectionContainer.ts
@@ -251,7 +251,9 @@ class CanvasSectionContainer {
 		this.scrollLineHeight = parseInt(window.getComputedStyle(tempElement).fontSize);
 		document.body.removeChild(tempElement); // Remove the temporary element.
 
-		this.clearColor = window.getComputedStyle(document.documentElement).getPropertyValue('--color-canvas');
+		const colorCanvasPropety = (window as any).prefs.get('darkTheme') ? '--color-canvas-dark' : '--color-canvas-light';
+
+		this.clearColor = window.getComputedStyle(document.documentElement).getPropertyValue(colorCanvasPropety);
 		// Set document background color to the app background color for now until we get the real color from the kit
 		// through a LOK_CALLBACK_DOCUMENT_BACKGROUND_COLOR
 		this.documentBackgroundColor = window.getComputedStyle(document.documentElement).getPropertyValue('--color-background-document');

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -95,10 +95,14 @@ L.Control.UIManager = L.Control.extend({
 		this.map.fire('darkmodechanged');
 	},
 
-	setCanvasColorAfterModeChange: function() {
+	setCanvasColorAfterModeChange: function(nColor) {
 		if (app.sectionContainer) {
 			app.sectionContainer.setBackgroundColorMode(false);
-			app.sectionContainer.setClearColor(window.getComputedStyle(document.documentElement).getPropertyValue('--color-canvas'));
+			if (nColor == undefined ) {
+				const colorCanvasPropety = window.prefs.getBoolean('darkTheme') ? '--color-canvas-dark' : '--color-canvas-light';
+				nColor = window.getComputedStyle(document.documentElement).getPropertyValue(colorCanvasPropety);
+			}
+			app.sectionContainer.setClearColor(nColor);
 			//change back to it's default value after setting canvas color
 			app.sectionContainer.setBackgroundColorMode(true);
 		}
@@ -106,6 +110,14 @@ L.Control.UIManager = L.Control.extend({
 
 	invertBackground: function() {
 		app.socket.sendMessage('uno .uno:InvertBackground');
+		if (this.map.getDocType() == 'spreadsheet') {
+			var lightCanvasColor = window.getComputedStyle(document.documentElement).getPropertyValue('--color-canvas-light');
+			var darkCanvasColor = window.getComputedStyle(document.documentElement).getPropertyValue('--color-canvas-dark');
+			var nColor = app.sectionContainer.getClearColor(); // Current color of the canvas
+			// invert canvas color
+			nColor == lightCanvasColor ? nColor = darkCanvasColor : nColor = lightCanvasColor
+			this.setCanvasColorAfterModeChange(nColor);
+		}
 	},
 
 	toggleDarkMode: function() {


### PR DESCRIPTION
Inverts calc document color even app is dark mode. Follow-up 8cd1245efa3f98b64853053ebd8e479ae62db133

Other components has special DOCCOLOR and canvas color behind the document. Calc is special case because we see directly canvas color behind the cells. DOCCOLOR doesn't affect here directly. So we handle calc case in this commit.


Change-Id: I56b279495cb050d79ee5452b363c8bf7e5b1026e


* Resolves: #9061
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

