### PR TITLE
annotation: after importing comment set showResolved stat

### DIFF
--- a/browser/src/canvas/sections/CommentListSection.ts
+++ b/browser/src/canvas/sections/CommentListSection.ts
@@ -2137,6 +2137,9 @@ export class CommentSection extends app.definitions.canvasSectionObject {
 			this.update();
 		}
 
+		var showResolved = this.map.stateChangeHandler.getItemValue('ShowResolvedAnnotations');
+		app.map.showResolvedComments(showResolved === true || showResolved === 'true');
+
 		if (this.sectionProperties.docLayer._docType === 'spreadsheet')
 			this.hideAllComments(); // Apply drawing orders.
 


### PR DESCRIPTION
problem:
once comments are imported(i.e after reload) regardless of the show resolved comments, they were always shown


Change-Id: Ieb425faf2566bf7694723bea37dc9660f4c0ef5b


* Target version: master 


### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

