### PR TITLE
Handle limited open Connections due to keepalive connections (scratch pull draft pre-review, 2nd revision)

### DIFF
--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -17,6 +17,7 @@
 
 #include <common/StateEnum.hpp>
 #include "Util.hpp"
+#include "NetUtil.hpp"
 #include "net/Socket.hpp"
 #include <Poco/Exception.h>
 
@@ -405,6 +406,9 @@ public:
 
     /// Manipulate and modify the configuration before any usage.
     virtual void configure(Poco::Util::LayeredConfiguration& /* config */) {}
+
+    /// Manipulate and modify the net::Defaults for before any usage.
+    virtual void configure(net::Defaults& /* defaults */) {}
 
     /// Main-loop reached, time for testing.
     /// Invoked from coolwsd's main thread.

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1449,7 +1449,7 @@ bool Document::forkToSave(const std::function<void()> &childSave, int viewId)
     // FIXME: defer and queue a 2nd save if queued during save ...
 
     std::shared_ptr<StreamSocket> parentSocket, childSocket;
-    if (!StreamSocket::socketpair(parentSocket, childSocket))
+    if (!StreamSocket::socketpair(start, parentSocket, childSocket))
         return false;
 
     // To encode into the child process id for debugging

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -66,6 +66,7 @@
 #include <common/JsonUtil.hpp>
 #include "KitHelper.hpp"
 #include "Kit.hpp"
+#include <NetUtil.hpp>
 #include <Protocol.hpp>
 #include <Log.hpp>
 #include <Png.hpp>
@@ -2837,7 +2838,7 @@ void documentViewCallback(const int type, const char* payload, void* data)
 int pollCallback(void* pData, int timeoutUs)
 {
     if (timeoutUs < 0)
-        timeoutUs = SocketPoll::DefaultPollTimeoutMicroS.count();
+        timeoutUs = net::Defaults::get().SocketPollTimeout.count();
 #ifndef IOS
     if (!pData)
         return 0;

--- a/net/DelaySocket.cpp
+++ b/net/DelaySocket.cpp
@@ -23,9 +23,16 @@ std::once_flag Delay::DelayPollOnceFlag;
 /// Reads from fd, delays that and then writes to _dest.
 class DelaySocket : public Socket {
     int _delayMs;
-    enum State { ReadWrite,      // normal socket
-                 EofFlushWrites, // finish up writes and close
-                 Closed };
+    enum class State : uint8_t { ReadWrite,      // normal socket
+                                 EofFlushWrites, // finish up writes and close
+                                 Closed };
+
+    static const char* toString(State s) {
+        if( s == State::ReadWrite ) return "ReadWrite";
+        else if( s == State::EofFlushWrites ) return "EofFlushWrites";
+        else return "Closed";
+    }
+
     State _state;
     std::shared_ptr<DelaySocket> _dest; // our writing twin.
 
@@ -50,7 +57,7 @@ class DelaySocket : public Socket {
 public:
     DelaySocket(int delayMs, int fd) :
         Socket (fd, Socket::Type::Unix), _delayMs(delayMs),
-        _state(ReadWrite)
+        _state(State::ReadWrite)
 	{
 //        setSocketBufferSize(Socket::DefaultSendBufferSize);
 	}
@@ -104,30 +111,30 @@ public:
     {
         switch (newState)
         {
-        case ReadWrite:
+        case State::ReadWrite:
             assert (false);
             break;
-        case EofFlushWrites:
-            assert (_state == ReadWrite);
+        case State::EofFlushWrites:
+            assert (_state == State::ReadWrite);
             assert (_dest);
             _dest->pushCloseChunk();
             _dest = nullptr;
             break;
-        case Closed:
-            if (_dest && _state == ReadWrite)
+        case State::Closed:
+            if (_dest && _state == State::ReadWrite)
                 _dest->pushCloseChunk();
             _dest = nullptr;
             shutdown();
             break;
         }
-        DELAY_LOG('#' << getFD() << " changed to state " << newState << '\n');
+        DELAY_LOG('#' << getFD() << " changed to state " << toString(newState) << '\n');
         _state = newState;
     }
 
     void handlePoll(SocketDisposition &disposition,
                     std::chrono::steady_clock::time_point now, int events) override
     {
-        if (_state == ReadWrite && (events & POLLIN))
+        if (_state == State::ReadWrite && (events & POLLIN))
         {
             auto chunk = std::make_shared<WriteChunk>(_delayMs);
 
@@ -139,7 +146,7 @@ public:
             } while (len < 0 && errno == EINTR);
 
             if (len == 0) // EOF.
-                changeState(EofFlushWrites);
+                changeState(State::EofFlushWrites);
             else if (len >= 0)
             {
                 DELAY_LOG('#' << getFD() << " read " << len
@@ -153,14 +160,14 @@ public:
             else if (errno != EAGAIN && errno != EWOULDBLOCK)
             {
                 DELAY_LOG('#' << getFD() << " error : " << Util::symbolicErrno(errno) << ": " << strerror(errno) << '\n');
-                changeState(Closed); // FIXME - propagate the error ?
+                changeState(State::Closed); // FIXME - propagate the error ?
             }
         }
 
         if (_chunks.empty())
         {
-            if (_state == EofFlushWrites)
-                changeState(Closed);
+            if (_state == State::EofFlushWrites)
+                changeState(State::Closed);
         }
         else // Write if we have delayed enough.
         {
@@ -171,7 +178,7 @@ public:
                 if (chunk->getData().empty())
                 { // delayed error or close
                     DELAY_LOG('#' << getFD() << " handling delayed close\n");
-                    changeState(Closed);
+                    changeState(State::Closed);
                 }
                 else
                 {
@@ -193,7 +200,7 @@ public:
                                       << chunk->getData().size()
                                       << " queue: " << _chunks.size() << " error: "
                                       << Util::symbolicErrno(errno) << ": " << strerror(errno) << '\n');
-                            changeState(Closed);
+                            changeState(State::Closed);
                         }
                     }
                     else
@@ -214,10 +221,10 @@ public:
         if (events & (POLLERR | POLLHUP | POLLNVAL))
         {
             DELAY_LOG('#' << getFD() << " error events: " << events << '\n');
-            changeState(Closed);
+            changeState(State::Closed);
         }
 
-        if (_state == Closed)
+        if (_state == State::Closed)
             disposition.setClosed();
     }
 };

--- a/net/DelaySocket.cpp
+++ b/net/DelaySocket.cpp
@@ -55,8 +55,8 @@ class DelaySocket : public Socket {
 
     std::vector<std::shared_ptr<WriteChunk>> _chunks;
 public:
-    DelaySocket(int delayMs, int fd) :
-        Socket (fd, Socket::Type::Unix), _delayMs(delayMs),
+    DelaySocket(int delayMs, int fd, std::chrono::steady_clock::time_point creationTime) :
+        Socket(fd, Socket::Type::Unix, creationTime), _delayMs(delayMs),
         _state(State::ReadWrite)
 	{
 //        setSocketBufferSize(Socket::DefaultSendBufferSize);
@@ -264,8 +264,9 @@ int Delay::create(int delayMs, int physicalFd)
         int internalFd = pair[0];
         int delayFd = pair[1];
 
-        auto physical = std::make_shared<DelaySocket>(delayMs, physicalFd);
-        auto internal = std::make_shared<DelaySocket>(delayMs, internalFd);
+        const std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
+        auto physical = std::make_shared<DelaySocket>(delayMs, physicalFd, now);
+        auto internal = std::make_shared<DelaySocket>(delayMs, internalFd, now);
         physical->setDestination(internal);
         internal->setDestination(physical);
 

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -1199,9 +1199,9 @@ public:
     }
 
     /// Returns the default timeout.
-    static constexpr std::chrono::milliseconds getDefaultTimeout()
+    static std::chrono::milliseconds getDefaultTimeout()
     {
-        return std::chrono::seconds(30);
+        return std::chrono::duration_cast<std::chrono::milliseconds>( net::Defaults::get().HTTPTimeout );
     }
 
     /// Returns the current protocol scheme.

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -153,6 +153,8 @@ STATE_ENUM(FieldParseState,
 /// See https://en.wikipedia.org/wiki/List_of_HTTP_status_codes
 enum class StatusCode : unsigned
 {
+    None = 0, // Undefined status (unknown)
+
     // Informational
     Continue = 100,
     SwitchingProtocols = 101,

--- a/net/NetUtil.hpp
+++ b/net/NetUtil.hpp
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <functional>
 #include <string>
 #include <memory>
@@ -27,6 +28,43 @@ struct sockaddr;
 
 namespace net
 {
+
+class Defaults
+{
+public:
+    /// WebSocketHandler ping timeout in us (2s default). Zero disables metric.
+    std::chrono::microseconds WSPingTimeout;
+    /// WebSocketHandler ping period in us (3s default), i.e. duration until next ping. Zero disables metric.
+    std::chrono::microseconds WSPingPeriod;
+    /// http::Session timeout in us (30s default). Zero disables metric.
+    std::chrono::microseconds HTTPTimeout;
+
+    /// Socket minimum bits per seconds throughput (0). Zero disables metric.
+    double MinBytesPerSec;
+
+    /// Socket poll timeout in us (64s), useful to increase for debugging.
+    std::chrono::microseconds SocketPollTimeout;
+
+private:
+    Defaults()
+        : WSPingTimeout(std::chrono::microseconds(2000000))
+        , WSPingPeriod(std::chrono::microseconds(3000000))
+        , HTTPTimeout(std::chrono::microseconds(30000000))
+        , MinBytesPerSec(0.0)
+        , SocketPollTimeout(std::chrono::microseconds(64000000))
+    {
+    }
+
+public:
+    Defaults(const Defaults&) = delete;
+    Defaults(Defaults&&) = delete;
+
+    static Defaults& get()
+    {
+        static Defaults def;
+        return def;
+    }
+};
 
 #if !MOBILEAPP
 

--- a/net/NetUtil.hpp
+++ b/net/NetUtil.hpp
@@ -39,6 +39,8 @@ public:
     /// http::Session timeout in us (30s default). Zero disables metric.
     std::chrono::microseconds HTTPTimeout;
 
+    /// Maximum total connections (9999 or MAX_CONNECTIONS). Zero disables metric.
+    size_t MaxConnections;
     /// Socket minimum bits per seconds throughput (0). Zero disables metric.
     double MinBytesPerSec;
 
@@ -50,6 +52,7 @@ private:
         : WSPingTimeout(std::chrono::microseconds(2000000))
         , WSPingPeriod(std::chrono::microseconds(3000000))
         , HTTPTimeout(std::chrono::microseconds(30000000))
+        , MaxConnections(9999)
         , MinBytesPerSec(0.0)
         , SocketPollTimeout(std::chrono::microseconds(64000000))
     {

--- a/net/ServerSocket.hpp
+++ b/net/ServerSocket.hpp
@@ -39,7 +39,7 @@ public:
     }
 
     /// Control access to a bound TCP socket
-    enum Type { Local, Public };
+    enum class Type : uint8_t { Local, Public };
 
     /// Create a new server socket - accepted sockets will be added
     /// to the @clientSockets' poll when created with @factory.

--- a/net/ServerSocket.hpp
+++ b/net/ServerSocket.hpp
@@ -28,8 +28,10 @@ public:
 class ServerSocket : public Socket
 {
 public:
-    ServerSocket(Socket::Type type, SocketPoll& clientPoller, std::shared_ptr<SocketFactory> sockFactory) :
-        Socket(type),
+    ServerSocket(Socket::Type type,
+                 std::chrono::steady_clock::time_point creationTime,
+                 SocketPoll& clientPoller, std::shared_ptr<SocketFactory> sockFactory) :
+        Socket(type, creationTime),
 #if !MOBILEAPP
         _type(type),
 #endif
@@ -43,11 +45,14 @@ public:
 
     /// Create a new server socket - accepted sockets will be added
     /// to the @clientSockets' poll when created with @factory.
-    static std::shared_ptr<ServerSocket> create(ServerSocket::Type type, int port,
-                                                Socket::Type socketType, SocketPoll& clientSocket,
+    static std::shared_ptr<ServerSocket> create(ServerSocket::Type type,
+                                                int port,
+                                                Socket::Type socketType,
+                                                std::chrono::steady_clock::time_point creationTime,
+                                                SocketPoll& clientSocket,
                                                 std::shared_ptr<SocketFactory> factory)
     {
-        auto serverSocket = std::make_shared<ServerSocket>(socketType, clientSocket, std::move(factory));
+        auto serverSocket = std::make_shared<ServerSocket>(socketType, creationTime, clientSocket, std::move(factory));
 
         if (serverSocket && serverSocket->bind(type, port) && serverSocket->listen())
             return serverSocket;
@@ -130,8 +135,9 @@ private:
 class LocalServerSocket : public ServerSocket
 {
 public:
-    LocalServerSocket(SocketPoll& clientPoller, std::shared_ptr<SocketFactory> sockFactory) :
-        ServerSocket(Socket::Type::Unix, clientPoller, std::move(sockFactory))
+    LocalServerSocket(std::chrono::steady_clock::time_point creationTime,
+                      SocketPoll& clientPoller, std::shared_ptr<SocketFactory> sockFactory) :
+        ServerSocket(Socket::Type::Unix, creationTime, clientPoller, std::move(sockFactory))
     {
     }
     ~LocalServerSocket() override;

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -1344,6 +1344,36 @@ LocalServerSocket::~LocalServerSocket()
 #  define LOG_CHUNK(X)
 #endif
 
+#endif // !MOBILEAPP
+
+std::string StreamSocket::toString(WSState t)
+{
+    if( WSState::WS == t )
+    {
+        return "WS";
+    }
+    return "HTTP";
+}
+
+std::ostream& StreamSocket::stream(std::ostream& os) const
+{
+    os << "StreamSocket[#" << getFD()
+       << ", " << toString(_wsState)
+       << ", " << Socket::toString(type())
+       << " @ ";
+    if (Type::IPv6 == type())
+    {
+        os << "[" << clientAddress() << "]:" << clientPort();
+    }
+    else
+    {
+        os << clientAddress() << ":" << clientPort();
+    }
+    return os << "]";
+}
+
+#if !MOBILEAPP
+
 bool StreamSocket::parseHeader(const char *clientName,
                                Poco::MemoryInputStream &message,
                                Poco::Net::HTTPRequest &request,

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -1409,6 +1409,7 @@ std::ostream& StreamSocket::stream(std::ostream& os) const
 bool StreamSocket::parseHeader(const char *clientName,
                                Poco::MemoryInputStream &message,
                                Poco::Net::HTTPRequest &request,
+                               std::chrono::steady_clock::time_point &lastHTTPHeader,
                                MessageMap& map)
 {
     assert(map._headerSize == 0 && map._messageSize == 0);
@@ -1417,7 +1418,7 @@ bool StreamSocket::parseHeader(const char *clientName,
         std::chrono::duration_cast<std::chrono::milliseconds>(_httpTimeout);
 
     std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
-    std::chrono::duration<float, std::milli> delayMs = now - _lastSeenHTTPHeader;
+    std::chrono::duration<float, std::milli> delayMs = now - lastHTTPHeader;
 
     // Find the end of the header, if any.
     static const std::string marker("\r\n\r\n");
@@ -1511,7 +1512,7 @@ bool StreamSocket::parseHeader(const char *clientName,
                 if (chunkLen == 0) // we're complete.
                 {
                     map._messageSize = chunkOffset;
-                    _lastSeenHTTPHeader = now;
+                    lastHTTPHeader = now;
                     return true;
                 }
 
@@ -1604,7 +1605,7 @@ bool StreamSocket::parseHeader(const char *clientName,
         return false;
     }
 
-    _lastSeenHTTPHeader = now;
+    lastHTTPHeader = now;
     return true;
 }
 

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -550,6 +550,14 @@ int SocketPoll::poll(int64_t timeoutMaxMicroS)
                 // removed in a callback
                 ++itemsErased;
             }
+            else if (!_pollSockets[i]->isOpen())
+            {
+                // closed socket ..
+                ++itemsErased;
+                LOGA_TRC(Socket, '#' << _pollFds[i].fd << ": Removing socket (at " << i
+                         << " of " << _pollSockets.size() << ") from " << _name);
+                _pollSockets[i] = nullptr;
+            }
             else if (_pollFds[i].fd == _pollSockets[i]->getFD())
             {
                 SocketDisposition disposition(_pollSockets[i]);
@@ -569,7 +577,7 @@ int SocketPoll::poll(int64_t timeoutMaxMicroS)
                     rc = -1;
                 }
 
-                if (!disposition.isContinue())
+                if (!_pollSockets[i]->isOpen() || !disposition.isContinue())
                 {
                     ++itemsErased;
                     LOGA_TRC(Socket, '#' << _pollFds[i].fd << ": Removing socket (at " << i

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -20,6 +20,7 @@
 #include <cctype>
 #include <iomanip>
 #include <memory>
+#include <ostream>
 #include <ratio>
 #include <sstream>
 #include <cstdio>
@@ -67,6 +68,22 @@ std::unique_ptr<Watchdog> SocketPoll::PollWatchdog;
 
 #define SOCKET_ABSTRACT_UNIX_NAME "0coolwsd-"
 
+std::string Socket::toString(Type t)
+{
+    switch (t)
+    {
+        case Type::IPv4:
+            return "IPv4";
+        case Type::IPv6:
+            return "IPv6";
+        case Type::All:
+            return "All";
+        case Type::Unix:
+            return "Unix";
+    }
+    return "Unknown";
+}
+
 int Socket::createSocket([[maybe_unused]] Socket::Type type)
 {
 #if !MOBILEAPP
@@ -86,6 +103,28 @@ int Socket::createSocket([[maybe_unused]] Socket::Type type)
 #endif
 }
 
+std::ostream& Socket::streamImpl(std::ostream& os) const
+{
+    os << "Socket[#" << getFD()
+       << ", " << toString(type())
+       << " @ ";
+    if (Type::IPv6 == type())
+    {
+        os << "[" << clientAddress() << "]:" << clientPort();
+    }
+    else
+    {
+        os << clientAddress() << ":" << clientPort();
+    }
+    return os << "]";
+}
+
+std::string Socket::toStringImpl() const
+{
+    std::ostringstream oss;
+    streamImpl(oss);
+    return oss.str();
+}
 
 bool StreamSocket::socketpair(std::shared_ptr<StreamSocket> &parent,
                               std::shared_ptr<StreamSocket> &child)
@@ -108,7 +147,6 @@ bool StreamSocket::socketpair(std::shared_ptr<StreamSocket> &parent,
     return true;
 #endif
 }
-
 
 #if ENABLE_DEBUG
 static std::atomic<long> socketErrorCount;
@@ -1105,7 +1143,7 @@ std::shared_ptr<Socket> ServerSocket::accept()
             std::shared_ptr<Socket> _socket = createSocketFromAccept(rc, type);
 
             ::inet_ntop(clientInfo.sin6_family, inAddr, addrstr, sizeof(addrstr));
-            _socket->setClientAddress(addrstr); // @ clientInfo.sin6_port
+            _socket->setClientAddress(addrstr, clientInfo.sin6_port);
 
             LOG_TRC("Accepted socket #" << _socket->getFD() << " has family "
                                         << clientInfo.sin6_family << " address "

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -121,8 +121,9 @@ std::string Socket::toStringImpl() const
     return oss.str();
 }
 
-bool StreamSocket::socketpair(std::shared_ptr<StreamSocket> &parent,
-                              std::shared_ptr<StreamSocket> &child)
+bool StreamSocket::socketpair(const std::chrono::steady_clock::time_point &creationTime,
+                              std::shared_ptr<StreamSocket>& parent,
+                              std::shared_ptr<StreamSocket>& child)
 {
 #if MOBILEAPP
     return false;
@@ -132,10 +133,10 @@ bool StreamSocket::socketpair(std::shared_ptr<StreamSocket> &parent,
     if (rc != 0)
         return false;
 
-    child = std::make_shared<StreamSocket>("save-child", pair[0], Socket::Type::Unix, true);
+    child = std::make_shared<StreamSocket>("save-child", pair[0], Socket::Type::Unix, true, ReadType::NormalRead, creationTime);
     child->setNoShutdown();
     child->setClientAddress("save-child");
-    parent = std::make_shared<StreamSocket>("save-kit-parent", pair[1], Socket::Type::Unix, true);
+    parent = std::make_shared<StreamSocket>("save-kit-parent", pair[1], Socket::Type::Unix, true, ReadType::NormalRead, creationTime);
     parent->setNoShutdown();
     parent->setClientAddress("save-parent");
 

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -56,11 +56,6 @@
 #include <Watchdog.hpp>
 #include <wasm/base64.hpp>
 
-// Bug in pre C++17 where static constexpr must be defined. Fixed in C++17.
-constexpr std::chrono::microseconds SocketPoll::DefaultPollTimeoutMicroS;
-constexpr std::chrono::microseconds WebSocketHandler::InitialPingDelayMicroS;
-constexpr std::chrono::microseconds WebSocketHandler::PingFrequencyMicroS;
-
 std::atomic<bool> SocketPoll::InhibitThreadChecks(false);
 std::atomic<bool> Socket::InhibitThreadChecks(false);
 
@@ -259,6 +254,7 @@ namespace {
 
 SocketPoll::SocketPoll(std::string threadName)
     : _name(std::move(threadName)),
+      _pollTimeout( net::Defaults::get().SocketPollTimeout ),
       _pollStartIndex(0),
       _stop(false),
       _threadStarted(0),
@@ -975,7 +971,7 @@ void WebSocketHandler::dumpState(std::ostream& os, const std::string& /*indent*/
 
 void StreamSocket::dumpState(std::ostream& os)
 {
-    int64_t timeoutMaxMicroS = SocketPoll::DefaultPollTimeoutMicroS.count();
+    int64_t timeoutMaxMicroS = _pollTimeout.count();
     const int events = getPollEvents(std::chrono::steady_clock::now(), timeoutMaxMicroS);
     os << '\t' << std::setw(6) << getFD() << "\t0x" << std::hex << events << std::dec << '\t'
        << (ignoringInput() ? "ignore\t" : "process\t") << std::setw(6) << _inBuffer.size() << '\t'
@@ -1381,8 +1377,8 @@ bool StreamSocket::parseHeader(const char *clientName,
 {
     assert(map._headerSize == 0 && map._messageSize == 0);
 
-    constexpr std::chrono::duration<float, std::milli> delayMax =
-        std::chrono::duration_cast<std::chrono::milliseconds>(SocketPoll::DefaultPollTimeoutMicroS);
+    const std::chrono::duration<float, std::milli> delayMax =
+        std::chrono::duration_cast<std::chrono::milliseconds>(_httpTimeout);
 
     std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
     std::chrono::duration<float, std::milli> delayMs = now - _lastSeenHTTPHeader;

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -175,14 +175,14 @@ public:
     /// Returns true if this socket has been closed, i.e. rejected from polling and potentially shutdown
     bool isClosed() const { return !_open; }
 
-    Type type() const { return _type; }
-    bool isIPType() const { return Type::IPv4 == _type || Type::IPv6 == _type; }
+    constexpr Type type() const { return _type; }
+    constexpr bool isIPType() const { return Type::IPv4 == _type || Type::IPv6 == _type; }
     void setClientAddress(const std::string& address, unsigned int port=0) { _clientAddress = address; _clientPort=port; }
     const std::string& clientAddress() const { return _clientAddress; }
     unsigned int clientPort() const { return _clientPort; }
 
     /// Returns the OS native socket fd.
-    int getFD() const { return _fd; }
+    constexpr int getFD() const { return _fd; }
 
     std::ostream& streamStats(std::ostream& os, const std::chrono::steady_clock::time_point &now) const;
     std::string getStatsString(const std::chrono::steady_clock::time_point &now) const;
@@ -190,20 +190,20 @@ public:
     virtual std::ostream& stream(std::ostream& os) const  { return streamImpl(os); }
 
     /// Returns monotonic creation timestamp
-    std::chrono::steady_clock::time_point getCreationTime() const { return _creationTime; }
+    constexpr std::chrono::steady_clock::time_point getCreationTime() const { return _creationTime; }
     /// Returns monotonic timestamp of last received signal from remote
-    std::chrono::steady_clock::time_point getLastSeenTime() const { return _lastSeenTime; }
+    constexpr std::chrono::steady_clock::time_point getLastSeenTime() const { return _lastSeenTime; }
 
     /// Sets monotonic timestamp of last received signal from remote
     void setLastSeenTime(std::chrono::steady_clock::time_point now) { _lastSeenTime = now; }
 
     /// Returns bytes sent statistic
-    uint64_t bytesSent() const { return _bytesSent; }
+    constexpr uint64_t bytesSent() const { return _bytesSent; }
     /// Returns bytes received statistic
-    uint64_t bytesRcvd() const { return _bytesRcvd; }
+    constexpr uint64_t bytesRcvd() const { return _bytesRcvd; }
 
     /// Get input/output statistics on this stream
-    void getIOStats(uint64_t &sent, uint64_t &recv) const
+    constexpr void getIOStats(uint64_t &sent, uint64_t &recv) const
     {
         sent = _bytesSent;
         recv = _bytesRcvd;
@@ -421,9 +421,9 @@ protected:
     inline void logPrefix(std::ostream& os) const { os << '#' << _fd << ": "; }
 
     /// Adds `len` sent bytes to statistic
-    void notifyBytesSent(uint64_t len) { _bytesSent += len; }
+    constexpr void notifyBytesSent(uint64_t len) { _bytesSent += len; }
     /// Adds `len` received bytes to statistic
-    void notifyBytesRcvd(uint64_t len) { _bytesRcvd += len; }
+    constexpr void notifyBytesRcvd(uint64_t len) { _bytesRcvd += len; }
 
     /// avoid doing a shutdown before close
     void setNoShutdown() { _noShutdown = true; }

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -164,15 +164,8 @@ public:
     /// Returns true if this socket has been closed, i.e. rejected from polling and potentially shutdown
     bool isClosed() const { return !_open; }
 
-    void setClientAddress(const std::string& address)
-    {
-        _clientAddress = address;
-    }
-
-    const std::string& clientAddress() const
-    {
-        return _clientAddress;
-    }
+    void setClientAddress(const std::string& address) { _clientAddress = address; }
+    const std::string& clientAddress() const { return _clientAddress; }
 
     /// Returns the OS native socket fd.
     int getFD() const { return _fd; }

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -809,6 +809,15 @@ public:
     /// Global wakeup - signal safe: wakeup all socket polls.
     static void wakeupWorld();
 
+    /// Enable connection accounting and limiter
+    /// Internally we allow one extra connection for the WS upgrade
+    /// @param connectionLimit socket connection limit
+    void setLimiter(size_t connectionLimit)
+    {
+        _limitedConnections = true;
+        _connectionLimit = connectionLimit > 0 ? connectionLimit + 1 : 0;
+    }
+
     /// Insert a new socket to be polled.
     /// A socket is removed when it is closed, readIncomingData
     /// returns false, or when removeSockets is called (which is
@@ -972,6 +981,8 @@ private:
     /// Debug name used for logging.
     const std::string _name;
     const std::chrono::microseconds _pollTimeout;
+    bool _limitedConnections;
+    size_t _connectionLimit;
 
     /// main-loop wakeup pipe
     int _wakeup[2];
@@ -998,6 +1009,13 @@ private:
     /// Time-stamp for profiling
     int _ownerThreadId;
     std::atomic<uint64_t> _watchdogTime;
+
+    static std::mutex StatsMutex;
+    static std::atomic<size_t> StatsConnectionCount; // total of all _pollSockets (excluding _newSockets)
+    static size_t StatsConnectionMod(size_t added, size_t removed); // safe add-sub of StatsConnectionCount
+
+public:
+    static int64_t GetStatsConnectionCount() { return StatsConnectionCount.load(std::memory_order_seq_cst); }
 };
 
 /// A SocketPoll that will stop polling and

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -141,6 +141,7 @@ public:
     // NB. see other Socket::Socket by init below.
     Socket(Type type)
         : _fd(createSocket(type))
+        , _open(_fd >= 0)
     {
         init(type);
     }
@@ -158,7 +159,13 @@ public:
 #endif
     }
 
+    /// Returns true if this socket is open, i.e. allowed to be polled and not shutdown
+    bool isOpen() const { return _open; }
+    /// Returns true if this socket has been closed, i.e. rejected from polling and potentially shutdown
+    bool isClosed() const { return !_open; }
+
     /// Create socket of the given type.
+    /// return >= 0 for a successfully created socket, -1 on error
     static int createSocket(Type type);
 
     void setClientAddress(const std::string& address)
@@ -363,6 +370,7 @@ protected:
     /// Used by accept() only.
     Socket(const int fd, Type type)
         : _fd(fd)
+        , _open(_fd >= 0)
     {
         init(type);
     }
@@ -371,6 +379,9 @@ protected:
 
     /// avoid doing a shutdown before close
     void setNoShutdown() { _noShutdown = true; }
+
+    /// Explicitly marks this socket closed, i.e. rejected from polling and potentially shutdown
+    void setClosed() { _open = false; }
 
 private:
     void init(Type type)
@@ -397,6 +408,8 @@ private:
 
     std::string _clientAddress;
     const int _fd;
+    /// True if this socket is open.
+    bool _open;
 
     // If _ignoreInput is true no more input from this socket will be processed.
     bool _ignoreInput;
@@ -955,7 +968,6 @@ public:
         _bytesSent(0),
         _bytesRecvd(0),
         _wsState(WSState::HTTP),
-        _closed(false),
         _sentHTTPContinue(false),
         _shutdownSignalled(false),
         _readType(readType),
@@ -970,7 +982,7 @@ public:
         LOG_TRC("StreamSocket dtor called with pending write: " << _outBuffer.size()
                                                                 << ", read: " << _inBuffer.size());
 
-        if (!_closed)
+        if (isOpen())
         {
             ASSERT_CORRECT_SOCKET_THREAD(this);
             if (_socketHandler)
@@ -985,7 +997,6 @@ public:
         }
     }
 
-    bool isClosed() const { return _closed; }
     bool isWebSocket() const { return _wsState == WSState::WS; }
     void setWebSocket() { _wsState = WSState::WS; }
 
@@ -1439,11 +1450,11 @@ protected:
         if (closed)
         {
             LOG_TRC("Closed. Firing onDisconnect.");
-            _closed = true;
+            setClosed();
             _socketHandler->onDisconnect();
         }
 
-        if (_closed)
+        if (isClosed())
             disposition.setClosed();
     }
 
@@ -1630,9 +1641,6 @@ private:
     uint64_t _bytesRecvd;
 
     enum class WSState { HTTP, WS } _wsState;
-
-    /// True if we are already closed.
-    bool _closed;
 
     /// True if we've received a Continue in response to an Expect: 100-continue
     bool _sentHTTPContinue;

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -67,6 +67,8 @@ namespace Poco
 }
 
 class Socket;
+std::ostream& operator<<(std::ostream& os, const Socket &s);
+
 class Watchdog;
 class SocketPoll;
 
@@ -175,6 +177,8 @@ public:
     /// Returns the OS native socket fd.
     int getFD() const { return _fd; }
 
+    virtual std::ostream& stream(std::ostream& os) const  { return streamImpl(os); }
+
     /// Shutdown the socket.
     /// TODO: Support separate read/write shutdown.
     virtual void shutdown()
@@ -184,7 +188,7 @@ public:
             setClosed();
             return;
         }
-        LOG_TRC("Socket shutdown RDWR.");
+        LOG_TRC("Socket shutdown RDWR. " << *this);
 #if !MOBILEAPP
         ::shutdown(_fd, SHUT_RDWR);
 #else
@@ -432,6 +436,8 @@ private:
     /// We check the owner even in the release builds, needs to be always correct.
     std::thread::id _owner;
 };
+
+inline std::ostream& operator<<(std::ostream& os, const Socket &s) { return s.stream(os); }
 
 class StreamSocket;
 class MessageHandlerInterface;
@@ -1014,6 +1020,8 @@ public:
 
     /// Returns the peer hostname, if set.
     const std::string& hostname() const { return _hostname; }
+
+    std::ostream& stream(std::ostream& os) const override;
 
     /// Just trigger the async shutdown.
     void shutdown() override
@@ -1652,6 +1660,7 @@ private:
     uint64_t _bytesRecvd;
 
     enum class WSState { HTTP, WS } _wsState;
+    static std::string toString(WSState t);
 
     /// True if we've received a Continue in response to an Expect: 100-continue
     bool _sentHTTPContinue;

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -164,10 +164,6 @@ public:
     /// Returns true if this socket has been closed, i.e. rejected from polling and potentially shutdown
     bool isClosed() const { return !_open; }
 
-    /// Create socket of the given type.
-    /// return >= 0 for a successfully created socket, -1 on error
-    static int createSocket(Type type);
-
     void setClientAddress(const std::string& address)
     {
         _clientAddress = address;
@@ -391,6 +387,10 @@ protected:
     void setClosed(SocketDisposition &disposition) { setClosed(); disposition.setClosed(); }
 
 private:
+    /// Create socket of the given type.
+    /// return >= 0 for a successfully created socket, -1 on error
+    static int createSocket(Type type);
+
     void init(Type type)
     {
         if (type != Type::Unix)

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -35,6 +35,7 @@
 #include "Util.hpp"
 #include "Buffer.hpp"
 #include "SigUtil.hpp"
+#include "NetUtil.hpp"
 
 #if MOBILEAPP
 #include "FakeSocket.hpp"
@@ -654,8 +655,6 @@ public:
 
     static std::unique_ptr<Watchdog> PollWatchdog;
 
-    /// Default poll time - useful to increase for debugging.
-    static constexpr std::chrono::microseconds DefaultPollTimeoutMicroS = std::chrono::seconds(64);
     static std::atomic<bool> InhibitThreadChecks;
 
     /// Stop the polling thread.
@@ -881,7 +880,7 @@ private:
     {
         while (continuePolling())
         {
-            poll(DefaultPollTimeoutMicroS);
+            poll(_pollTimeout);
         }
     }
 
@@ -923,6 +922,7 @@ private:
 
     /// Debug name used for logging.
     const std::string _name;
+    const std::chrono::microseconds _pollTimeout;
 
     /// main-loop wakeup pipe
     int _wakeup[2];
@@ -982,6 +982,8 @@ public:
     StreamSocket(std::string host, const int fd, Type type, bool /* isClient */,
                  ReadType readType = ReadType::NormalRead) :
         Socket(fd, type),
+        _pollTimeout( net::Defaults::get().SocketPollTimeout ),
+        _httpTimeout( net::Defaults::get().HTTPTimeout ),
         _hostname(std::move(host)),
         _bytesSent(0),
         _bytesRecvd(0),
@@ -1648,6 +1650,9 @@ protected:
 #endif
 
 private:
+    const std::chrono::microseconds _pollTimeout;
+    const std::chrono::microseconds _httpTimeout;
+
     /// The hostname (or IP) of the peer we are connecting to.
     const std::string _hostname;
 
@@ -1673,7 +1678,7 @@ private:
     ReadType _readType;
     std::atomic_bool _inputProcessingEnabled;
 
-    // Used in parseHeader, SocketPoll::DefaultPollTimeoutMicroS acting as max delay
+    // Used in parseHeader, net::Defaults::HTTPTimeout acting as max delay
     std::chrono::steady_clock::time_point _lastSeenHTTPHeader;
 };
 

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -1033,8 +1033,7 @@ public:
         _sentHTTPContinue(false),
         _shutdownSignalled(false),
         _readType(readType),
-        _inputProcessingEnabled(true),
-        _lastSeenHTTPHeader( std::chrono::steady_clock::now() )
+        _inputProcessingEnabled(true)
     {
         LOG_TRC("StreamSocket ctor");
     }
@@ -1351,6 +1350,7 @@ public:
     bool parseHeader(const char *clientLoggingName,
                      Poco::MemoryInputStream &message,
                      Poco::Net::HTTPRequest &request,
+                     std::chrono::steady_clock::time_point &lastHTTPHeader,
                      MessageMap& map);
 
     Buffer& getInBuffer() { return _inBuffer; }
@@ -1711,9 +1711,6 @@ private:
     std::vector<int> _incomingFDs;
     ReadType _readType;
     std::atomic_bool _inputProcessingEnabled;
-
-    // Used in parseHeader, net::Defaults::HTTPTimeout acting as max delay
-    std::chrono::steady_clock::time_point _lastSeenHTTPHeader;
 };
 
 enum class WSOpCode : unsigned char {

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -144,11 +144,15 @@ public:
 
     // NB. see other Socket::Socket by init below.
     Socket(Type type,
-           std::chrono::steady_clock::time_point /*creationTime*/ = std::chrono::steady_clock::now())
+           std::chrono::steady_clock::time_point creationTime = std::chrono::steady_clock::now())
         : _type(type)
         , _clientPort(0)
         , _fd(createSocket(type))
         , _open(_fd >= 0)
+        , _creationTime(creationTime)
+        , _lastSeenTime(_creationTime)
+        , _bytesSent(0)
+        , _bytesRcvd(0)
     {
         init();
     }
@@ -179,7 +183,30 @@ public:
     /// Returns the OS native socket fd.
     int getFD() const { return _fd; }
 
+    std::ostream& streamStats(std::ostream& os, const std::chrono::steady_clock::time_point &now) const;
+    std::string getStatsString(const std::chrono::steady_clock::time_point &now) const;
+
     virtual std::ostream& stream(std::ostream& os) const  { return streamImpl(os); }
+
+    /// Returns monotonic creation timestamp
+    std::chrono::steady_clock::time_point getCreationTime() const { return _creationTime; }
+    /// Returns monotonic timestamp of last received signal from remote
+    std::chrono::steady_clock::time_point getLastSeenTime() const { return _lastSeenTime; }
+
+    /// Sets monotonic timestamp of last received signal from remote
+    void setLastSeenTime(std::chrono::steady_clock::time_point now) { _lastSeenTime = now; }
+
+    /// Returns bytes sent statistic
+    uint64_t bytesSent() const { return _bytesSent; }
+    /// Returns bytes received statistic
+    uint64_t bytesRcvd() const { return _bytesRcvd; }
+
+    /// Get input/output statistics on this stream
+    void getIOStats(uint64_t &sent, uint64_t &recv) const
+    {
+        sent = _bytesSent;
+        recv = _bytesRcvd;
+    }
 
     /// Shutdown the socket.
     /// TODO: Support separate read/write shutdown.
@@ -373,16 +400,25 @@ protected:
     /// Construct based on an existing socket fd.
     /// Used by accept() only.
     Socket(const int fd, Type type,
-           std::chrono::steady_clock::time_point /*creationTime*/ = std::chrono::steady_clock::now())
+           std::chrono::steady_clock::time_point creationTime = std::chrono::steady_clock::now())
         : _type(type)
         , _clientPort(0)
         , _fd(fd)
         , _open(_fd >= 0)
+        , _creationTime(creationTime)
+        , _lastSeenTime(_creationTime)
+        , _bytesSent(0)
+        , _bytesRcvd(0)
     {
         init();
     }
 
     inline void logPrefix(std::ostream& os) const { os << '#' << _fd << ": "; }
+
+    /// Adds `len` sent bytes to statistic
+    void notifyBytesSent(uint64_t len) { _bytesSent += len; }
+    /// Adds `len` received bytes to statistic
+    void notifyBytesRcvd(uint64_t len) { _bytesRcvd += len; }
 
     /// avoid doing a shutdown before close
     void setNoShutdown() { _noShutdown = true; }
@@ -429,6 +465,11 @@ private:
     const int _fd;
     /// True if this socket is open.
     bool _open;
+
+    const std::chrono::steady_clock::time_point _creationTime;
+    std::chrono::steady_clock::time_point _lastSeenTime;
+    uint64_t _bytesSent;
+    uint64_t _bytesRcvd;
 
     // If _ignoreInput is true no more input from this socket will be processed.
     bool _ignoreInput;
@@ -988,8 +1029,6 @@ public:
         _pollTimeout( net::Defaults::get().SocketPollTimeout ),
         _httpTimeout( net::Defaults::get().HTTPTimeout ),
         _hostname(std::move(host)),
-        _bytesSent(0),
-        _bytesRecvd(0),
         _wsState(WSState::HTTP),
         _sentHTTPContinue(false),
         _shutdownSignalled(false),
@@ -1210,7 +1249,7 @@ public:
             {
                 LOG_ASSERT_MSG(len <= ssize_t(sizeof(buf)),
                                "Read more data than the buffer size");
-                _bytesRecvd += len;
+                notifyBytesRcvd(len);
                 _inBuffer.append(&buf[0], len);
             }
             // else poll will handle errors.
@@ -1232,7 +1271,7 @@ public:
             std::vector<char>buf(available);
             len = readData(buf.data(), available);
             assert(len == available);
-            _bytesRecvd += len;
+            notifyBytesRcvd(len);
             assert(_inBuffer.empty());
             _inBuffer.append(buf.data(), len);
         }
@@ -1313,13 +1352,6 @@ public:
                      Poco::MemoryInputStream &message,
                      Poco::Net::HTTPRequest &request,
                      MessageMap& map);
-
-    /// Get input/output statistics on this stream
-    void getIOStats(uint64_t &sent, uint64_t &recv)
-    {
-        sent = _bytesSent;
-        recv = _bytesRecvd;
-    }
 
     Buffer& getInBuffer() { return _inBuffer; }
 
@@ -1528,7 +1560,7 @@ public:
             {
                 LOG_ASSERT_MSG(len <= ssize_t(_outBuffer.size()),
                                "Consumed more data than available");
-                _bytesSent += len;
+                notifyBytesSent(len);
                 _outBuffer.eraseFirst(len);
             }
             else
@@ -1666,9 +1698,6 @@ private:
 
     Buffer _inBuffer;
     Buffer _outBuffer;
-
-    uint64_t _bytesSent;
-    uint64_t _bytesRecvd;
 
     enum class WSState : uint8_t { HTTP, WS } _wsState;
     static std::string toString(WSState t);

--- a/net/SslSocket.hpp
+++ b/net/SslSocket.hpp
@@ -24,7 +24,7 @@ class SslStreamSocket final : public StreamSocket
 {
 public:
     SslStreamSocket(const std::string& host, const int fd, Type type, bool isClient,
-                    ReadType readType = NormalRead)
+                    ReadType readType = ReadType::NormalRead)
         : StreamSocket(host, fd, type, isClient, readType)
         , _bio(nullptr)
         , _ssl(nullptr)

--- a/net/SslSocket.hpp
+++ b/net/SslSocket.hpp
@@ -24,8 +24,9 @@ class SslStreamSocket final : public StreamSocket
 {
 public:
     SslStreamSocket(const std::string& host, const int fd, Type type, bool isClient,
-                    ReadType readType = ReadType::NormalRead)
-        : StreamSocket(host, fd, type, isClient, readType)
+                    ReadType readType = ReadType::NormalRead,
+                    std::chrono::steady_clock::time_point creationTime = std::chrono::steady_clock::now())
+        : StreamSocket(host, fd, type, isClient, readType, creationTime)
         , _bio(nullptr)
         , _ssl(nullptr)
         , _sslWantsTo(SslWantsTo::Neither)

--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -246,6 +246,19 @@ public:
         shutdownImpl(statusCode, statusMessage, hardShutdown, false);
     }
 
+    /// Don't wait for the remote Websocket to handshake with us; go down fast.
+    void shutdownAfterWriting()
+    {
+        shutdownImpl(WebSocketHandler::StatusCodes::NORMAL_CLOSE, std::string(),
+                     true /* hard async shutdown & close */, false);
+    }
+
+    /// Returns true if the underlying socket is connected.
+    bool isConnected() const {
+        std::shared_ptr<StreamSocket> socket = _socket.lock();
+        return nullptr != socket && !socket->isClosed();
+    }
+
 private:
     void shutdownSilent()
     {
@@ -281,22 +294,6 @@ private:
 #endif
         _shuttingDown = false;
     }
-
-public:
-    /// Don't wait for the remote Websocket to handshake with us; go down fast.
-    void shutdownAfterWriting()
-    {
-        shutdownImpl(WebSocketHandler::StatusCodes::NORMAL_CLOSE, std::string(),
-                     true /* hard async shutdown & close */, false);
-    }
-
-    /// Returns true if the underlying socket is connected.
-    bool isConnected() const {
-        std::shared_ptr<StreamSocket> socket = _socket.lock();
-        return nullptr != socket && !socket->isClosed();
-    }
-
-private:
     bool handleTCPStream(const std::shared_ptr<StreamSocket>& socket)
     {
         assert(socket && "Expected a valid socket instance.");

--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -11,12 +11,14 @@
 
 #pragma once
 
+#include "NetUtil.hpp"
 #include "Socket.hpp"
 #include "common/Common.hpp"
 #include "common/Log.hpp"
 #include "common/Protocol.hpp"
 #include "common/Unit.hpp"
 #include "common/Util.hpp"
+#include <limits>
 #include <net/HttpRequest.hpp>
 
 #include <Poco/Net/HTTPResponse.h>
@@ -33,8 +35,10 @@ private:
     std::weak_ptr<StreamSocket> _socket;
 
 #if !MOBILEAPP
+    std::chrono::microseconds _pingPeriod;
+    std::chrono::duration<double, std::micro> _pingTimeout;
     std::chrono::steady_clock::time_point _lastPingSentTime;
-    int _pingTimeUs;
+    Util::TimeAverage _pingMicroS;
     bool _isMasking;
     bool _inFragmentBlock;
     /// The security key. Meaningful only for clients.
@@ -60,7 +64,6 @@ protected:
     };
 
     static constexpr std::chrono::microseconds InitialPingDelayMicroS = std::chrono::milliseconds(25);
-    static constexpr std::chrono::microseconds PingFrequencyMicroS = std::chrono::seconds(18);
 
 public:
     /// Perform upgrade ourselves, or select a client web socket.
@@ -71,10 +74,11 @@ public:
     WebSocketHandler(bool isClient, [[maybe_unused]] bool isMasking)
         :
 #if !MOBILEAPP
+        _pingPeriod(net::Defaults::get().WSPingPeriod),
+        _pingTimeout(net::Defaults::get().WSPingTimeout),
         _lastPingSentTime(std::chrono::steady_clock::now() -
-                          std::chrono::microseconds(PingFrequencyMicroS) +
+                          _pingPeriod +
                           std::chrono::microseconds(InitialPingDelayMicroS))
-        , _pingTimeUs(0)
         , _isMasking(isClient && isMasking)
         , _inFragmentBlock(false)
         , _key(isClient ? generateKey() : std::string())
@@ -408,10 +412,13 @@ private:
                     if (_isClient)
                         LOG_WRN("Servers should not send pongs, only clients");
 
-                    _pingTimeUs = std::chrono::duration_cast<std::chrono::microseconds>
-                        (std::chrono::steady_clock::now() - _lastPingSentTime).count();
-                    LOGA_TRC(WebSocket, "Pong received: " << _pingTimeUs << " microseconds");
-                    gotPing(code, _pingTimeUs);
+                    const auto now = std::chrono::steady_clock::now();
+                    const int64_t us = std::chrono::duration_cast<std::chrono::microseconds>
+                                          (now - _lastPingSentTime).count();
+                    const double avg_us = _pingMicroS.add(_lastPingSentTime, static_cast<double>(us));
+                    LOGA_TRC(WebSocket, "Pong received: " << us << "us, avg " << avg_us << "us over "
+                                         << (int)_pingMicroS.duration() << "s");
+                    gotPing(code, static_cast<int>(us));
                 }
                 break;
             case WSOpCode::Ping:
@@ -420,10 +427,12 @@ private:
                         LOG_DBG("Clients should not send pings, only servers");
 
                     const auto now = std::chrono::steady_clock::now();
-                    _pingTimeUs = std::chrono::duration_cast<std::chrono::microseconds>
-                                            (now - _lastPingSentTime).count();
+                    const int64_t us = std::chrono::duration_cast<std::chrono::microseconds>
+                                          (now - _lastPingSentTime).count();
+                    const double avg_us = _pingMicroS.add(_lastPingSentTime, static_cast<double>(us));
                     sendPong(now, &ctrlPayload[0], payloadLen, socket);
-                    gotPing(code, _pingTimeUs);
+                    LOGA_TRC(WebSocket, "Ping received: " << us << " us -> avg " << avg_us << " us");
+                    gotPing(code, static_cast<int>(us));
                 }
                 break;
             case WSOpCode::Close:
@@ -591,7 +600,7 @@ protected:
             const auto timeSincePingMicroS
                 = std::chrono::duration_cast<std::chrono::microseconds>(now - _lastPingSentTime);
             timeoutMaxMicroS
-                = std::min(timeoutMaxMicroS, (int64_t)(PingFrequencyMicroS - timeSincePingMicroS).count());
+                = std::min(timeoutMaxMicroS, (int64_t)(_pingPeriod - timeSincePingMicroS).count());
         }
 #endif
         int events = POLLIN;
@@ -602,7 +611,14 @@ protected:
 
 #if !MOBILEAPP
 private:
-    /// Send a ping message
+    /// Sets last ping sent and received time, avoiding a timout
+    void setPingPongTime(std::chrono::steady_clock::time_point now)
+    {
+        _lastPingSentTime = now;
+        _pingMicroS.moveTo(now);
+    }
+
+    /// Sends a native control-frame ping or pong message
     void sendPingOrPong(std::chrono::steady_clock::time_point now,
                         const char* data, const size_t len,
                         const WSOpCode code,
@@ -614,48 +630,61 @@ private:
         if (!socket->isWebSocket())
         {
             LOG_WRN("Attempted ping on non-upgraded websocket! #" << socket->getFD());
-            _lastPingSentTime = now; // Pretend we sent it to avoid timing out immediately.
+            setPingPongTime(now); // Pretend we sent it to avoid timing out immediately.
             return;
         }
-
-        LOGA_TRC(WebSocket, "Sending " << (const char*)(code == WSOpCode::Ping ? " ping" : "pong"));
+        LOGA_TRC(WebSocket, "Ping: Sending " << (code == WSOpCode::Ping ? "ping" : "pong") );
+        _lastPingSentTime = now;
         // FIXME: allow an empty payload.
         sendMessage(data, len, code, false);
-        _lastPingSentTime = now;
     }
 
 public:
+    /// Sends a native control-frame ping message
     void sendPing(std::chrono::steady_clock::time_point now,
                   const std::shared_ptr<StreamSocket>& socket)
     {
-//        assert(!_isClient);
+        if (_isClient)
+            LOG_DBG("Clients should not send pings, only servers");
         sendPingOrPong(now, "", 1, WSOpCode::Ping, socket);
     }
 
+    /// Sends a native control-frame pong message
     void sendPong(std::chrono::steady_clock::time_point now,
                   const char* data, const size_t len,
                   const std::shared_ptr<StreamSocket>& socket)
     {
+        if (!_isClient)
+            LOG_WRN("Servers should not send pongs, only clients");
         sendPingOrPong(now, data, len, WSOpCode::Pong, socket);
     }
 #endif
 
     /// Do we need to handle a timeout ?
-    void checkTimeout([[maybe_unused]] std::chrono::steady_clock::time_point now) override
+    bool checkTimeout([[maybe_unused]] std::chrono::steady_clock::time_point now) override
     {
 #if !MOBILEAPP
         if (_isClient)
-            return;
+            return false;
 
-        const auto timeSincePingMicroS
-            = std::chrono::duration_cast<std::chrono::microseconds>(now - _lastPingSentTime);
-        if (timeSincePingMicroS >= PingFrequencyMicroS)
+        if (_pingTimeout.count() > std::numeric_limits<double>::epsilon() &&
+            _pingMicroS.average() >= _pingTimeout.count())
+        {
+            LOG_WRN("CheckTimeout: Timeout websocket: Ping: last " << _pingMicroS.last() << "us, avg "
+                    << _pingMicroS.average() << "us >= " << _pingTimeout.count() << "us over "
+                    << (int)_pingMicroS.duration() << "s");
+            shutdownSilent();
+            return true;
+        }
+        if (!_pingMicroS.initialized() || (_pingPeriod > std::chrono::microseconds::zero() &&
+                                           now - _pingMicroS.lastTime() >= _pingPeriod))
         {
             const std::shared_ptr<StreamSocket> socket = _socket.lock();
             if (socket)
                 sendPing(now, socket);
         }
 #endif
+        return false;
     }
 
 public:
@@ -1068,7 +1097,7 @@ protected:
 #if !MOBILEAPP
         // No need to ping right upon connection/upgrade,
         // but do reset the time to avoid pinging immediately after.
-        _lastPingSentTime = std::chrono::steady_clock::now();
+        setPingPongTime(std::chrono::steady_clock::now());
 #endif
     }
 

--- a/test/HttpRequestTests.cpp
+++ b/test/HttpRequestTests.cpp
@@ -145,6 +145,7 @@ public:
     void setUp()
     {
         LOG_INF("HttpRequestTests::setUp");
+        std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
         std::shared_ptr<SocketFactory> factory = std::make_shared<ServerSocketFactory>();
         _port = 9990;
         for (int i = 0; i < 40; ++i, ++_port)
@@ -152,7 +153,7 @@ public:
             // Try listening on this port.
             LOG_INF("HttpRequestTests::setUp: creating socket to listen on port " << _port);
             _socket = ServerSocket::create(ServerSocket::Type::Local, _port, Socket::Type::IPv4,
-                                           _pollServerThread, factory);
+                                           now, _pollServerThread, factory);
             if (_socket)
                 break;
         }

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -91,6 +91,10 @@ all_la_unit_tests = \
 	unit-join-disconnect.la \
 	unit-initial-load-fail.la \
 	unit-timeout.la \
+	unit-timeout_socket.la \
+	unit-timeout_wsping.la \
+	unit-timeout_conn.la \
+	unit-timeout_none.la \
 	unit-base.la
 #	unit-admin.la
 #	unit-tilecache.la # Empty test.
@@ -223,6 +227,14 @@ unit_join_disconnect_la_SOURCES = UnitJoinDisconnect.cpp
 unit_join_disconnect_la_LIBADD = $(CPPUNIT_LIBS)
 unit_timeout_la_SOURCES = UnitTimeout.cpp
 unit_timeout_la_LIBADD = $(CPPUNIT_LIBS)
+unit_timeout_socket_la_SOURCES = UnitTimeoutSocket.cpp
+unit_timeout_socket_la_LIBADD = $(CPPUNIT_LIBS)
+unit_timeout_wsping_la_SOURCES = UnitTimeoutWSPing.cpp
+unit_timeout_wsping_la_LIBADD = $(CPPUNIT_LIBS)
+unit_timeout_conn_la_SOURCES = UnitTimeoutConnections.cpp
+unit_timeout_conn_la_LIBADD = $(CPPUNIT_LIBS)
+unit_timeout_none_la_SOURCES = UnitTimeoutNone.cpp
+unit_timeout_none_la_LIBADD = $(CPPUNIT_LIBS)
 unit_prefork_la_SOURCES = UnitPrefork.cpp
 unit_prefork_la_LIBADD = $(CPPUNIT_LIBS)
 unit_storage_la_SOURCES = UnitStorage.cpp

--- a/test/UnitPerf.cpp
+++ b/test/UnitPerf.cpp
@@ -57,6 +57,8 @@ void UnitPerf::testPerf(std::string testType, std::string fileType, std::string 
     stats = std::make_shared<Stats>();
     stats->setTypeOfTest(std::move(testType));
 
+    const std::chrono::microseconds PollTimeoutMicroS = net::Defaults::get().SocketPollTimeout;
+
     TerminatingPoll poll("performance test");
 
     std::string docName = "empty." + fileType;
@@ -72,7 +74,7 @@ void UnitPerf::testPerf(std::string testType, std::string fileType, std::string 
         stats);
 
     do {
-        poll.poll(TerminatingPoll::DefaultPollTimeoutMicroS);
+        poll.poll(PollTimeoutMicroS);
     } while (poll.continuePolling() && poll.getSocketCount() > 0);
 
     stats->dump();

--- a/test/UnitTimeoutBase.hpp
+++ b/test/UnitTimeoutBase.hpp
@@ -1,0 +1,404 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <config.h>
+
+#include <memory>
+#include <string>
+
+#include <HttpRequest.hpp>
+#include <Socket.hpp>
+
+#include <Poco/Util/LayeredConfiguration.h>
+#include <test/lokassert.hpp>
+
+#include <Unit.hpp>
+#include <UserMessages.hpp>
+#include <Util.hpp>
+#include <helpers.hpp>
+#include <vector>
+
+/// Base test suite class for timeout and connection limit using HTTP and WS sessions.
+class UnitTimeoutBase0 : public UnitWSD
+{
+public:
+    bool assertMessage(http::WebSocketSession &session, const std::string expectedPrefix, const std::string expectedId)
+    {
+        std::vector<char> res = session.poll(
+            [&](const std::vector<char>& message) -> bool
+            {
+                const std::string msg(std::string(message.begin(), message.end()));
+                TST_LOG("Got WS response: " << msg);
+                if (!msg.starts_with("error:"))
+                {
+                    if( expectedPrefix == "progress:") {
+                        LOK_ASSERT_EQUAL(COOLProtocol::matchPrefix(expectedPrefix, msg), true);
+                        LOK_ASSERT(helpers::getProgressWithIdValue(msg, expectedId));
+                        TST_LOG("Good WS response(0): " << msg);
+                        return true;
+                    } else if( msg.find(expectedId) != std::string::npos ) {
+                        // simple match
+                        TST_LOG("Good WS response(1): " << msg);
+                        return true;
+                    } else {
+                        const bool c = session.isConnected();
+                        TST_LOG("Some WS response(2): " << msg << ", connected " << c);
+                        return !c; // continue waiting for 'it' if still connected
+                    }
+                }
+                else
+                {
+                    // check error message
+                    LOK_ASSERT_EQUAL(std::string(SERVICE_UNAVAILABLE_INTERNAL_ERROR), msg);
+
+                    // close frame message
+                    return true;
+                }
+            },
+            std::chrono::seconds(10), testname);
+        return !res.empty();
+    };
+
+    template<typename SessionType>
+    bool pollDisconnected(std::chrono::microseconds timeout, SessionType &session, SocketPoll *syncSocketPoller=nullptr)
+    {
+        std::chrono::steady_clock::time_point t0 = std::chrono::steady_clock::now();
+        std::chrono::steady_clock::time_point t1 = t0;
+        while( t1 - t0 < timeout && session.isConnected() )
+        {
+            if( nullptr != syncSocketPoller )
+                syncSocketPoller->poll(std::chrono::microseconds(1000));
+            t1 = std::chrono::steady_clock::now();
+        }
+        return !session.isConnected();
+    }
+
+    template<typename SessionType>
+    bool pollDisconnected(std::chrono::microseconds timeout, std::vector<std::shared_ptr<SessionType>> &sessions, SocketPoll *syncSocketPoller=nullptr)
+    {
+        std::chrono::steady_clock::time_point t0 = std::chrono::steady_clock::now();
+        std::chrono::steady_clock::time_point t1 = t0;
+        while( 0<sessions.size() && t1 - t0 < timeout )
+        {
+            if( nullptr != syncSocketPoller )
+                syncSocketPoller->poll(std::chrono::microseconds(1000));
+            for (auto iter=sessions.begin(); iter != sessions.end(); )
+            {
+                std::shared_ptr<SessionType>& session = *iter;
+                if( !session->isConnected() )
+                    iter = sessions.erase(iter);
+                else
+                    ++iter;
+            }
+            t1 = std::chrono::steady_clock::now();
+        }
+        return sessions.empty();
+    }
+
+    UnitTimeoutBase0(const std::string& testname_)
+        : UnitWSD(testname_)
+    {
+    }
+};
+
+/// Base test suite class for timeout and connection limit using HTTP and WS sessions.
+class UnitTimeoutBase1 : public UnitTimeoutBase0
+{
+public:
+    TestResult testHttp(const size_t connectionLimit, const size_t connectionsCount);
+    TestResult testWSPing(const size_t connectionLimit, const size_t connectionsCount);
+    TestResult testWSDChatPing(const size_t connectionLimit, const size_t connectionsCount);
+
+    UnitTimeoutBase1(const std::string& testname_)
+        : UnitTimeoutBase0(testname_)
+    {
+    }
+};
+
+inline UnitBase::TestResult UnitTimeoutBase1::testHttp(const size_t connectionLimit, const size_t connectionsCount)
+{
+    setTestname(__func__);
+    TST_LOG("Starting Test: " << testname);
+
+    const size_t MaxConnections = std::min(connectionsCount, connectionLimit);
+    const std::string documentURL = "/favicon.ico";
+
+    constexpr bool UseOwnPoller = true;
+    constexpr bool PollerOnClientThread = true;
+    std::vector<std::shared_ptr<TerminatingPoll>> socketPollers;
+    std::vector<std::shared_ptr<http::Session>> sessions;
+
+    try
+    {
+        for(size_t sockIdx = 0; sockIdx < connectionsCount; ++sockIdx) {
+            std::shared_ptr<TerminatingPoll> socketPoller;
+            if( UseOwnPoller )
+            {
+                socketPoller = std::make_shared<TerminatingPoll>(testname);
+                if( PollerOnClientThread )
+                {
+                    socketPoller->runOnClientThread();
+                } else {
+                    socketPoller->startThread();
+                }
+                socketPollers.push_back(socketPoller);
+            }
+
+            std::shared_ptr<http::Session> session = http::Session::create(helpers::getTestServerURI());
+            sessions.push_back( session );
+            TST_LOG("Test: " << testname << "[" << sockIdx << "]: `" << documentURL << "`");
+            http::Request request(documentURL, http::Request::VERB_GET);
+            const std::shared_ptr<const http::Response> response =
+                session->syncRequest(request, UseOwnPoller ? *socketPoller : *socketPoll());
+            TST_LOG("Response: " << response->header().toString());
+            TST_LOG("Response size: " << testname << "[" << sockIdx << "]: `" << documentURL << "`: " << response->header().getContentLength());
+            if( session->isConnected() ) {
+                LOK_ASSERT_EQUAL(http::StatusCode::OK, response->statusCode());
+                LOK_ASSERT_EQUAL(true, session->isConnected());
+                LOK_ASSERT(http::Header::ConnectionToken::None ==
+                           response->header().getConnectionToken());
+                LOK_ASSERT(0 < response->header().getContentLength());
+            } else {
+                // connection limit hit
+                LOK_ASSERT_EQUAL(http::StatusCode::None, response->statusCode());
+                LOK_ASSERT_EQUAL(false, session->isConnected());
+            }
+        }
+    }
+    catch (const Poco::Exception& exc)
+    {
+        LOK_ASSERT_FAIL(exc.displayText());
+    }
+    size_t connected = 0;
+    for(size_t sockIdx = 0; sockIdx < connectionsCount; ++sockIdx) {
+        std::shared_ptr<http::Session> &session = sessions[sockIdx];
+        TST_LOG("SessionA " << sockIdx << ": connected " << session->isConnected());
+        if( session->isConnected() )
+        {
+            ++connected;
+            session->asyncShutdown();
+        }
+        if( UseOwnPoller ) {
+            std::shared_ptr<TerminatingPoll> socketPoller = socketPollers[sockIdx];
+            if( PollerOnClientThread )
+            {
+                socketPoller->closeAllSockets();
+            } else {
+                socketPoller->joinThread();
+            }
+        }
+    }
+    TST_LOG("Test: X01 Connected: " << connected << " / " << connectionsCount << ", limit " << connectionLimit);
+    // LOK_ASSERT_EQUAL(MaxConnections, connected);
+    LOK_ASSERT(MaxConnections-1 <= connected && connected <= MaxConnections+1);
+
+    TST_LOG("Clearing Sessions: " << testname);
+    sessions.clear();
+    TST_LOG("Clearing Poller: " << testname);
+    socketPollers.clear();
+    TST_LOG("Ending Test: " << testname);
+    return TestResult::Ok;
+}
+
+/// Test the native WebSocket control-frame ping/pong facility -> No Timeout!
+inline UnitBase::TestResult UnitTimeoutBase1::testWSPing(const size_t connectionLimit, const size_t connectionsCount)
+{
+    setTestname(__func__);
+    TST_LOG("Starting Test: " << testname);
+
+    const size_t maxConnections = std::min(connectionsCount, connectionLimit);
+    std::string documentPath, documentURL;
+    helpers::getDocumentPathAndURL("hello.odt", documentPath, documentURL, testname);
+
+    constexpr bool UseOwnPoller = true;
+    constexpr bool PollerOnClientThread = false;
+    std::vector<std::shared_ptr<TerminatingPoll>> socketPollers;
+    std::vector<std::shared_ptr<http::WebSocketSession>> sessions;
+
+    size_t connected0 = 0;
+    for(size_t sockIdx = 0; sockIdx < connectionsCount; ++sockIdx) {
+        std::shared_ptr<TerminatingPoll> socketPoller;
+        if( UseOwnPoller )
+        {
+            socketPoller = std::make_shared<TerminatingPoll>(testname);
+            if( PollerOnClientThread )
+            {
+                socketPoller->runOnClientThread();
+            } else {
+                socketPoller->startThread();
+            }
+            socketPollers.push_back(socketPoller);
+        }
+
+        std::shared_ptr<http::WebSocketSession> session = http::WebSocketSession::create(helpers::getTestServerURI());
+        sessions.push_back( session );
+        TST_LOG("Test: " << testname << "[" << sockIdx << "]: `" << documentURL << "`");
+        http::Request req(documentURL);
+        session->asyncRequest(req, UseOwnPoller ? socketPoller : socketPoll());
+        session->sendMessage("load url=" + documentURL);
+
+        TST_LOG("Test: XX0 " << testname << "[" << sockIdx << "]: connected " << session->isConnected());
+        if( sockIdx < maxConnections ) {
+            LOK_ASSERT_EQUAL(true, session->isConnected());
+
+            assertMessage(*session, "progress:", "find");
+            assertMessage(*session, "progress:", "connect");
+            assertMessage(*session, "progress:", "ready");
+
+            TST_LOG("Test: XX1 " << testname << "[" << sockIdx << "]: connected " << session->isConnected());
+            LOK_ASSERT_EQUAL(true, session->isConnected());
+            ++connected0;
+        } else {
+            // Perform actual communication attempt, required to fail (disconnect)
+            TST_LOG("Test: XX2 " << testname << "[" << sockIdx << "]: connected " << session->isConnected());
+            bool comRes=false;
+            if( session->isConnected() )
+            {
+                comRes=assertMessage(*session, "progress:", "find");
+                if( session->isConnected() )
+                    ++connected0;
+            }
+            TST_LOG("Test: XX3 " << testname << "[" << sockIdx << "]: connected "
+                    << session->isConnected() << "/" << connected0 << ", com " << comRes);
+            LOK_ASSERT_EQUAL(false, comRes);
+            LOK_ASSERT_EQUAL(false, session->isConnected());
+        }
+    }
+    TST_LOG("Test: X01 Connected: " << connected0 << " / " << connectionsCount << ", limit " << connectionLimit);
+
+    size_t connected = 0;
+    for(size_t sockIdx = 0; sockIdx < connectionsCount; ++sockIdx) {
+        std::shared_ptr<http::WebSocketSession> wsSession = sessions[sockIdx];
+        TST_LOG("SessionA " << sockIdx << ": connected " << wsSession->isConnected());
+        if( wsSession->isConnected() )
+        {
+            ++connected;
+            // wsSession->asyncShutdown();
+            wsSession->shutdownWS();
+        }
+        if( UseOwnPoller ) {
+            std::shared_ptr<TerminatingPoll> socketPoller = socketPollers[sockIdx];
+            if( PollerOnClientThread )
+            {
+                socketPoller->closeAllSockets();
+            } else {
+                socketPoller->joinThread();
+            }
+        }
+    }
+    // 5 x Limiter hits occurred!
+    TST_LOG("Test: X02 Connected: " << connected << " / " << connectionsCount << ", limit " << connectionLimit);
+    LOK_ASSERT(maxConnections-1 <= connected && connected <= maxConnections+1);
+
+    TST_LOG("Clearing Sessions: " << testname);
+    sessions.clear();
+    TST_LOG("Clearing Poller: " << testname);
+    socketPollers.clear();
+    TST_LOG("Ending Test: " << testname);
+    return TestResult::Ok;
+}
+
+/// Tests the WSD chat ping/pong facility, where client sends the ping.
+/// See: https://github.com/CollaboraOnline/online/blob/master/wsd/protocol.txt/
+inline UnitBase::TestResult UnitTimeoutBase1::testWSDChatPing(const size_t connectionLimit, const size_t connectionsCount)
+{
+    setTestname(__func__);
+    TST_LOG("Starting Test: " << testname);
+
+    const size_t maxConnections = std::min(connectionsCount, connectionLimit);
+    std::string documentPath, documentURL;
+    helpers::getDocumentPathAndURL("hello.odt", documentPath, documentURL, testname);
+
+    constexpr bool UseOwnPoller = true;
+    constexpr bool PollerOnClientThread = false;
+    std::vector<std::shared_ptr<TerminatingPoll>> socketPollers;
+    std::vector<std::shared_ptr<http::WebSocketSession>> sessions;
+
+    for(size_t sockIdx = 0; sockIdx < connectionsCount; ++sockIdx) {
+        std::shared_ptr<TerminatingPoll> socketPoller;
+        if( UseOwnPoller )
+        {
+            socketPoller = std::make_shared<TerminatingPoll>(testname);
+            if( PollerOnClientThread )
+            {
+                socketPoller->runOnClientThread();
+            } else {
+                socketPoller->startThread();
+            }
+            socketPollers.push_back(socketPoller);
+        }
+
+        std::shared_ptr<http::WebSocketSession> session = http::WebSocketSession::create(helpers::getTestServerURI());
+        sessions.push_back( session );
+        TST_LOG("Test: " << testname << "[" << sockIdx << "]: `" << documentURL << "`");
+        http::Request req(documentURL);
+        session->asyncRequest(req, UseOwnPoller ? socketPoller : socketPoll());
+        session->sendMessage("load url=" + documentURL);
+
+        TST_LOG("Test: XX0 " << testname << "[" << sockIdx << "]: connected " << session->isConnected());
+        if( sockIdx < maxConnections-1 ) {
+            LOK_ASSERT_EQUAL(true, session->isConnected());
+
+            assertMessage(*session, "progress:", "find");
+            assertMessage(*session, "progress:", "connect");
+            assertMessage(*session, "progress:", "ready");
+
+            TST_LOG("Test: XX1 " << testname << "[" << sockIdx << "]: connected " << session->isConnected());
+            // LOK_ASSERT_EQUAL(true, wsSession->isConnected());
+        } else {
+            TST_LOG("Test: XX2 " << testname << "[" << sockIdx << "]: connected " << session->isConnected());
+            // LOK_ASSERT_EQUAL(false, wsSession->isConnected());
+        }
+    }
+    for(size_t sockIdx = 0; sockIdx < connectionsCount; ++sockIdx) {
+        std::shared_ptr<http::WebSocketSession> wsSession = sessions[sockIdx];
+        TST_LOG("Test: XX3a " << testname << "[" << sockIdx << "]: connected " << wsSession->isConnected());
+        if( wsSession->isConnected() )
+        {
+            wsSession->sendMessage("ping");
+            TST_LOG("Test: XX3b " << testname << "[" << sockIdx << "]: connected " << wsSession->isConnected());
+            assertMessage(*wsSession, "", "pong");
+            TST_LOG("Test: XX3c " << testname << "[" << sockIdx << "]: connected " << wsSession->isConnected());
+        }
+    }
+
+    size_t connected = 0;
+    for(size_t sockIdx = 0; sockIdx < connectionsCount; ++sockIdx) {
+        std::shared_ptr<http::WebSocketSession> wsSession = sessions[sockIdx];
+        TST_LOG("SessionA " << sockIdx << ": connected " << wsSession->isConnected());
+        if( wsSession->isConnected() )
+        {
+            ++connected;
+            wsSession->shutdownWS();
+        }
+        if( UseOwnPoller ) {
+            std::shared_ptr<TerminatingPoll> socketPoller = socketPollers[sockIdx];
+            if( PollerOnClientThread )
+            {
+                socketPoller->closeAllSockets();
+            } else {
+                socketPoller->joinThread();
+            }
+        }
+    }
+    // 5 x Limiter hits occurred!
+    TST_LOG("Test: X01 Connected: " << connected << " / " << connectionsCount << ", limit " << connectionLimit);
+    LOK_ASSERT(maxConnections-1 <= connected && connected <= maxConnections+1);
+
+    TST_LOG("Clearing Sessions: " << testname);
+    sessions.clear();
+    TST_LOG("Clearing Poller: " << testname);
+    socketPollers.clear();
+    TST_LOG("Ending Test: " << testname);
+    return TestResult::Ok;
+}
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/test/UnitTimeoutConnections.cpp
+++ b/test/UnitTimeoutConnections.cpp
@@ -1,0 +1,76 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <config.h>
+
+#include <string>
+
+#include <HttpRequest.hpp>
+#include <Socket.hpp>
+
+#include <Poco/Util/LayeredConfiguration.h>
+#include <test/lokassert.hpp>
+
+#include <Unit.hpp>
+#include <UserMessages.hpp>
+#include <Util.hpp>
+#include <helpers.hpp>
+
+#include "UnitTimeoutBase.hpp"
+
+static constexpr size_t ConnectionLimit = 5;
+static constexpr size_t ConnectionCount = 9;
+
+/// Base test suite class for connection limit (limited) using HTTP and WS sessions.
+class UnitTimeoutConnections : public UnitTimeoutBase1
+{
+    void configure(net::Defaults& defaults) override
+    {
+        // defaults.WSPingTimeout = std::chrono::microseconds(2000000);
+        // defaults.WSPingPeriod = std::chrono::microseconds(3000000);
+        // defaults.HTTPTimeout = std::chrono::microseconds(30000000);
+        // defaults.MaxConnections = 9999;
+        defaults.MaxConnections = ConnectionLimit;
+        // defaults.MinBytesPerSec = 0.0;
+        // defaults.SocketPollTimeout = std::chrono::microseconds(64000000);
+    }
+
+public:
+    UnitTimeoutConnections()
+        : UnitTimeoutBase1("UnitTimeoutConnections")
+    {
+    }
+
+    void invokeWSDTest() override;
+};
+
+void UnitTimeoutConnections::invokeWSDTest()
+{
+    UnitBase::TestResult result = TestResult::Ok;
+
+    result = testHttp(ConnectionLimit, ConnectionCount);
+    if (result != TestResult::Ok)
+        exitTest(result);
+
+    result = testWSPing(ConnectionLimit, ConnectionCount);
+    if (result != TestResult::Ok)
+        exitTest(result);
+
+    result = testWSDChatPing(ConnectionLimit, ConnectionCount);
+    if (result != TestResult::Ok)
+        exitTest(result);
+
+    exitTest(TestResult::Ok);
+}
+
+UnitBase* unit_create_wsd(void) { return new UnitTimeoutConnections(); }
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/test/UnitTimeoutNone.cpp
+++ b/test/UnitTimeoutNone.cpp
@@ -1,0 +1,76 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <config.h>
+
+#include <string>
+
+#include <HttpRequest.hpp>
+#include <Socket.hpp>
+
+#include <test/lokassert.hpp>
+
+#include <Unit.hpp>
+#include <UserMessages.hpp>
+#include <Util.hpp>
+#include <helpers.hpp>
+
+#include "UnitTimeoutBase.hpp"
+
+static constexpr size_t ConnectionLimit = 9999;
+static constexpr size_t ConnectionCount = 9;
+
+/// Base test suite class for connection limit (no limits) using HTTP and WS sessions.
+class UnitTimeoutNone : public UnitTimeoutBase1
+{
+    void configure(net::Defaults& /* defaults */) override
+    {
+        // Keep original values -> No timeout
+        // defaults.WSPingTimeout = std::chrono::microseconds(2000000);
+        // defaults.WSPingPeriod = std::chrono::microseconds(3000000);
+        // defaults.HTTPTimeout = std::chrono::microseconds(30000000);
+        // defaults.MaxConnections = 9999;
+        // defaults.MaxConnections = ConnectionLimit;
+        // defaults.MinBytesPerSec = 0.0;
+        // defaults.SocketPollTimeout = std::chrono::microseconds(64000000);
+    }
+
+public:
+    UnitTimeoutNone()
+        : UnitTimeoutBase1("UnitTimeoutNone")
+    {
+    }
+
+    void invokeWSDTest() override;
+};
+
+void UnitTimeoutNone::invokeWSDTest()
+{
+    UnitBase::TestResult result;
+
+    result = testHttp(ConnectionLimit, ConnectionCount);
+    if (result != TestResult::Ok)
+        exitTest(result);
+
+    result = testWSPing(ConnectionLimit, ConnectionCount);
+    if (result != TestResult::Ok)
+        exitTest(result);
+
+    result = testWSDChatPing(ConnectionLimit, ConnectionCount);
+    if (result != TestResult::Ok)
+        exitTest(result);
+
+    exitTest(TestResult::Ok);
+}
+
+UnitBase* unit_create_wsd(void) { return new UnitTimeoutNone(); }
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/test/UnitTimeoutSocket.cpp
+++ b/test/UnitTimeoutSocket.cpp
@@ -1,0 +1,192 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <config.h>
+
+#include <memory>
+#include <string>
+
+#include <HttpRequest.hpp>
+#include <Socket.hpp>
+
+#include <Poco/Util/LayeredConfiguration.h>
+#include <test/lokassert.hpp>
+
+#include <Unit.hpp>
+#include <UserMessages.hpp>
+#include <Util.hpp>
+#include <helpers.hpp>
+#include <vector>
+
+#include "UnitTimeoutBase.hpp"
+
+/// Test suite class for Socket max-duration timeout limit using HTTP and WS sessions.
+class UnitTimeoutSocket : public UnitTimeoutBase0
+{
+    TestResult testHttp();
+    TestResult testWSPing();
+    TestResult testWSDChatPing();
+
+    void configure(net::Defaults& defaults) override
+    {
+        // defaults.WSPingTimeout = std::chrono::microseconds(2000000);
+        // defaults.WSPingPeriod = std::chrono::microseconds(3000000);
+        // defaults.HTTPTimeout = std::chrono::microseconds(30000000);
+        // defaults.HTTPTimeout = std::chrono::microseconds(1);
+        // defaults.MaxConnections = 9999;
+        // defaults.MinBytesPerSec = 0.0;
+        defaults.MinBytesPerSec = 100000.0; // 100kBps
+        // defaults.SocketPollTimeout = std::chrono::microseconds(64000000);
+    }
+
+public:
+    UnitTimeoutSocket()
+        : UnitTimeoutBase0("UnitTimeoutSocket")
+    {
+    }
+
+    void invokeWSDTest() override;
+};
+
+UnitBase::TestResult UnitTimeoutSocket::testHttp()
+{
+    setTestname(__func__);
+    TST_LOG("Starting Test: " << testname);
+
+    const std::string documentURL = "/favicon.ico";
+
+    // Keep alive socket, avoid forced socket disconnect via dtor
+    TerminatingPoll socketPoller(testname);
+    socketPoller.runOnClientThread();
+
+    const int sockCount = 4;
+    // Reused http session, keep-alive
+    std::vector<std::shared_ptr<http::Session>> sessions;
+
+    try
+    {
+        for(int sockIdx = 0; sockIdx < sockCount; ++sockIdx) {
+            sessions.push_back( http::Session::create(helpers::getTestServerURI()) );
+            TST_LOG("Test: " << testname << "[" << sockIdx << "]: `" << documentURL << "`");
+            http::Request request(documentURL, http::Request::VERB_GET);
+            const std::shared_ptr<const http::Response> response =
+                sessions[sockIdx]->syncRequest(request, socketPoller);
+            TST_LOG("Response: " << response->header().toString());
+            TST_LOG("Response size: " << testname << "[" << sockIdx << "]: `" << documentURL << "`: " << response->header().getContentLength());
+            LOK_ASSERT_EQUAL(http::StatusCode::OK, response->statusCode());
+            LOK_ASSERT_EQUAL(true, sessions[sockIdx]->isConnected());
+            LOK_ASSERT(http::Header::ConnectionToken::None ==
+                       response->header().getConnectionToken());
+            LOK_ASSERT(0 < response->header().getContentLength());
+        }
+    }
+    catch (const Poco::Exception& exc)
+    {
+        LOK_ASSERT_FAIL(exc.displayText());
+    }
+    LOK_ASSERT_EQUAL(true, pollDisconnected(std::chrono::microseconds(1000000), sessions, &socketPoller));
+
+    TST_LOG("Clearing Sessions: " << testname);
+    sessions.clear();
+    TST_LOG("Clearing Poller: " << testname);
+    socketPoller.closeAllSockets();
+    TST_LOG("Ending Test: " << testname);
+    return TestResult::Ok;
+}
+
+/// Test the native WebSocket control-frame ping/pong facility -> No Timeout!
+UnitBase::TestResult UnitTimeoutSocket::testWSPing()
+{
+    setTestname(__func__);
+    TST_LOG("Starting Test: " << testname);
+
+    std::string documentPath, documentURL;
+    helpers::getDocumentPathAndURL("hello.odt", documentPath, documentURL, testname);
+
+    std::shared_ptr<http::WebSocketSession> session = http::WebSocketSession::create(helpers::getTestServerURI());
+    http::Request req(documentURL);
+    session->asyncRequest(req, socketPoll());
+
+    // wsd/ClientSession.cpp:709 sendTextFrameAndLogError("error: cmd=" + tokens[0] + " kind=nodocloaded");
+    constexpr const bool loadDoc = true; // Required for WSD chat -> wsd/ClientSession.cpp:709, common/Session.hpp:160
+    if( loadDoc ) {
+        session->sendMessage("load url=" + documentURL);
+    }
+
+    LOK_ASSERT_EQUAL(true, session->isConnected());
+
+    assertMessage(*session, "progress:", "find");
+    assertMessage(*session, "progress:", "connect");
+    assertMessage(*session, "progress:", "ready");
+
+    LOK_ASSERT_EQUAL(true, pollDisconnected(std::chrono::microseconds(1000000), *session));
+
+    TST_LOG("Ending Test: " << testname);
+    return TestResult::Ok;
+}
+
+/// Tests the WSD chat ping/pong facility, where client sends the ping.
+/// See: https://github.com/CollaboraOnline/online/blob/master/wsd/protocol.txt/
+UnitBase::TestResult UnitTimeoutSocket::testWSDChatPing()
+{
+    setTestname(__func__);
+    TST_LOG("Starting Test: " << testname);
+
+    std::string documentPath, documentURL;
+    helpers::getDocumentPathAndURL("hello.odt", documentPath, documentURL, testname);
+
+    std::shared_ptr<http::WebSocketSession> session = http::WebSocketSession::create(helpers::getTestServerURI());
+    http::Request req(documentURL);
+    session->asyncRequest(req, socketPoll());
+
+    // wsd/ClientSession.cpp:709 sendTextFrameAndLogError("error: cmd=" + tokens[0] + " kind=nodocloaded");
+    constexpr const bool loadDoc = true; // Required for WSD chat -> wsd/ClientSession.cpp:709, common/Session.hpp:160
+    if( loadDoc ) {
+        session->sendMessage("load url=" + documentURL);
+    }
+
+    LOK_ASSERT_EQUAL(true, session->isConnected());
+
+    assertMessage(*session, "progress:", "find");
+    assertMessage(*session, "progress:", "connect");
+    assertMessage(*session, "progress:", "ready");
+
+    session->sendMessage("ping");
+    assertMessage(*session, "", "pong");
+
+    LOK_ASSERT_EQUAL(true, pollDisconnected(std::chrono::microseconds(1000000), *session));
+
+    TST_LOG("Ending Test: " << testname);
+    return TestResult::Ok;
+}
+
+void UnitTimeoutSocket::invokeWSDTest()
+{
+    UnitBase::TestResult result = TestResult::Ok;
+
+    result = testHttp();
+    if (result != TestResult::Ok)
+        exitTest(result);
+
+    result = testWSPing();
+    if (result != TestResult::Ok)
+        exitTest(result);
+
+    result = testWSDChatPing();
+    if (result != TestResult::Ok)
+        exitTest(result);
+
+    exitTest(TestResult::Ok);
+}
+
+UnitBase* unit_create_wsd(void) { return new UnitTimeoutSocket(); }
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/test/UnitTimeoutWSPing.cpp
+++ b/test/UnitTimeoutWSPing.cpp
@@ -1,0 +1,101 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <config.h>
+
+#include <memory>
+#include <string>
+
+#include <HttpRequest.hpp>
+#include <Socket.hpp>
+
+#include <Poco/Util/LayeredConfiguration.h>
+#include <test/lokassert.hpp>
+
+#include <Unit.hpp>
+#include <UserMessages.hpp>
+#include <Util.hpp>
+#include <helpers.hpp>
+
+#include "UnitTimeoutBase.hpp"
+
+/// Test suite class for WS Ping (native frame) timeout limit using a WS sessions.
+class UnitTimeoutWSPing : public UnitTimeoutBase0
+{
+    TestResult testWSPing();
+
+    void configure(net::Defaults& defaults) override
+    {
+        // defaults.WSPingTimeout = std::chrono::microseconds(2000000);
+        // defaults.WSPingPeriod = std::chrono::microseconds(3000000);
+        defaults.WSPingTimeout = std::chrono::microseconds(20);
+        defaults.WSPingPeriod = std::chrono::microseconds(10000);
+        // defaults.HTTPTimeout = std::chrono::microseconds(30000000);
+        // defaults.MaxConnections = 9999;
+        // defaults.MinBytesPerSec = 0.0;
+        // defaults.SocketPollTimeout = std::chrono::microseconds(64000000);
+    }
+
+public:
+    UnitTimeoutWSPing()
+        : UnitTimeoutBase0("UnitTimeoutWSPing")
+    {
+    }
+
+    void invokeWSDTest() override;
+};
+
+/// Attempt to test the native WebSocket control-frame ping/pong facility -> Timeout!
+UnitBase::TestResult UnitTimeoutWSPing::testWSPing()
+{
+    setTestname(__func__);
+    TST_LOG("Starting Test: " << testname);
+
+    std::string documentPath, documentURL;
+    helpers::getDocumentPathAndURL("hello.odt", documentPath, documentURL, testname);
+
+    // NOTE: Do not replace with wrappers. This has to be explicit.
+    std::shared_ptr<http::WebSocketSession> session = http::WebSocketSession::create(helpers::getTestServerURI());
+    http::Request req(documentURL);
+    session->asyncRequest(req, socketPoll());
+
+    // wsd/ClientSession.cpp:709 sendTextFrameAndLogError("error: cmd=" + tokens[0] + " kind=nodocloaded");
+    constexpr const bool loadDoc = true; // Required for WSD chat -> wsd/ClientSession.cpp:709, common/Session.hpp:160
+    if( loadDoc ) {
+        session->sendMessage("load url=" + documentURL);
+    }
+
+    LOK_ASSERT_EQUAL(true, session->isConnected());
+
+    assertMessage(*session, "progress:", "find");
+    assertMessage(*session, "progress:", "connect");
+    assertMessage(*session, "progress:", "ready");
+
+    LOK_ASSERT_EQUAL(true, pollDisconnected(std::chrono::microseconds(1000000), *session));
+
+    TST_LOG("Ending Test: " << testname);
+    return TestResult::Ok;
+}
+
+void UnitTimeoutWSPing::invokeWSDTest()
+{
+    UnitBase::TestResult result;
+
+    result = testWSPing();
+    if (result != TestResult::Ok)
+        exitTest(result);
+
+    exitTest(TestResult::Ok);
+}
+
+UnitBase* unit_create_wsd(void) { return new UnitTimeoutWSPing(); }
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/tools/Stress.cpp
+++ b/tools/Stress.cpp
@@ -89,6 +89,8 @@ int Stress::main(const std::vector<std::string>& args)
     }
 #endif
 
+    const std::chrono::microseconds PollTimeoutMicroS = net::Defaults::get().SocketPollTimeout;
+
     std::string server = args[0];
 
     if (!strncmp(server.c_str(), "http", 4))
@@ -104,7 +106,7 @@ int Stress::main(const std::vector<std::string>& args)
         StressSocketHandler::addPollFor(poll, server, args[i], args[i+1], stats);
 
     do {
-        poll.poll(TerminatingPoll::DefaultPollTimeoutMicroS);
+        poll.poll(PollTimeoutMicroS);
     } while (poll.continuePolling() && poll.getSocketCount() > 0);
 
     stats->dump();

--- a/tools/WebSocketDump.cpp
+++ b/tools/WebSocketDump.cpp
@@ -264,7 +264,9 @@ int main (int argc, char **argv)
 
     // Setup listening socket with a factory for connected sockets.
     auto serverSocket = std::make_shared<ServerSocket>(
-        Socket::Type::All, DumpSocketPoll,
+        Socket::Type::All,
+        std::chrono::steady_clock::now(),
+        DumpSocketPoll,
         std::make_shared<DumpSocketFactory>(isSSL));
 
     if (!serverSocket->bind(ServerSocket::Type::Public, port))

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -3865,7 +3865,7 @@ private:
 
             _pid = pid;
             _socketFD = socket->getFD();
-            child->setSMapsFD(socket->getIncomingFD(SMAPS));
+            child->setSMapsFD(socket->getIncomingFD(SharedFDType::SMAPS));
             _childProcess = child; // weak
 
             addNewChild(std::move(child));

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -922,8 +922,8 @@ std::shared_ptr<ChildProcess> getNewChild_Blocks(SocketPoll &destPoll, unsigned 
 class InotifySocket : public Socket
 {
 public:
-    InotifySocket():
-        Socket(inotify_init1(IN_NONBLOCK), Socket::Type::Unix)
+    InotifySocket(std::chrono::steady_clock::time_point creationTime):
+        Socket(inotify_init1(IN_NONBLOCK), Socket::Type::Unix, creationTime)
         , m_stopOnConfigChange(true)
     {
         if (getFD() == -1)
@@ -4185,7 +4185,8 @@ private:
     {
         std::shared_ptr<SocketFactory> factory = std::make_shared<PrisonerSocketFactory>();
 #if !MOBILEAPP
-        auto socket = std::make_shared<LocalServerSocket>(*PrisonerPoll, factory);
+        auto socket = std::make_shared<LocalServerSocket>(
+                        std::chrono::steady_clock::now(), *PrisonerPoll, factory);
 
         const std::string location = socket->bind();
         if (!location.length())
@@ -4214,7 +4215,7 @@ private:
         constexpr int DEFAULT_MASTER_PORT_NUMBER = 9981;
         std::shared_ptr<ServerSocket> socket
             = ServerSocket::create(ServerSocket::Type::Public, DEFAULT_MASTER_PORT_NUMBER,
-                                   ClientPortProto, *PrisonerPoll, factory);
+                                   ClientPortProto, std::chrono::steady_clock::now(), *PrisonerPoll, factory);
 
         COOLWSD::prisonerServerSocketFD = socket->getFD();
         LOG_INF("Listening to prisoner connections on #" << COOLWSD::prisonerServerSocketFD);
@@ -4226,6 +4227,7 @@ private:
     std::shared_ptr<ServerSocket> findServerPort()
     {
         std::shared_ptr<SocketFactory> factory;
+        std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
 
         if (ClientPortNumber <= 0)
         {
@@ -4242,7 +4244,7 @@ private:
             factory = std::make_shared<PlainSocketFactory>();
 
         std::shared_ptr<ServerSocket> socket = ServerSocket::create(
-            ClientListenAddr, ClientPortNumber, ClientPortProto, *WebServerPoll, factory);
+            ClientListenAddr, ClientPortNumber, ClientPortProto, now, *WebServerPoll, factory);
 
         const int firstPortNumber = ClientPortNumber;
         while (!socket &&
@@ -4257,7 +4259,7 @@ private:
             LOG_INF("Client port " << (ClientPortNumber - 1) << " is busy, trying "
                                    << ClientPortNumber);
             socket = ServerSocket::create(ClientListenAddr, ClientPortNumber, ClientPortProto,
-                                          *WebServerPoll, factory);
+                                          now, *WebServerPoll, factory);
         }
 
         if (!socket)
@@ -4554,7 +4556,7 @@ int COOLWSD::innerMain()
 
 #ifdef __linux__
     if (getConfigValue<bool>("stop_on_config_change", false)) {
-        std::shared_ptr<InotifySocket> inotifySocket = std::make_shared<InotifySocket>();
+        std::shared_ptr<InotifySocket> inotifySocket = std::make_shared<InotifySocket>(startStamp);
         mainWait.insertNewSocket(inotifySocket);
     }
 #endif

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -595,6 +595,7 @@ void ClientRequestDispatcher::onConnect(const std::shared_ptr<StreamSocket>& soc
 {
     _id = COOLWSD::GetConnectionId();
     _socket = socket;
+    _lastSeenHTTPHeader = socket->getLastSeenTime();
     setLogContext(socket->getFD());
     LOG_TRC("Connected to ClientRequestDispatcher");
 }
@@ -664,7 +665,7 @@ void ClientRequestDispatcher::handleIncomingMessage(SocketDisposition& dispositi
     Poco::Net::HTTPRequest request;
 
     StreamSocket::MessageMap map;
-    if (!socket->parseHeader("Client", startmessage, request, map))
+    if (!socket->parseHeader("Client", startmessage, request, _lastSeenHTTPHeader, map))
         return;
 
     const bool closeConnection = !request.getKeepAlive(); // HTTP/1.1: closeConnection true w/ "Connection: close" only!

--- a/wsd/ClientRequestDispatcher.hpp
+++ b/wsd/ClientRequestDispatcher.hpp
@@ -119,6 +119,9 @@ private:
     std::weak_ptr<StreamSocket> _socket;
     std::string _id;
 
+    // Used for StreamSocket::parseHeader, net::Defaults::HTTPTimeout acting as max delay
+    std::chrono::steady_clock::time_point _lastSeenHTTPHeader;
+
 #if !MOBILEAPP
     /// WASM document request handler. Used only when WASM is enabled.
     std::unique_ptr<WopiProxy> _wopiProxy;

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -140,6 +140,7 @@ public:
         TerminatingPoll(threadName),
         _docBroker(docBroker)
     {
+        setLimiter( net::Defaults::get().MaxConnections );
     }
 
     void pollingThread() override

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -38,6 +38,7 @@
 #include "Exceptions.hpp"
 #include "COOLWSD.hpp"
 #include "FileServer.hpp"
+#include <NetUtil.hpp>
 #include "Socket.hpp"
 #include "Storage.hpp"
 #include "TileCache.hpp"
@@ -363,14 +364,14 @@ void DocumentBroker::pollThread()
     std::chrono::time_point<std::chrono::steady_clock> migrationMsgStartTime;
     static const std::chrono::microseconds migrationMsgTimeout = std::chrono::seconds(
         COOLWSD::getConfigValue<int>("indirection_endpoint.migration_timeout_secs", 180));
+    const std::chrono::microseconds PollTimeoutMicroS = net::Defaults::get().SocketPollTimeout;
 
     // Main polling loop goodness.
     while (!_stop && _poll->continuePolling() && !SigUtil::getTerminationFlag())
     {
         // Poll more frequently while unloading to cleanup sooner.
         const bool unloading = isMarkedToDestroy() || _docState.isUnloadRequested();
-        _poll->poll(unloading ? SocketPoll::DefaultPollTimeoutMicroS / 16
-                              : SocketPoll::DefaultPollTimeoutMicroS);
+        _poll->poll(unloading ? PollTimeoutMicroS / 16 : PollTimeoutMicroS);
 
         // Consolidate updates across multiple processed events.
         processBatchUpdates();

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -98,8 +98,8 @@ public:
         , _jailId(jailId)
         , _smapsFD(-1)
     {
-        int urpFromKitFD = socket->getIncomingFD(URPFromKit);
-        int urpToKitFD = socket->getIncomingFD(URPToKit);
+        int urpFromKitFD = socket->getIncomingFD(SharedFDType::URPFromKit);
+        int urpToKitFD = socket->getIncomingFD(SharedFDType::URPToKit);
         if (urpFromKitFD != -1 && urpToKitFD != -1)
         {
             _urpFromKit = StreamSocket::create<StreamSocket>(

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -102,12 +102,15 @@ public:
         int urpToKitFD = socket->getIncomingFD(SharedFDType::URPToKit);
         if (urpFromKitFD != -1 && urpToKitFD != -1)
         {
+            std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
             _urpFromKit = StreamSocket::create<StreamSocket>(
                 std::string(), urpFromKitFD, Socket::Type::Unix,
-                false, std::make_shared<UrpHandler>(this));
+                false, std::make_shared<UrpHandler>(this),
+                StreamSocket::ReadType::NormalRead, now);
             _urpToKit = StreamSocket::create<StreamSocket>(
                 std::string(), urpToKitFD, Socket::Type::Unix,
-                false, std::make_shared<UrpHandler>(this));
+                false, std::make_shared<UrpHandler>(this),
+                StreamSocket::ReadType::NormalRead, now);
         }
     }
 

--- a/wsd/ProxyProtocol.hpp
+++ b/wsd/ProxyProtocol.hpp
@@ -40,10 +40,6 @@ public:
     int getPollEvents(std::chrono::steady_clock::time_point /* now */,
                       int64_t &/* timeoutMaxMs */) override;
 
-    void checkTimeout(std::chrono::steady_clock::time_point /* now */) override
-    {
-    }
-
     void performWrites(std::size_t capacity) override;
 
     void onDisconnect() override


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

#### Changes to original PR
- net::Config -> net::Defaults, without any xml config file side-effects
  - only allow net::Defaults to be changed in unit tests via dedicated callback
- removed Socket age criteria via Socket::creationTime and net::defaults::MaxDuration
  - Socket::creationTime still relevant for minimum throughput criteria
  - dropped the net::defaults::MaxDuration 
- max-connections
  - removed under- overflow checks
  - using SC atomic ops (not just relaxed)
- enhanced API doc of Util::TimeAverage (clarification)
- unit tests in one place / commit
- more unification/squashing to single semantic commits
- more sensible order of commits
- removed dead code
- dropped noexcept patch

Further:
- cleaned up the commit messages
- removed the COOLWSD.cpp default config reordering
- reordered the 'Unify socket stats', as it must be upfront the actual connection count limitation
  and before moved _lastSeenHTTPHeader
- fixed another intermediate breakage in the commit chain
- bisectable proof (but no unit test runs ofc) .. via
  - passed `git rebase -i --exec "make -j 20"` for all commits
   
### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

