### PR TITLE
github, codeql: no need to run tests

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -77,7 +77,7 @@ jobs:
 
     - if: matrix.language == 'cpp'
       name: Build
-      run: make -j `nproc`
+      run: make -j `nproc` build-nocheck
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
Those are invoked in other checks (on Jenkins) and recently one unit
test started to fail only here, so disable that till the problem is
understood there.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I57704c72ed239aadc460de1d2fd67b5cf0bc3597
