### PR TITLE
CI: I do not think we need libreoffice build deps

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -57,8 +57,7 @@ jobs:
         sudo sh -c "echo deb-src http://security.ubuntu.com/ubuntu/ noble-security multiverse >> /etc/apt/sources.list"
         sudo apt-get update
         sudo apt install -y libunwind-dev
-        sudo apt-get install -y build-essential git libpoco-dev libcap-dev python3-polib npm libpng-dev python3-lxml libpam-dev libzstd-dev
-        sudo apt-get build-dep -y libreoffice
+        sudo apt-get install -y build-essential git libpoco-dev libcap-dev python3-polib npm libpng-dev python3-lxml libpam-dev libzstd-dev libssl-dev libcppunit-dev
 
     - if: matrix.language == 'cpp'
       name: Configure


### PR DESCRIPTION
Change-Id: I73fea30cc75a2a9ff2a3890c4c8e0ae2103c5a81


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
It makes the CI a bit faster. libreoffice build deps are huge, and unnecessary. We use pre-built core assets.
