### PR TITLE
draw: just get the UNO commands for presentation

### DIFF
--- a/browser/src/unocommands.js
+++ b/browser/src/unocommands.js
@@ -532,6 +532,9 @@ window._UNO = function(string, component, isContext) {
 	if (entry === undefined) {
 		return command;
 	}
+	if (component == 'drawing') {
+		component = 'presentation';
+	}
 	var componentEntry = entry[component];
 	if (componentEntry === undefined) {
 		componentEntry = entry['global'];


### PR DESCRIPTION
Now the ChangeBezier uno command has a proper context menu item in draw

Fixes https://github.com/CollaboraOnline/online/issues/9813


Change-Id: I834c19a80e6d8c6a279ae298e78ba650bbea1fb1


* Resolves: #9813 
* Target version: master 

### Summary

Turns out presentation and drawing have the same set of commands, but we distinguish on the doc type.

### TODO

- [ ] ...

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

