### PR TITLE
Meven/button notebookbar pointer

### DIFF
--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -197,7 +197,6 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 }
 
 .unotoolbutton.notebookbar .unobutton {
-	cursor: pointer;
 	box-sizing: border-box;
 	padding: 0;
 	width: var(--btn-size);
@@ -280,6 +279,7 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 }
 
 .unotoolbutton.notebookbar {
+	cursor: pointer;
 	margin-inline-end: 5px !important;
 	text-align: center;
 }


### PR DESCRIPTION
* Target version: master 

### Summary
Currently only the icon of the notebookbar buttons that have the pointer (hand) cursor, but neither the hovered region nor the button label.

This allows to have the pointer cursor on the whole notebookbar buttons.

![image](https://github.com/user-attachments/assets/125ac49c-af01-49d6-be8e-ce04171be212)

improves upon https://github.com/CollaboraOnline/online/commit/41063ceafbd6234ae180c55ea8f501de51f5ab2f

### Checklist

- [x] I have issued `make run` and manually verified that everything looks okay


