### PR TITLE
fix: unusual spacing between the icons in the mobile view 

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -239,7 +239,6 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 }
 
 .jsdialog.ui-separator.horizontal {
-	width: 100%;
 	margin: 0px;
 	background-color: var(--color-border-lighter);
 	border: none;


### PR DESCRIPTION
Change-Id: Ic3d751e2f781441f0b860183773fac752147972e


* Fixes : https://github.com/CollaboraOnline/online/issues/9320
* Target version: master 

### Summary


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

