### PR TITLE
RequestVettingStation can be deleted before callback is executed

### DIFF
--- a/wsd/RequestVettingStation.cpp
+++ b/wsd/RequestVettingStation.cpp
@@ -200,7 +200,7 @@ void RequestVettingStation::handleRequest(const std::string& id,
 
             // Remove from the current poll and transfer.
             disposition.setMove(
-                [this, docKey, url, uriPublic,
+                [selfLifecycle = shared_from_this(), this, docKey, url, uriPublic,
                  isReadOnly](const std::shared_ptr<Socket>& moveSocket)
                 {
                     LOG_TRC_S('#' << moveSocket->getFD()
@@ -222,7 +222,7 @@ void RequestVettingStation::handleRequest(const std::string& id,
                             << docKey << "] is for a WOPI document");
             // Remove from the current poll and transfer.
             disposition.setMove(
-                [this, docKey, url, uriPublic,
+                [selfLifecycle = shared_from_this(), this, docKey, url, uriPublic,
                  isReadOnly](const std::shared_ptr<Socket>& moveSocket)
                 {
                     LOG_TRC_S('#' << moveSocket->getFD()

--- a/wsd/RequestVettingStation.hpp
+++ b/wsd/RequestVettingStation.hpp
@@ -38,7 +38,7 @@
 /// then. Or, it might have timed out. Alternatively, the WebSocket
 /// might never arrive (say, because the user clicked away).
 /// We take these possibilities into account and support them here.
-class RequestVettingStation
+class RequestVettingStation final : public std::enable_shared_from_this<RequestVettingStation>
 {
 public:
     /// Create an instance with a SocketPoll and a RequestDetails instance.


### PR DESCRIPTION
symptoms appear as:

/usr/bin/coolwsd
	SigUtil::dumpBacktrace()
		common/SigUtil.cpp:450
/lib/x86_64-linux-gnu/libpthread.so.0
	__restore_rt
		??:?
/lib/x86_64-linux-gnu/libc.so.6
	__GI_raise
		/build/glibc-aGgxh2/glibc-2.27/signal/../sysdeps/unix/sysv/linux/raise.c:51 (discriminator 3)
/lib/x86_64-linux-gnu/libc.so.6
	__GI_abort
		/build/glibc-aGgxh2/glibc-2.27/stdlib/abort.c:81
/lib/x86_64-linux-gnu/libpthread.so.0
	__restore_rt
		??:?
/lib/x86_64-linux-gnu/libpthread.so.0
	__GI___pthread_mutex_lock
		/build/glibc-aGgxh2/glibc-2.27/nptl/../nptl/pthread_mutex_lock.c:67
/usr/bin/coolwsd
	ServerAuditUtil::set(std::string, std::string)
		/opt/rh/devtoolset-12/root/usr/include/c++/12/bits/std_mutex.h:103
/usr/bin/coolwsd
	SocketDisposition::execute()
		/opt/rh/devtoolset-12/root/usr/include/c++/12/bits/std_function.h:591
/usr/bin/coolwsd
	SocketPoll::poll(long)
		/opt/rh/devtoolset-12/root/usr/include/c++/12/bits/shared_ptr_base.h:1070
/usr/bin/coolwsd
	SocketPoll::pollingThreadEntry()
		net/Socket.hpp:847

sticking:
std::this_thread::sleep_for(std::chrono::milliseconds(5000)); before
_docBroker->setCertAuditWarning();
is enough to reproduce dtor before use with local nextcloud instance

tid: 1696904 RequestVettingStation ctor 0x7fa548008240 tid: 1696904 Add RequestVettingStation 0x7fa548008240 to RequestVettingStations tid: 1696904 Erase RequestVettingStation 0x7fa548008240 from RequestVettingStations tid: 1696904 start handleRequest: RequestVettingStation 0x7fa548008240 tid: 1696904 set Move: RequestVettingStation 0x7fa548008240 tid: 1696904 end handleRequest: RequestVettingStation 0x7fa548008240 tid: 1696904 do Move: RequestVettingStation 0x7fa548008240 tid: 1696904 sleep before setCertAuditWarning: RequestVettingStation 0x7fa548008240 tid: 1696947 RequestVettingStation dtor 0x7fa548008240 tid: 1696904 use of _docBroker: RequestVettingStation 0x7fa548008240
Signed-off-by: Caolán McNamara <caolan.mcnamara@collabora.com>
Change-Id: I0546225a71ea9a148857914899e36b602489464b (cherry picked from commit d81e29d2be1b55849ffafe68b563b8e1dca269ed)


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

