### PR TITLE
slideshow: Fix typo in method name

### DIFF
--- a/browser/src/slideshow/SlideShowPresenter.ts
+++ b/browser/src/slideshow/SlideShowPresenter.ts
@@ -174,7 +174,7 @@ class SlideShowPresenter {
 		});
 	}
 
-	_previoustSlide() {
+	_previousSlide() {
 		if (this._isAnimationPlaying) {
 			this._map.fire('skipanimation');
 			return;
@@ -208,7 +208,7 @@ class SlideShowPresenter {
 		if (event.code === 'Space' || event.code === 'ArrowRight')
 			this._nextSlide();
 		else if (event.code === 'Backspace' || event.code === 'ArrowLeft')
-			this._previoustSlide();
+			this._previousSlide();
 	}
 
 	private centerCanvas() {


### PR DESCRIPTION
Change-Id: I29a0a44bd0cbfebba82865ac6ff8f74969c192c8


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

This typo in the method name was confusing me

### TODO

- [ ] ...

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

