### PR TITLE
fix: animate zoomreset to remove traces of previous document zoom level

### DIFF
--- a/browser/src/control/Control.StatusBar.js
+++ b/browser/src/control/Control.StatusBar.js
@@ -212,7 +212,7 @@ class StatusBar extends JSDialog.Toolbar {
 			{ id: 'zoom100', text: '100', scale: 10},
 			{ id: 'zoom120', text: '120', scale: 11},
 			{ id: 'zoom150', text: '150', scale: 12},
-			{ id: 'zoom175', text: '175', scale: 13},
+			{ id: 'zoom170', text: '170', scale: 13},
 			{ id: 'zoom200', text: '200', scale: 14},
 			{ id: 'zoom235', text: '235', scale: 15},
 			{ id: 'zoom280', text: '280', scale: 16},

--- a/browser/src/docdispatcher.ts
+++ b/browser/src/docdispatcher.ts
@@ -173,7 +173,7 @@ class Dispatcher {
 			app.map.zoomOut(1, null, true /* animate? */);
 		};
 		this.actionsMap['zoomreset'] = () => {
-			app.map.setZoom(app.map.options.zoom);
+			app.map.setZoom(app.map.options.zoom, null, true);
 		};
 
 		this.actionsMap['searchprev'] = () => {


### PR DESCRIPTION
- Fix: animate "Reset Zoom" to remove traces of previous document zoom level
- sync zoom options


Change-Id: I1dc7847e21ab3cb56b9ec01a1a8f577bb26366d1


* Resolves: #7214
* Target version: master 

### Checklist

- [X] Code is properly formatted
- [X] All commits have Change-Id
- [ ] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

