### PR TITLE
backport: fix(mobile): Surface real information in "about"

### DIFF
--- a/browser/html/cool.html.m4
+++ b/browser/html/cool.html.m4
@@ -201,8 +201,7 @@ m4_ifelse(MOBILEAPP,[true],
             <div id="slow-proxy"></div>
             m4_ifelse(DEBUG,[true],[<div id="js-dialog">JSDialogs: <a href="javascript:void(function() { app.socket.sendMessage('uno .uno:WidgetTestDialog') }() )">View widgets</a></div>])
             <div id="routeToken"></div>
-            <div id="wopi-host-id">%WOPI_HOST_ID%</div>
-            <div id="proxy-prefix-id">%PROXY_PREFIX_ENABLED%</div>
+            m4_ifelse(MOBILEAPP,[],[<div id="wopi-host-id">%WOPI_HOST_ID%</div><div id="proxy-prefix-id">%PROXY_PREFIX_ENABLED%</div>],[<p></p>])
             <p class="about-dialog-info-div"><span dir="ltr">Copyright © _YEAR_, VENDOR.</span></p>
           </div>
         </div>
@@ -219,6 +218,7 @@ m4_ifelse(MOBILEAPP, [true],
           data-access-header='%ACCESS_HEADER%'
         ]
       )
+      data-mobile-app-name='MOBILEAPPNAME'
       />
       ],
      [

--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -390,8 +390,10 @@ class MobileAppInitializer extends InitializerBase {
 		  window.postMobileMessage('HYPERLINK ' + url); /* don't call the 'normal' window.open on mobile at all */
 		};
 
-		window.MobileAppName = 'MOBILEAPPNAME';
-		window.brandProductName = 'MOBILEAPPNAME';
+		const element = document.getElementById("initial-variables");
+
+		window.MobileAppName = element.dataset.mobileAppName;
+		window.brandProductName = element.dataset.mobileAppName;
 
 		window.coolLogging = "true";
 		window.outOfFocusTimeoutSecs = 1000000;


### PR DESCRIPTION
This is a backport of #9884

Previously we exposed WOPI_HOST_ID and PROXY_PREFIX_ENABLED,
despite those variables being undefined for mobile. Additionally, we
incorrectly displayed the app name as MOBILEAPPNAME.

These appear to be regressions from https://github.com/CollaboraOnline/online/pull/9442