### PR TITLE
Revert "browser: remove unused function "Base64ToArrayBuffer""

### DIFF
--- a/browser/html/cool.html.m4
+++ b/browser/html/cool.html.m4
@@ -107,6 +107,18 @@ m4_ifelse(EMSCRIPTENAPP,[true],
   [   window.ThisIsTheEmscriptenApp = false;]
 )
 
+// This function may look unused, but it's needed in WASM and Android to send data through the fake websocket. Please
+// don't remove it without first grepping for 'Base64ToArrayBuffer' in the C++ code
+var Base64ToArrayBuffer = function(base64Str) {
+  var binStr = atob(base64Str);
+  var ab = new ArrayBuffer(binStr.length);
+  var bv = new Uint8Array(ab);
+  for (var i = 0, l = binStr.length; i < l; i++) {
+    bv[[i]] = binStr.charCodeAt(i);
+  }
+  return ab;
+}
+
   window.bundlejsLoaded = false;
   window.fullyLoadedAndReady = false;
   window.addEventListener('load', function() {


### PR DESCRIPTION
This reverts commit 1ed033efe816ab3c2fb02cbe8455bc2525fb4ffc, and I've also added a comment to avoid the same mistake happening again.

Removing this function prevents the Android webview communicating with the C++ code, it's vitally important for it to remain so long as this is still the case. It's not directly used in our JavaScript, though, so this is a fairly easy mistake to make.


Change-Id: I160363d5739a4ea3601348c0059488e39468c4b6

This will need to be ported to master, however I wanted to merge to 23.05 first as that is the current Android base