### PR TITLE
fix(mobile): reorder stylesheets

### DIFF
--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -304,8 +304,12 @@ class InitializerBase {
 			brandingLink.setAttribute("href", this.brandingUriPrefix + theme_prefix + 'branding-desktop.css');
 		}
 
-		document.getElementsByTagName("head")[[0]].appendChild(link);
-		document.getElementsByTagName("head")[[0]].appendChild(brandingLink);
+		const otherStylesheets = document.querySelectorAll('link[rel="stylesheet"]');
+		const lastOtherStylesheet = otherStylesheets[otherStylesheets.length - 1];
+
+		lastOtherStylesheet
+			.insertAdjacentElement('afterend', link)
+			.insertAdjacentElement('afterend', brandingLink);
 	}
 
 	initializeViewMode() {


### PR DESCRIPTION
As we insert other stylesheets after the head (and therefore later than stylesheets in the head), they take precedence over stylesheets in the head.

Therefore, we can't insert our device and branding stylesheets in the end of the <head>. We need to insert them after the latest other stylesheet.

This appears to a regression from https://github.com/CollaboraOnline/online/pull/9442


Change-Id: I829c0dc1ad95a28650845d39aad9f975692319b8


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

