### PR TITLE
sidebar: avoid dispatching an undefined UNO command

### DIFF
--- a/browser/src/control/Control.Sidebar.ts
+++ b/browser/src/control/Control.Sidebar.ts
@@ -167,7 +167,8 @@ class Sidebar {
 	}
 
 	changeDeck(unoCommand: string | null) {
-		if (unoCommand !== null) app.socket.sendMessage('uno ' + unoCommand);
+		if (unoCommand !== null && unoCommand !== undefined)
+			app.socket.sendMessage('uno ' + unoCommand);
 		this.setupTargetDeck(unoCommand);
 	}
 


### PR DESCRIPTION
Execute 'make run' with a debug core, open e.g. writer-edit.fodt, and
notice this warning:

warn:lok:17376:17363:desktop/source/lib/init.cxx:283: lok exception 'Failed to dispatch undefined'

Seems it's harmless, but the JS side should never send such a command on
the websocket.

It turns out sometimes Sidebar.onSidebar() calls Sidebar.changeDeck()
with an undefined parameter, so guard for this.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Iacdad1392bc53ce9427fbb90863c8b58fc1fa3df
