### PR TITLE
calc: fix copy hyperlink outside of edit mode

### DIFF
--- a/browser/src/control/Control.Toolbar.js
+++ b/browser/src/control/Control.Toolbar.js
@@ -1404,7 +1404,14 @@ function setupToolbar(e) {
 				//click pos tweak
 				cellCursor._northEast.lng = cellCursor._southWest.lng;
 				map._docLayer._closeURLPopUp();
-				map._docLayer._showURLPopUp(cellCursor._northEast, e.url);
+				var linkPosition;
+				if (strTwips.length > 7) {
+					linkPosition = {
+						x: parseInt(strTwips[6]),
+						y: parseInt(strTwips[7])
+					};
+				}
+				map._docLayer._showURLPopUp(cellCursor._northEast, e.url, linkPosition);
 			} else {
 				map.fire('warn', {url: e.url, map: map, cmd: 'openlink'});
 			}

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -2598,7 +2598,7 @@ L.CanvasTileLayer = L.Layer.extend({
 		return resultList;
 	},
 
-	_showURLPopUp: function(position, url) {
+	_showURLPopUp: function (position, url, linkPosition) {
 		var parent = L.DomUtil.create('div', '');
 		L.DomUtil.createWithId('div', 'hyperlink-pop-up-preview', parent);
 		var link = L.DomUtil.createWithId('a', 'hyperlink-pop-up', parent);
@@ -2654,8 +2654,22 @@ L.CanvasTileLayer = L.Layer.extend({
 				map_.sendUnoCommand('.uno:JumpToMark?Bookmark:string=' + encodeURIComponent(url.substring(1)));
 		});
 		this._setupClickFuncForId('hyperlink-pop-up-copy', function () {
-			if (app.file.permission !== 'readonly')
-				map_.sendUnoCommand('.uno:CopyHyperlinkLocation');
+			if (app.file.permission !== 'readonly') {
+				var params;
+				if (linkPosition) {
+					params = {
+						PositionX: {
+							type: 'long',
+							value: linkPosition.x
+						},
+						PositionY: {
+							type: 'long',
+							value: linkPosition.y
+						}
+					};
+				}
+				map_.sendUnoCommand('.uno:CopyHyperlinkLocation', params);
+			}
 			else {
 				var json = { content: url, mimeType: 'text/plain' };
 				map_._docLayer._onMessage('clipboardchanged: ' + JSON.stringify(json));

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -1911,6 +1911,9 @@ bool ChildSession::unoCommand(const StringVector& tokens)
 
     getLOKitDocument()->setView(_viewId);
 
+    if (tokens.equals(1, ".uno:Copy") || tokens.equals(1, ".uno:CopyHyperlinkLocation"))
+        _copyToClipboard = true;
+
     if (tokens.size() == 2)
     {
         if (tokens.equals(1, ".uno:fakeDiskFull"))
@@ -1919,9 +1922,6 @@ bool ChildSession::unoCommand(const StringVector& tokens)
         }
         else
         {
-            if (tokens.equals(1, ".uno:Copy") || tokens.equals(1, ".uno:CopyHyperlinkLocation"))
-                _copyToClipboard = true;
-
             getLOKitDocument()->postUnoCommand(tokens[1].c_str(), nullptr, bNotify);
         }
     }


### PR DESCRIPTION
Right now .uno:CopyHyperlinkLocation only works on edit mode or
inside a draw object, but LOK_CALLBACK_HYPERLINK_CLICKED is
dispatched outside of edit mode and the copy command from
the pop-up is ignored.

Since there is no text cursor, the position of the hyperlink is
needed to discriminate the correct field, since there could be
multiple hyperlink fields inside the same cell.

Signed-off-by: Jaume Pujantell <jaume.pujantell@collabora.com>
Change-Id: Ie814867e0a4a319e78381b68343847491034d85f
