### PR TITLE
Add support for "getpresentationinfo" command

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1642,6 +1642,9 @@ L.CanvasTileLayer = L.Layer.extend({
 				app.isAdminUser = null;
 
 			this._map.fire('adminuser');
+		} else if (textMsg.startsWith('presentationinfo:')) {
+			window.app.console.log('_onMessage: ' + textMsg);
+			//content = JSON.parse(textMsg.substring('presentationinfo:'.length + 1));
 		}
 	},
 

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -483,7 +483,8 @@ bool ChildSession::_handleInput(const char *buffer, int length)
                tokens.equals(0, "a11ystate") ||
                tokens.equals(0, "geta11yfocusedparagraph") ||
                tokens.equals(0, "geta11ycaretposition") ||
-               tokens.equals(0, "toggletiledumping"));
+               tokens.equals(0, "toggletiledumping") ||
+               tokens.equals(0, "getpresentationinfo"));
 
         ProfileZone pz("ChildSession::_handleInput:" + tokens[0]);
         if (tokens.equals(0, "clientzoom"))
@@ -729,6 +730,10 @@ bool ChildSession::_handleInput(const char *buffer, int length)
         else if (tokens.equals(0, "toggletiledumping"))
         {
             setDumpTiles(tokens[1] == "true");
+        }
+        else if (tokens.equals(0, "getpresentationinfo"))
+        {
+            return getPresentationInfo();
         }
         else
         {
@@ -2765,6 +2770,18 @@ bool ChildSession::getA11yCaretPosition()
     getLOKitDocument()->setView(_viewId);
     int pos = getLOKitDocument()->getA11yCaretPosition();
     sendTextFrame("a11ycaretposition: " + std::to_string(pos));
+    return true;
+}
+
+bool ChildSession::getPresentationInfo()
+{
+    getLOKitDocument()->setView(_viewId);
+
+    char* info = nullptr;
+    info = getLOKitDocument()->getPresentationInfo();
+    std::string data(info);
+    free(info);
+    sendTextFrame("presentationinfo: " + data);
     return true;
 }
 

--- a/kit/ChildSession.hpp
+++ b/kit/ChildSession.hpp
@@ -178,6 +178,7 @@ private:
     bool setAccessibilityState(bool enable);
     bool getA11yFocusedParagraph();
     bool getA11yCaretPosition();
+    bool getPresentationInfo();
 
     void rememberEventsForInactiveUser(const int type, const std::string& payload);
 

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1190,7 +1190,8 @@ bool ClientSession::_handleInput(const char *buffer, int length)
              tokens.equals(0, "removetextcontext") ||
              tokens.equals(0, "rendersearchresult") ||
              tokens.equals(0, "geta11yfocusedparagraph") ||
-             tokens.equals(0, "geta11ycaretposition"))
+             tokens.equals(0, "geta11ycaretposition") ||
+             tokens.equals(0, "getpresentationinfo"))
     {
         if (tokens.equals(0, "key"))
             _keyEvents++;


### PR DESCRIPTION
This adds support for getting the presentation info from core. This change uses the new GetPresentationInfo() funciton that was added to the LOKit API.


Change-Id: I19f5809fd841e4b2603a2446e1d9d54392dd1bd7


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

