### PR TITLE
Context menu fixes

### DIFF
--- a/browser/src/control/Control.ContextMenu.js
+++ b/browser/src/control/Control.ContextMenu.js
@@ -159,6 +159,7 @@ L.Control.ContextMenu = L.Control.extend({
 				selector: '.leaflet-layer',
 				className: 'cool-font',
 				trigger: 'none',
+				zIndex: 1500,
 				build: function() {
 					return {
 						callback: function(key) {

--- a/browser/src/control/Control.MobileWizardWindow.js
+++ b/browser/src/control/Control.MobileWizardWindow.js
@@ -254,6 +254,8 @@ L.Control.MobileWizardWindow = L.Control.extend({
 		else
 			$(contentToShow).children('.ui-content').first().show();
 
+		this.mobileWizard.scrollTop(0);
+
 		this._currentDepth++;
 		if (!this._inBuilding)
 			history.pushState({context: 'mobile-wizard', level: this._currentDepth}, 'mobile-wizard-level-' + this._currentDepth);
@@ -323,6 +325,8 @@ L.Control.MobileWizardWindow = L.Control.extend({
 			$('#mobile-wizard.funcwizard div#mobile-wizard-content').removeClass('showHelpBG');
 			$('#mobile-wizard.funcwizard div#mobile-wizard-content').addClass('hideHelpBG');
 			headers.show('slide', { direction: 'left' }, 'fast');
+
+			this.mobileWizard.scrollTop(0);
 
 			if (this._currentDepth == 0 || (this._isTabMode && this._currentDepth == 1)) {
 				this._inMainMenu = true;

--- a/browser/src/layer/tile/CommentListSection.ts
+++ b/browser/src/layer/tile/CommentListSection.ts
@@ -953,6 +953,7 @@ export class CommentSection extends CanvasSectionObject {
 		L.installContextMenu({
 			selector: '.cool-annotation-menu',
 			trigger: 'none',
+			zIndex: 1500,
 			className: 'cool-font',
 			build: function ($trigger: any) {
 				return {
@@ -1013,6 +1014,7 @@ export class CommentSection extends CanvasSectionObject {
 		L.installContextMenu({
 			selector: '.cool-annotation-menu-redline',
 			trigger: 'none',
+			zIndex: 1500,
 			className: 'cool-font',
 			items: {
 				modify: {


### PR DESCRIPTION
This is a trivial backport of my context menu fixes, #9228 and #9230.

I didn't include #9277, as it is not yet merged.

---

On small window sizes, a context menu may be forced to open in such a
way that it goes over the same region as the notebookbar or spreadsheet
tabs.

In that case, the context menu should be above the other element, or
some of the context menu options could be unreachable.

Change-Id: Id269e3fb9bc2251677a0792d83fc51bd56b9cb21

---

Previously, when entering or exiting mobile wizard sublevels you would
start scrolled down to the place you were before. For example, if you
scrolled down a few items on the main context menu of an image in order
to reach "arrange", you would always end up right at the bottom of the
"arrange" menu.

By always scrolling up to the top, we can prevent you from ever having
content hidden above you.

Change-Id: I02365ecef859fb6f199d14a12a49937d5a30b8e7