### PR TITLE
feat(mobile): Show move/copy in calc

### DIFF
--- a/browser/src/control/Control.Tabs.js
+++ b/browser/src/control/Control.Tabs.js
@@ -95,32 +95,27 @@ L.Control.Tabs = L.Control.extend({
 				callback: (this._moveSheetRight).bind(this),
 				visible: areTabsMultiple
 			},
-		};
-
-		if (!window.mode.isMobile()) {
-
-			// no blacklisting available for this context menu so only add when needed
-			this._menuItem['.uno:Move'] = {
+			'.uno:Move': {
 				name: _UNO('.uno:Move', 'spreadsheet', true),
 				callback: (this._moveOrCopySheet).bind(this),
 				visible: areTabsMultiple
-			};
-
-			this._menuItem['.uno:CopyTab'] = {
+			},
+			'.uno:CopyTab': {
 				name: _('Copy Sheet...'),
 				callback: function() {this._map.sendUnoCommand('.uno:Move');}.bind(this),
 				visible: function() {
 					return !areTabsMultiple();
 				}
-			};
-			    if (!this._map.isReadOnlyMode() || window.mode.isTablet()) {
-				L.installContextMenu({
-					selector: '.spreadsheet-tab',
-					className: 'cool-font',
-					items: this._menuItem,
-					zIndex: 1000
-				});
-			}
+			},
+		};
+
+		if ((!window.mode.isMobile() && !this._map.isReadOnlyMode()) || window.mode.isTablet()) {
+			L.installContextMenu({
+				selector: '.spreadsheet-tab',
+				className: 'cool-font',
+				items: this._menuItem,
+				zIndex: 1000
+			});
 		}
 
 		map.on('updateparts', this._updateDisabled, this);
@@ -180,6 +175,13 @@ L.Control.Tabs = L.Control.extend({
 							'Hide': this._menuItem['.uno:Hide'],
 							'movesheetleft': this._menuItem['movesheetleft'],
 							'movesheetright': this._menuItem['movesheetright'],
+							'Move': this._menuItem['.uno:Move'],
+						}
+					);
+				} else {
+					Object.assign(menuItemMobile,
+						{
+							'CopyTab': this._menuItem['.uno:CopyTab'],
 						}
 					);
 				}


### PR DESCRIPTION
Previously the move/copy button wasn't a jsdialog, so it couldn't be a mobile wizard. After core change I23cef6330a5d5f64ac8b1746ef22516dc76f9d8e, we made it a jsdialog, so we can show it on mobile. Let's do that!

Requires: https://gerrit.libreoffice.org/c/core/+/172975
Fixes: #9787

Change-Id: Idc172ed37ca346d809c3181fdfefbbb5dc0d400b


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

