### PR TITLE
fix: various fixes to prefs

### DIFF
--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -325,7 +325,7 @@ window.app = {
 
 			const uiDefault = global.prefs._getUIDefault(key);
 			if (
-				global.prefs._getUIDefault('SavedUIState', 'true').toLowerCase() === 'false' &&
+				!global.savedUIState &&
 				uiDefault !== undefined
 			) {
 				return uiDefault;

--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -294,6 +294,22 @@ window.app = {
 			}
 		})(),
 
+		_renameLocalStoragePref: function(oldName, newName) {
+			if (!global.prefs.canPersist) {
+				return;
+			}
+
+			const oldValue = global.localStorage.getItem(oldName);
+			const newValue = global.localStorage.getItem(newName);
+
+			if (oldValue === null || newValue !== null) {
+				return;
+			}
+
+			// we do not remove the old value, both for downgrades and incase we split an old global preference to a per-app one
+			global.localStorage.setItem(newName, oldValue);
+		},
+
 		/// Similar to using window.uiDefaults directly, but this can handle dotted keys like "presentation.ShowSidebar" and does not allow partially referencing a value (like just "presentation")
 		_getUIDefault: function(key, defaultValue = undefined) {
 			const parts = key.split('.');
@@ -387,6 +403,32 @@ window.app = {
 			return parsedValue;
 		},
 	};
+
+	// Renamed in 24.04.4.1
+	const prefDocTypes = ['text', 'spreadsheet', 'presentation', 'drawing'];
+	for (const docType of prefDocTypes) {
+		global.prefs._renameLocalStoragePref(`UIDefaults_${docType}_darkTheme`, 'darkTheme');
+	}
+
+	const oldDocTypePrefs = [
+		"A11yCheckDeck",
+		"NavigatorDeck",
+		"PropertyDeck",
+		"SdCustomAnimationDeck",
+		"SdMasterPagesDeck",
+		"SdSlideTransitionDeck",
+		"ShowResolved",
+		"ShowRuler",
+		"ShowSidebar",
+		"ShowStatusbar",
+		"ShowToolbar",
+	];
+	for (const pref of oldDocTypePrefs) {
+		for (const docType of prefDocTypes) {
+			global.prefs._renameLocalStoragePref(`UIDefaults_${docType}_${pref}`, `${docType}.${pref}`);
+		}
+	}
+	// End 24.04.4.1 renames
 
 	global.keyboard = {
 		onscreenKeyboardHint: global.uiDefaults['onscreenKeyboardHint'],

--- a/test/FileServeWhiteBoxTests.cpp
+++ b/test/FileServeWhiteBoxTests.cpp
@@ -59,22 +59,22 @@ void FileServeTests::testUIDefaults()
     LOK_ASSERT_EQUAL(std::string("classic"), uiMode);
 
     LOK_ASSERT_EQUAL(
-        std::string("{\"spreadsheet\":{\"ShowSidebar\":false},\"text\":{\"ShowRuler\":true}}"),
+        std::string("{\"spreadsheet\":{\"ShowSidebar\":\"false\"},\"text\":{\"ShowRuler\":\"true\"}}"),
         FileServerRequestHandler::uiDefaultsToJSON("TextRuler=true;SpreadsheetSidebar=false",
                                                    uiMode, uiTheme, savedUIState));
     LOK_ASSERT_EQUAL(std::string(""), uiMode);
 
     LOK_ASSERT_EQUAL(
-        std::string("{\"presentation\":{\"ShowStatusbar\":false},\"spreadsheet\":{\"ShowSidebar\":"
-                    "false},\"text\":{\"ShowRuler\":true},\"uiMode\":\"notebookbar\"}"),
+        std::string("{\"presentation\":{\"ShowStatusbar\":\"false\"},\"spreadsheet\":{\"ShowSidebar\":"
+                    "\"false\"},\"text\":{\"ShowRuler\":\"true\"},\"uiMode\":\"notebookbar\"}"),
         FileServerRequestHandler::uiDefaultsToJSON(
             ";;UIMode=notebookbar;;PresentationStatusbar=false;;TextRuler=true;;bah=ugh;;"
             "SpreadsheetSidebar=false",
             uiMode, uiTheme, savedUIState));
 
-    LOK_ASSERT_EQUAL(std::string("{\"drawing\":{\"ShowStatusbar\":true},\"presentation\":{"
-                                 "\"ShowStatusbar\":false},\"spreadsheet\":{\"ShowSidebar\":false},"
-                                 "\"text\":{\"ShowRuler\":true},\"uiMode\":\"notebookbar\"}"),
+    LOK_ASSERT_EQUAL(std::string("{\"drawing\":{\"ShowStatusbar\":\"true\"},\"presentation\":{"
+                                 "\"ShowStatusbar\":\"false\"},\"spreadsheet\":{\"ShowSidebar\":\"false\"},"
+                                 "\"text\":{\"ShowRuler\":\"true\"},\"uiMode\":\"notebookbar\"}"),
                      FileServerRequestHandler::uiDefaultsToJSON(
                          ";;UIMode=notebookbar;;PresentationStatusbar=false;;TextRuler=true;;bah="
                          "ugh;;SpreadsheetSidebar=false;;DrawingStatusbar=true",

--- a/test/integration-http-server.cpp
+++ b/test/integration-http-server.cpp
@@ -239,7 +239,7 @@ void HTTPServerTest::testCoolPost()
         std::string::npos);
     LOK_ASSERT(
         html.find(
-            R"xx(window.uiDefaults = {"presentation":{"ShowSidebar":false,"ShowStatusbar":false},"spreadsheet":{"ShowSidebar":false,"ShowStatusbar":false},"text":{"ShowRuler":false,"ShowSidebar":false,"ShowStatusbar":false},"uiMode":"classic"};)xx") !=
+            R"xx(window.uiDefaults = {"presentation":{"ShowSidebar":"false","ShowStatusbar":"false"},"spreadsheet":{"ShowSidebar":"false","ShowStatusbar":"false"},"text":{"ShowRuler":"false","ShowSidebar":"false","ShowStatusbar":"false"},"uiMode":"classic"};)xx") !=
         std::string::npos);
     LOK_ASSERT(
         html.find(

--- a/wsd/FileServerUtil.cpp
+++ b/wsd/FileServerUtil.cpp
@@ -233,7 +233,11 @@ std::string FileServerRequestHandler::uiDefaultsToJSON(const std::string& uiDefa
         // detect the UITheme default, light or dark
         if (keyValue.equals(0, "UITheme"))
         {
-            json.set("darkTheme", keyValue.equals(1, "dark"));
+            if (keyValue.equals(1, "dark")) {
+                json.set("darkTheme", "true");
+            } else {
+                json.set("darkTheme", "false");
+            }
             uiTheme = keyValue[1];
             continue;
         }
@@ -262,12 +266,12 @@ std::string FileServerRequestHandler::uiDefaultsToJSON(const std::string& uiDefa
         }
         if (keyValue.equals(0, "TouchscreenHint"))
         {
-            json.set("touchscreenHint", keyValue.equals(1, "true"));
+            json.set("touchscreenHint", keyValue[1]);
             continue;
         }
         if (keyValue.equals(0, "OnscreenKeyboardHint"))
         {
-            json.set("onscreenKeyboardHint", keyValue.equals(1, "true"));
+            json.set("onscreenKeyboardHint", keyValue[1]);
             continue;
         }
         else if (keyValue.startsWith(0, "Text"))
@@ -301,9 +305,9 @@ std::string FileServerRequestHandler::uiDefaultsToJSON(const std::string& uiDefa
         // detect the actual UI widget we want to hide or show
         if (key == "Ruler" || key == "Sidebar" || key == "Statusbar" || key == "Toolbar")
         {
-            bool value(true);
+            std::string value("true");
             if (keyValue.equals(1, "false") || keyValue.equals(1, "False") || keyValue.equals(1, "0"))
-                value = false;
+                value = "false";
 
             currentDef->set("Show" + key, value);
         }


### PR DESCRIPTION
savedUIState isn't a normal UI_default, so it doesn't show up in the
ui_defaults list, and we can't fetch it with our prefs helper. Instead,
we should use the property on window

---

Previously we converted some ui_defaults values to booleans.
Unfortunately, when we save similar preferences to LocalStorage, we can
only save them as strings. To make sure code doesn't get booleans when
it's expecting everything to be a string, let's only send strings back
in our ui_defaults json

---

Finally, I figured out a way to stop compatibility breakages being so annoying
with the prefs refactor without needing to keep a prefs dictionary
around forever.  If, on starting the application, we set new preference
names to old preference values we can choose when to break
compatibility.

This will allow us to do so later on, i.e. a significant time after the
rename, when many users will have had their preferences migrated and the
version with the old preference names is no longer supported.

---

A nice followup to this might be to continue standardizing ui_defaults
transformation code on the server side so that its use is minimal (e.g.
uiMode, uiTheme variables, treating savedUIState as a normal bit of
ui_defaults, etc.), however an overhaul of server-side
ui_defaults was deemed to risky for now