### PR TITLE
Fix CI: Remove unused BackColor uno command

### DIFF
--- a/test/UnitUNOCommand.cpp
+++ b/test/UnitUNOCommand.cpp
@@ -94,7 +94,6 @@ UnitBase::TestResult UnitUNOCommand::testStateUnoCommandWriter()
 {
     std::set<std::string> writerCommands
     {
-        ".uno:BackColor=",
         ".uno:BackgroundColor=",
         ".uno:Bold=",
         ".uno:CenterPara=",


### PR DESCRIPTION
after it was removed from core invalidation list:
commit db27cd2246cfc54abd94885ce5edbdca69688af0
LOK: do not use deprecated .uno:BackColor
