### PR TITLE
feat(UI): Improve split button styling

### DIFF
--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -10,14 +10,10 @@
 }
 
 /* toolbuttons */
-
-.unotoolbutton .unobutton img {
-	width: var(--btn-size);
-	height: var(--btn-size);
-}
 .unotoolbutton .unobutton.selected + .ui-content.unolabel {
 	color: var(--color-text-dark);
 }
+
 /* toolbuttons non selected */
 #clearFormatting,
 .hasnotebookbar .ui-content.unotoolbutton.has-label,

--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -25,17 +25,32 @@
 .hasnotebookbar .ui-content.unotoolbutton:not(.has-label):not(.inline),
 .sidebar.unotoolbutton,
 .jsdialog.unotoolbutton,
+.notebookbar.unotoolbutton,
 #closebutton {
 	background-color: transparent;
 	border: 1px solid transparent;
 	color: var(--color-main-text);
 	border-radius: var(--border-radius);
 }
+
+/* toolbuttons non selected hover */
+.hasnotebookbar .ui-content.unotoolbutton.has-label:hover,
+.hasnotebookbar .ui-content.unotoolbutton.inline:hover,
+.hasnotebookbar .ui-content.unotoolbutton:not(.has-label):not(.inline):hover,
+.sidebar.unotoolbutton:hover,
+.jsdialog.unotoolbutton:hover,
+.notebookbar.unotoolbutton:hover {
+	border: 1px solid var(--color-border-darker);
+	color: var(--color-text-darker);
+	border-radius: var(--border-radius);
+}
+
 /* toolbuttons selected */
 .hasnotebookbar .ui-content.unotoolbutton.selected.has-label,
 .hasnotebookbar .ui-content.unotoolbutton.selected.inline,
 .hasnotebookbar .ui-content.unotoolbutton.selected:not(.has-label):not(.inline),
 .sidebar.unotoolbutton.selected,
+.notebookbar.unotoolbutton.selected,
 .jsdialog.unotoolbutton.selected {
 	background-color: var(--color-background-dark);
 	border: 1px solid var(--color-border-dark);
@@ -50,14 +65,16 @@
 	background-color: var(--color-background-darker);
 	border-color: var(--color-border-darker);
 }
+
 /* toolbuttons selected hover */
+.hasnotebookbar .ui-content.unotoolbutton.has-label:hover,
 .hasnotebookbar .ui-content.unotoolbutton.selected:hover,
 .unotoolbutton.notebookbar:hover,
 .unotoolbutton.jsdialog:hover,
 .hasnotebookbar .ui-content.unotoolbutton.selected:not(.has-label):not(.inline):hover,
 .sidebar.unotoolbutton.selected:hover,
+.notebookbar.unotoolbutton.selected:hover,
 .jsdialog.unotoolbutton.selected:hover {
-	background-color: var(--color-background-darker) !important;
 	border: 1px solid var(--color-border-darker);
 	color: var(--color-text-darker);
 	border-radius: var(--border-radius);

--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -13,9 +13,16 @@
 	/* Shared color for cell and selection border */
 	--cell-cursor-selection-border-color: var(--color-primary);
 
-	--btn-size: 24px;
-	--btn-size-m: 18px;
-	--btn-size-s: 16px;
+	--btn-size: 28px;
+	--btn-padding: 2px;
+	--btn-img-size: calc(var(--btn-size) - var(--btn-padding) * 2);
+
+	--btn-size-m: 22px;
+	--btn-img-size-m: calc(var(--btn-size-m) - var(--btn-padding) * 2);
+
+	--btn-size-s: 20px;
+	--btn-img-size-s: calc(var(--btn-size-s) - var(--btn-padding) * 2);
+
 	--border-radius: 4px; /* buttons, widgets */
 	--border-radius-large: 10px; /* dialog */
 

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -248,6 +248,7 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 .ui-toolbar .ui-separator.vertical {
 	height: 14px;
 	align-self: center;
+	margin: 0 3px;
 }
 
 .jsdialog.ui-separator.horizontal {
@@ -1316,7 +1317,6 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	height: 5px;
 	width: 24px;
 	position: relative;
-	top: -5px;
 	grid-column: 1;
 	grid-row: 2;
 	border: 1px solid var(--color-border-dark);
@@ -1344,17 +1344,18 @@ input[type='number']:hover::-webkit-outer-spin-button {
 .arrowbackground {
 	box-sizing: border-box;
 	width: 16px;
-	height: 24px;
+	height: 100%;
 	display: flex;
 	align-items: center;
 	border-left: 1px solid transparent;
 	background-color: transparent;
 	grid-column: 3;
+	position: relative;
 }
 
 .arrowbackground:hover {
 	border-left-color: transparent;
-	background-color: transparent;
+	background-color: var(--color-background-darker);
 }
 
 .unoarrow:not([disabled]):hover, .arrowbackground:not([disabled]):hover .unoarrow {
@@ -1372,10 +1373,6 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	padding: 8px 10px;
 	margin: 2px 0px;
 	background-color: var(--color-background-dark);
-}
-
-.menubutton span {
-	margin: 0px 5px;
 }
 
 .jsdialog.menubutton img {
@@ -1764,17 +1761,30 @@ input[type='number']:hover::-webkit-outer-spin-button {
 }
 
 /* toolbuttons */
-
-.jsdialog:not(.menubutton) > .ui-content.unobutton {
-	width: var(--btn-size);
-}
-
 .jsdialog .ui-content.unobutton {
-	height: var(--btn-size);
-	padding: 0px;
+	display: flex;
+	flex-direction: column;
+	padding: 3px;
 	vertical-align: middle;
 	background-color: transparent;
 	border: none;
+	position: relative;
+}
+
+.unoarrow::after,
+.jsdialog .ui-content.unobutton::after {
+	--click-increment: -1px;
+	position: absolute;
+	content: '';
+	top: var(--click-increment);
+	right: var(--click-increment);
+	bottom: var(--click-increment);
+	left: var(--click-increment);
+}
+
+.notebookbar .ui-content.unobutton:hover,
+.jsdialog .ui-content.unobutton:hover {
+	background-color: var(--color-background-darker);
 }
 
 .unotoolbutton.has-dropdown {
@@ -1782,10 +1792,6 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	align-items: center;
 	grid-auto-flow: column;
 	grid-template-rows: auto 0px;
-}
-
-.unotoolbutton.jsdialog.sidebar.ui-content > .arrowbackground {
-	width: auto;
 }
 
 /* handling show/hide state */

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -418,8 +418,8 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 }
 
 .ui-listview-icon {
-	height: var(--btn-size-s);
-	width: var(--btn-size-s);
+	height: var(--btn-img-size-s);
+	width: var(--btn-img-size-s);
 	margin-inline-end: 8px;
 	vertical-align: middle;
 }
@@ -1315,10 +1315,8 @@ input[type='number']:hover::-webkit-outer-spin-button {
 /* color selector */
 .unotoolbutton .selected-color {
 	height: 5px;
-	width: 24px;
+	width: calc(var(--btn-img-size) - var(--btn-padding) * 2);
 	position: relative;
-	grid-column: 1;
-	grid-row: 2;
 	border: 1px solid var(--color-border-dark);
 	border-radius: 7px;
 	outline: 1px solid var(--color-background-lighter);
@@ -1375,8 +1373,9 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	background-color: var(--color-background-dark);
 }
 
-.jsdialog.menubutton img {
-	vertical-align: middle;
+.jsdialog .unobutton img {
+	min-width: 0;
+	min-height: 0;
 }
 
 .menubutton .arrow {
@@ -1762,13 +1761,18 @@ input[type='number']:hover::-webkit-outer-spin-button {
 
 /* toolbuttons */
 .jsdialog .ui-content.unobutton {
+	height: var(--btn-size);
+	width: var(--btn-size);
 	display: flex;
 	flex-direction: column;
-	padding: 3px;
+	padding: var(--btn-padding);
 	vertical-align: middle;
 	background-color: transparent;
 	border: none;
 	position: relative;
+	overflow: hidden;
+	justify-content: center;
+	align-items: center;
 }
 
 .unoarrow::after,

--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -26,11 +26,6 @@ img.sidebar.ui-drawing-area {
 	margin: 0;
 }
 
-.sidebar .unobutton > img {
-	width: var(--btn-size);
-	height: var(--btn-size);
-}
-
 #document-container:not(.mobile) + #sidebar-dock-wrapper {
 	padding: 0;
 	box-sizing: border-box;
@@ -182,6 +177,10 @@ div.sidebar.ui-grid .checkbutton.sidebar,
 
 .sidebar.menubutton.has-colorpicker:hover span {
 	box-shadow: revert;
+}
+
+.sidebar #FrameLineColor-button img {
+	margin-bottom: -4px;
 }
 
 /* writer */

--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -24,7 +24,6 @@ img.sidebar.ui-drawing-area {
 .sidebar .ui-content .unobutton {
 	box-sizing: border-box;
 	margin: 0;
-	padding: 0;
 }
 
 .sidebar .unobutton > img {
@@ -71,6 +70,7 @@ img.sidebar.ui-drawing-area {
 	width: 10px;
 	height: 10px;
 	margin-inline-end: 10px;
+	padding: 0;
 }
 
 .ui-expander.jsdialog.sidebar .ui-expander-icon-right img {
@@ -90,6 +90,9 @@ img.sidebar.ui-drawing-area {
 #ParaPropertyPanel.sidebar.ui-grid #box1.sidebar.ui-grid-cell,
 #NumberFormatPropertyPanel.sidebar.ui-grid #grid1 {
 	justify-content: space-between !important;
+	row-gap: 8px;
+	grid-auto-flow: revert !important;
+	grid-template-columns: repeat(2, auto);
 }
 
 /* section content */
@@ -125,26 +128,10 @@ div.sidebar.ui-grid .checkbutton.sidebar,
 	background-color: var(--color-background-dark);
 }
 
-.menubutton.sidebar span {
-	display: none;
-}
-
-.menubutton.sidebar:hover span {
-	position: absolute;
-	font-size: var(--default-font-size);
-	display: block;
-	width: auto;
-	padding: 14px 4px;
-	border-radius: var(--border-radius);
-	white-space: nowrap;
-	margin-inline-start: -14px;
-	margin-block-start: 2px;
-}
-
 .sidebar.ui-grid.ui-grid-cell .menubutton {
 	justify-content: space-between;
 	justify-self: end;
-	padding: 4px;
+	padding: 0;
 	margin-right: 1px;
 }
 
@@ -178,7 +165,7 @@ div.sidebar.ui-grid .checkbutton.sidebar,
 }
 .sidebar.unotoolbutton {
 	border: 1px solid transparent;
-	margin-right: 5px;
+	margin-right: 3px;
 }
 .sidebar.jsdialog.checkbutton {
 	font-size: var(--default-font-size);
@@ -191,6 +178,10 @@ div.sidebar.ui-grid .checkbutton.sidebar,
 	line-height: 1;
 	flex-direction: column;
 	justify-content: center;
+}
+
+.sidebar.menubutton.has-colorpicker:hover span {
+	box-shadow: revert;
 }
 
 /* writer */

--- a/browser/css/menubar.css
+++ b/browser/css/menubar.css
@@ -74,7 +74,6 @@
 	position: relative;
 	background: transparent;
 	line-height: 0;
-	height: 24px;
 	align-items: center;
 	justify-content: center;
 }

--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -83,10 +83,18 @@ button.ui-tab.notebookbar {
 	height: 31px;
 }
 
+.notebookbar-shortcuts-bar .unotoolbutton.notebookbar .unobutton {
+	width: var(--btn-size-m);
+	height: var(--btn-size-m);
+	padding: var(--btn-padding);
+	justify-content: center;
+	align-items: center;
+}
+
 .notebookbar-shortcuts-bar .unotoolbutton.notebookbar .unobutton img {
-	width: 16px !important;
-	height: 16px !important;
-	margin: 0 !important;
+	width: 16px;
+	height: 16px;
+	margin: 0;
 }
 
 .unoSave.savemodified .unobutton img,
@@ -94,7 +102,6 @@ button.ui-tab.notebookbar {
 #save.saving img,
 #save.saved img {
 	box-sizing: border-box;
-	padding-left: 24px;
 }
 
 html:not([data-theme='dark']) .unoSave.savemodified .unobutton img,
@@ -202,9 +209,9 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 
 .unotoolbutton.notebookbar .unobutton {
 	box-sizing: border-box;
-	padding: 3px;
-	min-width: var(--btn-size);
-	min-height: var(--btn-size);
+	padding: var(--btn-padding);
+	width: var(--btn-size);
+	height: var(--btn-size);
 	background-color: transparent;
 	margin: 0;
 	vertical-align: middle;
@@ -215,6 +222,8 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 	display: flex;
 	flex-direction: column;
 	position: relative;
+	justify-content: center;
+	align-items: center;
 }
 
 .unotoolbutton.notebookbar .unobutton::after {
@@ -236,8 +245,8 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 }
 
 .ui-tabs-content .unobutton > img {
-	width: var(--btn-size);
-	height: var(--btn-size);
+	min-height: 0;
+	min-width: 0;
 }
 
 .has-dropdown--color.notebookbar {
@@ -362,10 +371,6 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 	line-height: 22px;
 }
 
-.has-colorpicker.menubutton img {
-	width: var(--btn-size-m) !important;
-	height: var(--btn-size-m) !important;
-}
 /* Styles preview */
 
 #stylesview {

--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -180,6 +180,8 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 	grid-auto-flow: column;
 	grid-gap: 4px;
 	align-items: center;
+	justify-items: center;
+	width: max-content;
 }
 
 /* unobuttons */
@@ -200,9 +202,9 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 
 .unotoolbutton.notebookbar .unobutton {
 	box-sizing: border-box;
-	padding: 0;
-	width: var(--btn-size);
-	height: var(--btn-size);
+	padding: 3px;
+	min-width: var(--btn-size);
+	min-height: var(--btn-size);
 	background-color: transparent;
 	margin: 0;
 	vertical-align: middle;
@@ -210,7 +212,23 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 	line-height: 0em;
 	color: var(--color-main-text);
 	font-size: var(--default-font-size);
-	border-radius: var(--border-radius);
+	display: flex;
+	flex-direction: column;
+	position: relative;
+}
+
+.unotoolbutton.notebookbar .unobutton::after {
+	--click-increment: -1px;
+	position: absolute;
+	content: '';
+	top: var(--click-increment);
+	right: var(--click-increment);
+	bottom: var(--click-increment);
+	left: var(--click-increment);
+}
+
+.unotoolbutton.notebookbar.inline:hover {
+	background-color: var(--color-background-darker);
 }
 
 .jsdialog .ui-tabs-content {
@@ -289,7 +307,6 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 }
 
 .unotoolbutton.notebookbar {
-	margin-inline-end: 5px !important;
 	text-align: center;
 }
 
@@ -348,7 +365,6 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 .has-colorpicker.menubutton img {
 	width: var(--btn-size-m) !important;
 	height: var(--btn-size-m) !important;
-	padding-bottom: calc(var(--btn-size) - var(--btn-size-m));
 }
 /* Styles preview */
 

--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -73,6 +73,7 @@
 #toolbar-down {
 	z-index: 11;
 	border-top: 1px solid var(--color-toolbar-border);
+	min-height: 32px;
 }
 #toolbar-down > .ui-scroll-wrapper > .vertical {
 	/* To do: test if all .ui-scroll-wrapper.vertical

--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -46,7 +46,7 @@
 .ui-toolbar > div > div > .ui-pushbutton,
 .ui-toolbar > div > div .ui-badge {
 	margin: auto 2px;
-	padding: 3px;
+	padding: 0;
 	white-space: nowrap;
 	height: inherit;
 }

--- a/browser/src/control/jsdialog/Widget.ColorPickerButton.js
+++ b/browser/src/control/jsdialog/Widget.ColorPickerButton.js
@@ -188,7 +188,7 @@ JSDialog.colorPickerButton = function (parentContainer, data, builder) {
 			var valueNode = L.DomUtil.create(
 				'span',
 				'selected-color',
-				menubutton.container,
+				menubutton.button,
 			);
 			valueNode.addEventListener('click', applyFunction);
 

--- a/browser/src/control/jsdialog/Widget.ColorPickerButton.js
+++ b/browser/src/control/jsdialog/Widget.ColorPickerButton.js
@@ -186,7 +186,7 @@ JSDialog.colorPickerButton = function (parentContainer, data, builder) {
 			);
 
 			var valueNode = L.DomUtil.create(
-				'div',
+				'span',
 				'selected-color',
 				menubutton.container,
 			);

--- a/cypress_test/integration_tests/desktop/impress/delete_objects_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/delete_objects_spec.js
@@ -38,6 +38,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Delete Objects', function(
 
 	it('Delete Chart' , function() {
 		cy.cGet('#toolbar-up > .ui-scroll-right').click();
+		cy.cGet('#toolbar-up > .ui-scroll-right').click();
 		//insert
 		cy.cGet('#insertobjectchart').click();
 		cy.cGet('#test-div-shapeHandlesSection').should('exist');


### PR DESCRIPTION
Change-Id: I4f0474e02411ada5547c8c2f23dda22cb4433557


* Resolves: #8566
* Target version: master 

### Summary
This is my proposal for UI splitting the buttons in 2 parts.
I hope I didn't take too much liberty with the design ^^

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

