### PR TITLE
fix(comments): avoid comment collapse during edit

### DIFF
--- a/browser/src/canvas/sections/CommentListSection.ts
+++ b/browser/src/canvas/sections/CommentListSection.ts
@@ -200,7 +200,20 @@ export class CommentSection extends app.definitions.canvasSectionObject {
 		}
 	}
 
+	private isEditing(): boolean {
+		const sections = this.containerObject.sections;
+		const textBoxes = sections
+			.flatMap((section: any) => [section.sectionProperties.nodeModifyText, section.sectionProperties.nodeReplyText])
+			.filter((textBox: any) => textBox !== undefined);
+
+		return textBoxes.includes(document.activeElement);
+	}
+
 	public setCollapsed(): void {
+		if (this.isEditing()) {
+			return;
+		}
+
 		this.isCollapsed = true;
 		this.unselect();
 		for (var i: number = 0; i < this.sectionProperties.commentList.length; i++) {


### PR DESCRIPTION
This is particularly relevant on touch devices, where some events can be triggered a bit differently to desktop. Previously it was sometimes hard to reply to or edit a comment as upon hitting the modify/reply buttons we would consider the comment deselected and collapse it.

The easiest way I have found to deal with this is to prevent the collapse during an edit


Change-Id: I740b1c260e9ee63bac6e667f99ed6da141d71a9c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

