### PR TITLE
Follow up pr for 10144 (Save notification )

### DIFF
--- a/browser/css/menubar.css
+++ b/browser/css/menubar.css
@@ -89,7 +89,7 @@ nav.hasnotebookbar #save::after {
 }
 
 nav.hasnotebookbar #save.saving::after {
-	content: 'Saving';
+	content: var(--save-state);
 	font-size: var(--default-font-size);
 	font-family: var(--cool-font);
 	color: var(--color-main-text);
@@ -101,7 +101,7 @@ nav.hasnotebookbar #save.saving::after {
 }
 
 nav.hasnotebookbar #save.saved::after {
-	content: 'Saved';
+	content: var(--save-state);
 	color: #309048;
 }
 

--- a/browser/css/menubar.css
+++ b/browser/css/menubar.css
@@ -73,7 +73,7 @@
 	font-family: var(--cool-font);
 	position: relative;
 	background: transparent;
-	padding-inline-start: 2px;
+	line-height: 0;
 	height: 24px;
 	align-items: center;
 	justify-content: center;
@@ -85,7 +85,7 @@
 
 nav.hasnotebookbar #save::after {
 	position: absolute;
-	top: 18px;
+	bottom: 0px;
 }
 
 nav.hasnotebookbar #save.saving::after {

--- a/browser/css/menubar.css
+++ b/browser/css/menubar.css
@@ -165,6 +165,7 @@ nav.hasnotebookbar #save.saved::after {
 	background: var(--color-main-background);
 	padding: 0px;
 	overflow: scroll hidden;
+	padding-inline-start: 5px;
 }
 
 /* Customizations to sm-simple theme to make it look like LO menu, lo-menu class */

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2475,7 +2475,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 
 		$(controls.button).on('click', clickFunction);
 		$(controls.label).on('click', clickFunction);
-		// We need a way to also handle the cutome tooltip for any tool button like save in shortcut bar
+		// We need a way to also handle the cutom tooltip for any tool button like save in shortcut bar
 		if (data.isCustomTooltip) {
 			this._handleCutomTooltip(div, builder);
 		}

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -1182,6 +1182,9 @@ L.Control.UIManager = L.Control.extend({
 		if (saveEle.classList.contains('savemodified')) {
 			const saveIconEl = document.querySelector('#save img');
 			saveEle.classList.remove('savemodified');
+			// Dynamically set the content string for saving state
+			const savingText = _('Saving')
+			saveEle.style.setProperty('--save-state', `"${savingText}"`);
 			saveEle.classList.add('saving');
 			saveIconEl.classList.add('rotate-icon'); // Start the icon rotation
 			saveEle.setAttribute('disabled', true);  // Disable the button
@@ -1197,6 +1200,9 @@ L.Control.UIManager = L.Control.extend({
 			const saveIconEl = document.querySelector('#save img');
 			saveEle.classList.remove('saving');
 			saveIconEl.classList.remove('rotate-icon'); // Stop the icon rotation
+			// Dynamically set the content string for saved state
+			const savedText = _('Saved');
+			saveEle.style.setProperty('--save-state', `"${savedText}"`);
 			saveEle.classList.add('saved');
 			// Add some delay to show "saved" status, then hide this info
 			setTimeout(() => {

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -1183,7 +1183,7 @@ L.Control.UIManager = L.Control.extend({
 			const saveIconEl = document.querySelector('#save img');
 			saveEle.classList.remove('savemodified');
 			saveEle.classList.add('saving');
-			saveIconEl.classList.add('rotate-icon'); // Stop the icon rotation
+			saveIconEl.classList.add('rotate-icon'); // Start the icon rotation
 			saveEle.setAttribute('disabled', true);  // Disable the button
 		}
 	},
@@ -1201,7 +1201,7 @@ L.Control.UIManager = L.Control.extend({
 			// Add some delay to show "saved" status, then hide this info
 			setTimeout(() => {
 				saveEle.classList.remove('saved');
-				saveEle.removeAttribute('disabled');  // Disable the button
+				saveEle.removeAttribute('disabled');  // Enable the button
 			}, 2000);
 		}
 	},

--- a/browser/src/map/Map.js
+++ b/browser/src/map/Map.js
@@ -461,7 +461,7 @@ L.Map = L.Evented.extend({
 
 		clearTimeout(this._modTimeout);
 
-		// just for safty check sometimes this var may not be intialized then in that case better to return empty
+		// just for safety check sometimes this var may not be intialized then in that case better to return empty
 		if (!this._lastmodtime)
 			return;
 


### PR DESCRIPTION
### Summary

- Fix typos in comment messages & correct the wrong comment message with right meaningful messages
- Dynamically set CSS content for saving and saved states
- Add padding-inline-start to retain margin when logo is removed
- fix: Set line-height to 0 to prevent cropping of "Saving" text

### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

