### PR TITLE
Attempt to fix curious assertion around ServerAuditUtil.

### DIFF
--- a/wsd/ServerAuditUtil.cpp
+++ b/wsd/ServerAuditUtil.cpp
@@ -12,7 +12,7 @@
 #include "ServerAuditUtil.hpp"
 
 ServerAuditUtil::ServerAuditUtil()
-: disabled(false)
+    : _disabled(false)
 {
     set("is_admin", "ok");
     set("certwarning", "ok");
@@ -20,14 +20,16 @@ ServerAuditUtil::ServerAuditUtil()
 
 std::string ServerAuditUtil::getResultsJSON() const
 {
+    std::lock_guard<std::mutex> lock(_mutex);
+
     std::string result = "{\"serverAudit\": [";
 
-    bool bFirst = true;
-    for (auto entry : entries)
+    bool isFirst = true;
+    for (auto entry : _entries)
     {
-        if (!bFirst)
+        if (!isFirst)
             result += ", ";
-        bFirst = false;
+        isFirst = false;
 
         result += "{\"code\": \"" + entry.first + "\", \"status\": \"" + entry.second + "\"}";
     }
@@ -38,8 +40,9 @@ std::string ServerAuditUtil::getResultsJSON() const
 
 void ServerAuditUtil::set(std::string code, std::string status)
 {
-    std::lock_guard<std::mutex> lock(mapMutex);
-    entries[code] = std::move(status);
+    std::lock_guard<std::mutex> lock(_mutex);
+
+    _entries[code] = std::move(status);
 }
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/ServerAuditUtil.hpp
+++ b/wsd/ServerAuditUtil.hpp
@@ -19,11 +19,12 @@
  */
 class ServerAuditUtil
 {
-    // <code, status>
-    std::map<std::string, std::string> entries;
-    std::mutex mapMutex;
+    mutable std::mutex _mutex;
 
-    bool disabled;
+    // <code, status>
+    std::map<std::string, std::string> _entries;
+
+    bool _disabled;
 
 public:
     ServerAuditUtil();
@@ -32,8 +33,8 @@ public:
 
     void set(std::string code, std::string status);
 
-    void disable() { disabled = true; }
-    bool isDisabled() const { return disabled; }
+    void disable() { _disabled = true; }
+    bool isDisabled() const { return _disabled; }
 };
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */


### PR DESCRIPTION
  [ websrv_poll ] SIG   Fatal signal received: SIGABRT code: 18446744073709551610 for address: 0x730000696e
  Backtrace 26990 - wsd 24.04.4.4snapshot 07bc101:
    __GI_abort                                     glibc-2.27/stdlib/abort.c:81
    __GI___pthread_mutex_lock                      glibc-2.27/nptl/../nptl/pthread_mutex_lock.c:67
    ServerAuditUtil::set(std::string, std::string) /usr/include/c++/12/bits/std_mutex.h:103
    SocketDisposition::execute()                   /usr/include/c++/12/bits/std_function.h:591
    SocketPoll::poll(long)                         /usr/include/c++/12/bits/shared_ptr_base.h:1070

  Also cleanup member naming to match the COOL standard.


Change-Id: I4fd6f4d57c3cbfe1edf7121895e5dab7e13fa4fc


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

