### PR TITLE
fix regression from "Use a hidden variable to get the css vars from url"

### DIFF
--- a/wsd/FileServerUtil.cpp
+++ b/wsd/FileServerUtil.cpp
@@ -11,14 +11,14 @@
 
 #include <config.h>
 
-#include <wasm/base64.hpp>
-
 #include "FileServer.hpp"
 #include "StringVector.hpp"
 
 #include <JsonUtil.hpp>
 
 #include <cctype>
+
+#include <wasm/base64.hpp>
 
 PreProcessedFile::PreProcessedFile(std::string filename, const std::string& data)
     : _filename(std::move(filename))


### PR DESCRIPTION
Compiler complains about unknown uint32_t type.

Signed-off-by: Marco Cecchetti <marco.cecchetti@collabora.com>
Change-Id: I690d89470bfdd977e7fa71957cdc118d9257b7b9
