### PR TITLE
postmessage demo: insert graphic test

### DIFF
--- a/browser/html/framed.doc.html
+++ b/browser/html/framed.doc.html
@@ -99,6 +99,12 @@
             });
       }
 
+      function insertGraphic(text) {
+        post({'MessageId': 'Action_InsertGraphic',
+              'Values': {'filename': 'date.png', 'url': 'https://sdk.collaboraonline.com/_static/collabora.svg'}
+            });
+      }
+
       function capitalize() {
         post({'MessageId': 'CallPythonScript',
               'SendTime': Date.now(),
@@ -551,6 +557,7 @@
           </div>
           <div class="vbox">
             <button onclick="ShowInsertButton(); return false;" title="via Insert_Button">Insert custom button</button>
+            <button onclick="insertGraphic(); return false;">Sent InsertGraphic post message</button>
           </div>
           <div class="vbox">
             <button onclick="ShowNotebookbar(false); return false;">Compact Toolbar</button>


### PR DESCRIPTION
Add button in the post message tester to verify if inserting an image works properly. I used resource from our SDK so it is external domain, if not allowed it shows an error. We need to add domain to coolwsd.xml in the lok_allow section to allow importing the image.