### PR TITLE
All vertical separators should be automatically centered

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -247,6 +247,7 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 
 .ui-toolbar .ui-separator.vertical {
 	height: 14px;
+	align-self: center;
 }
 
 .jsdialog.ui-separator.horizontal {


### PR DESCRIPTION
So no matter the height, they are well aligned:
- fixes compact mode separators

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Iea6501d827093dfa24af0595b7a61f93e1621c08
