### PR TITLE
perf: de-prioritize rendering non-visible tiles

### DIFF
--- a/kit/KitQueue.cpp
+++ b/kit/KitQueue.cpp
@@ -640,6 +640,12 @@ void KitQueue::pushTileQueue(const Payload &value)
     _tileQueue.push_back(desc);
 }
 
+void KitQueue::pushTileQueue(const std::vector<TileDesc>& tiles)
+{
+    for(const TileDesc desc : tiles)
+        _tileQueue.push_back(desc);
+}
+
 std::string KitQueue::combineRemoveText(const StringVector& tokens)
 {
     std::string id;

--- a/kit/KitQueue.hpp
+++ b/kit/KitQueue.hpp
@@ -70,6 +70,7 @@ public:
     /// Tiles are special manage a separate queue of them
     void clearTileQueue() { _tileQueue.clear(); }
     void pushTileQueue(const Payload &value);
+    void pushTileQueue(const std::vector<TileDesc>& tiles);
     void pushTileCombineRequest(const Payload &value);
     TileCombined popTileQueue();
     std::vector<TileCombined> popWholeTileQueue();


### PR DESCRIPTION
* Resolves: #9989
* Target version: master 

### Summary
Render combined-tiles, timeout limited, invisible last
    
Requested combined-tiles are send until timeout,
at least one item, visible items first.
This approach shall increase responsiveness.

`KitSocketPoll::kitPoll` loops through max-clipped 100ms `poll` slices,
allowing new incoming client requests.
`TileCombined` request are sent as much as remaining time allows,
at least on item while favoring visible items.

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

