### PR TITLE
test: Make cypress fail on exception

### DIFF
--- a/browser/html/debug.html
+++ b/browser/html/debug.html
@@ -43,6 +43,29 @@
        var form = document.getElementById("form");
        form.action = constructWopiUrl();
        form.submit();
+
+        window.addEventListener(
+            'message',
+            (event) => {
+                if (event.origin !== window.origin) {
+                    return;
+                }
+
+                if (typeof event.data !== 'object' || event.data === null) {
+                    return;
+                }
+
+                if (typeof event.data.name !== 'string') {
+                    return;
+                }
+
+                if (!event.data.name.endsWith("Error")) {
+                    return;
+                }
+
+                throw event.data;
+            }
+        );
     </script>
 </body>
 </html>

--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -591,6 +591,12 @@ function getInitializerClass() {
 				var desc = err ? err.message || '(no message)': '(no err)', stack = err ? err.stack || '(no stack)': '(no err)';
 				var log = 'jserror ' + JSON.stringify(data, null, 2) + '\n' + desc + '\n' + stack + '\n';
 				global.logServer(log);
+
+				if (L.Browser.cypressTest && window.parent !== window && err !== null) {
+					console.log("Sending global error to Cypress...:", err);
+					window.parent.postMessage(err);
+				}
+
 				return false;
 			};
 		}

--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -428,6 +428,14 @@ app.definitions.Socket = L.Class.extend({
 						if (window.enableDebug)
 							this._map.uiManager.showInfoModal(
 								'cool_alert', '', msg, '', _('Close'), function() { /* Do nothing. */ }, false);
+
+						// If we're cypress testing, fail the run. Cypress will fail anyway, but this way we may get
+						// a nice error in the logs rather than guessing that the run failed from our popup blocking input...
+						if (L.Browser.cypressTest && window.parent !== window && e !== null) {
+							console.log("Sending event error to Cypress...", e);
+							window.parent.postMessage(e);
+						}
+
 					}
 					finally {
 						if (completeEventOneMessage)

--- a/cypress_test/data/multiuser/cypress-multiuser.html
+++ b/cypress_test/data/multiuser/cypress-multiuser.html
@@ -39,6 +39,29 @@
        var form2 = document.getElementById("form2");
        form2.action = wopiUrl
        form2.submit();
+
+        window.addEventListener(
+            'message',
+            (event) => {
+                if (event.origin !== window.origin) {
+                    return;
+                }
+
+                if (typeof event.data !== 'object' || event.data === null) {
+                    return;
+                }
+
+                if (typeof event.data.name !== 'string') {
+                    return;
+                }
+
+                if (!event.data.name.endsWith("Error")) {
+                    return;
+                }
+
+                throw event.data;
+            }
+        );
     </script>
 </body>
 </html>


### PR DESCRIPTION
In I636e07a93d2ed17d56b2a9fc11d66b7e4c3c19f3, Michael Meeks added a new
popup to show when we have an exception in an event. This is excellent,
and is catching errors. Unfortunately, the messages we get in our
Cypress tests when this fails are... not amazing.

They don't include the error, and instead the new popup just makes some
actions that we wanted to perform silently fail to happen. This causes
later assertion errors, but they are disconnected from the root cause -
the error. It's much neater to throw here if we're in cypress, failing
the test.

Signed-off-by: Skyler Grey <skyler.grey@collabora.com>
Change-Id: Ia729489ba2adc3be0e9286f942d128acafd29858* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

