### PR TITLE
SlideShow: reset cached slides to show updated content

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -410,6 +410,7 @@ COOL_JS_LST =\
 	src/control/Styles.js \
 	src/control/Ruler.js \
 	src/control/VRuler.ts \
+	src/slideshow/SlideCache.ts \
 	src/slideshow/SlideCompositor.ts \
 	src/slideshow/LayerDrawing.ts \
 	src/slideshow/LayersCompositor.ts \
@@ -878,6 +879,7 @@ pot:
 		src/control/jsdialog/Widget.SidebarContainers.ts \
 		src/control/jsdialog/Widget.Timefield.js \
 		src/control/jsdialog/Widget.TreeView.js \
+		src/slideshow/SlideCache.ts \
 		src/slideshow/SlideCompositor.ts \
 		src/slideshow/LayerDrawing.ts \
 		src/slideshow/LayersCompositor.ts \

--- a/browser/src/slideshow/LayerDrawing.ts
+++ b/browser/src/slideshow/LayerDrawing.ts
@@ -72,7 +72,7 @@ class LayerDrawing {
 	private map: any = null;
 	private helper: LayersCompositor;
 
-	private renderedSlides: Map<string, ImageBitmap> = new Map();
+	private slideCache: SlideCache = new SlideCache();
 	private requestedSlideHash: string = null;
 	private prefetchedSlideHash: string = null;
 	private nextRequestedSlideHash: string = null;
@@ -133,7 +133,11 @@ class LayerDrawing {
 
 	public getSlide(slideNumber: number): ImageBitmap {
 		const startSlideHash = this.helper.getSlideHash(slideNumber);
-		return this.renderedSlides.get(startSlideHash);
+		return this.slideCache.get(startSlideHash);
+	}
+
+	public invalidateAll(): void {
+		this.slideCache.invalidateAll();
 	}
 
 	public getCanvasSize(): [number, number] {
@@ -216,7 +220,7 @@ class LayerDrawing {
 			this.prefetchedSlideHash = null;
 		}
 
-		if (this.renderedSlides.has(slideHash)) {
+		if (this.slideCache.has(slideHash)) {
 			this.onSlideRenderingComplete();
 			return;
 		}
@@ -499,7 +503,7 @@ class LayerDrawing {
 
 		this.cacheAndNotify();
 		// fetch next slide and draw it on offscreen canvas
-		if (!this.renderedSlides.has(reqSlideInfo.next)) {
+		if (!this.slideCache.has(reqSlideInfo.next)) {
 			this.requestSlideImpl(reqSlideInfo.next, true);
 		}
 	}
@@ -511,9 +515,9 @@ class LayerDrawing {
 			);
 			return;
 		}
-		if (!this.renderedSlides.has(this.requestedSlideHash)) {
+		if (!this.slideCache.has(this.requestedSlideHash)) {
 			const renderedSlide = this.offscreenCanvas.transferToImageBitmap();
-			this.renderedSlides.set(this.requestedSlideHash, renderedSlide);
+			this.slideCache.set(this.requestedSlideHash, renderedSlide);
 		}
 		this.requestedSlideHash = null;
 

--- a/browser/src/slideshow/LayersCompositor.ts
+++ b/browser/src/slideshow/LayersCompositor.ts
@@ -72,6 +72,8 @@ class LayersCompositor extends SlideShow.SlideCompositor {
 		this._presentationInfo = presentationInfo;
 		this.onSlidesInfo(presentationInfo);
 		this.layerDrawing.onUpdatePresentationInfo();
+		// TODO: optimize
+		this.layerDrawing.invalidateAll();
 	}
 
 	private onSlidesInfo(data: any) {

--- a/browser/src/slideshow/SlideCache.ts
+++ b/browser/src/slideshow/SlideCache.ts
@@ -1,0 +1,44 @@
+/** */
+
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * SlideCache is storing the cached layers
+ */
+
+declare var SlideShow: any;
+
+class SlideCache {
+	private renderedSlides: Map<string, ImageBitmap> = new Map();
+	// TODO: cache other layers here
+
+	public has(slideHash: string) {
+		return this.renderedSlides.has(slideHash);
+	}
+
+	public get(slideHash: string): ImageBitmap {
+		return this.renderedSlides.get(slideHash);
+	}
+
+	public set(slideHash: string, image: ImageBitmap): void {
+		this.renderedSlides.set(slideHash, image);
+	}
+
+	public invalidate(slideHash: string): void {
+		this.renderedSlides.delete(slideHash);
+	}
+
+	public invalidateAll(): void {
+		this.renderedSlides.clear();
+	}
+}
+
+SlideShow.SlideCache = SlideCache;


### PR DESCRIPTION
Introduce container for cached content. Reset data when we receive new presentation info. This should be improved in the future to detect and reset only modified slides. Also we want to put into cach all other layers.