### PR TITLE
Fix build & ignore test csv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ test/data/hello-world.odp
 test/data/hello-world.odg
 test/fakesockettest
 test/unithttplib
+test/*.csv
 jsstress
 
 *.o

--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -482,10 +482,10 @@ public:
 
 
     // Called when a document has started loading
-    virtual void onDocumentLoading(){}
+    virtual void onPerfDocumentLoading(){}
 
     // Called when a document has finished loading
-    virtual void onDocumentLoaded(){}
+    virtual void onPerfDocumentLoaded(){}
 
     /// To force the save operation being handled as auto-save from a unit test.
     virtual bool isAutosave()

--- a/test/UnitPerf.cpp
+++ b/test/UnitPerf.cpp
@@ -46,8 +46,8 @@ class UnitPerf : public UnitWSD
 public:
     UnitPerf();
     void invokeWSDTest() override;
-    void onDocumentLoading() override;
-    void onDocumentLoaded() override;
+    void onPerfDocumentLoading() override;
+    void onPerfDocumentLoaded() override;
     std::unique_ptr<Util::SysStopwatch> _timer;
     std::shared_ptr<Stats> stats;
 };
@@ -110,13 +110,13 @@ void UnitPerf::invokeWSDTest()
 }
 
 //Called when document loading process starts e.g. setup finishes
-void UnitPerf::onDocumentLoading()
+void UnitPerf::onPerfDocumentLoading()
 {
     stats->endPhase(Log::Phase::Setup);
 }
 
 //called when document has been loaded into core
-void UnitPerf::onDocumentLoaded()
+void UnitPerf::onPerfDocumentLoaded()
 {
     stats->endPhase(Log::Phase::Load);
 }

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -893,7 +893,7 @@ bool DocumentBroker::download(
 
         if(_unitWsd != nullptr)
         {
-            _unitWsd->onDocumentLoading();
+            _unitWsd->onPerfDocumentLoading();
         }
 
         // Pass the public URI to storage as it needs to load using the token
@@ -2447,7 +2447,7 @@ void DocumentBroker::setLoaded()
 
         if(_unitWsd != nullptr)
         {
-            _unitWsd->onDocumentLoaded();
+            _unitWsd->onPerfDocumentLoaded();
         }
 
     }


### PR DESCRIPTION
Fix build in UnitPerf
    
    ./common/Unit.hpp:488:18: error: 'UnitWSD::onDocumentLoaded' hides overloaded virtual function [-Werror,-Woverloaded-virtual]
    
caused by commit 6e790c63d0997094979b2a237f428ef7706e62ef
feat: Changes to UnitPerf measuring