### PR TITLE
undefined docLayer seen on _onWheelScroll

### DIFF
--- a/browser/src/map/handler/Map.Scroll.js
+++ b/browser/src/map/handler/Map.Scroll.js
@@ -44,9 +44,9 @@ L.Map.Scroll = L.Handler.extend({
 		var mousePos = this._map.mouseEventToLatLng(e);
 
 		var docLayer = this._map._docLayer;
-		if (docLayer.isCalc()) {
+		if (docLayer && docLayer.isCalc()) {
 			this._zoomCenter = mousePos;
-		} else if (docLayer.isWriter()) {
+		} else if (docLayer && docLayer.isWriter()) {
 			// Preserve the y coordinate position of the document where the mouse is.
 			// Also preserve x coordinate if the current view does not have margins.
 			//  If view has margins, we cannot center w.r.t arbitary position in the page because


### PR DESCRIPTION
wsd-308160-312471 2024-07-17 08:14:44.302140 +0000 [ docbroker_031 ] ERR  ToClient-7e2: jserror {
  "userAgent": "mozilla/5.0 (x11; linux x86_64; rv:127.0) gecko/20100101 firefox/127.0",
  "vendor": "",
  "message": "TypeError: docLayer is undefined",
  "source": ".../browser/.../bundle.js",
  "line": 20766,
  "column": 37
}
docLayer is undefined
L.Map.Scroll<._onWheelScroll<@.../browser/.../bundle.js:20766:37


Change-Id: Ibaa7aef4051977e708b7dad5396ac0564b06a5af


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

