### PR TITLE
Use IsAdminUser (23.05)

### DIFF
--- a/browser/src/docstate.js
+++ b/browser/src/docstate.js
@@ -13,6 +13,7 @@ window.app = { // Shouldn't have any functions defined.
 	definitions: {}, // Class instances are created using definitions under this variable.
 	dpiScale: window.devicePixelRatio,
 	roundedDpiScale: Math.round(window.devicePixelRatio),
+	isAdminUser: null, // Is admin on the integrator side - used eg. to show update warnings
 	map: null, // Make map object a part of this.
 	twipsToPixels: 0, // Twips to pixels multiplier.
 	pixelsToTwips: 0, // Pixels to twips multiplier.

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1970,6 +1970,8 @@ L.CanvasTileLayer = L.Layer.extend({
 					console.warn('Integrator didn\'t set IsAdminUser property for the session');
 				}
 			}
+
+			this._map.fire('adminuser');
 		}
 		else if (textMsg.startsWith('readonlyhyperlinkclicked: ')) {
 			var jsonString = textMsg.replace('readonlyhyperlinkclicked: ', '');

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1949,14 +1949,26 @@ L.CanvasTileLayer = L.Layer.extend({
 				}
 			}
 		} else if (textMsg.startsWith('adminuser:')) {
+			// this message arrives after first viewinfo:
+
 			var value = textMsg.substr(10).trim();
 			if (value === 'true')
 				app.isAdminUser = true;
 			else if (value === 'false')
 				app.isAdminUser = false;
 			else {
-				console.warn('Integrator didn\'t set IsAdminUser property for the session');
 				app.isAdminUser = null;
+
+				if (!this._map._viewInfo)
+					return;
+
+				var viewInfo = this._map._viewInfo[this._viewId];
+				if (viewInfo && viewInfo.userextrainfo && viewInfo.userextrainfo.is_admin !== undefined) {
+					app.isAdminUser = !!viewInfo.userextrainfo.is_admin;
+					console.warn('Integrator uses deprecated is_admin property. Please Use IsAdminUser instead.');
+				} else {
+					console.warn('Integrator didn\'t set IsAdminUser property for the session');
+				}
 			}
 		}
 		else if (textMsg.startsWith('readonlyhyperlinkclicked: ')) {

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1948,6 +1948,16 @@ L.CanvasTileLayer = L.Layer.extend({
 					delete app.colorPalettes[key];
 				}
 			}
+		} else if (textMsg.startsWith('adminuser:')) {
+			var value = textMsg.substr(10).trim();
+			if (value === 'true')
+				app.isAdminUser = true;
+			else if (value === 'false')
+				app.isAdminUser = false;
+			else {
+				console.warn('Integrator didn\'t set IsAdminUser property for the session');
+				app.isAdminUser = null;
+			}
 		}
 		else if (textMsg.startsWith('readonlyhyperlinkclicked: ')) {
 			var jsonString = textMsg.replace('readonlyhyperlinkclicked: ', '');

--- a/browser/src/map/handler/Map.VersionBar.js
+++ b/browser/src/map/handler/Map.VersionBar.js
@@ -16,11 +16,7 @@ L.Map.VersionBar = L.Handler.extend({
 	},
 
 	onUpdateInfo: function () {
-		var docLayer = this._map._docLayer || {};
-		var viewInfo = this._map._viewInfo[docLayer._viewId];
-
-		if (viewInfo && viewInfo.userextrainfo &&
-		    viewInfo.userextrainfo.is_admin) {
+		if (app.isAdminUser) {
 			var laterDate = new Date();
 			var currentDate = new Date();
 			var timeValue = window.localStorage.getItem('InfoBarLaterDate');

--- a/browser/src/map/handler/Map.VersionBar.js
+++ b/browser/src/map/handler/Map.VersionBar.js
@@ -6,13 +6,13 @@
 
 L.Map.VersionBar = L.Handler.extend({
 	onAdd: function () {
-		this._map.on('updateviewslist', this.onUpdateInfo, this);
+		this._map.on('adminuser', this.onUpdateInfo, this);
 		this._map.on('versionbar', this.onversionbar, this);
 	},
 
 	onRemove: function () {
 		this._map.off('versionbar', this.onversionbar, this);
-		this._map.off('updateviewlist', this.onUpdateInfo, this);
+		this._map.off('adminuser', this.onUpdateInfo, this);
 	},
 
 	onUpdateInfo: function () {

--- a/common/Session.cpp
+++ b/common/Session.cpp
@@ -41,7 +41,9 @@ Session::Session(const std::shared_ptr<ProtocolHandlerInterface> &protocol,
     _isAllowChangeComments(false),
     _haveDocPassword(false),
     _isDocPasswordProtected(false),
+#if !MOBILEAPP
     _isAdminUser(std::nullopt),
+#endif
     _watermarkOpacity(0.2),
     _accessibilityState(false)
 {

--- a/common/Session.cpp
+++ b/common/Session.cpp
@@ -41,7 +41,7 @@ Session::Session(const std::shared_ptr<ProtocolHandlerInterface> &protocol,
     _isAllowChangeComments(false),
     _haveDocPassword(false),
     _isDocPasswordProtected(false),
-    _isAdminUser(false),
+    _isAdminUser(std::nullopt),
     _watermarkOpacity(0.2),
     _accessibilityState(false)
 {

--- a/common/Session.cpp
+++ b/common/Session.cpp
@@ -41,6 +41,7 @@ Session::Session(const std::shared_ptr<ProtocolHandlerInterface> &protocol,
     _isAllowChangeComments(false),
     _haveDocPassword(false),
     _isDocPasswordProtected(false),
+    _isAdminUser(false),
     _watermarkOpacity(0.2),
     _accessibilityState(false)
 {

--- a/common/Session.hpp
+++ b/common/Session.hpp
@@ -208,6 +208,8 @@ public:
 
     void setWatermarkText(const std::string& watermarkText) { _watermarkText = watermarkText; }
 
+    void setIsAdminUser(const bool isAdminUser) { _isAdminUser = isAdminUser; }
+
     void setUserExtraInfo(const std::string& userExtraInfo) { _userExtraInfo = userExtraInfo; }
 
     void setUserPrivateInfo(const std::string& userPrivateInfo) { _userPrivateInfo = userPrivateInfo; }
@@ -239,6 +241,8 @@ public:
     void setDocPassword(const std::string& password) { _docPassword = password; }
 
     const std::string& getDocPassword() const { return _docPassword; }
+
+    bool getIsAdminUser() const { return _isAdminUser; }
 
     const std::string& getUserExtraInfo() const { return _userExtraInfo; }
 
@@ -345,6 +349,9 @@ private:
 
     /// Name of the user to whom the session belongs to, anonymized for logging.
     std::string _userNameAnonym;
+
+    /// If user is admin on the integrator side
+    bool _isAdminUser;
 
     /// Extra info per user, mostly mail, avatar, links, etc.
     std::string _userExtraInfo;

--- a/common/Session.hpp
+++ b/common/Session.hpp
@@ -16,6 +16,7 @@
 #include <memory>
 #include <map>
 #include <ostream>
+#include <optional>
 #include <type_traits>
 
 #include <Poco/Path.h>
@@ -208,7 +209,7 @@ public:
 
     void setWatermarkText(const std::string& watermarkText) { _watermarkText = watermarkText; }
 
-    void setIsAdminUser(const bool isAdminUser) { _isAdminUser = isAdminUser; }
+    void setIsAdminUser(const std::optional<bool> isAdminUser) { _isAdminUser = isAdminUser; }
 
     void setUserExtraInfo(const std::string& userExtraInfo) { _userExtraInfo = userExtraInfo; }
 
@@ -242,7 +243,7 @@ public:
 
     const std::string& getDocPassword() const { return _docPassword; }
 
-    bool getIsAdminUser() const { return _isAdminUser; }
+    const std::optional<bool> getIsAdminUser() const { return _isAdminUser; }
 
     const std::string& getUserExtraInfo() const { return _userExtraInfo; }
 
@@ -351,7 +352,7 @@ private:
     std::string _userNameAnonym;
 
     /// If user is admin on the integrator side
-    bool _isAdminUser;
+    std::optional<bool> _isAdminUser;
 
     /// Extra info per user, mostly mail, avatar, links, etc.
     std::string _userExtraInfo;

--- a/common/Session.hpp
+++ b/common/Session.hpp
@@ -209,7 +209,9 @@ public:
 
     void setWatermarkText(const std::string& watermarkText) { _watermarkText = watermarkText; }
 
+#if !MOBILEAPP
     void setIsAdminUser(const std::optional<bool> isAdminUser) { _isAdminUser = isAdminUser; }
+#endif
 
     void setUserExtraInfo(const std::string& userExtraInfo) { _userExtraInfo = userExtraInfo; }
 
@@ -243,7 +245,9 @@ public:
 
     const std::string& getDocPassword() const { return _docPassword; }
 
+#if !MOBILEAPP
     const std::optional<bool> getIsAdminUser() const { return _isAdminUser; }
+#endif
 
     const std::string& getUserExtraInfo() const { return _userExtraInfo; }
 
@@ -351,8 +355,10 @@ private:
     /// Name of the user to whom the session belongs to, anonymized for logging.
     std::string _userNameAnonym;
 
+#if !MOBILEAPP
     /// If user is admin on the integrator side
     std::optional<bool> _isAdminUser;
+#endif
 
     /// Extra info per user, mostly mail, avatar, links, etc.
     std::string _userExtraInfo;

--- a/test/httpwstest.cpp
+++ b/test/httpwstest.cpp
@@ -280,7 +280,8 @@ void HTTPWSTest::testInactiveClient()
                                             token == "rulerupdate:" ||
                                             token == "tableselected:" ||
                                             token == "colorpalettes:" ||
-                                            token == "jsdialog:");
+                                            token == "jsdialog:" ||
+                                            token == "adminuser:");
 
                     // End when we get state changed.
                     return (token != "statechanged:");

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -94,8 +94,10 @@ ClientSession::ClientSession(
     _serverURL(requestDetails),
     _isTextDocument(false),
     _thumbnailSession(false),
-    _canonicalViewId(0),
-    _sentAdmin(false)
+    _canonicalViewId(0)
+#if !MOBILEAPP
+    ,_sentAdmin(false)
+#endif
 {
     const std::size_t curConnections = ++COOLWSD::NumConnections;
     LOG_INF("ClientSession ctor [" << getName() << "] for URI: [" << _uriPublic.toString()
@@ -2969,9 +2971,11 @@ std::string ClientSession::processSVGContent(const std::string& svg)
     return broken ? svg : oss.str();
 }
 
+#if !MOBILEAPP
 std::string ClientSession::getIsAdminUserStatus() const
 {
     return getIsAdminUser().has_value() ? (getIsAdminUser().value() ? "true" : "false") : "null";
 }
+#endif
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -2364,7 +2364,7 @@ bool ClientSession::handleKitToClientMessage(const std::shared_ptr<Message>& pay
             {
                 _sentAdmin = true;
                 // send information about admin user
-                const std::string admin = std::string("adminuser: ") + std::string(getIsAdminUser() ? "true" : "false");
+                const std::string admin = std::string("adminuser: ") + getIsAdminUserStatus();
                 forwardToClient(std::make_shared<Message>(admin, Message::Dir::Out));
             }
 
@@ -2967,6 +2967,11 @@ std::string ClientSession::processSVGContent(const std::string& svg)
     }
 
     return broken ? svg : oss.str();
+}
+
+std::string ClientSession::getIsAdminUserStatus() const
+{
+    return getIsAdminUser().has_value() ? (getIsAdminUser().value() ? "true" : "false") : "null";
 }
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -94,7 +94,8 @@ ClientSession::ClientSession(
     _serverURL(requestDetails),
     _isTextDocument(false),
     _thumbnailSession(false),
-    _canonicalViewId(0)
+    _canonicalViewId(0),
+    _sentAdmin(false)
 {
     const std::size_t curConnections = ++COOLWSD::NumConnections;
     LOG_INF("ClientSession ctor [" << getName() << "] for URI: [" << _uriPublic.toString()
@@ -2353,6 +2354,23 @@ bool ClientSession::handleKitToClientMessage(const std::shared_ptr<Message>& pay
                 LOG_ERR("invalidatecursor parsing failure: " << exception.what());
             }
         }
+#if !MOBILEAPP
+        // don't sent it again, eg when some user joins
+        else if (!_sentAdmin && tokens.equals(0, "viewinfo:"))
+        {
+            bool status = forwardToClient(payload);
+
+            if (docBroker)
+            {
+                _sentAdmin = true;
+                // send information about admin user
+                const std::string admin = std::string("adminuser: ") + std::string(getIsAdminUser() ? "true" : "false");
+                forwardToClient(std::make_shared<Message>(admin, Message::Dir::Out));
+            }
+
+            return status;
+        }
+#endif
         else if (tokens.equals(0, "renderfont:"))
         {
             std::string font, text;

--- a/wsd/ClientSession.hpp
+++ b/wsd/ClientSession.hpp
@@ -320,7 +320,9 @@ private:
     /// If this session is read-only because of failed lock, try to unlock and make it read-write.
     bool attemptLock(const std::shared_ptr<DocumentBroker>& docBroker);
 
+#if !MOBILEAPP
     std::string getIsAdminUserStatus() const;
+#endif
 
 private:
     std::weak_ptr<DocumentBroker> _docBroker;
@@ -422,8 +424,10 @@ private:
     /// the canonical id unique to the set of rendering properties of this session
     int _canonicalViewId;
 
+#if !MOBILEAPP
     /// If adminuser message was already sent
     bool _sentAdmin;
+#endif
 };
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/ClientSession.hpp
+++ b/wsd/ClientSession.hpp
@@ -320,6 +320,8 @@ private:
     /// If this session is read-only because of failed lock, try to unlock and make it read-write.
     bool attemptLock(const std::shared_ptr<DocumentBroker>& docBroker);
 
+    std::string getIsAdminUserStatus() const;
+
 private:
     std::weak_ptr<DocumentBroker> _docBroker;
 

--- a/wsd/ClientSession.hpp
+++ b/wsd/ClientSession.hpp
@@ -419,6 +419,9 @@ private:
 
     /// the canonical id unique to the set of rendering properties of this session
     int _canonicalViewId;
+
+    /// If adminuser message was already sent
+    bool _sentAdmin;
 };
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -830,7 +830,7 @@ bool DocumentBroker::download(const std::shared_ptr<ClientSession>& session, con
     std::string userPrivateInfo;
     std::string watermarkText;
     std::string templateSource;
-    bool isAdminUser = false;
+    std::optional<bool> isAdminUser;
 
 #if !MOBILEAPP
     std::chrono::milliseconds checkFileInfoCallDurationMs = std::chrono::milliseconds::zero();

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -830,7 +830,6 @@ bool DocumentBroker::download(const std::shared_ptr<ClientSession>& session, con
     std::string userPrivateInfo;
     std::string watermarkText;
     std::string templateSource;
-    std::optional<bool> isAdminUser;
 
 #if !MOBILEAPP
     std::chrono::milliseconds checkFileInfoCallDurationMs = std::chrono::milliseconds::zero();
@@ -851,7 +850,8 @@ bool DocumentBroker::download(const std::shared_ptr<ClientSession>& session, con
         userPrivateInfo = wopiFileInfo->getUserPrivateInfo();
         watermarkText = wopiFileInfo->getWatermarkText();
         templateSource = wopiFileInfo->getTemplateSource();
-        isAdminUser = wopiFileInfo->getIsAdminUser();
+
+        session->setIsAdminUser(wopiFileInfo->getIsAdminUser());
 
         _isViewFileExtension = COOLWSD::IsViewFileExtension(wopiStorage->getFileExtension());
         if (!wopiFileInfo->getUserCanWrite()) // Readonly.
@@ -1023,7 +1023,6 @@ bool DocumentBroker::download(const std::shared_ptr<ClientSession>& session, con
     session->setUserExtraInfo(userExtraInfo);
     session->setUserPrivateInfo(userPrivateInfo);
     session->setWatermarkText(watermarkText);
-    session->setIsAdminUser(isAdminUser);
 
     LOG_DBG("Setting username [" << COOLWSD::anonymizeUsername(username) << "] and userId [" <<
             COOLWSD::anonymizeUsername(userId) << "] for session [" << sessionId <<

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -830,6 +830,7 @@ bool DocumentBroker::download(const std::shared_ptr<ClientSession>& session, con
     std::string userPrivateInfo;
     std::string watermarkText;
     std::string templateSource;
+    bool isAdminUser = false;
 
 #if !MOBILEAPP
     std::chrono::milliseconds checkFileInfoCallDurationMs = std::chrono::milliseconds::zero();
@@ -850,6 +851,7 @@ bool DocumentBroker::download(const std::shared_ptr<ClientSession>& session, con
         userPrivateInfo = wopiFileInfo->getUserPrivateInfo();
         watermarkText = wopiFileInfo->getWatermarkText();
         templateSource = wopiFileInfo->getTemplateSource();
+        isAdminUser = wopiFileInfo->getIsAdminUser();
 
         _isViewFileExtension = COOLWSD::IsViewFileExtension(wopiStorage->getFileExtension());
         if (!wopiFileInfo->getUserCanWrite()) // Readonly.
@@ -1021,6 +1023,7 @@ bool DocumentBroker::download(const std::shared_ptr<ClientSession>& session, con
     session->setUserExtraInfo(userExtraInfo);
     session->setUserPrivateInfo(userPrivateInfo);
     session->setWatermarkText(watermarkText);
+    session->setIsAdminUser(isAdminUser);
 
     LOG_DBG("Setting username [" << COOLWSD::anonymizeUsername(username) << "] and userId [" <<
             COOLWSD::anonymizeUsername(userId) << "] for session [" << sessionId <<

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -861,6 +861,16 @@ WopiStorage::WOPIFileInfo::WOPIFileInfo(const FileInfo& fileInfo,
     JsonUtil::findJSONValue(object, "BreadcrumbDocName", _breadcrumbDocName);
     JsonUtil::findJSONValue(object, "FileUrl", _fileUrl);
 
+    // check if user is admin on the integrator side
+    if (!JsonUtil::findJSONValue(object, "IsAdminUser", _isAdminUser))
+    {
+        // check deprecated is_admin inside UserExtraInfo
+        if (_userExtraInfo.find("is_admin") != std::string::npos)
+            LOG_DBG("Integration is using depreated is_admin property. Please use IsAdminUser instead.");
+        else
+            LOG_DBG("Missing IsAdminUser property in CheckFileInfo.");
+    }
+
     // Update the scheme to https if ssl or ssl termination is on
     if (Util::startsWith(_postMessageOrigin, "http://") &&
         (COOLWSD::isSSLEnabled() || COOLWSD::isSSLTermination()))

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -862,13 +862,20 @@ WopiStorage::WOPIFileInfo::WOPIFileInfo(const FileInfo& fileInfo,
     JsonUtil::findJSONValue(object, "FileUrl", _fileUrl);
 
     // check if user is admin on the integrator side
-    if (!JsonUtil::findJSONValue(object, "IsAdminUser", _isAdminUser))
+    bool isAdminUser = false;
+    if (!JsonUtil::findJSONValue(object, "IsAdminUser", isAdminUser))
     {
+        _isAdminUser = std::nullopt;
+
         // check deprecated is_admin inside UserExtraInfo
         if (_userExtraInfo.find("is_admin") != std::string::npos)
             LOG_DBG("Integration is using depreated is_admin property. Please use IsAdminUser instead.");
         else
             LOG_DBG("Missing IsAdminUser property in CheckFileInfo.");
+    }
+    else
+    {
+        _isAdminUser = isAdminUser;
     }
 
     // Update the scheme to https if ssl or ssl termination is on

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -861,6 +861,7 @@ WopiStorage::WOPIFileInfo::WOPIFileInfo(const FileInfo& fileInfo,
     JsonUtil::findJSONValue(object, "BreadcrumbDocName", _breadcrumbDocName);
     JsonUtil::findJSONValue(object, "FileUrl", _fileUrl);
 
+#if !MOBILEAPP
     // check if user is admin on the integrator side
     bool isAdminUser = false;
     if (!JsonUtil::findJSONValue(object, "IsAdminUser", isAdminUser))
@@ -877,6 +878,7 @@ WopiStorage::WOPIFileInfo::WOPIFileInfo(const FileInfo& fileInfo,
     {
         _isAdminUser = isAdminUser;
     }
+#endif
 
     // Update the scheme to https if ssl or ssl termination is on
     if (Util::startsWith(_postMessageOrigin, "http://") &&

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -16,6 +16,7 @@
 #include <memory>
 #include <string>
 #include <chrono>
+#include <optional>
 
 #include <Poco/URI.h>
 #include <Poco/Util/Application.h>
@@ -621,7 +622,7 @@ public:
         bool getSupportsLocks() const { return _supportsLocks; }
         bool getUserCanRename() const { return _userCanRename; }
 
-        bool getIsAdminUser() const { return _isAdminUser; }
+        std::optional<bool> getIsAdminUser() const { return _isAdminUser; }
 
         TriState getDisableChangeTrackingShow() const { return _disableChangeTrackingShow; }
         TriState getDisableChangeTrackingRecord() const { return _disableChangeTrackingRecord; }
@@ -701,7 +702,7 @@ public:
         /// If user is allowed to rename the document
         bool _userCanRename = false;
         /// If user is considered as admin on the integrator side
-        bool _isAdminUser = false;
+        std::optional<bool> _isAdminUser = std::nullopt;
     };
 
     /// Returns the response of CheckFileInfo WOPI call for URI that was

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -621,6 +621,8 @@ public:
         bool getSupportsLocks() const { return _supportsLocks; }
         bool getUserCanRename() const { return _userCanRename; }
 
+        bool getIsAdminUser() const { return _isAdminUser; }
+
         TriState getDisableChangeTrackingShow() const { return _disableChangeTrackingShow; }
         TriState getDisableChangeTrackingRecord() const { return _disableChangeTrackingRecord; }
         TriState getHideChangeTrackingControls() const { return _hideChangeTrackingControls; }
@@ -698,6 +700,8 @@ public:
         bool _supportsRename = false;
         /// If user is allowed to rename the document
         bool _userCanRename = false;
+        /// If user is considered as admin on the integrator side
+        bool _isAdminUser = false;
     };
 
     /// Returns the response of CheckFileInfo WOPI call for URI that was

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -622,7 +622,9 @@ public:
         bool getSupportsLocks() const { return _supportsLocks; }
         bool getUserCanRename() const { return _userCanRename; }
 
+#if !MOBILEAPP
         std::optional<bool> getIsAdminUser() const { return _isAdminUser; }
+#endif
 
         TriState getDisableChangeTrackingShow() const { return _disableChangeTrackingShow; }
         TriState getDisableChangeTrackingRecord() const { return _disableChangeTrackingRecord; }
@@ -701,8 +703,11 @@ public:
         bool _supportsRename = false;
         /// If user is allowed to rename the document
         bool _userCanRename = false;
+
+#if !MOBILEAPP
         /// If user is considered as admin on the integrator side
         std::optional<bool> _isAdminUser = std::nullopt;
+#endif
     };
 
     /// Returns the response of CheckFileInfo WOPI call for URI that was


### PR DESCRIPTION
This is partial backport from master (without audit dialog). Unifies admin detection.
Should fix problem with notifying regular users about updates.

-----------------------------------
    Fallback and warning for using is_admin in the browser
    
    We migrated to using IsAdminUser:
    https://sdk.collaboraonline.com/docs/advanced_integration.html#isadminuser
    
    Warn in the browser logs about that for debugging the integration.
    Also use fallback if someone is still using old is_admin property.
    These properties are used to show additional notifications in the UI
    like: new version is available.
    
-----------------------------------

    Use optional isAdminUser to detect when it is missing

-------------------------------

    Pass IsAdminUser property to the client
    
    - use app.isAdminUser for storing it
    - use adminuser: message to pass it from the server
      which is sent after viewinfo:
    - do not send message on every user joined and on
      document unload
