### PR TITLE
following: fix status update in writer (backport 24.04)

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -999,8 +999,14 @@ L.CanvasTileLayer = L.Layer.extend({
 		this._move();
 		this._moveInProgress = false;
 
-		if (app.calc.cellCursorVisible || app.file.textCursor.visible) {
-			var cursorPos = this._map._docLayer._twipsToLatLng({ x: app.calc.cellCursorRectangle.x2, y: app.calc.cellCursorRectangle.y2 });
+		var isCellCursorVisible = app.calc.cellCursorVisible;
+		var isTextCursorVisible = app.file.textCursor.visible;
+		if (isCellCursorVisible || isTextCursorVisible) {
+			if (isCellCursorVisible)
+				var cursorPos = this._map._docLayer._twipsToLatLng({ x: app.calc.cellCursorRectangle.x2, y: app.calc.cellCursorRectangle.y2 });
+			else
+				cursorPos = this._map._docLayer._twipsToLatLng({ x: app.file.textCursor.rectangle.x2, y: app.file.textCursor.rectangle.y2 });
+
 			var centerOffset = this._map._getCenterOffset(cursorPos);
 			var viewHalf = this._map.getSize()._divideBy(2);
 			var cursorPositionInView =


### PR DESCRIPTION
We want to follow our own cursor if we see it on the screen. We used calc's cell cursor always, but in Writer we need text cursor.
