### PR TITLE
Fix hover text labels in Table menu for consistency and clarity

### DIFF
--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -2357,7 +2357,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 							},
 							{
 								'type': 'toolitem',
-								'text': _UNO('.uno:DeleteColumns', 'text'),
+								'text': _UNO('.uno:DeleteColumns', 'text', true),
 								'command': '.uno:DeleteColumns'
 							}
 						]
@@ -2377,7 +2377,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 							},
 							{
 								'type': 'toolitem',
-								'text': _UNO('.uno:DeleteRows', 'text'),
+								'text': _UNO('.uno:DeleteRows', 'text', true),
 								'command': '.uno:DeleteRows'
 							}
 						]
@@ -2444,7 +2444,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 			},
 			{
 				'type': 'bigtoolitem',
-				'text': _UNO('.uno:EntireCell', 'text'),
+				'text': _UNO('.uno:EntireCell', 'text', true),
 				'command': '.uno:EntireCell'
 			},
 			{
@@ -2455,12 +2455,12 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 						'children': [
 							{
 								'type': 'toolitem',
-								'text': _UNO('.uno:EntireColumn', 'text'),
+								'text': _UNO('.uno:EntireColumn', 'presentation'),
 								'command': '.uno:EntireColumn'
 							},
 							{
 								'type': 'toolitem',
-								'text': _UNO('.uno:SelectTable', 'text'),
+								'text': _UNO('.uno:SelectTable', 'text', true),
 								'command': '.uno:SelectTable'
 							},
 						]
@@ -2470,12 +2470,12 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 						'children': [
 							{
 								'type': 'toolitem',
-								'text': _UNO('.uno:EntireRow', 'text'),
+								'text': _UNO('.uno:EntireRow', 'presentation'),
 								'command': '.uno:EntireRow'
 							},
 							{
 								'type': 'toolitem',
-								'text': _UNO('.uno:DeleteTable', 'text'),
+								'text': _UNO('.uno:DeleteTable', 'text', true),
 								'command': '.uno:DeleteTable'
 							},
 						]


### PR DESCRIPTION
+ Corrected the hover text labels in the Table menu to ensure they accurately describe the actions they represent:
+ Adjustments are done based on which string should be displayed from unocommand.js file( "Context" or "menu")

This resolves inconsistencies and improves user experience by providing clearer descriptions for each menu action.- 

Updated string :

-  "Cell" to "Select Cell"
-  "Table" to "Delete Table" and "Select Table" accordingly
-  "Row" to "Select Row"
-  "Column" to "Select Column"
-  "Columns" and "Rows" to "Delete Selected Columns" and "Delete Selected Rows"

Change-Id: Iec2f04434eb175cbf5a38a5b91dd3e4e896ce7e9


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

