### PR TITLE
Remove sidebar.css and fix Impress' transition text on dark mode

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -3,6 +3,7 @@
 .sidebar * {
 	font-family: var(--jquery-ui-font);
 	text-transform: none !important;
+	color: var(--color-main-text);
 }
 
 img.sidebar.ui-image {


### PR DESCRIPTION
commit e8f304033886564e2ab54bdad4d0db0b3b4a7891 (HEAD -> private/pedro/sidebar-n-transition-btntext, origin/private/pedro/sidebar-n-transition-btntext, master)
Author: Pedro Pinto Silva <pedro.silva@collabora.com>
Date:   Tue Sep 3 10:02:40 2024 +0200

    Impress: Transition sidebar buttons are unreadable in dark mode
    
    Before this commit the sidebar elements were not being set with any
    particular text color.
    
    Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
    Change-Id: I8e8eab765619fcc6fec151c89854b4b478906324

commit 025d56b067ab650f82af8c7a1f34f20e351b1813
Author: Pedro Pinto Silva <pedro.silva@collabora.com>
Date:   Tue Sep 3 10:01:13 2024 +0200

    sidebar.css: Remove 0 byte legacy file
    
    It seems there is not need to update browser/Makefile.am, the file is
    not listed there
    
    Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
    Change-Id: Ibe2ae11c045f90631e64e6eeb04ff0359f36971d
