### PR TITLE
following: correctly turn off

### DIFF
--- a/browser/src/control/Control.UserList.ts
+++ b/browser/src/control/Control.UserList.ts
@@ -124,19 +124,21 @@ class UserList extends L.Control {
 	followUser(viewId: number) {
 		const myViewId = this.map._docLayer._viewId;
 		const followingViewId = app.getFollowedViewId();
-
-		const follow = viewId !== followingViewId;
+		const followMyself = viewId === followingViewId;
 
 		app.setFollowingUser(viewId);
 
-		if (!follow) {
+		if (followMyself) {
 			this.map._goToViewId(myViewId);
 			this.map._setFollowing(true, myViewId);
 			this.renderAll();
 			return;
-		} else if (followingViewId !== -1) {
+		} else if (viewId !== -1) {
 			this.map._goToViewId(viewId);
 			this.map._setFollowing(true, viewId);
+		} else {
+			this.unfollowAll();
+			this.map._setFollowing(false, -1);
 		}
 
 		this.selectUser(viewId);


### PR DESCRIPTION
When user used "following user XYZ" chip to unfollow someone, then not all properties of the state were set and the next try of following someone was not jumping th the cursor.

This fixes that without much change in the code. As a followup I will try to reduce the complexity by keeping single state for the following. Currently we duplicate it in the UserList component and docstate

