### PR TITLE
invalidatetiles not logged like the other incoming messages

### DIFF
--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -176,11 +176,9 @@ app.definitions.Socket = L.Class.extend({
 	},
 
 	_doSend: function(msg) {
-		if (this._map._debug.debugNeverStarted || this._map._debug.logOutgoingMessages) {
-			// Only attempt to log text frames, not binary ones.
-			if (typeof msg === 'string')
-				this._logSocket('OUTGOING', msg);
-		}
+		// Only attempt to log text frames, not binary ones.
+		if (typeof msg === 'string')
+			this._logSocket('OUTGOING', msg);
 
 		this.socket.send(msg);
 	},
@@ -302,6 +300,10 @@ app.definitions.Socket = L.Class.extend({
 	},
 
 	_logSocket: function(type, msg) {
+		var logMessage = this._map._debug.debugNeverStarted || this._map._debug.logIncomingMessages;
+		if (!logMessage)
+			return;
+
 		if (window.ThisIsTheGtkApp)
 			window.postMobileDebug(type + ' ' + msg);
 
@@ -611,9 +613,7 @@ app.definitions.Socket = L.Class.extend({
 		textMsg = e.textMsg;
 		imgBytes = e.imgBytes;
 
-		if (this._map._debug.debugNeverStarted || this._map._debug.logIncomingMessages) {
-			this._logSocket('INCOMING', textMsg);
-		}
+		this._logSocket('INCOMING', textMsg);
 
 		var command = this.parseServerCmd(textMsg);
 		if (textMsg.startsWith('coolserver ')) {

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1701,6 +1701,7 @@ L.CanvasTileLayer = L.Layer.extend({
 		var textMsg = evt.textMsg;
 
 		if (textMsg.startsWith('invalidatetiles:')) {
+			app.socket._logSocket('INCOMING', textMsg);
 			this.handleInvalidateTilesMsg(textMsg);
 			return true; // filter
 		}


### PR DESCRIPTION
its skipped because its filtered on slurp
add explicit logging for it in its handler

_logSocket is currently only called in two places that both check the same debugging flags so move that check inside _logSocket.


Change-Id: Icacd8b99b4aaf5feaa468f89b3273101d6722ca6


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

