### PR TITLE
play, pause the video during slideshow, transition, unmute sound

### DIFF
--- a/browser/src/slideshow/SlideShowPresenter.ts
+++ b/browser/src/slideshow/SlideShowPresenter.ts
@@ -121,6 +121,7 @@ class SlideShowPresenter {
 
 	_stopFullScreen() {
 		if (!this._slideShowCanvas) return;
+		this._slideRenderer.pauseVideos();
 
 		window.removeEventListener('keydown', this._onCanvasKeyDown.bind(this));
 		L.DomUtil.remove(this._slideShowCanvas);


### PR DESCRIPTION
During slideshow the video could still continue playing if the slide with a video was the last one.

Also stop rendering when all the videos are paused.

Additionally unmute the video, so we have the sound from the video during the slideshow.


Change-Id: I32f3f405b0c92e446f84ba4f4f3f60f9dd294eb1


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

