### PR TITLE
coolwsd-deprecated package missing its postinst

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -456,6 +456,7 @@ EXTRA_DIST = discovery.xml \
              debian/control \
              debian/coolwsd.install \
              debian/coolwsd-deprecated.install \
+             debian/coolwsd-deprecated.postinst \
              debian/coolwsd.postinst \
              debian/coolwsd.postrm \
              etc/key.pem \


### PR DESCRIPTION
so the step to set caps is missing

https://github.com/CollaboraOnline/online/issues/9948

Change-Id: I9dd2cd2309f2169d05c4b7d3ecdaca5a978b965b


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

