### PR TITLE
[co-23.05] cool#9219 fix paste between two servers

### DIFF
--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -319,15 +319,15 @@ L.Clipboard = L.Class.extend({
 				}
 
 				var formData = new FormData();
-				formData.append('data', new Blob([fallbackHtml]), 'clipboard');
+				formData.append('data', new Blob([src]), 'clipboard');
 				that._doAsyncDownload(
 					'POST', dest, formData, false,
 					function() {
 						if (that._checkAndDisablePasteSpecial()) {
-							window.app.console.log('up-load of fallback done, now paste special');
+							window.app.console.log('up-load of URL done, now paste special');
 							app.socket.sendMessage('uno .uno:PasteSpecial');
 						} else {
-							window.app.console.log('up-load of fallback done, now paste');
+							window.app.console.log('up-load of URL done, now paste');
 							app.socket.sendMessage('uno .uno:Paste');
 						}
 

--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -319,18 +319,20 @@ L.Clipboard = L.Class.extend({
 				}
 
 				var formData = new FormData();
-				formData.append('data', new Blob([src]), 'clipboard');
+				var commandName = null;
+				if (that._checkAndDisablePasteSpecial()) {
+					commandName = '.uno:PasteSpecial';
+				} else {
+					commandName = '.uno:Paste';
+				}
+				var data = JSON.stringify({
+					url: src,
+					commandName: commandName,
+				});
+				formData.append('data', new Blob([data]), 'clipboard');
 				that._doAsyncDownload(
 					'POST', dest, formData, false,
 					function() {
-						if (that._checkAndDisablePasteSpecial()) {
-							window.app.console.log('up-load of URL done, now paste special');
-							app.socket.sendMessage('uno .uno:PasteSpecial');
-						} else {
-							window.app.console.log('up-load of URL done, now paste');
-							app.socket.sendMessage('uno .uno:Paste');
-						}
-
 					}.bind(this),
 					function(progress) { return 50 + progress/2; },
 					function() {

--- a/common/Clipboard.hpp
+++ b/common/Clipboard.hpp
@@ -32,6 +32,36 @@ struct ClipboardData
     {
     }
 
+    /// Determines if inStream is a list of mimetype-length-bytes tuples, as expected.
+    static bool isOwnFormat(std::istream& inStream)
+    {
+        if (inStream.eof())
+        {
+            return false;
+        }
+
+        std::string mime, hexLen;
+        std::getline(inStream, mime, '\n');
+        if (mime.empty())
+        {
+            return false;
+        }
+
+        std::getline(inStream, hexLen, '\n');
+        if (hexLen.empty())
+        {
+            return false;
+        }
+
+        uint64_t len = strtoll(hexLen.c_str(), nullptr, 16);
+        if (len == 0)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
     void read(std::istream& inStream)
     {
         while (!inStream.eof())

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -1306,19 +1306,44 @@ bool ChildSession::setClipboard(const char* buffer, int length, const StringVect
         std::string command; // skip command
         std::getline(stream, command, '\n');
 
-        data.read(stream);
+        // See if the data is in the usual mimetype-size-content format or is just plain HTML.
+        std::streampos pos = stream.tellg();
+        std::string firstLine;
+        std::getline(stream, firstLine, '\n');
+        std::vector<char> html;
+        bool hasHTML = Util::startsWith(firstLine, "<!DOCTYPE html>");
+        stream.seekg(pos, stream.beg);
+        if (hasHTML)
+        {
+            // It's just HTML: copy that as-is.
+            std::vector<char> buf(std::istreambuf_iterator<char>(stream), {});
+            html = std::move(buf);
+        }
+        else
+        {
+            data.read(stream);
+        }
 //        data.dumpState(std::cerr);
 
-        const size_t nInCount = data.size();
+        const size_t nInCount = html.empty() ? data.size() : 1;
         std::vector<size_t> pInSizes(nInCount);
         std::vector<const char*> pInMimeTypes(nInCount);
         std::vector<const char*> pInStreams(nInCount);
 
-        for (size_t i = 0; i < nInCount; ++i)
+        if (html.empty())
         {
-            pInSizes[i] = data._content[i].length();
-            pInStreams[i] = data._content[i].c_str();
-            pInMimeTypes[i] = data._mimeTypes[i].c_str();
+            for (size_t i = 0; i < nInCount; ++i)
+            {
+                pInSizes[i] = data._content[i].length();
+                pInStreams[i] = data._content[i].c_str();
+                pInMimeTypes[i] = data._mimeTypes[i].c_str();
+            }
+        }
+        else
+        {
+            pInSizes[0] = html.size();
+            pInStreams[0] = html.data();
+            pInMimeTypes[0] = "text/html";
         }
 
         getLOKitDocument()->setView(_viewId);

--- a/test/HttpWhiteBoxTests.cpp
+++ b/test/HttpWhiteBoxTests.cpp
@@ -13,6 +13,7 @@
 
 #include <string>
 
+#include <common/Clipboard.hpp>
 #include <net/HttpRequest.hpp>
 
 #include <test/lokassert.hpp>
@@ -36,6 +37,7 @@ class HttpWhiteBoxTests : public CPPUNIT_NS::TestFixture
 
     CPPUNIT_TEST(testRequestParserValidComplete);
     CPPUNIT_TEST(testRequestParserValidIncomplete);
+    CPPUNIT_TEST(testClipboardIsOwnFormat);
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -46,6 +48,7 @@ class HttpWhiteBoxTests : public CPPUNIT_NS::TestFixture
     void testHeader();
     void testRequestParserValidComplete();
     void testRequestParserValidIncomplete();
+    void testClipboardIsOwnFormat();
 };
 
 void HttpWhiteBoxTests::testStatusLineParserValidComplete()
@@ -224,6 +227,29 @@ void HttpWhiteBoxTests::testRequestParserValidIncomplete()
     LOK_ASSERT_EQUAL(expUrl, req.getUrl());
     LOK_ASSERT_EQUAL(expVersion, req.getVersion());
     LOK_ASSERT_EQUAL(expHost, req.header().get("Host"));
+}
+
+void HttpWhiteBoxTests::testClipboardIsOwnFormat()
+{
+    constexpr auto testname = __func__;
+    {
+        std::string body = R"x(application/x-openoffice-embed-source-xml;windows_formatname="Star Embed Source (XML)"
+1def
+PK)x";
+        std::istringstream stream(body);
+
+        LOK_ASSERT_EQUAL(ClipboardData::isOwnFormat(stream), true);
+    }
+    {
+        std::string body = R"(<!DOCTYPE html>
+<html>
+<head>)";
+        std::istringstream stream(body);
+
+        // This is expected to fail: format is mimetype-length-bytes tuples and here the second line
+        // is not a hex size.
+        LOK_ASSERT_EQUAL(ClipboardData::isOwnFormat(stream), false);
+    }
 }
 
 CPPUNIT_TEST_SUITE_REGISTRATION(HttpWhiteBoxTests);

--- a/test/UnitCopyPaste.cpp
+++ b/test/UnitCopyPaste.cpp
@@ -364,6 +364,17 @@ public:
                                   existing + newcontent + '\n'))
             return;
 
+        // Test setting HTML clipboard:
+        std::string html("<!DOCTYPE html><html><body>myword</body></html>");
+        // Intentionally no buildClipboardText() here, just raw HTML.
+        if (!setClipboard(_clipURI, html, HTTPResponse::HTTP_OK))
+            return;
+        // This failed with: ERROR: Forced failure: Missing clipboard mime type, because we tried to
+        // parse HTML when we expected a list of mimetype-size-bytes entries.
+        if (!fetchClipboardAssert(_clipURI, "text/html", html))
+            return;
+
+        // Setup state that will be also asserte in postCloseTest():
         LOG_TST("Setup clipboards:");
         if (!setClipboard(_clipURI2, buildClipboardText("kippers"), HTTPResponse::HTTP_OK))
             return;

--- a/test/UnitCopyPaste.cpp
+++ b/test/UnitCopyPaste.cpp
@@ -75,6 +75,10 @@ public:
         std::shared_ptr<const http::Response> httpResponse =
             httpSession->syncRequest(http::Request(Poco::URI(clipURIstr).getPathAndQuery()));
 
+        // Note that this is expected for both living and closed documents.
+        // This failed when either case didn't add the custom header.
+        LOK_ASSERT_EQUAL(std::string("true"), httpResponse->get("X-COOL-Clipboard"));
+
         LOG_TST("getClipboard: sent request: " << clipURI.getPathAndQuery());
 
         try {

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -339,6 +339,14 @@ void ClientSession::handleClipboardRequest(DocumentBroker::ClipboardRequest     
                             return;
                         }
 
+                        // Check if this is likely produced by us.
+                        std::string clipboardHeader = httpResponse->get("X-COOL-Clipboard");
+                        if (clipboardHeader != "true")
+                        {
+                            LOG_ERR("Clipboard response is missing the required 'X-COOL-Clipboard: true' header");
+                            return;
+                        }
+
                         std::string body = httpResponse->getBody();
                         std::istringstream stream(body);
                         if (ClipboardData::isOwnFormat(stream))
@@ -2042,12 +2050,14 @@ bool ClientSession::handleKitToClientMessage(const std::shared_ptr<Message>& pay
                 continue;
 
             std::ostringstream oss;
+            // The custom header for the clipboard of a living document.
             oss << "HTTP/1.1 200 OK\r\n"
                 << "Last-Modified: " << Util::getHttpTimeNow() << "\r\n"
                 << "User-Agent: " << WOPI_AGENT_STRING << "\r\n"
                 << "Content-Length: " << (empty ? 0 : (payload->size() - header)) << "\r\n"
                 << "Content-Type: application/octet-stream\r\n"
                 << "X-Content-Type-Options: nosniff\r\n"
+                << "X-COOL-Clipboard: true\r\n"
                 << "Connection: close\r\n"
                 << "\r\n";
 

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -347,10 +347,18 @@ void ClientSession::handleClipboardRequest(DocumentBroker::ClipboardRequest     
 
                     std::shared_ptr<http::Session> httpSession = http::Session::create(url);
                     httpSession->setFinishedHandler(std::move(finishedCallback));
-                    http::Request httpRequest(Poco::URI(url).getPathAndQuery());
-                    if (!httpSession->asyncRequest(httpRequest, docBroker->getPoll()))
+                    std::string pathAndQuery = Poco::URI(url).getPathAndQuery();
+                    if (pathAndQuery.find("/cool/clipboard") != std::string::npos)
                     {
-                        LOG_ERR("Failed to start an async clipboard download request");
+                        http::Request httpRequest(Poco::URI(url).getPathAndQuery());
+                        if (!httpSession->asyncRequest(httpRequest, docBroker->getPoll()))
+                        {
+                            LOG_ERR("Failed to start an async clipboard download request");
+                        }
+                    }
+                    else
+                    {
+                        LOG_ERR("Clipboard download URL does not look like a clipboard one");
                     }
                 }
             }

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -316,6 +316,7 @@ void ClientSession::handleClipboardRequest(DocumentBroker::ClipboardRequest     
         {
             preProcessSetClipboardPayload(*data);
 
+#if !MOBILEAPP
             if (Util::startsWith(*data, "{"))
             {
                 // We got JSON, extract the URL and the UNO command name.
@@ -354,6 +355,7 @@ void ClientSession::handleClipboardRequest(DocumentBroker::ClipboardRequest     
                 }
             }
             else
+#endif
             {
                 // List of mimetype-size-data tuples, pass that over as-is.
                 docBroker->forwardToChild(client_from_this(), "setclipboard\n" + *data, true);

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -326,14 +326,30 @@ void ClientSession::handleClipboardRequest(DocumentBroker::ClipboardRequest     
                     JsonUtil::findJSONValue(json, "url", url);
                     std::string commandName;
                     JsonUtil::findJSONValue(json, "commandName", commandName);
-                    std::shared_ptr<http::Session> httpSession = http::Session::create(url);
-                    std::shared_ptr<const http::Response> httpResponse =
-                        httpSession->syncRequest(http::Request(Poco::URI(url).getPathAndQuery()));
-                    if (httpResponse->statusLine().statusCode() == http::StatusCode::OK)
+                    http::Session::FinishedCallback finishedCallback =
+                        [this, docBroker,
+                         commandName](const std::shared_ptr<http::Session>& session)
                     {
+                        const std::shared_ptr<const http::Response> httpResponse =
+                            session->response();
+                        if (httpResponse->statusLine().statusCode() != http::StatusCode::OK)
+                        {
+                            LOG_ERR("Clipboard download request failed");
+                            return;
+                        }
+
                         std::string body = httpResponse->getBody();
-                        docBroker->forwardToChild(client_from_this(), "setclipboard\n" + body, true);
+                        docBroker->forwardToChild(client_from_this(), "setclipboard\n" + body,
+                                                  true);
                         docBroker->forwardToChild(client_from_this(), "uno " + commandName);
+                    };
+
+                    std::shared_ptr<http::Session> httpSession = http::Session::create(url);
+                    httpSession->setFinishedHandler(std::move(finishedCallback));
+                    http::Request httpRequest(Poco::URI(url).getPathAndQuery());
+                    if (!httpSession->asyncRequest(httpRequest, docBroker->getPoll()))
+                    {
+                        LOG_ERR("Failed to start an async clipboard download request");
                     }
                 }
             }

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -315,7 +315,24 @@ void ClientSession::handleClipboardRequest(DocumentBroker::ClipboardRequest     
         if (data.get())
         {
             preProcessSetClipboardPayload(*data);
-            docBroker->forwardToChild(client_from_this(), "setclipboard\n" + *data, true);
+
+            if (Util::startsWith(*data, "http"))
+            {
+                // We got a URL, download that and set the result as the clipboard.
+                std::shared_ptr<http::Session> httpSession = http::Session::create(*data);
+                std::shared_ptr<const http::Response> httpResponse =
+                    httpSession->syncRequest(http::Request(Poco::URI(*data).getPathAndQuery()));
+                if (httpResponse->statusLine().statusCode() == http::StatusCode::OK)
+                {
+                    std::string body = httpResponse->getBody();
+                    docBroker->forwardToChild(client_from_this(), "setclipboard\n" + body, true);
+                }
+            }
+            else
+            {
+                // List of mimetype-size-data tuples, pass that over as-is.
+                docBroker->forwardToChild(client_from_this(), "setclipboard\n" + *data, true);
+            }
 
             // FIXME: work harder for error detection ?
             std::ostringstream oss;

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -340,9 +340,18 @@ void ClientSession::handleClipboardRequest(DocumentBroker::ClipboardRequest     
                         }
 
                         std::string body = httpResponse->getBody();
-                        docBroker->forwardToChild(client_from_this(), "setclipboard\n" + body,
-                                                  true);
-                        docBroker->forwardToChild(client_from_this(), "uno " + commandName);
+                        std::istringstream stream(body);
+                        if (ClipboardData::isOwnFormat(stream))
+                        {
+                            docBroker->forwardToChild(client_from_this(), "setclipboard\n" + body,
+                                    true);
+                            docBroker->forwardToChild(client_from_this(), "uno " + commandName);
+                        }
+                        else
+                        {
+                            LOG_ERR("Clipboard download: unexpected data format");
+                            return;
+                        }
                     };
 
                     std::shared_ptr<http::Session> httpSession = http::Session::create(url);

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -2996,6 +2996,10 @@ void DocumentBroker::addSocketToPoll(const std::shared_ptr<StreamSocket>& socket
 {
     _poll->insertNewSocket(socket);
 }
+SocketPoll& DocumentBroker::getPoll()
+{
+    return *_poll;
+}
 
 void DocumentBroker::alertAllUsers(const std::string& msg)
 {

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -3308,12 +3308,14 @@ bool DocumentBroker::lookupSendClipboardTag(const std::shared_ptr<StreamSocket> 
     if (saved)
     {
             std::ostringstream oss;
+            // The custom header for the clipboard of an already closed document.
             oss << "HTTP/1.1 200 OK\r\n"
                 << "Last-Modified: " << Util::getHttpTimeNow() << "\r\n"
                 << "User-Agent: " << WOPI_AGENT_STRING << "\r\n"
                 << "Content-Length: " << saved->length() << "\r\n"
                 << "Content-Type: application/octet-stream\r\n"
                 << "X-Content-Type-Options: nosniff\r\n"
+                << "X-COOL-Clipboard: true\r\n"
                 << "Connection: close\r\n"
                 << "\r\n";
             oss.write(saved->c_str(), saved->length());

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -415,6 +415,8 @@ public:
     /// Transfer this socket into our polling thread / loop.
     void addSocketToPoll(const std::shared_ptr<StreamSocket>& socket);
 
+    SocketPoll& getPoll();
+
     void alertAllUsers(const std::string& msg);
 
     void alertAllUsers(const std::string& cmd, const std::string& kind)


### PR DESCRIPTION
- **cool#9219 kit: fix setclipboard command with HTML payload**
- **cool#9219 clipboard: support URLs in the payload of the setclipboard command**
- **cool#9219 clipboard: replace URL with a JSON for setclipboard**
- **cool#9219 clipboard: use async HTTP in setclipboard**
- **cool#9219 clipboard: fix Android build**
- **cool#9219 clipboard: only download clipboard-looking URLs**
- **cool#9219 clipboard: only accept downloaded data in own format**
- **cool#9219 clipboard: add custom X-COOL-Clipboard header**
