### PR TITLE
Fix failing impress annotation tests

### DIFF
--- a/cypress_test/integration_tests/desktop/impress/annotation_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/annotation_spec.js
@@ -118,7 +118,7 @@ describe(['tagdesktop'], 'Collapsed Annotation Tests', function() {
 		cy.cGet('.cool-annotation-content > div').should('include.text','some reply text');
 	});
 
-	it.skip('Autosave Collapse', function() {
+	it('Autosave Collapse', function() {
 		desktopHelper.insertComment(undefined, false);
 		cy.cGet('#map').focus();
 		helper.typeIntoDocument('{home}');
@@ -137,7 +137,7 @@ describe(['tagdesktop'], 'Collapsed Annotation Tests', function() {
 		helper.reloadDocument(newFilePath);
 		cy.cGet('.cool-annotation-img').click();
 		cy.cGet('.cool-annotation-content-wrapper').should('exist');
-		cy.cGet('#annotation-content-area-1').should('have.text','some text0');
+		cy.cGet('[id^=annotation-content-area-]').should('have.text','some text0');
 		cy.cGet('.cool-annotation-info-collapsed').should('be.not.visible');
 	})
 });

--- a/cypress_test/integration_tests/desktop/impress/slide_operations_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/slide_operations_spec.js
@@ -40,7 +40,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Slide operations', functio
 
 	});
 
-	it.skip('Duplicate slide', function() {
+	it('Duplicate slide', function() {
 		// Also check if comments are getting duplicated
 		cy.cGet('#options-modify-page').click();
 		desktopHelper.insertComment();
@@ -49,7 +49,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Slide operations', functio
 
 		impressHelper.assertNumberOfSlidePreviews(2);
 		cy.cGet('#SlideStatus').should('have.text', 'Slide 2 of 2');
-		cy.cGet('#annotation-content-area-2').should('include.text', 'some text0');
+		cy.cGet('[id^=annotation-content-area-]').should('include.text', 'some text0');
 
 	});
 


### PR DESCRIPTION
There is some instability with annotation ids. Sometimes it has the id annotation-content-2 instead of annotation-content-1. (or -3 instead of -2). The fix is to make the test look for either id.


Change-Id: Ie3759b5001f7194efea2d613752363bb0462f61f


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

