### PR TITLE
slideshow: autostart in window

### DIFF
--- a/browser/src/slideshow/SlideShowPresenter.ts
+++ b/browser/src/slideshow/SlideShowPresenter.ts
@@ -520,8 +520,8 @@ class SlideShowPresenter {
 	}
 
 	_doFallbackPresentation() {
-		// TODO: fallback to "open in new tab"
 		this._stopFullScreen();
+		this._doInWindowPresentation();
 	}
 
 	_doInWindowPresentation() {
@@ -734,6 +734,11 @@ class SlideShowPresenter {
 
 		const numberOfSlides = this._getSlidesCount();
 		if (numberOfSlides === 0) return;
+
+		if (!this.getCanvas()) {
+			console.debug('onSlideShowInfo: no canvas available');
+			return;
+		}
 
 		let skipTransition = false;
 


### PR DESCRIPTION
If we use presentation with autostart (.pps) then
fullscreen request fails as it is not invoked by the user interaction. For now do the fallback -> open in window. If user has disabled popup, he will be asked in the message box to allow the popup.