### PR TITLE
Add links processing also for slideshow window

### DIFF
--- a/browser/src/map/handler/Map.SlideShow.js
+++ b/browser/src/map/handler/Map.SlideShow.js
@@ -146,11 +146,6 @@ L.Map.SlideShow = L.Handler.extend({
 		this._slideURL = e.url;
 		window.app.console.debug('slide file url : ', this._slideURL);
 
-		if ('processCoolUrl' in window) {
-			this._processSlideshowLinks();
-		}
-		this._processSlideshowVideoForSafari();
-
 		this._startPlaying();
 	},
 
@@ -181,6 +176,12 @@ L.Map.SlideShow = L.Handler.extend({
 			iFrame.style.height = '100%';
 			iFrame.style.border = 'none';
 			this._slideShowWindowProxy.document.body.appendChild(iFrame);
+			this._slideShow = iFrame;
+
+			if ('processCoolUrl' in window) {
+				this._processSlideshowLinks();
+			}
+			this._processSlideshowVideoForSafari();
 
 			this._slideShowWindowProxy.document.close();
 			this._slideShowWindowProxy.focus();
@@ -201,10 +202,17 @@ L.Map.SlideShow = L.Handler.extend({
 					clearInterval(this._windowCloseInterval);
 					this._map.uiManager.closeSnackbar();
 					this._slideShowWindowProxy = null;
+					this._slideShow = null;
 				}
 			}.bind(this), 500);
 			return;
 		}
+
+		if ('processCoolUrl' in window) {
+			this._processSlideshowLinks();
+		}
+		this._processSlideshowVideoForSafari();
+
 		// Cypress Presentation
 		if (this._cypressSVGPresentationTest || !this._slideShow) {
 			window.open(this._slideURL, '_self');


### PR DESCRIPTION
Change-Id: Ic2d92dd99534b027d0024852a86d88b977667a45


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
When a function for processing slideshow links is added, the slideshow in a separate window is not working as this combination is not handled.

### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

