### PR TITLE
Refactor some elements in about dialog box.

### DIFF
--- a/browser/html/cool.html.m4
+++ b/browser/html/cool.html.m4
@@ -201,12 +201,12 @@ m4_ifelse(MOBILEAPP,[true],
               <div class="spacer"></div>
               <div id="lokit-version-label"></div>
               <div class="about-dialog-info-div"><div id="lokit-version" dir="ltr"></div></div>
-              m4_ifelse(MOBILEAPP,[],[<div id="served-by" style="display: none;"><span id="served-by-label"></span>&nbsp;<span id="os-info"></span>&nbsp;<wbr><span id="coolwsd-id"></span></div>],[<p></p>])
+              m4_ifelse(MOBILEAPP,[],[<div id="served-by"><span id="served-by-label"></span>&nbsp;<span id="os-info"></span>&nbsp;<wbr><span id="coolwsd-id"></span></div>],[<p></p>])
               <div id="slow-proxy"></div>
               m4_ifelse(DEBUG,[true],[<div id="js-dialog">JSDialogs: <a href="#">View widgets</a></div>])
               <div id="routeToken"></div>
               <div id="timeZone"></div>
-              m4_ifelse(MOBILEAPP,[],[<div id="wopi-host-id" style="display: none;">%WOPI_HOST_ID%</div>],[<p></p>])
+              m4_ifelse(MOBILEAPP,[],[<div id="wopi-host-id">%WOPI_HOST_ID%</div>],[<p></p>])
               <p class="about-dialog-info-div"><span dir="ltr">Copyright © _YEAR_, VENDOR.</span></p>
             </div>
           </div>

--- a/browser/src/control/Control.AboutDialog.ts
+++ b/browser/src/control/Control.AboutDialog.ts
@@ -32,6 +32,26 @@ class AboutDialog {
 		}
 	}
 
+	private adjustIDs(content: HTMLElement) {
+		const servedBy = content.querySelector(':scope #served-by');
+		if (servedBy) servedBy.id += '-cloned';
+
+		const wopiHostId = content.querySelector(':scope #wopi-host-id');
+		if (wopiHostId) wopiHostId.id += '-cloned';
+	}
+
+	private hideElementsHiddenByDefault(content: HTMLElement) {
+		const servedBy = content.querySelector(
+			':scope #served-by-cloned',
+		) as HTMLElement;
+		if (servedBy) servedBy.style.display = 'none';
+
+		const wopiHostId = content.querySelector(
+			':scope #wopi-host-id-cloned',
+		) as HTMLElement;
+		if (wopiHostId) wopiHostId.style.display = 'none';
+	}
+
 	public show() {
 		const windowAny = window as any;
 		// Just as a test to exercise the Async Trace Event functionality, uncomment this
@@ -44,6 +64,14 @@ class AboutDialog {
 			.getElementById(aboutDialogId)
 			.cloneNode(true) as HTMLElement;
 		content.style.display = 'block';
+
+		/*
+			Now we copied the about dialog content which was already in the document, hidden.
+			This copied content also includes the IDs. So we have now duplicate IDs for elements, which is contrary to HTML rules.
+			Let's modify the IDs of such elements and add "-cloned" at the end.
+		*/
+		this.adjustIDs(content);
+		this.hideElementsHiddenByDefault(content); // Now we can safely hide the elements that we want hidden by default.
 
 		if (content.querySelector('#js-dialog')) {
 			(content.querySelector('#js-dialog') as HTMLAnchorElement).onclick =

--- a/browser/src/core/Debug.js
+++ b/browser/src/core/Debug.js
@@ -64,8 +64,13 @@ L.DebugManager = L.Class.extend({
 		this._automatedUserTasks = {};
 
 		// Display debug info in About box
-		document.querySelector('#wopi-host-id').style.display = 'block';
-		document.querySelector('#served-by').style.display = 'flex';
+		const wopiHostId = document.getElementById('wopi-host-id-cloned');
+		if (wopiHostId)
+			wopiHostId.style.display = 'block';
+
+		const servedBy = document.getElementById('served-by-cloned');
+		if (servedBy)
+			servedBy.style.display = 'flex';
 	},
 
 	_stop: function() {
@@ -83,8 +88,13 @@ L.DebugManager = L.Class.extend({
 		this._controls = {};
 
 		// Hide debug info in About box
-		document.querySelector('#wopi-host-id').style.display = 'none';
-		document.querySelector('#served-by').style.display = 'none';
+		const wopiHostId = document.getElementById('wopi-host-id-cloned');
+		if (wopiHostId)
+			wopiHostId.style.display = 'none';
+
+		const servedBy = document.getElementById('served-by-cloned');
+		if (servedBy)
+			servedBy.style.display = 'none';
 	},
 
 	_addDebugTool: function (tool) {


### PR DESCRIPTION
We want to hide some elements outside of debugging mode, which is activated by triple click on about dialog. That requires some elements to be created hidden by default. This commit removes the "style="display:none"" code from HTML. Because that way of defaulting to hidden raises CSP issues. Instead, we hide them right before we show the about dialog.

Also, there were duplicate IDs of elements in about dialog. Since we clone a dialog which already exists, all the IDs in that dialog are duplicated. This commit adds "-cloned" suffix to 2 elements which have duplicate IDs. We probably need to check also other duplicates.


Change-Id: Idef8e842b2b2fd90a1639db63dd490d7718ff1c9


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

