### PR TITLE
Impress: Fixes invisible typing issue on notes view.

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -3213,7 +3213,8 @@ void ChildSession::loKitCallback(const int type, const std::string& payload)
             else if (tokens.size() == 3 && tokens.equals(0, "EMPTY"))
             {
                 // with mode:    "EMPTY, <part>, <mode>"
-                const std::string part = (_docType != "text" ? tokens[1].c_str() : "0"); // Writer renders everything as part 0.
+                // Writer renders everything as part 0.
+                const std::string part = (_docType != "text" ? (_docType == "presentation" ? std::to_string(getLOKitDocument()->getPart()) : tokens[1].c_str()) : "0");
                 const std::string mode = (_docType != "text" ? tokens[2].c_str() : "0"); // Writer is not using mode.
                 sendTextFrame("invalidatetiles: EMPTY, " + part + ", " + mode +
                               " wid=" + std::to_string(getCurrentWireId()));

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -84,7 +84,7 @@ ClientSession::ClientSession(
     _splitX(0),
     _splitY(0),
     _clientSelectedPart(-1),
-    _clientSelectedMode(0),
+    _clientSelectedMode(ViewMode::NORMAL_VIEW),
     _tileWidthPixel(0),
     _tileHeightPixel(0),
     _tileWidthTwips(0),
@@ -1221,9 +1221,9 @@ bool ClientSession::_handleInput(const char *buffer, int length)
             We set the view mode beforehand here.
         */
         if (firstLine == "uno .uno:NormalMultiPaneGUI")
-            _clientSelectedMode = 0;
+            _clientSelectedMode = ViewMode::NORMAL_VIEW;
         else if (firstLine == "uno .uno:NotesMode")
-            _clientSelectedMode = 2;
+            _clientSelectedMode = ViewMode::NOTES_VIEW;
 
         if (!filterMessage(firstLine))
         {
@@ -2315,7 +2315,7 @@ bool ClientSession::handleKitToClientMessage(const std::shared_ptr<Message>& pay
 
                 int mode = 0;
                 if(getTokenInteger(tokens.getParam(token), "mode", mode))
-                    _clientSelectedMode = mode;
+                    _clientSelectedMode = static_cast<ViewMode>(mode);
 
                 // Get document type too
                 std::string docType;
@@ -2337,7 +2337,7 @@ bool ClientSession::handleKitToClientMessage(const std::shared_ptr<Message>& pay
         {
             uint32_t newValue;
             if (tokens.getUInt32(7, "mode", newValue))
-                this->_clientSelectedMode = newValue;
+                this->_clientSelectedMode = static_cast<ViewMode>(newValue);
         }
         else if (tokens.equals(0, "commandvalues:"))
         {
@@ -2872,7 +2872,7 @@ void ClientSession::handleTileInvalidation(const std::string& message,
     int normalizedViewId = getCanonicalViewId();
 
     std::vector<TileDesc> invalidTiles;
-    if((part == _clientSelectedPart && mode == _clientSelectedMode) || _isTextDocument)
+    if((part == _clientSelectedPart && static_cast<ViewMode>(mode) == _clientSelectedMode) || _isTextDocument)
     {
         for(int paneIdx = 0; paneIdx < numPanes; ++paneIdx)
         {

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1215,6 +1215,16 @@ bool ClientSession::_handleInput(const char *buffer, int length)
             docBroker->updateLastModifyingActivityTime();
         }
 
+        /*
+            When the UI mode is switched, tile invalidation callback is sent before the mode switch callback.
+            This causes the tiles' ui mode to conflict with the view mode.
+            We set the view mode beforehand here.
+        */
+        if (firstLine == "uno .uno:NormalMultiPaneGUI")
+            _clientSelectedMode = 0;
+        else if (firstLine == "uno .uno:NotesMode")
+            _clientSelectedMode = 2;
+
         if (!filterMessage(firstLine))
         {
             const std::string dummyFrame = "dummymsg";
@@ -2322,6 +2332,12 @@ bool ClientSession::handleKitToClientMessage(const std::shared_ptr<Message>& pay
 
             // Forward the status response to the client.
             return forwardToClient(payload);
+        }
+        else if (tokens.equals(0, "statusupdate:"))
+        {
+            uint32_t newValue;
+            if (tokens.getUInt32(7, "mode", newValue))
+                this->_clientSelectedMode = newValue;
         }
         else if (tokens.equals(0, "commandvalues:"))
         {

--- a/wsd/ClientSession.hpp
+++ b/wsd/ClientSession.hpp
@@ -50,6 +50,12 @@ public:
                WAIT_DISCONNECT // closed and waiting for Kit's disconnected message
     );
 
+    enum ViewMode {
+        NORMAL_VIEW = 0, // For all.
+        MASTER_VIEW = 1, // Impress master page view.
+        NOTES_VIEW = 2 // Impress notes view.
+    };
+
     /// Returns true if this session has loaded a view (i.e. we got status message).
     bool isViewLoaded() const { return _state == SessionState::LIVE; }
 
@@ -369,7 +375,7 @@ private:
     int _clientSelectedPart;
 
     /// Selected mode of the presentation viewed by the client (in Impress)
-    int _clientSelectedMode;
+    ViewMode _clientSelectedMode;
 
     /// Zoom properties of the client
     int _tileWidthPixel;


### PR DESCRIPTION
This is a backport of https://github.com/CollaboraOnline/online/pull/10026, it's only against 24.04-mobile as while it does improve things it also causes a regression - so we can't put it in our fully stable release, but hopefully it should still make things better enough to justify it being in this mobile release. 

_clientSelectedMode is set after the first tiles invalidation.
So this commit sets it beforehand.

See Core side ViewShellBase.cxx -> getEditMode for more info.

Signed-off-by: Gökay Şatır <gokaysatir@collabora.com>
Change-Id: Iddd2e0b235cc754f850223f2aff36ba6fc2aeb85* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

