### PR TITLE
Tablet: use dialog width which fits the screen

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1908,7 +1908,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 }
 
 #zoterolist.jsdialog {
-	width: 800px;
+	width: calc(min(800px, 80vw));
 }
 
 .jsdialog[id^='zotero'][id$='-label'] {
@@ -2148,5 +2148,5 @@ kbd,
 }
 
 #ServerAuditDialog #ServerAuditDialog-mainbox {
-	min-width: 800px;
+	min-width: calc(min(800px, 80vw));
 }


### PR DESCRIPTION
In case 800px is bigger than 80% of the screen - use 80%. This helps with "server audit" and "zotero" on tablet like iPad mini

After:
![ipadmini](https://github.com/CollaboraOnline/online/assets/5307369/9e3f7264-51b2-45c6-88a7-be065476e942)
