### PR TITLE
Related: cool#9735 kit: make sure we don't process events in the any input callback

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -2875,19 +2875,31 @@ int pollCallback(void* pData, int timeoutUs)
 bool anyInputCallback(void* data)
 {
     auto kitSocketPoll = reinterpret_cast<KitSocketPoll*>(data);
-    int ret = kitSocketPoll->poll(std::chrono::microseconds(0));
     std::shared_ptr<Document> document = kitSocketPoll->getDocument();
-    if (document)
+    if (!document)
     {
-        std::shared_ptr<KitQueue> queue = document->getQueue();
-        if (!document->hasCallbacks() && queue && queue->getTileQueueSize() == 0)
-        {
-            // Have no pending callbacks and the tile queue is also empty, report that we have no
-            // pending input events.
-            ret = 0;
-        }
+        return false;
     }
-    return ret > 0;
+
+    if (document->hasCallbacks())
+    {
+        return true;
+    }
+
+    std::shared_ptr<KitQueue> queue = document->getQueue();
+    if (!queue)
+    {
+        return false;
+    }
+
+    if (queue->getTileQueueSize() > 0)
+    {
+        return true;
+    }
+
+    // Have no pending callbacks and the tile queue is also empty, report that we have no
+    // pending input events.
+    return true;
 }
 
 /// Called by LOK main-loop


### PR DESCRIPTION
Commit 930cd616fb6defd8c0de0163bd92e637c7b6b76f (Related: cool#9735 kit:
use the new registerAnyInputCallback() LOK API, 2024-08-26) started to
interrupt Writer layout and other idle tasks when we have pending
events.

The intent was to check if we have pending events in anyInputCallback(),
but it turns out that poll() not only checks if there are events to be
processed but also potentially processes them, which I didn't realize
when I did the above commit.

Fix the problem by only checking the callbacks list and the tile queue
in anyInputCallback(): that is enough to keep the interactivity win and
makes sure to avoid a re-entrancy hazard there.

The 300 pages bugdoc with its numbered list is still laid out in 2 steps
(visible page layout, repaint, rest of the layout) after this.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I7632d8dcfa29ddbf4d09b064bc445bb0ea7e7f13
