### PR TITLE
More Async Locking Prerequisites

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1534,20 +1534,20 @@ bool DocumentBroker::lockDocumentInStorage(const Authorization& auth, std::strin
         auth, *_lockCtx, StorageBase::LockState::LOCK, _currentStorageAttrs);
     error = _lockCtx->_lockFailureReason;
 
-    switch (result)
+    switch (result.getStatus())
     {
-        case StorageBase::LockUpdateResult::UNSUPPORTED:
+        case StorageBase::LockUpdateResult::Status::UNSUPPORTED:
             LOG_DBG("Locks on docKey [" << _docKey << "] are unsupported");
             return true; // Not an error.
             break;
-        case StorageBase::LockUpdateResult::OK:
+        case StorageBase::LockUpdateResult::Status::OK:
             LOG_DBG("Locked docKey [" << _docKey << "] successfully");
             return true;
             break;
-        case StorageBase::LockUpdateResult::UNAUTHORIZED:
+        case StorageBase::LockUpdateResult::Status::UNAUTHORIZED:
             LOG_ERR("Failed to lock docKey [" << _docKey << "]. Invalid or expired access token");
             break;
-        case StorageBase::LockUpdateResult::FAILED:
+        case StorageBase::LockUpdateResult::Status::FAILED:
             LOG_ERR("Failed to lock docKey [" << _docKey << "] with reason: " << error);
             break;
     }
@@ -1575,18 +1575,18 @@ bool DocumentBroker::updateStorageLockState(ClientSession& session, StorageBase:
         session.getAuthorization(), *_lockCtx, lock, _currentStorageAttrs);
     error = _lockCtx->_lockFailureReason;
 
-    switch (result)
+    switch (result.getStatus())
     {
-        case StorageBase::LockUpdateResult::UNSUPPORTED:
+        case StorageBase::LockUpdateResult::Status::UNSUPPORTED:
             LOG_DBG("Locks on docKey [" << _docKey << "] are unsupported");
             return true; // Not an error.
             break;
-        case StorageBase::LockUpdateResult::OK:
+        case StorageBase::LockUpdateResult::Status::OK:
             LOG_DBG((lock == StorageBase::LockState::LOCK ? "Locked" : "Unlocked")
                     << " docKey [" << _docKey << "] successfully");
             return true;
             break;
-        case StorageBase::LockUpdateResult::UNAUTHORIZED:
+        case StorageBase::LockUpdateResult::Status::UNAUTHORIZED:
             LOG_ERR("Failed to " << (lock == StorageBase::LockState::LOCK ? "Locked" : "Unlocked")
                                  << " docKey [" << _docKey
                                  << "]. Invalid or expired access token. Notifying client and "
@@ -1599,7 +1599,7 @@ bool DocumentBroker::updateStorageLockState(ClientSession& session, StorageBase:
                 session.setLockFailed(error);
             }
             break;
-        case StorageBase::LockUpdateResult::FAILED:
+        case StorageBase::LockUpdateResult::Status::FAILED:
             LOG_ERR("Failed to " << (lock == StorageBase::LockState::LOCK ? "Locked" : "Unlocked")
                                  << " docKey [" << _docKey << "] with reason [" << error
                                  << "]. Notifying client and making session [" << session.getId()

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1532,7 +1532,7 @@ bool DocumentBroker::lockDocumentInStorage(const Authorization& auth, std::strin
 
     const StorageBase::LockUpdateResult result = _storage->updateLockState(
         auth, *_lockCtx, StorageBase::LockState::LOCK, _currentStorageAttrs);
-    error = _lockCtx->_lockFailureReason;
+    error = result.getReason();
 
     switch (result.getStatus())
     {
@@ -1573,7 +1573,7 @@ bool DocumentBroker::updateStorageLockState(ClientSession& session, StorageBase:
 
     const StorageBase::LockUpdateResult result = _storage->updateLockState(
         session.getAuthorization(), *_lockCtx, lock, _currentStorageAttrs);
-    error = _lockCtx->_lockFailureReason;
+    error = result.getReason();
 
     switch (result.getStatus())
     {

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -2498,7 +2498,8 @@ void DocumentBroker::refreshLock()
     else
     {
         const std::string savingSessionId = session->getId();
-        LOG_TRC("Refresh lock " << _lockCtx->_lockToken << " with session [" << savingSessionId << ']');
+        LOG_TRC("Refresh lock " << _lockCtx->lockToken() << " with session [" << savingSessionId
+                                << ']');
         std::string error;
         if (!updateStorageLockState(*session, StorageBase::LockState::LOCK, error))
         {

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -269,7 +269,7 @@ public:
     /// Represents the Lock request result, with a Result code
     /// and a reason message (typically for errors).
     /// Note: the reason message may be displayed to the clients.
-    class LockResult final
+    class LockUpdateResult final
     {
     public:
         STATE_ENUM(Status,
@@ -279,12 +279,12 @@ public:
                    FAILED //< Other failures.
         );
 
-        explicit LockResult(Status status)
+        explicit LockUpdateResult(Status status)
             : _status(status)
         {
         }
 
-        LockResult(Status status, std::string reason)
+        LockUpdateResult(Status status, std::string reason)
             : _status(status)
             , _reason(std::move(reason))
         {
@@ -304,7 +304,7 @@ public:
     };
 
     /// The state of an asynchronous lock request.
-    using AsyncLockRequest = AsyncRequest<LockResult>;
+    using AsyncLockUpdate = AsyncRequest<LockUpdateResult>;
 
     enum class COOLStatusCode
     {
@@ -379,19 +379,12 @@ public:
                UNLOCK, //< Unlock the document .
     );
 
-    STATE_ENUM(LockUpdateResult,
-               UNSUPPORTED, //< Locking is not supported on this host.
-               OK, //< Succeeded to either lock or unlock (see LockContext).
-               UNAUTHORIZED, //< 401, 403, 404.
-               FAILED //< Other failures.
-    );
-
     /// Update the locking state (check-in/out) of the associated file synchronously.
     virtual LockUpdateResult updateLockState(const Authorization& auth, LockContext& lockCtx,
                                              LockState lock, const Attributes& attribs) = 0;
 
     /// The asynchronous upload completion callback function.
-    using AsyncLockStateCallback = std::function<void(const AsyncLockRequest&)>;
+    using AsyncLockStateCallback = std::function<void(const AsyncLockUpdate&)>;
 
     /// Update the locking state (check-in/out) of the associated file asynchronously.
     virtual void updateLockStateAsync(const Authorization& auth, LockContext& lockCtx,
@@ -535,7 +528,7 @@ public:
     LockUpdateResult updateLockState(const Authorization&, LockContext&, StorageBase::LockState,
                                      const Attributes&) override
     {
-        return LockUpdateResult::OK;
+        return LockUpdateResult(LockUpdateResult::Status::OK);
     }
 
     void updateLockStateAsync(const Authorization&, LockContext&, LockState, const Attributes&,

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -541,6 +541,13 @@ struct LockContext
     /// Returns true if locked.
     bool isLocked() const { return _lockState == StorageBase::LockState::LOCK; }
 
+    /// Sets the new state and bumps the timer.
+    void setState(StorageBase::LockState state)
+    {
+        _lockState = state;
+        bumpTimer();
+    }
+
     /// wait another refresh cycle
     void bumpTimer() { _lastLockTime = std::chrono::steady_clock::now(); }
 

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -26,7 +26,7 @@
 /// Limits number of HTTP redirections to prevent from redirection loops
 static constexpr auto RedirectionLimit = 21;
 
-struct LockContext;
+class LockContext;
 
 /// Base class of all Storage abstractions.
 class StorageBase
@@ -558,7 +558,7 @@ private:
 
 /// Represents whether the underlying file is locked
 /// and with what token.
-struct LockContext
+class LockContext final
 {
     /// Do we have support for locking for a storage.
     bool _supportsLocks;
@@ -569,6 +569,7 @@ struct LockContext
     /// Time of last successful lock (re-)acquisition
     std::chrono::steady_clock::time_point _lastLockTime;
 
+public:
     LockContext()
         : _supportsLocks(false)
         , _lockState(StorageBase::LockState::UNLOCK)
@@ -581,6 +582,10 @@ struct LockContext
 
     /// Returns true if locks are supported.
     bool supportsLocks() const { return _supportsLocks; }
+
+    /// Returns the lock token used identify our lock on the server.
+    /// Meaningful only when supportsLocks is true.
+    const std::string& lockToken() const { return _lockToken; }
 
     /// Returns true if locked.
     bool isLocked() const { return _lockState == StorageBase::LockState::LOCK; }

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -568,8 +568,6 @@ struct LockContext
     std::string _lockToken;
     /// Time of last successful lock (re-)acquisition
     std::chrono::steady_clock::time_point _lastLockTime;
-    /// Reason for unsuccessful locking request
-    std::string _lockFailureReason;
 
     LockContext()
         : _supportsLocks(false)

--- a/wsd/wopi/WopiStorage.cpp
+++ b/wsd/wopi/WopiStorage.cpp
@@ -784,10 +784,12 @@ void WopiStorage::uploadLocalFileToStorageAsync(const Authorization& auth, LockC
         LOG_DBG(wopiLog << " async upload request: " << httpRequest.header().toString());
 
         // Make the request.
-        _uploadHttpSession->asyncRequest(httpRequest, socketPoll);
+        if (_uploadHttpSession->asyncRequest(httpRequest, socketPoll))
+        {
+            scopedInvokeCallback.setArg(
+                AsyncUpload(AsyncUpload::State::Running, UploadResult(UploadResult::Result::OK)));
+        }
 
-        scopedInvokeCallback.setArg(
-            AsyncUpload(AsyncUpload::State::Running, UploadResult(UploadResult::Result::OK)));
         return;
     }
     catch (const Poco::Exception& ex)

--- a/wsd/wopi/WopiStorage.cpp
+++ b/wsd/wopi/WopiStorage.cpp
@@ -398,8 +398,7 @@ StorageBase::LockUpdateResult WopiStorage::updateLockState(const Authorization& 
 
         if (httpResponse->statusLine().statusCode() == http::StatusCode::OK)
         {
-            lockCtx._lockState = lock;
-            lockCtx.bumpTimer();
+            lockCtx.setState(lock);
             return LockUpdateResult::OK;
         }
 

--- a/wsd/wopi/WopiStorage.cpp
+++ b/wsd/wopi/WopiStorage.cpp
@@ -355,7 +355,7 @@ StorageBase::LockUpdateResult WopiStorage::updateLockState(const Authorization& 
 {
     lockCtx._lockFailureReason.clear();
     if (!lockCtx.supportsLocks())
-        return LockUpdateResult::UNSUPPORTED;
+        return LockUpdateResult(LockUpdateResult::Status::UNSUPPORTED);
 
     Poco::URI uriObject(getUri());
     auth.authorizeURI(uriObject);
@@ -399,7 +399,7 @@ StorageBase::LockUpdateResult WopiStorage::updateLockState(const Authorization& 
         if (httpResponse->statusLine().statusCode() == http::StatusCode::OK)
         {
             lockCtx.setState(lock);
-            return LockUpdateResult::OK;
+            return LockUpdateResult(LockUpdateResult::Status::OK);
         }
 
         std::string failureReason = httpResponse->get("X-WOPI-LockFailureReason", "");
@@ -417,13 +417,13 @@ StorageBase::LockUpdateResult WopiStorage::updateLockState(const Authorization& 
                                      << httpResponse->statusLine().statusCode() << failureReason
                                      << " and response: " << responseString);
 
-            return LockUpdateResult::UNAUTHORIZED;
+            return LockUpdateResult(LockUpdateResult::Status::UNAUTHORIZED);
         }
 
         LOG_ERR("Un-successful " << wopiLog << " with HTTP status "
                                  << httpResponse->statusLine().statusCode() << failureReason
                                  << " and response: " << responseString);
-        return LockUpdateResult::FAILED;
+        return LockUpdateResult(LockUpdateResult::Status::FAILED);
     }
     catch (const BadRequestException& exc)
     {
@@ -431,7 +431,7 @@ StorageBase::LockUpdateResult WopiStorage::updateLockState(const Authorization& 
     }
 
     lockCtx._lockFailureReason = "Request failed";
-    return LockUpdateResult::FAILED;
+    return LockUpdateResult(LockUpdateResult::Status::FAILED);
 }
 
 void WopiStorage::updateLockStateAsync(const Authorization& /*auth*/, LockContext& /*lockCtx*/,

--- a/wsd/wopi/WopiStorage.cpp
+++ b/wsd/wopi/WopiStorage.cpp
@@ -377,7 +377,7 @@ StorageBase::LockUpdateResult WopiStorage::updateLockState(const Authorization& 
         http::Header& httpHeader = httpRequest.header();
 
         httpHeader.set("X-WOPI-Override", lock == StorageBase::LockState::LOCK ? "LOCK" : "UNLOCK");
-        httpHeader.set("X-WOPI-Lock", lockCtx._lockToken);
+        httpHeader.set("X-WOPI-Lock", lockCtx.lockToken());
         if (!attribs.getExtendedData().empty())
         {
             httpHeader.set("X-COOL-WOPI-ExtendedData", attribs.getExtendedData());
@@ -685,7 +685,7 @@ void WopiStorage::uploadLocalFileToStorageAsync(const Authorization& auth, LockC
 
         // must include this header except for SaveAs
         if (!isSaveAs && lockCtx.supportsLocks())
-            httpHeader.set("X-WOPI-Lock", lockCtx._lockToken);
+            httpHeader.set("X-WOPI-Lock", lockCtx.lockToken());
 
         if (!isSaveAs && !isRename)
         {

--- a/wsd/wopi/WopiStorage.cpp
+++ b/wsd/wopi/WopiStorage.cpp
@@ -353,7 +353,6 @@ StorageBase::LockUpdateResult WopiStorage::updateLockState(const Authorization& 
                                                            StorageBase::LockState lock,
                                                            const Attributes& attribs)
 {
-    lockCtx._lockFailureReason.clear();
     if (!lockCtx.supportsLocks())
         return LockUpdateResult(LockUpdateResult::Status::UNSUPPORTED);
 
@@ -402,11 +401,7 @@ StorageBase::LockUpdateResult WopiStorage::updateLockState(const Authorization& 
             return LockUpdateResult(LockUpdateResult::Status::OK);
         }
 
-        std::string failureReason = httpResponse->get("X-WOPI-LockFailureReason", "");
-        if (!failureReason.empty())
-        {
-            lockCtx._lockFailureReason = failureReason;
-        }
+        const std::string failureReason = httpResponse->get("X-WOPI-LockFailureReason", "");
 
         if (httpResponse->statusLine().statusCode() == http::StatusCode::Unauthorized ||
             httpResponse->statusLine().statusCode() == http::StatusCode::Forbidden ||
@@ -430,7 +425,6 @@ StorageBase::LockUpdateResult WopiStorage::updateLockState(const Authorization& 
         LOG_ERR("Cannot " << wopiLog << " uri [" << uriAnonym << "]. Error: " << exc.what());
     }
 
-    lockCtx._lockFailureReason = "Request failed";
     return LockUpdateResult(LockUpdateResult::Status::FAILED, "Internal error");
 }
 

--- a/wsd/wopi/WopiStorage.cpp
+++ b/wsd/wopi/WopiStorage.cpp
@@ -434,6 +434,12 @@ StorageBase::LockUpdateResult WopiStorage::updateLockState(const Authorization& 
     return LockUpdateResult::FAILED;
 }
 
+void WopiStorage::updateLockStateAsync(const Authorization& /*auth*/, LockContext& /*lockCtx*/,
+                                       LockState /*lock*/, const Attributes& /*attribs*/,
+                                       const AsyncLockStateCallback& /*asyncLockStateCallback*/)
+{
+}
+
 /// uri format: http://server/<...>/wopi*/files/<id>/content
 std::string WopiStorage::downloadStorageFileToLocal(const Authorization& auth,
                                                     LockContext& /*lockCtx*/,

--- a/wsd/wopi/WopiStorage.hpp
+++ b/wsd/wopi/WopiStorage.hpp
@@ -197,6 +197,10 @@ public:
                                      StorageBase::LockState lock,
                                      const Attributes& attribs) override;
 
+    void updateLockStateAsync(const Authorization& auth, LockContext& lockCtx, LockState lock,
+                              const Attributes& attribs,
+                              const AsyncLockStateCallback& asyncLockStateCallback) override;
+
     /// uri format: http://server/<...>/wopi*/files/<id>/content
     std::string downloadStorageFileToLocal(const Authorization& auth, LockContext& lockCtx,
                                            const std::string& templateUri) override;


### PR DESCRIPTION
- wsd: generalize ScopedInvokeAsyncUploadCallback for reuse
- wsd: encapsulate updating the lock state
- wsd: asynchronous locking stubs
- wsd: unify LockResult and LockUpdateResult
- wsd: return lock update failure through the result
- wsd: remove the LockContext lockFailureReason
- wsd: encapsulate the LockContext lockToken
- wsd: simplified updateLockState error handling
- wsd: check for asyncRequest success for uploading
