### PR TITLE
Related: cool#9735 kit: use the new registerAnyInputCallback() LOK API

### DIFF
--- a/kit/Kit.hpp
+++ b/kit/Kit.hpp
@@ -169,6 +169,7 @@ public:
 #endif
     int kitPoll(int timeoutMicroS);
     void setDocument(std::shared_ptr<Document> document) { _document = std::move(document); }
+    std::shared_ptr<Document> getDocument() const { return _document; }
 
     // unusual LOK event from another thread, push into our loop to process.
     static bool pushToMainThread(LibreOfficeKitCallback callback, int type, const char* p,
@@ -382,6 +383,8 @@ public:
 
     /// Are we currently performing a load ?
     bool isLoadOngoing() const { return _duringLoad > 0; }
+
+    std::shared_ptr<KitQueue> getQueue() const { return _queue; }
 
 private:
     void postForceModifiedCommand(bool modified);


### PR DESCRIPTION
core.git has an Application::AnyInput() mechanism to inform idle jobs
when they should stop their work (and continue that at a later stage),
but this was not aware of pending online.git work. This lead to e.g.
performing all the idle layout after pasting into a numbered list in a
Writer document, instead of first rendering tiles for the visible area,
and only then doing the rest of the layout.

This is a problem for interactivity, e.g. the above scenario with 300
Writer pages results in a 274 ms hang till the first tile is rendered.

Fix the problem by using the new registerAnyInputCallback() LOK API, so
interested core.git code can ask our side if there are pending input
events.

The first naive implementation resulted in interrupting core.git idles
far too often, so apart from calling poll() on the KitSocketPoll, so
check if there are pending callbacks or tiles to be rendered, and only
report pending inputs in that case. This seems to result in an event
order that is similar to what happens for desktop Writer already.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I9a50d8b1ca59224084d5fa58f9ab29c9f29ef27b
