### PR TITLE
slideshow: do not render invisible element for transition

### DIFF
--- a/browser/src/slideshow/LayerDrawing.ts
+++ b/browser/src/slideshow/LayerDrawing.ts
@@ -578,6 +578,7 @@ class LayerDrawing {
 						}
 						return; // no layer means it is not visible
 					}
+					if (!animatedElement.getVisibility()) return;
 				}
 				this.drawBitmap(content.content as ImageInfo);
 			}


### PR DESCRIPTION
if we switch slides with some transition and on the next slide there is animated layer with initial visibility = false then we need to avoid rendering it. without that we had blinking object which was visible during the transition but not when it was finished.
