### PR TITLE
calc: fix edit and remove hypelink outside of edit mode

### DIFF
--- a/browser/src/canvas/sections/URLPopUpSection.ts
+++ b/browser/src/canvas/sections/URLPopUpSection.ts
@@ -74,29 +74,30 @@ class URLPopUpSection extends HTMLObjectSection {
 				app.map.sendUnoCommand('.uno:JumpToMark?Bookmark:string=' + encodeURIComponent(this.sectionProperties.url.substring(1)));
 		};
 
+		var params: any;
+		if (linkPosition) {
+			params = {
+				PositionX: {
+					type: 'long',
+					value: linkPosition.x
+				},
+				PositionY: {
+					type: 'long',
+					value: linkPosition.y
+				}
+			};
+		}
+
 		document.getElementById(this.copyButtonId).onclick = () => {
-			var params;
-			if (linkPosition) {
-				params = {
-					PositionX: {
-						type: 'long',
-						value: linkPosition.x
-					},
-					PositionY: {
-						type: 'long',
-						value: linkPosition.y
-					}
-				};
-			}
 			app.map.sendUnoCommand('.uno:CopyHyperlinkLocation', params);
 		};
 
 		document.getElementById(this.editButtonId).onclick = () => {
-			app.map.sendUnoCommand('.uno:EditHyperlink');
+			app.map.sendUnoCommand('.uno:EditHyperlink', params);
 		};
 
 		document.getElementById(this.removeButtonId).onclick = () => {
-			app.map.sendUnoCommand('.uno:RemoveHyperlink');
+			app.map.sendUnoCommand('.uno:RemoveHyperlink', params);
 		};
 	}
 


### PR DESCRIPTION
Right now .uno:EditHyperlink and .uno:RemoveHyperlink only work on
edit mode or inside a draw object, but LOK_CALLBACK_HYPERLINK_CLICKED
is dispatched outside of edit mode.

Since there is no text cursor, the position of the hyperlink is
needed to discriminate the correct field.

Signed-off-by: Jaume Pujantell <jaume.pujantell@collabora.com>
Change-Id: I8499b430d5e62b904caba5bb5c7c34e784a8b850
