### PR TITLE
Accessibility Check btn: Fix label

### DIFF
--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -376,7 +376,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 							'id': 'accessibility-check',
 							'class': 'unoAccessibilityCheck',
 							'type': 'bigtoolitem',
-							'text': _UNO('.uno:SidebarDeck.A11yCheckDeck', 'text'),
+							'text': _('Accessibility Check'),
 							'command': '.uno:SidebarDeck.A11yCheckDeck',
 							'accessibility': { focusBack: false, combination: 'A', de: null }
 						} : {},
@@ -2301,7 +2301,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 			{
 				'id': 'review-accessibility-check',
 				'type': 'bigtoolitem',
-				'text': _UNO('.uno:SidebarDeck.A11yCheckDeck', 'text'),
+				'text': _('Accessibility Check'),
 				'command': '.uno:SidebarDeck.A11yCheckDeck',
 				'accessibility': { focusBack: false, combination: 'A1', de: 'B' }
 			}


### PR DESCRIPTION
Use the previously translated string "Accessibility Check" instead of
the one that comes from the uno command "Open Accessibility Check Deck"

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Id4ace21a933e31405a76eda7a530c05aea4d1c21
