### PR TITLE
Can't show the cursor before the _tileWidthTwips is set.

### DIFF
--- a/browser/src/layer/marker/TextInput.js
+++ b/browser/src/layer/marker/TextInput.js
@@ -485,7 +485,7 @@ L.TextInput = L.Layer.extend({
 	// Displays the caret and the under-caret marker.
 	// Fetches the coordinates of the caret from the map's doclayer.
 	showCursor: function() {
-		if (!this._map._docLayer._cursorMarker) {
+		if (!this._map._docLayer._cursorMarker || !this._map._docLayer._tileWidthTwips) {
 			return;
 		}
 


### PR DESCRIPTION
Change-Id: I6bc6575cc28126388c7c88424128d0ec7f341610


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

