### PR TITLE
clipboard: mobile: fixed js error

### DIFF
--- a/browser/src/control/Control.DownloadProgress.js
+++ b/browser/src/control/Control.DownloadProgress.js
@@ -138,7 +138,8 @@ L.Control.DownloadProgress = L.Control.extend({
 				e.preventDefault();
 			}
 		};
-		document.getElementById(eventTargetId).onkeydown = keyDownCallback.bind(this);
+		if (document.getElementById(eventTargetId))
+			document.getElementById(eventTargetId).onkeydown = keyDownCallback.bind(this);
 	},
 
 	setupKeyboardShortcutForDialog: function (modalId) {


### PR DESCRIPTION
in mobile when user copied anything using context menu, user used to get unwanted message due to incorrectly triggered keydown event. message said "use on screen keyboard for copy/paste" which is not even possible in case of copying


Change-Id: I586021db1d1551d53993ba0791071ede8e742681


* Target version: master 



### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

