### PR TITLE
slideshow rework: bug: some transitions are wrong

### DIFF
--- a/browser/src/slideshow/LayersCompositor.ts
+++ b/browser/src/slideshow/LayersCompositor.ts
@@ -15,8 +15,7 @@
  */
 
 declare var app: any;
-// declare var SlideShow: any;
-declare namespace SlideShow {}
+declare var SlideShow: any;
 
 class LayersCompositor extends SlideShow.SlideCompositor {
 	private firstSlideHash: string = null;

--- a/browser/src/slideshow/SlideAnimations.ts
+++ b/browser/src/slideshow/SlideAnimations.ts
@@ -50,6 +50,44 @@ enum TransitionMode {
 	in
 }
 
+class SourceEventElement {
+	constructor(sId: string, aEventBaseElem: any, aEventMultiplexer: any) {
+		app.window.console.log('SourceEventElement: ' + sId + aEventBaseElem + aEventMultiplexer)
+	}
+}
+
+class NodeContext {
+	aContext: any = null;
+	aAnimationNodeMap: any = null;
+	aAnimatedElementMap: any = null;
+	aSourceEventElementMap: any = null;
+	nStartDelay = 0.0;
+	bFirstRun: boolean | undefined = undefined;
+	bIsInvalid = false;
+	aSlideHeight: number;
+	aSlideWidth: number;
+
+	constructor(aSlideShowContext: any) {
+		this.aContext = aSlideShowContext;
+	}
+
+	makeSourceEventElement(sId: string, aEventBaseElem: any) {
+		if (!aEventBaseElem) {
+			app.window.console.log('NodeContext.makeSourceEventElement: event base element is not valid');
+			return null;
+		}
+
+		if (!this.aContext.aEventMultiplexer) {
+			app.window.console.log('NodeContext.makeSourceEventElement: event multiplexer not initialized');
+			return null;
+		}
+
+		if (!this.aSourceEventElementMap[sId]) {
+			this.aSourceEventElementMap[sId] = new SourceEventElement(sId, aEventBaseElem, this.aContext.aEventMultiplexer);
+		}
+		return this.aSourceEventElementMap[sId];
+	}
+}
 
 function getAnimationNodeType(aNode:any) {
 	const typeStr = aNode.nodeName as keyof typeof AnimationNodeType;

--- a/browser/src/slideshow/transition/CombTransition.ts
+++ b/browser/src/slideshow/transition/CombTransition.ts
@@ -13,8 +13,8 @@
 declare var SlideShow: any;
 
 enum CombSubType {
-	COMBVERTICAL,
 	COMBHORIZONTAL,
+	COMBVERTICAL,
 }
 
 class CombTransition extends Transition2d {

--- a/browser/src/slideshow/transition/FadeTransition.ts
+++ b/browser/src/slideshow/transition/FadeTransition.ts
@@ -70,14 +70,14 @@ class FadeTransition extends SlideShow.Transition2d {
 					vec4 color1 = texture(enteringSlideTexture, v_texCoord);
 					vec4 transitionColor;
 
-					if (effectType == 1) {
+					if (effectType == 0) {
 						// Fade through black
 						transitionColor = vec4(0.0, 0.0, 0.0, 1.0);
-					} else if (effectType == 2) {
+					} else if (effectType == 1) {
 						// Fade through white
 						transitionColor = vec4(1.0, 1.0, 1.0, 1.0);
 					}
-					if (effectType == 3) {
+					if (effectType == 2) {
 						// Smooth fade
 						float smoothTime = smoothstep(0.0, 1.0, time);
 						outColor = mix(color0, color1, smoothTime);

--- a/browser/src/slideshow/transition/PushWipeTransition.ts
+++ b/browser/src/slideshow/transition/PushWipeTransition.ts
@@ -17,10 +17,13 @@ function PushWipeTransition(transitionParameters: TransitionParameters) {
 		stringToTransitionSubTypeMap[
 			transitionParameters.slideInfo.transitionSubtype
 		];
-	if (transitionSubType == TransitionSubType.FROMTOP) {
-		return new SlideShow.PushTransition(transitionParameters);
-	} else {
+	if (
+		transitionSubType == TransitionSubType.COMBHORIZONTAL ||
+		transitionSubType == TransitionSubType.COMBVERTICAL
+	) {
 		return new SlideShow.CombTransition(transitionParameters);
+	} else {
+		return new SlideShow.PushTransition(transitionParameters);
 	}
 }
 


### PR DESCRIPTION
pushWipe transition subtypes are routed to the wrong gl transition
horizontal and vertical comb are inverted
fade transition subtyped are routed to the wrong gl transition (index
start from 1 instead of 0)

Signed-off-by: Marco Cecchetti <marco.cecchetti@collabora.com>
Change-Id: Ibe1e63a2678af1e5c298272f63f188234e10bbb5
