### PR TITLE
C++ Cleanup: Default ctor/deleter, drop virtual of virtual-overrides and fix Util::getSystemClockAsString()

### DIFF
--- a/common/Util.cpp
+++ b/common/Util.cpp
@@ -711,7 +711,7 @@ namespace Util
         localtime_r(&t, &tm);
 
         char buffer[128] = { 0 };
-        std::strftime(buffer, 80, "%a %b %d %H:%M", &tm);
+        std::strftime(buffer, 80, "%a %b %d %H:%M:%S", &tm);
         std::stringstream ss;
         ss << buffer << '.' << std::setfill('0') << std::setw(3) << msFraction << ' '
            << tm.tm_year + 1900;

--- a/net/DelaySocket.cpp
+++ b/net/DelaySocket.cpp
@@ -45,8 +45,7 @@ class DelaySocket : public Socket {
         bool isError() const { return _data.empty(); }
         std::chrono::steady_clock::time_point getSendTime() const { return _sendTime; }
         std::vector<char>& getData() { return _data; }
-    private:
-        WriteChunk();
+        WriteChunk() = delete;
     };
 
     std::vector<std::shared_ptr<WriteChunk>> _chunks;

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -2016,7 +2016,7 @@ private:
         return events;
     }
 
-    virtual void handleIncomingMessage(SocketDisposition& /*disposition*/) override
+    void handleIncomingMessage(SocketDisposition& /*disposition*/) override
     {
         if (!isConnected())
         {

--- a/net/ServerSocket.hpp
+++ b/net/ServerSocket.hpp
@@ -136,8 +136,8 @@ public:
     }
     ~LocalServerSocket();
 
-    virtual bool bind(Type, int) override { assert(false); return false; }
-    virtual std::shared_ptr<Socket> accept() override;
+    bool bind(Type, int) override { assert(false); return false; }
+    std::shared_ptr<Socket> accept() override;
     std::string bind();
 #ifndef HAVE_ABSTRACT_UNIX_SOCKETS
     bool link(std::string to);

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -1000,7 +1000,7 @@ public:
         LOG_TRC("Async shutdown requested.");
     }
 
-    virtual void ignoreInput() override
+    void ignoreInput() override
     {
         Socket::ignoreInput();
         _inBuffer.clear();
@@ -1023,7 +1023,7 @@ public:
         return events;
     }
 
-    virtual bool hasBuffered() const override
+    bool hasBuffered() const override
     {
         return !_outBuffer.empty() || !_inBuffer.empty();
     }

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -437,7 +437,7 @@ public:
     // ------------------------------------------------------------------
     // Interface for implementing low level socket goodness from streams.
     // ------------------------------------------------------------------
-    virtual ~ProtocolHandlerInterface() { }
+    virtual ~ProtocolHandlerInterface() = default;
 
     /// Called when the socket is newly created to
     /// set the socket associated with this ResponseClient.
@@ -521,7 +521,7 @@ class WebSocketHandler;
 class SimpleSocketHandler : public ProtocolHandlerInterface
 {
 public:
-    SimpleSocketHandler() {}
+    SimpleSocketHandler() = default;
     int sendTextMessage(const char*, const size_t, bool) const override { return 0; }
     int sendBinaryMessage(const char*, const size_t, bool) const override { return 0; }
     void shutdown(bool, const std::string &) override {}
@@ -539,7 +539,7 @@ protected:
     {
     }
 
-    virtual ~MessageHandlerInterface() {}
+    virtual ~MessageHandlerInterface() = default;
 
 public:
     /// Setup, after construction for shared_from_this

--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -532,7 +532,7 @@ private:
 
 protected:
     /// Implementation of the ProtocolHandlerInterface.
-    virtual void handleIncomingMessage(SocketDisposition&) override
+    void handleIncomingMessage(SocketDisposition&) override
     {
         std::shared_ptr<StreamSocket> socket = _socket.lock();
 
@@ -697,7 +697,7 @@ public:
         return sendFrame(socket, data, len, WSFrameMask::Fin | static_cast<unsigned char>(code), flush);
     }
 
-    virtual bool processInputEnabled() const override
+    bool processInputEnabled() const override
     {
         std::shared_ptr<StreamSocket> socket = _socket.lock();
         if (socket)
@@ -1057,7 +1057,7 @@ protected:
 #endif
     }
 
-    virtual void enableProcessInput(bool enable = true) override
+    void enableProcessInput(bool enable = true) override
     {
         std::shared_ptr<StreamSocket> socket = _socket.lock();
         if (socket)


### PR DESCRIPTION
* Resolves: C++ ambiguity, no issue report
* Target version: master 

### Summary

Resolving some C++ ambiguities, no issue report.
See commit messages for details.

### Checklist

- [X] I have run `make prettier-write` and formatted the code.
- [X] All commits have Change-Id
- [X] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

