### PR TITLE
backport: fix(mobile): correct egregious dark UI colors

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -261,6 +261,7 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 .ui-badge {
 	padding: 5px !important;
 	background-color: var(--color-background-darker);
+	color: var(--color-text-darker);
 	border-width: 0px;
 	border-radius: var(--border-radius);
 	font-family: var(--cool-font);

--- a/browser/css/mobilewizard.css
+++ b/browser/css/mobilewizard.css
@@ -350,7 +350,7 @@ p.mobile-wizard.ui-combobox-text.selected {
 }
 
 .ui-header.mobile-wizard:active, .mobile-wizard.ui-combobox-text:active, .ui-header.mobile-wizard:focus, .mobile-wizard.ui-combobox-text:focus, .ui-header.mobile-wizard:hover, .mobile-wizard.ui-combobox-text:hover {
-	background-color: #eee;
+	background-color: var(--color-background-dark);
 }
 
 #mobile-wizard .ui-header.mobile-wizard-widebutton {
@@ -562,7 +562,7 @@ p.mobile-wizard.ui-combobox-text.selected {
 	padding-top: 0px;
 }
 .mobile-wizard input.spinfield:disabled {
-	background: linear-gradient(to right, white 0%, #ebebe4 15%, #ebebe4 40%, white 100%);
+	background: linear-gradient(to right, var(--color-background-lighter) 0%, var(--color-background-dark) 15%, var(--color-background-dark) 40%, var(--color-background-lighter) 100%);
 	color: var(--color-text-lighter) !important;
 	border-radius: var(--border-radius);
 	height: 48px !important;


### PR DESCRIPTION
This is a backport of #9890

Some of the coloring issues on mobile at the moment are truly egregious.
They leave dark mode text on a light mode background (or vice-versa),
leading to the text being entirely unreadable.

This happens because we have some colors hardcoded. Replacing them with
variables fixes this.

There are still some hardcoded colors after this change. I'm not sure
that this fixes everything, but it fixes the most obvious issues.

Signed-off-by: Skyler Grey <skyler.grey@collabora.com>
Change-Id: Ie1579751fb4154d1816dfd84becc726d06bc7876