### PR TITLE
fix(jsdialog): Trigger change without keyup

### DIFF
--- a/browser/src/control/jsdialog/Widget.MultilineEdit.js
+++ b/browser/src/control/jsdialog/Widget.MultilineEdit.js
@@ -56,13 +56,16 @@ function _multiLineEditControl(parentContainer, data, builder, callback) {
 		edit.disabled = true;
 	}
 
-	edit.addEventListener('keyup', function() {
+	function _keyupChangeHandler() {
 		if (callback)
 			callback(this.value);
 
 		builder.callback('edit', 'change', edit, this.value, builder);
 		setTimeout(function () { _sendSimpleSelection(edit, builder); }, 0);
-	});
+	}
+
+	edit.addEventListener('keyup', _keyupChangeHandler);
+	edit.addEventListener('change', _keyupChangeHandler); // required despite keyup as, e.g., iOS paste does not trigger keyup
 
 	edit.addEventListener('mouseup', function (event) {
 		if (edit.disabled) {


### PR DESCRIPTION
In 3bb07cdd528f37ec45af488ec6e58608cd041915, we changed the 'change' event for multiline text inputs to use 'keyup' instead. Unfortunately, that change forgets about ways in which the input field can change text without there being a 'keyup' event.

Of particular relevance to me is on iOS, where pasting into one a field won't trigger a 'keyup' event, leading to, e.g., QR codes to fail generation with pasted URLs

This patch is a bit unfortunate in that it makes things which *do* trigger 'keyup' events (which is most text edits) send double events for these text fields... I think there's some duplicate-event filtering that could be done, but I think it's better to get this in before worrying about it.


Change-Id: I188c13cfe7f5dbe2600551f4023d1c9d98bbbba2


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

