### PR TITLE
WaE: cleanup override warnings; with dumpStateIndent.

### DIFF
--- a/common/Util-mobile.cpp
+++ b/common/Util-mobile.cpp
@@ -16,7 +16,7 @@ namespace Util
 bool isMobileApp() { return true; }
 
 /// No-op implementation of desktop only functions
-DirectoryCounter::DirectoryCounter(const char* procPath) {}
+DirectoryCounter::DirectoryCounter(const char* procPath) { (void)_tasks; }
 DirectoryCounter::~DirectoryCounter() {}
 int DirectoryCounter::count() { return 0; }
 int spawnProcess(const std::string& cmd, const StringVector& args) { return 0; }

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -689,7 +689,7 @@ public:
     /// and/or to interrupt transmission.
     int64_t readData(const char* p, int64_t len);
 
-    void dumpState(std::ostream& os, const std::string& indent = "\n  ") const
+    void dumpStateIndent(std::ostream& os, const std::string& indent = "\n  ") const
     {
         os << indent << "http::Request: " << _version << ' ' << _verb << ' ' << _url;
         os << indent << "stage: " << name(_stage);
@@ -988,7 +988,7 @@ public:
     /// Sets the context used by logPrefix.
     void setLogContext(int fd) { _fd = fd; }
 
-    void dumpState(std::ostream& os, const std::string& indent = "\n  ") const
+    void dumpStateIndent(std::ostream& os, const std::string& indent = "\n  ") const
     {
         os << indent << "http::Response: #" << _fd;
         os << indent << "statusLine: " << _statusLine.httpVersion() << ' '
@@ -1323,7 +1323,7 @@ public:
     /// Returns the socket FD, for logging/informational purposes.
     int getFD() const { return _fd; }
 
-    void dumpState(std::ostream& os, const std::string& indent = "\n  ") const
+    void dumpStateIndent(std::ostream& os, const std::string& indent = "\n  ") const
     {
         const auto now = std::chrono::steady_clock::now();
         os << indent << "http::Session: #" << _fd;
@@ -1334,9 +1334,9 @@ public:
         os << indent << "protocol: " << name(_protocol);
         os << indent << "handshakeSslVerifyFailure: " << _handshakeSslVerifyFailure;
         os << indent << "startTime: " << Util::getTimeForLog(now, _startTime);
-        _request.dumpState(os, indent);
+        _request.dumpStateIndent(os, indent);
         if (_response)
-            _response->dumpState(os, indent);
+            _response->dumpStateIndent(os, indent);
         else
             os << indent << "response: null";
 
@@ -1837,7 +1837,7 @@ public:
         }
     }
 
-    void dumpState(std::ostream& os, const std::string& indent = "\n  ") const
+    void dumpStateIndent(std::ostream& os, const std::string& indent = "\n  ") const
     {
         const auto now = std::chrono::steady_clock::now();
         os << indent << "http::server::Session: #" << _fd;

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -4083,7 +4083,7 @@ public:
         if (FetchHttpSession)
         {
             os << "\nFetchHttpSession:\n";
-            FetchHttpSession->dumpState(os, "\n  ");
+            FetchHttpSession->dumpStateIndent(os, "\n  ");
         }
         else
 #endif // !MOBILEAPP


### PR DESCRIPTION
Many classes have a virtual dumpState method, so rename it for a different signature to avoid confusion.


Change-Id: I14e751aee552ed4a133051dc5de513ce491cbcf8


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

