### PR TITLE
admin: handle case where monitor connection to controller is disconnected

### DIFF
--- a/wsd/Admin.cpp
+++ b/wsd/Admin.cpp
@@ -30,7 +30,6 @@
 #include <Util.hpp>
 #include <common/JsonUtil.hpp>
 
-
 #include <net/Socket.hpp>
 #if ENABLE_SSL
 #include <SslSocket.hpp>
@@ -697,6 +696,25 @@ void Admin::pollingThread()
 
     if (!COOLWSD::IndirectionServerEnabled)
         return;
+
+    // if don't have monitor connection to the controller we set the _migrateMsgReceived
+    // for each docbroker so that docbroker can cleanup the documents
+    bool controllerMonitorConnection = false;
+    for (const auto& pair : _monitorSockets)
+    {
+        if (pair.first.find("controller") != std::string::npos)
+        {
+            controllerMonitorConnection = true;
+            break;
+        }
+    }
+
+    if (!controllerMonitorConnection)
+    {
+        LOG_WRN("Monitor connection to the controller doesn't exist, skipping shutdown migration");
+        COOLWSD::setAllMigrationMsgReceived();
+        return;
+    }
 
     _model.sendShutdownReceivedMsg();
 


### PR DESCRIPTION
- if monitor connection to doesn't exist because maybe controller died or something we shouldn't wait for migration messages


Change-Id: I568f365f534e100010fe31ef6ae80f1b4c839cc2

* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

