### PR TITLE
silence error from find during 'make dist'

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -164,7 +164,7 @@ NODE_MODULES_JS =\
 	node_modules/jquery-mousewheel/jquery.mousewheel.js \
 	node_modules/jquery-contextmenu/dist/jquery.contextMenu.js \
 	node_modules/jquery-ui/dist/jquery-ui.js \
-	$(shell find node_modules/jquery-ui/ui/i18n -name '*.js') \
+	$(shell find node_modules/jquery-ui/ui/i18n -name '*.js' 2>/dev/null) \
 	node_modules/smartmenus/dist/jquery.smartmenus.js \
 	node_modules/fzstd/umd/index.js
 


### PR DESCRIPTION
It is:
    find: 'node_modules/jquery-ui/ui/i18n': No such file or directory
This directory is created during normal build.


Change-Id: Ie7c2cee129f1f880a22c4a4d8a48788b73570d5b

