### PR TITLE
kit: show busy popup for exported file until ui is unblocked

### DIFF
--- a/browser/src/map/Map.js
+++ b/browser/src/map/Map.js
@@ -1460,10 +1460,10 @@ L.Map = L.Evented.extend({
 			switch (e.statusType)
 			{
 			case 'start':
-				if (e.text) {
-					// e.text translated by Core
-					this.showBusy(e.text);
-				}
+				// e.text translated by Core
+				this.showBusy(e.text ? e.text : _('Please wait!'));
+				if (e.forceid)
+					this._progressBar.forceid = e.forceid;
 				break;
 			case 'setvalue':
 				this._progressBar.setBar(true);
@@ -1472,7 +1472,10 @@ L.Map = L.Evented.extend({
 			case 'finish':
 			case 'coolloaded':
 			case 'reconnected':
+				if(this._progressBar.forceid !== e.forceid)
+					return;
 				this.hideBusy();
+				this._progressBar.forceid = undefined;
 				break;
 			}
 		}

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -3110,7 +3110,8 @@ std::string ChildSession::getBlockedCommandType(std::string command)
 }
 #endif
 
-bool ChildSession::sendProgressFrame(const char* id, const std::string &jsonProps)
+bool ChildSession::sendProgressFrame(const char* id, const std::string& jsonProps,
+                                     const std::string& forcedID)
 {
     std::string msg = "progress: { \"id\":\"";
     msg += id;
@@ -3121,6 +3122,10 @@ bool ChildSession::sendProgressFrame(const char* id, const std::string &jsonProp
     {
         msg += ", ";
         msg += jsonProps;
+    }
+    if (!forcedID.empty())
+    {
+        msg += ", \"forceid\": \"" + forcedID + "\"";
     }
     msg += " }";
     return sendTextFrame(msg);
@@ -3528,16 +3533,19 @@ void ChildSession::loKitCallback(const int type, const std::string& payload)
         if (isPending) // dialog ret=ok, local save has been started
         {
             sendTextFrame("blockui: ");
+            sendProgressFrame("start", "", "exporting");
             return;
         }
         else if (isAbort) // dialog ret=cancel, local save was aborted
         {
             _exportAsWopiUrl.clear();
+            sendProgressFrame("finish", "", "exporting");
             return;
         }
 
         // this is export status message
         sendTextFrame("unblockui: ");
+        sendProgressFrame("finish", "", "exporting");
 
         if (isError) // local save failed
         {

--- a/kit/ChildSession.hpp
+++ b/kit/ChildSession.hpp
@@ -101,7 +101,8 @@ public:
         return _docManager->sendFrame(msg.data(), msg.size(), WSOpCode::Binary);
     }
 
-    bool sendProgressFrame(const char* id, const std::string &jsonProps);
+    bool sendProgressFrame(const char* id, const std::string& jsonProps,
+                           const std::string& forcedID = "");
 
     using Session::sendTextFrame;
 


### PR DESCRIPTION
allow busy popups with specific ids to run until specific
busy popup is finished

problem:
busy popup used to disappear quickly, exported files may not have completed upload. User may think that exporting is finished and close the doc. Which caused failure in export.


Change-Id: I14bce386a200a4f2deae22b1fbefd597b9347268


* Target version: master 


### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

