### PR TITLE
statusbar save indicator: add coolwsd setting

### DIFF
--- a/browser/html/cool.html.m4
+++ b/browser/html/cool.html.m4
@@ -249,6 +249,7 @@ m4_ifelse(MOBILEAPP, [true],
       data-allow-update-notification = "%ENABLE_UPDATE_NOTIFICATION%"
       data-user-interface-mode = "%USER_INTERFACE_MODE%"
       data-use-integration-theme = "%USE_INTEGRATION_THEME%"
+      data-statusbar-save-indicator = "%STATUSBAR_SAVE_INDICATOR%"
       data-enable-macros-execution = "%ENABLE_MACROS_EXECUTION%"
       data-enable-accessibility = "%ENABLE_ACCESSIBILITY%"
       data-out-of-focus-timeout-secs = "%OUT_OF_FOCUS_TIMEOUT_SECS%"

--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -250,6 +250,7 @@ class InitializerBase {
 		window.frameAncestors = "";
 		window.socketProxy = false;
 		window.uiDefaults = {};
+		window.useStatusbarSaveIndicator = false;
 		window.checkFileInfoOverride = {};
 		window.deeplEnabled = false;
 		window.zoteroEnabled = false;
@@ -371,6 +372,7 @@ class BrowserInitializer extends InitializerBase {
 		window.allowUpdateNotification = element.dataset.allowUpdateNotification.toLowerCase().trim() === "true";
 		window.userInterfaceMode = element.dataset.userInterfaceMode;
 		window.useIntegrationTheme = element.dataset.useIntegrationTheme.toLowerCase().trim() === "true";
+		window.useStatusbarSaveIndicator = element.dataset.statusbarSaveIndicator.toLowerCase().trim() === "true";
 		window.enableMacrosExecution = element.dataset.enableMacrosExecution.toLowerCase().trim() === "true";
 		window.enableAccessibility = element.dataset.enableAccessibility.toLowerCase().trim() === "true";
 		window.outOfFocusTimeoutSecs = parseInt(element.dataset.outOfFocusTimeoutSecs);

--- a/browser/src/control/Control.StatusBar.js
+++ b/browser/src/control/Control.StatusBar.js
@@ -29,6 +29,10 @@ class StatusBar extends JSDialog.Toolbar {
 		map.on('updatemodificationindicator', this.onUpdateModificationIndicator, this);
 	}
 
+	isSaveIndicatorActive() {
+		return window.useStatusbarSaveIndicator;
+	}
+
 	localizeStateTableCell(text) {
 		var stateArray = text.split(';');
 		var stateArrayLength = stateArray.length;
@@ -533,6 +537,9 @@ class StatusBar extends JSDialog.Toolbar {
 	}
 
 	onInitModificationIndicator(lastmodtime) {
+		if (!this.isSaveIndicatorActive())
+			return;
+
 		const docstatcontainer = document.getElementById('documentstatus-container');
 		if (lastmodtime == null) {
 			if (docstatcontainer !== null && docstatcontainer !== undefined) {
@@ -547,6 +554,9 @@ class StatusBar extends JSDialog.Toolbar {
 
 	// status can be '', 'SAVING', 'MODIFIED' or 'SAVED'
 	onUpdateModificationIndicator(e) {
+		if (!this.isSaveIndicatorActive())
+			return;
+
 		if (this._lastModstatus !== e.status) {
 			this.updateHtmlItem('DocumentStatus', e.status);
 			this._lastModStatus = e.status;

--- a/browser/test/load.js
+++ b/browser/test/load.js
@@ -87,6 +87,7 @@ data = data.replace(/%AUTO_SHOW_FEEDBACK%/g, 'false');
 data = data.replace(/%ENABLE_UPDATE_NOTIFICATION%/g, 'false');
 data = data.replace(/%USER_INTERFACE_MODE%/g, '');
 data = data.replace(/%USE_INTEGRATION_THEME%/g, 'true');
+data = data.replace(/%STATUSBAR_SAVE_INDICATOR%/g, 'false');
 data = data.replace(/%ENABLE_MACROS_EXECUTION%/g, '');
 data = data.replace(/%OUT_OF_FOCUS_TIMEOUT_SECS%/g, '1000000');
 data = data.replace(/%IDLE_TIMEOUT_SECS%/g, '1000000');

--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -242,6 +242,7 @@
     <user_interface>
       <mode type="string" desc="Controls the user interface style. The 'default' means: Take the value from ui_defaults, or decide for one of compact or tabbed (default|compact|tabbed)" default="default">default</mode>
       <use_integration_theme desc="Use theme from the integrator" type="bool" default="true">true</use_integration_theme>
+      <statusbar_save_indicator desc="Show saving status indicator in the statusbar" type="bool" default="true">true</statusbar_save_indicator>
     </user_interface>
 
     <storage desc="Backend storage">

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -2179,6 +2179,7 @@ void COOLWSD::innerInitialize(Application& self)
 #endif
         { "user_interface.mode", "default" },
         { "user_interface.use_integration_theme", "true" },
+        { "user_interface.statusbar_save_indicator", "true" },
         { "quarantine_files[@enable]", "false" },
         { "quarantine_files.limit_dir_size_mb", "250" },
         { "quarantine_files.max_versions_to_maintain", "5" },

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -1303,6 +1303,10 @@ FileServerRequestHandler::ResourceAccessDetails FileServerRequestHandler::prepro
         COOLWSD::getConfigValue<bool>("hexify_embedded_urls", false) ? "true" : "false";
     Poco::replaceInPlace(preprocess, std::string("%HEXIFY_URL%"), hexifyEmbeddedUrls);
 
+    static const std::string useStatusbarSaveIndicator =
+        config.getBool("user_interface.statusbar_save_indicator", false) ? "true" : "false";
+    Poco::replaceInPlace(preprocess, std::string("%STATUSBAR_SAVE_INDICATOR%"), useStatusbarSaveIndicator);
+
     static const bool useIntegrationTheme =
         config.getBool("user_interface.use_integration_theme", true);
     const bool hasIntegrationTheme =


### PR DESCRIPTION
user_interface.statusbar_save_indicator can be used to hide statusbar indicator of the last save. By default it is visible if entry is missing.

followup for: https://github.com/CollaboraOnline/online/pull/4531/files