### PR TITLE
fix(mobile): Surface real information in "about"

### DIFF
--- a/browser/html/cool.html.m4
+++ b/browser/html/cool.html.m4
@@ -201,8 +201,7 @@ m4_ifelse(MOBILEAPP,[true],
             <div id="slow-proxy"></div>
             m4_ifelse(DEBUG,[true],[<div id="js-dialog">JSDialogs: <a href="javascript:void(function() { app.socket.sendMessage('uno .uno:WidgetTestDialog') }() )">View widgets</a></div>])
             <div id="routeToken"></div>
-            <div id="wopi-host-id">%WOPI_HOST_ID%</div>
-            <div id="proxy-prefix-id">%PROXY_PREFIX_ENABLED%</div>
+            m4_ifelse(MOBILEAPP,[],[<div id="wopi-host-id">%WOPI_HOST_ID%</div><div id="proxy-prefix-id">%PROXY_PREFIX_ENABLED%</div>],[<p></p>])
             <p class="about-dialog-info-div"><span dir="ltr">Copyright © _YEAR_, VENDOR.</span></p>
           </div>
         </div>
@@ -219,6 +218,7 @@ m4_ifelse(MOBILEAPP, [true],
           data-access-header='%ACCESS_HEADER%'
         ]
       )
+      data-mobile-app-name='MOBILEAPPNAME'
       />
       ],
      [

--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -392,8 +392,10 @@ class MobileAppInitializer extends InitializerBase {
 		  window.postMobileMessage('HYPERLINK ' + url); /* don't call the 'normal' window.open on mobile at all */
 		};
 
-		window.MobileAppName = 'MOBILEAPPNAME';
-		window.brandProductName = 'MOBILEAPPNAME';
+		const element = document.getElementById("initial-variables");
+
+		window.MobileAppName = element.dataset.mobileAppName;
+		window.brandProductName = element.dataset.mobileAppName;
 
 		window.coolLogging = "true";
 		window.outOfFocusTimeoutSecs = 1000000;


### PR DESCRIPTION
Previously we exposed "%WOPI_HOST_ID%" and "%PROXY_PREFIX_ENABLED%", despoenite those variables being undefined for mobile. Additionally, we incorrectly displayed the app name as MOBILEAPPNAME.

These appear to be regressions from https://github.com/CollaboraOnline/online/pull/9442


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

