### PR TITLE
TileCombined::toAABBox(): Return const reference, avoiding copy

### DIFF
--- a/wsd/TileDesc.hpp
+++ b/wsd/TileDesc.hpp
@@ -527,7 +527,7 @@ public:
     int getTileWidth() const { return _tileWidth; }
     int getTileHeight() const { return _tileHeight; }
     /// Returns the combined-tile's AABBox, i.e. min-position + max-extend
-    Util::Rectangle toAABBox() const { return _aabbox; }
+    const Util::Rectangle& toAABBox() const { return _aabbox; }
     bool getCombined() const { return _isCombined; }
 
     const std::vector<TileDesc>& getTiles() const { return _tiles; }


### PR DESCRIPTION
Change-Id: I84d16f3911d27e97cf613e0e434fe53dc6aa963d


* Resolves: #9989

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

