### PR TITLE
Fix Dockerfiles for local docker built

### DIFF
--- a/docker/from-source/Debian
+++ b/docker/from-source/Debian
@@ -13,7 +13,8 @@ RUN apt-get update && \
     apt-get -y install libpng16-16 fontconfig adduser cpio \
                findutils nano libcap2-bin openssl inotify-tools \
                procps libubsan1 openssh-client fonts-wqy-zenhei \
-               fonts-wqy-microhei fonts-droid-fallback fonts-noto-cjk
+               fonts-wqy-microhei fonts-droid-fallback fonts-noto-cjk\
+               ca-certificates
 
 
 # copy freshly built LOKit and Collabora Online
@@ -38,6 +39,6 @@ RUN setcap cap_fowner,cap_chown,cap_sys_chroot=ep /usr/bin/coolforkit-caps && \
 EXPOSE 9980
 
 # switch to cool user (use numeric user id to be compatible with Kubernetes Pod Security Policies)
-USER 101
+USER 100
 
 CMD ["/start-collabora-online.sh"]

--- a/docker/from-source/Debian
+++ b/docker/from-source/Debian
@@ -13,7 +13,7 @@ RUN apt-get update && \
     apt-get -y install libpng16-16 fontconfig adduser cpio \
                findutils nano libcap2-bin openssl inotify-tools \
                procps libubsan1 openssh-client fonts-wqy-zenhei \
-               fonts-wqy-microhei fonts-droid-fallback fonts-noto-cjk\
+               fonts-wqy-microhei fonts-droid-fallback fonts-noto-cjk \
                ca-certificates
 
 

--- a/docker/from-source/Ubuntu
+++ b/docker/from-source/Ubuntu
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-FROM ubuntu:18.04
+FROM ubuntu:24.04
 
 # refresh repos otherwise installations later may fail
 # install LibreOffice run-time dependencies
@@ -16,7 +16,7 @@ RUN apt-get update && \
                libcap2-bin openssl openssh-client inotify-tools procps \
                libxcb-shm0 libxcb-render0 libxrender1 libxext6 \
                fonts-wqy-zenhei fonts-wqy-microhei fonts-droid-fallback \
-               fonts-noto-cjk
+               fonts-noto-cjk ca-certificates
 
 # copy freshly built LOKit and Collabora Online
 COPY /instdir /
@@ -40,6 +40,6 @@ RUN setcap cap_fowner,cap_chown,cap_sys_chroot=ep /usr/bin/coolforkit-caps && \
 EXPOSE 9980
 
 # switch to cool user (use numeric user id to be compatible with Kubernetes Pod Security Policies)
-USER 101
+USER 100
 
 CMD ["/start-collabora-online.sh"]


### PR DESCRIPTION
Update Dockerfiles to be able to build local via docker (not via GitHub actions).
- Update to ubuntu 24.04 image to reflect change in gh action
- adapt user-id necessary since Debian 12 / Ubuntu 24.04
- add missing ca-certificates package that prevented WSD starting