### PR TITLE
DocStructure: fix extract test

### DIFF
--- a/test/integration-http-server.cpp
+++ b/test/integration-http-server.cpp
@@ -618,6 +618,7 @@ void HTTPServerTest::testExtractDocStructure()
     Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_POST, "/cool/extract-document-structure");
     Poco::Net::HTMLForm form;
     form.setEncoding(Poco::Net::HTMLForm::ENCODING_MULTIPART);
+    form.set("filter", "contentcontrol");
     form.addPart("data", new Poco::Net::FilePartSource(srcPath));
     form.prepareSubmit(request);
     try
@@ -698,6 +699,7 @@ void HTTPServerTest::testTransformDocStructure()
         Poco::Net::HTMLForm form;
         form.setEncoding(Poco::Net::HTMLForm::ENCODING_MULTIPART);
         form.set("format", "docx");
+        form.set("filter", "contentcontrol");
         form.addPart("data", new Poco::Net::FilePartSource(srcPath2));
         form.prepareSubmit(request);
         try


### PR DESCRIPTION
Added filter = contentcontrol to the test, so new updates will not change the extracted result.


Change-Id: Ie090147940e3c2b1994ffa2106d12546f4b45c67


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

