### PR TITLE
Handle limited open Connections due to keepalive connections

### DIFF
--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -17,6 +17,7 @@
 
 #include <common/StateEnum.hpp>
 #include "Util.hpp"
+#include "NetUtil.hpp"
 #include "net/Socket.hpp"
 #include <Poco/Exception.h>
 
@@ -412,6 +413,9 @@ public:
 
     /// Manipulate and modify the configuration before any usage.
     virtual void configure(Poco::Util::LayeredConfiguration& /* config */) {}
+
+    /// Manipulate and modify the net::Defaults for before any usage.
+    virtual void configure(net::Defaults& /* defaults */) {}
 
     /// Main-loop reached, time for testing.
     /// Invoked from coolwsd's main thread.

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -67,6 +67,7 @@
 #include <common/JsonUtil.hpp>
 #include "KitHelper.hpp"
 #include "Kit.hpp"
+#include <NetUtil.hpp>
 #include <Protocol.hpp>
 #include <Log.hpp>
 #include <Png.hpp>
@@ -1449,7 +1450,7 @@ bool Document::forkToSave(const std::function<void()> &childSave, int viewId)
     // FIXME: defer and queue a 2nd save if queued during save ...
 
     std::shared_ptr<StreamSocket> parentSocket, childSocket;
-    if (!StreamSocket::socketpair(parentSocket, childSocket))
+    if (!StreamSocket::socketpair(start, parentSocket, childSocket))
         return false;
 
     // To encode into the child process id for debugging
@@ -2910,7 +2911,7 @@ void documentViewCallback(const int type, const char* payload, void* data)
 int pollCallback(void* pData, int timeoutUs)
 {
     if (timeoutUs < 0)
-        timeoutUs = SocketPoll::DefaultPollTimeoutMicroS.count();
+        timeoutUs = net::Defaults::get().SocketPollTimeout.count();
 #ifndef IOS
     if (!pData)
         return 0;

--- a/net/DelaySocket.cpp
+++ b/net/DelaySocket.cpp
@@ -51,8 +51,8 @@ class DelaySocket : public Socket {
 
     std::vector<std::shared_ptr<WriteChunk>> _chunks;
 public:
-    DelaySocket(int delayMs, int fd) :
-        Socket (fd, Socket::Type::Unix), _delayMs(delayMs),
+    DelaySocket(int delayMs, int fd, std::chrono::steady_clock::time_point creationTime) :
+        Socket(fd, Socket::Type::Unix, creationTime), _delayMs(delayMs),
         _state(State::ReadWrite)
 	{
 //        setSocketBufferSize(Socket::DefaultSendBufferSize);
@@ -260,8 +260,9 @@ int Delay::create(int delayMs, int physicalFd)
         int internalFd = pair[0];
         int delayFd = pair[1];
 
-        auto physical = std::make_shared<DelaySocket>(delayMs, physicalFd);
-        auto internal = std::make_shared<DelaySocket>(delayMs, internalFd);
+        const std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
+        auto physical = std::make_shared<DelaySocket>(delayMs, physicalFd, now);
+        auto internal = std::make_shared<DelaySocket>(delayMs, internalFd, now);
         physical->setDestination(internal);
         internal->setDestination(physical);
 

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -1199,9 +1199,9 @@ public:
     }
 
     /// Returns the default timeout.
-    static constexpr std::chrono::milliseconds getDefaultTimeout()
+    static std::chrono::milliseconds getDefaultTimeout()
     {
-        return std::chrono::seconds(30);
+        return std::chrono::duration_cast<std::chrono::milliseconds>( net::Defaults::get().HTTPTimeout );
     }
 
     /// Returns the current protocol scheme.

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -153,6 +153,8 @@ STATE_ENUM(FieldParseState,
 /// See https://en.wikipedia.org/wiki/List_of_HTTP_status_codes
 enum class StatusCode : unsigned
 {
+    None = 0, // Undefined status (unknown)
+
     // Informational
     Continue = 100,
     SwitchingProtocols = 101,

--- a/net/NetUtil.hpp
+++ b/net/NetUtil.hpp
@@ -39,6 +39,8 @@ public:
     /// http::Session timeout in us (30s default). Zero disables metric.
     std::chrono::microseconds HTTPTimeout;
 
+    /// Maximum total connections (9999 or MAX_CONNECTIONS). Zero disables metric.
+    size_t MaxConnections;
     /// Socket minimum bits per seconds throughput (0). Zero disables metric.
     double MinBytesPerSec;
 
@@ -50,6 +52,7 @@ private:
         : WSPingTimeout(std::chrono::microseconds(2000000))
         , WSPingPeriod(std::chrono::microseconds(3000000))
         , HTTPTimeout(std::chrono::microseconds(30000000))
+        , MaxConnections(9999)
         , MinBytesPerSec(0.0)
         , SocketPollTimeout(std::chrono::microseconds(64000000))
     {

--- a/net/NetUtil.hpp
+++ b/net/NetUtil.hpp
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <functional>
 #include <string>
 #include <memory>
@@ -27,6 +28,43 @@ struct sockaddr;
 
 namespace net
 {
+
+class Defaults
+{
+public:
+    /// WebSocketHandler ping timeout in us (2s default). Zero disables metric.
+    std::chrono::microseconds WSPingTimeout;
+    /// WebSocketHandler ping period in us (3s default), i.e. duration until next ping. Zero disables metric.
+    std::chrono::microseconds WSPingPeriod;
+    /// http::Session timeout in us (30s default). Zero disables metric.
+    std::chrono::microseconds HTTPTimeout;
+
+    /// Socket minimum bits per seconds throughput (0). Zero disables metric.
+    double MinBytesPerSec;
+
+    /// Socket poll timeout in us (64s), useful to increase for debugging.
+    std::chrono::microseconds SocketPollTimeout;
+
+private:
+    Defaults()
+        : WSPingTimeout(std::chrono::microseconds(2000000))
+        , WSPingPeriod(std::chrono::microseconds(3000000))
+        , HTTPTimeout(std::chrono::microseconds(30000000))
+        , MinBytesPerSec(0.0)
+        , SocketPollTimeout(std::chrono::microseconds(64000000))
+    {
+    }
+
+public:
+    Defaults(const Defaults&) = delete;
+    Defaults(Defaults&&) = delete;
+
+    static Defaults& get()
+    {
+        static Defaults def;
+        return def;
+    }
+};
 
 class HostEntry
 {

--- a/net/ServerSocket.hpp
+++ b/net/ServerSocket.hpp
@@ -39,7 +39,7 @@ public:
     }
 
     /// Control access to a bound TCP socket
-    enum Type { Local, Public };
+    STATE_ENUM(Type, Local, Public);
 
     /// Create a new server socket - accepted sockets will be added
     /// to the @clientSockets' poll when created with @factory.

--- a/net/ServerSocket.hpp
+++ b/net/ServerSocket.hpp
@@ -28,8 +28,10 @@ public:
 class ServerSocket : public Socket
 {
 public:
-    ServerSocket(Socket::Type type, SocketPoll& clientPoller, std::shared_ptr<SocketFactory> sockFactory) :
-        Socket(type),
+    ServerSocket(Socket::Type type,
+                 std::chrono::steady_clock::time_point creationTime,
+                 SocketPoll& clientPoller, std::shared_ptr<SocketFactory> sockFactory) :
+        Socket(type, creationTime),
 #if !MOBILEAPP
         _type(type),
 #endif
@@ -43,11 +45,14 @@ public:
 
     /// Create a new server socket - accepted sockets will be added
     /// to the @clientSockets' poll when created with @factory.
-    static std::shared_ptr<ServerSocket> create(ServerSocket::Type type, int port,
-                                                Socket::Type socketType, SocketPoll& clientSocket,
+    static std::shared_ptr<ServerSocket> create(ServerSocket::Type type,
+                                                int port,
+                                                Socket::Type socketType,
+                                                std::chrono::steady_clock::time_point creationTime,
+                                                SocketPoll& clientSocket,
                                                 std::shared_ptr<SocketFactory> factory)
     {
-        auto serverSocket = std::make_shared<ServerSocket>(socketType, clientSocket, std::move(factory));
+        auto serverSocket = std::make_shared<ServerSocket>(socketType, creationTime, clientSocket, std::move(factory));
 
         if (serverSocket && serverSocket->bind(type, port) && serverSocket->listen())
             return serverSocket;
@@ -130,8 +135,9 @@ private:
 class LocalServerSocket : public ServerSocket
 {
 public:
-    LocalServerSocket(SocketPoll& clientPoller, std::shared_ptr<SocketFactory> sockFactory) :
-        ServerSocket(Socket::Type::Unix, clientPoller, std::move(sockFactory))
+    LocalServerSocket(std::chrono::steady_clock::time_point creationTime,
+                      SocketPoll& clientPoller, std::shared_ptr<SocketFactory> sockFactory) :
+        ServerSocket(Socket::Type::Unix, creationTime, clientPoller, std::move(sockFactory))
     {
     }
     ~LocalServerSocket() override;

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -556,6 +556,14 @@ int SocketPoll::poll(int64_t timeoutMaxMicroS)
                 // removed in a callback
                 ++itemsErased;
             }
+            else if (!_pollSockets[i]->isOpen())
+            {
+                // closed socket ..
+                ++itemsErased;
+                LOGA_TRC(Socket, '#' << _pollFds[i].fd << ": Removing socket (at " << i
+                         << " of " << _pollSockets.size() << ") from " << _name);
+                _pollSockets[i] = nullptr;
+            }
             else if (_pollFds[i].fd == _pollSockets[i]->getFD())
             {
                 SocketDisposition disposition(_pollSockets[i]);
@@ -575,7 +583,7 @@ int SocketPoll::poll(int64_t timeoutMaxMicroS)
                     rc = -1;
                 }
 
-                if (!disposition.isContinue())
+                if (!_pollSockets[i]->isOpen() || !disposition.isContinue())
                 {
                     ++itemsErased;
                     LOGA_TRC(Socket, '#' << _pollFds[i].fd << ": Removing socket (at " << i

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -1354,6 +1354,36 @@ LocalServerSocket::~LocalServerSocket()
 #  define LOG_CHUNK(X)
 #endif
 
+#endif // !MOBILEAPP
+
+std::string StreamSocket::toString(WSState t)
+{
+    if( WSState::WS == t )
+    {
+        return "WS";
+    }
+    return "HTTP";
+}
+
+std::ostream& StreamSocket::stream(std::ostream& os) const
+{
+    os << "StreamSocket[#" << getFD()
+       << ", " << toString(_wsState)
+       << ", " << Socket::toString(type())
+       << " @ ";
+    if (Type::IPv6 == type())
+    {
+        os << "[" << clientAddress() << "]:" << clientPort();
+    }
+    else
+    {
+        os << clientAddress() << ":" << clientPort();
+    }
+    return os << "]";
+}
+
+#if !MOBILEAPP
+
 bool StreamSocket::parseHeader(const char *clientName,
                                Poco::MemoryInputStream &message,
                                Poco::Net::HTTPRequest &request,

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -99,6 +99,41 @@ int Socket::createSocket([[maybe_unused]] Socket::Type type)
     return fakeSocketSocket();
 }
 
+std::ostream& Socket::streamStats(std::ostream& os, const std::chrono::steady_clock::time_point &now) const
+{
+    const auto durTotal = std::chrono::duration_cast<std::chrono::milliseconds>(now - _creationTime);
+    const auto durLast = std::chrono::duration_cast<std::chrono::milliseconds>(now - _lastSeenTime);
+
+    float kBpsIn, kBpsOut;
+    if (durTotal.count() > 0)
+    {
+        kBpsIn = (float)_bytesRcvd / (float)durTotal.count();
+        kBpsOut = (float)_bytesSent / (float)durTotal.count();
+    }
+    else
+    {
+        kBpsIn = (float)_bytesRcvd / 1000.0f;
+        kBpsOut = (float)_bytesSent / 1000.0f;
+    }
+
+    const std::streamsize p = os.precision();
+    os.precision(1);
+    os << "Stats[dur[total "
+        << durTotal.count() << "ms, last "
+        << durLast.count() << " ms], kBps[in "
+        << kBpsIn << ", out " << kBpsOut
+        << "]]";
+    os.precision(p);
+    return os;
+}
+
+std::string Socket::getStatsString(const std::chrono::steady_clock::time_point &now) const
+{
+    std::ostringstream oss;
+    streamStats(oss, now);
+    return oss.str();
+}
+
 std::ostream& Socket::streamImpl(std::ostream& os) const
 {
     os << "Socket[#" << getFD()
@@ -986,8 +1021,8 @@ void StreamSocket::dumpState(std::ostream& os)
     const int events = getPollEvents(std::chrono::steady_clock::now(), timeoutMaxMicroS);
     os << '\t' << std::setw(6) << getFD() << "\t0x" << std::hex << events << std::dec << '\t'
        << (ignoringInput() ? "ignore\t" : "process\t") << std::setw(6) << _inBuffer.size() << '\t'
-       << std::setw(6) << _outBuffer.size() << '\t' << " r: " << std::setw(6) << _bytesRecvd
-       << "\t w: " << std::setw(6) << _bytesSent << '\t' << clientAddress() << '\t';
+       << std::setw(6) << _outBuffer.size() << '\t' << " r: " << std::setw(6) << bytesRcvd()
+       << "\t w: " << std::setw(6) << bytesSent() << '\t' << clientAddress() << '\t';
     _socketHandler->dumpState(os);
     if (_inBuffer.size() > 0)
         Util::dumpHex(os, _inBuffer, "\t\tinBuffer:\n", "\t\t");
@@ -1613,7 +1648,7 @@ bool StreamSocket::compactChunks(MessageMap& map)
 bool StreamSocket::sniffSSL() const
 {
     // Only sniffing the first bytes of a socket.
-    if (_bytesSent > 0 || _bytesRecvd != _inBuffer.size() || _bytesRecvd < 6)
+    if (bytesSent() > 0 || bytesRcvd() != _inBuffer.size() || bytesRcvd() < 6)
         return false;
 
     // 0x0000  16 03 01 02 00 01 00 01

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -15,6 +15,7 @@
 #include "TraceEvent.hpp"
 #include "Util.hpp"
 
+#include <atomic>
 #include <chrono>
 #include <cstring>
 #include <cctype>
@@ -60,6 +61,25 @@ std::atomic<bool> SocketPoll::InhibitThreadChecks(false);
 std::atomic<bool> Socket::InhibitThreadChecks(false);
 
 std::unique_ptr<Watchdog> SocketPoll::PollWatchdog;
+
+std::mutex SocketPoll::StatsMutex;
+std::atomic<size_t> SocketPoll::StatsConnectionCount(0);
+
+size_t SocketPoll::StatsConnectionMod(size_t added, size_t removed) {
+    if( added == 0 && removed == 0 ) {
+        return GetStatsConnectionCount();
+    }
+    size_t res, pre;
+    {
+        std::lock_guard<std::mutex> lock(StatsMutex);
+        pre = GetStatsConnectionCount();
+        res = pre + added; // overflow impossible due to MAX_CONNECTIONS
+        res -= removed; // underflow impossible due to MAX_CONNECTIONS
+        StatsConnectionCount.store(res, std::memory_order_seq_cst);
+    }
+    LOG_DBG("SocketPoll::ConnectionCount: " << pre << " +" << added << " -" << removed << " = " << res);
+    return res;
+}
 
 #define SOCKET_ABSTRACT_UNIX_NAME "0coolwsd-"
 
@@ -293,6 +313,8 @@ namespace {
 SocketPoll::SocketPoll(std::string threadName)
     : _name(std::move(threadName)),
       _pollTimeout( net::Defaults::get().SocketPollTimeout ),
+      _limitedConnections( false ),
+      _connectionLimit( 0 ),
       _pollStartIndex(0),
       _stop(false),
       _threadStarted(0),
@@ -494,6 +516,8 @@ int SocketPoll::poll(int64_t timeoutMaxMicroS)
     // The events to poll on change each spin of the loop.
     setupPollFds(now, timeoutMaxMicroS);
     const size_t size = _pollSockets.size();
+    size_t itemsAdded = 0;
+    size_t itemsErased = 0;
 
     // disable watchdog - it's good to sleep
     disableWatchdog();
@@ -546,7 +570,29 @@ int SocketPoll::poll(int64_t timeoutMaxMicroS)
         std::vector<CallbackFn> invoke;
         {
             std::lock_guard<std::mutex> lock(_mutex);
+            const size_t newConnCount = _newSockets.size();
+            const size_t globCount = GetStatsConnectionCount();
 
+            if( _limitedConnections &&
+                _connectionLimit > 0 &&
+                globCount + newConnCount > _connectionLimit)
+            {
+                // For now we simply drop new connections
+                const size_t overhead = globCount + newConnCount - _connectionLimit;
+                for(size_t i=0; i<overhead; ++i)
+                {
+                    std::shared_ptr<Socket>& socket = _newSockets.back(); // oldest
+                    assert(socket);
+
+                    LOG_WRN("Limiter: #" << socket->getFD() << ": Removing "
+                             << (i+1) << " / " << overhead << " new socket of (pre "
+                             << globCount << " + new " << newConnCount << ") / max " << _connectionLimit
+                             << " from " << _name);
+
+                    socket->resetThreadOwner();
+                    _newSockets.pop_back();
+                }
+            }
             if (!_newSockets.empty())
             {
                 LOGA_TRC(Socket, "Inserting " << _newSockets.size() << " new sockets after the existing "
@@ -558,6 +604,8 @@ int SocketPoll::poll(int64_t timeoutMaxMicroS)
 
                 // Copy the new sockets over and clear.
                 _pollSockets.insert(_pollSockets.end(), _newSockets.begin(), _newSockets.end());
+
+                itemsAdded += _newSockets.size();
 
                 _newSockets.clear();
             }
@@ -592,10 +640,15 @@ int SocketPoll::poll(int64_t timeoutMaxMicroS)
         }
     }
 
-    if (_pollSockets.size() != size)
+    if (itemsAdded != _pollSockets.size() - size)
     {
-        LOG_TRC("PollSocket container size has changed from " << size << " to "
-                                                              << _pollSockets.size());
+        // unexpected
+        LOG_WRN("PollSocket container size has changed from " << size
+            << " + " << itemsAdded << " to " << _pollSockets.size());
+    } else if (itemsAdded > 0)
+    {
+        LOG_TRC("PollSocket container size increased from " << size
+            << " + " << itemsAdded << " to " << _pollSockets.size());
     }
 
     // If we had sockets to process.
@@ -612,7 +665,6 @@ int SocketPoll::poll(int64_t timeoutMaxMicroS)
         if (_pollStartIndex > size - 1)
             _pollStartIndex = 0;
 
-        size_t itemsErased = 0;
         size_t i = _pollStartIndex;
         for (std::size_t j = 0; j < size; ++j)
         {
@@ -691,15 +743,35 @@ int SocketPoll::poll(int64_t timeoutMaxMicroS)
 
         if (itemsErased)
         {
-            LOG_TRC("Scanning to removing " << itemsErased << " defunct sockets from "
-                    << _pollSockets.size() << " sockets");
+            const size_t itemsErasedPre = itemsErased;
+            itemsErased = 0; // correcting itemsErased
 
             _pollSockets.erase(
                 std::remove_if(_pollSockets.begin(), _pollSockets.end(),
-                    [](const std::shared_ptr<Socket>& s)->bool
-                    { return !s; }),
+                               [&itemsErased](const std::shared_ptr<Socket>& s) -> bool
+                               {
+                                   if (!s)
+                                   {
+                                       ++itemsErased;
+                                       return true;
+                                   }
+                                   else
+                                   {
+                                       return false;
+                                   }
+                               }),
                 _pollSockets.end());
+
+            LOG_TRC("Removed " << itemsErased
+                    << "(" << itemsErasedPre << ") defunct sockets from "
+                    << _pollSockets.size() << " sockets");
         }
+    }
+    if( _limitedConnections )
+    {
+        // Perform bookkeeping if required
+        // New connections might be dropped if exceeding limits, see _newSockets above.
+        StatsConnectionMod(itemsAdded, itemsErased);
     }
 
     return rc;
@@ -807,9 +879,11 @@ void SocketPoll::createWakeups()
 void SocketPoll::removeSockets()
 {
     LOG_DBG("Removing all " << _pollSockets.size() + _newSockets.size()
-                            << " sockets from SocketPoll thread " << _name);
+                            << " sockets from SocketPoll thread " << _name
+                            << " of " << GetStatsConnectionCount() << " total poll sockets");
     ASSERT_CORRECT_SOCKET_THREAD(this);
 
+    size_t removedPollSockets = 0;
     while (!_pollSockets.empty())
     {
         const std::shared_ptr<Socket>& socket = _pollSockets.back();
@@ -820,6 +894,10 @@ void SocketPoll::removeSockets()
         socket->resetThreadOwner();
 
         _pollSockets.pop_back();
+        ++removedPollSockets;
+    }
+    if( _limitedConnections ) {
+        StatsConnectionMod(0, removedPollSockets);
     }
 
     while (!_newSockets.empty())
@@ -1087,7 +1165,9 @@ void SocketPoll::dumpState(std::ostream& os) const
     const auto pollSockets = _pollSockets;
 
     os << "\n  SocketPoll [" << name() << "] with " << pollSockets.size() << " socket"
-       << (pollSockets.size() == 1 ? "" : "s") << " - wakeup rfd: " << _wakeup[0]
+       << (pollSockets.size() == 1 ? "" : "s")
+       << " of " << GetStatsConnectionCount()
+       << " total - wakeup rfd: " << _wakeup[0]
        << " wfd: " << _wakeup[1] << '\n';
     const auto callbacks = _newCallbacks.size();
     if (callbacks > 0)
@@ -1452,15 +1532,14 @@ bool StreamSocket::checkRemoval(std::chrono::steady_clock::time_point now)
                 LOG_WRN("Socket still open post onDisconnect(), forced shutdown.");
                 shutdown(); // signal
                 closeConnection(); // real -> setClosed()
-                assert(isOpen() == false); // should have issued shutdown
             }
         }
         else
         {
             shutdown(); // signal
             closeConnection(); // real -> setClosed()
-            assert(isOpen() == false); // should have issued shutdown
         }
+        assert(isOpen() == false); // should have issued shutdown
         return true;
     }
     else if (_socketHandler && _socketHandler->checkTimeout(now))
@@ -1469,8 +1548,6 @@ bool StreamSocket::checkRemoval(std::chrono::steady_clock::time_point now)
         setClosed();
         LOG_WRN("CheckRemoval: Timeout: " << getStatsString(now) << ", " << *this);
         return true;
-    } else {
-        LOG_DBG("CheckRemoval: Test " << getStatsString(now) << ", " << *this);
     }
     return false;
 }

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -1410,6 +1410,7 @@ std::ostream& StreamSocket::stream(std::ostream& os) const
 bool StreamSocket::parseHeader(const char *clientName,
                                Poco::MemoryInputStream &message,
                                Poco::Net::HTTPRequest &request,
+                               std::chrono::steady_clock::time_point &lastHTTPHeader,
                                MessageMap& map)
 {
     assert(map._headerSize == 0 && map._messageSize == 0);
@@ -1418,7 +1419,7 @@ bool StreamSocket::parseHeader(const char *clientName,
         std::chrono::duration_cast<std::chrono::milliseconds>(_httpTimeout);
 
     std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
-    std::chrono::duration<float, std::milli> delayMs = now - _lastSeenHTTPHeader;
+    std::chrono::duration<float, std::milli> delayMs = now - lastHTTPHeader;
 
     // Find the end of the header, if any.
     static const std::string marker("\r\n\r\n");
@@ -1512,7 +1513,7 @@ bool StreamSocket::parseHeader(const char *clientName,
                 if (chunkLen == 0) // we're complete.
                 {
                     map._messageSize = chunkOffset;
-                    _lastSeenHTTPHeader = now;
+                    lastHTTPHeader = now;
                     return true;
                 }
 
@@ -1605,7 +1606,7 @@ bool StreamSocket::parseHeader(const char *clientName,
         return false;
     }
 
-    _lastSeenHTTPHeader = now;
+    lastHTTPHeader = now;
     return true;
 }
 

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -20,6 +20,7 @@
 #include <cctype>
 #include <iomanip>
 #include <memory>
+#include <ostream>
 #include <ratio>
 #include <sstream>
 #include <cstdio>
@@ -67,6 +68,22 @@ std::unique_ptr<Watchdog> SocketPoll::PollWatchdog;
 
 #define SOCKET_ABSTRACT_UNIX_NAME "0coolwsd-"
 
+std::string Socket::toString(Type t)
+{
+    switch (t)
+    {
+        case Type::IPv4:
+            return "IPv4";
+        case Type::IPv6:
+            return "IPv6";
+        case Type::All:
+            return "All";
+        case Type::Unix:
+            return "Unix";
+    }
+    return "Unknown";
+}
+
 int Socket::createSocket([[maybe_unused]] Socket::Type type)
 {
     if constexpr (!Util::isMobileApp())
@@ -87,6 +104,28 @@ int Socket::createSocket([[maybe_unused]] Socket::Type type)
     return fakeSocketSocket();
 }
 
+std::ostream& Socket::streamImpl(std::ostream& os) const
+{
+    os << "Socket[#" << getFD()
+       << ", " << toString(type())
+       << " @ ";
+    if (Type::IPv6 == type())
+    {
+        os << "[" << clientAddress() << "]:" << clientPort();
+    }
+    else
+    {
+        os << clientAddress() << ":" << clientPort();
+    }
+    return os << "]";
+}
+
+std::string Socket::toStringImpl() const
+{
+    std::ostringstream oss;
+    streamImpl(oss);
+    return oss.str();
+}
 
 bool StreamSocket::socketpair(std::shared_ptr<StreamSocket> &parent,
                               std::shared_ptr<StreamSocket> &child)
@@ -110,7 +149,6 @@ bool StreamSocket::socketpair(std::shared_ptr<StreamSocket> &parent,
 
     return true;
 }
-
 
 #if ENABLE_DEBUG
 static std::atomic<long> socketErrorCount;
@@ -1115,7 +1153,7 @@ std::shared_ptr<Socket> ServerSocket::accept()
             std::shared_ptr<Socket> _socket = createSocketFromAccept(rc, type);
 
             ::inet_ntop(clientInfo.sin6_family, inAddr, addrstr, sizeof(addrstr));
-            _socket->setClientAddress(addrstr); // @ clientInfo.sin6_port
+            _socket->setClientAddress(addrstr, clientInfo.sin6_port);
 
             LOG_TRC("Accepted socket #" << _socket->getFD() << " has family "
                                         << clientInfo.sin6_family << " address "

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -1356,19 +1356,10 @@ LocalServerSocket::~LocalServerSocket()
 
 #endif // !MOBILEAPP
 
-std::string StreamSocket::toString(WSState t)
-{
-    if( WSState::WS == t )
-    {
-        return "WS";
-    }
-    return "HTTP";
-}
-
 std::ostream& StreamSocket::stream(std::ostream& os) const
 {
     os << "StreamSocket[#" << getFD()
-       << ", " << toString(_wsState)
+       << ", " << toStringShort(_wsState)
        << ", " << Socket::toString(type())
        << " @ ";
     if (Type::IPv6 == type())

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -165,15 +165,8 @@ public:
     /// Returns true if this socket has been closed, i.e. rejected from polling and potentially shutdown
     bool isClosed() const { return !_open; }
 
-    void setClientAddress(const std::string& address)
-    {
-        _clientAddress = address;
-    }
-
-    const std::string& clientAddress() const
-    {
-        return _clientAddress;
-    }
+    void setClientAddress(const std::string& address) { _clientAddress = address; }
+    const std::string& clientAddress() const { return _clientAddress; }
 
     /// Returns the OS native socket fd.
     int getFD() const { return _fd; }

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -139,6 +139,7 @@ public:
     // NB. see other Socket::Socket by init below.
     Socket(Type type)
         : _fd(createSocket(type))
+        , _open(_fd >= 0)
     {
         init(type);
     }
@@ -159,7 +160,13 @@ public:
         }
     }
 
+    /// Returns true if this socket is open, i.e. allowed to be polled and not shutdown
+    bool isOpen() const { return _open; }
+    /// Returns true if this socket has been closed, i.e. rejected from polling and potentially shutdown
+    bool isClosed() const { return !_open; }
+
     /// Create socket of the given type.
+    /// return >= 0 for a successfully created socket, -1 on error
     static int createSocket(Type type);
 
     void setClientAddress(const std::string& address)
@@ -373,6 +380,7 @@ protected:
     /// Used by accept() only.
     Socket(const int fd, Type type)
         : _fd(fd)
+        , _open(_fd >= 0)
     {
         init(type);
     }
@@ -381,6 +389,9 @@ protected:
 
     /// avoid doing a shutdown before close
     void setNoShutdown() { _noShutdown = true; }
+
+    /// Explicitly marks this socket closed, i.e. rejected from polling and potentially shutdown
+    void setClosed() { _open = false; }
 
 private:
     void init(Type type)
@@ -408,6 +419,8 @@ private:
 
     std::string _clientAddress;
     const int _fd;
+    /// True if this socket is open.
+    bool _open;
 
     // If _ignoreInput is true no more input from this socket will be processed.
     bool _ignoreInput;
@@ -978,7 +991,6 @@ public:
         _bytesRecvd(0),
         _wsState(WSState::HTTP),
         _isLocalHost(hostType == LocalHost),
-        _closed(false),
         _sentHTTPContinue(false),
         _shutdownSignalled(false),
         _readType(readType),
@@ -993,7 +1005,7 @@ public:
         LOG_TRC("StreamSocket dtor called with pending write: " << _outBuffer.size()
                                                                 << ", read: " << _inBuffer.size());
 
-        if (!_closed)
+        if (isOpen())
         {
             ASSERT_CORRECT_SOCKET_THREAD(this);
             if (_socketHandler)
@@ -1008,7 +1020,6 @@ public:
         }
     }
 
-    bool isClosed() const { return _closed; }
     bool isWebSocket() const { return _wsState == WSState::WS; }
     void setWebSocket() { _wsState = WSState::WS; }
     bool isLocalHost() const { return _isLocalHost; }
@@ -1468,11 +1479,11 @@ protected:
         if (closed)
         {
             LOG_TRC("Closed. Firing onDisconnect.");
-            _closed = true;
+            setClosed();
             _socketHandler->onDisconnect();
         }
 
-        if (_closed)
+        if (isClosed())
             disposition.setClosed();
     }
 
@@ -1662,9 +1673,6 @@ private:
 
     /// True if host is localhost
     bool _isLocalHost;
-
-    /// True if we are already closed.
-    bool _closed;
 
     /// True if we've received a Continue in response to an Expect: 100-continue
     bool _sentHTTPContinue;

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -165,10 +165,6 @@ public:
     /// Returns true if this socket has been closed, i.e. rejected from polling and potentially shutdown
     bool isClosed() const { return !_open; }
 
-    /// Create socket of the given type.
-    /// return >= 0 for a successfully created socket, -1 on error
-    static int createSocket(Type type);
-
     void setClientAddress(const std::string& address)
     {
         _clientAddress = address;
@@ -399,6 +395,10 @@ protected:
     void setClosed(SocketDisposition &disposition) { setClosed(); disposition.setClosed(); }
 
 private:
+    /// Create socket of the given type.
+    /// return >= 0 for a successfully created socket, -1 on error
+    static int createSocket(Type type);
+
     void init(Type type)
     {
         if (type != Type::Unix)

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -176,14 +176,14 @@ public:
     /// Returns true if this socket has been closed, i.e. rejected from polling and potentially shutdown
     bool isClosed() const { return !_open; }
 
-    Type type() const { return _type; }
-    bool isIPType() const { return Type::IPv4 == _type || Type::IPv6 == _type; }
+    constexpr Type type() const { return _type; }
+    constexpr bool isIPType() const { return Type::IPv4 == _type || Type::IPv6 == _type; }
     void setClientAddress(const std::string& address, unsigned int port=0) { _clientAddress = address; _clientPort=port; }
     const std::string& clientAddress() const { return _clientAddress; }
     unsigned int clientPort() const { return _clientPort; }
 
     /// Returns the OS native socket fd.
-    int getFD() const { return _fd; }
+    constexpr int getFD() const { return _fd; }
 
     std::ostream& streamStats(std::ostream& os, const std::chrono::steady_clock::time_point &now) const;
     std::string getStatsString(const std::chrono::steady_clock::time_point &now) const;
@@ -191,20 +191,20 @@ public:
     virtual std::ostream& stream(std::ostream& os) const  { return streamImpl(os); }
 
     /// Returns monotonic creation timestamp
-    std::chrono::steady_clock::time_point getCreationTime() const { return _creationTime; }
+    constexpr std::chrono::steady_clock::time_point getCreationTime() const { return _creationTime; }
     /// Returns monotonic timestamp of last received signal from remote
-    std::chrono::steady_clock::time_point getLastSeenTime() const { return _lastSeenTime; }
+    constexpr std::chrono::steady_clock::time_point getLastSeenTime() const { return _lastSeenTime; }
 
     /// Sets monotonic timestamp of last received signal from remote
     void setLastSeenTime(std::chrono::steady_clock::time_point now) { _lastSeenTime = now; }
 
     /// Returns bytes sent statistic
-    uint64_t bytesSent() const { return _bytesSent; }
+    constexpr uint64_t bytesSent() const { return _bytesSent; }
     /// Returns bytes received statistic
-    uint64_t bytesRcvd() const { return _bytesRcvd; }
+    constexpr uint64_t bytesRcvd() const { return _bytesRcvd; }
 
     /// Get input/output statistics on this stream
-    void getIOStats(uint64_t &sent, uint64_t &recv) const
+    constexpr void getIOStats(uint64_t &sent, uint64_t &recv) const
     {
         sent = _bytesSent;
         recv = _bytesRcvd;
@@ -429,9 +429,9 @@ protected:
     inline void logPrefix(std::ostream& os) const { os << '#' << _fd << ": "; }
 
     /// Adds `len` sent bytes to statistic
-    void notifyBytesSent(uint64_t len) { _bytesSent += len; }
+    constexpr void notifyBytesSent(uint64_t len) { _bytesSent += len; }
     /// Adds `len` received bytes to statistic
-    void notifyBytesRcvd(uint64_t len) { _bytesRcvd += len; }
+    constexpr void notifyBytesRcvd(uint64_t len) { _bytesRcvd += len; }
 
     /// avoid doing a shutdown before close
     void setNoShutdown() { _noShutdown = true; }

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -135,13 +135,16 @@ public:
     static std::atomic<bool> InhibitThreadChecks;
 
     enum Type { IPv4, IPv6, All, Unix };
+    static std::string toString(Type t);
 
     // NB. see other Socket::Socket by init below.
     Socket(Type type)
-        : _fd(createSocket(type))
+        : _type(type)
+        , _clientPort(0)
+        , _fd(createSocket(type))
         , _open(_fd >= 0)
     {
-        init(type);
+        init();
     }
 
     virtual ~Socket()
@@ -152,7 +155,7 @@ public:
         if constexpr (!Util::isMobileApp())
         {
             ::close(_fd);
-            LOG_DBG("Closed socket to [" << clientAddress() << ']');
+            LOG_DBG("Closed socket " << toStringImpl());
         }
         else
         {
@@ -165,8 +168,10 @@ public:
     /// Returns true if this socket has been closed, i.e. rejected from polling and potentially shutdown
     bool isClosed() const { return !_open; }
 
-    void setClientAddress(const std::string& address) { _clientAddress = address; }
+    Type type() const { return _type; }
+    void setClientAddress(const std::string& address, unsigned int port=0) { _clientAddress = address; _clientPort=port; }
     const std::string& clientAddress() const { return _clientAddress; }
+    unsigned int clientPort() const { return _clientPort; }
 
     /// Returns the OS native socket fd.
     int getFD() const { return _fd; }
@@ -370,10 +375,12 @@ protected:
     /// Construct based on an existing socket fd.
     /// Used by accept() only.
     Socket(const int fd, Type type)
-        : _fd(fd)
+        : _type(type)
+        , _clientPort(0)
+        , _fd(fd)
         , _open(_fd >= 0)
     {
-        init(type);
+        init();
     }
 
     inline void logPrefix(std::ostream& os) const { os << '#' << _fd << ": "; }
@@ -392,15 +399,18 @@ private:
     /// return >= 0 for a successfully created socket, -1 on error
     static int createSocket(Type type);
 
-    void init(Type type)
+    std::ostream& streamImpl(std::ostream& os) const;
+    std::string toStringImpl() const;
+
+    void init()
     {
-        if (type != Type::Unix)
+        if (_type != Type::Unix)
             setNoDelay();
         _ignoreInput = false;
         _noShutdown = false;
         _sendBufferSize = DefaultSendBufferSize;
         _owner = std::this_thread::get_id();
-        LOG_TRC("Created socket. Thread affinity set to " << Log::to_string(_owner));
+        LOG_TRC("Created socket. Thread affinity set to " << Log::to_string(_owner) << ", " << toStringImpl());
 
         if constexpr (!Util::isMobileApp())
         {
@@ -416,6 +426,8 @@ private:
     }
 
     std::string _clientAddress;
+    const Type _type;
+    unsigned int _clientPort;
     const int _fd;
     /// True if this socket is open.
     bool _open;

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -65,6 +65,8 @@ namespace Poco
 }
 
 class Socket;
+std::ostream& operator<<(std::ostream& os, const Socket &s);
+
 class Watchdog;
 class SocketPoll;
 
@@ -176,6 +178,8 @@ public:
     /// Returns the OS native socket fd.
     int getFD() const { return _fd; }
 
+    virtual std::ostream& stream(std::ostream& os) const  { return streamImpl(os); }
+
     /// Shutdown the socket.
     /// TODO: Support separate read/write shutdown.
     virtual void shutdown()
@@ -183,7 +187,7 @@ public:
         setClosed();
         if (!_noShutdown)
         {
-            LOG_TRC("Socket shutdown RDWR.");
+            LOG_TRC("Socket shutdown RDWR. " << *this);
             if constexpr (!Util::isMobileApp())
                 ::shutdown(_fd, SHUT_RDWR);
             else
@@ -441,6 +445,8 @@ private:
     /// We check the owner even in the release builds, needs to be always correct.
     std::thread::id _owner;
 };
+
+inline std::ostream& operator<<(std::ostream& os, const Socket &s) { return s.stream(os); }
 
 class StreamSocket;
 class MessageHandlerInterface;
@@ -1036,6 +1042,8 @@ public:
 
     /// Returns the peer hostname, if set.
     const std::string& hostname() const { return _hostname; }
+
+    std::ostream& stream(std::ostream& os) const override;
 
     /// Just trigger the async shutdown.
     void shutdown() override
@@ -1679,6 +1687,7 @@ private:
     uint64_t _bytesRecvd;
 
     enum class WSState { HTTP, WS } _wsState;
+    static std::string toString(WSState t);
 
     /// True if host is localhost
     bool _isLocalHost;

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -1050,8 +1050,7 @@ public:
         _sentHTTPContinue(false),
         _shutdownSignalled(false),
         _readType(readType),
-        _inputProcessingEnabled(true),
-        _lastSeenHTTPHeader( std::chrono::steady_clock::now() )
+        _inputProcessingEnabled(true)
     {
         LOG_TRC("StreamSocket ctor");
     }
@@ -1374,6 +1373,7 @@ public:
     bool parseHeader(const char *clientLoggingName,
                      Poco::MemoryInputStream &message,
                      Poco::Net::HTTPRequest &request,
+                     std::chrono::steady_clock::time_point &lastHTTPHeader,
                      MessageMap& map);
 
     Buffer& getInBuffer() { return _inBuffer; }
@@ -1739,9 +1739,6 @@ private:
     std::vector<int> _incomingFDs;
     ReadType _readType;
     std::atomic_bool _inputProcessingEnabled;
-
-    // Used in parseHeader, net::Defaults::HTTPTimeout acting as max delay
-    std::chrono::steady_clock::time_point _lastSeenHTTPHeader;
 };
 
 enum class WSOpCode : unsigned char {

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -177,6 +177,7 @@ public:
     bool isClosed() const { return !_open; }
 
     Type type() const { return _type; }
+    bool isIPType() const { return Type::IPv4 == _type || Type::IPv6 == _type; }
     void setClientAddress(const std::string& address, unsigned int port=0) { _clientAddress = address; _clientPort=port; }
     const std::string& clientAddress() const { return _clientAddress; }
     unsigned int clientPort() const { return _clientPort; }
@@ -208,6 +209,10 @@ public:
         sent = _bytesSent;
         recv = _bytesRcvd;
     }
+
+    /// Checks whether socket is due for forced removal, e.g. by internal timeout or small throughput. Method will shutdown connection and socket on forced removal.
+    /// Returns true in case of forced removal, caller shall stop processing
+    virtual bool checkRemoval(std::chrono::steady_clock::time_point /* now */) { return false; }
 
     /// Shutdown the socket.
     /// TODO: Support separate read/write shutdown.
@@ -540,8 +545,9 @@ public:
     virtual int getPollEvents(std::chrono::steady_clock::time_point now,
                               int64_t &timeoutMaxMicroS) = 0;
 
-    /// Do we need to handle a timeout ?
-    virtual void checkTimeout(std::chrono::steady_clock::time_point /* now */) {}
+    /// Checks whether a timeout has occurred. Method will shutdown connection and socket on timeout.
+    /// Returns true in case of a timeout, caller shall stop processing
+    virtual bool checkTimeout(std::chrono::steady_clock::time_point /* now */) { return false; }
 
     /// Do some of the queued writing.
     virtual void performWrites(std::size_t capacity) = 0;
@@ -1044,6 +1050,7 @@ public:
         Socket(fd, type, creationTime),
         _pollTimeout( net::Defaults::get().SocketPollTimeout ),
         _httpTimeout( net::Defaults::get().HTTPTimeout ),
+        _minBytesPerSec( net::Defaults::get().MinBytesPerSec ),
         _hostname(std::move(host)),
         _wsState(WSState::HTTP),
         _isLocalHost(hostType == LocalHost),
@@ -1083,6 +1090,8 @@ public:
     const std::string& hostname() const { return _hostname; }
 
     std::ostream& stream(std::ostream& os) const override;
+
+    bool checkRemoval(std::chrono::steady_clock::time_point now) override;
 
     /// Just trigger the async shutdown.
     void shutdown() override
@@ -1424,10 +1433,10 @@ protected:
     {
         ASSERT_CORRECT_SOCKET_THREAD(this);
 
-        _socketHandler->checkTimeout(now);
-
         if (!events && _inBuffer.empty())
             return;
+
+        setLastSeenTime(now);
 
         bool closed = (events & (POLLHUP | POLLERR | POLLNVAL));
 
@@ -1714,6 +1723,8 @@ private:
     const std::chrono::microseconds _pollTimeout;
     /// defaults to 30s, see net::Defaults::HTTPTimeout
     const std::chrono::microseconds _httpTimeout;
+    /// defaults to 0 (disabled), see net::Defaults::MinBytesPerSec
+    const double _minBytesPerSec;
 
     /// The hostname (or IP) of the peer we are connecting to.
     const std::string _hostname;

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -817,6 +817,15 @@ public:
     /// Global wakeup - signal safe: wakeup all socket polls.
     static void wakeupWorld();
 
+    /// Enable connection accounting and limiter
+    /// Internally we allow one extra connection for the WS upgrade
+    /// @param connectionLimit socket connection limit
+    void setLimiter(size_t connectionLimit)
+    {
+        _limitedConnections = true;
+        _connectionLimit = connectionLimit > 0 ? connectionLimit + 1 : 0;
+    }
+
     /// Insert a new socket to be polled.
     /// A socket is removed when it is closed, readIncomingData
     /// returns false, or when removeSockets is called (which is
@@ -990,6 +999,8 @@ private:
     /// Debug name used for logging.
     const std::string _name;
     const std::chrono::microseconds _pollTimeout;
+    bool _limitedConnections;
+    size_t _connectionLimit;
 
     /// main-loop wakeup pipe
     int _wakeup[2];
@@ -1016,6 +1027,13 @@ private:
     /// Time-stamp for profiling
     int _ownerThreadId;
     std::atomic<uint64_t> _watchdogTime;
+
+    static std::mutex StatsMutex;
+    static std::atomic<size_t> StatsConnectionCount; // total of all _pollSockets (excluding _newSockets)
+    static size_t StatsConnectionMod(size_t added, size_t removed); // safe add-sub of StatsConnectionCount
+
+public:
+    static int64_t GetStatsConnectionCount() { return StatsConnectionCount.load(std::memory_order_seq_cst); }
 };
 
 /// A SocketPoll that will stop polling and

--- a/net/SslSocket.hpp
+++ b/net/SslSocket.hpp
@@ -24,8 +24,9 @@ class SslStreamSocket final : public StreamSocket
 {
 public:
     SslStreamSocket(const std::string& host, const int fd, Type type, bool isClient,
-                    HostType hostType, ReadType readType = NormalRead)
-        : StreamSocket(host, fd, type, isClient, hostType, readType)
+                    HostType hostType, ReadType readType = ReadType::NormalRead,
+                    std::chrono::steady_clock::time_point creationTime = std::chrono::steady_clock::now())
+        : StreamSocket(host, fd, type, isClient, hostType, readType, creationTime)
         , _bio(nullptr)
         , _ssl(nullptr)
         , _sslWantsTo(SslWantsTo::Neither)

--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -246,6 +246,20 @@ public:
         shutdownImpl(statusCode, statusMessage, hardShutdown, false);
     }
 
+    /// Don't wait for the remote Websocket to handshake with us; go down fast.
+    void shutdownAfterWriting()
+    {
+        shutdownImpl(WebSocketHandler::StatusCodes::NORMAL_CLOSE, std::string(),
+                     true /* hard async shutdown & close */, false);
+    }
+
+    /// Returns true if the underlying socket is connected.
+    bool isConnected() const
+    {
+        std::shared_ptr<StreamSocket> socket = _socket.lock();
+        return socket && !socket->isClosed();
+    }
+
 private:
     void shutdownSilent()
     {
@@ -281,22 +295,6 @@ private:
 #endif
         _shuttingDown = false;
     }
-
-public:
-    /// Don't wait for the remote Websocket to handshake with us; go down fast.
-    void shutdownAfterWriting()
-    {
-        shutdownImpl(WebSocketHandler::StatusCodes::NORMAL_CLOSE, std::string(),
-                     true /* hard async shutdown & close */, false);
-    }
-
-    /// Returns true if the underlying socket is connected.
-    bool isConnected() const {
-        std::shared_ptr<StreamSocket> socket = _socket.lock();
-        return nullptr != socket && !socket->isClosed();
-    }
-
-private:
     bool handleTCPStream(const std::shared_ptr<StreamSocket>& socket)
     {
         assert(socket && "Expected a valid socket instance.");

--- a/test/HttpRequestTests.cpp
+++ b/test/HttpRequestTests.cpp
@@ -145,6 +145,7 @@ public:
     void setUp()
     {
         LOG_INF("HttpRequestTests::setUp");
+        std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
         std::shared_ptr<SocketFactory> factory = std::make_shared<ServerSocketFactory>();
         _port = 9990;
         for (int i = 0; i < 40; ++i, ++_port)
@@ -152,7 +153,7 @@ public:
             // Try listening on this port.
             LOG_INF("HttpRequestTests::setUp: creating socket to listen on port " << _port);
             _socket = ServerSocket::create(ServerSocket::Type::Local, _port, Socket::Type::IPv4,
-                                           _pollServerThread, factory);
+                                           now, _pollServerThread, factory);
             if (_socket)
                 break;
         }

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -91,6 +91,10 @@ all_la_unit_tests = \
 	unit-join-disconnect.la \
 	unit-initial-load-fail.la \
 	unit-timeout.la \
+	unit-timeout_socket.la \
+	unit-timeout_wsping.la \
+	unit-timeout_conn.la \
+	unit-timeout_none.la \
 	unit-base.la
 #	unit-admin.la
 #	unit-tilecache.la # Empty test.
@@ -223,6 +227,14 @@ unit_join_disconnect_la_SOURCES = UnitJoinDisconnect.cpp
 unit_join_disconnect_la_LIBADD = $(CPPUNIT_LIBS)
 unit_timeout_la_SOURCES = UnitTimeout.cpp
 unit_timeout_la_LIBADD = $(CPPUNIT_LIBS)
+unit_timeout_socket_la_SOURCES = UnitTimeoutSocket.cpp
+unit_timeout_socket_la_LIBADD = $(CPPUNIT_LIBS)
+unit_timeout_wsping_la_SOURCES = UnitTimeoutWSPing.cpp
+unit_timeout_wsping_la_LIBADD = $(CPPUNIT_LIBS)
+unit_timeout_conn_la_SOURCES = UnitTimeoutConnections.cpp
+unit_timeout_conn_la_LIBADD = $(CPPUNIT_LIBS)
+unit_timeout_none_la_SOURCES = UnitTimeoutNone.cpp
+unit_timeout_none_la_LIBADD = $(CPPUNIT_LIBS)
 unit_prefork_la_SOURCES = UnitPrefork.cpp
 unit_prefork_la_LIBADD = $(CPPUNIT_LIBS)
 unit_storage_la_SOURCES = UnitStorage.cpp

--- a/test/UnitPerf.cpp
+++ b/test/UnitPerf.cpp
@@ -57,6 +57,8 @@ void UnitPerf::testPerf(std::string testType, std::string fileType, std::string 
     stats = std::make_shared<Stats>();
     stats->setTypeOfTest(std::move(testType));
 
+    const std::chrono::microseconds PollTimeoutMicroS = net::Defaults::get().SocketPollTimeout;
+
     TerminatingPoll poll("performance test");
 
     std::string docName = "empty." + fileType;
@@ -72,7 +74,7 @@ void UnitPerf::testPerf(std::string testType, std::string fileType, std::string 
         stats);
 
     do {
-        poll.poll(TerminatingPoll::DefaultPollTimeoutMicroS);
+        poll.poll(PollTimeoutMicroS);
     } while (poll.continuePolling() && poll.getSocketCount() > 0);
 
     stats->dump();

--- a/test/UnitTimeoutBase.hpp
+++ b/test/UnitTimeoutBase.hpp
@@ -1,0 +1,404 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <config.h>
+
+#include <memory>
+#include <string>
+
+#include <HttpRequest.hpp>
+#include <Socket.hpp>
+
+#include <Poco/Util/LayeredConfiguration.h>
+#include <test/lokassert.hpp>
+
+#include <Unit.hpp>
+#include <UserMessages.hpp>
+#include <Util.hpp>
+#include <helpers.hpp>
+#include <vector>
+
+/// Base test suite class for timeout and connection limit using HTTP and WS sessions.
+class UnitTimeoutBase0 : public UnitWSD
+{
+public:
+    bool assertMessage(http::WebSocketSession &session, const std::string expectedPrefix, const std::string expectedId)
+    {
+        std::vector<char> res = session.poll(
+            [&](const std::vector<char>& message) -> bool
+            {
+                const std::string msg(std::string(message.begin(), message.end()));
+                TST_LOG("Got WS response: " << msg);
+                if (!msg.starts_with("error:"))
+                {
+                    if( expectedPrefix == "progress:") {
+                        LOK_ASSERT_EQUAL(COOLProtocol::matchPrefix(expectedPrefix, msg), true);
+                        LOK_ASSERT(helpers::getProgressWithIdValue(msg, expectedId));
+                        TST_LOG("Good WS response(0): " << msg);
+                        return true;
+                    } else if( msg.find(expectedId) != std::string::npos ) {
+                        // simple match
+                        TST_LOG("Good WS response(1): " << msg);
+                        return true;
+                    } else {
+                        const bool c = session.isConnected();
+                        TST_LOG("Some WS response(2): " << msg << ", connected " << c);
+                        return !c; // continue waiting for 'it' if still connected
+                    }
+                }
+                else
+                {
+                    // check error message
+                    LOK_ASSERT_EQUAL(std::string(SERVICE_UNAVAILABLE_INTERNAL_ERROR), msg);
+
+                    // close frame message
+                    return true;
+                }
+            },
+            std::chrono::seconds(10), testname);
+        return !res.empty();
+    };
+
+    template<typename SessionType>
+    bool pollDisconnected(std::chrono::microseconds timeout, SessionType &session, SocketPoll *syncSocketPoller=nullptr)
+    {
+        std::chrono::steady_clock::time_point t0 = std::chrono::steady_clock::now();
+        std::chrono::steady_clock::time_point t1 = t0;
+        while( t1 - t0 < timeout && session.isConnected() )
+        {
+            if( nullptr != syncSocketPoller )
+                syncSocketPoller->poll(std::chrono::microseconds(1000));
+            t1 = std::chrono::steady_clock::now();
+        }
+        return !session.isConnected();
+    }
+
+    template<typename SessionType>
+    bool pollDisconnected(std::chrono::microseconds timeout, std::vector<std::shared_ptr<SessionType>> &sessions, SocketPoll *syncSocketPoller=nullptr)
+    {
+        std::chrono::steady_clock::time_point t0 = std::chrono::steady_clock::now();
+        std::chrono::steady_clock::time_point t1 = t0;
+        while( 0<sessions.size() && t1 - t0 < timeout )
+        {
+            if( nullptr != syncSocketPoller )
+                syncSocketPoller->poll(std::chrono::microseconds(1000));
+            for (auto iter=sessions.begin(); iter != sessions.end(); )
+            {
+                std::shared_ptr<SessionType>& session = *iter;
+                if( !session->isConnected() )
+                    iter = sessions.erase(iter);
+                else
+                    ++iter;
+            }
+            t1 = std::chrono::steady_clock::now();
+        }
+        return sessions.empty();
+    }
+
+    UnitTimeoutBase0(const std::string& testname_)
+        : UnitWSD(testname_)
+    {
+    }
+};
+
+/// Base test suite class for timeout and connection limit using HTTP and WS sessions.
+class UnitTimeoutBase1 : public UnitTimeoutBase0
+{
+public:
+    TestResult testHttp(const size_t connectionLimit, const size_t connectionsCount);
+    TestResult testWSPing(const size_t connectionLimit, const size_t connectionsCount);
+    TestResult testWSDChatPing(const size_t connectionLimit, const size_t connectionsCount);
+
+    UnitTimeoutBase1(const std::string& testname_)
+        : UnitTimeoutBase0(testname_)
+    {
+    }
+};
+
+inline UnitBase::TestResult UnitTimeoutBase1::testHttp(const size_t connectionLimit, const size_t connectionsCount)
+{
+    setTestname(__func__);
+    TST_LOG("Starting Test: " << testname);
+
+    const size_t MaxConnections = std::min(connectionsCount, connectionLimit);
+    const std::string documentURL = "/favicon.ico";
+
+    constexpr bool UseOwnPoller = true;
+    constexpr bool PollerOnClientThread = true;
+    std::vector<std::shared_ptr<TerminatingPoll>> socketPollers;
+    std::vector<std::shared_ptr<http::Session>> sessions;
+
+    try
+    {
+        for(size_t sockIdx = 0; sockIdx < connectionsCount; ++sockIdx) {
+            std::shared_ptr<TerminatingPoll> socketPoller;
+            if( UseOwnPoller )
+            {
+                socketPoller = std::make_shared<TerminatingPoll>(testname);
+                if( PollerOnClientThread )
+                {
+                    socketPoller->runOnClientThread();
+                } else {
+                    socketPoller->startThread();
+                }
+                socketPollers.push_back(socketPoller);
+            }
+
+            std::shared_ptr<http::Session> session = http::Session::create(helpers::getTestServerURI());
+            sessions.push_back( session );
+            TST_LOG("Test: " << testname << "[" << sockIdx << "]: `" << documentURL << "`");
+            http::Request request(documentURL, http::Request::VERB_GET);
+            const std::shared_ptr<const http::Response> response =
+                session->syncRequest(request, UseOwnPoller ? *socketPoller : *socketPoll());
+            TST_LOG("Response: " << response->header().toString());
+            TST_LOG("Response size: " << testname << "[" << sockIdx << "]: `" << documentURL << "`: " << response->header().getContentLength());
+            if( session->isConnected() ) {
+                LOK_ASSERT_EQUAL(http::StatusCode::OK, response->statusCode());
+                LOK_ASSERT_EQUAL(true, session->isConnected());
+                LOK_ASSERT(http::Header::ConnectionToken::None ==
+                           response->header().getConnectionToken());
+                LOK_ASSERT(0 < response->header().getContentLength());
+            } else {
+                // connection limit hit
+                LOK_ASSERT_EQUAL(http::StatusCode::None, response->statusCode());
+                LOK_ASSERT_EQUAL(false, session->isConnected());
+            }
+        }
+    }
+    catch (const Poco::Exception& exc)
+    {
+        LOK_ASSERT_FAIL(exc.displayText());
+    }
+    size_t connected = 0;
+    for(size_t sockIdx = 0; sockIdx < connectionsCount; ++sockIdx) {
+        std::shared_ptr<http::Session> &session = sessions[sockIdx];
+        TST_LOG("SessionA " << sockIdx << ": connected " << session->isConnected());
+        if( session->isConnected() )
+        {
+            ++connected;
+            session->asyncShutdown();
+        }
+        if( UseOwnPoller ) {
+            std::shared_ptr<TerminatingPoll> socketPoller = socketPollers[sockIdx];
+            if( PollerOnClientThread )
+            {
+                socketPoller->closeAllSockets();
+            } else {
+                socketPoller->joinThread();
+            }
+        }
+    }
+    TST_LOG("Test: X01 Connected: " << connected << " / " << connectionsCount << ", limit " << connectionLimit);
+    // LOK_ASSERT_EQUAL(MaxConnections, connected);
+    LOK_ASSERT(MaxConnections-1 <= connected && connected <= MaxConnections+1);
+
+    TST_LOG("Clearing Sessions: " << testname);
+    sessions.clear();
+    TST_LOG("Clearing Poller: " << testname);
+    socketPollers.clear();
+    TST_LOG("Ending Test: " << testname);
+    return TestResult::Ok;
+}
+
+/// Test the native WebSocket control-frame ping/pong facility -> No Timeout!
+inline UnitBase::TestResult UnitTimeoutBase1::testWSPing(const size_t connectionLimit, const size_t connectionsCount)
+{
+    setTestname(__func__);
+    TST_LOG("Starting Test: " << testname);
+
+    const size_t maxConnections = std::min(connectionsCount, connectionLimit);
+    std::string documentPath, documentURL;
+    helpers::getDocumentPathAndURL("hello.odt", documentPath, documentURL, testname);
+
+    constexpr bool UseOwnPoller = true;
+    constexpr bool PollerOnClientThread = false;
+    std::vector<std::shared_ptr<TerminatingPoll>> socketPollers;
+    std::vector<std::shared_ptr<http::WebSocketSession>> sessions;
+
+    size_t connected0 = 0;
+    for(size_t sockIdx = 0; sockIdx < connectionsCount; ++sockIdx) {
+        std::shared_ptr<TerminatingPoll> socketPoller;
+        if( UseOwnPoller )
+        {
+            socketPoller = std::make_shared<TerminatingPoll>(testname);
+            if( PollerOnClientThread )
+            {
+                socketPoller->runOnClientThread();
+            } else {
+                socketPoller->startThread();
+            }
+            socketPollers.push_back(socketPoller);
+        }
+
+        std::shared_ptr<http::WebSocketSession> session = http::WebSocketSession::create(helpers::getTestServerURI());
+        sessions.push_back( session );
+        TST_LOG("Test: " << testname << "[" << sockIdx << "]: `" << documentURL << "`");
+        http::Request req(documentURL);
+        session->asyncRequest(req, UseOwnPoller ? socketPoller : socketPoll());
+        session->sendMessage("load url=" + documentURL);
+
+        TST_LOG("Test: XX0 " << testname << "[" << sockIdx << "]: connected " << session->isConnected());
+        if( sockIdx < maxConnections ) {
+            LOK_ASSERT_EQUAL(true, session->isConnected());
+
+            assertMessage(*session, "progress:", "find");
+            assertMessage(*session, "progress:", "connect");
+            assertMessage(*session, "progress:", "ready");
+
+            TST_LOG("Test: XX1 " << testname << "[" << sockIdx << "]: connected " << session->isConnected());
+            LOK_ASSERT_EQUAL(true, session->isConnected());
+            ++connected0;
+        } else {
+            // Perform actual communication attempt, required to fail (disconnect)
+            TST_LOG("Test: XX2 " << testname << "[" << sockIdx << "]: connected " << session->isConnected());
+            bool comRes=false;
+            if( session->isConnected() )
+            {
+                comRes=assertMessage(*session, "progress:", "find");
+                if( session->isConnected() )
+                    ++connected0;
+            }
+            TST_LOG("Test: XX3 " << testname << "[" << sockIdx << "]: connected "
+                    << session->isConnected() << "/" << connected0 << ", com " << comRes);
+            LOK_ASSERT_EQUAL(false, comRes);
+            LOK_ASSERT_EQUAL(false, session->isConnected());
+        }
+    }
+    TST_LOG("Test: X01 Connected: " << connected0 << " / " << connectionsCount << ", limit " << connectionLimit);
+
+    size_t connected = 0;
+    for(size_t sockIdx = 0; sockIdx < connectionsCount; ++sockIdx) {
+        std::shared_ptr<http::WebSocketSession> wsSession = sessions[sockIdx];
+        TST_LOG("SessionA " << sockIdx << ": connected " << wsSession->isConnected());
+        if( wsSession->isConnected() )
+        {
+            ++connected;
+            // wsSession->asyncShutdown();
+            wsSession->shutdownWS();
+        }
+        if( UseOwnPoller ) {
+            std::shared_ptr<TerminatingPoll> socketPoller = socketPollers[sockIdx];
+            if( PollerOnClientThread )
+            {
+                socketPoller->closeAllSockets();
+            } else {
+                socketPoller->joinThread();
+            }
+        }
+    }
+    // 5 x Limiter hits occurred!
+    TST_LOG("Test: X02 Connected: " << connected << " / " << connectionsCount << ", limit " << connectionLimit);
+    LOK_ASSERT(maxConnections-1 <= connected && connected <= maxConnections+1);
+
+    TST_LOG("Clearing Sessions: " << testname);
+    sessions.clear();
+    TST_LOG("Clearing Poller: " << testname);
+    socketPollers.clear();
+    TST_LOG("Ending Test: " << testname);
+    return TestResult::Ok;
+}
+
+/// Tests the WSD chat ping/pong facility, where client sends the ping.
+/// See: https://github.com/CollaboraOnline/online/blob/master/wsd/protocol.txt/
+inline UnitBase::TestResult UnitTimeoutBase1::testWSDChatPing(const size_t connectionLimit, const size_t connectionsCount)
+{
+    setTestname(__func__);
+    TST_LOG("Starting Test: " << testname);
+
+    const size_t maxConnections = std::min(connectionsCount, connectionLimit);
+    std::string documentPath, documentURL;
+    helpers::getDocumentPathAndURL("hello.odt", documentPath, documentURL, testname);
+
+    constexpr bool UseOwnPoller = true;
+    constexpr bool PollerOnClientThread = false;
+    std::vector<std::shared_ptr<TerminatingPoll>> socketPollers;
+    std::vector<std::shared_ptr<http::WebSocketSession>> sessions;
+
+    for(size_t sockIdx = 0; sockIdx < connectionsCount; ++sockIdx) {
+        std::shared_ptr<TerminatingPoll> socketPoller;
+        if( UseOwnPoller )
+        {
+            socketPoller = std::make_shared<TerminatingPoll>(testname);
+            if( PollerOnClientThread )
+            {
+                socketPoller->runOnClientThread();
+            } else {
+                socketPoller->startThread();
+            }
+            socketPollers.push_back(socketPoller);
+        }
+
+        std::shared_ptr<http::WebSocketSession> session = http::WebSocketSession::create(helpers::getTestServerURI());
+        sessions.push_back( session );
+        TST_LOG("Test: " << testname << "[" << sockIdx << "]: `" << documentURL << "`");
+        http::Request req(documentURL);
+        session->asyncRequest(req, UseOwnPoller ? socketPoller : socketPoll());
+        session->sendMessage("load url=" + documentURL);
+
+        TST_LOG("Test: XX0 " << testname << "[" << sockIdx << "]: connected " << session->isConnected());
+        if( sockIdx < maxConnections-1 ) {
+            LOK_ASSERT_EQUAL(true, session->isConnected());
+
+            assertMessage(*session, "progress:", "find");
+            assertMessage(*session, "progress:", "connect");
+            assertMessage(*session, "progress:", "ready");
+
+            TST_LOG("Test: XX1 " << testname << "[" << sockIdx << "]: connected " << session->isConnected());
+            // LOK_ASSERT_EQUAL(true, wsSession->isConnected());
+        } else {
+            TST_LOG("Test: XX2 " << testname << "[" << sockIdx << "]: connected " << session->isConnected());
+            // LOK_ASSERT_EQUAL(false, wsSession->isConnected());
+        }
+    }
+    for(size_t sockIdx = 0; sockIdx < connectionsCount; ++sockIdx) {
+        std::shared_ptr<http::WebSocketSession> wsSession = sessions[sockIdx];
+        TST_LOG("Test: XX3a " << testname << "[" << sockIdx << "]: connected " << wsSession->isConnected());
+        if( wsSession->isConnected() )
+        {
+            wsSession->sendMessage("ping");
+            TST_LOG("Test: XX3b " << testname << "[" << sockIdx << "]: connected " << wsSession->isConnected());
+            assertMessage(*wsSession, "", "pong");
+            TST_LOG("Test: XX3c " << testname << "[" << sockIdx << "]: connected " << wsSession->isConnected());
+        }
+    }
+
+    size_t connected = 0;
+    for(size_t sockIdx = 0; sockIdx < connectionsCount; ++sockIdx) {
+        std::shared_ptr<http::WebSocketSession> wsSession = sessions[sockIdx];
+        TST_LOG("SessionA " << sockIdx << ": connected " << wsSession->isConnected());
+        if( wsSession->isConnected() )
+        {
+            ++connected;
+            wsSession->shutdownWS();
+        }
+        if( UseOwnPoller ) {
+            std::shared_ptr<TerminatingPoll> socketPoller = socketPollers[sockIdx];
+            if( PollerOnClientThread )
+            {
+                socketPoller->closeAllSockets();
+            } else {
+                socketPoller->joinThread();
+            }
+        }
+    }
+    // 5 x Limiter hits occurred!
+    TST_LOG("Test: X01 Connected: " << connected << " / " << connectionsCount << ", limit " << connectionLimit);
+    LOK_ASSERT(maxConnections-1 <= connected && connected <= maxConnections+1);
+
+    TST_LOG("Clearing Sessions: " << testname);
+    sessions.clear();
+    TST_LOG("Clearing Poller: " << testname);
+    socketPollers.clear();
+    TST_LOG("Ending Test: " << testname);
+    return TestResult::Ok;
+}
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/test/UnitTimeoutConnections.cpp
+++ b/test/UnitTimeoutConnections.cpp
@@ -1,0 +1,76 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <config.h>
+
+#include <string>
+
+#include <HttpRequest.hpp>
+#include <Socket.hpp>
+
+#include <Poco/Util/LayeredConfiguration.h>
+#include <test/lokassert.hpp>
+
+#include <Unit.hpp>
+#include <UserMessages.hpp>
+#include <Util.hpp>
+#include <helpers.hpp>
+
+#include "UnitTimeoutBase.hpp"
+
+static constexpr size_t ConnectionLimit = 5;
+static constexpr size_t ConnectionCount = 9;
+
+/// Base test suite class for connection limit (limited) using HTTP and WS sessions.
+class UnitTimeoutConnections : public UnitTimeoutBase1
+{
+    void configure(net::Defaults& defaults) override
+    {
+        // defaults.WSPingTimeout = std::chrono::microseconds(2000000);
+        // defaults.WSPingPeriod = std::chrono::microseconds(3000000);
+        // defaults.HTTPTimeout = std::chrono::microseconds(30000000);
+        // defaults.MaxConnections = 9999;
+        defaults.MaxConnections = ConnectionLimit;
+        // defaults.MinBytesPerSec = 0.0;
+        // defaults.SocketPollTimeout = std::chrono::microseconds(64000000);
+    }
+
+public:
+    UnitTimeoutConnections()
+        : UnitTimeoutBase1("UnitTimeoutConnections")
+    {
+    }
+
+    void invokeWSDTest() override;
+};
+
+void UnitTimeoutConnections::invokeWSDTest()
+{
+    UnitBase::TestResult result = TestResult::Ok;
+
+    result = testHttp(ConnectionLimit, ConnectionCount);
+    if (result != TestResult::Ok)
+        exitTest(result);
+
+    result = testWSPing(ConnectionLimit, ConnectionCount);
+    if (result != TestResult::Ok)
+        exitTest(result);
+
+    result = testWSDChatPing(ConnectionLimit, ConnectionCount);
+    if (result != TestResult::Ok)
+        exitTest(result);
+
+    exitTest(TestResult::Ok);
+}
+
+UnitBase* unit_create_wsd(void) { return new UnitTimeoutConnections(); }
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/test/UnitTimeoutNone.cpp
+++ b/test/UnitTimeoutNone.cpp
@@ -1,0 +1,76 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <config.h>
+
+#include <string>
+
+#include <HttpRequest.hpp>
+#include <Socket.hpp>
+
+#include <test/lokassert.hpp>
+
+#include <Unit.hpp>
+#include <UserMessages.hpp>
+#include <Util.hpp>
+#include <helpers.hpp>
+
+#include "UnitTimeoutBase.hpp"
+
+static constexpr size_t ConnectionLimit = 9999;
+static constexpr size_t ConnectionCount = 9;
+
+/// Base test suite class for connection limit (no limits) using HTTP and WS sessions.
+class UnitTimeoutNone : public UnitTimeoutBase1
+{
+    void configure(net::Defaults& /* defaults */) override
+    {
+        // Keep original values -> No timeout
+        // defaults.WSPingTimeout = std::chrono::microseconds(2000000);
+        // defaults.WSPingPeriod = std::chrono::microseconds(3000000);
+        // defaults.HTTPTimeout = std::chrono::microseconds(30000000);
+        // defaults.MaxConnections = 9999;
+        // defaults.MaxConnections = ConnectionLimit;
+        // defaults.MinBytesPerSec = 0.0;
+        // defaults.SocketPollTimeout = std::chrono::microseconds(64000000);
+    }
+
+public:
+    UnitTimeoutNone()
+        : UnitTimeoutBase1("UnitTimeoutNone")
+    {
+    }
+
+    void invokeWSDTest() override;
+};
+
+void UnitTimeoutNone::invokeWSDTest()
+{
+    UnitBase::TestResult result;
+
+    result = testHttp(ConnectionLimit, ConnectionCount);
+    if (result != TestResult::Ok)
+        exitTest(result);
+
+    result = testWSPing(ConnectionLimit, ConnectionCount);
+    if (result != TestResult::Ok)
+        exitTest(result);
+
+    result = testWSDChatPing(ConnectionLimit, ConnectionCount);
+    if (result != TestResult::Ok)
+        exitTest(result);
+
+    exitTest(TestResult::Ok);
+}
+
+UnitBase* unit_create_wsd(void) { return new UnitTimeoutNone(); }
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/test/UnitTimeoutSocket.cpp
+++ b/test/UnitTimeoutSocket.cpp
@@ -1,0 +1,192 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <config.h>
+
+#include <memory>
+#include <string>
+
+#include <HttpRequest.hpp>
+#include <Socket.hpp>
+
+#include <Poco/Util/LayeredConfiguration.h>
+#include <test/lokassert.hpp>
+
+#include <Unit.hpp>
+#include <UserMessages.hpp>
+#include <Util.hpp>
+#include <helpers.hpp>
+#include <vector>
+
+#include "UnitTimeoutBase.hpp"
+
+/// Test suite class for Socket max-duration timeout limit using HTTP and WS sessions.
+class UnitTimeoutSocket : public UnitTimeoutBase0
+{
+    TestResult testHttp();
+    TestResult testWSPing();
+    TestResult testWSDChatPing();
+
+    void configure(net::Defaults& defaults) override
+    {
+        // defaults.WSPingTimeout = std::chrono::microseconds(2000000);
+        // defaults.WSPingPeriod = std::chrono::microseconds(3000000);
+        // defaults.HTTPTimeout = std::chrono::microseconds(30000000);
+        // defaults.HTTPTimeout = std::chrono::microseconds(1);
+        // defaults.MaxConnections = 9999;
+        // defaults.MinBytesPerSec = 0.0;
+        defaults.MinBytesPerSec = 100000.0; // 100kBps
+        // defaults.SocketPollTimeout = std::chrono::microseconds(64000000);
+    }
+
+public:
+    UnitTimeoutSocket()
+        : UnitTimeoutBase0("UnitTimeoutSocket")
+    {
+    }
+
+    void invokeWSDTest() override;
+};
+
+UnitBase::TestResult UnitTimeoutSocket::testHttp()
+{
+    setTestname(__func__);
+    TST_LOG("Starting Test: " << testname);
+
+    const std::string documentURL = "/favicon.ico";
+
+    // Keep alive socket, avoid forced socket disconnect via dtor
+    TerminatingPoll socketPoller(testname);
+    socketPoller.runOnClientThread();
+
+    const int sockCount = 4;
+    // Reused http session, keep-alive
+    std::vector<std::shared_ptr<http::Session>> sessions;
+
+    try
+    {
+        for(int sockIdx = 0; sockIdx < sockCount; ++sockIdx) {
+            sessions.push_back( http::Session::create(helpers::getTestServerURI()) );
+            TST_LOG("Test: " << testname << "[" << sockIdx << "]: `" << documentURL << "`");
+            http::Request request(documentURL, http::Request::VERB_GET);
+            const std::shared_ptr<const http::Response> response =
+                sessions[sockIdx]->syncRequest(request, socketPoller);
+            TST_LOG("Response: " << response->header().toString());
+            TST_LOG("Response size: " << testname << "[" << sockIdx << "]: `" << documentURL << "`: " << response->header().getContentLength());
+            LOK_ASSERT_EQUAL(http::StatusCode::OK, response->statusCode());
+            LOK_ASSERT_EQUAL(true, sessions[sockIdx]->isConnected());
+            LOK_ASSERT(http::Header::ConnectionToken::None ==
+                       response->header().getConnectionToken());
+            LOK_ASSERT(0 < response->header().getContentLength());
+        }
+    }
+    catch (const Poco::Exception& exc)
+    {
+        LOK_ASSERT_FAIL(exc.displayText());
+    }
+    LOK_ASSERT_EQUAL(true, pollDisconnected(std::chrono::microseconds(1000000), sessions, &socketPoller));
+
+    TST_LOG("Clearing Sessions: " << testname);
+    sessions.clear();
+    TST_LOG("Clearing Poller: " << testname);
+    socketPoller.closeAllSockets();
+    TST_LOG("Ending Test: " << testname);
+    return TestResult::Ok;
+}
+
+/// Test the native WebSocket control-frame ping/pong facility -> No Timeout!
+UnitBase::TestResult UnitTimeoutSocket::testWSPing()
+{
+    setTestname(__func__);
+    TST_LOG("Starting Test: " << testname);
+
+    std::string documentPath, documentURL;
+    helpers::getDocumentPathAndURL("hello.odt", documentPath, documentURL, testname);
+
+    std::shared_ptr<http::WebSocketSession> session = http::WebSocketSession::create(helpers::getTestServerURI());
+    http::Request req(documentURL);
+    session->asyncRequest(req, socketPoll());
+
+    // wsd/ClientSession.cpp:709 sendTextFrameAndLogError("error: cmd=" + tokens[0] + " kind=nodocloaded");
+    constexpr const bool loadDoc = true; // Required for WSD chat -> wsd/ClientSession.cpp:709, common/Session.hpp:160
+    if( loadDoc ) {
+        session->sendMessage("load url=" + documentURL);
+    }
+
+    LOK_ASSERT_EQUAL(true, session->isConnected());
+
+    assertMessage(*session, "progress:", "find");
+    assertMessage(*session, "progress:", "connect");
+    assertMessage(*session, "progress:", "ready");
+
+    LOK_ASSERT_EQUAL(true, pollDisconnected(std::chrono::microseconds(1000000), *session));
+
+    TST_LOG("Ending Test: " << testname);
+    return TestResult::Ok;
+}
+
+/// Tests the WSD chat ping/pong facility, where client sends the ping.
+/// See: https://github.com/CollaboraOnline/online/blob/master/wsd/protocol.txt/
+UnitBase::TestResult UnitTimeoutSocket::testWSDChatPing()
+{
+    setTestname(__func__);
+    TST_LOG("Starting Test: " << testname);
+
+    std::string documentPath, documentURL;
+    helpers::getDocumentPathAndURL("hello.odt", documentPath, documentURL, testname);
+
+    std::shared_ptr<http::WebSocketSession> session = http::WebSocketSession::create(helpers::getTestServerURI());
+    http::Request req(documentURL);
+    session->asyncRequest(req, socketPoll());
+
+    // wsd/ClientSession.cpp:709 sendTextFrameAndLogError("error: cmd=" + tokens[0] + " kind=nodocloaded");
+    constexpr const bool loadDoc = true; // Required for WSD chat -> wsd/ClientSession.cpp:709, common/Session.hpp:160
+    if( loadDoc ) {
+        session->sendMessage("load url=" + documentURL);
+    }
+
+    LOK_ASSERT_EQUAL(true, session->isConnected());
+
+    assertMessage(*session, "progress:", "find");
+    assertMessage(*session, "progress:", "connect");
+    assertMessage(*session, "progress:", "ready");
+
+    session->sendMessage("ping");
+    assertMessage(*session, "", "pong");
+
+    LOK_ASSERT_EQUAL(true, pollDisconnected(std::chrono::microseconds(1000000), *session));
+
+    TST_LOG("Ending Test: " << testname);
+    return TestResult::Ok;
+}
+
+void UnitTimeoutSocket::invokeWSDTest()
+{
+    UnitBase::TestResult result = TestResult::Ok;
+
+    result = testHttp();
+    if (result != TestResult::Ok)
+        exitTest(result);
+
+    result = testWSPing();
+    if (result != TestResult::Ok)
+        exitTest(result);
+
+    result = testWSDChatPing();
+    if (result != TestResult::Ok)
+        exitTest(result);
+
+    exitTest(TestResult::Ok);
+}
+
+UnitBase* unit_create_wsd(void) { return new UnitTimeoutSocket(); }
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/test/UnitTimeoutWSPing.cpp
+++ b/test/UnitTimeoutWSPing.cpp
@@ -1,0 +1,101 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <config.h>
+
+#include <memory>
+#include <string>
+
+#include <HttpRequest.hpp>
+#include <Socket.hpp>
+
+#include <Poco/Util/LayeredConfiguration.h>
+#include <test/lokassert.hpp>
+
+#include <Unit.hpp>
+#include <UserMessages.hpp>
+#include <Util.hpp>
+#include <helpers.hpp>
+
+#include "UnitTimeoutBase.hpp"
+
+/// Test suite class for WS Ping (native frame) timeout limit using a WS sessions.
+class UnitTimeoutWSPing : public UnitTimeoutBase0
+{
+    TestResult testWSPing();
+
+    void configure(net::Defaults& defaults) override
+    {
+        // defaults.WSPingTimeout = std::chrono::microseconds(2000000);
+        // defaults.WSPingPeriod = std::chrono::microseconds(3000000);
+        defaults.WSPingTimeout = std::chrono::microseconds(20);
+        defaults.WSPingPeriod = std::chrono::microseconds(10000);
+        // defaults.HTTPTimeout = std::chrono::microseconds(30000000);
+        // defaults.MaxConnections = 9999;
+        // defaults.MinBytesPerSec = 0.0;
+        // defaults.SocketPollTimeout = std::chrono::microseconds(64000000);
+    }
+
+public:
+    UnitTimeoutWSPing()
+        : UnitTimeoutBase0("UnitTimeoutWSPing")
+    {
+    }
+
+    void invokeWSDTest() override;
+};
+
+/// Attempt to test the native WebSocket control-frame ping/pong facility -> Timeout!
+UnitBase::TestResult UnitTimeoutWSPing::testWSPing()
+{
+    setTestname(__func__);
+    TST_LOG("Starting Test: " << testname);
+
+    std::string documentPath, documentURL;
+    helpers::getDocumentPathAndURL("hello.odt", documentPath, documentURL, testname);
+
+    // NOTE: Do not replace with wrappers. This has to be explicit.
+    std::shared_ptr<http::WebSocketSession> session = http::WebSocketSession::create(helpers::getTestServerURI());
+    http::Request req(documentURL);
+    session->asyncRequest(req, socketPoll());
+
+    // wsd/ClientSession.cpp:709 sendTextFrameAndLogError("error: cmd=" + tokens[0] + " kind=nodocloaded");
+    constexpr const bool loadDoc = true; // Required for WSD chat -> wsd/ClientSession.cpp:709, common/Session.hpp:160
+    if( loadDoc ) {
+        session->sendMessage("load url=" + documentURL);
+    }
+
+    LOK_ASSERT_EQUAL(true, session->isConnected());
+
+    assertMessage(*session, "progress:", "find");
+    assertMessage(*session, "progress:", "connect");
+    assertMessage(*session, "progress:", "ready");
+
+    LOK_ASSERT_EQUAL(true, pollDisconnected(std::chrono::microseconds(1000000), *session));
+
+    TST_LOG("Ending Test: " << testname);
+    return TestResult::Ok;
+}
+
+void UnitTimeoutWSPing::invokeWSDTest()
+{
+    UnitBase::TestResult result;
+
+    result = testWSPing();
+    if (result != TestResult::Ok)
+        exitTest(result);
+
+    exitTest(TestResult::Ok);
+}
+
+UnitBase* unit_create_wsd(void) { return new UnitTimeoutWSPing(); }
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/tools/Stress.cpp
+++ b/tools/Stress.cpp
@@ -89,6 +89,8 @@ int Stress::main(const std::vector<std::string>& args)
     }
 #endif
 
+    const std::chrono::microseconds PollTimeoutMicroS = net::Defaults::get().SocketPollTimeout;
+
     std::string server = args[0];
 
     if (!strncmp(server.c_str(), "http", 4))
@@ -104,7 +106,7 @@ int Stress::main(const std::vector<std::string>& args)
         StressSocketHandler::addPollFor(poll, server, args[i], args[i+1], stats);
 
     do {
-        poll.poll(TerminatingPoll::DefaultPollTimeoutMicroS);
+        poll.poll(PollTimeoutMicroS);
     } while (poll.continuePolling() && poll.getSocketCount() > 0);
 
     stats->dump();

--- a/tools/WebSocketDump.cpp
+++ b/tools/WebSocketDump.cpp
@@ -264,7 +264,9 @@ int main (int argc, char **argv)
 
     // Setup listening socket with a factory for connected sockets.
     auto serverSocket = std::make_shared<ServerSocket>(
-        Socket::Type::All, DumpSocketPoll,
+        Socket::Type::All,
+        std::chrono::steady_clock::now(),
+        DumpSocketPoll,
         std::make_shared<DumpSocketFactory>(isSSL));
 
     if (!serverSocket->bind(ServerSocket::Type::Public, port))

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -3871,7 +3871,7 @@ private:
 
             _pid = pid;
             _socketFD = socket->getFD();
-            child->setSMapsFD(socket->getIncomingFD(SMAPS));
+            child->setSMapsFD(socket->getIncomingFD(SharedFDType::SMAPS));
             _childProcess = child; // weak
 
             addNewChild(std::move(child));

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -595,6 +595,7 @@ void ClientRequestDispatcher::onConnect(const std::shared_ptr<StreamSocket>& soc
 {
     _id = COOLWSD::GetConnectionId();
     _socket = socket;
+    _lastSeenHTTPHeader = socket->getLastSeenTime();
     setLogContext(socket->getFD());
     LOG_TRC("Connected to ClientRequestDispatcher");
 }
@@ -664,7 +665,7 @@ void ClientRequestDispatcher::handleIncomingMessage(SocketDisposition& dispositi
     Poco::Net::HTTPRequest request;
 
     StreamSocket::MessageMap map;
-    if (!socket->parseHeader("Client", startmessage, request, map))
+    if (!socket->parseHeader("Client", startmessage, request, _lastSeenHTTPHeader, map))
         return;
 
     const bool closeConnection = !request.getKeepAlive(); // HTTP/1.1: closeConnection true w/ "Connection: close" only!

--- a/wsd/ClientRequestDispatcher.hpp
+++ b/wsd/ClientRequestDispatcher.hpp
@@ -119,6 +119,9 @@ private:
     std::weak_ptr<StreamSocket> _socket;
     std::string _id;
 
+    // Used for StreamSocket::parseHeader, net::Defaults::HTTPTimeout acting as max delay
+    std::chrono::steady_clock::time_point _lastSeenHTTPHeader;
+
 #if !MOBILEAPP
     /// WASM document request handler. Used only when WASM is enabled.
     std::unique_ptr<WopiProxy> _wopiProxy;

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -140,6 +140,7 @@ public:
         TerminatingPoll(threadName),
         _docBroker(docBroker)
     {
+        setLimiter( net::Defaults::get().MaxConnections );
     }
 
     void pollingThread() override

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -98,8 +98,8 @@ public:
         , _jailId(jailId)
         , _smapsFD(-1)
     {
-        int urpFromKitFD = socket->getIncomingFD(URPFromKit);
-        int urpToKitFD = socket->getIncomingFD(URPToKit);
+        int urpFromKitFD = socket->getIncomingFD(SharedFDType::URPFromKit);
+        int urpToKitFD = socket->getIncomingFD(SharedFDType::URPToKit);
         if (urpFromKitFD != -1 && urpToKitFD != -1)
         {
             _urpFromKit = StreamSocket::create<StreamSocket>(

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -102,12 +102,15 @@ public:
         int urpToKitFD = socket->getIncomingFD(SharedFDType::URPToKit);
         if (urpFromKitFD != -1 && urpToKitFD != -1)
         {
+            std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
             _urpFromKit = StreamSocket::create<StreamSocket>(
                 std::string(), urpFromKitFD, Socket::Type::Unix,
-                false, HostType::Other, std::make_shared<UrpHandler>(this));
+                false, HostType::Other, std::make_shared<UrpHandler>(this),
+                StreamSocket::ReadType::NormalRead, now);
             _urpToKit = StreamSocket::create<StreamSocket>(
                 std::string(), urpToKitFD, Socket::Type::Unix,
-                false, HostType::Other, std::make_shared<UrpHandler>(this));
+                false, HostType::Other, std::make_shared<UrpHandler>(this),
+                StreamSocket::ReadType::NormalRead, now);
         }
     }
 

--- a/wsd/ProxyProtocol.hpp
+++ b/wsd/ProxyProtocol.hpp
@@ -40,10 +40,6 @@ public:
     int getPollEvents(std::chrono::steady_clock::time_point /* now */,
                       int64_t &/* timeoutMaxMs */) override;
 
-    void checkTimeout(std::chrono::steady_clock::time_point /* now */) override
-    {
-    }
-
     void performWrites(std::size_t capacity) override;
 
     void onDisconnect() override


### PR DESCRIPTION
* Resolves: #9833
* Target version: master 

### Summary
    
- ProtocolHandlerInterface::checkTimeout(..)
  is now called via StreamSocket::checkRemoval()
  to ensure tests even w/o input data (was: handlePoll())
    
- ProtocolHandlerInterface::checkTimeout(..)
  - Add bool return value: true -> shutdown connection, caller shall stop processing
  - Implemented for http::Session
    - Timeout (30s) net::Defaults::HTTPTimeout with missing response
  - Implemented for WebSocketHandler
    - Timeout (2s = net::Defaults::WSPingTimeout)
      after missing WS native frame ping/pong (server only)
    
- StreamSocket -> Socket (properties moved)
  - bytes sent/received
  - closed state
    
- Socket (added properties)
  - creation- and last-seen -time
  - socket type and port
  - checkRemoval(..)
    - called directly from SocketPoll::poll()
    - only for IPv4/v6 network connections
    - similar to ProtocolHandlerInterface::checkTimeout(..)
    - added further criteria (age, throughput, ..)
      - Timeout (64s = net::Defaults::SocketPollTimeout)
        if (now - lastSeen) > timeout
      - Timeout (net::Defaults::MinBytesPerSec)
        if Throughput < MinBytesPerSec (disabled by default)
      - TODO: Add maximimal IPv4/IPv6 socket-count criteria, drop oldest.
      - age via Socket::creationTime is currently not used as requested
    
- SocketPoll::poll()
  - Additionally erases if !socket->isOpen() || socket->checkRemoval()

#### Changes to original PR
- net::Config -> net::Defaults, without any xml config file side-effects
  - only allow net::Defaults to be changed in unit tests via dedicated callback
- removed Socket age criteria via Socket::creationTime and net::defaults::MaxDuration
  - Socket::creationTime still relevant for minimum throughput criteria
  - dropped the net::defaults::MaxDuration 
- max-connections
  - removed under- overflow checks
  - using SC atomic ops (not just relaxed)
- enhanced API doc of Util::TimeAverage (clarification)
- unit tests in one place / commit
- more unification/squashing to single semantic commits
- more sensible order of commits
- removed dead code
- dropped noexcept patch

Further:
- cleaned up the commit messages
- removed the COOLWSD.cpp default config reordering
- reordered the 'Unify socket stats', as it must be upfront the actual connection count limitation
  and before moved _lastSeenHTTPHeader
- fixed another intermediate breakage in the commit chain
- bisectable proof (but no unit test runs ofc) .. via
  - passed `git rebase -i --exec "make -j 20"` for all commits
- Use scoped enums with efficient types (STATE_ENUM)
  - now using desired STATE_ENUM

Unit tests:   +7 files, 879 insertions(+), remaining changed lines +800, -222

### Checklist
- [X] I have run `make prettier-write` and formatted the code.
- [X] All commits have Change-Id
- [ ] I have run tests with `make check`
- [X] Passed certain unit tests and cypress desktop annotations.js
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required
