### PR TITLE
Fix failure to load documents in iOS app

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1162,11 +1162,12 @@ bool DocumentBroker::doDownloadDocument(const Authorization& auth,
         LOG_WRN("Failed to process plugins on file [" << localPath << ']');
         return false;
     }
+
+    const std::string localFilePath = Poco::Path(FileUtil::buildLocalPathToJail(COOLWSD::EnableMountNamespaces, getJailRoot(), localPath)).toString();
+#else  //!MOBILEAPP
+    const std::string localFilePath = Poco::Path(getJailRoot(), localPath).toString();
 #endif //!MOBILEAPP
 
-    const std::string localFilePath = Poco::Path(FileUtil::buildLocalPathToJail(COOLWSD::EnableMountNamespaces,
-                                                                                getJailRoot(),
-                                                                                localPath)).toString();
     std::ifstream istr(localFilePath, std::ios::binary);
     Poco::SHA1Engine sha1;
     Poco::DigestOutputStream dos(sha1);


### PR DESCRIPTION
The iOS app (and presumably the Android app) do not have jails. Instead, they read and write files directly from the user's local file system.