### PR TITLE
calc: fix edit and remove hypelink outside of edit mode

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -2681,21 +2681,21 @@ L.CanvasTileLayer = L.Layer.extend({
 			else
 				map_.sendUnoCommand('.uno:JumpToMark?Bookmark:string=' + encodeURIComponent(url.substring(1)));
 		});
+		var params;
+		if (linkPosition) {
+			params = {
+				PositionX: {
+					type: 'long',
+					value: linkPosition.x
+				},
+				PositionY: {
+					type: 'long',
+					value: linkPosition.y
+				}
+			};
+		}
 		this._setupClickFuncForId('hyperlink-pop-up-copy', function () {
 			if (app.file.permission !== 'readonly') {
-				var params;
-				if (linkPosition) {
-					params = {
-						PositionX: {
-							type: 'long',
-							value: linkPosition.x
-						},
-						PositionY: {
-							type: 'long',
-							value: linkPosition.y
-						}
-					};
-				}
 				map_.sendUnoCommand('.uno:CopyHyperlinkLocation', params);
 			}
 			else {
@@ -2706,10 +2706,10 @@ L.CanvasTileLayer = L.Layer.extend({
 
 		if (app.file.permission !== 'readonly') {
 			this._setupClickFuncForId('hyperlink-pop-up-edit', function () {
-				map_.sendUnoCommand('.uno:EditHyperlink');
+				map_.sendUnoCommand('.uno:EditHyperlink', params);
 			});
 			this._setupClickFuncForId('hyperlink-pop-up-remove', function () {
-				map_.sendUnoCommand('.uno:RemoveHyperlink');
+				map_.sendUnoCommand('.uno:RemoveHyperlink', params);
 			});
 		}
 


### PR DESCRIPTION
Right now .uno:EditHyperlink and .uno:RemoveHyperlink only work on
edit mode or inside a draw object, but LOK_CALLBACK_HYPERLINK_CLICKED
is dispatched outside of edit mode.

Since there is no text cursor, the position of the hyperlink is
needed to discriminate the correct field.

Signed-off-by: Jaume Pujantell <jaume.pujantell@collabora.com>
Change-Id: I6ce3c21c60ea85dbe2e6e2523710ae1dcdff78a6
