### PR TITLE
[24.04] Revert "Fix canvas margin when ruler is toggled on"

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -42,7 +42,6 @@
 
 	/* Ruler */
 	--ruler-height: 20px;
-	--canvas-container-y: var(--ruler-height);
 }
 .focus-hidden:focus {
 	outline: none;

--- a/browser/css/leaflet.css
+++ b/browser/css/leaflet.css
@@ -882,7 +882,7 @@ input.clipboard {
 	margin: 0px; /*Ruler styling*/
 }
 .cool-ruler {
-	background-color: transparent;
+	background-color: var(--color-main-background);
 	height: var(--ruler-height);
 	width: 100vw;
 	margin: 0px !important;
@@ -1058,18 +1058,13 @@ input.clipboard {
 .leaflet-canvas-container {
 	position: absolute;
 	left: 0;
-	top: var(--canvas-container-y);
+	top: 0;
 	bottom: 0;
 	right: 0;
 	z-index: 9;
 	user-select: none;
 	-webkit-touch-callout: none !important;
 	-webkit-user-select: none !important;
-}
-
-.spreadsheet-doctype #canvas-container {
-	/* For Calc never account for ruler */
-	top: 0;
 }
 
 .leaflet-pane-splitter {

--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -451,11 +451,9 @@ L.Control.Notebookbar = L.Control.extend({
 	onRulerChange: function() {
 		if (this.map.uiManager.isRulerVisible()) {
 			$('#showruler').addClass('selected');
-			document.documentElement.style.setProperty("--canvas-container-y", "var(--ruler-height)");
 		}
 		else {
 			$('#showruler').removeClass('selected');
-			document.documentElement.style.setProperty("--canvas-container-y", "0");
 		}
 	},
 

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -829,14 +829,10 @@ L.Control.UIManager = L.Control.extend({
 	},
 
 	toggleRuler: function() {
-		if (this.isRulerVisible()){
+		if (this.isRulerVisible())
 			this.hideRuler();
-			document.documentElement.style.setProperty("--canvas-container-y", "0");
-		}
-		else {
+		else
 			this.showRuler();
-			document.documentElement.style.setProperty("--canvas-container-y", "var(--ruler-height)");
-		}
 	},
 
 	isRulerVisible: function() {


### PR DESCRIPTION
This reverts commit 2e00fea4b6aba889834b3ee037565930d42f32bd.

So to fix the text cursor being in wrong place:
1. User A switches ruler on
2. User B Switches ruler off
3. Users click in line 1 but the blinking cursor is rendered in the
line 2

It seems we cannot change the top position of
.leaflet-canvas-container without introducing a regression affecting
cursors. Probably browser/src/layer/marker/Cursor.ts need to be
updated also and maybe other markers also such as form controls.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ice70463934b0065b5eda4429c4a51995aeb9a4df
