### PR TITLE
remove apparmor profile that depends in abi 4.0 if that is not available

### DIFF
--- a/debian/coolwsd.postinst.in
+++ b/debian/coolwsd.postinst.in
@@ -3,6 +3,15 @@
 set -e
 
 case "$1" in
+    install|upgrade|configure)
+        # If abi 4.0 is not present, then remove the apparmor profile config
+        if [ ! -e /etc/apparmor.d/abi/4.0 ]; then
+            rm -f /etc/apparmor.d/usr.bin.coolwsd
+        fi
+        ;;
+esac
+
+case "$1" in
     configure)
 	if [ -f /etc/loolwsd/loolwsd.xml ]; then /usr/bin/coolconfig migrateconfig --write || true; fi
 

--- a/debian/coolwsd.postrm
+++ b/debian/coolwsd.postrm
@@ -3,3 +3,4 @@
 set -e
 
 rm -f /etc/apt/apt.conf.d/25coolwsd
+rm -f /etc/apparmor.d/usr.bin.coolwsd


### PR DESCRIPTION
Change-Id: I40e3b4069486141df7e01ba8df480fd9a4820e91


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

