### PR TITLE
hyperlink modal text and link focus

### DIFF
--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -757,6 +757,11 @@ L.Map.include({
 		var id = 'hyperlink';
 		var title = _('Insert hyperlink');
 
+		let focusId = 'hyperlink-link-box-input';
+		if (defaultText === '') {
+			focusId = 'hyperlink-text-box';
+		}
+
 		var dialogId = 'modal-dialog-' + id;
 		var json = map.uiManager._modalDialogJSON(id, title, true, [
 			{
@@ -802,7 +807,7 @@ L.Map.include({
 				vertical: false,
 				layoutstyle: 'end'
 			},
-		], 'hyperlink-link-box-input');
+		], focusId);
 
 		map.uiManager.showModal(json, [
 			{id: 'response-ok', func: function() {

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1381,6 +1381,11 @@ L.CanvasTileLayer = L.Layer.extend({
 				// widget.
 				const extracted = this._map.extractContent(textMsgHtml);
 				hyperlinkTextBox.value = extracted.trim();
+
+				const hyperlinkLinkBoxInput = document.getElementById('hyperlink-link-box-input')
+				if (extracted !== '' && hyperlinkLinkBoxInput) {
+					hyperlinkLinkBoxInput.focus();
+				}
 			} else if (this._map._clip) {
 				this._map._clip.setTextSelectionHTML(textMsgHtml, textMsgPlainText);
 			} else

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1382,7 +1382,7 @@ L.CanvasTileLayer = L.Layer.extend({
 				const extracted = this._map.extractContent(textMsgHtml);
 				hyperlinkTextBox.value = extracted.trim();
 
-				const hyperlinkLinkBoxInput = document.getElementById('hyperlink-link-box-input')
+				const hyperlinkLinkBoxInput = document.getElementById('hyperlink-link-box-input');
 				if (extracted !== '' && hyperlinkLinkBoxInput) {
 					hyperlinkLinkBoxInput.focus();
 				}


### PR DESCRIPTION
Change-Id: Idd24de6d8765a983c7f36a3b5459f41d52a69b43


* Resolves: #6521
* Target version: master 

### Summary

If text is selected when opening the hyperlink modal, focus will be set on the link input. If no text is select, then focus will be set on the text input. 