### PR TITLE
test: avoid showing too large files

### DIFF
--- a/test/run_unit.sh.in
+++ b/test/run_unit.sh.in
@@ -97,7 +97,11 @@ if ${trace} \
 	exit 0
 else
 	echo "Test $tst FAILED. Finished in ${SECONDS}s."
-	cat $tst_log
+        if test $(stat -c %s $tst_log) -le 1000000000; then
+            cat $tst_log
+        else
+            echo "Not showing $tst_log, which is larger than 1GB in size."
+        fi
 	echo "============================================================="
 	echo "Test failed on $tst after ${SECONDS}s. Re-run with (remove --unattended to run without gdb and get prompted):"
 	echo "   $ gdb --args ${abs_top_builddir}/coolwsd --o:sys_template_path=\"$systemplate_path\" \\"


### PR DESCRIPTION
If it's this large, it will be some endless loop and the start will go
outside the console history anyway, but it can fill the disk with logs on
CI.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I89f9cc1afb6436210d825f1f60cbccb8ed5e48b3
