### PR TITLE
UnitBase: No-side-effect usage of AtomicSharedPtr<SocketPoll> instead of single `shared_ptr<T>` and `mutex`

### DIFF
--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -411,12 +411,6 @@ private:
         return false;
     }
 
-    std::shared_ptr<SocketPoll> getSocketPoll()
-    {
-        std::lock_guard<std::mutex> guard(_lockSocketPoll);
-        return _socketPoll;
-    }
-
     static UnitBase* get(UnitType type);
 
     /// setup global instance for get() method
@@ -440,8 +434,7 @@ private:
     UnitType _type;
 
     std::mutex _lock; //< Used to protect cleanup functions.
-    std::mutex _lockSocketPoll; //< Used to sync _socketPoll
-    std::shared_ptr<SocketPoll> _socketPoll; //< Poll thread for async http comm.
+    AtomicSharedPtr<SocketPoll> _socketPoll; //< Poll thread for async http comm.
 
 protected:
 


### PR DESCRIPTION
* Resolves: #10228 
* Target version: master 

### Summary
The two seperate single non-recursive mutex _lockSocketPoll and _lock were required due to the recursive call from _lock protected code into _lockSocketPoll protected code.

This PR offers new `AtomicSharedPtr<T>` for thread-sync'ed `shared_ptr<T>` access    
- provides atomic operation for `std::shared_ptr<T>` similar to `std::atomic<std::shared_ptr<T>>`.
- further provides thread-safe `assignIfNull` and `assignIfNotNull` atomic conditional assignment methods.
- implementation uses `std::mutex` to synchronize `std::shared_ptr<T>` access.

Using AtomicSharedPtr<T> for SocketPoll removes any potential unwarranted synchronization side-effects,
similar to `std::atomic<std::shared_ptr<T>>`, while also providing conditional atomic assignment.

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

