### PR TITLE
clang: fix unknown uint32_t error

### DIFF
--- a/common/SigUtil.hpp
+++ b/common/SigUtil.hpp
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 namespace SigUtil


### PR DESCRIPTION
fix build with clang 15 after commit e4b51310e268aa05ad83ea6ed79e92885b783eb6 wsd: header cleanup

In file included from common/SigUtil.cpp:14:
./common/SigUtil.hpp:117:50: error: unknown type name 'uint32_t'
    extern "C" { typedef void (*SigChildHandler)(uint32_t); }
                                                 ^
