### PR TITLE
Use Workers to do tile decompression and unpremultiply

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -203,6 +203,7 @@ COOL_JS_LST =\
 	src/core/Rectangle.ts \
 	src/core/Class.js \
 	src/core/Events.js \
+	src/core/SocketWorker.js \
 	src/core/Socket.js \
 	src/core/Matrix.js \
 	src/core/Debug.js \
@@ -262,6 +263,7 @@ COOL_JS_LST =\
 	src/layer/vector/CanvasOverlay.ts \
 	src/canvas/sections/ScrollSection.ts \
 	src/layer/tile/CanvasTileLayer.js \
+	src/layer/tile/CanvasTileUtils.ts \
 	src/layer/vector/CDarkOverlay.ts \
 	src/layer/SplitPanesContext.ts \
 	src/layer/CalcSplitPanesContext.ts \
@@ -905,6 +907,7 @@ pot:
 		src/slideshow/transition/SlideWipeTransition.ts \
 		src/slideshow/transition/BarWipeTransition.ts \
 		src/core/Socket.js \
+		src/core/SocketWorker.js \
 		src/core/Debug.js \
 		src/docstate.js \
 		src/docstatefunctions.js \
@@ -912,6 +915,7 @@ pot:
 		src/app/DocEvents.ts \
 		src/errormessages.js \
 		src/layer/tile/CanvasTileLayer.js \
+		src/layer/tile/CanvasTileUtils.ts \
 		src/canvas/sections/CommentListSection.ts \
 		src/canvas/sections/CommentSection.ts \
 		src/main.js \

--- a/browser/src/core/SocketWorker.js
+++ b/browser/src/core/SocketWorker.js
@@ -1,0 +1,112 @@
+/* -*- js-indent-level: 8; fill-column: 100 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/* eslint-disable no-inner-declarations */
+/* eslint no-unused-vars: ["warn", { "argsIgnorePattern": "^_" }] */
+/* global importScripts Uint8Array cool */
+
+if ('undefined' === typeof window) {
+	importScripts('../../node_modules/fzstd/umd/index.js');
+	importScripts('../layer/tile/CanvasTileUtils.js');
+	addEventListener('message', onMessage);
+
+	console.info('SocketWorker initialised', self.fzstd);
+
+	var keyframeBufferSize = 0;
+	var keyframeBuffer;
+
+	function onMessage(e) {
+		switch (e.data.message) {
+			case 'tile':
+				var buffer = e.data.buffer;
+				var offset = 0;
+				var processed = [];
+				var buffers = [buffer.buffer];
+				for (const tile of e.data.tiles) {
+					// Allocate key-frame decompression buffer
+					if (tile.size > keyframeBufferSize) {
+						keyframeBufferSize = tile.size;
+						keyframeBuffer = new Uint8Array(tile.size);
+					}
+
+					var startOffset = tile.isKeyframe ? 0 : offset;
+					var fzstdBuffer = tile.isKeyframe ? keyframeBuffer : buffer;
+					var fzstdOffset = startOffset;
+
+					var stream = new self.fzstd.Decompress((chunk, _isLast) => {
+						fzstdBuffer.set(chunk, fzstdOffset);
+						fzstdOffset += chunk.length;
+					});
+					stream.push(tile.rawData);
+
+					if (tile.isKeyframe) {
+						cool.CanvasTileUtils.unrle(
+							keyframeBuffer,
+							tile.tileSize,
+							tile.tileSize,
+							buffer,
+							offset,
+						);
+						startOffset = offset;
+						offset += tile.tileSize * tile.tileSize * 4;
+					} else offset = fzstdOffset;
+
+					var data = new Uint8Array(
+						buffer.buffer,
+						startOffset,
+						offset - startOffset,
+					);
+
+					// Unpremultiply delta updates
+					if (!tile.isKeyframe) {
+						var stop = false;
+						for (var i = 0; i < data.length && !stop; ) {
+							switch (data[i]) {
+								case 99: // 'c': // copy row
+									i += 4;
+									break;
+								case 100: // 'd': // new run
+									var span = data[i + 3] * 4;
+									i += 4;
+									cool.CanvasTileUtils.unpremultiply(data, span, i);
+									i += span;
+									break;
+								case 116: // 't': // terminate delta
+									stop = true;
+									i++;
+									break;
+								default:
+									console.error(
+										'[' + i + ']: ERROR: Unknown delta code ' + data[i],
+									);
+									i = data.length;
+									break;
+							}
+						}
+					}
+					processed.push({
+						id: tile.id,
+						rawData: tile.rawData,
+						processedData: data,
+					});
+					buffers.push(tile.rawData.buffer);
+				}
+				postMessage(
+					{ message: e.data.message, tiles: processed, buffer: buffer },
+					buffers,
+				);
+				break;
+
+			default:
+				console.error('Unrecognised preprocessor message', e);
+		}
+	}
+}

--- a/browser/src/layer/tile/CanvasTileUtils.ts
+++ b/browser/src/layer/tile/CanvasTileUtils.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+declare var L: any;
+
+namespace cool {
+	export abstract class CanvasTileUtils {
+		public static unpremultiply(
+			data: Uint8Array,
+			byteLength: number,
+			byteOffset: number = 0,
+		): void {
+			for (var i = byteOffset; i < byteOffset + byteLength; i += 4) {
+				// premultiplied rgba -> unpremultiplied rgba
+				var alpha = data[i + 3];
+				if (alpha === 0) {
+					data.fill(0, i, i + 3);
+				} else if (alpha !== 255) {
+					data[i] = Math.ceil((data[i] * 255) / alpha);
+					data[i + 1] = Math.ceil((data[i + 1] * 255) / alpha);
+					data[i + 2] = Math.ceil((data[i + 2] * 255) / alpha);
+				}
+			}
+		}
+
+		private static lastPixel = new Uint8Array(4);
+
+		public static unrle(
+			data: Uint8Array,
+			width: number,
+			height: number,
+			output: Uint8Array,
+			outputOffset: number = 0,
+		): number {
+			// Byte bashing fun
+			var offset = 0;
+			for (var y = 0; y < height; ++y) {
+				var rleSize = data[offset] + data[offset + 1] * 256;
+				offset += 2;
+
+				var rleMask = offset;
+				const rleMaskSizeBytes = 256 / 8;
+
+				offset += rleMaskSizeBytes;
+
+				if (rleSize > 0) this.unpremultiply(data, rleSize * 4, offset);
+
+				// It would be rather nice to have real 64bit types [!]
+				this.lastPixel.fill(0);
+				var lastMask = 0;
+				var bitToCheck = 256;
+				var rleMaskOffset = rleMask;
+
+				var pixOffset = y * width * 4 + outputOffset;
+				var pixSrc = offset;
+
+				for (var x = 0; x < width; ++x) {
+					if (bitToCheck > 128) {
+						bitToCheck = 1;
+						lastMask = data[rleMaskOffset++];
+					}
+					if (!(lastMask & bitToCheck)) {
+						this.lastPixel.set(data.subarray(pixSrc, pixSrc + 4));
+						pixSrc += 4;
+					}
+					bitToCheck = bitToCheck << 1;
+
+					output.set(this.lastPixel, pixOffset);
+					pixOffset += 4;
+				}
+
+				offset += rleSize * 4;
+			}
+
+			return offset;
+		}
+	}
+} // namespace cool


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

Two patches; the first fixes a bug where if we receive new keyframe tiledata and need to ensure the canvas, we end up decompressing/unpremultiplying/putting the old data unnecessarily (I think). The second uses a worker to offload the majority of tile image data decompression and unpremultiplying from the main thread and improves response during large update operations (such as scrolling through a document).

The code is not properly formatted yet, I'm opening this PR now and will update it with fixes once I figure out what those fixes are...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

