### PR TITLE
accessibility: Improve keyboard accessibility for style selection

### DIFF
--- a/browser/src/control/jsdialog/Widget.IconView.ts
+++ b/browser/src/control/jsdialog/Widget.IconView.ts
@@ -47,8 +47,14 @@ function _iconViewEntry(
 		builder.options.cssClass + ' ui-iconview-entry',
 		parentContainer,
 	);
-	if (entry.selected && entry.selected === true)
+
+	// By default `aria-presed` should be false
+	entryContainer.setAttribute('aria-pressed', 'false');
+
+	if (entry.selected && entry.selected === true) {
 		$(entryContainer).addClass('selected');
+		entryContainer.setAttribute('aria-pressed', 'true');
+	}
 
 	const icon = L.DomUtil.create(
 		'div',
@@ -65,6 +71,9 @@ function _iconViewEntry(
 		placeholder.innerText = entry.text;
 		if (entry.tooltip) placeholder.title = entry.tooltip;
 		else placeholder.title = entry.text;
+
+		// Add tabindex attribute for accessibility, enabling keyboard navigation in the icon preview
+		entryContainer.setAttribute('tabindex', '0');
 		JSDialog.OnDemandRenderer(
 			builder,
 			parentData.id,


### PR DESCRIPTION
- Allow style selection using arrow keys and tab
- Communicate selection state using aria-pressed attribute
- Ensures better accessibility for users relying on keyboard navigation.

Signed-off-by: Darshan-upadhyay1110 <darshan.upadhyay@collabora.com>
Change-Id: Ib33d2a3a04e0dacbd0194012e7697b1a3bc87de3


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

