### PR TITLE
feat(android): Use native copy/paste

### DIFF
--- a/android/lib/src/main/java/org/libreoffice/androidlib/LOActivity.java
+++ b/android/lib/src/main/java/org/libreoffice/androidlib/LOActivity.java
@@ -959,6 +959,40 @@ public class LOActivity extends AppCompatActivity {
     }
 
     /**
+     * Specialized function for Collabora Online, returns an array of length 2 where the first
+     * element is the clipboard's text content, and the second is the clipboard's HTML content. One
+     * or both of these may be null if the clipboard does not contain it.
+     */
+    @JavascriptInterface
+    public String[] readFromClipboard() {
+        ClipboardManager clipboard = (ClipboardManager) getSystemService(Context.CLIPBOARD_SERVICE);
+
+        ClipData clipboardData = clipboard.getPrimaryClip();
+
+        if (clipboardData == null) return new String[] { null, null };
+
+        ClipData.Item clipboardItem = clipboardData.getItemAt(0);
+
+        return new String[] { clipboardItem.getHtmlText(), clipboardItem.coerceToText(getApplicationContext()).toString() };
+    }
+
+    @JavascriptInterface
+    public void writeToClipboard(String plain, String html) {
+        ClipboardManager clipboard = (ClipboardManager) getSystemService(Context.CLIPBOARD_SERVICE);
+
+        ClipData.Item clipboardItem = new ClipData.Item(plain, html);
+
+        ClipDescription clipboardItemMetadata = new ClipDescription(plain, new String[] {
+                ClipDescription.MIMETYPE_TEXT_HTML,
+                ClipDescription.MIMETYPE_TEXT_HTML,
+        });
+
+        ClipData clipboardData = new ClipData(clipboardItemMetadata, clipboardItem);
+
+        clipboard.setPrimaryClip(clipboardData);
+    }
+
+    /**
      * Passing message the other way around - from Java to the FakeWebSocket in JS.
      */
     void callFakeWebsocketOnMessage(final String message) {

--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -781,34 +781,6 @@ L.Clipboard = L.Class.extend({
 		}, 150 /* ms */);
 	},
 
-	// navigator.clipboard.read() callback
-	_navigatorClipboardReadCallback: function(clipboardContents) {
-		if (clipboardContents.length < 1) {
-			window.app.console.log('navigator.clipboard has no clipboard items');
-			return;
-		}
-
-		var clipboardContent = clipboardContents[0];
-
-		var that = this;
-		if (clipboardContent.types.includes('text/html')) {
-			clipboardContent.getType('text/html').then(function(blob) {
-				that._navigatorClipboardGetTypeCallback(clipboardContent, blob, 'text/html');
-			}, function(error) {
-				window.app.console.log('clipboardContent.getType(text/html) failed: ' + error.message);
-			});
-		} else if (clipboardContent.types.includes('text/plain')) {
-			clipboardContent.getType('text/plain').then(function(blob) {
-				that._navigatorClipboardGetTypeCallback(clipboardContent, blob, 'text/plain');
-			}, function(error) {
-				window.app.console.log('clipboardContent.getType(text/plain) failed: ' + error.message);
-			});
-		} else {
-			window.app.console.log('navigator.clipboard has no text/html or text/plain');
-			return;
-		}
-	},
-
 	// ClipboardContent.getType() callback: used with the Paste button
 	_navigatorClipboardGetTypeCallback: async function(clipboardContent, blob, type) {
 		if (type == 'image/png') {
@@ -884,6 +856,65 @@ L.Clipboard = L.Class.extend({
 		}
 	},
 
+	_asyncAttemptNavigatorClipboardWrite: async function() {
+		const command = this._unoCommandForCopyCutPaste;
+		app.socket.sendMessage('uno ' + command);
+
+		// This is sent down the websocket URL which can race with the
+		// web fetch - so first step is to wait for the result of
+		// that command so we are sure the clipboard is set before
+		// fetching it.
+
+		if (this._commandCompletion.length > 0)
+			window.app.console.error('Already have ' + this._commandCompletion.length +
+						 ' pending clipboard command(s)');
+
+		const url = this.getMetaURL() + '&MimeType=text/html,text/plain;charset=utf-8';
+
+		// Share a single fetch
+		const fetchPromise = (async () => {
+			const response = await fetch(url);
+			return await response.text();
+		})();
+
+		const awaitPromise = (mimetype, shorttype) => {
+			return new Promise((resolve, reject) => {
+				window.app.console.log('New ' + command + ' promise');
+				// FIXME: add a timeout cleanup too ...
+				this._commandCompletion.push({
+					fetch: fetchPromise,
+					command: command,
+					resolve: resolve,
+					reject: reject,
+					mimetype: mimetype,
+					shorttype: shorttype,
+				});
+		}); };
+
+		const text = new ClipboardItem({
+			'text/plain': awaitPromise('text/plain', 'plain'),
+			'text/html': awaitPromise('text/html', 'html'),
+		});
+		let clipboard = navigator.clipboard;
+		if (L.Browser.cypressTest) {
+			clipboard = this._dummyClipboard;
+		}
+
+		try {
+			await clipboard.write([text]);
+		} catch (error) {
+			window.app.console.log('navigator.clipboard.write() failed: ' + error.message);
+
+			// Warn that the copy failed.
+			this._warnCopyPaste();
+			// Once broken, always broken.
+			L.Browser.hasNavigatorClipboardWrite = false;
+			window.prefs.set('hasNavigatorClipboardWrite', false);
+			// Prefetch selection, so next time copy will work with the keyboard.
+			app.socket.sendMessage('gettextselection mimetype=text/html,text/plain;charset=utf-8');
+		}
+	},
+
 	// Executes the navigator.clipboard.write() call, if it's available.
 	_navigatorClipboardWrite: function() {
 		if (!L.Browser.hasNavigatorClipboardWrite) {
@@ -894,61 +925,7 @@ L.Clipboard = L.Class.extend({
 			return false;
 		}
 
-		const command = this._unoCommandForCopyCutPaste;
-		app.socket.sendMessage('uno ' + command);
-
-		// This is sent down the websocket URL which can race with the
-		// web fetch - so first step is to wait for the result of
-		// that command so we are sure the clipboard is set before
-		// fetching it.
-
-		const that = this;
-
-		if (that._commandCompletion.length > 0)
-			window.app.console.error('Already have ' + that._commandCompletion.length +
-						 ' pending clipboard command(s)');
-
-		const url = that.getMetaURL() + '&MimeType=text/html,text/plain;charset=utf-8';
-
-		// Share a single fetch
-		var fetchPromise = new Promise((resolve, reject) => {
-			try {
-				var result = fetch(url).then(response => response.text());
-				resolve(result);
-			} catch (err) {
-				reject(err);
-			}
-		});
-
-		var awaitPromise = function(url, mimetype, shorttype) {
-			return new Promise((resolve, reject) => {
-				window.app.console.log('New ' + command + ' promise');
-				// FIXME: add a timeout cleanup too ...
-				that._commandCompletion.push({ fetch: fetchPromise, command: command,
-							       resolve: resolve, reject: reject,
-							       mimetype: mimetype, shorttype: shorttype});
-		}); };
-
-		const text = new ClipboardItem({
-			'text/html': awaitPromise(url, 'text/html', 'html'),
-			'text/plain': awaitPromise(url, 'text/plain', 'plain')
-		});
-		let clipboard = navigator.clipboard;
-		if (L.Browser.cypressTest) {
-			clipboard = this._dummyClipboard;
-		}
-		clipboard.write([text]).then(function() {
-		}, function(error) {
-			window.app.console.log('navigator.clipboard.write() failed: ' + error.message);
-
-			// Warn that the copy failed.
-			that._warnCopyPaste();
-			// Once broken, always broken.
-			L.Browser.hasNavigatorClipboardWrite = false;
-			window.prefs.set('hasNavigatorClipboardWrite', false);
-			// Prefetch selection, so next time copy will work with the keyboard.
-			app.socket.sendMessage('gettextselection mimetype=text/html,text/plain;charset=utf-8');
-		});
+		this._asyncAttemptNavigatorClipboardWrite();
 
 		return true;
 	},
@@ -976,32 +953,75 @@ L.Clipboard = L.Class.extend({
 		};
 	},
 
+	_asyncAttemptNavigatorClipboardRead: async function(isSpecial) {
+		let clipboard = navigator.clipboard;
+
+		if (L.Browser.cypressTest) {
+			clipboard = this._dummyClipboard;
+		}
+
+		let clipboardContents;
+
+		try {
+			clipboardContents = await clipboard.read();
+		} catch (error) {
+			window.app.console.log(
+				'navigator.clipboard.read() failed: ' + error.message,
+			);
+			if (isSpecial) {
+				// Fallback to the old code, as in filterExecCopyPaste().
+				this._openPasteSpecialPopup();
+			} else {
+				// Fallback to the old code, as in _execCopyCutPaste().
+				this._afterCopyCutPaste('paste');
+			}
+			return;
+		}
+
+		if (isSpecial) {
+			this._navigatorClipboardPasteSpecial = true;
+		}
+
+		if (clipboardContents.length < 1) {
+			window.app.console.log('clipboard has no items');
+			return;
+		}
+
+		var clipboardContent = clipboardContents[0];
+
+		if (clipboardContent.types.includes('text/html')) {
+			let blob;
+			try {
+				blob = await clipboardContent.getType('text/html');
+			} catch (error) {
+				window.app.console.log('clipboardContent.getType(text/html) failed: ' + error.message);
+				return;
+			}
+
+			this._navigatorClipboardGetTypeCallback(clipboardContent, blob, 'text/html');
+		} else if (clipboardContent.types.includes('text/plain')) {
+			let blob;
+			try {
+				blob = await clipboardContent.getType('text/plain');
+			} catch (error) {
+				window.app.console.log('clipboardContent.getType(text/plain) failed: ' + error.message);
+				return;
+			}
+
+			this._navigatorClipboardGetTypeCallback(clipboardContent, blob, 'text/plain');
+		} else {
+			window.app.console.log('navigator.clipboard has no text/html or text/plain');
+		}
+	},
+
 	// Executes the navigator.clipboard.read() call, if it's available.
 	_navigatorClipboardRead: function(isSpecial) {
 		if (!L.Browser.hasNavigatorClipboardRead) {
 			return false;
 		}
 
-		var that = this;
-		var clipboard = navigator.clipboard;
-		if (L.Browser.cypressTest) {
-			clipboard = this._dummyClipboard;
-		}
-		clipboard.read().then(function(clipboardContents) {
-			if (isSpecial) {
-				that._navigatorClipboardPasteSpecial = true;
-			}
-			that._navigatorClipboardReadCallback(clipboardContents);
-		}, function(error) {
-			window.app.console.log('navigator.clipboard.read() failed: ' + error.message);
-			if (isSpecial) {
-				// Fallback to the old code, as in filterExecCopyPaste().
-				that._openPasteSpecialPopup();
-			} else {
-				// Fallback to the old code, as in _execCopyCutPaste().
-				that._afterCopyCutPaste('paste');
-			}
-		});
+		this._asyncAttemptNavigatorClipboardRead(isSpecial)
+
 		return true;
 	},
 


### PR DESCRIPTION
Copy/paste is utterly broken on Android, but Android apps have a really
high level of permission to the clipboard: they are allowed to access
it, without further consent or notification, as long as they are in the
foreground(!!).

This permission does not apply to applications in a webview, they have
the navigator.clipboard object but - it appears - no way to request
permissions for it, leaving them unable to properly use it.

Instead of worrying about that, we can write a native bridge to let us
use the high permissions of the Android app while we are in the webview.
This commit implements that native bridge.

The same issue exists on iOS, but this pull request does not fix it at this time. Another commit (either in this PR or a later one) will be needed to handle it in a similar way to Android