### PR TITLE
fix(android): don't start drag on unmoving tap

### DIFF
--- a/browser/src/canvas/CanvasSectionContainer.ts
+++ b/browser/src/canvas/CanvasSectionContainer.ts
@@ -1261,9 +1261,11 @@ class CanvasSectionContainer {
 		this.stopLongPress();
 		if (!this.multiTouch) {
 			this.mousePosition = this.convertPositionToCanvasLocale(e);
-			this.draggingSomething = true;
 
 			this.dragDistance = [this.mousePosition[0] - this.positionOnMouseDown[0], this.mousePosition[1] - this.positionOnMouseDown[1]];
+
+			if (this.dragDistance[0] ** 2 + this.dragDistance[1] ** 2 > 0.1)
+				this.draggingSomething = true;
 
 			var section: CanvasSectionObject = this.getSectionWithName(this.sectionOnMouseDown);
 			if (section) {

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -3358,8 +3358,13 @@ L.CanvasTileLayer = L.Layer.extend({
 	// Update cursor layer (blinking cursor).
 	_onUpdateCursor: function (scroll, zoom, keepCaretPositionRelativeToScreen) {
 
-		if (!app.file.textCursor.visible ||
-			this._map.ignoreCursorUpdate()) {
+		if (this._map.ignoreCursorUpdate()) {
+			return;
+		}
+
+		if (!app.file.textCursor.visible) {
+			this._updateCursorAndOverlay();
+			app.definitions.otherViewCursorSection.updateVisibilities(true);
 			return;
 		}
 


### PR DESCRIPTION
This is a trivial backport of https://github.com/CollaboraOnline/online/pull/9824, it's needed for the upcoming android release, which is why there is a backport

---

### fix(android): don't start drag on unmoving tap

Previously in impress we would always start a drag no matter how little
a tap had moved. This commonly inhibited us from tapping into a text
field to edit it, particularly when we didn't have something else
selected first.

I wondered for a little while about detecting whether the tap brought up
the keyboard, but it seems that by the time we know that it's already
too late. This tap distance detection seems reliable while also being
very simple to implement, and a drag of less than 0.1 would be an
unrealistically small drag anyway.

---

Additionally, 

### fix(cursor): hide on cursorvisible: false

Previously when we got a `cursorvisible: false` message from COOLWSD, we
would set `app.file.textCursor.visible` to `false` and then attempt to
update the cursor.

Unfortunately, updating the cursor was disabled when
`app.file.textCursor.visible` was false, leading to the cursor not being
hidden. This could lead to issues, e.g. where on Android your keyboard
and cursor would be shown but you would not be able to type anything,
leading to frustration...

We can still short-circuit through most of the cursor update logic, but
we should make sure to run `this._updateCursorAndOverlay` (which
actually hides the cursor, and is normally run after the rest of the
cursor invalidation/updating)