### PR TITLE
don't recursively call StreamSocket::dumpState

### DIFF
--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -929,16 +929,20 @@ void WebSocketHandler::dumpState(std::ostream& os, const std::string& /*indent*/
 
 void StreamSocket::dumpState(std::ostream& os)
 {
+    _dumpingNestingLevel++;
     int64_t timeoutMaxMicroS = SocketPoll::DefaultPollTimeoutMicroS.count();
     const int events = getPollEvents(std::chrono::steady_clock::now(), timeoutMaxMicroS);
     os << '\t' << std::setw(6) << getFD() << "\t0x" << std::hex << events << std::dec << '\t'
        << (ignoringInput() ? "ignore\t" : "process\t") << std::setw(6) << _inBuffer.size() << '\t'
        << std::setw(6) << _outBuffer.size() << '\t' << " r: " << std::setw(6) << _bytesRecvd
        << "\t w: " << std::setw(6) << _bytesSent << '\t' << clientAddress() << '\t';
-    _socketHandler->dumpState(os);
+    // Only dump sockerHandler state on a top level dumpState
+    if (_dumpingNestingLevel == 1)
+        _socketHandler->dumpState(os);
     if (_inBuffer.size() > 0)
         Util::dumpHex(os, _inBuffer, "\t\tinBuffer:\n", "\t\t");
     _outBuffer.dumpHex(os, "\t\toutBuffer:\n", "\t\t");
+    _dumpingNestingLevel--;
 }
 
 bool StreamSocket::send(const http::Response& response)

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -958,6 +958,7 @@ public:
         _wsState(WSState::HTTP),
         _closed(false),
         _sentHTTPContinue(false),
+        _dumpingNestingLevel(0),
         _shutdownSignalled(false),
         _readType(readType),
         _inputProcessingEnabled(true),
@@ -1640,6 +1641,9 @@ private:
 
     /// True if we've received a Continue in response to an Expect: 100-continue
     bool _sentHTTPContinue;
+
+    /// Track recursive dumping
+    int _dumpingNestingLevel;
 
     /// True when shutdown was requested via shutdown().
     /// It's accessed from different threads.


### PR DESCRIPTION
 #82030 0x000000000064f99f in DocumentBroker::pollThread() () at wsd/DocumentBroker.cpp:683
 #82029 0x000000000062b7a1 in DocumentBroker::dumpState(std::ostream&) () at /usr/include/c++/12/bits/unique_ptr.h:461
 #82028 0x0000000000802955 in SocketPoll::dumpState(std::ostream&) const () at /usr/include/c++/12/bits/shared_ptr_base.h:1665
 #82027 StreamSocket::dumpState(std::ostream&) () at net/Socket.cpp:936
 ^^^ first call
 #82026 0x0000000000803339 in ProtocolHandlerInterface::dumpState (os=..., this=0x7f8d54162cb0) at /usr/include/c++/12/bits/
 #82025 0x00000000006b19ad in http::Session::dumpState (this=0x7f8d54162cb0, os=..., indent="\n ") at ./net/HttpRequest.hpp:1345
 #82024 StreamSocket::dumpState(std::ostream&) () at net/Socket.cpp:936
 ^^^ reenter

probably an issue since:

commit 1fe50c58cf0ef2912858996a6393cb7dadafe151
CommitDate: Fri Aug 2 08:44:28 2024 -0400

    wsd: add dumpState to http classes


Change-Id: I92a12a6db2f89bc39e226b8945d10616600337c4


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

