### PR TITLE
Added method to disable spell check if document is read-only

### DIFF
--- a/common/Session.cpp
+++ b/common/Session.cpp
@@ -246,6 +246,17 @@ void Session::parseDocOptions(const StringVector& tokens, int& part, std::string
                 _docOptions += tokens.cat(' ', offset + 1);
         }
     }
+
+    // Disable spell check if the document is read-only
+    disableSpellCheckIfReadOnly();
+}
+
+void Session::disableSpellCheckIfReadOnly()
+{
+    if (_isReadOnly)
+    {
+        _spellOnline = "false";
+    }
 }
 
 void Session::disconnect()

--- a/common/Session.hpp
+++ b/common/Session.hpp
@@ -271,6 +271,8 @@ public:
 
     bool getAccessibilityState() const { return _accessibilityState; }
 
+    void disableSpellCheckIfReadOnly();
+
 protected:
     Session(const std::shared_ptr<ProtocolHandlerInterface> &handler,
             const std::string& name, const std::string& id, bool readonly);


### PR DESCRIPTION
Change-Id: I04eba16400825869522012eb16ba033200effeaa


* Resolves: #7935
* Target version: master 

### Summary
1. disableSpellCheckIfReadOnly Method:
    - Created a private method called disableSpellCheckIfReadOnly that updates the spellOnline property based on the isReadOnly status.
    - This method sets spellOnline to "false" if _isReadOnly is true, and keeps the current value otherwise.
    - Called disableSpellCheckIfReadOnly at the end of the parseDocOptions method to ensure spellOnline is set correctly based on the initial document options.

### Checklist

- [X] I have run `make prettier-write` and formatted the code.
- [X] All commits have Change-Id
- [ ] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required