### PR TITLE
uno: fix CallPythonScript calling js error

### DIFF
--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -350,7 +350,7 @@ L.Map.include({
 	},
 
 	sendUnoCommand: function (command, json, force) {
-		if (command.indexOf('.uno:') < 0)
+		if (command.indexOf('.uno:') < 0 || command.indexOf('vnd.sun.star.script') < 0)
 			console.error('Trying to send uno command without prefix: "' + command + '"');
 
 		if ((command.startsWith('.uno:Sidebar') && !command.startsWith('.uno:SidebarShow')) ||


### PR DESCRIPTION
we send "vnd.sun.star.script" message without uno prefix via uno command


Change-Id: If0e103bd74ac7f34a57559b2eebc1001352b0057


* Target version: master 


### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

