### PR TITLE
slideshow: avoid infinite render

### DIFF
--- a/browser/src/slideshow/StaticTextRenderer.ts
+++ b/browser/src/slideshow/StaticTextRenderer.ts
@@ -31,8 +31,7 @@ class StaticTextRenderer extends TextureAnimationBase {
 	}
 
 	public animate(): void {
-		this.render();
-		requestAnimationFrame(this.animate.bind(this));
+		requestAnimationFrame(this.render.bind(this));
 	}
 
 	public createTextTexture(displayText: string): WebGLTexture {


### PR DESCRIPTION
if we went to the last slide saying "click to close" the rendering was retriggered all the time.
that caused issue with going to the previous slides which were covered by the black slide with text