### PR TITLE
chore: discourage .beforeprettier changes

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# Automatically mention people if .beforeprettier is being changed, as this
+# should be rare but sometimes people mistakenly add new stuff...
+/browser/.beforeprettier    @minion3665 @eszkadev

--- a/browser/.beforeprettier
+++ b/browser/.beforeprettier
@@ -1,3 +1,13 @@
+#===========================================================================#
+#                    PLEASE DON'T ADD STUFF TO THIS FILE                    #
+#                                                                           #
+# It's here as a way to stop files that were unformatted when we added      #
+# prettier from needing to be formatted. It shouldn't be used on new files, #
+# especially files which are newly-converted from JavaScript to Typescript. #
+#                                                                           #
+# Please instead format new files by running `make prettier-write`          #
+#===========================================================================#
+
 /src/control/ColorPicker.js
 /src/control/Control.AlertDialog.js
 /src/control/Control.Attribution.js


### PR DESCRIPTION
When we added prettier, we didn't want to format all the files in the repository then and there, so the compromise we came to was the .beforeprettier file

.beforeprettier is there to ignore files that were there "before prettier", i.e. legacy files that do not need to be formatted

Unfortunately, we didn't make this intent as clear as we could have, and the file has been changed several times since (see https://github.com/CollaboraOnline/online/commits/master/browser/.beforeprettier), including during migrations of files from JavaScript to Typescript and additions of new files, both of which should result in the file being formatted.

This change adds a comment to the top of the file, explaining that people shouldn't add new content to it. It also makes a CODEOWNERS file to ping myself and @eszkadev for review in the case that someone does try to change this file, allowing us to more easily spot changes that do so.


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

