### PR TITLE
Invalid syntax for tileprocessed wireid 'NaN'

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -3474,6 +3474,9 @@ void DocumentBroker::handleTileRequest(const StringVector &tokens, bool forceKey
     Tile cachedTile = _tileCache->lookupTile(tile);
     if (cachedTile && cachedTile->isValid())
     {
+        if (tile.getWireId() == 0)
+            tile.setWireId(cachedTile->_wids.back());
+
         session->sendTileNow(tile, cachedTile);
         return;
     }


### PR DESCRIPTION
this is similar to:

commit 01165fbe1f074e530c0a6cb057fbc9b3b177971f
AuthorDate: Tue Jul 4 15:33:15 2023 +0100

    On a cache hit for a tile the result typically had a wireId of 0

this one can typically be reproduced by opening a presentation and can be seen when the slide preview tiles are requested


Change-Id: If5f7d0717a4068332aa96052a8a285171a13c03d


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

