### PR TITLE
signal waiting - always wait for signals before _Exit.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -377,6 +377,7 @@ shared_headers = common/Common.hpp \
                  common/Rectangle.hpp \
                  common/RenderTiles.hpp \
                  common/SigUtil.hpp \
+                 common/SigHandlerTrap.hpp \
                  common/security.h \
                  common/SpookyV2.h \
                  common/CommandControl.hpp \

--- a/common/SigHandlerTrap.hpp
+++ b/common/SigHandlerTrap.hpp
@@ -1,0 +1,48 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <unistd.h>
+
+// Lives in Util.cpp for dependency reasons.
+namespace SigUtil
+{
+    /// This traps the signal-handler so we don't _Exit
+    /// while dumping stack trace. It's re-entrant.
+    /// Used to safely increment and decrement the signal-handler trap.
+    class SigHandlerTrap
+    {
+        static std::atomic<int> SigHandling;
+    public:
+        SigHandlerTrap() { ++SigHandlerTrap::SigHandling; }
+        ~SigHandlerTrap() { --SigHandlerTrap::SigHandling; }
+
+        /// Check that we have exclusive access to the trap.
+        /// Otherwise, there is another signal in progress.
+        bool isExclusive() const
+        {
+            // Return true if we are alone.
+            return SigHandlerTrap::SigHandling == 1;
+        }
+
+        /// Wait for the trap to clear.
+        static void wait()
+        {
+            while (SigHandlerTrap::SigHandling)
+                sleep(1);
+        }
+    };
+
+} // end namespace SigUtil
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/common/SigUtil.hpp
+++ b/common/SigUtil.hpp
@@ -86,10 +86,6 @@ namespace SigUtil
     /// Signal log number
     void signalLogNumber(std::size_t num, int base = 10);
 
-    /// Wait for the signal handler, if any,
-    /// and prevent _Exit while collecting backtrace.
-    void waitSigHandlerTrap();
-
     /// Returns the name of the signal.
     const char* signalName(int signo);
 

--- a/common/Util.cpp
+++ b/common/Util.cpp
@@ -17,6 +17,7 @@
 #endif
 
 #include "Util.hpp"
+#include "SigHandlerTrap.hpp"
 
 #include <poll.h>
 
@@ -828,6 +829,10 @@ namespace Util
         __gcov_dump();
 #endif
 
+        /// Wait for the signal handler, if any,
+        /// and prevent _Exit while collecting backtrace.
+        SigUtil::SigHandlerTrap::wait();
+
         std::_Exit(code);
     }
 
@@ -1115,5 +1120,9 @@ namespace Util
     }
 
 } // namespace Util
+
+namespace SigUtil {
+    std::atomic<int> SigHandlerTrap::SigHandling;
+} // end namespace SigUtil
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -3566,8 +3566,6 @@ void lokit_main(
 
     LOG_INF("Kit process for Jail [" << jailId << "] finished.");
     flushTraceEventRecordings();
-    // Wait for the signal handler, if invoked, to prevent exiting until done.
-    SigUtil::waitSigHandlerTrap();
     if (!Util::isKitInProcess())
         Util::forcedExit(EX_OK);
 


### PR DESCRIPTION
Centralize waiting in a single, normal exit location. This avoids us loosing and not being able to attach to and debug a crashed child thread when another thread decides to _Exit for some reason while the signal handler is running in the other thread.


Change-Id: I9a788960712506593c61b68305ed6cb90f948ead


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

