### PR TITLE
Jail Clean-up

### DIFF
--- a/common/FileUtil.cpp
+++ b/common/FileUtil.cpp
@@ -248,6 +248,25 @@ namespace FileUtil
 #endif
     }
 
+    /// Remove directories only, which must be empty for this to work.
+    static int nftw_rmdir_cb(const char* fpath, const struct stat*, int type, struct FTW*)
+    {
+        if (type == FTW_DP)
+        {
+            rmdir(fpath);
+        }
+
+        // Always continue even when things go wrong.
+        return 0;
+    }
+
+    void removeEmptyDirTree(const std::string& path)
+    {
+        LOG_DBG("Removing empty directories at [" << path << "] recursively");
+
+        nftw(path.c_str(), nftw_rmdir_cb, 128, FTW_DEPTH | FTW_PHYS);
+    }
+
     std::string realpath(const char* path)
     {
         char* resolved = ::realpath(path, nullptr);

--- a/common/FileUtil.hpp
+++ b/common/FileUtil.hpp
@@ -65,6 +65,10 @@ namespace FileUtil
         removeFile(path.toString(), recursive);
     }
 
+    /// Remove empty directories recursively.
+    /// We seem to leave behind empty directories in jails and that causes a lot of noise.
+    void removeEmptyDirTree(const std::string& path);
+
     /// Returns true iff the directory is empty (or doesn't exist).
     bool isEmptyDirectory(const char* path);
     inline bool isEmptyDirectory(const std::string& path) { return isEmptyDirectory(path.c_str()); }

--- a/common/JailUtil.cpp
+++ b/common/JailUtil.cpp
@@ -101,7 +101,7 @@ static bool unmount(const std::string& target, bool silent = false)
         // which may be left-over and now the config has changed.
         // This happens more often in dev labs than in prod.
         if (JailUtil::isBindMountingEnabled() && !silent)
-            LOG_ERR("Failed to unmount [" << target << ']');
+            LOG_WRN("Failed to unmount [" << target << ']');
         else
             LOG_DBG("Failed to unmount [" << target << ']');
     }

--- a/common/JailUtil.cpp
+++ b/common/JailUtil.cpp
@@ -152,9 +152,16 @@ static bool safeRemoveDir(const std::string& path)
     }
 
     // Recursively remove if link/copied.
-    const bool recursive = copied;
-    //FIXME: do not delete the 'copied' marker until the very end.
-    FileUtil::removeFile(path, recursive);
+    if (copied)
+    {
+        //FIXME: do not delete the 'copied' marker until the very end.
+        FileUtil::removeFile(path, /*recursive=*/true);
+    }
+    else
+    {
+        FileUtil::removeEmptyDirTree(path);
+    }
+
     return true;
 }
 

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -1134,7 +1134,7 @@ public:
     /// Get the timeout, in microseconds.
     std::chrono::microseconds getTimeout() const { return _timeout; }
 
-    std::shared_ptr<Response> response() { return _response; }
+    /// The response we _got_ for our request. Do *not* use this to _send_ a response!
     const std::shared_ptr<Response>& response() const { return _response; }
     const std::string& getUrl() const { return _request.getUrl(); }
 


### PR DESCRIPTION
- wsd: do not re-use incoming response for outgoing
- wsd: jails: remove empty directories
- wsd: jails: failure to unmount is not an error
- wsd: simplify renaming after save
