### PR TITLE
fix(contextMenus): move above UI elements

### DIFF
--- a/browser/src/canvas/sections/CommentListSection.ts
+++ b/browser/src/canvas/sections/CommentListSection.ts
@@ -950,6 +950,7 @@ export class CommentSection extends app.definitions.canvasSectionObject {
 		L.installContextMenu({
 			selector: '.cool-annotation-menu',
 			trigger: 'none',
+			zIndex: 1500,
 			className: 'cool-font',
 			build: function ($trigger: any) {
 				return {
@@ -1010,6 +1011,7 @@ export class CommentSection extends app.definitions.canvasSectionObject {
 		L.installContextMenu({
 			selector: '.cool-annotation-menu-redline',
 			trigger: 'none',
+			zIndex: 1500,
 			className: 'cool-font',
 			items: {
 				modify: {

--- a/browser/src/control/Control.ContextMenu.js
+++ b/browser/src/control/Control.ContextMenu.js
@@ -169,6 +169,7 @@ L.Control.ContextMenu = L.Control.extend({
 				selector: '.leaflet-layer',
 				className: 'cool-font',
 				trigger: 'none',
+				zIndex: 1500,
 				build: function() {
 					return {
 						callback: function(key) {


### PR DESCRIPTION
On small window sizes, a context menu may be forced to open in such a way that it goes over the same region as the notebookbar or spreadsheet tabs.

In that case, the context menu should be above the other element, or some of the context menu options could be unreachable.


Change-Id: Id269e3fb9bc2251677a0792d83fc51bd56b9cb21