### PR TITLE
Fix comment box cut-off issue when zooming in

### DIFF
--- a/browser/src/layer/tile/CommentListSection.ts
+++ b/browser/src/layer/tile/CommentListSection.ts
@@ -102,7 +102,7 @@ export class CommentSection extends CanvasSectionObject {
 		this.sectionProperties.width = Math.round(1 * app.dpiScale); // Configurable variable.
 		this.sectionProperties.scrollAnnotation = null; // For impress, when 1 or more comments exist.
 		this.sectionProperties.commentWidth = 200 * 1.3; // CSS pixels.
-		this.sectionProperties.collapsedMarginToTheEdge = (<any>window).mode.isTablet() ? 120: 70; // CSS pixels.
+		this.sectionProperties.collapsedMarginToTheEdge = 120; // CSS pixels.
 		this.sectionProperties.deflectionOfSelectedComment = 160; // CSS pixels.
 		this.sectionProperties.calcCurrentComment = null; // We don't automatically show a Calc comment when cursor is on its cell. But we remember it to show if user presses Alt+C keys.
 		// This (commentsAreListed) variable means that comments are shown as a list on the right side of the document.


### PR DESCRIPTION
Backport: 23.055 => https://github.com/CollaboraOnline/online/pull/9866

- Adjusted the collapsedMarginToTheEdge so comment box does not get cut after document zoom
- better to have value same for all devices


Change-Id: I626388cdbf1db5bedf5f3fc5fe180e3d15a9ecfc


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

