### PR TITLE
fix(COOLWSD): Fix a typo `remove_font_config`->`remote`

### DIFF
--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -1451,7 +1451,7 @@ public:
         }
         catch (const Poco::NullPointerException&)
         {
-            LOG_INF("Overriding the remote font config URL failed because the remove_font_config entry does not exist");
+            LOG_INF("Overriding the remote font config URL failed because the remote_font_config entry does not exist");
         }
         catch (const std::exception& exc)
         {


### PR DESCRIPTION
* Target version: master 

Signed-off-by: Josh Richards <josh.t.richards@gmail.com>
Change-Id: Ib2c5bc13ded052aa3e76b0dcb280b32d7febedb5
    
### Summary


### TODO


### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

