### PR TITLE
Cursor pointer not allowed for disabled buttons

### DIFF
--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -282,6 +282,10 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 	cursor: pointer;
 }
 
+.unotoolbutton[disabled] * {
+	cursor: not-allowed !important;
+}
+
 .unotoolbutton.notebookbar {
 	margin-inline-end: 5px !important;
 	text-align: center;


### PR DESCRIPTION
Example:

- Buttons like Up/Down arrows in status bar to cycle through matched text.
- this buttons should not have cursor type pointer if it is disabled

![image](https://github.com/user-attachments/assets/55c8408a-45ce-4035-b083-ff75a2b5cd0e)

Change-Id: I0a24397758d77e5eec766e2f5560d56d4270846f


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

