### PR TITLE
fix(calc): Stop incorrect movement in selection

### DIFF
--- a/browser/src/canvas/sections/CellSelectionHandleSection.ts
+++ b/browser/src/canvas/sections/CellSelectionHandleSection.ts
@@ -48,7 +48,7 @@ class CellSelectionHandle extends app.definitions.canvasSectionObject {
 		newPoint.pX = this.position[0] + point[0];
 		newPoint.pY = this.position[1] + point[1];
 
-		app.map.fire('handleautoscroll', { pos: { x: 0, y: newPoint.cY }, map: app.map });
+		app.map.fire('handleautoscroll', { pos: { x: newPoint.cX, y: newPoint.cY }, map: app.map });
 
 		this.sharedOnDragAndEnd(newPoint);
 	}


### PR DESCRIPTION
When selecting multiple cells in a spreadsheet with lots of narrow cells, the selection drifted to the left. This made it very difficult to make accurate selections.

It appears this is due to erroneously missing the correct X position in the selection autoscroll.

Fixes: CollaboraOnline/online#9906


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

