### PR TITLE
fix: Properly check for ui mode set by coolwsd

### DIFF
--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -77,7 +77,7 @@ L.Control.UIManager = L.Control.extend({
 	shouldUseNotebookbarMode: function() {
 		let forceCompact = window.prefs.getBoolean('compactMode', null);
 		// all other cases should default to notebookbar
-		let shouldUseClassic = (window.userInterfaceMode === 'compact' && forceCompact == null) || forceCompact === true;
+		let shouldUseClassic = (window.userInterfaceMode === 'classic' && forceCompact == null) || forceCompact === true;
 		return !shouldUseClassic;
 	},
 


### PR DESCRIPTION
I noticed this in our richdocuments cypress tests which try to open a file with both classic and notebookbar mode depending what is configured by the admin.

This fixes the compact mode when integrators set it through the ui_defaults with UIMode=classic or UIMode=compact

Currently the backend uses either notebookbar or classic as UI mode values not compact, so the check seems to have never worked as intended

https://github.com/CollaboraOnline/online/blob/master/wsd/FileServer.cpp#L1300-L1307
https://github.com/CollaboraOnline/online/blob/master/wsd/COOLWSD.cpp#L2171-L2178
https://github.com/CollaboraOnline/online/blob/master/wsd/FileServerUtil.cpp#L217-L228

Patch that can be used for testing:

```
--- a/browser/html/debug.html
+++ b/browser/html/debug.html
@@ -17,6 +17,8 @@
 <body>
     <form id="form" action enctype="multipart/form-data" target="coolframe" method="post">
          <input name="access_token" value="test" type="hidden"/>
+         <input name="theme" value="nextcloud" type="hidden"/>
+         <input name="ui_defaults" value="UIMode=compact" type="hidden"/>
     </form>
     <iframe id="coolframe" name= "coolframe" style="width:100%;height:100%;position:absolute;">
     </iframe>
```

Signed-off-by: Julius Härtl <jus@bitgrid.net>
Change-Id: I0fc476d193c179eb6892d0de640bfcb13f48eb8e


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

