### PR TITLE
Fix switching from notes view to normal view issue.

### DIFF
--- a/browser/src/layer/tile/ImpressTileLayer.js
+++ b/browser/src/layer/tile/ImpressTileLayer.js
@@ -50,9 +50,19 @@ L.ImpressTileLayer = L.CanvasTileLayer.extend({
 	},
 
 	_onContextChange(e) {
-		app.impress.notesMode = e.detail.context === 'NotesPage';
+		/*
+			We need to check the context content for now. Because we are using this property for both context and the page kind.
+			When user modifies the content of the notes, the context is changed again. As we use context as a view mode, we shouldn't change our variable in that case.
+			We need to check if the context is something related to view mode or not.
+			For a better solution, we need to send the page kinds along with status messages. Then we will check the page kind and set the notes view toggle accordingly.
+		*/
 
-		if (app.map.uiManager.getCurrentMode() === 'notebookbar') {
+		const isDrawOrNotesPage = ['DrawPage', 'NotesPage'].includes(e.detail.context);
+
+		if (isDrawOrNotesPage)
+			app.impress.notesMode = e.detail.context === 'NotesPage';
+
+		if (app.map.uiManager.getCurrentMode() === 'notebookbar' && isDrawOrNotesPage) {
 			const targetElement = document.getElementById('notesmode');
 			if (!targetElement) return;
 
@@ -62,7 +72,7 @@ L.ImpressTileLayer = L.CanvasTileLayer.extend({
 				targetElement.classList.remove('selected');
 		}
 
-		if (['DrawPage', 'NotesPage'].includes(e.detail.context)) {
+		if (isDrawOrNotesPage) {
 			this._selectedMode = e.detail.context === 'NotesPage' ? 2 : 0;
 			this._refreshTilesInBackground();
 			this._update();


### PR DESCRIPTION
Reproducer:
* Open an impress file.
* Switch to notes view.
* Edit the note of page.
* Don't remove focus from note object (rectangle).
* Try to switch back to normal view.

We still send the notes view UI command because when user clicked on the note rectangle, context changed again. Now our UI thinks that we are in different mode. We will set our internal selectedMode variable selectively.


Change-Id: Iee73a1bb16aed7c19190ef15592910e39a056beb


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

