### PR TITLE
cool#9219 clipboard: add custom X-COOL-Clipboard header

### DIFF
--- a/test/UnitCopyPaste.cpp
+++ b/test/UnitCopyPaste.cpp
@@ -74,6 +74,10 @@ public:
         std::shared_ptr<const http::Response> httpResponse =
             httpSession->syncRequest(http::Request(Poco::URI(clipURIstr).getPathAndQuery()));
 
+        // Note that this is expected for both living and closed documents.
+        // This failed when either case didn't add the custom header.
+        LOK_ASSERT_EQUAL(std::string("true"), httpResponse->get("X-COOL-Clipboard"));
+
         LOG_TST("getClipboard: sent request: " << clipURI.getPathAndQuery());
 
         try {

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -343,6 +343,14 @@ void ClientSession::handleClipboardRequest(DocumentBroker::ClipboardRequest     
                             return;
                         }
 
+                        // Check if this is likely produced by us.
+                        std::string clipboardHeader = httpResponse->get("X-COOL-Clipboard");
+                        if (clipboardHeader != "true")
+                        {
+                            LOG_ERR("Clipboard response is missing the required 'X-COOL-Clipboard: true' header");
+                            return;
+                        }
+
                         std::string body = httpResponse->getBody();
                         std::istringstream stream(body);
                         if (ClipboardData::isOwnFormat(stream))
@@ -2020,12 +2028,14 @@ bool ClientSession::handleKitToClientMessage(const std::shared_ptr<Message>& pay
                 continue;
 
             std::ostringstream oss;
+            // The custom header for the clipboard of a living document.
             oss << "HTTP/1.1 200 OK\r\n"
                 << "Last-Modified: " << Util::getHttpTimeNow() << "\r\n"
                 << "User-Agent: " << http::getAgentString() << "\r\n"
                 << "Content-Length: " << (empty ? 0 : (payload->size() - header)) << "\r\n"
                 << "Content-Type: application/octet-stream\r\n"
                 << "X-Content-Type-Options: nosniff\r\n"
+                << "X-COOL-Clipboard: true\r\n"
                 << "Connection: close\r\n"
                 << "\r\n";
 

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -3487,12 +3487,14 @@ bool DocumentBroker::lookupSendClipboardTag(const std::shared_ptr<StreamSocket> 
     if (saved)
     {
             std::ostringstream oss;
+            // The custom header for the clipboard of an already closed document.
             oss << "HTTP/1.1 200 OK\r\n"
                 << "Last-Modified: " << Util::getHttpTimeNow() << "\r\n"
                 << "User-Agent: " << http::getAgentString() << "\r\n"
                 << "Content-Length: " << saved->length() << "\r\n"
                 << "Content-Type: application/octet-stream\r\n"
                 << "X-Content-Type-Options: nosniff\r\n"
+                << "X-COOL-Clipboard: true\r\n"
                 << "Connection: close\r\n"
                 << "\r\n";
             oss.write(saved->c_str(), saved->length());


### PR DESCRIPTION
This is something no sensible webserver would ever server for a normal
file, so we likely only download COOL clipboards and nothing else.

Noticed the missing DocumentBroker::lookupSendClipboardTag() case while
working on the test.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Ib69115feaed6bff36b270b072a0e38fabe35d8c9
