### PR TITLE
feat: record the performance of CPU,Network,Latency

### DIFF
--- a/test/.gitignore
+++ b/test/.gitignore
@@ -14,3 +14,7 @@ gdb.txt
 ./unithttplib
 run_unit.sh
 run_unit_standalone.sh
+CPU.csv
+Network.csv
+PingLatency.csv
+TileLatency.csv


### PR DESCRIPTION

Change-Id: I415d414c832a00d2b55815df89f28a2d836a1290


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
The performance of the CPU is measured by the run time in ms, Network by the incoming and outgoing bandwidth in kB/s and latency is split into buckets of ping and tiles in ms. The data is stored in separate CSV files which will be updated each unit test allowing the performance data to be in a form which can be re-used, graphed or at-least monitored in the future.



### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

