### PR TITLE
Cleanup Socket/SocketPoll 'Limited open Connections' Changes

### DIFF
--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -1507,21 +1507,19 @@ bool StreamSocket::checkRemoval(std::chrono::steady_clock::time_point now)
         const auto durLast =
             std::chrono::duration_cast<std::chrono::milliseconds>(now - getLastSeenTime());
         const double bytesPerSecIn = durTotal.count() > 0 ? (double)bytesRcvd() / ((double)durTotal.count() / 1000.0) : 0.0;
-        /// TO Criteria: Violate creation time? (invalid passed now)
-        const bool cNow = now < getCreationTime();
         /// TO Criteria: Violate maximum idle (_pollTimeout default 64s)
-        const bool cIDLE = _pollTimeout > std::chrono::microseconds::zero() &&
+        const bool isIDLE = _pollTimeout > std::chrono::microseconds::zero() &&
                            durLast > _pollTimeout;
         /// TO Criteria: Violate minimum bytes-per-sec throughput? (_minBytesPerSec default 0, disabled)
-        const bool cMinThroughput = _minBytesPerSec > std::numeric_limits<double>::epsilon() &&
+        const bool isMinThroughput = _minBytesPerSec > std::numeric_limits<double>::epsilon() &&
                                     bytesPerSecIn > std::numeric_limits<double>::epsilon() &&
                                     bytesPerSecIn < _minBytesPerSec;
         /// TO Criteria: Shall terminate?
-        const bool cTermination = SigUtil::getTerminationFlag();
-        if (cNow || cIDLE || cMinThroughput || cTermination )
+        const bool isTermination = SigUtil::getTerminationFlag();
+        if (isIDLE || isMinThroughput || isTermination )
         {
-            LOG_WRN("CheckRemoval: Timeout: {Now " << cNow << ", IDLE " << cIDLE
-                    << ", MinThroughput " << cMinThroughput << ", Termination " << cTermination << "}, "
+            LOG_WRN("CheckRemoval: Timeout: {IDLE " << isIDLE
+                    << ", MinThroughput " << isMinThroughput << ", Termination " << isTermination << "}, "
                     << getStatsString(now) << ", "
                     << *this);
             if (_socketHandler)

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -1441,8 +1441,6 @@ public:
         return std::string();
     }
 
-protected:
-
     /// Called when a polling event is received.
     /// @events is the mask of events that triggered the wake.
     void handlePoll(SocketDisposition &disposition,
@@ -1567,7 +1565,6 @@ protected:
             disposition.setClosed();
     }
 
-public:
     /// Override to write data out to socket.
     /// Returns the last return from writeData.
     virtual int writeOutgoingData()


### PR DESCRIPTION
* Resolves: #9833
* Target version: master 

### Summary
Originally contained PR #10270 fixing a regression caused by PR #9916, leading to 100% CPU utilization on idle,
due to WebSocketHandler's checkTimeout not being called and hence no ping sent.

This PR contains remaining cleanups related to PR #9916

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

