### PR TITLE
In CSS, "Calc" should start with lowercase "c".

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -1195,8 +1195,8 @@ nav.spreadsheet-color-indicator ~ #sidebar-dock-wrapper {
 	transform: rotate(45deg);
 	display: inline-block;
 	position: relative;
-	top: calc(25px);
-	left: Calc(-50% + 10px);
+	top: 25px;
+	left: calc(-50% + 10px);
 	background-color: inherit;
 }
 


### PR DESCRIPTION
Or browsers may ignore the rule. Also removed an unnecessary "calc" function.


Change-Id: Iab2715d93d84a6c3f314d1619b31f88c96b4d3cf


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

