### PR TITLE
fix(invert): Specify desired theme

### DIFF
--- a/browser/css/color-palette-dark.css
+++ b/browser/css/color-palette-dark.css
@@ -45,7 +45,9 @@
 	--color-warning: #eca700;
 	--color-success: #46ba61;
 
-	--color-cursor-blink-background: #fff;
-
 	--color-box-shadow: rgba(0, 0, 0, 0.5);
+}
+
+[data-bg-theme='dark'] {
+	--color-cursor-blink-background: #fff;
 }

--- a/browser/css/color-palette.css
+++ b/browser/css/color-palette.css
@@ -46,7 +46,9 @@
 	--color-warning: #eca700;
 	--color-success: #46ba61;
 
-	--color-cursor-blink-background: #000;
-
 	--color-box-shadow: rgba(77, 77, 77, 0.5);
+}
+
+[data-bg-theme='light'] {
+	--color-cursor-blink-background: #000;
 }

--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -607,7 +607,7 @@ function getInitializerClass() {
 	};
 
 	global.prefs = {
-		_localStorageChanges: {}, // TODO: change this to new Map() when JS version allows
+		_localStorageCache: {}, // TODO: change this to new Map() when JS version allows
 		canPersist: (function() {
 			var str = 'localstorage_test';
 			try {
@@ -660,8 +660,8 @@ function getInitializerClass() {
 		},
 
 		get: function(key, defaultValue = undefined) {
-			if (key in global.prefs._localStorageChanges) {
-				return global.prefs._localStorageChanges[key];
+			if (key in global.prefs._localStorageCache) {
+				return global.prefs._localStorageCache[key];
 			}
 
 			const uiDefault = global.prefs._getUIDefault(key);
@@ -669,6 +669,7 @@ function getInitializerClass() {
 				!global.savedUIState &&
 				uiDefault !== undefined
 			) {
+				global.prefs._localStorageCache[key] = uiDefault;
 				return uiDefault;
 			}
 
@@ -676,14 +677,17 @@ function getInitializerClass() {
 				const localStorageItem = global.localStorage.getItem(key);
 
 				if (localStorageItem) {
+					global.prefs._localStorageCache[key] = localStorageItem;
 					return localStorageItem;
 				}
 			}
 
 			if (uiDefault !== undefined) {
+				global.prefs._localStorageCache[key] = uiDefault;
 				return uiDefault;
 			}
 
+			global.prefs._localStorageCache[key] = defaultValue;
 			return defaultValue;
 		},
 
@@ -692,14 +696,14 @@ function getInitializerClass() {
 			if (global.prefs.canPersist) {
 				global.localStorage.setItem(key, value);
 			}
-			global.prefs._localStorageChanges[key] = value;
+			global.prefs._localStorageCache[key] = value;
 		},
 
 		remove: function(key) {
 			if (global.prefs.canPersist) {
 				global.localStorage.removeItem(key);
 			}
-			global.prefs._localStorageChanges[key] = undefined;
+			global.prefs._localStorageCache[key] = undefined;
 		},
 
 		getBoolean: function(key, defaultValue = false) {

--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -1664,6 +1664,9 @@ function getInitializerClass() {
 				const darkTheme = window.prefs.getBoolean('darkTheme');
 				msg += ' darkTheme=' + darkTheme;
 
+				const darkBackground = window.prefs.getBoolean('darkBackgroundForTheme.' + (darkTheme ? 'dark' : 'light'), darkTheme);
+				msg += ' darkBackground=' + darkBackground;
+
 				msg += ' timezone=' + Intl.DateTimeFormat().resolvedOptions().timeZone;
 
 				global.socket.send(msg);

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -112,21 +112,32 @@ L.Control.UIManager = L.Control.extend({
 		var cmd = { 'NewTheme': { 'type': 'string', 'value': '' } };
 		activate ? cmd.NewTheme.value = 'Dark' : cmd.NewTheme.value = 'Light';
 		app.socket.sendMessage('uno .uno:InvertBackground ' + JSON.stringify(cmd));
-		if (this.map.getDocType() == 'spreadsheet') {
-			var lightCanvasColor = window.getComputedStyle(document.documentElement).getPropertyValue('--color-canvas-light');
-			var darkCanvasColor = window.getComputedStyle(document.documentElement).getPropertyValue('--color-canvas-dark');
-			var nColor = app.sectionContainer.getClearColor(); // Current color of the canvas
-			// invert canvas color
-			nColor == lightCanvasColor ? nColor = darkCanvasColor : nColor = lightCanvasColor
-			this.setCanvasColorAfterModeChange(nColor);
-		}
+		this.initDarkBackgroundUI(activate);
 	},
 
-	applyInvert: function() {
+	initDarkBackgroundUI: function(activate) {
+		if (this.map.getDocType() == 'spreadsheet') {
+			var canvasColor;
+			if (activate) {
+				canvasColor = window.getComputedStyle(document.documentElement).getPropertyValue('--color-canvas-dark');
+			} else {
+				canvasColor = window.getComputedStyle(document.documentElement).getPropertyValue('--color-canvas-light');
+			}
+			this.setCanvasColorAfterModeChange(canvasColor);
+		}
+		document.documentElement.setAttribute('data-bg-theme', activate ? 'dark' : 'light');
+	},
+
+	applyInvert: function(skipCore) {
 		// get the initial mode
 		var inDarkTheme = window.prefs.getBoolean('darkTheme');
 		var backgroundDark = window.prefs.getBoolean('darkBackgroundForTheme.' + (inDarkTheme ? 'dark' : 'light'), inDarkTheme);
-		this.setDarkBackground(backgroundDark);
+
+		if (skipCore) {
+			this.initDarkBackgroundUI(backgroundDark);
+		} else {
+			this.setDarkBackground(backgroundDark);
+		}
 	},
 
 	toggleInvert: function() {
@@ -174,6 +185,8 @@ L.Control.UIManager = L.Control.extend({
 		} else {
 			this.loadLightMode();
 		}
+
+		this.applyInvert(true);
 	},
 
 	activateDarkModeInCore: function(activate) {

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -108,8 +108,10 @@ L.Control.UIManager = L.Control.extend({
 		}
 	},
 
-	invertBackground: function() {
-		app.socket.sendMessage('uno .uno:InvertBackground');
+	setDarkBackground: function(activate) {
+		var cmd = { 'NewTheme': { 'type': 'string', 'value': '' } };
+		activate ? cmd.NewTheme.value = 'Dark' : cmd.NewTheme.value = 'Light';
+		app.socket.sendMessage('uno .uno:InvertBackground ' + JSON.stringify(cmd));
 		if (this.map.getDocType() == 'spreadsheet') {
 			var lightCanvasColor = window.getComputedStyle(document.documentElement).getPropertyValue('--color-canvas-light');
 			var darkCanvasColor = window.getComputedStyle(document.documentElement).getPropertyValue('--color-canvas-dark');
@@ -117,6 +119,30 @@ L.Control.UIManager = L.Control.extend({
 			// invert canvas color
 			nColor == lightCanvasColor ? nColor = darkCanvasColor : nColor = lightCanvasColor
 			this.setCanvasColorAfterModeChange(nColor);
+		}
+	},
+
+	applyInvert: function() {
+		// get the initial mode
+		var inDarkTheme = window.prefs.getBoolean('darkTheme');
+		var backgroundDark = window.prefs.getBoolean('darkBackgroundForTheme.' + (inDarkTheme ? 'dark' : 'light'), inDarkTheme);
+		this.setDarkBackground(backgroundDark);
+	},
+
+	toggleInvert: function() {
+		// get the initial mode
+		var inDarkTheme = window.prefs.getBoolean('darkTheme');
+		var darkBackgroundPrefName = 'darkBackgroundForTheme.' + (inDarkTheme ? 'dark' : 'light');
+		var backgroundDark = window.prefs.getBoolean(darkBackgroundPrefName, inDarkTheme);
+
+		// swap them by invoking the appropriate load function and saving the state
+		if (backgroundDark) {
+			window.prefs.set(darkBackgroundPrefName, false);
+			this.setDarkBackground(false);
+		}
+		else {
+			window.prefs.set(darkBackgroundPrefName, true);
+			this.setDarkBackground(true);
 		}
 	},
 
@@ -154,6 +180,7 @@ L.Control.UIManager = L.Control.extend({
 		var cmd = { 'NewTheme': { 'type': 'string', 'value': '' } };
 		activate ? cmd.NewTheme.value = 'Dark' : cmd.NewTheme.value = 'Light';
 		app.socket.sendMessage('uno .uno:ChangeTheme ' + JSON.stringify(cmd));
+		this.applyInvert();
 	},
 
 	renameDocument: function() {

--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -248,6 +248,9 @@ app.definitions.Socket = L.Class.extend({
 		const darkTheme = window.prefs.getBoolean('darkTheme');
 		msg += ' darkTheme=' + darkTheme;
 
+		const darkBackground = window.prefs.getBoolean('darkBackgroundForTheme.' + (darkTheme ? 'dark' : 'light'), darkTheme);
+		msg += ' darkBackground=' + darkBackground;
+
 		var isCalcTest =
 			window.docURL.includes('data/desktop/calc/') ||
 			window.docURL.includes('data/mobile/calc/') ||

--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -250,6 +250,7 @@ app.definitions.Socket = L.Class.extend({
 
 		const darkBackground = window.prefs.getBoolean('darkBackgroundForTheme.' + (darkTheme ? 'dark' : 'light'), darkTheme);
 		msg += ' darkBackground=' + darkBackground;
+		this._map.uiManager.initDarkBackgroundUI(darkBackground);
 
 		var isCalcTest =
 			window.docURL.includes('data/desktop/calc/') ||
@@ -1512,8 +1513,11 @@ app.definitions.Socket = L.Class.extend({
 			this._map._docLayer._refreshTilesInBackground();
 			this._map.fire('statusindicator', { statusType: 'reconnected' });
 
-			var selectedMode = window.prefs.getBoolean('darkTheme');
-			this._map.uiManager.activateDarkModeInCore(selectedMode);
+			var darkTheme = window.prefs.getBoolean('darkTheme');
+			this._map.uiManager.activateDarkModeInCore(darkTheme);
+
+			var darkBackground = window.prefs.getBoolean('darkBackgroundForTheme.' + (darkTheme ? 'dark' : 'light'), darkTheme);
+			this._map.uiManager.setDarkBackground(darkBackground);
 
 			var uiMode = this._map.uiManager.getCurrentMode();
 			if (uiMode === 'notebookbar') {

--- a/browser/src/docdispatcher.ts
+++ b/browser/src/docdispatcher.ts
@@ -103,7 +103,7 @@ class Dispatcher {
 			app.map.uiManager.toggleDarkMode();
 		};
 		this.actionsMap['invertbackground'] = function () {
-			app.map.uiManager.invertBackground();
+			app.map.uiManager.toggleInvert();
 		};
 		this.actionsMap['home-search'] = function () {
 			app.map.uiManager.focusSearch();

--- a/common/Session.cpp
+++ b/common/Session.cpp
@@ -202,6 +202,11 @@ void Session::parseDocOptions(const StringVector& tokens, int& part, std::string
             _darkTheme = value;
             ++offset;
         }
+        else if (name == "darkBackground")
+        {
+            _darkBackground = value;
+            ++offset;
+        }
         else if (name == "batch")
         {
             _batch = value;

--- a/common/Session.hpp
+++ b/common/Session.hpp
@@ -263,6 +263,8 @@ public:
 
     const std::string& getDarkTheme() const { return _darkTheme; }
 
+    const std::string& getDarkBackground() const { return _darkBackground; }
+
     const std::string& getBatchMode() const { return _batch; }
 
     const std::string& getEnableMacrosExecution() const { return _enableMacrosExecution; }
@@ -384,6 +386,9 @@ private:
 
     /// The start value for Dark Theme whether it is active or not on start.
     std::string _darkTheme;
+    ///
+    /// The start value for Dark Background whether it is active or not on start.
+    std::string _darkBackground;
 
     /// Disable dialogs interactivity.
     std::string _batch;

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1752,6 +1752,12 @@ std::string Document::getDefaultTheme(const std::shared_ptr<ChildSession>& sessi
     return darkTheme ? "Dark" : "Light";
 }
 
+std::string Document::getDefaultBackgroundTheme(const std::shared_ptr<ChildSession>& session) const
+{
+    bool darkTheme = session->getDarkBackground() == "true";
+    return darkTheme ? "Dark" : "Light";
+}
+
 std::shared_ptr<lok::Document> Document::load(const std::shared_ptr<ChildSession>& session,
                                               const std::string& renderOpts)
 {
@@ -1934,12 +1940,14 @@ std::shared_ptr<lok::Document> Document::load(const std::shared_ptr<ChildSession
     }
     std::string theme = getDefaultTheme(session);
 
+    std::string backgroundTheme = getDefaultBackgroundTheme(session);
+
     LOG_INF("Initializing for rendering session [" << sessionId << "] on document url [" <<
-            anonymizeUrl(_url) << "] with: [" << makeRenderParams(_renderOpts, userNameAnonym, spellOnline, theme) << "].");
+            anonymizeUrl(_url) << "] with: [" << makeRenderParams(_renderOpts, userNameAnonym, spellOnline, theme, backgroundTheme) << "].");
 
     // initializeForRendering() should be called before
     // registerCallback(), as the previous creates a new view in Impress.
-    const std::string renderParams = makeRenderParams(_renderOpts, userName, spellOnline, theme);
+    const std::string renderParams = makeRenderParams(_renderOpts, userName, spellOnline, theme, backgroundTheme);
 
     _loKitDocument->initializeForRendering(renderParams.c_str());
 
@@ -2082,7 +2090,8 @@ Object::Ptr makePropertyValue(const std::string& type, const T& val)
 }
 
 /* static */ std::string Document::makeRenderParams(const std::string& renderOpts, const std::string& userName,
-                                                    const std::string& spellOnline, const std::string& theme)
+                                                    const std::string& spellOnline, const std::string& theme,
+                                                    const std::string& backgroundTheme)
 {
     Object::Ptr renderOptsObj;
 
@@ -2114,6 +2123,9 @@ Object::Ptr makePropertyValue(const std::string& type, const T& val)
 
     if (!theme.empty())
         renderOptsObj->set(".uno:ChangeTheme", makePropertyValue("string", theme));
+
+    if (!backgroundTheme.empty())
+        renderOptsObj->set(".uno:InvertBackground", makePropertyValue("string", backgroundTheme));
 
     if (renderOptsObj)
     {

--- a/kit/Kit.hpp
+++ b/kit/Kit.hpp
@@ -312,13 +312,16 @@ private:
 
     std::string getDefaultTheme(const std::shared_ptr<ChildSession>& session) const;
 
+    std::string getDefaultBackgroundTheme(const std::shared_ptr<ChildSession>& session) const;
+
     std::shared_ptr<lok::Document> load(const std::shared_ptr<ChildSession>& session,
                                         const std::string& renderOpts);
 
     bool forwardToChild(const std::string& prefix, const std::vector<char>& payload);
 
     static std::string makeRenderParams(const std::string& renderOpts, const std::string& userName,
-                                        const std::string& spellOnline, const std::string& theme);
+                                        const std::string& spellOnline, const std::string& theme,
+                                        const std::string& backgroundTheme);
     bool isTileRequestInsideVisibleArea(const TileCombined& tileCombined);
 
 public:

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1348,6 +1348,11 @@ bool ClientSession::loadDocument(const char* /*buffer*/, int /*length*/,
             oss << " darkTheme=" << getDarkTheme();
         }
 
+        if (!getDarkBackground().empty())
+        {
+            oss << " darkBackground=" << getDarkBackground();
+        }
+
         if (!getWatermarkText().empty())
         {
             std::string encodedWatermarkText;


### PR DESCRIPTION
This change makes our calls to .uno:InvertBackground specify the desired
theme (requires core change I05486860c5f562c3cfa59b4a7fc492d48913a181),
saves the background theme for different color themes, applying it when
they are loaded, and sends the previous theme on document load (requires
core change I8c22c03d3b4589736d48509004f7789dd5166389)

We need to send the desired background theme manually, as otherwise Core
looks at a global document background theme, meaning that switching your
background theme actually switches to whatever wasn't the last background
theme set by anyone

It's also nice to preserve this inverted document background, both when
switching in/out of dark mode and when reloading the document entirely.

Storing the desired preference on a per-theme basis avoids us having a
dark background in light mode when we enabled inversion in dark mode,
but means we need to enable the preference whenever we switch theme.

---

Additionally, I noticed another issue with our saving/loading, so here's a more general fix to that:

fix(prefs): Cache localStorage values on read

Sometimes we'll read a value, change it in another tab, and later read
an inconsistent value from preferences. This can do things like making
the invert background button need to be pressed twice to change whether
the background is inverted, if you change it in another tab

It's better to only use localStorage for saving/loading values and use
something else to read from where possible as this makes sure the
preference values we read will be stable unless we change them

To reflect it no longer storing only changes, I've changed the name of
the _localStorageChanges to _localStorageCache

---

Restoring the theme on load/theme change doesn't seem to work properly in calc, however as there are other similar issues with invert background in calc (e.g. #9627) I think it's better to get this in and then make another change fixing the calc issues here...