### PR TITLE
slideshow: stop timer if closing

### DIFF
--- a/browser/src/slideshow/PauseTimer.ts
+++ b/browser/src/slideshow/PauseTimer.ts
@@ -18,6 +18,7 @@ declare var SlideShow: any;
 
 abstract class PauseTimer {
 	public abstract startTimer(): void;
+	public abstract stopTimer(): void;
 }
 
 class PauseTimer2d implements PauseTimer {
@@ -33,6 +34,9 @@ class PauseTimer2d implements PauseTimer {
 	public startTimer(): void {
 		this.onComplete();
 	}
+
+	// eslint-disable-next-line @typescript-eslint/no-empty-function
+	public stopTimer(): void {}
 }
 
 class PauseTimerGl extends StaticTextRenderer implements PauseTimer {
@@ -64,6 +68,11 @@ class PauseTimerGl extends StaticTextRenderer implements PauseTimer {
 	public startTimer(): void {
 		this.startTime = performance.now();
 		requestAnimationFrame(this.animate.bind(this));
+	}
+
+	public stopTimer(): void {
+		this.pauseTimeRemaining = 0;
+		this.delete2dTextCanvas();
 	}
 
 	public animate(): void {

--- a/browser/src/slideshow/SlideShowPresenter.ts
+++ b/browser/src/slideshow/SlideShowPresenter.ts
@@ -116,6 +116,7 @@ class SlideShowPresenter {
 	_canvasLoader: CanvasLoader | null = null;
 	_isAnimationPlaying: boolean = false;
 	_isPresentInWindow: boolean = false;
+	private _pauseTimer: PauseTimerGl | PauseTimer2d;
 	private _slideShowHandler: SlideShowHandler;
 	private _slideShowNavigator: SlideShowNavigator;
 	private _metaPresentation: MetaPresentation;
@@ -368,17 +369,19 @@ class SlideShowPresenter {
 		);
 		const PauseTimerType =
 			renderContext instanceof RenderContextGl ? PauseTimerGl : PauseTimer2d;
-		const pauseTimer: PauseTimer = new PauseTimerType(
+		this._pauseTimer = new PauseTimerType(
 			renderContext,
 			loopAndRepeatDuration,
 			onTimeoutHandler,
 		);
 
-		pauseTimer.startTimer();
+		this._pauseTimer.startTimer();
 	}
 
 	endPresentation(force: boolean) {
 		console.debug('SlideShowPresenter.endPresentation');
+		if (this._pauseTimer) this._pauseTimer.stopTimer();
+
 		const settings = this._presentationInfo;
 		if (force || !settings.isEndless) {
 			if (!force && this.exitSlideshowWithWarning()) {


### PR DESCRIPTION
If we close "pause screen" with counter before it ends. Timer was still active causing an error in the browser console.