### PR TITLE
deltas: force keyframe on the next render if deltas get too large.

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -3348,7 +3348,7 @@ void DocumentBroker::handleTileRequest(const StringVector &tokens, bool forceKey
         return;
     }
 
-    if (!cachedTile)
+    if (!cachedTile || cachedTile->tooLarge())
         tile.forceKeyframe();
 
     auto now = std::chrono::steady_clock::now();
@@ -3411,9 +3411,10 @@ void DocumentBroker::handleTileCombinedRequest(TileCombined& tileCombined, bool 
         }
 
         Tile cachedTile = _tileCache->lookupTile(tile);
-        if(!cachedTile || !cachedTile->isValid())
+        bool tooLarge = cachedTile && cachedTile->tooLarge();
+        if(!cachedTile || !cachedTile->isValid() || tooLarge)
         {
-            if (!cachedTile)
+            if (!cachedTile || tooLarge)
                 tile.forceKeyframe();
             tilesNeedsRendering.push_back(tile);
             _debugRenderedTileCount++;


### PR DESCRIPTION
This should save server memory, and also complexity de-compressing and also browser CPU re-rendering deltas from raw fzstd compressed pixels.


Change-Id: I12281fb85416a059d31b5df52b9ec8d79e4af316


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

