### PR TITLE
Fix build with feature lock

### DIFF
--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -748,7 +748,7 @@ void ClientRequestDispatcher::handleIncomingMessage(SocketDisposition& dispositi
                             unlockImageUri.getScheme() + "://" + unlockImageUri.getAuthority();
                         ProxyRequestHandler::handleRequest(
                             uri.substr(pos + sizeof("/remote/static") - 1), socket, serverUri);
-                        served = true;
+                        servedSync = true;
                     }
                 }
 #endif


### PR DESCRIPTION
When built with additional configure flag: --enable-feature-lock

regression from commit cdbc3af0d764b46458de5ea696b695ade79c662d
cool#10042: Close incoming HTTP Connection if requested (Regression of cool#9621)