### PR TITLE
fix(jsdialog): Sync radio text disabled status

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -1268,6 +1268,8 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		};
 
 		$(radiobuttonLabel).click(() => {
+			if ($(radiobutton).prop('disabled')) return;
+
 			$(radiobutton).prop('checked', true);
 			toggleFunction.bind({checked: true})();
 		});


### PR DESCRIPTION
Previously the radio button text ignored whether the radio button was disabled, allowing you to click it and switch to a disabled radio button.


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

