### PR TITLE
backport 24.04: Fix mobile build breakage

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1785,6 +1785,7 @@ std::shared_ptr<lok::Document> Document::load(const std::shared_ptr<ChildSession
     if (FileUtil::Stat(wopiCertDir).exists())
         ::setenv("LO_CERTIFICATE_AUTHORITY_PATH", wopiCertDir.c_str(), 1);
 
+#if !MOBILEAPP
     // if ssl client verification was disabled in online for the wopi server,
     // and this is a https connection then also exempt that host from ssl host
     // verification in 'core'
@@ -1794,6 +1795,7 @@ std::shared_ptr<lok::Document> Document::load(const std::shared_ptr<ChildSession
         if (net::parseUri(session->getDocURL(), scheme, host, port) && scheme == "https://")
             ::setenv("LOK_EXEMPT_VERIFY_HOST", host.c_str(), 1);
     }
+#endif
 
     std::string spellOnline = session->getSpellOnline();
     if (!_loKitDocument)

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -2049,7 +2049,9 @@ void COOLWSD::innerInitialize(Application& self)
         { "ssl.sts.max_age", "31536000" },
         { "ssl.key_file_path", COOLWSD_CONFIGDIR "/key.pem" },
         { "ssl.termination", "true" },
+#if !MOBILEAPP
         { "ssl.ssl_verification", SSL_VERIFY },
+#endif
         { "stop_on_config_change", "false" },
         { "storage.filesystem[@allow]", "false" },
         // "storage.ssl.enable" - deliberately not set; for back-compat

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1259,10 +1259,12 @@ bool ClientSession::loadDocument(const char* /*buffer*/, int /*length*/,
         std::ostringstream oss;
         oss << "load url=" << docBroker->getPublicUri().toString();
 
+#if !MOBILEAPP
         // if ssl client verification was disabled in online for the wopi server,
         // then exempt that host from ssl host verification also in core
         if (ssl::Manager::getClientVerification() == ssl::CertificateVerification::Disabled)
             oss << " verifyHost=false";
+#endif
 
         if (!getUserId().empty() && !getUserName().empty())
         {

--- a/wsd/RequestVettingStation.cpp
+++ b/wsd/RequestVettingStation.cpp
@@ -127,12 +127,14 @@ void RequestVettingStation::sendUnauthorizedErrorAndShutdown()
 {
     std::string error = "error: cmd=internal kind=unauthorized";
 
+#if !MOBILEAPP
     if (_checkFileInfo)
     {
         std::string sslVerifyResult = _checkFileInfo->getSslVerifyMessage();
         if (!sslVerifyResult.empty())
             error += " code=" + base64Encode(sslVerifyResult);
     }
+#endif
     sendErrorAndShutdown(_ws, error,
                          WebSocketHandler::StatusCodes::POLICY_VIOLATION);
 }


### PR DESCRIPTION
This is a trivial backport of #9340

The iOS and Android platforms run the LibreOffice backend in the client
process so there is no SSL sockets. Instead, all client and server
communication is done through a buffer shared between threads.