### PR TITLE
backport: fix(mobile): reorder stylesheets

### DIFF
--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -303,8 +303,12 @@ class InitializerBase {
 			brandingLink.setAttribute("href", this.brandingUriPrefix + theme_prefix + 'branding-desktop.css');
 		}
 
-		document.getElementsByTagName("head")[[0]].appendChild(link);
-		document.getElementsByTagName("head")[[0]].appendChild(brandingLink);
+		const otherStylesheets = document.querySelectorAll('link[rel="stylesheet"]');
+		const lastOtherStylesheet = otherStylesheets[otherStylesheets.length - 1];
+
+		lastOtherStylesheet
+			.insertAdjacentElement('afterend', link)
+			.insertAdjacentElement('afterend', brandingLink);
 	}
 
 	initializeViewMode() {


### PR DESCRIPTION
As we insert other stylesheets after the head (and therefore later than
stylesheets in the head), they take precedence over stylesheets in the
head.

Therefore, we can't insert our device and branding stylesheets in the
end of the <head>. We need to insert them after the latest other
stylesheet.

This appears to a regression from https://github.com/CollaboraOnline/online/pull/9442