### PR TITLE
introduce autofill preview tooltip

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -407,6 +407,7 @@ COOL_JS_LST =\
 	src/control/Control.Mention.ts \
 	src/control/Control.FormulaUsagePopup.ts \
 	src/control/Control.FormulaAutoCompletePopup.ts \
+	src/control/Control.AutoFillPreviewTooltip.ts \
 	src/control/Control.Zotero.js \
 	src/control/Search.js \
 	src/control/Permission.js \

--- a/browser/css/jquery-ui-lightness.css
+++ b/browser/css/jquery-ui-lightness.css
@@ -522,7 +522,7 @@ button.ui-button::-moz-focus-inner {
 .ui-dialog .ui-dialog-content {
 	position: relative;
 	border: 0;
-	padding: 0em 0.2em;
+	padding: .5em 1em;
 	background: none;
 	overflow: auto;
 }

--- a/browser/css/jquery-ui-lightness.css
+++ b/browser/css/jquery-ui-lightness.css
@@ -522,7 +522,7 @@ button.ui-button::-moz-focus-inner {
 .ui-dialog .ui-dialog-content {
 	position: relative;
 	border: 0;
-	padding: .5em 1em;
+	padding: 0em 0.2em;
 	background: none;
 	overflow: auto;
 }

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -56,6 +56,11 @@
 	margin: 0 !important;
 }
 
+div#autoFillPreviewTooltip {
+	min-width: fit-content;
+	max-width: fit-content;
+}
+
 .jsdialog-window.modalpopup:not(.snackbar),
 .hyperlink-pop-up-container {
 	min-width: 198px;

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -61,6 +61,10 @@ div#autoFillPreviewTooltip {
 	max-width: fit-content;
 }
 
+div#autoFillPreviewTooltip .lokdialog.ui-dialog-content.ui-widget-content {
+	padding: 0em 0.2em;
+}
+
 .jsdialog-window.modalpopup:not(.snackbar),
 .hyperlink-pop-up-container {
 	min-width: 198px;

--- a/browser/src/control/AutoCompletePopup.ts
+++ b/browser/src/control/AutoCompletePopup.ts
@@ -9,7 +9,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 /*
- * AutoCompletePopup - base class for mention, auto complete and auto fill popup
+ * AutoCompletePopup - base class for mention, formula auto complete, auto fill popup and auto fill preview popup
  */
 
 /* global app */

--- a/browser/src/control/Control.AutoFillPreviewTooltip.ts
+++ b/browser/src/control/Control.AutoFillPreviewTooltip.ts
@@ -74,7 +74,6 @@ class AutoFillPreviewTooltip extends L.Control.AutoCompletePopup {
 	}
 
 	openAutoFillPopup(ev: FireEvent): void {
-		const framePos = this.getAutoFillAreaBottomRightLocation(ev); // bottom-right position
 		const entry = ev.data.text;
 		let data: PopupData;
 
@@ -83,20 +82,23 @@ class AutoFillPreviewTooltip extends L.Control.AutoCompletePopup {
 
 			const control = this.getSimpleTextJSON(entry);
 			if (L.DomUtil.get(this.popupId + 'fixedtext')) {
-				data = this.getPopupJSON(control, framePos);
+				data = this.getPopupJSON(control, {
+					x: ev.data.location.cX,
+					y: ev.data.location.cY,
+				});
 				this.sendUpdate(data);
 				return;
 			}
 
 			if (L.DomUtil.get(this.popupId))
 				this.closeMentionPopup({ typingMention: true } as CloseMessageEvent);
-			data = this.newPopupData;
+			data = Object.assign({}, this.newPopupData);
 			data.children[0].children[0] = control;
 		}
 
 		// add position
-		data.posx = framePos.x;
-		data.posy = framePos.y;
+		data.posx = ev.data.location.cX;
+		data.posy = ev.data.location.cY;
 		this.sendJSON(data);
 	}
 }

--- a/browser/src/control/Control.AutoFillPreviewTooltip.ts
+++ b/browser/src/control/Control.AutoFillPreviewTooltip.ts
@@ -1,0 +1,105 @@
+/* -*- js-indent-level: 8 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+/*
+ * Control.AutoFillPreviewTooltip - class for tooltip of cell previews during auto fill
+ */
+
+/* global app */
+
+class AutoFillPreviewTooltip extends L.Control.AutoCompletePopup {
+	usageText: string;
+	newPopupData: PopupData;
+
+	constructor(map: ReturnType<typeof L.map>) {
+		super('autoFillPreviewTooltip', map);
+		this.newPopupData = {
+			children: [
+				{
+					id: 'container',
+					type: 'container',
+					enabled: false,
+					children: new Array<WidgetJSON>(),
+					vertical: false,
+				} as any as WidgetJSON,
+			] as Array<WidgetJSON>,
+			jsontype: 'dialog',
+			type: 'modalpopup',
+			cancellable: false,
+			popupParent: '_POPOVER_',
+			clickToClose: '_POPOVER_',
+			id: 'autoFillPreviewTooltip',
+			canHaveFocus: false,
+			noOverlay: true,
+			title: '',
+		} as PopupData;
+	}
+
+	onAdd() {
+		this.newPopupData.isAutoCompletePopup = true;
+		this.map.on('openautofillpopup', this.openAutoFillPopup, this);
+		this.map.on('sendautofilllocation', this.sendAutoFillLocation, this);
+	}
+
+	getAutoFillAreaBottomRightLocation(ev: FireEvent): Point {
+		var currPos = {
+			x: app.calc.cellCursorRectangle.pX2 + ev.data.location.x,
+			y: app.calc.cellCursorRectangle.pY2 + ev.data.location.y,
+		};
+
+		// console.error("--core   : " + JSON.stringify(ev.data.location));
+		// console.error("--currPos: " + JSON.stringify(currPos));
+
+		return new L.Point(currPos.x, currPos.y);
+	}
+
+	sendAutoFillLocation(ev: FireEvent) {
+		this.openAutoFillPopup({ data: ev.data });
+	}
+
+	getSimpleTextJSON(cellValue: string): TextWidget {
+		return {
+			id: this.popupId + 'fixedtext',
+			type: 'fixedtext',
+			text: cellValue,
+			enabled: false,
+		} as TextWidget;
+	}
+
+	openAutoFillPopup(ev: FireEvent): void {
+		const framePos = this.getAutoFillAreaBottomRightLocation(ev); // bottom-right position
+		const entry = ev.data.text;
+		let data: PopupData;
+
+		if (entry.length > 0) {
+			this.closeMentionPopup({ typingMention: true } as CloseMessageEvent);
+
+			const control = this.getSimpleTextJSON(entry);
+			if (L.DomUtil.get(this.popupId + 'fixedtext')) {
+				data = this.getPopupJSON(control, framePos);
+				this.sendUpdate(data);
+				return;
+			}
+
+			if (L.DomUtil.get(this.popupId))
+				this.closeMentionPopup({ typingMention: true } as CloseMessageEvent);
+			data = this.newPopupData;
+			data.children[0].children[0] = control;
+		}
+
+		// add position
+		data.posx = framePos.x;
+		data.posy = framePos.y;
+		this.sendJSON(data);
+	}
+}
+L.control.autofillpreviewtooltip = function (map: any) {
+	return new AutoFillPreviewTooltip(map);
+};

--- a/browser/src/control/Control.AutoFillPreviewTooltip.ts
+++ b/browser/src/control/Control.AutoFillPreviewTooltip.ts
@@ -20,31 +20,14 @@ class AutoFillPreviewTooltip extends L.Control.AutoCompletePopup {
 
 	constructor(map: ReturnType<typeof L.map>) {
 		super('autoFillPreviewTooltip', map);
-		this.newPopupData = {
-			children: [
-				{
-					id: 'container',
-					type: 'container',
-					enabled: false,
-					children: new Array<WidgetJSON>(),
-					vertical: false,
-				} as any as WidgetJSON,
-			] as Array<WidgetJSON>,
-			jsontype: 'dialog',
-			type: 'modalpopup',
-			cancellable: false,
-			popupParent: '_POPOVER_',
-			clickToClose: '_POPOVER_',
-			id: 'autoFillPreviewTooltip',
-			canHaveFocus: false,
-			noOverlay: true,
-			title: '',
-			isAutoFillPreviewTooltip: true,
-		} as PopupData;
 	}
 
 	onAdd() {
-		this.newPopupData.isAutoCompletePopup = true;
+		this.newPopupData.isAutoFillPreviewTooltip = true;
+		this.newPopupData.canHaveFocus = false;
+		this.newPopupData.noOverlay = true;
+		this.newPopupData.id = 'autoFillPreviewTooltip';
+
 		this.map.on(
 			'openautofillpreviewpopup',
 			this.openAutoFillPreviewPopup,
@@ -67,6 +50,25 @@ class AutoFillPreviewTooltip extends L.Control.AutoCompletePopup {
 	}
 
 	openAutoFillPreviewPopup(ev: FireEvent): void {
+		// calculate the popup position
+		var cellRange = this.map._docLayer._parseCellRange(
+			JSON.stringify(ev.data.celladdress),
+		);
+		ev.data.celladdress = this.map._docLayer
+			._cellRangeToTwipRect(cellRange)
+			.toRectangle();
+
+		ev.data.celladdress = new app.definitions.simplePoint(
+			parseInt(ev.data.celladdress[0]),
+			parseInt(ev.data.celladdress[1]),
+		);
+		ev.data.celladdress.pX -=
+			app.sectionContainer.getDocumentTopLeft()[0] -
+			app.sectionContainer.getDocumentAnchor()[0];
+		ev.data.celladdress.pY -=
+			app.sectionContainer.getDocumentTopLeft()[1] -
+			app.sectionContainer.getDocumentAnchor()[1];
+
 		const entry = ev.data.text;
 		let data: PopupData;
 

--- a/browser/src/control/Control.ContextMenu.js
+++ b/browser/src/control/Control.ContextMenu.js
@@ -165,6 +165,8 @@ L.Control.ContextMenu = L.Control.extend({
 				spellingContextMenu = true;
 				break;
 			} else if (menuItem.indexOf('.uno:AutoFill') !== -1) {
+				// we should close the autofill preview popup before open autofill context menu
+				map.fire('closeautofillpreviewpopup');
 				autoFillContextMenu = true;
 				break;
 			}

--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -211,6 +211,10 @@ L.Control.JSDialog = L.Control.extend({
 		// Dialogue overlay which will allow automatic positioning and cancellation of the dialogue if cancellable.
 		var overlay = L.DomUtil.get(instance.id + '-overlay');
 		if (!overlay) {
+
+			if (instance.noOverlay)
+				return;
+
 			overlay = L.DomUtil.create('div', 'jsdialog-overlay ' + (instance.cancellable && !instance.hasOverlay ? 'cancellable' : ''), instance.containerParent);
 			overlay.id = instance.id + '-overlay';
 			if (instance.cancellable) {

--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -733,10 +733,9 @@ L.Control.JSDialog = L.Control.extend({
 			} else {
 				instance.updatePos();
 			}
-
-			if (instance.isAutofilter && instance.id !== 'autoFillPreviewTooltip')
+			if (instance.isAutofilter && !instance.isAutoFillPreviewTooltip)
 				this.calculateAutoFilterPosition(instance);
-			else if (instance.id === 'autoFillPreviewTooltip')
+			else if (instance.isAutoFillPreviewTooltip)
 				this.updatePosition(instance.container, instance.posx, instance.posy);
 
 			this.dialogs[instance.id] = instance;

--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -734,8 +734,10 @@ L.Control.JSDialog = L.Control.extend({
 				instance.updatePos();
 			}
 
-			if (instance.isAutofilter)
+			if (instance.isAutofilter && instance.id !== 'autoFillPreviewTooltip')
 				this.calculateAutoFilterPosition(instance);
+			else if (instance.id === 'autoFillPreviewTooltip')
+				this.updatePosition(instance.container, instance.posx, instance.posy);
 
 			this.dialogs[instance.id] = instance;
 

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -255,6 +255,7 @@ L.Control.UIManager = L.Control.extend({
 			this.map.mention = L.control.mention(this.map);
 			this.map.formulaautocomplete = L.control.formulaautocomplete(this.map);
 			this.map.formulausage = L.control.formulausage(this.map);
+			this.map.autofillpreviewtooltip = L.control.autofillpreviewtooltip(this.map);
 		}
 
 		this.map.jsdialog = L.control.jsDialog();

--- a/browser/src/control/jsdialog/Definitions.Types.ts
+++ b/browser/src/control/jsdialog/Definitions.Types.ts
@@ -48,6 +48,8 @@ interface JSDialogJSON extends DialogJSON {
 interface PopupData extends JSDialogJSON {
 	isAutoCompletePopup?: boolean;
 	cancellable?: boolean;
+	canHaveFocus: boolean;
+	noOverlay: boolean;
 	popupParent?: string;
 	clickToClose?: string;
 	posx: number;

--- a/browser/src/control/jsdialog/Definitions.Types.ts
+++ b/browser/src/control/jsdialog/Definitions.Types.ts
@@ -47,6 +47,7 @@ interface JSDialogJSON extends DialogJSON {
 // JSDialog message for popup
 interface PopupData extends JSDialogJSON {
 	isAutoCompletePopup?: boolean;
+	isAutoFillPreviewTooltip?: boolean;
 	cancellable?: boolean;
 	canHaveFocus: boolean;
 	noOverlay: boolean;

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1482,6 +1482,32 @@ L.CanvasTileLayer = L.Layer.extend({
 				var tooltipInfo = JSON.parse(textMsg.substring(textMsg.indexOf('{')));
 				this._map.uiManager.showDocumentTooltip(tooltipInfo);
 			}
+			else if (tooltipInfo.type === 'autofillpreviewtooltip') {
+
+				var strTwips = textMsg.match(/\d+/g);
+				if (strTwips != null && this._map.isEditMode()) {
+					var topLeftTwips = new L.Point(parseInt(strTwips[0]), parseInt(strTwips[1]));
+					// var offset = new L.Point(parseInt(strTwips[2]), parseInt(strTwips[3]));
+
+					var topLeftPixels = this._twipsToCorePixels(topLeftTwips);
+					// var offsetPixels = this._twipsToCorePixels(offset);
+					// var bottomRightTwips = topLeftTwips.add(offsetPixels);
+					// this._cellAutoFillAreaPixels = L.LOUtil.createRectangle(bottomRightTwips.x, bottomRightTwips.y, offsetPixels.x, offsetPixels.y);
+
+					// textMsg = textMsg.substring('cellautofilltooltipinfo: '.length);
+					// var strTwips = textMsg.match(/\d+/g);
+					// var tooltipInfo = JSON.parse(textMsg);
+
+					// tooltipInfo.location = this._map._docLayer._twipsToPixels(topLeftTwips);
+
+					tooltipInfo.location = this._map._docLayer._twipsToPixels(topLeftPixels);;
+
+					// tooltipInfo.location = this._map._docLayer._twipsToLatLng(buttonAreaTwips[1], this._map.getZoom());
+					// tooltipInfo.location = this._cellAutoFillAreaPixels;
+					this._map.fire('sendautofilllocation', { data: tooltipInfo });
+
+				}
+			}
 			else {
 				console.error('unknown tooltip type');
 			}

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1486,13 +1486,15 @@ L.CanvasTileLayer = L.Layer.extend({
 
 				var strTwips = textMsg.match(/\d+/g);
 				if (strTwips != null && this._map.isEditMode()) {
-					tooltipInfo.location = new app.definitions.simplePoint(parseInt(strTwips[1]), parseInt(strTwips[2]));
 
-					tooltipInfo.location.pX -= app.sectionContainer.getDocumentTopLeft()[0] - app.sectionContainer.getDocumentAnchor()[0];
-					tooltipInfo.location.pY -= app.sectionContainer.getDocumentTopLeft()[1] - app.sectionContainer.getDocumentAnchor()[1];
+					var cellRange = this._map._docLayer._parseCellRange(JSON.stringify(tooltipInfo.celladdress));
+					tooltipInfo.celladdress = this._map._docLayer._cellRangeToTwipRect(cellRange).toRectangle();
 
-					this._map.fire('sendautofilllocation', { data: tooltipInfo });
+					tooltipInfo.celladdress = new app.definitions.simplePoint(parseInt(tooltipInfo.celladdress[0]), parseInt(tooltipInfo.celladdress[1]));
+					tooltipInfo.celladdress.pX -= app.sectionContainer.getDocumentTopLeft()[0] - app.sectionContainer.getDocumentAnchor()[0];
+					tooltipInfo.celladdress.pY -= app.sectionContainer.getDocumentTopLeft()[1] - app.sectionContainer.getDocumentAnchor()[1];
 
+					this._map.fire('openautofillpreviewpopup', { data: tooltipInfo });
 				}
 			}
 			else {

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1485,17 +1485,8 @@ L.CanvasTileLayer = L.Layer.extend({
 			else if (tooltipInfo.type === 'autofillpreviewtooltip') {
 
 				var strTwips = textMsg.match(/\d+/g);
-				if (strTwips != null && this._map.isEditMode()) {
-
-					var cellRange = this._map._docLayer._parseCellRange(JSON.stringify(tooltipInfo.celladdress));
-					tooltipInfo.celladdress = this._map._docLayer._cellRangeToTwipRect(cellRange).toRectangle();
-
-					tooltipInfo.celladdress = new app.definitions.simplePoint(parseInt(tooltipInfo.celladdress[0]), parseInt(tooltipInfo.celladdress[1]));
-					tooltipInfo.celladdress.pX -= app.sectionContainer.getDocumentTopLeft()[0] - app.sectionContainer.getDocumentAnchor()[0];
-					tooltipInfo.celladdress.pY -= app.sectionContainer.getDocumentTopLeft()[1] - app.sectionContainer.getDocumentAnchor()[1];
-
+				if (strTwips != null && this._map.isEditMode())
 					this._map.fire('openautofillpreviewpopup', { data: tooltipInfo });
-				}
 			}
 			else {
 				console.error('unknown tooltip type');

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1486,24 +1486,11 @@ L.CanvasTileLayer = L.Layer.extend({
 
 				var strTwips = textMsg.match(/\d+/g);
 				if (strTwips != null && this._map.isEditMode()) {
-					var topLeftTwips = new L.Point(parseInt(strTwips[0]), parseInt(strTwips[1]));
-					// var offset = new L.Point(parseInt(strTwips[2]), parseInt(strTwips[3]));
+					tooltipInfo.location = new app.definitions.simplePoint(parseInt(strTwips[1]), parseInt(strTwips[2]));
 
-					var topLeftPixels = this._twipsToCorePixels(topLeftTwips);
-					// var offsetPixels = this._twipsToCorePixels(offset);
-					// var bottomRightTwips = topLeftTwips.add(offsetPixels);
-					// this._cellAutoFillAreaPixels = L.LOUtil.createRectangle(bottomRightTwips.x, bottomRightTwips.y, offsetPixels.x, offsetPixels.y);
+					tooltipInfo.location.pX -= app.sectionContainer.getDocumentTopLeft()[0] - app.sectionContainer.getDocumentAnchor()[0];
+					tooltipInfo.location.pY -= app.sectionContainer.getDocumentTopLeft()[1] - app.sectionContainer.getDocumentAnchor()[1];
 
-					// textMsg = textMsg.substring('cellautofilltooltipinfo: '.length);
-					// var strTwips = textMsg.match(/\d+/g);
-					// var tooltipInfo = JSON.parse(textMsg);
-
-					// tooltipInfo.location = this._map._docLayer._twipsToPixels(topLeftTwips);
-
-					tooltipInfo.location = this._map._docLayer._twipsToPixels(topLeftPixels);;
-
-					// tooltipInfo.location = this._map._docLayer._twipsToLatLng(buttonAreaTwips[1], this._map.getZoom());
-					// tooltipInfo.location = this._cellAutoFillAreaPixels;
 					this._map.fire('sendautofilllocation', { data: tooltipInfo });
 
 				}


### PR DESCRIPTION
Change-Id: Ice62a3eb891a1653b5ec6ad5b10efe2fac0e914f


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

- show cell value previews in a popup while using autofill feature.
- this will allow users to see what value will be filled in the current cell in advance.
- add AutoFillPreviewTooltip class
- requires: https://gerrit.libreoffice.org/c/core/+/172589 (merged - 24.04 - master)
- requires: https://gerrit.libreoffice.org/c/core/+/174502 (merged - 24.04)


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

