### PR TITLE
backport: fix(contextMenu): Avoid displaying empty menus

### DIFF
--- a/browser/src/control/Control.ContextMenu.js
+++ b/browser/src/control/Control.ContextMenu.js
@@ -149,6 +149,12 @@ L.Control.ContextMenu = L.Control.extend({
 		this._amendContextMenuData(obj);
 
 		var contextMenu = this._createContextMenuStructure(obj);
+
+		if (Object.keys(contextMenu).length == 0) {
+			// We can sometimes end up filtering out everything in the menu ... in this case, there's nothing to display
+			return;
+		}
+
 		var spellingContextMenu = false;
 		var autoFillContextMenu = false;
 		for (var menuItem in contextMenu) {


### PR DESCRIPTION
This is a backport of #9741

It's possible sometimes for us to filter out everything in a context menu with _createContextMenuStructure. If we do that on mobile, we will end up with an empty mobile wizard, so it's much better to skip the context menu altogether...

Fixes: #9740

Change-Id: Iae65aa95a38c4e46f4bea544bd0b41195000cba1


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

