### PR TITLE
fix: allow changing compact to tabbed mode

### DIFF
--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -544,7 +544,7 @@ L.Control.UIManager = L.Control.extend({
 			break;
 		}
 
-		this.setDocTypePref('compactMode', uiMode.mode === 'classic');
+		window.prefs.set('compactMode', uiMode.mode === 'classic');
 		this.initializeSidebar();
 		this.insertCustomButtons();
 


### PR DESCRIPTION
This is a fix for a regression from
I4cc9cc885aa8cd0b40646629cd73bef236963a94

Compact/tabbed mode was saved on a per-app basis, but read on a global basis. This meant that the read preference was never changed, causing it to be impossible to switch out of compact mode once you had entered it.

The fix is to change back to the previous behavior of saving and reading on a global basis

Refs: CollaboraOnline/Online#9181

Change-Id: Ie9d72d6b7e10e209f10acf662535c866e06a98de