### PR TITLE
Prerequisites for Smarter Upload Failure Handling

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -2210,9 +2210,11 @@ void DocumentBroker::uploadToStorageInternal(const std::shared_ptr<ClientSession
     _nextStorageAttrs.reset();
 
     _storageManager.markLastUploadRequestTime();
-    _storage->uploadLocalFileToStorageAsync(session->getAuthorization(), *_lockCtx, saveAsPath,
-                                            saveAsFilename, isRename, _lastStorageAttrs, *_poll,
-                                            asyncUploadCallback);
+    const std::size_t size = _storage->uploadLocalFileToStorageAsync(
+        session->getAuthorization(), *_lockCtx, saveAsPath, saveAsFilename, isRename,
+        _lastStorageAttrs, *_poll, asyncUploadCallback);
+
+    _storageManager.setSizeAsUploaded(size);
 }
 
 void DocumentBroker::handleUploadToStorageResponse(const StorageBase::UploadResult& uploadResult)

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -1287,6 +1287,7 @@ private:
     public:
         StorageManager(std::chrono::milliseconds minTimeBetweenUploads)
             : _request(minTimeBetweenUploads)
+            , _sizeAsUploaded(0)
         {
             if (Log::traceEnabled())
             {
@@ -1346,6 +1347,14 @@ private:
         /// Returns the last modified time of the document.
         const std::string& getLastModifiedTime() const { return _lastModifiedTime; }
 
+        /// Set size of the document as we've uploaded.
+        /// Used to resynchronize after an upload failure that break reliance on the LastModifiedTime.
+        void setSizeAsUploaded(std::size_t size) { _sizeAsUploaded = size; }
+
+        /// Get size of the document as we've set in our PutFile header.
+        /// Used to resynchronize after an upload failure that break reliance on the LastModifiedTime.
+        std::size_t getSizeAsUploaded() const { return _sizeAsUploaded; }
+
         /// Returns how long the last upload took.
         std::chrono::milliseconds lastUploadDuration() const
         {
@@ -1377,6 +1386,7 @@ private:
             os << indent << "last upload was successful: " << std::boolalpha
                << lastUploadSuccessful();
             os << indent << "upload failure count: " << uploadFailureCount();
+            os << indent << "last upload size: " << _sizeAsUploaded;
         }
 
     private:
@@ -1388,6 +1398,10 @@ private:
 
         /// The modified time of the document in storage, as reported by the server.
         std::string _lastModifiedTime;
+
+        /// The size of the document as we uploaded to the server.
+        /// Used to help resynchronize the LastModifiedTime after an upload failure.
+        std::size_t _sizeAsUploaded;
     };
 
     /// Represents a lock-state update request.

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -1287,6 +1287,7 @@ private:
     public:
         StorageManager(std::chrono::milliseconds minTimeBetweenUploads)
             : _request(minTimeBetweenUploads)
+            , _sizeOnServer(0)
             , _sizeAsUploaded(0)
         {
             if (Log::traceEnabled())
@@ -1347,6 +1348,12 @@ private:
         /// Returns the last modified time of the document.
         const std::string& getLastModifiedTime() const { return _lastModifiedTime; }
 
+        /// Set size of the document as we've downloaded it, or after a successful upload.
+        void setSizeOnServer(std::size_t size) { _sizeOnServer = size; }
+
+        /// Get size of the document as we've downloaded it, or after a successful upload.
+        std::size_t getSizeOnServer() const { return _sizeOnServer; }
+
         /// Set size of the document as we've uploaded.
         /// Used to resynchronize after an upload failure that break reliance on the LastModifiedTime.
         void setSizeAsUploaded(std::size_t size) { _sizeAsUploaded = size; }
@@ -1386,6 +1393,7 @@ private:
             os << indent << "last upload was successful: " << std::boolalpha
                << lastUploadSuccessful();
             os << indent << "upload failure count: " << uploadFailureCount();
+            os << indent << "size on server: " << _sizeOnServer;
             os << indent << "last upload size: " << _sizeAsUploaded;
         }
 
@@ -1398,6 +1406,11 @@ private:
 
         /// The modified time of the document in storage, as reported by the server.
         std::string _lastModifiedTime;
+
+        /// The size of the document, as we downloaded from the server,
+        /// and after successfully uploading.
+        /// Used to help resynchronize the LastModifiedTime after an upload failure.
+        std::size_t _sizeOnServer;
 
         /// The size of the document as we uploaded to the server.
         /// Used to help resynchronize the LastModifiedTime after an upload failure.

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -1632,6 +1632,9 @@ private:
     /// Performs aggregated work after servicing all client sessions
     void processBatchUpdates();
 
+    /// Called when document conflict is detected (i.e. it changed in storage).
+    void handleDocumentConflict();
+
     /// The main state of the document.
     DocumentState _docState;
 

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -406,11 +406,12 @@ public:
     /// Writes the contents of the file back to the source asynchronously, if possible.
     /// @param savedFile When the operation was saveAs, this is the path to the file that was saved.
     /// @param asyncUploadCallback Used to communicate the result back to the caller.
-    virtual void uploadLocalFileToStorageAsync(const Authorization& auth, LockContext& lockCtx,
-                                               const std::string& saveAsPath,
-                                               const std::string& saveAsFilename,
-                                               const bool isRename, const Attributes&, SocketPoll&,
-                                               const AsyncUploadCallback& asyncUploadCallback) = 0;
+    /// @returns The size of the document.
+    virtual std::size_t
+    uploadLocalFileToStorageAsync(const Authorization& auth, LockContext& lockCtx,
+                                  const std::string& saveAsPath, const std::string& saveAsFilename,
+                                  const bool isRename, const Attributes&, SocketPoll&,
+                                  const AsyncUploadCallback& asyncUploadCallback) = 0;
 
     /// Get the progress state of an asynchronous LocalFileToStorage upload.
     virtual AsyncUpload queryLocalFileToStorageAsyncUploadState()
@@ -551,11 +552,11 @@ public:
     std::string downloadStorageFileToLocal(const Authorization& auth, LockContext& lockCtx,
                                            const std::string& templateUri) override;
 
-    void uploadLocalFileToStorageAsync(const Authorization& auth, LockContext& lockCtx,
-                                       const std::string& saveAsPath,
-                                       const std::string& saveAsFilename, const bool isRename,
-                                       const Attributes&, SocketPoll&,
-                                       const AsyncUploadCallback& asyncUploadCallback) override;
+    std::size_t
+    uploadLocalFileToStorageAsync(const Authorization& auth, LockContext& lockCtx,
+                                  const std::string& saveAsPath, const std::string& saveAsFilename,
+                                  const bool isRename, const Attributes&, SocketPoll&,
+                                  const AsyncUploadCallback& asyncUploadCallback) override;
 
 private:
 #if !MOBILEAPP

--- a/wsd/wopi/WopiStorage.cpp
+++ b/wsd/wopi/WopiStorage.cpp
@@ -731,12 +731,10 @@ std::string WopiStorage::downloadDocument(const Poco::URI& uriObject, const std:
         return Poco::Path(getJailPath(), getFileInfo().getFilename()).toString();
 }
 
-void WopiStorage::uploadLocalFileToStorageAsync(const Authorization& auth, LockContext& lockCtx,
-                                                const std::string& saveAsPath,
-                                                const std::string& saveAsFilename,
-                                                const bool isRename, const Attributes& attribs,
-                                                SocketPoll& socketPoll,
-                                                const AsyncUploadCallback& asyncUploadCallback)
+std::size_t WopiStorage::uploadLocalFileToStorageAsync(
+    const Authorization& auth, LockContext& lockCtx, const std::string& saveAsPath,
+    const std::string& saveAsFilename, const bool isRename, const Attributes& attribs,
+    SocketPoll& socketPoll, const AsyncUploadCallback& asyncUploadCallback)
 {
     auto profileZone =
         std::make_shared<ProfileZone>(std::string("WopiStorage::uploadLocalFileToStorage"),
@@ -751,7 +749,7 @@ void WopiStorage::uploadLocalFileToStorageAsync(const Authorization& auth, LockC
         asyncUploadCallback(
             AsyncUpload(AsyncUpload::State::Error,
                 UploadResult(UploadResult::Result::FAILED, "Already in progress.")));
-        return;
+        return 0;
     }
 
     const bool isSaveAs = !saveAsPath.empty() && !saveAsFilename.empty();
@@ -765,7 +763,7 @@ void WopiStorage::uploadLocalFileToStorageAsync(const Authorization& auth, LockC
         asyncUploadCallback(
             AsyncUpload(AsyncUpload::State::Error,
                 UploadResult(UploadResult::Result::FAILED, "File not found.")));
-        return;
+        return 0;
     }
 
     const std::size_t size = (fileStat.good() ? fileStat.size() : 0);
@@ -912,7 +910,7 @@ void WopiStorage::uploadLocalFileToStorageAsync(const Authorization& auth, LockC
         // Make the request.
         _uploadHttpSession->asyncRequest(httpRequest, socketPoll);
 
-        return;
+        return size;
     }
     catch (const Poco::Exception& ex)
     {
@@ -930,6 +928,8 @@ void WopiStorage::uploadLocalFileToStorageAsync(const Authorization& auth, LockC
 
     asyncUploadCallback(AsyncUpload(
         AsyncUpload::State::Error, UploadResult(UploadResult::Result::FAILED, "Internal error.")));
+
+    return 0;
 }
 
 StorageBase::UploadResult

--- a/wsd/wopi/WopiStorage.hpp
+++ b/wsd/wopi/WopiStorage.hpp
@@ -205,11 +205,11 @@ public:
     std::string downloadStorageFileToLocal(const Authorization& auth, LockContext& lockCtx,
                                            const std::string& templateUri) override;
 
-    void uploadLocalFileToStorageAsync(const Authorization& auth, LockContext& lockCtx,
-                                       const std::string& saveAsPath,
-                                       const std::string& saveAsFilename, const bool isRename,
-                                       const Attributes&, SocketPoll& socketPoll,
-                                       const AsyncUploadCallback& asyncUploadCallback) override;
+    std::size_t
+    uploadLocalFileToStorageAsync(const Authorization& auth, LockContext& lockCtx,
+                                  const std::string& saveAsPath, const std::string& saveAsFilename,
+                                  const bool isRename, const Attributes&, SocketPoll& socketPoll,
+                                  const AsyncUploadCallback& asyncUploadCallback) override;
 
     /// Total time taken for making WOPI calls during uploading.
     std::chrono::milliseconds getWopiSaveDuration() const { return _wopiSaveDuration; }


### PR DESCRIPTION
This is in preparation to re-synchronize the LastModifiedTime after we fail to upload.
_Best to review one commit at a time._

- wsd: wopi: remember the document size we uploaded
- wsd: wopi: track the document size on the server
- wsd: wopi: return the file-size from uploadLocalFileToStorageAsync
- wsd: centralize document conflict handling
