### PR TITLE
don't use hasCorrectUID for mount namespace case

### DIFF
--- a/common/CoolMount.cpp
+++ b/common/CoolMount.cpp
@@ -15,13 +15,13 @@
 #include <config.h>
 
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <errno.h>
 #include <sys/mount.h>
 #include <sys/stat.h>
 #include <sysexits.h>
 #include <unistd.h>
-
-#include <security.h>
 
 #ifdef __FreeBSD__
 #include <stdlib.h>
@@ -149,14 +149,6 @@ void usage(const char* program)
 
 int domount(int argc, const char* const* argv)
 {
-    /*WARNING: PRIVILEGED CODE CHECKING START */
-    /*WARNING*/ if (!hasCorrectUID(/* appName = */ "coolmount"))
-    /*WARNING*/ {
-    /*WARNING*/    fprintf(stderr, "Aborting.\n");
-    /*WARNING*/    return EX_SOFTWARE;
-    /*WARNING*/ }
-    /*WARNING: PRIVILEGED CODE CHECKING END */
-
     const char* program = argv[0];
     if (argc < 3)
     {

--- a/tools/mount.cpp
+++ b/tools/mount.cpp
@@ -15,11 +15,22 @@
 #include <config.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <sysexits.h>
+
+#include <security.h>
 
 extern int domount(int argc, const char* const* argv);
 
 int main(int argc, char** argv)
 {
+    /*WARNING: PRIVILEGED CODE CHECKING START */
+    /*WARNING*/ if (!hasCorrectUID(/* appName = */ "coolmount"))
+    /*WARNING*/ {
+    /*WARNING*/    fprintf(stderr, "Aborting.\n");
+    /*WARNING*/    return EX_SOFTWARE;
+    /*WARNING*/ }
+    /*WARNING: PRIVILEGED CODE CHECKING END */
+
     return domount(argc, argv);
 }
 


### PR DESCRIPTION
because we have changed uid within that namespace to 0 when using mount namespaces

--enable-debug disables this check, so missed that.


Change-Id: I162ad8c384064dc49056155b2858fd95cd05b2cb


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

