### PR TITLE
Don't show audit snackbar if all entries are all 'ok' state

### DIFF
--- a/browser/src/control/Control.ServerAuditDialog.ts
+++ b/browser/src/control/Control.ServerAuditDialog.ts
@@ -161,8 +161,17 @@ class ServerAuditDialog {
 			: null;
 
 		if (app.serverAudit.length) {
-			// TODO: enable annoying snackbar later
+			let hasErrors = false;
+			app.serverAudit.forEach((entry: any) => {
+				if (entry.status !== 'ok') {
+					hasErrors = true;
+				}
+			});
+
+			// only show the snackbar if there are specific warnings
+			// and if the current view is_admin
 			if (
+				hasErrors &&
 				viewInfo &&
 				viewInfo.userextrainfo &&
 				viewInfo.userextrainfo.is_admin === true
@@ -174,6 +183,7 @@ class ServerAuditDialog {
 				);
 			}
 
+			// but if we any results, enable the toolbar entry for the server audit
 			this.map.uiManager.refreshUI();
 		}
 	}


### PR DESCRIPTION
I see this on a local nextcloud where the audit dialog only has one entry which is "ok".


Change-Id: I55f12125cbc0ca4c88c9220ed114d455e84639e0


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

