### PR TITLE
browser: toolbar: avoid forcing to clear references

### DIFF
--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -951,9 +951,6 @@ L.Map.include({
 		$('#AutoSumMenu-button').css('margin-inline', '0');
 		$('#AutoSumMenu .unoarrow').css('margin', '0');
 
-		// clear reference marks
-		map._docLayer._clearReferences();
-
 		map.formulabar.blurField();
 		$('#addressInput-input').blur();
 	},


### PR DESCRIPTION
1) press F2 to edit a formula cell with defined range
2) The reference it is marked and painted
3) The formula bar lost focus and force to clear the mark

The references will be cleared due to response from server message.

Change-Id: I32fbacc8d846cf8ba8b3371f3386d07e9cebe470
Signed-off-by: Henry Castro <hcastro@collabora.com>
