### PR TITLE
Initialize storage.ssl.* config items

### DIFF
--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -2057,6 +2057,10 @@ void COOLWSD::innerInitialize(Application& self)
         { "stop_on_config_change", "false" },
         { "storage.filesystem[@allow]", "false" },
         // "storage.ssl.enable" - deliberately not set; for back-compat
+        { "storage.ssl.ca_file_path", "" },
+        { "storage.ssl.cert_file_path", "" },
+        { "storage.ssl.cipher_list", "" },
+        { "storage.ssl.key_file_path", "" },
         { "storage.wopi.max_file_size", "0" },
         { "storage.wopi[@allow]", "true" },
         { "storage.wopi.locking.refresh", "900" },


### PR DESCRIPTION
We need to initialize these, because we saw in the wild that a customer removed the empty defaults from coolwsd.xml and coolwsd stopped with fatal error.


Change-Id: Ifc75e3eb2fe50c2028f84d8f61ba5a034b14b4cf

