### PR TITLE
Update full chip when stoped following #9682

### DIFF
--- a/browser/src/control/Control.UserList.ts
+++ b/browser/src/control/Control.UserList.ts
@@ -577,7 +577,7 @@ class UserList extends L.Control {
 
 		followingChip.onclick = () => {
 			this.unfollowAll();
-			this.renderFollowingChip();
+			this.renderAll();
 		};
 
 		followingChip.title = this.options.followingChipTooltipText;


### PR DESCRIPTION
This fixes issue #9682 :
- open session with multiple users
- user A is following the other user
- user A stops following by click on a following chip Result: chip is not rendered correctly