### PR TITLE
backport: fix(header): Prevent context menu on mobile

### DIFF
--- a/browser/src/control/Control.Header.ts
+++ b/browser/src/control/Control.Header.ts
@@ -487,6 +487,11 @@ export class Header extends app.definitions.canvasSectionObject {
 	}
 
 	_bindContextMenu(): void {
+		if ((window as any).mode.isMobile()) {
+			// On mobile, we use the mobile wizard rather than the context menu
+			return;
+		}
+
 		this._unBindContextMenu();
 		$.contextMenu({
 			selector: '#canvas-container',


### PR DESCRIPTION
This is a backport of #9745

Previously, we bound a context menu on mouse-over even when we were in the mobile view and therefore should be using the mobile wizard instead... this can cause trouble when using mice on mobile, in the mobile view on browsers, or possibly if selecting the header before activating the menu...

...by inactivating the unnecessary _bindContextMenu function in mobile view, we can prevent this happening entirely

Fixes: #9744

Change-Id: I74f5802d8c058fa1b30cf06cc44c06d5df321e54


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

