### PR TITLE
cool#9992 doc sign: fix missing enable on the cert chooser description entry

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2975,6 +2975,12 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			break;
 
 		case 'enable':
+			// E.g. GtkEntry is represented as an <input> inside a <div>, the disabled
+			// attribute is on the <input>, not the <div>.
+			var innerInput = control.querySelector('input');
+			if (innerInput)
+				control = innerInput;
+
 			control.disabled = false;
 			control.removeAttribute('disabled');
 			break;

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -1513,8 +1513,10 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		if (data.password === true)
 			edit.type = 'password';
 
-		if (data.enabled === 'false' || data.enabled === false)
+		if (data.enabled === 'false' || data.enabled === false) {
+			container.setAttribute('disabled', 'true');
 			edit.disabled = true;
+		}
 
 		JSDialog.SynchronizeDisabledState(container, [edit]);
 

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -1514,7 +1514,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			edit.type = 'password';
 
 		if (data.enabled === 'false' || data.enabled === false)
-			$(edit).prop('disabled', true);
+			edit.disabled = true;
 
 		JSDialog.SynchronizeDisabledState(container, [edit]);
 
@@ -2975,12 +2975,6 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			break;
 
 		case 'enable':
-			// E.g. GtkEntry is represented as an <input> inside a <div>, the disabled
-			// attribute is on the <input>, not the <div>.
-			var innerInput = control.querySelector('input');
-			if (innerInput)
-				control = innerInput;
-
 			control.disabled = false;
 			control.removeAttribute('disabled');
 			break;


### PR DESCRIPTION
Open the signatures dialog, add a signature, the certificate chooser
sub-dialog appears. Select a certificate, that enables e.g. the sign
button, but not the description input field for some reason.

Checking the websocket incoming traffic, the message for the working
button and the broken entry is the same:
jsdialog: { "jsontype": "dialog", "action": "action", "id": 10, "data": { "control_id": "viewcert", "action_type": "enable"}}
jsdialog: { "jsontype": "dialog", "action": "action", "id": 10, "data": { "control_id": "description", "action_type": "enable"}}
But the DOM is different:

```html
<button class="ui-pushbutton jsdialog" id="viewcert" accesskey="V" disabled tabindex="0"><u class="access-key">V</u>iew Certificate</button>
<div class="ui-edit-container jsdialog" id="description" tabindex="0"><input class="ui-edit jsdialog" id="description-input" dir="auto" disabled></div>
```

Fix the problem similar to what commit
0d4e4af2cf174aba3435e44cf76aa5aa834ebb20 (jsdialog: find real input on
setText action, 2022-08-24) did for the setText action type: if there is
a child input element, work with that instead.

Probably doing so for the disable case would also make sense, but I this
dialog never disables input fields, so leave that alone for now.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I94a9a3c5fd846be86a5db175ce93ffff136881de
