### PR TITLE
Keyboard shortcuts dialog: Improve formatting on copy shortcut

### DIFF
--- a/browser/html/cool-help.html
+++ b/browser/html/cool-help.html
@@ -88,7 +88,7 @@
             <tr class="sub-section"> <td class="function">Undo</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Z</kbd></td> </tr>
             <tr class="sub-section"> <td class="function">Redo</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Y</kbd></td> </tr>
             <tr class="sub-section"> <td class="function">Cut</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>X</kbd></td> </tr>
-            <tr class="sub-section"> <td class="function">Copy</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>C</kbd>, <kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Insert</kbd></td></tr>
+            <tr class="sub-section"> <td class="function">Copy</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>C</kbd>,</br><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Insert</kbd></td></tr>
             <tr class="sub-section"> <td class="function">Paste as unformatted text</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>V</kbd></td> </tr>
             <tr class="sub-section"> <td class="function">Paste special</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Alt</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>V</kbd></td> </tr>
             <tr class="sub-section"> <td class="function">Print (Download as PDF)</td> <td class="shortcut"><kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>P</kbd></td> </tr>


### PR DESCRIPTION
Before this commit the 2 shortcuts that trigger copy were placed
side by side with a comma in between, this was breaking the visual
table.

-> Add a break line so, it's easier to scan.

Note: the alternative would be using a rowspan="2" in the <tr> and
then add a new <tr> after that so, to achieve the same result but that
would break the search results (searching for copy would only show the
first shortcut). Conclusion: better to just add a </br>

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Id1bd13dce0cacba7cdc38934f5b067fb26baf060
