### PR TITLE
httpecho_fuzzer: fix build

### DIFF
--- a/fuzzer/HttpEcho.cpp
+++ b/fuzzer/HttpEcho.cpp
@@ -49,7 +49,7 @@ class HttpRequestTests final
         std::shared_ptr<Socket> create(const int physicalFd, Socket::Type type) override
         {
             return StreamSocket::create<StreamSocket>("localhost", physicalFd, type, false,
-                                                      std::make_shared<ServerRequestHandler>());
+                                                      HostType::LocalHost, std::make_shared<ServerRequestHandler>());
         }
     };
 


### PR DESCRIPTION
Probably after commit 24c4af9f8bac7e318543f1f51ab57f32945d130b (we have
the DNS info at StreamSocket ctor time that its localhost, 2024-10-10).

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I81fb60f5471a81a4cc276f5879d4b84d48b873e0
