### PR TITLE
cypress: fail on exceptions even without debug

### DIFF
--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -414,7 +414,7 @@ app.definitions.Socket = L.Class.extend({
 						window.app.console.error(msg);
 
 						// When debugging let QA know something is up.
-						if (window.enableDebug)
+						if (window.enableDebug || L.Browser.cypressTest)
 							this._map.uiManager.showInfoModal(
 								'cool_alert', '', msg, '', _('Close'), function() { /* Do nothing. */ }, false);
 


### PR DESCRIPTION
this will fail on CI jobs - protecting us from breaking local testing

