### PR TITLE
Fix reconstituting old keyframes unnecessarily in CanvasTileLayer

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -6159,6 +6159,18 @@ L.CanvasTileLayer = L.Layer.extend({
 					       ' of length ' + rawDelta.length +
 					       (this._debugDeltasDetail ? (' hex: ' + hex2string(rawDelta)) : ''));
 
+		if (isKeyframe) {
+			// Important to do this before ensuring the context, or we'll needlessly
+			// reconstitute the old keyframe from compressed data.
+			if (tile.rawDeltas && tile.rawDeltas != rawDelta) { // help the gc?
+				tile.rawDeltas.length = 0;
+				tile.rawDeltas = null;
+				if (tile.imgDataCache)
+					tile.imgDataCache.length = 0;
+				tile.imgDataCache = null;
+			}
+		}
+
 		// Important to recurse & re-constitute from tile.rawDeelts
 		// before appending rawDelta and then applying it again.
 		var ctx = this._ensureContext(tile);
@@ -6201,8 +6213,6 @@ L.CanvasTileLayer = L.Layer.extend({
 		// better.
 		if (isKeyframe)
 		{
-			if (tile.rawDeltas && tile.rawDeltas != rawDelta) // help the gc?
-				tile.rawDeltas.length = 0;
 			tile.rawDeltas = rawDelta; // overwrite
 		}
 		else if (!tile.rawDeltas)


### PR DESCRIPTION
It looks like in the case where _ensureContext needs to create a new context in response to a keyframe delta, we were decompressing, unpremultiplying and drawing the old data first.

This patch clears the old data immediately when receiving a keyframe.


Change-Id: Iebc4de1a4f08cb4353c3daa50cdfe27309f01b9f


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

