### PR TITLE
Fix error on context change after mode switch

### DIFF
--- a/browser/src/control/Control.TopToolbar.js
+++ b/browser/src/control/Control.TopToolbar.js
@@ -22,7 +22,7 @@ class TopToolbar extends JSDialog.Toolbar {
 		app.events.on('updatepermission', this.onUpdatePermission.bind(this));
 		map.on('wopiprops', this.onWopiProps, this);
 		map.on('commandstatechanged', this.onCommandStateChanged, this);
-		map.on('contextchange', this.onContextChange.bind(this), this);
+		map.on('contextchange', this.onContextChange, this);
 
 		if (!window.mode.isMobile()) {
 			map.on('updatetoolbarcommandvalues', this.updateCommandValues, this);
@@ -36,8 +36,10 @@ class TopToolbar extends JSDialog.Toolbar {
 		}
 
 		this.map.off('doclayerinit', this.onDocLayerInit, this);
+		// TODO: app.events.off('updatepermission', this.onUpdatePermission.bind(this));
 		this.map.off('wopiprops', this.onWopiProps, this);
 		this.map.off('commandstatechanged', this.onCommandStateChanged, this);
+		this.map.off('contextchange', this.onContextChange, this);
 
 		if (!window.mode.isMobile()) {
 			this.map.off('updatetoolbarcommandvalues', this.updateCommandValues, this);


### PR DESCRIPTION
Fixes #9816

When we open classic/compact mode, then switch to notebookbar mode - the old component of top toolbar is not correctly removed. What leads to an error.

Steps to Reproduce:
1. Open any document, use compact mode
2. Switch to notebookbar mode
3. Change context, eg. select shape then select text

Don't use bind(this) so we successfully remove the same instance of handler we inserted, we already pass "this" as 3rd param. Notice we should also remove callback from app.events but it doesn't have that function yet
