### PR TITLE
fix dark mode & invert BG icon should be highlighted on mode change

### DIFF
--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -477,11 +477,9 @@ L.Control.Notebookbar = L.Control.extend({
 
 	onDarkModeToggleChange: function() {
 		if (window.prefs.getBoolean('darkTheme')) {
-			$('#toggledarktheme').addClass('selected');
 			$('#invertbackground').show();
 		}
 		else {
-			$('#toggledarktheme').removeClass('selected');
 			$('#invertbackground').hide();
 		}
 	},

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -66,6 +66,8 @@ L.Control.UIManager = L.Control.extend({
 		});
 
 		this.map.on('updateviewslist', this.onUpdateViews, this);
+
+		this.map['stateChangeHandler'].setItemValue('toggledarktheme', 'false');
 	},
 
 	// UI initialization
@@ -85,11 +87,13 @@ L.Control.UIManager = L.Control.extend({
 
 	loadLightMode: function() {
 		document.documentElement.setAttribute('data-theme','light');
+		this._map.fire('commandstatechanged', {commandName : 'toggledarktheme', state : 'false'});
 		this.map.fire('darkmodechanged');
 	},
 
 	loadDarkMode: function() {
 		document.documentElement.setAttribute('data-theme','dark');
+		this._map.fire('commandstatechanged', {commandName : 'toggledarktheme', state : 'true'});
 		this.map.fire('darkmodechanged');
 	},
 

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -68,6 +68,7 @@ L.Control.UIManager = L.Control.extend({
 		this.map.on('updateviewslist', this.onUpdateViews, this);
 
 		this.map['stateChangeHandler'].setItemValue('toggledarktheme', 'false');
+		this.map['stateChangeHandler'].setItemValue('invertbackground', 'false');
 	},
 
 	// UI initialization
@@ -121,6 +122,12 @@ L.Control.UIManager = L.Control.extend({
 
 	initDarkBackgroundUI: function(activate) {
 		document.documentElement.setAttribute('data-bg-theme', activate ? 'dark' : 'light');
+		if (activate) {
+			this._map.fire('commandstatechanged', {commandName : 'invertbackground', state : 'false'});
+		}
+		else {
+			this._map.fire('commandstatechanged', {commandName : 'invertbackground', state : 'true'});
+		}
 		this.setCanvasColorAfterModeChange();
 	},
 

--- a/browser/src/map/handler/Map.StateChanges.js
+++ b/browser/src/map/handler/Map.StateChanges.js
@@ -42,8 +42,9 @@ L.Map.StateChangeHandler = L.Handler.extend({
 				state = e.state;
 			}
 		}
+		const commandName = this.ensureUnoCommandPrefix(e.commandName);
 
-		this._items[e.commandName] = state;
+		this._items[commandName] = state;
 		if (e.commandName === '.uno:CurrentTrackedChangeId') {
 			var redlineId = 'change-' + state;
 			this._map._docLayer._annotations.selectById(redlineId);
@@ -84,19 +85,22 @@ L.Map.StateChangeHandler = L.Handler.extend({
 	},
 
 	getItemValue: function(unoCmd) {
-		if (unoCmd && unoCmd.substring(0, 5) !== '.uno:') {
-			unoCmd = '.uno:' + unoCmd;
-		}
+		unoCmd = this.ensureUnoCommandPrefix(unoCmd);
 
 		return this._items[unoCmd];
 	},
 
 	setItemValue: function(unoCmd, value) {
-		if (unoCmd && unoCmd.substring(0, 5) !== '.uno:') {
-			unoCmd = '.uno:' + unoCmd;
-		}
+		unoCmd = this.ensureUnoCommandPrefix(unoCmd);
 
 		this._items[unoCmd] = value;
+	},
+
+	ensureUnoCommandPrefix(unoCmd) {
+		if (unoCmd && unoCmd.substring(0, 5) !== '.uno:') {
+			return '.uno:' + unoCmd;
+		}
+		return unoCmd;
 	}
 });
 


### PR DESCRIPTION
Fix dark mode icon not highlighted on reload
- StateChange Handler needs to get initialized for 'toggleInvert' on load.

Invert background button should get highlighted on toggle.
- add classs 'selected' on invertbackground after we change state or apply invert
- StateChange Handler needs to get initialized for 'invertbackground' on load.

* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

