### PR TITLE
Private/caolan/usermount9

### DIFF
--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -2007,11 +2007,6 @@ void COOLWSD::setupChildRoot(const bool UseMountNamespaces)
     IsBindMountingEnabled = (status & (1 << 1));
     LOG_INF("Using Bind Mounting: " << IsBindMountingEnabled);
     EnableMountNamespaces = (status & (1 << 0));
-    if (EnableMountNamespaces && !IsBindMountingEnabled)
-    {
-        LOG_ERR("MountNamespaces possible, but BindMount + MountNamespace fails, disabling");
-        EnableMountNamespaces = false;
-    }
     LOG_INF("Using Mount Namespaces: " << EnableMountNamespaces);
     if (IsBindMountingEnabled)
         JailUtil::enableBindMounting();


### PR DESCRIPTION
### Summary

Allow Namespace use even if BindMounting failed. In advance of potential fix for that problem to test standalone that a Namespace + Failed Bindmount works.

### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

