### PR TITLE
Keyboard: Add Ctrl + Insert as Copy Shortcut

### DIFF
--- a/browser/html/cool-help.html
+++ b/browser/html/cool-help.html
@@ -88,6 +88,7 @@
             <tr class="sub-section"> <td class="function">Undo</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Z</kbd></td> </tr>
             <tr class="sub-section"> <td class="function">Redo</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Y</kbd></td> </tr>
             <tr class="sub-section"> <td class="function">Cut</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>X</kbd></td> </tr>
+            <tr class="sub-section"> <td class="function">Copy</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>C</kbd>, <kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Insert</kbd></td></tr>
             <tr class="sub-section"> <td class="function">Paste as unformatted text</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>V</kbd></td> </tr>
             <tr class="sub-section"> <td class="function">Paste special</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>V</kbd></td> </tr>
             <tr class="sub-section"> <td class="function">Print (Download as PDF)</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>P</kbd></td> </tr>

--- a/browser/src/map/handler/Map.Keyboard.js
+++ b/browser/src/map/handler/Map.Keyboard.js
@@ -635,6 +635,11 @@ L.Map.Keyboard = L.Handler.extend({
 			return true;
 		}
 
+		// Control + INSERT
+		if (this._isCtrlKey(e) && e.keyCode === this.keyCodes.INSERT) {
+			return true;
+		}
+
 		if (e.keyCode !== this.keyCodes.C[DEFAULT] && e.keyCode !== this.keyCodes.V[DEFAULT] && e.keyCode !== this.keyCodes.X[DEFAULT] &&
 		/* Safari */ e.keyCode !== this.keyCodes.C[MAC] && e.keyCode !== this.keyCodes.V[MAC] && e.keyCode !== this.keyCodes.X[MAC]) {
 			// not copy or paste


### PR DESCRIPTION
Change-Id: I369d73c85beff934968fbafadf2da8bd4dccf8be

* Target version: master 

### Summary

Wire conventional alternative shortcut for Copy with Crtl + Insert.

### Checklist
- [x] All commits have Change-Id
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

Not sure where to find the user manual.