### PR TITLE
[Draft] Enable nodePort specification on helm

### DIFF
--- a/kubernetes/helm/collabora-online/templates/service.yaml
+++ b/kubernetes/helm/collabora-online/templates/service.yaml
@@ -16,6 +16,9 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+      {{- with .Values.service.nodePort }}
+      nodePort: {{ . }}
+      {{- end }}
   selector:
     {{- include "collabora-online.selectorLabels" . | nindent 4 }}
     type: main


### PR DESCRIPTION
Allow for nodePort specification for simple development setups without ingress controllers.

* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

This PR allows nodePort to be specified on helm chart values.yaml, allowing for simplified deployments on temporary bare metal setups. It removes the necessity of setting up an ingress controller, although it should not be used in production setups.

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

