### PR TITLE
Request for Chinese (Hong Kong) localization should fall back to Chin…

### DIFF
--- a/browser/l10n/admin-localizations.json
+++ b/browser/l10n/admin-localizations.json
@@ -123,6 +123,8 @@
     "zh-cn": "../l10n/ui-zh_CN.json",
     "zh-CN": "../l10n/ui-zh_CN.json",
     "zh-Hans": "../l10n/ui-zh_CN.json",
+    "zh-hk": "../l10n/ui-zh_TW.json",
+    "zh-HK": "../l10n/ui-zh_TW.json",
     "zh-tw": "../l10n/ui-zh_TW.json",
     "zh-TW": "../l10n/ui-zh_TW.json",
     "zh-Hant": "../l10n/ui-zh_TW.json",

--- a/browser/l10n/help-localizations.json
+++ b/browser/l10n/help-localizations.json
@@ -76,6 +76,8 @@
     "zh-cn": "%SERVICE_ROOT%/browser/%VERSION%/l10n/help-zh_CN.json",
     "zh-CN": "%SERVICE_ROOT%/browser/%VERSION%/l10n/help-zh_CN.json",
     "zh-Hans": "%SERVICE_ROOT%/browser/%VERSION%/l10n/help-zh_CN.json",
+    "zh-hk": "%SERVICE_ROOT%/browser/%VERSION%/l10n/help-zh_TW.json",
+    "zh-HK": "%SERVICE_ROOT%/browser/%VERSION%/l10n/help-zh_TW.json",
     "zh-tw": "%SERVICE_ROOT%/browser/%VERSION%/l10n/help-zh_TW.json",
     "zh-TW": "%SERVICE_ROOT%/browser/%VERSION%/l10n/help-zh_TW.json",
     "zh-Hant": "%SERVICE_ROOT%/browser/%VERSION%/l10n/help-zh_TW.json"

--- a/browser/l10n/localizations.json
+++ b/browser/l10n/localizations.json
@@ -79,6 +79,8 @@
     "zh-cn": "%SERVICE_ROOT%/browser/%VERSION%/l10n/ui-zh_CN.json",
     "zh-CN": "%SERVICE_ROOT%/browser/%VERSION%/l10n/ui-zh_CN.json",
     "zh-Hans": "%SERVICE_ROOT%/browser/%VERSION%/l10n/ui-zh_CN.json",
+    "zh-hk": "%SERVICE_ROOT%/browser/%VERSION%/l10n/ui-zh_TW.json",
+    "zh-HK": "%SERVICE_ROOT%/browser/%VERSION%/l10n/ui-zh_TW.json",
     "zh-tw": "%SERVICE_ROOT%/browser/%VERSION%/l10n/ui-zh_TW.json",
     "zh-TW": "%SERVICE_ROOT%/browser/%VERSION%/l10n/ui-zh_TW.json",
     "zh-Hant": "%SERVICE_ROOT%/browser/%VERSION%/l10n/ui-zh_TW.json"

--- a/browser/l10n/locore-localizations.json
+++ b/browser/l10n/locore-localizations.json
@@ -129,6 +129,8 @@
     "zh-cn": "%SERVICE_ROOT%/browser/%VERSION%/l10n/locore/zh-CN.json",
     "zh-CN": "%SERVICE_ROOT%/browser/%VERSION%/l10n/locore/zh-CN.json",
     "zh-Hans": "%SERVICE_ROOT%/browser/%VERSION%/l10n/locore/zh-CN.json",
+    "zh-hk": "%SERVICE_ROOT%/browser/%VERSION%/l10n/locore/zh-TW.json",
+    "zh-HK": "%SERVICE_ROOT%/browser/%VERSION%/l10n/locore/zh-TW.json",
     "zh-tw": "%SERVICE_ROOT%/browser/%VERSION%/l10n/locore/zh-TW.json",
     "zh-TW": "%SERVICE_ROOT%/browser/%VERSION%/l10n/locore/zh-TW.json",
     "zh-Hant": "%SERVICE_ROOT%/browser/%VERSION%/l10n/locore/zh-TW.json",

--- a/browser/l10n/uno-localizations.json
+++ b/browser/l10n/uno-localizations.json
@@ -131,6 +131,8 @@
     "zh-cn": "%SERVICE_ROOT%/browser/%VERSION%/l10n/uno/zh-CN.json",
     "zh-CN": "%SERVICE_ROOT%/browser/%VERSION%/l10n/uno/zh-CN.json",
     "zh-Hans": "%SERVICE_ROOT%/browser/%VERSION%/l10n/uno/zh-CN.json",
+    "zh-hk": "%SERVICE_ROOT%/browser/%VERSION%/l10n/uno/zh-TW.json",
+    "zh-HK": "%SERVICE_ROOT%/browser/%VERSION%/l10n/uno/zh-TW.json",
     "zh-tw": "%SERVICE_ROOT%/browser/%VERSION%/l10n/uno/zh-TW.json",
     "zh-TW": "%SERVICE_ROOT%/browser/%VERSION%/l10n/uno/zh-TW.json",
     "zh-Hant": "%SERVICE_ROOT%/browser/%VERSION%/l10n/uno/zh-TW.json",


### PR DESCRIPTION
…ese (Taiwan)

Both locales use the traditional Chinese script, and we do not have a separate language pack for Chinese (Hong Kong) in core and online.


Change-Id: Idbbd972308db534b8dda5f7e758f05302dfc344c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

