### PR TITLE
rle data size is two bytes not one

### DIFF
--- a/kit/Delta.hpp
+++ b/kit/Delta.hpp
@@ -837,7 +837,7 @@ class DeltaGenerator {
             outb.size = maxCompressed;
             outb.pos = 0;
 
-            unsigned char packedLine[1 + spaceForBitmask + width * 4];
+            unsigned char packedLine[2 + spaceForBitmask + width * 4];
 
             for (int y = 0; y < height; ++y)
             {


### PR DESCRIPTION
==3858==ERROR: AddressSanitizer: dynamic-stack-buffer-overflow /usr/bin/coolforkit
	__asan_memcpy
		asan/asan_interceptors_memintrinsics.cpp:22
/usr/bin/coolforkit
	DeltaGenerator::copy_row(unsigned char*, unsigned char const*, unsigned int, LibreOfficeKitTileMode)
		online/./kit/Delta.hpp:522
/usr/bin/coolforkit
	DeltaGenerator::DeltaBitmapRow::packForNetwork(unsigned char*, LibreOfficeKitTileMode) const
		online/./kit/Delta.hpp:175

presumably an issue since:

commit a9d4dcb71d61e3c8825c439b84cf0739f48b6341
Date:   Mon Jun 10 17:07:00 2024 +0100

    deltas: zstd compress already RLE compressed pixels.


Change-Id: Iba3288a3efc3f6df3411ff2ecc66ce5d89693ea2


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

