### PR TITLE
slideshow rework: bugfix: fadeovercolor transition

### DIFF
--- a/browser/src/slideshow/SlideShowPresenter.ts
+++ b/browser/src/slideshow/SlideShowPresenter.ts
@@ -37,6 +37,7 @@ interface SlideInfo {
 	transitionDirection: boolean;
 	transitionType: string | undefined;
 	transitionSubtype: string | undefined;
+	transitionFadeColor: string | undefined;
 	background: {
 		isCustom: boolean;
 		fillColor: string;

--- a/browser/src/slideshow/transition/FadeTransition.ts
+++ b/browser/src/slideshow/transition/FadeTransition.ts
@@ -36,11 +36,10 @@ class FadeTransition extends SlideShow.Transition2d {
 			this.effectTransition = FadeSubType.SMOOTHLY;
 		} else if (
 			transitionSubType == TransitionSubType.FADEOVERCOLOR &&
-			this.slideInfo.transitionDirection
+			this.slideInfo.transitionFadeColor &&
+			this.slideInfo.transitionFadeColor.toUpperCase() === '#FFFFFF'
 		) {
 			this.effectTransition = FadeSubType.FADEOVERWHITE;
-		} else {
-			this.effectTransition = FadeSubType.FADEOVERBLACK;
 		}
 
 		this.startTransition();


### PR DESCRIPTION
Fade over color transition is based on the transition fade color
property not on the direction.

Signed-off-by: Marco Cecchetti <marco.cecchetti@collabora.com>
Change-Id: Idf5b0cef385f7e9f31159dd0f5669d08f4258cef
