### PR TITLE
slideshow: avoid reccurent calls with wrong number

### DIFF
--- a/browser/src/slideshow/engine/SlideShowNavigator.ts
+++ b/browser/src/slideshow/engine/SlideShowNavigator.ts
@@ -194,7 +194,10 @@ class SlideShowNavigator {
 				', bSkipTransition: ' +
 				bSkipTransition,
 		);
-		if (nNewSlide === undefined || nNewSlide < 0) return;
+		if (nNewSlide === undefined || nNewSlide < 0) {
+			NAVDBG.print('SlideShowNavigator.displaySlide: unexpected nNewSlide');
+			return;
+		}
 		if (nNewSlide >= this.theMetaPres.numberOfSlides) {
 			this.currentSlide = nNewSlide;
 			const force = nNewSlide > this.theMetaPres.numberOfSlides;
@@ -221,6 +224,10 @@ class SlideShowNavigator {
 			let offset = 1;
 			if (this.currentSlide !== undefined)
 				offset = Math.sign(nNewSlide - this.currentSlide);
+			if (offset === 0) {
+				NAVDBG.print('SlideShowNavigator.displaySlide: offset === 0');
+				return;
+			}
 			this.displaySlide(nNewSlide + offset, bSkipTransition);
 			return;
 		}
@@ -236,6 +243,14 @@ class SlideShowNavigator {
 			if (this.prevSlide >= this.theMetaPres.numberOfSlides)
 				this.prevSlide = undefined;
 			this.currentSlide = nNewSlide;
+
+			if (this.currentSlide === this.prevSlide) {
+				NAVDBG.print(
+					'SlideShowNavigator.displaySlide: slideCompositor.fetchAndRun: this.currentSlide === this.prevSlide',
+				);
+				return;
+			}
+
 			this.slideShowHandler.displaySlide(
 				this.currentSlide,
 				this.prevSlide,


### PR DESCRIPTION
global.js:552 Uncaught RangeError: Maximum call stack size exceeded
    at Arguments.slice (<anonymous>)
    at Object.logWithCool [as log] (global.js:552:40)
    at DebugPrinter.print (tools.ts:181:23)
    at SlideShowNavigator.displaySlide (SlideShowNavigator.ts:189:10)
    at SlideShowNavigator.displaySlide (SlideShowNavigator.ts:224:9)
    at SlideShowNavigator.displaySlide (SlideShowNavigator.ts:224:9)