### PR TITLE
revert scrollwindow patches breaking function wizard (co-24.04)

### DIFF
--- a/browser/src/control/jsdialog/Widget.ScrolledWindow.js
+++ b/browser/src/control/jsdialog/Widget.ScrolledWindow.js
@@ -142,8 +142,6 @@ function _scrolledWindowControl(parentContainer, data, builder) {
 		resizeObserver.observe(content);
 	}
 
-	var lastScrollV = null;
-	var lastScrollH = null;
 	var sendTimer = null;
 	if ((!noVertical && verticalSteps) || (!noHorizontal && horizontalSteps)) {
 		scrollwindow.addEventListener('scroll', function() {
@@ -161,18 +159,8 @@ function _scrolledWindowControl(parentContainer, data, builder) {
 			if (sendTimer)
 				clearTimeout(sendTimer);
 			sendTimer = setTimeout(function () {
-				var newScrollV = Math.round(scrollwindow.scrollTop / rowHeight);
-				if (lastScrollV !== newScrollV) {
-					lastScrollV = newScrollV;
-					builder.callback('scrolledwindow', 'scrollv', scrollwindow, newScrollV, builder);
-				}
-
-				var newScrollH = Math.round(scrollwindow.scrollLeft / 10);
-				if (lastScrollH !== newScrollH) {
-					lastScrollH = newScrollH;
-					builder.callback('scrolledwindow', 'scrollh', scrollwindow, newScrollH, builder);
-				}
-			}, 50);
+				builder.callback('scrolledwindow', 'scrollv', scrollwindow, Math.round(scrollwindow.scrollTop / rowHeight), builder);
+				builder.callback('scrolledwindow', 'scrollh', scrollwindow, Math.round(scrollwindow.scrollLeft / 10), builder); }, 50);
 		});
 	}
 

--- a/browser/src/control/jsdialog/Widget.ScrolledWindow.js
+++ b/browser/src/control/jsdialog/Widget.ScrolledWindow.js
@@ -89,8 +89,6 @@ function _scrolledWindowControl(parentContainer, data, builder) {
 	if (horizontalSteps < 0 || noHorizontal)
 		horizontalSteps = 0;
 
-	var rowHeight = 0;
-	
 	var timeoutLimit = 2;
 	var updateSize = function () {
 		realContentHeight = scrollwindow.scrollHeight;
@@ -100,67 +98,44 @@ function _scrolledWindowControl(parentContainer, data, builder) {
 				setTimeout(updateSize, 100);
 			return;
 		}
-		
-		if (!noVertical && data.vertical.upper > 0) {
-			if (rowHeight == 0) {
-				// determine the height a row
-				rowHeight = content.clientHeight / Math.min(data.vertical.upper, data.vertical.page_size);
-				// the content height might not include a new row being added, take it into account with the -1
-				if (!Number.isInteger(rowHeight)) {
-					rowHeight = content.clientHeight / (Math.min(data.vertical.upper, data.vertical.page_size) - 1);
-				}
-			}
-			var viewHeight = data.vertical.page_size * rowHeight;
-			var totalContentHeight = (data.vertical.upper -1) * rowHeight;
 
-			if (totalContentHeight != scrollwindow.scrollHeight) {
-				// only if view has changed
-				var marginTop = data.vertical.value * rowHeight;
-
-				content.style.marginBlockStart = marginTop + 'px';
-				content.style.height = (totalContentHeight - marginTop) + 'px';
-				scrollwindow.style.height = viewHeight + 'px';
-				scrollwindow.scrollTop = marginTop;
-			}
+		if (!noVertical) {
+			content.style.height = (realContentHeight + verticalSteps) + 'px';
+			scrollwindow.style.height = (realContentHeight + margin) + 'px';
 		}
 		if (!noHorizontal) {
 			content.style.width = (realContentWidth + horizontalSteps) + 'px';
 			scrollwindow.style.width = (realContentWidth + margin) + 'px';
 		}
 
+		content.scrollTop = data.vertical.value * 10;
 		content.scrollLeft = data.horizontal.value * 10;
-		content.style.marginInlineEnd = margin + 'px';
-		content.style.marginInlineStart = content.scrollLeft + 'px';
+
+		content.style.margin = content.scrollTop + 'px ' + margin + 'px ' + margin + 'px ' + content.scrollLeft + 'px';
 	};
 
-	if (data.user_managed_scrolling !== false) {
+	if (data.user_managed_scrolling !== false)
 		setTimeout(updateSize, 0);
 
-		var resizeObserver = new ResizeObserver(function () {
-			updateSize();
-		});
-		resizeObserver.observe(content);
-	}
-
 	var sendTimer = null;
+
 	if ((!noVertical && verticalSteps) || (!noHorizontal && horizontalSteps)) {
-		scrollwindow.addEventListener('scroll', function() {
+		scrollwindow.addEventListener('scroll', function () {
+			// keep content at the same place on the screen
+			var scrollTop = scrollwindow.scrollTop;
+			var scrollLeft = scrollwindow.scrollLeft;
+
 			if (data.user_managed_scrolling !== false) {
-				var viewHeight = data.vertical.page_size * rowHeight;
-				var totalContentHeight = Math.max((data.vertical.upper - 1) * rowHeight, viewHeight);
-				var marginTop = Math.round(scrollwindow.scrollTop / rowHeight) * rowHeight;
-	
-				content.style.marginBlockStart = marginTop + 'px';
-				content.style.height = (totalContentHeight - marginTop) + 'px';
-				content.style.width = (realContentWidth - scrollwindow.scrollLeft + horizontalSteps) + 'px';
-				content.style.marginInlineStart = scrollwindow.scrollLeft + 'px';
+				content.style.margin = scrollTop + 'px ' + margin + 'px ' + margin + 'px ' + scrollLeft + 'px';
+				content.style.height = (realContentHeight - scrollTop + verticalSteps) + 'px';
+				content.style.width = (realContentWidth - scrollLeft + horizontalSteps) + 'px';
 			}
 
 			if (sendTimer)
 				clearTimeout(sendTimer);
 			sendTimer = setTimeout(function () {
-				builder.callback('scrolledwindow', 'scrollv', scrollwindow, Math.round(scrollwindow.scrollTop / rowHeight), builder);
-				builder.callback('scrolledwindow', 'scrollh', scrollwindow, Math.round(scrollwindow.scrollLeft / 10), builder); }, 50);
+				builder.callback('scrolledwindow', 'scrollv', scrollwindow, Math.round(scrollTop / 10), builder);
+				builder.callback('scrolledwindow', 'scrollh', scrollwindow, Math.round(scrollLeft / 10), builder); }, 50);
 		});
 	}
 

--- a/browser/src/control/jsdialog/Widget.ScrolledWindow.js
+++ b/browser/src/control/jsdialog/Widget.ScrolledWindow.js
@@ -77,7 +77,7 @@ function _scrolledWindowControl(parentContainer, data, builder) {
 		scrollwindow.style.overflowX = 'scroll';
 
 	var realContentHeight = scrollwindow.scrollHeight;
-	var realContentWidth = scrollwindow.scrollWidth;
+	var realContentWidth = scrollwindow.scrollwidth;
 
 	var margin = 15;
 
@@ -94,7 +94,7 @@ function _scrolledWindowControl(parentContainer, data, builder) {
 	var timeoutLimit = 2;
 	var updateSize = function () {
 		realContentHeight = scrollwindow.scrollHeight;
-		realContentWidth = scrollwindow.scrollWidth;
+		realContentWidth = scrollwindow.scrollwidth;
 		if (realContentHeight === 0 || realContentWidth === 0) {
 			if (timeoutLimit--)
 				setTimeout(updateSize, 100);


### PR DESCRIPTION
This reverts subset of: https://github.com/CollaboraOnline/online/pull/8011
Impact:
- calc function wizard
- insert symbol
- file properties - custom properties

Related bugs on master:
https://github.com/CollaboraOnline/online/issues/9614
https://github.com/CollaboraOnline/online/issues/9559
https://github.com/CollaboraOnline/online/issues/9770

It seems it fixes all of them, but breaks "polished look" of custom properties. Which is less damage.
cc: @meven @thebearon @timar 

