### PR TITLE
fix: Reorder resize event listeners

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -794,7 +794,6 @@ L.CanvasTileLayer = L.Layer.extend({
 			this._map.on('movestart', this._painter.startUpdates, this._painter);
 			this._map.on('moveend', this._painter.stopUpdates, this._painter);
 		}
-		this._map.on('resize', this._syncTileContainerSize, this);
 		this._map.on('zoomend', this._painter.update, this._painter);
 		this._map.on('splitposchanged', this._painter.update, this._painter);
 		this._map.on('sheetgeometrychanged', this._painter.update, this._painter);
@@ -4388,6 +4387,7 @@ L.CanvasTileLayer = L.Layer.extend({
 			// always true since autoFitWidth is never set
 			map.on('resize', this._fitWidthZoom, this);
 		}
+		this._map.on('resize', this._syncTileContainerSize, this);
 		// Retrieve the initial cell cursor position (as LOK only sends us an
 		// updated cell cursor when the selected cell is changed and not the initial
 		// cell).


### PR DESCRIPTION
As event listeners are called in the order they are registered, and both the resize listener I have moved and the one registered directly above its new location call this._update, this._update is called *before* the second event listener (whichever it is) gets a chance to execute. In the old case, this causes us to request tiles for a different view level, which at the start of the program requests tiles for a default position and zoom level. In Android this triggers a core bug that sends us blank tiles. These tiles are then later treated as valid for the section and lead to a blank render.

Got all that? Good, because that confusion you feel is exactly why this fix isn't a particularly good one! This "fix" is hacky, hard to understand, and does it all through something I can reasonably describe as "spooky action at a distance". The direct problem I've been working on is fixed, but other nasty effects as well as rendering issues in core are not.  Additionally, this commit has the downside of introducing a commit that's unfortunately challenging to understand, and possibly quite fragile if people don't come across it before changing stuff around here in future

Finally, I also don't know that I'm not missing something that necessitates a different order. It's entirely possible that I have

The structure of this makes me think somewhat of a DAG - a "directed acyclic graph" - where we have various dependencies from all over the place and need to execute them in an order that doesn't end up munging them... maybe that could be a nice solution to this part of the puzzle

Sadly, for now, this appears to be an improvement with far less effort


Change-Id: I05870f65a822a66e963407fcf461f18f5748ad1c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

