### PR TITLE
backport: Uncaught TypeError: Cannot read properties of null (reading '_docLayer')

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -780,7 +780,7 @@ L.CanvasTileLayer = L.Layer.extend({
 		this._canvasOverlay = new CanvasOverlay(this._map, app.sectionContainer.getContext());
 		app.sectionContainer.addSection(this._canvasOverlay);
 
-		app.sectionContainer.addSection(L.getNewScrollSection(() => this._map._docLayer.isCalcRTL()));
+		app.sectionContainer.addSection(L.getNewScrollSection(() => this.isCalcRTL()));
 
 		// For mobile/tablet the hammerjs swipe handler already uses a requestAnimationFrame to fire move/drag events
 		// Using L.TileSectionManager's own requestAnimationFrame loop to do the updates in that case does not perform well.


### PR DESCRIPTION
This is a backport of #9721

reproducible with hello-world.ods and insert a comment, some text and ok, close document

when document is closing...

_map is null at

this._map._docLayer.isCalcRTL()

(anonymous) @ bundle.js:16912
ScrollSection.drawVerticalScrollBar @ bundle.js:16463 ScrollSection.onDraw @ bundle.js:16511
CanvasSectionContainer.drawSections @ bundle.js:12702 CanvasSectionContainer.requestReDraw @ bundle.js:12339 CommentSection.onResize @ bundle.js:13746
CanvasSectionContainer.reNewAllSections @ bundle.js:12616 CanvasSectionContainer.paintOnResumeOrEnable @ bundle.js:12254 CanvasSectionContainer.resumeDrawing @ bundle.js:12253 CommentSection.clearList @ bundle.js:14159
(anonymous) @ bundle.js:11008
fire @ bundle.js:9893
close @ bundle.js:9940

stepping into this._map._docLayer.isCalcRTL() suggests that the isCalcRTL() called is the one belonging to L.CanvasTileLayer anyway, so presumably we could sidestep the issue by using that directly.


Change-Id: Ic5e0c76f90fe15fae0be5b41b9d55d17fa148fb8


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

