### PR TITLE
Stylesview: Fix dark mode background and border

### DIFF
--- a/browser/css/color-palette-dark.css
+++ b/browser/css/color-palette-dark.css
@@ -19,6 +19,8 @@
 	--color-background-lighter: #262626; /* hover, toolbar, dialog, disabled */
 	--color-overlay: #1c5fa814;
 	--color-background-tabs-group: #303030;
+	--color-stylesview-background: white;
+	--brightness-stylesview: 0.9;
 
 	--color-primary: #0b87e7; /* border-color */
 	--color-primary-text: #fff; /* text color when primary-lighter is background */
@@ -33,6 +35,8 @@
 
 	--color-btn-border: #b6b6b6;
 	--color-btn-border-dis: #c0bfbc;
+
+	--color-stylesview-border: transparent;
 
 	--color-error: #e9322d;
 	--color-warning: #eca700;

--- a/browser/css/color-palette.css
+++ b/browser/css/color-palette.css
@@ -20,6 +20,8 @@
 	--color-background-lighter: #fff; /* hover, toolbar, dialog, disabled */
 	--color-overlay: #1c5fa814;
 	--color-background-tabs-group: #f1f1f1;
+	--color-stylesview-background: var(--color-background-lighter);
+	--brightness-stylesview: 1;
 
 
 	--color-primary: #0b87e7; /* border-color */
@@ -35,6 +37,8 @@
 
 	--color-btn-border: #b6b6b6;
 	--color-btn-border-dis: #c0bfbc;
+
+	--color-stylesview-border: var(--color-border);
 
 	--color-error: #e9322d;
 	--color-warning: #eca700;

--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -368,10 +368,15 @@ button.ui-tab.notebookbar {
 	width: 530px;
 	overflow: auto;
 	padding: 0px;
-	border: 1px solid var(--color-border);
+	border: 1px solid var(--color-stylesview-border);
 	border-radius: var(--border-radius);
 	border-collapse: separate; /*To use box-shadow in Internet Explorer 9 or later*/
 	scrollbar-width: none;
+	background-color: var(--color-stylesview-background);
+	filter: brightness(var(--brightness-stylesview));
+}
+#stylesview:hover {
+	filter: none;
 }
 
 #stylesview::-webkit-scrollbar {


### PR DESCRIPTION
Before this commit there were
- Odd border artifact
- The styles previews were being rendered and looked like detached
rectangles (with different background than the background of the main
container)

This commit fixes those while making use of css vars. Additionally,
decrease the brightness of the whole stylesview to 90% (100% on hover
state) so the user doesn't have a very bright component always up
there.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I1bb21871d8a866f8f4308efda937904ac97504bb
