### PR TITLE
fix(ios): better approximate our version format

### DIFF
--- a/ios/Mobile/Info.plist.in
+++ b/ios/Mobile/Info.plist.in
@@ -247,9 +247,13 @@
 
 	     Also, currently the version in configure.ac is four numbers. This
 	     CFBundleShortVersionString must, however, be three numbers.
+
+	     To avoid us getting as out-of-sync, we merge the year and major into Apple's "major"
+	     version, allowing us to bump patch without it becoming a new release. This looks slightly
+	     weird, but at least isn't as bad as being completely misleading.
 	-->
 	<key>CFBundleShortVersionString</key>
-	<string>24.04.8</string>
+	<string>2404.8.2</string>
 	<key>CFBundleVersion</key>
 	<string>@IOSAPP_BUNDLE_VERSION@</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/ios/modify_bundle_version.sh
+++ b/ios/modify_bundle_version.sh
@@ -4,10 +4,9 @@ set +x
 # Modify the Info.plist to ensure that CFBundleVersion is always incremented
 # AppStoreConnect requires each upload, whether it is released or not, to be
 # higher than the previous successful upload's CFBundleVersion. So this
-# script sets the CFBundleVersion to the first and second components of
-# CFBundleShortVersionString and the UTC timestamp of when this script was
-# run is appended as the third component (or the second component if there
-# isn't a second component in CFBundleShortVersionString).
+# script sets the CFBundleVersion to the first component of
+# CFBundleShortVersionString and the UTC timestamp of when this script was run
+# is appended as the second component
 info_plist="$BUILT_PRODUCTS_DIR/$INFOPLIST_PATH"
 if [ ! -f "$info_plist" ]; then
     echo "Error: $info_plist does not exist or is not a regular file" >&2
@@ -26,13 +25,7 @@ if [ -z "$major_version" -o "$major_version" = "0" ]; then
     exit 1
 fi
 
-bundle_version="$major_version"
-minor_version=`echo "$bundle_short_version" | cut -d. -f2`
-if [ ! -z "$minor_version" ]; then
-    bundle_version="$bundle_version.$minor_version"
-fi
-
-bundle_version="$bundle_version.`date -u '+%Y%m%d%H%M'`"
+bundle_version="$major_version.`date -u '+%Y%m%d%H%M'`"
 /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $bundle_version" "$info_plist"
 
 echo "Succesfully Updated CFBundleVersion"


### PR DESCRIPTION
Previously we were using versions like "24.04.7" for release "24.04.7.3". Unfortunately, this works poorly if we want to have a patch release, as we can't reuse codes so we have to immediately go to "24.04.8", even when releasing from a "24.04.7" tag.

Merging our year and major release into Apple's major release number makes more sense with how we expect releases to change over time...


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

