### PR TITLE
feat: recording CPU usage and peak memory usage

### DIFF
--- a/test/.gitignore
+++ b/test/.gitignore
@@ -18,3 +18,5 @@ CPU.csv
 Network.csv
 PingLatency.csv
 TileLatency.csv
+CPUUsage.csv
+PeakMemoryUsage.csv

--- a/test/UnitPerf.cpp
+++ b/test/UnitPerf.cpp
@@ -32,6 +32,7 @@
 class UnitPerf : public UnitWSD
 {
     void testPerf();
+
     void dumpCPUTimeToCSV(long cpuTime);
 
     void configure(Poco::Util::LayeredConfiguration& config) override

--- a/test/UnitPerf.cpp
+++ b/test/UnitPerf.cpp
@@ -32,6 +32,7 @@
 class UnitPerf : public UnitWSD
 {
     void testPerf();
+    void dumpCPUTimeToCSV(long cpuTime);
 
     void configure(Poco::Util::LayeredConfiguration& config) override
     {
@@ -72,6 +73,20 @@ void UnitPerf::testPerf()
     stats->dump();
 }
 
+void UnitPerf::dumpCPUTimeToCSV(long cpuTime)
+{
+    std::ofstream file("CPUUsage.csv", std::ios::out | std::ios::app);
+
+    if(file.tellp() == 0)
+    {
+        file << "CPU Time";
+        file << "\n";
+    }
+
+    file << cpuTime;
+    file << "\n";
+}
+
 UnitPerf::UnitPerf() : UnitWSD("UnitPerf")
 {
     // Double of the default.
@@ -88,7 +103,10 @@ void UnitPerf::invokeWSDTest()
 
     testPerf();
 
-    std::cerr << "test: " << _timer->elapsedTime().count() << "us\n";
+    long cpuTime = _timer->elapsedTime().count();
+    dumpCPUTimeToCSV(cpuTime);
+
+    std::cerr << "test: " << cpuTime << "us\n";
 
     exitTest(TestResult::Ok);
 }

--- a/tools/Replay.hpp
+++ b/tools/Replay.hpp
@@ -106,7 +106,8 @@ struct Histogram {
             if(i < 10)
             {
                 subOneHundredCount += _buckets[i];
-            }else
+            }
+            else
             {
                 overOneHundredCount += _buckets[i];
             }
@@ -158,8 +159,10 @@ struct Stats {
         std::string line;
         size_t totalDirtyPss = 0;
 
-        while (std::getline(smapsFile, line)) {
-            if (line.find("Pss_Dirty:") == 0) {
+        while (std::getline(smapsFile, line))
+        {
+            if (line.find("Pss_Dirty:") == 0)
+            {
                 std::stringstream ss(line);
                 std::string key;
                 size_t value;
@@ -228,7 +231,6 @@ struct Stats {
         const size_t runMs = std::chrono::duration_cast<std::chrono::milliseconds>(now - _start).count();
 
         std::cout << "Peak memory usage: " << _peakMemoryUsage << "kB";
-
         std::cout << "Stress run took " << runMs << " ms\n";
         std::cout << "  tiles: " << _tileCount << " => TPS: " << ((_tileCount * 1000.0)/runMs) << "\n";
         _pingLatency.dump("ping latency:");


### PR DESCRIPTION
Change-ID:Iee66f82e1026eae517f4452decf074fc0959bce0

* Resolves: <!-- related github issue -->
* Target version: master 

### Summary
The CPU usage is calculated by the difference between the start up stats
compared to when the unit test has completed. Peak memory usage is measured
by comparing the memory of the process initially compared to, post loading a
document. Both metrics are recorded into seperate CSV files.


### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

