### PR TITLE
draw: Fix the unocommands.py

### DIFF
--- a/scripts/unocommands.py
+++ b/scripts/unocommands.py
@@ -328,6 +328,9 @@ window._UNO = function(string, component, isContext) {
 \tif (entry === undefined) {
 \t\treturn command;
 \t}
+\tif (component == 'drawing') {
+\t\tcomponent = 'presentation';
+\t}
 \tvar componentEntry = entry[component];
 \tif (componentEntry === undefined) {
 \t\tcomponentEntry = entry['global'];


### PR DESCRIPTION
This is a followup to commit daf8ad7
The unocommands.js is a generated file, and the code is part of it.

Fixes https://github.com/CollaboraOnline/online/issues/9813


Change-Id: I00856c21b3f49437739240830c142efec41c9602


* Resolves: #9813
* Target version: master 

### Summary

This was overlooked in the previous patch.

### TODO

- [ ] ...

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

