### PR TITLE
fix(jsdialog): Clean up radio button styling

### DIFF
--- a/browser/css/mobilewizard.css
+++ b/browser/css/mobilewizard.css
@@ -827,6 +827,10 @@ div#mobile-wizard-content .spinfieldcontainer .spinfieldimage.disabled {
 .checkbutton,
 .radiobutton{
 	clear: both;
+	width: 92%;
+	margin: 0 4%;
+	display: flex;
+	align-items: center;
 }
 .checkbutton label {
 	line-height: 44px;
@@ -886,8 +890,7 @@ div#mobile-wizard-content .spinfieldcontainer .spinfieldimage.disabled {
 	border-radius: 50%;
 	width: var(--btn-size);
 	height: var(--btn-size);
-	margin: 10px 20px 10px 0px !important;
-	float: right;
+	margin: 10px 10px 10px auto !important;
 	-webkit-appearance: none;
 	-moz-appearance: none;
 	-o-appearance: none;

--- a/browser/src/control/Control.MobileWizardBuilder.js
+++ b/browser/src/control/Control.MobileWizardBuilder.js
@@ -268,15 +268,15 @@ L.Control.MobileWizardBuilder = L.Control.JSDialogBuilder.extend({
 		L.DomUtil.addClass(container, 'radiobutton');
 		L.DomUtil.addClass(container, builder.options.cssClass);
 
+		var radiobuttonLabel = L.DomUtil.create('label', '', container);
+		radiobuttonLabel.textContent = builder._cleanText(data.text);
+		radiobuttonLabel.htmlFor = data.id;
+
 		var radiobutton = L.DomUtil.create('input', '', container);
 		radiobutton.type = 'radio';
 
 		if (data.group)
 			radiobutton.name = data.group;
-
-		var radiobuttonLabel = L.DomUtil.create('label', '', container);
-		radiobuttonLabel.textContent = builder._cleanText(data.text);
-		radiobuttonLabel.htmlFor = data.id;
 
 		if (data.enabled === 'false' || data.enabled === false)
 			$(radiobutton).attr('disabled', 'disabled');


### PR DESCRIPTION
The following were issues with the old radio button design:
- It flowed to the edge of the container, whereas everything else has a margin
- It didn't properly center the button vertically
- It had a strangely-sized right margin

To fix this, I've used flex to align everything (as float: right takes elements out of layout so can't be used without making the centering of the label brittle). I've also swapped the order of the creation of the button and label (as previously we were relying on float: right to visually swap them, and while you can do the same with flex's order property it's generally a poor idea for accessibility support)


Change-Id: I7863e1d41bcd5b9dc859fbb10b031f3e7a2859e3


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

