### PR TITLE
SlideShowPresenter: some fixes

### DIFF
--- a/browser/src/slideshow/LayerDrawing.ts
+++ b/browser/src/slideshow/LayerDrawing.ts
@@ -337,6 +337,11 @@ class LayerDrawing {
 
 	private drawBackground(slideHash: string) {
 		this.clearCanvas();
+
+		// always draw a solid white rectangle behind the background
+		this.offscreenContext.fillStyle = '#FFFFFF';
+		this.offscreenContext.fillRect(0, 0, this.canvasWidth, this.canvasHeight);
+
 		const slideInfo = this.getSlideInfo(slideHash);
 		if (!slideInfo.background) return true;
 

--- a/browser/src/slideshow/SlideRenderer.ts
+++ b/browser/src/slideshow/SlideRenderer.ts
@@ -131,6 +131,8 @@ class SlideRenderer2d extends SlideRenderer {
 
 	protected render() {
 		const gl = this._context.get2dGl();
+		gl.clearRect(0, 0, gl.canvas.width, gl.canvas.height);
+
 		const width = (this._slideTexture as ImageBitmap).width;
 		const height = (this._slideTexture as ImageBitmap).height;
 		const halfWidth = (1.0 * gl.canvas.width - width) / 2.0;

--- a/browser/src/slideshow/SlideShowPresenter.ts
+++ b/browser/src/slideshow/SlideShowPresenter.ts
@@ -316,6 +316,7 @@ class SlideShowPresenter {
 				if (slideShowWindow.closed) {
 					clearInterval(this._windowCloseInterval);
 					this._map.uiManager.closeSnackbar();
+					this._slideShowCanvas = null;
 					this._slideShowWindowProxy = null;
 				}
 			}.bind(this),


### PR DESCRIPTION
Draw a white rectangle behind a slide or shape with a not
solid color will not look correct if the slide has no background.

Set canvas to null when presentation is over also for the present in a
window case or we can't play presentation a second time.

Signed-off-by: Marco Cecchetti <marco.cecchetti@collabora.com>
Change-Id: Ice9b66b1f262eca8758366ba4badbd44f0244248
