### PR TITLE
indirection: get timezone from coolwsd.xml

### DIFF
--- a/common/Util.cpp
+++ b/common/Util.cpp
@@ -388,7 +388,7 @@ namespace Util
         return id;
     }
 
-    std::string getVersionJSON(bool enableExperimental, bool geolocationSetup)
+    std::string getVersionJSON(bool enableExperimental, const std::string& timezone)
     {
         std::string version, hash;
         Util::getVersionInfo(version, hash);
@@ -415,13 +415,10 @@ namespace Util
                            "\"Id\":          \"" +
                            Util::getProcessIdentifier() + "\", ";
 
-        if (geolocationSetup)
-            json += "\"TimeZone\":     \"" + getIANATimezone() +
-                    "\", "
-                    "\"Options\":     \"" +
-                    std::string(enableExperimental ? " (E)" : "") + "\" }";
-        else
-            json += "\"Options\":     \"" + std::string(enableExperimental ? " (E)" : "") + "\" }";
+        if (!timezone.empty())
+            json += "\"TimeZone\":     \"" + timezone + "\", ";
+
+        json += "\"Options\":     \"" + std::string(enableExperimental ? " (E)" : "") + "\" }";
         return json;
     }
 
@@ -961,26 +958,6 @@ namespace Util
                 std::this_thread::sleep_for(std::chrono::seconds(delaySecs));
             }
         }
-    }
-
-    std::string getIANATimezone()
-    {
-        const char* tzfile = "/etc/localtime";
-        char buf[PATH_MAX];
-
-        ssize_t len = readlink(tzfile, buf, sizeof(buf) - 1);
-        if (len != -1)
-        {
-            buf[len] = '\0';
-            std::string fullPath(buf);
-
-            std::string prefix = "../usr/share/zoneinfo/";
-            if (fullPath.substr(0, prefix.size()) == prefix)
-            {
-                return fullPath.substr(prefix.size());
-            }
-        }
-        return std::string();
     }
 
     std::string Backtrace::Symbol::toString() const

--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -332,7 +332,7 @@ namespace Util
     ///< A random hex string that identifies the current process.
     const std::string& getProcessIdentifier();
 
-    std::string getVersionJSON(bool enableExperimental, bool geolocationSetup);
+    std::string getVersionJSON(bool enableExperimental, const std::string& timezone);
 
     /// Return a string that is unique across processes and calls.
     std::string UniqueId();
@@ -1546,9 +1546,6 @@ int main(int argc, char**argv)
         joinPair(oss, container, delimiter);
         return oss.str();
     }
-
-    /// Get IANA timezone name
-    std::string getIANATimezone();
 
     /// Asserts in the debug builds, otherwise just logs.
     void assertCorrectThread(std::thread::id owner, const char* fileName, int lineNo);

--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -324,8 +324,9 @@
       <migration_timeout_secs desc="The maximum number of seconds waiting for shutdown migration message from indirection server before unloading an document. Defaults to 180 second." type="uint" default="180"></migration_timeout_secs>
       <geolocation_setup>
         <enable desc="Enable geolocation_setup when using indirection server with geolocation configuration" type="bool" default="false">false</enable>
+        <timezone desc="IANA timezone of server. For example: Europe/Berlin "></timezone>
       </geolocation_setup>
-      <server_name desc="server name to show in cluster overview admin panel"></server_name>
+      <server_name desc="server name to show in cluster overview admin panel" type="string" default=""></server_name>
     </indirection_endpoint>
 
     @LOCK_CONFIGURATION@

--- a/wsd/Admin.cpp
+++ b/wsd/Admin.cpp
@@ -13,6 +13,7 @@
 
 #include <chrono>
 #include <iomanip>
+#include <string>
 #include <sys/poll.h>
 #include <unistd.h>
 
@@ -22,6 +23,7 @@
 #include "Admin.hpp"
 #include "AdminModel.hpp"
 #include "Auth.hpp"
+#include "ConfigUtil.hpp"
 #include <Common.hpp>
 #include <Log.hpp>
 #include <Protocol.hpp>
@@ -131,9 +133,11 @@ void AdminSocketHandler::handleMessage(const std::vector<char> &payload)
     else if (tokens.equals(0, "version"))
     {
         // Send COOL version information
-        sendTextFrame("coolserver " +
-                      Util::getVersionJSON(EnableExperimental, COOLWSD::IndirectionServerEnabled &&
-                                                                   COOLWSD::GeolocationSetup));
+        std::string timezoneName;
+        if (COOLWSD::IndirectionServerEnabled && COOLWSD::GeolocationSetup)
+            timezoneName = config::getString("indirection_endpoint.geolocation_setup.timezone", "");
+
+        sendTextFrame("coolserver " + Util::getVersionJSON(EnableExperimental, timezoneName));
 
         // Send LOKit version information
         sendTextFrame("lokitversion " + COOLWSD::LOKitVersion);

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -2196,6 +2196,7 @@ void COOLWSD::innerInitialize(Application& self)
         { "deepl.enabled", "false" },
         { "zotero.enable", "true" },
         { "indirection_endpoint.geolocation_setup.enable", "false" },
+        { "indirection_endpoint.geolocation_setup.timezone", "" },
         { "indirection_endpoint.server_name", "" },
         { "indirection_endpoint.url", "" },
 #if !MOBILEAPP

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -2088,7 +2088,8 @@ static std::string getCapabilitiesJson(bool convertToAvailable)
 
     if (COOLWSD::IndirectionServerEnabled && COOLWSD::GeolocationSetup)
     {
-        std::string timezoneName = Util::getIANATimezone();
+        std::string timezoneName =
+            config::getString("indirection_endpoint.geolocation_setup.timezone", "");
         if (!timezoneName.empty())
             capabilities->set("timezone", std::string(timezoneName));
     }

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -25,6 +25,7 @@
 #include <Poco/StreamCopier.h>
 #include <Poco/URI.h>
 
+#include "ConfigUtil.hpp"
 #include "DocumentBroker.hpp"
 #include "COOLWSD.hpp"
 #include "FileServer.hpp"
@@ -635,10 +636,12 @@ bool ClientSession::_handleInput(const char *buffer, int length)
             }
         }
 
+        std::string timezoneName;
+        if (COOLWSD::IndirectionServerEnabled && COOLWSD::GeolocationSetup)
+            timezoneName = config::getString("indirection_endpoint.geolocation_setup.timezone", "");
+
         // Send COOL version information
-        sendTextFrame("coolserver " +
-                      Util::getVersionJSON(EnableExperimental, COOLWSD::IndirectionServerEnabled &&
-                                                                   COOLWSD::GeolocationSetup));
+        sendTextFrame("coolserver " + Util::getVersionJSON(EnableExperimental, timezoneName));
         // Send LOKit version information
         sendTextFrame("lokitversion " + COOLWSD::LOKitVersion);
 


### PR DESCRIPTION
- before this patch we were trying to get timezone from the os timezone file. But that is not consistent because most of the VMs would have timezone set to UTC

Change-Id: Id241ad6f57eeb3c084733f174ba5d1c4a547ced6

* Resolves: # <!-- related github issue -->
* Target version: master 
