### PR TITLE
fix(userlist): Don't show popup if you "leave"

### DIFF
--- a/browser/src/control/Control.UserList.ts
+++ b/browser/src/control/Control.UserList.ts
@@ -399,9 +399,7 @@ class UserList extends L.Control {
 			readonly: e.readonly,
 		});
 
-		if (!you) {
-			this.showJoinLeaveMessage('join', username, color);
-		}
+		this.showJoinLeaveMessage('join', e.viewId, username, color);
 
 		this.renderAll();
 	}
@@ -415,7 +413,7 @@ class UserList extends L.Control {
 		}
 
 		if (user !== undefined) {
-			this.showJoinLeaveMessage('leave', user.username, user.color);
+			this.showJoinLeaveMessage('leave', e.viewId, user.username, user.color);
 		}
 
 		this.renderAll();
@@ -451,10 +449,15 @@ class UserList extends L.Control {
 
 	showJoinLeaveMessage(
 		type: 'join' | 'leave',
-		username: string,
+		viewId: number,
+		username: string, // As the user no longer exists when we are showing a leave message, we can't get this from the viewId
 		_color: string /* TODO: make this display in user colors */,
 	) {
 		let message;
+
+		if (viewId === this.map._docLayer._viewId) {
+			return;
+		}
 
 		if (type === 'join') {
 			message = this.options.userJoinedPopupMessage.replace('{user}', username);


### PR DESCRIPTION
There are a few cases where you can be shown a popup for yourself
leaving a document. These are generally where either the server has
disconnected (e.g. it crashed) or the document has moved (e.g. you
rename it in the NextCloud title bar)

In this case, it's rather weird to show the popup, and the current
message ("You has left") is gramatically incorrect because we do not
expect this to happen. It's better to not permit yourself to show in a
join/leave message at all...

Signed-off-by: Skyler Grey <skyler.grey@collabora.com>
Change-Id: I0da9fee162ab3d6cbfffccb461c5fc292c94f480