### PR TITLE
jsdialog: transparent as color picker's last color

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2805,8 +2805,11 @@ L.Control.JSDialogBuilder = L.Control.extend({
 						app.colorLastSelection[data.command] = selectedColor;
 					}
 
+					if (parseInt(selectedColor) === -1) selectedColor = 'transparent';
+
 					valueNode.style.backgroundColor =
-						selectedColor[0] !== '#' ? '#' + selectedColor : selectedColor;
+						(selectedColor[0] !== '#' && selectedColor !== 'transparent')
+						? '#' + selectedColor : selectedColor;
 
 					// Make sure the border around the color indicator is not too bright
 					// when the color is black so to avoid weird contast artifacts

--- a/browser/src/control/jsdialog/Widget.ColorPicker.ts
+++ b/browser/src/control/jsdialog/Widget.ColorPicker.ts
@@ -182,14 +182,7 @@ function createAutoColorButton(
 	autoButton.focus();
 
 	autoButton.addEventListener('click', () => {
-		builder.map['stateChangeHandler'].setItemValue(data.command, -1);
-
-		var parameters;
-		if (data.command === '.uno:FontColor')
-			parameters = { FontColor: { type: 'long', value: -1 } };
-		else parameters = { Color: { type: 'long', value: -1 } };
-
-		builder.map.sendUnoCommand(data.command, parameters);
+		builder._sendColorCommand(builder, data, 'transparent');
 		builder.callback('colorpicker', 'hidedropdown', data, '-1', builder);
 	});
 }


### PR DESCRIPTION
1. pick any color you like first from notebookbar's color picker (Background)
2. open color picker and click no-fill
result: no change in the last color indicator