### PR TITLE
slideshow: fix present from current slide

### DIFF
--- a/browser/src/control/Control.PartsPreview.js
+++ b/browser/src/control/Control.PartsPreview.js
@@ -467,7 +467,7 @@ L.Control.PartsPreview = L.Control.extend({
 		}
 
 		var part = this._findClickedPart(e.target.parentNode);
-		if (part !== null) {
+		if (part !== -1) {
 			var partId = parseInt(part) - 1; // The first part is just a drop-site for reordering.
 
 			if (app.file.fileBasedView) {

--- a/browser/src/control/Parts.js
+++ b/browser/src/control/Parts.js
@@ -132,6 +132,8 @@ L.Map.include({
 	selectPart: function (part, how, external) {
 		//TODO: Update/track selected parts(?).
 		var docLayer = this._docLayer;
+		var oldParts = docLayer._selectedParts.slice();
+		var newParts = docLayer._selectedParts;
 		var index = docLayer._selectedParts.indexOf(part);
 		if (index >= 0 && how != 1) {
 			// Remove (i.e. deselect)
@@ -140,6 +142,12 @@ L.Map.include({
 		else if (how != 0) {
 			// Add (i.e. select)
 			docLayer._selectedParts.push(part);
+		}
+
+		// did we change anything?
+		if (oldParts.length === newParts.length &&
+			oldParts.every((value, index) => { return value === newParts[index]; })) {
+			return;
 		}
 
 		this.fire('updateparts', {

--- a/browser/src/slideshow/SlideShowPresenter.ts
+++ b/browser/src/slideshow/SlideShowPresenter.ts
@@ -159,6 +159,13 @@ class SlideShowPresenter {
 			'keydown',
 			this._slideShowNavigator.onKeyDown.bind(this._slideShowNavigator),
 		);
+
+		if (this._fullscreen) {
+			// we need to cleanup current/prev slide,
+			// Escape handler is not called as we disabled it above
+			this._slideShowNavigator.endPresentation(false);
+		}
+
 		L.DomUtil.remove(this._slideShowCanvas);
 		this._slideShowCanvas = null;
 		if (this._presenterContainer) {

--- a/browser/src/slideshow/engine/SlideShowNavigator.ts
+++ b/browser/src/slideshow/engine/SlideShowNavigator.ts
@@ -142,8 +142,6 @@ class SlideShowNavigator {
 			'SlideShowNavigator.quit: current index: ' + this.currentSlide,
 		);
 		this.endPresentation(true);
-		this.currentSlide = undefined;
-		this.prevSlide = undefined;
 		this.removeHandlers();
 	}
 
@@ -214,6 +212,8 @@ class SlideShowNavigator {
 	}
 
 	endPresentation(force: boolean = false) {
+		this.currentSlide = undefined;
+		this.prevSlide = undefined;
 		this.presenter.endPresentation(force);
 	}
 


### PR DESCRIPTION
When we close fullscreen we don't call escape handler as earlier we turn off it's handler so we didn't properly clear status of navigator.

This caused bug when presenting second time. We didn't start from current slide but the last slide of previous fullscreen slideshow.