### PR TITLE
Use dedicated signal for version bar initialization

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1624,6 +1624,8 @@ L.CanvasTileLayer = L.Layer.extend({
 				app.isAdminUser = false;
 			else
 				app.isAdminUser = null;
+
+			this._map.fire('adminuser');
 		}
 	},
 

--- a/browser/src/map/handler/Map.VersionBar.js
+++ b/browser/src/map/handler/Map.VersionBar.js
@@ -6,13 +6,13 @@
 
 L.Map.VersionBar = L.Handler.extend({
 	onAdd: function () {
-		this._map.on('updateviewslist', this.onUpdateInfo, this);
+		this._map.on('adminuser', this.onUpdateInfo, this);
 		this._map.on('versionbar', this.onversionbar, this);
 	},
 
 	onRemove: function () {
 		this._map.off('versionbar', this.onversionbar, this);
-		this._map.off('updateviewslist', this.onUpdateInfo, this);
+		this._map.off('adminuser', this.onUpdateInfo, this);
 	},
 
 	onUpdateInfo: function () {


### PR DESCRIPTION
It will look like this in the browser logs:
- IN viewinfo: ...
- IN adminuser: ...

and if we are the admin:
- OUT versionbar
- IN versionbar: ... < latest version ... if needed show the message

Thanks to that snackbar will be shown on the load, not when next user joins.