### PR TITLE
Calc: don't force view reset if not needed

### DIFF
--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -425,7 +425,7 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 				this._map.fire('scrolllimits', {x: width, y: height});
 			}
 			else {
-				this._updateMaxBounds(true);
+				this._updateMaxBounds();
 			}
 			this._hiddenParts = command.hiddenparts || [];
 

--- a/cypress_test/integration_tests/desktop/calc/cell_cursor_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/cell_cursor_spec.js
@@ -35,6 +35,19 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Test jumping on large cell
 		cy.cGet('input#addressInput-input').should('have.prop', 'value', 'A10');
 		desktopHelper.assertScrollbarPosition('horizontal', 40, 60);
 	});
+
+	it('Show cursor on sheet insertion', function() {
+		// scroll down
+		cy.cGet('input#addressInput-input').type('{selectAll}A110{enter}');
+		desktopHelper.assertScrollbarPosition('vertical', 205, 315);
+
+		// insert sheet before
+		calcHelper.selectOptionFromContextMenu('Insert sheet before this');
+
+		// we should see the top left corner of the sheet
+		cy.cGet('input#addressInput-input').should('have.prop', 'value', 'A1');
+		desktopHelper.assertScrollbarPosition('vertical', 0, 30);
+	});
 });
 
 describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Test jumping on large cell selection with split panes', function() {


### PR DESCRIPTION
Fixes #9783 :
Calc: cannot see the cell cursor after "insert sheet before"

Steps to Reproduce:
1. Go to Calc
2. Scroll to around 100 row
3. Right-click on a sheet tab, Insert sheet before

Expected Behavior:
We should see new sheet with visible cursor at A1

Actual Behavior:
We don't see A1 but in my case row 25. Might depend on window size.

In case when new sheet has bigger size than a visible area - we were forcing view reset by bounds update which caused view jump. We were jumping outside of cursor visibility so user following was disabled and in the end user was not able to see own cursor.

Related to the following functionality change in:
commit df158a9
calc: don't jump to own cursor if not looking
