### PR TITLE
fix co-24.04 build

### DIFF
--- a/test/DeltaTests.cpp
+++ b/test/DeltaTests.cpp
@@ -330,13 +330,13 @@ void DeltaTests::testRleRandom()
 
     DeltaGenerator::DeltaData data(
         1, randomImg.data(), 0, 0, 256, 256,
-        TileLocation(9, 9, 9, 0, 1, 0), 256, 256);
+        TileLocation(9, 9, 9, 0, 1), 256, 256);
 
     // Compress
     std::vector<char> output;
     size_t size = gen.compressOrDelta(
         randomImg.data(), 0, 0, 256, 256, 256, 256,
-        TileLocation(42, 2, 3, 0, 1, 0),
+        TileLocation(42, 2, 3, 0, 1),
         output, 1, true, false, LOK_TILEMODE_RGBA);
     LOK_ASSERT(size > 1);
     LOK_ASSERT(output[0] == 'Z');


### PR DESCRIPTION
the master commit:

commit 9d49ea31131972bc8e1581a353441230850a78c2
CommitDate: Tue Oct 15 06:51:14 2024 +0300

    Add viewMode property to TileLocation to ensure that correct delta is replaced with the new one.

isn't in co-24, so the test of:

commit 0e7d356c960afdf51f0db4b85eda7352472a54ae
CommitDate: Sat Oct 19 18:50:26 2024 +0100

deltas: test random image - to check we have space allocation right

needs to be adjusted to account for that


Change-Id: If7a54fac69f34ab3fa75fee6fe67aea42d44c669


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

