### PR TITLE
Async Lock Refreshing

### DIFF
--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1604,8 +1604,9 @@ bool ClientSession::filterMessage(const std::string& message) const
 void ClientSession::setReadOnly(bool bVal)
 {
     Session::setReadOnly(bVal);
-    // Also inform the client
-    const std::string sPerm = bVal ? "readonly" : "edit";
+
+    // Also inform the client.
+    const std::string sPerm = isReadOnly() ? "readonly" : "edit";
     sendTextFrame("perm: " + sPerm);
 }
 

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1120,9 +1120,10 @@ void DocumentBroker::lockIfEditing(const std::shared_ptr<ClientSession>& session
             std::string error;
             if (!updateStorageLockState(*session, StorageBase::LockState::LOCK, error))
             {
-                LOG_ERR("Failed to lock docKey [" << _docKey << "] with session ["
-                                                  << session->getId()
-                                                  << "] after downloading: " << error);
+                LOG_ERR("Failed to lock docKey ["
+                        << _docKey << "] with session [" << session->getId()
+                        << "] before downloading. Session will be read-only: " << error);
+                session->setWritable(false);
             }
         }
 

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -471,8 +471,10 @@ void DocumentBroker::pollThread()
             _admin.addBytes(getDocKey(), deltaSent, deltaRecv);
         }
 
-        if (_storage && _lockCtx->needsRefresh(now))
+        if (_storage && !_lockStateUpdateRequest && _lockCtx->needsRefresh(now))
+        {
             refreshLock();
+        }
 #endif
 
         LOG_TRC("Poll: current activity: " << DocumentState::name(_docState.activity()));
@@ -1617,6 +1619,111 @@ bool DocumentBroker::updateStorageLockState(ClientSession& session, StorageBase:
     return false;
 }
 
+bool DocumentBroker::updateStorageLockStateAsync(const std::shared_ptr<ClientSession>& session,
+                                                 StorageBase::LockState lock, std::string& error)
+{
+    LOG_TRC("Requesting async " << (lock == StorageBase::LockState::LOCK ? "Locking" : "Unlocking")
+                                << " of [" << _docKey << "] by session #" << session->getId());
+
+    if (session->getAuthorization().isExpired())
+    {
+        error = "Expired authorization token";
+        return false;
+    }
+
+    if (lock == StorageBase::LockState::LOCK && session->isReadOnly())
+    {
+        // Readonly sessions cannot lock, only editors can.
+        error = "Readonly session";
+        return false;
+    }
+
+    if (_lockStateUpdateRequest)
+    {
+        error = "A lock-update request is already in progress";
+        return false;
+    }
+
+    // Do *not* capture the session shared_ptr, to let it close if necessary.
+    // Instead, we capture a weak_ptr, which allows for graceful cleanup of closed sesssions.
+    StorageBase::AsyncLockStateCallback asyncLockCallback =
+        [this](const StorageBase::AsyncLockUpdate& asyncLock)
+    {
+        if (!_lockStateUpdateRequest)
+        {
+            LOG_ERR("There is no asynchronous lock-state update request to process callback");
+            return;
+        }
+
+        if (asyncLock.state() == StorageBase::AsyncLockUpdate::State::Running)
+        {
+            LOG_TRC("Async locking of [" << _docKey << "] is in progress during "
+                                         << DocumentState::name(_docState.activity()));
+            return;
+        }
+
+        const std::shared_ptr<ClientSession> requestingSession = _lockStateUpdateRequest->session();
+        _lockStateUpdateRequest.reset(); // No longer needed.
+
+        // We have some result, look at the result status.
+        const StorageBase::LockState requestedLock = asyncLock.result().requestedLockState();
+        switch (asyncLock.result().getStatus())
+        {
+            case StorageBase::LockUpdateResult::Status::UNSUPPORTED:
+                LOG_DBG("Locks on docKey [" << _docKey << "] are unsupported while trying to "
+                                            << StorageBase::name(requestedLock));
+                return; // Not an error.
+                break;
+
+            case StorageBase::LockUpdateResult::Status::OK:
+                LOG_DBG((requestedLock == StorageBase::LockState::LOCK ? "Locked" : "Unlocked")
+                        << " docKey [" << _docKey << "] successfully");
+                return;
+                break;
+
+            case StorageBase::LockUpdateResult::Status::UNAUTHORIZED:
+            {
+                LOG_ERR("Failed to "
+                        << (requestedLock == StorageBase::LockState::LOCK ? "Locked" : "Unlocked")
+                        << " docKey [" << _docKey
+                        << "]. Invalid or expired access token. Notifying client and "
+                           "invalidating the authorization token of session ["
+                        << requestingSession->getId() << "]. This session will now be read-only");
+                requestingSession->invalidateAuthorizationToken();
+                if (requestedLock == StorageBase::LockState::LOCK)
+                {
+                    // If we can't unlock, we don't want to set the document to read-only mode.
+                    requestingSession->setLockFailed(asyncLock.result().getReason());
+                }
+            }
+            break;
+
+            case StorageBase::LockUpdateResult::Status::FAILED:
+            {
+                LOG_ERR("Failed to "
+                        << (requestedLock == StorageBase::LockState::LOCK ? "Locked" : "Unlocked")
+                        << " docKey [" << _docKey << "] with reason ["
+                        << asyncLock.result().getReason()
+                        << "]. Notifying client and making session [" << requestingSession->getId()
+                        << "] read-only");
+
+                if (requestedLock == StorageBase::LockState::LOCK)
+                {
+                    // If we can't unlock, we don't want to set the document to read-only mode.
+                    requestingSession->setLockFailed(asyncLock.result().getReason());
+                }
+            }
+            break;
+        }
+    };
+
+    _lockStateUpdateRequest = std::make_unique<LockStateUpdateRequest>(lock, session);
+
+    _storage->updateLockStateAsync(session->getAuthorization(), *_lockCtx, lock,
+                                   _currentStorageAttrs, *_poll, asyncLockCallback);
+    return true;
+}
+
 bool DocumentBroker::attemptLock(ClientSession& session, std::string& failReason)
 {
     return updateStorageLockState(session, StorageBase::LockState::LOCK, failReason);
@@ -2502,7 +2609,7 @@ void DocumentBroker::refreshLock()
         LOG_TRC("Refresh lock " << _lockCtx->lockToken() << " with session [" << savingSessionId
                                 << ']');
         std::string error;
-        if (!updateStorageLockState(*session, StorageBase::LockState::LOCK, error))
+        if (!updateStorageLockStateAsync(session, StorageBase::LockState::LOCK, error))
         {
             LOG_ERR("Failed to refresh lock of docKey [" << _docKey << "] with session ["
                                                          << savingSessionId << "]: " << error);

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -389,6 +389,7 @@ public:
     /// Update the locking state (check-in/out) of the associated file asynchronously.
     virtual void updateLockStateAsync(const Authorization& auth, LockContext& lockCtx,
                                       LockState lock, const Attributes& attribs,
+                                      SocketPoll& socketPoll,
                                       const AsyncLockStateCallback& asyncLockStateCallback) = 0;
 
     /// Returns a local file path for the given URI.
@@ -532,8 +533,14 @@ public:
     }
 
     void updateLockStateAsync(const Authorization&, LockContext&, LockState, const Attributes&,
-                              const AsyncLockStateCallback&) override
+                              SocketPoll&,
+                              const AsyncLockStateCallback& asyncLockStateCallback) override
     {
+        if (asyncLockStateCallback)
+        {
+            asyncLockStateCallback(AsyncLockUpdate(AsyncLockUpdate::State::Complete,
+                                                   LockUpdateResult(LockUpdateResult::Status::OK)));
+        }
     }
 
     std::string downloadStorageFileToLocal(const Authorization& auth, LockContext& lockCtx,

--- a/wsd/wopi/WopiStorage.cpp
+++ b/wsd/wopi/WopiStorage.cpp
@@ -393,8 +393,8 @@ StorageBase::LockUpdateResult WopiStorage::updateLockState(const Authorization& 
             httpSession->syncRequest(httpRequest);
         const std::string responseString = httpResponse->getBody();
 
-        LOG_INF(wopiLog << " response: [" << responseString
-                        << "], status: " << httpResponse->statusLine().statusCode());
+        LOG_INF(wopiLog << " status: " << httpResponse->statusLine().statusCode()
+                        << ", response: " << responseString);
 
         if (httpResponse->statusLine().statusCode() == http::StatusCode::OK)
         {
@@ -503,8 +503,8 @@ void WopiStorage::updateLockStateAsync(const Authorization& auth, LockContext& l
         // Handle the response.
         const std::string responseString = httpResponse->getBody();
 
-        LOG_INF(wopiLog << " response: [" << responseString
-                        << "], status: " << httpResponse->statusLine().statusCode());
+        LOG_INF(wopiLog << " status: " << httpResponse->statusLine().statusCode()
+                        << ", response: " << responseString);
 
         if (httpResponse->statusLine().statusCode() == http::StatusCode::OK)
         {

--- a/wsd/wopi/WopiStorage.hpp
+++ b/wsd/wopi/WopiStorage.hpp
@@ -198,7 +198,7 @@ public:
                                      const Attributes& attribs) override;
 
     void updateLockStateAsync(const Authorization& auth, LockContext& lockCtx, LockState lock,
-                              const Attributes& attribs,
+                              const Attributes& attribs, SocketPoll& socketPoll,
                               const AsyncLockStateCallback& asyncLockStateCallback) override;
 
     /// uri format: http://server/<...>/wopi*/files/<id>/content
@@ -261,6 +261,9 @@ private:
 
     /// The http::Session used for uploading asynchronously.
     std::shared_ptr<http::Session> _uploadHttpSession;
+
+    /// The http::Session used for locking asynchronously.
+    std::shared_ptr<http::Session> _lockHttpSession;
 
     /// Filename converter to UTF-7.
     Util::CharacterConverter _utf7Converter;


### PR DESCRIPTION
- wsd: async updateLockState
- wsd: disable editing when document locking fails
- wsd: LockUpdateResult captures the requested lock state
- wsd: read the readonly flag after writing
- wsd: async lock/unlock documents
- wsd: better logging of http status in WopiStorage
