### PR TITLE
uint32_t needs <cstdint>

### DIFF
--- a/wasm/base64.hpp
+++ b/wasm/base64.hpp
@@ -29,6 +29,7 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <cstdint>
 #include <string>
 
 namespace macaron {


### PR DESCRIPTION
./wasm/base64.hpp:109:7: error: ‘uint32_t’ was not declared in this scope


Change-Id: I9de3054504fc6108b473f99c8b43cc3c7cc567fe


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

