### PR TITLE
continue with coolwsd-systemplate-setup if already mounted

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -488,8 +488,13 @@ endif
 # the systemplate directory, which we can't rm if it's mounted.
 $(SYSTEM_STAMP): ${top_srcdir}/coolwsd-systemplate-setup $(CLEANUP_DEPS)
 	$(CLEANUP_COMMAND)
-	if test "z@SYSTEMPLATE_PATH@" != "z"; then chmod u+w -R --silent "@SYSTEMPLATE_PATH@" ; rm -rf "@SYSTEMPLATE_PATH@" && \
-	${top_srcdir}/coolwsd-systemplate-setup "@SYSTEMPLATE_PATH@" "@LO_PATH@" && touch $@; fi
+	if test "z@SYSTEMPLATE_PATH@" != "z"; then \
+		chmod u+w -R --silent "@SYSTEMPLATE_PATH@"; \
+		(rm -rf "@SYSTEMPLATE_PATH@" || \
+			echo "WARNING: failed to remove the systemplate") && \
+		${top_srcdir}/coolwsd-systemplate-setup "@SYSTEMPLATE_PATH@" "@LO_PATH@" && \
+		touch $@; \
+	fi
 
 @JAILS_PATH@:
 	@$(CLEANUP_COMMAND)


### PR DESCRIPTION
like how clean-local already ignores failure to entirely remove the old systemplate.

This can happen if a non-namespace mount was left behind by a non-namespace ver of online. Then a namespace version lacks the privileges to remove the classic mounts.


Change-Id: I3aade8540b1cace405f13fa3b41a8e91b50ab06c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

