### PR TITLE
cool#9772: VSCodium/clangd: Add generation of .clangd and .vscode files to ease editing via IDE/language-server

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -302,7 +302,8 @@ coolbench_LDADD = libsimd.a
 
 coolconvert_SOURCES = tools/Tool.cpp
 
-coolstress_CPPFLAGS = -DTDOC=\"$(abs_top_srcdir)/test/data\" ${include_paths}
+coolstress_TDOC_CPPFLAGS = -DTDOC=\"$(abs_top_srcdir)/test/data\"
+coolstress_CPPFLAGS = ${coolstress_TDOC_CPPFLAGS} ${include_paths}
 coolstress_SOURCES = tools/Stress.cpp \
                      common/DummyTraceEventEmitter.cpp \
                      $(shared_sources)
@@ -659,7 +660,7 @@ endef
 CLANGXX_COMPILE_FLAGS=clang++ $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) \
 	$(AM_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS)
 
-JSON_COMPILE_FLAGS=$(subst ",\",$(subst \,\\,$(CLANGXX_COMPILE_FLAGS)))
+JSON_COMPILE_FLAGS=$(subst ",\",$(subst \,\\,$(CLANGXX_COMPILE_FLAGS) $(coolstress_TDOC_CPPFLAGS)))
 
 JSON_COMPILE_SRC = $(patsubst %.cpp,%.cmd,$(wildcard **/*.cpp))
 
@@ -668,7 +669,7 @@ $(eval $(call file_targets,$(JSON_COMPILE_SRC)))
 .cpp.cmd:
 	@echo -n "{\"directory\":\"$(abs_builddir)\",\"command\":\"" > $@
 	@echo -n $(JSON_COMPILE_FLAGS) >> $@
-	@echo -n "\",\"file\":\"$<\"}" >> $@
+	@echo -n " -o $(patsubst %.cpp,%.o,$<) -c $<\",\"file\":\"$<\"}" >> $@
 
 $(abs_srcdir)/compile_commands.json: $(JSON_COMPILE_SRC)
 	@echo -n "[" > $@

--- a/Makefile.am
+++ b/Makefile.am
@@ -683,6 +683,29 @@ $(abs_srcdir)/compile_commands.json: $(JSON_COMPILE_SRC)
 
 compile_commands: $(abs_srcdir)/compile_commands.json
 
+$(abs_srcdir)/.clangd: config.d/clangd.am
+	@sed -e 's|@COOL_DIR@|${abs_srcdir}|g' -e 's|@LOKIT_DIR@|${LOKIT_PATH}|g' $< > $@
+
+dot_clangd: $(abs_srcdir)/.clangd
+
+$(abs_srcdir)/.vscode/settings.json: config.d/vscode/settings.json.am
+	mkdir -p $(abs_srcdir)/.vscode
+	sed -e 's|@COOL_DIR@|${abs_srcdir}|g' -e 's|@LOKIT_DIR@|${LOKIT_PATH}|g' $< > $@
+
+$(abs_srcdir)/.vscode/online.code-workspace: config.d/vscode/online.code-workspace.am
+	mkdir -p $(abs_srcdir)/.vscode
+	sed -e 's|@COOL_DIR@|${abs_srcdir}|g' -e 's|@LOKIT_DIR@|${LOKIT_PATH}|g' $< > $@
+
+gen-clangd: $(abs_srcdir)/compile_commands.json $(abs_srcdir)/.clangd
+
+gen-vscode: gen-clangd $(abs_srcdir)/.vscode/settings.json $(abs_srcdir)/.vscode/online.code-workspace
+
+clean-clangd:
+	cd $(abs_srcdir) && rm -f .clangd
+
+clean-vscode: clean-clangd
+	cd $(abs_srcdir) && rm -rf .vscode
+
 browser/node_modules: browser/package.json browser/archived-packages
 	@cd browser && npm install
 

--- a/config.d/clangd.am
+++ b/config.d/clangd.am
@@ -1,0 +1,27 @@
+#
+# DO NOT EDIT - this file is generated from config.d/clangd.am
+#
+
+Index:
+  Background: Build
+  StandardLibrary: No
+
+CompileFlags:
+  CompilationDatabase: @COOL_DIR@
+  Add: [-Wall, -Wextra, -Wshadow, -Wundef, -Werror, -DENABLE_SSL=0, -DENABLE_DEBUG=1, -DDEBUG, -DMOBILEAPP=0, -DAPP_NAME="App", -DTDOC="test/data", -std=c++20, -isystem, @COOL_DIR@, -isystem, @COOL_DIR@/common, -isystem, @COOL_DIR@/net, -isystem, @COOL_DIR@/wsd, -isystem, @COOL_DIR@/kit, -isystem, @COOL_DIR@/test, -isystem, /usr/include/libpng16, -isystem, @LOKIT_DIR@]
+
+Diagnostics:
+  UnusedIncludes: Strict
+  ClangTidy:
+    FastCheckFilter: Loose
+
+InlayHints:
+  Enabled: No
+  BlockEnd: Yes
+  Designators: No
+  ParameterNames: Yes
+  DeducedTypes: Yes
+  TypeNameLimit: 24
+
+Hover:
+  ShowAKA: Yes

--- a/config.d/vscode/online.code-workspace.am
+++ b/config.d/vscode/online.code-workspace.am
@@ -1,0 +1,84 @@
+//
+// DO NOT EDIT - this file is generated from config.d/vscode/online.code-workspace.am
+//
+{
+  "folders": [
+    {
+      "name": "COOL",
+      "path": "@COOL_DIR@"
+    }
+  ],
+  "settings": {
+    // "security.workspace.trust.untrustedFiles": "open",
+    // "window.openFilesInNewWindow": "on",
+    // "window.zoomLevel": 0.5,
+    // "editor.fontSize": 11.5,
+    // "editor.lineHeight": 1.22,
+    // "editor.fontWeight": "normal",
+    // "editor.fontFamily": "'DejaVu Sans Mono', 'monospace', monospace",
+    // "editor.guides.indentation": false,
+    // "editor.renderWhitespace": "none",
+    // "editor.cursorStyle": "line",
+    // "editor.semanticTokenColorCustomizations": {
+    // },
+    // "editor.tokenColorCustomizations": {
+    //     "[Visual Studio Light]": {}
+    // },
+    // "workbench.colorTheme": "Visual Studio Light",
+    "workbench.editor.labelFormat": "medium",
+    "java.jdt.ls.java.home": "/usr/lib/jvm/java-17-openjdk-amd64",
+    "java.codeGeneration.useBlocks": true,
+    "java.inlayHints.parameterNames.enabled": "literals",
+    "java.configuration.runtimes": [    
+      { 
+        "name": "JavaSE-17",
+        "path": "/usr/lib/jvm/java-17-openjdk-amd64",
+        "default": true
+      },
+      { 
+        "name": "JavaSE-21",
+        "path": "/opt-linux-x86_64/jdk21",
+        "default": true
+      }
+    ],
+    "[cpp]": {
+      "breadcrumbs.showKeys": true,
+      "breadcrumbs.showArrays": true,
+      "editor.hover.enabled": true,
+      "breadcrumbs.showFunctions": true,
+      "editor.defaultFormatter": "llvm-vs-code-extensions.vscode-clangd"
+    },
+    "clangd.onConfigChanged": "restart",
+    "clangd.checkUpdates": true,
+    "clangd.arguments": [ // "-log=verbose",
+                         "-pretty"
+                         , "--background-index"
+                         , "--compile-commands-dir=${workspaceFolder}"
+                         // , "--project-root=${workspaceFolder}"
+                         // , "--query-driver=/bin/arm-buildroot-linux-gnueabihf-g++" //for cross compile usage
+                         ],
+    "files.associations": {
+        "*.hpp": "cpp",
+        "*.cpp": "cpp",
+        "*.cxx": "cpp"
+    },
+    "ShortcutMenuBar.compareWithSaved": false,
+    "ShortcutMenuBar.openFilesList": false,
+    "ShortcutMenuBar.saveAll": true,
+    "ShortcutMenuBar.toggleTerminal": false,
+    "ShortcutMenuBar.userButton01Command": "clangd.inlayHints.toggle",
+    "ShortcutMenuBar.userButton02Command": "clangd.memoryUsage",
+    "ShortcutMenuBar.userButton03Command": "workbench.action.reloadWindow",
+    "ShortcutMenuBar.userButton04Command": "clangd.restart",
+    // "clang-tidy.buildPath": "${workspaceFolder}",
+  },
+  "extensions": {
+    "recommendations": [
+        "llvm-vs-code-extensions.vscode-clangd",
+        "notskm.clang-tidy",
+        "cschlosser.doxdocgen",
+        "jerrygoyal.shortcut-menu-bar"
+    ]
+  }
+}
+

--- a/config.d/vscode/settings.json.am
+++ b/config.d/vscode/settings.json.am
@@ -1,0 +1,5 @@
+//
+// DO NOT EDIT - this file is generated from config.d/vscode/settings.json.am
+//
+{
+}


### PR DESCRIPTION
Change-Id: Ic53e554598302e0b5e67568c6b72b9be1bd890a4

* Resolves: #9772
* Target version: master 

### Summary

Initial integration of .clangd via `make gen-clangd` and vscode via `make gen-vscode`, for
- compile_commands.json
  - already supported via make compile_commands
  - fixed with earlier commit
- .clangd
  - in addition to compile_commands.json (CompileFlags), allowing setting include defaults, workspace-dir
    as well as other clangd settings: Index, Diagnostics (clang-tidy IDE setup), InlayHints (IDE), Hover (IDE).
- .vscode/settings.json
  - VSCodium workspace settings (actually empty)
- .vscode/online.code-workspace
  - VSCodium workspace project file (proposal)
    
New make targets:
- `gen-clangd` Produces `.clangd` and `compile_commands.json` files
- `gen-vscode` Produces `.clangd` and and `compile_commands.json` files
               and `.vscode` directory.
- `clean-clangd` removes `.clangd` file.
- `clean-vscode` removes `.clangd` file and `.vscode` directory.
    
Note: The clang* setup has been tested with
- VSCodium Version: 1.91.1, Release: 24193,
           Commit: 8512cb3341b26a5dba985a9a17eed8d7c3362886, Date: 2024-07-11T18:37:10.462Z
- Eclipse cdt-jsp: C/C++ LSP Support    , 2.1.0.202408070815,
          org.eclipse.cdt.lsp.feature.feature.group, Eclipse CDT

### TODO

Maybe we can refine
- Documentation (manuals or wiki) ?

### Checklist

- [X] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

