### PR TITLE
cool#9219 clipboard: support URLs in the payload of the setclipboard command

### DIFF
--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -354,15 +354,15 @@ L.Clipboard = L.Class.extend({
 				}
 
 				var formData = new FormData();
-				formData.append('data', new Blob([fallbackHtml]), 'clipboard');
+				formData.append('data', new Blob([src]), 'clipboard');
 				that._doAsyncDownload(
 					'POST', dest, formData, false,
 					function() {
 						if (that._checkAndDisablePasteSpecial()) {
-							window.app.console.log('up-load of fallback done, now paste special');
+							window.app.console.log('up-load of URL done, now paste special');
 							app.socket.sendMessage('uno .uno:PasteSpecial');
 						} else {
-							window.app.console.log('up-load of fallback done, now paste');
+							window.app.console.log('up-load of URL done, now paste');
 							app.socket.sendMessage('uno .uno:Paste');
 						}
 

--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -354,18 +354,20 @@ L.Clipboard = L.Class.extend({
 				}
 
 				var formData = new FormData();
-				formData.append('data', new Blob([src]), 'clipboard');
+				let commandName = null;
+				if (that._checkAndDisablePasteSpecial()) {
+					commandName = '.uno:PasteSpecial';
+				} else {
+					commandName = '.uno:Paste';
+				}
+				const data = JSON.stringify({
+					url: src,
+					commandName: commandName,
+				});
+				formData.append('data', new Blob([data]), 'clipboard');
 				that._doAsyncDownload(
 					'POST', dest, formData, false,
 					function() {
-						if (that._checkAndDisablePasteSpecial()) {
-							window.app.console.log('up-load of URL done, now paste special');
-							app.socket.sendMessage('uno .uno:PasteSpecial');
-						} else {
-							window.app.console.log('up-load of URL done, now paste');
-							app.socket.sendMessage('uno .uno:Paste');
-						}
-
 					}.bind(this),
 					function(progress) { return 50 + progress/2; },
 					function() {

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -319,6 +319,7 @@ void ClientSession::handleClipboardRequest(DocumentBroker::ClipboardRequest     
         {
             preProcessSetClipboardPayload(*data);
 
+#if !MOBILEAPP
             if (data->starts_with('{'))
             {
                 // We got JSON, extract the URL and the UNO command name.
@@ -357,6 +358,7 @@ void ClientSession::handleClipboardRequest(DocumentBroker::ClipboardRequest     
                 }
             }
             else
+#endif
             {
                 // List of mimetype-size-data tuples, pass that over as-is.
                 docBroker->forwardToChild(client_from_this(), "setclipboard\n" + *data, true);

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -319,16 +319,25 @@ void ClientSession::handleClipboardRequest(DocumentBroker::ClipboardRequest     
         {
             preProcessSetClipboardPayload(*data);
 
-            if (data->starts_with("http"))
+            if (data->starts_with('{'))
             {
-                // We got a URL, download that and set the result as the clipboard.
-                std::shared_ptr<http::Session> httpSession = http::Session::create(*data);
-                std::shared_ptr<const http::Response> httpResponse =
-                    httpSession->syncRequest(http::Request(Poco::URI(*data).getPathAndQuery()));
-                if (httpResponse->statusLine().statusCode() == http::StatusCode::OK)
+                // We got JSON, extract the URL and the UNO command name.
+                Poco::JSON::Object::Ptr json;
+                if (JsonUtil::parseJSON(*data, json))
                 {
-                    std::string body = httpResponse->getBody();
-                    docBroker->forwardToChild(client_from_this(), "setclipboard\n" + body, true);
+                    std::string url;
+                    JsonUtil::findJSONValue(json, "url", url);
+                    std::string commandName;
+                    JsonUtil::findJSONValue(json, "commandName", commandName);
+                    std::shared_ptr<http::Session> httpSession = http::Session::create(url);
+                    std::shared_ptr<const http::Response> httpResponse =
+                        httpSession->syncRequest(http::Request(Poco::URI(url).getPathAndQuery()));
+                    if (httpResponse->statusLine().statusCode() == http::StatusCode::OK)
+                    {
+                        std::string body = httpResponse->getBody();
+                        docBroker->forwardToChild(client_from_this(), "setclipboard\n" + body, true);
+                        docBroker->forwardToChild(client_from_this(), "uno " + commandName);
+                    }
                 }
             }
             else

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -350,10 +350,18 @@ void ClientSession::handleClipboardRequest(DocumentBroker::ClipboardRequest     
 
                     std::shared_ptr<http::Session> httpSession = http::Session::create(url);
                     httpSession->setFinishedHandler(std::move(finishedCallback));
-                    http::Request httpRequest(Poco::URI(url).getPathAndQuery());
-                    if (!httpSession->asyncRequest(httpRequest, docBroker->getPoll()))
+                    std::string pathAndQuery = Poco::URI(url).getPathAndQuery();
+                    if (pathAndQuery.find("/cool/clipboard") != std::string::npos)
                     {
-                        LOG_ERR("Failed to start an async clipboard download request");
+                        http::Request httpRequest(Poco::URI(url).getPathAndQuery());
+                        if (!httpSession->asyncRequest(httpRequest, docBroker->getPoll()))
+                        {
+                            LOG_ERR("Failed to start an async clipboard download request");
+                        }
+                    }
+                    else
+                    {
+                        LOG_ERR("Clipboard download URL does not look like a clipboard one");
                     }
                 }
             }

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -3165,6 +3165,10 @@ void DocumentBroker::addSocketToPoll(const std::shared_ptr<StreamSocket>& socket
 {
     _poll->insertNewSocket(socket);
 }
+SocketPoll& DocumentBroker::getPoll()
+{
+    return *_poll;
+}
 
 void DocumentBroker::alertAllUsers(const std::string& msg)
 {

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -443,6 +443,8 @@ public:
     /// Transfer this socket into our polling thread / loop.
     void addSocketToPoll(const std::shared_ptr<StreamSocket>& socket);
 
+    SocketPoll& getPoll();
+
     void alertAllUsers(const std::string& msg);
 
     void alertAllUsers(const std::string& cmd, const std::string& kind)


### PR DESCRIPTION
Copying the full clipboard (including ODF) from a remote server into the
JS client failed with:

Refused to connect to '...' because it violates the following Content Security Policy directive: "connect-src ..."

If this happens, still send the original URL to the server, so it can
download the full clipboard, which gives better result for pasting,
compared to going via HTML only.

Not done in this commit: 1) the JS still tries to get the clipboard
itself, we download on the server only on failure and 2) the server does
a blocking HTTP download, which may not be wanted.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I9ed8c8050f9dbe71dc8fcd36c9d8fa6e8bba44f6
