### PR TITLE
fix view jumping in calc (backport 24.04)

### DIFF
--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -390,8 +390,10 @@ L.Map.include({
 				break;
 			}
 		}
+
+		var map = this;
+
 		if (command.startsWith('.uno:SpellOnline')) {
-			var map = this;
 			var val = map['stateChangeHandler'].getItemValue('.uno:SpellOnline');
 
 			// proceed if the toggle button is pressed
@@ -408,9 +410,11 @@ L.Map.include({
 			&& !command.startsWith('.uno:ToolbarMode') && !force) {
 			console.debug('Cannot execute: ' + command + ' when dialog is opened.');
 			this.dialog.blinkOpenDialog();
-		} else if (this.isEditMode() || isAllowedInReadOnly) {
-			if (!this.messageNeedsToBeRedirected(command))
-				app.socket.sendMessage('uno ' + command + (json ? ' ' + JSON.stringify(json) : ''));
+		} else if ((this.isEditMode() || isAllowedInReadOnly) && !this.messageNeedsToBeRedirected(command)) {
+			app.socket.sendMessage('uno ' + command + (json ? ' ' + JSON.stringify(json) : ''));
+			// user interaction turns off the following of other users
+			if (map.userList && map._docLayer && map._docLayer._viewId)
+				map.userList.followUser(map._docLayer._viewId);
 		}
 	},
 

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -2240,8 +2240,7 @@ L.CanvasTileLayer = L.Layer.extend({
 		var sameAddress = oldCursorAddress.equals(app.calc.cellAddress.toArray());
 
 		var isFollowingOwnCursor = parseInt(app.getFollowedViewId()) === parseInt(this._viewId);
-		var wasSearchRequested = this._searchRequested;
-		var notJump = !wasSearchRequested && (sameAddress || !isFollowingOwnCursor);
+		var notJump = sameAddress || !isFollowingOwnCursor;
 		var scrollToCursor = this._sheetSwitch.tryRestore(notJump, this._selectedPart);
 
 		this._onUpdateCellCursor(scrollToCursor, notJump);

--- a/cypress_test/integration_tests/desktop/calc/cell_cursor_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/cell_cursor_spec.js
@@ -19,6 +19,22 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Test jumping on large cell
 		cy.cGet('input#addressInput-input').should('have.prop', 'value', 'A1:Z1');
 		desktopHelper.assertScrollbarPosition('horizontal', 205, 315);
 	});
+
+	it('Jump on address with not visible cursor', function() {
+		desktopHelper.assertScrollbarPosition('vertical', 0, 30);
+		cy.cGet('input#addressInput-input').should('have.prop', 'value', 'Z11');
+
+		cy.cGet('input#addressInput-input').type('{selectAll}A110{enter}');
+		desktopHelper.assertScrollbarPosition('vertical', 205, 315);
+	});
+
+	it('Jump on search with not visible cursor', function() {
+		desktopHelper.assertScrollbarPosition('horizontal', 205, 315);
+		cy.cGet('input#search-input').clear().type('FIRST{enter}');
+
+		cy.cGet('input#addressInput-input').should('have.prop', 'value', 'A10');
+		desktopHelper.assertScrollbarPosition('horizontal', 40, 60);
+	});
 });
 
 describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Test jumping on large cell selection with split panes', function() {

--- a/cypress_test/integration_tests/desktop/impress/scrolling_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/scrolling_spec.js
@@ -30,7 +30,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Scroll through document', 
 		cy.wait(1000);
 		clickOnTheCenter();
 		desktopHelper.pressKey(9,'uparrow');
-		cy.cGet('#test-div-vertical-scrollbar').should('have.text', '0');
+		desktopHelper.assertScrollbarPosition('vertical', 0, 1);
 		desktopHelper.pressKey(18,'downarrow');
 		desktopHelper.assertScrollbarPosition('vertical', 306, 355);
 	});
@@ -42,7 +42,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Scroll through document', 
 		clickOnTheCenter();
 		cy.wait(500);
 		helper.typeIntoDocument('{home}');
-		cy.cGet('#test-div-horizontal-scrollbar').should('have.text', '0').wait(500);
+		desktopHelper.assertScrollbarPosition('horizontal', 0, 1);
 		helper.typeIntoDocument('{end}');
 		desktopHelper.assertScrollbarPosition('horizontal', 340, 660);
 	});


### PR DESCRIPTION
This is revert of commit https://github.com/CollaboraOnline/online/commit/468cf22b4bf95a7a24282d828d46d05ce5c1ae3d
calc: jump to cell on address input
and partial revert of commit https://github.com/CollaboraOnline/online/commit/bab8c94f0a87c7e637c2d187d932f3a9ac4898f4
calc: fix view jump after search

When uno command is sent user interacted with the app so we should
reset following state to - follow my own cursor.
This helps solving the issue with "address bar", "search" usage in
calc. Also removed old hack which caused to jump back to cursor
after address bar was used in calc.