### PR TITLE
Fix canvas margin when ruler is toggled on

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -42,6 +42,7 @@
 
 	/* Ruler */
 	--ruler-height: 20px;
+	--canvas-container-y: var(--ruler-height);
 }
 .focus-hidden:focus {
 	outline: none;

--- a/browser/css/leaflet.css
+++ b/browser/css/leaflet.css
@@ -882,7 +882,7 @@ input.clipboard {
 	margin: 0px; /*Ruler styling*/
 }
 .cool-ruler {
-	background-color: var(--color-main-background);
+	background-color: transparent;
 	height: var(--ruler-height);
 	width: 100vw;
 	margin: 0px !important;
@@ -1058,13 +1058,18 @@ input.clipboard {
 .leaflet-canvas-container {
 	position: absolute;
 	left: 0;
-	top: 0;
+	top: var(--canvas-container-y);
 	bottom: 0;
 	right: 0;
 	z-index: 9;
 	user-select: none;
 	-webkit-touch-callout: none !important;
 	-webkit-user-select: none !important;
+}
+
+.spreadsheet-doctype #canvas-container {
+	/* For Calc never account for ruler */
+	top: 0;
 }
 
 .leaflet-pane-splitter {

--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -451,9 +451,11 @@ L.Control.Notebookbar = L.Control.extend({
 	onRulerChange: function() {
 		if (this.map.uiManager.isRulerVisible()) {
 			$('#showruler').addClass('selected');
+			document.documentElement.style.setProperty("--canvas-container-y", "var(--ruler-height)");
 		}
 		else {
 			$('#showruler').removeClass('selected');
+			document.documentElement.style.setProperty("--canvas-container-y", "0");
 		}
 	},
 

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -830,10 +830,14 @@ L.Control.UIManager = L.Control.extend({
 	},
 
 	toggleRuler: function() {
-		if (this.isRulerVisible())
+		if (this.isRulerVisible()){
 			this.hideRuler();
-		else
+			document.documentElement.style.setProperty("--canvas-container-y", "0");
+		}
+		else {
 			this.showRuler();
+			document.documentElement.style.setProperty("--canvas-container-y", "var(--ruler-height)");
+		}
 	},
 
 	isRulerVisible: function() {


### PR DESCRIPTION
Before this commit:
- Canvas margin would be ignored when showruler is triggered
  - Because of this the bg ruler couldn't be transparent (otherwise
  the canvas scrollbar would be visible overlapping it)

With this commit: Whenever ruler is visible -> re set the canvas
container y position

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Id320a025675b92eb3b32734308a91dd6dd34dc43
