### PR TITLE
survive if config.xml is missing indirection_endpoint.geolocation_set…

### DIFF
--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -2192,6 +2192,7 @@ void COOLWSD::innerInitialize(Application& self)
         { "deepl.auth_key", "" },
         { "deepl.enabled", "false" },
         { "zotero.enable", "true" },
+        { "indirection_endpoint.geolocation_setup.enable", "false" },
         { "indirection_endpoint.url", "" },
 #if !MOBILEAPP
         { "help_url", HELP_URL },

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -1368,7 +1368,7 @@ FileServerRequestHandler::ResourceAccessDetails FileServerRequestHandler::prepro
     Poco::URI indirectionURI(config.getString("indirection_endpoint.url", ""));
     Poco::replaceInPlace(preprocess, std::string("%INDIRECTION_URL%"), indirectionURI.toString());
 
-    bool geoLocationSetup = config.getBool("indirection_endpoint.geolocation_setup.enable");
+    bool geoLocationSetup = config.getBool("indirection_endpoint.geolocation_setup.enable", false);
     if (geoLocationSetup)
         Poco::replaceInPlace(preprocess, std::string("%GEOLOCATION_SETUP%"),
                              boolToString(geoLocationSetup));


### PR DESCRIPTION
…up.enable

which an old config will not have and results in failure to connect as exception is thrown


Change-Id: Ic2c9f66aa180251c90424578eb6cc2cd5aaecb09


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

