### PR TITLE
fix(gitignore): Add dist_git_hash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,8 +135,9 @@ zstdlib-symlink
 ICU.dat
 ios/Mobile/Assets.xcassets/AppIcon.appiconset
 
-# iOS app build number
+# build numbers/versions
 BUNDLE-VERSION
+/dist_git_hash
 
 # android stuff
 /android/lib/src/main/assets/dist


### PR DESCRIPTION
dist_git_hash is used in distribution, and might also be needed if git is unavailable or broken (for example certain bind-mounts into docker containers or use of tools such as jj).

One thing you absolutely mustn't do, however, is commit it. It overrides future git commit detection, which would subtly cause caching and/or version issues for everyone.

Let's gitignore it to avoid that.


Change-Id: I9cf5412bf6693afab7cb7b0ca2a8a377575ed929


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

