### PR TITLE
Fix view jumping on keypress in writer (backport 24.04)

### DIFF
--- a/browser/src/control/Control.UserList.ts
+++ b/browser/src/control/Control.UserList.ts
@@ -121,7 +121,7 @@ class UserList extends L.Control {
 		app.setFollowingOff();
 	}
 
-	followUser(viewId: number) {
+	followUser(viewId: number, instantJump: boolean = true) {
 		const myViewId = this.map._docLayer._viewId;
 		const followingViewId = app.getFollowedViewId();
 		const followMyself = viewId === followingViewId;
@@ -129,13 +129,11 @@ class UserList extends L.Control {
 		app.setFollowingUser(viewId);
 
 		if (followMyself) {
-			this.map._goToViewId(myViewId);
-			this.map._setFollowing(true, myViewId);
+			this.map._setFollowing(true, myViewId, instantJump);
 			this.renderAll();
 			return;
 		} else if (viewId !== -1) {
-			this.map._goToViewId(viewId);
-			this.map._setFollowing(true, viewId);
+			this.map._setFollowing(true, viewId, instantJump);
 		} else {
 			this.unfollowAll();
 			this.map._setFollowing(false, -1);

--- a/browser/src/map/Map.js
+++ b/browser/src/map/Map.js
@@ -1670,7 +1670,8 @@ L.Map = L.Evented.extend({
 		}
 	},
 
-	_setFollowing: function(followingState, viewId) {
+	/// instantJump = false allows to set the following but waits for a cursor from core to scroll
+	_setFollowing: function(followingState, viewId, instantJump) {
 		var userDefined = viewId !== null && viewId !== undefined;
 		var followDefined = followingState !== null && followingState !== undefined;
 
@@ -1688,13 +1689,13 @@ L.Map = L.Evented.extend({
 		}
 
 		if (followUser) {
-			this._goToViewId(viewId);
+			if (instantJump) this._goToViewId(viewId);
 			app.setFollowingUser(viewId);
 		}
 		else if (followEditor) {
 			var editorId = this._docLayer._editorId;
 			if (editorId !== -1 && editorId !== this._docLayer.viewId) {
-				this._goToViewId(editorId);
+				if (instantJump) this._goToViewId(editorId);
 				app.setFollowingEditor(editorId);
 			}
 		}

--- a/browser/src/map/handler/Map.Keyboard.js
+++ b/browser/src/map/handler/Map.Keyboard.js
@@ -452,7 +452,7 @@ L.Map.Keyboard = L.Handler.extend({
 		}
 
 		// if any key is pressed, we stop the following other users
-		this._map.userList.followUser(this._map._docLayer._viewId);
+		this._map.userList.followUser(this._map._docLayer._viewId, false);
 
 		if (window.KeyboardShortcuts.processEvent(app.UI.language.fromURL, ev)) {
 			ev.preventDefault();

--- a/cypress_test/integration_tests/desktop/writer/scrolling_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/scrolling_spec.js
@@ -13,6 +13,17 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Scroll through document', 
 		cy.cGet('#sidebar').click({force: true});
 	});
 
+	it('Check if we jump the view on new page insertion', function() {
+		desktopHelper.assertScrollbarPosition('vertical', 0, 10);
+		helper.typeIntoDocument('{ctrl+enter}');
+		helper.typeIntoDocument('{ctrl+enter}');
+
+		cy.wait(500);
+		cy.cGet('#StatePageNumber').should('have.text', 'Pages 2 and 3 of 6');
+
+		desktopHelper.assertScrollbarPosition('vertical', 140, 160);
+	});
+
 	it('Scrolling to bottom/top', function() {
 		desktopHelper.selectZoomLevel('40');
 		helper.typeIntoDocument('{ctrl}{home}');


### PR DESCRIPTION
    cypress: check new page view jump in writer
    
    ---------------------------------------------------------------

    following: simplify followUser
    
    The UI component should only trigger map._setFollowing
    with correct parameters. Don't do own view jump management.
    This will help to finally centralize the following feature.
    
    This patch fixes the issue with jumping to own cursor on any
    key press, example:
    1. open writer with many pages
    2. scroll to other page so you don't see the cursor
    3. pres CTRL on the keyboard
    Result: jump back to the cursor
    Expected: nothing happens
    
    Keypress should activate following own cursor, but wait with
    the jump for a signal from the core