### PR TITLE
Remove noexcept usage.

### DIFF
--- a/common/Util.cpp
+++ b/common/Util.cpp
@@ -1096,7 +1096,7 @@ namespace Util
         }
         return os;
     }
-    std::string Backtrace::toString() const noexcept
+    std::string Backtrace::toString() const
     {
         std::string s = "Backtrace:\n";
         int fidx = skipFrames;

--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -1280,10 +1280,10 @@ int main(int argc, char**argv)
         std::ostream& send(std::ostream& os) const;
 
         /// Produces a string representation, one line per frame
-        std::string toString() const noexcept;
+        std::string toString() const;
 
-        /* constexpr */ size_t size() const noexcept { return _frames.size(); }
-        /* constexpr */ const Symbol& operator[](size_t idx) const noexcept
+        /* constexpr */ size_t size() const { return _frames.size(); }
+        /* constexpr */ const Symbol& operator[](size_t idx) const
         {
             return _frames[idx].second;
         }


### PR DESCRIPTION
noexcept is banned in coolwsd. It is a premature optimization that brings risk of unexpected termination of a server process. For simple in-line methods, the compiler will deduce this anyway, and for complex methods - it is unlikely that we can maintain this reliably.

Performance should be optimized after profiling.


Change-Id: Ib11e56580131d57d106976db5591f392803f4328


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

