### PR TITLE
test: Fix '-Werror=unused-variable' for non-debug build

### DIFF
--- a/test/testlog.hpp
+++ b/test/testlog.hpp
@@ -101,6 +101,10 @@ inline void tstLog(const std::ostringstream& stream) { writeTestLog(stream.str()
 #define TST_LOG_NAME(NAME, X)                                                                      \
     do                                                                                             \
     {                                                                                              \
+        /* silence '-Werror=unused-variable' */                                                    \
+        (void)NAME;                                                                                \
+        std::stringstream dummyStringstream;                                                       \
+        dummyStringstream << X;                                                                    \
     } while (0)
 #endif // !ENABLE_DEBUG
 


### PR DESCRIPTION
* Target version: master 

### Summary

Add (dummy) uses of the `NAME` and `X` params to the non-debug-build version of the `TST_LOG_NAME` macro.

This fixes build failures like the following ones seen in a GCC 13 build without the `--enable-debug` configure option:

    WopiProofTests.cpp: In member function ‘void WopiProofTests::testCapiBlob()’:
    WopiProofTests.cpp:63:20: error: unused variable ‘testname’ [-Werror=unused-variable]
       63 |     constexpr auto testname = __func__;
          |                    ^~~~~~~~
    KitQueueTests.cpp: In member function ‘void KitQueueTests::testKitQueuePriority()’:
    KitQueueTests.cpp:77:20: error: unused variable ‘testname’ [-Werror=unused-variable]
       77 |     constexpr auto testname = __func__;
          |                    ^~~~~~~~
    KitQueueTests.cpp: In member function ‘void KitQueueTests::testTileCombinedRendering()’:
    KitQueueTests.cpp:125:20: error: unused variable ‘testname’ [-Werror=unused-variable]
      125 |     constexpr auto testname = __func__;
          |                    ^~~~~~~~
    KitQueueTests.cpp: In member function ‘void KitQueueTests::testTileRecombining()’:
    KitQueueTests.cpp:159:20: error: unused variable ‘testname’ [-Werror=unused-variable]
      159 |     constexpr auto testname = __func__;


### Checklist

- [x] Code is properly formatted
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

(`make check` doesn't work without `--enable-debug`  and `make run` would apparently require more work to actually run in my current setup, but that's unrelated to this PR.)