### PR TITLE
Fix: Restrict invert background feature to document content only

### DIFF
--- a/browser/css/color-palette-dark.css
+++ b/browser/css/color-palette-dark.css
@@ -21,6 +21,8 @@
 	--color-stylesview-background: white;
 	--brightness-stylesview: 0.9;
 
+	--color-canvas: #141414;
+
 	--color-primary: #0b87e7; /* border-color */
 	--color-primary-text: #fff; /* text color when primary-lighter is background */
 	--color-primary-dark: #0063b1;
@@ -48,6 +50,5 @@
 
 [data-bg-theme='dark'] {
 	--color-cursor-blink-background: #fff;
-	--color-canvas: #141414;
 	--color-background-document: #121212;
 }

--- a/browser/css/color-palette.css
+++ b/browser/css/color-palette.css
@@ -22,6 +22,7 @@
 	--color-stylesview-background: var(--color-background-lighter);
 	--brightness-stylesview: 1;
 
+	--color-canvas: #f5f5f5;
 
 	--color-primary: #0b87e7; /* border-color */
 	--color-primary-text: #fff; /* text color when primary-lighter is background */
@@ -49,6 +50,5 @@
 
 [data-bg-theme='light'] {
 	--color-cursor-blink-background: #000;
-	--color-canvas: #f5f5f5;
 	--color-background-document: #FFFFFF;
 }


### PR DESCRIPTION
- Ensure that background inversion applies exclusively to the document page/slide and not the surrounding areas.
- This fixes unintended behavior where inversion affected the non-document regions, which is inconsistent with expected behavior and user experience in most editing environments.


Change-Id: Id3113185b1cd954ad48c9b63df573a919c871049


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

