### PR TITLE
slideshow: fix error on vertex array delete

### DIFF
--- a/browser/src/slideshow/RenderContext.ts
+++ b/browser/src/slideshow/RenderContext.ts
@@ -90,7 +90,7 @@ class RenderContextGl extends RenderContext {
 
 	public deleteVertexArray(vao: WebGLVertexArrayObject): void {
 		const gl = this.getGl();
-		gl.deleteTexture(vao);
+		gl.deleteVertexArray(vao);
 	}
 
 	public createEmptySlide(): WebGLTexture | ImageBitmap {


### PR DESCRIPTION
Solves problem with closing slideshow with the video: SlideRenderer.ts:381 Uncaught TypeError: Failed to execute 'deleteTexture' on 'WebGL2RenderingContext': parameter 1 is not of type 'WebGLTexture'.
    at RenderContextGl.deleteVertexArray (RenderContext.ts:93:6)
    at VideoRenderInfo.replaceVao (SlideRenderer.ts:36:11)

