### PR TITLE
Accessibility: Add ARIA roles for buttons

### DIFF
--- a/browser/html/cool.html.m4
+++ b/browser/html/cool.html.m4
@@ -216,7 +216,7 @@ m4_ifelse(MOBILEAPP,[true],
       </div>
      </nav>
 
-     <div id="toolbar-wrapper">
+     <div id="toolbar-wrapper" role="toolbar" aria-orientation="horizontal">
         <div id="toolbar-row" class="toolbar-row">
           <div id="toolbar-logo"></div>
           <div id="toolbar-mobile-back" class="editmode-off"></div>

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2287,6 +2287,10 @@ L.Control.JSDialogBuilder = L.Control.extend({
 
 			button = L.DomUtil.create('button', 'ui-content unobutton', div);
 			button.id = buttonId;
+
+			if(data.text)
+				button.setAttribute('aria-label', data.text);
+
 			if (!data.accessKey)
 				builder._setAccessKey(button, builder._getAccessKeyFromText(data.text));
 			else


### PR DESCRIPTION
Changes are based on below points to improve accessibility

- The element that serves as the toolbar container has role toolbar.
- If the toolbar has a visible label, it is referenced by aria-labelledby on the toolbar element. Otherwise, the toolbar element has a label provided by aria-label.
- If the controls are arranged vertically, the toolbar element has aria-orientation set to vertical. The default orientation is horizontal.

Signed-off-by: Darshan-upadhyay1110 <darshan.upadhyay@collabora.com>

Change-Id: I38f234461d4bf7982eec01ffe866c390256f50a0