### PR TITLE
cool#10106 browser, context menu: fix label of the paste special menu item

### DIFF
--- a/browser/src/control/Control.ContextMenu.js
+++ b/browser/src/control/Control.ContextMenu.js
@@ -297,7 +297,9 @@ L.Control.ContextMenu = L.Control.extend({
 				if (commandName == 'None' && !item.text)
 					continue;
 
-				if (hasParam || commandName === 'None' || commandName === 'FontDialogForParagraph' || commandName === 'Delete') {
+				if (hasParam || commandName === 'None' || commandName === 'FontDialogForParagraph' || commandName === 'Delete' || commandName == 'PasteSpecial') {
+					// These commands have a custom item.text, don't overwrite
+					// that with a label based on 'item.command'.
 					itemName = window.removeAccessKey(item.text);
 					itemName = itemName.replace(' ', '\u00a0');
 				} else {


### PR DESCRIPTION
Open Writer, copy some text, unselect, right click: a 'more options'
menu item is there for paste special, but the desktop has a clear 'paste
special' menu item instead.

Commit ab896c1c78ed220044ca7fc10b6746d78cdb529a (clipboard: add Paste
Special also in context menu, 2022-04-05) collapsed the desktop context
menu to only have 'paste special' as a menu item instead of a submenu,
which is fine -- but the 'item.text' set is overwritten later based on
the label of the uno command. That 'more options' label is fine, but
only in the context of the 'paste special' context menu, not standalone.

Fix the problem by adding PasteSpecial to the list of UNO commands where
we don't overwrite the label based on the command name.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I27996c48710b43fd2bfaa227be5c632e4d22eb27
