### PR TITLE
browser: fix PageDown cursor position

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -2390,6 +2390,12 @@ L.CanvasTileLayer = L.Layer.extend({
 			return;
 		}
 
+		if (obj.scroll) {
+			this.scrollToPos(new app.definitions.simplePoint(recCursor.getTopLeft().x,
+									 recCursor.getTopLeft().y));
+			return;
+		}
+
 		// tells who trigerred cursor invalidation, but recCursors is stil "our"
 		var modifierViewId = parseInt(obj.viewId);
 		var weAreModifier = (modifierViewId === this._viewId);


### PR DESCRIPTION
Scroll the new position if the cursor is not
visible.

Change-Id: Ib5a77fefa5ec16defa0695806c770f21beec4243
Signed-off-by: Henry Castro <hcastro@collabora.com>
