### PR TITLE
cool#10220 doc sign: don't assume that user private data is a dict json

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -2142,9 +2142,16 @@ Object::Ptr makePropertyValue(const std::string& type, const T& val)
     {
         Parser parser;
         Poco::Dynamic::Var var = parser.parse(userPrivateInfo);
-        userPrivateInfoObj = var.extract<Object::Ptr>();
+        try
+        {
+            userPrivateInfoObj = var.extract<Object::Ptr>();
+        }
+        catch (const Poco::BadCastException& exception)
+        {
+            LOG_DBG("user private data is not a dictionary: " << exception.what());
+        }
     }
-    else
+    if (!userPrivateInfoObj)
     {
         userPrivateInfoObj = new Object();
     }


### PR DESCRIPTION
Generate a /s/token style share link in Nextcloud, open that link in
incognito window, the document fails to load.

The guest user has no private infos, but instead of {}, we get a [],
which is well-formed JSON and we used to tolerate that.

Fix the problem by assuming an empty object when the JSON is not a
dictionary but something else.

Ideally nextcloud would not send us such JSON, but we used to tolerate
that previously, so first fix this here.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Ie1b1a5db796c351f383dcfa8d44b003c84810d0e
