### PR TITLE
fix(mobile): Unmangle unicode text messages

### DIFF
--- a/android/lib/src/main/cpp/androidapp.cpp
+++ b/android/lib/src/main/cpp/androidapp.cpp
@@ -129,7 +129,7 @@ static void send2JS(const JNIThreadContext &jctx, const std::vector<char>& buffe
     {
         const unsigned char *ubufp = (const unsigned char *)buffer.data();
         std::stringstream ss;
-        ss << "atob('";
+        ss << "b64d('";
 
         Poco::Base64Encoder encoder(ss);
         encoder.rdbuf()->setLineLength(0); // unlimited

--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -24,6 +24,17 @@ var Base64ToArrayBuffer = function(base64Str) {
 	return ab;
 };
 
+// Written and named as a sort of analog to plain atob ... except this one supports non-ascii
+// Nothing is perfect so this also mangles binary - don't decode tiles with it
+// This function may look unused, but it's needed in WASM and mobile to send data through the fake websocket. Please
+// don't remove it without first grepping for 'Base64ToArrayBuffer' in the C++ code
+// eslint-disable-next-line
+var b64d = function(base64Str) {
+	var binStr = atob(base64Str);
+	var u8Array = Uint8Array.from(binStr, c => c.codePointAt(0));
+	return new TextDecoder().decode(u8Array);
+}
+
 // Put these into a class to separate them better.
 class BrowserProperties {
 	static initiateBrowserProperties(global) {

--- a/wasm/wasmapp.cpp
+++ b/wasm/wasmapp.cpp
@@ -52,7 +52,7 @@ static void send2JS(const std::vector<char>& buffer)
     }
     else
     {
-        js = "window.TheFakeWebSocket.onmessage({'data': window.atob('";
+        js = "window.TheFakeWebSocket.onmessage({'data': window.b64d('";
         js = js + macaron::Base64::Encode(std::string(buffer.data(), buffer.size()));
         js = js + "')});";
     }


### PR DESCRIPTION
In I66f8edb5f35e2300e3a0407a139e72039bec0d8d I introduced a regression where unicode messages were decoded as ascii, leading to, e.g., accented characters in jsdialogs being mangled.

I've written a function ("b64d") to decode these messages. I picked the name because it's the same length as the original "atob" (which is useful for buffer size compatibility) and stands for "base 64 decode".


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

