### PR TITLE
if creating a user ns worked, but mount doesn't then map orig uid

### DIFF
--- a/common/JailUtil.cpp
+++ b/common/JailUtil.cpp
@@ -70,14 +70,16 @@ bool enterMountingNS(uid_t uid, gid_t gid)
         return false;
     }
 
+    setdeny();
+
     // Do not propagate any mounts from this new namespace to the system.
     if (mount("none", "/", nullptr, MS_REC | MS_PRIVATE, nullptr) != 0)
     {
         LOG_ERR("enterMountingNS, root mount failed: " << strerror(errno));
+        // set to original uid so coolmount check isn't surprised by 'nobody'
+        mapuser(uid, uid, gid, gid);
         return false;
     }
-
-    setdeny();
 
     // Map this user as the root user of the new namespace
     mapuser(uid, 0, gid, 0);


### PR DESCRIPTION
if, like with apparmor, user namespaces are possible, but mounts are not (not even the initial "none" mount to not propogate mounts to the host env) then we are in a namespace, but not seen in our env as any particular user.

that leads to worrying warnings about "incorrect user-name" like:

```
[ coolwsd ] DBG  Move into user namespace as uid 0| wsd/COOLWSD.cpp:1965
[ coolwsd ] ERR  enterMountingNS, root mount failed: Inappropriate ioctl for device| common/JailUtil.cpp:78
[ coolwsd ] ERR  creating usernamespace for mount user failed.| wsd/COOLWSD.cpp:1969
[ coolwsd ] INF  Cleaning up childroot directory [/opt/cool/child-roots/].| common/JailUtil.cpp:307
[ coolwsd ] TRC  Checking pid for jail 3192148 /opt/cool/child-roots/| common/JailUtil.cpp:335
[ coolwsd ] DBG  Removing [/opt/cool/child-roots/3192148-91211bec/tmp] recursively.| common/FileUtil.cpp:210
[ coolwsd ] DBG  Removing [/opt/cool/child-roots/3192148-91211bec/linkable] recursively.| common/FileUtil.cpp
> Security: coolmount incorrect user-name, other than 'cool' Aborting.
```
so on namespace success, but initial mount failure, map the namespace user the original uid so coolmount is happy to continue


Change-Id: Ia4b5c79ae60c2c588a645850924728951d64446b


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

