### PR TITLE
Attempt to use a more precise filter for time field.

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -1478,12 +1478,6 @@ L.Control.JSDialogBuilder = L.Control.extend({
 
 		value = parseFloat(data.value);
 
-		// time formatter or empty field
-		if (data.unit === ':' || (!data.unit && !data.text)) {
-			controls.spinfield.type = undefined;
-			value = data.text;
-		}
-
 		$(controls.spinfield).val(value);
 
 		return false;


### PR DESCRIPTION
Core side PR: https://gerrit.libreoffice.org/c/core/+/172239

The problem:
When there is no unit for the number field, it is treated as time field.
Users with "," as decimal separator have issues when the field type is not set properly.