### PR TITLE
docker: update URLs used (24.04)

### DIFF
--- a/docker/from-packages/Dockerfile
+++ b/docker/from-packages/Dockerfile
@@ -11,7 +11,7 @@ ARG author
 LABEL author=${author:-"Collabora Productivity Ltd."}
 LABEL description="Collabora Online is a powerful collaborative Office suite that supports all major document, spreadsheet and presentation file formats, which you can integrate into your own infrastructure. Collabora Online provides data security and sovereignty, and is ideally suited to the demands of a modern distributed working environment. Delivering a familiar look and feel, Collabora Online represents a real alternative to other big-brands solutions, giving you control and flexibility."
 ARG releasenotes
-LABEL release.notes=${releasenotes:-"https://www.collaboraoffice.com/code-24-04-release-notes/"}
+LABEL release.notes=${releasenotes:-"https://www.collaboraonline.com/code-24-04-release-notes/"}
 ARG version
 LABEL version=${version:-"24.04.1.3"}
 ARG coretag
@@ -43,7 +43,7 @@ RUN --mount=type=secret,id=secret_key \
 # Install dependencies of installer of Collabora Online
     apt-get -y install cpio tzdata libcap2-bin apt-transport-https gnupg2 ca-certificates curl && \
 # Setup Collabora repo
-    repourl="https://collaboraoffice.com/${repo:-repos}/CollaboraOnline/"; \
+    repourl="https://collaboraonline.com/${repo:-repos}/CollaboraOnline/"; \
     secret_key=$(cat /run/secrets/secret_key); \
     if [ "$type" = "cool" ] && [ -n ${secret_key+set} ]; then \
         echo "Based on the provided build arguments Collabora Online from customer repo will be used."; \
@@ -58,10 +58,10 @@ RUN --mount=type=secret,id=secret_key \
     echo "deb [signed-by=/usr/share/keyrings/collaboraonline-release-keyring.gpg] ${repourl} /" > /etc/apt/sources.list.d/collabora.list && \
 # Download Collabora package signing key
     if [ "$repo" = "repos-snapshot" ]; then \
-        curl https://www.collaboraoffice.com/downloads/gpg/collaboraonline-snapshot-keyring.gpg --output /usr/share/keyrings/collaboraonline-snapshot-keyring.gpg; \
+        curl -L https://www.collaboraonline.com/downloads/gpg/collaboraonline-snapshot-keyring.gpg --output /usr/share/keyrings/collaboraonline-snapshot-keyring.gpg; \
         sed -i "s/collaboraonline-release-keyring/collaboraonline-snapshot-keyring/" /etc/apt/sources.list.d/collabora.list; \
     else \
-        curl https://www.collaboraoffice.com/downloads/gpg/collaboraonline-release-keyring.gpg --output /usr/share/keyrings/collaboraonline-release-keyring.gpg; \
+        curl -L https://www.collaboraonline.com/downloads/gpg/collaboraonline-release-keyring.gpg --output /usr/share/keyrings/collaboraonline-release-keyring.gpg; \
     fi && \
 # Update repos again
     apt-get update && \


### PR DESCRIPTION
Ports #9623/#9624 to `distro/collabora/24.04` branch. 

* Resolves: (no open Github issues)
* Target version: 24.04
* ChangeId: I39cc4329fcb640f853d691663fe3ef92619eafbe

### Summary

This fix was necessary to ensure curl would follow redirects following the change of domain from collaboraoffice.com to collaboraonline.com. This PR cherry-picks the same commit and applies it to the `distro/collabora/24.04` branch.

