### PR TITLE
Misc Improvements

### DIFF
--- a/common/Log.cpp
+++ b/common/Log.cpp
@@ -283,8 +283,6 @@ namespace Log
         inline std::size_t size() const { return _tlb.size(); }
         inline std::size_t available() const { return _tlb.available(); }
 
-        inline void flush() { _tlb.flush(); }
-
         inline void buffer(const char* data, std::size_t size) { _tlb.buffer(data, size); }
 
         template <std::size_t N> inline void buffer(const char (&data)[N])
@@ -298,6 +296,8 @@ namespace Log
         ~BufferedConsoleChannel() { flush(); }
 
         void close() override { flush(); }
+
+        static inline void flush() { _tlb.flush(); }
 
         void log(const Poco::Message& msg) override
         {
@@ -700,7 +700,13 @@ namespace Log
 
         Poco::Logger::shutdown();
 
-        // Flush
+        flush();
+    }
+
+    void flush()
+    {
+        BufferedConsoleChannel::flush();
+
         fflush(stdout);
         fflush(stderr);
     }

--- a/common/Log.hpp
+++ b/common/Log.hpp
@@ -74,6 +74,8 @@ namespace Log
     /// Shutdown and release the logging system.
     void shutdown();
 
+    void flush();
+
     /// Cleanup state after forking
     void postFork();
 

--- a/common/Session.cpp
+++ b/common/Session.cpp
@@ -27,24 +27,25 @@ using namespace COOLProtocol;
 
 using Poco::Exception;
 
-Session::Session(const std::shared_ptr<ProtocolHandlerInterface> &protocol,
-                 const std::string& name, const std::string& id, bool readOnly) :
-    MessageHandlerInterface(protocol),
-    _id(id),
-    _name(name),
-    _disconnected(false),
-    _isActive(true),
-    _lastActivityTime(std::chrono::steady_clock::now()),
-    _isCloseFrame(false),
-    _isWritable(!readOnly),
-    _isReadOnly(readOnly),
-    _isAllowChangeComments(false),
-    _haveDocPassword(false),
-    _isDocPasswordProtected(false),
-    _isAdminUser(std::nullopt),
-    _watermarkOpacity(0.2),
-    _accessibilityState(false),
-    _disableVerifyHost(false)
+Session::Session(const std::shared_ptr<ProtocolHandlerInterface>& protocol, const std::string& name,
+                 const std::string& id, bool readOnly)
+    : MessageHandlerInterface(protocol)
+    , _id(id)
+    , _name(name)
+    , _disconnected(false)
+    , _isActive(true)
+    , _lastActivityTime(std::chrono::steady_clock::now())
+    , _isCloseFrame(false)
+    , _writePermission(!readOnly)
+    , _isWritable(!readOnly)
+    , _isReadOnly(readOnly)
+    , _isAllowChangeComments(false)
+    , _haveDocPassword(false)
+    , _isDocPasswordProtected(false)
+    , _isAdminUser(std::nullopt)
+    , _watermarkOpacity(0.2)
+    , _accessibilityState(false)
+    , _disableVerifyHost(false)
 {
 }
 
@@ -318,11 +319,13 @@ void Session::getIOStats(uint64_t &sent, uint64_t &recv)
 
 void Session::dumpState(std::ostream& os)
 {
-    os << "\n\t\tid: " << _id
+    os << std::boolalpha
+       << "\n\t\tid: " << _id
        << "\n\t\tname: " << _name
        << "\n\t\tdisconnected: " << _disconnected
        << "\n\t\tisActive: " << _isActive
        << "\n\t\tisCloseFrame: " << _isCloseFrame
+       << "\n\t\twritePermission: " << _writePermission
        << "\n\t\tisWritable: " << _isWritable
        << "\n\t\tisReadOnly: " << _isReadOnly
        << "\n\t\tisAllowChangeComments: " << _isAllowChangeComments

--- a/common/Session.hpp
+++ b/common/Session.hpp
@@ -82,7 +82,17 @@ public:
     bool isDisconnected() const { return _disconnected; }
 
     /// Sets the permission to write to storage (for a given document).
-    void setWritePermission(bool write) { _writePermission = write; }
+    /// If set to false, will setWritable(false).
+    void setWritePermission(bool write)
+    {
+        _writePermission = write;
+        if (!write)
+        {
+            // Disable writing.
+            setWritable(false);
+        }
+    }
+
     /// Gets the permission to write to storage (for a given document).
     bool getWritePermission() const { return _writePermission; }
 

--- a/common/Session.hpp
+++ b/common/Session.hpp
@@ -81,6 +81,11 @@ public:
     const std::string& getName() const { return _name; }
     bool isDisconnected() const { return _disconnected; }
 
+    /// Sets the permission to write to storage (for a given document).
+    void setWritePermission(bool write) { _writePermission = write; }
+    /// Gets the permission to write to storage (for a given document).
+    bool getWritePermission() const { return _writePermission; }
+
     /// Controls whether writing in the Storage is enabled in this session.
     /// If set to false, will setReadOnly(true) and setAllowChangeComments(false).
     void setWritable(bool writable)
@@ -100,7 +105,7 @@ public:
     virtual void setReadOnly(bool readonly) { _isReadOnly = readonly; }
     bool isReadOnly() const { return _isReadOnly; }
 
-    /// Controls whether commenting is enabled in this session
+    /// Controls whether commenting is enabled in this session.
     void setAllowChangeComments(bool allow) { _isAllowChangeComments = allow; }
     bool isAllowChangeComments() const { return _isAllowChangeComments; }
 
@@ -308,10 +313,15 @@ private:
     // Whether websocket received close frame.  Closing Handshake
     std::atomic<bool> _isCloseFrame;
 
-    /// Whether the session can write in storage.
+    /// Whether the session has write permission in storage, as received from WOPI or URL parameters.
+    /// This doesn't change once set.
+    bool _writePermission;
+
+    /// Whether the session can write in storage. May be disabled on error (e.g. low storage).
+    /// Note: A read-only document may still be writable (if _isAllowChangeComments is true), f.e. PDF.
     bool _isWritable;
 
-    /// Whether the session can edit the document.
+    /// Whether the session can edit the document. Disabled when we fail to lock, for example.
     bool _isReadOnly;
 
     /// Whether the session can add/change comments.

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -924,7 +924,10 @@ void WebSocketHandler::dumpState(std::ostream& os, const std::string& /*indent*/
         Util::dumpHex(os, _wsPayload, "\t\tws queued payload:\n", "\t\t");
     os << '\n';
     if (_msgHandler)
+    {
+        os << "msgHandler:\n";
         _msgHandler->dumpState(os);
+    }
 }
 
 void StreamSocket::dumpState(std::ostream& os)
@@ -986,16 +989,16 @@ void SocketPoll::dumpState(std::ostream& os) const
     // FIXME: NOT thread-safe! _pollSockets is modified from the polling thread!
     const auto pollSockets = _pollSockets;
 
-    os << "\n  SocketPoll:";
-    os << "\n    Poll [" << name() << "] with " << pollSockets.size() << " socket"
+    os << "\n  SocketPoll [" << name() << "] with " << pollSockets.size() << " socket"
        << (pollSockets.size() == 1 ? "" : "s") << " - wakeup rfd: " << _wakeup[0]
        << " wfd: " << _wakeup[1] << '\n';
     const auto callbacks = _newCallbacks.size();
     if (callbacks > 0)
         os << "\tcallbacks: " << callbacks << '\n';
     os << "\t    fd\tevents\trbuffered\twbuffered\trtotal\twtotal\tclientaddress\n";
-    for (const auto& i : pollSockets)
-        i->dumpState(os);
+    for (const std::shared_ptr<Socket>& socket : pollSockets)
+        socket->dumpState(os);
+    os << "\n  Done [" << name() << ']';
 }
 
 /// Returns true on success only.

--- a/test/UnitProxy.cpp
+++ b/test/UnitProxy.cpp
@@ -35,7 +35,7 @@ public:
           _poll("proxy-poll"),
           _sentRequest(false)
     {
-        setTimeout(std::chrono::seconds(5));
+        setTimeout(std::chrono::seconds(10));
     }
 
     void invokeWSDTest() override
@@ -46,10 +46,11 @@ public:
 
         auto httpSession = http::Session::create(helpers::getTestServerURI());
 
-        httpSession->setTimeout(std::chrono::seconds(5));
+        httpSession->setTimeout(std::chrono::seconds(9));
 
         TST_LOG("Attempt proxy URL fetch");
 
+        // Request from rating.collaboraonline.com.
         _req = http::Request("/browser/a90f83c/foo/remote/static/lokit-extra-img.svg");
 
         httpSession->setConnectFailHandler([this]() {

--- a/test/WOPIUploadConflictCommon.hpp
+++ b/test/WOPIUploadConflictCommon.hpp
@@ -121,24 +121,29 @@ public:
         setExpectedGetFile(1); // All the tests GetFile once.
         setExpectedPutRelative(0); // No renaming in these tests.
 
-        if (_scenario == Scenario::VerifyOverwrite)
+        switch (_scenario)
         {
-            // By default, we don't upload when verifying (unless always_save_on_exit is set).
-            setExpectedPutFile(0);
-        }
-        else if (_scenario == Scenario::Disconnect || _scenario == Scenario::SaveDiscard ||
-                 _scenario == Scenario::CloseDiscard)
-        {
-            // When there is no client connected, there is no way
-            // to decide how to resolve the conflict externally.
-            // So we quarantine and let it be.
-            // Similarly, when the client decides to discard changes.
-            setExpectedPutFile(1);
-        }
-        else
-        {
-            // With conflicts, we typically do two PutFile requests.
-            setExpectedPutFile(2);
+            case Scenario::Disconnect:
+            {
+                // When there is no client connected, there is no way
+                // to decide how to resolve the conflict externally.
+                // So we quarantine and let it be.
+                setExpectedPutFile(1);
+            }
+            break;
+            case Scenario::SaveDiscard:
+                setExpectedPutFile(1); // The client discards their changes; don't upload.
+                break;
+            case Scenario::CloseDiscard:
+                setExpectedPutFile(1); // The client discards their changes; don't upload.
+                break;
+            case Scenario::SaveOverwrite:
+                setExpectedPutFile(2); // Upload a second time to force client's changes.
+                break;
+            case Scenario::VerifyOverwrite:
+                // By default, we don't upload when verifying (unless always_save_on_exit is set).
+                setExpectedPutFile(0);
+                break;
         }
     }
 

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -2281,11 +2281,7 @@ bool ClientSession::handleKitToClientMessage(const std::shared_ptr<Message>& pay
                 }
             }
 
-            // A view loaded.
-            if (UnitWSD::isUnitTesting())
-            {
-                UnitWSD::get().onDocBrokerViewLoaded(docBroker->getDocKey(), client_from_this());
-            }
+            docBroker->onViewLoaded(client_from_this());
 
 #if !MOBILEAPP
             Admin::instance().setViewLoadDuration(

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -2410,7 +2410,16 @@ void DocumentBroker::handleUploadToStorageResponse(const StorageBase::UploadResu
     {
         return handleUploadToStorageSuccessful(uploadResult);
     }
-    else if (uploadResult.getResult() == StorageBase::UploadResult::Result::TOO_LARGE)
+
+    handleUploadToStorageFailed(uploadResult);
+}
+
+void DocumentBroker::handleUploadToStorageFailed(const StorageBase::UploadResult& uploadResult)
+{
+    assert(uploadResult.getResult() != StorageBase::UploadResult::Result::OK &&
+           "Expected upload failure");
+
+    if (uploadResult.getResult() == StorageBase::UploadResult::Result::TOO_LARGE)
     {
         LOG_WRN("Got Entitity Too Large while uploading docKey ["
                 << _docKey << "] to URI [" << _uploadRequest->uriAnonym()

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -179,7 +179,7 @@ DocumentBroker::DocumentBroker(ChildType type, const std::string& uri, const Poc
     , _cursorWidth(0)
     , _cursorHeight(0)
     , _poll(
-          std::make_unique<DocumentBrokerPoll>("doc" SHARED_DOC_THREADNAME_SUFFIX + _docId, *this))
+          std::make_shared<DocumentBrokerPoll>("doc" SHARED_DOC_THREADNAME_SUFFIX + _docId, *this))
     , _stop(false)
     , _lockCtx(std::make_unique<LockContext>())
     , _tileVersion(0)
@@ -189,7 +189,8 @@ DocumentBroker::DocumentBroker(ChildType type, const std::string& uri, const Poc
     , _mobileAppDocId(mobileAppDocId)
     , _alwaysSaveOnExit(COOLWSD::getConfigValue<bool>("per_document.always_save_on_exit", false))
     , _backgroundAutoSave(COOLWSD::getConfigValue<bool>("per_document.background_autosave", true))
-    , _backgroundManualSave(COOLWSD::getConfigValue<bool>("per_document.background_manualsave", true))
+    , _backgroundManualSave(
+          COOLWSD::getConfigValue<bool>("per_document.background_manualsave", true))
 #if !MOBILEAPP
     , _admin(Admin::instance())
 #endif

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -2625,6 +2625,22 @@ void DocumentBroker::onViewLoaded(const std::shared_ptr<ClientSession>& session)
     //TODO: Take the WOPI lock, if necessary.
 }
 
+std::shared_ptr<ClientSession> DocumentBroker::getFirstAuthorizedSession() const
+{
+    ASSERT_CORRECT_THREAD();
+
+    for (const auto& sessionIt : _sessions)
+    {
+        const auto& session = sessionIt.second;
+        if (!session->getAuthorization().isExpired())
+        {
+            return session;
+        }
+    }
+
+    return std::shared_ptr<ClientSession>();
+}
+
 std::shared_ptr<ClientSession> DocumentBroker::getWriteableSession() const
 {
     ASSERT_CORRECT_THREAD();

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -2614,6 +2614,17 @@ void DocumentBroker::setInteractive(bool value)
     }
 }
 
+void DocumentBroker::onViewLoaded(const std::shared_ptr<ClientSession>& session)
+{
+    // A view loaded.
+    if (UnitWSD::isUnitTesting())
+    {
+        UnitWSD::get().onDocBrokerViewLoaded(getDocKey(), session);
+    }
+
+    //TODO: Take the WOPI lock, if necessary.
+}
+
 std::shared_ptr<ClientSession> DocumentBroker::getWriteableSession() const
 {
     ASSERT_CORRECT_THREAD();

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -616,6 +616,9 @@ private:
     /// Note that if there is no loaded and writable session, the first will be returned.
     std::shared_ptr<ClientSession> getWriteableSession() const;
 
+    /// Get the first session that has a valid authorization.
+    std::shared_ptr<ClientSession> getFirstAuthorizedSession() const;
+
     void refreshLock();
 
     /// Downloads the document ahead-of-time.

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -1696,7 +1696,7 @@ private:
     int _cursorPosY;
     int _cursorWidth;
     int _cursorHeight;
-    std::unique_ptr<DocumentBrokerPoll> _poll;
+    std::shared_ptr<DocumentBrokerPoll> _poll;
     std::atomic<bool> _stop;
     std::string _closeReason;
     std::unique_ptr<LockContext> _lockCtx;

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -771,6 +771,9 @@ private:
     /// Handles the completion of successful uploading to storage.
     void handleUploadToStorageSuccessful(const StorageBase::UploadResult& uploadResult);
 
+    /// Handles the completion of failed uploading to storage.
+    void handleUploadToStorageFailed(const StorageBase::UploadResult& uploadResult);
+
     /// Sends the .uno:Save command to LoKit.
     bool sendUnoSave(const std::shared_ptr<ClientSession>& session, bool dontTerminateEdit = true,
                      bool dontSaveIfUnmodified = true, bool isAutosave = false, bool finalWrite = false,

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -768,6 +768,9 @@ private:
     /// Handles the completion of uploading to storage, both success and failure cases.
     void handleUploadToStorageResponse(const StorageBase::UploadResult& uploadResult);
 
+    /// Handles the completion of successful uploading to storage.
+    void handleUploadToStorageSuccessful(const StorageBase::UploadResult& uploadResult);
+
     /// Sends the .uno:Save command to LoKit.
     bool sendUnoSave(const std::shared_ptr<ClientSession>& session, bool dontTerminateEdit = true,
                      bool dontSaveIfUnmodified = true, bool isAutosave = false, bool finalWrite = false,

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -363,6 +363,9 @@ public:
     /// Notify that the document has dialogs before load
     virtual void setInteractive(bool value);
 
+    /// Called when a new view is loaded.
+    void onViewLoaded(const std::shared_ptr<ClientSession>& session);
+
     /// If not yet locked, try to lock
     bool attemptLock(ClientSession& session, std::string& failReason);
 


### PR DESCRIPTION
Larger than I'd have liked due two breaking up upload handling into 3 functions (non-functional refactoring).
Otherwise, _mostly_ trivial changes.

- wsd: minor non-functional improvements to Delta
- wsd: test: better Rename test
- wsd: refactor the handling of successful upload
- wsd: refactor the handling of failed upload
- wsd: end renaming upon upload failure
- wsd: make DocumentBrokerPoll a shared_ptr
- wsd: capture the original storage write Permission
- wsd: setWritePermission on each loaded session
- wsd: add DocumentBroker::onViewLoaded
- wsd: test: better setExpectedPutFile in UploadConflictCommon
- wsd: test: extend the timeouts in UnitProxy
- wsd: log: support on-deman flushing own buffer
- wsd: mark the dump-state better
- wsd: add getFirstAuthorizedSession to DocBroker
