### PR TITLE
annotation: fixed incorrect function call

### DIFF
--- a/browser/src/canvas/sections/CommentListSection.ts
+++ b/browser/src/canvas/sections/CommentListSection.ts
@@ -2141,7 +2141,7 @@ export class CommentSection extends app.definitions.canvasSectionObject {
 		}
 
 		var showResolved = this.map.stateChangeHandler.getItemValue('ShowResolvedAnnotations');
-		app.map.showResolvedComments(showResolved === true || showResolved === 'true');
+		this.setViewResolved(showResolved === true || showResolved === 'true');
 
 		if (this.sectionProperties.docLayer._docType === 'spreadsheet')
 			this.hideAllComments(); // Apply drawing orders.


### PR DESCRIPTION
problem:
incorrect function call was sending additional ShowResolvedAnnotations requests it caused to disregard the ShowResolvedAnnotations stat on reload unless document was saved


Change-Id: I3ab0f8b804428ea813582c04c85540363e51e210


* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

