### PR TITLE
We shouldn't split the sentences into multiple parts if they are to b…

### DIFF
--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -1281,8 +1281,11 @@ L.Clipboard = L.Class.extend({
 		p = document.createElement('p');
 		innerDiv.appendChild(p);
 		const bold = document.createElement('b');
-		bold.textContent = _('Please press ');
+		bold.textContent = _('Please use following combination to see more options:');
 		p.appendChild(bold);
+
+		p = document.createElement('p');
+		innerDiv.appendChild(p);
 		let kbd = document.createElement('kbd');
 		kbd.textContent = ctrlText;
 		p.appendChild(kbd);
@@ -1293,7 +1296,7 @@ L.Clipboard = L.Class.extend({
 		kbd = document.createElement('kbd');
 		kbd.textContent = 'V';
 		p.appendChild(kbd);
-		p.appendChild(document.createTextNode(_(' to see more options')));
+
 		p = document.createElement('p');
 		innerDiv.appendChild(p);
 		p.textContent = _('Close popup to ignore paste special');


### PR DESCRIPTION
…e translated.

If we split the sentences, we would have guessed that every language has the splitted parts in the same order. Since this case is not possible, we will try to keep one sentence as a whole string.

This commit fixes a regression that is caused by below PR:
* https://github.com/CollaboraOnline/online/pull/10065

Now the string is not splitted into 2 and the constant text is sent to another paragraph.

Before:

![1](https://github.com/user-attachments/assets/5954e2ac-3a0a-4b2f-9304-d234b0499714)


After:

![2](https://github.com/user-attachments/assets/d0b1998d-a4c0-426c-9dbf-4ad5846aed60)
