### PR TITLE
test: Add betterer

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -730,6 +730,12 @@ prettier: browser/node_modules
 prettier-write: browser/node_modules
 	@make -C browser prettier-write
 
+betterer: browser/node_modules
+	@make -C browser betterer
+
+betterer-write: browser/node_modules
+	@make -C browser betterer-write
+
 install-exec-hook:
 	cd $(DESTDIR)$(bindir) && \
 	$(LN_S) coolconfig loolconfig && \
@@ -773,7 +779,7 @@ check-for-system-nss:
 
 check-recursive: eslint
 
-check: check-for-system-nss prettier eslint check-recursive
+check: check-for-system-nss prettier eslint betterer check-recursive
 	$(GEN_COVERAGE_COMMAND)
 
 coverage-report:

--- a/browser/.betterer.js
+++ b/browser/.betterer.js
@@ -1,0 +1,14 @@
+const { eslint: eslintBetter } = require('@betterer/eslint');
+const globby = import('globby');
+const { resolve } = require('path');
+
+const eslintIgnorePath = resolve(__dirname, ".eslintignore");
+
+const eslintTypescriptIncludes = async () => (await globby).globbySync(["**/*.ts"], { ignoreFiles: eslintIgnorePath });
+
+module.exports = {
+	'avoid expressions which have no effect': async () =>
+		eslintBetter({
+			'@typescript-eslint/no-unused-expressions': 'error',
+		}).include(await eslintTypescriptIncludes()),
+};

--- a/browser/.betterer.results
+++ b/browser/.betterer.results
@@ -1,0 +1,39 @@
+// BETTERER RESULTS V2.
+// 
+// If this file contains merge conflicts, use `betterer merge` to automatically resolve them:
+// https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
+//
+exports[`avoid expressions which have no effect`] = {
+  value: `{
+    "mocha_tests/Rectangle.test.ts:3311899269": [
+      [137, 4, 44, "Expected an assignment or function call and instead saw an expression.", "59882392"],
+      [175, 4, 44, "Expected an assignment or function call and instead saw an expression.", "1509182872"],
+      [212, 4, 55, "Expected an assignment or function call and instead saw an expression.", "3330792896"],
+      [285, 4, 46, "Expected an assignment or function call and instead saw an expression.", "3589066905"],
+      [321, 4, 54, "Expected an assignment or function call and instead saw an expression.", "2205591640"]
+    ],
+    "src/canvas/sections/CalcGridSection.ts:4187413316": [
+      [18, 8, 77, "Expected an assignment or function call and instead saw an expression.", "1426129941"],
+      [20, 8, 294, "Expected an assignment or function call and instead saw an expression.", "2353581431"]
+    ],
+    "src/canvas/sections/CommentListSection.ts:2180680674": [
+      [1873, 4, 86, "Expected an assignment or function call and instead saw an expression.", "4162620073"]
+    ],
+    "src/control/Control.Header.ts:301747788": [
+      [602, 2, 73, "Expected an assignment or function call and instead saw an expression.", "59194745"]
+    ],
+    "src/control/Control.IdleHandler.ts:1404505661": [
+      [210, 2, 76, "Expected an assignment or function call and instead saw an expression.", "802093524"]
+    ],
+    "src/control/jsdialog/Widget.SidebarContainers.ts:4170730336": [
+      [51, 2, 13, "Expected an assignment or function call and instead saw an expression.", "412599327"]
+    ],
+    "src/layer/CalcSplitPanesContext.ts:1499463670": [
+      [59, 3, 106, "Expected an assignment or function call and instead saw an expression.", "2941789142"],
+      [60, 3, 106, "Expected an assignment or function call and instead saw an expression.", "3922277399"]
+    ],
+    "src/slideshow/SlideShowPresenter.ts:3217713974": [
+      [675, 4, 2, "Expected an assignment or function call and instead saw an expression.", "5859342"]
+    ]
+  }`
+};

--- a/browser/.eslintrc
+++ b/browser/.eslintrc
@@ -51,7 +51,9 @@
         "@typescript-eslint/no-namespace": "off",
         "no-inner-declarations": "off",
         "no-constant-condition": "off",
-        "@typescript-eslint/triple-slash-reference": "off"
+        "@typescript-eslint/triple-slash-reference": "off",
+
+        "@typescript-eslint/no-unused-expressions": "off" // improving in .betterer.ts
       }
     }
   ]

--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -608,6 +608,10 @@ define global_file
 		@$(NODE) node_modules/uglify-js/bin/uglifyjs $< --output $@)
 endef
 
+define run_betterer_check
+	node_modules/@betterer/cli/bin/betterer -c ./.betterer.js $(1)
+endef
+
 define run_eslint_check
 	@$(NODE) node_modules/eslint/bin/eslint.js \
 		--resolve-plugins-relative-to $(abs_builddir) \
@@ -705,6 +709,7 @@ $(INTERMEDIATE_DIR)/cool-src.js: tscompile.done $(call prereq_cool) $(COOL_JS_DS
 	@printf "Checking for obsolete JS build intermediates in this makefile... "
 	@if ! test "z$(COOL_ASSERT_INTERSECT)" == "z"; then echo; echo "Error: please remove obsolete files:"; echo "$(COOL_ASSERT_INTERSECT)"; exit 1; else echo "clean"; fi
 	@echo "Checking for cool JS errors..."
+	$(call run_betterer_check,ci) || echo "Betterer doesn't have the latest state of the project. To fix it, you can run 'make betterer-write'"
 	$(call run_eslint_check,$(srcdir)/src $(srcdir)/js)
 	$(call run_prettier_check,--debug-check $(srcdir)/src $(srcdir)/js/global.js)
 	@echo "Bundling cool..."
@@ -1155,6 +1160,12 @@ prettier-write:
 		$(srcdir)/src \
 		$(srcdir)/js \
 		$(srcdir)/admin/src)
+
+betterer:
+	$(call run_betterer_check,ci) || (echo "Betterer doesn't have the latest state of the project. To fix it, you can run 'make betterer-write'" && exit 1)
+
+betterer-write:
+	$(call run_betterer_check,run)
 
 MOCHA_TEST_LOG = "`pwd`/mocha.log"
 DUPLICATION_TEST_LOG = "`pwd`/duplication.log"

--- a/browser/package.json
+++ b/browser/package.json
@@ -3,6 +3,8 @@
   "version": "0.8.0-dev",
   "description": "Collabora Online front-end",
   "devDependencies": {
+    "@betterer/cli": "^5.4.0",
+    "@betterer/eslint": "^5.4.0",
     "@braintree/sanitize-url": "6.0.2",
     "@types/jquery": "^3.5.29",
     "@types/jquery.contextmenu": "^1.7.38",
@@ -52,11 +54,13 @@
   ],
   "license": "BSD-2-Clause",
   "dependencies": {
+    "globby": "^14.0.2",
     "jsdom": "^16.4.0"
   },
   "scripts": {
     "test": "mocha 'mocha_tests/**/*.js'",
     "test-single": "mocha",
-    "duplication": "jscpd ./src/ --exitCode 1 --min-lines 17"
+    "duplication": "jscpd ./src/ --exitCode 1 --min-lines 17",
+    "betterer": "betterer -c ./.betterer.js"
   }
 }


### PR DESCRIPTION
Betterer is a snapshot test runner which tries to reduce the number of errors. With, for example, eslint, we need to get to 0 errors for the test to pass. This is prohibitive for large changes (e.g. turning on a new eslint option), as you then have to make a lot of changes in the same pull request. For betterer, you only have to avoid making the test fail *more*, so it's OK to fix errors or leave things alone.

---

It runs as a part of check, and outputs (but doesn't block) building.

You can also run it manually, in the same way as prettier or eslint

$ make betterer

And get it to update its snapshots, again in the same way as prettier

$ make betterer-write

---

I avoided adding the betterer precommit, as running eslint takes a long while and this blocked the commit for longer than I considered acceptable. There's probably a way to make this work with eslint-d and a custom test, but even so it's likely custom, brittle and non-ideal.

---

This is a prerequisite for #9975, which is a prerequisite for #8221


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

