### PR TITLE
Fix: Remove non-read-only context menu options in read-only mode

### DIFF
--- a/browser/src/control/Control.Header.ts
+++ b/browser/src/control/Control.Header.ts
@@ -487,7 +487,7 @@ export class Header extends app.definitions.canvasSectionObject {
 	}
 
 	_bindContextMenu(): void {
-		if ((window as any).mode.isMobile()) {
+		if ((window as any).mode.isMobile() || this._map.isReadOnlyMode()) {
 			// On mobile, we use the mobile wizard rather than the context menu
 			return;
 		}


### PR DESCRIPTION

- Disabled non-read-only operations in context menu for row/column headers when in read-only mode.
- Ensured that the context menu does not display options for actions that are not permitted.


Signed-off-by: Darshan-upadhyay1110 <darshan.upadhyay@collabora.com>
Change-Id: I0a7cd1f0722529acb52d44f93ca6fc885b571efd


* Resolves: #9748 
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

