### PR TITLE
Add hardware resource warning to server audit widget

### DIFF
--- a/browser/src/control/Control.ServerAuditDialog.ts
+++ b/browser/src/control/Control.ServerAuditDialog.ts
@@ -76,6 +76,20 @@ class ServerAuditDialog {
 					'https://sdk.collaboraonline.com/docs/postmessage_api.html#initialization',
 				],
 			},
+			hardwarewarning: {
+				lowresources: [
+					_(
+						'Your server is configured with insufficient hardware resources, which may lead to poor performance.',
+					),
+					'SDK: hardware-requirements',
+					'https://sdk.collaboraonline.com/docs/installation/Configuration.html#performance',
+				],
+				ok: [
+					_('Hardware resources are sufficient for optimal performance'),
+					'',
+					'',
+				],
+			},
 		};
 	}
 

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -739,6 +739,7 @@ Util::RuntimeConstant<bool> COOLWSD::SSLTermination;
 #endif
 unsigned COOLWSD::MaxConnections;
 unsigned COOLWSD::MaxDocuments;
+std::string COOLWSD::HardwareResourceWarning = "ok";
 std::string COOLWSD::OverrideWatermark;
 std::set<const Poco::Util::AbstractConfiguration*> COOLWSD::PluginConfigurations;
 std::chrono::steady_clock::time_point COOLWSD::StartTime;
@@ -2714,9 +2715,12 @@ void COOLWSD::innerInitialize(Application& self)
     // It is worth avoiding configuring with a large number of under-weight
     // containers / VMs - better to have fewer, stronger ones.
     if (nThreads < 4)
+    {
         LOG_WRN("Fewer threads than recommended. Having at least four threads for "
                 "provides significant parallelism that can be used for burst "
                 "compression of newly visible document pages, giving lower latency.");
+        HardwareResourceWarning = "lowresources";
+    }
 
 #elif defined(__EMSCRIPTEN__)
     // disable threaded image scaling for wasm for now

--- a/wsd/COOLWSD.hpp
+++ b/wsd/COOLWSD.hpp
@@ -320,6 +320,7 @@ public:
     static std::unordered_set<std::string> EditFileExtensions;
     static unsigned MaxConnections;
     static unsigned MaxDocuments;
+    static std::string HardwareResourceWarning;
     static std::string OverrideWatermark;
     static std::set<const Poco::Util::AbstractConfiguration*> PluginConfigurations;
     static std::chrono::steady_clock::time_point StartTime;
@@ -348,6 +349,11 @@ public:
     static std::string GetConnectionId()
     {
         return Util::encodeId(NextConnectionId++, 3);
+    }
+
+    static const std::string& getHardwareResourceWarning()
+    {
+        return HardwareResourceWarning;
     }
 
     static bool isSSLEnabled()

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1249,6 +1249,9 @@ DocumentBroker::updateSessionWithWopiInfo(const std::shared_ptr<ClientSession>& 
     if (!wopiFileInfo->getIsAdminUserError().empty())
         _serverAudit.set("is_admin", wopiFileInfo->getIsAdminUserError());
 
+    if (!COOLWSD::getHardwareResourceWarning().empty())
+        _serverAudit.set("hardwarewarning", COOLWSD::getHardwareResourceWarning());
+
     if (!wopiFileInfo->getUserCanWrite() ||
         session->isReadOnly()) // Readonly. Second boolean checks for URL "permission=readonly"
     {

--- a/wsd/ServerAuditUtil.cpp
+++ b/wsd/ServerAuditUtil.cpp
@@ -16,6 +16,7 @@ ServerAuditUtil::ServerAuditUtil()
 {
     set("is_admin", "ok");
     set("certwarning", "ok");
+    set("hardwarewarning", "ok");
 }
 
 std::string ServerAuditUtil::getResultsJSON() const


### PR DESCRIPTION
- Implemented a new error code type `hardwarewarning` to indicate insufficient hardware resources.
- Updated server audit widget to display the new hardware warning message.
- Included link to hardware requirements documentation for user reference.


Change-Id: I3151b57acc1275564d8de1cdc18922685e8edebe


* Resolves: #9491
* Target version: master 

### Checklist

- [X] I have run `make prettier-write` and formatted the code.
- [X] All commits have Change-Id
- [ ] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

