### PR TITLE
fix(pan): avoid range error in long pan

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -967,7 +967,7 @@ L.CanvasTileLayer = L.Layer.extend({
 		var newScrollPos = centerPixel.subtract(this._map.getSize().divideBy(2));
 		var x = Math.round(newScrollPos.x < 0 ? 0 : newScrollPos.x);
 		var y = Math.round(newScrollPos.y < 0 ? 0 : newScrollPos.y);
-		this._map.fire('updatescrolloffset', {x: x, y: y, updateHeaders: true});
+		requestAnimationFrame(() => this._map.fire('updatescrolloffset', {x: x, y: y, updateHeaders: true}));
 	},
 
 	_getTileSize: function () {


### PR DESCRIPTION
Previously, continuously panning for too long would cause a range error
like so...

TilesSection.ts:153 Uncaught RangeError: Maximum call stack size exceeded
TilesSection.drawTileInPane @ TilesSection.ts:153
-------------- 8< snip --------------
fire @ Events.js:152
_updateScrollOffset @ CanvasTileLayer.js:970
-------------- 8< snip --------------
fire @ Events.js:152
_updateScrollOffset @ CanvasTileLayer.js:970
-------------- 8< snip --------------
fire @ Events.js:152
_updateScrollOffset @ CanvasTileLayer.js:970

...this appears to be due to us continually checking if we're panning,
and if so continuing to recurse. Eventually, we run out of call stack
and error.

Erroring causes:
- A failure to draw tiles and UI properly, including but not limited to
  completely blanking out headers
- On some platforms, an error dialog
- An error in the console

To avoid this we can use requestAnimationFrame to defer part of this
loop, but still complete it before the next repaint...

Previous attempts at this patch had issues where using
requestAnimationFrame caused ordering issues... but this is called as an
event in relatively few places so I believe it to be safer...


Change-Id: Ib7422cadd3374590d163187c7c1c3ebe4ae0644e


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

