### PR TITLE
slideshow: keep connection when presenting

### DIFF
--- a/browser/src/control/Control.IdleHandler.ts
+++ b/browser/src/control/Control.IdleHandler.ts
@@ -150,6 +150,9 @@ class IdleHandler {
 	}
 
 	_dim() {
+		if (this.map.slideShowPresenter && this.map.slideShowPresenter._checkAlreadyPresenting())
+			return; // do not stop presentation
+
 		this.map.fire('closealldialogs');
 		const message = this.getIdleMessage();
 


### PR DESCRIPTION
don't enter idle mode if presenting, that diconnects us from the websocket and causes to stop the presentation in current point