### PR TITLE
check for null _graphicSelection on _onShapeSelectionContent

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1986,14 +1986,18 @@ L.CanvasTileLayer = L.Layer.extend({
 	_onShapeSelectionContent: function (textMsg) {
 		textMsg = textMsg.substring('shapeselectioncontent:'.length + 1);
 
-		var extraInfo = this._graphicSelection.extraInfo;
-		if (extraInfo && extraInfo.id) {
-			this._map._cacheSVG[extraInfo.id] = textMsg;
+		var extraInfoId = null;
+		if (this._graphicSelection && this._graphicSelection.extraInfo)
+			extraInfoId = this._graphicSelection.extraInfo.id;
+		if (extraInfoId) {
+			this._map._cacheSVG[extraInfoId] = textMsg;
 		}
 
 		// video is handled in _onEmbeddedVideoContent
-		if (this._graphicMarker && this._graphicMarker.sectionProperties.hasVideo)
-			this._map._cacheSVG[extraInfo.id] = undefined;
+		if (this._graphicMarker && this._graphicMarker.sectionProperties.hasVideo) {
+			if (extraInfoId)
+				this._map._cacheSVG[extraInfoId] = undefined;
+		}
 		else if (this._graphicMarker)
 			this._graphicMarker.setSVG(textMsg);
 	},


### PR DESCRIPTION
Sometimes a TypeError JS Exception was raised due to accessing
this._graphicSelection.extraInfo while _graphicSelection is null.

Signed-off-by: Jaume Pujantell <jaume.pujantell@collabora.com>
Change-Id: I7520e125dd0f1a5815f4324ada8a74950fdbac7d
