### PR TITLE
this._marker.closePopup not a function

### DIFF
--- a/browser/src/layer/marker/Marker.Drag.js
+++ b/browser/src/layer/marker/Marker.Drag.js
@@ -60,7 +60,6 @@ L.Handler.MarkerDrag = L.Handler.extend({
 
 	_onDragStart: function (e) {
 		this._marker
-		    .closePopup()
 		    .fire('movestart', e)
 		    .fire('dragstart', e);
 	},


### PR DESCRIPTION
this can be reproduced by inserting a table in writer, and then clicking and dragging one of the "marker" indicators above the columns

wsd-308187-308314 2024-07-17 06:59:38.909586 +0000 [ websrv_poll ] ERR  jserror {
  "userAgent": "mozilla/5.0 (x11; linux x86_64; rv:109.0) gecko/20100101 firefox/115.0",
  "vendor": "",
  "message": "TypeError: this._marker.closePopup is not a function",
  "source": "https://.../browser/.../bundle.js",
  "line": 21863,
  "column": 88
}
this._marker.closePopup is not a function
_onDragStart@https://.../browser/.../bundle.js:21863:88

possibly since:

commit 9932ad7516f55c46a0713231fe1f481bebdba378
AuthorDate: Tue Jul 9 18:41:52 2024 +0300

    Remove unused files, variables and functions.


Change-Id: I34b21713b980beba0e1123a9738c870334c10354


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

