### PR TITLE
Rename UnitWSD::config{ure -> Net}, to allow -Woverloaded-virtual

### DIFF
--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -415,7 +415,7 @@ public:
     virtual void configure(Poco::Util::LayeredConfiguration& /* config */) {}
 
     /// Manipulate and modify the net::Defaults for before any usage.
-    virtual void configure(net::Defaults& /* defaults */) {}
+    virtual void configNet(net::Defaults& /* defaults */) {}
 
     /// Main-loop reached, time for testing.
     /// Invoked from coolwsd's main thread.

--- a/test/UnitTimeoutConnections.cpp
+++ b/test/UnitTimeoutConnections.cpp
@@ -32,7 +32,7 @@ static constexpr size_t ConnectionCount = 9;
 /// Base test suite class for connection limit (limited) using HTTP and WS sessions.
 class UnitTimeoutConnections : public UnitTimeoutBase1
 {
-    void configure(net::Defaults& defaults) override
+    void configNet(net::Defaults& defaults) override
     {
         // defaults.WSPingTimeout = std::chrono::microseconds(2000000);
         // defaults.WSPingPeriod = std::chrono::microseconds(3000000);

--- a/test/UnitTimeoutNone.cpp
+++ b/test/UnitTimeoutNone.cpp
@@ -31,7 +31,7 @@ static constexpr size_t ConnectionCount = 9;
 /// Base test suite class for connection limit (no limits) using HTTP and WS sessions.
 class UnitTimeoutNone : public UnitTimeoutBase1
 {
-    void configure(net::Defaults& /* defaults */) override
+    void configNet(net::Defaults& /* defaults */) override
     {
         // Keep original values -> No timeout
         // defaults.WSPingTimeout = std::chrono::microseconds(2000000);

--- a/test/UnitTimeoutSocket.cpp
+++ b/test/UnitTimeoutSocket.cpp
@@ -35,7 +35,7 @@ class UnitTimeoutSocket : public UnitTimeoutBase0
     TestResult testWSPing();
     TestResult testWSDChatPing();
 
-    void configure(net::Defaults& defaults) override
+    void configNet(net::Defaults& defaults) override
     {
         // defaults.WSPingTimeout = std::chrono::microseconds(2000000);
         // defaults.WSPingPeriod = std::chrono::microseconds(3000000);

--- a/test/UnitTimeoutWSPing.cpp
+++ b/test/UnitTimeoutWSPing.cpp
@@ -32,7 +32,7 @@ class UnitTimeoutWSPing : public UnitTimeoutBase0
 {
     TestResult testWSPing();
 
-    void configure(net::Defaults& defaults) override
+    void configNet(net::Defaults& defaults) override
     {
         // defaults.WSPingTimeout = std::chrono::microseconds(2000000);
         // defaults.WSPingPeriod = std::chrono::microseconds(3000000);

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -2373,7 +2373,7 @@ void COOLWSD::innerInitialize(Application& self)
     {
         net::Defaults& defaults = net::Defaults::get();
         net::Defaults::get().MaxConnections = std::max<size_t>(3, MAX_CONNECTIONS);
-        UnitWSD::get().configure(defaults);
+        UnitWSD::get().configNet(defaults);
     }
     // Trace Event Logging.
     EnableTraceEventLogging = getConfigValue<bool>(conf, "trace_event[@enable]", false);


### PR DESCRIPTION
Change-Id: I1a3b433cfadbf8d4da1be4bb72bddb40231e27c5

### Summary
Avoid overloading virtual function `UnitWSD::configure`,
allowing to use compiler flag -Woverloaded-virtual

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

