### PR TITLE
Combobox: decrease height so it aligns with 24px buttons

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -752,6 +752,9 @@ input[type='number']:hover::-webkit-outer-spin-button {
 .ui-combobox {
 	display: flex;
 	margin: auto 0;
+	align-items: center;
+	box-sizing: border-box;
+	height: 24px;
 }
 
 .ui-listbox {
@@ -766,7 +769,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	-webkit-appearance: none;
 	-moz-appearance: none;
 	appearance: none;
-	height: 28px;
+	height: 24px;
 	line-height: normal;
 	font-size: var(--default-font-size);
 	font-family: var(--jquery-ui-font);
@@ -798,14 +801,13 @@ input[type='number']:hover::-webkit-outer-spin-button {
 .ui-listbox-arrow {
 	content: '';
 	background: url('images/jquery-ui-lightness/ui-icons_222222_256x240.png') no-repeat transparent;
-	background-position: -67px -18px !important;
+	background-position: -67px -17px !important;
 	display: inline-block;
 	position: relative;
 	width: 11px;
 	height: 11px;
 	cursor: pointer;
 	pointer-events: none;
-	margin-block-start: 8px;
 	margin-inline-start: -16px;
 	margin-inline-end: 4px;
 }
@@ -827,12 +829,15 @@ input[type='number']:hover::-webkit-outer-spin-button {
 }
 
 .ui-combobox-content {
+	box-sizing: border-box;
 	width: 100%;
+	height: 100%;
 	border: none;
 	border-start-start-radius: var(--border-radius);
 	border-end-start-radius: var(--border-radius);
 	color: var(--color-text-dark);
 	background-color: var(--color-background-lighter);
+	padding-inline: 5px;
 }
 
 .ui-combobox-button {

--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -335,9 +335,6 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 .notebookbar.ui-combobox * {
 	line-height: 22px;
 }
-.ui-combobox-content {
-	padding-inline: 5px;
-}
 
 .has-colorpicker.menubutton img {
 	width: var(--btn-size-m) !important;


### PR DESCRIPTION
Additionally, move the single .ui-combobox-content's css
property (padding) from notebookbar.css to jsdialogs.css. Better to
have it everything in one place.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I24c93ce1a31a1bbb92071f77cf1ab9479e9dc3f3
