### PR TITLE
Provide snprintf string formatting.

### DIFF
--- a/common/Util.cpp
+++ b/common/Util.cpp
@@ -727,6 +727,44 @@ namespace Util
 #endif
     }
 
+    std::string vformatString(const char* format, va_list ap)
+    {
+        size_t nchars;
+        std::string str;
+        {
+            const size_t bsz = 1024; // including EOS
+            str.reserve(bsz); // incl. EOS
+            str.resize(bsz - 1); // excl. EOS
+
+            nchars = ::vsnprintf(&str[0], bsz, format,
+                                 ap); // NOLINT(clang-analyzer-valist.Uninitialized): clang-tidy bug
+            if (nchars < bsz)
+            {
+                str.resize(nchars);
+                str.shrink_to_fit();
+                return str;
+            }
+        }
+        {
+            const size_t bsz = std::min<size_t>(nchars + 1, str.max_size() + 1); // limit incl. EOS
+            str.reserve(bsz); // incl. EOS
+            str.resize(bsz - 1); // excl. EOS
+            nchars = ::vsnprintf(&str[0], bsz, format,
+                                 ap); // NOLINT(clang-analyzer-valist.Uninitialized): clang-tidy bug
+            str.resize(nchars);
+            return str;
+        }
+    }
+
+    std::string formatString(const char* format, ...)
+    {
+        va_list args;
+        ::va_start(args, format);
+        std::string str = vformatString(format, args);
+        ::va_end(args);
+        return str;
+    }
+
     std::map<std::string, std::string> stringVectorToMap(const std::vector<std::string>& strvector, const char delimiter)
     {
         std::map<std::string, std::string> result;

--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -15,6 +15,7 @@
 #include <cerrno>
 #include <chrono>
 #include <cinttypes>
+#include <cstdarg>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
@@ -541,6 +542,17 @@ namespace Util
         dumpHex(oss, data, legend, prefix, skipDup, width);
         return oss.str();
     }
+
+    /// Returns a string according to `vprintf()` formatting rules
+    /// using `va_list` instead of a variable number of arguments.
+    /// @param format `printf()` compliant format string
+    /// @param ap `va_list` arguments
+    std::string vformatString(const char* format, va_list ap);
+
+    /// Returns a string according to `printf()` formatting rules
+    /// and variable number of arguments following the `format` argument.
+    /// @param format `printf()` compliant format string
+    std::string formatString(const char* format, ...);
 
     size_t findInVector(const std::vector<char>& tokens, const char *cstring, std::size_t offset = 0);
 


### PR DESCRIPTION
Provide snprintf string formatting.

Change-Id: I8097727936038d2b0b63a47ec3e195c7c934c638

* Resolves: Add missing convenient snprintf -> std::string, no issue reported
* Target version: master 

### Summary

Adds missing convenient snprintf -> std::string, no issue reported.

Despite snprintf formatting being the `ugly duckling` due to security concern,
at least in a controlled environment it provides an efficient way for string formatting.

Note C++20 `std::format` is not yet available on our current toolchains
and its evaluation has to be completed.

Note On a remotely related work path inspired by the discussion,
please find [argument type checker jau::cfmt](https://github.com/sgothel/jaulib/commit/4b886061fcf166bced932f9a8df8655ec4af2347) which may 
also likes to be integrated into our Util block for security reasons IFF we intend to 
use `snprintf` formatting in the first place.

### TODO

- [ ] ...

### Checklist

- [X] I have run `make prettier-write` and formatted the code.
- [X] All commits have Change-Id
- [X] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

