### PR TITLE
Make Styles preview box width flexible

### DIFF
--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -354,11 +354,13 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 
 #stylesview {
 	height: 64px;
-	width: 530px;
+	width: 35vw;
 	overflow: auto;
-	display: inline-flex;
-	display: -ms-inline-flexbox;
-	flex-wrap: wrap;
+	display: grid;
+	/* Preview base64's width = 100px + container border's etc */
+	grid-template-columns: repeat(auto-fit, minmax(122px, 1fr));
+	/* Preview base64's height = 30px  + container border's etc */
+	grid-template-rows: repeat(auto-fit, minmax(33px, 1fr));
 	padding: 0px;
 	border: 1px solid var(--color-stylesview-border);
 	border-radius: var(--border-radius);

--- a/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
@@ -45,6 +45,7 @@ describe(['tagdesktop'], 'Top toolbar tests.', function() {
 	it('Apply style.', function() {
 		cy.cGet('#toolbar-up .ui-scroll-right').click();
 		helper.setDummyClipboardForCopy();
+		cy.cGet('#stylesview').scrollTo('bottom') ;
 		cy.cGet('.notebookbar.ui-iconview-entry img[title=Title]').click();
 		refreshCopyPasteContainer();
 		helper.copy();


### PR DESCRIPTION
Resolves Styles preview box width depand on window size #2210

No need to set hard coded width. Better to set it to a portion of the
viewport's width. Also make sure the grid is tidier by actually using
a grid and not inline-flex and setting the proper width and height
of each cell.

Note if more buttons are added to the Home tab then that 35vw should
be updated accordingly

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ifd8696caf0d9b49fcb2c6929ea5f23505d7cff42
