### PR TITLE
cool#9992 doc sign: hide sign button when user pref doesn't provide cert or key

### DIFF
--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -1035,7 +1035,11 @@ L.Control.UIManager = L.Control.extend({
 		}
 
 		var userPrivateInfo = myViewData.userprivateinfo;
-		if (userPrivateInfo && window.zoteroEnabled) {
+		if (userPrivateInfo === undefined)
+		{
+			return;
+		}
+		if (window.zoteroEnabled) {
 			var apiKey = userPrivateInfo.ZoteroAPIKey;
 			if (apiKey !== undefined && !this.map.zotero) {
 				this.map.zotero = L.control.zotero(this.map);
@@ -1043,6 +1047,12 @@ L.Control.UIManager = L.Control.extend({
 				this.map.addControl(this.map.zotero);
 				this.map.zotero.updateUserID();
 			}
+		}
+		if (window.documentSigningEnabled && this.notebookbar) {
+			const show = userPrivateInfo.SignatureCert && userPrivateInfo.SignatureKey;
+			// Show or hide the signature button on the notebookbar depending on if we
+			// have a signing cert/key specified.
+			this.showButton('signature', show);
 		}
 	},
 


### PR DESCRIPTION
Have no sign keys configured, open a document, go to the File tab on the
notebookbar, the signature button clutters the UI but it provides no
actual functionality.

The JS UI already got the private user info in Control.UIManager.js
onUpdateViews(), where we initialize the Zotero UI.

Do something similar for the sign UI: keep it enabled by default, but
once we learn about the private user info and it has no signing
key/cert, then hide the button.

The notebookbar gets re-initialized from time to time, so best to do
this via showButton(), which can remember which buttons are shown/hidden
and gets maintained even after a rebuild of the notebookbar. (The
postmessage API uses the same code to hide a button from an
integration.)

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Ifad78220a002ed19a5d822d8affed9aea6073737
