### PR TITLE
Hide these elements in About box effectively

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -73,7 +73,7 @@ body {
 }
 
 #wopi-host-id, #proxy-prefix-id {
-	display: none;
+	display: none !important;
 }
 
 .about-dialog-info-div {


### PR DESCRIPTION
Change-Id: I94999b6d8de45ddf9c7c1012d9314694ec5be33b

Fixes the problem of visible "false" string in About box.

![image](https://github.com/user-attachments/assets/79bf1669-390c-49da-bd1f-5bd94569bb71)
