### PR TITLE
systemplate and its immediate subdirs should be owned by 'cool'

### DIFF
--- a/common/JailUtil.cpp
+++ b/common/JailUtil.cpp
@@ -490,14 +490,13 @@ void setupDynamicFiles(const std::string& sysTemplate)
     const std::string etcSysTemplatePath = Poco::Path(sysTemplate, "etc").toString();
     LinkDynamicFiles = true; // Prefer linking, unless it fails.
 
-    if (!updateDynamicFilesImpl(sysTemplate))
+    const bool uptodate = updateDynamicFilesImpl(sysTemplate);
+    if (!uptodate)
     {
         // Can't copy!
         LOG_WRN("Failed to update the dynamic files in ["
                 << sysTemplate
-                << "]. Will disable bind-mounting in this run and clone systemplate into the "
-                   "jails, which is more resource intensive.");
-        disableBindMounting(); // We can't mount from incomplete systemplate.
+                << "]. Will clone dynamic elements of systemplate to the jails.");
         LinkDynamicFiles = false;
     }
 

--- a/kit/ForKit.cpp
+++ b/kit/ForKit.cpp
@@ -386,7 +386,7 @@ static int createLibreOfficeKit(const std::string& childRoot,
     const std::string jailId = Util::rng::getFilename(16);
 
     // Update the dynamic files as necessary.
-    JailUtil::SysTemplate::updateDynamicFiles(sysTemplate);
+    const bool sysTemplateIncomplete = !JailUtil::SysTemplate::updateDynamicFiles(sysTemplate);
 
     // Used to label the spare kit instances
     static size_t spareKitId = 0;
@@ -398,10 +398,12 @@ static int createLibreOfficeKit(const std::string& childRoot,
     pid_t pid = 0;
     if (Util::isKitInProcess())
     {
-        std::thread([childRoot, jailId, sysTemplate, loTemplate, queryVersion] {
+        std::thread([childRoot, jailId, sysTemplate, loTemplate, queryVersion,
+                     sysTemplateIncomplete] {
             sleepForDebugger();
             lokit_main(childRoot, jailId, sysTemplate, loTemplate, true, true,
-                       false, queryVersion, DisplayVersion, spareKitId);
+                       false, queryVersion, DisplayVersion, sysTemplateIncomplete,
+                       spareKitId);
         })
             .detach();
     }
@@ -446,7 +448,8 @@ static int createLibreOfficeKit(const std::string& childRoot,
             UnitKit::get().postFork();
 
             lokit_main(childRoot, jailId, sysTemplate, loTemplate, NoCapsForKit, NoSeccomp,
-                       useMountNamespaces, queryVersion, DisplayVersion, spareKitId);
+                       useMountNamespaces, queryVersion, DisplayVersion,
+                       sysTemplateIncomplete, spareKitId);
         }
         else
         {

--- a/kit/Kit.hpp
+++ b/kit/Kit.hpp
@@ -39,7 +39,7 @@ void lokit_main(
 #if !MOBILEAPP
     const std::string& childRoot, const std::string& jailId, const std::string& sysTemplate,
     const std::string& loTemplate, bool noCapabilities, bool noSeccomp, bool useMountNamespaces,
-    bool queryVersionInfo, bool displayVersion,
+    bool queryVersionInfo, bool displayVersion, bool sysTemplateIncomplete,
 #else
     int docBrokerSocket, const std::string& userInterface,
 #endif


### PR DESCRIPTION
otherwise post-install they can't be updated by coolforkit if they fall out of sync.

f.e.

service coolwsd stop
rm /opt/cool/systemplate/etc/hosts
service coolwsd start

```
[ coolforkit ] DBG  File contents mismatch: [/opt/cool/systemplate//etc/hosts] missing, 0 bytes, modified at 0 =/= [/etc/hosts]: exists, 423 bytes, modified at 1721313302| common/FileUtil.hpp:301
[ coolforkit ] INF  No write access to path [/opt/cool/systemplate]: Permission denied| common/FileUtil.cpp:305
[ coolforkit ] WRN  The systemplate directory [/opt/cool/systemplate] is read-only, and at least [/opt/cool/systemplate//etc/hosts] is out-of-date. Will have to copy sysTemplate to jails. To restore optimal performance, make sure the files in [/opt/cool/systemplate/etc] are up-to-date.| common/JailUtil.cpp:557
[ coolforkit ] WRN  Failed to update the dynamic files in [/opt/cool/systemplate]. Will disable bind-mounting in this run and clone systemplate into the jails, which is more resource intensive.| common/JailUtil.cpp:496
```
And in a podman scenario it's practically guaranteed that /etc/hosts etc are out of date at launch time.

So set the default owner of /opt/cool/systemplate and its immediate subdirs to cool:cool. The contents can remain at whatever owner they are created by to retain hard links.


Change-Id: Ib4a28c46bb2c0368693bf6b7ea6a61f48d33c15a


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

