### PR TITLE
jsdialog: use early initialized map

### DIFF
--- a/browser/src/control/jsdialog/Util.MessageRouter.ts
+++ b/browser/src/control/jsdialog/Util.MessageRouter.ts
@@ -31,11 +31,11 @@ class JSDialogMessageRouter {
 			var fireJSDialogEvent = function () {
 				switch (msgData.action) {
 					case 'update':
-						app.map.fire('jsdialogupdate', { data: msgData });
+						app.socket._map.fire('jsdialogupdate', { data: msgData });
 						return true;
 
 					case 'action':
-						app.map.fire('jsdialogaction', { data: msgData });
+						app.socket._map.fire('jsdialogaction', { data: msgData });
 						return true;
 				}
 
@@ -43,7 +43,7 @@ class JSDialogMessageRouter {
 			};
 
 			var isNotebookbarInitialized =
-				app.map.uiManager && app.map.uiManager.notebookbar;
+				app.socket._map.uiManager && app.socket._map.uiManager.notebookbar;
 			if (msgData.jsontype === 'notebookbar' && !isNotebookbarInitialized) {
 				setTimeout(fireJSDialogEvent, 1000);
 				return;
@@ -66,14 +66,17 @@ class JSDialogMessageRouter {
 				(msgData.type === 'modalpopup' &&
 					msgData.id === JSDialog.generateModalId(app.idleHandlerId))
 			) {
-				app.map.fire('jsdialog', { data: msgData, callback: callbackFn });
+				app.socket._map.fire('jsdialog', {
+					data: msgData,
+					callback: callbackFn,
+				});
 				return;
 			}
 
 			// use mobile wizard
 			if (msgData.type == 'borderwindow') return;
 			if (msgData.jsontype === 'formulabar') {
-				app.map.fire('formulabar', { data: msgData });
+				app.socket._map.fire('formulabar', { data: msgData });
 				return;
 			}
 			if (
@@ -81,7 +84,10 @@ class JSDialogMessageRouter {
 				msgData.jsontype === 'dialog' ||
 				msgData.type === 'modalpopup'
 			) {
-				app.map.fire('mobilewizard', { data: msgData, callback: callbackFn });
+				app.socket._map.fire('mobilewizard', {
+					data: msgData,
+					callback: callbackFn,
+				});
 			} else {
 				console.warn(
 					'jsdialog: unhandled jsdialog mobile message: {jsontype: "' +
@@ -92,17 +98,17 @@ class JSDialogMessageRouter {
 				);
 			}
 		} else if (msgData.jsontype === 'dialog') {
-			app.map.fire('jsdialog', { data: msgData, callback: callbackFn });
+			app.socket._map.fire('jsdialog', { data: msgData, callback: callbackFn });
 		} else if (msgData.jsontype === 'sidebar') {
-			app.map.fire('sidebar', { data: msgData });
+			app.socket._map.fire('sidebar', { data: msgData });
 		} else if (msgData.jsontype === 'formulabar') {
-			app.map.fire('formulabar', { data: msgData });
+			app.socket._map.fire('formulabar', { data: msgData });
 		} else if (msgData.jsontype === 'notebookbar') {
 			if (msgData.children) {
 				for (var i = 0; i < msgData.children.length; i++) {
 					if (msgData.children[i].type === 'control') {
 						msgData.children[i].id = msgData.id;
-						app.map.fire('notebookbar', msgData.children[i]);
+						app.socket._map.fire('notebookbar', msgData.children[i]);
 						return;
 					}
 				}


### PR DESCRIPTION
Fix for using uninitialized app.map, when calling cool.html without parameters:

Uncaught TypeError: Cannot read properties of null (reading 'fire')
    at JSDialogMessageRouter.processMessage (Util.MessageRouter.ts:95:12)
    at NewClass._onJSDialog (Socket.js:1540:26)
    at NewClass._onMessage (Socket.js:1292:9)
    at NewClass.showModal (Control.UIManager.js:1139:14)
    at NewClass.showInfoModal (Control.UIManager.js:1250:8)
    at main.js:79:16
    at main.js:137:2
