### PR TITLE
Accessibility Check btn: Fix label: avoid new translatable string

### DIFF
--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -405,7 +405,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 							'id': 'accessibility-check',
 							'class': 'unoAccessibilityCheck',
 							'type': 'bigtoolitem',
-							'text': _('Accessibility Check'),
+							'text': _UNO('.uno:AccessibilityCheck', 'text'),
 							'command': '.uno:SidebarDeck.A11yCheckDeck',
 							'accessibility': { focusBack: false, combination: 'A', de: null }
 						} : {},
@@ -2330,7 +2330,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 			{
 				'id': 'review-accessibility-check',
 				'type': 'bigtoolitem',
-				'text': _('Accessibility Check'),
+				'text': _UNO('.uno:AccessibilityCheck', 'text'),
 				'command': '.uno:SidebarDeck.A11yCheckDeck',
 				'accessibility': { focusBack: false, combination: 'A1', de: 'B' }
 			}


### PR DESCRIPTION
The initial fix was merged with
33163c1f8789d461ca77f425e1c43d5b8b5f1e84 but was introducing a new
translatable string with it

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I3723e1e3d4bb204894b9c0ec74b9e35937f914b3
