### PR TITLE
add option to the helm chart to configure wopi proof keys

### DIFF
--- a/kubernetes/helm/collabora-online/templates/deployment.yaml
+++ b/kubernetes/helm/collabora-online/templates/deployment.yaml
@@ -125,6 +125,14 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            {{- if .Values.collabora.proofKeysSecretRef }}
+            - name: wopi-proof
+              mountPath: /etc/coolwsd/proof_key
+              subPath: proof_key
+            - name: wopi-proof
+              mountPath: /etc/coolwsd/proof_key.pub
+              subPath: proof_key.pub
+            {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -140,4 +148,11 @@ spec:
       volumes:
         - name: tmp
           emptyDir: {}
+        {{- if .Values.collabora.proofKeysSecretRef }}
+        - name: wopi-proof
+          secret:
+            secretName: {{ .Values.collabora.proofKeysSecretRef | quote }}
+        {{- end }}
+
+
 {{- end }}

--- a/kubernetes/helm/collabora-online/values.yaml
+++ b/kubernetes/helm/collabora-online/values.yaml
@@ -45,6 +45,13 @@ collabora:
   username: admin
   env: []
 
+  # name of a secret that holds the WOPI proof keys for Collabora
+  # How to generate this secret:
+  # 1. ssh-keygen -t rsa -N "" -m PEM -f proof_key
+  # 2. kubectl create secret generic <name-of-the-secret> --from-file=proof_key --from-file=proof_key.pub
+  # finally set proofKeysSecretRef to the name of the secret
+  proofKeysSecretRef: ""
+
 prometheus:
   servicemonitor:
     enabled: false


### PR DESCRIPTION
* Resolves: https://github.com/CollaboraOnline/online/issues/10020
* Target version: master 

### Summary

Allows to configure wopi proof keys when installing Collabroa via the Helm Chart.

I tested it using the oCIS deployment example that has Collabora: https://github.com/owncloud/ocis-charts/blob/91b8eb2b6fa3a1e7d7ee7687c732b255b92c3f0c/deployments/ocis-office/helmfile.yaml

I modified this helmfile a little bit for testing:

```diff
   - name: collabora
     namespace: collabora
-    chart: collabora/collabora-online
-    version: 1.1.23
+    # chart: collabora/collabora-online
+    chart: /home/wkloucek/Projects/github.com/CollaboraOnline/online/kubernetes/helm/collabora-online
+    # version: 1.1.23
     values:
       - collabora:
           aliasgroups:
             - host: "wopi-collabora.kube.owncloud.test" # needed because we connect via the ingress to the collaboration service
             # - host: "collaboration-collabora.ocis.svc.cluster.local" # needed if we would use the cluster internal Service to connect to the collaboration service
           extra_params: --o:ssl.enable=false --o:ssl.termination=true --o:net.frame_ancestors=ocis.kube.owncloud.test
+          proofKeysSecretRef: wopi-proof
       - ingress:
           enabled: true
           className: "nginx"
@@ -145,7 +77,7 @@ releases:
                   enabled: true
                   uri: "https://collabora.kube.owncloud.test"
                   insecure: true
-                  disableProof: true # TODO: https://github.com/CollaboraOnline/online/issues/10020
+                  disableProof: false
                   iconURI: https://collabora.kube.owncloud.test/favicon.ico
                   ingress:
                     # Collabora connects to the collaboration service via Ingress in this case
```




### TODO

- nothing outstanding from my side

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

