### PR TITLE
unobuttons: have cursor pointer also on buttons

### DIFF
--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -278,8 +278,11 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 	filter: grayscale(100%) brightness(100%);
 }
 
-.unotoolbutton.notebookbar {
+.unotoolbutton:not(.disabled) * {
 	cursor: pointer;
+}
+
+.unotoolbutton.notebookbar {
 	margin-inline-end: 5px !important;
 	text-align: center;
 }


### PR DESCRIPTION
Fix ce3b222049b2d1db3ffc5289a39e502ff7f1edb0

change-Id: I3abec2756997a589123ccc872114cb3c85edd826

Buttons and label wouldn't get the cursor, and disabled items would get the cursor too, while it is supposed to have the cursor "not-allowed".

disabled items are not properly handled currently, but that's a different issue.

ce3b222049b2d1db3ffc5289a39e502ff7f1edb0 needed to be adapted.

