### PR TITLE
annotation: avoid creating comment insert box if annotations disabled

### DIFF
--- a/browser/src/canvas/sections/CommentListSection.ts
+++ b/browser/src/canvas/sections/CommentListSection.ts
@@ -15,6 +15,8 @@
 
 L.Map.include({
 	insertComment: function() {
+		if (this.stateChangeHandler.getItemValue('InsertAnnotation') === 'disabled')
+			return;
 		if (cool.Comment.isAnyEdit()) {
 			cool.CommentSection.showCommentEditingWarning();
 			return;


### PR DESCRIPTION
problem:
some elements can not have comments, when these elements get selection, comment button in menus were disabled but shortcuts still worked, this ensures no element for comment insert is created in first place


Change-Id: Ib76366c23e9ad7f6fc29f98add65b0840d00ead9


* Target version: master 


### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

