### PR TITLE
cool#10159 browser, clipboard: visible warning on copy without async clipboard

### DIFF
--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -847,6 +847,10 @@ L.Clipboard = L.Class.extend({
 	// Executes the navigator.clipboard.write() call, if it's available.
 	_navigatorClipboardWrite: function() {
 		if (!L.Browser.hasNavigatorClipboardWrite) {
+			// Show a visible warning, this should not happen in production.
+			this._map.uiManager.showSnackbar(
+				_('The async Clipboard API is not supported by your browser, switching to HTTPS is meant to fix that.')
+			);
 			return false;
 		}
 


### PR DESCRIPTION
    Visit a URL like
    http://192.168.0.3:9980/browser/.../debug.html?file_path=..., select
    some text, copy, wonder why you get the old popup for complex selections
    even on Chrome.
    
    Compared to about half a year ago, Firefox now also supports the async
    clipboard, see
    <https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/127#apis>,
    which means that the lack of async clipboard is not considered OK in
    production. (Firefox ESR is now at 128.2.0esr, Chrome/Safari supported
    async clipboard already). Also, non-localhost HTTP URLs have the entire
    navigator.clipboard JS object as undefined, so a local dev setup can hit
    this even with Chrome.
    
    Fix the problem by showing a snackbar when we detect a broken setup, to
    help understanding the root cause.
    
    Show this all the time when async clipboard support is missing for now,
    probably it's not needed to limit this to the case when
    window.location.protocol is not 'https:'.