### PR TITLE
Secret name can not start with "GITHUB"

### DIFF
--- a/.github/workflows/contributor_fetch.yml
+++ b/.github/workflows/contributor_fetch.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: CollaboraOnline/CollaboraOnline.github.io  # Target GitHub Pages repository
-          token: ${{ secrets.GITHUB_TOKEN }}  # Use the GitHub token for authentication
+          token: ${{ secrets.PAT_TOKEN }}  # Use the GitHub(Personal access token) token for authentication
           path: repo  # Specify the path for the repo checkout
 
       - name: Copy generated file to GitHub IO repo


### PR DESCRIPTION
Change-Id: Ia3aad6d977e36e6a786d5adf4f23a60f2c294373


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

