### PR TITLE
Calc: Convert print twips to tile before using point info for shape h…

### DIFF
--- a/browser/src/canvas/sections/ShapeHandlesSection.ts
+++ b/browser/src/canvas/sections/ShapeHandlesSection.ts
@@ -314,6 +314,11 @@ class ShapeHandlesSection extends CanvasSectionObject {
 		this.getCustomHandles(halfWidth, halfHeight);
 		this.getPolyHandles(halfWidth, halfHeight);
 		this.getGluePoints();
+
+		if (app.map._docLayer._docType === 'spreadsheet') {
+			for (let i = 0; i < this.sectionProperties.handles.length; i++)
+				app.map._docLayer.sheetGeometry.convertToTileTwips(this.sectionProperties.handles[i].point);
+		}
 	}
 
 	// Update this section's size according to handle coordinates.


### PR DESCRIPTION
…andles.

Change-Id: I59cf06e28f336aaf8f4d32627fd2df9ee4bf4fb8

When there is an image to the bottom rows, selection handles are offset.
This PR ensures they are correctly positioned.