### PR TITLE
Use current statuses for caching normal-notes view changes.

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -3256,19 +3256,19 @@ void ChildSession::loKitCallback(const int type, const std::string& payload)
         break;
     case LOK_CALLBACK_STATE_CHANGED:
     {
-        if (payload == ".uno:DocumentStatus") // a special pseudo-command
+        if (payload == ".uno:NotesMode=true" || payload == ".uno:NotesMode=false")
         {
             std::string status = LOKitHelper::documentStatus(getLOKitDocument()->get());
             sendTextFrame("statusupdate: " + status);
-            break;
         }
-
-        bool filter = false;
-        if (payload.find(".uno:ModifiedStatus") != std::string::npos)
-            filter = _docManager->trackDocModifiedState(payload);
-
-        if (!filter)
+        else if (payload.find(".uno:ModifiedStatus") != std::string::npos)
+        {
+            if (!_docManager->trackDocModifiedState(payload))
+                sendTextFrame("statechanged: " + payload);
+        }
+        else
             sendTextFrame("statechanged: " + payload);
+
         break;
     }
     case LOK_CALLBACK_SEARCH_NOT_FOUND:


### PR DESCRIPTION
Works with https://gerrit.libreoffice.org/c/core/+/172796


Change-Id: Ifb9dc903c9518d4097f2f0ea2679add840b47233


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

