### PR TITLE
fix: Cell header context menu

### DIFF
--- a/browser/src/control/Control.Header.ts
+++ b/browser/src/control/Control.Header.ts
@@ -491,7 +491,7 @@ export class Header extends app.definitions.canvasSectionObject {
 		$.contextMenu({
 			selector: '#canvas-container',
 			className: 'cool-font',
-			zIndex: 10,
+			zIndex: 1500,
 			items: this._menuItem,
 			callback: function() { return; }
 		});


### PR DESCRIPTION
Previously, when a row or column header context menu is openend, you could access the spreadsheet toolbar (switch sheets, scroll right etc..) and the context menu would stay open.

This was also an issue with the cell context menu aswell but skyler fixed it by changing the z-index of the its overlay. Howevever, the row and column header context menu's were left unchanged, so now the overlay for the context menu is above the spreadsheet toolbar.


Change-Id: I8dfe2304d86c15d1b343890797b9b2600ed61e31


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

