### PR TITLE
UT Stability: Resolve UnitBase data races

### DIFF
--- a/common/Unit.cpp
+++ b/common/Unit.cpp
@@ -32,9 +32,9 @@
 #include <common/SigUtil.hpp>
 #include <common/StringVector.hpp>
 
-UnitKit *GlobalKit = nullptr;
-UnitWSD *GlobalWSD = nullptr;
-UnitTool *GlobalTool = nullptr;
+std::atomic<UnitKit *>GlobalKit = nullptr;
+std::atomic<UnitWSD *>GlobalWSD = nullptr;
+std::atomic<UnitTool *>GlobalTool = nullptr;
 UnitBase** UnitBase::GlobalArray = nullptr;
 int UnitBase::GlobalIndex = -1;
 char* UnitBase::UnitLibPath = nullptr;
@@ -704,8 +704,9 @@ void UnitWSD::DocBrokerDestroy(const std::string& key)
 
                 LOG_TST("Starting test #" << GlobalIndex + 1 << ": "
                                           << GlobalArray[GlobalIndex]->getTestname());
-                if (GlobalWSD)
-                    GlobalWSD->configure(Poco::Util::Application::instance().config());
+                UnitWSD *globalWSD = GlobalWSD;
+                if (globalWSD)
+                    globalWSD->configure(Poco::Util::Application::instance().config());
                 GlobalArray[GlobalIndex]->initialize();
             }
 
@@ -717,8 +718,9 @@ void UnitWSD::DocBrokerDestroy(const std::string& key)
 
 UnitWSD& UnitWSD::get()
 {
-    assert(GlobalWSD);
-    return *GlobalWSD;
+    UnitWSD *globalWSD = GlobalWSD;
+    assert(globalWSD);
+    return *globalWSD;
 }
 
 void UnitWSD::onExitTest(TestResult result, const std::string&)
@@ -768,8 +770,9 @@ UnitKit& UnitKit::get()
     if (Util::isKitInProcess() && !GlobalKit)
         GlobalKit = new UnitKit("UnitKit");
 
-    assert(GlobalKit);
-    return *GlobalKit;
+    UnitKit *globalKit = GlobalKit;
+    assert(globalKit);
+    return *globalKit;
 }
 
 void UnitKit::onExitTest(TestResult, const std::string&)

--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -333,6 +333,12 @@ private:
         return false;
     }
 
+    std::shared_ptr<SocketPoll> getSocketPoll()
+    {
+        std::lock_guard<std::mutex> guard(_lockSocketPoll);
+        return _socketPoll;
+    }
+
     static UnitBase* get(UnitType type);
 
     /// setup global instance for get() method
@@ -356,6 +362,7 @@ private:
     UnitType _type;
 
     std::mutex _lock; //< Used to protect cleanup functions.
+    std::mutex _lockSocketPoll; //< Used to sync _socketPoll
     std::shared_ptr<SocketPoll> _socketPoll; //< Poll thread for async http comm.
 
 protected:

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -243,7 +243,7 @@ SocketPoll::SocketPoll(std::string threadName)
 
     createWakeups();
 
-    LOG_DBG("New SocketPoll [" << _name << "] owned by " << Log::to_string(_owner));
+    LOG_DBG("New " << logInfo());
 
     if (PollWatchdog)
         PollWatchdog->addTime(&_watchdogTime, &_ownerThreadId);
@@ -251,7 +251,7 @@ SocketPoll::SocketPoll(std::string threadName)
 
 SocketPoll::~SocketPoll()
 {
-    LOG_TRC("~SocketPoll [" << _name << "] destroying. Joining thread now.");
+    LOG_DBG("~" << logInfo());
 
     if (PollWatchdog)
         PollWatchdog->removeTime(&_watchdogTime);

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -633,7 +633,7 @@ public:
     /// Stop the polling thread.
     void stop()
     {
-        LOG_DBG("Stopping SocketPoll thread " << _name);
+        LOG_DBG("Stopping " << logInfo());
         _stop = true;
         if constexpr (!Util::isMobileApp())
         {
@@ -886,6 +886,16 @@ private:
         _pollFds[size].fd = _wakeup[0];
         _pollFds[size].events = POLLIN;
         _pollFds[size].revents = 0;
+    }
+
+    std::string logInfo() const {
+        std::ostringstream os;
+        os << "SocketPoll[this " << std::hex << this << std::dec
+           << ", thread[name " << _name
+           << ", id[owner " << Log::to_string(_owner)
+           << ", caller " << Log::to_string(std::this_thread::get_id())
+           << "]]]";
+        return os.str();
     }
 
     /// The polling thread entry.


### PR DESCRIPTION
* Resolves: #10228 

### Summary
- Resolve UnitBase's _socketPoll data race via its socketPoll()
- Resolve UnitBase's UnitWSD::get() data-race

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

