### PR TITLE
fix(mobile): Send onscreen keyboard guess to core

### DIFF
--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -73,7 +73,7 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 		map.on('splitposchanged', this.setSplitCellFromPos, this);
 		map.on('commandstatechanged', this._onCommandStateChanged, this);
 		map.uiManager.initializeSpecializedUI('spreadsheet');
-		window.keyboard.hintOnscreenKeyboard(window.keyboard.onscreenKeyboardHint);
+		window.keyboard.hintOnscreenKeyboard(window.keyboard.guessOnscreenKeyboard());
 	},
 
 	onAdd: function (map) {
@@ -398,7 +398,7 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 			if (app.socket._reconnecting) {
 				app.socket.sendMessage('setclientpart part=' + this._selectedPart);
 				this._resetInternalState();
-				window.keyboard.hintOnscreenKeyboard(window.keyboard.onscreenKeyboardHint);
+				window.keyboard.hintOnscreenKeyboard(window.keyboard.guessOnscreenKeyboard());
 			} else {
 				this._selectedPart = command.selectedPart;
 			}


### PR DESCRIPTION
This is a trivial backport of #10207, which I'll merge when that is merged.

Previously we sent our UI_Defaults onscreen keyboard information to core rather than our guess, which could result in inconsistent scenarios where we didn't activate coreside onscreen keyboard features (like not preventing keyboard close on enter in calc) but did activate our onscreen keyboard features.

Unfortunately, one of these situations was also the mobile app - oops!

By using our guess, we make sure that we always send the right thing, whether a UI_Default is provided or not.


Change-Id: I58d131f46fa02eeee63d24b615d08b902d0e22c9


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

