### PR TITLE
fix(debug): Correct newlines

### DIFF
--- a/browser/src/core/Debug.js
+++ b/browser/src/core/Debug.js
@@ -855,13 +855,13 @@ L.DebugManager = L.Class.extend({
 		var updates = this._tileDataTotalUpdates;
 		var invalidates = this._tileDataTotalInvalidates;
 		this.setOverlayMessage('tileData',
-			'Total tile messages: ' + messages + '<br>' +
+			'Total tile messages: ' + messages + '\n' +
 			'loads: ' + loads + ' ' +
 			'deltas: ' + deltas + ' ' +
-			'updates: ' + updates + '<br>' +
-			'invalidates: ' + invalidates + '<br>' +
-			'<b>Tile update waste: ' + Math.round(100.0 * updates / (updates + deltas)) + '%</b>' + '<br>' +
-			'<b>New Tile ratio: ' + Math.round(100.0 * loads / (loads + updates + deltas)) + '%</b>'
+			'updates: ' + updates + '\n' +
+			'invalidates: ' + invalidates + '\n' +
+			'Tile update waste: ' + Math.round(100.0 * updates / (updates + deltas)) + '%\n' +
+			'New Tile ratio: ' + Math.round(100.0 * loads / (loads + updates + deltas)) + '%'
 			);
 	},
 
@@ -932,7 +932,7 @@ L.DebugManager = L.Class.extend({
 		var messages = '';
 		for (var i = this._tileInvalidationId - 1; i > this._tileInvalidationId - 6; i--) {
 			if (i >= 0 && this._tileInvalidationMessages[i]) {
-				messages += '' + i + ': ' + this._tileInvalidationMessages[i] + ' <br>';
+				messages += '' + i + ': ' + this._tileInvalidationMessages[i] + '\n';
 			}
 		}
 		this.setOverlayMessage('tileInvalidationMessages',messages);


### PR DESCRIPTION
Previously we were using \<br/> tags to do newlines in debug mode. In https://github.com/CollaboraOnline/online/pull/9980, we changed from innerHTML to innerText - which is generally a good idea. Unfortunately, it also broke the HTML tags. We can use '\n' for newlines instead.

We also used \<b>, but that wouldn't be possible without introducing extra complexity into the debug overlay.


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

