### PR TITLE
backport: fix(mobile): Unmangle unicode text messages

### DIFF
--- a/android/lib/src/main/cpp/androidapp.cpp
+++ b/android/lib/src/main/cpp/androidapp.cpp
@@ -128,7 +128,7 @@ static void send2JS(const JNIThreadContext &jctx, const std::vector<char>& buffe
     {
         const unsigned char *ubufp = (const unsigned char *)buffer.data();
         std::stringstream ss;
-        ss << "atob('";
+        ss << "b64d('";
 
         Poco::Base64Encoder encoder(ss);
         encoder.rdbuf()->setLineLength(0); // unlimited

--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -24,6 +24,17 @@ var Base64ToArrayBuffer = function(base64Str) {
 	return ab;
 };
 
+// Written and named as a sort of analog to plain atob ... except this one supports non-ascii
+// Nothing is perfect so this also mangles binary - don't decode tiles with it
+// This function may look unused, but it's needed in WASM and mobile to send data through the fake websocket. Please
+// don't remove it without first grepping for 'Base64ToArrayBuffer' in the C++ code
+// eslint-disable-next-line
+var b64d = function(base64Str) {
+	var binStr = atob(base64Str);
+	var u8Array = Uint8Array.from(binStr, c => c.codePointAt(0));
+	return new TextDecoder().decode(u8Array);
+}
+
 // Put these into a class to separate them better.
 class BrowserProperties {
 	static initiateBrowserProperties(global) {

--- a/ios/Mobile/CODocument.mm
+++ b/ios/Mobile/CODocument.mm
@@ -103,13 +103,18 @@ static std::atomic<unsigned> appDocIdCounter(1);
 - (void)send2JS:(const char *)buffer length:(int)length {
     LOG_DBG("To JS: " << COOLProtocol::getAbbreviatedMessage(buffer, length).c_str());
 
+    const char *pretext = "window.TheFakeWebSocket.onmessage({'data': window.atob('";
+    const char *posttext = "')});";
+    const int pretextlen = strlen(pretext);
+    const int posttextlen = strlen(posttext);
+
     std::vector<char> data;
     // Reserve the maxiumum possible length after encoding
     // This avoids an excessive number of reallocations. This is overkill
     // for non-binary messages, but most non-binary messages appear to be
     // under 1K bytes in length. In contrast, it appears that binary
     // messags routinely use at least 75% of the maximum possible length.
-    data.reserve((length * 4) + 1);
+    data.reserve(pretextlen + (length * 4) + posttextlen + 1);
     bool newlineFound = false;
     bool binaryMessage = (isMessageOfType(buffer, "tile:", length) ||
                           isMessageOfType(buffer, "tilecombine:", length) ||
@@ -118,20 +123,18 @@ static std::atomic<unsigned> appDocIdCounter(1);
                           isMessageOfType(buffer, "rendersearchlist:", length) ||
                           isMessageOfType(buffer, "windowpaint:", length));
 
-    const char *pretext = "window.TheFakeWebSocket.onmessage({'data': window.atob('";
-    const int pretextlen = strlen(pretext);
     for (int i = 0; i < pretextlen; i++)
         data.push_back(pretext[i]);
 
-    const NSData * payload = [[NSData alloc] initWithBytes:buffer length:length];
-    const NSString * encodedPayload = [payload base64EncodedStringWithOptions: 0];
-    const std::string utf8EncodedPayload = std::string([encodedPayload UTF8String]);
-    
-    for (const char& character : utf8EncodedPayload)
-        data.push_back(character);
+    @autoreleasepool {
+        const NSData * payload = [NSData dataWithBytesNoCopy:const_cast<char*>(buffer) length:length freeWhenDone:NO];
+        const NSString * encodedPayload = [payload base64EncodedStringWithOptions: 0];
+        const std::string_view utf8EncodedPayload = [encodedPayload UTF8String];
 
-    const char *posttext = "')});";
-    const int posttextlen = strlen(posttext);
+        for (const char& character : utf8EncodedPayload)
+            data.push_back(character);
+    }
+
     for (int i = 0; i < posttextlen; i++)
         data.push_back(posttext[i]);
 

--- a/ios/Mobile/Info.plist.in
+++ b/ios/Mobile/Info.plist.in
@@ -249,7 +249,7 @@
 	     CFBundleShortVersionString must, however, be three numbers.
 	-->
 	<key>CFBundleShortVersionString</key>
-	<string>24.04.6</string>
+	<string>24.04.7</string>
 	<key>CFBundleVersion</key>
 	<string>@IOSAPP_BUNDLE_VERSION@</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/wasm/wasmapp.cpp
+++ b/wasm/wasmapp.cpp
@@ -52,7 +52,7 @@ static void send2JS(const std::vector<char>& buffer)
     }
     else
     {
-        js = "window.TheFakeWebSocket.onmessage({'data': window.atob('";
+        js = "window.TheFakeWebSocket.onmessage({'data': window.b64d('";
         js = js + macaron::Base64::Encode(std::string(buffer.data(), buffer.size()));
         js = js + "')});";
     }


### PR DESCRIPTION
This additionally backports #9986 from @plubius, as the unmangle change doesn't apply cleanly without it