### PR TITLE
fix build: ambiguous overload for ‘operator==’

### DIFF
--- a/wsd/RequestVettingStation.cpp
+++ b/wsd/RequestVettingStation.cpp
@@ -271,7 +271,7 @@ void RequestVettingStation::handleRequest(const std::string& id,
                     else
                     {
                         // We had a response, but it was empty/error. Meaning the user is unauthorized.
-                        assert(_checkFileInfo && _checkFileInfo->wopiInfo() == nullptr &&
+                        assert(_checkFileInfo && !_checkFileInfo->wopiInfo() &&
                                "Unexpected to have wopiInfo");
 
                         LOG_ERR_S('#'


### PR DESCRIPTION
ambiguous overload for ‘operator==’ (operand types are ‘Poco::JSON::Object::Ptr’ {aka ‘Poco::SharedPtr<Poco::JSON::Object>’} and ‘std::nullptr_t’)
                       assert(_checkFileInfo && _checkFileInfo->wopiInfo() == nullptr &&
                                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~

Change-Id: I9b11cdc3304506832aae9326fed4d7d3618c77dc
Signed-off-by: Henry Castro <hcastro@collabora.com>
