### PR TITLE
annotations: isAutoSaved helper check correct author

### DIFF
--- a/browser/src/canvas/sections/CommentSection.ts
+++ b/browser/src/canvas/sections/CommentSection.ts
@@ -864,7 +864,7 @@ export class Comment extends CanvasSectionObject {
 		if (!autoSavedComment)
 			return false;
 
-		var authorMatch = autoSavedComment.sectionProperties.data.author === this.sectionProperties.data.author;
+		var authorMatch = this.sectionProperties.data.author === this.map.getViewName(this.sectionProperties.docLayer._viewId);
 		return authorMatch;
 	}
 

--- a/cypress_test/integration_tests/multiuser/writer/annotation_spec.js
+++ b/cypress_test/integration_tests/multiuser/writer/annotation_spec.js
@@ -334,5 +334,24 @@ describe(['tagmultiuser'], 'Multiuser Annotation Tests', function () {
 		cy.cGet('#annotation-content-area-2').should('not.exist');
 	});
 
+	it('Reply autosave different author', function () {
+		cy.cSetActiveFrame('#iframe1');
+		desktopHelper.insertComment();
+
+		cy.cSetActiveFrame('#iframe2');
+		cy.cGet('.cool-annotation-content-wrapper').should('exist');
+		cy.cGet('#annotation-content-area-1').should('have.text', 'some text0');
+		cy.cGet('#comment-annotation-menu-1').click();
+		cy.cGet('body').contains('.context-menu-item', 'Reply').click();
+		cy.cGet('#annotation-reply-textarea-1').type('some reply text');
+		cy.cGet('#map').focus();
+		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
+		cy.cGet('#annotation-modify-textarea-2').should('be.visible');
+
+		cy.cSetActiveFrame('#iframe1');
+		cy.cGet('.cool-annotation-content-wrapper').should('exist');
+		cy.cGet('#annotation-content-area-2').should('have.text', 'some reply text');
+	});
+
 	});
 });


### PR DESCRIPTION
The helper function isAutoSave checked the author of the new
comment against the author of autoSavedComment. But in case of
an autosaved reply, autoSavedComment is the parent of the reply.
So we must check the new comment's author against the username,
who would be the author of an autosaved reply.

Signed-off-by: Jaume Pujantell <jaume.pujantell@collabora.com>
Change-Id: Ica5d12c81c58f81e00d70a5333053a2fa514f360
