### PR TITLE
Fix event binding issue by initializing event handlers once

### DIFF
--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -1497,6 +1497,11 @@ L.Control.Menubar = L.Control.extend({
 	},
 
 	_onRefresh: function() {
+		if (!this._initialized) {
+			this._initialized = true;
+			this._onDocLayerInit();
+		}
+
 		// clear initial menu
 		L.DomUtil.removeChildNodes(this._menubarCont);
 
@@ -1532,6 +1537,24 @@ L.Control.Menubar = L.Control.extend({
 		document.getElementById('main-menu').setAttribute('role', 'menubar');
 		this._addTabIndexPropsToMainMenu();
 		this._createFileIcon();
+	},
+
+	// Function to check if an event is already bound
+	_isEventBound: function(element, eventType, namespace) {
+		var events = $._data($(element)[0], 'events');
+		if (events && events[eventType]) {
+			return namespace 
+				? events[eventType].some(event => event.namespace === namespace)
+				: true;
+		}
+		return false;
+	},
+
+	// Function to bind an event if it's not already bound
+	_bindEventIfNotBound: function(element, eventType, namespace, data, handler) {
+		if (!this._isEventBound(element, eventType, namespace)) {
+			$(element).bind(eventType + (namespace ? '.' + namespace : ''), data, handler);
+		}
 	},
 
 	_onStyleMenu: function (e) {
@@ -1577,12 +1600,11 @@ L.Control.Menubar = L.Control.extend({
 	_onDocLayerInit: function() {
 		this._onRefresh();
 
-		$('#main-menu').bind('select.smapi', {self: this}, this._onItemSelected);
-
-		$('#main-menu').bind('beforeshow.smapi', {self: this}, this._beforeShow);
-		$('#main-menu').bind('click.smapi', {self: this}, this._onClicked);
-
-		$('#main-menu').bind('keydown', {self: this}, this._onKeyDown);
+		// Usage
+		this._bindEventIfNotBound('#main-menu', 'select', 'smapi', {self: this}, this._onItemSelected);
+		this._bindEventIfNotBound('#main-menu', 'beforeshow', 'smapi', {self: this}, this._beforeShow);
+		this._bindEventIfNotBound('#main-menu', 'click', 'smapi', {self: this}, this._onClicked);
+		this._bindEventIfNotBound('#main-menu', 'keydown', '', {self: this}, this._onKeyDown);
 
 		if (window.mode.isMobile()) {
 			$('#main-menu').parent().css('height', '0');


### PR DESCRIPTION
- For 'marked read only' file somehow menubar item does not get initialized.

This patch:

- Introduced `isEventBound` function to check if an event with a specific type and namespace is already bound to an element.
- Simplified the `isEventBound` function to use the `Array.prototype.some` method for namespace checking.
- Created `bindEventIfNotBound` function to bind events only if they are not already bound.
- Updated event binding for `#main-menu` to use `bindEventIfNotBound`, preventing duplicate bindings for 'select.smapi', 'beforeshow.smapi', 'click.smapi', and 'keydown' events.

Signed-off-by: Darshan-upadhyay1110 <darshan.upadhyay@collabora.com>
Change-Id: I26c95a7e366270b0020ce0fb27055f5acf9c1539


* Resolves: #9632 
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

