### PR TITLE
slideshow: fix error on dummy slides click

### DIFF
--- a/browser/src/slideshow/engine/SlideShowNavigator.ts
+++ b/browser/src/slideshow/engine/SlideShowNavigator.ts
@@ -294,7 +294,11 @@ class SlideShowNavigator {
 	private clickHandler(aEvent: MouseEvent) {
 		if (aEvent.button === 0) {
 			const slideInfo = this.theMetaPres.getSlideInfoByIndex(this.currentSlide);
-			if (slideInfo.interactions.length == 0) {
+			if (
+				!slideInfo ||
+				!slideInfo.interactions ||
+				slideInfo.interactions.length == 0
+			) {
 				this.dispatchEffect();
 				return;
 			}


### PR DESCRIPTION
after interaction feature was done we expect to always have it's data. but we also have dummy slides without any data for showing the text on blakc brackground (click to exit, etc)