### PR TITLE
browser: do not scale angle on shape rotation

### DIFF
--- a/browser/src/canvas/sections/ShapeHandleRotationSubSection.ts
+++ b/browser/src/canvas/sections/ShapeHandleRotationSubSection.ts
@@ -127,7 +127,7 @@ class ShapeHandleRotationSubSection extends CanvasSectionObject {
 
 			if (this.containerObject.isDraggingSomething() && this.sectionProperties.parentHandlerSection.sectionProperties.svg) {
 				this.sectionProperties.parentHandlerSection.sectionProperties.svg.style.opacity = 0.5;
-				const angleDifference = (-this.getAngleDifference() / 100) * app.dpiScale;
+				const angleDifference = -this.getAngleDifference() / 100;
 				this.sectionProperties.parentHandlerSection.sectionProperties.svg.style.transform = 'rotate(' + angleDifference + 'deg)';
 				this.containerObject.requestReDraw();
 				this.sectionProperties.parentHandlerSection.showSVG();


### PR DESCRIPTION
Angle values do not change with dpi. Right now if a browser has a dpi
different than 1 the shape rotation preview jumps around due to this
extra scaling.

Signed-off-by: Jaume Pujantell <jaume.pujantell@collabora.com>
Change-Id: I21d7fb34f6c496235004dc75ee512e23b804b386
