### PR TITLE
indirection: expose server_name when provided

### DIFF
--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -325,6 +325,7 @@
       <geolocation_setup>
         <enable desc="Enable geolocation_setup when using indirection server with geolocation configuration" type="bool" default="false">false</enable>
       </geolocation_setup>
+      <server_name desc="server name to show in cluster overview admin panel"></server_name>
     </indirection_endpoint>
 
     @LOCK_CONFIGURATION@

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -2193,6 +2193,7 @@ void COOLWSD::innerInitialize(Application& self)
         { "deepl.enabled", "false" },
         { "zotero.enable", "true" },
         { "indirection_endpoint.geolocation_setup.enable", "false" },
+        { "indirection_endpoint.server_name", "" },
         { "indirection_endpoint.url", "" },
 #if !MOBILEAPP
         { "help_url", HELP_URL },

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -2058,8 +2058,11 @@ static std::string getCapabilitiesJson(bool convertToAvailable)
     capabilities->set("hasWASMSupport",
                       COOLWSD::WASMState != COOLWSD::WASMActivationState::Disabled);
 
+    const std::string serverName = config::getString("indirection_endpoint.server_name", "");
     if (const char* podName = std::getenv("POD_NAME"))
         capabilities->set("podName", podName);
+    else if (!serverName.empty())
+        capabilities->set("podName", serverName);
 
     bool geoLocationSetup =
         config::getBool(std::string("indirection_endpoint.geolocation_setup.enable"), false);


### PR DESCRIPTION
- this is useful for controller, collabora online vm setup
- usually when running the collabora online in k8s environment we pass POD_NAME env variable. POD_NAME is needed as a env variable because on every restart POD_NAME changes that's not the case for COOL running in the vms
- why don't use POD_NAME for VMs as well ? In container you only create one user and COOL process run under same user. If we set env variable in container it sets env varialble for that user only and COOL process can access it. For VMs, that's not the case we might have multiple users. so you need to set global env variable to make it. Instead of doing that I prefer providing the name inside coolwsd.xml


Change-Id: I92c204a0315c74ab121b5aa48795646b9dede39a

