### PR TITLE
cool#9992 doc sign: add a setting to be able to disable this

### DIFF
--- a/browser/html/cool.html.m4
+++ b/browser/html/cool.html.m4
@@ -257,6 +257,7 @@ m4_ifelse(MOBILEAPP, [true],
       data-check-file-info-override = "%CHECK_FILE_INFO_OVERRIDE%"
       data-deepl-enabled = "%DEEPL_ENABLED%"
       data-zotero-enabled = "%ZOTERO_ENABLED%"
+      data-document-signing-enabled = "%DOCUMENT_SIGNING_ENABLED%"
       data-saved-ui-state = "%SAVED_UI_STATE%"
       data-wasm-enabled = "%WASM_ENABLED%"
       data-indirection-url = "%INDIRECTION_URL%"

--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -385,6 +385,7 @@ class BrowserInitializer extends InitializerBase {
 		window.checkFileInfoOverride = element.dataset.checkFileInfoOverride;
 		window.deeplEnabled = element.dataset.deeplEnabled.toLowerCase().trim() === "true";
 		window.zoteroEnabled = element.dataset.zoteroEnabled.toLowerCase().trim() === "true";
+		window.documentSigningEnabled = element.dataset.documentSigningEnabled.toLowerCase().trim() === "true";
 		window.savedUIState = element.dataset.savedUiState.toLowerCase().trim() === "true";
 		window.wasmEnabled = element.dataset.wasmEnabled.toLowerCase().trim() === "true";
 		window.indirectionUrl = element.dataset.indirectionUrl;

--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -242,8 +242,9 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 						'accessibility': { focusBack: true,	combination: 'PR', de: null }
 					}
 				]
-			},
-			{
+		});
+		if (window.documentSigningEnabled) {
+			content.push({
 				'type': 'container',
 				'children': [
 					{
@@ -254,7 +255,9 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 						'accessibility': { focusBack: true, combination: 'SN' }
 					}
 				]
-			},
+			});
+		}
+		content.push(
 			{
 				'type': 'container',
 				'children': [

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -309,8 +309,9 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 						'command': '.uno:SetDocumentProperties'
 					}
 				]
-			},
-			{
+		});
+		if (window.documentSigningEnabled) {
+			content.push({
 				'type': 'container',
 				'children': [
 					{
@@ -321,7 +322,9 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 						'accessibility': { focusBack: true, combination: 'SN' }
 					}
 				]
-			},
+			});
+		}
+		content.push(
 			{
 				'type': 'container',
 				'children': [

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -311,8 +311,9 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 						'accessibility': { focusBack: true,	combination: 'I', de: 'I' }
 					}
 				]
-			},
-			{
+		});
+		if (window.documentSigningEnabled) {
+			content.push({
 				'type': 'container',
 				'children': [
 					{
@@ -324,6 +325,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 					}
 				]
 			});
+		}
 
 		content.push({
 			'type': 'container',

--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -229,7 +229,7 @@
     </security>
 
     <certificates>
-      <database_path type="string" desc="Path to the NSS certificates that are used for signing documents" default=""></database_path>
+      <database_path type="string" desc="Path to the NSS certificates that are available to all users" default=""></database_path>
     </certificates>
 
     <watermark>
@@ -347,5 +347,9 @@
         <enable desc="Enable WASM support" type="bool" default="false"></enable>
         <force desc="When enabled, all requests are redirected to WASM." type="bool" default="false"></force>
     </wasm>
+
+    <document_signing desc="Document signing settings">
+        <enable desc="Enable document signing" type="bool" default="true">true</enable>
+    </document_signing>
 
 </config>

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -2209,6 +2209,7 @@ void COOLWSD::innerInitialize(Application& self)
         { "admin_console.logging.admin_action", "true" },
         { "wasm.enable", "false" },
         { "wasm.force", "false" },
+        { "document_signing.enable", "true" },
     };
 
     // Set default values, in case they are missing from the config file.

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -2088,6 +2088,9 @@ static std::string getCapabilitiesJson(bool convertToAvailable)
     capabilities->set("hasWASMSupport",
                       COOLWSD::WASMState != COOLWSD::WASMActivationState::Disabled);
 
+    // Set if this instance supports document signing.
+    capabilities->set("hasDocumentSigningSupport", config::getBool("document_signing.enable", true));
+
     const std::string serverName = config::getString("indirection_endpoint.server_name", "");
     if (const char* podName = std::getenv("POD_NAME"))
         capabilities->set("podName", podName);

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -1413,6 +1413,7 @@ FileServerRequestHandler::ResourceAccessDetails FileServerRequestHandler::prepro
 
     Poco::replaceInPlace(preprocess, std::string("%DEEPL_ENABLED%"), boolToString(config.getBool("deepl.enabled", false)));
     Poco::replaceInPlace(preprocess, std::string("%ZOTERO_ENABLED%"), boolToString(config.getBool("zotero.enable", true)));
+    Poco::replaceInPlace(preprocess, std::string("%DOCUMENT_SIGNING_ENABLED%"), boolToString(config.getBool("document_signing.enable", true)));
     Poco::replaceInPlace(preprocess, std::string("%WASM_ENABLED%"), boolToString(COOLWSD::getConfigValue<bool>("wasm.enable", false)));
     Poco::URI indirectionURI(config.getString("indirection_endpoint.url", ""));
     Poco::replaceInPlace(preprocess, std::string("%INDIRECTION_URL%"), indirectionURI.toString());


### PR DESCRIPTION
Once an integration would provide the signing certificate/key, it's
necessary to configure this on the user settings page of the
integration. Given that document signing is not relevant for many
deployments, the integration may want to hide this.

The way this is done for the Zotero case is that coolwsd has a flag
(enabled by default, the sysadmin can disable it), and then the
/hosting/capabilities JSON informs the integration if this COOL instance
supports document signing or not.

Fix the problem by adding a similar flag for document signing.

At the moment this influences our capabilities JSON & disables the
JS UI buttons; the JS UI button doesn't check if the view actually
provides a signing certificate yet.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Icb7a8b438374d9244e4513e5488fb88bbc46f323
