### PR TITLE
Dropdowns: Don't force any specific width

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1784,6 +1784,10 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	align-items: center;
 }
 
+.has-dropdown > .ui-content.unobutton {
+	width: auto;
+}
+
 .unoarrow::after,
 .jsdialog .ui-content.unobutton::after {
 	--click-increment: -1px;


### PR DESCRIPTION
This is a follow up of 3e8edc705578a624aaec22c008801784522e8e47

It fixes the cropped combo boxes in the status bar

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I05ed4778c5663dfa92551a23f2383ea5aafd023b
