### PR TITLE
slideshow rework: presentation info changed on playing slideshow

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1649,14 +1649,21 @@ L.CanvasTileLayer = L.Layer.extend({
 			if (this._map.slideShowPresenter) {
 				this._map.slideShowPresenter.onSlideShowInfo(content);
 			}
+		} else if (textMsg.startsWith('presentationinfochanged:')) {
+			if (this._map.slideShowPresenter) {
+				this._map.slideShowPresenter.onSlideShowInfoChanged();
+			}
 		} else if (textMsg.startsWith('slidelayer:')) {
 			const content = JSON.parse(textMsg.substring('slidelayer:'.length + 1));
 			this._map.fire('slidelayer', {
 				message: content,
 				image: img
 			});
-		} else if (textMsg.startsWith('sliderenderingcomplete')) {
-			this._map.fire('sliderenderingcomplete');
+		} else if (textMsg.startsWith('sliderenderingcomplete:')) {
+			const status = textMsg.substring('sliderenderingcomplete:'.length + 1);
+			this._map.fire('sliderenderingcomplete', {
+				success: status === 'success'
+			});
 		}
 	},
 

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1649,10 +1649,6 @@ L.CanvasTileLayer = L.Layer.extend({
 			if (this._map.slideShowPresenter) {
 				this._map.slideShowPresenter.onSlideShowInfo(content);
 			}
-		} else if (textMsg.startsWith('presentationinfochanged:')) {
-			if (this._map.slideShowPresenter) {
-				this._map.slideShowPresenter.onSlideShowInfoChanged();
-			}
 		} else if (textMsg.startsWith('slidelayer:')) {
 			const content = JSON.parse(textMsg.substring('slidelayer:'.length + 1));
 			this._map.fire('slidelayer', {

--- a/browser/src/slideshow/SlideShowPresenter.ts
+++ b/browser/src/slideshow/SlideShowPresenter.ts
@@ -88,6 +88,7 @@ class SlideShowPresenter {
 		this._map.on('newfullscreen', this._onStart, this);
 		this._map.on('newpresentinwindow', this._onStartInWindow, this);
 		L.DomEvent.on(document, 'fullscreenchange', this._onFullScreenChange, this);
+		this._map.on('updateparts', this.onUpdateParts, this);
 	}
 
 	removeHooks() {
@@ -99,6 +100,7 @@ class SlideShowPresenter {
 			this._onFullScreenChange,
 			this,
 		);
+		this._map.off('updateparts', this.onUpdateParts, this);
 	}
 
 	private _init() {
@@ -109,6 +111,10 @@ class SlideShowPresenter {
 		this._slideShowNavigator.disable();
 		this._slideShowHandler.setNavigator(this._slideShowNavigator);
 		this._slideShowNavigator.setPresenter(this);
+	}
+
+	private onUpdateParts() {
+		if (this._checkAlreadyPresenting()) this.onSlideShowInfoChanged();
 	}
 
 	public getSlideInfo(slideNumber: number): SlideInfo | null {
@@ -746,6 +752,8 @@ class SlideShowPresenter {
 	}
 
 	onSlideShowInfoChanged() {
+		if (this._presentationInfoChanged) return;
+
 		this._presentationInfoChanged = true;
 		app.socket.sendMessage('getpresentationinfo');
 	}

--- a/browser/src/slideshow/engine/MetaPresentation.ts
+++ b/browser/src/slideshow/engine/MetaPresentation.ts
@@ -131,16 +131,17 @@ class MetaPresentation {
 	}
 
 	public getMetaSlideByIndex(slideIndex: number): MetaSlide {
-		return this.metaSlides.get(this.getSlideHash(slideIndex));
+		return this.getMetaSlide(this.getSlideHash(slideIndex));
 	}
 
 	public getSlideInfo(slideHash: string): SlideInfo {
-		return this.metaSlides.get(slideHash).info;
+		const metaSlide = this.getMetaSlide(slideHash);
+		return metaSlide ? metaSlide.info : null;
 	}
 
 	public getSlideInfoByIndex(slideIndex: number): SlideInfo {
 		const slideHash = this.getSlideHash(slideIndex);
-		return slideHash ? this.metaSlides.get(slideHash).info : null;
+		return slideHash ? this.getSlideInfo(slideHash) : null;
 	}
 
 	public setCurrentSlide(nSlideIndex: number) {

--- a/browser/src/slideshow/engine/SlideShowHandler.ts
+++ b/browser/src/slideshow/engine/SlideShowHandler.ts
@@ -705,6 +705,30 @@ class SlideShowHandler {
 		}
 	}
 
+	cleanLeavingSlideStatus(nOldSlide: number, bSkipSlideTransition: boolean) {
+		const aMetaDoc = this.theMetaPres;
+		if (nOldSlide !== undefined) {
+			const oldMetaSlide = aMetaDoc.getMetaSlideByIndex(nOldSlide);
+			if (this.isEnabled()) {
+				if (
+					oldMetaSlide.animationsHandler &&
+					oldMetaSlide.animationsHandler.isAnimated()
+				) {
+					// force end animations
+					oldMetaSlide.animationsHandler.end(bSkipSlideTransition);
+
+					// clear all queues
+					this.dispose();
+				}
+			}
+
+			if (this.automaticAdvanceTimeout !== null) {
+				clearTimeout(this.automaticAdvanceTimeout as number);
+				this.automaticAdvanceTimeout = null;
+			}
+		}
+	}
+
 	displaySlide(
 		nNewSlide: number,
 		nOldSlide: number | undefined,
@@ -737,24 +761,7 @@ class SlideShowHandler {
 
 		// handle current slide
 		if (nOldSlide !== undefined) {
-			const oldMetaSlide = aMetaDoc.getMetaSlideByIndex(nOldSlide);
-			if (this.isEnabled()) {
-				if (
-					oldMetaSlide.animationsHandler &&
-					oldMetaSlide.animationsHandler.isAnimated()
-				) {
-					// force end animations
-					oldMetaSlide.animationsHandler.end(bSkipSlideTransition);
-
-					// clear all queues
-					this.dispose();
-				}
-			}
-
-			if (this.automaticAdvanceTimeout !== null) {
-				clearTimeout(this.automaticAdvanceTimeout as number);
-				this.automaticAdvanceTimeout = null;
-			}
+			this.cleanLeavingSlideStatus(nOldSlide, bSkipSlideTransition);
 		}
 
 		this.notifySlideStart(nNewSlide, nOldSlide);

--- a/browser/src/slideshow/engine/SlideShowNavigator.ts
+++ b/browser/src/slideshow/engine/SlideShowNavigator.ts
@@ -20,6 +20,7 @@ class SlideShowNavigator {
 	private _canvasClickHandler: MouseClickHandler;
 	private currentSlide: number;
 	private prevSlide: number;
+	private isEnabled: boolean;
 
 	constructor(slideShowHandler: SlideShowHandler) {
 		this.slideShowHandler = slideShowHandler;
@@ -141,6 +142,9 @@ class SlideShowNavigator {
 			'SlideShowNavigator.quit: current index: ' + this.currentSlide,
 		);
 		this.endPresentation(true);
+		this.currentSlide = undefined;
+		this.prevSlide = undefined;
+		this.removeHandlers();
 	}
 
 	switchSlide(nOffset: number, bSkipTransition: boolean) {
@@ -204,7 +208,9 @@ class SlideShowNavigator {
 				nStartSlide,
 		);
 		this.slideShowHandler.isStarting = true;
-		this.displaySlide(nStartSlide, false);
+		this.currentSlide = undefined;
+		this.prevSlide = undefined;
+		this.displaySlide(nStartSlide, bSkipTransition);
 	}
 
 	endPresentation(force: boolean = false) {
@@ -214,6 +220,8 @@ class SlideShowNavigator {
 	onClick(aEvent: MouseEvent) {
 		aEvent.preventDefault();
 		aEvent.stopPropagation();
+
+		if (!this.isEnabled) return;
 
 		const metaSlide = this.theMetaPres.getMetaSlideByIndex(this.currentSlide);
 		if (!metaSlide)
@@ -242,6 +250,7 @@ class SlideShowNavigator {
 	onKeyDown(aEvent: KeyboardEvent) {
 		aEvent.preventDefault();
 		aEvent.stopPropagation();
+		if (!this.isEnabled && aEvent.code !== 'Escape') return;
 		const handler = this.keyHandlerMap[aEvent.code];
 		if (handler) handler();
 	}
@@ -252,5 +261,13 @@ class SlideShowNavigator {
 
 	private get slideCompositor(): SlideCompositor {
 		return this.presenter._slideCompositor;
+	}
+
+	enable() {
+		this.isEnabled = true;
+	}
+
+	disable() {
+		this.isEnabled = false;
 	}
 }

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -3637,11 +3637,6 @@ void ChildSession::loKitCallback(const int type, const std::string& payload)
         sendTextFrame("tooltip: " + payload);
         break;
     }
-    case LOK_CALLBACK_PRESENTATION_INFO_CHANGED:
-    {
-        sendTextFrame("presentationinfochanged: " + payload);
-        break;
-    }
     default:
         LOG_ERR("Unknown callback event (" << lokCallbackTypeToString(type) << "): " << payload);
     }


### PR DESCRIPTION
handle presentation info has changed message
request for updated presentation info
clean current status
restart presentation from last displayed slide if it still exists from
first slide otherwise

make SlideSHowNavigator.quit to be invoked on closing the presentation
window through the window close button.

Signed-off-by: Marco Cecchetti <marco.cecchetti@collabora.com>
Change-Id: I72cf065056245b2c98ff5474be7131235e9683da

this needs core patch: https://gerrit.libreoffice.org/c/core/+/173061
