### PR TITLE
C++ Misc Cleanup: More override, std-header, std::make_* usage, ..

### DIFF
--- a/net/ServerSocket.hpp
+++ b/net/ServerSocket.hpp
@@ -134,7 +134,7 @@ public:
         ServerSocket(Socket::Type::Unix, clientPoller, std::move(sockFactory))
     {
     }
-    ~LocalServerSocket();
+    ~LocalServerSocket() override;
 
     bool bind(Type, int) override { assert(false); return false; }
     std::shared_ptr<Socket> accept() override;

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -967,7 +967,7 @@ public:
         LOG_TRC("StreamSocket ctor");
     }
 
-    ~StreamSocket()
+    ~StreamSocket() override
     {
         LOG_TRC("StreamSocket dtor called with pending write: " << _outBuffer.size()
                                                                 << ", read: " << _inBuffer.size());


### PR DESCRIPTION
### Summary

- Use override for virtual function overrides (incl. dtor)
- Use C++ std headers, e.g. cctype instead of ctype.h
- Use global anonym namespace for system functions or std:: system functions, whichever is applicable
- Use std::make_shared<StreamSocket>(..)
- Use std::make_unique<Watchdog>()
- Use 'const' where applicable
- Use pre-incr where applicable
- Use typename where applicable
- Drop redundant type conversions

Change-Id: Id844187c82fce3c6e9bceb512c07180705608ebc

* Prepares for: #9833
* Target version: master 

### Checklist

- [X] I have run `make prettier-write` and formatted the code.
- [X] All commits have Change-Id
- [X] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

