### PR TITLE
slideshow: pause all videos when changing the slide

### DIFF
--- a/browser/src/slideshow/SlideRenderer.ts
+++ b/browser/src/slideshow/SlideRenderer.ts
@@ -22,7 +22,7 @@ class VideoRenderInfo {
 abstract class SlideRenderer {
 	public _context: RenderContext = null;
 	public _slideTexture: WebGLTexture | ImageBitmap;
-	protected _videos: VideoRenderInfo[];
+	protected _videos: VideoRenderInfo[] = [];
 	protected _canvas: HTMLCanvasElement;
 
 	constructor(canvas: HTMLCanvasElement) {
@@ -66,6 +66,12 @@ abstract class SlideRenderer {
 		this._slideTexture = currentSlideTexture;
 		this.prepareVideos(slideInfo, docWidth, docHeight);
 		requestAnimationFrame(this.render.bind(this));
+	}
+
+	public pauseVideos() {
+		for (var videoRenderInfo of this._videos) {
+			videoRenderInfo.videoElement.pause();
+		}
 	}
 
 	protected getDocumentPositions(
@@ -115,6 +121,7 @@ class SlideRenderer2d extends SlideRenderer {
 		docWidth: number,
 		docHeight: number,
 	) {
+		this.pauseVideos();
 		this._videos = [];
 		if (slideInfo?.videos !== undefined) {
 			for (var videoInfo of slideInfo.videos) {
@@ -306,6 +313,7 @@ class SlideRendererGl extends SlideRenderer {
 		docWidth: number,
 		docHeight: number,
 	) {
+		this.pauseVideos();
 		this._videos = [];
 		if (slideInfo.videos !== undefined) {
 			for (var videoInfo of slideInfo.videos) {

--- a/browser/src/slideshow/SlideShowPresenter.ts
+++ b/browser/src/slideshow/SlideShowPresenter.ts
@@ -329,8 +329,8 @@ class SlideShowPresenter {
 	}
 
 	_doPresentation() {
+		this._slideRenderer.pauseVideos();
 		const slideInfo = this.getSlideInfo(this._currentSlide);
-
 		// To speed up the process, if we have transition info, then only render
 		// a black empty slide as the first slide. otherwise, directly render the first slide.
 		if (


### PR DESCRIPTION
Make sure the video is paused when we change the slide, so that we don't keep playing the video in the background.


Change-Id: I39b9118f7606a997f4cdf2eb4e3f1b736812074f


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

