### PR TITLE
cool#9992 doc sign: set the view's sign cert from the WOPI UserPrivateInfo

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1803,6 +1803,7 @@ std::shared_ptr<lok::Document> Document::load(const std::shared_ptr<ChildSession
     const std::string& macroSecurityLevel = session->getMacroSecurityLevel();
     const bool accessibilityState = session->getAccessibilityState();
     const std::string& userTimezone = session->getTimezone();
+    const std::string& userPrivateInfo = session->getUserPrivateInfo();
 
     if (!Util::isMobileApp())
         consistencyCheckFileExists(uri);
@@ -1969,12 +1970,13 @@ std::shared_ptr<lok::Document> Document::load(const std::shared_ptr<ChildSession
 
     std::string backgroundTheme = getDefaultBackgroundTheme(session);
 
+    // Avoid logging userPrivateInfo till it's not anonymized.
     LOG_INF("Initializing for rendering session [" << sessionId << "] on document url [" <<
-            anonymizeUrl(_url) << "] with: [" << makeRenderParams(_renderOpts, userNameAnonym, spellOnline, theme, backgroundTheme) << "].");
+            anonymizeUrl(_url) << "] with: [" << makeRenderParams(_renderOpts, userNameAnonym, spellOnline, theme, backgroundTheme, "") << "].");
 
     // initializeForRendering() should be called before
     // registerCallback(), as the previous creates a new view in Impress.
-    const std::string renderParams = makeRenderParams(_renderOpts, userName, spellOnline, theme, backgroundTheme);
+    const std::string renderParams = makeRenderParams(_renderOpts, userName, spellOnline, theme, backgroundTheme, userPrivateInfo);
 
     _loKitDocument->initializeForRendering(renderParams.c_str());
 
@@ -2118,7 +2120,8 @@ Object::Ptr makePropertyValue(const std::string& type, const T& val)
 
 /* static */ std::string Document::makeRenderParams(const std::string& renderOpts, const std::string& userName,
                                                     const std::string& spellOnline, const std::string& theme,
-                                                    const std::string& backgroundTheme)
+                                                    const std::string& backgroundTheme,
+                                                    const std::string& userPrivateInfo)
 {
     Object::Ptr renderOptsObj;
 
@@ -2134,11 +2137,43 @@ Object::Ptr makePropertyValue(const std::string& type, const T& val)
         renderOptsObj = new Object();
     }
 
+    Object::Ptr userPrivateInfoObj;
+    if (!userPrivateInfo.empty())
+    {
+        Parser parser;
+        Poco::Dynamic::Var var = parser.parse(userPrivateInfo);
+        userPrivateInfoObj = var.extract<Object::Ptr>();
+    }
+    else
+    {
+        userPrivateInfoObj = new Object();
+    }
+
     // Append name of the user, if any, who opened the document to rendering options
     if (!userName.empty())
     {
         // userName must be decoded already.
         renderOptsObj->set(".uno:Author", makePropertyValue("string", userName));
+    }
+
+    // Extract settings relevant as view options from userPrivateInfo.
+    std::string signatureCert;
+    JsonUtil::findJSONValue(userPrivateInfoObj, "SignatureCert", signatureCert);
+    if (!signatureCert.empty())
+    {
+        renderOptsObj->set(".uno:SignatureCert", makePropertyValue("string", signatureCert));
+    }
+    std::string signatureKey;
+    JsonUtil::findJSONValue(userPrivateInfoObj, "SignatureKey", signatureKey);
+    if (!signatureKey.empty())
+    {
+        renderOptsObj->set(".uno:SignatureKey", makePropertyValue("string", signatureKey));
+    }
+    std::string signatureCa;
+    JsonUtil::findJSONValue(userPrivateInfoObj, "SignatureCa", signatureCa);
+    if (!signatureCa.empty())
+    {
+        renderOptsObj->set(".uno:SignatureCa", makePropertyValue("string", signatureCa));
     }
 
     // By default we enable spell-checking, unless it's disabled explicitly.

--- a/kit/Kit.hpp
+++ b/kit/Kit.hpp
@@ -325,7 +325,8 @@ private:
 
     static std::string makeRenderParams(const std::string& renderOpts, const std::string& userName,
                                         const std::string& spellOnline, const std::string& theme,
-                                        const std::string& backgroundTheme);
+                                        const std::string& backgroundTheme,
+                                        const std::string& userPrivateInfo);
     bool isTileRequestInsideVisibleArea(const TileCombined& tileCombined);
 
 public:


### PR DESCRIPTION
To be able to sign documents, at least the 'local file' WOPI provider
sets 3 keys under UserPrivateInfo to give the wsd, and then the kit
process the signing certificate.

The other end is the core side, which takes 3 keys as a view options in
initializeForRendering().

What was missing is to connect these two: this way a 'make run' session
can sign documents without hardcoding cert/key/ca PEM files anywhere.

The integration side and cypress tests are not yet done here.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I1f847349e10336c69019c7f1747208e6be954362
