### PR TITLE
cool#9710 admin console: expose poco version

### DIFF
--- a/browser/admin/src/AdminSocketSettings.js
+++ b/browser/admin/src/AdminSocketSettings.js
@@ -96,7 +96,11 @@ var AdminSocketSettings = AdminSocketBase.extend({
 			else {
 				$('#coolwsd-version').text(coolwsdVersionObj.Version);
 			}
-			$('#coolwsd-buildconfig').html(coolwsdVersionObj.BuildConfig);
+			let buildConfig = coolwsdVersionObj.BuildConfig;
+			if (coolwsdVersionObj.PocoVersion !== undefined) {
+				buildConfig += ' (poco version: ' + coolwsdVersionObj.PocoVersion + ')';
+			}
+			$('#coolwsd-buildconfig').html(buildConfig);
 		}
 		else if (textMsg.startsWith('lokitversion ')) {
 			var lokitVersionObj = JSON.parse(textMsg.substring(textMsg.indexOf('{')));

--- a/common/Util.cpp
+++ b/common/Util.cpp
@@ -66,6 +66,7 @@
 #include <Poco/TemporaryFile.h>
 #include <Poco/Util/Application.h>
 #include <Poco/URI.h>
+#include <Poco/Version.h>
 
 #include "Log.hpp"
 #include "JsonUtil.hpp"
@@ -380,10 +381,17 @@ namespace Util
     {
         std::string version, hash;
         Util::getVersionInfo(version, hash);
+
+        std::string pocoVersion;
+        pocoVersion += std::to_string((POCO_VERSION & 0xff000000) >> 24) + ".";
+        pocoVersion += std::to_string((POCO_VERSION & 0x00ff0000) >> 16) + ".";
+        pocoVersion += std::to_string((POCO_VERSION & 0x0000ff00) >> 8);
+
         return
             "{ \"Version\":     \"" + version + "\", "
               "\"Hash\":        \"" + hash + "\", "
               "\"BuildConfig\": \"" + std::string(COOLWSD_BUILDCONFIG) + "\", "
+              "\"PocoVersion\": \"" + pocoVersion + "\", "
               "\"Protocol\":    \"" + COOLProtocol::GetProtocolVersion() + "\", "
               "\"Id\":          \"" + Util::getProcessIdentifier() + "\", "
               "\"Options\":     \"" + std::string(enableExperimental ? " (E)" : "") + "\" }";


### PR DESCRIPTION
It can happen that performance depends on what poco version is used, in
this case exposing this information helps debugging.

Of course it won't help with old versions, but at least start showing
this info, to help in the future.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I32439d70022b918094a7110bfce3aff29ce8b35d
