### PR TITLE
cool#9219 kit: fix setclipboard command with HTML payload

### DIFF
--- a/test/UnitCopyPaste.cpp
+++ b/test/UnitCopyPaste.cpp
@@ -363,6 +363,17 @@ public:
                                   existing + newcontent + '\n'))
             return;
 
+        // Test setting HTML clipboard:
+        std::string html("<!DOCTYPE html><html><body>myword</body></html>");
+        // Intentionally no buildClipboardText() here, just raw HTML.
+        if (!setClipboard(_clipURI, html, HTTPResponse::HTTP_OK))
+            return;
+        // This failed with: ERROR: Forced failure: Missing clipboard mime type, because we tried to
+        // parse HTML when we expected a list of mimetype-size-bytes entries.
+        if (!fetchClipboardAssert(_clipURI, "text/html", html))
+            return;
+
+        // Setup state that will be also asserte in postCloseTest():
         LOG_TST("Setup clipboards:");
         if (!setClipboard(_clipURI2, buildClipboardText("kippers"), HTTPResponse::HTTP_OK))
             return;


### PR DESCRIPTION
Have two COOL servers, copy on one instance, paste an on other instance,
nothing happens on Ctrl-V.

It appears the JS code in Clipboard.js
_dataTransferDownloadAndPasteAsync() gets the correct HTML, but when it
tries to contact the "copy" server for the underlying full clipboard,
some security policy prevents the JS code from doing that. Which means
1) perhaps we should do that HTTP fetch on the server, not in JS and 2)
the fallback code should at least work via normal HTML.

Fix 2) by extending ChildSession::setClipboard() to recognize if the
data has the typical HTML header, and only start the usual parsing in
case the data we got is not bare HTML.

The 1) still needs fixing.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I55a102c2a39d21ac898f82041760a220e46784cb
