### PR TITLE
Fix Calc: cannot see the cell cursor after "insert sheet before"

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -989,6 +989,15 @@ L.CanvasTileLayer = L.Layer.extend({
 		this._onCurrentPageUpdate();
 	},
 
+	_isLatLngInView: function (position) {
+		var centerOffset = this._map._getCenterOffset(position);
+		var viewHalf = this._map._getCenterLayerPoint();
+		var positionInView =
+			centerOffset.x > -viewHalf.x && centerOffset.x < viewHalf.x &&
+			centerOffset.y > -viewHalf.y && centerOffset.y < viewHalf.y;
+		return positionInView;
+	},
+
 	_moveEnd: function () {
 		this._move();
 		this._moveInProgress = false;
@@ -1000,12 +1009,7 @@ L.CanvasTileLayer = L.Layer.extend({
 				var cursorPos = this._map._docLayer._twipsToLatLng({ x: app.calc.cellCursorRectangle.x2, y: app.calc.cellCursorRectangle.y2 });
 			else
 				cursorPos = this._map._docLayer._twipsToLatLng({ x: app.file.textCursor.rectangle.x2, y: app.file.textCursor.rectangle.y2 });
-
-			var centerOffset = this._map._getCenterOffset(cursorPos);
-			var viewHalf = this._map.getSize()._divideBy(2);
-			var cursorPositionInView =
-				centerOffset.x > -viewHalf.x && centerOffset.x < viewHalf.x &&
-				centerOffset.y > -viewHalf.y && centerOffset.y < viewHalf.y;
+			var cursorPositionInView = this._isLatLngInView(cursorPos);
 			if (parseInt(app.getFollowedViewId()) === parseInt(this._viewId) && !cursorPositionInView) {
 				app.setFollowingOff();
 			} else if (parseInt(app.getFollowedViewId()) === -1 && cursorPositionInView) {
@@ -4022,11 +4026,7 @@ L.CanvasTileLayer = L.Layer.extend({
 				&& this._map._docLayer._cursorMarker && this._map._docLayer._cursorMarker.isDomAttached();
 			if (!heightIncreased && isTabletOrMobile && this._map._docLoaded && hasVisibleCursor) {
 				var cursorPos = this._map._docLayer._twipsToLatLng({ x: app.file.textCursor.rectangle.x1, y: app.file.textCursor.rectangle.y2 });
-				var centerOffset = this._map._getCenterOffset(cursorPos);
-				var viewHalf = this._map.getSize()._divideBy(2);
-				var cursorPositionInView =
-					centerOffset.x > -viewHalf.x && centerOffset.x < viewHalf.x &&
-					centerOffset.y > -viewHalf.y && centerOffset.y < viewHalf.y;
+				var cursorPositionInView = this._isLatLngInView(cursorPos);
 				if (!cursorPositionInView)
 					this._map.panTo(cursorPos);
 			}

--- a/browser/src/map/Map.js
+++ b/browser/src/map/Map.js
@@ -1311,7 +1311,12 @@ L.Map = L.Evented.extend({
 			this.fire('zoomlevelschange');
 		}
 
+		// don't allow to turn off the following when moving to other sheet
+		var backupFollowed = app.getFollowedViewId();
+
 		this.fire('moveend', {hard: !preserveMapOffset});
+
+		app.setFollowingUser(backupFollowed);
 	},
 
 	_rawPanBy: function (offset) {

--- a/cypress_test/integration_tests/desktop/calc/cell_cursor_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/cell_cursor_spec.js
@@ -35,6 +35,19 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Test jumping on large cell
 		cy.cGet('input#addressInput-input').should('have.prop', 'value', 'A10');
 		desktopHelper.assertScrollbarPosition('horizontal', 40, 60);
 	});
+
+	it('Show cursor on sheet insertion', function() {
+		// scroll down
+		cy.cGet('input#addressInput-input').type('{selectAll}A110{enter}');
+		desktopHelper.assertScrollbarPosition('vertical', 205, 315);
+
+		// insert sheet before
+		calcHelper.selectOptionFromContextMenu('Insert sheet before this');
+
+		// we should see the top left corner of the sheet
+		cy.cGet('input#addressInput-input').should('have.prop', 'value', 'A1');
+		desktopHelper.assertScrollbarPosition('vertical', 0, 30);
+	});
 });
 
 describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Test jumping on large cell selection with split panes', function() {


### PR DESCRIPTION
Fixes #9783

Calc: don't force view reset if not needed
    
Fixes #9783 :
Calc: cannot see the cell cursor after "insert sheet before"

Steps to Reproduce:
1. Go to Calc
2. Scroll to around 100 row
3. Right-click on a sheet tab, Insert sheet before

Expected Behavior:
We should see new sheet with visible cursor at A1

Actual Behavior:
We don't see A1 but in my case row 25. Might depend on window size.

In case when new sheet has bigger size than a visible area - we
were forcing view reset by bounds update which caused view jump.
We were jumping outside of cursor visibility so user following
was disabled and in the end user was not able to see own cursor.

Related to the following functionality change in:
commit df158a9
calc: don't jump to own cursor if not looking