### PR TITLE
default make run to use mount namespaces

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -478,12 +478,6 @@ SYSTEM_STAMP = @SYSTEMPLATE_PATH@/system_stamp
 CAPABILITIES = $(if @ENABLE_SETCAP@,true,false)
 RUN_GDB = $(if $(GDB_FRONTEND),$(GDB_FRONTEND),gdb --tui --args)
 
-if ENABLE_SETCAP
-SET_CAPS_COMMAND=sudo @SETCAP@ cap_fowner,cap_chown,cap_sys_chroot=ep coolforkit && sudo @SETCAP@ cap_sys_admin=ep coolmount
-else
-SET_CAPS_COMMAND=echo "Skipping capability setting"
-endif
-
 if ENABLE_LIBFUZZER
 CLEANUP_DEPS=
 else
@@ -493,7 +487,6 @@ endif
 # Build coolwsd and coolmount first, so we can cleanup before updating
 # the systemplate directory, which we can't rm if it's mounted.
 $(SYSTEM_STAMP): ${top_srcdir}/coolwsd-systemplate-setup $(CLEANUP_DEPS)
-	$(SET_CAPS_COMMAND)
 	$(CLEANUP_COMMAND)
 	if test "z@SYSTEMPLATE_PATH@" != "z"; then chmod u+w -R --silent "@SYSTEMPLATE_PATH@" ; rm -rf "@SYSTEMPLATE_PATH@" && \
 	${top_srcdir}/coolwsd-systemplate-setup "@SYSTEMPLATE_PATH@" "@LO_PATH@" && touch $@; fi
@@ -541,7 +534,8 @@ COMMON_PARAMS = \
 	--o:ssl.cert_file_path="$(abs_top_srcdir)/etc/cert.pem" \
 	--o:ssl.key_file_path="$(abs_top_srcdir)/etc/key.pem" \
 	--o:ssl.ca_file_path="$(abs_top_srcdir)/etc/ca-chain.cert.pem" \
-	--o:admin_console.username=admin --o:admin_console.password=admin
+	--o:admin_console.username=admin --o:admin_console.password=admin \
+	--o:mount_namespaces[@default]=true
 
 run: setup-wsd
 	./coolwsd $(COMMON_PARAMS) \
@@ -636,7 +630,6 @@ endif
 # capabilities won't survive packaging anyway. Instead, handle it when
 # installing the RPM or Debian package.
 all-local: $(ALL_LOCAL_DEPS) @JAILS_PATH@ $(SYSTEM_STAMP)
-	$(SET_CAPS_COMMAND)
 	@$(abs_top_srcdir)/scripts/refresh-git-hooks
 
 # just run the build without any tests

--- a/configure.ac
+++ b/configure.ac
@@ -84,11 +84,6 @@ fi
 
 AC_LANG_PUSH([C++])
 
-AS_IF([test `uname -s` = Linux -a "$host_os" != "emscripten"],
-      [AC_PATH_PROG([SETCAP], setcap,[],[/bin:/usr/bin:/sbin:/usr/sbin])]
-       AS_IF([test -z "$SETCAP"],
-       [AC_MSG_ERROR([The setcap command is needed. It might be in a package called libcap-progs.])]))
-
 # check for python modules
 for MODULE in lxml polib; do
     AC_MSG_CHECKING([for ${MODULE} for python3])

--- a/cypress_test/Makefile.am
+++ b/cypress_test/Makefile.am
@@ -207,6 +207,7 @@ define start_coolwsd_instance
 			--o:user_interface.mode=$(USER_INTERFACE) \
 			--o:accessibility.enable=$(A11Y_ENABLE) \
 			--o:security.enable_macros_execution=true \
+			--o:mount_namespaces[@default]=true \
 			$(if $(SHORT_IDLE),--o:per_view.out_of_focus_timeout_secs=1) \
 			$(if $(SHORT_IDLE),--o:per_view.idle_timeout_secs=7) \
 			--port=$(FREE_PORT) \

--- a/test/run_unit.sh.in
+++ b/test/run_unit.sh.in
@@ -89,6 +89,7 @@ if ${trace} \
 				   --o:ssl.ca_file_path="${abs_top_builddir}/etc/ca-chain.cert.pem" \
 				   --o:admin_console.username=admin --o:admin_console.password=admin \
 				   --o:storage.ssl.enable=false \
+				   --o:mount_namespaces[@default]=true \
 				   --o:experimental_features=true \
 				   --unattended \
 				   --unitlib="${abs_top_builddir}/test/.libs/$tst.so" 2> "$tst_log" 1>&2; then
@@ -114,6 +115,7 @@ else
 	echo "         --o:ssl.ca_file_path=\"${abs_top_builddir}/etc/ca-chain.cert.pem\" \\"
 	echo "         --o:admin_console.username=admin --o:admin_console.password=admin \\"
 	echo "         --o:storage.ssl.enable=false \\"
+	echo "         --o:mount_namespaces[@default]=true \\"
 	echo "         --unattended \\"
 	echo "         --unitlib=\"${abs_top_builddir}/test/.libs/$tst.so\""
 	echo ""

--- a/wsd/README.md
+++ b/wsd/README.md
@@ -39,10 +39,6 @@ When building from a tarball less magic is needed.
 
 Run 'make check' after each commit.
 
-Note that the coolforkit program needs the CAP_SYS_CHROOT capability,
-thus you will be asked the root password when running make as it
-invokes sudo to run /sbin/setcap.
-
 If you have self-built Poco, add the following to ./configure:
 
     --with-poco-includes=<POCOINST>/include --with-poco-libs=<POCOINST>/lib


### PR DESCRIPTION
which don't use coolmount and coolforkit, but instead use linux mount spaces with coolforkitns instead.

That doesn't need sudo, so drop automatically calling that in make to setcaps on coolmount + coolforkit for an easier developer experience.


Change-Id: I6f8ddaf1053d084ec8c1f22adf830a677e80cadc


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

