### PR TITLE
Widget: enable iconview with text

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1044,6 +1044,8 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	border: 1px solid transparent;
 	border-radius: var(--border-radius);
 	padding-top: 5px;
+	text-wrap: nowrap;
+	font-family: var(--jquery-ui-font);
 }
 
 .ui-iconview-entry.selected {

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1061,6 +1061,17 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	flex: 0 0 99%;
 }
 
+.icon-view-item-container {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+	margin: 5px;
+	text-align: center;
+	word-wrap: break-word;
+	overflow-wrap: break-word;
+}
+
 /* Autofilter dropdown */
 
 .autofilter.row {

--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -370,6 +370,10 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 	padding-top: 0px;
 }
 
+#stylesview .ui-iconview-entry-title {
+	display: none;
+}
+
 #stylesview .ui-iconview-entry.selected {
 	border: 1px solid var(--color-border-darker);
 	border-collapse: separate; /*To use box-shadow in Internet Explorer 9 or later*/

--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -365,7 +365,6 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 }
 
 #stylesview .ui-iconview-entry {
-	width: 30%;
 	box-sizing: border-box;
 	padding-top: 0px;
 }

--- a/browser/src/control/jsdialog/Definitions.Types.ts
+++ b/browser/src/control/jsdialog/Definitions.Types.ts
@@ -124,4 +124,5 @@ interface IconViewEntry {
 interface IconViewJSON extends WidgetJSON {
 	entries: Array<IconViewEntry>;
 	singleclickactivate: boolean; // activates element on single click instead of just selection
+	textWithIconEnabled: boolean; // To identify if we should add text below the icon or not.
 }

--- a/browser/src/control/jsdialog/Widget.IconView.ts
+++ b/browser/src/control/jsdialog/Widget.IconView.ts
@@ -176,13 +176,33 @@ JSDialog.iconView = function (
 		const dropdown = container.querySelectorAll('.ui-iconview-entry');
 		if (dropdown[pos]) {
 			dropdown[pos].innerHTML = '';
-			const img = L.DomUtil.create('img', '', dropdown[pos]);
+			let container = dropdown[pos];
+
+			if (data.entries[pos].text && data.textWithIconEnabled) {
+				container = L.DomUtil.create(
+					'div',
+					builder.options.cssClass,
+					dropdown[pos],
+				);
+			}
+			const img = L.DomUtil.create('img', '', container);
 			img.src = builder.rendersCache[data.id].images[pos];
 
 			const entry = data.entries[pos];
 			img.alt = entry.text;
 			if (entry.tooltip) img.title = entry.tooltip;
 			else img.title = entry.text;
+
+			if (data.entries[pos].text && data.textWithIconEnabled) {
+				// Add text below Icon
+				L.DomUtil.addClass(container, 'icon-view-item-container');
+				const placeholder = L.DomUtil.create(
+					'span',
+					'ui-iconview-entry-title',
+					container,
+				);
+				placeholder.innerText = entry.text;
+			}
 		}
 	};
 

--- a/browser/src/control/jsdialog/Widget.IconView.ts
+++ b/browser/src/control/jsdialog/Widget.IconView.ts
@@ -25,6 +25,31 @@
 
 declare var JSDialog: any;
 
+function _createEntryImage(
+	parent: HTMLElement,
+	builder: any,
+	entryData: IconViewEntry,
+	image: string,
+) {
+	const img = L.DomUtil.create('img', builder.options.cssClass, parent);
+	if (image) img.src = image;
+	img.alt = entryData.text;
+
+	if (entryData.tooltip) img.title = entryData.tooltip;
+	else img.title = entryData.text;
+}
+
+function _createEntryText(parent: HTMLElement, entryData: IconViewEntry) {
+	// Add text below Icon
+	L.DomUtil.addClass(parent, 'icon-view-item-container');
+	const placeholder = L.DomUtil.create(
+		'span',
+		'ui-iconview-entry-title',
+		parent,
+	);
+	placeholder.innerText = entryData.text;
+}
+
 function _iconViewEntry(
 	parentContainer: Element,
 	parentData: IconViewJSON,
@@ -32,6 +57,7 @@ function _iconViewEntry(
 	builder: any,
 ) {
 	const disabled = parentData.enabled === false;
+	const hasText = entry.text && parentData.textWithIconEnabled;
 
 	if (entry.separator && entry.separator === true) {
 		L.DomUtil.create(
@@ -84,11 +110,8 @@ function _iconViewEntry(
 			entry.text,
 		);
 	} else {
-		const img = L.DomUtil.create('img', builder.options.cssClass, icon);
-		if (entry.image) img.src = entry.image;
-		img.alt = entry.text;
-		if (entry.tooltip) img.title = entry.tooltip;
-		else img.title = entry.text;
+		_createEntryImage(icon, builder, entry, entry.image);
+		if (hasText) _createEntryText(icon, entry);
 	}
 
 	if (!disabled) {
@@ -175,34 +198,22 @@ JSDialog.iconView = function (
 	container.updateRenders = (pos: number) => {
 		const dropdown = container.querySelectorAll('.ui-iconview-entry');
 		if (dropdown[pos]) {
-			dropdown[pos].innerHTML = '';
 			let container = dropdown[pos];
+			const entry = data.entries[pos];
+			const image = builder.rendersCache[data.id].images[pos];
+			const hasText = entry.text && data.textWithIconEnabled;
 
-			if (data.entries[pos].text && data.textWithIconEnabled) {
+			container.innerHTML = '';
+			if (hasText) {
 				container = L.DomUtil.create(
 					'div',
 					builder.options.cssClass,
 					dropdown[pos],
 				);
 			}
-			const img = L.DomUtil.create('img', '', container);
-			img.src = builder.rendersCache[data.id].images[pos];
 
-			const entry = data.entries[pos];
-			img.alt = entry.text;
-			if (entry.tooltip) img.title = entry.tooltip;
-			else img.title = entry.text;
-
-			if (data.entries[pos].text && data.textWithIconEnabled) {
-				// Add text below Icon
-				L.DomUtil.addClass(container, 'icon-view-item-container');
-				const placeholder = L.DomUtil.create(
-					'span',
-					'ui-iconview-entry-title',
-					container,
-				);
-				placeholder.innerText = entry.text;
-			}
+			_createEntryImage(container, builder, entry, image);
+			if (hasText) _createEntryText(container, entry);
 		}
 	};
 


### PR DESCRIPTION
Change-Id: I44e3e40b3be1dcfd0d099939e6f6a9a4e574fdbd


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
- Previously, we only showed icons in cases where we wanted to display the IconView from the core. Now, if the IconView contains text, the text will be displayed below the icon from the IconView.

![Screenshot from 2024-08-01 18-22-46](https://github.com/user-attachments/assets/1b7bf413-5e97-4716-b7d7-e4aa2646164d)
