### PR TITLE
duplicate _update() calls

### DIFF
--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -459,7 +459,6 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 				source: 'status'
 			});
 			this._resetPreFetching(true);
-			this._update();
 			if (firstSelectedPart) {
 				this._switchSplitPanesContext();
 			}

--- a/browser/src/layer/tile/ImpressTileLayer.js
+++ b/browser/src/layer/tile/ImpressTileLayer.js
@@ -280,7 +280,6 @@ L.ImpressTileLayer = L.CanvasTileLayer.extend({
 			}
 			this._selectedMode = (command.mode !== undefined) ? command.mode : 0;
 			this._resetPreFetching(true);
-			this._update();
 			var partMatch = textMsg.match(/[^\r\n]+/g);
 			// only get the last matches
 			var newPartHashes = partMatch.slice(partMatch.length - this._parts);

--- a/browser/src/layer/tile/WriterTileLayer.js
+++ b/browser/src/layer/tile/WriterTileLayer.js
@@ -178,6 +178,5 @@ L.WriterTileLayer = L.CanvasTileLayer.extend({
 			docType: this._docType
 		});
 		this._resetPreFetching(true);
-		this._update();
 	},
 });


### PR DESCRIPTION
_onStatusMsg(textMsg) is only called from one place and there it is always followed by a call to _update();

since:

commit dffaeb228bb787af2be6b7a88048fc97c1df07d5
AuthorDate: Mon Nov 14 13:44:41 2022 +0100

    masterpage: correclty refresh after switching mode

    Mode is sent via status message so handle it there to avoid
    race

but each _onStatusMsg impl might also call _update() so there are duplicate tilecombine requests


Change-Id: I6403852321cb727750aba4874d053a2d3c37abc4


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

