### PR TITLE
error on dragging col/row indicator in writer table

### DIFF
--- a/browser/src/layer/tile/TileLayer.TableOverlay.js
+++ b/browser/src/layer/tile/TileLayer.TableOverlay.js
@@ -320,8 +320,8 @@ L.CanvasTileLayer.include({
 		this._postSelectTextEvent('end', e.target._end.x - 5, e.target._end.y - 5);
 	},
 	_onSelectRowColumnDrag: function(e) {
-		e.target.freezeX(true);
-		e.target.freezeY(true);
+		e.target.dragging.freezeX(true);
+		e.target.dragging.freezeY(true);
 	},
 
 	// Update dragged text selection.


### PR DESCRIPTION
insert table in writer, there are square indicators over each column, click on on and try and drag it

TypeError: e.target.freezeX is not a function
    at NewClass._onSelectRowColumnDrag (https://share.collaboraonline.com/browser/8628721/bundle.js:17952:45)
    at NewClass.fire (https://share.collaboraonline.com/browser/8628721/bundle.js:9885:62)
    at NewClass._onDragStart (https://share.collaboraonline.com/browser/8628721/bundle.js:21839:23)
    at NewClass.fire (https://share.collaboraonline.com/browser/8628721/bundle.js:9885:62)
    at NewClass._onMove (https://share.collaboraonline.com/browser/8628721/bundle.js:20505:59)
    at NewClass.<anonymous> (https://share.collaboraonline.com/browser/8628721/bundle.js:20477:10)
    at HTMLDocument.handler (https://share.collaboraonline.com/browser/8628721/bundle.js:20421:35)

Change-Id: I41b28518aca2f78bc309ce1c88f1eb270cd77010


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

