### PR TITLE
Remove HTML style tags from copied content before setting it to clipb…

### DIFF
--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -972,6 +972,10 @@ L.Clipboard = L.Class.extend({
 				text = text.substring(idx, text.length);
 			textHtml = text;
 		}
+
+		if (!app.sectionContainer.testing)
+			textHtml = this.stripStyle(textHtml);
+
 		return {
 			'html': textHtml,
 			'plain': textPlain


### PR DESCRIPTION
To reproduce:

* Clear the browser cache.
* Copy some content with bold text (to be sure to have style tag).
* There is a JS error related to CSP.

This commit fixes the JS error.