### PR TITLE
fix(calc): Restore inverted document on load

### DIFF
--- a/browser/css/color-palette-dark.css
+++ b/browser/css/color-palette-dark.css
@@ -12,8 +12,6 @@
 	--color-text-lighter: #fff; /* secondard text, disabled */
 	--color-status-badge: #d6d6d6;
 
-	--color-canvas-dark: #141414;
-	--color-background-document: #121212;
 	--color-main-background: #121212;
 	--color-background-dark: #1E1E1E;  /* select */
 	--color-background-darker: #000;  /* todo: apply to pressed (active), li:hover(top menu on classic mode)*/
@@ -50,4 +48,6 @@
 
 [data-bg-theme='dark'] {
 	--color-cursor-blink-background: #fff;
+	--color-canvas: #141414;
+	--color-background-document: #121212;
 }

--- a/browser/css/color-palette.css
+++ b/browser/css/color-palette.css
@@ -13,8 +13,6 @@
 	--color-text-lighter: #696969; /* secondard text, disabled */
 	--color-status-badge: #616161;
 
-	--color-canvas-light: #f5f5f5;
-	--color-background-document: #FFFFFF;
 	--color-main-background: #F8F9FA;
 	--color-background-dark: #e8e8e8;  /* select */
 	--color-background-darker: #c0bfbc;  /* todo: apply to pressed (active), li:hover(top menu on classic mode)*/
@@ -51,4 +49,6 @@
 
 [data-bg-theme='light'] {
 	--color-cursor-blink-background: #000;
+	--color-canvas: #f5f5f5;
+	--color-background-document: #FFFFFF;
 }

--- a/browser/src/canvas/CanvasSectionContainer.ts
+++ b/browser/src/canvas/CanvasSectionContainer.ts
@@ -251,10 +251,7 @@ class CanvasSectionContainer {
 		this.scrollLineHeight = parseInt(window.getComputedStyle(tempElement).fontSize);
 		document.body.removeChild(tempElement); // Remove the temporary element.
 
-		const colorCanvasPropety = (window as any).prefs ?
-			((window as any).prefs.getBoolean('darkTheme') ? '--color-canvas-dark' : '--color-canvas-light') : '--color-canvas-light';
-
-		this.clearColor = window.getComputedStyle(document.documentElement).getPropertyValue(colorCanvasPropety);
+		this.clearColor = window.getComputedStyle(document.documentElement).getPropertyValue('--color-canvas');
 		// Set document background color to the app background color for now until we get the real color from the kit
 		// through a LOK_CALLBACK_DOCUMENT_BACKGROUND_COLOR
 		this.documentBackgroundColor = window.getComputedStyle(document.documentElement).getPropertyValue('--color-background-document');

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -85,24 +85,24 @@ L.Control.UIManager = L.Control.extend({
 
 	loadLightMode: function() {
 		document.documentElement.setAttribute('data-theme','light');
-		this.setCanvasColorAfterModeChange();
 		this.map.fire('darkmodechanged');
 	},
 
 	loadDarkMode: function() {
 		document.documentElement.setAttribute('data-theme','dark');
-		this.setCanvasColorAfterModeChange();
 		this.map.fire('darkmodechanged');
 	},
 
-	setCanvasColorAfterModeChange: function(nColor) {
+	setCanvasColorAfterModeChange: function() {
 		if (app.sectionContainer) {
 			app.sectionContainer.setBackgroundColorMode(false);
-			if (nColor == undefined ) {
-				const colorCanvasPropety = window.prefs.getBoolean('darkTheme') ? '--color-canvas-dark' : '--color-canvas-light';
-				nColor = window.getComputedStyle(document.documentElement).getPropertyValue(colorCanvasPropety);
+
+			if (this.map.getDocType() == 'spreadsheet') {
+				app.sectionContainer.setClearColor(window.getComputedStyle(document.documentElement).getPropertyValue('--color-background-document'));
+			} else {
+				app.sectionContainer.setClearColor(window.getComputedStyle(document.documentElement).getPropertyValue('--color-canvas'));
 			}
-			app.sectionContainer.setClearColor(nColor);
+
 			//change back to it's default value after setting canvas color
 			app.sectionContainer.setBackgroundColorMode(true);
 		}
@@ -116,16 +116,8 @@ L.Control.UIManager = L.Control.extend({
 	},
 
 	initDarkBackgroundUI: function(activate) {
-		if (this.map.getDocType() == 'spreadsheet') {
-			var canvasColor;
-			if (activate) {
-				canvasColor = window.getComputedStyle(document.documentElement).getPropertyValue('--color-canvas-dark');
-			} else {
-				canvasColor = window.getComputedStyle(document.documentElement).getPropertyValue('--color-canvas-light');
-			}
-			this.setCanvasColorAfterModeChange(canvasColor);
-		}
 		document.documentElement.setAttribute('data-bg-theme', activate ? 'dark' : 'light');
+		this.setCanvasColorAfterModeChange();
 	},
 
 	applyInvert: function(skipCore) {
@@ -171,6 +163,8 @@ L.Control.UIManager = L.Control.extend({
 			this.loadDarkMode();
 			this.activateDarkModeInCore(true);
 		}
+		this.applyInvert();
+		this.setCanvasColorAfterModeChange();
 		if (!window.mode.isMobile())
 			this.refreshAfterThemeChange();
 
@@ -193,7 +187,6 @@ L.Control.UIManager = L.Control.extend({
 		var cmd = { 'NewTheme': { 'type': 'string', 'value': '' } };
 		activate ? cmd.NewTheme.value = 'Dark' : cmd.NewTheme.value = 'Light';
 		app.socket.sendMessage('uno .uno:ChangeTheme ' + JSON.stringify(cmd));
-		this.applyInvert();
 	},
 
 	renameDocument: function() {

--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -1515,9 +1515,8 @@ app.definitions.Socket = L.Class.extend({
 
 			var darkTheme = window.prefs.getBoolean('darkTheme');
 			this._map.uiManager.activateDarkModeInCore(darkTheme);
-
-			var darkBackground = window.prefs.getBoolean('darkBackgroundForTheme.' + (darkTheme ? 'dark' : 'light'), darkTheme);
-			this._map.uiManager.setDarkBackground(darkBackground);
+			this._map.uiManager.applyInvert();
+			this._map.uiManager.setCanvasColorAfterModeChange();
 
 			var uiMode = this._map.uiManager.getCurrentMode();
 			if (uiMode === 'notebookbar') {


### PR DESCRIPTION
Previously, we didn't have a way to restore the document background color on load for Calc, leading to a document that was inverted according to our LocalStorage and Core, but which didn't have the background to show it. This led to text rendering issues, as well as needing multiple presses to switch into invert background mode properly...

...in this change, I've simplified the calc background code to rely on our existing css data-bg-theme property, and made it consistently set the background color to --color-background-document ... it's possible this causes problems with changing themes alongside LOK_CALLBACK_DOCUMENT_BACKGROUND_COLOR, but I'm confident this is an improvement over the previous behavior as that should also have been true of it...

...this brings Calc invert backgrounds to parity with the other apps, in terms of saving/loading them properly...


Change-Id: I45b2fe174f1e7d0ed8fb6bc582a5932c86d4d3d1
Fixes: https://github.com/CollaboraOnline/online/issues/9538


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

