### PR TITLE
calc: save edited cell on exit

### DIFF
--- a/browser/src/control/Control.FormulaBarJSDialog.js
+++ b/browser/src/control/Control.FormulaBarJSDialog.js
@@ -283,6 +283,13 @@ class FormulaBar {
 		return L.DomUtil.hasClass(input, 'focused');
 	}
 
+	isInEditMode() {
+		var acceptButton = this.parentContainer.querySelector('#acceptformula');
+		if (acceptButton)
+			return !acceptButton.classList.contains('hidden');
+		return false;
+	}
+
 	showFormulabar() {
 		if (this.parentContainer)
 			this.parentContainer.style.setProperty('display', 'table-cell');

--- a/browser/src/control/Control.IdleHandler.ts
+++ b/browser/src/control/Control.IdleHandler.ts
@@ -106,6 +106,7 @@ class IdleHandler {
 		if (window.mode.isDesktop()
 		&& !this.map.uiManager.isAnyDialogOpen()
 		&& !cool.Comment.isAnyEdit()
+		&& (this.map.formulabar && !this.map.formulabar.hasFocus())
 		&& $('input:focus').length === 0) {
 			this.map.focus();
 		}
@@ -229,6 +230,9 @@ class IdleHandler {
 
 			return;
 		}
+
+		if (app.map && app.map.formulabar && app.map.formulabar.hasFocus())
+			app.dispatcher.dispatch('acceptformula'); // save data from the edited cell on exit
 
 		this._startOutOfFocusTimer();
 	}

--- a/browser/src/control/Control.IdleHandler.ts
+++ b/browser/src/control/Control.IdleHandler.ts
@@ -231,7 +231,8 @@ class IdleHandler {
 			return;
 		}
 
-		if (app.map && app.map.formulabar && app.map.formulabar.hasFocus())
+		if (app.map && app.map.formulabar &&
+			(app.map.formulabar.hasFocus() || app.map.formulabar.isInEditMode()))
 			app.dispatcher.dispatch('acceptformula'); // save data from the edited cell on exit
 
 		this._startOutOfFocusTimer();

--- a/browser/src/layer/marker/TextInput.js
+++ b/browser/src/layer/marker/TextInput.js
@@ -238,9 +238,6 @@ L.TextInput = L.Layer.extend({
 		if (ev.type === 'blur' && this._isComposing) {
 			this._abortComposition(ev);
 		}
-
-		if (ev.type === 'blur' && this._hasFormulaBarFocus())
-			this._map.formulabar.blurField();
 	},
 
 	// Focus the textarea/contenteditable


### PR DESCRIPTION
This fixes the main problem which is data loss when we
exit without confirmation of a cell content but also
problem with losing focus from formulabar on some actions.
Especially when we click outside iframe - we lost
focus on formulabar but we were still catching input to
it on the server side.