### PR TITLE
fuzzer: reject increasing the log level

### DIFF
--- a/common/Log.cpp
+++ b/common/Log.cpp
@@ -721,6 +721,13 @@ namespace Log
         auto& logger = GenericLogger::create(Static.getName() + "." + std::to_string(counter++),
                                              std::move(channel),
                                              Poco::Logger::parseLevel(logLevel));
+
+        if (Util::isFuzzing())
+        {
+            // Ignore errors for fuzzing, even if the log level would be increased.
+            return;
+        }
+
         Static.setThreadLocalLogger(&logger);
     }
 

--- a/fuzzer/data/crash-87714cc10c192b4d917cdc3a6fac1841a11d91f4
+++ b/fuzzer/data/crash-87714cc10c192b4d917cdc3a6fac1841a11d91f4
@@ -1,0 +1,2 @@
+load url=1
+loggingleveloverride error


### PR DESCRIPTION
This was similar to commit 2c82f0a712962f1e5c7285912014a738626fd48b
(fuzzer: fix default log level, 2024-05-29), but here the fuzzer figured
out how to increase the log level. Explicitly avoid setting the log
level in setThreadLocalLogLevel() for the fuzzing case to avoid the
huge, uninteresting logs: we just want the output from the fuzzer
itself, not from the fuzzed code.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I92623f1c384ce7d4b746d3cbdc6a7c911a2f29a6
