### PR TITLE
backport: invert background fixes

### DIFF
--- a/browser/css/color-palette-dark.css
+++ b/browser/css/color-palette-dark.css
@@ -12,8 +12,6 @@
 	--color-text-lighter: #fff; /* secondard text, disabled */
 	--color-status-badge: #d6d6d6;
 
-	--color-canvas-dark: #141414;
-	--color-background-document: #121212;
 	--color-main-background: #121212;
 	--color-background-dark: #1E1E1E;  /* select */
 	--color-background-darker: #000;  /* todo: apply to pressed (active), li:hover(top menu on classic mode)*/
@@ -50,4 +48,6 @@
 
 [data-bg-theme='dark'] {
 	--color-cursor-blink-background: #fff;
+	--color-canvas: #141414;
+	--color-background-document: #121212;
 }

--- a/browser/css/color-palette-dark.css
+++ b/browser/css/color-palette-dark.css
@@ -45,7 +45,9 @@
 	--color-warning: #eca700;
 	--color-success: #46ba61;
 
-	--color-cursor-blink-background: #fff;
-
 	--color-box-shadow: rgba(0, 0, 0, 0.5);
+}
+
+[data-bg-theme='dark'] {
+	--color-cursor-blink-background: #fff;
 }

--- a/browser/css/color-palette.css
+++ b/browser/css/color-palette.css
@@ -13,8 +13,6 @@
 	--color-text-lighter: #696969; /* secondard text, disabled */
 	--color-status-badge: #616161;
 
-	--color-canvas-light: #f5f5f5;
-	--color-background-document: #FFFFFF;
 	--color-main-background: #F8F9FA;
 	--color-background-dark: #e8e8e8;  /* select */
 	--color-background-darker: #c0bfbc;  /* todo: apply to pressed (active), li:hover(top menu on classic mode)*/
@@ -51,4 +49,6 @@
 
 [data-bg-theme='light'] {
 	--color-cursor-blink-background: #000;
+	--color-canvas: #f5f5f5;
+	--color-background-document: #FFFFFF;
 }

--- a/browser/css/color-palette.css
+++ b/browser/css/color-palette.css
@@ -46,7 +46,9 @@
 	--color-warning: #eca700;
 	--color-success: #46ba61;
 
-	--color-cursor-blink-background: #000;
-
 	--color-box-shadow: rgba(77, 77, 77, 0.5);
+}
+
+[data-bg-theme='light'] {
+	--color-cursor-blink-background: #000;
 }

--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -1376,6 +1376,9 @@ window.app = {
 				const darkTheme = window.prefs.getBoolean('darkTheme');
 				msg += ' darkTheme=' + darkTheme;
 
+				const darkBackground = window.prefs.getBoolean('darkBackgroundForTheme.' + (darkTheme ? 'dark' : 'light'), darkTheme);
+				msg += ' darkBackground=' + darkBackground;
+
 				msg += ' timezone=' + Intl.DateTimeFormat().resolvedOptions().timeZone;
 
 				global.socket.send(msg);

--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -282,7 +282,7 @@ window.app = {
 	};
 
 	global.prefs = {
-		_localStorageChanges: {}, // TODO: change this to new Map() when JS version allows
+		_localStorageCache: {}, // TODO: change this to new Map() when JS version allows
 		canPersist: (function() {
 			var str = 'localstorage_test';
 			try {
@@ -335,8 +335,8 @@ window.app = {
 		},
 
 		get: function(key, defaultValue = undefined) {
-			if (key in global.prefs._localStorageChanges) {
-				return global.prefs._localStorageChanges[key];
+			if (key in global.prefs._localStorageCache) {
+				return global.prefs._localStorageCache[key];
 			}
 
 			const uiDefault = global.prefs._getUIDefault(key);
@@ -344,6 +344,7 @@ window.app = {
 				!global.savedUIState &&
 				uiDefault !== undefined
 			) {
+				global.prefs._localStorageCache[key] = uiDefault;
 				return uiDefault;
 			}
 
@@ -351,14 +352,17 @@ window.app = {
 				const localStorageItem = global.localStorage.getItem(key);
 
 				if (localStorageItem) {
+					global.prefs._localStorageCache[key] = localStorageItem;
 					return localStorageItem;
 				}
 			}
 
 			if (uiDefault !== undefined) {
+				global.prefs._localStorageCache[key] = uiDefault;
 				return uiDefault;
 			}
 
+			global.prefs._localStorageCache[key] = defaultValue;
 			return defaultValue;
 		},
 
@@ -367,14 +371,14 @@ window.app = {
 			if (global.prefs.canPersist) {
 				global.localStorage.setItem(key, value);
 			}
-			global.prefs._localStorageChanges[key] = value;
+			global.prefs._localStorageCache[key] = value;
 		},
 
 		remove: function(key) {
 			if (global.prefs.canPersist) {
 				global.localStorage.removeItem(key);
 			}
-			global.prefs._localStorageChanges[key] = undefined;
+			global.prefs._localStorageCache[key] = undefined;
 		},
 
 		getBoolean: function(key, defaultValue = false) {

--- a/browser/src/canvas/CanvasSectionContainer.ts
+++ b/browser/src/canvas/CanvasSectionContainer.ts
@@ -251,10 +251,7 @@ class CanvasSectionContainer {
 		this.scrollLineHeight = parseInt(window.getComputedStyle(tempElement).fontSize);
 		document.body.removeChild(tempElement); // Remove the temporary element.
 
-		const colorCanvasPropety = (window as any).prefs ?
-			((window as any).prefs.getBoolean('darkTheme') ? '--color-canvas-dark' : '--color-canvas-light') : '--color-canvas-light';
-
-		this.clearColor = window.getComputedStyle(document.documentElement).getPropertyValue(colorCanvasPropety);
+		this.clearColor = window.getComputedStyle(document.documentElement).getPropertyValue('--color-canvas');
 		// Set document background color to the app background color for now until we get the real color from the kit
 		// through a LOK_CALLBACK_DOCUMENT_BACKGROUND_COLOR
 		this.documentBackgroundColor = window.getComputedStyle(document.documentElement).getPropertyValue('--color-background-document');

--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -1007,6 +1007,7 @@ L.Control.Menubar = L.Control.extend({
 				{uno: '.uno:SpellOnline'},
 				{name: _UNO('.uno:ShowResolvedAnnotations', 'text'), id: 'showresolved', type: 'action', uno: '.uno:ShowResolvedAnnotations'},
 				{name: _('Dark Mode'), id: 'toggledarktheme', type: 'action'},
+				{name: _('Invert Background'), id: 'invertbackground', type: 'action'},
 			]
 			},
 			window.enableAccessibility ?
@@ -1059,6 +1060,7 @@ L.Control.Menubar = L.Control.extend({
 				{uno: '.uno:SpellOnline'},
 				{name: _UNO('.uno:FullScreen', 'presentation'), id: 'fullscreen', type: 'action', mobileapp: false},
 				{name: _('Dark Mode'), id: 'toggledarktheme', type: 'action'},
+				{name: _('Invert Background'), id: 'invertbackground', type: 'action'},
 			]
 			},
 			{name: _UNO('.uno:TableMenu', 'text'/*HACK should be 'presentation', but not in xcu*/), id: 'tablemenu', type: 'menu', menu: [
@@ -1119,6 +1121,7 @@ L.Control.Menubar = L.Control.extend({
 				{uno: '.uno:SpellOnline'},
 				{name: _UNO('.uno:FullScreen', 'presentation'), id: 'fullscreen', type: 'action', mobileapp: false},
 				{name: _('Dark Mode'), id: 'toggledarktheme', type: 'action'},
+				{name: _('Invert Background'), id: 'invertbackground', type: 'action'},
 			]
 			},
 			{name: _UNO('.uno:TableMenu', 'text'/*HACK should be 'presentation', but not in xcu*/), id: 'tablemenu', type: 'menu', menu: [
@@ -1178,6 +1181,7 @@ L.Control.Menubar = L.Control.extend({
 				{uno: '.uno:SpellOnline'},
 				{name: _UNO('.uno:FullScreen', 'presentation'), id: 'fullscreen', type: 'action', mobileapp: false},
 				{name: _('Dark Mode'), id: 'toggledarktheme', type: 'action'},
+				{name: _('Invert Background'), id: 'invertbackground', type: 'action'},
 			]
 			},
 			{name: _UNO('.uno:SheetMenu', 'spreadsheet'), id: 'sheetmenu', type: 'menu', menu: [
@@ -2175,6 +2179,9 @@ L.Control.Menubar = L.Control.extend({
 			return false;
 
 		if (menuItem.id === 'changesmenu' && this._map['wopi'].HideChangeTrackingControls)
+			return false;
+
+		if (menuItem.id === 'invertbackground' && !window.prefs.getBoolean('darkTheme'))
 			return false;
 
 

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -85,24 +85,24 @@ L.Control.UIManager = L.Control.extend({
 
 	loadLightMode: function() {
 		document.documentElement.setAttribute('data-theme','light');
-		this.setCanvasColorAfterModeChange();
 		this.map.fire('darkmodechanged');
 	},
 
 	loadDarkMode: function() {
 		document.documentElement.setAttribute('data-theme','dark');
-		this.setCanvasColorAfterModeChange();
 		this.map.fire('darkmodechanged');
 	},
 
-	setCanvasColorAfterModeChange: function(nColor) {
+	setCanvasColorAfterModeChange: function() {
 		if (app.sectionContainer) {
 			app.sectionContainer.setBackgroundColorMode(false);
-			if (nColor == undefined ) {
-				const colorCanvasPropety = window.prefs.getBoolean('darkTheme') ? '--color-canvas-dark' : '--color-canvas-light';
-				nColor = window.getComputedStyle(document.documentElement).getPropertyValue(colorCanvasPropety);
+
+			if (this.map.getDocType() == 'spreadsheet') {
+				app.sectionContainer.setClearColor(window.getComputedStyle(document.documentElement).getPropertyValue('--color-background-document'));
+			} else {
+				app.sectionContainer.setClearColor(window.getComputedStyle(document.documentElement).getPropertyValue('--color-canvas'));
 			}
-			app.sectionContainer.setClearColor(nColor);
+
 			//change back to it's default value after setting canvas color
 			app.sectionContainer.setBackgroundColorMode(true);
 		}
@@ -116,16 +116,8 @@ L.Control.UIManager = L.Control.extend({
 	},
 
 	initDarkBackgroundUI: function(activate) {
-		if (this.map.getDocType() == 'spreadsheet') {
-			var canvasColor;
-			if (activate) {
-				canvasColor = window.getComputedStyle(document.documentElement).getPropertyValue('--color-canvas-dark');
-			} else {
-				canvasColor = window.getComputedStyle(document.documentElement).getPropertyValue('--color-canvas-light');
-			}
-			this.setCanvasColorAfterModeChange(canvasColor);
-		}
 		document.documentElement.setAttribute('data-bg-theme', activate ? 'dark' : 'light');
+		this.setCanvasColorAfterModeChange();
 	},
 
 	applyInvert: function(skipCore) {
@@ -171,6 +163,8 @@ L.Control.UIManager = L.Control.extend({
 			this.loadDarkMode();
 			this.activateDarkModeInCore(true);
 		}
+		this.applyInvert();
+		this.setCanvasColorAfterModeChange();
 		if (!window.mode.isMobile())
 			this.refreshAfterThemeChange();
 
@@ -193,7 +187,6 @@ L.Control.UIManager = L.Control.extend({
 		var cmd = { 'NewTheme': { 'type': 'string', 'value': '' } };
 		activate ? cmd.NewTheme.value = 'Dark' : cmd.NewTheme.value = 'Light';
 		app.socket.sendMessage('uno .uno:ChangeTheme ' + JSON.stringify(cmd));
-		this.applyInvert();
 	},
 
 	renameDocument: function() {

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -112,21 +112,32 @@ L.Control.UIManager = L.Control.extend({
 		var cmd = { 'NewTheme': { 'type': 'string', 'value': '' } };
 		activate ? cmd.NewTheme.value = 'Dark' : cmd.NewTheme.value = 'Light';
 		app.socket.sendMessage('uno .uno:InvertBackground ' + JSON.stringify(cmd));
-		if (this.map.getDocType() == 'spreadsheet') {
-			var lightCanvasColor = window.getComputedStyle(document.documentElement).getPropertyValue('--color-canvas-light');
-			var darkCanvasColor = window.getComputedStyle(document.documentElement).getPropertyValue('--color-canvas-dark');
-			var nColor = app.sectionContainer.getClearColor(); // Current color of the canvas
-			// invert canvas color
-			nColor == lightCanvasColor ? nColor = darkCanvasColor : nColor = lightCanvasColor
-			this.setCanvasColorAfterModeChange(nColor);
-		}
+		this.initDarkBackgroundUI(activate);
 	},
 
-	applyInvert: function() {
+	initDarkBackgroundUI: function(activate) {
+		if (this.map.getDocType() == 'spreadsheet') {
+			var canvasColor;
+			if (activate) {
+				canvasColor = window.getComputedStyle(document.documentElement).getPropertyValue('--color-canvas-dark');
+			} else {
+				canvasColor = window.getComputedStyle(document.documentElement).getPropertyValue('--color-canvas-light');
+			}
+			this.setCanvasColorAfterModeChange(canvasColor);
+		}
+		document.documentElement.setAttribute('data-bg-theme', activate ? 'dark' : 'light');
+	},
+
+	applyInvert: function(skipCore) {
 		// get the initial mode
 		var inDarkTheme = window.prefs.getBoolean('darkTheme');
 		var backgroundDark = window.prefs.getBoolean('darkBackgroundForTheme.' + (inDarkTheme ? 'dark' : 'light'), inDarkTheme);
-		this.setDarkBackground(backgroundDark);
+
+		if (skipCore) {
+			this.initDarkBackgroundUI(backgroundDark);
+		} else {
+			this.setDarkBackground(backgroundDark);
+		}
 	},
 
 	toggleInvert: function() {
@@ -174,6 +185,8 @@ L.Control.UIManager = L.Control.extend({
 		} else {
 			this.loadLightMode();
 		}
+
+		this.applyInvert(true);
 	},
 
 	activateDarkModeInCore: function(activate) {

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -108,8 +108,10 @@ L.Control.UIManager = L.Control.extend({
 		}
 	},
 
-	invertBackground: function() {
-		app.socket.sendMessage('uno .uno:InvertBackground');
+	setDarkBackground: function(activate) {
+		var cmd = { 'NewTheme': { 'type': 'string', 'value': '' } };
+		activate ? cmd.NewTheme.value = 'Dark' : cmd.NewTheme.value = 'Light';
+		app.socket.sendMessage('uno .uno:InvertBackground ' + JSON.stringify(cmd));
 		if (this.map.getDocType() == 'spreadsheet') {
 			var lightCanvasColor = window.getComputedStyle(document.documentElement).getPropertyValue('--color-canvas-light');
 			var darkCanvasColor = window.getComputedStyle(document.documentElement).getPropertyValue('--color-canvas-dark');
@@ -117,6 +119,30 @@ L.Control.UIManager = L.Control.extend({
 			// invert canvas color
 			nColor == lightCanvasColor ? nColor = darkCanvasColor : nColor = lightCanvasColor
 			this.setCanvasColorAfterModeChange(nColor);
+		}
+	},
+
+	applyInvert: function() {
+		// get the initial mode
+		var inDarkTheme = window.prefs.getBoolean('darkTheme');
+		var backgroundDark = window.prefs.getBoolean('darkBackgroundForTheme.' + (inDarkTheme ? 'dark' : 'light'), inDarkTheme);
+		this.setDarkBackground(backgroundDark);
+	},
+
+	toggleInvert: function() {
+		// get the initial mode
+		var inDarkTheme = window.prefs.getBoolean('darkTheme');
+		var darkBackgroundPrefName = 'darkBackgroundForTheme.' + (inDarkTheme ? 'dark' : 'light');
+		var backgroundDark = window.prefs.getBoolean(darkBackgroundPrefName, inDarkTheme);
+
+		// swap them by invoking the appropriate load function and saving the state
+		if (backgroundDark) {
+			window.prefs.set(darkBackgroundPrefName, false);
+			this.setDarkBackground(false);
+		}
+		else {
+			window.prefs.set(darkBackgroundPrefName, true);
+			this.setDarkBackground(true);
 		}
 	},
 
@@ -154,6 +180,7 @@ L.Control.UIManager = L.Control.extend({
 		var cmd = { 'NewTheme': { 'type': 'string', 'value': '' } };
 		activate ? cmd.NewTheme.value = 'Dark' : cmd.NewTheme.value = 'Light';
 		app.socket.sendMessage('uno .uno:ChangeTheme ' + JSON.stringify(cmd));
+		this.applyInvert();
 	},
 
 	renameDocument: function() {

--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -1506,9 +1506,8 @@ app.definitions.Socket = L.Class.extend({
 
 			var darkTheme = window.prefs.getBoolean('darkTheme');
 			this._map.uiManager.activateDarkModeInCore(darkTheme);
-
-			var darkBackground = window.prefs.getBoolean('darkBackgroundForTheme.' + (darkTheme ? 'dark' : 'light'), darkTheme);
-			this._map.uiManager.setDarkBackground(darkBackground);
+			this._map.uiManager.applyInvert();
+			this._map.uiManager.setCanvasColorAfterModeChange();
 
 			var uiMode = this._map.uiManager.getCurrentMode();
 			if (uiMode === 'notebookbar') {

--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -248,6 +248,9 @@ app.definitions.Socket = L.Class.extend({
 		const darkTheme = window.prefs.getBoolean('darkTheme');
 		msg += ' darkTheme=' + darkTheme;
 
+		const darkBackground = window.prefs.getBoolean('darkBackgroundForTheme.' + (darkTheme ? 'dark' : 'light'), darkTheme);
+		msg += ' darkBackground=' + darkBackground;
+
 		var isCalcTest =
 			window.docURL.includes('data/desktop/calc/') ||
 			window.docURL.includes('data/mobile/calc/') ||

--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -250,6 +250,7 @@ app.definitions.Socket = L.Class.extend({
 
 		const darkBackground = window.prefs.getBoolean('darkBackgroundForTheme.' + (darkTheme ? 'dark' : 'light'), darkTheme);
 		msg += ' darkBackground=' + darkBackground;
+		this._map.uiManager.initDarkBackgroundUI(darkBackground);
 
 		var isCalcTest =
 			window.docURL.includes('data/desktop/calc/') ||
@@ -1503,8 +1504,11 @@ app.definitions.Socket = L.Class.extend({
 			this._map._docLayer._refreshTilesInBackground();
 			this._map.fire('statusindicator', { statusType: 'reconnected' });
 
-			var selectedMode = window.prefs.getBoolean('darkTheme');
-			this._map.uiManager.activateDarkModeInCore(selectedMode);
+			var darkTheme = window.prefs.getBoolean('darkTheme');
+			this._map.uiManager.activateDarkModeInCore(darkTheme);
+
+			var darkBackground = window.prefs.getBoolean('darkBackgroundForTheme.' + (darkTheme ? 'dark' : 'light'), darkTheme);
+			this._map.uiManager.setDarkBackground(darkBackground);
 
 			var uiMode = this._map.uiManager.getCurrentMode();
 			if (uiMode === 'notebookbar') {

--- a/browser/src/docdispatcher.ts
+++ b/browser/src/docdispatcher.ts
@@ -99,7 +99,7 @@ class Dispatcher {
 			app.map.uiManager.toggleDarkMode();
 		};
 		this.actionsMap['invertbackground'] = function () {
-			app.map.uiManager.invertBackground();
+			app.map.uiManager.toggleInvert();
 		};
 		this.actionsMap['home-search'] = function () {
 			app.map.uiManager.focusSearch();

--- a/common/Session.cpp
+++ b/common/Session.cpp
@@ -202,6 +202,11 @@ void Session::parseDocOptions(const StringVector& tokens, int& part, std::string
             _darkTheme = value;
             ++offset;
         }
+        else if (name == "darkBackground")
+        {
+            _darkBackground = value;
+            ++offset;
+        }
         else if (name == "batch")
         {
             _batch = value;

--- a/common/Session.hpp
+++ b/common/Session.hpp
@@ -263,6 +263,8 @@ public:
 
     const std::string& getDarkTheme() const { return _darkTheme; }
 
+    const std::string& getDarkBackground() const { return _darkBackground; }
+
     const std::string& getBatchMode() const { return _batch; }
 
     const std::string& getEnableMacrosExecution() const { return _enableMacrosExecution; }
@@ -384,6 +386,9 @@ private:
 
     /// The start value for Dark Theme whether it is active or not on start.
     std::string _darkTheme;
+    ///
+    /// The start value for Dark Background whether it is active or not on start.
+    std::string _darkBackground;
 
     /// Disable dialogs interactivity.
     std::string _batch;

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1753,6 +1753,12 @@ std::string Document::getDefaultTheme(const std::shared_ptr<ChildSession>& sessi
     return darkTheme ? "Dark" : "Light";
 }
 
+std::string Document::getDefaultBackgroundTheme(const std::shared_ptr<ChildSession>& session) const
+{
+    bool darkTheme = session->getDarkBackground() == "true";
+    return darkTheme ? "Dark" : "Light";
+}
+
 std::shared_ptr<lok::Document> Document::load(const std::shared_ptr<ChildSession>& session,
                                               const std::string& renderOpts)
 {
@@ -1935,12 +1941,14 @@ std::shared_ptr<lok::Document> Document::load(const std::shared_ptr<ChildSession
     }
     std::string theme = getDefaultTheme(session);
 
+    std::string backgroundTheme = getDefaultBackgroundTheme(session);
+
     LOG_INF("Initializing for rendering session [" << sessionId << "] on document url [" <<
-            anonymizeUrl(_url) << "] with: [" << makeRenderParams(_renderOpts, userNameAnonym, spellOnline, theme) << "].");
+            anonymizeUrl(_url) << "] with: [" << makeRenderParams(_renderOpts, userNameAnonym, spellOnline, theme, backgroundTheme) << "].");
 
     // initializeForRendering() should be called before
     // registerCallback(), as the previous creates a new view in Impress.
-    const std::string renderParams = makeRenderParams(_renderOpts, userName, spellOnline, theme);
+    const std::string renderParams = makeRenderParams(_renderOpts, userName, spellOnline, theme, backgroundTheme);
 
     _loKitDocument->initializeForRendering(renderParams.c_str());
 
@@ -2083,7 +2091,8 @@ Object::Ptr makePropertyValue(const std::string& type, const T& val)
 }
 
 /* static */ std::string Document::makeRenderParams(const std::string& renderOpts, const std::string& userName,
-                                                    const std::string& spellOnline, const std::string& theme)
+                                                    const std::string& spellOnline, const std::string& theme,
+                                                    const std::string& backgroundTheme)
 {
     Object::Ptr renderOptsObj;
 
@@ -2115,6 +2124,9 @@ Object::Ptr makePropertyValue(const std::string& type, const T& val)
 
     if (!theme.empty())
         renderOptsObj->set(".uno:ChangeTheme", makePropertyValue("string", theme));
+
+    if (!backgroundTheme.empty())
+        renderOptsObj->set(".uno:InvertBackground", makePropertyValue("string", backgroundTheme));
 
     if (renderOptsObj)
     {

--- a/kit/Kit.hpp
+++ b/kit/Kit.hpp
@@ -312,13 +312,16 @@ private:
 
     std::string getDefaultTheme(const std::shared_ptr<ChildSession>& session) const;
 
+    std::string getDefaultBackgroundTheme(const std::shared_ptr<ChildSession>& session) const;
+
     std::shared_ptr<lok::Document> load(const std::shared_ptr<ChildSession>& session,
                                         const std::string& renderOpts);
 
     bool forwardToChild(const std::string& prefix, const std::vector<char>& payload);
 
     static std::string makeRenderParams(const std::string& renderOpts, const std::string& userName,
-                                        const std::string& spellOnline, const std::string& theme);
+                                        const std::string& spellOnline, const std::string& theme,
+                                        const std::string& backgroundTheme);
     bool isTileRequestInsideVisibleArea(const TileCombined& tileCombined);
 
 public:

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1350,6 +1350,11 @@ bool ClientSession::loadDocument(const char* /*buffer*/, int /*length*/,
             oss << " darkTheme=" << getDarkTheme();
         }
 
+        if (!getDarkBackground().empty())
+        {
+            oss << " darkBackground=" << getDarkBackground();
+        }
+
         if (!getWatermarkText().empty())
         {
             std::string encodedWatermarkText;


### PR DESCRIPTION
This contains various invert background fixes, backporting #9652, #9667 and #9697

These changes both allow invert background to be used on phones, as well as fixing it for devices (e.g. tablets) that already had it

Signed-off-by: Skyler Grey <skyler.grey@collabora.com>
Change-Id: I221058206b0fbbaa7b2a73e06f12d5e95e3b700a* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

