### PR TITLE
[Backport] Offset outline in input fields placed inside of a dialog

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -612,6 +612,10 @@ input[type='checkbox']:checked.autofilter, .jsdialog input[type='checkbox']:chec
 }
 /* input text */
 
+.ui-dialog .jsdialog.ui-edit:focus-visible {
+	outline-offset: -2px;
+}
+
 .jsdialog.ui-edit, #hyperlink-text-box:not(.mobile-wizard) {
 	color: var(--color-text-dark);
 	background-color: var(--color-background-dark);

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -1548,7 +1548,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		if (data.id && data.id === 'changepass' && builder.map['wopi'].IsOwner === false) {
 			data.enabled = false;
 		}
-		var wrapper = L.DomUtil.create('div', '', parentContainer); // need for locking overlay
+		var wrapper = L.DomUtil.create('div', 'd-flex justify-content-center', parentContainer); // need for locking overlay
 		var pushbutton = L.DomUtil.create('button', 'ui-pushbutton ' + builder.options.cssClass, wrapper);
 		pushbutton.id = data.id;
 		builder._setAccessKey(pushbutton, builder._getAccessKeyFromText(data.text));


### PR DESCRIPTION
PushButtonControl: Fix alignment (regression from locking overlay)

With the "new" wrapper introduced in
e02e1df76d8379e4da7e7c87f10c594bc558d6d2 all the buttons are misaligned.
- Ensure that the wrapper is set with its child centered

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I73b0c7952daf70851a59e4b0e290ba3d32feed23

-----

Offset outline in input fields placed inside of a dialog

Before this commit, when the field was getting the focus in some
dialogs (example rename file) the outline was being cropped

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I9edb516143c7f6aff47681e01fd8822a5b9e6743

----

Backport of #https://github.com/CollaboraOnline/online/pull/9599
