### PR TITLE
cool#9621: Have WSD Keep Download-Socket open for file and favicon.ico requests (ClientRequestDispatcher); ..

### DIFF
--- a/net/HttpHelper.cpp
+++ b/net/HttpHelper.cpp
@@ -92,9 +92,9 @@ void sendDeflatedFileContent(const std::shared_ptr<StreamSocket>& socket, const 
     }
 }
 
-void sendFileAndShutdown(const std::shared_ptr<StreamSocket>& socket, const std::string& path,
-                         http::Response& response, const bool noCache,
-                         const bool deflate, const bool headerOnly)
+void sendFile(const std::shared_ptr<StreamSocket>& socket, const std::string& path,
+              http::Response& response, const bool noCache,
+              const bool deflate, const bool headerOnly)
 {
     FileUtil::Stat st(path);
     if (st.bad())
@@ -151,6 +151,13 @@ void sendFileAndShutdown(const std::shared_ptr<StreamSocket>& socket, const std:
         if (!headerOnly)
             sendDeflatedFileContent(socket, path, st.size());
     }
+}
+
+void sendFileAndShutdown(const std::shared_ptr<StreamSocket>& socket, const std::string& path,
+                         http::Response& response, const bool noCache,
+                         const bool deflate, const bool headerOnly)
+{
+    sendFile(socket, path, response, noCache, deflate, headerOnly);
     socket->shutdown();
 }
 

--- a/net/HttpHelper.hpp
+++ b/net/HttpHelper.hpp
@@ -34,7 +34,12 @@ void sendErrorAndShutdown(http::StatusCode errorCode, const std::shared_ptr<Stre
 /// Sends file as HTTP response and shutdown the socket.
 void sendFileAndShutdown(const std::shared_ptr<StreamSocket>& socket, const std::string& path,
                          http::Response& response,
-                         bool noCache = false, bool deflate = false, const bool headerOnly = false);
+                         const bool noCache = false, const bool deflate = false, const bool headerOnly = false);
+
+/// Sends file as HTTP response.
+void sendFile(const std::shared_ptr<StreamSocket>& socket, const std::string& path,
+              http::Response& response,
+              const bool noCache = false, const bool deflate = false, const bool headerOnly = false);
 
 /// Verifies that the given WOPISrc is properly URI-encoded.
 /// Warns if it isn't and, in debug builds, closes the socket (if given) and returns false.

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -364,7 +364,8 @@ public:
         ConnectionToken,
         None, //< No `Connection` header token set
         Close, //< `Connection: close` [RFC2616 14.10](https://www.rfc-editor.org/rfc/rfc2616#section-14.10)
-        KeepAlive //< `Connection: Keep-Alive` Obsolete [RFC2068 19.7.1](https://www.rfc-editor.org/rfc/rfc2068#section-19.7.1)
+        KeepAlive, //< `Connection: Keep-Alive` Obsolete [RFC2068 19.7.1](https://www.rfc-editor.org/rfc/rfc2068#section-19.7.1)
+        Upgrade //< `Connection: Upgrade` HTTP/1.1 only [RFC2817](https://www.rfc-editor.org/rfc/rfc2817)
     );
 
     /// Describes the header state during parsing.
@@ -470,18 +471,21 @@ public:
             return ConnectionToken::Close;
         } else if( Util::iequal("keep-alive", token) ) {
             return ConnectionToken::KeepAlive;
+        } else if( Util::iequal("upgrade", token) ) {
+            return ConnectionToken::Upgrade;
         } else {
             return ConnectionToken::None;
         }
     }
     void setConnectionToken(ConnectionToken token) {
-        if( ConnectionToken::Close == token ) {
-            set(CONNECTION, "close");
-        } else if( ConnectionToken::KeepAlive == token ) {
-            set(CONNECTION, "Keep-Alive");
-        } else {
-            remove(CONNECTION);
+        std::string value;
+        switch( token ) {
+            case ConnectionToken::Close: value = "close"; break;
+            case ConnectionToken::KeepAlive: value = "Keep-Alive"; break;
+            case ConnectionToken::Upgrade: value = "Upgrade"; break;
+            default: remove(CONNECTION); return;
         }
+        set(CONNECTION, value);
     }
 
     /// Adds a new "Cookie" header entry with the given content.

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -360,10 +360,11 @@ public:
     static constexpr const char* CONNECTION = "Connection";
 
     /// Describes the `Connection` header token value
-    STATE_ENUM(ConnectionToken,
-               None,        //< No `Connection` header token set
-               Close,       //< `Connection: close` [RFC2616 14.10](https://www.rfc-editor.org/rfc/rfc2616#section-14.10)
-               KeepAlive    //< `Connection: Keep-Alive` Obsolete [RFC2068 19.7.1](https://www.rfc-editor.org/rfc/rfc2068#section-19.7.1)
+    STATE_ENUM(
+        ConnectionToken,
+        None, //< No `Connection` header token set
+        Close, //< `Connection: close` [RFC2616 14.10](https://www.rfc-editor.org/rfc/rfc2616#section-14.10)
+        KeepAlive //< `Connection: Keep-Alive` Obsolete [RFC2068 19.7.1](https://www.rfc-editor.org/rfc/rfc2068#section-19.7.1)
     );
 
     /// Describes the header state during parsing.
@@ -464,7 +465,7 @@ public:
 
     bool hasConnectionToken() const { return has(CONNECTION); }
     ConnectionToken getConnectionToken() const {
-        const std::string token = get(CONTENT_LENGTH);
+        const std::string token = get(CONNECTION);
         if( Util::iequal("close", token) ) {
             return ConnectionToken::Close;
         } else if( Util::iequal("keep-alive", token) ) {

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -1472,7 +1472,7 @@ private:
                 }
             }
 
-            if (_response->get("Connection", "") == "close")
+            if( _response->header().getConnectionToken() == Header::ConnectionToken::Close )
             {
                 LOG_TRC("Our peer has sent the 'Connection: close' token. Disconnecting.");
                 onDisconnect();

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -465,25 +465,43 @@ public:
     bool getChunkedTransferEncoding() const { return _chunked; }
 
     bool hasConnectionToken() const { return has(CONNECTION); }
-    ConnectionToken getConnectionToken() const {
+    ConnectionToken getConnectionToken() const
+    {
         const std::string token = get(CONNECTION);
-        if( Util::iequal("close", token) ) {
+        if (Util::iequal("close", token))
+        {
             return ConnectionToken::Close;
-        } else if( Util::iequal("keep-alive", token) ) {
+        }
+        else if (Util::iequal("keep-alive", token))
+        {
             return ConnectionToken::KeepAlive;
-        } else if( Util::iequal("upgrade", token) ) {
+        }
+        else if (Util::iequal("upgrade", token))
+        {
             return ConnectionToken::Upgrade;
-        } else {
+        }
+        else
+        {
             return ConnectionToken::None;
         }
     }
-    void setConnectionToken(ConnectionToken token) {
+    void setConnectionToken(ConnectionToken token)
+    {
         std::string value;
-        switch( token ) {
-            case ConnectionToken::Close: value = "close"; break;
-            case ConnectionToken::KeepAlive: value = "Keep-Alive"; break;
-            case ConnectionToken::Upgrade: value = "Upgrade"; break;
-            default: remove(CONNECTION); return;
+        switch (token)
+        {
+            case ConnectionToken::Close:
+                value = "close";
+                break;
+            case ConnectionToken::KeepAlive:
+                value = "Keep-Alive";
+                break;
+            case ConnectionToken::Upgrade:
+                value = "Upgrade";
+                break;
+            default:
+                remove(CONNECTION);
+                return;
         }
         set(CONNECTION, value);
     }
@@ -1476,7 +1494,7 @@ private:
                 }
             }
 
-            if( _response->header().getConnectionToken() == Header::ConnectionToken::Close )
+            if (_response->header().getConnectionToken() == Header::ConnectionToken::Close)
             {
                 LOG_TRC("Our peer has sent the 'Connection: close' token. Disconnecting.");
                 onDisconnect();

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -969,7 +969,7 @@ bool StreamSocket::send(http::Request& request)
 
 bool StreamSocket::sendAndShutdown(http::Response& response)
 {
-    response.set("Connection", "close");
+    response.header().setConnectionToken(http::Header::ConnectionToken::Close);
     if (send(response))
     {
         shutdown();

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -960,7 +960,8 @@ public:
         _sentHTTPContinue(false),
         _shutdownSignalled(false),
         _readType(readType),
-        _inputProcessingEnabled(true)
+        _inputProcessingEnabled(true),
+        _lastSeenHTTPHeader( std::chrono::steady_clock::now() )
     {
         LOG_TRC("StreamSocket ctor");
     }
@@ -993,7 +994,7 @@ public:
     const std::string& hostname() const { return _hostname; }
 
     /// Just trigger the async shutdown.
-    virtual void shutdown() override
+    void shutdown() override
     {
         _shutdownSignalled = true;
         LOG_TRC("Async shutdown requested.");
@@ -1442,8 +1443,7 @@ protected:
                     }
                 }
             }
-        }
-        while (oldSize != _outBuffer.size());
+        } while (oldSize != _outBuffer.size());
 
         if (closed)
         {
@@ -1653,6 +1653,9 @@ private:
     std::vector<int> _incomingFDs;
     ReadType _readType;
     std::atomic_bool _inputProcessingEnabled;
+
+    // Used in parseHeader, SocketPoll::DefaultPollTimeoutMicroS acting as max delay
+    std::chrono::steady_clock::time_point _lastSeenHTTPHeader;
 };
 
 enum class WSOpCode : unsigned char {

--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -152,7 +152,7 @@ public:
         req.set("Date", Util::getHttpTimeNow());
         req.set("User-Agent", http::getAgentString());
 
-        req.set("Connection", "Upgrade");
+        req.header().setConnectionToken(http::Header::ConnectionToken::Upgrade);
         req.set("Upgrade", "websocket");
         req.set("Sec-WebSocket-Version", "13");
         req.set("Sec-WebSocket-Key", getWebSocketKey());
@@ -984,7 +984,7 @@ protected:
 
         http::Response httpResponse(http::StatusCode::SwitchingProtocols, socket->getFD());
         httpResponse.set("Upgrade", "websocket");
-        httpResponse.set("Connection", "Upgrade");
+        httpResponse.header().setConnectionToken(http::Header::ConnectionToken::Upgrade);
         httpResponse.set("Sec-WebSocket-Accept", computeAccept(wsKey));
         LOGA_TRC(WebSocket, "Sending WS Upgrade response: " << httpResponse.header().toString());
         socket->send(httpResponse);
@@ -1010,7 +1010,7 @@ protected:
             {
                 if (response.statusLine().statusCode() == http::StatusCode::SwitchingProtocols &&
                     Util::iequal(response.get("Upgrade"), "websocket") &&
-                    Util::iequal(response.get("Connection", ""), "Upgrade") &&
+                    response.header().getConnectionToken() == http::Header::ConnectionToken::Upgrade &&
                     response.get("Sec-WebSocket-Accept", "") == computeAccept(_key))
                 {
                     LOGA_TRC(WebSocket, "Accepted incoming websocket response");

--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -271,6 +271,12 @@ public:
                  true /* hard async shutdown & close */);
     }
 
+    /// Returns true if the underlying socket is connected.
+    bool isConnected() const {
+        std::shared_ptr<StreamSocket> socket = _socket.lock();
+        return nullptr != socket && !socket->isClosed();
+    }
+
 private:
     bool handleTCPStream(const std::shared_ptr<StreamSocket>& socket)
     {

--- a/test/UnitSession.cpp
+++ b/test/UnitSession.cpp
@@ -83,7 +83,7 @@ UnitBase::TestResult UnitSession::testBadRequest()
     {
         // Try to load a bogus url.
         const std::string documentURL = "/lol/file%3A%2F%2F%2Ffake.doc";
-        std::shared_ptr<http::Session> session = helpers::createHTTPSession( Poco::URI( helpers::getTestServerURI() ) );
+        std::shared_ptr<http::Session> session = http::Session::create(helpers::getTestServerURI());
         http::Request request(documentURL, http::Request::VERB_GET);
         request.set("Connection", "Upgrade");
         request.set("Upgrade", "websocket");
@@ -196,7 +196,8 @@ UnitBase::TestResult UnitSession::testSlideShow()
 
         TerminatingPoll dlSocketPoller(testname+"-dl");
         dlSocketPoller.runOnClientThread();
-        std::shared_ptr<http::Session> dlSession = helpers::createHTTPSession( Poco::URI( helpers::getTestServerURI() ) );
+        std::shared_ptr<http::Session> dlSession =
+            http::Session::create(helpers::getTestServerURI());
         http::Request requestSVG(path, http::Request::VERB_GET);
         TST_LOG("Requesting SVG from " << path);
         const std::shared_ptr<const http::Response> responseSVG = dlSession->syncRequest(requestSVG, dlSocketPoller);
@@ -266,7 +267,8 @@ UnitBase::TestResult UnitSession::testSlideShowMultiDL()
         // Reused http download-session for document and favicon download from server
         TerminatingPoll dlSocketPoller(testname+"-dl");
         dlSocketPoller.runOnClientThread();
-        std::shared_ptr<http::Session> dlSession = helpers::createHTTPSession( Poco::URI( helpers::getTestServerURI() ) );
+        std::shared_ptr<http::Session> dlSession =
+            http::Session::create(helpers::getTestServerURI());
         // dlSession->setKeepAlive(true);
 
         for( dlIter=0; dlIter < dlCount; ++dlIter ) {

--- a/test/UnitSession.cpp
+++ b/test/UnitSession.cpp
@@ -90,12 +90,11 @@ UnitBase::TestResult UnitSession::testBadRequest()
         const std::string documentURL = "/lol/file%3A%2F%2F%2Ffake.doc";
         std::shared_ptr<http::Session> session = http::Session::create(helpers::getTestServerURI());
         http::Request request(documentURL, http::Request::VERB_GET);
-        request.set("Connection", "Upgrade");
+        request.header().setConnectionToken(http::Header::ConnectionToken::Upgrade);
         request.set("Upgrade", "websocket");
         request.set("Sec-WebSocket-Version", "13");
         request.set("Sec-WebSocket-Key", "");
         // request.header().setChunkedTransferEncoding(false);
-        request.header().setConnectionToken(http::Header::ConnectionToken::KeepAlive);
         const std::shared_ptr<const http::Response> response =
             session->syncRequest(request, socketPoller);
         // TST_LOG("Response: " << response->header().toString());

--- a/test/UnitSession.cpp
+++ b/test/UnitSession.cpp
@@ -92,10 +92,10 @@ UnitBase::TestResult UnitSession::testBadRequest()
         // request.header().setChunkedTransferEncoding(false);
         request.header().setConnectionToken(http::Header::ConnectionToken::KeepAlive);
         const std::shared_ptr<const http::Response> response = session->syncRequest(request, socketPoller);
+        // TST_LOG("Response: " << response->header().toString());
         LOK_ASSERT_EQUAL(http::StatusCode::BadRequest, response->statusCode());
         LOK_ASSERT_EQUAL(false, session->isConnected());
-        // LOK_ASSERT(http::Header::ConnectionToken::Close == response->header().getConnectionToken());
-
+        LOK_ASSERT(http::Header::ConnectionToken::Close == response->header().getConnectionToken());
     }
     catch (const Poco::Exception& exc)
     {

--- a/test/helpers.hpp
+++ b/test/helpers.hpp
@@ -208,18 +208,6 @@ inline void sendTextFrame(const std::shared_ptr<http::WebSocketSession>& ws,
     ws->sendMessage(string);
 }
 
-inline std::shared_ptr<http::Session> createHTTPSession(const Poco::URI& uri, const int timeoutSec=30) {
-    auto protocol = http::Session::Protocol::HttpUnencrypted;
-#if ENABLE_SSL
-    if (uri.getScheme() == "https" || uri.getScheme() == "wss") {
-        protocol = http::Session::Protocol::HttpSsl;
-    }
-#endif
-    auto httpSession = http::Session::create(uri.getHost(), protocol, uri.getPort());
-    httpSession->setTimeout(std::chrono::seconds(timeoutSec));
-    return httpSession;
-}
-
 inline std::unique_ptr<Poco::Net::HTTPClientSession> createSession(const Poco::URI& uri)
 {
 #if ENABLE_SSL

--- a/test/helpers.hpp
+++ b/test/helpers.hpp
@@ -208,6 +208,18 @@ inline void sendTextFrame(const std::shared_ptr<http::WebSocketSession>& ws,
     ws->sendMessage(string);
 }
 
+inline std::shared_ptr<http::Session> createHTTPSession(const Poco::URI& uri, const int timeoutSec=30) {
+    auto protocol = http::Session::Protocol::HttpUnencrypted;
+#if ENABLE_SSL
+    if (uri.getScheme() == "https" || uri.getScheme() == "wss") {
+        protocol = http::Session::Protocol::HttpSsl;
+    }
+#endif
+    auto httpSession = http::Session::create(uri.getHost(), protocol, uri.getPort());
+    httpSession->setTimeout(std::chrono::seconds(timeoutSec));
+    return httpSession;
+}
+
 inline std::unique_ptr<Poco::Net::HTTPClientSession> createSession(const Poco::URI& uri)
 {
 #if ENABLE_SSL

--- a/wsd/Admin.cpp
+++ b/wsd/Admin.cpp
@@ -1202,7 +1202,7 @@ void Admin::sendMetrics(const std::shared_ptr<StreamSocket>& socket,
     std::ostringstream oss;
     getMetrics(oss);
 
-    response->add("Connection", "close");
+    response->header().setConnectionToken(http::Header::ConnectionToken::Close);
     response->setBody(oss.str(), "text/plain");
 
     socket->send(*response);

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -9,6 +9,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include <Poco/Net/HTTPRequest.h>
 #include <config.h>
 #include <config_version.h>
 
@@ -762,6 +763,10 @@ void ClientRequestDispatcher::handleIncomingMessage(SocketDisposition& dispositi
                         "Expected identical WOPISrc in the request as in cool.html");
 
                     launchAsyncCheckFileInfo(_id, accessDetails, RequestVettingStations);
+                }
+                if (request.getMethod() == Poco::Net::HTTPRequest::HTTP_POST)
+                {
+                    socket->shutdown();
                 }
                 served = true;
             }

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -1173,6 +1173,7 @@ void ClientRequestDispatcher::handleRobotsTxtRequest(const Poco::Net::HTTPReques
     {
         socket->send(responseString);
     }
+    socket->flush();
     LOG_INF_S("Sent robots.txt response successfully");
 }
 

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -763,8 +763,6 @@ void ClientRequestDispatcher::handleIncomingMessage(SocketDisposition& dispositi
 
                     launchAsyncCheckFileInfo(_id, accessDetails, RequestVettingStations);
                 }
-
-                socket->shutdown();
                 served = true;
             }
 
@@ -983,12 +981,10 @@ void ClientRequestDispatcher::handleRootRequest(const RequestDetails& requestDet
     httpResponse.set("Content-Length", std::to_string(responseString.size()));
     httpResponse.set("Content-Type", mimeType);
     httpResponse.set("Last-Modified", Util::getHttpTimeNow());
-    httpResponse.set("Connection", "close");
     httpResponse.writeData(socket->getOutBuffer());
     if (requestDetails.isGet())
         socket->send(responseString);
     socket->flush();
-    socket->shutdown();
     LOG_INF("Sent / response successfully.");
 }
 
@@ -1036,7 +1032,7 @@ void ClientRequestDispatcher::handleWopiDiscoveryRequest(
     httpResponse.set("Last-Modified", Util::getHttpTimeNow());
     httpResponse.set("X-Content-Type-Options", "nosniff");
     LOG_TRC("Sending back discovery.xml: " << xml);
-    socket->sendAndShutdown(httpResponse);
+    socket->send(httpResponse);
     LOG_INF("Sent discovery.xml successfully.");
 }
 
@@ -1171,15 +1167,12 @@ void ClientRequestDispatcher::handleRobotsTxtRequest(const Poco::Net::HTTPReques
     httpResponse.set("Last-Modified", Util::getHttpTimeNow());
     httpResponse.set("Content-Length", std::to_string(responseString.size()));
     httpResponse.set("Content-Type", "text/plain");
-    httpResponse.set("Connection", "close");
     httpResponse.writeData(socket->getOutBuffer());
 
     if (request.getMethod() == Poco::Net::HTTPRequest::HTTP_GET)
     {
         socket->send(responseString);
     }
-
-    socket->shutdown();
     LOG_INF_S("Sent robots.txt response successfully");
 }
 
@@ -2060,7 +2053,7 @@ static void sendCapabilities(bool convertToAvailable,
     httpResponse.set("Last-Modified", Util::getHttpTimeNow());
     httpResponse.setBody(getCapabilitiesJson(convertToAvailable), "application/json");
     httpResponse.set("X-Content-Type-Options", "nosniff");
-    socket->sendAndShutdown(httpResponse);
+    socket->send(httpResponse);
     LOG_INF("Sent capabilities.json successfully.");
 }
 

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -1007,7 +1007,7 @@ void ClientRequestDispatcher::handleFaviconRequest(const RequestDetails& request
     if (!Poco::File(faviconPath).exists())
         faviconPath = COOLWSD::FileServerRoot + "/favicon.ico";
 
-    HttpHelper::sendFileAndShutdown(socket, faviconPath, response);
+    HttpHelper::sendFile(socket, faviconPath, response);
 }
 
 void ClientRequestDispatcher::handleWopiDiscoveryRequest(
@@ -1675,7 +1675,7 @@ void ClientRequestDispatcher::handlePostRequest(const RequestDetails& requestDet
 
             try
             {
-                HttpHelper::sendFileAndShutdown(socket, filePath.toString(), response);
+                HttpHelper::sendFile(socket, filePath.toString(), response);
             }
             catch (const Poco::Exception& exc)
             {

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -4448,7 +4448,7 @@ bool RenderSearchResultBroker::handleInput(const std::shared_ptr<Message>& messa
                 FileServerRequestHandler::hstsHeaders(httpResponse);
                 // really not ideal that the response works only with std::string
                 httpResponse.setBody(std::string(_aResposeData.data(), _aResposeData.size()), "image/png");
-                httpResponse.set("Connection", "close");
+                httpResponse.header().setConnectionToken(http::Header::ConnectionToken::Close);
                 _socket->sendAndShutdown(httpResponse);
 
                 removeSession(_clientSession);

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -691,7 +691,7 @@ void FileServerRequestHandler::handleRequest(const HTTPRequest& request,
                     response.set("Content-Encoding", "br");
                 }
 
-                HttpHelper::sendFileAndShutdown(socket, filePath, response, noCache);
+                HttpHelper::sendFile(socket, filePath, response, noCache); // shutdown by caller
                 return;
             }
 #endif

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -572,8 +572,10 @@ void FileServerRequestHandler::handleRequest(const HTTPRequest& request,
 
         // Is this a file we read at startup - if not; it's not for serving.
         if (FileHash.find(relPath) == FileHash.end() &&
-            FileHash.find(relPath + ".br") == FileHash.end()) {
-            throw Poco::FileNotFoundException("Invalid URI request (hash): [" + requestUri.toString() + "].");
+            FileHash.find(relPath + ".br") == FileHash.end())
+        {
+            throw Poco::FileNotFoundException("Invalid URI request (hash): [" +
+                                              requestUri.toString() + "].");
         }
 
         if (endPoint == "welcome.html")

--- a/wsd/wopi/WopiStorage.cpp
+++ b/wsd/wopi/WopiStorage.cpp
@@ -702,9 +702,10 @@ void WopiStorage::uploadLocalFileToStorageAsync(const Authorization& auth, LockC
                 httpHeader.set("X-LOOL-WOPI-IsExitSave", attribs.isExitSave() ? "true" : "false");
             }
 
-            if (attribs.isExitSave())
-                httpHeader.set("Connection",
-                               "close"); // Don't maintain the socket if we are exiting.
+            if (attribs.isExitSave()) {
+                // Don't maintain the socket if we are exiting.
+                httpHeader.setConnectionToken(http::Header::ConnectionToken::Close);
+            }
             if (!attribs.getExtendedData().empty())
             {
                 httpHeader.set("X-COOL-WOPI-ExtendedData", attribs.getExtendedData());


### PR DESCRIPTION
### Summary

WSD's ClientRequestDispatcher shall keep the socket open on successful document and favicon download requests.

HttpHelper::sendFile(..) is refactored from HttpHelper::sendFileAndShutdown(..) w/o the socket closing (shutdown) and used in WSD's ClientRequestDispatcher accordingly.

WebSocketHandler: Added public isConnected() StreamSocket queries, allowing our unit tests to validate the connected state.

### TODO

#### Keep-Alive Utilization
FileServer.cpp's FileServerRequestHandler::handleRequest(..) also keeps the socket alive (ENABLE_DEBUG and env 'COOL_SERVE_FROM_FS') with this patch.

Check whether this is desired, as not covered by a unit test!

+++

Analyze whether the following maintained HttpHelper::sendFileAndShutdown(..) use-cases shall be converted to keep-alive as well:
- WSD's ClientSession::handleKitToClientMessage()

+++

Unit tests w/ WopiTestServer still use HttpHelper::sendFileAndShutdown(..):
- test/UnitWOPIFileUrl.cpp:145
- test/UnitWOPITemplate.cpp:81

Currently the whole WopiTestServer code closes the sockets even after serving a request successfully.
We might want to change this behavior towards keep-alive as well? This would also allow us to employ 'local' performance unit tests with such a WopiTestServer.

#### Poco HTTP Message Parsing
Replace Poco http request message parsing
starting with Ash's net/HttpRequest


Change-Id: I83c09e0a8101931efece42e42e5a8e3abd7e696f

* Resolves: #9621
* Target version: master 


### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

