### PR TITLE
Add missing icon for download as PNG in draw

### DIFF
--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -550,6 +550,10 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 	background: url('images/lc_downloadas-odg.svg') center;
 }
 
+[class*='as-png-submenu-icon'] {
+	background: url('images/lc_insertgraphic.svg') center;
+}
+
 [class*='as-rtf-submenu-icon'] {
 	background: url('images/lc_downloadas-rtf.svg') center;
 }


### PR DESCRIPTION
- added icon path for `as-png-submenu-icon`

![image](https://github.com/user-attachments/assets/3483eedc-2423-407f-93ca-211c1d286a86)

Change-Id: I82599f0a3ce757d62f2215ccb8118060cd9b7eb6


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

