### PR TITLE
fix: sometimes userlist is empty on reconnect

### DIFF
--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -1608,6 +1608,7 @@ app.definitions.Socket = L.Class.extend({
 
 			this._map._docLayer._resetCanonicalIdStatus();
 			this._map._docLayer._resetViewId();
+			this._map._docLayer._resetDocumentInfo();
 		}
 
 		if (isActive && this._reconnecting) {

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -920,6 +920,10 @@ L.CanvasTileLayer = L.Layer.extend({
 		this._viewId = undefined;
 	},
 
+	_resetDocumentInfo: function () {
+		this._documentInfo = "";
+	},
+
 	_getViewId: function () {
 		return this._viewId;
 	},

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -2690,6 +2690,15 @@ L.CanvasTileLayer = L.Layer.extend({
 			delete this._cellViewCursors[viewId];
 		}
 
+		// update graphicviewselection
+		if (typeof this._graphicViewMarkers[viewId] !== 'undefined') {
+			this._graphicViewMarkers[viewId].bounds = L.LatLngBounds.createDefault();
+			this._graphicViewMarkers[viewId].part = 0;
+			this._graphicViewMarkers[viewId].mode = 0;
+			this._onUpdateGraphicViewSelection(viewId);
+			delete this._graphicViewMarkers[viewId];
+		}
+
 		this._map.removeView(viewId);
 	},
 

--- a/browser/src/map/handler/Map.VersionBar.js
+++ b/browser/src/map/handler/Map.VersionBar.js
@@ -12,7 +12,7 @@ L.Map.VersionBar = L.Handler.extend({
 
 	onRemove: function () {
 		this._map.off('versionbar', this.onversionbar, this);
-		this._map.off('updateviewlist', this.onUpdateInfo, this);
+		this._map.off('updateviewslist', this.onUpdateInfo, this);
 	},
 
 	onUpdateInfo: function () {


### PR DESCRIPTION
- before setting the viewId we check for _documentInfo in onStatusMsg, it might happen that on reconnect documentInfo remains same.
 - steps to reproduce:
   1. Open writer document 4 times in different tabs
   2. Kill the server (Ctrl + C)
   3. Run the server again and wait of clients to reconnect
   4. Check all the tabs, there must one tab where you should see the userlist empty. If not, kill and run server again...
- this patch fixes it by reseting the _documentInfo on socket disconnection


Change-Id: I7be045f2b2433b9e12b6749fefbdd53ab5f0a0cd


* Resolves: # <!-- related github issue -->
* Target version: master

