### PR TITLE
wsd: reap the background save process

### DIFF
--- a/kit/Kit.hpp
+++ b/kit/Kit.hpp
@@ -264,6 +264,9 @@ private:
         _queue->putCallback(-1, type, payload);
     }
 
+    /// Cleanup bgSave child processes.
+    static void reapZombieChildren();
+
 public:
     /// Request loading a document, or a new view, if one exists,
     /// and register callbacks.


### PR DESCRIPTION
This reaps zombie child processes that we
couldn't reap after getting disconnected
from them. Very likely because the kernel
hadn't unloaded the process yet.

We reap any child process after spawning
a background save. This way, we would
have at most 1 zombie at any time.

This gives the minimum overhead while
ensuring that we don't leak.

Change-Id: Idd8531ec721744fa31d7ec767b87dc3deb18c193
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
