### PR TITLE
Fix keyboard shortcuts not working outside map region

### DIFF
--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -955,7 +955,7 @@ L.Control.UIManager = L.Control.extend({
 
 	focusSearch: function() {
 		this.showStatusBar();
-		document.getElementById('search-input').focus();
+		this.map.fire('focussearch');
 	},
 
 	isStatusBarVisible: function() {

--- a/browser/src/dom/NotebookbarAccessibility.js
+++ b/browser/src/dom/NotebookbarAccessibility.js
@@ -272,6 +272,12 @@ var NotebookbarAccessibility = function() {
 		}
 	};
 
+	this.onInputKeyDown = function(event) {
+		if (event.ctrlKey) {
+			this.resetState();
+		}
+	};
+
 	this.onInputKeyUp = function(event) {
 		var key = event.key.toUpperCase();
 		event.preventDefault();
@@ -395,6 +401,7 @@ var NotebookbarAccessibility = function() {
 		this.accessibilityInputElement.onfocus = this.onInputFocus.bind(this);
 		this.accessibilityInputElement.onblur = this.onInputBlur.bind(this);
 		this.accessibilityInputElement.onkeyup = this.onInputKeyUp.bind(this);
+		this.accessibilityInputElement.onkeydown = this.onInputKeyDown.bind(this);
 		this.accessibilityInputElement.autocomplete = 'off';
 
 		var container = document.createElement('div');

--- a/browser/src/map/handler/Map.Keyboard.js
+++ b/browser/src/map/handler/Map.Keyboard.js
@@ -397,6 +397,10 @@ L.Map.Keyboard = L.Handler.extend({
 		if (this._map.uiManager.isUIBlocked())
 			return;
 
+		if (window.KeyboardShortcuts.processEvent(app.UI.language.fromURL, ev)) {
+			ev.preventDefault();
+			return;
+		}
 		if (this._map.jsdialog
 			&& (this._map.jsdialog.hasDialogOpened() || this._map.jsdialog.hasSnackbarOpened() || this._map.jsdialog.hasDropdownOpened())
 			&& this._map.jsdialog.handleKeyEvent(ev)) {
@@ -436,23 +440,6 @@ L.Map.Keyboard = L.Handler.extend({
 				this._map._docLayer._preview.partsFocused = false;
 			}
 		}
-		else if (this._isCtrlKey(ev) && !ev.shiftKey && !ev.altKey && ev.keyCode === this.keyCodes.F) {
-			if (app.UI.language.fromURL === 'de' && this._map.getDocType() === 'text') {
-				this._map.sendUnoCommand('.uno:Navigator');
-			}
-			else {
-				if (!this._map.uiManager.isStatusBarVisible()) {
-					this._map.uiManager.showStatusBar();
-				}
-				this._map.fire('focussearch');
-			}
-
-			ev.preventDefault();
-		}
-		else if (this._isCtrlKey(ev) && !ev.shiftKey && ev.altKey && ev.keyCode === this.keyCodes.S && app.UI.language.fromURL === 'de' && this._map.getDocType() === 'text') {
-			this._map.fire('focussearch');
-			ev.preventDefault();
-		}
 		else if (this._isCtrlKey(ev) && ev.keyCode === this.keyCodes.S) {
 			// Save only when not read-only and when HideSaveOption is false.
 			if (!this._map.isReadOnlyMode() && !this._map['wopi'].HideSaveOption) {
@@ -490,7 +477,6 @@ L.Map.Keyboard = L.Handler.extend({
 			ev.preventDefault();
 			return;
 		}
-
 		var docLayer = this._map._docLayer;
 		if (!keyEventFn && docLayer && docLayer.postKeyboardEvent) {
 			// default is to post keyboard events on the document

--- a/browser/src/map/handler/Map.Keyboard.js
+++ b/browser/src/map/handler/Map.Keyboard.js
@@ -436,6 +436,37 @@ L.Map.Keyboard = L.Handler.extend({
 				this._map._docLayer._preview.partsFocused = false;
 			}
 		}
+		else if (this._isCtrlKey(ev) && !ev.shiftKey && !ev.altKey && ev.keyCode === this.keyCodes.F) {
+			if (app.UI.language.fromURL === 'de' && this._map.getDocType() === 'text') {
+				this._map.sendUnoCommand('.uno:Navigator');
+			}
+			else {
+				if (!this._map.uiManager.isStatusBarVisible()) {
+					this._map.uiManager.showStatusBar();
+				}
+				this._map.fire('focussearch');
+			}
+
+			ev.preventDefault();
+		}
+		else if (this._isCtrlKey(ev) && !ev.shiftKey && ev.altKey && ev.keyCode === this.keyCodes.S && app.UI.language.fromURL === 'de' && this._map.getDocType() === 'text') {
+			this._map.fire('focussearch');
+			ev.preventDefault();
+		}
+		else if (this._isCtrlKey(ev) && ev.keyCode === this.keyCodes.S) {
+			// Save only when not read-only and when HideSaveOption is false.
+			if (!this._map.isReadOnlyMode() && !this._map['wopi'].HideSaveOption) {
+				this._map.fire('postMessage', {msgId: 'UI_Save', args: { source: 'keyboard' }});
+				if (!this._map._disableDefaultAction['UI_Save']) {
+					this._map.save(
+						false /* An explicit save should terminate cell edit */,
+						false /* An explicit save should save it again */,
+					);
+				}
+			}
+			ev.preventDefault();
+		}
+		
 	},
 
 	// _handleKeyEvent - checks if the given keyboard event shall trigger
@@ -714,27 +745,6 @@ L.Map.Keyboard = L.Handler.extend({
 			return true;
 		}
 
-		if (this._isCtrlKey(e) && !e.shiftKey && !e.altKey && e.keyCode === this.keyCodes.F) {
-			if (app.UI.language.fromURL === 'de' && this._map.getDocType() === 'text') {
-				this._map.sendUnoCommand('.uno:Navigator');
-			}
-			else {
-				if (!this._map.uiManager.isStatusBarVisible()) {
-					this._map.uiManager.showStatusBar();
-				}
-				this._map.fire('focussearch');
-			}
-
-			e.preventDefault();
-			return true;
-		}
-
-		if (this._isCtrlKey(e) && !e.shiftKey && e.altKey && e.keyCode === this.keyCodes.S && app.UI.language.fromURL === 'de' && this._map.getDocType() === 'text') {
-			this._map.fire('focussearch');
-			e.preventDefault();
-			return true;
-		}
-
 		if (e.altKey || e.shiftKey) {
 
 			// need to handle Ctrl + Alt + C separately for Firefox
@@ -837,14 +847,7 @@ L.Map.Keyboard = L.Handler.extend({
 			this._map.print();
 			return true;
 		case this.keyCodes.S: // s
-			// Save only when not read-only and when HideSaveOption is false.
-			if (!this._map.isReadOnlyMode() && !this._map['wopi'].HideSaveOption) {
-				this._map.fire('postMessage', {msgId: 'UI_Save', args: { source: 'keyboard' }});
-				if (!this._map._disableDefaultAction['UI_Save']) {
-					this._map.save(false /* An explicit save should terminate cell edit */,
-					               false /* An explicit save should save it again */);
-				}
-			}
+			// Handle save event in globalEventHandler
 			return true;
 		case this.keyCodes.V[DEFAULT]: // v
 		case this.keyCodes.V[MAC]: // v (Safari) needs a separate mapping in keyCodes

--- a/browser/src/map/handler/Map.KeyboardShortcuts.ts
+++ b/browser/src/map/handler/Map.KeyboardShortcuts.ts
@@ -166,23 +166,28 @@ keyboardShortcuts.definitions.set('default', new Array<ShortcutDescriptor>(
     */
     new ShortcutDescriptor(null, 'keydown', 0, 'F1', null, 'showhelp', null),
     new ShortcutDescriptor(null, 'keydown', Mod.ALT, 'F1', null, 'focustonotebookbar', null),
+    new ShortcutDescriptor(null, 'keydown', Mod.CTRL, 'f', null,'home-search', null),
 
     new ShortcutDescriptor('spreadsheet', 'keydown', Mod.CTRL | Mod.SHIFT, 'PageUp', undefined, undefined),
     new ShortcutDescriptor('spreadsheet', 'keydown', Mod.CTRL | Mod.SHIFT, 'PageDown', undefined, undefined),
     new ShortcutDescriptor('spreadsheet', 'keydown', 0, 'F5', null, null, null),
 
+
     new ShortcutDescriptor('text', 'keydown', 0, 'F2', null, null, null),
     new ShortcutDescriptor('text', 'keydown', 0, 'F5', null, null, null),
+
 
     new ShortcutDescriptor('presentation', 'keydown', 0, 'F5', null, 'presentation', null),
     new ShortcutDescriptor('presentation', 'keydown', 0, 'PageUp', null, 'previouspart', ViewType.ReadOnly),
     new ShortcutDescriptor('presentation', 'keydown', 0, 'PageDown', null, 'nextpart', ViewType.ReadOnly),
+
 
     new ShortcutDescriptor('drawing', 'keydown', 0, 'F5', null, null, null),
     new ShortcutDescriptor('drawing', 'keydown', 0, 'PageUp', null, 'previouspart', ViewType.ReadOnly),
     new ShortcutDescriptor('drawing', 'keydown', 0, 'PageDown', null, 'nextpart', ViewType.ReadOnly),
     new ShortcutDescriptor('drawing', 'keydown', 0, 'End', null, 'lastpart', ViewType.ReadOnly),
     new ShortcutDescriptor('drawing', 'keydown', 0, 'Home', null, 'firstpart', ViewType.ReadOnly),
+
 
     new ShortcutDescriptor(null, 'keydown', Mod.ALT | Mod.CTRL, 'p', null, 'userlist', null),
 ));
@@ -197,6 +202,8 @@ keyboardShortcuts.definitions.set('de', new Array<ShortcutDescriptor>(
 
     new ShortcutDescriptor('text', 'keydown', Mod.SHIFT, 'F3', '.uno:ChangeCaseRotateCase', null),
     new ShortcutDescriptor('text', 'keydown', 0, 'F5', '.uno:GoToPage', null, null),
+    new ShortcutDescriptor('text', 'keydown', Mod.CTRL, 'f', '.uno:Navigator', null),
+    new ShortcutDescriptor('text', 'keydown',  Mod.ALT | Mod.CTRL, 's', null, 'home-search', null),
 
     new ShortcutDescriptor('spreadsheet', 'keydown', Mod.SHIFT, 'F3', '.uno:FunctionDialog', null),
     new ShortcutDescriptor('spreadsheet', 'keydown', Mod.SHIFT, 'F2', null, 'insertcomment', null),

--- a/cypress_test/integration_tests/desktop/draw/pdf_page_up_down_spec.js
+++ b/cypress_test/integration_tests/desktop/draw/pdf_page_up_down_spec.js
@@ -11,7 +11,6 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'PDF View Tests', function(
 	});
 
 	it('PDF page down', { env: { 'pdf-view': true } }, function() {
-		cy.cGet('#map').type('{pagedown}'); // Not sure if first button press should change the page.
 		cy.cGet('#map').type('{pagedown}');
 		cy.cGet('#preview-frame-part-1').should('have.attr', 'style', 'border: 2px solid darkgrey;');
 		cy.cGet('#map').type('{pageup}');


### PR DESCRIPTION
- Save and find events were not considered as global event, which is the reason of Keyboard shortcuts like CTRL + S or CTRL + F are not working outside `map`
- this patch will fix that issue. Now user can get focus on search input from anywhere on the document also document save will also work as expected.
- problems like after CTRL + S sometimes we got web browser save popup will be fixed by this patch

 +++ Problem +++

- CTRL + S and Ctrl + F are not working before this patch for cases like
    - Press alt (to activate the accesskey tooltip) in the notebookbar
    - Place the cursor inside of the document name Press ctrl + S
    - open About dialog
        - Press ctrl + F it triggers in the browser search and not the status bar.
        - Press ctrl + S it triggers in the browser save and not the COOL save action.

Change-Id: I1e1f5aa59b1c47e7e888198568e45e8a3a84843c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

