### PR TITLE
slideshow: remove resolution adjustment - use the screen size

### DIFF
--- a/browser/src/slideshow/LayersCompositor.ts
+++ b/browser/src/slideshow/LayersCompositor.ts
@@ -189,11 +189,16 @@ class LayersCompositor extends SlideShow.SlideCompositor {
 	public computeLayerResolution(width: number, height: number) {
 		width *= 1.2;
 		height *= 1.2;
-
 		let resolutionWidth = 960;
 		let resolutionHeight = 540;
 
-		if (width > 1920 || height > 1080) {
+		if (width > 3840 || height > 2160) {
+			resolutionWidth = 3840;
+			resolutionHeight = 2160;
+		} else if (width > 2560 || height > 1440) {
+			resolutionWidth = 2560;
+			resolutionHeight = 1440;
+		} else if (width > 1920 || height > 1080) {
 			resolutionWidth = 1920;
 			resolutionHeight = 1080;
 		} else if (width > 1280 || height > 720) {


### PR DESCRIPTION
Previously, we adjusted the resolution of the slides, so the size of the slide would be max 1920x1080. This restriction is removed now so the slide size can use the actual size of the screen. With this change the slides look much better on a high DPI screen (4k), but will also take longer to be transfered to the client as the size of the slides is bigger also.


Change-Id: I9b132ad5ac897f956768c5d5a1e77fa18cb34246


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

