### PR TITLE
calc autofilter disable already filtered entries

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -467,7 +467,8 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 	padding-inline-end: 3px;
 }
 
-.ui-treeview.disabled {
+.ui-treeview.disabled,
+.ui-treeview-entry.disabled {
 	background-color: var(--color-background-dark) !important;
 	color: var(--color-text-lighter) !important;
 }

--- a/browser/src/control/jsdialog/Widget.TreeView.js
+++ b/browser/src/control/jsdialog/Widget.TreeView.js
@@ -51,6 +51,7 @@
  *
  * 'row' property is used in the callback to differentiate entries
  * 'state' property defines if entry has the checkbox (false/true), when is missing - no checkbox
+ * 'enabled' property defines if entry checkbox is enabled
  * 'ondemand' property can be set to provide nodes lazy loading
  * 'collapsed' property means, this entry have childrens, but they are not visible, because
  *             this branch is collapsed.
@@ -82,7 +83,10 @@ function _createCheckbox(parentContainer, treeViewData, builder, entry) {
 	if (entry.state === 'true' || entry.state === true)
 		checkbox.checked = true;
 
-	if (treeViewData.enabled !== false && treeViewData.enabled !== 'false') {
+	if (entry.enabled === false || entry.enabled === "false") {
+		checkbox.disabled = true;
+	}
+	else if (treeViewData.enabled !== false && treeViewData.enabled !== 'false') {
 		$(checkbox).change(function() {
 			_changeCheckboxStateOnClick(this, treeViewData, builder, entry);
 		});
@@ -180,7 +184,7 @@ function _treelistboxEntry(parentContainer, treeViewData, entry, builder, isTree
 
 	treeRoot = treeRoot ? treeRoot : parentContainer;
 
-	var disabled = treeViewData.enabled === 'false' || treeViewData.enabled === false;
+	var disabled = treeViewData.enabled === 'false' || treeViewData.enabled === false || entry.enabled === false || entry.enabled === 'false';
 
 	var li = L.DomUtil.create('li', builder.options.cssClass, parentContainer);
 	if (_isSeparator(entry)) {
@@ -207,6 +211,9 @@ function _treelistboxEntry(parentContainer, treeViewData, entry, builder, isTree
 
 	var span = L.DomUtil.create('span', builder.options.cssClass + ' ui-treeview-entry ' + (entry.children ? ' ui-treeview-expandable' : 'ui-treeview-notexpandable'), li);
 	span.setAttribute('role', isTreeView ? 'treeitem' : 'option');
+	if (entry.enabled === false || entry.enabled === 'false') {
+		L.DomUtil.addClass(span, 'disabled');
+	}
 
 	var expander = L.DomUtil.create('div', builder.options.cssClass + ' ui-treeview-expander ', span);
 

--- a/cypress_test/integration_tests/desktop/calc/autofilter_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/autofilter_spec.js
@@ -118,4 +118,20 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'AutoFilter', function() {
 
 		calcHelper.assertSheetContents(['Cypress Test', 'Status', 'Test 1', 'Pass'], true);
 	});
+
+	it('Disable already filtered', function () {
+		// Filter row with ['Test 4', ''] on the first column
+		calcHelper.openAutoFilterMenu();
+		cy.cGet('#check_list_box > tbody > ul > li:nth-child(4) > span > input').click();
+		cy.cGet('#ok').click();
+		// Wait for autofilter dialog to close
+		cy.cGet('div.autofilter').should('not.exist');
+
+		// Open autofilter menu on the second column
+		calcHelper.openAutoFilterMenu(true);
+		// Check that '(empty)' option is disabled
+		cy.cGet('#check_list_box > tbody > ul > li:nth-child(3) > span').should('contain.text', '(empty)');
+		cy.cGet('#check_list_box > tbody > ul > li:nth-child(3) > span > input').should('be.disabled');
+
+	});
 });


### PR DESCRIPTION
On autofilter disable entries that have already been filtered out by
another autofilter. The same as it works on desktop.

Signed-off-by: Jaume Pujantell <jaume.pujantell@collabora.com>
Change-Id: I72a9999d9a6ba2f257bb88f8abeee99b01e55e4a
