### PR TITLE
Widget: enable iconview with text

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1060,6 +1060,13 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	flex: 0 0 99%;
 }
 
+.icon-view-item-container {
+	max-width: 50px;
+	display: inline-block;
+	margin: 5px;
+	text-align: center;
+}
+
 /* Autofilter dropdown */
 
 .autofilter.row {

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1061,10 +1061,14 @@ input[type='number']:hover::-webkit-outer-spin-button {
 }
 
 .icon-view-item-container {
-	max-width: 50px;
-	display: inline-block;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
 	margin: 5px;
 	text-align: center;
+	word-wrap: break-word;
+	overflow-wrap: break-word;
 }
 
 /* Autofilter dropdown */

--- a/browser/src/control/jsdialog/Widget.IconView.ts
+++ b/browser/src/control/jsdialog/Widget.IconView.ts
@@ -177,12 +177,15 @@ JSDialog.iconView = function (
 		if (dropdown[pos]) {
 			dropdown[pos].innerHTML = '';
 
-			const container = L.DomUtil.create(
-				'div',
-				builder.options.cssClass,
-				dropdown[pos],
-			);
+			let container = dropdown[pos];
 
+			if (!data.entries[pos].tooltip) {
+				container = L.DomUtil.create(
+					'div',
+					builder.options.cssClass,
+					dropdown[pos],
+				);
+			}
 			const img = L.DomUtil.create('img', '', container);
 			img.src = builder.rendersCache[data.id].images[pos];
 

--- a/browser/src/control/jsdialog/Widget.IconView.ts
+++ b/browser/src/control/jsdialog/Widget.IconView.ts
@@ -176,13 +176,31 @@ JSDialog.iconView = function (
 		const dropdown = container.querySelectorAll('.ui-iconview-entry');
 		if (dropdown[pos]) {
 			dropdown[pos].innerHTML = '';
-			const img = L.DomUtil.create('img', '', dropdown[pos]);
+
+			const container = L.DomUtil.create(
+				'div',
+				builder.options.cssClass,
+				dropdown[pos],
+			);
+
+			const img = L.DomUtil.create('img', '', container);
 			img.src = builder.rendersCache[data.id].images[pos];
 
 			const entry = data.entries[pos];
 			img.alt = entry.text;
 			if (entry.tooltip) img.title = entry.tooltip;
-			else img.title = entry.text;
+			else { 
+				img.title = entry.text;
+				
+				// Add text below Icon
+				L.DomUtil.addClass(container, 'icon-view-item-container');
+				const placeholder = L.DomUtil.create(
+					'span',
+					".ui-iconview-entry-title",
+					container,
+				);
+				placeholder.innerText = entry.text;
+			}
 		}
 	};
 

--- a/browser/src/control/jsdialog/Widget.IconView.ts
+++ b/browser/src/control/jsdialog/Widget.IconView.ts
@@ -189,14 +189,14 @@ JSDialog.iconView = function (
 			const entry = data.entries[pos];
 			img.alt = entry.text;
 			if (entry.tooltip) img.title = entry.tooltip;
-			else { 
+			else {
 				img.title = entry.text;
-				
+
 				// Add text below Icon
 				L.DomUtil.addClass(container, 'icon-view-item-container');
 				const placeholder = L.DomUtil.create(
 					'span',
-					".ui-iconview-entry-title",
+					'.ui-iconview-entry-title',
 					container,
 				);
 				placeholder.innerText = entry.text;


### PR DESCRIPTION
Change-Id: I26aa8adc8bfdd8706fcb2dc28ad6c6af8d01196e

* Target version: master 

### Summary
- Previously, we only showed icons in cases where we wanted to display the IconView from the core. Now, if the IconView contains text, the text will be displayed below the icon from the IconView.

![Screenshot from 2024-08-01 18-22-46](https://github.com/user-attachments/assets/1b7bf413-5e97-4716-b7d7-e4aa2646164d)


### TODO

- [ ] Need to check everyplace use IconView. Make sure IconView is not broken.
