### PR TITLE
Dark mode: Fix dropdown shadow: use correct css var

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -61,7 +61,7 @@
 	max-width: 498px;
 	border: 1px solid var(--color-border-darker) !important;
 	border-radius: var(--border-radius);
-	box-shadow: 0 0 3px var(--color-border-darker);
+	box-shadow: 0 0 3px var(--color-box-shadow);
 	overflow: auto;
 	position: relative;
 	margin: auto;


### PR DESCRIPTION
Before this commit things like status language dropdown etc were being
rendered with a light color

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ie2af6f4f88ff1b99fa6ee658a8dc8e700deac977
