### PR TITLE
_prevMouseOverEntry seen as null on dragging row resize indicator right

### DIFF
--- a/browser/src/control/Control.Header.ts
+++ b/browser/src/control/Control.Header.ts
@@ -563,7 +563,9 @@ export class Header extends app.definitions.canvasSectionObject {
 			this._dragDistance = dragDistance;
 			this.containerObject.requestReDraw(); // Remove previously drawn line and paint a new one.
 
-			if (this._lastSelectedIndex == this._prevMouseOverEntry.index || this._dragEntry)
+			if (this._prevMouseOverEntry && this._lastSelectedIndex == this._prevMouseOverEntry.index)
+				return;
+			if (this._dragEntry)
 				return;
 			const modifier = typeof this._lastSelectedIndex === 'number' && this._lastSelectedIndex >= 0 ? UNOModifier.SHIFT : 0;
 			this._lastSelectedIndex = this._mouseOverEntry.index;


### PR DESCRIPTION
in a spreadsheet with a rows tall enough to show the vertical resize indicator in the column ui to the spreadsheet left

select the row by clicking on its entry in the column ui, then hover the mouse over the resize indicator and click and drag to the right, and release over the spreadsheet content, it might take 3 or 4 attempts.


Change-Id: I95d3a76b33a50d4f1cc600832c6759785f0f16cf


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

