### PR TITLE
wsd: no need to create existing mount-point

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -2945,12 +2945,17 @@ void lokit_main(
 
                 // Mount loTemplate inside it.
                 LOG_INF("Mounting " << loTemplate << " -> " << loJailDestPath);
-                JailUtil::createJailPath(loJailDestPath);
+                if (!FileUtil::Stat(loJailDestPath).exists())
+                {
+                    LOG_DBG("The mount-point [" << loJailDestPath
+                                                << "] doesn't exist. Binding will likely fail");
+                }
+
                 if (!JailUtil::bind(loTemplate, loJailDestPath)
                     || !JailUtil::remountReadonly(loTemplate, loJailDestPath))
                 {
                     LOG_WRN("Failed to mount [" << loTemplate << "] -> [" << loJailDestPath
-                                                << "], will link/copy contents.");
+                                                << "], will link/copy contents");
                     return false;
                 }
 


### PR DESCRIPTION
**Backported**

The mount-point must exist already, since
we always mount read-only. There is no
directory to create, but the subsequent
chmod always fails, since the mounted
directory is read-only. Since we started
warning when chmod fails recently,
6208b37a327266c583f47cdd13948d57ecfcce05,
these previously-silent failures became
noisy.

Change-Id: I9efaa89182c016e9a7a5d36cc3da5bfa7ee599c2
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
(cherry picked from commit c1ced10f17d1190f259030d93b8002aee177ce6b)
