### PR TITLE
Only remove apparmor profile during package removal

### DIFF
--- a/debian/coolwsd.postrm
+++ b/debian/coolwsd.postrm
@@ -3,4 +3,9 @@
 set -e
 
 rm -f /etc/apt/apt.conf.d/25coolwsd
-rm -f /etc/apparmor.d/usr.bin.coolwsd
+
+case "$1" in
+    remove)
+        rm -f /etc/apparmor.d/usr.bin.coolwsd
+    ;;
+esac


### PR DESCRIPTION
postrm is also called when upgrading, after the files are unpacked ie. /etc/apparmor.d/usr.bin.coolwsd always got deleted.


Change-Id: I569a1ef6fe8f9346ed164bc1fd7e86e5bc113646


* Target version: master 

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [X] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

