### PR TITLE
Dump Memory Usage with SIGUSR1

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -2529,8 +2529,14 @@ void Document::dumpState(std::ostream& oss)
         << "\n\tduringLoad: " << _duringLoad
         << "\n\tmodified: " << name(_modified)
         << "\n\tbgSaveProc: " << _isBgSaveProcess
-        << "\n\tbgSaveDisabled: "<< _isBgSaveDisabled
-        << "\n";
+        << "\n\tbgSaveDisabled: "<< _isBgSaveDisabled;
+
+    std::string smap;
+    if (const ssize_t size = FileUtil::readFile("/proc/self/smaps_rollup", smap); size <= 0)
+        oss << "\n  smaps_rollup: <unavailable>";
+    else
+        oss << "\n  smaps_rollup: " << smap;
+    oss << '\n';
 
     // dumpState:
     // TODO: _websocketHandler - but this is an odd one.
@@ -2542,7 +2548,7 @@ void Document::dumpState(std::ostream& oss)
             << " editorId: " << it.second->getDoc()->getEditorId()
             << " mobileAppDocId: " << it.second->getDoc()->getMobileAppDocId();
     }
-    oss << "\n";
+    oss << '\n';
 
     _deltaPool.dumpState(oss);
     _sessions.dumpState(oss);
@@ -2557,7 +2563,7 @@ void Document::dumpState(std::ostream& oss)
         oss << "\n\t\tviewId: " << it.first
             << " last update time(ms): " << ms;
     }
-    oss << "\n";
+    oss << '\n';
 
     oss << "\tspeedCount:";
     for (const auto &it : _speedCount)
@@ -2578,14 +2584,14 @@ void Document::dumpState(std::ostream& oss)
             << " readOnly: " << it.second.isReadOnly()
             << " connected: " << it.second.isConnected();
     }
-    oss << "\n";
+    oss << '\n';
 
     char *pState = nullptr;
     _loKit->dumpState("", &pState);
     oss << "lok state:\n";
     if (pState)
         oss << pState;
-    oss << "\n";
+    oss << '\n';
 }
 
 #if !defined BUILDING_TESTS && !MOBILEAPP && !LIBFUZZER

--- a/test/WopiProofTests.cpp
+++ b/test/WopiProofTests.cpp
@@ -157,7 +157,7 @@ void WopiProofTests::testOurProof()
     LOK_ASSERT_EQUAL(pairs[2].first, std::string("X-WOPI-ProofOld"));
     std::string proofOld = pairs[2].second;
 
-    int64_t ticks = std::stoll(timestamp.c_str(), nullptr, 10);
+    int64_t ticks = std::stoll(timestamp, nullptr, 10);
     verifySignature(access_token, uri, ticks, modulus, exponent, proof, testname);
     verifySignature(access_token, uri, ticks, modulus, exponent, proofOld, testname);
 
@@ -175,7 +175,7 @@ void WopiProofTests::testOurProof()
     LOK_ASSERT_EQUAL(pairs[2].first, std::string("X-WOPI-ProofOld"));
     proofOld = pairs[2].second;
 
-    ticks = std::stoll(timestamp.c_str(), nullptr, 10);
+    ticks = std::stoll(timestamp, nullptr, 10);
     verifySignature(access_token, uri, ticks, modulus, exponent, proof, testname);
     verifySignature(access_token, uri, ticks, modulus, exponent, proofOld, testname);
 }

--- a/wsd/Admin.cpp
+++ b/wsd/Admin.cpp
@@ -13,6 +13,7 @@
 
 #include <chrono>
 #include <iomanip>
+#include <sstream>
 #include <string>
 #include <sys/poll.h>
 #include <unistd.h>
@@ -693,6 +694,17 @@ void Admin::pollingThread()
                 _pendingConnects.erase(_pendingConnects.begin());
                 connectToMonitorSync(rec.getUri());
             }
+        }
+
+        bool dumpMetrics = true;
+        if (_dumpMetrics.compare_exchange_strong(dumpMetrics, false))
+        {
+            std::ostringstream oss;
+            oss << "Admin Metrics:\n";
+            getMetrics(oss);
+            const std::string str = oss.str();
+            fprintf(stderr, "%s\n", str.c_str());
+            LOG_TRC(str);
         }
 
         // Handle websockets & other work.

--- a/wsd/Admin.hpp
+++ b/wsd/Admin.hpp
@@ -173,6 +173,9 @@ public:
 
     void getMetrics(std::ostringstream &metrics);
 
+    /// Will dump the metrics in the log and stderr from the Admin SocketPoll.
+    static void dumpMetrics() { instance()._dumpMetrics = true; }
+
     // delete entry from _monitorSocket map
     void deleteMonitorSocket(const std::string &uriWithoutParam);
 
@@ -225,6 +228,9 @@ private:
     uint64_t _lastSentCount;
     uint64_t _lastRecvCount;
     std::string _forkitLogLevel;
+
+    /// When set, the metrics will be dumped into the log and stderr.
+    std::atomic_bool _dumpMetrics;
 
     struct MonitorConnectRecord
     {

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -4104,6 +4104,12 @@ public:
            << "\n  UserInterface: " << COOLWSD::UserInterface
             ;
 
+        std::string smap;
+        if (const ssize_t size = FileUtil::readFile("/proc/self/smaps_rollup", smap); size <= 0)
+            os << "\n  smaps_rollup: <unavailable>";
+        else
+            os << "\n  smaps_rollup: " << smap;
+
 #if !MOBILEAPP
         if (FetchHttpSession)
         {

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -4960,6 +4960,10 @@ void dump_state()
     const std::string msg = oss.str();
     fprintf(stderr, "%s\n", msg.c_str());
     LOG_TRC(msg);
+
+#if !MOBILEAPP
+    Admin::dumpMetrics();
+#endif
 }
 
 void lslr_childroot()


### PR DESCRIPTION
- wsd: avoid unnecessary temporary strings
- wsd: support reading unknown-sized files
- wsd: dump the smaps summary on USR1
