### PR TITLE
Annotations (comment): do not change background on hover

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -538,7 +538,6 @@ nav.spreadsheet-color-indicator ~ #sidebar-dock-wrapper {
 
 .cool-annotation:not(.annotation-active) .cool-annotation-content-wrapper:hover,
 .cool-annotation:not(.annotation-active) .cool-annotation-redline-content-wrapper:hover {
-	background-color: var(--color-background-dark);
 	color: var(--color-text-dark);
 }
 


### PR DESCRIPTION
We already have high brightness on light mode and low brightness on
dark mode for comment background -> no need to try to increase it
further on hover since there is no high/low values to claim.

It fixes weird hover effect on the whole card.

Also related with
https://github.com/CollaboraOnline/online/issues/9631

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I102bf161f90e6059bd6d981abb00d2abc854193d
