### PR TITLE
Tile Intersection: Use a Rectangle/AABBox for Tile/TileCombined to reduce complexity

### DIFF
--- a/common/Rectangle.hpp
+++ b/common/Rectangle.hpp
@@ -18,16 +18,29 @@
 namespace Util
 {
 
-/// Holds the position and size of a rectangle.
+/// Axis-aligned 2D rectangle (AABBox)
+/// with 0/0 as top-left origin extending to +x/+y bottom-right corner.
 struct Rectangle
 {
 private:
+    /// left
     int _x1;
+    /// top
     int _y1;
+    /// right
     int _x2;
+    /// bottom
     int _y2;
 
+    explicit Rectangle(bool, int x1, int y1, int x2, int y2)
+        : _x1(x1)
+        , _y1(y1)
+        , _x2(x2)
+        , _y2(y2)
+    {}
+
 public:
+    /// Ctor using inverse top/left and bottom/right extremes, allowing to extend this AABBox
     Rectangle()
         : _x1(std::numeric_limits<int>::max())
         , _y1(std::numeric_limits<int>::max())
@@ -35,6 +48,8 @@ public:
         , _y2(std::numeric_limits<int>::min())
     {}
 
+    /// Ctor via top/left coordinates and extent, validating for overflow
+    /// If width or height exceeds maximum, the right or bottom addition is dropped.
     Rectangle(int x, int y, int width, int height)
         : _x1(x)
         , _y1(y)
@@ -51,7 +66,14 @@ public:
         }
     }
 
-    void extend(Rectangle& rectangle)
+    /// Ctor via top/left and bottom/right coordinates
+    static Rectangle create(int x1, int y1, int x2, int y2)
+    {
+        return Rectangle(true, x1, y1, x2, y2);
+    }
+
+    /// Grow this rectangle to enclose the given one
+    void extend(const Rectangle& rectangle)
     {
         if (rectangle._x1 < _x1)
             _x1 = rectangle._x1;
@@ -87,15 +109,25 @@ public:
 
     bool hasSurface() const { return _x1 < _x2 && _y1 < _y2; }
 
-    bool intersects(const Rectangle& rOther)
+    /// Returns whether this Rectangle intersects (partially contains) given Rectangle.
+    bool intersects(const Rectangle& rOther) const
     {
-        Util::Rectangle intersection;
-        intersection._x1 = std::max(_x1, rOther._x1);
-        intersection._y1 = std::max(_y1, rOther._y1);
-        intersection._x2 = std::min(_x2, rOther._x2);
-        intersection._y2 = std::min(_y2, rOther._y2);
-        return intersection.isValid();
+        const int x1 = std::max(_x1, rOther._x1);
+        const int y1 = std::max(_y1, rOther._y1);
+        const int x2 = std::min(_x2, rOther._x2);
+        const int y2 = std::min(_y2, rOther._y2);
+        return x1 <= x2 && y1 <= y2;
     }
+
+    /// Returns whether this Rectangle fully contains given Rectangle.
+    bool contains(const Rectangle& o) const
+    {
+        return    _x2 >= o._x2
+               && _y2 >= o._y2
+               && _y1 <= o._y1
+               && _x1 <= o._x1;
+    }
+
     std::string toString()
     {
         std::ostringstream oss;

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -1226,6 +1226,11 @@ bool ChildSession::isTileInsideVisibleArea(const TileDesc& tile) const
     return tile.intersects( _clientVisibleArea );
 }
 
+bool ChildSession::isTileInsideVisibleArea(const TileCombined& tileCombined) const
+{
+    return tileCombined.toAABBox().intersects( _clientVisibleArea );
+}
+
 bool ChildSession::outlineState(const StringVector& tokens)
 {
     std::string type, state;

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -1223,8 +1223,7 @@ bool ChildSession::clientVisibleArea(const StringVector& tokens)
 
 bool ChildSession::isTileInsideVisibleArea(const TileDesc& tile) const
 {
-    return (tile.getTilePosX() >= _clientVisibleArea.getLeft() && tile.getTilePosX() <= _clientVisibleArea.getRight() &&
-        tile.getTilePosY() >= _clientVisibleArea.getTop() && tile.getTilePosY() <= _clientVisibleArea.getBottom());
+    return tile.intersects( _clientVisibleArea );
 }
 
 bool ChildSession::outlineState(const StringVector& tokens)

--- a/kit/ChildSession.hpp
+++ b/kit/ChildSession.hpp
@@ -128,6 +128,7 @@ public:
     std::string getViewRenderState() { return _viewRenderState; }
 
     bool isTileInsideVisibleArea(const TileDesc& tile) const;
+    bool isTileInsideVisibleArea(const TileCombined& tileCombined) const;
 
 private:
     bool loadDocument(const StringVector& tokens);

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -2204,12 +2204,7 @@ bool Document::isTileRequestInsideVisibleArea(const TileCombined& tileCombined)
     const auto session = _sessions.findByCanonicalId(tileCombined.getNormalizedViewId());
     if (!session)
         return false;
-    for (const auto& rTile : tileCombined.getTiles())
-    {
-        if (session->isTileInsideVisibleArea(rTile))
-            return true;
-    }
-    return false;
+    return session->isTileInsideVisibleArea(tileCombined);
 }
 
 // poll is idle, are we ?

--- a/kit/KitQueue.cpp
+++ b/kit/KitQueue.cpp
@@ -387,8 +387,7 @@ int KitQueue::priority(const TileDesc &tile)
     for (int i = static_cast<int>(_viewOrder.size()) - 1; i >= 0; --i)
     {
         auto& cursor = _cursorPositions[_viewOrder[i]];
-        if (tile.intersectsWithRect(cursor.getX(), cursor.getY(), cursor.getWidth(),
-                                    cursor.getHeight()))
+        if (tile.intersects(cursor.toAABBox()))
             return i;
     }
 

--- a/kit/KitQueue.hpp
+++ b/kit/KitQueue.hpp
@@ -154,6 +154,8 @@ private:
         int getY() const { return _y; }
         int getWidth() const { return _width; }
         int getHeight() const { return _height; }
+        /// Returns the cursor's AABBox, i.e. cursor-position + cursor-extend
+        Util::Rectangle toAABBox() const { return Util::Rectangle::create(_x, _y, _x+_width, _y+_height); }
 
     private:
         int _part = 0;

--- a/kit/TestStubs.cpp
+++ b/kit/TestStubs.cpp
@@ -24,6 +24,7 @@ void ChildSession::disconnect() {}
 int ChildSession::getSpeed() { return 0; }
 bool ChildSession::_handleInput(const char* /*buffer*/, int /*length*/) { return false; }
 bool ChildSession::isTileInsideVisibleArea(const TileDesc& /*tile*/) const { return false; }
+bool ChildSession::isTileInsideVisibleArea(const TileCombined& /*tileCombined*/) const { return false; }
 ChildSession::~ChildSession() {}
 
 int simd_initPixRowSimd(const uint32_t *, uint32_t *, size_t *, uint64_t *) { return 0; }

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -2978,8 +2978,7 @@ bool ClientSession::isTileInsideVisibleArea(const TileDesc& tile) const
 {
     if (!_splitX && !_splitY)
     {
-        return (tile.getTilePosX() >= _clientVisibleArea.getLeft() && tile.getTilePosX() <= _clientVisibleArea.getRight() &&
-            tile.getTilePosY() >= _clientVisibleArea.getTop() && tile.getTilePosY() <= _clientVisibleArea.getBottom());
+        return tile.intersects( _clientVisibleArea );
     }
 
     constexpr SplitPaneName panes[4] = {
@@ -2994,9 +2993,8 @@ bool ClientSession::isTileInsideVisibleArea(const TileDesc& tile) const
         if (!isSplitPane(panes[i]))
             continue;
 
-        Util::Rectangle paneRect = getNormalizedVisiblePaneArea(panes[i]);
-        if (tile.getTilePosX() >= paneRect.getLeft() && tile.getTilePosX() <= paneRect.getRight() &&
-            tile.getTilePosY() >= paneRect.getTop() && tile.getTilePosY() <= paneRect.getBottom())
+        const Util::Rectangle paneRect = getNormalizedVisiblePaneArea(panes[i]);
+        if( tile.intersects( paneRect ) )
             return true;
     }
 

--- a/wsd/TileDesc.hpp
+++ b/wsd/TileDesc.hpp
@@ -13,6 +13,7 @@
 
 #include <Exceptions.hpp>
 #include <Protocol.hpp>
+#include <Rectangle.hpp>
 #include <StringVector.hpp>
 
 #include <cassert>
@@ -146,23 +147,43 @@ public:
         return a ^ b;
     }
 
-    static bool rectanglesIntersect(int x1, int y1, int w1, int h1, int x2, int y2, int w2, int h2)
+    /// Returns the tile's AABBox, i.e. tile-position + tile-extend
+    Util::Rectangle toAABBox() const
     {
-        return x1 + w1 >= x2 &&
-               x1 <= x2 + w2 &&
-               y1 + h1 >= y2 &&
-               y1 <= y2 + h2;
+        return Util::Rectangle::create(getTilePosX(), getTilePosY(),
+                 getTilePosX()+getTileWidth(), getTilePosY()+getTileHeight());
     }
 
+    /// Returns whether the given rectangle `a` intersects (partially contains) the given rectangle `b`.
+    static bool rectanglesIntersect(int ax, int ay, int aw, int ah, int bx, int by, int bw, int bh)
+    {
+        const Util::Rectangle a = Util::Rectangle::create(ax, ay, ax+aw, ay+ah);
+        const Util::Rectangle b = Util::Rectangle::create(bx, by, bx+bw, by+bh);
+        return a.intersects(b);
+    }
+
+    /// Returns whether this Tile's AABBox intersects (partially contains) given rectangle.
     bool intersectsWithRect(int x, int y, int w, int h) const
     {
-        return rectanglesIntersect(getTilePosX(), getTilePosY(), getTileWidth(), getTileHeight(), x, y, w, h);
+        return toAABBox().intersects( Util::Rectangle::create(x, y, x+w, y+h) );
     }
 
+    /// Returns whether this Tile's AABBox intersects (partially contains) given Tile's AABBox.
     bool intersects(const TileDesc& other) const
     {
-        return intersectsWithRect(other.getTilePosX(), other.getTilePosY(),
-                                  other.getTileWidth(), other.getTileHeight());
+        return toAABBox().intersects(other.toAABBox());
+    }
+
+    /// Returns whether this Tile's AABBox intersects (partially contains) given AABBox.
+    bool intersects(const Util::Rectangle& otherAABBox) const
+    {
+        return toAABBox().intersects(otherAABBox);
+    }
+
+    /// Returns whether this Tile's AABBox is fully contained by the given AABBox.
+    bool isContained(const Util::Rectangle& otherAABBox) const
+    {
+        return otherAABBox.contains(toAABBox());
     }
 
     bool isAdjacent(const TileDesc& other) const

--- a/wsd/TileDesc.hpp
+++ b/wsd/TileDesc.hpp
@@ -499,6 +499,7 @@ private:
             _tiles.emplace_back(_normalizedViewId, _part, _mode, _width, _height, x, y, _tileWidth, _tileHeight, ver, imgSize, -1);
             _tiles.back().setOldWireId(oldWireId);
             _tiles.back().setWireId(wireId);
+            _aabbox.extend(_tiles.back().toAABBox());
         }
     }
 protected:
@@ -525,6 +526,8 @@ public:
     int getHeight() const { return _height; }
     int getTileWidth() const { return _tileWidth; }
     int getTileHeight() const { return _tileHeight; }
+    /// Returns the combined-tile's AABBox, i.e. min-position + max-extend
+    Util::Rectangle toAABBox() const { return _aabbox; }
     bool getCombined() const { return _isCombined; }
 
     const std::vector<TileDesc>& getTiles() const { return _tiles; }
@@ -791,6 +794,7 @@ protected:
     bool _hasOldWids : 1;
     bool _isCombined : 1;
     bool _hasImgSizes : 1;
+    Util::Rectangle _aabbox;
 };
 
 class TileCombinedBuilder : public TileCombined


### PR DESCRIPTION
* Resolves: #9989
* Target version: master 

### Summary
Tile Intersection: Use a Rectangle/AABBox for Tile/TileCombined to reduce complexity

Use consolidated Rectangle Intersection on ChildSession/ClientSession's isTileInsideVisibleArea
Previous implementation left out the tile boundaries intersecting with the _clientVisibleArea, which is now fixed.

Use an AABBox in TileCombined for ChildSession::isTileInsideVisibleArea(), reducing complexity in Document::drainQueue

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

