### PR TITLE
Fix video playback with load balancer (23.05)

### DIFF
--- a/browser/src/layer/vector/SVGGroup.js
+++ b/browser/src/layer/vector/SVGGroup.js
@@ -88,6 +88,14 @@ L.SVGGroup = L.Layer.extend({
 
 		var videoContainer = svgLastChild.querySelector('body');
 		var videos = svgLastChild.getElementsByTagName('video');
+
+		// fix URL, it's important to have correct WOPISrc, we need to decode "&" before other params
+		// like ServerId and Tag so load balancer will not use it as a part of WOPISrc
+		// this has to be done here (after parseSVG), because it other case we will fail to get
+		// the svg object
+		var source = svgLastChild.getElementsByTagName('source');
+		source[0].src = decodeURIComponent(source[0].src);
+
 		this.addVideoSupportHandlers(videos);
 
 		function _fixSVGPos() {


### PR DESCRIPTION
It's important to have correct WOPISrc for load balancers. We need to decode "&" before other params like ServerId and Tag so load balancer will not use it as a part of WOPISrc.

In other case when I had 2 instances of COOL behind HAProxy sometimes request to get the video was forwarded to the wrong instance.