### PR TITLE
slideshow: repeated presentation with initial transition

### DIFF
--- a/browser/src/slideshow/engine/SlideShowNavigator.ts
+++ b/browser/src/slideshow/engine/SlideShowNavigator.ts
@@ -121,7 +121,7 @@ class SlideShowNavigator {
 		NAVDBG.print(
 			'SlideShowNavigator.goToFirstSlide: current index: ' + this.currentSlide,
 		);
-		this.displaySlide(0, true);
+		this.startPresentation(0, false);
 	}
 
 	goToLastSlide() {


### PR DESCRIPTION
If we have presentation which has enabled repeated slideshow\with timer, we see at the end counter and presentation starts from the first slide. This was not working correctly as we didn't see first transition when we repeated first slide after seeing counter. Let's use better function which does initial setup too.