### PR TITLE
Use link color comes from core instead config

### DIFF
--- a/coolkitconfig.xcu
+++ b/coolkitconfig.xcu
@@ -101,14 +101,6 @@
                 <value>0</value>
             </prop>
         </node>
-        <node oor:name="Links">
-            <prop oor:name="Color" oor:op="fuse">
-                <value>128</value>
-            </prop>
-            <prop oor:name="IsVisible" oor:op="fuse">
-                <value>true</value>
-            </prop>
-        </node>
         <node oor:name="LinksVisited">
             <prop oor:name="Color" oor:op="fuse">
                 <value>204</value>
@@ -418,14 +410,6 @@
         <node oor:name="FontColor">
             <prop oor:name="Color" oor:op="fuse">
                 <value>0xFFFFFF</value>
-            </prop>
-        </node>
-        <node oor:name="Links">
-            <prop oor:name="Color" oor:op="fuse">
-                <value>1939955</value>
-            </prop>
-            <prop oor:name="IsVisible" oor:op="fuse">
-                <value>true</value>
             </prop>
         </node>
         <node oor:name="LinksVisited">


### PR DESCRIPTION
This patch is dependent to core patch that sends true link color for online cliens according to they are in dark mode or bright mode.


Change-Id: I7b819e9619a1254176424d85af2fd5c12c28f483


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

