### PR TITLE
CAP_MKNOD is no longer used

### DIFF
--- a/coolwsd.service
+++ b/coolwsd.service
@@ -18,7 +18,7 @@ ReadWritePaths=/opt/cool /var/log
 ProtectHome=yes
 PrivateTmp=yes
 ProtectControlGroups=yes
-CapabilityBoundingSet=CAP_FOWNER CAP_CHOWN CAP_MKNOD CAP_SYS_CHROOT CAP_SYS_ADMIN
+CapabilityBoundingSet=CAP_FOWNER CAP_CHOWN CAP_SYS_CHROOT CAP_SYS_ADMIN
 
 [Install]
 WantedBy=multi-user.target

--- a/debian/coolwsd.service
+++ b/debian/coolwsd.service
@@ -18,7 +18,7 @@ ReadWritePaths=/opt/cool /var/log
 ProtectHome=yes
 PrivateTmp=yes
 ProtectControlGroups=yes
-CapabilityBoundingSet=CAP_FOWNER CAP_CHOWN CAP_MKNOD CAP_SYS_CHROOT CAP_SYS_ADMIN
+CapabilityBoundingSet=CAP_FOWNER CAP_CHOWN CAP_SYS_CHROOT CAP_SYS_ADMIN
 
 [Install]
 WantedBy=multi-user.target

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -3178,7 +3178,6 @@ void lokit_main(
 
 #ifndef __FreeBSD__
             dropCapability(CAP_SYS_CHROOT);
-            dropCapability(CAP_MKNOD);
             dropCapability(CAP_FOWNER);
             dropCapability(CAP_CHOWN);
 #endif


### PR DESCRIPTION
Since commit 144b701453de72c7c5a741cc148a42b25c309ad4 
cool#8703 - Drop random node creation and rely on inherited fd.


Change-Id: Iea3610989fa9eb46c41a9d3d2d6627ffa479cbd1
