### PR TITLE
Ruler: Clip it, don't spill over other UI elements

### DIFF
--- a/browser/css/leaflet.css
+++ b/browser/css/leaflet.css
@@ -887,6 +887,7 @@ input.clipboard {
 	width: 100vw;
 	margin: 0px !important;
 	position: fixed;
+	overflow: hidden;
 }
 
 .cool-ruler-breakcontainer {


### PR DESCRIPTION
Before this commit the vertical ruler when the page is zoomed in would
expand beyond its parent. The result: ruler was present under
tabs. Example:
- Integrator has tab container margin (ruler would be visible full
height)
- User customized the color of the tab container making it transparent

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I71d17c18c899cdb19b2c7e3bfd9903ba87221a78
