### PR TITLE
slideshow: don't cache fields for now

### DIFF
--- a/browser/src/slideshow/LayerDrawing.ts
+++ b/browser/src/slideshow/LayerDrawing.ts
@@ -62,11 +62,13 @@ interface LayerInfo {
 	index?: number;
 	type?: 'bitmap' | 'placeholder' | 'animated';
 	content: LayerContentType;
+	isField?: boolean;
 }
 
 interface LayerEntry {
 	type: 'bitmap' | 'placeholder' | 'animated';
 	content: LayerContentType;
+	isField?: boolean;
 }
 
 class LayerDrawing {
@@ -362,6 +364,7 @@ class LayerDrawing {
 		const layerEntry: LayerEntry = {
 			type: info.type,
 			content: info.content,
+			isField: info.isField,
 		};
 		if (info.type === 'bitmap') {
 			if (!this.checkAndAttachImageData(layerEntry.content as ImageInfo, img))
@@ -456,6 +459,7 @@ class LayerDrawing {
 		}
 
 		for (const layer of layers) {
+			if (layer.isField) return false;
 			this.drawMasterPageLayer(layer, slideHash);
 		}
 		return true;


### PR DESCRIPTION
Fields are "template" elements like page number which are different on different pages. If we will cache one of them then we tried to reuse it on all other pages as we thought we already have correct data.

This patch disables caching for master pages with fields. This is temporary solution until we implement correct text fields handling on the core side. This change requires minimal "isField" JSON property add in the core to work.

requires: https://gerrit.libreoffice.org/c/core/+/173160