### PR TITLE
fix format > columns menu misaligned style text

### DIFF
--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -79,7 +79,7 @@ button.jsdialog img {
 :not(.main-nav) > div > button:not(.ui-tab):not(.ui-corner-all):not(.button-primary):not(.unobutton):not(.form-field-button):not(.col) {
 	box-sizing: border-box;
 	height: 32px;
-	line-height: 0em;
+	line-height: normal;
 	color: var(--color-main-text);
 	font-size: var(--default-font-size);
 	min-width: 62px;


### PR DESCRIPTION
Change-Id: Icdac9332fcd9584dc004f98a52772da041ff8496


* Resolves: #7591
* Target version: master 

### Summary

When "None" is selected for the Columns style, the text is misaligned with the arrow.

![image](https://github.com/user-attachments/assets/69299393-e563-428c-9cc5-2cb170b9b948)