### PR TITLE
fuzzer: reject increasing the log level via update-log-levels

### DIFF
--- a/common/Log.cpp
+++ b/common/Log.cpp
@@ -714,7 +714,7 @@ namespace Log
 
         if (Util::isFuzzing())
         {
-            // Ignore errors for fuzzing, even if the log level would be increased.
+            // loggingleveloverride tries to increase log level, ignore.
             return;
         }
 
@@ -788,6 +788,12 @@ namespace Log
     void setLogLevelByName(const std::string &channel,
                            const std::string &level)
     {
+        if (Util::isFuzzing())
+        {
+            // update-log-levels tries to increase log level, ignore.
+            return;
+        }
+
         // FIXME: seems redundant do we need that ?
         std::string lvl = level;
 

--- a/fuzzer/admin-data/crash-c3a9755c1f4fbbb7414b80f8eee6e1f518cad28f
+++ b/fuzzer/admin-data/crash-c3a9755c1f4fbbb7414b80f8eee6e1f518cad28f
@@ -1,0 +1,1 @@
+update-log-levels wsd=m


### PR DESCRIPTION
Similar to commit 9e3de293af4a0df9d6d2834356ba964657a9d41a (fuzzer:
reject increasing the log level, 2024-06-12), but that was for
setThreadLocalLogLevel() used by the loggingleveloverride protocol
command, and this is for setLogLevelByName() used by the
update-log-levels protocol command.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I56eb8c311e01a995604d408d1933559890499a0b
