### PR TITLE
Fix branding of COOL Lite when key is not present or expired

### DIFF
--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -1263,8 +1263,8 @@ FileServerRequestHandler::ResourceAccessDetails FileServerRequestHandler::prepro
         SupportKey key(keyString);
         if (!key.verify() || key.validDaysRemaining() <= 0)
         {
-            brandCSS = Poco::format(linkCSS, responseRoot, SUPPORT_KEY_BRANDING_UNSUPPORTED);
-            brandJS = Poco::format(scriptJS, responseRoot, SUPPORT_KEY_BRANDING_UNSUPPORTED);
+            brandCSS = Poco::format(linkCSS, responseRoot, std::string(SUPPORT_KEY_BRANDING_UNSUPPORTED));
+            brandJS = Poco::format(scriptJS, responseRoot, std::string(SUPPORT_KEY_BRANDING_UNSUPPORTED));
         }
     }
 


### PR DESCRIPTION
regression from 246e87fea21d6121fd4bd2daeff8a4f92082477e 
we've got [ERRFMT].js and [ERRFMT].css

Change-Id: Ic59257fedb6d9ae6712f7f9ff16022c01f70112a
