### PR TITLE
Misc Improvements

### DIFF
--- a/common/Clipboard.hpp
+++ b/common/Clipboard.hpp
@@ -125,8 +125,7 @@ class ClipboardCache
 
         bool hasExpired(const std::chrono::steady_clock::time_point &now)
         {
-            return std::chrono::duration_cast<std::chrono::minutes>(
-                now - _inserted).count() >= CLIPBOARD_EXPIRY_MINUTES;
+            return (now - _inserted) >= std::chrono::minutes(CLIPBOARD_EXPIRY_MINUTES);
         }
     };
     // clipboard key -> data

--- a/common/Common.hpp
+++ b/common/Common.hpp
@@ -53,6 +53,9 @@ constexpr long READ_BUFFER_SIZE = 64 * 1024;
 /// or as intentionally flooding the server.
 constexpr int MAX_MESSAGE_SIZE = 2 * 1024 * READ_BUFFER_SIZE;
 
+/// Limits number of HTTP redirections to prevent endless redirection loops.
+static constexpr int HTTP_REDIRECTION_LIMIT = 21;
+
 constexpr const char JAILED_DOCUMENT_ROOT[] = "/tmp/user/docs/";
 constexpr const char CHILD_URI[] = "/coolws/child?";
 constexpr const char NEW_CHILD_URI[] = "/coolws/newchild";

--- a/common/FileUtil.cpp
+++ b/common/FileUtil.cpp
@@ -540,7 +540,10 @@ namespace FileUtil
 #if defined(__linux__) || defined(__FreeBSD__)
         struct statfs sfs;
         if (statfs(path.c_str(), &sfs) == -1)
-            return true;
+        {
+            LOG_SYS("Failed to stat filesystem [" << path << ']');
+            return true; // We assume the worst.
+        }
 
         const int64_t freeBytes = static_cast<int64_t>(sfs.f_bavail) * sfs.f_bsize;
 

--- a/common/FileUtil.cpp
+++ b/common/FileUtil.cpp
@@ -494,7 +494,7 @@ namespace FileUtil
         if (cacheLastCheck)
         {
             // Don't check more often than once a minute
-            if (std::chrono::duration_cast<std::chrono::seconds>(now - lastCheck).count() < 60)
+            if ((now - lastCheck) < std::chrono::minutes(1))
                 return lastResult;
 
             lastCheck = now;

--- a/common/SigUtil.cpp
+++ b/common/SigUtil.cpp
@@ -68,7 +68,7 @@ static std::atomic<bool> ForwardSigUsr2Flag(false); //< Flags to forward SIG_USR
 #endif
 #endif
 
-static size_t ActivityStringIndex = 0;
+static std::atomic<size_t> ActivityStringIndex = 0;
 static std::string ActivityHeader;
 static std::array<std::atomic<char *>, 16> ActivityStrings;
 static bool UnattendedRun = false;

--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -1475,12 +1475,6 @@ int main(int argc, char**argv)
         return iequal(lhs.c_str(), lhs.size(), rhs.c_str(), rhs.size());
     }
 
-    /// Get system_clock now in milliseconds.
-    inline int64_t getNowInMS()
-    {
-        return std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::system_clock::now()).time_since_epoch().count();
-    }
-
     /// Convert a vector to a string. Useful for conversion in templates.
     template <typename T> inline std::string toString(const T& x)
     {

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -3048,7 +3048,7 @@ void ChildSession::updateSpeed()
     std::chrono::steady_clock::time_point now(std::chrono::steady_clock::now());
 
     while (_cursorInvalidatedEvent.size() != 0 &&
-           std::chrono::duration_cast<std::chrono::milliseconds>(now - _cursorInvalidatedEvent.front()).count() > _eventStorageIntervalMs)
+           (now - _cursorInvalidatedEvent.front()) > EventStorageInterval)
     {
         _cursorInvalidatedEvent.pop();
     }
@@ -3062,7 +3062,7 @@ int ChildSession::getSpeed()
     std::chrono::steady_clock::time_point now(std::chrono::steady_clock::now());
 
     while (_cursorInvalidatedEvent.size() > 0 &&
-           std::chrono::duration_cast<std::chrono::milliseconds>(now - _cursorInvalidatedEvent.front()).count() > _eventStorageIntervalMs)
+           (now - _cursorInvalidatedEvent.front()) > EventStorageInterval)
     {
         _cursorInvalidatedEvent.pop();
     }

--- a/kit/ChildSession.hpp
+++ b/kit/ChildSession.hpp
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <unordered_map>
 #include <queue>
 
@@ -256,7 +257,7 @@ private:
     std::shared_ptr<Watermark> _docWatermark;
 
     std::queue<std::chrono::steady_clock::time_point> _cursorInvalidatedEvent;
-    const unsigned _eventStorageIntervalMs = 15*1000;
+    static constexpr std::chrono::seconds EventStorageInterval{ 15 };
 
     /// View ID, returned by createView() or 0 by default.
     int _viewId;

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -2350,7 +2350,7 @@ void Document::postForceModifiedCommand(bool modified)
 
 void Document::forceDocUnmodifiedForBgSave(int viewId)
 {
-    LOG_TRC("force document unmodified from state " << toString(_modified));
+    LOG_TRC("force document unmodified from state " << name(_modified));
     if (_modified == ModifiedState::Modified)
     {
         getLOKitDocument()->setView(viewId);
@@ -2418,8 +2418,7 @@ bool Document::trackDocModifiedState(const std::string &stateChanged)
         break;
     }
     if (_modified != newState)
-        LOG_TRC("Transition modified state from " <<
-                toString(_modified) << " to " << toString(newState));
+        LOG_TRC("Transition modified state from " << name(_modified) << " to " << name(newState));
     _modified = newState;
 
     return filter;
@@ -2463,7 +2462,7 @@ void Document::dumpState(std::ostream& oss)
         << "\n\tmobileAppDocId: " << _mobileAppDocId
         << "\n\tinputProcessingEnabled: " << processInputEnabled()
         << "\n\tduringLoad: " << _duringLoad
-        << "\n\tmodified: " << toString(_modified)
+        << "\n\tmodified: " << name(_modified)
         << "\n\tbgSaveProc: " << _isBgSaveProcess
         << "\n\tbgSaveDisabled: "<< _isBgSaveDisabled
         << "\n";

--- a/test/UnitWOPIHttpRedirect.cpp
+++ b/test/UnitWOPIHttpRedirect.cpp
@@ -185,13 +185,13 @@ public:
             assertCheckFileInfoRequest(request);
 
             std::string sExpectedMessage = "It is expected to stop requesting after " +
-                                           std::to_string(RedirectionLimit) + " redirections";
-            LOK_ASSERT_MESSAGE(sExpectedMessage, redirectionCount <= RedirectionLimit);
+                                           std::to_string(HTTP_REDIRECTION_LIMIT) + " redirections";
+            LOK_ASSERT_MESSAGE(sExpectedMessage, redirectionCount <= HTTP_REDIRECTION_LIMIT);
 
             LOK_ASSERT_MESSAGE("Expected to be in Phase::Load or Phase::Redirected",
                                _phase == Phase::Load || _phase == Phase::Redirected);
 
-            if (redirectionCount == RedirectionLimit)
+            if (redirectionCount == HTTP_REDIRECTION_LIMIT)
             {
                 exitTest(TestResult::Ok);
                 return true;

--- a/test/WopiTestServer.hpp
+++ b/test/WopiTestServer.hpp
@@ -483,40 +483,40 @@ protected:
             LOG_TST("FakeWOPIHost: Forced document upload");
         }
 
-            std::unique_ptr<http::Response> response = assertPutFileRequest(request);
-            if (!response || response->statusLine().statusCategory() ==
-                                 http::StatusLine::StatusCodeClass::Successful)
-            {
-                const std::streamsize size = request.getContentLength();
-                LOG_TST("FakeWOPIHost: Writing document contents in storage (" << size << "bytes)");
-                std::vector<char> buffer(size);
-                message.read(buffer.data(), size);
-                setFileContent(Util::toString(buffer));
-            }
-
-            const Poco::URI uriReq(request.getURI());
-            if (response)
-            {
-                LOG_TST("FakeWOPIHost: Response to POST "
-                        << uriReq.getPath() << ": " << response->statusLine().statusCode() << ' '
-                        << response->statusLine().reasonPhrase());
-                socket->sendAndShutdown(*response);
-            }
-            else
-            {
-                // By default we return success.
-                const std::string body = "{\"LastModifiedTime\": \"" +
-                                         Util::getIso8601FracformatTime(getFileLastModifiedTime()) +
-                                         "\" }";
-                LOG_TST("FakeWOPIHost: Response (default) to POST " << uriReq.getPath()
-                                                                    << ": 200 OK " << body);
-                http::Response httpResponse(http::StatusCode::OK);
-                httpResponse.setBody(body, "application/json; charset=utf-8");
-                socket->sendAndShutdown(httpResponse);
-            }
-
-            return true;
+        std::unique_ptr<http::Response> response = assertPutFileRequest(request);
+        if (!response || response->statusLine().statusCategory() ==
+                             http::StatusLine::StatusCodeClass::Successful)
+        {
+            const std::streamsize size = request.getContentLength();
+            LOG_TST("FakeWOPIHost: Writing document contents in storage (" << size << "bytes)");
+            std::vector<char> buffer(size);
+            message.read(buffer.data(), size);
+            setFileContent(Util::toString(buffer));
         }
+
+        const Poco::URI uriReq(request.getURI());
+        if (response)
+        {
+            LOG_TST("FakeWOPIHost: Response to POST " << uriReq.getPath() << ": "
+                                                      << response->statusLine().statusCode() << ' '
+                                                      << response->statusLine().reasonPhrase());
+            socket->sendAndShutdown(*response);
+        }
+        else
+        {
+            // By default we return success.
+            const std::string body = "{\"LastModifiedTime\": \"" +
+                                     Util::getIso8601FracformatTime(getFileLastModifiedTime()) +
+                                     "\" }";
+            LOG_TST("FakeWOPIHost: Response (default) to POST " << uriReq.getPath() << ": 200 OK "
+                                                                << body);
+            http::Response httpResponse(http::StatusCode::OK);
+            httpResponse.setBody(body, "application/json; charset=utf-8");
+            socket->sendAndShutdown(httpResponse);
+        }
+
+        return true;
+    }
 
     /// In some very rare cases we may get requests from other tests.
     /// This asserts that the URI in question is for our test.

--- a/wasm/base64.hpp
+++ b/wasm/base64.hpp
@@ -37,7 +37,7 @@ namespace macaron {
 class Base64 {
  public:
 
-  static std::string Encode(const std::string data) {
+  static std::string Encode(const std::string& data) {
     static constexpr char sEncodingTable[] = {
       'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H',
       'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P',
@@ -119,7 +119,7 @@ class Base64 {
       if (j < out_len) out[j++] = (triple >> 0 * 8) & 0xFF;
     }
 
-    return "";
+    return std::string();
   }
 
 };

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -430,7 +430,7 @@ void COOLWSD::checkDiskSpaceAndWarnClients(const bool cacheLastCheck)
         const std::string fs = FileUtil::checkDiskSpaceOnRegisteredFileSystems(cacheLastCheck);
         if (!fs.empty())
         {
-            LOG_WRN("File system of [" << fs << "] is dangerously low on disk space.");
+            LOG_WRN("Filesystem [" << fs << "] is dangerously low on disk space");
             COOLWSD::alertAllUsersInternal("error: cmd=internal kind=diskfull");
         }
     }

--- a/wsd/ContentSecurityPolicy.hpp
+++ b/wsd/ContentSecurityPolicy.hpp
@@ -49,7 +49,7 @@ public:
 
     /// Append the given URL to a directive.
     /// @value must be space-delimited and cannot have semicolon.
-    void appendDirectiveUrl(std::string directive, std::string url)
+    void appendDirectiveUrl(std::string directive, const std::string& url)
     {
         appendDirective(std::move(directive), Util::trimURI(url));
     }

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -944,7 +944,7 @@ bool DocumentBroker::download(
             auto poller = std::make_shared<TerminatingPoll>("CFISynReqPoll");
             poller->runOnClientThread();
             CheckFileInfo checkFileInfo(poller, session->getPublicUri(), [](CheckFileInfo&) {});
-            checkFileInfo.checkFileInfoSync(RedirectionLimit);
+            checkFileInfo.checkFileInfoSync(HTTP_REDIRECTION_LIMIT);
             wopiFileInfo = checkFileInfo.wopiFileInfo(session->getPublicUri());
             if (!wopiFileInfo)
             {

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -615,12 +615,12 @@ void DocumentBroker::pollThread()
 #if !MOBILEAPP
         if (std::chrono::duration_cast<std::chrono::minutes>(now - lastClipboardHashUpdateTime).count() >= 2)
         {
-            for (auto &it : _sessions)
+            for (const auto& it : _sessions)
             {
                 if (it.second->staleWaitDisconnect(now))
                 {
-                    std::string id = it.second->getId();
-                    LOG_WRN("Unusual, Kit session " + id + " failed its disconnect handshake, killing");
+                    LOG_WRN("Unusual, Kit session " << it.second->getId()
+                                                    << " failed its disconnect handshake, killing");
                     finalRemoveSession(it.second);
                     break; // it invalid.
                 }
@@ -630,7 +630,7 @@ void DocumentBroker::pollThread()
         if (std::chrono::duration_cast<std::chrono::minutes>(now - lastClipboardHashUpdateTime).count() >= 5)
         {
             LOG_TRC("Rotating clipboard keys");
-            for (auto &it : _sessions)
+            for (const auto& it : _sessions)
                 it.second->rotateClipboardKey(true);
 
             lastClipboardHashUpdateTime = now;

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -1498,8 +1498,7 @@ private:
         DocumentState::Status status() const { return _status; }
         void setStatus(Status newStatus)
         {
-            LOG_TRC("Setting DocumentState from " << toString(_status) << " to "
-                                                  << toString(newStatus));
+            LOG_TRC("Setting DocumentState from " << name(_status) << " to " << name(newStatus));
             assert(newStatus >= _status && "The document status cannot regress");
             _status = newStatus;
         }
@@ -1507,8 +1506,8 @@ private:
         DocumentState::Activity activity() const { return _activity; }
         void setActivity(Activity newActivity)
         {
-            LOG_TRC("Setting Document Activity from " << toString(_activity) << " to "
-                                                      << toString(newActivity));
+            LOG_TRC("Setting Document Activity from " << name(_activity) << " to "
+                                                      << name(newActivity));
             _activity = newActivity;
         }
 
@@ -1521,7 +1520,7 @@ private:
         /// Transitions to Status::Live, implying the document has loaded.
         void setLive()
         {
-            LOG_TRC("Setting DocumentState to Status::Live from " << toString(_status));
+            LOG_TRC("Setting DocumentState to Status::Live from " << name(_status));
             // assert(_status == Status::Loading
             //        && "Document wasn't in Loading state to transition to Status::Live");
             _loaded = true;
@@ -1551,13 +1550,13 @@ private:
 
         void dumpState(std::ostream& os, const std::string& indent = "\n  ") const
         {
-            os << indent << "doc state: " << toString(status());
-            os << indent << "doc activity: " << toString(activity());
+            os << indent << "doc state: " << name(status());
+            os << indent << "doc activity: " << name(activity());
             os << indent << "doc loaded: " << _loaded;
             os << indent << "interactive: " << _interactive;
             os << indent << "close requested: " << _closeRequested;
             os << indent << "unload requested: " << _unloadRequested;
-            os << indent << "disconnected from kit: " << toString(_disconnected);
+            os << indent << "disconnected from kit: " << name(_disconnected);
         }
 
     private:
@@ -1583,12 +1582,13 @@ private:
         if (_docState.activity() != DocumentState::Activity::None)
         {
             LOG_DBG("Error: Cannot start new activity ["
-                    << DocumentState::toString(activity) << "] while executing ["
-                    << DocumentState::toString(_docState.activity()) << ']');
+                    << DocumentState::name(activity) << "] while executing ["
+                    << DocumentState::name(_docState.activity()) << ']');
             assert(!"Cannot start new activity while executing another.");
             return false;
         }
 
+        LOG_DBG("Starting [" << DocumentState::name(activity) << "] activity");
         _docState.setActivity(activity);
         return true;
     }
@@ -1596,7 +1596,7 @@ private:
     /// Ends the current activity.
     void endActivity()
     {
-        LOG_DBG("Ending [" << DocumentState::toString(_docState.activity()) << "] activity.");
+        LOG_DBG("Ending [" << DocumentState::name(_docState.activity()) << "] activity");
         _docState.setActivity(DocumentState::Activity::None);
     }
 

--- a/wsd/RequestVettingStation.cpp
+++ b/wsd/RequestVettingStation.cpp
@@ -100,7 +100,7 @@ void RequestVettingStation::handleRequest(const std::string& id)
                             << docKey << "] is for a WOPI document");
 
             // CheckFileInfo asynchronously.
-            checkFileInfo(uriPublic, isReadOnly, RedirectionLimit);
+            checkFileInfo(uriPublic, isReadOnly, HTTP_REDIRECTION_LIMIT);
             break;
 #endif //!MOBILEAPP
     }
@@ -254,7 +254,7 @@ void RequestVettingStation::handleRequest(const std::string& id,
                     {
                         // We haven't tried or we timed-out. Retry.
                         _checkFileInfo.reset();
-                        checkFileInfo(uriPublic, isReadOnly, RedirectionLimit);
+                        checkFileInfo(uriPublic, isReadOnly, HTTP_REDIRECTION_LIMIT);
                     }
                     else
                     {

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -23,9 +23,6 @@
 #include <string>
 #include <chrono>
 
-/// Limits number of HTTP redirections to prevent from redirection loops
-static constexpr auto RedirectionLimit = 21;
-
 class LockContext;
 
 /// Base class of all Storage abstractions.

--- a/wsd/wopi/WopiProxy.cpp
+++ b/wsd/wopi/WopiProxy.cpp
@@ -112,7 +112,7 @@ void WopiProxy::handleRequest([[maybe_unused]] const std::shared_ptr<Terminating
                     poll->insertNewSocket(moveSocket);
 
                     // CheckFileInfo and only when it's good create DocBroker.
-                    checkFileInfo(poll, uriPublic, RedirectionLimit);
+                    checkFileInfo(poll, uriPublic, HTTP_REDIRECTION_LIMIT);
                 });
             break;
 #endif //!MOBILEAPP
@@ -165,7 +165,7 @@ void WopiProxy::checkFileInfo(const std::shared_ptr<TerminatingPoll>& poll, cons
                 try
                 {
                     LOG_INF("WOPI::GetFile using FileUrl: " << fileUrlAnonym);
-                    return download(poll, url, Poco::URI(fileUrl), RedirectionLimit);
+                    return download(poll, url, Poco::URI(fileUrl), HTTP_REDIRECTION_LIMIT);
                 }
                 catch (const std::exception& ex)
                 {
@@ -186,7 +186,7 @@ void WopiProxy::checkFileInfo(const std::shared_ptr<TerminatingPoll>& poll, cons
             try
             {
                 LOG_INF("WOPI::GetFile using default URI: " << uriAnonym);
-                return download(poll, url, uriObject, RedirectionLimit);
+                return download(poll, url, uriObject, HTTP_REDIRECTION_LIMIT);
             }
             catch (const std::exception& ex)
             {

--- a/wsd/wopi/WopiStorage.cpp
+++ b/wsd/wopi/WopiStorage.cpp
@@ -559,7 +559,7 @@ std::string WopiStorage::downloadStorageFileToLocal(const Authorization& auth,
         {
             LOG_INF("WOPI::GetFile template source: " << templateUriAnonym);
             return downloadDocument(Poco::URI(templateUri), templateUriAnonym, auth,
-                                    RedirectionLimit);
+                                    HTTP_REDIRECTION_LIMIT);
         }
         catch (const std::exception& ex)
         {
@@ -576,7 +576,8 @@ std::string WopiStorage::downloadStorageFileToLocal(const Authorization& auth,
         try
         {
             LOG_INF("WOPI::GetFile using FileUrl: " << fileUrlAnonym);
-            return downloadDocument(Poco::URI(_fileUrl), fileUrlAnonym, auth, RedirectionLimit);
+            return downloadDocument(Poco::URI(_fileUrl), fileUrlAnonym, auth,
+                                    HTTP_REDIRECTION_LIMIT);
         }
         catch (const StorageSpaceLowException&)
         {
@@ -604,7 +605,7 @@ std::string WopiStorage::downloadStorageFileToLocal(const Authorization& auth,
     try
     {
         LOG_INF("WOPI::GetFile using default URI: " << uriAnonym);
-        return downloadDocument(uriObject, uriAnonym, auth, RedirectionLimit);
+        return downloadDocument(uriObject, uriAnonym, auth, HTTP_REDIRECTION_LIMIT);
     }
     catch (const std::exception& ex)
     {


### PR DESCRIPTION
- wsd: formatting
- wsd: minimize includes
- wsd: move RedirectionLimit to Common.hpp
- wsd: use std::chrono where possible
- wsd: remove unused Util::getNowInMs()
- wsd: clang-tidy fixes
- wsd: cosmetics
- wsd: quarantine logging and checks
- wsd: log statfs failures
- wsd: consistent logging of filesystem issues
- wsd: avoid unnecessary argument copying
- wsd: avoid temporary strings when serializing STATE_ENUM
- wsd: make the signal activity index atomic
