### PR TITLE
enable cleanup of namespacing using jails

### DIFF
--- a/common/JailUtil.cpp
+++ b/common/JailUtil.cpp
@@ -116,18 +116,20 @@ bool enterUserNS(uid_t uid, gid_t gid)
 #endif
 }
 
-bool coolmount(const std::string& arg, std::string source, std::string target)
+bool coolmount(const std::string& arg, std::string source, std::string target, bool silent = false)
 {
     source = Util::trim(source, '/');
     target = Util::trim(target, '/');
 
     if (isMountNamespacesEnabled())
     {
-        const char *argv[4];
+        const char *argv[5];
         argv[0] = "notcoolmount";
         int argc = 1;
         if (!arg.empty())
             argv[argc++] = arg.c_str();
+        if (silent)
+            argv[argc++] = "-s";
         if (!source.empty())
             argv[argc++] = source.c_str();
         if (!target.empty())
@@ -136,7 +138,7 @@ bool coolmount(const std::string& arg, std::string source, std::string target)
     }
 
     const std::string cmd = Poco::Path(Util::getApplicationPath(), "coolmount").toString() + ' '
-                            + arg + ' ' + source + ' ' + target;
+                            + arg + (silent ? " -s" : " ") + source + ' ' + target;
     LOG_TRC("Executing coolmount command: " << cmd);
     return !system(cmd.c_str());
 }
@@ -187,7 +189,7 @@ bool remountReadonly(const std::string& source, const std::string& target)
 static bool unmount(const std::string& target, bool silent = false)
 {
     LOG_DBG("Unmounting [" << target << ']');
-    const bool res = coolmount("-u", "", target);
+    const bool res = coolmount("-u", "", target, silent);
     if (res)
         LOG_TRC("Unmounted [" << target << "] successfully.");
     else


### PR DESCRIPTION
They used namespace mounts for / so that was both unmounted automatically when the child exited, and not visible to the parent anyway, so there is no "lo" dir to check for.


Change-Id: Ia98032abaae8a33abd57cef38bdc97f6ff4fb0c2


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

