### PR TITLE
Notebookbar: Promote Reset zoom to bigmenubartoolitem

### DIFF
--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -1163,7 +1163,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 			{
 				'id': 'zoomreset',
 				'class': 'unozoomreset',
-				'type': 'menubartoolitem',
+				'type': 'bigmenubartoolitem',
 				'text': _('Reset zoom'),
 				'command': _('Reset zoom'),
 				'accessibility': { focusBack: true,	combination: 'J', de: null }

--- a/browser/src/control/Control.NotebookbarDraw.js
+++ b/browser/src/control/Control.NotebookbarDraw.js
@@ -345,7 +345,7 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 			{
 				'id': 'zoomreset',
 				'class': 'unozoomreset',
-				'type': 'menubartoolitem',
+				'type': 'bigmenubartoolitem',
 				'text': _('Reset zoom'),
 				'command': _('Reset zoom'),
 				'accessibility': { focusBack: true, combination: 'RZ', de: null }

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -362,7 +362,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 			{
 				'id': 'zoomreset',
 				'class': 'unozoomreset',
-				'type': 'menubartoolitem',
+				'type': 'bigmenubartoolitem',
 				'text': _('Reset zoom'),
 				'command': _('Reset zoom'),
 				'accessibility': { focusBack: true, combination: 'ZR', de: null }

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -1409,7 +1409,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 			{
 				'id': 'zoomreset',
 				'class': 'unozoomreset',
-				'type': 'menubartoolitem',
+				'type': 'bigmenubartoolitem',
 				'text': _('Reset zoom'),
 				'command': _('Reset zoom'),
 				'accessibility': { focusBack: true, combination: 'J', de: 'O' }


### PR DESCRIPTION
The zoomreset button was occupying 100% of the vertical space but was
being render in one line instead of a big icon. Better to render it as
a big icon to aid in grouping.

Note on future implementations: Ideally we would actually have in one
line and we would replace the zoom out and zoom in btn with one
menu (something like `ZoomMenu`) that would allow the user to change
the zoom level (similar as already happens in the status bar). The
menu definition would be moved to menuDefinitions.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ia136aa95e410f192984629feeb8eb05922372226
