### PR TITLE
Async Locking Prerequisites

### DIFF
--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -142,6 +142,7 @@ using Poco::Net::PartHandler;
 #  include <SslSocket.hpp>
 #endif
 #include "Storage.hpp"
+#include <wsd/wopi/StorageConnectionManager.hpp>
 #include "TraceFile.hpp"
 #include <Unit.hpp>
 #include <Util.hpp>
@@ -1157,7 +1158,7 @@ public:
                 try
                 {
                     std::shared_ptr<http::Session> httpSession(
-                            StorageBase::getHttpSession(remoteServerURI));
+                            StorageConnectionManager::getHttpSession(remoteServerURI));
                     http::Request request(remoteServerURI.getPathAndQuery());
 
                     //we use ETag header to check whether JSON is modified or not
@@ -1805,7 +1806,7 @@ private:
     bool downloadPlain(const std::string& uri)
     {
         const Poco::URI fontUri{uri};
-        std::shared_ptr<http::Session> httpSession(StorageBase::getHttpSession(fontUri));
+        std::shared_ptr<http::Session> httpSession(StorageConnectionManager::getHttpSession(fontUri));
         http::Request request(fontUri.getPathAndQuery());
 
         request.set("User-Agent", http::getAgentString());
@@ -1819,7 +1820,7 @@ private:
     bool eTagUnchanged(const std::string& uri, const std::string& oldETag)
     {
         const Poco::URI fontUri{uri};
-        std::shared_ptr<http::Session> httpSession(StorageBase::getHttpSession(fontUri));
+        std::shared_ptr<http::Session> httpSession(StorageConnectionManager::getHttpSession(fontUri));
         http::Request request(fontUri.getPathAndQuery());
 
         if (!oldETag.empty())
@@ -1844,7 +1845,7 @@ private:
     bool downloadWithETag(const std::string& uri, const std::string& oldETag)
     {
         const Poco::URI fontUri{uri};
-        std::shared_ptr<http::Session> httpSession(StorageBase::getHttpSession(fontUri));
+        std::shared_ptr<http::Session> httpSession(StorageConnectionManager::getHttpSession(fontUri));
         http::Request request(fontUri.getPathAndQuery());
 
         if (!oldETag.empty())
@@ -2939,6 +2940,9 @@ void COOLWSD::innerInitialize(Application& self)
 
 #if !MOBILEAPP
     net::AsyncDNS::startAsyncDNS();
+
+    LOG_TRC("Initialize StorageConnectionManager");
+    StorageConnectionManager::initialize();
 #endif
 
     PrisonerPoll = std::make_unique<PrisonPoll>();
@@ -4255,7 +4259,7 @@ void COOLWSD::processFetchUpdate(SocketPoll& poll)
         uriFetch.addQueryParameter("product", config::getString("product_name", APP_NAME));
         uriFetch.addQueryParameter("version", COOLWSD_VERSION);
         LOG_TRC("Infobar update request from " << uriFetch.toString());
-        FetchHttpSession = StorageBase::getHttpSession(uriFetch);
+        FetchHttpSession = StorageConnectionManager::getHttpSession(uriFetch);
         if (!FetchHttpSession)
             return;
 

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1112,7 +1112,7 @@ void DocumentBroker::lockIfEditing(const std::shared_ptr<ClientSession>& session
         {
             LOG_DBG("Locking docKey [" << _docKey << "], which is editable");
             std::string error;
-            if (!updateStorageLockState(*session, /*lock=*/true, error))
+            if (!updateStorageLockState(*session, StorageBase::LockState::LOCK, error))
             {
                 LOG_ERR("Failed to lock docKey [" << _docKey << "] with session ["
                                                   << session->getId()
@@ -1538,8 +1538,8 @@ bool DocumentBroker::lockDocumentInStorage(const Authorization& auth, std::strin
     assert(_lockCtx->_supportsLocks && "Expected to have lock support");
     assert(!_lockCtx->_isLocked && "Expected not to have locked already");
 
-    const StorageBase::LockUpdateResult result =
-        _storage->updateLockState(auth, *_lockCtx, /*lock=*/true, _currentStorageAttrs);
+    const StorageBase::LockUpdateResult result = _storage->updateLockState(
+        auth, *_lockCtx, StorageBase::LockState::LOCK, _currentStorageAttrs);
     error = _lockCtx->_lockFailureReason;
 
     switch (result)
@@ -1563,7 +1563,8 @@ bool DocumentBroker::lockDocumentInStorage(const Authorization& auth, std::strin
     return false;
 }
 
-bool DocumentBroker::updateStorageLockState(ClientSession& session, bool lock, std::string& error)
+bool DocumentBroker::updateStorageLockState(ClientSession& session, StorageBase::LockState lock,
+                                            std::string& error)
 {
     if (session.getAuthorization().isExpired())
     {
@@ -1571,7 +1572,7 @@ bool DocumentBroker::updateStorageLockState(ClientSession& session, bool lock, s
         return false;
     }
 
-    if (lock && session.isReadOnly())
+    if (lock == StorageBase::LockState::LOCK && session.isReadOnly())
     {
         // Readonly sessions cannot lock, only editors can.
         error = "Readonly session";
@@ -1589,28 +1590,30 @@ bool DocumentBroker::updateStorageLockState(ClientSession& session, bool lock, s
             return true; // Not an error.
             break;
         case StorageBase::LockUpdateResult::OK:
-            LOG_DBG((lock ? "Locked" : "Unlocked") << " docKey [" << _docKey << "] successfully");
+            LOG_DBG((lock == StorageBase::LockState::LOCK ? "Locked" : "Unlocked")
+                    << " docKey [" << _docKey << "] successfully");
             return true;
             break;
         case StorageBase::LockUpdateResult::UNAUTHORIZED:
-            LOG_ERR("Failed to " << (lock ? "Locked" : "Unlocked") << " docKey [" << _docKey
+            LOG_ERR("Failed to " << (lock == StorageBase::LockState::LOCK ? "Locked" : "Unlocked")
+                                 << " docKey [" << _docKey
                                  << "]. Invalid or expired access token. Notifying client and "
                                     "invalidating the authorization token of session ["
                                  << session.getId() << "]. This session will now be read-only");
             session.invalidateAuthorizationToken();
-            if (lock)
+            if (lock == StorageBase::LockState::LOCK)
             {
                 // If we can't unlock, we don't want to set the document to read-only mode.
                 session.setLockFailed(error);
             }
             break;
         case StorageBase::LockUpdateResult::FAILED:
-            LOG_ERR("Failed to " << (lock ? "Locked" : "Unlocked") << " docKey [" << _docKey
-                                 << "] with reason [" << error
+            LOG_ERR("Failed to " << (lock == StorageBase::LockState::LOCK ? "Locked" : "Unlocked")
+                                 << " docKey [" << _docKey << "] with reason [" << error
                                  << "]. Notifying client and making session [" << session.getId()
                                  << "] read-only");
 
-            if (lock)
+            if (lock == StorageBase::LockState::LOCK)
             {
                 // If we can't unlock, we don't want to set the document to read-only mode.
                 session.setLockFailed(error);
@@ -1623,7 +1626,7 @@ bool DocumentBroker::updateStorageLockState(ClientSession& session, bool lock, s
 
 bool DocumentBroker::attemptLock(ClientSession& session, std::string& failReason)
 {
-    return updateStorageLockState(session, /*lock=*/true, failReason);
+    return updateStorageLockState(session, StorageBase::LockState::LOCK, failReason);
 }
 
 DocumentBroker::NeedToUpload DocumentBroker::needToUploadToStorage() const
@@ -2499,7 +2502,7 @@ void DocumentBroker::refreshLock()
         const std::string savingSessionId = session->getId();
         LOG_TRC("Refresh lock " << _lockCtx->_lockToken << " with session [" << savingSessionId << ']');
         std::string error;
-        if (!updateStorageLockState(*session, /*lock=*/true, error))
+        if (!updateStorageLockState(*session, StorageBase::LockState::LOCK, error))
         {
             LOG_ERR("Failed to refresh lock of docKey [" << _docKey << "] with session ["
                                                          << savingSessionId << "]: " << error);
@@ -3129,7 +3132,7 @@ void DocumentBroker::disconnectSessionInternal(const std::shared_ptr<ClientSessi
         // Unlock the document, if last editable sessions, before we lose a token that can unlock.
         std::string error;
         if (lastEditableSession && _lockCtx->_isLocked && _storage &&
-            !updateStorageLockState(*session, /*lock=*/false, error))
+            !updateStorageLockState(*session, StorageBase::LockState::UNLOCK, error))
         {
             LOG_ERR("Failed to unlock docKey [" << _docKey
                                                 << "] before disconnecting last editable session ["

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1098,7 +1098,7 @@ bool DocumentBroker::download(
 void DocumentBroker::lockIfEditing(const std::shared_ptr<ClientSession>& session,
                                    const Poco::URI& uriPublic, bool userCanWrite)
 {
-    if (_lockCtx == nullptr || !_lockCtx->_supportsLocks || _lockCtx->_isLocked)
+    if (_lockCtx == nullptr || !_lockCtx->_supportsLocks || _lockCtx->isLocked())
     {
         return; // Nothing to do.
     }
@@ -1536,7 +1536,7 @@ bool DocumentBroker::lockDocumentInStorage(const Authorization& auth, std::strin
 {
     assert(_lockCtx && "Expected an initialized LockContext");
     assert(_lockCtx->_supportsLocks && "Expected to have lock support");
-    assert(!_lockCtx->_isLocked && "Expected not to have locked already");
+    assert(!_lockCtx->isLocked() && "Expected not to have locked already");
 
     const StorageBase::LockUpdateResult result = _storage->updateLockState(
         auth, *_lockCtx, StorageBase::LockState::LOCK, _currentStorageAttrs);
@@ -3126,12 +3126,12 @@ void DocumentBroker::disconnectSessionInternal(const std::shared_ptr<ClientSessi
 
         LOG_TRC("Disconnect session internal "
                 << id << ", LastEditableSession: " << lastEditableSession << " destroy? "
-                << _docState.isMarkedToDestroy() << " locked? " << _lockCtx->_isLocked << ", have "
+                << _docState.isMarkedToDestroy() << " locked? " << _lockCtx->isLocked() << ", have "
                 << _sessions.size() << " sessions (inclusive)");
 
         // Unlock the document, if last editable sessions, before we lose a token that can unlock.
         std::string error;
-        if (lastEditableSession && _lockCtx->_isLocked && _storage &&
+        if (lastEditableSession && _lockCtx->isLocked() && _storage &&
             !updateStorageLockState(*session, StorageBase::LockState::UNLOCK, error))
         {
             LOG_ERR("Failed to unlock docKey [" << _docKey

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1145,7 +1145,7 @@ void DocumentBroker::lockIfEditing(const std::shared_ptr<ClientSession>& session
         {
             LOG_DBG("Locking docKey [" << _docKey << "], which is editable");
             std::string error;
-            if (!updateStorageLockState(Authorization::create(uriPublic), error))
+            if (!lockDocumentInStorage(Authorization::create(uriPublic), error))
             {
                 LOG_ERR("Failed to lock docKey [" << _docKey << "] in advance: " << error);
             }
@@ -1532,7 +1532,7 @@ void DocumentBroker::endRenameFileCommand()
     endActivity();
 }
 
-bool DocumentBroker::updateStorageLockState(const Authorization& auth, std::string& error)
+bool DocumentBroker::lockDocumentInStorage(const Authorization& auth, std::string& error)
 {
     assert(_lockCtx && "Expected an initialized LockContext");
     assert(_lockCtx->_supportsLocks && "Expected to have lock support");
@@ -1553,12 +1553,10 @@ bool DocumentBroker::updateStorageLockState(const Authorization& auth, std::stri
             return true;
             break;
         case StorageBase::LockUpdateResult::UNAUTHORIZED:
-            LOG_ERR("Failed to " << "Locked docKey [" << _docKey
-                                 << "]. Invalid or expired access token");
+            LOG_ERR("Failed to lock docKey [" << _docKey << "]. Invalid or expired access token");
             break;
         case StorageBase::LockUpdateResult::FAILED:
-            LOG_ERR("Failed to " << "Locked docKey [" << _docKey << "] with reason [" << error
-                                 << ']');
+            LOG_ERR("Failed to lock docKey [" << _docKey << "] with reason: " << error);
             break;
     }
 

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1098,7 +1098,7 @@ bool DocumentBroker::download(
 void DocumentBroker::lockIfEditing(const std::shared_ptr<ClientSession>& session,
                                    const Poco::URI& uriPublic, bool userCanWrite)
 {
-    if (_lockCtx == nullptr || !_lockCtx->_supportsLocks || _lockCtx->isLocked())
+    if (_lockCtx == nullptr || !_lockCtx->supportsLocks() || _lockCtx->isLocked())
     {
         return; // Nothing to do.
     }
@@ -1535,7 +1535,7 @@ void DocumentBroker::endRenameFileCommand()
 bool DocumentBroker::lockDocumentInStorage(const Authorization& auth, std::string& error)
 {
     assert(_lockCtx && "Expected an initialized LockContext");
-    assert(_lockCtx->_supportsLocks && "Expected to have lock support");
+    assert(_lockCtx->supportsLocks() && "Expected to have lock support");
     assert(!_lockCtx->isLocked() && "Expected not to have locked already");
 
     const StorageBase::LockUpdateResult result = _storage->updateLockState(

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -652,7 +652,7 @@ private:
     bool updateStorageLockState(ClientSession& session, bool lock, std::string& error);
 
     /// Take the lock before loading the first session, if we know we can edit.
-    bool updateStorageLockState(const Authorization& auth, std::string& error);
+    bool lockDocumentInStorage(const Authorization& auth, std::string& error);
 
     std::size_t getIdleTimeSecs() const
     {

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -649,7 +649,8 @@ private:
 
     /// Updates the document's lock in storage to either locked or unlocked.
     /// Returns true iff the operation was successful.
-    bool updateStorageLockState(ClientSession& session, bool lock, std::string& error);
+    bool updateStorageLockState(ClientSession& session, StorageBase::LockState lock,
+                                std::string& error);
 
     /// Take the lock before loading the first session, if we know we can edit.
     bool lockDocumentInStorage(const Authorization& auth, std::string& error);

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -466,37 +466,6 @@ void LocalStorage::uploadLocalFileToStorageAsync(const Authorization& /*auth*/,
 
 #if !MOBILEAPP
 
-Poco::Net::HTTPClientSession* StorageBase::getHTTPClientSession(const Poco::URI& uri)
-{
-    bool useSSL = false;
-    if (SSLAsScheme)
-    {
-        // the WOPI URI itself should control whether we use SSL or not
-        // for whether we verify vs. certificates, cf. above
-        useSSL = uri.getScheme() != "http";
-    }
-    else
-    {
-        // We decoupled the Wopi communication from client communication because
-        // the Wopi communication must have an independent policy.
-        // So, we will use here only Storage settings.
-        useSSL = SSLEnabled || COOLWSD::isSSLTermination();
-    }
-    // We decoupled the Wopi communication from client communication because
-    // the Wopi communication must have an independent policy.
-    // So, we will use here only Storage settings.
-    Poco::Net::HTTPClientSession* session = useSSL
-        ? new Poco::Net::HTTPSClientSession(uri.getHost(), uri.getPort(),
-                                            Poco::Net::SSLManager::instance().defaultClientContext())
-        : new Poco::Net::HTTPClientSession(uri.getHost(), uri.getPort());
-
-    // Set the timeout to the configured value.
-    static int timeoutSec = COOLWSD::getConfigValue<int>("net.connection_timeout_secs", 30);
-    session->setTimeout(Poco::Timespan(timeoutSec, 0));
-
-    return session;
-}
-
 std::shared_ptr<http::Session> StorageBase::getHttpSession(const Poco::URI& uri)
 {
     bool useSSL = false;

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -545,17 +545,20 @@ void LockContext::initSupportsLocks()
 
 bool LockContext::needsRefresh(const std::chrono::steady_clock::time_point &now) const
 {
-    return _supportsLocks && _isLocked && _refreshSeconds > std::chrono::seconds::zero() &&
+    return _supportsLocks && isLocked() && _refreshSeconds > std::chrono::seconds::zero() &&
            (now - _lastLockTime) >= _refreshSeconds;
 }
 
 void LockContext::dumpState(std::ostream& os) const
 {
     if (!_supportsLocks)
+    {
+        os << "\n  LockContext: Unsupported";
         return;
+    }
 
     os << "\n  LockContext:";
-    os << "\n    locked: " << _isLocked;
+    os << "\n    locked: " << isLocked();
     os << "\n    token: " << _lockToken;
     os << "\n    last locked: " << Util::getSteadyClockAsString(_lastLockTime);
 }

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -20,16 +20,6 @@
 
 #if !MOBILEAPP
 
-#include <Poco/Net/AcceptCertificateHandler.h>
-#include <Poco/Net/Context.h>
-#include <Poco/Net/HTTPClientSession.h>
-#include <Poco/Net/HTTPRequest.h>
-#include <Poco/Net/HTTPResponse.h>
-#include <Poco/Net/HTTPSClientSession.h>
-#include <Poco/Net/KeyConsoleHandler.h>
-#include <Poco/Net/NameValueCollection.h>
-#include <Poco/Net/SSLManager.h>
-
 #include <cassert>
 #include <errno.h>
 
@@ -67,8 +57,6 @@
 #endif // IOS
 
 bool StorageBase::FilesystemEnabled;
-bool StorageBase::SSLAsScheme = true;
-bool StorageBase::SSLEnabled = false;
 
 #if !MOBILEAPP
 
@@ -103,81 +91,9 @@ void StorageBase::initialize()
 
     HostUtil::parseAliases(app.config());
 
-#if ENABLE_SSL
-    // FIXME: should use our own SSL socket implementation here.
-    Poco::Crypto::initializeCrypto();
-    Poco::Net::initializeSSL();
-
-    // Init client
-    Poco::Net::Context::Params sslClientParams;
-
-    // false default for upgrade to preserve legacy configuration
-    // in-config-file defaults are true.
-    SSLAsScheme = COOLWSD::getConfigValue<bool>("storage.ssl.as_scheme", false);
-
-    // Fallback to ssl.enable if not set - for back compatibility & simplicity.
-    SSLEnabled = COOLWSD::getConfigValue<bool>(
-        "storage.ssl.enable", COOLWSD::getConfigValue<bool>("ssl.enable", true));
-
-#if ENABLE_DEBUG
-    char *StorageSSLEnabled = getenv("STORAGE_SSL_ENABLE");
-    if (StorageSSLEnabled != NULL)
-    {
-        if (!strcasecmp(StorageSSLEnabled, "true"))
-            SSLEnabled = true;
-        else if (!strcasecmp(StorageSSLEnabled, "false"))
-            SSLEnabled = false;
-    }
-#endif
-
-    if (SSLEnabled || SSLAsScheme)
-    {
-        if (COOLWSD::isSSLEnabled())
-        {
-            sslClientParams.certificateFile = COOLWSD::getPathFromConfigWithFallback("storage.ssl.cert_file_path", "ssl.cert_file_path");
-            sslClientParams.privateKeyFile = COOLWSD::getPathFromConfigWithFallback("storage.ssl.key_file_path", "ssl.key_file_path");
-            sslClientParams.caLocation = COOLWSD::getPathFromConfigWithFallback("storage.ssl.ca_file_path", "ssl.ca_file_path");
-        }
-        else
-        {
-            sslClientParams.certificateFile = COOLWSD::getPathFromConfig("storage.ssl.cert_file_path");
-            sslClientParams.privateKeyFile = COOLWSD::getPathFromConfig("storage.ssl.key_file_path");
-            sslClientParams.caLocation = COOLWSD::getPathFromConfig("storage.ssl.ca_file_path");
-        }
-        sslClientParams.cipherList = COOLWSD::getPathFromConfigWithFallback("storage.ssl.cipher_list", "ssl.cipher_list");
-        const bool sslVerification = COOLWSD::getConfigValue<bool>("ssl.ssl_verification", true);
-        sslClientParams.verificationMode = !sslVerification ? Poco::Net::Context::VERIFY_NONE : Poco::Net::Context::VERIFY_STRICT;
-        sslClientParams.loadDefaultCAs = true;
-    }
-    else
-        sslClientParams.verificationMode = Poco::Net::Context::VERIFY_NONE;
-
-    Poco::SharedPtr<Poco::Net::PrivateKeyPassphraseHandler> consoleClientHandler = new Poco::Net::KeyConsoleHandler(false);
-    Poco::SharedPtr<Poco::Net::InvalidCertificateHandler> invalidClientCertHandler = new Poco::Net::AcceptCertificateHandler(false);
-
-    Poco::Net::Context::Ptr sslClientContext = new Poco::Net::Context(Poco::Net::Context::CLIENT_USE, sslClientParams);
-    sslClientContext->disableProtocols(Poco::Net::Context::Protocols::PROTO_SSLV2 |
-                                       Poco::Net::Context::Protocols::PROTO_SSLV3 |
-                                       Poco::Net::Context::Protocols::PROTO_TLSV1);
-    Poco::Net::SSLManager::instance().initializeClient(std::move(consoleClientHandler),
-                                                       std::move(invalidClientCertHandler),
-                                                       std::move(sslClientContext));
-
-    // Initialize our client SSL context.
-    ssl::Manager::initializeClientContext(
-        sslClientParams.certificateFile, sslClientParams.privateKeyFile, sslClientParams.caLocation,
-        sslClientParams.cipherList,
-        sslClientParams.verificationMode == Poco::Net::Context::VERIFY_NONE
-            ? ssl::CertificateVerification::Disabled
-            : ssl::CertificateVerification::Required);
-    if (!ssl::Manager::isClientContextInitialized())
-        LOG_ERR("Failed to initialize Client SSL.");
-    else
-        LOG_INF("Initialized Client SSL.");
-#endif
-#else
+#else // !MOBILEAPP
     FilesystemEnabled = true;
-#endif
+#endif // MOBILEAPP
 }
 
 #if !MOBILEAPP
@@ -463,39 +379,6 @@ void LocalStorage::uploadLocalFileToStorageAsync(const Authorization& /*auth*/,
     if (asyncUploadCallback)
         asyncUploadCallback(AsyncUpload(AsyncUpload::State::Complete, res));
 }
-
-#if !MOBILEAPP
-
-std::shared_ptr<http::Session> StorageBase::getHttpSession(const Poco::URI& uri)
-{
-    bool useSSL = false;
-    if (SSLAsScheme)
-    {
-        // the WOPI URI itself should control whether we use SSL or not
-        // for whether we verify vs. certificates, cf. above
-        useSSL = uri.getScheme() != "http";
-    }
-    else
-    {
-        // We decoupled the Wopi communication from client communication because
-        // the Wopi communication must have an independent policy.
-        // So, we will use here only Storage settings.
-        useSSL = SSLEnabled || COOLWSD::isSSLTermination();
-    }
-
-    const auto protocol
-        = useSSL ? http::Session::Protocol::HttpSsl : http::Session::Protocol::HttpUnencrypted;
-
-    // Create the session.
-    auto httpSession = http::Session::create(uri.getHost(), protocol, uri.getPort());
-
-    static int timeoutSec = COOLWSD::getConfigValue<int>("net.connection_timeout_secs", 30);
-    httpSession->setTimeout(std::chrono::seconds(timeoutSec));
-
-    return httpSession;
-}
-
-#endif // !MOBILEAPP
 
 void LockContext::initSupportsLocks()
 {

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -553,6 +553,9 @@ struct LockContext
     /// one-time setup for supporting locks & create token
     void initSupportsLocks();
 
+    /// Returns true if locks are supported.
+    bool supportsLocks() const { return _supportsLocks; }
+
     /// Returns true if locked.
     bool isLocked() const { return _lockState == StorageBase::LockState::LOCK; }
 

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -29,15 +29,6 @@
 /// Limits number of HTTP redirections to prevent from redirection loops
 static constexpr auto RedirectionLimit = 21;
 
-namespace Poco
-{
-namespace Net
-{
-class HTTPClientSession;
-}
-
-} // namespace Poco
-
 struct LockContext;
 
 /// Base class of all Storage abstractions.
@@ -413,7 +404,6 @@ public:
     static std::unique_ptr<StorageBase> create(const Poco::URI& uri, const std::string& jailRoot,
                                                const std::string& jailPath, bool takeOwnership);
 
-    static Poco::Net::HTTPClientSession* getHTTPClientSession(const Poco::URI& uri);
     static std::shared_ptr<http::Session> getHttpSession(const Poco::URI& uri);
 
 protected:

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -404,8 +404,6 @@ public:
     static std::unique_ptr<StorageBase> create(const Poco::URI& uri, const std::string& jailRoot,
                                                const std::string& jailPath, bool takeOwnership);
 
-    static std::shared_ptr<http::Session> getHttpSession(const Poco::URI& uri);
-
 protected:
 
     /// Sanitize a URI by removing authorization tokens.
@@ -447,10 +445,6 @@ private:
     bool _isDownloaded;
 
     static bool FilesystemEnabled;
-    /// If true, use only the WOPI URL for whether to use SSL to talk to storage server
-    static bool SSLAsScheme;
-    /// If true, force SSL communication with storage server
-    static bool SSLEnabled;
 };
 
 /// Trivial implementation of local storage that does not need do anything.

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -201,16 +201,14 @@ public:
     class UploadResult final
     {
     public:
-        enum class Result
-        {
-            OK = 0,
-            DISKFULL,
-            TOO_LARGE, //< 413
-            UNAUTHORIZED, //< 401, 403, 404
-            DOC_CHANGED, /**< Document changed in storage */
-            CONFLICT, //< 409
-            FAILED
-        };
+        STATE_ENUM(Result,
+                   OK = 0, //< Uploaded successfully
+                   DISKFULL, //< Unused.
+                   TOO_LARGE, //< 413
+                   UNAUTHORIZED, //< 401, 403, 404
+                   DOC_CHANGED, /**< Document changed in storage */
+                   CONFLICT, //< 409
+                   FAILED);
 
         explicit UploadResult(Result result)
             : _result(result)
@@ -252,13 +250,13 @@ public:
     template <typename TResult> class AsyncRequest final
     {
     public:
-        enum class State
-        {
+        STATE_ENUM(
+            State,
             None, //< No async upload in progress or isn't supported.
             Running, //< An async upload request is in progress.
             Error, //< Failed to make an async upload request or timed out, no UploadResult.
             Complete //< The last async upload request completed (regardless of the server's response).
-        };
+        );
 
         AsyncRequest(State state, TResult result)
             : _state(state)

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -383,6 +383,11 @@ public:
 
     std::string getFileExtension() const { return Poco::Path(_fileInfo.getFilename()).getExtension(); }
 
+    STATE_ENUM(LockState,
+               LOCK, //< Lock the document.
+               UNLOCK, //< Unlock the document .
+    );
+
     STATE_ENUM(LockUpdateResult,
                UNSUPPORTED, //< Locking is not supported on this host.
                OK, //< Succeeded to either lock or unlock (see LockContext).
@@ -390,9 +395,9 @@ public:
                FAILED //< Other failures.
     );
 
-    /// Update the locking state (check-in/out) of the associated file
+    /// Update the locking state (check-in/out) of the associated file synchronously.
     virtual LockUpdateResult updateLockState(const Authorization& auth, LockContext& lockCtx,
-                                             bool lock, const Attributes& attribs) = 0;
+                                             LockState lock, const Attributes& attribs) = 0;
 
     /// Returns a local file path for the given URI.
     /// If necessary copies the file locally first.
@@ -535,7 +540,7 @@ public:
     /// obtained using getFileInfo method
     std::unique_ptr<LocalFileInfo> getLocalFileInfo();
 
-    LockUpdateResult updateLockState(const Authorization&, LockContext&, bool,
+    LockUpdateResult updateLockState(const Authorization&, LockContext&, StorageBase::LockState,
                                      const Attributes&) override
     {
         return LockUpdateResult::OK;

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -248,8 +248,8 @@ public:
         std::string _reason;
     };
 
-    /// The state of an asynchronous upload request.
-    class AsyncUpload final
+    /// The state of an asynchronous request.
+    template <typename TResult> class AsyncRequest final
     {
     public:
         enum class State
@@ -260,7 +260,7 @@ public:
             Complete //< The last async upload request completed (regardless of the server's response).
         };
 
-        AsyncUpload(State state, UploadResult result)
+        AsyncRequest(State state, TResult result)
             : _state(state)
             , _result(std::move(result))
         {
@@ -270,12 +270,15 @@ public:
         State state() const { return _state; }
 
         /// Returns the result of the async upload.
-        const UploadResult& result() const { return _result; }
+        const TResult& result() const { return _result; }
 
     private:
         State _state;
-        UploadResult _result;
+        TResult _result;
     };
+
+    /// The state of an asynchronous Upload request.
+    using AsyncUpload = AsyncRequest<UploadResult>;
 
     enum class COOLStatusCode
     {

--- a/wsd/wopi/StorageConnectionManager.hpp
+++ b/wsd/wopi/StorageConnectionManager.hpp
@@ -49,103 +49,10 @@ public:
     /// Create an http::Request with the common headers.
     static http::Request createHttpRequest(const Poco::URI& uri, const Authorization& auth);
 
+    static void initialize();
+
 private:
     StorageConnectionManager() {}
-
-#if 0
-    void initialize()
-    {
-#if !MOBILEAPP
-        const auto& app = Poco::Util::Application::instance();
-        FilesystemEnabled = app.config().getBool("storage.filesystem[@allow]", false);
-
-        //parse wopi.storage.host only when there is no storage.wopi.alias_groups entry in config
-        if (!app.config().has("storage.wopi.alias_groups"))
-        {
-            HostUtil::parseWopiHost(app.config());
-        }
-
-#if ENABLE_FEATURE_LOCK
-        CommandControl::LockManager::parseLockedHost(app.config());
-#endif
-
-        HostUtil::parseAliases(app.config());
-
-#if ENABLE_SSL
-        // FIXME: should use our own SSL socket implementation here.
-        Poco::Crypto::initializeCrypto();
-        Poco::Net::initializeSSL();
-
-        // Init client
-        Poco::Net::Context::Params sslClientParams;
-
-        // false default for upgrade to preserve legacy configuration
-        // in-config-file defaults are true.
-        SSLAsScheme = COOLWSD::getConfigValue<bool>("storage.ssl.as_scheme", false);
-
-        // Fallback to ssl.enable if not set - for back compatibility & simplicity.
-        SSLEnabled = COOLWSD::getConfigValue<bool>(
-            "storage.ssl.enable", COOLWSD::getConfigValue<bool>("ssl.enable", true));
-
-#if ENABLE_DEBUG
-        char* StorageSSLEnabled = getenv("STORAGE_SSL_ENABLE");
-        if (StorageSSLEnabled != NULL)
-        {
-            if (!strcasecmp(StorageSSLEnabled, "true"))
-                SSLEnabled = true;
-            else if (!strcasecmp(StorageSSLEnabled, "false"))
-                SSLEnabled = false;
-        }
-#endif
-
-        if (SSLEnabled)
-        {
-            sslClientParams.certificateFile = COOLWSD::getPathFromConfigWithFallback(
-                "storage.ssl.cert_file_path", "ssl.cert_file_path");
-            sslClientParams.privateKeyFile = COOLWSD::getPathFromConfigWithFallback(
-                "storage.ssl.key_file_path", "ssl.key_file_path");
-            sslClientParams.caLocation = COOLWSD::getPathFromConfigWithFallback(
-                "storage.ssl.ca_file_path", "ssl.ca_file_path");
-            sslClientParams.cipherList = COOLWSD::getPathFromConfigWithFallback(
-                "storage.ssl.cipher_list", "ssl.cipher_list");
-
-            sslClientParams.verificationMode =
-                (sslClientParams.caLocation.empty() ? Poco::Net::Context::VERIFY_NONE
-                                                    : Poco::Net::Context::VERIFY_STRICT);
-            sslClientParams.loadDefaultCAs = true;
-        }
-        else
-            sslClientParams.verificationMode = Poco::Net::Context::VERIFY_NONE;
-
-        Poco::SharedPtr<Poco::Net::PrivateKeyPassphraseHandler> consoleClientHandler =
-            new Poco::Net::KeyConsoleHandler(false);
-        Poco::SharedPtr<Poco::Net::InvalidCertificateHandler> invalidClientCertHandler =
-            new Poco::Net::AcceptCertificateHandler(false);
-
-        Poco::Net::Context::Ptr sslClientContext =
-            new Poco::Net::Context(Poco::Net::Context::CLIENT_USE, sslClientParams);
-        sslClientContext->disableProtocols(Poco::Net::Context::Protocols::PROTO_SSLV2 |
-                                           Poco::Net::Context::Protocols::PROTO_SSLV3 |
-                                           Poco::Net::Context::Protocols::PROTO_TLSV1);
-        Poco::Net::SSLManager::instance().initializeClient(
-            consoleClientHandler, invalidClientCertHandler, sslClientContext);
-
-        // Initialize our client SSL context.
-        ssl::Manager::initializeClientContext(
-            sslClientParams.certificateFile, sslClientParams.privateKeyFile,
-            sslClientParams.caLocation, sslClientParams.cipherList,
-            sslClientParams.caLocation.empty() ? ssl::CertificateVerification::Disabled
-                                               : ssl::CertificateVerification::Required);
-        if (!ssl::Manager::isClientContextInitialized())
-            LOG_ERR("Failed to initialize Client SSL.");
-        else
-            LOG_INF("Initialized Client SSL.");
-#endif
-#else
-        FilesystemEnabled = true;
-#endif
-    }
-#endif
 
     /// Sanitize a URI by removing authorization tokens.
     Poco::URI sanitizeUri(Poco::URI uri)
@@ -171,7 +78,6 @@ private:
     /// Saves new URI when resource was moved
     // void setUri(const Poco::URI& uri) { _uri = sanitizeUri(uri); }
 
-    static bool FilesystemEnabled;
     /// If true, use only the WOPI URL for whether to use SSL to talk to storage server
     static bool SSLAsScheme;
     /// If true, force SSL communication with storage server

--- a/wsd/wopi/WopiStorage.cpp
+++ b/wsd/wopi/WopiStorage.cpp
@@ -12,6 +12,7 @@
 #include <config.h>
 
 #include "WopiStorage.hpp"
+#include "wopi/StorageConnectionManager.hpp"
 
 #include <Auth.hpp>
 #include <CommandControl.hpp>
@@ -342,7 +343,8 @@ StorageBase::LockUpdateResult WopiStorage::updateLockState(const Authorization& 
 
     try
     {
-        std::shared_ptr<http::Session> httpSession = getHttpSession(uriObject);
+        std::shared_ptr<http::Session> httpSession =
+            StorageConnectionManager::getHttpSession(uriObject);
 
         http::Request httpRequest = initHttpRequest(uriObject, auth);
         httpRequest.setVerb(http::Request::VERB_POST);
@@ -482,7 +484,8 @@ std::string WopiStorage::downloadDocument(const Poco::URI& uriObject, const std:
                                           const Authorization& auth, unsigned redirectLimit)
 {
     const auto startTime = std::chrono::steady_clock::now();
-    std::shared_ptr<http::Session> httpSession = getHttpSession(uriObject);
+    std::shared_ptr<http::Session> httpSession =
+        StorageConnectionManager::getHttpSession(uriObject);
 
     http::Request httpRequest = initHttpRequest(uriObject, auth);
 
@@ -671,7 +674,7 @@ void WopiStorage::uploadLocalFileToStorageAsync(const Authorization& auth, LockC
     try
     {
         assert(!_uploadHttpSession && "Unexpected to have an upload http::session");
-        _uploadHttpSession = getHttpSession(uriObject);
+        _uploadHttpSession = StorageConnectionManager::getHttpSession(uriObject);
 
         http::Request httpRequest = initHttpRequest(uriObject, auth);
         httpRequest.setVerb(http::Request::VERB_POST);

--- a/wsd/wopi/WopiStorage.cpp
+++ b/wsd/wopi/WopiStorage.cpp
@@ -373,7 +373,7 @@ StorageBase::LockUpdateResult WopiStorage::updateLockState(const Authorization& 
 
         if (response.getStatus() == Poco::Net::HTTPResponse::HTTP_OK)
         {
-            lockCtx._isLocked = (lock == StorageBase::LockState::LOCK);
+            lockCtx._lockState = lock;
             lockCtx.bumpTimer();
             return LockUpdateResult::OK;
         }

--- a/wsd/wopi/WopiStorage.cpp
+++ b/wsd/wopi/WopiStorage.cpp
@@ -327,7 +327,7 @@ StorageBase::LockUpdateResult WopiStorage::updateLockState(const Authorization& 
                                                            const Attributes& attribs)
 {
     lockCtx._lockFailureReason.clear();
-    if (!lockCtx._supportsLocks)
+    if (!lockCtx.supportsLocks())
         return LockUpdateResult::UNSUPPORTED;
 
     Poco::URI uriObject(getUri());
@@ -688,7 +688,7 @@ void WopiStorage::uploadLocalFileToStorageAsync(const Authorization& auth, LockC
         http::Header& httpHeader = httpRequest.header();
 
         // must include this header except for SaveAs
-        if (!isSaveAs && lockCtx._supportsLocks)
+        if (!isSaveAs && lockCtx.supportsLocks())
             httpHeader.set("X-WOPI-Lock", lockCtx._lockToken);
 
         if (!isSaveAs && !isRename)

--- a/wsd/wopi/WopiStorage.hpp
+++ b/wsd/wopi/WopiStorage.hpp
@@ -193,7 +193,8 @@ public:
     void handleWOPIFileInfo(const WOPIFileInfo& wopiFileInfo, LockContext& lockCtx);
 
     /// Update the locking state (check-in/out) of the associated file
-    LockUpdateResult updateLockState(const Authorization& auth, LockContext& lockCtx, bool lock,
+    LockUpdateResult updateLockState(const Authorization& auth, LockContext& lockCtx,
+                                     StorageBase::LockState lock,
                                      const Attributes& attribs) override;
 
     /// uri format: http://server/<...>/wopi*/files/<id>/content


### PR DESCRIPTION
**Possibly for RED.**

Some Kill-Poco and refactored locking to prepare for async locking.

- wsd: updateStorageLockState -> lockDocumentInStorage
- wsd: use an enum for lock states
- wsd: use LockState enum in LockContext
- wsd: encapsulate supportsLocks in LockContext
- wsd: refactor AsyncUpload for reuse
- wsd: use STATE_ENUM
- killpoco: document locking without poco
- killpoco: remove unused http helpers
- wsd: move and update StorageConnectionManager::initialize()
- wsd: use StorageConnectionManager::getHttpSession()
