### PR TITLE
mount an up to date copy of etc if ro systemplate's etc is out of date

### DIFF
--- a/common/JailUtil.cpp
+++ b/common/JailUtil.cpp
@@ -581,13 +581,13 @@ bool updateDynamicFilesImpl(const std::string& sysTemplate)
 
         if (checkWritableSysTemplate && !FileUtil::isWritable(sysTemplate))
         {
-            disableBindMounting(); // We can't mount from incomplete systemplate that can't be updated.
             LinkDynamicFiles = false;
             LOG_WRN("The systemplate directory ["
                     << sysTemplate << "] is read-only, and at least [" << dstFilename
-                    << "] is out-of-date. Will have to copy sysTemplate to jails. To restore "
-                       "optimal performance, make sure the files in ["
-                    << sysTemplate << "/etc] are up-to-date.");
+                    << "] is out-of-date. Will have to clone dynamic elements of "
+                    << "systemplate to the jails. To restore optimal performance, "
+                    << "make sure the files in [" << sysTemplate << "/etc] "
+                    << "are up-to-date.");
             return false;
         }
 


### PR DESCRIPTION
same as:

commit 852e8545af3f1807ff6619fe52a922f35bbd9da4
Author:     Caolán McNamara <caolan.mcnamara@collabora.com>
AuthorDate: Mon Jul 22 13:07:17 2024 +0100

    mount an up to date copy of etc if systemplate's etc is out of date

but also do this is the out of date systemplate dynamic files are in a ro systemplate.

reproducible in make run with

rm -f systemplate/etc/hosts && chmod a-w systemplate

where the earlier change only works for

rm -f systemplate/etc/hosts && chmod a-w systemplate/etc


Change-Id: I054d844f15456f189d19cb204fd80541f827dcbf


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

