### PR TITLE
Correct background URL for save modified icon in classic menu

### DIFF
--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -1057,7 +1057,7 @@ button.leaflet-control-search-next
 .w2ui-icon.sign_not_ok{ background: url('images/sign_not_ok.svg') no-repeat center; }
 .w2ui-icon.save{ background: url('images/lc_save.svg') no-repeat center; }
 .w2ui-icon.saveas{ background: url('images/lc_saveas.svg') no-repeat center; }
-.w2ui-icon.savemodified{ background: url('images/savemodified_large.svg') no-repeat center; }
+.w2ui-icon.savemodified{ background: url('images/lc_savemodified_large.svg') no-repeat center; }
 .w2ui-icon.zoomin{ background: url('images/plus.svg') no-repeat center; }
 .w2ui-icon.zoomout{ background: url('images/minus.svg') no-repeat center; }
 .w2ui-icon.zoomreset{ background: url('images/lc_view100.svg') no-repeat center; }
@@ -1348,7 +1348,7 @@ button.leaflet-control-search-next
 [data-theme='dark'] .w2ui-icon.sign_not_ok{ background: url('images/dark/sign_not_ok.svg') no-repeat center; }
 [data-theme='dark'] .w2ui-icon.save{ background: url('images/dark/lc_save.svg') no-repeat center; }
 [data-theme='dark'] .w2ui-icon.saveas{ background: url('images/dark/lc_saveas.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.savemodified{ background: url('images/dark/savemodified_large.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.savemodified{ background: url('images/dark/lc_savemodified_large.svg') no-repeat center; }
 [data-theme='dark'] .w2ui-icon.zoomin{ background: url('images/dark/plus.svg') no-repeat center; }
 [data-theme='dark'] .w2ui-icon.zoomout{ background: url('images/dark/minus.svg') no-repeat center; }
 [data-theme='dark'] .w2ui-icon.zoomreset{ background: url('images/dark/lc_view100.svg') no-repeat center; }


### PR DESCRIPTION
* Resolves: No issue is created for this minor but
* Target version: distro/collabora/co-24.04
* Commit Id : 712ad4f8160f7d380abe2a45b1ecb68bbe02cb0e

### Summary
When we edit a document while using the classic menu as a menu bar, then the icon that represents the document is modified and empty. The reason behind this is a very minor issue which is resolved by updating the URL of the background.

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

