### PR TITLE
Accessibility : Make JSDialog close button accessible via keyboard

### DIFF
--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -266,7 +266,7 @@ L.Control.JSDialog = L.Control.extend({
 			title.innerText = instance.title;
 			instance.titleCloseButton = L.DomUtil.create('button', 'ui-button ui-corner-all ui-widget ui-button-icon-only ui-dialog-titlebar-close', instance.titlebar);
 			instance.titleCloseButton.setAttribute('aria-label', _('Close dialog'));
-			instance.titleCloseButton.tabIndex = '-1';
+			instance.titleCloseButton.tabIndex = '0';
 			L.DomUtil.create('span', 'ui-button-icon ui-icon ui-icon-closethick', instance.titleCloseButton);
 		}
 


### PR DESCRIPTION
Resolved accessibility issue by changing the close button's tabindex from -1 to 0, enabling keyboard focus and interaction. Note: to access the close button using keyboard we need to add in cycle ( the tab cycle which will help to reach close button using keyboard )


Change-Id: I9ec0cef8a36de92daefa4bc0051a19e6ef3df1c2


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

