### PR TITLE
wsd: correctly override dumpState

### DIFF
--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -1323,7 +1323,7 @@ public:
     /// Returns the socket FD, for logging/informational purposes.
     int getFD() const { return _fd; }
 
-    void dumpState(std::ostream& os, const std::string& indent = "\n  ") const override
+    void dumpState(std::ostream& os, const std::string& indent) const override
     {
         const auto now = std::chrono::steady_clock::now();
         os << indent << "http::Session: #" << _fd;
@@ -1837,7 +1837,7 @@ public:
         }
     }
 
-    void dumpState(std::ostream& os, const std::string& indent = "\n  ") const
+    void dumpState(std::ostream& os, const std::string& indent) const override
     {
         const auto now = std::chrono::steady_clock::now();
         os << indent << "http::server::Session: #" << _fd;

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -1323,7 +1323,7 @@ public:
     /// Returns the socket FD, for logging/informational purposes.
     int getFD() const { return _fd; }
 
-    void dumpState(std::ostream& os, const std::string& indent = "\n  ") const
+    void dumpState(std::ostream& os, const std::string& indent = "\n  ") const override
     {
         const auto now = std::chrono::steady_clock::now();
         os << indent << "http::Session: #" << _fd;

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -912,7 +912,7 @@ void SocketDisposition::execute()
     }
 }
 
-void WebSocketHandler::dumpState(std::ostream& os) const
+void WebSocketHandler::dumpState(std::ostream& os, const std::string& /*indent*/) const
 {
     os << (_shuttingDown ? "shutd " : "alive ");
 #if !MOBILEAPP

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -505,8 +505,13 @@ public:
 
     virtual void getIOStats(uint64_t &sent, uint64_t &recv) = 0;
 
+    virtual void dumpState(std::ostream& os) const
+    {
+        dumpState(os, "\n ");
+    }
+
     /// Append pretty printed internal state to a line
-    virtual void dumpState(std::ostream& os, const std::string& indent = "\n") const
+    virtual void dumpState(std::ostream& os, const std::string& indent) const
     {
         os << indent;
     }

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -506,7 +506,10 @@ public:
     virtual void getIOStats(uint64_t &sent, uint64_t &recv) = 0;
 
     /// Append pretty printed internal state to a line
-    virtual void dumpState(std::ostream& os) const { os << '\n'; }
+    virtual void dumpState(std::ostream& os, const std::string& indent = "\n") const
+    {
+        os << indent;
+    }
 };
 
 // Forward declare WebSocketHandler, which is inherited from ProtocolHandlerInterface.

--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -944,7 +944,7 @@ protected:
     }
 
     /// Implementation of the ProtocolHandlerInterface.
-    void dumpState(std::ostream& os) const override;
+    void dumpState(std::ostream& os, const std::string& indent = "\n  ") const override;
 
     static std::string generateKey();
     static std::string computeAccept(const std::string &key);

--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -944,7 +944,7 @@ protected:
     }
 
     /// Implementation of the ProtocolHandlerInterface.
-    void dumpState(std::ostream& os, const std::string& indent = "\n  ") const override;
+    void dumpState(std::ostream& os, const std::string& indent) const override;
 
     static std::string generateKey();
     static std::string computeAccept(const std::string &key);

--- a/wsd/ProxyProtocol.hpp
+++ b/wsd/ProxyProtocol.hpp
@@ -60,7 +60,7 @@ public:
     void shutdown(bool goingAway = false, const std::string &statusMessage = "") override;
     void getIOStats(uint64_t &sent, uint64_t &recv) override;
     // don't duplicate ourselves for every socket
-    void dumpState(std::ostream&) const override {}
+    void dumpState(std::ostream&, const std::string&) const override {}
     // instead do it centrally.
     void dumpProxyState(std::ostream& os);
     bool parseEmitIncoming(const std::shared_ptr<StreamSocket> &socket);


### PR DESCRIPTION
Fixes compiler warnings with `-Woverloaded-virtual`.