### PR TITLE
cypress: fix errors due to missing a11y handling

### DIFF
--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -691,6 +691,27 @@ function getInitializerClass() {
 		},
 	};
 
+	global.getAccessibilityState = function () {
+		var isCalcTest =
+			global.docURL.includes('data/desktop/calc/') ||
+			global.docURL.includes('data/mobile/calc/') ||
+			global.docURL.includes('data/idle/calc/') ||
+			global.docURL.includes('data/multiuser/calc/');
+
+		// FIXME: a11y doesn't work in calc under cypress
+		if (L.Browser.cypressTest && isCalcTest)
+			global.enableAccessibility = false;
+
+		if (L.Browser.cypressTest) {
+			global.prefs.set('accessibilityState', global.enableAccessibility);
+			global.app.accessibilityState = global.enableAccessibility;
+		}
+
+		var accessibilityState = global.prefs.getBoolean('accessibilityState');
+		global.app.accessibilityState = accessibilityState;
+		return accessibilityState;
+	};
+
 	// Renamed in 24.04.4.1
 	const prefDocTypes = ['text', 'spreadsheet', 'presentation', 'drawing'];
 	for (const docType of prefDocTypes) {
@@ -1589,17 +1610,7 @@ function getInitializerClass() {
 				var now2 = Date.now();
 				global.socket.send('coolclient ' + ProtocolVersionNumber + ' ' + ((now0 + now2) / 2) + ' ' + now1);
 
-				var isCalcTest =
-					global.docURL.includes('data/desktop/calc/') ||
-					global.docURL.includes('data/mobile/calc/') ||
-					global.docURL.includes('data/idle/calc/') ||
-					global.docURL.includes('data/multiuser/calc/');
-
-				if (L.Browser.cypressTest && isCalcTest)
-					global.enableAccessibility = false;
-
-				var accessibilityState = global.prefs.getBoolean('accessibilityState');
-				accessibilityState = accessibilityState || (L.Browser.cypressTest && !isCalcTest);
+				var accessibilityState = global.getAccessibilityState();
 				msg += ' accessibilityState=' + accessibilityState;
 
 				if (global.ThisIsAMobileApp) {

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -221,7 +221,7 @@ L.Control.UIManager = L.Control.extend({
 		var enableNotebookbar = this.shouldUseNotebookbarMode();
 		var that = this;
 
-		this.map._accessibilityState = window.prefs.getBoolean('accessibilityState');
+		app.accessibilityState = window.prefs.getBoolean('accessibilityState');
 
 		if (window.mode.isMobile() || !enableNotebookbar) {
 			var menubar = L.control.menubar();

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -972,19 +972,4 @@ L.Map.include({
 		if (this.formulabar)
 			this.formulabar.dirty = true;
 	},
-
-	setAccessibilityState: function(enable) {
-		if (this._accessibilityState === enable)
-			return;
-		this._accessibilityState = enable;
-		app.socket.sendMessage('a11ystate ' + enable);
-
-		this.removeLayer(this._textInput);
-		this._textInput = enable ? L.a11yTextInput() : L.textInput();
-		this.addLayer(this._textInput);
-		if (enable) {
-			this._textInput._requestFocusedParagraph();
-		}
-		this._textInput.showCursor();
-	},
 });

--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -252,17 +252,7 @@ app.definitions.Socket = L.Class.extend({
 		msg += ' darkBackground=' + darkBackground;
 		this._map.uiManager.initDarkBackgroundUI(darkBackground);
 
-		var isCalcTest =
-			window.docURL.includes('data/desktop/calc/') ||
-			window.docURL.includes('data/mobile/calc/') ||
-			window.docURL.includes('data/idle/calc/') ||
-			window.docURL.includes('data/multiuser/calc/');
-
-		if (L.Browser.cypressTest && isCalcTest)
-			window.enableAccessibility = false;
-
-		var accessibilityState = window.prefs.getBoolean('accessibilityState');
-		accessibilityState = accessibilityState || (L.Browser.cypressTest && !isCalcTest);
+		var accessibilityState = window.getAccessibilityState();
 		msg += ' accessibilityState=' + accessibilityState;
 
 		this._doSend(msg);

--- a/browser/src/docstate.js
+++ b/browser/src/docstate.js
@@ -33,6 +33,7 @@ window.app = {
 	dispatcher: null, // A Dispatcher class instance is assigned to this.
 	twipsToPixels: 0, // Twips to pixels multiplier.
 	pixelsToTwips: 0, // Pixels to twips multiplier.
+	accessibilityState: false, // If accessibility was enabled by user
 	UI: {
 		language: {
 			fromURL: window.langParam, // This is set in global.js.

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1553,7 +1553,7 @@ L.CanvasTileLayer = L.Layer.extend({
 			this._map.fire('versionbar', obj);
 		}
 		else if (textMsg.startsWith('a11y')) {
-			if (!app.map || !app.map._accessibilityState)
+			if (!app.accessibilityState)
 				throw 'A11y events come from the core while it is disabled in the client session.';
 
 			if (textMsg.startsWith('a11yfocuschanged:')) {

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1552,50 +1552,55 @@ L.CanvasTileLayer = L.Layer.extend({
 			obj = JSON.parse(textMsg.substring('versionbar:'.length + 1));
 			this._map.fire('versionbar', obj);
 		}
-		else if (textMsg.startsWith('a11yfocuschanged:')) {
-			obj = JSON.parse(textMsg.substring('a11yfocuschanged:'.length + 1));
-			var listPrefixLength = obj.listPrefixLength !== undefined ? parseInt(obj.listPrefixLength) : 0;
-			this._map._textInput.onAccessibilityFocusChanged(
-				obj.content, parseInt(obj.position), parseInt(obj.start), parseInt(obj.end),
-				listPrefixLength, parseInt(obj.force) > 0);
-		}
-		else if (textMsg.startsWith('a11ycaretchanged:')) {
-			obj = JSON.parse(textMsg.substring('a11yfocuschanged:'.length + 1));
-			this._map._textInput.onAccessibilityCaretChanged(parseInt(obj.position));
-		}
-		else if (textMsg.startsWith('a11ytextselectionchanged:')) {
-			obj = JSON.parse(textMsg.substring('a11ytextselectionchanged:'.length + 1));
-			this._map._textInput.onAccessibilityTextSelectionChanged(parseInt(obj.start), parseInt(obj.end));
-		}
-		else if (textMsg.startsWith('a11yfocusedcellchanged:')) {
-			obj = JSON.parse(textMsg.substring('a11yfocusedcellchanged:'.length + 1));
-			var outCount = obj.outCount !== undefined ? parseInt(obj.outCount) : 0;
-			var inList = obj.inList !== undefined ? obj.inList : [];
-			var row = parseInt(obj.row);
-			var col = parseInt(obj.col);
-			var rowSpan = obj.rowSpan !== undefined ? parseInt(obj.rowSpan) : 1;
-			var colSpan = obj.colSpan !== undefined ? parseInt(obj.colSpan) : 1;
-			this._map._textInput.onAccessibilityFocusedCellChanged(
-				outCount, inList, row, col, rowSpan, colSpan, obj.paragraph);
-		}
-		else if (textMsg.startsWith('a11yeditinginselectionstate:')) {
-			obj = JSON.parse(textMsg.substring('a11yeditinginselectionstate:'.length + 1));
-			this._map._textInput.onAccessibilityEditingInSelectionState(
-				parseInt(obj.cell) > 0, parseInt(obj.enabled) > 0, obj.selection, obj.paragraph);
-		}
-		else if (textMsg.startsWith('a11yselectionchanged:')) {
-			obj = JSON.parse(textMsg.substring('a11yselectionchanged:'.length + 1));
-			this._map._textInput.onAccessibilitySelectionChanged(
-				parseInt(obj.cell) > 0, obj.action, obj.name, obj.text);
-		}
-		else if (textMsg.startsWith('a11yfocusedparagraph:')) {
-			obj = JSON.parse(textMsg.substring('a11yfocusedparagraph:'.length + 1));
-			this._map._textInput.setA11yFocusedParagraph(
-				obj.content, parseInt(obj.position), parseInt(obj.start), parseInt(obj.end));
-		}
-		else if (textMsg.startsWith('a11ycaretposition:')) {
-			var pos = textMsg.substring('a11ycaretposition:'.length + 1);
-			this._map._textInput.setA11yCaretPosition(parseInt(pos));
+		else if (textMsg.startsWith('a11y')) {
+			if (!app.map || !app.map._accessibilityState)
+				throw 'A11y events come from the core while it is disabled in the client session.';
+
+			if (textMsg.startsWith('a11yfocuschanged:')) {
+				obj = JSON.parse(textMsg.substring('a11yfocuschanged:'.length + 1));
+				var listPrefixLength = obj.listPrefixLength !== undefined ? parseInt(obj.listPrefixLength) : 0;
+				this._map._textInput.onAccessibilityFocusChanged(
+					obj.content, parseInt(obj.position), parseInt(obj.start), parseInt(obj.end),
+					listPrefixLength, parseInt(obj.force) > 0);
+			}
+			else if (textMsg.startsWith('a11ycaretchanged:')) {
+				obj = JSON.parse(textMsg.substring('a11yfocuschanged:'.length + 1));
+				this._map._textInput.onAccessibilityCaretChanged(parseInt(obj.position));
+			}
+			else if (textMsg.startsWith('a11ytextselectionchanged:')) {
+				obj = JSON.parse(textMsg.substring('a11ytextselectionchanged:'.length + 1));
+				this._map._textInput.onAccessibilityTextSelectionChanged(parseInt(obj.start), parseInt(obj.end));
+			}
+			else if (textMsg.startsWith('a11yfocusedcellchanged:')) {
+				obj = JSON.parse(textMsg.substring('a11yfocusedcellchanged:'.length + 1));
+				var outCount = obj.outCount !== undefined ? parseInt(obj.outCount) : 0;
+				var inList = obj.inList !== undefined ? obj.inList : [];
+				var row = parseInt(obj.row);
+				var col = parseInt(obj.col);
+				var rowSpan = obj.rowSpan !== undefined ? parseInt(obj.rowSpan) : 1;
+				var colSpan = obj.colSpan !== undefined ? parseInt(obj.colSpan) : 1;
+				this._map._textInput.onAccessibilityFocusedCellChanged(
+					outCount, inList, row, col, rowSpan, colSpan, obj.paragraph);
+			}
+			else if (textMsg.startsWith('a11yeditinginselectionstate:')) {
+				obj = JSON.parse(textMsg.substring('a11yeditinginselectionstate:'.length + 1));
+				this._map._textInput.onAccessibilityEditingInSelectionState(
+					parseInt(obj.cell) > 0, parseInt(obj.enabled) > 0, obj.selection, obj.paragraph);
+			}
+			else if (textMsg.startsWith('a11yselectionchanged:')) {
+				obj = JSON.parse(textMsg.substring('a11yselectionchanged:'.length + 1));
+				this._map._textInput.onAccessibilitySelectionChanged(
+					parseInt(obj.cell) > 0, obj.action, obj.name, obj.text);
+			}
+			else if (textMsg.startsWith('a11yfocusedparagraph:')) {
+				obj = JSON.parse(textMsg.substring('a11yfocusedparagraph:'.length + 1));
+				this._map._textInput.setA11yFocusedParagraph(
+					obj.content, parseInt(obj.position), parseInt(obj.start), parseInt(obj.end));
+			}
+			else if (textMsg.startsWith('a11ycaretposition:')) {
+				var pos = textMsg.substring('a11ycaretposition:'.length + 1);
+				this._map._textInput.setA11yCaretPosition(parseInt(pos));
+			}
 		}
 		else if (textMsg.startsWith('colorpalettes:')) {
 			var json = JSON.parse(textMsg.substring('colorpalettes:'.length + 1));


### PR DESCRIPTION
regression from commit e36d6ffb9b13ffd440744425da128a9446530f01 fix: fix UI preference inconsistencies

where we introduced second place where enableAccessibility is controlled. This caused that we were out of sync in few places so we used regular TextInput while having a11y enabled...

We got bunch of this._map._textInput.onAccessibilityFocusChanged is not a function

This was visible only after we added additional dialogs/errors on unhandled exceptions inside cypress recently.