### PR TITLE
Add missing trailing slash

### DIFF
--- a/browser/html/cool.html.m4
+++ b/browser/html/cool.html.m4
@@ -61,7 +61,7 @@ m4_ifelse(BUNDLE,[],
   <!-- Using individual CSS files -->
   m4_foreachq([fileCSS],[COOL_CSS],[<link rel="stylesheet" href="][m4_ifelse(MOBILEAPP,[],[%SERVICE_ROOT%/browser/%VERSION%/])][fileCSS" />
 ]),
-[<link rel="stylesheet" href="][m4_ifelse(MOBILEAPP,[],[%SERVICE_ROOT%/browser/%VERSION%/][bundle.css"])])
+[<link rel="stylesheet" href="][m4_ifelse(MOBILEAPP,[],[%SERVICE_ROOT%/browser/%VERSION%/][bundle.css" />])])
 
 <!--%BRANDING_CSS%--> <!-- add your logo here -->
 m4_ifelse(IOSAPP,[true],

--- a/browser/src/slideshow/transition/CombTransition.ts
+++ b/browser/src/slideshow/transition/CombTransition.ts
@@ -1,3 +1,5 @@
+/** */
+
 /*
  * Copyright the Collabora Online contributors.
  *

--- a/browser/src/slideshow/transition/DiagonalTransition.ts
+++ b/browser/src/slideshow/transition/DiagonalTransition.ts
@@ -1,3 +1,5 @@
+/** */
+
 /*
  * Copyright the Collabora Online contributors.
  *

--- a/browser/src/slideshow/transition/PushWipeTransition.ts
+++ b/browser/src/slideshow/transition/PushWipeTransition.ts
@@ -1,3 +1,5 @@
+/** */
+
 /*
  * Copyright the Collabora Online contributors.
  *


### PR DESCRIPTION
By looking at the top of the document "`<!DOCTYPE html>`" it seems we
don't need trailing slash for self-closing tags but maybe the parser
needs (?). This seems to be super safe and it would be nice to see if
it fixes the "fails to build a proper html tag, unclosed link tag" problem.

- For consistency (in other lines we use it)
- For XHTML-compatibility

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I00bf34104a5b56d094196cb2b912e1dc308b6253
