### PR TITLE
fix(android): Stop saving readonly docs

### DIFF
--- a/android/lib/src/main/java/org/libreoffice/androidlib/LOActivity.java
+++ b/android/lib/src/main/java/org/libreoffice/androidlib/LOActivity.java
@@ -417,7 +417,7 @@ public class LOActivity extends AppCompatActivity {
         Log.i(TAG, "onNewIntent");
 
         if (documentLoaded) {
-            postMobileMessageNative("save dontTerminateEdit=true dontSaveIfUnmodified=true");
+            postMobileMessageNative("save dontTerminateEdit=1 dontSaveIfUnmodified=1");
         }
 
         final Intent finalIntent = intent;
@@ -609,7 +609,7 @@ public class LOActivity extends AppCompatActivity {
     protected void onPause() {
         // A Save similar to an autosave
         if (documentLoaded)
-            postMobileMessageNative("save dontTerminateEdit=true dontSaveIfUnmodified=true");
+            postMobileMessageNative("save dontTerminateEdit=1 dontSaveIfUnmodified=1");
 
         super.onPause();
         Log.d(TAG, "onPause() - hinting to save, we might need to return to the doc");

--- a/browser/src/canvas/sections/CommentListSection.ts
+++ b/browser/src/canvas/sections/CommentListSection.ts
@@ -2232,6 +2232,10 @@ export class CommentSection extends app.definitions.canvasSectionObject {
 			}
 		}
 	}
+
+	public hasAnyComments(): boolean {
+		return this.containerObject.sections.some((x: any) => x.constructor.name == "Comment")
+	}
 }
 
 }

--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -1340,12 +1340,13 @@ L.Control.Menubar = L.Control.extend({
 		allowedReadonlyMenus: ['file', 'downloadas', 'view', 'insert', 'slide', 'help'],
 
 		allowedViewModeActions: [
-			'savecomments', 'shareas', 'print', // file menu
+			() => app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).hasAnyComments() ? 'savecomments' : undefined,
+			'shareas', 'print', // file menu
 			'downloadas-odt', 'downloadas-doc', 'downloadas-docx', 'downloadas-rtf', // file menu
 			'downloadas-odp', 'downloadas-ppt', 'downloadas-pptx', 'downloadas-odg', 'exportpdf' , // file menu
 			!window.ThisIsAMobileApp ? 'exportdirectpdf' : 'downloadas-pdf', !window.ThisIsAMobileApp ? 'exportepub' : 'downloadas-epub', // file menu
 			'downloadas-ods', 'downloadas-xls', 'downloadas-xlsx', 'downloadas-csv', 'closedocument', // file menu
-			'fullscreen', 'zoomin', 'zoomout', 'zoomreset', 'showstatusbar', 'showresolved', 'toggledarktheme', // view menu
+			!(L.Browser.ie || L.Browser.edge) ? 'fullscreen' : undefined, 'zoomin', 'zoomout', 'zoomreset', 'showstatusbar', 'showresolved', 'toggledarktheme', // view menu
 			'about', 'keyboard-shortcuts', 'latestupdates', 'feedback', 'serveraudit', 'online-help', 'report-an-issue', // help menu
 			'insertcomment'
 		]
@@ -1744,10 +1745,6 @@ L.Control.Menubar = L.Control.extend({
 					if (id === 'fullscreen') { // Full screen works weirdly on IE 11 and on Edge
 						if (L.Browser.ie || L.Browser.edge) {
 							$(aItem).addClass('disabled');
-							var index = self.options.allowedViewModeActions.indexOf('fullscreen');
-							if (index > 0) {
-								self.options.allowedViewModeActions.splice(index, 1);
-							}
 						} else if (self._map.uiManager.isFullscreen()) {
 							$(aItem).addClass(constChecked);
 						} else {
@@ -1849,7 +1846,11 @@ L.Control.Menubar = L.Control.extend({
 				} else if (type === 'action') { // disable all except allowedViewModeActions
 					var found = false;
 					for (var i in self.options.allowedViewModeActions) {
-						if (self.options.allowedViewModeActions[i] === id) {
+						let action = self.options.allowedViewModeActions[i];
+						if (typeof action === "string" && action === id) {
+							found = true;
+							break;
+						} else if (typeof action === "function" && action() === id) {
 							found = true;
 							break;
 						}

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1713,7 +1713,7 @@ void DocumentBroker::handleSaveResponse(const std::shared_ptr<ClientSession>& se
     // wasModified is only set when LOKit saves the document.
     // If the document was modified before saving, it would
     // be true. Otherwise, it's false. Meaningful when forced
-    // saving (i.e. dontSaveIfUnmodified=false), otherwise
+    // saving (i.e. dontSaveIfUnmodified=0), otherwise
     // result is blank in that case and we can't know if
     // the document saved was modified or not.
     if (json->has("wasModified"))

--- a/wsd/protocol.txt
+++ b/wsd/protocol.txt
@@ -249,9 +249,9 @@ uno <command> [arguments]
 
 save dontTerminateEdit=<value> dontSaveIfUnmodified=<value>
 
-    A wrapper over UNO save command. A non-zero <value> is considered true.
-    'dontTerminateEdit' means not terminating the edit session in
-    spreadsheets when saving the document. In most cases, you should set it to
+    A wrapper over UNO save command. A non-zero integer <value> is considered true (non-integer
+    values such as 'true' are not allowed). 'dontTerminateEdit' means not terminating the edit
+    session in spreadsheets when saving the document. In most cases, you should set it to
     non-zero. 'dontSaveIfUnmodified' when set to non-zero skips saving the document when it is
     unmodified.
 


### PR DESCRIPTION
When we switch apps, we previously always saved the document. This causes trouble with some documents, such as PDFs, that can't be saved. When we try, the save fails and we cause an error popup.

Instead, let's not save the document when we switch apps and aren't in edit mode. To avoid missing any saves, we should also save the document when we leave edit mode.


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

