### PR TITLE
notebookbar: remove menubartoolitems #8029

### DIFF
--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -2005,7 +2005,7 @@ L.Control.Menubar = L.Control.extend({
 		} else if (id === 'closedocument') {
 			window.onClose();
 		} else if (id === 'repair') {
-			app.socket.sendMessage('commandvalues command=.uno:DocumentRepair');
+			app.dispatcher.dispatch('repair');
 		} else if (id === 'searchdialog') {
 			if (this._map.isReadOnlyMode()) {
 				$('#toolbar-down').hide();

--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -1965,7 +1965,7 @@ L.Control.Menubar = L.Control.extend({
 		} else if (id === 'toggleuimode') {
 			app.dispatcher.dispatch('toggleuimode');
 		} else if (id === 'showstatusbar') {
-			this._map.uiManager.toggleStatusBar();
+			app.dispatcher.dispatch('showstatusbar');
 		} else if (id === 'togglemenubar') {
 			this._map.uiManager.toggleMenubar();
 		} else if (id === 'collapsenotebookbar') {

--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -1953,7 +1953,7 @@ L.Control.Menubar = L.Control.extend({
 		} else if (id === 'showresolved') {
 			app.dispatcher.dispatch('.uno:ShowResolvedAnnotations');
 		} else if (id === 'zoomout' && this._map.getZoom() > this._map.getMinZoom()) {
-			this._map.zoomOut(1, null, true /* animate? */);
+			app.dispatcher.dispatch('zoomout');
 		} else if (id === 'zoomreset') {
 			app.dispatcher.dispatch('zoomreset');
 		} else if (id === 'fullscreen') {

--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -1955,7 +1955,7 @@ L.Control.Menubar = L.Control.extend({
 		} else if (id === 'zoomout' && this._map.getZoom() > this._map.getMinZoom()) {
 			this._map.zoomOut(1, null, true /* animate? */);
 		} else if (id === 'zoomreset') {
-			this._map.setZoom(this._map.options.zoom);
+			app.dispatcher.dispatch('zoomreset');
 		} else if (id === 'fullscreen') {
 			L.toggleFullScreen();
 		} else if (id === 'showruler') {

--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -1949,7 +1949,7 @@ L.Control.Menubar = L.Control.extend({
 		} else if (id === 'selectbackground') {
 			L.DomUtil.get('selectbackground').click();
 		} else if (id === 'zoomin' && this._map.getZoom() < this._map.getMaxZoom()) {
-			this._map.zoomIn(1, null, true /* animate? */);
+			app.dispatcher.dispatch('zoomin');
 		} else if (id === 'showresolved') {
 			app.dispatcher.dispatch('.uno:ShowResolvedAnnotations');
 		} else if (id === 'zoomout' && this._map.getZoom() > this._map.getMinZoom()) {

--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -1959,7 +1959,7 @@ L.Control.Menubar = L.Control.extend({
 		} else if (id === 'fullscreen') {
 			L.toggleFullScreen();
 		} else if (id === 'showruler') {
-			this._map.uiManager.toggleRuler();
+			app.dispatcher.dispatch('showruler');
 		} else if (id === 'togglea11ystate') {
 			app.dispatcher.dispatch('togglea11ystate');
 		} else if (id === 'toggleuimode') {

--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -1947,7 +1947,7 @@ L.Control.Menubar = L.Control.extend({
 		} else if (id === 'insertgraphicremote') {
 			this._map.fire('postMessage', {msgId: 'UI_InsertGraphic'});
 		} else if (id === 'selectbackground') {
-			L.DomUtil.get('selectbackground').click();
+			app.dispatcher.dispatch('selectbackground');
 		} else if (id === 'zoomin' && this._map.getZoom() < this._map.getMaxZoom()) {
 			app.dispatcher.dispatch('zoomin');
 		} else if (id === 'showresolved') {

--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -2019,7 +2019,7 @@ L.Control.Menubar = L.Control.extend({
 			this._map.fire('showwizardsidebar', {noRefresh: true});
 			window.pageMobileWizard = true;
 		} else if (id === 'showslide') {
-			this._map.showSlide();
+			app.dispatcher.dispatch('showslide');
 		} else if (id === 'hideslide') {
 			this._map.hideSlide();
 		} else if (id.indexOf('morelanguages-') != -1) {

--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -2021,7 +2021,7 @@ L.Control.Menubar = L.Control.extend({
 		} else if (id === 'showslide') {
 			app.dispatcher.dispatch('showslide');
 		} else if (id === 'hideslide') {
-			this._map.hideSlide();
+			app.dispatcher.dispatch('hideslide');
 		} else if (id.indexOf('morelanguages-') != -1) {
 			this._map.fire('morelanguages', { applyto: id.substr('morelanguages-'.length) });
 		} else if (id === 'acceptalltrackedchanges') {

--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -1969,7 +1969,7 @@ L.Control.Menubar = L.Control.extend({
 		} else if (id === 'togglemenubar') {
 			this._map.uiManager.toggleMenubar();
 		} else if (id === 'collapsenotebookbar') {
-			this._map.uiManager.collapseNotebookbar();
+			app.dispatcher.dispatch('collapsenotebookbar');
 		} else if (id === 'fullscreen-presentation' && this._map.getDocType() === 'presentation') {
 			app.dispatcher.dispatch('fullscreen-presentation');
 		} else if (id === 'presentation-currentslide' && this._map.getDocType() === 'presentation') {

--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -1963,11 +1963,7 @@ L.Control.Menubar = L.Control.extend({
 		} else if (id === 'togglea11ystate') {
 			app.dispatcher.dispatch('togglea11ystate');
 		} else if (id === 'toggleuimode') {
-			if (this._map.uiManager.shouldUseNotebookbarMode()) {
-				this._map.uiManager.onChangeUIMode({mode: 'classic', force: true});
-			} else {
-				this._map.uiManager.onChangeUIMode({mode: 'notebookbar', force: true});
-			}
+			app.dispatcher.dispatch('toggleuimode');
 		} else if (id === 'showstatusbar') {
 			this._map.uiManager.toggleStatusBar();
 		} else if (id === 'togglemenubar') {

--- a/browser/src/control/Control.NotebookbarBuilder.js
+++ b/browser/src/control/Control.NotebookbarBuilder.js
@@ -477,6 +477,17 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 					'command': 'exportpdf'
 				}
 			] : []);
+		} else if (docType === 'drawing') {
+			submenuOpts = [
+				{
+					'action': 'downloadas-odg',
+					'text': _('ODF Drawing (.odg)')
+				},
+				{
+					'action': 'downloadas-png',
+					'text': _('Image (.png)')
+				}
+			];
 		}
 
 		submenuOpts.forEach(function mapIconToItem(menuItem) {

--- a/browser/src/control/Control.NotebookbarBuilder.js
+++ b/browser/src/control/Control.NotebookbarBuilder.js
@@ -23,10 +23,8 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 	},
 
 	_overrideHandlers: function() {
-		this._controlHandlers['bigmenubartoolitem'] = this._bigMenubarToolItemHandler;
 		this._controlHandlers['bigtoolitem'] = this._bigtoolitemHandler;
 		this._controlHandlers['combobox'] = this._comboboxControl;
-		this._controlHandlers['menubartoolitem'] = this._inlineMenubarToolItemHandler;
 		this._controlHandlers['exportmenubutton'] = this._exportMenuButton;
 		this._controlHandlers['tabcontrol'] = this._overriddenTabsControlHandler;
 		this._controlHandlers['tabpage'] = this._overriddenTabPageHandler;
@@ -322,45 +320,6 @@ L.Control.NotebookbarBuilder = L.Control.JSDialogBuilder.extend({
 				app.registerExportFormat(text, format);
 			}
 		}
-
-		return false;
-	},
-
-	_menubarToolItemHandler: function(parentContainer, data, builder) {
-		data.command = data.id;
-
-		var control = builder._unoToolButton(parentContainer, data, builder);
-
-		$(control.button).unbind('click');
-		$(control.label).unbind('click');
-		if (!builder.map.isLockedItem(data)) {
-			$(control.container).click(function (e) {
-				e.preventDefault();
-				L.control.menubar()._executeAction.bind({_map: builder.options.map})(undefined, {id: data.id});
-			});
-		}
-
-		return false;
-	},
-
-	_inlineMenubarToolItemHandler: function(parentContainer, data, builder) {
-		var originalInLineState = builder.options.useInLineLabelsForUnoButtons;
-		builder.options.useInLineLabelsForUnoButtons = true;
-
-		builder._menubarToolItemHandler(parentContainer, data, builder);
-
-		builder.options.useInLineLabelsForUnoButtons = originalInLineState;
-
-		return false;
-	},
-
-	_bigMenubarToolItemHandler: function(parentContainer, data, builder) {
-		var noLabels = builder.options.noLabelsForUnoButtons;
-		builder.options.noLabelsForUnoButtons = false;
-
-		builder._menubarToolItemHandler(parentContainer, data, builder);
-
-		builder.options.noLabelsForUnoButtons = noLabels;
 
 		return false;
 	},

--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -1174,9 +1174,8 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 							{
 								'id': 'zoomout',
 								'class': 'unozoomout',
-								'type': 'menubartoolitem',
+								'type': 'customtoolitem',
 								'text': _UNO('.uno:ZoomMinus'),
-								'command': '.uno:ZoomMinus',
 								'accessibility': { focusBack: true,	combination: 'ZO', de: null }
 							}
 						]

--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -221,9 +221,8 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 					{
 						'id': 'repair',
 						'class': 'unorepair',
-						'type': 'bigmenubartoolitem',
+						'type': 'bigcustomtoolitem',
 						'text': _('Repair'),
-						'command': _('Repair'),
 						'accessibility': { focusBack: true,	combination: 'RP', de: null }
 					}
 				],

--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -821,9 +821,8 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 								{
 									'id': 'home-search',
 									'class': 'unoSearch',
-									'type': 'menubartoolitem',
+									'type': 'customtoolitem',
 									'text': _('Search'),
-									'command': _('Show Status Bar'),
 									'accessibility': { focusBack: false,	combination: 'SS',	de: 'SS' }
 								}
 							]

--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -1223,9 +1223,8 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 							{
 								'id': 'showstatusbar',
 								'class': 'unoshowstatusbar',
-								'type': 'menubartoolitem',
+								'type': 'customtoolitem',
 								'text': _('Status Bar'),
-								'command': _('Show Status Bar'),
 								'accessibility': { focusBack: true,	combination: 'SB', de: null }
 							}
 						]

--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -1235,7 +1235,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 			{
 				'id':'toggledarktheme',
 				'class': 'unotoggledarktheme',
-				'type': 'bigmenubartoolitem',
+				'type': 'bigcustomtoolitem',
 				'text': _('Dark Mode'),
 				'accessibility': { focusBack: true,	combination: 'DT', de: null }
 			},

--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -1198,9 +1198,8 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 			{
 				'id': 'toggleuimode',
 				'class': 'unotoggleuimode',
-				'type': 'bigmenubartoolitem',
+				'type': 'bigcustomtoolitem',
 				'text': _('Compact view'),
-				'command': _('Toggle UI Mode'),
 				'accessibility': { focusBack: true,	combination: 'UI', de: null }
 			},
 			{

--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -1211,7 +1211,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 							{
 								'id': 'collapsenotebookbar',
 								'class': 'unocollapsenotebookbar',
-								'type': 'menubartoolitem',
+								'type': 'customtoolitem',
 								'text': _('Collapse Tabs'),
 								'accessibility': { focusBack: true,	combination: 'CT', de: null }
 							}

--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -1186,9 +1186,8 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 							{
 								'id': 'zoomin',
 								'class': 'unozoomin',
-								'type': 'menubartoolitem',
+								'type': 'customtoolitem',
 								'text': _UNO('.uno:ZoomPlus'),
-								'command': '.uno:ZoomPlus',
 								'accessibility': { focusBack: true,	combination: 'ZI', de: null }
 							}
 						]

--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -1163,9 +1163,8 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 			{
 				'id': 'zoomreset',
 				'class': 'unozoomreset',
-				'type': 'bigmenubartoolitem',
+				'type': 'bigcustomtoolitem',
 				'text': _('Reset zoom'),
-				'command': _('Reset zoom'),
 				'accessibility': { focusBack: true,	combination: 'J', de: null }
 			},
 			{

--- a/browser/src/control/Control.NotebookbarDraw.js
+++ b/browser/src/control/Control.NotebookbarDraw.js
@@ -969,9 +969,8 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 								{
 									'id': 'home-search',
 									'class': 'unoSearch',
-									'type': 'menubartoolitem',
+									'type': 'customtoolitem',
 									'text': _('Search'),
-									'command': _('Show Status Bar'),
 									'accessibility': { focusBack: false,	combination: 'SS',	de: 'SS' }
 								}
 							]

--- a/browser/src/control/Control.NotebookbarDraw.js
+++ b/browser/src/control/Control.NotebookbarDraw.js
@@ -1034,9 +1034,8 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 							{
 								'id': 'selectbackground',
 								'class': 'unoselectbackground',
-								'type': 'menubartoolitem',
+								'type': 'customtoolitem',
 								'text': _UNO('.uno:SelectBackground', 'presentation'),
-								'command': '',
 								'accessibility': { focusBack: true, combination: 'SB', de: null }
 							}
 						]

--- a/browser/src/control/Control.NotebookbarDraw.js
+++ b/browser/src/control/Control.NotebookbarDraw.js
@@ -288,9 +288,8 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 					{
 						'id': 'repair',
 						'class': 'unorepair',
-						'type': 'bigtoolitem',
+						'type': 'bigcustomtoolitem',
 						'text': _('Repair'),
-						'command': _('Repair'),
 						'accessibility': { focusBack: true, combination: 'RF', de: null }
 					}
 				]

--- a/browser/src/control/Control.NotebookbarDraw.js
+++ b/browser/src/control/Control.NotebookbarDraw.js
@@ -226,29 +226,13 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 		}
 
 		if (!this._map['wopi'].HideExportOption) {
-			content.push(
-			{
-				'id': 'file-downloadas-odg-downloadas-png',
-				'type': 'container',
-				'children': [
-					{
-						'id': 'downloadas-odg',
-						'class': 'unodownloadas-odg',
-						'type': 'menubartoolitem',
-						'text': _('ODF Drawing (.odg)'),
-						'command': '',
-						'accessibility': { focusBack: true, combination: 'DO', de: null }
-					},
-					{
-						'id': 'downloadas-png',
-						'class': 'unodownloadas-png',
-						'type': 'menubartoolitem',
-						'text': _('Image (.png)'),
-						'command': '',
-						'accessibility': { focusBack: true, combination: 'DP', de: null }
-					},
-				],
-				'vertical': 'true'
+			content.push({
+				'id': 'downloadas:DownloadAsMenu',
+				'command': 'downloadas',
+				'class': 'unodownloadas',
+				'type': 'exportmenubutton',
+				'text': _('Download'),
+				'accessibility': { focusBack: true, combination: 'DA', de: null }
 			});
 		}
 

--- a/browser/src/control/Control.NotebookbarDraw.js
+++ b/browser/src/control/Control.NotebookbarDraw.js
@@ -345,9 +345,8 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 			{
 				'id': 'zoomreset',
 				'class': 'unozoomreset',
-				'type': 'bigmenubartoolitem',
+				'type': 'bigcustomtoolitem',
 				'text': _('Reset zoom'),
-				'command': _('Reset zoom'),
 				'accessibility': { focusBack: true, combination: 'RZ', de: null }
 			},
 			{

--- a/browser/src/control/Control.NotebookbarDraw.js
+++ b/browser/src/control/Control.NotebookbarDraw.js
@@ -418,7 +418,7 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 			{
 				'id': 'collapsenotebookbar',
 				'class': 'unocollapsenotebookbar',
-				'type': 'bigmenubartoolitem',
+				'type': 'bigcustomtoolitem',
 				'text': _('Collapse Tabs'),
 				'accessibility': { focusBack: true, combination: 'CU', de: null }
 			},

--- a/browser/src/control/Control.NotebookbarDraw.js
+++ b/browser/src/control/Control.NotebookbarDraw.js
@@ -357,9 +357,8 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 							{
 								'id': 'zoomout',
 								'class': 'unozoomout',
-								'type': 'menubartoolitem',
+								'type': 'customtoolitem',
 								'text': _UNO('.uno:ZoomMinus'),
-								'command': '.uno:ZoomMinus',
 								'accessibility': { focusBack: true, combination: 'ZO', de: null }
 							}
 						]

--- a/browser/src/control/Control.NotebookbarDraw.js
+++ b/browser/src/control/Control.NotebookbarDraw.js
@@ -424,7 +424,7 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 			},
 			{
 				'id':'toggledarktheme',
-				'type': 'bigmenubartoolitem',
+				'type': 'bigcustomtoolitem',
 				'text': _('Dark Mode'),
 				'accessibility': { focusBack: true, combination: 'DT', de: null }
 			},

--- a/browser/src/control/Control.NotebookbarDraw.js
+++ b/browser/src/control/Control.NotebookbarDraw.js
@@ -369,9 +369,8 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 							{
 								'id': 'zoomin',
 								'class': 'unozoomin',
-								'type': 'menubartoolitem',
+								'type': 'customtoolitem',
 								'text': _UNO('.uno:ZoomPlus'),
-								'command': '.uno:ZoomPlus',
 								'accessibility': { focusBack: true, combination: 'ZI', de: null }
 							}
 						]

--- a/browser/src/control/Control.NotebookbarDraw.js
+++ b/browser/src/control/Control.NotebookbarDraw.js
@@ -406,9 +406,8 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 							{
 								'id': 'showstatusbar',
 								'class': 'unoshowstatusbar',
-								'type': 'menubartoolitem',
+								'type': 'customtoolitem',
 								'text': _('Status Bar'),
-								'command': _('Show Status Bar'),
 								'accessibility': { focusBack: true, combination: 'SB', de: null }
 							}
 						]

--- a/browser/src/control/Control.NotebookbarDraw.js
+++ b/browser/src/control/Control.NotebookbarDraw.js
@@ -394,9 +394,8 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 							{
 								'id': 'showruler',
 								'class': 'unoshowruler',
-								'type': 'menubartoolitem',
+								'type': 'customtoolitem',
 								'text': _('Ruler'),
-								'command': _('Show Ruler'),
 								'accessibility': { focusBack: true, combination: 'R', de: 'L' }
 							}
 						]

--- a/browser/src/control/Control.NotebookbarDraw.js
+++ b/browser/src/control/Control.NotebookbarDraw.js
@@ -381,9 +381,8 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 			{
 				'id': 'toggleuimode',
 				'class': 'unotoggleuimode',
-				'type': 'bigmenubartoolitem',
+				'type': 'bigcustomtoolitem',
 				'text': _('Compact view'),
-				'command': _('Toggle UI Mode'),
 				'accessibility': { focusBack: true, combination: 'UI', de: null }
 			},
 			{

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -435,7 +435,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 			{
 				'id': 'collapsenotebookbar',
 				'class': 'unocollapsenotebookbar',
-				'type': 'bigmenubartoolitem',
+				'type': 'bigcustomtoolitem',
 				'text': _('Collapse Tabs'),
 				'accessibility': { focusBack: true, combination: 'CU', de: null }
 			},

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -1460,9 +1460,8 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 			{
 				'id': 'hideslide',
 				'class': 'unohideslide',
-				'type': 'bigmenubartoolitem',
+				'type': 'bigcustomtoolitem',
 				'text': _UNO('.uno:HideSlide', 'presentation'),
-				'command': '.uno:HideSlide',
 				'accessibility': { focusBack: true, combination: 'HS', de: null }
 			},
 			{

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -398,9 +398,8 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 			{
 				'id': 'toggleuimode',
 				'class': 'unotoggleuimode',
-				'type': 'bigmenubartoolitem',
+				'type': 'bigcustomtoolitem',
 				'text': _('Compact view'),
-				'command': _('Toggle UI Mode'),
 				'accessibility': { focusBack: true, combination: 'TU', de: null }
 			},
 			{

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -423,9 +423,8 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 							{
 								'id': 'showstatusbar',
 								'class': 'unoshowstatusbar',
-								'type': 'menubartoolitem',
+								'type': 'customtoolitem',
 								'text': _('Status Bar'),
-								'command': _('Show Status Bar'),
 								'accessibility': { focusBack: true, combination: 'SB', de: null }
 							}
 						]

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -1021,9 +1021,8 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 								{
 									'id': 'home-search',
 									'class': 'unoSearch',
-									'type': 'menubartoolitem',
+									'type': 'customtoolitem',
 									'text': _('Search'),
-									'command': _('Show Status Bar'),
 									'accessibility': { focusBack: false,	combination: 'SS',	de: 'SS' }
 								}
 							]

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -289,9 +289,8 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 					{
 						'id': 'repair',
 						'class': 'unorepair',
-						'type': 'bigmenubartoolitem',
+						'type': 'bigcustomtoolitem',
 						'text': _('Repair'),
-						'command': _('Repair'),
 						'accessibility': { focusBack: true, combination: 'RF', de: null }
 					}
 				],

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -374,9 +374,8 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 							{
 								'id': 'zoomout',
 								'class': 'unozoomout',
-								'type': 'menubartoolitem',
+								'type': 'customtoolitem',
 								'text': _UNO('.uno:ZoomMinus'),
-								'command': '.uno:ZoomMinus',
 								'accessibility': { focusBack: true, combination: 'ZO', de: null }
 							}
 						]

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -411,9 +411,8 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 							{
 								'id': 'showruler',
 								'class': 'unoshowruler',
-								'type': 'menubartoolitem',
+								'type': 'customtoolitem',
 								'text': _('Ruler'),
-								'command': _('Show Ruler'),
 								'accessibility': { focusBack: true, combination: 'R', de: 'L' }
 							}
 						]

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -362,9 +362,8 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 			{
 				'id': 'zoomreset',
 				'class': 'unozoomreset',
-				'type': 'bigmenubartoolitem',
+				'type': 'bigcustomtoolitem',
 				'text': _('Reset zoom'),
-				'command': _('Reset zoom'),
 				'accessibility': { focusBack: true, combination: 'ZR', de: null }
 			},
 			{

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -467,7 +467,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 			{
 				'id':'toggledarktheme',
 				'class': 'unotoggledarktheme',
-				'type': 'bigmenubartoolitem',
+				'type': 'bigcustomtoolitem',
 				'text': _('Dark Mode'),
 				'accessibility': { focusBack: true, combination: 'TT', de: null }
 			},

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -386,9 +386,8 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 							{
 								'id': 'zoomin',
 								'class': 'unozoomin',
-								'type': 'menubartoolitem',
+								'type': 'customtoolitem',
 								'text': _UNO('.uno:ZoomPlus'),
-								'command': '.uno:ZoomPlus',
 								'accessibility': { focusBack: true, combination: 'ZI', de: null }
 							}
 						]

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -1453,9 +1453,8 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 			},
 			{
 				'id': 'showslide',
-				'type': 'bigmenubartoolitem',
+				'type': 'bigcustomtoolitem',
 				'text': _UNO('.uno:ShowSlide', 'presentation'),
-				'command': '.uno:ShowSlide',
 				'accessibility': { focusBack: true, combination: 'SS', de: null }
 			},
 			{

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -1432,9 +1432,8 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 							{
 								'id': 'zoomin',
 								'class': 'unozoomin',
-								'type': 'menubartoolitem',
+								'type': 'customtoolitem',
 								'text': _UNO('.uno:ZoomPlus'),
-								'command': '.uno:ZoomPlus',
 								'accessibility': { focusBack: true, combination: 'ZI', de: null }
 							}
 						]

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -1444,9 +1444,8 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 			{
 				'id': 'toggleuimode',
 				'class': 'unotoggleuimode',
-				'type': 'bigmenubartoolitem',
+				'type': 'bigcustomtoolitem',
 				'text': _('Compact view'),
-				'command': _('Toggle UI Mode'),
 				'accessibility': { focusBack: false, combination: 'UI', de: null }
 			},
 			{

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -290,9 +290,8 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 					{
 						'id': 'repair',
 						'class': 'unorepair',
-						'type': 'bigmenubartoolitem',
+						'type': 'bigcustomtoolitem',
 						'text': _('Repair'),
-						'command': _('Repair'),
 						'accessibility': { focusBack: true,	combination: 'RF', de: null }
 					}
 				],

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -1937,7 +1937,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				{
 					'id': 'zoteroaddeditbibliography',
 					'class': 'unozoteroaddeditbibliography',
-					'type': 'bigmenubartoolitem',
+					'type': 'bigcustomtoolitem',
 					'text': _('Add Bibliography'),
 					'command': 'zoteroeditbibliography'
 				},

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -1420,9 +1420,8 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 							{
 								'id': 'zoomout',
 								'class': 'unozoomout',
-								'type': 'menubartoolitem',
+								'type': 'customtoolitem',
 								'text': _UNO('.uno:ZoomMinus'),
-								'command': '.uno:ZoomMinus',
 								'accessibility': { focusBack: true, combination: 'ZO', de: null }
 							}
 						]

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -1469,9 +1469,8 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 							{
 								'id': 'showstatusbar',
 								'class': 'unoshowstatusbar',
-								'type': 'menubartoolitem',
+								'type': 'customtoolitem',
 								'text': _('Status Bar'),
-								'command': _('Show Status Bar'),
 								'accessibility': { focusBack: true, combination: 'AH', de: null }
 							}
 						]

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -1457,9 +1457,8 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 							{
 								'id': 'showruler',
 								'class': 'unoshowruler',
-								'type': 'menubartoolitem',
+								'type': 'customtoolitem',
 								'text': _('Ruler'),
-								'command': _('Show Ruler'),
 								'accessibility': { focusBack: true, combination: 'R', de: 'L' }
 							}
 						]

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -1409,9 +1409,8 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 			{
 				'id': 'zoomreset',
 				'class': 'unozoomreset',
-				'type': 'bigmenubartoolitem',
+				'type': 'bigcustomtoolitem',
 				'text': _('Reset zoom'),
-				'command': _('Reset zoom'),
 				'accessibility': { focusBack: true, combination: 'J', de: 'O' }
 			},
 			{

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -870,9 +870,8 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 								{
 									'id': 'home-search',
 									'class': 'unoSearch',
-									'type': 'menubartoolitem',
+									'type': 'customtoolitem',
 									'text': _('Search'),
-									'command': _('Show Status Bar'),
 									'accessibility': { focusBack: false,	combination: 'SS',	de: 'SS' }
 								}
 							]

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -1481,7 +1481,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 			{
 				'id': 'collapsenotebookbar',
 				'class': 'unocollapsenotebookbar',
-				'type': 'bigmenubartoolitem',
+				'type': 'bigcustomtoolitem',
 				'text': _('Collapse Tabs')
 			},
 			{

--- a/browser/src/docdispatcher.ts
+++ b/browser/src/docdispatcher.ts
@@ -252,6 +252,10 @@ class Dispatcher {
 		this.actionsMap['showstatusbar'] = () => {
 			app.map.uiManager.toggleStatusBar();
 		};
+
+		this.actionsMap['collapsenotebookbar'] = () => {
+			app.map.uiManager.collapseNotebookbar();
+		};
 	}
 
 	private addExportCommands() {

--- a/browser/src/docdispatcher.ts
+++ b/browser/src/docdispatcher.ts
@@ -244,6 +244,10 @@ class Dispatcher {
 				app.map.uiManager.onChangeUIMode({ mode: 'notebookbar', force: true });
 			}
 		};
+
+		this.actionsMap['showruler'] = () => {
+			app.map.uiManager.toggleRuler();
+		};
 	}
 
 	private addExportCommands() {

--- a/browser/src/docdispatcher.ts
+++ b/browser/src/docdispatcher.ts
@@ -236,6 +236,14 @@ class Dispatcher {
 				window.prefs.getBoolean('accessibilityState');
 			app.map.setAccessibilityState(!prevAccessibilityState);
 		};
+
+		this.actionsMap['toggleuimode'] = () => {
+			if (app.map.uiManager.shouldUseNotebookbarMode()) {
+				app.map.uiManager.onChangeUIMode({ mode: 'classic', force: true });
+			} else {
+				app.map.uiManager.onChangeUIMode({ mode: 'notebookbar', force: true });
+			}
+		};
 	}
 
 	private addExportCommands() {

--- a/browser/src/docdispatcher.ts
+++ b/browser/src/docdispatcher.ts
@@ -505,6 +505,10 @@ class Dispatcher {
 				}),
 			);
 		};
+
+		this.actionsMap['selectbackground'] = function () {
+			L.DomUtil.get('selectbackground').click();
+		};
 	}
 
 	private addZoteroCommands() {

--- a/browser/src/docdispatcher.ts
+++ b/browser/src/docdispatcher.ts
@@ -248,6 +248,10 @@ class Dispatcher {
 		this.actionsMap['showruler'] = () => {
 			app.map.uiManager.toggleRuler();
 		};
+
+		this.actionsMap['showstatusbar'] = () => {
+			app.map.uiManager.toggleStatusBar();
+		};
 	}
 
 	private addExportCommands() {


### PR DESCRIPTION
Fixes #8029 
All menubartoolitems which left are now converted to customtoolitems which use dispatcher to invoke internal commands. Code is shared with menubar this way. Remove it so noone will add more of them again.