### PR TITLE
[Backport] Calc: sheet tabs: center tabs

### DIFF
--- a/browser/css/spreadsheet.css
+++ b/browser/css/spreadsheet.css
@@ -2,13 +2,14 @@
 	margin: 0;
 	padding: 0;
 	position: relative;
-	height: 39px;
+	height: 38px;
 	overflow: hidden;
 	width: 100%;
 	white-space: nowrap;
 	text-align: start;
 	background-color: transparent;
 	vertical-align: middle;
+	align-content: center;
 }
 
 .spreadsheet-tab-scroll {
@@ -20,7 +21,7 @@
 }
 
 .spreadsheet-tab {
-	margin: 5px 0px 0px !important;
+	margin: 0 !important;
 	padding: 6px 9px 4px !important;
 	text-decoration: none;
 
@@ -281,7 +282,7 @@
 	display: grid;
 	grid-auto-flow: column;
 	align-content: center;
-	height: 39px;
+	height: 38px;
 }
 
 .tab-drop-area {


### PR DESCRIPTION
- Don't rely on margin to align it
  - We are using flex box, add missing align property
- Fix height of containers: Use even numbers otherwise we end up with
  - non equal margins: (39-32)/2 = 3.5. Use 38 instead.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I467acc1ec81fdccd48d76a52bb7bbc39d28e1ba6
