### PR TITLE
annotation: resolved comment highlights get visible on resize

### DIFF
--- a/browser/src/canvas/sections/CommentListSection.ts
+++ b/browser/src/canvas/sections/CommentListSection.ts
@@ -708,7 +708,10 @@ export class CommentSection extends app.definitions.canvasSectionObject {
 	}
 
 	public select (annotation: Comment, force: boolean = false): void {
-		if (force || (annotation && !annotation.pendingInit && annotation !== this.sectionProperties.selectedComment)) {
+		if (force
+			|| (annotation && !annotation.pendingInit && annotation !== this.sectionProperties.selectedComment
+			&& (annotation.sectionProperties.data.resolved !== 'true' || this.sectionProperties.showResolved)
+			)) {
 			// Select the root comment
 			var idx = this.getRootIndexOf(annotation.sectionProperties.data.id);
 

--- a/browser/src/canvas/sections/CommentSection.ts
+++ b/browser/src/canvas/sections/CommentSection.ts
@@ -688,13 +688,14 @@ export class Comment extends CanvasSectionObject {
 			this.sectionProperties.container.style.visibility = '';
 			this.sectionProperties.container.style.display = '';
 		}
-		if (this.sectionProperties.data.resolved === 'false' || this.sectionProperties.commentListSection.sectionProperties.showResolved)
+		if (this.sectionProperties.data.resolved !== 'true' || this.sectionProperties.commentListSection.sectionProperties.showResolved) {
 			L.DomUtil.addClass(this.sectionProperties.container, 'cool-annotation-collapsed-show');
+			this.sectionProperties.showSelectedCoordinate = true;
+		}
 		this.sectionProperties.contentNode.style.display = '';
 		this.sectionProperties.nodeModify.style.display = 'none';
 		this.sectionProperties.nodeReply.style.display = 'none';
 		this.sectionProperties.collapsedInfoNode.style.visibility = '';
-		this.sectionProperties.showSelectedCoordinate = true;
 	}
 
 	private showCalc() {


### PR DESCRIPTION
problem:
even if resolved comments were not shown,
on resizing window enough to change stat of comments from collapsed to full or vice versa, text containing comment was highlighted


Change-Id: Ia69fd39392411478d84a409fb92af0050db71a1e


* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

