### PR TITLE
result of cap_get_proc should be released with cap_free

### DIFF
--- a/kit/ForKit.cpp
+++ b/kit/ForKit.cpp
@@ -199,9 +199,9 @@ protected:
 #ifndef __FreeBSD__
 static bool haveCapability(cap_value_t capability)
 {
-    cap_t caps = cap_get_proc();
-
-    if (caps == nullptr)
+    using ScopedCaps = std::unique_ptr<std::remove_pointer<cap_t>::type, int (*)(void*)>;
+    ScopedCaps caps(cap_get_proc(), cap_free);
+    if (!caps)
     {
         LOG_SFL("cap_get_proc() failed");
         return false;
@@ -210,7 +210,7 @@ static bool haveCapability(cap_value_t capability)
     char *cap_name = cap_to_name(capability);
     cap_flag_value_t value;
 
-    if (cap_get_flag(caps, capability, CAP_EFFECTIVE, &value) == -1)
+    if (cap_get_flag(caps.get(), capability, CAP_EFFECTIVE, &value) == -1)
     {
         if (cap_name)
         {


### PR DESCRIPTION
```
Direct leak of 104 byte(s) in 1 object(s) allocated from:
    #0 0x8a2200 in __interceptor_calloc
    #1 0x7f6fc253d114 in cap_init (/usr/lib64/libcap.so.2+0x3114)
    #2 0xaa6b57 in haveCorrectCapabilities() kit/ForKit.cpp:261:10
    #3 0xa9e77e in forkit_main(int, char**) kit/ForKit.cpp:778:50
    #4 0x110a0ad in main kit/forkit-main.cpp:19:12
    #5 0x7f6fc1bb424c in __libc_start_main (/lib64/libc.so.6+0x3524c)
```

Change-Id: I74f8c01f3e5db12a690fa9fbfcd858fe0740f16e


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

