### PR TITLE
split out a deprecated subpackage of the helpers not needed with namespaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,11 +83,15 @@ browser/dist
 browser/compilets
 browser/typescript_js
 
+coolforkit
+coolforkitns
+coolforkit-caps
+coolforkit-nocaps
+coolforkit-ns
 connect
 lokitclient
 coolwsd
 loolwsd
-coolforkit
 coolmount
 coolmap
 coolconvert
@@ -95,14 +99,12 @@ coolsocketdump
 coolstress
 coolconfig
 loolconfig
-coolforkit-nocaps
 loadtest
 unittest
 clientnb
 libsimd.a
 coolwsd-inproc
 coolbench
-coolforkitns
 
 # Fuzzer
 *_fuzzer

--- a/Makefile.am
+++ b/Makefile.am
@@ -19,8 +19,8 @@ SUBDIRS = . browser test cypress_test
 export ENABLE_DEBUG
 
 bin_PROGRAMS = \
-	coolforkit \
-	coolforkitns \
+	coolforkit-caps \
+	coolforkit-ns \
 	coolmount \
         coolstress \
 	coolconvert coolconfig
@@ -36,7 +36,7 @@ endif
 dist_bin_SCRIPTS = coolwsd-systemplate-setup
 
 man_MANS = man/coolwsd.1 \
-           man/coolforkit.1 \
+           man/coolforkit-ns.1 \
            man/coolconvert.1 \
            man/coolconfig.1 \
            man/coolstress.1 \
@@ -206,17 +206,19 @@ coolforkit_sources = kit/ChildSession.cpp \
                      kit/Kit.cpp \
                      kit/KitWebSocket.cpp
 
-coolforkit_SOURCES = $(coolforkit_sources) \
-                     $(shared_sources) \
-                     kit/forkit-main.cpp
+coolforkit_ldadd = libsimd.a
 
-coolforkit_LDADD = libsimd.a
+coolforkit_caps_SOURCES = $(coolforkit_sources) \
+                          $(shared_sources) \
+                          kit/forkit-main.cpp
 
-coolforkitns_SOURCES = $(coolforkit_sources) \
-                       $(shared_sources) \
-                       kit/forkit-main.cpp
+coolforkit_caps_LDADD = ${coolforkit_ldadd}
 
-coolforkitns_LDADD = libsimd.a
+coolforkit_ns_SOURCES = $(coolforkit_sources) \
+                        $(shared_sources) \
+                        kit/forkit-main.cpp
+
+coolforkit_ns_LDADD = ${coolforkit_ldadd}
 
 if ENABLE_DEBUG
 coolwsd_inproc_SOURCES = $(coolwsd_sources) \
@@ -225,13 +227,13 @@ coolwsd_inproc_SOURCES = $(coolwsd_sources) \
                          wsd/coolwsd-inproc.cpp
 
 coolwsd_inproc_LDADD = ${coolwsd_LDADD} \
-                       ${coolforkit_LDADD}
+                       ${coolforkit_ldadd}
 endif
 
 if ENABLE_LIBFUZZER
-coolforkit_SOURCES += \
+coolforkit_caps_SOURCES += \
 		       common/DummyTraceEventEmitter.cpp
-coolforkitns_SOURCES += \
+coolforkit_ns_SOURCES += \
 		       common/DummyTraceEventEmitter.cpp
 
 common_fuzzer_sources = \
@@ -484,7 +486,7 @@ RUN_GDB = $(if $(GDB_FRONTEND),$(GDB_FRONTEND),gdb --tui --args)
 if ENABLE_LIBFUZZER
 CLEANUP_DEPS=
 else
-CLEANUP_DEPS=coolwsd coolmount coolforkit coolforkitns
+CLEANUP_DEPS=coolwsd coolmount coolforkit-caps coolforkit-ns
 endif
 
 # Build coolwsd and coolmount first, so we can cleanup before updating

--- a/coolwsd.spec.in
+++ b/coolwsd.spec.in
@@ -62,7 +62,7 @@ echo "account    required     pam_unix.so" >>  %{buildroot}/etc/pam.d/coolwsd
 /usr/bin/loolwsd
 /usr/bin/coolwsd-systemplate-setup
 /usr/bin/loolwsd-systemplate-setup
-/usr/bin/coolforkitns
+/usr/bin/coolforkit-ns
 /usr/bin/coolconvert
 /usr/bin/coolconfig
 /usr/bin/loolconfig
@@ -77,7 +77,7 @@ echo "account    required     pam_unix.so" >>  %{buildroot}/etc/pam.d/coolwsd
 /usr/share/doc/coolwsd/reference.md
 /usr/share/doc/coolwsd/THIRDPARTYLICENSES
 /usr/share/man/man1/coolwsd.1.gz
-/usr/share/man/man1/coolforkit.1.gz
+/usr/share/man/man1/coolforkit-ns.1.gz
 /usr/share/man/man1/coolconvert.1.gz
 /usr/share/man/man1/coolconfig.1.gz
 /usr/share/man/man1/coolstress.1.gz
@@ -96,7 +96,7 @@ echo "account    required     pam_unix.so" >>  %{buildroot}/etc/pam.d/coolwsd
 
 %files deprecated
 %defattr(-,root,root,-)
-/usr/bin/coolforkit
+/usr/bin/coolforkit-caps
 /usr/bin/coolmount
 
 %pre
@@ -142,7 +142,7 @@ coolconfig generate-proof-key >/dev/null 2>&1
 if [ $COOLWSD_IS_ACTIVE == "1" ]; then systemctl start coolwsd; fi
 
 %post deprecated
-setcap cap_fowner,cap_chown,cap_sys_chroot=ep /usr/bin/coolforkit
+setcap cap_fowner,cap_chown,cap_sys_chroot=ep /usr/bin/coolforkit-caps
 setcap cap_sys_admin=ep /usr/bin/coolmount
 
 %preun

--- a/coolwsd.spec.in
+++ b/coolwsd.spec.in
@@ -15,11 +15,18 @@ License:        EULA
 Source0:        coolwsd-@PACKAGE_VERSION@.tar.gz
 BuildRequires:  libcap-devel pam-devel rsync
 Requires:       collaboraoffice collaboraoffice-ure collaboraofficebasis-core collaboraofficebasis-writer collaboraofficebasis-impress collaboraofficebasis-graphicfilter collaboraofficebasis-en-US collaboraofficebasis-calc collaboraofficebasis-ooofonts collaboraofficebasis-images collaboraofficebasis-draw collaboraofficebasis-extension-pdf-import collaboraofficebasis-ooolinguistic collaboraofficebasis-math
-Requires(post): coreutils grep sed cpio /usr/sbin/setcap
+Requires(post): coreutils grep sed cpio
 Provides: loolwsd
 Obsoletes: loolwsd collaboraoffice-dict-br collaboraoffice-dict-et collaboraoffice-dict-gd collaboraoffice-dict-gu collaboraoffice-dict-hi collaboraoffice-dict-lt collaboraoffice-dict-lv collaboraoffice-dict-ro collaboraoffice-dict-sr collaboraoffice-dict-te collaboraofficebasis-as collaboraofficebasis-bn-IN collaboraofficebasis-ast collaboraofficebasis-br collaboraofficebasis-ca-valencia collaboraofficebasis-cy collaboraofficebasis-et collaboraofficebasis-ga collaboraofficebasis-gd collaboraofficebasis-gu collaboraofficebasis-hi collaboraofficebasis-km collaboraofficebasis-kn collaboraofficebasis-lt collaboraofficebasis-lv collaboraofficebasis-ml collaboraofficebasis-mr collaboraofficebasis-nn collaboraofficebasis-or collaboraofficebasis-pa-IN collaboraofficebasis-ro collaboraofficebasis-sr collaboraofficebasis-sr-Latn collaboraofficebasis-ta collaboraofficebasis-te
 
 %description
+
+%package deprecated
+Summary: Collabora Online WebSocket Daemon Deprecated Utilities
+Requires: %{name} = %{version}-%{release}
+Requires(post): /usr/sbin/setcap
+
+%description deprecated
 
 %prep
 %setup -n coolwsd-@PACKAGE_VERSION@
@@ -55,13 +62,11 @@ echo "account    required     pam_unix.so" >>  %{buildroot}/etc/pam.d/coolwsd
 /usr/bin/loolwsd
 /usr/bin/coolwsd-systemplate-setup
 /usr/bin/loolwsd-systemplate-setup
-/usr/bin/coolforkit
 /usr/bin/coolforkitns
 /usr/bin/coolconvert
 /usr/bin/coolconfig
 /usr/bin/loolconfig
 /usr/bin/coolstress
-/usr/bin/coolmount
 /usr/share/coolwsd/discovery.xml
 /usr/share/coolwsd/favicon.ico
 /usr/share/coolwsd/browser
@@ -89,13 +94,16 @@ echo "account    required     pam_unix.so" >>  %{buildroot}/etc/pam.d/coolwsd
 
 %doc README.md
 
+%files deprecated
+%defattr(-,root,root,-)
+/usr/bin/coolforkit
+/usr/bin/coolmount
+
 %pre
 getent group cool >/dev/null || groupadd -r cool
 getent passwd cool >/dev/null || useradd -g cool -r cool -d /opt/cool -s /bin/bash
 
 %post
-setcap cap_fowner,cap_chown,cap_sys_chroot=ep /usr/bin/coolforkit
-setcap cap_sys_admin=ep /usr/bin/coolmount
 if [ -f /etc/loolwsd/loolwsd.xml ]; then /usr/bin/coolconfig migrateconfig --write; fi
 # compatibility with older systemd versions
 SYSTEMD_VERSION=$(busctl --system get-property org.freedesktop.systemd1 /org/freedesktop/systemd1 org.freedesktop.systemd1.Manager Version | grep -Eo [0-9]{3} | head -n 1)
@@ -133,6 +141,9 @@ coolconfig generate-proof-key >/dev/null 2>&1
 
 if [ $COOLWSD_IS_ACTIVE == "1" ]; then systemctl start coolwsd; fi
 
+%post deprecated
+setcap cap_fowner,cap_chown,cap_sys_chroot=ep /usr/bin/coolforkit
+setcap cap_sys_admin=ep /usr/bin/coolmount
 
 %preun
 if [ $1 -eq 0 ]; then
@@ -146,6 +157,8 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
+* Mon Aug 12 2024 Caolán McNamara
+- split out a deprecated subpackage of the helpers not needed with namespaces
 * Mon Aug 03 2015 Mihai Varga
 - added the cronjob
 * Tue May 19 2015 Tor Lillqvist

--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -37,7 +37,7 @@
     <sys_template_path desc="Path to a template tree with shared libraries etc to be used as source for chroot jails for child processes." type="path" relative="true" default="systemplate"></sys_template_path>
     <child_root_path desc="Path to the directory under which the chroot jails for the child processes will be created. Should be on the same file system as systemplate and lotemplate. Must be an empty directory." type="path" relative="true" default="jails"></child_root_path>
     <mount_jail_tree desc="Controls whether the systemplate and lotemplate contents are mounted or not, which is much faster than the default of linking/copying each file." type="bool" default="true"></mount_jail_tree>
-    <mount_namespaces desc="Use mount namespaces instead of coolmount." type="bool" default="@ENABLE_EXPERIMENTAL@"></mount_namespaces>
+    <mount_namespaces desc="Use mount namespaces instead of coolmount." type="bool" default="true"></mount_namespaces>
 
     <server_name desc="External hostname:port of the server running coolwsd. If empty, it's derived from the request (please set it if this doesn't work). May be specified when behind a reverse-proxy or when the hostname is not reachable directly." type="string" default=""></server_name>
     <file_server_root_path desc="Path to the directory that should be considered root for the file server. This should be the directory containing cool." type="path" relative="true" default="browser/../"></file_server_root_path>

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Package: coolwsd
 Section: web
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends},
- adduser, fontconfig, cpio, libcap2-bin,
+ adduser, fontconfig, cpio,
  collaboraofficebasis-calc,
  collaboraofficebasis-core,
  collaboraofficebasis-graphicfilter,
@@ -99,3 +99,15 @@ Replaces: loolwsd,
 Description: Collabora Online WebSocket Daemon
  COOLWSD is a daemon that talks to web browser clients and provides LibreOffice
  services.
+
+Package: coolwsd-deprecated
+Section: web
+Architecture: any
+Depends: ${shlibs:Depends}, ${misc:Depends},
+ coolwsd, libcap2-bin
+Description: Collabora Online WebSocket Daemon Deprecated Utilities
+ COOLWSD is a daemon that talks to web browser clients and provides LibreOffice
+ services.
+ .
+ This package provides helpers to function in the absence of working mount
+ namespaces.

--- a/debian/coolwsd-deprecated.install
+++ b/debian/coolwsd-deprecated.install
@@ -1,2 +1,2 @@
-usr/bin/coolforkit
+usr/bin/coolforkit-caps
 usr/bin/coolmount

--- a/debian/coolwsd-deprecated.install
+++ b/debian/coolwsd-deprecated.install
@@ -1,0 +1,2 @@
+usr/bin/coolforkit
+usr/bin/coolmount

--- a/debian/coolwsd-deprecated.postinst
+++ b/debian/coolwsd-deprecated.postinst
@@ -4,7 +4,7 @@ set -e
 
 case "$1" in
     configure)
-	setcap cap_fowner,cap_chown,cap_sys_chroot=ep /usr/bin/coolforkit || true
+	setcap cap_fowner,cap_chown,cap_sys_chroot=ep /usr/bin/coolforkit-caps || true
 	setcap cap_sys_admin=ep /usr/bin/coolmount || true
 	;;
 

--- a/debian/coolwsd-deprecated.postinst
+++ b/debian/coolwsd-deprecated.postinst
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -e
+
+case "$1" in
+    configure)
+	setcap cap_fowner,cap_chown,cap_sys_chroot=ep /usr/bin/coolforkit || true
+	setcap cap_sys_admin=ep /usr/bin/coolmount || true
+	;;
+
+esac
+
+#DEBHELPER#

--- a/debian/coolwsd.install
+++ b/debian/coolwsd.install
@@ -1,7 +1,7 @@
 etc/
 usr/bin/coolconfig
 usr/bin/coolconvert
-usr/bin/coolforkitns
+usr/bin/coolforkit-ns
 usr/bin/coolstress
 usr/bin/coolwsd
 usr/bin/coolwsd-systemplate-setup

--- a/debian/coolwsd.install
+++ b/debian/coolwsd.install
@@ -1,0 +1,11 @@
+etc/
+usr/bin/coolconfig
+usr/bin/coolconvert
+usr/bin/coolforkitns
+usr/bin/coolstress
+usr/bin/coolwsd
+usr/bin/coolwsd-systemplate-setup
+usr/bin/loolconfig
+usr/bin/loolwsd
+usr/bin/loolwsd-systemplate-setup
+usr/share/

--- a/debian/coolwsd.postinst.in
+++ b/debian/coolwsd.postinst.in
@@ -4,8 +4,6 @@ set -e
 
 case "$1" in
     configure)
-	setcap cap_fowner,cap_chown,cap_sys_chroot=ep /usr/bin/coolforkit || true
-	setcap cap_sys_admin=ep /usr/bin/coolmount || true
 	if [ -f /etc/loolwsd/loolwsd.xml ]; then /usr/bin/coolconfig migrateconfig --write || true; fi
 
 	adduser --quiet --system --group --home /opt/cool cool

--- a/docker/from-source-gh-action/Dockerfile
+++ b/docker/from-source-gh-action/Dockerfile
@@ -62,7 +62,7 @@ COPY /start-collabora-online.sh /start-collabora-online.sh
 
 # set up Collabora Online (normally done by postinstall script of package)
 # Fix permissions
-RUN setcap cap_fowner,cap_chown,cap_sys_chroot=ep /usr/bin/coolforkit && \
+RUN setcap cap_fowner,cap_chown,cap_sys_chroot=ep /usr/bin/coolforkit-caps && \
     setcap cap_sys_admin=ep /usr/bin/coolmount && \
     adduser --quiet --system --group --home /opt/cool cool && \
     rm -rf /opt/cool && \

--- a/docker/from-source/ArchLinux
+++ b/docker/from-source/ArchLinux
@@ -20,7 +20,7 @@ COPY /start-collabora-online.sh /
 
 # set up Collabora Online (normally done by postinstall script of package)
 # Fix permissions
-RUN setcap cap_fowner,cap_chown,cap_sys_chroot=ep /usr/bin/coolforkit && \
+RUN setcap cap_fowner,cap_chown,cap_sys_chroot=ep /usr/bin/coolforkit-caps && \
     setcap cap_sys_admin=ep /usr/bin/coolmount && \
     useradd --system --user-group --create-home --home-dir /opt/cool cool && \
     rm -rf /opt/cool && \

--- a/docker/from-source/Debian
+++ b/docker/from-source/Debian
@@ -24,7 +24,7 @@ COPY /start-collabora-online.sh /
 
 # set up Collabora Online (normally done by postinstall script of package)
 # Fix permissions
-RUN setcap cap_fowner,cap_chown,cap_sys_chroot=ep /usr/bin/coolforkit && \
+RUN setcap cap_fowner,cap_chown,cap_sys_chroot=ep /usr/bin/coolforkit-caps && \
     setcap cap_sys_admin=ep /usr/bin/coolmount && \
     adduser --quiet --system --group --home /opt/cool cool && \
     rm -rf /opt/cool && \

--- a/docker/from-source/Fedora
+++ b/docker/from-source/Fedora
@@ -17,7 +17,7 @@ COPY /start-collabora-online.sh /
 
 # set up Collabora Online (normally done by postinstall script of package)
 # Fix permissions
-RUN setcap cap_fowner,cap_chown,cap_sys_chroot=ep /usr/bin/coolforkit && \
+RUN setcap cap_fowner,cap_chown,cap_sys_chroot=ep /usr/bin/coolforkit-caps && \
     setcap cap_sys_admin=ep /usr/bin/coolmount && \
     groupadd -r cool && \
     useradd -g cool -r cool -d /opt/cool -s /bin/bash && \

--- a/docker/from-source/Ubuntu
+++ b/docker/from-source/Ubuntu
@@ -26,7 +26,7 @@ COPY /start-collabora-online.sh /
 
 # set up Collabora Online (normally done by postinstall script of package)
 # Fix permissions
-RUN setcap cap_fowner,cap_chown,cap_sys_chroot=ep /usr/bin/coolforkit && \
+RUN setcap cap_fowner,cap_chown,cap_sys_chroot=ep /usr/bin/coolforkit-caps && \
     setcap cap_sys_admin=ep /usr/bin/coolmount && \
     adduser --quiet --system --group --home /opt/cool cool && \
     rm -rf /opt/cool && \

--- a/docker/from-source/openSUSE
+++ b/docker/from-source/openSUSE
@@ -20,7 +20,7 @@ COPY /start-collabora-online.sh /
 
 # set up Collabora Online (normally done by postinstall script of package)
 # Fix permissions
-RUN setcap cap_fowner,cap_chown,cap_sys_chroot=ep /usr/bin/coolforkit && \
+RUN setcap cap_fowner,cap_chown,cap_sys_chroot=ep /usr/bin/coolforkit-caps && \
     setcap cap_sys_admin=ep /usr/bin/coolmount && \
     groupadd -r cool && \
     useradd -g cool -r cool -d /opt/cool -s /bin/bash && \

--- a/man/coolconfig.1
+++ b/man/coolconfig.1
@@ -53,4 +53,4 @@ update\-system\-template
 .SS "generate\-proof\-key"
 The \fBgenerate\-proof\-key\fR command creates an RSA key pair in /etc/coolwsd for the WOPI Proof headers. The postinstall script of coolwsd package usually creates this RSA key pair in case of new installation.
 .SH "SEE ALSO"
-coolforkit(1), coolconvert(1), coolwsd(1), coolwsd-systemplate-setup(1), coolmount(1)
+coolforkit-ns(1), coolconvert(1), coolwsd(1), coolwsd-systemplate-setup(1), coolmount(1)

--- a/man/coolconvert.1
+++ b/man/coolconvert.1
@@ -17,4 +17,4 @@ coolconvert OPTIONS FILE(S)
 \fB\-\-no\-check\-certificate\fR  Disable checking of SSL certs
 .PP
 .SH "SEE ALSO"
-coolwsd(1), coolforkit(1), coolconfig(1), coolwsd-systemplate-setup(1), coolmount(1)
+coolwsd(1), coolforkit-ns(1), coolconfig(1), coolwsd-systemplate-setup(1), coolmount(1)

--- a/man/coolforkit-ns.1
+++ b/man/coolforkit-ns.1
@@ -1,8 +1,8 @@
-.TH COOLFORKIT "1" "May 2018" "coolforkit " "User Commands"
+.TH COOLFORKIT "1" "May 2018" "coolforkit-ns " "User Commands"
 .SH NAME
-coolforkit \- Utility that spawns LOK instances for Collabora Online
+coolforkit-ns \- Utility that spawns LOK instances for Collabora Online
 .SH SYNOPSIS
-coolforkit OPTIONS
+coolforkit-ns OPTIONS
 .SH DESCRIPTION
 Single-threaded process that spawns LibreOfficeKit (LOK) instances.
 .PP

--- a/man/coolmount.1
+++ b/man/coolmount.1
@@ -8,4 +8,4 @@ This is a very tiny helper to allow overlay mounting.
 .PP
 \fBNote\fR: Running this standalone is not possible. It is used internally by coolwsd when it creates the jail for the document.
 .SH "SEE ALSO"
-coolwsd(1), coolconvert(1), coolconfig(1), coolwsd-systemplate-setup(1), coolforkit(1)
+coolwsd(1), coolconvert(1), coolconfig(1), coolwsd-systemplate-setup(1), coolforkit-ns(1)

--- a/man/coolstress.1
+++ b/man/coolstress.1
@@ -36,4 +36,4 @@ in terms of keys-per-second, as well as creating unusual documents from a spell/
 perspective.
 
 .SH "SEE ALSO"
-coolforkit(1), coolconvert(1), coolwsd(1)
+coolforkit-ns(1), coolconvert(1), coolwsd(1)

--- a/man/coolwsd-systemplate-setup.1
+++ b/man/coolwsd-systemplate-setup.1
@@ -6,4 +6,4 @@ coolwsd-systemplate-setup <chroot template directory for system libs to create> 
 .SH DESCRIPTION
 coolwsd-systemplate-setup creates a minimal system template for running the LibreOfficeKit in a chroot jail. The system template contains the bare minimum of system libraries to run LibreOfficeKit, and also fonts and locale data from the system.
 .SH "SEE ALSO"
-coolforkit(1), coolconvert(1), coolconfig(1), coolwsd(1), coolmount(1)
+coolforkit-ns(1), coolconvert(1), coolconfig(1), coolwsd(1), coolmount(1)

--- a/man/coolwsd.1
+++ b/man/coolwsd.1
@@ -33,4 +33,4 @@ coolwsd OPTIONS
 \fB\-\-use\-env\-vars\fR                Override coolwsd.xml config with options from the environment variables described in https://col.la/dockercodeconfigviaenv
 .PP
 .SH "SEE ALSO"
-coolforkit(1), coolconvert(1), coolconfig(1), coolwsd-systemplate-setup(1), coolmount(1)
+coolforkit-ns(1), coolconvert(1), coolconfig(1), coolwsd-systemplate-setup(1), coolmount(1)

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -3580,14 +3580,17 @@ bool COOLWSD::createForKit()
     std::string forKitPath = "/usr/bin/valgrind";
 #else
     std::string forKitPath = std::move(parentPath);
-    if (EnableMountNamespaces)
+    if (EnableMountNamespaces || NoCapsForKit)
     {
         forKitPath += "coolforkit-ns";
-        args.push_back("--namespace");
+        if (EnableMountNamespaces)
+            args.push_back("--namespace");
     }
     else
     {
         forKitPath += "coolforkit-caps";
+        if (!FileUtil::Stat(forKitPath).exists())
+            LOG_FTL("coolforkit-caps does not exist, install coolwsd-deprecated package");
     }
 #endif
 

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -3516,7 +3516,7 @@ bool COOLWSD::createForKit()
     args.push_back("-tt");
     args.push_back("-s");
     args.push_back("256");
-    args.push_back(parentPath + "coolforkit");
+    args.push_back(parentPath + "coolforkit-caps");
 #elif VALGRIND_COOLFORKIT
     NoCapsForKit = true;
     NoSeccomp = true;
@@ -3533,7 +3533,7 @@ bool COOLWSD::createForKit()
     args.push_back("--error-limit=no");
     args.push_back("--num-callers=128");
     std::string nocapsCopy = parentPath + "coolforkit-nocaps";
-    FileUtil::copy(parentPath + "coolforkit", nocapsCopy, true, true);
+    FileUtil::copy(parentPath + "coolforkit-caps", nocapsCopy, true, true);
     args.push_back(nocapsCopy);
 #endif
     args.push_back("--systemplate=" + SysTemplate);
@@ -3582,12 +3582,12 @@ bool COOLWSD::createForKit()
     std::string forKitPath = std::move(parentPath);
     if (EnableMountNamespaces)
     {
-        forKitPath += "coolforkitns";
+        forKitPath += "coolforkit-ns";
         args.push_back("--namespace");
     }
     else
     {
-        forKitPath += "coolforkit";
+        forKitPath += "coolforkit-caps";
     }
 #endif
 


### PR DESCRIPTION
Default namespaces to on, and move non-namespaces helpers to a deprecated subpackage

- centos
  - 8.0 works with namespaces out of the box
  - 7.9 (EOL*) not enabled by default, possible with echo 10000 > /proc/sys/user/max_user_namespaces
    * RHEL7 is EOM
- debian
  - 11 (bullseye) works with namespaces out of the box
  - 10 (buster) EOL, not enabled by default, possible with sudo sysctl -w kernel.unprivileged_userns_clone=1
  - 9 (stretch) EOL, not enabled by default, possible with sudo sysctl -w kernel.unprivileged_userns_clone=1
- ubuntu
  - 16.04 works with namespaces out of the box


Change-Id: Iffabea0a871d23797c1482cb8d2ca7de3e98f34a


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

