### PR TITLE
wsd: CheckFileInfo - avoid over-complicating things.

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -916,7 +916,7 @@ bool DocumentBroker::download(
         {
             std::chrono::steady_clock::time_point start = std::chrono::steady_clock::now();
             auto poller = std::make_shared<TerminatingPoll>("CFISynReqPoll");
-            poller->startThread();
+            poller->runOnClientThread();
             CheckFileInfo checkFileInfo(poller, session->getPublicUri(), [](CheckFileInfo&) {});
             checkFileInfo.checkFileInfoSync(RedirectionLimit);
             wopiFileInfo = checkFileInfo.wopiFileInfo(session->getPublicUri());

--- a/wsd/wopi/CheckFileInfo.hpp
+++ b/wsd/wopi/CheckFileInfo.hpp
@@ -54,6 +54,8 @@ public:
     /// Returns the state of the request.
     State state() const { return _state; }
 
+    bool completed() const { return _state != State::None && _state != State::Active; }
+
     /// Returns the sanitized document URL.
     const Poco::URI& url() const { return _url; }
 
@@ -97,6 +99,4 @@ private:
     std::atomic<State> _state;
     Poco::JSON::Object::Ptr _wopiInfo;
     ProfileZone _profileZone;
-    std::mutex _mutex;
-    std::condition_variable _cv;
 };


### PR DESCRIPTION
We don't need a mutex & a condition - we can just spin our own TerminatingPoll to get what we need; saves launching an un-necessary thread, and reducing threading complexity.


Change-Id: Ia65398aa8a59ca297cd0a0caf0fa607681960764


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

