### PR TITLE
fix(hooks): Replace git diff-index call

### DIFF
--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -40,7 +40,7 @@ sub check_whitespaces($)
             print STDERR "$filename:$lineno:$line\n";
         }
     }
-    open( FILES, "git-diff-index -p -M --cached $h |" ) ||  die "Cannot run git diff-index.";
+    open( FILES, "git diff-index -p -M --cached $h |" ) ||  die "Cannot run git diff-index.";
     while (<FILES>)
     {
         if (m|^diff --git a/(.*) b/\1$|)
@@ -169,7 +169,7 @@ EOM
 }
 
 # Block large files.
-open( FILES, "git diff --cached --name-only --diff-filter=A -z $against |" ) ||  die "Cannot run git diff-index.";
+open( FILES, "git diff --cached --name-only --diff-filter=A -z $against |" ) ||  die "Cannot run git diff.";
 while (<FILES>)
 {
     if (/\.ui$/) # .ui files can get large


### PR DESCRIPTION
git-diff-index isn't always provided separately to the main git binary, so we can't necessarily use that as the command. We should always be able to use `git diff-index`, as the git binary will find files named `git-foo` when you run command `git foo`, so this will work whether the binary is separate or not


Change-Id: Id705855eedfd7e12c0706a9c7638e0bfb911b3fd

* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

