### PR TITLE
Fix build in clang

### DIFF
--- a/test/HttpRequestTests.cpp
+++ b/test/HttpRequestTests.cpp
@@ -310,7 +310,7 @@ void HttpRequestTests::testSimpleGet()
 
         std::unique_lock<std::mutex> lock(mutex);
 
-        httpSession->setConnectFailHandler([this]() {
+        httpSession->setConnectFailHandler([]() {
             LOK_ASSERT(false);
         });
 
@@ -534,7 +534,7 @@ void HttpRequestTests::test500GetStatuses()
         std::unique_lock<std::mutex> lock(mutex);
         timedout = true; // Assume we timed out until we prove otherwise.
 
-        httpSession->setConnectFailHandler([this]() {
+        httpSession->setConnectFailHandler([]() {
             LOK_ASSERT(false);
         });
 
@@ -627,7 +627,7 @@ void HttpRequestTests::testSimplePost_External()
 
     std::unique_lock<std::mutex> lock(mutex);
 
-    httpSession->setConnectFailHandler([this]() {
+    httpSession->setConnectFailHandler([]() {
         LOK_ASSERT(false);
     });
 

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -46,7 +46,7 @@
 // Forwards.
 class PrisonerRequestDispatcher;
 class DocumentBroker;
-struct LockContext;
+class LockContext;
 class TileCache;
 class Message;
 


### PR DESCRIPTION
Some older PR was not compatible.

There was old check of success introduced in
commit 76fded3ef0065a04753422ba8b2910802943efcb
wsd: check for asyncRequest success for uploading

but in the meantime we have new callback for connection
fail what requires change from us:

commit f6ce37b579c1753e61a71788a78bb25d5d60eb1d
hook Session::asyncRequest up to use net::asyncConnect
calls _onConnectFail on async connect fail instead of returning false on
sync connect fail

So let's not use scoped callback trigger but rather do it manually
on returns and in the fail callback. Successfull one is already
done this way. Notice: on success we were firing it two times:
on Running state and Complete. Running doesn't happen if we fail
on connection...
