### PR TITLE
fix: ensure presentation starts only after document is fully loaded

### DIFF
--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -395,9 +395,12 @@ L.Control.UIManager = L.Control.extend({
 		}
 
 		var startPresentationGet = this.map.isPresentationOrDrawing() && window.coolParams.get('startPresentation');
-		if (startPresentationGet === 'true' || startPresentationGet === '1') {
-			app.dispatcher.dispatch('presentation');
-		}
+		// check for "presentation" dispatch event only after document gets fully loaded
+		this.map.on('docloaded', function() {
+			if (startPresentationGet === 'true' || startPresentationGet === '1') {
+				app.dispatcher.dispatch('presentation');
+			}
+		});
 	},
 
 	initializeSidebar: function() {


### PR DESCRIPTION


- Previously, when attempting to open a presentation file using the `&startPresentation=true` parameter, the presentation would not load, leading to either a browser console error or a direct error from Collabora.

-  This issue was resolved by dispatching the 'presentation' event only after the document has fully loaded, preventing premature attempts to start the presentation.


Change-Id: Ib066a28c0aff0ed4f979b5d6d463bfd900519730


* Resolves: #10198 
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

