### PR TITLE
Fix failure to load documents in iOS app

### DIFF
--- a/ios/Mobile.xcodeproj/xcshareddata/xcschemes/Mobile.xcscheme
+++ b/ios/Mobile.xcodeproj/xcshareddata/xcschemes/Mobile.xcscheme
@@ -53,7 +53,7 @@
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "COOL_LOGLEVEL"
-            value = "trace"
+            value = "debug"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>

--- a/ios/Mobile/CODocument.mm
+++ b/ios/Mobile/CODocument.mm
@@ -101,7 +101,7 @@ static std::atomic<unsigned> appDocIdCounter(1);
 }
 
 - (void)send2JS:(const char *)buffer length:(int)length {
-    LOG_TRC("To JS: " << COOLProtocol::getAbbreviatedMessage(buffer, length).c_str());
+    LOG_DBG("To JS: " << COOLProtocol::getAbbreviatedMessage(buffer, length).c_str());
 
     const unsigned char *ubufp = (const unsigned char *)buffer;
     std::vector<char> data;

--- a/ios/Mobile/DocumentViewController.mm
+++ b/ios/Mobile/DocumentViewController.mm
@@ -302,7 +302,7 @@ static IMP standardImpOfInputAccessoryView = nil;
         if (subBody.length < ((NSString*)message.body).length)
             subBody = [subBody stringByAppendingString:@"..."];
 
-        LOG_TRC("To Online: " << [subBody UTF8String]);
+        LOG_DBG("To Online: " << [subBody UTF8String]);
 
 #if 0
         static int n = 0;

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -2873,8 +2873,12 @@ bool DocumentBroker::sendUnoSave(const std::shared_ptr<ClientSession>& session,
 
 std::string DocumentBroker::getJailRoot() const
 {
+#if !MOBILEAPP
     assert(!_jailId.empty());
     return Poco::Path(COOLWSD::ChildRoot, _jailId).toString();
+#else
+    return std::string();
+#endif
 }
 
 std::size_t DocumentBroker::addSession(const std::shared_ptr<ClientSession>& session,


### PR DESCRIPTION
The iOS app (and presumably the Android app) do not have jails. Instead, they read and write files directly from the user's local file system.

Also, running the iOS in trace mode is nearly unusable so move the key "To JS" and "To Online" iOS messages to LOG_DBG and run the app with "debug" instead of "trace" by default.
