### PR TITLE
build(android): Simplify configure abi selection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -213,8 +213,9 @@ AC_ARG_WITH(android-abi,
                             by colons).  The supported ABIs are: armeabi-v7a, arm64-v8a, x86 and x86_64.
                             Please note that you need to specify the parameters for --with-lo-builddir,
                             --with-poco-includes and --with-poco-libs in the order of armeabi-v7a:arm64-v8a:x86:x86_64.
-                            For example, when you use --with-android-abi=x86_64,
-                            you have to specify --with-lo-builddir=:::/path/to/x86-64/builddir]),
+                            For example, when you use --with-android-abi="x86_64 x86",
+                            you have to specify --with-lo-builddir=::/path/to/x86/builddir:/path/to/x86-64/builddir.
+                            If you are building for only a single ABI you may omit the colons.]),
 ,)
 
 AC_ARG_WITH([app-name],
@@ -264,9 +265,15 @@ AC_ARG_WITH([lo-builddir],
                             file and change the references to "../ios-device" to refer to the corresponding
                             LibreOffice core source directory (which typically would be the same as the build
                             directory you specify with this option).
-                            In case of Android, you can provide 2 builddirs
-                            separated by a colon ':' - the first is for
-                            armeabi-v7a, the second is for arm64-v8a]))
+
+                            For Android, if building for multiple ABIs, you should specify multiple trees in the
+                            format --with-lo-builddir=/path/to/armeabi-v7a/builddir:/path/to/arm64-v8a/builddir:/path/to/x86/builddir:/path/to/x86_64/builddir.
+                            You may omit any ABIs you are not building for, except for armeabi-v7a which must
+                            always be provided.
+
+                            If you are building Android for a single ABI only, you may optionally specify only
+                            the core for your ABI without any colons. In this case, providing an armeabi-v7a core
+                            is not a requirement]))
 
 AC_ARG_WITH([logfile],
             AS_HELP_STRING([--with-logfile=<path>],
@@ -279,26 +286,22 @@ AC_ARG_WITH([trace-event-file],
 AC_ARG_WITH([poco-includes],
             AS_HELP_STRING([--with-poco-includes=<path>],
                            [Path to the "include" directory with the Poco
-                            headers.  If you are building for Android 64bit,
-                            you need two, separated by a colon ':'.]))
+                            headers. For Android, this has the same format as --with-lo-builddir]))
 
 AC_ARG_WITH([zstd-libs],
             AS_HELP_STRING([--with-zstd-libs=<path>],
                            [Path to the directory containing libzstd.a
-                            libraries.  If you are building for Android 64bit,
-                            you need two, separated by a colon ':'.]))
+                            libraries. For Android, this has the same format as --with-lo-builddir]))
 
 AC_ARG_WITH([zstd-includes],
             AS_HELP_STRING([--with-zstd-includes=<path>],
                            [Path to the "include" directory with the zstd
-                            headers.  If you are building for Android 64bit,
-                            you need two, separated by a colon ':'.]))
+                            headers. For Android, this has the same format as --with-lo-builddir]))
 
 AC_ARG_WITH([poco-libs],
             AS_HELP_STRING([--with-poco-libs=<path>],
                            [Path to the "lib" directory with the Poco
-                            libraries.  If you are building for Android 64bit,
-                            you need two, separated by a colon ':'.]))
+                            libraries.  For Android, this has the same format as --with-lo-builddir]))
 
 AC_ARG_WITH([libpng-includes],
             AS_HELP_STRING([--with-libpng-includes=<path>],
@@ -591,6 +594,16 @@ if test \( "$enable_iosapp" = "yes" -a `uname -s` = "Darwin" \) -o \( "$enable_a
          LOBUILDDIR_X86=`echo $with_lo_builddir | cut -d: -f3`
          LOBUILDDIR_X86_64=`echo $with_lo_builddir | cut -d: -f4`
       fi
+
+      if test -z "$LOBUILDDIR_ARM64_V8A" ; then
+         LOBUILDDIR_ARM64_V8A="$LOBUILDDIR"
+      fi
+      if test -z "$LOBUILDDIR_X86" ; then
+         LOBUILDDIR_X86="$LOBUILDDIR"
+      fi
+      if test -z "$LOBUILDDIR_X86_64" ; then
+         LOBUILDDIR_X86_64="$LOBUILDDIR"
+      fi
    fi
 
    # Get the git hash of the core build
@@ -640,6 +653,16 @@ if test \( "$enable_iosapp" = "yes" -a `uname -s` = "Darwin" \) -o \( "$enable_a
          POCOINCLUDE_X86=`echo $with_poco_includes | cut -d: -f3`
          POCOINCLUDE_X86_64=`echo $with_poco_includes | cut -d: -f4`
       fi
+
+      if test -z "$POCOINCLUDE_ARM64_V8A" ; then
+         POCOINCLUDE_ARM64_V8A="$POCOINCLUDE"
+      fi
+      if test -z "$POCOINCLUDE_X86" ; then
+         POCOINCLUDE_X86="$POCOINCLUDE"
+      fi
+      if test -z "$POCOINCLUDE_X86_64" ; then
+         POCOINCLUDE_X86_64="$POCOINCLUDE"
+      fi
    fi
 
    # Sanity checks
@@ -660,6 +683,16 @@ if test \( "$enable_iosapp" = "yes" -a `uname -s` = "Darwin" \) -o \( "$enable_a
          POCOLIB_ARM64_V8A=`echo $with_poco_libs | cut -d: -f2`
          POCOLIB_X86=`echo $with_poco_libs | cut -d: -f3`
          POCOLIB_X86_64=`echo $with_poco_libs | cut -d: -f4`
+      fi
+
+      if test -z "$POCOLIB_ARM64_V8A" ; then
+         POCOLIB_ARM64_V8A="$POCOLIB"
+      fi
+      if test -z "$POCOLIB_X86" ; then
+         POCOLIB_X86="$POCOLIB"
+      fi
+      if test -z "$POCOLIB_X86_64" ; then
+         POCOLIB_X86_64="$POCOLIB"
       fi
    fi
 
@@ -686,6 +719,16 @@ if test \( "$enable_iosapp" = "yes" -a `uname -s` = "Darwin" \) -o \( "$enable_a
          ZSTDINCLUDE_X86=`echo $with_zstd_includes | cut -d: -f3`
          ZSTDINCLUDE_X86_64=`echo $with_zstd_includes | cut -d: -f4`
       fi
+
+      if test -z "$ZSTDINCLUDE_ARM64_V8A" ; then
+         ZSTDINCLUDE_ARM64_V8A="$ZSTDINCLUDE"
+      fi
+      if test -z "$ZSTDINCLUDE_X86" ; then
+         ZSTDINCLUDE_X86="$ZSTDINCLUDE"
+      fi
+      if test -z "$ZSTDINCLUDE_X86_64" ; then
+         ZSTDINCLUDE_X86_64="$ZSTDINCLUDE"
+      fi
    fi
 
    # Sanity checks
@@ -701,6 +744,16 @@ if test \( "$enable_iosapp" = "yes" -a `uname -s` = "Darwin" \) -o \( "$enable_a
          ZSTDLIB_ARM64_V8A=`echo $with_zstd_libs | cut -d: -f2`
          ZSTDLIB_X86=`echo $with_zstd_libs | cut -d: -f3`
          ZSTDLIB_X86_64=`echo $with_zstd_libs | cut -d: -f4`
+      fi
+
+      if test -z "$ZSTDLIB_ARM64_V8A" ; then
+         ZSTDLIB_ARM64_V8A="$ZSTDLIB"
+      fi
+      if test -z "$ZSTDLIB_X86" ; then
+         ZSTDLIB_X86="$ZSTDLIB"
+      fi
+      if test -z "$ZSTDLIB_X86_64" ; then
+         ZSTDLIB_X86_64="$ZSTDLIB"
       fi
    fi
 


### PR DESCRIPTION
Previously it was quite cumbersome to specify a different architecture than armeabi-v7a, as you had to specify *both* a core in the armeabi section and one for whatever architecture you wanted to build (these could be the same core, the armeabi one didn't need to actually be armeabi...)

This was made more confusing by the requirement to specify cores in the right position - requiring you to put colons between cores even when you were only planning to build a single ABI, but only if that ABI wasn't armeabi-v7a...

For example, to build arm64-v8a you would have to do something like

--with-lo-builddir=$(realpath ../android-core):$(realpath ../android-core)::

This is now changed, so specifying a single core is equivalent to specifying it 4 times, i.e. these are both the same thing

--with-lo-builddir=$(realpath ../android-core)

or

--with-lo-builddir=$(realpath ../android-core):$(realpath ../android-core):$(realpath ../android-core):$(realpath ../android-core)

This is a lot neater, and should allow us to make some nicer instructions on our build page
(https://collaboraonline.github.io/post/build-code-android/) which don't care about the architecture you're building for. This is made all the more important as the vast majority of modern devices are arm64-v8a rather than armeabi-v7a

---

We may additionally want to make a followup so that...

--with-lo-builddir=$(realpath ../android-core):$(realpath ../android-core)::

...is equivalent to...

--with-lo-builddir=$(realpath ../android-core):$(realpath ../android-core)::

...but this is less urgent


Change-Id: I875451423cb773df5198074587fe4d4365b30347


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

