### PR TITLE
cool#9992 doc sign: add sign button to the home tab of the notebookbar

### DIFF
--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -247,6 +247,18 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				'type': 'container',
 				'children': [
 					{
+						'id': 'signature',
+						'type': 'bigtoolitem',
+						'text': _('Signature'),
+						'command': '.uno:Signature',
+						'accessibility': { focusBack: true, combination: 'SN' }
+					}
+				]
+			},
+			{
+				'type': 'container',
+				'children': [
+					{
 						'id': 'renamedocument',
 						'class': 'unoRenameDocument',
 						'type': 'bigcustomtoolitem',

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -314,6 +314,18 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'type': 'container',
 				'children': [
 					{
+						'id': 'signature',
+						'type': 'bigtoolitem',
+						'text': _('Signature'),
+						'command': '.uno:Signature',
+						'accessibility': { focusBack: true, combination: 'SN' }
+					}
+				]
+			},
+			{
+				'type': 'container',
+				'children': [
+					{
 						'id': 'renamedocument',
 						'class': 'unoRenameDocument',
 						'type': 'bigcustomtoolitem',

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -311,6 +311,18 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 						'accessibility': { focusBack: true,	combination: 'I', de: 'I' }
 					}
 				]
+			},
+			{
+				'type': 'container',
+				'children': [
+					{
+						'id': 'signature',
+						'type': 'bigtoolitem',
+						'text': _('Signature'),
+						'command': '.uno:Signature',
+						'accessibility': { focusBack: true, combination: 'SN' }
+					}
+				]
 			});
 
 		content.push({


### PR DESCRIPTION
If the document has one signature, then the status bar has an icon and
you can add more signatures. But you can't add a signature if the doc
has no signature at all, which is the primary use-case.

There is no icon is the "no sign" case because signing is a relatively
obscure feature, and it's good to not clutter the status bar with an
icon by default.

Fix the problem by adding a button for it on the File tab of the
notebookbar. This has the benefit that it's not visible by default (Home
is the default), and it's also next to the Properties button, matching
the desktop order in the File menu.

Possibly later we'll hide these when we learn that user has no sign
certificates configured, that's not yet done here.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I8383f6f5b14a2770e0fd6a5e804f68ed7c67a215
