### PR TITLE
Locking Documents

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -953,13 +953,11 @@ bool DocumentBroker::download(
                 {
                     LOG_DBG("Setting session [" << sessionId << "] as readonly");
                     session->setReadOnly(true);
-                    if (_isViewFileExtension)
-                    {
-                        LOG_DBG("Allow session ["
-                                << sessionId << "] to change comments on document with extension ["
-                                << localStorage->getFileExtension() << ']');
-                        session->setAllowChangeComments(true);
-                    }
+                    LOG_DBG("Allow session [" << sessionId
+                                              << "] to change comments on document with extension ["
+                                              << localStorage->getFileExtension() << ']');
+                    session->setAllowChangeComments(true);
+
                     // Related to fix for issue #5887: only send a read-only
                     // message for "view file extension" document types
                     session->sendFileMode(session->isReadOnly(), session->isAllowChangeComments());

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -931,6 +931,7 @@ bool DocumentBroker::download(
         }
 
         wopiStorage->handleWOPIFileInfo(*wopiFileInfo, *_lockCtx);
+        _isViewFileExtension = COOLWSD::IsViewFileExtension(wopiStorage->getFileExtension());
 
         if (session)
         {
@@ -1179,7 +1180,6 @@ DocumentBroker::updateSessionWithWopiInfo(const std::shared_ptr<ClientSession>& 
     if (!wopiFileInfo->getIsAdminUserError().empty())
         _serverAudit.set("is_admin", wopiFileInfo->getIsAdminUserError());
 
-    _isViewFileExtension = COOLWSD::IsViewFileExtension(wopiStorage->getFileExtension());
     if (!wopiFileInfo->getUserCanWrite() ||
         session->isReadOnly()) // Readonly. Second boolean checks for URL "permission=readonly"
     {

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -626,8 +626,7 @@ private:
 
     /// Actual document download and post-download processing.
     /// Must be called only when creating the storage for the first time.
-    bool doDownloadDocument(const std::shared_ptr<ClientSession>& session,
-                            const Authorization& auth, const std::string& templateSource,
+    bool doDownloadDocument(const Authorization& auth, const std::string& templateSource,
                             const std::string& filename,
                             std::chrono::milliseconds& getFileCallDurationMs);
 
@@ -645,9 +644,15 @@ private:
     bool isLoaded() const { return _docState.hadLoaded(); }
     bool isInteractive() const { return _docState.isInteractive(); }
 
+    void lockIfEditing(const std::shared_ptr<ClientSession>& session, const Poco::URI& uriPublic,
+                       bool userCanWrite);
+
     /// Updates the document's lock in storage to either locked or unlocked.
     /// Returns true iff the operation was successful.
     bool updateStorageLockState(ClientSession& session, bool lock, std::string& error);
+
+    /// Take the lock before loading the first session, if we know we can edit.
+    bool updateStorageLockState(const Authorization& auth, std::string& error);
 
     std::size_t getIdleTimeSecs() const
     {


### PR DESCRIPTION
This resolves #9185.

The issue relates to loading asynchronously. This ahead-of-time loading is done before the client opens the WebSocket. This meant that the locking function didn't have the necessary details to decide whether locking was needed or not, and so it was skipped. The issue wouldn't happen if by the time we downloaded the document the WebSocket was created. As such, this is a time-sensitive bug. However, reports indicate that it's not uncommon that we weren't taking the lock.

The issue is resolved with this PR and now we take the lock when the _first_ editor joins (and as before, we unlock when the _last_ editor leaves). An improved unit-test asserts this behavior.

- wsd: all view-only extensions accept comments
- wsd: minor refactor around on-demand CFI
- wsd: always set view-file-extension flag
- wsd: reliable locking with async loading
