### PR TITLE
Server audit: add config option to disable

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1604,9 +1604,16 @@ L.CanvasTileLayer = L.Layer.extend({
 				}
 			}
 		} else if (textMsg.startsWith('serveraudit:')) {
-			var json = JSON.parse(textMsg.substr(12));
-			app.serverAudit = json.serverAudit;
-			app.map.fire('receivedserveraudit');
+			var serverAudit = textMsg.substr(12).trim();
+			if (serverAudit !== 'disabled') {
+				// if isAdminUser property is not set by integration - enable audit dialog for all users
+				if (app.isAdminUser !== false)
+					this._map.serverAuditDialog = JSDialog.serverAuditDialog(this._map);
+
+				var json = JSON.parse(serverAudit);
+				app.serverAudit = json.serverAudit;
+				app.map.fire('receivedserveraudit');
+			}
 		} else if (textMsg.startsWith('adminuser:')) {
 			var value = textMsg.substr(10).trim();
 			if (value === 'true')
@@ -1615,10 +1622,6 @@ L.CanvasTileLayer = L.Layer.extend({
 				app.isAdminUser = false;
 			else
 				app.isAdminUser = null;
-
-			// if isAdminUser property is not set by integration - show audit dialog for all users
-			if (app.isAdminUser !== false)
-				this._map.serverAuditDialog = JSDialog.serverAuditDialog(this._map);
 		}
 	},
 

--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -118,6 +118,7 @@
         </anonymize>
         <docstats type="bool" desc="Enable to see document handling information in logs." default="false">false</docstats>
         <userstats desc="Enable user stats. i.e: logs the details of a file and user" type="bool" default="false">false</userstats>
+        <disable_server_audit type="bool" desc="Disabled server audit dialog and notification. Admin will no longer see warnings in the application user interface. This doesn't affect log file." default="false">false</disable_server_audit>
     </logging>
 
     <!--

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -1994,6 +1994,7 @@ void COOLWSD::innerInitialize(Application& self)
         { "logging.lokit_sal_log", "-INFO-WARN" },
         { "logging.docstats", "false" },
         { "logging.userstats", "false" },
+        { "logging.disable_server_audit", "false" },
         { "browser_logging", "false" },
         { "mount_jail_tree", "true" },
         { "net.connection_timeout_secs", "30" },

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -2345,8 +2345,10 @@ bool ClientSession::handleKitToClientMessage(const std::shared_ptr<Message>& pay
                 forwardToClient(std::make_shared<Message>(admin, Message::Dir::Out));
 
                 // send server audit results after we received information about users (who is admin)
-                const std::string serverAudit = std::string("serveraudit: ") + docBroker->getServerAudit();
-                forwardToClient(std::make_shared<Message>(serverAudit, Message::Dir::Out));
+                const ServerAuditUtil& serverAudit = docBroker->getServerAudit();
+                std::string audit = serverAudit.isDisabled() ? "disabled" : serverAudit.getResultsJSON();
+                const std::string auditMessage = std::string("serveraudit: ") + audit;
+                forwardToClient(std::make_shared<Message>(auditMessage, Message::Dir::Out));
             }
 
             return status;

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1295,6 +1295,11 @@ DocumentBroker::updateSessionWithWopiInfo(const std::shared_ptr<ClientSession>& 
         LOG_ANY("User stats: " << userStatsString);
     }
 
+    if (config::getBool("logging.disable_server_audit", false))
+    {
+        _serverAudit.disable();
+    }
+
     // Pass the ownership to the client session.
     session->setWopiFileInfo(wopiFileInfo);
     session->setUserId(userId);
@@ -4487,11 +4492,6 @@ void DocumentBroker::onUrpMessage(const char* data, size_t len)
 }
 
 #if !MOBILEAPP && !WASMAPP
-
-std::string DocumentBroker::getServerAudit() const
-{
-    return _serverAudit.getResultsJSON();
-}
 
 void DocumentBroker::switchMode(const std::shared_ptr<ClientSession>& session,
                                 const std::string& mode)

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -596,8 +596,8 @@ public:
     void setMigrationMsgReceived() { _migrateMsgReceived = true; }
 
 #if !MOBILEAPP && !WASMAPP
-    /// Get JSON with audit status
-    std::string getServerAudit() const;
+    /// Get server audit util
+    const ServerAuditUtil& getServerAudit() const { return _serverAudit; }
 
     /// Switch between Online and Offline modes.
     void switchMode(const std::shared_ptr<ClientSession>& session, const std::string& mode);

--- a/wsd/ServerAuditUtil.cpp
+++ b/wsd/ServerAuditUtil.cpp
@@ -12,6 +12,7 @@
 #include "ServerAuditUtil.hpp"
 
 ServerAuditUtil::ServerAuditUtil()
+: disabled(false)
 {
     set("is_admin", "ok");
     set("certwarning", "ok");

--- a/wsd/ServerAuditUtil.hpp
+++ b/wsd/ServerAuditUtil.hpp
@@ -21,12 +21,17 @@ class ServerAuditUtil
     // <code, status>
     std::map<std::string, std::string> entries;
 
+    bool disabled;
+
 public:
     ServerAuditUtil();
 
     std::string getResultsJSON() const;
 
     void set(std::string code, std::string status);
+
+    void disable() { disabled = true; }
+    bool isDisabled() const { return disabled; }
 };
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */


### PR DESCRIPTION
Setting logging.disable_server_audit to true will
disable server audit dialog, button in the menus and notification.

In that case we will receive "serveraudit: diabled" message in the client. This doesn't disable any logging to the file.