### PR TITLE
backport: fix(android): Use uno command for all clipboard

### DIFF
--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -978,7 +978,7 @@ L.Clipboard = L.Class.extend({
 			return true;
 		}
 
-		if (window.ThisIsAMobileApp && (cmd === '.uno:Paste' || cmd === '.uno:PasteSpecial')) {
+		if (window.ThisIsAMobileApp) {
 			// perform internal operations
 			app.socket.sendMessage('uno ' + cmd);
 			return true;


### PR DESCRIPTION
This is a trivial backport of #10111

Previously on mobile, we were only using the uno commands for some clipboard operations - the pasting ones. That's incorrect, as on Android and iOS we don't have access to the browser clipboard APIs and should be using the native bits, which for Android intercept these UNO calls and use them to manage the clipboard.

For iOS, this still falls over - albeit in a slighly different way - but the iOS clipboard code is in core and is nontrivial to fix. I have a patch in the works which would make an API similar to navigator.clipboard for iOS/Android (hopefully reducing our pains here) but I don't see a point in not making a tiny, temporary Android fix.

When I change the clipboard system's mobile app bits, this will go away anyway :)


Change-Id: Ifa68b6e956cd5ca75dc8f54b4198a441b2bf1887


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

