### PR TITLE
Calc: fixes misaligned checkbox

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -722,6 +722,10 @@ input[type='checkbox']:checked.autofilter, .jsdialog input[type='checkbox']:chec
 	margin: auto 5px;
 }
 
+.jsdialog.ui-grid-cell input[type='checkbox'] + label[for^='hidden-part-checkbox'] {
+	vertical-align: super;
+}
+
 .jsdialog.ui-text {
 	padding-inline-start: 8px;
 }


### PR DESCRIPTION
Change-Id: I338d995f23f898faffaadd5a32c17f982011c33b


* Resolves: #10041 
* Target version: master 

### Summary

Fixes checkbox and label being misaligned in the Show Sheet modal

![image](https://github.com/user-attachments/assets/a2bfe5df-78f5-4352-8556-7b622cb5cb5f)


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

