### PR TITLE
In context menu, separators don't have a "text" property.

### DIFF
--- a/browser/src/control/Control.ContextMenu.js
+++ b/browser/src/control/Control.ContextMenu.js
@@ -236,7 +236,7 @@ L.Control.ContextMenu = L.Control.extend({
 			}
 
 			// reduce Paste Special submenu
-			if (item.type === 'menu' && item.text.replace('~', '') === 'Paste Special'
+			if (item.type === 'menu' && item.text && item.text.replace('~', '') === 'Paste Special'
 				&& item.menu && item.menu.length) {
 				item.text = _('Paste Special');
 				item.command = '.uno:PasteSpecial';
@@ -244,7 +244,7 @@ L.Control.ContextMenu = L.Control.extend({
 				item.menu = undefined;
 			}
 
-			if (item.type === 'command' && item.text.replace('~', '') === 'Copy Cells'
+			if (item.type === 'command' && item.text && item.text.replace('~', '') === 'Copy Cells'
 				&& item.menu && item.menu.length) {
 				item.text = _('Copy Cells');
 				item.command = '.uno:AutoFill?Copy:bool=true';
@@ -252,7 +252,7 @@ L.Control.ContextMenu = L.Control.extend({
 				item.menu = undefined;
 			}
 
-			if (item.type === 'command' && item.text.replace('~', '') === 'Fill Series'
+			if (item.type === 'command' && item.text && item.text.replace('~', '') === 'Fill Series'
 				&& item.menu && item.menu.length) {
 				item.text = _('Fill Series');
 				item.command = '.uno:AutoFill?Copy:bool=false';


### PR DESCRIPTION
In "_createContextMenuStructure" function, we are checkin the text against certain texts.

We first need to check if there is a "text" property.

To reproduce the issue, one can use the right click menu for spell-checked and redlined text portions.


Change-Id: Ic9a919e453886f752182a0aedc84e46597c13f2e


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

