### PR TITLE
docs(mobile): Mention co-24.04-mobile in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,37 @@ Please consult the README files in the component's directory for more details:
 
 ## iOS and Android apps
 
+### Building
+
 See the corresponding READMEs:
 * **[ios/README](ios/README)**
 * **[android/README](android/README)**
+
+### Releases and pre-releases
+
+Releases and pre-release builds are made from the
+`distro/collabora/co-24.04-mobile` branch. Releases for Android and iOS are
+generally built from the same commit, and are tagged as a release on GitHub.
+
+Android snapshots are automatically built once a week, but may be built more
+frequently if there's something new to test. iOS testflight builds are
+exclusively built when there is something new to test. Pre-release builds are
+not tagged in GitHub.
+
+### Getting changes into 24.04-mobile
+
+You should still develop against `master`, even if you're working on
+mobile-only features. Changes made in `master` will be moved into the
+`distro/collabora/co-24.04` branch according to the release schedule. Changes
+from the `distro/collabora/co-24.04` branch are then regularly cherry-picked
+into the `distro/collabora/co-24.04-mobile` branch.
+
+If you have a change which you want to get into mobile snapshots or releases
+more quickly, you should still develop it against `master`. When it's merged
+into `master`, you should make a backport pull request against
+`distro/collabora/co-24.04-mobile`. Please don't make pull requests directly
+against `distro/collabora/co-24.04-mobile` (i.e. without the change first being
+merged into `master`).
 
 ## GitPod
 


### PR DESCRIPTION
For contributors to mobile, it's nice to mention the process around the co-24.04-mobile branch in relation to master and co-24.04. I've opted not to use the platform-specific READMEs as (1) it applies to both platforms and (2) those aren't very good and probably need to be rewritten more generally

* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

