### PR TITLE
wip: github action for nightly docker

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,59 @@
+name: Build nightly docker image
+
+on:
+  schedule:
+    - cron: "30 0 * * *"
+  push:
+
+jobs:
+  docker:
+    name: Build docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: buildx-${{ github.sha }}
+          restore-keys: |
+            buildx-
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build container image
+        uses: docker/build-push-action@v6
+        with:
+          push: false
+          context: docker/from-source-gh-action/
+          # platforms: linux/amd64,linux/arm64
+          file: docker/from-source/Dockerfile
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/code-nightly:${{ github.sha }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+      - name: Push container image
+        uses: docker/build-push-action@v6
+        # if: github.ref == 'refs/heads/master' || github.event_name == 'release'
+        with:
+          push: true
+          context: docker/from-source-gh-action/
+          # platforms: linux/amd64,linux/arm64
+          file: docker/from-source/Dockerfile
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/code-nightly:latest
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+      - name: Move cache
+        if: always()
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/docker/from-source-gh-action/Dockerfile
+++ b/docker/from-source-gh-action/Dockerfile
@@ -1,0 +1,80 @@
+FROM ubuntu:24.04 AS builder
+
+ENV CORE_ASSETS https://github.com/CollaboraOnline/online/releases/download/for-code-assets/core-co-24.04-assets.tar.gz
+ENV BUILDDIR /build
+
+WORKDIR /build
+
+RUN --mount=type=cache,target=/var/cache/apt apt-get update && \
+    DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install libpng16-16 fontconfig adduser cpio tzdata \
+    findutils nano \
+    libcap2-bin openssl openssh-client inotify-tools procps \
+    libxcb-shm0 libxcb-render0 libxrender1 libxext6 \
+    fonts-wqy-zenhei fonts-wqy-microhei fonts-droid-fallback \
+    fonts-noto-cjk \
+    libpoco-dev python3-polib libcap-dev npm \
+    libpam-dev libzstd-dev wget git build-essential libtool \
+    libcap2-bin python3-lxml libpng-dev libcppunit-dev \
+    pkg-config fontconfig snapd chromium-browser \
+    rsync curl \
+    # core build dependencies
+    git build-essential zip ccache junit4 libkrb5-dev nasm graphviz python3 python3-dev qtbase5-dev libkf5coreaddons-dev libkf5i18n-dev libkf5config-dev libkf5windowsystem-dev libkf5kio-dev libqt5x11extras5-dev autoconf libcups2-dev libfontconfig1-dev gperf openjdk-17-jdk doxygen libxslt1-dev xsltproc libxml2-utils libxrandr-dev libx11-dev bison flex libgtk-3-dev libgstreamer-plugins-base1.0-dev libgstreamer1.0-dev ant ant-optional libnss3-dev libavahi-client-dev libxt-dev
+
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x -o nodesource_setup.sh && bash nodesource_setup.sh && apt install -y nodejs
+
+RUN mkdir -p $BUILDDIR
+
+# Build poco separately to cache it
+ADD https://github.com/pocoproject/poco/archive/poco-1.11.1-release.tar.gz /build/builddir/poco-1.11.1-release.tar.gz
+
+RUN cd builddir && tar xf poco-1.11.1-release.tar.gz && cd poco-poco-1.11.1-release/ && \
+    ./configure --static --no-tests --no-samples --no-sharedlibs --cflags="-fPIC" --omit=Zip,Data,Data/SQLite,Data/ODBC,Data/MySQL,MongoDB,PDF,CppParser,PageCompiler,Redis,Encodings,ActiveRecord --prefix=$BUILDDIR/poco && \
+    make -j $(nproc) && \
+    make install
+
+COPY / $BUILDDIR/
+
+RUN bash build.sh
+
+# Build the final image
+FROM ubuntu:24.04
+
+# refresh repos otherwise installations later may fail
+# install LibreOffice run-time dependencies
+# install adduser, findutils, openssl and cpio that we need later
+# install tzdata to accept the TZ environment variable
+# install an editor
+# tdf#117557 - Add CJK Fonts to Collabora Online Docker Image
+RUN apt-get update \
+    && apt-get -y install libpng16-16 fontconfig adduser cpio tzdata \
+    findutils nano \
+    libcap2-bin openssl openssh-client inotify-tools procps \
+    libxcb-shm0 libxcb-render0 libxrender1 libxext6 \
+    fonts-wqy-zenhei fonts-wqy-microhei fonts-droid-fallback \
+    fonts-noto-cjk ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+# copy freshly built LOKit and Collabora Online
+COPY --from=builder /build/instdir /
+
+# copy the shell script which can start Collabora Online (coolwsd)
+COPY /start-collabora-online.sh /start-collabora-online.sh
+
+# set up Collabora Online (normally done by postinstall script of package)
+# Fix permissions
+RUN setcap cap_fowner,cap_chown,cap_sys_chroot=ep /usr/bin/coolforkit && \
+    setcap cap_sys_admin=ep /usr/bin/coolmount && \
+    adduser --quiet --system --group --home /opt/cool cool && \
+    rm -rf /opt/cool && \
+    mkdir -p /opt/cool/child-roots && \
+    coolwsd-systemplate-setup /opt/cool/systemplate /opt/lokit >/dev/null 2>&1 && \
+    touch /var/log/coolwsd.log && \
+    chown cool:cool /var/log/coolwsd.log && \
+    chown -R cool:cool /opt/ && \
+    chown -R cool:cool /etc/coolwsd
+
+EXPOSE 9980
+
+# switch to cool user (use numeric user id to be compatible with Kubernetes Pod Security Policies)
+USER 100
+
+CMD ["/start-collabora-online.sh"]

--- a/docker/from-source-gh-action/README.md
+++ b/docker/from-source-gh-action/README.md
@@ -1,0 +1,12 @@
+This directory contains relevant files for building a docker image from source code using GitHub Actions. The Dockerfile is used to build the image is different from the regular from-source approach as it isolates the build within docker so that the build environment is not dependent on the host environment.
+
+Right now core is not built from source but uses the prebuilt binaries.
+
+## Build locally
+
+To build the image locally, run the following command:
+
+```bash
+docker build -t code .
+```
+

--- a/docker/from-source-gh-action/build.sh
+++ b/docker/from-source-gh-action/build.sh
@@ -1,0 +1,120 @@
+#! /bin/bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# -- Available env vars --
+# * CORE_ASSETS  - which prebuilt assets to build in core
+# * CORE_BRANCH  - which branch to build in core
+# * COLLABORA_ONLINE_REPO - which git repo to clone online from
+# * COLLABORA_ONLINE_BRANCH - which branch to build in online
+# * CORE_BUILD_TARGET - which make target to run (in core repo)
+# * ONLINE_EXTRA_BUILD_OPTIONS - extra build options for online
+
+if [ -z "$CORE_ASSETS" ]; then
+  if [ -z "$CORE_BRANCH" ]; then
+    CORE_BRANCH="distro/collabora/co-24.05"
+  fi;
+  echo "Building core branch '$CORE_BRANCH'"
+else
+  echo "Building from core assets $CORE_ASSETS"
+fi;
+
+if [ -z "$COLLABORA_ONLINE_REPO" ]; then
+  COLLABORA_ONLINE_REPO="https://github.com/CollaboraOnline/online.git"
+fi;
+if [ -z "$COLLABORA_ONLINE_BRANCH" ]; then
+  COLLABORA_ONLINE_BRANCH="master"
+fi;
+echo "Building online branch '$COLLABORA_ONLINE_BRANCH' from '$COLLABORA_ONLINE_REPO'"
+
+if [ -z "$CORE_BUILD_TARGET" ]; then
+  CORE_BUILD_TARGET=""
+fi;
+echo "LOKit (core) build target: '$CORE_BUILD_TARGET'"
+
+SRCDIR=$(realpath `dirname $0`)
+INSTDIR="$SRCDIR/instdir"
+BUILDDIR="$SRCDIR/builddir"
+
+mkdir -p "$BUILDDIR"
+cd "$BUILDDIR"
+
+rm -rf "$INSTDIR" || true
+mkdir -p "$INSTDIR"
+
+##### build static poco #####
+
+if test ! -f poco/lib/libPocoFoundation.a ; then
+    wget https://github.com/pocoproject/poco/archive/poco-1.11.1-release.tar.gz
+    tar -xzf poco-1.11.1-release.tar.gz
+    cd poco-poco-1.11.1-release/
+    ./configure --static --no-tests --no-samples --no-sharedlibs --cflags="-fPIC" --omit=Zip,Data,Data/SQLite,Data/ODBC,Data/MySQL,MongoDB,PDF,CppParser,PageCompiler,Redis,Encodings,ActiveRecord --prefix=$BUILDDIR/poco
+    make -j $(nproc)
+    make install
+    cd ..
+fi
+
+
+##### cloning & updating #####
+
+# core repo
+# only if CORE_ASSETS is not set
+if [ -z "$CORE_ASSETS" ]; then
+  if test ! -d core ; then
+    git clone https://git.libreoffice.org/core || exit 1
+  fi
+
+  ( cd core && git fetch --all && git checkout $CORE_BRANCH && ./g pull -r ) || exit 1
+else
+  mkdir -p core
+  ( cd core/ && wget "$CORE_ASSETS" -O core-assets.tar.xz && tar -xzf core-assets.tar.xz && rm core-assets.tar.xz) || exit 1
+fi
+
+
+# Clone online repo
+if test ! -d online ; then
+  git clone --depth=1 "$COLLABORA_ONLINE_REPO" online || exit 1
+fi
+
+( cd online && git fetch --all && git checkout -f $COLLABORA_ONLINE_BRANCH && git clean -f -d && git pull -r ) || exit 1
+
+##### LOKit (core) #####
+
+# only if core assets are not set
+if [ -z "$CORE_ASSETS" ]; then
+  # build
+  if [ "$CORE_BRANCH" == "distro/collabora/co-22.05" ]; then
+    ( cd core && ./autogen.sh --with-distro=CPLinux-LOKit --disable-epm --without-package-format --disable-symbols ) || exit 1
+  else
+    ( cd core && ./autogen.sh --with-distro=LibreOfficeOnline ) || exit 1
+  fi
+  ( cd core && make $CORE_BUILD_TARGET ) || exit 1
+
+  # copy stuff
+  mkdir -p "$INSTDIR"/opt/
+  cp -a core/instdir "$INSTDIR"/opt/lokit
+else
+  echo "Using prebuilt core assets"
+  mkdir -p "$INSTDIR"/opt/
+  cp -a core/instdir "$INSTDIR"/opt/lokit
+fi
+
+##### coolwsd & cool #####
+
+# build
+( cd online && ./autogen.sh ) || exit 1
+( cd online && ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var --enable-silent-rules --disable-tests --with-lokit-path="$BUILDDIR"/core/include --with-lo-path=/opt/lokit --with-poco-includes=$BUILDDIR/poco/include --with-poco-libs=$BUILDDIR/poco/lib $ONLINE_EXTRA_BUILD_OPTIONS) || exit 1
+( cd online && make -j $(nproc)) || exit 1
+
+# copy stuff
+( cd online && DESTDIR="$INSTDIR" make install ) || exit 1
+
+# Build online branding if available
+if test -d online-branding ; then
+  npm install -g sass
+  cd online-branding
+  ./brand.sh $INSTDIR/opt/lokit $INSTDIR/usr/share/coolwsd/browser/dist 6 # CODE
+  ./brand.sh $INSTDIR/opt/lokit $INSTDIR/usr/share/coolwsd/browser/dist 7 # Nextcloud Office
+  cd ..
+fi

--- a/docker/from-source-gh-action/start-collabora-online.sh
+++ b/docker/from-source-gh-action/start-collabora-online.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+if test "${DONT_GEN_SSL_CERT-set}" = set; then
+# Generate new SSL certificate instead of using the default
+mkdir -p /tmp/ssl/
+cd /tmp/ssl/
+mkdir -p certs/ca
+openssl rand -writerand /opt/cool/.rnd
+openssl genrsa -out certs/ca/root.key.pem 2048
+openssl req -x509 -new -nodes -key certs/ca/root.key.pem -days 9131 -out certs/ca/root.crt.pem -subj "/C=DE/ST=BW/L=Stuttgart/O=Dummy Authority/CN=Dummy Authority"
+mkdir -p certs/servers
+mkdir -p certs/tmp
+mkdir -p certs/servers/localhost
+openssl genrsa -out certs/servers/localhost/privkey.pem 2048
+if test "${cert_domain-set}" = set; then
+openssl req -key certs/servers/localhost/privkey.pem -new -sha256 -out certs/tmp/localhost.csr.pem -subj "/C=DE/ST=BW/L=Stuttgart/O=Dummy Authority/CN=localhost"
+else
+openssl req -key certs/servers/localhost/privkey.pem -new -sha256 -out certs/tmp/localhost.csr.pem -subj "/C=DE/ST=BW/L=Stuttgart/O=Dummy Authority/CN=${cert_domain}"
+fi
+openssl x509 -req -in certs/tmp/localhost.csr.pem -CA certs/ca/root.crt.pem -CAkey certs/ca/root.key.pem -CAcreateserial -out certs/servers/localhost/cert.pem -days 9131
+mv -f certs/servers/localhost/privkey.pem /etc/coolwsd/key.pem
+mv -f certs/servers/localhost/cert.pem /etc/coolwsd/cert.pem
+mv -f certs/ca/root.crt.pem /etc/coolwsd/ca-chain.cert.pem
+fi
+
+# Start coolwsd
+exec /usr/bin/coolwsd --version --use-env-vars --o:sys_template_path=/opt/cool/systemplate --o:child_root_path=/opt/cool/child-roots --o:file_server_root_path=/usr/share/coolwsd --o:logging.color=false --o:stop_on_config_change=true ${extra_params}


### PR DESCRIPTION
Change-Id: I56d28f4b2428b248c52d550825d1ac337a536bdf

### Summary

Provides a separate docker build method to build a container isolated from the host system. The goal is to have a nightly docker image on the github container registry that can be used for easier testing and running automated tests in integrators.

For now only the built from the precompiled core assets is covered.

Note I've tested building in the github action in my local fork https://github.com/juliushaertl/online/actions/runs/10083478724 but not in here yet.

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

