### PR TITLE
calc: jump to cell on address input (backport 24.04)

### DIFF
--- a/browser/src/control/Control.FormulaBarJSDialog.js
+++ b/browser/src/control/Control.FormulaBarJSDialog.js
@@ -91,6 +91,8 @@ class FormulaBar {
 
 		};
 		this.map.sendUnoCommand('.uno:GoToCell', command);
+		// TODO: create clear helper to provide one-time allow ticket for view jump
+		this.map._docLayer._searchRequested = true;
 	}
 
 	createFormulabar(text) {


### PR DESCRIPTION
To test:
type into "address" input next to the the formula bar
view should jump to the target cell