### PR TITLE
Use $host instead of $http_host

### DIFF
--- a/etc/nginx/coolwsd.conf
+++ b/etc/nginx/coolwsd.conf
@@ -1,19 +1,19 @@
     # static files
     location ^~ /browser {
         proxy_pass http://localhost:9980;
-        proxy_set_header Host $http_host;
+        proxy_set_header Host $host;
     }
 
     # WOPI discovery URL
     location ^~ /hosting/discovery {
         proxy_pass http://localhost:9980;
-        proxy_set_header Host $http_host;
+        proxy_set_header Host $host;
     }
 
     # Capabilities
     location ^~ /hosting/capabilities {
         proxy_pass http://localhost:9980;
-        proxy_set_header Host $http_host;
+        proxy_set_header Host $host;
     }
 
     # main websocket
@@ -21,7 +21,7 @@
         proxy_pass http://localhost:9980;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";
-        proxy_set_header Host $http_host;
+        proxy_set_header Host $host;
         proxy_read_timeout 36000s;
     }
 
@@ -29,7 +29,7 @@
     # we accept 'lool' to be backward compatible
     location ~ ^/(c|l)ool {
         proxy_pass http://localhost:9980;
-        proxy_set_header Host $http_host;
+        proxy_set_header Host $host;
     }
 
     # Admin Console websocket
@@ -37,6 +37,6 @@
         proxy_pass http://localhost:9980;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";
-        proxy_set_header Host $http_host;
+        proxy_set_header Host $host;
         proxy_read_timeout 36000s;
     }


### PR DESCRIPTION
See https://trac.nginx.org/nginx/ticket/2468#comment:1


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- The documentation on https://sdk.collaboraonline.com/docs/installation/Proxy_settings.html#reverse-proxy-with-nginx-webserver should be updated, but I wasn't able to find a repo for it.

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

