### PR TITLE
annotation: match the reply order to core (backport)

### DIFF
--- a/browser/src/layer/tile/CommentListSection.ts
+++ b/browser/src/layer/tile/CommentListSection.ts
@@ -1187,7 +1187,7 @@ export class CommentSection extends CanvasSectionObject {
 			else {
 				var parentComment = this.sectionProperties.commentList[parentIdx];
 				if (parentComment && !parentComment.sectionProperties.children.includes(comment))
-					parentComment.sectionProperties.children.push(comment);
+					parentComment.sectionProperties.children.unshift(comment);
 			}
 		}
 


### PR DESCRIPTION
problem:
Core behaviour:
if comment A has 3 replies (i.e: in order B, C, D) when user again replies to comment A
a new reply will be inserted after A but before B.

But in online same reply will be displayed after D. On reload of the document or after save-as when comments are reloaded, this order will change as comments in the doc is saved according to the core behaviour.


Change-Id: I3bf4e06c4b6f48eb086c7eaebe102eac0f90681d


* Target version: distro/collabora/co-23.05 


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

