### PR TITLE
Test Improvements

### DIFF
--- a/common/Unit.cpp
+++ b/common/Unit.cpp
@@ -487,9 +487,23 @@ bool UnitBase::filterSendWebSocketMessage(const char* data, const std::size_t le
             LOG_TST("Expected json unocommandresult. Ignoring: " << message);
         }
     }
-    else if (message.starts_with("status:"))
+    else if (message.starts_with("loaded:"))
     {
-        if (onDocumentLoaded(message))
+        if (message.find("isfirst=true") != std::string::npos)
+        {
+            // The Document loaded.
+            if (onDocumentLoaded(message))
+                return false;
+        }
+
+        // A view loaded.
+        if (onViewLoaded(message))
+            return false;
+    }
+    else if (message.starts_with("unloaded:"))
+    {
+        // A view unloaded.
+        if (onViewUnloaded(message))
             return false;
     }
     else if (message == "statechanged: .uno:ModifiedStatus=true")

--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -210,9 +210,19 @@ public:
     }
 
     /// Called when the document has been loaded,
-    /// based on the "status:" message, in the context of filterSendWebSocketMessage.
+    /// based on the "loaded:" message, in the context of filterSendWebSocketMessage.
     /// Return true to stop further handling of messages.
     virtual bool onDocumentLoaded(const std::string&) { return false; }
+
+    /// Called when a view has been loaded,
+    /// based on the "loaded:" message, in the context of filterSendWebSocketMessage.
+    /// Return true to stop further handling of messages.
+    virtual bool onViewLoaded(const std::string&) { return false; }
+
+    /// Called when a view has been unloaded,
+    /// based on the "unloaded:" message, in the context of filterSendWebSocketMessage.
+    /// Return true to stop further handling of messages.
+    virtual bool onViewUnloaded(const std::string&) { return false; }
 
     /// Called when the document's 'modified' status
     /// changes to true.

--- a/kit/Kit.hpp
+++ b/kit/Kit.hpp
@@ -350,6 +350,9 @@ public:
 
     void dumpState(std::ostream& oss);
 
+    /// Returns true iff we have a LOKit Document instance.
+    bool isLoaded() const { return !!_loKitDocument; }
+
     /// Return access to the lok::Office instance.
     std::shared_ptr<lok::Office> getLOKit() { return _loKit; }
 

--- a/test/UnitWOPILanguages.cpp
+++ b/test/UnitWOPILanguages.cpp
@@ -37,8 +37,8 @@ public:
         return nullptr;
     }
 
-    /// The document is loaded.
-    bool onDocumentLoaded(const std::string& message) override
+    /// A view loaded.
+    bool onViewLoaded(const std::string& message) override
     {
         LOG_TST("onDocumentLoaded #" << ++_loaded_count << ": [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::Save);
@@ -129,8 +129,8 @@ public:
     {
     }
 
-    /// The document is loaded.
-    bool onDocumentLoaded(const std::string& message) override
+    /// A view is loaded.
+    bool onViewLoaded(const std::string& message) override
     {
         LOG_TST("onDocumentLoaded #" << ++_loaded_count << ": [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::Load2);
@@ -256,8 +256,8 @@ public:
     {
     }
 
-    /// The document is loaded.
-    bool onDocumentLoaded(const std::string& message) override
+    /// A view is loaded.
+    bool onViewLoaded(const std::string& message) override
     {
         LOG_TST("onDocumentLoaded #" << ++_loaded_count << ": [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::Load2);

--- a/test/httpwstest.cpp
+++ b/test/httpwstest.cpp
@@ -283,6 +283,8 @@ void HTTPWSTest::testInactiveClient()
                                             token == "colorpalettes:" ||
                                             token == "jsdialog:" ||
                                             token == "serveraudit:" ||
+                                            token == "loaded:" ||
+                                            token == "unloaded:" ||
                                             token == "adminuser:");
 
                     // End when we get state changed.

--- a/wsd/protocol.txt
+++ b/wsd/protocol.txt
@@ -471,6 +471,17 @@ invalidatetiles: EMPTY, <partNumber>, <mode>, wid=<wid>
 
     Tells the client to invalidate all cached tiles.
 
+loaded: viewid=<viewId> views=<number of active views> isfirst=<true|false>
+
+    Sent after a view has been loaded successfully.
+    Best to rely on this to detect loading events (rather than status:).
+
+    <viewId> the unique ID of this view (meaningful only in LOKit).
+    <views> the total number of active views in the document after finishing loading this one.
+    <isfirst> "true" if this is the first view (i.e. the document has just loaded), otherwise "false".
+
+    See also unloaded:.
+
 pong rendercount=<num>
 
     sent in reply to a 'ping' message, where <num> is the total number
@@ -490,7 +501,7 @@ status: type=<typeName> parts=<numberOfParts> current=<currentPartNumber> width=
 statusupdate: type=<typeName> parts=<numberOfParts> current=<currentPartNumber> width=<width> height=<height> viewid=<viewId> hiddenparts=<part1,part2,...> selectedparts=<part1,part2,...> [partNames]
 
     Same as status: but issued whenever the document parts have updated significantly.
-    status: implies document loading. statusupdate: is just an update.
+    status: implies document loading (deprecated, use loaded: instead). statusupdate: is just an update.
 
 styles: {"styleFamily": ["styles in family"], etc. }
 
@@ -689,6 +700,17 @@ contentcontrol: <JSON>
         - items - array of items for dropdown
 
 canonicalidchange: viewid=<id> canonicalid=<id> viewrenderedstate=<Light|Dark|Empty>
+
+unloaded: viewid=<viewId> views=<number of active views>
+
+    Sent after a view has been unloaded successfully.
+    Best to rely on this to detect unloading events.
+
+    <viewId> the unique ID of this view (meaningful only in LOKit).
+    <views> the total number of active views in the document after finishing loading this one.
+
+    See also loaded:.
+
 
 child -> parent
 ===============


### PR DESCRIPTION
Adds `loaded:` and `unloaded:` commands to signal the loading/unloading of views (and documents). This avoid the overloading of `status:`, which is issued for a number of other LOK events, and indeed can be issued on demand (via a command), as well.

This fixes a test-case failure due to document size change, which issued `status:` and that triggered the `onDocumentLoaded` callback on the test, which was unexpected and failed the test. This has happened at least 2 times in the past ~week or so.

- wsd: new loaded: and unloaded: commands
- wsd: test: use loaded: to trigger load events
