### PR TITLE
[Backport] Status bar: Presentation there is no insertmode nor selection status

### DIFF
--- a/browser/src/control/Control.StatusBar.js
+++ b/browser/src/control/Control.StatusBar.js
@@ -57,8 +57,6 @@ class StatusBar extends JSDialog.Toolbar {
 			this.showItem('statusselectionmode-container', false);
 		} else {
 			this.enableItem('languagestatus', true);
-			this.showItem('insertmode-container', true);
-			this.showItem('statusselectionmode-container', true);
 		}
 		this.updateVisibilityForToolbar(context);
 	}


### PR DESCRIPTION
So, don't show those items by default. For the other apps we already
specifically show them within the switch case in onDocLayerInit()

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: If25b09a8a37bcd5270f421f1d07d6e381be1d3d2

----

Backport of https://github.com/CollaboraOnline/online/pull/9615
