### PR TITLE
cool#9621: Resolve POST fileserver request

### DIFF
--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -1256,12 +1256,6 @@ public:
     }
 
     /// Remove the first @count bytes from input buffer
-    void eraseFirstInputBytes(const MessageMap &map)
-    {
-        eraseFirstInputBytes(map._headerSize);
-    }
-
-    /// Remove the first @count bytes from input buffer
     void eraseFirstInputBytes(const std::size_t count)
     {
         size_t toErase = std::min(count, _inBuffer.size());

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -763,10 +763,6 @@ void ClientRequestDispatcher::handleIncomingMessage(SocketDisposition& dispositi
 
                     launchAsyncCheckFileInfo(_id, accessDetails, RequestVettingStations);
                 }
-                if (request.getMethod() == Poco::Net::HTTPRequest::HTTP_POST)
-                {
-                    socket->shutdown();
-                }
                 served = true;
             }
 
@@ -930,9 +926,9 @@ void ClientRequestDispatcher::handleIncomingMessage(SocketDisposition& dispositi
         return;
     }
 
-    // if we succeeded - remove the request from our input buffer
-    // we expect one request per socket
-    socket->eraseFirstInputBytes(map);
+    // If we succeeded - remove the complete request message from our input buffer
+    // We expect multiple requests per socket
+    socket->eraseFirstInputBytes(map._messageSize);
 #else // !MOBILEAPP
     Poco::Net::HTTPRequest request;
 

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -694,7 +694,7 @@ void FileServerRequestHandler::handleRequest(const HTTPRequest& request,
                     response.set("Content-Encoding", "br");
                 }
 
-                HttpHelper::sendFile(socket, filePath, response, noCache); // shutdown by caller
+                HttpHelper::sendFile(socket, filePath, response, noCache);
                 return;
             }
 #endif
@@ -779,7 +779,7 @@ void FileServerRequestHandler::sendError(http::StatusCode errorCode,
             longMessage + ' ' + pathSanitized + '\n' +
             "Please contact your system administrator.";
     }
-    HttpHelper::sendError(errorCode, socket, body, headers);
+    HttpHelper::sendErrorAndShutdown(errorCode, socket, body, headers);
 }
 
 void FileServerRequestHandler::readDirToHash(const std::string &basePath, const std::string &path, const std::string &prefix)


### PR DESCRIPTION
* Resolves: #9621 POST fileserver request
* Target version: master 

Change-Id: I7db359aeb7773733f817a31e8777e076b8cd4408

### Summary
cool#9621: Resolve POST fileserver request, commit 6e4d2b2350100367f780664a4c5af1f5d7702488
    
Commit 6e4d2b2350100367f780664a4c5af1f5d7702488 mitigated the issue of
wrongly handled POST requests in ClientRequestDispatcher::handleIncomingMessage()
by simply shutting down the socket (non keep-alive socket).
   
This patch resolves the issue by removing the complete HTTP request
including the optional HTTP POST body from the socket's buffer,
i.e. removing map._messageSize bytes.
    
It also includes a fix in StreamSocket::parseHeader()
of only adjusting map._messageSize w/ contentLength if the latter is valid.
    
Hence we also allow reusing the given socket connection
for POST HTTP requests including mixing POST and GET.    

### Checklist

- [X] I have run `make prettier-write` and formatted the code.
- [X] All commits have Change-Id
- [X] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

