### PR TITLE
sc: change how .uno:FreezePanesColumn/Row get the index

### DIFF
--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -915,7 +915,7 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 
 		var unoName = isSplitCol ? 'FreezePanesColumn' : 'FreezePanesRow';
 		var command = {};
-		command[unoName] = {
+		command['Index'] = {
 			type: 'int32',
 			value: newSplitIndex
 		};


### PR DESCRIPTION
On commit "browser: fix freeze row/column panes"
fe45327ba0e8b330dfa5ea99e6247ed7c9abefad the type of FreezePanesColumn
and FreezePanesRow was changed from Int32 to Point. Since then, calls
trying to set the frozen panes with this commands sending an index fail,
setting the index to 1.

This change allows again a way to set them passing only an index of type
Int32.

Signed-off-by: Jaume Pujantell <jaume.pujantell@collabora.com>
Change-Id: I9837586f6c531bf885f24b5913af9a372dc0f5a1
