### PR TITLE
Fix context submeny arrow key color

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -507,9 +507,8 @@ nav.spreadsheet-color-indicator ~ #sidebar-dock-wrapper {
 .context-menu-hover > span > a {
 	color: var(--color-text-darker);
 }
-
-.context-menu-submenu.context-menu-hover:after {
-	border-color: transparent transparent transparent var(--color-background-lighter);
+.context-menu-submenu:after {
+	border-color: transparent transparent transparent var(--color-text-darker) !important;
 }
 
 /* With RTL write direction the arrow of the context menu's submenu should be flipped */
@@ -517,13 +516,10 @@ nav.spreadsheet-color-indicator ~ #sidebar-dock-wrapper {
 [dir='rtl'] .context-menu-submenu:after {
 	right: unset;
 	left: .5em;
-	border-color: transparent #2f2f2f transparent transparent;
+	border-color: transparent var(--color-text-darker) transparent transparent;
 	border-width: .25em .25em .25em 0;
 }
 
-[dir='rtl'] .context-menu-submenu.context-menu-hover:after {
-	border-color: transparent var(--color-background-lighter) transparent transparent;
-}
 
 #mobile-wizard {
 	display: none;


### PR DESCRIPTION
- Context sub-menu arrow key color was same as menu item bg color. Replaced with appropriate color variable

Before:
![image](https://github.com/user-attachments/assets/d1b1317f-3116-43c8-b052-f0a402bfec33)

After:
![image](https://github.com/user-attachments/assets/d2d791e6-db2e-408b-8d22-e0fa5b162631)

Change-Id: I57bff4640156fa52f92ce1678caa364218349b9c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

