### PR TITLE
config: remove font color value and use fallback 

### DIFF
--- a/coolkitconfig-mobile.xcu
+++ b/coolkitconfig-mobile.xcu
@@ -83,11 +83,6 @@
                 <value>true</value>
             </prop>
         </node>
-        <node oor:name="FontColor">
-            <prop oor:name="Color" oor:op="fuse">
-                <value>0</value>
-            </prop>
-        </node>
         <node oor:name="Links">
             <prop oor:name="Color" oor:op="fuse">
                 <value>128</value>
@@ -400,11 +395,6 @@
             </prop>
             <prop oor:name="IsVisible" oor:op="fuse">
                 <value>true</value>
-            </prop>
-        </node>
-        <node oor:name="FontColor">
-            <prop oor:name="Color" oor:op="fuse">
-                <value>0</value>
             </prop>
         </node>
         <node oor:name="Links">

--- a/coolkitconfig.xcu
+++ b/coolkitconfig.xcu
@@ -96,11 +96,6 @@
                 <value>true</value>
             </prop>
         </node>
-        <node oor:name="FontColor">
-            <prop oor:name="Color" oor:op="fuse">
-                <value>0</value>
-            </prop>
-        </node>
         <node oor:name="Links">
             <prop oor:name="Color" oor:op="fuse">
                 <value>128</value>
@@ -413,11 +408,6 @@
             </prop>
             <prop oor:name="IsVisible" oor:op="fuse">
                 <value>true</value>
-            </prop>
-        </node>
-        <node oor:name="FontColor">
-            <prop oor:name="Color" oor:op="fuse">
-                <value>0xFFFFFF</value>
             </prop>
         </node>
         <node oor:name="Links">


### PR DESCRIPTION
problem:
font color did not account for the alpha channel
due to not having alpha channel, some conditions would evaluate false in core even if they are same color
i.e: fontColor == COL_AUTO because (COL_AUTO contains alpha channel)


Change-Id: I4c1d62a5203ae4efd03244a4c7fa9d0999a365dd

* Target version: master 


### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

