### PR TITLE
fix(calc): Prevent following view jumps

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -2604,7 +2604,7 @@ L.CanvasTileLayer = L.Layer.extend({
 
 				if (scrollX !== 0 || scrollY !== 0) {
 					var newCenter = mapBounds.getCenter();
-					newCenter.lat += scrollX;
+					newCenter.lng += scrollX;
 					newCenter.lat += scrollY;
 					this.scrollToPos(newCenter);
 				}


### PR DESCRIPTION
Previously we were mixing up lat/lng, which made calc jump to unexpected places when the person we're following's cursor is offscreen.


Change-Id: I4db4c93118fbc3ffd04c7152652ccd2b26209b5d


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

