### PR TITLE
fix: Remove build error when building without ssl

### DIFF
--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -1276,12 +1276,15 @@ public:
 #endif
     }
 
+#if ENABLE_SSL
     std::string getSslCert(std::string& subjectHash)
     {
-#if ENABLE_SSL
         std::shared_ptr<StreamSocket> socket = _socket.lock();
         if (socket)
             return socket->getSslCert(subjectHash);
+#else
+    std::string getSslCert(std::string&)
+    {
 #endif
         return std::string();
     }

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1259,10 +1259,14 @@ bool ClientSession::loadDocument(const char* /*buffer*/, int /*length*/,
         std::ostringstream oss;
         oss << "load url=" << docBroker->getPublicUri().toString();
 
+#if ENABLE_SSL
         // if ssl client verification was disabled in online for the wopi server,
         // then exempt that host from ssl host verification also in core
         if (ssl::Manager::getClientVerification() == ssl::CertificateVerification::Disabled)
             oss << " verifyHost=false";
+#else
+        oss << " verifyHost=false";
+#endif
 
         if (!getUserId().empty() && !getUserName().empty())
         {


### PR DESCRIPTION
Previously getSslCert took a parameter that was only used when SSL was
enabled, causing an unused parameter when SSL was disabled. As we have
-Werror=unused-parameter, this caused the build to fail

Similarly, ClientSession::loadDocument used ssl:: when it couldn't be
defined because of a lack of SSL support in the build

Change-Id: Ie0b4a5f3531a8fb6aba66f352ba109fbffd7687a


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

