### PR TITLE
fuzzer: don't leak poco loggers

### DIFF
--- a/common/Log.cpp
+++ b/common/Log.cpp
@@ -712,6 +712,12 @@ namespace Log
             return;
         }
 
+        if (Util::isFuzzing())
+        {
+            // Ignore errors for fuzzing, even if the log level would be increased.
+            return;
+        }
+
         // Use the same channel for all Poco loggers.
         auto channel = Static.getLogger()->getChannel();
 
@@ -721,12 +727,6 @@ namespace Log
         auto& logger = GenericLogger::create(Static.getName() + "." + std::to_string(counter++),
                                              std::move(channel),
                                              Poco::Logger::parseLevel(logLevel));
-
-        if (Util::isFuzzing())
-        {
-            // Ignore errors for fuzzing, even if the log level would be increased.
-            return;
-        }
 
         Static.setThreadLocalLogger(&logger);
     }


### PR DESCRIPTION
The failure was:

	==79463== ERROR: libFuzzer: out-of-memory (used: 2053Mb; limit: 2048Mb)
	392260464 byte(s) (45%) in 5448062 allocation(s)
	    #0 0x5648cd721266 in operator new(unsigned long) /home/abuild/rpmbuild/BUILD/llvm-15.0.7.src/build/../projects/compiler-rt/lib/asan/asan_new_delete.cpp:95:3
	    #1 0x7f8c4bd0e7ed in Poco::Logger::add(Poco::AutoPtr<Poco::Logger>) (/usr/lib64/libPocoFoundation.so.92+0xf57ed)

Given that Log::setThreadLocalLogLevel() calls GenericLogger::create(),
which calls Poco::Logger::add(); and given that
StaticHelper::setThreadLocalLogger() explicitly leaks loggers, fix the
problem by returning earlier in Log::setThreadLocalLogLevel() for the
fuzzing case, the new logger would not be activated anyway.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I0d7a6c9caf6e1498f898d3dbecccd278ed722947
