### PR TITLE
File tab: Revision history sometimes is rendered as inline button

### DIFF
--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -191,31 +191,60 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 			});
 		}
 
-		content.push(
-			{
+		if (hasShare && hasRevisionHistory) {
+			content.push(
+				{
+					'type': 'container',
+					'children': [
+						{
+							'id': 'ShareAs',
+							'class': 'unoShareAs',
+							'type': 'customtoolitem',
+							'text': _('Share'),
+							'command': 'shareas',
+							'inlineLabel': true,
+							'accessibility': { focusBack: true, combination: 'SH' }
+						}, {
+							'id': 'Rev-History',
+							'class': 'unoRev-History',
+							'type': 'customtoolitem',
+							'text': _('See history'),
+							'command': 'rev-history',
+							'inlineLabel': true,
+							'accessibility': { focusBack: true, combination: 'RH' }
+						}
+					],
+					'vertical': true
+				});
+		} else if (hasShare) {
+			content.push({
 				'type': 'container',
 				'children': [
-					hasShare ? {
+					{
 						'id': 'ShareAs',
 						'class': 'unoShareAs',
-						'type': 'customtoolitem',
+						'type': 'bigcustomtoolitem',
 						'text': _('Share'),
 						'command': 'shareas',
-						'inlineLabel': true,
-						'accessibility': { focusBack: true,	combination: 'SH' }
-					}: {},
-					hasRevisionHistory ? {
+						'accessibility': { focusBack: true, combination: 'SH' }
+					}
+				]
+			});
+		} else if (hasRevisionHistory) {
+			content.push({
+				'type': 'container',
+				'children': [
+					{
 						'id': 'Rev-History',
 						'class': 'unoRev-History',
-						'type': 'customtoolitem',
+						'type': 'bigcustomtoolitem',
 						'text': _('See history'),
 						'command': 'rev-history',
-						'inlineLabel': true,
-						'accessibility': { focusBack: true,	combination: 'RH' }
-					}: {}
-				],
-				'vertical': true
+						'accessibility': { focusBack: true, combination: 'RH' }
+					}
+				]
 			});
+		}
 
 		if (hasPrint) {
 			content.push(


### PR DESCRIPTION
Sometimes when a user shares a file that doesn't allows to be re-shared
but allows to see revision history the button is rendered oddly

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I8119b063d6c243141e06bdfeeb00acc326e2370f
