### PR TITLE
Add 'title' attribute to iframe for accessibility

### DIFF
--- a/browser/html/debug.html
+++ b/browser/html/debug.html
@@ -18,7 +18,7 @@
     <form id="form" action enctype="multipart/form-data" target="coolframe" method="post">
          <input name="access_token" value="test" type="hidden"/>
     </form>
-    <iframe id="coolframe" name= "coolframe" style="width:100%;height:100%;position:absolute;">
+    <iframe id="coolframe" name= "coolframe" style="width:100%;height:100%;position:absolute;" title="Collabora Online">
     </iframe>
     <script>
         function constructWopiUrl() {

--- a/browser/html/wasm.html
+++ b/browser/html/wasm.html
@@ -22,7 +22,7 @@
     <form id="form" action enctype="multipart/form-data" target="coolframe" method="post">
         <input name="access_token" value="test" type="hidden" />
     </form>
-    <iframe id="coolframe" name="coolframe" style="width:100%;height:100%;position:absolute;">
+    <iframe id="coolframe" name="coolframe" style="width:100%;height:100%;position:absolute;" title="Collabora Online">
     </iframe>
     <script>
         function constructWopiUrl() {

--- a/browser/src/map/handler/Map.Print.js
+++ b/browser/src/map/handler/Map.Print.js
@@ -3,6 +3,8 @@
  * L.Map.Print is handling the print action
  */
 
+/* global _ */
+
 L.Map.mergeOptions({
 	printHandler: true
 });
@@ -39,6 +41,7 @@ L.Map.Print = L.Handler.extend({
 		var blob = new Blob([e.response], {type: 'application/pdf'});
 		var url = URL.createObjectURL(blob);
 		this._printIframe = L.DomUtil.create('iframe', '', document.body);
+		this._printIframe.title = _('Print dialog');
 		this._printIframe.onload = L.bind(this._onIframeLoaded, this);
 		L.DomUtil.setStyle(this._printIframe, 'visibility', 'hidden');
 		L.DomUtil.setStyle(this._printIframe, 'position', 'fixed');

--- a/browser/src/map/handler/Map.Welcome.js
+++ b/browser/src/map/handler/Map.Welcome.js
@@ -78,6 +78,7 @@ L.Map.Welcome = L.Handler.extend({
 		var params = [{'ui_theme' : uiTheme}];
 
 		this._iframeWelcome = L.iframeDialog(this._url, params, null, { prefix: 'iframe-welcome' });
+		this._iframeWelcome._iframe.title = _('Welcome Dialog');
 	},
 
 	removeHooks: function () {


### PR DESCRIPTION
- Add a 'title' attribute to each iframe element, providing a brief but clear description of the content and purpose of the iframe

Signed-off-by: Darshan-upadhyay1110 <darshan.upadhyay@collabora.com>
Change-Id: Ie2179e9d39d9f4f00be5eebf7d30509d0b31cc0b
