### PR TITLE
Fix failing test mobile/calc/cell_appearance_spec.js

### DIFF
--- a/cypress_test/integration_tests/common/helper.js
+++ b/cypress_test/integration_tests/common/helper.js
@@ -1146,7 +1146,8 @@ function setDummyClipboardForCopy(type) {
 
 // Clicks the Copy button on the UI.
 function copy() {
-	cy.window().then(win => {
+	cy.log('helper.copy()');
+	cy.window({log: false}).then(win => {
 		const app = win['0'].app;
 		const clipboard = app.map._clip;
 		clipboard.filterExecCopyPaste('.uno:Copy');

--- a/cypress_test/integration_tests/mobile/calc/cell_appearance_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/cell_appearance_spec.js
@@ -73,6 +73,10 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Change cell appearance.', f
 		// First add left border
 		cy.cGet('#border-2').click();
 
+		// Close mobile wizard gracefully now to avoid sporadic
+		// failures when reopening it later
+		mobileHelper.closeMobileWizard();
+
 		calcHelper.selectEntireSheet();
 		helper.copy();
 


### PR DESCRIPTION
Mobile wizard was failing to reopen after being forced
closed by selecting a cell. In this file, it only affects
this one testpoint. Solution: Close mobile wizard gracefully
before reopening

Also improve logging for helper.copy() 