### PR TITLE
Set the properties of CellCursor so it isn't drawn over the Calc head…

### DIFF
--- a/browser/src/canvas/sections/CellCursorSection.ts
+++ b/browser/src/canvas/sections/CellCursorSection.ts
@@ -11,9 +11,9 @@
 
 class CellCursorSection extends CanvasSectionObject {
 	name: string = "OwnCellCursor";
-	processingOrder: number = L.CSections.AutoFillMarker.processingOrder;
-	drawingOrder: number = L.CSections.AutoFillMarker.drawingOrder;
-	zIndex: number = L.CSections.AutoFillMarker.zIndex;
+    zIndex: number = L.CSections.ColumnHeader.zIndex;
+    drawingOrder: number = L.CSections.OtherViewCellCursor.drawingOrder;
+    processingOrder: number = L.CSections.OtherViewCellCursor.processingOrder;
 
 	constructor (color: string, weight: number, viewId: number) {
         super();


### PR DESCRIPTION
…ers.

Change-Id: Ifff79fc47849687151098914a3c78a22ffcf9037


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

