### PR TITLE
fix(mobileWizard): Always start at the top

### DIFF
--- a/browser/src/control/Control.MobileWizardWindow.js
+++ b/browser/src/control/Control.MobileWizardWindow.js
@@ -253,6 +253,8 @@ L.Control.MobileWizardWindow = L.Control.extend({
 		else
 			$(contentToShow).children('.ui-content').first().show();
 
+		this.mobileWizard.scrollTop(0);
+
 		this._currentDepth++;
 		if (!this._inBuilding)
 			history.pushState({context: 'mobile-wizard', level: this._currentDepth}, 'mobile-wizard-level-' + this._currentDepth);
@@ -322,6 +324,8 @@ L.Control.MobileWizardWindow = L.Control.extend({
 			$('#mobile-wizard.funcwizard div#mobile-wizard-content').removeClass('showHelpBG');
 			$('#mobile-wizard.funcwizard div#mobile-wizard-content').addClass('hideHelpBG');
 			headers.show('slide', { direction: 'left' }, 'fast');
+
+			this.mobileWizard.scrollTop(0);
 
 			if (this._currentDepth == 0 || (this._isTabMode && this._currentDepth == 1)) {
 				this._inMainMenu = true;


### PR DESCRIPTION
Previously, when entering or exiting mobile wizard sublevels you would start scrolled down to the place you were before. For example, if you scrolled down a few items on the main context menu of an image in order to reach "arrange", you would always end up right at the bottom of the "arrange" menu.

By always scrolling up to the top, we can prevent you from ever having content hidden above you.


Change-Id: I02365ecef859fb6f199d14a12a49937d5a30b8e7