### PR TITLE
Fix keyboard shortcuts not working after row/column selection in Calc

### DIFF
--- a/browser/src/control/Control.Header.ts
+++ b/browser/src/control/Control.Header.ts
@@ -235,6 +235,8 @@ export class Header extends app.definitions.canvasSectionObject {
 
 		this._map.wholeRowSelected = true; // This variable is set early, state change will set this again.
 		this._map.sendUnoCommand('.uno:SelectRow ', command);
+		// Ensures the focus is returned to the map area after the row is selected
+		this._map.focus();
 	}
 
 	_insertRowAbove(): void {
@@ -378,6 +380,8 @@ export class Header extends app.definitions.canvasSectionObject {
 
 		this._map.wholeColumnSelected = true; // This variable is set early, state change will set this again.
 		this._map.sendUnoCommand('.uno:SelectColumn ', command);
+		// Ensures the focus is returned to the map area after the column is selected
+		this._map.focus();
 	}
 
 	_insertColBefore(): void {


### PR DESCRIPTION
- After selecting a row or column, the focus shifts from the 'map' to the 'document'
- Keyboard shortcuts are intended to work specifically within the 'map' area
- This patch ensures that focus returns to the 'map' after selection, allowing keyboard shortcuts to function correctly

This fix resolves the issue where shortcuts would stop working after a row/column selection.

To check this fix :

- Go to ods file
- click on row/column header
- Press CTRL + B 

Without this patch, nothing will happen. Expected behavior should be to make all text bold

Change-Id: Ic5265a7d3eced20e4f005aa1ce50acbc87946b4f


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

