### PR TITLE
following: reset on user interaction by uno command

### DIFF
--- a/browser/src/control/Control.FormulaBarJSDialog.js
+++ b/browser/src/control/Control.FormulaBarJSDialog.js
@@ -91,8 +91,6 @@ class FormulaBar {
 
 		};
 		this.map.sendUnoCommand('.uno:GoToCell', command);
-		// TODO: create clear helper to provide one-time allow ticket for view jump
-		this.map._docLayer._searchRequested = true;
 	}
 
 	createFormulabar(text) {

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -390,8 +390,10 @@ L.Map.include({
 				break;
 			}
 		}
+
+		var map = this;
+
 		if (command.startsWith('.uno:SpellOnline')) {
-			var map = this;
 			var val = map['stateChangeHandler'].getItemValue('.uno:SpellOnline');
 
 			// proceed if the toggle button is pressed
@@ -408,9 +410,11 @@ L.Map.include({
 			&& !command.startsWith('.uno:ToolbarMode') && !force) {
 			console.debug('Cannot execute: ' + command + ' when dialog is opened.');
 			this.dialog.blinkOpenDialog();
-		} else if (this.isEditMode() || isAllowedInReadOnly) {
-			if (!this.messageNeedsToBeRedirected(command))
-				app.socket.sendMessage('uno ' + command + (json ? ' ' + JSON.stringify(json) : ''));
+		} else if ((this.isEditMode() || isAllowedInReadOnly) && !this.messageNeedsToBeRedirected(command)) {
+			app.socket.sendMessage('uno ' + command + (json ? ' ' + JSON.stringify(json) : ''));
+			// user interaction turns off the following of other users
+			if (map.userList && map._docLayer && map._docLayer._viewId)
+				map.userList.followUser(map._docLayer._viewId);
 		}
 	},
 

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -2254,8 +2254,7 @@ L.CanvasTileLayer = L.Layer.extend({
 		var sameAddress = oldCursorAddress.equals(app.calc.cellAddress.toArray());
 
 		var isFollowingOwnCursor = parseInt(app.getFollowedViewId()) === parseInt(this._viewId);
-		var wasSearchRequested = this._searchRequested;
-		var notJump = !wasSearchRequested && (sameAddress || !isFollowingOwnCursor);
+		var notJump = sameAddress || !isFollowingOwnCursor;
 		var scrollToCursor = this._sheetSwitch.tryRestore(notJump, this._selectedPart);
 
 		this._onUpdateCellCursor(scrollToCursor, notJump);

--- a/cypress_test/integration_tests/desktop/calc/cell_cursor_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/cell_cursor_spec.js
@@ -19,6 +19,22 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Test jumping on large cell
 		cy.cGet('input#addressInput-input').should('have.prop', 'value', 'A1:Z1');
 		desktopHelper.assertScrollbarPosition('horizontal', 205, 315);
 	});
+
+	it('Jump on address with not visible cursor', function() {
+		desktopHelper.assertScrollbarPosition('vertical', 0, 30);
+		cy.cGet('input#addressInput-input').should('have.prop', 'value', 'Z11');
+
+		cy.cGet('input#addressInput-input').type('{selectAll}A110{enter}');
+		desktopHelper.assertScrollbarPosition('vertical', 205, 315);
+	});
+
+	it('Jump on search with not visible cursor', function() {
+		desktopHelper.assertScrollbarPosition('horizontal', 205, 315);
+		cy.cGet('input#search-input').clear().type('FIRST{enter}');
+
+		cy.cGet('input#addressInput-input').should('have.prop', 'value', 'A10');
+		desktopHelper.assertScrollbarPosition('horizontal', 40, 60);
+	});
 });
 
 describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Test jumping on large cell selection with split panes', function() {

--- a/cypress_test/integration_tests/desktop/impress/scrolling_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/scrolling_spec.js
@@ -30,7 +30,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Scroll through document', 
 		cy.wait(1000);
 		clickOnTheCenter();
 		desktopHelper.pressKey(9,'uparrow');
-		cy.cGet('#test-div-vertical-scrollbar').should('have.text', '0');
+		desktopHelper.assertScrollbarPosition('vertical', 0, 1);
 		desktopHelper.pressKey(18,'downarrow');
 		desktopHelper.assertScrollbarPosition('vertical', 306, 355);
 	});
@@ -42,7 +42,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Scroll through document', 
 		clickOnTheCenter();
 		cy.wait(500);
 		helper.typeIntoDocument('{home}');
-		cy.cGet('#test-div-horizontal-scrollbar').should('have.text', '0').wait(500);
+		desktopHelper.assertScrollbarPosition('horizontal', 0, 1);
 		helper.typeIntoDocument('{end}');
 		desktopHelper.assertScrollbarPosition('horizontal', 340, 660);
 	});


### PR DESCRIPTION
This is revert of commit 468cf22b4bf95a7a24282d828d46d05ce5c1ae3d calc: jump to cell on address input

When uno command is sent user interacted with the app so we should reset following state to - follow my own cursor.
This helps solving the issue with "address bar", "search" usage in calc. Also removed old hack which caused to jump back to cursor after address bar was used in calc.