### PR TITLE
Renaming and Other Improvements

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -349,6 +349,7 @@ wsd_headers = wsd/Admin.hpp \
               wsd/wopi/WopiStorage.hpp
 
 shared_headers = common/Common.hpp \
+                 common/CharacterConverter.hpp \
                  common/Clipboard.hpp \
                  common/Crypto.hpp \
                  common/JsonUtil.hpp \

--- a/common/Authorization.cpp
+++ b/common/Authorization.cpp
@@ -96,12 +96,12 @@ Authorization Authorization::create(const Poco::URI& uri)
     {
         if (param.first == "access_token")
         {
-            Poco::URI::decode(param.second, decoded);
+            decoded = Util::decodeURIComponent(param.second);
             return Authorization(Authorization::Type::Token, decoded);
         }
 
         if (param.first == "access_header")
-            Poco::URI::decode(param.second, decoded);
+            decoded = Util::decodeURIComponent(param.second);
     }
 
     if (!decoded.empty())

--- a/common/CharacterConverter.hpp
+++ b/common/CharacterConverter.hpp
@@ -1,0 +1,89 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <Log.hpp>
+
+#include <cstdint>
+#include <iconv.h>
+#include <string>
+#include <vector>
+
+namespace Util
+{
+
+/// Using iconv(3) API, converts strings between character encodings.
+class CharacterConverter
+{
+public:
+    /// Create an instance to convert @from encoding @to encoding.
+    /// Note that the order of these two arguments are reversed,
+    /// compared to iconv_open(3).
+    CharacterConverter(const std::string& from, const std::string& to)
+        : _iconvd(iconv_open(to.data(), from.data()))
+    {
+        if (reinterpret_cast<int64_t>(_iconvd) == -1)
+        {
+            LOG_SYS("Failed to initialize iconv to convert from ["
+                    << from << "] to [" << to << "] and will return the source string unmodified");
+        }
+    }
+
+    ~CharacterConverter()
+    {
+        if (reinterpret_cast<int64_t>(_iconvd) != -1)
+        {
+            iconv_close(_iconvd);
+        }
+    }
+
+    /// Convert the given source string to the desired encoding.
+    std::string convert(std::string source) const
+    {
+        if (reinterpret_cast<int64_t>(_iconvd) == -1)
+        {
+            LOG_WRN("Failed to initize iconv and cannot convert [" + source + ']');
+            return source;
+        }
+
+        char* in = source.data();
+        std::size_t in_left = source.size();
+
+        std::vector<char> buffer(8 * source.size());
+        char* out = &buffer[0];
+        std::size_t out_left = buffer.size();
+
+        // Convert.
+        if (iconv(_iconvd, &in, &in_left, &out, &out_left) == static_cast<size_t>(-1))
+        {
+            LOG_ERR("Failed to convert [" << source << ']');
+            return source;
+        }
+
+        // Flush.
+        if (iconv(_iconvd, nullptr, nullptr, &out, &out_left) == static_cast<size_t>(-1))
+        {
+            LOG_ERR("Failed to flush [" << source << ']');
+            return source;
+        }
+
+        return std::string(&buffer[0], buffer.size() - out_left);
+    }
+
+private:
+    /// The character-set conversion descriptor.
+    iconv_t _iconvd;
+};
+
+} // end namespace Util
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/common/Session.cpp
+++ b/common/Session.cpp
@@ -115,32 +115,32 @@ void Session::parseDocOptions(const StringVector& tokens, int& part, std::string
         }
         else if (name == "authorid")
         {
-            Poco::URI::decode(value, _userId);
+            _userId = Util::decodeURIComponent(value);
             ++offset;
         }
         else if (name == "xauthorid")
         {
-            Poco::URI::decode(value, _userIdAnonym);
+            _userIdAnonym = Util::decodeURIComponent(value);
             ++offset;
         }
         else if (name == "author")
         {
-            Poco::URI::decode(value, _userName);
+            _userName = Util::decodeURIComponent(value);
             ++offset;
         }
         else if (name == "xauthor")
         {
-            Poco::URI::decode(value, _userNameAnonym);
+            _userNameAnonym = Util::decodeURIComponent(value);
             ++offset;
         }
         else if (name == "authorextrainfo")
         {
-            Poco::URI::decode(value, _userExtraInfo);
+            _userExtraInfo = Util::decodeURIComponent(value);
             ++offset;
         }
         else if (name == "authorprivateinfo")
         {
-            Poco::URI::decode(value, _userPrivateInfo);
+            _userPrivateInfo = Util::decodeURIComponent(value);
             ++offset;
         }
         else if (name == "readonly")
@@ -169,7 +169,7 @@ void Session::parseDocOptions(const StringVector& tokens, int& part, std::string
         }
         else if (name == "watermarkText")
         {
-            Poco::URI::decode(value, _watermarkText);
+            _watermarkText = Util::decodeURIComponent(value);
             ++offset;
         }
         else if (name == "watermarkOpacity")

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -182,8 +182,7 @@ namespace
 
     std::string pathFromFileURL(const std::string &uri)
     {
-        std::string decoded;
-        Poco::URI::decode(uri, decoded);
+        const std::string decoded = Util::decodeURIComponent(uri);
         if (decoded.rfind("file://", 0) != 0)
         {
             LOG_ERR("Asked to load a very unusual file path: '" << uri << "' -> '" << decoded << "'");

--- a/test/UnitWOPIRenameFile.cpp
+++ b/test/UnitWOPIRenameFile.cpp
@@ -25,8 +25,9 @@ class UnitWOPIRenameFile : public WopiTestServer
     STATE_ENUM(Phase, Load, RenameFile, WaitRenameNotification, Done)
     _phase;
 
-    static constexpr auto FilenameUtf8 = "a new filename";
-    static constexpr auto FilenameUtf7 = "a new filename";
+    static constexpr auto FilenameUtf8 = "Ḽơᶉëᶆ ȋṕšᶙṁ ḍỡḽǭᵳ ʂǐť";
+    static constexpr auto FilenameUtf7 =
+        "+HjwBoR2JAOsdhg +AgseVQFhHZkeQQ +Hg0e4R49Ae0dcw +AoIB0AFl-";
 
 public:
     UnitWOPIRenameFile()

--- a/test/UtilTests.cpp
+++ b/test/UtilTests.cpp
@@ -25,12 +25,16 @@ class UtilTests : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST(testStringifyHexLine);
     CPPUNIT_TEST(testHexify);
     CPPUNIT_TEST(testBytesToHex);
+#if ENABLE_DEBUG
+    CPPUNIT_TEST(testUtf8);
+#endif
 
     CPPUNIT_TEST_SUITE_END();
 
     void testStringifyHexLine();
     void testHexify();
     void testBytesToHex();
+    void testUtf8();
 };
 
 void UtilTests::testStringifyHexLine()
@@ -79,6 +83,18 @@ void UtilTests::testBytesToHex()
         const std::string s = Util::hexStringToBytes(hex);
         LOK_ASSERT_EQUAL(d, s);
     }
+}
+
+void UtilTests::testUtf8()
+{
+#if ENABLE_DEBUG
+    constexpr auto testname = __func__;
+    LOK_ASSERT(Util::isValidUtf8("foo"));
+    LOK_ASSERT(Util::isValidUtf8("©")); // 2 char
+    LOK_ASSERT(Util::isValidUtf8("→ ")); // 3 char
+    LOK_ASSERT(Util::isValidUtf8("🏃 is not 🏊."));
+    LOK_ASSERT(!Util::isValidUtf8("\xff\x03"));
+#endif
 }
 
 CPPUNIT_TEST_SUITE_REGISTRATION(UtilTests);

--- a/test/UtilTests.cpp
+++ b/test/UtilTests.cpp
@@ -14,6 +14,7 @@
 #include <test/lokassert.hpp>
 
 #include <Util.hpp>
+#include <CharacterConverter.hpp>
 
 #include <cppunit/extensions/HelperMacros.h>
 
@@ -25,6 +26,7 @@ class UtilTests : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST(testStringifyHexLine);
     CPPUNIT_TEST(testHexify);
     CPPUNIT_TEST(testBytesToHex);
+    CPPUNIT_TEST(testCharacterConverter);
 #if ENABLE_DEBUG
     CPPUNIT_TEST(testUtf8);
 #endif
@@ -34,6 +36,7 @@ class UtilTests : public CPPUNIT_NS::TestFixture
     void testStringifyHexLine();
     void testHexify();
     void testBytesToHex();
+    void testCharacterConverter();
     void testUtf8();
 };
 
@@ -82,6 +85,41 @@ void UtilTests::testBytesToHex()
         const std::string hex = Util::bytesToHexString(d);
         const std::string s = Util::hexStringToBytes(hex);
         LOK_ASSERT_EQUAL(d, s);
+    }
+}
+void UtilTests::testCharacterConverter()
+{
+    constexpr auto testname = __func__;
+
+    const std::string utf8 = "Ḽơᶉëᶆ ȋṕšᶙṁ ḍỡḽǭᵳ ʂǐť";
+    const std::string utf7 = "+HjwBoR2JAOsdhg +AgseVQFhHZkeQQ +Hg0e4R49Ae0dcw +AoIB0AFl-";
+    {
+        Util::CharacterConverter utf8_to_7("UTF-8", "UTF-7");
+        LOK_ASSERT_EQUAL_STR(utf7, utf8_to_7.convert(utf8));
+        LOK_ASSERT_EQUAL_STR(utf7, utf8_to_7.convert(utf8)); // Convert again.
+
+        Util::CharacterConverter utf7_to_8("UTF-7", "UTF-8");
+        LOK_ASSERT_EQUAL_STR(utf8, utf7_to_8.convert(utf7));
+        LOK_ASSERT_EQUAL_STR(utf8, utf7_to_8.convert(utf7)); // Convert again.
+    }
+
+    {
+        const std::string utf8l =
+            R"xxx(ăѣ𝔠ծềſģȟᎥ𝒋ǩľḿꞑȯ𝘱𝑞𝗋𝘴ȶ𝞄𝜈ψ𝒙𝘆𝚣1234567890!@#$%^&*()-_=+[{]};:'",<.>/?~𝘈Ḇ𝖢𝕯٤ḞԍНǏ𝙅ƘԸⲘ𝙉০Ρ𝗤Ɍ𝓢ȚЦ𝒱Ѡ𝓧ƳȤѧᖯć𝗱ễ𝑓𝙜Ⴙ𝞲𝑗𝒌ļṃŉо𝞎𝒒ᵲꜱ𝙩ừ𝗏ŵ𝒙𝒚ź1234567890!@#$%^&*()-_=+[{]};:'",<.>/?~АḂⲤ𝗗𝖤𝗙ꞠꓧȊ𝐉𝜥ꓡ𝑀𝑵Ǭ𝙿𝑄Ŗ𝑆𝒯𝖴𝘝𝘞ꓫŸ𝜡ả𝘢ƀ𝖼ḋếᵮℊ𝙝Ꭵ𝕛кιṃդⱺ𝓅𝘲𝕣𝖘ŧ𝑢ṽẉ𝘅ყž1234567890!@#$%^&*()-_=+[{]};:'",<.>/?~Ѧ𝙱ƇᗞΣℱԍҤ١𝔍К𝓛𝓜ƝȎ𝚸𝑄Ṛ𝓢ṮṺƲᏔꓫ𝚈𝚭𝜶Ꮟçძ𝑒𝖿𝗀ḧ𝗂𝐣ҝɭḿ𝕟𝐨𝝔𝕢ṛ𝓼тú𝔳ẃ⤬𝝲𝗓1234567890!@#$%^&*()-_=+[{]};:'",<.>/?~𝖠Β𝒞𝘋𝙴𝓕ĢȞỈ𝕵ꓗʟ𝙼ℕ০𝚸𝗤ՀꓢṰǓⅤ𝔚Ⲭ𝑌𝙕𝘢𝕤)xxx";
+        const std::string utf7l =
+            R"xxx(+AQMEY9g13SAFbh7BAX8BIwIfE6XYNdyLAekBPh4/p5ECL9g13jHYNdxe2DXdy9g13jQCNtg134TYNd8IA8jYNdyZ2DXeBtg13qM-1234567890+ACEAQAAjACQAJQBeACYAKg()-+AF8APQArAFsAewBdAH0AOw:'+ACI,+ADw.+AD4-/?+AH7YNd4IHgbYNd2i2DXdbwZkHh4FDQQdAc/YNd5FAZgFOCyY2DXeSQnmA6HYNd3kAkzYNdziAhoEJtg13LEEYNg13OcBswIkBGcVrwEH2DXd8R7F2DXcU9g13lwQudg137LYNdxX2DXcjAE8HkMBSQQ+2DXfjtg13JIdcqcx2DXeaR7r2DXdzwF12DXcmdg13JoBeg-1234567890+ACEAQAAjACQAJQBeACYAKg()-+AF8APQArAFsAewBdAH0AOw:'+ACI,+ADw.+AD4-/?+AH4EEB4CLKTYNd3X2DXdpNg13dmnoKTnAgrYNdwJ2DXfJaTh2DXcQNg13HUB7Ng13n/YNdxEAVbYNdxG2DXcr9g13bTYNd4d2DXeHqTrAXjYNd8hHqPYNd4iAYDYNd28Hgsevx1uIQrYNd5dE6XYNd1bBDoDuR5DBWQsetg13MXYNd4y2DXdY9g13ZgBZ9g13GIefR6J2DXeBRDnAX4-1234567890+ACEAQAAjACQAJQBeACYAKg()-+AF8APQArAFsAewBdAH0AOw:'+ACI,+ADw.+AD4-/?+AH4EZtg13nEBhxXeA6MhMQUNBKQGYdg13Q0EGtg13NvYNdzcAZ0CDtg13rjYNdxEHlrYNdziHm4eegGyE9Sk69g13ojYNd6t2DXfNhPPAOcQ69g13FLYNd2/2DXdwB4n2DXdwtg13CMEnQJtHj/YNd1f2DXcKNg131TYNd1iHlvYNdz8BEIA+tg13TMegyks2DXfctg13dM-1234567890+ACEAQAAjACQAJQBeACYAKg()-+AF8APQArAFsAewBdAH0AOw:'+ACI,+ADw.+AD4-/?+AH7YNd2gA5LYNdye2DXeC9g13nTYNdzVASICHh7I2DXddaTXAp/YNd58IRUJ5tg13rjYNd3kBUCk4h5wAdMhZNg13RosrNg13EzYNd5V2DXeItg13WQ-)xxx";
+
+        Util::CharacterConverter utf8_to_7("UTF-8", "UTF-7");
+        LOK_ASSERT_EQUAL_STR(utf7, utf8_to_7.convert(utf8));
+        LOK_ASSERT_EQUAL_STR(utf7l, utf8_to_7.convert(utf8l));
+        LOK_ASSERT_EQUAL_STR(utf7, utf8_to_7.convert(utf8));
+        LOK_ASSERT_EQUAL_STR(utf7l, utf8_to_7.convert(utf8l));
+
+        Util::CharacterConverter utf7_to_8("UTF-7", "UTF-8");
+        LOK_ASSERT_EQUAL_STR(utf8, utf7_to_8.convert(utf7));
+        LOK_ASSERT_EQUAL_STR(utf8l, utf7_to_8.convert(utf7l));
+        LOK_ASSERT_EQUAL_STR(utf8, utf7_to_8.convert(utf7));
+        LOK_ASSERT_EQUAL_STR(utf8l, utf7_to_8.convert(utf7l));
     }
 }
 

--- a/test/UtilTests.cpp
+++ b/test/UtilTests.cpp
@@ -23,10 +23,14 @@ class UtilTests : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST_SUITE(UtilTests);
 
     CPPUNIT_TEST(testStringifyHexLine);
+    CPPUNIT_TEST(testHexify);
+    CPPUNIT_TEST(testBytesToHex);
 
     CPPUNIT_TEST_SUITE_END();
 
     void testStringifyHexLine();
+    void testHexify();
+    void testBytesToHex();
 };
 
 void UtilTests::testStringifyHexLine()
@@ -40,6 +44,41 @@ void UtilTests::testStringifyHexLine()
     std::string result2("68 65 72 65 0A 74  | here.t");
     LOK_ASSERT_EQUAL(result1, Util::stringifyHexLine(test, 0));
     LOK_ASSERT_EQUAL(result2, Util::stringifyHexLine(test, 6, 6));
+}
+
+void UtilTests::testHexify()
+{
+    constexpr auto testname = __func__;
+
+    const std::string s1 = "some ascii text with !@#$%^&*()_+/-\\|";
+    const auto hex = Util::dataToHexString(s1, 0, s1.size());
+    std::string decoded;
+    LOK_ASSERT(Util::dataFromHexString(hex, decoded));
+    LOK_ASSERT_EQUAL(s1, decoded);
+
+    for (std::size_t randStrLen = 1; randStrLen < 129; ++randStrLen)
+    {
+        const auto s2 = Util::rng::getBytes(randStrLen);
+        LOK_ASSERT_EQUAL(randStrLen, s2.size());
+        const auto hex2 = Util::dataToHexString(s2, 0, s2.size());
+        LOK_ASSERT_EQUAL(randStrLen * 2, hex2.size());
+        std::vector<char> decoded2;
+        LOK_ASSERT(Util::dataFromHexString(hex2, decoded2));
+        LOK_ASSERT_EQUAL(randStrLen, decoded2.size());
+        LOK_ASSERT_EQUAL(Util::toString(s2), Util::toString(decoded2));
+    }
+}
+
+void UtilTests::testBytesToHex()
+{
+    constexpr auto testname = __func__;
+
+    {
+        const std::string d("Some text");
+        const std::string hex = Util::bytesToHexString(d);
+        const std::string s = Util::hexStringToBytes(hex);
+        LOK_ASSERT_EQUAL(d, s);
+    }
 }
 
 CPPUNIT_TEST_SUITE_REGISTRATION(UtilTests);

--- a/test/WhiteBoxTests.cpp
+++ b/test/WhiteBoxTests.cpp
@@ -64,9 +64,6 @@ class WhiteBoxTests : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST(testParseUrl);
     CPPUNIT_TEST(testSafeAtoi);
     CPPUNIT_TEST(testJsonUtilEscapeJSONValue);
-#if ENABLE_DEBUG
-    CPPUNIT_TEST(testUtf8);
-#endif
     CPPUNIT_TEST(testFindInVector);
     CPPUNIT_TEST(testThreadPool);
     CPPUNIT_TEST_SUITE_END();
@@ -95,7 +92,6 @@ class WhiteBoxTests : public CPPUNIT_NS::TestFixture
     void testParseUrl();
     void testSafeAtoi();
     void testJsonUtilEscapeJSONValue();
-    void testUtf8();
     void testFindInVector();
     void testThreadPool();
 
@@ -1240,18 +1236,6 @@ void WhiteBoxTests::testJsonUtilEscapeJSONValue()
     const std::string in = "domain\\username";
     const std::string expected = "domain\\\\username";
     LOK_ASSERT_EQUAL(JsonUtil::escapeJSONValue(in), expected);
-}
-
-void WhiteBoxTests::testUtf8()
-{
-#if ENABLE_DEBUG
-    constexpr auto testname = __func__;
-    LOK_ASSERT(Util::isValidUtf8("foo"));
-    LOK_ASSERT(Util::isValidUtf8("©")); // 2 char
-    LOK_ASSERT(Util::isValidUtf8("→ ")); // 3 char
-    LOK_ASSERT(Util::isValidUtf8("🏃 is not 🏊."));
-    LOK_ASSERT(!Util::isValidUtf8("\xff\x03"));
-#endif
 }
 
 void WhiteBoxTests::testFindInVector()

--- a/test/WhiteBoxTests.cpp
+++ b/test/WhiteBoxTests.cpp
@@ -57,14 +57,12 @@ class WhiteBoxTests : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST(testIso8601Time);
     CPPUNIT_TEST(testClockAsString);
     CPPUNIT_TEST(testBufferClass);
-    CPPUNIT_TEST(testHexify);
     CPPUNIT_TEST(testStat);
     CPPUNIT_TEST(testStringCompare);
     CPPUNIT_TEST(testParseUri);
     CPPUNIT_TEST(testParseUriUrl);
     CPPUNIT_TEST(testParseUrl);
     CPPUNIT_TEST(testSafeAtoi);
-    CPPUNIT_TEST(testBytesToHex);
     CPPUNIT_TEST(testJsonUtilEscapeJSONValue);
 #if ENABLE_DEBUG
     CPPUNIT_TEST(testUtf8);
@@ -90,14 +88,12 @@ class WhiteBoxTests : public CPPUNIT_NS::TestFixture
     void testIso8601Time();
     void testClockAsString();
     void testBufferClass();
-    void testHexify();
     void testStat();
     void testStringCompare();
     void testParseUri();
     void testParseUriUrl();
     void testParseUrl();
     void testSafeAtoi();
-    void testBytesToHex();
     void testJsonUtilEscapeJSONValue();
     void testUtf8();
     void testFindInVector();
@@ -971,30 +967,6 @@ void WhiteBoxTests::testBufferClass()
     LOK_ASSERT_EQUAL(true, buf.empty());
 }
 
-
-void WhiteBoxTests::testHexify()
-{
-    constexpr auto testname = __func__;
-
-    const std::string s1 = "some ascii text with !@#$%^&*()_+/-\\|";
-    const auto hex = Util::dataToHexString(s1, 0, s1.size());
-    std::string decoded;
-    LOK_ASSERT(Util::dataFromHexString(hex, decoded));
-    LOK_ASSERT_EQUAL(s1, decoded);
-
-    for (std::size_t randStrLen = 1; randStrLen < 129; ++randStrLen)
-    {
-        const auto s2 = Util::rng::getBytes(randStrLen);
-        LOK_ASSERT_EQUAL(randStrLen, s2.size());
-        const auto hex2 = Util::dataToHexString(s2, 0, s2.size());
-        LOK_ASSERT_EQUAL(randStrLen * 2, hex2.size());
-        std::vector<char> decoded2;
-        LOK_ASSERT(Util::dataFromHexString(hex2, decoded2));
-        LOK_ASSERT_EQUAL(randStrLen, decoded2.size());
-        LOK_ASSERT_EQUAL(Util::toString(s2), Util::toString(decoded2));
-    }
-}
-
 void WhiteBoxTests::testStat()
 {
     constexpr auto testname = __func__;
@@ -1258,18 +1230,6 @@ void WhiteBoxTests::testSafeAtoi()
     }
     {
         LOK_ASSERT_EQUAL(0, Util::safe_atoi(nullptr, 0));
-    }
-}
-
-void WhiteBoxTests::testBytesToHex()
-{
-    constexpr auto testname = __func__;
-
-    {
-        const std::string d("Some text");
-        const std::string hex = Util::bytesToHexString(d);
-        const std::string s = Util::hexStringToBytes(hex);
-        LOK_ASSERT_EQUAL(d, s);
     }
 }
 

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -834,7 +834,7 @@ void ClientRequestDispatcher::handleIncomingMessage(SocketDisposition& dispositi
         else if (requestDetails.equals(RequestDetails::Field::Type, "cool") &&
                  requestDetails.equals(1, "clipboard"))
         {
-//          Util::dumpHex(std::cerr, socket->getInBuffer(), "clipboard:\n"); // lots of data ...
+            //              Util::dumpHex(std::cerr, socket->getInBuffer(), "clipboard:\n"); // lots of data ...
             handleClipboardRequest(request, message, disposition, socket);
         }
 
@@ -1166,8 +1166,7 @@ void ClientRequestDispatcher::handleMediaRequest(const Poco::Net::HTTPRequest& r
 
     LOG_DBG_S("Media request: " << request.getURI());
 
-    std::string decoded;
-    Poco::URI::decode(request.getURI(), decoded);
+    const std::string decoded = Util::decodeURIComponent(request.getURI());
     Poco::URI requestUri(decoded);
     Poco::URI::QueryParameters params = requestUri.getQueryParameters();
     std::string WOPISrc, serverId, viewId, tag, mime;
@@ -1606,8 +1605,7 @@ void ClientRequestDispatcher::handlePostRequest(const RequestDetails& requestDet
 
         bool foundDownloadId = !url.empty();
 
-        std::string decoded;
-        Poco::URI::decode(url, decoded);
+        const std::string decoded = Util::decodeURIComponent(url);
 
         const Poco::Path filePath(FileUtil::buildLocalPathToJail(COOLWSD::EnableMountNamespaces, COOLWSD::ChildRoot + jailId,
                                                                  JAILED_DOCUMENT_ROOT + decoded));

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -804,9 +804,7 @@ bool ClientSession::_handleInput(const char *buffer, int length)
                         COOLProtocol::stringToInteger(attr[1], dontSaveIfUnmodified);
                     else if (attr[0] == "extendedData")
                     {
-                        std::string decoded;
-                        Poco::URI::decode(attr[1], decoded);
-                        extendedData = decoded;
+                        extendedData = Util::decodeURIComponent(attr[1]);
                     }
                 }
             }
@@ -1001,8 +999,7 @@ bool ClientSession::_handleInput(const char *buffer, int length)
             return false;
         }
 
-        std::string wopiFilename;
-        Poco::URI::decode(encodedWopiFilename, wopiFilename);
+        std::string wopiFilename = Util::decodeURIComponent(encodedWopiFilename);
         const std::string error =
             docBroker->handleRenameFileCommand(getId(), std::move(wopiFilename));
         if (!error.empty())
@@ -1939,8 +1936,7 @@ bool ClientSession::handleKitToClientMessage(const std::shared_ptr<Message>& pay
         }
 
         // Save-as completed, inform the ClientSession.
-        std::string wopiFilename;
-        Poco::URI::decode(encodedWopiFilename, wopiFilename);
+        const std::string wopiFilename = Util::decodeURIComponent(encodedWopiFilename);
 
         // URI constructor implicitly decodes when it gets std::string as param
         Poco::URI resultURL(encodedURL);
@@ -1950,7 +1946,7 @@ bool ClientSession::handleKitToClientMessage(const std::shared_ptr<Message>& pay
         {
             std::string relative;
             if (isConvertTo || isExportAs)
-                Poco::URI::decode(resultURL.getPath(), relative);
+                relative = Util::decodeURIComponent(resultURL.getPath());
             else
                 relative = resultURL.getPath();
 

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -3365,8 +3365,7 @@ bool DocumentBroker::handleInput(const std::shared_ptr<Message>& message)
             COOLProtocol::getTokenString((*message)[3], "clientid", clientId);
             LOG_CHECK_RET(!clientId.empty(), false);
 
-            std::string decoded;
-            Poco::URI::decode(url, decoded);
+            const std::string decoded = Util::decodeURIComponent(url);
             const std::string filePath(FileUtil::buildLocalPathToJail(COOLWSD::EnableMountNamespaces,
                                                                       COOLWSD::ChildRoot + getJailId(),
                                                                       JAILED_DOCUMENT_ROOT + decoded));

--- a/wsd/QuarantineUtil.cpp
+++ b/wsd/QuarantineUtil.cpp
@@ -344,7 +344,7 @@ bool Quarantine::quarantineFile(const std::string& docPath)
 
         if (lastFileStat.isIdenticalTo(sourceStat))
         {
-            LOG_WRN("Quarantining of file ["
+            LOG_INF("Quarantining of file ["
                     << docPath << "] to [" << linkedFilePath
                     << "] is skipped because this file version is already quarantined as ["
                     << lastFile.fullPath() << ']');

--- a/wsd/TraceFile.hpp
+++ b/wsd/TraceFile.hpp
@@ -134,9 +134,7 @@ public:
 
         if (_takeSnapshot)
         {
-            std::string decodedUri;
-            Poco::URI::decode(uri, decodedUri);
-            const std::string url = Poco::URI(decodedUri).getPath();
+            const std::string url = Poco::URI(Util::decodeURIComponent(uri)).getPath();
             const auto it = _urlToSnapshot.find(url);
             if (it != _urlToSnapshot.end())
             {
@@ -215,9 +213,7 @@ public:
                     std::string url;
                     if (COOLProtocol::getTokenString(tokens[1], "url", url))
                     {
-                        std::string decodedUrl;
-                        Poco::URI::decode(url, decodedUrl);
-                        Poco::URI uriPublic = Poco::URI(decodedUrl);
+                        Poco::URI uriPublic = Poco::URI(Util::decodeURIComponent(url));
                         if (uriPublic.isRelative() || uriPublic.getScheme() == "file")
                         {
                             uriPublic.normalize();

--- a/wsd/wopi/WopiStorage.cpp
+++ b/wsd/wopi/WopiStorage.cpp
@@ -869,8 +869,7 @@ WopiStorage::handleUploadToStorageResponse(const WopiUploadDetails& details,
                         JsonUtil::findJSONValue(object, "Name", filename))
                     {
                         // Get the FileId form the URL, which we use as the anonymized filename.
-                        std::string decodedUrl;
-                        Poco::URI::decode(url, decodedUrl);
+                        const std::string decodedUrl = Util::decodeURIComponent(url);
                         const std::string obfuscatedFileId = Util::getFilenameFromURL(decodedUrl);
                         Util::mapAnonymized(obfuscatedFileId,
                                             obfuscatedFileId); // Identity, to avoid re-anonymizing.

--- a/wsd/wopi/WopiStorage.hpp
+++ b/wsd/wopi/WopiStorage.hpp
@@ -166,7 +166,7 @@ public:
         std::optional<bool> _isAdminUser = std::nullopt;
 
         /// error code if integration does not use isAdminUser field properly
-        std::string _isAdminUserError = "";
+        std::string _isAdminUserError;
     };
 
     WopiStorage(const Poco::URI& uri, const std::string& localStorePath,

--- a/wsd/wopi/WopiStorage.hpp
+++ b/wsd/wopi/WopiStorage.hpp
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "CharacterConverter.hpp"
 #include <COOLWSD.hpp>
 #include <HttpRequest.hpp>
 #include <Log.hpp>
@@ -173,6 +174,7 @@ public:
                 const std::string& jailPath)
         : StorageBase(uri, localStorePath, jailPath)
         , _wopiSaveDuration(std::chrono::milliseconds::zero())
+        , _utf7Converter("UTF-8", "UTF-7")
         , _legacyServer(COOLWSD::getConfigValue<bool>("storage.wopi.is_legacy_server", false))
     {
         LOG_INF("WopiStorage ctor with localStorePath: ["
@@ -254,6 +256,9 @@ private:
 
     /// The http::Session used for uploading asynchronously.
     std::shared_ptr<http::Session> _uploadHttpSession;
+
+    /// Filename converter to UTF-7.
+    Util::CharacterConverter _utf7Converter;
 
     /// Whether or not this is a legacy server.
     const bool _legacyServer;


### PR DESCRIPTION
- wsd: skipped quarantines is not a warning
- killpoco: Poco::URI::decode
- wsd: test: move hex tests to UtilTests
- wsd: test: move isValidUtf8 test to UtilTests
- wsd: remove redundant initialization
- wsd: test: better rename test
- wsd: new CharacterConverter utility
- wsd: use CharacterConverter
