### PR TITLE
css: fix icons size after split button rework

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1383,8 +1383,8 @@ input[type='number']:hover::-webkit-outer-spin-button {
 }
 
 .jsdialog .unobutton img {
-	min-width: 0;
-	min-height: 0;
+	width: var(--btn-img-size);
+	height: var(--btn-img-size);
 }
 
 .menubutton .arrow {

--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -245,8 +245,8 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 }
 
 .ui-tabs-content .unobutton > img {
-	min-height: 0;
-	min-width: 0;
+	width: var(--btn-size);
+	height: var(--btn-size);
 }
 
 .has-dropdown--color.notebookbar {

--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -350,7 +350,10 @@
 	background-position: right;
 	background-repeat: no-repeat;
 }
-
+.unospan-optionstoolboxdown .unobutton > img {
+	width: var(--btn-size);
+	height: var(--btn-size);
+}
 #closebuttonwrapper {
 	order: 99;
 	flex-shrink: 0;


### PR DESCRIPTION
it was broken after PR:
commit db10c453e95f732d85c489fe8da8708cec0ad09c
fix(UI): set button size with a CSS variable

related to: https://github.com/CollaboraOnline/online/pull/10027