### PR TITLE
Fix: Enable keyboard arrow navigation in custom input fields within grids

### DIFF
--- a/browser/src/control/jsdialog/Util.KeyboardGridNavigation.ts
+++ b/browser/src/control/jsdialog/Util.KeyboardGridNavigation.ts
@@ -10,7 +10,7 @@
  */
 
 /*
- * JSDialog.ScrollableBar - helper for creating toolbars with scrolling left/right
+ * JSDialog.KeyboardGridNavigation - handles keyboard-based focus and selection in grid-based UI components
  */
 
 declare var JSDialog: any;
@@ -138,13 +138,21 @@ JSDialog.KeyboardGridNavigation = function (
 ) {
 	container.addEventListener('keydown', (event: KeyboardEvent) => {
 		const activeElement = document.activeElement as HTMLElement;
-		handleKeyboardNavigation(
-			event,
-			activeElement,
-			activeElement.parentElement,
-			selectionHandler,
-			builder,
-			widgetData,
-		);
+		if (
+			!(
+				(activeElement.tagName === 'INPUT' &&
+					(activeElement as HTMLInputElement).type === 'text') ||
+				activeElement.tagName === 'TEXTAREA'
+			)
+		) {
+			handleKeyboardNavigation(
+				event,
+				activeElement,
+				activeElement.parentElement,
+				selectionHandler,
+				builder,
+				widgetData,
+			);
+		}
 	});
 };


### PR DESCRIPTION

- Resolved an issue where keyboard arrow keys were not moving the cursor in custom input fields within grid elements.
- Ensured consistent keyboard interaction across all input fields in grid-based components.


Change-Id: Ice8023bec31d2dfb318d2a4ec92ebb8329c5bac9