### PR TITLE
fix EOL issue in transform Document Structure

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -395,17 +395,11 @@ bool ChildSession::_handleInput(const char *buffer, int length)
             LOG_TRC("Transformation JSON was not provided.");
             return false;
         }
-
-        std::string transformQueryJSON;
-        Poco::URI::decode(encodedTransformQueryJSON, transformQueryJSON);
-
-        // we put JSON inside JSON - avoid plain quote characters
-        std::string encodedJSON = regex_replace(transformQueryJSON, std::regex("\""), "\\\"");
-
+        // Send encoded string, this way it survive until it arrive at core.
         const std::string arguments = "{"
             "\"DataJson\":{"
                 "\"type\":\"string\","
-                "\"value\":\"" + encodedJSON + "\""
+                "\"value\":\"" + encodedTransformQueryJSON + "\""
             "}}";
 
         getLOKitDocument()->postUnoCommand(command.c_str(), arguments.c_str(), false);


### PR DESCRIPTION
Send encoded JSON string instead of decoded.
This way it will not have special characters, and it will reach the core side even with a \n or \r inside ot it.

This way we can set multi-line text to a contentControl.


Change-Id: I8b32aeef522faf7f4597405bec9bbb37b99d53cf


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

