### PR TITLE
namespace mount can fail due to adding MS_NOATIME

### DIFF
--- a/common/JailUtil.cpp
+++ b/common/JailUtil.cpp
@@ -33,7 +33,7 @@
 #include "Log.hpp"
 #include <SigUtil.hpp>
 
-extern int domount(int argc, const char* const* argv);
+extern int domount(bool namespace_mount, int argc, const char* const* argv);
 
 namespace JailUtil
 {
@@ -130,7 +130,7 @@ bool coolmount(const std::string& arg, std::string source, std::string target)
             argv[argc++] = source.c_str();
         if (!target.empty())
             argv[argc++] = target.c_str();
-        return domount(argc, argv) == EX_OK;
+        return domount(true, argc, argv) == EX_OK;
     }
 
     const std::string cmd = Poco::Path(Util::getApplicationPath(), "coolmount").toString() + ' '

--- a/tools/mount.cpp
+++ b/tools/mount.cpp
@@ -19,7 +19,7 @@
 
 #include <security.h>
 
-extern int domount(int argc, const char* const* argv);
+extern int domount(bool namespace_mount, int argc, const char* const* argv);
 
 int main(int argc, char** argv)
 {
@@ -31,7 +31,7 @@ int main(int argc, char** argv)
     /*WARNING*/ }
     /*WARNING: PRIVILEGED CODE CHECKING END */
 
-    return domount(argc, argv);
+    return domount(false, argc, argv);
 }
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */


### PR DESCRIPTION
in deployment on remounting the mount pointing to /opt/cool/systemplate with an additional MS_NOATIME results in EPERM.  Where that dir is on a (toplevel) [rel]atime mount.

man 2 mount states 'An attempt was made to modify (MS_REMOUNT) the MS_RDONLY, MS_NOSUID, or MS_NOEXEC flag, or one of the "atime" flags (MS_NOATIME, MS_NODIRATIME, MS_RELATIME) of an existing mount, but the mount is locked'. Presumably we can add flags that drop privs, but not those that could circumvent original mount policy.


Change-Id: I4c0c6a6e4a0e7fae04255e247b18cd5a86c3f327


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

