### PR TITLE
wsd: avoid nested startActivity()

### DIFF
--- a/fuzzer/data/crash-b496d62466ab907e19b8418d1dde11855a4ebc50
+++ b/fuzzer/data/crash-b496d62466ab907e19b8418d1dde11855a4ebc50
@@ -1,0 +1,13 @@
+load url=
+tildwwtii 
+8leperŒ‹esurl=~outlinestwitch_rprerŒ‹e 0
+ve=0
+switch_request online
+a
+t
+tii 
+8leperŒ‹esurl=~outlinestwitch_rprerŒ‹e 0
+ve=0
+switch_request online
+a
+t

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -4650,6 +4650,12 @@ void DocumentBroker::startSwitchingToOnline()
 {
     LOG_DBG("Starting switching to Online mode");
 
+    if (_docState.activity() != DocumentState::Activity::None)
+    {
+        // It's not safe to call startActivity() while executing another.
+        return;
+    }
+
     // Transition.
     if (!startActivity(DocumentState::Activity::SwitchingToOnline))
     {


### PR DESCRIPTION
Avoids this assertion failure:

    #7 0x7f9fbef8fcf1 in __assert_fail (/lib64/libc.so.6+0x42cf1) (BuildId: cfb059a57e69ac95d5dadab831626b3bd48a4309)
    #8 0x55d44ed78891 in DocumentBroker::startActivity(DocumentBroker::DocumentState::Activity) /home/vmiklos/git/collaboraonline/online-fuzz/./wsd/DocumentBroker.hpp:1550:13
    #9 0x55d44ee0884f in DocumentBroker::startSwitchingToOnline() /home/vmiklos/git/collaboraonline/online-fuzz/wsd/DocumentBroker.cpp:4654:10
    #10 0x55d44f05760a in ClientSession::_handleInput(char const*, int) /home/vmiklos/git/collaboraonline/online-fuzz/wsd/ClientSession.cpp:1168:20

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Iedc515b90c0e4f43dc14f0d998ba5c756fddd10d
