### PR TITLE
remove mount_namespaces config option

### DIFF
--- a/.gitpod-files/coolwsd-gitpod.xml
+++ b/.gitpod-files/coolwsd-gitpod.xml
@@ -37,13 +37,11 @@
     <sys_template_path desc="Path to a template tree with shared libraries etc to be used as source for chroot jails for child processes." type="path" relative="true" default="systemplate"></sys_template_path>
     <child_root_path desc="Path to the directory under which the chroot jails for the child processes will be created. Should be on the same file system as systemplate and lotemplate. Must be an empty directory." type="path" relative="true" default="jails"></child_root_path>
     <mount_jail_tree desc="Controls whether the systemplate and lotemplate contents are mounted or not, which is much faster than the default of linking/copying each file." type="bool" default="true"></mount_jail_tree>
-    <mount_namespaces desc="Use mount namespaces instead of coolmount." type="bool" default="true"></mount_namespaces>
 
     <server_name desc="External hostname:port of the server running coolwsd. If empty, it's derived from the request (please set it if this doesn't work). May be specified when behind a reverse-proxy or when the hostname is not reachable directly." type="string" default=""></server_name>
     <file_server_root_path desc="Path to the directory that should be considered root for the file server. This should be the directory containing cool." type="path" relative="true" default="browser/../"></file_server_root_path>
     <hexify_embedded_urls desc="Enable to protect encoded URLs from getting decoded by intermediate hops. Particularly useful on Azure deployments" type="bool" default="false"></hexify_embedded_urls>
     <experimental_features desc="Enable/Disable experimental features" type="bool" default="true">true</experimental_features>
-    <mount_namespaces desc="Use mount namespaces instead of coolmount. Only possible to experimental_features is enabled." type="bool" default="true"></mount_namespaces>
 
     <memproportion desc="The maximum percentage of available memory consumed by all of the Collabora Online Development Edition processes, after which we start cleaning up idle documents. If cgroup memory limits are set, this is the maximum percentage of that limit to consume." type="double" default="80.0"></memproportion>
     <num_prespawn_children desc="Number of child processes to keep started in advance and waiting for new clients." type="uint" default="4">1</num_prespawn_children>

--- a/Makefile.am
+++ b/Makefile.am
@@ -554,8 +554,7 @@ COMMON_PARAMS = \
 	--o:ssl.cert_file_path="$(abs_top_srcdir)/etc/cert.pem" \
 	--o:ssl.key_file_path="$(abs_top_srcdir)/etc/key.pem" \
 	--o:ssl.ca_file_path="$(abs_top_srcdir)/etc/ca-chain.cert.pem" \
-	--o:admin_console.username=admin --o:admin_console.password=admin \
-	--o:mount_namespaces[@default]=true
+	--o:admin_console.username=admin --o:admin_console.password=admin
 
 run: setup-wsd
 	@if test "${TEST_APPARMOR}" = "enabled"; then \

--- a/browser/test/bootstrap.js
+++ b/browser/test/bootstrap.js
@@ -25,7 +25,6 @@ const debug = false;
 const port = '9999';
 let args = [
 	`--o:sys_template_path=${top_builddir}/systemplate`,
-	'--o:mount_namespaces[@default]=true',
 	`--o:child_root_path=${top_builddir}/jails`,
 	'--o:storage.filesystem[@allow]=true',
 	'--o:admin_console.username=admin',

--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -37,7 +37,6 @@
     <sys_template_path desc="Path to a template tree with shared libraries etc to be used as source for chroot jails for child processes." type="path" relative="true" default="systemplate"></sys_template_path>
     <child_root_path desc="Path to the directory under which the chroot jails for the child processes will be created. Should be on the same file system as systemplate and lotemplate. Must be an empty directory." type="path" relative="true" default="jails"></child_root_path>
     <mount_jail_tree desc="Controls whether the systemplate and lotemplate contents are mounted or not, which is much faster than the default of linking/copying each file." type="bool" default="true"></mount_jail_tree>
-    <mount_namespaces desc="Use mount namespaces instead of coolmount." type="bool" default="true"></mount_namespaces>
 
     <server_name desc="External hostname:port of the server running coolwsd. If empty, it's derived from the request (please set it if this doesn't work). May be specified when behind a reverse-proxy or when the hostname is not reachable directly." type="string" default=""></server_name>
     <file_server_root_path desc="Path to the directory that should be considered root for the file server. This should be the directory containing cool." type="path" relative="true" default="browser/../"></file_server_root_path>

--- a/cypress_test/Makefile.am
+++ b/cypress_test/Makefile.am
@@ -205,7 +205,6 @@ define start_coolwsd_instance
 			--o:user_interface.mode=$(USER_INTERFACE) \
 			--o:accessibility.enable=$(A11Y_ENABLE) \
 			--o:security.enable_macros_execution=true \
-			--o:mount_namespaces[@default]=true \
 			$(if $(SHORT_IDLE),--o:per_view.out_of_focus_timeout_secs=1) \
 			$(if $(SHORT_IDLE),--o:per_view.idle_timeout_secs=7) \
 			--port=$(FREE_PORT) \

--- a/test/run_unit.sh.in
+++ b/test/run_unit.sh.in
@@ -78,7 +78,6 @@ if ${trace} \
 				   --o:ssl.ca_file_path="${abs_top_builddir}/etc/ca-chain.cert.pem" \
 				   --o:admin_console.username=admin --o:admin_console.password=admin \
 				   --o:storage.ssl.enable=false \
-				   --o:mount_namespaces[@default]=true \
 				   --o:experimental_features=true \
 				   --unattended \
 				   --unitlib="${abs_top_builddir}/test/.libs/$tst.so" 2> "$tst_log" 1>&2; then
@@ -103,7 +102,6 @@ else
 	echo "         --o:ssl.ca_file_path=\"${abs_top_builddir}/etc/ca-chain.cert.pem\" \\"
 	echo "         --o:admin_console.username=admin --o:admin_console.password=admin \\"
 	echo "         --o:storage.ssl.enable=false \\"
-	echo "         --o:mount_namespaces[@default]=true \\"
 	echo "         --unattended \\"
 	echo "         --unitlib=\"${abs_top_builddir}/test/.libs/$tst.so\""
 	echo ""

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -2079,7 +2079,6 @@ void COOLWSD::innerInitialize(Application& self)
         { "logging.disable_server_audit", "false" },
         { "browser_logging", "false" },
         { "mount_jail_tree", "true" },
-        { "mount_namespaces", "true" },
         { "net.connection_timeout_secs", "30" },
         { "net.listen", "any" },
         { "net.proto", "all" },
@@ -2635,7 +2634,7 @@ void COOLWSD::innerInitialize(Application& self)
 #endif // CODE_COVERAGE
 
     // Setup the jails.
-    bool UseMountNamespaces = getConfigValue<bool>(conf, "mount_namespaces", true);
+    bool UseMountNamespaces = true;
 
     NoCapsForKit =
         Util::isKitInProcess() || !getConfigValue<bool>(conf, "security.capabilities", true);


### PR DESCRIPTION
During development using of Linux Namespaces was an experimental feature. Therefore it was disabled in production builds, and enabled only in development edition (CODE). Later, as it matured, it was on by default. This change caused problems with upgrade, because when a user had mount_namespaces=false in /etc/coolwsd/coolwsd.xml, it remained false. Probably it is better to get rid of this configuration option, and try to use Linux Namespaces unconditionally. If it's not possible, the code will fall back to use coolforkit-caps and coolmount that require capabilities. And of course if these are not installed (coolwsd-deprecated package), a log entry will be made. It is assumed that this is a rare case. It is also assumed that nobody would want to disable using of Linux Namespaces, when the feature is available on the system.

**If you think this patch makes sense, I'd like to have it in COOL 24.04.8.3, too.**

Change-Id: Iabf23198043baa1c4b8d50e82212ddf9e17ddad0


* Resolves: # <!-- related github issue -->
* Target version: master and distro/collabora/co-24.04

