### PR TITLE
Fix broken transitions due to global WebGL state changes

### DIFF
--- a/browser/src/slideshow/transition/SimpleTransition.ts
+++ b/browser/src/slideshow/transition/SimpleTransition.ts
@@ -32,6 +32,9 @@ class SimpleTransition extends SlideShow.Transition3d {
 	}
 
 	public initWebglFlags(): void {
+		this.gl.disable(this.gl.DEPTH_TEST);
+		this.gl.disable(this.gl.CULL_FACE);
+
 		// Enable alpha blending
 		this.gl.enable(this.gl.BLEND);
 		this.gl.blendFunc(this.gl.SRC_ALPHA, this.gl.ONE_MINUS_SRC_ALPHA);


### PR DESCRIPTION
This fixes a regression introduced in commit 3a1f0357c0e918cd2681211a9061a934c1dd2349.

In the FlipTilesTransition, we enabled several WebGL flags such as DEPTH_TEST and CULL_FACE, and disabled BLEND. Since WebGL uses a global state machine for each canvas, these state changes inadvertently affected other transitions that rely on different WebGL states, causing them to break.

To fix this issue we have to disable those flags in initWebglFlags.


Change-Id: I92d73ba079d29fa05c5077d06c5d64b9480ddd7c

