### PR TITLE
Calc: update geometry and position on new sheet insertion

### DIFF
--- a/browser/src/canvas/sections/CommentListSection.ts
+++ b/browser/src/canvas/sections/CommentListSection.ts
@@ -1511,7 +1511,7 @@ export class CommentSection extends app.definitions.canvasSectionObject {
 	private adjustCommentFileBasedView (comment: any): void {
 		// Below calculations are the same with the ones we do while drawing tiles in fileBasedView.
 		var partHeightTwips = this.sectionProperties.docLayer._partHeightTwips + this.sectionProperties.docLayer._spaceBetweenParts;
-		var index = this.sectionProperties.docLayer._partHashes.indexOf(String(comment.parthash));
+		var index = app.impress.partHashes.indexOf(String(comment.parthash));
 		var yAddition = index * partHeightTwips;
 		comment.yAddition = yAddition; // We'll use this while we save the new position of the comment.
 

--- a/browser/src/canvas/sections/CommentSection.ts
+++ b/browser/src/canvas/sections/CommentSection.ts
@@ -117,7 +117,7 @@ export class Comment extends CanvasSectionObject {
 
 		if (this.sectionProperties.docLayer._docType === 'presentation' || this.sectionProperties.docLayer._docType === 'drawing') {
 			this.sectionProperties.parthash = this.sectionProperties.data.parthash;
-			this.sectionProperties.partIndex = this.sectionProperties.docLayer._partHashes.indexOf(String(this.sectionProperties.parthash));
+			this.sectionProperties.partIndex = app.impress.partHashes.indexOf(String(this.sectionProperties.parthash));
 		}
 
 		this.sectionProperties.isHighlighted = false;
@@ -645,7 +645,7 @@ export class Comment extends CanvasSectionObject {
 				}),
 				draggable: true
 			});
-			if (this.sectionProperties.docLayer._partHashes[this.sectionProperties.docLayer._selectedPart] === this.sectionProperties.data.parthash || app.file.fileBasedView)
+			if (app.impress.partHashes[this.sectionProperties.docLayer._selectedPart] === this.sectionProperties.data.parthash || app.file.fileBasedView)
 				this.map.addLayer(this.sectionProperties.annotationMarker);
 		}
 		if (this.sectionProperties.data.rectangle != null) {

--- a/browser/src/control/Parts.js
+++ b/browser/src/control/Parts.js
@@ -15,6 +15,11 @@
 /* global app _ cool */
 
 L.Map.include({
+	/*
+		@param {number} part - Target part
+		@param {boolean} external - Do we need to inform a core
+		@param {boolean} calledFromSetPartHandler - Requests a scroll to the cursor
+	*/
 	setPart: function (part, external, calledFromSetPartHandler) {
 		if (cool.Comment.isAnyEdit()) {
 			cool.CommentSection.showCommentEditingWarning();
@@ -22,8 +27,21 @@ L.Map.include({
 		}
 
 		var docLayer = this._docLayer;
+		var docType = docLayer._docType;
+		var isTheSamePart = true;
 
-		if (docLayer._selectedPart === part) {
+		// check hashes, when we add/delete/move parts they can have the same part number as before
+		if (docType === 'spreadsheet') {
+			isTheSamePart =
+				app.calc.partHashes[docLayer._prevSelectedPart] === app.calc.partHashes[part];
+		} else if (docType === 'presentation' || docType === 'drawing') {
+			isTheSamePart =
+				app.impress.partHashes[docLayer._prevSelectedPart] === app.impress.partHashes[part];
+		} else if (docType !== 'text') {
+			console.error('Unknown docType: ' + docType);
+		}
+
+		if (docLayer._selectedPart === part && isTheSamePart) {
 			return;
 		}
 

--- a/browser/src/docstate.js
+++ b/browser/src/docstate.js
@@ -28,6 +28,7 @@ window.app = {
 		cellCursorRectangle: null, // To be assigned SimpleRectangle.
 		otherCellCursors: {},
 		splitCoordinate: null, // SimplePoint.
+		partHashes: null, // hashes used to distinguish parts (we use sheet name)
 	},
 	impress: {
 		partHashes: null, // hashes used to distinguish parts

--- a/browser/src/docstate.js
+++ b/browser/src/docstate.js
@@ -29,6 +29,9 @@ window.app = {
 		otherCellCursors: {},
 		splitCoordinate: null, // SimplePoint.
 	},
+	impress: {
+		partHashes: null, // hashes used to distinguish parts
+	},
 	map: null, // Make map object a part of this.
 	dispatcher: null, // A Dispatcher class instance is assigned to this.
 	twipsToPixels: 0, // Twips to pixels multiplier.

--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -444,6 +444,7 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 			// only get the last matches
 			var oldPartNames = this._partNames;
 			this._partNames = partNames.slice(partNames.length - this._parts);
+			app.calc.partHashes = this._partNames; // TODO: generate unique hash on the core side
 			// if the number of parts, or order has changed then refresh comment positions
 			if (oldPartNames !== this._partNames) {
 				app.socket.sendMessage('commandvalues command=.uno:ViewAnnotationsPosition');

--- a/browser/src/layer/tile/ImpressTileLayer.js
+++ b/browser/src/layer/tile/ImpressTileLayer.js
@@ -24,7 +24,7 @@ L.ImpressTileLayer = L.CanvasTileLayer.extend({
 		}
 
 		this._preview = L.control.partsPreview();
-		this._partHashes = null;
+		app.impress.partHashes = null;
 		if (window.mode.isMobile()) {
 			this._addButton = L.control.mobileSlide();
 			L.DomUtil.addClass(L.DomUtil.get('mobile-edit-button'), 'impress');
@@ -83,7 +83,7 @@ L.ImpressTileLayer = L.CanvasTileLayer.extend({
 		comment.anchorPos = [docTopLeft[0], docTopLeft[1]];
 		comment.rectangle = [docTopLeft[0], docTopLeft[1], 566, 566];
 
-		comment.parthash = this._partHashes[this._selectedPart];
+		comment.parthash = app.impress.partHashes[this._selectedPart];
 		var annotation = app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).add(comment);
 		app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).modify(annotation);
 	},
@@ -284,15 +284,15 @@ L.ImpressTileLayer = L.CanvasTileLayer.extend({
 			var partMatch = textMsg.match(/[^\r\n]+/g);
 			// only get the last matches
 			var newPartHashes = partMatch.slice(partMatch.length - this._parts);
-			var refreshAnnotation = this._partHashes && (this._partHashes.length !== newPartHashes.length || !this._partHashes.every(function(element,i) { return element === newPartHashes[i]; }));
-			this._partHashes = newPartHashes;
+			var refreshAnnotation = app.impress.partHashes && (app.impress.partHashes.length !== newPartHashes.length || !app.impress.partHashes.every(function(element,i) { return element === newPartHashes[i]; }));
+			app.impress.partHashes = newPartHashes;
 			this._hiddenSlides = new Set(command.hiddenparts);
 			this._map.fire('updateparts', {
 				selectedPart: this._selectedPart,
 				selectedParts: this._selectedParts,
 				parts: this._parts,
 				docType: this._docType,
-				partNames: this._partHashes
+				partNames: app.impress.partHashes
 			});
 			if (refreshAnnotation)
 				app.socket.sendMessage('commandvalues command=.uno:ViewAnnotations');

--- a/cypress_test/integration_tests/multiuser/calc/cell_cursor_spec.js
+++ b/cypress_test/integration_tests/multiuser/calc/cell_cursor_spec.js
@@ -1,6 +1,7 @@
 /* global describe it cy beforeEach require */
 
 var helper = require('../../common/helper');
+var calcHelper = require('../../common/calc_helper');
 var desktopHelper = require('../../common/desktop_helper');
 
 describe(['tagmultiuser'], 'Check cell cursor and view behavior', function() {
@@ -45,5 +46,43 @@ describe(['tagmultiuser'], 'Check cell cursor and view behavior', function() {
 
 		// second view should still have cursor at the previous cell: A588+1
 		cy.cGet('input#addressInput-input').should('have.prop', 'value', 'A589');
+	});
+
+	it('Jump to the other sheet', function() {
+		// second view follow the first one
+		cy.cSetActiveFrame('#iframe2');
+		cy.cGet('#userListHeader').click();
+		cy.cGet('.user-list-item').eq(1).click();
+		cy.cGet('.jsdialog-overlay').click({force: true});
+
+		// first view goes somewhere in the middle of a sheet
+		cy.cSetActiveFrame('#iframe1');
+
+		cy.cGet('input#addressInput-input').type('{selectAll}A400{enter}');
+		desktopHelper.assertScrollbarPosition('vertical', 210, 240);
+		calcHelper.clickOnFirstCell(true, true, false);
+		cy.cGet('body').type('abc{enter}');
+
+		// second view should jump there
+		cy.cSetActiveFrame('#iframe2');
+		desktopHelper.assertScrollbarPosition('vertical', 210, 240);
+
+		// first view inserts sheet before current one
+		cy.cSetActiveFrame('#iframe1');
+		calcHelper.selectOptionFromContextMenu('Insert sheet before this');
+		cy.cGet('#map').focus();
+
+		// we should see A1
+		cy.cGet('input#addressInput-input').should('have.prop', 'value', 'A1');
+		desktopHelper.assertScrollbarPosition('vertical', 0, 30);
+
+		// verify that second view followed the first one
+		cy.cSetActiveFrame('#iframe2');
+		desktopHelper.assertScrollbarPosition('vertical', 0, 30);
+
+		// first goes to second sheet and we should see A388
+		cy.cSetActiveFrame('#iframe1');
+		cy.cGet('#spreadsheet-tab1').click();
+		desktopHelper.assertScrollbarPosition('vertical', 210, 240);
 	});
 });


### PR DESCRIPTION
calc: use hashes for parts
    
part number is not enough when adding/deleting/moving the sheets

fixes regression from commit 703dae0ea2322cee3f7af3d293f6ab7307f4d91a
Don't save position data when not switching sheets

1. Open Calc
2. in the current sheet scroll down a but and make some rows bigger
3. right-click on the sheet tab, insert sheet before

Result: resized rows are still visible
Expected: new sheet has equal small rows

---------------------------------------

impress: move part hashes to the docstate

// unify code with calc