### PR TITLE
Revert "Calc: don't force view reset if not needed"

### DIFF
--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -425,7 +425,7 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 				this._map.fire('scrolllimits', {x: width, y: height});
 			}
 			else {
-				this._updateMaxBounds();
+				this._updateMaxBounds(true);
 			}
 			this._hiddenParts = command.hiddenparts || [];
 

--- a/cypress_test/integration_tests/desktop/calc/cell_cursor_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/cell_cursor_spec.js
@@ -35,19 +35,6 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Test jumping on large cell
 		cy.cGet('input#addressInput-input').should('have.prop', 'value', 'A10');
 		desktopHelper.assertScrollbarPosition('horizontal', 40, 60);
 	});
-
-	it('Show cursor on sheet insertion', function() {
-		// scroll down
-		cy.cGet('input#addressInput-input').type('{selectAll}A110{enter}');
-		desktopHelper.assertScrollbarPosition('vertical', 205, 315);
-
-		// insert sheet before
-		calcHelper.selectOptionFromContextMenu('Insert sheet before this');
-
-		// we should see the top left corner of the sheet
-		cy.cGet('input#addressInput-input').should('have.prop', 'value', 'A1');
-		desktopHelper.assertScrollbarPosition('vertical', 0, 30);
-	});
 });
 
 describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Test jumping on large cell selection with split panes', function() {


### PR DESCRIPTION
This reverts commit ec33245158dd168ff57e7eb8563bd61f02722b5e. We need to test it more as detected in the reivew of other change. When you scroll down in calc and resize celected row - it jumps.