### PR TITLE
jsdialog: css: use CSS grid in icon view

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1019,10 +1019,10 @@ input[type='number']:hover::-webkit-outer-spin-button {
 
 .ui-iconview {
 	overflow: auto;
-	display: inline-flex;
-	display: -ms-inline-flexbox;
-	flex-wrap: wrap;
 	justify-content: space-between;
+	display: grid;
+	grid-template-columns: 1fr 1fr 1fr;
+	max-height: 40vh;
 }
 
 .ui-iconview.mobile-wizard {

--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -347,6 +347,9 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 	height: 64px;
 	width: 530px;
 	overflow: auto;
+	display: inline-flex;
+	display: -ms-inline-flexbox;
+	flex-wrap: wrap;
 	padding: 0px;
 	border: 1px solid var(--color-stylesview-border);
 	border-radius: var(--border-radius);
@@ -355,6 +358,7 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 	background-color: var(--color-stylesview-background);
 	filter: brightness(var(--brightness-stylesview));
 }
+
 #stylesview:hover {
 	filter: none;
 }


### PR DESCRIPTION
By default use well aligned 3 column grid.
In styles preview use old flex layout so
we don't change the behavior we had.