### PR TITLE
annotation: avoid creating comment insert box if annotations disabled

### DIFF
--- a/browser/src/layer/tile/CommentListSection.ts
+++ b/browser/src/layer/tile/CommentListSection.ts
@@ -13,6 +13,8 @@
 
 L.Map.include({
 	insertComment: function() {
+		if (this.stateChangeHandler.getItemValue('InsertAnnotation') === 'disabled')
+			return;
 		if (cool.Comment.isAnyEdit()) {
 			cool.CommentSection.showCommentEditingWarning();
 			return;


### PR DESCRIPTION
problem:
some elements can not have comments, when these elements get selection, comment button in menus were disabled but shortcuts still worked, this ensures no element for comment insert is created in first place

Signed-off-by: Pranam Lashkari <lpranam@collabora.com>
Change-Id: Ib76366c23e9ad7f6fc29f98add65b0840d00ead9 (cherry picked from commit 0461fd3876165d00b0e04c949e5144b1a64f031b)

* Target version: 23.05

### Checklist

- [X] I have run `make prettier-write` and formatted the code.
- [X] All commits have Change-Id
- [ ] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

