### PR TITLE
Revert "wsd: always exit Kit when unloading"

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1246,56 +1246,53 @@ bool Document::onLoad(const std::string& sessionId,
 
 void Document::onUnload(const ChildSession& session)
 {
-    // This is called when we receive 'child-??? disconnect'.
-    // First, we _sessions.erase(), which destroys the ChildSession instance.
-    // We are called from ~ChildSession.
-
     const auto& sessionId = session.getId();
-    LOG_INF("Unloading session [" << sessionId << "] on url [" << anonymizeUrl(_url) << ']');
-
-    if (_loKitDocument == nullptr)
-    {
-        LOG_ERR("Unloading session [" << sessionId << "] without loKitDocument, exiting bluntly");
-        flushAndExit(EX_OK);
-        return;
-    }
-
-    // If we have no more sessions, we have nothing more to do.
-    if (!Util::isMobileApp() && _sessions.empty())
-    {
-        // Sanitiy check.
-        const int views = _loKitDocument->getViewsCount();
-        if (views > 1)
-        {
-            LOG_ERR("Document [" << anonymizeUrl(_url) << "] has no more sessions but " << views
-                                 << " views");
-            assert(views <= 1 && "Unexpected document views without matching child sessions");
-        }
-
-        LOG_INF("Document [" << anonymizeUrl(_url) << "] has no more sessions, exiting bluntly");
-        flushAndExit(EX_OK);
-        return;
-    }
+    LOG_INF("Unloading session [" << sessionId << "] on url [" << anonymizeUrl(_url) << "].");
 
     const int viewId = session.getViewId();
     _queue->removeCursorPosition(viewId);
 
-    // Unload the view.
+    if (_loKitDocument == nullptr)
+    {
+        LOG_ERR("Unloading session [" << sessionId << "] without loKitDocument.");
+        return;
+    }
+
     _loKitDocument->setView(viewId);
     _loKitDocument->registerCallback(nullptr, nullptr);
     _loKit->registerCallback(nullptr, nullptr);
-    _loKitDocument->destroyView(viewId);
+
+    int viewCount = _loKitDocument->getViewsCount();
+    if (viewCount == 1)
+    {
+        if (!Util::isMobileApp() && _sessions.empty())
+        {
+            LOG_INF("Document [" << anonymizeUrl(_url) << "] has no more views, exiting bluntly.");
+            flushAndExit(EX_OK);
+        }
+        LOG_INF("Document [" << anonymizeUrl(_url) << "] has no more views, but has " <<
+                _sessions.size() << " sessions still. Destroying the document.");
+#ifdef __ANDROID__
+        _loKitDocumentForAndroidOnly.reset();
+#endif
+        _loKitDocument.reset();
+        LOG_INF("Document [" << anonymizeUrl(_url) << "] session [" << sessionId << "] unloaded Document.");
+        return;
+    }
+    else
+    {
+        _loKitDocument->destroyView(viewId);
+    }
 
     // Since callback messages are processed on idle-timer,
     // we could receive callbacks after destroying a view.
     // Retain the CallbackDescriptor object, which is shared with Core.
     // Do not: _viewIdToCallbackDescr.erase(viewId);
 
-    const int viewCount = _loKitDocument->getViewsCount();
-    LOG_INF("Document [" << anonymizeUrl(_url) << "] session [" << sessionId << "] unloaded view ["
-                         << viewId << "]. Have " << viewCount << " view"
-                         << (viewCount != 1 ? "s" : "") << " and " << _sessions.size() << " session"
-                         << (_sessions.size() != 1 ? "s" : ""));
+    viewCount = _loKitDocument->getViewsCount();
+    LOG_INF("Document [" << anonymizeUrl(_url) << "] session [" <<
+            sessionId << "] unloaded view [" << viewId << "]. Have " <<
+            viewCount << " view" << (viewCount != 1 ? "s." : "."));
 
     if (viewCount > 0)
     {


### PR DESCRIPTION
TEST ON CI

This reverts commit 31e4d54d28ae4a925c68b0a520ec6191f509468e. wsd: always exit Kit when unloading

It was causeing unit-wopi-languages to fail with:
wsd-02950-03865 2024-06-14 08:46:09.965324 +0200 [ docbroker_001 ] TRC  Removed non-readonly session [001] from docKey [http%3A%2F%2F127.0.0.1%3A9983%2Fwopi%2Ffiles%2F0] to have 0 sessions:| wsd/DocumentBroker.cpp:3092 coolforkit: kit/Kit.cpp:1272: void Document::onUnload(const ChildSession &): Assertion `views <= 1 && "Unexpected document views without matching child sessions"' failed.
kit-03815-03815 2024-06-14 08:46:09.965352 +0200 [ kitbroker_001 ] SIG   Fatal signal received: SIGABRT code: 18446744073709551610 for address: 0x3e800000ee7
