### PR TITLE
let the user copy text from a comment

### DIFF
--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -568,7 +568,7 @@ L.Clipboard = L.Class.extend({
 		return true; // prevent default
 	},
 
-	_isAnyInputFieldSelected: function() {
+	_isAnyInputFieldSelected: function(forCopy = false) {
 		if ($('#search-input').is(':focus'))
 			return true;
 
@@ -589,6 +589,13 @@ L.Clipboard = L.Class.extend({
 		if (app.view.commentHasFocus)
 		    return true;
 
+		if (forCopy) {
+			let selection = window.getSelection();
+			selection = selection && selection.toString();
+			if (selection && selection.length !== 0)
+				return true;
+		}
+
 		return false;
 	},
 
@@ -602,7 +609,7 @@ L.Clipboard = L.Class.extend({
 	_beforeSelect: function(ev) {
 		window.app.console.log('Got event ' + ev.type + ' setting up selection');
 
-		if (this._isAnyInputFieldSelected())
+		if (this._isAnyInputFieldSelected(ev.type === 'beforecopy'))
 			return;
 
 		this._beforeSelectImpl();
@@ -1011,7 +1018,7 @@ L.Clipboard = L.Class.extend({
 	_doCopyCut: function(ev, unoName) {
 		window.app.console.log(unoName);
 
-		if (this._isAnyInputFieldSelected())
+		if (this._isAnyInputFieldSelected(unoName === 'Copy'))
 			return;
 
 		if (this._downloadProgressStatus() === 'downloadButton')


### PR DESCRIPTION
Right now if a user selects text from a comment and tries to copy it,
the copy command goes to the document instead. This change allows the
user to copy from the content of a comment.

Signed-off-by: Jaume Pujantell <jaume.pujantell@collabora.com>
Change-Id: I9dc9198fd28f5a723c454444644f361bc31a4c49
