### PR TITLE
Slideshow: Fix mirrored pause text issue with video slides

### DIFF
--- a/browser/src/slideshow/SlideRenderer.ts
+++ b/browser/src/slideshow/SlideRenderer.ts
@@ -482,6 +482,7 @@ class SlideRendererGl extends SlideRenderer {
 				gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
 				this.updateTexture(video.getTexture(), video.videoElement);
 				gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
+				gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
 			}
 		}
 


### PR DESCRIPTION
When a slide contains a video, the pause timer text appears mirrored. This was due to the gl.UNPACK_FLIP_Y_WEBGL flag is true while rendering videos, which flips textures vertically. The flag was not reset afterward, causing subsequent textures (like the pause text) to be flipped.

This fix resets gl.UNPACK_FLIP_Y_WEBGL to false after rendering videos, ensuring that the pause text displays correctly


Change-Id: I529bfec5a1ebbac62d938dbeb7ce2782bfdf4a61

