### PR TITLE
Shows calc comment indicator as a triangle.

### DIFF
--- a/browser/src/canvas/sections/CommentSection.ts
+++ b/browser/src/canvas/sections/CommentSection.ts
@@ -1325,13 +1325,18 @@ export class Comment extends CanvasSectionObject {
 				if (cellSize[0] !== 0 && cellSize[1] !== 0) { // don't draw notes in hidden cells
 					// For calc comments (aka postits) draw the same sort of square as ScOutputData::DrawNoteMarks
 					// does for offline
-					var margin = 3;
+					var margin = cellSize[0] * 0.06;
 					var squareDim = 6;
 					// this.size may currently have an artifically wide size if mouseEnter without moveLeave seen
 					// so fetch the real size
 					var x = this.isCalcRTL() ? margin : cellSize[0] - (margin + squareDim);
-					this.context.fillStyle = '#FF0000';
-					this.context.fillRect(x, 0, squareDim, squareDim);
+					this.context.fillStyle = '#BF819E';
+					var region = new Path2D();
+					region.moveTo(x, 0);
+					region.lineTo(cellSize[0], 0);
+					region.lineTo(cellSize[0], cellSize[1]/2);
+					region.closePath();
+					this.context.fill(region);
 				}
 			}
 		}


### PR DESCRIPTION
Comment indicator is changed in core d395b42cdf3ef517d215dee905e5ccf2ae73b2b8 We draw that indicator on online side separately. Now we see the same indicator on online too.


Change-Id: I2c640f4850473724e8a14e75fa7d3c00f76d4e9e


* Resolves: #7130
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

