### PR TITLE
coolstress: Rewrite removed commands

### DIFF
--- a/tools/Replay.hpp
+++ b/tools/Replay.hpp
@@ -391,6 +391,10 @@ public:
 
         if (tokens.equals(0, "tileprocessed"))
             out.clear(); // we do this accurately below
+        else if (tokens.equals(0, "requestloksession") || (tokens.equals(0, "canceltiles")))
+            out.clear(); // These commands have been removed.
+        else if (tokens.equals(0, "uno .uno:Save"))
+            out = "save dontTerminateEdit=0 dontSaveIfUnmodified=1"; // .uno:Save will crash in debug
 
         else if (tokens.equals(0, "load")) {
             std::string url = tokens[1];


### PR DESCRIPTION
Rewrite .uno:Save as it crash (in debug)


Change-Id: Ifae0ffb007ab13150f4e021e2c557fdf062910b5


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

To allow older replays, two of the commands have been removed and case the test to bail out. `.uno:Save` is no longer allowed directly, and triggers an assert (fatal in debug) so it is rewritten.

### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

