### PR TITLE
README: Fix links to other READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,14 +66,14 @@ This project has several components:
 ## Further recommended reading with build details
 
 Please consult the README files in the component's directory for more details:
-- **[wsd/README](wsd)**
-- **[browser/README](browser)**
+- **[wsd/README.md](wsd/README.md)**
+- **[browser/README](browser/README)**
 
 ## iOS and Android apps
 
 See the corresponding READMEs:
-* **[ios/README](ios)**
-* **[android/README](android)**
+* **[ios/README](ios/README)**
+* **[android/README](android/README)**
 
 ## GitPod
 


### PR DESCRIPTION
* Target version: master 

### Summary

In the top-level README.md, fix links to
other READMEs:

* adjust the reference to the wsd one to include the `.md` suffix as the file was renamed in commit 79b667a3317335f04f4829688b7bd31c6b555d98

* Use the path to the actual file for the URL/target, not just to the parent directory, as just browsing to the containing directory when clicking on the link text showing a specific file name is rather unexpected

### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

I actually tried the build steps above, but they failed. I tried to use both, COOL master and LibreOffice master, which fails with

```
make[2]: Entering directory '/home/michi/development/git/collabora-online'
  CXX      kit/Kit.o
kit/Kit.cpp: In member function ‘void Document::startThreads()’:
kit/Kit.cpp:1342:17: error: ‘using std::__shared_ptr_access<lok::Office, __gnu_cxx::_S_atomic, false, false>::element_type = class lok::Office’ {aka ‘class lok::Office’} has no member named ‘startThreads’
 1342 |     getLOKit()->startThreads();
      |                 ^~~~~~~~~~~~
make[2]: *** [Makefile:3384: kit/Kit.o] Error 1
make[2]: Leaving directory '/home/michi/development/git/collabora-online'
make[1]: *** [Makefile:7281: all-recursive] Error 1
make[1]: Leaving directory '/home/michi/development/git/collabora-online'
make: *** [Makefile:2026: all] Error 2

```
, but I'm confident that this is unrelated to this README change.

From a quick glance, the reason might rather be that LibreOffice core git master doesn't yet contain relevant commits from Collabora branches, like https://git.libreoffice.org/core/commit/66de5312607e93b985ca5934e851718453a24693.
