### PR TITLE
drop storage.ssl.key_file_path

### DIFF
--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -267,7 +267,6 @@
             <as_scheme type="bool" default="true" desc="When set we exclusively use the WOPI URI's scheme to enable SSL for storage">true</as_scheme>
             <enable type="bool" desc="If as_scheme is false or not set, this can be set to force SSL encryption between storage and coolwsd. When empty this defaults to following the ssl.enable setting"></enable>
             <cert_file_path desc="Path to the cert file. When empty this defaults to following the ssl.cert_file_path setting" relative="false"></cert_file_path>
-            <key_file_path desc="Path to the key file. When empty this defaults to following the ssl.key_file_path settinge" relative="false"></key_file_path>
             <ca_file_path desc="Path to the ca file. When empty this defaults to following the ssl.ca_file_path setting" relative="false"></ca_file_path>
             <cipher_list desc="List of OpenSSL ciphers to accept. If empty the defaults are used. These can be overridden only if absolutely needed."></cipher_list>
         </ssl>

--- a/fuzzer/Common.cpp
+++ b/fuzzer/Common.cpp
@@ -27,7 +27,7 @@ bool DoInitialization()
     std::map<std::string, std::string> logProperties;
     Log::initialize("wsd", logLevel, withColor, logToFile, logProperties);
     ssl::Manager::initializeClientContext(
-            /*certificateFile=*/"", /*privateKeyFile=*/"", /*caLocation=*/"",
+            /*certificateFile=*/"", /*caLocation=*/"",
             /*cipherList=*/"", ssl::CertificateVerification::Required);
     return true;
 }

--- a/net/Ssl.hpp
+++ b/net/Ssl.hpp
@@ -98,14 +98,13 @@ public:
     }
 
     static void initializeClientContext(const std::string& certFilePath,
-                                        const std::string& keyFilePath,
                                         const std::string& caFilePath,
                                         const std::string& cipherList,
                                         ssl::CertificateVerification verification)
     {
         assert(!isClientContextInitialized() &&
                "Cannot initialize the client context more than once");
-        ClientInstance = std::make_unique<SslContext>(certFilePath, keyFilePath, caFilePath,
+        ClientInstance = std::make_unique<SslContext>(certFilePath, std::string(), caFilePath,
                                                       cipherList, verification);
     }
 

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -119,7 +119,7 @@ int main(int argc, char** argv)
                                               ssl_ca_file_path, ssl_cipher_list,
                                               ssl::CertificateVerification::Disabled);
 
-        ssl::Manager::initializeClientContext(ssl_cert_file_path, ssl_key_file_path,
+        ssl::Manager::initializeClientContext(ssl_cert_file_path,
                                               ssl_ca_file_path, ssl_cipher_list,
                                               ssl::CertificateVerification::Required);
     }

--- a/tools/Stress.cpp
+++ b/tools/Stress.cpp
@@ -80,7 +80,7 @@ int Stress::main(const std::vector<std::string>& args)
         throw std::runtime_error("Failed to init unit test pieces.");
 
 #if ENABLE_SSL
-    ssl::Manager::initializeClientContext("", "", "", "ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH",
+    ssl::Manager::initializeClientContext("", "", "ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH",
                                           ssl::CertificateVerification::Disabled);
     if (!ssl::Manager::isClientContextInitialized())
     {

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -2137,7 +2137,6 @@ void COOLWSD::innerInitialize(Application& self)
         { "storage.ssl.ca_file_path", "" },
         { "storage.ssl.cert_file_path", "" },
         { "storage.ssl.cipher_list", "" },
-        { "storage.ssl.key_file_path", "" },
         { "storage.wopi.max_file_size", "0" },
         { "storage.wopi[@allow]", "true" },
         { "storage.wopi.locking.refresh", "900" },

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -135,13 +135,11 @@ void StorageBase::initialize()
         if (COOLWSD::isSSLEnabled())
         {
             sslClientParams.certificateFile = COOLWSD::getPathFromConfigWithFallback("storage.ssl.cert_file_path", "ssl.cert_file_path");
-            sslClientParams.privateKeyFile = COOLWSD::getPathFromConfigWithFallback("storage.ssl.key_file_path", "ssl.key_file_path");
             sslClientParams.caLocation = COOLWSD::getPathFromConfigWithFallback("storage.ssl.ca_file_path", "ssl.ca_file_path");
         }
         else
         {
             sslClientParams.certificateFile = COOLWSD::getPathFromConfig("storage.ssl.cert_file_path");
-            sslClientParams.privateKeyFile = COOLWSD::getPathFromConfig("storage.ssl.key_file_path");
             sslClientParams.caLocation = COOLWSD::getPathFromConfig("storage.ssl.ca_file_path");
         }
         sslClientParams.cipherList = COOLWSD::getPathFromConfigWithFallback("storage.ssl.cipher_list", "ssl.cipher_list");
@@ -165,7 +163,7 @@ void StorageBase::initialize()
 
     // Initialize our client SSL context.
     ssl::Manager::initializeClientContext(
-        sslClientParams.certificateFile, sslClientParams.privateKeyFile, sslClientParams.caLocation,
+        sslClientParams.certificateFile, sslClientParams.caLocation,
         sslClientParams.cipherList,
         sslClientParams.verificationMode == Poco::Net::Context::VERIFY_NONE
             ? ssl::CertificateVerification::Disabled

--- a/wsd/wopi/StorageConnectionManager.hpp
+++ b/wsd/wopi/StorageConnectionManager.hpp
@@ -102,8 +102,6 @@ private:
         {
             sslClientParams.certificateFile = COOLWSD::getPathFromConfigWithFallback(
                 "storage.ssl.cert_file_path", "ssl.cert_file_path");
-            sslClientParams.privateKeyFile = COOLWSD::getPathFromConfigWithFallback(
-                "storage.ssl.key_file_path", "ssl.key_file_path");
             sslClientParams.caLocation = COOLWSD::getPathFromConfigWithFallback(
                 "storage.ssl.ca_file_path", "ssl.ca_file_path");
             sslClientParams.cipherList = COOLWSD::getPathFromConfigWithFallback(
@@ -132,7 +130,7 @@ private:
 
         // Initialize our client SSL context.
         ssl::Manager::initializeClientContext(
-            sslClientParams.certificateFile, sslClientParams.privateKeyFile,
+            sslClientParams.certificateFile,
             sslClientParams.caLocation, sslClientParams.cipherList,
             sslClientParams.caLocation.empty() ? ssl::CertificateVerification::Disabled
                                                : ssl::CertificateVerification::Required);


### PR DESCRIPTION
do we really want ssl *client* private certs


Change-Id: I4af2714acb78a2721465724cf726abb437badeaf


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

