### PR TITLE
improve closing the calc with unsaved changes

### DIFF
--- a/browser/src/control/Control.FormulaBarJSDialog.js
+++ b/browser/src/control/Control.FormulaBarJSDialog.js
@@ -241,9 +241,11 @@ class FormulaBar {
 		// in the core we have DrawingArea not TextView
 		if (object.id.indexOf('sc_input_window') === 0) {
 			objectType = 'drawingarea';
-			if (eventType === 'keypress' && data === UNOKey.RETURN || data === UNOKey.ESCAPE)
+			if (eventType === 'keypress' && data === UNOKey.RETURN || data === UNOKey.ESCAPE) {
+				// TODO: not used anymore? now acceptformula dispatch command is executed instead
 				builder.map.focus();
-			else if (eventType === 'grab_focus') {
+				app.allowExit();
+			} else if (eventType === 'grab_focus') {
 				this.focusField();
 				builder.map.onFormulaBarFocus();
 			}
@@ -254,10 +256,12 @@ class FormulaBar {
 
 	focusField() {
 		L.DomUtil.addClass(this.getInputField(), 'focused');
+		app.preventExit();
 	}
 
 	blurField() {
 		L.DomUtil.removeClass(this.getInputField(), 'focused');
+		app.allowExit();
 	}
 
 	enable() {

--- a/browser/src/control/Control.IdleHandler.ts
+++ b/browser/src/control/Control.IdleHandler.ts
@@ -230,6 +230,10 @@ class IdleHandler {
 			return;
 		}
 
+		// save content of a cell if leaving the app
+		if (app.map && app.map.getDocType() === 'spreadsheet')
+			app.dispatcher.dispatch('acceptformula');
+
 		this._startOutOfFocusTimer();
 	}
 }

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -294,7 +294,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 				 !window._firstDialogHandled &&
 				 (eventType === 'close' ||
 				 (objectType === 'responsebutton' && data == 7))) {
-				window.onClose();
+				app.dispatcher.dispatch('closeapp');
 			}
 			switch (typeof data) {
 			case 'string':

--- a/browser/src/control/Control.LokDialog.js
+++ b/browser/src/control/Control.LokDialog.js
@@ -262,7 +262,7 @@ L.Control.LokDialog = L.Control.extend({
 		// In that state the document is not really loaded and closing or cancelling it
 		// returns docnotloaded error. Instead of this we can return to the integration
 		if (!this._map._docLoaded && !window._firstDialogHandled) {
-			window.onClose();
+			app.dispatcher.dispatch('closeapp');
 		}
 	},
 

--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -2013,7 +2013,7 @@ L.Control.Menubar = L.Control.extend({
 		} else if (L.Params.revHistoryEnabled && (id === 'rev-history' || id === 'Rev-History' || id === 'last-mod')) {
 			app.dispatcher.dispatch('rev-history');
 		} else if (id === 'closedocument') {
-			window.onClose();
+			app.dispatcher.dispatch('closeapp');
 		} else if (id === 'repair') {
 			app.dispatcher.dispatch('repair');
 		} else if (id === 'searchdialog') {

--- a/browser/src/control/Control.Toolbar.js
+++ b/browser/src/control/Control.Toolbar.js
@@ -36,18 +36,6 @@ function getUNOCommand(unoData) {
 	return unoData.objectCommand;
 }
 
-function onClose() {
-	if (window.ThisIsAMobileApp) {
-		window.postMobileMessage('BYE');
-	} else {
-		map.fire('postMessage', {msgId: 'close', args: {EverModified: map._everModified, Deprecated: true}});
-		map.fire('postMessage', {msgId: 'UI_Close', args: {EverModified: map._everModified}});
-	}
-	if (!map._disableDefaultAction['UI_Close']) {
-		map.remove();
-	}
-}
-
 function _setBorders(left, right, bottom, top, horiz, vert, color) {
 	var params = {
 		OuterBorder: {
@@ -1191,10 +1179,11 @@ function setupToolbar(e) {
 		$('#closebuttonwrapper').css('display', 'block');
 	}
 
-	$('#closebutton').click(onClose);
+	$('#closebutton').click(function () {
+		global.app.dispatcher.dispatch('closeapp');
+	});
 }
 
-global.onClose = onClose;
 global.setupToolbar = setupToolbar;
 global.insertTable = insertTable;
 global.getInsertTablePopupElements = getInsertTablePopupElements;

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -1056,7 +1056,7 @@ L.Control.UIManager = L.Control.extend({
 				toolbar.selectItem('close', false);
 			}
 		} else {
-			window.onClose();
+			app.dispatcher.dispatch('closeapp');
 		}
 	},
 

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -957,6 +957,8 @@ L.Map.include({
 			jsdialogFormulabar.show('cancelformula');
 			jsdialogFormulabar.show('acceptformula');
 		}
+
+		app.preventExit();
 	},
 
 	onFormulaBarBlur: function() {

--- a/browser/src/docdispatcher.ts
+++ b/browser/src/docdispatcher.ts
@@ -41,6 +41,11 @@ class Dispatcher {
 			if ((window as any).ThisIsAMobileApp) {
 				window.postMobileMessage('BYE');
 			} else {
+				if (window.onbeforeunload) {
+					alert(app.getUnsavedCloseMessage());
+					return;
+				}
+
 				app.map.fire('postMessage', {
 					msgId: 'close',
 					args: { EverModified: app.map._everModified, Deprecated: true },
@@ -319,6 +324,7 @@ class Dispatcher {
 			app.map.onFormulaBarBlur();
 			app.map.formulabarBlur();
 			app.map.formulabarSetDirty();
+			app.allowExit();
 		};
 
 		this.actionsMap['cancelformula'] = function () {
@@ -326,6 +332,7 @@ class Dispatcher {
 			app.map.onFormulaBarBlur();
 			app.map.formulabarBlur();
 			app.map.formulabarSetDirty();
+			app.allowExit();
 		};
 
 		this.actionsMap['startformula'] = function () {

--- a/browser/src/docdispatcher.ts
+++ b/browser/src/docdispatcher.ts
@@ -37,6 +37,22 @@ class Dispatcher {
 			}
 		};
 
+		this.actionsMap['closeapp'] = () => {
+			if ((window as any).ThisIsAMobileApp) {
+				window.postMobileMessage('BYE');
+			} else {
+				app.map.fire('postMessage', {
+					msgId: 'close',
+					args: { EverModified: app.map._everModified, Deprecated: true },
+				});
+				app.map.fire('postMessage', {
+					msgId: 'UI_Close',
+					args: { EverModified: app.map._everModified },
+				});
+			}
+			if (!app.map._disableDefaultAction['UI_Close']) app.map.remove();
+		};
+
 		this.actionsMap['userlist'] = () => {
 			if (app.map.userList) app.map.userList.openDropdown();
 		};

--- a/browser/src/docstatefunctions.js
+++ b/browser/src/docstatefunctions.js
@@ -15,7 +15,7 @@
  * This file is meant to be used for setting and getting the document states.
  */
 
-/* global app */
+/* global app _ */
 
 window.addEventListener('load', function () {
 	app.calc.cellCursorRectangle = new app.definitions.simpleRectangle(
@@ -149,4 +149,16 @@ app.isExperimentalMode = function () {
 	if (app.socket && app.socket.WSDServer && app.socket.WSDServer.Options)
 		return app.socket.WSDServer.Options.indexOf('E') !== -1;
 	return false;
+};
+
+app.getUnsavedCloseMessage = function () {
+	return _('You have unsaved changes. Are you sure you want to quit?');
+};
+
+app.preventExit = function () {
+	window.onbeforeunload = app.getUnsavedCloseMessage;
+};
+
+app.allowExit = function () {
+	window.onbeforeunload = undefined;
 };

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1467,13 +1467,8 @@ L.CanvasTileLayer = L.Layer.extend({
 		}
 		else if (textMsg.startsWith('removesession')) {
 			var viewId = parseInt(textMsg.substring('removesession'.length + 1));
-			if (this._map._docLayer._viewId === viewId) {
-				this._map.fire('postMessage', {msgId: 'close', args: {EverModified: this._map._everModified, Deprecated: true}});
-				this._map.fire('postMessage', {msgId: 'UI_Close', args: {EverModified: this._map._everModified}});
-				if (!this._map._disableDefaultAction['UI_Close']) {
-					this._map.remove();
-				}
-			}
+			if (this._map._docLayer._viewId === viewId)
+				app.dispatcher.dispatch('closeapp');
 		}
 		else if (textMsg.startsWith('calcfunctionlist:')) {
 			this._onCalcFunctionListMsg(textMsg.substring('calcfunctionlist:'.length + 1));


### PR DESCRIPTION
Warn on closing when have cells under edit
    
    When we edit a cell and we don't confirm by click outside
    or the Enter key - we can lost the typed text when window
    is closed. To avoid that let's introduce native browser warning
    before leaving the page. We also need to catch when we exit
    using commands as we are embedded in the iframe and not all
    cases trigger the beforeunload event.
    
    Also when we lose focus due to switch to other tab we will
    accept the content.

New behavior: accept content on tab switch, ask when closing the tab

[accept-2024-10-08_11.31.50.webm](https://github.com/user-attachments/assets/41caddc1-4b0b-4351-ba5c-8b5d939e5533)
