### PR TITLE
fix debugging overlay

### DIFF
--- a/browser/src/layer/vector/Polygon.js
+++ b/browser/src/layer/vector/Polygon.js
@@ -42,7 +42,7 @@ L.Polygon = L.Polyline.extend({
 	},
 
 	_clipPoints: function () {
-		if (this.options.noClip || this._renderer instanceof L.SplitPanesSVG) {
+		if (this.options.noClip) {
 			// TODO: need some work to get this right and performant, especially in the case of
 			// a poly* spread across multiple split-panes.
 			this._parts = this._rings;

--- a/browser/src/layer/vector/Polyline.js
+++ b/browser/src/layer/vector/Polyline.js
@@ -130,7 +130,7 @@ L.Polyline = L.Path.extend({
 
 	// clip polyline by renderer bounds so that we have less to render for performance
 	_clipPoints: function () {
-		if (this.options.noClip || this._renderer instanceof L.SplitPanesSVG) {
+		if (this.options.noClip) {
 			this._parts = this._rings;
 			return;
 		}


### PR DESCRIPTION
instanceof L.SplitPanesSVG is not found since removed at:

commit 2c92b1e8c95126d5032db0e3d1fc24bac8cdb0f7
Date:   Fri Jun 28 21:14:29 2024 +0300

    Remove unused files.


Change-Id: Idb83dd388a7d93cce35f0fb97c8049d35c95851c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

