### PR TITLE
fix(android): Allow document loading

### DIFF
--- a/browser/html/cool.html.m4
+++ b/browser/html/cool.html.m4
@@ -36,7 +36,7 @@ m4_ifelse(EMSCRIPTENAPP,[true],[m4_define([MOBILEAPP],[true])])
 m4_ifelse(MOBILEAPP, [true],
 [
   <input type="hidden" id="init-app-type" value="mobile" />
-  <input type="hidden" id="init-help-file" value="m4_syscmd([cat html/cool-help.html])" />
+  <input type="hidden" id="init-help-file" value="m4_syscmd([cat html/cool-help.html | sed 's/"/\&quot;/g'])" />
 ],
 [
   <input type="hidden" id="init-welcome-url" value="%WELCOME_URL%" />

--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -255,9 +255,9 @@ class InitializerBase {
 		this.uriPrefix = document.getElementById('init-uri-prefix').value;
 		this.brandingUriPrefix = this.uriPrefix;
 
-		window.welcomeUrl = document.getElementById("init-welcome-url").value ? document.getElementById("init-welcome-url").value: "";
-		window.feedbackUrl = document.getElementById("init-feedback-url").value ? document.getElementById("init-feedback-url").value: "";
-		window.buyProductUrl = document.getElementById("init-buy-product-url").value ? document.getElementById("init-buy-product-url").value: "";
+		window.welcomeUrl = document.getElementById("init-welcome-url") ? document.getElementById("init-welcome-url").value: "";
+		window.feedbackUrl = document.getElementById("init-feedback-url") ? document.getElementById("init-feedback-url").value: "";
+		window.buyProductUrl = document.getElementById("init-buy-product-url") ? document.getElementById("init-buy-product-url").value: "";
 
 		const element = document.getElementById("initial-variables");
 


### PR DESCRIPTION
In I3155e799530d4c307569e88612a13570d0913e03, the mobile app was broken in 2 ways. This change fixes both of them. Here they are:

- First, certain elements were excluded on mobile. We presumably meant to check whether they were present before reading their value, but instead looked at whether they had a value ... this caused an error where we attempted to get a property on "undefined", crashing out of our initialization
- Second, we hardcoded the help information by catting `html/cool-help.html` into an input's value attribute in m4. Unfortunately, we neglected to add any form of escaping to speech marks, which caused it to flow out of its attribute... polluting the rest of the page with broken help information. I've used sed to replace speech marks with escaped HTML entities


Change-Id: I74d84afc3d333d4158f3be9c103f2c3131f26299


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

